### PR TITLE
Multiifo inf minifollowup

### DIFF
--- a/bin/minifollowups/pycbc_injection_minifollowup
+++ b/bin/minifollowups/pycbc_injection_minifollowup
@@ -146,7 +146,7 @@ for num_event in range(num_events):
     for single in single_triggers:
         ifo = single.ifo
         for seg in insp_data_seglists[single.ifo]:
-            if trig_time in seg:
+            if time in seg:
                 det = Detector(ifo)
                 lon = f['injections/longitude'][injection_index]
                 lat = f['injections/latitude'][injection_index]

--- a/bin/minifollowups/pycbc_injection_minifollowup
+++ b/bin/minifollowups/pycbc_injection_minifollowup
@@ -35,7 +35,7 @@ def to_file(path, ifo=None):
     return fil
 
 parser = argparse.ArgumentParser(description=__doc__[1:])
-parser.add_argument('--version', action='version', version=pycbc.version.git_verbose_msg) 
+parser.add_argument('--version', action='version', version=pycbc.version.git_verbose_msg)
 parser.add_argument('--workflow-name', default='my_unamed_run')
 parser.add_argument("-d", "--output-dir", default=None,
                     help="Path to output directory.")
@@ -67,13 +67,13 @@ parser.add_argument('--tags', nargs='+', default=[])
 wf.add_workflow_command_line_group(parser)
 args = parser.parse_args()
 
-logging.basicConfig(format='%(asctime)s:%(levelname)s : %(message)s', 
+logging.basicConfig(format='%(asctime)s:%(levelname)s : %(message)s',
                     level=logging.INFO)
 
 workflow = wf.Workflow(args, args.workflow_name)
 
 wf.makedir(args.output_dir)
-             
+
 # create a FileList that will contain all output files
 layouts = []
 
@@ -117,7 +117,7 @@ except:
                'L1': f['injections/eff_dist_l'][:][missed],
                'V1': f['injections/eff_dist_v'][:][missed],
                }
-    dec_dist = numpy.maximum(eff_dist[single_triggers[0].ifo], 
+    dec_dist = numpy.maximum(eff_dist[single_triggers[0].ifo],
                              eff_dist[single_triggers[1].ifo])
 
     mchirp, eta = pycbc.pnutils.mass1_mass2_to_mchirp_eta(\
@@ -135,25 +135,31 @@ if len(missed) < num_events:
 found_inj_idxes = f['found_after_vetoes/injection_index'][:]
 for num_event in range(num_events):
     files = wf.FileList([])
-    
+
     injection_index = missed[sorting][num_event]
     time = f['injections/end_time'][injection_index]
-    
+
     ifo_times = ''
     inj_params = {}
     for val in ['mass1', 'mass2', 'spin1z', 'spin2z', 'end_time']:
         inj_params[val] = f['injections/%s' %(val,)][injection_index]
     for single in single_triggers:
         ifo = single.ifo
-        det = Detector(ifo)
-        lon = f['injections/longitude'][injection_index]
-        lat = f['injections/latitude'][injection_index]
-        ifo_time = time + det.time_delay_from_earth_center(lon, lat, time)
-        ifo_times += ' %s:%s ' % (ifo, ifo_time) 
+        for seg in insp_data_seglists[single.ifo]:
+            if trig_time in seg:
+                det = Detector(ifo)
+                lon = f['injections/longitude'][injection_index]
+                lat = f['injections/latitude'][injection_index]
+                ifo_time = time + det.time_delay_from_earth_center(lon, lat, time)
+                break
+        else:
+            ifo_time = -1.0
+
+        ifo_times += ' %s:%s ' % (ifo, ifo_time)
         inj_params[ifo+'_end_time'] = ifo_time
-          
+
     layouts += [(mini.make_inj_info(workflow, injection_file, injection_index, num_event,
-                               args.output_dir, tags=args.tags + [str(num_event)])[0],)]   
+                               args.output_dir, tags=args.tags + [str(num_event)])[0],)]
     if injection_index in found_inj_idxes:
         trig_id = numpy.where(found_inj_idxes == injection_index)[0][0]
         layouts += [(mini.make_coinc_info
@@ -164,15 +170,19 @@ for num_event in range(num_events):
     files += mini.make_trigger_timeseries(workflow, single_triggers,
                               ifo_times, args.output_dir,
                               tags=args.tags + [str(num_event)])
-    
+
     for single in single_triggers:
-        files += mini.make_singles_timefreq(workflow, single, tmpltbank_file, 
-                                time, args.output_dir,
+        checkedtime = time
+        if (inj_params[single.ifo+'_end_time'] == -1.0):
+            checkedtime = -1.0
+
+        files += mini.make_singles_timefreq(workflow, single, tmpltbank_file,
+                                checkedtime, args.output_dir,
                                 data_segments=insp_data_seglists[single.ifo],
                                 tags=args.tags + [str(num_event)])
 
         files += mini.make_qscan_plot\
-            (workflow, single.ifo, time, args.output_dir,
+            (workflow, single.ifo, checkedtime, args.output_dir,
              data_segments=insp_data_seglists[single.ifo],
              injection_file=injection_xml_file,
              tags=args.tags + [str(num_event)])
@@ -215,7 +225,7 @@ for num_event in range(num_events):
         # Use SNR here or NewSNR??
         snr = hd_sngl.snr
         lgc_mask = abs(end_times - inj_params['end_time']) < args.inj_window
-        
+
         if len(snr[lgc_mask]) == 0:
             continue
 

--- a/bin/minifollowups/pycbc_page_injinfo
+++ b/bin/minifollowups/pycbc_page_injinfo
@@ -67,7 +67,7 @@ if 'optimal_snr_1' in f['injections'].keys():
     labels['optimal_snr_2'] = 'Opt.&nbsp;SNR %s' % f.attrs['detector_2']
     params += ['optimal_snr_1', 'optimal_snr_2']
 elif 'ifos' in f.attrs:
-    ifolist = attrs['ifos'].split(' ')
+    ifolist = f.attrs['ifos'].split(' ')
     for ifo in ifolist:
         labels['optimal_snr_%s' % ifo] = 'Opt.&nbsp;SNR %s' % ifo
         params += ['optimal_snr_%s' % ifo]

--- a/bin/minifollowups/pycbc_page_injinfo
+++ b/bin/minifollowups/pycbc_page_injinfo
@@ -66,7 +66,7 @@ if 'optimal_snr_1' in f['injections'].keys():
     labels['optimal_snr_1'] = 'Opt.&nbsp;SNR %s' % f.attrs['detector_1']
     labels['optimal_snr_2'] = 'Opt.&nbsp;SNR %s' % f.attrs['detector_2']
     params += ['optimal_snr_1', 'optimal_snr_2']
-elif 'ifos' in f.keys():
+elif 'ifos' in f.attrs:
     ifolist = attrs['ifos'].split(' ')
     for ifo in ifolist:
         labels['optimal_snr_%s' % ifo] = 'Opt.&nbsp;SNR %s' % ifo

--- a/bin/minifollowups/pycbc_page_injinfo
+++ b/bin/minifollowups/pycbc_page_injinfo
@@ -42,8 +42,6 @@ data = []
 
 labels = {
     'end_time': 'End&nbsp;time',
-    'optimal_snr_1' : 'Opt.&nbsp;SNR %s' % f.attrs['detector_1'],
-    'optimal_snr_2' : 'Opt.&nbsp;SNR %s' % f.attrs['detector_2'],
     'dec_chirp_dist': 'Dec.&nbsp;chirp dist',
     'eff_dist_h'    : 'D<sub>eff</sub>&nbsp;H',
     'eff_dist_l'    : 'D<sub>eff</sub>&nbsp;L',
@@ -65,7 +63,14 @@ labels = {
 params += ['end_time']
 
 if 'optimal_snr_1' in f['injections'].keys():
+    labels['optimal_snr_1'] = 'Opt.&nbsp;SNR %s' % f.attrs['detector_1']
+    labels['optimal_snr_2'] = 'Opt.&nbsp;SNR %s' % f.attrs['detector_2']
     params += ['optimal_snr_1', 'optimal_snr_2']
+elif 'ifos' in f.keys():
+    ifolist = attrs['ifos'].split(' ')
+    for ifo in ifolist:
+        labels['optimal_snr_%s' % ifo] = 'Opt.&nbsp;SNR %s' % ifo
+        params += ['optimal_snr_%s' % ifo]
 else:
     params += ['dec_chirp_dist', 'eff_dist_h', 'eff_dist_l']
     dec_dist = max(f['injections']['eff_dist_h'][iidx], f['injections']['eff_dist_l'][iidx])

--- a/bin/plotting/pycbc_plot_qscan
+++ b/bin/plotting/pycbc_plot_qscan
@@ -106,7 +106,7 @@ if center_time == -1.0:
     plt.grid(False)
     plt.xlabel('Time from {:.3f} (s)'.format(opts.center_time))
     plt.ylabel('Frequency (Hz)')
-    title = 'No triggers or this IFO'
+    title = 'No data for this IFO'
     pycbc.results.save_fig_with_metadata\
     (fig, opts.output_file, cmd=' '.join(sys.argv), fig_kwds={'dpi': 150},
      title=title, caption=opts.plot_caption)

--- a/bin/workflows/pycbc_create_offline_search_workflow
+++ b/bin/workflows/pycbc_create_offline_search_workflow
@@ -644,10 +644,10 @@ for inj_file, tag in zip(inj_files, inj_tags):
                                            'subsection-suffix', tags=[tag])
         curr_dir_nam += '_' + suf_str
     currdir = rdir[curr_dir_nam]
-    #wf.setup_injection_minifollowups(workflow, found_inj, small_inj_file,
-    #                                 insps,  hdfbank[0], insp_files_seg_file,
-    #                                 data_analysed_name, trig_generated_name,
-    #                                 'daxes', currdir, tags=[tag])
+    wf.setup_injection_minifollowups(workflow, found_inj, small_inj_file,
+                                     insps,  hdfbank[0], insp_files_seg_file,
+                                     data_analysed_name, trig_generated_name,
+                                     'daxes', currdir, tags=[tag])
 
     # If option given, make throughput plots
     if workflow.cp.has_option_tags('workflow-matchedfilter',


### PR DESCRIPTION
This PR enables injection minifollowups. Changes: give time = -1.0 to the plotting code when the injection is looked for an ifo that is not online. This is how combine statmap determines and foreground and single followup expects the codes.

Work in progress, some pycbc_single_template and pycbc_page_injinfo jobs still fail. 