### PR TITLE
Add low-frequency cutoff option for every detector

### DIFF
--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -200,7 +200,7 @@ if 'data' in likelihood_class.required_kwargs:
     logging.info("Loading data")
     strain_dict, stilde_dict, psd_dict = option_utils.data_from_cli(opts)
     low_frequency_cutoff_dict = option_utils.low_frequency_cutoff_from_cli(opts)
-    likelihood_args['f_lower'] = low_frequency_cutoff_dict.values()[0]
+    likelihood_args['f_lower'] = low_frequency_cutoff_dict
     likelihood_args['psds'] = psd_dict
 else:
     strain_dict = stilde_dict = psd_dict = low_frequency_cutoff_dict = None

--- a/pycbc/inference/likelihood.py
+++ b/pycbc/inference/likelihood.py
@@ -729,7 +729,7 @@ class GaussianLikelihood(BaseLikelihoodEvaluator):
         data set must be the same as the waveform generator's epoch.
     f_lower : dict
         A dictionary of starting frequencies, in which the keys are the detector
-        names and the values are the starting frequency for that detector to be 
+        names and the values are the starting frequency for that detector to be
         used for computing inner products.
     psds : {None, dict}
         A dictionary of FrequencySeries keyed by the detector names. The
@@ -857,7 +857,7 @@ class GaussianLikelihood(BaseLikelihoodEvaluator):
             self._weight = {det: Array(numpy.sqrt(norm/psds[det]))
                             for det in data}
             numpy.seterr(**numpysettings)
-        
+
         lognl = 0.
         self._kmin = {}
         self._kmax = {}

--- a/pycbc/inference/likelihood.py
+++ b/pycbc/inference/likelihood.py
@@ -869,7 +869,8 @@ class GaussianLikelihood(BaseLikelihoodEvaluator):
             self._kmin[det] = kmin
             self._kmax[det] = kmax
             # compute log likelihood function inner product
-            lognl += (-0.5*(self._data[det][kmin:kmax].inner(self._data[det][kmin:kmax]).real))
+            lognl += (-0.5*(self._data[det][kmin:kmax].inner(
+                            self._data[det][kmin:kmax]).real))
 
         # save the log likelihood function of the noise
         self.set_lognl(lognl)

--- a/pycbc/inference/likelihood.py
+++ b/pycbc/inference/likelihood.py
@@ -1073,7 +1073,8 @@ class MarginalizedPhaseGaussianLikelihood(GaussianLikelihood):
                 continue
             h[self._kmin[det]:kmax] *= self._weight[det][self._kmin[det]:kmax]
             hh += h[self._kmin[det]:kmax].inner(h[self._kmin[det]:kmax]).real
-            hd += self.data[det][self._kmin[det]:kmax].inner(h[self._kmin[det]:kmax])
+            hd += self.data[det][self._kmin[det]:kmax].inner(
+                                                    h[self._kmin[det]:kmax])
         hd = abs(hd)
         return numpy.log(special.i0e(hd)) + hd - 0.5*hh
 

--- a/pycbc/inference/option_utils.py
+++ b/pycbc/inference/option_utils.py
@@ -293,7 +293,7 @@ def add_low_frequency_cutoff_opt(parser):
     # Allow for different frequency cutoffs to be used for every detector
     parser.add_argument("--low-frequency-cutoff", type=float, nargs="+",
                         action=MultiDetOptionAction, metavar='IFO:FLOW',
-                         help="Low frequency cutoff for each IFO.")
+                        help="Low frequency cutoff for each IFO.")
 
 
 def low_frequency_cutoff_from_cli(opts):

--- a/pycbc/inference/option_utils.py
+++ b/pycbc/inference/option_utils.py
@@ -36,6 +36,7 @@ from pycbc.psd import from_cli_multi_ifos as psd_from_cli_multi_ifos
 from pycbc.strain import from_cli_multi_ifos as strain_from_cli_multi_ifos
 from pycbc.strain import gates_from_cli, psd_gates_from_cli, apply_gates_to_td, \
                        apply_gates_to_fd
+from pycbc.types import MultiDetOptionAction
 
 
 #-----------------------------------------------------------------------------
@@ -289,11 +290,10 @@ def validate_checkpoint_files(checkpoint_file, backup_file):
 
 def add_low_frequency_cutoff_opt(parser):
     """Adds the low-frequency-cutoff option to the given parser."""
-    # FIXME: this just uses the same frequency cutoff for every instrument for
-    # now. We should allow for different frequency cutoffs to be used; that
-    # will require (minor) changes to the Likelihood class
-    parser.add_argument("--low-frequency-cutoff", type=float,
-                        help="Low frequency cutoff for each IFO.")
+    # Allow for different frequency cutoffs to be used for every detector
+    parser.add_argument("--low-frequency-cutoff", type=float, nargs="+",
+                        action=MultiDetOptionAction, metavar='IFO:FLOW',
+                         help="Low frequency cutoff for each IFO.")
 
 
 def low_frequency_cutoff_from_cli(opts):
@@ -304,11 +304,7 @@ def low_frequency_cutoff_from_cli(opts):
     dict
         Dictionary of instruments -> low frequency cutoff.
     """
-    # FIXME: this just uses the same frequency cutoff for every instrument for
-    # now. We should allow for different frequency cutoffs to be used; that
-    # will require (minor) changes to the Likelihood class
-    return {ifo: opts.low_frequency_cutoff for ifo in opts.instruments}
-
+    return opts.low_frequency_cutoff
 
 def data_from_cli(opts):
     """Loads the data needed for a likelihood evaluator from the given

--- a/pycbc/inference/option_utils.py
+++ b/pycbc/inference/option_utils.py
@@ -94,7 +94,7 @@ def read_sampling_args_from_config(cp, section_group=None,
     for args in cp.options(section):
         map_args = cp.get(section, args)
         sampling_params.update(set(map(str.strip, map_args.split(','))))
-        replaced_params.update(set(map(str.strip, args.split(',')))) 
+        replaced_params.update(set(map(str.strip, args.split(','))))
     return list(sampling_params), list(replaced_params)
 
 

--- a/test/test_inference.py
+++ b/test/test_inference.py
@@ -53,7 +53,7 @@ class TestSamplers(unittest.TestCase):
         self.fdomain_samples = self.data_length * self.sample_rate / 2 + 1
         self.delta_f = 1.0 / self.data_length
         self.fmin = {ifo : 30.0 for ifo in self.ifos}
-        
+
         self.psds = {}
         # set an analyitcal PSD for each detector
         for ifo in self.ifos:


### PR DESCRIPTION
This PR adds the ability to read in different low-frequency cutoffs for every detector to pycbc inference. So one can provide for eg. : `--low-frequency-cutoff H1:20 L1:25` in the CLI. If a single low-frequency cutoff is provided, for eg. : `--low-frequency-cutoff 20`, that'll be used for all the detectors. 