### PR TITLE
Ensure plot parameters are stored as a list when --parameters argument is not provided

### DIFF
--- a/pycbc/inference/option_utils.py
+++ b/pycbc/inference/option_utils.py
@@ -544,7 +544,7 @@ def results_from_cli(opts, load_samples=True, **kwargs):
         fp = InferenceFile(input_file, "r")
 
         # get parameters and a dict of labels for each parameter
-        parameters = fp.variable_args if opts.parameters is None \
+        parameters = list(fp.variable_args) if opts.parameters is None \
                          else opts.parameters
         parameters, ldict = parse_parameters_opt(parameters)
 


### PR DESCRIPTION
When using `pycbc_inference_plot_posterior` to plot from multiple files without providing the `--parameters` command-line argument, the plotting parameters default to being stored as a list of arrays. Then the line
```
parameters = parameters if isinstance(parameters[0], list) else [parameters]
```
wraps the parameters in another list, causing the following code block to fail with an 'unhashable type' error:
```
for p in parameters[0]:
    if p not in mins:
        mins[p] = numpy.array([s[p].min() for s in samples]).min()
    if p not in maxs:
        maxs[p] = numpy.array([s[p].max() for s in samples]).max()
```
This patch changes the default behavior to storing each file's plotting parameters as a list when `--parameters` is not provided.