### PR TITLE
use build dependency feature now to enforce numpy / cython are available

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,5 @@
+[build-system]
+requires = ["setuptools", 
+            "wheel", 
+            "cython", 
+            "numpy>=1.13.0,<1.15.3"]


### PR DESCRIPTION
Pip looks at pyproject.toml to allow one to enforce that a package be installed *before* building a wheel out of your project. This is needed in python3 for pycbc to ensure numpy of the right version is available before building the compiled code. In python2 the wheel build fails anyway (related to weave) so it runs setup.py at the end of the process to finish the install and bypasses this problem. 

See https://www.python.org/dev/peps/pep-0518/ for details. 