### PR TITLE
update to lalsuite 89a30fc and change base directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM pycbc/pycbc-base-el7:v1.7-0231cca
+FROM pycbc/pycbc-base-el7:v1.8-89a30fc
 
 USER pycbc
-WORKDIR /home/pycbc
+WORKDIR /opt/pycbc


### PR DESCRIPTION
This changes the docker image to use the 89a30fc lalsuite tag (it has been stuck at an old tag for a while) and changes the pycbc home directory to `/opt/pycbc` so the docker image can be converted to singularity.