### PR TITLE
remove debug print statement

### DIFF
--- a/pycbc/scheme.py
+++ b/pycbc/scheme.py
@@ -177,7 +177,6 @@ def schemed(prefix):
                     backend = __import__(prefix + scheme_prefix[sch], fromlist=[fn.__name__])
                     schemed_fn = getattr(backend, fn.__name__)
                 except (ImportError, AttributeError) as e:
-                    print(e)
                     continue
 
                 if mgr.state not in _import_cache:

--- a/pycbc/scheme.py
+++ b/pycbc/scheme.py
@@ -176,7 +176,7 @@ def schemed(prefix):
                 try:
                     backend = __import__(prefix + scheme_prefix[sch], fromlist=[fn.__name__])
                     schemed_fn = getattr(backend, fn.__name__)
-                except (ImportError, AttributeError) as e:
+                except (ImportError, AttributeError):
                     continue
 
                 if mgr.state not in _import_cache:


### PR DESCRIPTION
@soumide1102 This was the source of the 'array_mkl' print statements you were seeing. Sorry, this was a holdover debug statement. This patch removes that message. 