### PR TITLE
Add ability to plot HPD credible interval in 1D histograms

### DIFF
--- a/bin/inference/pycbc_inference_plot_posterior
+++ b/bin/inference/pycbc_inference_plot_posterior
@@ -107,23 +107,27 @@ for fp in fps:
 
 # if no plotting options selected, then the default options are based
 # on the number of parameters
-plot_options = [opts.plot_marginal, opts.plot_scatter, opts.plot_density]
+if opts.plot_marginal is not None:
+    marginal = True
+else:
+    marginal = False
+plot_options = [marginal, opts.plot_scatter, opts.plot_density]
 if not numpy.any(plot_options):
     if len(parameters) == 1:
-        opts.plot_marginal = True
+        opts.plot_marginal = "percentiles"
     else:
         opts.plot_scatter = True
         # FIXME: right now if there are two parameters it wants
         # both plot_scatter and plot_marginal. One should have the option
         # of give only plot_scatter and that should be the default for
         # two or more parameters
-        opts.plot_marginal = True
+        opts.plot_marginal = "percentiles"
 
 if opts.plot_prior is not None:
     # check that we're plotting 1D marginals
-    if not opts.plot_marginal:
+    if opts.plot_marginal is None:
         raise ValueError("prior may only be plotted on 1D marginal plot; "
-                         "either turn on --plot-marginal, or turn off "
+                         "either provide --plot-marginal, or turn off "
                          "--plot-prior")
     logging.info("Loading prior")
     cp = WorkflowConfigParser(opts.plot_prior)
@@ -201,6 +205,7 @@ for (i, s) in enumerate(samples):
                     parameters, s, labels=labels, fig=fig, axis_dict=axis_dict,
                     plot_marginal=opts.plot_marginal,
                     marginal_percentiles=opts.marginal_percentiles,
+                    marginal_hpd_percent=opts.marginal_hpd_percent,
                     plot_scatter=opts.plot_scatter,
                     zvals=zvals[i] if zvals is not None else None,
                     show_colorbar=opts.z_arg is not None,
@@ -226,7 +231,7 @@ if opts.plot_prior:
         hist_color = colors.next()
     fig, axis_dict = create_multidim_plot(
         parameters, prior_samples, fig=fig, axis_dict=axis_dict,
-        labels=labels, plot_marginal=True, marginal_percentiles=[],
+        labels=labels, plot_marginal=opts.plot_marginal, marginal_percentiles=[],
         plot_scatter=False, plot_density=False, plot_contours=False,
         fill_color=None,
         marginal_title=False, marginal_linestyle=':',

--- a/pycbc/inference/option_utils.py
+++ b/pycbc/inference/option_utils.py
@@ -267,7 +267,7 @@ def add_plot_posterior_option_group(parser):
                              "diagonal axes with lines drawn at the estimated "
                              "value of the respective parameters and the bounds "
                              "of their uncertainties, calculated using the "
-                             "given method. Choose from percentiles or hpd.")
+                             "given method. Choose from `percentiles` or `hpd`.")
     pgroup.add_argument('--marginal-percentiles', nargs='+', default=None,
                         type=float,
                         help="Percentiles to draw lines at on the 1D "
@@ -275,7 +275,9 @@ def add_plot_posterior_option_group(parser):
                              "option is `percentiles`.")
     pgroup.add_argument('--marginal-hpd-percent', default=None, type=float,
                         help="Percentage probability to include in the HPD "
-                             "credible interval. To be used only if "
+                             "credible interval. Lines will be drawn at the "
+                             "median (50th percentile) and at the lower and "
+                             "upper bounds of the HPD CI. To be used only if "
                              "`--plot-marginal` option is `hpd`.")
     pgroup.add_argument("--plot-scatter", action='store_true', default=False,
                         help="Plot each sample point as a scatter plot.")

--- a/pycbc/inference/option_utils.py
+++ b/pycbc/inference/option_utils.py
@@ -262,13 +262,21 @@ def add_plot_posterior_option_group(parser):
     """
     pgroup = parser.add_argument_group("Options for what plots to create and "
                                        "their formats.")
-    pgroup.add_argument('--plot-marginal', action='store_true', default=False,
+    pgroup.add_argument('--plot-marginal', default=None,
                         help="Plot 1D marginalized distributions on the "
-                             "diagonal axes.")
+                             "diagonal axes with lines drawn at the estimated "
+                             "value of the respective parameters and the bounds "
+                             "of their uncertainties, calculated using the "
+                             "given method. Choose from percentiles or hpd.")
     pgroup.add_argument('--marginal-percentiles', nargs='+', default=None,
                         type=float,
                         help="Percentiles to draw lines at on the 1D "
-                             "histograms.")
+                             "histograms. To be used only if `--plot-marginal` "
+                             "option is `percentiles`.")
+    pgroup.add_argument('--marginal-hpd-percent', default=None, type=float,
+                        help="Percentage probability to include in the HPD "
+                             "credible interval. To be used only if "
+                             "`--plot-marginal` option is `hpd`.")
     pgroup.add_argument("--plot-scatter", action='store_true', default=False,
                         help="Plot each sample point as a scatter plot.")
     pgroup.add_argument("--plot-density", action="store_true", default=False,

--- a/pycbc/inference/option_utils.py
+++ b/pycbc/inference/option_utils.py
@@ -262,7 +262,7 @@ def add_plot_posterior_option_group(parser):
     """
     pgroup = parser.add_argument_group("Options for what plots to create and "
                                        "their formats.")
-    pgroup.add_argument('--plot-marginal', default=None,
+    pgroup.add_argument('--plot-marginal', default=None, type=str,
                         help="Plot 1D marginalized distributions on the "
                              "diagonal axes with lines drawn at the estimated "
                              "value of the respective parameters and the bounds "

--- a/pycbc/inference/option_utils.py
+++ b/pycbc/inference/option_utils.py
@@ -262,17 +262,19 @@ def add_plot_posterior_option_group(parser):
     """
     pgroup = parser.add_argument_group("Options for what plots to create and "
                                        "their formats.")
-    pgroup.add_argument('--plot-marginal', default=None, type=str,
+    pgroup.add_argument('--plot-marginal', choices=["percentiles", "hpd"],
+                        default=None, type=str,
                         help="Plot 1D marginalized distributions on the "
-                             "diagonal axes with lines drawn at the estimated "
-                             "value of the respective parameters and the bounds "
-                             "of their uncertainties, calculated using the "
-                             "given method. Choose from `percentiles` or `hpd`.")
+                             "diagonal axes with lines drawn at the "
+                             "estimated value of the respective parameters "
+                             "and the bounds of their uncertainties, "
+                             "calculated using the given method. Choose from "
+                             "`percentiles` or `hpd`.")
     pgroup.add_argument('--marginal-percentiles', nargs='+', default=None,
                         type=float,
                         help="Percentiles to draw lines at on the 1D "
-                             "histograms. To be used only if `--plot-marginal` "
-                             "option is `percentiles`.")
+                             "histograms. To be used only if "
+                             "`--plot-marginal` option is `percentiles`.")
     pgroup.add_argument('--marginal-hpd-percent', default=None, type=float,
                         help="Percentage probability to include in the HPD "
                              "credible interval. Lines will be drawn at the "

--- a/pycbc/results/scatter_histograms.py
+++ b/pycbc/results/scatter_histograms.py
@@ -351,7 +351,9 @@ def create_marginalized_hist(ax, values, label, estimate_method='percentiles',
         upper 90th percentile and the median).
     hpd_percent : {None, float}
         If `estimate_method=hpd`, percentage probability of values to be
-        included in the HPD credible interval.
+        included in the HPD credible interval. Lines will be drawn at the
+        median(50th percentile) and the upper and lower bounds of the HPD
+        credible interval.
     color : {'k', string}
         What color to make the histogram; default is black.
     fillcolor : {'gray', string, or None}
@@ -603,23 +605,24 @@ def create_multidim_plot(parameters, samples, labels=None,
     marginal_title : bool, optional
         Add a title over the 1D marginal plots that gives an estimated value
         +/- uncertainty. If the input for ``--plot-marginal`` is ``percentiles``,
-        the estimated value is the pecentile halfway between the max/min of
+        the estimated value is the percentile halfway between the max/min of
         ``marginal_percentiles``, while the uncertainty is given by the
         max/min of the ``marginal_percentiles. If the input for
         ``--plot-marginal`` is ``percentiles``, and no ``marginal_percentiles``
-        are specified, the median +/- 95/5 percentiles will be quoted. If the input
-        for ``--plot-marginal`` is ``hpd``, the median +/- the upper/lower bounds
-        of the ``marginal_hpd_percent`` Highest Posterior Density credible 
-        interval will be quoted. If the input for ``--plot-marginal`` is
-        ``hpd``, and no ``marginal_hpd_percent`` is specified, the median +/-
-        upper/lower bounds of 90% HPD credible interval will be quoted.
+        are specified, the median +/- 95/5 percentiles will be quoted. If the
+        input for ``--plot-marginal`` is ``hpd``, the median +/- the
+        upper/lower bounds of the ``marginal_hpd_percent`` Highest Posterior
+        Density (HPD) credible interval will be quoted. If the input for
+        ``--plot-marginal`` is ``hpd``, and no ``marginal_hpd_percent`` is
+        specified, the median +/- upper/lower bounds of 90% HPD credible
+        interval will be quoted.
     marginal_linestyle : str, optional
         What line style to use for the marginal histograms.
     marginal_hpd_percent : {None, float}
         To be used if `plot_marginal=hpd`. What percentage of probability to
-        include in HPD interval if plotting a
-        HPD credible interval on the 1D histograms. If None, will draw lines at
-        the median(50th percentile) and bounds of the 90% HPD credible interval.
+        include in HPD interval if plotting a HPD credible interval on the 1D
+        histograms. If None, will draw lines at the median (50th percentile)
+        and bounds of the 90% HPD credible interval.
     contour_percentiles : {None, array}
         What percentile contours to draw on the scatter plots. If None,
         will plot the 50th and 90th percentiles.

--- a/pycbc/results/scatter_histograms.py
+++ b/pycbc/results/scatter_histograms.py
@@ -291,6 +291,7 @@ def create_density_plot(xparam, yparam, samples, plot_density=True,
 
     return fig, ax
 
+
 def compute_hpd_credible_interval(samples_array, hpd_percent=None):
     """Returns an array containing the boundaries of the highest probability
     density (HPD) credible interval for a set of samples.
@@ -302,6 +303,12 @@ def compute_hpd_credible_interval(samples_array, hpd_percent=None):
     hpd_percent : {None, float}
         Percentage probability to be included in the HPD credible
         interval.
+
+    Returns
+    -------
+    array
+        An array that contains the lower and upper bounds of the HPD
+        credible interval.
     """
     # Make a copy of the samples and sort it
     samples_array_sorted = numpy.sort(numpy.copy(samples_array))
@@ -344,7 +351,7 @@ def create_marginalized_hist(ax, values, label, estimate_method='percentiles',
     label : str
         A label to use for the title.
     estimate_method : {'percentiles', string}
-       Method to compute the uncertainties in the estimated parameter values.   
+       Method to compute the uncertainties in the estimated parameter values.
     marginal_percentiles : {None, float or array}
         If `estimate_method=percentiles`, what percentiles to draw lines at.
         If None, will draw lines at `[5, 50, 95]` (i.e., the bounds on the
@@ -391,7 +398,7 @@ def create_marginalized_hist(ax, values, label, estimate_method='percentiles',
     ax.hist(values, bins=50, histtype=htype, orientation=orientation,
             facecolor=fillcolor, edgecolor=color, ls=linestyle, lw=2,
             density=True)
-    if estimate_method=="hpd":
+    if estimate_method == "hpd":
         # Plot HPD credible interval
         if hpd_percent is None:
             hpd_percent = 90.
@@ -419,11 +426,11 @@ def create_marginalized_hist(ax, values, label, estimate_method='percentiles',
         else:
             ax.axvline(expected_value, color=expected_color, lw=1.5, zorder=2)
     if title:
-        if estimate_method=="hpd":
+        if estimate_method == "hpd":
             values_med = numpy.percentile(values, 50)
             values_min = plotp.min()
             values_max = plotp.max()
-        if estimate_method=="percentiles":
+        if estimate_method == "percentiles":
             if len(marginal_percentiles) > 0:
                 minp = min(marginal_percentiles)
                 maxp = max(marginal_percentiles)
@@ -591,7 +598,7 @@ def create_multidim_plot(parameters, samples, labels=None,
         What color to make the expected parameters cross.
     plot_marginal : {None, string}
         Plot the marginalized distribution on the diagonals, with lines at
-        the `[5, 50, 95]` percentiles if the input option is `percentiles`. 
+        the `[5, 50, 95]` percentiles if the input option is `percentiles`.
         If the input option is `hpd`, lines are drawn at the median (50th
         percentile), and lower and upper bounds of the HPD credible interval.
         If None, the diagonal axes will be turned off.
@@ -604,10 +611,10 @@ def create_multidim_plot(parameters, samples, labels=None,
         upper 90th percentile and the median).
     marginal_title : bool, optional
         Add a title over the 1D marginal plots that gives an estimated value
-        +/- uncertainty. If the input for ``--plot-marginal`` is ``percentiles``,
-        the estimated value is the percentile halfway between the max/min of
-        ``marginal_percentiles``, while the uncertainty is given by the
-        max/min of the ``marginal_percentiles. If the input for
+        +/- uncertainty. If the input for ``--plot-marginal`` is
+        ``percentiles``, the estimated value is the percentile halfway
+        between the max/min of ``marginal_percentiles``, while the uncertainty
+        is given by the max/min of the ``marginal_percentiles. If the input for
         ``--plot-marginal`` is ``percentiles``, and no ``marginal_percentiles``
         are specified, the median +/- 95/5 percentiles will be quoted. If the
         input for ``--plot-marginal`` is ``hpd``, the median +/- the


### PR DESCRIPTION
Rebooting the HPD credible interval PR #2331 here. That PR is out of date and might not be compatible with the current PyCBC Inference code. Now made `--plot-marginal` take a string input. Choices are `hpd` and `percentiles`, and defaults to `None` like  @cmbiwer  suggested. There's a `--marginal-hpd-percent` option to give the code the HPD % CI to plot. Kept that separate from `--marginal-percentiles` that reads in the input for `plot-marginal=percentiles`, as using a common option for reading the percentiles for the `percentiles` method and % CI for the HPD method could be confusing.

If `plot-marginal=percentiles`: will plot the percentiles provided in `--marginal-percentiles`. If `--marginal-percentiles` is not provided will plot the 5, 50, 95 percentiles.

If `plot-marginal=hpd`: will plot the `--marginal-hpd-percent` % HPD CI. If `--marginal-hpd-percent` is not provided, will plot the 90% HPD CI.