### PR TITLE
Remove unnecessary and impossible automatic transforms 

### DIFF
--- a/pycbc/transforms.py
+++ b/pycbc/transforms.py
@@ -1566,7 +1566,8 @@ def get_common_cbc_transforms(requested_params, variable_args,
                 converter.outputs.isdisjoint(requested_params)):
             continue
         intersect = converter.outputs.intersection(requested_params)
-        if len(intersect) < 1 or intersect.issubset(converter.inputs):
+        if (len(intersect) < 1 or intersect.issubset(converter.inputs) or 
+                intersect.issubset(variable_args)):
             continue
         requested_params.update(converter.inputs)
         from_base_c.append(converter)

--- a/pycbc/transforms.py
+++ b/pycbc/transforms.py
@@ -1566,7 +1566,7 @@ def get_common_cbc_transforms(requested_params, variable_args,
                 converter.outputs.isdisjoint(requested_params)):
             continue
         intersect = converter.outputs.intersection(requested_params)
-        if (len(intersect) < 1 or intersect.issubset(converter.inputs) or 
+        if (not intersect or intersect.issubset(converter.inputs) or
                 intersect.issubset(variable_args)):
             continue
         requested_params.update(converter.inputs)


### PR DESCRIPTION
Add one line in get_common_cbc_transforms in transforms.py : 
Before adding a transform from the base parameters to the requested parameters for automatic transformation, check if the intersection between requested parameters and the output of the transforms is already in the sampled parameters. If that is the case, we should not possibly gain anything useful from applying the transform, so this transform should not be added. 

Additionally, adding these transforms can lead to errors when plotting: If we request a parameter that is sampled in, for example q, and there is a transform that outputs this parameters AND another one, i.e. MChirp, which doesn't have q as an input parameter, than this transform will be added to the transforms that should be applied. Continuing the example, sampling in q and m_total and plotting only q will try to apply the inverse transform of MchirpQToMass1Mass2, which in turn needs mass1 and mass2, however those are not available, hence the error. 

In symbols: Sample in P1, request P1, there is a transform p3,p4  -> P1,P2 in common_cbc_inverse_transforms: This transform will be applied as long as P2 is NOT sampled in, no matter if p3,p4 are available. 

After the change an additional check if done, if P1 is already available. This makes plotting in the described situation possible again, but might not remove all problems. 