### PR TITLE
Don't send ifos to plot_spectrum - it can fail

### DIFF
--- a/pycbc/workflow/plotting.py
+++ b/pycbc/workflow/plotting.py
@@ -94,7 +94,6 @@ def make_spectrum_plot(workflow, psd_files, out_dir, tags=None,
                           out_dir=out_dir, tags=tags).create_node()
     node.add_input_list_opt('--psd-files', psd_files)
     node.new_output_file_opt(workflow.analysis_time, '.png', '--output-file')
-    node.add_opt('--ifos', ' '.join(workflow.ifos))
 
     if hdf_group is not None:
         node.add_opt('--hdf-group', hdf_group)


### PR DESCRIPTION
It looks like there's been some issues with plot_spectrum as this code now runs in the inference workflow.

One fail mode I've seen is that the list of ifos, and the list of PSD files, must match up (e.g. if H1 appears first in the ifo list, the H1 PSD file must go first). This doesn't appear to have caused problems in the past, but some combination of python3 changes and inference changes have now allowed this to be a failure mode.

The solution is simple: Don't tell plot_spectrum the ifos. If not given this option it just gets the ifos from the supplied files. This seems the "best" solution without providing redundant information.

This has been tested and fixes the failure mode I saw.