### PR TITLE
turn on reporting of integrity error and other performance data

### DIFF
--- a/pycbc/workflow/pegasus_files/pegasus-properties.conf
+++ b/pycbc/workflow/pegasus_files/pegasus-properties.conf
@@ -44,3 +44,8 @@ pegasus.metrics.app=ligo-pycbc
 # though the files maybe marked to be registered in the 
 # replica catalog
 pegasus.register=True
+
+# Help Pegasus developers by sharing performance data (optional)
+# Requires python package amqplib to be installed
+pegasus.monitord.encoding = json
+pegasus.catalog.workflow.amqp.url = amqp://friend:donatedata@msgs.pegasus.isi.edu:5672/prod/workflows


### PR DESCRIPTION
AMQP reporting requires python package amqplib to be installed.
if not installed and enabled, then it can break monitord population to sqlite backend.
this is now fixed in pegasus 4.9.1dev also
https://jira.isi.edu/browse/PM-1333

Additionally, the 4.9.1dev RPM's do have python-amqplib listed as a dependency.

If not installing from RPM, then please install amqplib via pip