### PR TITLE
Cast iterator to list where needed

### DIFF
--- a/pycbc/tmpltbank/bank_output_utils.py
+++ b/pycbc/tmpltbank/bank_output_utils.py
@@ -203,7 +203,7 @@ def calculate_ethinca_metric_comps(metricParams, ethincaParams, mass1, mass2,
     # frequency for which moments were calculated
     fMax_theor = pnutils.frequency_cutoff_from_name(
         ethincaParams.cutoff, mass1, mass2, spin1z, spin2z)
-    fMaxes = metricParams.moments['J4'].keys()
+    fMaxes = list(metricParams.moments['J4'].keys())
     fMaxIdx = abs(numpy.array(fMaxes,dtype=float) - fMax_theor).argmin()
     fMax = fMaxes[fMaxIdx]
 

--- a/test/test_detector.py
+++ b/test/test_detector.py
@@ -55,7 +55,7 @@ class TestDetector(unittest.TestCase):
                 self.assertAlmostEqual(t1, t2, 7)
 
     def test_antenna_pattern(self):
-        vals = zip(self.ra, self.dec, self.pol, self.time)
+        vals = list(zip(self.ra, self.dec, self.pol, self.time))
         for ifo in self.d:
             fp = []
             fc = []


### PR DESCRIPTION
This PR fixes two instances of indexing/repeating an iterator that causes the test suite to fail when using python3. The simple solution is to cast to `list`.