### PR TITLE
Some bug fixes

### DIFF
--- a/pycbc/filter/matchedfilter.py
+++ b/pycbc/filter/matchedfilter.py
@@ -1133,14 +1133,28 @@ def get_cutoff_indices(flow, fhigh, df, N):
     """
     if flow:
         kmin = int(flow / df)
+        if kmin < 0:
+            err_msg = "Start frequency cannot be negative. "
+            err_msg += "Supplied value and kmin {} and {}".format(flow, kmin)
+            raise ValueError(err_msg)
     else:
         kmin = 1
     if fhigh:
         kmax = int(fhigh / df )
+        if kmax > int((N + 1)/2.):
+            kmax = int((N + 1)/2.)
     else:
         # int() truncates towards 0, so this is
         # equivalent to the floor of the float
         kmax = int((N + 1)/2.)
+
+    if kmax <= kmin:
+        err_msg = "Kmax cannot be less than or equal to kmin. "
+        err_msg += "Provided values of freqencies (min,max) were "
+        err_msg += "{} and {} ".format(fmin, fmax)
+        err_msg += "corresponding to (kmin, kmax) of "
+        err_msg += "{} and {}.".format(kmin, kmax)
+        raise ValueError(err_msg)
 
     return kmin,kmax
 

--- a/pycbc/pnutils.py
+++ b/pycbc/pnutils.py
@@ -35,7 +35,7 @@ from pycbc import conversions
 def nearest_larger_binary_number(input_len):
     """ Return the nearest binary number larger than input_len.
     """
-    return 2**numpy.ceil(numpy.log2(input_len))
+    return int(2**numpy.ceil(numpy.log2(input_len)))
 
 def chirp_distance(dist, mchirp, ref_mass=1.4):
     return conversions.chirp_distance(dist, mchirp, ref_mass=ref_mass)


### PR DESCRIPTION
I guess the uptick of usage of PyCBC because of GWin was always going to undercover some subtle bugs in code-paths we don't use often in the search. Here are fixes to two problems reported by @SergeiOssokine 

 * First some of the waveform module will calculate `N` using `nearest_larger_binary_number`. That code currently returns a float, which is a problem, so cast this to int.
 * We don't check that kmin and kmax are actually within the allowed bounds in `get_cutoff_indices` in matchedfilter.py. Python will generally do *something* in the case that you define a slice with indices outside the range of the array, but it often won't be what you want! Here enforce limits. High frequency cutoff being larger than that defined seems to be a valid use case, so in that case we just drop the cutoff to the maximum allowed without raising an error or anything.