### PR TITLE
Load constraints when reading prior from config for plotting

### DIFF
--- a/pycbc/inference/option_utils.py
+++ b/pycbc/inference/option_utils.py
@@ -485,24 +485,12 @@ def prior_from_config(cp, sections=None):
     # parse command line values for section and subsection
     # if only section then look for subsections
     # and add distributions to list
-    variable_params = []
-    dists = []
-    if sections is None:
-        sections = ['prior']
-    for sec in sections:
-        section = sec.split("-")[0]
-        subsec = sec.split("-")[1:]
-        if len(subsec) > 0:
-            subsections = ["-".join(subsec)]
-        else:
-            subsections = cp.get_subsections(section)
-        for subsection in subsections:
-            name = cp.get_opt_tag(section, "name", subsection)
-            dist = distributions.distribs[name].from_config(
-                cp, section, subsection)
-            variable_params += dist.params
-            dists.append(dist)
+    variable_params, static_params = distributions.read_params_from_config(
+                                             cp,
+                                             vargs_section='variable_params',
+                                             sargs_section='static_params')
     constraints = distributions.read_constraints_from_config(cp)
+    dists = distributions.read_distributions_from_config(cp)
     # construct class that will return draws from the prior
     return distributions.JointDistribution(variable_params, *dists,
-                                        **{"constraints" : constraints})
+                                           **{"constraints":constraints})

--- a/pycbc/inference/option_utils.py
+++ b/pycbc/inference/option_utils.py
@@ -481,15 +481,15 @@ def prior_from_config(cp, sections=None):
     distributions.JointDistribution
         The prior distribution.
     """
-    # get prior distribution for each variable parameter
-    # parse command line values for section and subsection
-    # if only section then look for subsections
-    # and add distributions to list
+    # Read variable and static parameters from the config file
     variable_params, static_params = distributions.read_params_from_config(
                                              cp,
                                              vargs_section='variable_params',
                                              sargs_section='static_params')
+    # Read constraints to apply to priors from the config file
     constraints = distributions.read_constraints_from_config(cp)
+    # Get PyCBC distribution instances for each variable parameter in the
+    # config file
     dists = distributions.read_distributions_from_config(cp)
     # construct class that will return draws from the prior
     return distributions.JointDistribution(variable_params, *dists,

--- a/pycbc/inference/option_utils.py
+++ b/pycbc/inference/option_utils.py
@@ -465,7 +465,7 @@ def add_density_option_group(parser):
     return density_group
 
 
-def prior_from_config(cp, sections=None):
+def prior_from_config(cp, sections='prior'):
     """Loads a prior distribution from the given config file.
 
     Parameters
@@ -483,12 +483,13 @@ def prior_from_config(cp, sections=None):
     """
     # Read variable and static parameters from the config file
     variable_params, _ = distributions.read_params_from_config(
-        cp, vargs_section='variable_params', sargs_section='static_params')
+        cp, prior_section=sections, vargs_section='variable_params',
+        sargs_section='static_params')
     # Read constraints to apply to priors from the config file
     constraints = distributions.read_constraints_from_config(cp)
     # Get PyCBC distribution instances for each variable parameter in the
     # config file
-    dists = distributions.read_distributions_from_config(cp)
+    dists = distributions.read_distributions_from_config(cp, sections)
     # construct class that will return draws from the prior
     return distributions.JointDistribution(variable_params, *dists,
-                                           **{"constraints":constraints})
+                                           **{"constraints": constraints})

--- a/pycbc/inference/option_utils.py
+++ b/pycbc/inference/option_utils.py
@@ -482,10 +482,8 @@ def prior_from_config(cp, sections=None):
         The prior distribution.
     """
     # Read variable and static parameters from the config file
-    variable_params, static_params = distributions.read_params_from_config(
-                                             cp,
-                                             vargs_section='variable_params',
-                                             sargs_section='static_params')
+    variable_params, _ = distributions.read_params_from_config(
+        cp, vargs_section='variable_params', sargs_section='static_params')
     # Read constraints to apply to priors from the config file
     constraints = distributions.read_constraints_from_config(cp)
     # Get PyCBC distribution instances for each variable parameter in the

--- a/pycbc/inference/option_utils.py
+++ b/pycbc/inference/option_utils.py
@@ -502,5 +502,7 @@ def prior_from_config(cp, sections=None):
                 cp, section, subsection)
             variable_params += dist.params
             dists.append(dist)
+    constraints = distributions.read_constraints_from_config(cp)
     # construct class that will return draws from the prior
-    return distributions.JointDistribution(variable_params, *dists)
+    return distributions.JointDistribution(variable_params, *dists,
+                                        **{"constraints" : constraints})


### PR DESCRIPTION
This PR adds the ability to load constraints from the config file in the `prior_from_config` function called for plotting priors.

@cdcapano Can we not just use 
```
variable_params, static_params = distributions.read_params_from_config(...)
dists = distributions.read_distributions_from_config(...)
```
instead of this block of code https://github.com/gwastro/pycbc/blob/master/pycbc/inference/option_utils.py#L488-L504 ?