### PR TITLE
add time estimates for NRTidal

### DIFF
--- a/pycbc/waveform/waveform.py
+++ b/pycbc/waveform/waveform.py
@@ -809,6 +809,8 @@ _filter_time_lengths["SEOBNRv4"] = seobnrv4_length_in_time
 _filter_time_lengths["IMRPhenomC"] = imrphenomd_length_in_time
 _filter_time_lengths["IMRPhenomD"] = imrphenomd_length_in_time
 _filter_time_lengths["IMRPhenomPv2"] = imrphenomd_length_in_time
+_filter_time_lengths["IMRPhenomD_NRTidal"] = imrphenomd_length_in_time
+_filter_time_lengths["IMRPhenomPv2_NRTidal"] = imrphenomd_length_in_time
 _filter_time_lengths["SpinTaylorF2"] = spa_length_in_time
 _filter_time_lengths["TaylorF2NL"] = spa_length_in_time
 


### PR DESCRIPTION
Allows PhenomD_NRTidal and PhenomPv2_NRTidal
to be used with get_td_wavefrom and get_td_wavefrom_from_fd

PhenomPv2_NRTidal is now on the master branch of lalsuite too.