### PR TITLE
Let's not fail if analysing O3 data

### DIFF
--- a/pycbc/dq.py
+++ b/pycbc/dq.py
@@ -153,8 +153,8 @@ def query_flag(ifo, name, start_time, end_time,
         duration = end_time - start_time
         try:
             url = GWOSC_URL.format(get_run(start_time + duration/2),
-                               ifo, segment_name,
-                               int(start_time), int(duration))
+                                   ifo, segment_name,
+                                   int(start_time), int(duration))
 
             fname = download_file(url, cache=cache)
             data = json.load(open(fname, 'r'))

--- a/pycbc/dq.py
+++ b/pycbc/dq.py
@@ -151,11 +151,11 @@ def query_flag(ifo, name, start_time, end_time,
             return (data - negate).coalesce()
 
         duration = end_time - start_time
-        url = GWOSC_URL.format(get_run(start_time + duration/2),
+        try:
+            url = GWOSC_URL.format(get_run(start_time + duration/2),
                                ifo, segment_name,
                                int(start_time), int(duration))
 
-        try:
             fname = download_file(url, cache=cache)
             data = json.load(open(fname, 'r'))
             if 'segments' in data:


### PR DESCRIPTION
The new DQ module fails if trying to analyse data outside of LOSC released times. For obvious reasons this is not good for those of us in the LVC.

Moving a try block is all that's needed here (but I'm sure if I like the "try both" approach, as it prints a confusing Traceback in python3 and prints warnings about O3 data not being in GWOSC).