### PR TITLE
Sort tmpltbanks

### DIFF
--- a/pycbc/workflow/jobsetup.py
+++ b/pycbc/workflow/jobsetup.py
@@ -295,7 +295,7 @@ def sngl_ifo_job_setup(workflow, ifo, out_files, curr_exe_job, science_segs,
             # one job. If there are no curr_parents it is set to [None] and I
             # make a single job. This catches the case of a split template bank
             # where I run a number of jobs to cover a single range of time.
-            for pnum, parent in enumerate(curr_parent):
+            for pnum, parent in enumerate(sorted(curr_parent)):
                 if len(curr_parent) != 1:
                     tag = ["JOB%d" %(pnum,)]
                 else:

--- a/pycbc/workflow/jobsetup.py
+++ b/pycbc/workflow/jobsetup.py
@@ -295,7 +295,9 @@ def sngl_ifo_job_setup(workflow, ifo, out_files, curr_exe_job, science_segs,
             # one job. If there are no curr_parents it is set to [None] and I
             # make a single job. This catches the case of a split template bank
             # where I run a number of jobs to cover a single range of time.
-            for pnum, parent in enumerate(sorted(curr_parent)):
+            sorted_parents = sorted(curr_parent,
+                                    key=lambda fobj: fobj.tagged_description)
+            for pnum, parent in enumerate(sorted_parents):
                 if len(curr_parent) != 1:
                     tag = ["JOB%d" %(pnum,)]
                 else:

--- a/pycbc/workflow/jobsetup.py
+++ b/pycbc/workflow/jobsetup.py
@@ -295,6 +295,8 @@ def sngl_ifo_job_setup(workflow, ifo, out_files, curr_exe_job, science_segs,
             # one job. If there are no curr_parents it is set to [None] and I
             # make a single job. This catches the case of a split template bank
             # where I run a number of jobs to cover a single range of time.
+
+            # Sort parent jobs to ensure predictable order
             sorted_parents = sorted(curr_parent,
                                     key=lambda fobj: fobj.tagged_description)
             for pnum, parent in enumerate(sorted_parents):


### PR DESCRIPTION
This pull request addresses an issue where the assignment between splitbanks and inspiral jobs is somewhat random (and can apparently change). Here we sort the template banks to ensure a predictable matching. Note that as we are sorting by string `BANK10` is smaller than `BANK1` so `JOB1` might get `BANK10`, but at least the matching is predictable. If it is felt that there is a strong advantage to having `BANK1` -> `JOB1` I can add that, but it will be a little more complicated.

As a note: I'm still not sure what caused the ordering to change, but this change should make things a lot more stable!