### PR TITLE
Updated more usage of dict keys and values for python3

### DIFF
--- a/bin/bank/pycbc_brute_bank
+++ b/bin/bank/pycbc_brute_bank
@@ -142,7 +142,7 @@ class TriangleBank(object):
     def check_params(self, gen, params, threshold):
         num_tried = 0
         num_added = 0
-        for i in range(len(params.values()[0])):
+        for i in range(len(tuple(params.values())[0])):
             num_tried += 1.0
 
             try:

--- a/bin/hdfcoinc/pycbc_average_psd
+++ b/bin/hdfcoinc/pycbc_average_psd
@@ -55,7 +55,7 @@ delta_f = None
 for input_file in args.input_files:
     logging.info('Reading %s', input_file)
     f = h5py.File(input_file, 'r')
-    ifo = f.keys()[0]
+    ifo = tuple(f.keys())[0]
     df = f[ifo + '/psds/0'].attrs['delta_f']
     if delta_f is None:
         delta_f = df

--- a/bin/hdfcoinc/pycbc_coinc_findtrigs
+++ b/bin/hdfcoinc/pycbc_coinc_findtrigs
@@ -69,7 +69,7 @@ class ReadByTemplate(object):
     def __init__(self, filename, bank=None, segment_name=[], veto_files=[]):
         self.filename = filename
         self.file = h5py.File(filename, 'r')
-        self.ifo = self.file.keys()[0]
+        self.ifo = tuple(self.file.keys())[0]
         self.valid = None
         self.bank = h5py.File(bank, 'r') if bank else None
 

--- a/bin/hdfcoinc/pycbc_coinc_mergetrigs
+++ b/bin/hdfcoinc/pycbc_coinc_mergetrigs
@@ -49,7 +49,7 @@ for fname in args.trigger_files:
     except IOError:
         logging.error("Cannot open %s" % fname)
         raise IOError
-    ifo = f2.keys()[0]
+    ifo = tuple(f2.keys())[0]
     if len(f2[ifo].keys()) > 0:
         k = f2[ifo].keys()
         trigger_columns = f2[ifo].keys()

--- a/bin/hdfcoinc/pycbc_merge_psds
+++ b/bin/hdfcoinc/pycbc_merge_psds
@@ -34,7 +34,7 @@ inc = {}
 start, end = {}, {}
 for psd_file in args.psd_files:
     f = h5py.File(psd_file, 'r')
-    ifo = f.keys()[0]
+    ifo = tuple(f.keys())[0]
     if ifo not in inc:
         inc[ifo] = 0
         start[ifo], end[ifo] = [], []

--- a/bin/hdfcoinc/pycbc_multiifo_coinc_findtrigs
+++ b/bin/hdfcoinc/pycbc_multiifo_coinc_findtrigs
@@ -73,7 +73,7 @@ class ReadByTemplate(object):
     def __init__(self, filename, bank=None, segment_name=[], veto_files=[]):
         self.filename = filename
         self.file = h5py.File(filename, 'r')
-        self.ifo = self.file.keys()[0]
+        self.ifo = tuple(self.file.keys())[0]
         self.valid = None
         self.bank = h5py.File(bank, 'r') if bank else None
 

--- a/bin/hdfcoinc/pycbc_page_coinc_snrchi
+++ b/bin/hdfcoinc/pycbc_page_coinc_snrchi
@@ -55,7 +55,7 @@ b_tids[f.attrs['detector_1']] = f['background_exc/trigger_id1']
 b_tids[f.attrs['detector_2']] = f['background_exc/trigger_id2']
 
 f = h5py.File(args.single_trigger_file, 'r')
-ifo = f.keys()[0]
+ifo = tuple(f.keys())[0]
 f = f[ifo]
 tid = b_tids[ifo][:]
 bkg_snr = f['snr'][:][tid]

--- a/bin/hdfcoinc/pycbc_page_snrchi
+++ b/bin/hdfcoinc/pycbc_page_snrchi
@@ -20,7 +20,7 @@ parser.add_argument('--chisq-choice', choices=chisq_choices,
 args = parser.parse_args()
 
 f = h5py.File(args.trigger_file, 'r')
-ifo = f.keys()[0]
+ifo = tuple(f.keys())[0]
 f = f[ifo]
 snr = f['snr'][:]
 chisq = get_chisq_from_file_choice(f, args.chisq_choice)

--- a/bin/hdfcoinc/pycbc_plot_gating
+++ b/bin/hdfcoinc/pycbc_plot_gating
@@ -36,7 +36,7 @@ have_gates = False
 for fn in args.input_file:
     logging.info('Reading gates from %s', fn)
     f = h5py.File(fn, 'r')
-    ifo = f.keys()[0]
+    ifo = tuple(f.keys())[0]
     for gate_type in ['file', 'auto']:
         try:
             gate_time = f[ifo + '/gating/' + gate_type + '/time'][:]

--- a/bin/hdfcoinc/pycbc_plot_hist
+++ b/bin/hdfcoinc/pycbc_plot_hist
@@ -44,7 +44,7 @@ pycbc.init_logging(args.verbose)
 
 # read trigger file to determine IFO
 f = h5py.File(args.trigger_file, 'r')
-ifo = f.keys()[0]
+ifo = tuple(f.keys())[0]
 
 # read single-detector triggers
 trigs = pycbc.io.SingleDetTriggers(args.trigger_file, args.bank_file,

--- a/bin/hdfcoinc/pycbc_plot_psd_file
+++ b/bin/hdfcoinc/pycbc_plot_psd_file
@@ -54,7 +54,7 @@ for psd_file in args.psd_files:
     elif "ifo_list" in f.attrs.keys():
         ifo_list = f.attrs["ifo_list"]
     else:
-        ifo_list = [f.keys()[0]]
+        ifo_list = [tuple(f.keys())[0]]
     for ifo in ifo_list:
         fac = 1.0 / pycbc.DYN_RANGE_FAC
         df = f[ifo + '/psds/0'].attrs['delta_f']

--- a/bin/hdfcoinc/pycbc_plot_psd_timefreq
+++ b/bin/hdfcoinc/pycbc_plot_psd_timefreq
@@ -59,7 +59,7 @@ ax=fig.gca()
 logging.info('Reading %s', opts.psd_file)
 
 f = h5py.File(opts.psd_file, 'r')
-ifo = f.keys()[0]
+ifo = tuple(f.keys())[0]
 df = f[ifo + '/psds/0'].attrs['delta_f']
 keys = f[ifo + '/psds'].keys()
 psds = [f[ifo + '/psds/' + str(key)][:] for key in range(len(f[ifo + '/psds']))]

--- a/bin/hdfcoinc/pycbc_plot_range
+++ b/bin/hdfcoinc/pycbc_plot_range
@@ -26,7 +26,7 @@ pylab.grid()
 
 for psd_file in args.psd_files:
     f = h5py.File(psd_file, 'r')
-    ifo = f.keys()[0]
+    ifo = tuple(f.keys())[0]
     flow = f.attrs['low_frequency_cutoff']
     keys = f[ifo + '/psds'].keys()
     start, end = f[ifo + '/start_time'][:], f[ifo + '/end_time'][:]

--- a/bin/hdfcoinc/pycbc_plot_range_vs_mtot
+++ b/bin/hdfcoinc/pycbc_plot_range_vs_mtot
@@ -29,7 +29,7 @@ plt.grid()
 
 for psd_file in args.psd_files:
     f = h5py.File(psd_file, 'r')
-    ifo = f.keys()[0]
+    ifo = tuple(f.keys())[0]
     flow = f.attrs['low_frequency_cutoff']
     keys = f[ifo + '/psds'].keys()
     start, end = f[ifo + '/start_time'][:], f[ifo + '/end_time'][:]

--- a/bin/hdfcoinc/pycbc_plot_throughput
+++ b/bin/hdfcoinc/pycbc_plot_throughput
@@ -23,7 +23,7 @@ fig, (ax1, ax2, ax3) = pl.subplots(3,1,figsize=(10,10))
 
 for pa in args.input_file:
     f = h5py.File(pa, 'r')
-    ifo = f.keys()[0]
+    ifo = tuple(f.keys())[0]
     if 'templates_per_core' in f['%s/search' % ifo].keys():
         tpc = f['%s/search/templates_per_core' % ifo][:]
     else:

--- a/bin/hdfcoinc/pycbc_template_recovery_hist
+++ b/bin/hdfcoinc/pycbc_template_recovery_hist
@@ -60,7 +60,7 @@ for f, b, t in zip(args.found, args.bank_files, args.trig):
     foundstat = np.concatenate((foundstat, f['found_after_vetoes/stat'][:]))
     foundifar = np.concatenate((foundifar, f['found_after_vetoes/ifar'][:]))
     # acrobatics to find right ifo
-    ifo = t.keys()[0] if t else None
+    ifo = tuple(t.keys())[0] if t else None
     ## each tuple is of form ('L1', 'detector_1')
     #dettuples = [(val, key) for (key, val) in f.attrs.items()
     #             if "detector" in key]

--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -182,7 +182,7 @@ with ctx:
     # should be fixed in a future version of PyCBC. Once it is,
     # update this. Until then, just use the first file.
     if opts.injection_file:
-        injection_file = opts.injection_file.values()[0]  # None if not set
+        injection_file = tuple(opts.injection_file.values())[0]  # None if not set
     else:
         injection_file = None
     sampler.setup_output(opts.output_file, force=opts.force,

--- a/bin/inference/pycbc_inference_plot_acf
+++ b/bin/inference/pycbc_inference_plot_acf
@@ -89,13 +89,13 @@ acfs = samplers[fp.sampler].compute_acf(fp.filename,
 
 # check if we have multiple temperatures
 if opts.per_walker:
-    multi_tempered = acfs.values()[0].ndim == 3
+    multi_tempered = tuple(acfs.values())[0].ndim == 3
 else:
-    multi_tempered = acfs.values()[0].ndim == 2
+    multi_tempered = tuple(acfs.values())[0].ndim == 2
 try:
     temps = additional_args['temps']
     if temps == 'all':
-        temps = range(acfs.values()[0].shape[0])
+        temps = range(tuple(acfs.values())[0].shape[0])
     if isinstance(temps, int):
         temps = [temps]
 except KeyError:

--- a/bin/minifollowups/pycbc_foreground_minifollowup
+++ b/bin/minifollowups/pycbc_foreground_minifollowup
@@ -134,11 +134,13 @@ for num_event in range(num_events):
     ifo_tids = ''
 
     if 'detector_1' in f.attrs:
-        ifo_times = '%s:%s %s:%s' % (times.keys()[0], times[times.keys()[0]][num_event],
-                                     times.keys()[1], times[times.keys()[1]][num_event])
+        key0, key1 = tuple(times.keys())[:2]
+        ifo_times = '%s:%s %s:%s' % (key0, times[key0][num_event],
+                                     key1, times[key1][num_event])
 
-        ifo_tids = '%s:%s %s:%s' % (tids.keys()[0], tids[tids.keys()[0]][num_event],
-                                    tids.keys()[1], tids[tids.keys()[1]][num_event])
+        key0, key1 = tuple(tids.keys())[:2]
+        ifo_tids = '%s:%s %s:%s' % (key0, tids[key0][num_event],
+                                    key1, tids[key1][num_event])
     else:
         # Version used for multi-ifo coinc code
         ifo_times_strings = []

--- a/bin/plotting/pycbc_plot_vt_ratio
+++ b/bin/plotting/pycbc_plot_vt_ratio
@@ -49,7 +49,7 @@ ax_mi.grid(True, zorder=1)
 labels = ['$ ' + label.split('\\in')[-1] for label in ffirst_set['data'].keys()]
 
 # read in the splitting parameter name from the first data set
-x_param = r'$' + ffirst_set['data'].keys()[0].split('\\in')[0].strip('$').strip() + r'$'
+x_param = r'$' + tuple(ffirst_set['data'].keys())[0].split('\\in')[0].strip('$').strip() + r'$'
 
 # read in the positions from the labels
 xpos = np.array([float(l.split('[')[1].split(',')[0]) for l in labels])

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -561,7 +561,7 @@ with ctx:
         pr.enable()
 
     # main analysis loop
-    data_end = lambda: data_reader[data_reader.keys()[0]].end_time
+    data_end = lambda: data_reader[tuple(data_reader.keys())[0]].end_time
     last_bg_dump_time = int(data_end())
     while data_end() < args.end_time:
         t1 = time()

--- a/bin/pycbc_optimal_snr
+++ b/bin/pycbc_optimal_snr
@@ -48,7 +48,7 @@ class TimeVaryingPSD(object):
     def __init__(self, file_name, length=None, delta_f=None, f_low=None):
         f = h5py.File(file_name, 'r')
         self.file_name = file_name
-        detector = f.keys()[0]
+        detector = tuple(f.keys())[0]
         self.start_times = f[detector + '/start_time'][:]
         self.end_times = f[detector + '/end_time'][:]
         self.file_f_low = f.attrs['low_frequency_cutoff']

--- a/bin/pygrb/pycbc_make_offline_grb_workflow
+++ b/bin/pygrb/pycbc_make_offline_grb_workflow
@@ -109,7 +109,7 @@ if len(sciSegs.keys()) == 0:
 elif len(sciSegs.keys()) < 2 and not single_ifo:
     plot_met = make_grb_segments_plot(wflow, segmentlistdict(sciSegs),
             triggertime, triggername, segDir)
-    msg = "Science segments exist only for %s. " % sciSegs.keys()[0]
+    msg = "Science segments exist only for %s. " % tuple(sciSegs.keys())[0]
     msg += "If you wish to enable single IFO running add the option "
     msg += "'allow-single-ifo-search' to the [workflow] section of your "
     msg += "configuration file." 
@@ -127,7 +127,7 @@ if onSrc is None:
     sys.exit()
 else:
     plot_met = make_grb_segments_plot(wflow, sciSegs, triggertime, triggername,
-            segDir, coherent_seg=offSrc[offSrc.keys()[0]][0])
+            segDir, coherent_seg=offSrc[tuple(offSrc.keys())[0]][0])
     segs_plot = _workflow.File(plot_met[0], plot_met[1], plot_met[2],
                                file_url=plot_met[3])
     segs_plot.PFN(segs_plot.cache_entry.path, site="local")
@@ -141,7 +141,7 @@ elif len(sciSegs) > 1:
     mf_tag = "coherent"
 
 # Update analysis time after coherent segment calculation
-ifo = sciSegs.keys()[0]
+ifo = tuple(sciSegs.keys())[0]
 wflow.cp = _workflow.set_grb_start_end(wflow.cp, int(sciSegs[ifo][0][0]),
                                        int(sciSegs[ifo][0][1]))
 

--- a/examples/inspiral/check_GW150914_detection.py
+++ b/examples/inspiral/check_GW150914_detection.py
@@ -12,7 +12,7 @@ gw150914_snr = {'H1': 19.71, 'L1': 13.28}
 gw150914_chi2r = {'H1': 1.05, 'L1': 0.45}
 
 f = h5py.File(sys.argv[1], 'r')
-detector = f.keys()[0]
+detector = tuple(f.keys())[0]
 end_times = f[detector]['end_time'][:]
 snrs = f[detector]['snr'][:]
 chi2rs = f[detector]['chisq'][:] / (2 * f[detector]['chisq_dof'][:] - 2)

--- a/pycbc/distributions/joint.py
+++ b/pycbc/distributions/joint.py
@@ -116,7 +116,7 @@ class JointDistribution(object):
                     samples[param] = draw[param][:]
 
             # evaluate constraints
-            result = numpy.ones(len(samples.values()[0]), dtype=bool)
+            result = numpy.ones(len(tuple(samples.values())[0]), dtype=bool)
             for constraint in self._constraints:
                 result = constraint(samples) & result
 

--- a/pycbc/events/triggers.py
+++ b/pycbc/events/triggers.py
@@ -72,7 +72,7 @@ def bank_bins_from_cli(opts):
     if opts.bank_bins:
         bins_idx = coinc.background_bin_from_string(opts.bank_bins, bank)
     else:
-        bins_idx = {"all" : numpy.arange(0, len(bank[fp.keys()[0]]))}
+        bins_idx = {"all" : numpy.arange(0, len(bank[tuple(fp.keys())[0]]))}
     fp.close()
     return bins_idx, bank
 
@@ -191,7 +191,7 @@ def loudest_triggers_from_cli(opts, coinc_parameters=None,
 
             # only use one IFO
             if len(opts.sngl_trigger_files.keys()) == 1:
-                ifo = opts.sngl_trigger_files.keys()[0]
+                ifo = tuple(opts.sngl_trigger_files.keys())[0]
             else:
                 raise ValueError("Too many IFOs")
 

--- a/pycbc/inference/io/base_hdf.py
+++ b/pycbc/inference/io/base_hdf.py
@@ -738,9 +738,9 @@ class BaseInferenceFile(h5py.File):
                               write_args=write_args)
             # if any down selection was done, re-set the default
             # thin-start/interval/end
-            p = self[self.samples_group].keys()[0]
+            p = tuple(self[self.samples_group].keys())[0]
             my_shape = self[self.samples_group][p].shape
-            p = other[other.samples_group].keys()[0]
+            p = tuple(other[other.samples_group].keys())[0]
             other_shape = other[other.samples_group][p].shape
             if my_shape != other_shape:
                 other.attrs['thin_start'] = 0

--- a/pycbc/inference/io/base_hdf.py
+++ b/pycbc/inference/io/base_hdf.py
@@ -767,7 +767,7 @@ class BaseInferenceFile(h5py.File):
             if val is None:
                 val = str(None)
             if isinstance(val, dict):
-                attrs[arg] = val.keys()
+                attrs[arg] = list(val.keys())
                 # just call self again with the dict as kwargs
                 cls.write_kwargs_to_attrs(attrs, **val)
             else:

--- a/pycbc/inference/io/base_multitemper.py
+++ b/pycbc/inference/io/base_multitemper.py
@@ -124,7 +124,7 @@ class MultiTemperedMCMCIO(object):
             attribute is > 1, this is needed to determine where to start
             thinning the samples to match what has already been stored on disk.
         """
-        ntemps, nwalkers, niterations = samples.values()[0].shape
+        ntemps, nwalkers, niterations = tuple(samples.values())[0].shape
         assert all(p.shape == (ntemps, nwalkers, niterations)
                    for p in samples.values()), (
                "all samples must have the same shape")

--- a/pycbc/inference/io/multinest.py
+++ b/pycbc/inference/io/multinest.py
@@ -45,7 +45,7 @@ class MultinestFile(BaseSamplerFile):
             Only write the specified parameters to the file. If None, will
             write all of the keys in the ``samples`` dict.
         """
-        niterations = len(samples.values()[0])
+        niterations = len(tuple(samples.values())[0])
         assert all(len(p) == niterations for p in samples.values()), (
             "all samples must have the same shape")
         group = self.samples_group + '/{name}'

--- a/pycbc/inference/models/marginalized_gaussian_noise.py
+++ b/pycbc/inference/models/marginalized_gaussian_noise.py
@@ -465,7 +465,7 @@ class MarginalizedGaussianNoise(GaussianNoise):
             raise ValueError("no approximant provided in the static args")
         generator_function = generator.select_waveform_generator(approximant)
         waveform_generator = generator.FDomainDetFrameGenerator(
-            generator_function, epoch=data.values()[0].start_time,
+            generator_function, epoch=tuple(data.values())[0].start_time,
             variable_args=variable_params, detectors=data.keys(),
             delta_f=delta_f, delta_t=delta_t,
             recalib=recalibration, gates=gates,

--- a/pycbc/inference/models/single_template.py
+++ b/pycbc/inference/models/single_template.py
@@ -53,7 +53,7 @@ class SingleTemplate(BaseDataModel):
             high_frequency_cutoff = float(high_frequency_cutoff)
 
         # Generate template waveforms
-        df = data[data.keys()[0]].delta_f
+        df = data[tuple(data.keys())[0]].delta_f
         p = self.static_params.copy()
         if 'distance' in p:
             p.pop('distance')
@@ -63,7 +63,7 @@ class SingleTemplate(BaseDataModel):
         hp, _ = get_fd_waveform(delta_f=df, distance=1, inclination=0, **p)
 
         if high_frequency_cutoff is None:
-            high_frequency_cutoff = len(data[data.keys()[0]]-1) * df
+            high_frequency_cutoff = len(data[tuple(data.keys())[0]]-1) * df
 
         # Extend data and template to high sample rate
         flen = int(sample_rate / df) / 2 + 1

--- a/pycbc/inference/sampler/cpnest.py
+++ b/pycbc/inference/sampler/cpnest.py
@@ -95,7 +95,7 @@ class CPNestSampler(BaseSampler):
 
     @property
     def niterations(self):
-        return len(self.samples.values()[0])
+        return len(tuple(self.samples.values())[0])
 
     @classmethod
     def from_config(cls, cp, model, nprocesses=1, use_mpi=False):

--- a/pycbc/inject/inject.py
+++ b/pycbc/inject/inject.py
@@ -345,7 +345,7 @@ class _HDFInjectionSet(object):
         if len(parameters) == 0:
             numinj = 1
         else:
-            numinj = injvals.values()[0].size
+            numinj = tuple(injvals.values())[0].size
         # add any static args in the file
         try:
             self.static_args = group.attrs['static_args']

--- a/pycbc/psd/read.py
+++ b/pycbc/psd/read.py
@@ -165,7 +165,7 @@ def from_xml(filename, length, delta_f, low_freq_cutoff, ifo_string=None,
         psd_freq_series = psd_dict[ifo_string]
     else:
         if len(psd_dict.keys()) == 1:
-            psd_freq_series = psd_dict[psd_dict.keys()[0]]
+            psd_freq_series = psd_dict[tuple(psd_dict.keys())[0]]
         else:
             err_msg = "No ifo string given and input XML file contains not "
             err_msg += "exactly one PSD. Specify which PSD you want to use."

--- a/pycbc/results/legacy_grb.py
+++ b/pycbc/results/legacy_grb.py
@@ -220,7 +220,7 @@ def write_antenna(page, args, seg_plot=None, grid=False, ipn=False):
                 antenna_ifo[ifo].append(round(f_q,3))
         dectKeys = antenna_ifo.keys()
 
-        for elements in range(len(antenna_ifo.values()[0])):
+        for elements in range(len(tuple(antenna_ifo.values())[0])):
             newDict={}
             for detectors in range(len(antenna_ifo.keys())):
                 newDict[dectKeys[detectors]] = antenna_ifo[\

--- a/pycbc/tmpltbank/option_utils.py
+++ b/pycbc/tmpltbank/option_utils.py
@@ -1088,7 +1088,7 @@ class ethincaParameters(object):
                 cutoff in pnutils.named_frequency_cutoffs.keys()):
             raise ValueError("Need a valid cutoff formula to calculate "
                              "ethinca! Possible values are "+
-                             str(pnutils.named_frequency_cutoffs.keys()))
+                             str(tuple(pnutils.named_frequency_cutoffs.keys())))
         if self.doEthinca and not freqStep:
             raise ValueError("Need to specify a cutoff frequency step to "
                              "calculate ethinca! (ethincaFreqStep)")
@@ -1139,7 +1139,7 @@ def insert_ethinca_metric_options(parser):
                     "order will be used as for the bank metric.")
     ethincaGroup.add_argument("--filter-cutoff",
                     default=None, 
-                    choices=pnutils.named_frequency_cutoffs.keys(),
+                    choices=tuple(pnutils.named_frequency_cutoffs.keys()),
                     help="Specify an upper frequency cutoff formula for the "
                     "ethinca metric calculation, and for the values of f_final"
                     " assigned to the templates.  REQUIRED if the "
@@ -1171,7 +1171,7 @@ def verify_ethinca_metric_options(opts, parser):
               pnutils.named_frequency_cutoffs.keys()):
         parser.error("Need a valid cutoff formula to calculate ethinca or "
                      "assign filter f_final values! Possible values are "
-                     +str(pnutils.named_frequency_cutoffs.keys()))
+                     +str(tuple(pnutils.named_frequency_cutoffs.keys())))
     if (opts.calculate_ethinca_metric or opts.calculate_time_metric_components)\
                                            and not opts.ethinca_frequency_step:
         parser.error("Need to specify a cutoff frequency step to calculate "

--- a/pycbc/transforms.py
+++ b/pycbc/transforms.py
@@ -138,7 +138,7 @@ class BaseTransform(object):
         else:
             additional_opts = additional_opts.copy()
         outputs = set(outputs.split(VARARGS_DELIM))
-        special_args = ['name'] + skip_opts + additional_opts.keys()
+        special_args = ['name'] + skip_opts + list(additional_opts.keys())
         # get any extra arguments to pass to init
         extra_args = {}
         for opt in cp.options("-".join([section, tag])):

--- a/pycbc/workflow/segment.py
+++ b/pycbc/workflow/segment.py
@@ -1052,7 +1052,7 @@ def get_triggered_coherent_segment(workflow, sciencesegs):
 
     # Check available data segments meet criteria specified in arguments
     commonsegs = sciencesegs.extract_common(sciencesegs.keys())
-    offsrclist = commonsegs[commonsegs.keys()[0]]
+    offsrclist = commonsegs[tuple(commonsegs.keys())[0]]
     if len(offsrclist) > 1:
         logging.info("Removing network segments that do not contain trigger "
                      "time")
@@ -1212,7 +1212,7 @@ def generate_triggered_segment(workflow, out_dir, sciencesegs):
                 best_comb = max(seg_lens.iterkeys(),
                                 key=(lambda key: seg_lens[key]))
             else:
-                best_comb = offsource.keys()[0]
+                best_comb = tuple(offsource.keys())[0]
             logging.info("No combination of %d IFOs with suitable science "
                          "segment.", num_ifos)
         else:

--- a/tools/einsteinathome/check_GW150914_detection.py
+++ b/tools/einsteinathome/check_GW150914_detection.py
@@ -14,7 +14,7 @@ gw150914_snr = {'H1': 19.71, 'L1': 13.28}
 gw150914_chi2r = {'H1': 1.05, 'L1': 0.45}
 
 f = h5py.File(sys.argv[1], 'r')
-detector = f.keys()[0]
+detector = tuple(f.keys())[0]
 end_times = f[detector]['end_time'][:]
 snrs = f[detector]['snr'][:]
 chi2rs = f[detector]['chisq'][:] / (2 * f[detector]['chisq_dof'][:] - 2)


### PR DESCRIPTION
This PR updates usage of `dict.keys()` and `dict.values()` for python3, mainly the fact that you can't directly index those objects in python3, and you can't store them as HDF5 attributes.