### PR TITLE
Update Calibration

### DIFF
--- a/pycbc/strain/__init__.py
+++ b/pycbc/strain/__init__.py
@@ -1,4 +1,4 @@
-from .recalibrate import Recalibrate
+from .recalibrate import CubicSpline, PhysicalModel
 
 from .strain import detect_loud_glitches
 from .strain import from_cli, from_cli_single_ifo, from_cli_multi_ifos
@@ -10,8 +10,10 @@ from .gate import add_gate_option_group, gates_from_cli
 from .gate import apply_gates_to_td, apply_gates_to_fd, psd_gates_from_cli
 
 models = {
-    Recalibrate.name : Recalibrate
+    CubicSpline.name: CubicSpline,
+    PhysicalModel.name: PhysicalModel
 }
+
 
 def read_model_from_config(cp, ifo, section="calibration"):
     """Returns an instance of the calibration model specified in the
@@ -31,7 +33,7 @@ def read_model_from_config(cp, ifo, section="calibration"):
     instance
         An instance of the calibration model class.
     """
-    name = cp.get_opt_tag(section, "name", None)
-    recalibrator = models[name].from_config(cp, ifo.lower(), section)
+    model = cp.get_opt_tag(section, "{}_model".format(ifo.lower()), None)
+    recalibrator = models[model].from_config(cp, ifo.lower(), section)
 
     return recalibrator

--- a/pycbc/strain/recalibrate.py
+++ b/pycbc/strain/recalibrate.py
@@ -16,11 +16,166 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-import numpy
+import numpy as np
 from scipy.interpolate import UnivariateSpline
 from pycbc.types import FrequencySeries
+from abc import (ABCMeta, abstractmethod)
+import inspect
+
 
 class Recalibrate(object):
+    __metaclass__ = ABCMeta
+    name = None
+
+    def __init__(self, ifo_name):
+        self.ifo_name = ifo_name
+        self.params = dict()
+
+    @abstractmethod
+    def apply_calibration(self, strain):
+        """Apply calibration model
+
+        This method should be overwritten by subclasses
+
+        Parameters
+        ----------
+        strain : FrequencySeries
+            The strain to be recalibrated.
+
+        Return
+        ------
+        strain_adjusted : FrequencySeries
+            The recalibrated strain.
+        """
+        return
+
+    def map_to_adjust(self, strain, prefix='recalib_', **params):
+        """Map an input dictionary of sampling parameters to the
+        adjust_strain function by filtering the dictionary for the
+        calibration parameters, then calling adjust_strain.
+
+        Parameters
+        ----------
+        strain : FrequencySeries
+            The strain to be recalibrated.
+        prefix: str
+            Prefix for calibration parameter names
+        params : dict
+            Dictionary of sampling parameters which includes
+            calibration parameters.
+        Return
+        ------
+        strain_adjusted : FrequencySeries
+            The recalibrated strain.
+        """
+
+        self.params.update({
+            key[len(prefix):]: params[key]
+            for key in params if prefix in key and self.ifo_name in key})
+
+        strain_adjusted = self.apply_calibration(strain)
+
+        return strain_adjusted
+
+    @classmethod
+    def from_config(cls, cp, ifo, section):
+        """Read a config file to get calibration options and transfer
+        functions which will be used to intialize the model.
+
+        Parameters
+        ----------
+        cp : WorkflowConfigParser
+            An open config file.
+        ifo : string
+            The detector (H1, L1) for which the calibration model will
+            be loaded.
+        section : string
+            The section name in the config file from which to retrieve
+            the calibration options.
+        Return
+        ------
+        instance
+            An instance of the class.
+        """
+        all_params = dict(cp.items(section))
+        params = {key[len(ifo)+1:]: all_params[key]
+                  for key in all_params if ifo.lower() in key}
+        arg_names = inspect.getargspec(cls.__init__)[0]
+        params = {key: params[key] for key in params if key in arg_names}
+        params['ifo_name'] = ifo.lower()
+
+        return cls(**params)
+
+
+class CubicSpline(Recalibrate):
+    name = 'cubic_spline'
+
+    def __init__(self, minimum_frequency, maximum_frequency, n_points,
+                 ifo_name):
+        """
+        Cubic spline recalibration
+
+        see https://dcc.ligo.org/LIGO-T1400682/public
+
+        This assumes the spline points follow
+        np.logspace(np.log(minimum_frequency), np.log(maximum_frequency),
+                    n_points)
+
+        Parameters
+        ----------
+        minimum_frequency: float
+            minimum frequency of spline points
+        maximum_frequency: float
+            maximum frequency of spline points
+        n_points: int
+            number of spline points
+        """
+        Recalibrate.__init__(self, ifo_name=ifo_name)
+        minimum_frequency = float(minimum_frequency)
+        maximum_frequency = float(maximum_frequency)
+        n_points = int(n_points)
+        if n_points < 4:
+            raise ValueError(
+                'Use at least 4 spline points for calibration model')
+        self.n_points = n_points
+        self.spline_points = np.logspace(np.log10(minimum_frequency),
+                                         np.log10(maximum_frequency), n_points)
+
+    def apply_calibration(self, strain):
+        """Apply calibration model
+
+        This applies cubic spline calibration to the strain.
+
+        Parameters
+        ----------
+        strain : FrequencySeries
+            The strain to be recalibrated.
+
+        Return
+        ------
+        strain_adjusted : FrequencySeries
+            The recalibrated strain.
+        """
+        amplitude_parameters =\
+            [self.params['amplitude_{}_{}'.format(self.ifo_name, ii)]
+             for ii in range(self.n_points)]
+        amplitude_spline = UnivariateSpline(self.spline_points,
+                                            amplitude_parameters)
+        delta_amplitude = amplitude_spline(strain.sample_frequencies.numpy())
+
+        phase_parameters =\
+            [self.params['phase_{}_{}'.format(self.ifo_name, ii)]
+             for ii in range(self.n_points)]
+        phase_spline = UnivariateSpline(self.spline_points, phase_parameters)
+        delta_phase = phase_spline(strain.sample_frequencies.numpy())
+
+        strain_adjusted = strain * (1.0 + delta_amplitude)\
+            * (2.0 + 1j * delta_phase) / (2.0 - 1j * delta_phase)
+
+        return strain_adjusted
+
+
+class PhysicalModel(Recalibrate):
     """ Class for adjusting time-varying calibration parameters of given
     strain data.
 
@@ -59,7 +214,7 @@ class Recalibrate(object):
     def __init__(self, freq=None, fc0=None, c0=None, d0=None,
                  a_tst0=None, a_pu0=None, fs0=None, qinv0=None):
 
-        self.freq = numpy.real(freq)
+        self.freq = np.real(freq)
         self.c0 = c0
         self.d0 = d0
         self.a_tst0 = a_tst0
@@ -236,8 +391,8 @@ class Recalibrate(object):
         k = r_adjusted / self.r0
 
         # decompose into amplitude and unwrapped phase
-        k_amp = numpy.abs(k)
-        k_phase = numpy.unwrap(numpy.angle(k))
+        k_amp = np.abs(k)
+        k_phase = np.unwrap(np.angle(k))
 
         # convert to FrequencySeries by interpolating then resampling
         order = 1
@@ -245,7 +400,7 @@ class Recalibrate(object):
         k_phase_off = UnivariateSpline(self.freq, k_phase, k=order, s=0)
         freq_even = strain.sample_frequencies.numpy()
         k_even_sample = k_amp_off(freq_even) * \
-                        numpy.exp(1.0j * k_phase_off(freq_even))
+                        np.exp(1.0j * k_phase_off(freq_even))
         strain_adjusted = FrequencySeries(strain.numpy() * \
                                           k_even_sample,
                                           delta_f=strain.delta_f)
@@ -267,10 +422,10 @@ class Recalibrate(object):
         ------
         numpy.array
         """
-        data = numpy.loadtxt(path, delimiter=delimiter)
+        data = np.loadtxt(path, delimiter=delimiter)
         freq = data[:, 0]
         h = data[:, 1] + 1.0j * data[:, 2]
-        return numpy.array([freq, h]).transpose()
+        return np.array([freq, h]).transpose()
 
     @classmethod
     def from_config(cls, cp, ifo, section):

--- a/test/test_calibration.py
+++ b/test/test_calibration.py
@@ -1,0 +1,80 @@
+import pytest
+
+from pycbc import strain
+from pycbc.types import FrequencySeries
+import numpy as np
+from pycbc.workflow.configuration import WorkflowConfigParser
+from pycbc.strain.recalibrate import Recalibrate
+
+
+@pytest.fixture
+def strain_array():
+    frequency_array = np.linspace(0, 2048, 100)
+    delta_f = frequency_array[1] - frequency_array[0]
+    strain_array = frequency_array**2
+    return FrequencySeries(strain_array, delta_f)
+
+
+def test_cannot_instantiate_base_class():
+    with pytest.raises(TypeError):
+        Recalibrate('test')
+
+
+@pytest.mark.parametrize("name, params", [
+    ('cubic_spline', dict(ifo_name='test',
+                          minimum_frequency=10,
+                          maximum_frequency=1024,
+                          n_points=5)),
+])
+def test_instantiation(name, params):
+    model = strain.models[name](**params)
+    assert model.name == name
+
+
+@pytest.mark.parametrize("name, init_params, dict_params", [
+    ('cubic_spline',
+     dict(ifo_name='test', minimum_frequency=10,
+          maximum_frequency=1024, n_points=5),
+     dict(recalib_amplitude_test_0=0.1,
+          recalib_amplitude_test_1=0.1,
+          recalib_amplitude_test_2=0.1,
+          recalib_amplitude_test_3=0.1,
+          recalib_amplitude_test_4=0.1,
+          recalib_phase_test_0=0.1,
+          recalib_phase_test_1=0.1,
+          recalib_phase_test_2=0.1,
+          recalib_phase_test_3=0.1,
+          recalib_phase_test_4=0.1,
+          )
+     )
+])
+def test_update_parameters(name, init_params, dict_params):
+    model = strain.models[name](**init_params)
+    dict_params.update(dict(foo='bar'))
+    prefix = 'recalib_'
+    model.map_to_adjust(strain_array(), prefix=prefix, **dict_params)
+    model_keys = [key[len(prefix):] for key in dict_params if prefix in key]
+    assert all([model.params[key] == dict_params[prefix+key]
+                for key in model_keys])
+
+
+@pytest.mark.parametrize("name, parameters", [
+    ('cubic_spline', dict(minimum_frequency='10', maximum_frequency='1024',
+                          n_points='5'))
+])
+def test_instantiation_from_config(name, parameters):
+    cp = WorkflowConfigParser()
+    cp.add_section('test')
+    ifo_name = 'ifo'
+    cp.set('test', '{}_model'.format(ifo_name), name)
+    for key in parameters:
+        cp.set('test', '{}_{}'.format(ifo_name, key), parameters[key])
+    from_config = strain.read_model_from_config(cp, ifo_name, 'test')
+    assert all([from_config.name == name, from_config.ifo_name == ifo_name])
+
+
+def test_too_few_spline_points_fails():
+    with pytest.raises(ValueError):
+        strain.CubicSpline(
+            ifo_name='test', minimum_frequency=10,
+            maximum_frequency=1024, n_points=3)


### PR DESCRIPTION
@cdcapano @ahnitz this PR is adding the calibration functionality previously introduced to `gwin` (https://github.com/gwastro/gwin/pull/63).

This is basically a cut and paste from the code I added there.

I renamed the existing `Recalibrate` class to `PhysicalModel` to keep `Recalibrate` available for the base class.

If/when this is merged I'll open a PR in `gwin` to update the calibration functionality there to use this.