### PR TITLE
Use ACL-per-walker and change the N acl burn-in

### DIFF
--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -444,7 +444,7 @@ with ctx:
             if opts.n_independent_samples is not None or end >= get_nsamples \
                     or not opts.checkpoint_fast:
                 logging.info("Computing acls")
-                acls = sampler.compute_acls(fp)
+                acls = sampler.compute_acls(fp, pool=sampler.pool)
                 sampler.write_acls(fp, acls)
 
         # write to backup

--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -437,7 +437,8 @@ with ctx:
                 is_burned_in = False
             if not is_burned_in:
                 logging.info("Calculating burn in")
-                burnidx, is_burned_in = burn_in_eval.update(sampler, fp)
+                burnidx, is_burned_in = burn_in_eval.update(sampler, fp,
+                    pool=sampler.pool)
 
             # compute the acls and write
             acls = None

--- a/bin/inference/pycbc_inference_plot_inj_recovery
+++ b/bin/inference/pycbc_inference_plot_inj_recovery
@@ -40,9 +40,12 @@ pycbc.init_logging(opts.verbose)
 # read results
 fp, parameters, labels, samples = option_utils.results_from_cli(opts)
 
+# read injections from input files
+inj_parameters = option_utils.injections_from_cli(opts)
+
 # only plot one parameter
 assert(len(opts.parameters) == 1)
-parameter = parameters[0] if isinstance(parameters, list) else parameters
+parameter = parameters[0][0] if isinstance(parameters, list) else parameters
 label = labels[0][0] if isinstance(labels, list) else labels
 
 # create figure
@@ -87,19 +90,9 @@ logging.info("Plotting")
 for i, (input_file, input_fp, input_samples) in enumerate(zip(opts.input_file,
                                                               fp, samples)):
 
-    # read injections from HDF input file
-    injs = inject.InjectionSet(input_file, hdf_group=opts.injection_hdf_group)
-
-    # check if need extra parameters than parameters stored in injection file
-    _, ts = transforms.get_common_cbc_transforms(opts.parameters,
-                                                 injs.table.fieldnames)
-
-    # add parameters not included in injection file
-    inj_parameters = transforms.apply_transforms(injs.table, ts)
-
     # get paramter values
-    sampled_vals = input_samples[parameter].to_array()
-    injected_vals = [e[0] for e in inj_parameters[parameter]]
+    sampled_vals = input_samples[parameter]
+    injected_vals = inj_parameters[parameter][i]
 
     # compute quantiles of sampled results
     quantiles = numpy.array([numpy.percentile(sampled_vals, 100 * q)
@@ -117,8 +110,6 @@ for i, (input_file, input_fp, input_samples) in enumerate(zip(opts.input_file,
         color = "black"
 
     # plot a point for each injection
-    if len(injected_vals) > 1:
-        logging.warn("More than one injection in file %s", input_file)
     ax.errorbar([injected_vals],
                 [med - injected_vals],
                 yerr=[[(med - low)], [(high - med)]],

--- a/bin/workflows/pycbc_make_inference_inj_workflow
+++ b/bin/workflows/pycbc_make_inference_inj_workflow
@@ -147,16 +147,16 @@ for ifo in workflow.ifos:
                                "workflow", "%s-channel-name" % ifo.lower(), "")
 
 # get what parameters to plot in the PP and recovery plots
-if 'pp-plot-parameters' in  workflow.cp.options("workflow-plots"):
+if 'pp-plot-parameters' in  workflow.cp.options("workflow-inference"):
     pp_plot_params = workflow.cp.get_opt_tag("workflow", 'pp-plot-parameters',
-                                             'plots').split(" ")
+                                             'inference').split(" ")
 else:
     # just use the variable args
     pp_plot_params = workflow.cp.options(cp.options("variable_args"))
 
 # get groups of parameters to plot in posterior and samples plots
 plot_groups = {}
-for option in workflow.cp.options("workflow-plots"):
+for option in workflow.cp.options("workflow-inference"):
     if option.startswith("plot-group-"):
         group = option.replace("plot-group-", "").replace("-", "_")
         plot_groups[group] = workflow.cp.get_opt_tag(

--- a/bin/workflows/pycbc_make_inference_inj_workflow
+++ b/bin/workflows/pycbc_make_inference_inj_workflow
@@ -89,8 +89,6 @@ opts = parser.parse_args()
 # make data output directory
 core.makedir(opts.output_dir)
 
-# change working directory to the output
-os.chdir(opts.output_dir)
 # the file we'll store all output files in
 filedir = '/'.join([opts.output_dir, 'output'])
 
@@ -105,6 +103,9 @@ finalize_workflow = core.Workflow(opts, opts.workflow_name + "-finalization")
 
 # read inference configuration file
 cp = configuration.WorkflowConfigParser([opts.inference_config_file])
+
+# change working directory to the output
+os.chdir(opts.output_dir)
 
 # sections for output HTML pages
 rdir = layout.SectionNumber("results",

--- a/bin/workflows/pycbc_make_inference_inj_workflow
+++ b/bin/workflows/pycbc_make_inference_inj_workflow
@@ -21,6 +21,7 @@
 import argparse
 import logging
 import os
+import shlex
 import Pegasus.DAX3 as dax
 import pycbc.version
 import socket
@@ -154,8 +155,8 @@ for ifo in workflow.ifos:
 
 # get what parameters to plot in the PP and recovery plots
 if 'pp-plot-parameters' in  workflow.cp.options("workflow-inference"):
-    pp_plot_params = workflow.cp.get_opt_tag("workflow", 'pp-plot-parameters',
-                                             'inference').split(" ")
+    pp_plot_params = shlex.split(workflow.cp.get_opt_tag("workflow",
+        'pp-plot-parameters', 'inference'))
 else:
     # just use the variable args
     pp_plot_params = workflow.cp.options(cp.options("variable_args"))
@@ -165,8 +166,8 @@ plot_groups = {}
 for option in workflow.cp.options("workflow-inference"):
     if option.startswith("plot-group-"):
         group = option.replace("plot-group-", "").replace("-", "_")
-        plot_groups[group] = workflow.cp.get_opt_tag(
-                                "workflow", option, "inference").split(" ")
+        plot_groups[group] = shelex.split(workflow.cp.get_opt_tag(
+                                "workflow", option, "inference"))
 all_plot_parameters = sorted([param for group in plot_groups.values()
                               for param in group])
 unique_plot_parameters = set(all_plot_parameters)

--- a/bin/workflows/pycbc_make_inference_inj_workflow
+++ b/bin/workflows/pycbc_make_inference_inj_workflow
@@ -95,6 +95,9 @@ container = core.Workflow(opts, opts.workflow_name)
 workflow = core.Workflow(opts, opts.workflow_name + "-main")
 finalize_workflow = core.Workflow(opts, opts.workflow_name + "-finalization")
 
+# read inference configuration file
+cp = configuration.WorkflowConfigParser([opts.inference_config_file])
+
 # sections for output HTML pages
 rdir = layout.SectionNumber("results",
                             ["posteriors", "samples", "workflow"])
@@ -143,9 +146,17 @@ for ifo in workflow.ifos:
     channel_names[ifo] = workflow.cp.get_opt_tags(
                                "workflow", "%s-channel-name" % ifo.lower(), "")
 
-# figure out what parameters user wants to plot from workflow configuration
+# get what parameters to plot in the PP and recovery plots
+if 'pp-plot-parameters' in  workflow.cp.options("workflow-plots"):
+    pp_plot_params = workflow.cp.get_opt_tag("workflow", 'pp-plot-parameters',
+                                             'plots').split(" ")
+else:
+    # just use the variable args
+    pp_plot_params = workflow.cp.options(cp.options("variable_args"))
+
+# get groups of parameters to plot in posterior and samples plots
 plot_groups = {}
-for option in workflow.cp.options("workflow-inference"):
+for option in workflow.cp.options("workflow-plots"):
     if option.startswith("plot-group-"):
         group = option.replace("plot-group-", "").replace("-", "_")
         plot_groups[group] = workflow.cp.get_opt_tag(
@@ -248,20 +259,17 @@ for group in sorted(plot_groups.keys()):
     layout.single_layout(rdir[sample_group_fmt.format(group)],
                          sample_group_files[group])
 
-# read inference configuration file
-cp = configuration.WorkflowConfigParser([opts.inference_config_file])
-
 # add injection recovery plots
 if not opts.data_type == "analytical":
     inj_int_files = inference_followups.make_inference_inj_plots(
                                          workflow,
                                          inference_files, rdir.base,
-                                         cp.options("variable_args"),
+                                         pp_plot_params,
                                          name="inference_intervals")
     inj_rec_files = inference_followups.make_inference_inj_plots(
                                          workflow,
                                          inference_files, rdir.base,
-                                         cp.options("variable_args"),
+                                         pp_plot_params,
                                          name="inference_recovery")
     layout.two_column_layout(rdir.base,
                              [(a, b)

--- a/bin/workflows/pycbc_make_inference_inj_workflow
+++ b/bin/workflows/pycbc_make_inference_inj_workflow
@@ -50,7 +50,7 @@ parser.add_argument(
     help="Name of the workflow to append in various places.")
 parser.add_argument(
     "--output-dir",
-    default=None,
+    default='run',
     help="Path that will contain output data files from the workflow.")
 parser.add_argument(
     "--output-map",
@@ -86,6 +86,14 @@ configuration.add_workflow_command_line_group(parser)
 # parser command line
 opts = parser.parse_args()
 
+# make data output directory
+core.makedir(opts.output_dir)
+
+# change working directory to the output
+os.chdir(opts.output_dir)
+# the file we'll store all output files in
+filedir = '/'.join([opts.output_dir, 'output'])
+
 # log to stdout until we know where the path to log output file
 log_format = "%(asctime)s:%(levelname)s : %(message)s"
 logging.basicConfig(format=log_format, level=logging.INFO)
@@ -101,9 +109,6 @@ cp = configuration.WorkflowConfigParser([opts.inference_config_file])
 # sections for output HTML pages
 rdir = layout.SectionNumber("results",
                             ["posteriors", "samples", "workflow"])
-
-# make data output directory
-core.makedir(opts.output_dir)
 
 # make results directories
 core.makedir(rdir.base)
@@ -133,12 +138,12 @@ config_file = core.File.from_path(opts.inference_config_file)
 # construct Executable for creating injections
 create_injections_exe = jobsetup.PycbcCreateInjectionsExecutable(
                            workflow.cp, "create_injections",
-                           ifo=workflow.ifos, out_dir=opts.output_dir)
+                           ifo=workflow.ifos, out_dir=filedir)
 
 # construct Executable for running sampler
 inference_exe = jobsetup.PycbcInferenceExecutable(
                            workflow.cp, "inference",
-                           ifo=workflow.ifos, out_dir=opts.output_dir)
+                           ifo=workflow.ifos, out_dir=filedir)
 
 # get channel names from workflow configuration file
 channel_names = {}

--- a/bin/workflows/pycbc_make_inference_inj_workflow
+++ b/bin/workflows/pycbc_make_inference_inj_workflow
@@ -166,7 +166,7 @@ plot_groups = {}
 for option in workflow.cp.options("workflow-inference"):
     if option.startswith("plot-group-"):
         group = option.replace("plot-group-", "").replace("-", "_")
-        plot_groups[group] = shelex.split(workflow.cp.get_opt_tag(
+        plot_groups[group] = shlex.split(workflow.cp.get_opt_tag(
                                 "workflow", option, "inference"))
 all_plot_parameters = sorted([param for group in plot_groups.values()
                               for param in group])

--- a/bin/workflows/pycbc_make_inference_inj_workflow
+++ b/bin/workflows/pycbc_make_inference_inj_workflow
@@ -104,6 +104,9 @@ finalize_workflow = core.Workflow(opts, opts.workflow_name + "-finalization")
 # read inference configuration file
 cp = configuration.WorkflowConfigParser([opts.inference_config_file])
 
+# typecast str from command line to File instances
+config_file = core.File.from_path(opts.inference_config_file)
+
 # change working directory to the output
 os.chdir(opts.output_dir)
 
@@ -132,9 +135,6 @@ formatter = logging.Formatter(log_format)
 log_file.setFormatter(formatter)
 logging.getLogger("").addHandler(log_file)
 logging.info("Created log file {}".format(log_file_txt.storage_path))
-
-# typecast str from command line to File instances
-config_file = core.File.from_path(opts.inference_config_file)
 
 # construct Executable for creating injections
 create_injections_exe = jobsetup.PycbcCreateInjectionsExecutable(

--- a/pycbc/inference/burn_in.py
+++ b/pycbc/inference/burn_in.py
@@ -29,7 +29,7 @@ have burned in.
 import numpy
 from scipy.stats import ks_2samp
 
-def ks_test(sampler, fp, threshold=0.9):
+def ks_test(sampler, fp, threshold=0.9, **kwargs):
     """Burn in based on whether the p-value of the KS test between the samples
     at the last iteration and the samples midway along the chain for each
     parameter is > ``threshold``.
@@ -81,7 +81,7 @@ def ks_test(sampler, fp, threshold=0.9):
     return burn_in_idx, is_burned_in
 
 
-def n_acl(sampler, fp, nacls=100):
+def n_acl(sampler, fp, nacls=100, pool=None, **kwargs):
     """Burn in based on ACL.
 
     This applies the following test to determine burn in:
@@ -117,7 +117,8 @@ def n_acl(sampler, fp, nacls=100):
         of all False or True.
     """
     N = fp.niterations
-    acl = numpy.array(sampler.compute_acls(fp, start_index=N/2).values()).max()
+    acl = numpy.array(
+        sampler.compute_acls(fp, pool=pool, start_index=N/2).values()).max()
     is_burned_in = nacls * acl < N/2
     if not is_burned_in:
         burn_idx = N
@@ -128,7 +129,7 @@ def n_acl(sampler, fp, nacls=100):
            numpy.repeat(is_burned_in, nwalkers).astype(bool)
 
 
-def max_posterior(sampler, fp):
+def max_posterior(sampler, fp, **kwargs):
     """Burn in based on samples being within dim/2 of maximum posterior.
 
     Parameters
@@ -177,16 +178,16 @@ def max_posterior(sampler, fp):
     return burn_in_idx, is_burned_in
 
 
-def acl_or_max_posterior(sampler, fp):
+def acl_or_max_posterior(sampler, fp, **kwargs):
     """Burn in that uses the minimum of `n_acl` and `max_posteior`.
     """
-    acl_bidx, acl_ibi = n_acl(sampler, fp)
-    maxp_bidx, maxp_ibi = max_posterior(sampler, fp)
+    acl_bidx, acl_ibi = n_acl(sampler, fp, **kwargs)
+    maxp_bidx, maxp_ibi = max_posterior(sampler, fp, **kwargs)
     burn_in_idx = numpy.min([acl_bidx, maxp_bidx], axis=0)
     is_burned_in = acl_ibi | maxp_ibi
     return burn_in_idx, is_burned_in
 
-def posterior_step(sampler, fp):
+def posterior_step(sampler, fp, **kwargs):
     """Burn in based on the last time a chain made a jump > dim/2.
 
     Parameters
@@ -228,7 +229,7 @@ def posterior_step(sampler, fp):
     return burn_in_idx, numpy.ones(nwalkers, dtype=bool)
 
 
-def half_chain(sampler, fp):
+def half_chain(sampler, fp, **kwargs):
     """Takes the second half of the iterations as post-burn in.
 
     Parameters
@@ -254,7 +255,7 @@ def half_chain(sampler, fp):
            numpy.ones(nwalkers, dtype=bool)
 
 
-def use_sampler(sampler, fp=None):
+def use_sampler(sampler, fp=None, **kwargs):
     """Uses the sampler's burn_in function.
 
     Parameters
@@ -330,7 +331,7 @@ class BurnIn(object):
         self.burn_in_functions = {fname: burn_in_functions[fname]
                                   for fname in function_names}
 
-    def evaluate(self, sampler, fp):
+    def evaluate(self, sampler, fp, **kwargs):
         """Evaluates sampler's chains to find burn in.
 
         Parameters
@@ -367,7 +368,7 @@ class BurnIn(object):
         if self.burn_in_functions != {}:
             newidx = []
             for func in self.burn_in_functions.values():
-                idx, state = func(sampler, fp)
+                idx, state = func(sampler, fp, **kwargs)
                 newidx.append(idx)
                 is_burned_in &= state
             newidx = numpy.vstack(newidx).max(axis=0)
@@ -379,7 +380,7 @@ class BurnIn(object):
         burnidx[burnidx < self.min_iterations] = self.min_iterations
         return burnidx, is_burned_in
 
-    def update(self, sampler, fp):
+    def update(self, sampler, fp, **kwargs):
         """Evaluates burn in and saves the updated indices to the given file.
 
         Parameters
@@ -398,7 +399,7 @@ class BurnIn(object):
         is_burned_in : array
             Array of booleans indicating whether each chain is burned in.
         """
-        burnidx, is_burned_in = self.evaluate(sampler, fp)
+        burnidx, is_burned_in = self.evaluate(sampler, fp, **kwargs)
         sampler.burn_in_iterations = burnidx
         sampler.write_burn_in_iterations(fp, burnidx, is_burned_in)
         return burnidx, is_burned_in

--- a/pycbc/inference/sampler_base.py
+++ b/pycbc/inference/sampler_base.py
@@ -121,6 +121,7 @@ class _BaseSampler(object):
     def __init__(self, likelihood_evaluator):
         self.likelihood_evaluator = likelihood_evaluator
         self.lastclear = 0
+        self.pool = None
 
     @classmethod
     def from_cli(cls, opts, likelihood_evaluator, pool=None,

--- a/pycbc/inference/sampler_emcee.py
+++ b/pycbc/inference/sampler_emcee.py
@@ -81,6 +81,7 @@ class EmceeEnsembleSampler(BaseMCMCSampler):
         super(EmceeEnsembleSampler, self).__init__(
               sampler, likelihood_evaluator)
         self._nwalkers = nwalkers
+        self.pool = pool
 
     @classmethod
     def from_cli(cls, opts, likelihood_evaluator, pool=None,
@@ -288,6 +289,7 @@ class EmceePTSampler(BaseMCMCSampler):
               sampler, likelihood_evaluator)
         self._nwalkers = nwalkers
         self._ntemps = ntemps
+        self.pool = pool
 
     @classmethod
     def from_cli(cls, opts, likelihood_evaluator, pool=None,

--- a/pycbc/inference/sampler_kombine.py
+++ b/pycbc/inference/sampler_kombine.py
@@ -85,6 +85,7 @@ class KombineSampler(BaseMCMCSampler):
         super(KombineSampler, self).__init__(sampler, likelihood_evaluator)
         self._nwalkers = nwalkers
         self.update_interval = update_interval
+        self.pool = pool
 
     @property
     def acceptance_fraction(self):

--- a/pycbc/workflow/inference_followups.py
+++ b/pycbc/workflow/inference_followups.py
@@ -283,11 +283,11 @@ def make_inference_1d_posterior_plots(
                     analysis_seg=None, tags=None):
     parameters = [] if parameters is None else parameters
     files = FileList([])
-    for parameter in parameters:
+    for (ii, parameter) in enumerate(parameters):
         files += make_inference_posterior_plot(
                     workflow, inference_file, output_dir,
                     parameters=[parameter], analysis_seg=analysis_seg,
-                    tags=tags + [parameter])
+                    tags=tags + ['param{}'.format(ii)])
     return files
 
 def make_inference_samples_plot(
@@ -405,9 +405,10 @@ def make_inference_inj_plots(workflow, inference_files, output_dir,
     makedir(output_dir)
 
     # add command line options
-    for param in parameters:
+    for (ii, param) in enumerate(parameters):
         plot_exe = PlotExecutable(workflow.cp, name, ifos=workflow.ifos,
-                                  out_dir=output_dir, tags=tags + [param])
+                                  out_dir=output_dir,
+                                  tags=tags+['param{}'.format(ii)])
         node = plot_exe.create_node()
         node.add_input_list_opt("--input-file", inference_files)
         node.new_output_file_opt(analysis_seg, ".png", "--output-file")


### PR DESCRIPTION
Following https://dfm.io/posts/autocorr/, this changes the calculation of the ACL for the MCMC samplers. Instead of finding the ACL of the average of the walkers, an ACL is found for each walker, then the mean over the ACLs is taken. Since this takes more time, the ACL calculation is now parallelized over the inference pool.

Also, this changes the `n_acl` burn-in function. Now, the first half of the chains is ignored. An ACL is computed from the second half. If the second half contains 100*ACL, then the sampler is considered to be burned in at the half-way point. I changed this because I found that switching to the mean ACL over the walkers resulted in an ACL that was ~ a factor of 10 lower than the previous method. This might be fine, but using only 10ACLs (what the `n_acl` function currently does) resulted in the sampler thinking it was burned in much too early. The bit about excluding the first half of the chain is from talking to Will Farr. It also fixes an issue with the current implementation, where the sampler would have to run for a long time after burn-in to recalculate an ACL.

This PR depends on #2168.

I'm not really certain that this is the correct way to calculate an ACL, and that this new burn in test will work. So I'm marking as a work in progress for now, while I test it out in a PP test. If it looks ok (and #2168 is merged), I'll remove the label.