### PR TITLE
Install six>=1.10.0 in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ install_requires =  setup_requires + ['Mako>=1.0.1',
                       'corner>=2.0.1',
                       'requests>=1.2.1',
                       'beautifulsoup4>=4.6.0',
-                      'six',
+                      'six>=1.10.0',
                       ]
 
 #FIXME Remove me when we bump to h5py > 2.5


### PR DESCRIPTION
While installing PyCBC into a virtual environment via `pip install pycbc`, I found that matplotlib requires `six>1.10` while the installer only checks for `six>1.4`. The system I was on already had 1.9.0, so it wasn't forced to upgrade the installation to a version compatible with matplotlib.

`pip install pycbc` shows:

```
Requirement already satisfied: six>=1.4 in /usr/lib/python2.7/site-packages (from unittest2->pycbc) (1.9.0)
```

and importing matplotlib shows:

```
Traceback (most recent call last):
  File "/home/thomas.massinger/opt/pycbc-hwinj/bin/pycbc_plot_hwinj", line 23, in <module>
    import matplotlib as mpl; mpl.use("Agg")
  File "/home/thomas.massinger/opt/pycbc-hwinj/lib/python2.7/site-packages/matplotlib/__init__.py", line 195, in <module>
    "Matplotlib requires six>=1.10; you have %s" % six.__version__)
ImportError: Matplotlib requires six>=1.10; you have 1.9.0
```

This PR should avoid this edge case in the future.