### PR TITLE
adding multi-ifo functionality to foundmissed plotting script

### DIFF
--- a/bin/hdfcoinc/pycbc_page_foundmissed
+++ b/bin/hdfcoinc/pycbc_page_foundmissed
@@ -31,6 +31,8 @@ parser.add_argument('--far-type', choices=('inclusive', 'exclusive'), default='i
                          "'exclusive'. Default = 'inclusive'")
 parser.add_argument('--missed-on-top', action='store_true',
                     help="Plot missed injections on top of found ones")
+parser.add_argument('--ifos', nargs='+',default=False,
+                    help="List of IFOs in search")
 parser.add_argument('--version', action='version', version=pycbc.version.git_verbose_msg)
 args = parser.parse_args()
 
@@ -51,9 +53,6 @@ elif args.far_type == 'exclusive':
     ifar_found = f['found_after_vetoes/ifar_exc'][:]
     far_title = 'Exclusive'
 
-# This hardcodes HL search !!!!!, replace with function that takes or/sky/det
-hdist = f['injections/eff_dist_h'][:]
-ldist = f['injections/eff_dist_l'][:]
 s1z = f['injections/spin1z'][:]
 s2z = f['injections/spin2z'][:]
 dist = f['injections/distance'][:]
@@ -69,8 +68,12 @@ vals['mtotal'] = m1 + m2
 vals['mass_ratio'] = numpy.maximum(m1/m2, m2/m1)
 
 dvals = {}
-dvals['decisive_distance'] = numpy.maximum(hdist, ldist)
-dvals['dec_chirp_distance'] = pycbc.pnutils.chirp_distance(dvals['decisive_distance'], vals['mchirp'])
+if not args.ifos:
+    hdist = f['injections/eff_dist_h'][:]
+    ldist = f['injections/eff_dist_l'][:]
+    dvals['decisive_distance'] = numpy.maximum(hdist, ldist)
+    dvals['dec_chirp_distance'] = pycbc.pnutils.chirp_distance(dvals['decisive_distance'], vals['mchirp'])
+
 dvals['chirp_distance'] = pycbc.pnutils.chirp_distance(dist, vals['mchirp'])
 if args.distance_type == 'redshift':
     dvals['redshift'] = f['injections/redshift'][:]
@@ -80,6 +83,16 @@ if 'optimal_snr_1' in f['injections']:
     opt_snr_2 = f['injections/optimal_snr_2'][:]
     dvals['comb_optimal_snr'] = numpy.sqrt(opt_snr_1 ** 2 + opt_snr_2 ** 2)
     dvals['decisive_optimal_snr'] = numpy.where(opt_snr_1 < opt_snr_2, opt_snr_1, opt_snr_2)
+elif args.ifos:
+    opt_snrs_sqd = ()
+    for ifo in args.ifos:
+        opt_snrs_sqd += (f['injections/optimal_snr_%s' % ifo][:]**2,)
+
+    dvals['comb_optimal_snr'] = [numpy.sqrt(sum(set_opt_snrs_sqd)) for set_opt_snrs_sqd in zip(*opt_snrs_sqd)]
+    dvals['decisive_optimal_snr'] = [numpy.sqrt(sorted(set_opt_snrs_sqd)[-2]) for set_opt_snrs_sqd in zip(*opt_snrs_sqd)]
+else:
+    logging.error('IFOs not given in command line, and optimal_snr_1 not in input file. Needs one of them')
+
 
 fdvals = dvals[args.distance_type][found]
 mdvals = dvals[args.distance_type][missed]

--- a/bin/hdfcoinc/pycbc_page_foundmissed
+++ b/bin/hdfcoinc/pycbc_page_foundmissed
@@ -75,23 +75,25 @@ if not args.ifos:
     dvals['dec_chirp_distance'] = pycbc.pnutils.chirp_distance(dvals['decisive_distance'], vals['mchirp'])
 
 dvals['chirp_distance'] = pycbc.pnutils.chirp_distance(dist, vals['mchirp'])
-		if args.distance_type == 'redshift':
-	    dvals['redshift'] = f['injections/redshift'][:]
+if args.distance_type == 'redshift':
+    dvals['redshift'] = f['injections/redshift'][:]
 
-	if 'optimal_snr_1' in f['injections']:
-	    opt_snr_1 = f['injections/optimal_snr_1'][:]
-	    opt_snr_2 = f['injections/optimal_snr_2'][:]
-	    dvals['comb_optimal_snr'] = numpy.sqrt(opt_snr_1 ** 2 + opt_snr_2 ** 2)
-	    dvals['decisive_optimal_snr'] = numpy.where(opt_snr_1 < opt_snr_2, opt_snr_1, opt_snr_2)
-	elif args.ifos:
-	    opt_snrs_sqd = ()
-	    for ifo in args.ifos:
-		opt_snrs_sqd += (f['injections/optimal_snr_%s' % ifo][:]**2,)
+if 'optimal_snr_1' in f['injections']:
+    opt_snr_1 = f['injections/optimal_snr_1'][:]
+    opt_snr_2 = f['injections/optimal_snr_2'][:]
+    dvals['comb_optimal_snr'] = numpy.sqrt(opt_snr_1 ** 2 + opt_snr_2 ** 2)
+    dvals['decisive_optimal_snr'] = numpy.where(opt_snr_1 < opt_snr_2, opt_snr_1, opt_snr_2)
+elif args.ifos:
+    opt_snrs_sqd = ()
+    for ifo in args.ifos:
+        opt_snrs_sqd += (f['injections/optimal_snr_%s' % ifo][:]**2,)
 
-	    dvals['comb_optimal_snr'] = [numpy.sqrt(sum(set_opt_snrs_sqd)) for set_opt_snrs_sqd in zip(*opt_snrs_sqd)]
-	    dvals['decisive_optimal_snr'] = [numpy.sqrt(sorted(set_opt_snrs_sqd)[-2]) for set_opt_snrs_sqd in zip(*opt_snrs_sqd)]
-	else:
-	    logging.error('IFOs not given in command line, and optimal_snr_1 not in input file. Needs one of them')
+    
+
+    dvals['comb_optimal_snr'] = numpy.array([numpy.sqrt(sum(set_opt_snrs_sqd)) for set_opt_snrs_sqd in zip(*opt_snrs_sqd)])
+    dvals['decisive_optimal_snr'] = numpy.array([numpy.sqrt(sorted(set_opt_snrs_sqd)[-2]) for set_opt_snrs_sqd in zip(*opt_snrs_sqd)])
+else:
+    logging.error('IFOs not given in command line, and optimal_snr_1 not in input file. Needs one of them')
 
 fdvals = dvals[args.distance_type][found]
 mdvals = dvals[args.distance_type][missed]

--- a/bin/hdfcoinc/pycbc_page_foundmissed
+++ b/bin/hdfcoinc/pycbc_page_foundmissed
@@ -88,11 +88,13 @@ elif args.ifos:
     for ifo in args.ifos:
         opt_snrs_sqd += (f['injections/optimal_snr_%s' % ifo][:]**2,)
 
-    dvals['comb_optimal_snr'] = [numpy.sqrt(sum(set_opt_snrs_sqd)) for set_opt_snrs_sqd in zip(*opt_snrs_sqd)]
-    dvals['decisive_optimal_snr'] = [numpy.sqrt(sorted(set_opt_snrs_sqd)[-2]) for set_opt_snrs_sqd in zip(*opt_snrs_sqd)]
+    
+
+    dvals['comb_optimal_snr'] = numpy.array([numpy.sqrt(sum(set_opt_snrs_sqd)) for set_opt_snrs_sqd in zip(*opt_snrs_sqd)])
+    dvals['decisive_optimal_snr'] = numpy.array([numpy.sqrt(sorted(set_opt_snrs_sqd)[-2]) for set_opt_snrs_sqd in zip(*opt_snrs_sqd)])
 else:
     logging.error('IFOs not given in command line, and optimal_snr_1 not in input file. Needs one of them')
-
+    exit()
 
 fdvals = dvals[args.distance_type][found]
 mdvals = dvals[args.distance_type][missed]

--- a/bin/hdfcoinc/pycbc_page_foundmissed
+++ b/bin/hdfcoinc/pycbc_page_foundmissed
@@ -31,8 +31,9 @@ parser.add_argument('--far-type', choices=('inclusive', 'exclusive'), default='i
                          "'exclusive'. Default = 'inclusive'")
 parser.add_argument('--missed-on-top', action='store_true',
                     help="Plot missed injections on top of found ones")
-parser.add_argument('--ifos', nargs='+',default=False,
-                    help="List of IFOs in search")
+parser.add_argument('--ifos', nargs='+', default=False,
+                    help="List of IFOs to use for displaying optimal SNR. If not given, "
+                         "H1L1 search will be assumed")
 parser.add_argument('--version', action='version', version=pycbc.version.git_verbose_msg)
 args = parser.parse_args()
 
@@ -68,32 +69,32 @@ vals['mtotal'] = m1 + m2
 vals['mass_ratio'] = numpy.maximum(m1/m2, m2/m1)
 
 dvals = {}
-if not args.ifos:
+if not args.ifos:  # behaviour with hard-coded H1L1 search for backwards compatibility
     hdist = f['injections/eff_dist_h'][:]
     ldist = f['injections/eff_dist_l'][:]
     dvals['decisive_distance'] = numpy.maximum(hdist, ldist)
-    dvals['dec_chirp_distance'] = pycbc.pnutils.chirp_distance(dvals['decisive_distance'], vals['mchirp'])
+    dvals['dec_chirp_distance'] = pycbc.pnutils.chirp_distance(
+                                                 dvals['decisive_distance'], vals['mchirp'])
 
 dvals['chirp_distance'] = pycbc.pnutils.chirp_distance(dist, vals['mchirp'])
 if args.distance_type == 'redshift':
     dvals['redshift'] = f['injections/redshift'][:]
 
-if 'optimal_snr_1' in f['injections']:
-    opt_snr_1 = f['injections/optimal_snr_1'][:]
-    opt_snr_2 = f['injections/optimal_snr_2'][:]
-    dvals['comb_optimal_snr'] = numpy.sqrt(opt_snr_1 ** 2 + opt_snr_2 ** 2)
-    dvals['decisive_optimal_snr'] = numpy.where(opt_snr_1 < opt_snr_2, opt_snr_1, opt_snr_2)
-elif args.ifos:
-    opt_snrs_sqd = ()
-    for ifo in args.ifos:
-        opt_snrs_sqd += (f['injections/optimal_snr_%s' % ifo][:]**2,)
-
-    
-
-    dvals['comb_optimal_snr'] = numpy.array([numpy.sqrt(sum(set_opt_snrs_sqd)) for set_opt_snrs_sqd in zip(*opt_snrs_sqd)])
-    dvals['decisive_optimal_snr'] = numpy.array([numpy.sqrt(sorted(set_opt_snrs_sqd)[-2]) for set_opt_snrs_sqd in zip(*opt_snrs_sqd)])
-else:
-    logging.error('IFOs not given in command line, and optimal_snr_1 not in input file. Needs one of them')
+if 'snr' in args.distance_type:  # only evaluate SNRs if needed
+    if 'optimal_snr_1' in f['injections']:  # old 2-ifo search behaviour
+        opt_snr_1 = f['injections/optimal_snr_1'][:]
+        opt_snr_2 = f['injections/optimal_snr_2'][:]
+        dvals['comb_optimal_snr'] = numpy.sqrt(opt_snr_1 ** 2. + opt_snr_2 ** 2.)
+        dvals['decisive_optimal_snr'] = numpy.where(opt_snr_1 < opt_snr_2, opt_snr_1, opt_snr_2)
+    elif args.ifos:
+        opt_snrsq_arr = (['injections/optimal_snr_%s' % ifo][:] ** 2. for ifo in args.ifos)
+        dvals['comb_optimal_snr'] = numpy.array([numpy.sqrt(sum(opt_snrsq)) 
+                                                 for opt_snrsq in zip(*opt_snrsq_arr)])
+        # Decisive optimal SNR is the 2nd largest optimal SNR
+        dvals['decisive_optimal_snr'] = numpy.array([numpy.sqrt(sorted(opt_snrsq)[-2]) \
+                                                     for opt_snrsq in zip(*opt_snrsq_arr)])
+    else:
+        raise RuntimeError('Need either --ifos option or optimal_snr_1 in input file to evaluate optimal SNRs')
 
 fdvals = dvals[args.distance_type][found]
 mdvals = dvals[args.distance_type][missed]
@@ -217,4 +218,3 @@ pycbc.results.save_fig_with_metadata\
     (fig, args.output_file, fig_kwds=fig_kwds,
      title='%s: %s vs %s' % (fig_title, args.axis_type, args.distance_type),
      cmd=' '.join(sys.argv), caption=caption)
-

--- a/bin/hdfcoinc/pycbc_page_foundmissed
+++ b/bin/hdfcoinc/pycbc_page_foundmissed
@@ -75,26 +75,23 @@ if not args.ifos:
     dvals['dec_chirp_distance'] = pycbc.pnutils.chirp_distance(dvals['decisive_distance'], vals['mchirp'])
 
 dvals['chirp_distance'] = pycbc.pnutils.chirp_distance(dist, vals['mchirp'])
-if args.distance_type == 'redshift':
-    dvals['redshift'] = f['injections/redshift'][:]
+		if args.distance_type == 'redshift':
+	    dvals['redshift'] = f['injections/redshift'][:]
 
-if 'optimal_snr_1' in f['injections']:
-    opt_snr_1 = f['injections/optimal_snr_1'][:]
-    opt_snr_2 = f['injections/optimal_snr_2'][:]
-    dvals['comb_optimal_snr'] = numpy.sqrt(opt_snr_1 ** 2 + opt_snr_2 ** 2)
-    dvals['decisive_optimal_snr'] = numpy.where(opt_snr_1 < opt_snr_2, opt_snr_1, opt_snr_2)
-elif args.ifos:
-    opt_snrs_sqd = ()
-    for ifo in args.ifos:
-        opt_snrs_sqd += (f['injections/optimal_snr_%s' % ifo][:]**2,)
+	if 'optimal_snr_1' in f['injections']:
+	    opt_snr_1 = f['injections/optimal_snr_1'][:]
+	    opt_snr_2 = f['injections/optimal_snr_2'][:]
+	    dvals['comb_optimal_snr'] = numpy.sqrt(opt_snr_1 ** 2 + opt_snr_2 ** 2)
+	    dvals['decisive_optimal_snr'] = numpy.where(opt_snr_1 < opt_snr_2, opt_snr_1, opt_snr_2)
+	elif args.ifos:
+	    opt_snrs_sqd = ()
+	    for ifo in args.ifos:
+		opt_snrs_sqd += (f['injections/optimal_snr_%s' % ifo][:]**2,)
 
-    
-
-    dvals['comb_optimal_snr'] = numpy.array([numpy.sqrt(sum(set_opt_snrs_sqd)) for set_opt_snrs_sqd in zip(*opt_snrs_sqd)])
-    dvals['decisive_optimal_snr'] = numpy.array([numpy.sqrt(sorted(set_opt_snrs_sqd)[-2]) for set_opt_snrs_sqd in zip(*opt_snrs_sqd)])
-else:
-    logging.error('IFOs not given in command line, and optimal_snr_1 not in input file. Needs one of them')
-    exit()
+	    dvals['comb_optimal_snr'] = [numpy.sqrt(sum(set_opt_snrs_sqd)) for set_opt_snrs_sqd in zip(*opt_snrs_sqd)]
+	    dvals['decisive_optimal_snr'] = [numpy.sqrt(sorted(set_opt_snrs_sqd)[-2]) for set_opt_snrs_sqd in zip(*opt_snrs_sqd)]
+	else:
+	    logging.error('IFOs not given in command line, and optimal_snr_1 not in input file. Needs one of them')
 
 fdvals = dvals[args.distance_type][found]
 mdvals = dvals[args.distance_type][missed]

--- a/bin/hdfcoinc/pycbc_page_foundmissed
+++ b/bin/hdfcoinc/pycbc_page_foundmissed
@@ -13,10 +13,12 @@ parser.add_argument('--injection-file',
 parser.add_argument('--axis-type', default='mchirp', choices=['mchirp',
                     'effective_spin', 'time', 'mtotal', 'mass_ratio'])
 parser.add_argument('--log-x', action='store_true', default=False)
-parser.add_argument('--distance-type', default='decisive_distance',
+parser.add_argument('--distance-type', default='decisive_optimal_snr',
                     choices=['decisive_distance', 'dec_chirp_distance',
                              'chirp_distance', 'comb_optimal_snr',
-                             'decisive_optimal_snr', 'redshift'])
+                             'decisive_optimal_snr', 'redshift'],
+                    help="Variable related to injected distance. Decisive distance and dec"
+                         " chirp distance only available for 2-ifo search")
 parser.add_argument('--plot-all-distance', action='store_true', default=False,
                     help="Plot all values of distance or SNR. If not given, "
                          "the plot will be truncated below 1")
@@ -88,13 +90,14 @@ if 'snr' in args.distance_type:  # only evaluate SNRs if needed
         dvals['decisive_optimal_snr'] = numpy.where(opt_snr_1 < opt_snr_2, opt_snr_1, opt_snr_2)
     elif args.ifos:
         opt_snrsq_arr = (['injections/optimal_snr_%s' % ifo][:] ** 2. for ifo in args.ifos)
-        dvals['comb_optimal_snr'] = numpy.array([numpy.sqrt(sum(opt_snrsq)) 
+        dvals['comb_optimal_snr'] = numpy.array([numpy.sqrt(sum(opt_snrsq))
                                                  for opt_snrsq in zip(*opt_snrsq_arr)])
         # Decisive optimal SNR is the 2nd largest optimal SNR
-        dvals['decisive_optimal_snr'] = numpy.array([numpy.sqrt(sorted(opt_snrsq)[-2]) \
+        dvals['decisive_optimal_snr'] = numpy.array([numpy.sqrt(sorted(opt_snrsq)[-2])
                                                      for opt_snrsq in zip(*opt_snrsq_arr)])
     else:
-        raise RuntimeError('Need either --ifos option or optimal_snr_1 in input file to evaluate optimal SNRs')
+        raise RuntimeError('Need either --ifos option or optimal_snr_1 in input file to evaluate '
+                           'optimal SNRs')
 
 fdvals = dvals[args.distance_type][found]
 mdvals = dvals[args.distance_type][missed]
@@ -156,7 +159,7 @@ else:
                           marker='o', label='found', zorder=zfound)
     caption = (fig_title + ": Red x's are missed injections. "
                "Circles are found injections. The color indicates the value of "
-               "the false alarm rate. " )
+               "the false alarm rate." )
     plot.subplots_adjust(right=0.99)
     try:
         c = plot.colorbar()


### PR DESCRIPTION
needs extra input of --ifos to determine the multi-ifo nature of the input file

Adding ability to deal with hdf_injfind output as updated in #2499 

Note that decisive_distance and dec_chirp_distance are no longer sensible things to plot, so are ignored in the multi-ifo case