### PR TITLE
Fix bug in posterior file labelling

### DIFF
--- a/bin/inference/pycbc_inference_plot_posterior
+++ b/bin/inference/pycbc_inference_plot_posterior
@@ -192,10 +192,13 @@ for (i, s) in enumerate(samples):
 # add legend to upper right for input files
 if len(opts.input_file) > 1:
     handles = []
-    for color, label in zip(hist_colors, opts.input_file_labels):
+    labels = []
+    for color, fn in zip(hist_colors, opts.input_file):
+        label = opts.input_file_labels[fn]
         handles.append(patches.Patch(color=color, label=label))
+        labels.append(label)
     fig.legend(loc="upper right", handles=handles,
-               labels=opts.input_file_labels)
+               labels=labels)
 
 # set DPI
 fig.set_dpi(200)


### PR DESCRIPTION
The inference dev branch introduced a bug into the input file labeling. This fixes that.

File labels are now automatically parsed from`--input-file file[:label]` and stored to `opts.input_file_labels` as a `file name -> file label` dict. The part where the legend is created is treating this as a list though, which results in the keys (the filenames) being used. Worse yet, because order isn't preserved in a dictionary, the colors and names could get swapped. This fixes that, ensuring order is preserved.
