### PR TITLE
Inference dev

### DIFF
--- a/bin/inference/pycbc_inference_plot_inj_intervals
+++ b/bin/inference/pycbc_inference_plot_inj_intervals
@@ -17,13 +17,13 @@ from matplotlib import pyplot as plt
 
 import pycbc
 from pycbc.results import save_fig_with_metadata
+from pycbc.inference import (option_utils, io)
 
 from pycbc import __version__
-from pycbc.inference import option_utils
 
 # parse command line
-parser = argparse.ArgumentParser(usage=__file__ + " [--options]",
-                                 description=__doc__)
+parser = io.ResultsArgumentParser(description="Plots fraction of injections with their parameter value recovered "
+                                               "within a credible interval versus credible interval.")
 parser.add_argument('--version', action='version', version=__version__,
                     help='show version number and exit')
 parser.add_argument("--output-file", required=True, type=str,
@@ -32,7 +32,6 @@ parser.add_argument("--verbose", action="store_true",
                     help="Allows print statements.")
 parser.add_argument("--injection-hdf-group", default="H1/injections",
                     help="HDF group that contains injection values.")
-option_utils.add_inference_results_option_group(parser)
 option_utils.add_scatter_option_group(parser)
 opts = parser.parse_args()
 
@@ -40,24 +39,23 @@ opts = parser.parse_args()
 pycbc.init_logging(opts.verbose)
 
 # read results
-_, parameters, labels, samples = option_utils.results_from_cli(opts)
-labels = labels[0]
+logging.info('Loading parameters')
+_, parameters, labels, samples = io.results_from_cli(opts)
 
 # typecast to list for iteration
-parameters = [parameters] if not isinstance(samples, list) else parameters
-labels = [labels] if not isinstance(labels, list) else labels
 samples = [samples] if not isinstance(samples, list) else samples
 
 # loop over input files and its samples
 logging.info("Plotting")
 measured_percentiles = {}
-for input_file, input_parameters, input_samples in zip(
-                                        opts.input_file, parameters, samples):
+
+for input_file, input_samples in zip(
+                                        opts.input_file, samples):
     # load the injections
     opts.input_file = input_file
-    inj_parameters = option_utils.injections_from_cli(opts)
+    inj_parameters = io.injections_from_cli(opts)
 
-    for p in input_parameters:
+    for p in parameters:
         inj_val = inj_parameters[p]
         sample_vals = input_samples[p]
         measured = stats.percentileofscore(sample_vals, inj_val, kind='weak')
@@ -72,7 +70,7 @@ fig = plt.figure()
 ax = fig.add_subplot(111)
 
 # calculate the expected percentile for each injection and plot
-for param,label in zip(input_parameters, labels):
+for param,label in zip(parameters, labels):
     # calculate expected
     meas = numpy.array(measured_percentiles[param])
     meas.sort()

--- a/bin/inference/pycbc_inference_plot_inj_intervals
+++ b/bin/inference/pycbc_inference_plot_inj_intervals
@@ -70,8 +70,9 @@ fig = plt.figure()
 ax = fig.add_subplot(111)
 
 # calculate the expected percentile for each injection and plot
-for param,label in zip(parameters, labels):
-    # calculate expected
+
+for param in parameters:
+    label = labels[param]
     meas = numpy.array(measured_percentiles[param])
     meas.sort()
     expected = numpy.array([stats.percentileofscore(meas, x, kind='weak')
@@ -80,6 +81,7 @@ for param,label in zip(parameters, labels):
     ks, p = stats.kstest(meas/100., 'uniform')
     ax.plot(meas/100., expected/100.,
                 label='{} $D_{{KS}}$: {:.3f} p-value: {:.3f}'.format(label, ks, p))
+
 
 # set legend
 ax.legend()

--- a/bin/inference/pycbc_inference_plot_inj_recovery
+++ b/bin/inference/pycbc_inference_plot_inj_recovery
@@ -15,11 +15,12 @@ from matplotlib import cm
 from pycbc import inject
 from pycbc import transforms
 from pycbc import __version__
-from pycbc.inference import option_utils
+from pycbc.inference import (option_utils, io)
 
 # parse command line
-parser = argparse.ArgumentParser(usage=__file__ + " [--options]",
-                                 description=__doc__)
+parser = io.ResultsArgumentParser(description="Plots the recovered versus injected parameter values "
+                                               "from a population.")
+
 parser.add_argument("--version", action="version", version=__version__,
                     help="Prints version information.")
 parser.add_argument("--output-file", required=True, type=str,
@@ -28,9 +29,6 @@ parser.add_argument("--verbose", action="store_true",
                     help="Allows print statements.")
 parser.add_argument("--quantiles", nargs=2, type=float, default=[0.05, 0.95],
                     help="Quantiles to use as limits.")
-parser.add_argument("--injection-hdf-group", default="H1/injections",
-                    help="HDF group that contains injection values.")
-option_utils.add_inference_results_option_group(parser)
 option_utils.add_scatter_option_group(parser)
 opts = parser.parse_args()
 
@@ -38,12 +36,12 @@ opts = parser.parse_args()
 pycbc.init_logging(opts.verbose)
 
 # read results
-fp, parameters, labels, samples = option_utils.results_from_cli(opts)
+fp, parameters, labels, samples = io.results_from_cli(opts)
 
 # only plot one parameter
-assert(len(opts.parameters) == 1)
-parameter = parameters[0] if isinstance(parameters, list) else parameters
-label = labels[0][0] if isinstance(labels, list) else labels
+assert len(parameters) == 1
+parameter = parameters[0] 
+label = labels[parameters[0]] 
 
 # create figure
 fig = plt.figure()
@@ -52,24 +50,24 @@ ax = fig.add_subplot(111)
 # typecast to list for iteratation
 samples = [samples] if not isinstance(samples, list) else samples
 fp = [fp] if not isinstance(fp, list) else fp
+injs = io.injections_from_cli(opts)
+_, ts = transforms.get_common_cbc_transforms(opts.parameters,
+                                                 injs.fieldnames)
+
+# add parameters not included in injection file
+inj_parameters = transforms.apply_transforms(injs, ts)
+
 
 # if user wants a colorbar
-if opts.z_arg:
 
-    # store list of z-axis values and label
+# if a z-arg is specified, load samples for it
+if opts.z_arg is not None:
+    logging.info("Getting samples for colorbar")
+    zlbl = opts.z_arg_labels[opts.z_arg]
     zvals = []
-    zlabel = None
-
-    # loop over input files
-    logging.info("Reading %s values", opts.z_arg)
-    for i, input_fp in enumerate(fp):
-
-        # get z-axis values and label
-        likelihood_stats = input_fp.read_likelihood_stats(
-             thin_start=opts.thin_start, thin_end=opts.thin_end,
-             thin_interval=opts.thin_interval, iteration=opts.iteration)
-        vals, zlabel = option_utils.get_zvalues(input_fp, opts.z_arg,
-                                                likelihood_stats)
+    for fp in fps:
+        zsamples = fp.samples_from_cli(opts, parameters=opts.z_arg)
+        vals = zsamples[opts.z_arg]
         zvals.append(numpy.median(vals))
 
         # update range of colorbar
@@ -86,21 +84,9 @@ if opts.z_arg:
 logging.info("Plotting")
 for i, (input_file, input_fp, input_samples) in enumerate(zip(opts.input_file,
                                                               fp, samples)):
-
-    # read injections from HDF input file
-    injs = inject.InjectionSet(input_file, hdf_group=opts.injection_hdf_group)
-
-    # check if need extra parameters than parameters stored in injection file
-    _, ts = transforms.get_common_cbc_transforms(opts.parameters,
-                                                 injs.table.fieldnames)
-
-    # add parameters not included in injection file
-    inj_parameters = transforms.apply_transforms(injs.table, ts)
-
     # get paramter values
-    sampled_vals = input_samples[parameter].to_array()
-    injected_vals = [e[0] for e in inj_parameters[parameter]]
-
+    sampled_vals = input_samples[parameter]
+    injected_vals = inj_parameters[parameter][i]
     # compute quantiles of sampled results
     quantiles = numpy.array([numpy.percentile(sampled_vals, 100 * q)
                              for q in opts.quantiles])
@@ -117,8 +103,6 @@ for i, (input_file, input_fp, input_samples) in enumerate(zip(opts.input_file,
         color = "black"
 
     # plot a point for each injection
-    if len(injected_vals) > 1:
-        logging.warn("More than one injection in file %s", input_file)
     ax.errorbar([injected_vals],
                 [med - injected_vals],
                 yerr=[[(med - low)], [(high - med)]],


### PR DESCRIPTION
Fixed the import and functions in injection recovery plots. I plotted following plot from 2 test injections and runs:

>> pycbc_inference_plot_inj_recovery --input-file run_files/inference1.hdf:1 run_files/inference2.hdf:2 --parameters mass1 --output-file test2.png

![test2](https://user-images.githubusercontent.com/10362037/46293192-0932f900-c593-11e8-9169-5133a5c1738c.png)
