### PR TITLE
Allow setting scheme from environment

### DIFF
--- a/pycbc/scheme.py
+++ b/pycbc/scheme.py
@@ -151,16 +151,31 @@ class MKLScheme(CPUScheme):
 class NumpyScheme(CPUScheme):
     pass
 
-class DefaultScheme(CPUScheme):
+scheme_prefix = {
+    CUDAScheme: "cuda",
+    CPUScheme: "cpu",
+    MKLScheme: "mkl",
+    NumpyScheme: "numpy",
+}
+_scheme_map = {v: k  for (k, v) in scheme_prefix.items()}
+
+_default_scheme_prefix = os.getenv("PYCBC_SCHEME", "cpu")
+try:
+    _default_scheme_class = _scheme_map[_default_scheme_prefix]
+except KeyError as exc:
+    raise RuntimeError(
+        "PYCBC_SCHEME={!r} not recognised, please select one of: {}".format(
+            _default_scheme_prefix,
+            ", ".join(map(repr, _scheme_map)),
+        ),
+    )
+
+class DefaultScheme(_default_scheme_class):
     pass
 
 default_context = DefaultScheme()
 mgr.state = default_context
-scheme_prefix = {CUDAScheme: "cuda",
-                 CPUScheme: "cpu",
-                 MKLScheme: "mkl",
-                 NumpyScheme: "numpy",
-                 DefaultScheme: 'cpu'}
+scheme_prefix[DefaultScheme] = _default_scheme_prefix
 
 def current_prefix():
     return scheme_prefix[type(mgr.state)]

--- a/pycbc/scheme.py
+++ b/pycbc/scheme.py
@@ -151,13 +151,14 @@ class MKLScheme(CPUScheme):
 class NumpyScheme(CPUScheme):
     pass
 
+
 scheme_prefix = {
     CUDAScheme: "cuda",
     CPUScheme: "cpu",
     MKLScheme: "mkl",
     NumpyScheme: "numpy",
 }
-_scheme_map = {v: k  for (k, v) in scheme_prefix.items()}
+_scheme_map = {v: k for (k, v) in scheme_prefix.items()}
 
 _default_scheme_prefix = os.getenv("PYCBC_SCHEME", "cpu")
 try:


### PR DESCRIPTION
This PR adds support for setting the default processing scheme using the `PYCBC_SCHEME` environment variable (default `"cpu"`), which must match one of the available schemes. 

```pytb
$ python -c "from pycbc.scheme import *; print(scheme_prefix[DefaultScheme])"
cpu
$ PYCBC_SCHEME="numpy" python -c "from pycbc.scheme import *; print(scheme_prefix[DefaultScheme])"
numpy
$ PYCBC_SCHEME="blah" python -c "from pycbc.scheme import *; print(scheme_prefix[DefaultScheme])"
Traceback (most recent call last):
  File "/Users/duncan/git/pycbc-fork/pycbc/scheme.py", line 164, in <module>
    _default_scheme_class = _scheme_map[_default_scheme_prefix]
KeyError: 'blah'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/duncan/git/pycbc-fork/pycbc/__init__.py", line 154, in <module>
    import pycbc.fft.mkl
  File "/Users/duncan/git/pycbc-fork/pycbc/fft/__init__.py", line 17, in <module>
    from .parser_support import insert_fft_option_group, verify_fft_options, from_cli
  File "/Users/duncan/git/pycbc-fork/pycbc/fft/parser_support.py", line 29, in <module>
    from .backend_support import get_backend_modules, get_backend_names
  File "/Users/duncan/git/pycbc-fork/pycbc/fft/backend_support.py", line 30, in <module>
    import pycbc.scheme
  File "/Users/duncan/git/pycbc-fork/pycbc/scheme.py", line 169, in <module>
    ", ".join(map(repr, _scheme_map)),
RuntimeError: PYCBC_SCHEME='blah' not recognised, please select one of: 'cuda', 'cpu', 'mkl', 'numpy'
```

Because the `PYCBC_SCHEME` is evaluated at `import` time, this doesn't support switching the default scheme inside a single python session, but that's probably not something very useful anyway.