### PR TITLE
Try to get labels from waveform.parameters

### DIFF
--- a/pycbc/inference/option_utils.py
+++ b/pycbc/inference/option_utils.py
@@ -23,6 +23,7 @@ import pycbc.inference.sampler
 from pycbc import inject
 from pycbc.io.record import FieldArray
 from pycbc.inference import burn_in
+from pycbc import waveform
 from pycbc import conversions
 from pycbc import transforms
 from pycbc.distributions import bounded
@@ -482,6 +483,11 @@ def parse_parameters_opt(parameters):
         if len(p.split(':')) == 2:
             p, label = p.split(':')
             parameters[ii] = p
+            # try to get the label from waveform.parameters
+            try:
+                label = getattr(waveform.parameters, label).label
+            except AttributeError:
+                pass
             labels[p] = label
     return parameters, labels
 


### PR DESCRIPTION
This makes specifying labels for plots on the command line easier. If the parameter is one of the ones in `waveform.parameters`, you can just give that parameter name and you will get the label associated with it. For example,
before:
`--parameters 'mchirp_from_mass1_mass2(mass1, mass2):$\mathcal{M}$'`
now:
`--parameters 'mchirp_from_mass1_mass2(mass1, mass2):mchirp`.