### PR TITLE
Fix histogram bug and update for new versions of pycbc inference in pycbc_plot_acceptance_rate

### DIFF
--- a/bin/inference/pycbc_inference_plot_acceptance_rate
+++ b/bin/inference/pycbc_inference_plot_acceptance_rate
@@ -18,50 +18,44 @@
 
 import argparse
 import logging
-import sys
-
 from matplotlib import use
 use('agg')
-from matplotlib import pyplot as plt
-
+import matplotlib.pyplot as plt
+import numpy
+import pycbc
+import pycbc.version
 from pycbc import results
-
 from pycbc import __version__
-# FIXME: needs to be updated for new io api
-from pycbc.io.inference.hdf import InferenceFile
+from pycbc.inference import io
+import sys
 
-# command line usage
+# add options to command line
 parser = argparse.ArgumentParser(
             usage="pycbc_inference_plot_acceptance_rate [--options]",
-            description="Plots histogram of the fractions of steps accepted by walkers.")
-parser.add_argument('--version', action='version', version=__version__,
-                    help='show version number and exit')
-
-# add data options
+            description="Plots histogram of the fractions of steps "
+                        "accepted by walkers.")
 parser.add_argument("--input-file", type=str, required=True,
                     help="Path to input HDF file.")
-
+parser.add_argument('--version', action='version', version=__version__,
+                    help='show version number and exit')
 # output plot options
 parser.add_argument("--output-file", type=str, required=True,
                     help="Path to output plot.")
-
 # add walkers to plot
 parser.add_argument("--walkers", type=int, nargs='+', default=None,
                     help="Specify walkers whose acceptance fraction would "
                     "be plotted. The acceptance fraction for a walker is the "
                     "fraction of steps accepted by it. Default is plot for "
                     "all walkers.")
-
-# add temperatures if using parallel tempered samplers
-parser.add_argument("--temps", type=int, nargs='+', default=None,
-                    help="Specify temperatures, the acceptance fraction of "
-                    "whose walkers would be plotted. Default is plot for all "
-                    "temperatures.")
-
+parser.add_argument("--temps", type=int, nargs="+", default=None,
+                    help="Specify temperatures whose acceptance fraction "
+                         "would be plotted (if available). [default=None] "
+                         "specifies that all temperatures will be plotted. "
+                         "This will create N histograms on the plot for N "
+                         "temperatures in file.")
 # add number of bins for histogram
 parser.add_argument("--bins", type=int, default=10,
                     help="Specify number of bins for the histogram plot.")
-
 # verbose option
 parser.add_argument("--verbose", action="store_true", default=False,
                     help="")
@@ -70,11 +64,11 @@ parser.add_argument("--verbose", action="store_true", default=False,
 opts = parser.parse_args()
 
 # setup log
-if opts.verbose:
-    log_level = logging.DEBUG
-else:
-    log_level = logging.WARN
-logging.basicConfig(format="%(asctime)s : %(message)s", level=log_level)
+pycbc.init_logging(opts.verbose)
+
+# load the samples
+logging.info("Reading input file")
+fp = io.loadfile(opts.input_file)
 
 # if using a parallel-tempered sampler, then
 # add the temperature arguments if it is specified
@@ -82,15 +76,14 @@ additional_args = {}
 if opts.temps is not None:
     additional_args['temps'] = opts.temps
 
-# read input file
-logging.info("Reading input file")
-fp = InferenceFile(opts.input_file, "r")
 acceptance_fraction = fp.read_acceptance_fraction(walkers=opts.walkers,
                                                   **additional_args)
 # plot acceptance rate and drawn values
 logging.info("Plotting acceptance fraction")
 fig = plt.figure()
-plt.hist(acceptance_fraction, opts.bins, histtype="step", lw=2, normed=True)
+
+plt.hist(acceptance_fraction.transpose(), opts.bins, histtype="step", lw=2)
+
 plt.ylabel("Number of walkers")
 plt.xlabel("Mean Acceptance Rate")
 
@@ -105,5 +98,4 @@ results.save_fig_with_metadata(fig, opts.output_file,
 plt.close()
 
 # exit
-fp.close()
 logging.info("Done")

--- a/bin/inference/pycbc_inference_plot_acceptance_rate
+++ b/bin/inference/pycbc_inference_plot_acceptance_rate
@@ -68,7 +68,7 @@ pycbc.init_logging(opts.verbose)
 
 # load the samples
 logging.info("Reading input file")
-fp = io.loadfile(opts.input_file)
+fp = io.loadfile(opts.input_file, "r")
 
 # if using a parallel-tempered sampler, then
 # add the temperature arguments if it is specified

--- a/bin/inference/pycbc_inference_plot_acceptance_rate
+++ b/bin/inference/pycbc_inference_plot_acceptance_rate
@@ -78,6 +78,9 @@ if opts.temps is not None:
 
 acceptance_fraction = fp.read_acceptance_fraction(walkers=opts.walkers,
                                                   **additional_args)
+# Close the file
+fp.close()
+
 # plot acceptance rate and drawn values
 logging.info("Plotting acceptance fraction")
 fig = plt.figure()

--- a/pycbc/inference/io/emcee.py
+++ b/pycbc/inference/io/emcee.py
@@ -26,7 +26,7 @@
 
 from .base_hdf import BaseInferenceFile
 from .base_mcmc import MCMCIO
-
+import numpy
 
 class EmceeFile(MCMCIO, BaseInferenceFile):
     """Class to handle file IO for the ``emcee`` sampler."""

--- a/pycbc/inference/io/emcee_pt.py
+++ b/pycbc/inference/io/emcee_pt.py
@@ -21,7 +21,7 @@ from __future__ import absolute_import
 
 from .base_hdf import BaseInferenceFile
 from .base_multitemper import MultiTemperedMCMCIO
-
+import numpy
 
 class EmceePTFile(MultiTemperedMCMCIO, BaseInferenceFile):
     """Class to handle file IO for the ``emcee`` sampler."""


### PR DESCRIPTION
Fixes histogram normalizing bug, puts necessary `numpy` imports in emcee and emcee_pt.

Using this ini file:
```
[model]
name = test_normal
[sampler]
name = emcee_pt
ntemps = 3
nwalkers = 5000
niterations = 9
checkpoint-interval = 4
[variable_params]
x =
y =
[prior-x]
name = uniform
min-x = -10
max-x = 10
[prior-y]
name = uniform
min-y = -10
max-y = 10
```
and this run script:
```
#! /usr/bin
pycbc_inference \
        --verbose \
        --config-files 2d_gauss.ini \
        --output-file 2d_gauss.hdf \
        --nprocesses 4 \
        --force
```

and this is what comes out from:
```
$ pycbc_inference_plot_acceptance_rate --input-file 2d_gauss.hdf --output-file ~/secure_html/astro/check_pe/plot_accept_rate_gauss_2d_examp.png
```

![image](https://user-images.githubusercontent.com/12528399/46201080-4b351400-c2e1-11e8-9cdb-c781e02831c3.png)
