### PR TITLE
Adding sgchisq calculation to PyCBC Live

### DIFF
--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -25,6 +25,7 @@ from pycbc.events.coinc import LiveCoincTimeslideBackgroundEstimator as Coincer
 from pycbc.events.single import LiveSingleFarThreshold
 from pycbc.io.live import SingleCoincForGraceDB
 import pycbc.waveform.bank
+from pycbc.vetoes.sgchisq import SingleDetSGChisq
 
 
 def ptof(p, ft):
@@ -377,6 +378,7 @@ scheme.insert_processing_option_group(parser)
 LiveSingleFarThreshold.insert_args(parser)
 fft.insert_fft_option_group(parser)
 Coincer.insert_args(parser)
+SingleDetSGChisq.insert_option_group(parser)
 args = parser.parse_args()
 scheme.verify_processing_options(args, parser)
 fft.verify_fft_options(args, parser)
@@ -409,6 +411,8 @@ evnt = LiveEventManager(args.output_path,
                         enable_gracedb_upload=args.enable_gracedb_upload,
                         gracedb_testing=not args.enable_production_gracedb_upload,
                        )
+
+sg_chisq = SingleDetSGChisq.from_cli(args, bank, args.chisq_bins)
 
 if args.size_override:
     evnt.size=args.size_override
@@ -452,11 +456,12 @@ with ctx:
         lengths = numpy.array([1.0 / waveform.delta_f for waveform in waveforms])
         psd_len = args.psd_segment_length * (args.psd_samples / 2 + 1)
         maxlen = max(lengths.max(), psd_len)
-        mf = LiveBatchMatchedFilter(waveforms, args.snr_threshold, args.chisq_bins,
-                                     snr_abort_threshold=args.snr_abort_threshold,
-                                     newsnr_threshold=args.newsnr_threshold,
-                                     max_triggers_in_batch=args.max_triggers_in_batch,
-                                     maxelements=args.max_batch_size)
+        mf = LiveBatchMatchedFilter(waveforms, args.snr_threshold,
+                                    args.chisq_bins, sg_chisq,
+                                    snr_abort_threshold=args.snr_abort_threshold,
+                                    newsnr_threshold=args.newsnr_threshold,
+                                    max_triggers_in_batch=args.max_triggers_in_batch,
+                                    maxelements=args.max_batch_size)
     if args.max_length is not None:
         maxlen = args.max_length
     maxlen = int(maxlen)

--- a/pycbc/filter/matchedfilter.py
+++ b/pycbc/filter/matchedfilter.py
@@ -1465,7 +1465,7 @@ class LiveBatchMatchedFilter(object):
 
     """Calculate SNR and signal consistency tests in a batched progression"""
 
-    def __init__(self, templates, snr_threshold, chisq_bins, sgchisq,
+    def __init__(self, templates, snr_threshold, chisq_bins, sg_chisq,
                  maxelements=2**27,
                  snr_abort_threshold=None,
                  newsnr_threshold=None,
@@ -1481,8 +1481,8 @@ class LiveBatchMatchedFilter(object):
         chisq_bins: str
             Str that determines how the number of chisq bins varies as a
             function of the template bank parameters.
-        sgchisq: pycbc.vetoes.SingleDetSGChisq
-            Instance of the sgchisq class to calculate sgchisq with.
+        sg_chisq: pycbc.vetoes.SingleDetSGChisq
+            Instance of the sg_chisq class to calculate sg_chisq with.
         maxelements: {int, 2**27}
             Maximum size of a batched fourier transform.
         snr_abort_threshold: {float, None}
@@ -1617,7 +1617,7 @@ class LiveBatchMatchedFilter(object):
                                ndmin=1)
         results['chisq'] = chisq
         results['chisq_dof'] = dof
-        results['sgchisq'] = sgchisq
+        results['sg_chisq'] = sg_chisq
 
         keep = []
         for i, (snrv, norm, l, htilde, stilde) in enumerate(veto_info):
@@ -1627,7 +1627,7 @@ class LiveBatchMatchedFilter(object):
             chisq[i] = c[0] / d[0]
             dof[i] = d[0]
 
-            sgchisq = self.sg_chisq.values\
+            results['sg_chisq'] = self.sg_chisq.values\
                 (stilde, htilde, stilde.psd, snrv, norm, c, d, [l])
 
             if self.newsnr_threshold:

--- a/pycbc/filter/matchedfilter.py
+++ b/pycbc/filter/matchedfilter.py
@@ -1627,8 +1627,8 @@ class LiveBatchMatchedFilter(object):
             chisq[i] = c[0] / d[0]
             dof[i] = d[0]
 
-            results['sg_chisq'] = self.sg_chisq.values\
-                (stilde, htilde, stilde.psd, snrv, norm, c, d, [l])
+            sg_chisq[i] = self.sg_chisq.values\
+                (stilde, htilde, stilde.psd, snrv, norm, c, d, [l])[0]
 
             if self.newsnr_threshold:
                 newsnr = events.newsnr(results['snr'][i], chisq[i])

--- a/pycbc/filter/matchedfilter.py
+++ b/pycbc/filter/matchedfilter.py
@@ -1465,7 +1465,7 @@ class LiveBatchMatchedFilter(object):
 
     """Calculate SNR and signal consistency tests in a batched progression"""
 
-    def __init__(self, templates, snr_threshold, chisq_bins,
+    def __init__(self, templates, snr_threshold, chisq_bins, sgchisq,
                  maxelements=2**27,
                  snr_abort_threshold=None,
                  newsnr_threshold=None,
@@ -1480,7 +1480,9 @@ class LiveBatchMatchedFilter(object):
             Minimum value to record peaks in the SNR time series.
         chisq_bins: str
             Str that determines how the number of chisq bins varies as a
-        function of the template bank parameters.
+            function of the template bank parameters.
+        sgchisq: pycbc.vetoes.SingleDetSGChisq
+            Instance of the sgchisq class to calculate sgchisq with.
         maxelements: {int, 2**27}
             Maximum size of a batched fourier transform.
         snr_abort_threshold: {float, None}
@@ -1500,6 +1502,7 @@ class LiveBatchMatchedFilter(object):
 
         from pycbc import vetoes
         self.power_chisq = vetoes.SingleDetPowerChisq(chisq_bins, None)
+        self.sg_chisq = sg_chisq
 
         durations = numpy.array([1.0 / t.delta_f for t in templates])
 
@@ -1610,8 +1613,11 @@ class LiveBatchMatchedFilter(object):
         """Calculate signal based vetoes"""
         chisq = numpy.array(numpy.zeros(len(veto_info)), numpy.float32, ndmin=1)
         dof = numpy.array(numpy.zeros(len(veto_info)), numpy.uint32, ndmin=1)
+        sg_chisq = numpy.array(numpy.zeros(len(veto_info)), numpy.float32,
+                               ndmin=1)
         results['chisq'] = chisq
         results['chisq_dof'] = dof
+        results['sgchisq'] = sgchisq
 
         keep = []
         for i, (snrv, norm, l, htilde, stilde) in enumerate(veto_info):
@@ -1620,6 +1626,9 @@ class LiveBatchMatchedFilter(object):
                                            norm, stilde.psd, [l], htilde)
             chisq[i] = c[0] / d[0]
             dof[i] = d[0]
+
+            sgchisq = self.sg_chisq.values\
+                (stilde, htilde, stilde.psd, snrv, norm, c, d, [l])
 
             if self.newsnr_threshold:
                 newsnr = events.newsnr(results['snr'][i], chisq[i])

--- a/pycbc/waveform/sinegauss.py
+++ b/pycbc/waveform/sinegauss.py
@@ -28,9 +28,9 @@ def fd_sine_gaussian(amp, quality, central_frequency, fmin, fmax, delta_f):
     sg: pycbc.types.Frequencyseries
         A Fourier domain sine-Gaussian
     """
-    f = numpy.arange(fmin, fmax, delta_f)
-    kmax = int(fmax / delta_f)
-    kmin = int(fmin / delta_f)
+    kmin = int(round(fmin / delta_f))
+    kmax = int(round(fmax / delta_f))
+    f = numpy.arange(kmin, kmax) * delta_f
     tau = quality / 2 / numpy.pi / central_frequency
     A = amp * numpy.pi ** 0.5 / 2 * tau
     d = A * numpy.exp(-(numpy.pi  * tau  * (f - central_frequency))**2.0)


### PR DESCRIPTION
Trying to add sgchisq to pycbc_live. I need a testing example so at the moment this is only me guessing at a few things. But I think this *might* work.

Basically:

 * It seems that actually calculating sg_chisq is easy enough. Bruce chisq is calculated in the same way as in pycbc_inspiral, so we can add sg_chisq in the same place. I've done that.
 * It seems that sg_chisq would now be populated in the result array.
 * The statistic is computed using this result array and the standard stat classes. As far as I can see this will just use the `sg_chisq` array (maybe I got some of the names wrong, I need to test to see that)

So I think with this patch one can just flip the statistic. Am I missing anything?