### PR TITLE
Update pycbc_submit_dax

### DIFF
--- a/bin/pycbc_submit_dax
+++ b/bin/pycbc_submit_dax
@@ -424,10 +424,10 @@ echo
 rm -f submitdir
 ln -sf $SUBMIT_DIR submitdir
 
-echo pegasus-status $SUBMIT_DIR/work > status
+echo pegasus-status --verbose --long -$SUBMIT_DIR/work > status
 chmod 755 status
 
-echo pegasus-analyzer $SUBMIT_DIR/work > debug
+echo pegasus-analyzer -r -v $SUBMIT_DIR/work > debug
 chmod 755 debug
 
 echo pegasus-remove $SUBMIT_DIR/work > stop
@@ -469,7 +469,7 @@ fi
 EOF
 fi
 
-echo pegasus-run $SUBMIT_DIR/work >> start
+echo pegasus-run $SUBMIT_DIR/work > start
 
 chmod 755 start
 


### PR DESCRIPTION
Add more verbose default for analyze and pegasus status so that our default './status' and './debug' scripts give more meaningful output always. This means that status now reports the condor ids for example, which is pretty useful. 