### PR TITLE
Updated configparser imports for python3

### DIFF
--- a/bin/pygrb/pycbc_make_grb_summary_page
+++ b/bin/pygrb/pycbc_make_grb_summary_page
@@ -22,7 +22,7 @@
 
 from __future__ import division
 
-import os,sys,datetime,re,glob,shutil,ConfigParser
+import os,sys,datetime,re,glob,shutil
 from argparse import ArgumentParser
 import random
 import string

--- a/pycbc/inference/models/base.py
+++ b/pycbc/inference/models/base.py
@@ -28,7 +28,7 @@
 import numpy
 import logging
 from abc import (ABCMeta, abstractmethod)
-from ConfigParser import NoSectionError
+from six.moves.configparser import NoSectionError
 from pycbc import (transforms, distributions)
 from pycbc.io import FieldArray
 


### PR DESCRIPTION
This PR updates all references to python2's `ConfigParser` module (one update, removed one unused import).

I did notice that there is one example of

https://github.com/gwastro/pycbc/blob/bce57349af445f957f66ce2f28f8b633d9516a3e/pycbc/workflow/configparser_test.py#L3-L7

which is not guaranteed to give the same result as `from six.moves import configparser`, specifically in environments where the [`configparser`](https://pypi.org/project/configparser/) backports module is available.