### PR TITLE
Only re-calculate burn-in if needed

### DIFF
--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -430,8 +430,13 @@ with ctx:
             logging.info("Writing results to file")
             sampler.write_results(fp,static_args=static_args,
                                   ifos=opts.instruments)
-            logging.info("Updating burn in")
-            burnidx, is_burned_in = burn_in_eval.update(sampler, fp)
+            try:
+                is_burned_in = fp.is_burned_in
+            except AttributeError, KeyError:
+                is_burned_in = False
+            if not is_burned_in:
+                logging.info("Calculating burn in")
+                burnidx, is_burned_in = burn_in_eval.update(sampler, fp)
 
             # compute the acls and write
             acls = None

--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -432,7 +432,7 @@ with ctx:
                                   ifos=opts.instruments)
             try:
                 is_burned_in = fp.is_burned_in
-            except AttributeError, KeyError:
+            except (AttributeError, KeyError):
                 is_burned_in = False
             if not is_burned_in:
                 logging.info("Calculating burn in")


### PR DESCRIPTION
Currently, the burn-in iteration is re-calculated at every checkpoint, even if the sampler has already burned in. This makes it so that burn-in is only calculated if the sampler hasn't burned in yet.