### PR TITLE
Use string_types for type checking

### DIFF
--- a/pycbc/inference/io/base_hdf.py
+++ b/pycbc/inference/io/base_hdf.py
@@ -30,6 +30,7 @@ from __future__ import absolute_import
 import sys
 import logging
 from abc import (ABCMeta, abstractmethod)
+from six import string_types
 import numpy
 
 import h5py
@@ -640,7 +641,7 @@ class BaseInferenceFile(h5py.File):
         # copy non-samples/stats data
         if ignore is None:
             ignore = []
-        if isinstance(ignore, (str, unicode)):
+        if isinstance(ignore, string_types):
             ignore = [ignore]
         ignore = set(ignore + [self.samples_group])
         copy_groups = set(self.keys()) - ignore
@@ -726,7 +727,7 @@ class BaseInferenceFile(h5py.File):
         # info
         if ignore is None:
             ignore = []
-        if isinstance(ignore, (str, unicode)):
+        if isinstance(ignore, string_types):
             ignore = [ignore]
         self.copy_info(other, ignore=ignore)
         # samples

--- a/pycbc/inference/io/base_mcmc.py
+++ b/pycbc/inference/io/base_mcmc.py
@@ -26,6 +26,8 @@
 
 from __future__ import (absolute_import, division)
 
+from six import string_types
+
 import numpy
 import argparse
 
@@ -386,7 +388,7 @@ class SingleTempMCMCIO(object):
         dict
             A dictionary of field name -> numpy array pairs.
         """
-        if isinstance(fields, (str, unicode)):
+        if isinstance(fields, string_types):
             fields = [fields]
         # walkers to load
         if walkers is not None:

--- a/pycbc/inference/io/base_multitemper.py
+++ b/pycbc/inference/io/base_multitemper.py
@@ -26,6 +26,7 @@
 
 from __future__ import absolute_import
 import argparse
+from six import string_types
 from .base_mcmc import (MCMCMetadataIO, thin_samples_for_writing)
 import numpy
 
@@ -43,7 +44,7 @@ class ParseTempsArg(argparse.Action):
         super(ParseTempsArg, self).__init__(type=type, **kwargs)
 
     def __call__(self, parser, namespace, values, option_string=None):
-        singlearg = isinstance(values, (str, unicode))
+        singlearg = isinstance(values, string_types)
         if singlearg:
             values = [values]
         if values[0] == 'all':
@@ -198,7 +199,7 @@ class MultiTemperedMCMCIO(object):
             An instance of the given array class populated with values
             retrieved from the fields.
         """
-        if isinstance(fields, (str, unicode)):
+        if isinstance(fields, string_types):
             fields = [fields]
         # walkers to load
         if walkers is not None:

--- a/pycbc/inference/io/multinest.py
+++ b/pycbc/inference/io/multinest.py
@@ -19,6 +19,8 @@
 
 from __future__ import absolute_import
 
+from six import string_types
+
 from .base_sampler import BaseSamplerFile
 
 
@@ -90,7 +92,7 @@ class MultinestFile(BaseSamplerFile):
             self.attrs['importance_dlog_evidence'] = importance_dlnz
 
     def read_raw_samples(self, fields, iteration=None):
-        if isinstance(fields, (str, unicode)):
+        if isinstance(fields, string_types):
             fields = [fields]
         # load
         group = self.samples_group + '/{name}'

--- a/pycbc/inference/models/base.py
+++ b/pycbc/inference/models/base.py
@@ -29,6 +29,7 @@ import numpy
 import logging
 from abc import (ABCMeta, abstractmethod)
 from six.moves.configparser import NoSectionError
+from six import string_types
 from pycbc import (transforms, distributions)
 from pycbc.io import FieldArray
 
@@ -362,7 +363,7 @@ class BaseModel(object):
     def __init__(self, variable_params, static_params=None, prior=None,
                  sampling_transforms=None, waveform_transforms=None):
         # store variable and static args
-        if isinstance(variable_params, basestring):
+        if isinstance(variable_params, string_types):
             variable_params = (variable_params,)
         if not isinstance(variable_params, tuple):
             variable_params = tuple(variable_params)

--- a/pycbc/inference/option_utils.py
+++ b/pycbc/inference/option_utils.py
@@ -20,6 +20,8 @@
 import logging
 import argparse
 
+from six import string_types
+
 from pycbc.psd import from_cli_multi_ifos as psd_from_cli_multi_ifos
 from pycbc.strain import from_cli_multi_ifos as strain_from_cli_multi_ifos
 from pycbc.strain import (gates_from_cli, psd_gates_from_cli,
@@ -160,7 +162,7 @@ class ParseLabelArg(argparse.Action):
                                             **kwargs)
 
     def __call__(self, parser, namespace, values, option_string=None):
-        singlearg = isinstance(values, (str, unicode))
+        singlearg = isinstance(values, string_types)
         if singlearg:
             values = [values]
         params = []

--- a/pycbc/inference/sampler/base_mcmc.py
+++ b/pycbc/inference/sampler/base_mcmc.py
@@ -35,6 +35,8 @@ from pycbc.filter import autocorrelation
 
 from pycbc.inference.io import validate_checkpoint_files
 
+from six import string_types
+
 #
 # =============================================================================
 #
@@ -800,7 +802,7 @@ class MCMCAutocorrSupport(object):
         with cls._io(filename, 'r') as fp:
             if parameters is None:
                 parameters = fp.variable_params
-            if isinstance(parameters, str) or isinstance(parameters, unicode):
+            if isinstance(parameters, string_types):
                 parameters = [parameters]
             for param in parameters:
                 if per_walker:

--- a/pycbc/inference/sampler/base_multitemper.py
+++ b/pycbc/inference/sampler/base_multitemper.py
@@ -26,6 +26,8 @@ samplers."""
 
 from __future__ import absolute_import
 
+from six import string_types
+
 import numpy
 from pycbc.filter import autocorrelation
 
@@ -94,7 +96,7 @@ class MultiTemperedAutocorrSupport(object):
         with cls._io(filename, 'r') as fp:
             if parameters is None:
                 parameters = fp.variable_params
-            if isinstance(parameters, str) or isinstance(parameters, unicode):
+            if isinstance(parameters, string_types):
                 parameters = [parameters]
             if isinstance(temps, int):
                 temps = [temps]


### PR DESCRIPTION
This PR removes `isinstance` references to `basestring` and `unicode` and replaces them with `six.string_types`.