### PR TITLE
allow pycbc to be installed in python3

### DIFF
--- a/pycbc/scheme.py
+++ b/pycbc/scheme.py
@@ -176,7 +176,8 @@ def schemed(prefix):
                 try:
                     backend = __import__(prefix + scheme_prefix[sch], fromlist=[fn.__name__])
                     schemed_fn = getattr(backend, fn.__name__)
-                except (ImportError, AttributeError):
+                except (ImportError, AttributeError) as e:
+                    print(e)
                     continue
 
                 if mgr.state not in _import_cache:

--- a/pycbc/waveform/waveform.py
+++ b/pycbc/waveform/waveform.py
@@ -37,9 +37,10 @@ from pycbc.waveform import utils as wfutils
 from pycbc.waveform import parameters
 from pycbc.filter import interpolate_complex_frequency, resample_to_delta_t
 import pycbc
-from spa_tmplt import spa_tmplt, spa_tmplt_norm, spa_tmplt_end, \
+from .spa_tmplt import spa_tmplt, spa_tmplt_norm, spa_tmplt_end, \
                       spa_tmplt_precondition, spa_amplitude_factor, \
                       spa_length_in_time
+from six.moves import range as xrange
 
 class NoWaveformError(Exception):
     """This should be raised if generating a waveform would just result in all
@@ -263,8 +264,8 @@ if pycbc.HAVE_CUDA:
     _cuda_fd_approximants["IMRPhenomC"] = imrphenomc_tmplt
     _cuda_fd_approximants["SpinTaylorF2"] = cuda_spintaylorf2
 
-cuda_td = dict(_lalsim_td_approximants.items() + _cuda_td_approximants.items())
-cuda_fd = dict(_lalsim_fd_approximants.items() + _cuda_fd_approximants.items())
+cuda_td = dict(list(_lalsim_td_approximants.items()) + list(_cuda_td_approximants.items()))
+cuda_fd = dict(list(_lalsim_fd_approximants.items()) + list(_cuda_fd_approximants.items()))
 
 
 # List the various available approximants ####################################

--- a/pycbc/weave.py
+++ b/pycbc/weave.py
@@ -22,9 +22,11 @@ import os.path, sys
 import logging
 import shutil, atexit, signal
 import fcntl
-import weave.inline_tools as inline_tools
 
-_compile_function = inline_tools.compile_function
+PY3 = sys.version_info[0] == 3
+if not PY3:
+    import weave.inline_tools as inline_tools
+    _compile_function = inline_tools.compile_function
 
 ## Blatently taken from weave to implement a crude file locking scheme
 def pycbc_compile_function(code,arg_names,local_dict,global_dict,
@@ -61,8 +63,13 @@ def pycbc_compile_function(code,arg_names,local_dict,global_dict,
 
     return func
 
-inline_tools.compile_function = pycbc_compile_function
-from weave import inline
+if not PY3:
+    inline_tools.compile_function = pycbc_compile_function
+    from weave import inline
+else:
+    def inline(*args, **kwds):
+        raise RuntimeError("Oh no! You tried to use capabilities"
+                           "s we haven't ported to python3 yet")
 
 def insert_weave_option_group(parser):
     """

--- a/pycbc/weave.py
+++ b/pycbc/weave.py
@@ -22,8 +22,8 @@ import os.path, sys
 import logging
 import shutil, atexit, signal
 import fcntl
+from six import PY3
 
-PY3 = sys.version_info[0] == 3
 if not PY3:
     import weave.inline_tools as inline_tools
     _compile_function = inline_tools.compile_function
@@ -69,7 +69,7 @@ if not PY3:
 else:
     def inline(*args, **kwds):
         raise RuntimeError("Oh no! You tried to use capabilities"
-                           "s we haven't ported to python3 yet")
+                           " we haven't ported to python3 yet")
 
 def insert_weave_option_group(parser):
     """

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ install_requires =  setup_requires + ['Mako>=1.0.1',
                       ]
 
 if not PY3:
-    install_requires += ['weave>0.16.0']
+    install_requires += ['weave>=0.16.0']
 
 def find_package_data(dirname):
     def find_paths(dirname):

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,8 @@ from setuptools.command.install_egg_info import install_egg_info as egg_info
 from setuptools import Extension, setup, Command
 from setuptools.command.build_ext import build_ext as _build_ext
 
+PY3 = sys.version_info[0] == 3
+
 requires = []
 setup_requires = ['numpy>=1.13.0',]
 install_requires =  setup_requires + ['Mako>=1.0.1',
@@ -47,7 +49,6 @@ install_requires =  setup_requires + ['Mako>=1.0.1',
                       'cython',
                       'decorator>=3.4.2',
                       'scipy>=0.16.0',
-                      'weave>=0.16.0',
                       'unittest2',
                       'matplotlib>=1.5.1',
                       'pillow',
@@ -63,6 +64,9 @@ install_requires =  setup_requires + ['Mako>=1.0.1',
                       'beautifulsoup4>=4.6.0',
                       'six>=1.10.0',
                       ]
+
+if not PY3:
+    install_requires += ['weave>0.16.0']
 
 def find_package_data(dirname):
     def find_paths(dirname):

--- a/setup.py
+++ b/setup.py
@@ -526,4 +526,3 @@ setup (
         'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
     ],
 )
-


### PR DESCRIPTION
This disables weave when in a python3 environment. Many things will be broken, but it allows *something* to run in python 3. Waveform generation, for example, *does* work with this patch. 