### PR TITLE
Bug in pycbc_page_coincinfo for 2-ifo workflow

### DIFF
--- a/bin/minifollowups/pycbc_page_coincinfo
+++ b/bin/minifollowups/pycbc_page_coincinfo
@@ -62,7 +62,7 @@ else:
     raise ValueError()
 
 # Check if using input files from old (2-ifo) coinc code
-if 'time1' in f.attrs:
+if 'detector_1' in f.attrs:
     # make a table for the coincident information #################################
     headers = ["Coincident ranking statistic",
                "Inclusive IFAR (yr)",
@@ -102,7 +102,7 @@ html = pycbc.results.dq.redirect_javascript + \
 # make a table for the single detector information ############################
 idx = {}
 # Check if using input files from old (2-ifo) coinc code
-if 'time1' in f.attrs:
+if 'detector_1' in f.attrs:
     # 2 detector version
     ifo1, ifo2 = f.attrs['detector_1'], f.attrs['detector_2']
     idx = {ifo1:d['trigger_id1'][n], ifo2:d['trigger_id2'][n]}


### PR DESCRIPTION
'time1' is not an attribute of the statmap file so this path failed in the 2-ifo workflow. 