### PR TITLE
Pycbc plot samples fix

### DIFF
--- a/bin/inference/pycbc_inference_plot_samples
+++ b/bin/inference/pycbc_inference_plot_samples
@@ -23,7 +23,6 @@ import logging
 from matplotlib import use
 use('agg')
 from matplotlib import pyplot as plt
-import numpy
 import pycbc
 from pycbc import (results, transforms)
 from pycbc import __version__

--- a/bin/inference/pycbc_inference_plot_samples
+++ b/bin/inference/pycbc_inference_plot_samples
@@ -20,34 +20,24 @@
 
 import argparse
 import logging
-import sys
-
 from matplotlib import use
 use('agg')
 from matplotlib import pyplot as plt
-
+import numpy
 import pycbc
 from pycbc import (results, transforms)
-
 from pycbc import __version__
-from pycbc.inference import option_utils
+from pycbc.inference import (option_utils, io)
+import sys
 
 # command line usage
-parser = argparse.ArgumentParser(usage=__file__ + " [--options]",
-                                 description=__doc__)
-
-# verbose option
+parser = argparse.parser = io.ResultsArgumentParser()
 parser.add_argument("--verbose", action="store_true", default=False,
                     help="Print logging info.")
 parser.add_argument("--version", action="version", version=__version__,
                     help="show version number and exit")
-
-# output plot options
 parser.add_argument("--output-file", type=str, required=True,
                     help="Path to output plot.")
-
-# add results group options
-option_utils.add_inference_results_option_group(parser)
 
 # parse the command line
 opts = parser.parse_args()
@@ -56,8 +46,8 @@ opts = parser.parse_args()
 pycbc.init_logging(opts.verbose)
 
 # load the results
-fp, parameters, labels, _ = option_utils.results_from_cli(opts,
-                                                          load_samples=False)
+fp, parameters, labels, _ = io.results_from_cli(opts,
+                                                load_samples=False)
 
 # get number of dimensions
 ndim = len(parameters)
@@ -71,22 +61,29 @@ plt.xlabel("Iteration")
 # loop over parameters
 axs = [axs] if not hasattr(axs, "__iter__") else axs
 for i, arg in enumerate(parameters):
-
+<<<<<<< HEAD
+    # plot each walker as a different line on the subplot
+    for j in range(fp.nwalkers):
+=======
     # loop over walkers
     for j in range(fp.nwalkers):
-
         # plot each walker as a different line on the subplot
+>>>>>>> Minor changes to enable plotting code to work
         file_parameters, cs = transforms.get_common_cbc_transforms(
                                                  parameters, fp.variable_params)
         y = fp.read_samples(file_parameters, walkers=j,
                             thin_start=opts.thin_start,
                             thin_interval=opts.thin_interval,
                             thin_end=opts.thin_end)
+<<<<<<< HEAD
+=======
         y = transforms.apply_transforms(y, cs)
-        axs[i].plot(y[arg], alpha=0.25)
+>>>>>>> Minor changes to enable plotting code to work
 
-        # y-axis label
-        axs[i].set_ylabel(labels[i])
+        axs[i].plot(y[arg], alpha=0.25)
+        # Set y labels
+        axs[i].set_ylabel(labels[arg])
+fp.close()
 
 # save figure with meta-data
 caption_kwargs = {
@@ -102,5 +99,4 @@ results.save_fig_with_metadata(fig, opts.output_file,
 plt.close()
 
 # exit
-fp.close()
 logging.info("Done")

--- a/bin/inference/pycbc_inference_plot_samples
+++ b/bin/inference/pycbc_inference_plot_samples
@@ -61,24 +61,16 @@ plt.xlabel("Iteration")
 # loop over parameters
 axs = [axs] if not hasattr(axs, "__iter__") else axs
 for i, arg in enumerate(parameters):
-<<<<<<< HEAD
     # plot each walker as a different line on the subplot
     for j in range(fp.nwalkers):
-=======
-    # loop over walkers
-    for j in range(fp.nwalkers):
         # plot each walker as a different line on the subplot
->>>>>>> Minor changes to enable plotting code to work
         file_parameters, cs = transforms.get_common_cbc_transforms(
                                                  parameters, fp.variable_params)
         y = fp.read_samples(file_parameters, walkers=j,
                             thin_start=opts.thin_start,
                             thin_interval=opts.thin_interval,
                             thin_end=opts.thin_end)
-<<<<<<< HEAD
-=======
         y = transforms.apply_transforms(y, cs)
->>>>>>> Minor changes to enable plotting code to work
 
         axs[i].plot(y[arg], alpha=0.25)
         # Set y labels


### PR DESCRIPTION

Changing a few things around, and plotting the samples from gaussian example (x, y)

![image](https://user-images.githubusercontent.com/12528399/46212301-a8da5800-c303-11e8-92cb-36966001f2a2.png)

A future commit will reduce the number of time spend importing samples. It should just read all the samples and slice along the axis of walker. This should greatly reduce the time required to plot these samples.