### PR TITLE
Fix for acl-interval argument

### DIFF
--- a/pycbc/io/inference_hdf.py
+++ b/pycbc/io/inference_hdf.py
@@ -205,13 +205,21 @@ class InferenceFile(h5py.File):
     def burn_in_iterations(self):
         """Returns number of iterations in the burn in.
         """
-        return self.attrs["burn_in_iterations"]
+        try:
+            return self.attrs["burn_in_iterations"]
+        except KeyError:
+            # wasn't written; assume the last
+            return self.niterations
 
     @property
     def is_burned_in(self):
         """Returns whether or not the sampler is burned in.
         """
-        return self.attrs["is_burned_in"]
+        try:
+            return self.attrs["is_burned_in"]
+        except KeyError:
+            # wasn't written; assume False
+            return False
 
     @property
     def nwalkers(self):


### PR DESCRIPTION
If the `acl-interval` argument introduced in PR #2174 is set to something other than the checkpoint-interval on a new run, a KeyError will be raised. This is because when the code checks for the number of independent samples, it tries to access the `is_burned_in` and `burn_in_iteration` attrs in `InferenceFile`, but these will not have been set yet. This fixes this by returning False if `is_burned_in` yet has not been set, and the number of iterations in the file if `burn_in_iteration` has not been set.