### PR TITLE
Enable pylint and edit CodeClimate config

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,39 @@
+version: "2"         # required to adjust maintainability checks
+checks:
+  argument-count:
+    config:
+      threshold: 4
+  complex-logic:
+    config:
+      threshold: 4
+  file-lines:
+    config:
+      threshold: 250
+  method-complexity:
+    config:
+      threshold: 5
+  method-count:
+    config:
+      threshold: 20
+  method-lines:
+    config:
+      threshold: 25
+  nested-control-flow:
+    config:
+      threshold: 4
+  return-statements:
+    config:
+      threshold: 4
+  similar-code:
+    config:
+      threshold: # language-specific defaults. an override will affect all languages.
+  identical-code:
+    config:
+      threshold: # language-specific defaults. an override will affect all languages.
+engines:
+  pylint:
+    enabled: true
+    channel: "beta"
+plugins:
+  pep8:
+    enabled: true

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -30,10 +30,9 @@ checks:
   identical-code:
     config:
       threshold: # language-specific defaults. an override will affect all languages.
-engines:
+plugins:
   pylint:
     enabled: true
     channel: "beta"
-plugins:
   pep8:
     enabled: true

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -2,22 +2,22 @@ version: "2"         # required to adjust maintainability checks
 checks:
   argument-count:
     config:
-      threshold: 4
+      threshold: 30
   complex-logic:
     config:
       threshold: 4
   file-lines:
     config:
-      threshold: 250
+      threshold: 1000
   method-complexity:
     config:
-      threshold: 5
+      threshold: 4
   method-count:
     config:
-      threshold: 20
+      threshold: 50
   method-lines:
     config:
-      threshold: 25
+      threshold: 100
   nested-control-flow:
     config:
       threshold: 4
@@ -31,8 +31,29 @@ checks:
     config:
       threshold: # language-specific defaults. an override will affect all languages.
 plugins:
+  duplication:
+    enabled: true
+    config:
+      languages:
+      - python
+  fixme:
+    enabled: true
+    config:
+      strings:
+      - FIXME
+      - XXX
   pylint:
     enabled: true
     channel: "beta"
+    checks:
+      import-error:
+        enabled: false
   pep8:
     enabled: true
+
+exclude_paths:
+- docs/*
+- tools/*
+- examples/*
+- test/*
+


### PR DESCRIPTION
This PR moves the CodeClimate config management from the web front-end (visible only be me) to a config file in the repository. This starts from the existing config then:

 * I add exclude rules for test, docs, examples and tools. 
 * I have added support for pylint (currently in beta, but useful nonetheless, will move out of beta when it moves out of beta in CodeClimate)
 * Loosened CodeClimate built-in test severity, following what @cdcapano did in GWIN.
 * Added additional plugins used by GWIN, but not yet used here.

This might need some further tuning, but CodeClimate can help to explain how to disable a test if someone thinks some results are not useful (I can also mark issues in the front-end as "not a real issue" where needed).

.... I still miss landscape, but CodeClimate is coming close to restoring functionality.