### PR TITLE
allow to reset cache when new psd is generated

### DIFF
--- a/pycbc/filter/matchedfilter.py
+++ b/pycbc/filter/matchedfilter.py
@@ -1489,7 +1489,8 @@ class LiveBatchMatchedFilter(object):
         self.max_triggers_in_batch = max_triggers_in_batch
 
         from pycbc import vetoes
-        self.power_chisq = vetoes.SingleDetPowerChisq(chisq_bins, None)
+        self.power_chisq = vetoes.SingleDetPowerChisq(chisq_bins, None,
+                                                      fixed_cache=True)
 
         durations = numpy.array([1.0 / t.delta_f for t in templates])
 

--- a/pycbc/vetoes/chisq.py
+++ b/pycbc/vetoes/chisq.py
@@ -299,7 +299,7 @@ class SingleDetPowerChisq(object):
     """Class that handles precomputation and memory management for efficiently
     running the power chisq in a single detector inspiral analysis.
     """
-    def __init__(self, num_bins=0, snr_threshold=None):
+    def __init__(self, num_bins=0, snr_threshold=None, fixed_cache=False):
         if not (num_bins == "0" or num_bins == 0):
             self.do = True
             self.column_name = "chisq"
@@ -308,6 +308,7 @@ class SingleDetPowerChisq(object):
         else:
             self.do = False
         self.snr_threshold = snr_threshold
+        self.fixed_cache=fixed_cache
 
     @staticmethod
     def parse_option(row, arg):
@@ -321,6 +322,10 @@ class SingleDetPowerChisq(object):
         key = id(psd)
         if not hasattr(psd, '_chisq_cached_key'):
             psd._chisq_cached_key = {}
+            
+            # In this mode we reset the caches if we get a new PSD
+            if self.fixed_cache:
+                template._bin_cache = {}
 
         if not hasattr(template, '_bin_cache'):
             template._bin_cache = {}

--- a/pycbc/vetoes/chisq.py
+++ b/pycbc/vetoes/chisq.py
@@ -322,10 +322,6 @@ class SingleDetPowerChisq(object):
         key = id(psd)
         if not hasattr(psd, '_chisq_cached_key'):
             psd._chisq_cached_key = {}
-            
-            # In this mode we reset the caches if we get a new PSD
-            if self.fixed_cache:
-                template._bin_cache = {}
 
         if not hasattr(template, '_bin_cache'):
             template._bin_cache = {}
@@ -341,6 +337,11 @@ class SingleDetPowerChisq(object):
                     psd.sigmasq_vec[template.approximant], num_bins, kmin, kmax)
             else:
                 bins = power_chisq_bins(template, num_bins, psd, template.f_lower)
+                
+            # In this mode we reset the caches if we get a new PSD
+            if self.fixed_cache:
+                template._bin_cache = {}
+                
             template._bin_cache[key] = bins
 
         return template._bin_cache[key]


### PR DESCRIPTION
I don't know if this is a source of the memory leak you are seeing, but this is one case. When you generate a new PSD, the caches used to speed up the sigmasq generation are never reduced in size. They can only grow, even though we'll never use the old PSD again in this case. This adds an option to turn that off and does so for pycbc live.