### PR TITLE
Implement condor checkpointing

### DIFF
--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -139,7 +139,8 @@ with ctx:
     cp = option_utils.config_parser_from_cli(opts)
 
     # create an empty checkpoint file, if needed
-    if cp.has_option('sampler', 'checkpoint-signal'):
+    condor_ckpt = cp.has_option('sampler', 'checkpoint-signal')
+    if condor_ckpt:
         logging.info(
             "Sampler will exit with signal {} after checkpointing".format(
                 cp.get('sampler', 'checkpoint-signal')))
@@ -210,9 +211,8 @@ with ctx:
     # Finalize the output 
     sampler.finalize()
 
-if cp.has_option('sampler', 'checkpoint-signal'):
-   # create an empty checkpoint file and unlink the empty output file
-   open(sampler.checkpoint_file, 'a').close()
+if condor_ckpt:
+   # unlink the empty output file
    try:
        os.unlink(opts.output_file)
    except:
@@ -224,6 +224,10 @@ os.rename(sampler.checkpoint_file, opts.output_file)
 if not opts.save_backup:
     logging.info("Deleting backup file")
     os.remove(sampler.backup_file)
+
+if condor_ckpt:
+   # create an empty checkpoint file
+   open(sampler.checkpoint_file, 'a').close()
 
 # exit
 logging.info("Done")

--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -209,5 +209,8 @@ if not opts.save_backup:
     logging.info("Deleting backup file")
     os.remove(sampler.backup_file)
 
+# create an empty checkpoint file, if needed
+if cp.has_option('sampler', 'checkpoint-signal'):
+   open(sampler.checkpoint_file, 'a').close()
 # exit
 logging.info("Done")

--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -138,6 +138,14 @@ with ctx:
     # read configuration file
     cp = option_utils.config_parser_from_cli(opts)
 
+    # create an empty checkpoint file, if needed
+    if cp.has_option('sampler', 'checkpoint-signal'):
+        logging.info(
+            "Sampler will exit with signal {} after checkpointing".format(
+                cp.get('sampler', 'checkpoint-signal')))
+        # create an empty output file to keep condor happy
+        open(opts.output_file, 'a').close()
+
     # get ifo-specific instances of calibration model
     if cp.has_section('calibration'):
         logging.info("Initializing calibration model")
@@ -202,6 +210,14 @@ with ctx:
     # Finalize the output 
     sampler.finalize()
 
+if cp.has_option('sampler', 'checkpoint-signal'):
+   # create an empty checkpoint file and unlink the empty output file
+   open(sampler.checkpoint_file, 'a').close()
+   try:
+       os.unlink(opts.output_file)
+   except:
+       pass
+
 # rename checkpoint to output and delete backup
 logging.info("Moving checkpoint to output")
 os.rename(sampler.checkpoint_file, opts.output_file)
@@ -209,8 +225,5 @@ if not opts.save_backup:
     logging.info("Deleting backup file")
     os.remove(sampler.backup_file)
 
-# create an empty checkpoint file, if needed
-if cp.has_option('sampler', 'checkpoint-signal'):
-   open(sampler.checkpoint_file, 'a').close()
 # exit
 logging.info("Done")

--- a/pycbc/inference/sampler/base_mcmc.py
+++ b/pycbc/inference/sampler/base_mcmc.py
@@ -25,6 +25,8 @@
 
 from __future__ import (absolute_import, division)
 
+import os
+import signal
 from abc import (ABCMeta, abstractmethod, abstractproperty)
 import logging
 import numpy

--- a/pycbc/inference/sampler/base_mcmc.py
+++ b/pycbc/inference/sampler/base_mcmc.py
@@ -608,7 +608,7 @@ class BaseMCMC(object):
             # kill myself with the specified signal
             logging.info("Exiting with SIG{}".format(self.checkpoint_signal))
             kill_cmd="os.kill(os.getpid(), signal.SIG{})".format(
-                self.checkpoint_signal))
+                self.checkpoint_signal)
             exec(kill_cmd)
         # clear the in-memory chain to save memory
         logging.info("Clearing samples from memory")

--- a/pycbc/inference/sampler/base_mcmc.py
+++ b/pycbc/inference/sampler/base_mcmc.py
@@ -190,6 +190,7 @@ class BaseMCMC(object):
     nwalkers
     niterations
     checkpoint_interval
+    checkpoint_signal
     target_niterations
     target_eff_nsamples
     thin_interval
@@ -210,6 +211,7 @@ class BaseMCMC(object):
     _burn_in = None
     _acls = None
     _checkpoint_interval = None
+    _checkpoint_signal = None
     _target_niterations = None
     _target_eff_nsamples = None
     _thin_interval = 1
@@ -248,6 +250,11 @@ class BaseMCMC(object):
     def checkpoint_interval(self):
         """The number of iterations to do between checkpoints."""
         return self._checkpoint_interval
+
+    @property
+    def checkpoint_signal(self):
+        """The signal to use when checkpointing."""
+        return self._checkpoint_signal
 
     @property
     def target_niterations(self):
@@ -597,6 +604,12 @@ class BaseMCMC(object):
             self.checkpoint_file, self.backup_file)
         if not checkpoint_valid:
             raise IOError("error writing to checkpoint file")
+        elif self.checkpoint_signal:
+            # kill myself with the specified signal
+            logging.info("Exiting with SIG{}".format(self.checkpoint_signal))
+            kill_cmd="os.kill(os.getpid(), signal.SIG{})".format(
+                self.checkpoint_signal))
+            exec(kill_cmd)
         # clear the in-memory chain to save memory
         logging.info("Clearing samples from memory")
         self.clear_samples()
@@ -621,6 +634,27 @@ class BaseMCMC(object):
         """
         return get_optional_arg_from_config(cp, section, 'checkpoint-interval',
                                             dtype=int)
+
+    @staticmethod
+    def ckpt_signal_from_config(cp, section):
+        """Gets the checkpoint signal from the given config file.
+
+        This looks for 'checkpoint-signal' in the section.
+
+        Parameters
+        ----------
+        cp : ConfigParser
+            Open config parser to retrieve the argument from.
+        section : str
+            Name of the section to retrieve from.
+
+        Return
+        ------
+        int or None :
+            The checkpoint interval, if it is in the section. Otherw
+        """
+        return get_optional_arg_from_config(cp, section, 'checkpoint-signal',
+                                            dtype=str)
 
     def set_target_from_config(self, cp, section):
         """Sets the target using the given config file.

--- a/pycbc/inference/sampler/emcee.py
+++ b/pycbc/inference/sampler/emcee.py
@@ -67,7 +67,8 @@ class EmceeEnsembleSampler(MCMCAutocorrSupport, BaseMCMC, BaseSampler):
     _io = EmceeFile
     burn_in_class = MCMCBurnInTests
 
-    def __init__(self, model, nwalkers, checkpoint_interval=None,
+    def __init__(self, model, nwalkers,
+                 checkpoint_interval=None, checkpoint_signal=None,
                  logpost_function=None, nprocesses=1, use_mpi=False):
 
         self.model = model
@@ -95,6 +96,7 @@ class EmceeEnsembleSampler(MCMCAutocorrSupport, BaseMCMC, BaseSampler):
         rstate = numpy.random.get_state()
         self._sampler.random_state = rstate
         self._checkpoint_interval = checkpoint_interval
+        self._checkpoint_signal = checkpoint_signal
 
     @property
     def io(self):
@@ -199,9 +201,12 @@ class EmceeEnsembleSampler(MCMCAutocorrSupport, BaseMCMC, BaseSampler):
         nwalkers = int(cp.get(section, "nwalkers"))
         # get the checkpoint interval, if it's specified
         checkpoint_interval = cls.checkpoint_from_config(cp, section)
+        checkpoint_signal = cls.ckpt_signal_from_config(cp, section)
         # get the logpost function
         lnpost = get_optional_arg_from_config(cp, section, 'logpost-function')
-        obj = cls(model, nwalkers, checkpoint_interval=checkpoint_interval,
+        obj = cls(model, nwalkers,
+                  checkpoint_interval=checkpoint_interval,
+                  checkpoint_signal=checkpoint_signal,
                   logpost_function=lnpost, nprocesses=nprocesses,
                   use_mpi=use_mpi)
         # set target

--- a/pycbc/inference/sampler/emcee_pt.py
+++ b/pycbc/inference/sampler/emcee_pt.py
@@ -65,7 +65,8 @@ class EmceePTSampler(MultiTemperedAutocorrSupport, MultiTemperedSupport,
     burn_in_class = MultiTemperedMCMCBurnInTests
 
     def __init__(self, model, ntemps, nwalkers, betas=None,
-                 checkpoint_interval=None, loglikelihood_function=None,
+                 checkpoint_interval=None, checkpoint_signal=None,
+                 loglikelihood_function=None,
                  nprocesses=1, use_mpi=False):
 
         self.model = model
@@ -100,6 +101,7 @@ class EmceePTSampler(MultiTemperedAutocorrSupport, MultiTemperedSupport,
         self._nwalkers = nwalkers
         self._ntemps = ntemps
         self._checkpoint_interval = checkpoint_interval
+        self._checkpoint_signal = checkpoint_signal
 
     @property
     def io(self):
@@ -153,10 +155,12 @@ class EmceePTSampler(MultiTemperedAutocorrSupport, MultiTemperedSupport,
             ntemps = int(cp.get(section, "ntemps"))
         # get the checkpoint interval, if it's specified
         checkpoint_interval = cls.checkpoint_from_config(cp, section)
+        checkpoint_signal = cls.ckpt_signal_from_config(cp, section)
         # get the loglikelihood function
         logl = get_optional_arg_from_config(cp, section, 'logl-function')
         obj = cls(model, ntemps, nwalkers, betas=betas,
                   checkpoint_interval=checkpoint_interval,
+                  checkpoint_signal=checkpoint_signal,
                   loglikelihood_function=logl, nprocesses=nprocesses,
                   use_mpi=use_mpi)
         # set target

--- a/pycbc/workflow/jobsetup.py
+++ b/pycbc/workflow/jobsetup.py
@@ -1869,7 +1869,7 @@ class PycbcInferenceExecutable(Executable):
 
         if self.cp.has_option("pegasus_profile-inference",
                               "condor|+CheckpointSig"):
-            ckpt_file_name = "{}.checkpoint".format(inference_file)
+            ckpt_file_name = "{}.checkpoint".format(inference_file.name)
             ckpt_file = dax.File(ckpt_file_name)
             node._dax_node.uses(ckpt_file, link=dax.Link.OUTPUT,
                                 register=False, transfer=False)

--- a/pycbc/workflow/jobsetup.py
+++ b/pycbc/workflow/jobsetup.py
@@ -1867,7 +1867,8 @@ class PycbcInferenceExecutable(Executable):
                                                   ".hdf", "--output-file",
                                                   tags=tags)
 
-        if self.cp.has_option("sampler", "checkpoint-signal"):
+        if self.cp.has_option("pegasus_profile-inference",
+                              "condor|+CheckpointSig"):
             ckpt_file_name = "{}.checkpoint".format(inference_file)
             ckpt_file = dax.File(ckpt_file_name)
             node._dax_node.uses(ckpt_file, link=dax.Link.OUTPUT,

--- a/pycbc/workflow/jobsetup.py
+++ b/pycbc/workflow/jobsetup.py
@@ -1867,4 +1867,11 @@ class PycbcInferenceExecutable(Executable):
                                                   ".hdf", "--output-file",
                                                   tags=tags)
 
+        if self.cp.has_option("sampler", "checkpoint-signal"):
+            ckpt_file_name = "{}.checkpoint".format(inference_file)
+            ckpt_file = dax.File(ckpt_file_name)
+            node._dax_node.uses(ckpt_file, link=dax.Link.OUTPUT,
+                                register=False, transfer=False)
+            node.add_opt("samples-file", ckpt_file_name)
+
         return node, inference_file

--- a/pycbc/workflow/jobsetup.py
+++ b/pycbc/workflow/jobsetup.py
@@ -1873,6 +1873,5 @@ class PycbcInferenceExecutable(Executable):
             ckpt_file = dax.File(ckpt_file_name)
             node._dax_node.uses(ckpt_file, link=dax.Link.OUTPUT,
                                 register=False, transfer=False)
-            node.add_opt("--samples-file", ckpt_file_name)
 
         return node, inference_file

--- a/pycbc/workflow/jobsetup.py
+++ b/pycbc/workflow/jobsetup.py
@@ -1873,6 +1873,6 @@ class PycbcInferenceExecutable(Executable):
             ckpt_file = dax.File(ckpt_file_name)
             node._dax_node.uses(ckpt_file, link=dax.Link.OUTPUT,
                                 register=False, transfer=False)
-            node.add_opt("samples-file", ckpt_file_name)
+            node.add_opt("--samples-file", ckpt_file_name)
 
         return node, inference_file


### PR DESCRIPTION
This patch allows the user to specify a signal in the workflow ini file which triggers the sampler to exit after it has written a checkpoint. If the right set of ini options are specified, then the condor will restart the job, taking care of the transfer of checkpoint files.

To enable this using `SIGUSR2`, add the following pegasus profiles for the executable:
```
[pegasus_profile-inference]
pegasus|gridstart = NoGridStart
condor|+CheckpointExitBySignal = True
condor|+CheckpointExitSignal = 12
condor|+SuccessCheckpointExitBySignal = True
condor|+SuccessCheckpointExitSignal = 12
condor|+WantFTOnCheckpoint = True
condor|+CheckpointSig = 12
condor|periodic_remove = (HoldReasonCode is 13)
```
and the following option for the sampler:
```
[sampler]
checkpoint-signal = USR2
```