### PR TITLE
Point to the right ini file in BBH example

### DIFF
--- a/examples/inference/bbh-injection/make_injection.sh
+++ b/examples/inference/bbh-injection/make_injection.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 pycbc_create_injections --verbose \
-        --config-files inference.ini \
+        --config-files injection.ini \
         --ninjections 1 \
         --seed 10 \
         --output-file injection.hdf \


### PR DESCRIPTION
I noticed the `make_injection.sh` script in the BBH example points to the wrong configuration file. It should point to `injection.ini`, not `inference.ini`.