### PR TITLE
add --verbose option to pycbc_make_inference_workflow

### DIFF
--- a/bin/workflows/pycbc_make_inference_workflow
+++ b/bin/workflows/pycbc_make_inference_workflow
@@ -113,6 +113,10 @@ parser.add_argument("--frame-files", nargs="+", default=None,
                     action=MultiDetOptionAppendAction,
                     help="GWF frame files to use.")
 
+# verbosity flag (to be passed through to main inference executable)
+parser.add_argument("--verbose", action="store_true",
+                    help="Turn on --verbose for main pycbc_inference executable.")
+
 # add option groups
 configuration.add_workflow_command_line_group(parser)
 
@@ -272,6 +276,8 @@ for num_event in range(num_events):
 
     # make node for running sampler
     node = inference_exe.create_node()
+    if opts.verbose:
+        node.add_opt("--verbose")
     node.add_opt("--instruments", " ".join(workflow.ifos))
     node.add_opt("--gps-start-time", gps_start_time)
     node.add_opt("--gps-end-time", gps_end_time)


### PR DESCRIPTION
 -will simply be passed through to main inference executable

@cmbiwer @cdcapano another fairly simple change we found useful to make runs easier to debug. The extra output will end up in one of the files like workflow/submitdir/work/runname_inference-main_ID0000001.000/inference-H1L1_ID0_ID0000001.out.0xx if I remember correctly.