### PR TITLE
Minor fix in ringdown example docs

### DIFF
--- a/examples/workflow/inference/ringdown_inference.ini
+++ b/examples/workflow/inference/ringdown_inference.ini
@@ -1,6 +1,7 @@
 [model]
 name = gaussian_noise
-low-frequency-cutoff = 20
+h1-low-frequency-cutoff = 20
+l1-low-frequency-cutoff = 20
 
 [sampler]
 name = emcee_pt


### PR DESCRIPTION
I believe the current configuration file example for ringdown PE in the documentation would not work because of PR #2626.
Here I am just changing `low-frequency-cutoff = 20` for what it should be with the current code, i.e.
`h1-low-frequency-cutoff = 20
l1-low-frequency-cutoff = 20`