### PR TITLE
Adding/fixing phasetd_newsnr_sgveto for PyCBC Live

### DIFF
--- a/pycbc/events/coinc.py
+++ b/pycbc/events/coinc.py
@@ -719,7 +719,6 @@ class LiveCoincTimeslideBackgroundEstimator(object):
             If true, background triggers will also be included in the file
             output.
         """
-        from pycbc import detector
         from . import stat
         self.num_templates = num_templates
         self.analysis_block = analysis_block
@@ -746,7 +745,7 @@ class LiveCoincTimeslideBackgroundEstimator(object):
         self.lookback_time = (ifar_limit * lal.YRJUL_SI * timeslide_interval) ** 0.5
         self.buffer_size = int(numpy.ceil(self.lookback_time / analysis_block))
 
-        det0, det1 = detector.Detector(ifos[0]), detector.Detector(ifos[1])
+        det0, det1 = Detector(ifos[0]), Detector(ifos[1])
         self.time_window = det0.light_travel_time_to_detector(det1) + coinc_threshold
         self.coincs = CoincExpireBuffer(self.buffer_size, self.ifos)
 
@@ -819,8 +818,11 @@ class LiveCoincTimeslideBackgroundEstimator(object):
 
     @staticmethod
     def insert_args(parser):
+        from . import stat
+
         group = parser.add_argument_group('Coincident Background Estimation')
         group.add_argument('--background-statistic', default='newsnr',
+            choices=sorted(stat.statistic_dict.keys()),
             help="Ranking statistic to use for candidate coincident events")
         group.add_argument('--background-statistic-files', nargs='+',
             help="Files containing precalculate values to calculate ranking"

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -252,6 +252,8 @@ class PhaseTDStatistic(NewSNRStatistic):
                     ('sigmasq', numpy.float32),
                     ('snr', numpy.float32)]
 
+        self.get_newsnr = get_newsnr
+
     def single(self, trigs):
         """
         Calculate the single detector statistic and assemble other parameters
@@ -268,7 +270,7 @@ class PhaseTDStatistic(NewSNRStatistic):
         numpy.ndarray
             Array of single detector parameter values
         """
-        sngl_stat = get_newsnr(trigs)
+        sngl_stat = self.get_newsnr(trigs)
         singles = numpy.zeros(len(sngl_stat), dtype=self.single_dtype)
         singles['snglstat'] = sngl_stat
         singles['coa_phase'] = trigs['coa_phase'][:]
@@ -340,6 +342,17 @@ class PhaseTDStatistic(NewSNRStatistic):
         cstat = rstat + 2. * self.logsignalrate(s0, s1, slide, step)
         cstat[cstat < 0] = 0
         return cstat ** 0.5
+
+
+class PhaseTDSGStatistic(PhaseTDStatistic):
+    """PhaseTDStatistic but with sine-Gaussian veto added to the
+
+    single detector ranking
+    """
+
+    def __init__(self, files):
+        PhaseTDStatistic.__init__(self, files)
+        self.get_newsnr = get_newsnr_sgveto
 
 
 class ExpFitStatistic(NewSNRStatistic):
@@ -553,6 +566,7 @@ statistic_dict = {
     'network_snr': NetworkSNRStatistic,
     'newsnr_cut': NewSNRCutStatistic,
     'phasetd_newsnr': PhaseTDStatistic,
+    'phasetd_newsnr_sgveto': PhaseTDSGStatistic,
     'exp_fit_stat': ExpFitStatistic,
     'exp_fit_csnr': ExpFitCombinedSNR,
     'exp_fit_sg_csnr': ExpFitSGCombinedSNR,

--- a/pycbc/filter/matchedfilter.py
+++ b/pycbc/filter/matchedfilter.py
@@ -1627,8 +1627,10 @@ class LiveBatchMatchedFilter(object):
             chisq[i] = c[0] / d[0]
             dof[i] = d[0]
 
-            sg_chisq[i] = self.sg_chisq.values\
-                (stilde, htilde, stilde.psd, snrv, norm, c, d, [l])[0]
+            sgv = self.sg_chisq.values(stilde, htilde, stilde.psd,
+                                       snrv, norm, c, d, [l])
+            if sgv is not None:
+                sg_chisq[i] = sgv[0]
 
             if self.newsnr_threshold:
                 newsnr = events.newsnr(results['snr'][i], chisq[i])

--- a/pycbc/vetoes/sgchisq.py
+++ b/pycbc/vetoes/sgchisq.py
@@ -1,7 +1,8 @@
-""" Chisq based on sine-gaussian tiles """
+"""Chisq based on sine-gaussian tiles.
+See https://arxiv.org/abs/1709.08974 for a discussion.
+"""
 
 import numpy
-import logging
 
 from pycbc.waveform.utils import apply_fseries_time_shift
 from pycbc.filter import sigma
@@ -173,6 +174,5 @@ class SingleDetSGChisq(SingleDetPowerChisq):
                 chisq[i] = 1
             else:
                 chisq[i] /= dof
-            logging.info('Found chisq %s', chisq[i])
         return chisq
 


### PR DESCRIPTION
Adds a `phasetd_newsnr_sgveto` statistic. As this is a coinc-only statistic it is not added to the singles statistic dictionary.

UNTESTED