### PR TITLE
Caching

### DIFF
--- a/pycbc/opt.py
+++ b/pycbc/opt.py
@@ -197,6 +197,7 @@ def verify_optimization_options(opt, parser):
 class LimitedSizeDict(OrderedDict):
     """ Fixed sized dict for FIFO caching"""
 
+
     def __init__(self, *args, **kwds):
         self.size_limit = kwds.pop("size_limit", None)
         OrderedDict.__init__(self, *args, **kwds)

--- a/pycbc/opt.py
+++ b/pycbc/opt.py
@@ -195,6 +195,8 @@ def verify_optimization_options(opt, parser):
         logging.info("Pinned to CPUs %s " % requested_cpus)
 
 class LimitedSizeDict(OrderedDict):
+    """ Fixed sized dict for FIFO caching"""
+
     def __init__(self, *args, **kwds):
         self.size_limit = kwds.pop("size_limit", None)
         OrderedDict.__init__(self, *args, **kwds)

--- a/pycbc/opt.py
+++ b/pycbc/opt.py
@@ -197,7 +197,6 @@ def verify_optimization_options(opt, parser):
 class LimitedSizeDict(OrderedDict):
     """ Fixed sized dict for FIFO caching"""
 
-
     def __init__(self, *args, **kwds):
         self.size_limit = kwds.pop("size_limit", None)
         OrderedDict.__init__(self, *args, **kwds)

--- a/pycbc/opt.py
+++ b/pycbc/opt.py
@@ -20,8 +20,8 @@ other modules and packages may use in addition to some optimized utilities.
 """
 import os, sys
 import logging
-import pycbc
 from collections import OrderedDict
+import pycbc
 
 # Work around different Python versions to get runtime
 # info on hardware cache sizes
@@ -206,5 +206,5 @@ class LimitedSizeDict(OrderedDict):
 
     def _check_size_limit(self):
         if self.size_limit is not None:
-        while len(self) > self.size_limit:
-            self.popitem(last=False)
+            while len(self) > self.size_limit:
+                self.popitem(last=False)

--- a/pycbc/opt.py
+++ b/pycbc/opt.py
@@ -16,11 +16,12 @@
 
 """
 This module defines optimization flags and determines hardware features that some
-other modules and packages may use.
+other modules and packages may use in addition to some optimized utilities.
 """
 import os, sys
 import logging
 import pycbc
+from collections import OrderedDict
 
 # Work around different Python versions to get runtime
 # info on hardware cache sizes
@@ -192,3 +193,18 @@ def verify_optimization_options(opt, parser):
             sys.exit(1)
 
         logging.info("Pinned to CPUs %s " % requested_cpus)
+
+class LimitedSizeDict(OrderedDict):
+  def __init__(self, *args, **kwds):
+    self.size_limit = kwds.pop("size_limit", None)
+    OrderedDict.__init__(self, *args, **kwds)
+    self._check_size_limit()
+
+  def __setitem__(self, key, value):
+    OrderedDict.__setitem__(self, key, value)
+    self._check_size_limit()
+
+  def _check_size_limit(self):
+    if self.size_limit is not None:
+      while len(self) > self.size_limit:
+        self.popitem(last=False)

--- a/pycbc/opt.py
+++ b/pycbc/opt.py
@@ -195,16 +195,16 @@ def verify_optimization_options(opt, parser):
         logging.info("Pinned to CPUs %s " % requested_cpus)
 
 class LimitedSizeDict(OrderedDict):
-  def __init__(self, *args, **kwds):
-    self.size_limit = kwds.pop("size_limit", None)
-    OrderedDict.__init__(self, *args, **kwds)
-    self._check_size_limit()
+    def __init__(self, *args, **kwds):
+        self.size_limit = kwds.pop("size_limit", None)
+        OrderedDict.__init__(self, *args, **kwds)
+        self._check_size_limit()
 
-  def __setitem__(self, key, value):
-    OrderedDict.__setitem__(self, key, value)
-    self._check_size_limit()
+    def __setitem__(self, key, value):
+        OrderedDict.__setitem__(self, key, value)
+        self._check_size_limit()
 
-  def _check_size_limit(self):
-    if self.size_limit is not None:
-      while len(self) > self.size_limit:
-        self.popitem(last=False)
+    def _check_size_limit(self):
+        if self.size_limit is not None:
+        while len(self) > self.size_limit:
+            self.popitem(last=False)

--- a/pycbc/types/array.py
+++ b/pycbc/types/array.py
@@ -131,7 +131,7 @@ class Array(object):
         The default is to copy the given object.
         """
         self._scheme=_scheme.mgr.state
-        self._saved = LimitedSizeDict(size_limit=1000)
+        self._saved = LimitedSizeDict(size_limit=2**5)
         
         #Unwrap initial_array
         if isinstance(initial_array, Array):
@@ -751,7 +751,7 @@ class Array(object):
         if new_size == len(self):
             return
         else:
-            self._saved = {}
+            self._saved = LimitedSizeDict(size_limit=2**5)
             new_arr = zeros(new_size, dtype=self.dtype)
             if len(self) <= new_size:
                 new_arr[0:len(self)] = self
@@ -764,7 +764,7 @@ class Array(object):
     def roll(self, shift):
         """shift vector
         """
-        self._saved = {}
+        self._saved = LimitedSizeDict(size_limit=2**5)
         new_arr = zeros(len(self), dtype=self.dtype)
 
         if shift == 0:

--- a/pycbc/types/array.py
+++ b/pycbc/types/array.py
@@ -42,6 +42,7 @@ from numpy.linalg import norm
 import pycbc.scheme as _scheme
 from pycbc.scheme import schemed, cpuonly
 from pycbc.types.aligned import ArrayWithAligned
+from pycbc.opt import LimitedSizeDict
 
 #! FIXME: the uint32 datatype has not been fully tested,
 # we should restrict any functions that do not allow an
@@ -130,7 +131,7 @@ class Array(object):
         The default is to copy the given object.
         """
         self._scheme=_scheme.mgr.state
-        self._saved = {}
+        self._saved = LimitedSizeDict(size_limit=1000)
         
         #Unwrap initial_array
         if isinstance(initial_array, Array):

--- a/pycbc/vetoes/chisq.py
+++ b/pycbc/vetoes/chisq.py
@@ -318,12 +318,14 @@ class SingleDetPowerChisq(object):
         return eval(arg, {"__builtins__":None}, safe_dict)
 
     def cached_chisq_bins(self, template, psd):
+        from pycbc.opt import LimitedSizeDict
+
         key = id(psd)
         if not hasattr(psd, '_chisq_cached_key'):
-            psd._chisq_cached_key = {}
+            psd._chisq_cached_key = LimitedSizeDict(size_limit=2**15)
 
         if not hasattr(template, '_bin_cache'):
-            template._bin_cache = {}
+            template._bin_cache = LimitedSizeDict(size_limite=2**10)
 
         if key not in template._bin_cache or id(template.params) not in psd._chisq_cached_key:
             psd._chisq_cached_key[id(template.params)] = True

--- a/pycbc/vetoes/chisq.py
+++ b/pycbc/vetoes/chisq.py
@@ -322,10 +322,10 @@ class SingleDetPowerChisq(object):
 
         key = id(psd)
         if not hasattr(psd, '_chisq_cached_key'):
-            psd._chisq_cached_key = LimitedSizeDict(size_limit=2**15)
+            psd._chisq_cached_key = {}
 
         if not hasattr(template, '_bin_cache'):
-            template._bin_cache = LimitedSizeDict(size_limite=2**10)
+            template._bin_cache = LimitedSizeDict(size_limite=2**2)
 
         if key not in template._bin_cache or id(template.params) not in psd._chisq_cached_key:
             psd._chisq_cached_key[id(template.params)] = True

--- a/pycbc/waveform/bank.py
+++ b/pycbc/waveform/bank.py
@@ -44,7 +44,7 @@ def sigma_cached(self, psd):
     """
     if not hasattr(self, '_sigmasq'):
         from pycbc.opt import LimitedSizeDict
-        self._sigmasq = LimitedSizeDict(size_limit=2**15)
+        self._sigmasq = LimitedSizeDict(size_limit=2**5)
 
     key = id(psd)
     if not hasattr(psd, '_sigma_cached_key'):

--- a/pycbc/waveform/bank.py
+++ b/pycbc/waveform/bank.py
@@ -42,6 +42,10 @@ import pycbc.io
 def sigma_cached(self, psd):
     """ Cache sigma calculate for use in tandem with the FilterBank class
     """
+    if not hasattr(self, '_sigmasq'):
+        from pycbc.opt import LimitedSizeDict
+        self._sigmasq = LimitedSizeDict(size_limit=2**15)
+
     key = id(psd)
     if not hasattr(psd, '_sigma_cached_key'):
         psd._sigma_cached_key = {}
@@ -579,7 +583,6 @@ class LiveFilterBank(TemplateBank):
 
         # Add sigmasq as a method of this instance
         htilde.sigmasq = types.MethodType(sigma_cached, htilde)
-        htilde._sigmasq = {}
 
         htilde.id = self.id_from_hash(hash((htilde.params.mass1,
                                       htilde.params.mass2,


### PR DESCRIPTION
@titodalcanton I'm not confident this completely removes the memory leak problem, but it reduces it in at least one case I am very confident of now. If you set the SNR threshold high, it completely removes any leak, and testing over the weekend produced a stable memory useage for several days. I think there may be still some sort of leak in the later trigger handling, but I think think we should consider this patch separately. 