### PR TITLE
add clustering option to pycbc inspiral to cluster triggers in chirp bins.

### DIFF
--- a/bin/pycbc_inspiral
+++ b/bin/pycbc_inspiral
@@ -161,6 +161,8 @@ parser.add_argument("--user-tag", type=str, metavar="TAG", help="""
                     This is used to identify FULL_DATA jobs for
                     compatibility with pipedown post-processing.
                     Option will be removed when no longer needed.""")
+parser.add_argument("--keep-loudest-log-chirp-window", type=float,
+                    help="Keep loudest triggers within log chirp mass window")
 parser.add_argument("--keep-loudest-interval", type=float,
                     help="Window in seconds to maximize triggers over bank")
 parser.add_argument("--keep-loudest-num", type=int,
@@ -214,10 +216,10 @@ with ctx:
 
     # Read specified user-provided wisdom files
     if opt.fftw_input_float_wisdom_file is not None:
-        import_single_wisdom_from_filename(opt.fftw_input_float_wisdom_file)        
+        import_single_wisdom_from_filename(opt.fftw_input_float_wisdom_file)
 
     if opt.fftw_input_double_wisdom_file is not None:
-        import_double_wisdom_from_filename(opt.fftw_input_double_wisdom_file)    
+        import_double_wisdom_from_filename(opt.fftw_input_double_wisdom_file)
 
     flow = opt.low_frequency_cutoff
     flen = strain_segments.freq_len
@@ -344,7 +346,7 @@ with ctx:
     # from the bank.
     for t_num in xrange(len(bank)):
         tmplt_generated = False
-       
+
         for s_num, stilde in enumerate(segments):
             # Filter check checks the 'inj_filter_rejector' options to
             # determine whether
@@ -433,8 +435,10 @@ if opt.keep_loudest_interval:
     logging.info("Removing triggers that are not within the top %s loudest"
                  " of a %s second interval" % (opt.keep_loudest_num,
                                                opt.keep_loudest_interval))
-    event_mgr.keep_loudest_in_interval(opt.keep_loudest_interval * opt.sample_rate,
-                                       opt.keep_loudest_num)
+    event_mgr.keep_loudest_in_interval(
+        opt.keep_loudest_interval * opt.sample_rate,
+        opt.keep_loudest_num,
+        log_chirp_width=opt.keep_loudest_log_chirp_window)
     logging.info("%d remaining triggers" % len(event_mgr.events))
 
 if opt.injection_window and hasattr(gwstrain, 'injections'):

--- a/bin/pycbc_inspiral
+++ b/bin/pycbc_inspiral
@@ -162,7 +162,7 @@ parser.add_argument("--user-tag", type=str, metavar="TAG", help="""
                     compatibility with pipedown post-processing.
                     Option will be removed when no longer needed.""")
 parser.add_argument("--keep-loudest-log-chirp-window", type=float,
-                    help="Keep loudest triggers within log chirp mass window")
+                    help="Keep loudest triggers within ln chirp mass window")
 parser.add_argument("--keep-loudest-interval", type=float,
                     help="Window in seconds to maximize triggers over bank")
 parser.add_argument("--keep-loudest-num", type=int,

--- a/pycbc/events/events.py
+++ b/pycbc/events/events.py
@@ -221,7 +221,7 @@ def newsnr_sgveto(snr, bchisq, sgchisq):
         return nsnr[0]
 
 def newsnr_sgveto_psdvar(snr, bchisq, sgchisq, psd_var_val):
-    """ Combined SNR derived from NewSNR, Sine-Gaussian Chisq and PSD 
+    """ Combined SNR derived from NewSNR, Sine-Gaussian Chisq and PSD
     variation statistic """
     nsnr = newsnr_sgveto(snr, bchisq, sgchisq)
     nsnr = numpy.array(nsnr, ndmin=1)
@@ -308,7 +308,7 @@ class EventManager(object):
         i = indices_within_times(gpstime, inj_time - window, inj_time + window)
         self.events = self.events[i]
 
-    def keep_loudest_in_interval(self, window, num_keep):
+    def keep_loudest_in_interval(self, window, num_keep, log_chirp_width=None):
         if len(self.events) == 0:
             return
 
@@ -319,11 +319,29 @@ class EventManager(object):
         wtime = (time / window).astype(numpy.int32)
         bins = numpy.unique(wtime)
 
+        if log_chirp_width:
+            from pycbc.conversions import mchirp_from_mass1_mass2
+            m1 = numpy.array([p['tmplt'].mass1 for p in self.template_params])
+            m2 = numpy.array([p['tmplt'].mass2 for p in self.template_params])
+
+            # chirp mass of each template
+            mc = mchirp_from_mass1_mass2(m1, m2)[e['template_id']]
+            lmc = numpy.log(mc)
+            imc = (lmc / log_chirp_width).astype(numpy.int32)
+            cbins = numpy.unique(imc)
+
         keep = []
         for b in bins:
-            bloc = numpy.where((wtime == b))[0]
-            bloudest = stat[bloc].argsort()[-num_keep:]
-            keep.append(bloc[bloudest])
+            if log_chirp_width:
+                for b2 in cbins:
+                    bloc = numpy.where((wtime == b) & (imc == b2))[0]
+                    bloudest = stat[bloc].argsort()[-num_keep:]
+                    keep.append(bloc[bloudest])
+            else:
+                bloc = numpy.where((wtime == b))[0]
+                bloudest = stat[bloc].argsort()[-num_keep:]
+                keep.append(bloc[bloudest])
+
         keep = numpy.concatenate(keep)
         self.events = e[keep]
 

--- a/pycbc/events/events.py
+++ b/pycbc/events/events.py
@@ -324,8 +324,6 @@ class EventManager(object):
             from pycbc.conversions import mchirp_from_mass1_mass2
             m1 = numpy.array([p['tmplt'].mass1 for p in self.template_params])
             m2 = numpy.array([p['tmplt'].mass2 for p in self.template_params])
-
-            # chirp mass of each template
             mc = mchirp_from_mass1_mass2(m1, m2)[e['template_id']]
 
             # convert chirp mass to an integer which indicates its cluster bin

--- a/pycbc/events/events.py
+++ b/pycbc/events/events.py
@@ -316,6 +316,7 @@ class EventManager(object):
         stat = newsnr(abs(e['snr']), e['chisq'] / e['chisq_dof'])
         time = e['time_index']
 
+        # convert time to time bin index
         wtime = (time / window).astype(numpy.int32)
         bins = numpy.unique(wtime)
 
@@ -326,8 +327,9 @@ class EventManager(object):
 
             # chirp mass of each template
             mc = mchirp_from_mass1_mass2(m1, m2)[e['template_id']]
-            lmc = numpy.log(mc)
-            imc = (lmc / log_chirp_width).astype(numpy.int32)
+
+            # convert chirp mass to an integer which indicates its cluster bin
+            imc = (numpy.log(mc) / log_chirp_width).astype(numpy.int32)
             cbins = numpy.unique(imc)
 
         keep = []


### PR DESCRIPTION
This helps smooth out the triggers a bit as a function of chirp mass more than the raw bins in chirp mass made by splitting the template bank. 

Adds *optional* argument to pycbc inspiral

--keep-loudest-log-chirp-window which allows binning in the log chirp mass of the template being analyzed. Clustering is then done in each bin separately over time. 

