### PR TITLE
cast ldiff to array to avoid TypeError

### DIFF
--- a/pycbc/conversions.py
+++ b/pycbc/conversions.py
@@ -381,7 +381,7 @@ def lambda_tilde(mass1, mass2, lambda1, lambda2):
     m1, m2, lambda1, lambda2, input_is_array = ensurearray(
         mass1, mass2, lambda1, lambda2)
     lsum = lambda1 + lambda2
-    ldiff = lambda1 - lambda2
+    ldiff, _ = ensurearray(lambda1 - lambda2)
     mask = m1 < m2
     ldiff[mask] = -ldiff[mask]
     eta = eta_from_mass1_mass2(m1, m2)


### PR DESCRIPTION
This patch fixes a bug in `pycbc.conversions.lambda_tilde` where calling the function with integer or float values for `lambda1` and `lambda2` would return a TypeError:
```
In [1]: from pycbc.conversions import lambda_tilde

In [2]: lambda_tilde(1.4, 1.4, 500., 500.)
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-2-284d36db949b> in <module>()
----> 1 lambda_tilde(1.4, 1.4, 500., 500.)

/home/daniel.finstad/src/pycbc/pycbc/conversions.py in lambda_tilde(mass1, mass2, lambda1, lambda2)
    384     ldiff = lambda1 - lambda2
    385     mask = m1 < m2
--> 386     ldiff[mask] = -ldiff[mask]
    387     eta = eta_from_mass1_mass2(m1, m2)
    388     p1 = (lsum) * (1 + 7. * eta - 31 * eta ** 2.0)

TypeError: 'numpy.float64' object does not support item assignment
```
Ensuring `ldiff = lambda1 - lambda2` is an array avoids this.