### PR TITLE
Bump matplotlib version to 2.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ astropy>=2.0.3,<3.0.0
 Mako>=1.0.1
 decorator>=3.4.2
 scipy>=0.16.0
-matplotlib>=1.5.1
+matplotlib>=2.0.0
 numpy>=1.13.0,<1.15.3
 pillow
 h5py>=2.5


### PR DESCRIPTION
The matplotlib version is quite old, which can cause problems when using the CVMFS build.