### PR TITLE
Optimize SNR time series in PyCBC Live

### DIFF
--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -15,6 +15,7 @@ from time import time
 import os.path
 import itertools
 import platform
+import subprocess
 from mpi4py import MPI as mpi
 from pycbc.pool import BroadcastPool
 from pycbc import fft, version, waveform, scheme, makedir

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -228,6 +228,7 @@ class LiveEventManager(object):
                     coinc_results['foreground/{}/template_id'.format(ifos[0])]
                 p = props(bank.table[template_id])
                 apr = p.pop('approximant')
+                min_buffer = bank.minimum_buffer + 0.5
                 buff_size = \
                     pycbc.waveform.get_waveform_filter_length_in_time(apr, **p)
 

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -250,7 +250,7 @@ class LiveEventManager(object):
                     * bank.sample_rate)
                 flen = int(tlen / 2 + 1)
                 delta_f = bank.sample_rate / float(tlen)
-                cmd = 'timeout 150 '
+                cmd = 'timeout 400 '
                 exepath = distutils.spawn.find_executable('pycbc_optimize_snr')
                 cmd += exepath + ' '
                 data_fils_str = '--data-files '

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -239,15 +239,15 @@ class LiveEventManager(object):
                 for ifo in ifos:
                     curr_fname = \
                         fname.replace('.xml.gz',
-                                      '{}_data_overwhitened.hdf'.format(ifo))
+                                      '_{}_data_overwhitened.hdf'.format(ifo))
                     curr_data = data_readers[ifo].overwhitened_data(delta_f)
                     curr_data.save(curr_fname)
                     curr_fname = fname.replace('.xml.gz', 
-                                               '{}_psd.hdf'.format(ifo))
+                                               '_{}_psd.hdf'.format(ifo))
                     curr_psd = curr_data.psd
                     curr_psd.save(curr_fname)
 
-                curr_fname = fname.replace('.xml.gz', 'attributes.hdf')
+                curr_fname = fname.replace('.xml.gz', '_attributes.hdf')
                 hdfp = h5py.File(curr_fname, 'w')
                 for ifo in coinc_ifos:
                     curr_time = \
@@ -265,6 +265,7 @@ class LiveEventManager(object):
                 hdfp['mass2'] = bank.table[template_id].mass2
                 hdfp['spin1z'] = bank.table[template_id].spin1z
                 hdfp['spin2z'] = bank.table[template_id].spin2z
+                hdfp['ifar'] = ifar
 
 
     def check_singles(self, results, data_reader, psds, f_low):

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -225,7 +225,7 @@ class LiveEventManager(object):
 
             if self.store_data_and_psds:
                 template_id = \
-                    triggers['foreground/{}/template_id'.format(ifos[0])]
+                    coinc_results['foreground/{}/template_id'.format(ifos[0])]
                 p = props(bank.table[template_id])
                 apr = p.pop('approximant')
                 buff_size = \

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -293,7 +293,8 @@ class LiveEventManager(object):
                 hdfp['ifar'] = ifar
                 hdfp['gid'] = gid
                 for ifo in args.channel_name:
-                    hdfp['channel_names'][ifo] = args.channel_name[ifo]
+                    hdfp['channel_names/{}'.format(ifo)] = \
+                        args.channel_name[ifo]
 
                 cmd += '--params-file {} '.format(curr_fname)
                 cmd += '--approximant IMRPhenomD '

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -237,7 +237,7 @@ class LiveEventManager(object):
                     * bank.sample_rate)
                 flen = int(tlen / 2 + 1)
                 delta_f = bank.sample_rate / float(tlen)
-                cmd = 'timeout 150 `which pycbc_optimize_snr` '
+                cmd = 'timeout 150 /virtualenvs/pycbc_multiifo_online/bin/pycbc_optimize_snr '
                 data_fils_str = '--data-files '
                 psd_fils_str = '--psd-files '
                 for ifo in ifos:

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -223,6 +223,10 @@ class LiveEventManager(object):
                 event.save(fname)
 
             if self.store_data_and_psds:
+                tlen = bank.round_up((buff_size + min_buffer) \
+                    * bank.sample_rate)
+                flen = int(tlen / 2 + 1)
+                delta_f = bank.sample_rate / float(tlen)
                 for ifo in ifos:
                     curr_fname = \
                         fname.replace('.xml.gz',
@@ -240,10 +244,6 @@ class LiveEventManager(object):
                     curr_time = \
                         coinc_results['foreground/{}/end_time'.format(ifo)]
                     hdfp['coinc_times/{}'.format(ifo)] = curr_time
-                tlen = bank.round_up((buff_size + min_buffer) \
-                    * bank.sample_rate)
-                flen = int(tlen / 2 + 1)
-                delta_f = bank.sample_rate / float(tlen)
                 f_end = bank.end_frequency(template_id)
                 if f_end is None or f_end >= (flen * delta_f):
                     f_end = (flen-1) * delta_f

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -17,6 +17,8 @@ import itertools
 import platform
 import distutils
 import subprocess
+import random
+import string
 from mpi4py import MPI as mpi
 from pycbc.pool import BroadcastPool
 from pycbc import fft, version, waveform, scheme, makedir
@@ -52,6 +54,13 @@ def combine_ifar_pvalue(ifar, pvalue, livetime):
     nifar = 1. / ptof(pnew, livetime)
     # take max of original IFAR and combined IFAR & apply trials factor
     return numpy.maximum(ifar, nifar) / 2.
+
+# https://pynative.com/python-generate-random-string/
+def random_string(stringLength=10):
+    """Generate a random string of fixed length """
+    letters = string.ascii_lowercase
+    return ''.join(random.choice(letters) for i in range(stringLength))
+
 
 class LiveEventManager(object):
     def __init__(self, output_path,
@@ -212,10 +221,13 @@ class LiveEventManager(object):
                                           low_frequency_cutoff=f_low,
                                           channel_names=args.channel_name)
 
-            end_time = int(coinc_results['foreground/%s/end_time' % coinc_ifos[0]])
-            fname = os.path.join(self.path, 'coinc-%s.xml.gz' % end_time)
+            end_time = int(coinc_results['foreground/%s/end_time'
+                                         % coinc_ifos[0]])
+            fname = 'coinc-{}-{}.xml.gz'.format(end_time, random_string(6))
+            fname = os.path.join(self.path, fname)
             logging.info('Coincident candidate! Saving as %s', fname)
-            comments = ['using ranking statistic: %s' % args.background_statistic]
+            comments = ['using ranking statistic: %s' 
+                        % args.background_statistic]
 
             ifar = coinc_results['foreground/ifar']
             if self.enable_gracedb_upload and self.ifar_upload_threshold < ifar:

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -28,6 +28,7 @@ from pycbc.events.single import LiveSingleFarThreshold
 from pycbc.io.live import SingleCoincForGraceDB
 import pycbc.waveform.bank
 from pycbc.vetoes.sgchisq import SingleDetSGChisq
+from pycbc.waveform.waveform import props
 
 
 def ptof(p, ft):

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -281,6 +281,10 @@ class LiveEventManager(object):
                 cmd += '--params-file {} '.format(curr_fname)
                 cmd += '--approximant IMRPhenomD '
                 cmd += '--verbose '
+                log_fname = \
+                        fname.replace('.xml.gz', '_optimize_snr_log.dat')
+
+                cmd += '&> {} '.format(log_fname)
                 logging.info('Running {}.'.format(cmd))
                 subprocess.Popen(cmd, shell=True)
 

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -237,7 +237,7 @@ class LiveEventManager(object):
                     * bank.sample_rate)
                 flen = int(tlen / 2 + 1)
                 delta_f = bank.sample_rate / float(tlen)
-                cmd = 'timeout 150 pycbc_optimize_snr '
+                cmd = 'timeout 150 `which pycbc_optimize_snr` '
                 data_fils_str = '--data-files '
                 psd_fils_str = '--psd-files '
                 for ifo in ifos:

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -223,6 +223,11 @@ class LiveEventManager(object):
                 event.save(fname)
 
             if self.store_data_and_psds:
+                p = props(bank.table[template_id])
+                apr = p.pop('approximant')
+                buff_size = \
+                    pycbc.waveform.get_waveform_filter_length_in_time(apr, **p)
+
                 tlen = bank.round_up((buff_size + min_buffer) \
                     * bank.sample_rate)
                 flen = int(tlen / 2 + 1)

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -224,6 +224,8 @@ class LiveEventManager(object):
                 event.save(fname)
 
             if self.store_data_and_psds:
+                template_id = \
+                    triggers['foreground/{}/template_id'.format(ifos[0])]
                 p = props(bank.table[template_id])
                 apr = p.pop('approximant')
                 buff_size = \
@@ -257,8 +259,6 @@ class LiveEventManager(object):
                 hdfp['delta_f'] = delta_f
                 hdfp['f_end'] = f_end
                 hdfp['sample_rate'] = bank.sample_Rate
-                template_id = \
-                    triggers['foreground/{}/template_id'.format(ifos[0])]
                 hdfp['flow'] = bank.table[template_id].f_lower
                 hdfp['mass1'] = bank.table[template_id].mass1
                 hdfp['mass2'] = bank.table[template_id].mass2

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -259,7 +259,7 @@ class LiveEventManager(object):
                 hdfp['flen'] = flen
                 hdfp['delta_f'] = delta_f
                 hdfp['f_end'] = f_end
-                hdfp['sample_rate'] = bank.sample_Rate
+                hdfp['sample_rate'] = bank.sample_rate
                 hdfp['flow'] = bank.table[template_id].f_lower
                 hdfp['mass1'] = bank.table[template_id].mass1
                 hdfp['mass2'] = bank.table[template_id].mass2

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -277,7 +277,8 @@ class LiveEventManager(object):
 
                 cmd += '--params_file {} '.format(curr_fname)
                 cmd += '--approximant IMRPhenomD '
-                print cmd
+                cmd += '--verbose '
+                logging.info('Running {}.'.format(cmd))
                 subprocess.Popen([cmd])
 
 

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -288,8 +288,12 @@ class LiveEventManager(object):
                 hdfp['mass2'] = bank.table[template_id].mass2
                 hdfp['spin1z'] = bank.table[template_id].spin1z
                 hdfp['spin2z'] = bank.table[template_id].spin2z
+                hdfp['template_duration'] = \
+                    bank.table[template_id].template_duration
                 hdfp['ifar'] = ifar
                 hdfp['gid'] = gid
+                for ifo in args.channel_name:
+                    hdfp['channel_names'][ifo] = args.channel_name[ifo]
 
                 cmd += '--params-file {} '.format(curr_fname)
                 cmd += '--approximant IMRPhenomD '

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -297,13 +297,16 @@ class LiveEventManager(object):
                         args.channel_name[ifo]
 
                 cmd += '--params-file {} '.format(curr_fname)
-                cmd += '--approximant IMRPhenomD '
+                cmd += '--approximant {} '.format(apr)
+                cmd += '--gracedb-server {} '.format(args.gracedb_server)
+                if not self.gracedb_testing:
+                    cmd += '--production '
                 cmd += '--verbose '
                 log_fname = \
                         fname.replace('.xml.gz', '_optimize_snr_log.dat')
 
                 cmd += '&> {} '.format(log_fname)
-                logging.info('Running {}.'.format(cmd))
+                logging.info('Running %s', cmd)
                 subprocess.Popen(cmd, shell=True)
 
 

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -11,16 +11,18 @@ See https://arxiv.org/abs/1805.11174 for an overview."""
 
 import sys
 import argparse, numpy, pycbc, logging, cProfile, h5py, lal, json
+import random
 from time import time
+import types
 import os.path
 import itertools
 import platform
 from mpi4py import MPI as mpi
 from pycbc.pool import BroadcastPool
 from pycbc import fft, version, waveform, scheme, makedir
-from pycbc.types import MultiDetOptionAction
+from pycbc.types import MultiDetOptionAction, zeros
 from pycbc.filter import LiveBatchMatchedFilter, compute_followup_snr_series
-from pycbc.filter import followup_event_significance
+from pycbc.filter import followup_event_significance, matched_filter_core
 from pycbc.strain import StrainBuffer
 from pycbc.events.ranking import newsnr
 from pycbc.events.coinc import LiveCoincTimeslideBackgroundEstimator as Coincer
@@ -28,6 +30,29 @@ from pycbc.events.single import LiveSingleFarThreshold
 from pycbc.io.live import SingleCoincForGraceDB
 import pycbc.waveform.bank
 from pycbc.vetoes.sgchisq import SingleDetSGChisq
+from pycbc import DYN_RANGE_FAC
+from pycbc.conversions import mchirp_from_mass1_mass2, eta_from_mass1_mass2
+from pycbc.conversions import mtotal_from_mchirp_eta, mass1_from_mtotal_eta
+from pycbc.conversions import mass2_from_mtotal_eta
+
+import cProfile
+def profile(filename=None, comm=mpi.COMM_WORLD):
+  def prof_decorator(f):
+    def wrap_f(*args, **kwargs):
+      pr = cProfile.Profile()
+      pr.enable()
+      result = f(*args, **kwargs)
+      pr.disable()
+
+      if filename is None:
+        pr.print_stats()
+      else:
+        filename_r = filename + ".{}".format(comm.rank)
+        pr.dump_stats(filename_r)
+
+      return result
+    return wrap_f
+  return prof_decorator
 
 
 def ptof(p, ft):
@@ -49,6 +74,53 @@ def combine_ifar_pvalue(ifar, pvalue, livetime):
     nifar = 1. / ptof(pnew, livetime)
     # take max of original IFAR and combined IFAR & apply trials factor
     return numpy.maximum(ifar, nifar) / 2.
+
+# Define the function for computing network snr
+def compute_network_snr(v, *argv):
+    data = argv[0]
+    coinc_times = argv[1]
+    ifos = argv[2]
+    flen = argv[3]
+    approximant = argv[4]
+    flow = argv[5]
+    f_end = argv[6]
+    delta_f = argv[7]
+    sample_rate = argv[8]
+    min_f_lower = argv[9]
+    extra_args = argv[10]
+    distance = 1.0 / DYN_RANGE_FAC
+    mtotal = mtotal_from_mchirp_eta(v[0], v[1])
+    mass1 = mass1_from_mtotal_eta(mtotal, v[1])
+    mass2 = mass2_from_mtotal_eta(mtotal, v[1])
+
+    htilde = pycbc.waveform.get_waveform_filter\
+        (zeros(flen, dtype=numpy.complex64),
+         approximant=approximant,
+         mass1=mass1, mass2=mass2, spin1z=v[2], spin2z=v[3],
+         f_lower=flow, f_final=f_end, delta_f=delta_f,
+         delta_t=1.0/sample_rate, distance=distance,
+         **extra_args)
+    htilde.sigmasq = types.MethodType(pycbc.waveform.bank.sigma_cached,
+                                      htilde)
+    htilde.approximant = approximant
+    htilde.min_f_lower = min_f_lower
+    htilde.end_frequency = f_end
+    htilde.f_lower = flow
+    network_snrsq = 0
+    for ifo in ifos:
+        sigmasq = htilde.sigmasq(data[ifo].psd)
+        snr, _, norm = matched_filter_core(htilde, data[ifo],
+                                           h_norm=sigmasq)
+        duration = 0.095
+        half_dur_samples = int(snr.sample_rate * duration / 2)
+        onsource_idx = float(coinc_times[ifo] - snr.start_time) * snr.sample_rate
+        onsource_idx = int(round(onsource_idx))
+        onsource_slice = slice(onsource_idx - half_dur_samples,
+                               onsource_idx + half_dur_samples + 1)
+        snr_series = snr[onsource_slice] * norm
+        network_snrsq += max(abs(snr_series._data))**2
+    return - (network_snrsq**0.5)
+
 
 class LiveEventManager(object):
     def __init__(self, output_path,
@@ -109,7 +181,7 @@ class LiveEventManager(object):
             raise RuntimeError("Not root process")
 
     def compute_followup_data(self, ifos, triggers, data_readers, bank,
-                              followup_ifos=None):
+                              followup_ifos=None, override_htilde=None):
         """Figure out which of the followup detectors are usable, and compute
         SNR time series for all the available detectors.
         """
@@ -117,7 +189,10 @@ class LiveEventManager(object):
         followup_ifos = [] if followup_ifos is None else followup_ifos
 
         template_id = triggers['foreground/' + ifos[0] + '/template_id']
-        htilde = bank[template_id]
+        if override_htilde is not None:
+            htilde = override_htilde
+        else:
+            htilde = bank[template_id]
 
         coinc_times = {ifo: triggers['foreground/' + ifo + '/end_time'] for ifo in ifos}
 
@@ -170,6 +245,79 @@ class LiveEventManager(object):
         triggers[base + 'coa_phase'] = numpy.angle(snr_series_peak)
         triggers[base + 'sigmasq'] = sigma2
 
+
+    def optimize_snr_timeseries(self, ifos, triggers, data_readers, bank,
+                                followup_ifos=None):
+        from scipy.optimize import differential_evolution, minimize
+        from pycbc.waveform.waveform import props
+
+        coinc_times = {ifo: triggers['foreground/' + ifo + '/end_time'] for ifo in ifos}
+
+        # Define properties for template generation
+        template_id = triggers['foreground/' + ifos[0] + '/template_id']	
+        approximant = 'IMRPhenomD'
+        f_end = bank.end_frequency(template_id)
+        flow = bank.table[template_id].f_lower
+        min_buffer = bank.minimum_buffer + 0.5
+        p = props(bank.table[template_id])
+        p.pop('approximant')
+        buff_size = \
+            pycbc.waveform.get_waveform_filter_length_in_time(approximant, **p)
+        tlen = bank.round_up((buff_size + min_buffer) * bank.sample_rate)
+        flen = int(tlen / 2 + 1)
+        delta_f = bank.sample_rate / float(tlen)
+        if f_end is None or f_end >= (flen * delta_f):
+            f_end = (flen-1) * delta_f
+
+        data = {ifo: data_readers[ifo].overwhitened_data(delta_f) 
+                for ifo in ifos}
+        
+        trig_mchirp = mchirp_from_mass1_mass2(bank.table[template_id].mass1,
+                                              bank.table[template_id].mass2)
+        trig_eta = eta_from_mass1_mass2(bank.table[template_id].mass1,
+                                        bank.table[template_id].mass2)
+        bounds = [(trig_mchirp*0.9, trig_mchirp*1.1),
+                  (0.01, 0.2499), (-0.9, 0.9), (-0.9, 0.9)]
+        # Might be nice to use chi_eff and chi_a, but then boundaries become
+        # highly non-trivial
+        trig_spin1z = bank.table[template_id].spin1z
+        trig_spin2z = bank.table[template_id].spin2z
+
+        extra_args = (data, coinc_times, ifos, flen,
+                      approximant, flow, f_end, delta_f, bank.sample_rate,
+                      bank.min_f_lower, bank.extra_args)
+
+        results = differential_evolution(compute_network_snr, bounds,
+                                         maxiter=100, seed=1, workers=-1,
+                                         popsize=200, mutation=(1.,1),
+                                         recombination=0.25,
+                                         updating='deferred',
+                                         args=extra_args)
+
+        optimized_vals = results.x
+        mtotal = mtotal_from_mchirp_eta(optimized_vals[0], optimized_vals[1])
+        opt_mass1 = mass1_from_mtotal_eta(mtotal, optimized_vals[1])
+        opt_mass2 = mass2_from_mtotal_eta(mtotal, optimized_vals[1])
+        opt_spin1z = optimized_vals[2]
+        opt_spin2z = optimized_vals[3]
+        opt_htilde = pycbc.waveform.get_waveform_filter\
+            (zeros(flen, dtype=numpy.complex64),
+             approximant=approximant,
+             mass1=opt_mass1, mass2=opt_mass2, spin1z=opt_spin1z,
+             spin2z=opt_spin2z,
+             f_lower=flow, f_final=f_end, delta_f=delta_f,
+             delta_t=1.0/bank.sample_rate, distance=1.0 / DYN_RANGE_FAC,
+             **bank.extra_args)
+        opt_htilde.sigmasq = types.MethodType(pycbc.waveform.bank.sigma_cached,
+                                              opt_htilde)
+        opt_htilde.approximant = approximant
+        opt_htilde.min_f_lower = bank.min_f_lower
+        opt_htilde.end_frequency = f_end
+        opt_htilde.f_lower = flow
+
+        return [opt_mass1, opt_mass2, opt_spin1z, opt_spin2z], opt_htilde
+
+
     def check_coincs(self, ifos, coinc_results, psds, f_low,
                      data_readers, bank):
         """ Perform any followup and save zerolag triggers to a coinc xml file
@@ -212,6 +360,66 @@ class LiveEventManager(object):
             comments = ['using ranking statistic: %s' % args.background_statistic]
 
             ifar = coinc_results['foreground/ifar']
+            if self.enable_gracedb_upload and self.ifar_upload_threshold < ifar:
+                event.upload(fname, gracedb_server=args.gracedb_server,
+                             testing=self.gracedb_testing,
+                             extra_strings=comments)
+            else:
+                event.save(fname)
+
+            new_vals, opt_htilde = \
+                self.optimize_snr_timeseries(coinc_ifos, coinc_results,
+                                             data_readers, bank, followup_ifos)
+
+            fud = self.compute_followup_data(coinc_ifos, coinc_results,
+                                             data_readers, bank, followup_ifos,
+                                             override_htilde=opt_htilde)
+
+            # Now we can override the SNRs and masses
+            network_snrsq = 0.
+            for ifo in coinc_ifos:
+                fppref = 'foreground/{}/'.format(ifo)
+                coinc_results[fppref+'mass1'] = new_vals[0]
+                coinc_results[fppref+'mass2'] = new_vals[1]
+                coinc_results[fppref+'spin1z'] = new_vals[2]
+                coinc_results[fppref+'spin2z'] = new_vals[3]
+                coinc_results[fppref+'approximant'] = 'IMRPhenomD'
+                snrtseries = fud[ifo]['snr_series']
+                maxidx = numpy.argmax(abs(snrtseries))
+                # Subsample interpolation of SNR peak
+                # Following sbank here
+                maxsnrsq = abs(snrtseries[maxidx])**2
+                maxsnrpsq = abs(snrtseries[maxidx+1])**2
+                maxsnrmsq = abs(snrtseries[maxidx-1])**2
+                dy = 0.5 * (maxsnrpsq - maxsnrmsq)
+                d2y = 2. * maxsnrsq - maxsnrmsq - maxsnrpsq
+                maxsnrsq = maxsnrsq + 0.5*dy*dy/d2y
+                maxsnr = maxsnrsq**0.5
+                maxtime = snrtseries.sample_times[maxidx]
+                maxtime += 0.5 * snrtseries.delta_t * (maxsnrmsq - maxsnrpsq) /\
+                    (maxsnrmsq + maxsnrpsq - 2 * maxsnrsq)
+                # Do I need to interpolate this?
+                maxsnrphase = numpy.angle(snrtseries[maxidx])
+                network_snrsq += maxsnr**2
+                coinc_results[fppref+'snr'] = maxsnr
+                coinc_results[fppref+'end_time'] = maxtime
+                coinc_results[fppref+'stat'] = maxsnr
+                coinc_results[fppref+'chisq'] = 0.
+                coinc_results[fppref+'chisq_dof'] = 0
+                coinc_results[fppref+'sg_chisq'] = 0.
+                coinc_results[fppref+'coa_phase'] = maxsnrphase
+
+            coinc_results['foreground/stat'] = numpy.array([network_snrsq**0.5])
+
+            event = SingleCoincForGraceDB(live_ifos, coinc_results, bank=bank,
+                                          psds=psds, followup_data=fud,
+                                          low_frequency_cutoff=f_low,
+                                          channel_names=args.channel_name)
+
+            fname = os.path.join(self.path, 'coinc_opt-%s.xml.gz' % end_time)
+            logging.info('Optimized SNR! Saving as %s', fname)
+            comments.append('Optimized SNR time series over masses/spins')
+
             if self.enable_gracedb_upload and self.ifar_upload_threshold < ifar:
                 event.upload(fname, gracedb_server=args.gracedb_server,
                              testing=self.gracedb_testing,

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -236,16 +236,23 @@ class LiveEventManager(object):
                     * bank.sample_rate)
                 flen = int(tlen / 2 + 1)
                 delta_f = bank.sample_rate / float(tlen)
+                cmd = 'timeout 150 pycbc_optimize_snr '
+                data_fils_str = '--data-files '
+                psd_fils_str = '--psd-files '
                 for ifo in ifos:
                     curr_fname = \
                         fname.replace('.xml.gz',
                                       '_{}_data_overwhitened.hdf'.format(ifo))
                     curr_data = data_readers[ifo].overwhitened_data(delta_f)
                     curr_data.save(curr_fname)
+                    data_fils_str += '{}:{} ' .format(ifo, curr_fname)
                     curr_fname = fname.replace('.xml.gz', 
                                                '_{}_psd.hdf'.format(ifo))
                     curr_psd = curr_data.psd
                     curr_psd.save(curr_fname)
+                    psd_fils_str += '{}:{} ' .format(ifo, curr_fname)
+                cmd += data_fils_str
+                cmd += psd_fils_str
 
                 curr_fname = fname.replace('.xml.gz', '_attributes.hdf')
                 hdfp = h5py.File(curr_fname, 'w')
@@ -266,6 +273,12 @@ class LiveEventManager(object):
                 hdfp['spin1z'] = bank.table[template_id].spin1z
                 hdfp['spin2z'] = bank.table[template_id].spin2z
                 hdfp['ifar'] = ifar
+
+                cmd += '--params_file {} '.format(curr_fname)
+                cmd += '--approximant IMRPhenomD '
+                print cmd
+                DETACHED_PROCESS = 0x00000008
+                subprocess.Popen([cmd], creationflags=DETACHED_PROCESS)
 
 
     def check_singles(self, results, data_reader, psds, f_low):

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -71,6 +71,9 @@ class LiveEventManager(object):
         self.gracedb_testing = gracedb_testing
         self.enable_gracedb_upload = enable_gracedb_upload
 
+        # FIXME: Make CLA
+        self.store_data_and_psds = True
+
     def commit_results(self, results):
         self.comm.gather(results, root=0)
 
@@ -218,6 +221,44 @@ class LiveEventManager(object):
                              extra_strings=comments)
             else:
                 event.save(fname)
+
+            if self.store_data_and_psds:
+                for ifo in ifos:
+                    curr_fname = \
+                        fname.replace('.xml.gz',
+                                      '{}_data_overwhitened.hdf'.format(ifo))
+                    curr_data = data_readers[ifo].overwhitened_data(delta_f)
+                    curr_data.save(curr_fname)
+                    curr_fname = fname.replace('.xml.gz', 
+                                               '{}_psd.hdf'.format(ifo))
+                    curr_psd = curr_data.psd
+                    curr_psd.save(curr_fname)
+
+                curr_fname = fname.replace('.xml.gz', 'attributes.hdf')
+                hdfp = h5py.File(curr_fname, 'w')
+                for ifo in coinc_ifos:
+                    curr_time = \
+                        coinc_results['foreground/{}/end_time'.format(ifo)]
+                    hdfp['coinc_times/{}'.format(ifo)] = curr_time
+                tlen = bank.round_up((buff_size + min_buffer) \
+                    * bank.sample_rate)
+                flen = int(tlen / 2 + 1)
+                delta_f = bank.sample_rate / float(tlen)
+                f_end = bank.end_frequency(template_id)
+                if f_end is None or f_end >= (flen * delta_f):
+                    f_end = (flen-1) * delta_f
+                hdfp['flen'] = flen
+                hdfp['delta_f'] = delta_f
+                hdfp['f_end'] = f_end
+                hdfp['sample_rate'] = bank.sample_Rate
+                template_id = \
+                    triggers['foreground/{}/template_id'.format(ifos[0])]
+                hdfp['flow'] = bank.table[template_id].f_lower
+                hdfp['mass1'] = bank.table[template_id].mass1
+                hdfp['mass2'] = bank.table[template_id].mass2
+                hdfp['spin1z'] = bank.table[template_id].spin1z
+                hdfp['spin2z'] = bank.table[template_id].spin2z
+
 
     def check_singles(self, results, data_reader, psds, f_low):
         active = [k for k in results if results[k] != None]

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -64,12 +64,12 @@ def random_string(stringLength=10):
 
 class LiveEventManager(object):
     def __init__(self, output_path,
-                       use_date_prefix=False,
-                       ifar_upload_threshold=None,
-                       pval_livetime=None,
-                       enable_gracedb_upload=False,
-                       gracedb_testing=True,
-                 ):
+                 use_date_prefix=False,
+                 ifar_upload_threshold=None,
+                 pval_livetime=None,
+                 enable_gracedb_upload=False,
+                 gracedb_testing=True,
+                 run_snr_optimization=False):
         self.path = output_path
 
         # Figure out what we are supposed to process within the pool of MPI processes
@@ -83,8 +83,7 @@ class LiveEventManager(object):
         self.gracedb_testing = gracedb_testing
         self.enable_gracedb_upload = enable_gracedb_upload
 
-        # FIXME: Make CLA
-        self.store_data_and_psds = True
+        self.run_snr_optimization = run_snr_optimization
 
     def commit_results(self, results):
         self.comm.gather(results, root=0)
@@ -238,7 +237,7 @@ class LiveEventManager(object):
                 gid = None
                 event.save(fname)
 
-            if self.store_data_and_psds:
+            if self.run_snr_optimization and gid is not None:
                 template_id = \
                     coinc_results['foreground/{}/template_id'.format(ifos[0])]
                 p = props(bank.table[template_id])
@@ -531,6 +530,11 @@ parser.add_argument('--size-override', type=int, metavar='N',
                          " Useful for debugging and running a portion of a bank")
 parser.add_argument('--fftw-planning-limit', type=float,
                     help="Time in seconds to allow for a plan to be created")
+parser.add_argument('--run-snr-optimization', action='store_true',
+                    default=False,
+                    help='Run spawned followup processes to maximize SNR for '
+                         'any trigger uploaded to GraceDB')
+                   
 
 scheme.insert_processing_option_group(parser)
 LiveSingleFarThreshold.insert_args(parser)
@@ -567,7 +571,7 @@ evnt = LiveEventManager(args.output_path,
                         pval_livetime=args.pvalue_combination_livetime,
                         enable_gracedb_upload=args.enable_gracedb_upload,
                         gracedb_testing=not args.enable_production_gracedb_upload,
-                       )
+                        run_snr_optimization=args.run_snr_optimization)
 
 sg_chisq = SingleDetSGChisq.from_cli(args, bank, args.chisq_bins)
 

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -279,7 +279,7 @@ class LiveEventManager(object):
                 cmd += '--approximant IMRPhenomD '
                 cmd += '--verbose '
                 logging.info('Running {}.'.format(cmd))
-                subprocess.Popen([cmd])
+                subprocess.Popen(cmd, shell=True)
 
 
     def check_singles(self, results, data_reader, psds, f_low):

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -278,7 +278,7 @@ class LiveEventManager(object):
                 hdfp['spin2z'] = bank.table[template_id].spin2z
                 hdfp['ifar'] = ifar
 
-                cmd += '--params_file {} '.format(curr_fname)
+                cmd += '--params-file {} '.format(curr_fname)
                 cmd += '--approximant IMRPhenomD '
                 cmd += '--verbose '
                 logging.info('Running {}.'.format(cmd))

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -278,8 +278,7 @@ class LiveEventManager(object):
                 cmd += '--params_file {} '.format(curr_fname)
                 cmd += '--approximant IMRPhenomD '
                 print cmd
-                DETACHED_PROCESS = 0x00000008
-                subprocess.Popen([cmd], creationflags=DETACHED_PROCESS)
+                subprocess.Popen([cmd])
 
 
     def check_singles(self, results, data_reader, psds, f_low):

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -11,18 +11,16 @@ See https://arxiv.org/abs/1805.11174 for an overview."""
 
 import sys
 import argparse, numpy, pycbc, logging, cProfile, h5py, lal, json
-import random
 from time import time
-import types
 import os.path
 import itertools
 import platform
 from mpi4py import MPI as mpi
 from pycbc.pool import BroadcastPool
 from pycbc import fft, version, waveform, scheme, makedir
-from pycbc.types import MultiDetOptionAction, zeros
+from pycbc.types import MultiDetOptionAction
 from pycbc.filter import LiveBatchMatchedFilter, compute_followup_snr_series
-from pycbc.filter import followup_event_significance, matched_filter_core
+from pycbc.filter import followup_event_significance
 from pycbc.strain import StrainBuffer
 from pycbc.events.ranking import newsnr
 from pycbc.events.coinc import LiveCoincTimeslideBackgroundEstimator as Coincer
@@ -30,29 +28,6 @@ from pycbc.events.single import LiveSingleFarThreshold
 from pycbc.io.live import SingleCoincForGraceDB
 import pycbc.waveform.bank
 from pycbc.vetoes.sgchisq import SingleDetSGChisq
-from pycbc import DYN_RANGE_FAC
-from pycbc.conversions import mchirp_from_mass1_mass2, eta_from_mass1_mass2
-from pycbc.conversions import mtotal_from_mchirp_eta, mass1_from_mtotal_eta
-from pycbc.conversions import mass2_from_mtotal_eta
-
-import cProfile
-def profile(filename=None, comm=mpi.COMM_WORLD):
-  def prof_decorator(f):
-    def wrap_f(*args, **kwargs):
-      pr = cProfile.Profile()
-      pr.enable()
-      result = f(*args, **kwargs)
-      pr.disable()
-
-      if filename is None:
-        pr.print_stats()
-      else:
-        filename_r = filename + ".{}".format(comm.rank)
-        pr.dump_stats(filename_r)
-
-      return result
-    return wrap_f
-  return prof_decorator
 
 
 def ptof(p, ft):
@@ -74,53 +49,6 @@ def combine_ifar_pvalue(ifar, pvalue, livetime):
     nifar = 1. / ptof(pnew, livetime)
     # take max of original IFAR and combined IFAR & apply trials factor
     return numpy.maximum(ifar, nifar) / 2.
-
-# Define the function for computing network snr
-def compute_network_snr(v, *argv):
-    data = argv[0]
-    coinc_times = argv[1]
-    ifos = argv[2]
-    flen = argv[3]
-    approximant = argv[4]
-    flow = argv[5]
-    f_end = argv[6]
-    delta_f = argv[7]
-    sample_rate = argv[8]
-    min_f_lower = argv[9]
-    extra_args = argv[10]
-    distance = 1.0 / DYN_RANGE_FAC
-    mtotal = mtotal_from_mchirp_eta(v[0], v[1])
-    mass1 = mass1_from_mtotal_eta(mtotal, v[1])
-    mass2 = mass2_from_mtotal_eta(mtotal, v[1])
-
-    htilde = pycbc.waveform.get_waveform_filter\
-        (zeros(flen, dtype=numpy.complex64),
-         approximant=approximant,
-         mass1=mass1, mass2=mass2, spin1z=v[2], spin2z=v[3],
-         f_lower=flow, f_final=f_end, delta_f=delta_f,
-         delta_t=1.0/sample_rate, distance=distance,
-         **extra_args)
-    htilde.sigmasq = types.MethodType(pycbc.waveform.bank.sigma_cached,
-                                      htilde)
-    htilde.approximant = approximant
-    htilde.min_f_lower = min_f_lower
-    htilde.end_frequency = f_end
-    htilde.f_lower = flow
-    network_snrsq = 0
-    for ifo in ifos:
-        sigmasq = htilde.sigmasq(data[ifo].psd)
-        snr, _, norm = matched_filter_core(htilde, data[ifo],
-                                           h_norm=sigmasq)
-        duration = 0.095
-        half_dur_samples = int(snr.sample_rate * duration / 2)
-        onsource_idx = float(coinc_times[ifo] - snr.start_time) * snr.sample_rate
-        onsource_idx = int(round(onsource_idx))
-        onsource_slice = slice(onsource_idx - half_dur_samples,
-                               onsource_idx + half_dur_samples + 1)
-        snr_series = snr[onsource_slice] * norm
-        network_snrsq += max(abs(snr_series._data))**2
-    return - (network_snrsq**0.5)
-
 
 class LiveEventManager(object):
     def __init__(self, output_path,
@@ -181,7 +109,7 @@ class LiveEventManager(object):
             raise RuntimeError("Not root process")
 
     def compute_followup_data(self, ifos, triggers, data_readers, bank,
-                              followup_ifos=None, override_htilde=None):
+                              followup_ifos=None):
         """Figure out which of the followup detectors are usable, and compute
         SNR time series for all the available detectors.
         """
@@ -189,10 +117,7 @@ class LiveEventManager(object):
         followup_ifos = [] if followup_ifos is None else followup_ifos
 
         template_id = triggers['foreground/' + ifos[0] + '/template_id']
-        if override_htilde is not None:
-            htilde = override_htilde
-        else:
-            htilde = bank[template_id]
+        htilde = bank[template_id]
 
         coinc_times = {ifo: triggers['foreground/' + ifo + '/end_time'] for ifo in ifos}
 
@@ -245,79 +170,6 @@ class LiveEventManager(object):
         triggers[base + 'coa_phase'] = numpy.angle(snr_series_peak)
         triggers[base + 'sigmasq'] = sigma2
 
-
-    def optimize_snr_timeseries(self, ifos, triggers, data_readers, bank,
-                                followup_ifos=None):
-        from scipy.optimize import differential_evolution, minimize
-        from pycbc.waveform.waveform import props
-
-        coinc_times = {ifo: triggers['foreground/' + ifo + '/end_time'] for ifo in ifos}
-
-        # Define properties for template generation
-        template_id = triggers['foreground/' + ifos[0] + '/template_id']	
-        approximant = 'IMRPhenomD'
-        f_end = bank.end_frequency(template_id)
-        flow = bank.table[template_id].f_lower
-        min_buffer = bank.minimum_buffer + 0.5
-        p = props(bank.table[template_id])
-        p.pop('approximant')
-        buff_size = \
-            pycbc.waveform.get_waveform_filter_length_in_time(approximant, **p)
-        tlen = bank.round_up((buff_size + min_buffer) * bank.sample_rate)
-        flen = int(tlen / 2 + 1)
-        delta_f = bank.sample_rate / float(tlen)
-        if f_end is None or f_end >= (flen * delta_f):
-            f_end = (flen-1) * delta_f
-
-        data = {ifo: data_readers[ifo].overwhitened_data(delta_f) 
-                for ifo in ifos}
-        
-        trig_mchirp = mchirp_from_mass1_mass2(bank.table[template_id].mass1,
-                                              bank.table[template_id].mass2)
-        trig_eta = eta_from_mass1_mass2(bank.table[template_id].mass1,
-                                        bank.table[template_id].mass2)
-        bounds = [(trig_mchirp*0.9, trig_mchirp*1.1),
-                  (0.01, 0.2499), (-0.9, 0.9), (-0.9, 0.9)]
-        # Might be nice to use chi_eff and chi_a, but then boundaries become
-        # highly non-trivial
-        trig_spin1z = bank.table[template_id].spin1z
-        trig_spin2z = bank.table[template_id].spin2z
-
-        extra_args = (data, coinc_times, ifos, flen,
-                      approximant, flow, f_end, delta_f, bank.sample_rate,
-                      bank.min_f_lower, bank.extra_args)
-
-        results = differential_evolution(compute_network_snr, bounds,
-                                         maxiter=100, seed=1, workers=-1,
-                                         popsize=200, mutation=(1.,1),
-                                         recombination=0.25,
-                                         updating='deferred',
-                                         args=extra_args)
-
-        optimized_vals = results.x
-        mtotal = mtotal_from_mchirp_eta(optimized_vals[0], optimized_vals[1])
-        opt_mass1 = mass1_from_mtotal_eta(mtotal, optimized_vals[1])
-        opt_mass2 = mass2_from_mtotal_eta(mtotal, optimized_vals[1])
-        opt_spin1z = optimized_vals[2]
-        opt_spin2z = optimized_vals[3]
-        opt_htilde = pycbc.waveform.get_waveform_filter\
-            (zeros(flen, dtype=numpy.complex64),
-             approximant=approximant,
-             mass1=opt_mass1, mass2=opt_mass2, spin1z=opt_spin1z,
-             spin2z=opt_spin2z,
-             f_lower=flow, f_final=f_end, delta_f=delta_f,
-             delta_t=1.0/bank.sample_rate, distance=1.0 / DYN_RANGE_FAC,
-             **bank.extra_args)
-        opt_htilde.sigmasq = types.MethodType(pycbc.waveform.bank.sigma_cached,
-                                              opt_htilde)
-        opt_htilde.approximant = approximant
-        opt_htilde.min_f_lower = bank.min_f_lower
-        opt_htilde.end_frequency = f_end
-        opt_htilde.f_lower = flow
-
-        return [opt_mass1, opt_mass2, opt_spin1z, opt_spin2z], opt_htilde
-
-
     def check_coincs(self, ifos, coinc_results, psds, f_low,
                      data_readers, bank):
         """ Perform any followup and save zerolag triggers to a coinc xml file
@@ -360,66 +212,6 @@ class LiveEventManager(object):
             comments = ['using ranking statistic: %s' % args.background_statistic]
 
             ifar = coinc_results['foreground/ifar']
-            if self.enable_gracedb_upload and self.ifar_upload_threshold < ifar:
-                event.upload(fname, gracedb_server=args.gracedb_server,
-                             testing=self.gracedb_testing,
-                             extra_strings=comments)
-            else:
-                event.save(fname)
-
-            new_vals, opt_htilde = \
-                self.optimize_snr_timeseries(coinc_ifos, coinc_results,
-                                             data_readers, bank, followup_ifos)
-
-            fud = self.compute_followup_data(coinc_ifos, coinc_results,
-                                             data_readers, bank, followup_ifos,
-                                             override_htilde=opt_htilde)
-
-            # Now we can override the SNRs and masses
-            network_snrsq = 0.
-            for ifo in coinc_ifos:
-                fppref = 'foreground/{}/'.format(ifo)
-                coinc_results[fppref+'mass1'] = new_vals[0]
-                coinc_results[fppref+'mass2'] = new_vals[1]
-                coinc_results[fppref+'spin1z'] = new_vals[2]
-                coinc_results[fppref+'spin2z'] = new_vals[3]
-                coinc_results[fppref+'approximant'] = 'IMRPhenomD'
-                snrtseries = fud[ifo]['snr_series']
-                maxidx = numpy.argmax(abs(snrtseries))
-                # Subsample interpolation of SNR peak
-                # Following sbank here
-                maxsnrsq = abs(snrtseries[maxidx])**2
-                maxsnrpsq = abs(snrtseries[maxidx+1])**2
-                maxsnrmsq = abs(snrtseries[maxidx-1])**2
-                dy = 0.5 * (maxsnrpsq - maxsnrmsq)
-                d2y = 2. * maxsnrsq - maxsnrmsq - maxsnrpsq
-                maxsnrsq = maxsnrsq + 0.5*dy*dy/d2y
-                maxsnr = maxsnrsq**0.5
-                maxtime = snrtseries.sample_times[maxidx]
-                maxtime += 0.5 * snrtseries.delta_t * (maxsnrmsq - maxsnrpsq) /\
-                    (maxsnrmsq + maxsnrpsq - 2 * maxsnrsq)
-                # Do I need to interpolate this?
-                maxsnrphase = numpy.angle(snrtseries[maxidx])
-                network_snrsq += maxsnr**2
-                coinc_results[fppref+'snr'] = maxsnr
-                coinc_results[fppref+'end_time'] = maxtime
-                coinc_results[fppref+'stat'] = maxsnr
-                coinc_results[fppref+'chisq'] = 0.
-                coinc_results[fppref+'chisq_dof'] = 0
-                coinc_results[fppref+'sg_chisq'] = 0.
-                coinc_results[fppref+'coa_phase'] = maxsnrphase
-
-            coinc_results['foreground/stat'] = numpy.array([network_snrsq**0.5])
-
-            event = SingleCoincForGraceDB(live_ifos, coinc_results, bank=bank,
-                                          psds=psds, followup_data=fud,
-                                          low_frequency_cutoff=f_low,
-                                          channel_names=args.channel_name)
-
-            fname = os.path.join(self.path, 'coinc_opt-%s.xml.gz' % end_time)
-            logging.info('Optimized SNR! Saving as %s', fname)
-            comments.append('Optimized SNR time series over masses/spins')
-
             if self.enable_gracedb_upload and self.ifar_upload_threshold < ifar:
                 event.upload(fname, gracedb_server=args.gracedb_server,
                              testing=self.gracedb_testing,

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -219,10 +219,11 @@ class LiveEventManager(object):
 
             ifar = coinc_results['foreground/ifar']
             if self.enable_gracedb_upload and self.ifar_upload_threshold < ifar:
-                event.upload(fname, gracedb_server=args.gracedb_server,
-                             testing=self.gracedb_testing,
-                             extra_strings=comments)
+                gid = event.upload(fname, gracedb_server=args.gracedb_server,
+                                   testing=self.gracedb_testing,
+                                   extra_strings=comments)
             else:
+                gid = None
                 event.save(fname)
 
             if self.store_data_and_psds:
@@ -277,6 +278,7 @@ class LiveEventManager(object):
                 hdfp['spin1z'] = bank.table[template_id].spin1z
                 hdfp['spin2z'] = bank.table[template_id].spin2z
                 hdfp['ifar'] = ifar
+                hdfp['gid'] = gid
 
                 cmd += '--params-file {} '.format(curr_fname)
                 cmd += '--approximant IMRPhenomD '

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -15,6 +15,7 @@ from time import time
 import os.path
 import itertools
 import platform
+import distutils
 import subprocess
 from mpi4py import MPI as mpi
 from pycbc.pool import BroadcastPool
@@ -237,7 +238,9 @@ class LiveEventManager(object):
                     * bank.sample_rate)
                 flen = int(tlen / 2 + 1)
                 delta_f = bank.sample_rate / float(tlen)
-                cmd = 'timeout 150 /virtualenvs/pycbc_multiifo_online/bin/pycbc_optimize_snr '
+                cmd = 'timeout 150 '
+                exepath = distutils.spawn.find_executable('pycbc_optimize_snr')
+                cmd += exepath + ' '
                 data_fils_str = '--data-files '
                 psd_fils_str = '--psd-files '
                 for ifo in ifos:

--- a/bin/pycbc_optimize_snr
+++ b/bin/pycbc_optimize_snr
@@ -49,15 +49,18 @@ def compute_network_snr_core(v, *argv):
     mass1 = mass1_from_mtotal_eta(mtotal, v[1])
     mass2 = mass2_from_mtotal_eta(mtotal, v[1])
 
-    htilde = waveform.get_waveform_filter\
-        (zeros(flen, dtype=numpy.complex64),
-         approximant=approximant,
-         mass1=mass1, mass2=mass2, spin1z=v[2], spin2z=v[3],
-         f_lower=flow, f_final=f_end, delta_f=delta_f,
-         delta_t=1.0/sample_rate, distance=distance)
+    htilde = waveform.get_waveform_filter(
+            zeros(flen, dtype=numpy.complex64),
+            approximant=approximant,
+            mass1=mass1, mass2=mass2, spin1z=v[2], spin2z=v[3],
+            f_lower=flow, f_final=f_end, delta_f=delta_f,
+            delta_t=1.0/sample_rate, distance=distance)
+    if not hasattr(htilde, 'params'):
+        htilde.params = dict(mass1=mass1, mass2=mass2,
+                             spin1z=v[2], spin2z=v[3])
+    htilde.approximant = approximant
     htilde.sigmasq = types.MethodType(pycbc.waveform.bank.sigma_cached,
                                       htilde)
-    htilde.approximant = approximant
     htilde.min_f_lower = flow
     htilde.end_frequency = f_end
     htilde.f_lower = flow

--- a/bin/pycbc_optimize_snr
+++ b/bin/pycbc_optimize_snr
@@ -58,6 +58,8 @@ def compute_network_snr_core(v, *argv):
     if not hasattr(htilde, 'params'):
         htilde.params = dict(mass1=mass1, mass2=mass2,
                              spin1z=v[2], spin2z=v[3])
+    if not hasattr(htilde, 'end_idx'):
+        htilde.end_idx = int(f_end / htilde.delta_f)
     htilde.approximant = approximant
     htilde.sigmasq = types.MethodType(pycbc.waveform.bank.sigma_cached,
                                       htilde)

--- a/bin/pycbc_optimize_snr
+++ b/bin/pycbc_optimize_snr
@@ -52,7 +52,7 @@ def compute_network_snr_core(v, *argv):
 
     # enforce broadly accepted search space boundaries
     if mass1 < 1 or mass2 < 1 or mtotal > 500:
-        return -np.inf, {}
+        return -numpy.inf, {}
 
     try:
         htilde = waveform.get_waveform_filter(
@@ -64,7 +64,7 @@ def compute_network_snr_core(v, *argv):
     except RuntimeError:
         # assume a failure in the waveform approximant
         # due to the choice of parameters
-        return -np.inf, {}
+        return -numpy.inf, {}
 
     if not hasattr(htilde, 'params'):
         htilde.params = dict(mass1=mass1, mass2=mass2,

--- a/bin/pycbc_optimize_snr
+++ b/bin/pycbc_optimize_snr
@@ -1,5 +1,7 @@
 #! /usr/bin/env python
 
+"""Followup utility to optimize the SNR of a PyCBC Live trigger."""
+
 import argparse, numpy, h5py
 from time import time
 import types
@@ -20,6 +22,7 @@ from pycbc.io import live
 from pycbc.detector import Detector
 from pycbc.psd import interpolate
 import time
+
 
 Nfeval = 0
 start_time = time.time()
@@ -82,7 +85,7 @@ def compute_network_snr(v, *argv):
     return -nsnr
 
 
-parser = argparse.ArgumentParser()
+parser = argparse.ArgumentParser(description=__doc__)
 parser.add_argument('--version', action='version',
                     version=version.git_verbose_msg)
 parser.add_argument('--verbose', action='store_true')
@@ -104,6 +107,11 @@ parser.add_argument("--approximant", required=True,
 parser.add_argument("--snr-threshold", default=4.0,
                     help="If the SNR in ifo X is below this threshold do not "
                          "consider it part of the coincidence.")
+parser.add_argument('--gracedb-server', metavar='URL',
+                    help='URL of GraceDB server API for uploading events. '
+                         'If not provided, the default URL is used.')
+parser.add_argument('--production', action='store_true',
+                    help='Upload a production event rather than a test event')
 
 args = parser.parse_args()
 pycbc.init_logging(args.verbose)
@@ -279,12 +287,10 @@ comments = ['Automatic PyCBC followup to find largest SNR parameters']
 doc = live.SingleCoincForGraceDB(coinc_ifos, coinc_results,
                                  upload_snr_series=True,
                                  followup_ifos=fup_ifos, **kwargs)
-gracedb_server = 'https://gracedb-playground.ligo.org/api/'
-test_event = True
 tmpdir = tempfile.mkdtemp()
 gid = doc.upload(tmpdir + '/' + str(loudest_snr_times[ifos[0]])+'.xml',
-                 gracedb_server=gracedb_server,
-                 testing=test_event,
+                 gracedb_server=args.gracedb_server,
+                 testing=(not args.production),
                  extra_strings=comments)
 
-logging.info('Event uploaded as {}.'.format(gid))
+logging.info('Event uploaded as %s', gid)

--- a/bin/pycbc_optimize_snr
+++ b/bin/pycbc_optimize_snr
@@ -18,6 +18,18 @@ from scipy.optimize import differential_evolution
 from pycbc.waveform.waveform import props
 from pycbc.io import live
 from pycbc.detector import Detector
+from pycbc.psd import interpolate
+import time
+
+Nfeval = 0
+start_time = time.time()
+
+def callback_func(Xi, convergence=0):
+    global Nfeval
+    logging.info("CURRENTLY AT {} {}".format(Nfeval, convergence))
+    if (time.time() - start_time) > 120:
+        return True
+    Nfeval += 1
 
 # Define the function for computing network snr
 def compute_network_snr_core(v, *argv):
@@ -95,6 +107,7 @@ parser.add_argument("--snr-threshold", default=4.0,
 
 args = parser.parse_args()
 pycbc.init_logging(args.verbose)
+logging.getLogger('matplotlib').setLevel(logging.WARNING)
 
 logging.info('Starting optimize SNR')
 
@@ -143,7 +156,7 @@ logging.info('Starting optimization')
 results = differential_evolution(compute_network_snr, bounds,
                                  maxiter=100, workers=-1,
                                  popsize=200, mutation=(0.5,1),
-                                 recombination=0.7,
+                                 recombination=0.7, callback=callback_func,
                                  args=extra_args)
 
 logging.info('Optimization complete')
@@ -210,7 +223,8 @@ for idx, ifo in enumerate(ifos):
     coinc_results['foreground/'+ifo+'/sample_rate'] = int(sample_rate)
     coinc_results['foreground/'+ifo+'/template_id'] = 0
     followup_data[ifo] = {}
-    followup_data[ifo]['psd'] = data[ifo].psd
+    fseries = interpolate(data[ifo].psd, 0.25)
+    followup_data[ifo]['psd'] = fseries
     followup_data[ifo]['snr_series'] = snr_series_dict[ifo]
 
     # Should this trigger be considered part of the coincidence?

--- a/bin/pycbc_optimize_snr
+++ b/bin/pycbc_optimize_snr
@@ -3,6 +3,7 @@
 import argparse, numpy, h5py
 from time import time
 import types
+import logging
 import pycbc
 from pycbc import version, waveform
 from pycbc.types import MultiDetOptionAction, zeros, load_frequencyseries

--- a/bin/pycbc_optimize_snr
+++ b/bin/pycbc_optimize_snr
@@ -281,7 +281,8 @@ kwargs = {'psds': {ifo: followup_data[ifo]['psd'] for ifo in ifos},
           'low_frequency_cutoff': flow,
           'followup_data': followup_data,
           'channel_names': channel_names}
-comments = ['Automatic PyCBC followup to find largest SNR parameters']
+comments = ['Automatic PyCBC followup of trigger {} to find the parameters '
+            'that maximize the SNR'.format(fp['gid'][()])]
 
 doc = live.SingleCoincForGraceDB(coinc_ifos, coinc_results,
                                  upload_snr_series=True,

--- a/bin/pycbc_optimize_snr
+++ b/bin/pycbc_optimize_snr
@@ -2,6 +2,7 @@
 
 """Followup utility to optimize the SNR of a PyCBC Live trigger."""
 
+import os, shutil
 import argparse, numpy, h5py
 import time
 import types
@@ -49,12 +50,22 @@ def compute_network_snr_core(v, *argv):
     mass1 = mass1_from_mtotal_eta(mtotal, v[1])
     mass2 = mass2_from_mtotal_eta(mtotal, v[1])
 
-    htilde = waveform.get_waveform_filter(
-            zeros(flen, dtype=numpy.complex64),
-            approximant=approximant,
-            mass1=mass1, mass2=mass2, spin1z=v[2], spin2z=v[3],
-            f_lower=flow, f_final=f_end, delta_f=delta_f,
-            delta_t=1.0/sample_rate, distance=distance)
+    # enforce broadly accepted search space boundaries
+    if mass1 < 1 or mass2 < 1 or mtotal > 500:
+        return -np.inf, {}
+
+    try:
+        htilde = waveform.get_waveform_filter(
+                zeros(flen, dtype=numpy.complex64),
+                approximant=approximant,
+                mass1=mass1, mass2=mass2, spin1z=v[2], spin2z=v[3],
+                f_lower=flow, f_final=f_end, delta_f=delta_f,
+                delta_t=1.0/sample_rate, distance=distance)
+    except RuntimeError:
+        # assume a failure in the waveform approximant
+        # due to the choice of parameters
+        return -np.inf, {}
+
     if not hasattr(htilde, 'params'):
         htilde.params = dict(mass1=mass1, mass2=mass2,
                              spin1z=v[2], spin2z=v[3])
@@ -241,8 +252,7 @@ for idx, ifo in enumerate(ifos):
     coinc_results['foreground/'+ifo+'/template_duration'] = \
         fp['template_duration'][()]
     followup_data[ifo] = {}
-    fseries = interpolate(data[ifo].psd, 0.25)
-    followup_data[ifo]['psd'] = fseries
+    followup_data[ifo]['psd'] = interpolate(data[ifo].psd, 0.25)
     followup_data[ifo]['snr_series'] = snr_series_dict[ifo]
 
     # Find loudest SNR within coincidence window of the largest peak
@@ -273,8 +283,7 @@ for idx, ifo in enumerate(ifos):
         = snr_series_dict['sigmasq_' + ifo]
     coinc_results['foreground/'+ifo+'/coa_phase'] \
         = numpy.angle(loudest_snr)
-    coinc_results['foreground/'+ifo+'/chisq'] = 1.
-    coinc_results['foreground/'+ifo+'/chisq_dof'] = 1
+
 coinc_results['foreground/stat'] = numpy.sqrt(netsnr)
 coinc_results['foreground/ifar'] = fp['ifar'][()]
 
@@ -286,17 +295,22 @@ kwargs = {'psds': {ifo: followup_data[ifo]['psd'] for ifo in ifos},
           'low_frequency_cutoff': flow,
           'followup_data': followup_data,
           'channel_names': channel_names}
-comments = ['Automatic PyCBC followup of trigger {} to find the parameters '
-            'that maximize the SNR'.format(fp['gid'][()])]
+comments = ['Automatic PyCBC followup of trigger {0} to find the parameters '
+            'that maximize the SNR. The FAR of this trigger is copied from '
+            '{0} and does not reflect this triggers\' '
+            'parameters.'.format(fp['gid'][()])]
 
 doc = live.SingleCoincForGraceDB(coinc_ifos, coinc_results,
                                  upload_snr_series=True,
                                  followup_ifos=fup_ifos, **kwargs)
 tmpdir = tempfile.mkdtemp()
-gid = doc.upload(tmpdir + '/' + str(loudest_snr_times[ifos[0]])+'.xml',
+xml_path = os.path.join(
+        tmpdir, '{:.3f}.xml.gz'.format(loudest_snr_time_allifos))
+gid = doc.upload(xml_path,
                  gracedb_server=args.gracedb_server,
                  testing=(not args.production),
                  extra_strings=comments)
 
 if gid is not None:
     logging.info('Event uploaded as %s', gid)
+    shutil.rmtree(tmpdir)

--- a/bin/pycbc_optimize_snr
+++ b/bin/pycbc_optimize_snr
@@ -92,7 +92,7 @@ parser.add_argument("--snr-threshold", default=5.0,
                          "consider it part of the coincidence.")
 
 args = parser.parse_args()
-pycbc.init_logging(args.verbose, format=log_format)
+pycbc.init_logging(args.verbose)
 
 logging.info('Starting optimize SNR')
 

--- a/bin/pycbc_optimize_snr
+++ b/bin/pycbc_optimize_snr
@@ -268,7 +268,7 @@ coinc_results['foreground/ifar'] = fp['ifar'][()]
 
 channel_names = {}
 for ifo in fp['channel_names'].keys():
-    channel_names['ifo'] = hdfp['channel_names'][ifo]
+    channel_names['ifo'] = fp['channel_names'][ifo]
 
 kwargs = {'psds': {ifo: followup_data[ifo]['psd'] for ifo in ifos},
           'low_frequency_cutoff': flow,

--- a/bin/pycbc_optimize_snr
+++ b/bin/pycbc_optimize_snr
@@ -3,6 +3,7 @@
 import argparse, numpy, h5py
 from time import time
 import types
+import pycbc
 from pycbc import version, waveform
 from pycbc.types import MultiDetOptionAction, zeros, load_frequencyseries
 from pycbc.filter import matched_filter_core
@@ -91,6 +92,9 @@ parser.add_argument("--snr-threshold", default=5.0,
                          "consider it part of the coincidence.")
 
 args = parser.parse_args()
+pycbc.init_logging(args.verbose, format=log_format)
+
+logging.info('Starting optimize SNR')
 
 data = {}
 for ifo in args.data_files.keys():
@@ -131,16 +135,16 @@ maxchirp = 80 if maxchirp > 80 else maxchirp
 
 bounds = [(minchirp, maxchirp), (0.01, 0.2499), (-0.9, 0.9), (-0.9, 0.9)]
 
-# UNCOMMENT FOR TESTING SPEED OF OPTIMIZATION
-#import time as ctime
-#t1 = ctime.time()
+logging.info('Starting optimization')
 
 results = differential_evolution(compute_network_snr, bounds,
                                  maxiter=100, workers=-1,
                                  popsize=200, mutation=(0.5,1),
                                  recombination=0.7,
                                  args=extra_args)
-#t2 = ctime.time()
+
+logging.info('Optimization complete')
+
 mtotal = mtotal_from_mchirp_eta(results.x[0], results.x[1])
 mass1 = mass1_from_mtotal_eta(mtotal, results.x[1])
 mass2 = mass2_from_mtotal_eta(mtotal, results.x[1])
@@ -249,3 +253,5 @@ gid = doc.upload(str(loudest_snr_times[ifos[0]])+'.xml',
                  gracedb_server=gracedb_server,
                  testing=test_event,
                  extra_strings=comments)
+
+logging.info('Event uploaded as {}.'.format(gid))

--- a/bin/pycbc_optimize_snr
+++ b/bin/pycbc_optimize_snr
@@ -115,10 +115,11 @@ for ifo in ifos:
 
 coinc_ifos = list(coinc_times.keys())
     
+logging.info("Following up GID {}".format(fp['gid'][()]))
 flen = fp['flen'][()]
 approximant = args.approximant
-flow = fp['flow'][()]
-f_end = fp['f_end'][()]
+flow = float(fp['flow'][()])
+f_end = float(fp['f_end'][()])
 delta_f = fp['delta_f'][()]
 sample_rate = fp['sample_rate'][()]
 

--- a/bin/pycbc_optimize_snr
+++ b/bin/pycbc_optimize_snr
@@ -268,7 +268,7 @@ coinc_results['foreground/ifar'] = fp['ifar'][()]
 
 channel_names = {}
 for ifo in fp['channel_names'].keys():
-    channel_names['ifo'] = fp['channel_names'][ifo]
+    channel_names[ifo] = fp['channel_names'][ifo][()]
 
 kwargs = {'psds': {ifo: followup_data[ifo]['psd'] for ifo in ifos},
           'low_frequency_cutoff': flow,

--- a/bin/pycbc_optimize_snr
+++ b/bin/pycbc_optimize_snr
@@ -30,7 +30,7 @@ start_time = time.time()
 def callback_func(Xi, convergence=0):
     global Nfeval
     logging.info("CURRENTLY AT {} {}".format(Nfeval, convergence))
-    if (time.time() - start_time) > 120:
+    if (time.time() - start_time) > 360:
         return True
     Nfeval += 1
 
@@ -249,6 +249,9 @@ for idx, ifo in enumerate(ifos):
     coinc_results['foreground/'+ifo+'/window'] = 0.1
     coinc_results['foreground/'+ifo+'/sample_rate'] = int(sample_rate)
     coinc_results['foreground/'+ifo+'/template_id'] = 0
+    # Apparently GraceDB gets upset if chi-squared is not set
+    coinc_results['foreground/'+ifo+'/chisq'] = 1.
+    coinc_results['foreground/'+ifo+'/chisq_dof'] = 1
     coinc_results['foreground/'+ifo+'/template_duration'] = \
         fp['template_duration'][()]
     followup_data[ifo] = {}

--- a/bin/pycbc_optimize_snr
+++ b/bin/pycbc_optimize_snr
@@ -267,7 +267,7 @@ coinc_results['foreground/stat'] = numpy.sqrt(netsnr)
 coinc_results['foreground/ifar'] = fp['ifar'][()]
 
 channel_names = {}
-for ifo in hdfp['channel_names'].keys():
+for ifo in fp['channel_names'].keys():
     channel_names['ifo'] = hdfp['channel_names'][ifo]
 
 kwargs = {'psds': {ifo: followup_data[ifo]['psd'] for ifo in ifos},

--- a/bin/pycbc_optimize_snr
+++ b/bin/pycbc_optimize_snr
@@ -298,4 +298,5 @@ gid = doc.upload(tmpdir + '/' + str(loudest_snr_times[ifos[0]])+'.xml',
                  testing=(not args.production),
                  extra_strings=comments)
 
-logging.info('Event uploaded as %s', gid)
+if gid is not None:
+    logging.info('Event uploaded as %s', gid)

--- a/bin/pycbc_optimize_snr
+++ b/bin/pycbc_optimize_snr
@@ -319,9 +319,8 @@ comments = ['Automatic PyCBC followup of trigger {0} to find the parameters '
             '{0} and does not reflect this triggers\' '
             'parameters.'.format(fp['gid'][()])]
 
-doc = live.SingleCoincForGraceDB(coinc_ifos, coinc_results,
-                                 upload_snr_series=True,
-                                 followup_ifos=fup_ifos, **kwargs)
+doc = live.SingleCoincForGraceDB(ifos, coinc_results,
+                                 upload_snr_series=True, **kwargs)
 tmpdir = tempfile.mkdtemp()
 xml_path = os.path.join(
         tmpdir, '{:.3f}.xml.gz'.format(loudest_snr_time_allifos))

--- a/bin/pycbc_optimize_snr
+++ b/bin/pycbc_optimize_snr
@@ -4,6 +4,7 @@ import argparse, numpy, h5py
 from time import time
 import types
 import logging
+import tempfile
 import pycbc
 from pycbc import version, waveform
 from pycbc.types import MultiDetOptionAction, zeros, load_frequencyseries
@@ -88,7 +89,7 @@ parser.add_argument("--psd-files", type=str, nargs='+',
                          "by PyCBC Live.")
 parser.add_argument("--approximant", required=True,
                     help="Waveform approximant string.")
-parser.add_argument("--snr-threshold", default=5.0,
+parser.add_argument("--snr-threshold", default=4.0,
                     help="If the SNR in ifo X is below this threshold do not "
                          "consider it part of the coincidence.")
 
@@ -250,7 +251,8 @@ doc = live.SingleCoincForGraceDB(coinc_ifos, coinc_results,
                                  followup_ifos=fup_ifos, **kwargs)
 gracedb_server = 'https://gracedb-playground.ligo.org/api/'
 test_event = True
-gid = doc.upload(str(loudest_snr_times[ifos[0]])+'.xml',
+tmpdir = tempfile.mkdtemp()
+gid = doc.upload(tmpdir + '/' + str(loudest_snr_times[ifos[0]])+'.xml',
                  gracedb_server=gracedb_server,
                  testing=test_event,
                  extra_strings=comments)

--- a/bin/pycbc_optimize_snr
+++ b/bin/pycbc_optimize_snr
@@ -187,6 +187,10 @@ loudest_snrs = {}
 loudest_snr_times = {}
 loudest_snr_idxs = {}
 
+# Determine which ifo has the loudest SNR peak ... We'll use this to determine
+# the time window for other ifos (e.g. if one ifo has a loud SNR peak, and the
+# other has SNR < 4, we would need to determine the loudest SNR for the quieter
+# instrument within light-travel time of the loud SNR peak)
 for ifo in ifos:
     duration = 0.095
     half_dur_samples = int(sample_rate * duration / 2)
@@ -222,43 +226,54 @@ for idx, ifo in enumerate(ifos):
     coinc_results['foreground/'+ifo+'/window'] = 0.1
     coinc_results['foreground/'+ifo+'/sample_rate'] = int(sample_rate)
     coinc_results['foreground/'+ifo+'/template_id'] = 0
+    coinc_results['foreground/'+ifo+'/template_duration'] = \
+        fp['template_duration'][()]
     followup_data[ifo] = {}
     fseries = interpolate(data[ifo].psd, 0.25)
     followup_data[ifo]['psd'] = fseries
     followup_data[ifo]['snr_series'] = snr_series_dict[ifo]
 
-    # Should this trigger be considered part of the coincidence?
-    # Check snr_peak
+    # Find loudest SNR within coincidence window of the largest peak
     snr_peak = abs(loudest_snrs[ifo])
     # And check light travel time
     lttbd = Detector(ifo).light_travel_time_to_detector(Detector(loudest_ifo))
     # Add small buffer
     lttbd += 0.005
 
-    if snr_peak < args.snr_threshold or \
-            abs(loudest_snr_times[ifo] - loudest_snr_time_allifos) > lttbd:
-        coinc_results['foreground/'+ifo+'/end_time'] = loudest_snr_time_allifos
-        continue
+    time_window = [loudest_snr_time_allifos-lttbd,
+                   loudest_snr_time_allifos+lttbd]
 
-    coinc_results['foreground/'+ifo+'/end_time'] = loudest_snr_times[ifo]
+    snr_slice = snr_series_dict[ifo].time_slice(time_window[0], time_window[1])
+    max_snr_idx = numpy.argmax(abs(snr_slice))
+    loudest_snr_time = snr_slice.sample_times[max_snr_idx]
+    loudest_snr = snr_slice[max_snr_idx]
+
+    coinc_results['foreground/'+ifo+'/end_time'] = loudest_snr_time_allifos
+    coinc_results['foreground/'+ifo+'/end_time'] = loudest_snr_time
     coinc_results['foreground/'+ifo+'/snr_series'] = snr_series_dict[ifo]
     coinc_results['foreground/'+ifo+'/psd_series'] = data[ifo].psd
     coinc_results['foreground/'+ifo+'/delta_f'] = delta_f
-    coinc_results['foreground/'+ifo+'/event_id'] = 'sngl_inspiral:event_id:'+str(idx)
-    coinc_results['foreground/'+ifo+'/snr'] = abs(loudest_snrs[ifo])
-    netsnr += abs(loudest_snrs[ifo])**2
+    coinc_results['foreground/'+ifo+'/event_id'] = \
+        'sngl_inspiral:event_id:'+str(idx)
+    coinc_results['foreground/'+ifo+'/snr'] = abs(loudest_snr)
+    netsnr += abs(loudest_snr)**2
     coinc_results['foreground/'+ifo+'/sigmasq'] \
         = snr_series_dict['sigmasq_' + ifo]
     coinc_results['foreground/'+ifo+'/coa_phase'] \
-        = numpy.angle(loudest_snrs[ifo])
+        = numpy.angle(loudest_snr)
     coinc_results['foreground/'+ifo+'/chisq'] = 1.
     coinc_results['foreground/'+ifo+'/chisq_dof'] = 1
 coinc_results['foreground/stat'] = numpy.sqrt(netsnr)
 coinc_results['foreground/ifar'] = fp['ifar'][()]
 
+channel_names = {}
+for ifo in hdfp['channel_names'].keys():
+    channel_names['ifo'] = hdfp['channel_names'][ifo]
+
 kwargs = {'psds': {ifo: followup_data[ifo]['psd'] for ifo in ifos},
           'low_frequency_cutoff': flow,
-          'followup_data': followup_data}
+          'followup_data': followup_data,
+          'channel_names': channel_names}
 comments = ['Automatic PyCBC followup to find largest SNR parameters']
 
 doc = live.SingleCoincForGraceDB(coinc_ifos, coinc_results,

--- a/bin/pycbc_optimize_snr
+++ b/bin/pycbc_optimize_snr
@@ -235,6 +235,23 @@ for ifo in ifos:
         loudest_ifo = ifo
         loudest_snr_time_allifos = loudest_snr_times[ifo]
 
+# Now we can create the snr_series_dict
+for ifo in ifos:
+    # Find loudest SNR within coincidence window of the largest peak
+    snr_peak = abs(loudest_snrs[ifo])
+    # And check light travel time
+    lttbd = Detector(ifo).light_travel_time_to_detector(Detector(loudest_ifo))
+    # Add small buffer
+    lttbd += 0.005
+
+    time_window = [loudest_snr_time_allifos-lttbd,
+                   loudest_snr_time_allifos+lttbd]
+
+    snr_slice = snr_series_dict[ifo].time_slice(time_window[0], time_window[1])
+    max_snr_idx = numpy.argmax(abs(snr_slice))
+    idx_offset = snr_slice.start_time - snr_series_dict[ifo].start_time
+    idx_offset = int(idx_offset * sample_rate + 0.5)
+    max_snr_idx = max_snr_idx + idx_offset
     new_snr_slice = slice(max_snr_idx - int(sample_rate/10),
                           max_snr_idx + int(sample_rate/10)+1)
     snr_series_dict[ifo] = snr_series_dict[ifo][new_snr_slice]
@@ -273,7 +290,6 @@ for idx, ifo in enumerate(ifos):
     loudest_snr_time = snr_slice.sample_times[max_snr_idx]
     loudest_snr = snr_slice[max_snr_idx]
 
-    coinc_results['foreground/'+ifo+'/end_time'] = loudest_snr_time_allifos
     coinc_results['foreground/'+ifo+'/end_time'] = loudest_snr_time
     coinc_results['foreground/'+ifo+'/snr_series'] = snr_series_dict[ifo]
     coinc_results['foreground/'+ifo+'/psd_series'] = data[ifo].psd

--- a/bin/pycbc_optimize_snr
+++ b/bin/pycbc_optimize_snr
@@ -3,7 +3,7 @@
 """Followup utility to optimize the SNR of a PyCBC Live trigger."""
 
 import argparse, numpy, h5py
-from time import time
+import time
 import types
 import logging
 import tempfile
@@ -13,15 +13,14 @@ from pycbc.types import MultiDetOptionAction, zeros, load_frequencyseries
 from pycbc.filter import matched_filter_core
 import pycbc.waveform.bank
 from pycbc import DYN_RANGE_FAC
-from pycbc.conversions import mchirp_from_mass1_mass2
-from pycbc.conversions import mtotal_from_mchirp_eta, mass1_from_mtotal_eta
-from pycbc.conversions import mass2_from_mtotal_eta
+from pycbc.conversions import (
+    mchirp_from_mass1_mass2, mtotal_from_mchirp_eta,
+    mass1_from_mtotal_eta, mass2_from_mtotal_eta
+)
 from scipy.optimize import differential_evolution
-from pycbc.waveform.waveform import props
 from pycbc.io import live
 from pycbc.detector import Detector
 from pycbc.psd import interpolate
-import time
 
 
 Nfeval = 0
@@ -151,7 +150,7 @@ mass1 = fp['mass1'][()]
 mass2 = fp['mass2'][()]
 spin1z = fp['spin1z'][()]
 spin2z = fp['spin2z'][()]
-mchirp = pycbc.conversions.mchirp_from_mass1_mass2(mass1, mass2)
+mchirp = mchirp_from_mass1_mass2(mass1, mass2)
 minchirp = mchirp * (1 - mchirp / 50.0)
 maxchirp = mchirp * (1 + mchirp / 50.0)
 minchirp = 1 if minchirp < 1 else minchirp

--- a/bin/pycbc_optimize_snr
+++ b/bin/pycbc_optimize_snr
@@ -1,0 +1,251 @@
+#! /usr/bin/env python
+
+import argparse, numpy, h5py
+from time import time
+import types
+from pycbc import version, waveform
+from pycbc.types import MultiDetOptionAction, zeros, load_frequencyseries
+from pycbc.filter import matched_filter_core
+import pycbc.waveform.bank
+from pycbc import DYN_RANGE_FAC
+from pycbc.conversions import mchirp_from_mass1_mass2
+from pycbc.conversions import mtotal_from_mchirp_eta, mass1_from_mtotal_eta
+from pycbc.conversions import mass2_from_mtotal_eta
+from scipy.optimize import differential_evolution
+from pycbc.waveform.waveform import props
+from pycbc.io import live
+from pycbc.detector import Detector
+
+# Define the function for computing network snr
+def compute_network_snr_core(v, *argv):
+    data = argv[0]
+    coinc_times = argv[1]
+    ifos = argv[2]
+    flen = argv[3]
+    approximant = argv[4]
+    flow = argv[5]
+    f_end = argv[6]
+    delta_f = argv[7]
+    sample_rate = argv[8]
+    distance = 1.0 / DYN_RANGE_FAC
+    mtotal = mtotal_from_mchirp_eta(v[0], v[1])
+    mass1 = mass1_from_mtotal_eta(mtotal, v[1])
+    mass2 = mass2_from_mtotal_eta(mtotal, v[1])
+
+    htilde = waveform.get_waveform_filter\
+        (zeros(flen, dtype=numpy.complex64),
+         approximant=approximant,
+         mass1=mass1, mass2=mass2, spin1z=v[2], spin2z=v[3],
+         f_lower=flow, f_final=f_end, delta_f=delta_f,
+         delta_t=1.0/sample_rate, distance=distance)
+    htilde.sigmasq = types.MethodType(pycbc.waveform.bank.sigma_cached,
+                                      htilde)
+    htilde.approximant = approximant
+    htilde.min_f_lower = flow
+    htilde.end_frequency = f_end
+    htilde.f_lower = flow
+    network_snrsq = 0
+    snr_series_dict = {}
+    for ifo in ifos:
+        sigmasq = htilde.sigmasq(data[ifo].psd)
+        snr, _, norm = matched_filter_core(htilde, data[ifo],
+                                           h_norm=sigmasq)
+        duration = 0.095
+        half_dur_samples = int(snr.sample_rate * duration / 2)
+        onsource_idx = float(coinc_times[ifo] - snr.start_time) * snr.sample_rate
+        onsource_idx = int(round(onsource_idx))
+        onsource_slice = slice(onsource_idx - half_dur_samples,
+                               onsource_idx + half_dur_samples + 1)
+        snr_series = snr[onsource_slice] * norm
+        snr_series_dict[ifo] = snr * norm
+        snr_series_dict['sigmasq_' + ifo] = sigmasq
+        network_snrsq += max(abs(snr_series._data))**2
+    return (network_snrsq**0.5), snr_series_dict
+
+def compute_network_snr(v, *argv):
+    nsnr, _ = compute_network_snr_core(v, *argv)
+    return -nsnr
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--version', action='version',
+                    version=version.git_verbose_msg)
+parser.add_argument('--verbose', action='store_true')
+parser.add_argument('--params-file',
+                    help='Location of the attributes file created by PyCBC '
+                         'Live')
+parser.add_argument("--data-files", type=str, nargs='+',
+                    action=MultiDetOptionAction,
+                    metavar='IFO:DATA_FILE',
+                    help="Locations of the overwhitened data files produced "
+                         "by PyCBC Live.")
+parser.add_argument("--psd-files", type=str, nargs='+',
+                    action=MultiDetOptionAction,
+                    metavar='IFO:PSD_FILE',
+                    help="Locations of the PSD files produced "
+                         "by PyCBC Live.")
+parser.add_argument("--approximant", required=True,
+                    help="Waveform approximant string.")
+parser.add_argument("--snr-threshold", default=5.0,
+                    help="If the SNR in ifo X is below this threshold do not "
+                         "consider it part of the coincidence.")
+
+args = parser.parse_args()
+
+data = {}
+for ifo in args.data_files.keys():
+    data[ifo] = load_frequencyseries(args.data_files[ifo])
+    data[ifo].psd = load_frequencyseries(args.psd_files[ifo])
+
+fp = h5py.File(args.params_file, 'r')
+ifos = data.keys()
+
+coinc_times = {}
+for ifo in ifos:
+    try:
+        coinc_times[ifo] = fp['coinc_times'][ifo][()]
+    except KeyError:
+        pass
+
+coinc_ifos = list(coinc_times.keys())
+    
+flen = fp['flen'][()]
+approximant = args.approximant
+flow = fp['flow'][()]
+f_end = fp['f_end'][()]
+delta_f = fp['delta_f'][()]
+sample_rate = fp['sample_rate'][()]
+
+extra_args = [data, coinc_times, coinc_ifos, flen,
+              approximant, flow, f_end, delta_f, sample_rate]
+
+mass1 = fp['mass1'][()]
+mass2 = fp['mass2'][()]
+spin1z = fp['spin1z'][()]
+spin2z = fp['spin2z'][()]
+mchirp = pycbc.conversions.mchirp_from_mass1_mass2(mass1, mass2)
+minchirp = mchirp * (1 - mchirp / 50.0)
+maxchirp = mchirp * (1 + mchirp / 50.0)
+minchirp = 1 if minchirp < 1 else minchirp
+maxchirp = 80 if maxchirp > 80 else maxchirp
+
+bounds = [(minchirp, maxchirp), (0.01, 0.2499), (-0.9, 0.9), (-0.9, 0.9)]
+
+# UNCOMMENT FOR TESTING SPEED OF OPTIMIZATION
+#import time as ctime
+#t1 = ctime.time()
+
+results = differential_evolution(compute_network_snr, bounds,
+                                 maxiter=100, workers=-1,
+                                 popsize=200, mutation=(0.5,1),
+                                 recombination=0.7,
+                                 args=extra_args)
+#t2 = ctime.time()
+mtotal = mtotal_from_mchirp_eta(results.x[0], results.x[1])
+mass1 = mass1_from_mtotal_eta(mtotal, results.x[1])
+mass2 = mass2_from_mtotal_eta(mtotal, results.x[1])
+spin1z = results.x[2]
+spin2z = results.x[3]
+
+fup_ifos = set(ifos) - set(coinc_ifos)
+
+for ifo in fup_ifos:
+    coinc_times[ifo] = coinc_times[coinc_ifos[0]]
+
+extra_args[2] = ifos
+
+_, snr_series_dict = compute_network_snr_core(results.x, *extra_args)
+
+# Prepare for GraceDB upload
+coinc_results = {}
+followup_data = {}
+
+loudest_ifo = None
+loudest_snr_allifos = 0
+loudest_snr_time_allifos = None
+loudest_snrs = {}
+loudest_snr_times = {}
+loudest_snr_idxs = {}
+
+for ifo in ifos:
+    duration = 0.095
+    half_dur_samples = int(sample_rate * duration / 2)
+    onsource_idx = float(coinc_times[ifo] - snr_series_dict[ifo].start_time) \
+        * snr_series_dict[ifo].sample_rate
+    onsource_idx = int(round(onsource_idx))
+    onsource_slice = slice(onsource_idx - half_dur_samples,
+                           onsource_idx + half_dur_samples + 1)
+    max_snr_idx = numpy.argmax(abs(snr_series_dict[ifo][onsource_slice]))
+    max_snr_idx = max_snr_idx + onsource_idx - half_dur_samples
+    max_snr = snr_series_dict[ifo][max_snr_idx]
+    max_snr_time = snr_series_dict[ifo].start_time \
+        + max_snr_idx*(1./sample_rate)
+    loudest_snr_idxs[ifo] = max_snr_idx
+    loudest_snr_times[ifo] = float(max_snr_time)
+    loudest_snrs[ifo] = max_snr
+    if abs(max_snr) > loudest_snr_allifos:
+        loudest_snr_allifos = abs(max_snr)
+        loudest_ifo = ifo
+        loudest_snr_time_allifos = loudest_snr_times[ifo]
+
+    new_snr_slice = slice(max_snr_idx - int(sample_rate/10),
+                          max_snr_idx + int(sample_rate/10)+1)
+    snr_series_dict[ifo] = snr_series_dict[ifo][new_snr_slice]
+
+netsnr = 0
+for idx, ifo in enumerate(ifos):
+    coinc_results['foreground/'+ifo+'/mass1'] = mass1
+    coinc_results['foreground/'+ifo+'/mass2'] = mass2
+    coinc_results['foreground/'+ifo+'/spin1z'] = spin1z
+    coinc_results['foreground/'+ifo+'/spin2z'] = spin2z
+    coinc_results['foreground/'+ifo+'/f_lower'] = flow
+    coinc_results['foreground/'+ifo+'/window'] = 0.1
+    coinc_results['foreground/'+ifo+'/sample_rate'] = int(sample_rate)
+    coinc_results['foreground/'+ifo+'/template_id'] = 0
+    followup_data[ifo] = {}
+    followup_data[ifo]['psd'] = data[ifo].psd
+    followup_data[ifo]['snr_series'] = snr_series_dict[ifo]
+
+    # Should this trigger be considered part of the coincidence?
+    # Check snr_peak
+    snr_peak = abs(loudest_snrs[ifo])
+    # And check light travel time
+    lttbd = Detector(ifo).light_travel_time_to_detector(Detector(loudest_ifo))
+    # Add small buffer
+    lttbd += 0.005
+
+    if snr_peak < args.snr_threshold or \
+            abs(loudest_snr_times[ifo] - loudest_snr_time_allifos) > lttbd:
+        coinc_results['foreground/'+ifo+'/end_time'] = loudest_snr_time_allifos
+        continue
+
+    coinc_results['foreground/'+ifo+'/end_time'] = loudest_snr_times[ifo]
+    coinc_results['foreground/'+ifo+'/snr_series'] = snr_series_dict[ifo]
+    coinc_results['foreground/'+ifo+'/psd_series'] = data[ifo].psd
+    coinc_results['foreground/'+ifo+'/delta_f'] = delta_f
+    coinc_results['foreground/'+ifo+'/event_id'] = 'sngl_inspiral:event_id:'+str(idx)
+    coinc_results['foreground/'+ifo+'/snr'] = abs(loudest_snrs[ifo])
+    netsnr += abs(loudest_snrs[ifo])**2
+    coinc_results['foreground/'+ifo+'/sigmasq'] \
+        = snr_series_dict['sigmasq_' + ifo]
+    coinc_results['foreground/'+ifo+'/coa_phase'] \
+        = numpy.angle(loudest_snrs[ifo])
+    coinc_results['foreground/'+ifo+'/chisq'] = 1.
+    coinc_results['foreground/'+ifo+'/chisq_dof'] = 1
+coinc_results['foreground/stat'] = numpy.sqrt(netsnr)
+coinc_results['foreground/ifar'] = fp['ifar'][()]
+
+kwargs = {'psds': {ifo: followup_data[ifo]['psd'] for ifo in ifos},
+          'low_frequency_cutoff': flow,
+          'followup_data': followup_data}
+comments = ['Automatic PyCBC followup to find largest SNR parameters']
+
+doc = live.SingleCoincForGraceDB(coinc_ifos, coinc_results,
+                                 upload_snr_series=True,
+                                 followup_ifos=fup_ifos, **kwargs)
+gracedb_server = 'https://gracedb-playground.ligo.org/api/'
+test_event = True
+gid = doc.upload(str(loudest_snr_times[ifos[0]])+'.xml',
+                 gracedb_server=gracedb_server,
+                 testing=test_event,
+                 extra_strings=comments)

--- a/pycbc/events/coinc.py
+++ b/pycbc/events/coinc.py
@@ -954,6 +954,9 @@ class LiveCoincTimeslideBackgroundEstimator(object):
         """
         if len(self.singles.keys()) == 0:
             self.set_singles_buffer(results)
+        # If this *still* didn't work, no triggers in first set, try next time
+        if len(self.singles.keys()) == 0:
+            return {}
 
         # convert to single detector trigger values
         # FIXME Currently configured to use pycbc live output

--- a/pycbc/events/coinc.py
+++ b/pycbc/events/coinc.py
@@ -916,7 +916,8 @@ class LiveCoincTimeslideBackgroundEstimator(object):
         self.singles_dtype = []
         data = False
         for ifo in self.ifos:
-            if ifo in results and results[ifo] is not False:
+            if ifo in results and results[ifo] is not False \
+                    and len(results[ifo]['snr']):
                 data = results[ifo]
                 break
 

--- a/pycbc/filter/matchedfilter.py
+++ b/pycbc/filter/matchedfilter.py
@@ -1218,7 +1218,6 @@ def matched_filter_core(template, data, psd=None, low_frequency_cutoff=None,
     kmin, kmax = get_cutoff_indices(low_frequency_cutoff,
                                    high_frequency_cutoff, stilde.delta_f, N)
 
-
     if corr_out is not None:
         qtilde = corr_out
     else:
@@ -1242,30 +1241,12 @@ def matched_filter_core(template, data, psd=None, low_frequency_cutoff=None,
         else:
             raise TypeError("PSD must be a FrequencySeries")
 
-
-    from pycbc.fft.core import _check_fft_args
-    from pycbc.fft.npfft import ifft as npifft
-    prec, itype, otype = _check_fft_args(qtilde, _q)
-    npifft(qtilde, _q, prec, itype, otype)
-    invec = qtilde
-    outvec = _q
-    if isinstance(invec, TimeSeries):
-        outvec._epoch = invec._epoch
-        outvec._delta_f = 1.0/(invec._delta_t * len(outvec))
-        outvec *= invec._delta_t
-    elif isinstance(invec, FrequencySeries):
-        outvec._epoch = invec._epoch
-        outvec._delta_t = 1.0/(invec._delta_f * len(outvec))
-        outvec *= invec._delta_f
-
-    #ifft(qtilde, _q)
+    ifft(qtilde, _q)
 
     if h_norm is None:
         h_norm = sigmasq(htilde, psd, low_frequency_cutoff, high_frequency_cutoff)
 
-
     norm = (4.0 * stilde.delta_f) / sqrt( h_norm)
-
 
     return (TimeSeries(_q, epoch=stilde._epoch, delta_t=stilde.delta_t, copy=False),
            FrequencySeries(qtilde, epoch=stilde._epoch, delta_f=stilde.delta_f, copy=False),
@@ -1751,8 +1732,7 @@ class LiveBatchMatchedFilter(object):
 def followup_event_significance(ifo, data_reader, bank,
                                 template_id, coinc_times,
                                 coinc_threshold=0.005,
-                                lookback=150, duration=0.095,
-                                override_htilde=None):
+                                lookback=150, duration=0.095):
     """ Followup an event in another detector and determine its significance
     """
     from pycbc.waveform import get_waveform_filter_length_in_time
@@ -1801,10 +1781,7 @@ def followup_event_significance(ifo, data_reader, bank,
             return None, None, None, None
 
     # Calculate SNR time series for this duration
-    if override_htilde is None:
-        htilde = bank.get_template(template_id, min_buffer=bdur)
-    else:
-        htilde = override_htilde
+    htilde = bank.get_template(template_id, min_buffer=bdur)
     stilde = data_reader.overwhitened_data(htilde.delta_f)
 
     sigma2 = htilde.sigmasq(stilde.psd)

--- a/pycbc/io/live.py
+++ b/pycbc/io/live.py
@@ -364,7 +364,7 @@ class SingleCoincForGraceDB(object):
 
             extra_strings = [] if extra_strings is None else extra_strings
             for text in extra_strings:
-                gracedb.writeLog(gid, text)
+                gracedb.writeLog(gid, text, tag_name=['analyst_comments'])
 
             # upload SNR series in HDF format and plots
             if self.snr_series is not None:


### PR DESCRIPTION
We've been considering ways to improve the skymaps that are generated by PyCBC Live. One proposed method was, following the upload of an initial trigger, to go back and optimize the SNR time series of the trigger (mostly by finding the waveform with largest SNR). For e.g. high-mass triggers might be reported currently at lower masses because of higher glitchiness at high-masses. This adds a systematic bias. Here we propose a solution by uploading a second event after optimizing the SNR time series. This might take a little time to generate (O(minute)??) but can get an improved skymap quicker than the full PE, so is kind of an intermediate step.

 * This does increase the SNR, here's an example: https://gracedb-playground.ligo.org/events/T17156/view/ https://gracedb-playground.ligo.org/events/T17157/view/ where two triggers get uploaded for the same event.
 * I haven't tried adding a followup detector into the mix, the idea is that the coinc detectors would be optimized and then the followup added with the "new" template. That *should* work already.
 * What sort of sanity checks should be done after optimizing? Should we demand time- phase- etc. consistency after maximizing?
 * Optimizing is pretty slow with the current settings (1-2 minutes). I can reduce time at the cost of accuracy, so playing with this could be useful. I have this reduced to a play case here in CIT `/home/spxiwh/tmp_testoptimize`. Maybe I chose a bad test case.
 * I need to be able to disable the FFT context to enable the optimization to use single-threaded FFTs. (The changes to matched-filter to take this apart are obviously not intended to be merged). How can I run the optimize function with a single-core FFT context?
 * I added subsample interpolation. It does little in this case.
 * The f-lower is 30 Hz. Lowering that will gain a similar increase in SNR. We should do that here (if possible).
 * Should we spawn this into a new process to stop delaying the rest of the work while this is happening? What's the best way of doing this?
 * This should be proof against failures. E.g. if something doesn't work here, don't upload a second event and just keep going.