### PR TITLE
Add HPD credible interval plotting code for 1D histograms

### DIFF
--- a/bin/inference/pycbc_inference_plot_posterior
+++ b/bin/inference/pycbc_inference_plot_posterior
@@ -184,6 +184,9 @@ for i, (p, l, s) in enumerate(zip(parameters, labels, samples)):
                     p, s, labels=l, fig=fig, axis_dict=axis_dict,
                     plot_marginal=opts.plot_marginal,
                     marginal_percentiles=opts.marginal_percentiles,
+                    plot_marginal_hpd_credible_interval=
+                    opts.plot_marginal_hpd_credible_interval,
+                    marginal_hpd_percent=opts.marginal_hpd_percent,
                     plot_scatter=opts.plot_scatter,
                     zvals=zvals[i] if zvals is not None else None,
                     show_colorbar=show_colorbar,

--- a/pycbc/inference/option_utils.py
+++ b/pycbc/inference/option_utils.py
@@ -678,6 +678,14 @@ def add_plot_posterior_option_group(parser):
                         type=float,
                         help="Percentiles to draw lines at on the 1D "
                              "histograms.")
+    pgroup.add_argument('--plot-marginal-hpd-credible-interval', action='store_true',
+                        default=False,
+                        help="Plot HPD credible interval on the 1D "
+                             "marginalized histograms.")
+    pgroup.add_argument('--marginal-hpd-percent', default=None, type=float,
+                        help="Percentage probability to include in the HPD "
+                             "credible interval. Applicable only if "
+                             "plot-marginal-hpd-credible-interval is True.")
     pgroup.add_argument("--plot-scatter", action='store_true', default=False,
                         help="Plot each sample point as a scatter plot.")
     pgroup.add_argument("--plot-density", action="store_true", default=False,

--- a/pycbc/inference/option_utils.py
+++ b/pycbc/inference/option_utils.py
@@ -678,8 +678,8 @@ def add_plot_posterior_option_group(parser):
                         type=float,
                         help="Percentiles to draw lines at on the 1D "
                              "histograms.")
-    pgroup.add_argument('--plot-marginal-hpd-credible-interval', action='store_true',
-                        default=False,
+    pgroup.add_argument('--plot-marginal-hpd-credible-interval',
+                        action='store_true', default=False,
                         help="Plot HPD credible interval on the 1D "
                              "marginalized histograms.")
     pgroup.add_argument('--marginal-hpd-percent', default=None, type=float,

--- a/pycbc/results/scatter_histograms.py
+++ b/pycbc/results/scatter_histograms.py
@@ -305,7 +305,7 @@ def compute_hpd_credible_interval(samples_array, hpd_percent=None):
     # Widths of all intervals in the sorted samples array that contain
     # "num_samples_hpd" samples.
     intervals_width = samples_array_sorted[num_samples_hpd:] - \
-                    samples_array_sorted[:n-num_samples_hpd]
+        samples_array_sorted[:n-num_samples_hpd]
 
     # Minimal interval
     min_interval_idx = numpy.argmin(intervals_width)

--- a/pycbc/results/scatter_histograms.py
+++ b/pycbc/results/scatter_histograms.py
@@ -305,7 +305,7 @@ def compute_hpd_credible_interval(samples_array, hpd_percent=None):
     # Widths of all intervals in the sorted samples array that contain
     # "num_samples_hpd" samples.
     intervals_width = samples_array_sorted[num_samples_hpd:] - \
-                        samples_array_sorted[:n-num_samples_hpd]
+                    samples_array_sorted[:n-num_samples_hpd]
 
     # Minimal interval
     min_interval_idx = numpy.argmin(intervals_width)
@@ -524,8 +524,8 @@ def create_multidim_plot(parameters, samples, labels=None,
                 marginal_percentiles=None,
                 plot_marginal_hpd_credible_interval=False,
                 marginal_hpd_percent=None,
-                contour_percentiles=None, zvals=None,
-                show_colorbar=True, cbar_label=None,
+                contour_percentiles=None,
+                zvals=None, show_colorbar=True, cbar_label=None,
                 vmin=None, vmax=None, scatter_cmap='plasma', scatter_size=5,
                 plot_density=False, plot_contours=True,
                 density_cmap='viridis',


### PR DESCRIPTION
This PR adds code for plotting HPD credible intervals on 1D marginalized histograms to `scatter_histograms.py`. Also lets `pycbc_inference_plot_posterior` use this feature.  If the HPD credible interval option is to be plotted, `--plot-marginal-hpd-credible-interval` has to be provided to `pycbc_inference_plot_posterior`. The % HPD credible interval can be provided with `--marginal-hpd-percent`. If the latter is not provided, but `--plot-marginal-hpd-credible-interval` is `True`, will default to a 90% probability for the HPD CI . If `--plot-marginal-hpd-credible-interval` is not provided, will plot the regular symmetric credible interval.