### PR TITLE
Use string_types for string type checking

### DIFF
--- a/pycbc/inference/likelihood.py
+++ b/pycbc/inference/likelihood.py
@@ -26,6 +26,8 @@ This modules provides classes and functions for evaluating the log likelihood
 for parameter estimation.
 """
 
+from six import string_types
+
 from pycbc import conversions
 from pycbc import filter
 import pycbc.transforms
@@ -175,7 +177,7 @@ class BaseLikelihoodEvaluator(object):
                  sampling_parameters=None, replace_parameters=None,
                  sampling_transforms=None, waveform_transforms=None,
                  return_meta=True):
-        if isinstance(variable_args, str) or isinstance(variable_args, unicode):
+        if isinstance(variable_args, string_types):
             variable_args = (variable_args,)
         if not isinstance(variable_args, tuple):
             variable_args = tuple(variable_args)

--- a/pycbc/inference/sampler_base.py
+++ b/pycbc/inference/sampler_base.py
@@ -26,6 +26,8 @@ This modules provides classes and functions for using different sampler
 packages for parameter estimation.
 """
 
+from six import string_types
+
 import numpy
 from pycbc.io import FieldArray
 from pycbc.filter import autocorrelation
@@ -921,7 +923,7 @@ class BaseMCMCSampler(_BaseSampler):
         acfs = {}
         if parameters is None:
             parameters = fp.variable_args
-        if isinstance(parameters, str) or isinstance(parameters, unicode):
+        if isinstance(parameters, string_types):
             parameters = [parameters]
         for param in parameters:
             if per_walker:

--- a/pycbc/inference/sampler_emcee.py
+++ b/pycbc/inference/sampler_emcee.py
@@ -26,6 +26,8 @@ This modules provides classes and functions for using the emcee sampler
 packages for parameter estimation.
 """
 
+from six import string_types
+
 import numpy
 from pycbc.inference.sampler_base import BaseMCMCSampler, _check_fileformat
 from pycbc.io import FieldArray
@@ -865,7 +867,7 @@ class EmceePTSampler(BaseMCMCSampler):
         acfs = {}
         if parameters is None:
             parameters = fp.variable_args
-        if isinstance(parameters, str) or isinstance(parameters, unicode):
+        if isinstance(parameters, string_types):
             parameters = [parameters]
         if isinstance(temps, int):
             temps = [temps]

--- a/pycbc/io/live.py
+++ b/pycbc/io/live.py
@@ -3,6 +3,7 @@ import os
 import pycbc
 import numpy
 import lal
+from six import u as unicode
 from pycbc.ligolw import ligolw
 from pycbc.ligolw import lsctables
 from pycbc.ligolw import utils as ligolw_utils

--- a/pycbc/io/record.py
+++ b/pycbc/io/record.py
@@ -29,6 +29,7 @@ waves.
 """
 
 import os, sys, types, re, copy, numpy, inspect
+from six import string_types
 from pycbc.ligolw import types as ligolw_types
 from pycbc import coordinates, conversions, cosmology
 from pycbc.detector import Detector
@@ -223,7 +224,7 @@ def get_needed_fieldnames(arr, names):
     # we'll need the class that the array is an instance of to evaluate some 
     # things
     cls = arr.__class__
-    if isinstance(names, (str, unicode)):
+    if isinstance(names, string_types):
         names = [names]
     # parse names for variables, incase some of them are functions of fields
     parsed_names = set([])
@@ -396,7 +397,7 @@ def add_fields(input_array, arrays, names=None, assubarray=False):
     arrays = _ensure_array_list(arrays)
     # set the names
     if names is not None:
-        if isinstance(names, (str, unicode)):
+        if isinstance(names, string_types):
             names = [names]
         # check if any names are subarray names; if so, we have to add them
         # separately
@@ -933,7 +934,7 @@ class FieldArray(numpy.recarray):
         """Adds the given method(s) as instance method(s) of self. The
         method(s) must take `self` as a first argument.
         """
-        if isinstance(names, (str, unicode)):
+        if isinstance(names, string_types):
             names = [names]
             methods = [methods]
         for name,method in zip(names, methods):
@@ -946,7 +947,7 @@ class FieldArray(numpy.recarray):
         """
         cls = type(self)
         cls = type(cls.__name__, (cls,), dict(cls.__dict__))
-        if isinstance(names, (str, unicode)):
+        if isinstance(names, string_types):
             names = [names]
             methods = [methods]
         for name,method in zip(names, methods):
@@ -960,7 +961,7 @@ class FieldArray(numpy.recarray):
         are properties that are assumed to operate on one or more of self's
         fields, thus returning an array of values.
         """
-        if isinstance(names, (str, unicode)):
+        if isinstance(names, string_types):
             names = [names]
             methods = [methods]
         out = self.add_properties(names, methods)
@@ -982,7 +983,7 @@ class FieldArray(numpy.recarray):
         functions : (list of) function(s)
             The function(s) to call.
         """
-        if isinstance(names, (str, unicode)):
+        if isinstance(names, string_types):
             names = [names]
             functions = [functions]
         if len(functions) != len(names):
@@ -1001,7 +1002,7 @@ class FieldArray(numpy.recarray):
         names : (list of) string(s)
             Name or list of names of the functions to remove.
         """
-        if isinstance(names, (str, unicode)):
+        if isinstance(names, string_types):
             names = [names]
         for name in names:
             self._functionlib.pop(name)
@@ -1176,7 +1177,7 @@ class FieldArray(numpy.recarray):
         """
         if fields is None:
             fields = self.fieldnames
-        if isinstance(fields, (str, unicode)):
+        if isinstance(fields, string_types):
             fields = [fields]
         return numpy.stack([self[f] for f in fields], axis=axis)
 
@@ -1450,7 +1451,7 @@ class FieldArray(numpy.recarray):
             The list of names of the fields that are needed in order to
             evaluate the given parameters.
         """
-        if isinstance(possible_fields, (str, unicode)):
+        if isinstance(possible_fields, string_types):
             possible_fields = [possible_fields]
         possible_fields = map(str, possible_fields)
         # we'll just use float as the dtype, as we just need this for names
@@ -1481,7 +1482,7 @@ def fields_from_names(fields, names=None):
 
     if names is None:
         return fields
-    if isinstance(names, (str, unicode)):
+    if isinstance(names, string_types):
         names = [names]
     aliases_to_names = aliases_from_fields(fields)
     names_to_aliases = dict(zip(aliases_to_names.values(),
@@ -1580,7 +1581,7 @@ class _FieldArrayWithDefaults(FieldArray):
             **field_kwargs)
         if 'names' in kwargs:
             names = kwargs.pop('names')
-            if isinstance(names, (str, unicode)):
+            if isinstance(names, string_types):
                 names = [names]
             # evaluate the names to figure out what base fields are needed
             # to do this, we'll create a small default instance of self (since
@@ -1623,7 +1624,7 @@ class _FieldArrayWithDefaults(FieldArray):
         new array : instance of this array
             A copy of this array with the field added.
         """
-        if isinstance(names, (str, unicode)):
+        if isinstance(names, string_types):
             names = [names]
         default_fields = self.default_fields(include_virtual=False, **kwargs)
         # parse out any virtual fields

--- a/pycbc/transforms.py
+++ b/pycbc/transforms.py
@@ -19,6 +19,7 @@ This modules provides classes and functions for transforming parameters.
 import copy
 import logging
 import numpy
+from six import string_types
 from pycbc import conversions
 from pycbc import coordinates
 from pycbc import cosmology
@@ -197,9 +198,9 @@ class CustomTransform(BaseTransform):
 
     def __init__(self, input_args, output_args, transform_functions,
                  jacobian=None):
-        if isinstance(input_args, str) or isinstance(input_args, unicode):
+        if isinstance(input_args, string_types):
             input_args = [input_args]
-        if isinstance(output_args, str) or isinstance(output_args, unicode):
+        if isinstance(output_args, string_types):
             output_args = [output_args]
         self.inputs = set(input_args)
         self.outputs = set(output_args)

--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -31,6 +31,7 @@ import ConfigParser, copy
 import numpy, cPickle, random
 from itertools import combinations, groupby, permutations
 from operator import attrgetter
+from six import string_types
 import lal
 import lal.utils
 import Pegasus.DAX3
@@ -155,7 +156,7 @@ class Executable(pegasus_workflow.Executable):
         tags : list of strings
             A list of strings that is used to identify this job.
         """
-        if isinstance(ifos, (str, unicode)):
+        if isinstance(ifos, string_types):
             self.ifo_list = [ifos]
         else:
             self.ifo_list = ifos
@@ -938,7 +939,7 @@ class File(pegasus_workflow.File):
         self.metadata = {}
         
         # Set the science metadata on the file
-        if isinstance(ifos, (str, unicode)):
+        if isinstance(ifos, string_types):
             self.ifo_list = [ifos]
         else:
             self.ifo_list = ifos

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ lscsoft-glue>=1.58.2
 weave>=0.16.0
 requests>=1.2.1
 beautifulsoup4>=4.6.0
+six
 
 # Ensure pyOpenSSL is recent enough
 pyOpenSSL==17.2.0

--- a/setup.py
+++ b/setup.py
@@ -80,6 +80,7 @@ install_requires =  setup_requires + ['Mako>=1.0.1',
                       'corner>=2.0.1',
                       'requests>=1.2.1',
                       'beautifulsoup4>=4.6.0',
+                      'six',
                       ]
 
 #FIXME Remove me when we bump to h5py > 2.5


### PR DESCRIPTION
This PR updates string type checks for python3 by replacing references to unicode with `six.string_types` where appropriate.

**This adds a dependency on `six`** which has been added to `setup.py` and `requirements.txt`.

I deliberately didn't update `pycbc.ligolw` because `glue.ligolw` has already been patched.