### PR TITLE
move correlate functions to cython

### DIFF
--- a/examples/waveform/match_waveform.py
+++ b/examples/waveform/match_waveform.py
@@ -25,10 +25,10 @@ hp.resize(tlen)
 
 # Generate the aLIGO ZDHP PSD
 delta_f = 1.0 / sp.duration
-flen = tlen/2 + 1
+flen = tlen//2 + 1
 psd = aLIGOZeroDetHighPower(flen, delta_f, f_low)
 
 # Note: This takes a while the first time as an FFT plan is generated
 # subsequent calls are much faster.
 m, i = match(hp, sp, psd=psd, low_frequency_cutoff=f_low)
-print 'The match is: %1.3f' % m
+print('The match is: {:.4f}'.format(m))

--- a/pycbc/filter/autocorrelation.py
+++ b/pycbc/filter/autocorrelation.py
@@ -86,7 +86,7 @@ def calculate_acf(data, delta_t=1.0, unbiased=False):
 
     # correlate
     # do not need to give the congjugate since correlate function does it
-    cdata = FrequencySeries(zeros(len(fdata), dtype=numpy.complex64),
+    cdata = FrequencySeries(zeros(len(fdata), dtype=fdata.dtype),
                            delta_f=fdata.delta_f, copy=False)
     correlate(fdata, fdata, cdata)
 

--- a/pycbc/filter/matchedfilter.py
+++ b/pycbc/filter/matchedfilter.py
@@ -51,12 +51,16 @@ class BatchCorrelator(object):
     def __init__(self, xs, zs, size):
         """ Correlate x and y, store in z. Arrays need not be equal length, but
         must be at least size long and of the same dtype. No error checking
-        will be performed, so be careful. All dtypes must be the same.
+        will be performed, so be careful. All dtypes must be complex64.
         Note, must be created within the processing context that it will be used in.
         """
         self.size = int(size)
         self.dtype = xs[0].dtype
         self.num_vectors = len(xs)
+        
+        # keep reference to arrays 
+        self.xs = xs
+        self.zs = zs
 
         # Store each pointer as in integer array
         self.x = Array([v.ptr for v in xs], dtype=numpy.int)

--- a/pycbc/filter/matchedfilter.py
+++ b/pycbc/filter/matchedfilter.py
@@ -44,11 +44,6 @@ def correlate(x, y, z):
     err_msg += "scheme. You shouldn't be seeing this error!"
     raise ValueError(err_msg)
 
-@pycbc.scheme.schemed(BACKEND_PREFIX)
-def _correlate_factory(x, y, z):
-    err_msg = "This class is a stub that should be overridden using the "
-    err_msg += "scheme. You shouldn't be seeing this error!"
-    raise ValueError(err_msg)
 
 class BatchCorrelator(object):
     """ Create a batch correlation engine
@@ -72,6 +67,13 @@ class BatchCorrelator(object):
         pass
 
     execute = batch_correlate_execute
+
+
+@pycbc.scheme.schemed(BACKEND_PREFIX)
+def _correlate_factory(x, y, z):
+    err_msg = "This class is a stub that should be overridden using the "
+    err_msg += "scheme. You shouldn't be seeing this error!"
+    raise ValueError(err_msg)
 
 
 class Correlator(object):

--- a/pycbc/filter/matchedfilter.py
+++ b/pycbc/filter/matchedfilter.py
@@ -57,8 +57,8 @@ class BatchCorrelator(object):
         self.size = int(size)
         self.dtype = xs[0].dtype
         self.num_vectors = len(xs)
-        
-        # keep reference to arrays 
+
+        # keep reference to arrays
         self.xs = xs
         self.zs = zs
 

--- a/pycbc/filter/matchedfilter_cpu.pyx
+++ b/pycbc/filter/matchedfilter_cpu.pyx
@@ -1,4 +1,4 @@
-# Copyright (C) 2012  Alex Nitz
+# Copyright (C) 2018  Alex Nitz, Josh Willis
 # This program is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License as published by the
 # Free Software Foundation; either version 3 of the License, or (at your
@@ -30,77 +30,30 @@ from .simd_correlate import default_segsize, corr_parallel_code, corr_support
 from .matchedfilter import _BaseCorrelator
 cimport numpy, cython
 
-batch_correlator_code = """
-    #pragma omp parallel for
-    for (int i=0; i<num_vectors; i++){
-        std::complex<float>* xp = (std::complex<float>*) x[i];
-        std::complex<float>* zp = (std::complex<float>*) z[i];
-        for (int j=0; j<size; j++){
-            float xr, yr, xi, yi, re, im;
-            xr = xp[j].real();
-            xi = xp[j].imag();
-            yr = y[j].real();
-            yi = y[j].imag();
-            re = xr*yr + xi*yi;
-            im = xr*yi - xi*yr;
-            zp[j] = std::complex<float>(re, im);
-        }
-    }
-"""
+ctypedef fused COMPLEXTYPE:
+    float complex
+    double complex
+
+def _batch_correlate(numpy.ndarray [long, ndim=1] x, 
+                     numpy.ndarray [float complex, ndim=1] y,
+                     numpy.ndarray [long, ndim=1] z, 
+                     size, num_vectors):
+    cdef unsigned int nvec = num_vectors
+    cdef unsigned int vsize = size
+
+    cdef float complex* xp
+    cdef float complex* zp
+    
+    for i in range(nvec):
+        xp = <float complex*> x[i]
+        zp = <float complex*> z[i]
+        for j in range(vsize):
+            zp[j] = xp[j].conjugate() * y[j]
 
 def batch_correlate_execute(self, y):
     num_vectors = self.num_vectors # pylint:disable=unused-variable
     size = self.size # pylint:disable=unused-variable
-    x = numpy.array(self.x.data, copy=False) # pylint:disable=unused-variable
-    z = numpy.array(self.z.data, copy=False) # pylint:disable=unused-variable
-    y = numpy.array(y.data, copy=False)
-    inline(batch_correlator_code, ['x', 'y', 'z', 'size', 'num_vectors'],
-                extra_compile_args=[WEAVE_FLAGS] + omp_flags,
-                libraries=omp_libs)
-
-support = """
-    #include <stdio.h>
-    #include <math.h>
-"""
-
-code_batch = """
-#pragma omp parallel for
-for (int i=0; i<N; i++){
-    TYPE xr, yr, xi, yi, re, im;
-    xr = xa[i].real();
-    xi = xa[i].imag();
-    yr = ya[i].real();
-    yi = ya[i].imag();
-
-    re = xr*yr + xi*yi;
-    im = xr*yi - xi*yr;
-
-    za[i] = std::complex<TYPE>(re, im);
-}
-"""
-single_codeb = code_batch.replace('TYPE', 'float')
-double_codeb = code_batch.replace('TYPE', 'double')
-
-def correlate_batch_inline(x, y, z):
-    if z.precision == 'single':
-        the_code = single_codeb
-    else:
-        the_code = double_codeb
-
-    za = numpy.array(z.ptr, copy=False) # pylint:disable=unused-variable
-    xa = numpy.array(x.ptr, copy=False) # pylint:disable=unused-variable
-    ya = numpy.array(y.ptr, copy=False) # pylint:disable=unused-variable
-    N = len(x)  # pylint:disable=unused-variable
-    inline(the_code, ['xa', 'ya', 'za', 'N'],
-                    extra_compile_args=[WEAVE_FLAGS] + omp_flags,
-                    support_code = support,
-                    libraries=omp_libs
-          )
-
-
-ctypedef fused COMPLEXTYPE:
-    float complex
-    double complex
+    _batch_correlate(self.x.data, y.data, self.z.data, size, num_vectors)
 
 def correlate_numpy(x, y, z):
     z.data[:] = numpy.conjugate(x.data)[:]
@@ -123,23 +76,9 @@ class CPUCorrelator(_BaseCorrelator):
         self.x = numpy.array(x.data, copy=False)
         self.y = numpy.array(y.data, copy=False)
         self.z = numpy.array(z.data, copy=False)
-        self.arrlen = len(self.x)
-        self.code = corr_parallel_code
-        self.support = corr_support
-        self.segsize = default_segsize
 
     def correlate(self):
-        htilde = self.x # pylint:disable=unused-variable
-        stilde = self.y # pylint:disable=unused-variable
-        qtilde = self.z # pylint:disable=unused-variable
-        arrlen = self.arrlen # pylint:disable=unused-variable
-        segsize = self.segsize # pylint:disable=unused-variable
-        inline(self.code, ['htilde', 'stilde', 'qtilde', 'arrlen', 'segsize'],
-               extra_compile_args = [WEAVE_FLAGS] + omp_flags,
-               #extra_compile_args = ['-mno-avx -mno-sse2 -mno-sse3 -mno-ssse3 -mno-sse4 -mno-sse4.1 -mno-sse4.2 -mno-sse4a -O2 -w'] + omp_flags,
-               #extra_compile_args = ['-msse3 -O3 -w'] + omp_flags,
-               libraries = omp_libs, support_code = self.support, auto_downcast = 1)
-
+        _correlate(self.x, self.y, self.y)
 
 def _correlate_factory(x, y, z):
     return CPUCorrelator

--- a/pycbc/filter/matchedfilter_cpu.pyx
+++ b/pycbc/filter/matchedfilter_cpu.pyx
@@ -21,6 +21,7 @@
 #
 # =============================================================================
 #
+# cython: embedsignature=True
 from __future__ import absolute_import
 import numpy
 from .matchedfilter import _BaseCorrelator
@@ -30,16 +31,16 @@ ctypedef fused COMPLEXTYPE:
     float complex
     double complex
 
-def _batch_correlate(numpy.ndarray [long, ndim=1] x, 
+def _batch_correlate(numpy.ndarray [long, ndim=1] x,
                      numpy.ndarray [float complex, ndim=1] y,
-                     numpy.ndarray [long, ndim=1] z, 
+                     numpy.ndarray [long, ndim=1] z,
                      size, num_vectors):
     cdef unsigned int nvec = num_vectors
     cdef unsigned int vsize = size
 
     cdef float complex* xp
     cdef float complex* zp
-    
+
     for i in range(nvec):
         xp = <float complex*> x[i]
         zp = <float complex*> z[i]
@@ -54,7 +55,7 @@ def batch_correlate_execute(self, y):
 def correlate_numpy(x, y, z):
     z.data[:] = numpy.conjugate(x.data)[:]
     z *= y
-        
+
 @cython.boundscheck(False)
 @cython.wraparound(False)
 def _correlate(numpy.ndarray [COMPLEXTYPE, ndim=1] x,
@@ -62,7 +63,7 @@ def _correlate(numpy.ndarray [COMPLEXTYPE, ndim=1] x,
                numpy.ndarray [COMPLEXTYPE, ndim=1] z):
     cdef unsigned int xmax = x.shape[0]
     for i in range(xmax):
-        z[i] = x[i].conjugate() * y[i]        
+        z[i] = x[i].conjugate() * y[i]
 
 def correlate(x, y, z):
     _correlate(x.data, y.data, z.data)

--- a/pycbc/filter/matchedfilter_cpu.pyx
+++ b/pycbc/filter/matchedfilter_cpu.pyx
@@ -23,10 +23,6 @@
 #
 from __future__ import absolute_import
 import numpy
-from pycbc.opt import omp_libs, omp_flags
-from pycbc import WEAVE_FLAGS
-from pycbc.weave import inline
-from .simd_correlate import default_segsize, corr_parallel_code, corr_support
 from .matchedfilter import _BaseCorrelator
 cimport numpy, cython
 

--- a/setup.py
+++ b/setup.py
@@ -210,7 +210,8 @@ for name in cythonext:
     e = Extension("pycbc.%s_cpu" % name,
                   ["pycbc/%s_cpu.pyx" % name.replace('.', '/')],
                   extra_compile_args=[ '-O3', '-w', '-msse4.2',
-                                 '-ffast-math', '-ffinite-math-only'])
+                                 '-ffast-math', '-ffinite-math-only'],                           
+                  compiler_directives={'embedsignature': True})
     ext.append(e)
 
 setup (

--- a/setup.py
+++ b/setup.py
@@ -210,7 +210,7 @@ for name in cythonext:
     e = Extension("pycbc.%s_cpu" % name,
                   ["pycbc/%s_cpu.pyx" % name.replace('.', '/')],
                   extra_compile_args=[ '-O3', '-w', '-msse4.2',
-                                 '-ffast-math', '-ffinite-math-only'],                           
+                                 '-ffast-math', '-ffinite-math-only'],
                   compiler_directives={'embedsignature': True})
     ext.append(e)
 

--- a/setup.py
+++ b/setup.py
@@ -202,7 +202,9 @@ extras_require = {'cuda': ['pycuda>=2015.1', 'scikit-cuda']}
 # do the actual work of building the package
 VERSION = get_version_info()
 
-cythonext = ['waveform.spa_tmplt', 'types.array']
+cythonext = ['waveform.spa_tmplt',
+             'types.array',
+             'filter.matchedfilter']
 ext = []
 for name in cythonext:
     e = Extension("pycbc.%s_cpu" % name,

--- a/test/test_correlate.py
+++ b/test/test_correlate.py
@@ -66,7 +66,7 @@ class Testcorrelate(unittest.TestCase):
         z = self.z * 1
         corr = Correlator(x, y, z)
         corr.correlate()
-        
+
         self.assertTrue(z.almost_equal_elem(self.z, self.tolerance))
 
     def test_batch_correlate(self):
@@ -75,10 +75,10 @@ class Testcorrelate(unittest.TestCase):
         zs = [self.z+0, self.z*1, self.z*2, self.z*3]
         b = BatchCorrelator(xs, zs, size)
         b.execute(self.y)
-        
+
         for i in range(len(xs)):
             trusted_correlate(xs[i], self.y, self.z)
-            self.assertTrue(self.z.almost_equal_elem(zs[i], self.tolerance)) 
+            self.assertTrue(self.z.almost_equal_elem(zs[i], self.tolerance))
 
 suite = unittest.TestSuite()
 suite.addTest(unittest.TestLoader().loadTestsFromTestCase(Testcorrelate))

--- a/test/test_correlate.py
+++ b/test/test_correlate.py
@@ -33,6 +33,7 @@ from pycbc.scheme import *
 from pycbc.filter import *
 import pycbc.fft
 from utils import parse_args_all_schemes, simple_exit
+from pycbc.filter.matchedfilter import BatchCorrelator, Correlator
 
 _scheme, _context = parse_args_all_schemes("correlate")
 
@@ -58,6 +59,26 @@ class Testcorrelate(unittest.TestCase):
             z = zeros(2**20, dtype=complex64)
             correlate(self.x, self.y, z)
             self.assertTrue(self.z.almost_equal_elem(z, self.tolerance))
+
+    def test_correlator(self):
+        x = self.x * 1
+        y = self.y * 1
+        z = self.z * 1
+        corr = Correlator(x, y, z)
+        corr.correlate()
+        
+        self.assertTrue(z.almost_equal_elem(self.z, self.tolerance))
+
+    def test_batch_correlate(self):
+        size = len(self.x)
+        xs = [self.x+0, self.x+1, self.x+2, self.x+3]
+        zs = [self.z+0, self.z*1, self.z*2, self.z*3]
+        b = BatchCorrelator(xs, zs, size)
+        b.execute(self.y)
+        
+        for i in range(len(xs)):
+            trusted_correlate(xs[i], self.y, self.z)
+            self.assertTrue(self.z.almost_equal_elem(zs[i], self.tolerance)) 
 
 suite = unittest.TestSuite()
 suite.addTest(unittest.TestLoader().loadTestsFromTestCase(Testcorrelate))

--- a/tools/install_travis.sh
+++ b/tools/install_travis.sh
@@ -50,4 +50,4 @@ pip install -r requirements.txt
 
 echo -e ">> [`date`] installing pycbc"
 pip install .
-
+python setup.py build_ext --inplace

--- a/tools/install_travis.sh
+++ b/tools/install_travis.sh
@@ -50,4 +50,3 @@ pip install -r requirements.txt
 
 echo -e ">> [`date`] installing pycbc"
 pip install .
-python setup.py build_ext --inplace

--- a/tools/timing/correlate_perf.py
+++ b/tools/timing/correlate_perf.py
@@ -7,7 +7,7 @@ niter = 2000
 
 
 for N in [2**10, 2**15, 2**18]:
-    a = zeros(N, dtype=complex64) 
+    a = zeros(N, dtype=complex64)
     a.data += uniform(-1, 1, size=len(a))
     b = a * 0.5
     c = a * 1.5
@@ -26,12 +26,12 @@ for N in [2**10, 2**15, 2**18]:
 
 for dtp in [complex64, complex128]:
     for N in [2**10, 2**15, 2**20]:
-        a = zeros(N, dtype=dtp) 
+        a = zeros(N, dtype=dtp)
         a += Array(uniform(-1, 1, size=N) * (1 + -.5j), dtype=a.dtype)
         b = zeros(N, dtype=dtp)
         c = zeros(N, dtype=dtp)
         correlate(a, b, c)
-        
+
         t1 = time()
         for i in range(niter):
             correlate(a, b, c)
@@ -47,5 +47,4 @@ for dtp in [complex64, complex128]:
             t2 = time()
             print("Correlator Perf Type:{} Size:{} Time:{:3.3f}".format(repr(dtp),
                   N, (t2-t1)*1000 / niter))
-
 

--- a/tools/timing/correlate_perf.py
+++ b/tools/timing/correlate_perf.py
@@ -1,0 +1,22 @@
+from pycbc.filter import correlate
+from pycbc.types import zeros, complex64, complex128
+from time import time
+from numpy.random import uniform
+niter = 1000
+
+for dtp in [complex64, complex128]:
+    for N in [2**10, 2**15, 2**20]:
+        a = zeros(N, dtype=dtp) 
+        a.data += uniform(-1, 1, size=len(a))
+        b = a * 0.5
+        c = a * 1.5
+        correlate(a, b, c)
+        
+        t1 = time()
+        for i in range(niter):
+            correlate(a, b, c)
+        t2 = time()
+        print("Correlate Perf Type:{} Size:{} Time:{:3.3f}".format(repr(dtp),
+              N, (t2-t1)*1000 / niter))
+
+

--- a/tools/timing/correlate_perf.py
+++ b/tools/timing/correlate_perf.py
@@ -1,15 +1,35 @@
 from pycbc.filter import correlate
-from pycbc.types import zeros, complex64, complex128
+from pycbc.filter.matchedfilter import BatchCorrelator, Correlator
+from pycbc.types import zeros, complex64, complex128, Array
 from time import time
 from numpy.random import uniform
-niter = 1000
+niter = 2000
+
+
+for N in [2**10, 2**15, 2**18]:
+    a = zeros(N, dtype=complex64) 
+    a.data += uniform(-1, 1, size=len(a))
+    b = a * 0.5
+    c = a * 1.5
+
+    xs = [a*1, a*2, a*3]
+    zs = [c*1, c*2, c*3]
+    corr = BatchCorrelator(xs, zs, N)
+    t1 = time()
+    for i in range(niter):
+        corr.execute(b)
+
+    t2 = time()
+    print("Batch Correlate Perf Size:{} Time:{:3.3f}".format(
+          N, (t2-t1)*1000 / niter))
+
 
 for dtp in [complex64, complex128]:
     for N in [2**10, 2**15, 2**20]:
         a = zeros(N, dtype=dtp) 
-        a.data += uniform(-1, 1, size=len(a))
-        b = a * 0.5
-        c = a * 1.5
+        a += Array(uniform(-1, 1, size=N) * (1 + -.5j), dtype=a.dtype)
+        b = zeros(N, dtype=dtp)
+        c = zeros(N, dtype=dtp)
         correlate(a, b, c)
         
         t1 = time()
@@ -18,5 +38,14 @@ for dtp in [complex64, complex128]:
         t2 = time()
         print("Correlate Perf Type:{} Size:{} Time:{:3.3f}".format(repr(dtp),
               N, (t2-t1)*1000 / niter))
+
+        if dtp is complex64:
+            corr = Correlator(a, b, c)
+            t1 = time()
+            for i in range(niter):
+                corr.correlate()
+            t2 = time()
+            print("Correlator Perf Type:{} Size:{} Time:{:3.3f}".format(repr(dtp),
+                  N, (t2-t1)*1000 / niter))
 
 


### PR DESCRIPTION
This moves the correlate functions to use cython. It uses the simplest implementations for this initial version. I'm sure @josh-willis may want to re-enable some optimizations later one, but for now, I'm advocating getting to python3 compatibility first. 

* Adds unittest for the Correlator and BatchBorrelator
* Adds performance testing script for correlation functions (can be run on older pycbc as well for later regression comparison)

This enables functionality like match and matched_filter now work in some simple cases on python3. 