### PR TITLE
pycbc/results fixes for Python 3

### DIFF
--- a/pycbc/results/layout.py
+++ b/pycbc/results/layout.py
@@ -16,7 +16,12 @@
 """ This module contains result page layout and numbering helper functions
 """
 import os.path
-from itertools import izip_longest
+try:
+    # FIXME Python 2
+    from itertools import izip_longest
+except ImportError:
+    # FIXME Python 3
+    from itertools import zip_longest as izip_longest
 
 def two_column_layout(path, cols, **kwargs):
     """ Make a well layout in a two column format

--- a/pycbc/results/layout.py
+++ b/pycbc/results/layout.py
@@ -16,12 +16,7 @@
 """ This module contains result page layout and numbering helper functions
 """
 import os.path
-try:
-    # FIXME Python 2
-    from itertools import izip_longest
-except ImportError:
-    # FIXME Python 3
-    from itertools import zip_longest as izip_longest
+from six.moves import zip_longest
 
 def two_column_layout(path, cols, **kwargs):
     """ Make a well layout in a two column format
@@ -53,7 +48,7 @@ def grouper(iterable, n, fillvalue=None):
     """ Group items into chunks of n length
     """
     args = [iter(iterable)] * n
-    return izip_longest(*args, fillvalue=fillvalue)
+    return zip_longest(*args, fillvalue=fillvalue)
 
 def group_layout(path, files, **kwargs):
     """ Make a well layout in chunks of two from a list of files

--- a/pycbc/results/metadata.py
+++ b/pycbc/results/metadata.py
@@ -3,18 +3,8 @@ This Module contains generic utility functions for creating plots within
 PyCBC.
 """
 import os.path, pycbc.version
-try:
-    # FIXME Python 2
-    import ConfigParser
-except ImportError:
-    # FIXME Python 3
-    import configparser as ConfigParser
-try:
-    # FIXME Python 2
-    from HTMLParser import HTMLParser
-except ImportError:
-    # FIXME Python 3
-    from html.parser import HTMLParser
+from six.moves import configparser as ConfigParser
+from six.moves.html_parser import HTMLParser
 from xml.sax.saxutils import escape, unescape
 
 escape_table = {

--- a/pycbc/results/metadata.py
+++ b/pycbc/results/metadata.py
@@ -3,8 +3,18 @@ This Module contains generic utility functions for creating plots within
 PyCBC.
 """
 import os.path, pycbc.version
-import ConfigParser
-from HTMLParser import HTMLParser
+try:
+    # FIXME Python 2
+    import ConfigParser
+except ImportError:
+    # FIXME Python 3
+    import configparser as ConfigParser
+try:
+    # FIXME Python 2
+    from HTMLParser import HTMLParser
+except ImportError:
+    # FIXME Python 3
+    from html.parser import HTMLParser
 from xml.sax.saxutils import escape, unescape
 
 escape_table = {


### PR DESCRIPTION
This change allowed me to use `pycbc.results` and `ligo.skymap` in the same env.