### PR TITLE
require python3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,10 +64,6 @@ matrix:
   - env: PYCBC_CONTAINER=build_and_test LAL_DATA_PATH=$TRAVIS_BUILD_DIR LD_LIBRARY_PATH=$TRAVIS_BUILD_DIR PYTHON3='TRUE'
     language: python
     python: 3.6
-  allow_failures:
-  - env: PYCBC_CONTAINER=build_and_test LAL_DATA_PATH=$TRAVIS_BUILD_DIR LD_LIBRARY_PATH=$TRAVIS_BUILD_DIR PYTHON3='TRUE'
-    language: python
-    python: 3.6
 
 before_install:
 - if [ "x${PYCBC_CONTAINER}" == "xpycbc_rhel_virtualenv" ] ; then docker pull $DOCKER_IMG; fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,5 +2,4 @@
 requires = ["setuptools",
             "wheel",
             "cython",
-            'numpy>=1.13.0,<1.15.3; python_version <= "2.7"',
-            'numpy>=1.13.0; python_version > "3.0"']
+            "numpy>=1.13.0,<1.15.3"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [build-system]
-requires = ["setuptools", 
-            "wheel", 
-            "cython", 
-            "numpy>=1.13.0,<1.15.3"]
+requires = ["setuptools",
+            "wheel",
+            "cython",
+            'numpy>=1.13.0,<1.15.3; python_version <= "2.7"',
+            'numpy>=1.13.0; python_version > "3.0"']

--- a/setup.py
+++ b/setup.py
@@ -255,6 +255,7 @@ setup (
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.6',
         'Intended Audience :: Science/Research',
         'Natural Language :: English',
         'Topic :: Scientific/Engineering',

--- a/setup.py
+++ b/setup.py
@@ -236,7 +236,7 @@ setup (
     version = VERSION,
     description = 'Core library to analyze gravitational-wave data, find signals, and study their parameters.',
     long_description = open('descr.rst').read(),
-    author = 'Ligo-Virgo Collaborations and the PyCBC team',
+    author = 'The PyCBC team',
     author_email = 'alex.nitz@gmail.org',
     url = 'http://www.pycbc.org/',
     download_url = 'https://github.com/gwastro/pycbc/tarball/v%s' % VERSION,
@@ -253,7 +253,6 @@ setup (
     ext_modules = ext,
     classifiers=[
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.6',
         'Intended Audience :: Science/Research',


### PR DESCRIPTION
The python3 travis test now passes, we should require it to pass now into the future.

Other minor changes
   * Match pyproject.toml with setup.py so numpy can be less restrictive for python3