### PR TITLE
Allow statistic files in single_minifollowup

### DIFF
--- a/bin/minifollowups/pycbc_sngl_minifollowup
+++ b/bin/minifollowups/pycbc_sngl_minifollowup
@@ -72,6 +72,10 @@ parser.add_argument('--min-snr', type=float, default=6.5,
                     help="Minimum SNR to consider for loudest triggers")
 parser.add_argument('--ranking-statistic',
                 help="How to rank triggers when determining loudest triggers.")
+parser.add_argument('--statistic-files', nargs='+', default=None,
+                    help='Use this to supply supplementary files that are '
+                         'necessary for computing the ranking statistic. For '
+                         'example the phase-time consistency file.')
 parser.add_argument('--non-coinc-time-only', default=False,
                     action='store_true',
                     help="If given remove (veto) single-detector triggers "
@@ -182,8 +186,9 @@ if len(trigs.snr) == 0:
     sys.exit(0)
 
 logging.info('finding loudest clustered events')
-trigs.mask_to_n_loudest_clustered_events(n_loudest=num_events,
-                                      ranking_statistic=args.ranking_statistic)
+trigs.mask_to_n_loudest_clustered_events\
+    (n_loudest=num_events, ranking_statistic=args.ranking_statistic,
+     statistic_files=args.statistic_files)
 if len(trigs.stat) < num_events:
     num_events = len(trigs.stat)
 

--- a/bin/minifollowups/pycbc_sngl_minifollowup
+++ b/bin/minifollowups/pycbc_sngl_minifollowup
@@ -96,6 +96,7 @@ parser.add_argument('--output-file')
 parser.add_argument('--tags', nargs='+', default=[])
 wf.add_workflow_command_line_group(parser)
 args = parser.parse_args()
+args.statistic_files = sum(args.statistic_files, [])
 
 logging.basicConfig(format='%(asctime)s:%(levelname)s : %(message)s',
                     level=logging.INFO)

--- a/bin/minifollowups/pycbc_sngl_minifollowup
+++ b/bin/minifollowups/pycbc_sngl_minifollowup
@@ -96,6 +96,7 @@ parser.add_argument('--output-file')
 parser.add_argument('--tags', nargs='+', default=[])
 wf.add_workflow_command_line_group(parser)
 args = parser.parse_args()
+# args.statistic_files might be a list of lists. This will flatten this to a single list.
 args.statistic_files = sum(args.statistic_files, [])
 
 logging.basicConfig(format='%(asctime)s:%(levelname)s : %(message)s',

--- a/bin/minifollowups/pycbc_sngl_minifollowup
+++ b/bin/minifollowups/pycbc_sngl_minifollowup
@@ -72,7 +72,8 @@ parser.add_argument('--min-snr', type=float, default=6.5,
                     help="Minimum SNR to consider for loudest triggers")
 parser.add_argument('--ranking-statistic',
                 help="How to rank triggers when determining loudest triggers.")
-parser.add_argument('--statistic-files', nargs='+', default=None,
+parser.add_argument('--statistic-files', nargs='+',
+                    action='append', default=[],
                     help='Use this to supply supplementary files that are '
                          'necessary for computing the ranking statistic. For '
                          'example the phase-time consistency file.')

--- a/bin/workflows/pycbc_make_coinc_search_workflow
+++ b/bin/workflows/pycbc_make_coinc_search_workflow
@@ -175,7 +175,7 @@ insps = wf.merge_single_detector_hdf_files(workflow, hdfbank[0],
 
 # setup sngl trigger distribution fitting jobs
 # 'statfiles' is list of files used in calculating coinc statistic
-statfiles = []
+statfiles = wf.FileList([])
 statfiles += wf.setup_trigger_fitting(workflow, insps, hdfbank,
                                       final_veto_file, final_veto_name)
 

--- a/bin/workflows/pycbc_make_coinc_search_workflow
+++ b/bin/workflows/pycbc_make_coinc_search_workflow
@@ -418,6 +418,7 @@ for insp_file in full_insps:
                                       trig_generated_name, 'daxes', currdir,
                                       veto_file=censored_veto,
                                       veto_segment_name='closed_box',
+                                      statfiles=statfiles,
                                       tags=insp_file.tags + [subsec])
 
 ################## Setup segment / veto related plots #########################

--- a/pycbc/io/hdf.py
+++ b/pycbc/io/hdf.py
@@ -468,13 +468,16 @@ class SingleDetTriggers(object):
 
     def mask_to_n_loudest_clustered_events(self, n_loudest=10,
                                            ranking_statistic="newsnr",
-                                           cluster_window=10):
+                                           cluster_window=10,
+                                           statistic_files=None):
         """Edits the mask property of the class to point to the N loudest
         single detector events as ranked by ranking statistic. Events are
         clustered so that no more than 1 event within +/- cluster-window will
         be considered."""
+        if statistic_files is None:
+            statistic_files = []
         # If this becomes memory intensive we can optimize
-        stat_instance = sngl_statistic_dict[ranking_statistic]([])
+        stat_instance = sngl_statistic_dict[ranking_statistic](statistic_files)
         stat = stat_instance.single(self.trig_dict())
 
         # Used for naming in plots ... Seems an odd place for this to live!

--- a/pycbc/workflow/minifollowups.py
+++ b/pycbc/workflow/minifollowups.py
@@ -128,9 +128,10 @@ def setup_foreground_minifollowups(workflow, coinc_file, single_triggers,
     logging.info('Leaving minifollowups module')
 
 def setup_single_det_minifollowups(workflow, single_trig_file, tmpltbank_file,
-                                  insp_segs, insp_data_name, insp_anal_name,
-                                  dax_output, out_dir, veto_file=None,
-                                  veto_segment_name=None, tags=None):
+                                   insp_segs, insp_data_name, insp_anal_name,
+                                   dax_output, out_dir, veto_file=None,
+                                   veto_segment_name=None, statfiles=None,
+                                   tags=None):
     """ Create plots that followup the Nth loudest clustered single detector
     triggers from a merged single detector trigger HDF file.
 
@@ -150,6 +151,9 @@ def setup_single_det_minifollowups(workflow, single_trig_file, tmpltbank_file,
         The name of the segmentlist storing data analyzed.
     out_dir: path
         The directory to store minifollowups result plots and files
+    statfiles: FileList (optional, default=None)
+        Supplementary files necessary for computing the single-detector
+        statistic. 
     tags: {None, optional}
         Tags to add to the minifollowups executables
     Returns
@@ -197,6 +201,9 @@ def setup_single_det_minifollowups(workflow, single_trig_file, tmpltbank_file,
         assert(veto_segment_name is not None)
         node.add_input_opt('--veto-file', veto_file)
         node.add_opt('--veto-segment-name', veto_segment_name)
+    if statfiles is not None:
+        statfiles = statfiles.find_output_with_ifo(curr_ifo)
+        node.add_input_list_opt('--statistic-files', statfiles)
     node.new_output_file_opt(workflow.analysis_time, '.dax', '--output-file', tags=tags)
     node.new_output_file_opt(workflow.analysis_time, '.dax.map', '--output-map', tags=tags)
     node.new_output_file_opt(workflow.analysis_time, '.tc.txt', '--transformation-catalog', tags=tags)

--- a/pycbc/workflow/minifollowups.py
+++ b/pycbc/workflow/minifollowups.py
@@ -153,7 +153,7 @@ def setup_single_det_minifollowups(workflow, single_trig_file, tmpltbank_file,
         The directory to store minifollowups result plots and files
     statfiles: FileList (optional, default=None)
         Supplementary files necessary for computing the single-detector
-        statistic. 
+        statistic.
     tags: {None, optional}
         Tags to add to the minifollowups executables
     Returns


### PR DESCRIPTION
This patch edits the `pycbc_single_minifollowups` code to be able to use the various `exp_fit` statistics, which require supplementary files. This has been tested as per examples shared in the SLACK channel.

We still need to send the same files to the jobs running within the DAX that this will produce, but I leave that to a separate PR.