### PR TITLE
move checkpoint check after pool lock

### DIFF
--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -148,19 +148,6 @@ if os.path.exists(opts.output_file) and not opts.force:
     raise OSError("output-file already exists; use --force if you wish to "
                   "overwrite it.")
 
-# check for backup file(s)
-checkpoint_file = opts.output_file + '.checkpoint'
-backup_file = opts.output_file + '.bkup'
-checkpoint_valid = validate_checkpoint_files(checkpoint_file, backup_file)
-
-# determine what to do with checkpoints
-if checkpoint_valid and not opts.resume_from_checkpoint and not opts.force:
-    raise OSError("valid checkpoint file {} found, but "
-                  "resume-from-checkpoint not on. If you wish to overwrite "
-                  "use --force; otherwise, use --resume-from-checkpoint")
-if not opts.resume_from_checkpoint and opts.force:
-    checkpoint_valid = False
-
 # check for how many iterations to run
 max_iterations = opts.niterations
 if opts.niterations is not None and opts.n_independent_samples is not None:
@@ -294,6 +281,19 @@ with ctx:
 
     # create sampler that will run
     sampler = option_utils.sampler_from_cli(opts, likelihood)
+
+    # check for backup file(s)
+    checkpoint_file = opts.output_file + '.checkpoint'
+    backup_file = opts.output_file + '.bkup'
+    checkpoint_valid = validate_checkpoint_files(checkpoint_file, backup_file)
+
+    # determine what to do with checkpoints
+    if checkpoint_valid and not opts.resume_from_checkpoint and not opts.force:
+        raise OSError("valid checkpoint file {} found, but "
+                      "resume-from-checkpoint not on. If you wish to overwrite "
+                      "use --force; otherwise, use --resume-from-checkpoint")
+    if not opts.resume_from_checkpoint and opts.force:
+        checkpoint_valid = False
 
     # save information about this data and settings
     if not checkpoint_valid:

--- a/pycbc/pool.py
+++ b/pycbc/pool.py
@@ -16,7 +16,7 @@ def is_main_process():
         comm = MPI.COMM_WORLD
         rank = comm.Get_rank()
         return rank == 0
-    except ImportError, ValueError, RuntimeError:
+    except (ImportError, ValueError, RuntimeError):
         return True
 
 # Allow the pool to be interrupted, need to disable the children processes

--- a/pycbc/pool.py
+++ b/pycbc/pool.py
@@ -16,7 +16,7 @@ def is_main_process():
         comm = MPI.COMM_WORLD
         rank = comm.Get_rank()
         return rank == 0
-    except:
+    except ImportError, ValueError, RuntimeError:
         return True
 
 # Allow the pool to be interrupted, need to disable the children processes

--- a/pycbc/pool.py
+++ b/pycbc/pool.py
@@ -8,6 +8,17 @@ import types
 import signal
 import atexit
 
+def is_main_process():
+    """ Check if this is the main control process and may handle one time tasks
+    """
+    try:
+        from mpi4py import MPI
+        comm = MPI.COMM_WORLD
+        rank = comm.Get_rank()
+        return rank == 0
+    except:
+        return True
+
 # Allow the pool to be interrupted, need to disable the children processes
 # from intercepting the keyboard interrupt
 def _noint(init, *args):


### PR DESCRIPTION
Checkpoint validation should be after the sampler creation as this is where the mpi process will branch. If you do it afterwards it ensures that this part is *only* run by the master process, preventing a failure mode where every process tries to do a file copy of the backup or checkpoint file. 