### PR TITLE
Add sampling transforms back to Gaussian noise model 

### DIFF
--- a/pycbc/inference/models/base.py
+++ b/pycbc/inference/models/base.py
@@ -693,7 +693,22 @@ class BaseModel(object):
 
     @classmethod
     def _init_args_from_config(cls, cp):
-        """Helper function for loading parameters."""
+        """Helper function for loading parameters.
+        
+        This retrieves the prior, variable parameters, static parameterss,
+        constraints, and sampling transforms.
+
+        Parameters
+        ----------
+        cp : ConfigParser
+            Config parser to read.
+        
+        Returns
+        -------
+        dict :
+            Dictionary of the arguments. Has keys ``variable_params``,
+            ``static_params``, ``prior``, and ``sampling_transforms``.
+        """
         section = "model"
         prior_section = "prior"
         vparams_section = 'variable_params'
@@ -714,6 +729,13 @@ class BaseModel(object):
         args = {'variable_params': variable_params,
                 'static_params': static_params,
                 'prior': prior}
+        # try to load sampling transforms
+        try:
+            sampling_transforms = SamplingTransforms.from_config(
+                cp, variable_params)
+        except ValueError:
+            sampling_transforms = None
+        args['sampling_transforms'] = sampling_transforms
         # get any other keyword arguments provided
         args.update(cls.extra_args_from_config(cp, section,
                                                skip_args=['name']))
@@ -732,13 +754,6 @@ class BaseModel(object):
             provided keyword will over ride what is in the config file.
         """
         args = cls._init_args_from_config(cp)
-        # try to load sampling transforms
-        try:
-            sampling_transforms = SamplingTransforms.from_config(
-                cp, args['variable_params'])
-        except ValueError:
-            sampling_transforms = None
-        args['sampling_transforms'] = sampling_transforms
         args.update(kwargs)
         return cls(**args)
 

--- a/pycbc/inference/models/base.py
+++ b/pycbc/inference/models/base.py
@@ -694,7 +694,7 @@ class BaseModel(object):
     @classmethod
     def _init_args_from_config(cls, cp):
         """Helper function for loading parameters.
-        
+
         This retrieves the prior, variable parameters, static parameterss,
         constraints, and sampling transforms.
 
@@ -702,7 +702,7 @@ class BaseModel(object):
         ----------
         cp : ConfigParser
             Config parser to read.
-        
+
         Returns
         -------
         dict :

--- a/pycbc/inference/models/marginalized_gaussian_noise.py
+++ b/pycbc/inference/models/marginalized_gaussian_noise.py
@@ -27,7 +27,6 @@ from pycbc.distributions import read_distributions_from_config
 from pycbc.waveform import generator
 
 from .gaussian_noise import GaussianNoise
-from .base import SamplingTransforms
 
 
 class MarginalizedGaussianNoise(GaussianNoise):

--- a/pycbc/inference/models/marginalized_gaussian_noise.py
+++ b/pycbc/inference/models/marginalized_gaussian_noise.py
@@ -306,13 +306,6 @@ class MarginalizedGaussianNoise(GaussianNoise):
         """
         prior_section = "marginalized_prior"
         args = cls._init_args_from_config(cp)
-        # try to load sampling transforms
-        try:
-            sampling_transforms = SamplingTransforms.from_config(
-                cp, args['variable_params'])
-        except ValueError:
-            sampling_transforms = None
-        args['sampling_transforms'] = sampling_transforms
         marg_prior = read_distributions_from_config(cp, prior_section)
         if len(marg_prior) == 0:
             raise AttributeError("No priors are specified for the "


### PR DESCRIPTION
Currently, Gaussian noise model does not load sampling transforms from the config file. This is a bug. This patch fixes this by moving the code that loads the sampling transforms into `_init_args_from_config`.

The marginalized Gaussian noise model was loading sampling transforms in its `from_config`. Since this is now done in `init_args_from_config`, I've removed that block of code from it.