### PR TITLE
Make waveform visible in documentation

### DIFF
--- a/examples/gw150914/gw150914_shape.py
+++ b/examples/gw150914/gw150914_shape.py
@@ -29,6 +29,7 @@ for ifo in ['H1', 'L1']:
 
 pylab.legend()
 pylab.xlim(1126259462.21, 1126259462.45)
+pylab.ylim(-150, 150)
 pylab.ylabel('Smoothed-Whitened Strain')
 pylab.grid()
 pylab.xlabel('GPS Time (s)')


### PR DESCRIPTION
Currently, the example "Plotting the whitened strain" for GW150914 in the documentation shows a plot that just looks as a zero line (with a small wiggle if someone is paying close attention):
https://pycbc.org/pycbc/latest/html/gw150914.html#plotting-the-whitened-strain

This PR just changes the y-limits to make the waveform nicely visible.