### PR TITLE
Separate MCMCIO classes into MetadataIO and samples IO

### DIFF
--- a/bin/inference/pycbc_inference_plot_acf
+++ b/bin/inference/pycbc_inference_plot_acf
@@ -64,14 +64,12 @@ opts = parser.parse_args()
 # setup log
 pycbc.init_logging(opts.verbose)
 
-# add the temperature args if it is specified
+# add the temperature args if it exists
 additional_args = {}
-if opts.temps is not None:
-    if 'all' in opts.temps:
-        temps = 'all'
-    else:
-        temps = map(int, opts.temps)
-    additional_args['temps'] = temps 
+try:
+    additional_args['temps'] = opts.temps
+except AttributeError:
+    pass
 
 # load the results
 logging.info('Loading parameters')
@@ -97,6 +95,8 @@ try:
     temps = additional_args['temps']
     if temps == 'all':
         temps = range(acfs.values()[0].shape[0])
+    if isinstance(temps, int):
+        temps = [temps]
 except KeyError:
     temps = [0]
 fig_height = max(6, 3*len(temps))

--- a/pycbc/inference/io/base_mcmc.py
+++ b/pycbc/inference/io/base_mcmc.py
@@ -314,21 +314,31 @@ class SingleTempMCMCIO(object):
         if walkers is not None:
             widx = numpy.zeros(self.nwalkers, dtype=bool)
             widx[walkers] = True
+            nwalkers = widx.sum()
         else:
             widx = slice(0, None)
+            nwalkers = self.nwalkers
         # get the slice to use
         if iteration is not None:
             get_index = int(iteration)
+            niterations = 1
         else:
             get_index = self.get_slice(thin_start=thin_start,
                                        thin_end=thin_end,
                                        thin_interval=thin_interval)
+            # we'll just get the number of iterations from the returned shape
+            niterations = None
         # load
         group = self.samples_group + '/{name}'
         arrays = {}
         for name in fields:
             arr = self[group.format(name=name)][widx, get_index]
+            if niterations is None:
+                niterations = arr.shape[-1]
             if flatten:
                 arr = arr.flatten()
+            else:
+                # ensure that the returned array is 2D
+                arr = arr.reshape((nwalkers, niterations))
             arrays[name] = arr
         return arrays

--- a/pycbc/inference/io/base_multitemper.py
+++ b/pycbc/inference/io/base_multitemper.py
@@ -75,9 +75,9 @@ class MultiTemperedMetadataIO(MCMCMetadataIO):
         return self[self.sampler_group].attrs['ntemps']
 
     def write_sampler_metadata(self, sampler):
-        """Adds writing ntemps to MCMCIO.
+        """Adds writing ntemps to file.
         """
-        super(MultiTemperedMCMCIO, self).write_sampler_metadata(sampler)
+        super(MultiTemperedMetadataIO, self).write_sampler_metadata(sampler)
         self[self.sampler_group].attrs["ntemps"] = sampler.ntemps
 
     @staticmethod
@@ -86,11 +86,11 @@ class MultiTemperedMetadataIO(MCMCMetadataIO):
         """
         if skip_args is None:
             skip_args = []
-        parser, actions = MCMCIO.extra_args_parser(
+        parser, actions = MCMCMetadataIO.extra_args_parser(
             parser=parser, skip_args=skip_args, **kwargs)
         if 'temps' not in skip_args:
             act = parser.add_argument(
-                "--temps", nargs="+", default=None, action=ParseTempsArg,
+                "--temps", nargs="+", default=0, action=ParseTempsArg,
                 help="Get the given temperatures. May provide either a "
                      "sequence of integers specifying the temperatures to "
                      "plot, or 'all' for all temperatures. Default is to only "
@@ -167,7 +167,7 @@ class MultiTemperedMCMCIO(object):
 
     def read_raw_samples(self, fields,
                          thin_start=None, thin_interval=None, thin_end=None,
-                         iteration=None, temps=None, walkers=None,
+                         iteration=None, temps='all', walkers=None,
                          flatten=True):
         """Base function for reading samples.
 
@@ -188,11 +188,9 @@ class MultiTemperedMCMCIO(object):
             Only read the given iteration. If this provided, it overrides
             the ``thin_(start|interval|end)`` options.
         temps : 'all' or (list of) int, optional
-            The temperature index (or list of indices) to retrieve. If None,
-            only samples from the coldest (= 0) temperature chain will be
-            retrieved. To retrieve all temperates pass 'all', or a list of
-            all of the temperatures. Default is to only load the coldest
-            temperature.
+            The temperature index (or list of indices) to retrieve. To retrieve
+            all temperates pass 'all', or a list of all of the temperatures.
+            Default is 'all'.
         walkers : (list of) int, optional
             Only read from the given walkers. Default is to read all.
         flatten : bool, optional
@@ -218,10 +216,7 @@ class MultiTemperedMCMCIO(object):
             nwalkers = self.nwalkers
         # temperatures to load
         selecttemps = False
-        if temps is None:
-            tidx = 0
-            ntemps = 1
-        elif isinstance(temps, int):
+        if isinstance(temps, int):
             tidx = temps
             ntemps = 1
         else:

--- a/pycbc/inference/io/emcee.py
+++ b/pycbc/inference/io/emcee.py
@@ -25,10 +25,10 @@
 """
 import h5py, numpy
 from .base_hdf import BaseInferenceFile
-from .base_mcmc import MCMCIO
+from .base_mcmc import (MCMCMetadataIO, SingleTempMCMCIO)
 from .posterior import PosteriorFile
 
-class EmceeFile(MCMCIO, BaseInferenceFile):
+class EmceeFile(SingleTempMCMCIO, MCMCMetadataIO, BaseInferenceFile):
     """Class to handle file IO for the ``emcee`` sampler."""
 
     name = 'emcee_file'

--- a/pycbc/inference/io/emcee_pt.py
+++ b/pycbc/inference/io/emcee_pt.py
@@ -20,11 +20,12 @@
 from __future__ import absolute_import
 import h5py, numpy
 from .base_hdf import BaseInferenceFile
-from .base_multitemper import MultiTemperedMCMCIO
+from .base_multitemper import (MultiTemperedMetadataIO, MultiTemperedMCMCIO)
 from .posterior import PosteriorFile
 
 
-class EmceePTFile(MultiTemperedMCMCIO, BaseInferenceFile):
+class EmceePTFile(MultiTemperedMCMCIO, MultiTemperedMetadataIO,
+                  BaseInferenceFile):
     """Class to handle file IO for the ``emcee`` sampler."""
 
     name = 'emcee_pt_file'

--- a/pycbc/inference/sampler/base_mcmc.py
+++ b/pycbc/inference/sampler/base_mcmc.py
@@ -319,7 +319,9 @@ class BaseMCMC(object):
         if samples_file is not None:
             with self.io(samples_file, 'r') as fp:
                 samples = fp.read_samples(self.variable_params,
-                                          iteration=-1)
+                                          iteration=-1, flatten=False)
+                # remove the (length 1) niterations dimension
+                samples = samples[..., 0]
                 # make sure we have the same shape
                 assert samples.shape == self.base_shape, (
                        "samples in file {} have shape {}, but I have shape {}".


### PR DESCRIPTION
Splits `MCMCIO` into `MCMCMetadataIO` and `SingleTempMCMCIO`. The latter only contains `read_raw_samples` and `write_samples`. Likewise, splits `MultiTemperMCMCIO` into `MultiTemperMCMCIO` and `MultiTemperMetdataIO`; the latter inherits from `MCMCMetadataIO`. This fixes the need to override `read_raw_samples` and `write_samples` for multi-tempered samplers, which also avoids changing the function signature.

Also fixes an issue in `pycbc_inference_plot_acf` that prevented it from working with both single temperature and multi-temperature samplers, which I came across while testing.