### PR TITLE
Fixed DeprecationWarning when using numpy.linspace

### DIFF
--- a/pycbc/cosmology.py
+++ b/pycbc/cosmology.py
@@ -95,7 +95,7 @@ class _DistToZ(object):
         else:
             self.omega = default_omega
         self.default_maxz = default_maxz
-        self.numpoints = numpoints
+        self.numpoints = int(numpoints)
         self.z2d = numpy.vectorize(lal.LuminosityDistance)
         # for computing nearby (z < 1) redshifts
         zs = numpy.linspace(0., 1., num=self.numpoints)

--- a/pycbc/cosmology.py
+++ b/pycbc/cosmology.py
@@ -98,12 +98,12 @@ class _DistToZ(object):
         self.numpoints = numpoints
         self.z2d = numpy.vectorize(lal.LuminosityDistance)
         # for computing nearby (z < 1) redshifts
-        zs = numpy.linspace(0., 1., num=numpoints)
+        zs = numpy.linspace(0., 1., num=self.numpoints)
         ds = self.z2d(self.omega, zs)
         self.nearby_d2z = interpolate.interp1d(ds, zs, kind='linear',
                                                 bounds_error=False)
         # for computing far away (z > 1) redshifts
-        zs = numpy.logspace(0, numpy.log10(default_maxz), num=numpoints)
+        zs = numpy.logspace(0, numpy.log10(default_maxz), num=self.numpoints)
         ds = self.z2d(self.omega, zs)
         self.faraway_d2z = interpolate.interp1d(ds, zs, kind='linear',
                                                  bounds_error=False)


### PR DESCRIPTION
This PR modifies `pycbc.cosmology._DistToZ` to store `numpoints` internally as `int`, meaning when `numpy.linspace` is called, we don't get a `DeprecationWarning` any more.