### PR TITLE
Ringdown module improvements

### DIFF
--- a/pycbc/waveform/ringdown.py
+++ b/pycbc/waveform/ringdown.py
@@ -87,12 +87,12 @@ def format_lmns(lmns):
 
     # Case 2: a list with only one string with a list (with or without comma),
     # ["221' '331"] or ["221', '331"]
-    elif (len(lmns)==1 and isinstance(lmns[0], (str, unicode)) 
+    elif (len(lmns) == 1 and isinstance(lmns[0], (str, unicode))
           and len(lmns[0]) > 3):
         try:
             # It could be a single mode list with an extra space, ['221 ']
             lmns = [str(int(lmn)) for lmn in lmns]
-        except:
+        except ValueError:
             delimiter = ',' if bool(re.search(',', lmns[0])) else ' '
             lmns = lmns[0].split(delimiter)
 

--- a/pycbc/waveform/ringdown.py
+++ b/pycbc/waveform/ringdown.py
@@ -75,8 +75,6 @@ def format_lmns(lmns):
     will return the appropriate list of strings. If a different format is
     given, raise an error.
     """
-#    if len(str(lmns[0])) == 3:
-#        lmns = [str(lmn) for lmn in lmns]
 
     # Case 1: the list is in a string (with or without comma),
     # "[221, 331]" or "[221 331]"

--- a/pycbc/waveform/ringdown.py
+++ b/pycbc/waveform/ringdown.py
@@ -25,7 +25,7 @@
 """Generate ringdown templates in the time and frequency domain.
 """
 
-import numpy, lal
+import numpy, lal, re
 import lalsimulation as lalsim
 from pycbc.types import TimeSeries, FrequencySeries, float64, complex128, zeros
 from pycbc.waveform.waveform import get_obj_attrs
@@ -37,7 +37,7 @@ lm_required_args = ['freqs','taus','l','m','nmodes']
 mass_spin_required_args = ['final_mass','final_spin', 'lmns', 'inclination']
 freqtau_required_args = ['lmns']
 
-max_freq = 16384.
+max_freq = 16384/2.
 min_dt = 1. / (2 * max_freq)
 pi = numpy.pi
 two_pi = 2 * numpy.pi
@@ -64,6 +64,33 @@ def props(obj, required, **kwargs):
             raise ValueError('Please provide ' + str(arg))
 
     return input_params
+
+def format_lmns(lmns):
+    """ Checks if the format of the parameter lmns is correct, returning the
+    appropriate format if not
+    """
+    # Case 0: the lmns is in the right format, return
+    if len(lmns[0]) == 3:
+        return lmns
+    
+    # Case 1: the list is in a string with or without comma,
+    # "[221, 331]" or "[221 331]"
+    elif lmns[0]=='[' and lmns[-1]==']':
+        lmns = lmns.strip('[]')
+
+    # Case 2: a list with only one string with or without comma,
+    # ["221' '331"] or ["221', '331"]
+    elif len(lmns[0]) > 3:
+        lmns = lmns[0]
+    
+    # Check if there is a comma or not
+    if bool(re.search(',', lmns)):
+        lmns = lmns.split(',')
+    else:
+        lmns = lmns.split()
+
+    # There may still be extra spaces or quotes, loop over items
+    return [lmns[n].strip().strip('\'') for n in range(len(lmns))]
 
 def lm_amps_phases(**kwargs):
     """ Take input_params and return dictionaries with amplitudes and phases
@@ -292,6 +319,58 @@ def taper_shift(waveform, output):
 ######################################################
 #### Basic functions to generate damped sinusoid
 ######################################################
+
+def td_damped_sinusoid(f_0, tau, amp, phi, inclination=None, l=2, m=2,
+                       delta_t=None, t_final=None, taper=None)
+    """Return a time domain damped sinusoid (plus and cross polarizations).
+    If taper, will add a tapering at the beginning of the waveform with
+    duration taper * tau
+    """
+
+    if not delta_t:
+        delta_t = 1. / qnm_freq_decay(f_0, tau, 1./1000)
+        if delta_t < min_dt:
+            delta_t = min_dt
+    if not t_final:
+        t_final = qnm_time_decay(tau, 1./1000)
+    kmax = int(t_final / delta_t) + 1
+    times = numpy.arange(kmax) * delta_t
+
+    if inclination is not None:
+        Y_plus, Y_cross = spher_harms(l, m, inclination)
+    else:
+        Y_plus, Y_cross = 1, 1
+
+    hplus = amp * Y_plus * numpy.exp(-times/tau) * \
+                                numpy.cos(two_pi*f_0*times + phi)
+    hcross = amp * Y_cross * numpy.exp(-times/tau) * \
+                                numpy.sin(two_pi*f_0*times + phi)
+
+    if taper and delta_t < taper*tau:
+        taper_window = int(taper*tau/delta_t)
+        kmax += taper_window
+
+    outplus = TimeSeries(zeros(kmax), delta_t=delta_t)
+    outcross = TimeSeries(zeros(kmax), delta_t=delta_t)
+
+    # If size of tapering window is less than delta_t, do not apply taper.
+    if not taper or delta_t > taper*tau:
+        outplus.data[:kmax] = hplus
+        outcross.data[:kmax] = hcross
+
+        return outplus, outcross
+
+    else:
+        taper_hp, taper_hc = apply_taper(delta_t, taper, f_0, tau, amp,
+                                         phi, l, m, inclination)
+        start = - taper * tau
+        outplus.data[:taper_window] = taper_hp
+        outplus.data[taper_window:] = hplus
+        outcross.data[:taper_window] = taper_hc
+        outcross.data[taper_window:] = hcross
+        outplus._epoch, outcross._epoch = start, start
+
+        return outplus, outcross
 
 def get_td_qnm(template=None, taper=None, **kwargs):
     """Return a time domain damped sinusoid.
@@ -763,7 +842,7 @@ def get_td_from_final_mass_spin(template=None, taper=None,
     # Get required args
     final_mass = input_params['final_mass']
     final_spin = input_params['final_spin']
-    lmns = input_params['lmns']
+    lmns = format_lmns(input_params['lmns'])
     for lmn in lmns:
         if int(lmn[2]) == 0:
             raise ValueError('Number of overtones (nmodes) must be greater '
@@ -867,7 +946,7 @@ def get_fd_from_final_mass_spin(template=None, distance=None, **kwargs):
     # Get required args
     final_mass = input_params['final_mass']
     final_spin = input_params['final_spin']
-    lmns = input_params['lmns']
+    lmns = format_lmns(input_params['lmns'])
     for lmn in lmns:
         if int(lmn[2]) == 0:
             raise ValueError('Number of overtones (nmodes) must be greater '
@@ -960,12 +1039,12 @@ def get_td_from_freqtau(template=None, taper=None, **kwargs):
     input_params = props(template, freqtau_required_args, **kwargs)
 
     # Get required args
-    f_0, tau = lm_freqs_taus(**input_params)
-    lmns = input_params['lmns']
+    lmns = format_lmns(input_params['lmns'])
     for lmn in lmns:
         if int(lmn[2]) == 0:
             raise ValueError('Number of overtones (nmodes) must be greater '
                              'than zero.')
+    f_0, tau = lm_freqs_taus(**input_params)
     # following may not be in input_params
     inc = input_params.pop('inclination', None)
     delta_t = input_params.pop('delta_t', None)
@@ -1056,12 +1135,12 @@ def get_fd_from_freqtau(template=None, **kwargs):
     input_params = props(template, freqtau_required_args, **kwargs)
 
     # Get required args
-    f_0, tau = lm_freqs_taus(**input_params)
-    lmns = input_params['lmns']
+    lmns = format_lmns(input_params['lmns'])
     for lmn in lmns:
         if int(lmn[2]) == 0:
             raise ValueError('Number of overtones (nmodes) must be greater '
                              'than zero.')
+    f_0, tau = lm_freqs_taus(**input_params)
     # The following may not be in input_params
     inc = input_params.pop('inclination', None)
     delta_f = input_params.pop('delta_f', None)

--- a/pycbc/waveform/ringdown.py
+++ b/pycbc/waveform/ringdown.py
@@ -161,7 +161,7 @@ def qnm_time_decay(tau, decay):
 
     Parameters
     ----------
-    tau : float
+    tau: float
         The damping time of the sinusoid.
     decay: float
         The fraction of the peak amplitude.
@@ -181,9 +181,9 @@ def qnm_freq_decay(f_0, tau, decay):
 
     Parameters
     ----------
-    f_0 : float
+    f_0: float
         The ringdown-frequency, which gives the peak amplitude.
-    tau : float
+    tau: float
         The damping time of the sinusoid.
     decay: float
         The fraction of the peak amplitude.
@@ -519,37 +519,37 @@ def get_td_from_final_mass_spin(template=None, **kwargs):
         waveform to avoid the abrupt turn on of the ringdown.
         Each mode and overtone will have a different taper depending on its tau,
         the final taper being the superposition of all the tapers.
-    distance : {None, float}, optional
+    distance: {None, float}, optional
         Luminosity distance of the system. If specified, the returned ringdown
         will include the Kerr factor (final_mass/distance).
-    final_mass : float
+    final_mass: float
         Mass of the final black hole in solar masses.
-    final_spin : float
+    final_spin: float
         Dimensionless spin of the final black hole.
-    lmns : list
+    lmns: list
         Desired lmn modes as strings (lm modes available: 22, 21, 33, 44, 55).
         The n specifies the number of overtones desired for the corresponding
         lm pair (maximum n=8).
         Example: lmns = ['223','331'] are the modes 220, 221, 222, and 330
-    amp220 : float
-        Amplitude of the fundamental 220 mode. Note that if distance is given,
+    amp220: float
+        Amplitude of the fundamental 220 mode.  Always required, even if 220
+        mode has not been selected. Note that if distance is given,
         this parameter will have a completely different order of magnitude.
         See table II in https://arxiv.org/abs/1107.0854 for an estimate.
-        Always required, even if 220 mode has not been selected.
-    amplmn : float
+    amplmn: float
         Fraction of the amplitude of the lmn overtone relative to the
         fundamental mode, i.e. amplmn/amp220. Provide as many as the number
         of selected subdominant modes.
-    philmn : float
+    philmn: float
         Phase of the lmn overtone, as many as the number of modes. Should also
         include the information from the azimuthal angle, philmn=(phi + m*Phi).
-    inclination : float
+    inclination: float
         Inclination of the system in radians (for the spherical harmonics).
-    delta_t : {None, float}, optional
+    delta_t: {None, float}, optional
         The time step used to generate the ringdown.
         If None, it will be set to the inverse of the frequency at which the
         amplitude is 1/1000 of the peak amplitude (the minimum of all modes).
-    t_final : {None, float}, optional
+    t_final: {None, float}, optional
         The ending time of the output frequency series.
         If None, it will be set to the time at which the amplitude
         is 1/1000 of the peak amplitude (the maximum of all modes).
@@ -571,49 +571,49 @@ def get_fd_from_final_mass_spin(template=None, **kwargs):
     """Return frequency domain ringdown with all the modes specified.
     Parameters
     ----------
-    template : object
+    template: object
         An object that has attached properties. This can be used to substitute
         for keyword arguments. A common example would be a row in an xml table.
-    distance : {None, float}, optional
+    distance: {None, float}, optional
         Luminosity distance of the system. If specified, the returned ringdown
         will include the Kerr factor (final_mass/distance).
-    final_mass : float
+    final_mass: float
         Mass of the final black hole in solar masses.
-    final_spin : float
+    final_spin: float
         Dimensionless spin of the final black hole.
-    lmns : list
+    lmns: list
         Desired lmn modes as strings (lm modes available: 22, 21, 33, 44, 55).
         The n specifies the number of overtones desired for the corresponding
         lm pair (maximum n=8).
         Example: lmns = ['223','331'] are the modes 220, 221, 222, and 330
-    amp220 : float
-        Amplitude of the fundamental 220 mode. Always required, even if 220
+    amp220: float
+        Amplitude of the fundamental 220 mode.  Always required, even if 220
         mode has not been selected. Note that if distance is given,
         this parameter will have a completely different order of magnitude.
         See table II in https://arxiv.org/abs/1107.0854 for an estimate.
-    amplmn : float
+    amplmn: float
         Fraction of the amplitude of the lmn overtone relative to the
         fundamental mode, i.e. amplmn/amp220. Provide as many as the number
         of selected subdominant modes.
-    philmn : float
+    philmn: float
         Phase of the lmn overtone, as many as the number of modes. Should also
         include the information from the azimuthal angle, philmn=(phi + m*Phi).
-    inclination : float
+    inclination: float
         Inclination of the system in radians (for the spherical harmonics).
-    delta_f : {None, float}, optional
+    delta_f: {None, float}, optional
         The frequency step used to generate the ringdown.
         If None, it will be set to the inverse of the time at which the
         amplitude is 1/1000 of the peak amplitude (the minimum of all modes).
     f_lower: {None, float}, optional
         The starting frequency of the output frequency series.
         If None, it will be set to delta_f.
-    f_final : {None, float}, optional
+    f_final: {None, float}, optional
         The ending frequency of the output frequency series.
         If None, it will be set to the frequency at which the amplitude
         is 1/1000 of the peak amplitude (the maximum of all modes).
     Returns
     -------
-    hplustilde: FrequencySeries
+    hplustile: FrequencySeries
         The plus phase of a ringdown with the lm modes specified and
         n overtones in frequency domain.
     hcrosstilde: FrequencySeries
@@ -638,7 +638,7 @@ def get_td_from_freqtau(template=None, **kwargs):
         waveform to avoid the abrupt turn on of the ringdown.
         Each mode and overtone will have a different taper depending on its tau,
         the final taper being the superposition of all the tapers.
-    lmns : list
+    lmns: list
         Desired lmn modes as strings (lm modes available: 22, 21, 33, 44, 55).
         The n specifies the number of overtones desired for the corresponding
         lm pair (maximum n=8).
@@ -647,26 +647,26 @@ def get_td_from_freqtau(template=None, **kwargs):
         Central frequency of the lmn overtone, as many as number of modes.
     tau_lmn: float
         Damping time of the lmn overtone, as many as number of modes.
-    amp220 : float
+    amp220: float
         Amplitude of the fundamental 220 mode. Note that if distance is given,
         this parameter will have a completely different order of magnitude.
         See table II in https://arxiv.org/abs/1107.0854 for an estimate.
         Always required, even if 220 mode has not been selected.
-    amplmn : float
+    amplmn: float
         Fraction of the amplitude of the lmn overtone relative to the
         fundamental mode, i.e. amplmn/amp220. Provide as many as the number
         of selected subdominant modes.
-    philmn : float
+    philmn: float
         Phase of the lmn overtone, as many as the number of modes. Should also
         include the information from the azimuthal angle, philmn=(phi + m*Phi).
-    inclination : float
+    inclination: float
         Inclination of the system in radians (for the spherical harmonics).
         If None, the spherical harmonics will be set to 1.
-    delta_t : {None, float}, optional
+    delta_t: {None, float}, optional
         The time step used to generate the ringdown.
         If None, it will be set to the inverse of the frequency at which the
         amplitude is 1/1000 of the peak amplitude (the minimum of all modes).
-    t_final : {None, float}, optional
+    t_final: {None, float}, optional
         The ending time of the output frequency series.
         If None, it will be set to the time at which the amplitude
         is 1/1000 of the peak amplitude (the maximum of all modes).
@@ -693,7 +693,7 @@ def get_fd_from_freqtau(template=None, **kwargs):
     template: object
         An object that has attached properties. This can be used to substitute
         for keyword arguments. A common example would be a row in an xml table.
-    lmns : list
+    lmns: list
         Desired lmn modes as strings (lm modes available: 22, 21, 33, 44, 55).
         The n specifies the number of overtones desired for the corresponding
         lm pair (maximum n=8).
@@ -702,27 +702,27 @@ def get_fd_from_freqtau(template=None, **kwargs):
         Central frequency of the lmn overtone, as many as number of modes.
     tau_lmn: float
         Damping time of the lmn overtone, as many as number of modes.
-    amp220 : float
+    amp220: float
         Amplitude of the fundamental 220 mode. Always required, even if 220
         mode has not been selected.
-    amplmn : float
+    amplmn: float
         Fraction of the amplitude of the lmn overtone relative to the
         fundamental mode, i.e. amplmn/amp220. Provide as many as the number
         of selected subdominant modes.
-    philmn : float
+    philmn: float
         Phase of the lmn overtone, as many as the number of modes. Should also
         include the information from the azimuthal angle (phi + m*Phi).
-    inclination : {None, float}, optional
+    inclination: {None, float}, optional
         Inclination of the system in radians. If None, the spherical harmonics
         will be set to 1.
-    delta_f : {None, float}, optional
+    delta_f: {None, float}, optional
         The frequency step used to generate the ringdown.
         If None, it will be set to the inverse of the time at which the
         amplitude is 1/1000 of the peak amplitude (the minimum of all modes).
     f_lower: {None, float}, optional
         The starting frequency of the output frequency series.
         If None, it will be set to delta_f.
-    f_final : {None, float}, optional
+    f_final: {None, float}, optional
         The ending frequency of the output frequency series.
         If None, it will be set to the frequency at which the amplitude
         is 1/1000 of the peak amplitude (the maximum of all modes).

--- a/pycbc/waveform/ringdown.py
+++ b/pycbc/waveform/ringdown.py
@@ -105,7 +105,7 @@ def lm_amps_phases(**kwargs):
     """ Take input_params and return dictionaries with amplitudes and phases
     of each overtone of a specific lm mode, checking that all of them are given.
     """
-    lmns = kwargs['lmns']
+    lmns = format_lmns(kwargs['lmns'])
     amps, phis = {}, {}
     # amp220 is always required, because the amplitudes of subdominant modes
     # are given as fractions of amp220.

--- a/pycbc/waveform/ringdown.py
+++ b/pycbc/waveform/ringdown.py
@@ -571,7 +571,7 @@ def get_fd_from_final_mass_spin(template=None, **kwargs):
     """Return frequency domain ringdown with all the modes specified.
     Parameters
     ----------
-    template: object
+    template : object
         An object that has attached properties. This can be used to substitute
         for keyword arguments. A common example would be a row in an xml table.
     distance : {None, float}, optional
@@ -587,10 +587,10 @@ def get_fd_from_final_mass_spin(template=None, **kwargs):
         lm pair (maximum n=8).
         Example: lmns = ['223','331'] are the modes 220, 221, 222, and 330
     amp220 : float
-        Amplitude of the fundamental 220 mode. Note that if distance is given,
+        Amplitude of the fundamental 220 mode. Always required, even if 220
+        mode has not been selected. Note that if distance is given,
         this parameter will have a completely different order of magnitude.
         See table II in https://arxiv.org/abs/1107.0854 for an estimate.
-        Always required, even if 220 mode has not been selected.
     amplmn : float
         Fraction of the amplitude of the lmn overtone relative to the
         fundamental mode, i.e. amplmn/amp220. Provide as many as the number

--- a/pycbc/waveform/ringdown.py
+++ b/pycbc/waveform/ringdown.py
@@ -76,28 +76,17 @@ def format_lmns(lmns):
     given, raise an error.
     """
 
-    # Case 1: the list is in a string (with or without comma),
-    # "[221, 331]" or "[221 331]"
+    # Case 1: the list is in a string "[221, 331]"
     if isinstance(lmns, (str, unicode)):
         # strip off brackets
         lmns = lmns.strip('[]')
         # convert to list
-        delimiter = ',' if bool(re.search(',', lmns)) else ' '
-        lmns = lmns.split(delimiter)
+        lmns = lmns.split(',')
 
-    # Case 2: a list with only one string with a list (with or without comma),
-    # ["221' '331"] or ["221', '331"]
+    # Case 2: a list with only one string with a list ["221', '331"]
     elif (len(lmns) == 1 and isinstance(lmns[0], (str, unicode))
           and len(lmns[0]) > 3):
-        try:
-            # It could be a single mode list with an extra space, ['221 ']
-            lmns = [str(int(lmn)) for lmn in lmns]
-        except ValueError:
-            delimiter = ',' if bool(re.search(',', lmns[0])) else ' '
-            lmns = lmns[0].split(delimiter)
-
-    # Remove any extra spaces or quotes
-    lmns = [lmn.strip().strip('\'') for lmn in lmns]
+        lmns = lmns[0].split(',')
 
     out = []
     # Cycle over the lmns to ensure that we get back a list of strings that
@@ -151,20 +140,21 @@ def lm_freqs_taus(**kwargs):
     times of each overtone of a specific lm mode, checking that all of them
     are given.
     """
-    lmns = kwargs['lmns']
+    lmns = format_lmns(kwargs['lmns'])
     freqs, taus = {}, {}
 
     for lmn in lmns:
-        l, m, nmodes = int(lmn[0]), int(lmn[1]), int(lmn[2])
+        lm, nmodes = lmn[0:-1], int(lmn[2])
         for n in range(nmodes):
+            mode = lm + '{}'.format(n)
             try:
-                freqs['%d%d%d' %(l,m,n)] = kwargs['f_%d%d%d' %(l,m,n)]
+                freqs[mode] = kwargs['f_' + mode]
             except KeyError:
-                raise ValueError('f_%d%d%d is required' %(l,m,n))
+                raise ValueError('f_{} is required'.format(mode))
             try:
-                taus['%d%d%d' %(l,m,n)] = kwargs['tau_%d%d%d' %(l,m,n)]
+                taus[mode] = kwargs['tau_' + mode]
             except KeyError:
-                raise ValueError('tau_%d%d%d is required' %(l,m,n))
+                raise ValueError('tau_{} is required'.format(mode))
 
     return freqs, taus
 

--- a/pycbc/waveform/ringdown.py
+++ b/pycbc/waveform/ringdown.py
@@ -464,11 +464,11 @@ def multimode_base(input_params):
     """Return a superposition of damped sinusoids in either time or frequency
     domains with parameters set by input_params.
     """
-    lmns = format_lmns(input_params['lmns'])
+    input_params['lmns'] = format_lmns(input_params['lmns'])
     amps, phis = lm_amps_phases(**input_params)
     if 'final_mass' in input_params.keys():
         freqs, taus = get_lm_f0tau_allmodes(input_params['final_mass'],
-                        input_params['final_spin'], lmns)
+                        input_params['final_spin'], input_params['lmns'])
         norm = Kerr_factor(input_params['final_mass'],
             input_params['distance']) if 'distance' in input_params.keys() \
             else 1.

--- a/pycbc/waveform/ringdown.py
+++ b/pycbc/waveform/ringdown.py
@@ -75,43 +75,47 @@ def format_lmns(lmns):
     will return the appropriate list of strings. If a different format is
     given, raise an error.
     """
-    # Case 0: the lmns is in the right format (a list of strings) or a list
-    # of ints
-    if len(str(lmns[0])) == 3:
-        lmns = [str(lmn) for lmn in lmns]
+#    if len(str(lmns[0])) == 3:
+#        lmns = [str(lmn) for lmn in lmns]
 
-    else:
-        # Case 1: the list is in a string with or without comma,
-        # "[221, 331]" or "[221 331]"
-        if lmns[0] == '[' and lmns[-1] == ']':
-            lmns = lmns.strip('[]')
+    # Case 1: the list is in a string (with or without comma),
+    # "[221, 331]" or "[221 331]"
+    if isinstance(lmns, (str, unicode)):
+        # strip off brackets
+        lmns = lmns.strip('[]')
+        # convert to list
+        delimiter = ',' if bool(re.search(',', lmns)) else ' '
+        lmns = lmns.split(delimiter)
 
-        # Case 2: a list with only one string with or without comma,
-        # ["221' '331"] or ["221', '331"]
-        elif len(lmns[0]) > 3:
-            lmns = lmns[0]
+    # Case 2: a list with only one string with a list (with or without comma),
+    # ["221' '331"] or ["221', '331"]
+    elif (len(lmns)==1 and isinstance(lmns[0], (str, unicode)) 
+          and len(lmns[0]) > 3):
+        try:
+            # It could be a single mode list with an extra space, ['221 ']
+            lmns = [str(int(lmn)) for lmn in lmns]
+        except:
+            delimiter = ',' if bool(re.search(',', lmns[0])) else ' '
+            lmns = lmns[0].split(delimiter)
 
-        # Case 3: none of the above
-        else:
+    # Remove any extra spaces or quotes
+    lmns = [lmn.strip().strip('\'') for lmn in lmns]
+
+    out = []
+    # Cycle over the lmns to ensure that we get back a list of strings that
+    # are three digits long, and that nmodes!=0
+    for lmn in lmns:
+        # Try to convert to int and then str, to ensure the right format
+        lmn = str(int(lmn))
+        if len(lmn) != 3:
             raise ValueError('Format of parameter lmns not recognized. See '
                              'approximant documentation for more info.')
-
-        # Check if there is a comma or not
-        if bool(re.search(',', lmns)):
-            lmns = lmns.split(',')
-        else:
-            lmns = lmns.split()
-
-        # There may still be extra spaces or quotes, loop over items
-        lmns = [lmns[n].strip().strip('\'') for n in range(len(lmns))]
-
-    # Check that nmodes != 0
-    for lmn in lmns:
-        if int(lmn[2]) == 0:
+        elif int(lmn[2]) == 0:
             raise ValueError('Number of overtones (nmodes) must be greater '
-                             'than zero.')
+                             'than zero in lmn={}.'.format(lmn))
+        out.append(lmn)
 
-    return lmns
+    return out
 
 def lm_amps_phases(**kwargs):
     """ Take input_params and return dictionaries with amplitudes and phases


### PR DESCRIPTION
The ringdown module has become a bit messy: two functions (time and freq domain) to create a single damped sinusoid, two functions to create the superposition of damped sinusoids with same l, m (i.e. add overtones), and two functions to create the superposition of different l, m modes with their overtones. In essence, all the functions are repeating the same lines over and over (getting the input parameters, making the output vector, etc.) and calling the previous functions. Also, the only difference between the mass-spin and the freq-tau approximants is the input parameters they take, but there are different functions for each approximant that again repeat the same lines.
Furthermore, the tapering option is not even working!

This PR tries to simplify all of this. I have create functions that generate the output vector of the appropriate length, functions that only generate the damped sinusoid, and then a `multimode_base` function that generates the corresponding superposition of modes for any approximant. Then, all the approximant functions have only two lines: one for getting the different input parameters, and one calling the multimode_base function with these parameters.
Furthermore, I have fixed the tapering option (and slightly tweaked the tapering function used).
Some plots to show the results (using the generator module) are here:
https://www.atlas.aei.uni-hannover.de/~miriam.cabero/plots/ringdown_dev/
The "compare_approximants_*" plots check that the mass-spin and freq-tau approximants return the same ringdown, and that the "master" result is the same as the "dev" result (compare between plots).
The "compare_taper_*" plot only has the "dev" option, because the tapering is broken in master (as mentioned above). 