### PR TITLE
exp_fit_sg_coinc_rate stat Inf issue

### DIFF
--- a/pycbc/events/coinc_rate.py
+++ b/pycbc/events/coinc_rate.py
@@ -82,12 +82,11 @@ def combination_noise_coinc_rate(rates, slop):
         Value is expected coincidence rate in the combination, units Hz
     """
     # multiply product of trigger rates by the overlap time
-    allowed_area = multiifo_noise_coincident_area(list(rates), slop)
-    # list(dict.values()) is python-3-proof
-    rateprod = numpy.prod(list(rates.values()), axis=0)
-    combo_coinc_rate = allowed_area * rateprod
+    log_rates = {k:numpy.log(r) for (k,r) in rates.items()}
+    combo_coinc_rate = combination_noise_coinc_rate_log(log_rates, slop)
 
     return combo_coinc_rate
+
 
 def combination_noise_coinc_rate_log(log_rates, slop):
     """
@@ -110,12 +109,14 @@ def combination_noise_coinc_rate_log(log_rates, slop):
         Value is expected coincidence rate in the combination, units Hz
     """
     # multiply product of trigger rates by the overlap time
-    allowed_area = numpy.log(multiifo_noise_coincident_area(list(log_rates), slop))
+    allowed_area = numpy.log(multiifo_noise_coincident_area(list(log_rates),
+                                                            slop))
     # list(dict.values()) is python-3-proof
     rateprod = numpy.sum(list(log_rates.values()), axis=0)
     combo_coinc_rate = allowed_area + rateprod
 
     return combo_coinc_rate
+
 
 def multiifo_noise_coincident_area(ifos, slop):
     """

--- a/pycbc/events/coinc_rate.py
+++ b/pycbc/events/coinc_rate.py
@@ -65,6 +65,8 @@ def combination_noise_coinc_rate(rates, slop):
     """
     Calculate the expected rate of noise coincidences for a combination of
     detectors
+    WARNING: for high stat values, this can cause numerical underflow in the
+    rate calculation
 
     Parameters
     ----------
@@ -81,7 +83,7 @@ def combination_noise_coinc_rate(rates, slop):
     combo_coinc_rate: numpy array
         Value is expected coincidence rate in the combination, units Hz
     """
-    # multiply product of trigger rates by the overlap time
+    # convert rates to log rates for use in combination_noise_coinc_rate_log
     log_rates = {k: numpy.log(r) for (k, r) in rates.items()}
     combo_coinc_rate = combination_noise_coinc_rate_log(log_rates, slop)
 
@@ -91,7 +93,7 @@ def combination_noise_coinc_rate(rates, slop):
 def combination_noise_coinc_rate_log(log_rates, slop):
     """
     Calculate the expected rate of noise coincidences for a combination of
-    detectors
+    detectors given log of single detector noise rates
 
     Parameters
     ----------
@@ -120,9 +122,10 @@ def combination_noise_coinc_rate_log(log_rates, slop):
 
 def multiifo_noise_coincident_area(ifos, slop):
     """
-    calculate the total extent of time offset between 2 detectors,
+    Calculate the total extent of time offset between 2 detectors,
     or area of the 2d space of time offsets for 3 detectors, for
     which a coincidence can be generated
+    This function cannot yet handle more than 3 detectors
 
     Parameters
     ----------

--- a/pycbc/events/coinc_rate.py
+++ b/pycbc/events/coinc_rate.py
@@ -89,6 +89,33 @@ def combination_noise_coinc_rate(rates, slop):
 
     return combo_coinc_rate
 
+def combination_noise_coinc_rate_log(log_rates, slop):
+    """
+    Calculate the expected rate of noise coincidences for a combination of
+    detectors
+
+    Parameters
+    ----------
+    log_rates: dict
+        Dictionary keyed on ifo string
+        Value is a sequence of logarithm of single-detector trigger rates,
+        units assumed to be Hz
+    slop: float
+        time added to maximum time-of-flight between detectors to account
+        for timing error
+
+    Returns
+    -------
+    combo_coinc_rate: numpy array
+        Value is expected coincidence rate in the combination, units Hz
+    """
+    # multiply product of trigger rates by the overlap time
+    allowed_area = numpy.log(multiifo_noise_coincident_area(list(log_rates), slop))
+    # list(dict.values()) is python-3-proof
+    rateprod = numpy.sum(list(log_rates.values()), axis=0)
+    combo_coinc_rate = allowed_area + rateprod
+
+    return combo_coinc_rate
 
 def multiifo_noise_coincident_area(ifos, slop):
     """

--- a/pycbc/events/coinc_rate.py
+++ b/pycbc/events/coinc_rate.py
@@ -10,9 +10,10 @@
 """
 
 import itertools
+import logging
 import numpy
 import pycbc.detector
-import logging
+
 
 def multiifo_noise_coinc_lograte(log_rates, slop):
     """
@@ -23,17 +24,17 @@ def multiifo_noise_coinc_lograte(log_rates, slop):
     ----------
     log_rates: dict
         Dictionary keyed on ifo string
-        Value is a sequence of single-detector trigger rates, units assumed
-        to be Hz
+        Value is a sequence of single-detector trigger logarithm of rates,
+        units assumed to be Hz
     slop: float
         time added to maximum time-of-flight between detectors to account
         for timing error
 
     Returns
     -------
-    expected_coinc_rates: dict
+    expected_coinc_log_rates: dict
         Dictionary keyed on the ifo combination string
-        Value is expected coincidence rate in the combination, units Hz
+        Value is expected coincidence log rate in the combination, units log Hz
     """
     expected_coinc_log_rates = {}
 
@@ -43,7 +44,7 @@ def multiifo_noise_coinc_lograte(log_rates, slop):
 
     # Calculate coincidence for all-ifo combination
     expected_coinc_log_rates[ifostring] = \
-                              combination_noise_coinc_lograte(log_rates, slop)
+        combination_noise_coinc_lograte(log_rates, slop)
 
     # If more than one possible coincidence type exists,
     # calculate coincidence for subsets through recursion
@@ -57,7 +58,8 @@ def multiifo_noise_coinc_lograte(log_rates, slop):
             sub_coinc_rates = multiifo_noise_coinc_lograte(rates_subset, slop)
             # add these sub-coincidences to the overall dictionary
             for sub_coinc in sub_coinc_rates:
-                expected_coinc_log_rates[sub_coinc] = sub_coinc_rates[sub_coinc]
+                expected_coinc_log_rates[sub_coinc] = \
+                    sub_coinc_rates[sub_coinc]
 
     return expected_coinc_log_rates
 

--- a/pycbc/events/coinc_rate.py
+++ b/pycbc/events/coinc_rate.py
@@ -85,9 +85,7 @@ def combination_noise_coinc_rate(rates, slop):
     """
     # convert rates to log rates for use in combination_noise_coinc_rate_log
     log_rates = {k: numpy.log(r) for (k, r) in rates.items()}
-    combo_coinc_rate = combination_noise_coinc_rate_log(log_rates, slop)
-
-    return combo_coinc_rate
+    return numpy.exp(combination_noise_coinc_rate_log(log_rates, slop))
 
 
 def combination_noise_coinc_rate_log(log_rates, slop):
@@ -111,13 +109,10 @@ def combination_noise_coinc_rate_log(log_rates, slop):
         Value is expected coincidence rate in the combination, units Hz
     """
     # multiply product of trigger rates by the overlap time
-    allowed_area = numpy.log(multiifo_noise_coincident_area(list(log_rates),
-                                                            slop))
+    allowed_area = multiifo_noise_coincident_area(list(log_rates), slop)
     # list(dict.values()) is python-3-proof
     rateprod = numpy.sum(list(log_rates.values()), axis=0)
-    combo_coinc_rate = allowed_area + rateprod
-
-    return combo_coinc_rate
+    return numpy.log(allowed_area) + rateprod
 
 
 def multiifo_noise_coincident_area(ifos, slop):

--- a/pycbc/events/coinc_rate.py
+++ b/pycbc/events/coinc_rate.py
@@ -23,8 +23,7 @@ def multiifo_noise_coinc_lograte(log_rates, slop):
     Parameters
     ----------
     log_rates: dict
-        Dictionary keyed on ifo string
-        Value is a sequence of single-detector trigger logarithm of rates,
+        Key: ifo string, Value: sequence of log single-detector trigger rates,
         units assumed to be Hz
     slop: float
         time added to maximum time-of-flight between detectors to account
@@ -33,8 +32,8 @@ def multiifo_noise_coinc_lograte(log_rates, slop):
     Returns
     -------
     expected_coinc_log_rates: dict
-        Dictionary keyed on the ifo combination string
-        Value is expected coincidence log rate in the combination, units log Hz
+        Key: ifo combination string
+        Value: expected log coincidence rate in the combination, units log Hz
     """
     expected_coinc_log_rates = {}
 
@@ -68,43 +67,12 @@ def combination_noise_coinc_rate(rates, slop):
     """
     Calculate the expected rate of noise coincidences for a combination of
     detectors
-    WARNING: for high stat values, this can cause numerical underflow in the
-    rate calculation
+    WARNING: for high stat values, numerical underflow can occur
 
     Parameters
     ----------
     rates: dict
-        Dictionary keyed on ifo string
-        Value is a sequence of single-detector trigger rates, units assumed
-        to be Hz
-    slop: float
-        time added to maximum time-of-flight between detectors to account
-        for timing error
-
-    Returns
-    -------
-    combo_coinc_rate: numpy array
-        Value is expected coincidence rate in the combination, units Hz
-    """
-    logging.warning('The combination_noise_coinc_rate function is liable to '
-                    'numerical underflows, we suggest to use '
-                    'combination_noise_coinc_rate_log instead')
-    # convert rates to log rates for use in combination_noise_coinc_rate_log
-    log_rates = {k: numpy.log(r) for (k, r) in rates.items()}
-    return numpy.exp(combination_noise_coinc_lograte(log_rates, slop))
-
-
-def combination_noise_coinc_lograte(log_rates, slop):
-
-    """
-    Calculate the expected rate of noise coincidences for a combination of
-    detectors given log of single detector noise rates
-
-    Parameters
-    ----------
-    log_rates: dict
-        Dictionary keyed on ifo string
-        Value is a sequence of logarithm of single-detector trigger rates,
+        Key: ifo string, Value: sequence of single-detector trigger rates,
         units assumed to be Hz
     slop: float
         time added to maximum time-of-flight between detectors to account
@@ -113,7 +81,34 @@ def combination_noise_coinc_lograte(log_rates, slop):
     Returns
     -------
     combo_coinc_rate: numpy array
-        Value is expected coincidence rate in the combination, units Hz
+        Expected coincidence rate in the combination, units Hz
+    """
+    logging.warning('combination_noise_coinc_rate() is liable to numerical '
+                    'underflows, use combination_noise_coinc_rate_log '
+                    'instead')
+    log_rates = {k: numpy.log(r) for (k, r) in rates.items()}
+    # exp may underflow
+    return numpy.exp(combination_noise_coinc_lograte(log_rates, slop))
+
+
+def combination_noise_coinc_lograte(log_rates, slop):
+    """
+    Calculate the expected rate of noise coincidences for a combination of
+    detectors given log of single detector noise rates
+
+    Parameters
+    ----------
+    log_rates: dict
+        Key: ifo string, Value: sequence of log single-detector trigger rates,
+        units assumed to be Hz
+    slop: float
+        time added to maximum time-of-flight between detectors to account
+        for timing error
+
+    Returns
+    -------
+    combo_coinc_rate: numpy array
+        Expected log coincidence rate in the combination, units Hz
     """
     # multiply product of trigger rates by the overlap time
     allowed_area = multiifo_noise_coincident_area(list(log_rates), slop)
@@ -127,7 +122,7 @@ def multiifo_noise_coincident_area(ifos, slop):
     Calculate the total extent of time offset between 2 detectors,
     or area of the 2d space of time offsets for 3 detectors, for
     which a coincidence can be generated
-    This function cannot yet handle more than 3 detectors
+    Cannot yet handle more than 3 detectors.
 
     Parameters
     ----------

--- a/pycbc/events/coinc_rate.py
+++ b/pycbc/events/coinc_rate.py
@@ -82,7 +82,7 @@ def combination_noise_coinc_rate(rates, slop):
         Value is expected coincidence rate in the combination, units Hz
     """
     # multiply product of trigger rates by the overlap time
-    log_rates = {k:numpy.log(r) for (k,r) in rates.items()}
+    log_rates = {k: numpy.log(r) for (k, r) in rates.items()}
     combo_coinc_rate = combination_noise_coinc_rate_log(log_rates, slop)
 
     return combo_coinc_rate

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -600,10 +600,10 @@ class ExpFitSGCoincRateStatistic(ExpFitStatistic):
     def coinc_multiifo(self, s, slide,
                        step, **kwargs): # pylint:disable=unused-argument
         """Calculate the final coinc ranking statistic"""
-        sngl_rates_dict = {ifo: numpy.exp(log_rate) for (ifo, log_rate)\
+        sngl_rates_dict = {ifo: log_rate for (ifo, log_rate)\
                            in s.items()}
-        ln_coinc_rate = numpy.log(coinc_rate.combination_noise_coinc_rate(
-                                  sngl_rates_dict, kwargs['time_addition']))
+        ln_coinc_rate = coinc_rate.combination_noise_coinc_rate_log(
+                                  sngl_rates_dict, kwargs['time_addition'])
         loglr = - ln_coinc_rate + self.benchmark_lograte
         return loglr
 

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -597,11 +597,11 @@ class ExpFitSGCoincRateStatistic(ExpFitStatistic):
             coeff_file['count_above_thresh'][:][tid_sort] / \
             float(coeff_file.attrs['analysis_time'])
 
-    def coinc_multiifo(self, sngl_stat, slide,
+    def coinc_multiifo(self, s, slide,
                        step, **kwargs): # pylint:disable=unused-argument
         """Calculate the final coinc ranking statistic"""
         ln_coinc_rate = coinc_rate.combination_noise_coinc_rate_log(
-                                  sngl_stat, kwargs['time_addition'])
+                                  s, kwargs['time_addition'])
         loglr = - ln_coinc_rate + self.benchmark_lograte
         return loglr
 

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -597,13 +597,11 @@ class ExpFitSGCoincRateStatistic(ExpFitStatistic):
             coeff_file['count_above_thresh'][:][tid_sort] / \
             float(coeff_file.attrs['analysis_time'])
 
-    def coinc_multiifo(self, s, slide,
+    def coinc_multiifo(self, sngl_stat, slide,
                        step, **kwargs): # pylint:disable=unused-argument
         """Calculate the final coinc ranking statistic"""
-        sngl_rates_dict = {ifo: log_rate for (ifo, log_rate)\
-                           in s.items()}
         ln_coinc_rate = coinc_rate.combination_noise_coinc_rate_log(
-                                  sngl_rates_dict, kwargs['time_addition'])
+                                  sngl_stat, kwargs['time_addition'])
         loglr = - ln_coinc_rate + self.benchmark_lograte
         return loglr
 

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -600,7 +600,7 @@ class ExpFitSGCoincRateStatistic(ExpFitStatistic):
     def coinc_multiifo(self, s, slide,
                        step, **kwargs): # pylint:disable=unused-argument
         """Calculate the final coinc ranking statistic"""
-        ln_coinc_rate = coinc_rate.combination_noise_coinc_rate_log(
+        ln_coinc_rate = coinc_rate.combination_noise_coinc_lograte(
                                   s, kwargs['time_addition'])
         loglr = - ln_coinc_rate + self.benchmark_lograte
         return loglr


### PR DESCRIPTION
performing exp of the log coinc rate (single statistic) in the coincident calculation (`coinc_multiifo` function) was causing numerical underflow with high-statistic singles

This PR changes the calculation to retain the log rates in order to prevent this

I do not know if we should remove the `combination_noise_coinc_rate` function from the `coinc_rate` module, or leave it, or rewrite to be a wrapper the log version (suggestions welcome)