### PR TITLE
Plot average chains for parameters by default

### DIFF
--- a/bin/inference/pycbc_inference_plot_samples
+++ b/bin/inference/pycbc_inference_plot_samples
@@ -38,11 +38,10 @@ parser.add_argument("--verbose", action="store_true", default=False,
 parser.add_argument("--version", action="version", version=__version__,
                     help="show version number and exit")
 parser.add_argument("--walkers", nargs='+', default=None,
-                    help="Walker indices from the temperature `--temps`  to "
-                         "plot. Options are 'all' or one or more walker "
-                         "indices. Default is to plot the average of all "
-                         "walkers from the common temperature `--temps` for "
-                         "the input `--parameters`.")
+                    help="Walker indices to plot. Options are 'all' or one "
+                         "or more walker indices. Default is to plot the "
+                         "average of all walkers for the input "
+                         "`--parameters`.")
 parser.add_argument("--output-file", type=str, required=True,
                     help="Path to output plot.")
 
@@ -52,12 +51,8 @@ opts = parser.parse_args()
 # setup log
 pycbc.init_logging(opts.verbose)
 
-rc('text', usetex=True)
-
 # load the results
-fp, parameters, labels, _ = io.results_from_cli(opts,
-                                                load_samples=False,
-                                                walkers=None)
+fp, parameters, labels, _ = io.results_from_cli(opts, load_samples=False)
 
 # get number of dimensions
 ndim = len(parameters)
@@ -79,48 +74,48 @@ axs = [axs] if not hasattr(axs, "__iter__") else axs
 
 file_parameters, cs = transforms.get_common_cbc_transforms(
                                             parameters, fp.variable_params)
+
 if opts.thin_start is not None:
     xmin = opts.thin_start
 else:
-    xmin = fp.attrs['thin_start']
-
-if opts.thin_end is not None:
-    xmax = opts.thin_end
-else:
     try:
-        xmax = fp.attrs['thin_end']
+        xmin = fp.attrs['thin_start']
     except KeyError:
-        xmax = fp.niterations
+        xmin = 0
 
 if opts.thin_interval is not None:
     xint = opts.thin_interval
 else:
     xint = fp.attrs['thin_interval']
 
-if xmin > xmax:
-    raise ValueError("Start iteration {} provided for reading samples is "
-                     "higher than the end iteration {}.".format(xmin, xmax))
-xvals = numpy.arange(xmin, xmax, xint)
+thinned_by = fp.thinned_by*xint
+
+# add the temperature args if it exists
+additional_args = {}
+try:
+    additional_args['temps'] = opts.temps
+except AttributeError:
+    pass
 
 for i, arg in enumerate(parameters):
     chains_arg = []
     for widx in walkers:
-        chain = fp.read_samples(file_parameters, temps=opts.temps,
-                                walkers=widx, thin_start=opts.thin_start,
+        chain = fp.read_samples(file_parameters, walkers=widx,
+                                thin_start=opts.thin_start,
                                 thin_interval=opts.thin_interval,
-                                thin_end=opts.thin_end)
+                                thin_end=opts.thin_end, **additional_args)
         chain = transforms.apply_transforms(chain, cs)
         chains_arg.append(chain[arg])
     if opts.walkers is not None:
         for chain in chains_arg:
             # plot each walker as a different line on the subplot
-            axs[i].plot(xvals, chain, alpha=0.6)
+            axs[i].plot((numpy.arange(len(chain)))*thinned_by + xmin, chain, alpha=0.6)
     else:
         # plot the average of all walkers for the parameter on the subplot
         chains_arg = numpy.array(chains_arg)
-        avg_chain = [chains_arg[:, j].sum()/fp.nwalkers 
+        avg_chain = [chains_arg[:, j].sum()/fp.nwalkers
                      for j in range(len(chains_arg[0]))]
-        axs[i].plot(xvals, avg_chain)
+        axs[i].plot((numpy.arange(len(avg_chain)))*thinned_by + xmin, avg_chain)
     # Set y labels
     axs[i].set_ylabel(labels[arg])
 fp.close()

--- a/bin/inference/pycbc_inference_plot_samples
+++ b/bin/inference/pycbc_inference_plot_samples
@@ -38,11 +38,11 @@ parser.add_argument("--verbose", action="store_true", default=False,
 parser.add_argument("--version", action="version", version=__version__,
                     help="show version number and exit")
 parser.add_argument("--walkers", nargs='+', default=None,
-                    help="Walker indices from the coldest temperature to "
+                    help="Walker indices from the temperature `--temps`  to "
                          "plot. Options are 'all' or one or more walker "
                          "indices. Default is to plot the average of all "
-                         "walkers from the coldest temperature for the input "
-                         "`--parameters`.")
+                         "walkers from the common temperature `--temps` for "
+                         "the input `--parameters`.")
 parser.add_argument("--output-file", type=str, required=True,
                     help="Path to output plot.")
 

--- a/bin/inference/pycbc_inference_plot_samples
+++ b/bin/inference/pycbc_inference_plot_samples
@@ -23,6 +23,8 @@ import logging
 from matplotlib import use
 use('agg')
 from matplotlib import pyplot as plt
+from matplotlib import rc
+import numpy
 import pycbc
 from pycbc import (results, transforms)
 from pycbc import __version__
@@ -30,11 +32,17 @@ from pycbc.inference import (option_utils, io)
 import sys
 
 # command line usage
-parser = argparse.parser = io.ResultsArgumentParser()
+parser = argparse.parser = io.ResultsArgumentParser(skip_args=['walkers'])
 parser.add_argument("--verbose", action="store_true", default=False,
                     help="Print logging info.")
 parser.add_argument("--version", action="version", version=__version__,
                     help="show version number and exit")
+parser.add_argument("--walkers", nargs='+', default=None,
+                    help="Walker indices from the coldest temperature to "
+                         "plot. Options are 'all' or one or more walker "
+                         "indices. Default is to plot the average of all "
+                         "walkers from the coldest temperature for the input "
+                         "`--parameters`.")
 parser.add_argument("--output-file", type=str, required=True,
                     help="Path to output plot.")
 
@@ -44,44 +52,87 @@ opts = parser.parse_args()
 # setup log
 pycbc.init_logging(opts.verbose)
 
+rc('text', usetex=True)
+
 # load the results
 fp, parameters, labels, _ = io.results_from_cli(opts,
-                                                load_samples=False)
+                                                load_samples=False,
+                                                walkers=None)
 
 # get number of dimensions
 ndim = len(parameters)
 
+# get walker indices
+if opts.walkers == ['all'] or opts.walkers == None:
+    walkers = range(fp.nwalkers)
+else:
+    walkers = list(map(int, opts.walkers))
+
 # plot samples
 # plot each parameter as a different subplot
 logging.info("Plotting samples")
-fig, axs = plt.subplots(ndim, sharex=True)
+fig, axs = plt.subplots(ndim, figsize=(10,8), sharex=True)
 plt.xlabel("Iteration")
 
 # loop over parameters
 axs = [axs] if not hasattr(axs, "__iter__") else axs
-for i, arg in enumerate(parameters):
-    # plot each walker as a different line on the subplot
-    for j in range(fp.nwalkers):
-        # plot each walker as a different line on the subplot
-        file_parameters, cs = transforms.get_common_cbc_transforms(
-                                                 parameters, fp.variable_params)
-        y = fp.read_samples(file_parameters, walkers=j,
-                            thin_start=opts.thin_start,
-                            thin_interval=opts.thin_interval,
-                            thin_end=opts.thin_end)
-        y = transforms.apply_transforms(y, cs)
 
-        axs[i].plot(y[arg], alpha=0.25)
-        # Set y labels
-        axs[i].set_ylabel(labels[arg])
+file_parameters, cs = transforms.get_common_cbc_transforms(
+                                            parameters, fp.variable_params)
+if opts.thin_start is not None:
+    xmin = opts.thin_start
+else:
+    xmin = fp.attrs['thin_start']
+
+if opts.thin_end is not None:
+    xmax = opts.thin_end
+else:
+    try:
+        xmax = fp.attrs['thin_end']
+    except KeyError:
+        xmax = fp.niterations
+
+if opts.thin_interval is not None:
+    xint = opts.thin_interval
+else:
+    xint = fp.attrs['thin_interval']
+
+if xmin > xmax:
+    raise ValueError("Start iteration {} provided for reading samples is "
+                     "higher than the end iteration {}.".format(xmin, xmax))
+xvals = numpy.arange(xmin, xmax, xint)
+
+for i, arg in enumerate(parameters):
+    chains_arg = []
+    for widx in walkers:
+        chain = fp.read_samples(file_parameters, temps=opts.temps,
+                                walkers=widx, thin_start=opts.thin_start,
+                                thin_interval=opts.thin_interval,
+                                thin_end=opts.thin_end)
+        chain = transforms.apply_transforms(chain, cs)
+        chains_arg.append(chain[arg])
+    if opts.walkers is not None:
+        for chain in chains_arg:
+            # plot each walker as a different line on the subplot
+            axs[i].plot(xvals, chain, alpha=0.6)
+    else:
+        # plot the average of all walkers for the parameter on the subplot
+        chains_arg = numpy.array(chains_arg)
+        avg_chain = [chains_arg[:, j].sum()/fp.nwalkers 
+                     for j in range(len(chains_arg[0]))]
+        axs[i].plot(xvals, avg_chain)
+    # Set y labels
+    axs[i].set_ylabel(labels[arg])
 fp.close()
 
 # save figure with meta-data
 caption_kwargs = {
     "parameters" : ", ".join(labels),
 }
-caption = r"""All samples from all the walker chains for the parameters. Each
-line is a different chain of walker samples."""
+caption = r"""Parameter samples from the walker chains whose indices were
+provided as inputs. Each line is a different chain of walker samples in that
+case. If no walker indices were provided, the plot shows the variation of the
+parameter sample values averaged over all walkers."""
 title = "Samples for {parameters}".format(**caption_kwargs)
 results.save_fig_with_metadata(fig, opts.output_file,
                                cmd=" ".join(sys.argv),

--- a/bin/inference/pycbc_inference_plot_samples
+++ b/bin/inference/pycbc_inference_plot_samples
@@ -89,6 +89,7 @@ else:
     xint = fp.attrs['thin_interval']
 
 thinned_by = fp.thinned_by*xint
+xmin = xmin*fp.thinned_by
 
 # add the temperature args if it exists
 additional_args = {}


### PR DESCRIPTION
This PR:
- makes `pycbc_inference_plot_samples` plot the average of all walkers for `--parameters` by default, if no `--walkers` is provided as input.
- Options for `--walkers` if provided are `'all'` which plots chains for all walkers from the common temperature `--temps`, or a sequence of indices which plots chains corresponding to those walker indices from the common temperature `--temps`. 
- plots the real iterations in the x axis now instead of intervals which were labeled as iterations before.
- added a figsize so that the labels are not cut off and some font edits.

Examples : 
No `--walkers` provided, so plots averaged chain : https://sugwg-jobs.phy.syr.edu/~soumi.de/tmp/samples_mchirp_m1_walkersNone.png
`--walkers 'all'` : https://sugwg-jobs.phy.syr.edu/~soumi.de/tmp/samples_mchirp_m1_walkersall.png
`--walkers 0 50 100 150 199` : https://sugwg-jobs.phy.syr.edu/~soumi.de/tmp/samples_mchirp_m1_walkersidxs0_50_100_150_199.png