### PR TITLE
set time scale pedantically

### DIFF
--- a/pycbc/detector.py
+++ b/pycbc/detector.py
@@ -41,7 +41,7 @@ from numpy import cos, sin
 # presented in https://arxiv.org/pdf/gr-qc/0008066.pdf
 
 def gmst_accurate(gps_time):
-    gmst = Time(gps_time, format='gps',
+    gmst = Time(gps_time, format='gps', scale='utc',
                 location=(0, 0)).sidereal_time('mean').rad
     return gmst
 


### PR DESCRIPTION
Technically we use a utc scale, so set this consistently instead of leaving it to the default. 