### PR TITLE
Minor change in GW150914 examples

### DIFF
--- a/examples/gw150914/gw150914_h1_snr.py
+++ b/examples/gw150914/gw150914_h1_snr.py
@@ -12,11 +12,11 @@ h1 = read_frame('H-H1_LOSC_4_V2-1126259446-32.gwf', 'H1:LOSC-STRAIN')
 h1 = highpass_fir(h1, 15, 8)
 
 # Calculate the noise spectrum
-psd = interpolate(welch(h1), 1.0 / 32)
+psd = interpolate(welch(h1), 1.0 / h1.duration)
 
 # Generate a template to filter with
 hp, hc = get_fd_waveform(approximant="IMRPhenomD", mass1=40, mass2=32,
-                         f_lower=20, delta_f=1.0/32)
+                         f_lower=20, delta_f=1.0/h1.duration)
 hp.resize(len(h1) / 2 + 1)
 
 # Calculate the complex (two-phase SNR)

--- a/examples/gw150914/gw150914_shape.py
+++ b/examples/gw150914/gw150914_shape.py
@@ -14,7 +14,7 @@ for ifo in ['H1', 'L1']:
     h1 = highpass_fir(h1, 15, 8)
 
     # Calculate the noise spectrum
-    psd = interpolate(welch(h1), 1.0 / 32)
+    psd = interpolate(welch(h1), 1.0 / h1.duration)
 
     # whiten
     white_strain = (h1.to_frequencyseries() / psd ** 0.5 * psd.delta_f).to_timeseries()


### PR DESCRIPTION
In the GW150914 examples, the delta_f arguments are given as 1./32
This seems not very informative for people who are not familiar with signal processing. First, they would have to notice that there is a "32" in the frame file name and realize that they might be related. Second, they might not necessarily know that delta_f = 1/duration (or even that the 32 in the frame file name is the duration of the data).
To make it a little bit more clear, and since this was an easy change not requiring extra comments/explanations, I have changed those 1./32 by ```1./h1.duration```

It would be possible to even add some comments explaining, for example, what the arguments of the low/highpass_fir are, why choose those specific low_freqs, or things like that. I didn't dare to do that though because I didn't want to overkill it.