### PR TITLE
Adding non-None values for GraceDB values

### DIFF
--- a/pycbc/io/live.py
+++ b/pycbc/io/live.py
@@ -205,6 +205,13 @@ class SingleCoincForGraceDB(object):
             if sngl.ifo in followup_ifos:
                 for bcf in bayestar_check_fields:
                     setattr(sngl, bcf, getattr(sngl_populated, bcf))
+                # GraceDB needs these populated
+                sngl.eff_distance = 100000
+                sngl.coa_phase = 0.
+                sngl.snr = 0.
+                sngl.chisq = 0.
+                sngl.chisq_dof = 1.
+
                 sngl.set_end(lal.LIGOTimeGPS(subthreshold_sngl_time))
 
         outdoc.childNodes[0].appendChild(coinc_event_map_table)


### PR DESCRIPTION
This will add numerical values for columns like SNR for the "followup" detector values. This currently seems to be required by GraceDB.

I should add that I think it is wrong to be uploading sngl_inspiral entries for detectors which did not participate in the coincidence. If the purpose is to indicate a detector being active (but not participating), then that can be specified in the process table. ... So I don't know if this is the right fix, but this patch would at least solve the current problem, so I put it here if needed.