### PR TITLE
Reduce tag count

### DIFF
--- a/bin/workflows/pycbc_create_offline_search_workflow
+++ b/bin/workflows/pycbc_create_offline_search_workflow
@@ -311,26 +311,28 @@ inj_coincs = wf.FileList()
 files_for_combined_injfind = []
 for inj_file, tag in zip(inj_files, inj_tags):
     output_dir = '%s_coinc' % tag
+    ctags = [tag, 'injections']
 
     if workflow.cp.has_option_tags('workflow-injections',
-                                   'compute-optimal-snr', tags=[tag]):
+                                   'compute-optimal-snr', tags=ctags):
         optimal_snr_file = wf.compute_inj_optimal_snr(
-                workflow, inj_file, psd_files, 'inj_files', tags=[tag])
+                workflow, inj_file, psd_files, 'inj_files', tags=ctags)
         file_for_injfind = optimal_snr_file
     else:
         file_for_injfind = inj_file
 
-    if workflow.cp.has_option_tags('workflow-injections', 'inj-cut', tags=[tag]):
+    if workflow.cp.has_option_tags('workflow-injections', 'inj-cut',
+                                   tags=ctags):
         file_for_vetoes = wf.cut_distant_injections(
-                workflow, file_for_injfind, 'inj_files', tags=[tag])
+                workflow, file_for_injfind, 'inj_files', tags=ctags)
     else:
         file_for_vetoes = inj_file
 
     if workflow.cp.has_option_tags('workflow-injections', 'strip-injections',
-                                   tags=[tag]):
+                                   tags=ctags):
         small_inj_file = wf.veto_injections(workflow, file_for_vetoes,
                              insp_files_seg_file, trig_generated_name,
-                             "inj_files", tags=[tag])
+                             "inj_files", tags=ctags)
     else:
         small_inj_file = file_for_vetoes
 
@@ -340,10 +342,10 @@ for inj_file, tag in zip(inj_files, inj_tags):
     insps = wf.setup_matchedfltr_workflow(workflow, analyzable_segs,
                                      datafind_files, splitbank_files_inj,
                                      output_dir, injection_file=small_inj_file,
-                                     tags = [tag])
+                                     tags=ctags)
 
     insps = wf.merge_single_detector_hdf_files(workflow, hdfbank[0],
-                                               insps, output_dir, tags=[tag])
+                                               insps, output_dir, tags=ctags)
 
 
 # Create the final log file

--- a/bin/workflows/pycbc_create_offline_search_workflow
+++ b/bin/workflows/pycbc_create_offline_search_workflow
@@ -217,7 +217,7 @@ statfiles += wf.setup_trigger_fitting(workflow, insps, hdfbank,
 # final_bg_files contains coinc results using vetoes final_veto_files
 # ifo_ids will store an (integer) index for each ifo in the precedence list
 full_insps = insps
-ctags = [tag, 'full']
+ctags = [tag]
 bg_files = []
 final_bg_files = []
 ifo_ids = {}
@@ -251,7 +251,7 @@ for i in range(2, len(insps)+1):
 
         # Create coinc tag, and set up the coinc job for the combination
         coinctag = '{}det_'.format(len(ifocomb)) + pivot_ifo + fixed_ifo
-        ctagcomb = [tag, 'full', coinctag]
+        ctagcomb = [tag, coinctag]
         bg_files += wf.setup_multiifo_interval_coinc(workflow, hdfbank, inspcomb, statfiles,
                                cum_veto_files, veto_names,
                                output_dir, pivot_ifo, fixed_ifo, tags=ctagcomb)
@@ -310,7 +310,6 @@ layout.two_column_layout(rdir['detector_sensitivity'],
 inj_coincs = wf.FileList()
 files_for_combined_injfind = []
 for inj_file, tag in zip(inj_files, inj_tags):
-    ctags = [tag, 'inj']
     output_dir = '%s_coinc' % tag
 
     if workflow.cp.has_option_tags('workflow-injections',

--- a/bin/workflows/pycbc_make_coinc_search_workflow
+++ b/bin/workflows/pycbc_make_coinc_search_workflow
@@ -197,7 +197,7 @@ inj_files, inj_tags = wf.setup_injection_workflow(workflow,
 
 ######################## Setup the FULL DATA run ##############################
 tag = output_dir = "full_data"
-ctags = [tag, 'full']
+ctags = [tag]
 
 # setup the matchedfilter jobs
 ind_insps = insps = wf.setup_matchedfltr_workflow(workflow, analyzable_segs,

--- a/bin/workflows/pycbc_make_coinc_search_workflow
+++ b/bin/workflows/pycbc_make_coinc_search_workflow
@@ -512,28 +512,29 @@ layout.single_layout(rdir['analysis_time/veto_definer'], ([vetodef_table]))
 inj_coincs = wf.FileList()
 files_for_combined_injfind = []
 for inj_file, tag in zip(inj_files, inj_tags):
-    ctags = [tag, 'inj']
+    ctags = [tag, 'injections']
     output_dir = '%s_coinc' % tag
 
     if workflow.cp.has_option_tags('workflow-injections',
-                                   'compute-optimal-snr', tags=[tag]):
+                                   'compute-optimal-snr', tags=ctags):
         optimal_snr_file = wf.compute_inj_optimal_snr(
-                workflow, inj_file, psd_files, 'inj_files', tags=[tag])
+                workflow, inj_file, psd_files, 'inj_files', tags=ctags)
         file_for_injfind = optimal_snr_file
     else:
         file_for_injfind = inj_file
 
-    if workflow.cp.has_option_tags('workflow-injections', 'inj-cut', tags=[tag]):
+    if workflow.cp.has_option_tags('workflow-injections', 'inj-cut',
+                                   tags=ctags):
         file_for_vetoes = wf.cut_distant_injections(
-                workflow, file_for_injfind, 'inj_files', tags=[tag])
+                workflow, file_for_injfind, 'inj_files', tags=ctags)
     else:
         file_for_vetoes = inj_file
 
     if workflow.cp.has_option_tags('workflow-injections', 'strip-injections',
-                                   tags=[tag]):
+                                   tags=ctags):
         small_inj_file = wf.veto_injections(workflow, file_for_vetoes,
                              insp_files_seg_file, trig_generated_name,
-                             "inj_files", tags=[tag])
+                             "inj_files", tags=ctags)
     else:
         small_inj_file = file_for_vetoes
 
@@ -543,15 +544,15 @@ for inj_file, tag in zip(inj_files, inj_tags):
     insps = wf.setup_matchedfltr_workflow(workflow, analyzable_segs,
                                      datafind_files, splitbank_files_inj,
                                      output_dir, injection_file=small_inj_file,
-                                     tags = [tag])
+                                     tags=ctags)
 
     insps = wf.merge_single_detector_hdf_files(workflow, hdfbank[0],
-                                               insps, output_dir, tags=[tag])
+                                               insps, output_dir, tags=ctags)
 
     inj_coinc = wf.setup_interval_coinc_inj(workflow, hdfbank,
                                     full_insps, insps, statfiles, bin_files,
                                     final_veto_file[0], final_veto_name[0],
-                                    output_dir, tags = ctags)
+                                    output_dir, tags=ctags)
     found_inj = wf.find_injections_in_hdf_coinc(workflow, wf.FileList([inj_coinc]),
                                     wf.FileList([file_for_injfind]),
                                     final_veto_file[0], final_veto_name[0],
@@ -564,7 +565,7 @@ for inj_file, tag in zip(inj_files, inj_tags):
                    exclude=['all', 'summ'], require='sub', tags=ctags)
     f = wf.make_foundmissed_plot(workflow, found_inj,
                    rdir['injections/%s' % tag],
-                   exclude=['all', 'summ'], require='sub', tags=[tag])
+                   exclude=['all', 'summ'], require='sub', tags=ctags)
 
     # Extra foundmissed/sensitivity plots
     wf.make_sensitivity_plot(workflow, found_inj,
@@ -572,17 +573,21 @@ for inj_file, tag in zip(inj_files, inj_tags):
                    exclude=['all', 'summ', 'sub'], tags=ctags)
     wf.make_foundmissed_plot(workflow, found_inj,
                    rdir['injections/%s' % tag],
-                   exclude=['all', 'summ', 'sub'], tags=[tag])
-
+                   exclude=['all', 'summ', 'sub'], tags=ctags)
     found_table = wf.make_inj_table(workflow, found_inj,
-                  rdir['injections/%s' % tag], singles=insps, tags=[tag + 'found'])
+                                    rdir['injections/%s' % tag],
+                                    singles=insps,
+                                    tags=ctags + ['found'])
     missed_table = wf.make_inj_table(workflow, found_inj,
-                  rdir['injections/%s' % tag], missed=True, tags=[tag + 'missed'])
+                                     rdir['injections/%s' % tag],
+                                     missed=True,
+                                     tags=ctags + ['missed'])
 
     for inj_insp, trig_insp in zip(insps, full_insps):
         f += wf.make_coinc_snrchi_plot(workflow, found_inj, inj_insp,
-                                  final_bg_file, trig_insp,
-                                  rdir['injections/%s' % tag], tags=[tag])
+                                       final_bg_file, trig_insp,
+                                       rdir['injections/%s' % tag],
+                                       tags=ctags)
 
     inj_layout = list(layout.grouper(f, 2)) + [(found_table,), (missed_table,)]
     if len(s) > 0: layout.group_layout(rdir['search_sensitivity/%s' % tag], s)
@@ -591,40 +596,41 @@ for inj_file, tag in zip(inj_files, inj_tags):
     # run minifollowups on nearest missed injections
     curr_dir_nam = 'injections/followup_of_{}'.format(tag)
     if workflow.cp.has_option_tags('workflow-injection_minifollowups',
-                                   'subsection-suffix', tags=[tag]):
+                                   'subsection-suffix', tags=ctags):
         suf_str = workflow.cp.get_opt_tags('workflow-injection_minifollowups',
-                                           'subsection-suffix', tags=[tag])
+                                           'subsection-suffix', tags=ctags)
         curr_dir_nam += '_' + suf_str
     currdir = rdir[curr_dir_nam]
     wf.setup_injection_minifollowups(workflow, found_inj, small_inj_file,
                                      insps,  hdfbank[0], insp_files_seg_file,
                                      data_analysed_name, trig_generated_name,
-                                     'daxes', currdir, tags=[tag])
+                                     'daxes', currdir, tags=ctags)
 
     # If option given, make throughput plots
     if workflow.cp.has_option_tags('workflow-matchedfilter',
-                                   'plot-throughput', tags=[tag]):
+                                   'plot-throughput', tags=ctags):
         wf.make_throughput_plot(workflow, insps, rdir['workflow/throughput'],
-                                tags=[tag])
+                                tags=ctags)
 
 # Make combined injection plots
 inj_summ = []
+ctags = ['combined', 'injections']
 if len(files_for_combined_injfind) > 0:
     found_inj = wf.find_injections_in_hdf_coinc(workflow, inj_coincs,
                             files_for_combined_injfind, censored_veto,
-                            'closed_box', 'allinj', tags=['ALLINJ'])
+                            'closed_box', 'allinj', tags=ctags)
     sen = wf.make_sensitivity_plot(workflow, found_inj, rdir['search_sensitivity'],
-                            require='all', tags=['ALLINJ'])
+                            require='all', tags=ctags)
     layout.group_layout(rdir['search_sensitivity'], sen)
     inj = wf.make_foundmissed_plot(workflow, found_inj, rdir['injections'],
-                            require='all', tags=['ALLINJ'])
+                            require='all', tags=ctags)
     layout.group_layout(rdir['injections'], inj)
 
     # Make summary page foundmissed and sensitivity plot
     sen = wf.make_sensitivity_plot(workflow, found_inj,
-                rdir['search_sensitivity'], require='summ', tags=['ALLINJ'])
+                rdir['search_sensitivity'], require='summ', tags=ctags)
     inj = wf.make_foundmissed_plot(workflow, found_inj,
-                rdir['injections'], require='summ', tags=['ALLINJ'])
+                rdir['injections'], require='summ', tags=ctags)
     inj_summ = list(layout.grouper(inj + sen, 2))
 
 # make analysis time summary

--- a/pycbc/workflow/coincidence.py
+++ b/pycbc/workflow/coincidence.py
@@ -332,7 +332,7 @@ def setup_simple_statmap(workflow, coinc_files, out_dir, tags=None):
                                               ifos=workflow.ifos,
                                               tags=tags, out_dir=out_dir)
 
-    stat_node = statmap_exe.create_node(coinc_files, tags=tags)
+    stat_node = statmap_exe.create_node(coinc_files)
     workflow.add_node(stat_node)
     return stat_node.output_files[0], stat_node.output_files
 
@@ -356,12 +356,12 @@ def setup_background_bins(workflow, coinc_files, bank_file, out_dir, tags=None):
 
     statmap_files = FileList([])
     for i, coinc_file in enumerate(bins_node.output_files):
-        statnode = statmap_exe.create_node(FileList([coinc_file]), tags=tags + ['BIN_%s' % i])
+        statnode = statmap_exe.create_node(FileList([coinc_file]), tags=['BIN_%s' % i])
         workflow += statnode
         statmap_files.append(statnode.output_files[0])
         statmap_files[i].bin_name = bins_node.names[i]
 
-    cstat_node = cstat_exe.create_node(statmap_files, tags=tags)
+    cstat_node = cstat_exe.create_node(statmap_files)
     workflow += cstat_node
 
     return cstat_node.output_files[0], statmap_files
@@ -402,7 +402,7 @@ def setup_background_bins_inj(workflow, coinc_files, background_file, bank_file,
     background_bins = [x for x in background_bins if x != '']
 
     for inj_type in ['injinj', 'injfull', 'fullinj']:
-        bins_node = bins_exe.create_node(FileList(coinc_files[inj_type]), bank_file, background_bins, tags=tags + [inj_type])
+        bins_node = bins_exe.create_node(FileList(coinc_files[inj_type]), bank_file, background_bins, tags=[inj_type])
         workflow += bins_node
         coinc_files[inj_type] = bins_node.output_files
 
@@ -410,11 +410,11 @@ def setup_background_bins_inj(workflow, coinc_files, background_file, bank_file,
     for i in range(len(background_bins)):
         statnode = statmap_exe.create_node(FileList([coinc_files['injinj'][i]]), FileList([background_file[i]]),
                                      FileList([coinc_files['injfull'][i]]), FileList([coinc_files['fullinj'][i]]),
-                                     tags=tags + ['BIN_%s' % i])
+                                     tags=['BIN_%s' % i])
         workflow += statnode
         statmap_files.append(statnode.output_files[0])
 
-    cstat_node = cstat_exe.create_node(statmap_files, tags=tags)
+    cstat_node = cstat_exe.create_node(statmap_files)
     workflow += cstat_node
 
     return cstat_node.output_files[0]


### PR DESCRIPTION
We've been adding too many tags to some of the jobs. This has gotten to the point where it's affecting performance as in some places we check all possible *combinations* of tags. This reduces to what it should have been.

**This will break config file functionality** as we had started using both "full" and "full_data" to mean the injection-less runs (ie. the actual search). Here I am standardizing on full_data, so sections like `coinc-full` need to become `coinc-full_data`.

I CC @tdent and @tapaimarton to advise that this change will be needed. Please let me know what config files I should update to this change (or if we should standardize in some different way).

Please note that this is not the only configuration-file-backwards-incompatible change in the works. Marton's fixes will require changes and Alex's segment changes will require changes.