### PR TITLE
Add method to convert a section into command-line string

### DIFF
--- a/pycbc/workflow/configuration.py
+++ b/pycbc/workflow/configuration.py
@@ -1075,6 +1075,26 @@ class WorkflowConfigParser(glue.pipeline.DeepCopyableConfigParser):
         except ConfigParser.Error:
             return False
 
+    def section_to_cli(self, section):
+        """Converts a section into a command-line string.
+
+        For example:
+
+        .. code::
+
+            [section_name]
+            foo =
+            bar = 10
+
+        yields: `'--foo --bar 10'`.
+        """
+        opts = []
+        for opt in self.options(section):
+            opts.append('--{}'.format(opt))
+            val = cp.get(section, opt)
+            if val != '':
+                opts.append(val)
+        return ' '.join(opts)
 
     @staticmethod
     def add_config_opts_to_parser(parser):

--- a/pycbc/workflow/configuration.py
+++ b/pycbc/workflow/configuration.py
@@ -1091,7 +1091,7 @@ class WorkflowConfigParser(glue.pipeline.DeepCopyableConfigParser):
         opts = []
         for opt in self.options(section):
             opts.append('--{}'.format(opt))
-            val = cp.get(section, opt)
+            val = self.get(section, opt)
             if val != '':
                 opts.append(val)
         return ' '.join(opts)


### PR DESCRIPTION
This adds a class method to `WorkflowConfigParser` that will convert all of the options in a given section into a command-line-like string of options. (The string can then be passed to an argument parser.) See the example in the doc string.

Needed by #2803. 