### PR TITLE
Update Dockerfile to use v1.7-8cbd1b7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM pycbc/pycbc-base-el7:v1.6-95ad957
+FROM pycbc/pycbc-base-el7:v1.7-8cbd1b7
 
 USER pycbc
 WORKDIR /home/pycbc


### PR DESCRIPTION
Update the Docker file image to use a lalsuite build that uses hash 8cbd1b7