### PR TITLE
Make PSD plotting compatible with inference and search workflows

### DIFF
--- a/bin/hdfcoinc/pycbc_plot_psd_file
+++ b/bin/hdfcoinc/pycbc_plot_psd_file
@@ -69,9 +69,9 @@ for psd_file in args.psd_files:
                     flow = base_file.attrs[
                                '{}_likelihood_low_freq'.format(ifo)]
             except KeyError:
-                raise ValueError("low_frequency_cutoff not found in hdf file; "
-                                 "please specify a value using the "
-                                 "--low-frequency-cutoff option")
+                raise RuntimeError("hdf file %s does not contain an attribute giving "
+                                   "low frequency cutoff, please specify a value using "
+                                   "the --low-frequency-cutoff option" % psd_file)
         kmin = int(flow / df)
         kmax = len(f[ifo + '/psds/' + keys[0]][:])
         klen = kmax - kmin

--- a/bin/hdfcoinc/pycbc_plot_psd_file
+++ b/bin/hdfcoinc/pycbc_plot_psd_file
@@ -59,7 +59,11 @@ for psd_file in args.psd_files:
         fac = 1.0 / pycbc.DYN_RANGE_FAC
         df = f[ifo + '/psds/0'].attrs['delta_f']
         keys = f[ifo + '/psds'].keys()
-        if args.low_frequency_cutoff is None:
+        if args.low_frequency_cutoff is not None:
+            flow = args.low_frequency_cutoff
+        elif 'low_frequency_cutoff' in f.attrs.keys():
+            flow = f.attrs['low_frequency_cutoff']
+        else:
             try:
                 with h5py.File(psd_file, 'r') as base_file:
                     flow = base_file.attrs[
@@ -68,8 +72,6 @@ for psd_file in args.psd_files:
                 raise ValueError("low_frequency_cutoff not found in hdf file; "
                                  "please specify a value using the "
                                  "--low-frequency-cutoff option")
-        else:
-            flow = args.low_frequency_cutoff
         kmin = int(flow / df)
         kmax = len(f[ifo + '/psds/' + keys[0]][:])
         klen = kmax - kmin

--- a/bin/inference/pycbc_inference_plot_samples
+++ b/bin/inference/pycbc_inference_plot_samples
@@ -86,7 +86,10 @@ else:
 if opts.thin_interval is not None:
     xint = opts.thin_interval
 else:
-    xint = fp.attrs['thin_interval']
+    try:
+        xint = fp.attrs['thin_interval']
+    except KeyError:
+        xint = 1
 
 thinned_by = fp.thinned_by*xint
 xmin = xmin*fp.thinned_by


### PR DESCRIPTION
This fixes a bug introduced in #2696 that caused PSD plotting to fail when running `pycbc_make_coinc_search_workflow`. The plotting code will now look for a low frequency cutoff in file locations used by both the search and inference workflows.