### PR TITLE
Fixed a bug in the roll function for time series.

### DIFF
--- a/pycbc/types/array.py
+++ b/pycbc/types/array.py
@@ -823,11 +823,12 @@ class Array(object):
         self._saved = LimitedSizeDict(size_limit=2**5)
         new_arr = zeros(len(self), dtype=self.dtype)
 
+        if shift < 0:
+            shift = shift - len(self) * (shift // len(self))
+        
         if shift == 0:
             return
-        if shift < 0:
-            shift=len(self) + shift
-
+        
         new_arr[0:shift] = self[len(self)-shift: len(self)]
         new_arr[shift:len(self)] = self[0:len(self)-shift]
             


### PR DESCRIPTION
For a pycbc.types.timeseries.TimeSeries the prepend_zeros function can be called with negative arguments removeing samples in the front. If this number was larger than half the length of the TimeSeries the roll funtion would crash. This was caused by the roll function which would try to access negative array indices.
To fix this the function now adds n * len(array) to the shift, where n is the smallest (integer) value such that the shift is positive afterwards.
The check for a shift of 0 hence is now performed afterwards.