### PR TITLE
Make plotting acceptance rate and sample chains optional

### DIFF
--- a/bin/workflows/pycbc_make_inference_inj_workflow
+++ b/bin/workflows/pycbc_make_inference_inj_workflow
@@ -227,11 +227,12 @@ for i in range(n_injections):
                           analysis_seg=workflow.analysis_time,
                           tags=[str(i)])
 
-    # make node for plotting acceptance rate
-    accept_files += inference_followups.make_inference_acceptance_rate_plot(
-                          workflow, inference_file, rdir["samples"],
-                          analysis_seg=workflow.analysis_time,
-                          tags=[str(i)])
+    if "inference_rate" in workflow.cp.options("executables"):
+        # make node for plotting acceptance rate
+        accept_files += inference_followups.make_inference_acceptance_rate_plot(
+                              workflow, inference_file, rdir["samples"],
+                              analysis_seg=workflow.analysis_time,
+                              tags=[str(i)])
 
     # plot grouped parameters
     for group in plot_groups.keys():
@@ -246,13 +247,14 @@ for i in range(n_injections):
                           analysis_seg=workflow.analysis_time,
                           tags=[str(i), group])
 
-        # make nodes for plotting sample as function of sampler iterations
-        for j, parameter in enumerate(plot_groups[group]):
-            sample_group_files[group] += \
-                    inference_followups.make_inference_samples_plot(
-                          workflow, inference_file,
-                          rdir[sample_group_fmt.format(group)],
-                          parameters=[parameter],
+        if "inference_samples" in workflow.cp.options("executables"):
+            # make nodes for plotting sample as function of sampler iterations
+            for j, parameter in enumerate(plot_groups[group]):
+                sample_group_files[group] += \
+                        inference_followups.make_inference_samples_plot(
+                              workflow, inference_file,
+                              rdir[sample_group_fmt.format(group)],
+                              parameters=[parameter],
                           analysis_seg=workflow.analysis_time,
                           tags=[str(i), group, str(j)])
 

--- a/bin/workflows/pycbc_make_inference_inj_workflow
+++ b/bin/workflows/pycbc_make_inference_inj_workflow
@@ -255,8 +255,8 @@ for i in range(n_injections):
                               workflow, inference_file,
                               rdir[sample_group_fmt.format(group)],
                               parameters=[parameter],
-                          analysis_seg=workflow.analysis_time,
-                          tags=[str(i), group, str(j)])
+                              analysis_seg=workflow.analysis_time,
+                              tags=[str(i), group, str(j)])
 
 # add plots to HTML pages
 layout.single_layout(rdir["posteriors"],

--- a/bin/workflows/pycbc_make_inference_workflow
+++ b/bin/workflows/pycbc_make_inference_workflow
@@ -321,23 +321,25 @@ for num_event in range(num_events):
                           tags=opts.tags + [str(num_event), group])
         layout.group_layout(rdir[base], post_1d_files)
 
-    # files for samples summary subsection
-    base = "samples"
-    samples_files = []
-    for parameter in all_parameters:
-        samples_files += inffu.make_inference_samples_plot(
-                          workflow, inference_file, rdir[base],
-                          parameters=[parameter], analysis_seg=analysis_time,
-                          tags=opts.tags + [str(num_event), parameter])
-    layout.group_layout(rdir[base], samples_files)
+    if "inference_samples" in workflow.cp.options("executables"):
+        # files for samples summary subsection
+        base = "samples"
+        samples_files = []
+        for parameter in all_parameters:
+            samples_files += inffu.make_inference_samples_plot(
+                              workflow, inference_file, rdir[base],
+                              parameters=[parameter], analysis_seg=analysis_time,
+                              tags=opts.tags + [str(num_event), parameter])
+        layout.group_layout(rdir[base], samples_files)
 
-    # files for samples acceptance_rate subsection
-    base = "samples/acceptance_rate"
-    acceptance_files = inffu.make_inference_acceptance_rate_plot(
-                          workflow, inference_file, rdir[base],
-                          analysis_seg=analysis_time,
-                          tags=opts.tags + [str(num_event)])
-    layout.single_layout(rdir[base], acceptance_files)
+    if "inference_rate" in workflow.cp.options("executables"):
+        # files for samples acceptance_rate subsection
+        base = "samples/acceptance_rate"
+        acceptance_files = inffu.make_inference_acceptance_rate_plot(
+                              workflow, inference_file, rdir[base],
+                              analysis_seg=analysis_time,
+                              tags=opts.tags + [str(num_event)])
+        layout.single_layout(rdir[base], acceptance_files)
 
     # files for detector_sensitivity summary subsection
     base = "detector_sensitivity"


### PR DESCRIPTION
This updates `pycbc_make_inference_inj_workflow` and `pycbc_make_inference_workflow` to make plotting of acceptance rate and sample chains optional. This makes the workflows compatible with nested samplers that might not have an acceptance rate or meaningful sample chains.

With this patch, to include plotting of acceptance rate or sample chains you simply need to include the corresponding `inference_rate` or `inference_samples` in the `executables` section of the workflow config file.