### PR TITLE
Error message for fake strain with injections

### DIFF
--- a/pycbc/strain.py
+++ b/pycbc/strain.py
@@ -378,7 +378,7 @@ def from_cli(opt, dyn_range_fac=1, precision='single',
             strain = resample_to_delta_t(strain, 1.0/opt.sample_rate)
 
         if opt.injection_file or opt.sgburst_injection_file \
-            or opt.ringdown_injection_file and not opt.channel_name:
+          or opt.ringdown_injection_file and not opt.channel_name:
             raise ValueError('Please provide channel names with the format '
                              'ifo:channel (e.g. H1:CALIB-STRAIN) to inject '
                              'simulated signals into fake strain')

--- a/pycbc/strain.py
+++ b/pycbc/strain.py
@@ -378,7 +378,7 @@ def from_cli(opt, dyn_range_fac=1, precision='single',
             strain = resample_to_delta_t(strain, 1.0/opt.sample_rate)
 
         if opt.injection_file or opt.sgburst_injection_file \
-          or opt.ringdown_injection_file and not opt.channel_name:
+                or opt.ringdown_injection_file and not opt.channel_name:
             raise ValueError('Please provide channel names with the format '
                              'ifo:channel (e.g. H1:CALIB-STRAIN) to inject '
                              'simulated signals into fake strain')

--- a/pycbc/strain.py
+++ b/pycbc/strain.py
@@ -377,14 +377,15 @@ def from_cli(opt, dyn_range_fac=1, precision='single',
                                           low_frequency_cutoff=lowfreq)
             strain = resample_to_delta_t(strain, 1.0/opt.sample_rate)
 
+        if opt.injection_file or opt.sgburst_injection_file \
+        or opt.ringdown_injection_file and not opt.channel_name:
+            raise ValueError('Please provide channel names with the format '
+                             'ifo:channel (e.g. H1:CALIB-STRAIN) to inject '
+                             'simulated signals into fake strain')
 
         if opt.injection_file:
             logging.info("Applying injections")
             injector = InjectionSet(opt.injection_file)
-            if not opt.channel_name:
-                raise ValueError('Please provide channel names with the format '
-                                 'ifo:channel (e.g. H1:CALIB-STRAIN) to inject '
-                                 'simulated signals into fake strain')
             injections = \
                 injector.apply(strain, opt.channel_name[0:2],
                                distance_scale=opt.injection_scale_factor,
@@ -393,20 +394,12 @@ def from_cli(opt, dyn_range_fac=1, precision='single',
         if opt.sgburst_injection_file:
             logging.info("Applying sine-Gaussian burst injections")
             injector =  SGBurstInjectionSet(opt.sgburst_injection_file)
-            if not opt.channel_name:
-                raise ValueError('Please provide channel names with the format '
-                                 'ifo:channel (e.g. H1:CALIB-STRAIN) to inject '
-                                 'simulated signals into fake strain')
             injector.apply(strain, opt.channel_name[0:2],
                              distance_scale=opt.injection_scale_factor)
 
         if opt.ringdown_injection_file:
             logging.info("Applying ringdown-only injection.")
             injector = RingdownInjectionSet(opt.ringdown_injection_file)
-            if not opt.channel_name:
-                raise ValueError('Please provide channel names with the format '
-                                 'ifo:channel (e.g. H1:CALIB-STRAIN) to inject '
-                                 'simulated signals into fake strain')
             injector.apply(strain, opt.channel_name[0:2])
 
         if precision == 'single':

--- a/pycbc/strain.py
+++ b/pycbc/strain.py
@@ -378,7 +378,7 @@ def from_cli(opt, dyn_range_fac=1, precision='single',
             strain = resample_to_delta_t(strain, 1.0/opt.sample_rate)
 
         if opt.injection_file or opt.sgburst_injection_file \
-        or opt.ringdown_injection_file and not opt.channel_name:
+            or opt.ringdown_injection_file and not opt.channel_name:
             raise ValueError('Please provide channel names with the format '
                              'ifo:channel (e.g. H1:CALIB-STRAIN) to inject '
                              'simulated signals into fake strain')

--- a/pycbc/strain.py
+++ b/pycbc/strain.py
@@ -347,7 +347,7 @@ def from_cli(opt, dyn_range_fac=1, precision='single',
         logging.info("Generating Fake Strain")
         if not opt.low_frequency_cutoff:
             raise ValueError('Please provide low frequency cutoff to '
-                              'generate a fake strain')
+                             'generate a fake strain')
         duration = opt.gps_end_time - opt.gps_start_time
         tlen = duration * opt.sample_rate
         pdf = 1.0/128
@@ -381,6 +381,9 @@ def from_cli(opt, dyn_range_fac=1, precision='single',
         if opt.injection_file:
             logging.info("Applying injections")
             injector = InjectionSet(opt.injection_file)
+            if not opt.channel_name:
+                raise ValueError('Please provide channel names to inject '
+                                 'simulated signals into fake strain')
             injections = \
                 injector.apply(strain, opt.channel_name[0:2],
                                distance_scale=opt.injection_scale_factor,
@@ -389,12 +392,18 @@ def from_cli(opt, dyn_range_fac=1, precision='single',
         if opt.sgburst_injection_file:
             logging.info("Applying sine-Gaussian burst injections")
             injector =  SGBurstInjectionSet(opt.sgburst_injection_file)
+            if not opt.channel_name:
+                raise ValueError('Please provide channel names to inject '
+                                 'simulated signals into fake strain')
             injector.apply(strain, opt.channel_name[0:2],
                              distance_scale=opt.injection_scale_factor)
 
         if opt.ringdown_injection_file:
             logging.info("Applying ringdown-only injection.")
             injector = RingdownInjectionSet(opt.ringdown_injection_file)
+            if not opt.channel_name:
+                raise ValueError('Please provide channel names to inject '
+                                 'simulated signals into fake strain')
             injector.apply(strain, opt.channel_name[0:2])
 
         if precision == 'single':

--- a/pycbc/strain.py
+++ b/pycbc/strain.py
@@ -382,7 +382,8 @@ def from_cli(opt, dyn_range_fac=1, precision='single',
             logging.info("Applying injections")
             injector = InjectionSet(opt.injection_file)
             if not opt.channel_name:
-                raise ValueError('Please provide channel names to inject '
+                raise ValueError('Please provide channel names with the format '
+                                 'ifo:channel (e.g. H1:CALIB-STRAIN) to inject '
                                  'simulated signals into fake strain')
             injections = \
                 injector.apply(strain, opt.channel_name[0:2],
@@ -393,7 +394,8 @@ def from_cli(opt, dyn_range_fac=1, precision='single',
             logging.info("Applying sine-Gaussian burst injections")
             injector =  SGBurstInjectionSet(opt.sgburst_injection_file)
             if not opt.channel_name:
-                raise ValueError('Please provide channel names to inject '
+                raise ValueError('Please provide channel names with the format '
+                                 'ifo:channel (e.g. H1:CALIB-STRAIN) to inject '
                                  'simulated signals into fake strain')
             injector.apply(strain, opt.channel_name[0:2],
                              distance_scale=opt.injection_scale_factor)
@@ -402,7 +404,8 @@ def from_cli(opt, dyn_range_fac=1, precision='single',
             logging.info("Applying ringdown-only injection.")
             injector = RingdownInjectionSet(opt.ringdown_injection_file)
             if not opt.channel_name:
-                raise ValueError('Please provide channel names to inject '
+                raise ValueError('Please provide channel names with the format '
+                                 'ifo:channel (e.g. H1:CALIB-STRAIN) to inject '
                                  'simulated signals into fake strain')
             injector.apply(strain, opt.channel_name[0:2])
 


### PR DESCRIPTION
In principle one could think that when generating a fake strain and using an ASD file there is no need to provide a channel name, since one might expect that the channel name is only used for reading frame files. However, when one tries to add an injection to this fake strain, then a not very helpful error message appears (if one does not know the strain module, it could take them a while to figure out what the problem is). That is because the strain module uses the first two letters of the channel name to figure out which detector it is injecting the signal to.
With this PR, if one wants to generate a fake strain and provides an injection file to add a simulated signal to the strain, but not a channel name, then the error message will request a channel name in the corresponding format.