### PR TITLE
Make understandable which options are missing for fake strain

### DIFF
--- a/pycbc/strain.py
+++ b/pycbc/strain.py
@@ -345,6 +345,9 @@ def from_cli(opt, dyn_range_fac=1, precision='single',
 
     if opt.fake_strain or opt.fake_strain_from_file:
         logging.info("Generating Fake Strain")
+        if not opt.low_frequency_cutoff:
+            raise ValueError('Please provide low frequency cutoff to '
+                              'generate a fake strain')
         duration = opt.gps_end_time - opt.gps_start_time
         tlen = duration * opt.sample_rate
         pdf = 1.0/128
@@ -367,10 +370,11 @@ def from_cli(opt, dyn_range_fac=1, precision='single',
         else:
             logging.info("Making colored noise")
             from pycbc.noise.reproduceable import colored_noise
+            lowfreq = opt.strain_high_pass if opt.strain_high_pass else 10.
             strain = colored_noise(strain_psd, opt.gps_start_time,
                                           opt.gps_end_time,
                                           seed=opt.fake_strain_seed,
-                                          low_frequency_cutoff=opt.strain_high_pass)
+                                          low_frequency_cutoff=lowfreq)
             strain = resample_to_delta_t(strain, 1.0/opt.sample_rate)
 
 

--- a/pycbc/strain.py
+++ b/pycbc/strain.py
@@ -370,7 +370,7 @@ def from_cli(opt, dyn_range_fac=1, precision='single',
         else:
             logging.info("Making colored noise")
             from pycbc.noise.reproduceable import colored_noise
-            lowfreq = opt.strain_high_pass if opt.strain_high_pass else 10.
+            lowfreq = opt.low_frequency_cutoff / 2.
             strain = colored_noise(strain_psd, opt.gps_start_time,
                                           opt.gps_end_time,
                                           seed=opt.fake_strain_seed,


### PR DESCRIPTION
Currently, pycbc_condition_strain is a bit cryptic for new users trying to generate a fake strain:

* if the user chooses a fake-strain option but does not provide a low-frequency-cutoff, the code fails at generating the PSD complaining about not being able to divide a 'NoneType' and a 'float'. In this PR I have added a sanity check in the strain module, such that it will raise a ValueError asking for the low-frequency-cutoff if a fake-strain option has been selected without the frequency option. This will make it easier to understand why the code failed.

* if the user chooses a fake-strain option different from zero noise, the strain-high-pass option is required to be passed as low frequency cutoff for the colored_noise function. Again it raises the same error as in the previous case if no strain-high-pass is provided, making it difficult to understand what is missing. However, the colored_noise function has a default low_frequency_cutoff=10 (or 1 depending on the acceptance of PR #2139), so that in principle the user wouldn't necessarily need to provide a strain-high-pass. Furthermore, as it currently is, the default in colored_noise is overwritten by 'None' if the user does not provide the strain-high-pass option, hence the error. In this PR I made the low_frequency_cutoff for the colored_noise function to be either the opt.strain_high_pass given by the user or the default 10. Hz if not provided by the user. Therefore, it will not fail if the user does not provide strain-high-pass, but it also gives the option to select a different strain-high-pass than the default.