### PR TITLE
Bug in _HDFInjectionSet

### DIFF
--- a/pycbc/inject/inject.py
+++ b/pycbc/inject/inject.py
@@ -93,7 +93,7 @@ class _HDFInjectionSet(object):
         # get parameters
         parameters = group.keys()
         # get all injection parameter values
-        injvals = {param: group[param][:] for param in parameters}
+        injvals = {param: group[param][()] for param in parameters}
         # if there were no variable args, then we only have a single injection
         if len(parameters) == 0:
             numinj = 1


### PR DESCRIPTION
In the _HDFInjectionSet class, the injvals are read from the hdf file using 
`injvals = {param: group[param][:] for param in parameters}`

It seems like this class targets hdf files that set a group of "static_args", which will be common for all variable_args, and it expects that if there is only one injection this will be stored in the static_args and then `injvals = []`.
However, it could also be a file that does not contain a group "static_args" and stores only one value for each param, so that `group[param][:]` will return an error
`ValueError: Illegal slicing argument for scalar dataspace`

This PR changes [:] for [()], so that it will work independently of how many values are stored in group[param]