### PR TITLE
Add Lambda(m) transform interpolating from TOV integrated EOS file

### DIFF
--- a/pycbc/conversions.py
+++ b/pycbc/conversions.py
@@ -34,7 +34,7 @@ import numpy
 import lal
 import lalsimulation as lalsim
 from pycbc.detector import Detector
-
+import pycbc.cosmology
 from .coordinates import spherical_to_cartesian as _spherical_to_cartesian
 
 #
@@ -402,6 +402,19 @@ def lambda_tilde(mass1, mass2, lambda1, lambda2):
     p1 = (lsum) * (1 + 7. * eta - 31 * eta ** 2.0)
     p2 = (1 - 4 * eta)**0.5 * (1 + 9 * eta - 11 * eta ** 2.0) * (ldiff)
     return formatreturn(8.0 / 13.0 * (p1 + p2), input_is_array)
+
+
+def lambda_from_mass_tov_file(mass, tov_file, distance=0.):
+    """Return the lambda parameter(s) corresponding to the input mass(es)
+    interpolating from the mass-Lambda data for a particular EOS read in from
+    an ASCII file.
+    """
+    data = numpy.loadtxt(tov_file)
+    mass_from_file = data[:, 0]
+    lambda_from_file = data[:, 1]
+    mass_src = mass/(1.0 + pycbc.cosmology.redshift(distance))
+    lambdav = numpy.interp(mass_src, mass_from_file, lambda_from_file)
+    return lambdav
 
 #
 # =============================================================================
@@ -1397,7 +1410,8 @@ def nltides_gw_phase_diff_isco(f_low, f0, amplitude, n, m1, m2):
     return formatreturn(phi_i - phi_l, input_is_array)
 
 
-__all__ = ['dquadmon_from_lambda', 'lambda_tilde', 'primary_mass',
+__all__ = ['dquadmon_from_lambda', 'lambda_tilde',
+           'lambda_from_mass_tov_file', 'primary_mass',
            'secondary_mass', 'mtotal_from_mass1_mass2',
            'q_from_mass1_mass2', 'invq_from_mass1_mass2',
            'eta_from_mass1_mass2', 'mchirp_from_mass1_mass2',

--- a/pycbc/cosmology.py
+++ b/pycbc/cosmology.py
@@ -35,7 +35,7 @@ from scipy import interpolate
 import astropy.cosmology
 from astropy import units
 from astropy.cosmology.core import CosmologyError
-from pycbc.conversions import ensurearray, formatreturn
+import pycbc.conversions
 
 DEFAULT_COSMOLOGY = 'Planck15'
 
@@ -130,7 +130,7 @@ def z_at_value(func, fval, unit, zmax=1000., **kwargs):
     float
         The redshift at the requested values.
     """
-    fval, input_is_array = ensurearray(fval)
+    fval, input_is_array = pycbc.conversions.ensurearray(fval)
     # make sure fval is atleast 1D
     if fval.size == 1 and fval.ndim == 0:
         fval = fval.reshape(1)
@@ -170,8 +170,7 @@ def z_at_value(func, fval, unit, zmax=1000., **kwargs):
                                 "have been set to inf. If you would like "
                                 "better precision, call God.".format(zmax))
                 break
-    return formatreturn(zs, input_is_array)
-
+    return pycbc.conversions.formatreturn(zs, input_is_array)
 
 def _redshift(distance, **kwargs):
     r"""Uses astropy to get redshift from the given luminosity distance.
@@ -254,7 +253,7 @@ class DistToZ(object):
     def get_redshift(self, dist):
         """Returns the redshift for the given distance.
         """
-        dist, input_is_array = ensurearray(dist)
+        dist, input_is_array = pycbc.conversions.ensurearray(dist)
         try:
             zs = self.nearby_d2z(dist)
         except TypeError:
@@ -275,7 +274,7 @@ class DistToZ(object):
                 raise ValueError("distance must be finite and > 0")
             zs[replacemask] = _redshift(dist[replacemask],
                                         cosmology=self.cosmology)
-        return formatreturn(zs, input_is_array)
+        return pycbc.conversions.formatreturn(zs, input_is_array)
 
     def __call__(self, dist):
         return self.get_redshift(dist)

--- a/pycbc/transforms.py
+++ b/pycbc/transforms.py
@@ -1020,7 +1020,7 @@ class LambdaFromTOVFile(BaseTransform):
 
     @staticmethod
     def lambda_from_tov_data(m, d, mass_data, lambda_data):
-        r"""Returns Lambda corresponding to a given mass interpolating from the
+        """Returns Lambda corresponding to a given mass interpolating from the
         TOV data.
         Parameters
         ----------
@@ -1042,7 +1042,7 @@ class LambdaFromTOVFile(BaseTransform):
         return lambdav
 
     def transform(self, maps):
-        r"""Computes the transformation of mass to Lambda.
+        """Computes the transformation of mass to Lambda.
         Parameters
         ----------
         maps : dict or FieldArray

--- a/pycbc/transforms.py
+++ b/pycbc/transforms.py
@@ -967,7 +967,8 @@ class LambdaFromTOVFile(BaseTransform):
         The name of the tidal deformability parameter that mass_param is to
         be converted to interpolating from the data in the mass-Lambda file.
     mass_lambda_file : str
-        Path of the mass-Lambda data file
+        Path of the mass-Lambda data file. The first column in the data file
+        should contain mass values, and the second column Lambda values.
     distance : float, optional
     """
     name = 'lambda_from_tov_file'


### PR DESCRIPTION
This PR : 
- Adds a transform class`LambdaFromTOVFile`, that reads in an ASCII file containing mass-Lambda data from a particular EOS, name of a `mass_param` (for example `mass1`, `mass2`), name of a `lambda_param`(for example `lambda1`, `lambda2`) to transform the given `mass_param` samples to `lambda_param` samples interpolating from the data in the ASCII file. The mass, Lambda data read in are stored as class properties. The provided `mass_param` samples can be in the detector frame ( which is the case mostly when the transforms are used in the PE run ), but the `mass` data in the EOS file is in the source frame. So the `mass_param` samples should be converted to source frame before the interpolation. To do that, either a fixed `distance` value can be provided as input to the class, or `distance` samples can be provided during the transformation. If the `mass_param` samples are in the source frame, `distance=0` should be provided to the class.

- Adds a `lambda_from_mass_tov_file` function in the conversions module, that reads in mass, mass-lambda ASCII file, distance values to convert mass to lambda. This can be used for example, to transform mass+distance posterior samples from PE runs to lambda samples reading off from the ASCII file used.

- Also updated a couple of imports in cosmology.py, as importing `pycbc.cosmology` or `redshift` from `pycbc.cosmology`, and then calling `lambda_from_mass_tov_file` gave me the error that `ensurearray` cannot be imported in cosmology.py .