### PR TITLE
Add zero likelihood analytic model

### DIFF
--- a/pycbc/inference/models/__init__.py
+++ b/pycbc/inference/models/__init__.py
@@ -20,7 +20,8 @@ assuming various noise models.
 """
 
 
-from .analytic import (TestEggbox, TestNormal, TestRosenbrock, TestVolcano)
+from .analytic import (TestEggbox, TestNormal, TestRosenbrock, TestVolcano,
+                       TestZeroLikelihood)
 from .gaussian_noise import GaussianNoise
 from .marginalized_gaussian_noise import MarginalizedGaussianNoise
 from .single_template import SingleTemplate
@@ -177,6 +178,7 @@ models = {_cls.name: _cls for _cls in (
     TestNormal,
     TestRosenbrock,
     TestVolcano,
+    TestZeroLikelihood,
     GaussianNoise,
     MarginalizedGaussianNoise,
     SingleTemplate

--- a/pycbc/inference/models/__init__.py
+++ b/pycbc/inference/models/__init__.py
@@ -21,7 +21,7 @@ assuming various noise models.
 
 
 from .analytic import (TestEggbox, TestNormal, TestRosenbrock, TestVolcano,
-                       TestZeroLikelihood)
+                       TestPrior)
 from .gaussian_noise import GaussianNoise
 from .marginalized_gaussian_noise import MarginalizedGaussianNoise
 from .single_template import SingleTemplate
@@ -178,7 +178,7 @@ models = {_cls.name: _cls for _cls in (
     TestNormal,
     TestRosenbrock,
     TestVolcano,
-    TestZeroLikelihood,
+    TestPrior,
     GaussianNoise,
     MarginalizedGaussianNoise,
     SingleTemplate

--- a/pycbc/inference/models/analytic.py
+++ b/pycbc/inference/models/analytic.py
@@ -190,6 +190,7 @@ class TestVolcano(BaseModel):
             numpy.exp(-r/35) + 1 / (sigma * numpy.sqrt(2 * numpy.pi)) *
             numpy.exp(-0.5 * ((r - mu) / sigma) ** 2))
 
+
 class TestZeroLikelihood(BaseModel):
     r"""The test distribution is zero likelihood.
 

--- a/pycbc/inference/models/analytic.py
+++ b/pycbc/inference/models/analytic.py
@@ -189,3 +189,25 @@ class TestVolcano(BaseModel):
         return 25 * (
             numpy.exp(-r/35) + 1 / (sigma * numpy.sqrt(2 * numpy.pi)) *
             numpy.exp(-0.5 * ((r - mu) / sigma) ** 2))
+
+class TestZeroLikelihood(BaseModel):
+    r"""The test distribution is zero likelihood.
+
+    Parameters
+    ----------
+    variable_params : (tuple of) string(s)
+        A tuple of parameter names that will be varied. Must have length 2.
+    **kwargs :
+        All other keyword arguments are passed to ``BaseModel``.
+
+    """
+    name = "test_zero_likelihood"
+
+    def __init__(self, variable_params, **kwargs):
+        # set up base likelihood parameters
+        super(TestZeroLikelihood, self).__init__(variable_params, **kwargs)
+
+    def _loglikelihood(self):
+        """Returns the log prior.
+        """
+        return self.logprior

--- a/pycbc/inference/models/analytic.py
+++ b/pycbc/inference/models/analytic.py
@@ -192,7 +192,7 @@ class TestVolcano(BaseModel):
 
 
 class TestPrior(BaseModel):
-    r"""The test distribution is zero likelihood.
+    r"""Uses the prior as the test distribution.
 
     Parameters
     ----------
@@ -206,7 +206,7 @@ class TestPrior(BaseModel):
 
     def __init__(self, variable_params, **kwargs):
         # set up base likelihood parameters
-        super(TestZeroLikelihood, self).__init__(variable_params, **kwargs)
+        super(TestPrior, self).__init__(variable_params, **kwargs)
 
     def _loglikelihood(self):
         """Returns zero.

--- a/pycbc/inference/models/analytic.py
+++ b/pycbc/inference/models/analytic.py
@@ -191,7 +191,7 @@ class TestVolcano(BaseModel):
             numpy.exp(-0.5 * ((r - mu) / sigma) ** 2))
 
 
-class TestZeroLikelihood(BaseModel):
+class TestPrior(BaseModel):
     r"""The test distribution is zero likelihood.
 
     Parameters
@@ -202,13 +202,13 @@ class TestZeroLikelihood(BaseModel):
         All other keyword arguments are passed to ``BaseModel``.
 
     """
-    name = "test_zero_likelihood"
+    name = "test_prior"
 
     def __init__(self, variable_params, **kwargs):
         # set up base likelihood parameters
         super(TestZeroLikelihood, self).__init__(variable_params, **kwargs)
 
     def _loglikelihood(self):
-        """Returns the log prior.
+        """Returns zero.
         """
-        return self.logprior
+        return 0.


### PR DESCRIPTION
This adds the analytic zero-likelihood model, whose `loglikelihood` method just returns the `logprior`.