### PR TITLE
Allow psd group to be specified in plot_psd

### DIFF
--- a/bin/hdfcoinc/pycbc_plot_psd_file
+++ b/bin/hdfcoinc/pycbc_plot_psd_file
@@ -17,8 +17,10 @@ parser.add_argument('--hdf-group', default=None,
                     help="Group in the HDF file(s) to read the psd from. "
                          "PSDs will be read from {psd_group}/{ifo}. Default "
                          "is to look in the top level.")
-parser.add_argument('--low-frequency-cutoff', type=float)
-parser.add_argument('--plot-reference', action='store_true')
+parser.add_argument('--low-frequency-cutoff', type=float, 
+                    help="The low frequency cutoff of the PSD. If not "
+                         "provided, will try to retrive it from the "
+                         "hdf-group's attrs.")
 parser.add_argument("--ifos", nargs="+",
                     help="What ifo(s) to plot. If none provided, will look "
                          "for an 'ifo_list' attribute in the hdf file.")
@@ -102,7 +104,7 @@ for psd_file in args.psd_files:
         ax.loglog(samples, middle, linewidth=0.3, color=color, label=ifo)
         ax.set_xlim(flow, samples[-1])
 
-if args.plot_reference:
+if args.psd_model or args.psd_file or args.asd_file:
     reference_psd = pycbc.psd.from_cli(args, 2048, 1., 10., None)
     if reference_psd is not None:
         ax.loglog(reference_psd.sample_frequencies, reference_psd ** 0.5,

--- a/bin/hdfcoinc/pycbc_plot_psd_file
+++ b/bin/hdfcoinc/pycbc_plot_psd_file
@@ -13,6 +13,12 @@ parser.add_argument("--version", action="version",
                     version=pycbc.version.git_verbose_msg)
 parser.add_argument("--psd-files", nargs='+', required=True,
                     help='HDF file(s) containing the PSDs to plot')
+parser.add_argument('--hdf-group', default=None,
+                    help="Group in the HDF file(s) to read the psd from. "
+                         "PSDs will be read from {psd_group}/{ifo}. Default "
+                         "is to look in the top level.")
+parser.add_argument('--low-frequency-cutoff', type=float)
+parser.add_argument('--plot-reference', action='store_true')
 parser.add_argument("--ifos", nargs="+",
                     help="What ifo(s) to plot. If none provided, will look "
                          "for an 'ifo_list' attribute in the hdf file.")
@@ -37,6 +43,8 @@ y_min = None
 
 for psd_file in args.psd_files:
     f = h5py.File(psd_file, 'r')
+    if args.hdf_group is not None:
+        f = f[args.hdf_group]
 
     if args.ifos is not None:
         ifo_list = args.ifos
@@ -49,7 +57,10 @@ for psd_file in args.psd_files:
         fac = 1.0 / pycbc.DYN_RANGE_FAC
         df = f[ifo + '/psds/0'].attrs['delta_f']
         keys = f[ifo + '/psds'].keys()
-        flow = f.attrs['low_frequency_cutoff']
+        if args.low_frequency_cutoff is None:
+            flow = f.attrs['low_frequency_cutoff']
+        else:
+            flow = args.low_frequency_cutoff
         kmin = int(flow / df)
         kmax = len(f[ifo + '/psds/' + keys[0]][:])
         klen = kmax - kmin
@@ -91,10 +102,11 @@ for psd_file in args.psd_files:
         ax.loglog(samples, middle, linewidth=0.3, color=color, label=ifo)
         ax.set_xlim(flow, samples[-1])
 
-reference_psd = pycbc.psd.from_cli(args, 2048, 1., 10., None)
-if reference_psd is not None:
-    ax.loglog(reference_psd.sample_frequencies, reference_psd ** 0.5,
-              '-k', lw=0.3, label='Reference')
+if args.plot_reference:
+    reference_psd = pycbc.psd.from_cli(args, 2048, 1., 10., None)
+    if reference_psd is not None:
+        ax.loglog(reference_psd.sample_frequencies, reference_psd ** 0.5,
+                  '-k', lw=0.3, label='Reference')
 
 ax.set_ylim(y_min * 0.5, y_min * 100)
 

--- a/bin/hdfcoinc/pycbc_plot_psd_file
+++ b/bin/hdfcoinc/pycbc_plot_psd_file
@@ -60,7 +60,12 @@ for psd_file in args.psd_files:
         df = f[ifo + '/psds/0'].attrs['delta_f']
         keys = f[ifo + '/psds'].keys()
         if args.low_frequency_cutoff is None:
-            flow = f.attrs['low_frequency_cutoff']
+            try:
+                flow = f.attrs['low_frequency_cutoff']
+            except KeyError:
+                raise ValueError("low_frequency_cutoff not found in hdf file; "
+                                 "please specify a value using the "
+                                 "--low-frequency-cutoff option")
         else:
             flow = args.low_frequency_cutoff
         kmin = int(flow / df)


### PR DESCRIPTION
This adds an `hdf-group` option to `plot_psd` to specify the group to look in for the PSD. This allows `plot_psd` to be run on inference hdf files, in which the psd is stored in the `data` group. If the `hdf-group` option isn't given, it will default to the top level group, as it does now.

This also makes it optional to plot a reference PSD. Right now, if you don't specify one of `psd-file`, `asd-file` or `psd-model`, you'll get an error.

Finally, I added a `low-frequency-cutoff` option so that this can be specified in case it isn't stored in the hdf file, as is (currently) the case for inference hdf files.