### PR TITLE
Move waveform dependence out of BaseDataModel

### DIFF
--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -122,8 +122,6 @@ model_args = {}
 strain_dict, stilde_dict, psd_dict = option_utils.data_from_cli(opts)
 if stilde_dict:
     model_args['data'] = stilde_dict
-    model_args['delta_f'] = stilde_dict.values()[0].delta_f
-    model_args['delta_t'] = strain_dict.values()[0].delta_t
     model_args['psds'] = psd_dict
 
 with ctx:

--- a/pycbc/inference/models/base.py
+++ b/pycbc/inference/models/base.py
@@ -709,7 +709,8 @@ class BaseModel(object):
         """Helper function for loading parameters.
 
         This retrieves the prior, variable parameters, static parameterss,
-        constraints, and sampling transforms.
+        constraints, sampling transforms, and waveform transforms
+        (if provided).
 
         Parameters
         ----------
@@ -720,7 +721,9 @@ class BaseModel(object):
         -------
         dict :
             Dictionary of the arguments. Has keys ``variable_params``,
-            ``static_params``, ``prior``, and ``sampling_transforms``.
+            ``static_params``, ``prior``, and ``sampling_transforms``. If
+            waveform transforms are in the config file, will also have
+            ``waveform_transforms``.
         """
         section = "model"
         prior_section = "prior"

--- a/pycbc/inference/models/base.py
+++ b/pycbc/inference/models/base.py
@@ -330,6 +330,13 @@ class BaseModel(object):
     sampling_transforms : list, optional
         List of transforms to use to go between the ``variable_params`` and the
         sampling parameters. Required if ``sampling_params`` is not None.
+    waveform_transforms : list, optional
+        A list of transforms to convert the ``variable_params`` into something
+        understood by the likelihood model. This is useful if the prior is
+        more easily parameterized in parameters that are different than what
+        the likelihood is most easily defined in. Since these are used solely
+        for converting parameters, and not for rescaling the parameter space,
+        a Jacobian is not required for these transforms.
 
     Properties
     ----------
@@ -351,7 +358,7 @@ class BaseModel(object):
     name = None
 
     def __init__(self, variable_params, static_params=None, prior=None,
-                 sampling_transforms=None):
+                 sampling_transforms=None, waveform_transforms=None):
         # store variable and static args
         if isinstance(variable_params, basestring):
             variable_params = (variable_params,)
@@ -368,8 +375,9 @@ class BaseModel(object):
             assert prior.variable_args == variable_params, (
                 "variable params of prior and model must be the same")
             self.prior_distribution = prior
-        # store sampling transforms
+        # store transforms
         self.sampling_transforms = sampling_transforms
+        self.waveform_transforms = waveform_transforms
         # initialize current params to None
         self._current_params = None
         # initialize a model stats
@@ -615,6 +623,11 @@ class BaseModel(object):
         # variable args
         if self.sampling_transforms is not None:
             params = self.sampling_transforms.apply(params, inverse=True)
+        # apply waveform transforms
+        if self.waveform_transforms is not None:
+            params = transforms.apply_transforms(params,
+                                                 self.waveform_transforms,
+                                                 inverse=False)
         # apply boundary conditions
         params = self.prior_distribution.apply_boundary_conditions(**params)
         return params
@@ -736,6 +749,12 @@ class BaseModel(object):
         except ValueError:
             sampling_transforms = None
         args['sampling_transforms'] = sampling_transforms
+        # get any waveform transforms
+        if any(cp.get_subsections('waveform_transforms')):
+            logging.info("Loading waveform transforms")
+            args['waveform_transforms'] = \
+                transforms.read_transforms_from_config(
+                    cp, 'waveform_transforms')
         # get any other keyword arguments provided
         args.update(
                 cls.extra_args_from_config(cp, section, skip_args=['name']))

--- a/pycbc/inference/models/base.py
+++ b/pycbc/inference/models/base.py
@@ -755,9 +755,6 @@ class BaseModel(object):
             args['waveform_transforms'] = \
                 transforms.read_transforms_from_config(
                     cp, 'waveform_transforms')
-        # get any other keyword arguments provided
-        args.update(
-                cls.extra_args_from_config(cp, section, skip_args=['name']))
         return args
 
     @classmethod
@@ -773,6 +770,9 @@ class BaseModel(object):
             provided keyword will over ride what is in the config file.
         """
         args = cls._init_args_from_config(cp)
+        # get any other keyword arguments provided in the model section
+        args.update(cls.extra_args_from_config(cp, "model",
+                                               skip_args=['name']))
         args.update(kwargs)
         return cls(**args)
 

--- a/pycbc/inference/models/base_data.py
+++ b/pycbc/inference/models/base_data.py
@@ -30,7 +30,6 @@ import logging
 from abc import (ABCMeta, abstractmethod)
 
 from pycbc import transforms
-from pycbc.waveform import generator
 
 from .base import BaseModel
 
@@ -142,11 +141,6 @@ class BaseDataModel(BaseModel):
             return logp
         else:
             return logp + self.loglr
-
-    @property
-    def data(self):
-        """Returns the data that was set."""
-        return self._data
 
     @property
     def detectors(self):

--- a/pycbc/inference/models/base_data.py
+++ b/pycbc/inference/models/base_data.py
@@ -26,10 +26,7 @@
 """
 
 import numpy
-import logging
 from abc import (ABCMeta, abstractmethod)
-
-from pycbc import transforms
 
 from .base import BaseModel
 
@@ -78,6 +75,7 @@ class BaseDataModel(BaseModel):
 
     def __init__(self, variable_params, data, recalibration=None, gates=None,
                  **kwargs):
+        self._data = None
         self.data = data
         self.recalibration = recalibration
         self.gates = gates
@@ -85,6 +83,7 @@ class BaseDataModel(BaseModel):
 
     @property
     def data(self):
+        """Dictionary mapping detector names to data."""
         return self._data
 
     @data.setter

--- a/pycbc/inference/models/base_data.py
+++ b/pycbc/inference/models/base_data.py
@@ -52,24 +52,20 @@ class BaseDataModel(BaseModel):
     data : dict
         A dictionary of data, in which the keys are the detector names and the
         values are the data.
-    waveform_generator : generator class
-        A generator class that creates waveforms.
-    waveform_transforms : list, optional
-        List of transforms to use to go from the variable args to parameters
-        understood by the waveform generator.
+    recalibration : dict of pycbc.calibration.Recalibrate, optional
+        Dictionary of detectors -> recalibration class instances for
+        recalibrating data.
+    gates : dict of tuples, optional
+        Dictionary of detectors -> tuples of specifying gate times. The
+        sort of thing returned by `pycbc.gate.gates_from_cli`.
 
     \**kwargs :
         All other keyword arguments are passed to ``BaseModel``.
 
     Attributes
     ----------
-    waveform_generator : dict
-        The waveform generator that the class was initialized with.
     data : dict
         The data that the class was initialized with.
-
-    Properties
-    ----------
     lognl :
         Returns the log likelihood of the noise.
     loglr :
@@ -81,14 +77,21 @@ class BaseDataModel(BaseModel):
     """
     __metaclass__ = ABCMeta
 
-    def __init__(self, variable_params, data, waveform_generator,
-                 waveform_transforms=None, **kwargs):
-        # we'll store a copy of the data
-        self._data = {ifo: d.copy() for (ifo, d) in data.items()}
-        self._waveform_generator = waveform_generator
-        self._waveform_transforms = waveform_transforms
-        super(BaseDataModel, self).__init__(
-            variable_params, **kwargs)
+    def __init__(self, variable_params, data, recalibration=None, gates=None,
+                 **kwargs):
+        self.data = data
+        self.recalibration = recalibration
+        self.gates = gates
+        super(BaseDataModel, self).__init__(variable_params, **kwargs)
+
+    @property
+    def data(self):
+        return self._data
+
+    @data.setter
+    def data(self, data):
+        """Store a copy of the data."""
+        self._data = {det: d.copy() for (det, d) in data.items()}
 
     @property
     def _extra_stats(self):
@@ -141,11 +144,6 @@ class BaseDataModel(BaseModel):
             return logp + self.loglr
 
     @property
-    def waveform_generator(self):
-        """Returns the waveform generator that was set."""
-        return self._waveform_generator
-
-    @property
     def data(self):
         """Returns the data that was set."""
         return self._data
@@ -154,88 +152,6 @@ class BaseDataModel(BaseModel):
     def detectors(self):
         """Returns the detectors used."""
         return self._data.keys()
-
-    def _transform_params(self, **params):
-        """Adds waveform transforms to parent's ``_transform_params``."""
-        params = super(BaseDataModel, self)._transform_params(**params)
-        # apply waveform transforms
-        if self._waveform_transforms is not None:
-            params = transforms.apply_transforms(params,
-                                                 self._waveform_transforms,
-                                                 inverse=False)
-        return params
-
-    @classmethod
-    def _init_args_from_config(cls, cp):
-        """Adds loading waveform_transforms to parent function.
-
-        For details on parameters, see ``from_config``.
-        """
-        args = super(BaseDataModel, cls)._init_args_from_config(cp)
-        # add waveform transforms to the arguments
-        if any(cp.get_subsections('waveform_transforms')):
-            logging.info("Loading waveform transforms")
-            args['waveform_transforms'] = \
-                transforms.read_transforms_from_config(
-                    cp, 'waveform_transforms')
-        return args
-
-    @classmethod
-    def from_config(cls, cp, data=None, delta_f=None, delta_t=None,
-                    gates=None, recalibration=None,
-                    **kwargs):
-        """Initializes an instance of this class from the given config file.
-
-        Parameters
-        ----------
-        cp : WorkflowConfigParser
-            Config file parser to read.
-        data : dict
-            A dictionary of data, in which the keys are the detector names and
-            the values are the data. This is not retrieved from the config
-            file, and so must be provided.
-        delta_f : float
-            The frequency spacing of the data; needed for waveform generation.
-        delta_t : float
-            The time spacing of the data; needed for time-domain waveform
-            generators.
-        recalibration : dict of pycbc.calibration.Recalibrate, optional
-            Dictionary of detectors -> recalibration class instances for
-            recalibrating data.
-        gates : dict of tuples, optional
-            Dictionary of detectors -> tuples of specifying gate times. The
-            sort of thing returned by `pycbc.gate.gates_from_cli`.
-        \**kwargs :
-            All additional keyword arguments are passed to the class. Any
-            provided keyword will over ride what is in the config file.
-        """
-        if data is None:
-            raise ValueError("must provide data")
-        args = cls._init_args_from_config(cp)
-        args['data'] = data
-        args.update(kwargs)
-
-        variable_params = args['variable_params']
-        try:
-            static_params = args['static_params']
-        except KeyError:
-            static_params = {}
-
-        # set up waveform generator
-        try:
-            approximant = static_params['approximant']
-        except KeyError:
-            raise ValueError("no approximant provided in the static args")
-        generator_function = generator.select_waveform_generator(approximant)
-        waveform_generator = generator.FDomainDetFrameGenerator(
-            generator_function, epoch=data.values()[0].start_time,
-            variable_args=variable_params, detectors=data.keys(),
-            delta_f=delta_f, delta_t=delta_t,
-            recalib=recalibration, gates=gates,
-            **static_params)
-        args['waveform_generator'] = waveform_generator
-
-        return cls(**args)
 
     def write_metadata(self, fp):
         """Adds data to the metadata that's written.

--- a/pycbc/inference/models/gaussian_noise.py
+++ b/pycbc/inference/models/gaussian_noise.py
@@ -106,7 +106,7 @@ class GaussianNoise(BaseDataModel):
         will be used.
     static_params : dict, optional
         A dictionary of parameter names -> values to keep fixed.
-    **kwargs :
+    \**kwargs :
         All other keyword arguments are passed to ``BaseDataModel``.
 
     Examples
@@ -470,7 +470,7 @@ class GaussianNoise(BaseDataModel):
 
     @classmethod
     def from_config(cls, cp, **kwargs):
-        """Initializes an instance of this class from the given config file.
+        r"""Initializes an instance of this class from the given config file.
 
         Parameters
         ----------

--- a/pycbc/inference/models/gaussian_noise.py
+++ b/pycbc/inference/models/gaussian_noise.py
@@ -122,7 +122,7 @@ class GaussianNoise(BaseDataModel):
     >>> N = seglen*sample_rate/2+1
     >>> fmin = 30.
     >>> static_params = {'approximant': 'IMRPhenomD', 'f_lower': fmin,
-    ...                  'mass1': 38.6, 'mass2': 29.3, 
+    ...                  'mass1': 38.6, 'mass2': 29.3,
     ...                  'spin1z': 0., 'spin2z': 0., 'ra': 1.37, 'dec': -1.26,
     ...                  'polarization': 2.76, 'distance': 3*500.}
     >>> variable_params = ['tc']
@@ -260,14 +260,17 @@ class GaussianNoise(BaseDataModel):
 
     @property
     def waveform_generator(self):
+        """The waveform generator used."""
         return self._waveform_generator
 
     @property
     def low_frequency_cutoff(self):
+        """The low frequency cutoff of the inner product."""
         return self._f_lower
 
     @property
     def high_frequency_cutoff(self):
+        """The high frequency cutoff of the inner product."""
         return self._f_upper
 
     @property
@@ -528,14 +531,14 @@ def create_waveform_generator(variable_params, data,
     # get data parameters; we'll just use one of the data to get the
     # values, then check that all the others are the same
     delta_f = None
-    for (det, d) in data.items():
+    for d in data.values():
         if delta_f is None:
             delta_f = d.delta_f
             delta_t = d.delta_t
             start_time = d.start_time
         else:
             if not all([d.delta_f == delta_f, d.delta_t == delta_t,
-                       d.start_time == start_time]):
+                        d.start_time == start_time]):
                 raise ValueError("data must all have the same delta_t, "
                                  "delta_f, and start_time")
     waveform_generator = generator.FDomainDetFrameGenerator(
@@ -602,4 +605,3 @@ def high_frequency_cutoff_from_config(cp):
     else:
         high_frequency_cutoff = None
     return high_frequency_cutoff
-

--- a/pycbc/inference/models/gaussian_noise.py
+++ b/pycbc/inference/models/gaussian_noise.py
@@ -483,6 +483,10 @@ class GaussianNoise(BaseDataModel):
         args = cls._init_args_from_config(cp)
         args['low_frequency_cutoff'] = low_frequency_cutoff_from_config(cp)
         args['high_frequency_cutoff'] = high_frequency_cutoff_from_config(cp)
+        # get any other keyword arguments provided in the model section
+        ignore_args = ['name', 'low-frequency-cutoff', 'high-frequency-cutoff']
+        args.update(cls.extra_args_from_config(cp, "model",
+                                               skip_args=ignore_args))
         args.update(kwargs)
         return cls(**args)
 


### PR DESCRIPTION
This moves stuff about waveform generation out of `BaseDataModel`. Now `BaseDataModel` only introduces attributes for data, and the concepts of log likelihood ratio and log likelihood noise. This should make it easier inheriting for things like the ROQ model.

Setting up the waveform generator is now moved to within `GaussianNoise.__init__`, with the actual generator setup farmed out to stand alone functions. This means that `GaussianNoise` no longer takes the generator as input, but instead uses the other inputs (which provide enough information) it already needed to set up the generator. This makes it simpler to initialize `GaussianNoise`.

Finally, I moved the stuff about loading low frequency cutoff from the config file that Stephan added to a stand alone function, which is now called directly from a reimplementation of `from_config` for `GaussianNoise`, thereby getting rid of a long spaghetti train of `_init_args_from_config`. I also added a function to read the high frequency cutoff from the config file, so that functionality may also be used when doing runs.