### PR TITLE
Updates to n acl burn-in

### DIFF
--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -119,7 +119,7 @@ parser.add_argument("--checkpoint-fast", action="store_true",
 parser.add_argument("--acl-interval", type=int, default=None,
                     help="Specify the interval on which to calculate ACL and "
                          "burn-in. If not provided, will use the "
-                         "checkpoint-interval. This is doubled after 10000 "
+                         "checkpoint-interval. This is doubled after 50000 "
                          "iterations; doubled again after 100000 iterations; "
                          "and doubled again after 200000 iterations.")
 
@@ -488,7 +488,7 @@ with ctx:
                 acl_interval = 8 * opts.acl_interval
             elif niters > 100000:
                 acl_interval = 4 * opts.acl_interval
-            elif niters > 10000:
+            elif niters > 50000:
                 acl_interval = 2 * opts.acl_interval
 
         # clear the in-memory chain to save memory

--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -116,6 +116,7 @@ parser.add_argument("--checkpoint-fast", action="store_true",
                     help="Do not calculate ACL after each checkpoint, only at "
                          "the end. Not applicable if n-independent-samples "
                          "have been specified.")
+parser.add_argument("--acl-interval", type=int, default=None)
 
 # verbose option
 parser.add_argument("--verbose", action="store_true", default=False,
@@ -164,7 +165,6 @@ elif opts.n_independent_samples is not None:
 else:
     raise ValueError("Must specify niterations or n-independent-samples; "
                      "see --help")
-
 
 # get likelihood class
 likelihood_class = inference.likelihood_evaluators[opts.likelihood_evaluator]
@@ -407,7 +407,12 @@ with ctx:
     if interval is None:
         interval = get_nsamples
 
+    acl_interval = opts.acl_interval
+    if acl_interval is None:
+        acl_interval = checkpoint_interval
+
     # run sampler until we have the desired number of samples
+    acl_interval_count = 0
     while nsamples < get_nsamples:
 
         end = start + interval
@@ -429,22 +434,24 @@ with ctx:
             logging.info("Writing results to file")
             sampler.write_results(fp,static_args=static_args,
                                   ifos=opts.instruments)
-            try:
-                update_burn_in = not fp.is_burned_in
-                burnidx = fp.burn_in_iterations
-            except (AttributeError, KeyError):
-                update_burn_in = True
-            if update_burn_in:
-                logging.info("Calculating burn in")
-                burnidx, is_burned_in = burn_in_eval.update(sampler, fp)
+            acl_interval_count += interval
+            if acl_interval_count >= acl_interval:
+                try:
+                    update_burn_in = not fp.is_burned_in
+                    burnidx = fp.burn_in_iterations
+                except (AttributeError, KeyError):
+                    update_burn_in = True
+                if update_burn_in:
+                    logging.info("Calculating burn in")
+                    burnidx, is_burned_in = burn_in_eval.update(sampler, fp)
 
-            # compute the acls and write
-            acls = None
-            if opts.n_independent_samples is not None or end >= get_nsamples \
-                    or not opts.checkpoint_fast:
-                logging.info("Computing acls")
-                acls = sampler.compute_acls(fp)
-                sampler.write_acls(fp, acls)
+                # compute the acls and write
+                acls = None
+                if opts.n_independent_samples is not None or end >= get_nsamples \
+                        or not opts.checkpoint_fast:
+                    logging.info("Computing acls")
+                    acls = sampler.compute_acls(fp)
+                    sampler.write_acls(fp, acls)
 
         # write to backup
         with InferenceFile(backup_file, "a") as fp:
@@ -452,10 +459,11 @@ with ctx:
             logging.info("Writing to backup file")
             sampler.write_results(fp,static_args=static_args,
                                   ifos=opts.instruments)
-            if update_burn_in:
-                sampler.write_burn_in_iterations(fp, burnidx, is_burned_in)
-            if acls is not None:
-                sampler.write_acls(fp, acls)
+            if acl_interval_count >= acl_interval:
+                if update_burn_in:
+                    sampler.write_burn_in_iterations(fp, burnidx, is_burned_in)
+                if acls is not None:
+                    sampler.write_acls(fp, acls)
 
         # check validity
         checkpoint_valid = validate_checkpoint_files(checkpoint_file,
@@ -471,6 +479,17 @@ with ctx:
         else:
             nsamples += interval
 
+        if acl_interval_count >= acl_interval:
+            acl_interval_count = 0
+
+        with InferenceFile(checkpoint_file, 'r') as fp:
+            niters = fp.niterations
+            if niters > 10000:
+                acl_interval = 4000
+            if niters > 100000:
+                acl_interval = 8000
+            if niters > 200000:
+                acl_interval = 16000
 
         # clear the in-memory chain to save memory
         logging.info("Clearing chain")

--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -116,7 +116,12 @@ parser.add_argument("--checkpoint-fast", action="store_true",
                     help="Do not calculate ACL after each checkpoint, only at "
                          "the end. Not applicable if n-independent-samples "
                          "have been specified.")
-parser.add_argument("--acl-interval", type=int, default=None)
+parser.add_argument("--acl-interval", type=int, default=None,
+                    help="Specify the interval on which to calculate ACL and "
+                         "burn-in. If not provided, will use the "
+                         "checkpoint-interval. This is doubled after 10000 "
+                         "iterations; doubled again after 100000 iterations; "
+                         "and doubled again after 200000 iterations.")
 
 # verbose option
 parser.add_argument("--verbose", action="store_true", default=False,
@@ -407,9 +412,10 @@ with ctx:
     if interval is None:
         interval = get_nsamples
 
+    if opts.acl_interval is None:
+        opts.acl_interval = interval
+
     acl_interval = opts.acl_interval
-    if acl_interval is None:
-        acl_interval = checkpoint_interval
 
     # run sampler until we have the desired number of samples
     acl_interval_count = 0
@@ -484,12 +490,12 @@ with ctx:
 
         with InferenceFile(checkpoint_file, 'r') as fp:
             niters = fp.niterations
-            if niters > 10000:
-                acl_interval = 4000
-            if niters > 100000:
-                acl_interval = 8000
             if niters > 200000:
-                acl_interval = 16000
+                acl_interval = 8 * opts.acl_interval
+            elif niters > 100000:
+                acl_interval = 4 * opts.acl_interval
+            elif niters > 10000:
+                acl_interval = 2 * opts.acl_interval
 
         # clear the in-memory chain to save memory
         logging.info("Clearing chain")

--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -430,11 +430,11 @@ with ctx:
             sampler.write_results(fp,static_args=static_args,
                                   ifos=opts.instruments)
             try:
-                is_burned_in = fp.is_burned_in
+                update_burn_in = not fp.is_burned_in
                 burnidx = fp.burn_in_iterations
             except (AttributeError, KeyError):
-                is_burned_in = False
-            if not is_burned_in:
+                update_burn_in = True
+            if update_burn_in:
                 logging.info("Calculating burn in")
                 burnidx, is_burned_in = burn_in_eval.update(sampler, fp)
 
@@ -452,7 +452,8 @@ with ctx:
             logging.info("Writing to backup file")
             sampler.write_results(fp,static_args=static_args,
                                   ifos=opts.instruments)
-            sampler.write_burn_in_iterations(fp, burnidx, is_burned_in)
+            if update_burn_in:
+                sampler.write_burn_in_iterations(fp, burnidx, is_burned_in)
             if acls is not None:
                 sampler.write_acls(fp, acls)
 

--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -442,18 +442,13 @@ with ctx:
                                   ifos=opts.instruments)
             acl_interval_count += interval
             if acl_interval_count >= acl_interval:
-                try:
-                    update_burn_in = not fp.is_burned_in
-                    burnidx = fp.burn_in_iterations
-                except (AttributeError, KeyError):
-                    update_burn_in = True
-                if update_burn_in:
-                    logging.info("Calculating burn in")
-                    burnidx, is_burned_in = burn_in_eval.update(sampler, fp)
+                logging.info("Calculating burn in")
+                burnidx, is_burned_in = burn_in_eval.update(sampler, fp)
 
                 # compute the acls and write
                 acls = None
-                if opts.n_independent_samples is not None or end >= get_nsamples \
+                if opts.n_independent_samples is not None \
+                        or end >= get_nsamples \
                         or not opts.checkpoint_fast:
                     logging.info("Computing acls")
                     acls = sampler.compute_acls(fp)
@@ -466,8 +461,7 @@ with ctx:
             sampler.write_results(fp,static_args=static_args,
                                   ifos=opts.instruments)
             if acl_interval_count >= acl_interval:
-                if update_burn_in:
-                    sampler.write_burn_in_iterations(fp, burnidx, is_burned_in)
+                sampler.write_burn_in_iterations(fp, burnidx, is_burned_in)
                 if acls is not None:
                     sampler.write_acls(fp, acls)
 

--- a/pycbc/inference/burn_in.py
+++ b/pycbc/inference/burn_in.py
@@ -81,7 +81,7 @@ def ks_test(sampler, fp, threshold=0.9):
     return burn_in_idx, is_burned_in
 
 
-def n_acl(sampler, fp, nacls=5):
+def n_acl(sampler, fp, nacls=25):
     """Burn in based on ACL.
 
     This applies the following test to determine burn in:

--- a/pycbc/inference/burn_in.py
+++ b/pycbc/inference/burn_in.py
@@ -355,13 +355,8 @@ class BurnIn(object):
         if fp.niterations < self.min_iterations:
             return numpy.repeat(self.min_iterations, fp.nwalkers), \
                    numpy.zeros(fp.nwalkers, dtype=bool)
-        # if the file already has burn in iterations saved, use those as a
-        # base
-        try:
-            burnidx = fp['burn_in_iterations'][:]
-        except KeyError:
-            # just use the minimum
-            burnidx = numpy.repeat(self.min_iterations, fp.nwalkers)
+        # start assuming the minimum
+        burnidx = numpy.repeat(self.min_iterations, fp.nwalkers)
         # start by assuming is burned in; the &= below will make this false
         # if any test yields false
         is_burned_in = numpy.ones(fp.nwalkers, dtype=bool)

--- a/pycbc/inference/burn_in.py
+++ b/pycbc/inference/burn_in.py
@@ -81,12 +81,18 @@ def ks_test(sampler, fp, threshold=0.9):
     return burn_in_idx, is_burned_in
 
 
-def n_acl(sampler, fp, nacls=10):
+def n_acl(sampler, fp, nacls=5):
     """Burn in based on ACL.
 
-    The sampler is considered burned in if the number of itertions is >=
-    ``nacls`` times the maximum ACL over all parameters, as measured from the
-    first iteration.
+    This applies the following test to determine burn in:
+
+    1. The first half of the samples are ignored.
+
+    2. An ACL is calculated from the second half.
+
+    3. If the ``nacls`` times the ACL is < the number of iterations / 2,
+       the sampler is considered to be burned in at the half-way point.
+
 
     Parameters
     ----------
@@ -111,11 +117,13 @@ def n_acl(sampler, fp, nacls=10):
         all chains obtain burn in at the same time, this is either an array
         of all False or True.
     """
-    acl = numpy.array(sampler.compute_acls(fp, start_index=0).values()).max()
-    burn_idx = nacls * acl
-    is_burned_in = burn_idx < fp.niterations
+    N = fp.niterations
+    acl = numpy.array(sampler.compute_acls(fp, start_index=N/2).values()).max()
+    is_burned_in = nacls * acl < N/2
     if not is_burned_in:
-        burn_idx = fp.niterations
+        burn_idx = N
+    else:
+        burn_idx = N/2
     nwalkers = fp.nwalkers
     return numpy.repeat(burn_idx, nwalkers).astype(int), \
            numpy.repeat(is_burned_in, nwalkers).astype(bool)

--- a/pycbc/inference/burn_in.py
+++ b/pycbc/inference/burn_in.py
@@ -81,7 +81,7 @@ def ks_test(sampler, fp, threshold=0.9):
     return burn_in_idx, is_burned_in
 
 
-def n_acl(sampler, fp, nacls=25):
+def n_acl(sampler, fp, nacls=5):
     """Burn in based on ACL.
 
     This applies the following test to determine burn in:
@@ -103,7 +103,7 @@ def n_acl(sampler, fp, nacls=25):
         Open inference hdf file containing the samples to load for determing
         burn in.
     nacls : int
-        Number of ACLs to use for burn in. Default is 10.
+        Number of ACLs to use for burn in. Default is 5.
 
     Returns
     -------


### PR DESCRIPTION
This changes the `n_acl` burn-in function to do the following:

 1. Only the second half of the chain is used to compute ACL.
 2. If the number of iterations in the second half is > `n_acl * ACL`, then the sampler is considered burned in at the half way point.

The default `n_acl` is set to 25. If 200 walkers are used, with a desired number of independent samples of 5000, then this means the job will complete as soon as this burn-in test passes. This method seems to work best for `ecmee_pt`.

The way the ACL is computed is not changed. This PR supersedes #2169, which did something similar, but also switched to using the mean of ACLs instead of the ACL of the mean chain. Calculating ACL that way does not seem to work with `emcee_pt`, as the ACL was severely underestimated.

This also causes `BurnIn.update` to ignore what burn-in-iteration were previously saved in the file, as that was problematic for this test.

Depends on #2168; putting on hold until that is merged.