### PR TITLE
add options to choose temp file directory in pycbc, output  posterior file

### DIFF
--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -54,7 +54,7 @@ parser.add_argument("--save-backup", action="store_true",
                          "completed.")
 parser.add_argument("--cleanup-files", action="store_true",
                     help="Clean up the temporary backup and checkpoint files")
-parser.add_argument("--temp-file-dir",
+parser.add_argument("--tmp-file-dir", default='./',
                     help="Set the output directory for temporary files")
 # parallelization options
 parser.add_argument("--nprocesses", type=int, default=1,
@@ -170,7 +170,8 @@ with ctx:
         injection_file = opts.injection_file.values()[0]  # None if not set
     else:
         injection_file = None
-    sampler.setup_output(opts.output_file, force=opts.force,
+    sampler.setup_output(opts.output_file, output_dir=opts.tmp_file_dir,
+                         force=opts.force,
                          injection_file=injection_file)
 
     # Figure out where to get the initial conditions from: a samples file,
@@ -194,15 +195,16 @@ with ctx:
     # Run the sampler
     sampler.run()
 
-    # Finalize the output 
-    sampler.finalize()
+    # Finalize the output
+    sampler.finalize(opts.output_file)
 
-# rename checkpoint to output and delete backup
-logging.info("Moving checkpoint to output")
-os.rename(sampler.checkpoint_file, opts.output_file)
 if not opts.save_backup:
     logging.info("Deleting backup file")
     os.remove(sampler.backup_file)
+
+if opts.cleanup_files:
+    logging.info("Deleting checkpoint file")
+    os.remove(sampler.checkpoint_file)
 
 # exit
 logging.info("Done")

--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -52,6 +52,10 @@ parser.add_argument("--save-backup", action="store_true",
                     default=False,
                     help="Don't delete the backup file after the run has "
                          "completed.")
+parser.add_argument("--cleanup-files", action="store_true",
+                    help="Clean up the temporary backup and checkpoint files")
+parser.add_argument("--temp-file-dir",
+                    help="Set the output directory for temporary files")
 # parallelization options
 parser.add_argument("--nprocesses", type=int, default=1,
                     help="Number of processes to use. If not given then only "

--- a/bin/inference/pycbc_inference_extract_samples
+++ b/bin/inference/pycbc_inference_extract_samples
@@ -63,6 +63,6 @@ fp, params, labels, samples = results_from_cli(opts)
 
 if not opts.posterior_only:
     raise ValueError("Program not yet able to produce "
-                     "anything but hte posterior output.")
+                     "anything but the posterior output.")
 else:
     fp.write_posterior(opts.output_file)

--- a/pycbc/inference/models/base.py
+++ b/pycbc/inference/models/base.py
@@ -358,7 +358,7 @@ class BaseModel(object):
     name = None
 
     def __init__(self, variable_params, static_params=None, prior=None,
-                 sampling_transforms=None, waveform_transforms=None):
+                 sampling_transforms=None, waveform_transforms=None, **kwargs):
         # store variable and static args
         if isinstance(variable_params, basestring):
             variable_params = (variable_params,)

--- a/pycbc/inference/sampler/base.py
+++ b/pycbc/inference/sampler/base.py
@@ -167,7 +167,7 @@ class BaseSampler(object):
         """
         # check for backup file(s)
         checkpoint_file = os.path.join(output_dir,
-                                        output_file + '.checkpoint')
+                                       output_file + '.checkpoint')
         backup_file = os.path.join(output_dir, output_file + '.bkup')
         # check if we have a good checkpoint and/or backup file
         logging.info("Looking for checkpoint file")

--- a/pycbc/inference/sampler/base.py
+++ b/pycbc/inference/sampler/base.py
@@ -139,11 +139,12 @@ class BaseSampler(object):
         pass
 
     @abstractmethod
-    def finalize(self):
+    def finalize(self, output_file):
         """Do any finalization to the samples file before exiting."""
         pass
 
-    def setup_output(self, output_file, force=False, injection_file=None):
+    def setup_output(self, output_file, output_dir='./',
+                     force=False, injection_file=None):
         """Sets up the sampler's checkpoint and output files.
 
         The checkpoint file has the same name as the output file, but with
@@ -165,8 +166,9 @@ class BaseSampler(object):
             If an injection was added to the data, write its information.
         """
         # check for backup file(s)
-        checkpoint_file = output_file + '.checkpoint'
-        backup_file = output_file + '.bkup'
+        checkpoint_file = os.path.join(output_dir,
+                                        output_file + '.checkpoint')
+        backup_file = os.path.join(output_dir, output_file + '.bkup')
         # check if we have a good checkpoint and/or backup file
         logging.info("Looking for checkpoint file")
         checkpoint_valid = validate_checkpoint_files(checkpoint_file,

--- a/pycbc/inference/sampler/emcee.py
+++ b/pycbc/inference/sampler/emcee.py
@@ -181,10 +181,11 @@ class EmceeEnsembleSampler(MCMCAutocorrSupport, BaseMCMC, BaseSampler):
             # write random state
             fp.write_random_state(state=self._sampler.random_state)
 
-    def finalize(self):
+    def finalize(self, output_file):
         """All data is written by the last checkpoint in the run method, so
         this just passes."""
-        pass
+        with self.io(self.checkpoint_file, 'a') as fp:
+            fp.write_posterior(output_file)
 
     @classmethod
     def from_config(cls, cp, model, nprocesses=1, use_mpi=False):

--- a/pycbc/inference/sampler/emcee_pt.py
+++ b/pycbc/inference/sampler/emcee_pt.py
@@ -275,7 +275,7 @@ class EmceePTSampler(MultiTemperedAutocorrSupport, MultiTemperedSupport,
         return dummy_sampler.thermodynamic_integration_log_evidence(
             logls=logls, fburnin=0.)
 
-    def finalize(self):
+    def finalize(self, output_file):
         """Calculates the log evidence and writes to the checkpoint file.
 
         The thin start/interval/end for calculating the log evidence are
@@ -284,6 +284,7 @@ class EmceePTSampler(MultiTemperedAutocorrSupport, MultiTemperedSupport,
         logging.info("Calculating log evidence")
         # get the thinning settings
         with self.io(self.checkpoint_file, 'r') as fp:
+            fp.write_posterior(output_file)
             thin_start = fp.thin_start
             thin_interval = fp.thin_interval
             thin_end = fp.thin_end


### PR DESCRIPTION
This adds two options
--tmp-file-dir
Which sets the location of the checkpoint and backup files. This is useful for not taking down ATLAS when running > 1000 inference jobs. 
--cleanup-files
With this option enabled both the backup and checkpoint file are cleaned up at the end of the program.

The storage format is also now only the posterior format. 