### PR TITLE
Enable staging site for minifollowups

### DIFF
--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -730,7 +730,8 @@ class Workflow(pegasus_workflow.Workflow):
         if self.in_workflow is not False:
             self.in_workflow._adag.addFile(transformation_catalog_file)
 
-        staging_site = self.staging_site
+        if staging_site is None:
+            staging_site = self.staging_site
 
         Workflow.set_job_properties(self.as_job, output_map_file,
                                     transformation_catalog_file,

--- a/pycbc/workflow/minifollowups.py
+++ b/pycbc/workflow/minifollowups.py
@@ -107,9 +107,16 @@ def setup_foreground_minifollowups(workflow, coinc_file, single_triggers,
     # execute this in a sub-workflow
     fil = node.output_files[0]
 
+    # determine if a staging site has been specified
+    try:
+        staging_site = workflow.cp.get('workflow-foreground_minifollowups',
+                                       'staging-site')
+    except:
+        staging_site = None
+
     job = dax.DAX(fil)
     job.addArguments('--basename %s' % os.path.splitext(os.path.basename(name))[0])
-    Workflow.set_job_properties(job, map_file, tc_file)
+    Workflow.set_job_properties(job, map_file, tc_file, staging_site=staging_site)
     workflow._adag.addJob(job)
     dep = dax.Dependency(parent=node._dax_node, child=job)
     workflow._adag.addDependency(dep)
@@ -202,10 +209,17 @@ def setup_single_det_minifollowups(workflow, single_trig_file, tmpltbank_file,
     # execute this in a sub-workflow
     fil = node.output_files[0]
 
+    # determine if a staging site has been specified
+    try:
+        staging_site = workflow.cp.get('workflow-sngl_minifollowups',
+                                       'staging-site')
+    except:
+        staging_site = None
+
     job = dax.DAX(fil)
     job.addArguments('--basename %s' \
                      % os.path.splitext(os.path.basename(name))[0])
-    Workflow.set_job_properties(job, map_file, tc_file)
+    Workflow.set_job_properties(job, map_file, tc_file, staging_site=staging_site)
     workflow._adag.addJob(job)
     dep = dax.Dependency(parent=node._dax_node, child=job)
     workflow._adag.addDependency(dep)
@@ -290,9 +304,16 @@ def setup_injection_minifollowups(workflow, injection_file, inj_xml_file,
     # execute this in a sub-workflow
     fil = node.output_files[0]
 
+    # determine if a staging site has been specified
+    try:
+        staging_site = workflow.cp.get('workflow-injection_minifollowups',
+                                       'staging-site')
+    except:
+        staging_site = None
+
     job = dax.DAX(fil)
     job.addArguments('--basename %s' % os.path.splitext(os.path.basename(name))[0])
-    Workflow.set_job_properties(job, map_file, tc_file)
+    Workflow.set_job_properties(job, map_file, tc_file, staging_site=staging_site)
     workflow._adag.addJob(job)
     dep = dax.Dependency(parent=node._dax_node, child=job)
     workflow._adag.addDependency(dep)


### PR DESCRIPTION
In order for the jobs in a minifollowup workflow to run from a container on OSGConnect, the staging sit must be passed to pegasus when it plans the minifollowup DAX.