### PR TITLE
Update documentation on OSG running

### DIFF
--- a/docs/workflow/pycbc_make_coinc_search_workflow.rst
+++ b/docs/workflow/pycbc_make_coinc_search_workflow.rst
@@ -940,9 +940,22 @@ If you are running your own build of ``pycbc_inspiral``, you will need to give
 a path to a gsiftp URL and tell Pegasus that the executable is not installed
 on the OSG with the two ``--config-overrides`` options::
 
-    'executables:inspiral:gsiftp://server.hostname/path/to/pycbc_inspiral'
+    "executables:inspiral:gsiftp://server.hostname/path/to/pycbc_inspiral"
+    "pegasus_profile-inspiral:pycbc|installed:False"
 
 Make sure this executable is build following the instructions on the page :ref:`building_bundled_executables`.
+
+Some of the files generated during the workflow will need to be served via gridftp from the LDG
+head node from which you submit, however the gravitational wave frame data files are too large for this.
+They are available from CVMFS and other fall-back locations, however you will need to
+ensure that your datafind server returns these locations (it may not do so on an LDG head node,
+for example, if you use the default datafind server). If you have LIGO.org credentials, you should
+execute::
+
+    export LIGO_DATAFIND_SERVER="datafind.ligo.org"
+
+before you run ``pycbc_make_coinc_search_workflow``. Otherwise, contact your local system administrator for
+a valid datafind server that points to publicly available frame files.
 
 Add the following to the list of ``--config-overrides`` when running ``pycbc_make_coinc_search_workflow`` to tell Pegasus to run the inspiral code on the OSG::
      
@@ -977,13 +990,50 @@ follwing lines to your ``executables.ini`` file::
 Running the workflow
 --------------------
 
-Add the following arguments to ``pycbc_submit_dax``::
+Add the following additional arguments to ``pycbc_submit_dax``::
 
     --no-create-proxy \
     --execution-sites osg \
     --append-pegasus-property 'pegasus.transfer.bypass.input.staging=true' \
     --remote-staging-server `hostname -f` \
 
-``hostname -f`` will give the correct value if there is a gsiftp server running on the submit machine.  If not, change this as needed. The remote-staging-site is the intermediary computer than can pass files between the submitting computer and the computers doing the work.  ``hostname -f`` returns the full name of the computer. The full name of the computer that ``hostname -f`` has to be one that is accessible to both the submit machine and the workers. 
+``hostname -f`` will give the correct value if there is a gsiftp server running on the submit machine.  If not, change this as needed. The remote-staging-site is the intermediary computer than can pass files between the submitting computer and the computers doing the work.  ``hostname -f`` returns the full name of the computer. The full name of the computer that ``hostname -f`` has to be one that is accessible to both the submit machine and the workers. The ``--no-create-proxy`` may be omitted if you have LIGO.org credentials and will be
+retrieving data from authenticated locations in CVMFS.
+
+The set of arguments above will allow ``pycbc_inspiral`` to run on any OSG machine to which you have access, as well as
+the local compute cluster. If you do not want your jobs to run on the local cluster, but only on shared resources, then add
+the argument::
+
+    --append-site-profile 'osg:condor|Requirements:IS_GLIDEIN=?=True' \
+
+to ``pycbc_submit_dax``. If, in addition, you would like to run on an XSEDE resource on which you have an allocation, then
+add the argument::
+
+    --append-site-profile 'osg:condor|+DESIRED_XSEDE_Sites:"Comet"' \
+
+where you replace the desired site (in this example the Comet cluster) with wherever you have an allocation. If you want to
+run **only** on that XSEDE cluster, then also add::
+
+    --append-site-profile 'osg:condor|+DESIRED_SITES:"Comet"' \
+
+Summarizing, the following option will submit jobs to the local cluster, the Open Science Grid, and
+the specified XSEDE cluster::
+
+    --append-site-profile 'osg:condor|+DESIRED_XSEDE_Sites:"Comet"' \
+
+To submit to the XSEDE cluster and the OSG, but not the local cluster, use::
+
+    --append-site-profile 'osg:condor|+DESIRED_XSEDE_Sites:"Comet"' \
+    --append-site-profile 'osg:condor|Requirements:IS_GLIDEIN=?=True' \
+
+and to submit only to the specified XSEDE cluster, use::
+
+    --append-site-profile 'osg:condor|+DESIRED_XSEDE_Sites:"Comet"' \                                                                      
+    --append-site-profile 'osg:condor|Requirements:IS_GLIDEIN=?=True' \
+    --append-site-profile 'osg:condor|+DESIRED_SITES:"Comet"' \
+
+Of course, you must still give all of the other arguments necessary to ``pycbc_submit_dax``; both those other
+arguments needed to run on the Open Science Grid and specified in this section, and other standard arguments,
+such as specifying an LDG accounting group, if you will be running from an LDG cluster.
 
 Shared file system can not be used with OSG, so make sure that the ``--enable-shared-filesystem`` argument is not added to ``pycbc_submit_dax``.


### PR DESCRIPTION
Add changes to the documentation to better describe running on the Open Science Grid, including:

 1. The need to specify a different `LIGO_DATAFIND_SERVER`, and
 2. Different arguments to `pycbc_submit_dax` that affect whether the inspiral jobs will run on a particular combination of the local cluster, the OSG, and possibly a specific XSEDE site.