### PR TITLE
Allow the segments to query O1 or O2 times

### DIFF
--- a/pycbc/dq.py
+++ b/pycbc/dq.py
@@ -151,7 +151,8 @@ def query_flag(ifo, name, start_time, end_time,
             return (data - negate).coalesce()
 
         duration = end_time - start_time
-        url = GWOSC_URL.format(_get_run(start_time + duration/2), ifo, segment_name,
+        url = GWOSC_URL.format(_get_run(start_time + duration/2),
+                               ifo, segment_name,
                                int(start_time), int(duration))
 
         try:

--- a/pycbc/dq.py
+++ b/pycbc/dq.py
@@ -29,7 +29,7 @@ import json
 import numpy
 from astropy.utils.data import download_file
 from ligo.segments import segmentlist, segment
-from pycbc.frame.losc import _get_run
+from pycbc.frame.losc import get_run
 
 def parse_veto_definer(veto_def_filename):
     """ Parse a veto definer file from the filename and return a dictionary
@@ -151,7 +151,7 @@ def query_flag(ifo, name, start_time, end_time,
             return (data - negate).coalesce()
 
         duration = end_time - start_time
-        url = GWOSC_URL.format(_get_run(start_time + duration/2),
+        url = GWOSC_URL.format(get_run(start_time + duration/2),
                                ifo, segment_name,
                                int(start_time), int(duration))
 

--- a/pycbc/dq.py
+++ b/pycbc/dq.py
@@ -29,7 +29,7 @@ import json
 import numpy
 from astropy.utils.data import download_file
 from ligo.segments import segmentlist, segment
-
+from pycbc.frame.losc import _get_run
 
 def parse_veto_definer(veto_def_filename):
     """ Parse a veto definer file from the filename and return a dictionary
@@ -92,7 +92,7 @@ def parse_veto_definer(veto_def_filename):
     return data
 
 
-GWOSC_URL = 'https://www.gw-openscience.org/timeline/segments/json/O1/{}_{}/{}/{}/'
+GWOSC_URL = 'https://www.gw-openscience.org/timeline/segments/json/{}/{}_{}/{}/{}/'
 
 
 def query_flag(ifo, name, start_time, end_time,
@@ -151,7 +151,7 @@ def query_flag(ifo, name, start_time, end_time,
             return (data - negate).coalesce()
 
         duration = end_time - start_time
-        url = GWOSC_URL.format(ifo, segment_name,
+        url = GWOSC_URL.format(_get_run(start_time + duration/2), ifo, segment_name,
                                int(start_time), int(duration))
 
         try:

--- a/pycbc/frame/losc.py
+++ b/pycbc/frame/losc.py
@@ -20,7 +20,7 @@ from astropy.utils.data import download_file
 
 _losc_url = "https://losc.ligo.org/archive/links/%s/%s/%s/%s/json/"
 
-def _get_run(time):
+def get_run(time):
     if 1164556817 <= time <= 1187733618:
         return 'O2_16KHZ_R1'
     if 1126051217 <= time <= 1137254417:
@@ -57,8 +57,8 @@ def losc_frame_json(ifo, start_time, end_time):
         requested times.
     """
     import urllib, json
-    run = _get_run(start_time)
-    run2 = _get_run(end_time)
+    run = get_run(start_time)
+    run2 = get_run(end_time)
     if run != run2:
         raise ValueError('Spanning multiple runs is not currently supported.'
                          'You have requested data that uses '


### PR DESCRIPTION
This makes the segment query of GWOSC info run independent and not hardcoded to just O1 segment info.