### PR TITLE
Human readable x axis for pycbc_inference_plot_samples

### DIFF
--- a/bin/inference/pycbc_inference_plot_samples
+++ b/bin/inference/pycbc_inference_plot_samples
@@ -78,7 +78,9 @@ for i, arg in enumerate(parameters):
                             thin_interval=1,
                             thin_end=opts.thin_end)
         y = transforms.apply_transforms(y, cs)
-        axs[i].plot(y[arg], alpha=0.25)
+        x = range(opts.thin_start, opts.thin_end + 1)
+
+        axs[i].plot(x, y[arg], alpha=0.25)
 
         # y-axis label
         axs[i].set_ylabel(labels[i])

--- a/bin/inference/pycbc_inference_plot_samples
+++ b/bin/inference/pycbc_inference_plot_samples
@@ -83,6 +83,13 @@ for i, arg in enumerate(parameters):
         # y-axis label
         axs[i].set_ylabel(labels[i])
 
+# x-axis label
+if opts.thin_interval is not None:
+    axs[-1].set_xlabel("Intervals (%s iterations per interval)" % opts.thin_interval)
+# Default to old behavior
+else :
+    axs[-1].set_xlabel("Autocorrelation Lengths [%s iteration(s) per interval]" % fp.attrs['acl'])
+
 # save figure with meta-data
 caption_kwargs = {
     "parameters" : ", ".join(labels),

--- a/bin/inference/pycbc_inference_plot_samples
+++ b/bin/inference/pycbc_inference_plot_samples
@@ -75,20 +75,13 @@ for i, arg in enumerate(parameters):
                                                  parameters, fp.variable_args)
         y = fp.read_samples(file_parameters, walkers=j,
                             thin_start=opts.thin_start,
-                            thin_interval=opts.thin_interval,
+                            thin_interval=1,
                             thin_end=opts.thin_end)
         y = transforms.apply_transforms(y, cs)
         axs[i].plot(y[arg], alpha=0.25)
 
         # y-axis label
         axs[i].set_ylabel(labels[i])
-
-# x-axis label
-if opts.thin_interval is not None:
-    axs[-1].set_xlabel("Intervals [%s iteration(s) per interval]" % opts.thin_interval)
-# Default to old behavior
-else :
-    axs[-1].set_xlabel("Autocorrelation Lengths [%s iteration(s) per interval]" % fp.attrs['acl'])
 
 # save figure with meta-data
 caption_kwargs = {

--- a/bin/inference/pycbc_inference_plot_samples
+++ b/bin/inference/pycbc_inference_plot_samples
@@ -75,7 +75,7 @@ for i, arg in enumerate(parameters):
                                                  parameters, fp.variable_args)
         y = fp.read_samples(file_parameters, walkers=j,
                             thin_start=opts.thin_start,
-                            thin_interval=1,
+                            thin_interval=opts.thin_interval,
                             thin_end=opts.thin_end)
         y = transforms.apply_transforms(y, cs)
         x = range(opts.thin_start, opts.thin_end + 1)
@@ -84,6 +84,13 @@ for i, arg in enumerate(parameters):
 
         # y-axis label
         axs[i].set_ylabel(labels[i])
+
+# x-axis label
+if opts.thin_interval is not None:
+    axs[-1].set_xlabel("Intervals [%s iteration(s) per interval]" % opts.thin_interval)
+# Default to old behavior
+else :
+    axs[-1].set_xlabel("Autocorrelation Lengths [%s iteration(s) per interval]" % fp.attrs['acl'])
 
 # save figure with meta-data
 caption_kwargs = {

--- a/bin/inference/pycbc_inference_plot_samples
+++ b/bin/inference/pycbc_inference_plot_samples
@@ -85,7 +85,7 @@ for i, arg in enumerate(parameters):
 
 # x-axis label
 if opts.thin_interval is not None:
-    axs[-1].set_xlabel("Intervals (%s iterations per interval)" % opts.thin_interval)
+    axs[-1].set_xlabel("Intervals [%s iteration(s) per interval]" % opts.thin_interval)
 # Default to old behavior
 else :
     axs[-1].set_xlabel("Autocorrelation Lengths [%s iteration(s) per interval]" % fp.attrs['acl'])


### PR DESCRIPTION
Change the x-axis for plot samples. It currently writes iterations as the label, even though it's actually plotting interval lengths.

If `thin-interval` is not specified, the code is supposed to default to plotting in intervals of ACL.

This patch does not use the ACL for each parameter (which I think it should do). Maybe that can go in a future patch. Probably a good idea would be to calculate the ACL for each parameter, and plot different x-axes in the case that these ACL differ from one another.

Current behavior with thin-interval = 1000:
https://sugwg-jobs.phy.syr.edu/~steven.reyes/O2/test_PE/params_chain.png

Current behavior with no thin-interval given:
https://sugwg-jobs.phy.syr.edu/~steven.reyes/O2/test_PE/params_chain_acl.png

Prior behavior would just write Iterations as the x-axis label but would generate all of the same ticks for both plots.