### PR TITLE
Fix py3 error when analytical PSD length is not int

### DIFF
--- a/pycbc/psd/analytical.py
+++ b/pycbc/psd/analytical.py
@@ -18,6 +18,7 @@
 """
 
 import warnings
+import numbers
 from pycbc.types import FrequencySeries, zeros
 import lal
 import lalsimulation
@@ -97,9 +98,10 @@ def from_string(psd_name, length, delta_f, low_freq_cutoff):
         raise ValueError(psd_name + ' not found among analytical '
                          'PSD functions.')
 
-    if type(length) is not int:
+    # make sure length has the right type for CreateREAL8FrequencySeries
+    if not isinstance(length, numbers.Integral):
         warnings.warn('forcing length argument to int', RuntimeWarning)
-        length = int(length)
+    length = int(length)
 
     # if PSD model is in LALSimulation
     if psd_name in get_lalsim_psd_list():

--- a/pycbc/psd/analytical.py
+++ b/pycbc/psd/analytical.py
@@ -17,6 +17,7 @@
 """Provides reference PSDs from LALSimulation.
 """
 
+import warnings
 from pycbc.types import FrequencySeries, zeros
 import lal
 import lalsimulation
@@ -95,6 +96,10 @@ def from_string(psd_name, length, delta_f, low_freq_cutoff):
     if psd_name not in get_psd_model_list():
         raise ValueError(psd_name + ' not found among analytical '
                          'PSD functions.')
+
+    if type(length) is not int:
+        warnings.warn('forcing length argument to int', RuntimeWarning)
+        length = int(length)
 
     # if PSD model is in LALSimulation
     if psd_name in get_lalsim_psd_list():


### PR DESCRIPTION
I noticed a common error in the Python 3 unit test, seemingly due to passing non-int lengths to a LAL function taking a `size_t`.