### PR TITLE
Corrects an error caused by pull request #2562.

### DIFF
--- a/bin/inference/pycbc_inference_plot_prior
+++ b/bin/inference/pycbc_inference_plot_prior
@@ -66,7 +66,7 @@ parser.add_argument("--parameters", nargs="+", action=ParseParametersArg,
                          "property of that parameter will be used. If not "
                          "provided, will plot all of the parameters in the "
                          "[variable_params] section of the config file.")
-parser.add_argument("--sections", type=str, nargs="+", default=["prior"],
+parser.add_argument("--prior-section", type=str, default="prior",
                     help="Name of section with distribution configurations. "
                          "Default is 'prior'.")
 # add output options
@@ -92,7 +92,7 @@ logging.info("Reading configuration files")
 cp = WorkflowConfigParser(opts.config_files)
 
 logging.info("Loading prior")
-prior = prior_from_config(cp, sections=opts.sections)
+prior = prior_from_config(cp, prior_section=opts.prior_section)
 logging.info("Drawing samples from prior")
 samples = prior.rvs(opts.nsamples)
 

--- a/pycbc/inference/option_utils.py
+++ b/pycbc/inference/option_utils.py
@@ -465,7 +465,7 @@ def add_density_option_group(parser):
     return density_group
 
 
-def prior_from_config(cp, sections='prior'):
+def prior_from_config(cp, prior_section='prior'):
     """Loads a prior distribution from the given config file.
 
     Parameters
@@ -483,13 +483,13 @@ def prior_from_config(cp, sections='prior'):
     """
     # Read variable and static parameters from the config file
     variable_params, _ = distributions.read_params_from_config(
-        cp, prior_section=sections, vargs_section='variable_params',
+        cp, prior_section=prior_section, vargs_section='variable_params',
         sargs_section='static_params')
     # Read constraints to apply to priors from the config file
     constraints = distributions.read_constraints_from_config(cp)
     # Get PyCBC distribution instances for each variable parameter in the
     # config file
-    dists = distributions.read_distributions_from_config(cp, sections)
+    dists = distributions.read_distributions_from_config(cp, prior_section)
     # construct class that will return draws from the prior
     return distributions.JointDistribution(variable_params, *dists,
                                            **{"constraints": constraints})


### PR DESCRIPTION
Changes parser.add_argument from default = ["prior"] to default="prior".  It also changes the option name from --sections to --prior-section