### PR TITLE
add multi ifo support to pycbc live

### DIFF
--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -108,17 +108,23 @@ class LiveEventManager(object):
         return out
 
     def check_coincs(self, ifos, coinc_results, psds, f_low,
-                     data_readers, bank, followup_ifos=None):
+                     data_readers, bank):
         """ Save zerolag triggers to a coinc xml file """
+    
         if 'foreground/ifar' in coinc_results:
-            fud = self.compute_followup_data(ifos, coinc_results, data_readers,
+            logging.info('computing followup data for coinc')
+
+            coinc_ifos = coinc_results['foreground/type'].split('-')
+            followup_ifos = [ifo for ifo in ifos if ifo not in coinc_ifos]
+
+            fud = self.compute_followup_data(coinc_ifos, coinc_results, data_readers,
                                              bank, followup_ifos)
-            event = SingleCoincForGraceDB(ifos, coinc_results, bank=bank,
+            event = SingleCoincForGraceDB(coinc_ifos, coinc_results, bank=bank,
                                           psds=psds, followup_data=fud,
                                           low_frequency_cutoff=f_low,
                                           channel_names=args.channel_name)
 
-            end_time = int(coinc_results['foreground/%s/end_time' % ifos[0]])
+            end_time = int(coinc_results['foreground/%s/end_time' % coinc_ifos[0]])
             fname = os.path.join(self.path, 'coinc-%s.xml.gz' % end_time)
             logging.info('Coincident candidate! Saving as %s', fname)
             comments = ['using ranking statistic: %s' % args.background_statistic]
@@ -131,8 +137,7 @@ class LiveEventManager(object):
             else:
                 event.save(fname)
 
-    def check_singles(self, results, data_reader, psds, f_low,
-                      followup_ifos=None):
+    def check_singles(self, results, data_reader, psds, f_low):
         active = [k for k in results if results[k] != None]
         if len(active) == 1:
             ifo = active[0]
@@ -140,7 +145,7 @@ class LiveEventManager(object):
 
             if single is not None:
                 fud = self.compute_followup_data([ifo], single, data_reader,
-                                                 bank, followup_ifos)
+                                                 bank, [])
                 event = SingleCoincForGraceDB([ifo], single, bank=bank,
                                               psds=psds, followup_data=fud,
                                               low_frequency_cutoff=f_low,
@@ -527,8 +532,17 @@ with ctx:
                     logging.info('Coincs: %s-%s: %s in cbuffer',
                                  c.ifos[0], c.ifos[1], c.coincs.index)
 
-            # Pick the best coinc in this chunk
-            best_coinc = Coincer.pick_best_coinc(coinc_results)
+                # Pick the best coinc in this chunk
+                best_coinc = Coincer.pick_best_coinc(coinc_results)
+
+                evnt.check_coincs(results.keys(), best_coinc,
+                                  psds, args.low_frequency_cutoff,
+                                  data_reader, bank)
+
+            # Check for singles if we don't have coinc time
+            if args.enable_single_detector_background:
+                evnt.check_singles(results, data_reader, psds,
+                                   args.low_frequency_cutoff)
 
             # map the results file to an hdf file
             prefix = '%s-%s-%s-%s' % (''.join(ifos), args.file_prefix, data_end() - args.analysis_chunk, valid_pad)

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -31,9 +31,10 @@ def ftop(f, ft):
 
 def combine_ifar_pvalue(ifar, pvalue):
     from scipy.stats import combine_pvalues
-    reference_foreground = .05
+    reference_foreground = 0.01 * ifar
     _, pnew = combine_pvalues([ftop(1.0/ifar, reference_foreground), pvalue])
-    return 1.0 / ptof(pnew, reference_foreground)
+    nifar = 1.0 / ptof(pnew, reference_foreground)
+    return nifar
 
 class LiveEventManager(object):
     def __init__(self, output_path,

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -32,7 +32,7 @@ def ftop(f, ft):
 def combine_ifar_pvalue(ifar, pvalue):
     from scipy.stats import combine_pvalues
     reference_foreground = .05
-    pnew = combine_pvalues([ftop(1.0/ifar, reference_foreground), pvalue])
+    _, pnew = combine_pvalues([ftop(1.0/ifar, reference_foreground), pvalue])
     return 1.0 / ptof(pnew, reference_foreground)
 
 class LiveEventManager(object):
@@ -124,24 +124,25 @@ class LiveEventManager(object):
             if snr_series is not None:
                 out[ifo] = {'snr_series': snr_series}
 
-            triggers = self.combine_far_with_followup(coinc_ifos, ifo, triggers,
-                                                      snr_series, ptime, pvalue)
-
+            self.combine_far_with_followup(ifos[0], ifo, triggers,
+                                           snr_series, ptime, pvalue)
         return out
 
-    def combine_far_with_followup(self, coinc_ifos, ifo, triggers, snr_series, ptime, pvalue):      
+    def combine_far_with_followup(self, coinc_ifo, ifo, triggers, snr_series, ptime, pvalue):      
         # Set new ifar
         triggers['foreground/ifar'] = combine_ifar_pvalue(triggers['foreground/ifar'], pvalue)
         
-        # Set properties of this trigger
-        for key in coinc_ifos:
-            if 'foreground/{}/'.format(coinc_ifos[0]) in key:
+        # Copy the triggers
+        for key in triggers.copy():
+            if 'foreground/{}/'.format(coinc_ifo) in key:
                 _, _, name = key.split('/')
                 triggers['foreground/{}/{}'.format(ifo, name)] = triggers[key]
 
-        triggers['foreground/{}/end_time'.format(ifo)] = ptime
-        triggers['foreground/{}/snr'].format(ifo)] = abs(snr_series.at_time(ptime))
-        triggers['foreground/{}/coa_phase'].format(ifo)] = numpy.angle(snr_series.at_time(ptime))
+        # Set the critical stats manually
+        triggers['foreground/{}/end_time'.format(ifo)] = float(ptime)
+        triggers['foreground/{}/snr'.format(ifo)] = abs(snr_series.at_time(ptime))
+        triggers['foreground/{}/stat'.format(ifo)] = triggers['foreground/{}/snr'.format(ifo)]
+        triggers['foreground/{}/coa_phase'.format(ifo)] = numpy.angle(snr_series.at_time(ptime))
         triggers['foreground/{}/chisq'.format(ifo)] = 0
                      
     def check_coincs(self, ifos, coinc_results, psds, f_low,

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -3,6 +3,7 @@ import argparse, numpy, pycbc, logging, cProfile, h5py, lal, json
 from pycbc import fft, version, waveform, scheme, frame
 from pycbc.types import MultiDetOptionAction
 from pycbc.filter import LiveBatchMatchedFilter, compute_followup_snr_series
+from pycbc.filter import followup_event_significance
 from pycbc.strain import StrainBuffer
 from time import time
 import os.path
@@ -84,24 +85,30 @@ class LiveEventManager(object):
         SNR time series for all the available detectors.
         """
         out = {}
+        followup_ifos = [] if followup_ifos is None else followup_ifos
 
         template_id = triggers['foreground/' + ifos[0] + '/template_id']
         htilde = bank[template_id]
 
-        subthreshold_sngl_time = numpy.mean(
-                [triggers['foreground/' + ifo + '/end_time'] for ifo in ifos])
+        coinc_times = {ifo: triggers['foreground/' + ifo + '/end_time'] for ifo in ifos}
 
-        for ifo in ifos + (followup_ifos or []):
-            if ifo in ifos:
-                trig_time = triggers['foreground/' + ifo + '/end_time']
-            else:
-                trig_time = subthreshold_sngl_time
+        # Get the SNR series for the ifos that made the initial coinc
+        for ifo in ifos:
             # NOTE we only check the state/DQ of followup IFOs here.
             # IFOs producing the coincidence are assumed to also
             # produce valid SNR series.
             snr_series = compute_followup_snr_series(
-                    data_readers[ifo], htilde, trig_time,
-                    check_state=(ifo in followup_ifos))
+                    data_readers[ifo], htilde, coinc_times[ifo],
+                    check_state=False)
+
+            if snr_series is not None:
+                out[ifo] = {'snr_series': snr_series}
+
+        # Determine if the other ifos can contribute to the coincident event
+        for ifo in followup_ifos:
+            snr_series, ptime, pvalue = followup_event_significance(ifo, 
+                            data_readers[ifo], bank, template_id, coinc_times)
+
             if snr_series is not None:
                 out[ifo] = {'snr_series': snr_series}
 

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -23,6 +23,18 @@ def makedir(path):
     if path is not None and not os.path.exists(path):
         os.makedirs(path)
 
+def ptof(p, ft):
+    return numpy.log(1.0-p) / -ft
+    
+def ftop(f, ft):
+    return 1 - numpy.exp(-ft * f)
+
+def combine_ifar_pvalue(ifar, pvalue):
+    from scipy.stats import combine_pvalues
+    reference_foreground = .05
+    pnew = combine_pvalues([ftop(1.0/ifar, reference_foreground), pvalue])
+    return 1.0 / ptof(pnew, reference_foreground)
+
 class LiveEventManager(object):
     def __init__(self, output_path,
                        use_date_prefix=False,
@@ -112,8 +124,26 @@ class LiveEventManager(object):
             if snr_series is not None:
                 out[ifo] = {'snr_series': snr_series}
 
+            triggers = self.combine_far_with_followup(coinc_ifos, ifo, triggers,
+                                                      snr_series, ptime, pvalue)
+
         return out
 
+    def combine_far_with_followup(self, coinc_ifos, ifo, triggers, snr_series, ptime, pvalue):      
+        # Set new ifar
+        triggers['foreground/ifar'] = combine_ifar_pvalue(triggers['foreground/ifar'], pvalue)
+        
+        # Set properties of this trigger
+        for key in coinc_ifos:
+            if 'foreground/{}/'.format(coinc_ifos[0]) in key:
+                _, _, name = key.split('/')
+                triggers['foreground/{}/{}'.format(ifo, name)] = triggers[key]
+
+        triggers['foreground/{}/end_time'.format(ifo)] = ptime
+        triggers['foreground/{}/snr'].format(ifo)] = abs(snr_series.at_time(ptime))
+        triggers['foreground/{}/coa_phase'].format(ifo)] = numpy.angle(snr_series.at_time(ptime))
+        triggers['foreground/{}/chisq'.format(ifo)] = 0
+                     
     def check_coincs(self, ifos, coinc_results, psds, f_low,
                      data_readers, bank):
         """ Save zerolag triggers to a coinc xml file """
@@ -126,8 +156,6 @@ class LiveEventManager(object):
 
             fud = self.compute_followup_data(coinc_ifos, coinc_results, data_readers,
                                              bank, followup_ifos)
-
-
 
             event = SingleCoincForGraceDB(coinc_ifos, coinc_results, bank=bank,
                                           psds=psds, followup_data=fud,

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -119,6 +119,9 @@ class LiveEventManager(object):
 
             fud = self.compute_followup_data(coinc_ifos, coinc_results, data_readers,
                                              bank, followup_ifos)
+
+
+
             event = SingleCoincForGraceDB(coinc_ifos, coinc_results, bank=bank,
                                           psds=psds, followup_data=fud,
                                           low_frequency_cutoff=f_low,

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -453,10 +453,11 @@ with ctx:
     # Create double coincident background estimator for every combo
     if args.enable_background_estimation and evnt.rank == 0:
         ifo_combos  = itertools.combinations(ifos, 2)
-        logging.info('Calculating %s backgrounds', ifo_combos)
+        estimators = []
         for combo in ifo_combos:
-            estimators = LiveCoincTimeslideBackgroundEstimator.from_cli(args,
-                            len(bank), args.analysis_chunk, list(combo))
+            logging.info('Will calculate %s background', combo)
+            estimators.append(LiveCoincTimeslideBackgroundEstimator.from_cli(args,
+                            len(bank), args.analysis_chunk, list(combo)))
 
 
 
@@ -523,6 +524,8 @@ with ctx:
             if args.enable_background_estimation:
                 for c in estimators:
                     coinc_results = c.add_singles(results, data_reader)
+                    logging.info('Coincs: %s-%s: %s in cbuffer',
+                                 c.ifos[0], c.ifos[1], c.coincs.index)
 
             final_results = coinc_results
 

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -8,7 +8,7 @@ from time import time
 import os.path
 from mpi4py import MPI as mpi
 from pycbc.events import newsnr
-from pycbc.events.coinc import LiveCoincTimeslideBackgroundEstimator
+from pycbc.events.coinc import LiveCoincTimeslideBackgroundEstimator as Coincer
 from pycbc.events.single import LiveSingleFarThreshold
 from pycbc.io.live import SingleCoincForGraceDB
 import pycbc.waveform.bank
@@ -320,7 +320,7 @@ parser.add_argument('--fftw-planning-limit', type=float,
 scheme.insert_processing_option_group(parser)
 LiveSingleFarThreshold.insert_args(parser)
 fft.insert_fft_option_group(parser)
-LiveCoincTimeslideBackgroundEstimator.insert_args(parser)
+Coincer.insert_args(parser)
 args = parser.parse_args()
 scheme.verify_processing_options(args, parser)
 fft.verify_fft_options(args, parser)
@@ -456,8 +456,8 @@ with ctx:
         estimators = []
         for combo in ifo_combos:
             logging.info('Will calculate %s background', combo)
-            estimators.append(LiveCoincTimeslideBackgroundEstimator.from_cli(args,
-                            len(bank), args.analysis_chunk, list(combo)))
+            estimators.append(Coincer.from_cli(args,
+                              len(bank), args.analysis_chunk, list(combo)))
 
 
 
@@ -520,14 +520,15 @@ with ctx:
                             results[ifo][key] = results[ifo][key][idx]
 
             # Look for coincident triggers and do background estimation
-            coinc_results = {}
+            coinc_results = []
             if args.enable_background_estimation:
                 for c in estimators:
-                    coinc_results = c.add_singles(results, data_reader)
+                    coinc_results.append(c.add_singles(results, data_reader))
                     logging.info('Coincs: %s-%s: %s in cbuffer',
                                  c.ifos[0], c.ifos[1], c.coincs.index)
 
-            final_results = coinc_results
+            # Pick the best coinc in this chunk
+            best_coinc = Coincer.pick_best_coinc(coinc_results)
 
             # map the results file to an hdf file
             prefix = '%s-%s-%s-%s' % (''.join(ifos), args.file_prefix, data_end() - args.analysis_chunk, valid_pad)
@@ -535,7 +536,7 @@ with ctx:
             evnt.dump(results, prefix, time_index=data_end(),
                       store_psd=False if args.store_psd is False else psds,
                       store_loudest_index=args.store_loudest_index,
-                      raw_results=final_results,
+                      raw_results=best_coinc,
                      )
 
             logging.info('Finished Analyzing up to %s', data_end())

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -12,6 +12,7 @@ from pycbc.events.coinc import LiveCoincTimeslideBackgroundEstimator
 from pycbc.events.single import LiveSingleFarThreshold
 from pycbc.io.live import SingleCoincForGraceDB
 import pycbc.waveform.bank
+import itertools
 
 def makedir(path):
     """
@@ -29,7 +30,7 @@ class LiveEventManager(object):
                        gracedb_testing=True,
                  ):
         self.path = output_path
-        
+
         # Figure out what we are supposed to process within the pool of MPI processes
         self.comm = mpi.COMM_WORLD
         self.size = self.comm.Get_size()
@@ -57,15 +58,15 @@ class LiveEventManager(object):
         if self.rank == 0:
             all_results = self.comm.gather(None, root=0)
             data_ends = [a[1] for a in all_results if a is not None]
-            results = [a[0] for a in all_results if a is not None]    
-        
+            results = [a[0] for a in all_results if a is not None]
+
             combined = {}
             for ifo in results[0]:
 
                 # check if any of the results returned invalid
-                try: 
+                try:
                     for r in results:
-                        if r[ifo] is False: 
+                        if r[ifo] is False:
                             raise ValueError
                 except ValueError:
                     continue
@@ -219,13 +220,13 @@ parser.add_argument('--snr-abort-threshold', type=float)
 
 parser.add_argument('--channel-name', action=MultiDetOptionAction, nargs='+',
                     required=True)
-parser.add_argument('--state-channel', action=MultiDetOptionAction, nargs='+', 
+parser.add_argument('--state-channel', action=MultiDetOptionAction, nargs='+',
           help="The channel containing frame status information. This is used "
                "to determine when to analyze the hoft data. This somewhat "
                "corresponds to CAT1 information")
-parser.add_argument('--analyze-flags', nargs='+', default=['HOFT_OK', 'SCIENCE_INTENT'], 
+parser.add_argument('--analyze-flags', nargs='+', default=['HOFT_OK', 'SCIENCE_INTENT'],
                     help='The flags that must be in the "good" state to analzye data')
-parser.add_argument('--data-quality-channel', action=MultiDetOptionAction, nargs='+', 
+parser.add_argument('--data-quality-channel', action=MultiDetOptionAction, nargs='+',
           help="The channel containing data quality information. This is used "
                 "to determine when hoft may be suspect and may be used to veto"
                 "triggers or not analyze a segment of data. This roughly "
@@ -250,7 +251,7 @@ parser.add_argument('--psd-samples', type=int, required=True,
                         help="Number of PSD segments to use in the rolling estimate")
 parser.add_argument('--psd-segment-length', type=int, required=True,
                         help="Length in seconds of each PSD segment")
-parser.add_argument('--psd-inverse-length', type=float, 
+parser.add_argument('--psd-inverse-length', type=float,
                         help="Lenght in time for the equivelant FIR filter")
 parser.add_argument('--trim-padding', type=float, default=0.25,
                         help="Padding around the overwhitened analysis block")
@@ -287,7 +288,7 @@ parser.add_argument('--max-triggers-in-batch', type=int)
 parser.add_argument('--max-length', type=float,
                     help='Maximum duration of templates, used to set the data buffer size')
 
-parser.add_argument('--enable-profiling', type=int, 
+parser.add_argument('--enable-profiling', type=int,
                     help="Dump out profiling information from an MPI process at"
                          " the end of program executrion")
 
@@ -309,7 +310,7 @@ parser.add_argument('--round-start-time', type=int,
 parser.add_argument('--gracedb-server',
                     help="Location of gracedb server. If not provide, the "
                          "default location is used. ")
-parser.add_argument('--size-override', 
+parser.add_argument('--size-override',
                     help="Override the internal MPI size layout. "
                          " Useful for debugging and running a portion of a bank",
                     type=int)
@@ -335,7 +336,7 @@ sr = args.sample_rate
 flow = args.low_frequency_cutoff
 
 if args.round_start_time:
-    args.start_time = int(args.start_time / args.round_start_time + 1) * args.round_start_time 
+    args.start_time = int(args.start_time / args.round_start_time + 1) * args.round_start_time
     logging.info('Starting from: %s', args.start_time)
 
 # Approximant guess of the total padding
@@ -346,9 +347,9 @@ bank = waveform.LiveFilterBank(args.bank_file, sr, total_pad,
                        approximant=args.approximant,
                        increment=args.increment)
 
-evnt = LiveEventManager(args.output_path, 
-                        use_date_prefix=args.day_hour_output_prefix, 
-                        ifar_upload_threshold=args.ifar_upload_threshold, 
+evnt = LiveEventManager(args.output_path,
+                        use_date_prefix=args.day_hour_output_prefix,
+                        ifar_upload_threshold=args.ifar_upload_threshold,
                         enable_gracedb_upload=args.enable_gracedb_upload,
                         gracedb_testing=not args.enable_production_gracedb_upload,
                        )
@@ -358,11 +359,6 @@ if args.size_override:
 
 # ifos used for primary analysis (only two at the moment)
 ifos = set(args.channel_name.keys())
-followup_ifos = set(args.followup_detectors)
-ifos -= followup_ifos
-ifos, followup_ifos = list(ifos), list(followup_ifos)
-# the root must also advance followup ifos, other threads don't need to
-advancing_ifos = (ifos + followup_ifos) if evnt.rank == 0 else ifos
 
 # make sure we can talk to GraceDB
 if evnt.rank == 0 and args.enable_gracedb_upload:
@@ -401,7 +397,7 @@ with ctx:
         psd_len = args.psd_segment_length * (args.psd_samples / 2 + 1)
         maxlen = max(lengths.max(), psd_len)
         mf = LiveBatchMatchedFilter(waveforms, args.snr_threshold, args.chisq_bins,
-                                     snr_abort_threshold=args.snr_abort_threshold, 
+                                     snr_abort_threshold=args.snr_abort_threshold,
                                      newsnr_threshold=args.newsnr_threshold,
                                      max_triggers_in_batch=args.max_triggers_in_batch,
                                      maxelements=args.max_batch_size)
@@ -410,7 +406,7 @@ with ctx:
     maxlen = int(maxlen)
     data_reader = {}
     sngl_estimator = {}
-    for ifo in advancing_ifos:
+    for ifo in ifos:
         state = dq = dqf = None
         if args.state_channel and ifo in args.state_channel:
             state = '%s:%s' % (ifo, args.state_channel[ifo])
@@ -452,9 +448,13 @@ with ctx:
                             analyze_flags=args.analyze_flags,
                             data_quality_flags=dqf,
                             dq_padding=args.data_quality_padding)
+
+    # Create double coincident background estimator for every combo
     if args.enable_background_estimation and evnt.rank == 0:
-        estimator = LiveCoincTimeslideBackgroundEstimator.from_cli(args,
-                            len(bank), args.analysis_chunk, ifos)
+        ifo_combos  = itertools.combinations(ifos, 2)
+        for combo in ifo_combos:
+            estimators = LiveCoincTimeslideBackgroundEstimator.from_cli(args,
+                            len(bank), args.analysis_chunk, list(combo))
 
 
 
@@ -470,9 +470,8 @@ with ctx:
         t1 = time()
         logging.info('%s: Analyzing from %s', evnt.rank, data_end())
         results = {}
-        usable_followup_ifos = []
 
-        for ifo in advancing_ifos:
+        for ifo in ifos:
             results[ifo] = False
             status = data_reader[ifo].advance(valid_pad, timeout=args.frame_read_timeout)
 
@@ -484,14 +483,7 @@ with ctx:
                 if dist < args.min_psd_abort_distance or dist > args.max_psd_abort_distance:
                     logging.info("%s PSD outside acceptable sensitivity %s - %s, have %s",
                                  ifo, args.min_psd_abort_distance, args.max_psd_abort_distance, dist)
-                    status = False               
-
-            if ifo in followup_ifos:
-                # we advanced the data and handled the PSD, that's it
-                if status is True:
-                    usable_followup_ifos.append(ifo)
-                    logging.info('%s usable for followup', ifo)
-                continue
+                    status = False
 
             if status is True:
                 logging.info('%s: Filtering: %s', evnt.rank, ifo)
@@ -527,25 +519,16 @@ with ctx:
             # Look for coincident triggers and do background estimation
             coinc_results = {}
             if args.enable_background_estimation:
-                coinc_results = estimator.add_singles(results, data_reader)
-                evnt.check_coincs(results.keys(), coinc_results,
-                                  psds, args.low_frequency_cutoff, data_reader, bank,
-                                  followup_ifos=usable_followup_ifos)
-
-            # Check for singles if we don't have coinc time
-            if args.enable_single_detector_background:
-                evnt.check_singles(results, data_reader, psds,
-                                   args.low_frequency_cutoff,
-                                   followup_ifos=usable_followup_ifos)
+                for c in estimators:
+                    coinc_results = c.add_singles(results, data_reader)
 
             prefix = '%s-%s-%s-%s' % (''.join(ifos), args.file_prefix, data_end() - args.analysis_chunk, valid_pad)
-            evnt.dump(results, prefix, time_index=data_end(),
-                      store_psd=False if args.store_psd is False else psds,
-                      store_loudest_index=args.store_loudest_index,
-                      raw_results=coinc_results,
-                     )     
 
-            logging.info('Finished analyzing up to %s', data_end())
+            #evnt.dump(results, prefix, time_index=data_end(),
+            #          store_psd=False if args.store_psd is False else psds,
+            #          store_loudest_index=args.store_loudest_index,
+            #          raw_results=coinc_results,
+            #         )
 
         if args.sync:
             evnt.barrier()

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -24,11 +24,12 @@ def makedir(path):
         os.makedirs(path)
 
 def ptof(p, ft):
-    return numpy.log(1.0-p) / -ft
+    return numpy.log(1.0 - p) / -ft
 
 def ftop(f, ft):
     return 1 - numpy.exp(-ft * f)
 
+# REVISIT THIS WITH BETTER FORMULA
 def combine_ifar_pvalue(ifar, pvalue):
     from scipy.stats import combine_pvalues
     reference_foreground = 0.01 * ifar
@@ -499,7 +500,7 @@ with ctx:
 
     # Create double coincident background estimator for every combo
     if args.enable_background_estimation and evnt.rank == 0:
-        ifo_combos  = itertools.combinations(ifos, 2)
+        ifo_combos = itertools.combinations(ifos, 2)
         estimators = []
         for combo in ifo_combos:
             logging.info('Will calculate %s background', combo)

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -25,7 +25,7 @@ def makedir(path):
 
 def ptof(p, ft):
     return numpy.log(1.0-p) / -ft
-    
+
 def ftop(f, ft):
     return 1 - numpy.exp(-ft * f)
 
@@ -119,7 +119,7 @@ class LiveEventManager(object):
 
         # Determine if the other ifos can contribute to the coincident event
         for ifo in followup_ifos:
-            snr_series, ptime, pvalue = followup_event_significance(ifo, 
+            snr_series, ptime, pvalue = followup_event_significance(ifo,
                             data_readers[ifo], bank, template_id, coinc_times)
 
             if snr_series is not None:
@@ -129,10 +129,10 @@ class LiveEventManager(object):
                                            snr_series, ptime, pvalue)
         return out
 
-    def combine_far_with_followup(self, coinc_ifo, ifo, triggers, snr_series, ptime, pvalue):      
+    def combine_far_with_followup(self, coinc_ifo, ifo, triggers, snr_series, ptime, pvalue):
         # Set new ifar
         triggers['foreground/ifar'] = combine_ifar_pvalue(triggers['foreground/ifar'], pvalue)
-        
+
         # Copy the triggers
         for key in triggers.copy():
             if 'foreground/{}/'.format(coinc_ifo) in key:
@@ -145,11 +145,13 @@ class LiveEventManager(object):
         triggers['foreground/{}/stat'.format(ifo)] = triggers['foreground/{}/snr'.format(ifo)]
         triggers['foreground/{}/coa_phase'.format(ifo)] = numpy.angle(snr_series.at_time(ptime))
         triggers['foreground/{}/chisq'.format(ifo)] = 0
-                     
+        triggers['foreground/{}/chisq_dof'.format(ifo)] = 0
+
     def check_coincs(self, ifos, coinc_results, psds, f_low,
                      data_readers, bank):
-        """ Save zerolag triggers to a coinc xml file """
-    
+        """ Perform any followup and save zerolag triggers to a coinc xml file
+        """
+
         if 'foreground/ifar' in coinc_results:
             logging.info('computing followup data for coinc')
 
@@ -404,7 +406,7 @@ if args.size_override:
 
 # ifos used for primary analysis (only two at the moment)
 ifos = set(args.channel_name.keys())
-logging.info('Running with: %s ifos', len(ifos))
+logging.info('Running with %s', ', '.join(sorted(ifos)))
 
 # make sure we can talk to GraceDB
 if evnt.rank == 0 and args.enable_gracedb_upload:
@@ -529,8 +531,9 @@ with ctx:
             if data_reader[ifo].psd is not None:
                 dist = data_reader[ifo].psd.dist
                 if dist < args.min_psd_abort_distance or dist > args.max_psd_abort_distance:
-                    logging.info("%s PSD outside acceptable sensitivity %s - %s, have %s",
-                                 ifo, args.min_psd_abort_distance, args.max_psd_abort_distance, dist)
+                    logging.info("PSD outside acceptable sensitivity %s - %s, have %s",
+                                 args.min_psd_abort_distance, args.max_psd_abort_distance, dist)
+
                     status = False
 
             if status is True:
@@ -585,7 +588,10 @@ with ctx:
                                    args.low_frequency_cutoff)
 
             # map the results file to an hdf file
-            prefix = '%s-%s-%s-%s' % (''.join(ifos), args.file_prefix, data_end() - args.analysis_chunk, valid_pad)
+            prefix = '{}-{}-{}-{}'.format(''.join(sorted(ifos)),
+                                          args.file_prefix,
+                                          data_end() - args.analysis_chunk,
+                                          valid_pad)
 
             evnt.dump(results, prefix, time_index=data_end(),
                       store_psd=False if args.store_psd is False else psds,

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -273,7 +273,7 @@ parser.add_argument('--state-channel', action=MultiDetOptionAction, nargs='+',
                "to determine when to analyze the hoft data. This somewhat "
                "corresponds to CAT1 information")
 parser.add_argument('--analyze-flags', nargs='+', default=['HOFT_OK', 'SCIENCE_INTENT'],
-                    help='The flags that must be in the "good" state to analzye data')
+                    help='The flags that must be in the "good" state to analyze data')
 parser.add_argument('--data-quality-channel', action=MultiDetOptionAction, nargs='+',
           help="The channel containing data quality information. This is used "
                 "to determine when hoft may be suspect and may be used to veto"
@@ -437,7 +437,6 @@ with ctx:
         print(e)
         exit()
 
-
     maxlen = args.psd_segment_length * (args.psd_samples / 2 + 1)
     if evnt.rank > 0:
         bank.table.sort(order='mchirp')
@@ -506,7 +505,6 @@ with ctx:
             logging.info('Will calculate %s background', combo)
             estimators.append(Coincer.from_cli(args,
                               len(bank), args.analysis_chunk, list(combo)))
-
 
 
     logging.info('%s: Starting... ', evnt.rank)

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -359,6 +359,7 @@ if args.size_override:
 
 # ifos used for primary analysis (only two at the moment)
 ifos = set(args.channel_name.keys())
+logging.info('Running with: %s ifos', len(ifos))
 
 # make sure we can talk to GraceDB
 if evnt.rank == 0 and args.enable_gracedb_upload:
@@ -452,6 +453,7 @@ with ctx:
     # Create double coincident background estimator for every combo
     if args.enable_background_estimation and evnt.rank == 0:
         ifo_combos  = itertools.combinations(ifos, 2)
+        logging.info('Calculating %s backgrounds', ifo_combos)
         for combo in ifo_combos:
             estimators = LiveCoincTimeslideBackgroundEstimator.from_cli(args,
                             len(bank), args.analysis_chunk, list(combo))
@@ -522,13 +524,18 @@ with ctx:
                 for c in estimators:
                     coinc_results = c.add_singles(results, data_reader)
 
+            final_results = coinc_results
+
+            # map the results file to an hdf file
             prefix = '%s-%s-%s-%s' % (''.join(ifos), args.file_prefix, data_end() - args.analysis_chunk, valid_pad)
 
-            #evnt.dump(results, prefix, time_index=data_end(),
-            #          store_psd=False if args.store_psd is False else psds,
-            #          store_loudest_index=args.store_loudest_index,
-            #          raw_results=coinc_results,
-            #         )
+            evnt.dump(results, prefix, time_index=data_end(),
+                      store_psd=False if args.store_psd is False else psds,
+                      store_loudest_index=args.store_loudest_index,
+                      raw_results=final_results,
+                     )
+
+            logging.info('Finished Analyzing up to %s', data_end())
 
         if args.sync:
             evnt.barrier()

--- a/pycbc/events/coinc.py
+++ b/pycbc/events/coinc.py
@@ -782,7 +782,19 @@ class LiveCoincTimeslideBackgroundEstimator(object):
         from . import stat
         self.num_templates = num_templates
         self.analysis_block = analysis_block
-        self.stat_calculator = stat.get_statistic(background_statistic)(stat_files)
+
+        # Only pass a valid stat file for this ifo pair
+        for fname in stat_files:
+            f = h5py.File(fname, 'r')
+            ifos_set = set([f.attrs['ifo0'], f.attrs['ifo1']])
+            f.close()
+            if ifos_set == set(ifos):
+                stat_file = fname
+                logging.info('Setup ifos %s-%s with file %s and stat %s',
+                             ifos[0], ifos[1], fname, background_statistic)
+
+        self.stat_calculator = stat.get_statistic(background_statistic)([stat_file])
+
         self.timeslide_interval = timeslide_interval
         self.return_background = return_background
         

--- a/pycbc/events/coinc.py
+++ b/pycbc/events/coinc.py
@@ -836,7 +836,6 @@ class LiveCoincTimeslideBackgroundEstimator(object):
             If there is a coinc, this will contain the 'best' one. Otherwise
             it will return the provided dict.
         """
-        # Choose best by ifar, if equal choose loudest statistic value
         mstat = 0
         mifar = 0
         mresult = None

--- a/pycbc/events/coinc.py
+++ b/pycbc/events/coinc.py
@@ -585,6 +585,9 @@ class MultiRingBuffer(object):
         count[self.index < self.start] += self.pad_count
         return count
 
+    def buffer_total(self):
+        return self.ring_sizes().sum()
+
     def num_elements(self):
         total = self.ring_sizes().sum()
         return total

--- a/pycbc/events/coinc.py
+++ b/pycbc/events/coinc.py
@@ -776,9 +776,6 @@ class LiveCoincTimeslideBackgroundEstimator(object):
         return_background: boolean
             If true, background triggers will also be included in the file
             output.
-        save_background_on_interrupt: boolean
-            If true, an interrupt can be given to save a pickled version of
-            the background instance for later restoration. !NOT IMPLEMENTED!
         """
         from pycbc import detector
         from . import stat

--- a/pycbc/events/coinc.py
+++ b/pycbc/events/coinc.py
@@ -789,11 +789,11 @@ class LiveCoincTimeslideBackgroundEstimator(object):
             ifos_set = set([f.attrs['ifo0'], f.attrs['ifo1']])
             f.close()
             if ifos_set == set(ifos):
-                stat_file = fname
+                stat_files = [fname]
                 logging.info('Setup ifos %s-%s with file %s and stat %s',
                              ifos[0], ifos[1], fname, background_statistic)
 
-        self.stat_calculator = stat.get_statistic(background_statistic)([stat_file])
+        self.stat_calculator = stat.get_statistic(background_statistic)(stat_files)
 
         self.timeslide_interval = timeslide_interval
         self.return_background = return_background

--- a/pycbc/events/coinc.py
+++ b/pycbc/events/coinc.py
@@ -1087,7 +1087,7 @@ class LiveCoincTimeslideBackgroundEstimator(object):
             zerolag_idx = (offsets == 0)
             bkg_idx = (offsets != 0)
 
-            for ifo in ifos:
+            for ifo in self.ifos:
                 single_expire[ifo] = numpy.concatenate(single_expire[ifo])
                 single_expire[ifo] = single_expire[ifo][cidx][bkg_idx]
 

--- a/pycbc/events/coinc.py
+++ b/pycbc/events/coinc.py
@@ -1177,7 +1177,8 @@ class LiveCoincTimeslideBackgroundEstimator(object):
         updated_indices = self._add_singles_to_buffer(results, ifos=valid_ifos)
 
         # Calculate zerolag and background coincidences
-        num_background, coinc_results = self._find_coincs(results, ifos=valid_ifos)
+        num_background, coinc_results = self._find_coincs(results,
+                                                          ifos=valid_ifos)
 
         # record if a coinc is possible in this chunk
         if len(valid_ifos) == 2:

--- a/pycbc/events/coinc.py
+++ b/pycbc/events/coinc.py
@@ -810,8 +810,6 @@ class LiveCoincTimeslideBackgroundEstimator(object):
 
         self.singles = {}
 
-    # Adding this here as it requires the results format dict as defined by this
-    # class.
     @classmethod
     def pick_best_coinc(cls, coinc_results):
         """Choose the best two-ifo coinc by ifar first, then statistic if needed.
@@ -841,8 +839,8 @@ class LiveCoincTimeslideBackgroundEstimator(object):
         # maximize over
         trials = 0
         for result in coinc_results:
-            # Check that a coinc was possible. This was added in the
-            # 'add_singles' method of this class
+            # Check that a coinc was possible. See the 'add_singles' method
+            # to see where this flag was added into the results dict
             if 'coinc_possible' in result:
                 trials += 1
 

--- a/pycbc/filter/matchedfilter.py
+++ b/pycbc/filter/matchedfilter.py
@@ -1805,6 +1805,7 @@ def compute_followup_snr_series(data_reader, htilde, trig_time,
     snr = TimeSeries(snr[slice(valid_start, valid_end)],
                      delta_t=dt, epoch=epoch)
 
+    # Onsource slice for Bayestar followup
     onsource_idx = int(round(float(trig_time - snr.start_time) * sr))
     onsource_slice = slice(onsource_idx - half_dur_samples,
                            onsource_idx + half_dur_samples + 1)

--- a/pycbc/filter/matchedfilter.py
+++ b/pycbc/filter/matchedfilter.py
@@ -1773,7 +1773,6 @@ def followup_event_significance(ifo, data_reader, bank,
     peak_time = peak * snr.delta_t + onsrc.start_time
     peak_value = abs(onsrc[peak])
 
-
     bstart = float(snr.start_time) + htilde.length_in_time + trim_pad
 
     bkg = abs(snr.time_slice(bstart, onsource_start)).numpy()

--- a/pycbc/filter/matchedfilter.py
+++ b/pycbc/filter/matchedfilter.py
@@ -1722,7 +1722,7 @@ class LiveBatchMatchedFilter(object):
 def followup_event_significance(ifo, data_reader, bank,
                                 template_id, coinc_times,
                                 coinc_threshold=0.005,
-                                lookback=100, duration=0.095):
+                                lookback=200, duration=0.095):
     """ Followup an event in another detector and determine its significance
     """
     # calculate onsource time range

--- a/pycbc/filter/matchedfilter.py
+++ b/pycbc/filter/matchedfilter.py
@@ -1765,18 +1765,16 @@ def compute_followup_snr_series(data_reader, htilde, trig_time,
         state_start_time = trig_time - duration / 2 - htilde.length_in_time
         state_end_time = trig_time + duration / 2
         state_duration = state_end_time - state_start_time
-        if data_reader.state is not None \
-                and not data_reader.state.is_extent_valid(
-                        state_start_time, state_duration):
-            return None
+        if data_reader.state is not None:
+            if not data_reader.state.is_extent_valid(state_start_time, state_duration):
+                return None
 
         # was the data quality ok for the full amount of involved data?
         dq_start_time = state_start_time - data_reader.dq_padding
         dq_duration = state_duration + 2 * data_reader.dq_padding
-        if data_reader.dq is not None \
-                and not data_reader.dq.is_extent_valid(
-                        dq_start_time, dq_duration):
-            return None
+        if data_reader.dq is not None:
+            if not data_reader.dq.is_extent_valid(dq_start_time, dq_duration):
+                return None
 
     stilde = data_reader.overwhitened_data(htilde.delta_f)
 

--- a/pycbc/filter/matchedfilter.py
+++ b/pycbc/filter/matchedfilter.py
@@ -1725,6 +1725,12 @@ def followup_event_significance(ifo, data_reader, bank,
                                 lookback=200, duration=0.095):
     """ Followup an event in another detector and determine its significance
     """
+    # Lookback for background must be shorter than the strain buffer
+    if lookback > data_reader.strain.duration:
+        lookback = data_reader.strain.duration / 2
+        logging.warn('Setting lookback for background to '
+                     '%s to ensure data exists' % lookback)
+
     # calculate onsource time range
     from pycbc.detector import Detector
     onsource_start = -numpy.inf
@@ -1754,7 +1760,7 @@ def followup_event_significance(ifo, data_reader, bank,
     # We won't require that all DQ checks be valid for now, except at
     # onsource time.
     if data_reader.dq is not None:
-        if not data_reader.dq.is_extend_valid(onsource_start - duration / 2.0,
+        if not data_reader.dq.is_extent_valid(onsource_start - duration / 2.0,
                                               onsource_end + duration / 2.0):
             return None, None, None
 

--- a/pycbc/strain/strain.py
+++ b/pycbc/strain/strain.py
@@ -1434,14 +1434,14 @@ class StrainBuffer(pycbc.frame.DataBuffer):
         htilde: FrequencySeries
             Overwhited strain data
         """
-        # we haven't alread computed htilde for this delta_f
+        # we haven't already computed htilde for this delta_f
         if delta_f not in self.segments:
             buffer_length = int(1.0 / delta_f)
             e = len(self.strain)
             s = int(e - buffer_length * self.sample_rate - self.reduced_pad * 2)
             fseries = make_frequency_series(self.strain[s:e])
 
-            # we haven't calculate a resample psd for this delta_f
+            # we haven't calculated a resample psd for this delta_f
             if delta_f not in self.psds:
                 psdt = pycbc.psd.interpolate(self.psd, fseries.delta_f)
                 psdt = pycbc.psd.inverse_spectrum_truncation(psdt,
@@ -1473,6 +1473,7 @@ class StrainBuffer(pycbc.frame.DataBuffer):
                 fseries_trimmed = FrequencySeries(zeros(len(overwhite2) / 2 + 1,
                                                   dtype=fseries.dtype), delta_f=delta_f)
                 pycbc.fft.fft(overwhite2, fseries_trimmed)
+                fseries_trimmed.start_time = fseries.start_time + self.reduced_pad * self.strain.delta_t
             else:
                 fseries_trimmed = fseries
 
@@ -1485,11 +1486,6 @@ class StrainBuffer(pycbc.frame.DataBuffer):
     def near_hwinj(self):
         """Check that the current set of triggers could be influenced by
         a hardware injection.
-
-        Parameters
-        ----------
-        data_reader: dict of StrainBuffers
-            A dict of StrainBuffer instances, indexed by ifos.
         """
         if not self.state:
             return False

--- a/pycbc/types/timeseries.py
+++ b/pycbc/types/timeseries.py
@@ -145,7 +145,7 @@ class TimeSeries(Array):
     def get_sample_rate(self):
         """Return the sample rate of the time series.
         """
-        return round(1.0/self.delta_t)
+        return int(round(1.0/self.delta_t))
     sample_rate = property(get_sample_rate,
                            doc="The sample rate of the time series.")
 

--- a/pycbc/types/timeseries.py
+++ b/pycbc/types/timeseries.py
@@ -76,7 +76,7 @@ class TimeSeries(Array):
                 else:
                     epoch = _lal.LIGOTimeGPS(0)
             elif epoch is not None:
-                try: 
+                try:
                     epoch = _lal.LIGOTimeGPS(epoch)
                 except:
                     raise TypeError('epoch must be either None or a lal.LIGOTimeGPS')
@@ -110,7 +110,7 @@ class TimeSeries(Array):
             new_delta_t = self._delta_t * index.step
         else:
             new_delta_t = self._delta_t
-        
+
         return TimeSeries(Array._getslice(self, index), new_delta_t,
                           new_epoch, copy=False)
 
@@ -141,11 +141,11 @@ class TimeSeries(Array):
         return len(self) * self._delta_t
     duration = property(get_duration,
                         doc="Duration of time series in seconds.")
-    
+
     def get_sample_rate(self):
         """Return the sample rate of the time series.
         """
-        return int(1.0/self.delta_t)
+        return round(1.0/self.delta_t)
     sample_rate = property(get_sample_rate,
                            doc="The sample rate of the time series.")
 
@@ -421,7 +421,7 @@ class TimeSeries(Array):
 
     def save_to_wav(self, file_name):
         """ Save this time series to a wav format audio file.
-        
+
         Parameters
         ----------
         file_name : string
@@ -429,20 +429,20 @@ class TimeSeries(Array):
         """
         scaled = _numpy.int16(self.numpy()/max(abs(self)) * 32767)
         write_wav(file_name, self.sample_rate, scaled)
-        
+
     def psd(self, segment_duration, **kwds):
         """ Calculate the power spectral density of this time series.
-        
+
         Use the `pycbc.psd.welch` method to estimate the psd of this time segment.
         For more complete options, please see that function.
-        
+
         Parameters
         ----------
         segment_duration: float
             Duration in seconds to use for each sample of the spectrum.
         kwds : keywords
             Additional keyword arguments are passed on to the `pycbc.psd.welch` method.
-            
+
         Returns
         -------
         psd : FrequencySeries
@@ -482,7 +482,7 @@ class TimeSeries(Array):
             the data.
         kwds : keywords
             Additional keyword arguments are passed on to the `pycbc.psd.welch` method.
-            
+
         Returns
         -------
         whitened_data : TimeSeries
@@ -493,7 +493,7 @@ class TimeSeries(Array):
         psd = self.psd(segment_duration, **kwds)
         psd = interpolate(psd, self.delta_f)
         max_filter_len = int(max_filter_duration * self.sample_rate)
-        
+
         # Interpolate and smooth to the desired corruption length
         psd = inverse_spectrum_truncation(psd,
                    max_filter_len=max_filter_len,
@@ -514,7 +514,7 @@ class TimeSeries(Array):
     def qtransform(self, delta_t=None, delta_f=None, logfsteps=None,
                   frange=None, qrange=(4,64), mismatch=0.2, return_complex=False):
         """ Return the interpolated 2d qtransform of this data
-        
+
         Parameters
         ----------
         delta_t : {self.delta_t, float}
@@ -532,7 +532,7 @@ class TimeSeries(Array):
             Mismatch between frequency tiles
         return_complex: {False, bool}
             return the raw complex series instead of the normalized power.
-         
+
         Returns
         -------
         times : numpy.ndarray
@@ -543,11 +543,11 @@ class TimeSeries(Array):
             The two dimensional interpolated qtransform of this time series.
         """
         from pycbc.filter.qtransform import qtiling, qplane
-        from scipy.interpolate import interp2d       
+        from scipy.interpolate import interp2d
 
         if frange is None:
             frange = (30, int(self.sample_rate / 2 * 8))
-        
+
         q_base = qtiling(self, qrange, frange, mismatch)
         _, times, freqs, q_plane = qplane(q_base, self.to_frequencyseries(),
                                           return_complex=return_complex)
@@ -557,11 +557,11 @@ class TimeSeries(Array):
         # Interpolate if requested
         if delta_f or delta_t or logfsteps:
             if return_complex:
-                interp_amp = interp2d(times, freqs, abs(q_plane))   
-                interp_phase = interp2d(times, freqs, _numpy.angle(q_plane))             
+                interp_amp = interp2d(times, freqs, abs(q_plane))
+                interp_phase = interp2d(times, freqs, _numpy.angle(q_plane))
             else:
                 interp = interp2d(times, freqs, q_plane)
-            
+
         if delta_t:
             times = _numpy.arange(float(self.start_time),
                                     float(self.end_time), delta_t)
@@ -611,7 +611,7 @@ class TimeSeries(Array):
         return ts
 
     def lowpass_fir(self, frequency, order, beta=5.0, remove_corrupted=True):
-        """ Lowpass filter the time series using an FIR filtered generated from 
+        """ Lowpass filter the time series using an FIR filtered generated from
         the ideal response passed through a kaiser window (beta = 5.0)
 
         Parameters
@@ -619,7 +619,7 @@ class TimeSeries(Array):
         Time Series: TimeSeries
             The time series to be low-passed.
         frequency: float
-            The frequency below which is suppressed. 
+            The frequency below which is suppressed.
         order: int
             Number of corrupted samples on each side of the time series
         beta: float
@@ -636,7 +636,7 @@ class TimeSeries(Array):
         return ts
 
     def highpass_fir(self, frequency, order, beta=5.0, remove_corrupted=True):
-        """ Highpass filter the time series using an FIR filtered generated from 
+        """ Highpass filter the time series using an FIR filtered generated from
         the ideal response passed through a kaiser window (beta = 5.0)
 
         Parameters
@@ -644,7 +644,7 @@ class TimeSeries(Array):
         Time Series: TimeSeries
             The time series to be high-passed.
         frequency: float
-            The frequency below which is suppressed. 
+            The frequency below which is suppressed.
         order: int
             Number of corrupted samples on each side of the time series
         beta: float
@@ -662,7 +662,7 @@ class TimeSeries(Array):
 
     def fir_zero_filter(self, coeff):
         """Filter the timeseries with a set of FIR coefficients
-        
+
         Parameters
         ----------
         coeff: numpy.ndarray
@@ -690,7 +690,7 @@ class TimeSeries(Array):
         path: string
             Destination file path. Must end with either .hdf, .npy or .txt.
 
-        group: string 
+        group: string
             Additional name for internal storage use. Ex. hdf storage uses
             this as the key value.
 
@@ -722,21 +722,21 @@ class TimeSeries(Array):
             ds.attrs['delta_t'] = float(self.delta_t)
         else:
             raise ValueError('Path must end with .npy, .txt or .hdf')
-                
+
     @_nocomplex
     def to_frequencyseries(self, delta_f=None):
         """ Return the Fourier transform of this time series
-        
+
         Parameters
         ----------
         delta_f : {None, float}, optional
-            The frequency resolution of the returned frequency series. By 
+            The frequency resolution of the returned frequency series. By
         default the resolution is determined by the duration of the timeseries.
-        
+
         Returns
-        -------        
-        FrequencySeries: 
-            The fourier transform of this time series. 
+        -------
+        FrequencySeries:
+            The fourier transform of this time series.
         """
         from pycbc.fft import fft
         if not delta_f:
@@ -753,11 +753,11 @@ class TimeSeries(Array):
         if not delta_f:
             tmp = self
         else:
-            tmp = TimeSeries(zeros(tlen, dtype=self.dtype), 
+            tmp = TimeSeries(zeros(tlen, dtype=self.dtype),
                              delta_t=self.delta_t, epoch=self.start_time)
             tmp[:len(self)] = self[:]
-        
-        f = FrequencySeries(zeros(flen, 
+
+        f = FrequencySeries(zeros(flen,
                            dtype=complex_same_precision_as(self)),
                            delta_f=delta_f)
         fft(tmp, f)
@@ -796,12 +796,12 @@ class TimeSeries(Array):
     @_nocomplex
     def cyclic_time_shift(self, dt):
         """Shift the data and timestamps by a given number of seconds
-        
-        Shift the data and timestamps in the time domain a given number of 
-        seconds. To just change the time stamps, do ts.start_time += dt. 
+
+        Shift the data and timestamps in the time domain a given number of
+        seconds. To just change the time stamps, do ts.start_time += dt.
         The time shift may be smaller than the intrinsic sample rate of the data.
         Note that data will be cycliclly rotated, so if you shift by 2
-        seconds, the final 2 seconds of your data will now be at the 
+        seconds, the final 2 seconds of your data will now be at the
         beginning of the data set.
 
         Parameters
@@ -876,7 +876,7 @@ def load_timeseries(path, group=None):
     path: string
         source file path. Must end with either .npy or .txt.
 
-    group: string 
+    group: string
         Additional name for internal storage use. Ex. hdf storage uses
         this as the key value.
 
@@ -887,7 +887,7 @@ def load_timeseries(path, group=None):
     """
     ext = _os.path.splitext(path)[1]
     if ext == '.npy':
-        data = _numpy.load(path)    
+        data = _numpy.load(path)
     elif ext == '.txt':
         data = _numpy.loadtxt(path)
     elif ext == '.hdf':
@@ -895,12 +895,12 @@ def load_timeseries(path, group=None):
         f = h5py.File(path)
         data = f[key][:]
         series = TimeSeries(data, delta_t=f[key].attrs['delta_t'],
-                                  epoch=f[key].attrs['start_time']) 
+                                  epoch=f[key].attrs['start_time'])
         f.close()
         return series
     else:
         raise ValueError('Path must end with .npy, .hdf, or .txt')
-        
+
     if data.ndim == 2:
         delta_t = (data[-1][0] - data[0][0]) / (len(data)-1)
         epoch = _lal.LIGOTimeGPS(data[0][0])

--- a/pycbc/waveform/bank.py
+++ b/pycbc/waveform/bank.py
@@ -530,7 +530,7 @@ class LiveFilterBank(TemplateBank):
 
         return self.get_template(index)
 
-    def get_template(self, index, delta_f=None):
+    def get_template(self, index, min_buffer=None):
 
         approximant = self.approximant(index)
         f_end = self.end_frequency(index)
@@ -538,7 +538,9 @@ class LiveFilterBank(TemplateBank):
 
         # Determine the length of time of the filter, rounded up to
         # nearest power of two
-        min_buffer = .5 + self.minimum_buffer
+        if min_buffer is None:
+            min_buffer =  self.minimum_buffer
+        min_buffer += 0.5
 
         from pycbc.waveform.waveform import props
         p = props(self.table[index])
@@ -548,8 +550,7 @@ class LiveFilterBank(TemplateBank):
         tlen = self.round_up((buff_size + min_buffer) * self.sample_rate)
         flen = int(tlen / 2 + 1)
 
-        if delta_f is None:
-            delta_f = self.sample_rate / float(tlen)
+        delta_f = self.sample_rate / float(tlen)
 
         if f_end is None or f_end >= (flen * delta_f):
             f_end = (flen-1) * delta_f

--- a/pycbc/waveform/bank.py
+++ b/pycbc/waveform/bank.py
@@ -528,6 +528,10 @@ class LiveFilterBank(TemplateBank):
         if isinstance(index, slice):
             return self.getslice(index)
 
+        return self.get_template(index)
+
+    def get_template(self, index, delta_f=None):
+
         approximant = self.approximant(index)
         f_end = self.end_frequency(index)
         flow = self.table[index].f_lower
@@ -544,7 +548,8 @@ class LiveFilterBank(TemplateBank):
         tlen = self.round_up((buff_size + min_buffer) * self.sample_rate)
         flen = int(tlen / 2 + 1)
 
-        delta_f = self.sample_rate / float(tlen)
+        if delta_f is None:
+            delta_f = self.sample_rate / float(tlen)
 
         if f_end is None or f_end >= (flen * delta_f):
             f_end = (flen-1) * delta_f
@@ -589,6 +594,7 @@ class LiveFilterBank(TemplateBank):
                                       htilde.params.spin1z,
                                       htilde.params.spin2z)))
         return htilde
+
 
 class FilterBank(TemplateBank):
     def __init__(self, filename, filter_length, delta_f, dtype,


### PR DESCRIPTION
This adds multi ifo support to pycbc live. 
    * Supports arbitrary number of detectors for outputting triggers
    * All ifos contribute to significance of detectors
    * No SNR threshold for all but the two ifos

The basic features are all there, so please review. 

[WIP]
 * formatting / pep8 / some documentation.

Notes:

This removes the "followup" detector options. No detectors can just be followup at the moment, they will always contribute to significance and will have single triggers generated. We may want to add options to ignore some ifos for some purposes, but we can add that in a future patch.