### PR TITLE
update io to reduce memory useage

### DIFF
--- a/bin/minifollowups/pycbc_page_coincinfo
+++ b/bin/minifollowups/pycbc_page_coincinfo
@@ -116,16 +116,20 @@ else:
 table = []
 files = {}
 for fname in args.single_trigger_files:
-    f = h5py.File(fname, 'r')
-    ifos = f.keys()
+    f2 = h5py.File(fname, 'r')
+    ifos = f2.keys()
     for ifo in ifos:
-        files[ifo] = f[ifo]
+        files[ifo] = f2[ifo]
 
 bank = h5py.File(args.bank_file, 'r')
 statmapfile = d
 for ifo in files.keys():
-    if statmapfile['%s/time' % ifo][n] == -1.0:
-        continue
+
+    # ignore ifo if coinc didn't participate (only for multi-ifo workflow)
+    if ('detector_1' not in f.attrs) and \
+       (statmapfile['%s/time' % ifo][n] == -1.0):
+            continue
+
     d = files[ifo]
     i = idx[ifo]
     tid = d['template_id'][i]

--- a/bin/minifollowups/pycbc_page_snglinfo
+++ b/bin/minifollowups/pycbc_page_snglinfo
@@ -74,8 +74,8 @@ elif args.n_loudest is not None:
     # loudest
     stat = sngl_file.stat
     l = stat.argsort()
-    stat = stat[l[-1]]
-    sngl_file.mask = sngl_file.mask[l[-1]]
+    stat = stat[l[0]]
+    sngl_file.mask = sngl_file.mask[l[0]]
 else:
     raise ValueError("Must give --n-loudest or --trigger-id.")
 

--- a/bin/minifollowups/pycbc_page_snglinfo
+++ b/bin/minifollowups/pycbc_page_snglinfo
@@ -61,7 +61,7 @@ sngl_file = hdf.SingleDetTriggers(args.single_trigger_file, args.bank_file,
 
 
 if args.trigger_id is not None:
-    sngl_file.mask = numpy.array([args.trigger_id])
+    sngl_file.mask = [args.trigger_id]
     sngl_file.mask_to_n_loudest_clustered_events(n_loudest=1,
                                       ranking_statistic=args.ranking_statistic)
     stat = sngl_file.stat[0]
@@ -72,20 +72,22 @@ elif args.n_loudest is not None:
                                       ranking_statistic=args.ranking_statistic)
     # Restrict to only the nth loudest, instead of all triggers up to nth
     # loudest
-    stat = sngl_file.stat[-1]
-    sngl_file.mask = sngl_file.mask[-1]
+    stat = sngl_file.stat
+    l = stat.argsort()
+    stat = stat[l[-1]]
+    sngl_file.mask = sngl_file.mask[l[-1]]
 else:
     raise ValueError("Must give --n-loudest or --trigger-id.")
 
 # make a table for the single detector information ############################
-time = sngl_file.end_time 
+time = sngl_file.end_time
 utc = lal.GPSToUTC(int(time))[0:6]
 data = [[pycbc.results.dq.get_summary_page_link(args.instrument, utc),
         str(datetime.datetime(*utc)),
         '%.3f'  % time,
         '%5.2f' % sngl_file.snr,
         '%5.2f' % stat,
-        '%5.2f' % sngl_file.rchisq,            
+        '%5.2f' % sngl_file.rchisq,
         '%i'    % sngl_file.get_column('chisq_dof'),
         '%5.2f' % sngl_file.get_column('coa_phase'),
         '%5.2f' % sngl_file.mass1,

--- a/bin/minifollowups/pycbc_sngl_minifollowup
+++ b/bin/minifollowups/pycbc_sngl_minifollowup
@@ -142,11 +142,6 @@ trigs = hdf.SingleDetTriggers(args.single_detector_file, args.bank_file,
                               args.veto_file, args.veto_segment_name,
                               None, args.instrument, premask=snr_mask)
 
-def restrict_triggers_to_logic_mask(triggers, logic_mask):
-    orig_indices = triggers.mask.nonzero()[0][logic_mask]
-    triggers.mask[:] = False
-    triggers.mask[orig_indices] = True
-
 if args.non_coinc_time_only:
     from glue.ligolw.ligolw import LIGOLWContentHandler as h
     lsctables.use_in(h)
@@ -162,20 +157,20 @@ if args.non_coinc_time_only:
             trigs.end_time, [args.inspiral_segments],
             ifo=ifo, segment_name=args.inspiral_data_analyzed_name)
         curr_veto_mask.sort()
-        restrict_triggers_to_logic_mask(trigs, curr_veto_mask)
+        trigs.apply_mask(curr_veto_mask)
 
 if args.minimum_duration is not None:
     logging.info('applying minimum duration')
     durations = trigs.template_duration
     lgc_mask = durations > args.minimum_duration
-    restrict_triggers_to_logic_mask(trigs, lgc_mask)
+    trigs.apply_mask(lgc_mask)
     logging.info('remaining triggers: %s', trigs.mask.sum())
 
 if args.maximum_duration is not None:
     logging.info('applying maximum duration')
     durations = trigs.template_duration
     lgc_mask = durations < args.maximum_duration
-    restrict_triggers_to_logic_mask(trigs, lgc_mask)
+    trigs.apply_mask(lgc_mask)
     logging.info('remaining triggers: %s', trigs.mask.sum())
 
 if len(trigs.snr) == 0:

--- a/bin/minifollowups/pycbc_sngl_minifollowup
+++ b/bin/minifollowups/pycbc_sngl_minifollowup
@@ -45,7 +45,7 @@ def add_wiki_row(outfile, cols):
         f.write('||%s||\n' % '||'.join(map(str,cols)))
 
 parser = argparse.ArgumentParser(description=__doc__[1:])
-parser.add_argument('--version', action='version', version=pycbc.version.git_verbose_msg) 
+parser.add_argument('--version', action='version', version=pycbc.version.git_verbose_msg)
 parser.add_argument('--workflow-name', default='my_unamed_run')
 parser.add_argument("-d", "--output-dir", default=None,
                     help="Path to output directory.")
@@ -53,7 +53,7 @@ parser.add_argument('--bank-file',
                     help="HDF format template bank file")
 parser.add_argument('--single-detector-file',
                     help="HDF format merged single detector trigger files")
-parser.add_argument('--instrument', help="Name of interferometer e.g. H1") 
+parser.add_argument('--instrument', help="Name of interferometer e.g. H1")
 parser.add_argument('--veto-file',
     help="The veto file to be used if vetoing triggers (optional).")
 parser.add_argument('--veto-segment-name',
@@ -68,6 +68,8 @@ parser.add_argument('--inspiral-data-read-name',
 parser.add_argument('--inspiral-data-analyzed-name',
                     help="Name of inspiral segmentlist containing data "
                          "analyzed by each analysis job.")
+parser.add_argument('--min-snr', type=float, default=6.5,
+                    help="Minimum SNR to consider for loudest triggers")
 parser.add_argument('--ranking-statistic',
                 help="How to rank triggers when determining loudest triggers.")
 parser.add_argument('--non-coinc-time-only', default=False,
@@ -90,7 +92,7 @@ parser.add_argument('--tags', nargs='+', default=[])
 wf.add_workflow_command_line_group(parser)
 args = parser.parse_args()
 
-logging.basicConfig(format='%(asctime)s:%(levelname)s : %(message)s', 
+logging.basicConfig(format='%(asctime)s:%(levelname)s : %(message)s',
                     level=logging.INFO)
 
 workflow = wf.Workflow(args, args.workflow_name)
@@ -102,8 +104,8 @@ wf.makedir(args.output_dir)
 if args.wiki_file:
     # initialize a wiki table and add the column headers
     wiki_file = os.path.join(args.output_dir, args.wiki_file)
-    add_wiki_row(wiki_file, ['GPS time', 'UTC time', 'newSNR', 'SNR', 
-                      'm1', 'm2', 's1', 's2', 'duration', 'omega', 'notes', 
+    add_wiki_row(wiki_file, ['GPS time', 'UTC time', 'newSNR', 'SNR',
+                      'm1', 'm2', 's1', 's2', 'duration', 'omega', 'notes',
                       'veto'])
 
 # create a FileList that will contain all output files
@@ -124,9 +126,26 @@ insp_data_seglists.coalesce()
 num_events = int(workflow.cp.get_opt_tags('workflow-sngl_minifollowups',
                  'num-sngl-events', ''))
 
+# This helps speed up the processing to ignore a large fraction of triggers
+snr_mask = None
+if args.min_snr:
+    logging.info('Calculating Prefilter')
+    f = hdf.HFile(args.single_detector_file, 'r')
+    idx, _ = f.select(lambda snr: snr > args.min_snr,
+                      '{}/snr'.format(args.instrument),
+                      return_indices=True)
+    snr_mask = numpy.zeros(len(f['{}/snr'.format(args.instrument)]),
+                           dtype=bool)
+    snr_mask[idx] = True
+
 trigs = hdf.SingleDetTriggers(args.single_detector_file, args.bank_file,
                               args.veto_file, args.veto_segment_name,
-                              None, args.instrument)
+                              None, args.instrument, premask=snr_mask)
+
+def restrict_triggers_to_logic_mask(triggers, logic_mask):
+    orig_indices = triggers.mask.nonzero()[0][logic_mask]
+    triggers.mask[:] = False
+    triggers.mask[orig_indices] = True
 
 if args.non_coinc_time_only:
     from glue.ligolw.ligolw import LIGOLWContentHandler as h
@@ -142,26 +161,22 @@ if args.non_coinc_time_only:
         curr_veto_mask, segs = pycbc.events.veto.indices_outside_segments(
             trigs.end_time, [args.inspiral_segments],
             ifo=ifo, segment_name=args.inspiral_data_analyzed_name)
-        trigs.mask = trigs.mask[curr_veto_mask]
-
-def restrict_triggers_to_logic_mask(triggers, logic_mask):
-    if triggers.mask.dtype == 'bool':
-        orig_indices = triggers.mask.nonzero()[0][logic_mask]
-        triggers.mask = numpy.in1d(numpy.arange(len(triggers.mask)),
-                                                orig_indices,
-                                                assume_unique=True)
-    else:
-        triggers.mask = triggers.mask[logic_mask]
+        curr_veto_mask.sort()
+        restrict_triggers_to_logic_mask(trigs, curr_veto_mask)
 
 if args.minimum_duration is not None:
+    logging.info('applying minimum duration')
     durations = trigs.template_duration
     lgc_mask = durations > args.minimum_duration
     restrict_triggers_to_logic_mask(trigs, lgc_mask)
+    logging.info('remaining triggers: %s', trigs.mask.sum())
+
 if args.maximum_duration is not None:
+    logging.info('applying maximum duration')
     durations = trigs.template_duration
     lgc_mask = durations < args.maximum_duration
     restrict_triggers_to_logic_mask(trigs, lgc_mask)
-    
+    logging.info('remaining triggers: %s', trigs.mask.sum())
 
 if len(trigs.snr) == 0:
     # There are no triggers, make no-op job and exit
@@ -171,9 +186,9 @@ if len(trigs.snr) == 0:
                   transformation_catalog_path=args.transformation_catalog)
     sys.exit(0)
 
+logging.info('finding loudest clustered events')
 trigs.mask_to_n_loudest_clustered_events(n_loudest=num_events,
                                       ranking_statistic=args.ranking_statistic)
-
 if len(trigs.stat) < num_events:
     num_events = len(trigs.stat)
 
@@ -181,20 +196,23 @@ times = trigs.end_time
 tids = trigs.template_id
 
 # loop over number of loudest events to be followed up
-for num_event in range(num_events):
+order = trigs.stat.argsort()
+for rank, num_event in enumerate(order):
+    logging.info('Processing event: %s', num_event)
+
     files = wf.FileList([])
     time = times[num_event]
     ifo_time = '%s:%s' %(args.instrument, str(time))
     tid = trigs.mask[num_event]
     ifo_tid = '%s:%s' %(args.instrument, str(tid))
-    
+
     layouts += (mini.make_sngl_ifo(workflow, sngl_file, tmpltbank_file,
                                    tid, args.output_dir, args.instrument,
-                                   tags=args.tags + [str(num_event)],
-                                   rank=num_event),)
+                                   tags=args.tags + [str(rank)],
+                                   rank=rank),)
     files += mini.make_trigger_timeseries(workflow, [sngl_file],
                               ifo_time, args.output_dir, special_tids=ifo_tid,
-                              tags=args.tags + [str(num_event)])
+                              tags=args.tags + [str(rank)])
     curr_params = {}
     curr_params['mass1'] = trigs.mass1[num_event]
     curr_params['mass2'] = trigs.mass2[num_event]
@@ -218,7 +236,7 @@ for num_event in range(num_events):
         pass
 
     if wiki_file:
-        add_wiki_row(wiki_file, [time, 
+        add_wiki_row(wiki_file, [time,
                           str(datetime.datetime(*GPSToUTC(int(time))[0:6])),
                           trigs.stat[num_event], trigs.snr[num_event],
                           curr_params['mass1'], curr_params['mass2'],
@@ -228,26 +246,25 @@ for num_event in range(num_events):
     files += mini.make_single_template_plots(workflow, insp_segs,
                             args.inspiral_data_read_name,
                             args.inspiral_data_analyzed_name, curr_params,
-                            args.output_dir, 
-                            tags=args.tags+[str(num_event)])
+                            args.output_dir,
+                            tags=args.tags+[str(rank)])
 
     files += mini.make_plot_waveform_plot(workflow, curr_params,
                                         args.output_dir, [args.instrument],
-                                        tags=args.tags + [str(num_event)])
+                                        tags=args.tags + [str(rank)])
 
 
-    files += mini.make_singles_timefreq(workflow, sngl_file, tmpltbank_file, 
+    files += mini.make_singles_timefreq(workflow, sngl_file, tmpltbank_file,
                             time, args.output_dir,
                             data_segments=insp_data_seglists,
-                            tags=args.tags + [str(num_event)])                 
+                            tags=args.tags + [str(rank)])
 
     files += mini.make_qscan_plot(workflow, args.instrument, time,
                                   args.output_dir,
                                   data_segments=insp_data_seglists,
-                                  tags=args.tags + [str(num_event)])
+                                  tags=args.tags + [str(rank)])
 
     layouts += list(layout.grouper(files, 2))
-    num_event += 1
 
 workflow.save(filename=args.output_file, output_map_path=args.output_map,
               transformation_catalog_path=args.transformation_catalog)

--- a/pycbc/io/hdf.py
+++ b/pycbc/io/hdf.py
@@ -457,7 +457,7 @@ class SingleDetTriggers(object):
 
     def apply_mask(self, logic_mask):
         """Apply a boolean array to the set of triggers"""
-        if hasattr(self.mask, 'dtype') and (self.mask.dtype == 'bool')
+        if hasattr(self.mask, 'dtype') and (self.mask.dtype == 'bool'):
             orig_indices = self.mask.nonzero()[0][logic_mask]
             self.mask[:] = False
             self.mask[orig_indices] = True

--- a/pycbc/io/hdf.py
+++ b/pycbc/io/hdf.py
@@ -462,7 +462,7 @@ class SingleDetTriggers(object):
             self.mask[:] = False
             self.mask[orig_indices] = True
         else:
-            self.mask = list(numpy.array(self.mask)[logic_mask])
+            self.mask = list(np.array(self.mask)[logic_mask])
 
     def mask_to_n_loudest_clustered_events(self, n_loudest=10,
                                            ranking_statistic="newsnr",

--- a/pycbc/io/hdf.py
+++ b/pycbc/io/hdf.py
@@ -409,8 +409,8 @@ class SingleDetTriggers(object):
             logging.info('%i triggers remain after vetoes',
                           len(self.veto_mask))
 
-        ### FIXME this should use the hfile select interface to avoid
-        ### memory and processing limitations.
+        # FIXME this should use the hfile select interface to avoid
+        # memory and processing limitations.
         if filter_func:
             # get required columns into the namespace with dummy attribute
             # names to avoid confusion with other class properties
@@ -454,6 +454,15 @@ class SingleDetTriggers(object):
         """Returns a list of plottable CBC parameter variables"""
         return [m[0] for m in inspect.getmembers(cls) \
             if type(m[1]) == property]
+
+    def apply_mask(self, logic_mask):
+        """Apply a boolean array to the set of triggers"""
+        if hasattr(self.mask, 'dtype') and (self.mask.dtype == 'bool')
+            orig_indices = self.mask.nonzero()[0][logic_mask]
+            self.mask[:] = False
+            self.mask[orig_indices] = True
+        else:
+            self.mask = list(numpy.array(self.mask)[logic_mask])
 
     def mask_to_n_loudest_clustered_events(self, n_loudest=10,
                                            ranking_statistic="newsnr",


### PR DESCRIPTION
I'm trying to get the workflow to complete more consistently when handling larger numbers of triggers and some of the post-processing is unnecessarily choking. 

So far this patch addresses memory / performance issues with 

* pycbc_page_snglinfo 
    * original useage in my 2-ogc runs peaked at ~79 GB of memory.
    * ~ 50 x reduction in memory and compute time when following up a known trigger id 
* Single minifollowup workflow generator (also had to check it ran after changes to single triggers class)