### PR TITLE
Use astropy.cosmology in the cosmology module

### DIFF
--- a/pycbc/cosmology.py
+++ b/pycbc/cosmology.py
@@ -45,8 +45,7 @@ def get_cosmology(cosmology=DEFAULT_COSMOLOGY):
     Parameters
     ----------
     cosmology : str, optional
-        The name of the cosmology to use. Must be the name of a cosmology
-        available in astropy.cosmology. For the list of options, see
+        The name of the cosmology to use. For the list of options, see
         :py:attr:`astropy.cosmology.parameters.available`. Default is
         ``'Planck15'``.
 
@@ -83,8 +82,7 @@ def redshift(distance, cosmology=DEFAULT_COSMOLOGY):
     distance : float
         The luminosity distance, in Mpc.
     cosmology : str, optional
-        The name of the cosmology to use. Must be the name of a cosmology
-        available in astropy.cosmology. For the list of options, see
+        The name of the cosmology to use. For the list of options, see
         :py:attr:`astropy.cosmology.parameters.available`. Default is
         ``'Planck15'``.
 
@@ -105,8 +103,7 @@ def distance_from_comoving_volume(vc, cosmology=DEFAULT_COSMOLOGY):
     vc : float
         The comoving volume, in units of cubed Mpc.
     cosmology : str, optional
-        The name of the cosmology to use. Must be the name of a cosmology
-        available in astropy.cosmology. For the list of options, see
+        The name of the cosmology to use. For the list of options, see
         :py:attr:`astropy.cosmology.parameters.available`. Default is
         ``'Planck15'``.
 

--- a/pycbc/cosmology.py
+++ b/pycbc/cosmology.py
@@ -165,9 +165,9 @@ def z_at_value(func, fval, unit, zmax=1000., **kwargs):
             if counter == 5:
                 # give up and warn the user
                 logging.warning("One or more values correspond to a "
-                             "redshift > {0:.1e}. The redshift for these have "
-                             "been set to inf. If you would like better "
-                             "precision, call God.".format(zmax))
+                                "redshift > {0:.1e}. The redshift for these "
+                                "have been set to inf. If you would like "
+                                "better precision, call God.".format(zmax))
                 break
     return formatreturn(zs, input_is_array)
 

--- a/pycbc/cosmology.py
+++ b/pycbc/cosmology.py
@@ -361,5 +361,39 @@ def comoving_distance_from_comoving_volume(vc, **kwargs):
     return cosmology.comoving_distance(z).value
 
 
+def cosmological_quantity_from_redshift(z, quantity, strip_unit=True,
+                                        **kwargs):
+    """Returns the value of a cosmological quantity (e.g., age) at a redshift.
 
-__all__ = ['redshift', 'distance_from_comoving_volume']
+    Parameters
+    ----------
+    z : float
+        The redshift.
+    quantity : str
+        The name of the quantity to get. The name may be any attribute of
+        :py:class:`astropy.cosmology.FlatLambdaCDM`.
+    strip_unit : bool, optional
+        Just return the value of the quantity, sans units. Default is True.
+    \**kwargs :
+        All other keyword args are passed to :py:func:`get_cosmology` to
+        select a cosmology. If none provided, will use
+        :py:attr:`DEFAULT_COSMOLOGY`.
+
+    Returns
+    -------
+    float or astropy.units.quantity :
+        The value of the quantity at the requested value. If ``strip_unit`` is
+        ``True``, will return the value. Otherwise, will return the value with
+        units.
+    """
+    cosmology = get_cosmology(**kwargs)
+    val = getattr(cosmology, quantity)(z)
+    if strip_unit:
+        val = val.value
+    return val
+
+
+__all__ = ['redshift', 'distance_from_comoving_volume',
+           'comoving_distance_from_comoving_volume',
+           'cosmological_quantity_from_redshift',
+           ]

--- a/pycbc/cosmology.py
+++ b/pycbc/cosmology.py
@@ -71,13 +71,14 @@ def get_cosmology(cosmology=None, **kwargs):
                   Tcmb0=2.725 K, Neff=3.05, m_nu=[0.   0.   0.06] eV,
                   Ob0=0.0486)
 
-    Don't trust Planck? Use WMAP!
+    Use properties measured by WMAP instead:
 
     >>> get_cosmology("WMAP9")
     FlatLambdaCDM(name="WMAP9", H0=69.3 km / (Mpc s), Om0=0.286, Tcmb0=2.725 K,
                   Neff=3.04, m_nu=[0. 0. 0.] eV, Ob0=0.0463)
 
-    Don't trust anyone? Create your own!
+    Create your own cosmology (see :py:class:`astropy.cosmology.FlatLambdaCDM`
+    for details on the default values used):
 
     >>> get_cosmology(H0=70., Om0=0.3)
     FlatLambdaCDM(H0=70 km / (Mpc s), Om0=0.3, Tcmb0=0 K, Neff=3.04, m_nu=None,
@@ -334,7 +335,6 @@ def redshift_from_comoving_volume(vc, **kwargs):
         The redshift at the given comoving volume.
     """
     cosmology = get_cosmology(**kwargs)
-    # first get the redshift associated with the given comoving volume
     return z_at_value(cosmology.comoving_volume, vc, units.Mpc**3)
 
 

--- a/pycbc/cosmology.py
+++ b/pycbc/cosmology.py
@@ -29,26 +29,28 @@ Note: in all functions, ``distance`` is short hand for ``luminosity_distance``.
 Any other distance measure is explicitly named; e.g., ``comoving_distance``.
 """
 
+import numpy
+import logging
+from scipy import interpolate
 import astropy.cosmology
 from astropy import units
-
-import numpy
-import lal
-from scipy import interpolate
+from astropy.cosmology.core import CosmologyError
 from pycbc.conversions import ensurearray, formatreturn
 
 DEFAULT_COSMOLOGY='Planck15'
+
 
 def get_cosmology(cosmology=None, **kwargs):
     """Gets an astropy cosmology class.
 
     Parameters
     ----------
-    cosmology : str, optional
+    cosmology : str or astropy.cosmology.FlatLambdaCDM, optional
         The name of the cosmology to use. For the list of options, see
         :py:attr:`astropy.cosmology.parameters.available`. If None, and no
         other keyword arguments are provided, will default to
-        :py:attr:`DEFAULT_COSMOLOGY`.
+        :py:attr:`DEFAULT_COSMOLOGY`. If an instance of
+        :py:class:`astropy.cosmology.FlatLambdaCDM`, will just return that.
     \**kwargs :
         If any other keyword arguments are provided they will be passed to
         :py:attr:`astropy.cosmology.FlatLambdaCDM` to create a custom
@@ -82,10 +84,13 @@ def get_cosmology(cosmology=None, **kwargs):
                   Ob0=None)
 
     """
+    if kwargs and cosmology is not None:
+        raise ValueError("if providing custom cosmological parameters, do "
+                         "not provide a `cosmology` argument")
+    if isinstance(cosmology, astropy.cosmology.FlatLambdaCDM):
+        # just return
+        return cosmology
     if kwargs:
-        if cosmology is not None:
-            raise ValueError("if providing custom cosmological parameters, do "
-                             "not provide a `cosmology` argument")
         cosmology = astropy.cosmology.FlatLambdaCDM(**kwargs)
     else:
         if cosmology is None:
@@ -96,22 +101,79 @@ def get_cosmology(cosmology=None, **kwargs):
     return cosmology
 
 
-def z_at_value(func, fval, unit, **kwargs):
+def z_at_value(func, fval, unit, zmax=1000., **kwargs):
     """Wrapper around astropy.cosmology.z_at_value to handle numpy arrays.
-    
-    The unit must be specified as a separate argument.
+
+    Getting a z for a cosmological quantity involves numerically inverting
+    ``func``. The ``zmax`` argument sets how large of a z to guess (see
+    :py:func:`astropy.cosmology.z_at_value` for details). If a z is larger than
+    ``zmax``, this will try a larger zmax up to ``zmax * 10**5``. If that still
+    is not large enough, will just return ``numpy.inf``.
+
+    Parameters
+    ----------
+    func : function or method
+        A function that takes redshift as input.
+    fval : float
+        The value of ``func(z)``.
+    unit : astropy.unit
+        The unit of ``fval``.
+    zmax : float, optional
+        The initial maximum search limit for ``z``. Default is 1000.
+    \**kwargs :
+        All other keyword arguments are passed to
+        :py:func:``astropy.cosmology.z_at_value``.
+
+    Returns
+    -------
+    float
+        The redshift at the requested values.
     """
     fval, input_is_array = ensurearray(fval)
     # make sure fval is atleast 1D
     if fval.size == 1 and fval.ndim == 0:
         fval = fval.reshape(1)
-    zs = [astropy.cosmology.z_at_value(func, val*unit, **kwargs)
-          for val in fval]
-    return formatreturn(numpy.array(zs), input_is_array)
+    zs = numpy.zeros(fval.shape, dtype=float)  # the output array
+    for (ii, val) in enumerate(fval):
+        try:
+            zs[ii] = astropy.cosmology.z_at_value(func, val*unit, zmax=zmax,
+                                                  **kwargs)
+        except CosmologyError:
+            # we'll get this if the z was larger than zmax; in that case we'll
+            # try bumping up zmax later to get a value
+            zs[ii] = numpy.inf
+    # check if there were any zs > zmax
+    replacemask = numpy.isinf(zs)
+    # try bumping up zmax to get a result
+    if replacemask.any():
+        # we'll keep bumping up the maxz until we can get a result
+        counter = 0  # to prevent running forever
+        while replacemask.any():
+            kwargs['zmin'] = zmax
+            zmax = 10 * zmax
+            idx = numpy.where(replacemask)
+            for ii in idx:
+                val = fval[ii]
+                try:
+                    zs[ii] = astropy.cosmology.z_at_value(
+                        func, val*unit, zmax=zmax, **kwargs)
+                    replacemask[ii] = False
+                except CosmologyError:
+                    # didn't work, try on next loop
+                    pass
+            counter += 1
+            if counter == 5:
+                # give up and warn the user
+                logging.warn("One or more values correspond to a "
+                             "redshift > {0:.1e}. The redshift for these have "
+                             "been set to inf. If you would like better "
+                             "precision, call God.".format(zmax)) 
+                break
+    return formatreturn(zs, input_is_array)
 
 
-def redshift(distance, **kwargs):
-    """Returns the redshift associated with the given luminosity distance.
+def _redshift(distance, **kwargs):
+    """Uses astropy to get redshift from the given luminosity distance.
 
     Parameters
     ----------
@@ -119,7 +181,8 @@ def redshift(distance, **kwargs):
         The luminosity distance, in Mpc.
     \**kwargs :
         All other keyword args are passed to :py:func:`get_cosmology` to
-        select a cosmology. If none provided, will use the default.
+        select a cosmology. If none provided, will use
+        :py:attr:`DEFAULT_COSMOLOGY`.
 
     Returns
     -------
@@ -128,6 +191,128 @@ def redshift(distance, **kwargs):
     """
     cosmology = get_cosmology(**kwargs)
     return z_at_value(cosmology.luminosity_distance, distance, units.Mpc)
+
+
+class DistToZ(object):
+    """Interpolates luminosity distance as a function of redshift to allow for
+    fast conversion.
+
+    The :mod:`astropy.cosmology` module provides methods for converting any
+    cosmological parameter (like luminosity distance) to redshift. This can be
+    very slow when operating on a large array, as it involves numerically
+    inverting :math:`z(D)` (where :math:`D` is the luminosity distance). This
+    class speeds that up by pre-interpolating :math:`D(z)`. It works by setting
+    up a dense grid of redshifts, then using linear interpolation to find the
+    inverse function.  The interpolation uses a grid linear in z for z < 1, and
+    log in z for ``default_maxz`` > z > 1. This interpolater is setup the first
+    time `get_redshift` is called.  If a distance is requested that results in
+    a z > ``default_maxz``, the class falls back to calling astropy directly.
+
+    Instances of this class can be called like a function on luminosity
+    distances, which will return the corresponding redshifts.
+
+    Parameters
+    ----------
+    default_maxz : float, optional
+        The maximum z to interpolate up to before falling back to calling
+        astropy directly. Default is 1000.
+    numpoints : int, optional
+        The number of points to use in the linear interpolation between 0 to 1
+        and 1 to ``default_maxz``. Default is 10000.
+    \**kwargs :
+        All other keyword args are passed to :py:func:`get_cosmology` to
+        select a cosmology. If none provided, will use
+        :py:attr:`DEFAULT_COSMOLOGY`.
+    """
+    def __init__(self, default_maxz=1000., numpoints=10000, **kwargs):
+        self.numpoints = int(numpoints)
+        self.default_maxz = default_maxz
+        self.cosmology = get_cosmology(**kwargs)
+        # the interpolating functions; we'll set them to None for now, then set
+        # them up when get_redshift is first called
+        self.nearby_d2z = None
+        self.faraway_d2z = None
+
+    def setup_interpolant(self):
+        """Initializes the z(d) interpolation."""
+        # for computing nearby (z < 1) redshifts
+        zs = numpy.linspace(0., 1., num=self.numpoints)
+        ds = self.cosmology.luminosity_distance(zs).value
+        self.nearby_d2z = interpolate.interp1d(ds, zs, kind='linear',
+                                                bounds_error=False)
+        # for computing far away (z > 1) redshifts
+        zs = numpy.logspace(0, numpy.log10(self.default_maxz),
+                            num=self.numpoints)
+        ds = self.cosmology.luminosity_distance(zs).value
+        self.faraway_d2z = interpolate.interp1d(ds, zs, kind='linear',
+                                                 bounds_error=False)
+        # store the default maximum distance
+        self.default_maxdist = ds.max()
+
+    def get_redshift(self, dist):
+        """Returns the redshift for the given distance.
+        """
+        dist, input_is_array = ensurearray(dist)
+        try:
+            zs = self.nearby_d2z(dist)
+        except TypeError:
+            # interpolant hasn't been setup yet
+            self.setup_interpolant()
+            zs = self.nearby_d2z(dist)
+        # if any points had red shifts beyond the nearby, will have nans;
+        # replace using the faraway interpolation
+        replacemask = numpy.isnan(zs)
+        if replacemask.any():
+            zs[replacemask] = self.faraway_d2z(dist[replacemask])
+            replacemask = numpy.isnan(zs)
+        # if we still have nans, means that some distances are beyond our
+        # furthest default; fall back to using astropy
+        if replacemask.any():
+            # well... check that the distance is positive and finite first
+            if not (dist > 0.).all() and numpy.isfinite(dist).all():
+                raise ValueError("distance must be finite and > 0")
+            zs[replacemask] = _redshift(dist[replacemask],
+                                        cosmology=self.cosmology)
+        return formatreturn(zs, input_is_array)
+
+    def __call__(self, dist):
+        return self.get_redshift(dist)
+
+
+# set up D(z) interpolating classes for the standard cosmologies
+_d2zs = {_c: DistToZ(cosmology=_c)
+         for _c in astropy.cosmology.parameters.available}
+
+
+def redshift(distance, **kwargs):
+    """Returns the redshift associated with the given luminosity distance.
+
+    If the requested cosmology is one of the pre-defined ones in
+    :py:attr:`astropy.cosmology.parameters.available`, :py:class:`DistToZ` is
+    used to provide a fast interpolation. This takes a few seconds to setup
+    on the first call.
+
+    Parameters
+    ----------
+    distance : float
+        The luminosity distance, in Mpc.
+    \**kwargs :
+        All other keyword args are passed to :py:func:`get_cosmology` to
+        select a cosmology. If none provided, will use
+        :py:attr:`DEFAULT_COSMOLOGY`.
+
+    Returns
+    -------
+    float :
+        The redshift corresponding to the given distance.
+    """
+    cosmology = get_cosmology(**kwargs)
+    try:
+        z = _d2zs[cosmology.name](distance)
+    except KeyError:
+        # not a standard cosmology, call the redshift function
+        z = _redshift(distance, cosmology=cosmology)
+    return z
 
 
 def distance_from_comoving_volume(vc, **kwargs):
@@ -139,7 +324,8 @@ def distance_from_comoving_volume(vc, **kwargs):
         The comoving volume, in units of cubed Mpc.
     \**kwargs :
         All other keyword args are passed to :py:func:`get_cosmology` to
-        select a cosmology. If none provided, will use the default.
+        select a cosmology. If none provided, will use
+        :py:attr:`DEFAULT_COSMOLOGY`.
 
     Returns
     -------
@@ -153,161 +339,27 @@ def distance_from_comoving_volume(vc, **kwargs):
     return cosmology.luminosity_distance(z).value
 
 
-class _DistToZ(object):
-    """Class to convert luminosity distance to redshift using the given
-    cosmology.
-
-    Cosmological constants `h, om, ol, w0, w1, w2` may optionally be provided
-    (see below). Otherwise, standard LambdaCDM will be used by default; see
-    `LALCosmologyCalculator` for details.
-
-    LAL provides functions to convert redshift to luminosity distance,
-    assuming a cosmology. This class works by setting up a dense grid of
-    redshifts, then using linear interpolation to find the inverse function.
-    The interpolation uses a grid linear in z for z < 1, and log in z for z >
-    1.  For speed, a default interpolater is setup on initialization for
-    redshifts out to `default_maxz`. If a requested distance is found to have
-    a redshift greater than `default_maxz`, a new set of grid points is
-    created from `0.1*default_maxz` to `1e5*default_maxz` and re-interpolated.
-    This continues until a redshift can be found.
-
-    Instances of this class can be called like a function on luminosity
-    distances, which will return the corresponding redshifts.
+def comoving_distance_from_comoving_volume(vc, **kwargs):
+    """Returns the comoving distance from the comoving volume.
 
     Parameters
     ----------
-    h : {None, float}
-        The normalized Hubble constant to use. If None, will default to
-        standard cosmology.
-    om : {None, float}
-        The matter energy density. If None, will default to standard cosmology.
-    ol : {None, float}
-        The cosmological-constant density. If None, will default to standard
-        cosmology.
-    w0 : {None, float}
-        The 0th-order dark energy equation of state parameter. If None, will
-        default to standard cosmology.
-    w1 : {None, float}
-        The first-order dark energy equation of state parameter. If None, will
-        default to standard cosmology.
-    w2 : {None, float}
-        The second-order dark energy equation of state parameter. If None, will
-        default to standard cosmology.
-    default_maxz : {2., float}
-        The default maximum redshift to use for the interpolation.
-    numpoints : {5e4, int}
-        The number of points to use between for the interpolation.
-    """
-    def __init__(self, h=None, om=None, ol=None, w0=None, w1=None, w2=None,
-                 default_maxz=1e5, numpoints=1e4):
-        default_omega = lal.CreateCosmologicalParameters(0., 0., 0., 0., 0.,
-                                                         0.)
-        lal.SetCosmologicalParametersDefaultValue(default_omega)
-        # if any cosmological parameter was specified, create a custom
-        # cosmology
-        if any([p is not None for p in [h, om, ol, w0, w1, w2]]):
-            h = h if h is not None else default_omega.h
-            om = om if om is not None else default_omega.om
-            ol = ol if ol is not None else default_omega.ol
-            w0 = w0 if w0 is not None else default_omega.w0
-            w1 = w1 if w1 is not None else default_omega.w1
-            w2 = w2 if w2 is not None else default_omega.w2
-            self.omega = lal.CreateCosmologicalParameters(h, om, ol,
-                                                          w0, w1, w2)
-        else:
-            self.omega = default_omega
-        self.default_maxz = default_maxz
-        self.numpoints = int(numpoints)
-        self.z2d = numpy.vectorize(lal.LuminosityDistance)
-        # for computing nearby (z < 1) redshifts
-        zs = numpy.linspace(0., 1., num=self.numpoints)
-        ds = self.z2d(self.omega, zs)
-        self.nearby_d2z = interpolate.interp1d(ds, zs, kind='linear',
-                                                bounds_error=False)
-        # for computing far away (z > 1) redshifts
-        zs = numpy.logspace(0, numpy.log10(default_maxz), num=self.numpoints)
-        ds = self.z2d(self.omega, zs)
-        self.faraway_d2z = interpolate.interp1d(ds, zs, kind='linear',
-                                                 bounds_error=False)
-        # store the default maximum distance
-        self.default_maxdist = ds.max()
-
-    def get_redshift(self, dist):
-        """Returns the redshift for the given distance.
-        """
-        dist, input_is_array = ensurearray(dist)
-        zs = self.nearby_d2z(dist)
-        # if any points had red shifts beyond the nearby, will have nans;
-        # replace using the faraway interpolation
-        replacemask = numpy.isnan(zs)
-        if replacemask.any():
-            zs[replacemask] = self.faraway_d2z(dist[replacemask])
-            replacemask = numpy.isnan(zs)
-            # if we still have nans, means that some distances are beyond our
-            # furthest default; replace
-            if replacemask.any():
-                # well... check that the distance is positive and finite first
-                if not (dist > 0.).all() and numpy.isfinite(dist).all():
-                    raise ValueError("distance must be finite and > 0")
-                minz = numpy.log10(self.default_maxz) - 1.
-                maxz = minz + 5
-                while replacemask.any():
-                    gridzs = numpy.logspace(minz, maxz, num=self.numpoints)
-                    ds = self.z2d(self.omega, gridzs)
-                    d2z = interpolate.interp1d(ds, gridzs, kind='linear',
-                                                bounds_error=False)
-                    zs[replacemask] = d2z(dist[replacemask])
-                    replacemask = numpy.isnan(zs)
-                    minz = maxz - 1
-                    maxz = minz + 5
-        return formatreturn(zs, input_is_array)
-
-    def __call__(self, dist):
-        return self.get_redshift(dist)
-
-# we'll use the default cosmology for computing red shifts.
-_d2z = _DistToZ()
-
-def lalredshift(distance, h=None, om=None, ol=None, w0=None, w1=None, w2=None):
-    """Returns the redshift associated with the given distance.
-
-    Cosmological constants `h, om, ol, w0, w1, w2` may optionally be provided
-    (see below). Otherwise, standard LambdaCDM will be used by default; see
-    `LALCosmologyCalculator` for details.
-
-    Parameters
-    ----------
-    distance : float
-        The luminosity distance, in Mpc.
-    h : {None, float}
-        The normalized Hubble constant to use. If None, will default to
-        standard cosmology.
-    om : {None, float}
-        The matter energy density. If None, will default to standard cosmology.
-    ol : {None, float}
-        The cosmological-constant density. If None, will default to standard
-        cosmology.
-    w0 : {None, float}
-        The 0th-order dark energy equation of state parameter. If None, will
-        default to standard cosmology.
-    w1 : {None, float}
-        The first-order dark energy equation of state parameter. If None, will
-        default to standard cosmology.
-    w2 : {None, float}
-        The second-order dark energy equation of state parameter. If None, will
-        default to standard cosmology.
+    vc : float
+        The comoving volume, in units of cubed Mpc.
+    \**kwargs :
+        All other keyword args are passed to :py:func:`get_cosmology` to
+        select a cosmology. If none provided, will use
+        :py:attr:`DEFAULT_COSMOLOGY`.
 
     Returns
     -------
     float :
-        The redshift corresponding to the given distance.
+        The comoving distance at the given comoving volume.
     """
-    if all([p is None for p in [h, om, ol, w0, w1, w2]]):
-        # just use the default converter
-        d2z = _d2z
-    else:
-        d2z = _DistToZ(h=h, om=om, ol=ol, w0=w0, w1=w1, w2=w2)
-    return d2z(distance)
+    cosmology = get_cosmology(**kwargs)
+    z = z_at_value(cosmology.comoving_volume, vc, units.Mpc**3)
+    return cosmology.comoving_distance(z).value
 
 
-__all__ = ['redshift', 'distance_from_comoving_volume', 'lalredshift']
+
+__all__ = ['redshift', 'distance_from_comoving_volume']


### PR DESCRIPTION
Uses `astropy.cosmology` in the cosmology module. Currently, only a `distance_from_comoving_volume` function is added (which will allow for injections uniform in comoving volume), but more can be added later.

Here is a plot showing the luminosity distance returned by the function vs comoving volume: [link](https://www.atlas.aei.uni-hannover.de/~cdcapano/public_scratch/github_prs/use_astropy_cosmology/dist-comoving_volume.png)

This patch also replaces the current `redshift` function with equivalent function from `astropy`. Here is a plot comparing the redshift as a function of luminosity distance between the current redshift function and the new one: [link](https://www.atlas.aei.uni-hannover.de/~cdcapano/public_scratch/github_prs/use_astropy_cosmology/redshift_compare.png). Results are nearly identical.

There's a catch though... the `redshift` function using astropy is much slower than the current `redshift` function (which I've renamed `lalredshift`):
```
>>> distances = numpy.linspace(100, 10000, num=1000)

>>> %timeit redshifts = cosmology.redshift(distances)
1 loop, best of 3: 6.05 s per loop

>>> %timeit lal_redshifts = cosmology.lalredshift(distances)
The slowest run took 4.89 times longer than the fastest. This could mean that an intermediate result is being cached.
10000 loops, best of 3: 80 µs per loop
```
For this reason I didn't remove the current function. I'm not sure what the best long-term solution is though. ~6s for 1000 samples will make plotting source mass posteriors a pain. Typically we have O(10000) samples, so that would take a O(minutes) to do per parameter.