### PR TITLE
Allow  conversions to be used in PP dax

### DIFF
--- a/bin/inference/pycbc_inference_plot_inj_recovery
+++ b/bin/inference/pycbc_inference_plot_inj_recovery
@@ -40,9 +40,12 @@ pycbc.init_logging(opts.verbose)
 # read results
 fp, parameters, labels, samples = option_utils.results_from_cli(opts)
 
+# read injections from input files
+inj_parameters = option_utils.injections_from_cli(opts)
+
 # only plot one parameter
 assert(len(opts.parameters) == 1)
-parameter = parameters[0] if isinstance(parameters, list) else parameters
+parameter = parameters[0][0] if isinstance(parameters, list) else parameters
 label = labels[0][0] if isinstance(labels, list) else labels
 
 # create figure
@@ -87,19 +90,9 @@ logging.info("Plotting")
 for i, (input_file, input_fp, input_samples) in enumerate(zip(opts.input_file,
                                                               fp, samples)):
 
-    # read injections from HDF input file
-    injs = inject.InjectionSet(input_file, hdf_group=opts.injection_hdf_group)
-
-    # check if need extra parameters than parameters stored in injection file
-    _, ts = transforms.get_common_cbc_transforms(opts.parameters,
-                                                 injs.table.fieldnames)
-
-    # add parameters not included in injection file
-    inj_parameters = transforms.apply_transforms(injs.table, ts)
-
     # get paramter values
-    sampled_vals = input_samples[parameter].to_array()
-    injected_vals = [e[0] for e in inj_parameters[parameter]]
+    sampled_vals = input_samples[parameter]
+    injected_vals = inj_parameters[parameter][i]
 
     # compute quantiles of sampled results
     quantiles = numpy.array([numpy.percentile(sampled_vals, 100 * q)
@@ -117,8 +110,6 @@ for i, (input_file, input_fp, input_samples) in enumerate(zip(opts.input_file,
         color = "black"
 
     # plot a point for each injection
-    if len(injected_vals) > 1:
-        logging.warn("More than one injection in file %s", input_file)
     ax.errorbar([injected_vals],
                 [med - injected_vals],
                 yerr=[[(med - low)], [(high - med)]],

--- a/bin/workflows/pycbc_make_inference_inj_workflow
+++ b/bin/workflows/pycbc_make_inference_inj_workflow
@@ -147,16 +147,16 @@ for ifo in workflow.ifos:
                                "workflow", "%s-channel-name" % ifo.lower(), "")
 
 # get what parameters to plot in the PP and recovery plots
-if 'pp-plot-parameters' in  workflow.cp.options("workflow-plots"):
+if 'pp-plot-parameters' in  workflow.cp.options("workflow-inference"):
     pp_plot_params = workflow.cp.get_opt_tag("workflow", 'pp-plot-parameters',
-                                             'plots').split(" ")
+                                             'inference').split(" ")
 else:
     # just use the variable args
     pp_plot_params = workflow.cp.options(cp.options("variable_args"))
 
 # get groups of parameters to plot in posterior and samples plots
 plot_groups = {}
-for option in workflow.cp.options("workflow-plots"):
+for option in workflow.cp.options("workflow-inference"):
     if option.startswith("plot-group-"):
         group = option.replace("plot-group-", "").replace("-", "_")
         plot_groups[group] = workflow.cp.get_opt_tag(

--- a/bin/workflows/pycbc_make_inference_inj_workflow
+++ b/bin/workflows/pycbc_make_inference_inj_workflow
@@ -89,8 +89,6 @@ opts = parser.parse_args()
 # make data output directory
 core.makedir(opts.output_dir)
 
-# change working directory to the output
-os.chdir(opts.output_dir)
 # the file we'll store all output files in
 filedir = '/'.join([opts.output_dir, 'output'])
 
@@ -105,6 +103,9 @@ finalize_workflow = core.Workflow(opts, opts.workflow_name + "-finalization")
 
 # read inference configuration file
 cp = configuration.WorkflowConfigParser([opts.inference_config_file])
+
+# change working directory to the output
+os.chdir(opts.output_dir)
 
 # sections for output HTML pages
 rdir = layout.SectionNumber("results",

--- a/bin/workflows/pycbc_make_inference_inj_workflow
+++ b/bin/workflows/pycbc_make_inference_inj_workflow
@@ -91,7 +91,7 @@ opts = parser.parse_args()
 core.makedir(opts.output_dir)
 
 # the file we'll store all output files in
-filedir = '/'.join([opts.output_dir, 'output'])
+filedir = 'output'
 
 # log to stdout until we know where the path to log output file
 log_format = "%(asctime)s:%(levelname)s : %(message)s"

--- a/bin/workflows/pycbc_make_inference_inj_workflow
+++ b/bin/workflows/pycbc_make_inference_inj_workflow
@@ -21,6 +21,7 @@
 import argparse
 import logging
 import os
+import shlex
 import Pegasus.DAX3 as dax
 import pycbc.version
 import socket
@@ -154,8 +155,8 @@ for ifo in workflow.ifos:
 
 # get what parameters to plot in the PP and recovery plots
 if 'pp-plot-parameters' in  workflow.cp.options("workflow-inference"):
-    pp_plot_params = workflow.cp.get_opt_tag("workflow", 'pp-plot-parameters',
-                                             'inference').split(" ")
+    pp_plot_params = shlex.split(workflow.cp.get_opt_tag("workflow",
+        'pp-plot-parameters', 'inference'))
 else:
     # just use the variable args
     pp_plot_params = workflow.cp.options(cp.options("variable_args"))
@@ -165,8 +166,8 @@ plot_groups = {}
 for option in workflow.cp.options("workflow-inference"):
     if option.startswith("plot-group-"):
         group = option.replace("plot-group-", "").replace("-", "_")
-        plot_groups[group] = workflow.cp.get_opt_tag(
-                                "workflow", option, "inference").split(" ")
+        plot_groups[group] = shelex.split(workflow.cp.get_opt_tag(
+                                "workflow", option, "inference"))
 all_plot_parameters = sorted([param for group in plot_groups.values()
                               for param in group])
 unique_plot_parameters = set(all_plot_parameters)

--- a/bin/workflows/pycbc_make_inference_inj_workflow
+++ b/bin/workflows/pycbc_make_inference_inj_workflow
@@ -95,6 +95,9 @@ container = core.Workflow(opts, opts.workflow_name)
 workflow = core.Workflow(opts, opts.workflow_name + "-main")
 finalize_workflow = core.Workflow(opts, opts.workflow_name + "-finalization")
 
+# read inference configuration file
+cp = configuration.WorkflowConfigParser([opts.inference_config_file])
+
 # sections for output HTML pages
 rdir = layout.SectionNumber("results",
                             ["posteriors", "samples", "workflow"])
@@ -143,9 +146,17 @@ for ifo in workflow.ifos:
     channel_names[ifo] = workflow.cp.get_opt_tags(
                                "workflow", "%s-channel-name" % ifo.lower(), "")
 
-# figure out what parameters user wants to plot from workflow configuration
+# get what parameters to plot in the PP and recovery plots
+if 'pp-plot-parameters' in  workflow.cp.options("workflow-plots"):
+    pp_plot_params = workflow.cp.get_opt_tag("workflow", 'pp-plot-parameters',
+                                             'plots').split(" ")
+else:
+    # just use the variable args
+    pp_plot_params = workflow.cp.options(cp.options("variable_args"))
+
+# get groups of parameters to plot in posterior and samples plots
 plot_groups = {}
-for option in workflow.cp.options("workflow-inference"):
+for option in workflow.cp.options("workflow-plots"):
     if option.startswith("plot-group-"):
         group = option.replace("plot-group-", "").replace("-", "_")
         plot_groups[group] = workflow.cp.get_opt_tag(
@@ -248,20 +259,17 @@ for group in sorted(plot_groups.keys()):
     layout.single_layout(rdir[sample_group_fmt.format(group)],
                          sample_group_files[group])
 
-# read inference configuration file
-cp = configuration.WorkflowConfigParser([opts.inference_config_file])
-
 # add injection recovery plots
 if not opts.data_type == "analytical":
     inj_int_files = inference_followups.make_inference_inj_plots(
                                          workflow,
                                          inference_files, rdir.base,
-                                         cp.options("variable_args"),
+                                         pp_plot_params,
                                          name="inference_intervals")
     inj_rec_files = inference_followups.make_inference_inj_plots(
                                          workflow,
                                          inference_files, rdir.base,
-                                         cp.options("variable_args"),
+                                         pp_plot_params,
                                          name="inference_recovery")
     layout.two_column_layout(rdir.base,
                              [(a, b)

--- a/bin/workflows/pycbc_make_inference_inj_workflow
+++ b/bin/workflows/pycbc_make_inference_inj_workflow
@@ -50,7 +50,7 @@ parser.add_argument(
     help="Name of the workflow to append in various places.")
 parser.add_argument(
     "--output-dir",
-    default=None,
+    default='run',
     help="Path that will contain output data files from the workflow.")
 parser.add_argument(
     "--output-map",
@@ -86,6 +86,14 @@ configuration.add_workflow_command_line_group(parser)
 # parser command line
 opts = parser.parse_args()
 
+# make data output directory
+core.makedir(opts.output_dir)
+
+# change working directory to the output
+os.chdir(opts.output_dir)
+# the file we'll store all output files in
+filedir = '/'.join([opts.output_dir, 'output'])
+
 # log to stdout until we know where the path to log output file
 log_format = "%(asctime)s:%(levelname)s : %(message)s"
 logging.basicConfig(format=log_format, level=logging.INFO)
@@ -101,9 +109,6 @@ cp = configuration.WorkflowConfigParser([opts.inference_config_file])
 # sections for output HTML pages
 rdir = layout.SectionNumber("results",
                             ["posteriors", "samples", "workflow"])
-
-# make data output directory
-core.makedir(opts.output_dir)
 
 # make results directories
 core.makedir(rdir.base)
@@ -133,12 +138,12 @@ config_file = core.File.from_path(opts.inference_config_file)
 # construct Executable for creating injections
 create_injections_exe = jobsetup.PycbcCreateInjectionsExecutable(
                            workflow.cp, "create_injections",
-                           ifo=workflow.ifos, out_dir=opts.output_dir)
+                           ifo=workflow.ifos, out_dir=filedir)
 
 # construct Executable for running sampler
 inference_exe = jobsetup.PycbcInferenceExecutable(
                            workflow.cp, "inference",
-                           ifo=workflow.ifos, out_dir=opts.output_dir)
+                           ifo=workflow.ifos, out_dir=filedir)
 
 # get channel names from workflow configuration file
 channel_names = {}

--- a/bin/workflows/pycbc_make_inference_inj_workflow
+++ b/bin/workflows/pycbc_make_inference_inj_workflow
@@ -166,7 +166,7 @@ plot_groups = {}
 for option in workflow.cp.options("workflow-inference"):
     if option.startswith("plot-group-"):
         group = option.replace("plot-group-", "").replace("-", "_")
-        plot_groups[group] = shelex.split(workflow.cp.get_opt_tag(
+        plot_groups[group] = shlex.split(workflow.cp.get_opt_tag(
                                 "workflow", option, "inference"))
 all_plot_parameters = sorted([param for group in plot_groups.values()
                               for param in group])

--- a/bin/workflows/pycbc_make_inference_inj_workflow
+++ b/bin/workflows/pycbc_make_inference_inj_workflow
@@ -104,6 +104,9 @@ finalize_workflow = core.Workflow(opts, opts.workflow_name + "-finalization")
 # read inference configuration file
 cp = configuration.WorkflowConfigParser([opts.inference_config_file])
 
+# typecast str from command line to File instances
+config_file = core.File.from_path(opts.inference_config_file)
+
 # change working directory to the output
 os.chdir(opts.output_dir)
 
@@ -132,9 +135,6 @@ formatter = logging.Formatter(log_format)
 log_file.setFormatter(formatter)
 logging.getLogger("").addHandler(log_file)
 logging.info("Created log file {}".format(log_file_txt.storage_path))
-
-# typecast str from command line to File instances
-config_file = core.File.from_path(opts.inference_config_file)
 
 # construct Executable for creating injections
 create_injections_exe = jobsetup.PycbcCreateInjectionsExecutable(

--- a/pycbc/workflow/inference_followups.py
+++ b/pycbc/workflow/inference_followups.py
@@ -283,11 +283,11 @@ def make_inference_1d_posterior_plots(
                     analysis_seg=None, tags=None):
     parameters = [] if parameters is None else parameters
     files = FileList([])
-    for parameter in parameters:
+    for (ii, parameter) in enumerate(parameters):
         files += make_inference_posterior_plot(
                     workflow, inference_file, output_dir,
                     parameters=[parameter], analysis_seg=analysis_seg,
-                    tags=tags + [parameter])
+                    tags=tags + ['param{}'.format(ii)])
     return files
 
 def make_inference_samples_plot(
@@ -405,9 +405,10 @@ def make_inference_inj_plots(workflow, inference_files, output_dir,
     makedir(output_dir)
 
     # add command line options
-    for param in parameters:
+    for (ii, param) in enumerate(parameters):
         plot_exe = PlotExecutable(workflow.cp, name, ifos=workflow.ifos,
-                                  out_dir=output_dir, tags=tags + [param])
+                                  out_dir=output_dir,
+                                  tags=tags+['param{}'.format(ii)])
         node = plot_exe.create_node()
         node.add_input_list_opt("--input-file", inference_files)
         node.new_output_file_opt(analysis_seg, ".png", "--output-file")


### PR DESCRIPTION
The changes in #2136 and #2154 means that PP plots will not work anymore since mass1 will not necessarily be >= mass2 in the samples files. In order to get sane plots, we need to be able to pass `primary_mass(mass1, mass2)` from the workflow config file to `inj_interval` and `inj_recovery`. This patch does that by adding a `pp-plot-parameters` option to `workflow-inference` section. In this section you specify what parameters to plot for the PP and recovery plots. (If nothing is provided, it defaults to the variable args.) An example:

```
[workflow-inference]                                                            
; how the workflow generator should setup inference nodes                       
num-injections = 100                                                            
data-seconds-before-trigger = 6                                                 
data-seconds-after-trigger = 2                                                  
pp-plot-parameters = 'primary_mass(mass1,mass2):$m_1$'                          
                     'secondary_mass(mass1,mass2):$m_2$'                        
                     'primary_spin(mass1,mass2,spin1_a,spin2_a):$|\chi_1|$'     
                     'primary_spin(mass1,mass2,spin1_azimuthal,spin2_azimuthal):$\theta_1^\mathrm{azimuthal}$'
                     'primary_spin(mass1,mass2,spin1_polar,spin2_polar):$\theta_1^\mathrm{polar}$'
                     'secondary_spin(mass1,mass2,spin1_a,spin2_a):$\chi_2|$'    
                     'secondary_spin(mass1,mass2,spin1_azimuthal,spin2_azimuthal):$\theta_2^\mathrm{azimuthal}$'
                     'secondary_spin(mass1,mass2,spin1_polar,spin2_polar):$\theta_2^\mathrm{polar}$'
                     ra dec polarization distance inclination tc                
plot-group-all = ${pp-plot-parameters}                                          
plot-group-masses = 'primary_mass(mass1,mass2):$m_1$' 'secondary_mass(mass1,mass2):$m_2$' mchirp q
plot-group-spins = 'chi_p:$\chi_p$' chi_eff q  
```

To get the config file to pass through the functions appropriately, I had to use `shlex.split` for parsing the parameters. I also had to change the names of the output plot files. Previously they tried to stick the parameter in the file name, which causes issues if your parameter is `primary_mass(mass1, mass2):$m_1$`. Now the file names just have `param0`, `param1`, etc. 

Finally, this patch changes the directory structure so that the output files are written to a sub-directory (default is `run`, but this can be changed with `output-dir`) of where you run `pycbc_make_inference_inj_workflow`. This makes it easier to get rid of old runs that have errors in them, and make it more like the pycbc search workflow.

I'm currently testing this patch on atlas.