### PR TITLE
add hook to allow getting waveforms from external libraries to pycbc

### DIFF
--- a/pycbc/waveform/waveform.py
+++ b/pycbc/waveform/waveform.py
@@ -26,6 +26,7 @@
 waveforms.
 """
 
+import os
 import lal, lalsimulation, numpy, copy
 from pycbc.types import TimeSeries, FrequencySeries, zeros, Array
 from pycbc.types import real_same_precision_as, complex_same_precision_as
@@ -821,6 +822,16 @@ _filter_time_lengths[apx_name] = _filter_time_lengths["SpinTaylorF2"]
 
 from . nltides import nonlinear_tidal_spa
 cpu_fd["TaylorF2NL"] = nonlinear_tidal_spa
+
+# Load external waveforms #####################################################
+if 'PYCBC_WAVEFORM' in os.environ:
+    mods = os.environ['PYCBC_WAVEFORM'].split(':')
+    for mod in mods:
+        mhandle = __import__(mod, fromlist=[''])
+        mhandle.add_me(cpu_fd=cpu_fd, 
+                       cpu_td=cpu_td,
+                       filter_time_lengths=_filter_time_lengths,
+                      )
 
 for apx in copy.copy(_filter_time_lengths):
     fd_apx = list(cpu_fd.keys())

--- a/pycbc/waveform/waveform.py
+++ b/pycbc/waveform/waveform.py
@@ -828,10 +828,9 @@ if 'PYCBC_WAVEFORM' in os.environ:
     mods = os.environ['PYCBC_WAVEFORM'].split(':')
     for mod in mods:
         mhandle = __import__(mod, fromlist=[''])
-        mhandle.add_me(cpu_fd=cpu_fd, 
+        mhandle.add_me(cpu_fd=cpu_fd,
                        cpu_td=cpu_td,
-                       filter_time_lengths=_filter_time_lengths,
-                      )
+                       filter_time_lengths=_filter_time_lengths)
 
 for apx in copy.copy(_filter_time_lengths):
     fd_apx = list(cpu_fd.keys())


### PR DESCRIPTION
This adds a prototype functionality to allow one to pull in waveform approximants from python codes outside of pycbc.

 The method here is you would set an environement variable to let pycbc know which libraries have this copability. On the other side, the external library would provide the function to add itself to pycbc. I think this functionality is useful for both PE and searches. 

We've been getting some requests form external groups to make it easier to support their models without having to modify our code. This is an approach I think we can test with them. 