### PR TITLE
Thin inference samples on the fly

### DIFF
--- a/docs/inference.rst
+++ b/docs/inference.rst
@@ -155,7 +155,8 @@ the ``[sampler]`` section of the configuration file. They are:
    samples will be thinned on disk, and new samples will be thinned to match.
    The thinning interval will grow with longer runs as a result. To ensure
    that enough samples exist to determine burn in and to measure an
-   autocorrelation length, ``max-samples-per-chain`` must be $\geq$ 100.
+   autocorrelation length, ``max-samples-per-chain`` must be greater than
+   or equal to 100.
 
 ^^^^^^^^^^^^^^^^^^^^^
 Configuring the prior

--- a/docs/inference.rst
+++ b/docs/inference.rst
@@ -127,6 +127,36 @@ max_postrior`` would instead consider the sampler to be burned in when either
 the ``nacl`` *or* ``max_posterior`` tests were satisfied. For more information
 on what tests are available, see the :py:mod:`pycbc.inference.burn_in` module.
 
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Thinning samples (MCMC only)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The default behavior for the MCMC samplers (``emcee``, ``emcee_pt``) is to save
+every iteration of the Markov chains to the output file. This can quickly lead
+to very large files. For example, a BBH analysis (~15 parameters) with 200
+walkers, 20 temperatures may take ~50 000 iterations to acquire ~5000
+independent samples. This will lead to a file that is ~ 50 000 iterations x 200
+walkers x 20 temperatures x 15 parameters x 8 bytes ~ 20GB.  Quieter signals
+can take an order of magnitude more iterations to converge, leading to O(100GB)
+files. Clearly, since we only obtain 5000 independent samples from such a run,
+the vast majority of these samples are of little interest.
+
+To prevent large file size growth, samples may be thinned before they are
+written to disk. Two thinning options are available, both of which are set in
+the ``[sampler]`` section of the configuration file. They are:
+
+ * ``thin-interval``: This will thin the samples by the given integer before
+   writing the samples to disk. File sizes can still grow unbounded, but at
+   a slower rate. The interval must be less than the checkpoint interval.
+ * ``max-samples-per-chain``: This will cap the maximum number of samples per
+   walker and per temperature to the given integer. This ensures that file
+   sizes never exceed ~ ``max-samples-per-chain`` x ``nwalkers`` x ``ntemps``
+   x ``nparameters`` x 8 bytes. Once the limit is reached,
+   samples will be thinned on disk, and new samples will be thinned to match.
+   The thinning interval will grow with longer runs as a result. To ensure
+   that enough samples exist to determine burn in and to measure an
+   autocorrelation length, ``max-samples-per-chain`` must be $\geq$ 100.
+
 ^^^^^^^^^^^^^^^^^^^^^
 Configuring the prior
 ^^^^^^^^^^^^^^^^^^^^^

--- a/docs/inference.rst
+++ b/docs/inference.rst
@@ -158,6 +158,33 @@ the ``[sampler]`` section of the configuration file. They are:
    autocorrelation length, ``max-samples-per-chain`` must be greater than
    or equal to 100.
 
+The thinned interval that was used for thinning samples is saved to the output
+file's ``thinned_by`` attribute (stored in the HDF file's ``.attrs``).  Note
+that this is not the autocorrelation length (ACL), which is the amount that the
+samples need to be further thinned to obtain independent samples.
+
+
+.. note::
+
+    In the output file creates by the MCMC samplers, we adopt the convention
+    that "iteration" means iteration of the sampler, not index of the samples.
+    For example, if a burn in test is used, ``burn_in_iteration`` will be
+    stored to the ``sampler_info`` group in the output file. This gives the
+    iteration of the sampler at which burn in occurred, not the sample on disk.
+    To determine  which samples an iteration corresponds to in the file, divide
+    iteration by ``thinned_by``.
+
+    Likewise, we adopt the convention that autocorrelation **length** (ACL) is
+    the autocorrelation length of the thinned samples (the number of samples on
+    disk that you need to skip to get independent samples) whereas
+    autocorrelation **time** (ACT) is the autocorrelation length in terms of
+    iteration (it is the number of **iterations** that you need to skip to get
+    independent samples); i.e., ``ACT = thinned_by x ACL``. The ACT is (up to
+    measurement resolution) independent of the thinning used, and thus is
+    useful for comparing the performance of the sampler.
+
+
+
 ^^^^^^^^^^^^^^^^^^^^^
 Configuring the prior
 ^^^^^^^^^^^^^^^^^^^^^

--- a/examples/inference/bbh-injection/inference.ini
+++ b/examples/inference/bbh-injection/inference.ini
@@ -8,6 +8,7 @@ nwalkers = 200
 ntemps = 20
 effective-nsamples = 1000
 checkpoint-interval = 2000
+max-samples-per-chain = 1000
 
 [sampler-burn_in]
 burn-in-test = nacl

--- a/examples/inference/gw150914/inference.ini
+++ b/examples/inference/gw150914/inference.ini
@@ -8,6 +8,7 @@ nwalkers = 200
 ntemps = 20
 effective-nsamples = 1000
 checkpoint-interval = 2000
+max-samples-per-chain = 1000
 
 [sampler-burn_in]
 burn-in-test = nacl

--- a/pycbc/inference/burn_in.py
+++ b/pycbc/inference/burn_in.py
@@ -26,6 +26,8 @@ This modules provides classes and functions for determining when Markov Chains
 have burned in.
 """
 
+from __future__ import division
+
 import numpy
 from scipy.stats import ks_2samp
 
@@ -171,6 +173,7 @@ class MCMCBurnInTests(object):
         self.burn_in_data = {t: {} for t in self.do_tests}
         self.is_burned_in = False
         self.burn_in_iteration = NOT_BURNED_IN_ITER
+        self.burn_in_index = NOT_BURNED_IN_ITER
         # Arguments specific to each test...
         # for nacl:
         self._nacls = int(kwargs.pop('nacls', 5))
@@ -192,6 +195,36 @@ class MCMCBurnInTests(object):
             except KeyError:
                 niters = 0
         return niters
+
+    def _getnsamples(self, filename):
+        """Convenience function to get the number of samples saved in the file.
+
+        If no samples have been written to the file yet, just returns 0.
+        """
+        with self.sampler.io(filename, 'r') as fp:
+            try:
+                group = fp[fp.samples_group]
+                # we'll just use the first parameter
+                params = group.keys()
+                nsamples = group[params[0]].shape[-1]
+            except (KeyError, IndexError):
+                nsamples = 0
+        return nsamples
+
+    def _index2iter(self, filename, index):
+        """Converts the index in some samples at which burn in occurs to the
+        iteration of the sampler that corresponds to.
+        """
+        with self.sampler.io(filename, 'r') as fp:
+            thin_interval = fp.thinned_by
+        return index * thin_interval
+
+    def _iter2index(self, filename, iteration):
+        """Converts an iteration to the index it corresponds to.
+        """
+        with self.sampler.io(filename, 'r') as fp:
+            thin_interval = fp.thinned_by
+        return iteration // thin_interval
 
     def _getlogposts(self, filename):
         """Convenience function for retrieving log posteriors.
@@ -254,11 +287,12 @@ class MCMCBurnInTests(object):
         # required things to store
         data['is_burned_in'] = is_burned_in.all()
         if data['is_burned_in']:
-            data['burn_in_iteration'] = burn_in_idx.max()
+            data['burn_in_iteration'] = self._index2iter(
+                filename, burn_in_idx.max())
         else:
             data['burn_in_iteration'] = NOT_BURNED_IN_ITER
         # additional info
-        data['iteration_per_walker'] = burn_in_idx
+        data['iteration_per_walker'] = self._index2iter(filename, burn_in_idx)
         data['status_per_walker'] = is_burned_in
 
     def posterior_step(self, filename):
@@ -270,9 +304,10 @@ class MCMCBurnInTests(object):
         # this test cannot determine when something will burn in
         # only when it was not burned in in the past
         data['is_burned_in'] = True
-        data['burn_in_iteration'] = burn_in_idx.max()
+        data['burn_in_iteration'] = self._index2iter(
+            filename, burn_in_idx.max())
         # additional info
-        data['iteration_per_walker'] = burn_in_idx
+        data['iteration_per_walker'] = self._index2iter(filename, burn_in_idx)
 
     def nacl(self, filename):
         """Burn in based on ACL.
@@ -283,11 +318,11 @@ class MCMCBurnInTests(object):
 
         2. An ACL is calculated from the second half.
 
-        3. If ``nacls`` times the ACL is < the number of iterations / 2,
+        3. If ``nacls`` times the ACL is < the length of the chain / 2,
            the chain is considered to be burned in at the half-way point.
         """
-        niters = self._getniters(filename)
-        kstart = int(niters / 2.)
+        nsamples = self._getnsamples(filename)
+        kstart = int(nsamples / 2.)
         acls = self._getacls(filename, start_index=kstart)
         is_burned_in = {param: (self._nacls * acl) < kstart
                         for (param, acl) in acls.items()}
@@ -295,7 +330,7 @@ class MCMCBurnInTests(object):
         # required things to store
         data['is_burned_in'] = all(is_burned_in.values())
         if data['is_burned_in']:
-            data['burn_in_iteration'] = kstart
+            data['burn_in_iteration'] = self._index2iter(filename, kstart)
         else:
             data['burn_in_iteration'] = NOT_BURNED_IN_ITER
         # additional information
@@ -303,11 +338,11 @@ class MCMCBurnInTests(object):
 
     def ks_test(self, filename):
         """Applies ks burn-in test."""
+        nsamples = self._getnsamples(filename)
         with self.sampler.io(filename, 'r') as fp:
-            niters = fp.niterations
             # get the samples from the mid point
             samples1 = fp.read_raw_samples(
-                ['loglikelihood', 'logprior'], iteration=int(niters/2.))
+                ['loglikelihood', 'logprior'], iteration=int(nsamples/2.))
             # get the last samples
             samples2 = fp.read_raw_samples(
                 ['loglikelihood', 'logprior'], iteration=-1)
@@ -319,7 +354,8 @@ class MCMCBurnInTests(object):
         # required things to store
         data['is_burned_in'] = all(is_the_same.values())
         if data['is_burned_in']:
-            data['burn_in_iteration'] = int(niters/2.)
+            data['burn_in_iteration'] = self._index2iter(
+                filename, int(nsamples/2.))
         else:
             data['burn_in_iteration'] = NOT_BURNED_IN_ITER
         # additional
@@ -356,8 +392,10 @@ class MCMCBurnInTests(object):
         self.is_burned_in = is_burned_in
         if is_burned_in:
             self.burn_in_iteration = ii
+            self.burn_in_index = self._iter2index(filename, ii)
         else:
             self.burn_in_iteration = NOT_BURNED_IN_ITER
+            self.burn_in_index = NOT_BURNED_IN_ITER
 
     @classmethod
     def from_config(cls, cp, sampler):

--- a/pycbc/inference/io/__init__.py
+++ b/pycbc/inference/io/__init__.py
@@ -151,19 +151,21 @@ def check_integrity(filename):
     with loadfile(filename, 'r') as fp:
         # check that all datasets in samples have the same shape
         parameters = fp[fp.samples_group].keys()
-        group = fp.samples_group + '/{}'
-        # use the first parameter as a reference shape
-        ref_shape = fp[group.format(parameters[0])].shape
-        if not all(fp[group.format(param)].shape == ref_shape
-                   for param in parameters):
-            raise IOError("not all datasets in the samples group have the "
-                          "same shape")
-        # check that we can read the first/last sample
-        firstidx = tuple([0]*len(ref_shape))
-        lastidx = tuple([-1]*len(ref_shape))
-        for param in parameters:
-            _ = fp[group.format(param)][firstidx]
-            _ = fp[group.format(param)][lastidx]
+        # but only do the check if parameters have been written
+        if len(parameters) > 0:
+            group = fp.samples_group + '/{}'
+            # use the first parameter as a reference shape
+            ref_shape = fp[group.format(parameters[0])].shape
+            if not all(fp[group.format(param)].shape == ref_shape
+                       for param in parameters):
+                raise IOError("not all datasets in the samples group have the "
+                              "same shape")
+            # check that we can read the first/last sample
+            firstidx = tuple([0]*len(ref_shape))
+            lastidx = tuple([-1]*len(ref_shape))
+            for param in parameters:
+                _ = fp[group.format(param)][firstidx]
+                _ = fp[group.format(param)][lastidx]
 
 
 def validate_checkpoint_files(checkpoint_file, backup_file):

--- a/pycbc/inference/io/base_hdf.py
+++ b/pycbc/inference/io/base_hdf.py
@@ -339,6 +339,17 @@ class BaseInferenceFile(h5py.File):
         except KeyError:
             return 0
 
+    @thin_start.setter
+    def thin_start(self, thin_start):
+        """Sets the thin start attribute.
+
+        Parameters
+        ----------
+        thin_start : int or None
+            Value to set the thin start to.
+        """
+        self.attrs['thin_start'] = thin_start
+
     @property
     def thin_interval(self):
         """The default interval to use when reading samples.
@@ -351,6 +362,17 @@ class BaseInferenceFile(h5py.File):
         except KeyError:
             return 1
 
+    @thin_interval.setter
+    def thin_interval(self, thin_interval):
+        """Sets the thin start attribute.
+
+        Parameters
+        ----------
+        thin_interval : int or None
+            Value to set the thin interval to.
+        """
+        self.attrs['thin_interval'] = thin_interval
+
     @property
     def thin_end(self):
         """The defaut end index to use when reading samples.
@@ -362,6 +384,17 @@ class BaseInferenceFile(h5py.File):
             return self.attrs['thin_end']
         except KeyError:
             return None
+
+    @thin_end.setter
+    def thin_end(self, thin_end):
+        """Sets the thin end attribute.
+
+        Parameters
+        ----------
+        thin_end : int or None
+            Value to set the thin end to.
+        """
+        self.attrs['thin_end'] = thin_end
 
     @property
     def cmd(self):

--- a/pycbc/inference/io/base_mcmc.py
+++ b/pycbc/inference/io/base_mcmc.py
@@ -28,8 +28,6 @@ from __future__ import (absolute_import, division)
 
 import numpy
 import argparse
-import logging
-
 
 class MCMCMetadataIO(object):
     """Provides functions for reading/writing MCMC metadata to file.
@@ -470,9 +468,6 @@ def thin_samples_for_writing(fp, samples, parameters, last_iteration):
             # in the samples data to start using samples.
             thin_start = fp.last_iteration(param) + fp.thinned_by \
                 - (last_iteration - nsamples) - 1
-            logging.info("Thinning %s samples using interval %i starting "
-                         "from %i before writing", param, fp.thinned_by,
-                         thin_start)
             thinned_samples[param] = data[..., thin_start::fp.thinned_by]
     else:
         thinned_samples = samples

--- a/pycbc/inference/io/base_mcmc.py
+++ b/pycbc/inference/io/base_mcmc.py
@@ -455,9 +455,16 @@ def thin_samples_for_writing(fp, samples, last_iteration):
         thinned_samples = {}
         for param, data in samples.items():
             nsamples = data.shape[-1]
+            # To figure out where to start:
+            # the last iteration in the file + the file's thinning interval
+            # gives the iteration of the next sample that should be written;
+            # last_iteration - nsamples gives the iteration of the first
+            # sample in samples. Subtracting the latter from the former - 1
+            # (-1 to convert from iteration to index) therefore gives the index
+            # in the samples data to start using samples.
             thin_start = fp.last_iteration(param) + fp.thinned_by \
-                         - (last_iteration - nsamples)
-            thinned_samples[param] = data[..., thin_start::self.thinned_by]
+                         - (last_iteration - nsamples) - 1
+            thinned_samples[param] = data[..., thin_start::fp.thinned_by]
     else:
-        thinned_samples = samples[param]
+        thinned_samples = samples
     return thinned_samples

--- a/pycbc/inference/io/base_mcmc.py
+++ b/pycbc/inference/io/base_mcmc.py
@@ -295,12 +295,12 @@ class SingleTempMCMCIO(object):
         samples are appended to the current.
 
         If the current samples on disk have been thinned (determined by the
-        ``thinned_by`` attribute in the samples group), then the samples
-        will be thinned by the same amount before being written. The thinning
-        is started at the sample in ``samples`` that occured at the iteration
-        equal to the last that's stored iteration on disk + the ``thinned_by``
-        interval. If this iteration is larger than the iteration of the last
-        given sample, then none of the samples will be written.
+        ``thinned_by`` attribute in the samples group), then the samples will
+        be thinned by the same amount before being written. The thinning is
+        started at the sample in ``samples`` that occured at the iteration
+        equal to the last iteration on disk plus the ``thinned_by`` interval.
+        If this iteration is larger than the iteration of the last given
+        sample, then none of the samples will be written.
 
         Parameters
         -----------

--- a/pycbc/inference/io/base_mcmc.py
+++ b/pycbc/inference/io/base_mcmc.py
@@ -199,8 +199,8 @@ class MCMCMetadataIO(object):
         group.attrs['burn_in_test'] = burn_in.burn_in_test
         group.attrs['is_burned_in'] = burn_in.is_burned_in
         group.attrs['burn_in_iteration'] = burn_in.burn_in_iteration
-        # set the defaut thin_start to be the burn_in_iteration
-        self.thin_start = burn_in.burn_in_iteration
+        # set the defaut thin_start to be the burn_in_index
+        self.thin_start = burn_in.burn_in_index
         # write individual test data
         for tst in burn_in.burn_in_data:
             key = 'burn_in_tests/{}'.format(tst)

--- a/pycbc/inference/io/base_mcmc.py
+++ b/pycbc/inference/io/base_mcmc.py
@@ -101,7 +101,7 @@ class MCMCMetadataIO(object):
         found, will just return 1.
         """
         try:
-            thinned_by = self[self.samples_group].attrs['thinned_by']
+            thinned_by = self.attrs['thinned_by']
         except KeyError:
             thinned_by = 1
         return thinned_by
@@ -114,7 +114,7 @@ class MCMCMetadataIO(object):
         given value is written to
         ``self[self.samples_group].attrs['thinned_by']``.
         """
-        self[self.samples_group].attrs['thinned_by'] = int(thinned_by)
+        self.attrs['thinned_by'] = int(thinned_by)
 
     def last_iteration(self, parameter=None):
         """Returns the iteration of the last sample of the given parameter.

--- a/pycbc/inference/io/base_mcmc.py
+++ b/pycbc/inference/io/base_mcmc.py
@@ -26,7 +26,6 @@
 
 from __future__ import (absolute_import, division)
 
-import logging
 import numpy
 import argparse
 
@@ -116,7 +115,7 @@ class MCMCMetadataIO(object):
 
     def last_iteration(self, parameter=None):
         """Returns the iteration of the last sample of the given parameter.
-        
+
         If parameter is ``None``, will just use the first parameter in the
         samples group.
         """
@@ -424,7 +423,7 @@ class SingleTempMCMCIO(object):
 
 def thin_samples_for_writing(fp, samples, last_iteration):
     """Thins samples for writing to disk.
-    
+
     The thinning interval to use is determined by the given file handler's
     ``thinned_by`` attribute. If that attribute is 1, just returns the samples.
 
@@ -451,7 +450,7 @@ def thin_samples_for_writing(fp, samples, last_iteration):
         if last_iteration is None:
             raise ValueError("File's thinned_by attribute is > 1 ({}), "
                              "but last_iteration not provided."
-                             .format(self.thinned_by))
+                             .format(fp.thinned_by))
         thinned_samples = {}
         for param, data in samples.items():
             nsamples = data.shape[-1]
@@ -463,7 +462,7 @@ def thin_samples_for_writing(fp, samples, last_iteration):
             # (-1 to convert from iteration to index) therefore gives the index
             # in the samples data to start using samples.
             thin_start = fp.last_iteration(param) + fp.thinned_by \
-                         - (last_iteration - nsamples) - 1
+                - (last_iteration - nsamples) - 1
             thinned_samples[param] = data[..., thin_start::fp.thinned_by]
     else:
         thinned_samples = samples

--- a/pycbc/inference/io/base_mcmc.py
+++ b/pycbc/inference/io/base_mcmc.py
@@ -75,12 +75,13 @@ class MCMCMetadataIO(object):
         samples = self.read_raw_samples(params, thin_interval=thin_interval,
                                         flatten=False)
         # now resize and write the data back to disk
+        group = self[self.samples_group]
         for param in params:
             data = samples[param]
             # resize the arrays on disk
-            self[self.samples_group].resize(data.shape)
+            group[param].resize(data.shape)
             # and write
-            self[self.samples_group][:] = data
+            group[param][:] = data
         # store the interval that samples were thinned by
         self.thinned_by *= thin_interval
         # If a default thin interval and thin start exist, reduce them by the

--- a/pycbc/inference/io/base_mcmc.py
+++ b/pycbc/inference/io/base_mcmc.py
@@ -343,7 +343,6 @@ class SingleTempMCMCIO(object):
                              - (last_iteration - nsamples)
                 if thin_start >= last_iteration:
                     # nothing to write, move on
-                    logging.info("Writing 0 samples of %s", param)
                     continue
                 else:
                     # thin the samples

--- a/pycbc/inference/io/base_mcmc.py
+++ b/pycbc/inference/io/base_mcmc.py
@@ -28,6 +28,7 @@ from __future__ import (absolute_import, division)
 
 import numpy
 import argparse
+import logging
 
 
 class MCMCMetadataIO(object):
@@ -463,6 +464,8 @@ def thin_samples_for_writing(fp, samples, last_iteration):
             # in the samples data to start using samples.
             thin_start = fp.last_iteration(param) + fp.thinned_by \
                 - (last_iteration - nsamples) - 1
+            logging.info("Thinning samples using interval %i starting "
+                         "from %i before writing", fp.thinned_by, thin_start)
             thinned_samples[param] = data[..., thin_start::fp.thinned_by]
     else:
         thinned_samples = samples

--- a/pycbc/inference/io/base_mcmc.py
+++ b/pycbc/inference/io/base_mcmc.py
@@ -277,8 +277,7 @@ class SingleTempMCMCIO(object):
     only a single temperature.
     """
 
-    def write_samples(self, samples, parameters=None,
-                      start_iteration=None, max_iterations=None):
+    def write_samples(self, samples, parameters=None):
         """Writes samples to the given file.
 
         Results are written to ``samples_group/{vararg}``, where ``{vararg}``
@@ -293,47 +292,30 @@ class SingleTempMCMCIO(object):
         parameters : list, optional
             Only write the specified parameters to the file. If None, will
             write all of the keys in the ``samples`` dict.
-        start_iteration : int, optional
-            Write results to the file's datasets starting at the given
-            iteration. Default is to append after the last iteration in the
-            file.
-        max_iterations : int, optional
-            Set the maximum size that the arrays in the hdf file may be resized
-            to. Only applies if the samples have not previously been written
-            to file. The default (None) is to use the maximum size allowed by
-            h5py.
         """
         nwalkers, niterations = samples.values()[0].shape
         assert all(p.shape == (nwalkers, niterations)
                    for p in samples.values()), (
                "all samples must have the same shape")
-        if max_iterations is not None and max_iterations < niterations:
-            raise IndexError("The provided max size is less than the "
-                             "number of iterations")
         group = self.samples_group + '/{name}'
         if parameters is None:
             parameters = samples.keys()
         # loop over number of dimensions
         for param in parameters:
             dataset_name = group.format(name=param)
-            istart = start_iteration
             try:
                 fp_niterations = self[dataset_name].shape[-1]
-                if istart is None:
-                    istart = fp_niterations
+                istart = fp_niterations
                 istop = istart + niterations
                 if istop > fp_niterations:
                     # resize the dataset
                     self[dataset_name].resize(istop, axis=1)
             except KeyError:
                 # dataset doesn't exist yet
-                if istart is not None and istart != 0:
-                    raise ValueError("non-zero start_iteration provided, "
-                                     "but dataset doesn't exist yet")
                 istart = 0
                 istop = istart + niterations
                 self.create_dataset(dataset_name, (nwalkers, istop),
-                                    maxshape=(nwalkers, max_iterations),
+                                    maxshape=(nwalkers, None),
                                     dtype=samples[param].dtype,
                                     fletcher32=True)
             self[dataset_name][:, istart:istop] = samples[param]

--- a/pycbc/inference/io/base_mcmc.py
+++ b/pycbc/inference/io/base_mcmc.py
@@ -61,25 +61,6 @@ class MCMCMetadataIO(object):
         """Returns the number of walkers used by the sampler."""
         return self[self.sampler_group].attrs['nwalkers']
 
-    @property
-    def prethin_interval(self):
-        """Returns the prethinning interval used.
-
-        The prethinning interval is the interval that the samples are thinned
-        by before writing to disk.
-
-        If ``None``, no prethinning is done.
-        """
-        try:
-            return self[self.sampler_group].attrs['prethin_interval']
-        except KeyError:
-            return None
-
-    @prethin_interval.setter
-    def prethin_interval(self, interval):
-        """Writes the given prethin interval to file."""
-        self[self.sampler_group].attrs['prethin_interval'] = int(interval)
-
     def thin(self, thin_interval):
         """Thins the samples on disk using the given thinning interval.
 

--- a/pycbc/inference/io/base_multitemper.py
+++ b/pycbc/inference/io/base_multitemper.py
@@ -131,7 +131,8 @@ class MultiTemperedMCMCIO(object):
         if parameters is None:
             parameters = samples.keys()
         # thin the samples
-        samples = thin_samples_for_writing(self, samples, last_iteration)
+        samples = thin_samples_for_writing(self, samples, parameters,
+                                           last_iteration)
         # loop over number of dimensions
         for param in parameters:
             dataset_name = group.format(name=param)

--- a/pycbc/inference/io/base_multitemper.py
+++ b/pycbc/inference/io/base_multitemper.py
@@ -153,7 +153,7 @@ class MultiTemperedMCMCIO(object):
                 istop = istart + data.shape[2]
                 self.create_dataset(dataset_name, (ntemps, nwalkers, istop),
                                     maxshape=(ntemps, nwalkers,
-                                              max_iterations),
+                                              None),
                                     dtype=data.dtype,
                                     fletcher32=True)
             self[dataset_name][:, :, istart:istop] = data

--- a/pycbc/inference/sampler/base.py
+++ b/pycbc/inference/sampler/base.py
@@ -230,6 +230,9 @@ def create_new_output_file(sampler, filename, force=False, injection_file=None,
                           "wish to overwrite it.")
     logging.info("Creating file {}".format(filename))
     with sampler.io(filename, "w") as fp:
+        # create the samples group and sampler info group
+        fp.create_group(fp.samples_group)
+        fp.create_group(fp.sampler_group)
         # save the sampler's metadata
         fp.write_sampler_metadata(sampler)
         # save injection parameters

--- a/pycbc/inference/sampler/base_mcmc.py
+++ b/pycbc/inference/sampler/base_mcmc.py
@@ -306,7 +306,7 @@ class BaseMCMC(object):
         """Gets the thin interval to use.
 
         If ``max_samples_per_chain`` is set, this will figure out what thin
-        interval to needed to satisfy that criteria. In that case, the thin
+        interval is needed to satisfy that criteria. In that case, the thin
         interval used must be a multiple of the currently used thin interval.
         """
         if self.max_samples_per_chain is not None:
@@ -701,7 +701,8 @@ class BaseMCMC(object):
         """
         if self.acls is None:
             return None
-        return {p: acl * self.thin_interval for (p, acl) in self.acls.items()}
+        return {p: acl * self.get_thin_interval()
+                for (p, acl) in self.acls.items()}
 
     @abstractmethod
     def compute_acf(cls, filename, **kwargs):

--- a/pycbc/inference/sampler/base_mcmc.py
+++ b/pycbc/inference/sampler/base_mcmc.py
@@ -663,10 +663,12 @@ class BaseMCMC(object):
         """
         if cp.has_option(section, "thin-interval"):
             thin_interval = int(cp.get(section, "thin-interval"))
+            logging.info("Will thin samples using interval %i", thin_interval)
         else:
             thin_interval = None
         if cp.has_option(section, "max-samples-per-chain"):
             max_samps_per_chain = int(cp.get(section, "max-samples-per-chain"))
+            logging.info("Setting max samples per chain to %i", max_samples_per_chain)
         else:
             max_samps_per_chain = None
         # check for consistency

--- a/pycbc/inference/sampler/base_mcmc.py
+++ b/pycbc/inference/sampler/base_mcmc.py
@@ -267,7 +267,7 @@ class BaseMCMC(object):
     @thin_interval.setter
     def thin_interval(self, interval):
         """Sets the thin interval to use.
-        
+
         If ``None`` provided, will default to 1.
         """
         if interval is None:
@@ -319,7 +319,7 @@ class BaseMCMC(object):
             # make the new interval is a multiple of the previous, to ensure
             # that any samples currently on disk can be thinned accordingly
             thin_interval = (thinfactor // self.thin_interval) * \
-                            self.thin_interval
+                self.thin_interval
             # make sure it's at least 1
             thin_interval = max(thin_interval, 1)
         else:
@@ -350,7 +350,7 @@ class BaseMCMC(object):
     @property
     def pos(self):
         """A dictionary of the current walker positions.
-        
+
         If the sampler hasn't been run yet, returns p0.
         """
         pos = self._pos
@@ -364,7 +364,7 @@ class BaseMCMC(object):
     @property
     def p0(self):
         """A dictionary of the initial position of the walkers.
-        
+
         This is set by using ``set_p0``. If not set yet, a ``ValueError`` is
         raised when the attribute is accessed.
         """
@@ -563,7 +563,7 @@ class BaseMCMC(object):
             nsamples_written = fp.last_iteration() - fp_lastiter
         if nsamples_written == 0:
             logging.info("No samples written due to thinning")
-        else: 
+        else:
             # check for burn in, compute the acls
             self.acls = None
             if self.burn_in is not None:

--- a/pycbc/inference/sampler/base_mcmc.py
+++ b/pycbc/inference/sampler/base_mcmc.py
@@ -553,7 +553,8 @@ class BaseMCMC(object):
                                          "of %i", fn, int(thin_by))
                             fp.thin(thin_by)
                 fp_lastiter = fp.last_iteration()
-            logging.info("Writing samples to %s", fn)
+            logging.info("Writing samples to %s with thin interval %i", fn,
+                         thin_interval)
             self.write_results(fn)
         # see if we had anything to write after thinning; if not, don't try
         # to compute anything

--- a/pycbc/inference/sampler/base_mcmc.py
+++ b/pycbc/inference/sampler/base_mcmc.py
@@ -310,12 +310,10 @@ class BaseMCMC(object):
         interval used must be a multiple of the currently used thin interval.
         """
         if self.max_samples_per_chain is not None:
-            # get the number of samples per walker if we did no thinning
-            samps_per_chain = self.niterations // self.nwalkers
             # the extra factor of 2 is to account for the fact that the thin
             # interval will need to be at least twice as large as a previously
             # used interval
-            thinfactor = samps_per_chain // self.max_samples_per_chain // 2
+            thinfactor = 2 * self.niterations // self.max_samples_per_chain
             # make the new interval is a multiple of the previous, to ensure
             # that any samples currently on disk can be thinned accordingly
             thin_interval = (thinfactor // self.thin_interval) * \
@@ -668,7 +666,7 @@ class BaseMCMC(object):
             thin_interval = None
         if cp.has_option(section, "max-samples-per-chain"):
             max_samps_per_chain = int(cp.get(section, "max-samples-per-chain"))
-            logging.info("Setting max samples per chain to %i", max_samples_per_chain)
+            logging.info("Setting max samples per chain to %i", max_samps_per_chain)
         else:
             max_samps_per_chain = None
         # check for consistency

--- a/pycbc/inference/sampler/base_mcmc.py
+++ b/pycbc/inference/sampler/base_mcmc.py
@@ -185,13 +185,20 @@ class BaseMCMC(object):
 
     Attributes
     ----------
-    p0 : dict
-        A dictionary of the initial position of the walkers. Set by using
-        ``set_p0``. If not set yet, a ``ValueError`` is raised when the
-        attribute is accessed.
-    pos : dict
-        A dictionary of the current walker positions. If the sampler hasn't
-        been run yet, returns p0.
+    p0
+    pos
+    nwalkers
+    niterations
+    checkpoint_interval
+    target_niterations
+    target_eff_nsamples
+    thin_interval
+    max_samples_per_chain
+    thin_safety_factor
+    burn_in
+    effective_nsamples
+    acls
+    acts
     """
     __metaclass__ = ABCMeta
 
@@ -221,14 +228,14 @@ class BaseMCMC(object):
 
     @property
     def nwalkers(self):
-        """Get the number of walkers."""
+        """The number of walkers used."""
         if self._nwalkers is None:
             raise ValueError("number of walkers not set")
         return self._nwalkers
 
     @property
     def niterations(self):
-        """Get the current number of iterations."""
+        """The current number of iterations."""
         itercounter = self._itercounter
         if itercounter is None:
             itercounter = 0
@@ -269,7 +276,7 @@ class BaseMCMC(object):
 
     @property
     def thin_safety_factor(self):
-        """Safety factor used for max samples per chain."""
+        """The minimum value that ``max_samples_per_chain`` may be set to."""
         return 100
 
     @property
@@ -342,9 +349,9 @@ class BaseMCMC(object):
 
     @property
     def pos(self):
-        """The current position of the walkers.
-
-        Returns a dictionary mapping the sampling paramters to the values.
+        """A dictionary of the current walker positions.
+        
+        If the sampler hasn't been run yet, returns p0.
         """
         pos = self._pos
         if pos is None:
@@ -356,10 +363,10 @@ class BaseMCMC(object):
 
     @property
     def p0(self):
-        """The starting position of the walkers in the sampling param space.
-
-        The returned object is a dict mapping the sampling parameters to the
-        values.
+        """A dictionary of the initial position of the walkers.
+        
+        This is set by using ``set_p0``. If not set yet, a ``ValueError`` is
+        raised when the attribute is accessed.
         """
         if self._p0 is None:
             raise ValueError("initial positions not set; run set_p0")
@@ -688,8 +695,9 @@ class BaseMCMC(object):
     def acts(self):
         """The autocorrelation times of each parameter.
 
-        The autocorrelation time is the ACL times the ``thin_interval``; it
-        gives the number of iterations between independent samples.
+        The autocorrelation time is defined as the ACL times the
+        ``thin_interval``. It gives the number of iterations between
+        independent samples.
         """
         if self.acls is None:
             return None

--- a/pycbc/inference/sampler/base_mcmc.py
+++ b/pycbc/inference/sampler/base_mcmc.py
@@ -278,7 +278,9 @@ class BaseMCMC(object):
     def thin_factor(self, factor):
         """Sets the thin factor.
         """
-        return self._thin_factor = int(factor)
+        if factor is not None:
+            factor = int(factor)
+        self._thin_factor = factor
 
     def get_thin_interval(self):
         """Gets the thin interval to use.
@@ -523,14 +525,15 @@ class BaseMCMC(object):
                 if thin_interval > 1:
                     # if this is the first time writing, set the file's
                     # thinned_by
-                    if fp.last_iteration == 0:
+                    if fp.last_iteration() == 0:
                         fp.thinned_by = thin_interval
-                    # check if we need to thin the current samples on disk
-                    thin_by = thin_interval // fp.thinned_by
-                    if thin_by > 1:
-                        logging.info("Thinning samples in %s by a factor of "
-                                     "%i", fn, thin_by)
-                        fp.thin(thin_by)
+                    else:
+                        # check if we need to thin the current samples on disk
+                        thin_by = thin_interval // fp.thinned_by
+                        if thin_by > 1:
+                            logging.info("Thinning samples in %s by a factor "
+                                         "of %i", fn, thin_by)
+                            fp.thin(thin_by)
             logging.info("Writing samples to %s", fn)
             self.write_results(fn)
         # check for burn in, compute the acls

--- a/pycbc/inference/sampler/base_mcmc.py
+++ b/pycbc/inference/sampler/base_mcmc.py
@@ -667,7 +667,8 @@ class BaseMCMC(object):
             thin_interval = None
         if cp.has_option(section, "max-samples-per-chain"):
             max_samps_per_chain = int(cp.get(section, "max-samples-per-chain"))
-            logging.info("Setting max samples per chain to %i", max_samps_per_chain)
+            logging.info("Setting max samples per chain to %i",
+                         max_samps_per_chain)
         else:
             max_samps_per_chain = None
         # check for consistency

--- a/pycbc/inference/sampler/base_mcmc.py
+++ b/pycbc/inference/sampler/base_mcmc.py
@@ -316,8 +316,8 @@ class BaseMCMC(object):
             # interval will need to be at least twice as large as a previously
             # used interval
             thinfactor = samps_per_chain // self.max_samples_per_chain // 2
-            # make the new interval a multiple of the previous, to ensure that
-            # any samples currently on disk can be thinned accordingly
+            # make the new interval is a multiple of the previous, to ensure
+            # that any samples currently on disk can be thinned accordingly
             thin_interval = (thinfactor // self.thin_interval) * \
                             self.thin_interval
             # make sure it's at least 1

--- a/pycbc/inference/sampler/emcee.py
+++ b/pycbc/inference/sampler/emcee.py
@@ -177,7 +177,7 @@ class EmceeEnsembleSampler(MCMCAutocorrSupport, BaseMCMC, BaseSampler):
                              last_iteration=self.niterations)
             # write stats
             fp.write_samples(self.model_stats,
-                             last_iteration=sef.niterations)
+                             last_iteration=self.niterations)
             # write accpetance
             fp.write_acceptance_fraction(self._sampler.acceptance_fraction)
             # write random state

--- a/pycbc/inference/sampler/emcee.py
+++ b/pycbc/inference/sampler/emcee.py
@@ -173,9 +173,11 @@ class EmceeEnsembleSampler(MCMCAutocorrSupport, BaseMCMC, BaseSampler):
         """
         with self.io(filename, 'a') as fp:
             # write samples
-            fp.write_samples(self.samples, self.model.variable_params)
+            fp.write_samples(self.samples, self.model.variable_params,
+                             last_iteration=self.niterations)
             # write stats
-            fp.write_samples(self.model_stats)
+            fp.write_samples(self.model_stats,
+                             last_iteration=sef.niterations)
             # write accpetance
             fp.write_acceptance_fraction(self._sampler.acceptance_fraction)
             # write random state
@@ -206,4 +208,6 @@ class EmceeEnsembleSampler(MCMCAutocorrSupport, BaseMCMC, BaseSampler):
         obj.set_target_from_config(cp, section)
         # add burn-in if it's specified
         obj.set_burn_in_from_config(cp)
+        # set prethin options
+        obj.set_prethin_from_config(cp, section)
         return obj

--- a/pycbc/inference/sampler/emcee.py
+++ b/pycbc/inference/sampler/emcee.py
@@ -209,5 +209,5 @@ class EmceeEnsembleSampler(MCMCAutocorrSupport, BaseMCMC, BaseSampler):
         # add burn-in if it's specified
         obj.set_burn_in_from_config(cp)
         # set prethin options
-        obj.set_prethin_from_config(cp, section)
+        obj.set_thin_interval_from_config(cp, section)
         return obj

--- a/pycbc/inference/sampler/emcee_pt.py
+++ b/pycbc/inference/sampler/emcee_pt.py
@@ -218,9 +218,10 @@ class EmceePTSampler(MultiTemperedAutocorrSupport, MultiTemperedSupport,
         """
         with self.io(filename, 'a') as fp:
             # write samples
-            fp.write_samples(self.samples, self.model.variable_params)
+            fp.write_samples(self.samples, self.model.variable_params,
+                             last_iteration=self.niterations)
             # write stats
-            fp.write_samples(self.model_stats)
+            fp.write_samples(self.model_stats, last_iteration=self.niterations)
             # write accpetance
             fp.write_acceptance_fraction(self._sampler.acceptance_fraction)
             # write random state

--- a/pycbc/inference/sampler/emcee_pt.py
+++ b/pycbc/inference/sampler/emcee_pt.py
@@ -128,6 +128,8 @@ class EmceePTSampler(MultiTemperedAutocorrSupport, MultiTemperedSupport,
         obj.set_target_from_config(cp, section)
         # add burn-in if it's specified
         obj.set_burn_in_from_config(cp)
+        # set prethin options
+        obj.set_thin_interval_from_config(cp, section)
         return obj
 
     @property


### PR DESCRIPTION
This introduces the ability to thin inference samples before writing to disk (for MCMC samplers), which should substantially cut down on checkpoint file sizes.

Two options for thinning are provided, which are set in the sampler section of the config file. You can either:
 * Set `thin-interval` In that case, samples will be thinned by the given interval before being written to disk on each checkpoint. File sizes will still grow unbounded, but at a slower rate.
 * Set `max-samples-per-chain`. In that case, the maximum number of samples that will be stored per walker and per temperature will be capped at the given value by increasing the thinning interval as the run goes on. This caps the file size to ~ `ntemps x nwalkers x nparameters x max-samples-per-chain x 8` bytes.

For `max-samples-per-chain`, whenever the thinning interval is incremented, current samples on disk are thinned again to make room. To keep the interval between samples the same, the thinning interval can only be incremented in powers of 2. To ensure that enough samples exist to calculate an ACL, `max-samples-per-chain` cannot be set to less than 100.

For long running jobs, using `max-samples-per-chain` can result in the thin interval exceeding the checkpoint interval. In that case, no samples are written on some checkpoints. This can be fixed by having the last sample always written to a different group in the file, and have resumed runs start from there, rather than using the last sample in `samples`. But that can be addressed in a future patch.

In a number of places (like the burn-in module) it's assumed that iteration = index of samples on disk. To fix this, I the burn in class now has a `burn_in_iteration` and a `burn_in_index`. The former is the iteration of the sampler at which burn in occurred; the latter is the index of the samples at which that point occurs.  The burn in iteration is still stored in the file, as this is useful for comparing the performance of different samplers/methods. It's also independent of any thinning that's done.

Along the same lines, the `BaseMCMC` class now has an autocorrelation time (`acts`) attribute in addition to `acls`. The definition I adopted is ACLs gives the number of samples you need to skip of the thinned chains, while ACTs gives the number of iterations between independent samples. I think this is consistent with what's in the literature.

A ``thinned_by`` attribute is added to the samples file giving the thinning interval of the samples. This can be used to convert from burn in iteration to index and ACL to ACT.

I'm running a test on the BBH injection and GW150914 now. Will remove the WIP tag when it's done. I'll also add some documentation about this to the inference docs page.