### PR TITLE
Fix permissions on installed directories in docker image

### DIFF
--- a/docker/etc/docker-install.sh
+++ b/docker/etc/docker-install.sh
@@ -12,4 +12,5 @@ mkdir -p /opt/pycbc/pycbc-software/share/lal-data
 rsync --exclude='SEOBNRv1ROM*' --exclude='SEOBNRv2ROM_DS_HI_v1.0.hdf5' --exclude='NRSur4d2s_FDROM.hdf5' -ravz /cvmfs/oasis.opensciencegrid.org/ligo/sw/pycbc/lalsuite-extra/current/share/lalsimulation/ /opt/pycbc/pycbc-software/share/lal-data/
 umount /cvmfs/config-osg.opensciencegrid.org
 umount /cvmfs/oasis.opensciencegrid.org
+chown -R 1000:1000 /opt/pycbc/src /opt/pycbc/pycbc-software
 exit 0


### PR DESCRIPTION
/opt/pycbc has a couple of directories owned by root. They should be owned by the pycbc user in the image.