### PR TITLE
Add support for singularity containers in workflows

### DIFF
--- a/bin/minifollowups/pycbc_foreground_minifollowup
+++ b/bin/minifollowups/pycbc_foreground_minifollowup
@@ -52,6 +52,7 @@ parser.add_argument('--inspiral-data-analyzed-name',
                          "analyzed by each analysis job.")
 parser.add_argument('--output-map')
 parser.add_argument('--output-file')
+parser.add_argument('--transformation-catalog')
 parser.add_argument('--tags', nargs='+', default=[])
 wf.add_workflow_command_line_group(parser)
 args = parser.parse_args()
@@ -95,7 +96,8 @@ if len(stat) == 0:
     # There are no triggers, make no-op job and exit
     noop_node = mini.create_noop_node()
     workflow += noop_node
-    workflow.save(filename=args.output_file, output_map_path=args.output_map)
+    workflow.save(filename=args.output_file, output_map_path=args.output_map,
+                  transformation_catalog_path=args.transformation_catalog)
     sys.exit(0)
 
 if len(stat) < num_events:

--- a/bin/minifollowups/pycbc_injection_minifollowup
+++ b/bin/minifollowups/pycbc_injection_minifollowup
@@ -62,6 +62,7 @@ parser.add_argument('--ifar-threshold', type=float, default=None,
                          "than this threshold.")
 parser.add_argument('--output-map')
 parser.add_argument('--output-file')
+parser.add_argument('--transformation-catalog')
 parser.add_argument('--tags', nargs='+', default=[])
 wf.add_workflow_command_line_group(parser)
 args = parser.parse_args()
@@ -253,5 +254,6 @@ for num_event in range(num_events):
     layouts += list(layout.grouper(files, 2))
     num_event += 1
 
-workflow.save(filename=args.output_file, output_map_path=args.output_map)
+workflow.save(filename=args.output_file, output_map_path=args.output_map,
+              transformation_catalog_path=args.transformation_catalog)
 layout.two_column_layout(args.output_dir, layouts)

--- a/bin/minifollowups/pycbc_sngl_minifollowup
+++ b/bin/minifollowups/pycbc_sngl_minifollowup
@@ -84,6 +84,7 @@ parser.add_argument('--maximum-duration', default=None, type=float,
 parser.add_argument('--wiki-file',
                     help="Name of file to save wiki-formatted table in")
 parser.add_argument('--output-map')
+parser.add_argument('--transformation-catalog')
 parser.add_argument('--output-file')
 parser.add_argument('--tags', nargs='+', default=[])
 wf.add_workflow_command_line_group(parser)
@@ -166,7 +167,8 @@ if len(trigs.snr) == 0:
     # There are no triggers, make no-op job and exit
     noop_node = mini.create_noop_node()
     workflow += noop_node
-    workflow.save(filename=args.output_file, output_map_path=args.output_map)
+    workflow.save(filename=args.output_file, output_map_path=args.output_map,
+                  transformation_catalog_path=args.transformation_catalog)
     sys.exit(0)
 
 trigs.mask_to_n_loudest_clustered_events(n_loudest=num_events,

--- a/bin/workflows/pycbc_make_inference_workflow
+++ b/bin/workflows/pycbc_make_inference_workflow
@@ -77,6 +77,8 @@ parser.add_argument("--output-dir", default=None,
                     help="Path to output directory.")
 parser.add_argument("--output-map", required=True,
                     help="Path to output map file.")
+parser.add_argument("--transformation-catalog", required=True,
+                    help="Path to transformation catalog file.")
 parser.add_argument("--output-file", required=True,
                     help="Path to DAX file.")
 
@@ -402,7 +404,8 @@ dep = dax.Dependency(parent=workflow.as_job, child=finalize_workflow.as_job)
 container._adag.addDependency(dep)
 
 # write dax
-container.save(filename=opts.output_file, output_map_path=opts.output_map)
+container.save(filename=opts.output_file, output_map_path=opts.output_map,
+               transformation_catalog_path=args.transformation_catalog)
 
 # save workflow configuration file
 base = rdir["workflow/configuration"]

--- a/pycbc/workflow/inference_followups.py
+++ b/pycbc/workflow/inference_followups.py
@@ -92,6 +92,8 @@ def setup_foreground_inference(workflow, coinc_file, single_triggers,
                                      tags=tags)
     node.new_output_file_opt(workflow.analysis_time, ".dax.map",
                                      "--output-map", tags=tags)
+    node.new_output_file_opt(workflow.analysis_time, ".tc.txt",
+                                     "--transformation-catalog", tags=tags)
 
     # get dax name and use it for the workflow name
     name = node.output_files[0].name
@@ -101,6 +103,9 @@ def setup_foreground_inference(workflow, coinc_file, single_triggers,
     map_file = node.output_files[1]
     node.add_opt("--output-dir", out_dir)
 
+    # get the transformation catalog name
+    tc_file = node.output_files[2]
+
     # add this node to the workflow
     workflow += node
 
@@ -109,7 +114,7 @@ def setup_foreground_inference(workflow, coinc_file, single_triggers,
     fil = node.output_files[0]
     job = dax.DAX(fil)
     job.addArguments("--basename %s" % os.path.splitext(os.path.basename(name))[0])
-    Workflow.set_job_properties(job, map_file)
+    Workflow.set_job_properties(job, map_file, tc_file)
     workflow._adag.addJob(job)
 
     # make dax a child of the inference workflow generator node

--- a/pycbc/workflow/minifollowups.py
+++ b/pycbc/workflow/minifollowups.py
@@ -92,9 +92,11 @@ def setup_foreground_minifollowups(workflow, coinc_file, single_triggers,
     node.add_opt('--inspiral-data-analyzed-name', insp_anal_name)
     node.new_output_file_opt(workflow.analysis_time, '.dax', '--output-file', tags=tags)
     node.new_output_file_opt(workflow.analysis_time, '.dax.map', '--output-map', tags=tags)
+    node.new_output_file_opt(workflow.analysis_time, '.tc.txt', '--transformation-catalog', tags=tags)
 
     name = node.output_files[0].name
     map_file = node.output_files[1]
+    tc_file = node.output_files[2]
 
     node.add_opt('--workflow-name', name)
     node.add_opt('--output-dir', out_dir)
@@ -106,7 +108,7 @@ def setup_foreground_minifollowups(workflow, coinc_file, single_triggers,
 
     job = dax.DAX(fil)
     job.addArguments('--basename %s' % os.path.splitext(os.path.basename(name))[0])
-    Workflow.set_job_properties(job, map_file)
+    Workflow.set_job_properties(job, map_file, tc_file)
     workflow._adag.addJob(job)
     dep = dax.Dependency(parent=node._dax_node, child=job)
     workflow._adag.addDependency(dep)
@@ -184,9 +186,11 @@ def setup_single_det_minifollowups(workflow, single_trig_file, tmpltbank_file,
         node.add_opt('--veto-segment-name', veto_segment_name)
     node.new_output_file_opt(workflow.analysis_time, '.dax', '--output-file', tags=tags)
     node.new_output_file_opt(workflow.analysis_time, '.dax.map', '--output-map', tags=tags)
+    node.new_output_file_opt(workflow.analysis_time, '.tc.txt', '--transformation-catalog', tags=tags)
 
     name = node.output_files[0].name
     map_file = node.output_files[1]
+    tc_file = node.output_files[2]
 
     node.add_opt('--workflow-name', name)
     node.add_opt('--output-dir', out_dir)
@@ -199,7 +203,7 @@ def setup_single_det_minifollowups(workflow, single_trig_file, tmpltbank_file,
     job = dax.DAX(fil)
     job.addArguments('--basename %s' \
                      % os.path.splitext(os.path.basename(name))[0])
-    Workflow.set_job_properties(job, map_file)
+    Workflow.set_job_properties(job, map_file, tc_file)
     workflow._adag.addJob(job)
     dep = dax.Dependency(parent=node._dax_node, child=job)
     workflow._adag.addDependency(dep)
@@ -269,9 +273,11 @@ def setup_injection_minifollowups(workflow, injection_file, inj_xml_file,
     node.add_opt('--inspiral-data-analyzed-name', insp_anal_name)
     node.new_output_file_opt(workflow.analysis_time, '.dax', '--output-file', tags=tags)
     node.new_output_file_opt(workflow.analysis_time, '.dax.map', '--output-map', tags=tags)
+    node.new_output_file_opt(workflow.analysis_time, '.tc.txt', '--transformation-catalog', tags=tags)
 
     name = node.output_files[0].name
     map_file = node.output_files[1]
+    tc_file = node.output_files[2]
 
     node.add_opt('--workflow-name', name)
     node.add_opt('--output-dir', out_dir)
@@ -283,7 +289,7 @@ def setup_injection_minifollowups(workflow, injection_file, inj_xml_file,
 
     job = dax.DAX(fil)
     job.addArguments('--basename %s' % os.path.splitext(os.path.basename(name))[0])
-    Workflow.set_job_properties(job, map_file)
+    Workflow.set_job_properties(job, map_file, tc_file)
     workflow._adag.addJob(job)
     dep = dax.Dependency(parent=node._dax_node, child=job)
     workflow._adag.addDependency(dep)

--- a/pycbc/workflow/pegasus_files/orangegrid-site-template.xml
+++ b/pycbc/workflow/pegasus_files/orangegrid-site-template.xml
@@ -13,5 +13,6 @@
     <profile namespace="condor" key="when_to_transfer_output">ON_EXIT_OR_EVICT</profile>
     <profile namespace="condor" key="+OrangeGrid">True</profile>
     <profile namespace="condor" key="run_as_owner">False</profile>
+    <profile namespace="condor" key="getenv">False</profile>
     <profile namespace="env" key="NO_TMPDIR">1</profile>
     <profile namespace="env" key="LAL_DATA_PATH">/cvmfs/oasis.opensciencegrid.org/ligo/sw/pycbc/lalsuite-extra/e02dab8c/share/lalsimulation</profile>

--- a/pycbc/workflow/pegasus_workflow.py
+++ b/pycbc/workflow/pegasus_workflow.py
@@ -69,12 +69,18 @@ class Executable(ProfileShortcuts):
     """
     id = 0
     def __init__(self, name, namespace=None, os='linux',
-                       arch='x86_64', installed=True, version=None):
+                       arch='x86_64', installed=True, version=None,
+                       container=None):
         self.logical_name = name + "_ID%s" % str(Executable.id)
         Executable.id += 1
         self.namespace = namespace
         self.version = version
-        self._dax_executable = dax.Executable(self.logical_name,
+        if container:
+            self._dax_executable = dax.Executable(self.logical_name,
+                   namespace=self.namespace, version=version, os=os,
+                   arch=arch, installed=installed, container=container)
+        else:
+            self._dax_executable = dax.Executable(self.logical_name,
                    namespace=self.namespace, version=version, os=os,
                    arch=arch, installed=installed)
         self.in_workflow = False
@@ -392,6 +398,10 @@ class Workflow(object):
 
         for e in self._adag.executables.copy():
             tc.add(e)
+            try:
+                tc.add_container(e.container)
+            except:
+                pass
             self._adag.removeExecutable(e)
 
         f = open(filename, "w")

--- a/pycbc/workflow/pegasus_workflow.py
+++ b/pycbc/workflow/pegasus_workflow.py
@@ -26,9 +26,10 @@
 """ This module provides thin wrappers around Pegasus.DAX3 functionality that
 provides additional abstraction and argument handling.
 """
-import Pegasus.DAX3 as dax
 import os
 import urlparse
+from Pegasus.catalogs.transformation_catalog import TransformationCatalog
+import Pegasus.DAX3 as dax
 
 class ProfileShortcuts(object):
     """ Container of common methods for setting pegasus profile information
@@ -362,7 +363,7 @@ class Workflow(object):
             raise TypeError('Cannot add type %s to this workflow' % type(other))
 
 
-    def save(self, filename=None):
+    def save(self, filename=None, tc=None):
         """ Write this workflow to DAX file
         """
         if filename is None:
@@ -371,8 +372,32 @@ class Workflow(object):
         for sub in self.sub_workflows:
             sub.save()
 
+        # FIXME this is ugly as pegasus 4.9.0 does not support the full
+        # transformation catalog in the DAX. I have asked Karan to fix this so
+        # that executables and containers can be specified in the DAX itself.
+        # Karan says that XML is going away in Pegasus 5.x and so this code
+        # will need to be re-written anyway.
+        #
+        # the transformation catalog is written in the same directory as the
+        # DAX.  pycbc_submit_dax needs to know this so that the right
+        # transformation catalog is used when the DAX is planned.
+        if tc is None:
+            tc = '{}.tc.txt'.format(filename)
+        p = os.path.dirname(tc)
+        f = os.path.basename(tc)
+        if not p:
+            p = '.'
+
+        tc = TransformationCatalog(p, f)
+
+        for e in self._adag.executables.copy():
+            tc.add(e)
+            self._adag.removeExecutable(e)
+
         f = open(filename, "w")
         self._adag.writeXML(f)
+        tc.write()
+
 
 class DataStorage(object):
     """ A workflow representation of a place to store and read data from.


### PR DESCRIPTION
This pull request adds support for singularity containers in PyCBC workflows. It changes `pycbc/workflow` to use text-based transformation catalogs written using the [new python api](https://pegasus.isi.edu/docs/4.9.0dev/python/transformation_catalog.html), rather than putting the transformation catalog information in the DAX, since the XML-based transformation catalog code doesn't support the [Container](https://pegasus.isi.edu/docs/4.9.0dev/python/index.html#Container) class.

With that fix, it adds support for setting up Pegasus jobs to run in singularity containers with the following config overrides:

1.  `"pegasus_container-inspiral:type:singularity"` tells PyCBC to use [singularity](https://www.sylabs.io/docs/) containers for the `inspiral` jobs.
2. `"pegasus_container-inspiral:image:file://localhost/cvmfs/singularity.opensciencegrid.org/pycbc/pycbc-el7:latest"` tells PyCBC to use the specified file as the singularity image. Note that @bbockelm automatically generates PyCBC containers for us using [cvmfs-singularity-sync](https://github.com/opensciencegrid/cvmfs-singularity-sync) so we can use containers from `/cvmfs` on sites that have it.
3. `"pegasus_container-inspiral:image_site:orangegrid"` sets the site for the container's PFN. Set this to the name of the execute site so that Pegasus knows that the container is already staged there (assuming `pegasus.transfer.bypass.input.staging=true` as it is for OSG/OrangeGrid jobs).
4. `"pegasus_container-inspiral:mount:/cvmfs:/cvmfs:ro"` makes CVMFS available inside the container.
5. `"executables:inspiral:/opt/pycbc/pycbc-software/bin/pycbc_inspiral"` should be set to the path of the executable *inside* the container. Note that the `INSTALLED` transformation catalog profile should be set using `pegasus_profile-inspiral:pycbc|installed:True`, but this is the default for PyCBC workflows unless overridden.

There are a few `FIXME`s in here, primarily because I don't like the way that Pegasus handles the output map and transformation catalog in a different way to the DAX. I talked to @vahi and @rynge about this and he said that they are going to re-visit this for Pegasus 5.x, so we can resolve that then.

Note that this patch is backward compatible with Pegasus 4.x so it can be merged now, as long as you don't try and specify a container. For it to work, we will need Pegasus 4.9.1 with https://github.com/pegasus-isi/pegasus/pull/14 which will be released soon.