### PR TITLE
Adding autogating in live

### DIFF
--- a/pycbc/strain/strain.py
+++ b/pycbc/strain/strain.py
@@ -1588,12 +1588,28 @@ class StrainBuffer(pycbc.frame.DataBuffer):
             strain = gate_data(strain, [(strain.start_time, 0., self.autogating_pad)])
             self.taper_immediate_strain = False
 
+        # apply gating if needed
+        if self.autogating_threshold is not None:
+            # the + 0 is for making a copy
+            glitch_times = detect_loud_glitches(
+                    strain + 0., psd_duration=1., psd_stride=.5,
+                    threshold=self.autogating_threshold,
+                    cluster_window=self.autogating_cluster,
+                    low_freq_cutoff=self.highpass_frequency,
+                    high_freq_cutoff=self.sample_rate/2,
+                    corrupt_time=self.autogating_pad)
+            if len(glitch_times) > 0:
+                logging.info('Autogating at %s',
+                                 ', '.join(['%.3f' % gt for gt in glitch_times]))
+                gate_params = [[gt, self.autogating_window, self.autogating_pad] \
+                               for gt in glitch_times]
+                strain = gate_data(strain, gate_params)
+
         # Stitch into continuous stream
         self.strain.roll(-sample_step)
         self.strain[len(self.strain) - csize + self.corruption:] = strain[:]
         self.strain.start_time += blocksize
 
-        # apply gating if need be: NOT YET IMPLEMENTED
         if self.psd is None and self.wait_duration <=0:
             self.recalculate_psd()
 

--- a/pycbc/strain/strain.py
+++ b/pycbc/strain/strain.py
@@ -1600,7 +1600,7 @@ class StrainBuffer(pycbc.frame.DataBuffer):
                     corrupt_time=self.autogating_pad)
             if len(glitch_times) > 0:
                 logging.info('Autogating at %s',
-                                 ', '.join(['%.3f' % gt for gt in glitch_times]))
+                             ', '.join(['%.3f' % gt for gt in glitch_times]))
                 gate_params = [[gt, self.autogating_window, self.autogating_pad] \
                                for gt in glitch_times]
                 strain = gate_data(strain, gate_params)


### PR DESCRIPTION
Adds autogating functionality to the low latency searches. 

Autogating threshold, clustering time, gating padding, gating window, corrupt time could be specified in pycbc_live arguments.
[Perhaps should add arguments in pycbc_live to specify psd duration and overlap for detect_loud_glitches(). For now it's hardcoded in to be (1s, 0.5s).]

Tested with simulated data with loud glitches. 