### PR TITLE
Added option to provide a filter string in pycbc_plot_singles_vs_params

### DIFF
--- a/bin/hdfcoinc/pycbc_plot_singles_vs_params
+++ b/bin/hdfcoinc/pycbc_plot_singles_vs_params
@@ -86,8 +86,6 @@ snr_filter = '(self.snr>%f)' % (opts.min_snr) if opts.min_snr > 0. else None
 filts = [f for f in [snr_filter, opts.filter_string] if f is not None]
 filter_func = ' & '.join(filts) if filts else None
 
-print filter_func
-
 trigs = pycbc.io.SingleDetTriggers(opts.single_trig_file, opts.bank_file,
                   opts.veto_file, opts.segment_name, filter_func, opts.detector)
 

--- a/bin/hdfcoinc/pycbc_plot_singles_vs_params
+++ b/bin/hdfcoinc/pycbc_plot_singles_vs_params
@@ -49,6 +49,8 @@ parser.add_argument('--veto-file', type=str,
                     help='Optional path to file containing veto segments')
 parser.add_argument('--segment-name', default=None, type=str,
                     help='Optional, name of segment list to use for vetoes')
+parser.add_argument('--filter-string', default=None, type=str,
+                    help='Optional, boolean expression for filtering triggers')
 parser.add_argument('--min-snr', default=0., type=float,
                     help='Only plot triggers above the given SNR')
 parser.add_argument('--output-file', type=str, required=True,
@@ -80,7 +82,10 @@ opts = parser.parse_args()
 
 logging.basicConfig(format='%(asctime)s %(message)s', level=logging.INFO)
 
-filter_func = 'self.snr>%f' % (opts.min_snr) if opts.min_snr > 0. else None 
+snr_filter = 'self.snr>%f' % (opts.min_snr) if opts.min_snr > 0. else None 
+filts = [f for f in [snr_filter, opts.filter_string] if f is not None]
+filter_func = ' & '.join(filts) if np.any(filts) else None
+
 trigs = pycbc.io.SingleDetTriggers(opts.single_trig_file, opts.bank_file,
                   opts.veto_file, opts.segment_name, filter_func, opts.detector)
 

--- a/bin/hdfcoinc/pycbc_plot_singles_vs_params
+++ b/bin/hdfcoinc/pycbc_plot_singles_vs_params
@@ -82,9 +82,11 @@ opts = parser.parse_args()
 
 logging.basicConfig(format='%(asctime)s %(message)s', level=logging.INFO)
 
-snr_filter = 'self.snr>%f' % (opts.min_snr) if opts.min_snr > 0. else None 
+snr_filter = '(self.snr>%f)' % (opts.min_snr) if opts.min_snr > 0. else None 
 filts = [f for f in [snr_filter, opts.filter_string] if f is not None]
-filter_func = ' & '.join(filts) if np.any(filts) else None
+filter_func = ' & '.join(filts) if filts else None
+
+print filter_func
 
 trigs = pycbc.io.SingleDetTriggers(opts.single_trig_file, opts.bank_file,
                   opts.veto_file, opts.segment_name, filter_func, opts.detector)


### PR DESCRIPTION
This PR allows for custom trigger filtering in `pycbc_plot_singles_vs_params`.

The functionality of the `--min-snr` argument is retained by combining that option with `--filter-string` to make an overall trigger filter.

Code ran successfully when providing `--min-snr 5.` and `--filter-string "(self.snr < 100) & (self.mass1 > 30)"` as individual arguments, one at a time, and with neither provided.