### PR TITLE
Multiifo hdf injfind

### DIFF
--- a/bin/hdfcoinc/pycbc_coinc_hdfinjfind
+++ b/bin/hdfcoinc/pycbc_coinc_hdfinjfind
@@ -9,6 +9,7 @@ from glue.ligolw import ligolw, table, lsctables, utils as ligolw_utils
 from glue import segments
 import os.path, numpy
 from pycbc.events import indices_within_segments as veto_indices
+import pycbc.events
 from pycbc.types import MultiDetOptionAction
 import pycbc.version
 
@@ -24,7 +25,7 @@ def hdf_append(f, key, value):
         f[key] = tmp
     else:
         f[key] = value
-       
+
 h5py.File.append = types.MethodType(hdf_append, h5py.File)
 
 def keep_ind(times, start, end):
@@ -35,22 +36,23 @@ def keep_ind(times, start, end):
     indices = numpy.array([], dtype=numpy.uint32)
     left = numpy.searchsorted(times, start, side='left')
     right = numpy.searchsorted(times, end, side='right')
-    
+
     for li, ri in zip(left, right):
         seg_indices = numpy.arange(li, ri, 1).astype(numpy.uint32)
-        indices=numpy.union1d(seg_indices, indices)  
-    return time_sorting[indices] 
+        indices=numpy.union1d(seg_indices, indices)
+    return time_sorting[indices]
 
 def xml_to_hdf(table, hdf_file, hdf_key, columns):
     """ Save xml columns as hdf columns, only float32 supported atm.
     """
     for col in columns:
-        key = os.path.join(hdf_key, col) 
-        hdf_append(hdf_file, key, numpy.array(table.get_column(col), 
+        key = os.path.join(hdf_key, col)
+        hdf_append(hdf_file, key, numpy.array(table.get_column(col),
                                         dtype=numpy.float32))
-     
+
 parser = argparse.ArgumentParser(description=__doc__)
-parser.add_argument('--version', action='version', version=pycbc.version.git_verbose_msg)
+parser.add_argument('--version', action='version',
+                    version=pycbc.version.git_verbose_msg)
 parser.add_argument('--trigger-files', nargs='+', required=True)
 parser.add_argument('--injection-files', nargs='+', required=True)
 parser.add_argument('--veto-file')
@@ -64,6 +66,8 @@ parser.add_argument('--optimal-snr-column', nargs='+',
 parser.add_argument('--redshift-column', default=None,
                     help='Name of sim_inspiral column containing redshift. '
                     'Optional')
+parser.add_argument('--ifos', nargs='+', default=None,
+                    help='List of IFOs involved in coincidences')
 parser.add_argument('--verbose', action='count')
 parser.add_argument('--output-file', required=True)
 args = parser.parse_args()
@@ -74,7 +78,8 @@ if args.verbose:
 
 fo = h5py.File(args.output_file, 'w')
 injection_index = 0
-for trigger_file, injection_file in zip(args.trigger_files, args.injection_files):   
+for trigger_file, injection_file in zip(args.trigger_files,
+                                        args.injection_files):
     logging.info('Read in the coinc data: %s' % trigger_file)
     f = h5py.File(trigger_file, 'r')
 
@@ -84,31 +89,67 @@ for trigger_file, injection_file in zip(args.trigger_files, args.injection_files
     ifar = f['foreground/ifar'][:]
     fap = f['foreground/fap'][:]
     fap_exc = f['foreground/fap_exc'][:]
-    time1 = f['foreground/time1'][:]
-    time2 = f['foreground/time2'][:]
-    trig1 = f['foreground/trigger_id1'][:]
-    trig2 = f['foreground/trigger_id2'][:]
-    ana_start = f['segments/coinc/start'][:]
-    ana_end = f['segments/coinc/end'][:]
-    time = 0.5 * (time1 + time2)
+    if not args.ifos:
+        # Using the original, non-multiifo-style organisation
+        time1 = f['foreground/time1'][:]
+        time2 = f['foreground/time2'][:]
+        trig1 = f['foreground/trigger_id1'][:]
+        trig2 = f['foreground/trigger_id2'][:]
+        ana_start = f['segments/coinc/start'][:]
+        ana_end = f['segments/coinc/end'][:]
+        time = 0.5 * (time1 + time2)
+    else:
+        ifo_times = ()
+        time_dict = {}
+        trig_dict = {}
+        for ifo in args.ifos:
+             ifo_times += (f['foreground/%s/time' % ifo][:],)
+             time_dict[ifo] = f['foreground/%s/time' % ifo][:]
+             trig_dict[ifo] = f['foreground/%s/trigger_id' % ifo][:]
+        time = numpy.array([pycbc.events.mean_if_greater_than_zero(vals)[0]
+                            for vals in zip(*ifo_times)])
+        # The injections missed because of 'off' time will be in
+        # 'no-coincident-detector' time, so need to combine segments
+        # to give the time when any two detectors are on
+        any_seg = segments.segmentlist([])
+        for key in f:
+            if key == 'foreground':
+                continue
+            elif key == 'segments':
+                for k2 in f['segments']:
+                    starts = f['segments/' + k2 + '/start'][:]
+                    ends = f['segments/' + k2 + '/end'][:]
+                    any_seg += pycbc.events.start_end_to_segments(starts,ends)
+            else:
+                starts = f[key + '/segments/start'][:]
+                ends = f[key + '/segments/end'][:]
+                any_seg += pycbc.events.start_end_to_segments(starts,ends)
+        ana_start, ana_end = pycbc.events.segments_to_start_end(any_seg)
+
     time_sorting = time.argsort()
 
     logging.info('Read in the injection file')
-    indoc = ligolw_utils.load_filename(injection_file, False, contenthandler=LIGOLWContentHandler)
+    indoc = ligolw_utils.load_filename(injection_file, False,
+                                       contenthandler=LIGOLWContentHandler)
     sim_table = table.get_table(indoc, lsctables.SimInspiralTable.tableName)
-    inj_time = numpy.array(sim_table.get_column('geocent_end_time') + 1e-9 * sim_table.get_column('geocent_end_time_ns'), dtype=numpy.float64)
+    inj_time = numpy.array(sim_table.get_column('geocent_end_time')
+                           + 1e-9 * sim_table.get_column('geocent_end_time_ns'),
+                           dtype=numpy.float64)
 
     logging.info('Determined the found injections by time')
-    left = numpy.searchsorted(time[time_sorting], inj_time - args.injection_window, side='left')
-    right = numpy.searchsorted(time[time_sorting], inj_time + args.injection_window, side='right')
+    left = numpy.searchsorted(time[time_sorting],
+                              inj_time - args.injection_window, side='left')
+    right = numpy.searchsorted(time[time_sorting],
+                               inj_time + args.injection_window, side='right')
     found = numpy.where((right-left) == 1)[0]
     missed = numpy.where((right-left) == 0)[0]
     ambiguous = numpy.where((right-left) > 1)[0]
     missed = numpy.concatenate([missed, ambiguous])
-    logging.info('Found: %s, Missed: %s Ambiguous: %s' % (len(found), len(missed), len(ambiguous)))
+    logging.info('Found: %s, Missed: %s Ambiguous: %s'
+                 % (len(found), len(missed), len(ambiguous)))
 
     if len(ambiguous) > 0:
-        logging.warn('More than one coinc trigger found associated to injection') 
+        logging.warn('More than one coinc trigger found associated to injection')
         am = numpy.arange(0, len(inj_time), 1)[left[ambiguous]]
         bm = numpy.arange(0, len(inj_time), 1)[right[ambiguous]]
 
@@ -116,71 +157,115 @@ for trigger_file, injection_file in zip(args.trigger_files, args.injection_files
     ki = keep_ind(inj_time, ana_start, ana_end)
     found_within_time = numpy.intersect1d(ki, found)
     missed_within_time = numpy.intersect1d(ki, missed)
-    logging.info('Found: %s, Missed: %s' % (len(found_within_time), len(missed_within_time)))
+    logging.info('Found: %s, Missed: %s'
+                 % (len(found_within_time), len(missed_within_time)))
 
     logging.info('Removing injections in vetoed time')
-    i1, v1 = veto_indices(inj_time, [args.veto_file], ifo='H1', 
-                                    segment_name=args.segment_name)
-    i2, v2 = veto_indices(inj_time, [args.veto_file], ifo='L1', 
-                                     segment_name=args.segment_name)
-    vi = numpy.concatenate([i1, i2])
+    if args.ifos:
+        vi = numpy.array([])
+        for ifo in args.ifos:
+            vi = numpy.append(vi, veto_indices(inj_time, [args.veto_file],
+                                    ifo=ifo, segment_name=args.segment_name))
+    else:
+        i1, v1 = veto_indices(inj_time, [args.veto_file], ifo='H1',
+                                        segment_name=args.segment_name)
+        i2, v2 = veto_indices(inj_time, [args.veto_file], ifo='L1',
+                                         segment_name=args.segment_name)
+        vi = numpy.concatenate([i1, i2])
 
-    found_after_vetoes = numpy.delete(found_within_time, numpy.where(numpy.in1d(found_within_time, vi))[0])
-    missed_after_vetoes = numpy.delete(missed_within_time, numpy.where(numpy.in1d(missed_within_time, vi))[0])
-    logging.info('Found: %s, Missed: %s' % (len(found_after_vetoes), len(missed_after_vetoes)))
+    if len(vi)==0:
+        logging.info('no injections found in vetoed time')
+        found_after_vetoes = found_within_time
+        missed_after_vetoes = missed_within_time
+    else:
+        found_after_vetoes = numpy.delete(found_within_time,
+                                          numpy.where(numpy.in1d(found_within_time, vi))[0])
+        missed_after_vetoes = numpy.delete(missed_within_time,
+                                           numpy.where(numpy.in1d(missed_within_time, vi))[0])
+        logging.info('Found: %s, Missed: %s' % (len(found_after_vetoes),
+                                                len(missed_after_vetoes)))
 
     found_fore = numpy.arange(0, len(stat), 1)[left[found]]
     found_fore_v = numpy.arange(0, len(stat), 1)[left[found_after_vetoes]]
 
     logging.info('Saving injection information')
-    columns = ['mass1', 'mass2', 'spin1x', 'spin1y', 
+    columns = ['mass1', 'mass2', 'spin1x', 'spin1y',
                'spin1z', 'spin2x', 'spin2y', 'spin2z',
-               'eff_dist_l', 'eff_dist_h', 'eff_dist_v', 
-               'inclination', 'polarization', 'coa_phase', 
+               'eff_dist_l', 'eff_dist_h', 'eff_dist_v',
+               'inclination', 'polarization', 'coa_phase',
                'latitude', 'longitude', 'distance']
     xml_to_hdf(sim_table, fo, 'injections', columns)
     hdf_append(fo, 'injections/end_time', inj_time)
 
     # pick up optimal SNRs
-    ifo_map = {f.attrs['detector_1']: 1,
-               f.attrs['detector_2']: 2}
-    for ifo, column in args.optimal_snr_column.items():
-        hdf_append(fo, 'injections/optimal_snr_%d' % ifo_map[ifo],
-                   sim_table.get_column(column))
+    if args.ifos:
+        for ifo, column in args.optimal_snr_column.items():
+            hdf_append(fo, 'injections/optimal_snr_%s' % ifo,
+                       sim_table.get_column(column))
+    else:
+        ifo_map = {f.attrs['detector_1']: 1,
+                   f.attrs['detector_2']: 2}
+        for ifo, column in args.optimal_snr_column.items():
+            hdf_append(fo, 'injections/optimal_snr_%d' % ifo_map[ifo],
+                       sim_table.get_column(column))
 
     # pick up redshift
     if args.redshift_column:
         hdf_append(fo, 'injections/redshift',
                    sim_table.get_column(args.redshift_column))
 
-    fo.attrs['detector_1'] = f.attrs['detector_1']
-    fo.attrs['detector_2'] = f.attrs['detector_2']
-    fo.attrs['foreground_time_exc'] = f.attrs['foreground_time_exc']
+    if not args.ifos:
+        fo.attrs['detector_1'] = f.attrs['detector_1']
+        fo.attrs['detector_2'] = f.attrs['detector_2']
+        fo.attrs['foreground_time_exc'] = f.attrs['foreground_time_exc']
+    else:
+        for key in f.keys():
+            if key == 'foreground':
+                continue
+            if key not in fo:
+                 fo.create_group(key)
+            fo[key].attrs['pivot'] = f[key].attrs['pivot']
+            fo[key].attrs['fixed'] = f[key].attrs['fixed']
+            fo[key].attrs['foreground_time_exc'] = f[key].attrs['foreground_time_exc']
+
     hdf_append(fo, 'missed/all', missed + injection_index)
     hdf_append(fo, 'missed/within_analysis', missed_within_time + injection_index)
     hdf_append(fo, 'missed/after_vetoes', missed_after_vetoes + injection_index)
-
     hdf_append(fo, 'found/template_id', template_id[time_sorting][found_fore])
     hdf_append(fo, 'found/injection_index', found + injection_index)
     hdf_append(fo, 'found/stat', stat[time_sorting][found_fore])
-    hdf_append(fo, 'found/time1', time1[time_sorting][found_fore])
-    hdf_append(fo, 'found/time2', time2[time_sorting][found_fore])
-    hdf_append(fo, 'found/trigger_id1', trig1[time_sorting][found_fore])
-    hdf_append(fo, 'found/trigger_id2', trig2[time_sorting][found_fore])
     hdf_append(fo, 'found/ifar', ifar[time_sorting][found_fore])
     hdf_append(fo, 'found/ifar_exc', ifar_exc[time_sorting][found_fore])
     hdf_append(fo, 'found/fap', fap[time_sorting][found_fore])
-    hdf_append(fo, 'found/fap_exc', fap_exc[time_sorting][found_fore])
-
-    hdf_append(fo, 'found_after_vetoes/template_id', template_id[time_sorting][found_fore_v])
-    hdf_append(fo, 'found_after_vetoes/injection_index', found_after_vetoes + injection_index)
+    hdf_append(fo, 'found_after_vetoes/template_id',
+               template_id[time_sorting][found_fore_v])
+    hdf_append(fo, 'found_after_vetoes/injection_index',
+               found_after_vetoes + injection_index)
     hdf_append(fo, 'found_after_vetoes/stat', stat[time_sorting][found_fore_v])
-    hdf_append(fo, 'found_after_vetoes/time1', time1[time_sorting][found_fore_v])
-    hdf_append(fo, 'found_after_vetoes/time2', time2[time_sorting][found_fore_v])
-    hdf_append(fo, 'found_after_vetoes/trigger_id1', trig1[time_sorting][found_fore_v])
-    hdf_append(fo, 'found_after_vetoes/trigger_id2', trig2[time_sorting][found_fore_v])
     hdf_append(fo, 'found_after_vetoes/ifar', ifar[time_sorting][found_fore_v])
     hdf_append(fo, 'found_after_vetoes/ifar_exc', ifar_exc[time_sorting][found_fore_v])
     hdf_append(fo, 'found_after_vetoes/fap', fap[time_sorting][found_fore_v])
-    hdf_append(fo, 'found_after_vetoes/fap_exc', fap_exc[time_sorting][found_fore_v])    
+    hdf_append(fo, 'found_after_vetoes/fap_exc', fap_exc[time_sorting][found_fore_v])
+    if args.ifos:
+        for ifo in args.ifos:
+            hdf_append(fo, 'found/%s/time' % ifo,
+                       time_dict[ifo][time_sorting][found_fore])
+            hdf_append(fo, 'found/%s/trigger_id' % ifo,
+                       trig_dict[ifo][time_sorting][found_fore])
+            hdf_append(fo, 'found_after_vetoes/%s/time' % ifo,
+                       time_dict[ifo][time_sorting][found_fore_v])
+            hdf_append(fo, 'found_after_vetoes/%s/trigger_id' % ifo,
+                       trig_dict[ifo][time_sorting][found_fore_v])
+    else:
+        hdf_append(fo, 'found/time1', time1[time_sorting][found_fore])
+        hdf_append(fo, 'found/time2', time2[time_sorting][found_fore])
+        hdf_append(fo, 'found/trigger_id1', trig1[time_sorting][found_fore])
+        hdf_append(fo, 'found/trigger_id2', trig2[time_sorting][found_fore])
+        hdf_append(fo, 'found_after_vetoes/time1', time1[time_sorting][found_fore_v])
+        hdf_append(fo, 'found_after_vetoes/time2', time2[time_sorting][found_fore_v])
+        hdf_append(fo, 'found_after_vetoes/trigger_id1',
+                   trig1[time_sorting][found_fore_v])
+        hdf_append(fo, 'found_after_vetoes/trigger_id2',
+                   trig2[time_sorting][found_fore_v])
+
     injection_index += len(sim_table)

--- a/bin/hdfcoinc/pycbc_coinc_hdfinjfind
+++ b/bin/hdfcoinc/pycbc_coinc_hdfinjfind
@@ -66,8 +66,6 @@ parser.add_argument('--optimal-snr-column', nargs='+',
 parser.add_argument('--redshift-column', default=None,
                     help='Name of sim_inspiral column containing redshift. '
                     'Optional')
-parser.add_argument('--ifos', nargs='+', default=None,
-                    help='List of IFOs involved in coincidences')
 parser.add_argument('--verbose', action='count')
 parser.add_argument('--output-file', required=True)
 args = parser.parse_args()
@@ -83,13 +81,21 @@ for trigger_file, injection_file in zip(args.trigger_files,
     logging.info('Read in the coinc data: %s' % trigger_file)
     f = h5py.File(trigger_file, 'r')
 
+    #detect whether trigger file is two-ifo or multi-ifo style
+    if 'foreground/time1' in f:
+        multi_ifo_style = False
+    else:
+        multi_ifo_style = True
+        # get list of groups which contain subgroup 'time' - these will be the IFOs
+        ifo_list = [key for key in f['foreground'] if 'time' in f['foreground/%s/' % key]]
+
     template_id = f['foreground/template_id'][:]
     stat = f['foreground/stat'][:]
     ifar_exc = f['foreground/ifar_exc'][:]
     ifar = f['foreground/ifar'][:]
     fap = f['foreground/fap'][:]
     fap_exc = f['foreground/fap_exc'][:]
-    if not args.ifos:
+    if not multi_ifo_style:
         # Using the original, non-multiifo-style organisation
         time1 = f['foreground/time1'][:]
         time2 = f['foreground/time2'][:]
@@ -102,7 +108,7 @@ for trigger_file, injection_file in zip(args.trigger_files,
         ifo_times = ()
         time_dict = {}
         trig_dict = {}
-        for ifo in args.ifos:
+        for ifo in ifo_list:
              ifo_times += (f['foreground/%s/time' % ifo][:],)
              time_dict[ifo] = f['foreground/%s/time' % ifo][:]
              trig_dict[ifo] = f['foreground/%s/trigger_id' % ifo][:]
@@ -161,9 +167,9 @@ for trigger_file, injection_file in zip(args.trigger_files,
                  % (len(found_within_time), len(missed_within_time)))
 
     logging.info('Removing injections in vetoed time')
-    if args.ifos:
+    if multi_ifo_style:
         vi = numpy.array([])
-        for ifo in args.ifos:
+        for ifo in ifo_list:
             vi = numpy.append(vi, veto_indices(inj_time, [args.veto_file],
                                     ifo=ifo, segment_name=args.segment_name))
     else:
@@ -193,7 +199,7 @@ for trigger_file, injection_file in zip(args.trigger_files,
     hdf_append(fo, 'injections/end_time', inj_time)
 
     # pick up optimal SNRs
-    if args.ifos:
+    if multi_ifo_style:
         for ifo, column in args.optimal_snr_column.items():
             hdf_append(fo, 'injections/optimal_snr_%s' % ifo,
                        sim_table.get_column(column))
@@ -209,7 +215,7 @@ for trigger_file, injection_file in zip(args.trigger_files,
         hdf_append(fo, 'injections/redshift',
                    sim_table.get_column(args.redshift_column))
 
-    if not args.ifos:
+    if not multi_ifo_style:
         fo.attrs['detector_1'] = f.attrs['detector_1']
         fo.attrs['detector_2'] = f.attrs['detector_2']
         fo.attrs['foreground_time_exc'] = f.attrs['foreground_time_exc']
@@ -241,8 +247,8 @@ for trigger_file, injection_file in zip(args.trigger_files,
     hdf_append(fo, 'found_after_vetoes/ifar_exc', ifar_exc[time_sorting][found_fore_v])
     hdf_append(fo, 'found_after_vetoes/fap', fap[time_sorting][found_fore_v])
     hdf_append(fo, 'found_after_vetoes/fap_exc', fap_exc[time_sorting][found_fore_v])
-    if args.ifos:
-        for ifo in args.ifos:
+    if multi_ifo_style:
+        for ifo in ifo_list:
             hdf_append(fo, 'found/%s/time' % ifo,
                        time_dict[ifo][time_sorting][found_fore])
             hdf_append(fo, 'found/%s/trigger_id' % ifo,

--- a/bin/hdfcoinc/pycbc_coinc_hdfinjfind
+++ b/bin/hdfcoinc/pycbc_coinc_hdfinjfind
@@ -4,12 +4,11 @@
 files.
 """
 
-import argparse, h5py, logging, types
+import argparse, h5py, logging, types, numpy, os.path
 from glue.ligolw import ligolw, table, lsctables, utils as ligolw_utils
-from glue import segments
-import os.path, numpy
+from ligo import segments
+from pycbc import events
 from pycbc.events import indices_within_segments as veto_indices
-import pycbc.events
 from pycbc.types import MultiDetOptionAction
 import pycbc.version
 
@@ -81,13 +80,13 @@ for trigger_file, injection_file in zip(args.trigger_files,
     logging.info('Read in the coinc data: %s' % trigger_file)
     f = h5py.File(trigger_file, 'r')
 
-    #detect whether trigger file is two-ifo or multi-ifo style
+    # Detect whether trigger file is two-ifo or multi-ifo style
     if 'foreground/time1' in f:
         multi_ifo_style = False
         ifo_list = ['H1', 'L1']
     else:
         multi_ifo_style = True
-        # get list of groups which contain subgroup 'time' - these will be the IFOs
+        # Get list of groups which contain subgroup 'time' - these will be the IFOs
         ifo_list = [key for key in f['foreground'] if 'time' in f['foreground/%s/' % key]]
         assert len(ifo_list) > 1
 
@@ -106,8 +105,8 @@ for trigger_file, injection_file in zip(args.trigger_files,
              ifo_times += (f['foreground/%s/time' % ifo][:],)
              time_dict[ifo] = f['foreground/%s/time' % ifo][:]
              trig_dict[ifo] = f['foreground/%s/trigger_id' % ifo][:]
-        time = numpy.array([pycbc.events.mean_if_greater_than_zero(vals)[0]
-                            for vals in zip(*ifo_times)])
+        time = numpy.array([events.mean_if_greater_than_zero(vals)[0] 
+                                                       for vals in zip(*ifo_times)])
         # We will discard injections which cannot be associated with a
         # coincident event, thus combine segments over all combinations
         # of coincident detectors to determine which times to keep
@@ -118,8 +117,8 @@ for trigger_file, injection_file in zip(args.trigger_files,
             else:
                 starts = f[key + '/segments/start'][:]
                 ends = f[key + '/segments/end'][:]
-                any_seg += pycbc.events.start_end_to_segments(starts,ends)
-        ana_start, ana_end = pycbc.events.segments_to_start_end(any_seg)
+                any_seg += events.start_end_to_segments(starts,ends)
+        ana_start, ana_end = events.segments_to_start_end(any_seg)
     else:
         # Using the old 2-ifo organisation
         time1 = f['foreground/time1'][:]
@@ -134,7 +133,7 @@ for trigger_file, injection_file in zip(args.trigger_files,
 
     logging.info('Read in the injection file')
     indoc = ligolw_utils.load_filename(injection_file, False,
-                                       contenthandler=LIGOLWContentHandler)
+                                            contenthandler=LIGOLWContentHandler)
     sim_table = table.get_table(indoc, lsctables.SimInspiralTable.tableName)
     inj_time = numpy.array(sim_table.get_column('geocent_end_time')
                            + 1e-9 * sim_table.get_column('geocent_end_time_ns'),

--- a/bin/hdfcoinc/pycbc_coinc_hdfinjfind
+++ b/bin/hdfcoinc/pycbc_coinc_hdfinjfind
@@ -173,17 +173,12 @@ for trigger_file, injection_file in zip(args.trigger_files,
                                          segment_name=args.segment_name)
         vi = numpy.concatenate([i1, i2])
 
-    if len(vi)==0:
-        logging.info('no injections found in vetoed time')
-        found_after_vetoes = found_within_time
-        missed_after_vetoes = missed_within_time
-    else:
-        found_after_vetoes = numpy.delete(found_within_time,
-                                          numpy.where(numpy.in1d(found_within_time, vi))[0])
-        missed_after_vetoes = numpy.delete(missed_within_time,
-                                           numpy.where(numpy.in1d(missed_within_time, vi))[0])
-        logging.info('Found: %s, Missed: %s' % (len(found_after_vetoes),
-                                                len(missed_after_vetoes)))
+    found_after_vetoes = numpy.delete(found_within_time,
+                                      numpy.where(numpy.in1d(found_within_time, vi))[0])
+    missed_after_vetoes = numpy.delete(missed_within_time,
+                                       numpy.where(numpy.in1d(missed_within_time, vi))[0])
+    logging.info('Found: %s, Missed: %s' % (len(found_after_vetoes),
+                                            len(missed_after_vetoes)))
 
     found_fore = numpy.arange(0, len(stat), 1)[left[found]]
     found_fore_v = numpy.arange(0, len(stat), 1)[left[found_after_vetoes]]

--- a/bin/hdfcoinc/pycbc_coinc_hdfinjfind
+++ b/bin/hdfcoinc/pycbc_coinc_hdfinjfind
@@ -84,10 +84,12 @@ for trigger_file, injection_file in zip(args.trigger_files,
     #detect whether trigger file is two-ifo or multi-ifo style
     if 'foreground/time1' in f:
         multi_ifo_style = False
+        ifo_list = ['H1', 'L1']
     else:
         multi_ifo_style = True
         # get list of groups which contain subgroup 'time' - these will be the IFOs
         ifo_list = [key for key in f['foreground'] if 'time' in f['foreground/%s/' % key]]
+        assert len(ifo_list) > 1
 
     template_id = f['foreground/template_id'][:]
     stat = f['foreground/stat'][:]
@@ -95,16 +97,8 @@ for trigger_file, injection_file in zip(args.trigger_files,
     ifar = f['foreground/ifar'][:]
     fap = f['foreground/fap'][:]
     fap_exc = f['foreground/fap_exc'][:]
-    if not multi_ifo_style:
-        # Using the original, non-multiifo-style organisation
-        time1 = f['foreground/time1'][:]
-        time2 = f['foreground/time2'][:]
-        trig1 = f['foreground/trigger_id1'][:]
-        trig2 = f['foreground/trigger_id2'][:]
-        ana_start = f['segments/coinc/start'][:]
-        ana_end = f['segments/coinc/end'][:]
-        time = 0.5 * (time1 + time2)
-    else:
+    if multi_ifo_style:
+        # using multi-ifo-style trigger file input
         ifo_times = ()
         time_dict = {}
         trig_dict = {}
@@ -121,16 +115,20 @@ for trigger_file, injection_file in zip(args.trigger_files,
         for key in f:
             if key == 'foreground':
                 continue
-            elif key == 'segments':
-                for k2 in f['segments']:
-                    starts = f['segments/' + k2 + '/start'][:]
-                    ends = f['segments/' + k2 + '/end'][:]
-                    any_seg += pycbc.events.start_end_to_segments(starts,ends)
             else:
                 starts = f[key + '/segments/start'][:]
                 ends = f[key + '/segments/end'][:]
                 any_seg += pycbc.events.start_end_to_segments(starts,ends)
         ana_start, ana_end = pycbc.events.segments_to_start_end(any_seg)
+    else:
+        # Using the original, non-multiifo-style organisation
+        time1 = f['foreground/time1'][:]
+        time2 = f['foreground/time2'][:]
+        trig1 = f['foreground/trigger_id1'][:]
+        trig2 = f['foreground/trigger_id2'][:]
+        ana_start = f['segments/coinc/start'][:]
+        ana_end = f['segments/coinc/end'][:]
+        time = 0.5 * (time1 + time2)
 
     time_sorting = time.argsort()
 
@@ -167,17 +165,11 @@ for trigger_file, injection_file in zip(args.trigger_files,
                  % (len(found_within_time), len(missed_within_time)))
 
     logging.info('Removing injections in vetoed time')
-    if multi_ifo_style:
-        vi = numpy.array([])
-        for ifo in ifo_list:
-            vi = numpy.append(vi, veto_indices(inj_time, [args.veto_file],
-                                    ifo=ifo, segment_name=args.segment_name))
-    else:
-        i1, v1 = veto_indices(inj_time, [args.veto_file], ifo='H1',
-                                        segment_name=args.segment_name)
-        i2, v2 = veto_indices(inj_time, [args.veto_file], ifo='L1',
-                                         segment_name=args.segment_name)
-        vi = numpy.concatenate([i1, i2])
+
+    vi = numpy.array([])
+    for ifo in ifo_list:
+        vi = numpy.append(vi, veto_indices(inj_time, [args.veto_file],
+                                           ifo=ifo, segment_name=args.segment_name))
 
     found_after_vetoes = numpy.delete(found_within_time,
                                       numpy.where(numpy.in1d(found_within_time, vi))[0])
@@ -215,11 +207,7 @@ for trigger_file, injection_file in zip(args.trigger_files,
         hdf_append(fo, 'injections/redshift',
                    sim_table.get_column(args.redshift_column))
 
-    if not multi_ifo_style:
-        fo.attrs['detector_1'] = f.attrs['detector_1']
-        fo.attrs['detector_2'] = f.attrs['detector_2']
-        fo.attrs['foreground_time_exc'] = f.attrs['foreground_time_exc']
-    else:
+    if multi_ifo_style:
         for key in f.keys():
             if key == 'foreground':
                 continue
@@ -228,6 +216,10 @@ for trigger_file, injection_file in zip(args.trigger_files,
             fo[key].attrs['pivot'] = f[key].attrs['pivot']
             fo[key].attrs['fixed'] = f[key].attrs['fixed']
             fo[key].attrs['foreground_time_exc'] = f[key].attrs['foreground_time_exc']
+    else:
+        fo.attrs['detector_1'] = f.attrs['detector_1']
+        fo.attrs['detector_2'] = f.attrs['detector_2']
+        fo.attrs['foreground_time_exc'] = f.attrs['foreground_time_exc']
 
     hdf_append(fo, 'missed/all', missed + injection_index)
     hdf_append(fo, 'missed/within_analysis', missed_within_time + injection_index)

--- a/bin/hdfcoinc/pycbc_coinc_hdfinjfind
+++ b/bin/hdfcoinc/pycbc_coinc_hdfinjfind
@@ -108,9 +108,9 @@ for trigger_file, injection_file in zip(args.trigger_files,
              trig_dict[ifo] = f['foreground/%s/trigger_id' % ifo][:]
         time = numpy.array([pycbc.events.mean_if_greater_than_zero(vals)[0]
                             for vals in zip(*ifo_times)])
-        # The injections missed because of 'off' time will be in
-        # 'no-coincident-detector' time, so need to combine segments
-        # to give the time when any two detectors are on
+        # We will discard injections which cannot be associated with a
+        # coincident event, thus combine segments over all combinations
+        # of coincident detectors to determine which times to keep
         any_seg = segments.segmentlist([])
         for key in f:
             if key == 'foreground':
@@ -121,7 +121,7 @@ for trigger_file, injection_file in zip(args.trigger_files,
                 any_seg += pycbc.events.start_end_to_segments(starts,ends)
         ana_start, ana_end = pycbc.events.segments_to_start_end(any_seg)
     else:
-        # Using the original, non-multiifo-style organisation
+        # Using the old 2-ifo organisation
         time1 = f['foreground/time1'][:]
         time2 = f['foreground/time2'][:]
         trig1 = f['foreground/trigger_id1'][:]

--- a/bin/hdfcoinc/pycbc_fit_sngls_by_template
+++ b/bin/hdfcoinc/pycbc_fit_sngls_by_template
@@ -135,10 +135,16 @@ if args.save_trig_param:
     tparam = trigf[args.ifo+'/'+args.save_trig_param][:][abovethresh]
 logging.info('%i trigs left after thresholding' % len(stat))
 
+# as approximant to total time, make segment between first and last triggers
+all_segments = events.veto.start_end_to_segments([min(time)],[max(time)])
+
 # now do vetoing
 for veto_file, veto_segment_name in zip(args.veto_file, args.veto_segment_name):
     retain, junk = events.veto.indices_outside_segments(time, [veto_file],
                                  ifo=args.ifo, segment_name=veto_segment_name)
+    all_segments -= events.veto.select_segments_by_definer(veto_file,
+                                                           ifo=args.ifo,
+                                                           segment_name=veto_segment_name)
     stat = stat[retain]
     tid = tid[retain]
     time = time[retain]
@@ -146,6 +152,8 @@ for veto_file, veto_segment_name in zip(args.veto_file, args.veto_segment_name):
         tparam = tparam[retain]
     logging.info('%i trigs left after vetoing with %s' %
                                                        (len(stat), veto_file))
+
+total_time = sum([seg_end - seg_start for seg_start, seg_end in all_segments])
 
 # do pruning (removal of trigs at N loudest times defined over param bins)
 if args.prune_param:
@@ -276,6 +284,7 @@ outfile.attrs.create("sngl_stat", data=args.sngl_stat)
 if args.save_trig_param:
     outfile.attrs.create("save_trig_param", data=args.save_trig_param)
 outfile.attrs.create("stat_threshold", data=args.stat_threshold)
+outfile.attrs.create("analysis_time", data=total_time)
 
 outfile.close()
 logging.info('Done!')

--- a/bin/hdfcoinc/pycbc_fit_sngls_by_template
+++ b/bin/hdfcoinc/pycbc_fit_sngls_by_template
@@ -135,16 +135,10 @@ if args.save_trig_param:
     tparam = trigf[args.ifo+'/'+args.save_trig_param][:][abovethresh]
 logging.info('%i trigs left after thresholding' % len(stat))
 
-# as approximant to total time, make segment between first and last triggers
-all_segments = events.veto.start_end_to_segments([min(time)],[max(time)])
-
 # now do vetoing
 for veto_file, veto_segment_name in zip(args.veto_file, args.veto_segment_name):
     retain, junk = events.veto.indices_outside_segments(time, [veto_file],
                                  ifo=args.ifo, segment_name=veto_segment_name)
-    all_segments -= events.veto.select_segments_by_definer(veto_file,
-                                                           ifo=args.ifo,
-                                                           segment_name=veto_segment_name)
     stat = stat[retain]
     tid = tid[retain]
     time = time[retain]
@@ -152,8 +146,6 @@ for veto_file, veto_segment_name in zip(args.veto_file, args.veto_segment_name):
         tparam = tparam[retain]
     logging.info('%i trigs left after vetoing with %s' %
                                                        (len(stat), veto_file))
-
-total_time = sum([seg_end - seg_start for seg_start, seg_end in all_segments])
 
 # do pruning (removal of trigs at N loudest times defined over param bins)
 if args.prune_param:
@@ -284,7 +276,6 @@ outfile.attrs.create("sngl_stat", data=args.sngl_stat)
 if args.save_trig_param:
     outfile.attrs.create("save_trig_param", data=args.save_trig_param)
 outfile.attrs.create("stat_threshold", data=args.stat_threshold)
-outfile.attrs.create("analysis_time", data=total_time)
 
 outfile.close()
 logging.info('Done!')


### PR DESCRIPTION
hdf injfind code altered to allow for multiifo-style input. The way to differentiate between original-style and multi-ifo-style input is in the input hdf file

Difference in output:
 - `optimal_snr_N` where `N` is 1 or 2 becomes `optimal_snr_I1` for `I1` as detector Identifier
 - `found/timeN` --> `found/I1/time`, similarly for `trigger_id` instead of `time` and `found_after_vetoes` instead of `found`

Note that some file-reading parts may change depending on throughput options chosen earlier in the pipeline
