### PR TITLE
Account for thinning in plot ACF

### DIFF
--- a/bin/inference/pycbc_inference_plot_acf
+++ b/bin/inference/pycbc_inference_plot_acf
@@ -20,6 +20,7 @@ import argparse
 import logging
 import sys
 
+import numpy
 from matplotlib import use
 use('agg')
 from matplotlib import pyplot as plt
@@ -117,11 +118,14 @@ for kk,tk in enumerate(temps):
             acf = acfs[param]
         if opts.per_walker:
             lbl = '{}, walker {}'
+            # account for thinning that was done on the fly
+            xvals = numpy.arange(acf.shape[1])*fp.thinned_by
             for wi in range(acf.shape[0]):
                 wnum = opts.walkers[wi] if opts.walkers is not None else wi
-                ax.plot(acf[wi,:], label=lbl.format(labels[param], wnum))
+                ax.plot(xvals, acf[wi,:], label=lbl.format(labels[param], wnum))
         else:
-            ax.plot(acf, label=labels[param])
+            xvals = numpy.arange(len(acf))*fp.thinned_by
+            ax.plot(xvals, acf, label=labels[param])
     if multi_tempered:
         t = 1./fp[fp.sampler_group].attrs['betas'][tk]
         ax.set_title(r'$T = {}$ (chain {})'.format(t, tk))


### PR DESCRIPTION
If thinning was done on the fly with either `thin-interval` or `max-samples-per-chain`, the x-axis of `plot_acf` will be off by whatever thinning factor was used. This accounts for that. Example on 100 iterations, in which a thinning interval of 4 was used:
 * [Before](https://www.atlas.aei.uni-hannover.de/~work-cdcapano/scratch/prs/fix_plot_acf/before.png)
 * [After](https://www.atlas.aei.uni-hannover.de/~work-cdcapano/scratch/prs/fix_plot_acf/after.png)
The x-axis spans 0-100 in the update.