### PR TITLE
Add LOSC https urls as fallback

### DIFF
--- a/pycbc/workflow/datafind.py
+++ b/pycbc/workflow/datafind.py
@@ -724,6 +724,26 @@ def convert_cachelist_to_filelist(datafindcache_list):
                     # Datafind returned a URL valid on the osg as well
                     # so add the additional PFNs to allow OSG access.
                     currFile.PFN(frame.url, site='osg')
+                    if 'H1_LOSC_4_V1' in frame.url:
+                        currFile.PFN(frame.url.replace(
+                            'file:///cvmfs/gwosc.osgstorage.org/gwdata/O1/strain.4k/frame.v1/H1/',
+                            'https://losc.ligo.org/archive/data/O1/'),
+                            site='osg')
+                    elif 'L1_LOSC_4_V1' in frame.url:
+                        currFile.PFN(frame.url.replace(
+                            'file:///cvmfs/gwosc.osgstorage.org/gwdata/O1/strain.4k/frame.v1/L1/',
+                            'https://losc.ligo.org/archive/data/O1/'),
+                            site='osg')
+                    elif 'H1_LOSC_16_V1' in frame.url:
+                        currFile.PFN(frame.url.replace(
+                            'file:///cvmfs/gwosc.osgstorage.org/gwdata/O1/strain.16k/frame.v1/H1/',
+                            'https://losc.ligo.org/archive/data/O1_16KHZ/'),
+                            site='osg')
+                    elif 'L1_LOSC_16_V1' in frame.url:
+                        currFile.PFN(frame.url.replace(
+                            'file:///cvmfs/gwosc.osgstorage.org/gwdata/O1/strain.16k/frame.v1/L1/',
+                            'https://losc.ligo.org/archive/data/O1_16KHZ/'),
+                            site='osg')
             else:
                 currFile.PFN(frame.url, site='notlocal')
 


### PR DESCRIPTION
This commit adds URLs on `https://losc.ligo.org` as back-up URLs for the LOSC CVMFS frame data. Similar to the code above for the regular LIGO data, this should really be handled at the datafind server level, but we keep patching here for now.