### PR TITLE
Adding more plots, and a few other things

### DIFF
--- a/bin/hdfcoinc/pycbc_page_foreground
+++ b/bin/hdfcoinc/pycbc_page_foreground
@@ -21,7 +21,6 @@ parser.add_argument('--bank-file')
 parser.add_argument('--single-detector-triggers', nargs='+', default=None)
 parser.add_argument('--verbose', action='count')
 parser.add_argument('--output-file')
-parser.add_argument('--foreground-tag')
 parser.add_argument('--num-coincs-to-write', type=int)
 parser.add_argument('--use-hierarchical-level', type=int, default=None,
                     help='Indicate which FARs to write to the table '

--- a/bin/workflows/pycbc_create_offline_search_workflow
+++ b/bin/workflows/pycbc_create_offline_search_workflow
@@ -404,50 +404,52 @@ for insp_file in full_insps:
 # Main results with combined file (we mix open and closed box here, but
 # separate them in the result page)
 
-snrifar = wf.make_snrifar_plot(workflow, combined_bg_file,
-                               rdir['open_box_result'],
-                               tags=combined_bg_file.tags)
-snrifar_cb = wf.make_snrifar_plot(workflow, combined_bg_file,
-                                  rdir['coincident_triggers'], closed_box=True,
-                                  tags=combined_bg_file.tags + ['closed'])
-ratehist = wf.make_snrratehist_plot(workflow, combined_bg_file,
-                                    rdir['open_box_result'],
-                                    tags=combined_bg_file.tags)
+# FIXME: COMMENTED OUT JOBS ARE FAILING ... NEED FIXING!!
+#        (Currently that's most of the jobs :-( )
+#snrifar = wf.make_snrifar_plot(workflow, combined_bg_file,
+#                               rdir['open_box_result'],
+#                               tags=combined_bg_file.tags)
+#snrifar_cb = wf.make_snrifar_plot(workflow, combined_bg_file,
+#                                  rdir['coincident_triggers'], closed_box=True,
+#                                  tags=combined_bg_file.tags + ['closed'])
+#ratehist = wf.make_snrratehist_plot(workflow, combined_bg_file,
+#                                    rdir['open_box_result'],
+#                                    tags=combined_bg_file.tags)
 snrifar_ifar = wf.make_snrifar_plot(workflow, combined_bg_file,
                                     rdir['open_box_result/significance'],
                                     cumulative=False,
                                     tags=combined_bg_file.tags + ['ifar'])
-ifar_ob = wf.make_ifar_plot(workflow, combined_bg_file,
-                            rdir['open_box_result/significance'],
-                            tags=combined_bg_file.tags + ['open_box'])
-ifar_cb = wf.make_ifar_plot(workflow, combined_bg_file,
-                            rdir['coincident_triggers'],
-                            tags=combined_bg_file.tags + ['closed_box'])
-table = wf.make_foreground_table(workflow, combined_bg_file,
-                                 hdfbank[0], rdir['open_box_result'],
-                                 singles=insps,  extension='.html',
-                                 tags=["html"])
-symlink_result(snrifar, 'open_box_result/significance')
-symlink_result(ratehist, 'open_box_result/significance')
-symlink_result(table, 'open_box_result/significance')
+#ifar_ob = wf.make_ifar_plot(workflow, combined_bg_file,
+#                            rdir['open_box_result/significance'],
+#                            tags=combined_bg_file.tags + ['open_box'])
+#ifar_cb = wf.make_ifar_plot(workflow, combined_bg_file,
+#                            rdir['coincident_triggers'],
+#                            tags=combined_bg_file.tags + ['closed_box'])
+#table = wf.make_foreground_table(workflow, combined_bg_file,
+#                                 hdfbank[0], rdir['open_box_result'],
+#                                 singles=insps,  extension='.html',
+#                                 tags=["html"])
+#symlink_result(snrifar, 'open_box_result/significance')
+#symlink_result(ratehist, 'open_box_result/significance')
+#symlink_result(table, 'open_box_result/significance')
 
 # Set html pages
-main_page = [(snrifar, ratehist),(table,)]
-layout.two_column_layout(rdir['open_box_result'], main_page)
+#main_page = [(snrifar, ratehist),(table,)]
+#layout.two_column_layout(rdir['open_box_result'], main_page)
 
-detailed_page = [(snrifar, ratehist), (snrifar_ifar, ifar_ob), (table,)]
-layout.two_column_layout(rdir['open_box_result/significance'], detailed_page)
+#detailed_page = [(snrifar, ratehist), (snrifar_ifar, ifar_ob), (table,)]
+#layout.two_column_layout(rdir['open_box_result/significance'], detailed_page)
 
-closed_page = [(snrifar_cb, ifar_cb), (bank_plot,)]
-layout.two_column_layout(rdir['coincident_triggers'], closed_page)
+#closed_page = [(snrifar_cb, ifar_cb), (bank_plot,)]
+#layout.two_column_layout(rdir['coincident_triggers'], closed_page)
 
 # run minifollowups on the output of the loudest events
 mfup_dir = rdir['open_box_result/loudest_events_followup']
-wf.setup_foreground_minifollowups(workflow, combined_bg_file,
-                                  full_insps,  hdfbank[0], insp_files_seg_file,
-                                  data_analysed_name, trig_generated_name,
-                                  'daxes', mfup_dir,
-                                  tags=combined_bg_file.tags)
+#wf.setup_foreground_minifollowups(workflow, combined_bg_file,
+#                                  full_insps,  hdfbank[0], insp_files_seg_file,
+#                                  data_analysed_name, trig_generated_name,
+#                                  'daxes', mfup_dir,
+#                                  tags=combined_bg_file.tags)
 
 # Sub-pages for each ifo combination
 
@@ -466,18 +468,21 @@ for key in final_bg_files:
     snrifar_ifar = wf.make_snrifar_plot(workflow, bg_file, open_dir,
                                         cumulative=False,
                                         tags=bg_file.tags + ['ifar'])
-    ifar_ob = wf.make_ifar_plot(workflow, bg_file, open_dir,
-                                tags=bg_file.tags + ['open_box'])
-    ifar_cb = wf.make_ifar_plot(workflow, bg_file, closed_dir,
-                                tags=bg_file.tags + ['closed_box'])
-    table = wf.make_foreground_table(workflow, bg_file, hdfbank[0], open_dir,
-                                     singles=insps,  extension='.html',
-                                     tags=["html"])
+    #ifar_ob = wf.make_ifar_plot(workflow, bg_file, open_dir,
+    #                            tags=bg_file.tags + ['open_box'])
+    #ifar_cb = wf.make_ifar_plot(workflow, bg_file, closed_dir,
+    #                            tags=bg_file.tags + ['closed_box'])
+    #table = wf.make_foreground_table(workflow, bg_file, hdfbank[0], open_dir,
+    #                                 singles=insps,  extension='.html',
+    #                                 tags=["html"])
 
-    detailed_page = [(snrifar, ratehist), (snrifar_ifar, ifar_ob), (table,)]
+    #detailed_page = [(snrifar, ratehist), (snrifar_ifar, ifar_ob), (table,)]
+    # FIXME: NEED TO ADD NOT WORKING PLOTS, AS ABOVE
+    detailed_page = [(snrifar, ratehist), (snrifar_ifar,)]
     layout.two_column_layout(open_dir, detailed_page)
 
-    closed_page = [(snrifar_cb, ifar_cb)]
+    #closed_page = [(snrifar_cb, ifar_cb)]
+    closed_page = [(snrifar_cb,)]
     layout.two_column_layout(closed_dir, closed_page)
 
 

--- a/bin/workflows/pycbc_create_offline_search_workflow
+++ b/bin/workflows/pycbc_create_offline_search_workflow
@@ -415,10 +415,10 @@ for insp_file in full_insps:
 #ratehist = wf.make_snrratehist_plot(workflow, combined_bg_file,
 #                                    rdir['open_box_result'],
 #                                    tags=combined_bg_file.tags)
-snrifar_ifar = wf.make_snrifar_plot(workflow, combined_bg_file,
-                                    rdir['open_box_result/significance'],
-                                    cumulative=False,
-                                    tags=combined_bg_file.tags + ['ifar'])
+#snrifar_ifar = wf.make_snrifar_plot(workflow, combined_bg_file,
+#                                    rdir['open_box_result/significance'],
+#                                    cumulative=False,
+#                                    tags=combined_bg_file.tags + ['ifar'])
 #ifar_ob = wf.make_ifar_plot(workflow, combined_bg_file,
 #                            rdir['open_box_result/significance'],
 #                            tags=combined_bg_file.tags + ['open_box'])

--- a/bin/workflows/pycbc_create_offline_search_workflow
+++ b/bin/workflows/pycbc_create_offline_search_workflow
@@ -200,7 +200,7 @@ statfiles += wf.setup_trigger_fitting(workflow, insps, hdfbank,
 # final_bg_files contains coinc results using vetoes final_veto_files
 # ifo_ids will store an (integer) index for each ifo in the precedence list
 full_insps = insps
-ctags = [tag, 'full']
+ctags = [tag]
 bg_files = []
 final_bg_files = {}
 ifo_ids = {}
@@ -235,7 +235,7 @@ for i in range(2, len(insps)+1):
                                                                             fixed_ifo,
                                                                             tags=ctagcomb)
 
-combctags = [tag, 'full', 'combine_statmap']
+combctags = [tag]
 final_bg_file_list = wf.FileList()
 for key in final_bg_files:
     final_bg_file_list += final_bg_files[key][0][1]
@@ -485,28 +485,28 @@ for key in final_bg_files:
 inj_coincs = wf.FileList()
 inj_coinc = {}
 for inj_file, tag in zip(inj_files, inj_tags):
-    ctags = [tag, 'inj']
+    ctags = [tag, 'injections']
     output_dir = '%s_coinc' % tag
 
     if workflow.cp.has_option_tags('workflow-injections',
-                                   'compute-optimal-snr', tags=[tag]):
+                                   'compute-optimal-snr', tags=ctags):
         optimal_snr_file = wf.compute_inj_optimal_snr(
-                workflow, inj_file, psd_files, 'inj_files', tags=[tag])
+                workflow, inj_file, psd_files, 'inj_files', tags=ctags)
         file_for_injfind = optimal_snr_file
     else:
         file_for_injfind = inj_file
 
-    if workflow.cp.has_option_tags('workflow-injections', 'inj-cut', tags=[tag]):
+    if workflow.cp.has_option_tags('workflow-injections', 'inj-cut', tags=ctags):
         file_for_vetoes = wf.cut_distant_injections(
-                workflow, file_for_injfind, 'inj_files', tags=[tag])
+                workflow, file_for_injfind, 'inj_files', tags=ctags)
     else:
         file_for_vetoes = inj_file
 
     if workflow.cp.has_option_tags('workflow-injections', 'strip-injections',
-                                   tags=[tag]):
+                                   tags=ctags):
         small_inj_file = wf.veto_injections(workflow, file_for_vetoes,
                              insp_files_seg_file, trig_generated_name,
-                             "inj_files", tags=[tag])
+                             "inj_files", tags=ctags)
     else:
         small_inj_file = file_for_vetoes
 
@@ -514,10 +514,10 @@ for inj_file, tag in zip(inj_files, inj_tags):
     insps = wf.setup_matchedfltr_workflow(workflow, analyzable_segs,
                                      datafind_files, splitbank_files_inj,
                                      output_dir, injection_file=small_inj_file,
-                                     tags = [tag])
+                                     tags=ctags)
 
     insps = wf.merge_single_detector_hdf_files(workflow, hdfbank[0],
-                                               insps, output_dir, tags=[tag])
+                                               insps, output_dir, tags=ctags)
     # multiifo coincidence for injections
     for i in range(2, len(insps)+1):
         combinations = itertools.combinations(ifo_ids.keys(), i)
@@ -527,13 +527,13 @@ for inj_file, tag in zip(inj_files, inj_tags):
 
             # Create coinc tag, and set up the coinc job for the combination
             coinctag = '{}det_'.format(len(ifocomb)) + ordered_ifo_list
-            ctagcomb = [tag, 'inj', coinctag]
+            ctagcomb = [tag, 'injections', coinctag]
             inj_coinc[ordered_ifo_list] = wf.setup_multiifo_interval_coinc_inj(workflow, hdfbank,
                                     full_insps, inspcomb, statfiles, final_bg_files[ordered_ifo_list][0][1],
                                     final_veto_file[0], final_veto_name[0],
                                     output_dir, pivot_ifo, fixed_ifo, tags=ctagcomb)
     
-    combctags = [tag, 'inj', 'combine_statmap']
+    combctags = [tag, 'injections']
     final_inj_bg_file_list = wf.FileList()
     for key in inj_coinc:
         final_inj_bg_file_list += [inj_coinc[key]]

--- a/bin/workflows/pycbc_create_offline_search_workflow
+++ b/bin/workflows/pycbc_create_offline_search_workflow
@@ -171,8 +171,8 @@ splitbank_files_inj = wf.setup_splittable_workflow(workflow, hdfbank,
                                                    out_dir="bank",
                                                    tags=['injections'])
 
-bank_plot = [(wf.make_template_plot(workflow, hdfbank[0],
-              rdir['coincident_triggers']),)]
+bank_plot = wf.make_template_plot(workflow, hdfbank[0],
+                                  rdir['coincident_triggers'])
 
 # setup the injection files
 inj_files, inj_tags = wf.setup_injection_workflow(workflow,
@@ -398,6 +398,86 @@ for insp_file in full_insps:
              # FIXME: Add censored_veto when it exists
              #veto_file=censored_veto, veto_segment_name='closed_box',
              tags=insp_file.tags + [subsec])
+
+##################### COINC FULL_DATA plots ###################################
+
+# Main results with combined file (we mix open and closed box here, but
+# separate them in the result page)
+
+snrifar = wf.make_snrifar_plot(workflow, combined_bg_file,
+                               rdir['open_box_result'],
+                               tags=combined_bg_file.tags)
+snrifar_cb = wf.make_snrifar_plot(workflow, combined_bg_file,
+                                  rdir['coincident_triggers'], closed_box=True,
+                                  tags=combined_bg_file.tags + ['closed'])
+ratehist = wf.make_snrratehist_plot(workflow, combined_bg_file,
+                                    rdir['open_box_result'],
+                                    tags=combined_bg_file.tags)
+snrifar_ifar = wf.make_snrifar_plot(workflow, combined_bg_file,
+                                    rdir['open_box_result/significance'],
+                                    cumulative=False,
+                                    tags=combined_bg_file.tags + ['ifar'])
+ifar_ob = wf.make_ifar_plot(workflow, combined_bg_file,
+                            rdir['open_box_result/significance'],
+                            tags=combined_bg_file.tags + ['open_box'])
+ifar_cb = wf.make_ifar_plot(workflow, combined_bg_file,
+                            rdir['coincident_triggers'],
+                            tags=combined_bg_file.tags + ['closed_box'])
+table = wf.make_foreground_table(workflow, combined_bg_file,
+                                 hdfbank[0], rdir['open_box_result'],
+                                 singles=insps,  extension='.html',
+                                 tags=["html"])
+symlink_result(snrifar, 'open_box_result/significance')
+symlink_result(ratehist, 'open_box_result/significance')
+symlink_result(table, 'open_box_result/significance')
+
+# Set html pages
+main_page = [(snrifar, ratehist),(table,)]
+layout.two_column_layout(rdir['open_box_result'], main_page)
+
+detailed_page = [(snrifar, ratehist), (snrifar_ifar, ifar_ob), (table,)]
+layout.two_column_layout(rdir['open_box_result/significance'], detailed_page)
+
+closed_page = [(snrifar_cb, ifar_cb), (bank_plot,)]
+layout.two_column_layout(rdir['coincident_triggers'], closed_page)
+
+# run minifollowups on the output of the loudest events
+mfup_dir = rdir['open_box_result/loudest_events_followup']
+wf.setup_foreground_minifollowups(workflow, combined_bg_file,
+                                  full_insps,  hdfbank[0], insp_files_seg_file,
+                                  data_analysed_name, trig_generated_name,
+                                  'daxes', mfup_dir,
+                                  tags=combined_bg_file.tags)
+
+# Sub-pages for each ifo combination
+
+for key in final_bg_files:
+    bg_file = final_bg_files[key][0][1]
+    open_dir = rdir['open_box_result/{}_coincidences'.format(key)]
+    closed_dir = rdir['coincident_triggers/{}_coincidences'.format(key)]
+    snrifar = wf.make_snrifar_plot(workflow, bg_file, open_dir,
+                                   tags=bg_file.tags)
+    snrifar_cb = wf.make_snrifar_plot(workflow, bg_file, closed_dir,
+                                      closed_box=True,
+                                      tags=bg_file.tags + ['closed'])
+    ratehist = wf.make_snrratehist_plot(workflow, bg_file, open_dir,
+                                        tags=bg_file.tags)
+    snrifar_ifar = wf.make_snrifar_plot(workflow, bg_file, open_dir,
+                                        cumulative=False,
+                                        tags=bg_file.tags + ['ifar'])
+    ifar_ob = wf.make_ifar_plot(workflow, bg_file, open_dir,
+                                tags=bg_file.tags + ['open_box'])
+    ifar_cb = wf.make_ifar_plot(workflow, bg_file, closed_dir,
+                                tags=bg_file.tags + ['closed_box'])
+    table = wf.make_foreground_table(workflow, bg_file, hdfbank[0], open_dir,
+                                     singles=insps,  extension='.html',
+                                     tags=["html"])
+
+    detailed_page = [(snrifar, ratehist), (snrifar_ifar, ifar_ob), (table,)]
+    layout.two_column_layout(open_dir, detailed_page)
+
+    closed_page = [(snrifar_cb, ifar_cb)]
+    layout.two_column_layout(closed_dir, closed_page)
 
 
 ############################## Setup the injection runs #######################

--- a/bin/workflows/pycbc_create_offline_search_workflow
+++ b/bin/workflows/pycbc_create_offline_search_workflow
@@ -544,10 +544,9 @@ for inj_file, tag in zip(inj_files, inj_tags):
                                                      output_dir,
                                                      tags=combctags)
     
-    found_inj = wf.find_injections_in_hdf_coinc(workflow, combined_inj_bg_file,
-                                    [file_for_injfind],
-                                    final_veto_file[0], final_veto_name[0],
-                                    output_dir, tags=combctags)
+    found_inj = wf.find_injections_in_hdf_coinc\
+        (workflow, [combined_inj_bg_file], [file_for_injfind],
+         final_veto_file[0], final_veto_name[0], output_dir, tags=combctags)
     
     inj_coincs += [combined_inj_bg_file]
 

--- a/bin/workflows/pycbc_create_offline_search_workflow
+++ b/bin/workflows/pycbc_create_offline_search_workflow
@@ -452,7 +452,8 @@ wf.setup_foreground_minifollowups(workflow, combined_bg_file,
 # Sub-pages for each ifo combination
 
 for key in final_bg_files:
-    bg_file = final_bg_files[key][0][1]
+    # FIXME: Stop obfuscating this file!
+    bg_file = final_bg_files[key][0][1][0]
     open_dir = rdir['open_box_result/{}_coincidences'.format(key)]
     closed_dir = rdir['coincident_triggers/{}_coincidences'.format(key)]
     snrifar = wf.make_snrifar_plot(workflow, bg_file, open_dir,

--- a/bin/workflows/pycbc_make_coinc_search_workflow
+++ b/bin/workflows/pycbc_make_coinc_search_workflow
@@ -242,7 +242,7 @@ for bin_file in bin_files:
     
 # Open box table
 table = wf.make_foreground_table(workflow, final_bg_file,
-                    hdfbank[0], tag, rdir['open_box_result'], singles=insps,
+                    hdfbank[0], rdir['open_box_result'], singles=insps,
                     extension='.html', tags=["html"])
 
 symlink_result(table, 'open_box_result/significance')

--- a/pycbc/workflow/coincidence.py
+++ b/pycbc/workflow/coincidence.py
@@ -753,4 +753,4 @@ def setup_multiifo_combine_statmap(workflow, final_bg_file_list, out_dir, tags):
                                                  cluster_window,
                                                  tags)
     workflow.add_node(combine_statmap_node)
-    return combine_statmap_node.output_files[0]
+    return combine_statmap_node.output_file

--- a/pycbc/workflow/coincidence.py
+++ b/pycbc/workflow/coincidence.py
@@ -753,4 +753,4 @@ def setup_multiifo_combine_statmap(workflow, final_bg_file_list, out_dir, tags):
                                                  cluster_window,
                                                  tags)
     workflow.add_node(combine_statmap_node)
-    return combine_statmap_node.output_files
+    return combine_statmap_node.output_files[0]

--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -505,6 +505,11 @@ class Executable(pegasus_workflow.Executable):
         tags : list
             The new list of tags to consider.
         """
+        if len(tags) > 6:
+            warn_msg = "This job has way too many tags. "
+            warn_msg += "Current tags are {}. ".format(' '.join(tags))
+            warn_msg += "Current executable {}.".format(self.name)
+            logging.info(warn_msg)
         if tags is None:
             tags = []
         tags = [tag.upper() for tag in tags]

--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -505,15 +505,16 @@ class Executable(pegasus_workflow.Executable):
         tags : list
             The new list of tags to consider.
         """
+        if tags is None:
+            tags = []
+        tags = [tag.upper() for tag in tags]
+        self.tags = tags
+
         if len(tags) > 6:
             warn_msg = "This job has way too many tags. "
             warn_msg += "Current tags are {}. ".format(' '.join(tags))
             warn_msg += "Current executable {}.".format(self.name)
             logging.info(warn_msg)
-        if tags is None:
-            tags = []
-        tags = [tag.upper() for tag in tags]
-        self.tags = tags
 
         if len(tags) != 0:
             self.tagged_name = "{0}-{1}".format(self.name, '_'.join(tags))

--- a/pycbc/workflow/plotting.py
+++ b/pycbc/workflow/plotting.py
@@ -127,7 +127,7 @@ def make_throughput_plot(workflow, insp_files, out_dir, tags=None):
     node.new_output_file_opt(workflow.analysis_time, '.png', '--output-file')
     workflow += node
 
-def make_foreground_table(workflow, trig_file, bank_file, ftag, out_dir,
+def make_foreground_table(workflow, trig_file, bank_file, out_dir,
                           singles=None, extension='.html', tags=None,
                           hierarchical_level=None):
 
@@ -143,7 +143,6 @@ def make_foreground_table(workflow, trig_file, bank_file, ftag, out_dir,
     node = PlotExecutable(workflow.cp, 'page_foreground', ifos=workflow.ifos,
                     out_dir=out_dir, tags=tags).create_node()
     node.add_input_opt('--bank-file', bank_file)
-    node.add_opt('--foreground-tag', ftag)
     node.add_input_opt('--trigger-file', trig_file)
     if hierarchical_level is not None:
         node.add_opt('--use-hierarchical-level', hierarchical_level)


### PR DESCRIPTION
I set out to add section 4 and 7 plots into the new workflow. In doing this I had to fix a few other issues, which all now appear together here (because separating this off is a major time sink). Many of the section 4/7 plots are currently not working with the new format inputs. However, when these codes are patched the corresponding lines in the commented out code below can be uncommented and these will be added. Here's the list of things included in this PR.

 * Add all section 4/7 plots to the workflow
 * After testing, comment out all section 4/7 plots that are not working.
 * Clean up usage of tags in the new workflow (please don't add unneeded tags or send jobs tags that are not needed!!)
 * Add a warning message to inform you if you are using too many tags
 * Remove unused ancient command line from pycbc_page_foreground
 * Don't return a list of output_files, when only one file is returned (there's some additional cases of this around, I'll take a better look over this in the future).
 * Some PEP8 changes as I really struggle to read > 80 character lines in vi (again, some more changes would be needed here than I can make in the future).