### PR TITLE
Two quick fixes for minifollowups

### DIFF
--- a/bin/minifollowups/pycbc_page_snglinfo
+++ b/bin/minifollowups/pycbc_page_snglinfo
@@ -42,10 +42,11 @@ parser.add_argument('--veto-file',
 parser.add_argument('--veto-segment-name',
     help="If using veto file, the name of the segments to use as a veto.")
 parser.add_argument("--instrument", help="Name of ifo (e.g. H1)")
-parser.add_argument("--n-loudest", type=int, default=None,
+trig_args = parser.add_mutually_exclusive_group(required=True)
+trig_args.add_argument("--n-loudest", type=int, default=None,
     help="Examine the n'th loudest trigger (loudest is n=0). Must supply "
          "either this or --trigger-id.")
-parser.add_argument("--trigger-id", type=int, default=None,
+trig_args.add_argument("--trigger-id", type=int, default=None,
     help="Use the trigger with this ID in the HDF file. Must supply either "
          "this option or --n-loudest.")
 parser.add_argument('--ranking-statistic', default='newsnr',
@@ -53,10 +54,6 @@ parser.add_argument('--ranking-statistic', default='newsnr',
          "'newsnr'")
 
 args = parser.parse_args()
-
-if args.trigger_id is not None and args.n_loudest is not None:
-    err_msg = "Must provide only one of --n-loudest and --trigger-id"
-    raise ValueError(err_msg)
 
 pycbc.init_logging(args.verbose)
 

--- a/bin/minifollowups/pycbc_page_snglinfo
+++ b/bin/minifollowups/pycbc_page_snglinfo
@@ -53,6 +53,11 @@ parser.add_argument('--ranking-statistic', default='newsnr',
          "'newsnr'")
 
 args = parser.parse_args()
+
+if args.trigger_id is not None and args.n_loudest is not None:
+    err_msg = "Must provide only one of --n-loudest and --trigger-id"
+    raise ValueError(err_msg)
+
 pycbc.init_logging(args.verbose)
 
 # Get the single-ifo triggers

--- a/bin/minifollowups/pycbc_sngl_minifollowup
+++ b/bin/minifollowups/pycbc_sngl_minifollowup
@@ -203,8 +203,7 @@ for rank, num_event in enumerate(order):
 
     layouts += (mini.make_sngl_ifo(workflow, sngl_file, tmpltbank_file,
                                    tid, args.output_dir, args.instrument,
-                                   tags=args.tags + [str(rank)],
-                                   rank=rank),)
+                                   tags=args.tags + [str(rank)]),)
     files += mini.make_trigger_timeseries(workflow, [sngl_file],
                               ifo_time, args.output_dir, special_tids=ifo_tid,
                               tags=args.tags + [str(rank)])

--- a/bin/minifollowups/pycbc_sngl_minifollowup
+++ b/bin/minifollowups/pycbc_sngl_minifollowup
@@ -191,7 +191,7 @@ times = trigs.end_time
 tids = trigs.template_id
 
 # loop over number of loudest events to be followed up
-order = trigs.stat.argsort()
+order = trigs.stat.argsort()[::-1]
 for rank, num_event in enumerate(order):
     logging.info('Processing event: %s', num_event)
 

--- a/pycbc/workflow/minifollowups.py
+++ b/pycbc/workflow/minifollowups.py
@@ -548,7 +548,7 @@ def make_coinc_info(workflow, singles, bank, coinc, out_dir,
     return files
 
 def make_sngl_ifo(workflow, sngl_file, bank_file, trigger_id, out_dir, ifo,
-                  tags=None, rank=None):
+                  tags=None):
     """Setup a job to create sngl detector sngl ifo html summary snippet.
     """
     tags = [] if tags is None else tags
@@ -560,8 +560,6 @@ def make_sngl_ifo(workflow, sngl_file, bank_file, trigger_id, out_dir, ifo,
     node.add_input_opt('--single-trigger-file', sngl_file)
     node.add_input_opt('--bank-file', bank_file)
     node.add_opt('--trigger-id', str(trigger_id))
-    if rank is not None:
-        node.add_opt('--n-loudest', str(rank))
     node.add_opt('--instrument', ifo)
     node.new_output_file_opt(workflow.analysis_time, '.html', '--output-file')
     workflow += node


### PR DESCRIPTION
This patch makes two quick fixes for sngl minifollowups:

 * Order the sngls in the right order again (loudest event first, not last)
 * Stop sending n-loudest by sngl_page_info, and make the code fail if it is sent both options (fixes #2728)

This is not yet tested.