### PR TITLE
Support XML PSD files

### DIFF
--- a/pycbc/psd/__init__.py
+++ b/pycbc/psd/__init__.py
@@ -72,7 +72,8 @@ def from_cli(opt, length, delta_f, low_frequency_cutoff,
     except AttributeError:
         psd_estimation = False
 
-    exclusive_opts = [opt.psd_model, opt.psd_file, opt.asd_file, psd_estimation]
+    exclusive_opts = [opt.psd_model, opt.psd_file, opt.asd_file,
+                      psd_estimation]
     if sum(map(bool, exclusive_opts)) != 1:
         err_msg = "You must specify exactly one of '--psd-file', "
         err_msg += "'--psd-model', '--asd-file', '--psd-estimation'"

--- a/pycbc/psd/__init__.py
+++ b/pycbc/psd/__init__.py
@@ -77,12 +77,22 @@ def from_cli(opt, length, delta_f, low_frequency_cutoff,
         # PSD from lalsimulation or file
         if opt.psd_model:
             psd = from_string(opt.psd_model, length, delta_f, f_low)
-        elif opt.psd_file:
-            psd = from_txt(opt.psd_file, length,
-                           delta_f, f_low, is_asd_file=False)
-        elif opt.asd_file:
-            psd = from_txt(opt.asd_file, length,
-                           delta_f, f_low, is_asd_file=True)
+        elif opt.psd_file or opt.asd_file:
+            if opt.asd_file:
+                psd_file_name = opt.asd_file
+            else:
+                psd_file_name = opt.psd_file
+            if psd_file_name.endswith(('.dat', '.txt')):
+                is_asd_file = bool(opt.asd_file)
+                psd = from_txt(psd_file_name, length,
+                               delta_f, f_low, is_asd_file=is_asd_file)
+            elif opt.asd_file:
+                err_msg = "ASD files are only valid as ASCII files (.dat or "
+                err_msg += ".txt). Supplied {}.".format(psd_file_name)
+            elif psd_file_name.endswith(('.xml', '.xml.gz')):
+                psd = from_xml(psd_file_name, length, delta_f, f_low,
+                               ifo_string=opt.psd_file_xml_ifo_string,
+                               root_name=opt.psd_file_xml_root_name)
         # Set values < flow to the value at flow
         kmin = int(low_frequency_cutoff / psd.delta_f)
         psd[0:kmin] = psd[kmin]
@@ -175,6 +185,19 @@ def insert_psd_option_group(parser, output=True, include_data_options=True):
                              help="(Optional) The maximum length of the "
                              "impulse response of the overwhitening "
                              "filter (s)")
+    # Options specific to XML PSD files
+    psd_options.add_argument("--psd-file-xml-ifo-string",
+                             help="If using an XML PSD file, use the PSD in "
+                                  "the file's PSD dictionary with this "
+                                  "ifo string. If not given and only one "
+                                  "PSD present in the file return that, if "
+                                  "not given and multiple (or zero) PSDs "
+                                  "present an exception will be raised.")
+    psd_options.add_argument("--psd-file-xml-root-name", default='psd',
+                             help="If given use this as the root name for "
+                                  "the PSD XML file. If this means nothing "
+                                  "to you, then it is probably safe to "
+                                  "ignore this option.")
     # Options for PSD variation
     psd_options.add_argument("--psdvar_short_segment", type=float,
                              metavar="SECONDS", help="Length of short segment "

--- a/pycbc/psd/read.py
+++ b/pycbc/psd/read.py
@@ -159,7 +159,7 @@ def from_xml(filename, length, delta_f, low_freq_cutoff, ifo_string=None,
     fp = open(filename, 'r')
     ct_handler = lal.series.PSDContentHandler
     fileobj, _ = ligolw_utils.load_fileobj(fp, contenthandler=ct_handler)
-    psd_dict = lal.series.read_psd_xmldoc(filobj, root_name=root_name)
+    psd_dict = lal.series.read_psd_xmldoc(fileobj, root_name=root_name)
 
     if ifo_string is not None:
         psd_freq_series = psd_dict[ifo_string]
@@ -172,8 +172,7 @@ def from_xml(filename, length, delta_f, low_freq_cutoff, ifo_string=None,
             raise ValueError(err_msg)
 
     noise_data = psd_freq_series.data.data[:]
-    freq_data = numpy.arange(len(noise_data)) * psd_freq_series.delta_f
+    freq_data = numpy.arange(len(noise_data)) * psd_freq_series.deltaF
 
     return from_numpy_arrays(freq_data, noise_data, length, delta_f,
                              low_freq_cutoff)
-

--- a/pycbc/psd/read.py
+++ b/pycbc/psd/read.py
@@ -45,7 +45,7 @@ def from_numpy_arrays(freq_data, noise_data, length, delta_f, low_freq_cutoff):
     """
     # Only include points above the low frequency cutoff
     if freq_data[0] > low_freq_cutoff:
-        raise ValueError('Lowest frequency in input file ' + filename + \
+        raise ValueError('Lowest frequency in input data '
           ' is higher than requested low-frequency cutoff ' + str(low_freq_cutoff))
 
     kmin = int(low_freq_cutoff / delta_f)

--- a/pycbc/psd/read.py
+++ b/pycbc/psd/read.py
@@ -21,6 +21,59 @@ import numpy
 import scipy.interpolate
 from pycbc.types import FrequencySeries
 
+def from_numpy_arrays(freq_data, noise_data, length, delta_f, low_freq_cutoff):
+    """Interpolate n PSD (as two 1-dimensional arrays of frequency and data)
+    to the desired length, delta_f and low frequency cutoff.
+
+    Parameters
+    ----------
+    freq_data : array
+        Array of frequencies.
+    noise_data : array
+        PSD values corresponding to frequencies in freq_arr.
+    length : int
+        Length of the frequency series in samples.
+    delta_f : float
+        Frequency resolution of the frequency series in Herz.
+    low_freq_cutoff : float
+        Frequencies below this value are set to zero.
+
+    Returns
+    -------
+    psd : FrequencySeries
+        The generated frequency series.
+    """
+    # Only include points above the low frequency cutoff
+    if freq_data[0] > low_freq_cutoff:
+        raise ValueError('Lowest frequency in input file ' + filename + \
+          ' is higher than requested low-frequency cutoff ' + str(low_freq_cutoff))
+
+    kmin = int(low_freq_cutoff / delta_f)
+    flow = kmin * delta_f
+
+    data_start = (0 if freq_data[0]==low_freq_cutoff else numpy.searchsorted(freq_data, flow) - 1)
+
+    # If the cutoff is exactly in the file, start there
+    if freq_data[data_start+1] == low_freq_cutoff:
+        data_start += 1
+
+    freq_data = freq_data[data_start:]
+    noise_data = noise_data[data_start:]
+
+    flog = numpy.log(freq_data)
+    slog = numpy.log(noise_data)
+
+    psd_interp = scipy.interpolate.interp1d(flog, slog)
+
+    kmin = int(low_freq_cutoff / delta_f)
+    psd = numpy.zeros(length, dtype=numpy.float64)
+
+    vals = numpy.log(numpy.arange(kmin, length) * delta_f)
+    psd[kmin:] =  numpy.exp(psd_interp(vals))
+
+    return FrequencySeries(psd, delta_f=delta_f)
+
+
 def from_txt(filename, length, delta_f, low_freq_cutoff, is_asd_file=True):
     """Read an ASCII file containing one-sided ASD or PSD  data and generate
     a frequency series with the corresponding PSD. The ASD or PSD data is
@@ -62,36 +115,65 @@ def from_txt(filename, length, delta_f, low_freq_cutoff, is_asd_file=True):
 
     freq_data = file_data[:, 0]
     noise_data = file_data[:, 1]
-
-    # Only include points above the low frequency cutoff
-    if freq_data[0] > low_freq_cutoff:
-        raise ValueError('Lowest frequency in input file ' + filename + \
-          ' is higher than requested low-frequency cutoff ' + str(low_freq_cutoff))
-
-    kmin = int(low_freq_cutoff / delta_f)
-    flow = kmin * delta_f
-
-    data_start = (0 if freq_data[0]==low_freq_cutoff else numpy.searchsorted(freq_data, flow) - 1)
-
-    # If the cutoff is exactly in the file, start there
-    if freq_data[data_start+1] == low_freq_cutoff:
-        data_start += 1
-
-    freq_data = freq_data[data_start:]
-    noise_data = noise_data[data_start:]
-
-    flog = numpy.log(freq_data)
     if is_asd_file:
-        slog = numpy.log(noise_data ** 2)
+        noise_data = noise_data ** 2
+
+    return from_numpy_arrays(freq_data, noise_data, length, delta_f,
+                             low_freq_cutoff)
+
+def from_xml(filename, length, delta_f, low_freq_cutoff, ifo_string=None,
+             root_name='psd'):
+    """Read an ASCII file containing one-sided ASD or PSD  data and generate
+    a frequency series with the corresponding PSD. The ASD or PSD data is
+    interpolated in order to match the desired resolution of the
+    generated frequency series.
+
+    Parameters
+    ----------
+    filename : string
+        Path to a two-column ASCII file. The first column must contain
+        the frequency (positive frequencies only) and the second column
+        must contain the amplitude density OR power spectral density.
+    length : int
+        Length of the frequency series in samples.
+    delta_f : float
+        Frequency resolution of the frequency series in Herz.
+    low_freq_cutoff : float
+        Frequencies below this value are set to zero.
+    ifo_string : string
+        Use the PSD in the file's PSD dictionary with this ifo string.
+        If not given and only one PSD present in the file return that, if not
+        given and multiple (or zero) PSDs present an exception will be raised.
+    root_name : string (default='psd')
+        If given use this as the root name for the PSD XML file. If this means
+        nothing to you, then it is probably safe to ignore this option.
+
+    Returns
+    -------
+    psd : FrequencySeries
+        The generated frequency series.
+
+    """
+    import lal.series
+    from glue.ligolw import utils as ligolw_utils
+    fp = open(filename, 'r')
+    ct_handler = lal.series.PSDContentHandler
+    fileobj, _ = ligolw_utils.load_fileobj(fp, contenthandler=ct_handler)
+    psd_dict = lal.series.read_psd_xmldoc(filobj, root_name=root_name)
+
+    if ifo_string is not None:
+        psd_freq_series = psd_dict[ifo_string]
     else:
-        slog = numpy.log(noise_data)
+        if len(psd_dict.keys()) == 1:
+            psd_freq_series = psd_dict[psd_dict.keys()[0]]
+        else:
+            err_msg = "No ifo string given and input XML file contains not "
+            err_msg += "exactly one PSD. Specify which PSD you want to use."
+            raise ValueError(err_msg)
 
-    psd_interp = scipy.interpolate.interp1d(flog, slog)
+    noise_data = psd_freq_series.data.data[:]
+    freq_data = numpy.arange(len(noise_data)) * psd_freq_series.delta_f
 
-    kmin = int(low_freq_cutoff / delta_f)
-    psd = numpy.zeros(length, dtype=numpy.float64)
+    return from_numpy_arrays(freq_data, noise_data, length, delta_f,
+                             low_freq_cutoff)
 
-    vals = numpy.log(numpy.arange(kmin, length) * delta_f)
-    psd[kmin:] =  numpy.exp(psd_interp(vals))
-
-    return FrequencySeries(psd, delta_f=delta_f)


### PR DESCRIPTION
This one has been on the to-do list for a while: We should support XML input files in the XML `from_cli` function.

While PyCBC may be moving away from XML files, these are still used extensively elsewhere, including in template bank generation codes (sbank and Soumen's new code). So we need to be able to read these files in.

This patch does that without touching any other functionality. (A little bit of moving code around in `read.py` to avoid code duplication and to make it easier to add other `from_XXX` formats).