### PR TITLE
Change m_1 > m_2 when getting masses from mc and q

### DIFF
--- a/pycbc/conversions.py
+++ b/pycbc/conversions.py
@@ -271,13 +271,13 @@ def eta_from_q(q):
 
 def mass1_from_mchirp_q(mchirp, q):
     """Returns the primary mass from the given chirp mass and mass ratio."""
-    return mass1_from_mchirp_eta(mchirp, eta_from_q(q))
-
+    mass1 = (q**(2./5.))*((1.0 + q)**(1./5.))*mchirp
+    return mass1
 
 def mass2_from_mchirp_q(mchirp, q):
     """Returns the secondary mass from the given chirp mass and mass ratio."""
-    return mass2_from_mchirp_eta(mchirp, eta_from_q(q))
-
+    mass2 = (q**(-3./5.))*((1.0 + q)**(1./5.))*mchirp
+    return mass2
 
 def _a0(f_lower):
     """Used in calculating chirp times: see Cokelaer, arxiv.org:0706.4437

--- a/pycbc/transforms.py
+++ b/pycbc/transforms.py
@@ -442,7 +442,7 @@ class ChirpDistanceToDistance(BaseTransform):
         >>> t = transforms.ChirpDistanceToDistance()
         >>> t.transform({'chirp_distance': np.array([40.]), 'mchirp': np.array([1.2])})
         {'mchirp': array([ 1.2]), 'chirp_distance': array([ 40.]), 'distance': array([ 39.48595679])}
-        
+
         Returns
         -------
         out : dict

--- a/pycbc/transforms.py
+++ b/pycbc/transforms.py
@@ -356,20 +356,12 @@ class MchirpQToMass1Mass2(BaseTransform):
             of transformed values.
         """
         out = {}
-        mchirp = maps[parameters.mchirp]
-        q = maps[parameters.q]
-        # the mass{1,2}_from_mchirp_q functions always returns mass1 >= mass2
-        primary = conversions.mass1_from_mchirp_q(mchirp, q)
-        secondary = conversions.mass2_from_mchirp_q(mchirp, q)
-        # if q > 1 means mass1 > mass2; if q < 1 means mass2 > mass1
-        if q < 1:
-            m1 = secondary
-            m2 = primary
-        else:
-            m1 = primary
-            m2 = secondary
-        out[parameters.mass1] = m1
-        out[parameters.mass2] = m2
+        out[parameters.mass1] = conversions.mass1_from_mchirp_q(
+                                                maps[parameters.mchirp],
+                                                maps[parameters.q])
+        out[parameters.mass2] = conversions.mass2_from_mchirp_q(
+                                                maps[parameters.mchirp],
+                                                maps[parameters.q])
         return self.format_output(maps, out)
 
     def inverse_transform(self, maps):


### PR DESCRIPTION
This PR : 
1. Changes the formulae in `mass1_from_mchirp_q` and `mass2_from_mchirp_q` so that if q < 1 they will return mass1 as the smaller mass and mass2 as the bigger mass, based on the definition of `q=mass1/mass2` used in PyCBC.
2. Removes the check in `MchirpQToMass1Mass2` in `transforms.py` for the smaller or bigger mass based on whether q < 1 or q > 1.

testing this PR : 
```
In [10]: mchirp = conversions.mchirp_from_mass1_mass2(1.62402681, 3.24805362)

In [11]: q = 1.62402681/3.24805362

In [12]: mchirp
Out[12]: 1.9760000029651446

In [13]: q
Out[13]: 0.5

In [14]: conversions.mass1_from_mchirp_q(1.9760000029651446, 0.5)
Out[14]: 1.6240268099999997

In [15]: conversions.mass2_from_mchirp_q(1.9760000029651446, 0.5)
Out[15]: 3.2480536199999994
```
I get `mass1` as the smaller mass because I gave `q < 1`

Also, checking if this is doing the same job as PR #2136 was meant to do : 
PR 2136 : 
``` 
In [3]: t = transforms.MchirpQToMass1Mass2()

In [4]: t.transform({'mchirp': numpy.array([1.976]), 'q': numpy.array([0.5])})
Out[4]: 
{'mass1': array([1.62402681]),
 'mass2': array([3.24805362]),
 'mchirp': array([1.976]),
 'q': array([0.5])}

In [5]: t.transform({'mchirp': numpy.array([1.976]), 'q': numpy.array([2.0])})
Out[5]: 
{'mass1': array([3.24805362]),
 'mass2': array([1.62402681]),
 'mchirp': array([1.976]),
 'q': array([2.])}
```

This PR : 
```
In [3]: t = transforms.MchirpQToMass1Mass2()

In [4]: t.transform({'mchirp': numpy.array([1.976]), 'q': numpy.array([0.5])})
Out[4]: 
{'mass1': array([1.62402681]),
 'mass2': array([3.24805362]),
 'mchirp': array([1.976]),
 'q': array([0.5])}

In [5]: t.transform({'mchirp': numpy.array([1.976]), 'q': numpy.array([2.0])})
Out[5]: 
{'mass1': array([3.24805362]),
 'mass2': array([1.62402681]),
 'mchirp': array([1.976]),
 'q': array([2.])}
```