### PR TITLE
Add Jensen-Shannon divergence to entropy

### DIFF
--- a/pycbc/inference/entropy.py
+++ b/pycbc/inference/entropy.py
@@ -6,6 +6,30 @@ import numpy
 
 from scipy import stats
 
+def entropy(pdf1, pdf2=None, base=numpy.e):
+    """ Computes the information entropy for a single parameter
+    from one probability density function.
+
+    Parameters
+    ----------
+    pdf1 : numpy.array
+        Probability density function.
+    pdf2 : {None, numpy.array}, optional
+        Probability density function of a second distribution to
+        calculate the Kullback-Leibler divergence.
+    base : {numpy.e, numpy.float64}, optional
+        The logarithmic base to use (choose base 2 for information measured
+        in bits, default is nats).
+
+    Returns
+    -------
+    numpy.float64
+        The information entropy value (or the Kullback-Leibler divergence if
+        two distributions are given).
+    """
+
+    return stats.entropy(pdf1, qk=pdf2, base=base)
+
 
 def kl(samples1, samples2, pdf1=False, pdf2=False,
        bins=30, hist_min=None, hist_max=None, base=numpy.e):
@@ -45,7 +69,8 @@ def kl(samples1, samples2, pdf1=False, pdf2=False,
     if not pdf2:
         samples2, _ = numpy.histogram(samples2, bins=bins,
                                       range=hist_range, normed=True)
-    return stats.entropy(samples1, qk=samples2, base=base)
+    return entropy(samples1, pdf2=samples2, base=base)
+
 
 def js(samples1, samples2, pdf1=False, pdf2=False,
        bins=30, hist_min=None, hist_max=None, base=numpy.e):
@@ -82,9 +107,9 @@ def js(samples1, samples2, pdf1=False, pdf2=False,
     join_samples = numpy.concatenate((samples1, samples2))
     samplesm, _ = numpy.histogram(join_samples, bins=bins,
                                   range=hist_range, normed=True)
-    return (1./2)*kl(samples1, (1./2)*samplesm, pdf1=False, pdf2=True, 
+    return (1./2)*kl(samples1, (1./2)*samplesm, pdf1=pdf1, pdf2=True,
                      bins=bins, hist_min=hist_min, hist_max=hist_max,
                      base=base) + \
-           (1./2)*kl(samples2, (1./2)*samplesm, pdf1=False, pdf2=True,
+           (1./2)*kl(samples2, (1./2)*samplesm, pdf1=pdf2, pdf2=True,
                      bins=bins, hist_min=hist_min, hist_max=hist_max,
                      base=base)

--- a/pycbc/inference/entropy.py
+++ b/pycbc/inference/entropy.py
@@ -73,21 +73,17 @@ def kl(samples1, samples2, pdf1=False, pdf2=False,
     return entropy(samples1, pdf2=samples2, base=base)
 
 
-def js(samples1, samples2, pdf1=False, pdf2=False,
-       bins=30, hist_min=None, hist_max=None, base=numpy.e):
+def js(samples1, samples2, bins=30, hist_min=None, hist_max=None,
+       base=numpy.e):
     """ Computes the Jensen-Shannon divergence for a single parameter
     from two distributions.
 
     Parameters
     ----------
     samples1 : numpy.array
-        Samples or probability density function (must also set `pdf1=True`).
+        Samples.
     samples2 : numpy.array
-        Samples or probability density function (must also set `pdf2=True`).
-    pdf1 : bool
-        Set to `True` if `samples1` is a probability density funtion already.
-    pdf2 : bool
-        Set to `True` if `samples2` is a probability density funtion already.
+        Samples.
     bins : int
         Number of bins to use when calculating probability density function
         from a set of samples of the distribution.
@@ -108,9 +104,9 @@ def js(samples1, samples2, pdf1=False, pdf2=False,
     join_samples = numpy.concatenate((samples1, samples2))
     samplesm, _ = numpy.histogram(join_samples, bins=bins,
                                   range=hist_range, normed=True)
-    return (1./2)*kl(samples1, (1./2)*samplesm, pdf1=pdf1, pdf2=True,
+    return (1./2)*kl(samples1, (1./2)*samplesm, pdf1=False, pdf2=True,
                      bins=bins, hist_min=hist_min, hist_max=hist_max,
                      base=base) + \
-           (1./2)*kl(samples2, (1./2)*samplesm, pdf1=pdf2, pdf2=True,
+           (1./2)*kl(samples2, (1./2)*samplesm, pdf1=False, pdf2=True,
                      bins=bins, hist_min=hist_min, hist_max=hist_max,
                      base=base)

--- a/pycbc/inference/entropy.py
+++ b/pycbc/inference/entropy.py
@@ -14,6 +14,8 @@ def check_hist_params(samples, hist_min, hist_max, hist_bins):
 
     Parameters
     ----------
+    samples : numpy.array
+        Set of samples to get the min/max if only one of the bounds is given.
     hist_min : numpy.float64
         Minimum value for the histogram.
     hist_max : numpy.float64
@@ -27,8 +29,10 @@ def check_hist_params(samples, hist_min, hist_max, hist_bins):
 
     Returns
     -------
-    range : tuple
-        The bounds (hist_min, hist_max).
+    hist_range : tuple or None
+        The bounds (hist_min, hist_max) or None.
+    hist_bins : int or str
+        Number of bins or method for optimal width bin calculation.
     """
 
     hist_methods = ['auto', 'fd', 'doane', 'scott', 'stone', 'rice',
@@ -39,21 +43,20 @@ def check_hist_params(samples, hist_min, hist_max, hist_bins):
         raise ValueError('Method for calculating bins width must be one of'
                          ' {}'.format(hist_methods))
 
+    # No bounds given, return None
+    if not hist_min and not hist_max:
+        return None, hist_bins
+
     # One of the bounds is missing
     if hist_min and not hist_max:
         hist_max = samples.max()
     elif hist_max and not hist_min:
         hist_min = samples.min()
-
     # Both bounds given
-    if hist_min and hist_max:
-        if hist_min >= hist_max:
-            raise ValueError('hist_min must be lower than hist_max.')
-        else:
-            hist_range = (hist_min, hist_max)
-    # No bounds given
-    elif not hist_min and not hist_max:
-        hist_range = None
+    elif hist_min and hist_max and hist_min >= hist_max:
+        raise ValueError('hist_min must be lower than hist_max.')
+
+    hist_range = (hist_min, hist_max)
 
     return hist_range, hist_bins
 

--- a/pycbc/inference/entropy.py
+++ b/pycbc/inference/entropy.py
@@ -8,7 +8,7 @@ from scipy import stats
 
 
 def kl(samples1, samples2, pdf1=False, pdf2=False,
-       bins=30, hist_min=None, hist_max=None):
+       bins=30, hist_min=None, hist_max=None, base=numpy.e):
     """ Computes the Kullback-Leibler divergence for a single parameter
     from two distributions.
 
@@ -29,6 +29,9 @@ def kl(samples1, samples2, pdf1=False, pdf2=False,
         Minimum of the distributions' values to use.
     hist_max : numpy.float64
         Maximum of the distributions' values to use.
+    base : numpy.float64
+        The logarithmic base to use (choose base 2 for information measured
+        in bits, default is nats).
 
     Returns
     -------
@@ -42,4 +45,46 @@ def kl(samples1, samples2, pdf1=False, pdf2=False,
     if not pdf2:
         samples2, _ = numpy.histogram(samples2, bins=bins,
                                       range=hist_range, normed=True)
-    return stats.entropy(samples1, qk=samples2)
+    return stats.entropy(samples1, qk=samples2, base=base)
+
+def js(samples1, samples2, pdf1=False, pdf2=False,
+       bins=30, hist_min=None, hist_max=None, base=numpy.e):
+    """ Computes the Jensen-Shannon divergence for a single parameter
+    from two distributions.
+
+    Parameters
+    ----------
+    samples1 : numpy.array
+        Samples or probability density function (must also set `pdf1=True`).
+    samples2 : numpy.array
+        Samples or probability density function (must also set `pdf2=True`).
+    pdf1 : bool
+        Set to `True` if `samples1` is a probability density funtion already.
+    pdf2 : bool
+        Set to `True` if `samples2` is a probability density funtion already.
+    bins : int
+        Number of bins to use when calculating probability density function
+        from a set of samples of the distribution.
+    hist_min : numpy.float64
+        Minimum of the distributions' values to use.
+    hist_max : numpy.float64
+        Maximum of the distributions' values to use.
+    base : numpy.float64
+        The logarithmic base to use (choose base 2 for information measured
+        in bits, default is nats).
+
+    Returns
+    -------
+    numpy.float64
+        The Jensen-Shannon divergence value.
+    """
+    hist_range = (hist_min, hist_max)
+    join_samples = numpy.concatenate((samples1, samples2))
+    samplesm, _ = numpy.histogram(join_samples, bins=bins,
+                                  range=hist_range, normed=True)
+    return (1./2)*kl(samples1, (1./2)*samplesm, pdf1=False, pdf2=True, 
+                     bins=bins, hist_min=hist_min, hist_max=hist_max,
+                     base=base) + \
+           (1./2)*kl(samples2, (1./2)*samplesm, pdf1=False, pdf2=True,
+                     bins=bins, hist_min=hist_min, hist_max=hist_max,
+                     base=base)

--- a/pycbc/inference/entropy.py
+++ b/pycbc/inference/entropy.py
@@ -6,6 +6,7 @@ import numpy
 
 from scipy import stats
 
+
 def entropy(pdf1, pdf2=None, base=numpy.e):
     """ Computes the information entropy for a single parameter
     from one probability density function.

--- a/pycbc/inference/entropy.py
+++ b/pycbc/inference/entropy.py
@@ -32,7 +32,7 @@ def check_hist_params(hist_min, hist_max, hist_bins):
     """
 
     hist_methods = ['auto', 'fd', 'doane', 'scott', 'stone', 'rice',
-                     'sturges', 'sqrt']
+                    'sturges', 'sqrt']
     if not hist_bins:
         hist_bins = 'fd'
     elif isinstance(hist_bins, str) and hist_bins not in hist_methods:
@@ -135,7 +135,7 @@ def kl(samples1, samples2, pdf1=False, pdf2=False, kde=False,
         else:
             hist_range, hist_bins = check_hist_params(hist_min, hist_max, bins)
             pdfs[n], _ = numpy.histogram(samples, bins=hist_bins,
-                                         range=hist_range, normed=True)
+                                         range=hist_range, density=True)
 
     return stats.entropy(pdfs[0], qk=pdfs[1], base=base)
 
@@ -183,7 +183,7 @@ def js(samples1, samples2, kde=False, bins=None, hist_min=None, hist_max=None,
     else:
         hist_range, hist_bins = check_hist_params(hist_min, hist_max, bins)
         samplesm, _ = numpy.histogram(join_samples, bins=hist_bins,
-                                      range=hist_range, normed=True)
+                                      range=hist_range, density=True)
     samplesm = (1./2) * samplesm
 
     js_div = 0

--- a/pycbc/inference/entropy.py
+++ b/pycbc/inference/entropy.py
@@ -6,11 +6,11 @@ import numpy
 from scipy import stats
 
 
-def check_hist_bounds(hist_min, hist_max, hist_bins):
+def check_hist_params(hist_min, hist_max, hist_bins):
     """ Checks that the bound values given for the histogram are consistent,
     returning the range if they are or raising an error if they are not.
-    Also checks that the hist_bins is either an int or a str from the list
-    of available methods in numpy.histogram
+    Also checks that if hist_bins is a str, it corresponds to a method
+    available in numpy.histogram
 
     Parameters
     ----------
@@ -33,11 +33,11 @@ def check_hist_bounds(hist_min, hist_max, hist_bins):
 
     hist_methods = ['auto', 'fd', 'doane', 'scott', 'stone', 'rice',
                      'sturges', 'sqrt']
-    if isinstance(hist_bins, str) and hist_bins not in hist_methods:
+    if not hist_bins:
+        hist_bins = 'fd'
+    elif isinstance(hist_bins, str) and hist_bins not in hist_methods:
         raise ValueError('Method for calculating bins width must be one of'
                          ' {}'.format(hist_methods))
-    elif not hist_bins:
-        hist_bins = 'fd'
 
     # One of the bounds is missing
     if hist_min and not hist_max:
@@ -133,7 +133,7 @@ def kl(samples1, samples2, pdf1=False, pdf2=False, kde=False,
             samples_kde = stats.gaussian_kde(samples)
             pdfs[n] = samples_kde.evaluate(samples)
         else:
-            hist_range, hist_bins = check_hist_bounds(hist_min, hist_max, bins)
+            hist_range, hist_bins = check_hist_params(hist_min, hist_max, bins)
             pdfs[n], _ = numpy.histogram(samples, bins=hist_bins,
                                          range=hist_range, normed=True)
 
@@ -181,7 +181,7 @@ def js(samples1, samples2, kde=False, bins=None, hist_min=None, hist_max=None,
         samplesm_kde = stats.gaussian_kde(join_samples)
         samplesm = samplesm_kde.evaluate(join_samples)
     else:
-        hist_range, hist_bins = check_hist_bounds(hist_min, hist_max, bins)
+        hist_range, hist_bins = check_hist_params(hist_min, hist_max, bins)
         samplesm, _ = numpy.histogram(join_samples, bins=hist_bins,
                                       range=hist_range, normed=True)
     samplesm = (1./2) * samplesm

--- a/pycbc/inference/entropy.py
+++ b/pycbc/inference/entropy.py
@@ -98,7 +98,7 @@ def compute_pdf(samples, method, bins, hist_min, hist_max):
         draw = samples_kde.resample(npts)
         pdf = samples_kde.evaluate(draw)
     elif method == 'hist':
-        hist_range, hist_bins = check_hist_params(samples, hist_min, 
+        hist_range, hist_bins = check_hist_params(samples, hist_min,
                                                   hist_max, bins)
         pdf, _ = numpy.histogram(samples, bins=hist_bins,
                                  range=hist_range, density=True)
@@ -178,7 +178,7 @@ def kl(samples1, samples2, pdf1=False, pdf2=False, kde=False,
 
     sample_groups = {'P': (samples1, pdf1), 'Q': (samples2, pdf2)}
     pdfs = {}
-    for n in sample_groups.keys():
+    for n in sample_groups:
         samples, pdf = sample_groups[n]
         if pdf:
             pdfs[n] = samples
@@ -228,7 +228,7 @@ def js(samples1, samples2, kde=False, bins=None, hist_min=None, hist_max=None,
 
     sample_groups = {'P': samples1, 'Q': samples2}
     pdfs = {}
-    for n in sample_groups.keys():
+    for n in sample_groups:
         samples = sample_groups[n]
         method = 'kde' if kde else 'hist'
         pdfs[n] = compute_pdf(samples, method, bins, hist_min, hist_max)

--- a/pycbc/inference/entropy.py
+++ b/pycbc/inference/entropy.py
@@ -57,6 +57,7 @@ def check_hist_params(hist_min, hist_max, hist_bins):
 
     return hist_range, hist_bins
 
+
 def entropy(pdf1, base=numpy.e):
     """ Computes the information entropy for a single parameter
     from one probability density function.

--- a/pycbc/inference/entropy.py
+++ b/pycbc/inference/entropy.py
@@ -129,10 +129,10 @@ def kl(samples1, samples2, pdf1=False, pdf2=False, kde=False,
         raise ValueError('KDE can only be used when at least one of pdf1 or '
                          'pdf2 is False.')
 
-    sample_groups = {1:(samples1, pdf1), 2:(samples2, pdf2)}
+    sample_groups = {1: (samples1, pdf1), 2: (samples2, pdf2)}
     pdfs = {}
-    for n in sample_groups.keys:
-        samples, pdf = samples_group[n]
+    for n in sample_groups.keys():
+        samples, pdf = sample_groups[n]
         if pdf:
             pdfs[n] = samples
         elif kde:


### PR DESCRIPTION
This PR adds three things to the entropy module:
* a function `entropy` that returns the regular information entropy for a single distribution https://en.wikipedia.org/wiki/Entropy_(information_theory)
* a function `js` to calculate the Jensen-Shannon divergence https://en.wikipedia.org/wiki/Jensen%E2%80%93Shannon_divergence
* the option `base` (defaults to scipy.stats's default), to have the option to get all these results in bits rather than nats.
