### PR TITLE
Make transforms a kwarg to custom constraints

### DIFF
--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -210,19 +210,8 @@ with ctx:
     # read configuration file
     cp = WorkflowConfigParser.from_cli(opts)
 
-    # get the vairable and static arguments from the config file
-    variable_args, static_args = distributions.read_params_from_config(cp)
-    constraints = distributions.read_constraints_from_config(cp)
-
-    # get prior distribution for each variable parameter
-    logging.info("Setting up priors for each parameter")
-    dists = distributions.read_distributions_from_config(cp, "prior")
-
-    # construct class that will return the prior
-    prior_eval = distributions.JointDistribution(variable_args, *dists,
-                                      **{"constraints" : constraints})
-
     # get sampling transformations
+    all_transforms = []
     if cp.has_section('sampling_parameters'):
         sampling_parameters, replace_parameters = \
             option_utils.read_sampling_args_from_config(cp)
@@ -230,6 +219,7 @@ with ctx:
             'sampling_transforms')
         logging.info("Sampling in {} in place of {}".format(
             ', '.join(sampling_parameters), ', '.join(replace_parameters)))
+        all_transforms = sampling_transforms
     else:
         sampling_parameters = replace_parameters = sampling_transforms = None
 
@@ -238,8 +228,22 @@ with ctx:
         logging.info("Loading waveform transforms")
         waveform_transforms = transforms.read_transforms_from_config(cp,
             'waveform_transforms')
+        all_transforms.extend(waveform_transforms)
     else:
         waveform_transforms = None
+
+    # get the vairable and static arguments from the config file
+    variable_args, static_args = distributions.read_params_from_config(cp)
+    constraints = distributions.read_constraints_from_config(
+        cp, transforms=all_transforms)
+
+    # get prior distribution for each variable parameter
+    logging.info("Setting up priors for each parameter")
+    dists = distributions.read_distributions_from_config(cp, "prior")
+
+    # construct class that will return the prior
+    prior_eval = distributions.JointDistribution(variable_args, *dists,
+                                      **{"constraints" : constraints})
 
     # get ifo-specific instances of calibration model
     if cp.has_section('calibration'):

--- a/pycbc/distributions/__init__.py
+++ b/pycbc/distributions/__init__.py
@@ -149,13 +149,16 @@ def read_params_from_config(cp, prior_section='prior',
     return variable_args, static_args
 
 
-def read_constraints_from_config(cp, constraint_section='constraint'):
+def read_constraints_from_config(cp, transforms=None,
+                                 constraint_section='constraint'):
     """Loads parameter constraints from a configuration file.
 
     Parameters
     ----------
     cp : WorkflowConfigParser
         An open config parser to read from.
+    transforms : list, optional
+        List of transforms to apply to parameters before applying constraints.
     constraint_section : str, optional
         The section to get the constraints from. Default is 'constraint'.
 
@@ -184,7 +187,8 @@ def read_constraints_from_config(cp, constraint_section='constraint'):
                 except ValueError:
                     pass
             kwargs[key] = val
-        cons.append(constraints.constraints[name](variable_args,
-                                                  constraint_arg, **kwargs))
+        cons.append(constraints.constraints[name](constraint_arg,
+                                                  transforms=transforms,
+                                                  **kwargs))
 
     return cons


### PR DESCRIPTION
This fixes `read_constraints_from_config` by removing `variable_args` from the required init parameters for constraints. The variable args were used for figuring out what transforms to apply. Instead, a `transforms` keyword may now be provided which gives the list of transforms to apply explicitly. In `pycbc_inference`, the combination of the sampling and waveform transforms are given as this keyword.