### PR TITLE
Use six.with_metaclass to add metaclasses in python2 and 3

### DIFF
--- a/pycbc/inference/io/base_hdf.py
+++ b/pycbc/inference/io/base_hdf.py
@@ -30,15 +30,16 @@ from __future__ import absolute_import
 import sys
 import logging
 from abc import (ABCMeta, abstractmethod)
-from six import string_types
-import numpy
 
-from six import add_metaclass
+from six import (add_metaclass, string_types)
+
+import numpy
 
 import h5py
 
 from pycbc.io import FieldArray
 from pycbc.inject import InjectionSet
+
 
 @add_metaclass(ABCMeta)
 class BaseInferenceFile(h5py.File):

--- a/pycbc/inference/io/base_hdf.py
+++ b/pycbc/inference/io/base_hdf.py
@@ -33,11 +33,14 @@ from abc import (ABCMeta, abstractmethod)
 from six import string_types
 import numpy
 
+from six import add_metaclass
+
 import h5py
 
 from pycbc.io import FieldArray
 from pycbc.inject import InjectionSet
 
+@add_metaclass(ABCMeta)
 class BaseInferenceFile(h5py.File):
     """Base class for all inference hdf files.
 
@@ -51,7 +54,6 @@ class BaseInferenceFile(h5py.File):
     mode : {None, str}
         The mode to open the file, eg. "w" for write and "r" for read.
     """
-    __metaclass__ = ABCMeta
 
     name = None
     samples_group = 'samples'

--- a/pycbc/inference/io/base_sampler.py
+++ b/pycbc/inference/io/base_sampler.py
@@ -19,17 +19,18 @@ from __future__ import absolute_import
 
 from abc import (ABCMeta, abstractmethod)
 
+from six import add_metaclass
+
 from .base_hdf import BaseInferenceFile
 
 
+@add_metaclass(ABCMeta)
 class BaseSamplerFile(BaseInferenceFile):
     """Base HDF class for all samplers.
 
     This adds abstract methods ``write_resume_point`` and
     ``write_sampler_metadata`` to :py:class:`BaseInferenceFile`.
     """
-    __metaclass__ = ABCMeta
-
     @abstractmethod
     def write_resume_point(self):
         """Should write the point that a sampler starts up.

--- a/pycbc/inference/models/base.py
+++ b/pycbc/inference/models/base.py
@@ -29,7 +29,7 @@ import numpy
 import logging
 from abc import (ABCMeta, abstractmethod)
 from six.moves.configparser import NoSectionError
-from six import string_types
+from six import (add_metaclass, string_types)
 from pycbc import (transforms, distributions)
 from pycbc.io import FieldArray
 
@@ -284,6 +284,7 @@ def read_sampling_params_from_config(cp, section_group=None,
 #
 
 
+@add_metaclass(ABCMeta)
 class BaseModel(object):
     r"""Base class for all models.
 
@@ -357,7 +358,6 @@ class BaseModel(object):
     logplr :
         A function that returns the log of the prior-weighted likelihood ratio.
     """
-    __metaclass__ = ABCMeta
     name = None
 
     def __init__(self, variable_params, static_params=None, prior=None,

--- a/pycbc/inference/models/base_data.py
+++ b/pycbc/inference/models/base_data.py
@@ -28,9 +28,12 @@
 import numpy
 from abc import (ABCMeta, abstractmethod)
 
+from six import add_metaclass
+
 from .base import BaseModel
 
 
+@add_metaclass(ABCMeta)
 class BaseDataModel(BaseModel):
     r"""Base class for models that require data and a waveform generator.
 
@@ -71,8 +74,6 @@ class BaseDataModel(BaseModel):
 
     See ``BaseModel`` for additional attributes and properties.
     """
-    __metaclass__ = ABCMeta
-
     def __init__(self, variable_params, data, recalibration=None, gates=None,
                  **kwargs):
         self._data = None

--- a/pycbc/inference/sampler/base.py
+++ b/pycbc/inference/sampler/base.py
@@ -30,9 +30,11 @@ from __future__ import absolute_import
 from abc import ABCMeta, abstractmethod, abstractproperty
 import os
 import shutil
-from pycbc import distributions
 import logging
 
+from six import add_metaclass
+
+from pycbc import distributions
 from pycbc.inference.io import validate_checkpoint_files
 
 #
@@ -44,6 +46,7 @@ from pycbc.inference.io import validate_checkpoint_files
 #
 
 
+@add_metaclass(ABCMeta)
 class BaseSampler(object):
     """Abstract base class for all inference samplers.
 
@@ -55,7 +58,6 @@ class BaseSampler(object):
     model : Model
         An instance of a model from ``pycbc.inference.models``.
     """
-    __metaclass__ = ABCMeta
     name = None
 
     def __init__(self, model):

--- a/pycbc/inference/sampler/base_mcmc.py
+++ b/pycbc/inference/sampler/base_mcmc.py
@@ -27,10 +27,10 @@ from __future__ import (absolute_import, division)
 
 import os
 import signal
-from abc import (ABCMeta, abstractmethod, abstractproperty)
 import logging
+from abc import (ABCMeta, abstractmethod, abstractproperty)
 
-from six import add_metaclass
+from six import (add_metaclass, string_types)
 
 import numpy
 
@@ -38,7 +38,6 @@ from pycbc.workflow import ConfigParser
 from pycbc.filter import autocorrelation
 from pycbc.inference.io import validate_checkpoint_files
 
-from six import string_types
 
 #
 # =============================================================================

--- a/pycbc/inference/sampler/base_mcmc.py
+++ b/pycbc/inference/sampler/base_mcmc.py
@@ -29,10 +29,13 @@ import os
 import signal
 from abc import (ABCMeta, abstractmethod, abstractproperty)
 import logging
+
+from six import add_metaclass
+
 import numpy
+
 from pycbc.workflow import ConfigParser
 from pycbc.filter import autocorrelation
-
 from pycbc.inference.io import validate_checkpoint_files
 
 from six import string_types
@@ -154,6 +157,7 @@ def get_optional_arg_from_config(cp, section, arg, dtype=str):
 #
 
 
+@add_metaclass(ABCMeta)
 class BaseMCMC(object):
     """Abstract base class that provides methods common to MCMCs.
 
@@ -205,8 +209,6 @@ class BaseMCMC(object):
     acls
     acts
     """
-    __metaclass__ = ABCMeta
-
     _lastclear = None  # the iteration when samples were cleared from memory
     _itercounter = None  # the number of iterations since the last clear
     _pos = None

--- a/pycbc/inject/inject.py
+++ b/pycbc/inject/inject.py
@@ -39,6 +39,8 @@ from pycbc.types import float64, float32, TimeSeries
 from pycbc.detector import Detector
 import pycbc.io
 
+from six import add_metaclass
+
 injection_func_map = {
     np.dtype(float32): sim.SimAddInjectionREAL4TimeSeries,
     np.dtype(float64): sim.SimAddInjectionREAL8TimeSeries
@@ -309,6 +311,7 @@ class _XMLInjectionSet(object):
 # -----------------------------------------------------------------------------
 
 
+@add_metaclass(ABCMeta)
 class _HDFInjectionSet(object):
     """Manages sets of injections: reads injections from hdf files
     and injects them into time series.
@@ -328,7 +331,6 @@ class _HDFInjectionSet(object):
     static_args
     extra_args
     """
-    __metaclass__ = ABCMeta
     _tableclass = pycbc.io.FieldArray
     injtype = None
 

--- a/pycbc/strain/calibration.py
+++ b/pycbc/strain/calibration.py
@@ -19,10 +19,11 @@
 import numpy as np
 from scipy.interpolate import UnivariateSpline
 from abc import (ABCMeta, abstractmethod)
+from six import add_metaclass
 
 
+@add_metaclass(ABCMeta)
 class Recalibrate(object):
-    __metaclass__ = ABCMeta
     name = None
 
     def __init__(self, ifo_name):

--- a/pycbc/strain/recalibrate.py
+++ b/pycbc/strain/recalibrate.py
@@ -19,14 +19,15 @@
 
 from abc import (ABCMeta, abstractmethod)
 
+from six import add_metaclass
+
 import numpy as np
 from scipy.interpolate import UnivariateSpline
 from pycbc.types import FrequencySeries
 
+@add_metaclass(ABCMeta)
 class Recalibrate(object):
     """ Base class for modifying calibration """
-
-    __metaclass__ = ABCMeta
     name = None
 
     def __init__(self, ifo_name):

--- a/pycbc/strain/recalibrate.py
+++ b/pycbc/strain/recalibrate.py
@@ -25,6 +25,7 @@ import numpy as np
 from scipy.interpolate import UnivariateSpline
 from pycbc.types import FrequencySeries
 
+
 @add_metaclass(ABCMeta)
 class Recalibrate(object):
     """ Base class for modifying calibration """


### PR DESCRIPTION
This PR replaces all uses of the `__metaclass__` class variable with calls to `six.with_metaclass` to support applying metaclasses in python2 and python3 at the same time.