### PR TITLE
Inference: do not ignore option "fields" in posterior

### DIFF
--- a/pycbc/inference/io/posterior.py
+++ b/pycbc/inference/io/posterior.py
@@ -34,7 +34,7 @@ class PosteriorFile(BaseInferenceFile):
 
     def read_raw_samples(self, fields, **kwargs):
         samples = self[self.samples_group]
-        return {field: samples[field][:] for field in samples}
+        return {field: samples[field][:] for field in fields}
 
     def write_posterior(self, filename, **kwargs):
         """Write me."""


### PR DESCRIPTION
The `read_raw_samples` function in the posterior module ignores the option "fields", so that it is reading samples for all parameters independently if how the function is called.
With this PR, it will read only samples for the parameters specified in "fields"