### PR TITLE
Fix bug in some single IFO pygrb runs

### DIFF
--- a/bin/pygrb/pycbc_make_offline_grb_workflow
+++ b/bin/pygrb/pycbc_make_offline_grb_workflow
@@ -110,11 +110,6 @@ elif len(sciSegs.keys()) < 2 and not single_ifo:
     logging.warning(msg)
     sys.exit()
 else:
-    if len(sciSegs.keys()) < 2:
-        logging.info("Generating a single IFO search.")
-        mf_tag = "sngl"
-    else:
-        mf_tag = "coherent"
     onSrc, offSrc = _workflow.generate_triggered_segment(wflow, segDir,
                                                          sciSegs)
 
@@ -132,6 +127,12 @@ else:
     segs_plot.PFN(segs_plot.cache_entry.path, site="local")
     sciSegs = offSrc
     all_files.extend(_workflow.FileList([segs_plot]))
+
+if len(sciSegs) == 1:
+    logging.info("Generating a single IFO search.")
+    mf_tag = "sngl"
+elif len(sciSegs) > 1:
+    mf_tag = "coherent"
 
 # Update analysis time after coherent segment calculation
 ifo = sciSegs.keys()[0]


### PR DESCRIPTION
This change fixes a bug introduced in #2143, where if segments existed for multiple IFOs within the start and end times, but after applying our data requirements we were left with only one IFO, the workflow generator behaved as if we still had multiple IFOs.

This change has been tested.