### PR TITLE
Including names of detectors available in lal

### DIFF
--- a/pycbc/detector.py
+++ b/pycbc/detector.py
@@ -31,6 +31,11 @@ import lal
 from numpy import cos, sin
 from pycbc.types import TimeSeries
 
+_ld = lal.__dict__
+_known_lal_names = [j for j in _ld.keys() if "DETECTOR_PREFIX" in j]
+_known_prefixes = [_ld[k] for k in _known_lal_names]
+_known_names = [_ld[k.replace('PREFIX','NAME')] for k in _known_lal_names]
+available_detectors = zip(_known_prefixes, _known_names)
 
 class Detector(object):
     """A gravitaional wave detector

--- a/pycbc/detector.py
+++ b/pycbc/detector.py
@@ -31,11 +31,25 @@ import lal
 from numpy import cos, sin
 from pycbc.types import TimeSeries
 
-_ld = lal.__dict__
-_known_lal_names = [j for j in _ld.keys() if "DETECTOR_PREFIX" in j]
-_known_prefixes = [_ld[k] for k in _known_lal_names]
-_known_names = [_ld[k.replace('PREFIX','NAME')] for k in _known_lal_names]
-available_detectors = zip(_known_prefixes, _known_names)
+
+def get_available_detectors():
+    """Return list of detectors known in the currently sourced lalsuite.
+
+    This function will query lalsuite about which detectors are known to
+    lalsuite. Detectors are identified by a two character string e.g. 'K1',
+    but also by a longer, and clearer name, e.g. KAGRA. This function returns
+    both. As LAL doesn't really expose this functionality we have to make some
+    assumptions about how this information is stored in LAL. Therefore while
+    we hope this function will work correctly, it's possible it will need
+    updating in the future. Better if lal would expose this information
+    properly.
+    """
+    ld = lal.__dict__
+    known_lal_names = [j for j in ld.keys() if "DETECTOR_PREFIX" in j]
+    known_prefixes = [ld[k] for k in known_lal_names]
+    known_names = [ld[k.replace('PREFIX', 'NAME')] for k in known_lal_names]
+    return zip(known_prefixes, known_names)
+
 
 class Detector(object):
     """A gravitaional wave detector

--- a/test/test_injection.py
+++ b/test/test_injection.py
@@ -87,9 +87,9 @@ class TestInjection(unittest.TestCase):
     def setUp(self):
         available_detectors = get_available_detectors()
         available_detectors = [a[0] for a in available_detectors]
-        self.assertTrue('H1' in available_detectors[0])
-        self.assertTrue('L1' in available_detectors[0])
-        self.assertTrue('V1' in available_detectors[0])
+        self.assertTrue('H1' in available_detectors)
+        self.assertTrue('L1' in available_detectors)
+        self.assertTrue('V1' in available_detectors)
         self.detectors = [Detector(d) for d in ['H1', 'L1', 'V1']]
         self.sample_rate = 4096.
         self.earth_time = lal.REARTH_SI / lal.C_SI

--- a/test/test_injection.py
+++ b/test/test_injection.py
@@ -22,7 +22,7 @@ import tempfile
 import lal
 import pycbc
 from pycbc.types import TimeSeries
-from pycbc.detector import Detector
+from pycbc.detector import Detector, get_available_detectors
 from pycbc.inject import InjectionSet
 import unittest
 import numpy
@@ -85,6 +85,11 @@ class MyInjection(object):
 
 class TestInjection(unittest.TestCase):
     def setUp(self):
+        available_detectors = get_available_detectors()
+        available_detectors = [a[0] for a in available_detectors]
+        self.assertTrue('H1' in available_detectors[0])
+        self.assertTrue('L1' in available_detectors[0])
+        self.assertTrue('V1' in available_detectors[0])
         self.detectors = [Detector(d) for d in ['H1', 'L1', 'V1']]
         self.sample_rate = 4096.
         self.earth_time = lal.REARTH_SI / lal.C_SI


### PR DESCRIPTION
I was asked today "What detectors does PyCBC's detector module support?" Finding out the answer was not so easy! So I added a list of the names that are allowed.

Tested as:

```
In [2]: pycbc.detector.available_detectors
Out[2]: 
[('G1', 'GEO_600'),
 ('A1', 'ALLEGRO_320'),
 ('H1', 'LHO_4k'),
 ('T1', 'TAMA_300'),
 ('V1', 'VIRGO'),
 ('E3', 'ET3_T1400308'),
 ('C1', 'EXPLORER'),
 ('P1', 'CIT_40'),
 ('K1', 'KAGRA'),
 ('E2', 'ET2_T1400308'),
 ('E0', 'ET0_T1400308'),
 ('I1', 'LIO_4k'),
 ('E1', 'ET1_T1400308'),
 ('O1', 'AURIGA'),
 ('B1', 'NIOBE'),
 ('H2', 'LHO_2k'),
 ('L1', 'LLO_4k'),
 ('N1', 'Nautilus')]
```

(Yes, some of these aren't even interferometers, but that's what we get.) .... This also provides the DETECTOR_NAME as defined in LAL, as some of these prefixes are very opaque.

The code to do this is a bit nasty. I had to use the `__dict__` attribute of lal. This is because LAL itself doesn't really supply any method to identify this, so I had to sort of reconstruct what was going on. Hopefully at some point this could be made nicer in LAL, but I think the benefit of having this outweighs a small amount of nasty code.
