### PR TITLE
loudest-keep-values default must be a list

### DIFF
--- a/bin/hdfcoinc/pycbc_coinc_findtrigs
+++ b/bin/hdfcoinc/pycbc_coinc_findtrigs
@@ -32,7 +32,8 @@ parser.add_argument("--coinc-threshold", type=float, default=0.0,
 parser.add_argument("--timeslide-interval", type=float,
                     help="Interval between timeslides in seconds. Timeslides "
                          "are disabled if the option is omitted.")
-parser.add_argument("--loudest-keep-values", type=str, nargs='*', default='6:1',
+parser.add_argument("--loudest-keep-values", type=str, nargs='*',
+                    default=['6:1'],
                     help="Apply successive multiplicative levels of decimation"
                          " to coincs with stat value below the given thresholds"
                          " Ex. 9:10 8.5:30 8:30 7.5:30. Default: no decimation")

--- a/bin/hdfcoinc/pycbc_multiifo_coinc_findtrigs
+++ b/bin/hdfcoinc/pycbc_multiifo_coinc_findtrigs
@@ -34,7 +34,8 @@ parser.add_argument("--coinc-threshold", type=float, default=0.0,
 parser.add_argument("--timeslide-interval", type=float,
                     help="Interval between timeslides in seconds. Timeslides are"
                          " disabled if the option is omitted.")
-parser.add_argument("--loudest-keep-values", type=str, nargs='*', default='6:1',
+parser.add_argument("--loudest-keep-values", type=str, nargs='*',
+                    default=['6:1'],
                     help="Apply successive multiplicative levels of decimation"
                          " to coincs with stat value below the given thresholds"
                          " Ex. 9:10 8.5:30 8:30 7.5:30. Default: no decimation")


### PR DESCRIPTION
This is a simple bugfix to an issue in the default value for `--loudest-keep-values`. I think the issue arose from somewhat confusing behaviour in argparse itself. Basically if you provide the "default value" on the command line some processing is done to this, (in this case it becomes a list because of nargs). However the `default=` value is *not* processed in the same way and should be the python type that this value will be set to.

So TL:DR it needs to be a list. (I'll defer to the argparse help for more questions about what argparse does).