### PR TITLE
Updated urllib imports for python3

### DIFF
--- a/bin/pycbc_losc_segment_query
+++ b/bin/pycbc_losc_segment_query
@@ -3,10 +3,14 @@
 import os
 import pwd
 import logging
-import urllib2
 import json
 import argparse
 import shutil
+try:
+    from urllib.request import urlopen
+except ImportError:   # python < 3
+    from urllib2 import urlopen
+
 import ligo.segments
 from glue import git_version
 from glue.ligolw import ligolw
@@ -46,7 +50,7 @@ def query_losc(ifo, segment_name, gps_start_time, duration):
         The segments returned by LOSC
     """
 
-    response = urllib2.urlopen(
+    response = urlopen(
         'https://www.gw-openscience.org/timeline/segments/json/O1/{}_{}/{}/{}/'.format(
         ifo, segment_name, gps_start_time, duration))
 

--- a/examples/gw150914/audio.py
+++ b/examples/gw150914/audio.py
@@ -2,12 +2,15 @@ from pycbc.frame import read_frame
 from pycbc.filter import highpass_fir, lowpass_fir
 from pycbc.psd import welch, interpolate
 from pycbc.types import TimeSeries
-import urllib
+try:
+    from urllib.request import urlretrieve
+except ImportError:  # python < 3
+    from urllib import urlretrieve
 
 # Read data and remove low frequency content
 fname = 'H-H1_LOSC_4_V2-1126259446-32.gwf'
 url = "https://www.gw-openscience.org/GW150914data/" + fname
-urllib.urlretrieve(url, filename=fname)
+urlretrieve(url, filename=fname)
 h1 = highpass_fir(read_frame(fname, 'H1:LOSC-STRAIN'), 15.0, 8)
 
 # Calculate the noise spectrum and whiten

--- a/examples/gw150914/gw150914_h1_snr.py
+++ b/examples/gw150914/gw150914_h1_snr.py
@@ -2,12 +2,15 @@ from pycbc.frame import read_frame
 from pycbc.filter import highpass_fir, matched_filter
 from pycbc.waveform import get_fd_waveform
 from pycbc.psd import welch, interpolate
-import urllib
+try:
+    from urllib.request import urlretrieve
+except ImportError:  # python < 3
+    from urllib import urlretrieve
 
 # Read data and remove low frequency content
 fname = 'H-H1_LOSC_4_V2-1126259446-32.gwf'
 url = "https://www.gw-openscience.org/GW150914data/" + fname
-urllib.urlretrieve(url, filename=fname)
+urlretrieve(url, filename=fname)
 h1 = read_frame('H-H1_LOSC_4_V2-1126259446-32.gwf', 'H1:LOSC-STRAIN')
 h1 = highpass_fir(h1, 15, 8)
 

--- a/pycbc/frame/losc.py
+++ b/pycbc/frame/losc.py
@@ -56,7 +56,11 @@ def losc_frame_json(ifo, start_time, end_time):
         A dictionary containing information about the files that span the
         requested times.
     """
-    import urllib, json
+    import json
+    try:
+        from urllib.request import urlopen
+    except ImportError:  # python < 3
+        from urllib import urlopen
     run = get_run(start_time)
     run2 = get_run(end_time)
     if run != run2:
@@ -67,7 +71,7 @@ def losc_frame_json(ifo, start_time, end_time):
     url = _losc_url % (run, ifo, int(start_time), int(end_time))
 
     try:
-        return json.loads(urllib.urlopen(url).read())
+        return json.loads(urlopen(url).read())
     except Exception as e:
         print(e)
         raise ValueError('Failed to find gwf files for '


### PR DESCRIPTION
This PR updates a few `urllib` imports to work for python3.