### PR TITLE
Remove primary-secondary mass constraints in chi_a calculations

### DIFF
--- a/pycbc/conversions.py
+++ b/pycbc/conversions.py
@@ -390,11 +390,7 @@ def chi_a(mass1, mass2, spin1z, spin2z):
     """ Returns the aligned mass-weighted spin difference from mass1, mass2,
     spin1z, and spin2z.
     """
-    m_p = primary_mass(mass1, mass2)
-    spin_p = primary_spin(mass1, mass2, spin1z, spin2z)
-    m_s = secondary_mass(mass1, mass2)
-    spin_s = secondary_spin(mass1, mass2, spin1z, spin2z)
-    return (spin_s * m_s - spin_p * m_p) / (m_s + m_p)
+    return (spin2z * mass2 - spin1z * mass1) / (mass2 + mass1)
 
 def chi_p(mass1, mass2, spin1x, spin1y, spin2x, spin2y):
     """Returns the effective precession spin from mass1, mass2, spin1x,

--- a/pycbc/transforms.py
+++ b/pycbc/transforms.py
@@ -631,12 +631,9 @@ class AlignedMassSpinToCartesianSpin(BaseTransform):
             A dict with key as parameter name and value as numpy.array or float
             of transformed values.
         """
-        mass1 = conversions.primary_mass(maps[parameters.mass1],
-                                         maps[parameters.mass2])
-        mass2 = conversions.secondary_mass(maps[parameters.mass1],
-                                           maps[parameters.mass2])
+        mass1 = maps[parameters.mass1]
+        mass2 = maps[parameters.mass2]
         out = {}
-        same_idx = numpy.where(mass1 != maps[parameters.mass1])[0]
         out[parameters.spin1z] = \
                          conversions.spin1z_from_mass1_mass2_chi_eff_chi_a(
                                mass1, mass2,
@@ -645,14 +642,6 @@ class AlignedMassSpinToCartesianSpin(BaseTransform):
                          conversions.spin2z_from_mass1_mass2_chi_eff_chi_a(
                                mass1, mass2,
                                maps[parameters.chi_eff], maps["chi_a"])
-        if len(same_idx) and isinstance(out[parameters.spin1z], float):
-            tmp = out[parameters.spin1z]
-            out[parameters.spin1z] = out[parameters.spin2z]
-            out[parameters.spin2z] = tmp
-        elif len(same_idx):
-            tmp = out[parameters.spin1z]
-            out[parameters.spin1z][same_idx] = out[parameters.spin2z]
-            out[parameters.spin2z][same_idx] = tmp[same_idx]
         return self.format_output(maps, out)
 
     def inverse_transform(self, maps):
@@ -669,16 +658,10 @@ class AlignedMassSpinToCartesianSpin(BaseTransform):
             A dict with key as parameter name and value as numpy.array or float
             of transformed values.
         """
-        mass1 = conversions.primary_mass(
-                              maps[parameters.mass1], maps[parameters.mass2])
-        spin1z = conversions.primary_spin(
-                              maps[parameters.mass1], maps[parameters.mass2],
-                              maps[parameters.spin1z], maps[parameters.spin2z])
-        mass2 = conversions.secondary_mass(
-                              maps[parameters.mass1], maps[parameters.mass2])
-        spin2z = conversions.secondary_spin(
-                              maps[parameters.mass1], maps[parameters.mass2],
-                              maps[parameters.spin1z], maps[parameters.spin2z])
+        mass1 = maps[parameters.mass1]
+        spin1z = maps[parameters.spin1z]
+        mass2 = maps[parameters.mass2]
+        spin2z = maps[parameters.spin2z]
         out = {
             parameters.chi_eff : conversions.chi_eff(mass1, mass2,
                                                      spin1z, spin2z),


### PR DESCRIPTION
This PR : 
1. Changes the `chi_a` calculation in `conversions.py` to use `spin1z`, `spin2z` instead of `spin_p`, `spin_s`
2. Makes `transforms.AlignedMassSpinToCartesianSpin` use `mass1`, `mass2`, `spin1z`, `spin2z` instead of `m_p`, `m_s`, `spin_p`, `spin_s`.

Test : 
```
In [5]: conversions.chi_a(1.2, 2.2, 0.5, 0.7)
Out[5]: 0.2764705882352941

In [6]: conversions.chi_eff(1.2, 2.2, 0.5, 0.7)
Out[6]: 0.6294117647058823

In [7]: conversions.spin1z_from_mass1_mass2_chi_eff_chi_a(1.2, 2.2, 0.6294117647058823, 0.2764705882352941)
Out[7]: 0.5000000000000001

In [8]: conversions.spin2z_from_mass1_mass2_chi_eff_chi_a(1.2, 2.2, 0.6294117647058823, 0.2764705882352941)
Out[8]: 0.6999999999999998

In [10]: t = transforms.AlignedMassSpinToCartesianSpin()

In [14]: t.transform({'mass1': numpy.array([1.2]), 'mass2': numpy.array([2.2]), 'chi_eff': numpy.array([0.6294117647058823]), 'chi_a': numpy.array([0.2764705882352941])})
Out[14]: 
{'chi_a': array([0.27647059]),
 'chi_eff': array([0.62941176]),
 'mass1': array([1.2]),
 'mass2': array([2.2]),
 'spin1z': array([0.5]),
 'spin2z': array([0.7])}
```