### PR TITLE
Simplify ACL algorithm

### DIFF
--- a/pycbc/filter/autocorrelation.py
+++ b/pycbc/filter/autocorrelation.py
@@ -128,9 +128,9 @@ def calculate_acl(data, m=5, dtype=int):
     where :math:`m` is a tuneable parameter (default = 5). If no such point
     exists, then the given data set it too short to estimate the ACL; in this
     case ``inf`` is returned.
-    
+
     This algorithm for computing the ACL is taken from:
-    
+
     N. Madras and A.D. Sokal, J. Stat. Phys. 50, 109 (1988).
 
     Parameters


### PR DESCRIPTION
This switches the ACL algorithm to that used in emcee (see Daniel Foreman-Mackey's blog post [here](https://dfm.io/posts/autocorr/)), which comes from notes & papers by A. Sokal. This is very similar to the current algorithm we use, but uses the entire data set for computing the ACL instead of just the first half. The function is also simplified to make it easier to read.