### PR TITLE
Turnoff recalculating Jacobian in emcee pt

### DIFF
--- a/pycbc/inference/sampler/emcee_pt.py
+++ b/pycbc/inference/sampler/emcee_pt.py
@@ -158,20 +158,21 @@ class EmceePTSampler(MultiTemperedAutocorrSupport, MultiTemperedSupport,
         logl = self._sampler.lnlikelihood
         # get prior from posterior
         logp = self._sampler.lnprobability - logl
-        logjacobian = numpy.zeros(logp.size)
+        logjacobian = numpy.zeros(logp.shape)
+        #logjacobian = numpy.zeros(logp.size)
         # if different coordinates were used for sampling, get the jacobian
-        if self.model.sampling_transforms is not None:
-            samples = self.samples
-            flattened_samples = {param: arr.ravel()
-                                 for param, arr in samples.items()}
-            for ii in range(logp.size):
-                these_samples = {param: vals[ii]
-                                 for param, vals in flattened_samples.items()}
-                self.model.update(**these_samples)
-                logjacobian[ii] = self.model.logjacobian
-        logjacobian = logjacobian.reshape(logp.shape)
+        #if self.model.sampling_transforms is not None:
+        #    samples = self.samples
+        #    flattened_samples = {param: arr.ravel()
+        #                         for param, arr in samples.items()}
+        #    for ii in range(logp.size):
+        #        these_samples = {param: vals[ii]
+        #                         for param, vals in flattened_samples.items()}
+        #        self.model.update(**these_samples)
+        #        logjacobian[ii] = self.model.logjacobian
+        #logjacobian = logjacobian.reshape(logp.shape)
         # put the logprior into the variable_params space
-        logp -= logjacobian
+        #logp -= logjacobian
         return {'loglikelihood': logl, 'logprior': logp,
                 'logjacobian': logjacobian}
 

--- a/pycbc/inference/sampler/emcee_pt.py
+++ b/pycbc/inference/sampler/emcee_pt.py
@@ -151,28 +151,23 @@ class EmceePTSampler(MultiTemperedAutocorrSupport, MultiTemperedSupport,
         The returned array has shape ntemps x nwalkers x niterations.
 
         Unfortunately, because ``emcee_pt`` does not have blob support, this
-        will only return the loglikelihood, logprior, and logjacobian,
-        regardless of what stats the model can return.
+        will only return the loglikelihood and logprior (with the logjacobian
+        set to zero) regardless of what stats the model can return.
+
+
+        .. warning::
+            Since the `logjacobian` is not saved by `emcee_pt`, the `logprior`
+            returned here is the log of the prior pdf in the sampling
+            coordinate frame rather than the variable params frame. This
+            differs from the variable params frame by the log of the Jacobian
+            of the transform from one frame to the other. If no sampling
+            transforms were used, then the `logprior` is the same.
         """
         # likelihood has shape ntemps x nwalkers x niterations
         logl = self._sampler.lnlikelihood
         # get prior from posterior
         logp = self._sampler.lnprobability - logl
         logjacobian = numpy.zeros(logp.shape)
-        #logjacobian = numpy.zeros(logp.size)
-        # if different coordinates were used for sampling, get the jacobian
-        #if self.model.sampling_transforms is not None:
-        #    samples = self.samples
-        #    flattened_samples = {param: arr.ravel()
-        #                         for param, arr in samples.items()}
-        #    for ii in range(logp.size):
-        #        these_samples = {param: vals[ii]
-        #                         for param, vals in flattened_samples.items()}
-        #        self.model.update(**these_samples)
-        #        logjacobian[ii] = self.model.logjacobian
-        #logjacobian = logjacobian.reshape(logp.shape)
-        # put the logprior into the variable_params space
-        #logp -= logjacobian
         return {'loglikelihood': logl, 'logprior': logp,
                 'logjacobian': logjacobian}
 


### PR DESCRIPTION
EmceePT does not have blob data support. This means that the only statistics that you can retrieve from it are the log likelihood and the log prior. If sampling transforms are used, then the log prior is the log prior in the sampling coordinate frame rather than the variable parameter frame. Currently, the code tries to fix this by recalculating the log Jacobian and subtracting it from the log prior before returning model stats. Since this is only done on the parent process, this can make checkpointing take nearly as long as it takes to run the sampler. For example, in a run using 1000 walkers and 4 temperatures, calculating the log Jacobian for every point took up to 40 minutes, which doubled the wall clock time of the run.

This patch fixes this by turning off the log Jacobian recalculation. This means that the log prior stored in `emcee_pt` files will be the `logprior` of the sampling coordinate frame, but since we rarely use that (and since it can always be recalculated by loading the prior from the config file), it's a fair trade off. In the 1000 walker, 4 temperature run above, this reduced the time it took to checkpoint from 40 minutes to a couple of minutes. I've added a warning box to the doc string of `EmceePTSampler.model_stats` to point out the difference.