### PR TITLE
Add uniform component masses distribution

### DIFF
--- a/examples/distributions/example.ini
+++ b/examples/distributions/example.ini
@@ -16,8 +16,8 @@ v7 =
 v8 =
 v9 =
 ;v10 =
-;mass1 =
-;mass2 =
+mass1 =
+mass2 =
 ;chi_eff =
 ;chi_a =
 ;xi1 =
@@ -73,6 +73,13 @@ max-v8 = 1.0000
 
 [prior-v9]
 name = uniform_angle
+
+[prior-mass1+mass2]
+name = uniform_component_masses
+min-mass1 = 10
+max-mass1 = 80
+min-mass2 = 10
+max-mass2 = 80
 
 ;[prior-10]
 ;name = fromfile

--- a/pycbc/distributions/__init__.py
+++ b/pycbc/distributions/__init__.py
@@ -23,11 +23,13 @@ from pycbc.distributions.power_law import *
 from pycbc.distributions.sky_location import *
 from pycbc.distributions.uniform import *
 from pycbc.distributions import uniform_log
+from pycbc.distributions.masses import UniformComponentMasses
 from pycbc.distributions.spins import IndependentChiPChiEff
 from pycbc.distributions.joint import JointDistribution
 
 # a dict of all available distributions
 distribs = {
+    UniformComponentMasses.name : UniformComponentMasses,
     IndependentChiPChiEff.name : IndependentChiPChiEff,
     Arbitrary.name : Arbitrary,
     FromFile.name : FromFile,

--- a/pycbc/distributions/masses.py
+++ b/pycbc/distributions/masses.py
@@ -27,11 +27,13 @@ class UniformComponentMasses(Uniform):
     masses must be specified. Random samples drawn from this distribution
     always have ``mass1 >= mass2``.
 
-    .. note:: The ranges of mass1 and mass2 may cover the same range; for
-    instance, in the examples below, both mass1 and mass2 have ranges
-    ``[10, 80)``. Likewise, the ``(log)pdf`` function does not require that
-    ``mass1 >= mass2``. It is only in the ``rvs`` function that this convention
-    is enforced.
+    .. note::
+
+        The ranges of mass1 and mass2 may cover the same range; for instance,
+        in the examples below, both mass1 and mass2 have ranges ``[10, 80)``.
+        Likewise, the ``(log)pdf`` function does not require that ``mass1 >=
+        mass2``. It is only in the ``rvs`` function that this convention is
+        enforced.
 
     Parameters
     ----------

--- a/pycbc/distributions/masses.py
+++ b/pycbc/distributions/masses.py
@@ -73,15 +73,17 @@ class UniformComponentMasses(Uniform):
             raise ValueError("must provide limits for mass2")
         super(UniformComponentMasses, self).__init__(mass1=mass2, mass2=mass2)
 
-    def rvs(self, size=1):
+    def rvs(self, size=1, param=None):
         """Gives a set of random values drawn from this distribution.
 
         In the returned set, mass2 <= mass1.
 
         Parameters
         ----------
-        size : {1, int}
+        size : int
             The number of values to generate; default is 1.
+        param : str, optional
+            If provided, will just return values for the given parameter.
 
         Returns
         -------
@@ -94,4 +96,6 @@ class UniformComponentMasses(Uniform):
         m2 = conversions.secondary_mass(arr['mass1'], arr['mass2'])
         arr['mass1'][:] = m1
         arr['mass2'][:] = m2
+        if param is not None:
+            arr = arr[param]
         return arr

--- a/pycbc/distributions/masses.py
+++ b/pycbc/distributions/masses.py
@@ -16,7 +16,6 @@
 This modules provides mass distributions of CBCs.
 """
 
-import numpy
 from pycbc import conversions
 from pycbc.distributions.uniform import Uniform
 

--- a/pycbc/distributions/masses.py
+++ b/pycbc/distributions/masses.py
@@ -1,0 +1,98 @@
+# Copyright (C) 2018 Collin Capano
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+"""
+This modules provides mass distributions of CBCs.
+"""
+
+import numpy
+from pycbc import conversions
+from pycbc.distributions.uniform import Uniform
+
+
+class UniformComponentMasses(Uniform):
+    """A distribution uniform in mass1 and mass2.
+
+    When initializing the distribution, the possible range in the component
+    masses must be specified. Random samples drawn from this distribution
+    always have ``mass1 >= mass2``.
+
+    .. note:: The ranges of mass1 and mass2 may cover the same range; for
+    instance, in the examples below, both mass1 and mass2 have ranges
+    ``[10, 80)``. Likewise, the ``(log)pdf`` function does not require that
+    ``mass1 >= mass2``. It is only in the ``rvs`` function that this convention
+    is enforced.
+
+    Parameters
+    ----------
+    mass1 : tuple or ``boundaries.Bounds``
+        The range for mass1.
+
+    mass2 : tuple of ``boundaries.Bounds``
+        The range for mass2.
+
+    Examples
+    --------
+    Initialize a distribution:
+
+    >>> from pycbc.distributions import UniformComponentMasses
+    >>> d = UniformComponentMasses(mass1=(10., 80.), mass2=(10., 80.))
+
+    Draw random variates from the distribution and check that mass1 >= mass2
+    for all values:
+
+    >>> vals = d.rvs(size=1000)
+    >>> (vals['mass1'] >= vals['mass2']).all()
+    True
+
+    Note that the pdf function does not require ``mass1 >= mass2``:
+
+    >>> d.pdf(mass1=60., mass2=20.)
+    0.00020408163265306107
+    >>> d.pdf(mass1=20., mass2=60.)
+    0.00020408163265306107
+
+    """
+    name = 'uniform_component_masses'
+
+    def __init__(self, mass1=None, mass2=None):
+        # check that parameters for mass1 and mass2 are both provided
+        if mass1 is None:
+            raise ValueError("must provide limits for mass1")
+        if mass2 is None:
+            raise ValueError("must provide limits for mass2")
+        super(UniformComponentMasses, self).__init__(mass1=mass2, mass2=mass2)
+
+    def rvs(self, size=1):
+        """Gives a set of random values drawn from this distribution.
+
+        In the returned set, mass2 <= mass1.
+
+        Parameters
+        ----------
+        size : {1, int}
+            The number of values to generate; default is 1.
+
+        Returns
+        -------
+        structured array
+            The random values in a numpy structured array.
+        """
+        arr = super(UniformComponentMasses, self).rvs(size=size)
+        # enforce m1 > m2
+        m1 = conversions.primary_mass(arr['mass1'], arr['mass2'])
+        m2 = conversions.secondary_mass(arr['mass1'], arr['mass2'])
+        arr['mass1'][:] = m1
+        arr['mass2'][:] = m2
+        return arr

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -32,7 +32,8 @@ from utils import simple_exit
 # some of these distributons have their own specific unit test
 EXCLUDE_DIST_NAMES = ["fromfile", "arbitrary",
                       "uniform_solidangle", "uniform_sky",
-                      "independent_chip_chieff"]
+                      "independent_chip_chieff",
+                      "uniform_component_masses"]
 
 # tests only need to happen on the CPU
 parse_args_cpu_only("Distributions")


### PR DESCRIPTION
This addes a `UniformComponentMasses` distribution. This is mostly a wrapper around `Uniform`, but it requires that `mass1` and `mass2` be provided, and it ensures that `mass1 >= mass2` in the array returned by the `rvs` function.  This should fix annoying book-keeping issues when doing PP tests.

I stuck the distribution in a new module. If we add more mass-specific priors in the future, they can be added to this module.