### PR TITLE
Live: enable per-detector analysis flags

### DIFF
--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -193,7 +193,7 @@ class LiveEventManager(object):
             fud = self.compute_followup_data(coinc_ifos, coinc_results,
                                              data_readers, bank, followup_ifos)
 
-            live_ifos = [ifo for ifo in ifos if 'snr_series' in fud[ifo]]
+            live_ifos = [ifo for ifo in fud if 'snr_series' in fud[ifo]]
 
             # FIXME delta_t can vary due to rounding errors, force them to be identical
             fix_delta_t = fud[coinc_ifos[0]]['snr_series'].delta_t

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -243,9 +243,7 @@ class LiveEventManager(object):
                     event.save(fname)
 
     def dump(self, results, name, store_psd=False, time_index=None,
-                  store_loudest_index=False,
-                  raw_results=None,
-                  gracedb_results=None):
+             store_loudest_index=False, raw_results=None):
         """ Save the results from this time block to an hdf output file """
         if self.use_date_prefix:
             tm = lal.GPSToUTC(int(time_index))
@@ -682,7 +680,7 @@ with ctx:
                                           valid_pad)
 
             evnt.dump(results, prefix, time_index=data_end(),
-                      store_psd=False if args.store_psd is False else psds,
+                      store_psd=(psds if args.store_psd else False),
                       store_loudest_index=args.store_loudest_index,
                       raw_results=best_coinc)
 

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -14,9 +14,10 @@ import argparse, numpy, pycbc, logging, cProfile, h5py, lal, json
 from time import time
 import os.path
 import itertools
+import platform
 from mpi4py import MPI as mpi
 from pycbc.pool import BroadcastPool
-from pycbc import fft, version, waveform, scheme, frame, makedir
+from pycbc import fft, version, waveform, scheme, makedir
 from pycbc.types import MultiDetOptionAction
 from pycbc.filter import LiveBatchMatchedFilter, compute_followup_snr_series
 from pycbc.filter import followup_event_significance
@@ -285,54 +286,6 @@ class LiveEventManager(object):
                 if store_psd[ifo] is not None:
                     store_psd[ifo].save(fname, group='%s/psd' % ifo)
 
-def init_data_reader(ifo, args, maxlen):
-    """Initialize a StrainBuffer object (data reader) for a particular
-    detector.
-    """
-    state_channel = analyze_flags = None
-    if args.state_channel and ifo in args.state_channel \
-            and args.analyze_flags and ifo in args.analyze_flags:
-        state_channel = ':'.join([ifo, args.state_channel[ifo]])
-        analyze_flags = args.analyze_flags[ifo].split(',')
-
-    dq_channel = dq_flags = None
-    if args.data_quality_channel and ifo in args.data_quality_channel \
-            and args.data_quality_flags and ifo in args.data_quality_flags:
-        dq_channel = ':'.join([ifo, args.data_quality_channel[ifo]])
-        dq_flags = args.data_quality_flags[ifo].split(',')
-
-    if args.frame_type:
-        frame_src = frame.frame_paths(args.frame_type[ifo], args.start_time,
-                                      args.end_time)
-    else:
-        frame_src = [args.frame_src[ifo]]
-    strain_channel = ':'.join([ifo, args.channel_name[ifo]])
-
-    return StrainBuffer(frame_src, strain_channel,
-                        args.start_time, max_buffer=maxlen * 2,
-                        state_channel=state_channel,
-                        data_quality_channel=dq_channel,
-                        sample_rate=args.sample_rate,
-                        low_frequency_cutoff=args.low_frequency_cutoff,
-                        highpass_frequency=args.highpass_frequency,
-                        highpass_reduction=args.highpass_reduction,
-                        highpass_bandwidth=args.highpass_bandwidth,
-                        psd_samples=args.psd_samples,
-                        trim_padding=args.trim_padding,
-                        psd_segment_length=args.psd_segment_length,
-                        psd_inverse_length=args.psd_inverse_length,
-                        autogating_threshold=args.autogating_threshold,
-                        autogating_cluster=args.autogating_cluster,
-                        autogating_window=args.autogating_window,
-                        autogating_pad=args.autogating_pad,
-                        psd_abort_difference=args.psd_abort_difference,
-                        psd_recalculate_difference=args.psd_recalculate_difference,
-                        force_update_cache=args.force_update_cache,
-                        increment_update_cache=args.increment_update_cache[ifo],
-                        analyze_flags=analyze_flags,
-                        data_quality_flags=dq_flags,
-                        dq_padding=args.data_quality_padding)
-
 
 parser = argparse.ArgumentParser(description=__doc__)
 pycbc.waveform.bank.add_approximant_arg(parser)
@@ -468,7 +421,6 @@ args = parser.parse_args()
 scheme.verify_processing_options(args, parser)
 fft.verify_fft_options(args, parser)
 
-import platform
 log_format = "%(asctime)s {0} %(message)s".format(platform.node())
 pycbc.init_logging(args.verbose, format=log_format)
 
@@ -535,7 +487,7 @@ with ctx:
     if evnt.rank > 0:
         bank.table.sort(order='mchirp')
         waveforms = list(bank[evnt.rank-1::evnt.size-1])
-        lengths = numpy.array([1.0 / waveform.delta_f for waveform in waveforms])
+        lengths = numpy.array([1.0 / wf.delta_f for wf in waveforms])
         psd_len = args.psd_segment_length * (args.psd_samples // 2 + 1)
         maxlen = max(lengths.max(), psd_len)
         mf = LiveBatchMatchedFilter(waveforms, args.snr_threshold,
@@ -559,7 +511,8 @@ with ctx:
     if args.max_length is not None:
         maxlen = args.max_length
     maxlen = int(maxlen)
-    data_reader = {ifo: init_data_reader(ifo, args, maxlen) for ifo in ifos}
+    data_reader = {ifo: StrainBuffer.from_cli(ifo, args, maxlen)
+                   for ifo in ifos}
 
     # create single-detector background "estimators"
     if args.enable_single_detector_background and evnt.rank == 0:

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -643,19 +643,21 @@ with ctx:
             for ifo in set(results.keys()) - evnt.live_detectors:
                 results.pop(ifo)
 
-            # Veto single detector triggers if they fail the DQ vector
-            if args.data_quality_channel:
-                logging.info('checking the dq vector')
-                for ifo in results:
-                    start = data_reader[ifo].start_time
-                    times = results[ifo]['end_time']
-                    idx = data_reader[ifo].dq.indices_of_flag(
-                            start, valid_pad, times,
-                            padding=data_reader[ifo].dq_padding)
-                    logging.info('Keeping %d/%d %s triggers', len(idx), len(times), ifo)
-                    for key in results[ifo]:
-                        if len(results[ifo][key]) > 0:
-                            results[ifo][key] = results[ifo][key][idx]
+            # Veto single detector triggers that fail the DQ vector
+            for ifo in results:
+                if data_reader[ifo].dq is None:
+                    continue
+                logging.info("Checking %s's DQ vector", ifo)
+                start = data_reader[ifo].start_time
+                times = results[ifo]['end_time']
+                idx = data_reader[ifo].dq.indices_of_flag(
+                        start, valid_pad, times,
+                        padding=data_reader[ifo].dq_padding)
+                logging.info('Keeping %d/%d %s triggers',
+                             len(idx), len(times), ifo)
+                for key in results[ifo]:
+                    if len(results[ifo][key]):
+                        results[ifo][key] = results[ifo][key][idx]
 
             # Look for coincident triggers and do background estimation
             if args.enable_background_estimation:

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -287,6 +287,54 @@ class LiveEventManager(object):
                 if store_psd[ifo] is not None:
                     store_psd[ifo].save(fname, group='%s/psd' % ifo)
 
+def init_data_reader(ifo, args, maxlen):
+    """Initialize a StrainBuffer object (data reader) for a particular
+    detector.
+    """
+    state_channel = analyze_flags = None
+    if args.state_channel and ifo in args.state_channel \
+            and args.analyze_flags and ifo in args.analyze_flags:
+        state_channel = ':'.join([ifo, args.state_channel[ifo]])
+        analyze_flags = args.analyze_flags[ifo].split(',')
+
+    dq_channel = dq_flags = None
+    if args.data_quality_channel and ifo in args.data_quality_channel \
+            and args.data_quality_flags and ifo in args.data_quality_flags:
+        dq_channel = ':'.join([ifo, args.data_quality_channel[ifo]])
+        dq_flags = args.data_quality_flags[ifo].split(',')
+
+    if args.frame_type:
+        frame_src = frame.frame_paths(args.frame_type[ifo], args.start_time,
+                                      args.end_time)
+    else:
+        frame_src = [args.frame_src[ifo]]
+    strain_channel = ':'.join([ifo, args.channel_name[ifo]])
+
+    return StrainBuffer(frame_src, strain_channel,
+                        args.start_time, max_buffer=maxlen * 2,
+                        state_channel=state_channel,
+                        data_quality_channel=dq_channel,
+                        sample_rate=args.sample_rate,
+                        low_frequency_cutoff=args.low_frequency_cutoff,
+                        highpass_frequency=args.highpass_frequency,
+                        highpass_reduction=args.highpass_reduction,
+                        highpass_bandwidth=args.highpass_bandwidth,
+                        psd_samples=args.psd_samples,
+                        trim_padding=args.trim_padding,
+                        psd_segment_length=args.psd_segment_length,
+                        psd_inverse_length=args.psd_inverse_length,
+                        autogating_threshold=args.autogating_threshold,
+                        autogating_cluster=args.autogating_cluster,
+                        autogating_window=args.autogating_window,
+                        autogating_pad=args.autogating_pad,
+                        psd_abort_difference=args.psd_abort_difference,
+                        psd_recalculate_difference=args.psd_recalculate_difference,
+                        force_update_cache=args.force_update_cache,
+                        increment_update_cache=args.increment_update_cache[ifo],
+                        analyze_flags=analyze_flags,
+                        data_quality_flags=dq_flags,
+                        dq_padding=args.data_quality_padding)
+
 
 parser = argparse.ArgumentParser(description=__doc__)
 pycbc.waveform.bank.add_approximant_arg(parser)
@@ -310,7 +358,7 @@ parser.add_argument('--state-channel', action=MultiDetOptionAction, nargs='+',
                     help="Channel containing frame status information. Used "
                          "to determine when to analyze the hoft data. This somewhat "
                          "corresponds to CAT1 information")
-parser.add_argument('--analyze-flags', nargs='+', default=['HOFT_OK', 'SCIENCE_INTENT'],
+parser.add_argument('--analyze-flags', action=MultiDetOptionAction, nargs='+',
                     help='The flags that must be in the "good" state to analyze data')
 parser.add_argument('--data-quality-channel', action=MultiDetOptionAction, nargs='+',
                     help="Channel containing data quality information. Used "
@@ -502,64 +550,23 @@ with ctx:
     # Synchronize start time if not provided on the command line
     if not args.start_time:
         evnt.barrier()
-        if evnt.rank == 0:
-            tnow = lal.GPSTimeNow()
-        else:
-            tnow = None
+        tnow = lal.GPSTimeNow() if evnt.rank == 0 else None
         args.start_time = evnt.comm.bcast(tnow, root=0)
 
     if args.round_start_time:
         args.start_time = int(args.start_time / args.round_start_time + 1) * args.round_start_time
         logging.info('Starting from: %s', args.start_time)
 
+    # initialize the data readers for all detectors
     if args.max_length is not None:
         maxlen = args.max_length
-
     maxlen = int(maxlen)
-    data_reader = {}
-    sngl_estimator = {}
-    for ifo in ifos:
-        state = dq = dqf = None
-        if args.state_channel and ifo in args.state_channel:
-            state = '%s:%s' % (ifo, args.state_channel[ifo])
-        if args.data_quality_channel and ifo in args.data_quality_channel \
-                and args.data_quality_flags and ifo in args.data_quality_flags:
-            dq ='%s:%s' % (ifo, args.data_quality_channel[ifo])
-            dqf = args.data_quality_flags[ifo].split(',')
+    data_reader = {ifo: init_data_reader(ifo, args, maxlen) for ifo in ifos}
 
-        if args.frame_type:
-            frame_src = frame.frame_paths(args.frame_type[ifo], args.start_time, args.end_time)
-        else:
-            frame_src = [args.frame_src[ifo]]
-
-        if args.enable_single_detector_background and evnt.rank == 0:
-            sngl_estimator[ifo] = LiveSingleFarThreshold.from_cli(args, ifo)
-
-        data_reader[ifo] = StrainBuffer(frame_src,
-                            '%s:%s' % (ifo, args.channel_name[ifo]),
-                            args.start_time, max_buffer=maxlen * 2,
-                            state_channel=state,
-                            data_quality_channel=dq,
-                            sample_rate=args.sample_rate,
-                            low_frequency_cutoff=args.low_frequency_cutoff,
-                            highpass_frequency=args.highpass_frequency,
-                            highpass_reduction=args.highpass_reduction,
-                            highpass_bandwidth=args.highpass_bandwidth,
-                            psd_samples=args.psd_samples,
-                            trim_padding=args.trim_padding,
-                            psd_segment_length=args.psd_segment_length,
-                            psd_inverse_length=args.psd_inverse_length,
-                            autogating_threshold=args.autogating_threshold,
-                            autogating_cluster=args.autogating_cluster,
-                            autogating_window=args.autogating_window,
-                            autogating_pad=args.autogating_pad,
-                            psd_abort_difference=args.psd_abort_difference,
-                            psd_recalculate_difference=args.psd_recalculate_difference,
-                            force_update_cache=args.force_update_cache,
-                            increment_update_cache=args.increment_update_cache[ifo],
-                            analyze_flags=args.analyze_flags,
-                            data_quality_flags=dqf,
-                            dq_padding=args.data_quality_padding)
+    # create single-detector background "estimators"
+    if args.enable_single_detector_background and evnt.rank == 0:
+        sngl_estimator = {ifo: LiveSingleFarThreshold.from_cli(args, ifo)
+                          for ifo in ifos}
 
     # Create double coincident background estimator for every combo
     if args.enable_background_estimation and evnt.rank == 0:
@@ -591,7 +598,7 @@ with ctx:
         pr = cProfile.Profile()
         pr.enable()
 
-    # get more data
+    # main analysis loop
     data_end = lambda: data_reader[data_reader.keys()[0]].end_time
     while data_end() < args.end_time:
         t1 = time()

--- a/pycbc/filter/matchedfilter.py
+++ b/pycbc/filter/matchedfilter.py
@@ -1770,7 +1770,7 @@ def followup_event_significance(ifo, data_reader, bank,
         state_start_time = data_reader.strain.end_time \
                 - data_reader.reduced_pad * data_reader.strain.delta_t - bdur
         if not data_reader.state.is_extent_valid(state_start_time, bdur):
-            return None, None, None
+            return None, None, None, None
 
     # We won't require that all DQ checks be valid for now, except at
     # onsource time.
@@ -1778,7 +1778,7 @@ def followup_event_significance(ifo, data_reader, bank,
         dq_start_time = onsource_start - duration / 2.0
         dq_duration = onsource_end - onsource_start + duration
         if not data_reader.dq.is_extent_valid(dq_start_time, dq_duration):
-            return None, None, None
+            return None, None, None, None
 
     # Calculate SNR time series for this duration
     htilde = bank.get_template(template_id, min_buffer=bdur)

--- a/pycbc/frame/__init__.py
+++ b/pycbc/frame/__init__.py
@@ -36,6 +36,7 @@ ETMX_ESD_DAC_OVERFLOW = 16
 # https://wiki.virgo-gw.eu/DetChar/DetCharVirgoStateVector
 VIRGO_GOOD_DQ = 1 << 10
 
+
 def flag_names_to_bitmask(flags):
     """Takes a list of flag names corresponding to bits in a status channel
     and returns the corresponding bit mask.

--- a/pycbc/frame/__init__.py
+++ b/pycbc/frame/__init__.py
@@ -35,3 +35,12 @@ ETMX_ESD_DAC_OVERFLOW = 16
 # CAT1 bit in the Virgo state vector
 # https://wiki.virgo-gw.eu/DetChar/DetCharVirgoStateVector
 VIRGO_GOOD_DQ = 1 << 10
+
+def flag_names_to_bitmask(flags):
+    """Takes a list of flag names corresponding to bits in a status channel
+    and returns the corresponding bit mask.
+    """
+    mask = 0
+    for flag in flags:
+        mask |= globals()[flag]
+    return mask

--- a/pycbc/frame/__init__.py
+++ b/pycbc/frame/__init__.py
@@ -5,6 +5,7 @@ from . frame import (locations_to_cache, read_frame, datafind_connection,
 
 # Status flags for the calibration state vector
 # See e.g. https://dcc.ligo.org/LIGO-G1700234
+# https://wiki.ligo.org/DetChar/DataQuality/O3Flags
 HOFT_OK = 1
 SCIENCE_INTENT = 2
 SCIENCE_QUALITY = 4
@@ -23,12 +24,14 @@ NO_GAP = 16384
 NO_HWINJ = NO_STOCH_HW_INJ | NO_CBC_HW_INJ | \
            NO_BURST_HW_INJ | NO_DETCHAR_HW_INJ
 
-# O2 Low-Latency DQ vector definition
+# relevant bits in the LIGO O2/O3 low-latency DQ vector
 # If the bit is 0 then we should veto
 # https://wiki.ligo.org/DetChar/DmtDqVector
+# https://wiki.ligo.org/DetChar/DataQuality/O3Flags
 OMC_DCPD_ADC_OVERFLOW = 2
 ETMY_ESD_DAC_OVERFLOW = 4
+ETMX_ESD_DAC_OVERFLOW = 16
 
-# Virgo state vector
+# CAT1 bit in the Virgo state vector
 # https://wiki.virgo-gw.eu/DetChar/DetCharVirgoStateVector
 VIRGO_GOOD_DQ = 1 << 10

--- a/pycbc/frame/frame.py
+++ b/pycbc/frame/frame.py
@@ -673,7 +673,7 @@ class StatusBuffer(DataBuffer):
                        max_buffer=2048,
                        valid_mask=3,
                        force_update_cache=False,
-                       increment_update_cache=None
+                       increment_update_cache=None,
                        valid_on_zero=False):
         """ Create a rolling buffer of status data from a frame
 

--- a/pycbc/strain/strain.py
+++ b/pycbc/strain/strain.py
@@ -1286,7 +1286,8 @@ class StrainBuffer(pycbc.frame.DataBuffer):
             if len(self.data_quality_flags) == 1 \
                     and self.data_quality_flags[0] == 'veto_nonzero':
                 veto_nonzero = True
-                logging.info('DQ channel %s interpreted as zero = good')
+                logging.info('DQ channel %s interpreted as zero = good',
+                             data_quality_channel)
             else:
                 veto_nonzero = False
                 valid_mask = pycbc.frame.flag_names_to_bitmask(

--- a/pycbc/strain/strain.py
+++ b/pycbc/strain/strain.py
@@ -1271,7 +1271,7 @@ class StrainBuffer(pycbc.frame.DataBuffer):
         # State channel
         if state_channel is not None:
             valid_mask = pycbc.frame.flag_names_to_bitmask(self.analyze_flags)
-            logging.info('State channel %s interpreted as mask %s = good',
+            logging.info('State channel %s interpreted as bitmask %s = good',
                          state_channel, bin(valid_mask))
             self.state = pycbc.frame.StatusBuffer(
                 frame_src,
@@ -1283,25 +1283,21 @@ class StrainBuffer(pycbc.frame.DataBuffer):
 
         # low latency dq channel
         if data_quality_channel is not None:
+            sb_kwargs = dict(max_buffer=max_buffer,
+                             force_update_cache=force_update_cache,
+                             increment_update_cache=increment_update_cache)
             if len(self.data_quality_flags) == 1 \
                     and self.data_quality_flags[0] == 'veto_nonzero':
-                veto_nonzero = True
+                sb_kwargs['valid_on_zero'] = True
                 logging.info('DQ channel %s interpreted as zero = good',
                              data_quality_channel)
             else:
-                veto_nonzero = False
-                valid_mask = pycbc.frame.flag_names_to_bitmask(
+                sb_kwargs['valid_mask'] = pycbc.frame.flag_names_to_bitmask(
                         self.data_quality_flags)
-                logging.info('DQ channel %s interpreted as mask %s = good',
+                logging.info('DQ channel %s interpreted as bitmask %s = good',
                              data_quality_channel, bin(valid_mask))
-            self.dq = pycbc.frame.StatusBuffer(
-                frame_src,
-                data_quality_channel, start_time,
-                max_buffer=max_buffer,
-                valid_mask=valid_mask,
-                force_update_cache=force_update_cache,
-                increment_update_cache=increment_update_cache,
-                valid_on_zero=veto_nonzero)
+            self.dq = pycbc.frame.StatusBuffer(frame_src, data_quality_channel,
+                                               start_time, **sb_kwargs)
 
         self.highpass_frequency = highpass_frequency
         self.highpass_reduction = highpass_reduction

--- a/pycbc/strain/strain.py
+++ b/pycbc/strain/strain.py
@@ -1300,7 +1300,7 @@ class StrainBuffer(pycbc.frame.DataBuffer):
                 valid_mask=valid_mask,
                 force_update_cache=force_update_cache,
                 increment_update_cache=increment_update_cache,
-                veto_nonzero=veto_nonzero)
+                valid_on_zero=veto_nonzero)
 
         self.highpass_frequency = highpass_frequency
         self.highpass_reduction = highpass_reduction

--- a/pycbc/strain/strain.py
+++ b/pycbc/strain/strain.py
@@ -1271,7 +1271,9 @@ class StrainBuffer(pycbc.frame.DataBuffer):
         if state_channel is not None:
             valid_mask = 0
             for flag in self.analyze_flags:
-                valid_mask = valid_mask | getattr(pycbc.frame, flag)
+                valid_mask |= getattr(pycbc.frame, flag)
+            logging.info('State channel %s using mask %s',
+                         state_channel, bin(valid_mask))
             self.state = pycbc.frame.StatusBuffer(
                 frame_src,
                 state_channel, start_time,
@@ -1284,7 +1286,9 @@ class StrainBuffer(pycbc.frame.DataBuffer):
         if data_quality_channel is not None:
             valid_mask = 0
             for flag in self.data_quality_flags:
-                valid_mask = valid_mask | getattr(pycbc.frame, flag)
+                valid_mask |= getattr(pycbc.frame, flag)
+            logging.info('DQ channel %s using mask %s',
+                         data_quality_channel, bin(valid_mask))
             self.dq = pycbc.frame.StatusBuffer(
                 frame_src,
                 data_quality_channel, start_time,

--- a/pycbc/strain/strain.py
+++ b/pycbc/strain/strain.py
@@ -1587,3 +1587,53 @@ class StrainBuffer(pycbc.frame.DataBuffer):
             return False
         else:
             return True
+
+    @classmethod
+    def from_cli(cls, ifo, args, maxlen):
+        """Initialize a StrainBuffer object (data reader) for a particular
+        detector.
+        """
+        state_channel = analyze_flags = None
+        if args.state_channel and ifo in args.state_channel \
+                and args.analyze_flags and ifo in args.analyze_flags:
+            state_channel = ':'.join([ifo, args.state_channel[ifo]])
+            analyze_flags = args.analyze_flags[ifo].split(',')
+
+        dq_channel = dq_flags = None
+        if args.data_quality_channel and ifo in args.data_quality_channel \
+                and args.data_quality_flags and ifo in args.data_quality_flags:
+            dq_channel = ':'.join([ifo, args.data_quality_channel[ifo]])
+            dq_flags = args.data_quality_flags[ifo].split(',')
+
+        if args.frame_type:
+            frame_src = pycbc.frame.frame_paths(args.frame_type[ifo],
+                                                args.start_time,
+                                                args.end_time)
+        else:
+            frame_src = [args.frame_src[ifo]]
+        strain_channel = ':'.join([ifo, args.channel_name[ifo]])
+
+        return cls(frame_src, strain_channel,
+                   args.start_time, max_buffer=maxlen * 2,
+                   state_channel=state_channel,
+                   data_quality_channel=dq_channel,
+                   sample_rate=args.sample_rate,
+                   low_frequency_cutoff=args.low_frequency_cutoff,
+                   highpass_frequency=args.highpass_frequency,
+                   highpass_reduction=args.highpass_reduction,
+                   highpass_bandwidth=args.highpass_bandwidth,
+                   psd_samples=args.psd_samples,
+                   trim_padding=args.trim_padding,
+                   psd_segment_length=args.psd_segment_length,
+                   psd_inverse_length=args.psd_inverse_length,
+                   autogating_threshold=args.autogating_threshold,
+                   autogating_cluster=args.autogating_cluster,
+                   autogating_window=args.autogating_window,
+                   autogating_pad=args.autogating_pad,
+                   psd_abort_difference=args.psd_abort_difference,
+                   psd_recalculate_difference=args.psd_recalculate_difference,
+                   force_update_cache=args.force_update_cache,
+                   increment_update_cache=args.increment_update_cache[ifo],
+                   analyze_flags=analyze_flags,
+                   data_quality_flags=dq_flags,
+                   dq_padding=args.data_quality_padding)


### PR DESCRIPTION
I do some refactoring of the data reader code in `pycbc_live`, and add the ability to use different analysis flags for different detectors. This is necessary for Virgo in O3.

Note that this patch will require a change in the current PyCBC Live configuration.

Needs testing.