### PR TITLE
pycbc_make_inference_workflow: optional file-path options

### DIFF
--- a/bin/workflows/pycbc_make_inference_workflow
+++ b/bin/workflows/pycbc_make_inference_workflow
@@ -77,11 +77,11 @@ parser.add_argument("--tags", nargs="+", default=[],
                     help="Tags to apend in various places.")
 parser.add_argument("--output-dir", default=None,
                     help="Path to output directory.")
-parser.add_argument("--output-map", required=True,
+parser.add_argument("--output-map", default=None,
                     help="Path to output map file.")
-parser.add_argument("--transformation-catalog", required=True,
+parser.add_argument("--transformation-catalog", default=None,
                     help="Path to transformation catalog file.")
-parser.add_argument("--output-file", required=True,
+parser.add_argument("--output-file", default=None,
                     help="Path to DAX file.")
 
 # input workflow file options
@@ -382,7 +382,8 @@ dep = dax.Dependency(parent=workflow.as_job, child=finalize_workflow.as_job)
 container._adag.addDependency(dep)
 
 # write dax
-container.save(filename=opts.output_file, output_map_path=opts.output_map,
+outputfile = "{}.dax".format(opts.workflow_name) if opts.output_file == None else opts.output_file
+container.save(filename=outputfile, output_map_path=opts.output_map,
                transformation_catalog_path=opts.transformation_catalog)
 
 # save workflow configuration file


### PR DESCRIPTION
This supersedes #2741 after feedback from @cmbiwer , not removing any of the 3 options, but making them optional instead. By default, --output-file will be set to workflow_name.dax, while auto-naming for the map and transform catalog are handled by the Workflow.save() method already so they can just stay "None" by default.

```
pycbc_make_inference_workflow: optional file-path options

 -normally, users shouldn't need to worry about filenames of
  --output-map, --transformation-catalog and --output-file
 -will be put in default --output-dir with default names automatically
 -but can still be manually set if required
 -closes #2739
```