### PR TITLE
Some ringdown updates

### DIFF
--- a/pycbc/conversions.py
+++ b/pycbc/conversions.py
@@ -767,9 +767,9 @@ def snr_from_loglr(loglr):
 def get_lm_f0tau(mass, spin, l, m, nmodes):
     """Return the f_0 and the tau of each overtone for a given lm mode
     """
-    qnmfreq = lal.CreateCOMPLEX16Vector(nmodes)
+    qnmfreq = lal.CreateCOMPLEX16Vector(int(nmodes))
     lalsim.SimIMREOBGenerateQNMFreqV2fromFinal(
-        qnmfreq, float(mass), float(spin), l, m, nmodes)
+        qnmfreq, float(mass), float(spin), int(l), int(m), int(nmodes))
     f_0 = [qnmfreq.data[n].real / (2 * numpy.pi) for n in range(nmodes)]
     tau = [1. / qnmfreq.data[n].imag for n in range(nmodes)]
     return f_0, tau

--- a/pycbc/conversions.py
+++ b/pycbc/conversions.py
@@ -791,11 +791,11 @@ def tau_from_final_mass_spin(final_mass, final_spin, l=2, m=2):
 # keys are l,m. Constants are for converting from
 # frequency and damping time to mass and spin
 _berti_spin_constants = {
-    (2,2) : (0.7, 1.4187, -0.4990),
+    (2,2): (0.7, 1.4187, -0.4990),
     }
 
 _berti_mass_constants = {
-    (2,2) : (1.5251, -1.1568, 0.1292),
+    (2,2): (1.5251, -1.1568, 0.1292),
     }
 
 

--- a/pycbc/conversions.py
+++ b/pycbc/conversions.py
@@ -764,27 +764,147 @@ def snr_from_loglr(loglr):
 #
 # =============================================================================
 #
-def get_lm_f0tau(mass, spin, l, m, nmodes):
-    """Return the f_0 and the tau of each overtone for a given lm mode
+def _genqnmfreq(mass, spin, l, m, nmodes, qnmfreq=None):
+    """Convenience function to generate QNM frequencies from lalsimulation.
+
+    Parameters
+    ----------
+    mass : float
+        The mass of the black hole (in solar masses).
+    spin : float
+        The dimensionless spin of the black hole.
+    l : int
+        l-index of the harmonic.
+    m : int
+        m-index of the harmonic.
+    nmodes : int
+        The number of overtones to generate.
+    qnmfreq : lal.COMPLEX16Vector, optional
+        LAL vector to write the results into. Must be the same length as
+        ``nmodes``. If None, will create one.
+
+    Returns
+    -------
+    lal.COMPLEX16Vector
+        LAL vector containing the complex QNM frequencies.
     """
-    qnmfreq = lal.CreateCOMPLEX16Vector(int(nmodes))
+    if qnmfreq is None:
+        qnmfreq = lal.CreateCOMPLEX16Vector(int(nmodes))
     lalsim.SimIMREOBGenerateQNMFreqV2fromFinal(
         qnmfreq, float(mass), float(spin), int(l), int(m), int(nmodes))
-    f_0 = [qnmfreq.data[n].real / (2 * numpy.pi) for n in range(nmodes)]
-    tau = [1. / qnmfreq.data[n].imag for n in range(nmodes)]
-    return f_0, tau
+    return qnmfreq
 
 
-def freq_from_final_mass_spin(final_mass, final_spin, l=2, m=2):
+def get_lm_f0tau(mass, spin, l, m, nmodes):
+    """Return the f0 and the tau of each overtone for a given l, m mode.
+
+    Parameters
+    ----------
+    mass : float or array
+        Mass of the black hole (in solar masses).
+    spin : float or array
+        Dimensionless spin of the final black hole.
+    l : int or array
+        l-index of the harmonic.
+    m : int or array
+        m-index of the harmonic.
+    nmodes : int
+        The number of overtones to generate.
+
+    Returns
+    -------
+    f0 : float or array
+        The frequency of the QNM(s), in Hz. If only a single mode is requested
+        (and mass, spin, l, and m are not arrays), this will be a float. If
+        multiple modes requested, will be an array with shape
+        ``[input shape x] nmodes``, where ``input shape`` is the broadcasted
+        shape of the inputs.
+    tau : float or array
+        The damping time of the QNM(s), in seconds. Return type is same as f0.
+    """
+    # convert to arrays
+    mass, spin, l, m, input_is_array = ensurearray(
+        mass, spin, l, m)
+    # we'll ravel the arrays so we can evaluate each parameter combination
+    # one at a a time
+    origshape = mass.shape
+    if nmodes > 1:
+        newshape = tuple(list(origshape)+[nmodes])
+    else:
+        newshape = origshape
+    f0s = numpy.zeros((mass.size, nmodes))
+    taus = numpy.zeros((mass.size, nmodes))
+    mass = mass.ravel()
+    spin = spin.ravel()
+    l = l.ravel()
+    m = m.ravel()
+    qnmfreq = None
+    modes = range(nmodes)
+    for ii in range(mass.size):
+        qnmfreq = _genqnmfreq(mass[ii], spin[ii], l[ii], m[ii], nmodes,
+                              qnmfreq=qnmfreq)
+        f0s[ii, :] = [qnmfreq.data[n].real/(2 * numpy.pi) for n in modes]
+        taus[ii, :] = [1./qnmfreq.data[n].imag for n in modes]
+    f0s = f0s.reshape(newshape)
+    taus = taus.reshape(newshape)
+    return (formatreturn(f0s, input_is_array),
+            formatreturn(taus, input_is_array))
+
+
+def freq_from_final_mass_spin(final_mass, final_spin, l=2, m=2, nmodes=1):
     """Returns QNM frequency for the given mass and spin and mode.
+
+    Parameters
+    ----------
+    final_mass : float or array
+        Mass of the black hole (in solar masses).
+    final_spin : float or array
+        Dimensionless spin of the final black hole.
+    l : int or array, optional
+        l-index of the harmonic. Default is 2.
+    m : int or array, optional
+        m-index of the harmonic. Default is 2.
+    nmodes : int, optional
+        The number of overtones to generate. Default is 1.
+
+    Returns
+    -------
+    float or array
+        The frequency of the QNM(s), in Hz. If only a single mode is requested
+        (and mass, spin, l, and m are not arrays), this will be a float. If
+        multiple modes requested, will be an array with shape
+        ``[input shape x] nmodes``, where ``input shape`` is the broadcasted
+        shape of the inputs.
     """
-    return get_lm_f0tau(final_mass, final_spin, l, m, 1)[0][0]
+    return get_lm_f0tau(final_mass, final_spin, l, m, nmodes)[0]
 
 
-def tau_from_final_mass_spin(final_mass, final_spin, l=2, m=2):
+def tau_from_final_mass_spin(final_mass, final_spin, l=2, m=2, nmodes=1):
     """Returns QNM damping time for the given mass and spin and mode.
+
+    Parameters
+    ----------
+    final_mass : float or array
+        Mass of the black hole (in solar masses).
+    final_spin : float or array
+        Dimensionless spin of the final black hole.
+    l : int or array, optional
+        l-index of the harmonic. Default is 2.
+    m : int or array, optional
+        m-index of the harmonic. Default is 2.
+    nmodes : int, optional
+        The number of overtones to generate. Default is 1.
+
+    Returns
+    -------
+    float or array
+        The damping time of the QNM(s), in seconds. If only a single mode is
+        requested (and mass, spin, l, and m are not arrays), this will be a
+        float. If multiple modes requested, will be an array with shape
+        ``[input shape x] nmodes``, where ``input shape`` is the broadcasted
+        shape of the inputs.
     """
-    return get_lm_f0tau(final_mass, final_spin, l, m, 1)[1][0]
+    return get_lm_f0tau(final_mass, final_spin, l, m, nmodes)[1]
 
 
 # following are from Berti et al. 2006.
@@ -801,19 +921,73 @@ _berti_mass_constants = {
 
 def final_spin_from_f0_tau(f0, tau, l=2, m=2):
     """Returns the final spin based on the given frequency and damping time.
+
+    .. note::
+        Currently, only l = m = 2 is supported. Any other indices will raise
+        a ``KeyError``.
+
+    Parameters
+    ----------
+    f0 : float or array
+        Frequency of the QNM (in Hz).
+    tau : float or array
+        Damping time of the QNM (in seconds).
+    l : int, optional
+        l-index of the harmonic. Default is 2.
+    m : int, optional
+        m-index of the harmonic. Default is 2.
+
+    Returns
+    -------
+    float or array
+        The spin of the final black hole. If the combination of frequency
+        and damping times give an unphysical result, ``numpy.nan`` will be
+        returned.
     """
+    f0, tau, input_is_array = ensurearray(f0, tau)
     # from Berti et al. 2006
     a, b, c = _berti_spin_constants[l,m]
-    Q = f0 * tau * numpy.pi
-    try:
-        return 1. - ((Q-a)/b)**(1./c)
-    except ValueError:
-        return numpy.nan
+    origshape = f0.shape
+    # flatten inputs for storing results
+    f0 = f0.ravel()
+    tau = tau.ravel()
+    spins = numpy.zeros(f0.size)
+    for ii in range(spins.size):
+        Q = f0[ii] * tau[ii] * numpy.pi
+        try:
+            s = 1. - ((Q-a)/b)**(1./c)
+        except ValueError:
+            s = numpy.nan
+        spins[ii] = s
+    spins = spins.reshape(origshape)
+    return formatreturn(spins, input_is_array)
 
 
 def final_mass_from_f0_tau(f0, tau, l=2, m=2):
     """Returns the final mass (in solar masses) based on the given frequency
     and damping time.
+
+    .. note::
+        Currently, only l = m = 2 is supported. Any other indices will raise
+        a ``KeyError``.
+
+    Parameters
+    ----------
+    f0 : float or array
+        Frequency of the QNM (in Hz).
+    tau : float or array
+        Damping time of the QNM (in seconds).
+    l : int, optional
+        l-index of the harmonic. Default is 2.
+    m : int, optional
+        m-index of the harmonic. Default is 2.
+
+    Returns
+    -------
+    float or array
+        The mass of the final black hole. If the combination of frequency
+        and damping times give an unphysical result, ``numpy.nan`` will be
+        returned.
     """
     # from Berti et al. 2006
     spin = final_spin_from_f0_tau(f0, tau, l=l, m=m)

--- a/pycbc/conversions.py
+++ b/pycbc/conversions.py
@@ -776,11 +776,50 @@ def get_lm_f0tau(mass, spin, l, m, nmodes):
 
 
 def freq_from_final_mass_spin(final_mass, final_spin, l=2, m=2):
+    """Returns QNM frequency for the given mass and spin and mode.
+    """
     return get_lm_f0tau(final_mass, final_spin, l, m, 1)[0][0]
 
 
 def tau_from_final_mass_spin(final_mass, final_spin, l=2, m=2):
+    """Returns QNM damping time for the given mass and spin and mode.
+    """
     return get_lm_f0tau(final_mass, final_spin, l, m, 1)[1][0]
+
+
+# following are from Berti et al. 2006.
+# keys are l,m. Constants are for converting from
+# frequency and damping time to mass and spin
+_berti_spin_constants = {
+    (2,2) : (0.7, 1.4187, -0.4990),
+    }
+
+_berti_mass_constants = {
+    (2,2) : (1.5251, -1.1568, 0.1292),
+    }
+
+
+def final_spin_from_f0_tau(f0, tau, l=2, m=2):
+    """Returns the final spin based on the given frequency and damping time.
+    """
+    # from Berti et al. 2006
+    a, b, c = _berti_spin_constants[l,m]
+    Q = f0 * tau * numpy.pi
+    try:
+        return 1. - ((Q-a)/b)**(1./c)
+    except ValueError:
+        return numpy.nan
+
+
+def final_mass_from_f0_tau(f0, tau, l=2, m=2):
+    """Returns the final mass (in solar masses) based on the given frequency
+    and damping time.
+    """
+    # from Berti et al. 2006
+    spin = final_spin_from_f0_tau(f0, tau, l=l, m=m)
+    a, b, c = _berti_mass_constants[l,m]
+    return (a + b*(1-spin)**c)/(2*numpy.pi*f0*lal.MTSUN_SI)
+
 
 #
 # =============================================================================
@@ -1007,7 +1046,8 @@ __all__ = ['dquadmon_from_lambda', 'lambda_tilde', 'primary_mass',
            'spin2y_from_mass1_mass2_xi2_phi_a_phi_s',
            'chirp_distance', 'det_tc', 'snr_from_loglr',
            'freq_from_final_mass_spin', 'tau_from_final_mass_spin',
+           'final_spin_from_f0_tau', 'final_mass_from_f0_tau',
            'optimal_dec_from_detector', 'optimal_ra_from_detector',
            'chi_eff_from_spherical', 'chi_p_from_spherical',
-           'nltides_gw_phase_diff_isco'
+           'nltides_gw_phase_diff_isco',
           ]

--- a/pycbc/distributions/__init__.py
+++ b/pycbc/distributions/__init__.py
@@ -32,6 +32,7 @@ from pycbc.distributions.uniform import Uniform
 from pycbc.distributions.uniform_log import UniformLog10
 from pycbc.distributions.masses import UniformComponentMasses
 from pycbc.distributions.spins import IndependentChiPChiEff
+from pycbc.distributions.qnm import UniformF0Tau
 from pycbc.distributions.joint import JointDistribution
 
 # a dict of all available distributions
@@ -50,6 +51,7 @@ distribs = {
     UniformSolidAngle.name : UniformSolidAngle,
     UniformSky.name : UniformSky,
     UniformLog10.name : UniformLog10,
+    UniformF0Tau.name : UniformF0Tau,
 }
 
 def read_distributions_from_config(cp, section="prior"):

--- a/pycbc/distributions/qnm.py
+++ b/pycbc/distributions/qnm.py
@@ -1,0 +1,74 @@
+# Copyright (C) 2018 Miriam Cabero, Collin Capano
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+
+from pycbc import conversions
+from . import uniform
+
+class UniformF0Tau(uniform.Uniform):
+    """A distribution uniform in QNM frequency and damping time.
+
+    Constraints may be placed to exclude frequencies and damping times
+    corresponding to specific masses and spins.
+    """
+
+    name = 'uniform_f0_tau'
+
+    def __init__(self, rdfreq='f_0', damping_time='tau', final_mass=None,
+                 final_spin=None, **kwargs):
+        self.rdfreq = rdfreq
+        self.damping_time = damping_time
+        super(UniformF0Tau, self).__init__(**kwargs)
+        if final_mass is None:
+            final_mass = (1., numpy.inf)
+        elif isinstance(final_mass, str) or isinstance(final_mass, unicode):
+            final_mass = map(float, final_mass.split(','))
+        if final_spin is None:
+            final_spin = (-0.996, 0.996)
+        elif isinstance(final_spin, str) or isinstance(final_spin, unicode):
+            final_spin = map(float, final_spin.split(','))
+        self.final_mass_bounds = bounded.boundaries.Bounds(
+            min_bound=final_mass[0], max_bound=final_mass[1])
+        self.final_spin_bounds = bounded.boundaries.Bounds(
+            min_bound=final_spin[0], max_bound=final_spin[1])
+
+    def __contains__(self, params):
+        isin = super(UniformF0Tau, self).__contains__(params)
+        if isin:
+            isin &= self._constraints(params)
+        return isin
+
+    def _constraints(self, params):
+        f_0 = params[self.rdfreq]
+        tau = params[self.damping_time]
+        mf = conversions.final_mass_from_f0_tau(f_0, tau)
+        sf = conversions.final_spin_from_f0_tau(f_0, tau)
+        return (self.final_mass_bounds.__contains__(mf)) & (
+                self.final_spin_bounds.__contains__(sf))
+
+    def rvs(self, size=1):
+        size = int(size)
+        dtype = [(p, float) for p in self.params]
+        arr = numpy.zeros(size, dtype=dtype)
+        remaining = size
+        keepidx = 0
+        while remaining:
+            draws = super(UniformF0Tau, self).rvs(size=remaining)
+            mask = self._constraints(draws)
+            addpts = mask.sum()
+            arr[keepidx:keepidx+addpts] = draws[mask]
+            keepidx += addpts
+            remaining = size - keepidx
+    return arr

--- a/pycbc/distributions/qnm.py
+++ b/pycbc/distributions/qnm.py
@@ -19,6 +19,7 @@ import pycbc
 from pycbc import conversions, boundaries
 from . import uniform, bounded
 
+
 class UniformF0Tau(uniform.Uniform):
     """A distribution uniform in QNM frequency and damping time.
 
@@ -59,7 +60,7 @@ class UniformF0Tau(uniform.Uniform):
 
     Examples
     --------
-    
+
     Create a distribution:
 
     >>> dist = UniformF0Tau(f0=(10., 2048.), tau=(1e-4,1e-2))
@@ -69,24 +70,30 @@ class UniformF0Tau(uniform.Uniform):
 
     >>> from pycbc import conversions
     >>> samples = dist.rvs(size=1000)
-    >>> (conversions.final_mass_from_f0_tau(samples['f0'], samples['tau']) > 1.).all()
+    >>> (conversions.final_mass_from_f0_tau(samples['f0'],
+            samples['tau']) > 1.).all()
     True
 
     Create a distribution with tighter bounds on final mass and spin:
 
-    >>> dist = UniformF0Tau(f0=(10., 2048.), tau=(1e-4,1e-2), final_mass=(20., 200.), final_spin=(0,0.996))
+    >>> dist = UniformF0Tau(f0=(10., 2048.), tau=(1e-4,1e-2),
+            final_mass=(20., 200.), final_spin=(0,0.996))
 
     Check that all random samples drawn from the distribution are in the
     final mass and spin constraints:
 
     >>> samples = dist.rvs(size=1000)
-    >>> (conversions.final_mass_from_f0_tau(samples['f0'], samples['tau']) >= 20.).all()
+    >>> (conversions.final_mass_from_f0_tau(samples['f0'],
+            samples['tau']) >= 20.).all()
     True
-    >>> (conversions.final_mass_from_f0_tau(samples['f0'], samples['tau']) < 200.).all()
+    >>> (conversions.final_mass_from_f0_tau(samples['f0'],
+            samples['tau']) < 200.).all()
     True
-    >>> (conversions.final_spin_from_f0_tau(samples['f0'], samples['tau']) >= 0.).all()
+    >>> (conversions.final_spin_from_f0_tau(samples['f0'],
+            samples['tau']) >= 0.).all()
     True
-    >>> (conversions.final_spin_from_f0_tau(samples['f0'], samples['tau']) < 0.996).all()
+    >>> (conversions.final_spin_from_f0_tau(samples['f0'],
+            samples['tau']) < 0.996).all()
     True
 
     """
@@ -151,7 +158,7 @@ class UniformF0Tau(uniform.Uniform):
 
     def rvs(self, size=1):
         """Draw random samples from this distribution.
-        
+
         Parameters
         ----------
         size : int, optional

--- a/pycbc/distributions/qnm.py
+++ b/pycbc/distributions/qnm.py
@@ -130,7 +130,7 @@ class UniformF0Tau(uniform.Uniform):
         # reset the random state
         numpy.random.set_state(s)
         num_in = self._constraints(draws).sum()
-        # if num_in is 0, than the requested tolerance is too large 
+        # if num_in is 0, than the requested tolerance is too large
         if num_in == 0:
             raise ValueError("the normalization is < then the norm_tolerance; "
                              "try again with a smaller nrom_tolerance")
@@ -243,10 +243,10 @@ class UniformF0Tau(uniform.Uniform):
             raise ValueError("variable args do not match rdfreq and "
                              "damping_time names")
         # get the final mass and spin values, if provided
-        final_mass = bounded.get_param_bounds_from_config(cp, section, tag,
-            'final_mass')
-        final_spin = bounded.get_param_bounds_from_config(cp, section, tag,
-            'final_spin')
+        final_mass = bounded.get_param_bounds_from_config(
+            cp, section, tag, 'final_mass')
+        final_spin = bounded.get_param_bounds_from_config(
+            cp, section, tag, 'final_spin')
         opts = {'final_mass': final_mass, 'final_spin': final_spin}
         extra_opts = {}
         if cp.has_option_tag(section, 'norm_tolerance', tag):

--- a/pycbc/distributions/qnm.py
+++ b/pycbc/distributions/qnm.py
@@ -14,34 +14,87 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 
-from pycbc import conversions
-from . import uniform
+import numpy
+import pycbc
+from pycbc import conversions, boundaries
+from . import uniform, bounded
 
 class UniformF0Tau(uniform.Uniform):
     """A distribution uniform in QNM frequency and damping time.
 
     Constraints may be placed to exclude frequencies and damping times
     corresponding to specific masses and spins.
+
+    Parameters
+    ----------
+    f0 : tuple or boundaries.Bounds
+        The range of QNM frequencies (in Hz).
+    tau : tuple or boundaries.Bounds
+        The range of QNM damping times (in s).
+    final_mass : tuple or boundaries.Bounds, optional
+        The range of final masses to allow. Default is [0,inf).
+    final_spin : tuple or boundaries.Bounds, optional
+        The range final spins to allow. Must be in [-0.996, 0.996], which is
+        the default.
+    rdfreq : str, optional
+        Use the given string as the name for the f0 parameter. Default is 'f0'.
+    damping_time : str, optional
+        Use the given string as the name for the tau parameter. Default is
+        'tau'.
+
+    Examples
+    --------
+    
+    Create a distribution:
+
+    >>> dist = UniformF0Tau(f0=(10., 2048.), tau=(1e-4,1e-2))
+
+    Check that all random samples drawn from the distribution yield final
+    masses > 1:
+
+    >>> from pycbc import conversions
+    >>> samples = dist.rvs(size=1000)
+    >>> (conversions.final_mass_from_f0_tau(samples['f0'], samples['tau']) > 1.).all()
+    True
+
+    Create a distribution with tighter bounds on final mass and spin:
+
+    >>> dist = UniformF0Tau(f0=(10., 2048.), tau=(1e-4,1e-2), final_mass=(20., 200.), final_spin=(0,0.996))
+
+    Check that all random samples drawn from the distribution are in the
+    final mass and spin constraints:
+
+    >>> samples = dist.rvs(size=1000)
+    >>> (conversions.final_mass_from_f0_tau(samples['f0'], samples['tau']) >= 20.).all()
+    True
+    >>> (conversions.final_mass_from_f0_tau(samples['f0'], samples['tau']) < 200.).all()
+    True
+    >>> (conversions.final_spin_from_f0_tau(samples['f0'], samples['tau']) >= 0.).all()
+    True
+    >>> (conversions.final_spin_from_f0_tau(samples['f0'], samples['tau']) < 0.996).all()
+    True
+
     """
 
     name = 'uniform_f0_tau'
 
-    def __init__(self, rdfreq='f_0', damping_time='tau', final_mass=None,
-                 final_spin=None, **kwargs):
+    def __init__(self, f0=None, tau=None, final_mass=None, final_spin=None,
+                 rdfreq='f0', damping_time='tau'):
+        if f0 is None:
+            raise ValueError("must provide a range for f0")
+        if tau is None:
+            raise ValueError("must provide a range for tau")
         self.rdfreq = rdfreq
         self.damping_time = damping_time
-        super(UniformF0Tau, self).__init__(**kwargs)
+        parent_args = {rdfreq: f0, damping_time: tau}
+        super(UniformF0Tau, self).__init__(**parent_args)
         if final_mass is None:
-            final_mass = (1., numpy.inf)
-        elif isinstance(final_mass, str) or isinstance(final_mass, unicode):
-            final_mass = map(float, final_mass.split(','))
+            final_mass = (0., numpy.inf)
         if final_spin is None:
             final_spin = (-0.996, 0.996)
-        elif isinstance(final_spin, str) or isinstance(final_spin, unicode):
-            final_spin = map(float, final_spin.split(','))
-        self.final_mass_bounds = bounded.boundaries.Bounds(
+        self.final_mass_bounds = boundaries.Bounds(
             min_bound=final_mass[0], max_bound=final_mass[1])
-        self.final_spin_bounds = bounded.boundaries.Bounds(
+        self.final_spin_bounds = boundaries.Bounds(
             min_bound=final_spin[0], max_bound=final_spin[1])
 
     def __contains__(self, params):
@@ -51,14 +104,26 @@ class UniformF0Tau(uniform.Uniform):
         return isin
 
     def _constraints(self, params):
-        f_0 = params[self.rdfreq]
+        f0 = params[self.rdfreq]
         tau = params[self.damping_time]
-        mf = conversions.final_mass_from_f0_tau(f_0, tau)
-        sf = conversions.final_spin_from_f0_tau(f_0, tau)
+        mf = conversions.final_mass_from_f0_tau(f0, tau)
+        sf = conversions.final_spin_from_f0_tau(f0, tau)
         return (self.final_mass_bounds.__contains__(mf)) & (
                 self.final_spin_bounds.__contains__(sf))
 
     def rvs(self, size=1):
+        """Draw random samples from this distribution.
+        
+        Parameters
+        ----------
+        size : int, optional
+            The number of draws to do. Default is 1.
+
+        Returns
+        -------
+        array
+            A structured array of the random draws.
+        """
         size = int(size)
         dtype = [(p, float) for p in self.params]
         arr = numpy.zeros(size, dtype=dtype)
@@ -71,4 +136,72 @@ class UniformF0Tau(uniform.Uniform):
             arr[keepidx:keepidx+addpts] = draws[mask]
             keepidx += addpts
             remaining = size - keepidx
-    return arr
+        return arr
+
+    @classmethod
+    def from_config(cls, cp, section, variable_args):
+        """Initialize this class from a config file.
+
+        Bounds on ``f0``, ``tau``, ``final_mass`` and ``final_spin`` should
+        be specified by providing ``min-{param}`` and ``max-{param}``. If
+        the ``f0`` or ``tau`` param should be renamed, ``rdfreq`` and
+        ``damping_time`` should be provided; these must match
+        ``variable_args``. If ``rdfreq`` and ``damping_time`` are not
+        provided, ``variable_args`` are expected to be ``f0`` and ``tau``.
+
+        Only ``min/max-f0`` and ``min/max-tau`` need to be provided.
+
+        Example:
+
+        .. code-block:: ini
+
+            [{section}-f0+tau]
+            name = uniform_f0_tau
+            min-f0 = 10
+            max-f0 = 2048
+            min-tau = 0.0001
+            max-tau = 0.010
+            min-final_mass = 10
+
+        Parameters
+        ----------
+        cp : pycbc.workflow.WorkflowConfigParser
+            WorkflowConfigParser instance to read.
+        section : str
+            The name of the section to read.
+        variable_args : str
+            The name of the variable args. These should be separated by
+            ``pycbc.VARARGS_DELIM``.
+
+        Returns
+        -------
+        UniformF0Tau :
+            This class initialized with the parameters provided in the config
+            file.
+        """
+        tag = variable_args
+        variable_args = set(variable_args.split(pycbc.VARARGS_DELIM))
+        # get f0 and tau
+        f0 = bounded.get_param_bounds_from_config(cp, section, tag, 'f0')
+        tau = bounded.get_param_bounds_from_config(cp, section, tag, 'tau')
+        # see if f0 and tau should be renamed
+        if cp.has_option_tag(section, 'rdfreq', tag):
+            rdfreq = cp.get_opt_tag(section, 'rdfreq', tag)
+        else:
+            rdfreq = 'f0'
+        if cp.has_option_tag(section, 'damping_time', tag):
+            damping_time = cp.get_opt_tag(section, 'damping_time', tag)
+        else:
+            damping_time = 'tau'
+        # check that they match whats in the variable args
+        if not variable_args == set([rdfreq, damping_time]):
+            raise ValueError("variable args do not match rdfreq and "
+                             "damping_time names")
+        # get the final mass and spin values, if provided
+        final_mass = bounded.get_param_bounds_from_config(cp, section, tag,
+            'final_mass')
+        final_spin = bounded.get_param_bounds_from_config(cp, section, tag,
+            'final_spin')
+        opts = {'final_mass': final_mass, 'final_spin': final_spin}
+        return cls(f0=f0, tau=tau, final_mass=final_mass, rdfreq=rdfreq,
+                   damping_time=damping_time)

--- a/pycbc/distributions/qnm.py
+++ b/pycbc/distributions/qnm.py
@@ -247,7 +247,6 @@ class UniformF0Tau(uniform.Uniform):
             cp, section, tag, 'final_mass')
         final_spin = bounded.get_param_bounds_from_config(
             cp, section, tag, 'final_spin')
-        opts = {'final_mass': final_mass, 'final_spin': final_spin}
         extra_opts = {}
         if cp.has_option_tag(section, 'norm_tolerance', tag):
             extra_opts['norm_tolerance'] = float(
@@ -255,5 +254,7 @@ class UniformF0Tau(uniform.Uniform):
         if cp.has_option_tag(section, 'norm_seed', tag):
             extra_opts['norm_seed'] = int(
                 cp.get_opt_tag(section, 'norm_seed', tag))
-        return cls(f0=f0, tau=tau, final_mass=final_mass, rdfreq=rdfreq,
-                   damping_time=damping_time, **extra_opts)
+        return cls(f0=f0, tau=tau,
+                   final_mass=final_mass, final_spin=final_spin,
+                   rdfreq=rdfreq, damping_time=damping_time,
+                   **extra_opts)

--- a/pycbc/waveform/ringdown.py
+++ b/pycbc/waveform/ringdown.py
@@ -29,7 +29,7 @@ import numpy, lal
 import lalsimulation as lalsim
 from pycbc.types import TimeSeries, FrequencySeries, float64, complex128, zeros
 from pycbc.waveform.waveform import get_obj_attrs
-from pycbc.conversions import get_lm_f0tau
+from pycbc.conversions import get_lm_f0tau_allmodes
 
 default_qnm_args = {'t_0':0}
 qnm_required_args = ['f_0', 'tau', 'amp', 'phi']
@@ -114,22 +114,6 @@ def lm_freqs_taus(**kwargs):
                 raise ValueError('tau_%d%d%d is required' %(l,m,n))
 
     return freqs, taus
-
-# Functions to obtain f_0 and tau from mass and spin #########################
-def get_lm_f0tau_allmodes(mass, spin, modes):
-    """Return a dictionary with the f_0 and tau for all the modes
-    in the list lmns (list of strings)
-    """
-
-    f_0, tau = {}, {}
-    for lmn in modes:
-        l, m, nmodes = int(lmn[0]), int(lmn[1]), int(lmn[2])
-        tmp_f0, tmp_tau = get_lm_f0tau(mass, spin, l, m, nmodes)
-        for n in range(nmodes):
-            f_0['%d%d%d' %(l,m,n)] = tmp_f0[n]
-            tau['%d%d%d' %(l,m,n)] = tmp_tau[n]
-
-    return f_0, tau
 
 # Functions to obtain t_final and f_final #####################################
 

--- a/pycbc/waveform/ringdown.py
+++ b/pycbc/waveform/ringdown.py
@@ -29,6 +29,7 @@ import numpy, lal
 import lalsimulation as lalsim
 from pycbc.types import TimeSeries, FrequencySeries, float64, complex128, zeros
 from pycbc.waveform.waveform import get_obj_attrs
+from pycbc.conversions import get_lm_f0tau
 
 default_qnm_args = {'t_0':0}
 qnm_required_args = ['f_0', 'tau', 'amp', 'phi']
@@ -115,18 +116,6 @@ def lm_freqs_taus(**kwargs):
     return freqs, taus
 
 # Functions to obtain f_0 and tau from mass and spin #########################
-
-def get_lm_f0tau(mass, spin, l, m, nmodes):
-    """Return the f_0 and the tau of each overtone for a given lm mode
-    """
-    qnmfreq = lal.CreateCOMPLEX16Vector(nmodes)
-    lalsim.SimIMREOBGenerateQNMFreqV2fromFinal(qnmfreq, mass, spin, l, m, nmodes)
-
-    f_0 = [qnmfreq.data[n].real / (2 * pi) for n in range(nmodes)]
-    tau = [1. / qnmfreq.data[n].imag for n in range(nmodes)]
-
-    return f_0, tau
-
 def get_lm_f0tau_allmodes(mass, spin, modes):
     """Return a dictionary with the f_0 and tau for all the modes
     in the list lmns (list of strings)

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -33,7 +33,7 @@ from pycbc.workflow import WorkflowConfigParser
 EXCLUDE_DIST_NAMES = ["fromfile", "arbitrary",
                       "uniform_solidangle", "uniform_sky",
                       "independent_chip_chieff",
-                      "uniform_component_masses"]
+                      "uniform_component_masses", "uniform_f0_tau"]
 
 # tests only need to happen on the CPU
 parse_args_cpu_only("Distributions")


### PR DESCRIPTION
This adds final mass and spin from `f0`, `tau` functions to conversions. These functions use the Berti et al. fits. Currently, only support for l = m = 2 is provided.

A `qnm` module is also added to `distributions`, which includes a `UniformF0Tau` distribution. This distribution allows for constraints on final mass and spin to be provided.

Both of these are largely copied from @micamu area theorem branch.

Note: strictly speaking, the `UniformF0Tau` distribution isn't needed, since the same thing could be accomplished by providing a `Uniform` distribution (for f0 and tau) along with constraints (for final mass and spin) to the `JointDistribution`. That's a bit complicated though. `UnformF0Tau` is a convenience class, similar to `UniformSky`.