### PR TITLE
Declare read-only file as read-only

### DIFF
--- a/pycbc/types/frequencyseries.py
+++ b/pycbc/types/frequencyseries.py
@@ -575,7 +575,7 @@ def load_frequencyseries(path, group=None):
         data = _numpy.loadtxt(path)
     elif ext == '.hdf':
         key = 'data' if group is None else group
-        f = h5py.File(path)
+        f = h5py.File(path, 'r')
         data = f[key][:]
         series = FrequencySeries(data, delta_f=f[key].attrs['delta_f'],
                                        epoch=f[key].attrs['epoch']) 


### PR DESCRIPTION
We have to be careful with HDF files read into multi-processing code that we open read-only files (in multiple processes) with the read-only flag, and open files for writing in only one thread.

Here's one example of this not happening.