### PR TITLE
Config file sanity check for inference

### DIFF
--- a/pycbc/distributions/__init__.py
+++ b/pycbc/distributions/__init__.py
@@ -132,6 +132,13 @@ def read_params_from_config(cp, prior_section='prior',
     if any(missing_prior):
         raise KeyError("You are missing a priors section in the config file "
                        "for parameter(s): {}".format(', '.join(missing_prior)))
+    # sanity check that each parameter with a priors section is in
+    # [variable_args]
+    missing_variable = tags - set(variable_args)
+    if any(missing_variable):
+        raise KeyError("Prior section found for parameter(s) {} but not "
+                       "listed as variable parameter(s)."
+                       .format(', '.join(missing_variable)))
     # get static args
     try:
         static_args = dict([(key, cp.get_opt_tags(sargs_section, key, []))


### PR DESCRIPTION
pycbc_inference will raise an error if a variable_param has no priors section. However, if there is a priors section for a variable that is not specified in the list of variable_params, it will just run without sampling over that parameter (which would raise no warnings/errors if that parameter has a default value in the waveform approximants).
This PR raises an error when reading the config file if it finds a priors section that has no matching variable in the variable_params section.