### PR TITLE
Invoke pycbc_inspiral with injections in the bundle build

### DIFF
--- a/tools/einsteinathome/H1L1-SINGLE_TEMPLATE_BANK.xml
+++ b/tools/einsteinathome/H1L1-SINGLE_TEMPLATE_BANK.xml
@@ -1,0 +1,134 @@
+<?xml version='1.0' encoding='utf-8'?>
+<!DOCTYPE LIGO_LW SYSTEM "http://ldas-sw.ligo.caltech.edu/doc/ligolwAPI/html/ligolw_dtd.txt">
+<LIGO_LW>
+	<Table Name="sngl_inspiral:table">
+		<Column Type="real_4" Name="sngl_inspiral:cont_chisq"/>
+		<Column Type="real_4" Name="sngl_inspiral:bank_chisq"/>
+		<Column Type="int_4s" Name="sngl_inspiral:chisq_dof"/>
+		<Column Type="real_8" Name="sngl_inspiral:end_time_gmst"/>
+		<Column Type="real_8" Name="sngl_inspiral:event_duration"/>
+		<Column Type="real_4" Name="sngl_inspiral:chisq"/>
+		<Column Type="real_4" Name="sngl_inspiral:spin1y"/>
+		<Column Type="real_4" Name="sngl_inspiral:spin1x"/>
+		<Column Type="real_4" Name="sngl_inspiral:alpha"/>
+		<Column Type="real_4" Name="sngl_inspiral:coa_phase"/>
+		<Column Type="real_4" Name="sngl_inspiral:alpha2"/>
+		<Column Type="real_4" Name="sngl_inspiral:mchirp"/>
+		<Column Type="real_4" Name="sngl_inspiral:alpha1"/>
+		<Column Type="real_4" Name="sngl_inspiral:alpha6"/>
+		<Column Type="real_4" Name="sngl_inspiral:alpha4"/>
+		<Column Type="real_4" Name="sngl_inspiral:alpha5"/>
+		<Column Type="ilwd:char" Name="sngl_inspiral:event_id"/>
+		<Column Type="real_4" Name="sngl_inspiral:chi"/>
+		<Column Type="int_4s" Name="sngl_inspiral:cont_chisq_dof"/>
+		<Column Type="real_4" Name="sngl_inspiral:spin2y"/>
+		<Column Type="real_4" Name="sngl_inspiral:tau2"/>
+		<Column Type="real_4" Name="sngl_inspiral:tau3"/>
+		<Column Type="real_4" Name="sngl_inspiral:tau0"/>
+		<Column Type="real_4" Name="sngl_inspiral:tau4"/>
+		<Column Type="real_4" Name="sngl_inspiral:tau5"/>
+		<Column Type="real_8" Name="sngl_inspiral:template_duration"/>
+		<Column Type="int_4s" Name="sngl_inspiral:impulse_time"/>
+		<Column Type="int_4s" Name="sngl_inspiral:impulse_time_ns"/>
+		<Column Type="real_4" Name="sngl_inspiral:rsqveto_duration"/>
+		<Column Type="lstring" Name="sngl_inspiral:channel"/>
+		<Column Type="real_4" Name="sngl_inspiral:mtotal"/>
+		<Column Type="real_4" Name="sngl_inspiral:alpha3"/>
+		<Column Type="real_4" Name="sngl_inspiral:spin1z"/>
+		<Column Type="real_4" Name="sngl_inspiral:Gamma5"/>
+		<Column Type="real_4" Name="sngl_inspiral:spin2x"/>
+		<Column Type="real_4" Name="sngl_inspiral:f_final"/>
+		<Column Type="real_4" Name="sngl_inspiral:beta"/>
+		<Column Type="ilwd:char" Name="sngl_inspiral:process_id"/>
+		<Column Type="real_4" Name="sngl_inspiral:snr"/>
+		<Column Type="int_4s" Name="sngl_inspiral:bank_chisq_dof"/>
+		<Column Type="real_4" Name="sngl_inspiral:kappa"/>
+		<Column Type="real_4" Name="sngl_inspiral:eff_distance"/>
+		<Column Type="real_4" Name="sngl_inspiral:Gamma7"/>
+		<Column Type="real_4" Name="sngl_inspiral:Gamma6"/>
+		<Column Type="lstring" Name="sngl_inspiral:search"/>
+		<Column Type="real_4" Name="sngl_inspiral:Gamma4"/>
+		<Column Type="real_4" Name="sngl_inspiral:mass1"/>
+		<Column Type="real_4" Name="sngl_inspiral:Gamma2"/>
+		<Column Type="real_4" Name="sngl_inspiral:Gamma1"/>
+		<Column Type="real_4" Name="sngl_inspiral:mass2"/>
+		<Column Type="real_4" Name="sngl_inspiral:ttotal"/>
+		<Column Type="real_4" Name="sngl_inspiral:Gamma0"/>
+		<Column Type="real_4" Name="sngl_inspiral:spin2z"/>
+		<Column Type="real_4" Name="sngl_inspiral:Gamma9"/>
+		<Column Type="real_4" Name="sngl_inspiral:Gamma8"/>
+		<Column Type="real_4" Name="sngl_inspiral:Gamma3"/>
+		<Column Type="real_4" Name="sngl_inspiral:eta"/>
+		<Column Type="real_4" Name="sngl_inspiral:psi0"/>
+		<Column Type="int_4s" Name="sngl_inspiral:end_time"/>
+		<Column Type="real_4" Name="sngl_inspiral:amplitude"/>
+		<Column Type="real_4" Name="sngl_inspiral:psi3"/>
+		<Column Type="int_4s" Name="sngl_inspiral:end_time_ns"/>
+		<Column Type="lstring" Name="sngl_inspiral:ifo"/>
+		<Column Type="real_8" Name="sngl_inspiral:sigmasq"/>
+		<Stream Delimiter="," Type="Local" Name="sngl_inspiral:table">
+                        0,0,0,0,0,0,0,0,0,0,0,1.4051032,0,0,0,0,"sngl_inspiral:event_id:0",0,0,0,0,0,0,0,0,0,0,0,0,"",3.689073,0,0.6024205,0,0,0,0,"process:process_id:1",0,0,0,0,0,0,"",0,2.668342,0,0,1.020731,0,0,0.04763185,0,0,0,0.20013281,0,0,0,0,0,"",0,
+		</Stream>
+	</Table>
+	<Table Name="process:table">
+		<Column Type="lstring" Name="process:comment"/>
+		<Column Type="lstring" Name="process:node"/>
+		<Column Type="lstring" Name="process:domain"/>
+		<Column Type="int_4s" Name="process:unix_procid"/>
+		<Column Type="int_4s" Name="process:start_time"/>
+		<Column Type="ilwd:char" Name="process:process_id"/>
+		<Column Type="int_4s" Name="process:is_online"/>
+		<Column Type="lstring" Name="process:ifos"/>
+		<Column Type="int_4s" Name="process:jobid"/>
+		<Column Type="lstring" Name="process:username"/>
+		<Column Type="lstring" Name="process:program"/>
+		<Column Type="int_4s" Name="process:end_time"/>
+		<Column Type="lstring" Name="process:version"/>
+		<Column Type="lstring" Name="process:cvs_repository"/>
+		<Column Type="int_4s" Name="process:cvs_entry_time"/>
+		<Stream Delimiter="," Type="Local" Name="process:table">
+			,"syzygy",,9987,1141603875,"process:process_id:0",0,,0,"altivec","lalapps_cbc_sbank",1141662416,"no version","sbank",1141607475
+		</Stream>
+	</Table>
+	<Table Name="process_params:table">
+		<Column Type="ilwd:char" Name="process_params:process_id"/>
+		<Column Type="lstring" Name="process_params:program"/>
+		<Column Type="lstring" Name="process_params:type"/>
+		<Column Type="lstring" Name="process_params:value"/>
+		<Column Type="lstring" Name="process_params:param"/>
+		<Stream Delimiter="," Type="Local" Name="process_params:table">
+			"process:process_id:0","lalapps_cbc_sbank","real_8","2.0","--mass1-min",
+			"process:process_id:0","lalapps_cbc_sbank","lstring","tau0","--neighborhood-param",
+			"process:process_id:0","lalapps_cbc_sbank",,,"--verbose",
+			"process:process_id:0","lalapps_cbc_sbank","int_8s","0","--gps-start-time",
+			"process:process_id:0","lalapps_cbc_sbank","real_8","99.0","--mass1-max",
+			"process:process_id:0","lalapps_cbc_sbank","real_8","100.0","--mtotal-max",
+			"process:process_id:0","lalapps_cbc_sbank","real_8","1.0","--qmin",
+			"process:process_id:0","lalapps_cbc_sbank","real_8","0.05","--ns-spin-max",
+			"process:process_id:0","lalapps_cbc_sbank","real_8","10.0","--mass2-min",
+			"process:process_id:0","lalapps_cbc_sbank","real_8","0.99","--bh-spin-max",
+			"process:process_id:0","lalapps_cbc_sbank","real_8","10.0","--mtotal-min",
+			"process:process_id:0","lalapps_cbc_sbank","real_8","8.0","--iterative-match-df-max",
+			"process:process_id:0","lalapps_cbc_sbank","lstring","aLIGOZeroDetHighPower","--noise-model",
+			"process:process_id:0","lalapps_cbc_sbank","real_8","50.0","--mass2-max",
+			"process:process_id:0","lalapps_cbc_sbank","real_8","-0.05","--ns-spin-min",
+			"process:process_id:0","lalapps_cbc_sbank","int_8s","0","--checkpoint",
+			"process:process_id:0","lalapps_cbc_sbank","lstring","H1L1","--instrument",
+			"process:process_id:0","lalapps_cbc_sbank","real_8","0.98","--match-min",
+			"process:process_id:0","lalapps_cbc_sbank","real_8","0.25","--neighborhood-size",
+			"process:process_id:0","lalapps_cbc_sbank","int_8s","999999999","--gps-end-time",
+			"process:process_id:0","lalapps_cbc_sbank","real_8","2.0","--ns-bh-boundary-mass",
+			"process:process_id:0","lalapps_cbc_sbank","real_8","-0.99","--bh-spin-min",
+			"process:process_id:0","lalapps_cbc_sbank",,,"--aligned-spin",
+			"process:process_id:0","lalapps_cbc_sbank","real_8","1024.0","--fhigh-max",
+			"process:process_id:0","lalapps_cbc_sbank","lstring","/home/altivec/projects/pycbc/pycbc-config/O1/psd/H1L1-ER8B_HARM_MEAN_PSD-1126051216-1220400.xml.gz","--reference-psd",
+			"process:process_id:0","lalapps_cbc_sbank","real_8","30.0","--flow",
+			"process:process_id:0","lalapps_cbc_sbank","real_8","97.0","--qmax",
+			"process:process_id:0","lalapps_cbc_sbank","lstring","IMRPhenomD","--approximant",
+			"process:process_id:0","lalapps_cbc_sbank","int_8s","7777","--seed",
+			"process:process_id:0","lalapps_cbc_sbank","real_8","inf","--templates-max",
+			"process:process_id:0","lalapps_cbc_sbank","lstring","GW150914","--user-tag",
+			"process:process_id:0","lalapps_cbc_sbank","int_8s","1024","--convergence-threshold"
+		</Stream>
+	</Table>
+</LIGO_LW>

--- a/tools/einsteinathome/HL-INJECTIONS.xml
+++ b/tools/einsteinathome/HL-INJECTIONS.xml
@@ -1,0 +1,127 @@
+<?xml version='1.0' encoding='utf-8' ?>
+<!DOCTYPE LIGO_LW SYSTEM "http://ldas-sw.ligo.caltech.edu/doc/ligolwAPI/html/ligolw_dtd.txt"><LIGO_LW>
+   <Table Name="process:table">
+      <Column Name="program" Type="lstring"/>
+      <Column Name="version" Type="lstring"/>
+      <Column Name="cvs_repository" Type="lstring"/>
+      <Column Name="cvs_entry_time" Type="int_4s"/>
+      <Column Name="comment" Type="lstring"/>
+      <Column Name="is_online" Type="int_4s"/>
+      <Column Name="node" Type="lstring"/>
+      <Column Name="username" Type="lstring"/>
+      <Column Name="unix_procid" Type="int_4s"/>
+      <Column Name="start_time" Type="int_4s"/>
+      <Column Name="end_time" Type="int_4s"/>
+      <Column Name="jobid" Type="int_4s"/>
+      <Column Name="domain" Type="lstring"/>
+      <Column Name="ifos" Type="lstring"/>
+      <Column Name="process_id" Type="ilwd:char"/>
+      <Stream Name="process:table" Type="Local" Delimiter=",">
+         "inspinj","0231cca7eb1af128de63a8d22a27ccc5099f4c7b","CLEAN: All modifications committed",1211720228," ",0,"CRUSH-SUGWG-OSG-10-5-205-13","50015",97,1214957032,1214957032,0,"lalapps","","process:process_id:0"
+      </Stream>
+   </Table>
+   <Table Name="process_params:table">
+      <Column Name="program" Type="lstring"/>
+      <Column Name="process:process_id" Type="ilwd:char"/>
+      <Column Name="param" Type="lstring"/>
+      <Column Name="type" Type="lstring"/>
+      <Column Name="value" Type="lstring"/>
+      <Stream Name="process_params:table" Type="Local" Delimiter=",">
+         "inspinj","process:process_id:0","--i-distr","string","uniform",
+         "inspinj","process:process_id:0","--l-distr","string","random",
+         "inspinj","process:process_id:0","--time-interval","float","2.500000e+01",
+         "inspinj","process:process_id:0","--time-step","float","1.000000e+02",
+         "inspinj","process:process_id:0","--m-distr","string","totalMass",
+         "inspinj","process:process_id:0","--min-mass1","float","5.000000e+00",
+         "inspinj","process:process_id:0","--max-mass1","float","9.500000e+01",
+         "inspinj","process:process_id:0","--min-mass2","float","5.000000e+00",
+         "inspinj","process:process_id:0","--max-mass2","float","9.500000e+01",
+         "inspinj","process:process_id:0","--min-mtotal","float","1.000000e+01",
+         "inspinj","process:process_id:0","--max-mtotal","float","1.000000e+02",
+         "inspinj","process:process_id:0","--enable-spin","string","",
+         "inspinj","process:process_id:0","--aligned","string","",
+         "inspinj","process:process_id:0","--min-spin1","float","0.000000e+00",
+         "inspinj","process:process_id:0","--max-spin1","float","9.000000e-01",
+         "inspinj","process:process_id:0","--min-spin2","float","0.000000e+00",
+         "inspinj","process:process_id:0","--max-spin2","float","9.000000e-01",
+         "inspinj","process:process_id:0","--waveform","string","IMRPhenomDpseudoFourPN",
+         "inspinj","process:process_id:0","--taper-injection","string","start",
+         "inspinj","process:process_id:0","--seed","int","123408",
+         "inspinj","process:process_id:0","--f-lower","float","20.000000",
+         "inspinj","process:process_id:0","--dchirp-distr","string","uniform",
+         "inspinj","process:process_id:0","--min-distance","float","5.000000e+03",
+         "inspinj","process:process_id:0","--max-distance","float","3.000000e+05",
+         "inspinj","process:process_id:0","--output","string","HL-INJECTIONS_BBHIMRPHENOMD_INJ-1126051217-1220400.xml",
+         "inspinj","process:process_id:0","--gps-start-time","int","1126051217",
+         "inspinj","process:process_id:0","--gps-end-time","int","1127271617"
+      </Stream>
+   </Table>
+   <Table Name="sim_inspiral:table">
+      <Column Name="process:process_id" Type="ilwd:char"/>
+      <Column Name="waveform" Type="lstring"/>
+      <Column Name="geocent_end_time" Type="int_4s"/>
+      <Column Name="geocent_end_time_ns" Type="int_4s"/>
+      <Column Name="h_end_time" Type="int_4s"/>
+      <Column Name="h_end_time_ns" Type="int_4s"/>
+      <Column Name="l_end_time" Type="int_4s"/>
+      <Column Name="l_end_time_ns" Type="int_4s"/>
+      <Column Name="g_end_time" Type="int_4s"/>
+      <Column Name="g_end_time_ns" Type="int_4s"/>
+      <Column Name="t_end_time" Type="int_4s"/>
+      <Column Name="t_end_time_ns" Type="int_4s"/>
+      <Column Name="v_end_time" Type="int_4s"/>
+      <Column Name="v_end_time_ns" Type="int_4s"/>
+      <Column Name="end_time_gmst" Type="real_8"/>
+      <Column Name="source" Type="lstring"/>
+      <Column Name="mass1" Type="real_4"/>
+      <Column Name="mass2" Type="real_4"/>
+      <Column Name="mchirp" Type="real_4"/>
+      <Column Name="eta" Type="real_4"/>
+      <Column Name="distance" Type="real_4"/>
+      <Column Name="longitude" Type="real_4"/>
+      <Column Name="latitude" Type="real_4"/>
+      <Column Name="inclination" Type="real_4"/>
+      <Column Name="coa_phase" Type="real_4"/>
+      <Column Name="polarization" Type="real_4"/>
+      <Column Name="psi0" Type="real_4"/>
+      <Column Name="psi3" Type="real_4"/>
+      <Column Name="alpha" Type="real_4"/>
+      <Column Name="alpha1" Type="real_4"/>
+      <Column Name="alpha2" Type="real_4"/>
+      <Column Name="alpha3" Type="real_4"/>
+      <Column Name="alpha4" Type="real_4"/>
+      <Column Name="alpha5" Type="real_4"/>
+      <Column Name="alpha6" Type="real_4"/>
+      <Column Name="beta" Type="real_4"/>
+      <Column Name="spin1x" Type="real_4"/>
+      <Column Name="spin1y" Type="real_4"/>
+      <Column Name="spin1z" Type="real_4"/>
+      <Column Name="spin2x" Type="real_4"/>
+      <Column Name="spin2y" Type="real_4"/>
+      <Column Name="spin2z" Type="real_4"/>
+      <Column Name="theta0" Type="real_4"/>
+      <Column Name="phi0" Type="real_4"/>
+      <Column Name="f_lower" Type="real_4"/>
+      <Column Name="f_final" Type="real_4"/>
+      <Column Name="eff_dist_h" Type="real_4"/>
+      <Column Name="eff_dist_l" Type="real_4"/>
+      <Column Name="eff_dist_g" Type="real_4"/>
+      <Column Name="eff_dist_t" Type="real_4"/>
+      <Column Name="eff_dist_v" Type="real_4"/>
+      <Column Name="numrel_mode_min" Type="int_4s"/>
+      <Column Name="numrel_mode_max" Type="int_4s"/>
+      <Column Name="numrel_data" Type="lstring"/>
+      <Column Name="amp_order" Type="int_4s"/>
+      <Column Name="taper" Type="lstring"/>
+      <Column Name="bandpass" Type="int_4s"/>
+      <Column Name="simulation_id" Type="ilwd:char"/>
+      <Stream Name="sim_inspiral:table" Type="Local" Delimiter=",">
+         "process:process_id:0","IMRPhenomDpseudoFourPN",1126259462,0,1126051217,826953082,1126051217,828729038,1126051217,829937582,1126051217,811433619,1126051217,828964075,3.6121869798039261e+04,"",9.147961e+00,2.736637e+01,1.338543e+01,1.877651e-01,1.219495e+02,2.173147e+00,-9.113324e-01,1.972003e+00,3.156865e+00,6.091669e+00,0.000000e+00,0.000000e+00,0.000000e+00,0.000000e+00,0.000000e+00,0.000000e+00,0.000000e+00,0.000000e+00,0.000000e+00,0.000000e+00,0.000000e+00,0.000000e+00,7.152426e-01,0.000000e+00,0.000000e+00,3.261685e-01,0.000000e+00,0.000000e+00,2.000000e+01,0.000000e+00,2.991161e+02,2.701712e+02,2.620886e+02,4.596135e+02,3.629208e+02,0,0,"",-1,"TAPER_START",0,"sim_inspiral:simulation_id:0",
+         "process:process_id:0","SEOBNRv3pseudoFourPN",1126259462,0,1126051241,336387972,1126051241,329537766,1126051241,339744225,1126051241,341443339,1126051241,337614814,3.6121871512602629e+04,"",4.681819e+01,5.165064e+01,4.279908e+01,2.493979e-01,3.256495e+03,4.939783e+00,-1.242261e+00,1.372486e+00,9.689482e-01,5.034219e+00,0.000000e+00,0.000000e+00,0.000000e+00,0.000000e+00,0.000000e+00,0.000000e+00,0.000000e+00,0.000000e+00,0.000000e+00,0.000000e+00,-2.760659e-02,8.554311e-01,1.457361e-01,-1.094587e-01,-4.044490e-01,4.255792e-01,0.000000e+00,0.000000e+00,2.000000e+01,0.000000e+00,2.628174e+04,2.459846e+04,8.890812e+03,7.910741e+03,2.347984e+04,0,0,"",-1,"TAPER_START",0,"sim_inspiral:simulation_id:0",
+         "process:process_id:0","SEOBNRv4pseudoFourPN",1126259462,0,1126051219,903221926,1126051219,893458846,1126051219,903802702,1126051219,921778956,1126051219,901975775,3.6121869950357221e+04,"",3.215090e+01,5.967397e+01,3.777415e+01,2.275398e-01,1.480807e+03,5.196215e+00,-4.983310e-01,1.356913e+00,3.807505e+00,3.100016e+00,0.000000e+00,0.000000e+00,0.000000e+00,0.000000e+00,0.000000e+00,0.000000e+00,0.000000e+00,0.000000e+00,0.000000e+00,0.000000e+00,0.000000e+00,0.000000e+00,-9.846289e-01,0.000000e+00,0.000000e+00,2.146929e-01,0.000000e+00,0.000000e+00,2.000000e+01,0.000000e+00,1.623233e+04,6.961979e+03,1.091442e+04,3.030591e+03,3.117477e+04,0,0,"",-1,"TAPER_START",0,"sim_inspiral:simulation_id:0",
+         "process:process_id:0","SpinTaylorT2threePointFivePN",1126259462,0,1126051224,584889235,1126051224,576973716,1126051224,592148448,1126051224,609206272,1126051224,591752839,3.6121870292520907e+04,"",2.831264e+00,1.135072e+00,1.529411e+00,2.042795e-01,2.175108e+02,4.902217e+00,-7.266782e-02,6.991236e-01,4.289782e+00,3.284987e+00,0.000000e+00,0.000000e+00,0.000000e+00,0.000000e+00,0.000000e+00,0.000000e+00,0.000000e+00,0.000000e+00,0.000000e+00,0.000000e+00,2.104985e-01,-1.885315e-01,-1.846041e-01,-5.067377e-03,-4.891878e-03,-2.185555e-03,0.000000e+00,0.000000e+00,2.500000e+01,0.000000e+00,5.500453e+02,3.548478e+02,6.244290e+02,3.665308e+02,1.047813e+03,0,0,"",-1,"TAPER_STARTEND",0,"sim_inspiral:simulation_id:0",
+         "process:process_id:0","SpinTaylorT4threePointFivePN",1126259462,0,1126051217,781564340,1126051217,789958562,1126051217,788337593,1126051217,761939976,1126051217,789575217,3.6121869795536033e+04,"",2.738469e+00,2.109556e+00,2.088846e+00,2.457928e-01,2.557382e+02,2.319681e+00,-1.001951e-01,1.832632e+00,2.765857e+00,2.754200e+00,0.000000e+00,0.000000e+00,0.000000e+00,0.000000e+00,0.000000e+00,0.000000e+00,0.000000e+00,0.000000e+00,0.000000e+00,0.000000e+00,2.597536e-02,-5.265598e-03,-4.895819e-02,4.478353e-04,2.889964e-03,-2.726816e-02,0.000000e+00,0.000000e+00,2.500000e+01,0.000000e+00,2.321635e+03,9.969776e+02,8.913379e+02,7.867435e+02,1.171558e+03,0,0,"",-1,"TAPER_STARTEND",0,"sim_inspiral:simulation_id:0",
+         "process:process_id:0","EOBNRv2HMpseudoFourPN",1126259462,0,1126051237,932606054,1126051237,929419654,1126051237,937287631,1126051237,928180836,1126051237,935581940,3.6121871264217567e+04,"",6.679238e+01,5.582708e+01,5.311672e+01,2.480008e-01,2.173118e+03,2.884471e+00,-1.391559e+00,8.011748e-01,4.356723e+00,1.038953e+00,0.000000e+00,0.000000e+00,0.000000e+00,0.000000e+00,0.000000e+00,0.000000e+00,0.000000e+00,0.000000e+00,0.000000e+00,0.000000e+00,0.000000e+00,0.000000e+00,0.000000e+00,0.000000e+00,0.000000e+00,0.000000e+00,0.000000e+00,0.000000e+00,1.500000e+01,0.000000e+00,4.697148e+03,5.666792e+03,3.404723e+03,4.919785e+03,3.753071e+03,0,0,"",-1,"TAPER_START",0,"sim_inspiral:simulation_id:0",
+      </Stream>
+   </Table>
+</LIGO_LW>

--- a/tools/einsteinathome/pycbc_build_eah.sh
+++ b/tools/einsteinathome/pycbc_build_eah.sh
@@ -1466,7 +1466,7 @@ do
       LEVEL2_CACHE_SIZE=8192 \
       WEAVE_FLAGS='-O3 -march=core2 -w' \
       FIXED_WEAVE_CACHE="$PWD/pycbc_inspiral"
-    base_args= "--fixed-weave-cache ${processing_scheme} \
+    base_args="--fixed-weave-cache ${processing_scheme} \
       --frame-files $frames \
       --sample-rate 2048 \
       --sgchisq-snr-threshold 6.0 \
@@ -1501,7 +1501,7 @@ do
       --verbose"
       args="${base_args} \
       --approximant ${approx_array[$i]} \
-      --bank-file ${bank_array[$i]} "
+      --bank-file ${bank_array[$i]}"
     if $silent_build; then
         "$ENVIRONMENT/dist/pycbc_inspiral/pycbc_inspiral" $args 2>&1|
           awk '{if ((!/Filtering template|points above|power chisq|point chisq|Found chisq|generating SEOBNR|generating SPA/) || (/segment 1/ && NR % 50 == 0) || / 0: generating/ || / 1: generating/ ) print}'

--- a/tools/einsteinathome/pycbc_build_eah.sh
+++ b/tools/einsteinathome/pycbc_build_eah.sh
@@ -1499,7 +1499,7 @@ do
       --gps-end-time 1126259846 \
       --output H1-INSPIRAL-OUT.hdf \
       --verbose"
-      args="${base_args} 
+      args="${base_args} \
       --approximant ${approx_array[$i]} \
       --bank-file ${bank_array[$i]} "
     if $silent_build; then


### PR DESCRIPTION
There is currently a bug in the v1.11.1 bundled executable that it is missing some weave code needed for injections. This causes the error
```Traceback (most recent call last):
  File "pycbc_inspiral", line 204, in 
  File "pycbc/strain/strain.py", line 257, in from_cli
  File "pycbc/inject/inject.py", line 355, in apply
  File "pycbc/inject/inject.py", line 414, in make_strain_from_inj_object
  File "pycbc/waveform/waveform.py", line 457, in get_td_waveform
  File "pycbc/waveform/waveform.py", line 622, in get_td_waveform_from_fd
  File "", line 2, in cyclic_time_shift
  File "pycbc/types/array.py", line 77, in _noreal
  File "pycbc/types/frequencyseries.py", line 492, in cyclic_time_shift
  File "pycbc/waveform/utils.py", line 410, in apply_fseries_time_shift
  File "weave/inline_tools.py", line 366, in inline
  File "pycbc/weave.py", line 57, in pycbc_compile_function
  File "weave/inline_tools.py", line 496, in compile_function
  File "weave/ext_tools.py", line 373, in compile
  File "weave/build_tools.py", line 242, in build_extension
  File "weave/platform_info.py", line 125, in get_compiler_dir
ValueError: The '' compiler was not found.
Failed to execute script pycbc_inspiral
```

This fixes the problem by running one of every type of injection used in the pipeline through a single template to make sure that all the relevant code paths are run.