### PR TITLE
More python3 compatibility changes

### DIFF
--- a/bin/bank/pycbc_aligned_bank_cat
+++ b/bin/bank/pycbc_aligned_bank_cat
@@ -28,6 +28,7 @@ import argparse
 import numpy
 import pycbc.version
 import h5py
+from six.moves import range
 from glue.ligolw import ligolw
 from glue.ligolw import lsctables
 from glue.ligolw import utils
@@ -186,7 +187,7 @@ elif options.output_file.endswith(('.h5','.hdf','.hdf5')):
     out_fp['spin2z'] = temp_bank[:,3]
     out_fp['f_lower'] = [options.f_low] * len(temp_bank[:,0])
     tmplt_durations = []
-    for i in xrange(len(temp_bank[:,0])):
+    for i in range(len(temp_bank[:,0])):
         gwflit = get_waveform_filter_length_in_time
         wfrm_length = gwflit('SPAtmplt', mass1=temp_bank[i,0],
                              mass2=temp_bank[i,1], f_lower=options.f_low,

--- a/bin/bank/pycbc_bank_verification
+++ b/bin/bank/pycbc_bank_verification
@@ -37,6 +37,7 @@ import copy
 import logging
 import numpy
 import h5py
+from six.moves import range
 from glue.ligolw import ligolw, table, lsctables, utils as ligolw_utils
 from pycbc import tmpltbank, psd, strain, pnutils
 import matplotlib
@@ -261,7 +262,7 @@ vecs = tmpltbank.get_cov_params(rMass1, rMass2, rSpin1z, rSpin2z,
                                 metricParams, refFreq)
 vecs = numpy.array(vecs)
 
-for idx_curr in xrange(opts.num_points):
+for idx_curr in range(opts.num_points):
     vs = vecs[:,idx_curr]
     if opts.vary_fupper:
         min_mismatch, idxes = partitioned_bank_object.calc_point_distance_vary(\
@@ -297,7 +298,7 @@ if opts.histogram_output_file:
 
 if opts.print_distances:
     print
-    for idx in xrange(len(points_mass1)):
+    for idx in range(len(points_mass1)):
         print "The test point with the following parameters (m1,m2,S1z,S2z)"
         print "%e %e %e %e" %(points_mass1[idx], points_mass2[idx],\
                               points_spin1z[idx], points_spin2z[idx])

--- a/bin/bank/pycbc_geom_aligned_2dstack
+++ b/bin/bank/pycbc_geom_aligned_2dstack
@@ -32,6 +32,7 @@ import copy
 import numpy
 import logging
 import h5py
+from six.moves import range
 import pycbc.tmpltbank
 import pycbc.version
 from pycbc import pnutils
@@ -325,7 +326,7 @@ for entry in temp_bank:
         numV3Temps = 1
     else:
         numV3Temps = int(round(vec3_depth // vec3DepthVal)) + 1
-    for ite in xrange(numV3Temps):
+    for ite in range(numV3Temps):
         if not opts.threed_lattice:
             xi3_des = vec3_min + \
                       (vec3_depth) * (2 * ite + 1) / (2. * (numV3Temps))
@@ -358,7 +359,7 @@ for entry in temp_bank:
             vec4_depthT = vec4_maxT - vec4_minT
             # Then loop over necessary templates in 4th direction
             numV4Temps = int(round(vec4_depthT // vec3DepthVal)) + 1
-            for ite in xrange(numV4Temps):
+            for ite in range(numV4Temps):
                 xi4_des = vec4_minT + \
                           (vec4_depthT) * (2 * ite + 1) / (2. * (numV4Temps))
                 dist = (xi1_des - xis[:,0])**2 + (xi2_des - xis[:,1])**2 + \

--- a/bin/bank/pycbc_geom_aligned_bank
+++ b/bin/bank/pycbc_geom_aligned_bank
@@ -34,6 +34,7 @@ import logging
 import distutils.spawn
 import h5py
 from scipy import spatial
+from six.moves import range
 from glue.ligolw import ligolw
 from glue.ligolw import table
 from glue.ligolw import lsctables
@@ -393,7 +394,7 @@ if opts.filter_points:
 
     logging.info("Removing far-away points.")
 
-    for i in xrange(len(v1s)):
+    for i in range(len(v1s)):
         if dists[i] < 2.:
             newV1s.append(v1s[i])
             newV2s.append(v2s[i])
@@ -422,7 +423,7 @@ logging.info("Printing split banks to HDF file.")
 v1s = []
 v2s = []
 v3s = []
-for i in xrange(len(newV1s)):
+for i in range(len(newV1s)):
     v1s.append(newV1s[i])
     v2s.append(newV2s[i])
     if opts.threed_lattice:
@@ -560,7 +561,7 @@ else:
 
 all_outs = wf.FileList([])
 
-for idx in xrange(num_banks):
+for idx in range(num_banks):
     stackid = 'job%05d' %(idx)
     stack_node = stack_exe.create_node(input_h5file, idx,
                                        workflow.analysis_time,

--- a/bin/bank/pycbc_geom_nonspinbank
+++ b/bin/bank/pycbc_geom_nonspinbank
@@ -26,6 +26,7 @@ import math
 import copy
 import numpy
 import logging
+from six.moves import range
 import pycbc
 import pycbc.version
 import pycbc.psd
@@ -299,10 +300,10 @@ numv2bins = int(math.ceil(v2sdiff / 1.))
 
 sortedBins = {}
 
-#for i in xrange(numv1bins):
+#for i in range(numv1bins):
 #    print i
 #    sortedBins[i] = {}
-#    for j in xrange(numv2bins):
+#    for j in range(numv2bins):
 #        sortedBins[i][j] = []
 
 logging.info("Sorting guide points")

--- a/bin/bank/pycbc_tmpltbank_to_chi_params
+++ b/bin/bank/pycbc_tmpltbank_to_chi_params
@@ -36,6 +36,7 @@ import copy
 import logging
 import numpy
 import h5py
+from six.moves import range
 from glue.ligolw import ligolw, table, lsctables, utils as ligolw_utils
 from pycbc import tmpltbank, psd, strain, pnutils
 import matplotlib
@@ -174,7 +175,7 @@ else:
     raise NotImplementedError(err_msg)
 
 fP = open(opts.output_file, "w")
-for idx in xrange(len(mass1)):
+for idx in range(len(mass1)):
     chi_coords = tmpltbank.get_cov_params(mass1[idx], mass2[idx], spin1z[idx],
                                           spin2z[idx], metricParams, refFreq)
     vals = " ".join([str(mass1[idx]), str(mass2[idx]), str(spin1z[idx]),

--- a/bin/hdfcoinc/pycbc_calculate_psd
+++ b/bin/hdfcoinc/pycbc_calculate_psd
@@ -33,10 +33,12 @@ def grouper(n, iterable):
     args = [iter(iterable)] * n
     return list([e for e in t if e != None] for t in itertools.izip_longest(*args))
 
-def get_psd((seg, i)):
+def get_psd(input_tuple):
     """ Get the PSDs for the given data chunck. This follows the same rules
     as pycbc_inspiral for determining where to calculate PSDs
     """
+    seg = input_tuple[0]
+    i = input_tuple[1]
     pycbc.multiprocess_cache_dir()
     
     logging.info('%d: getting strain for %.1f-%.1f (%.1f s)', i, seg[0],

--- a/bin/hdfcoinc/pycbc_calculate_psd
+++ b/bin/hdfcoinc/pycbc_calculate_psd
@@ -2,6 +2,7 @@
 """ Calculate psd estimates for analysis segments
 """
 import logging, argparse, numpy, h5py, itertools, multiprocessing, time
+from six.moves import range
 import pycbc, pycbc.psd, pycbc.strain, pycbc.events
 from pycbc.version import git_verbose_msg as version
 from pycbc.fft.fftw import set_measure_level
@@ -98,7 +99,7 @@ if len(segments) > 0:
     # FIXME: https://www.youtube.com/watch?v=DtRNg5uSKQ0
     get_psd( (segments[0], 0) )
 
-    psds = pool.map_async(get_psd, zip(segments, xrange(len(segments))))
+    psds = pool.map_async(get_psd, zip(segments, range(len(segments))))
     psds = psds.get()
 else:
     psds = []

--- a/bin/hdfcoinc/pycbc_page_segments
+++ b/bin/hdfcoinc/pycbc_page_segments
@@ -47,7 +47,7 @@ def plot_segs(start, end, color=None, y=0, h=1):
         plot_segs.colors = cycle(['red', 'blue', 'green', 'yellow', 'cyan', 'violet'])
 
     if color is None:
-        color = plot_segs.colors.next()
+        color = next(plot_segs.colors)
 
     for s, e in zip(start, end):
         ax = pylab.gca()

--- a/bin/hdfcoinc/pycbc_page_segplot
+++ b/bin/hdfcoinc/pycbc_page_segplot
@@ -114,7 +114,7 @@ for segment_file in opts.segment_files:
         for ifo in ifos:
 
             # get new color for this segment name
-            color = color_cycle[ifo].next()
+            color = next(color_cycle[ifo])
 
             for key in seg_dict.keys():
                 seg_key = ifo+':'+segment_name

--- a/bin/hdfcoinc/pycbc_plot_bank_bins
+++ b/bin/hdfcoinc/pycbc_plot_bank_bins
@@ -113,7 +113,7 @@ pylab.grid()
 for name in locs_dict:
     locs = locs_dict[name]
     pylab.scatter(x_var[locs], y_var[locs], label=name, edgecolor='none', s=1,
-                  c=color.next())
+                  c=next(color))
 
 pylab.legend(loc='upper left', markerscale=5)
 pylab.xlabel(x_var_name)

--- a/bin/hdfcoinc/pycbc_plot_hist
+++ b/bin/hdfcoinc/pycbc_plot_hist
@@ -87,7 +87,7 @@ elif args.background_bins:
 
     # assign a color for each bin
     color_cycle = cycle(['red', 'green', 'blue', 'black', 'magenta', 'cyan'])
-    loc_bin_colors = [color_cycle.next() for key in loc_bin_keys]
+    loc_bin_colors = [next(color_cycle) for key in loc_bin_keys]
 
     # get number of overflows for each background bin
     loc_bin_overflows = [len(vals[vals>=x_max]) for vals in loc_bin_vals]

--- a/bin/hdfcoinc/pycbc_plot_psd_file
+++ b/bin/hdfcoinc/pycbc_plot_psd_file
@@ -3,6 +3,7 @@
 """
 import matplotlib
 matplotlib.use('Agg')
+from six.moves import range
 import h5py, numpy, argparse, pylab, pycbc.results, sys
 import pycbc.psd
 import pycbc.version
@@ -84,7 +85,7 @@ for psd_file in args.psd_files:
         middle = numpy.zeros(klen)
         samples = numpy.arange(kmin, kmax) * df
 
-        for split_idx in xrange(num_splits):
+        for split_idx in range(num_splits):
             curr_kmin = kmin + split_idx * num_points_to_read
             curr_kmax = kmin + (split_idx+1) * num_points_to_read
             # klen may not divide by num_gb perfectly

--- a/bin/hdfcoinc/pycbc_plot_psd_timefreq
+++ b/bin/hdfcoinc/pycbc_plot_psd_timefreq
@@ -26,6 +26,7 @@ import argparse
 import numpy
 import h5py
 import sys
+from six.moves import range
 import matplotlib
 matplotlib.use('agg')
 import pylab
@@ -61,7 +62,7 @@ f = h5py.File(opts.psd_file, 'r')
 ifo = f.keys()[0]
 df = f[ifo + '/psds/0'].attrs['delta_f']
 keys = f[ifo + '/psds'].keys()
-psds = [f[ifo + '/psds/' + str(key)][:] for key in xrange(len(f[ifo + '/psds']))]
+psds = [f[ifo + '/psds/' + str(key)][:] for key in range(len(f[ifo + '/psds']))]
 
 flow = f.attrs['low_frequency_cutoff']
 kmin = int(flow / df)
@@ -83,7 +84,7 @@ else:
     asdmin = min(psds[0][kmin:]) ** 0.5 * fac
     asdmax = 1e-20
 
-for psd_segment in xrange(len(psds)):
+for psd_segment in range(len(psds)):
     logging.info('Plotting PSD segment number %d', psd_segment)
     time = numpy.array( [ start[psd_segment] , end[psd_segment] ] )
     if opts.normalize:
@@ -99,7 +100,7 @@ for psd_segment in xrange(len(psds)):
 
     # Take the ASD of each frequency bin using the method given
     asdless = []
-    for index in xrange( 1 , len(indices) ):
+    for index in range( 1 , len(indices) ):
         asdless.append( reduction_function[ opts.reduction_method ]
                                           ( asd[indices[index-1] : indices[index]] ))
 
@@ -121,7 +122,7 @@ ax.set_xlim( start.min() - 5000 , end.max() + 5000 )
 ax.set_ylim( numpy.min(freqs) , numpy.max(freqs) )
 
 ticks = []
-for days in xrange( (end.max() - start.min()) / 86400 + 1 ):
+for days in range( (end.max() - start.min()) / 86400 + 1 ):
     ticks.append( start.min() + 86400 * days )
 ticklabels = numpy.arange( (end.max() - start.min()) / 86400 + 1)
 ax.set_xticks( ticks )

--- a/bin/hdfcoinc/pycbc_plot_singles_timefreq
+++ b/bin/hdfcoinc/pycbc_plot_singles_timefreq
@@ -27,6 +27,7 @@ import argparse
 import numpy as np
 import matplotlib
 matplotlib.use('agg')
+from six.moves import range
 import pylab as pl
 import matplotlib.mlab as mlab
 from matplotlib.colors import LogNorm
@@ -167,7 +168,7 @@ if len(indices) > 0:
     sorted_template_ids = template_ids[sorter]
 
     try:
-        max_rank = max([sorted_rank[i] for i in xrange(len(sorted_rank)) \
+        max_rank = max([sorted_rank[i] for i in range(len(sorted_rank)) \
                         if sorted_end_time[i] <= opts.gps_end_time])
     except ValueError:
         max_rank = None

--- a/bin/inference/pycbc_inference_plot_posterior
+++ b/bin/inference/pycbc_inference_plot_posterior
@@ -183,8 +183,8 @@ for (i, s) in enumerate(samples):
         axis_dict = None
 
     # loop over some contour colors
-    contour_color = colors.next() if not opts.contour_color \
-                                                else opts.contour_color
+    contour_color = next(colors) if not opts.contour_color \
+        else opts.contour_color
 
     # make histograms filled if only one input file to plot
     fill_color = "gray" if len(opts.input_file) == 1 else None
@@ -223,7 +223,7 @@ for (i, s) in enumerate(samples):
 # plot the prior
 if opts.plot_prior:
     if len(opts.input_file) > 1:
-        hist_color = colors.next()
+        hist_color = next(colors)
     fig, axis_dict = create_multidim_plot(
         parameters, prior_samples, fig=fig, axis_dict=axis_dict,
         labels=labels, plot_marginal=True, marginal_percentiles=[],

--- a/bin/pycbc_inspiral
+++ b/bin/pycbc_inspiral
@@ -18,6 +18,7 @@
 
 import sys
 import logging, argparse, numpy, itertools
+from six.moves import range
 import pycbc
 import pycbc.version
 from pycbc import vetoes, psd, waveform, strain, scheme, fft, DYN_RANGE_FAC, events
@@ -347,7 +348,7 @@ with ctx:
     # within the loop.  Rather, the iteration simply fills the memory specifed in
     # the 'template_mem' argument to MatchedFilterControl with the next template
     # from the bank.
-    for t_num in xrange(len(bank)):
+    for t_num in range(len(bank)):
         tmplt_generated = False
 
         for s_num, stilde in enumerate(segments):

--- a/bin/pycbc_split_inspinj
+++ b/bin/pycbc_split_inspinj
@@ -56,7 +56,7 @@ new_inj_tables = [lsctables.New(tabletype, columns=allinjs.columnnames) \
 
 table_cycle = cycle(new_inj_tables)
 for inj in sorted(allinjs, key=lambda x: x.get_time_geocent()):
-    table_cycle.next().append(inj)
+    next(table_cycle).append(inj)
 
 if not args.output_files:
     temp = args.input_file.split('-')

--- a/bin/pycbc_split_inspinj
+++ b/bin/pycbc_split_inspinj
@@ -3,6 +3,7 @@
 # Copyright (C) 2014 Andrew Lundgren
 import sys
 import argparse
+from six.moves import range
 from glue.ligolw import utils as ligolw_utils
 from glue.ligolw import ligolw, lsctables
 from itertools import cycle
@@ -52,7 +53,7 @@ else:
     num_splits = len(args.output_files)
 
 new_inj_tables = [lsctables.New(tabletype, columns=allinjs.columnnames) \
-                  for idx in xrange(num_splits)]
+                  for idx in range(num_splits)]
 
 table_cycle = cycle(new_inj_tables)
 for inj in sorted(allinjs, key=lambda x: x.get_time_geocent()):

--- a/pycbc/filter/qtransform.py
+++ b/pycbc/filter/qtransform.py
@@ -29,6 +29,7 @@ This module retrives a timeseries and then calculates
 the q-transform of that time series
 """
 
+from six.moves import range
 import numpy
 from numpy import ceil, log, exp
 from pycbc.types.timeseries import FrequencySeries, TimeSeries
@@ -144,7 +145,7 @@ def _iter_qs(qrange, deltam):
     cumum = log(float(qrange[1]) / qrange[0]) / 2**(1/2.)
     nplanes = int(max(ceil(cumum / deltam), 1))
     dq = cumum / nplanes
-    for i in xrange(nplanes):
+    for i in range(nplanes):
         yield qrange[0] * exp(2**(1/2.) * dq * (i + .5))
     raise StopIteration()
 
@@ -174,7 +175,7 @@ def _iter_frequencies(q, frange, mismatch, dur):
     fstep = fcum_mismatch / nfreq
     fstepmin = 1. / dur
     # for each frequency, yield a QTile
-    for i in xrange(nfreq):
+    for i in range(nfreq):
         yield (float(minf) *
                exp(2 / (2 + q**2)**(1/2.) * (i + .5) * fstep) //
                fstepmin * fstepmin)

--- a/pycbc/io/hdf.py
+++ b/pycbc/io/hdf.py
@@ -6,6 +6,7 @@ import h5py
 import numpy as np
 import logging
 import inspect
+from six.moves import range
 
 from lal import LIGOTimeGPS, YRJUL_SI
 
@@ -787,7 +788,7 @@ class ForegroundTriggers(object):
         for name in sngl_col_names:
             sngl_col_vals[name] = self.get_snglfile_array_dict(name)
 
-        for idx in xrange(len(self.sort_arr)):
+        for idx in range(len(self.sort_arr)):
             # Set up IDs and mapping values
             coinc_id = lsctables.CoincID(idx)
 

--- a/pycbc/io/record.py
+++ b/pycbc/io/record.py
@@ -29,6 +29,7 @@ waves.
 """
 
 import os, sys, types, re, copy, numpy, inspect
+import six
 from six import string_types
 from glue.ligolw import types as ligolw_types
 from pycbc import coordinates, conversions, cosmology
@@ -784,9 +785,13 @@ class FieldArray(numpy.recarray):
             pass
         # numpy has some issues with dtype field names that are unicode,
         # so we'll force them to strings here
-        if self.dtype.names is not None and \
-                any(isinstance(name, unicode) for name in obj.dtype.names):
-            self.dtype.names = map(str, self.dtype.names)
+        if six.PY2:
+            if self.dtype.names is not None and \
+                    any(isinstance(name, unicode) for name in obj.dtype.names):
+                self.dtype.names = map(str, self.dtype.names)
+            # We don't want to do this in python3 because a str *is* unicode,
+            # but maybe numpy in python3 is more lenient of this. Let's just
+            # wait and see if this becomes a problem in python3
 
     def __copy_attributes__(self, other, default=None):
         """Copies the values of all of the attributes listed in
@@ -1139,7 +1144,7 @@ class FieldArray(numpy.recarray):
         if cast_to_dtypes is not None:
             dtype = [cast_to_dtypes[col] for col in columns]
         else:
-            dtype = columns.items()
+            dtype = list(columns.items())
         # get the values
         if _default_types_status['ilwd_as_int']:
             input_array = \

--- a/pycbc/noise/reproduceable.py
+++ b/pycbc/noise/reproduceable.py
@@ -21,6 +21,7 @@
 #
 # =============================================================================
 #
+from six.moves import range
 import numpy, pycbc.psd
 from pycbc.types import TimeSeries, FrequencySeries, complex_same_precision_as
 from numpy.random import RandomState
@@ -111,7 +112,7 @@ def colored_noise(psd, start_time, end_time, seed=0, low_frequency_cutoff=1.0):
 
     # Want to avoid zeroes in PSD.
     max_val = psd.max()
-    for i in xrange(len(psd)):
+    for i in range(len(psd)):
         if i >= (oldlen-1):
             psd.data[i] = psd[oldlen - 2]
         if psd[i] == 0:

--- a/pycbc/strain/strain.py
+++ b/pycbc/strain/strain.py
@@ -114,7 +114,7 @@ def detect_loud_glitches(strain, psd_duration=4., psd_stride=2.,
 
     # zero-pad strain to a power-of-2 length
     strain_pad_length = next_power_of_2(len(strain))
-    pad_start = strain_pad_length/2 - len(strain)/2
+    pad_start = int(strain_pad_length/2 - len(strain)/2)
     pad_end = pad_start + len(strain)
     strain_pad = pycbc.types.TimeSeries(
             pycbc.types.zeros(strain_pad_length, dtype=strain.dtype),

--- a/pycbc/tmpltbank/bank_output_utils.py
+++ b/pycbc/tmpltbank/bank_output_utils.py
@@ -1,4 +1,5 @@
 from __future__ import division
+from six.moves import range
 import numpy
 from lal import PI, MTSUN_SI, TWOPI, GAMMA
 from glue.ligolw import ligolw, lsctables, ilwd, utils as ligolw_utils
@@ -353,7 +354,7 @@ def output_sngl_inspiral_table(outputFile, tempBank, metricParams,
                     spin2z=sngl.spin2z, full_ethinca=ethincaParams.full_ethinca)
                 # assign the upper frequency cutoff and Gamma0-5 values
                 sngl.f_final = fMax_theor
-                for i in xrange(len(GammaVals)):
+                for i in range(len(GammaVals)):
                     setattr(sngl, "Gamma"+str(i), GammaVals[i])
         # If Gamma metric components are not wanted, assign f_final from an
         # upper frequency cutoff specified in ethincaParams

--- a/pycbc/tmpltbank/lattice_utils.py
+++ b/pycbc/tmpltbank/lattice_utils.py
@@ -15,6 +15,7 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 from __future__ import division
+from six.moves import range
 import copy
 import numpy
 import lal
@@ -65,7 +66,7 @@ def generate_hexagonal_lattice(maxv1, minv1, maxv2, minv2, mindist):
     initLine2 = copy.deepcopy(initLine)
     initLine2[:,0] += 0.5 * (3*mindist)**0.5
     initLine2[:,1] += 1.5 * (mindist)**0.5
-    for i in xrange(len(initLine2)):
+    for i in range(len(initLine2)):
         v1s.append(initLine2[i,0])
         v2s.append(initLine2[i,1])
     tmpv2_1 = initLine[0,1]
@@ -75,10 +76,10 @@ def generate_hexagonal_lattice(maxv1, minv1, maxv2, minv2, mindist):
         tmpv2_2 = tmpv2_2 + 3.0 * (mindist)**0.5
         initLine[:,1] = tmpv2_1
         initLine2[:,1] = tmpv2_2
-        for i in xrange(len(initLine)):
+        for i in range(len(initLine)):
             v1s.append(initLine[i,0])
             v2s.append(initLine[i,1])
-        for i in xrange(len(initLine2)):
+        for i in range(len(initLine2)):
             v1s.append(initLine2[i,0])
             v2s.append(initLine2[i,1])
     v1s = numpy.array(v1s)

--- a/pycbc/tmpltbank/lattice_utils.py
+++ b/pycbc/tmpltbank/lattice_utils.py
@@ -15,8 +15,8 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 from __future__ import division
-from six.moves import range
 import copy
+from six.moves import range
 import numpy
 import lal
 

--- a/pycbc/tmpltbank/partitioned_bank.py
+++ b/pycbc/tmpltbank/partitioned_bank.py
@@ -17,6 +17,7 @@
 import copy
 import numpy
 import logging
+from six.moves import range
 from pycbc.tmpltbank import coord_utils
 
 class PartitionedTmpltbank(object):
@@ -92,10 +93,10 @@ class PartitionedTmpltbank(object):
         massbank = {}
         bank = {}
         # Also add a little bit here
-        for i in xrange(-2, int((chi1_max - chi1_min) // bin_spacing + 2)):
+        for i in range(-2, int((chi1_max - chi1_min) // bin_spacing + 2)):
             bank[i] = {}
             massbank[i] = {}
-            for j in xrange(-2, int((chi2_max - chi2_min) // bin_spacing + 2)):
+            for j in range(-2, int((chi2_max - chi2_min) // bin_spacing + 2)):
                 bank[i][j] = []
                 massbank[i][j] = {}
                 massbank[i][j]['mass1s'] = numpy.array([])
@@ -218,12 +219,12 @@ class PartitionedTmpltbank(object):
              (chi1_bin > self.max_chi1_bin-bin_range_check) or
              (chi2_bin < self.min_chi2_bin+bin_range_check) or
              (chi2_bin > self.max_chi2_bin-bin_range_check) ):
-            for temp_chi1 in xrange(chi1_bin-bin_range_check,
+            for temp_chi1 in range(chi1_bin-bin_range_check,
                                                    chi1_bin+bin_range_check+1):
                 if temp_chi1 not in self.massbank:
                     self.massbank[temp_chi1] = {}
                     self.bank[temp_chi1] = {}
-                for temp_chi2 in xrange(chi2_bin-bin_range_check,
+                for temp_chi2 in range(chi2_bin-bin_range_check,
                                                    chi2_bin+bin_range_check+1):
                     if temp_chi2 not in self.massbank[temp_chi1]:
                         self.massbank[temp_chi1][temp_chi2] = {}
@@ -604,7 +605,7 @@ class PartitionedTmpltbank(object):
         mass2s = hdf_fp['mass2'][:]
         spin1zs = hdf_fp['spin1z'][:]
         spin2zs = hdf_fp['spin2z'][:]
-        for idx in xrange(len(mass1s)):
+        for idx in range(len(mass1s)):
             self.add_point_by_masses(mass1s[idx], mass2s[idx], spin1zs[idx],
                                      spin2zs[idx], vary_fupper=vary_fupper)
 
@@ -630,7 +631,7 @@ class PartitionedTmpltbank(object):
         spin2z = []
         for i in self.massbank.keys():
             for j in self.massbank[i].keys():
-                for k in xrange(len(self.massbank[i][j]['mass1s'])):
+                for k in range(len(self.massbank[i][j]['mass1s'])):
                     curr_bank = self.massbank[i][j]
                     mass1.append(curr_bank['mass1s'][k])
                     mass2.append(curr_bank['mass2s'][k])

--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -1744,7 +1744,7 @@ class SegFile(File):
             file object for segment xml file
         """
         # load xmldocument and SegmentDefTable and SegmentTables
-        fp = open(xml_file, 'r')
+        fp = open(xml_file, 'rb')
         xmldoc, _ = ligolw_utils.load_fileobj(fp,
                                               gz=xml_file.endswith(".gz"),
                                               contenthandler=ContentHandler)

--- a/pycbc/workflow/segment.py
+++ b/pycbc/workflow/segment.py
@@ -1207,7 +1207,7 @@ def generate_triggered_segment(workflow, out_dir, sciencesegs):
             # If none, offsource dict will contain segments showing criteria
             # that have not been met, for use in plotting
             if len(offsource.keys()) > 1:
-                seg_lens = {ifos: abs(offsource[ifos].itervalues().next()[0])
+                seg_lens = {ifos: abs(next(offsource[ifos].itervalues())[0])
                             for ifos in offsource.keys()}
                 best_comb = max(seg_lens.iterkeys(),
                                 key=(lambda key: seg_lens[key]))
@@ -1218,7 +1218,7 @@ def generate_triggered_segment(workflow, out_dir, sciencesegs):
         else:
             # Identify best analysis segment
             if len(valid_combs) > 1:
-                seg_lens = {ifos: abs(offsource[ifos].itervalues().next()[0])
+                seg_lens = {ifos: abs(next(offsource[ifos].itervalues())[0])
                             for ifos in valid_combs}
                 best_comb = max(seg_lens.iterkeys(),
                                 key=(lambda key: seg_lens[key]))
@@ -1228,11 +1228,11 @@ def generate_triggered_segment(workflow, out_dir, sciencesegs):
 
             offsourceSegfile = os.path.join(out_dir, "offSourceSeg.txt")
             segmentsUtils.tosegwizard(open(offsourceSegfile, "w"),
-                                      offsource[best_comb].itervalues().next())
+                                      next(offsource[best_comb].itervalues()))
 
             onsourceSegfile = os.path.join(out_dir, "onSourceSeg.txt")
             segmentsUtils.tosegwizard(file(onsourceSegfile, "w"),
-                                      onsource[best_comb].itervalues().next())
+                                      next(onsource[best_comb].itervalues()))
 
             bufferleft = int(cp.get('workflow-exttrig_segments',
                                     'num-buffer-before'))

--- a/test/test_autochisq.py
+++ b/test/test_autochisq.py
@@ -1,4 +1,5 @@
 import sys
+from six.moves import range
 import pycbc
 from pycbc.fft.fftw import set_measure_level
 set_measure_level(0)
@@ -83,7 +84,7 @@ class TestAutochisquare(unittest.TestCase):
         time = np.arange(0, len(hp))*self.del_t
         Nby2 = len(hp)/2
         sngt = np.zeros(len(hp))
-        for i in xrange(len(hp)):
+        for i in range(len(hp)):
             sngt[i] = 9.0e-21*exp(-(time[i]-time[Nby2])**2/self.Q)*sin(self.om*time[i])
 
         self.sig2 = np.zeros(self.seg_len_idx)
@@ -136,7 +137,7 @@ class TestAutochisquare(unittest.TestCase):
 	#self.assertTrue(obt_snr == achi_list[0, 1])
 	#self.assertTrue(obt_ach == achi_list[0, 2])
 
-    #    for i in xrange(1, len(achi_list)):
+    #    for i in range(1, len(achi_list)):
 	#   self.assertTrue(achi_list[i,2] > 4.0)
 
     def test_sg(self):
@@ -186,7 +187,7 @@ class TestAutochisquare(unittest.TestCase):
 	#self.assertTrue(obt_snr == achi_list[0, 1])
 	#self.assertTrue(obt_ach == achi_list[0, 2])
 
-    #    for i in xrange(1, len(achi_list)):
+    #    for i in range(1, len(achi_list)):
 	#   self.assertTrue(achi_list[i,2] > 2.e3)
 
 


### PR DESCRIPTION
Some more python3 fixes, which enable me to actually run a workflow up to (but not including) the INSPIRAL jobs.

 * I changed *all* instances of `xrange` to `six.moves.range`
 * I changed *all* instances of `.next()` to `next()`
 * Dealing with other assorted failures that arose (one integer division issue, one dictionary.items() is no longer a list issue, ...)