### PR TITLE
Add ability to read beta values in emcee_pt from external file

### DIFF
--- a/pycbc/inference/option_utils.py
+++ b/pycbc/inference/option_utils.py
@@ -139,7 +139,7 @@ def add_sampler_option_group(parser):
     sampler_group.add_argument("--ntemps", type=int, default=None,
         help="Number of temperatures to use in sampler. Required for parallel "
              "tempered MCMC samplers.")
-    sampler_group.add_argument("--betas-input-file", type=str, default=None,
+    sampler_group.add_argument("--inverse-temperatures-input-file", type=str, default=None,
         help="Input hdf file from which beta (inverse-temperature) values "
              "should be read in. Applicable for emcee_pt samplers.")
     sampler_group.add_argument("--burn-in-function", default=None, nargs='+',

--- a/pycbc/inference/option_utils.py
+++ b/pycbc/inference/option_utils.py
@@ -139,6 +139,9 @@ def add_sampler_option_group(parser):
     sampler_group.add_argument("--ntemps", type=int, default=None,
         help="Number of temperatures to use in sampler. Required for parallel "
              "tempered MCMC samplers.")
+    sampler_group.add_argument("--betas-input-file", type=str, default=None,
+        help="Input file from which beta (inverse-temperature) values should be read "
+             "in. Applicable for emcee_pt samplers.")
     sampler_group.add_argument("--burn-in-function", default=None, nargs='+',
         choices=burn_in.burn_in_functions.keys(),
         help="Use the given function to determine when chains are burned in. "

--- a/pycbc/inference/option_utils.py
+++ b/pycbc/inference/option_utils.py
@@ -140,8 +140,8 @@ def add_sampler_option_group(parser):
         help="Number of temperatures to use in sampler. Required for parallel "
              "tempered MCMC samplers.")
     sampler_group.add_argument("--betas-input-file", type=str, default=None,
-        help="Input hdf file from which beta (inverse-temperature) values should be read "
-             "in. Applicable for emcee_pt samplers.")
+        help="Input hdf file from which beta (inverse-temperature) values "
+             "should be read in. Applicable for emcee_pt samplers.")
     sampler_group.add_argument("--burn-in-function", default=None, nargs='+',
         choices=burn_in.burn_in_functions.keys(),
         help="Use the given function to determine when chains are burned in. "

--- a/pycbc/inference/option_utils.py
+++ b/pycbc/inference/option_utils.py
@@ -139,7 +139,8 @@ def add_sampler_option_group(parser):
     sampler_group.add_argument("--ntemps", type=int, default=None,
         help="Number of temperatures to use in sampler. Required for parallel "
              "tempered MCMC samplers.")
-    sampler_group.add_argument("--inverse-temperatures-input-file", type=str, default=None,
+    sampler_group.add_argument("--inverse-temperatures-input-file", type=str,
+        default=None,
         help="Input hdf file from which beta (inverse-temperature) values "
              "should be read in. Applicable for emcee_pt samplers.")
     sampler_group.add_argument("--burn-in-function", default=None, nargs='+',

--- a/pycbc/inference/option_utils.py
+++ b/pycbc/inference/option_utils.py
@@ -140,7 +140,7 @@ def add_sampler_option_group(parser):
         help="Number of temperatures to use in sampler. Required for parallel "
              "tempered MCMC samplers.")
     sampler_group.add_argument("--betas-input-file", type=str, default=None,
-        help="Input file from which beta (inverse-temperature) values should be read "
+        help="Input hdf file from which beta (inverse-temperature) values should be read "
              "in. Applicable for emcee_pt samplers.")
     sampler_group.add_argument("--burn-in-function", default=None, nargs='+',
         choices=burn_in.burn_in_functions.keys(),

--- a/pycbc/inference/sampler_emcee.py
+++ b/pycbc/inference/sampler_emcee.py
@@ -308,12 +308,12 @@ class EmceePTSampler(BaseMCMCSampler):
             An emcee sampler initialized based on the given arguments.
         """
         import h5py
-        if opts.ntemps is not None and opts.betas_input_file is not None:
+        if opts.ntemps is not None and opts.inverse_temperatures_input_file is not None:
             raise ValueError("Must specify either ntemps or "
-                             "betas-input-file, not both.")
+                             "inverse-temperatures-input-file, not both.")
 
-        if opts.betas_input_file:
-            with h5py.File(opts.betas_input_file, "r") as fp:
+        if opts.inverse_temperatures_input_file:
+            with h5py.File(opts.inverse_temperatures_input_file, "r") as fp:
                 try:
                     betas = numpy.array(fp.attrs['betas'])
                     ntemps = betas.shape[0]

--- a/pycbc/inference/sampler_emcee.py
+++ b/pycbc/inference/sampler_emcee.py
@@ -313,12 +313,13 @@ class EmceePTSampler(BaseMCMCSampler):
                              "betas-input-file, not both.")
 
         if opts.betas_input_file:
-            try:
-                with h5py.File(opts.betas_input_file, "r") as fp:
+            with h5py.File(opts.betas_input_file, "r") as fp:
+                try:
                     betas = numpy.array(fp.attrs['betas'])
                     ntemps = betas.shape[0]
-            except AttributeError:
-                    raise AttributeError(e)
+                except KeyError:
+                    raise AttributeError("No attribute called betas")
+
         else:
             betas = None
             ntemps = opts.ntemps

--- a/pycbc/inference/sampler_emcee.py
+++ b/pycbc/inference/sampler_emcee.py
@@ -308,7 +308,8 @@ class EmceePTSampler(BaseMCMCSampler):
             An emcee sampler initialized based on the given arguments.
         """
         import h5py
-        if opts.ntemps is not None and opts.inverse_temperatures_input_file is not None:
+        if opts.ntemps is not None and \
+                opts.inverse_temperatures_input_file is not None:
             raise ValueError("Must specify either ntemps or "
                              "inverse-temperatures-input-file, not both.")
 

--- a/test/test_inference.py
+++ b/test/test_inference.py
@@ -91,7 +91,7 @@ class TestSamplers(unittest.TestCase):
             niterations = 4
             update_interval = 2
             nprocesses = 2
-            betas_input_file = None
+            inverse_temperatures_input_file = None
 
         self.opts = Arguments()
 

--- a/test/test_inference.py
+++ b/test/test_inference.py
@@ -91,6 +91,8 @@ class TestSamplers(unittest.TestCase):
             niterations = 4
             update_interval = 2
             nprocesses = 2
+            betas_input_file = None
+
         self.opts = Arguments()
 
     def get_cbc_fdomain_generator(self, approximant="IMRPhenomPv2", f_lower=30.0):


### PR DESCRIPTION
This PR gives `pycbc_inference` the ability to read beta values from an external hdf file which stores them in its attrs `betas`. The file is read in using the argument `--inverse-temperatures-input-file`. Either the `--inverse-temperatures-input-file` or `--ntemps` will work, but not both. So this does not take away anything from how it works now. 
If `--ntemps` is provided, pycbc_inference will let `emcee` calculate the betas like it does now.

If `--inverse-temperatures-input-file` is provided, the `betas` will be read in from this file.