### PR TITLE
Removed unused imports of matplotlib.pyplot

### DIFF
--- a/bin/hdfcoinc/pycbc_get_loudest_params
+++ b/bin/hdfcoinc/pycbc_get_loudest_params
@@ -9,7 +9,6 @@ import numpy as np
 import h5py
 import argparse
 import logging
-import matplotlib.pyplot as plt
 import pycbc.events
 from pycbc.pnutils import mass1_mass2_to_mchirp_eta
 

--- a/bin/population/pycbc_population_plots
+++ b/bin/population/pycbc_population_plots
@@ -33,7 +33,7 @@ import h5py
 import pylab
 import numpy as np
 import scipy.stats as ss
-from matplotlib.pyplot import cm
+from matplotlib import cm
 from pycbc.population import rates_functions as rf
 from numpy import logaddexp, log, newaxis, expm1
 

--- a/bin/population/pycbc_population_rates
+++ b/bin/population/pycbc_population_rates
@@ -37,7 +37,6 @@ import pycbc.version
 import h5py
 import numpy as np
 import scipy.stats as ss
-from matplotlib import cm
 from pycbc.population import scale_injections as si
 from pycbc.population import rates_functions as rf
 from numpy import logaddexp, log, newaxis, expm1

--- a/bin/population/pycbc_population_rates
+++ b/bin/population/pycbc_population_rates
@@ -37,7 +37,7 @@ import pycbc.version
 import h5py
 import numpy as np
 import scipy.stats as ss
-from matplotlib.pyplot import cm
+from matplotlib import cm
 from pycbc.population import scale_injections as si
 from pycbc.population import rates_functions as rf
 from numpy import logaddexp, log, newaxis, expm1


### PR DESCRIPTION
This PR removes some unused/unnecessary imports of `matplotlib.pyplot` in the scripts, which can cause issues where `DISPLAY` is not set, etc etc.