### PR TITLE
Add burn in that uses the minimum of max posterior and n acl

### DIFF
--- a/pycbc/inference/burn_in.py
+++ b/pycbc/inference/burn_in.py
@@ -170,6 +170,15 @@ def max_posterior(sampler, fp):
     return burn_in_idx, is_burned_in
 
 
+def acl_or_max_posterior(sampler, fp):
+    """Burn in that uses the minimum of `n_acl` and `max_posteior`.
+    """
+    acl_bidx, acl_ibi = n_acl(sampler, fp)
+    maxp_bidx, maxp_ibi = max_poseterior(sampler, fp)
+    burn_in_idx = numpy.min([acl_bidx, maxp_bidx], axis=0)
+    is_burned_in = acl_ibi | maxp_ibi
+    return burn_in_idx, is_burned_in
+
 def posterior_step(sampler, fp):
     """Burn in based on the last time a chain made a jump > dim/2.
 
@@ -268,6 +277,7 @@ burn_in_functions = {
     'ks_test': ks_test,
     'n_acl': n_acl,
     'max_posterior': max_posterior,
+    'acl_or_max_posterior': acl_or_max_posterior,
     'posterior_step': posterior_step,
     'half_chain': half_chain,
     'use_sampler': use_sampler,

--- a/pycbc/inference/burn_in.py
+++ b/pycbc/inference/burn_in.py
@@ -174,7 +174,7 @@ def acl_or_max_posterior(sampler, fp):
     """Burn in that uses the minimum of `n_acl` and `max_posteior`.
     """
     acl_bidx, acl_ibi = n_acl(sampler, fp)
-    maxp_bidx, maxp_ibi = max_poseterior(sampler, fp)
+    maxp_bidx, maxp_ibi = max_posterior(sampler, fp)
     burn_in_idx = numpy.min([acl_bidx, maxp_bidx], axis=0)
     is_burned_in = acl_ibi | maxp_ibi
     return burn_in_idx, is_burned_in


### PR DESCRIPTION
This adds a burn-in function that uses sets the burn-in iteration to either `n_acl` or `max_posterior`, whichever comes first. This is useful for kombine: normally, `max_posterior` seems to work fine, but for low-SNR events `n_acl` is a better measure.