### PR TITLE
fit_sngls_by_template analysis time output

### DIFF
--- a/bin/hdfcoinc/pycbc_fit_sngls_by_template
+++ b/bin/hdfcoinc/pycbc_fit_sngls_by_template
@@ -127,14 +127,16 @@ logging.info('Counting number of triggers in each template')
 tb = trigf[args.ifo+'/template_boundaries'][:]
 hash_sort = np.argsort(templatef['template_hash'][:])
 tb_sorted = tb[hash_sort]
+tid = np.arange(len(hash_sort))
+tid_hash_sorted = tid[hash_sort]
+tid_order = np.argsort(tid_hash_sorted)
+
 # calculate the differences between the boundary indices, 
 # in order to get the number in each template
 # adding on total number at the end to get number in the last boundary
 total_number = len(trigf[args.ifo+'/template_id'][:])
-count_in_template = np.diff(np.append(tb_sorted,total_number))
-
-# Sort the hash_sort array, to get the ordering info so we can return to original id order
-tid_sort = np.argsort(hash_sort)
+count_in_template_hashorder = np.diff(np.append(tb_sorted,total_number))
+count_in_template = count_in_template_hashorder[tid_order]
 
 # get the stat values
 logging.info('Calculating stat values')
@@ -272,7 +274,7 @@ tpars = []
 for tnum in trange:
     stat_in_template = stat[tid == tnum]
     count_above = len(stat_in_template)
-    count_total = count_in_template[tid_sort[tnum]]
+    count_total = count_in_template[tnum]
     if count_above == 0:
         # 'stupid' value to indicate no data, shouldn't hurt if 1/alpha is averaged
         alpha = -100.

--- a/bin/hdfcoinc/pycbc_fit_sngls_by_template
+++ b/bin/hdfcoinc/pycbc_fit_sngls_by_template
@@ -129,11 +129,11 @@ hash_sort = np.argsort(templatef['template_hash'][:])
 tb_sorted = tb[hash_sort]
 # calculate the differences between the boundary indices, 
 # in order to get the number in each template
-count_in_template = np.diff(tb_sorted)
-#Add on the last template
-count_in_template = np.append(count_in_template,
-                               [len(trigf[args.ifo+'/template_id'][:]) - tb_sorted[-1]])
+# adding on total number at the end to get number in the last boundary
+total_number = len(trigf[args.ifo+'/template_id'][:])
+count_in_template = np.diff(np.append(tb_sorted,total_number))
 
+# Sort the hash_sort array, to get the ordering info so we can return to original id order
 tid_sort = np.argsort(hash_sort)
 
 # get the stat values

--- a/bin/hdfcoinc/pycbc_fit_sngls_by_template
+++ b/bin/hdfcoinc/pycbc_fit_sngls_by_template
@@ -129,7 +129,7 @@ hash_sort = np.argsort(templatef['template_hash'][:])
 tb_sorted = tb[hash_sort]
 # calculate the differences between the boundary indices, 
 # in order to get the number in each template
-count_in_template = tb_sorted[1:] - tb_sorted[:-1]
+count_in_template = np.diff(tb_sorted)
 #Add on the last template
 count_in_template = np.append(count_in_template,
                                [len(trigf[args.ifo+'/template_id'][:]) - tb_sorted[-1]])

--- a/bin/hdfcoinc/pycbc_fit_sngls_by_template
+++ b/bin/hdfcoinc/pycbc_fit_sngls_by_template
@@ -23,7 +23,6 @@ from pycbc import io, events
 from pycbc.events import trigger_fits as trstats
 from pycbc.events.stat import sngl_statistic_dict
 import pycbc.version
-from pycbc.workflow import SegFile
 
 #### DEFINITIONS AND FUNCTIONS ####
 
@@ -136,14 +135,12 @@ if args.save_trig_param:
     tparam = trigf[args.ifo+'/'+args.save_trig_param][:][abovethresh]
 logging.info('%i trigs left after thresholding' % len(stat))
 
-# Calculate total time being analysed from segment
+# Calculate total time being analysed from segment and vetos
 segment_starts = sorted(set(trigf['{}/search/start_time'.format(args.ifo)][:]))
 segment_ends = sorted(set(trigf['{}/search/end_time'.format(args.ifo)][:]))
 
 
 all_segments = events.veto.start_end_to_segments(segment_starts, segment_ends)
-
-total_time_preveto = sum([seg_end - seg_start for seg_start, seg_end in all_segments])
 
 # now do vetoing
 for veto_file, veto_segment_name in zip(args.veto_file, args.veto_segment_name):
@@ -161,8 +158,6 @@ for veto_file, veto_segment_name in zip(args.veto_file, args.veto_segment_name):
                                                        (len(stat), veto_file))
 
 total_time = sum([seg_end - seg_start for seg_start, seg_end in all_segments])
-
-print(total_time)
 
 # do pruning (removal of trigs at N loudest times defined over param bins)
 if args.prune_param:

--- a/bin/hdfcoinc/pycbc_fit_sngls_by_template
+++ b/bin/hdfcoinc/pycbc_fit_sngls_by_template
@@ -23,6 +23,7 @@ from pycbc import io, events
 from pycbc.events import trigger_fits as trstats
 from pycbc.events.stat import sngl_statistic_dict
 import pycbc.version
+from pycbc.workflow import SegFile
 
 #### DEFINITIONS AND FUNCTIONS ####
 
@@ -135,10 +136,22 @@ if args.save_trig_param:
     tparam = trigf[args.ifo+'/'+args.save_trig_param][:][abovethresh]
 logging.info('%i trigs left after thresholding' % len(stat))
 
+# Calculate total time being analysed from segment
+segment_starts = sorted(set(trigf['{}/search/start_time'.format(args.ifo)][:]))
+segment_ends = sorted(set(trigf['{}/search/end_time'.format(args.ifo)][:]))
+
+
+all_segments = events.veto.start_end_to_segments(segment_starts, segment_ends)
+
+total_time_preveto = sum([seg_end - seg_start for seg_start, seg_end in all_segments])
+
 # now do vetoing
 for veto_file, veto_segment_name in zip(args.veto_file, args.veto_segment_name):
     retain, junk = events.veto.indices_outside_segments(time, [veto_file],
                                  ifo=args.ifo, segment_name=veto_segment_name)
+    all_segments -= events.veto.select_segments_by_definer(veto_file,
+                                                           ifo=args.ifo,
+                                                           segment_name=veto_segment_name)
     stat = stat[retain]
     tid = tid[retain]
     time = time[retain]
@@ -146,6 +159,10 @@ for veto_file, veto_segment_name in zip(args.veto_file, args.veto_segment_name):
         tparam = tparam[retain]
     logging.info('%i trigs left after vetoing with %s' %
                                                        (len(stat), veto_file))
+
+total_time = sum([seg_end - seg_start for seg_start, seg_end in all_segments])
+
+print(total_time)
 
 # do pruning (removal of trigs at N loudest times defined over param bins)
 if args.prune_param:
@@ -276,6 +293,7 @@ outfile.attrs.create("sngl_stat", data=args.sngl_stat)
 if args.save_trig_param:
     outfile.attrs.create("save_trig_param", data=args.save_trig_param)
 outfile.attrs.create("stat_threshold", data=args.stat_threshold)
+outfile.attrs.create("analysis_time", data=total_time)
 
 outfile.close()
 logging.info('Done!')

--- a/bin/hdfcoinc/pycbc_fit_sngls_by_template
+++ b/bin/hdfcoinc/pycbc_fit_sngls_by_template
@@ -122,6 +122,20 @@ trigf = h5py.File(args.trigger_file, 'r')
 logging.info('Opening template file: %s' % args.bank_file)
 templatef = h5py.File(args.bank_file, 'r')
 
+# Count the number of triggers in each template, for calulation of the true noise rate
+logging.info('Counting number of triggers in each template')
+tb = trigf[args.ifo+'/template_boundaries'][:]
+hash_sort = np.argsort(templatef['template_hash'][:])
+tb_sorted = tb[hash_sort]
+# calculate the differences between the boundary indices, 
+# in order to get the number in each template
+count_in_template = tb_sorted[1:] - tb_sorted[:-1]
+#Add on the last template
+count_in_template = np.append(count_in_template,
+                               [len(trigf[args.ifo+'/template_id'][:]) - tb_sorted[-1]])
+
+tid_sort = np.argsort(hash_sort)
+
 # get the stat values
 logging.info('Calculating stat values')
 stat = get_stat(args.sngl_stat, trigf[args.ifo])
@@ -157,7 +171,7 @@ for veto_file, veto_segment_name in zip(args.veto_file, args.veto_segment_name):
     logging.info('%i trigs left after vetoing with %s' %
                                                        (len(stat), veto_file))
 
-total_time = sum([seg_end - seg_start for seg_start, seg_end in all_segments])
+total_time = abs(all_segments)
 
 # do pruning (removal of trigs at N loudest times defined over param bins)
 if args.prune_param:
@@ -250,7 +264,7 @@ trange = range(tmin, tmax)
 
 # initialize result storage
 tids = []
-counts = []
+counts_total = []
 counts_above = []
 fits = []
 tpars = []
@@ -258,6 +272,7 @@ tpars = []
 for tnum in trange:
     stat_in_template = stat[tid == tnum]
     count_above = len(stat_in_template)
+    count_total = count_in_template[tid_sort[tnum]]
     if count_above == 0:
         # 'stupid' value to indicate no data, shouldn't hurt if 1/alpha is averaged
         alpha = -100.
@@ -266,6 +281,7 @@ for tnum in trange:
                       args.fit_function, stat_in_template, args.stat_threshold)
     tids.append(tnum)
     counts_above.append(count_above)
+    counts_total.append(count_total)
     fits.append(alpha)
     if args.save_trig_param:
         # save the param value of the first trig in this template
@@ -281,6 +297,7 @@ outfile.create_dataset("count_above_thresh", data=counts_above)
 outfile.create_dataset("fit_coeff", data=fits)
 if args.save_trig_param:
     outfile.create_dataset("template_param", data=tpars)
+outfile.create_dataset("count_in_template", data=counts_total)
 # add some metadata
 outfile.attrs.create("ifo", data=args.ifo)
 outfile.attrs.create("fit_function", data=args.fit_function)

--- a/bin/hdfcoinc/pycbc_fit_sngls_by_template
+++ b/bin/hdfcoinc/pycbc_fit_sngls_by_template
@@ -122,21 +122,25 @@ trigf = h5py.File(args.trigger_file, 'r')
 logging.info('Opening template file: %s' % args.bank_file)
 templatef = h5py.File(args.bank_file, 'r')
 
-# Count the number of triggers in each template, for calulation of the true noise rate
 logging.info('Counting number of triggers in each template')
+# template boundaries dataset is in order of template_id
 tb = trigf[args.ifo+'/template_boundaries'][:]
+tid = np.arange(len(tb))
+# template boundary values ascend in the same order as template hash
+# hence sort by hash
 hash_sort = np.argsort(templatef['template_hash'][:])
-tb_sorted = tb[hash_sort]
-tid = np.arange(len(hash_sort))
-tid_hash_sorted = tid[hash_sort]
-tid_order = np.argsort(tid_hash_sorted)
+tb_hashorder = tb[hash_sort]
+# reorder template IDs in parallel to the boundary values
+tid_hashorder = tid[hash_sort]
 
-# calculate the differences between the boundary indices, 
-# in order to get the number in each template
-# adding on total number at the end to get number in the last boundary
-total_number = len(trigf[args.ifo+'/template_id'][:])
-count_in_template_hashorder = np.diff(np.append(tb_sorted,total_number))
-count_in_template = count_in_template_hashorder[tid_order]
+# Calculate the differences between the boundary indices to get the 
+# number in each template
+# adding on total number at the end to get number in the last template
+total_number = len(trigf[args.ifo + '/template_id'][:])
+count_in_template_hashorder = np.diff(np.append(tb_hashorder, total_number))
+# re-reorder values from hash order to tid order
+tid_sort = np.argsort(tid_hashorder)
+count_in_template = count_in_template_hashorder[tid_sort]
 
 # get the stat values
 logging.info('Calculating stat values')
@@ -145,17 +149,16 @@ stat = get_stat(args.sngl_stat, trigf[args.ifo])
 # do first thresholding operation to reduce trigger numbers
 abovethresh = stat >= args.stat_threshold
 stat = stat[abovethresh]
-tid = trigf[args.ifo+'/template_id'][:][abovethresh]
-time = trigf[args.ifo+'/end_time'][:][abovethresh]
+tid = trigf[args.ifo + '/template_id'][:][abovethresh]
+time = trigf[args.ifo + '/end_time'][:][abovethresh]
 if args.save_trig_param:
-    tparam = trigf[args.ifo+'/'+args.save_trig_param][:][abovethresh]
+    tparam = trigf[args.ifo + '/' + args.save_trig_param][:][abovethresh]
 logging.info('%i trigs left after thresholding' % len(stat))
 
-# Calculate total time being analysed from segment and vetos
+# Calculate total time being analysed from segments
+# use set() to eliminate duplicates
 segment_starts = sorted(set(trigf['{}/search/start_time'.format(args.ifo)][:]))
 segment_ends = sorted(set(trigf['{}/search/end_time'.format(args.ifo)][:]))
-
-
 all_segments = events.veto.start_end_to_segments(segment_starts, segment_ends)
 
 # now do vetoing
@@ -172,7 +175,6 @@ for veto_file, veto_segment_name in zip(args.veto_file, args.veto_segment_name):
         tparam = tparam[retain]
     logging.info('%i trigs left after vetoing with %s' %
                                                        (len(stat), veto_file))
-
 total_time = abs(all_segments)
 
 # do pruning (removal of trigs at N loudest times defined over param bins)
@@ -289,8 +291,8 @@ for tnum in trange:
         # save the param value of the first trig in this template
         param_in_template = tparam[tid == tnum]
         tpars.append(param_in_template[0])
-    if (tnum % 100 == 0): logging.info('Fitted template %i / %i' %
-                                                     (tnum - tmin,tmax - tmin))
+    if (tnum % 1000 == 0): logging.info('Fitted template %i / %i' %
+                                                    (tnum - tmin, tmax - tmin))
 
 outfile = h5py.File(args.output, 'w')
 # store template-dependent fit output

--- a/bin/hdfcoinc/pycbc_fit_sngls_over_multiparam
+++ b/bin/hdfcoinc/pycbc_fit_sngls_over_multiparam
@@ -57,8 +57,7 @@ parser.add_argument("--min-duration", type=float, default=0.,
                          "values of template_duration: add to duration values"
                          " before fitting. Units seconds.")
 parser.add_argument("--log-param", nargs='+',
-                    help="Take the log of the fit param before smoothing. "
-)
+                    help="Take the log of the fit param before smoothing.")
 parser.add_argument("--smoothing-width", type=float, nargs='+', required=True,
                     help="Distance in the space of fit param values (or the "
                          "logs of them) to smooth over. Required. For log "
@@ -96,11 +95,16 @@ for param, slog in zip(args.fit_param, args.log_param):
     else:
         raise ValueError("invalid log param argument, use 'true', or 'false'")
 
+if 'count_in_template' in fits.keys():  # recently introduced dataset
+    tcount = True
+else:
+    tcount = False
+
 # for an exponential fit 1/alpha is linear in the trigger statistic values
 # so taking weighted sums/averages of 1/alpha is appropriate
 nabove = fits['count_above_thresh'][:]
 nabove = nabove / numpy.mean(nabove)
-ntotal = fits['count_total'][:]
+if tcount: ntotal = fits['count_in_template'][:]
 
 invalpha = 1. / fits['fit_coeff'][:] 
 invalphan = invalpha * nabove
@@ -112,14 +116,14 @@ def dist(i1, i2):
     return dsq ** 0.5
 
 nabove_smoothed = []
-ntotal_smoothed = []
+if tcount: ntotal_smoothed = []
 alpha_smoothed = []
 rang = numpy.arange(0, len(nabove))
 for i in range(len(nabove)):
     dsq = dist(i, rang)
     l = (dsq < 1)
     
-    ntotal_smoothed.append(ntotal[l].mean())
+    if tcount: ntotal_smoothed.append(ntotal[l].mean())
     nabove_smoothed.append(nabove[l].mean())
     alpha_smoothed.append(nabove_smoothed[i] / invalphan[l].mean())
 
@@ -128,7 +132,7 @@ outfile = h5py.File(args.output, 'w')
 outfile['template_id'] = tid
 outfile['count_above_thresh'] = nabove_smoothed
 outfile['fit_coeff'] = alpha_smoothed
-outfile['count_total'] = ntotal_smoothed
+if tcount: outfile['count_total'] = ntotal_smoothed
 
 for param, vals, slog in zip(args.fit_param, parvals, args.log_param):
     if slog in ['false', 'False', 'FALSE']:

--- a/bin/hdfcoinc/pycbc_fit_sngls_over_multiparam
+++ b/bin/hdfcoinc/pycbc_fit_sngls_over_multiparam
@@ -100,6 +100,7 @@ for param, slog in zip(args.fit_param, args.log_param):
 # so taking weighted sums/averages of 1/alpha is appropriate
 nabove = fits['count_above_thresh'][:]
 nabove = nabove / numpy.mean(nabove)
+ntotal = fits['count_total'][:]
 
 invalpha = 1. / fits['fit_coeff'][:] 
 invalphan = invalpha * nabove
@@ -111,12 +112,14 @@ def dist(i1, i2):
     return dsq ** 0.5
 
 nabove_smoothed = []
+ntotal_smoothed = []
 alpha_smoothed = []
 rang = numpy.arange(0, len(nabove))
 for i in range(len(nabove)):
     dsq = dist(i, rang)
     l = (dsq < 1)
     
+    ntotal_smoothed.append(ntotal[l].mean())
     nabove_smoothed.append(nabove[l].mean())
     alpha_smoothed.append(nabove_smoothed[i] / invalphan[l].mean())
 
@@ -125,6 +128,8 @@ outfile = h5py.File(args.output, 'w')
 outfile['template_id'] = tid
 outfile['count_above_thresh'] = nabove_smoothed
 outfile['fit_coeff'] = alpha_smoothed
+outfile['count_total'] = ntotal_smoothed
+
 for param, vals, slog in zip(args.fit_param, parvals, args.log_param):
     if slog in ['false', 'False', 'FALSE']:
         outfile[param] = vals

--- a/bin/hdfcoinc/pycbc_fit_sngls_over_param
+++ b/bin/hdfcoinc/pycbc_fit_sngls_over_param
@@ -107,6 +107,7 @@ else:
 
 nabove = fits['count_above_thresh'][:]
 nabove = nabove/np.mean(nabove)
+ntotal = fits['count_in_template'][:]
 # for an exponential fit 1/alpha is linear in the trigger statistic values
 # so taking weighted sums/averages of 1/alpha is appropriate
 invalpha = 1./(fits['fit_coeff'][:])
@@ -138,6 +139,13 @@ if args.regression_method == 'nn':
     nabove_smoothed = [nabove_knn.predict([[p]]) for p in parvals]
     del nabove_knn
 
+    logging.info('Smoothing ntotal data')
+    ntotal_knn = knn.fit(parvals[:, np.newaxis], ntotal)
+    logging.info('Evaluating smoothed ntotal')
+    ntotal_smoothed = [ntotal_knn.predict([[p]]) for p in parvals]
+    del ntotal_knn
+
+
     logging.info('Smoothing invalpha data')
     # smooth the inverse alpha values times trig count above threshold
     invalphan = invalpha * nabove
@@ -155,6 +163,7 @@ elif args.regression_method == 'tricube':
     invalphan = invalpha * nabove
     invalpha_smoothed = []
     nabove_smoothed = []
+    ntotal_smoothed = []
     logging.info('Evaluating smoothed invalpha and n_above')
     for i, p in enumerate(parvals):
         if not i % 100:
@@ -167,14 +176,17 @@ elif args.regression_method == 'tricube':
         norm = weights.sum()
         # weighted average
         n_sm = (nabove[in_kernel] * weights).sum() / norm
+        nt_sm = (ntotal[in_kernel] * weights).sum() / norm
         invalphan_smoothed = (invalphan[in_kernel] * weights).sum() / norm
         invalpha_smoothed.append(invalphan_smoothed / n_sm)
         nabove_smoothed.append(n_sm)
+        ntotal_smoothed.append(nt_sm)
 
 # store template-dependent fit output
 outfile = h5py.File(args.output, 'w')
 outfile.create_dataset('template_id', data=tid)
 outfile.create_dataset('count_above_thresh', data=nabove_smoothed)
+outfile.create_dataset('count_total', data=ntotal_smoothed)
 outfile.create_dataset('fit_coeff', data=1. / np.array(invalpha_smoothed))
 outfile.create_dataset('param_val', data=(np.exp(parvals) if args.log_param
     else parvals))

--- a/bin/hdfcoinc/pycbc_fit_sngls_over_param
+++ b/bin/hdfcoinc/pycbc_fit_sngls_over_param
@@ -105,18 +105,24 @@ else:
     m1, m2, s1z, s2z = trstats.get_masses(bank, tid)
     parvals = trstats.get_param(args.fit_param, args, m1, m2, s1z, s2z) 
 
+if 'count_in_template' in fits.keys():  # recently introduced extra dataset
+    tcount = True
+else:
+    tcount = False
+
 nabove = fits['count_above_thresh'][:]
 nabove = nabove/np.mean(nabove)
-ntotal = fits['count_in_template'][:]
+if tcount: ntotal = fits['count_in_template'][:]
 # for an exponential fit 1/alpha is linear in the trigger statistic values
 # so taking weighted sums/averages of 1/alpha is appropriate
 invalpha = 1./(fits['fit_coeff'][:])
 
-# sort in ascending duration order
+# sort in ascending parameter order
 parsort = np.argsort(parvals)
 tid = tid[parsort]
 parvals = parvals[parsort]
 nabove = nabove[parsort]
+if tcount: ntotal = ntotal[parsort]
 invalpha = invalpha[parsort]
 
 if args.log_param:
@@ -139,12 +145,12 @@ if args.regression_method == 'nn':
     nabove_smoothed = [nabove_knn.predict([[p]]) for p in parvals]
     del nabove_knn
 
-    logging.info('Smoothing ntotal data')
-    ntotal_knn = knn.fit(parvals[:, np.newaxis], ntotal)
-    logging.info('Evaluating smoothed ntotal')
-    ntotal_smoothed = [ntotal_knn.predict([[p]]) for p in parvals]
-    del ntotal_knn
-
+    if tcount:
+        logging.info('Smoothing ntotal data')
+        ntotal_knn = knn.fit(parvals[:, np.newaxis], ntotal)
+        logging.info('Evaluating smoothed ntotal')
+        ntotal_smoothed = [ntotal_knn.predict([[p]]) for p in parvals]
+        del ntotal_knn
 
     logging.info('Smoothing invalpha data')
     # smooth the inverse alpha values times trig count above threshold
@@ -163,7 +169,7 @@ elif args.regression_method == 'tricube':
     invalphan = invalpha * nabove
     invalpha_smoothed = []
     nabove_smoothed = []
-    ntotal_smoothed = []
+    if tcount: ntotal_smoothed = []
     logging.info('Evaluating smoothed invalpha and n_above')
     for i, p in enumerate(parvals):
         if not i % 100:
@@ -176,7 +182,7 @@ elif args.regression_method == 'tricube':
         norm = weights.sum()
         # weighted average
         n_sm = (nabove[in_kernel] * weights).sum() / norm
-        nt_sm = (ntotal[in_kernel] * weights).sum() / norm
+        if tcount: nt_sm = (ntotal[in_kernel] * weights).sum() / norm
         invalphan_smoothed = (invalphan[in_kernel] * weights).sum() / norm
         invalpha_smoothed.append(invalphan_smoothed / n_sm)
         nabove_smoothed.append(n_sm)
@@ -186,7 +192,7 @@ elif args.regression_method == 'tricube':
 outfile = h5py.File(args.output, 'w')
 outfile.create_dataset('template_id', data=tid)
 outfile.create_dataset('count_above_thresh', data=nabove_smoothed)
-outfile.create_dataset('count_total', data=ntotal_smoothed)
+if tcount: outfile.create_dataset('count_total', data=ntotal_smoothed)
 outfile.create_dataset('fit_coeff', data=1. / np.array(invalpha_smoothed))
 outfile.create_dataset('param_val', data=(np.exp(parvals) if args.log_param
     else parvals))


### PR DESCRIPTION
Adding `analysis_time` output to `fit_sngls_by_template`

This will be needed for calculation of the new multiiforanking statistic (noise rate for each template = number of triggers/analysis time)

The analysis time is calculated through the trigger file segments and vetos as used in the fitting already