### PR TITLE
Allow mchirp, q transform to handle either q > 1 or q < 1

### DIFF
--- a/pycbc/transforms.py
+++ b/pycbc/transforms.py
@@ -369,7 +369,7 @@ class MchirpQToMass1Mass2(BaseTransform):
             m1 = primary
             m2 = secondary
         out[parameters.mass1] = m1
-        out[parameters.mass2] = m2 
+        out[parameters.mass2] = m2
         return self.format_output(maps, out)
 
     def inverse_transform(self, maps):

--- a/pycbc/transforms.py
+++ b/pycbc/transforms.py
@@ -356,12 +356,20 @@ class MchirpQToMass1Mass2(BaseTransform):
             of transformed values.
         """
         out = {}
-        out[parameters.mass1] = conversions.mass1_from_mchirp_q(
-                                                maps[parameters.mchirp],
-                                                maps[parameters.q])
-        out[parameters.mass2] = conversions.mass2_from_mchirp_q(
-                                                maps[parameters.mchirp],
-                                                maps[parameters.q])
+        mchirp = maps[parameters.mchirp]
+        q = maps[parameters.q]
+        # the mass{1,2}_from_mchirp_q functions always returns mass1 >= mass2
+        primary = conversions.mass1_from_mchirp_q(mchirp, q)
+        secondary = conversions.mass2_from_mchirp_q(mchirp, q)
+        # if q > 1 means mass1 > mass2; if q < 1 means mass2 > mass1
+        if q < 1:
+            m1 = secondary
+            m2 = primary
+        else:
+            m1 = primary
+            m2 = secondary
+        out[parameters.mass1] = m1
+        out[parameters.mass2] = m2 
         return self.format_output(maps, out)
 
     def inverse_transform(self, maps):
@@ -390,30 +398,26 @@ class MchirpQToMass1Mass2(BaseTransform):
             of transformed values.
         """
         out = {}
-        out[parameters.mchirp] = \
-                 conversions.mchirp_from_mass1_mass2(maps[parameters.mass1],
-                                                     maps[parameters.mass2])
-        m_p = conversions.primary_mass(maps[parameters.mass1],
-                                       maps[parameters.mass2])
-        m_s = conversions.secondary_mass(maps[parameters.mass1],
-                                         maps[parameters.mass2])
-        out[parameters.q] = m_p / m_s
+        m1 = maps[parameters.mass1]
+        m2 = maps[parameters.mass2]
+        out[parameters.mchirp] = conversions.mchirp_from_mass1_mass2(m1, m2)
+        out[parameters.q] = m1 / m2
         return self.format_output(maps, out)
 
     def jacobian(self, maps):
         """Returns the Jacobian for transforming mchirp and q to mass1 and
         mass2.
         """
-        mchirp = maps['mchirp']
-        q = maps['q']
+        mchirp = maps[parameters.mchirp]
+        q = maps[parameters.q]
         return mchirp * ((1.+q)/q**3.)**(2./5)
 
     def inverse_jacobian(self, maps):
         """Returns the Jacobian for transforming mass1 and mass2 to
         mchirp and q.
         """
-        m1 = conversions.primary_mass(maps['mass1'], maps['mass2'])
-        m2 = conversions.secondary_mass(maps['mass1'], maps['mass2'])
+        m1 = maps[parameters.mass1]
+        m2 = maps[parameters.mass2]
         return conversions.mchirp_from_mass1_mass2(m1, m2)/m2**2.
 
 


### PR DESCRIPTION
Right now the `MchirpQToMass1Mass2` transform and inverse assumes q > 1. This is problematic for PE if you are using a prior that is not symmetric around the mass1 = mass2 line, since it results in a sampler only sampling the mass1 > mass2 part of parameter space. This fixes this by making the transform return mass2 > mass1 if q < 1.