### PR TITLE
Allow changes to bandwidth for KDE from file

### DIFF
--- a/pycbc/distributions/arbitrary.py
+++ b/pycbc/distributions/arbitrary.py
@@ -239,7 +239,8 @@ class FromFile(Arbitrary):
         else:
             ps = params.keys()
         param_vals, bw = self.get_arrays_from_file(filename, params=ps)
-        super(FromFile, self).__init__(bounds=params, bandwidth=bw, **param_vals)
+        super(FromFile, self).__init__(bounds=params, bandwidth=bw,
+                                       **param_vals)
 
     @property
     def filename(self):
@@ -278,7 +279,7 @@ class FromFile(Arbitrary):
         params_values = {p:f[p][:] for p in params}
         try:
             bandwidth = f.attrs["set_bandwidth"]
-        except KeyError: 
+        except KeyError:
             bandwidth = "scott"
 
         f.close()

--- a/pycbc/distributions/arbitrary.py
+++ b/pycbc/distributions/arbitrary.py
@@ -278,7 +278,7 @@ class FromFile(Arbitrary):
             params = [str(k) for k in f.keys()]
         params_values = {p:f[p][:] for p in params}
         try:
-            bandwidth = f.attrs["set_bandwidth"]
+            bandwidth = f.attrs["bandwidth"]
         except KeyError:
             bandwidth = "scott"
 

--- a/pycbc/distributions/arbitrary.py
+++ b/pycbc/distributions/arbitrary.py
@@ -40,7 +40,7 @@ class Arbitrary(bounded.BoundedDist):
     """
     name = 'arbitrary'
 
-    def __init__(self, bounds=None, **kwargs):
+    def __init__(self, bounds=None, bandwidth="scott", **kwargs):
         # initialize the bounds
         if bounds is None:
             bounds = {}
@@ -72,6 +72,7 @@ class Arbitrary(bounded.BoundedDist):
                                  "be finite")
         # build the kde
         self._kde = self.get_kde_from_arrays(*[kwargs[p] for p in self.params])
+        self.set_bandwidth(bandwidth)
 
     @property
     def params(self):
@@ -129,6 +130,9 @@ class Arbitrary(bounded.BoundedDist):
             return -numpy.inf
         else:
             return numpy.log(self._pdf(**kwargs))
+
+    def set_bandwidth(self, set_bw="scott"):
+        self._kde.set_bandwidth(set_bw)
 
     def rvs(self, size=1, param=None):
         """Gives a set of random values drawn from the kde.
@@ -234,8 +238,8 @@ class FromFile(Arbitrary):
             ps = None
         else:
             ps = params.keys()
-        param_vals = self.get_arrays_from_file(filename, params=ps)
-        super(FromFile, self).__init__(bounds=params, **param_vals)
+        param_vals, bw = self.get_arrays_from_file(filename, params=ps)
+        super(FromFile, self).__init__(bounds=params, bandwidth=bw, **param_vals)
 
     @property
     def filename(self):
@@ -272,8 +276,13 @@ class FromFile(Arbitrary):
         else:
             params = [str(k) for k in f.keys()]
         params_values = {p:f[p][:] for p in params}
+        try:
+            bandwidth = f.attrs["set_bandwidth"]
+        except KeyError: 
+            bandwidth = "scott"
+
         f.close()
-        return params_values
+        return params_values, bandwidth
 
     @classmethod
     def from_config(cls, cp, section, variable_args):


### PR DESCRIPTION
Sometimes the Scott Bandwidth which is the preset in scipy.stats gaussian_kde isn't exactly what you want to use. This lets the user pre-set a bandwidth from file or change the bandwidth themselves.

example script:
```
import h5py
import matplotlib.pyplot as plt
import numpy
from pycbc.distributions import Arbitrary
from pycbc.distributions import FromFile

f_h5_addr ="your_file.hdf"
f = h5py.File(f_h5_addr, "r")
x = FromFile(filename=f_h5_addr)

# Read how many samples are in file
num_samples = len(f["mass1"][:])

# Generate number of samples using default bandwidth setting
scott_samples = x.rvs(num_samples)
bins = numpy.linspace(1.0, 2.0, 51, endpoint=True)
plt.hist(scott_samples["mass1"], bins=bins, histtype="step",
         label="(Default) Scott Bandwidth", normed=True)

# Change the bandwidth setting to be strict
x.set_bandwidth(0.001)
small_bw_samples = x.rvs(num_samples)
plt.hist(small_bw_samples["mass1"], bins=bins, histtype="step",
         label="0.001 Bandwidth", normed=True)

# Plot the samples from file where kde is being drawn from.
plt.hist(f["mass1"][:], bins=bins, histtype="step",
         label="Samples in File", normed=True)

plt.xlabel("mass1")
plt.ylabel("p(mass1)")
plt.legend(loc=1)
plt.tight_layout()
plt.xscale("linear")
plt.savefig("test.png")
```

![screen shot 2018-10-23 at 1 31 52 pm](https://user-images.githubusercontent.com/12528399/47379145-13df3a80-d6c8-11e8-8c8d-fba401ed684b.png)

I still need to test the setting for where the bandwidth is read from file, but it seems to be working as expected thus far.