### PR TITLE
Use naming convention params instead of args

### DIFF
--- a/bin/pycbc_create_injections
+++ b/bin/pycbc_create_injections
@@ -20,7 +20,7 @@
 
 Config file syntax
 ------------------
-The configuration file should have a [variable_args], a [static_args],
+The configuration file should have a [variable_params], a [static_params],
 and one or more [distribution] sections. Multiple [constraint] sections and
 one or more [waveform_transforms] sections may also be provided. An example:
 

--- a/bin/pycbc_create_injections
+++ b/bin/pycbc_create_injections
@@ -24,14 +24,14 @@ The configuration file should have a [variable_args], a [static_args],
 and one or more [distribution] sections. Multiple [constraint] sections and
 one or more [waveform_transforms] sections may also be provided. An example:
 
-    [variable_args]
+    [variable_params]
     mass1 =
     mass2 =
     spin1_a =
     spin1_azimuthal =
     spin1_polar =
 
-    [static_args]
+    [static_params]
     approximant = IMRPhenomPv2
     f_lower = 19
 
@@ -69,13 +69,13 @@ spin1_azimuthal). Because the waveform module expects spins to be provided in
 cartesian coordinates, the spherical spin coordinates are transformed prior to
 being written out to file.
 
-The [variable_args] section gives the list of waveform parameters to
-randomize.  The [static_args] section gives parameters that are fixed for all
+The [variable_params] section gives the list of waveform parameters to
+randomize.  The [static_params] section gives parameters that are fixed for all
 of the injections.
 
 The [distribution-{tag}] sections provide the arguments needed to initialize
 the distribution for each parameter. Every parameter specified in
-[variable_args] must have a distribution section; the name of the parameter(s)
+[variable_params] must have a distribution section; the name of the parameter(s)
 used by that distribution must be in the 'tag' part of the section header (the
 bit after the dash). If a distribution covers multiple parameters, the
 parameters should be separated by a '+'.  Any distribution in the distributions
@@ -83,9 +83,9 @@ module may be used.  The rest of the options should provide the necessary
 arguments to initialize that distribution; see the distributions module for
 details.
 
-The variable_args need not be parameters understood by the waveform module.  In
+The variable_params need not be parameters understood by the waveform module.  In
 that case, a [waveform_transforms] sections must be provided that map
-variable_args not understood by the waveform module to parameters that are
+variable_params not understood by the waveform module to parameters that are
 understood. In the above example, spin1_a, spin1_azimuthal, and spin1_polar are
 converted to spin1x, spin1y, and spin1z before being written out. Any transform
 in the transforms module may be used to do this; see that module for details.
@@ -101,7 +101,7 @@ provided, the union of all constraints are applied. Alternatively, multiple
 constraints may be joined in a single argument using numpy's logical operators.
 
 The parameter that constraints are applied to may be any parameter in
-variable_args or any output parameter of the transforms. Functions may be
+variable_params or any output parameter of the transforms. Functions may be
 applied on these parameters to obtain constraints on derived parameters. Any
 function in the conversions, coordinates, or cosmology module may be used,
 along with any numpy ufunc. So, in the above example, mass ratio (q) is
@@ -143,12 +143,12 @@ parser.add_argument('--output-file', required=True,
 parser.add_argument('--dist-section', default='distribution',
                     help='What section in the config file to load '
                           'distributions from. Default is distribution.')
-parser.add_argument('--variable-params-section', default='variable_args',
+parser.add_argument('--variable-params-section', default='variable_params',
                     help='What section in the config file to load the '
-                         'parameters to vary. Default is variable_args.')
-parser.add_argument('--static-args-section', default="static_args",
-                    help='What section to load the static args from. Default '
-                         'is static_args.')
+                         'parameters to vary. Default is variable_params.')
+parser.add_argument('--static-params-section', default="static_params",
+                    help='What section to load the static params from. Default '
+                         'is static_params.')
 parser.add_argument("--force", action="store_true", default=False,
                     help="If the output-file already exists, overwrite it. "
                          "Otherwise, an OSError is raised.")
@@ -168,10 +168,10 @@ logging.info("Loading config file")
 cp = WorkflowConfigParser.from_cli(opts)
 
 # get the vairable and static arguments from the config file
-variable_args, static_args = distributions.read_params_from_config(cp,
+variable_params, static_params = distributions.read_params_from_config(cp,
     prior_section=opts.dist_section,
     vargs_section=opts.variable_params_section,
-    sargs_section=opts.static_args_section)
+    sargs_section=opts.static_params_section)
 constraints = distributions.read_constraints_from_config(cp)
 
 if any(cp.get_subsections('waveform_transforms')):
@@ -179,14 +179,14 @@ if any(cp.get_subsections('waveform_transforms')):
         'waveform_transforms')
 else:
     waveform_transforms = None
-    write_args = variable_args
+    write_args = variable_params
 
 # get prior distribution for each variable parameter
 logging.info("Reading distributions")
 dists = distributions.read_distributions_from_config(cp, opts.dist_section)
 
 # construct class that will draw the samples
-randomsampler = JointDistribution(variable_args, *dists,
+randomsampler = JointDistribution(variable_params, *dists,
                                **{"constraints" : constraints})
 
 logging.info("Drawing samples")
@@ -195,16 +195,16 @@ samples = randomsampler.rvs(size=opts.ninjections)
 if waveform_transforms is not None:
     logging.info("Transforming to waveform transform parameters")
     for t in waveform_transforms:
-        if not set(t.inputs).isdisjoint(set(static_args.keys())):
-            for item in list(set(t.inputs) & set(static_args.keys())):
-                samples = samples.add_fields([numpy.repeat(static_args[item],
+        if not set(t.inputs).isdisjoint(set(static_params.keys())):
+            for item in list(set(t.inputs) & set(static_params.keys())):
+                samples = samples.add_fields([numpy.repeat(static_params[item],
                                              opts.ninjections).astype(float)],
                                              [item])
     samples = transforms.apply_transforms(samples, waveform_transforms)
     write_args = [arg for arg in samples.fieldnames
-                  if arg not in static_args.keys()]
+                  if arg not in static_params.keys()]
 
 # write results
 logging.info("Writing results")
-InjectionSet.write(opts.output_file, samples, write_args, static_args,
+InjectionSet.write(opts.output_file, samples, write_args, static_params,
                    cmd=" ".join(sys.argv))

--- a/bin/workflows/pycbc_make_inference_inj_workflow
+++ b/bin/workflows/pycbc_make_inference_inj_workflow
@@ -41,7 +41,7 @@ parser = argparse.ArgumentParser(description=__doc__[1:])
 # version option
 parser.add_argument(
     "--version", action="version",
-    version=pycbc.version.git_verbose_msg, 
+    version=pycbc.version.git_verbose_msg,
     help="Prints version information.")
 
 # workflow options
@@ -158,8 +158,8 @@ if 'pp-plot-parameters' in  workflow.cp.options("workflow-inference"):
     pp_plot_params = shlex.split(workflow.cp.get_opt_tag("workflow",
         'pp-plot-parameters', 'inference'))
 else:
-    # just use the variable args
-    pp_plot_params = workflow.cp.options(cp.options("variable_args"))
+    # just use the variable params
+    pp_plot_params = workflow.cp.options(cp.options("variable_params"))
 
 # get groups of parameters to plot in posterior and samples plots
 plot_groups = {}
@@ -216,7 +216,7 @@ for i in range(n_injections):
     # make node for writing HTML table of parameters
     post_table_files += inference_followups.make_inference_summary_table(
                           workflow, inference_file, rdir["posteriors"],
-                          variable_args=unique_plot_parameters,
+                          variable_params=unique_plot_parameters,
                           analysis_seg=workflow.analysis_time,
                           tags=[str(i)])
 

--- a/examples/inference/bbh-injection/make_injection.sh
+++ b/examples/inference/bbh-injection/make_injection.sh
@@ -5,5 +5,5 @@ pycbc_create_injections --verbose \
         --seed 10 \
         --output-file injection.hdf \
         --variable-params-section variable_params \
-        --static-args-section static_params \
+        --static-params-section static_params \
         --dist-section prior

--- a/pycbc/inference/io/base_hdf.py
+++ b/pycbc/inference/io/base_hdf.py
@@ -301,7 +301,7 @@ class BaseInferenceFile(h5py.File):
             Array of the loaded samples.
         """
         if parameters is None and opts.parameters is None:
-            parameters = self.variable_args
+            parameters = self.variable_params
         elif parameters is None:
             parameters = opts.parameters
         # parse optional arguments

--- a/pycbc/workflow/inference_followups.py
+++ b/pycbc/workflow/inference_followups.py
@@ -178,7 +178,7 @@ def make_inference_prior_plot(workflow, config_file, output_dir,
     return node.output_files
 
 def make_inference_summary_table(workflow, inference_file, output_dir,
-                    variable_args=None, name="inference_table",
+                    variable_params=None, name="inference_table",
                     analysis_seg=None, tags=None):
     """ Sets up the corner plot of the posteriors in the workflow.
 
@@ -190,8 +190,8 @@ def make_inference_summary_table(workflow, inference_file, output_dir,
         The file with posterior samples.
     output_dir: str
         The directory to store result plots and files.
-    variable_args : list
-        A list of parameters to use instead of [variable_args].
+    variable_params : list
+        A list of parameters to use instead of [variable_params].
     name: str
         The name in the [executables] section of the configuration file
         to use.
@@ -222,7 +222,7 @@ def make_inference_summary_table(workflow, inference_file, output_dir,
     # add command line options
     node.add_input_opt("--input-file", inference_file)
     node.new_output_file_opt(analysis_seg, ".html", "--output-file")
-    node.add_opt("--parameters", " ".join(variable_args))
+    node.add_opt("--parameters", " ".join(variable_params))
 
     # add node to workflow
     workflow += node


### PR DESCRIPTION
This changes to the convention of using `static_params` and `variable_params` in several places: the executables `pycbc_create_injections` and `pycbc_make_inference_inj_workflow`, and the `make_inference_summary_table` function in `pycbc.workflow.inference_followups`.

Note that `pycbc_make_inference_workflow` was already calling `make_inference_summary_table` with a `variable_params` arg. 