### PR TITLE
Fix bug introduced in error message

### DIFF
--- a/pycbc/strain.py
+++ b/pycbc/strain.py
@@ -377,8 +377,8 @@ def from_cli(opt, dyn_range_fac=1, precision='single',
                                           low_frequency_cutoff=lowfreq)
             strain = resample_to_delta_t(strain, 1.0/opt.sample_rate)
 
-        if not opt.channel_name and opt.injection_file \
-                or opt.sgburst_injection_file or opt.ringdown_injection_file:
+        if not opt.channel_name and (opt.injection_file \
+                or opt.sgburst_injection_file or opt.ringdown_injection_file):
             raise ValueError('Please provide channel names with the format '
                              'ifo:channel (e.g. H1:CALIB-STRAIN) to inject '
                              'simulated signals into fake strain')

--- a/pycbc/strain.py
+++ b/pycbc/strain.py
@@ -377,8 +377,8 @@ def from_cli(opt, dyn_range_fac=1, precision='single',
                                           low_frequency_cutoff=lowfreq)
             strain = resample_to_delta_t(strain, 1.0/opt.sample_rate)
 
-        if opt.injection_file or opt.sgburst_injection_file \
-                or opt.ringdown_injection_file and not opt.channel_name:
+        if not opt.channel_name and opt.injection_file \
+                or opt.sgburst_injection_file or opt.ringdown_injection_file:
             raise ValueError('Please provide channel names with the format '
                              'ifo:channel (e.g. H1:CALIB-STRAIN) to inject '
                              'simulated signals into fake strain')

--- a/pycbc/strain.py
+++ b/pycbc/strain.py
@@ -378,7 +378,8 @@ def from_cli(opt, dyn_range_fac=1, precision='single',
             strain = resample_to_delta_t(strain, 1.0/opt.sample_rate)
 
         if not opt.channel_name and (opt.injection_file \
-                or opt.sgburst_injection_file or opt.ringdown_injection_file):
+                                     or opt.sgburst_injection_file \
+                                     or opt.ringdown_injection_file):
             raise ValueError('Please provide channel names with the format '
                              'ifo:channel (e.g. H1:CALIB-STRAIN) to inject '
                              'simulated signals into fake strain')


### PR DESCRIPTION
I'm afraid I introduced a bug in PR #2173 when combining all the if statements into one.
When Xisco tried to run the pycbc_inference example from the PyCBC documentation, he was getting that error all the time even if he had specified the channel-name. After some trials I noticed the error would always appear if there was an injection-file given (I had been running with ringdown-injection-file, that's why I didn't spot it before).
In this PR I inverted the order of the options in the if statement to correct for that.