### PR TITLE
Add code to write html snippet

### DIFF
--- a/bin/plotting/pycbc_create_html_snippet
+++ b/bin/plotting/pycbc_create_html_snippet
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 
-# Copyright (C) 2015 Christopher M. Biwer
+# Copyright (C) 2019 Ian Harry
 #
 # This program is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License as published by the

--- a/bin/plotting/pycbc_create_html_snippet
+++ b/bin/plotting/pycbc_create_html_snippet
@@ -16,6 +16,7 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
+import sys
 import argparse
 import pycbc.version
 import pycbc.results

--- a/bin/plotting/pycbc_create_html_snippet
+++ b/bin/plotting/pycbc_create_html_snippet
@@ -1,0 +1,41 @@
+#!/usr/bin/python
+
+# Copyright (C) 2015 Christopher M. Biwer
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+import argparse
+import pycbc.version
+import pycbc.results
+
+# parse command line
+parser = argparse.ArgumentParser()
+parser.add_argument("--version", action="version", version=pycbc.version.git_verbose_msg)
+parser.add_argument('--output-file', type=str,
+                        help='Path of the output HTML file.')
+parser.add_argument('--html-text', type=str,
+                    help="Contents of output HTML file.")
+parser.add_argument('--title', type=str, default="Title",
+                    help="Title of figure for results webpage.")
+opts = parser.parse_args()
+
+# set caption beginning
+caption = opts.html_text
+
+# save the plot as an interactive HTML
+pycbc.results.save_fig_with_metadata(opts.html_text, opts.output_file,
+                                     title=opts.title,
+                                     cmd=' '.join(sys.argv),
+                                     caption=caption)


### PR DESCRIPTION
This PR adds a simple utility script to `bin/plotting`, which will take a string of html on the command line, and dump it to a file that can be appropriately parsed by the web-page generation. The specific use case here is that I want to add small blocks of text separating sections in one of the minifollowups, but this could be used in other areas of the results page, where you just want to print some simple, short, information.

This cannot be done in the `pycbc_XXX_minifollowups` script itself, because these scripts do not run in the `local` universe, and so would have to declare outputs to pegasus etc. in advance of the script running. However, we may not know what blocks of html text we need until running the workflow generator.