### PR TITLE
Fixed use of izip and izip_longest for python3

### DIFF
--- a/bin/hdfcoinc/pycbc_calculate_psd
+++ b/bin/hdfcoinc/pycbc_calculate_psd
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 """ Calculate psd estimates for analysis segments
 """
-import logging, argparse, numpy, h5py, itertools, multiprocessing, time
-from six.moves import range
+import logging, argparse, numpy, h5py, multiprocessing, time
+from six.moves import (range, zip_longest)
 import pycbc, pycbc.psd, pycbc.strain, pycbc.events
 from pycbc.version import git_verbose_msg as version
 from pycbc.fft.fftw import set_measure_level
@@ -32,7 +32,7 @@ pycbc.strain.StrainSegments.verify_segment_options(args, parser)
         
 def grouper(n, iterable):
     args = [iter(iterable)] * n
-    return list([e for e in t if e != None] for t in itertools.izip_longest(*args))
+    return list([e for e in t if e != None] for t in zip_longest(*args))
 
 def get_psd(input_tuple):
     """ Get the PSDs for the given data chunck. This follows the same rules

--- a/bin/hdfcoinc/pycbc_coinc_statmap_inj
+++ b/bin/hdfcoinc/pycbc_coinc_statmap_inj
@@ -5,7 +5,6 @@ by pycbc_coinc_findtrigs to generated a mapping between SNR and FAP, along
 with producing the combined foreground and background triggers
 """
 import argparse, h5py, logging, itertools, copy, pycbc.io, numpy, lal
-from itertools import izip
 from pycbc.events import veto, coinc
 import pycbc.version
 import pycbc.conversions as conv

--- a/bin/hdfcoinc/pycbc_multiifo_coinc_statmap_inj
+++ b/bin/hdfcoinc/pycbc_multiifo_coinc_statmap_inj
@@ -5,7 +5,6 @@ by pycbc_coinc_findtrigs to generated a mapping between SNR and FAP, along
 with producing the combined foreground and background triggers
 """
 import argparse, h5py, logging, itertools, copy, pycbc.io, numpy, lal
-from itertools import izip
 from pycbc.events import veto, coinc
 import pycbc.version
 import pycbc.conversions as conv

--- a/pycbc/workflow/inference_followups.py
+++ b/pycbc/workflow/inference_followups.py
@@ -21,7 +21,6 @@ import logging, os.path
 from pycbc.workflow.core import Executable, FileList, Node, makedir, File, Workflow
 from pycbc.workflow.plotting import PlotExecutable, requirestr, excludestr
 from pycbc.workflow import WorkflowConfigParser
-from itertools import izip_longest
 from Pegasus import DAX3 as dax
 from pycbc.workflow import pegasus_workflow as wdax
 


### PR DESCRIPTION
This PR fixes all uses of `izip` and `izip_longest` to work on python3 - most of those imports were unused.