### PR TITLE
Inj exc ifar

### DIFF
--- a/bin/hdfcoinc/pycbc_coinc_hdfinjfind
+++ b/bin/hdfcoinc/pycbc_coinc_hdfinjfind
@@ -1,5 +1,4 @@
 #!/usr/bin/python
-
 """Associate coincident triggers with injections listed in one or more LIGOLW
 files.
 """
@@ -106,9 +105,14 @@ for trigger_file, injection_file in zip(args.trigger_files,
     template_id = f['foreground/template_id'][:]
     stat = f['foreground/stat'][:]
     ifar_exc = f['foreground/ifar_exc'][:]
-    ifar = f['foreground/ifar'][:]
-    fap = f['foreground/fap'][:]
     fap_exc = f['foreground/fap_exc'][:]
+    try:
+        ifar = f['foreground/ifar'][:]
+        fap = f['foreground/fap'][:]
+    except KeyError:
+        logging.info('No inclusive ifar/fap. Proceeding anyway')
+        ifar = None
+        fap = None
     if multi_ifo_style:
         # using multi-ifo-style trigger file input
         ifo_times = ()
@@ -258,18 +262,21 @@ for trigger_file, injection_file in zip(args.trigger_files,
     hdf_append(fo, 'found/template_id', template_id[time_sorting][found_fore])
     hdf_append(fo, 'found/injection_index', found + injection_index)
     hdf_append(fo, 'found/stat', stat[time_sorting][found_fore])
-    hdf_append(fo, 'found/ifar', ifar[time_sorting][found_fore])
     hdf_append(fo, 'found/ifar_exc', ifar_exc[time_sorting][found_fore])
-    hdf_append(fo, 'found/fap', fap[time_sorting][found_fore])
+    hdf_append(fo, 'found/fap_exc', ifar_exc[time_sorting][found_fore])
+    if ifar is not None:
+        hdf_append(fo, 'found/ifar', ifar[time_sorting][found_fore])
+        hdf_append(fo, 'found/fap', fap[time_sorting][found_fore])
     hdf_append(fo, 'found_after_vetoes/template_id',
                template_id[time_sorting][found_fore_v])
     hdf_append(fo, 'found_after_vetoes/injection_index',
                found_after_vetoes + injection_index)
     hdf_append(fo, 'found_after_vetoes/stat', stat[time_sorting][found_fore_v])
-    hdf_append(fo, 'found_after_vetoes/ifar', ifar[time_sorting][found_fore_v])
     hdf_append(fo, 'found_after_vetoes/ifar_exc', ifar_exc[time_sorting][found_fore_v])
-    hdf_append(fo, 'found_after_vetoes/fap', fap[time_sorting][found_fore_v])
     hdf_append(fo, 'found_after_vetoes/fap_exc', fap_exc[time_sorting][found_fore_v])
+    if ifar is not None:
+        hdf_append(fo, 'found_after_vetoes/ifar', ifar[time_sorting][found_fore_v])
+        hdf_append(fo, 'found_after_vetoes/fap', fap[time_sorting][found_fore_v])
     if multi_ifo_style:
         for ifo in ifo_list:
             hdf_append(fo, 'found/%s/time' % ifo,

--- a/bin/hdfcoinc/pycbc_page_sensitivity
+++ b/bin/hdfcoinc/pycbc_page_sensitivity
@@ -28,6 +28,8 @@ parser.add_argument('--bins', nargs='+',
 parser.add_argument('--sig-type', choices=['ifar', 'fap', 'stat'],
                     default='ifar',
                     help="x-axis significance measure. Default 'ifar'")
+parser.add_argument('--exclusive-sig', action='store_true',
+                    help="Plot only exclusive injection FAR, not inclusive")
 parser.add_argument('--sig-bins', nargs='*',
                    help="Boundaries of x-axis significance bins. If not given"
                         ", hard-coded defaults will be used"),
@@ -154,14 +156,21 @@ for fi in args.injection_file:
             raise RuntimeError('Unrecognized --bin-type value!')
 
         if args.sig_type == 'stat':
-            sig = f['found_after_vetoes/stat'][:]
-            sig_exc = None
+            sig_exc = f['found_after_vetoes/stat'][:]
+            sig = None
         elif args.sig_type == 'ifar':
             sig = f['found_after_vetoes/ifar'][:]
             sig_exc = f['found_after_vetoes/ifar_exc'][:]
+            try:
+                sig = f['found_after_vetoes/ifar'][:]
+            except KeyError:  # multiifo inj files may not have inclusive FAR
+                sig = numpy.array([])
         elif args.sig_type == 'fap':
-            sig = f['found_after_vetoes/fap'][:]
             sig_exc = f['found_after_vetoes/fap_exc'][:]
+            try:
+                sig = f['found_after_vetoes/fap'][:]
+            except KeyError:  # multiifo inj files may not have inclusive FAP
+                sig = numpy.array([])
         else:
             raise RuntimeError('Unrecognized --sig-type value!')
 
@@ -215,18 +224,23 @@ if args.hdf_out:
     plotdict = {}
     plotdict['xvals'] = x_values
 
-# Switches for plotting both inclusive/exclusive significance
-color=iter(cm.rainbow(numpy.linspace(0, 1, len(args.bins)-1)))
-fvalues = [found['sig'], found['sig_exc']]
-do_labels = [True, False]
-alphas = [.8, .3]
+# Switches for plotting inclusive/exclusive significance
+color = iter(cm.rainbow(numpy.linspace(0, 1, len(args.bins)-1)))
+if not args.exclusive_sig:
+    fvalues = [found['sig'], found['sig_exc']]
+    do_labels = [True, False]
+    alphas = [.8, .3]
+else:
+    fvalues = [found['sig_exc']]
+    do_labels = [True]
+    alphas = [.6]
 
 fig = pylab.figure()
 # Cycle over parameter bins plotting each in turn
 for j in range(len(args.bins)-1):
     c = next(color)
 
-    # Plot both the inclusive and exclusive significance
+    # cycle over inclusive / exclusive significance if available
     for sig_val, do_label, alpha in zip(fvalues, do_labels, alphas):
         if sig_val[0] is None:
             logging.info('Skipping exclusive significance')

--- a/bin/minifollowups/pycbc_injection_minifollowup
+++ b/bin/minifollowups/pycbc_injection_minifollowup
@@ -14,8 +14,8 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-""" Followup foreground events
-"""
+""" Followup foreground events """
+
 import os, argparse, numpy, logging, h5py, copy
 import pycbc.workflow as wf
 from pycbc.types import MultiDetOptionAction
@@ -26,6 +26,7 @@ import pycbc.workflow.minifollowups as mini
 import pycbc.workflow.pegasus_workflow as wdax
 import pycbc.version, pycbc.pnutils
 from pycbc.io.hdf import SingleDetTriggers
+
 
 def to_file(path, ifo=None):
     fil = wdax.File(os.path.basename(path))
@@ -98,7 +99,11 @@ for ifo in args.single_detector_triggers:
 f = h5py.File(args.injection_file, 'r')
 missed = f['missed/after_vetoes'][:]
 if args.ifar_threshold is not None:
-    ifars = f['found_after_vetoes']['ifar'][:]
+    try:  # injections may not have (inclusive) IFAR present
+        ifars = f['found_after_vetoes']['ifar'][:]
+    except KeyError:
+        ifars = f['found_after_vetoes']['ifar_exc'][:]
+        logging.warn('Inclusive IFAR not found, using exclusive')
     lgc_arr = ifars < args.ifar_threshold
     missed = numpy.append(missed,
                           f['found_after_vetoes']['injection_index'][lgc_arr])
@@ -156,7 +161,7 @@ for num_event in range(num_events):
             ifo_time = -1.0
 
         ifo_times += ' %s:%s ' % (ifo, ifo_time)
-        inj_params[ifo+'_end_time'] = ifo_time
+        inj_params[ifo + '_end_time'] = ifo_time
 
     layouts += [(mini.make_inj_info(workflow, injection_file, injection_index, num_event,
                                args.output_dir, tags=args.tags + [str(num_event)])[0],)]
@@ -173,7 +178,7 @@ for num_event in range(num_events):
 
     for single in single_triggers:
         checkedtime = time
-        if (inj_params[single.ifo+'_end_time'] == -1.0):
+        if (inj_params[single.ifo + '_end_time'] == -1.0):
             checkedtime = -1.0
 
         files += mini.make_singles_timefreq(workflow, single, tmpltbank_file,
@@ -186,7 +191,6 @@ for num_event in range(num_events):
              data_segments=insp_data_seglists[single.ifo],
              injection_file=injection_xml_file,
              tags=args.tags + [str(num_event)])
-
 
     files += mini.make_single_template_plots(workflow, insp_segs,
                             args.inspiral_data_read_name,
@@ -201,8 +205,8 @@ for num_event in range(num_events):
                             args.inspiral_data_read_name,
                             args.inspiral_data_analyzed_name, inj_params,
                             args.output_dir, inj_file=injection_xml_file,
-                            tags=args.tags+['INJ_PARAMS_INVERTED',
-                                            str(num_event)],
+                            tags=args.tags + ['INJ_PARAMS_INVERTED',
+                                              str(num_event)],
                             params_str='injection parameters as template, ' +\
                                        'here the injection is made inverted',
                             use_exact_inj_params=True)
@@ -211,8 +215,8 @@ for num_event in range(num_events):
                             args.inspiral_data_read_name,
                             args.inspiral_data_analyzed_name, inj_params,
                             args.output_dir, inj_file=injection_xml_file,
-                            tags=args.tags+['INJ_PARAMS_NOINJ',
-                                            str(num_event)],
+                            tags=args.tags + ['INJ_PARAMS_NOINJ',
+                                              str(num_event)],
                             params_str='injection parameters, here no ' +\
                                        'injection was actually performed',
                             use_exact_inj_params=True)

--- a/bin/minifollowups/pycbc_page_coincinfo
+++ b/bin/minifollowups/pycbc_page_coincinfo
@@ -15,6 +15,7 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 """ Make tables describing a coincident foreground event"""
+
 import h5py, argparse, logging, sys
 import matplotlib; matplotlib.use('Agg')
 import numpy, lal, datetime
@@ -49,21 +50,27 @@ pycbc.init_logging(args.verbose)
 # Get the nth loudest trigger from the output of pycbc_coinc_statmap
 f = h5py.File(args.statmap_file, 'r')
 d = f[args.statmap_file_subspace_name]
+
 if args.n_loudest is not None:
     n = d['stat'][:].argsort()[::-1][args.n_loudest]
     title = 'Parameters of coincident event ranked %s' % (args.n_loudest + 1)
-    caption = 'Parameters of event ranked %s by the search. The figures below show the mini-followup data for this event.' % (args.n_loudest + 1)
+    caption = ('Parameters of event ranked %s by the search. The figures below'
+               ' show the mini-followup data for this event.' % 
+               (args.n_loudest + 1))
 elif args.trigger_id is not None:
     n = args.trigger_id
     title = 'Details of coincident trigger'
-    caption = 'Parameters of coincident event. The figures below show the mini-followup data for this event.'
+    caption = ('Parameters of coincident event. The figures below show the '
+               'mini-followup data for this event.')
 else:
     # It shouldn't be possible to get here!
     raise ValueError()
 
+# Make a table for the coincident information #################################
+
 # Check if using input files from old (2-ifo) coinc code
 if 'detector_1' in f.attrs:
-    # make a table for the coincident information #################################
+    # Make a table for the coincident information
     headers = ["Coincident ranking statistic",
                "Inclusive IFAR (yr)",
                "Inclusive FAP",
@@ -89,17 +96,24 @@ else:
                "Exclusive FAP"
               ]
 
-    table = numpy.array([['%5.2f' % d['stat'][n],
-                          '%5.2f' % d['ifar'][n],
-                          '%5.2e' % d['fap'][n],
-                          '%5.2f' % d['ifar_exc'][n],
-                          '%5.2e' % d['fap_exc'][n]
-                         ]], dtype=str)
+    try:
+        table = numpy.array([['%5.2f' % d['stat'][n],
+                              '%5.2f' % d['ifar'][n],
+                              '%5.2e' % d['fap'][n],
+                              '%5.2f' % d['ifar_exc'][n],
+                              '%5.2e' % d['fap_exc'][n]
+                             ]], dtype=str)
+    except KeyError: # injections may not have inclusive IFAR
+        table = numpy.array([['%5.2f' % d['stat'][n],
+                              '%5.2f' % d['ifar_exc'][n],
+                              '%5.2e' % d['fap_exc'][n]
+                             ]], dtype=str)
 
 html = pycbc.results.dq.redirect_javascript + \
                                 str(pycbc.results.static_table(table, headers))
 
-# make a table for the single detector information ############################
+# Make a table for the single detector information ############################
+
 idx = {}
 # Check if using input files from old (2-ifo) coinc code
 if 'detector_1' in f.attrs:


### PR DESCRIPTION
Temporarily suspending the calculation of inclusive IFAR for injections in the multi-ifo pipeline while we work out what to do with full data/zerolag.  (Also since as noted in #2824 the calculation is probably already buggy with existing code.)

These changes are needed to not break the pipeline given the absence of inclusive IFAR, but also preserve existing 2-ifo behaviour. 