### PR TITLE
Adding autogating to PyCBC Live

### DIFF
--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -351,7 +351,7 @@ parser.add_argument('--trim-padding', type=float, default=0.25,
 parser.add_argument("--enable-bank-start-frequency", action='store_true',
                     help="Read the starting frequency of template waveforms"
                          " from the template bank")
-parser.add_argument('--autogating-threshold', type=float, default=100)
+parser.add_argument('--autogating-threshold', type=float, default=None)
 parser.add_argument('--autogating-pad', type=float, default=.25)
 parser.add_argument('--autogating-window', type=float, default=0.5)
 parser.add_argument('--autogating-cluster', type=float, default=.25)

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -351,7 +351,7 @@ parser.add_argument('--trim-padding', type=float, default=0.25,
 parser.add_argument("--enable-bank-start-frequency", action='store_true',
                     help="Read the starting frequency of template waveforms"
                          " from the template bank")
-parser.add_argument('--autogating-threshold', type=float, default=None)
+parser.add_argument('--autogating-threshold', type=float)
 parser.add_argument('--autogating-pad', type=float, default=.25)
 parser.add_argument('--autogating-window', type=float, default=0.5)
 parser.add_argument('--autogating-cluster', type=float, default=.25)

--- a/pycbc/strain/strain.py
+++ b/pycbc/strain/strain.py
@@ -1201,7 +1201,7 @@ class StrainBuffer(pycbc.frame.DataBuffer):
                  psd_segment_length=4,
                  psd_inverse_length=3.5,
                  trim_padding=0.25,
-                 autogating_threshold=100,
+                 autogating_threshold=None,
                  autogating_cluster=0.25,
                  autogating_window=0.5,
                  autogating_pad=0.25,
@@ -1248,7 +1248,7 @@ class StrainBuffer(pycbc.frame.DataBuffer):
         trim_padding: {float, 0.25}, Optional
             Amount of padding in seconds to give for truncated the overwhitened
             data stream.
-        autogating_threshold: {float, 100}, Optional
+        autogating_threshold: {float, None}, Optional
             Sigma deviation required to cause gating of data
         autogating_cluster: {float, 0.25}, Optional
             Seconds to cluster possible gating locations

--- a/pycbc/strain/strain.py
+++ b/pycbc/strain/strain.py
@@ -96,7 +96,6 @@ def detect_loud_glitches(strain, psd_duration=4., psd_stride=2.,
     pycbc.fft.fftw.set_measure_level(0)
 
     if high_freq_cutoff:
-        logging.info('Autogating: downsampling strain')
         strain = resample_to_delta_t(strain, 0.5 / high_freq_cutoff,
                                      method='ldas')
     else:

--- a/pycbc/strain/strain.py
+++ b/pycbc/strain/strain.py
@@ -1613,7 +1613,6 @@ class StrainBuffer(pycbc.frame.DataBuffer):
                     threshold=self.autogating_threshold,
                     cluster_window=self.autogating_cluster,
                     low_freq_cutoff=self.highpass_frequency,
-                    high_freq_cutoff=self.sample_rate/2,
                     corrupt_time=self.autogating_window+self.autogating_pad)
             if len(glitch_times) > 0:
                 logging.info('Autogating %s at %s', self.detector,

--- a/pycbc/strain/strain.py
+++ b/pycbc/strain/strain.py
@@ -1604,27 +1604,27 @@ class StrainBuffer(pycbc.frame.DataBuffer):
             strain = gate_data(strain, [(strain.start_time, 0., self.autogating_pad)])
             self.taper_immediate_strain = False
 
+        # Stitch into continuous stream
+        self.strain.roll(-sample_step)
+        self.strain[len(self.strain) - csize + self.corruption:] = strain[:]
+        self.strain.start_time += blocksize
+
         # apply gating if needed
         if self.autogating_threshold is not None:
-            # the + 0 is for making a copy
             glitch_times = detect_loud_glitches(
-                    strain + 0., psd_duration=1., psd_stride=.5,
+                    strain[:-self.corruption],
+                    psd_duration=2., psd_stride=1.,
                     threshold=self.autogating_threshold,
                     cluster_window=self.autogating_cluster,
                     low_freq_cutoff=self.highpass_frequency,
                     high_freq_cutoff=self.sample_rate/2,
-                    corrupt_time=self.autogating_pad)
+                    corrupt_time=self.autogating_window+self.autogating_pad)
             if len(glitch_times) > 0:
                 logging.info('Autogating at %s',
                              ', '.join(['%.3f' % gt for gt in glitch_times]))
                 gate_params = [[gt, self.autogating_window, self.autogating_pad] \
                                for gt in glitch_times]
-                strain = gate_data(strain, gate_params)
-
-        # Stitch into continuous stream
-        self.strain.roll(-sample_step)
-        self.strain[len(self.strain) - csize + self.corruption:] = strain[:]
-        self.strain.start_time += blocksize
+                self.strain = gate_data(self.strain, gate_params)
 
         if self.psd is None and self.wait_duration <=0:
             self.recalculate_psd()

--- a/pycbc/strain/strain.py
+++ b/pycbc/strain/strain.py
@@ -1620,7 +1620,7 @@ class StrainBuffer(pycbc.frame.DataBuffer):
                     high_freq_cutoff=self.sample_rate/2,
                     corrupt_time=self.autogating_window+self.autogating_pad)
             if len(glitch_times) > 0:
-                logging.info('Autogating at %s',
+                logging.info('Autogating %s at %s', self.detector,
                              ', '.join(['%.3f' % gt for gt in glitch_times]))
                 gate_params = [[gt, self.autogating_window, self.autogating_pad] \
                                for gt in glitch_times]


### PR DESCRIPTION
Adds autogating functionality to the low latency searches: 
- pycbc_live argument `autogating-threshold` is default to `None`, and gating won't be triggered. Specifying an autogating-threshold value will trigger the autogating function. 
- `Clustering time`, `gating padding`, `gating window`, `corrupt time` could be specified in pycbc_live arguments.

[NOTE: Perhaps should add arguments in pycbc_live to specify psd duration and overlap for detect_loud_glitches(). For now it's hardcoded in to be (1s, 0.5s).]