### PR TITLE
Don't upimport pygrb results utils

### DIFF
--- a/pycbc/results/__init__.py
+++ b/pycbc/results/__init__.py
@@ -7,4 +7,3 @@ from pycbc.results.legacy_grb import *
 from pycbc.results.layout import *
 from pycbc.results.dq import *
 from pycbc.results.str_utils import *
-from pycbc.results.pygrb_plotting_utils import *


### PR DESCRIPTION
The pygrb plotting module is setting parts of rcparams and is also setting up logging directly in the import. The former has minor unintended affects on plots in other workflows, the latter hides the logging output from other programs entirely (i.e. the standard 2-ifo coinc workflow). I can't verify this completely, but it seems that many modules are directly importing this module anyway, so I don't think it's necessarily needed to upimport everything. Can someone on the PyGRB side verify? 

i.e. this wouldn't need to change.
https://github.com/gwastro/pycbc/blob/07c32dc38591b324cd34971beea55de2a0989377/bin/pygrb/pycbc_pygrb_plot_skygrid#L32