### PR TITLE
Add multi-threading to correlate function

### DIFF
--- a/pycbc/filter/matchedfilter_cpu.pyx
+++ b/pycbc/filter/matchedfilter_cpu.pyx
@@ -64,7 +64,6 @@ def _correlate(COMPLEXTYPE[:] x,
                COMPLEXTYPE[:] z):
     cdef unsigned int xmax = x.shape[0]
     cdef unsigned int i
-    cdef COMPLEXTYPE xconj;
     for i in prange(xmax, nogil=True):
         z[i] = x[i].conjugate() * y[i]
 

--- a/pycbc/filter/matchedfilter_cpu.pyx
+++ b/pycbc/filter/matchedfilter_cpu.pyx
@@ -26,6 +26,7 @@ from __future__ import absolute_import
 import numpy
 from .matchedfilter import _BaseCorrelator
 cimport numpy, cython
+from cython.parallel import prange
 
 ctypedef fused COMPLEXTYPE:
     float complex
@@ -58,11 +59,13 @@ def correlate_numpy(x, y, z):
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-def _correlate(numpy.ndarray [COMPLEXTYPE, ndim=1] x,
-               numpy.ndarray [COMPLEXTYPE, ndim=1] y,
-               numpy.ndarray [COMPLEXTYPE, ndim=1] z):
+def _correlate(COMPLEXTYPE[:] x,
+               COMPLEXTYPE[:] y,
+               COMPLEXTYPE[:] z):
     cdef unsigned int xmax = x.shape[0]
-    for i in range(xmax):
+    cdef unsigned int i
+    cdef COMPLEXTYPE xconj;
+    for i in prange(xmax, nogil=True):
         z[i] = x[i].conjugate() * y[i]
 
 def correlate(x, y, z):

--- a/setup.py
+++ b/setup.py
@@ -207,8 +207,10 @@ ext = []
 for name in cythonext:
     e = Extension("pycbc.%s_cpu" % name,
                   ["pycbc/%s_cpu.pyx" % name.replace('.', '/')],
-                  extra_compile_args=[ '-O3', '-w', '-msse4.2',
-                                 '-ffast-math', '-ffinite-math-only'],
+                  extra_compile_args=['-O3', '-w', '-msse4.2',
+                                      '-ffast-math', '-ffinite-math-only',
+                                      '-fopenmp'],
+                  extra_link_args=['-fopenmp'],
                   compiler_directives={'embedsignature': True})
     ext.append(e)
 


### PR DESCRIPTION
This adds multi-threading capability to the correlate function. This obeys the OMP_NUM_THREADS global environment variable, so will obey what is set in the `scheme`, but will probably default to multi-threading in any job *not* using an explicit scheme.

I also added in some optimization even for the single-threaded cases **THOU SHALT DECLARE ALL VARIABLES IN CYTHON**