### PR TITLE
ifos attribute in statmap_inj output

### DIFF
--- a/bin/hdfcoinc/pycbc_multiifo_coinc_statmap_inj
+++ b/bin/hdfcoinc/pycbc_multiifo_coinc_statmap_inj
@@ -56,6 +56,7 @@ f.attrs['num_of_ifos'] = zdata.attrs['num_of_ifos']
 f.attrs['pivot'] = zdata.attrs['pivot']
 f.attrs['fixed'] = zdata.attrs['fixed']
 f.attrs['timeslide_interval'] = zdata.attrs['timeslide_interval']
+f.attrs['ifos'] = ' '.join(sorted(args.ifos))
 
 # Copy over the segment for coincs and singles
 for key in zdata.seg.keys():


### PR DESCRIPTION
The change I made to combine_statmap (in https://github.com/gwastro/pycbc/pull/2773) requires ifos as an attribute in the statmap files, but this was not the case in statmap_inj outputs. This PR addresses that