### PR TITLE
Rework single-detector stat

### DIFF
--- a/bin/hdfcoinc/pycbc_fit_sngls_binned
+++ b/bin/hdfcoinc/pycbc_fit_sngls_binned
@@ -33,6 +33,8 @@ import pycbc.version
 #### DEFINITIONS AND FUNCTIONS ####
 
 def get_stat(statchoice, trigs):
+    # Initialize statclass with an empty file list. In general could feed it
+    # files here for statistics which need that.
     stat_instance = sngl_statistic_dict[statchoice]([])
     return stat_instance.single(trigs)
 

--- a/bin/hdfcoinc/pycbc_fit_sngls_binned
+++ b/bin/hdfcoinc/pycbc_fit_sngls_binned
@@ -27,27 +27,14 @@ from scipy.stats import kstest
 
 from pycbc import io, events, bin_utils, results
 from pycbc.events import trigger_fits as trstats
+from pycbc.events.stat import sngl_statistic_dict
 import pycbc.version
 
 #### DEFINITIONS AND FUNCTIONS ####
 
-stat_dict = {
-    "new_snr"       : events.newsnr,
-    "effective_snr" : events.effsnr,
-    "snr"           : lambda snr, rchisq : snr,
-    "snronchi"      : lambda snr, rchisq : snr / (rchisq ** 0.5),
-    "newsnr_sgveto"      : events.newsnr_sgveto,
-}
-
-def get_stat(statchoice, snr, rchisq, sgchisq, fac):
-    if fac is not None:
-        if statchoice not in ['new_snr', 'effective_snr']:
-            raise RuntimeError("Can't use --stat-factor with this statistic!")
-        return stat_dict[statchoice](snr, rchisq, fac)
-    elif statchoice == 'newsnr_sgveto':
-        return stat_dict[statchoice](snr, rchisq, sgchisq)
-    else:
-        return stat_dict[statchoice](snr, rchisq)
+def get_stat(statchoice, trigs):
+    stat_instance = sngl_statistic_dict[statchoice]([])
+    return stat_instance.single(trigs)
 
 #### MAIN ####
 
@@ -75,7 +62,7 @@ parser.add_argument("--fit-function",
                     choices=["exponential", "rayleigh", "power"],
                     help="Functional form for the maximum likelihood fit")
 parser.add_argument("--sngl-stat", default="new_snr",
-                    choices=["snr", "snronchi", "effective_snr", "new_snr", "newsnr_sgveto"],
+                    choices=sngl_statistic_dict.keys(),
                     help="Function of SNR and chisq to perform fits with")
 parser.add_argument("--stat-factor", type=float,
                     help="Adjustable magic number used in some sngl "
@@ -171,28 +158,7 @@ logging.info('Opening template file: %s' % args.bank_file)
 templatef = h5py.File(args.bank_file, 'r')
 
 # get the stat values
-minth = min(args.stat_threshold)
-snr = trigf[args.ifo+'/snr'][:]
-# SNR cut to reduce memory usage
-logging.info('Applying SNR cut at %f' % minth)
-aboveminth = snr >= minth
-snr = snr[aboveminth]
-chisq = trigf[args.ifo+'/chisq'][:][aboveminth]
-chisq_dof = trigf[args.ifo+'/chisq_dof'][:][aboveminth]
-rchisq = chisq / (2 * chisq_dof - 2)
-
-try:
-    sgchisq = trigf[args.ifo+'/sg_chisq'][:][aboveminth]
-except KeyError:
-    sgchisq = None
-
-del chisq
-del chisq_dof
-logging.info('Calculating stat values')
-stat = get_stat(args.sngl_stat, snr, rchisq, sgchisq, args.stat_factor)
-del snr
-del rchisq
-del sgchisq
+stat = get_stat(args.sngl_stat, trigf[args.ifo])
 
 # get the duration values if needed
 if args.bin_param == 'template_duration' and not args.f_lower:
@@ -205,10 +171,10 @@ else:
 minth = min(args.stat_threshold)
 abovethresh = stat >= minth
 stat = stat[abovethresh]
-tid = trigf[args.ifo+'/template_id'][:][aboveminth][abovethresh]
-time = trigf[args.ifo+'/end_time'][:][aboveminth][abovethresh]
+tid = trigf[args.ifo+'/template_id'][:][abovethresh]
+time = trigf[args.ifo+'/end_time'][:][abovethresh]
 if trig_dur:
-    tdur = trigf[args.ifo+'/template_duration'][:][aboveminth][abovethresh]
+    tdur = trigf[args.ifo+'/template_duration'][:][abovethresh]
 logging.info('%i trigs left after thresholding at %f' % (len(stat), minth))
 
 # now do vetoing

--- a/bin/hdfcoinc/pycbc_fit_sngls_by_template
+++ b/bin/hdfcoinc/pycbc_fit_sngls_by_template
@@ -27,6 +27,8 @@ import pycbc.version
 #### DEFINITIONS AND FUNCTIONS ####
 
 def get_stat(statchoice, trigs):
+    # Initialize statclass with an empty file list. In general could feed it
+    # files here for statistics which need that.
     stat_instance = sngl_statistic_dict[statchoice]([])
     return stat_instance.single(trigs)
 

--- a/bin/hdfcoinc/pycbc_fit_sngls_by_template
+++ b/bin/hdfcoinc/pycbc_fit_sngls_by_template
@@ -21,27 +21,15 @@ import copy, numpy as np
 
 from pycbc import io, events
 from pycbc.events import trigger_fits as trstats
+from pycbc.events.stat import sngl_statistic_dict
 import pycbc.version
 
 #### DEFINITIONS AND FUNCTIONS ####
 
-stat_dict = {
-    "new_snr"       : events.newsnr,
-    "effective_snr" : events.effsnr,
-    "snr"           : lambda snr, rchisq : snr,
-    "snronchi"      : lambda snr, rchisq : snr / (rchisq ** 0.5),
-    "newsnr_sgveto"      : events.newsnr_sgveto,
-}
+def get_stat(statchoice, trigs):
+    stat_instance = sngl_statistic_dict[statchoice]([])
+    return stat_instance.single(trigs)
 
-def get_stat(statchoice, snr, rchisq, sgchisq, fac):
-    if fac is not None:
-        if statchoice not in ['new_snr', 'effective_snr']:
-            raise RuntimeError("Can't use --stat-factor with this statistic!")
-        return stat_dict[statchoice](snr, rchisq, fac)
-    elif statchoice == 'newsnr_sgveto':
-        return stat_dict[statchoice](snr, rchisq, sgchisq)
-    else:
-        return stat_dict[statchoice](snr, rchisq)
 #### MAIN ####
 
 parser = argparse.ArgumentParser(usage="",
@@ -74,12 +62,8 @@ parser.add_argument("--fit-function",
                     choices=["exponential", "rayleigh", "power"],
                     help="Functional form for the maximum likelihood fit")
 parser.add_argument("--sngl-stat", default="new_snr",
-                    choices=["snr", "snronchi", "effective_snr", "new_snr", "newsnr_sgveto"],
+                    choices=sngl_statistic_dict.keys(),
                     help="Function of SNR and chisq to perform fits with")
-parser.add_argument("--stat-factor", type=float,
-                    help="Adjustable magic number used in some sngl "
-                    "statistics. Values commonly used: 6 for new_snr, 250 "
-                    "or 50 for effective_snr")
 parser.add_argument("--stat-threshold", type=float,
                     help="Only fit triggers with statistic value above this "
                     "threshold.  Required.  Typically 6-6.5")
@@ -137,22 +121,9 @@ logging.info('Opening template file: %s' % args.bank_file)
 templatef = h5py.File(args.bank_file, 'r')
 
 # get the stat values
-chisq = trigf[args.ifo+'/chisq'][:]
-chisq_dof = trigf[args.ifo+'/chisq_dof'][:]
-rchisq = chisq / (2 * chisq_dof - 2)
-try:
-    sgchisq = trigf[args.ifo+'/sg_chisq'][:]
-except KeyError:
-    sgchisq = None
-
-del chisq
-del chisq_dof
-snr = trigf[args.ifo+'/snr'][:]
 logging.info('Calculating stat values')
-stat = get_stat(args.sngl_stat, snr, rchisq, sgchisq, args.stat_factor)
-del snr
-del rchisq
-del sgchisq
+stat = get_stat(args.sngl_stat, trigf[args.ifo])
+
 # do first thresholding operation to reduce trigger numbers
 abovethresh = stat >= args.stat_threshold
 stat = stat[abovethresh]
@@ -300,8 +271,6 @@ if args.save_trig_param:
 outfile.attrs.create("ifo", data=args.ifo)
 outfile.attrs.create("fit_function", data=args.fit_function)
 outfile.attrs.create("sngl_stat", data=args.sngl_stat)
-if args.stat_factor:
-    outfile.attrs.create("stat_factor", data=args.stat_factor)
 if args.save_trig_param:
     outfile.attrs.create("save_trig_param", data=args.save_trig_param)
 outfile.attrs.create("stat_threshold", data=args.stat_threshold)

--- a/bin/plotting/pycbc_plot_trigrate
+++ b/bin/plotting/pycbc_plot_trigrate
@@ -26,27 +26,14 @@ from scipy import stats as scistats
 
 from pycbc import io, events, bin_utils, results
 from pycbc.events import trigger_fits as trstats
+from pycbc.events.stat import sngl_statistic_dict
 import pycbc.version
 
 #### DEFINITIONS AND FUNCTIONS ####
 
-stat_dict = {
-    "new_snr"       : events.newsnr,
-    "effective_snr" : events.effsnr,
-    "snr"           : lambda snr, rchisq : snr,
-    "snronchi"      : lambda snr, rchisq : snr / (rchisq ** 0.5),
-    "newsnr_sgveto"      : events.newsnr_sgveto,
-}
-
-def get_stat(statchoice, snr, rchisq, sgchisq, fac):
-    if fac is not None:
-        if statchoice not in ['new_snr', 'effective_snr']:
-            raise RuntimeError("Can't use --stat-factor with this statistic!")
-        return stat_dict[statchoice](snr, rchisq, fac)
-    elif statchoice == 'newsnr_sgveto':
-        return stat_dict[statchoice](snr, rchisq, sgchisq)
-    else:
-        return stat_dict[statchoice](snr, rchisq)
+def get_stat(statchoice, trigs):
+    stat_instance = sngl_statistic_dict[statchoice]([])
+    return stat_instance.single(trigs)
 
 #### MAIN ####
 
@@ -73,7 +60,7 @@ parser.add_argument("--gps-start-time", type=float,
 parser.add_argument("--gps-end-time", type=float,
                     help="End time up to which to load/plot triggers")
 parser.add_argument("--sngl-stat", default="new_snr",
-                    choices=["snr", "snronchi", "effective_snr", "new_snr", "newsnr_sgveto"],
+                    choices=sngl_statistic_dict.keys(),
                     help="Function of SNR and chisq to threshold on")
 parser.add_argument("--stat-factor", type=float,
                     help="Adjustable magic number used in some sngl "
@@ -148,27 +135,7 @@ logging.info('Opening template file: %s' % args.bank_file)
 templatef = h5py.File(args.bank_file, 'r')
 
 # get the stat values
-snr = trigf[args.ifo+'/snr'][:]
-# SNR cut to reduce memory usage
-logging.info('Applying SNR cut at %f' % args.stat_threshold)
-aboveth = snr >= args.stat_threshold
-snr = snr[aboveth]
-chisq = trigf[args.ifo+'/chisq'][:][aboveth]
-chisq_dof = trigf[args.ifo+'/chisq_dof'][:][aboveth]
-rchisq = chisq / (2 * chisq_dof - 2)
-
-try:
-    sgchisq = trigf[args.ifo+'/sg_chisq'][:][aboveth]
-except KeyError:
-    sgchisq = None
-
-del chisq
-del chisq_dof
-logging.info('Calculating stat values')
-stat = get_stat(args.sngl_stat, snr, rchisq, sgchisq, args.stat_factor)
-del snr
-del rchisq
-del sgchisq
+stat = get_stat(args.sngl_stat, trigf[args.ifo])
 
 # get the duration values if needed
 if args.bin_param == 'template_duration' and not args.f_lower:
@@ -180,10 +147,10 @@ else:
 # stat threshold to reduce trigger numbers
 abovethresh = stat >= args.stat_threshold
 stat = stat[abovethresh]
-tid = trigf[args.ifo+'/template_id'][:][aboveth][abovethresh]
-time = trigf[args.ifo+'/end_time'][:][aboveth][abovethresh]
+tid = trigf[args.ifo+'/template_id'][:][abovethresh]
+time = trigf[args.ifo+'/end_time'][:][abovethresh]
 if trig_dur:
-    tdur = trigf[args.ifo+'/template_duration'][:][aboveth][abovethresh]
+    tdur = trigf[args.ifo+'/template_duration'][:][abovethresh]
 logging.info('%i trigs left after thresholding at %f' % (len(stat), args.stat_threshold))
 del stat
 

--- a/bin/plotting/pycbc_plot_trigrate
+++ b/bin/plotting/pycbc_plot_trigrate
@@ -32,6 +32,8 @@ import pycbc.version
 #### DEFINITIONS AND FUNCTIONS ####
 
 def get_stat(statchoice, trigs):
+    # Initialize statclass with an empty file list. In general could feed it
+    # files here for statistics which need that.
     stat_instance = sngl_statistic_dict[statchoice]([])
     return stat_instance.single(trigs)
 

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -552,12 +552,7 @@ sngl_statistic_dict = {
     'newsnr_sgveto': NewSNRSGStatistic
 }
 
-# When we have python3 use this to make these immutable in the functions
-# below
-# from types import MappingProxyType
-# sngl_statistic_immut = MappingProxyType(default_config)
-
-def get_statistic(stat, stat_dict=statistic_dict):
+def get_statistic(stat):
     """
     Error-handling sugar around dict lookup for coincident statistics
 
@@ -577,7 +572,7 @@ def get_statistic(stat, stat_dict=statistic_dict):
         If the string is not recognized as corresponding to a Stat subclass
     """
     try:
-        return stat_dict[stat]
+        return statistic_dict[stat]
     except KeyError:
         raise RuntimeError('%s is not an available detection statistic' % stat)
 
@@ -600,5 +595,8 @@ def get_sngl_statistic(stat):
     RuntimeError
         If the string is not recognized as corresponding to a Stat subclass
     """
-    return get_statistic(stat, stat_dict=sngl_statistic_dict)
+    try:
+        return sngl_statistic_dict[stat]
+    except KeyError:
+        raise RuntimeError('%s is not an available detection statistic' % stat)
 

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -551,7 +551,7 @@ sngl_statistic_dict = {
     'newsnr_sgveto': NewSNRSGStatistic
 }
 
-def get_statistic(stat):
+def get_statistic(stat, stat_dict=statistic_dict):
     """
     Error-handling sugar around dict lookup for coincident statistics
 
@@ -571,7 +571,7 @@ def get_statistic(stat):
         If the string is not recognized as corresponding to a Stat subclass
     """
     try:
-        return statistic_dict[stat]
+        return stat_dict[stat]
     except KeyError:
         raise RuntimeError('%s is not an available detection statistic' % stat)
 
@@ -594,8 +594,5 @@ def get_sngl_statistic(stat):
     RuntimeError
         If the string is not recognized as corresponding to a Stat subclass
     """
-    try:
-        return sngl_statistic_dict[stat]
-    except KeyError:
-        raise RuntimeError('%s is not an available detection statistic' % stat)
+    return get_statistic(stat, stat_dict=sngl_statistic_dict)
 

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -64,8 +64,9 @@ def get_newsnr_sgveto(trigs):
         Array of newsnr values
     """
     dof = 2. * trigs['chisq_dof'][:] - 2.
-    nsnr_sg = events.newsnr_sgveto\
-        (trigs['snr'][:], trigs['chisq'][:] / dof, trigs['sg_chisq'][:])
+    nsnr_sg = events.newsnr_sgveto(trigs['snr'][:],
+                                   trigs['chisq'][:] / dof,
+                                   trigs['sg_chisq'][:])
     return numpy.array(nsnr_sg, ndmin=1, dtype=numpy.float32)
 
 
@@ -552,12 +553,12 @@ sngl_statistic_dict = {
 
 def get_statistic(stat):
     """
-    Error-handling sugar around dict lookup
+    Error-handling sugar around dict lookup for coincident statistics
 
     Parameters
     ----------
     stat : string
-        Name of the statistic
+        Name of the coincident statistic
 
     Returns
     -------
@@ -576,12 +577,12 @@ def get_statistic(stat):
 
 def get_sngl_statistic(stat):
     """
-    Error-handling sugar around dict lookup
+    Error-handling sugar around dict lookup for single-detector statistics
 
     Parameters
     ----------
     stat : string
-        Name of the statistic
+        Name of the single-detector statistic
 
     Returns
     -------

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -35,9 +35,9 @@ def get_newsnr(trigs):
 
     Parameters
     ----------
-    trigs: dict of numpy.ndarrays
-        Dictionary holding single detector trigger information.
-    'chisq_dof', 'snr', and 'chisq' are required keys
+    trigs: dict of numpy.ndarrays, h5py group (or similar dict-like object)
+        Dictionary-like object holding single detector trigger information.
+        'chisq_dof', 'snr', and 'chisq' are required keys
 
     Returns
     -------
@@ -54,9 +54,9 @@ def get_newsnr_sgveto(trigs):
 
     Parameters
     ----------
-    trigs: dict of numpy.ndarrays
-        Dictionary holding single detector trigger information.
-    'chisq_dof', 'snr', and 'chisq' are required keys
+    trigs: dict of numpy.ndarrays, h5py group (or similar dict-like object)
+        Dictionary-like object holding single detector trigger information.
+        'chisq_dof', 'snr', 'sg_chisq' and 'chisq' are required keys
 
     Returns
     -------
@@ -106,7 +106,8 @@ class NewSNRStatistic(Stat):
 
         Parameters
         ----------
-        trigs: dict of numpy.ndarrays
+        trigs: dict of numpy.ndarrays, h5py group (or similar dict-like object)
+            Dictionary-like object holding single detector trigger information.
 
         Returns
         -------
@@ -160,7 +161,8 @@ class NewSNRSGStatistic(NewSNRStatistic):
 
         Parameters
         ----------
-        trigs: dict of numpy.ndarrays
+        trigs: dict of numpy.ndarrays, h5py group (or similar dict-like object)
+            Dictionary-like object holding single detector trigger information.
 
         Returns
         -------
@@ -187,9 +189,8 @@ class NewSNRCutStatistic(NewSNRStatistic):
 
         Parameters
         ----------
-        trigs: dict of numpy.ndarrays
-            Dictionary of the single detector trigger information. 'chisq_dof',
-        'snr', and 'chisq' are required keys
+        trigs: dict of numpy.ndarrays, h5py group (or similar dict-like object)
+            Dictionary-like object holding single detector trigger information.
 
         Returns
         -------
@@ -257,10 +258,10 @@ class PhaseTDStatistic(NewSNRStatistic):
 
         Parameters
         ----------
-        trigs: dict of numpy.ndarrays
-            Dictionary holding single detector trigger information.
-        'chisq_dof', 'snr', 'chisq', 'coa_phase', 'end_time', and 'sigmasq'
-        are required keys.
+        trigs: dict of numpy.ndarrays, h5py group (or similar dict-like object)
+            Dictionary-like object holding single detector trigger information.
+            'chisq_dof', 'snr', 'chisq', 'coa_phase', 'end_time', and 'sigmasq'
+            are required keys.
 
         Returns
         -------
@@ -511,10 +512,10 @@ class MaxContTradNewSNRStatistic(NewSNRStatistic):
 
         Parameters
         ----------
-        trigs: dict of numpy.ndarrays
-            Dictionary of the single detector trigger information. 'chisq_dof',
-        'snr', 'cont_chisq', 'cont_chisq_dof', and 'chisq' are required arrays
-        for this statistic.
+        trigs: dict of numpy.ndarrays, h5py group (or similar dict-like object)
+            Dictionary-like object holding single detector trigger information.
+            'snr', 'cont_chisq', 'cont_chisq_dof', 'chisq_dof' and 'chisq'
+            are required keys for this statistic.
 
         Returns
         -------
@@ -550,6 +551,11 @@ sngl_statistic_dict = {
     'max_cont_trad_newsnr': MaxContTradNewSNRStatistic,
     'newsnr_sgveto': NewSNRSGStatistic
 }
+
+# When we have python3 use this to make these immutable in the functions
+# below
+# from types import MappingProxyType
+# sngl_statistic_immut = MappingProxyType(default_config)
 
 def get_statistic(stat, stat_dict=statistic_dict):
     """

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -44,8 +44,8 @@ def get_newsnr(trigs):
     numpy.ndarray
         Array of newsnr values
     """
-    dof = 2. * trigs['chisq_dof'] - 2.
-    newsnr = events.newsnr(trigs['snr'], trigs['chisq'] / dof)
+    dof = 2. * trigs['chisq_dof'][:] - 2.
+    newsnr = events.newsnr(trigs['snr'][:], trigs['chisq'][:] / dof)
     return numpy.array(newsnr, ndmin=1, dtype=numpy.float32)
 
 def get_newsnr_sgveto(trigs):
@@ -63,8 +63,9 @@ def get_newsnr_sgveto(trigs):
     numpy.ndarray
         Array of newsnr values
     """
-    dof = 2. * trigs['chisq_dof'] - 2.
-    nsnr_sg = events.newsnr_sgveto(trigs['snr'], trigs['chisq'] / dof, trigs['sg_chisq'])
+    dof = 2. * trigs['chisq_dof'][:] - 2.
+    nsnr_sg = events.newsnr_sgveto\
+        (trigs['snr'][:], trigs['chisq'][:] / dof, trigs['sg_chisq'][:])
     return numpy.array(nsnr_sg, ndmin=1, dtype=numpy.float32)
 
 
@@ -195,7 +196,7 @@ class NewSNRCutStatistic(NewSNRStatistic):
             Array of single detector values
         """
         newsnr = get_newsnr(trigs)
-        rchisq = trigs['chisq'] / (2. * trigs['chisq_dof'] - 2.)
+        rchisq = trigs['chisq'][:] / (2. * trigs['chisq_dof'][:] - 2.)
         newsnr[numpy.logical_and(newsnr < 10, rchisq > 2)] = -1
         return newsnr
 
@@ -268,10 +269,10 @@ class PhaseTDStatistic(NewSNRStatistic):
         sngl_stat = get_newsnr(trigs)
         singles = numpy.zeros(len(sngl_stat), dtype=self.single_dtype)
         singles['snglstat'] = sngl_stat
-        singles['coa_phase'] = trigs['coa_phase']
-        singles['end_time'] = trigs['end_time']
-        singles['sigmasq'] = trigs['sigmasq']
-        singles['snr'] = trigs['snr']
+        singles['coa_phase'] = trigs['coa_phase'][:]
+        singles['end_time'] = trigs['end_time'][:]
+        singles['sigmasq'] = trigs['sigmasq'][:]
+        singles['snr'] = trigs['snr'][:]
         return numpy.array(singles, ndmin=1)
 
     def logsignalrate(self, s0, s1, slide, step):
@@ -472,10 +473,10 @@ class PhaseTDExpFitStatistic(PhaseTDStatistic, ExpFitCombinedSNR):
         sngl_stat = ExpFitCombinedSNR.single(self, trigs)
         singles = numpy.zeros(len(sngl_stat), dtype=self.single_dtype)
         singles['snglstat'] = sngl_stat
-        singles['coa_phase'] = trigs['coa_phase']
-        singles['end_time'] = trigs['end_time']
-        singles['sigmasq'] = trigs['sigmasq']
-        singles['snr'] = trigs['snr']
+        singles['coa_phase'] = trigs['coa_phase'][:]
+        singles['end_time'] = trigs['end_time'][:]
+        singles['sigmasq'] = trigs['sigmasq'][:]
+        singles['snr'] = trigs['snr'][:]
         return numpy.array(singles, ndmin=1)
 
     def coinc(self, s0, s1, slide, step):
@@ -520,8 +521,8 @@ class MaxContTradNewSNRStatistic(NewSNRStatistic):
             The array of single detector values
         """
         chisq_newsnr = get_newsnr(trigs)
-        rautochisq = trigs['cont_chisq'] / trigs['cont_chisq_dof']
-        autochisq_newsnr = events.newsnr(trigs['snr'], rautochisq)
+        rautochisq = trigs['cont_chisq'][:] / trigs['cont_chisq_dof'][:]
+        autochisq_newsnr = events.newsnr(trigs['snr'][:], rautochisq)
         return numpy.array(numpy.minimum(chisq_newsnr, autochisq_newsnr,
                            dtype=numpy.float32), ndmin=1, copy=False)
 
@@ -536,6 +537,16 @@ statistic_dict = {
     'phasetd_exp_fit_stat': PhaseTDExpFitStatistic,
     'max_cont_trad_newsnr': MaxContTradNewSNRStatistic,
     'phasetd_exp_fit_stat_sgveto': PhaseTDExpFitSGStatistic,
+    'newsnr_sgveto': NewSNRSGStatistic
+}
+
+sngl_statistic_dict = {
+    'newsnr': NewSNRStatistic,
+    'new_snr': NewSNRStatistic, # For backwards compatibility
+    'snr': NetworkSNRStatistic,
+    'newsnr_cut': NewSNRCutStatistic,
+    'exp_fit_csnr': ExpFitCombinedSNR,
+    'max_cont_trad_newsnr': MaxContTradNewSNRStatistic,
     'newsnr_sgveto': NewSNRSGStatistic
 }
 
@@ -560,6 +571,30 @@ def get_statistic(stat):
     """
     try:
         return statistic_dict[stat]
+    except KeyError:
+        raise RuntimeError('%s is not an available detection statistic' % stat)
+
+def get_sngl_statistic(stat):
+    """
+    Error-handling sugar around dict lookup
+
+    Parameters
+    ----------
+    stat : string
+        Name of the statistic
+
+    Returns
+    -------
+    class
+        Subclass of Stat base class
+
+    Raises
+    ------
+    RuntimeError
+        If the string is not recognized as corresponding to a Stat subclass
+    """
+    try:
+        return sngl_statistic_dict[stat]
     except KeyError:
         raise RuntimeError('%s is not an available detection statistic' % stat)
 

--- a/pycbc/io/hdf.py
+++ b/pycbc/io/hdf.py
@@ -18,6 +18,7 @@ from pycbc import version as pycbc_version
 from pycbc.tmpltbank import return_search_summary
 from pycbc.tmpltbank import return_empty_sngl
 from pycbc import events, conversions, pnutils
+from pycbc.events.stat import sngl_statistic_dict
 
 class HFile(h5py.File):
     """ Low level extensions to the capabilities of reading an hdf5 File
@@ -400,24 +401,19 @@ class SingleDetTriggers(object):
         clustered so that no more than 1 event within +/- cluster-window will
         be considered."""
         # If this becomes memory intensive we can optimize
+        stat_instance = sngl_statistic_dict[ranking_statistic]([])
+        stat = stat_instance.single(self.trigs)[self.mask]
+
+        # Used for naming in plots ... Seems an odd place for this to live!
         if ranking_statistic == "newsnr":
-            stat = self.newsnr
-            # newsnr doesn't return an array if len(stat) == 1
-            if len(self.snr) == 1:
-                stat = np.array([stat])
             self.stat_name = "Reweighted SNR"
         elif ranking_statistic == "newsnr_sgveto":
-            stat = self.newsnr_sgveto
-            # newsnr doesn't return an array if len(stat) == 1
-            if len(self.snr) == 1:
-                stat = np.array([stat])
             self.stat_name = "Reweighted SNR (+sgveto)"
         elif ranking_statistic == "snr":
-            stat = self.snr
             self.stat_name = "SNR"
         else:
-            err_msg = "Don't recognize statistic %s." % (ranking_statistic)
-            raise ValueError(err_msg)
+            self.stat_name=ranking_statistic
+
         times = self.end_time
         index = stat.argsort()[::-1]
         new_times = []

--- a/pycbc/io/hdf.py
+++ b/pycbc/io/hdf.py
@@ -412,7 +412,7 @@ class SingleDetTriggers(object):
         elif ranking_statistic == "snr":
             self.stat_name = "SNR"
         else:
-            self.stat_name=ranking_statistic
+            self.stat_name = ranking_statistic
 
         times = self.end_time
         index = stat.argsort()[::-1]
@@ -632,7 +632,7 @@ class ForegroundTriggers(object):
                                                              self.trig_id[ifo]]
             except IndexError:
                 if len(self.trig_id[ifo]) == 0:
-                    curr = np.array([])
+                       curr = np.array([])
                 else:
                     raise
             return_dict[ifo] = curr
@@ -821,7 +821,7 @@ def get_chisq_from_file_choice(hdfile, chisq_choice):
     elif chisq_choice == 'max_bank_cont_trad':
         chisq = np.maximum(np.maximum(bank_chisq, cont_chisq), trad_chisq)
     else:
-        err_msg="Do not recognized --chisq-choice %s" % chisq_choice
+        err_msg = "Do not recognize --chisq-choice %s" % chisq_choice
         raise ValueError(err_msg)
     return chisq
 
@@ -855,4 +855,3 @@ def recursively_save_dict_contents_to_group(h5file, path, dic):
             recursively_save_dict_contents_to_group(h5file, path + key + '/', item)
         else:
             raise ValueError('Cannot save %s type'%type(item))
-

--- a/pycbc/io/hdf.py
+++ b/pycbc/io/hdf.py
@@ -632,7 +632,7 @@ class ForegroundTriggers(object):
                                                              self.trig_id[ifo]]
             except IndexError:
                 if len(self.trig_id[ifo]) == 0:
-                       curr = np.array([])
+                    curr = np.array([])
                 else:
                     raise
             return_dict[ifo] = curr


### PR DESCRIPTION
At the moment if one wants to try a new detection statistic they edit the `stat` module, but then they have to edit a bunch of different codes to allow that statistic to be used in the single-detector applications (minifollowups, plots, the fitting codes, ...). This can be a little frustrating.

As such I want to move all of this into the stat module. Of course the single-detector statistics are different from the multi-detector ones, but in most cases calling the "single" method of the Stat class gets what we want.

This patch implements the functionality where a "single-detector-statistic" dict is defined in the stat module, and this is inherited everywhere else. We might envisage Stat classes that might *only* have single methods, and only be valid for single-detector statistics, but for now we are just using existing classes to implement what we want.