### PR TITLE
Cast floats to int for numpy in test suite

### DIFF
--- a/test/bankvetotest.py
+++ b/test/bankvetotest.py
@@ -11,7 +11,7 @@ dt = 1.0/sr
 bl = 256
 df = 1.0/bl
 N = int(sr * bl)
-n = N/2 + 1
+n = int(N/2 + 1)
 
 psd = pycbc.psd.from_string("aLIGOZeroDetHighPower", n, df, 14)
 strain = noise_from_psd(N, dt, psd, seed=0)

--- a/test/test_autochisq.py
+++ b/test/test_autochisq.py
@@ -82,7 +82,7 @@ class TestAutochisquare(unittest.TestCase):
 
         # generate sin-gaussian signal
         time = np.arange(0, len(hp))*self.del_t
-        Nby2 = len(hp)/2
+        Nby2 = int(len(hp)/2)
         sngt = np.zeros(len(hp))
         for i in range(len(hp)):
             sngt[i] = 9.0e-21*exp(-(time[i]-time[Nby2])**2/self.Q)*sin(self.om*time[i])

--- a/test/test_matchedfilter.py
+++ b/test/test_matchedfilter.py
@@ -48,13 +48,13 @@ class TestMatchedFilter(unittest.TestCase):
         data = numpy.sin(numpy.arange(0,100,100/(4096.0*64)))
         self.filt = TimeSeries(data,dtype=float32,delta_t=1.0/4096)
         self.filt2 = (self.filt*1)
-        self.filt2[0:len(self.filt2)/2].fill(0)
+        self.filt2[0:int(len(self.filt2)/2)].fill(0)
         self.filt_offset = TimeSeries(numpy.roll(data,4096*32), dtype=float32,
                                       delta_t=1.0/4096)
 
         self.filtD = TimeSeries(data,dtype=float64,delta_t=1.0/4096)
         self.filt2D = (self.filtD*1)
-        self.filt2D[0:len(self.filt2D)/2].fill(0)
+        self.filt2D[0:int(len(self.filt2D)/2)].fill(0)
         self.filt_offsetD = TimeSeries(numpy.roll(data,4096*32), dtype=float64,
                                       delta_t=1.0/4096)
 

--- a/test/test_skymax.py
+++ b/test/test_skymax.py
@@ -236,8 +236,8 @@ class TestChisq(unittest.TestCase):
         self.filter_t_length = 16
         self.low_freq_filter = 30.
         self.sample_rate = 16384
-        self.filter_N = self.filter_t_length * self.sample_rate
-        self.filter_n = self.filter_N / 2 + 1
+        self.filter_N = int(self.filter_t_length * self.sample_rate)
+        self.filter_n = int(self.filter_N / 2 + 1)
         self.filter_delta_f = 1.0 / self.filter_t_length
         self.psd = psd.from_string('aLIGOZeroDetHighPowerGWINC',
                                    self.filter_n, self.filter_delta_f,


### PR DESCRIPTION
This PR fixes a few failures with new versions of numpy that don't like creating arrays with the size given as a `float`, or similar.