### PR TITLE
Consolidate triggers to control memory usage

### DIFF
--- a/bin/pycbc_inspiral
+++ b/bin/pycbc_inspiral
@@ -44,39 +44,6 @@ def update_progress(p,u,n):
             f.close()
         last_progress_update = p
 
-def process_triggers(event_mgr, opt, gwstrain=None):
-    """ Apply clustering and rejection vetoes to current triggers."""
-    logging.info("We currently have %d triggers" % len(event_mgr.events))
-    if opt.chisq_threshold and opt.chisq_bins:
-        logging.info("Removing triggers with poor chisq")
-        event_mgr.chisq_threshold(opt.chisq_threshold, opt.chisq_bins,
-                                  opt.chisq_delta)
-        logging.info("%d remaining triggers" % len(event_mgr.events))
-
-    if opt.newsnr_threshold and opt.chisq_bins:
-        logging.info("Removing triggers with NewSNR below threshold")
-        event_mgr.newsnr_threshold(opt.newsnr_threshold)
-        logging.info("%d remaining triggers" % len(event_mgr.events))
-
-    if opt.keep_loudest_interval:
-        logging.info("Removing triggers not within the top %s loudest of a %s "
-                     "second interval by %s" % (opt.keep_loudest_num,
-                                                opt.keep_loudest_interval,
-                                                opt.keep_loudest_stat))
-        event_mgr.keep_loudest_in_interval(
-            opt.keep_loudest_interval * opt.sample_rate,
-            opt.keep_loudest_num, statname=opt.keep_loudest_stat,
-            log_chirp_width=opt.keep_loudest_log_chirp_window)
-        logging.info("%d remaining triggers" % len(event_mgr.events))
-
-    if opt.injection_window and hasattr(gwstrain, 'injections'):
-        logging.info("Keeping triggers within %s seconds of injection" %
-                     opt.injection_window)
-        event_mgr.keep_near_injection(opt.injection_window,
-                                      gwstrain.injections)
-        logging.info("%d remaining triggers" % len(event_mgr.events))
-
-
 tstart = time.time()
 
 parser = argparse.ArgumentParser(usage='',
@@ -463,13 +430,11 @@ with ctx:
         event_mgr.finalize_template_events()
         if opt.finalize_events_template_rate is not None and \
                 not (t_num+1) % opt.finalize_events_template_rate:
-            event_mgr.consolidate_events()
-            process_triggers(event_mgr, opt, gwstrain=gwstrain)
-            event_mgr.consolidate_events()
+            event_mgr.consolidate_events(opt, gwstrain=gwstrain)
 
+event_mgr.consolidate_events(opt, gwstrain=gwstrain)
 event_mgr.finalize_events()
-logging.info("Found %s triggers" % str(len(event_mgr.events)))
-process_triggers(event_mgr, opt, gwstrain=gwstrain)
+logging.info("Outputting %s triggers" % str(len(event_mgr.events)))
 
 tstop = time.time()
 run_time = tstop - tstart

--- a/bin/pycbc_inspiral
+++ b/bin/pycbc_inspiral
@@ -180,7 +180,7 @@ parser.add_argument("--finalize-events-template-rate", default=None,
                          "usage if a lot of triggers that would be rejected "
                          "are being retained. A suggested value for this is "
                          "500, but a good number may depend on other settings "
-                         "and your specific use-case.)
+                         "and your specific use-case.")
 parser.add_argument("--gpu-callback-method", default='none')
 parser.add_argument("--use-compressed-waveforms", action="store_true", default=False,
                     help='Use compressed waveforms from the bank file.')

--- a/bin/pycbc_inspiral
+++ b/bin/pycbc_inspiral
@@ -178,7 +178,9 @@ parser.add_argument("--finalize-events-template-rate", default=None,
                          "end of this job. Default is to only do those things "
                          "at the end of the job. This can help control memory "
                          "usage if a lot of triggers that would be rejected "
-                         "are being retained.")
+                         "are being retained. A suggested value for this is "
+                         "500, but a good number may depend on other settings "
+                         "and your specific use-case.)
 parser.add_argument("--gpu-callback-method", default='none')
 parser.add_argument("--use-compressed-waveforms", action="store_true", default=False,
                     help='Use compressed waveforms from the bank file.')

--- a/bin/pycbc_inspiral
+++ b/bin/pycbc_inspiral
@@ -44,6 +44,38 @@ def update_progress(p,u,n):
             f.close()
         last_progress_update = p
 
+def process_triggers(event_mgr, opt, gwstrain=None):
+    """ Apply clustering and rejection vetoes to current triggers."""
+    if opt.chisq_threshold and opt.chisq_bins:
+        logging.info("Removing triggers with poor chisq")
+        event_mgr.chisq_threshold(opt.chisq_threshold, opt.chisq_bins,
+                                  opt.chisq_delta)
+        logging.info("%d remaining triggers" % len(event_mgr.events))
+
+    if opt.newsnr_threshold and opt.chisq_bins:
+        logging.info("Removing triggers with NewSNR below threshold")
+        event_mgr.newsnr_threshold(opt.newsnr_threshold)
+        logging.info("%d remaining triggers" % len(event_mgr.events))
+
+    if opt.keep_loudest_interval:
+        logging.info("Removing triggers not within the top %s loudest of a %s "
+                     "second interval by %s" % (opt.keep_loudest_num,
+                                                opt.keep_loudest_interval,
+                                                opt.keep_loudest_stat))
+        event_mgr.keep_loudest_in_interval(
+            opt.keep_loudest_interval * opt.sample_rate,
+            opt.keep_loudest_num, statname=opt.keep_loudest_stat,
+            log_chirp_width=opt.keep_loudest_log_chirp_window)
+        logging.info("%d remaining triggers" % len(event_mgr.events))
+
+    if opt.injection_window and hasattr(gwstrain, 'injections'):
+        logging.info("Keeping triggers within %s seconds of injection" %
+                     opt.injection_window)
+        event_mgr.keep_near_injection(opt.injection_window,
+                                      gwstrain.injections)
+        logging.info("%d remaining triggers" % len(event_mgr.events))
+
+
 tstart = time.time()
 
 parser = argparse.ArgumentParser(usage='',
@@ -171,6 +203,14 @@ parser.add_argument("--keep-loudest-num", type=int,
 parser.add_argument("--keep-loudest-stat", default="newsnr",
                     choices=events.stat.sngl_statistic_dict.keys(),
                     help="Statistic used to determine loudest to keep")
+parser.add_argument("--finalize-events-template-rate", default=None,
+                    type=int, metavar="NUM TEMPLATES",
+                    help="After NUM TEMPLATES perform the various clustering "
+                         "and rejection tests that would be performed at the "
+                         "end of this job. Default is to only do those things "
+                         "at the end of the job. This can help control memory "
+                         "usage if a lot of triggers that would be rejected "
+                         "are being retained.")
 parser.add_argument("--gpu-callback-method", default='none')
 parser.add_argument("--use-compressed-waveforms", action="store_true", default=False,
                     help='Use compressed waveforms from the bank file.')
@@ -420,36 +460,14 @@ with ctx:
 
         event_mgr.cluster_template_events("time_index", "snr", cluster_window)
         event_mgr.finalize_template_events()
+        if opt.finalize_events_template_rate is not None and \
+                not t_num % opt.finalize_events_template_rate:
+            event_mgr.consolidate_events()
+            process_triggers(event_mgr, opt, gwstrain=gwstrain)
 
 event_mgr.finalize_events()
 logging.info("Found %s triggers" % str(len(event_mgr.events)))
-
-if opt.chisq_threshold and opt.chisq_bins:
-    logging.info("Removing triggers with poor chisq")
-    event_mgr.chisq_threshold(opt.chisq_threshold, opt.chisq_bins,
-                              opt.chisq_delta)
-    logging.info("%d remaining triggers" % len(event_mgr.events))
-
-if opt.newsnr_threshold and opt.chisq_bins:
-    logging.info("Removing triggers with NewSNR below threshold")
-    event_mgr.newsnr_threshold(opt.newsnr_threshold)
-    logging.info("%d remaining triggers" % len(event_mgr.events))
-
-if opt.keep_loudest_interval:
-    logging.info("Removing triggers not within the top %s loudest of a %s "
-                 "second interval by %s" % (opt.keep_loudest_num,
-                                            opt.keep_loudest_interval,
-                                            opt.keep_loudest_stat))
-    event_mgr.keep_loudest_in_interval(
-        opt.keep_loudest_interval * opt.sample_rate,
-        opt.keep_loudest_num, statname=opt.keep_loudest_stat,
-        log_chirp_width=opt.keep_loudest_log_chirp_window)
-    logging.info("%d remaining triggers" % len(event_mgr.events))
-
-if opt.injection_window and hasattr(gwstrain, 'injections'):
-    logging.info("Keeping triggers within %s seconds of injection" % opt.injection_window)
-    event_mgr.keep_near_injection(opt.injection_window, gwstrain.injections)
-    logging.info("%d remaining triggers" % len(event_mgr.events))
+process_triggers(event_mgr, opt, gwstrain=gwstrain)
 
 tstop = time.time()
 run_time = tstop - tstart

--- a/bin/pycbc_inspiral
+++ b/bin/pycbc_inspiral
@@ -46,6 +46,7 @@ def update_progress(p,u,n):
 
 def process_triggers(event_mgr, opt, gwstrain=None):
     """ Apply clustering and rejection vetoes to current triggers."""
+    logging.info("We currently have %d triggers" % len(event_mgr.events))
     if opt.chisq_threshold and opt.chisq_bins:
         logging.info("Removing triggers with poor chisq")
         event_mgr.chisq_threshold(opt.chisq_threshold, opt.chisq_bins,
@@ -461,9 +462,10 @@ with ctx:
         event_mgr.cluster_template_events("time_index", "snr", cluster_window)
         event_mgr.finalize_template_events()
         if opt.finalize_events_template_rate is not None and \
-                not t_num % opt.finalize_events_template_rate:
+                not (t_num+1) % opt.finalize_events_template_rate:
             event_mgr.consolidate_events()
             process_triggers(event_mgr, opt, gwstrain=gwstrain)
+            event_mgr.consolidate_events()
 
 event_mgr.finalize_events()
 logging.info("Found %s triggers" % str(len(event_mgr.events)))

--- a/pycbc/events/eventmgr.py
+++ b/pycbc/events/eventmgr.py
@@ -343,36 +343,35 @@ class EventManager(object):
 
     def consolidate_events(self, opt, gwstrain=None):
         self.events = numpy.concatenate(self.accumulate)
-        logging.info("We currently have %d triggers" % len(self.events))
+        logging.info("We currently have %d triggers", len(self.events))
         if opt.chisq_threshold and opt.chisq_bins:
             logging.info("Removing triggers with poor chisq")
             self.chisq_threshold(opt.chisq_threshold, opt.chisq_bins,
                                  opt.chisq_delta)
-            logging.info("%d remaining triggers" % len(self.events))
+            logging.info("%d remaining triggers", len(self.events))
 
         if opt.newsnr_threshold and opt.chisq_bins:
             logging.info("Removing triggers with NewSNR below threshold")
             self.newsnr_threshold(opt.newsnr_threshold)
-            logging.info("%d remaining triggers" % len(self.events))
+            logging.info("%d remaining triggers", len(self.events))
 
         if opt.keep_loudest_interval:
             logging.info("Removing triggers not within the top %s "
-                         "loudest of a %s "
-                         "second interval by %s" % (opt.keep_loudest_num,
-                                                    opt.keep_loudest_interval,
-                                                    opt.keep_loudest_stat))
+                         "loudest of a %s second interval by %s",
+                         opt.keep_loudest_num, opt.keep_loudest_interval,
+                         opt.keep_loudest_stat)
             self.keep_loudest_in_interval\
                 (opt.keep_loudest_interval * opt.sample_rate,
                  opt.keep_loudest_num, statname=opt.keep_loudest_stat,
                  log_chirp_width=opt.keep_loudest_log_chirp_window)
-            logging.info("%d remaining triggers" % len(self.events))
+            logging.info("%d remaining triggers", len(self.events))
 
         if opt.injection_window and hasattr(gwstrain, 'injections'):
-            logging.info("Keeping triggers within %s seconds of injection" %
+            logging.info("Keeping triggers within %s seconds of injection",
                          opt.injection_window)
             self.keep_near_injection(opt.injection_window,
                                           gwstrain.injections)
-            logging.info("%d remaining triggers" % len(self.events))
+            logging.info("%d remaining triggers", len(self.events))
 
         self.accumulate = [self.events]
 

--- a/pycbc/events/eventmgr.py
+++ b/pycbc/events/eventmgr.py
@@ -236,7 +236,7 @@ class EventManager(object):
             raise RuntimeError('Chi-square test must be enabled in order to '
                                'use newsnr threshold')
 
-        nsnrs = ranking.newsnr(self.events['snr'],
+        nsnrs = ranking.newsnr(abs(self.events['snr']),
                                self.events['chisq'] / self.events['chisq_dof'])
         remove_idxs = numpy.where(nsnrs < threshold)[0]
         self.events = numpy.delete(self.events, remove_idxs)
@@ -343,17 +343,17 @@ class EventManager(object):
 
     def consolidate_events(self, opt, gwstrain=None):
         self.events = numpy.concatenate(self.accumulate)
-        logging.info("We currently have %d triggers" % len(event_mgr.events))
+        logging.info("We currently have %d triggers" % len(self.events))
         if opt.chisq_threshold and opt.chisq_bins:
             logging.info("Removing triggers with poor chisq")
-            event_mgr.chisq_threshold(opt.chisq_threshold, opt.chisq_bins,
-                                      opt.chisq_delta)
-            logging.info("%d remaining triggers" % len(event_mgr.events))
+            self.chisq_threshold(opt.chisq_threshold, opt.chisq_bins,
+                                 opt.chisq_delta)
+            logging.info("%d remaining triggers" % len(self.events))
 
         if opt.newsnr_threshold and opt.chisq_bins:
             logging.info("Removing triggers with NewSNR below threshold")
-            event_mgr.newsnr_threshold(opt.newsnr_threshold)
-            logging.info("%d remaining triggers" % len(event_mgr.events))
+            self.newsnr_threshold(opt.newsnr_threshold)
+            logging.info("%d remaining triggers" % len(self.events))
 
         if opt.keep_loudest_interval:
             logging.info("Removing triggers not within the top %s "
@@ -361,18 +361,18 @@ class EventManager(object):
                          "second interval by %s" % (opt.keep_loudest_num,
                                                     opt.keep_loudest_interval,
                                                     opt.keep_loudest_stat))
-            event_mgr.keep_loudest_in_interval\
+            self.keep_loudest_in_interval\
                 (opt.keep_loudest_interval * opt.sample_rate,
                  opt.keep_loudest_num, statname=opt.keep_loudest_stat,
                  log_chirp_width=opt.keep_loudest_log_chirp_window)
-            logging.info("%d remaining triggers" % len(event_mgr.events))
+            logging.info("%d remaining triggers" % len(self.events))
 
         if opt.injection_window and hasattr(gwstrain, 'injections'):
             logging.info("Keeping triggers within %s seconds of injection" %
                          opt.injection_window)
-            event_mgr.keep_near_injection(opt.injection_window,
+            self.keep_near_injection(opt.injection_window,
                                           gwstrain.injections)
-            logging.info("%d remaining triggers" % len(event_mgr.events))
+            logging.info("%d remaining triggers" % len(self.events))
 
         self.accumulate = [self.events]
 

--- a/pycbc/events/eventmgr.py
+++ b/pycbc/events/eventmgr.py
@@ -26,6 +26,7 @@ produces event triggers
 """
 from __future__ import absolute_import
 import numpy, copy, os.path
+import logging
 
 from pycbc import WEAVE_FLAGS
 from pycbc.types import Array

--- a/pycbc/events/eventmgr.py
+++ b/pycbc/events/eventmgr.py
@@ -340,6 +340,10 @@ class EventManager(object):
         self.accumulate.append(self.template_events)
         self.template_events = numpy.array([], dtype=self.event_dtype)
 
+    def consolidate_events(self):
+        self.events = numpy.concatenate(self.accumulate)
+        self.accumulate = [self.events]
+
     def finalize_events(self):
         self.events = numpy.concatenate(self.accumulate)
 

--- a/pycbc/events/eventmgr.py
+++ b/pycbc/events/eventmgr.py
@@ -370,7 +370,7 @@ class EventManager(object):
             logging.info("Keeping triggers within %s seconds of injection",
                          opt.injection_window)
             self.keep_near_injection(opt.injection_window,
-                                          gwstrain.injections)
+                                     gwstrain.injections)
             logging.info("%d remaining triggers", len(self.events))
 
         self.accumulate = [self.events]

--- a/pycbc/events/eventmgr.py
+++ b/pycbc/events/eventmgr.py
@@ -235,10 +235,10 @@ class EventManager(object):
             raise RuntimeError('Chi-square test must be enabled in order to '
                                'use newsnr threshold')
 
-        remove = [i for i, e in enumerate(self.events) if
-                  ranking.newsnr(abs(e['snr']), e['chisq'] / e['chisq_dof'])
-                  < threshold]
-        self.events = numpy.delete(self.events, remove)
+        nsnrs = ranking.newsnr(self.events['snr'],
+                               self.events['chisq'] / self.events['chisq_dof'])
+        remove_idxs = numpy.where(nsnrs < threshold)[0]
+        self.events = numpy.delete(self.events, remove_idxs)
 
     def keep_near_injection(self, window, injections):
         from pycbc.events.veto import indices_within_times


### PR DESCRIPTION
I've been noticing very large memory usage of INSPIRAL jobs in the current search workflow. This seems to grow slowly with time, so seems to be due to the large number of triggers being stored in memory in these jobs.

Most of these triggers are removed before writing to disk. This patch adds the ability to run the various "remove triggers" functions that are normally run at the end, every N templates. I also optimized one of these codes as it ran particularly slowly during testing (although it was being called more than expected because of a bug in my testing code, which is now fixed).

I also moved all of that stuff into `eventmgr.py` because it seems to make more sense there than in the inspiral code.