### PR TITLE
Fix bug in colored_noise function

### DIFF
--- a/pycbc/noise/reproduceable.py
+++ b/pycbc/noise/reproduceable.py
@@ -79,7 +79,7 @@ def normal(start, end, seed=0):
     ts = TimeSeries(data, delta_t=1.0 / SAMPLE_RATE, epoch=start)
     return ts.time_slice(start, end)
 
-def colored_noise(psd, start_time, end_time, seed=0, low_frequency_cutoff=1.0):
+def colored_noise(psd, start_time, end_time, seed=0, low_frequency_cutoff=10.0):
     """ Create noise from a PSD
 
     Return noise from the chosen PSD. Note that if unique noise is desired

--- a/pycbc/noise/reproduceable.py
+++ b/pycbc/noise/reproduceable.py
@@ -79,7 +79,7 @@ def normal(start, end, seed=0):
     ts = TimeSeries(data, delta_t=1.0 / SAMPLE_RATE, epoch=start)
     return ts.time_slice(start, end)
 
-def colored_noise(psd, start_time, end_time, seed=0, low_frequency_cutoff=10.0):
+def colored_noise(psd, start_time, end_time, seed=0, low_frequency_cutoff=1.0):
     """ Create noise from a PSD
 
     Return noise from the chosen PSD. Note that if unique noise is desired
@@ -95,7 +95,7 @@ def colored_noise(psd, start_time, end_time, seed=0, low_frequency_cutoff=10.0):
         End time in GPS seconds to generate nosie
     seed : {None, int}
         The seed to generate the noise.
-    low_frequency_cutof : {10.0, float}
+    low_frequency_cutof : {1.0, float}
         The low frequency cutoff to pass to the PSD generation.
 
     Returns


### PR DESCRIPTION
The colored noise function in the noise module has a default value for the low frequency cutoff. According to the documentation, that value us 10. Hz, but according to the function's arguments, that value is 1.0 Hz. 
This looks like a bug and it probably should be 10 Hz, so in this PR I am changing the function's argument to be low_frequency_cutoff=10.0