### PR TITLE
Allow inference posterior/movie executables to read CSV files

### DIFF
--- a/bin/inference/pycbc_inference_plot_movie
+++ b/bin/inference/pycbc_inference_plot_movie
@@ -198,7 +198,7 @@ if opts.z_arg is not None:
     likelihood_stats = fp.read_likelihood_stats(thin_start=thin_start,
         thin_end=thin_end, thin_interval=thinint, iteration=itermask,
         flatten=False)
-    zvals, zlbl = option_utils.get_zvalues(fp, opts.z_arg, likelihood_stats)
+    zvals, zlbl = option_utils.get_zvalues(fp, opts)
     show_colorbar = True
     # Set common min and max for colorbar in all plots
     if opts.vmin is None:

--- a/bin/inference/pycbc_inference_plot_posterior
+++ b/bin/inference/pycbc_inference_plot_posterior
@@ -86,11 +86,7 @@ if opts.z_arg is not None:
 
     # loop over each input file and append z-axis values and labels to lists
     for f in fp:
-        likelihood_stats = f.read_likelihood_stats(
-            thin_start=opts.thin_start, thin_end=opts.thin_end,
-            thin_interval=opts.thin_interval, iteration=opts.iteration)
-        f_zvals, f_zlbl = option_utils.get_zvalues(f, opts.z_arg,
-                                                   likelihood_stats)
+        f_zvals, f_zlbl = option_utils.get_zvalues(f, opts)
         zvals.append(f_zvals)
         zlbl.append(f_zlbl)
         f.close()

--- a/pycbc/inference/option_utils.py
+++ b/pycbc/inference/option_utils.py
@@ -629,10 +629,8 @@ def get_zvalues(fp, opts):
     fp : InferenceFile
         An open inference file; needed to get the value of the log noise
         likelihood.
-    arg : str
-        The argument to plot; must be one of `loglr`, `snr`, `logplr`,
-        `logposterior`, or `prior`. If not one of these, a ValueError is
-        raised.
+    opts : ArgumentParser
+        The parsed arguments from the command line.
 
     Returns
     -------
@@ -641,8 +639,9 @@ def get_zvalues(fp, opts):
     zlbl : str
         The label to use for the values on a plot.
     """
-    arg = opts.z_arg
 
+    # read values from file
+    arg = opts.z_arg
     try:
         likelihood_stats = fp.read_likelihood_stats(
             parameters=[arg],
@@ -654,6 +653,7 @@ def get_zvalues(fp, opts):
             thin_start=opts.thin_start, thin_end=opts.thin_end,
             thin_interval=opts.thin_interval, iteration=opts.iteration)
 
+    # get any dervied values and labels
     if arg == 'loglr':
         zvals = likelihood_stats.loglr
         zlbl = r'$\log\mathcal{L}(\vec{\vartheta})$'

--- a/pycbc/io/inference_csv.py
+++ b/pycbc/io/inference_csv.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2016 Christopher M. Biwer
+# Copyright (C) 2017 Christopher M. Biwer
 # This program is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License as published by the
 # Free Software Foundation; either version 3 of the License, or (at your

--- a/pycbc/io/inference_csv.py
+++ b/pycbc/io/inference_csv.py
@@ -1,0 +1,75 @@
+# Copyright (C) 2016 Christopher M. Biwer
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# self.option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+"""This modules defines functions for reading and samples that the
+inference samplers generate and are stored in CSV file.
+"""
+
+import numpy
+from pycbc.io import record
+from pycbc.waveform import parameters as wfparams
+
+COMMENT = ""
+DELIMITER = " "
+
+class InferenceCSVFile(object):
+
+    def __init__(self, path, mode=None, delimiter=DELIMITER):
+        self.path = path
+        self.delimiter = delimiter
+        if mode in ["r", "rb"]:
+            self.mode = mode
+        else:
+            raise ValueError("Mode for InferenceCSVFile must be 'r' or 'rb'.")
+
+        with open(self.path, self.mode) as fp:
+            header = fp.readline().rstrip("\n")
+        self._variable_args = header.split(self.delimiter)
+
+    @property
+    def variable_args(self):
+        return self._variable_args
+
+    def read_label(self, parameter, error_on_none=False):
+        try:
+            label = getattr(wfparams, parameter).label
+        except AttributeError:
+            if error_on_none:
+                raise ValueError(
+                            "Cannot find a label for paramter %s" %(parameter))
+            else:
+                return parameter
+        return label
+
+    def read_samples(self, parameters, **kwargs):
+        idxs = [self.variable_args.index(p) for p in parameters]
+        samples = numpy.loadtxt(self.path, delimiter=self.delimiter,
+                                comments=COMMENT, skiprows=1, usecols=idxs)
+        dtype = zip(parameters, len(idxs) * [float])
+        size = len(samples) if len(idxs) > 1 else samples.shape[0]
+        rec_samples = record.FieldArray(size, dtype=dtype)
+        if len(idxs) > 1:
+            for i, p in zip(idxs, parameters):
+                rec_samples[p] = samples[:, i]
+        else:
+            rec_samples[parameters[0]] = samples
+        return rec_samples
+
+    def read_likelihood_stats(self, parameters=None, **kwargs):
+        parameters = self.variable_args if parameters is None else parameters
+        return self.read_samples(parameters)
+
+    def close(self):
+        pass

--- a/pycbc/io/inference_hdf.py
+++ b/pycbc/io/inference_hdf.py
@@ -276,6 +276,9 @@ class InferenceFile(h5py.File):
 
         Parameters
         -----------
+        parameters : list
+            A list of parameters to return. Default is `None` which returns all
+            `likelihood_stats` parameters.
         \**kwargs :
             The keyword args are passed to the sampler's `read_likelihood_stats`
             method.

--- a/pycbc/io/inference_hdf.py
+++ b/pycbc/io/inference_hdf.py
@@ -13,14 +13,6 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-
-#
-# =============================================================================
-#
-#                                   Preamble
-#
-# =============================================================================
-#
 """This modules defines functions for reading and writing samples that the
 inference samplers generate.
 """
@@ -279,7 +271,7 @@ class InferenceFile(h5py.File):
                                                 samples_group=samples_group,
                                                 **kwargs)
 
-    def read_likelihood_stats(self, **kwargs):
+    def read_likelihood_stats(self, parameters=None, **kwargs):
         """Reads likelihood stats from self.
 
         Parameters
@@ -295,7 +287,11 @@ class InferenceFile(h5py.File):
             array are the names of the stats that are in the `likelihood_stats`
             group.
         """
-        parameters = self[self.stats_group].keys()
+        parameters = parameters if parameters \
+                         else self[self.stats_group].keys()
+        for p in parameters:
+            if p not in self[self.stats_group].keys():
+                raise KeyError("{} is not in likelihood_stats group".format(p))
         return self.read_samples(parameters, samples_group=self.stats_group,
                                  **kwargs)
 


### PR DESCRIPTION
Moves the calls to ``read_likelihood_stats`` inside ``get_zvalues`` and adds a ``InferenceCSVFile`` class that gets called to get values from posterior-only CSV files.

Example command lines tested:
```
# CSV
pycbc_inference_plot_posterior --input-file test.csv --output-file test_csv.png --parameters "m1:\$m_1\$" "m2:\$m_2\$" --plot-marginal --plot-contour --plot-scatter --z-arg optimal_snr
# HDF
pycbc_inference_plot_posterior --input-file test.hdf --output-file test_hdf.png --iteration 1000 --parameters mass1 mass2 --plot-marginal --plot-contour --plot-scatter --z-arg snr

```