### PR TITLE
Save different low-frequency-cutoffs for each ifo in InferenceFile

### DIFF
--- a/pycbc/io/inference_hdf.py
+++ b/pycbc/io/inference_hdf.py
@@ -479,10 +479,11 @@ class InferenceFile(h5py.File):
             group = subgroup
         else:
             group = '/'.join([group, subgroup])
-        self.attrs["low_frequency_cutoff"] = min(low_frequency_cutoff.values())
         for ifo in psds:
             self[group.format(ifo=ifo)] = psds[ifo]
             self[group.format(ifo=ifo)].attrs['delta_f'] = psds[ifo].delta_f
+            self[group.format(ifo=ifo)].attrs['low_frequency_cutoff'] = \
+                low_frequency_cutoff[ifo]
 
     def write_data(self, strain_dict=None, stilde_dict=None,
                    psd_dict=None, low_frequency_cutoff_dict=None,

--- a/pycbc/io/inference_hdf.py
+++ b/pycbc/io/inference_hdf.py
@@ -498,7 +498,7 @@ class InferenceFile(h5py.File):
             A dictionary of stilde. If None, no stilde will be written.
         psd_dict : {None, dict}
             A dictionary of psds. If None, no psds will be written.
-        low_freuency_cutoff_dict : {None, dict}
+        low_frequency_cutoff_dict : {None, dict}
             A dictionary of low frequency cutoffs used for each detector in
             `psd_dict`; must be provided if `psd_dict` is not None.
         group : {None, str}

--- a/pycbc/strain/strain.py
+++ b/pycbc/strain/strain.py
@@ -436,7 +436,7 @@ def from_cli_single_ifo(opt, ifo, **kwargs):
 
 def from_cli_multi_ifos(opt, ifos, **kwargs):
     """
-    Get the PSD for all ifos when using the multi-detector CLI
+    Get the strain for all ifos when using the multi-detector CLI
     """
     strain = {}
     for ifo in ifos:


### PR DESCRIPTION
pycbc_inference can use different low-frequency-cutoffs for the ifos now. This PR saves the low-frequency-cutoff of each IFO as an attribute in `{ifo}/psds/0` for that that ifo in the inference file.