### PR TITLE
Use automatically determined number of sig. figs in posterior titles

### DIFF
--- a/pycbc/results/scatter_histograms.py
+++ b/pycbc/results/scatter_histograms.py
@@ -364,7 +364,7 @@ def create_marginalized_hist(ax, values, label, percentiles=None,
         negerror = values_med - values_min
         poserror = values_max - values_med
         fmt = '${0}$'.format(str_utils.format_value(
-            values_med, negerror, plus_error=poserror, ndecs=2))
+            values_med, negerror, plus_error=poserror))
 
         if rotated:
             ax.yaxis.set_label_position("right")

--- a/pycbc/results/scatter_histograms.py
+++ b/pycbc/results/scatter_histograms.py
@@ -365,7 +365,6 @@ def create_marginalized_hist(ax, values, label, percentiles=None,
         poserror = values_max - values_med
         fmt = '${0}$'.format(str_utils.format_value(
             values_med, negerror, plus_error=poserror))
-
         if rotated:
             ax.yaxis.set_label_position("right")
 

--- a/pycbc/results/str_utils.py
+++ b/pycbc/results/str_utils.py
@@ -68,7 +68,7 @@ def get_signum(val, err, max_sig=numpy.inf):
         if round(float(coeff)) == 10.:
             pwr -= 1
         pwr = min(pwr, max_sig)
-        tmplt = '%.' + str(pwr) + 'f'
+        tmplt = '%.' + str(pwr+1) + 'f'
         return tmplt % val
     else:
         pwr = int(pwr[1:])
@@ -77,13 +77,13 @@ def get_signum(val, err, max_sig=numpy.inf):
         # if the error is large, we can sometimes get 0;
         # adjust the round until we don't get 0 (assuming the actual
         # value isn't 0)
-        return_val = round(val, -pwr)
+        return_val = round(val, -pwr+1)
         if val != 0.:
             loop_count = 0
             max_recursion = 100
             while return_val == 0.:
                 pwr -= 1
-                return_val = round(val, -pwr)
+                return_val = round(val, -pwr+1)
                 loop_count += 1
                 if loop_count > max_recursion:
                     raise ValueError("Maximum recursion depth hit! Input " +\
@@ -114,13 +114,13 @@ def format_value(value, error, plus_error=None, use_scientific_notation=3,
         the negative; i.e., value +plus_error -error. The number of
         significant figures printed is determined from min(error,
         plus_error).
-    use_scientific_notation : {3, int}
-        If ``abs(log10(value))`` is greater than the given, the return string will be
-        formated to "\%.1f \\times 10^{p}", where p is the powers of 10 needed
-        for the leading number in the value to be in the singles spot.
-        Otherwise will return "\%.(p+1)f". Default is 3.  To turn off,
-        set to 0. Note: using scientific notation assumes that the returned
-        value will be enclosed in LaTeX math mode.
+    use_scientific_notation : int, optional
+        If ``abs(log10(value))`` is greater than the given, the return string
+        will be formated to "\%.1f \\times 10^{p}", where p is the powers of 10
+        needed for the leading number in the value to be in the singles spot.
+        Otherwise will return "\%.(p+1)f". Default is 3.  To turn off, set to
+        ``numpy.inf``. Note: using scientific notation assumes that the
+        returned value will be enclosed in LaTeX math mode.
     include_error : {True, bool}
         Include the error in the return string; the output will be formated
         val \\pm err, where err is the error rounded to the same
@@ -148,15 +148,16 @@ def format_value(value, error, plus_error=None, use_scientific_notation=3,
 
     Format with error quoted:
     >>> format_value(val, err)
-    '3.9 \\pm 0.2\\times 10^{-22}'
+    '3.93 \\pm 0.22\\times 10^{-22}'
 
     Quote error as a relative error:
     >>> format_value(val, err, use_relative_error=True)
-    '3.9 \\times 10^{-22} \\pm5\\%'
+    '3.93 \\times 10^{-22} \\pm5.6\\%'
 
     Format without the error and without scientific notation:
-    >>> format_value(val, err, use_scientific_notation=0, include_error=False)
-    '0.00000000000000000000039'
+    >>> format_value(val, err, use_scientific_notation=float('inf'),
+                     include_error=False)
+    '0.000000000000000000000393'
 
     Given an plus error:
     >>> err_plus
@@ -164,11 +165,11 @@ def format_value(value, error, plus_error=None, use_scientific_notation=3,
 
     Format with both bounds quoted:
     >>> format_value(val, err, plus_error=err_plus)
-    '3.93^{+0.08}_{-0.22}\\times 10^{-22}'
+    '3.928^{+0.083}_{-0.224}\\times 10^{-22}'
 
     Format with both bounds quoted as a relative error:
     >>> format_value(val, err, plus_error=err_plus, use_relative_error=True)
-    '3.93\\times 10^{-22}\\,^{+2\\%}_{-6\\%}'
+    '3.928\\times 10^{-22}\\,^{+2.1\\%}_{-5.7\\%}'
     """
     minus_sign = '-' if value < 0. else ''
     value = abs(value)

--- a/pycbc/results/str_utils.py
+++ b/pycbc/results/str_utils.py
@@ -143,33 +143,41 @@ def format_value(value, error, plus_error=None, use_scientific_notation=3,
     Examples
     --------
     Given a value and its uncertainty:
+
     >>> val, err
     (3.9278372067613837e-22, 2.2351435286500487e-23)
 
     Format with error quoted:
+
     >>> format_value(val, err)
     '3.93 \\pm 0.22\\times 10^{-22}'
 
     Quote error as a relative error:
+
     >>> format_value(val, err, use_relative_error=True)
     '3.93 \\times 10^{-22} \\pm5.6\\%'
 
     Format without the error and without scientific notation:
+
     >>> format_value(val, err, use_scientific_notation=float('inf'),
                      include_error=False)
     '0.000000000000000000000393'
 
     Given an plus error:
+
     >>> err_plus
     8.2700310560051804e-24
 
     Format with both bounds quoted:
+
     >>> format_value(val, err, plus_error=err_plus)
     '3.928^{+0.083}_{-0.224}\\times 10^{-22}'
 
     Format with both bounds quoted as a relative error:
+
     >>> format_value(val, err, plus_error=err_plus, use_relative_error=True)
     '3.928\\times 10^{-22}\\,^{+2.1\\%}_{-5.7\\%}'
+
     """
     minus_sign = '-' if value < 0. else ''
     value = abs(value)


### PR DESCRIPTION
Currently, the titles in `plot_posterior` force the quoted values to two decimal places in the uncertainty. This causes the precision of some poorly constrained parameters to be over quoted, while other well constrained parameters to be under quoted. For example, here is a plot of the [intrinsic](https://www.atlas.aei.uni-hannover.de/~work-cdcapano/scratch/quoted_intervals/orig_intrinsic_posterior.png) and [extrinsic](https://www.atlas.aei.uni-hannover.de/~work-cdcapano/scratch/quoted_intervals/orig_extrinsic_posterior.png) parameters of a BNS run. The chirp mass is quoted as '1.35 + 0.00 - 0.00' because the uncertainty is < 0.01, while effective spin is quoted as '-0.0874 + 0.1371 - 0.1251', which is ridiculous since the error is at the 100% level.

The `format_value` function can automatically determine the number of sig. figs to quote based on the uncertainty, it's just been turned off until now. This patch turns that on. I've also adjusted the number of significant figures to quote. Currently, `format_value` rounds the estimated value such that only 1 sig. fig is quoted in the uncertainty. This is a bit too imprecise (e.g., doing so leads the effective spin above to be quoted as -0.1 + 0.1 - 0.1). So I've changed it so that it now rounds such that two significant figures are quoted in the uncertainty. Here are the same plots as above with this patch: [intrinsic](https://www.atlas.aei.uni-hannover.de/~work-cdcapano/scratch/quoted_intervals/intrinsic_posterior.png), [extrinsic](https://www.atlas.aei.uni-hannover.de/~work-cdcapano/scratch/quoted_intervals/extrinsic_posterior.png). Note that now, chirp mass is quoted as '1.3492 + 0.0029 - 0.0040' while effective spin is quoted as '-0.09 + 0.14 - 0.13'.