### PR TITLE
Multiifo ranking statistic

### DIFF
--- a/bin/hdfcoinc/pycbc_multiifo_coinc_findtrigs
+++ b/bin/hdfcoinc/pycbc_multiifo_coinc_findtrigs
@@ -32,12 +32,11 @@ parser.add_argument("--use-maxalpha", action="store_true")
 parser.add_argument("--coinc-threshold", type=float, default=0.0,
                     help="Seconds to add to time-of-flight coincidence window")
 parser.add_argument("--timeslide-interval", type=float,
-                    help="Interval between timeslides in seconds. Timeslides are"
-                         " disabled if the option is omitted.")
-parser.add_argument("--loudest-keep-values", type=str, nargs='*', default='6:1',
-                    help="Apply successive multiplicative levels of decimation"
-                         " to coincs with stat value below the given thresholds"
-                         " Ex. 9:10 8.5:30 8:30 7.5:30. Default: no decimation")
+                    help="Interval between timeslides in seconds. Timeslides are "
+                         "disabled if the option is omitted.")
+parser.add_argument("--loudest-keep-values", type=str, nargs='*',
+                     help="Apply a sequence of decimations at the given thresholds"
+                          "Ex. 8.5:10 8:10 7.5:10 7:10")
 parser.add_argument("--template-fraction-range", default="0/1",
                     help="Optional, analyze only part of template bank. Format"
                          " PART/NUM_PARTS")

--- a/bin/hdfcoinc/pycbc_multiifo_coinc_findtrigs
+++ b/bin/hdfcoinc/pycbc_multiifo_coinc_findtrigs
@@ -32,11 +32,12 @@ parser.add_argument("--use-maxalpha", action="store_true")
 parser.add_argument("--coinc-threshold", type=float, default=0.0,
                     help="Seconds to add to time-of-flight coincidence window")
 parser.add_argument("--timeslide-interval", type=float,
-                    help="Interval between timeslides in seconds. Timeslides are "
-                         "disabled if the option is omitted.")
-parser.add_argument("--loudest-keep-values", type=str, nargs='*',
-                     help="Apply a sequence of decimations at the given thresholds"
-                          "Ex. 8.5:10 8:10 7.5:10 7:10")
+                    help="Interval between timeslides in seconds. Timeslides are"
+                         " disabled if the option is omitted.")
+parser.add_argument("--loudest-keep-values", type=str, nargs='*', default='6:1',
+                    help="Apply successive multiplicative levels of decimation"
+                         " to coincs with stat value below the given thresholds"
+                         " Ex. 9:10 8.5:30 8:30 7.5:30. Default: no decimation")
 parser.add_argument("--template-fraction-range", default="0/1",
                     help="Optional, analyze only part of template bank. Format"
                          " PART/NUM_PARTS")
@@ -50,7 +51,6 @@ parser.add_argument("--output-file",
                     help="File to store the coincident triggers")
 parser.add_argument("--batch-singles", default=5000, type=int,
                     help="Number of single triggers to process at once")
-
 args = parser.parse_args()
 
 # flatten the list of lists of filenames to a single list (may be empty)
@@ -267,7 +267,7 @@ for tnum in template_ids:
             logging.info('Calculating Multi-Detector Combined Statistic')
             sdswithids = {}
             for ifo in sds:
-                sdswithids[ifo]=sds[ifo][ids[ifo]]
+                sdswithids[ifo] = sds[ifo][ids[ifo]]
             cstat = rank_method.coinc_multiifo(sdswithids, slide,
                                            args.timeslide_interval,
                                            time_addition=args.coinc_threshold)

--- a/bin/hdfcoinc/pycbc_multiifo_coinc_findtrigs
+++ b/bin/hdfcoinc/pycbc_multiifo_coinc_findtrigs
@@ -264,12 +264,11 @@ for tnum in template_ids:
                                                       args.pivot_ifo,
                                                       args.fixed_ifo)
             logging.info('Coincident Trigs: %s' % (len(ids[args.pivot_ifo])))
-            print(len(ids[args.pivot_ifo]))
             logging.info('Calculating Multi-Detector Combined Statistic')
             sdswithids = {}
             for ifo in sds:
                 sdswithids[ifo]=sds[ifo][ids[ifo]]
-            c = rank_method.coinc_multiifo(sdswithids, slide,
+            cstat = rank_method.coinc_multiifo(sdswithids, slide,
                                            args.timeslide_interval,
                                            time_addition=args.coinc_threshold)
 

--- a/bin/hdfcoinc/pycbc_multiifo_coinc_findtrigs
+++ b/bin/hdfcoinc/pycbc_multiifo_coinc_findtrigs
@@ -50,6 +50,7 @@ parser.add_argument("--output-file",
                     help="File to store the coincident triggers")
 parser.add_argument("--batch-singles", default=5000, type=int,
                     help="Number of single triggers to process at once")
+
 args = parser.parse_args()
 
 # flatten the list of lists of filenames to a single list (may be empty)
@@ -263,13 +264,14 @@ for tnum in template_ids:
                                                       args.pivot_ifo,
                                                       args.fixed_ifo)
             logging.info('Coincident Trigs: %s' % (len(ids[args.pivot_ifo])))
-
+            print(len(ids[args.pivot_ifo]))
             logging.info('Calculating Multi-Detector Combined Statistic')
             sdswithids = {}
             for ifo in sds:
-                sdswithids[ifo] = sds[ifo][ids[ifo]]
-            cstat = rank_method.coinc_multiifo(sdswithids, slide,
-                                               args.timeslide_interval)
+                sdswithids[ifo]=sds[ifo][ids[ifo]]
+            c = rank_method.coinc_multiifo(sdswithids, slide,
+                                           args.timeslide_interval,
+                                           time_addition=args.coinc_threshold)
 
             # index values of the zerolag triggers
             fi = numpy.where(slide == 0)[0]

--- a/bin/hdfcoinc/pycbc_multiifo_coinc_findtrigs
+++ b/bin/hdfcoinc/pycbc_multiifo_coinc_findtrigs
@@ -86,7 +86,7 @@ class ReadByTemplate(object):
         self.segs = veto.start_end_to_segments(s, e).coalesce()
         for vfile, name in zip(veto_files, segment_name):
             veto_segs = veto.select_segments_by_definer(vfile, ifo=self.ifo,
-                                                     segment_name=name)
+                                                        segment_name=name)
             self.segs = (self.segs - veto_segs).coalesce()
         self.valid = veto.segments_to_start_end(self.segs)
 
@@ -268,9 +268,11 @@ for tnum in template_ids:
             sdswithids = {}
             for ifo in sds:
                 sdswithids[ifo] = sds[ifo][ids[ifo]]
-            cstat = rank_method.coinc_multiifo(sdswithids, slide,
-                                           args.timeslide_interval,
-                                           time_addition=args.coinc_threshold)
+            cstat = rank_method.coinc_multiifo(sdswithids,
+                                               slide,
+                                               args.timeslide_interval,
+                                               time_addition=\
+                                                   args.coinc_threshold)
 
             # index values of the zerolag triggers
             fi = numpy.where(slide == 0)[0]
@@ -301,8 +303,7 @@ for tnum in template_ids:
 
                 bi_dec = numpy.concatenate([idx_keep, idx])
                 dec = numpy.concatenate([dec[upper],
-                                         numpy.repeat(total_factor, len(idx))]
-                                       )
+                                         numpy.repeat(total_factor, len(idx))])
 
             ti = numpy.concatenate([bi_dec, fi]).astype(numpy.uint32)
             dec_fac = numpy.concatenate([dec, numpy.ones(len(fi))])

--- a/pycbc/events/coinc_rate.py
+++ b/pycbc/events/coinc_rate.py
@@ -36,7 +36,7 @@ def multiifo_noise_coinc_rate(rates, slop):
         Value is expected coincidence rate in the combination, units Hz
     """
     expected_coinc_rates = {}
-   
+
     # Order of ifos must be stable in output dict keys, so sort them
     ifos = sorted(list(rates.keys()))
     ifostring = ' '.join(ifos)

--- a/pycbc/events/coinc_rate.py
+++ b/pycbc/events/coinc_rate.py
@@ -36,7 +36,7 @@ def multiifo_noise_coinc_rate(rates, slop):
         Value is expected coincidence rate in the combination, units Hz
     """
 
-    ifos = numpy.array(sorted(rates.keys()))
+    ifos = sorted(list(rates.keys()))
     expected_coinc_rates = {}
 
     # Calculate coincidence for all-ifo combination
@@ -46,7 +46,6 @@ def multiifo_noise_coinc_rate(rates, slop):
     # if more than one possible coincidence type exists,
     # calculate coincidence for subsets through recursion
     if len(ifos) > 2:
-        ifos = numpy.array(sorted(rates.keys()))
         # Calculate rate for each 'miss-one-out' detector combination
         subsets = itertools.combinations(ifos, len(ifos) - 1)
         for subset in subsets:
@@ -81,13 +80,9 @@ def combination_noise_coinc_rate(rates, slop):
     combo_coinc_rate: numpy array
         Value is expected coincidence rate in the combination, units Hz
     """
-    # extract ifo list and rates vectors from the dictionary
-    ifos = numpy.array(rates.keys())
-    rates_raw = [rates[ifo] for ifo in ifos]
-
     # multiply product of trigger rates by the overlap time
-    allowed_area = multiifo_noise_coincident_area(ifos, slop)
-    rateprod = [numpy.prod(rs) for rs in zip(*rates_raw)]
+    allowed_area = multiifo_noise_coincident_area(list(rates.keys()), slop)
+    rateprod = [numpy.prod(rs) for rs in zip(*rates.values())]
     combo_coinc_rate = allowed_area * numpy.array(rateprod)
 
     return combo_coinc_rate

--- a/pycbc/events/coinc_rate.py
+++ b/pycbc/events/coinc_rate.py
@@ -36,7 +36,7 @@ def multiifo_noise_coinc_rate(rates, slop):
         Value is expected coincidence rate in the combination, units Hz
     """
     expected_coinc_rates = {}
-        
+   
     # Order of ifos must be stable in output dict keys, so sort them
     ifos = sorted(list(rates.keys()))
     ifostring = ' '.join(ifos)

--- a/pycbc/events/coinc_rate.py
+++ b/pycbc/events/coinc_rate.py
@@ -35,15 +35,16 @@ def multiifo_noise_coinc_rate(rates, slop):
         Dictionary keyed on the ifo combination string
         Value is expected coincidence rate in the combination, units Hz
     """
-
-    ifos = sorted(list(rates.keys()))
     expected_coinc_rates = {}
+        
+    # Order of ifos must be stable in output dict keys, so sort them
+    ifos = sorted(list(rates.keys()))
+    ifostring = ' '.join(ifos)
 
     # Calculate coincidence for all-ifo combination
-    ifostring = ' '.join(ifos)
     expected_coinc_rates[ifostring] = combination_noise_coinc_rate(rates, slop)
 
-    # if more than one possible coincidence type exists,
+    # If more than one possible coincidence type exists,
     # calculate coincidence for subsets through recursion
     if len(ifos) > 2:
         # Calculate rate for each 'miss-one-out' detector combination
@@ -81,9 +82,10 @@ def combination_noise_coinc_rate(rates, slop):
         Value is expected coincidence rate in the combination, units Hz
     """
     # multiply product of trigger rates by the overlap time
-    allowed_area = multiifo_noise_coincident_area(list(rates.keys()), slop)
-    rateprod = [numpy.prod(rs) for rs in zip(*rates.values())]
-    combo_coinc_rate = allowed_area * numpy.array(rateprod)
+    allowed_area = multiifo_noise_coincident_area(list(rates), slop)
+    # list(dict.values()) is python-3-proof
+    rateprod = numpy.prod(list(rates.values()), axis=0)
+    combo_coinc_rate = allowed_area * rateprod
 
     return combo_coinc_rate
 

--- a/pycbc/events/coinc_rate.py
+++ b/pycbc/events/coinc_rate.py
@@ -37,7 +37,6 @@ def multiifo_noise_coinc_rate(rates, slop):
     """
 
     ifos = numpy.array(sorted(rates.keys()))
-    rates_raw = list(rates[ifo] for ifo in ifos)
     expected_coinc_rates = {}
 
     # Calculate coincidence for all-ifo combination
@@ -60,6 +59,7 @@ def multiifo_noise_coinc_rate(rates, slop):
                 expected_coinc_rates[sub_coinc] = sub_coinc_rates[sub_coinc]
 
     return expected_coinc_rates
+
 
 def combination_noise_coinc_rate(rates, slop):
     """
@@ -91,6 +91,7 @@ def combination_noise_coinc_rate(rates, slop):
     combo_coinc_rate = allowed_area * numpy.array(rateprod)
 
     return combo_coinc_rate
+
 
 def multiifo_noise_coincident_area(ifos, slop):
     """

--- a/pycbc/events/coinc_rate.py
+++ b/pycbc/events/coinc_rate.py
@@ -82,8 +82,8 @@ def combination_noise_coinc_rate(rates, slop):
         Value is expected coincidence rate in the combination, units Hz
     """
     # extract ifo list and rates vectors from the dictionary
-    ifos = numpy.array(sorted(rates.keys()))
-    rates_raw = list(rates[ifo] for ifo in ifos)
+    ifos = numpy.array(rates.keys())
+    rates_raw = [rates[ifo] for ifo in ifos]
 
     # multiply product of trigger rates by the overlap time
     allowed_area = multiifo_noise_coincident_area(ifos, slop)

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -602,7 +602,7 @@ class ExpFitSGCoincRateStatistic(ExpFitStatistic):
                        step, **kwargs): # pylint:disable=unused-argument
         """Calculate the final coinc ranking statistic"""
         sngl_rates_dict = {ifo: numpy.exp(sngl_rate) for (ifo, sngl_rate) in\
-                      zip(self.fits_by_tid.keys(), s.values()) }
+                           zip(self.fits_by_tid.keys(), s.values())}
         ln_coinc_rate = numpy.log(coinc_rate.combination_noise_coinc_rate(
                                   sngl_rates_dict, kwargs['time_addition']))
         loglr = - ln_coinc_rate + self.benchmark_lograte

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -578,19 +578,20 @@ class CoincRateCalcStatistic(ExpFitStatistic):
     def __init__(self, files, benchmark_lograte=-14.6):
         # benchmark_lograte is log of a representative noise trigger rate in H1L1 (O2)
         # this is 4.5e-7 Hz
-        ExpFitStatistic.__init__(self, files)
-        self.benchmark_lograte = benchmark_lograte
+        super(CoincRateCalcStatistic, self).__init__(files)
+        self.benchmark_lograte = 0#benchmark_lograte
 
-    def assign_fits(self, ifo):
+        for ifo in self.ifos:
+            self.reassign_rate(ifo)
+
+    def reassign_rate(self, ifo):
         coeff_file = self.files[ifo+'-fit_coeffs']
-        exp_fit_fits = ExpFitStatistic.assign_fits(self, ifo)
         template_id = coeff_file['template_id'][:]
         # the template_ids and fit coeffs are stored in an arbitrary order
         # create new arrays in template_id order for easier recall
         tid_sort = numpy.argsort(template_id)
-        exp_fit_fits['rates'] = coeff_file['count_in_template'][:][tid_sort] / \
+        self.fits_by_tid[ifo]['rate'] = coeff_file['count_in_template'][:][tid_sort] / \
                 float(coeff_file.attrs['analysis_time'])
-        return exp_fit_fits
 
     def coinc_multiifo(self, s, slide,
                   step, **kwargs): # pylint:disable=unused-argument

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -478,7 +478,7 @@ class ExpFitSGCombinedSNR(ExpFitCombinedSNR):
 
 class ExpFitSGPSDCombinedSNR(ExpFitCombinedSNR):
 
-    """ExpFitCombinedSNR bnted to do the latter .. so, make an init step that ensures this, or maybe make thiut with sine-Gaussian veto and PSD variation added to
+    """ExpFitCombinedSNR but with sine-Gaussian veto and PSD variation added to
 
     the single detector ranking
     """

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -458,7 +458,8 @@ class ExpFitCombinedSNR(ExpFitStatistic):
         # scale by 1/sqrt(2) to resemble network SNR
         return (s0 + s1) / 2.**0.5
 
-    def coinc_multiifo(self, s, slide, step, **kwargs): # pylint:disable=unused-argument
+    def coinc_multiifo(self, s, slide,
+                       step, **kwargs): # pylint:disable=unused-argument
         # scale by 1/sqrt(number of ifos) to resemble network SNR
         return sum(x for x in s.values()) / len(s)**0.5
 
@@ -576,10 +577,10 @@ class CoincRateCalcStatistic(ExpFitStatistic):
     """
 
     def __init__(self, files, benchmark_lograte=-14.6):
-        # benchmark_lograte is log of a representative noise trigger rate in H1L1 (O2)
-        # this is 4.5e-7 Hz
+        # benchmark_lograte is log of a representative noise trigger rate
+        # This comes from H1L1 (O2) and is 4.5e-7 Hz
         super(CoincRateCalcStatistic, self).__init__(files)
-        self.benchmark_lograte = 0#benchmark_lograte
+        self.benchmark_lograte = 0  # benchmark_lograte
 
         for ifo in self.ifos:
             self.reassign_rate(ifo)
@@ -590,17 +591,18 @@ class CoincRateCalcStatistic(ExpFitStatistic):
         # the template_ids and fit coeffs are stored in an arbitrary order
         # create new arrays in template_id order for easier recall
         tid_sort = numpy.argsort(template_id)
-        self.fits_by_tid[ifo]['rate'] = coeff_file['count_in_template'][:][tid_sort] / \
-                float(coeff_file.attrs['analysis_time'])
+        self.fits_by_tid[ifo]['rate'] = \
+            coeff_file['count_in_template'][:][tid_sort] / \
+            float(coeff_file.attrs['analysis_time'])
 
     def coinc_multiifo(self, s, slide,
-                  step, **kwargs): # pylint:disable=unused-argument
+                       step, **kwargs): # pylint:disable=unused-argument
         """Calculate the final coinc ranking statistic"""
         snglsprod = sum(x for x in s.values())
         ifo_list = [ifo for ifo in self.fits_by_tid]
         ln_coinc_area = numpy.log(coinc_rate.multiifo_noise_coincident_area(
-                                             ifo_list, kwargs['time_addition']))
-        loglr = - ln_coinc_area - snglsprod - self.benchmark_lograte
+                                  ifo_list, kwargs['time_addition']))
+        loglr = - ln_coinc_area + snglsprod - self.benchmark_lograte
         return loglr
 
 

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -582,7 +582,6 @@ class ExpFitSGCoincRateStatistic(ExpFitStatistic):
         super(ExpFitSGCoincRateStatistic, self).__init__(files)
         self.benchmark_lograte = benchmark_lograte
         self.get_newsnr = ranking.get_newsnr_sgveto
-        
         # Reassign the rate as the we are now calculating total number in
         # the template and dividing by time rather than just counting above
         # threshold as was done previously
@@ -596,7 +595,7 @@ class ExpFitSGCoincRateStatistic(ExpFitStatistic):
         # create new arrays in template_id order for easier recall
         tid_sort = numpy.argsort(template_id)
         self.fits_by_tid[ifo]['rate'] = \
-            coeff_file['count_in_template'][:][tid_sort] / \
+            coeff_file['count_above_thresh'][:][tid_sort] / \
             float(coeff_file.attrs['analysis_time'])
 
     def coinc_multiifo(self, s, slide,
@@ -604,8 +603,6 @@ class ExpFitSGCoincRateStatistic(ExpFitStatistic):
         """Calculate the final coinc ranking statistic"""
         sngl_rates_dict = {ifo: numpy.exp(sngl_rate) for (ifo, sngl_rate) in\
                       zip(self.fits_by_tid.keys(), s.values()) }
-        #snglsprod = sum(x for x in s.values())
-        #ifo_list = self.fits_by_tid.keys()
         ln_coinc_rate = numpy.log(coinc_rate.combination_noise_coinc_rate(
                                   sngl_rates_dict, kwargs['time_addition']))
         loglr = - ln_coinc_rate + self.benchmark_lograte

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -582,9 +582,8 @@ class ExpFitSGCoincRateStatistic(ExpFitStatistic):
         super(ExpFitSGCoincRateStatistic, self).__init__(files)
         self.benchmark_lograte = benchmark_lograte
         self.get_newsnr = ranking.get_newsnr_sgveto
-        # Reassign the rate as the we are now calculating total number in
-        # the template and dividing by time rather than just counting above
-        # threshold as was done previously
+        # Reassign the rate as it is now number per time rather than an
+        # arbitrarily normalised number
         for ifo in self.ifos:
             self.reassign_rate(ifo)
 


### PR DESCRIPTION
Multiifo ranking statistic:

Currently calculates the expected rate of coincidences at a given snr value, and subtracts this from a mean coincidence rate (this is a rate for _all_ coincidences, not including the snr infromation) in that detector combination