### PR TITLE
adding add_statmap code

### DIFF
--- a/bin/hdfcoinc/pycbc_multiifo_add_statmap
+++ b/bin/hdfcoinc/pycbc_multiifo_add_statmap
@@ -151,7 +151,7 @@ del idx_within_segment
 # interferometer combinations are available at the time of coincidence
 available_combos =[' '.join(sorted([key for key in is_in_combo_time 
                                     if is_in_combo_time[key][i]])
-                           ).encode('utf8') for i in np.arange(n_triggers)]
+                            ).encode('utf8') for i in np.arange(n_triggers)]
 
 all_combo_types = np.unique(available_combos)
 idx = {ct:np.where(np.array(available_combos)==ct)[0]
@@ -180,17 +180,19 @@ fg_ifar_exc = np.zeros(n_triggers)
 for ct in all_combo_types:
     cts = ct.split(' ')
     if len(cts) == 1:
-        logging.info('IFAR is the same as previosuly calculated for triggers in {} time'.format(ct))
+        logging.info('IFAR is the same as previously calculated for triggers in {} time'.format(ct))
         # If only one combination is available, then the stat is the same
         # as previously calulated
         fg_ifar[idx[ct]] = f['foreground/ifar'][:][idx[ct]]
         fg_ifar_exc[idx[ct]] = f['foreground/ifar_exc'][:][idx[ct]]
-    else:
+    elif len(cts) > 1:
         logging.info('Recalculating ifar for coincidences which are in {} time'.format(ct))
         far_new = np.sum([far[ifo_combo_key][idx[ct]] for ifo_combo_key in cts], axis=0)
         far_new_exc = np.sum([far_exc[ifo_combo_key][idx[ct]] for ifo_combo_key in cts], axis=0)
         fg_ifar[idx[ct]] = conv.sec_to_year(1. / np.array(far_new))
         fg_ifar_exc[idx[ct]] = conv.sec_to_year(1. / np.array(far_new_exc))
+    else:
+        raise RuntimeError('Empty combo type string, something has gone wrong')
 
 f.attrs['foreground_time_exc'] = f.attrs['foreground_time']
 

--- a/bin/hdfcoinc/pycbc_multiifo_add_statmap
+++ b/bin/hdfcoinc/pycbc_multiifo_add_statmap
@@ -1,0 +1,287 @@
+#!/bin/env python
+""" This clusters to find the most
+significant foreground, but leaves the background triggers alone.
+"""
+
+import h5py, numpy as np, argparse, logging, pycbc, pycbc.events, pycbc.io, lal
+import pycbc.version
+import pycbc.conversions as conv
+from pycbc.events import coinc
+from ligo import segments
+import itertools
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--version", action="version", version=pycbc.version.git_verbose_msg)
+parser.add_argument('--verbose', action='store_true')
+parser.add_argument('--statmap-files', nargs='+',
+                    help="List of coinc files to be redistributed")
+parser.add_argument('--cluster-window', type=float)
+parser.add_argument('-ranking-statistic', type=str,
+                    help='Ranking statistic used to calculate stat and ifar '
+                          'in previous codes, this is used to test whether '
+                          'the background distributions can be safely '
+                          'combined. Default=Not safe')
+parser.add_argument('--output-file', help="name of output file")
+args = parser.parse_args()
+
+pycbc.init_logging(args.verbose)
+
+files = [h5py.File(n, 'r') for n in args.statmap_files]
+
+f = h5py.File(args.output_file, "w")
+
+logging.info('Copying segments and attributes to %s' % args.output_file)
+# Move segments information into the final file - remove some duplication
+# in earlier files
+for fi in files:
+    for key in fi['segments']:
+        if key.startswith('foreground') or key.startswith('background'):
+            continue
+        f['segments/%s/end' % key] = fi['segments/%s/end' % key][:]
+        f['segments/%s/start' % key] = fi['segments/%s/start' % key][:]
+        if 'segments/foreground_veto' in fi:
+            f['segments/%s/foreground_veto/end' % key] = \
+                                         fi['segments/foreground_veto/end'][:]
+            f['segments/%s/foreground_veto/start' % key] = \
+                                       fi['segments/foreground_veto/start'][:]
+        for attr_name in fi.attrs:
+            if key not in f:
+                 f.create_group(key)
+            f[key].attrs[attr_name] = fi.attrs[attr_name]
+
+logging.info('combining foreground and foreground excluded segments')
+# Set up dictionaries to contain segments from the individual statmap files
+indiv_segs = segments.segmentlistdict({})
+indiv_segs_fg_exc = segments.segmentlistdict({})
+
+any_fg_vetoes = False
+# loop through statmap files and put segments into segmentlistdicts
+for fi in files:
+    key = fi.attrs['ifos'].replace(' ','')
+    # get analysed segments from individual statmap files
+    starts = fi['segments/{}/start'.format(key)][:]
+    ends = fi['segments/{}/end'.format(key)][:]
+    indiv_segs[key] = pycbc.events.veto.start_end_to_segments(starts, ends)
+    # get the foreground_vetoed times from individual statmap files
+    if 'foreground_veto' in fi['segments']:
+        any_fg_vetoes = True
+        remove_start_time = fi['segments/foreground_veto/start'][:]
+        remove_end_time = fi['segments/foreground_veto/end'][:]
+        vetoed_segs = pycbc.events.veto.start_end_to_segments(remove_start_time,
+                                                          remove_end_time)
+        # remove from analysis segments
+        indiv_segs_fg_exc[key] = indiv_segs[key] - vetoed_segs
+
+del remove_end_time, remove_start_time, vetoed_segs
+
+# Convert segmentlistdict to a list ('seglists') of segmentlists
+# then np.sum(seglists, axis=0) does seglists[0] + seglists[1] + ...
+foreground_segs = np.sum(list(indiv_segs.values()), axis=0)
+# obtain list of all ifos involved in the coinc_statmap files
+all_ifos = np.unique([ifo for fi in files
+                      for ifo in fi.attrs['ifos'].split(' ')])
+
+all_ifo_key = ''.join(all_ifos)
+
+# Note that 'exclusive' time only removes windows around coincs
+# that involve *all* active ifos (2 in 2-ifo time, 3 in 3-ifo time etc.)
+if any_fg_vetoes:
+    foreground_segs_exc = np.sum(list(indiv_segs_fg_exc.values()), axis=0)
+
+    # output foreground veto starts and ends to file
+    foreground_vetos_start, foreground_vetos_end = \
+                   pycbc.events.veto.segments_to_start_end(foreground_segs - \
+                                                           foreground_segs_exc)
+
+    f['segments/foreground_veto/start'] = foreground_vetos_start
+    f['segments/foreground_veto/end'] = foreground_vetos_end
+
+# output to file
+f.attrs['foreground_time'] = abs(foreground_segs)
+if any_fg_vetoes:
+    f.attrs['foreground_time_exc'] = abs(foreground_segs_exc)
+else:
+    f.attrs['foreground_time_exc'] = f.attrs['foreground_time']
+
+# Save the ifo list for future reference
+f.attrs['ifos'] = ' '.join(sorted(all_ifos))
+
+logging.info('Copying stat and decimation_factor')
+keys_to_copy = ['decimation_factor', 'stat']
+fg_bg = ['foreground','background', 'background_exc']
+for fg_type in fg_bg:
+    for k in keys_to_copy:
+        logging.info('copying ' + fg_type + '/' + k)
+        pycbc.io.combine_and_copy(f, files, fg_type + '/' + k)
+
+pycbc.io.combine_and_copy(f, files, 'foreground/ifar')
+pycbc.io.combine_and_copy(f, files, 'foreground/ifar_exc')
+
+logging.info('Collating triggers into single structure')
+
+all_trig_times = {}
+all_trig_ids = {}
+for ifo in all_ifos:
+    all_trig_times[ifo] = np.array([], dtype=np.uint32)
+    all_trig_ids[ifo] = np.array([], dtype=np.uint32)
+
+# For each file, append the trigger time and id data for each ifo
+# If an ifo does not participate in any given coinc then fill with -1 values
+for f_in in files:
+    key = f_in.attrs['ifos'].replace(' ','')
+    for ifo in all_ifos:
+        if ifo in f_in['foreground']:
+            all_trig_times[ifo] = np.concatenate([all_trig_times[ifo], \
+                                    f_in['foreground/{}/time'.format(ifo)][:]])
+            all_trig_ids[ifo] = np.concatenate([all_trig_ids[ifo],
+                              f_in['foreground/{}/trigger_id'.format(ifo)][:]])
+        else:
+            all_trig_times[ifo] = np.concatenate([all_trig_times[ifo],
+                                 -1*np.ones_like(f_in['foreground/fap'][:],
+                                                    dtype=np.uint32)])
+            all_trig_ids[ifo] = np.concatenate([all_trig_ids[ifo],
+                                 -1*np.ones_like(f_in['foreground/fap'][:],
+                                                    dtype=np.uint32)])
+
+# implement a list of the key which each trigger comes from
+logging.info('Adding column to output of the ifo combination used '
+             'for each trigger')
+for f_in in files:
+    key = f_in.attrs['ifos'].replace(' ','')
+    for fg_type in fg_bg:
+        type_combo_key = fg_type + '/ifo_combination'
+        combo_repeat = np.array(np.repeat(key.encode('utf8'),
+                                          f_in[fg_type + '/stat'].size))
+        if type_combo_key in f:
+            ifo_comb_fg_type = f[type_combo_key][:]
+            del f[type_combo_key]
+            ifo_comb_fg_type = np.concatenate([ifo_comb_fg_type, combo_repeat])
+        else:
+            ifo_comb_fg_type = combo_repeat
+	f[type_combo_key]=ifo_comb_fg_type
+
+del ifo_comb_fg_type, combo_repeat
+
+logging.info('Working out which ifo combinations are available for each '
+             'coincidence')
+clustered_times = (all_trig_times[ifo] for ifo in all_ifos)
+test_times = np.array([pycbc.events.mean_if_greater_than_zero(tc)[0]
+                          for tc in zip(*clustered_times)])
+for ifo in all_ifos:
+    f['foreground/{}/time'.format(ifo)] = all_trig_times[ifo]
+    f['foreground/{}/trigger_id'.format(ifo)] = all_trig_ids[ifo]
+
+is_in_combo_time = {}
+for key in f['segments']:
+    is_in_combo_time[key] = np.zeros_like(f['foreground/decimation_factor'][:])
+    if key.startswith('foreground') or key.startswith('background'):
+        continue
+    end_times = np.array(f['segments/%s/end' % key][:])
+    start_times = np.array(f['segments/%s/start' % key][:])
+    idx_within_segment = pycbc.events.indices_within_times(test_times,
+                                                           start_times,
+                                                           end_times)
+    is_in_combo_time[key][idx_within_segment] += np.ones_like(idx_within_segment)
+del idx_within_segment
+
+all_indices = np.arange(f['foreground/decimation_factor'].size)
+available_combos =[' '.join(sorted([key for key in is_in_combo_time if is_in_combo_time[key][i]])).encode('utf8') for i in all_indices]
+del all_indices
+f['foreground/available_combinations'] = available_combos
+
+all_combo_types = np.unique(available_combos)
+idx = {ct:np.where(np.array(available_combos)==ct)[0]
+       for ct in all_combo_types}
+
+del available_combos
+
+logging.info('Finding indices of which background events are from which detector combination')
+where_combo = {ifo_c:np.where(f['background/ifo_combination'][:]==ifo_c)[0]
+               for ifo_c in f['segments'] if ifo_c is not 'foreground_veto'}
+
+logging.info('Recalculating ifar according to summed trigger distributions')
+
+fg_ifar = np.zeros_like(f['foreground/decimation_factor'][:])
+fg_ifar_exc = np.zeros_like(f['foreground/decimation_factor'][:])
+
+for ct in all_combo_types:
+    cts = ct.split(' ')
+    if len(cts) == 1:
+        logging.info('copying over triggers which are only in {} time'.format(cts[0]))
+        # If only one combination is available, then the stat is the same
+        # as previously calulated
+        fg_ifar[idx[ct]] = f['foreground/ifar'][:][idx[ct]]
+        fg_ifar_exc[idx[ct]] = f['foreground/ifar_exc'][:][idx[ct]]
+        continue
+    logging.info('recalculating ifar for coincidences which are in {} time'.format(cts))
+    largest_combination = cts[np.argmax([len(ifo_c) for ifo_c in cts])]
+    bg_time = f[largest_combination].attrs['background_time']
+    bg_time_exc = f[largest_combination].attrs['background_time_exc']
+    inc_bg_list = [where_combo[ifo_c] for ifo_c in cts]
+    logging.info('itertools chain bit:')
+    inc_bg = list(itertools.chain(*inc_bg_list))
+    logging.info('chain done')
+    logging.info('fnlouder bit:')
+    inc_bg_exc_list = [np.where(f['background_exc/ifo_combination'][:]==ifo_c)[0]
+                          for ifo_c in cts]
+    inc_bg_exc = list(itertools.chain(*inc_bg_exc_list))
+    _, fnlouder = coinc.calculate_n_louder(f['background/stat'][:][inc_bg],
+                                           f['foreground/stat'][:][idx[ct]],
+                                           f['background/decimation_factor'][:][inc_bg])
+    _, fnlouder_exc = coinc.calculate_n_louder(f['background_exc/stat'][:][inc_bg_exc],
+                                               f['foreground/stat'][:][idx[ct]],
+                                               f['background_exc/decimation_factor'][:][inc_bg_exc])
+    logging.info('fnlouder done. ifar bit:')
+    ifar = bg_time / (fnlouder + 1)
+    ifar_exc = bg_time_exc / (fnlouder_exc + 1)
+    fg_ifar[idx[ct]] = conv.sec_to_year(ifar)
+    fg_ifar_exc[idx[ct]] = conv.sec_to_year(ifar_exc)
+    logging.info('ifar done')
+
+f['foreground/ifar'][:] = fg_ifar
+f['foreground/fap'] = 1 - np.exp(-f.attrs['foreground_time'] / fg_ifar)
+f['foreground/ifar_exc'][:] = fg_ifar_exc
+f['foreground/fap_exc'] = 1 - np.exp(-f.attrs['foreground_time_exc'] / fg_ifar_exc)
+
+
+logging.info('Copying foreground and background template_id and trigger_id')
+keys_to_copy = ['template_id','timeslide_id']
+for fg_type in fg_bg:
+    for k in keys_to_copy:
+        logging.info('copying ' + fg_type + '/' + k)
+        pycbc.io.combine_and_copy(f, files, fg_type + '/' + k)
+
+ifar_stat = np.core.records.fromarrays([f['foreground/ifar'][:],
+                                           f['foreground/stat'][:]],
+                                          names='ifar,stat')
+
+# all_times is a tuple of trigger time arrays
+all_times = (f['foreground/%s/time' % ifo][:] for ifo in all_ifos)
+
+def argmax(v):
+    return np.argsort(v)[-1]
+
+# Currently only clustering zerolag, i.e. foreground, so set all timeslide_ids
+# to zero
+cidx = pycbc.events.cluster_coincs_multiifo(ifar_stat, all_times,
+                                            np.zeros(len(ifar_stat)), 0,
+                                            args.cluster_window, argmax)
+
+def filter_dataset(h5file, name, idx):
+    # Dataset needs to be deleted and remade as it is a different size
+    filtered_dset = h5file[name][:][idx]
+    del h5file[name]
+    h5file[name] = filtered_dset
+
+# Downsample the foreground columns to only the loudest ifar between the
+# multiple files
+for key in f['foreground'].keys():
+    if key not in all_ifos:
+        filter_dataset(f, 'foreground/%s' % key, cidx)
+    else:  # key is an ifo
+        for k in f['foreground/%s' % key].keys():
+            filter_dataset(f, 'foreground/{}/{}'.format(key, k), cidx)
+
+
+f.close()
+logging.info('done')

--- a/bin/hdfcoinc/pycbc_multiifo_add_statmap
+++ b/bin/hdfcoinc/pycbc_multiifo_add_statmap
@@ -1,27 +1,28 @@
 #!/bin/env python
-""" Reduce IFAR for coincidences in times with more than one ifo combination
-available. Cluster for best IFAR. This clusters to find the most
-significant foreground, but leaves the background triggers alone.
+""" Calculate total FAR based on statistic ranking for coincidences in times
+with more than one ifo combination available. Cluster to keep coincs with the
+highest stat value . This clusters to find the most significant foreground,
+but leaves the background triggers alone.
 """
 
-import h5py, numpy as np, argparse, logging, pycbc, pycbc.events, pycbc.io, lal
+import h5py, numpy as np, argparse, logging, pycbc, pycbc.events, pycbc.io
 import pycbc.version
 import pycbc.conversions as conv
 from pycbc.events import coinc
 from ligo import segments
-import itertools
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--version", action="version", version=pycbc.version.git_verbose_msg)
 parser.add_argument('--verbose', action='store_true')
 parser.add_argument('--statmap-files', nargs='+',
-                    help="List of coinc files to be redistributed")
+                    help="List of coinc files to be combined")
 parser.add_argument('--censor-ifar-threshold', type=float, default=0.003,
     help="If provided, only window out foreground triggers with IFAR (years)"
          "above the threshold [default=0.003yr]")
 parser.add_argument('--veto-window', type=float, default=0.1,
     help="Time around each zerolag trigger to window out [default=.1s]")
-parser.add_argument('--cluster-window', type=float)
+parser.add_argument('--cluster-window', type=float,
+    help="Maximum time interval to cluster coincident events")
 parser.add_argument('--output-file', help="name of output file")
 args = parser.parse_args()
 
@@ -58,12 +59,11 @@ logging.info('Combining foreground segments')
 # Convert segmentlistdict to a list ('seglists') of segmentlists
 # then np.sum(seglists, axis=0) does seglists[0] + seglists[1] + ...
 foreground_segs = np.sum(list(indiv_segs.values()), axis=0)
+f.attrs['foreground_time'] = abs(foreground_segs)
+
 # obtain list of all ifos involved in the coinc_statmap files
 all_ifos = np.unique([ifo for fi in files
                       for ifo in fi.attrs['ifos'].split(' ')])
-
-# output to file
-f.attrs['foreground_time'] = abs(foreground_segs)
 
 logging.info('Copying foreground datasets')
 for k in files[0]['foreground']:
@@ -105,11 +105,11 @@ logging.info('{} triggers'.format(n_triggers))
 # all_times is a tuple of trigger time arrays
 all_times = (f['foreground/%s/time' % ifo][:] for ifo in all_ifos)
 
-# Currently only clustering zerolag, i.e. foreground, so set all timeslide_ids
-# to zero
+# Cluster by statistic value. Currently only clustering zerolag,
+# i.e. foreground, so set all timeslide_ids to zero
 cidx = pycbc.events.cluster_coincs_multiifo(f['foreground/stat'][:], all_times,
                                             np.zeros(n_triggers), 0,
-                                            args.cluster_window, argmax=np.argmax)
+                                            args.cluster_window)
 
 
 def filter_dataset(h5file, name, idx):
@@ -129,6 +129,7 @@ for key in f['foreground'].keys():
 
 n_triggers = f['foreground/ifar'].size
 
+# Calculating event times to determine which types of coinc are available
 times_tuple = (f['foreground/{}/time'.format(ifo)] for ifo in all_ifos)
 test_times = np.array([pycbc.events.mean_if_greater_than_zero(tc)[0]
                           for tc in zip(*times_tuple)])
@@ -146,7 +147,11 @@ for key in f['segments']:
     is_in_combo_time[key][idx_within_segment] = np.ones_like(idx_within_segment)
 del idx_within_segment
 
-available_combos =[' '.join(sorted([key for key in is_in_combo_time if is_in_combo_time[key][i]])).encode('utf8') for i in np.arange(n_triggers)]
+# available_combos is a string containing a space-separated list of which
+# interferometer combinations are available at the time of coincidence
+available_combos =[' '.join(sorted([key for key in is_in_combo_time 
+                                    if is_in_combo_time[key][i]])
+                           ).encode('utf8') for i in np.arange(n_triggers)]
 
 all_combo_types = np.unique(available_combos)
 idx = {ct:np.where(np.array(available_combos)==ct)[0]
@@ -154,7 +159,7 @@ idx = {ct:np.where(np.array(available_combos)==ct)[0]
 
 del available_combos
 
-logging.info('Calculating n_louder background triggers in each type for all foreground events')
+logging.info('Calculating false alarm rate over all coinc types for foreground events')
 
 far = {}
 far_exc = {}
@@ -169,27 +174,23 @@ for f_in in files:
                                                    f_in['background_exc/decimation_factor'][:])
         far_exc[ifo_combo_key] = (fnlouder_exc + 1) / f_in.attrs['background_time_exc']
 
-logging.info('Recalculating ifar according to summed trigger distributions')
-
-fg_ifar = np.zeros_like(f['foreground/decimation_factor'][:])
-fg_ifar_exc = np.zeros_like(f['foreground/decimation_factor'][:])
+fg_ifar = np.zeros(n_triggers)
+fg_ifar_exc = np.zeros(n_triggers)
 
 for ct in all_combo_types:
     cts = ct.split(' ')
     if len(cts) == 1:
-        logging.info('Copying over triggers which are only in {} time'.format(ct))
+        logging.info('IFAR is the same as previosuly calculated for triggers in {} time'.format(ct))
         # If only one combination is available, then the stat is the same
         # as previously calulated
         fg_ifar[idx[ct]] = f['foreground/ifar'][:][idx[ct]]
         fg_ifar_exc[idx[ct]] = f['foreground/ifar_exc'][:][idx[ct]]
-        continue
-    logging.info('Recalculating ifar for coincidences which are in {} time'.format(ct))
-    far_new = np.sum([far[ifo_combo_key][idx[ct]] for ifo_combo_key in cts], axis=0)
-    far_new_exc = np.sum([far_exc[ifo_combo_key][idx[ct]] for ifo_combo_key in cts], axis=0)
-    ifar = 1 / np.array(far_new)
-    ifar_exc = 1 / np.array(far_new_exc)
-    fg_ifar[idx[ct]] = conv.sec_to_year(ifar)
-    fg_ifar_exc[idx[ct]] = conv.sec_to_year(ifar_exc)
+    else:
+        logging.info('Recalculating ifar for coincidences which are in {} time'.format(ct))
+        far_new = np.sum([far[ifo_combo_key][idx[ct]] for ifo_combo_key in cts], axis=0)
+        far_new_exc = np.sum([far_exc[ifo_combo_key][idx[ct]] for ifo_combo_key in cts], axis=0)
+        fg_ifar[idx[ct]] = conv.sec_to_year(1. / np.array(far_new))
+        fg_ifar_exc[idx[ct]] = conv.sec_to_year(1. / np.array(far_new_exc))
 
 f.attrs['foreground_time_exc'] = f.attrs['foreground_time']
 

--- a/bin/hdfcoinc/pycbc_multiifo_add_statmap
+++ b/bin/hdfcoinc/pycbc_multiifo_add_statmap
@@ -1,5 +1,6 @@
 #!/bin/env python
-""" This clusters to find the most
+""" Reduce IFAR for coincidences in times with more than one ifo combination
+available. Cluster for best IFAR. This clusters to find the most
 significant foreground, but leaves the background triggers alone.
 """
 
@@ -16,11 +17,6 @@ parser.add_argument('--verbose', action='store_true')
 parser.add_argument('--statmap-files', nargs='+',
                     help="List of coinc files to be redistributed")
 parser.add_argument('--cluster-window', type=float)
-parser.add_argument('-ranking-statistic', type=str,
-                    help='Ranking statistic used to calculate stat and ifar '
-                          'in previous codes, this is used to test whether '
-                          'the background distributions can be safely '
-                          'combined. Default=Not safe')
 parser.add_argument('--output-file', help="name of output file")
 args = parser.parse_args()
 
@@ -49,12 +45,10 @@ for fi in files:
                  f.create_group(key)
             f[key].attrs[attr_name] = fi.attrs[attr_name]
 
-logging.info('combining foreground and foreground excluded segments')
+logging.info('Combining foreground and foreground excluded segments')
 # Set up dictionaries to contain segments from the individual statmap files
 indiv_segs = segments.segmentlistdict({})
-indiv_segs_fg_exc = segments.segmentlistdict({})
 
-any_fg_vetoes = False
 # loop through statmap files and put segments into segmentlistdicts
 for fi in files:
     key = fi.attrs['ifos'].replace(' ','')
@@ -62,17 +56,6 @@ for fi in files:
     starts = fi['segments/{}/start'.format(key)][:]
     ends = fi['segments/{}/end'.format(key)][:]
     indiv_segs[key] = pycbc.events.veto.start_end_to_segments(starts, ends)
-    # get the foreground_vetoed times from individual statmap files
-    if 'foreground_veto' in fi['segments']:
-        any_fg_vetoes = True
-        remove_start_time = fi['segments/foreground_veto/start'][:]
-        remove_end_time = fi['segments/foreground_veto/end'][:]
-        vetoed_segs = pycbc.events.veto.start_end_to_segments(remove_start_time,
-                                                          remove_end_time)
-        # remove from analysis segments
-        indiv_segs_fg_exc[key] = indiv_segs[key] - vetoed_segs
-
-del remove_end_time, remove_start_time, vetoed_segs
 
 # Convert segmentlistdict to a list ('seglists') of segmentlists
 # then np.sum(seglists, axis=0) does seglists[0] + seglists[1] + ...
@@ -81,41 +64,20 @@ foreground_segs = np.sum(list(indiv_segs.values()), axis=0)
 all_ifos = np.unique([ifo for fi in files
                       for ifo in fi.attrs['ifos'].split(' ')])
 
-all_ifo_key = ''.join(all_ifos)
-
-# Note that 'exclusive' time only removes windows around coincs
-# that involve *all* active ifos (2 in 2-ifo time, 3 in 3-ifo time etc.)
-if any_fg_vetoes:
-    foreground_segs_exc = np.sum(list(indiv_segs_fg_exc.values()), axis=0)
-
-    # output foreground veto starts and ends to file
-    foreground_vetos_start, foreground_vetos_end = \
-                   pycbc.events.veto.segments_to_start_end(foreground_segs - \
-                                                           foreground_segs_exc)
-
-    f['segments/foreground_veto/start'] = foreground_vetos_start
-    f['segments/foreground_veto/end'] = foreground_vetos_end
-
 # output to file
 f.attrs['foreground_time'] = abs(foreground_segs)
-if any_fg_vetoes:
-    f.attrs['foreground_time_exc'] = abs(foreground_segs_exc)
-else:
-    f.attrs['foreground_time_exc'] = f.attrs['foreground_time']
 
-# Save the ifo list for future reference
-f.attrs['ifos'] = ' '.join(sorted(all_ifos))
-
-logging.info('Copying stat and decimation_factor')
+logging.info('Copying foreground & background common datasets')
 keys_to_copy = ['decimation_factor', 'stat']
 fg_bg = ['foreground','background', 'background_exc']
 for fg_type in fg_bg:
     for k in keys_to_copy:
-        logging.info('copying ' + fg_type + '/' + k)
         pycbc.io.combine_and_copy(f, files, fg_type + '/' + k)
 
-pycbc.io.combine_and_copy(f, files, 'foreground/ifar')
-pycbc.io.combine_and_copy(f, files, 'foreground/ifar_exc')
+fg_only_keys_to_copy = ['template_id','timeslide_id', 'ifar', 'ifar_exc']
+logging.info('Copying foreground-only datasets')
+for k in fg_only_keys_to_copy:
+    pycbc.io.combine_and_copy(f, files, 'foreground/' + k)
 
 logging.info('Collating triggers into single structure')
 
@@ -128,7 +90,6 @@ for ifo in all_ifos:
 # For each file, append the trigger time and id data for each ifo
 # If an ifo does not participate in any given coinc then fill with -1 values
 for f_in in files:
-    key = f_in.attrs['ifos'].replace(' ','')
     for ifo in all_ifos:
         if ifo in f_in['foreground']:
             all_trig_times[ifo] = np.concatenate([all_trig_times[ifo], \
@@ -143,117 +104,43 @@ for f_in in files:
                                  -1*np.ones_like(f_in['foreground/fap'][:],
                                                     dtype=np.uint32)])
 
-# implement a list of the key which each trigger comes from
-logging.info('Adding column to output of the ifo combination used '
-             'for each trigger')
-for f_in in files:
-    key = f_in.attrs['ifos'].replace(' ','')
-    for fg_type in fg_bg:
-        type_combo_key = fg_type + '/ifo_combination'
-        combo_repeat = np.array(np.repeat(key.encode('utf8'),
-                                          f_in[fg_type + '/stat'].size))
-        if type_combo_key in f:
-            ifo_comb_fg_type = f[type_combo_key][:]
-            del f[type_combo_key]
-            ifo_comb_fg_type = np.concatenate([ifo_comb_fg_type, combo_repeat])
-        else:
-            ifo_comb_fg_type = combo_repeat
-	f[type_combo_key]=ifo_comb_fg_type
-
-del ifo_comb_fg_type, combo_repeat
-
-logging.info('Working out which ifo combinations are available for each '
-             'coincidence')
-clustered_times = (all_trig_times[ifo] for ifo in all_ifos)
-test_times = np.array([pycbc.events.mean_if_greater_than_zero(tc)[0]
-                          for tc in zip(*clustered_times)])
 for ifo in all_ifos:
     f['foreground/{}/time'.format(ifo)] = all_trig_times[ifo]
     f['foreground/{}/trigger_id'.format(ifo)] = all_trig_ids[ifo]
 
-is_in_combo_time = {}
-for key in f['segments']:
-    is_in_combo_time[key] = np.zeros_like(f['foreground/decimation_factor'][:])
-    if key.startswith('foreground') or key.startswith('background'):
-        continue
-    end_times = np.array(f['segments/%s/end' % key][:])
-    start_times = np.array(f['segments/%s/start' % key][:])
-    idx_within_segment = pycbc.events.indices_within_times(test_times,
-                                                           start_times,
-                                                           end_times)
-    is_in_combo_time[key][idx_within_segment] += np.ones_like(idx_within_segment)
-del idx_within_segment
+logging.info('Getting ifo combination information for each coincidence')
+for f_in in files:
+    key = f_in.attrs['ifos'].replace(' ','')
 
-all_indices = np.arange(f['foreground/decimation_factor'].size)
-available_combos =[' '.join(sorted([key for key in is_in_combo_time if is_in_combo_time[key][i]])).encode('utf8') for i in all_indices]
-del all_indices
-f['foreground/available_combinations'] = available_combos
+    for fg_type in fg_bg:
+        ifo_combo_key = fg_type + '/ifo_combination'
+        fg_comb_repeat = np.array(np.repeat(key.encode('utf8'),
+                                            f_in[fg_type + '/stat'].size))
+        if ifo_combo_key in f:
+            ifo_comb_fg = f[ifo_combo_key][:]
+            del f[ifo_combo_key]
+            ifo_comb_fg = np.concatenate([ifo_comb_fg, fg_comb_repeat])
+        else:
+            ifo_comb_fg = fg_comb_repeat
 
-all_combo_types = np.unique(available_combos)
-idx = {ct:np.where(np.array(available_combos)==ct)[0]
-       for ct in all_combo_types}
+        f[ifo_combo_key]=ifo_comb_fg
 
-del available_combos
+del fg_comb_repeat, ifo_comb_fg
+
+logging.info('Working available ifo combinations are available for each '
+             'coincidence')
 
 logging.info('Finding indices of which background events are from which detector combination')
+
 where_combo = {ifo_c:np.where(f['background/ifo_combination'][:]==ifo_c)[0]
                for ifo_c in f['segments'] if ifo_c is not 'foreground_veto'}
+where_combo_exc = {ifo_c:np.where(f['background_exc/ifo_combination'][:]==ifo_c)[0]
+               for ifo_c in f['segments'] if ifo_c is not 'foreground_veto'}
 
-logging.info('Recalculating ifar according to summed trigger distributions')
-
-fg_ifar = np.zeros_like(f['foreground/decimation_factor'][:])
-fg_ifar_exc = np.zeros_like(f['foreground/decimation_factor'][:])
-
-for ct in all_combo_types:
-    cts = ct.split(' ')
-    if len(cts) == 1:
-        logging.info('copying over triggers which are only in {} time'.format(cts[0]))
-        # If only one combination is available, then the stat is the same
-        # as previously calulated
-        fg_ifar[idx[ct]] = f['foreground/ifar'][:][idx[ct]]
-        fg_ifar_exc[idx[ct]] = f['foreground/ifar_exc'][:][idx[ct]]
-        continue
-    logging.info('recalculating ifar for coincidences which are in {} time'.format(cts))
-    largest_combination = cts[np.argmax([len(ifo_c) for ifo_c in cts])]
-    bg_time = f[largest_combination].attrs['background_time']
-    bg_time_exc = f[largest_combination].attrs['background_time_exc']
-    inc_bg_list = [where_combo[ifo_c] for ifo_c in cts]
-    logging.info('itertools chain bit:')
-    inc_bg = list(itertools.chain(*inc_bg_list))
-    logging.info('chain done')
-    logging.info('fnlouder bit:')
-    inc_bg_exc_list = [np.where(f['background_exc/ifo_combination'][:]==ifo_c)[0]
-                          for ifo_c in cts]
-    inc_bg_exc = list(itertools.chain(*inc_bg_exc_list))
-    _, fnlouder = coinc.calculate_n_louder(f['background/stat'][:][inc_bg],
-                                           f['foreground/stat'][:][idx[ct]],
-                                           f['background/decimation_factor'][:][inc_bg])
-    _, fnlouder_exc = coinc.calculate_n_louder(f['background_exc/stat'][:][inc_bg_exc],
-                                               f['foreground/stat'][:][idx[ct]],
-                                               f['background_exc/decimation_factor'][:][inc_bg_exc])
-    logging.info('fnlouder done. ifar bit:')
-    ifar = bg_time / (fnlouder + 1)
-    ifar_exc = bg_time_exc / (fnlouder_exc + 1)
-    fg_ifar[idx[ct]] = conv.sec_to_year(ifar)
-    fg_ifar_exc[idx[ct]] = conv.sec_to_year(ifar_exc)
-    logging.info('ifar done')
-
-f['foreground/ifar'][:] = fg_ifar
-f['foreground/fap'] = 1 - np.exp(-f.attrs['foreground_time'] / fg_ifar)
-f['foreground/ifar_exc'][:] = fg_ifar_exc
-f['foreground/fap_exc'] = 1 - np.exp(-f.attrs['foreground_time_exc'] / fg_ifar_exc)
-
-
-logging.info('Copying foreground and background template_id and trigger_id')
-keys_to_copy = ['template_id','timeslide_id']
-for fg_type in fg_bg:
-    for k in keys_to_copy:
-        logging.info('copying ' + fg_type + '/' + k)
-        pycbc.io.combine_and_copy(f, files, fg_type + '/' + k)
-
+logging.info('{} triggers'.format(f['foreground/ifar'].size))
 ifar_stat = np.core.records.fromarrays([f['foreground/ifar'][:],
-                                           f['foreground/stat'][:]],
-                                          names='ifar,stat')
+                                        f['foreground/stat'][:]],
+                                        names='ifar,stat')
 
 # all_times is a tuple of trigger time arrays
 all_times = (f['foreground/%s/time' % ifo][:] for ifo in all_ifos)
@@ -282,6 +169,82 @@ for key in f['foreground'].keys():
         for k in f['foreground/%s' % key].keys():
             filter_dataset(f, 'foreground/{}/{}'.format(key, k), cidx)
 
+times_tuple = (f['foreground/{}/time'.format(ifo)] for ifo in all_ifos)
+test_times = np.array([pycbc.events.mean_if_greater_than_zero(tc)[0]
+                          for tc in zip(*times_tuple)])
+
+is_in_combo_time = {}
+for key in f['segments']:
+    is_in_combo_time[key] = np.zeros_like(f['foreground/decimation_factor'][:])
+    if key.startswith('foreground') or key.startswith('background'):
+        continue
+    end_times = np.array(f['segments/%s/end' % key][:])
+    start_times = np.array(f['segments/%s/start' % key][:])
+    idx_within_segment = pycbc.events.indices_within_times(test_times,
+                                                           start_times,
+                                                           end_times)
+    is_in_combo_time[key][idx_within_segment] += np.ones_like(idx_within_segment)
+del idx_within_segment
+
+
+all_indices = np.arange(f['foreground/decimation_factor'].size)
+available_combos =[' '.join(sorted([key for key in is_in_combo_time if is_in_combo_time[key][i]])).encode('utf8') for i in all_indices]
+del all_indices
+f['foreground/available_combinations'] = available_combos
+
+all_combo_types = np.unique(available_combos)
+idx = {ct:np.where(np.array(available_combos)==ct)[0]
+       for ct in all_combo_types}
+
+del available_combos
+
+logging.info('Recalculating ifar according to summed trigger distributions')
+
+fg_ifar = np.zeros_like(f['foreground/decimation_factor'][:])
+fg_ifar_exc = np.zeros_like(f['foreground/decimation_factor'][:])
+
+for ct in all_combo_types:
+    cts = ct.split(' ')
+    if len(cts) == 1:
+        logging.info('Copying over triggers which are only in {} time'.format(ct))
+        # If only one combination is available, then the stat is the same
+        # as previously calulated
+        fg_ifar[idx[ct]] = f['foreground/ifar'][:][idx[ct]]
+        fg_ifar_exc[idx[ct]] = f['foreground/ifar_exc'][:][idx[ct]]
+        continue
+    logging.info('Recalculating ifar for coincidences which are in {} time'.format(ct))
+    largest_combination = cts[np.argmax([len(ifo_c) for ifo_c in cts])]
+    bg_time = f[largest_combination].attrs['background_time']
+    bg_time_exc = f[largest_combination].attrs['background_time_exc']
+    inc_bg_list = [where_combo[ifo_c] for ifo_c in cts]
+    inc_bg = list(itertools.chain(*inc_bg_list))
+    inc_bg_exc_list = [where_combo_exc[ifo_c] for ifo_c in cts]
+    inc_bg_exc = list(itertools.chain(*inc_bg_exc_list))
+    _, fnlouder = coinc.calculate_n_louder(f['background/stat'][:][inc_bg],
+                                           f['foreground/stat'][:][idx[ct]],
+                                           f['background/decimation_factor'][:][inc_bg])
+    _, fnlouder_exc = coinc.calculate_n_louder(
+                          f['background_exc/stat'][:][inc_bg_exc],
+                          f['foreground/stat'][:][idx[ct]],
+                          f['background_exc/decimation_factor'][:][inc_bg_exc]
+                                              )
+    ifar = bg_time / (fnlouder + 1)
+    ifar_exc = bg_time_exc / (fnlouder_exc + 1)
+    fg_ifar[idx[ct]] = conv.sec_to_year(ifar)
+    fg_ifar_exc[idx[ct]] = conv.sec_to_year(ifar_exc)
+
+for bg_type in ['background', 'background_exc']:
+    for k in ['stat','decimation_factor', 'ifo_combination']:
+        print(bg_type + '/' + k)
+        if bg_type + '/' + k in f:
+            print('deleting')
+            del f[bg_type + '/' + k]
+        else: print('not deleting')
+
+f['foreground/ifar'][:] = fg_ifar
+f['foreground/fap'] = 1 - np.exp(-f.attrs['foreground_time'] / fg_ifar)
+f['foreground/ifar_exc'][:] = fg_ifar_exc
+f['foreground/fap_exc'] = 1 - np.exp(-f.attrs['foreground_time_exc'] / fg_ifar_exc)
 
 f.close()
-logging.info('done')
+logging.info('Done!')

--- a/bin/hdfcoinc/pycbc_multiifo_add_statmap
+++ b/bin/hdfcoinc/pycbc_multiifo_add_statmap
@@ -16,6 +16,11 @@ parser.add_argument("--version", action="version", version=pycbc.version.git_ver
 parser.add_argument('--verbose', action='store_true')
 parser.add_argument('--statmap-files', nargs='+',
                     help="List of coinc files to be redistributed")
+parser.add_argument('--censor-ifar-threshold', type=float, default=0.003,
+    help="If provided, only window out foreground triggers with IFAR (years)"
+         "above the threshold [default=0.003yr]")
+parser.add_argument('--veto-window', type=float, default=0.1,
+    help="Time around each zerolag trigger to window out [default=.1s]")
 parser.add_argument('--cluster-window', type=float)
 parser.add_argument('--output-file', help="name of output file")
 args = parser.parse_args()
@@ -28,34 +33,27 @@ f = h5py.File(args.output_file, "w")
 
 logging.info('Copying segments and attributes to %s' % args.output_file)
 # Move segments information into the final file - remove some duplication
-# in earlier files
-for fi in files:
-    for key in fi['segments']:
-        if key.startswith('foreground') or key.startswith('background'):
-            continue
-        f['segments/%s/end' % key] = fi['segments/%s/end' % key][:]
-        f['segments/%s/start' % key] = fi['segments/%s/start' % key][:]
-        if 'segments/foreground_veto' in fi:
-            f['segments/%s/foreground_veto/end' % key] = \
-                                         fi['segments/foreground_veto/end'][:]
-            f['segments/%s/foreground_veto/start' % key] = \
-                                       fi['segments/foreground_veto/start'][:]
-        for attr_name in fi.attrs:
-            if key not in f:
-                 f.create_group(key)
-            f[key].attrs[attr_name] = fi.attrs[attr_name]
-
-logging.info('Combining foreground and foreground excluded segments')
-# Set up dictionaries to contain segments from the individual statmap files
+# in earlier files. Also set up dictionaries to contain segments from the
+# individual statmap files
 indiv_segs = segments.segmentlistdict({})
-
-# loop through statmap files and put segments into segmentlistdicts
 for fi in files:
     key = fi.attrs['ifos'].replace(' ','')
-    # get analysed segments from individual statmap files
     starts = fi['segments/{}/start'.format(key)][:]
     ends = fi['segments/{}/end'.format(key)][:]
     indiv_segs[key] = pycbc.events.veto.start_end_to_segments(starts, ends)
+    f['segments/{}/start'.format(key)] = starts
+    f['segments/{}/end'.format(key)] = ends
+    if 'segments/foreground_veto' in fi:
+        f['segments/%s/foreground_veto/end' % key] = \
+                                         fi['segments/foreground_veto/end'][:]
+        f['segments/%s/foreground_veto/start' % key] = \
+                                       fi['segments/foreground_veto/start'][:]
+    for attr_name in fi.attrs:
+        if key not in f:
+            f.create_group(key)
+        f[key].attrs[attr_name] = fi.attrs[attr_name]
+
+logging.info('Combining foreground segments')
 
 # Convert segmentlistdict to a list ('seglists') of segmentlists
 # then np.sum(seglists, axis=0) does seglists[0] + seglists[1] + ...
@@ -67,17 +65,10 @@ all_ifos = np.unique([ifo for fi in files
 # output to file
 f.attrs['foreground_time'] = abs(foreground_segs)
 
-logging.info('Copying foreground & background common datasets')
-keys_to_copy = ['decimation_factor', 'stat']
-fg_bg = ['foreground','background', 'background_exc']
-for fg_type in fg_bg:
-    for k in keys_to_copy:
-        pycbc.io.combine_and_copy(f, files, fg_type + '/' + k)
-
-fg_only_keys_to_copy = ['template_id','timeslide_id', 'ifar', 'ifar_exc']
-logging.info('Copying foreground-only datasets')
-for k in fg_only_keys_to_copy:
-    pycbc.io.combine_and_copy(f, files, 'foreground/' + k)
+logging.info('Copying foreground datasets')
+for k in files[0]['foreground']:
+    if not k.startswith('fap') and k not in all_ifos:
+        pycbc.io.combine_and_copy(f, files, 'foreground/' + k)
 
 logging.info('Collating triggers into single structure')
 
@@ -108,51 +99,18 @@ for ifo in all_ifos:
     f['foreground/{}/time'.format(ifo)] = all_trig_times[ifo]
     f['foreground/{}/trigger_id'.format(ifo)] = all_trig_ids[ifo]
 
-logging.info('Getting ifo combination information for each coincidence')
-for f_in in files:
-    key = f_in.attrs['ifos'].replace(' ','')
-
-    for fg_type in fg_bg:
-        ifo_combo_key = fg_type + '/ifo_combination'
-        fg_comb_repeat = np.array(np.repeat(key.encode('utf8'),
-                                            f_in[fg_type + '/stat'].size))
-        if ifo_combo_key in f:
-            ifo_comb_fg = f[ifo_combo_key][:]
-            del f[ifo_combo_key]
-            ifo_comb_fg = np.concatenate([ifo_comb_fg, fg_comb_repeat])
-        else:
-            ifo_comb_fg = fg_comb_repeat
-
-        f[ifo_combo_key]=ifo_comb_fg
-
-del fg_comb_repeat, ifo_comb_fg
-
-logging.info('Working available ifo combinations are available for each '
-             'coincidence')
-
-logging.info('Finding indices of which background events are from which detector combination')
-
-where_combo = {ifo_c:np.where(f['background/ifo_combination'][:]==ifo_c)[0]
-               for ifo_c in f['segments'] if ifo_c is not 'foreground_veto'}
-where_combo_exc = {ifo_c:np.where(f['background_exc/ifo_combination'][:]==ifo_c)[0]
-               for ifo_c in f['segments'] if ifo_c is not 'foreground_veto'}
-
-logging.info('{} triggers'.format(f['foreground/ifar'].size))
-ifar_stat = np.core.records.fromarrays([f['foreground/ifar'][:],
-                                        f['foreground/stat'][:]],
-                                        names='ifar,stat')
+n_triggers = f['foreground/ifar'].size
+logging.info('{} triggers'.format(n_triggers))
 
 # all_times is a tuple of trigger time arrays
 all_times = (f['foreground/%s/time' % ifo][:] for ifo in all_ifos)
 
-def argmax(v):
-    return np.argsort(v)[-1]
-
 # Currently only clustering zerolag, i.e. foreground, so set all timeslide_ids
 # to zero
-cidx = pycbc.events.cluster_coincs_multiifo(ifar_stat, all_times,
-                                            np.zeros(len(ifar_stat)), 0,
-                                            args.cluster_window, argmax)
+cidx = pycbc.events.cluster_coincs_multiifo(f['foreground/stat'][:], all_times,
+                                            np.zeros(n_triggers), 0,
+                                            args.cluster_window, argmax=np.argmax)
+
 
 def filter_dataset(h5file, name, idx):
     # Dataset needs to be deleted and remade as it is a different size
@@ -169,13 +127,15 @@ for key in f['foreground'].keys():
         for k in f['foreground/%s' % key].keys():
             filter_dataset(f, 'foreground/{}/{}'.format(key, k), cidx)
 
+n_triggers = f['foreground/ifar'].size
+
 times_tuple = (f['foreground/{}/time'.format(ifo)] for ifo in all_ifos)
 test_times = np.array([pycbc.events.mean_if_greater_than_zero(tc)[0]
                           for tc in zip(*times_tuple)])
 
 is_in_combo_time = {}
 for key in f['segments']:
-    is_in_combo_time[key] = np.zeros_like(f['foreground/decimation_factor'][:])
+    is_in_combo_time[key] = np.zeros(n_triggers)
     if key.startswith('foreground') or key.startswith('background'):
         continue
     end_times = np.array(f['segments/%s/end' % key][:])
@@ -183,14 +143,10 @@ for key in f['segments']:
     idx_within_segment = pycbc.events.indices_within_times(test_times,
                                                            start_times,
                                                            end_times)
-    is_in_combo_time[key][idx_within_segment] += np.ones_like(idx_within_segment)
+    is_in_combo_time[key][idx_within_segment] = np.ones_like(idx_within_segment)
 del idx_within_segment
 
-
-all_indices = np.arange(f['foreground/decimation_factor'].size)
-available_combos =[' '.join(sorted([key for key in is_in_combo_time if is_in_combo_time[key][i]])).encode('utf8') for i in all_indices]
-del all_indices
-f['foreground/available_combinations'] = available_combos
+available_combos =[' '.join(sorted([key for key in is_in_combo_time if is_in_combo_time[key][i]])).encode('utf8') for i in np.arange(n_triggers)]
 
 all_combo_types = np.unique(available_combos)
 idx = {ct:np.where(np.array(available_combos)==ct)[0]
@@ -198,6 +154,22 @@ idx = {ct:np.where(np.array(available_combos)==ct)[0]
 
 del available_combos
 
+logging.info('Calculating n_louder background triggers in each type for all foreground events')
+
+fnlouder = {}
+fnlouder_exc = {}
+for f_in in files:
+        ifo_combo_key = f_in.attrs['ifos'].replace(' ','')
+        _, fnlouder[ifo_combo_key] = coinc.calculate_n_louder(
+                                                   f_in['background/stat'][:],
+                                                   f['foreground/stat'][:],
+                                                   f_in['background/decimation_factor'][:]
+                                                             )
+        _, fnlouder_exc[ifo_combo_key] = coinc.calculate_n_louder(
+                                                   f_in['background_exc/stat'][:],
+                                                   f['foreground/stat'][:],
+                                                   f_in['background_exc/decimation_factor'][:]
+                                                             )
 logging.info('Recalculating ifar according to summed trigger distributions')
 
 fg_ifar = np.zeros_like(f['foreground/decimation_factor'][:])
@@ -216,30 +188,26 @@ for ct in all_combo_types:
     largest_combination = cts[np.argmax([len(ifo_c) for ifo_c in cts])]
     bg_time = f[largest_combination].attrs['background_time']
     bg_time_exc = f[largest_combination].attrs['background_time_exc']
-    inc_bg_list = [where_combo[ifo_c] for ifo_c in cts]
-    inc_bg = list(itertools.chain(*inc_bg_list))
-    inc_bg_exc_list = [where_combo_exc[ifo_c] for ifo_c in cts]
-    inc_bg_exc = list(itertools.chain(*inc_bg_exc_list))
-    _, fnlouder = coinc.calculate_n_louder(f['background/stat'][:][inc_bg],
-                                           f['foreground/stat'][:][idx[ct]],
-                                           f['background/decimation_factor'][:][inc_bg])
-    _, fnlouder_exc = coinc.calculate_n_louder(
-                          f['background_exc/stat'][:][inc_bg_exc],
-                          f['foreground/stat'][:][idx[ct]],
-                          f['background_exc/decimation_factor'][:][inc_bg_exc]
-                                              )
+    fnlouder = np.sum([fnlouder[ifo_combo_key][idx[ct]] for ifo_combo_key in cts])
+    fnlouder_exc = np.sum([fnlouder_exc[ifo_combo_key][idx[ct]] for ifo_combo_key in cts])
     ifar = bg_time / (fnlouder + 1)
     ifar_exc = bg_time_exc / (fnlouder_exc + 1)
     fg_ifar[idx[ct]] = conv.sec_to_year(ifar)
     fg_ifar_exc[idx[ct]] = conv.sec_to_year(ifar_exc)
 
-for bg_type in ['background', 'background_exc']:
-    for k in ['stat','decimation_factor', 'ifo_combination']:
-        print(bg_type + '/' + k)
-        if bg_type + '/' + k in f:
-            print('deleting')
-            del f[bg_type + '/' + k]
-        else: print('not deleting')
+f.attrs['foreground_time_exc'] = f.attrs['foreground_time']
+
+# Construct the foreground censor veto from the clustered candidate times
+# above the ifar threshold
+thr = test_times[fg_ifar > args.censor_ifar_threshold]
+vstart = thr - args.veto_window
+vend = thr + args.veto_window
+vtime = segments.segmentlist([segments.segment(s, e)
+                              for s, e in zip(vstart, vend)])
+logging.info('Censoring %.2f seconds', abs(vtime))
+f.attrs['foreground_time_exc'] -= abs(vtime)
+f['segments/foreground_veto/start'] = vstart
+f['segments/foreground_veto/end'] = vend
 
 f['foreground/ifar'][:] = fg_ifar
 f['foreground/fap'] = 1 - np.exp(-f.attrs['foreground_time'] / fg_ifar)

--- a/bin/hdfcoinc/pycbc_multiifo_add_statmap
+++ b/bin/hdfcoinc/pycbc_multiifo_add_statmap
@@ -156,20 +156,19 @@ del available_combos
 
 logging.info('Calculating n_louder background triggers in each type for all foreground events')
 
-fnlouder = {}
-fnlouder_exc = {}
+far = {}
+far_exc = {}
 for f_in in files:
         ifo_combo_key = f_in.attrs['ifos'].replace(' ','')
-        _, fnlouder[ifo_combo_key] = coinc.calculate_n_louder(
-                                                   f_in['background/stat'][:],
+        _, fnlouder = coinc.calculate_n_louder(f_in['background/stat'][:],
+                                               f['foreground/stat'][:],
+                                               f_in['background/decimation_factor'][:])
+        far[ifo_combo_key] = (fnlouder + 1) / f_in.attrs['background_time']
+        _, fnlouder_exc = coinc.calculate_n_louder(f_in['background_exc/stat'][:],
                                                    f['foreground/stat'][:],
-                                                   f_in['background/decimation_factor'][:]
-                                                             )
-        _, fnlouder_exc[ifo_combo_key] = coinc.calculate_n_louder(
-                                                   f_in['background_exc/stat'][:],
-                                                   f['foreground/stat'][:],
-                                                   f_in['background_exc/decimation_factor'][:]
-                                                             )
+                                                   f_in['background_exc/decimation_factor'][:])
+        far_exc[ifo_combo_key] = (fnlouder_exc + 1) / f_in.attrs['background_time_exc']
+
 logging.info('Recalculating ifar according to summed trigger distributions')
 
 fg_ifar = np.zeros_like(f['foreground/decimation_factor'][:])
@@ -185,13 +184,10 @@ for ct in all_combo_types:
         fg_ifar_exc[idx[ct]] = f['foreground/ifar_exc'][:][idx[ct]]
         continue
     logging.info('Recalculating ifar for coincidences which are in {} time'.format(ct))
-    largest_combination = cts[np.argmax([len(ifo_c) for ifo_c in cts])]
-    bg_time = f[largest_combination].attrs['background_time']
-    bg_time_exc = f[largest_combination].attrs['background_time_exc']
-    fnlouder = np.sum([fnlouder[ifo_combo_key][idx[ct]] for ifo_combo_key in cts])
-    fnlouder_exc = np.sum([fnlouder_exc[ifo_combo_key][idx[ct]] for ifo_combo_key in cts])
-    ifar = bg_time / (fnlouder + 1)
-    ifar_exc = bg_time_exc / (fnlouder_exc + 1)
+    far_new = np.sum([far[ifo_combo_key][idx[ct]] for ifo_combo_key in cts], axis=0)
+    far_new_exc = np.sum([far_exc[ifo_combo_key][idx[ct]] for ifo_combo_key in cts], axis=0)
+    ifar = 1 / np.array(far_new)
+    ifar_exc = 1 / np.array(far_new_exc)
     fg_ifar[idx[ct]] = conv.sec_to_year(ifar)
     fg_ifar_exc[idx[ct]] = conv.sec_to_year(ifar_exc)
 

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -600,8 +600,8 @@ class ExpFitSGCoincRateStatistic(ExpFitStatistic):
     def coinc_multiifo(self, s, slide,
                        step, **kwargs): # pylint:disable=unused-argument
         """Calculate the final coinc ranking statistic"""
-        sngl_rates_dict = {ifo: numpy.exp(sngl_rate) for (ifo, sngl_rate) in\
-                           zip(self.fits_by_tid.keys(), s.values())}
+        sngl_rates_dict = {ifo: numpy.exp(log_rate) for (ifo, log_rate)\
+                           in s.items()}
         ln_coinc_rate = numpy.log(coinc_rate.combination_noise_coinc_rate(
                                   sngl_rates_dict, kwargs['time_addition']))
         loglr = - ln_coinc_rate + self.benchmark_lograte


### PR DESCRIPTION
`pycbc_multiifo_add_statmap` code will use backgrounds of any coincidences where that detector combination is 'on'.

For example, if the foreground coincidence comes from H1L1, but V1 was also operating at the time, the background used for ifar/fap/ifar_exc/fap_exc calculation will combine backgrounds from H1L1, H1V1, L1V1 and H1L1V1