### PR TITLE
Deal with integer-in-float-format input

### DIFF
--- a/pycbc/workflow/jobsetup.py
+++ b/pycbc/workflow/jobsetup.py
@@ -53,6 +53,9 @@ def int_gps_time_to_str(t):
             return str(t.gpsSeconds)
         else:
             raise ValueError('Need an integer GPS time, got %s' % str(t))
+    else:
+        err_msg = "Didn't understand input type {}".format(type(t))
+        raise ValueError(err_msg)
 
 def select_tmpltbank_class(curr_exe):
     """ This function returns a class that is appropriate for setting up

--- a/pycbc/workflow/jobsetup.py
+++ b/pycbc/workflow/jobsetup.py
@@ -42,6 +42,12 @@ def int_gps_time_to_str(t):
 
     if type(t) == int:
         return str(t)
+    elif type(t) == float:
+        # Wouldn't this just work generically?
+        int_t = int(t)
+        if abs(t - int_t) > 0.:
+            raise ValueError('Need an integer GPS time, got %s' % str(t))
+        return str(int_t)
     elif type(t) == lal.LIGOTimeGPS:
         if t.gpsNanoSeconds == 0:
             return str(t.gpsSeconds)


### PR DESCRIPTION
The ability to run workflows using Gaussian noise is currently broken.

I'm not quite sure when this happened, but the problem seems to be that the GPS time is being stored as a float, which is not recognized by the `int_gps_time_to_str` function. Using float input doesn't really seem to be ideal here, but the float format is sufficient to store 10 digit integers, so I added support for "integer stored as float" input in this function. I also added a fallthrough so that the function *fails* if the type is not recognized rather than returning None and proceeding. 