### PR TITLE
Prepare for new release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -121,8 +121,8 @@ def get_version_info():
         vinfo = _version_helper.generate_git_version_info()
     except:
         vinfo = vdummy()
-        vinfo.version = '1.13.dev9'
-        vinfo.release = 'False'
+        vinfo.version = '1.14.0'
+        vinfo.release = 'True'
 
     with open('pycbc/version.py', 'w') as f:
         f.write("# coding: utf-8\n")


### PR DESCRIPTION
I think we are ready for a `v1.14` release, with "beta" support for python3 in at most of the main modules. (I think inference and tmpltbank are both untested in python3, and a bunch of executables haven't been tested, but most of the rest should work).