### PR TITLE
Temporarily disable pylint in codeclimate

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -45,7 +45,7 @@ plugins:
   pep8:
     enabled: true
 
-exclude_paths:
+exclude_patterns:
 - docs/*
 - tools/*
 - examples/*

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -42,12 +42,6 @@ plugins:
       strings:
       - FIXME
       - XXX
-  pylint:
-    enabled: true
-    channel: "beta"
-    checks:
-      import-error:
-        enabled: false
   pep8:
     enabled: true
 


### PR DESCRIPTION
At the moment this plugin is failing and I don't know why. I've opened an issue:

https://github.com/meuspedidos/codeclimate-pylint/issues/24

but for now we might have to disable this plugin.