### PR TITLE
Make low frequency cutoff required when using data in pycbc inference

### DIFF
--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -126,6 +126,10 @@ model_args = {}
 # get the data and psd
 strain_dict, stilde_dict, psd_dict = option_utils.data_from_cli(opts)
 if stilde_dict:
+    # make sure a low frequency cutoff was provided
+    if not opts.low_frequency_cutoff:
+        raise ValueError("must provide --low-frequency-cutoff for PSD "
+                         "estimation")
     model_args['data'] = stilde_dict
     model_args['psds'] = psd_dict
 

--- a/pycbc/inference/option_utils.py
+++ b/pycbc/inference/option_utils.py
@@ -74,7 +74,8 @@ def add_low_frequency_cutoff_opt(parser):
     # now. We should allow for different frequency cutoffs to be used; that
     # will require (minor) changes to the Likelihood class
     parser.add_argument("--low-frequency-cutoff", type=float,
-                        help="Low frequency cutoff for each IFO.")
+                        help="Low frequency cutoff to use for each IFO's PSD "
+                             "estimate.")
 
 
 def low_frequency_cutoff_from_cli(opts):


### PR DESCRIPTION
It turns out that the strain module needs a low frequency cutoff option to be specified, for inverse spectrum truncation. Otherwise, the low frequencies will overwhelm the inverse PSD estimate, resulting in a junk PSD. Not realizing this has caused a few different people to get junk PE results now, which we only realized after several days of running.

This patch adds a catch that will raise an error if data is loaded, but no low frequency cutoff was provided. The help message for `low-frequency-cutoff` is also modified to make it clear that the command-line option is for PSD estimation (while likelihood cutoff is specified in the config file).