### PR TITLE
Fix issue where injection is longer than filter length

### DIFF
--- a/bin/pycbc_single_template
+++ b/bin/pycbc_single_template
@@ -273,6 +273,14 @@ with ctx:
                                           method='ldas')
         td_template = td_template * pycbc.DYN_RANGE_FAC
         td_template._epoch -= inj.get_end(site=opt.channel_name[0])
+        # Check if waveform is too long
+        tlen = (flen-1) * 2
+        # FIXME: Hardcoded 7./8. factor here, but I'm not too bothered by this.
+        if len(td_template) > (7 * tlen /8):
+            new_start_idx = len(td_template) - (7 * tlen /8)
+            td_template = td_template[new_start_idx:]
+            taper_func = pycbc.waveform.utils.taper_timeseries
+            td_template = taper_func(td_template, tapermethod='TAPER_START')
         approximant = inj.waveform
         template = waveform.td_waveform_to_fd_waveform(td_template, length=flen)
         template = template.astype(complex_same_precision_as(segments[0]))

--- a/pycbc/waveform/waveform.py
+++ b/pycbc/waveform/waveform.py
@@ -924,6 +924,15 @@ def td_waveform_to_fd_waveform(waveform, out=None, length=None,
 
     # total duration of the waveform
     tmplt_length = len(waveform) * waveform.delta_t
+    if len(waveform) > N:
+        err_msg = "The time domain template is longer than the intended "
+        err_msg += "duration in the frequency domain. This situation is "
+        err_msg += "not supported in this function. Please shorten the "
+        err_msg += "waveform appropriately before calling this function or "
+        err_msg += "increase the allowed waveform length. "
+        err_msg += "Waveform length (in samples): {}".format(len(waveform))
+        err_msg += ". Intended length: {}.".format(N)
+        raise ValueError(err_msg)
     # for IMR templates the zero of time is at max amplitude (merger)
     # thus the start time is minus the duration of the template from
     # lower frequency cutoff to merger, i.e. minus the 'chirp time'


### PR DESCRIPTION
We're currently seeing an issue where `pycbc_single_template` will fail when running with "injection as filter mode" and when the injection is longer than the filter length. Not sure what broke this, as we've definitely run in this configuration before. However, probably this was doing something silly before. This patch does two things:

 * Raise an error in `td_waveform_to_fd_waveform` if the input TD waveform is longer than the filter length specified either with an output memory array of with an explicit length (without kwargs, the length is determined internally).
 * Cut the injection in `pycbc_single_template` if running with this option so that the jobs can succeed.