### PR TITLE
Propagate analysis time

### DIFF
--- a/bin/hdfcoinc/pycbc_multiifo_combine_statmap
+++ b/bin/hdfcoinc/pycbc_multiifo_combine_statmap
@@ -1,7 +1,8 @@
 #!/bin/env python
-""" Apply a trials factor based on the number of available detector combinations at the
-time of coincidence. This clusters to find the most significant foreground, but
-leaves the background triggers alone. """
+""" Apply a trials factor based on the number of available detector
+combinations at the time of coincidence. This clusters to find the most
+significant foreground, but leaves the background triggers alone.
+"""
 
 import h5py, numpy, argparse, logging, pycbc, pycbc.events, pycbc.io, lal
 import pycbc.version
@@ -25,7 +26,8 @@ files = [h5py.File(n, 'r') for n in args.statmap_files]
 f = h5py.File(args.output_file, "w")
 
 logging.info('Copying segments and attributes to %s' % args.output_file)
-# Move segments information into the final file - remove some duplication in earlier files
+# Move segments information into the final file - remove some duplication
+# in earlier files
 for fi in files:
     for key in fi['segments']:
         if key.startswith('foreground') or key.startswith('background'):
@@ -33,13 +35,16 @@ for fi in files:
         f['segments/%s/end' % key] = fi['segments/%s/end' % key][:]
         f['segments/%s/start' % key] = fi['segments/%s/start' % key][:]
         if 'segments/foreground_veto' in fi:
-            f['segments/%s/foreground_veto/end' % key] = fi['segments/foreground_veto/end'][:]
-            f['segments/%s/foreground_veto/start' % key] = fi['segments/foreground_veto/start'][:]
+            f['segments/%s/foreground_veto/end' % key] = \
+                                         fi['segments/foreground_veto/end'][:]
+            f['segments/%s/foreground_veto/start' % key] = \
+                                       fi['segments/foreground_veto/start'][:]
         for attr_name in fi.attrs:
             if key not in f:
                  f.create_group(key)
             f[key].attrs[attr_name] = fi.attrs[attr_name]
 
+logging.info('combining foreground and foreground excluded segments')
 # Set up dictionaries to contain segments from the individual statmap files
 indiv_segs = segments.segmentlistdict({})
 indiv_segs_fg_exc = segments.segmentlistdict({})
@@ -48,28 +53,22 @@ indiv_segs_fg_exc = segments.segmentlistdict({})
 all_ifos = numpy.unique([ifo for fi in files for ifo in \
                          fi.attrs['ifos'].split(' ')])
 
-# loop through statmap files and find all time in which any 2-ifo combination
-# is 'on
+# loop through statmap files and put segments into segmentlistdicts
 for fi in files:
     key = fi.attrs['ifos'].replace(' ','')
-    fi_ifos = fi.attrs['ifos'].split(' ')
+    # get analysed segments from individual statmap files
     starts = fi['segments/{}/start'.format(key)][:]
     ends = fi['segments/{}/end'.format(key)][:]
     indiv_segs[key] = pycbc.events.veto.start_end_to_segments(starts, ends)
-    # remove vetoed foreground time from the segments
-    # obtain average time of the foreground triggers
-    ave_fore_time = numpy.array([numpy.mean(times) for times in \
-                     zip(*tuple(fi['foreground/%s/time' % ifo][:] \
-                         for ifo in fi_ifos))])
-    # set up the veto window around the foreground triggers
-    remove_start_time = ave_fore_time - 0.1 #fi.attrs['veto_window']
-    remove_end_time = ave_fore_time + 0.1 #fi.attrs['veto_window']
+    # get the foreground_vetoed times from individual statmap files
+    remove_start_time = fi['segments/foreground_veto/start'][:]
+    remove_end_time = fi['segments/foreground_veto/end'][:]
     vetoed_segs = pycbc.events.veto.start_end_to_segments(remove_start_time,
                                                           remove_end_time)
     # remove from analysis segments
     indiv_segs_fg_exc[key] = indiv_segs[key] - vetoed_segs
 
-# Add together segments to obtain '2 or more detectors on' time
+# Add the segments to obtain '2 or more detectors on' time
 foreground_segs = numpy.sum(list(indiv_segs.values()), axis=0)
 foreground_segs_exc = numpy.sum(list(indiv_segs_fg_exc.values()), axis=0)
 
@@ -105,14 +104,16 @@ for f_in in files:
     for ifo in all_ifos:
         if ifo in f_in['foreground']:
             all_trig_times[ifo] = numpy.concatenate([all_trig_times[ifo], \
-                                     f_in['foreground/{}/time'.format(ifo)][:]])
+                                   f_in['foreground/{}/time'.format(ifo)][:]])
             all_trig_ids[ifo] = numpy.concatenate([all_trig_ids[ifo],
-                                     f_in['foreground/{}/trigger_id'.format(ifo)][:]])
+                             f_in['foreground/{}/trigger_id'.format(ifo)][:]])
         else:
             all_trig_times[ifo] = numpy.concatenate([all_trig_times[ifo],
-                                     -1*numpy.ones_like(f_in['foreground/fap'][:], dtype=numpy.uint32)])
+                                 -1*numpy.ones_like(f_in['foreground/fap'][:],
+                                                    dtype=numpy.uint32)])
             all_trig_ids[ifo] = numpy.concatenate([all_trig_ids[ifo],
-                                     -1*numpy.ones_like(f_in['foreground/fap'][:], dtype=numpy.uint32)])
+                                 -1*numpy.ones_like(f_in['foreground/fap'][:],
+                                                    dtype=numpy.uint32)])
     f_in.close()
 
 logging.info('Clustering triggers for loudest ifar value')
@@ -131,7 +132,8 @@ all_times = (f['foreground/%s/time' % ifo][:] for ifo in all_ifos)
 def argmax(v):
     return numpy.argsort(v)[-1]
 
-# Currently only clustering zerolag, i.e. foreground, so set all timeslide_ids to zero
+# Currently only clustering zerolag, i.e. foreground, so set all timeslide_ids
+# to zero
 cidx = pycbc.events.cluster_coincs_multiifo(ifar_stat, all_times,
                                             numpy.zeros(len(ifar_stat)), 0,
                                             args.cluster_window, argmax)
@@ -143,7 +145,8 @@ def filter_dataset(h5file, name, idx):
     h5file[name] = filtered_dset
     return idx
 
-# Downsample the foreground columns to only the loudest ifar between the multiple files
+# Downsample the foreground columns to only the loudest ifar between the
+# multiple files
 for key in f['foreground'].keys():
     if key not in all_ifos:
         id = filter_dataset(f, 'foreground/%s' % key, cidx)
@@ -167,18 +170,20 @@ for key in f['segments']:
         continue
     end_times = numpy.array(f['segments/%s/end' % key][:])
     start_times = numpy.array(f['segments/%s/start' % key][:])
-    idx_within_segment = pycbc.events.indices_within_times(test_times, start_times, end_times)
+    idx_within_segment = pycbc.events.indices_within_times(test_times,
+                                                           start_times,
+                                                           end_times)
     trials_factors[idx_within_segment] += numpy.ones_like(idx_within_segment)
 
 f['foreground/ifar'][:] = f['foreground/ifar'][:] / trials_factors
 f['foreground/ifar_exc'][:] = f['foreground/ifar_exc'][:] / trials_factors
 
-#TODO: work out how to calculate fap given that coinc_time changes for each detector combination
-#      commented out parts here need re-working out
+#TODO: work out how to calculate fap given that coinc_time changes for each
+# detector combination
 
 #TODO: add in background combinations
-# If there is a background set (full_data as opposed to injection run), then recalculate
-# the values for its triggers as well
+# If there is a background set (full_data as opposed to injection run), then
+# recalculate the values for its triggers as well
 
 f.close()
 logging.info('done')

--- a/bin/hdfcoinc/pycbc_multiifo_combine_statmap
+++ b/bin/hdfcoinc/pycbc_multiifo_combine_statmap
@@ -4,7 +4,8 @@ time of coincidence. This clusters to find the most significant foreground, but
 leaves the background triggers alone. """
 
 import h5py, numpy, argparse, logging, pycbc, pycbc.events, pycbc.io, lal
-import pycbc.version, ligo.segments
+import pycbc.version
+from ligo import segments
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--version", action="version", version=pycbc.version.git_verbose_msg)
@@ -39,14 +40,45 @@ for fi in files:
                  f.create_group(key)
             f[key].attrs[attr_name] = fi.attrs[attr_name]
 
-all_coincident_time = ligo.segments.segmentlist([])
+# Set up dictionaries to contain segments from the individual statmap files
+indiv_segs = segments.segmentlistdict({})
+indiv_segs_fg_exc = segments.segmentlistdict({})
+
+# obtain list of all ifos involved in the coinc_statmap files
+all_ifos = numpy.unique([ifo for fi in files for ifo in \
+                         fi.attrs['ifos'].split(' ')])
+
+# loop through statmap files and find all time in which any 2-ifo combination
+# is 'on
 for fi in files:
     key = fi.attrs['ifos'].replace(' ','')
-    for s, e in zip(['segments/%s/start' % key][:], fi['segments/%s/end' % key][:]):
-        all_coincident_time += ligo.segments.segment(s, e)
+    fi_ifos = fi.attrs['ifos'].split(' ')
+    starts = fi['segments/{}/start'.format(key)][:]
+    ends = fi['segments/{}/end'.format(key)][:]
+    indiv_segs[key] = pycbc.events.veto.start_end_to_segments(starts, ends)
+    # remove vetoed foreground time from the segments
+    # obtain average time of the foreground triggers
+    ave_fore_time = numpy.array([numpy.mean(times) for times in \
+                     zip(*tuple(fi['foreground/%s/time' % ifo][:] \
+                         for ifo in fi_ifos))])
+    # set up the veto window around the foreground triggers
+    remove_start_time = ave_fore_time - 0.1 #fi.attrs['veto_window']
+    remove_end_time = ave_fore_time + 0.1 #fi.attrs['veto_window']
+    vetoed_segs = pycbc.events.veto.start_end_to_segments(remove_start_time,
+                                                          remove_end_time)
+    # remove from analysis segments
+    indiv_segs_fg_exc[key] = indiv_segs[key] - vetoed_segs
+
+# Add together segments to obtain '2 or more detectors on' time
+foreground_segs = numpy.sum(list(indiv_segs.values()), axis=0)
+foreground_segs_exc = numpy.sum(list(indiv_segs_fg_exc.values()), axis=0)
+
+# output to file
+f.attrs['foreground_time'] = abs(foreground_segs)
+f.attrs['foreground_time_exc'] = abs(foreground_segs_exc)
 
 # Save the ifo list for easy access
-f.attrs['ifos'] = ' '.join(sorted(args.ifos))
+f.attrs['ifos'] = ' '.join(sorted(all_ifos))
 
 logging.info('Generating list of datasets in input files')
 
@@ -56,21 +88,21 @@ logging.info('Copying foreground non-ifo-specific data')
 # copy and concatenate all the columns in the foreground group
 # from all files /except/ the IFO groups
 for key in key_set:
-    if key.startswith('foreground') and not any([ifo in key for ifo in args.ifos]):
+    if key.startswith('foreground') and not any([ifo in key for ifo in all_ifos]):
         pycbc.io.combine_and_copy(f, files, key)
 
 logging.info('Collating triggers into single structure')
 
 all_trig_times = {}
 all_trig_ids = {}
-for ifo in args.ifos:
+for ifo in all_ifos:
     all_trig_times[ifo] = numpy.array([], dtype=numpy.uint32)
     all_trig_ids[ifo] = numpy.array([], dtype=numpy.uint32)
 
 # For each file, append the trigger time and id data for each ifo
 # If an ifo does not participate in any given coinc then fill with -1 values
 for f_in in files:
-    for ifo in args.ifos:
+    for ifo in all_ifos:
         if ifo in f_in['foreground']:
             all_trig_times[ifo] = numpy.concatenate([all_trig_times[ifo], \
                                      f_in['foreground/{}/time'.format(ifo)][:]])
@@ -85,7 +117,7 @@ for f_in in files:
 
 logging.info('Clustering triggers for loudest ifar value')
 
-for ifo in args.ifos:
+for ifo in all_ifos:
     f['foreground/{}/time'.format(ifo)] = all_trig_times[ifo]
     f['foreground/{}/trigger_id'.format(ifo)] = all_trig_ids[ifo]
 
@@ -94,7 +126,7 @@ ifar_stat = numpy.core.records.fromarrays([f['foreground/ifar'][:],
                                           names='ifar,stat')
 
 # all_times is a tuple of trigger time arrays
-all_times = (f['foreground/%s/time' % ifo][:] for ifo in args.ifos)
+all_times = (f['foreground/%s/time' % ifo][:] for ifo in all_ifos)
 
 def argmax(v):
     return numpy.argsort(v)[-1]
@@ -113,7 +145,7 @@ def filter_dataset(h5file, name, idx):
 
 # Downsample the foreground columns to only the loudest ifar between the multiple files
 for key in f['foreground'].keys():
-    if key not in args.ifos:
+    if key not in all_ifos:
         id = filter_dataset(f, 'foreground/%s' % key, cidx)
     else:  # key is an ifo
         for k in f['foreground/%s' % key].keys():
@@ -122,7 +154,7 @@ for key in f['foreground'].keys():
 logging.info('Applying trials factor')
 
 # Recalculate event times after clustering for trials factor calculation
-clustered_times = (f['foreground/%s/time' % ifo][:] for ifo in args.ifos)
+clustered_times = (f['foreground/%s/time' % ifo][:] for ifo in all_ifos)
 
 # Trials factor is how many possible 2+IFO combinations are 'on'
 #  at the time of the coincidence

--- a/bin/hdfcoinc/pycbc_multiifo_combine_statmap
+++ b/bin/hdfcoinc/pycbc_multiifo_combine_statmap
@@ -47,10 +47,6 @@ logging.info('combining foreground and foreground excluded segments')
 indiv_segs = segments.segmentlistdict({})
 indiv_segs_fg_exc = segments.segmentlistdict({})
 
-# obtain list of all ifos involved in the coinc_statmap files
-all_ifos = numpy.unique([ifo for fi in files for ifo in \
-                         fi.attrs['ifos'].split(' ')])
-
 # loop through statmap files and put segments into segmentlistdicts
 for fi in files:
     key = fi.attrs['ifos'].replace(' ','')
@@ -66,15 +62,22 @@ for fi in files:
     # remove from analysis segments
     indiv_segs_fg_exc[key] = indiv_segs[key] - vetoed_segs
 
-# Add the segments to obtain '2 or more detectors on' time
+# Convert segmentlistdict to a list ('seglists') of segmentlists
+# then numpy.sum(seglists, axis=0) does seglists[0] + seglists[1] + ...
 foreground_segs = numpy.sum(list(indiv_segs.values()), axis=0)
+# Note that 'exclusive' time only removes windows around coincs
+# that involve *all* active ifos (2 in 2-ifo time, 3 in 3-ifo time etc.)
 foreground_segs_exc = numpy.sum(list(indiv_segs_fg_exc.values()), axis=0)
 
 # output to file
 f.attrs['foreground_time'] = abs(foreground_segs)
 f.attrs['foreground_time_exc'] = abs(foreground_segs_exc)
 
-# Save the ifo list for easy access
+# obtain list of all ifos involved in the coinc_statmap files
+all_ifos = numpy.unique([ifo for fi in files for ifo in \
+                         fi.attrs['ifos'].split(' ')])
+
+# Save the ifo list for future reference
 f.attrs['ifos'] = ' '.join(sorted(all_ifos))
 
 logging.info('Generating list of datasets in input files')

--- a/bin/hdfcoinc/pycbc_multiifo_combine_statmap
+++ b/bin/hdfcoinc/pycbc_multiifo_combine_statmap
@@ -15,8 +15,6 @@ parser.add_argument('--statmap-files', nargs='+',
                     help="List of coinc files to be redistributed")
 parser.add_argument('--cluster-window', type=float)
 parser.add_argument('--output-file', help="name of output file")
-parser.add_argument('--ifos',nargs='+',
-                    help="list of interferometers in the input files" )
 args = parser.parse_args()
 
 pycbc.init_logging(args.verbose)

--- a/bin/hdfcoinc/pycbc_multiifo_combine_statmap
+++ b/bin/hdfcoinc/pycbc_multiifo_combine_statmap
@@ -4,7 +4,7 @@ time of coincidence. This clusters to find the most significant foreground, but
 leaves the background triggers alone. """
 
 import h5py, numpy, argparse, logging, pycbc, pycbc.events, pycbc.io, lal
-import pycbc.version
+import pycbc.version, ligo.segments
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--version", action="version", version=pycbc.version.git_verbose_msg)
@@ -38,6 +38,12 @@ for fi in files:
             if key not in f:
                  f.create_group(key)
             f[key].attrs[attr_name] = fi.attrs[attr_name]
+
+all_coincident_time = ligo.segments.segmentlist([])
+for fi in files:
+    key = fi.attrs['ifos'].replace(' ','')
+    for s, e in zip(['segments/%s/start' % key][:], fi['segments/%s/end' % key][:]):
+        all_coincident_time += ligo.segments.segment(s, e)
 
 # Save the ifo list for easy access
 f.attrs['ifos'] = ' '.join(sorted(args.ifos))

--- a/pycbc/workflow/coincidence.py
+++ b/pycbc/workflow/coincidence.py
@@ -251,7 +251,7 @@ class PyCBCCombineStatmap(Executable):
 
 class PyCBCMultiifoCombineStatmap(Executable):
     current_retention_level = Executable.MERGED_TRIGGERS
-    def create_node(self, statmap_files, ifos, cluster_window, tags=None):
+    def create_node(self, statmap_files, cluster_window, tags=None):
         if tags is None:
             tags = []
         node = Node(self)
@@ -748,7 +748,6 @@ def setup_multiifo_combine_statmap(workflow, final_bg_file_list, out_dir, tags):
                                                     'cluster-window',
                                                     tags))
     combine_statmap_node = cstat_exe.create_node(final_bg_file_list,
-                                                 ifolist,
                                                  cluster_window,
                                                  tags)
     workflow.add_node(combine_statmap_node)

--- a/pycbc/workflow/coincidence.py
+++ b/pycbc/workflow/coincidence.py
@@ -743,7 +743,6 @@ def setup_multiifo_combine_statmap(workflow, final_bg_file_list, out_dir, tags):
                                             tags=tags,
                                             out_dir=out_dir)
 
-    ifolist = ' '.join(workflow.ifos)
     cluster_window = float(workflow.cp.get_opt_tags('combine_statmap',
                                                     'cluster-window',
                                                     tags))

--- a/pycbc/workflow/coincidence.py
+++ b/pycbc/workflow/coincidence.py
@@ -258,7 +258,6 @@ class PyCBCMultiifoCombineStatmap(Executable):
         node.add_input_list_opt('--statmap-files', statmap_files)
         node.new_output_file_opt(statmap_files[0].segment, '.hdf',
                                  '--output-file', tags=tags)
-        node.add_opt('--ifos', ifos)
         node.add_opt('--cluster-window', cluster_window)
         return node
 


### PR DESCRIPTION
Give `foreground_time` and `foreground_time_exc` as outputs to the combine_statmap code

This output time is the amount of time for which two or more detectors are functioning, as well as this time with foreground events removed.

Note that if an event happens within >2 detector time, but has not triggered in all detectors, this will not be removed with the foreground veto

This helps to address https://github.com/gwastro/pycbc/issues/2727