### PR TITLE
Fix a memory leak when creating FFTW / MKL plans

### DIFF
--- a/pycbc/fft/mkl.py
+++ b/pycbc/fft/mkl.py
@@ -100,6 +100,7 @@ def fft(invec, outvec, prec, itype, otype):
     f = lib.DftiComputeForward
     f.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p]
     status = f(descr, invec.ptr, outvec.ptr)
+    lib.DftiFreeDescriptor(descr)
     check_status(status)
 
 def ifft(invec, outvec, prec, itype, otype):
@@ -108,6 +109,7 @@ def ifft(invec, outvec, prec, itype, otype):
     f = lib.DftiComputeBackward
     f.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p]
     status = f(descr, invec.ptr, outvec.ptr)
+    lib.DftiFreeDescriptor(descr)
     check_status(status)
 
 # Class based API


### PR DESCRIPTION
MKL and FFTW plans are currently never freed. That is a large memory leak when repeatedly calling fft using the function api. 