### PR TITLE
Update plot_inj_interval for fix imports for io mv

### DIFF
--- a/bin/inference/pycbc_inference_plot_inj_intervals
+++ b/bin/inference/pycbc_inference_plot_inj_intervals
@@ -17,13 +17,13 @@ from matplotlib import pyplot as plt
 
 import pycbc
 from pycbc.results import save_fig_with_metadata
+from pycbc.inference import (option_utils, io)
 
 from pycbc import __version__
-from pycbc.inference import option_utils
 
 # parse command line
-parser = argparse.ArgumentParser(usage=__file__ + " [--options]",
-                                 description=__doc__)
+parser = io.ResultsArgumentParser(description="Plots fraction of injections with their parameter value recovered "
+                                               "within a credible interval versus credible interval.")
 parser.add_argument('--version', action='version', version=__version__,
                     help='show version number and exit')
 parser.add_argument("--output-file", required=True, type=str,
@@ -32,7 +32,6 @@ parser.add_argument("--verbose", action="store_true",
                     help="Allows print statements.")
 parser.add_argument("--injection-hdf-group", default="H1/injections",
                     help="HDF group that contains injection values.")
-option_utils.add_inference_results_option_group(parser)
 option_utils.add_scatter_option_group(parser)
 opts = parser.parse_args()
 
@@ -40,24 +39,23 @@ opts = parser.parse_args()
 pycbc.init_logging(opts.verbose)
 
 # read results
-_, parameters, labels, samples = option_utils.results_from_cli(opts)
-labels = labels[0]
+logging.info('Loading parameters')
+_, parameters, labels, samples = io.results_from_cli(opts)
 
 # typecast to list for iteration
-parameters = [parameters] if not isinstance(samples, list) else parameters
-labels = [labels] if not isinstance(labels, list) else labels
 samples = [samples] if not isinstance(samples, list) else samples
 
 # loop over input files and its samples
 logging.info("Plotting")
 measured_percentiles = {}
-for input_file, input_parameters, input_samples in zip(
-                                        opts.input_file, parameters, samples):
+
+for input_file, input_samples in zip(
+                                        opts.input_file, samples):
     # load the injections
     opts.input_file = input_file
-    inj_parameters = option_utils.injections_from_cli(opts)
+    inj_parameters = io.injections_from_cli(opts)
 
-    for p in input_parameters:
+    for p in parameters:
         inj_val = inj_parameters[p]
         sample_vals = input_samples[p]
         measured = stats.percentileofscore(sample_vals, inj_val, kind='weak')
@@ -72,7 +70,7 @@ fig = plt.figure()
 ax = fig.add_subplot(111)
 
 # calculate the expected percentile for each injection and plot
-for param,label in zip(input_parameters, labels):
+for param,label in zip(parameters, labels):
     # calculate expected
     meas = numpy.array(measured_percentiles[param])
     meas.sort()

--- a/bin/inference/pycbc_inference_plot_inj_intervals
+++ b/bin/inference/pycbc_inference_plot_inj_intervals
@@ -70,8 +70,9 @@ fig = plt.figure()
 ax = fig.add_subplot(111)
 
 # calculate the expected percentile for each injection and plot
-for param,label in zip(parameters, labels):
-    # calculate expected
+
+for param in parameters:
+    label = labels[param]
     meas = numpy.array(measured_percentiles[param])
     meas.sort()
     expected = numpy.array([stats.percentileofscore(meas, x, kind='weak')
@@ -80,6 +81,7 @@ for param,label in zip(parameters, labels):
     ks, p = stats.kstest(meas/100., 'uniform')
     ax.plot(meas/100., expected/100.,
                 label='{} $D_{{KS}}$: {:.3f} p-value: {:.3f}'.format(label, ks, p))
+
 
 # set legend
 ax.legend()


### PR DESCRIPTION
Fixed the import and functions in injection interval plots. I plotted following plot from 2 test injections and runs:

pycbc_inference_plot_inj_intervals --input-file run_files/inference1.hdf:1 run_files/inference2.hdf:2 --output-file test.png --parameters mass1 mass2

![test](https://user-images.githubusercontent.com/10362037/46213275-70a13c80-c338-11e8-9102-125628af5b04.png)
