### PR TITLE
Prevent sampling_transforms from becoming all_transforms

### DIFF
--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -219,7 +219,7 @@ with ctx:
             'sampling_transforms')
         logging.info("Sampling in {} in place of {}".format(
             ', '.join(sampling_parameters), ', '.join(replace_parameters)))
-        all_transforms = sampling_transforms
+        all_transforms.extend(sampling_transforms)
     else:
         sampling_parameters = replace_parameters = sampling_transforms = None
 


### PR DESCRIPTION
If we use `all_transforms = sampling_transforms`, that leads to `sampling_transforms` becoming `all_transforms` which includes the `sampling_transforms` + `waveform_transforms`. These waveform_transforms included in sampling_transforms then want to behave like sampling_transforms making the code to fail.