### PR TITLE
put wisdom import within try/except for pycbc live

### DIFF
--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -328,16 +328,19 @@ if evnt.rank == 0 and args.enable_gracedb_upload:
 
 # I'm not the root, so do some actually filtering.
 with ctx:
-    # Import system wisdom.
-    if args.fftw_import_system_wisdom:
-        fft.fftw.import_sys_wisdom()
+    try:
+        # Import system wisdom.
+        if args.fftw_import_system_wisdom:
+            fft.fftw.import_sys_wisdom()
 
-    # Read specified user-provided wisdom files
-    if args.fftw_input_float_wisdom_file is not None:
-        fft.fftw.import_single_wisdom_from_filename(args.fftw_input_float_wisdom_file)
+        # Read specified user-provided wisdom files
+        if args.fftw_input_float_wisdom_file is not None:
+            fft.fftw.import_single_wisdom_from_filename(args.fftw_input_float_wisdom_file)
 
-    if args.fftw_input_double_wisdom_file is not None:
-        fft.fftw.import_double_wisdom_from_filename(args.fftw_input_double_wisdom_file)
+        if args.fftw_input_double_wisdom_file is not None:
+            fft.fftw.import_double_wisdom_from_filename(args.fftw_input_double_wisdom_file)
+    except:
+        pass
 
     maxlen = args.psd_segment_length * (args.psd_samples / 2 + 1)
     if evnt.rank > 0:

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -339,7 +339,7 @@ with ctx:
 
         if args.fftw_input_double_wisdom_file is not None:
             fft.fftw.import_double_wisdom_from_filename(args.fftw_input_double_wisdom_file)
-    except:
+    except RuntimeError:
         pass
 
     maxlen = args.psd_segment_length * (args.psd_samples / 2 + 1)


### PR DESCRIPTION
This is helpful as the head node may not be the same architecture and so can't import the same wisdom files. The files are only really needed for the compute nodes. 