### PR TITLE
fix mistake in pr2499 which broken injection matching

### DIFF
--- a/bin/hdfcoinc/pycbc_coinc_hdfinjfind
+++ b/bin/hdfcoinc/pycbc_coinc_hdfinjfind
@@ -33,6 +33,7 @@ def keep_ind(times, start, end):
     time_sorting = times.argsort()
     times = times[time_sorting]
     indices = numpy.array([], dtype=numpy.uint32)
+    left = numpy.searchsorted(times, start, side='left')
     right = numpy.searchsorted(times, end, side='right')
 
     for li, ri in zip(left, right):
@@ -105,7 +106,7 @@ for trigger_file, injection_file in zip(args.trigger_files,
              ifo_times += (f['foreground/%s/time' % ifo][:],)
              time_dict[ifo] = f['foreground/%s/time' % ifo][:]
              trig_dict[ifo] = f['foreground/%s/trigger_id' % ifo][:]
-        time = numpy.array([events.mean_if_greater_than_zero(vals)[0] 
+        time = numpy.array([events.mean_if_greater_than_zero(vals)[0]
                                                    for vals in zip(*ifo_times)])
         # We will discard injections which cannot be associated with a
         # coincident event, thus combine segments over all combinations

--- a/bin/hdfcoinc/pycbc_coinc_hdfinjfind
+++ b/bin/hdfcoinc/pycbc_coinc_hdfinjfind
@@ -33,10 +33,10 @@ def keep_ind(times, start, end):
     time_sorting = times.argsort()
     times = times[time_sorting]
     indices = numpy.array([], dtype=numpy.uint32)
-    left = numpy.searchsorted(times, start, side='left')
-    right = numpy.searchsorted(times, end, side='right')
+    leftidx = numpy.searchsorted(times, start, side='left')
+    rightidx = numpy.searchsorted(times, end, side='right')
 
-    for li, ri in zip(left, right):
+    for li, ri in zip(leftidx, rightidx):
         seg_indices = numpy.arange(li, ri, 1).astype(numpy.uint32)
         indices=numpy.union1d(seg_indices, indices)
     return time_sorting[indices]


### PR DESCRIPTION
It looks like PR#2499 accidentally removed a critical line. This is causing injections to be counted as missed when in actuality they are not recoverable at all due to being in times you aren't analyzing. 

https://github.com/gwastro/pycbc/commit/426cae0cc9546cb16e2e98f0532a8178405c3e21#diff-83b130558a65c4e4349ba945877e1758