### PR TITLE
Move to dqsegdb2 and a few minor fixes to dq.py

### DIFF
--- a/pycbc/dq.py
+++ b/pycbc/dq.py
@@ -161,7 +161,7 @@ def query_flag(ifo, segment_name, start_time, end_time,
             if source != 'any':
                 raise ValueError(msg)
             else:
-                print("Tried and failed GWOSC {}, trying dqsegdb", name)
+                print("Tried and failed GWOSC {}, trying dqsegdb", segment_name)
 
 
             return query_flag(ifo, segment_name, start_time, end_time,

--- a/pycbc/dq.py
+++ b/pycbc/dq.py
@@ -127,7 +127,6 @@ def query_flag(ifo, segment_name, start_time, end_time,
     segments: glue.segments.segmentlist
         List of segments
     """
-    
     flag_segments = segmentlist([])
 
     if source in ['GWOSC', 'any']:
@@ -203,7 +202,7 @@ def query_flag(ifo, segment_name, start_time, end_time,
 
         else:  # Standard case just query directly.
             try:
-                segs = query(':'.join([ifo, name, str(version)]),
+                segs = query(':'.join([ifo, segment_name]),
                              int(start_time), int(end_time),
                              host=server)['active']
                 for rseg in segs:

--- a/pycbc/dq.py
+++ b/pycbc/dq.py
@@ -161,8 +161,8 @@ def query_flag(ifo, segment_name, start_time, end_time,
             if source != 'any':
                 raise ValueError(msg)
             else:
-                print("Tried and failed GWOSC {}, trying dqsegdb", segment_name)
-
+                print("Tried and failed GWOSC {}, trying dqsegdb",
+                      segment_name)
 
             return query_flag(ifo, segment_name, start_time, end_time,
                               source='dqsegdb', server=server,

--- a/pycbc/dq.py
+++ b/pycbc/dq.py
@@ -96,7 +96,7 @@ def parse_veto_definer(veto_def_filename):
 GWOSC_URL = 'https://www.gw-openscience.org/timeline/segments/json/{}/{}_{}/{}/{}/'
 
 
-def query_flag(ifo, name, start_time, end_time,
+def query_flag(ifo, segment_name, start_time, end_time,
                source='any', server="segments.ligo.org",
                veto_definer=None, cache=False):
     """Return the times where the flag is active
@@ -105,7 +105,7 @@ def query_flag(ifo, name, start_time, end_time,
     ----------
     ifo: string
         The interferometer to query (H1, L1).
-    name: string
+    segment_name: string
         The status flag to query from LOSC.
     start_time: int
         The starting gps time to begin querying from LOSC
@@ -127,13 +127,7 @@ def query_flag(ifo, name, start_time, end_time,
     segments: glue.segments.segmentlist
         List of segments
     """
-    info = name.split(':')
-    if len(info) == 2:
-        segment_name, version = info
-    elif len(info) == 1:
-        segment_name = info[0]
-        version = 1
-
+    
     flag_segments = segmentlist([])
 
     if source in ['GWOSC', 'any']:
@@ -329,6 +323,12 @@ def parse_flag_str(flag_str):
 
     for flag in flags:
         # Check if the flag should add or subtract time
+        if not (flag[0] == '+' or flag[0] == '-'):
+            err_msg = "DQ flags must begin with a '+' or a '-' character. "
+            err_msg += "You provided {}.".format(flag)
+            err_msg += "See http://pycbc.org/pycbc/latest/html/workflow/segments.html "
+            err_msg += "for more information."
+            raise ValueError(err_msg)
         sign = flag[0] == '+'
         flag = flag[1:]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ emcee==2.2.1
 cpnest
 
 # For LDG service access
-dqsegdb
+dqsegdb2>=1.0.1
 http://download.pegasus.isi.edu/pegasus/4.9.0/pegasus-python-source-4.9.0.tar.gz; python_version <= '2.7'
 amqplib
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,6 +27,7 @@ emcee==2.2.1
 cpnest
 
 # For LDG service access
+dqsegdb
 dqsegdb2>=1.0.1
 http://download.pegasus.isi.edu/pegasus/4.9.0/pegasus-python-source-4.9.0.tar.gz; python_version <= '2.7'
 amqplib

--- a/test/test_dq.py
+++ b/test/test_dq.py
@@ -92,8 +92,10 @@ class TestDataQualityFlags(unittest.TestCase):
 
         d1 = query_str('H1', '+data', 1126051217, 1126051217 + 100000)
         d2 = query_str('H1', '+H1:data', 1126051217, 1126051217 + 100000)
-        d3 = query_str('H1', '+data:1', 1126051217, 1126051217 + 100000)
-        d4 = query_str('H1', '+data<0:0>[1126051217:1127051217]', 1126051217, 1126051217 + 100000)
+        d3 = query_str('H1', '+data[1126051217:1127051217]',
+                       1126051217, 1126051217 + 100000)
+        d4 = query_str('H1', '+data<0:0>[1126051217:1127051217]',
+                       1126051217, 1126051217 + 100000)
 
         self.assertTrue(abs(d - d1) == 0)
         self.assertTrue(abs(d - d2) == 0)


### PR DESCRIPTION
This patch moves `dq.py` to `dqsegdb2` because the interface is simpler and does not explicitly require a version flag to be specified. I've also had better results with `dqsegdb2` in python3, although I did not properly debug the original `dqsegdb` in python3.

I also enforce that flag names must start with a `+` or a `-`. I have tested this change under LVC conditions, but I do want to test running this using a veto-definer file "properly".