### PR TITLE
Allow mode array support in injection hdf files and fix bug with current implementation

### DIFF
--- a/pycbc/inject/inject.py
+++ b/pycbc/inject/inject.py
@@ -108,7 +108,18 @@ class _HDFInjectionSet(object):
         # we'll expand the static args to be arrays with the same size as
         # the other values
         for param in self.static_args:
-            injvals[param] = np.repeat(group.attrs[param], numinj)
+            val = group.attrs[param]
+            # if val is a list or numpy array, we need to store it as an
+            # object; otherwise, we'll get a shape mismatch between fields
+            if isinstance(val, (np.ndarray, list, tuple)):
+                arr = np.empty(numinj, dtype=object)
+                for ii in range(numinj):
+                    arr[ii] = val
+            else:
+                # otherwise, we can just repeat the value the needed number of
+                # times
+                arr = np.repeat(val, numinj)
+            injvals[param] = arr
         # make sure a coalescence time is specified for injections
         if 'tc' not in injvals:
             raise ValueError("no tc found in the given injection file; "

--- a/pycbc/waveform/parameters.py
+++ b/pycbc/waveform/parameters.py
@@ -441,7 +441,7 @@ side_bands = Parameter("side_bands",
                 dtype=int, default=0,
                 description="Flag for generating sidebands")
 mode_array = Parameter("mode_array",
-                dtype=int, default=0,
+                dtype=int, default=None,
                 description="Choose which (l,m) modes to include when "
                             "generating a waveform. "
                             "Only if approximant supports this feature."

--- a/pycbc/waveform/parameters.py
+++ b/pycbc/waveform/parameters.py
@@ -441,7 +441,7 @@ side_bands = Parameter("side_bands",
                 dtype=int, default=0,
                 description="Flag for generating sidebands")
 mode_array = Parameter("mode_array",
-                dtype=int, default=None,
+                dtype=list, default=None,
                 description="Choose which (l,m) modes to include when "
                             "generating a waveform. "
                             "Only if approximant supports this feature."

--- a/pycbc/waveform/waveform.py
+++ b/pycbc/waveform/waveform.py
@@ -124,7 +124,7 @@ def _check_lal_pars(p):
         lalsimulation.SimInspiralWaveformParamsInsertFrameAxis(lal_pars, p['frame_axis'])
     if p['side_bands']:
         lalsimulation.SimInspiralWaveformParamsInsertSideband(lal_pars, p['side_bands'])
-    if p['mode_array']:
+    if p['mode_array'] is not None:
         ma = lalsimulation.SimInspiralCreateModeArray()
         for l,m in p['mode_array']:
             lalsimulation.SimInspiralModeArrayActivateMode(ma, l, m)


### PR DESCRIPTION
When loading an injection hdf file any static arguments stored in the hdf file's `.attrs` are expanded to an array using `numpy.repeat` and added as another field to `InjectionSet`'s `table`. This is problematic if the static argument is an array, list or tuple, as it would be for `mode_array`. In that case, the repeat ends up given a flattened array of integers, which is not what you want. For example, if a file had 8 injections in it and `mode_array = [(2, 2), (2, 1)]`, you end up with:
```
>>> ninj = 8
>>> mode_array = [(2,2), (2,1)]
>>> arr = numpy.repeat(mode_array, ninj)
>>> arr
array([2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
       2, 2, 1, 1, 1, 1, 1, 1, 1, 1])
>>> table = WaveformArray.from_kwargs(mode_array=arr)
>>> table[0].mode_array
2
```

This patch fixes this by setting the `dtype` of any static arg that is an array, list, or tuple to `object` when loading the injection file. Then when the table is created, that field will return the original list for a single injection:
```
>>> arr = numpy.empty(ninj, dtype=object)
>>> for ii in range(ninj):
...     arr[ii] = mode_array
>>> table = WaveformArray.from_kwargs(mode_array=arr)
>>> table[0].mode_array
[(2, 2), (2, 1)]
```

Also, in testing this, I found that the current way `mode_array` is checked for in `waveform._check_lal_pars` causes an error if `mode_array` is a numpy array. I fixed this by making the default `mode_array` be `None`, then have `_check_lal_params` check if it is not None.