### PR TITLE
Tell PyCBC that LOSC frames are available on the OSG

### DIFF
--- a/pycbc/workflow/datafind.py
+++ b/pycbc/workflow/datafind.py
@@ -719,6 +719,11 @@ def convert_cachelist_to_filelist(datafindcache_list):
                     currFile.PFN(frame.url.replace(
                         'file:///cvmfs/oasis.opensciencegrid.org/',
                         'gsiftp://ldas-grid.ligo.caltech.edu/hdfs/'), site='osg')
+                elif frame.url.startswith(
+                    'file:///cvmfs/gwosc.osgstorage.org/'):
+                    # Datafind returned a URL valid on the osg as well
+                    # so add the additional PFNs to allow OSG access.
+                    currFile.PFN(frame.url, site='osg')
             else:
                 currFile.PFN(frame.url, site='notlocal')
 

--- a/pycbc/workflow/datafind.py
+++ b/pycbc/workflow/datafind.py
@@ -706,7 +706,7 @@ def convert_cachelist_to_filelist(datafindcache_list):
             if frame.url.startswith('file://'):
                 currFile.PFN(frame.url, site='local')
                 if frame.url.startswith(
-                    'file:///cvmfs/oasis.opensciencegrid.org/'):
+                    'file:///cvmfs/oasis.opensciencegrid.org/ligo/frames'):
                     # Datafind returned a URL valid on the osg as well
                     # so add the additional PFNs to allow OSG access.
                     currFile.PFN(frame.url, site='osg')


### PR DESCRIPTION
Since the current set of LIGO data find servers don't do this properly yet, PyCBC's datafind module needs to know if a URL that it gets is available at other (backup) locations. This implements two changes:

 1. Only the regular LIGO frames are available for gsiftp from UNL and CIT, so force a match on `file:///cvmfs/oasis.opensciencegrid.org/ligo/frames` to add those backup URLs.
 2. The LOSC frames in `file:///cvmfs/gwosc.osgstorage.org/` are available on the OSG, so if the URL matches, add them to the OSG site.