### PR TITLE
Update requirements

### DIFF
--- a/docs/conf_std.py
+++ b/docs/conf_std.py
@@ -32,7 +32,6 @@ extensions = ['sphinx.ext.autodoc', 'sphinx.ext.doctest',
               'sphinx.ext.intersphinx', 'sphinx.ext.coverage',
               'sphinx.ext.viewcode', 'sphinxcontrib.programoutput',
               'sphinx.ext.napoleon', 'sphinx.ext.mathjax',
-              'matplotlib.sphinxext.only_directives',
               'matplotlib.sphinxext.plot_directive', 'sphinx.ext.autosummary',
               'sphinx.ext.inheritance_diagram',
               ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,6 +35,6 @@ https://github.com/ahnitz/pegasus-wms-python3/archive/master.tar.gz; python_vers
 amqplib
 
 # For building documentation
-Sphinx>=1.5.0
+Sphinx>=1.5.0,<2.0.0
 sphinx-rtd-theme
 sphinxcontrib-programoutput>=0.11

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ astropy>=2.0.3; python_version >= '3.0'
 Mako>=1.0.1
 decorator>=3.4.2
 scipy>=0.16.0; python_version >= '3.5'
-scipy>=0.16.0,1.3.0; python_version <= '3.4'
+scipy>=0.16.0,<1.3.0; python_version <= '3.4'
 matplotlib>=2.0.0
 numpy>=1.13.0,<1.15.3
 pillow

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,8 @@ decorator>=3.4.2
 scipy>=0.16.0; python_version >= '3.5'
 scipy>=0.16.0,<1.3.0; python_version <= '3.4'
 matplotlib>=2.0.0
-numpy>=1.13.0,<1.15.3
+numpy>=1.13.0,<1.15.3; python_version <= '2.7'
+numpy>=1.13.0; python_version >= '3.0'
 pillow
 h5py>=2.5
 jinja2

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,8 @@ astropy>=2.0.3,<3.0.0; python_version <= '2.7'
 astropy>=2.0.3; python_version >= '3.0'
 Mako>=1.0.1
 decorator>=3.4.2
-scipy>=0.16.0
+scipy>=0.16.0; python_version >= '3.5'
+scipy>=0.16.0,1.3.0; python_version <= '3.4'
 matplotlib>=2.0.0
 numpy>=1.13.0,<1.15.3
 pillow

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # requirements for most basic library use
 astropy>=2.0.3,<3.0.0; python_version <= '2.7'
-astropy>=2.0.3; python_version > '3.4'
+astropy>=2.0.3; python_version >= '3.0'
 Mako>=1.0.1
 decorator>=3.4.2
 scipy>=0.16.0
@@ -30,6 +30,7 @@ cpnest
 dqsegdb
 dqsegdb2>=1.0.1
 http://download.pegasus.isi.edu/pegasus/4.9.0/pegasus-python-source-4.9.0.tar.gz; python_version <= '2.7'
+https://github.com/ahnitz/pegasus-wms-python3/archive/master.tar.gz; python_version >= '3'
 amqplib
 
 # For building documentation

--- a/setup.py
+++ b/setup.py
@@ -32,17 +32,19 @@ from setuptools.command.build_ext import build_ext as _build_ext
 from setuptools import find_packages
 
 requires = []
-setup_requires = ['numpy>=1.13.0,<1.15.3',]
+setup_requires = ['numpy>=1.13.0,<1.15.3; python_version <= "2.7"',
+                  'numpy>=1.13.0; python_version > "3.0"']
 install_requires =  setup_requires + ['Mako>=1.0.1',
                       'cython',
                       'decorator>=3.4.2',
-                      'scipy>=0.16.0',
+                      'scipy>=0.16.0; python_version >= "3.5"',
+                      'scipy>=0.16.0,<1.3.0; python_version <= "3.4"',
                       'matplotlib>=1.5.1',
                       'pillow',
                       'h5py>=2.5',
                       'jinja2',
                       'astropy>=2.0.3,<3.0.0; python_version <= "2.7"',
-                      'astropy>=2.0.3; python_version > "3.4"',
+                      'astropy>=2.0.3; python_version > "3.0"',
                       'mpld3>=0.3',
                       'lscsoft-glue>=1.59.3',
                       'emcee==2.2.1',


### PR DESCRIPTION
It seems that early June is code release day. This has caused some problems:

* scipy's new release does not support python2 (or python 3.4), but is being pulled by pip installs in python2. Explicitly exclude this in requirements.txt
* Some of the Sphinx stuff has been removed in the latest matplotlib release and needs removing here too.
* The latest sphinx release seems broken. `sphinx-apidoc` produces `.rst` files that are not valid. As I don't want to try to fix this, I'm excluding the 2.0 release branch for now.
* I've also allowed astropy to install on python3.4. I know we shouldn't be using it, but it makes the requirements consistent.

As a note weave are also planning a new release to support current numpy versions. It would be nice to drop the python2 upper limit on the numpy version!