### PR TITLE
Allow location parameters to be in waveform transforms

### DIFF
--- a/pycbc/inference/models/gaussian_noise.py
+++ b/pycbc/inference/models/gaussian_noise.py
@@ -232,8 +232,16 @@ class GaussianNoise(BaseDataModel):
                            "detector in the `[model]` section, where IFO is "
                            "the name of the detector.")
         # create the waveform generator
+        # the waveform generator will get the variable_params + the output
+        # of the waveform transforms, so we'll add them to the list of
+        # parameters
+        if self.waveform_transforms is not None:
+            wfoutputs = set.union(t.outputs for t in self.waveform_transforms)
+        else:
+            wfoutputs = set()
+        params = list(self.variable_params) + list(wfoutputs)
         self._waveform_generator = create_waveform_generator(
-            self.variable_params, self.data, recalibration=self.recalibration,
+            params, self.data, recalibration=self.recalibration,
             gates=self.gates, **self.static_params)
         # check that the data sets all have the same lengths
         dlens = numpy.array([len(d) for d in self.data.values()])

--- a/pycbc/inference/models/gaussian_noise.py
+++ b/pycbc/inference/models/gaussian_noise.py
@@ -236,7 +236,8 @@ class GaussianNoise(BaseDataModel):
         # of the waveform transforms, so we'll add them to the list of
         # parameters
         if self.waveform_transforms is not None:
-            wfoutputs = set.union(t.outputs for t in self.waveform_transforms)
+            wfoutputs = set.union(*[t.outputs
+                                    for t in self.waveform_transforms])
         else:
             wfoutputs = set()
         params = list(self.variable_params) + list(wfoutputs)

--- a/pycbc/waveform/generator.py
+++ b/pycbc/waveform/generator.py
@@ -70,9 +70,7 @@ class BaseGenerator(object):
     generator : function
         The function that is called for waveform generation.
     variable_args : tuple
-        The list of names of variable arguments. Values passed to the
-        `generate_from_args` function must be in the same order as the
-        arguments in this list.
+        The list of names of variable arguments.
     frozen_params : dict
         A dictionary of the frozen keyword arguments that are always passed
         to the waveform generator function.
@@ -100,14 +98,6 @@ class BaseGenerator(object):
     def static_args(self):
         """Returns a dictionary of the static arguments."""
         return self.frozen_params
-
-    def generate_from_args(self, *args):
-        """Generates a waveform. The list of arguments must be in the same
-        order as self's variable_args attribute.
-        """
-        if len(args) != len(self.variable_args):
-            raise ValueError("variable argument length mismatch")
-        return self.generate(**dict(zip(self.variable_args, args)))
 
     def generate(self, **kwargs):
         """Generates a waveform from the keyword args. The current params
@@ -534,14 +524,6 @@ class FDomainDetFrameGenerator(object):
     @property
     def epoch(self):
         return _lal.LIGOTimeGPS(self._epoch)
-
-    def generate_from_args(self, *args):
-        """Generates a waveform, applies a time shift and the detector response
-        function from the given args.
-
-        The args are assumed to be in the same order as the variable args.
-        """
-        return self.generate(**dict(zip(self.variable_args, args)))
 
     def generate(self, **kwargs):
         """Generates a waveform, applies a time shift and the detector response


### PR DESCRIPTION
Currently, when the `GaussianNoise`  model initializes the waveform generator (`FDomainDetFrameGenerator`), it passes its `variable_params` to the generator. When initialized, `FDomainDetFrameGenerator` checks if tc, ra, dec, and polarization are present in either the variable or static params, raising an error if they are not. This is a problem if you want one of these parameters to be the output of a waveform transform. For example, the following seems like it should work:
```
[variable_params]
delta_tc =
<etc.>

[static_params]
trigger_time = 1126259462.42
<etc.>

[prior-delta_tc]
name = uniform
min-delta_tc = -0.1
max-delta_tc = 0.1

[waveform_transforms-tc]
name = custom
inputs = delta_tc, trigger_time
tc = delta_tc + trigger_time
```
Instead, you get the error:
```
ValueError: detectors provided, but missing location parameters tc. These must be either in the frozen params or the variable args.
```

This fixes this by adding the output parameters of the waveform transforms to the list of variable params passed to the waveform generator on initialization. Since this will break the `generate_from_args` function in the waveform generators, I've removed that (nothing uses that function anymore anyway, as everything is done through the `.generate` function, which takes keyword args).

NB: At some point, we should just remove the `variable_args` argument from the waveform generator classes entirely. Since everything uses keyword args now, this is an appendage of an earlier time. But that's beyond this PR.