### PR TITLE
Use config argument group in pycbc inference

### DIFF
--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -137,7 +137,7 @@ if stilde_dict:
 with ctx:
 
     # read configuration file
-    cp = configuration.WorkflowConfigParser.from_clie(opts)
+    cp = configuration.WorkflowConfigParser.from_cli(opts)
 
     # create an empty checkpoint file, if needed
     condor_ckpt = cp.has_option('sampler', 'checkpoint-signal')

--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -34,6 +34,7 @@ from pycbc import __version__
 from pycbc import inference
 from pycbc.inference import (models, burn_in, option_utils)
 from pycbc.strain.calibration import Recalibrate
+from pycbc.workflow import configuration
 
 # command line usage
 parser = argparse.ArgumentParser(usage=__file__ + " [--options]",
@@ -79,7 +80,7 @@ parser.add_argument("--seed", type=int, default=0,
                     help="Seed to use for the random number generator that "
                          "initially distributes the walkers. Default is 0.")
 # add config options
-option_utils.add_config_opts_to_parser(parser)
+configuration.add_workflow_command_line_group(parser)
 # add module pre-defined options
 fft.insert_fft_option_group(parser)
 opt.insert_optimization_option_group(parser)
@@ -136,7 +137,7 @@ if stilde_dict:
 with ctx:
 
     # read configuration file
-    cp = option_utils.config_parser_from_cli(opts)
+    cp = configuration.WorkflowConfigParser.from_clie(opts)
 
     # create an empty checkpoint file, if needed
     condor_ckpt = cp.has_option('sampler', 'checkpoint-signal')

--- a/pycbc/inference/option_utils.py
+++ b/pycbc/inference/option_utils.py
@@ -20,45 +20,12 @@
 import logging
 import argparse
 
-from pycbc.workflow import WorkflowConfigParser
 from pycbc.psd import from_cli_multi_ifos as psd_from_cli_multi_ifos
 from pycbc.strain import from_cli_multi_ifos as strain_from_cli_multi_ifos
 from pycbc.strain import (gates_from_cli, psd_gates_from_cli,
                           apply_gates_to_td, apply_gates_to_fd)
 from pycbc import waveform
 from pycbc import distributions
-
-
-# -----------------------------------------------------------------------------
-#
-#                   Utilities for loading config files
-#
-# -----------------------------------------------------------------------------
-
-def add_config_opts_to_parser(parser):
-    """Adds options for the configuration files to the given parser.
-    """
-    parser.add_argument("--config-files", type=str, nargs="+", required=True,
-                        help="A file parsable by "
-                             "pycbc.workflow.WorkflowConfigParser.")
-    parser.add_argument("--config-overrides", type=str, nargs="+",
-                        default=None, metavar="SECTION:OPTION:VALUE",
-                        help="List of section:option:value combinations to "
-                             "add into the configuration file.")
-
-
-def config_parser_from_cli(opts):
-    """Loads a config file from the given options, applying any overrides
-    specified. Specifically, config files are loaded from the `--config-files`
-    options while overrides are loaded from `--config-overrides`.
-    """
-    # read configuration file
-    logging.info("Reading configuration file")
-    if opts.config_overrides is not None:
-        overrides = [override.split(":") for override in opts.config_overrides]
-    else:
-        overrides = None
-    return WorkflowConfigParser(opts.config_files, overrides)
 
 
 # -----------------------------------------------------------------------------

--- a/pycbc/workflow/configuration.py
+++ b/pycbc/workflow/configuration.py
@@ -300,8 +300,8 @@ def add_workflow_command_line_group(parser):
         The initialized argparse instance to add the workflow option group to.
     """
     workflowArgs = parser.add_argument_group('Configuration',
-                                             'Options needed for parsing the '
-                                             'config file.')
+                                             'Options needed for parsing '
+                                             'config file(s).')
     workflowArgs.add_argument("--config-files", nargs="+", action='store',
                            metavar="CONFIGFILE",
                            help="List of config files to be used in "

--- a/pycbc/workflow/configuration.py
+++ b/pycbc/workflow/configuration.py
@@ -299,8 +299,9 @@ def add_workflow_command_line_group(parser):
     parser : argparse.ArgumentParser instance
         The initialized argparse instance to add the workflow option group to.
     """
-    workflowArgs = parser.add_argument_group('workflow',
-                                          'Options needed for workflow setup.')
+    workflowArgs = parser.add_argument_group('Configuration',
+                                             'Options needed for parsing the '
+                                             'config file.')
     workflowArgs.add_argument("--config-files", nargs="+", action='store',
                            metavar="CONFIGFILE",
                            help="List of config files to be used in "


### PR DESCRIPTION
Currently, `pycbc_inference` used it's own config option group and parser (in `inference/option_utils`). This is redundant with the argument group and `from_cli` option that exists in `workflow/configuration`. It also lacks the `config-delete` option. This patch has `inference` use the functions in the workflow configuration module instead, and removes the redundant functions from `inference/options_utils`.

I also changes the heading and description on the configuration argument group, to make it less workflow-specific.