### PR TITLE
resize fix for pycbc live, some additional debug options

### DIFF
--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/home/ahnitz/projects/plive/env/bin/python
 import argparse, numpy, pycbc, logging, cProfile, h5py, lal
 from pycbc import fft, version, waveform, scheme, frame
 from pycbc.types import MultiDetOptionAction
@@ -304,6 +304,12 @@ parser.add_argument('--round-start-time', type=int,
 parser.add_argument('--gracedb-server',
                     help="Location of gracedb server. If not provide, the "
                          "default location is used. ")
+parser.add_argument('--size-override', 
+                    help="Override the internal MPI size layout. "
+                         " Useful for debugging and running a portion of a bank",
+                    type=int)
+parser.add_argument('--fftw-planning-limit', type=float,
+                    help="Time is seconds to allow for a plan to be created")
 
 scheme.insert_processing_option_group(parser)
 LiveSingleFarThreshold.insert_args(parser)
@@ -342,6 +348,9 @@ evnt = LiveEventManager(args.output_path,
                         gracedb_testing=not args.enable_production_gracedb_upload,
                        )
 
+if args.size_override:
+    evnt.size=args.size_override
+
 # ifos used for primary analysis (only two at the moment)
 ifos = set(args.channel_name.keys())
 followup_ifos = set(args.followup_detectors)
@@ -371,8 +380,13 @@ with ctx:
 
         if args.fftw_input_double_wisdom_file is not None:
             fft.fftw.import_double_wisdom_from_filename(args.fftw_input_double_wisdom_file)
-    except RuntimeError:
-        pass
+
+        if args.fftw_planning_limit:
+            fft.fftw.set_planning_limit(args.fftw_planning_limit)
+    except (ValueError, RuntimeError) as e:
+        print(e)
+        exit()
+
 
     maxlen = args.psd_segment_length * (args.psd_samples / 2 + 1)
     if evnt.rank > 0:
@@ -534,11 +548,12 @@ with ctx:
         logging.info('%s: Took %1.2f, duty factor of %.2f', evnt.rank, tdiff, tdiff / valid_pad)
         i += 1
 
-if args.fftw_output_float_wisdom_file:
-    fft.fftw.export_single_wisdom_to_filename(args.fftw_output_float_wisdom_file)
+if evnt.rank == 1:
+    if args.fftw_output_float_wisdom_file:
+        fft.fftw.export_single_wisdom_to_filename(args.fftw_output_float_wisdom_file)
 
-if args.fftw_output_double_wisdom_file:
-    fft.fftw.export_double_wisdom_to_filename(args.fftw_output_double_wisdom_file)
+    if args.fftw_output_double_wisdom_file:
+        fft.fftw.export_double_wisdom_to_filename(args.fftw_output_double_wisdom_file)
 
-if args.enable_profiling is not None and args.enable_profiling == evnt.rank:
-    pr.dump_stats('log')
+    if args.enable_profiling:
+        pr.dump_stats('log')

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -1,4 +1,4 @@
-#!/home/ahnitz/projects/plive/env/bin/python
+#!/usr/bin/env python
 import argparse, numpy, pycbc, logging, cProfile, h5py, lal
 from pycbc import fft, version, waveform, scheme, frame
 from pycbc.types import MultiDetOptionAction

--- a/pycbc/events/coinc.py
+++ b/pycbc/events/coinc.py
@@ -379,8 +379,8 @@ class MultiRingBuffer(object):
             raise ValueError("The new size must be larger than the old one")
         self.straighten()
         self.pad_count = size
-        self.buffer.resize((self.num_rings, size))
-        self.buffer_expire.resize((self.num_rings, size))
+        self.buffer = numpy.resize(self.buffer, (self.num_rings, size))
+        self.buffer_expire = numpy.resize(self.buffer, (self.num_rings, size))
 
     @property
     def start_time(self):
@@ -804,7 +804,7 @@ class LiveCoincTimeslideBackgroundEstimator(object):
 
                 single_expire[oifo].append(self.singles[oifo].expire_vector(template)[i1])
                 single_expire[ifo].append(numpy.zeros(len(c),
-                                          dtype=numpy.float64))
+                                          dtype=numpy.int32))
                 single_expire[ifo][-1].fill(self.singles[ifo].expire - 1)
 
                 # save the template and trigger ids to keep association

--- a/pycbc/events/coinc.py
+++ b/pycbc/events/coinc.py
@@ -380,7 +380,7 @@ class MultiRingBuffer(object):
         self.straighten()
         self.pad_count = size
         self.buffer = numpy.resize(self.buffer, (self.num_rings, size))
-        self.buffer_expire = numpy.resize(self.buffer, (self.num_rings, size))
+        self.buffer_expire = numpy.resize(self.buffer_expire, (self.num_rings, size))
 
     @property
     def start_time(self):

--- a/pycbc/fft/fftw.py
+++ b/pycbc/fft/fftw.py
@@ -222,11 +222,11 @@ def set_planning_limit(time):
         set_threads_backend()
 
     f = double_lib.fftw_set_timelimit
-    f.argtypes= [ctypes.c_double]
+    f.argtypes = [ctypes.c_double]
     f(time)
 
     f = float_lib.fftwf_set_timelimit
-    f.argtypes= [ctypes.c_double]
+    f.argtypes = [ctypes.c_double]
     f(time)
 
 # Create function maps for the dtypes

--- a/pycbc/fft/fftw.py
+++ b/pycbc/fft/fftw.py
@@ -217,6 +217,18 @@ def export_double_wisdom_to_filename(filename):
     if retval == 0:
         raise RuntimeError("Could not export wisdom to file {0}".format(filename))
 
+def set_planning_limit(time):
+    if not _fftw_threaded_set:
+        set_threads_backend()
+
+    f = double_lib.fftw_set_timelimit
+    f.argtypes= [ctypes.c_double]
+    f(time)
+
+    f = float_lib.fftwf_set_timelimit
+    f.argtypes= [ctypes.c_double]
+    f(time)
+
 # Create function maps for the dtypes
 plan_function = {'float32': {'complex64': float_lib.fftwf_plan_dft_r2c_1d},
                  'float64': {'complex128': double_lib.fftw_plan_dft_r2c_1d},


### PR DESCRIPTION
This requires #2292. 

Add a fix for the resize issue in #2253 

- add option to make it easier to debug / make plans for pycbc live. I.E.
   - option to set fftw planning limit
   - option to simulate run configuration on 2 nodes (i.e. master + one of the computes)