### PR TITLE
Fix a deprecation issue in matplotlib

### DIFF
--- a/bin/hdfcoinc/pycbc_plot_range
+++ b/bin/hdfcoinc/pycbc_plot_range
@@ -63,7 +63,7 @@ for psd_file in args.psd_files:
         wf_key = (m1, m2, apx)
         pylab.errorbar((start+end)/2, ranges[wf_key], xerr=(end-start)/2,
                        ecolor=pycbc.results.ifo_color(ifo), label=label,
-                       fmt=None)
+                       fmt='none')
 pylab.legend(loc="best", fontsize='small')
 
 if len(args.approximant) == 1:

--- a/bin/hdfcoinc/pycbc_plot_range_vs_mtot
+++ b/bin/hdfcoinc/pycbc_plot_range_vs_mtot
@@ -70,7 +70,7 @@ for psd_file in args.psd_files:
 
     for apx in args.approximant:
         label = '%s-%s' % (ifo, apx)
-        plt.errorbar(mbin, avg_range, yerr=rangerr, ecolor=pycbc.results.ifo_color(ifo), label=label, fmt=None)  
+        plt.errorbar(mbin, avg_range, yerr=rangerr, ecolor=pycbc.results.ifo_color(ifo), label=label, fmt='none')  
         plt.plot(mbin, avg_range, color=pycbc.results.ifo_color(ifo))
   
 plt.legend(loc="upper left")        


### PR DESCRIPTION
This one should be pretty simple.

Matplotlib has now made it a failure if `fmt=None` is sent to the `plt.errorbar` function. This should now be `fmt='none'`. This has been deprecation warning since matplotlib 1.4, and we've been ignoring it. The fix is trivial and tested.