### PR TITLE
Avoid applying additional gating padding multiple times

### DIFF
--- a/bin/pygrb/pycbc_make_offline_grb_workflow
+++ b/bin/pygrb/pycbc_make_offline_grb_workflow
@@ -160,14 +160,12 @@ dfDir = os.path.join(currDir, "datafind")
 datafind_files, _, sciSegs, _ = _workflow.setup_datafind_workflow(wflow,
         sciSegs, dfDir, segsFileList)
 if wflow.cp.has_option("workflow-condition_strain", "do-gating"):
+    new_seg = segment(sciSegs[ifo][0][0] + gate_pad,
+                      sciSegs[ifo][0][1] - gate_pad)
     for iifo in sciSegs:
-        sciSegs[iifo][0] = segment(sciSegs[iifo][0][0] + gate_pad,
-                                   sciSegs[iifo][0][1] - gate_pad)
+        sciSegs[iifo][0] = new_seg
     wflow.cp = _workflow.set_grb_start_end(wflow.cp, int(sciSegs[ifo][0][0]),
                                            int(sciSegs[ifo][0][1]))
-else:
-    datafind_files, _, sciSegs, _ = _workflow.setup_datafind_workflow(wflow,
-            sciSegs, dfDir, segsFileList)
 
 ifos = sorted(sciSegs.keys())
 ifo = ifos[0]


### PR DESCRIPTION
Hi @pannarale, this was the problem I believe. Within the loop the padding was being applied over and over since the segments for the different IFOs are actually all the same object.