### PR TITLE
Only allow master process to print to screen when using mpi

### DIFF
--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -93,6 +93,11 @@ strain.add_gate_option_group(parser)
 opts = parser.parse_args()
 
 # setup log
+# If we're running in MPI mode, only allow the parent to print
+if opts.use_mpi:
+    from mpi4py import MPI
+    rank = MPI.COMM_WORLD.Get_rank()
+    opts.verbose &= rank == 0
 pycbc.init_logging(opts.verbose)
 
 # verify options are sane


### PR DESCRIPTION
Currently, when you use MPI, all of the child processes print to screen before the pool is made, making for a bunch of repeated, confusing output. This shuts off logging for all child processes, so only the parent process prints.