### PR TITLE
Only use ACL from nacl test if it is the only test being done

### DIFF
--- a/pycbc/inference/burn_in.py
+++ b/pycbc/inference/burn_in.py
@@ -253,8 +253,10 @@ class MCMCBurnInTests(object):
         Since we calculate the acls, this will also store it to the sampler.
         """
         acls = self.sampler.compute_acl(filename, start_index=start_index)
-        # since we calculated it, save the acls to the sampler
-        self.sampler.acls = acls
+        # since we calculated it, save the acls to the sampler...
+        # but only do this if this is the only burn in test
+        if len(self.do_tests) == 1:
+            self.sampler.acls = acls
         return acls
 
     def halfchain(self, filename):


### PR DESCRIPTION
Currently, the `nacl` burn in test will save the ACL it gets to the sampler's ACL, so that the sampler doesn't try to recalculate it. This was done as a time saving measure; it's fine if `nacl` is the only test being used. However, if multiple tests are being used -- e.g., `nacl & max_posterior` -- and the other test results in a burn in iteration after the `nacl` then the ACL saved will be wrong.

This patch fixes that by turning off saving the ACL in the `nacl` test if more than one burn in is specified. This will result in calculating the ACL twice on each checkpoint, but the thinning patch has made this a faster calculation anyway.