### PR TITLE
Make sure variables to frame cache are strings

### DIFF
--- a/pycbc/frame/frame.py
+++ b/pycbc/frame/frame.py
@@ -104,7 +104,7 @@ def locations_to_cache(locations):
             if file_extension in [".lcf", ".cache"]:
                 cache = lal.CacheImport(file_path)
             elif file_extension == ".gwf":
-                cache = lalframe.FrOpen(dir_name, file_name).cache
+                cache = lalframe.FrOpen(str(dir_name), str(file_name)).cache
             else:
                 raise TypeError("Invalid location name")
 


### PR DESCRIPTION
I'm getting the following error when I try to use the strain from multi-ifo options:
```
Traceback (most recent call last):
  File "/work/cdcapano/virtualenv/pptest2/bin/pycbc_inference", line 4, in <module>
    __import__('pkg_resources').run_script('PyCBC==444748', 'pycbc_inference')
  File "/work/cdcapano/virtualenv/pptest2/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 657, in run_script
    self.require(requires)[0].run_script(script_name, ns)
  File "/work/cdcapano/virtualenv/pptest2/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 1437, in run_script
    exec(code, namespace, namespace)
  File "/work/cdcapano/virtualenv/pptest2/lib/python2.7/site-packages/PyCBC-444748-py2.7-linux-x86_64.egg/EGG-INFO/scripts/pycbc_inference", line 201, in <module>
    strain_dict, stilde_dict, psd_dict = option_utils.data_from_cli(opts)
  File "/work/cdcapano/virtualenv/pptest2/lib/python2.7/site-packages/PyCBC-444748-py2.7-linux-x86_64.egg/pycbc/inference/option_utils.py", line 338, in data_from_cli
    precision="double")
  File "/work/cdcapano/virtualenv/pptest2/lib/python2.7/site-packages/PyCBC-444748-py2.7-linux-x86_64.egg/pycbc/strain/strain.py", line 443, in from_cli_multi_ifos
    strain[ifo] = from_cli_single_ifo(opt, ifo, **kwargs)
  File "/work/cdcapano/virtualenv/pptest2/lib/python2.7/site-packages/PyCBC-444748-py2.7-linux-x86_64.egg/pycbc/strain/strain.py", line 435, in from_cli_single_ifo
    return from_cli(single_det_opt, **kwargs)
  File "/work/cdcapano/virtualenv/pptest2/lib/python2.7/site-packages/PyCBC-444748-py2.7-linux-x86_64.egg/pycbc/strain/strain.py", line 229, in from_cli
    sieve=sieve)
  File "/work/cdcapano/virtualenv/pptest2/lib/python2.7/site-packages/PyCBC-444748-py2.7-linux-x86_64.egg/pycbc/frame/frame.py", line 351, in query_and_read_frame
    check_integrity=check_integrity)
  File "/work/cdcapano/virtualenv/pptest2/lib/python2.7/site-packages/PyCBC-444748-py2.7-linux-x86_64.egg/pycbc/frame/frame.py", line 161, in read_frame
    cum_cache = locations_to_cache(locations)
  File "/work/cdcapano/virtualenv/pptest2/lib/python2.7/site-packages/PyCBC-444748-py2.7-linux-x86_64.egg/pycbc/frame/frame.py", line 107, in locations_to_cache
    cache = lalframe.FrOpen(dir_name, file_name).cache
TypeError: in method 'FrOpen', argument 3 of type 'CHAR const *'
```
The problem seems to be that `dir_name` and `file_name` are being passed as unicode. Forcing them to strings seems to fix the problem.