### PR TITLE
allow pycbc live to resolve only the latest frames

### DIFF
--- a/pycbc/frame/frame.py
+++ b/pycbc/frame/frame.py
@@ -98,7 +98,6 @@ def locations_to_cache(locations, latest=False):
         A cumulative lal cache object containing the files derived from the
     list of locations
     """
-    import os.path
     cum_cache = lal.Cache()
     for source in locations:
         flist = glob.glob(source)
@@ -780,4 +779,3 @@ class StatusBuffer(DataBuffer):
         except RuntimeError:
             self.null_advance(blocksize)
             return False
-

--- a/pycbc/frame/frame.py
+++ b/pycbc/frame/frame.py
@@ -80,7 +80,7 @@ def _read_channel(channel, stream, start, duration):
     return TimeSeries(data.data.data, delta_t=data.deltaT, epoch=start,
                       dtype=d_type)
 
-def locations_to_cache(locations):
+def locations_to_cache(locations, latest=False):
     """ Return a cumulative cache file build from the list of locations
 
     Parameters
@@ -88,6 +88,9 @@ def locations_to_cache(locations):
     locations : list
         A list of strings containing files, globs, or cache files used to build
     a combined lal cache file object.
+    latest : Optional, {False, Boolean}
+        Only return a cache with the most recent frame in the locations.
+        If false, all results are returned.
 
     Returns
     -------
@@ -95,9 +98,14 @@ def locations_to_cache(locations):
         A cumulative lal cache object containing the files derived from the
     list of locations
     """
+    import os.path
     cum_cache = lal.Cache()
     for source in locations:
-        for file_path in glob.glob(source):
+        flist = glob.glob(source)
+        if latest:
+            flist = [max(flist, key=os.path.getctime)]
+
+        for file_path in flist:
             dir_name, file_name = os.path.split(file_path)
             _, file_extension = os.path.splitext(file_name)
 
@@ -463,7 +471,7 @@ class DataBuffer(object):
         result may change due to more files being added to the filesystem,
         for example.
         """
-        cache = locations_to_cache(self.frame_src)
+        cache = locations_to_cache(self.frame_src, latest=True)
         stream = lalframe.FrStreamCacheOpen(cache)
         self.stream = stream
 
@@ -772,3 +780,4 @@ class StatusBuffer(DataBuffer):
         except RuntimeError:
             self.null_advance(blocksize)
             return False
+


### PR DESCRIPTION
This is a quality of life update for pycbc live. One issue I've found is that it tried to read *all* the frame files in the frame-src to get their metadata information. However, if a file is gone before it can do so, it will fail. This can create a problem when trying to initially start up the analysis and a random node will drag behind and kill the entire analysis. 