### PR TITLE
[WIP] More Python 3 fixes for PyCBC Live

### DIFF
--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -261,9 +261,9 @@ class LiveEventManager(object):
             f.attrs['num_live_detectors'] = len(self.live_detectors)
 
             def h5py_unicode_workaround(stuff):
-                # FIXME workaround for the fact that h5py cannot handle Unicode
+                # workaround for the fact that h5py cannot handle Unicode
                 # numpy arrays that show up with Python 3
-                if hasattr(stuff, 'dtype') and 'U' in stuff.dtype.str:
+                if hasattr(stuff, 'dtype') and stuff.dtype.kind == 'U':
                     return [s.encode('ascii') for s in stuff]
                 return stuff
 

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -260,12 +260,20 @@ class LiveEventManager(object):
             f.attrs['command_line'] = sys.argv
             f.attrs['num_live_detectors'] = len(self.live_detectors)
 
+            def h5py_unicode_workaround(stuff):
+                # FIXME workaround for the fact that h5py cannot handle Unicode
+                # numpy arrays that show up with Python 3
+                if hasattr(stuff, 'dtype') and 'U' in stuff.dtype.str:
+                    return [s.encode('ascii') for s in stuff]
+                return stuff
+
             for ifo in results:
                 for k in results[ifo]:
-                    f['%s/%s' % (ifo, k)] = results[ifo][k]
+                    f['%s/%s' % (ifo, k)] = \
+                            h5py_unicode_workaround(results[ifo][k])
 
             for key in raw_results:
-                f[key] = raw_results[key]
+                f[key] = h5py_unicode_workaround(raw_results[key])
 
             if store_loudest_index:
                 for ifo in results:

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -264,7 +264,7 @@ class LiveEventManager(object):
                 # workaround for the fact that h5py cannot handle Unicode
                 # numpy arrays that show up with Python 3
                 if hasattr(stuff, 'dtype') and stuff.dtype.kind == 'U':
-                    return [s.encode('ascii') for s in stuff]
+                    return [s.encode() for s in stuff]
                 return stuff
 
             for ifo in results:

--- a/pycbc/fft/fftw.py
+++ b/pycbc/fft/fftw.py
@@ -186,7 +186,7 @@ def import_single_wisdom_from_filename(filename):
         set_threads_backend()
     f = float_lib.fftwf_import_wisdom_from_filename
     f.argtypes = [ctypes.c_char_p]
-    retval = f(filename)
+    retval = f(filename.encode('ascii'))
     if retval == 0:
         raise RuntimeError("Could not import wisdom from file {0}".format(filename))
 
@@ -195,7 +195,7 @@ def import_double_wisdom_from_filename(filename):
         set_threads_backend()
     f = double_lib.fftw_import_wisdom_from_filename
     f.argtypes = [ctypes.c_char_p]
-    retval = f(filename)
+    retval = f(filename.encode('ascii'))
     if retval == 0:
         raise RuntimeError("Could not import wisdom from file {0}".format(filename))
 
@@ -204,7 +204,7 @@ def export_single_wisdom_to_filename(filename):
         set_threads_backend()
     f = float_lib.fftwf_export_wisdom_to_filename
     f.argtypes = [ctypes.c_char_p]
-    retval = f(filename)
+    retval = f(filename.encode('ascii'))
     if retval == 0:
         raise RuntimeError("Could not export wisdom to file {0}".format(filename))
 
@@ -213,7 +213,7 @@ def export_double_wisdom_to_filename(filename):
         set_threads_backend()
     f = double_lib.fftw_export_wisdom_to_filename
     f.argtypes = [ctypes.c_char_p]
-    retval = f(filename)
+    retval = f(filename.encode('ascii'))
     if retval == 0:
         raise RuntimeError("Could not export wisdom to file {0}".format(filename))
 

--- a/pycbc/fft/fftw.py
+++ b/pycbc/fft/fftw.py
@@ -181,41 +181,32 @@ def get_flag(mlvl,aligned):
 
 # Add the ability to read/store wisdom to filenames
 
-def import_single_wisdom_from_filename(filename):
+def wisdom_io(filename, precision, action):
+    """Import or export an FFTW plan for single or double precision.
+    """
     if not _fftw_threaded_set:
         set_threads_backend()
-    f = float_lib.fftwf_import_wisdom_from_filename
+    func_map = {('float', 'import'): float_lib.fftwf_import_wisdom_from_filename,
+                ('float', 'export'): float_lib.fftwf_export_wisdom_to_filename,
+                ('double', 'import'): double_lib.fftw_import_wisdom_from_filename,
+                ('double', 'export'): double_lib.fftw_export_wisdom_to_filename}
+    f = func_map[(precision, action)]
     f.argtypes = [ctypes.c_char_p]
-    retval = f(filename.encode('ascii'))
+    retval = f(filename.encode())
     if retval == 0:
-        raise RuntimeError("Could not import wisdom from file {0}".format(filename))
+        raise RuntimeError("Could not {0} wisdom from file {1}".format(action, filename))
+
+def import_single_wisdom_from_filename(filename):
+    wisdom_io(filename, 'float', 'import')
 
 def import_double_wisdom_from_filename(filename):
-    if not _fftw_threaded_set:
-        set_threads_backend()
-    f = double_lib.fftw_import_wisdom_from_filename
-    f.argtypes = [ctypes.c_char_p]
-    retval = f(filename.encode('ascii'))
-    if retval == 0:
-        raise RuntimeError("Could not import wisdom from file {0}".format(filename))
+    wisdom_io(filename, 'double', 'import')
 
 def export_single_wisdom_to_filename(filename):
-    if not _fftw_threaded_set:
-        set_threads_backend()
-    f = float_lib.fftwf_export_wisdom_to_filename
-    f.argtypes = [ctypes.c_char_p]
-    retval = f(filename.encode('ascii'))
-    if retval == 0:
-        raise RuntimeError("Could not export wisdom to file {0}".format(filename))
+    wisdom_io(filename, 'float', 'export')
 
 def export_double_wisdom_to_filename(filename):
-    if not _fftw_threaded_set:
-        set_threads_backend()
-    f = double_lib.fftw_export_wisdom_to_filename
-    f.argtypes = [ctypes.c_char_p]
-    retval = f(filename.encode('ascii'))
-    if retval == 0:
-        raise RuntimeError("Could not export wisdom to file {0}".format(filename))
+    wisdom_io(filename, 'double', 'export')
 
 def set_planning_limit(time):
     if not _fftw_threaded_set:

--- a/pycbc/fft/fftw.py
+++ b/pycbc/fft/fftw.py
@@ -186,15 +186,16 @@ def wisdom_io(filename, precision, action):
     """
     if not _fftw_threaded_set:
         set_threads_backend()
-    func_map = {('float', 'import'): float_lib.fftwf_import_wisdom_from_filename,
-                ('float', 'export'): float_lib.fftwf_export_wisdom_to_filename,
-                ('double', 'import'): double_lib.fftw_import_wisdom_from_filename,
-                ('double', 'export'): double_lib.fftw_export_wisdom_to_filename}
-    f = func_map[(precision, action)]
+    fmap = {('float', 'import'): float_lib.fftwf_import_wisdom_from_filename,
+            ('float', 'export'): float_lib.fftwf_export_wisdom_to_filename,
+            ('double', 'import'): double_lib.fftw_import_wisdom_from_filename,
+            ('double', 'export'): double_lib.fftw_export_wisdom_to_filename}
+    f = fmap[(precision, action)]
     f.argtypes = [ctypes.c_char_p]
     retval = f(filename.encode())
     if retval == 0:
-        raise RuntimeError("Could not {0} wisdom from file {1}".format(action, filename))
+        raise RuntimeError(('Could not {0} wisdom '
+                            'from file {1}').format(action, filename))
 
 def import_single_wisdom_from_filename(filename):
     wisdom_io(filename, 'float', 'import')

--- a/pycbc/filter/matchedfilter.py
+++ b/pycbc/filter/matchedfilter.py
@@ -1544,7 +1544,7 @@ class LiveBatchMatchedFilter(object):
             self.cout_mem[i] = zeros(size, dtype=numpy.complex64)
             self.ifts[i] = IFFT(self.cout_mem[i], self.out_mem[i],
                                 nbatch=count,
-                                size=len(self.cout_mem[i]) / count)
+                                size=len(self.cout_mem[i]) // count)
 
         # Split the templates into their processing groups
         for dur, count in mem_ids:

--- a/pycbc/strain/strain.py
+++ b/pycbc/strain/strain.py
@@ -1401,10 +1401,10 @@ class StrainBuffer(pycbc.frame.DataBuffer):
         """ Recalculate the psd
         """
 
-        seg_len = self.sample_rate * self.psd_segment_length
+        seg_len = int(self.sample_rate * self.psd_segment_length)
         e = len(self.strain)
-        s = e - ((self.psd_samples + 1) * self.psd_segment_length / 2) * self.sample_rate
-        psd = pycbc.psd.welch(self.strain[s:e], seg_len=seg_len, seg_stride=seg_len / 2)
+        s = e - (self.psd_samples + 1) * seg_len // 2
+        psd = pycbc.psd.welch(self.strain[s:e], seg_len=seg_len, seg_stride=seg_len//2)
 
         psd.dist = spa_distance(psd, 1.4, 1.4, self.low_frequency_cutoff) * pycbc.DYN_RANGE_FAC
 

--- a/pycbc/strain/strain.py
+++ b/pycbc/strain/strain.py
@@ -1354,7 +1354,7 @@ class StrainBuffer(pycbc.frame.DataBuffer):
         self.highpass_samples =  int(highpass_samples / 2)
         resample_corruption = 10 # If using the ldas method
         self.factor = int(1.0 / self.raw_buffer.delta_t / self.sample_rate)
-        self.corruption = self.highpass_samples / self.factor + resample_corruption
+        self.corruption = self.highpass_samples // self.factor + resample_corruption
 
         self.psd_corruption =  self.psd_inverse_length * self.sample_rate
         self.total_corruption = self.corruption + self.psd_corruption
@@ -1365,7 +1365,7 @@ class StrainBuffer(pycbc.frame.DataBuffer):
         if self.trim_padding > self.total_corruption:
             self.trim_padding = self.total_corruption
 
-        self.psd_duration = (psd_samples - 1) / 2 * psd_segment_length
+        self.psd_duration = (psd_samples - 1) // 2 * psd_segment_length
 
         self.reduced_pad = int(self.total_corruption - self.trim_padding)
         self.segments = {}


### PR DESCRIPTION
Fixing a few more errors that happen when PyCBC Live runs under Python 3. With these changes, PyCBC Live successfully runs under Python 3 and produces HDF files as well as coinc LIGOLW files.

I have not yet done a careful checks of the correctness of the results and GraceDB uploads are not tested yet.

I am not sure about the h5py workaround I did for saving the approximant array. Comments/alternatives are welcome.