### PR TITLE
Change import to pycbc.workflow.datafind and check if frame files returned from module

### DIFF
--- a/bin/workflows/pycbc_make_inference_workflow
+++ b/bin/workflows/pycbc_make_inference_workflow
@@ -34,6 +34,7 @@ from pycbc.types import MultiDetOptionAction
 from pycbc.types import MultiDetOptionAppendAction
 from pycbc.workflow import configuration
 from pycbc.workflow import core
+from pycbc.workflow import datafind
 from pycbc.workflow import plotting
 
 from pycbc import __version__
@@ -266,8 +267,8 @@ for num_event in range(num_events):
                 frame_file.PFN(frame_file.storage_path, site="local")
                 frame_files.append(frame_file)
     else:
-        frame_files, _, _, _ = core.setup_datafind_workflow(workflow, seg_dict,
-                                                          "datafind")
+        frame_files, _, _, _ = datafind.setup_datafind_workflow(workflow, seg_dict,
+                                                                "datafind")
 
     # make node for running sampler
     node = inference_exe.create_node()

--- a/bin/workflows/pycbc_make_inference_workflow
+++ b/bin/workflows/pycbc_make_inference_workflow
@@ -275,7 +275,8 @@ for num_event in range(num_events):
     node.add_opt("--instruments", " ".join(workflow.ifos))
     node.add_opt("--gps-start-time", gps_start_time)
     node.add_opt("--gps-end-time", gps_end_time)
-    node.add_multiifo_input_list_opt("--frame-files", frame_files)
+    if len(frame_files):
+        node.add_multiifo_input_list_opt("--frame-files", frame_files)
     node.add_opt("--channel-name", channel_names_str)
     node.add_input_opt("--config-file", config_file)
     analysis_time = segments.segment(gps_start_time, gps_end_time)

--- a/examples/workflow/inference/inference.ini
+++ b/examples/workflow/inference/inference.ini
@@ -1,6 +1,7 @@
 [model]
 name = marginalized_phase
-low-frequency-cutoff = 20
+h1-low-frequency-cutoff = 20
+l1-low-frequency-cutoff = 20
 
 [sampler]
 name = emcee_pt

--- a/examples/workflow/inference/workflow_config.ini
+++ b/examples/workflow/inference/workflow_config.ini
@@ -52,7 +52,6 @@ psd-segment-length = 16
 psd-segment-stride = 8
 psd-inverse-length = 16
 processing-scheme = mkl
-save-psd =
 
 [pegasus_profile-inference]
 ; pegasus profile for inference nodes

--- a/examples/workflow/inference/workflow_config.ini
+++ b/examples/workflow/inference/workflow_config.ini
@@ -52,6 +52,7 @@ psd-segment-length = 16
 psd-segment-stride = 8
 psd-inverse-length = 16
 processing-scheme = mkl
+data-conditioning-low-freq = 25
 
 [pegasus_profile-inference]
 ; pegasus profile for inference nodes


### PR DESCRIPTION
This PR changes the import for the call to ``pycbc.workflow.datafind`` from ``core`` to ``datafind``. It also checks if there were frame files returned from the module before added it to the ``File``.