### PR TITLE
Fix edge case in legacy banksim

### DIFF
--- a/bin/pycbc_banksim
+++ b/bin/pycbc_banksim
@@ -324,7 +324,7 @@ with ctx:
     for index, signal_params in enumerate(signal_table):
         if options.verbose:
             update_progress(float(index+1)/len(signal_table))
-        if not options.use_sky_location:
+        if not options.use_sky_location and hasattr(signal_params, 'latitude'):
             signal_params.latitude = 0.
             signal_params.longitude = 0.
         stilde = get_waveform(options.signal_approximant,


### PR DESCRIPTION
A strange edge-case bug was reported in `pycbc_banksim` recently, which I think can only be encountered with the old `pycbc_make_banksim` code. Basically, if running with injections in XML `sngl_inspiral` format, and not using `--use-sky-location` the code will try to set the latitude and longitude fields to 0. The sngl_inspiral table doesn't have these fields, so when trying to do this the glue python object does add them, but in a subtly different way to how the fields like `mass1` are defined. This then causes all *other* fields to be ignored and waveform generation will fail saying that you didn't provide masses.

Simple solution: If in this edge case do not set these fields to 0. they will default to 0 any way.

(Let's not get into discussion of retiring XML in banksim here. We need to properly retire the old banksim code first, and that requires some decent documentation for the new code *and* some more testing of the HDF injection generation code ... Hopefully that discussion can happen soon!)