### PR TITLE
Replaced dict.iter{items,values} with dict.{items,values}

### DIFF
--- a/bin/workflows/pycbc_make_inference_workflow
+++ b/bin/workflows/pycbc_make_inference_workflow
@@ -223,7 +223,7 @@ for ifo in workflow.ifos:
     channel_names[ifo] = workflow.cp.get_opt_tags(
                                "workflow", "%s-channel-name" % ifo.lower(), "")
 channel_names_str = " ".join([key + ":" + val for key, val in \
-                              channel_names.iteritems()])
+                              channel_names.items()])
 
 # figure out what parameters user wants to plot from workflow configuration
 plot_parameters = {}

--- a/pycbc/results/templates/files/file_default.html
+++ b/pycbc/results/templates/files/file_default.html
@@ -22,7 +22,7 @@
     <tbody>
 
     <!--table rows-->
-    {% for channel, segmentlist in content.iteritems() %}
+    {% for channel, segmentlist in content.items() %}
         {% for seg in segmentlist %}
             <tr>
                 <td>{{channel}}</td>

--- a/pycbc/workflow/jobsetup.py
+++ b/pycbc/workflow/jobsetup.py
@@ -1848,11 +1848,11 @@ class PycbcInferenceExecutable(Executable):
 
         # get multi-IFO opts
         channel_names_opt = " ".join(["{}:{}".format(k, v)
-                                      for k, v in channel_names.iteritems()])
+                                      for k, v in channel_names.items()])
         if fake_strain_seed is not None:
             fake_strain_seed_opt = " ".join([
                                     "{}:{}".format(k, v)
-                                    for k, v in fake_strain_seed.iteritems()])
+                                    for k, v in fake_strain_seed.items()])
 
         # make node for running executable
         node = Node(self)

--- a/pycbc/workflow/segment.py
+++ b/pycbc/workflow/segment.py
@@ -1207,7 +1207,7 @@ def generate_triggered_segment(workflow, out_dir, sciencesegs):
             # If none, offsource dict will contain segments showing criteria
             # that have not been met, for use in plotting
             if len(offsource.keys()) > 1:
-                seg_lens = {ifos: abs(next(offsource[ifos].itervalues())[0])
+                seg_lens = {ifos: abs(next(offsource[ifos].values())[0])
                             for ifos in offsource.keys()}
                 best_comb = max(seg_lens.iterkeys(),
                                 key=(lambda key: seg_lens[key]))
@@ -1218,7 +1218,7 @@ def generate_triggered_segment(workflow, out_dir, sciencesegs):
         else:
             # Identify best analysis segment
             if len(valid_combs) > 1:
-                seg_lens = {ifos: abs(next(offsource[ifos].itervalues())[0])
+                seg_lens = {ifos: abs(next(offsource[ifos].values())[0])
                             for ifos in valid_combs}
                 best_comb = max(seg_lens.iterkeys(),
                                 key=(lambda key: seg_lens[key]))
@@ -1228,11 +1228,11 @@ def generate_triggered_segment(workflow, out_dir, sciencesegs):
 
             offsourceSegfile = os.path.join(out_dir, "offSourceSeg.txt")
             segmentsUtils.tosegwizard(open(offsourceSegfile, "w"),
-                                      next(offsource[best_comb].itervalues()))
+                                      next(offsource[best_comb].values()))
 
             onsourceSegfile = os.path.join(out_dir, "onSourceSeg.txt")
             segmentsUtils.tosegwizard(file(onsourceSegfile, "w"),
-                                      next(onsource[best_comb].itervalues()))
+                                      next(onsource[best_comb].values()))
 
             bufferleft = int(cp.get('workflow-exttrig_segments',
                                     'num-buffer-before'))


### PR DESCRIPTION
This PR updates calls to `dict.iter{items,values}` with their non-`iter` equivalents, so that they work with python 3.