### PR TITLE
Don't open bank file for writing

### DIFF
--- a/bin/hdfcoinc/pycbc_coinc_findtrigs
+++ b/bin/hdfcoinc/pycbc_coinc_findtrigs
@@ -69,7 +69,7 @@ class ReadByTemplate(object):
         self.file = h5py.File(filename, 'r')
         self.ifo = self.file.keys()[0]
         self.valid = None
-        self.bank = h5py.File(bank) if bank else None
+        self.bank = h5py.File(bank, 'r') if bank else None
 
         # Determine the segments which define the boundaries of valid times
         # to use triggers


### PR DESCRIPTION
I've been struggling to push runs through on CIT for a few days (maybe some config change there)

The problem seems to be the following line. Without this change I see "Permission Denied" errors because the file cannot be opened with write permissions on multiple processes. Not really sure why we never saw this before.

Patch is simple and seems to fix the problem. 