### PR TITLE
Add normalization term to GaussianNoise model

### DIFF
--- a/pycbc/inference/models/gaussian_noise.py
+++ b/pycbc/inference/models/gaussian_noise.py
@@ -255,7 +255,7 @@ class GaussianNoise(BaseDataModel):
         # Set the cutoff indices
         self._kmin = {}
         self._kmax = {}
-        for det in self._data:
+        for (det, d) in self._data.items():
             kmin, kmax = pyfilter.get_cutoff_indices(self._f_lower[det],
                                                      self._f_upper[det],
                                                      d.delta_f, self._N)

--- a/pycbc/inference/models/gaussian_noise.py
+++ b/pycbc/inference/models/gaussian_noise.py
@@ -386,7 +386,7 @@ class GaussianNoise(BaseDataModel):
             kmin = self._kmin[det]
             kmax = self._kmax[det]
             lognorm = -float(self._N*numpy.log(numpy.pi*self._N*dt)/2.
-                            + numpy.log(p[kmin:kmax]).sum())
+                             + numpy.log(p[kmin:kmax]).sum())
             self._lognorm[det] = lognorm
             return self._lognorm[det]
 
@@ -486,7 +486,7 @@ class GaussianNoise(BaseDataModel):
 
         .. math::
 
-            \log p(d_i|n_i) = \log \alpha_i - 
+            \log p(d_i|n_i) = \log \alpha_i -
                 \frac{1}{2} \left<d_i | d_i\right>.
 
 


### PR DESCRIPTION
This adds the normalization term to the `GaussianNoise` model (see second term of Eq. 8 in [arXiv:1409.7215](https://arxiv.org/pdf/1409.7215.pdf), and updates the doc string accordingly. This is the first step toward adding support for hierarchical inference over multiple events, and for marginalizing over PSD uncertainties.