### PR TITLE
Pass MKL DFT descriptor by reference to desctructor

### DIFF
--- a/pycbc/fft/mkl.py
+++ b/pycbc/fft/mkl.py
@@ -100,7 +100,7 @@ def fft(invec, outvec, prec, itype, otype):
     f = lib.DftiComputeForward
     f.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p]
     status = f(descr, invec.ptr, outvec.ptr)
-    lib.DftiFreeDescriptor(descr)
+    lib.DftiFreeDescriptor(ctypes.byref(descr))
     check_status(status)
 
 def ifft(invec, outvec, prec, itype, otype):
@@ -109,7 +109,7 @@ def ifft(invec, outvec, prec, itype, otype):
     f = lib.DftiComputeBackward
     f.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p]
     status = f(descr, invec.ptr, outvec.ptr)
-    lib.DftiFreeDescriptor(descr)
+    lib.DftiFreeDescriptor(ctypes.byref(descr))
     check_status(status)
 
 # Class based API


### PR DESCRIPTION
This PR should fix #2202 . The problem was that the "descriptor" used by MKL's FFT was erroneously being passed by value to the destructor when it should have been passed by reference in the ctypes wrapping. This is now fixed for the function API; the class-based API has never attempted to free the descriptor (that would require a `__del__` method for the classes).