### PR TITLE
hdfinjfind: fix veto index bug, simplify some numpy logic

### DIFF
--- a/bin/hdfcoinc/pycbc_coinc_hdfinjfind
+++ b/bin/hdfcoinc/pycbc_coinc_hdfinjfind
@@ -8,7 +8,7 @@ import argparse, h5py, logging, types, numpy, os.path
 from glue.ligolw import ligolw, table, lsctables, utils as ligolw_utils
 from ligo import segments
 from pycbc import events
-from pycbc.events import indices_within_segments as veto_indices
+from pycbc.events import indices_within_segments
 from pycbc.types import MultiDetOptionAction
 import pycbc.version
 
@@ -134,10 +134,10 @@ for trigger_file, injection_file in zip(args.trigger_files,
 
     logging.info('Read in the injection file')
     indoc = ligolw_utils.load_filename(injection_file, False,
-                                            contenthandler=LIGOLWContentHandler)
+                                       contenthandler=LIGOLWContentHandler)
     sim_table = table.get_table(indoc, lsctables.SimInspiralTable.tableName)
-    inj_time = numpy.array(sim_table.get_column('geocent_end_time')
-                           + 1e-9 * sim_table.get_column('geocent_end_time_ns'),
+    inj_time = numpy.array(sim_table.get_column('geocent_end_time') +
+                           1e-9 * sim_table.get_column('geocent_end_time_ns'),
                            dtype=numpy.float64)
 
     logging.info('Determined the found injections by time')
@@ -153,7 +153,8 @@ for trigger_file, injection_file in zip(args.trigger_files,
                  % (len(found), len(missed), len(ambiguous)))
 
     if len(ambiguous) > 0:
-        logging.warn('More than one coinc trigger found associated to injection')
+        logging.warn('More than one coinc trigger found associated to
+                      injection')
         am = numpy.arange(0, len(inj_time), 1)[left[ambiguous]]
         bm = numpy.arange(0, len(inj_time), 1)[right[ambiguous]]
 
@@ -161,22 +162,22 @@ for trigger_file, injection_file in zip(args.trigger_files,
     ki = keep_ind(inj_time, ana_start, ana_end)
     found_within_time = numpy.intersect1d(ki, found)
     missed_within_time = numpy.intersect1d(ki, missed)
-    logging.info('Found: %s, Missed: %s'
-                 % (len(found_within_time), len(missed_within_time)))
+    logging.info('Found: %s, Missed: %s' %
+                 (len(found_within_time), len(missed_within_time)))
 
     logging.info('Removing injections in vetoed time')
-
-    vi = numpy.array([])
+    vetoid = numpy.array([])
     for ifo in ifo_list:
-        vi = numpy.append(vi, veto_indices(inj_time, [args.veto_file],
-                                        ifo=ifo, segment_name=args.segment_name))
-
-    found_after_vetoes = numpy.delete(found_within_time,
-                                      numpy.where(numpy.in1d(found_within_time, vi))[0])
-    missed_after_vetoes = numpy.delete(missed_within_time,
-                                       numpy.where(numpy.in1d(missed_within_time, vi))[0])
-    logging.info('Found: %s, Missed: %s' % (len(found_after_vetoes),
-                                            len(missed_after_vetoes)))
+        vi, _ = indices_within_segments(inj_time, [args.veto_file], ifo=ifo,
+                                        segment_name=args.segment_name)
+        vetoid = numpy.append(vetoid, vi)
+        del vi
+    found_after_vetoes = numpy.array([i for i in found_within_time
+                                      if i not in vetoid])
+    missed_after_vetoes = numpy.array([i for i in missed_within_time
+                                       if i not in vetoid])
+    logging.info('Found: %s, Missed: %s' %
+                 (len(found_after_vetoes), len(missed_after_vetoes)))
 
     found_fore = numpy.arange(0, len(stat), 1)[left[found]]
     found_fore_v = numpy.arange(0, len(stat), 1)[left[found_after_vetoes]]

--- a/bin/hdfcoinc/pycbc_coinc_hdfinjfind
+++ b/bin/hdfcoinc/pycbc_coinc_hdfinjfind
@@ -153,8 +153,8 @@ for trigger_file, injection_file in zip(args.trigger_files,
                  % (len(found), len(missed), len(ambiguous)))
 
     if len(ambiguous) > 0:
-        logging.warn('More than one coinc trigger found associated to
-                      injection')
+        logging.warn('More than one coinc trigger found associated to '
+                     'injection')
         am = numpy.arange(0, len(inj_time), 1)[left[ambiguous]]
         bm = numpy.arange(0, len(inj_time), 1)[right[ambiguous]]
 


### PR DESCRIPTION
It seems veto indices have not been being applied for some time due to an oversight in extracting the indices from segments. 

Also, `numpy.array([i for i in found_within_time if i not in vetoid])` is simpler than `numpy.delete(found_within_time, numpy.where(numpy.in1d(found_within_time, vetoid))[0])`