### PR TITLE
Fixes to docker container

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -93,8 +93,8 @@ script:
 - if [ "x${PYCBC_CONTAINER}" == "xbuild_and_test" ] ; then
     ./tools/pycbc_test_suite.sh ;
   elif [ "x${PYCBC_CONTAINER}" == "xpycbc_docker" ] ; then
-    docker run --privileged --name pycbc_inst -v `pwd`:/scratch:ro ${DOCKER_IMG}-tmp root /bin/bash -c /etc/docker-install.sh || exit 1 ;
-    docker commit pycbc_inst $DOCKER_IMG || exit 1 ;
+    docker run --privileged --name pycbc_inst -v `pwd`:/scratch:ro ${DOCKER_IMG}-tmp /bin/bash -c /scratch/docker/etc/docker-install.sh || exit 1 ;
+    docker commit --change='CMD ["/bin/su", "-l", "pycbc"]' pycbc_inst $DOCKER_IMG || exit 1 ;
   else
     ./tools/docker_build_and_test.sh ;
   fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,90 +1,38 @@
 FROM centos:centos7
 
-# Set up extra repositories
-RUN rpm -ivh http://software.ligo.org/lscsoft/scientific/7/x86_64/production/lscsoft-production-config-1.3-1.el7.noarch.rpm
-RUN yum install -y https://centos7.iuscommunity.org/ius-release.rpm
-RUN yum clean all
-RUN yum makecache
-
-# Install tool sets
-RUN yum -y groupinstall "Compatibility Libraries" \
-                        "Development Tools" \
-                        "Scientific Support"
-
-# Update pip and setuptools
-RUN yum -y install python2-pip python-setuptools
-
-# Add extra development libraries
-RUN yum -y install zlib-devel libpng-devel libjpeg-devel libsqlite3-dev sqlite-devel db4-devel openssl-devel
-
-# Install full git
-RUN rpm -e --nodeps git perl-Git
-RUN yum -y install git2u-all
-
-# Add numerical libraries needed for lal
-RUN yum install -y fftw-libs-single fftw-devel fftw fftw-libs-long fftw-libs fftw-libs-double
-RUN yum install -y gsl gsl-devel
-
-# Add LIGO libraries needed for lal
-RUN yum install -y libframe-utils libframe-devel libframe
-RUN yum install -y libmetaio libmetaio-devel libmetaio-utils
-
-# Add HDF5 development tools for PyCBC
-RUN yum install -y hdf5 hdf5-devel
-
-# Install MKL
-RUN pip install mkl
-
-# Install Python development tools
-RUN yum install -y python-devel which
-
-# Upgrade to latest python installers
-RUN pip install --upgrade pip setuptools
-
-# Install PyCBC dependencies
-RUN pip install ipython jupyter
-
-# set up environment
+COPY docker/.singularity.d /.singularity.d
 ADD docker/etc/profile.d/pycbc.sh /etc/profile.d/pycbc.sh
 ADD docker/etc/profile.d/pycbc.csh /etc/profile.d/pycbc.csh
+ADD docker/etc/cvmfs/default.local /etc/cvmfs/default.local
+ADD docker/etc/cvmfs/60-osg.conf /etc/cvmfs/60-osg.conf
+ADD docker/etc/cvmfs/config-osg.opensciencegrid.org.conf /etc/cvmfs/config-osg.opensciencegrid.org.conf
 
-# add singularity profiles
-COPY docker/.singularity.d /.singularity.d
+# Set up extra repositories
+RUN rpm -ivh http://software.ligo.org/lscsoft/scientific/7/x86_64/production/lscsoft-production-config-1.3-1.el7.noarch.rpm && yum install -y https://centos7.iuscommunity.org/ius-release.rpm && yum install -y https://ecsft.cern.ch/dist/cvmfs/cvmfs-release/cvmfs-release-latest.noarch.rpm && yum install -y cvmfs cvmfs-config-default && yum clean all && yum makecache && \
+    yum -y groupinstall "Compatibility Libraries" \
+                        "Development Tools" \
+                        "Scientific Support" && \
+    rpm -e --nodeps git perl-Git && yum -y install python2-pip python-setuptools zlib-devel libpng-devel libjpeg-devel libsqlite3-dev sqlite-devel db4-devel openssl-devel git2u-all fftw-libs-single fftw-devel fftw fftw-libs-long fftw-libs fftw-libs-double gsl gsl-devel libframe-utils libframe-devel libframe libmetaio libmetaio-devel libmetaio-utils hdf5 hdf5-devel python-devel which && pip install --upgrade pip setuptools && pip install mkl ipython jupyter
+
+# set up environment
 RUN cd / && \
     ln -s .singularity.d/actions/exec .exec && \
     ln -s .singularity.d/actions/run .run && \
     ln -s .singularity.d/actions/test .shell && \
-    ln -s .singularity.d/runscript singularity
+    ln -s .singularity.d/runscript singularity && \
+    mkdir -p /cvmfs/config-osg.opensciencegrid.org /cvmfs/oasis.opensciencegrid.org /cvmfs/gwosc.osgstorage.org && echo "config-osg.opensciencegrid.org /cvmfs/config-osg.opensciencegrid.org cvmfs ro,noauto 0 0" >> /etc/fstab && echo "oasis.opensciencegrid.org /cvmfs/oasis.opensciencegrid.org cvmfs ro,noauto 0 0" >> /etc/fstab && echo "gwosc.osgstorage.org /cvmfs/gwosc.osgstorage.org cvmfs ro,noauto 0 0" >> /etc/fstab && mkdir -p /oasis /scratch /projects /usr/lib64/slurm /var/run/munge && \
+    groupadd -g 1000 pycbc && useradd -u 1000 -g 1000 -d /opt/pycbc -k /etc/skel -m -s /bin/bash pycbc
 
 # Install MPI software needed for pycbc_inference
-RUN yum install -y libibverbs libibverbs-devel libibmad libibmad-devel libibumad libibumad-devel librdmacm librdmacm-devel libmlx5 libmlx4
-RUN curl http://mvapich.cse.ohio-state.edu/download/mvapich/mv2/mvapich2-2.1.tar.gz | tar -C /tmp -zxf - && \
+RUN yum install -y libibverbs libibverbs-devel libibmad libibmad-devel libibumad libibumad-devel librdmacm librdmacm-devel libmlx5 libmlx4 && curl http://mvapich.cse.ohio-state.edu/download/mvapich/mv2/mvapich2-2.1.tar.gz | tar -C /tmp -zxf - && \
     cd /tmp/mvapich2-2.1 && ./configure --prefix=/opt/mvapich2-2.1 && make install && \
-    rm -rf /tmp/mvapich2-2.1
-RUN pip install schwimmbad
-RUN MPICC=/opt/mvapich2-2.1/bin CFLAGS='-I /opt/mvapich2-2.1/include -L /opt/mvapich2-2.1/lib -lmpi' pip install --no-cache-dir mpi4py
+    cd / && rm -rf /tmp/mvapich2-2.1 && \
+    pip install schwimmbad && \
+    MPICC=/opt/mvapich2-2.1/bin CFLAGS='-I /opt/mvapich2-2.1/include -L /opt/mvapich2-2.1/lib -lmpi' pip install --no-cache-dir mpi4py
 
-# Install and set up cvmfs using static mounts
-RUN yum install -y https://ecsft.cern.ch/dist/cvmfs/cvmfs-release/cvmfs-release-latest.noarch.rpm && yum install -y cvmfs cvmfs-config-default
-ADD docker/etc/cvmfs/default.local /etc/cvmfs/default.local
-ADD docker/etc/cvmfs/60-osg.conf /etc/cvmfs/60-osg.conf
-ADD docker/etc/cvmfs/config-osg.opensciencegrid.org.conf /etc/cvmfs/config-osg.opensciencegrid.org.conf
-RUN mkdir -p /cvmfs/config-osg.opensciencegrid.org /cvmfs/oasis.opensciencegrid.org /cvmfs/gwosc.osgstorage.org
-RUN echo "config-osg.opensciencegrid.org /cvmfs/config-osg.opensciencegrid.org cvmfs ro,noauto 0 0" >> /etc/fstab && echo "oasis.opensciencegrid.org /cvmfs/oasis.opensciencegrid.org cvmfs ro,noauto 0 0" >> /etc/fstab && echo "gwosc.osgstorage.org /cvmfs/gwosc.osgstorage.org cvmfs ro,noauto 0 0" >> /etc/fstab
-
-# Mount points for the XSEDE Comet machine
-RUN mkdir -p /oasis /scratch /projects /usr/lib64/slurm /var/run/munge
-
-# Create a PyCBC user
-RUN groupadd -g 1000 pycbc && useradd -u 1000 -g 1000 -d /opt/pycbc -k /etc/skel -m -s /bin/bash pycbc
-
-# Add the script that installs PyCBC inside the container
-ADD docker/etc/docker-install.sh /etc/docker-install.sh
-
-# When the container is started with 
-#   docker run -it pycbc/pycbc-el7:latest 
-# the default is to start a loging shell as the pycbc user. This can be overridden by e.g.
-#   docker run -it pycbc/pycbc-el7:latest root /bin/bash -l 
-# which will start a container with a root login shell
-ENTRYPOINT ["/bin/su", "-l"]
-CMD ["pycbc", "/bin/bash", "-l"]
+# When the container is started with
+#   docker run -it pycbc/pycbc-el7:latest
+# the default is to start a loging shell as the pycbc user.
+# This can be overridden to log in as root with
+#   docker run -it pycbc/pycbc-el7:latest /bin/bash -l
+CMD ["/bin/su", "-l", "pycbc"]

--- a/docs/docker.rst
+++ b/docs/docker.rst
@@ -12,54 +12,21 @@ To start a Docker container with no graphics, type the commands::
 
 This example downloads current version of the code from the `GitHub master branch. <https://github.com/ligo-cbc/pycbc>`_ Replace the string ``latest`` with one of the `PyCBC release tags <https://github.com/ligo-cbc/pycbc/releases>`_ (e.g. ``v1.7.0``) to install a container containing a released version of PyCBC. The container includes all of the required software and dependencies to run PyCBC, including a compatible version of LALSuite installed into the root filesystem. The command above starts a login shell as the pycbc user. To override this and log in as root, run the command::
 
-   docker run -it pycbc/pycbc-el7:latest root /bin/bash -l
+   docker run -it pycbc/pycbc-el7:latest /bin/bash -l
 
 -------------------------------------
-Using jupyter-notebook within docker
+Using jupyter notebook within docker
 -------------------------------------
 
 One can start a jupyter notebook within docker and then port forward to your
-computer environment.::
+computer's environment.::
 
-    docker run -it -p 8888:8888 --name pycbc_test pycbc/pycbc-el7:latest pycbc /bin/bash -l -c jupyter notebook --no-browser --ip 0.0.0.0
+    docker run -it -p 8888:8888 --name pycbc_test pycbc/pycbc-el7:latest /bin/su -l pycbc -c "jupyter notebook --no-browser --ip 0.0.0.0"
 
---------------------
-Graphics on Mac OS X
---------------------
-
-To start a Docker container on Mac OS X that can display graphics on Mac OS X, you must be running `XQuartz <https://www.xquartz.org/>`_ version 2.7.11 or higher. To start an X11 server, run the command::
-
-    open -a Xquartz
-
-In the Xquartz preferences, make sure that ``Allow connections from network clients`` is checked, as shown below:
-
-.. image:: resources/xquartz_pref.png
-      :width: 400 px
-      :align: center
-
-Next, enable Docker to connect to your X11 server by running the commands::
-
-    ip=$(ifconfig en0 | grep inet | awk '$1=="inet" {print $2}')
-    xhost + $ip
-
-Finally, start the Docker container with::
-
-    docker run -e DISPLAY=${ip}:0 -it pycbc/pycbc-el7:latest
-
------------------
-Graphics on Linux
------------------
-
-To start a Docker container on Linux that can display graphics, run the commands::
-
-    docker run -e DISPLAY=${DISPLAY} -v /tmp/.X11-unix:/tmp/.X11-unix/ -it pycbc/pycbc-el7:latest
+Once the image is running, you can connect from your computer's web browser to the address printed to the screen by jupyter. This is typically the local host adddress, e.g. ``127.0.0.1``
 
 -------------------------------
 Sharing user files and SSH keys
 -------------------------------
 
-It can be useful to share your SSH public/private key with the Docker container, for example to allow you to git push and pull from your repository on GitHub. To do this, add the argument ``-v ${HOME}/.ssh:/home/pycbc/.ssh`` to the ``docker run`` commands.  You can also create e.g. a ``scratch`` directory and use the ``-v`` option to mount it in the container. This directory can be used to transfer files between the container and the host computer.  The command below will start a Docker container with graphics on a Mac and share ssh keys and a ``scratch`` directory::
-
-    mkdir -p scratch
-    docker run -e DISPLAY=$(ifconfig en0 | grep inet | awk '$1=="inet" {print $2}'):0 -v `pwd`/scratch:/opt/pycbc/scratch -v ${HOME}/.ssh:/opt/pycbc/.ssh -it pycbc/pycbc-el7:latest
-
+It can be useful to share your SSH public/private key with the Docker container, for example to allow you to git push and pull from your repository on GitHub. To do this, add the argument ``-v ${HOME}/.ssh:/opt/pycbc/.ssh`` to the ``docker run`` commands.  You can also create e.g. a ``scratch`` directory and use the ``-v`` option to mount it in the container. This directory can be used to transfer files between the container and the host computer. See the `Docker volumes documentation <https://docs.docker.com/storage/volumes/>`_ for a detailed explaination of mounting directories inside a docker container.


### PR DESCRIPTION
Apparently `docker commit` overrides `CMD` with whatever command you started the container with in `docker run`. This fixes that problem, simplifies the `CMD`, reduces the number of images as suggested by @spxiwh, and cleans up the documentation.