### PR TITLE
shuffle coincs to randomize between jobs

### DIFF
--- a/bin/hdfcoinc/pycbc_coinc_findtrigs
+++ b/bin/hdfcoinc/pycbc_coinc_findtrigs
@@ -49,9 +49,8 @@ parser.add_argument("--output-file",
 parser.add_argument("--randomize-template-order", action="store_true",
                     help="Random shuffle templates with fixed seed "
                          "before selecting range to analyze")
-parser.add_argument("--batch-statistic", default=1000000, type=int,
-                    help="Number of coincicent triggers to calculation statistics"
-                         "for at once")
+parser.add_argument("--batch-singles", default=1000000, type=int,
+                    help="Number of single triggers to process at once")
 args = parser.parse_args()
 
 # flatten the list of lists of filenames to a single list (may be empty)
@@ -217,90 +216,110 @@ else:
     template_ids = range(tmin, tmax)
 
 for tnum in template_ids:
-    tid0 = trigs0.set_template(tnum)
-    tid1 = trigs1.set_template(tnum)
+    tid0g = trigs0.set_template(tnum)
+    tid1g = trigs1.set_template(tnum)
 
     if (len(tid0) == 0) or (len(tid1) == 0):
         continue
 
-    t0 = trigs0['end_time']
-    t1 = trigs1['end_time']
+    t0g = trigs0['end_time']
+    t1g = trigs1['end_time']
     logging.info('Trigs for template %s, %s:%s %s:%s' % \
                 (tnum, trigs0.ifo, len(t0), trigs1.ifo, len(t1)))
 
-    i0, i1, slide = coinc.time_coincidence(t0, t1, time_window, args.timeslide_interval)
-
-    logging.info('Coincident Trigs: %s' % (len(i1)))
     logging.info('Calculating Single Detector Statistic')
-    s0, s1 = rank_method.single(trigs0), rank_method.single(trigs1)
+    s0g, s1g = rank_method.single(trigs0), rank_method.single(trigs1)
 
-    c = []
-    si = 0
-    while si < len(i0):
-        ei = args.batch_statistic + si
-        if ei > len(i0):
-            ei = len(i0)
+    # Loop over the single triggers and calculate the coincs they can 
+    # form
+    start0 = 0
+    while start0 < len(i0):
+        start1 = 0
+        while start1 < len(i0):
 
-        logging.info('Calculating Multi-Detector Combined Statistic: %s', si)
-        c += [rank_method.coinc(s0[i0[si:ei]],
-                                s1[i1[si:ei]],
-                                slide[si:ei], args.timeslide_interval)]
-        si += args.batch_statistic
-    c = numpy.concatenate(c)
+            end0 = start0 + args.batch_singles
+            end1 = start1 + args.batch_singles
+            if end0 > len(i0):
+                end0 = len(i0)
+            if end1 > len(i0):
+                end1 = len(i0)
+                
+            # Set the local parts of the single information we'll use
+            tid0 = tid0g[start0:end0]
+            tid1 = tid1g[start1:end1]
+            s0 = s0g[start0:end0]
+            s1 = s1g[start1:end1]
+            t0 = t0g[start0:end0]
+            t1 = t1g[start1:end1]
 
-    #index values of the zerolag triggers
-    fi = numpy.where(slide == 0)[0]
+            i0, i1, slide = coinc.time_coincidence(t0, t1, time_window,
+                                                   args.timeslide_interval)
 
-    #index values of the background triggers
-    bi = numpy.where(slide != 0)[0]
-    logging.info('%s foreground triggers' % len(fi))
-    logging.info('%s background triggers' % len(bi))
+            logging.info('Coincident Trigs: %s' % (len(i1)))
 
-    # We split the background triggers into two types which we keep track of
-    # in "bh" (triggers which are *not* decimated, stored in full) and
-    # "bl" (triggers which may not be stored in full, but we keep track of
-    # how many are removed)
-    # "bl_int" keeps track of which triggers are *not* in the bh set. Depending
-    # on the decimation factor option we may not store any of these or we may
-    # keep a fraction of them corresponding to a subset of the timeslides
-    if args.loudest_keep:
-        sep = len(bi) - args.loudest_keep
-        sep = 0 if sep < 0 else sep
 
-        bsort = numpy.argpartition(c[bi], sep)
-        bl_int = bi[bsort[0:sep]]
-        bh = bi[bsort[sep:]]
-        del bsort
-        del bi
-    elif args.loudest_keep_value:
-        bh = bi[c[bi] > args.loudest_keep_value]
-        bl_int = bi[c[bi] <= args.loudest_keep_value]
-    else:
-        bh = bi
+            logging.info('Calculating Multi-Detector Combined Statistic: %s', si)
+            c = rank_method.coinc(s0[i0[si:ei]],
+                                  s1[i1[si:ei]],
+                                  slide[si:ei],
+                                  args.timeslide_interval)
+ 
+            #index values of the zerolag triggers
+            fi = numpy.where(slide == 0)[0]
 
-    if args.decimation_factor:
-        bl = bl_int[slide[bl_int] % args.decimation_factor == 0]
-    else:
-        bl = []
+            #index values of the background triggers
+            bi = numpy.where(slide != 0)[0]
+            logging.info('%s foreground triggers' % len(fi))
+            logging.info('%s background triggers' % len(bi))
 
-    ti = numpy.concatenate([bl, bh, fi]).astype(numpy.uint32)
-    logging.info('%s after decimation' % len(ti))
+            # We split the background triggers into two types which we keep track of
+            # in "bh" (triggers which are *not* decimated, stored in full) and
+            # "bl" (triggers which may not be stored in full, but we keep track of
+            # how many are removed)
+            # "bl_int" keeps track of which triggers are *not* in the bh set. Depending
+            # on the decimation factor option we may not store any of these or we may
+            # keep a fraction of them corresponding to a subset of the timeslides
+            if args.loudest_keep:
+                sep = len(bi) - args.loudest_keep
+                sep = 0 if sep < 0 else sep
 
-    g0 = i0[ti]
-    g1 = i1[ti]
-    del i0
-    del i1
+                bsort = numpy.argpartition(c[bi], sep)
+                bl_int = bi[bsort[0:sep]]
+                bh = bi[bsort[sep:]]
+                del bsort
+                del bi
+            elif args.loudest_keep_value:
+                bh = bi[c[bi] > args.loudest_keep_value]
+                bl_int = bi[c[bi] <= args.loudest_keep_value]
+            else:
+                bh = bi
 
-    data['stat'] += [c[ti]]
-    dec_fac = numpy.repeat([args.decimation_factor, 1, 1],
-                           [len(bl), len(bh), len(fi)]).astype(numpy.uint32)
-    data['decimation_factor'] += [dec_fac]
-    data['time1'] += [t0[g0]]
-    data['time2'] += [t1[g1]]
-    data['trigger_id1'] += [tid0[g0]]
-    data['trigger_id2'] += [tid1[g1]]
-    data['timeslide_id'] += [slide[ti]]
-    data['template_id'] += [numpy.zeros(len(ti), dtype=numpy.uint32) + tnum]
+            if args.decimation_factor:
+                bl = bl_int[slide[bl_int] % args.decimation_factor == 0]
+            else:
+                bl = []
+
+            ti = numpy.concatenate([bl, bh, fi]).astype(numpy.uint32)
+            logging.info('%s after decimation' % len(ti))
+
+            g0 = i0[ti]
+            g1 = i1[ti]
+            del i0
+            del i1
+
+            data['stat'] += [c[ti]]
+            dec_fac = numpy.repeat([args.decimation_factor, 1, 1],
+                                   [len(bl),
+                                    len(bh),
+                                    len(fi)]).astype(numpy.uint32)
+            data['decimation_factor'] += [dec_fac]
+            data['time1'] += [t0[g0]]
+            data['time2'] += [t1[g1]]
+            data['trigger_id1'] += [tid0[g0]]
+            data['trigger_id2'] += [tid1[g1]]
+            data['timeslide_id'] += [slide[ti]]
+            data['template_id'] += [numpy.zeros(len(ti),
+                                    dtype=numpy.uint32) + tnum]
 
 if len(data['stat']) > 0:
     for key in data:

--- a/bin/hdfcoinc/pycbc_coinc_findtrigs
+++ b/bin/hdfcoinc/pycbc_coinc_findtrigs
@@ -3,6 +3,7 @@ import h5py, argparse, logging, numpy, numpy.random
 from pycbc import events, detector
 from pycbc.events import veto, coinc, stat
 import pycbc.version
+from numpy.random import seed, shuffle
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--verbose", action="count")
@@ -201,7 +202,15 @@ logging.info('The coincidence window is %3.1f ms' % (time_window * 1000))
 data = {'stat':[], 'decimation_factor':[], 'time1':[], 'time2':[],
         'trigger_id1':[], 'trigger_id2':[], 'timeslide_id':[], 'template_id':[]}
 
-for tnum in range(tmin, tmax):
+if args.randomize_template_order:
+    seed(0)
+    template_ids = numpy.arange(0, num_templates)
+    shuffle(template_ids)
+    template_ids = template_ids[tmin:tmax]
+else:
+    template_ids = range(tmin, tmax)
+
+for tnum in template_ids:
     tid0 = trigs0.set_template(tnum)
     tid1 = trigs1.set_template(tnum)
 

--- a/bin/hdfcoinc/pycbc_coinc_findtrigs
+++ b/bin/hdfcoinc/pycbc_coinc_findtrigs
@@ -230,7 +230,7 @@ for tnum in template_ids:
     logging.info('Calculating Single Detector Statistic')
     s0g, s1g = rank_method.single(trigs0), rank_method.single(trigs1)
 
-    # Loop over the single triggers and calculate the coincs they can 
+    # Loop over the single triggers and calculate the coincs they can
     # form
     start0 = 0
     while start0 < len(s0g):
@@ -243,7 +243,7 @@ for tnum in template_ids:
                 end0 = len(s0g)
             if end1 > len(s1g):
                 end1 = len(s1g)
-                
+
             # Set the local parts of the single information we'll use
             tid0 = tid0g[start0:end0]
             tid1 = tid1g[start1:end1]
@@ -261,7 +261,7 @@ for tnum in template_ids:
             logging.info('Calculating Multi-Detector Combined Statistic: %s, %s', end0, end1)
             c = rank_method.coinc(s0[i0], s1[i1], slide,
                                   args.timeslide_interval)
- 
+
             #index values of the zerolag triggers
             fi = numpy.where(slide == 0)[0]
 
@@ -321,6 +321,7 @@ for tnum in template_ids:
 
             start1 += args.batch_singles
         start0 += args.batch_singles
+
 if len(data['stat']) > 0:
     for key in data:
         data[key] = numpy.concatenate(data[key])

--- a/bin/hdfcoinc/pycbc_coinc_findtrigs
+++ b/bin/hdfcoinc/pycbc_coinc_findtrigs
@@ -49,6 +49,9 @@ parser.add_argument("--output-file",
 parser.add_argument("--randomize-template-order", action="store_true",
                     help="Random shuffle templates with fixed seed "
                          "before selecting range to analyze")
+parser.add_argument("--batch-statistic", default=1000000, type=int,
+                    help="Number of coincicent triggers to calculation statistics"
+                         "for at once")
 args = parser.parse_args()
 
 # flatten the list of lists of filenames to a single list (may be empty)
@@ -228,12 +231,22 @@ for tnum in template_ids:
     i0, i1, slide = coinc.time_coincidence(t0, t1, time_window, args.timeslide_interval)
 
     logging.info('Coincident Trigs: %s' % (len(i1)))
-
     logging.info('Calculating Single Detector Statistic')
     s0, s1 = rank_method.single(trigs0), rank_method.single(trigs1)
 
-    logging.info('Calculating Multi-Detector Combined Statistic')
-    c = rank_method.coinc(s0[i0], s1[i1], slide, args.timeslide_interval)
+    c = []
+    si = 0
+    while si < len(i0):
+        ei = args.batch_statistic + si
+        if ei > len(i0):
+            ei = len(i0)
+
+        logging.info('Calculating Multi-Detector Combined Statistic: %s', si)
+        c += [rank_method.coinc(s0[i0[si:ei]],
+                                s1[i1[si:ei]],
+                                slide[si:ei], args.timeslide_interval)]
+        si += args.batch_statistic
+    c = numpy.concatenate(c)
 
     #index values of the zerolag triggers
     fi = numpy.where(slide == 0)[0]

--- a/bin/hdfcoinc/pycbc_coinc_findtrigs
+++ b/bin/hdfcoinc/pycbc_coinc_findtrigs
@@ -49,7 +49,7 @@ parser.add_argument("--output-file",
 parser.add_argument("--randomize-template-order", action="store_true",
                     help="Random shuffle templates with fixed seed "
                          "before selecting range to analyze")
-parser.add_argument("--batch-singles", default=1000000, type=int,
+parser.add_argument("--batch-singles", default=5000, type=int,
                     help="Number of single triggers to process at once")
 args = parser.parse_args()
 
@@ -219,13 +219,13 @@ for tnum in template_ids:
     tid0g = trigs0.set_template(tnum)
     tid1g = trigs1.set_template(tnum)
 
-    if (len(tid0) == 0) or (len(tid1) == 0):
+    if (len(tid0g) == 0) or (len(tid1g) == 0):
         continue
 
     t0g = trigs0['end_time']
     t1g = trigs1['end_time']
     logging.info('Trigs for template %s, %s:%s %s:%s' % \
-                (tnum, trigs0.ifo, len(t0), trigs1.ifo, len(t1)))
+                (tnum, trigs0.ifo, len(t0g), trigs1.ifo, len(t1g)))
 
     logging.info('Calculating Single Detector Statistic')
     s0g, s1g = rank_method.single(trigs0), rank_method.single(trigs1)
@@ -233,16 +233,16 @@ for tnum in template_ids:
     # Loop over the single triggers and calculate the coincs they can 
     # form
     start0 = 0
-    while start0 < len(i0):
+    while start0 < len(s0g):
         start1 = 0
-        while start1 < len(i0):
+        while start1 < len(s1g):
 
             end0 = start0 + args.batch_singles
             end1 = start1 + args.batch_singles
-            if end0 > len(i0):
-                end0 = len(i0)
-            if end1 > len(i0):
-                end1 = len(i0)
+            if end0 > len(s0g):
+                end0 = len(s0g)
+            if end1 > len(s1g):
+                end1 = len(s1g)
                 
             # Set the local parts of the single information we'll use
             tid0 = tid0g[start0:end0]
@@ -258,10 +258,8 @@ for tnum in template_ids:
             logging.info('Coincident Trigs: %s' % (len(i1)))
 
 
-            logging.info('Calculating Multi-Detector Combined Statistic: %s', si)
-            c = rank_method.coinc(s0[i0[si:ei]],
-                                  s1[i1[si:ei]],
-                                  slide[si:ei],
+            logging.info('Calculating Multi-Detector Combined Statistic: %s, %s', end0, end1)
+            c = rank_method.coinc(s0[i0], s1[i1], slide,
                                   args.timeslide_interval)
  
             #index values of the zerolag triggers
@@ -321,6 +319,8 @@ for tnum in template_ids:
             data['template_id'] += [numpy.zeros(len(ti),
                                     dtype=numpy.uint32) + tnum]
 
+            start1 += args.batch_singles
+        start0 += args.batch_singles
 if len(data['stat']) > 0:
     for key in data:
         data[key] = numpy.concatenate(data[key])

--- a/bin/hdfcoinc/pycbc_coinc_findtrigs
+++ b/bin/hdfcoinc/pycbc_coinc_findtrigs
@@ -47,7 +47,8 @@ parser.add_argument("--cluster-window", type=float,
 parser.add_argument("--output-file",
                     help="File to store the coincident triggers")
 parser.add_argument("--randomize-template-order", action="store_true",
-                    help="Shuffle which templates are analyze")
+                    help="Random shuffle templates with fixed seed "
+                         "before selecting range to analyze")
 args = parser.parse_args()
 
 # flatten the list of lists of filenames to a single list (may be empty)

--- a/bin/hdfcoinc/pycbc_coinc_findtrigs
+++ b/bin/hdfcoinc/pycbc_coinc_findtrigs
@@ -46,6 +46,8 @@ parser.add_argument("--cluster-window", type=float,
                     "coincidences over the bank")
 parser.add_argument("--output-file",
                     help="File to store the coincident triggers")
+parser.add_argument("--randomize-template-order", action="store_true",
+                    help="Shuffle which templates are analyze")
 args = parser.parse_args()
 
 # flatten the list of lists of filenames to a single list (may be empty)

--- a/bin/hdfcoinc/pycbc_multiifo_coinc_findtrigs
+++ b/bin/hdfcoinc/pycbc_multiifo_coinc_findtrigs
@@ -50,7 +50,8 @@ parser.add_argument("--cluster-window", type=float,
 parser.add_argument("--output-file",
                     help="File to store the coincident triggers")
 parser.add_argument("--randomize-template-order", action="store_true",
-                    help="Shuffle which templates are analyze")
+                    help="Random shuffle templates with fixed seed "
+                         "before selecting range to analyze")
 args = parser.parse_args()
 
 # flatten the list of lists of filenames to a single list (may be empty)

--- a/bin/hdfcoinc/pycbc_multiifo_coinc_findtrigs
+++ b/bin/hdfcoinc/pycbc_multiifo_coinc_findtrigs
@@ -52,6 +52,8 @@ parser.add_argument("--output-file",
 parser.add_argument("--randomize-template-order", action="store_true",
                     help="Random shuffle templates with fixed seed "
                          "before selecting range to analyze")
+parser.add_argument("--batch-singles", default=5000, type=int,
+                    help="Number of single triggers to process at once")
 args = parser.parse_args()
 
 # flatten the list of lists of filenames to a single list (may be empty)
@@ -230,96 +232,115 @@ for tnum in template_ids:
         if len(tids[ifo] == 0):
             continue
 
-    times={}
+    times_full={}
     for ifo in trigs:
         times[ifo]=trigs[ifo]['end_time']
     logging.info('Trigs for template %s, '% (tnum))
     for ifo in times:
         logging.info('%s:%s' % (ifo, len(times[ifo])))
 
-    ids, slide = coinc.time_multi_coincidence(times, args.timeslide_interval,
-                                              args.coinc_threshold,
-                                              args.pivot_ifo,
-                                              args.fixed_ifo)
-
-    logging.info('Coincident Trigs: %s' % (len(ids[args.pivot_ifo])))
-
     logging.info('Calculating Single Detector Statistic')
-    sds={}
-    for ifo in trigs:
-        sds[ifo]=rank_method.single(trigs[ifo])
+    sds_full = {ifo:rank_method.single(trigs[ifo]) for ifo in trigs}
 
-    logging.info('Calculating Multi-Detector Combined Statistic')
+    # Loop over the single triggers and calculate the coincs they can form
+    start0 = 0
+    while start0 < len(sds[args.pivot_ifo]):
+        start1 = 0
+        while start1 < len(sds[args.fixed_ifo]):
+            end0 = start0 + args.batch_singles
+            end1 = start1 + args.batch_singles
+            if end0 > len(sds[args.pivot_ifo]):
+                end0 = len(sds[args.pivot_ifo])
+            if end1 > len(sds[args.fixed_ifo]):
+                end1 = len(sds[args.fixed_ifo])
 
-    sdswithids={}
-    for ifo in sds:
-        sdswithids[ifo]=sds[ifo][ids[ifo]]
-    c = rank_method.coinc_multiifo(sdswithids, slide, args.timeslide_interval)
+            times = times_full.copy()
+            times[args.pivot_ifo] = times_full[args.pivot_ifo][start0:end0]
+            times[args.fixed_ifo] = times_full[args.fixed_ifo][start1:end1]
 
-    #index values of the zerolag triggers
-    fi = numpy.where(slide == 0)[0]
+            sds = sds_full.copy()
+            sds[args.pivot_ifo] = sds_full[args.pivot_ifo][start0:end0]
+            sds[args.fixed_ifo] = sds_full[args.fixed_ifo][start1:end1]
 
-    #index values of the background triggers
-    bi = numpy.where(slide != 0)[0]
-    logging.info('%s foreground triggers' % len(fi))
-    logging.info('%s background triggers' % len(bi))
+            logging.info('Coincident Trigs: %s' % (len(ids[args.pivot_ifo])))
+            ids, slide = coinc.time_multi_coincidence(times,
+                                                      args.timeslide_interval,
+                                                      args.coinc_threshold,
+                                                      args.pivot_ifo,
+                                                      args.fixed_ifo)
 
-    # We split the background triggers into two types which we keep track of
-    # in "bh" (triggers which are *not* decimated, stored in full) and
-    # "bl" (triggers which may not be stored in full, but we keep track of
-    # how many are removed)
-    # "bl_int" keeps track of which triggers are *not* in the bh set. Depending
-    # on the decimation factor option we may not store any of these or we may
-    # keep a fraction of them corresponding to a subset of the timeslides
-    if args.loudest_keep:
-        sep = len(bi) - args.loudest_keep
-        sep = 0 if sep < 0 else sep
+            logging.info('Calculating Multi-Detector Combined Statistic')
 
-        bsort = numpy.argpartition(c[bi], sep)
-        bl_int = bi[bsort[0:sep]]
-        bh = bi[bsort[sep:]]
-        del bsort
-        del bi
-    elif args.loudest_keep_value:
-        bh = bi[c[bi] > args.loudest_keep_value]
-        bl_int = bi[c[bi] <= args.loudest_keep_value]
-    else:
-        bh = bi
+            sdswithids={}
+            for ifo in sds:
+                sdswithids[ifo]=sds[ifo][ids[ifo]]
+            c = rank_method.coinc_multiifo(sdswithids, slide,
+                                           args.timeslide_interval)
 
-    if args.decimation_factor:
-        bl = bl_int[slide[bl_int] % args.decimation_factor == 0]
-    else:
-        bl = []
+            #index values of the zerolag triggers
+            fi = numpy.where(slide == 0)[0]
 
-    ti = numpy.concatenate([bl, bh, fi]).astype(numpy.uint32)
-    logging.info('%s after decimation' % len(ti))
+            #index values of the background triggers
+            bi = numpy.where(slide != 0)[0]
+            logging.info('%s foreground triggers' % len(fi))
+            logging.info('%s background triggers' % len(bi))
 
-    gs={}
-    for ifo in ids:
-        gs[ifo]=ids[ifo][ti]
-    del ids
+            # We split the background triggers into two types which we keep track of
+            # in "bh" (triggers which are *not* decimated, stored in full) and
+            # "bl" (triggers which may not be stored in full, but we keep track of
+            # how many are removed)
+            # "bl_int" keeps track of which triggers are *not* in the bh set. Depending
+            # on the decimation factor option we may not store any of these or we may
+            # keep a fraction of them corresponding to a subset of the timeslides
+            if args.loudest_keep:
+                sep = len(bi) - args.loudest_keep
+                sep = 0 if sep < 0 else sep
 
-    # In the first for cycle the time and trigger_id keys will not exist,
-    # we need to create them, otherwise add new items into data.
-    checkstring = '%s/time' % args.pivot_ifo
-    if checkstring in data:
-        for ifo in gs:
-            addtime=times[ifo][gs[ifo]]
-            addtriggerid=tids[ifo][gs[ifo]]
-            data['%s/time' % ifo] += [addtime]
-            data['%s/trigger_id' % ifo] += [addtriggerid]
-    else:
-        for ifo in gs:
-            addtime=times[ifo][gs[ifo]]
-            addtriggerid=tids[ifo][gs[ifo]]
-            data['%s/time' % ifo] = [addtime]
-            data['%s/trigger_id' % ifo] = [addtriggerid]
-    data['stat'] += [c[ti]]
-    dec_fac = numpy.repeat([args.decimation_factor, 1, 1],
-                           [len(bl), len(bh), len(fi)]).astype(numpy.uint32)
-    data['decimation_factor'] += [dec_fac]
-    data['timeslide_id'] += [slide[ti]]
-    data['template_id'] += [numpy.zeros(len(ti), dtype=numpy.uint32) + tnum]
+                bsort = numpy.argpartition(c[bi], sep)
+                bl_int = bi[bsort[0:sep]]
+                bh = bi[bsort[sep:]]
+                del bsort
+                del bi
+            elif args.loudest_keep_value:
+                bh = bi[c[bi] > args.loudest_keep_value]
+                bl_int = bi[c[bi] <= args.loudest_keep_value]
+            else:
+                bh = bi
+
+            if args.decimation_factor:
+                bl = bl_int[slide[bl_int] % args.decimation_factor == 0]
+            else:
+                bl = []
+
+            ti = numpy.concatenate([bl, bh, fi]).astype(numpy.uint32)
+            logging.info('%s after decimation' % len(ti))
+
+            gs={}
+            for ifo in ids:
+                gs[ifo]=ids[ifo][ti]
+            del ids
+
+            # In the first for cycle the time and trigger_id keys will not exist,
+            # we need to create them, otherwise add new items into data.
+            checkstring = '%s/time' % args.pivot_ifo
+            if checkstring in data:
+                for ifo in gs:
+                    addtime=times[ifo][gs[ifo]]
+                    addtriggerid=tids[ifo][gs[ifo]]
+                    data['%s/time' % ifo] += [addtime]
+                    data['%s/trigger_id' % ifo] += [addtriggerid]
+            else:
+                for ifo in gs:
+                    addtime=times[ifo][gs[ifo]]
+                    addtriggerid=tids[ifo][gs[ifo]]
+                    data['%s/time' % ifo] = [addtime]
+                    data['%s/trigger_id' % ifo] = [addtriggerid]
+            data['stat'] += [c[ti]]
+            dec_fac = numpy.repeat([args.decimation_factor, 1, 1],
+                                   [len(bl), len(bh), len(fi)]).astype(numpy.uint32)
+            data['decimation_factor'] += [dec_fac]
+            data['timeslide_id'] += [slide[ti]]
+            data['template_id'] += [numpy.zeros(len(ti), dtype=numpy.uint32) + tnum]
 
 if len(data['stat']) > 0:
     for key in data:

--- a/bin/hdfcoinc/pycbc_multiifo_coinc_findtrigs
+++ b/bin/hdfcoinc/pycbc_multiifo_coinc_findtrigs
@@ -49,6 +49,8 @@ parser.add_argument("--cluster-window", type=float,
                     "coincidences over the bank")
 parser.add_argument("--output-file",
                     help="File to store the coincident triggers")
+parser.add_argument("--randomize-template-order", action="store_true",
+                    help="Shuffle which templates are analyze")
 args = parser.parse_args()
 
 # flatten the list of lists of filenames to a single list (may be empty)

--- a/bin/hdfcoinc/pycbc_multiifo_coinc_findtrigs
+++ b/bin/hdfcoinc/pycbc_multiifo_coinc_findtrigs
@@ -3,6 +3,7 @@ import h5py, argparse, logging, numpy, numpy.random
 from pycbc import events, detector
 from pycbc.events import veto, coinc, stat
 import pycbc.version
+from numpy.random import seed, shuffle
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--verbose", action="count")
@@ -209,7 +210,15 @@ if args.timeslide_interval is None:
 
 data = {'stat':[], 'decimation_factor':[], 'timeslide_id':[], 'template_id':[]}
 
-for tnum in range(tmin, tmax):
+if args.randomize_template_order:
+    seed(0)
+    template_ids = numpy.arange(0, num_templates)
+    shuffle(template_ids)
+    template_ids = template_ids[tmin:tmax]
+else:
+    template_ids = range(tmin, tmax)
+
+for tnum in template_ids:
     tids={}
     for ifo in trigs:
         tids[ifo]=trigs[ifo].set_template(tnum)


### PR DESCRIPTION
One issue with handling a lot of coincs in some of my test runs has been that sum jobs when sorted by mchirp produce very different memory useage patters. This PR addresses that problem by randomizing which templates are handled in each coinc job (but in a reproduceable way). 

I'll report back testing I'm doing on ATLAS when that's complete.