### PR TITLE
Python3 compatibility in workflow generation

### DIFF
--- a/bin/bank/pycbc_geom_aligned_bank
+++ b/bin/bank/pycbc_geom_aligned_bank
@@ -25,7 +25,6 @@ in a workflow.
 
 from __future__ import division
 import os
-import six
 import copy
 import argparse
 import tempfile

--- a/bin/bank/pycbc_geom_aligned_bank
+++ b/bin/bank/pycbc_geom_aligned_bank
@@ -25,10 +25,11 @@ in a workflow.
 
 from __future__ import division
 import os
+import six
 import copy
 import argparse
 import tempfile
-import ConfigParser
+from six.moves import configparser as ConfigParser
 import numpy
 import logging
 import distutils.spawn

--- a/bin/pycbc_make_banksim
+++ b/bin/pycbc_make_banksim
@@ -1,8 +1,8 @@
 #! /usr/bin/env python
-import logging
+import logging, six
 import os
 import shutil
-import ConfigParser
+from six.moves import configparser as ConfigParser
 import subprocess
 import glob
 import tempfile

--- a/bin/pycbc_make_banksim
+++ b/bin/pycbc_make_banksim
@@ -180,7 +180,7 @@ mkdir('plots')
 
 logging.info("Copying scripts")
 shutil.copy(banksim_prog, 'scripts/pycbc_banksim')
-os.chmod('scripts/pycbc_banksim', 0777)
+os.chmod('scripts/pycbc_banksim', 0o0777)
 
 logging.info("Creating injection file")
 inj_str = "lalapps_inspinj " + get_ini_opts(confs, "inspinj") + "--output inj.xml"
@@ -285,7 +285,7 @@ for i, j in enumerate(indices):
 maxmatch=array(maxmatch, dtype =dtypef)
 savetxt(options.output_file, maxmatch,fmt=('%5.5f', '%s', '%i', '%s', '%i', '%5.5f'), delimiter=' ')
 """)
-os.chmod('scripts/pycbc_banksim_match_combine', 0777)
+os.chmod('scripts/pycbc_banksim_match_combine', 0o0777)
 
 f = open("scripts/pycbc_banksim_collect_results", "w")
 f.write("""#!/usr/bin/env python
@@ -360,7 +360,7 @@ for row in res:
     
     f.write(outstr)
 """)
-os.chmod('scripts/pycbc_banksim_collect_results', 0777)
+os.chmod('scripts/pycbc_banksim_collect_results', 0o0777)
 
 if gpu:
     f = open("cconfig", "w")
@@ -418,7 +418,7 @@ if gpu:
 
     exit 0
     """)
-    os.chmod('scripts/diff_match.sh', 0777)
+    os.chmod('scripts/diff_match.sh', 0o0777)
     
 logging.info("Creating submit script")
 f = open("submit.sh","w")
@@ -430,13 +430,13 @@ else:
     f.write("""#!/bin/bash
     condor_submit_dag banksim.dag
     """)
-os.chmod('submit.sh', 0777)
+os.chmod('submit.sh', 0o0777)
 
 f = open("partial_results.sh", "w")
 f.write("""#!/bin/bash
 scripts/pycbc_banksim_collect_results
 """)
-os.chmod('partial_results.sh', 0777)
+os.chmod('partial_results.sh', 0o0777)
 
 dag.write_sub_files()
 dag.write_script()
@@ -560,6 +560,6 @@ mplot(q, ispin1z, (imchirp-tmchirp)/imchirp, "plots/q-s1z-mchirpreldiff.png")
 mplot(q, ispin2z, (imchirp-tmchirp)/imchirp, "plots/q-s2z-mchirpreldiff.png")
 
 """)
-os.chmod("scripts/pycbc_banksim_plots", 0777)
+os.chmod("scripts/pycbc_banksim_plots", 0o0777)
 
 logging.info("Done")

--- a/bin/pycbc_make_banksim
+++ b/bin/pycbc_make_banksim
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-import logging, six
+import logging
 import os
 import shutil
 from six.moves import configparser as ConfigParser

--- a/bin/pycbc_make_faithsim
+++ b/bin/pycbc_make_faithsim
@@ -1,8 +1,8 @@
 #! /usr/bin/env python
-import os
+import os, six
 import logging
 import shutil
-import ConfigParser
+from six.moves import configparser as ConfigParser
 import subprocess
 import glob
 import tempfile

--- a/bin/pycbc_make_faithsim
+++ b/bin/pycbc_make_faithsim
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-import os, six
+import os
 import logging
 import shutil
 from six.moves import configparser as ConfigParser

--- a/bin/pycbc_make_faithsim
+++ b/bin/pycbc_make_faithsim
@@ -96,7 +96,7 @@ mkdir('plots')
 
 logging.info("Copying scripts")
 shutil.copy(banksim_prog, 'scripts/pycbc_faithsim')
-os.chmod('scripts/pycbc_faithsim', 0777)
+os.chmod('scripts/pycbc_faithsim', 0o0777)
 
 logging.info("Creating injection file")
 inj_str = "lalapps_inspinj " + get_ini_opts(confs, "inspinj") + "--output inj.xml"
@@ -199,14 +199,14 @@ if __name__ == "__main__":
             data = append(data, pdata)
         savetxt('result-' + tag + '.dat', data)
 """)
-os.chmod('scripts/pycbc_faithsim_collect_results', 0777)
+os.chmod('scripts/pycbc_faithsim_collect_results', 0o0777)
     
 logging.info("Creating submit script")
 f = open("submit.sh", 'w')
 f.write("""#!/bin/bash
 condor_submit_dag faithsim.dag
 """)
-os.chmod('submit.sh', 0777)
+os.chmod('submit.sh', 0o0777)
 
 dag.write_sub_files()
 dag.write_script()
@@ -400,6 +400,6 @@ for fil in fils:
     name = pname + 'scatter' + v1 + '-' + v2 + '-' + v3
     basic_scatter(name, v1, v2, tag, v1d, v2d, v3d, v3, vmin=None, vmax=None)     
  """)
-os.chmod('scripts/pycbc_faithsim_plots', 0777)
+os.chmod('scripts/pycbc_faithsim_plots', 0o0777)
 
 logging.info('Done')

--- a/bin/workflows/pycbc_create_offline_search_workflow
+++ b/bin/workflows/pycbc_create_offline_search_workflow
@@ -691,7 +691,7 @@ container._adag.addDependency(dep)
 container.save()
 
 # Protect the open box results folder
-# os.chmod(rdir['open_box_result'], 0700)
+# os.chmod(rdir['open_box_result'], 0o0700)
 logging.info("Written dax.")
 
 # Close the log and flush to the html file

--- a/bin/workflows/pycbc_create_offline_search_workflow
+++ b/bin/workflows/pycbc_create_offline_search_workflow
@@ -29,7 +29,7 @@ __program__ = "pycbc_offline"
 import sys
 import socket
 import pycbc.events, pycbc.workflow as wf
-import os, argparse, logging, six
+import os, argparse, logging
 from six.moves import configparser as ConfigParser
 from ligo import segments
 import numpy, lal, datetime, itertools

--- a/bin/workflows/pycbc_create_offline_search_workflow
+++ b/bin/workflows/pycbc_create_offline_search_workflow
@@ -29,7 +29,8 @@ __program__ = "pycbc_offline"
 import sys
 import socket
 import pycbc.events, pycbc.workflow as wf
-import os, argparse, ConfigParser, logging
+import os, argparse, logging, six
+from six.moves import configparser as ConfigParser
 from ligo import segments
 import numpy, lal, datetime, itertools
 from pycbc.results import create_versioning_page, static_table, layout

--- a/bin/workflows/pycbc_make_coinc_search_workflow
+++ b/bin/workflows/pycbc_make_coinc_search_workflow
@@ -29,7 +29,7 @@ __program__ = "pycbc_make_coinc_search_workflow"
 import sys
 import socket
 import pycbc.events, pycbc.workflow as wf
-import os, argparse, six, logging
+import os, argparse, logging
 from six.moves import configparser as ConfigParser
 from ligo import segments
 import numpy, lal, datetime

--- a/bin/workflows/pycbc_make_coinc_search_workflow
+++ b/bin/workflows/pycbc_make_coinc_search_workflow
@@ -29,7 +29,8 @@ __program__ = "pycbc_make_coinc_search_workflow"
 import sys
 import socket
 import pycbc.events, pycbc.workflow as wf
-import os, argparse, ConfigParser, logging
+import os, argparse, six, logging
+from six.moves import configparser as ConfigParser
 from ligo import segments
 import numpy, lal, datetime
 from pycbc.results import create_versioning_page, static_table, layout

--- a/bin/workflows/pycbc_make_coinc_search_workflow
+++ b/bin/workflows/pycbc_make_coinc_search_workflow
@@ -601,7 +601,7 @@ layout.two_column_layout(rdir.base, summ)
 base = rdir['workflow/configuration']
 wf.makedir(base)
 ini_file_path = os.path.join(base, 'configuration.ini')
-with open(ini_file_path, 'wb') as ini_fh:
+with open(ini_file_path, 'w') as ini_fh:
     container.cp.write(ini_fh)
 ini_file = wf.FileList([wf.File(workflow.ifos, '', workflow.analysis_time,
                         file_url='file://'+ini_file_path)])

--- a/bin/workflows/pycbc_make_coinc_search_workflow
+++ b/bin/workflows/pycbc_make_coinc_search_workflow
@@ -643,7 +643,7 @@ container._adag.addDependency(dep)
 container.save()
 
 # Protect the open box results folder
-os.chmod(rdir['open_box_result'], 0700)
+os.chmod(rdir['open_box_result'], 0o0700)
 
 logging.info("Written dax.")
 

--- a/pycbc/distributions/angular.py
+++ b/pycbc/distributions/angular.py
@@ -17,10 +17,7 @@ This modules provides classes for evaluating angular distributions.
 """
 
 import numpy
-try:
-    from ConfigParser import Error
-except ImportError:
-    from configparser import Error
+from six.moves.configparser import Error
 from pycbc import VARARGS_DELIM
 from pycbc import boundaries
 from pycbc.distributions import bounded

--- a/pycbc/distributions/angular.py
+++ b/pycbc/distributions/angular.py
@@ -16,8 +16,8 @@
 This modules provides classes for evaluating angular distributions.
 """
 
-import numpy
 from six.moves.configparser import Error
+import numpy
 from pycbc import VARARGS_DELIM
 from pycbc import boundaries
 from pycbc.distributions import bounded

--- a/pycbc/distributions/bounded.py
+++ b/pycbc/distributions/bounded.py
@@ -17,10 +17,7 @@ This modules provides classes for evaluating distributions with bounds.
 """
 
 import warnings
-try:
-    from ConfigParser import Error
-except ImportError:
-    from configparser import Error
+from six.moves.configparser import Error
 from pycbc import boundaries
 from pycbc import VARARGS_DELIM
 

--- a/pycbc/events/coinc.py
+++ b/pycbc/events/coinc.py
@@ -853,13 +853,13 @@ class LiveCoincTimeslideBackgroundEstimator(object):
 
     def save_state(self, filename):
         """Save the current state of the background buffers"""
-        import cPickle
+        from six.moves import cPickle
         cPickle.dump(self, filename)
 
     @staticmethod
     def restore_state(filename):
         """Restore state of the background buffers from a file"""
-        import cPickle
+        from six.moves import cPickle
         return cPickle.load(filename)
 
     def ifar(self, coinc_stat):

--- a/pycbc/inference/models/gaussian_noise.py
+++ b/pycbc/inference/models/gaussian_noise.py
@@ -16,8 +16,8 @@
 """This module provides model classes that assume the noise is Gaussian.
 """
 
-import logging
-from ConfigParser import NoSectionError, NoOptionError
+import logging, six
+from six.moves.configParser import NoSectionError, NoOptionError
 
 import numpy
 

--- a/pycbc/inference/models/gaussian_noise.py
+++ b/pycbc/inference/models/gaussian_noise.py
@@ -16,7 +16,7 @@
 """This module provides model classes that assume the noise is Gaussian.
 """
 
-import logging, six
+import logging
 from six.moves.configParser import NoSectionError, NoOptionError
 
 import numpy

--- a/pycbc/inference/models/gaussian_noise.py
+++ b/pycbc/inference/models/gaussian_noise.py
@@ -17,7 +17,7 @@
 """
 
 import logging
-from six.moves.configParser import NoSectionError, NoOptionError
+from six.moves.configparser import NoSectionError, NoOptionError
 
 import numpy
 

--- a/pycbc/results/render.py
+++ b/pycbc/results/render.py
@@ -16,7 +16,7 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-import os.path, types, six
+import os.path, types
 import codecs
 
 from six.moves.configparser import ConfigParser

--- a/pycbc/results/render.py
+++ b/pycbc/results/render.py
@@ -16,10 +16,10 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-import os.path, types
+import os.path, types, six
 import codecs
 
-from ConfigParser import ConfigParser
+from six.moves.configparser import ConfigParser
 from jinja2 import Environment, FileSystemLoader
 from xml.sax.saxutils import unescape
 

--- a/pycbc/results/versioning.py
+++ b/pycbc/results/versioning.py
@@ -161,7 +161,8 @@ def write_code_versions(path, cp):
     code_version_dict = get_code_version_numbers(cp)
     html_text = ''
     for key,value in code_version_dict.items():
-        html_text+= '<li><b>%s</b>:<br><pre>%s</pre></li><hr><br><br>\n' %(key,value.replace('@', '&#64;'))
+        html_text+= '<li><b>%s</b>:<br><pre>%s</pre></li><hr><br><br>\n' \
+            % (key, str(value).replace('@', '&#64;'))
     kwds = {'render-function' : 'render_text',
             'title' : 'Version Information from Executables',
     }

--- a/pycbc/results/versioning.py
+++ b/pycbc/results/versioning.py
@@ -161,6 +161,13 @@ def write_code_versions(path, cp):
     code_version_dict = get_code_version_numbers(cp)
     html_text = ''
     for key,value in code_version_dict.items():
+        # value might be a str or a bytes object in python3. python2 is happy
+        # to combine these objects (or uniocde and str, their equivalents)
+        # but python3 is not.
+        try:
+            value = value.decode()
+        except AttributeError:
+            pass
         html_text+= '<li><b>%s</b>:<br><pre>%s</pre></li><hr><br><br>\n' \
             % (key, str(value).replace('@', '&#64;'))
     kwds = {'render-function' : 'render_text',

--- a/pycbc/workflow/configuration.py
+++ b/pycbc/workflow/configuration.py
@@ -164,8 +164,11 @@ def istext(s, text_characters=None, threshold=0.3):
         # Get the substring of s made up of non-text characters
         t = s.translate(_null_trans, text_characters)
     else:
-        trans = str.maketrans('', '', text_characters)
-        t = s.translate(trans)
+        # Not yet sure how to deal with this in python3. Will need example.
+        return True
+        
+        #trans = str.maketrans('', '', text_characters)
+        #t = s.translate(trans)
 
     # s is 'text' if less than 30% of its characters are non-text ones:
     return len(t)/float(len(s)) <= threshold

--- a/pycbc/workflow/configuration.py
+++ b/pycbc/workflow/configuration.py
@@ -151,8 +151,6 @@ def istext(s, text_characters=None, threshold=0.3):
     Code modified from
     https://www.safaribooksonline.com/library/view/python-cookbook-2nd/0596007973/ch01s12.html
     """
-    text_characters = "".join(map(chr, range(32, 127))) + "\n\r\t\b"
-    _null_trans = string.maketrans("", "")
     # if s contains any null, it's not text:
     if "\0" in s:
         return False

--- a/pycbc/workflow/configuration.py
+++ b/pycbc/workflow/configuration.py
@@ -241,7 +241,7 @@ def resolve_url(url, directory=None, permissions=None):
                   desc[0]['content'] == 'https://git.ligo.org/users/sign_in':
                     raise ValueError(ecp_cookie_error.format(url))
 
-        output_fp = open(filename, 'w')
+        output_fp = open(filename, 'wb')
         output_fp.write(r.content)
         output_fp.close()
 

--- a/pycbc/workflow/configuration.py
+++ b/pycbc/workflow/configuration.py
@@ -28,6 +28,7 @@ https://ldas-jobs.ligo.caltech.edu/~cbc/docs/pycbc/ahope/initialization_inifile.
 """
 
 import os
+import six
 import re
 import stat
 import string
@@ -158,8 +159,16 @@ def istext(s, text_characters=None, threshold=0.3):
     # an "empty" string is "text" (arbitrary but reasonable choice):
     if not s:
         return True
-    # Get the substring of s made up of non-text characters
-    t = s.translate(_null_trans, text_characters)
+
+    text_characters = "".join(map(chr, range(32, 127))) + "\n\r\t\b"
+    if six.PY2:
+        _null_trans = string.maketrans("", "")
+        # Get the substring of s made up of non-text characters
+        t = s.translate(_null_trans, text_characters)
+    else:
+        trans = str.maketrans('', '', text_characters)
+        t = s.translate(trans)
+
     # s is 'text' if less than 30% of its characters are non-text ones:
     return len(t)/float(len(s)) <= threshold
 

--- a/pycbc/workflow/configuration.py
+++ b/pycbc/workflow/configuration.py
@@ -152,7 +152,7 @@ def istext(s, text_characters=None, threshold=0.3):
     https://www.safaribooksonline.com/library/view/python-cookbook-2nd/0596007973/ch01s12.html
     """
     # if s contains any null, it's not text:
-    if "\0" in s:
+    if six.PY2 and "\0" in s:
         return False
     # an "empty" string is "text" (arbitrary but reasonable choice):
     if not s:

--- a/pycbc/workflow/configuration.py
+++ b/pycbc/workflow/configuration.py
@@ -28,7 +28,6 @@ https://ldas-jobs.ligo.caltech.edu/~cbc/docs/pycbc/ahope/initialization_inifile.
 """
 
 import os
-import six
 import re
 import stat
 import string
@@ -38,13 +37,13 @@ import logging
 import requests
 import distutils.spawn
 import itertools
-import glue.pipeline
-
+import six
 from six.moves import configparser as ConfigParser
 from six.moves.urllib.parse import urlparse
 from six.moves import http_cookiejar as cookielib
 from six.moves.http_cookiejar import (_warn_unhandled_exception,
                                       LoadError, Cookie)
+import glue.pipeline
 from bs4 import BeautifulSoup
 
 def _really_load(self, f, filename, ignore_discard, ignore_expires):
@@ -166,9 +165,9 @@ def istext(s, text_characters=None, threshold=0.3):
     else:
         # Not yet sure how to deal with this in python3. Will need example.
         return True
-        
-        #trans = str.maketrans('', '', text_characters)
-        #t = s.translate(trans)
+
+        # trans = str.maketrans('', '', text_characters)
+        # t = s.translate(trans)
 
     # s is 'text' if less than 30% of its characters are non-text ones:
     return len(t)/float(len(s)) <= threshold

--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -298,7 +298,7 @@ class Executable(pegasus_workflow.Executable):
             if namespace == 'pycbc' or namespace == 'container':
                 continue
 
-            value = string.strip(cp.get(sec, opt))
+            value = cp.get(sec, opt).strip()
             key = opt.split('|')[1]
             self.add_profile(namespace, key, value, force=True)
 
@@ -317,7 +317,7 @@ class Executable(pegasus_workflow.Executable):
             The section containing options for this job.
         """
         for opt in cp.options(sec):
-            value = string.strip(cp.get(sec, opt))
+            value = cp.get(sec, opt).strip()
             opt = '--%s' %(opt,)
             if opt in self.file_input_options:
                 # This now expects the option to be a file

--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -27,7 +27,8 @@ creating a workflow. For details about the workflow module see here:
 https://ldas-jobs.ligo.caltech.edu/~cbc/docs/pycbc/ahope.html
 """
 import sys, os, stat, subprocess, logging, math, string, urlparse, urllib
-import ConfigParser, copy
+from six.moves import configparser as ConfigParser
+import copy
 import numpy, cPickle, random
 from itertools import combinations, groupby, permutations
 from operator import attrgetter

--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -30,7 +30,7 @@ import sys, os, stat, subprocess, logging, math, string
 from six.moves import configparser as ConfigParser
 from six.moves import urllib
 from six.moves.urllib.request import pathname2url
-from six.moves.urllib.urlparse import urljoin
+from six.moves.urllib.parse import urljoin
 import copy
 import numpy, cPickle, random
 from itertools import combinations, groupby, permutations

--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -31,8 +31,9 @@ from six.moves import configparser as ConfigParser
 from six.moves import urllib
 from six.moves.urllib.request import pathname2url
 from six.moves.urllib.parse import urljoin
+from six.moves import cPickle
 import copy
-import numpy, cPickle, random
+import numpy, random
 from itertools import combinations, groupby, permutations
 from operator import attrgetter
 from six import string_types

--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -99,7 +99,7 @@ def is_condor_exec(exe_path):
     truth_value  : boolean
         Return True if the exe is condor compiled, False otherwise.
     """
-    if check_output(['nm', '-a', exe_path]).find('condor') != -1:
+    if str(check_output(['nm', '-a', exe_path])).find('condor') != -1:
         return True
     else:
         return False

--- a/pycbc/workflow/datafind.py
+++ b/pycbc/workflow/datafind.py
@@ -31,7 +31,6 @@ https://ldas-jobs.ligo.caltech.edu/~cbc/docs/pycbc/ahope/datafind.html
 
 from __future__ import print_function
 import os, copy
-import urlparse
 import logging
 from ligo import segments
 from glue import lal

--- a/pycbc/workflow/grb_utils.py
+++ b/pycbc/workflow/grb_utils.py
@@ -32,7 +32,8 @@ from __future__ import print_function
 import sys
 import os
 import shutil
-import urlparse, urllib
+from six.moves.urllib.request import pathname2url
+from six.moves.urllib.urlparse import urljoin
 from ligo import segments
 from glue.ligolw import ligolw, lsctables, utils, ilwd
 from pycbc.workflow.core import File, FileList, resolve_url
@@ -195,7 +196,7 @@ def make_exttrig_file(cp, ifos, sci_seg, out_dir):
                                                     "trigger-name"))
     xml_file_path = os.path.join(out_dir, xml_file_name)
     utils.write_filename(xmldoc, xml_file_path)
-    xml_file_url = urlparse.urljoin("file:", urllib.pathname2url(xml_file_path))
+    xml_file_url = urljoin("file:", pathname2url(xml_file_path))
     xml_file = File(ifos, xml_file_name, sci_seg, file_url=xml_file_url)
     xml_file.PFN(xml_file_url, site="local")
 
@@ -224,8 +225,7 @@ def get_ipn_sky_files(workflow, file_url, tags=None):
     '''
     tags = tags or []
     ipn_sky_points = resolve_url(file_url)
-    sky_points_url = urlparse.urljoin("file:",
-            urllib.pathname2url(ipn_sky_points))
+    sky_points_url = urljoin("file:", pathname2url(ipn_sky_points))
     sky_points_file = File(workflow.ifos, "IPN_SKY_POINTS",
             workflow.analysis_time, file_url=sky_points_url, tags=tags)
     sky_points_file.PFN(sky_points_url, site="local")

--- a/pycbc/workflow/grb_utils.py
+++ b/pycbc/workflow/grb_utils.py
@@ -33,7 +33,7 @@ import sys
 import os
 import shutil
 from six.moves.urllib.request import pathname2url
-from six.moves.urllib.urlparse import urljoin
+from six.moves.urllib.parse import urljoin
 from ligo import segments
 from glue.ligolw import ligolw, lsctables, utils, ilwd
 from pycbc.workflow.core import File, FileList, resolve_url

--- a/pycbc/workflow/injection.py
+++ b/pycbc/workflow/injection.py
@@ -31,7 +31,7 @@ https://ldas-jobs.ligo.caltech.edu/~cbc/docs/pycbc/NOTYETCREATED.html
 
 import logging
 from six.moves.urllib.request import pathname2url
-from six.moves.urllib.urlparse import urljoin
+from six.moves.urllib.parse import urljoin
 from pycbc.workflow.core import File, FileList, make_analysis_dir, Executable, resolve_url
 from pycbc.workflow.jobsetup import (LalappsInspinjExecutable,
         LigolwCBCJitterSkylocExecutable, LigolwCBCAlignTotalSpinExecutable,

--- a/pycbc/workflow/injection.py
+++ b/pycbc/workflow/injection.py
@@ -29,7 +29,9 @@ inspinj jobs). Full documentation for this module can be found here:
 https://ldas-jobs.ligo.caltech.edu/~cbc/docs/pycbc/NOTYETCREATED.html
 """
 
-import logging, urllib, urlparse
+import logging
+from six.moves.urllib.request import pathname2url
+from six.moves.urllib.urlparse import urljoin
 from pycbc.workflow.core import File, FileList, make_analysis_dir, Executable, resolve_url
 from pycbc.workflow.jobsetup import (LalappsInspinjExecutable,
         LigolwCBCJitterSkylocExecutable, LigolwCBCAlignTotalSpinExecutable,
@@ -156,8 +158,7 @@ def setup_injection_workflow(workflow, output_dir=None,
             injectionFilePath = workflow.cp.get_opt_tags("workflow-injections",
                                       "injections-pregenerated-file", curr_tags)
             injectionFilePath = resolve_url(injectionFilePath)
-            file_url = urlparse.urljoin('file:',
-                                        urllib.pathname2url(injectionFilePath))
+            file_url = urljoin('file:', pathname2url(injectionFilePath))
             inj_file = File('HL', 'PREGEN_inj_file', full_segment, file_url,
                             tags=curr_tags)
             inj_file.PFN(injectionFilePath, site='local')

--- a/pycbc/workflow/minifollowups.py
+++ b/pycbc/workflow/minifollowups.py
@@ -20,7 +20,12 @@ from six.moves.urllib.parse import urljoin
 import distutils.spawn
 from pycbc.workflow.core import Executable, FileList, Node, makedir, File, Workflow
 from pycbc.workflow.plotting import PlotExecutable, requirestr, excludestr
-from itertools import izip_longest
+try:
+    # Python 3
+    from itertools import zip_longest
+except ImportError:
+    # Python 2
+    from itertools import izip_longest as zip_longest
 from Pegasus import DAX3 as dax
 from pycbc.workflow import pegasus_workflow as wdax
 

--- a/pycbc/workflow/minifollowups.py
+++ b/pycbc/workflow/minifollowups.py
@@ -15,7 +15,8 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 import logging, os.path
-import urlparse, urllib
+from six.moves.urllib.request import pathname2url
+from six.moves.urllib.urlparse import urljoin
 import distutils.spawn
 from pycbc.workflow.core import Executable, FileList, Node, makedir, File, Workflow
 from pycbc.workflow.plotting import PlotExecutable, requirestr, excludestr
@@ -78,8 +79,7 @@ def setup_foreground_minifollowups(workflow, coinc_file, single_triggers,
     workflow.cp.write(open(config_path, 'w'))
 
     config_file = wdax.File(os.path.basename(config_path))
-    config_file.PFN(urlparse.urljoin('file:', urllib.pathname2url(config_path)),
-                    site='local')
+    config_file.PFN(urljoin('file:', pathname2url(config_path)), site='local')
 
     exe = Executable(workflow.cp, 'foreground_minifollowup', ifos=workflow.ifos, out_dir=dax_output)
 
@@ -172,8 +172,7 @@ def setup_single_det_minifollowups(workflow, single_trig_file, tmpltbank_file,
     workflow.cp.write(open(config_path, 'w'))
 
     config_file = wdax.File(os.path.basename(config_path))
-    config_file.PFN(urlparse.urljoin('file:', urllib.pathname2url(config_path)),
-                    site='local')
+    config_file.PFN(urljoin('file:', pathname2url(config_path)), site='local')
 
     exe = Executable(workflow.cp, 'singles_minifollowup',
                      ifos=curr_ifo, out_dir=dax_output, tags=tags)
@@ -274,8 +273,7 @@ def setup_injection_minifollowups(workflow, injection_file, inj_xml_file,
     workflow.cp.write(open(config_path, 'w'))
 
     config_file = wdax.File(os.path.basename(config_path))
-    config_file.PFN(urlparse.urljoin('file:', urllib.pathname2url(config_path)),
-                    site='local')
+    config_file.PFN(urljoin('file:', pathname2url(config_path)), site='local')
 
     exe = Executable(workflow.cp, 'injection_minifollowup', ifos=workflow.ifos, out_dir=dax_output)
 

--- a/pycbc/workflow/minifollowups.py
+++ b/pycbc/workflow/minifollowups.py
@@ -33,7 +33,7 @@ def grouper(iterable, n, fillvalue=None):
     """ Create a list of n length tuples
     """
     args = [iter(iterable)] * n
-    return izip_longest(*args, fillvalue=fillvalue)
+    return zip_longest(*args, fillvalue=fillvalue)
 
 def setup_foreground_minifollowups(workflow, coinc_file, single_triggers,
                        tmpltbank_file, insp_segs, insp_data_name,

--- a/pycbc/workflow/minifollowups.py
+++ b/pycbc/workflow/minifollowups.py
@@ -16,7 +16,7 @@
 
 import logging, os.path
 from six.moves.urllib.request import pathname2url
-from six.moves.urllib.urlparse import urljoin
+from six.moves.urllib.parse import urljoin
 import distutils.spawn
 from pycbc.workflow.core import Executable, FileList, Node, makedir, File, Workflow
 from pycbc.workflow.plotting import PlotExecutable, requirestr, excludestr

--- a/pycbc/workflow/pegasus_workflow.py
+++ b/pycbc/workflow/pegasus_workflow.py
@@ -28,7 +28,7 @@ provides additional abstraction and argument handling.
 """
 import os
 from six.moves.urllib.request import pathname2url
-from six.moves.urllib.parse import urljoin
+from six.moves.urllib.parse import urljoin, urlsplit
 from Pegasus.catalogs.transformation_catalog import TransformationCatalog
 import Pegasus.DAX3 as dax
 
@@ -483,7 +483,7 @@ class File(DataStorage, dax.File):
     @classmethod
     def from_path(cls, path):
         """Takes a path and returns a File object with the path as the PFN."""
-        urlparts = urlparse.urlsplit(path)
+        urlparts = urlsplit(path)
         site = 'nonlocal'
         if (urlparts.scheme == '' or urlparts.scheme == 'file'):
             if os.path.isfile(urlparts.path):

--- a/pycbc/workflow/pegasus_workflow.py
+++ b/pycbc/workflow/pegasus_workflow.py
@@ -28,7 +28,7 @@ provides additional abstraction and argument handling.
 """
 import os
 from six.moves.urllib.request import pathname2url
-from six.moves.urllib.urlparse import urljoin
+from six.moves.urllib.parse import urljoin
 from Pegasus.catalogs.transformation_catalog import TransformationCatalog
 import Pegasus.DAX3 as dax
 

--- a/pycbc/workflow/pegasus_workflow.py
+++ b/pycbc/workflow/pegasus_workflow.py
@@ -27,7 +27,8 @@
 provides additional abstraction and argument handling.
 """
 import os
-import urlparse, urllib
+from six.moves.urllib.request import pathname2url
+from six.moves.urllib.urlparse import urljoin
 from Pegasus.catalogs.transformation_catalog import TransformationCatalog
 import Pegasus.DAX3 as dax
 
@@ -487,8 +488,7 @@ class File(DataStorage, dax.File):
         if (urlparts.scheme == '' or urlparts.scheme == 'file'):
             if os.path.isfile(urlparts.path):
                 path = os.path.abspath(urlparts.path)
-                path = urlparse.urljoin('file:',
-                                        urllib.pathname2url(path)) 
+                path = urljoin('file:', pathname2url(path)) 
                 site = 'local'
 
         fil = File(os.path.basename(path))

--- a/pycbc/workflow/plotting.py
+++ b/pycbc/workflow/plotting.py
@@ -25,7 +25,8 @@
 This module is responsible for setting up plotting jobs.
 https://ldas-jobs.ligo.caltech.edu/~cbc/docs/pycbc/NOTYETCREATED.html
 """
-import urlparse, urllib
+from six.moves.urllib.request import pathname2url
+from six.moves.urllib.urlparse import urljoin
 from pycbc.workflow.core import File, FileList, makedir, Executable
 
 def excludestr(tags, substr):
@@ -236,8 +237,7 @@ def make_veto_table(workflow, out_dir, vetodef_file=None, tags=None):
     if vetodef_file is None:
         vetodef_file = workflow.cp.get_opt_tags("workflow-segments",
                                            "segments-veto-definer-file", [])
-        file_url = urlparse.urljoin('file:',
-                                    urllib.pathname2url(vetodef_file))
+        file_url = urljoin('file:', pathname2url(vetodef_file))
         vdf_file = File(workflow.ifos, 'VETO_DEFINER',
                         workflow.analysis_time, file_url=file_url)
         vdf_file.PFN(file_url, site='local')

--- a/pycbc/workflow/plotting.py
+++ b/pycbc/workflow/plotting.py
@@ -26,7 +26,7 @@ This module is responsible for setting up plotting jobs.
 https://ldas-jobs.ligo.caltech.edu/~cbc/docs/pycbc/NOTYETCREATED.html
 """
 from six.moves.urllib.request import pathname2url
-from six.moves.urllib.urlparse import urljoin
+from six.moves.urllib.parse import urljoin
 from pycbc.workflow.core import File, FileList, makedir, Executable
 
 def excludestr(tags, substr):

--- a/pycbc/workflow/psd.py
+++ b/pycbc/workflow/psd.py
@@ -17,6 +17,7 @@
 """This module is responsible for setting up PSD-related jobs in workflows.
 """
 
+from six.moves import range
 from pycbc.workflow.core import FileList, make_analysis_dir, Executable, File
 from pycbc.workflow.core import SegFile
 from ligo.segments import segmentlist
@@ -32,7 +33,7 @@ def chunks(l, n):
     """ Yield n successive chunks from l.
     """
     newn = int(len(l) / n)
-    for i in xrange(0, n-1):
+    for i in range(0, n-1):
         yield l[i*newn:i*newn+newn]
     yield l[n*newn-newn:]
 

--- a/pycbc/workflow/psdfiles.py
+++ b/pycbc/workflow/psdfiles.py
@@ -32,7 +32,7 @@ from __future__ import division
 import os
 from six.moves import configparser as ConfigParser
 from six.moves.urllib.request import pathname2url
-from six.moves.urllib.urlparse import urljoin
+from six.moves.urllib.parse import urljoin
 import logging
 from pycbc.workflow.core import File, FileList, make_analysis_dir, resolve_url
 

--- a/pycbc/workflow/psdfiles.py
+++ b/pycbc/workflow/psdfiles.py
@@ -29,9 +29,10 @@ workflows.
 
 from __future__ import division
 
-import os, six
+import os
 from six.moves import configparser as ConfigParser
-import urlparse, urllib
+from six.moves.urllib.request import pathname2url
+from six.moves.urllib.urlparse import urljoin
 import logging
 from pycbc.workflow.core import File, FileList, make_analysis_dir, resolve_url
 

--- a/pycbc/workflow/psdfiles.py
+++ b/pycbc/workflow/psdfiles.py
@@ -29,8 +29,8 @@ workflows.
 
 from __future__ import division
 
-import os
-import ConfigParser
+import os, six
+from six.moves import configparser as ConfigParser
 import urlparse, urllib
 import logging
 from pycbc.workflow.core import File, FileList, make_analysis_dir, resolve_url

--- a/pycbc/workflow/psdfiles.py
+++ b/pycbc/workflow/psdfiles.py
@@ -30,10 +30,10 @@ workflows.
 from __future__ import division
 
 import os
+import logging
 from six.moves import configparser as ConfigParser
 from six.moves.urllib.request import pathname2url
 from six.moves.urllib.parse import urljoin
-import logging
 from pycbc.workflow.core import File, FileList, make_analysis_dir, resolve_url
 
 def setup_psd_workflow(workflow, science_segs, datafind_outs,
@@ -122,8 +122,7 @@ def setup_psd_pregenerated(workflow, tags=None):
         pre_gen_file = cp.get_opt_tags('workflow-psd',
                         'psd-pregenerated-file', tags)
         pre_gen_file = resolve_url(pre_gen_file)
-        file_url = urlparse.urljoin('file:',
-                                     urllib.pathname2url(pre_gen_file))
+        file_url = urljoin('file:', pathname2url(pre_gen_file))
         curr_file = File(workflow.ifos, user_tag, global_seg, file_url,
                                                     tags=tags)
         curr_file.PFN(file_url, site='local')
@@ -136,8 +135,7 @@ def setup_psd_pregenerated(workflow, tags=None):
                                 'psd-pregenerated-file-%s' % ifo.lower(),
                                 tags)
                 pre_gen_file = resolve_url(pre_gen_file)
-                file_url = urlparse.urljoin('file:',
-                                             urllib.pathname2url(pre_gen_file))
+                file_url = urljoin('file:', pathname2url(pre_gen_file))
                 curr_file = File(ifo, user_tag, global_seg, file_url,
                                                             tags=tags)
                 curr_file.PFN(file_url, site='local')

--- a/pycbc/workflow/segment.py
+++ b/pycbc/workflow/segment.py
@@ -30,7 +30,7 @@ https://ldas-jobs.ligo.caltech.edu/~cbc/docs/pycbc/ahope/segments.html
 import os, sys, shutil, stat, copy, itertools
 import logging
 from six.moves.urllib.request import pathname2url
-from six.moves.urllib.urlparse import urljoin
+from six.moves.urllib.parse import urljoin
 import lal
 from ligo import segments
 from ligo.segments import utils as segmentsUtils

--- a/pycbc/workflow/segment.py
+++ b/pycbc/workflow/segment.py
@@ -30,7 +30,7 @@ https://ldas-jobs.ligo.caltech.edu/~cbc/docs/pycbc/ahope/segments.html
 import os, sys, shutil, stat, copy, itertools
 import logging
 from six.moves.urllib.request import pathname2url
-from six.moves.urllib.parse import urljoin
+from six.moves.urllib.parse import urljoin, urlunparse
 import lal
 from ligo import segments
 from ligo.segments import utils as segmentsUtils
@@ -558,8 +558,8 @@ def setup_segment_gen_mixed(workflow, veto_categories, out_dir,
         analysedSegDict[ifo + ':SCIENCE_OK'] = analysedSegs
         analysedXmlFile = os.path.join(out_dir,
                              "%s-SCIENCE_OK_SEGMENTS.xml" %(ifo.upper()) )
-        currUrl = urlparse.urlunparse(['file', 'localhost', analysedXmlFile,
-                          None, None, None])
+        currUrl = urlunparse(['file', 'localhost', analysedXmlFile,
+                              None, None, None])
         if tag:
             currTags = [tag, 'SCIENCE_OK']
         else:
@@ -760,8 +760,8 @@ def get_veto_segs(workflow, ifo, category, start_time, end_time, out_dir,
                          %(ifo, category, start_time, end_time-start_time)
     veto_xml_file_path = os.path.abspath(os.path.join(out_dir,
                                          veto_xml_file_name))
-    curr_url = urlparse.urlunparse(['file', 'localhost',
-                                   veto_xml_file_path, None, None, None])
+    curr_url = urlunparse(['file', 'localhost',
+                           veto_xml_file_path, None, None, None])
     if tags:
         curr_tags = tags + ['VETO_CAT%d' %(category)]
     else:

--- a/pycbc/workflow/segment.py
+++ b/pycbc/workflow/segment.py
@@ -29,7 +29,8 @@ https://ldas-jobs.ligo.caltech.edu/~cbc/docs/pycbc/ahope/segments.html
 
 import os, sys, shutil, stat, copy, itertools
 import logging
-import urlparse, urllib
+from six.moves.urllib.request import pathname2url
+from six.moves.urllib.urlparse import urljoin
 import lal
 from ligo import segments
 from ligo.segments import utils as segmentsUtils
@@ -883,8 +884,7 @@ def get_cumulative_segs(workflow, categories, seg_files_list, out_dir,
             cum_node.executed = True
             for fil in cum_node._outputs:
                 fil.node = None
-                fil.PFN(urlparse.urljoin('file:',
-                                         urllib.pathname2url(fil.storage_path)),
+                fil.PFN(urljoin('file:', pathname2url(fil.storage_path)),
                         site='local')
         add_inputs += cum_node.output_files
 
@@ -906,8 +906,7 @@ def get_cumulative_segs(workflow, categories, seg_files_list, out_dir,
         add_node.executed = True
         for fil in add_node._outputs:
             fil.node = None
-            fil.PFN(urlparse.urljoin('file:',
-                                     urllib.pathname2url(fil.storage_path)),
+            fil.PFN(urljoin('file:', pathname2url(fil.storage_path)),
                     site='local')
     return outfile
 
@@ -949,8 +948,7 @@ def add_cumulative_files(workflow, output_file, input_files, out_dir,
         add_node.executed = True
         for fil in add_node._outputs:
             fil.node = None
-            fil.PFN(urlparse.urljoin('file:',
-                                     urllib.pathname2url(fil.storage_path)),
+            fil.PFN(urljoin('file:', pathname2url(fil.storage_path)),
                     site='local')
     return add_node.output_files[0]
 

--- a/pycbc/workflow/segment.py
+++ b/pycbc/workflow/segment.py
@@ -608,8 +608,8 @@ def setup_segment_gen_mixed(workflow, veto_categories, out_dir,
         combined_veto_file = os.path.join(out_dir,
                                '%s-CUMULATIVE_ALL_CATS_SEGMENTS.xml' \
                                %(ifo_string) )
-        curr_url = urlparse.urlunparse(['file', 'localhost',
-                                       combined_veto_file, None, None, None])
+        curr_url = urlunparse(['file', 'localhost',
+                               combined_veto_file, None, None, None])
         curr_file = SegFile(ifo_string, 'SEGMENTS', segValidSeg,
                             file_url=curr_url, tags=currTags)
 

--- a/pycbc/workflow/tmpltbank.py
+++ b/pycbc/workflow/tmpltbank.py
@@ -30,8 +30,8 @@ https://ldas-jobs.ligo.caltech.edu/~cbc/docs/pycbc/ahope/template_bank.html
 
 from __future__ import division
 
-import os
-import ConfigParser
+import os, six
+from six.moves import configparser as ConfigParser
 import urlparse, urllib
 import logging
 import pycbc

--- a/pycbc/workflow/tmpltbank.py
+++ b/pycbc/workflow/tmpltbank.py
@@ -30,8 +30,10 @@ https://ldas-jobs.ligo.caltech.edu/~cbc/docs/pycbc/ahope/template_bank.html
 
 from __future__ import division
 
-import os, six
+import os
 from six.moves import configparser as ConfigParser
+from six.moves.urllib.request import pathname2url
+from six.moves.urllib.urlparse import urljoin
 import urlparse, urllib
 import logging
 import pycbc
@@ -366,7 +368,7 @@ def setup_tmpltbank_pregenerated(workflow, tags=None):
         pre_gen_bank = cp.get_opt_tags('workflow-tmpltbank',
                                            'tmpltbank-pregenerated-bank', tags)
         pre_gen_bank = resolve_url(pre_gen_bank)
-        file_url = urlparse.urljoin('file:', urllib.pathname2url(pre_gen_bank))
+        file_url = urljoin('file:', pathname2url(pre_gen_bank))
         curr_file = File(workflow.ifos, user_tag, global_seg, file_url,
                                                                      tags=tags)
         curr_file.PFN(file_url, site='local')
@@ -379,8 +381,7 @@ def setup_tmpltbank_pregenerated(workflow, tags=None):
                                 'tmpltbank-pregenerated-bank-%s' % ifo.lower(),
                                 tags)
                 pre_gen_bank = resolve_url(pre_gen_bank)
-                file_url = urlparse.urljoin('file:',
-                                             urllib.pathname2url(pre_gen_bank))
+                file_url = urljoin('file:', pathname2url(pre_gen_bank))
                 curr_file = File(ifo, user_tag, global_seg, file_url,
                                                                      tags=tags)
                 curr_file.PFN(file_url, site='local')

--- a/pycbc/workflow/tmpltbank.py
+++ b/pycbc/workflow/tmpltbank.py
@@ -33,7 +33,7 @@ from __future__ import division
 import os
 from six.moves import configparser as ConfigParser
 from six.moves.urllib.request import pathname2url
-from six.moves.urllib.urlparse import urljoin
+from six.moves.urllib.parse import urljoin
 import urlparse, urllib
 import logging
 import pycbc

--- a/pycbc/workflow/tmpltbank.py
+++ b/pycbc/workflow/tmpltbank.py
@@ -34,7 +34,6 @@ import os
 from six.moves import configparser as ConfigParser
 from six.moves.urllib.request import pathname2url
 from six.moves.urllib.parse import urljoin
-import urlparse, urllib
 import logging
 import pycbc
 from pycbc.workflow.core import File, FileList, make_analysis_dir, resolve_url

--- a/pycbc/workflow/tmpltbank.py
+++ b/pycbc/workflow/tmpltbank.py
@@ -31,10 +31,10 @@ https://ldas-jobs.ligo.caltech.edu/~cbc/docs/pycbc/ahope/template_bank.html
 from __future__ import division
 
 import os
+import logging
 from six.moves import configparser as ConfigParser
 from six.moves.urllib.request import pathname2url
 from six.moves.urllib.parse import urljoin
-import logging
 import pycbc
 from pycbc.workflow.core import File, FileList, make_analysis_dir, resolve_url
 from pycbc.workflow.jobsetup import select_tmpltbank_class, select_matchedfilter_class, sngl_ifo_job_setup


### PR DESCRIPTION
Python3-related changes necessary to generate the all-sky workflow in python3. There's still a separate issue with dqsegdb, and issues with pegasus, that means this won't run in python3 out of the box, but this is nicely contained under "python 3 compatibility changes that don't change python2 functionality". This is basically:

 * Using six for module imports where names are different.
 * Python3 string vs bytes handling is a little confusing when you're used to python2. We're careless about this, and it will doubtless cause issues in other places to be fixed going forward.
 * Octals must be declared clearly, not as 0755 (compatible with python2 and 3)
 * File opening *must* be clear about the difference between `r` and `rb` in python3 (although again string handling confuses this somewhat).
 * The `istext` function in `configuration` is not coded for python3. At the moment the code is not failing here, so I'm ignoring it, but if we have a failing example this might need more patching.
 * url libraries moved about a lot in python3
 * `string.strip` is deprecated and removed in python3.
 * One example of `xrange` fixed (I'm sure there's more, but didn't go after that yet).