### PR TITLE
Some more Cython functionality

### DIFF
--- a/pycbc/events/eventmgr.py
+++ b/pycbc/events/eventmgr.py
@@ -28,12 +28,13 @@ from __future__ import absolute_import
 import numpy, copy, os.path
 import logging
 
-from pycbc import WEAVE_FLAGS
 from pycbc.types import Array
 from pycbc.scheme import schemed
 from pycbc.detector import Detector
 
 from . import coinc, ranking
+
+from .eventmgr_cython import findchirp_cluster_over_window_cython
 
 @schemed("pycbc.events.threshold_")
 def threshold(series, value):
@@ -140,31 +141,14 @@ def findchirp_cluster_over_window(times, values, window_length):
     """
     assert window_length > 0, 'Clustering window length is not positive'
 
-    from weave import inline
-    indices = numpy.zeros(len(times), dtype=int)
-    tlen = len(times) # pylint:disable=unused-variable
-    k = numpy.zeros(1, dtype=int)
-    absvalues = abs(values) # pylint:disable=unused-variable
-    times = times.astype(int)
-    code = """
-        int j = 0;
-        int curr_ind = 0;
-        for (int i=0; i < tlen; i++){
-            if ((times[i] - times[curr_ind]) > window_length){
-                j += 1;
-                indices[j] = i;
-                curr_ind = i;
-            }
-            else if (absvalues[i] > absvalues[curr_ind]){
-                indices[j] = i;
-                curr_ind = i;
-            }
-        }
-        k[0] = j;
-    """
-    inline(code, ['times', 'absvalues', 'window_length', 'indices', 'tlen', 'k'],
-           extra_compile_args=[WEAVE_FLAGS])
-    return indices[0:k[0]+1]
+    indices = numpy.zeros(len(times), dtype=numpy.int32)
+    tlen = len(times)
+    absvalues = numpy.array(abs(values), copy=False)
+    times = numpy.array(times, dtype=numpy.int32, copy=False)
+    k = findchirp_cluster_over_window_cython(times, absvalues, window_length,
+                                             indices, tlen)
+
+    return indices[0:k+1]
 
 
 def cluster_reduce(idx, snr, window_size):

--- a/pycbc/events/eventmgr_cython.pyx
+++ b/pycbc/events/eventmgr_cython.pyx
@@ -1,0 +1,32 @@
+%%cython -a
+
+import numpy
+cimport numpy
+from cython import wraparound, boundscheck, cdivision
+
+
+ctypedef fused REALTYPE:
+    float
+    double
+
+
+@boundscheck(False)
+@wraparound(False)
+@cdivision(True)
+def findchirp_cluster_over_window_cython\
+        (numpy.ndarray[numpy.int32_t, ndim=1] times,
+         numpy.ndarray[REALTYPE, ndim=1] absvalues, int window_length,
+         numpy.ndarray[numpy.int32_t, ndim=1] indices, int tlen):
+    cdef int j = 0
+    cdef int curr_ind = 0
+    cdef int i
+    
+    for i in range(tlen):
+        if ((times[i] - times[curr_ind]) > window_length):
+            j += 1
+            indices[j] = i
+            curr_ind = i
+        elif (absvalues[i] > absvalues[curr_ind]):
+            indices[j] = i
+            curr_ind = i
+    return j

--- a/pycbc/events/eventmgr_cython.pyx
+++ b/pycbc/events/eventmgr_cython.pyx
@@ -1,5 +1,3 @@
-%%cython -a
-
 import numpy
 cimport numpy
 from cython import wraparound, boundscheck, cdivision

--- a/pycbc/events/threshold_cpu.py
+++ b/pycbc/events/threshold_cpu.py
@@ -28,6 +28,7 @@ from pycbc.weave import inline
 from .simd_threshold import thresh_cluster_support, default_segsize
 from .eventmgr import _BaseThresholdCluster
 from pycbc.opt import omp_libs, omp_flags
+from scipy.signal import find_peaks
 from six import PY3
 
 def threshold_numpy(series, value):
@@ -93,6 +94,7 @@ def threshold_inline(series, value):
     else:
         return numpy.array([], numpy.uint32), numpy.array([], numpy.float32)
 
+
 if PY3:
     threshold = threshold_numpy
 else:
@@ -112,7 +114,7 @@ class CPUThresholdCluster(_BaseThresholdCluster):
               """
         self.support = thresh_cluster_support
 
-    def threshold_and_cluster_weave(self, threshold, window):
+    def threshold_and_cluster_weave(self, threshold, window): # pylint:disable=unused-variable
         series = self.series # pylint:disable=unused-variable
         slen = self.slen # pylint:disable=unused-variable
         values = self.outv
@@ -138,9 +140,9 @@ class CPUThresholdCluster(_BaseThresholdCluster):
         # (e.g. in Cython) if needed
         thresh = threshold*threshold
         abs2_series = self.series.real**2 + self.series.imag**2
-        locs, retdict = find_peaks(abs2_series, height=thresh, distance=window)
+        locs, _ = find_peaks(abs2_series, height=thresh, distance=window)
         return self.series[locs], locs
-        
+
 
 def _threshold_cluster_factory(series):
     return CPUThresholdCluster

--- a/pycbc/fft/fftw_pruned.py
+++ b/pycbc/fft/fftw_pruned.py
@@ -13,7 +13,6 @@ twiddle factors.
 """
 from __future__ import absolute_import
 import numpy, ctypes, pycbc.types
-from pycbc import WEAVE_FLAGS
 from pycbc.libutils import get_ctypes_library
 import logging
 from .fftw_pruned_cython import second_phase_cython, fast_second_phase_cython
@@ -26,7 +25,7 @@ warn_msg = ("The FFTW_pruned module can be used to speed up computing SNR "
             "This code would need verification before trusting results. "
             "Please do contribute test cases.")
 
-logging.warn(warn_msg)
+logging.warning(warn_msg)
 
 # FFTW constants
 FFTW_FORWARD = -1

--- a/pycbc/fft/fftw_pruned.py
+++ b/pycbc/fft/fftw_pruned.py
@@ -160,46 +160,13 @@ def second_phase(invec, indices, N1, N2):
     """
     invec = numpy.array(invec.data, copy=False)
     NI = len(indices) # pylint:disable=unused-variable
-    N1=int(N1)
-    N2=int(N2)
+    N1 = int(N1)
+    N2 = int(N2)
     out = numpy.zeros(len(indices), dtype=numpy.complex64)
-    indices=numpy.array(indices, dtype=numpy.uint32)
-
-    second_phase_cython(N1, N2, NI, indices, out, invec)
-
-    return out
-
-def fast_second_phase(invec, indices, N1, N2):
-    """
-    This is the second phase of the FFT decomposition that actually performs
-    the pruning. It is an explicit calculation for the subset of points. Note
-    that there seem to be some numerical accumulation issues at various values
-    of N1 and N2.
-
-    Parameters
-    ----------
-    invec :
-        The result of the first phase FFT
-    indices : array of ints
-        The index locations to calculate the FFT
-    N1 : int
-        The length of the second phase "FFT"
-    N2 : int
-        The length of the first phase FFT
-
-    Returns
-    -------
-    out : array of floats
-    """
-    invec = numpy.array(invec.data, copy=False)
-    NI = len(indices) # pylint:disable=unused-variable
-    N1=int(N1)
-    N2=int(N2)
-    out = numpy.zeros(len(indices), dtype=numpy.complex64)
-    indices=numpy.array(indices, dtype=numpy.uint32)
+    indices = numpy.array(indices, dtype=numpy.uint32)
 
     # Note, the next step if this needs to be faster is to invert the loops
-    fast_second_phase_cython(N1, N2, NI, indices, out, invec)
+    second_phase_cython(N1, N2, NI, indices, out, invec)
 
     return out
 
@@ -226,24 +193,6 @@ def fft_transpose_fftw(vec):
         _thetransposeplan = plan_transpose(N1, N2)
     ftexecute(_thetransposeplan, vec.ptr, outvec.ptr)
     return  outvec
-
-def fft_transpose_numpy(vec):
-    """
-    Perform a numpy transpose from vec into outvec.
-    (Alex to provide more details in a write-up.)
-
-    Parameters
-    -----------
-    vec : array
-        Input array.
-
-    Returns
-    --------
-    outvec : array
-        Transposed output array.
-    """
-    N1, N2 = splay(vec)
-    return pycbc.types.Array(vec.data.copy().reshape(N2, N1).transpose().reshape(len(vec)).copy())
 
 fft_transpose = fft_transpose_fftw
 
@@ -284,5 +233,5 @@ def pruned_c2cifft(invec, outvec, indices, pretransposed=False):
     if not pretransposed:
         invec = fft_transpose(invec)
     first_phase(invec, outvec, N1=N1, N2=N2)
-    out = fast_second_phase(outvec, indices, N1=N1, N2=N2)
+    out = second_phase(outvec, indices, N1=N1, N2=N2)
     return out

--- a/pycbc/fft/fftw_pruned.py
+++ b/pycbc/fft/fftw_pruned.py
@@ -15,7 +15,7 @@ from __future__ import absolute_import
 import numpy, ctypes, pycbc.types
 from pycbc.libutils import get_ctypes_library
 import logging
-from .fftw_pruned_cython import second_phase_cython, fast_second_phase_cython
+from .fftw_pruned_cython import second_phase_cython
 
 warn_msg = ("The FFTW_pruned module can be used to speed up computing SNR "
             "timeseries by computing first at a low sample rate and then "

--- a/pycbc/fft/fftw_pruned_cython.pyx
+++ b/pycbc/fft/fftw_pruned_cython.pyx
@@ -1,5 +1,3 @@
-%%cython -a
-
 import numpy
 cimport numpy
 #from libc.stdlib cimport malloc, free

--- a/pycbc/fft/fftw_pruned_cython.pyx
+++ b/pycbc/fft/fftw_pruned_cython.pyx
@@ -14,33 +14,7 @@ ctypedef fused COMPLEXTYPE:
 @boundscheck(False)
 @wraparound(False)
 @cdivision(True)
-def second_phase_cython(int N1, int N2, int NI, numpy.ndarray[numpy.uint32_t, ndim=1] indices,
-                        numpy.ndarray[numpy.complex64_t, ndim=1] out,
-                        numpy.ndarray[COMPLEXTYPE, ndim=1] invec):
-    cdef float pi = 3.14159265359
-    cdef int N = N1 * N2
-    cdef numpy.uint32_t k, n1, k2
-    cdef float phase_inc, sp, sc, n1f, curr_angle
-    cdef COMPLEXTYPE val
-    for i in range(NI):
-        val = 0 + 0j
-        k = indices[i]
-        k2 = k % N2
-        phase_inc = (2 * pi * k) / <float> N
-        for n1 in range(N1):
-            n1f = <float> n1
-            # NOTE: Previously this used sincosf, which doesn't seem to be present in Cython
-            curr_angle = phase_inc * n1
-            sp = sin(curr_angle)
-            cp = cos(curr_angle)
-            val += (cp + sp * 1j) * invec[k2 + N2*n1]  
-        out[i] = val
-
-
-@boundscheck(False)
-@wraparound(False)
-@cdivision(True)
-def fast_second_phase_cython(int N1, int N2, int NI,
+def second_phase_cython(int N1, int N2, int NI,
                              numpy.ndarray[numpy.uint32_t, ndim=1] indices,
                              numpy.ndarray[numpy.complex64_t, ndim=1] out,
                              numpy.ndarray[COMPLEXTYPE, ndim=1] invec):

--- a/pycbc/fft/fftw_pruned_cython.pyx
+++ b/pycbc/fft/fftw_pruned_cython.pyx
@@ -1,0 +1,67 @@
+%%cython -a
+
+import numpy
+cimport numpy
+#from libc.stdlib cimport malloc, free
+#from libc.complex cimport creal, cimag
+from libc.math cimport sin, cos # This imports c's sin and cos function from the math library
+from cython import wraparound, boundscheck, cdivision
+
+ctypedef fused COMPLEXTYPE:
+    float complex
+    double complex
+
+@boundscheck(False)
+@wraparound(False)
+@cdivision(True)
+def second_phase_cython(int N1, int N2, int NI, numpy.ndarray[numpy.uint32_t, ndim=1] indices,
+                        numpy.ndarray[numpy.complex64_t, ndim=1] out,
+                        numpy.ndarray[COMPLEXTYPE, ndim=1] invec):
+    cdef float pi = 3.14159265359
+    cdef int N = N1 * N2
+    cdef numpy.uint32_t k, n1, k2
+    cdef float phase_inc, sp, sc, n1f, curr_angle
+    cdef COMPLEXTYPE val
+    for i in range(NI):
+        val = 0 + 0j
+        k = indices[i]
+        k2 = k % N2
+        phase_inc = (2 * pi * k) / <float> N
+        for n1 in range(N1):
+            n1f = <float> n1
+            # NOTE: Previously this used sincosf, which doesn't seem to be present in Cython
+            curr_angle = phase_inc * n1
+            sp = sin(curr_angle)
+            cp = cos(curr_angle)
+            val += (cp + sp * 1j) * invec[k2 + N2*n1]  
+        out[i] = val
+
+
+@boundscheck(False)
+@wraparound(False)
+@cdivision(True)
+def fast_second_phase_cython(int N1, int N2, int NI,
+                             numpy.ndarray[numpy.uint32_t, ndim=1] indices,
+                             numpy.ndarray[numpy.complex64_t, ndim=1] out,
+                             numpy.ndarray[COMPLEXTYPE, ndim=1] invec):
+    cdef float pi = 3.14159265359
+    cdef int N = N1 * N2
+    cdef float sp, cp, phase_inc, n1f
+    cdef numpy.uint32_t k, k2, n1
+    cdef COMPLEXTYPE val, twiddle_inc, twiddle
+    
+    for i in range(NI):
+        val = 0 + 0j
+        k = indices[i]
+        k2 = k % N2
+        phase_inc = (2 * pi * k) / <float> N
+        sp = sin(phase_inc)
+        cp = cos(phase_inc)
+        twiddle_inc = cp + cp * 1j
+        twiddle = 1 + 0j
+        
+        for n1 in range(N1):
+            n1f = <float> n1
+            val += twiddle * invec[k2 + N2*n1]
+            twiddle *= twiddle_inc
+        out[i] = val

--- a/pycbc/filter/matchedfilter.py
+++ b/pycbc/filter/matchedfilter.py
@@ -510,7 +510,7 @@ def compute_max_snr_over_sky_loc_stat(hplus, hcross, hphccorr,
         The SNR maximized over sky location
     """
     # NOTE: Not much optimization has been done here! This may need to be
-    # C-ified using scipy.weave.
+    # Cythonized.
 
     if out is None:
         out = zeros(len(hplus))

--- a/setup.py
+++ b/setup.py
@@ -217,8 +217,8 @@ for name in cythonext:
     ext.append(e)
 
 # Not all modules work like this:
-e = Extension("pycbc.filter.fftw_pruned_cython",
-              ["pycbc/filter/fftw_pruned_cython.pyx"],
+e = Extension("pycbc.fft.fftw_pruned_cython",
+              ["pycbc/fft/fftw_pruned_cython.pyx"],
               extra_compile_args=['-O3', '-w', '-msse4.2',
                                   '-ffast-math', '-ffinite-math-only'],
               compiler_directives={'embedsignature': True})

--- a/setup.py
+++ b/setup.py
@@ -216,6 +216,14 @@ for name in cythonext:
                   compiler_directives={'embedsignature': True})
     ext.append(e)
 
+# Not all modules work like this:
+e = Extension("pycbc.filter.fftw_pruned_cython",
+              ["pycbc/filter/fftw_pruned_cython.pyx",
+              extra_compile_args=['-O3', '-w', '-msse4.2',
+                                  '-ffast-math', '-ffinite-math-only'],
+              compiler_directives={'embedsignature': True})
+ext.append(e)
+
 setup (
     name = 'PyCBC',
     version = VERSION,

--- a/setup.py
+++ b/setup.py
@@ -223,6 +223,13 @@ e = Extension("pycbc.filter.fftw_pruned_cython",
                                   '-ffast-math', '-ffinite-math-only'],
               compiler_directives={'embedsignature': True})
 ext.append(e)
+e = Extension("pycbc.events.eventmgr_cython",
+              ["pycbc/events/eventmgr_cython.pyx",
+              extra_compile_args=['-O3', '-w', '-msse4.2',
+                                  '-ffast-math', '-ffinite-math-only'],
+              compiler_directives={'embedsignature': True})
+ext.append(e)
+
 
 setup (
     name = 'PyCBC',

--- a/setup.py
+++ b/setup.py
@@ -218,13 +218,13 @@ for name in cythonext:
 
 # Not all modules work like this:
 e = Extension("pycbc.filter.fftw_pruned_cython",
-              ["pycbc/filter/fftw_pruned_cython.pyx",
+              ["pycbc/filter/fftw_pruned_cython.pyx"],
               extra_compile_args=['-O3', '-w', '-msse4.2',
                                   '-ffast-math', '-ffinite-math-only'],
               compiler_directives={'embedsignature': True})
 ext.append(e)
 e = Extension("pycbc.events.eventmgr_cython",
-              ["pycbc/events/eventmgr_cython.pyx",
+              ["pycbc/events/eventmgr_cython.pyx"],
               extra_compile_args=['-O3', '-w', '-msse4.2',
                                   '-ffast-math', '-ffinite-math-only'],
               compiler_directives={'embedsignature': True})


### PR DESCRIPTION
I wanted to try to see if I could push towards a working python3 implementation of `pycbc_inspiral`.  The following places still use weave:

```
 * pycbc/waveform/decompress_cpu.py
 * pycbc/filter/simd_correlate.py
 * pycbc/fft/fftw_pruned.py
 * pycbc/events/eventmgr.py
 * pycbc/events/threshold_cpu.py
 * pycbc/events/simd_threshold.py
```

Decompress_cpu isn't [currently] used, so I left that one for now. Implementations of fftw_pruned (even though that also isn't really used) and eventmgr are included here. But then I hit the simd codes. These are quite detailed and appear to be highly optimized. I'm not sure what to do at this point. How do we port these codes out of weave?