### PR TITLE
Add basic plots to GraceDB uploads

### DIFF
--- a/pycbc/io/live.py
+++ b/pycbc/io/live.py
@@ -12,7 +12,6 @@ from glue.ligolw import param as ligolw_param
 from pycbc import version as pycbc_version
 from pycbc import pnutils
 from pycbc.tmpltbank import return_empty_sngl
-from pycbc.types import FrequencySeries
 from pycbc.results import ifo_color
 
 
@@ -321,18 +320,17 @@ class SingleCoincForGraceDB(object):
             pylab.figure()
             for ifo in self.snr_series:
                 # Undo dynamic range factor
-                curr_psd = FrequencySeries(self.psds[ifo],
-                                           dtype=numpy.float64)
+                curr_psd = self.psds[ifo].astype(numpy.float64)
                 curr_psd /= pycbc.DYN_RANGE_FAC ** 2.0
                 curr_psd.save(snr_series_fname, group='%s/psd' % ifo)
                 # Can't plot log(0) so start from point 1
                 pylab.loglog(curr_psd.sample_frequencies[1:],
-                             curr_psd[1:], c=ifo_color(ifo), label=ifo)
+                             curr_psd[1:]**0.5, c=ifo_color(ifo), label=ifo)
             pylab.legend()
             pylab.xlim([20, 2000])
-            pylab.ylim([1E-47, 1E-43])
+            pylab.ylim([1E-24, 1E-21])
             pylab.xlabel('Frequency (Hz)')
-            pylab.ylabel('PSD')
+            pylab.ylabel('ASD')
             pylab.savefig(psd_series_plot_fname)
 
         gid = None

--- a/pycbc/io/live.py
+++ b/pycbc/io/live.py
@@ -316,8 +316,8 @@ class SingleCoincForGraceDB(object):
                 curr_psd /= pycbc.DYN_RANGE_FAC ** 2.0
                 curr_psd.save(snr_series_fname, group='%s/psd' % ifo)
                 # Can't plot log(0) so start from point 1
-                pylab.loglog(self.psds[ifo].sample_frequencies[1:],
-                             self.psds[ifo][1:], label=ifo)
+                pylab.loglog(curr_psd.sample_frequencies[1:],
+                             curr_psd[1:], label=ifo)
             pylab.legend()
             pylab.xlim([20,2000])
             pylab.ylim([1E-47, 1E-43])

--- a/pycbc/io/live.py
+++ b/pycbc/io/live.py
@@ -297,13 +297,13 @@ class SingleCoincForGraceDB(object):
                 snr_series_fname = fname.replace('.xml', '.hdf')
             snr_series_plot_fname = snr_series_fname.replace('.hdf',
                                                              '_snr.png')
-            psd_series_plot_fname = snr_series_fname.replace('.hdf', 
+            psd_series_plot_fname = snr_series_fname.replace('.hdf',
                                                              '_psd.png')
             pylab.figure()
             for ifo in self.snr_series:
                 curr_snrs = self.snr_series[ifo]
                 curr_snrs.save(snr_series_fname, group='%s/snr' % ifo)
-                pylab.plot(curr_snrs.sample_times, abs(curr_snrs), 
+                pylab.plot(curr_snrs.sample_times, abs(curr_snrs),
                            c=ifo_color(ifo), label=ifo)
                 if ifo in self.ifos:
                     snr = self.coinc_results['foreground/%s/%s' %
@@ -329,12 +329,11 @@ class SingleCoincForGraceDB(object):
                 pylab.loglog(curr_psd.sample_frequencies[1:],
                              curr_psd[1:], c=ifo_color(ifo), label=ifo)
             pylab.legend()
-            pylab.xlim([20,2000])
+            pylab.xlim([20, 2000])
             pylab.ylim([1E-47, 1E-43])
             pylab.xlabel('Frequency (Hz)')
             pylab.ylabel('PSD')
             pylab.savefig(psd_series_plot_fname)
-
 
         gid = None
         try:

--- a/pycbc/io/live.py
+++ b/pycbc/io/live.py
@@ -306,8 +306,10 @@ class SingleCoincForGraceDB(object):
                 pylab.plot(curr_snrs.sample_times, abs(curr_snrs), 
                            c=ifo_color(ifo), label=ifo)
                 if ifo in self.ifos:
-                    snr = coinc_results['foreground/%s/%s' % (ifo, 'snr')]
-                    endt = coinc_results['foreground/%s/%s' % (ifo, 'end_time')]
+                    snr = self.coinc_results['foreground/%s/%s' %
+                                             (ifo, 'snr')]
+                    endt = self.coinc_results['foreground/%s/%s' %
+                                              (ifo, 'end_time')]
                     pylab.plot([endt], [snr], c=ifo_color(ifo), marker='x')
 
             pylab.legend()

--- a/pycbc/io/live.py
+++ b/pycbc/io/live.py
@@ -309,6 +309,8 @@ class SingleCoincForGraceDB(object):
 
             pylab.figure()
             for ifo in self.snr_series:
+                # Undo dynamic range factor
+                self.psds[ifo] /= pycbc.DYN_RANGE_FAC ** 2.0
                 self.psds[ifo].save(snr_series_fname,
                                     group='%s/psd' % ifo)
                 # Can't plot log(0) so start from point 1

--- a/pycbc/io/live.py
+++ b/pycbc/io/live.py
@@ -369,7 +369,7 @@ class SingleCoincForGraceDB(object):
                                  displayName=['SNR timeseries'])
                 gracedb.writeLog(gid, 'PSD plot upload',
                                  filename=psd_series_plot_fname,
-                                 tag_name=['background'], displayName=['PSDs'])
+                                 tag_name=['psd'], displayName=['PSDs'])
 
         except Exception as exc:
             logging.error('Something failed during the upload/annotation of '

--- a/pycbc/io/live.py
+++ b/pycbc/io/live.py
@@ -12,6 +12,7 @@ from glue.ligolw import param as ligolw_param
 from pycbc import version as pycbc_version
 from pycbc import pnutils
 from pycbc.tmpltbank import return_empty_sngl
+from pycbc.types import FrequencySeries
 
 
 #FIXME Legacy build PSD xml helpers, delete me when we move away entirely from
@@ -310,9 +311,10 @@ class SingleCoincForGraceDB(object):
             pylab.figure()
             for ifo in self.snr_series:
                 # Undo dynamic range factor
-                self.psds[ifo] /= pycbc.DYN_RANGE_FAC ** 2.0
-                self.psds[ifo].save(snr_series_fname,
-                                    group='%s/psd' % ifo)
+                curr_psd = FrequencySeries(self.psds[ifo],
+                                           dtype=numpy.float64)
+                curr_psd /= pycbc.DYN_RANGE_FAC ** 2.0
+                curr_psd.save(snr_series_fname, group='%s/psd' % ifo)
                 # Can't plot log(0) so start from point 1
                 pylab.loglog(self.psds[ifo].sample_frequencies[1:],
                              self.psds[ifo][1:], label=ifo)

--- a/pycbc/io/live.py
+++ b/pycbc/io/live.py
@@ -13,6 +13,7 @@ from pycbc import version as pycbc_version
 from pycbc import pnutils
 from pycbc.tmpltbank import return_empty_sngl
 from pycbc.types import FrequencySeries
+from pycbc.results import ifo_color
 
 
 #FIXME Legacy build PSD xml helpers, delete me when we move away entirely from
@@ -106,6 +107,8 @@ class SingleCoincForGraceDB(object):
             Will be recorded in the sngl_inspiral table.
         """
         self.template_id = coinc_results['foreground/%s/template_id' % ifos[0]]
+        self.coinc_results = coinc_results
+        self.ifos = ifos
 
         # remember if this should be marked as HWINJ
         self.is_hardware_injection = ('HWINJ' in coinc_results
@@ -300,7 +303,12 @@ class SingleCoincForGraceDB(object):
             for ifo in self.snr_series:
                 curr_snrs = self.snr_series[ifo]
                 curr_snrs.save(snr_series_fname, group='%s/snr' % ifo)
-                pylab.plot(curr_snrs.sample_times, abs(curr_snrs), label=ifo)
+                pylab.plot(curr_snrs.sample_times, abs(curr_snrs), 
+                           c=ifo_color(ifo), label=ifo)
+                if ifo in self.ifos:
+                    snr = coinc_results['foreground/%s/%s' % (ifo, 'snr')]
+                    endt = coinc_results['foreground/%s/%s' % (ifo, 'end_time')]
+                    pylab.plot([endt], [snr], c=ifo_color(ifo), marker='x')
 
             pylab.legend()
             pylab.xlabel('GPS time (s)')
@@ -317,7 +325,7 @@ class SingleCoincForGraceDB(object):
                 curr_psd.save(snr_series_fname, group='%s/psd' % ifo)
                 # Can't plot log(0) so start from point 1
                 pylab.loglog(curr_psd.sample_frequencies[1:],
-                             curr_psd[1:], label=ifo)
+                             curr_psd[1:], c=ifo_color(ifo), label=ifo)
             pylab.legend()
             pylab.xlim([20,2000])
             pylab.ylim([1E-47, 1E-43])


### PR DESCRIPTION
This patch creates plots of the PSDs and SNR timeseries when uploading events to GraceDB. As all this stuff is already in memory this shouldn't raise any concerns about latency (although we could spawn off the upload as Alex said if it becomes necessary later).

A test if this is here (sorry Alex):

https://gracedb-playground.ligo.org/events/T14662/view/

I also fix a deprecation warning in uploading the HDF file and undo the dynamic range factor from the PSD uploaded in the HDF file (the XML file is fine).