### PR TITLE
Trivial change fixing dictionary key sorting in analytical.py

### DIFF
--- a/pycbc/psd/analytical.py
+++ b/pycbc/psd/analytical.py
@@ -67,7 +67,6 @@ def get_pycbc_psd_list():
         Returns a list of names of all reference PSD functions coded in PyCBC.
     """
     pycbc_analytical_psd_list = pycbc_analytical_psds.keys()
-    #pycbc_analytical_psd_list.sort()
     pycbc_analytical_psd_list = sorted(pycbc_analytical_psd_list)
     return pycbc_analytical_psd_list
 

--- a/pycbc/psd/analytical.py
+++ b/pycbc/psd/analytical.py
@@ -67,7 +67,8 @@ def get_pycbc_psd_list():
         Returns a list of names of all reference PSD functions coded in PyCBC.
     """
     pycbc_analytical_psd_list = pycbc_analytical_psds.keys()
-    pycbc_analytical_psd_list.sort()
+    #pycbc_analytical_psd_list.sort()
+    pycbc_analytical_psd_list = sorted(pycbc_analytical_psd_list)
     return pycbc_analytical_psd_list
 
 def from_string(psd_name, length, delta_f, low_freq_cutoff):


### PR DESCRIPTION
This is a very trivial change that fixes the issue with the dictionary key sorting in line 70 of `analytical.py`. The original line is still in comment. This still does not fix the psd generation in Python3.6. I will open an issue with the other errors