### PR TITLE
timeseries.py: change to_frequencyseries to remove _nocomplex

### DIFF
--- a/pycbc/types/timeseries.py
+++ b/pycbc/types/timeseries.py
@@ -722,8 +722,7 @@ class TimeSeries(Array):
         else:
             raise ValueError('Path must end with .npy, .txt or .hdf')
                 
-    @_nocomplex
-    def to_frequencyseries(self, delta_f=None):
+    def to_frequencyseries(self, delta_f=None,twosided=False):
         """ Return the Fourier transform of this time series
         
         Parameters
@@ -743,7 +742,10 @@ class TimeSeries(Array):
 
         # add 0.5 to round integer
         tlen  = int(1.0 / delta_f / self.delta_t + 0.5)
-        flen = tlen / 2 + 1
+        flen = tlen / 2 + 1        
+        if twosided or self.dtype == np.complex128:
+            # two-sided complex FFT
+            flen = tlen
 
         if tlen < len(self):
             raise ValueError("The value of delta_f (%s) would be "
@@ -761,6 +763,48 @@ class TimeSeries(Array):
                            delta_f=delta_f)
         fft(tmp, f)
         return f
+
+    def to_frequencyseries_2sided(self, delta_f=None):
+        """ Return the Fourier transform of this time series, as a two-sided function.
+        See COMPLEX16FrequencySeries for example
+        
+        Parameters
+        ----------
+        delta_f : {None, float}, optional
+            The frequency resolution of the returned frequency series. By 
+        default the resolution is determined by the duration of the timeseries.
+        
+        Returns
+        -------        
+        FrequencySeries: 
+            The fourier transform of this time series.
+ 
+        """
+        from pycbc.fft import fft
+        if not delta_f:
+            delta_f = 1.0 / self.duration
+
+        # add 0.5 to round integer
+        tlen  = int(1.0 / delta_f / self.delta_t + 0.5)
+        flen = tlen
+
+        if tlen < len(self):
+            raise ValueError("The value of delta_f (%s) would be "
+                             "undersampled. Maximum delta_f "
+                             "is %s." % (delta_f, 1.0 / self.duration))
+        if not delta_f:
+            tmp = self
+        else:
+            tmp = TimeSeries(zeros(tlen, dtype=self.dtype), 
+                             delta_t=self.delta_t, epoch=self.start_time)
+            tmp[:len(self)] = self[:]
+        
+        f = FrequencySeries(zeros(flen, 
+                           dtype=complex_same_precision_as(self)),
+                           delta_f=delta_f)
+        fft(tmp, f)
+        return f
+
 
     def add_into(self, other):
         """Return the sum of the two time series accounting for the time stamp.


### PR DESCRIPTION
Enables twosided output, when TimeSeries object has complex form.
(The dtype allows the user to identify if a two-sided frequency series was used: this should only be called on complex input.)