### PR TITLE
Injections from file for pp-workflow

### DIFF
--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -35,6 +35,7 @@ from pycbc import inference
 from pycbc.inference import (models, burn_in, option_utils)
 from pycbc.strain.calibration import Recalibrate
 from pycbc.workflow import configuration
+from pycbc.inject import InjectionSet
 
 # command line usage
 parser = argparse.ArgumentParser(usage=__file__ + " [--options]",
@@ -147,7 +148,31 @@ with ctx:
                 cp.get('sampler', 'checkpoint-signal')))
         # create an empty output file to keep condor happy
         open(opts.output_file, 'a').close()
+    
+    # Note: PyCBC's multi-ifo parser uses key:ifo for
+    # the injection file, even though we will use the same
+    # injection file for all detectors. This
+    # should be fixed in a future version of PyCBC. Once it is,
+    # update this. Until then, just use the first file.
+    if opts.injection_file:
+        injection_file = tuple(opts.injection_file.values())[0]  
+        # None if not set
+    else:
+        injection_file = None
 
+    # If injection placeholders for static params are set in config file, 
+    # insert injected parameters.
+    if injection_file \
+        and "injection" in dict(cp.items('static_params')).values():
+        inj = InjectionSet(injection_file)
+        for opt in cp.options(section='static_params'):
+            if cp.get('static_params', opt) == "injection" \
+                                and opt not in inj.table.fieldnames:
+                raise ValueError("Static param placeholder \"injection\" \
+                            has no counterpart in injection file.")
+            elif cp.get('static_params', opt) == "injection":
+                cp.set('static_params', opt, str(inj.table[opt][0]))
+    
     # get ifo-specific instances of calibration model
     if cp.has_section('calibration'):
         logging.info("Initializing calibration model")
@@ -176,15 +201,6 @@ with ctx:
         cp, model, nprocesses=opts.nprocesses, use_mpi=opts.use_mpi)
 
     # set up output/checkpoint file
-    # Note: PyCBC's multi-ifo parser uses key:ifo for
-    # the injection file, even though we will use the same
-    # injection file all detectors. This
-    # should be fixed in a future version of PyCBC. Once it is,
-    # update this. Until then, just use the first file.
-    if opts.injection_file:
-        injection_file = tuple(opts.injection_file.values())[0]  # None if not set
-    else:
-        injection_file = None
     sampler.setup_output(opts.output_file, force=opts.force,
                          injection_file=injection_file)
 

--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -160,18 +160,23 @@ with ctx:
     else:
         injection_file = None
 
-    # If injection placeholders for static params are set in config file, 
+    # If FROM_INJECTION placeholders for static params are set in config file, 
     # insert injected parameters.
     if injection_file \
-        and "injection" in dict(cp.items('static_params')).values():
+        and "FROM_INJECTION" in dict(cp.items('static_params')).values():
         inj = InjectionSet(injection_file)
         for opt in cp.options(section='static_params'):
-            if cp.get('static_params', opt) == "injection" \
+            if cp.get('static_params', opt) == "FROM_INJECTION" \
                                 and opt not in inj.table.fieldnames:
-                raise ValueError("Static param placeholder \"injection\" \
+                raise ValueError("Static param placeholder \"FROM_INJECTION\" \
                             has no counterpart in injection file.")
-            elif cp.get('static_params', opt) == "injection":
-                cp.set('static_params', opt, str(inj.table[opt][0]))
+            elif cp.get('static_params', opt) == "FROM_INJECTION":
+                if isinstance(inj.table[opt][0], numpy.ndarray):
+                    if inj.table[opt][0].ndim > 0:
+                        cp.set('static_params', opt, 
+                               str(list(inj.table[opt][0])))
+                else: 
+                    cp.set('static_params', opt, str(inj.table[opt][0]))
     
     # get ifo-specific instances of calibration model
     if cp.has_section('calibration'):

--- a/bin/workflows/pycbc_make_inference_inj_workflow
+++ b/bin/workflows/pycbc_make_inference_inj_workflow
@@ -34,6 +34,8 @@ from pycbc.workflow import core
 from pycbc.workflow import jobsetup
 from pycbc.workflow import inference_followups
 from pycbc.workflow import plotting
+from pycbc.inject import InjectionSet
+from pycbc.io import FieldArray
 
 # set command line parser
 parser = argparse.ArgumentParser(description=__doc__[1:])
@@ -67,6 +69,12 @@ parser.add_argument(
     "--inference-config-file",
     type=str, required=True,
     help="WorkflowConfigParser parsable file with proir information.")
+
+# injections file
+parser.add_argument(
+    "--injection-files", 
+    type=str, nargs="+", 
+    help="hdf files containing injections.")
 
 # input data for workflow options
 parser.add_argument(
@@ -104,6 +112,12 @@ finalize_workflow = core.Workflow(opts, opts.workflow_name + "-finalization")
 
 # read inference configuration file
 cp = configuration.WorkflowConfigParser([opts.inference_config_file])
+
+# read injection files
+if opts.injection_files:
+    input_injection_files = []
+    for injfile in opts.injection_files:
+        input_injection_files.append(os.path.abspath(injfile))
 
 # typecast str from command line to File instances
 config_file = core.File.from_path(opts.inference_config_file)
@@ -159,7 +173,7 @@ if 'pp-plot-parameters' in  workflow.cp.options("workflow-inference"):
         'pp-plot-parameters', 'inference'))
 else:
     # just use the variable params
-    pp_plot_params = workflow.cp.options(cp.options("variable_params"))
+    pp_plot_params = cp.options("variable_params")
 
 # get groups of parameters to plot in posterior and samples plots
 plot_groups = {}
@@ -185,6 +199,39 @@ post_group_files = {g : core.FileList([]) for g in plot_groups.keys()}
 post_table_files = core.FileList([])
 accept_files = core.FileList([])
 sample_group_files = {g : core.FileList([]) for g in plot_groups.keys()}
+
+# if injection files given, separate into individual files for each injection
+if input_injection_files:
+    injection_files = core.FileList([])
+    os.mkdir("injections")
+    
+    total_numinj = 0
+    for i_input in range(len(input_injection_files)):
+        injections = InjectionSet(input_injection_files[i_input])
+        local_numinj = len(injections.table)
+        st_args = {k: injections.table[k][0] 
+                   for k in injections._injhandler.static_args}
+                    
+        for i in range(local_numinj):
+            samples = {f: injections.table[i][f] 
+                       for f in injections.table.fieldnames
+                       if f not in injections._injhandler.static_args}
+            
+            injections.write(
+                'injections/injection%s.hdf' %(i+total_numinj), 
+                 FieldArray.from_kwargs(**samples),
+                 write_params = [k for k in injections.table.fieldnames 
+                                 if k not in injections._injhandler.static_args],
+                 static_args = st_args)
+            
+            injection_files.append(
+                    core.File.from_path(
+                        'injections/injection%s.hdf' %(i+total_numinj)))
+        total_numinj += local_numinj
+    if total_numinj != n_injections:
+        raise ValueError('Given number of injections does not match '
+                         'injections in files.')
+
 for i in range(n_injections):
 
     # make node for drawing injection parameter values

--- a/bin/workflows/pycbc_make_inference_inj_workflow
+++ b/bin/workflows/pycbc_make_inference_inj_workflow
@@ -234,8 +234,12 @@ if input_injection_files:
 
 for i in range(n_injections):
 
+    # if injection files are given, use individual files
+    if opts.injection_files:
+        injection_file = injection_files[i]
+
     # make node for drawing injection parameter values
-    if not opts.data_type == "analytical":
+    elif not opts.data_type == "analytical":
         node, injection_file = create_injections_exe.create_node(config_file,
                                                                  seed=i,
                                                                  tags=[str(i)])


### PR DESCRIPTION
This allows to use the pp_workflow with a file containing pre-made injections. 

pycbc_make_inference_inj_workflow takes files with multiple injections and splits these into files containing one injection each for inference to run on. 

Also allows to insert the keyword 'injection' in the static_params section of the inference.ini file. Static parameters set to this are replaced with the value found in the corresponding injection. 