### PR TITLE
Fix example scripts

### DIFF
--- a/examples/inference/analytic-normal2d/make_movie.sh
+++ b/examples/inference/analytic-normal2d/make_movie.sh
@@ -1,4 +1,4 @@
-gwin_plot_movie --verbose \
+pycbc_inference_plot_movie --verbose \
         --nprocesses 4 \
         --input-file normal2d.hdf \
         --output-prefix frames-normal2d \

--- a/examples/inference/bbh-injection/run.sh
+++ b/examples/inference/bbh-injection/run.sh
@@ -21,10 +21,9 @@ GPS_START_TIME=$((${TRIGGER_TIME_INT} - ${SEGLEN}))
 GPS_END_TIME=$((${TRIGGER_TIME_INT} + ${SEGLEN}))
 
 # run sampler
-# specifies the number of threads for OpenMP
 # Running with OMP_NUM_THREADS=1 stops lalsimulation
 # from spawning multiple jobs that would otherwise be used
-# by gwin and cause a reduced runtime.
+# by pycbc_inference and cause a reduced runtime.
 OMP_NUM_THREADS=1 \
 pycbc_inference --verbose \
     --seed 12 \

--- a/examples/inference/gw150914/plot.sh
+++ b/examples/inference/gw150914/plot.sh
@@ -1,35 +1,14 @@
-ITER=-1
-INPUT_FILE=gwin.hdf.checkpoint
-
-OUTPUT_FILE=scatter_with_stats.png
-gwin_plot_posterior \
+pycbc_inference_plot_posterior \
     --verbose \
-    --iteration ${ITER} \
-    --input-file ${INPUT_FILE} \
-    --output-file ${OUTPUT_FILE} \
+    --input-file inference.hdf \
+    --output-file posterior-scatter.png \
     --plot-scatter \
     --plot-marginal \
-    --z-arg 'mchirp_from_mass1_mass2(mass1, mass2):mchirp' \
-    --parameters tc \
-                 'snr_from_loglr(abs(H1_cplx_loglr)):$\rho_H$' \
-                 'snr_from_loglr(abs(L1_cplx_loglr)):$\rho_L$' \
-                 'snr_from_loglr(abs(loglr)):$\rho$' \
-
-if false; then
-OUTPUT_FILE=scatter.png
-gwin_plot_posterior \
-    --verbose \
-    --iteration ${ITER} \
-    --input-file ${INPUT_FILE} \
-    --output-file ${OUTPUT_FILE} \
-    --plot-scatter \
-    --plot-marginal \
-    --z-arg 'snr_from_loglr(loglr):$\rho$' \
-    --parameters "ra*12/pi:$\alpha$ (h)" \
-                 "dec*180/pi:$\delta$ (deg)" \
-                 "polarization*180/pi:$\psi$ (deg)" \
+    --z-arg 'loglikelihood:$\log p(h|\vartheta)$' \
+    --parameters "ra*12/pi:ra" \
+                 "dec*180/pi:dec" \
+                 "polarization*180/pi:polarization" \
                  mass1 mass2 spin1_a spin1_azimuthal spin1_polar \
                  spin2_a spin2_azimuthal spin2_polar \
                  "inclination*180/pi:$\iota$ (deg)" distance \
-                 "coa_phase*180/pi:$\phi_0$ (deg)" tc
-fi
+                 tc


### PR DESCRIPTION
Renames `gwin` -> `pycbc_inference` that was missed in some of the example scripts, and fixes some other debugging things that I forgot to exclude.