### PR TITLE
Plot min and max expected parameters

### DIFF
--- a/bin/inference/pycbc_inference_plot_movie
+++ b/bin/inference/pycbc_inference_plot_movie
@@ -225,7 +225,9 @@ else:
 fp.close()
 
 # get expected parameters
-expected_parameters = option_utils.expected_parameters_from_cli(opts)
+expected_parameters = option_utils.expected_parameters_from_cli(opts.expected_parameters)
+expected_parameters_min = option_utils.expected_parameters_from_cli(opts.expected_parameters_min)
+expected_parameters_max = option_utils.expected_parameters_from_cli(opts.expected_parameters_max)
 expected_parameters_color = opts.expected_parameters_color
 
 logging.info('Choosing common characteristics for all figures')
@@ -269,6 +271,8 @@ def _make_frame(frame):
                             contour_color=opts.contour_color,
                             use_kombine=opts.use_kombine_kde,
                         expected_parameters=expected_parameters,
+                        expected_parameters_min=expected_parameters_min,
+                        expected_parameters_max=expected_parameters_max,
                         expected_parameters_color=expected_parameters_color)
 
     # Write sample number

--- a/bin/inference/pycbc_inference_plot_movie
+++ b/bin/inference/pycbc_inference_plot_movie
@@ -224,12 +224,6 @@ else:
 
 fp.close()
 
-# Check if expected parameters options if any, are provided properly
-if (opts.expected_parameters and opts.expected_parameters_min) is not None or
-    (opts.expected_parameters and opts.expected_parameters_max) is not None:
-    raise RuntimeError("Can't specify both --expected-parameters and
-    --expected-parameters-min or --expected-parameters-max!")
-
 # get expected parameters
 expected_parameters = option_utils.expected_parameters_from_cli(opts.expected_parameters)
 expected_parameters_min = option_utils.expected_parameters_from_cli(opts.expected_parameters_min)

--- a/bin/inference/pycbc_inference_plot_movie
+++ b/bin/inference/pycbc_inference_plot_movie
@@ -99,7 +99,7 @@ parser.add_argument("--end-sample", type=int, default=None,
                          "default to the last sample.")
 parser.add_argument("--frame-number", type=int,
                     help="Number of frames for the movie.")
-parser.add_argument("--frame-step", type=int, 
+parser.add_argument("--frame-step", type=int,
                     help="Step in the sample between frames for the movie. "
                          "Only provide if not --frame-number given.")
 parser.add_argument("--log-steps", action="store_true", default=False,
@@ -132,7 +132,7 @@ parser.add_argument("--cleanup", action='store_true',
 # add options for what plots to create
 option_utils.add_plot_posterior_option_group(parser)
 # add scatter and density configuration options
-option_utils.add_scatter_option_group(parser) 
+option_utils.add_scatter_option_group(parser)
 option_utils.add_density_option_group(parser)
 
 opts = parser.parse_args()
@@ -224,11 +224,26 @@ else:
 
 fp.close()
 
+# Check if expected parameters options if any, are provided properly
+if (opts.expected_parameters and opts.expected_parameters_min) is not None or
+    (opts.expected_parameters and opts.expected_parameters_max) is not None:
+    raise RuntimeError("Can't specify both --expected-parameters and
+    --expected-parameters-min or --expected-parameters-max!")
+
 # get expected parameters
 expected_parameters = option_utils.expected_parameters_from_cli(opts.expected_parameters)
 expected_parameters_min = option_utils.expected_parameters_from_cli(opts.expected_parameters_min)
 expected_parameters_max = option_utils.expected_parameters_from_cli(opts.expected_parameters_max)
 expected_parameters_color = opts.expected_parameters_color
+
+# Check if expected parameters options if any, are provided properly
+for x in expected_parameters:
+    if x in expected_parameters_min:
+        raise RuntimeError("Can't specify both --expected-parameters and "
+                           "--expected-parameters-min for {0}".format(x))
+    if x in expected_parameters_max:
+        raise RuntimeError("Can't specify both --expected-parameters and "
+                           "--expected-parameters-max for {0}".format(x))
 
 logging.info('Choosing common characteristics for all figures')
 # Set common min and max for axis in all plots

--- a/bin/inference/pycbc_inference_plot_movie
+++ b/bin/inference/pycbc_inference_plot_movie
@@ -230,15 +230,6 @@ expected_parameters_min = option_utils.expected_parameters_from_cli(opts.expecte
 expected_parameters_max = option_utils.expected_parameters_from_cli(opts.expected_parameters_max)
 expected_parameters_color = opts.expected_parameters_color
 
-# Check if expected parameters options if any, are provided properly
-for x in expected_parameters:
-    if x in expected_parameters_min:
-        raise RuntimeError("Can't specify both --expected-parameters and "
-                           "--expected-parameters-min for {0}".format(x))
-    if x in expected_parameters_max:
-        raise RuntimeError("Can't specify both --expected-parameters and "
-                           "--expected-parameters-max for {0}".format(x))
-
 logging.info('Choosing common characteristics for all figures')
 # Set common min and max for axis in all plots
 mins, maxs = option_utils.plot_ranges_from_cli(opts)

--- a/bin/inference/pycbc_inference_plot_posterior
+++ b/bin/inference/pycbc_inference_plot_posterior
@@ -135,7 +135,16 @@ for p in parameters[0]:
         maxs[p] = numpy.array([s[p].max() for s in samples]).max()
 
 # get expected parameter values from command line
-expected_parameters = option_utils.expected_parameters_from_cli(opts)
+expected_parameters = option_utils.expected_parameters_from_cli(
+                                                opts.expected_parameters)
+
+# get minimum expected parameter values from command line
+expected_parameters_min = option_utils.expected_parameters_from_cli(
+                                                opts.expected_parameters_min)
+
+# get maximum expected parameter values from command line
+expected_parameters_max = option_utils.expected_parameters_from_cli(
+                                                opts.expected_parameters_max)
 
 # assign some colors
 colors = itertools.cycle(["black"] + ["C{}".format(i) for i in range(10)])
@@ -186,6 +195,8 @@ for i, (p, l, s) in enumerate(zip(parameters, labels, samples)):
                     use_kombine=opts.use_kombine_kde,
                     mins=mins, maxs=maxs,
                     expected_parameters=expected_parameters,
+                    expected_parameters_min=expected_parameters_min,
+                    expected_parameters_max=expected_parameters_max,
                     expected_parameters_color=opts.expected_parameters_color)
 
 # add legend to upper right for input files

--- a/bin/inference/pycbc_inference_plot_posterior
+++ b/bin/inference/pycbc_inference_plot_posterior
@@ -146,6 +146,15 @@ expected_parameters_min = option_utils.expected_parameters_from_cli(
 expected_parameters_max = option_utils.expected_parameters_from_cli(
                                                 opts.expected_parameters_max)
 
+# Check if expected parameters options if any, are provided properly
+for x in expected_parameters:
+    if x in expected_parameters_min:
+        raise RuntimeError("Can't specify both --expected-parameters and "
+                           "--expected-parameters-min for {0}".format(x))
+    if x in expected_parameters_max:
+        raise RuntimeError("Can't specify both --expected-parameters and "
+                           "--expected-parameters-max for {0}".format(x))
+
 # assign some colors
 colors = itertools.cycle(["black"] + ["C{}".format(i) for i in range(10)])
 

--- a/bin/inference/pycbc_inference_plot_posterior
+++ b/bin/inference/pycbc_inference_plot_posterior
@@ -146,15 +146,6 @@ expected_parameters_min = option_utils.expected_parameters_from_cli(
 expected_parameters_max = option_utils.expected_parameters_from_cli(
                                                 opts.expected_parameters_max)
 
-# Check if expected parameters options if any, are provided properly
-for x in expected_parameters:
-    if x in expected_parameters_min:
-        raise RuntimeError("Can't specify both --expected-parameters and "
-                           "--expected-parameters-min for {0}".format(x))
-    if x in expected_parameters_max:
-        raise RuntimeError("Can't specify both --expected-parameters and "
-                           "--expected-parameters-max for {0}".format(x))
-
 # assign some colors
 colors = itertools.cycle(["black"] + ["C{}".format(i) for i in range(10)])
 

--- a/pycbc/inference/option_utils.py
+++ b/pycbc/inference/option_utils.py
@@ -755,14 +755,20 @@ def add_plot_posterior_option_group(parser):
                              "args in the input file.")
     pgroup.add_argument('--expected-parameters-min', nargs='+', metavar='PARAM:VAL',
                         default=[],
-                        help="Works like expected-parameters. If the parameter "
-                             "value is expected to lie within a range, this "
-                             "option can be used to plot the minimum value for "
-                             "that range. ")
+                        help="Specify the expected minimum boundary over of "
+                             "the range in which the parameter could lie. "
+                             "The expected region will be shaded in the 1D "
+                             "marginalized histogram plot for the parameter. "
+                             "Both this and --expected-parameters cannot be "
+                             "provided for a parameter.")
     pgroup.add_argument('--expected-parameters-max', nargs='+', metavar='PARAM:VAL',
                         default=[],
-                        help="Same as expected-parameters-min. Plots the maximum of "
-                             "the expected range. ")
+                        help="Specify the expected maximum boundary over of "
+                             "the range in which the parameter could lie. "
+                             "The expected region will be shaded in the 1D "
+                             "marginalized histogram plot for the parameter. "
+                             "Both this and --expected-parameters cannot be "
+                             "provided for a parameter.")
     pgroup.add_argument('--expected-parameters-color', default='r',
                         help="What to color the expected-parameters cross. "
                              "Default is red.")

--- a/pycbc/inference/option_utils.py
+++ b/pycbc/inference/option_utils.py
@@ -753,6 +753,16 @@ def add_plot_posterior_option_group(parser):
                              "(or, if no parameters are provided, the same as "
                              "the parameter name specified in the variable "
                              "args in the input file.")
+    pgroup.add_argument('--expected-parameters-min', nargs='+', metavar='PARAM:VAL',
+                        default=[],
+                        help="Works like expected-parameters. If the parameter "
+                             "value is expected to lie within a range, this "
+                             "option can be used to plot the minimum value for "
+                             "that range. ")
+    pgroup.add_argument('--expected-parameters-max', nargs='+', metavar='PARAM:VAL',
+                        default=[],
+                        help="Same as expected-parameters-min. Plots the maximum of "
+                             "the expected range. ")
     pgroup.add_argument('--expected-parameters-color', default='r',
                         help="What to color the expected-parameters cross. "
                              "Default is red.")
@@ -794,27 +804,28 @@ def plot_ranges_from_cli(opts):
     return mins, maxs
 
 
-def expected_parameters_from_cli(opts):
-    """Parses the --expected-parameters arguments from the `plot_posterior`
-    option group.
+def expected_parameters_from_cli(expected_parameters):
+    """Parses the expected parameters arguments.
 
     Parameters
     ----------
-    opts : ArgumentParser
+    expected_parameters : ArgumentParser
         The parsed arguments from the command line.
 
     Returns
     -------
     dict
         Dictionary of parameter name -> expected value. Only parameters that
-        were specified in the --expected-parameters option will be included; if
+        were specified in the expected parameters option will be included; if
         no parameters were provided, will return an empty dictionary.
     """
     expected = {}
-    for x in opts.expected_parameters:
+    for x in expected_parameters:
         x = x.split(':')
         if len(x) != 2:
-            raise ValueError("option --expected-paramters not specified "
+            raise ValueError("--expected-parameters or "
+                             "--expected-parameters-min or "
+                             "--expected-parameters-max not specified "
                              "correctly; see help")
         expected[x[0]] = float(x[1])
     return expected

--- a/pycbc/results/scatter_histograms.py
+++ b/pycbc/results/scatter_histograms.py
@@ -341,7 +341,7 @@ def create_marginalized_hist(ax, values, label, percentiles=None,
     else:
         orientation = 'vertical'
     ax.hist(values, bins=50, histtype=htype, orientation=orientation,
-            facecolor=fillcolor, edgecolor=color, lw=2, normed=True)
+            facecolor=fillcolor, alpha=0.85, edgecolor=color, lw=2, normed=True)
     if rotated:
         # Remove x-ticks
         ax.set_xticks([])
@@ -359,13 +359,13 @@ def create_marginalized_hist(ax, values, label, percentiles=None,
             ax.axhline(expected_value, color=expected_color, lw=1.5, zorder=2)
         elif (expected_value_min and expected_value_max) is not None:
             ax.axhspan(expected_value_min, expected_value_max, alpha=0.5,
-                       color=expected_color)
+                       color=expected_color, zorder=-1)
         elif expected_value_min is not None and expected_value_max is None:
             ax.axhspan(expected_value_min, plot_max, alpha=0.5,
-                       color=expected_color)
+                       color=expected_color, zorder=-1)
         elif expected_value_max is not None and expected_value_min is None:
             ax.axhspan(plot_min, expected_value_max, alpha=0.5,
-                       color=expected_color)
+                       color=expected_color, zorder=-1)
     else:
         # Remove y-ticks
         ax.set_yticks([])
@@ -383,14 +383,13 @@ def create_marginalized_hist(ax, values, label, percentiles=None,
             ax.axvline(expected_value, color=expected_color, lw=1.5, zorder=2)
         if (expected_value_min and expected_value_max) is not None:
             ax.axvspan(expected_value_min, expected_value_max, alpha=0.5,
-                       color=expected_color)
+                       color=expected_color, zorder=-1)
         elif expected_value_min is not None and expected_value_max is None:
             ax.axvspan(expected_value_min, plot_max, alpha=0.5,
-                       color=expected_color)
+                       color=expected_color, zorder=-1)
         elif expected_value_max is not None and expected_value_min is None:
             ax.axvspan(plot_min, expected_value_max, alpha=0.5,
-                       color=expected_color)
-
+                       color=expected_color, zorder=-1)
 
     if percentiles is None:
         percentiles = [5., 50., 95.]

--- a/pycbc/results/scatter_histograms.py
+++ b/pycbc/results/scatter_histograms.py
@@ -316,11 +316,11 @@ def create_marginalized_hist(ax, values, label, percentiles=None,
     expected_value : {None, float}
         Plot the expected value of the parameter.
     expected_value_min : {None, float}
-        Specify the expected lower boundary value of the range in which the 
-        parameter is expected to lie. The expected region will be shaded in the plot.
+        Specify the expected lower boundary value of the range in which the parameter
+        is expected to lie. The expected region will be shaded in the plot.
     expected_value_max : {None, float}
-        Specify the expected upper boundary value of the range in which the 
-        parameter is expected to lie. The expected region will be shaded in the plot.
+        Specify the expected upper boundary value of the range in which the parameter
+        is expected to lie. The expected region will be shaded in the plot.
     rotated : {False, bool}
         Plot the histogram on the y-axis instead of the x. Default is False.
     plot_min : {None, float}

--- a/pycbc/results/scatter_histograms.py
+++ b/pycbc/results/scatter_histograms.py
@@ -285,7 +285,8 @@ def create_density_plot(xparam, yparam, samples, plot_density=True,
 
 def create_marginalized_hist(ax, values, label, percentiles=None,
         color='k', fillcolor='gray', linecolor='navy',
-        title=True, expected_value=None, expected_color='red',
+        title=True, expected_value=None, expected_value_min=None,
+        expected_value_max=None, expected_color='red',
         rotated=False, plot_min=None, plot_max=None):
     """Plots a 1D marginalized histogram of the given param from the given
     samples.
@@ -312,6 +313,14 @@ def create_marginalized_hist(ax, values, label, percentiles=None,
     title : {True, bool}
         Add a title with the median value +/- uncertainty, with the
         max(min) `percentile` used for the +(-) uncertainty.
+    expected_value : {None, float}
+        Plot the expected value of the parameter.
+    expected_value_min : {None, float}
+        Plot the minimum expected value of the parameter, if parameter is 
+        expected to lie within a range.
+    expected_value_max : {None, float}
+        Plot the maximum expected value of the parameter, if parameter is 
+        expected to lie within a range.
     rotated : {False, bool}
         Plot the histogram on the y-axis instead of the x. Default is False.
     plot_min : {None, float}
@@ -347,6 +356,16 @@ def create_marginalized_hist(ax, values, label, percentiles=None,
             ax.axhline(expected_value, color=expected_color, lw=1.5, zorder=2)
         else:
             ax.axvline(expected_value, color=expected_color, lw=1.5, zorder=2)
+    if expected_value_min is not None:
+        if rotated:
+            ax.axhline(expected_value_min, color=expected_color, ls='dashdot', lw=1.5, zorder=2)
+        else:
+            ax.axvline(expected_value_min, color=expected_color, ls='dashdot', lw=1.5, zorder=2)
+    if expected_value_max is not None:
+        if rotated:
+            ax.axhline(expected_value_max, color=expected_color, ls='dashdot', lw=1.5, zorder=2)
+        else:
+            ax.axvline(expected_value_max, color=expected_color, ls='dashdot', lw=1.5, zorder=2)
     if title:
         values_med = numpy.median(values)
         values_min = values.min()
@@ -469,6 +488,7 @@ def set_marginal_histogram_title(ax, fmt, color, label=None, rotated=False):
 
 def create_multidim_plot(parameters, samples, labels=None,
                 mins=None, maxs=None, expected_parameters=None,
+                expected_parameters_min=None, expected_parameters_max=None,
                 expected_parameters_color='r',
                 plot_marginal=True, plot_scatter=True,
                 marginal_percentiles=None, contour_percentiles=None,
@@ -499,6 +519,14 @@ def create_multidim_plot(parameters, samples, labels=None,
         `samples`.
     expected_parameters : {None, dict}, optional
         Expected values of `parameters`, as a dictionary mapping parameter
+        names -> values. A cross will be plotted at the location of the
+        expected parameters on axes that plot any of the expected parameters.
+    expected_parameters_min : {None, dict}, optional
+        Expected minimum values of `parameters`, as a dictionary mapping parameter
+        names -> values. A cross will be plotted at the location of the
+        expected parameters on axes that plot any of the expected parameters.
+    expected_parameters_max : {None, dict}, optional
+        Expected maximum values of `parameters`, as a dictionary mapping parameter
         names -> values. A cross will be plotted at the location of the
         expected parameters on axes that plot any of the expected parameters.
     expected_parameters_color : {'r', string}, optional
@@ -635,9 +663,25 @@ def create_multidim_plot(parameters, samples, labels=None,
                     expected_value = None
             else:
                 expected_value = None
+            if expected_parameters_min is not None:
+                try:
+                    expected_value_min = expected_parameters_min[param]
+                except KeyError:
+                    expected_value_min = None
+            else:
+                expected_value_min = None
+            if expected_parameters_max is not None:
+                try:
+                    expected_value_max = expected_parameters_max[param]
+                except KeyError:
+                    expected_value_max = None
+            else:
+                expected_value_max = None
             create_marginalized_hist(ax, samples[param], label=labels[param],
                 color=hist_color, fillcolor=fill_color, linecolor=line_color,
                 title=True, expected_value=expected_value,
+                expected_value_min=expected_value_min,
+                expected_value_max=expected_value_max,
                 expected_color=expected_parameters_color,
                 rotated=rotated, plot_min=mins[param], plot_max=maxs[param],
                 percentiles=marginal_percentiles)
@@ -680,6 +724,30 @@ def create_multidim_plot(parameters, samples, labels=None,
                 pass
             try:
                 ax.axhline(expected_parameters[py], lw=1.5,
+                           color=expected_parameters_color, zorder=5)
+            except KeyError:
+                pass
+    
+        if expected_parameters_min is not None:
+            try:
+                ax.axvline(expected_parameters_min[px], ls='dashdot', lw=1.5,
+                           color=expected_parameters_color, zorder=5)
+            except KeyError:
+                pass
+            try:
+                ax.axhline(expected_parameters_min[py], ls='dashdot', lw=1.5,
+                           color=expected_parameters_color, zorder=5)
+            except KeyError:
+                pass
+
+        if expected_parameters_max is not None:
+            try:
+                ax.axvline(expected_parameters_max[px], ls='dashdot', lw=1.5,
+                           color=expected_parameters_color, zorder=5)
+            except KeyError:
+                pass
+            try:
+                ax.axhline(expected_parameters_max[py], ls='dashdot', lw=1.5,
                            color=expected_parameters_color, zorder=5)
             except KeyError:
                 pass

--- a/pycbc/results/scatter_histograms.py
+++ b/pycbc/results/scatter_histograms.py
@@ -316,11 +316,11 @@ def create_marginalized_hist(ax, values, label, percentiles=None,
     expected_value : {None, float}
         Plot the expected value of the parameter.
     expected_value_min : {None, float}
-        Plot the minimum expected value of the parameter, if parameter is
-        expected to lie within a range.
+        Specify the expected lower boundary value of the range in which the 
+        parameter is expected to lie. The expected region will be shaded in the plot.
     expected_value_max : {None, float}
-        Plot the maximum expected value of the parameter, if parameter is
-        expected to lie within a range.
+        Specify the expected upper boundary value of the range in which the 
+        parameter is expected to lie. The expected region will be shaded in the plot.
     rotated : {False, bool}
         Plot the histogram on the y-axis instead of the x. Default is False.
     plot_min : {None, float}
@@ -342,6 +342,56 @@ def create_marginalized_hist(ax, values, label, percentiles=None,
         orientation = 'vertical'
     ax.hist(values, bins=50, histtype=htype, orientation=orientation,
             facecolor=fillcolor, edgecolor=color, lw=2, normed=True)
+    if rotated:
+        # Remove x-ticks
+        ax.set_xticks([])
+        # turn off x-labels
+        ax.set_xlabel('')
+        # set limits
+        ymin, ymax = ax.get_ylim()
+        if plot_min is not None:
+            ymin = plot_min
+        if plot_max is not None:
+            ymax = plot_max
+        ax.set_ylim(ymin, ymax)
+        # Plot expected
+        if expected_value is not None:
+            ax.axhline(expected_value, color=expected_color, lw=1.5, zorder=2)
+        elif (expected_value_min and expected_value_max) is not None:
+            ax.axhspan(expected_value_min, expected_value_max, alpha=0.5,
+                       color=expected_color)
+        elif expected_value_min is not None and expected_value_max is None:
+            ax.axhspan(expected_value_min, plot_max, alpha=0.5,
+                       color=expected_color)
+        elif expected_value_max is not None and expected_value_min is None:
+            ax.axhspan(plot_min, expected_value_max, alpha=0.5,
+                       color=expected_color)
+    else:
+        # Remove y-ticks
+        ax.set_yticks([])
+        # turn off y-label
+        ax.set_ylabel('')
+        # set limits
+        xmin, xmax = ax.get_xlim()
+        if plot_min is not None:
+            xmin = plot_min
+        if plot_max is not None:
+            xmax = plot_max
+        ax.set_xlim(xmin, xmax)
+        # Plot expected
+        if expected_value is not None:
+            ax.axvline(expected_value, color=expected_color, lw=1.5, zorder=2)
+        if (expected_value_min and expected_value_max) is not None:
+            ax.axvspan(expected_value_min, expected_value_max, alpha=0.5,
+                       color=expected_color)
+        elif expected_value_min is not None and expected_value_max is None:
+            ax.axvspan(expected_value_min, plot_max, alpha=0.5,
+                       color=expected_color)
+        elif expected_value_max is not None and expected_value_min is None:
+            ax.axvspan(plot_min, expected_value_max, alpha=0.5,
+                       color=expected_color)
+
+
     if percentiles is None:
         percentiles = [5., 50., 95.]
     values = numpy.percentile(values, percentiles)
@@ -350,22 +400,7 @@ def create_marginalized_hist(ax, values, label, percentiles=None,
             ax.axhline(y=val, ls='dashed', color=linecolor, lw=2, zorder=3)
         else:
             ax.axvline(x=val, ls='dashed', color=linecolor, lw=2, zorder=3)
-    # plot expected
-    if expected_value is not None:
-        if rotated:
-            ax.axhline(expected_value, color=expected_color, lw=1.5, zorder=2)
-        else:
-            ax.axvline(expected_value, color=expected_color, lw=1.5, zorder=2)
-    if expected_value_min is not None:
-        if rotated:
-            ax.axhline(expected_value_min, color=expected_color, ls='dashdot', lw=1.5, zorder=2)
-        else:
-            ax.axvline(expected_value_min, color=expected_color, ls='dashdot', lw=1.5, zorder=2)
-    if expected_value_max is not None:
-        if rotated:
-            ax.axhline(expected_value_max, color=expected_color, ls='dashdot', lw=1.5, zorder=2)
-        else:
-            ax.axvline(expected_value_max, color=expected_color, ls='dashdot', lw=1.5, zorder=2)
+
     if title:
         values_med = numpy.median(values)
         values_min = values.min()
@@ -381,35 +416,10 @@ def create_marginalized_hist(ax, values, label, percentiles=None,
             # sets colored title for marginal histogram
             set_marginal_histogram_title(ax, fmt, color,
                                          label=label, rotated=rotated)
-
-            # Remove x-ticks
-            ax.set_xticks([])
-            # turn off x-labels
-            ax.set_xlabel('')
-            # set limits
-            ymin, ymax = ax.get_ylim()
-            if plot_min is not None:
-                ymin = plot_min
-            if plot_max is not None:
-                ymax = plot_max
-            ax.set_ylim(ymin, ymax)
-
         else:
 
             # sets colored title for marginal histogram
             set_marginal_histogram_title(ax, fmt, color, label=label)
-
-            # Remove y-ticks
-            ax.set_yticks([])
-            # turn off y-label
-            ax.set_ylabel('')
-            # set limits
-            xmin, xmax = ax.get_xlim()
-            if plot_min is not None:
-                xmin = plot_min
-            if plot_max is not None:
-                xmax = plot_max
-            ax.set_xlim(xmin, xmax)
 
 
 def set_marginal_histogram_title(ax, fmt, color, label=None, rotated=False):
@@ -523,12 +533,10 @@ def create_multidim_plot(parameters, samples, labels=None,
         expected parameters on axes that plot any of the expected parameters.
     expected_parameters_min : {None, dict}, optional
         Expected minimum values of `parameters`, as a dictionary mapping parameter
-        names -> values. A cross will be plotted at the location of the
-        expected parameters on axes that plot any of the expected parameters.
+        names -> values.
     expected_parameters_max : {None, dict}, optional
         Expected maximum values of `parameters`, as a dictionary mapping parameter
-        names -> values. A cross will be plotted at the location of the
-        expected parameters on axes that plot any of the expected parameters.
+        names -> values.
     expected_parameters_color : {'r', string}, optional
         What color to make the expected parameters cross.
     plot_marginal : {True, bool}
@@ -724,30 +732,6 @@ def create_multidim_plot(parameters, samples, labels=None,
                 pass
             try:
                 ax.axhline(expected_parameters[py], lw=1.5,
-                           color=expected_parameters_color, zorder=5)
-            except KeyError:
-                pass
-
-        if expected_parameters_min is not None:
-            try:
-                ax.axvline(expected_parameters_min[px], ls='dashdot', lw=1.5,
-                           color=expected_parameters_color, zorder=5)
-            except KeyError:
-                pass
-            try:
-                ax.axhline(expected_parameters_min[py], ls='dashdot', lw=1.5,
-                           color=expected_parameters_color, zorder=5)
-            except KeyError:
-                pass
-
-        if expected_parameters_max is not None:
-            try:
-                ax.axvline(expected_parameters_max[px], ls='dashdot', lw=1.5,
-                           color=expected_parameters_color, zorder=5)
-            except KeyError:
-                pass
-            try:
-                ax.axhline(expected_parameters_max[py], ls='dashdot', lw=1.5,
                            color=expected_parameters_color, zorder=5)
             except KeyError:
                 pass

--- a/pycbc/results/scatter_histograms.py
+++ b/pycbc/results/scatter_histograms.py
@@ -316,10 +316,10 @@ def create_marginalized_hist(ax, values, label, percentiles=None,
     expected_value : {None, float}
         Plot the expected value of the parameter.
     expected_value_min : {None, float}
-        Plot the minimum expected value of the parameter, if parameter is 
+        Plot the minimum expected value of the parameter, if parameter is
         expected to lie within a range.
     expected_value_max : {None, float}
-        Plot the maximum expected value of the parameter, if parameter is 
+        Plot the maximum expected value of the parameter, if parameter is
         expected to lie within a range.
     rotated : {False, bool}
         Plot the histogram on the y-axis instead of the x. Default is False.
@@ -727,7 +727,7 @@ def create_multidim_plot(parameters, samples, labels=None,
                            color=expected_parameters_color, zorder=5)
             except KeyError:
                 pass
-    
+
         if expected_parameters_min is not None:
             try:
                 ax.axvline(expected_parameters_min[px], ls='dashdot', lw=1.5,


### PR DESCRIPTION
Currently the posterior plotting code allows users to plot one specific expected value for each parameter. However, sometimes the parameters are expected to lie in a specific range, instead of one single value. This PR adds two more options `--expected-parameters-min` and `--expected-parameters-max` which will plot the boundaries of the expected range using "dashdot" lines. 

An example plot is here  https://sugwg-jobs.phy.syr.edu/~soumi.de/tmp/test.png .