### PR TITLE
Fixed two uses of python as a statement

### DIFF
--- a/pycbc/distributions/joint.py
+++ b/pycbc/distributions/joint.py
@@ -64,7 +64,7 @@ class JointDistribution(object):
     >>> uniform_prior = Uniform(mass1=mass_lim, mass2=mass_lim)
     >>> prior_eval = JointDistribution(["mass1", "mass2"], uniform_prior,
         ...                               constraints=[mtotal_lt_30])
-    >>> print prior_eval(mass1=20, mass2=1)
+    >>> print(prior_eval(mass1=20, mass2=1))
 
     """
     name = 'joint'    

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -425,7 +425,7 @@ class ExpFitCombinedSNR(ExpFitStatistic):
         # take reference slope as the harmonic mean of individual ifo slopes
         inv_alphas = [1./self.alphamax[i] for i in self.ifos]
         self.alpharef = (sum(inv_alphas)/len(inv_alphas))**-1
-        print self.alpharef
+        print(self.alpharef)
 
     def single(self, trigs):
         logr_n = self.lognoiserate(trigs)


### PR DESCRIPTION
This PR fixes two lingering uses of the python2 `print` statement, these need to be `print()` function calls in python3.