### PR TITLE
change coinc options to allow multiple decimation levels

### DIFF
--- a/bin/hdfcoinc/pycbc_coinc_findtrigs
+++ b/bin/hdfcoinc/pycbc_coinc_findtrigs
@@ -33,8 +33,9 @@ parser.add_argument("--timeslide-interval", type=float,
                          "disabled if the option is omitted.")
 parser.add_argument("--decimation-factor", type=int,
                     help="The factor to reduce the background trigger rate.")
-parser.add_argument("--loudest-keep-value", type=float,
-                     help="Keep all coincident triggers above this value.")
+parser.add_argument("--loudest-keep-values", type=str, nargs='*',
+                     help="Apply a sequence of decimations at the givne thresholds"
+                          "Ex. 8.5:10 8:10 7.5:10 7:10")
 parser.add_argument("--template-fraction-range", default="0/1",
                     help="Optional, analyze only part of template bank. Format"
                     " PART/NUM_PARTS")
@@ -274,18 +275,30 @@ for tnum in template_ids:
             # "bl_int" keeps track of which triggers are *not* in the bh set. Depending
             # on the decimation factor option we may not store any of these or we may
             # keep a fraction of them corresponding to a subset of the timeslides
-            if args.loudest_keep_value:
-                bh = bi[c[bi] > args.loudest_keep_value]
-                bl_int = bi[c[bi] <= args.loudest_keep_value]
-            else:
-                bh = bi
+            bi_dec = bi.copy()
+            dec = numpy.ones(len(bi))
 
-            if args.decimation_factor:
-                bl = bl_int[slide[bl_int] % args.decimation_factor == 0]
-            else:
-                bl = []
+            total_factor = 1
+            for decstr in args.loudest_keep_values:
+                thresh, factor = decstr.split(':')
+                thresh = float(thresh)
+                factor = int(factor)
+                total_factor *= factor
 
-            ti = numpy.concatenate([bl, bh, fi]).astype(numpy.uint32)
+                # triggers not being further decimated
+                idxk = bi_dec[c[bi_dec] >= thresh]
+
+                # we'll decimate these triggers now
+                idx = bi_dec[c[bi_dec] < thresh]
+                idx = idx[slide[idx] % total_factor == 0]
+
+                bi_dec = numpy.concatenate(idxk, idx)
+                dec = numpy.concatenate([dec[idxk],
+                                        numpy.repeat(total_factor, len(idx))]
+                                       )
+
+            ti = numpy.concatenate([bi_dec, fi]).astype(numpy.uint32)
+            dec_factor = numpy.concatenate([dec, numpy.ones(len(fi))])
             logging.info('%s after decimation' % len(ti))
 
             g0 = i0[ti]
@@ -294,10 +307,6 @@ for tnum in template_ids:
             del i1
 
             data['stat'] += [c[ti]]
-            dec_fac = numpy.repeat([args.decimation_factor, 1, 1],
-                                   [len(bl),
-                                    len(bh),
-                                    len(fi)]).astype(numpy.uint32)
             data['decimation_factor'] += [dec_fac]
             data['time1'] += [t0[g0]]
             data['time2'] += [t1[g1]]

--- a/bin/hdfcoinc/pycbc_coinc_findtrigs
+++ b/bin/hdfcoinc/pycbc_coinc_findtrigs
@@ -31,8 +31,6 @@ parser.add_argument("--coinc-threshold", type=float, default=0.0,
 parser.add_argument("--timeslide-interval", type=float,
                     help="Interval between timeslides in seconds. Timeslides are "
                          "disabled if the option is omitted.")
-parser.add_argument("--decimation-factor", type=int,
-                    help="The factor to reduce the background trigger rate.")
 parser.add_argument("--loudest-keep-values", type=str, nargs='*',
                      help="Apply a sequence of decimations at the givne thresholds"
                           "Ex. 8.5:10 8:10 7.5:10 7:10")
@@ -286,19 +284,20 @@ for tnum in template_ids:
                 total_factor *= factor
 
                 # triggers not being further decimated
-                idxk = bi_dec[c[bi_dec] >= thresh]
+                upper = c[bi_dec] >= thresh
+                idxk = bi_dec[upper]
 
                 # we'll decimate these triggers now
                 idx = bi_dec[c[bi_dec] < thresh]
                 idx = idx[slide[idx] % total_factor == 0]
 
-                bi_dec = numpy.concatenate(idxk, idx)
-                dec = numpy.concatenate([dec[idxk],
+                bi_dec = numpy.concatenate([idxk, idx])
+                dec = numpy.concatenate([dec[upper],
                                         numpy.repeat(total_factor, len(idx))]
                                        )
 
             ti = numpy.concatenate([bi_dec, fi]).astype(numpy.uint32)
-            dec_factor = numpy.concatenate([dec, numpy.ones(len(fi))])
+            dec_fac = numpy.concatenate([dec, numpy.ones(len(fi))])
             logging.info('%s after decimation' % len(ti))
 
             g0 = i0[ti]

--- a/bin/hdfcoinc/pycbc_coinc_findtrigs
+++ b/bin/hdfcoinc/pycbc_coinc_findtrigs
@@ -33,10 +33,7 @@ parser.add_argument("--timeslide-interval", type=float,
                          "disabled if the option is omitted.")
 parser.add_argument("--decimation-factor", type=int,
                     help="The factor to reduce the background trigger rate.")
-loudest = parser.add_mutually_exclusive_group()
-loudest.add_argument("--loudest-keep", type=int,
-                     help="Keep this number of loudest triggers from each template.")
-loudest.add_argument("--loudest-keep-value", type=float,
+parser.add_argument("--loudest-keep-value", type=float,
                      help="Keep all coincident triggers above this value.")
 parser.add_argument("--template-fraction-range", default="0/1",
                     help="Optional, analyze only part of template bank. Format"
@@ -277,16 +274,7 @@ for tnum in template_ids:
             # "bl_int" keeps track of which triggers are *not* in the bh set. Depending
             # on the decimation factor option we may not store any of these or we may
             # keep a fraction of them corresponding to a subset of the timeslides
-            if args.loudest_keep:
-                sep = len(bi) - args.loudest_keep
-                sep = 0 if sep < 0 else sep
-
-                bsort = numpy.argpartition(c[bi], sep)
-                bl_int = bi[bsort[0:sep]]
-                bh = bi[bsort[sep:]]
-                del bsort
-                del bi
-            elif args.loudest_keep_value:
+            if args.loudest_keep_value:
                 bh = bi[c[bi] > args.loudest_keep_value]
                 bl_int = bi[c[bi] <= args.loudest_keep_value]
             else:

--- a/bin/hdfcoinc/pycbc_multiifo_coinc_findtrigs
+++ b/bin/hdfcoinc/pycbc_multiifo_coinc_findtrigs
@@ -34,8 +34,6 @@ parser.add_argument("--coinc-threshold", type=float, default=0.0,
 parser.add_argument("--timeslide-interval", type=float,
                     help="Interval between timeslides in seconds. Timeslides are "
                          "disabled if the option is omitted.")
-parser.add_argument("--decimation-factor", type=int,
-                    help="The factor to reduce the background trigger rate.")
 parser.add_argument("--loudest-keep-values", type=str, nargs='*',
                      help="Apply a sequence of decimations at the givne thresholds"
                           "Ex. 8.5:10 8:10 7.5:10 7:10")
@@ -301,19 +299,20 @@ for tnum in template_ids:
                 total_factor *= factor
 
                 # triggers not being further decimated
-                idxk = bi_dec[c[bi_dec] >= thresh]
+                upper = c[bi_dec] >= thresh
+                idxk = bi_dec[upper]
 
                 # we'll decimate these triggers now
                 idx = bi_dec[c[bi_dec] < thresh]
                 idx = idx[slide[idx] % total_factor == 0]
 
-                bi_dec = numpy.concatenate(idxk, idx)
-                dec = numpy.concatenate([dec[idxk],
+                bi_dec = numpy.concatenate([idxk, idx])
+                dec = numpy.concatenate([dec[upper],
                                         numpy.repeat(total_factor, len(idx))]
                                        )
 
             ti = numpy.concatenate([bi_dec, fi]).astype(numpy.uint32)
-            dec_factor = numpy.concatenate([dec, numpy.ones(len(fi))])
+            dec_fac = numpy.concatenate([dec, numpy.ones(len(fi))])
             logging.info('%s after decimation' % len(ti))
 
             gs={}

--- a/bin/hdfcoinc/pycbc_multiifo_coinc_findtrigs
+++ b/bin/hdfcoinc/pycbc_multiifo_coinc_findtrigs
@@ -36,8 +36,9 @@ parser.add_argument("--timeslide-interval", type=float,
                          "disabled if the option is omitted.")
 parser.add_argument("--decimation-factor", type=int,
                     help="The factor to reduce the background trigger rate.")
-parser.add_argument("--loudest-keep-value", type=float,
-                     help="Keep all coincident triggers above this value.")
+parser.add_argument("--loudest-keep-values", type=str, nargs='*',
+                     help="Apply a sequence of decimations at the givne thresholds"
+                          "Ex. 8.5:10 8:10 7.5:10 7:10")
 parser.add_argument("--template-fraction-range", default="0/1",
                     help="Optional, analyze only part of template bank. Format"
                     " PART/NUM_PARTS")
@@ -289,18 +290,30 @@ for tnum in template_ids:
             # "bl_int" keeps track of which triggers are *not* in the bh set. Depending
             # on the decimation factor option we may not store any of these or we may
             # keep a fraction of them corresponding to a subset of the timeslides
-            if args.loudest_keep_value:
-                bh = bi[c[bi] > args.loudest_keep_value]
-                bl_int = bi[c[bi] <= args.loudest_keep_value]
-            else:
-                bh = bi
+            bi_dec = bi.copy()
+            dec = numpy.ones(len(bi))
 
-            if args.decimation_factor:
-                bl = bl_int[slide[bl_int] % args.decimation_factor == 0]
-            else:
-                bl = []
+            total_factor = 1
+            for decstr in args.loudest_keep_values:
+                thresh, factor = decstr.split(':')
+                thresh = float(thresh)
+                factor = int(factor)
+                total_factor *= factor
 
-            ti = numpy.concatenate([bl, bh, fi]).astype(numpy.uint32)
+                # triggers not being further decimated
+                idxk = bi_dec[c[bi_dec] >= thresh]
+
+                # we'll decimate these triggers now
+                idx = bi_dec[c[bi_dec] < thresh]
+                idx = idx[slide[idx] % total_factor == 0]
+
+                bi_dec = numpy.concatenate(idxk, idx)
+                dec = numpy.concatenate([dec[idxk],
+                                        numpy.repeat(total_factor, len(idx))]
+                                       )
+
+            ti = numpy.concatenate([bi_dec, fi]).astype(numpy.uint32)
+            dec_factor = numpy.concatenate([dec, numpy.ones(len(fi))])
             logging.info('%s after decimation' % len(ti))
 
             gs={}
@@ -324,8 +337,6 @@ for tnum in template_ids:
                     data['%s/time' % ifo] = [addtime]
                     data['%s/trigger_id' % ifo] = [addtriggerid]
             data['stat'] += [c[ti]]
-            dec_fac = numpy.repeat([args.decimation_factor, 1, 1],
-                                   [len(bl), len(bh), len(fi)]).astype(numpy.uint32)
             data['decimation_factor'] += [dec_fac]
             data['timeslide_id'] += [slide[ti]]
             data['template_id'] += [numpy.zeros(len(ti), dtype=numpy.uint32) + tnum]

--- a/bin/hdfcoinc/pycbc_multiifo_coinc_findtrigs
+++ b/bin/hdfcoinc/pycbc_multiifo_coinc_findtrigs
@@ -36,10 +36,7 @@ parser.add_argument("--timeslide-interval", type=float,
                          "disabled if the option is omitted.")
 parser.add_argument("--decimation-factor", type=int,
                     help="The factor to reduce the background trigger rate.")
-loudest = parser.add_mutually_exclusive_group()
-loudest.add_argument("--loudest-keep", type=int,
-                     help="Keep this number of loudest triggers from each template.")
-loudest.add_argument("--loudest-keep-value", type=float,
+parser.add_argument("--loudest-keep-value", type=float,
                      help="Keep all coincident triggers above this value.")
 parser.add_argument("--template-fraction-range", default="0/1",
                     help="Optional, analyze only part of template bank. Format"
@@ -292,16 +289,7 @@ for tnum in template_ids:
             # "bl_int" keeps track of which triggers are *not* in the bh set. Depending
             # on the decimation factor option we may not store any of these or we may
             # keep a fraction of them corresponding to a subset of the timeslides
-            if args.loudest_keep:
-                sep = len(bi) - args.loudest_keep
-                sep = 0 if sep < 0 else sep
-
-                bsort = numpy.argpartition(c[bi], sep)
-                bl_int = bi[bsort[0:sep]]
-                bh = bi[bsort[sep:]]
-                del bsort
-                del bi
-            elif args.loudest_keep_value:
+            if args.loudest_keep_value:
                 bh = bi[c[bi] > args.loudest_keep_value]
                 bl_int = bi[c[bi] <= args.loudest_keep_value]
             else:


### PR DESCRIPTION
Make the coinc code more flexible in terms of decimation levels. This *changes* the options to findtrigs

The new decimation option is 
```
--loudest-keep-values 9:10 8.5:100 8.0:100 7.5:10
```

Decimation is applied from left to right, so this can be read as (decimate all triggers < 9 by 10x) then (decimate remaining triggers < 8.5 by another 100x) and so on...