### PR TITLE
update waveform.py: remove old ref to flags

### DIFF
--- a/pycbc/waveform/waveform.py
+++ b/pycbc/waveform/waveform.py
@@ -412,9 +412,6 @@ def get_fd_waveform_sequence(template=None, **kwds):
     kwds['f_lower'] = -1
     p = props(template, required_args=fd_required_args, **kwds)
     lal_pars = _check_lal_pars(p)
-    flags = lalsimulation.SimInspiralCreateWaveformFlags()
-    lalsimulation.SimInspiralSetSpinOrder(flags, p['spin_order'])
-    lalsimulation.SimInspiralSetTidalOrder(flags, p['tidal_order'])
 
     hp, hc = lalsimulation.SimInspiralChooseFDWaveformSequence(float(p['coa_phase']),
                float(pnutils.solar_mass_to_kg(p['mass1'])),


### PR DESCRIPTION
This PR removes a reference to the old waveform interface that isn't used anymore.
It should not effect anything.

Could keeping the `SimInspiralCreateWaveformFlags` cause a memory leak? Not sure :)