### PR TITLE
Updated virtualenv builder to install LALSuite into standard virtualenv path

### DIFF
--- a/tools/docker_build_dist.sh
+++ b/tools/docker_build_dist.sh
@@ -176,13 +176,12 @@ export PKG_CONFIG_PATH\\
 # unset PYTHONHOME/" ${VIRTUAL_ENV}/bin/activate
 
   # unset PKG_CONFIG_PATH in deactivate
-  sed -in "s/declared at all/declared at all\\
-
+  sed -in "s/unset _OLD_VIRTUAL_PYTHONHOME/unset _OLD_VIRTUAL_PYTHONHOME\\
+    fi\\
     if ! [ -z \"\${_OLD_PKG_CONFIG_PATH+_}\" ]; then\\
         PKG_CONFIG_PATH=\"\$_OLD_PKG_CONFIG_PATH\"\\
         export PKG_CONFIG_PATH\\
-        unset _OLD_PKG_CONFIG_PATH\\
-    fi/" ${VIRTUAL_ENV}/bin/activate
+        unset _OLD_PKG_CONFIG_PATH/" ${VIRTUAL_ENV}/bin/activate
 
   deactivate
 

--- a/tools/docker_build_dist.sh
+++ b/tools/docker_build_dist.sh
@@ -167,6 +167,23 @@ if [ "x${PYCBC_CONTAINER}" == "xpycbc_rhel_virtualenv" ] || [ "x${PYCBC_CONTAINE
   ./configure --prefix=${VIRTUAL_ENV} --enable-swig-python --disable-lalstochastic --disable-lalxml --disable-lalinference --disable-laldetchar --disable-lalapps 2>&1 | grep -v checking
   make -j 2 2>&1 | grep Entering
   make install 2>&1 | grep Entering
+
+  # write PKG_CONFIG_PATH to activate
+  sed -in "s/# unset PYTHONHOME/_OLD_PKG_CONFIG_PATH=\"\${PKG_CONFIG_PATH}\"\\
+PKG_CONFIG_PATH=\"\${VIRTUAL_ENV}\/lib\/pkgconfig:\${PKG_CONFIG_PATH}\"\\
+export PKG_CONFIG_PATH\\
+\\
+# unset PYTHONHOME/" ${VIRTUAL_ENV}/bin/activate
+
+  # unset PKG_CONFIG_PATH in deactivate
+  sed -in "s/declared at all/declared at all\\
+
+    if ! [ -z \"\${_OLD_PKG_CONFIG_PATH+_}\" ]; then\\
+        PKG_CONFIG_PATH=\"\$_OLD_PKG_CONFIG_PATH\"\\
+        export PKG_CONFIG_PATH\\
+        unset _OLD_PKG_CONFIG_PATH\\
+    fi/" ${VIRTUAL_ENV}/bin/activate
+
   deactivate
 
   echo -e "\\n>> [`date`] Installing LALApps"

--- a/tools/docker_build_dist.sh
+++ b/tools/docker_build_dist.sh
@@ -164,19 +164,18 @@ if [ "x${PYCBC_CONTAINER}" == "xpycbc_rhel_virtualenv" ] || [ "x${PYCBC_CONTAINE
   cd ${VIRTUAL_ENV}/src/lalsuite
   git checkout ${LALSUITE_HASH}
   ./00boot
-  ./configure --prefix=${VIRTUAL_ENV}/opt/lalsuite --enable-swig-python --disable-lalstochastic --disable-lalxml --disable-lalinference --disable-laldetchar --disable-lalapps 2>&1 | grep -v checking
+  ./configure --prefix=${VIRTUAL_ENV} --enable-swig-python --disable-lalstochastic --disable-lalxml --disable-lalinference --disable-laldetchar --disable-lalapps 2>&1 | grep -v checking
   make -j 2 2>&1 | grep Entering
   make install 2>&1 | grep Entering
-  echo 'source ${VIRTUAL_ENV}/opt/lalsuite/etc/lalsuite-user-env.sh' >> ${VIRTUAL_ENV}/bin/activate
   deactivate
 
   echo -e "\\n>> [`date`] Installing LALApps"
   source ${VENV_PATH}/bin/activate
   cd $VIRTUAL_ENV/src/lalsuite/lalapps
   if [ "x${PYCBC_CONTAINER}" == "xpycbc_rhel_virtualenv" ] ; then
-    LIBS="-lhdf5_hl -lhdf5 -lcrypto -lssl -ldl -lz -lstdc++" ./configure --prefix=${VIRTUAL_ENV}/opt/lalsuite --disable-lalxml --disable-lalinference --disable-lalburst --disable-lalpulsar --disable-lalstochastic 2>&1 | grep -v checking
+    LIBS="-lhdf5_hl -lhdf5 -lcrypto -lssl -ldl -lz -lstdc++" ./configure --prefix=${VIRTUAL_ENV} --disable-lalxml --disable-lalinference --disable-lalburst --disable-lalpulsar --disable-lalstochastic 2>&1 | grep -v checking
   elif [ "x${PYCBC_CONTAINER}" == "xpycbc_debian_virtualenv" ] ; then
-    LIBS="-L/usr/lib/x86_64-linux-gnu/hdf5/serial -lhdf5_hl -lhdf5 -lcrypto -lssl -ldl -lz -lstdc++" ./configure --prefix=${VIRTUAL_ENV}/opt/lalsuite --disable-lalxml --disable-lalinference --disable-lalburst --disable-lalpulsar --disable-lalstochastic 2>&1 | grep -v checking
+    LIBS="-L/usr/lib/x86_64-linux-gnu/hdf5/serial -lhdf5_hl -lhdf5 -lcrypto -lssl -ldl -lz -lstdc++" ./configure --prefix=${VIRTUAL_ENV} --disable-lalxml --disable-lalinference --disable-lalburst --disable-lalpulsar --disable-lalstochastic 2>&1 | grep -v checking
   fi
   cd $VIRTUAL_ENV/src/lalsuite/lalapps/src/lalapps
   make -j 2 2>&1 | grep Entering


### PR DESCRIPTION
This PR updates the `cvmfs` virtualenv builder to install LALSuite into the standard `VIRTUAL_ENV` path, rather than `VIRTUAL_ENV/opt/lalsuite`. This removes the need to use the `lal*-user-env.sh` scripts, which set numerous variables that aren't unset by `deactivate` (so result in a corrupt environment after `deactivate`).

Fixes #2089.

This means that the following environment variables are no longer set/modified

- `PKG_CONFIG_PATH`
- `PYTHONPATH`
- `LAL*_PREFIX`
- `LAL*_DATADIR`