### PR TITLE
Allow static params to be in transforms

### DIFF
--- a/pycbc/inference/models/base.py
+++ b/pycbc/inference/models/base.py
@@ -415,6 +415,8 @@ class BaseModel(object):
         If any sampling transforms are specified, they are applied to the
         params before being stored.
         """
+        # add the static params
+        params.update(self.static_params)
         self._current_params = self._transform_params(**params)
         self._current_stats = ModelStats()
 


### PR DESCRIPTION
Currently, you can't use static parameters in sampling and waveform transforms. This fixes that.