### PR TITLE
Made hardware injections accept flexible list of detectors

### DIFF
--- a/bin/hwinj/pycbc_generate_hwinj_from_xml
+++ b/bin/hwinj/pycbc_generate_hwinj_from_xml
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # Copyright (C) 2015 Christopher M. Biwer
 #
@@ -29,9 +29,6 @@ class DefaultContentHandler(ligolw.LIGOLWContentHandler):
     pass
 lsctables.use_in(DefaultContentHandler)
 
-# list IFOs to generate waveforms
-ifos = ['H1', 'L1']
-
 # command line usage
 parser = argparse.ArgumentParser(
              usage='pycbc_generate_hwinj_from_xml --injection-file [INJECTION_FILE] --sample-rate [SAMPLE_RATE]',
@@ -54,7 +51,8 @@ parser.add_argument('--sample-rate', type=int, required=True,
              help='Sample rate that waveforms will be generated.')
 parser.add_argument("--tag", type=str, default='hwinjcbcsimid',
                     help="Prefix added to output filenames.")
-
+parser.add_argument('--ifos', nargs='+', default=['H1', 'L1'], required=True,
+                    help='List of IFOs to generate injections for.')
 # parse command line
 opts = parser.parse_args()
 
@@ -93,7 +91,7 @@ for sim in injections.table:
     num_samples = (end_time - start_time) * opts.sample_rate
 
     # loop over IFOs for writing waveforms to file
-    for ifo in ifos:
+    for ifo in opts.ifos:
 
         # create a time series of zeroes to inject waveform into
         initial_array = numpy.zeros(num_samples, dtype=h_plus.dtype)

--- a/bin/hwinj/pycbc_generate_hwinj_from_xml
+++ b/bin/hwinj/pycbc_generate_hwinj_from_xml
@@ -24,6 +24,7 @@ from glue.ligolw import ligolw, lsctables, table, utils
 from pycbc.inject import InjectionSet, legacy_approximant_name
 from pycbc.types import TimeSeries
 from pycbc.waveform import get_td_waveform
+from pycbc.detector import get_available_detectors
 
 class DefaultContentHandler(ligolw.LIGOLWContentHandler):
     pass
@@ -52,6 +53,7 @@ parser.add_argument('--sample-rate', type=int, required=True,
 parser.add_argument("--tag", type=str, default='hwinjcbcsimid',
                     help="Prefix added to output filenames.")
 parser.add_argument('--ifos', nargs='+', default=['H1', 'L1'], required=True,
+                    choices=zip(*get_available_detectors())[0],
                     help='List of IFOs to generate injections for.')
 # parse command line
 opts = parser.parse_args()


### PR DESCRIPTION
Moved detector selection into a command line argument so that `--ifos H1 L1 V1` can be invoked rather than a hard-coded list. Tested using an injection XML.