### PR TITLE
Fix marginal phase

### DIFF
--- a/pycbc/inference/models/__init__.py
+++ b/pycbc/inference/models/__init__.py
@@ -23,7 +23,7 @@ assuming various noise models.
 from .analytic import (TestEggbox, TestNormal, TestRosenbrock, TestVolcano,
                        TestPrior)
 from .gaussian_noise import GaussianNoise
-from .marginalized_gaussian_noise import MarginalizedGaussianNoise
+from .marginalized_gaussian_noise import (MarginalizedPhaseGaussianNoise, MarginalizedGaussianNoise)
 from .single_template import SingleTemplate
 
 
@@ -180,6 +180,7 @@ models = {_cls.name: _cls for _cls in (
     TestVolcano,
     TestPrior,
     GaussianNoise,
+    MarginalizedPhaseGaussianNoise,
     MarginalizedGaussianNoise,
     SingleTemplate
 )}

--- a/pycbc/inference/models/__init__.py
+++ b/pycbc/inference/models/__init__.py
@@ -23,7 +23,8 @@ assuming various noise models.
 from .analytic import (TestEggbox, TestNormal, TestRosenbrock, TestVolcano,
                        TestPrior)
 from .gaussian_noise import GaussianNoise
-from .marginalized_gaussian_noise import (MarginalizedPhaseGaussianNoise, MarginalizedGaussianNoise)
+from .marginalized_gaussian_noise import (MarginalizedPhaseGaussianNoise,
+                                          MarginalizedGaussianNoise)
 from .single_template import SingleTemplate
 
 

--- a/pycbc/inference/models/marginalized_gaussian_noise.py
+++ b/pycbc/inference/models/marginalized_gaussian_noise.py
@@ -157,7 +157,7 @@ class MarginalizedPhaseGaussianNoise(GaussianNoise):
             hd += hd_i
         hd = abs(hd)
         self._current_stats.maxl_phase = numpy.angle(hd)
-        return numpy.log(special.i0e(hd)) + hd - 0.5*hh 
+        return numpy.log(special.i0e(hd)) + hd - 0.5*hh
 
 
 class MarginalizedGaussianNoise(GaussianNoise):

--- a/pycbc/inference/models/marginalized_gaussian_noise.py
+++ b/pycbc/inference/models/marginalized_gaussian_noise.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2018  Charlie Hoy
+# Copyright (C) 2018  Charlie Hoy, Collin Capano
 # This program is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License as published by the
 # Free Software Foundation; either version 3 of the License, or (at your
@@ -27,6 +27,137 @@ from pycbc.distributions import read_distributions_from_config
 from pycbc.waveform import generator
 
 from .gaussian_noise import GaussianNoise
+
+
+class MarginalizedPhaseGaussianNoise(GaussianNoise):
+    r"""The likelihood is analytically marginalized over phase.
+
+    This class can be used with signal models that can be written as:
+
+    .. math::
+
+        \tilde{h}(f; \Theta, \phi) = A(f; \Theta)e^{i\Psi(f; \Theta) + i \phi},
+
+    where :math:`\phi` is an arbitrary phase constant. This phase constant
+    can be analytically marginalized over with a uniform prior as follows:
+    assuming the noise is stationary and Gaussian (see `GaussianNoise`
+    for details), the posterior is:
+
+    .. math::
+
+        p(\Theta,\phi|d)
+            &\propto p(\Theta)p(\phi)p(d|\Theta,\phi) \\
+            &\propto p(\Theta)\frac{1}{2\pi}\exp\left[
+                -\frac{1}{2}\sum_{i}^{N_D} \left<
+                    h_i(\Theta,\phi) - d_i, h_i(\Theta,\phi) - d_i
+                \right>\right].
+
+    Here, the sum is over the number of detectors :math:`N_D`, :math:`d_i`
+    and :math:`h_i` are the data and signal in detector :math:`i`,
+    respectively, and we have assumed a uniform prior on :math:`phi \in [0,
+    2\pi)`. With the form of the signal model given above, the inner product
+    in the exponent can be written as:
+
+    .. math::
+
+        -\frac{1}{2}\left<h_i - d_i, h_i- d_i\right>
+            &= \left<h_i, d_i\right> -
+               \frac{1}{2}\left<h_i, h_i\right> -
+               \frac{1}{2}\left<d_i, d_i\right> \\
+            &= \Re\left\{O(h^0_i, d_i)e^{-i\phi}\right\} -
+               \frac{1}{2}\left<h^0_i, h^0_i\right> -
+               \frac{1}{2}\left<d_i, d_i\right>,
+
+    where:
+
+    .. math::
+
+        h_i^0 &\equiv \tilde{h}_i(f; \Theta, \phi=0); \\
+        O(h^0_i, d_i) &\equiv 4 \int_0^\infty
+            \frac{\tilde{h}_i^*(f; \Theta,0)\tilde{d}_i(f)}{S_n(f)}\mathrm{d}f.
+
+    Gathering all of the terms that are not dependent on :math:`\phi` together:
+
+    .. math::
+
+        \alpha(\Theta, d) \equiv \exp\left[-\frac{1}{2}\sum_i
+            \left<h^0_i, h^0_i\right> + \left<d_i, d_i\right>\right],
+
+    we can marginalize the posterior over :math:`\phi`:
+
+    .. math::
+
+        p(\Theta|d)
+            &\propto p(\Theta)\alpha(\Theta,d)\frac{1}{2\pi}
+                     \int_{0}^{2\pi}\exp\left[\Re \left\{
+                         e^{-i\phi} \sum_i O(h^0_i, d_i)
+                     \right\}\right]\mathrm{d}\phi \\
+            &\propto p(\Theta)\alpha(\Theta, d)\frac{1}{2\pi}
+                     \int_{0}^{2\pi}\exp\left[
+                         x(\Theta,d)\cos(\phi) + y(\Theta, d)\sin(\phi)
+                     \right]\mathrm{d}\phi.
+
+    The integral in the last line is equal to :math:`2\pi I_0(\sqrt{x^2+y^2})`,
+    where :math:`I_0` is the modified Bessel function of the first kind. Thus
+    the marginalized log posterior is:
+
+    .. math::
+
+        \log p(\Theta|d) \propto \log p(\Theta) +
+            I_0\left(\left|\sum_i O(h^0_i, d_i)\right|\right) -
+            \frac{1}{2}\sum_i\left[ \left<h^0_i, h^0_i\right> -
+                                    \left<d_i, d_i\right> \right]
+    """
+    name = 'marginalized_phase'
+
+    @property
+    def _extra_stats(self):
+        """Adds ``loglr``, plus ``cplx_loglr`` and ``optimal_snrsq`` in each
+        detector."""
+        return ['loglr', 'maxl_phase'] + \
+               ['{}_optimal_snrsq'.format(det) for det in self._data]
+
+    def _loglr(self):
+        r"""Computes the log likelihood ratio,
+        .. math::
+            \log \mathcal{L}(\Theta) =
+                I_0 \left(\left|\sum_i O(h^0_i, d_i)\right|\right) -
+                \frac{1}{2}\left<h^0_i, h^0_i\right>,
+        at the current point in parameter space :math:`\Theta`.
+        Returns
+        -------
+        float
+            The value of the log likelihood ratio evaluated at the given point.
+        """
+        params = self.current_params
+        try:
+            wfs = self._waveform_generator.generate(**params)
+        except NoWaveformError:
+            return self._nowaveform_loglr()
+        hh = 0.
+        hd = 0j
+        for det, h in wfs.items():
+            # the kmax of the waveforms may be different than internal kmax
+            kmax = min(len(h), self._kmax)
+            if self._kmin >= kmax:
+                # if the waveform terminates before the filtering low frequency
+                # cutoff, then the loglr is just 0 for this detector
+                hh_i = 0.
+                hd_i = 0j
+            else:
+                # whiten the waveform
+                h[self._kmin:kmax] *= self._weight[det][self._kmin:kmax]
+                # calculate inner products
+                hh_i = h[self._kmin:kmax].inner(h[self._kmin:kmax]).real
+                hd_i = self.data[det][self._kmin:kmax].inner(
+                    h[self._kmin:kmax])
+            # store
+            setattr(self._current_stats, '{}_optimal_snrsq'.format(det), hh_i)
+            hh += hh_i
+            hd += hd_i
+        hd = abs(hd)
+        self._current_stats.maxl_phase = numpy.angle(hd)
+        return numpy.log(special.i0e(hd)) + hd - 0.5*hh 
 
 
 class MarginalizedGaussianNoise(GaussianNoise):


### PR DESCRIPTION
This puts the `MarginalizedPhaseGaussianNoise` back into the models module, as it is currently broken in `MarginalizedGaussianNoise`. For now, I'll leave `MarginalizedGaussianNoise` in there. In retrospect, having Charlie stick all the possible marginalizations into a single class was a bad idea. The plan now is to slowly move out all of the different combinations of marginalizations (6) into their own classes. Once that is done, `MarginalizedGaussianNoise` should be removed.

This supercedes #2423.