### PR TITLE
add from future division

### DIFF
--- a/pycbc/conversions.py
+++ b/pycbc/conversions.py
@@ -27,6 +27,7 @@ This modules provides a library of functions that calculate waveform parameters
 from other parameters. All exposed functions in this module's namespace return
 one parameter given a set of inputs.
 """
+from __future__ import division
 
 import copy
 import numpy


### PR DESCRIPTION
This fixes the issue in https://github.com/gwastro/pycbc/issues/2247 where integer masses were causing the wrong value of chi_p to be calculated.

Below is an example of integer masses that gives the expected chi_p result.

```
In [1]: from pycbc.conversions import chi_p
   ...:
   ...: # primary black hole parameters
   ...: m_primary = 10
   ...: sx_p,sy_p = 0.1, 0.
   ...:
   ...: # seondary black hole parameters
   ...: m_secondary = 3
   ...: sx_s,sy_s = 0.5, 0.
   ...:
   ...: print(chi_p(m_secondary, m_primary, sx_s, sy_s, sx_p, sy_p))
   ...:
0.128571428571
```