### PR TITLE
Fix bug in inline decompress code

### DIFF
--- a/pycbc/waveform/compress.py
+++ b/pycbc/waveform/compress.py
@@ -371,7 +371,7 @@ _linear_decompress_code = r"""
     }
 
     // zero out the beginning
-    memset(outptr, 0, sizeof(*outptr)*2*kmin);
+    memset(outptr, 0, sizeof(*outptr)*2*(kmin+1));
 
     // move to the start position
     outptr += 2*kmin;
@@ -441,7 +441,9 @@ _linear_decompress_code = r"""
     }
 
     // zero out the rest of the array
-    memset(outptr, 0, sizeof(*outptr)*2*(hlen-kmax));
+    if (hlen - (kmax+1) > 0) {
+        memset(outptr, 0, sizeof(*outptr)*2*(hlen - (kmax+1)));
+    }
 """
 # for single precision
 _linear_decompress_code32 = _linear_decompress_code.replace('double', 'float')


### PR DESCRIPTION
The C code used for the inline decompression can segfault when zeroing out the end of the array, if the scratch space is larger than needed. This is due to an off-by-one error in the memset that's called. (Basically, it tries to zero out one index beyond the memory allocated for the output.) This fixes that. This also ensures that if `kmin == kmax`, you just get a zeroed vector back.