### PR TITLE
Add new coinc event combiner executable

### DIFF
--- a/bin/hdfcoinc/pycbc_combine_coincident_events
+++ b/bin/hdfcoinc/pycbc_combine_coincident_events
@@ -1,0 +1,101 @@
+#!/usr/bin/env python
+"""
+This program combines together a set of STATMAP files from disjoint times.
+The resulting file would contain triggers from the full set of input files
+"""
+import numpy
+import argparse
+import logging
+import h5py
+
+import lal
+
+import pycbc
+import pycbc.events
+import pycbc.version
+
+import h5py, numpy, argparse, logging, pycbc, pycbc.events, lal
+import pycbc.version
+
+def com(f, files, group):
+    """ Combine the same column from multiple files into another file f"""
+    try:
+        f[group] = numpy.concatenate([fi[group][:] if group in fi else numpy.array([], dtype=numpy.uint32) for fi in files])
+    except:
+        print group
+        raise
+
+def com_with_swapping(f, files, group):
+    """
+    Combine data from multiple files where the group is dependent on which of
+    the two ifos the data belongs to, e.g. time1, time2 or trigger_id1,
+    trigger_id2. This function checks which of the two groups should be used
+    for each file, as each file might have a different convention, and combines
+    according to the attributes set in f.
+    """
+    # Set what the group should be for the "other" ifo
+    if group.endswith('1'):
+        ngroup = group[:-1] + '2'
+    elif group.endswith('2'):
+        ngroup = group[:-1] + '1'
+    else:
+        raise ValueError("Input must end in 1 or 2, got %s" % inp_str)
+
+    # Need to swap detector ID if this file uses the other convention
+    data_for_catting = [files[0][group][:]]
+    for nfp in files[1:]:
+        if nfp.attrs['detector_1'] == f.attrs['detector_1']:
+            data_for_catting.append(nfp[group][:])
+        else:
+            data_for_catting.append(nfp[ngroup][:])
+    f[group] = numpy.concatenate(data_for_catting)
+    
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--version", action="version", version=pycbc.version.git_verbose_msg)
+parser.add_argument('--verbose', action='store_true')
+parser.add_argument('--statmap-files', nargs='+',
+                    help="List of coinc files to be redistributed")
+parser.add_argument('--output-file', help="name of output file")
+args = parser.parse_args()
+
+pycbc.init_logging(args.verbose)
+
+files = [h5py.File(n) for n in args.statmap_files]
+
+# Start setting some of the attributes
+f = h5py.File(args.output_file, "w")
+# It's not guaranteed that all files will follow this, so be careful later!
+f.attrs['detector_1'] = files[0].attrs['detector_1']
+f.attrs['detector_2'] = files[0].attrs['detector_2']
+# This may not be constant over all files, but ignore for now
+f.attrs['timeslide_interval'] = files[0].attrs['timeslide_interval']
+
+f.attrs['background_time'] = \
+    sum([cfp.attrs['background_time'] for cfp in files])
+f.attrs['foreground_time'] = \
+    sum([cfp.attrs['foreground_time'] for cfp in files])
+f.attrs['background_time_exc'] = \
+    sum([cfp.attrs['background_time_exc'] for cfp in files])
+f.attrs['foreground_time_exc'] = \
+    sum([cfp.attrs['foreground_time_exc'] for cfp in files])
+
+# combine times that are foreground vetoed as they may differ between bins
+for key in files[0]['segments'].keys():
+    com(f, files, 'segments/%s/start' % key)
+    com(f, files, 'segments/%s/end' % key)
+
+# copy over all the columns in the foreground group. A few special cases here
+for fg_bg_key in ['foreground', 'background', 'background_exc']:
+    for key in files[0][fg_bg_key].keys():
+        if key not in ['time1', 'time2', 'trigger_id1', 'trigger_id2',
+                       'fap', 'fap_exc']:
+            com(f, files, '%s/%s' % (fg_bg_key,key))
+        elif key in ['time1', 'time2', 'trigger_id1', 'trigger_id2']:
+            # Check if all files use the same detector numbering
+            com_with_swapping(f, files, '%s/%s' % (fg_bg_key,key))
+        else:
+            # Do not store FAP numbers ... Could be recalculated.
+            continue
+    
+f.close()

--- a/bin/hdfcoinc/pycbc_combine_coincident_events
+++ b/bin/hdfcoinc/pycbc_combine_coincident_events
@@ -13,7 +13,9 @@ import pycbc.version
 
 def com(f, files, group):
     """ Combine the same column from multiple files into another file f"""
-    f[group] = numpy.concatenate([fi[group][:] if group in fi else numpy.array([], dtype=numpy.uint32) for fi in files])
+    f[group] = numpy.concatenate\
+        ([fi[group][:] if group in fi else numpy.array([], dtype=numpy.uint32)\
+         for fi in files])
 
 def com_with_detector_key(f, files, group):
     """
@@ -33,7 +35,7 @@ def com_with_detector_key(f, files, group):
     elif group.endswith('2'):
         ifo_name = f.attrs['detector_2']
     else:
-        raise ValueError("Input must end in 1 or 2, got %s" % inp_str)
+        raise ValueError("Group name must end in 1 or 2, got %s" % group)
 
     # We defined the format using the first file, so we can just add that
     data_for_catting = [files[0][group][:]]

--- a/bin/hdfcoinc/pycbc_combine_coincident_events
+++ b/bin/hdfcoinc/pycbc_combine_coincident_events
@@ -8,22 +8,12 @@ import argparse
 import logging
 import h5py
 
-import lal
-
 import pycbc
-import pycbc.events
-import pycbc.version
-
-import h5py, numpy, argparse, logging, pycbc, pycbc.events, lal
 import pycbc.version
 
 def com(f, files, group):
     """ Combine the same column from multiple files into another file f"""
-    try:
-        f[group] = numpy.concatenate([fi[group][:] if group in fi else numpy.array([], dtype=numpy.uint32) for fi in files])
-    except:
-        print group
-        raise
+    f[group] = numpy.concatenate([fi[group][:] if group in fi else numpy.array([], dtype=numpy.uint32) for fi in files])
 
 def com_with_detector_key(f, files, group):
     """
@@ -79,8 +69,6 @@ f = h5py.File(args.output_file, "w")
 # It's not guaranteed that all files will follow this, so be careful later!
 f.attrs['detector_1'] = files[0].attrs['detector_1']
 f.attrs['detector_2'] = files[0].attrs['detector_2']
-# This may not be constant over all files, but ignore for now
-f.attrs['timeslide_interval'] = files[0].attrs['timeslide_interval']
 
 f.attrs['background_time'] = \
     sum([cfp.attrs['background_time'] for cfp in files])
@@ -91,7 +79,7 @@ f.attrs['background_time_exc'] = \
 f.attrs['foreground_time_exc'] = \
     sum([cfp.attrs['foreground_time_exc'] for cfp in files])
 
-# combine times that are foreground vetoed as they may differ between bins
+# Combine segments
 for key in files[0]['segments'].keys():
     com(f, files, 'segments/%s/start' % key)
     com(f, files, 'segments/%s/end' % key)

--- a/bin/hdfcoinc/pycbc_combine_coincident_events
+++ b/bin/hdfcoinc/pycbc_combine_coincident_events
@@ -25,29 +25,40 @@ def com(f, files, group):
         print group
         raise
 
-def com_with_swapping(f, files, group):
+def com_with_detector_key(f, files, group):
     """
     Combine data from multiple files where the group is dependent on which of
     the two ifos the data belongs to, e.g. time1, time2 or trigger_id1,
-    trigger_id2. This function checks which of the two groups should be used
+    trigger_id2. This function checks which group should be used
     for each file, as each file might have a different convention, and combines
     according to the attributes set in f.
     """
-    # Set what the group should be for the "other" ifo
+    # We have to be careful here, because in these cases the group, for
+    # example time1 or time2 encodes a detector name, stored in the attributes.
+    # It may not be the *same* detector for each file.
+
+    # What detector are we dealing with
     if group.endswith('1'):
-        ngroup = group[:-1] + '2'
+        ifo_name = f.attrs['detector_1']
     elif group.endswith('2'):
-        ngroup = group[:-1] + '1'
+        ifo_name = f.attrs['detector_2']
     else:
         raise ValueError("Input must end in 1 or 2, got %s" % inp_str)
 
-    # Need to swap detector ID if this file uses the other convention
+    # We defined the format using the first file, so we can just add that
     data_for_catting = [files[0][group][:]]
+    # For the remaining files we must check the detector name
     for nfp in files[1:]:
-        if nfp.attrs['detector_1'] == f.attrs['detector_1']:
-            data_for_catting.append(nfp[group][:])
+        # What detector do we need in this file
+        if nfp.attrs['detector_1'] == ifo_name:
+            new_det_num = '1'
+        elif nfp.attrs['detector_2'] == ifo_name:
+            new_det_num = '2'
         else:
-            data_for_catting.append(nfp[ngroup][:])
+            raise ValueError("Cannot find detector %s in input file" % ifo_name)
+        new_group = group[:-1] + new_det_num
+
+        data_for_catting.append(nfp[new_group][:])
     f[group] = numpy.concatenate(data_for_catting)
     
 
@@ -92,8 +103,8 @@ for fg_bg_key in ['foreground', 'background', 'background_exc']:
                        'fap', 'fap_exc']:
             com(f, files, '%s/%s' % (fg_bg_key,key))
         elif key in ['time1', 'time2', 'trigger_id1', 'trigger_id2']:
-            # Check if all files use the same detector numbering
-            com_with_swapping(f, files, '%s/%s' % (fg_bg_key,key))
+            # Check if all files use the same detector convention
+            com_with_detector_key(f, files, '%s/%s' % (fg_bg_key,key))
         else:
             # Do not store FAP numbers ... Could be recalculated.
             continue

--- a/setup.py
+++ b/setup.py
@@ -410,6 +410,7 @@ setup (
                'bin/hdfcoinc/pycbc_coinc_findtrigs',
                'bin/hdfcoinc/pycbc_coinc_statmap',
                'bin/hdfcoinc/pycbc_coinc_statmap_inj',
+               'bin/hdfcoinc/pycbc_combine_coincident_events',
                'bin/hdfcoinc/pycbc_page_foreground',
                'bin/hdfcoinc/pycbc_page_foundmissed',
                'bin/hdfcoinc/pycbc_page_ifar',


### PR DESCRIPTION
This executable combines "STATMAP" files together into one database, which can be used with existing plotting code (e.g. plotifar or snrifar). For now I'm just combining the coincident events, and not worrying about the single-detector trigger information or the template bank parameters, but we could look to add that as a future feature if it becomes necessary.

This used the old `pycbc_combine_statmap` executable as an example to build on.