### PR TITLE
Fix special veto-definer end_time=0 case, and allow dqsegdb ini file option

### DIFF
--- a/pycbc/workflow/segment.py
+++ b/pycbc/workflow/segment.py
@@ -1437,7 +1437,7 @@ def get_segments_file(workflow, name, option_name, out_dir):
         flag_str = cp.get_opt_tags("workflow-segments", option_name, [ifo])
         key = ifo + ':' + name
         segs[key] = query_str(ifo, flag_str, start, end,
-                              source=source, server=server, 
+                              source=source, server=server,
                               veto_definer=veto_definer)
         logging.info("%s: got %s flags", ifo, option_name)
 

--- a/pycbc/workflow/segment.py
+++ b/pycbc/workflow/segment.py
@@ -1437,7 +1437,7 @@ def get_segments_file(workflow, name, option_name, out_dir):
         flag_str = cp.get_opt_tags("workflow-segments", option_name, [ifo])
         key = ifo + ':' + name
         segs[key] = query_str(ifo, flag_str, start, end,
-                              server=server, source=source,
+                              source=source, server=server, 
                               veto_definer=veto_definer)
         logging.info("%s: got %s flags", ifo, option_name)
 

--- a/pycbc/workflow/segment.py
+++ b/pycbc/workflow/segment.py
@@ -1428,12 +1428,16 @@ def get_segments_file(workflow, name, option_name, out_dir):
         server = cp.get("workflow-segments",
                                  "segments-database-url")
 
+    source = "any"
+    if cp.has_option("workflow-segments", "segments-source"):
+        source = cp.get("workflow-segments", "segments-source")
+
     segs = {}
     for ifo in workflow.ifos:
         flag_str = cp.get_opt_tags("workflow-segments", option_name, [ifo])
         key = ifo + ':' + name
         segs[key] = query_str(ifo, flag_str, start, end,
-                              server=server,
+                              server=server, source=source,
                               veto_definer=veto_definer)
         logging.info("%s: got %s flags", ifo, option_name)
 


### PR DESCRIPTION
Here we add support for the case where the veto-definer defines a flag to be valid until a time of `0`, which we should interpret as no ending time on the period of validity.

We also allow the user to choose a:

`segments-source=dqsegdb`

in the `[workflow-segments]` section of the config file. If this is done the code will not check GWOSC (and print confusing warning messages). This change is backwards compatible, so not providing this option will produce the previous behaviour.

I have tested that this fixes an instance where the end_time of 0 was needed to veto a missing stretch of data and tested both with and without the new flag.