### PR TITLE
Python3 fixes to make inference examples run

### DIFF
--- a/pycbc/inference/burn_in.py
+++ b/pycbc/inference/burn_in.py
@@ -205,7 +205,7 @@ class MCMCBurnInTests(object):
             try:
                 group = fp[fp.samples_group]
                 # we'll just use the first parameter
-                params = group.keys()
+                params = list(group.keys())
                 nsamples = group[params[0]].shape[-1]
             except (KeyError, IndexError):
                 nsamples = 0

--- a/pycbc/inference/io/__init__.py
+++ b/pycbc/inference/io/__init__.py
@@ -154,7 +154,7 @@ def check_integrity(filename):
     # will raise an IOError
     with loadfile(filename, 'r') as fp:
         # check that all datasets in samples have the same shape
-        parameters = fp[fp.samples_group].keys()
+        parameters = list(fp[fp.samples_group].keys())
         # but only do the check if parameters have been written
         if len(parameters) > 0:
             group = fp.samples_group + '/{}'

--- a/pycbc/inference/io/base_hdf.py
+++ b/pycbc/inference/io/base_hdf.py
@@ -173,8 +173,8 @@ class BaseInferenceFile(h5py.File):
         # convert to FieldArray
         samples = array_class.from_kwargs(**samples)
         # add the static params and attributes
-        addatrs = (self.static_params.items() +
-                   self[self.samples_group].attrs.items())
+        addatrs = (list(self.static_params.items()) +
+                   list(self[self.samples_group].attrs.items()))
         for (p, val) in addatrs:
             setattr(samples, p, val)
         return samples

--- a/pycbc/inference/io/base_mcmc.py
+++ b/pycbc/inference/io/base_mcmc.py
@@ -176,7 +176,7 @@ class MCMCMetadataIO(object):
                 # dataset doesn't exist yet
                 self[group.format(param)] = acls[param]
         # write the maximum over all params
-        acl = numpy.array(acls.values()).max()
+        acl = numpy.array(list(acls.values())).max()
         self[self.sampler_group].attrs['acl'] = acl
         # set the default thin interval to be the acl (if it is finite)
         if numpy.isfinite(acl):

--- a/pycbc/inference/io/base_multitemper.py
+++ b/pycbc/inference/io/base_multitemper.py
@@ -211,7 +211,7 @@ class MultiTemperedMCMCIO(object):
             nwalkers = self.nwalkers
         # temperatures to load
         selecttemps = False
-        if isinstance(temps, int):
+        if isinstance(temps, (int, numpy.int32, numpy.int64)):
             tidx = temps
             ntemps = 1
         else:

--- a/pycbc/inference/sampler/base_mcmc.py
+++ b/pycbc/inference/sampler/base_mcmc.py
@@ -112,7 +112,7 @@ def blob_data_to_dict(stat_names, blobs):
         "number of stat names must match length of tuples in the blobs")
     # convert to an array; to ensure that we get the dtypes correct, we'll
     # cast to a structured array
-    raw_stats = numpy.array(blobs, dtype=zip(stat_names, dtypes))
+    raw_stats = numpy.array(blobs, dtype=list(zip(stat_names, dtypes)))
     # transpose so that it has shape nwalkers x niterations
     raw_stats = raw_stats.transpose()
     # now return as a dictionary

--- a/pycbc/io/record.py
+++ b/pycbc/io/record.py
@@ -1458,10 +1458,10 @@ class FieldArray(numpy.recarray):
         """
         if isinstance(possible_fields, string_types):
             possible_fields = [possible_fields]
-        possible_fields = map(str, possible_fields)
+        possible_fields = list(map(str, possible_fields))
         # we'll just use float as the dtype, as we just need this for names
-        arr = cls(1, dtype=zip(possible_fields,
-                               len(possible_fields)*[float]))
+        arr = cls(1, dtype=list(zip(possible_fields,
+                                len(possible_fields)*[float])))
         # try to perserve order
         return list(get_needed_fieldnames(arr, parameters))
 


### PR DESCRIPTION
Here are the following changes necessary to make the inference examples run without failing on python3. I am reasonably certain that further changes will be needed to make things run smoothly, but I'll leave further testing for Collin.