### PR TITLE
Add documentation for developers about the new sampler API

### DIFF
--- a/docs/_include/inference_io_inheritance_diagrams.py
+++ b/docs/_include/inference_io_inheritance_diagrams.py
@@ -1,0 +1,34 @@
+# Creates RST for the sampler inheritance diagrams
+from __future__ import print_function
+import inspect
+from pycbc.inference.io import filetypes
+
+fname = 'inference_io_inheritance_diagrams.rst'
+
+def get_topclasses(cls):
+    """Gets the base classes that are in pycbc."""
+    bases = [c for c in inspect.getmro(cls)
+             if c.__module__.startswith('pycbc') and c != cls]
+    return ', '.join(['{}.{}'.format(c.__module__, c.__name__) for c in bases])
+
+tmplt = """.. _inheritance-io-{name}:
+
+* ``{name}``:
+
+.. inheritance-diagram:: {module}.{name}
+   :parts: 3
+   :top-classes: pycbc.inference.io.base_hdf.BaseInferenceFile
+
+|
+
+"""
+fp = open(fname, 'w')
+
+for ftname, cls in sorted(filetypes.items()):
+    # get the parents
+    topclasses = get_topclasses(cls)
+    out = tmplt.format(name=cls.__name__, module=cls.__module__)
+                       #topclasses=topclasses)
+    print(out, file=fp)
+
+fp.close()

--- a/docs/_include/inference_io_inheritance_diagrams.py
+++ b/docs/_include/inference_io_inheritance_diagrams.py
@@ -28,7 +28,6 @@ for ftname, cls in sorted(filetypes.items()):
     # get the parents
     topclasses = get_topclasses(cls)
     out = tmplt.format(name=cls.__name__, module=cls.__module__)
-                       #topclasses=topclasses)
     print(out, file=fp)
 
 fp.close()

--- a/docs/_include/inference_io_inheritance_diagrams.py
+++ b/docs/_include/inference_io_inheritance_diagrams.py
@@ -15,7 +15,7 @@ tmplt = """.. _inheritance-io-{name}:
 
 * ``{name}``:
 
-.. inheritance-diagram:: {module}.{name}
+.. inheritance-diagram:: {module}.{clsname}
    :parts: 3
    :top-classes: pycbc.inference.io.base_hdf.BaseInferenceFile
 
@@ -27,7 +27,8 @@ fp = open(fname, 'w')
 for ftname, cls in sorted(filetypes.items()):
     # get the parents
     topclasses = get_topclasses(cls)
-    out = tmplt.format(name=cls.__name__, module=cls.__module__)
+    out = tmplt.format(name=ftname, clsname=cls.__name__,
+                       module=cls.__module__)
     print(out, file=fp)
 
 fp.close()

--- a/docs/_include/sampler_inheritance_diagrams.py
+++ b/docs/_include/sampler_inheritance_diagrams.py
@@ -2,15 +2,13 @@
 from __future__ import print_function
 from pycbc.inference.sampler import samplers
 
-print("CREATING SAMPLER DIAGRAM")
-
 fname = 'sampler_inheritance_diagrams.rst'
 
-tmplt = """.. _inheritance-{}:
+tmplt = """.. _inheritance-{name}:
 
-* ``{}``:
+* ``{name}``:
 
-.. inheritance-diagram:: pycbc.inference.sampler.{}
+.. inheritance-diagram:: {module}.{name}
    :parts: 3
 
 |
@@ -19,6 +17,7 @@ tmplt = """.. _inheritance-{}:
 fp = open(fname, 'w')
 
 for sampler, cls in sorted(samplers.items()):
-    print(tmplt.format(sampler, sampler, cls.__name__), file=fp)
+    out = tmplt.format(name=cls.__name__, module=cls.__module__)
+    print(out, file=fp)
 
 fp.close()

--- a/docs/_include/sampler_inheritance_diagrams.py
+++ b/docs/_include/sampler_inheritance_diagrams.py
@@ -8,7 +8,7 @@ tmplt = """.. _inheritance-{name}:
 
 * ``{name}``:
 
-.. inheritance-diagram:: {module}.{name}
+.. inheritance-diagram:: {module}.{clsname}
    :parts: 3
 
 |
@@ -17,7 +17,8 @@ tmplt = """.. _inheritance-{name}:
 fp = open(fname, 'w')
 
 for sampler, cls in sorted(samplers.items()):
-    out = tmplt.format(name=cls.__name__, module=cls.__module__)
+    out = tmplt.format(name=sampler, clsname=cls.__name__,
+                       module=cls.__module__)
     print(out, file=fp)
 
 fp.close()

--- a/docs/_include/sampler_inheritance_diagrams.py
+++ b/docs/_include/sampler_inheritance_diagrams.py
@@ -1,0 +1,24 @@
+# Creates RST for the sampler inheritance diagrams
+from __future__ import print_function
+from pycbc.inference.sampler import samplers
+
+print("CREATING SAMPLER DIAGRAM")
+
+fname = 'sampler_inheritance_diagrams.rst'
+
+tmplt = """.. _inheritance-{}:
+
+* ``{}``:
+
+.. inheritance-diagram:: pycbc.inference.sampler.{}
+   :parts: 3
+
+|
+
+"""
+fp = open(fname, 'w')
+
+for sampler, cls in sorted(samplers.items()):
+    print(tmplt.format(sampler, sampler, cls.__name__), file=fp)
+
+fp.close()

--- a/docs/conf_std.py
+++ b/docs/conf_std.py
@@ -32,7 +32,8 @@ extensions = ['sphinx.ext.autodoc', 'sphinx.ext.doctest',
             'sphinxcontrib.programoutput',
          'sphinx.ext.napoleon',           'sphinx.ext.mathjax',
           'matplotlib.sphinxext.only_directives',
-          'matplotlib.sphinxext.plot_directive', 'sphinx.ext.autosummary']
+          'matplotlib.sphinxext.plot_directive', 'sphinx.ext.autosummary',
+          'sphinx.ext.inheritance_diagram']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -261,3 +262,10 @@ suppress_warnings = ['image.nonlocal_uri']
 def setup(app):
     app.add_javascript('typed.min.js')
     app.add_stylesheet('terminal.css')
+
+
+
+# -- Options for inheritance graphs -------------------------------------------
+
+# Makes the graphs be vertically aligned, with parents at the top
+inheritance_graph_attrs = {'rankdir': 'TB'}

--- a/docs/conf_std.py
+++ b/docs/conf_std.py
@@ -27,13 +27,13 @@ import pycbc.version
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = ['sphinx.ext.autodoc', 'sphinx.ext.doctest',
-          'sphinx.ext.intersphinx', 'sphinx.ext.coverage',
-              'sphinx.ext.viewcode',
-            'sphinxcontrib.programoutput',
-         'sphinx.ext.napoleon',           'sphinx.ext.mathjax',
-          'matplotlib.sphinxext.only_directives',
-          'matplotlib.sphinxext.plot_directive', 'sphinx.ext.autosummary',
-          'sphinx.ext.inheritance_diagram']
+              'sphinx.ext.intersphinx', 'sphinx.ext.coverage',
+              'sphinx.ext.viewcode', 'sphinxcontrib.programoutput',
+              'sphinx.ext.napoleon', 'sphinx.ext.mathjax',
+              'matplotlib.sphinxext.only_directives',
+              'matplotlib.sphinxext.plot_directive', 'sphinx.ext.autosummary',
+              'sphinx.ext.inheritance_diagram',
+              ]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -253,7 +253,9 @@ texinfo_documents = [
 
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'http://docs.python.org/': None}
+intersphinx_mapping = {'http://docs.python.org/': None,
+                       'h5py': ('http://docs.h5py.org/en/stable/', None),
+                      }
 
 napoleon_use_ivar = False
 

--- a/docs/conf_std.py
+++ b/docs/conf_std.py
@@ -13,6 +13,8 @@
 
 import sys, os
 import pycbc.version
+import subprocess
+import glob
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -260,6 +262,21 @@ intersphinx_mapping = {'http://docs.python.org/': None,
 napoleon_use_ivar = False
 
 suppress_warnings = ['image.nonlocal_uri']
+
+# build the dynamic files in _include
+def build_includes():
+    """Creates rst files in the _include directory using the python scripts
+    there."""
+    print("Running scripts in _include:")
+    cwd = os.getcwd()
+    os.chdir('_include')
+    pyfiles = glob.glob('*.py')
+    for fn in pyfiles:
+        print(fn)
+        subprocess.check_output(['python', fn])
+    os.chdir(cwd)
+
+build_includes()
 
 def setup(app):
     app.add_javascript('typed.min.js')

--- a/docs/inference.rst
+++ b/docs/inference.rst
@@ -575,3 +575,13 @@ Workflows
 
    workflow/pycbc_make_inference_workflow
    workflow/pycbc_make_inference_inj_workflow
+
+===============================================
+For Developers
+=============================================== 
+
+.. toctree::
+    :maxdepth: 1
+
+    inference/sampler_api.rst
+    inference/io.rst

--- a/docs/inference/io.rst
+++ b/docs/inference/io.rst
@@ -1,15 +1,171 @@
-=============================================================
+============
 Inference IO
-=============================================================
+============
 
-Emcee:
+.. Following are useful substituions for classes and modules
+.. |BaseInferenceFile| replace:: :py:class:`BaseInferenceFile <pycbc.inference.io.base_hdf.BaseInferenceFile>`
+.. |PosteriorFile| replace:: :py:class:`PosteriorFile <pycbc.inference.io.posterior.PosteriorFile>`
+.. |InferenceTXTFile| replace:: :py:class:`InferenceTXTFile <pycbc.inference.io.txt.InferenceTXTFile>`
+.. |MCMCIO| replace:: :py:class:`MCMCIO <pycbc.inference.io.base_mcmc.MCMCIO>`
+.. |MCMCIO.write_samples| replace:: :py:meth:`MCMCIO.write_samples <pycbc.inference.io.base_mcmc.MCMCIO.write_samples>`
+.. |MCMCIO.read_raw_samples| replace:: :py:meth:`MCMCIO.read_raw_samples <pycbc.inference.io.base_mcmc.MCMCIO.read_raw_samples>`
+.. |EmceeEnsembleSampler| replace:: :py:class:`EmceeEnsembleSampler <pycbc.inference.sampler.emcee.EmceeEnsembleSampler>`
+.. |EmceeFile| replace:: :py:class:`EmceeFile <pycbc.inference.io.emcee.EmceeFile>`
+
+The :py:mod:`pycbc.inference.io` module provides classes and utilities for
+reading and writing inference results to files. Each sampler must have a unique
+class for reading/writing that sampler's results from/to a file.  These are the
+*sampler IO classes*. Below, we provide an overview of the general structure of
+these IO classes.
+
+---------------------
+Overview & Guidelines
+---------------------
+
+The guidelines for creating sampler IO classes are similar to the :ref:`sampler
+classes <sampler_api-overview>`, though only having a single level of
+inheritance is not required (since the base file class, |BaseInferenceFile|,
+itself inherits from :py:class:`h5py.File <h5py:File>`). The following apply to
+all sampler IO classes:
+
+1. All sampler IO classes must inherit from |BaseInferenceFile|. This is an
+   :py:mod:`abstract base class <abc>` that inherits from
+   :py:class:`h5py.File <h5py:File>`; consequently, all samplers will write to
+   hdf files.
+2. All sampler IO classes must have a ``name`` attribute that is unique across
+   all IO classes in :py:mod:`pycbc.inference.io`. This name is saved to the
+   file and used to determine which class to read the file with when it is
+   loaded (see :py:meth:`io.loadfile <pycbc.inference.io.loadfile>` for
+   details). For example, the name attribute for |EmceeFile| -- the IO class
+   for |EmceeEnsembleSampler| -- is ``emcee_file``.
+3. Duplicate code should be avoided. If multiple samplers have common IO
+   methods, those methods should be added to one or more support classes that
+   the IO class can inherit from, in addition to |BaseInferenceFile|. For
+   example, all single-temperature MCMC samplers save their samples as
+   ``nchains x niteraitons`` datasets. Consequently, functionality to read and
+   write samples for single-temperature MCMC samplers is provided by the
+   |MCMCIO| class, by the |MCMCIO.read_raw_samples| and |MCMCIO.write_samples|
+   methods, respectively.
+4. The ratio of sampler IO classes to sampler classes should be 1:1. That is,
+   each sampler should have a unique IO class and each IO class should only be
+   used by one sampler.
+5. The files that the sampler IO classes provide IO to are used for
+   checkpointing by ``pycbc_inference``, and are the final data product that
+   the program creates. This means that a sampler IO class must store enough
+   information to the file such that the sampler can be initialized and
+   continue running (either to resume for checkpoint, or to use the output of
+   a run as the initial conditions for another run, to accumulate more
+   points) as if the sampler had run continuously.
+6. All samples, including any statistics returned by the
+   :py:mod:`model <pycbc.inference.models>` (log likelihood, log prior, etc.)
+   should be stored as datasets (one for each parameter or statistic) to the
+   file's ``samples`` group. The shape of the datasets may be sampler (and run)
+   specific.
+7. All sampler-specific data and metadata should be stored to the file's
+   ``sampler_info`` group. What is in the ``sampler_info`` group and its
+   organization may be sampler specific. This is where any additional
+   information needed to start the sampler from a checkpoint (such as the
+   random state) should be stored.
+8. Models may write additional information to the files. For example,
+   data-dependent models may save the data that was analyzed to the ``data``
+   group.  See the :py:mod:`pycbc.inference.models` module for more details.
+
+As mentioned above, the |BaseInferenceFile| class is the abstract base class
+that defines the methods and properties that all sampler IO classes must have.
+The abstract methods that IO classes must override are:
+
+ * :py:meth:`read_raw_samples <pycbc.inference.io.base_hdf.BaseInferenceFile.read_raw_samples>` 
+ * :py:meth:`write_samples <pycbc.inference.io.base_hdf.BaseInferenceFile.write_samples>` 
+ * :py:meth:`write_posterior <pycbc.inference.io.base_hdf.BaseInferenceFile.write_posterior>` 
+ * :py:meth:`write_resume_point <pycbc.inference.io.base_hdf.BaseInferenceFile.write_resume_point>` 
+ * :py:meth:`write_sampler_metadata <pycbc.inference.io.base_hdf.BaseInferenceFile.write_sampler_metadata>` 
+
+---------------
+Posterior Files
+---------------
+
+In addition to the sampler IO classes, there are two special classes who's
+purpose is to just store a posterior. These are the |PosteriorFile| and
+|InferenceTXTFile| classes.
+
+|PosteriorFile| read/writes hdf files. Like the sampler IO classes, it inherits
+from |BaseInferenceFile|. The key difference is that all of the datasets in
+the ``samples`` group are simple, flattened 1D arrays representing the
+posterior. All sampler IO classes must be able to write their samples to a
+|PosteriorFile| via their ``write_posterior`` method (which is required by
+|BaseInferenceFile|). A |PosteriorFile| may or may not have other metadata in
+it -- ``sampler_info``, model data, etc. -- depending on the file that it was
+created from. The only guaranteed property is that the ``samples`` are 1D
+arrays.
+
+Since a |PosteriorFile| may only contain 1D arrays of the samples, it most
+likely cannot be used to resume a ``pycbc_inference`` run, as a sampler IO file
+can. For example, a multi-tempered MCMC sampler would only write samples from
+its coldest temperature chain to a |PosteriorFile|, discarding samples from the
+hotter chains. A |PosteriorFile| is therefore not created by
+``pycbc_inference``.  Instead, ``pycbc_inference_extract_samples`` may be run
+on a sampler file to produce a |PosteriorFile|. The primary purpose of a
+|PosteriorFile| is to provide a compact, easy to read file that is universal
+for all samplers.
+
+The |InferenceTXTFile| class takes this universality one step further: it is a
+simple text file containing 1D arrays of the posterior samples for each
+parameter. The primary purpose of |InferenceTXTFile| is to provide an API for
+text files that is similar to the sampler IO and |PosteriorFile| classes, so
+that ``pycbc_inference_plot_posterior`` may be used on results from any
+software suite (e.g., this is used to compare results from ``pycbc_inference``
+to posteriors published by the LIGO Scientific Collaboration).
+
+---------------------
+Inheritance diagrams
+---------------------
+
+The following are inheritance diagrams for all of the currently supported IO
+classes:
+
+* ``emcee``:
 
 .. inheritance-diagram:: pycbc.inference.io.emcee
-    :parts: 2
-    :top-classes: pycbc.inference.io.base_hdf.BaseInferenceFile, pycbc.inference.io.base_mcmc.MCMCIO
+   :parts: 2
+   :top-classes: pycbc.inference.io.base_hdf.BaseInferenceFile, pycbc.inference.io.base_mcmc.MCMCIO
 
-Emcee PT:
+|
+
+* ``emcee_pt``:
 
 .. inheritance-diagram:: pycbc.inference.io.emcee_pt
-    :parts: 2
-    :top-classes: pycbc.inference.io.base_hdf.BaseInferenceFile, pycbc.inference.io.base_mcmc.MCMCIO
+   :parts: 2
+   :top-classes: pycbc.inference.io.base_hdf.BaseInferenceFile, pycbc.inference.io.base_mcmc.MCMCIO
+
+|
+
+.. _how-to-add-a-sampler-io:
+
+-----------------------------
+How to add a sampler IO class
+-----------------------------
+
+If you are :ref:`adding support for a new sampler <how-to-add-a-sampler>` you
+will also need to add a new sampler IO class. The following are steps to do
+that:
+
+1. Create a file in ``pycbc/inference/io`` for the new sampler IO class.
+2. Add the new class definition. The class must inherit from at least
+   |BaseInferenceFile|.
+3. Give a name attribute to the class that is unique across the sampler IO
+   classes.
+4. Add any other methods you need to satisfy the |BaseInferenceFile|'s required
+   methods, plus other functionality needed to read/write relevant metadata
+   about the sampler. You are free to write as much metadata in any format you
+   like to the ``sampler_info`` group. When adding methods, try to follow the
+   guidelines above: do not duplicate code, and try to use support classes that
+   offer functionality that you need. If you think some of the methods will be
+   useful for more than just your sampler, create a new support class and add
+   those methods to it.  However, if you're unsure what is available or how
+   best to arrange things, just add the methods you need to your new class
+   definition. Fixing code duplication or updating support classes to can be
+   done through the review process when you wish to add your new sampler to the
+   main gwastro repository.
+5. Add the sampler IO class to the ``filetypes`` dictionary in
+   ``pycbc/inference/io/__init__.py`` so that
+   :py:meth:`io.loadfile <pycbc.inference.io.loadfile>` is aware of it to use.

--- a/docs/inference/io.rst
+++ b/docs/inference/io.rst
@@ -1,0 +1,15 @@
+=============================================================
+Inference IO
+=============================================================
+
+Emcee:
+
+.. inheritance-diagram:: pycbc.inference.io.emcee
+    :parts: 2
+    :top-classes: pycbc.inference.io.base_hdf.BaseInferenceFile, pycbc.inference.io.base_mcmc.MCMCIO
+
+Emcee PT:
+
+.. inheritance-diagram:: pycbc.inference.io.emcee_pt
+    :parts: 2
+    :top-classes: pycbc.inference.io.base_hdf.BaseInferenceFile, pycbc.inference.io.base_mcmc.MCMCIO

--- a/docs/inference/io.rst
+++ b/docs/inference/io.rst
@@ -123,21 +123,7 @@ Inheritance diagrams
 The following are inheritance diagrams for all of the currently supported IO
 classes:
 
-* ``emcee``:
-
-.. inheritance-diagram:: pycbc.inference.io.emcee
-   :parts: 2
-   :top-classes: pycbc.inference.io.base_hdf.BaseInferenceFile, pycbc.inference.io.base_mcmc.MCMCIO
-
-|
-
-* ``emcee_pt``:
-
-.. inheritance-diagram:: pycbc.inference.io.emcee_pt
-   :parts: 2
-   :top-classes: pycbc.inference.io.base_hdf.BaseInferenceFile, pycbc.inference.io.base_mcmc.MCMCIO
-
-|
+.. include:: ../_include/inference_io_inheritance_diagrams.rst
 
 .. _how-to-add-a-sampler-io:
 

--- a/docs/inference/sampler_api.rst
+++ b/docs/inference/sampler_api.rst
@@ -87,7 +87,6 @@ Let's examine the |EmceeEnsembleSampler| class to see how these guidelines
 apply in practice. Here is its inheritance structure (click on the names of the
 classes to see their documentation):
 
-.. _inheritance-emcee:
 .. inheritance-diagram:: pycbc.inference.sampler.emcee
     :parts: 2
 

--- a/docs/inference/sampler_api.rst
+++ b/docs/inference/sampler_api.rst
@@ -154,16 +154,9 @@ unique features of different samplers, while keeping the base API that
 Inheritance diagrams
 ---------------------
 
-Here are inheritance diagrams for the rest of the samplers currently supported:
+Here are inheritance diagrams for all of the currently supported samplers:
 
-.. _inheritance-emcee_pt:
-
-* ``emcee_pt``:
-
-.. inheritance-diagram:: pycbc.inference.sampler.emcee_pt
-   :parts: 2
-
-|
+.. include:: ../_include/sampler_inheritance_diagrams.rst
 
 .. _how-to-add-a-sampler:
 

--- a/docs/inference/sampler_api.rst
+++ b/docs/inference/sampler_api.rst
@@ -15,7 +15,7 @@ Overview & Guidelines
 The following guidelines apply to the sampler classes:
 
 1. All sampler classes must inherit from the 
-   :py:class:`BaseSampler <pycbc.inference.sampler.BaseSampler>` class. This is
+   :py:class:`BaseSampler <pycbc.inference.sampler.base.BaseSampler>` class. This is
    an :py:mod:`abstract base class <abc>` that defines methods that all
    samplers must implement, as they will be used by ``pycbc_inference``. (See
    `this tutorial <https://www.python-course.eu/python3_abstract_classes.php>`_
@@ -64,6 +64,7 @@ structure (click on the names of the classes to see their documentation):
 .. _inheritance-emcee:
 .. inheritance-diagram:: pycbc.inference.sampler.emcee
     :parts: 2
+|
 
 In addition to :py:class:`BaseSampler <pycbc.inference.sampler.base.BaseSampler>`,
 :py:class:`EmceeEnsembleSampler <pycbc.inference.sampler.emcee.EmceeEnsembleSampler>`
@@ -160,3 +161,37 @@ Here are inheritance diagrams for the rest of the samplers currently supported:
 
 .. inheritance-diagram:: pycbc.inference.sampler.emcee_pt
     :parts: 2
+|
+
+--------------------
+How to add a sampler
+--------------------
+
+To add support for a new sampler, do the following:
+
+1. Create a file in ``pycbc/inference/sampler`` for the new sampler's class.
+2. Add the new class definition. The class must inherit from at least
+   :py:class:`BaseSampler <pycbc.inference.sampler.base.BaseSampler>`.
+3. Give a name attribute to the class that is unique across the supported
+   sampler classes.
+4. Add an IO class for the sampler to the :py:mod:`inference.io <pycbc.inference.io>`
+   modules. Set your new class's ``io`` attribute to point to this new class.
+
+5. Add any other methods you need to satisfy the
+   :py:class:`BaseSampler's <pycbc.inference.sampler.base.BaseSampler>`
+   required methods. When doing so, try to follow the guidelines above: do not
+   duplicate code, and try to use support classes that offer functionality that
+   you need. If you think some of the methods will be useful for more than just
+   your sampler, create a new support class and add those methods to it.
+   However, if you're unsure what is available or you would have to make
+   changes to the support classes that may break other samplers, just add the
+   methods you need to your new class definition. Fixing code duplication or
+   rearranging support classes to accommodate can be done through the review
+   process when you wish to add your new sampler to main gwastro repository.
+
+6. Add the sampler to the ``samplers`` dictionary in
+   ``pycbc/inference/sampler/__init__.py`` so that ``pycbc_inference`` is aware
+   of it to use.
+7. When you're satisfied that your new sampler works,
+   `file a pull request <https://github.com/gwastro/pycbc/blob/master/CONTRIBUTING.md#open-a-pull-request>`_ to get it into the main gwastro repostiory. Thank you for
+   your contributions!

--- a/docs/inference/sampler_api.rst
+++ b/docs/inference/sampler_api.rst
@@ -31,6 +31,8 @@ provide an overview of the general structure of the sampler classes, how it
 interacts with ``pycbc_inference``, and how to add support for new samplers. We
 also provide inheritance diagrams for all of the currently supported samplers.
 
+.. _sampler_api-overview:
+
 ---------------------
 Overview & Guidelines
 ---------------------
@@ -42,7 +44,12 @@ The following guidelines apply to the sampler classes:
    samplers must implement, as they will be used by ``pycbc_inference``. (See
    `this tutorial <https://www.python-course.eu/python3_abstract_classes.php>`_
    for a primer on abstract base classes.)
-2. Duplicate code should be avoided. If multiple samplers have common methods,
+2. All sampler classes must have a ``name`` attribute that is unique across
+   all sampler classes in :py:mod:`pycbc.inference.sampler`. This name is used
+   to reference the sampler throughout the code, and is how the user specifies
+   which sampler to use in their config file. For example,
+   |EmceeEnsembleSampler|'s name is ``'emcee'``.
+3. Duplicate code should be avoided. If multiple samplers have common methods,
    those methods should be added to one or more support classes that the
    samplers can inherit from, in addition to |BaseSampler|. For example, all
    MCMC samplers need to be able to compute an autocorrelation length. That
@@ -50,11 +57,11 @@ The following guidelines apply to the sampler classes:
    |MCMCAutocorrSupport| class. These support classes may themselves be
    abstract base classes which add more required methods to samplers that
    inherit from them.
-3. Inheritance is kept to one level. For example, if we have sampler class
+4. Inheritance is kept to one level. For example, if we have sampler class
    ``Foo(Bar, BaseSampler)``, both ``Bar`` and ``BaseSampler`` do not inherit
    from any parent classes, only ``object``.
-4. To avoid confusion, only inherited abstract methods should be overridden.
-5. All sampler classes need a corresponding class in the
+5. To avoid confusion, only inherited abstract methods should be overridden.
+6. All sampler classes need a corresponding class in the
    :py:mod:`pycbc.inference.io` module for handling reading and writing. See
    :doc:`io` for more details on IO classes.
 
@@ -83,6 +90,7 @@ classes to see their documentation):
 .. _inheritance-emcee:
 .. inheritance-diagram:: pycbc.inference.sampler.emcee
     :parts: 2
+
 |
 
 In addition to |BaseSampler|, |EmceeEnsembleSampler| inherits from |BaseMCMC|
@@ -149,11 +157,15 @@ Inheritance diagrams
 Here are inheritance diagrams for the rest of the samplers currently supported:
 
 .. _inheritance-emcee_pt:
+
 * ``emcee_pt``:
 
 .. inheritance-diagram:: pycbc.inference.sampler.emcee_pt
-    :parts: 2
+   :parts: 2
+
 |
+
+.. _how-to-add-a-sampler:
 
 --------------------
 How to add a sampler
@@ -166,20 +178,19 @@ To add support for a new sampler, do the following:
    |BaseSampler|.
 3. Give a name attribute to the class that is unique across the supported
    sampler classes.
-4. Add an IO class for the sampler to the :py:mod:`inference.io <pycbc.inference.io>`
-   modules. Set your new class's ``io`` attribute to point to this new class.
-
-5. Add any other methods you need to satisfy the |BaseSampler|'s
-   required methods. When doing so, try to follow the guidelines above: do not
-   duplicate code, and try to use support classes that offer functionality that
-   you need. If you think some of the methods will be useful for more than just
-   your sampler, create a new support class and add those methods to it.
-   However, if you're unsure what is available or you would have to make
-   changes to the support classes that may break other samplers, just add the
-   methods you need to your new class definition. Fixing code duplication or
-   rearranging support classes to accommodate can be done through the review
-   process when you wish to add your new sampler to main gwastro repository.
-
+4. :ref:`Add an IO class <how-to-add-a-sampler-io>` for the sampler to the
+   :py:mod:`inference.io <pycbc.inference.io>` modules. Set your new class's
+   ``io`` attribute to point to this new class.
+5. Add any other methods you need to satisfy the |BaseSampler|'s required
+   methods. When doing so, try to follow the guidelines above: do not duplicate
+   code, and try to use support classes that offer functionality that you need.
+   If you think some of the methods will be useful for more than just your
+   sampler, create a new support class and add those methods to it.  However,
+   if you're unsure what is available or you would have to make changes to the
+   support classes that may break other samplers, just add the methods you need
+   to your new class definition. Fixing code duplication or rearranging support
+   classes can be done through the review process when you wish to add your new
+   sampler to the main gwastro repository.
 6. Add the sampler to the ``samplers`` dictionary in
    ``pycbc/inference/sampler/__init__.py`` so that ``pycbc_inference`` is aware
    of it to use.

--- a/docs/inference/sampler_api.rst
+++ b/docs/inference/sampler_api.rst
@@ -2,6 +2,29 @@
 Sampler API
 ===========
 
+.. Following are useful substituions for classes and modules
+.. BaseSampler:
+.. |BaseSampler| replace:: :py:class:`BaseSampler <pycbc.inference.sampler.base.BaseSampler>`
+.. BaseMCMC:
+.. |BaseMCMC| replace:: :py:class:`BaseMCMC <pycbc.inference.sampler.base_mcmc.BaseMCMC>`
+.. |BaseMCMC.set_initial_conditions| replace:: :py:meth:`set_initial_conditions <pycbc.inference.sampler.base_mcmc.BaseMCMC.set_initial_conditions>`
+.. |BaseMCMC.run| replace:: :py:meth:`run <pycbc.inference.sampler.base_mcmc.BaseMCMC.run>`
+.. |BaseMCMC.run_mcmc| replace:: :py:meth:`BaseMCMC.run_mcmc <pycbc.inference.sampler.base_mcmc.BaseMCMC.run_mcmc>`
+.. |BaseMCMC.checkpoint| replace:: :py:meth:`checkpoint <pycbc.inference.sampler.base_mcmc.BaseMCMC.checkpoint>`
+.. |BaseMCMC.checkpoint_interval| replace:: :py:attr:`checkpoint_interval <pycbc.inference.sampler.base_mcmc.BaseMCMC.checkpoint_interval>`
+.. |BaseMCMC.set_target| replace:: :py:meth:`set_target <pycbc.inference.sampler.base_mcmc.BaseMCMC.set_target>`
+.. |BaseMCMC.compute_acf| replace:: :py:meth:`compute_acf <pycbc.inference.sampler.base_mcmc.BaseMCMC.compute_acf>`
+.. |BaseMCMC.compute_acl| replace:: :py:meth:`compute_acl <pycbc.inference.sampler.base_mcmc.BaseMCMC.compute_acl>`
+.. MCMCAutocorrSupport
+.. |MCMCAutocorrSupport| replace:: :py:class:`MCMCAutocorrSupport <pycbc.inference.sampler.base_mcmc.MCMCAutocorrSupport>`
+.. EmceEnsembleSampler
+.. |EmceeEnsembleSampler| replace:: :py:class:`EmceeEnsembleSampler <pycbc.inference.sampler.emcee.EmceeEnsembleSampler>`
+.. |EmceeEnsembleSampler.run_mcmc| replace:: :py:meth:`run_mcmc <pycbc.inference.sampler.emcee.EmceeEnsembleSampler.run_mcmc>`
+.. MultiTemperedAutocorrSupport
+.. |MultiTemperedAutocorrSupport| replace:: :py:class:`MultiTemperedAutocorrSupport <pycbc.sampler.base_multitemper.MultiTemperedAutocorrSuppport>`
+.. EmceePTSampler
+.. |EmceePTSampler| replace:: :py:class:`EmceePTSampler <pycbc.sampler.emcee_pt.EmceePTSampler>`
+
 The :py:mod:`pycbc.inference.sampler` module is the interface between
 ``pycbc_inference`` and the sampling engines, such as ``emcee``. Below, we
 provide an overview of the general structure of the sampler classes, how it
@@ -14,21 +37,19 @@ Overview & Guidelines
 
 The following guidelines apply to the sampler classes:
 
-1. All sampler classes must inherit from the 
-   :py:class:`BaseSampler <pycbc.inference.sampler.base.BaseSampler>` class. This is
+1. All sampler classes must inherit from the |BaseSampler| class. This is
    an :py:mod:`abstract base class <abc>` that defines methods that all
    samplers must implement, as they will be used by ``pycbc_inference``. (See
    `this tutorial <https://www.python-course.eu/python3_abstract_classes.php>`_
    for a primer on abstract base classes.)
 2. Duplicate code should be avoided. If multiple samplers have common methods,
    those methods should be added to one or more support classes that the
-   samplers can inherit from, in addition to
-   :py:class:`BaseSampler <pycbc.inference.sampler.base.BaseSampler>`. For
-   example, all MCMC samplers need to be able to compute an autocorrelation
-   length. That functionality is provided for single-temperature MCMCs in
-   :py:class:`MCMCAutocorrSupport <pycbc.inference.sampler.MCMCAutocoorSupport>`
-   class. These support classes may themselves be abstract base classes which
-   add more required methods to samplers that inherit from them.
+   samplers can inherit from, in addition to |BaseSampler|. For example, all
+   MCMC samplers need to be able to compute an autocorrelation length. That
+   functionality is provided for single-temperature MCMCs in the
+   |MCMCAutocorrSupport| class. These support classes may themselves be
+   abstract base classes which add more required methods to samplers that
+   inherit from them.
 3. Inheritance is kept to one level. For example, if we have sampler class
    ``Foo(Bar, BaseSampler)``, both ``Bar`` and ``BaseSampler`` do not inherit
    from any parent classes, only ``object``.
@@ -37,11 +58,10 @@ The following guidelines apply to the sampler classes:
    :py:mod:`pycbc.inference.io` module for handling reading and writing. See
    :doc:`io` for more details on IO classes.
 
-As mentioned above, the
-:py:class:`BaseSampler <pycbc.inference.sampler.base.BaseSampler>` class is an
-abstract base class. It defines a collection of abstract methods and properties
-that all samplers must override in order to function properly. These are (click
-on the names to see their documentation):
+As mentioned above, the |BaseSampler| class is an abstract base class. It
+defines a collection of abstract methods and properties that all samplers must
+override in order to function properly. These are (click on the names to see
+their documentation):
 
  * :py:meth:`from_config <pycbc.inference.sampler.base.BaseSampler.from_config>`
  * :py:attr:`io <pycbc.inference.sampler.base.BaseSampler.io>`
@@ -56,93 +76,65 @@ on the names to see their documentation):
 Detailed example
 ----------------
 
-Let's examine the
-:py:class:`EmceeEnsembleSampler <pycbc.inference.sampler.emcee.EmceeEnsembleSampler>`
-class to see how these guidelines apply in practice. Here is its inheritance
-structure (click on the names of the classes to see their documentation):
+Let's examine the |EmceeEnsembleSampler| class to see how these guidelines
+apply in practice. Here is its inheritance structure (click on the names of the
+classes to see their documentation):
 
 .. _inheritance-emcee:
 .. inheritance-diagram:: pycbc.inference.sampler.emcee
     :parts: 2
 |
 
-In addition to :py:class:`BaseSampler <pycbc.inference.sampler.base.BaseSampler>`,
-:py:class:`EmceeEnsembleSampler <pycbc.inference.sampler.emcee.EmceeEnsembleSampler>`
-inherits from :py:class:`BaseMCMC <pycbc.inference.sampler.base_mcmc.BaseMCMC>` and
-:py:class:`MCMCAutocorrSupport <pycbc.inference.sampler.base_mcmc.MCMCAutocorrSupport>`.
-Inspecting :py:class:`BaseMCMC <pycbc.inference.sampler.base_mcmc.BaseMCMC>`,
-we see that it implements several of the methods that
-:py:class:`BaseSampler <pycbc.inference.sampler.base.BaseSampler>` requires: namely,
-:py:meth:`set_initial_conditions <pycbc.inference.sampler.bsae_mcmc.BaseMCMC.set_initial_conditions>`,
-:py:meth:`run <pycbc.inference.sampler.base_mcmc.BaseMCMC.run>`, and
-:py:meth:`checkpoint <pycbc.inference.sampler.base_mcmc.BaseMCMC.checkpoint>`.
+In addition to |BaseSampler|, |EmceeEnsembleSampler| inherits from |BaseMCMC|
+and |MCMCAutocorrSupport|.  Inspecting |BaseMCMC|, we see that it implements
+several of the methods that |BaseSampler| requires: namely,
+|BaseMCMC.set_initial_conditions|, |BaseMCMC.run|, and |BaseMCMC.checkpoint|.
 This is because the steps taken in these functions are common across MCMC
-samplers. For example, in :py:meth:`run <pycbc.inference.sampler.base_mcmc.BaseMCMC.run>`,
-the sampler is run for blocks of iterations (specified by
-:py:attr:`checkpoint_interval <pycbc.inference.sampler.base_mcmc.checkpoint_interval>`)
-until the convergence criteria has been met (which is determined by
-:py:meth:`set_target <pycbc.inference.sampler.base_mcmc.set_target>`). This,
+samplers. For example, in |BaseMCMC.run|, the sampler is run for blocks of
+iterations (specified by |BaseMCMC.checkpoint_interval|) until the convergence
+criteria has been met (which is determined by |BaseMCMC.set_target|). This,
 generally, is what all MCMC samplers do.
 
 *How* an MCMC sampler is run for some number of iterations is unique to each
-sampling engine. Thus, in :py:meth:`run <pycbc.inference.sampler.base_mcmc.BaseMCMC.run>`,
-a call to :py:meth:`run_mcmc <pycbc.inference.sampler.base_mcmc.BaseMCMC.run_mcmc>`
-is made. This is an abstract method: i.e., :py:class:`BaseMCMC <pycbc.inference.sampler.base_mcmc.BaseMCMC>`
-is itself an abstract base class. Since
-:py:class:`EmceeEnsembleSampler <pycbc.inference.sampler.emcee.EmceeEnsembleSampler>`
-inherits from :py:class:`BaseSampler <pycbc.inference.sampler.base.BaseSampler>`
-followed by :py:class:`BaseMCMC <pycbc.inference.sampler.base_mcmc.BaseMCMC>`
-(see :ref:`note <python-inheritance-note>`),
-:py:class:`BaseMCMC <pycbc.inference.sampler.base_mcmc.BaseMCMC>` fulfils
-:py:class:`BaseSampler's <pycbc.inference.sampler.base.BaseSampler>` requirement
-that a ``run`` method be implemented, but replaces it with the requirement that
-a ``run_mcmc`` method be implemented. This is why
-:py:class:`EmceeEmsembleSampler <pycbc.inference.sampler.emcee.EmceeEnsembleSampler>`
-implements a :py:meth:`run_mcmc <pycbc.inference.sampler.emcee.EmceeEnsembleSampler.run_mcmc>`
-method.
+sampling engine. To accommodate this, |BaseMCMC| adds |BaseMCMC.run_mcmc|,
+which it calls from within its |BaseMCMC.run|.  |BaseMCMC.run_mcmc| is an
+abstract method -- |BaseMCMC| is itself an abstract base class. Since
+|EmceeEnsembleSampler| inherits from |BaseSampler|, followed by |BaseMCMC| (see
+:ref:`note <python-inheritance-note>`), |BaseMCMC| fulfils |BaseSampler|'s
+requirement that a ``run`` method be implemented, but replaces it with the
+requirement that the class define a ``run_mcmc`` method.  As a result,
+|EmceeEnsembleSampler| has its own |EmceeEnsembleSampler.run_mcmc|; this is
+where the call to the underlying sampling engine (external to pycbc) is made.
 
 .. _python-inheritance-note: 
 .. note::
-   In python, the order of inheritance when a class inherits from multiple
-   parents is determined by the order the parents are given in the class
-   definition, from right to left. For example,
-   :py:class:`EmceeEnsembleSampler <pycbc.inference.sampler.emcee.EmceeEnsembleSampler>`
-   is defined as:
+   In python, the order of inheritance is determined by the order the parents
+   are given in the class definition, from right to left. For example,
+   |EmceeEnsembleSampler| is defined as:
 
    .. code-block:: python
 
       class EmceeEnsembleSampler(MCMCAutocorrSupport, BaseMCMC, BaseSampler):
 
-   This means that methods introduced by
-   :py:class:`BaseSampler <pycbc.inference.sampler.base.BaseSampler>`
-   will be overridden by
-   :py:class:`BaseMCMC <pycbc.inference.sampler.base_mcmc.BaseMCMC>`, which in
-   turn will be overridden by
-   :py:class:`MCMCAutocorrSupport <pycbc.inference.sampler.base_mcmc.MCMCAutocorrSupport>`.
-   For this reason, all sampler class definitions must have
-   :py:class:`BaseSampler <pycbc.inference.sampler.base.BaseSampler>`
-   listed last.
+   This means that methods introduced by |BaseSampler| will be overridden by
+   |BaseMCMC|, which in turn will be overridden by |MCMCAutocorrSupport|.  For
+   this reason, all sampler class definitions must have |BaseSampler| listed
+   last.
 
-All MCMC samplers need to be able to compute an autocorrelation
-function (ACF) and length (ACL). This is used to determine how to thin the chains
-to obtain independent samples. Consequently, :py:class:`BaseMCMC <pycbc.inference.sampler.base_mcmc.BaseMCMC>`
-also adds abstract base methods :py:meth:`compute_acf <pycbc.inference.sampler.base_mcmc.BaseMCMC.compute_acf>`
-and :py:meth:`compute_acl <pycbc.inference.sampler.base_mcmc.BaseMCMC.compute_acl>`; these
-are called by its :py:class:`checkpoint <pycbc.inference.sampler.base_mcmc.BaseMCMC.checkpoint>` method.
-The :py:class:`MCMCAutocorrSupport <pycbc.inference.sampler.base_mcmc.MCMCAutocorrSupport>`
-provides these functions. These
-functions are provided in a class separate from :py:class:`BaseMCMC <pycbc.inference.sampler.base_mcmc.BaseMCMC>`
+All MCMC samplers need to be able to compute an autocorrelation function (ACF)
+and length (ACL). This is used to determine how to thin the chains to obtain
+independent samples. Consequently, |BaseMCMC| also adds abstract base methods
+|BaseMCMC.compute_acf| and |BaseMCMC.compute_acl|; these are called by its
+|BaseMCMC.checkpoint| method.  The |MCMCAutocorrSupport| class provides these
+functions. These functions are provided in a class separate from |BaseMCMC|
 because not all MCMC samplers estimate ACF/Ls in the same way. For example,
 multi-tempered samplers need to compute ACF/Ls separately for each temperature
-chain. Consequently, there is an equivalent class,
-:py:class:`MultiTemperedAutocorrSupport <pycbc.sampler.base_multitemper.MultiTemperedAutocorrSuppport>`
-which offers the same functions for multi-tempered MCMCs. This class is used by,
-e.g., :py:class:`EmceePTSampler <pycbc.sampler.emcee_pt.EmceePTSampler>` (see its
+chain. Consequently, there is an equivalent class
+|MultiTemperedAutocorrSupport| that offers the same functions for
+multi-tempered MCMCs. This class is used by, e.g., |EmceePTSampler| (see its
 :ref:`inheritance diagram <inheritance-emcee_pt>`, below). By making the
-compute ACF/L functions abstract base methods in
-:py:class:`BaseMCMC <pycbc.inference.sampler.base_mcmc.BaseMCMC>`, both single and
-multi-tempered MCMC samplers can inherit from
-:py:class:`BaseMCMC <pycbc.inference.sampler.base_mcmc.BaseMCMC>`.
+compute ACF/L functions abstract base methods in |BaseMCMC|, both single and
+multi-tempered MCMC samplers can inherit from |BaseMCMC|.
 
 
 We see that by separating functionality out into support classes
@@ -171,14 +163,13 @@ To add support for a new sampler, do the following:
 
 1. Create a file in ``pycbc/inference/sampler`` for the new sampler's class.
 2. Add the new class definition. The class must inherit from at least
-   :py:class:`BaseSampler <pycbc.inference.sampler.base.BaseSampler>`.
+   |BaseSampler|.
 3. Give a name attribute to the class that is unique across the supported
    sampler classes.
 4. Add an IO class for the sampler to the :py:mod:`inference.io <pycbc.inference.io>`
    modules. Set your new class's ``io`` attribute to point to this new class.
 
-5. Add any other methods you need to satisfy the
-   :py:class:`BaseSampler's <pycbc.inference.sampler.base.BaseSampler>`
+5. Add any other methods you need to satisfy the |BaseSampler|'s
    required methods. When doing so, try to follow the guidelines above: do not
    duplicate code, and try to use support classes that offer functionality that
    you need. If you think some of the methods will be useful for more than just

--- a/docs/inference/sampler_api.rst
+++ b/docs/inference/sampler_api.rst
@@ -1,0 +1,118 @@
+===========
+Sampler API
+===========
+
+The :py:mod:`pycbc.inference.sampler` module is the interface between
+``pycbc_inference`` and the sampling engines, such as ``emcee``. Below, we
+provide an overview of the general structure of the sampler classes, how it
+interacts with ``pycbc_inference``, and how to add support for new samplers. We
+also provide inheritance diagrams for all of the currently supported samplers.
+
+---------------------
+Overview & Guidelines
+---------------------
+
+The following guidelines apply to the sampler classes:
+
+1. All sampler classes must inherit from the 
+   :py:class:`BaseSampler <pycbc.inference.sampler.BaseSampler>` class. This is
+   an :py:mod:`abstract base class <abc>` that defines methods that all
+   samplers must implement, as they will be used by ``pycbc_inference``. (See
+   `this tutorial <https://www.python-course.eu/python3_abstract_classes.php>`_
+   for a primer on abstract base classes.)
+2. Duplicate code should be avoided. If multiple samplers have common methods,
+   those methods should be added to one or more support classes that the
+   samplers can inherit from, in addition to
+   :py:class:`BaseSampler <pycbc.inference.sampler.base.BaseSampler>`. For
+   example, all MCMC samplers need to be able to compute an autocorrelation
+   length. That functionality is provided for single-temperature MCMCs in
+   :py:class:`MCMCAutocorrSupport <pycbc.inference.sampler.MCMCAutocoorSupport>`
+   class. These support classes may themselves be abstract base classes which
+   add more required methods to samplers that inherit from them.
+3. Inheritance is kept to one level. For example, if we have sampler class
+   ``Foo(Bar, BaseSampler)``, both ``Bar`` and ``BaseSampler`` do not inherit
+   from any parent classes, only ``object``.
+4. To avoid confusion, only inherited abstract methods should be overridden.
+6. All sampler classes need a corresponding class in the
+   :py:mod:`pycbc.inference.io` module for handling reading and writing. See
+   :doc:`io` for more details on IO classes.
+
+As mentioned above, the
+:py:class:`BaseSampler <pycbc.inference.sampler.base.BaseSampler>` class is an
+abstract base class. It defines a collection of abstract methods and properties
+that all samplers must override in order to function properly. These are (click
+on the names to see their documentation):
+
+ * :py:meth:`from_config <pycbc.inference.sampler.base.BaseSampler.from_config>`
+ * :py:attr:`io <pycbc.inference.sampler.base.BaseSampler.io>`
+ * :py:meth:`set_initial_conditions <pycbc.inference.sampler.base.BaseSampler.set_initial_conditions>`
+ * :py:meth:`run <pycbc.inference.sampler.base.BaseSampler.run>`
+ * :py:meth:`checkpoint <pycbc.inference.sampler.base.BaseSampler.checkpoint>`
+ * :py:attr:`samples <pycbc.inference.sampler.base.BaseSampler.samples>`
+ * :py:attr:`model_stats <pycbc.inference.sampler.base.BaseSampler.model_stats>`
+ * :py:meth:`finalize <pycbc.inference.sampler.base.BaseSampler.finalize>`
+
+---------------------
+Detailed example
+---------------------
+
+Let's examine the
+:py:class:`EmceeEnsembleSampler <pycbc.inference.sampler.emcee.EmceeEnsembleSampler>`
+class to see how these guidelines apply in practice. Here is its inheritance
+structure (click on the names of the classes to see their documentation):
+
+.. inheritance-diagram:: pycbc.inference.sampler.emcee
+    :parts: 2
+
+In addition to :py:class:`BaseSampler <pycbc.inference.sampler.base.BaseSampler>`,
+:py:class:`EmceeEnsembleSampler <pycbc.inference.sampler.emcee.EmceeEnsembleSampler>`
+inherits from :py:class:`BaseMCMC <pycbc.inference.sampler.base_mcmc.BaseMCMC>` and
+:py:class:`MCMCAutocorrSupport <pycbc.inference.sampler.base_mcmc.MCMCAutocorrSupport>`.
+Inspecting :py:class:`BaseMCMC <pycbc.inference.sampler.base_mcmc.BaseMCMC>`,
+we see that it implements several of the methods that
+:py:class:`BaseSampler <pycbc.inference.sampler.base.BaseSampler>` requires: namely,
+:py:meth:`set_initial_conditions <pycbc.inference.sampler.bsae_mcmc.BaseMCMC.set_initial_conditions>`,
+:py:meth:`run <pycbc.inference.sampler.base_mcmc.BaseMCMC.run>`, and
+:py:meth:`checkpoint <pycbc.inference.sampler.base_mcmc.BaseMCMC.checkpoint>`.
+This is because the steps taken in these functions are common across MCMC
+samplers. For example, in :py:meth:`run <pycbc.inference.sampler.base_mcmc.BaseMCMC.run>`,
+the sampler is run for blocks of iterations (specified by
+:py:attr:`checkpoint_interval <pycbc.inference.sampler.base_mcmc.checkpoint_interval>`)
+until the convergence criteria has been met (which is determined by
+:py:meth:`set_target <pycbc.inference.sampler.base_mcmc.set_target>`). This,
+generally, is what all MCMC samplers do.
+
+*How* an MCMC sampler is run for some number of iterations is unique to each
+sampling engine. Thus, in :py:meth:`run <pycbc.inference.sampler.base_mcmc.BaseMCMC.run>`,
+a call to :py:meth:`run_mcmc <pycbc.inference.sampler.base_mcmc.BaseMCMC.run_mcmc>`
+is made. This is an abstract method: i.e., :py:class:`BaseMCMC <pycbc.inference.sampler.base_mcmc.BaseMCMC>`
+is itself an abstract base class. Since
+:py:class:`EmceeEnsembleSampler <pycbc.inference.sampler.emcee.EmceeEnsembleSampler>`
+inheritance is ``EmceeEnsembleSampler(MCMCAutocorrSupport, BaseMCMC, BaseSampler)``,
+:py:class:`BaseMCMC <pycbc.inference.sampler.base_mcmc.BaseMCMC>` fulfils
+:py:class:`BaseSampler's <pycbc.inference.sampler.base.BaseSampler>` requirement
+that a ``run`` method be implemented, but replaces it with the requirement that
+a ``run_mcmc`` method be implemented. Thus, looking at its source code, we see
+that :py:class:`EmceeEmsembleSampler <pycbc.inference.sampler.emcee.EmceeEnsembleSampler>`
+implements a :py:meth:`run_mcmc <pycbc.inference.sampler.emcee.EmceeEnsembleSampler.run_mcmc>`
+method. Likewise,
+
+(note
+that BaseSampler is furthest to the right: when multiple classes are specified
+
+
+iterations are looped over, with results being dumped to 
+dumped to file looking at the source code for
+:py:meth:`run <pycbc.inference.sampler.base_mcmc.BaseMCMC.run>`, we see that
+ther
+
+---------------------
+Inheritance diagrams
+---------------------
+
+Here are inheritance diagrams for the rest of the samplers currently supported:
+
+* ``emcee_pt``:
+
+.. inheritance-diagram:: pycbc.inference.sampler.emcee_pt
+    :parts: 2

--- a/pycbc/inference/io/base_mcmc.py
+++ b/pycbc/inference/io/base_mcmc.py
@@ -118,7 +118,7 @@ class MCMCIO(object):
             Start reading from the given iteration. Default is to start from
             the first iteration.
         thin_interval : int, optional
-            Only read every ``thin_interval``th sample. Default is 1.
+            Only read every ``thin_interval`` -th sample. Default is 1.
         thin_end : int, optional
             Stop reading at the given iteration. Default is to end at the last
             iteration.

--- a/pycbc/inference/io/base_multitemper.py
+++ b/pycbc/inference/io/base_multitemper.py
@@ -157,7 +157,7 @@ class MultiTemperedMCMCIO(MCMCIO):
             Start reading from the given iteration. Default is to start from
             the first iteration.
         thin_interval : int, optional
-            Only read every ``thin_interval``th sample. Default is 1.
+            Only read every ``thin_interval`` -th sample. Default is 1.
         thin_end : int, optional
             Stop reading at the given iteration. Default is to end at the last
             iteration.

--- a/pycbc/inference/sampler/base.py
+++ b/pycbc/inference/sampler/base.py
@@ -241,9 +241,9 @@ def create_new_output_file(sampler, filename, force=False, injection_file=None,
 
 
 def initial_dist_from_config(cp):
-    """Loads a distribution for the sampler start from the given config file.
+    r"""Loads a distribution for the sampler start from the given config file.
 
-    A distribution will only be loaded if the config file has a [initial-*]
+    A distribution will only be loaded if the config file has a [initial-\*]
     section(s).
 
     Parameters
@@ -254,7 +254,7 @@ def initial_dist_from_config(cp):
     Returns
     -------
     JointDistribution or None :
-        The initial distribution. If no [initial-*] section found in the
+        The initial distribution. If no [initial-\*] section found in the
         config file, will just return None.
     """
     if len(cp.get_subsections("initial")):

--- a/pycbc/inference/sampler/base.py
+++ b/pycbc/inference/sampler/base.py
@@ -48,7 +48,10 @@ from pycbc.inference.io import validate_checkpoint_files
 
 
 class BaseSampler(object):
-    """Base container class for inference samplers.
+    """Abstract base class for all inference samplers.
+
+    All sampler classes must inherit from this class and implement its abstract
+    methods.
 
     Parameters
     ----------

--- a/pycbc/inference/sampler/base_mcmc.py
+++ b/pycbc/inference/sampler/base_mcmc.py
@@ -151,10 +151,37 @@ def get_optional_arg_from_config(cp, section, arg, dtype=str):
 
 
 class BaseMCMC(object):
-    """This class provides methods common to MCMCs.
+    """Abstract base class that provides methods common to MCMCs.
 
-    It is not a sampler class itself. Sampler classes can inherit from this
+    This is not a sampler class itself. Sampler classes can inherit from this
     along with ``BaseSampler``.
+
+    This class provides ``set_initial_conditions``, ``run``, and ``checkpoint``
+    methods, which are some of the abstract methods required by
+    ``BaseSampler``.
+
+    This class introduces the following abstract properties and methods:
+
+    * base_shape
+        [`property`] Should give the shape of the samples arrays used by the
+        sampler, excluding the iteraitons dimension. Needed for writing
+        results.
+    * run_mcmc(niterations)
+        Should run the sampler for the given number of iterations. Called by
+        ``run``.
+    * clear_samples()
+        Should clear samples from memory. Called by ``run``.
+    * set_state_from_file(filename)
+        Should set the random state of the sampler using the given filename.
+        Called by ``set_initial_conditions``.
+    * write_results(filename)
+        Writes results to the given filename. Called by ``checkpoint``.
+    * compute_acf(filename, \**kwargs)
+        [`classmethod`] Should compute the autocorrelation function using
+        the given filename. Also allows for other keyword arguments.
+    * compute_acl(filename, \**kwargs)
+        [`classmethod`] Should compute the autocorrelation length using
+        the given filename. Also allows for other keyword arguments.
 
     Attributes
     ----------
@@ -245,6 +272,10 @@ class BaseMCMC(object):
 
     @property
     def pos(self):
+        """The current position of the walkers.
+
+        Returns a dictionary mapping the sampling paramters to the values.
+        """
         pos = self._pos
         if pos is None:
             return self.p0
@@ -494,8 +525,8 @@ class BaseMCMC(object):
     def set_target_from_config(self, cp, section):
         """Sets the target using the given config file.
 
-        This looks for 'niterations' to set the ``target_niterations``, and
-        'effective-nsamples' to set the ``target_eff_nsamples``.
+        This looks for ``niterations`` to set the ``target_niterations``, and
+        ``effective-nsamples`` to set the ``target_eff_nsamples``.
 
         Parameters
         ----------


### PR DESCRIPTION
Adds a page for the sampler classes and a page for the new IO classes. These are linked from the main inference help page, under a new section "For Developers".  Example is here:

[Sampler API](https://www.atlas.aei.uni-hannover.de/~cdcapano/public_scratch/github_prs/inference_dev-test_docs/html/inference/sampler_api.html)
[Inference IO](https://www.atlas.aei.uni-hannover.de/~cdcapano/public_scratch/github_prs/inference_dev-test_docs/html/inference/io.html)

@cmbiwer @soumide1102 Is this what you were thinking of?