### PR TITLE
Change suggested number of walkers and burn in

### DIFF
--- a/examples/inference/bbh-injection/inference.ini
+++ b/examples/inference/bbh-injection/inference.ini
@@ -4,14 +4,14 @@ low-frequency-cutoff = 20
 
 [sampler]
 name = emcee_pt
-nwalkers = 200
-ntemps = 20
+nwalkers = 1000
+ntemps = 4
 effective-nsamples = 1000
 checkpoint-interval = 2000
 max-samples-per-chain = 1000
 
 [sampler-burn_in]
-burn-in-test = nacl
+burn-in-test = nacl & max_posterior
 
 [variable_params]
 ; waveform parameters that will vary in MCMC


### PR DESCRIPTION
Sets the number of walkers and temps in the example configuration file to 1000 and 4, instead of 200 and 20. Also adds `max_posterior` to the burn in tests, which protects against `emcee_pt` quitting too early.