### PR TITLE
Return keys() as list from functions

### DIFF
--- a/pycbc/fft/backend_support.py
+++ b/pycbc/fft/backend_support.py
@@ -54,7 +54,7 @@ def get_backend_modules():
     return _all_backends_dict.values()
 
 def get_backend_names():
-    return _all_backends_dict.keys()
+    return list(_all_backends_dict.keys())
 
 BACKEND_PREFIX="pycbc.fft.backend_"
 

--- a/pycbc/inference/models/base.py
+++ b/pycbc/inference/models/base.py
@@ -59,7 +59,7 @@ class ModelStats(object):
     @property
     def statnames(self):
         """Returns the names of the stats that have been stored."""
-        return self.__dict__.keys()
+        return list(self.__dict__.keys())
 
     def getstats(self, names, default=numpy.nan):
         """Get the requested stats as a tuple.

--- a/pycbc/inference/models/base_data.py
+++ b/pycbc/inference/models/base_data.py
@@ -144,7 +144,7 @@ class BaseDataModel(BaseModel):
     @property
     def detectors(self):
         """Returns the detectors used."""
-        return self._data.keys()
+        return list(self._data.keys())
 
     def write_metadata(self, fp):
         """Adds data to the metadata that's written.

--- a/pycbc/waveform/waveform.py
+++ b/pycbc/waveform/waveform.py
@@ -295,25 +295,25 @@ def td_approximants(scheme=_scheme.mgr.state):
     """Return a list containing the available time domain approximants for
        the given processing scheme.
     """
-    return td_wav[type(scheme)].keys()
+    return list(td_wav[type(scheme)].keys())
 
 def fd_approximants(scheme=_scheme.mgr.state):
     """Return a list containing the available fourier domain approximants for
        the given processing scheme.
     """
-    return fd_wav[type(scheme)].keys()
+    return list(fd_wav[type(scheme)].keys())
 
 def sgburst_approximants(scheme=_scheme.mgr.state):
     """Return a list containing the available time domain sgbursts for
        the given processing scheme.
     """
-    return sgburst_wav[type(scheme)].keys()
+    return list(sgburst_wav[type(scheme)].keys())
 
 def filter_approximants(scheme=_scheme.mgr.state):
     """Return a list of fourier domain approximants including those
        written specifically as templates.
     """
-    return filter_wav[type(scheme)].keys()
+    return list(filter_wav[type(scheme)].keys())
 
 # Input parameter handling ###################################################
 


### PR DESCRIPTION
This PR updates those functions that call `keys()` directly in the `return` statement to return `list(<var>.keys())` instead, which is required to retain the same return type when using python3.