### PR TITLE
Make section names for distributions keyword args

### DIFF
--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -211,8 +211,8 @@ with ctx:
     cp = WorkflowConfigParser.from_cli(opts)
 
     # get the vairable and static arguments from the config file
-    variable_args, static_args, constraints = \
-        distributions.read_args_from_config(cp)
+    variable_args, static_args = distributions.read_params_from_config(cp)
+    constraints = distributions.read_constraints_from_config(cp)
 
     # get prior distribution for each variable parameter
     logging.info("Setting up priors for each parameter")

--- a/bin/pycbc_create_injections
+++ b/bin/pycbc_create_injections
@@ -227,8 +227,8 @@ logging.info("Loading config file")
 cp = WorkflowConfigParser.from_cli(opts)
 
 # get the vairable and static arguments from the config file
-variable_args, static_args, constraints = \
-    distributions.read_args_from_config(cp, prior_section=opts.dist_section)
+variable_args, static_args = distributions.read_params_from_config(cp)
+constraints = distributions.read_constraints_from_config(cp)
 
 if any(cp.get_subsections('waveform_transforms')):
     waveform_transforms = transforms.read_transforms_from_config(cp,

--- a/pycbc/distributions/__init__.py
+++ b/pycbc/distributions/__init__.py
@@ -97,10 +97,9 @@ def _convert_liststring_to_list(lstring):
     return lstring
 
 
-def read_args_from_config(cp, prior_section='prior',
-        vargs_section='variable_args', sargs_section='static_args',
-        constraint_section='constraint'):
-    """Loads static and variable arguments from a configuration file.
+def read_params_from_config(cp, prior_section='prior',
+        vargs_section='variable_args', sargs_section='static_args'):
+    """Loads static and variable parameters from a configuration file.
 
     Parameters
     ----------
@@ -114,8 +113,6 @@ def read_args_from_config(cp, prior_section='prior',
     sargs_section : str, optional
         The section to get the parameters that will remain fixed. Default is
         'static_args'.
-    constraint_section : str, optional
-        The section to get the constraints from. Default is 'constraint'.
 
     Returns
     -------
@@ -123,8 +120,6 @@ def read_args_from_config(cp, prior_section='prior',
         The names of the parameters to vary in the PE run.
     static_args : dict
         Dictionary of names -> values giving the parameters to keep fixed.
-    constraints : list
-        List of ``Constraint`` objects. Empty if no constraints were provided.
     """
     # sanity check that each parameter in [variable_args] has a priors section
     variable_args = cp.options(vargs_section)
@@ -151,7 +146,24 @@ def read_args_from_config(cp, prior_section='prior',
             # try converting to a list of strings; this function will just
             # return val if it does not begin (end) with [ (])
             static_args[key] = _convert_liststring_to_list(val)
+    return variable_args, static_args
 
+
+def read_constraints_from_config(cp, constraint_section='constraint'):
+    """Loads parameter constraints from a configuration file.
+
+    Parameters
+    ----------
+    cp : WorkflowConfigParser
+        An open config parser to read from.
+    constraint_section : str, optional
+        The section to get the constraints from. Default is 'constraint'.
+
+    Returns
+    -------
+    list
+        List of ``Constraint`` objects. Empty if no constraints were provided.
+    """
     # get additional constraints to apply in prior
     cons = []
     for subsection in cp.get_subsections(constraint_section):
@@ -174,4 +186,4 @@ def read_args_from_config(cp, prior_section='prior',
         cons.append(constraints.constraints[name](variable_args,
                                                   constraint_arg, **kwargs))
 
-    return variable_args, static_args, cons
+    return cons

--- a/pycbc/distributions/__init__.py
+++ b/pycbc/distributions/__init__.py
@@ -98,7 +98,7 @@ def _convert_liststring_to_list(lstring):
 
 
 def read_args_from_config(cp, prior_section='prior',
-        varargs_section='variable_args', staticargs_section='static_args',
+        vargs_section='variable_args', sargs_section='static_args',
         constraint_section='constraint'):
     """Loads static and variable arguments from a configuration file.
 
@@ -106,14 +106,16 @@ def read_args_from_config(cp, prior_section='prior',
     ----------
     cp : WorkflowConfigParser
         An open config parser to read from.
-    section_group : {None, str}
-        When reading the config file, only read from sections that begin with
-        `{section_group}_`. For example, if `section_group='foo'`, the
-        variable arguments will be retrieved from section
-        `[foo_variable_args]`. If None, no prefix will be appended to section
-        names.
     prior_section : str, optional
         Check that priors exist in the given section. Default is 'prior.'
+    vargs_section : str, optional
+        The section to get the parameters that will be varied/need priors
+        defined for them. Default is 'variable_args'.
+    sargs_section : str, optional
+        The section to get the parameters that will remain fixed. Default is
+        'static_args'.
+    constraint_section : str, optional
+        The section to get the constraints from. Default is 'constraint'.
 
     Returns
     -------
@@ -121,9 +123,11 @@ def read_args_from_config(cp, prior_section='prior',
         The names of the parameters to vary in the PE run.
     static_args : dict
         Dictionary of names -> values giving the parameters to keep fixed.
+    constraints : list
+        List of ``Constraint`` objects. Empty if no constraints were provided.
     """
     # sanity check that each parameter in [variable_args] has a priors section
-    variable_args = cp.options(varargs_section)
+    variable_args = cp.options(vargs_section)
     subsections = cp.get_subsections(prior_section)
     tags = set([p for tag in subsections for p in tag.split('+')])
     missing_prior = set(variable_args) - tags
@@ -133,8 +137,8 @@ def read_args_from_config(cp, prior_section='prior',
 
     # get parameters that do not change in sampler
     try:
-        static_args = dict([(key, cp.get_opt_tags(staticargs_section, key, []))
-            for key in cp.options(staticargs_section)])
+        static_args = dict([(key, cp.get_opt_tags(sargs_section, key, []))
+            for key in cp.options(sargs_section)])
     except _ConfigParser.NoSectionError:
         static_args = {}
     # try converting values to float

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -64,8 +64,9 @@ class TestDistributions(unittest.TestCase):
 
         # read configuration files
         self.cp = WorkflowConfigParser.from_cli(self.opts)
-        args = distributions.read_args_from_config(self.cp)
-        self.variable_args, self.static_args, self.contraints = args
+        self.variable_args, self.static_args = \
+            distributions.read_params_from_config(self.cp)
+        self.constraints = distributions.read_constraints_from_config(self.cp)
 
         # read distributions
         self.dists = distributions.read_distributions_from_config(self.cp)


### PR DESCRIPTION
This makes the sections to read the variable parameters, static parameters, and constraints keyword arguments in `distributions.read_args_from_config`. The defaults are what we currently use (`variable_args`, `static_args`, and `constraint`). Since these section names can now be specified explicitly, this also gets rid of the `section_group` argument.