### PR TITLE
Fix bug in acl burn in when using emcee_pt

### DIFF
--- a/pycbc/inference/burn_in.py
+++ b/pycbc/inference/burn_in.py
@@ -111,7 +111,7 @@ def n_acl(sampler, fp, nacls=10):
         all chains obtain burn in at the same time, this is either an array
         of all False or True.
     """
-    acl = max(sampler.compute_acls(fp, start_index=0).values())
+    acl = numpy.array(sampler.compute_acls(fp, start_index=0).values()).max()
     burn_idx = nacls * acl
     is_burned_in = burn_idx < fp.niterations
     if not is_burned_in:


### PR DESCRIPTION
Should've tested #2112 with `emcee_pt`... this allows the `n_acl` burn in to work with either single or parallel tempered samplers. Currently, when `n_acl` with `emcee_pt` you get the following error:
```
    acl = max(sampler.compute_acls(fp, start_index=0).values())
ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
```