### PR TITLE
use multi ifo action for pycbc live singles

### DIFF
--- a/pycbc/events/single.py
+++ b/pycbc/events/single.py
@@ -1,6 +1,7 @@
 """ utilities for assigning FAR to single detector triggers
 """
 from pycbc.events import newsnr
+from pycbc.types import MultiDetOptionAction
 
 class LiveSingleFarThreshold(object):
     def __init__(self, ifo,
@@ -16,17 +17,21 @@ class LiveSingleFarThreshold(object):
 
     @staticmethod
     def insert_args(parser):
-        parser.add_argument('--single-newsnr-threshold', type=float)
-        parser.add_argument('--single-reduced-chisq-threshold', type=float)
-        parser.add_argument('--single-fixed-ifar', type=float)
-        parser.add_argument('--single-duration-threshold', type=float)
+        parser.add_argument('--single-newsnr-threshold',
+                            type=float, action=MultiDetOptionAction)
+        parser.add_argument('--single-reduced-chisq-threshold',
+                            type=float, action=MultiDetOptionAction)
+        parser.add_argument('--single-fixed-ifar',
+                            type=float, action=MultiDetOptionAction)
+        parser.add_argument('--single-duration-threshold',
+                            type=float, action=MultiDetOptionAction)
 
     @classmethod
     def from_cli(cls, args, ifo):
-        return cls(ifo, newsnr_threshold=args.single_newsnr_threshold,
-                   reduced_chisq_threshold=args.single_reduced_chisq_threshold,
-                   fixed_ifar=args.single_fixed_ifar,
-                   duration_threshold=args.single_duration_threshold,
+        return cls(ifo, newsnr_threshold=args.single_newsnr_threshold[ifo],
+                   reduced_chisq_threshold=args.single_reduced_chisq_threshold[ifo],
+                   fixed_ifar=args.single_fixed_ifar[ifo],
+                   duration_threshold=args.single_duration_threshold[ifo],
                    )
 
     def check(self, triggers, data_reader):

--- a/pycbc/events/single.py
+++ b/pycbc/events/single.py
@@ -28,11 +28,12 @@ class LiveSingleFarThreshold(object):
 
     @classmethod
     def from_cli(cls, args, ifo):
-        return cls(ifo, newsnr_threshold=args.single_newsnr_threshold[ifo],
-                   reduced_chisq_threshold=args.single_reduced_chisq_threshold[ifo],
-                   fixed_ifar=args.single_fixed_ifar[ifo],
-                   duration_threshold=args.single_duration_threshold[ifo],
-                   )
+        return cls(
+           ifo, newsnr_threshold=args.single_newsnr_threshold[ifo],
+           reduced_chisq_threshold=args.single_reduced_chisq_threshold[ifo],
+           fixed_ifar=args.single_fixed_ifar[ifo],
+           duration_threshold=args.single_duration_threshold[ifo],
+           )
 
     def check(self, triggers, data_reader):
         """ Look for a single detector trigger that passes the thresholds in


### PR DESCRIPTION
This switches the single ifo options for pycbc live to multi detector options. In this way they can be set different for each ifo independently. The run script will need to be updated if this is merged.

[untested]