### PR TITLE
improve detector module

### DIFF
--- a/docs/detector.rst
+++ b/docs/detector.rst
@@ -27,12 +27,10 @@ Time source gravitational-wave passes through detector
 .. literalinclude:: ../examples/detector/delay.py
 .. command-output:: python ../examples/detector/delay.py
 
-======================================================
-Antenna pattern of a gravitational wave detector and
-projecting a signal into the detector frame
-======================================================
+================================================================
+Antenna Patterns and Projecting a Signal into the Detector Frame
+================================================================
 
 .. literalinclude:: ../examples/detector/ant.py
 .. command-output:: python ../examples/detector/ant.py
-
 

--- a/docs/detector.rst
+++ b/docs/detector.rst
@@ -1,0 +1,38 @@
+###################################################
+Gravitational-wave Detectors
+###################################################
+
+The pycbc.detector module provides the :py:mod:`pycbc.detector.Detector` class
+to access information about gravitational wave detectors and key information
+about how their orientation and position affects their view of a source
+
+=====================================
+Detector Locations
+=====================================
+
+.. literalinclude:: ../examples/detector/loc.py
+.. command-output:: python ../examples/detector/loc.py
+
+=====================================
+Light travel time between detectors
+=====================================
+
+.. literalinclude:: ../examples/detector/travel.py
+.. command-output:: python ../examples/detector/travel.py
+
+======================================================
+Time source gravitational-wave passes through detector
+======================================================
+
+.. literalinclude:: ../examples/detector/delay.py
+.. command-output:: python ../examples/detector/delay.py
+
+======================================================
+Antenna pattern of a gravitational wave detector and
+projecting a signal into the detector frame
+======================================================
+
+.. literalinclude:: ../examples/detector/ant.py
+.. command-output:: python ../examples/detector/ant.py
+
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -129,6 +129,7 @@ In addition we have some examples below.
    catalog
    gw150914
    frame
+   detector
    psd
    noise
    waveform

--- a/examples/detector/ant.py
+++ b/examples/detector/ant.py
@@ -1,0 +1,34 @@
+from pycbc.detector import Detector
+from pycbc.waveform import get_td_waveform
+
+# Time, orientation and location of the source in the sky
+ra = 1.7
+dec = 1.7
+pol = 0.2
+inc = 0
+time = 1000000000
+
+# We can calcualate the antenna pattern for Hanford at 
+# the specific sky location
+d = Detector("H1")
+
+# We get back the fp and fc antenna pattern weights.
+fp, fc = d.antenna_pattern(ra, dec, pol, time)
+print("fp={}, fc={}".format(fp, fc))
+
+# These factors allow us to project a signal into what the detector would
+# observe
+
+## Generate a waveform
+hp, hc = get_td_waveform(approximant="IMRPhenomD", mass1=10, mass2=10,
+                         f_lower=30, delta_t=1.0/4096, inclination=inc, 
+                         distance=400)
+                         
+## Apply the factors to get the detector frame strain
+ht = fp * hp + fc * hc
+
+
+# The projection process can also take into account the rotation of the
+# earth using the project wave function.
+hp.start_time = hc.start_time = time
+ht = d.project_wave(hp, hc, ra, dec, pol)

--- a/examples/detector/ant.py
+++ b/examples/detector/ant.py
@@ -8,7 +8,7 @@ pol = 0.2
 inc = 0
 time = 1000000000
 
-# We can calcualate the antenna pattern for Hanford at 
+# We can calcualate the antenna pattern for Hanford at
 # the specific sky location
 d = Detector("H1")
 
@@ -21,9 +21,9 @@ print("fp={}, fc={}".format(fp, fc))
 
 ## Generate a waveform
 hp, hc = get_td_waveform(approximant="IMRPhenomD", mass1=10, mass2=10,
-                         f_lower=30, delta_t=1.0/4096, inclination=inc, 
+                         f_lower=30, delta_t=1.0/4096, inclination=inc,
                          distance=400)
-                         
+
 ## Apply the factors to get the detector frame strain
 ht = fp * hp + fc * hc
 

--- a/examples/detector/delay.py
+++ b/examples/detector/delay.py
@@ -1,0 +1,20 @@
+from pycbc.detector import Detector
+
+# The source of the gravitational waves
+right_ascension = 0.7
+declination = -0.5
+
+# Reference location will be the Hanford detector
+# see the `time_delay_from_earth_center` method to use use geocentric time
+# as the reference
+dref = Detector("H1")
+
+# Time in GPS seconds that the GW passes
+time = 100000000
+
+# Time that the GW will (or has) passed through the given detector
+for ifo in ["H1", "L1", "V1"]:
+    d = Detector(ifo)
+    dt = d.time_delay_from_detector(dref, right_ascension, declination, time)
+    st = "GW passed through {} {} seconds relative to passing by Hanford"
+    print(st.format(ifo, dt))

--- a/examples/detector/loc.py
+++ b/examples/detector/loc.py
@@ -1,0 +1,13 @@
+from pycbc.detector import Detector, get_available_detectors
+
+# We can list the available detectors. This gives their detector abbreviation
+# along with a longer name. Note that some of these are not physical detectors
+# but may be useful for testing or study purposes
+
+for abv, long_name in get_available_detectors():
+    d = Detector(abv)
+    
+    # Note that units are all in radians
+    print("{} {} Latitude {} Longitude {}".format(long_name, abv,
+                                                  d.latitude,
+                                                  d.longitude))

--- a/examples/detector/loc.py
+++ b/examples/detector/loc.py
@@ -6,7 +6,7 @@ from pycbc.detector import Detector, get_available_detectors
 
 for abv, long_name in get_available_detectors():
     d = Detector(abv)
-    
+
     # Note that units are all in radians
     print("{} {} Latitude {} Longitude {}".format(long_name, abv,
                                                   d.latitude,

--- a/examples/detector/travel.py
+++ b/examples/detector/travel.py
@@ -1,0 +1,6 @@
+from pycbc.detector import Detector
+
+for ifo1 in ['H1', 'L1', 'V1']:
+    for ifo2 in ['H1', 'L1', 'V1']:
+        dt = Detector(ifo1).light_travel_time_to_detector(Detector(ifo2))
+        print("Direct Time from {} to {} is {} seconds".format(ifo1, ifo2, dt))

--- a/pycbc/__init__.py
+++ b/pycbc/__init__.py
@@ -25,15 +25,12 @@
 """PyCBC contains a toolkit for CBC gravitational wave analysis
 """
 from __future__ import (absolute_import, print_function)
+import subprocess, os, sys, tempfile, signal, warnings
 
 # Filter annoying Cython warnings that serve no good purpose.
-import warnings
 warnings.filterwarnings("ignore", message="numpy.dtype size changed")
 warnings.filterwarnings("ignore", message="numpy.ufunc size changed")
-
-import subprocess, os, sys, tempfile
 import logging
-import signal
 
 try:
     # This will fail when pycbc is imported during the build process,

--- a/pycbc/__init__.py
+++ b/pycbc/__init__.py
@@ -25,6 +25,12 @@
 """PyCBC contains a toolkit for CBC gravitational wave analysis
 """
 from __future__ import (absolute_import, print_function)
+
+# Filter annoying Cython warnings that serve no good purpose.
+import warnings
+warnings.filterwarnings("ignore", message="numpy.dtype size changed")
+warnings.filterwarnings("ignore", message="numpy.ufunc size changed")
+
 import subprocess, os, sys, tempfile
 import logging
 import signal

--- a/pycbc/detector.py
+++ b/pycbc/detector.py
@@ -185,11 +185,10 @@ class Detector(object):
                                              t_gps)
 
     def project_wave(self, hp, hc, longitude, latitude, polarization):
-        """Return the strain of a wave with given amplitudes and angles as
-        measured by the detector.
+        """Return the strain of a waveform as measured by the detector.
         
-        Apply the time shift for the given detector relative to the geocentric
-        frame and apply the antenna patterns to the pluss and cross 
+        Apply the time shift for the given detector relative to the assumed
+        geocentric frame and apply the antenna patterns to the plus and cross 
         polarizations.
         
         """

--- a/pycbc/detector.py
+++ b/pycbc/detector.py
@@ -181,7 +181,6 @@ class Detector(object):
         dx = other_location - self.location
         return dx.dot(ehat) / constants.c.value
 
-
     def time_delay_from_detector(self, other_detector, right_ascension,
                                  declination, t_gps):
         """Return the time delay from the given to detector for a signal with

--- a/pycbc/detector.py
+++ b/pycbc/detector.py
@@ -156,7 +156,9 @@ class Detector(object):
         """Return the optimal orientation in right ascension and declination
            for a given GPS time.
         """
-        ra = self.longitude + (lal.GreenwichMeanSiderealTime(t_gps) % (2*np.pi))
+        gmst = Time(t_gps, format='gps',
+                    location=(0, 0)).sidereal_time('mean').rad
+        ra = self.longitude + (gmst % (2.0*np.pi))
         dec = self.latitude
         return ra, dec
 

--- a/pycbc/detector.py
+++ b/pycbc/detector.py
@@ -28,9 +28,9 @@
 import lalsimulation
 import numpy as np
 import lal
-from numpy import cos, sin
 from pycbc.types import TimeSeries
 from astropy.time import Time
+from astropy import constants
 
 
 def get_available_detectors():
@@ -76,7 +76,8 @@ class Detector(object):
         time: float
             The light travel time in seconds
         """
-        return lal.LightTravelTime(self.frDetector, det.frDetector) * 1e-9
+        d = self.location - det.location
+        return d.dot(d)**0.5 / constants.c
 
     def antenna_pattern(self, right_ascension, declination, polarization, t_gps):
         """Return the detector response.

--- a/pycbc/detector.py
+++ b/pycbc/detector.py
@@ -86,7 +86,7 @@ class Detector(object):
 
     def antenna_pattern(self, right_ascension, declination, polarization, t_gps):
         """Return the detector response.
-        
+
         Parameters
         ----------
         right_ascension: float or numpy.ndarray
@@ -95,7 +95,7 @@ class Detector(object):
             The declination of the source
         polarization: float or numpy.ndarray
             The polarization angle of the source
-        
+
         Returns
         -------
         fplus: float or numpy.ndarray
@@ -105,7 +105,7 @@ class Detector(object):
         """
         gmst = Time(t_gps, format='gps', location=(0, 0))
         gha = gmst.sidereal_time('mean').rad - right_ascension
-        
+
         cosgha = cos(gha)
         singha = sin(gha)
         cosdec = cos(declination)
@@ -117,7 +117,7 @@ class Detector(object):
         x1 = -cospsi * cosgha + sinpsi * singha * sindec
         x2 =  sinpsi * cosdec
         x = np.array([x0, x1, x2])
-        
+
         dx = self.response.dot(x)
 
         y0 =  sinpsi * singha - cospsi * cosgha * sindec
@@ -125,14 +125,14 @@ class Detector(object):
         y2 =  cospsi * cosdec
         y = np.array([y0, y1, y2])
         dy = self.response.dot(y)
-        
+
         if hasattr(dx, 'shape'):
             fplus = (x * dx - y * dy).sum(axis=0)
             fcross = (x * dy + y * dx).sum(axis=0)
         else:
             fplus = (x * dx - y * dy).sum()
             fcross = (x * dy + y * dx).sum()
-        
+
         return fplus, fcross
 
     def time_delay_from_earth_center(self, right_ascension, declination, t_gps):
@@ -144,10 +144,10 @@ class Detector(object):
                                              t_gps)
 
     def time_delay_from_location(self, other_location, right_ascension,
-                                  declination, t_gps):
+                                 declination, t_gps):
         """Return the time delay from the given location to detector for
         a signal with the given sky location
-        
+
         In other words return `t1 - t2` where `t1` is the
         arrival time in this detector and `t2` is the arrival time in the
         other location.
@@ -172,11 +172,11 @@ class Detector(object):
                     location=(0, 0)).sidereal_time('mean').rad
         ra_angle = gmst - right_ascension
         cosd = cos(declination)
-        
+
         e0 = cosd * cos(ra_angle)
         e1 = cosd * -sin(ra_angle)
         e2 = sin(declination)
-        
+
         ehat = np.array([e0, e1, e2])
         dx = other_location - self.location
         return dx.dot(ehat) / constants.c.value
@@ -213,11 +213,11 @@ class Detector(object):
 
     def project_wave(self, hp, hc, longitude, latitude, polarization):
         """Return the strain of a waveform as measured by the detector.
-        
+
         Apply the time shift for the given detector relative to the assumed
-        geocentric frame and apply the antenna patterns to the plus and cross 
+        geocentric frame and apply the antenna patterns to the plus and cross
         polarizations.
-        
+
         """
         h_lal = lalsimulation.SimDetectorStrainREAL8TimeSeries(
                 hp.astype(np.float64).lal(), hc.astype(np.float64).lal(),
@@ -229,12 +229,12 @@ class Detector(object):
     def optimal_orientation(self, t_gps):
         """Return the optimal orientation in right ascension and declination
            for a given GPS time.
-           
+
         Parameters
         ----------
         t_gps: float
             Time in gps seconds
-            
+
         Returns
         -------
         ra: float

--- a/pycbc/detector.py
+++ b/pycbc/detector.py
@@ -187,6 +187,11 @@ class Detector(object):
     def project_wave(self, hp, hc, longitude, latitude, polarization):
         """Return the strain of a wave with given amplitudes and angles as
         measured by the detector.
+        
+        Apply the time shift for the given detector relative to the geocentric
+        frame and apply the antenna patterns to the pluss and cross 
+        polarizations.
+        
         """
         h_lal = lalsimulation.SimDetectorStrainREAL8TimeSeries(
                 hp.astype(np.float64).lal(), hc.astype(np.float64).lal(),

--- a/pycbc/detector.py
+++ b/pycbc/detector.py
@@ -32,6 +32,7 @@ import lal
 from pycbc.types import TimeSeries
 from astropy.time import Time
 from astropy import constants
+from numpy import cos, sin
 
 def get_available_detectors():
     """Return list of detectors known in the currently sourced lalsuite.
@@ -77,7 +78,7 @@ class Detector(object):
             The light travel time in seconds
         """
         d = self.location - det.location
-        return d.dot(d)**0.5 / constants.c
+        return float(d.dot(d)**0.5 / constants.c.value)
 
     def antenna_pattern(self, right_ascension, declination, polarization, t_gps):
         """Return the detector response.
@@ -111,7 +112,7 @@ class Detector(object):
     def time_delay_from_earth_center(self, right_ascension, declination, t_gps):
         """Return the time delay from the earth center
         """
-        return self.time_delay_from_location(numpy.array([0, 0, 0]),
+        return self.time_delay_from_location(np.array([0, 0, 0]),
                                              right_ascension,
                                              declination,
                                              t_gps)
@@ -150,9 +151,9 @@ class Detector(object):
         e1 = cosd * -sin(ra_angle)
         e2 = sin(declination)
         
-        ehat = numpy.array([e0, e1, e2])
+        ehat = np.array([e0, e1, e2])
         dx = other_location - self.location
-        return ehat.dot(dx) / constants.c
+        return float(ehat.dot(dx) / constants.c.value)
 
 
     def time_delay_from_detector(self, other_detector, right_ascension,

--- a/pycbc/detector.py
+++ b/pycbc/detector.py
@@ -34,6 +34,10 @@ from astropy.time import Time
 from astropy import constants
 from numpy import cos, sin
 
+# Response functions are modelled after those in lalsuite and as also 
+# presented in https://arxiv.org/pdf/gr-qc/0008066.pdf
+
+
 def get_available_detectors():
     """Return list of detectors known in the currently sourced lalsuite.
 
@@ -82,6 +86,22 @@ class Detector(object):
 
     def antenna_pattern(self, right_ascension, declination, polarization, t_gps):
         """Return the detector response.
+        
+        Parameters
+        ----------
+        right_ascension: float or numpy.ndarray
+            The right ascension of the source
+        declination: float or numpy.ndarray
+            The declination of the source
+        polarization: float or numpy.ndarray
+            The polarization angle of the source
+        
+        Returns
+        -------
+        fplus: float or numpy.ndarray
+            The plus polarization factor for this sky location / orientation
+        fcross: float or numpy.ndarray
+            The cross polarization factor for this sky location / orientation
         """
         gmst = Time(t_gps, format='gps', location=(0, 0))
         gha = gmst.sidereal_time('mean').rad - right_ascension
@@ -209,6 +229,18 @@ class Detector(object):
     def optimal_orientation(self, t_gps):
         """Return the optimal orientation in right ascension and declination
            for a given GPS time.
+           
+        Parameters
+        ----------
+        t_gps: float
+            Time in gps seconds
+            
+        Returns
+        -------
+        ra: float
+            Right ascension that is optimally oriented for the detector
+        dec: float
+            Declination that is optimally oriented for the detector
         """
         gmst = Time(t_gps, format='gps',
                     location=(0, 0)).sidereal_time('mean').rad

--- a/pycbc/detector.py
+++ b/pycbc/detector.py
@@ -34,7 +34,7 @@ from astropy.time import Time
 from astropy import constants
 from numpy import cos, sin
 
-# Response functions are modelled after those in lalsuite and as also 
+# Response functions are modelled after those in lalsuite and as also
 # presented in https://arxiv.org/pdf/gr-qc/0008066.pdf
 
 

--- a/pycbc/detector.py
+++ b/pycbc/detector.py
@@ -97,16 +97,22 @@ class Detector(object):
         x1 = -cospsi * cosgha + sinpsi * singha * sindec
         x2 =  sinpsi * cosdec
         x = np.array([x0, x1, x2])
-        dx = resp.dot(x)
+        
+        dx = self.response.dot(x)
 
         y0 =  sinpsi * singha - cospsi * cosgha * sindec
         y1 =  sinpsi * cosgha + cospsi * singha * sindec
         y2 =  cospsi * cosdec
         y = np.array([y0, y1, y2])
-        dy = resp.dot(y)
+        dy = self.response.dot(y)
         
-        fplus = (x * dx - y * dy).sum()
-        fcross = (x * dy + y * dx).sum()
+        if hasattr(dx, 'shape'):
+            fplus = (x * dx - y * dy).sum(axis=0)
+            fcross = (x * dy + y * dx).sum(axis=0)
+        else:
+            fplus = (x * dx - y * dy).sum()
+            fcross = (x * dy + y * dx).sum()
+        
         return fplus, fcross
 
     def time_delay_from_earth_center(self, right_ascension, declination, t_gps):
@@ -153,7 +159,7 @@ class Detector(object):
         
         ehat = np.array([e0, e1, e2])
         dx = other_location - self.location
-        return float(ehat.dot(dx) / constants.c.value)
+        return dx.dot(ehat) / constants.c.value
 
 
     def time_delay_from_detector(self, other_detector, right_ascension,

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ lscsoft-glue>=1.59.3
 weave>=0.16.0
 requests>=1.2.1
 beautifulsoup4>=4.6.0
-six
+six>1.10.0
 cython
 ligo-segments
 

--- a/test/test_detector.py
+++ b/test/test_detector.py
@@ -1,0 +1,110 @@
+# Copyright (C) 2018 Alex Nitz
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+#
+# =============================================================================
+#
+#                                   Preamble
+#
+# =============================================================================
+#
+"""
+These are the unittests for the pycbc.waveform module
+"""
+from __future__ import print_function
+import pycbc.detector as det
+import unittest, numpy
+from numpy.random import uniform, seed
+seed(0)
+
+# We require lal as a reference comparison
+import lal
+
+from utils import parse_args_all_schemes, simple_exit
+
+class TestDetector(unittest.TestCase):
+    def setUp(self,*args):
+        self.d = [det.Detector(ifo)
+                  for ifo, name in det.get_available_detectors()]
+                
+        # not distributed sanely, but should provide some good coverage  
+        N = 1000
+        self.ra = uniform(0, numpy.pi * 2, size=N)
+        self.dec = uniform(-numpy.pi, numpy.pi, size=N)
+        self.pol = uniform(0, numpy.pi * 2, size=N)
+        self.time = uniform(1000000000.0, 1500000000.0, size=N)
+
+    def test_light_time(self):
+        for d1 in self.d:
+            for d2 in self.d:
+                t1 = lal.LightTravelTime(d1.frDetector, d2.frDetector) * 1e-9
+                t2 = d1.light_travel_time_to_detector(d2)
+                self.assertAlmostEqual(t1, t2, 7)
+               
+    def test_antenna_pattern(self):
+        vals = zip(self.ra, self.dec, self.pol, self.time)
+        for det in self.d:
+            fp = []
+            fc = []
+            for ra1, dec1, pol1, time1 in vals:
+                gmst = lal.GreenwichMeanSiderealTime(time1)
+                fp1, fc1 = tuple(lal.ComputeDetAMResponse(det.response, ra1, dec1, pol1, gmst))
+                fp.append(fp1)
+                fc.append(fc1)
+            
+            fp2, fc2 = det.antenna_pattern(self.ra, self.dec, self.pol, self.time)
+            
+            fp = numpy.array(fp)
+            fc = numpy.array(fc)
+
+            diff1 = fp - fp2
+            diff2 = fc - fc2
+            diff = abs(numpy.concatenate([diff1, diff2]))
+            tolerance = 1e-4
+            print("Max antenna diff:", det.name, diff.max())
+            
+            self.assertLess(diff.max(), tolerance)
+
+    def test_delay_from_detector(self):
+        ra, dec, time = self.ra[0:10], self.dec[0:10], self.time[0:10]
+        for d1 in self.d:
+            for d2 in self.d:
+                time1 = []
+                for ra1, dec1, tim1 in zip(ra, dec, time):
+                    t1 = lal.ArrivalTimeDiff(d1.location, d2.location,
+                                             ra1, dec1, tim1) 
+                    time1.append(t1)
+                time1 = numpy.array(time1)
+                time2 = d1.time_delay_from_detector(d2, ra, dec, time)
+                self.assertLess(abs(time1 - time2).max(), 1e-4)
+                
+    def test_optimal_orientation(self):
+        for d1 in self.d:
+            ra, dec = d1.optimal_orientation(self.time[0])
+            ra1 = d1.longitude + lal.GreenwichMeanSiderealTime(self.time[0]) % (numpy.pi *2)
+            dec1 = d1.latitude
+            
+            self.assertAlmostEqual(ra, ra1, 4)
+            self.assertAlmostEqual(dec, dec1, 7)
+                    
+        
+
+suite = unittest.TestSuite()
+suite.addTest(unittest.TestLoader().loadTestsFromTestCase(TestDetector))
+
+if __name__ == '__main__':
+    results = unittest.TextTestRunner(verbosity=2).run(suite)
+    simple_exit(results)

--- a/test/test_detector.py
+++ b/test/test_detector.py
@@ -33,14 +33,14 @@ seed(0)
 # We require lal as a reference comparison
 import lal
 
-from utils import parse_args_all_schemes, simple_exit
+from utils simple_exit
 
 class TestDetector(unittest.TestCase):
-    def setUp(self,*args):
+    def setUp(self):
         self.d = [det.Detector(ifo)
                   for ifo, name in det.get_available_detectors()]
-                
-        # not distributed sanely, but should provide some good coverage  
+
+        # not distributed sanely, but should provide some good coverage
         N = 1000
         self.ra = uniform(0, numpy.pi * 2, size=N)
         self.dec = uniform(-numpy.pi, numpy.pi, size=N)
@@ -53,20 +53,20 @@ class TestDetector(unittest.TestCase):
                 t1 = lal.LightTravelTime(d1.frDetector, d2.frDetector) * 1e-9
                 t2 = d1.light_travel_time_to_detector(d2)
                 self.assertAlmostEqual(t1, t2, 7)
-               
+
     def test_antenna_pattern(self):
         vals = zip(self.ra, self.dec, self.pol, self.time)
-        for det in self.d:
+        for ifo in self.d:
             fp = []
             fc = []
             for ra1, dec1, pol1, time1 in vals:
                 gmst = lal.GreenwichMeanSiderealTime(time1)
-                fp1, fc1 = tuple(lal.ComputeDetAMResponse(det.response, ra1, dec1, pol1, gmst))
+                fp1, fc1 = tuple(lal.ComputeDetAMResponse(ifo.response, ra1, dec1, pol1, gmst))
                 fp.append(fp1)
                 fc.append(fc1)
-            
-            fp2, fc2 = det.antenna_pattern(self.ra, self.dec, self.pol, self.time)
-            
+
+            fp2, fc2 = ifo.antenna_pattern(self.ra, self.dec, self.pol, self.time)
+
             fp = numpy.array(fp)
             fc = numpy.array(fc)
 
@@ -74,7 +74,7 @@ class TestDetector(unittest.TestCase):
             diff2 = fc - fc2
             diff = abs(numpy.concatenate([diff1, diff2]))
             tolerance = 1e-4
-            print("Max antenna diff:", det.name, diff.max())
+            print("Max antenna diff:", ifo.name, diff.max())
             
             self.assertLess(diff.max(), tolerance)
 
@@ -85,22 +85,21 @@ class TestDetector(unittest.TestCase):
                 time1 = []
                 for ra1, dec1, tim1 in zip(ra, dec, time):
                     t1 = lal.ArrivalTimeDiff(d1.location, d2.location,
-                                             ra1, dec1, tim1) 
+                                             ra1, dec1, tim1)
                     time1.append(t1)
                 time1 = numpy.array(time1)
                 time2 = d1.time_delay_from_detector(d2, ra, dec, time)
                 self.assertLess(abs(time1 - time2).max(), 1e-4)
-                
+
     def test_optimal_orientation(self):
         for d1 in self.d:
             ra, dec = d1.optimal_orientation(self.time[0])
             ra1 = d1.longitude + lal.GreenwichMeanSiderealTime(self.time[0]) % (numpy.pi *2)
             dec1 = d1.latitude
-            
+
             self.assertAlmostEqual(ra, ra1, 4)
             self.assertAlmostEqual(dec, dec1, 7)
-                    
-        
+
 
 suite = unittest.TestSuite()
 suite.addTest(unittest.TestLoader().loadTestsFromTestCase(TestDetector))

--- a/test/test_detector.py
+++ b/test/test_detector.py
@@ -33,7 +33,7 @@ seed(0)
 # We require lal as a reference comparison
 import lal
 
-from utils simple_exit
+from utils import simple_exit
 
 class TestDetector(unittest.TestCase):
     def setUp(self):

--- a/tools/einsteinathome/pycbc_build_eah.sh
+++ b/tools/einsteinathome/pycbc_build_eah.sh
@@ -1562,6 +1562,8 @@ if $build_onefile_bundles; then
     echo -e "\\n\\n>> [`date`] building pycbc_inspiral_osg pyinstaller onefile spec" >&3
     pyi-makespec \
         --additional-hooks-dir $hooks/hooks \
+        --exclude-module astropy \
+        --add-data `python -c 'import astropy; print astropy.__path__[0],'`:astropy
         --runtime-hook $hooks/runtime-tkinter.py \
         --hidden-import=pkg_resources $hidden_imports \
         --onefile ./bin/pycbc_inspiral --name pycbc_inspiral_osg

--- a/tools/einsteinathome/pycbc_build_eah.sh
+++ b/tools/einsteinathome/pycbc_build_eah.sh
@@ -1119,7 +1119,7 @@ mkdir -p "$ENVIRONMENT/dist"
 # if the build machine has dbhash & shelve, scipy weave will use bsddb
 # make sure these exist and get added to the bundle(s)
 python -c "import dbhash, shelve"
-hidden_imports="--hidden-import=dbhash --hidden-import=shelve"
+hidden_imports="--hidden-import=dbhash --hidden-import=shelve --hidden-import=six"
 
 # PyInstaller
 if echo "$pyinstaller_version" | egrep '^[0-9]\.[0-9][0-9]*$' > /dev/null; then

--- a/tools/einsteinathome/pycbc_build_eah.sh
+++ b/tools/einsteinathome/pycbc_build_eah.sh
@@ -1119,7 +1119,7 @@ mkdir -p "$ENVIRONMENT/dist"
 # if the build machine has dbhash & shelve, scipy weave will use bsddb
 # make sure these exist and get added to the bundle(s)
 python -c "import dbhash, shelve"
-hidden_imports="--hidden-import=dbhash --hidden-import=shelve --hidden-import=six"
+hidden_imports="--hidden-import=dbhash --hidden-import=shelve --hidden-import=six --hidden-import=cmath"
 
 # PyInstaller
 if echo "$pyinstaller_version" | egrep '^[0-9]\.[0-9][0-9]*$' > /dev/null; then

--- a/tools/einsteinathome/pycbc_build_eah.sh
+++ b/tools/einsteinathome/pycbc_build_eah.sh
@@ -1240,7 +1240,7 @@ if $use_pycbc_pyinstaller_hooks; then
     pyi-makespec $upx \
         --additional-hooks-dir $hooks/hooks \
          --exclude-module astropy \
-        --add-data `python -c 'import astropy; print astropy.__path__[0],'`:astropy
+        --add-data `python -c 'import astropy; print astropy.__path__[0],'`:astropy \
         --runtime-hook $hooks/runtime-tkinter.py $hidden_imports \
         --hidden-import=pkg_resources \
         --onedir --name pycbc_inspiral$ext ./bin/pycbc_inspiral

--- a/tools/einsteinathome/pycbc_build_eah.sh
+++ b/tools/einsteinathome/pycbc_build_eah.sh
@@ -1239,13 +1239,17 @@ if $use_pycbc_pyinstaller_hooks; then
     export PYCBC_HOOKS_DIR="$hooks"
     pyi-makespec $upx \
         --additional-hooks-dir $hooks/hooks \
+         --exclude-module astropy \
+        --add-data `python -c 'import astropy; print astropy.__path__[0],'`:astropy
         --runtime-hook $hooks/runtime-tkinter.py $hidden_imports \
         --hidden-import=pkg_resources \
         --onedir --name pycbc_inspiral$ext ./bin/pycbc_inspiral
 else
     # find hidden imports (pycbc CPU modules)
     hidden_imports=`find $PREFIX/lib/python2.7/site-packages/pycbc/ -name '*_cpu.py' | sed 's%.*/site-packages/%%;s%\.py$%%;s%/%.%g;s%^% --hidden-import=%' | tr -d '\012'`
-    pyi-makespec $upx $hidden_imports --hidden-import=scipy.linalg.cython_blas --hidden-import=scipy.linalg.cython_lapack --hidden-import=pkg_resources --onedir --name pycbc_inspiral$ext ./bin/pycbc_inspiral
+    pyi-makespec $upx $hidden_imports --hidden-import=scipy.linalg.cython_blas --hidden-import=scipy.linalg.cython_lapack --hidden-import=pkg_resources --onedir --name pycbc_inspiral$ext ./bin/pycbc_inspiral \
+            --exclude-module astropy \
+        --add-data `python -c 'import astropy; print astropy.__path__[0],'`:astropy
 fi
 # patch spec file to add "-v" to python interpreter options
 if $verbose_pyinstalled_python; then

--- a/tools/einsteinathome/pycbc_build_eah.sh
+++ b/tools/einsteinathome/pycbc_build_eah.sh
@@ -1563,7 +1563,7 @@ if $build_onefile_bundles; then
     pyi-makespec \
         --additional-hooks-dir $hooks/hooks \
         --exclude-module astropy \
-        --add-data `python -c 'import astropy; print astropy.__path__[0],'`:astropy
+        --add-data `python -c 'import astropy; print astropy.__path__[0],'`:astropy \
         --runtime-hook $hooks/runtime-tkinter.py \
         --hidden-import=pkg_resources $hidden_imports \
         --onefile ./bin/pycbc_inspiral --name pycbc_inspiral_osg

--- a/tools/einsteinathome/pycbc_build_eah.sh
+++ b/tools/einsteinathome/pycbc_build_eah.sh
@@ -1237,7 +1237,11 @@ fi
 if $use_pycbc_pyinstaller_hooks; then
     export NOW_BUILDING=NULL
     export PYCBC_HOOKS_DIR="$hooks"
-    pyi-makespec $upx --additional-hooks-dir $hooks/hooks --runtime-hook $hooks/runtime-tkinter.py $hidden_imports --hidden-import=pkg_resources --onedir --name pycbc_inspiral$ext ./bin/pycbc_inspiral
+    pyi-makespec $upx \
+        --additional-hooks-dir $hooks/hooks \
+        --runtime-hook $hooks/runtime-tkinter.py $hidden_imports \
+        --hidden-import=pkg_resources \
+        --onedir --name pycbc_inspiral$ext ./bin/pycbc_inspiral
 else
     # find hidden imports (pycbc CPU modules)
     hidden_imports=`find $PREFIX/lib/python2.7/site-packages/pycbc/ -name '*_cpu.py' | sed 's%.*/site-packages/%%;s%\.py$%%;s%/%.%g;s%^% --hidden-import=%' | tr -d '\012'`
@@ -1249,7 +1253,9 @@ if $verbose_pyinstalled_python; then
 exe = EXE(pyz, options,%' pycbc_inspiral$ext.spec
 fi
 echo -e "\\n\\n>> [`date`] running pyinstaller" >&3
-pyinstaller $upx pycbc_inspiral$ext.spec
+pyinstaller $upx pycbc_inspiral$ext.spec \
+        --exclude-module astropy \
+        --add-data `python -c 'import astropy; print astropy.__path__[0],'`:astropy
 
 test ".$ext" != "." &&
     mv dist/pycbc_inspiral$ext dist/pycbc_inspiral

--- a/tools/einsteinathome/pycbc_build_eah.sh
+++ b/tools/einsteinathome/pycbc_build_eah.sh
@@ -1585,7 +1585,9 @@ if $build_onefile_bundles; then
         pycbc_inspiral_osg.spec1 > pycbc_inspiral_osg.spec
 
     echo -e ">> [`date`] running pyinstaller" >&3
-    pyinstaller pycbc_inspiral_osg.spec
+    pyinstaller pycbc_inspiral_osg.spec \
+                --exclude-module astropy \
+                --add-data `python -c 'import astropy; print astropy.__path__[0],'`:astropy
 
     if echo ".$pycbc_tag" | egrep '^\.v[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*$' >/dev/null; then
         mv dist/pycbc_inspiral_osg "dist/pycbc_inspiral_osg_$pycbc_tag"


### PR DESCRIPTION
* Make several methods more pythonic and allow vector input
* Switch to python for several methods and rely on astropy for more accurate sidereal time
* Add unit tests for the detector module
* Add examples and associated docs

Note, that the injection path is not changed and will still call into lal functions for now. The antenna pattern functions will agree to some precision to the lal ones, but should be more accurate as the sidereal time calculation is less of an approximation when using astropy vs lalsuite.