### PR TITLE
Re-enable using different low frequency cutoffs for different detectors

### DIFF
--- a/examples/inference/bbh-injection/inference.ini
+++ b/examples/inference/bbh-injection/inference.ini
@@ -1,6 +1,7 @@
 [model]
 name = gaussian_noise
-low-frequency-cutoff = 20
+h1-low-frequency-cutoff = 20
+l1-low-frequency-cutoff = 20
 
 [sampler]
 name = emcee_pt

--- a/examples/inference/bbh-injection/run.sh
+++ b/examples/inference/bbh-injection/run.sh
@@ -36,7 +36,7 @@ pycbc_inference --verbose \
     --fake-strain-seed 44 \
     --strain-high-pass ${F_MIN} \
     --sample-rate ${SAMPLE_RATE} \
-    --low-frequency-cutoff ${F_MIN} \
+    --data-conditioning-low-freq ${F_MIN} \
     --channel-name H1:FOOBAR L1:FOOBAR \
     --injection-file injection.hdf \
     --config-file ${CONFIG_PATH} \

--- a/examples/inference/gw150914/inference.ini
+++ b/examples/inference/gw150914/inference.ini
@@ -1,6 +1,7 @@
 [model]
 name = gaussian_noise
-low-frequency-cutoff = 20
+h1-low-frequency-cutoff = 20
+l1-low-frequency-cutoff = 20
 
 [sampler]
 name = emcee_pt

--- a/examples/inference/gw150914/run.sh
+++ b/examples/inference/gw150914/run.sh
@@ -63,7 +63,7 @@ pycbc_inference --verbose \
     --psd-segment-stride ${PSD_STRIDE} \
     --psd-inverse-length ${PSD_INVLEN} \
     --sample-rate ${SAMPLE_RATE} \
-    --low-frequency-cutoff ${F_MIN} \
+    --data-conditioning-low-freq ${F_MIN} \
     --config-file ${CONFIG_PATH} \
     --output-file ${OUTPUT_PATH} \
     --processing-scheme ${PROCESSING_SCHEME} \

--- a/examples/inference/gw150914/run_test.sh
+++ b/examples/inference/gw150914/run_test.sh
@@ -63,7 +63,7 @@ pycbc_inference --verbose \
     --psd-segment-stride ${PSD_STRIDE} \
     --psd-inverse-length ${PSD_INVLEN} \
     --sample-rate ${SAMPLE_RATE} \
-    --low-frequency-cutoff ${F_MIN} \
+    --data-conditioning-low-freq ${F_MIN} \
     --config-file ${CONFIG_PATH} \
     --output-file ${OUTPUT_PATH} \
     --processing-scheme ${PROCESSING_SCHEME} \

--- a/pycbc/inference/models/gaussian_noise.py
+++ b/pycbc/inference/models/gaussian_noise.py
@@ -90,8 +90,8 @@ class GaussianNoise(BaseDataModel):
         data set must be the same as the waveform generator's epoch.
     low_frequency_cutoff : dict
         A dictionary of starting frequencies, in which the keys are the detector
-        names and the values are the starting frequency for that detector to be
-        used for computing inner products.
+        names and the values are the starting frequencies for the respective 
+        detectors to be used for computing inner products.
     psds : {None, dict}
         A dictionary of FrequencySeries keyed by the detector names. The
         dictionary must have a psd for each detector specified in the data

--- a/pycbc/inference/models/gaussian_noise.py
+++ b/pycbc/inference/models/gaussian_noise.py
@@ -515,7 +515,7 @@ class GaussianNoise(BaseDataModel):
         ignore_args = ['name']
         for option in cp.options("model"):
             if any([option.endswith("-low-frequency-cutoff"),
-                   option.endswith("-high-frequency-cutoff")]):
+                    option.endswith("-high-frequency-cutoff")]):
                 ignore_args.append(option)
         args.update(cls.extra_args_from_config(cp, "model",
                                                skip_args=ignore_args))
@@ -615,7 +615,7 @@ def low_frequency_cutoff_from_config(cp):
                 low_frequency_cutoff[ifo] = float(cp.get("model", option))
             except Exception as e:
                 logging.warning("Low frequency cutoff of %s could not be "
-                                "converted to float" % ifo)
+                                "converted to float", ifo)
                 raise e
     return low_frequency_cutoff
 
@@ -648,6 +648,6 @@ def high_frequency_cutoff_from_config(cp):
                 high_frequency_cutoff[ifo] = float(cp.get("model", option))
             except Exception as e:
                 logging.warning("High frequency cutoff of %s could not be "
-                                "converted to float" % ifo)
+                                "converted to float", ifo)
                 raise e
     return high_frequency_cutoff

--- a/pycbc/inference/models/gaussian_noise.py
+++ b/pycbc/inference/models/gaussian_noise.py
@@ -251,9 +251,9 @@ class GaussianNoise(BaseDataModel):
                     self._f_upper[det] = high_frequency_cutoff[det]
                 else:
                     self._f_upper[det] = None
-         else:
-            [self._f_upper[det] = None for det in self.data.keys()]
-        print("self._f_upper", self._f_upper)
+        else:
+            for det in self._data.keys():
+                self._f_upper[det] = None
         if norm is None:
             norm = 4*d.delta_f
         # we'll store the weight to apply to the inner product
@@ -272,7 +272,6 @@ class GaussianNoise(BaseDataModel):
         self._kmin = {}
         self._kmax = {}
         for det in self._data:
-            self._f_upper = high_frequency_cutoff
             # whiten the data
             kmin, kmax = pyfilter.get_cutoff_indices(self._f_lower[det],
                                                      self._f_upper[det],
@@ -280,8 +279,6 @@ class GaussianNoise(BaseDataModel):
             self._data[det][kmin:kmax] *= self._weight[det][kmin:kmax]
             self._kmin[det] = kmin
             self._kmax[det] = kmax
-        print("self._kmin", self._kmin)
-        print("self._kmax", self._kmax)
 
     @property
     def waveform_generator(self):
@@ -517,8 +514,8 @@ class GaussianNoise(BaseDataModel):
         # get any other keyword arguments provided in the model section
         ignore_args = ['name']
         for option in cp.options("model"):
-            if option.endswith("-low-frequency-cutoff") or 
-                    option.endswith("-high-frequency-cutoff"):
+            if any([option.endswith("-low-frequency-cutoff"),
+                   option.endswith("-high-frequency-cutoff")]):
                 ignore_args.append(option)
         args.update(cls.extra_args_from_config(cp, "model",
                                                skip_args=ignore_args))

--- a/pycbc/inference/models/gaussian_noise.py
+++ b/pycbc/inference/models/gaussian_noise.py
@@ -17,10 +17,7 @@
 """
 
 import logging
-from six.moves.configparser import NoSectionError, NoOptionError
-
 import numpy
-
 from pycbc import filter as pyfilter
 from pycbc.waveform import NoWaveformError
 from pycbc.waveform import generator
@@ -89,9 +86,9 @@ class GaussianNoise(BaseDataModel):
         match the waveform generator's detectors keys, and the epoch of every
         data set must be the same as the waveform generator's epoch.
     low_frequency_cutoff : dict
-        A dictionary of starting frequencies, in which the keys are the detector
-        names and the values are the starting frequencies for the respective 
-        detectors to be used for computing inner products.
+        A dictionary of starting frequencies, in which the keys are the
+        detector names and the values are the starting frequencies for the
+        respective detectors to be used for computing inner products.
     psds : {None, dict}
         A dictionary of FrequencySeries keyed by the detector names. The
         dictionary must have a psd for each detector specified in the data
@@ -136,8 +133,8 @@ class GaussianNoise(BaseDataModel):
     >>> psd = pypsd.aLIGOZeroDetHighPower(N, 1./seglen, 20.)
     >>> psds = {'H1': psd, 'L1': psd}
     >>> low_frequency_cutoff = {'H1': fmin, 'L1': fmin}
-    >>> model = GaussianNoise(variable_params, signal, low_frequency_cutoff, psds=psds,
-                              static_params=static_params)
+    >>> model = GaussianNoise(variable_params, signal, low_frequency_cutoff,
+                              psds=psds, static_params=static_params)
     Set the current position to the coalescence time of the signal:
 
     >>> model.update(tc=tsig)
@@ -228,10 +225,10 @@ class GaussianNoise(BaseDataModel):
                            "match IFOs for which low-frequency-cutoff has "
                            "been provided for likelihood inner product "
                            "calculation. If loading the model settings from "
-                           "a config file, please provide a "
-                           "`IFO-low-frequency-cutoff` input for each detector "
-                           "in the `[model]` section, where IFO is the name "
-                           "of the detector.")
+                           "a config file, please provide an "
+                           "`IFO-low-frequency-cutoff` input for each "
+                           "detector in the `[model]` section, where IFO is "
+                           "the name of the detector.")
         # create the waveform generator
         self._waveform_generator = create_waveform_generator(
             self.variable_params, self.data, recalibration=self.recalibration,
@@ -265,7 +262,8 @@ class GaussianNoise(BaseDataModel):
         self._kmax = {}
         for det in self._data:
             # whiten the data
-            kmin, kmax = pyfilter.get_cutoff_indices(self._f_lower[det], self._f_upper,
+            kmin, kmax = pyfilter.get_cutoff_indices(self._f_lower[det],
+                                                     self._f_upper,
                                                      d.delta_f, (N-1)*2)
             self._data[det][kmin:kmax] *= self._weight[det][kmin:kmax]
             self._kmin[det] = kmin
@@ -480,8 +478,8 @@ class GaussianNoise(BaseDataModel):
         for det in self.detectors:
             # Save lognl for each IFO as attributes in the samples group
             attrs['{}_lognl'.format(det)] = self.det_lognl(det)
-            # Save each IFO's low frequency cutoff used in the likelihood computation
-            # as attributes
+            # Save each IFO's low frequency cutoff used in the likelihood
+            # computation as attributes
             fp.attrs['{}_likelihood_low_freq'.format(det)] = self._f_lower[det]
 
     @classmethod
@@ -601,8 +599,8 @@ def low_frequency_cutoff_from_config(cp):
             try:
                 low_frequency_cutoff[ifo] = float(cp.get("model", option))
             except Exception as e:
-                logging.warning("Low frequency cutoff of {} could not be "
-                                "converted to float".format(ifo))
+                logging.warning("Low frequency cutoff of %s could not be "
+                                "converted to float" % ifo)
                 raise e
     return low_frequency_cutoff
 

--- a/pycbc/inference/models/marginalized_gaussian_noise.py
+++ b/pycbc/inference/models/marginalized_gaussian_noise.py
@@ -146,9 +146,11 @@ class MarginalizedPhaseGaussianNoise(GaussianNoise):
                 hd_i = 0j
             else:
                 # whiten the waveform
-                h[self._kmin[det]:kmax] *= self._weight[det][self._kmin[det]:kmax]
+                h[self._kmin[det]:kmax] *= \
+                    self._weight[det][self._kmin[det]:kmax]
                 # calculate inner products
-                hh_i = h[self._kmin[det]:kmax].inner(h[self._kmin[det]:kmax]).real
+                hh_i = h[self._kmin[det]:kmax].inner(
+                    h[self._kmin[det]:kmax]).real
                 hd_i = self.data[det][self._kmin[det]:kmax].inner(
                     h[self._kmin[det]:kmax])
             # store
@@ -617,8 +619,10 @@ class MarginalizedGaussianNoise(GaussianNoise):
                 hh_i = 0.
                 hd_i = 0j
             else:
-                h[self._kmin[det]:kmax] *= self._weight[det][self._kmin[det]:kmax]
-                hh_i = h[self._kmin[det]:kmax].inner(h[self._kmin[det]:kmax]).real
+                h[self._kmin[det]:kmax] *= \
+                    self._weight[det][self._kmin[det]:kmax]
+                hh_i = h[self._kmin[det]:kmax].inner(
+                    h[self._kmin[det]:kmax]).real
                 hd_i = self._eval_mfsnr(h[self._kmin[det]:kmax],
                                         self.data[det][self._kmin[det]:kmax])
             opt_snr += hh_i

--- a/pycbc/inference/models/marginalized_gaussian_noise.py
+++ b/pycbc/inference/models/marginalized_gaussian_noise.py
@@ -138,19 +138,19 @@ class MarginalizedPhaseGaussianNoise(GaussianNoise):
         hd = 0j
         for det, h in wfs.items():
             # the kmax of the waveforms may be different than internal kmax
-            kmax = min(len(h), self._kmax)
-            if self._kmin >= kmax:
+            kmax = min(len(h), self._kmax[det])
+            if self._kmin[det] >= kmax:
                 # if the waveform terminates before the filtering low frequency
                 # cutoff, then the loglr is just 0 for this detector
                 hh_i = 0.
                 hd_i = 0j
             else:
                 # whiten the waveform
-                h[self._kmin:kmax] *= self._weight[det][self._kmin:kmax]
+                h[self._kmin[det]:kmax] *= self._weight[det][self._kmin[det]:kmax]
                 # calculate inner products
-                hh_i = h[self._kmin:kmax].inner(h[self._kmin:kmax]).real
-                hd_i = self.data[det][self._kmin:kmax].inner(
-                    h[self._kmin:kmax])
+                hh_i = h[self._kmin[det]:kmax].inner(h[self._kmin[det]:kmax]).real
+                hd_i = self.data[det][self._kmin[det]:kmax].inner(
+                    h[self._kmin[det]:kmax])
             # store
             setattr(self._current_stats, '{}_optimal_snrsq'.format(det), hh_i)
             hh += hh_i
@@ -607,20 +607,20 @@ class MarginalizedGaussianNoise(GaussianNoise):
         mf_snr = 0j
         for det, h in wfs.items():
             # the kmax of the waveforms may be different than internal kmax
-            kmax = min(len(h), self._kmax)
+            kmax = min(len(h), self._kmax[det])
             # time step
             self._deltat = h.delta_t
-            if self._kmin >= kmax:
+            if self._kmin[det] >= kmax:
                 # if the waveform terminates before the filtering low
                 # frequency cutoff, then the loglr is just 0 for this
                 # detector
                 hh_i = 0.
                 hd_i = 0j
             else:
-                h[self._kmin:kmax] *= self._weight[det][self._kmin:kmax]
-                hh_i = h[self._kmin:kmax].inner(h[self._kmin:kmax]).real
-                hd_i = self._eval_mfsnr(h[self._kmin:kmax],
-                                        self.data[det][self._kmin:kmax])
+                h[self._kmin[det]:kmax] *= self._weight[det][self._kmin[det]:kmax]
+                hh_i = h[self._kmin[det]:kmax].inner(h[self._kmin[det]:kmax]).real
+                hd_i = self._eval_mfsnr(h[self._kmin[det]:kmax],
+                                        self.data[det][self._kmin[det]:kmax])
             opt_snr += hh_i
             mf_snr += hd_i
             setattr(self._current_stats, '{}_optimal_snrsq'.format(det), hh_i)

--- a/pycbc/inference/option_utils.py
+++ b/pycbc/inference/option_utils.py
@@ -43,6 +43,7 @@ def add_low_frequency_cutoff_opt(parser):
                         metavar='IFO:FLOW', dest="low_frequency_cutoff",
                         help="Low frequency cutoff for fake strain.")
 
+
 def data_from_cli(opts):
     """Loads the data needed for a model from the given
     command-line options. Gates specifed on the command line are also applied.

--- a/pycbc/inference/option_utils.py
+++ b/pycbc/inference/option_utils.py
@@ -41,7 +41,8 @@ def add_low_frequency_cutoff_opt(parser):
     parser.add_argument("--data-conditioning-low-freq", type=float,
                         nargs="+", action=MultiDetOptionAction,
                         metavar='IFO:FLOW', dest="low_frequency_cutoff",
-                        help="Low frequency cutoff for fake strain.")
+                        help="Low frequency cutoff of the data. Needed for "
+                             "PSD estimation and when creating fake strain.")
 
 
 def data_from_cli(opts):


### PR DESCRIPTION
As title says.

@cdcapano  The PR makes the low frequency cutoffs for likelihood calculation to be read from the config file as 
```
h1-low-frequency-cutoff = 20
l1-low-frequency-cutoff = 30
```
etc. These will be saved in fp.attrs as `'{}_likelihood_low_freq'.format(det)`. 

The low frequencies for multi ifos for data conditioning is read in the command line with the option `--data-conditioning-low-freq`. This is then saved to `opts.low_frequency_cutoff` for passing to strain.from_cli_multi_ifos and psd.from_cli_multi_ifos. I've removed the `low_frequency_cutoff_from_cli` function as it should not be needed anymore.

I don't see how I can save the data conditioning low freqs in the output file though, as the metadata is being written now in the models module which which does not have access to the data conditioning settings, ie. the `opts` in `pycbc_inference`. 