### PR TITLE
Multiifo injfind

### DIFF
--- a/bin/hdfcoinc/pycbc_coinc_hdfinjfind
+++ b/bin/hdfcoinc/pycbc_coinc_hdfinjfind
@@ -88,8 +88,9 @@ for trigger_file, injection_file in zip(args.trigger_files,
         multi_ifo_style = False
         ifo_list = ['H1', 'L1']
         if args.min_required_ifos > 2:
-            raise NotImplementedError('min-required-ifos must be less than or '
-                                'equal to number of ifos involved in search')
+            raise RuntimeError('min-required-ifos (%s' % args.min_required_ifos + 
+                                ') must be less than or equal to the number ' +
+                                'of ifos involved in search (2)')
     else:
         multi_ifo_style = True
         # Get list of groups which contain subgroup 'time'
@@ -98,8 +99,10 @@ for trigger_file, injection_file in zip(args.trigger_files,
                     if 'time' in f['foreground/%s/' % key]]
         assert len(ifo_list) > 1
         if len(ifo_list) < args.min_required_ifos:
-            raise NotImplementedError('min-required-ifos must be less than or '
-                                'equal to number of ifos involved in search')
+            raise RuntimeError('min-required-ifos (%s' % args.min_required_ifos +
+                                ') must be less than or equal to the number ' +
+                                'of ifos involved in the search (%s)' %
+                                len(ifo_list))
     fo.attrs['ifos'] = ' '.join(sorted(ifo_list))
 
     template_id = f['foreground/template_id'][:]
@@ -178,8 +181,9 @@ for trigger_file, injection_file in zip(args.trigger_files,
 
     logging.info('Removing injections in vetoed time')
 
-    # Put individual detector vetoes into list of all vetoed indices, if it
-    # is vetoed in more than one detector, then it will be repeated
+    # Put individual detector vetoes into list of all vetoed indices, if an
+    # injection is vetoed in more than one ifo, then its index will appear
+    # more than once
     vetoid = numpy.array([])
     for ifo in ifo_list:
         vi, _ = indices_within_segments(inj_time, [args.veto_file], ifo=ifo,
@@ -191,11 +195,10 @@ for trigger_file, injection_file in zip(args.trigger_files,
     # vetoed index occurs - this is how many detectors it is vetoed in
     vetoid_unique, count_vetoid = numpy.unique(vetoid, return_counts=True)
 
-    # Vetoed for all combinations are ones which do not allow *any*
-    # combination of min_required_ifos detectors, and so veto more than
-    # (len(ifo_list) - args.min_required_ifos) detectors
-    vetoed_all = vetoid_unique[count_vetoid > (len(ifo_list) -
-                                               args.min_required_ifos)]
+    # remove injectons where the number of unvetoed ifos is less than the
+    # minimum specified by the user
+    vetoed_all = vetoid_unique[(len(ifo_list) - count_vetoid)
+                               < args.min_required_ifos]
 
     found_after_vetoes = numpy.array([i for i in found_within_time
                                       if i not in vetoed_all])

--- a/bin/hdfcoinc/pycbc_coinc_hdfinjfind
+++ b/bin/hdfcoinc/pycbc_coinc_hdfinjfind
@@ -172,21 +172,26 @@ for trigger_file, injection_file in zip(args.trigger_files,
     # combinations retain the veto
 
     # Put individual detector vetoes into a segment list dictionary keyed by ifo
-    vetoed_indices_dict ={}
+    vetoed_idxs_dict ={}
     for ifo in ifo_list:
-        vetoed_indices_dict[ifo], _ = veto_indices(inj_time, [args.veto_file],
+        vetoed_idxs_dict[ifo], _ = veto_indices(inj_time, [args.veto_file],
                                       ifo=ifo, segment_name=args.segment_name)
 
     # Get a flattened list of all indices vetoed in each detector
-    set_all_vetoed_indices = list(itertools.chain(*vetoed_indices_dict.values()))
+    set_all_vetoed_idxs = list(itertools.chain(*vetoed_idxs_dict.values()))
     # Find out which of these indices are unique, and how many times each
     # vetoed index occurs - this is how many detectors it is vetoed in
-    vetoed_indices, count_vetoes_per_index = numpy.unique(set_all_vetoed_indices, return_counts=True)
+    vetoed_idxs, count_vetoes_per_idx = numpy.unique(set_all_vetoed_idxs,
+                                                     return_counts=True)
 
     # vetoed for all combinations are ones which do not allow *any*
     # 2-ifo combination
-    vi = set_all_vetoed_indices[count_vetoes_per_index > (len(ifo_list) - 2)]
+    vi = vetoed_idxs[count_vetoes_per_idx > (len(ifo_list) - 2)]
 
+    found_after_vetoes = numpy.delete(found_within_time,
+                               numpy.where(numpy.in1d(found_within_time, vi)))
+    missed_after_vetoes = numpy.delete(missed_within_time,
+                              numpy.where(numpy.in1d(missed_within_time, vi)))
     ##########################################################################
     # Old style
     ##########################################################################
@@ -196,16 +201,15 @@ for trigger_file, injection_file in zip(args.trigger_files,
 #        vi = numpy.append(vi, veto_indices(inj_time, [args.veto_file],
 #                                        ifo=ifo, segment_name=args.segment_name))
 
-    found_after_vetoes = numpy.delete(found_within_time,
-                                      numpy.where(numpy.in1d(found_within_time, vi)))
-    missed_after_vetoes = numpy.delete(missed_within_time,
-                                       numpy.where(numpy.in1d(missed_within_time, vi)))
+#    found_after_vetoes = numpy.delete(found_within_time,
+#                                      numpy.where(numpy.in1d(found_within_time, vi)))[0]
+#    missed_after_vetoes = numpy.delete(missed_within_time,
+#                                       numpy.where(numpy.in1d(missed_within_time, vi)))[0]
     logging.info('Found: %s, Missed: %s' % (len(found_after_vetoes),
                                             len(missed_after_vetoes)))
 
     found_fore = numpy.arange(0, len(stat), 1)[left[found]]
     found_fore_v = numpy.arange(0, len(stat), 1)[left[found_after_vetoes]]
-    ##########################################################################
     logging.info('Saving injection information')
     columns = ['mass1', 'mass2', 'spin1x', 'spin1y',
                'spin1z', 'spin2x', 'spin2y', 'spin2z',

--- a/bin/hdfcoinc/pycbc_coinc_hdfinjfind
+++ b/bin/hdfcoinc/pycbc_coinc_hdfinjfind
@@ -172,18 +172,20 @@ for trigger_file, injection_file in zip(args.trigger_files,
     # combinations retain the veto
 
     # Put individual detector vetoes into a segment list dictionary keyed by ifo
-    vseg_dict_sngl = segments.segmentlistdict()
     vetoed_indices_dict ={}
     for ifo in ifo_list:
-        vetoed_indices_dict[ifo], vseg_dict_sngl[ifo] = veto_indices(inj_time, [args.veto_file],
+        vetoed_indices_dict[ifo], _ = veto_indices(inj_time, [args.veto_file],
                                       ifo=ifo, segment_name=args.segment_name)
 
-    all_vetoed_indices = list(itertools.chain(*vetoed_indices_dict.values()))
-    set_all_vetoed_indices = numpy.unique(all_vetoed_indices)
+    # Get a flattened list of all indices vetoed in each detector
+    set_all_vetoed_indices = list(itertools.chain(*vetoed_indices_dict.values()))
+    # Find out which of these indices are unique, and how many times each
+    # vetoed index occurs - this is how many detectors it is vetoed in
+    vetoed_indices, count_vetoes_per_index = numpy.unique(set_all_vetoed_indices, return_counts=True)
 
-    count_ifo_veto_index = numpy.array([sum([1 for veto_list in vetoed_indices_dict.values() if test_idx in veto_list]) for test_idx in set_all_vetoed_indices])
-    which_indices_veto_all = numpy.where(count_ifo_veto_index > (len(ifo_list) - 2))[0]
-    vi = set_all_vetoed_indices[which_indices_veto_all]
+    # vetoed for all combinations are ones which do not allow *any*
+    # 2-ifo combination
+    vi = set_all_vetoed_indices[count_vetoes_per_index > (len(ifo_list) - 2)]
 
     ##########################################################################
     # Old style

--- a/bin/hdfcoinc/pycbc_coinc_hdfinjfind
+++ b/bin/hdfcoinc/pycbc_coinc_hdfinjfind
@@ -4,6 +4,7 @@
 files.
 """
 
+import itertools
 import argparse, h5py, logging, types, numpy, os.path
 from glue.ligolw import ligolw, table, lsctables, utils as ligolw_utils
 from ligo import segments
@@ -181,7 +182,7 @@ for trigger_file, injection_file in zip(args.trigger_files,
 
     found_fore = numpy.arange(0, len(stat), 1)[left[found]]
     found_fore_v = numpy.arange(0, len(stat), 1)[left[found_after_vetoes]]
-
+    ##########################################################################
     logging.info('Saving injection information')
     columns = ['mass1', 'mass2', 'spin1x', 'spin1y',
                'spin1z', 'spin2x', 'spin2y', 'spin2z',

--- a/bin/hdfcoinc/pycbc_coinc_hdfinjfind
+++ b/bin/hdfcoinc/pycbc_coinc_hdfinjfind
@@ -59,6 +59,9 @@ parser.add_argument('--veto-file')
 parser.add_argument('--segment-name', default=None,
                     help='Name of segment list to use for vetoes. Optional')
 parser.add_argument('--injection-window', type=float, required=True)
+parser.add_argument('--min-required-ifos', type=int, default=2,
+                    help='Minimum number of IFOs required to be on to allow '
+                    'injection to be counted as found or missed. Default = 2')
 parser.add_argument('--optimal-snr-column', nargs='+',
                     action=MultiDetOptionAction, metavar='DETECTOR:COLUMN',
                     help='Names of the sim_inspiral columns containing the' \
@@ -154,8 +157,8 @@ for trigger_file, injection_file in zip(args.trigger_files,
                  % (len(found), len(missed), len(ambiguous)))
 
     if len(ambiguous) > 0:
-        logging.warn('More than one coinc trigger found associated to '
-                     'injection')
+        logging.warn('More than one coinc trigger found associated '
+                     'with injection')
         am = numpy.arange(0, len(inj_time), 1)[left[ambiguous]]
         bm = numpy.arange(0, len(inj_time), 1)[right[ambiguous]]
 
@@ -168,45 +171,33 @@ for trigger_file, injection_file in zip(args.trigger_files,
 
     logging.info('Removing injections in vetoed time')
 
-    # Vetoes will only mean that injection cannot be found if *all* 2-ifo 
-    # combinations retain the veto
-
-    # Put individual detector vetoes into a segment list dictionary keyed by ifo
-    vetoed_idxs_dict ={}
+    # Put individual detector vetoes into list of all vetoed indices, if it
+    # is vetoed in more than one detector, then it will be repeated
+    vetoid = numpy.array([])
     for ifo in ifo_list:
-        vetoed_idxs_dict[ifo], _ = veto_indices(inj_time, [args.veto_file],
-                                      ifo=ifo, segment_name=args.segment_name)
+        vi, _ = indices_within_segments(inj_time, [args.veto_file], ifo=ifo,
+                                        segment_name=args.segment_name)
+        vetoid = numpy.append(vetoid, vi)
+        del vi
 
-    # Get a flattened list of all indices vetoed in each detector
-    set_all_vetoed_idxs = list(itertools.chain(*vetoed_idxs_dict.values()))
     # Find out which of these indices are unique, and how many times each
     # vetoed index occurs - this is how many detectors it is vetoed in
-    vetoed_idxs, count_vetoes_per_idx = numpy.unique(set_all_vetoed_idxs,
-                                                     return_counts=True)
+    vetoid_unique, count_vetoid = numpy.unique(vetoid, return_counts=True)
 
-    # vetoed for all combinations are ones which do not allow *any*
-    # 2-ifo combination
-    vi = vetoed_idxs[count_vetoes_per_idx > (len(ifo_list) - 2)]
+    # Vetoed for all combinations are ones which do not allow *any*
+    # combination of min_required_ifos detectors, and so veto more than
+    # (len(ifo_list) - args.min_required_ifos) detectors
+    vetoed_all = vetoid_unique[count_vetoid > (len(ifo_list) - 
+                                               args.min_required_ifos)]
 
-    found_after_vetoes = numpy.delete(found_within_time,
-                               numpy.where(numpy.in1d(found_within_time, vi)))
-    missed_after_vetoes = numpy.delete(missed_within_time,
-                              numpy.where(numpy.in1d(missed_within_time, vi)))
-    ##########################################################################
-    # Old style
-    ##########################################################################
+    found_after_vetoes = numpy.array([i for i in found_within_time
+                                      if i not in vetoed_all])
+    missed_after_vetoes = numpy.array([i for i in missed_within_time
+                                       if i not in vetoed_all])
 
-#    vi = numpy.array([])
-#    for ifo in ifo_list:
-#        vi = numpy.append(vi, veto_indices(inj_time, [args.veto_file],
-#                                        ifo=ifo, segment_name=args.segment_name))
-
-#    found_after_vetoes = numpy.delete(found_within_time,
-#                                      numpy.where(numpy.in1d(found_within_time, vi)))[0]
-#    missed_after_vetoes = numpy.delete(missed_within_time,
-#                                       numpy.where(numpy.in1d(missed_within_time, vi)))[0]
-    logging.info('Found: %s, Missed: %s' % (len(found_after_vetoes),
-                                            len(missed_after_vetoes)))
+    
+    logging.info('Found: %s, Missed: %s' %
+                 (len(found_after_vetoes), len(missed_after_vetoes)))
 
     found_fore = numpy.arange(0, len(stat), 1)[left[found]]
     found_fore_v = numpy.arange(0, len(stat), 1)[left[found_after_vetoes]]

--- a/bin/hdfcoinc/pycbc_coinc_hdfinjfind
+++ b/bin/hdfcoinc/pycbc_coinc_hdfinjfind
@@ -167,18 +167,67 @@ for trigger_file, injection_file in zip(args.trigger_files,
                  (len(found_within_time), len(missed_within_time)))
 
     logging.info('Removing injections in vetoed time')
-    vetoid = numpy.array([])
+
+    # Vetoes will only mean that injection cannot be found if *all* 2-ifo 
+    # combinations retain the veto
+
+    # Put individual detector vetoes into a segment list dictionary keyed by ifo
+    vseg_dict_sngl = segments.segmentlistdict()
+    vetoed_indices_dict ={}
     for ifo in ifo_list:
-        vi, _ = indices_within_segments(inj_time, [args.veto_file], ifo=ifo,
-                                        segment_name=args.segment_name)
-        vetoid = numpy.append(vetoid, vi)
-        del vi
-    found_after_vetoes = numpy.array([i for i in found_within_time
-                                      if i not in vetoid])
-    missed_after_vetoes = numpy.array([i for i in missed_within_time
-                                       if i not in vetoid])
-    logging.info('Found: %s, Missed: %s' %
-                 (len(found_after_vetoes), len(missed_after_vetoes)))
+        vetoed_indices_dict[ifo], vseg_dict_sngl[ifo] = veto_indices(inj_time, [args.veto_file],
+                                      ifo=ifo, segment_name=args.segment_name)
+
+    all_vetoed_indices = list(itertools.chain(*vetoed_indices_dict.values()))
+    set_all_vetoed_indices = numpy.unique(all_vetoed_indices)
+
+    count_ifo_veto_index = numpy.array([sum([1 for veto_list in vetoed_indices_dict.values() if test_idx in veto_list]) for test_idx in set_all_vetoed_indices])
+    which_indices_veto_all = numpy.where(count_ifo_veto_index > (len(ifo_list) - 2))[0]
+    vi = set_all_vetoed_indices[which_indices_veto_all]
+
+    # (note that this may not be the most efficient way to perform this task)
+    # combine these vetoes into two-detector combination
+ #   ifo_2_combos = itertools.combinations(ifo_list, 3)
+ #   vseg_dict_comb = segments.segmentlistdict()
+ #   for ifo_combo in ifo_2_combos:
+ #       combokey = ''.join(ifo_combo)
+ #       ifo0 = ifo_combo[0]
+ #       ifo1 = ifo_combo[1]
+ #       vseg_dict_comb[combokey] = vseg_dict_sngl[ifo0] \
+ #                                        | vseg_dict_sngl[ifo1]
+
+    # Add two-detector combination segments together to get the 'less than
+    # two detectors are available' veto
+    # vetoed_segments = numpy.sum(list(vseg_dict_comb.values()), axis=0)
+ #   vetoed_segments = vseg_dict_comb['H1L1V1']
+
+    # convert to start-end lists in order to use standard
+ #   v_start, v_end = events.segments_to_start_end(vetoed_segments)
+ #   vi = numpy.array([], dtype=numpy.uint32)
+    # if any vetoes exist, work out which indices are within the times
+ #   if len(v_start) > 0:
+ #       vidx = events.indices_within_times(inj_time, v_start, v_end)
+ #       vi = numpy.union1d(vi, vidx)
+
+    print(len(vi))
+    print(vi)
+    print(numpy.where(numpy.in1d(found_within_time, vi)))
+
+    ##########################################################################
+    # Old style
+    ##########################################################################
+
+#    vi = numpy.array([])
+#    for ifo in ifo_list:
+#        vi = numpy.append(vi, veto_indices(inj_time, [args.veto_file],
+#                                        ifo=ifo, segment_name=args.segment_name))
+
+    found_after_vetoes = numpy.delete(found_within_time,
+                                      numpy.where(numpy.in1d(found_within_time, vi)))
+    missed_after_vetoes = numpy.delete(missed_within_time,
+                                       numpy.where(numpy.in1d(missed_within_time, vi)))
+    logging.info('Found: %s, Missed: %s' % (len(found_after_vetoes),
+                                            len(missed_after_vetoes)))
 
     found_fore = numpy.arange(0, len(stat), 1)[left[found]]
     found_fore_v = numpy.arange(0, len(stat), 1)[left[found_after_vetoes]]

--- a/bin/hdfcoinc/pycbc_coinc_hdfinjfind
+++ b/bin/hdfcoinc/pycbc_coinc_hdfinjfind
@@ -185,34 +185,6 @@ for trigger_file, injection_file in zip(args.trigger_files,
     which_indices_veto_all = numpy.where(count_ifo_veto_index > (len(ifo_list) - 2))[0]
     vi = set_all_vetoed_indices[which_indices_veto_all]
 
-    # (note that this may not be the most efficient way to perform this task)
-    # combine these vetoes into two-detector combination
- #   ifo_2_combos = itertools.combinations(ifo_list, 3)
- #   vseg_dict_comb = segments.segmentlistdict()
- #   for ifo_combo in ifo_2_combos:
- #       combokey = ''.join(ifo_combo)
- #       ifo0 = ifo_combo[0]
- #       ifo1 = ifo_combo[1]
- #       vseg_dict_comb[combokey] = vseg_dict_sngl[ifo0] \
- #                                        | vseg_dict_sngl[ifo1]
-
-    # Add two-detector combination segments together to get the 'less than
-    # two detectors are available' veto
-    # vetoed_segments = numpy.sum(list(vseg_dict_comb.values()), axis=0)
- #   vetoed_segments = vseg_dict_comb['H1L1V1']
-
-    # convert to start-end lists in order to use standard
- #   v_start, v_end = events.segments_to_start_end(vetoed_segments)
- #   vi = numpy.array([], dtype=numpy.uint32)
-    # if any vetoes exist, work out which indices are within the times
- #   if len(v_start) > 0:
- #       vidx = events.indices_within_times(inj_time, v_start, v_end)
- #       vi = numpy.union1d(vi, vidx)
-
-    print(len(vi))
-    print(vi)
-    print(numpy.where(numpy.in1d(found_within_time, vi)))
-
     ##########################################################################
     # Old style
     ##########################################################################

--- a/bin/hdfcoinc/pycbc_coinc_hdfinjfind
+++ b/bin/hdfcoinc/pycbc_coinc_hdfinjfind
@@ -4,7 +4,6 @@
 files.
 """
 
-import itertools
 import argparse, h5py, logging, types, numpy, os.path
 from glue.ligolw import ligolw, table, lsctables, utils as ligolw_utils
 from ligo import segments
@@ -88,11 +87,19 @@ for trigger_file, injection_file in zip(args.trigger_files,
     if 'foreground/time1' in f:
         multi_ifo_style = False
         ifo_list = ['H1', 'L1']
+        assert args.min_required_ifos > 2
+            raise NotImplementedError('min-required-ifos must be less than or '
+                                'equal to number of ifos involved in search')
     else:
         multi_ifo_style = True
-        # Get list of groups which contain subgroup 'time' - these will be the IFOs
-        ifo_list = [key for key in f['foreground'] if 'time' in f['foreground/%s/' % key]]
+        # Get list of groups which contain subgroup 'time'
+        # - these will be the IFOs
+        ifo_list = [key for key in f['foreground']
+                    if 'time' in f['foreground/%s/' % key]]
         assert len(ifo_list) > 1
+        if len(ifo_list) < args.min_required_ifos:
+            raise NotImplementedError('min-required-ifos must be less than or '
+                                'equal to number of ifos involved in search')
     fo.attrs['ifos'] = ' '.join(sorted(ifo_list))
 
     template_id = f['foreground/template_id'][:]

--- a/bin/hdfcoinc/pycbc_coinc_hdfinjfind
+++ b/bin/hdfcoinc/pycbc_coinc_hdfinjfind
@@ -100,7 +100,7 @@ for trigger_file, injection_file in zip(args.trigger_files,
     if len(ifo_list) < args.min_required_ifos:
         raise RuntimeError('min-required-ifos (%s) must be <= number of ifos'
                            ' being searched (%s)' %
-                           (args.min_required_ifos, len(ifo_list))
+                           (args.min_required_ifos, len(ifo_list)))
     fo.attrs['ifos'] = ' '.join(sorted(ifo_list))
 
     template_id = f['foreground/template_id'][:]

--- a/bin/hdfcoinc/pycbc_coinc_hdfinjfind
+++ b/bin/hdfcoinc/pycbc_coinc_hdfinjfind
@@ -187,7 +187,7 @@ for trigger_file, injection_file in zip(args.trigger_files,
     # Vetoed for all combinations are ones which do not allow *any*
     # combination of min_required_ifos detectors, and so veto more than
     # (len(ifo_list) - args.min_required_ifos) detectors
-    vetoed_all = vetoid_unique[count_vetoid > (len(ifo_list) - 
+    vetoed_all = vetoid_unique[count_vetoid > (len(ifo_list) -
                                                args.min_required_ifos)]
 
     found_after_vetoes = numpy.array([i for i in found_within_time
@@ -195,7 +195,7 @@ for trigger_file, injection_file in zip(args.trigger_files,
     missed_after_vetoes = numpy.array([i for i in missed_within_time
                                        if i not in vetoed_all])
 
-    
+
     logging.info('Found: %s, Missed: %s' %
                  (len(found_after_vetoes), len(missed_after_vetoes)))
 

--- a/bin/hdfcoinc/pycbc_coinc_hdfinjfind
+++ b/bin/hdfcoinc/pycbc_coinc_hdfinjfind
@@ -12,6 +12,7 @@ from pycbc.events import indices_within_segments
 from pycbc.types import MultiDetOptionAction
 import pycbc.version
 
+
 # dummy class needed for loading LIGOLW files
 class LIGOLWContentHandler(ligolw.LIGOLWContentHandler):
     pass
@@ -59,11 +60,11 @@ parser.add_argument('--segment-name', default=None,
                     help='Name of segment list to use for vetoes. Optional')
 parser.add_argument('--injection-window', type=float, required=True)
 parser.add_argument('--min-required-ifos', type=int, default=2,
-                    help='Minimum number of IFOs required to be on to allow '
-                    'injection to be counted as found or missed. Default = 2')
+                    help='Minimum number of IFOs required to be observing and'
+                    ' not vetoed for an injection to be counted. Default 2')
 parser.add_argument('--optimal-snr-column', nargs='+',
                     action=MultiDetOptionAction, metavar='DETECTOR:COLUMN',
-                    help='Names of the sim_inspiral columns containing the' \
+                    help='Names of the sim_inspiral columns containing the'
                     ' optimal SNRs.')
 parser.add_argument('--redshift-column', default=None,
                     help='Name of sim_inspiral column containing redshift. '
@@ -77,6 +78,7 @@ if args.verbose:
     logging.basicConfig(format='%(asctime)s : %(message)s', level=log_level)
 
 fo = h5py.File(args.output_file, 'w')
+
 injection_index = 0
 for trigger_file, injection_file in zip(args.trigger_files,
                                         args.injection_files):
@@ -87,10 +89,6 @@ for trigger_file, injection_file in zip(args.trigger_files,
     if 'foreground/time1' in f:
         multi_ifo_style = False
         ifo_list = ['H1', 'L1']
-        if args.min_required_ifos > 2:
-            raise RuntimeError('min-required-ifos (%s' % args.min_required_ifos + 
-                                ') must be less than or equal to the number ' +
-                                'of ifos involved in search (2)')
     else:
         multi_ifo_style = True
         # Get list of groups which contain subgroup 'time'
@@ -98,11 +96,11 @@ for trigger_file, injection_file in zip(args.trigger_files,
         ifo_list = [key for key in f['foreground']
                     if 'time' in f['foreground/%s/' % key]]
         assert len(ifo_list) > 1
-        if len(ifo_list) < args.min_required_ifos:
-            raise RuntimeError('min-required-ifos (%s' % args.min_required_ifos +
-                                ') must be less than or equal to the number ' +
-                                'of ifos involved in the search (%s)' %
-                                len(ifo_list))
+    # Check required ifos option
+    if len(ifo_list) < args.min_required_ifos:
+        raise RuntimeError('min-required-ifos (%s) must be <= number of ifos'
+                           ' being searched (%s)' %
+                           (args.min_required_ifos, len(ifo_list))
     fo.attrs['ifos'] = ' '.join(sorted(ifo_list))
 
     template_id = f['foreground/template_id'][:]
@@ -132,7 +130,7 @@ for trigger_file, injection_file in zip(args.trigger_files,
             else:
                 starts = f['/segments/%s/start' % key][:]
                 ends = f['/segments/%s/end' % key][:]
-                any_seg += events.start_end_to_segments(starts,ends)
+                any_seg += events.start_end_to_segments(starts, ends)
         ana_start, ana_end = events.segments_to_start_end(any_seg)
     else:
         # Using the old 2-ifo organisation
@@ -182,8 +180,7 @@ for trigger_file, injection_file in zip(args.trigger_files,
     logging.info('Removing injections in vetoed time')
 
     # Put individual detector vetoes into list of all vetoed indices, if an
-    # injection is vetoed in more than one ifo, then its index will appear
-    # more than once
+    # injection is vetoed in N ifos then its index will appear N times
     vetoid = numpy.array([])
     for ifo in ifo_list:
         vi, _ = indices_within_segments(inj_time, [args.veto_file], ifo=ifo,
@@ -195,16 +192,14 @@ for trigger_file, injection_file in zip(args.trigger_files,
     # vetoed index occurs - this is how many detectors it is vetoed in
     vetoid_unique, count_vetoid = numpy.unique(vetoid, return_counts=True)
 
-    # remove injectons where the number of unvetoed ifos is less than the
+    # remove injections where the number of unvetoed ifos is less than the
     # minimum specified by the user
     vetoed_all = vetoid_unique[(len(ifo_list) - count_vetoid)
                                < args.min_required_ifos]
-
     found_after_vetoes = numpy.array([i for i in found_within_time
                                       if i not in vetoed_all])
     missed_after_vetoes = numpy.array([i for i in missed_within_time
                                        if i not in vetoed_all])
-
 
     logging.info('Found: %s, Missed: %s' %
                  (len(found_after_vetoes), len(missed_after_vetoes)))

--- a/bin/hdfcoinc/pycbc_coinc_hdfinjfind
+++ b/bin/hdfcoinc/pycbc_coinc_hdfinjfind
@@ -87,7 +87,7 @@ for trigger_file, injection_file in zip(args.trigger_files,
     if 'foreground/time1' in f:
         multi_ifo_style = False
         ifo_list = ['H1', 'L1']
-        assert args.min_required_ifos > 2
+        if args.min_required_ifos > 2:
             raise NotImplementedError('min-required-ifos must be less than or '
                                 'equal to number of ifos involved in search')
     else:

--- a/bin/hdfcoinc/pycbc_page_foundmissed
+++ b/bin/hdfcoinc/pycbc_page_foundmissed
@@ -79,7 +79,7 @@ eff_dist_map = {'H1': 'eff_dist_h', 'H2': 'eff_dist_h', 'L1': 'eff_dist_l',
 try:
     eff_dists = [f['injections/{}'.format(eff_dist_map[ifo])][:]\
                  for ifo in ifos]
-    eff_dists = numpy.array(eff_dists).T 
+    eff_dists = numpy.array(eff_dists).T
     # "Decisive" distance is the second smallest effective distance
     dvals['decisive_distance'] = numpy.sort(eff_dists)[:,1]
     dvals['dec_chirp_distance'] = \
@@ -146,7 +146,7 @@ if not args.gradient_far:
     color[hundred] = 0.5
     color[thousand] = 1.0
 
-    mpoints = plot.scatter(vals[args.axis_type][missed], mdvals, s=10, linewidth=0.1,
+    mpoints = plot.scatter(vals[args.axis_type][missed], mdvals, s=10, linewidth=0.5,
                            marker='x', color='black', label='missed', zorder=zmissed)
     points = plot.scatter(vals[args.axis_type][found], fdvals, s=10,
                            c=color, linewidth=0, vmin=0, vmax=1,
@@ -166,7 +166,7 @@ else:
     if len(color) < 2:
         color=None
 
-    mpoints = plot.scatter(vals[args.axis_type][missed], mdvals, s=10, linewidth=0.1,
+    mpoints = plot.scatter(vals[args.axis_type][missed], mdvals, s=10, linewidth=0.5,
                            marker='x', color='red', label='missed', zorder=zmissed)
     points = plot.scatter(fvals, fdval, c=color, linewidth=0, s=10,
                           norm=matplotlib.colors.LogNorm(),

--- a/bin/hdfcoinc/pycbc_page_foundmissed
+++ b/bin/hdfcoinc/pycbc_page_foundmissed
@@ -146,9 +146,9 @@ if not args.gradient_far:
     color[hundred] = 0.5
     color[thousand] = 1.0
 
-    mpoints = plot.scatter(vals[args.axis_type][missed], mdvals,
+    mpoints = plot.scatter(vals[args.axis_type][missed], mdvals, s=10, linewidth=0.1,
                            marker='x', color='black', label='missed', zorder=zmissed)
-    points = plot.scatter(vals[args.axis_type][found], fdvals,
+    points = plot.scatter(vals[args.axis_type][found], fdvals, s=10,
                            c=color, linewidth=0, vmin=0, vmax=1,
                            marker='o', label='found', zorder=zfound)
     caption = (fig_title + ": Black x's are missed injections. "
@@ -166,9 +166,9 @@ else:
     if len(color) < 2:
         color=None
 
-    mpoints = plot.scatter(vals[args.axis_type][missed], mdvals,
+    mpoints = plot.scatter(vals[args.axis_type][missed], mdvals, s=10, linewidth=0.1,
                            marker='x', color='red', label='missed', zorder=zmissed)
-    points = plot.scatter(fvals, fdval, c=color, linewidth=0,
+    points = plot.scatter(fvals, fdval, c=color, linewidth=0, s=10,
                           norm=matplotlib.colors.LogNorm(),
                           marker='o', label='found', zorder=zfound)
     caption = (fig_title + ": Red x's are missed injections. "


### PR DESCRIPTION
hdfinjfind is removing some injections within valid time because of incorrect application of vetoes

This PR contains:
- updates to the veto removal logic to allow for vetos in one detector not to remove an injection which could be found coincident in others
- addition of a command line option which defines the minimum number of required ifos for an injection *not* to be vetoed
- a small update to foundmissed plots so that it isn't so 'blobby'