### PR TITLE
Priors on 1D marginal posterior plots

### DIFF
--- a/bin/inference/pycbc_inference_plot_posterior
+++ b/bin/inference/pycbc_inference_plot_posterior
@@ -120,8 +120,9 @@ if opts.plot_prior is not None:
                          "--plot-prior")
     logging.info("Loading prior")
     cp = WorkflowConfigParser(opts.plot_prior)
-    prior_samples = option_utils.prior_samples_from_config(
-        cp, nsamples=opts.prior_nsamples)
+    prior = option_utils.prior_samples_from_config(cp)
+    logging.info("Drawing samples from prior")
+    prior_samples = prior.rvs(opts.prior_nsamples)
     _, ts = transforms.get_common_cbc_transforms(
         opts.parameters, prior_samples.fieldnames)
     # add parameters not included in file

--- a/bin/inference/pycbc_inference_plot_posterior
+++ b/bin/inference/pycbc_inference_plot_posterior
@@ -120,7 +120,7 @@ if opts.plot_prior is not None:
                          "--plot-prior")
     logging.info("Loading prior")
     cp = WorkflowConfigParser(opts.plot_prior)
-    prior = option_utils.prior_samples_from_config(cp)
+    prior = option_utils.prior_from_config(cp)
     logging.info("Drawing samples from prior")
     prior_samples = prior.rvs(opts.prior_nsamples)
     _, ts = transforms.get_common_cbc_transforms(

--- a/bin/inference/pycbc_inference_plot_posterior
+++ b/bin/inference/pycbc_inference_plot_posterior
@@ -41,6 +41,7 @@ from pycbc.results import metadata
 from pycbc import __version__
 from pycbc.workflow import WorkflowConfigParser
 from pycbc.inference import (option_utils, io)
+from pycbc import transforms
 
 from pycbc.results.scatter_histograms import create_multidim_plot
 
@@ -57,7 +58,7 @@ parser.add_argument("--verbose", action="store_true", default=False,
                     help="Be verbose")
 parser.add_argument("--plot-prior", nargs="+", type=str,
                     help="Plot the prior on the 1D marginal plots using the "
-                         "given config file.")
+                         "given config file(s).")
 parser.add_argument("--prior-nsamples", type=int, default=10000,
                     help="The number of samples to use for plotting the "
                          "prior. Default is 10000.")
@@ -97,17 +98,6 @@ else:
 for fp in fps:
     fp.close()
 
-if opts.plot_prior is not None:
-    logging.info("Loading prior")
-    cp = WorkflowConfigParser(opts.plot_prior)
-    prior_samples = option_utils.prior_samples_from_config(
-        cp, nsamples=opts.prior_nsamples)
-    from pycbc import transforms
-    _, ts = transforms.get_common_cbc_transforms(
-        opts.parameters, prior_samples.fieldnames)
-    # add parameters not included in file
-    prior_samples = transforms.apply_transforms(prior_samples, ts)
-
 # if no plotting options selected, then the default options are based
 # on the number of parameters
 plot_options = [opts.plot_marginal, opts.plot_scatter, opts.plot_density]
@@ -121,6 +111,21 @@ if not numpy.any(plot_options):
         # of give only plot_scatter and that should be the default for
         # two or more parameters
         opts.plot_marginal = True
+
+if opts.plot_prior is not None:
+    # check that we're plotting 1D marginals
+    if not opts.plot_marginal:
+        raise ValueError("prior may only be plotted on 1D marginal plot; "
+                         "either turn on --plot-marginal, or turn off "
+                         "--plot-prior")
+    logging.info("Loading prior")
+    cp = WorkflowConfigParser(opts.plot_prior)
+    prior_samples = option_utils.prior_samples_from_config(
+        cp, nsamples=opts.prior_nsamples)
+    _, ts = transforms.get_common_cbc_transforms(
+        opts.parameters, prior_samples.fieldnames)
+    # add parameters not included in file
+    prior_samples = transforms.apply_transforms(prior_samples, ts)
 
 # get minimum and maximum ranges for each parameter from command line
 mins, maxs = option_utils.plot_ranges_from_cli(opts)
@@ -212,21 +217,13 @@ if opts.plot_prior:
     if len(opts.input_file) > 1:
         hist_color = colors.next()
     fig, axis_dict = create_multidim_plot(
-        parameters, prior_samples,
-        fig=fig, axis_dict=axis_dict,
-        labels=labels,
-        plot_marginal=True,
-        marginal_percentiles=[],
-        plot_scatter=False,
-        plot_density=False,
-        plot_contours=False,
+        parameters, prior_samples, fig=fig, axis_dict=axis_dict,
+        labels=labels, plot_marginal=True, marginal_percentiles=[],
+        plot_scatter=False, plot_density=False, plot_contours=False,
         fill_color=None,
-        marginal_title=False,
-        marginal_linestyle=':',
+        marginal_title=False, marginal_linestyle=':',
         hist_color=hist_color,
-        mins=mins, maxs=maxs,
-        )
-        #contour_percentiles=[50, 90],)
+        mins=mins, maxs=maxs)
 
 # add legend to upper right for input files
 if len(opts.input_file) > 1:

--- a/bin/inference/pycbc_inference_plot_posterior
+++ b/bin/inference/pycbc_inference_plot_posterior
@@ -39,6 +39,7 @@ import pycbc.version
 from pycbc.results import metadata
 
 from pycbc import __version__
+from pycbc.workflow import WorkflowConfigParser
 from pycbc.inference import (option_utils, io)
 
 from pycbc.results.scatter_histograms import create_multidim_plot
@@ -54,6 +55,12 @@ parser.add_argument("--output-file", type=str, required=True,
                     help="Output plot path.")
 parser.add_argument("--verbose", action="store_true", default=False,
                     help="Be verbose")
+parser.add_argument("--plot-prior", nargs="+", type=str,
+                    help="Plot the prior on the 1D marginal plots using the "
+                         "given config file.")
+parser.add_argument("--prior-nsamples", type=int, default=10000,
+                    help="The number of samples to use for plotting the "
+                         "prior. Default is 10000.")
 # add options for what plots to create
 option_utils.add_plot_posterior_option_group(parser)
 # scatter configuration
@@ -89,6 +96,17 @@ else:
 # closet the files, we don't need them anymore
 for fp in fps:
     fp.close()
+
+if opts.plot_prior is not None:
+    logging.info("Loading prior")
+    cp = WorkflowConfigParser(opts.plot_prior)
+    prior_samples = option_utils.prior_samples_from_config(
+        cp, nsamples=opts.prior_nsamples)
+    from pycbc import transforms
+    _, ts = transforms.get_common_cbc_transforms(
+        opts.parameters, prior_samples.fieldnames)
+    # add parameters not included in file
+    prior_samples = transforms.apply_transforms(prior_samples, ts)
 
 # if no plotting options selected, then the default options are based
 # on the number of parameters
@@ -182,12 +200,33 @@ for (i, s) in enumerate(samples):
                     density_cmap=opts.density_cmap,
                     contour_color=contour_color,
                     hist_color=hist_color,
-                    line_color=contour_color,
+                    line_color=linecolor,
                     fill_color=fill_color,
                     use_kombine=opts.use_kombine_kde,
                     mins=mins, maxs=maxs,
                     expected_parameters=expected_parameters,
                     expected_parameters_color=opts.expected_parameters_color)
+
+# plot the prior
+if opts.plot_prior:
+    if len(opts.input_file) > 1:
+        hist_color = colors.next()
+    fig, axis_dict = create_multidim_plot(
+        parameters, prior_samples,
+        fig=fig, axis_dict=axis_dict,
+        labels=labels,
+        plot_marginal=True,
+        marginal_percentiles=[],
+        plot_scatter=False,
+        plot_density=False,
+        plot_contours=False,
+        fill_color=None,
+        marginal_title=False,
+        marginal_linestyle=':',
+        hist_color=hist_color,
+        mins=mins, maxs=maxs,
+        )
+        #contour_percentiles=[50, 90],)
 
 # add legend to upper right for input files
 if len(opts.input_file) > 1:

--- a/bin/inference/pycbc_inference_plot_prior
+++ b/bin/inference/pycbc_inference_plot_prior
@@ -67,8 +67,8 @@ parser.add_argument("--parameters", nargs="+", action=ParseParametersArg,
                          "provided, will plot all of the parameters in the "
                          "[variable_params] section of the config file.")
 parser.add_argument("--sections", type=str, nargs="+", default=["prior"],
-                    help="Name of section plus with distribution "
-                         "configurations. Default is 'prior'.")
+                    help="Name of section with distribution configurations. "
+                         "Default is 'prior'.")
 # add output options
 parser.add_argument("--nsamples", type=int, default=10000,
                     help="The number of samples to draw from the prior for "

--- a/bin/inference/pycbc_inference_plot_prior
+++ b/bin/inference/pycbc_inference_plot_prior
@@ -67,12 +67,12 @@ parser.add_argument("--parameters", nargs="+", action=ParseParametersArg,
                          "provided, will plot all of the parameters in the "
                          "[variable_params] section of the config file.")
 parser.add_argument("--sections", type=str, nargs="+", default=["prior"],
-                    help="Name of section plus subsection with distribution "
-                         "configurations, eg. prior-mass1.")
+                    help="Name of section plus with distribution "
+                         "configurations. Default is 'prior'.")
 # add output options
 parser.add_argument("--nsamples", type=int, default=10000,
                     help="The number of samples to draw from the prior for "
-                         "plotting. Defaults is 10000.")
+                         "plotting. Default is 10000.")
 parser.add_argument("--output-file", type=str, required=True,
                     help="Path to output plot.")
 # verbose option

--- a/bin/inference/pycbc_inference_plot_prior
+++ b/bin/inference/pycbc_inference_plot_prior
@@ -126,12 +126,9 @@ fig, axis_dict = create_multidim_plot(
 fig.set_dpi(200)
 
 # save figure with meta-data
-caption_kwargs = {
-    "parameters" : ", ".join([param for param in variable_params])
-}
 caption = """This plot shows the probability density function (PDF) from the 
 prior distributions."""
-title = """Prior Distributions for {parameters}""".format(**caption_kwargs)
+title = "Prior Distribution"
 results.save_fig_with_metadata(fig, opts.output_file,
                                cmd=" ".join(sys.argv),
                                title=title,

--- a/bin/inference/pycbc_inference_plot_prior
+++ b/bin/inference/pycbc_inference_plot_prior
@@ -30,7 +30,8 @@ from matplotlib import pyplot as plt
 import pycbc
 from pycbc import __version__
 from pycbc import (distributions, results)
-from pycbc.inference.option_utils import ParseParametersArg
+from pycbc.inference.option_utils import (ParseParametersArg,
+                                          prior_samples_from_config)
 from pycbc.workflow import WorkflowConfigParser
 from pycbc.results.scatter_histograms import create_multidim_plot
 
@@ -90,33 +91,9 @@ pycbc.init_logging(opts.verbose)
 logging.info("Reading configuration files")
 cp = WorkflowConfigParser(opts.config_files)
 
-# get prior distribution for each variable parameter
-# parse command line values for section and subsection
-# if only section then look for subsections
-# and add distributions to list
-logging.info("Constructing prior")
-variable_params = []
-dists = []
-for sec in opts.sections:
-    section = sec.split("-")[0]
-    subsec = sec.split("-")[1:]
-    if len(subsec):
-        subsections = ["-".join(subsec)]
-    else:
-        subsections = cp.get_subsections(section)
-    for subsection in subsections:
-        name = cp.get_opt_tag(section, "name", subsection)
-        dist = distributions.distribs[name].from_config(
-                                            cp, section, subsection)
-        variable_params += dist.params
-        dists.append(dist)
-variable_params = sorted(variable_params)
-ndim = len(variable_params)
-
-# construct class that will return draws from the prior
-logging.info("Drawing samples")
-prior = distributions.JointDistribution(variable_params, *dists)
-samples = prior.rvs(opts.nsamples)
+logging.info("Drawing samples from prior")
+samples = prior_samples_from_config(cp, sections=opts.sections,
+                                    nsamples=opts.nsamples)
 
 # figure out what parameters to plot
 if opts.parameters is None:

--- a/bin/inference/pycbc_inference_plot_prior
+++ b/bin/inference/pycbc_inference_plot_prior
@@ -29,9 +29,9 @@ from matplotlib import pyplot as plt
 
 import pycbc
 from pycbc import __version__
-from pycbc import (distributions, results)
+from pycbc import (distributions, results, waveform)
 from pycbc.inference.option_utils import (ParseParametersArg,
-                                          prior_samples_from_config)
+                                          prior_from_config)
 from pycbc.workflow import WorkflowConfigParser
 from pycbc.results.scatter_histograms import create_multidim_plot
 
@@ -91,14 +91,21 @@ pycbc.init_logging(opts.verbose)
 logging.info("Reading configuration files")
 cp = WorkflowConfigParser(opts.config_files)
 
+logging.info("Loading prior")
+prior = prior_from_config(cp, sections=opts.sections)
 logging.info("Drawing samples from prior")
-samples = prior_samples_from_config(cp, sections=opts.sections,
-                                    nsamples=opts.nsamples)
+samples = prior.rvs(opts.nsamples)
 
 # figure out what parameters to plot
 if opts.parameters is None:
-    parameters = variable_params
-    labels = {param: param for param in variable_params}
+    parameters = prior.variable_args
+    labels = {}
+    for param in parameters:
+        # try to get the parameter label from the waveform module
+        try:
+            labels[param] = getattr(waveform.parameters, param).label
+        except AttributeError:
+            labels[param] = param
 else:
     parameters = opts.parameters
     labels = opts.parameters_labels

--- a/pycbc/inference/option_utils.py
+++ b/pycbc/inference/option_utils.py
@@ -467,7 +467,7 @@ def add_density_option_group(parser):
 
 def prior_from_config(cp, sections=None):
     """Loads a prior distribution from the given config file.
-    
+
     Parameters
     ----------
     cp : pycbc.workflow.WorkflowConfigParser
@@ -492,14 +492,14 @@ def prior_from_config(cp, sections=None):
     for sec in sections:
         section = sec.split("-")[0]
         subsec = sec.split("-")[1:]
-        if len(subsec):
+        if len(subsec) > 0:
             subsections = ["-".join(subsec)]
         else:
             subsections = cp.get_subsections(section)
         for subsection in subsections:
             name = cp.get_opt_tag(section, "name", subsection)
             dist = distributions.distribs[name].from_config(
-                                                cp, section, subsection)
+                cp, section, subsection)
             variable_params += dist.params
             dists.append(dist)
     # construct class that will return draws from the prior

--- a/pycbc/inference/option_utils.py
+++ b/pycbc/inference/option_utils.py
@@ -465,8 +465,8 @@ def add_density_option_group(parser):
     return density_group
 
 
-def prior_samples_from_config(cp, sections=None, nsamples=10000):
-    """Creates a set of random samples from the given config file.
+def prior_from_config(cp, sections=None):
+    """Loads a prior distribution from the given config file.
     
     Parameters
     ----------
@@ -475,14 +475,11 @@ def prior_samples_from_config(cp, sections=None, nsamples=10000):
     sections : list of str, optional
         The sections to retrieve the prior from. If ``None`` (the default),
         will look in sections starting with 'prior'.
-    nsamples : int, optional
-        The number of samples to draw for plotting the prior. Default is
-        10000.
 
     Returns
     -------
-    FieldArray :
-        The prior samples, as a ``FieldArray``.
+    distributions.JointDistribution
+        The prior distribution.
     """
     # get prior distribution for each variable parameter
     # parse command line values for section and subsection
@@ -506,5 +503,4 @@ def prior_samples_from_config(cp, sections=None, nsamples=10000):
             variable_params += dist.params
             dists.append(dist)
     # construct class that will return draws from the prior
-    prior = distributions.JointDistribution(variable_params, *dists)
-    return prior.rvs(nsamples)
+    return distributions.JointDistribution(variable_params, *dists)

--- a/pycbc/inference/option_utils.py
+++ b/pycbc/inference/option_utils.py
@@ -466,7 +466,24 @@ def add_density_option_group(parser):
 
 
 def prior_samples_from_config(cp, sections=None, nsamples=10000):
-    """Creates a set of random samples from the given config file."""
+    """Creates a set of random samples from the given config file.
+    
+    Parameters
+    ----------
+    cp : pycbc.workflow.WorkflowConfigParser
+        The config file to read.
+    sections : list of str, optional
+        The sections to retrieve the prior from. If ``None`` (the default),
+        will look in sections starting with 'prior'.
+    nsamples : int, optional
+        The number of samples to draw for plotting the prior. Default is
+        10000.
+
+    Returns
+    -------
+    FieldArray :
+        The prior samples, as a ``FieldArray``.
+    """
     # get prior distribution for each variable parameter
     # parse command line values for section and subsection
     # if only section then look for subsections

--- a/pycbc/results/scatter_histograms.py
+++ b/pycbc/results/scatter_histograms.py
@@ -322,9 +322,11 @@ def create_marginalized_hist(ax, values, label, percentiles=None,
         What line style to use for the histogram. Default is '-'.
     linecolor : {'navy', string}
         What color to use for the percentile lines. Default is 'navy'.
-    title : {True, bool}
-        Add a title with the median value +/- uncertainty, with the
-        max(min) `percentile` used for the +(-) uncertainty.
+    title : bool, optional
+        Add a title with a estimated value +/- uncertainty. The estimated value
+        is the pecentile corresponding to the average of ``percentiles`` +/-
+        the max/min of the ``percentiles``. If no percentiles are specified,
+        defaults to quoting the median +/- 95/5 percentiles.
     rotated : {False, bool}
         Plot the histogram on the y-axis instead of the x. Default is False.
     plot_min : {None, float}
@@ -349,9 +351,11 @@ def create_marginalized_hist(ax, values, label, percentiles=None,
             density=True)
     if percentiles is None:
         percentiles = [5., 50., 95.]
-    if percentiles:
-        percentiles = numpy.percentile(values, percentiles)
-    for val in percentiles:
+    if len(percentiles) > 0:
+        plotp = numpy.percentile(values, percentiles)
+    else:
+        plotp = []
+    for val in plotp:
         if rotated:
             ax.axhline(y=val, ls='dashed', color=linecolor, lw=2, zorder=3)
         else:
@@ -363,8 +367,7 @@ def create_marginalized_hist(ax, values, label, percentiles=None,
         else:
             ax.axvline(expected_value, color=expected_color, lw=1.5, zorder=2)
     if title:
-        values_med = numpy.median(values)
-        if len(percentiles) >= 2:
+        if len(percentiles) > 0:
             minp = min(percentiles)
             medp = numpy.array(percentiles).mean()
             maxp = max(percentiles)
@@ -539,8 +542,12 @@ def create_multidim_plot(parameters, samples, labels=None,
         If None, will draw lines at `[5, 50, 95]` (i.e., the bounds on the
         upper 90th percentile and the median).
     marginal_title : bool, optional
-        Whether or not to print a title over the marginal plots giving the
-        90% confidence interval. Default is True.
+        Add a title over the 1D marginal plots that gives an estimated value
+        +/- uncertainty. The estimated value is the pecentile corresponding to
+        the average of ``marginal_percentiles`` +/- the max/min of the
+        ``marginal_percentiles``. If no percentiles are specified in
+        ``marginal_percentiles``, defaults to quoting the median +/- 95/5
+        percentiles.
     marginal_linestyle : str, optional
         What line style to use for the marginal histograms.
     contour_percentiles : {None, array}

--- a/pycbc/results/scatter_histograms.py
+++ b/pycbc/results/scatter_histograms.py
@@ -364,8 +364,17 @@ def create_marginalized_hist(ax, values, label, percentiles=None,
             ax.axvline(expected_value, color=expected_color, lw=1.5, zorder=2)
     if title:
         values_med = numpy.median(values)
-        values_min = numpy.percentile(values, 5.)
-        values_max = numpy.percentile(values, 95.)
+        if len(percentiles) >= 2:
+            minp = min(percentiles)
+            medp = numpy.array(percentiles).mean()
+            maxp = max(percentiles)
+        else:
+            minp = 5
+            medp = 50
+            maxp = 95
+        values_min = numpy.percentile(values, minp)
+        values_med = numpy.percentile(values, medp)
+        values_max = numpy.percentile(values, maxp)
         negerror = values_med - values_min
         poserror = values_max - values_med
         fmt = '${0}$'.format(str_utils.format_value(

--- a/pycbc/results/scatter_histograms.py
+++ b/pycbc/results/scatter_histograms.py
@@ -529,6 +529,9 @@ def create_multidim_plot(parameters, samples, labels=None,
         What percentiles to draw lines at on the 1D histograms.
         If None, will draw lines at `[5, 50, 95]` (i.e., the bounds on the
         upper 90th percentile and the median).
+    marginal_title : bool, optional
+        Whether or not to print a title over the marginal plots giving the
+        90% confidence interval. Default is True.
     marginal_linestyle : str, optional
         What line style to use for the marginal histograms.
     contour_percentiles : {None, array}

--- a/pycbc/results/scatter_histograms.py
+++ b/pycbc/results/scatter_histograms.py
@@ -294,6 +294,7 @@ def create_density_plot(xparam, yparam, samples, plot_density=True,
 
 def create_marginalized_hist(ax, values, label, percentiles=None,
                              color='k', fillcolor='gray', linecolor='navy',
+                             linestyle='-',
                              title=True, expected_value=None,
                              expected_color='red', rotated=False,
                              plot_min=None, plot_max=None):
@@ -317,6 +318,8 @@ def create_marginalized_hist(ax, values, label, percentiles=None,
     fillcolor : {'gray', string, or None}
         What color to fill the histogram with. Set to None to not fill the
         histogram. Default is 'gray'.
+    linestyle : str, optional
+        What line style to use for the histogram. Default is '-'.
     linecolor : {'navy', string}
         What color to use for the percentile lines. Default is 'navy'.
     title : {True, bool}
@@ -342,11 +345,13 @@ def create_marginalized_hist(ax, values, label, percentiles=None,
     else:
         orientation = 'vertical'
     ax.hist(values, bins=50, histtype=htype, orientation=orientation,
-            facecolor=fillcolor, edgecolor=color, lw=2, density=True)
+            facecolor=fillcolor, edgecolor=color, ls=linestyle, lw=2,
+            density=True)
     if percentiles is None:
         percentiles = [5., 50., 95.]
-    values = numpy.percentile(values, percentiles)
-    for val in values:
+    if percentiles:
+        percentiles = numpy.percentile(values, percentiles)
+    for val in percentiles:
         if rotated:
             ax.axhline(y=val, ls='dashed', color=linecolor, lw=2, zorder=3)
         else:
@@ -359,8 +364,8 @@ def create_marginalized_hist(ax, values, label, percentiles=None,
             ax.axvline(expected_value, color=expected_color, lw=1.5, zorder=2)
     if title:
         values_med = numpy.median(values)
-        values_min = values.min()
-        values_max = values.max()
+        values_min = numpy.percentile(values, 5.)
+        values_max = numpy.percentile(values, 95.)
         negerror = values_med - values_min
         poserror = values_max - values_med
         fmt = '${0}$'.format(str_utils.format_value(
@@ -482,6 +487,7 @@ def create_multidim_plot(parameters, samples, labels=None,
                          expected_parameters_color='r',
                          plot_marginal=True, plot_scatter=True,
                          marginal_percentiles=None, contour_percentiles=None,
+                         marginal_title=True, marginal_linestyle='-',
                          zvals=None, show_colorbar=True, cbar_label=None,
                          vmin=None, vmax=None, scatter_cmap='plasma',
                          plot_density=False, plot_contours=True,
@@ -523,6 +529,8 @@ def create_multidim_plot(parameters, samples, labels=None,
         What percentiles to draw lines at on the 1D histograms.
         If None, will draw lines at `[5, 50, 95]` (i.e., the bounds on the
         upper 90th percentile and the median).
+    marginal_linestyle : str, optional
+        What line style to use for the marginal histograms.
     contour_percentiles : {None, array}
         What percentile contours to draw on the scatter plots. If None,
         will plot the 50th and 90th percentiles.
@@ -650,8 +658,9 @@ def create_multidim_plot(parameters, samples, labels=None,
                 expected_value = None
             create_marginalized_hist(
                 ax, samples[param], label=labels[param],
-                color=hist_color, fillcolor=fill_color, linecolor=line_color,
-                title=True, expected_value=expected_value,
+                color=hist_color, fillcolor=fill_color,
+                linestyle=marginal_linestyle, linecolor=line_color,
+                title=marginal_title, expected_value=expected_value,
                 expected_color=expected_parameters_color,
                 rotated=rotated, plot_min=mins[param], plot_max=maxs[param],
                 percentiles=marginal_percentiles)

--- a/pycbc/results/scatter_histograms.py
+++ b/pycbc/results/scatter_histograms.py
@@ -324,9 +324,10 @@ def create_marginalized_hist(ax, values, label, percentiles=None,
         What color to use for the percentile lines. Default is 'navy'.
     title : bool, optional
         Add a title with a estimated value +/- uncertainty. The estimated value
-        is the pecentile corresponding to the average of ``percentiles`` +/-
-        the max/min of the ``percentiles``. If no percentiles are specified,
-        defaults to quoting the median +/- 95/5 percentiles.
+        is the pecentile halfway between the max/min of ``percentiles``, while
+        the uncertainty is given by the max/min of the ``percentiles. If no
+        percentiles are specified, defaults to quoting the median +/- 95/5
+        percentiles.
     rotated : {False, bool}
         Plot the histogram on the y-axis instead of the x. Default is False.
     plot_min : {None, float}
@@ -369,8 +370,8 @@ def create_marginalized_hist(ax, values, label, percentiles=None,
     if title:
         if len(percentiles) > 0:
             minp = min(percentiles)
-            medp = numpy.array(percentiles).mean()
             maxp = max(percentiles)
+            medp = (maxp + minp) / 2.
         else:
             minp = 5
             medp = 50
@@ -543,11 +544,11 @@ def create_multidim_plot(parameters, samples, labels=None,
         upper 90th percentile and the median).
     marginal_title : bool, optional
         Add a title over the 1D marginal plots that gives an estimated value
-        +/- uncertainty. The estimated value is the pecentile corresponding to
-        the average of ``marginal_percentiles`` +/- the max/min of the
-        ``marginal_percentiles``. If no percentiles are specified in
-        ``marginal_percentiles``, defaults to quoting the median +/- 95/5
-        percentiles.
+        +/- uncertainty. The estimated value is the pecentile halfway between
+        the max/min of ``maginal_percentiles``, while the uncertainty is given
+        by the max/min of the ``marginal_percentiles. If no
+        ``marginal_percentiles`` are specified, the median +/- 95/5 percentiles
+        will be quoted.
     marginal_linestyle : str, optional
         What line style to use for the marginal histograms.
     contour_percentiles : {None, array}

--- a/pycbc/results/scatter_histograms.py
+++ b/pycbc/results/scatter_histograms.py
@@ -325,7 +325,7 @@ def create_marginalized_hist(ax, values, label, percentiles=None,
     title : bool, optional
         Add a title with a estimated value +/- uncertainty. The estimated value
         is the pecentile halfway between the max/min of ``percentiles``, while
-        the uncertainty is given by the max/min of the ``percentiles. If no
+        the uncertainty is given by the max/min of the ``percentiles``. If no
         percentiles are specified, defaults to quoting the median +/- 95/5
         percentiles.
     rotated : {False, bool}


### PR DESCRIPTION
This adds the ability to plot the prior on the 1D marginal plots in `plot_posterior`. The prior is plotted as a dotted line (in black for single files; for multiple file inputs, the next color in the sequence is used). Examples can be seen in Figure 4 of https://arxiv.org/abs/1902.09496.

The prior is loaded from the config file. I moved the lines of code that do this in `plot_prior` to a function in `option_utils`, then have both `plot_posterior` and `plot_prior` call the same function.

This also fixes a couple of bugs I noticed:
 1. The color of the confidence interval lines in the 1D marginal plots was being set to the contour colors. This meant that if you set the contour color to white (as you need to do when plotting density), the 1D marginal percentile lines wouldn't be visible.
 2. The quoted confidence intervals in the plot titles were being calculated from the location of the 1D marginal lines, not from the samples. That's ok as long as the requested percentiles to plot were symmetric (e.g., 5, 50, 95), but will give wrong results if not (e.g, 50). Even when the percentiles are symmetric, it could result in the precision in the title being worse than it actually is. I fixed this by getting getting the percentile from the samples instead. This means that they are hard coded to always quote the middle 90% confidence interval.