### PR TITLE
Live: avoid human confusion with χ² not being calculated

### DIFF
--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -134,34 +134,40 @@ class LiveEventManager(object):
 
         # Determine if the other ifos can contribute to the coincident event
         for ifo in followup_ifos:
-            snr_series, ptime, pvalue = followup_event_significance(
+            snr_series, ptime, pvalue, sigma2 = followup_event_significance(
                     ifo, data_readers[ifo], bank, template_id, coinc_times)
             if snr_series is not None:
                 out[ifo] = {'snr_series': snr_series}
                 self.combine_far_with_followup(ifos[0], ifo, triggers,
-                                               snr_series, ptime, pvalue)
+                                               snr_series, ptime, pvalue,
+                                               sigma2)
 
         return out
 
-    def combine_far_with_followup(self, coinc_ifo, ifo, triggers, snr_series, ptime, pvalue):
+    def combine_far_with_followup(self, coinc_ifo, ifo, triggers, snr_series,
+                                  ptime, pvalue, sigma2):
         # Calculate new ifar
         triggers['foreground/ifar'] = combine_ifar_pvalue(triggers['foreground/ifar'],
                                                           pvalue, self.pvalue_livetime)
 
-        # Copy the triggers
-        for key in triggers.copy():
+        # Copy the common fields from the other detector
+        # ignore fields that contain detector-specific data
+        fields_to_ignore = set(['end_time', 'snr', 'stat', 'coa_phase',
+                                'chisq', 'chisq_dof', 'sg_chisq', 'sigmasq'])
+        for key in set(triggers):
             if 'foreground/{}/'.format(coinc_ifo) in key:
                 _, _, name = key.split('/')
+                if name in fields_to_ignore:
+                    continue
                 triggers['foreground/{}/{}'.format(ifo, name)] = triggers[key]
 
-        # Set the critical stats manually
+        # Set the detector-specific fields for which we have data
         snr_series_peak = snr_series.at_time(ptime, nearest_sample=True)
-        triggers['foreground/{}/end_time'.format(ifo)] = float(ptime)
-        triggers['foreground/{}/snr'.format(ifo)] = abs(snr_series_peak)
-        triggers['foreground/{}/stat'.format(ifo)] = triggers['foreground/{}/snr'.format(ifo)]
-        triggers['foreground/{}/coa_phase'.format(ifo)] = numpy.angle(snr_series_peak)
-        triggers['foreground/{}/chisq'.format(ifo)] = None
-        triggers['foreground/{}/chisq_dof'.format(ifo)] = None
+        base = 'foreground/{}/'.format(ifo)
+        triggers[base + 'end_time'] = float(ptime)
+        triggers[base + 'snr'] = triggers[base + 'stat'] = abs(snr_series_peak)
+        triggers[base + 'coa_phase'] = numpy.angle(snr_series_peak)
+        triggers[base + 'sigmasq'] = sigma2
 
     def check_coincs(self, ifos, coinc_results, psds, f_low,
                      data_readers, bank):

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -160,8 +160,8 @@ class LiveEventManager(object):
         triggers['foreground/{}/snr'.format(ifo)] = abs(snr_series_peak)
         triggers['foreground/{}/stat'.format(ifo)] = triggers['foreground/{}/snr'.format(ifo)]
         triggers['foreground/{}/coa_phase'.format(ifo)] = numpy.angle(snr_series_peak)
-        triggers['foreground/{}/chisq'.format(ifo)] = 0
-        triggers['foreground/{}/chisq_dof'.format(ifo)] = 0
+        triggers['foreground/{}/chisq'.format(ifo)] = None
+        triggers['foreground/{}/chisq_dof'.format(ifo)] = None
 
     def check_coincs(self, ifos, coinc_results, psds, f_low,
                      data_readers, bank):

--- a/pycbc/filter/matchedfilter.py
+++ b/pycbc/filter/matchedfilter.py
@@ -1784,8 +1784,8 @@ def followup_event_significance(ifo, data_reader, bank,
     htilde = bank.get_template(template_id, min_buffer=bdur)
     stilde = data_reader.overwhitened_data(htilde.delta_f)
 
-    sigmasq = htilde.sigmasq(stilde.psd)
-    snr, _, norm = matched_filter_core(htilde, stilde, h_norm=sigmasq)
+    sigma2 = htilde.sigmasq(stilde.psd)
+    snr, _, norm = matched_filter_core(htilde, stilde, h_norm=sigma2)
 
     # Find peak in on-source and determine p-value
     onsrc = snr.time_slice(onsource_start, onsource_end)
@@ -1809,7 +1809,7 @@ def followup_event_significance(ifo, data_reader, bank,
     logging.info('Adding %s to candidate, pvalue %s, %s samples', ifo,
                  pvalue, nsamples)
 
-    return baysnr * norm, peak_time, pvalue, sigmasq
+    return baysnr * norm, peak_time, pvalue, sigma2
 
 def compute_followup_snr_series(data_reader, htilde, trig_time,
                                 duration=0.095, check_state=True,

--- a/pycbc/filter/matchedfilter.py
+++ b/pycbc/filter/matchedfilter.py
@@ -1784,8 +1784,8 @@ def followup_event_significance(ifo, data_reader, bank,
     htilde = bank.get_template(template_id, min_buffer=bdur)
     stilde = data_reader.overwhitened_data(htilde.delta_f)
 
-    snr, _, norm = matched_filter_core(htilde, stilde,
-                                          h_norm=htilde.sigmasq(stilde.psd))
+    sigmasq = htilde.sigmasq(stilde.psd)
+    snr, _, norm = matched_filter_core(htilde, stilde, h_norm=sigmasq)
 
     # Find peak in on-source and determine p-value
     onsrc = snr.time_slice(onsource_start, onsource_end)
@@ -1809,7 +1809,7 @@ def followup_event_significance(ifo, data_reader, bank,
     logging.info('Adding %s to candidate, pvalue %s, %s samples', ifo,
                  pvalue, nsamples)
 
-    return baysnr * norm, peak_time, pvalue
+    return baysnr * norm, peak_time, pvalue, sigmasq
 
 def compute_followup_snr_series(data_reader, htilde, trig_time,
                                 duration=0.095, check_state=True,


### PR DESCRIPTION
People suggested that we rather not populate the χ² fields of the LIGOLW uploads for the followup detectors, rather than setting them to zero. I think this is reasonable and should have no side effects.

I also spotted and fixed an incorrect behavior: some detector-dependent trigger fields (namely `sg_chisq` and `sigmasq`) were being copied from one of the above-threshold detectors into the fields of followup detectors. I think the only important side effect was that the effective distance of the followup detectors in GraceDB was incorrect. I now take the correct `sigmasq` from the SNR series calculation.