### PR TITLE
Background minifollowups

### DIFF
--- a/bin/minifollowups/pycbc_foreground_minifollowup
+++ b/bin/minifollowups/pycbc_foreground_minifollowup
@@ -50,12 +50,12 @@ parser.add_argument('--inspiral-data-read-name',
 parser.add_argument('--inspiral-data-analyzed-name',
                     help="Name of inspiral segmentlist containing data "
                          "analyzed by each analysis job.")
-parser.add_argument('--background-triggers', action='store_true',
-                    default=False,
-                    help="Perform followup on background triggers (with the "
-                         "foreground coincs excluded). If not given we will "
-                         "followup foreground triggers.")
-parser.add_argument('--output-map')
+parser.add_argument('--analysis-category', type=str, required=False,
+                    default='background_exc',
+                    choices = ['foreground', 'background', 'background_exc'],
+                    help='Designates whether to look at foreground triggers ',
+                         'background triggers (including "little dogs") '
+                         'or background triggers (with "little dogs" removed)')
 parser.add_argument('--output-file')
 parser.add_argument('--transformation-catalog')
 parser.add_argument('--tags', nargs='+', default=[])
@@ -93,10 +93,7 @@ for ifo in args.single_detector_triggers:
 
 num_events = int(workflow.cp.get_opt_tags('workflow-minifollowups', 'num-events', ''))
 f = h5py.File(args.statmap_file, 'r')
-if args.background_triggers:
-    file_val = 'background_exc'
-else:
-    file_val = 'foreground'
+file_val = args.analysis_category
 stat = f['{}/stat'.format(file_val)][:]
 
 sorting = stat.argsort()[::-1]

--- a/bin/minifollowups/pycbc_foreground_minifollowup
+++ b/bin/minifollowups/pycbc_foreground_minifollowup
@@ -138,7 +138,7 @@ else:
 bank_data = h5py.File(args.bank_file, 'r')
 
 # loop over number of loudest events to be followed up
-event_tids = {}
+event_times = {}
 skipped_data = []
 event_count = 0
 curr_idx = -1
@@ -156,18 +156,18 @@ while event_count < num_events and curr_idx < (events_to_read-1):
                                     key1, tids[key1][curr_idx])
         # For background do not want to follow up 10 background events caused
         # by the same event in ifo 1 and different, quiet, events in ifo 2,
-        if key0 not in event_tids:
-            event_tids[key0] = []
-        if int(tids[key0][curr_idx]) in event_tids[key0]:
-            skipped_data.append((key0, int(tids[key0][curr_idx])))
+        if key0 not in event_times:
+            event_times[key0] = []
+        if int(times[key0][curr_idx]) in event_times[key0]:
+            skipped_data.append((key0, int(times[key0][curr_idx])))
             continue
-        if key1 not in event_tids:
-            event_tids[key1] = []
-        if int(tids[key1][curr_idx]) in event_tids[key1]:
-            skipped_data.append((key1, int(tids[key1][curr_idx])))
+        if key1 not in event_times:
+            event_times[key1] = []
+        if int(times[key1][curr_idx]) in event_times[key1]:
+            skipped_data.append((key1, int(times[key1][curr_idx])))
             continue
-        event_tids[key0].append(int(tids[key0][curr_idx]))
-        event_tids[key1].append(int(tids[key1][curr_idx]))
+        event_times[key0].append(int(times[key0][curr_idx]))
+        event_times[key1].append(int(times[key1][curr_idx]))
 
     else:
         # Version used for multi-ifo coinc code
@@ -182,17 +182,17 @@ while event_count < num_events and curr_idx < (events_to_read-1):
 
             # For background do not want to follow up 10 background events
             # by the same event in ifo 1 and different, quiet, events in ifo 2,
-            if ifo not in event_tids:
-                event_tids[ifo] = []
-            if int(tids[ifo][curr_idx]) in event_tids[ifo]:
-                skipped_data.append((ifo, int(tids[ifo][curr_idx])))
+            if ifo not in event_times:
+                event_times[ifo] = []
+            if int(times[ifo][curr_idx]) in event_times[ifo]:
+                skipped_data.append((ifo, int(times[ifo][curr_idx])))
                 duplicate=True
                 break
 
         if duplicate:
             continue
         for ifo in times:
-            event_tids[ifo].append(int(tids[ifo][curr_idx]))
+            event_times[ifo].append(int(times[ifo][curr_idx]))
 
         ifo_times = ' '.join(ifo_times_strings)
         ifo_tids = ' '.join(ifo_tids_strings)

--- a/bin/minifollowups/pycbc_foreground_minifollowup
+++ b/bin/minifollowups/pycbc_foreground_minifollowup
@@ -159,12 +159,12 @@ while event_count < num_events and curr_idx < events_to_read:
         if key0 not in event_tids:
             event_tids[key0] = []
         if int(tids[key0][curr_idx]) in event_tids[key0]:
-            skipped_data.append((key0, int(tids[key0][curr_idx]))
+            skipped_data.append((key0, int(tids[key0][curr_idx])))
             continue
         if key1 not in events_tids
             event_tids[key1] = []
         if int(tids[key1][curr_idx]) in event_tids[key1]:
-            skipped_data.append((key1, int(tids[key1][curr_idx]))
+            skipped_data.append((key1, int(tids[key1][curr_idx])))
             continue
 
     else:

--- a/bin/minifollowups/pycbc_foreground_minifollowup
+++ b/bin/minifollowups/pycbc_foreground_minifollowup
@@ -134,34 +134,64 @@ else:
 bank_data = h5py.File(args.bank_file, 'r')
 
 # loop over number of loudest events to be followed up
+event_tids = {}
+skipped_data = []
+skip_count = 0
 for num_event in range(num_events):
     files = wf.FileList([])
 
     # Check if using input files from old (2-ifo) coinc code
-
-    ifo_timse = ''
-    ifo_tids = ''
-
     if 'detector_1' in f.attrs:
         key0, key1 = tuple(times.keys())[:2]
         ifo_times = '%s:%s %s:%s' % (key0, times[key0][num_event],
                                      key1, times[key1][num_event])
-
         key0, key1 = tuple(tids.keys())[:2]
         ifo_tids = '%s:%s %s:%s' % (key0, tids[key0][num_event],
                                     key1, tids[key1][num_event])
+        # For background do not want to follow up 10 background events caused
+        # by the same event in ifo 1 and different, quiet, events in ifo 2,
+        if key0 not in event_tids:
+            event_tids[key0] = []
+        if int(tids[key0][num_event]) in event_tids[key0]:
+            skipped_data.append((key0, int(tids[key0][num_event]))
+            continue
+        if key1 not in events_tids
+            event_tids[key1] = []
+        if int(tids[key1][num_event]) in event_tids[key1]:
+            skipped_data.append((key1, int(tids[key1][num_event]))
+            continue
+
     else:
         # Version used for multi-ifo coinc code
         ifo_times_strings = []
         ifo_tids_strings = []
+        duplicate = False
         for ifo in times:
             ifo_times_string = '%s:%s' % (ifo, times[ifo][num_event])
             ifo_tids_string = '%s:%s' % (ifo, tids[ifo][num_event])
             ifo_times_strings += [ifo_times_string]
             ifo_tids_strings += [ifo_tids_string]
 
+            # For background do not want to follow up 10 background events
+            # by the same event in ifo 1 and different, quiet, events in ifo 2,
+            if ifo not in event_tids:
+                event_tids[ifo] = []
+            if int(tids[ifo][num_event]) in event_tids[ifo]:
+                skipped_data.append((ifo, int(tids[ifo][num_event]))
+                duplicate=True
+                break
+
+        if duplicate:
+            continue
+
         ifo_times = ' '.join(ifo_times_strings)
         ifo_tids = ' '.join(ifo_tids_strings)
+
+    if skipped_data:
+        layouts += (mini.make_skipped_html(workflow, skipped_data,
+                                           tags='SKIP_{}'.format(skip_count)),)
+        skip_count += 1
+        skipped_data = []
 
     bank_id = f['{}/template_id'.format(file_val)][:][sorting][num_event]
 

--- a/bin/minifollowups/pycbc_foreground_minifollowup
+++ b/bin/minifollowups/pycbc_foreground_minifollowup
@@ -109,56 +109,62 @@ if len(stat) == 0:
                   transformation_catalog_path=args.transformation_catalog)
     sys.exit(0)
 
+events_to_read = num_events * 100
+
 if len(stat) < num_events:
     num_events = len(stat)
+if len(stat) < events_to_read:
+    events_to_read = len(stat)
 
-stat = stat[sorting][0:num_events]
+stat = stat[sorting][0:events_to_read]
 
 times = {}
 tids = {}
 # Check if using input files from old (2-ifo) coinc code
 if 'detector_1' in f.attrs:
-    times = {f.attrs['detector_1']: f['{}/time1'.format(file_val)][:][sorting][0:num_events],
-             f.attrs['detector_2']: f['{}/time2'.format(file_val)][:][sorting][0:num_events],
+    times = {f.attrs['detector_1']: f['{}/time1'.format(file_val)][:][sorting][0:events_to_read],
+             f.attrs['detector_2']: f['{}/time2'.format(file_val)][:][sorting][0:events_to_read],
             }
-    tids = {f.attrs['detector_1']: f['{}/trigger_id1'.format(file_val)][:][sorting][0:num_events],
-            f.attrs['detector_2']: f['{}/trigger_id2'.format(file_val)][:][sorting][0:num_events],
+    tids = {f.attrs['detector_1']: f['{}/trigger_id1'.format(file_val)][:][sorting][0:events_to_read],
+            f.attrs['detector_2']: f['{}/trigger_id2'.format(file_val)][:][sorting][0:events_to_read],
            }
 else:
     # Version used for multi-ifo coinc code
     ifo_list = f.attrs['ifos'].split(' ')
     for ifo in ifo_list:
-        times[ifo] = f['{}/{}/time'.format(file_val,ifo)][:][sorting][0:num_events]
-        tids[ifo] = f['{}/{}/trigger_id'.format(file_val, ifo)][:][sorting][0:num_events]
+        times[ifo] = f['{}/{}/time'.format(file_val,ifo)][:][sorting][0:events_to_read]
+        tids[ifo] = f['{}/{}/trigger_id'.format(file_val, ifo)][:][sorting][0:events_to_read]
 
 bank_data = h5py.File(args.bank_file, 'r')
 
 # loop over number of loudest events to be followed up
 event_tids = {}
 skipped_data = []
-skip_count = 0
-for num_event in range(num_events):
+event_count = 0
+curr_idx = -1
+while event_count < num_events and curr_idx < events_to_read:
+    curr_idx += 1
     files = wf.FileList([])
 
     # Check if using input files from old (2-ifo) coinc code
     if 'detector_1' in f.attrs:
         key0, key1 = tuple(times.keys())[:2]
-        ifo_times = '%s:%s %s:%s' % (key0, times[key0][num_event],
-                                     key1, times[key1][num_event])
+        ifo_times = '%s:%s %s:%s' % (key0, times[key0][curr_idx],
+                                     key1, times[key1][curr_idx])
         key0, key1 = tuple(tids.keys())[:2]
-        ifo_tids = '%s:%s %s:%s' % (key0, tids[key0][num_event],
-                                    key1, tids[key1][num_event])
+        ifo_tids = '%s:%s %s:%s' % (key0, tids[key0][curr_idx],
+                                    key1, tids[key1][curr_idx])
         # For background do not want to follow up 10 background events caused
         # by the same event in ifo 1 and different, quiet, events in ifo 2,
         if key0 not in event_tids:
             event_tids[key0] = []
-        if int(tids[key0][num_event]) in event_tids[key0]:
-            skipped_data.append((key0, int(tids[key0][num_event]))
+        if int(tids[key0][curr_idx]) in event_tids[key0]:
+            skipped_data.append((key0, int(tids[key0][curr_idx]))
             continue
         if key1 not in events_tids
             event_tids[key1] = []
-        if int(tids[key1][num_event]) in event_tids[key1]:
-            skipped_data.append((key1, int(tids[key1][num_event]))
+        if int(tids[key1][curr_idx]) in event_tids[key1]:
+            skipped_data.append((key1, int(tids[key1][curr_idx]))
             continue
 
     else:
@@ -167,8 +173,8 @@ for num_event in range(num_events):
         ifo_tids_strings = []
         duplicate = False
         for ifo in times:
-            ifo_times_string = '%s:%s' % (ifo, times[ifo][num_event])
-            ifo_tids_string = '%s:%s' % (ifo, tids[ifo][num_event])
+            ifo_times_string = '%s:%s' % (ifo, times[ifo][curr_idx])
+            ifo_tids_string = '%s:%s' % (ifo, tids[ifo][curr_idx])
             ifo_times_strings += [ifo_times_string]
             ifo_tids_strings += [ifo_tids_string]
 
@@ -176,8 +182,8 @@ for num_event in range(num_events):
             # by the same event in ifo 1 and different, quiet, events in ifo 2,
             if ifo not in event_tids:
                 event_tids[ifo] = []
-            if int(tids[ifo][num_event]) in event_tids[ifo]:
-                skipped_data.append((ifo, int(tids[ifo][num_event]))
+            if int(tids[ifo][curr_idx]) in event_tids[ifo]:
+                skipped_data.append((ifo, int(tids[ifo][curr_idx]))
                 duplicate=True
                 break
 
@@ -187,28 +193,28 @@ for num_event in range(num_events):
         ifo_times = ' '.join(ifo_times_strings)
         ifo_tids = ' '.join(ifo_tids_strings)
 
+    event_count += 1
     if skipped_data:
         layouts += (mini.make_skipped_html(workflow, skipped_data,
-                                           tags='SKIP_{}'.format(skip_count)),)
-        skip_count += 1
+                                           tags='SKIP_{}'.format(event_count)),)
         skipped_data = []
 
-    bank_id = f['{}/template_id'.format(file_val)][:][sorting][num_event]
+    bank_id = f['{}/template_id'.format(file_val)][:][sorting][curr_idx]
 
     layouts += (mini.make_coinc_info(workflow, single_triggers, tmpltbank_file,
-                              coinc_file, args.output_dir, n_loudest=num_event,
-                              tags=args.tags + [str(num_event)]),)
+                              coinc_file, args.output_dir, n_loudest=curr_idx,
+                              tags=args.tags + [str(event_count)]),)
     files += mini.make_trigger_timeseries(workflow, single_triggers,
                               ifo_times, args.output_dir, special_tids=ifo_tids,
-                              tags=args.tags + [str(num_event)])
+                              tags=args.tags + [str(event_count)])
 
     params = {}
     for ifo in times:
-        params['%s_end_time' % ifo] = times[ifo][num_event]
+        params['%s_end_time' % ifo] = times[ifo][curr_idx]
         try:
             # Only present for precessing case
             params['u_vals_%s'%ifo] = \
-                                 fsdt[ifo][ifo]['u_vals'][tids[ifo][num_event]]
+                                 fsdt[ifo][ifo]['u_vals'][tids[ifo][curr_idx]]
         except:
             pass
 
@@ -231,19 +237,19 @@ for num_event in range(num_events):
                                     args.inspiral_data_read_name,
                                     args.inspiral_data_analyzed_name,  params,
                                     args.output_dir,
-                                    tags=args.tags + [str(num_event)])
+                                    tags=args.tags + [str(event_count)])
 
     for single in single_triggers:
-        time = times[single.ifo][num_event]
+        time = times[single.ifo][curr_idx]
         files += mini.make_singles_timefreq(workflow, single, tmpltbank_file,
                                 time, args.output_dir,
                                 data_segments=insp_data_seglists[single.ifo],
-                                tags=args.tags + [str(num_event)])
+                                tags=args.tags + [str(event_count)])
 
         files += mini.make_qscan_plot\
             (workflow, single.ifo, time, args.output_dir,
              data_segments=insp_data_seglists[single.ifo],
-             tags=args.tags + [str(num_event)])
+             tags=args.tags + [str(event_count)])
 
 
     layouts += list(layout.grouper(files, 2))

--- a/bin/minifollowups/pycbc_foreground_minifollowup
+++ b/bin/minifollowups/pycbc_foreground_minifollowup
@@ -163,7 +163,7 @@ for num_event in range(num_events):
         ifo_times = ' '.join(ifo_times_strings)
         ifo_tids = ' '.join(ifo_tids_strings)
 
-    bank_id = f['foreground/template_id'][:][sorting][num_event]
+    bank_id = f['{}/template_id'.format(file_val)][:][sorting][num_event]
 
     layouts += (mini.make_coinc_info(workflow, single_triggers, tmpltbank_file,
                               coinc_file, args.output_dir, n_loudest=num_event,

--- a/bin/minifollowups/pycbc_foreground_minifollowup
+++ b/bin/minifollowups/pycbc_foreground_minifollowup
@@ -53,7 +53,7 @@ parser.add_argument('--inspiral-data-analyzed-name',
 parser.add_argument('--analysis-category', type=str, required=False,
                     default='background_exc',
                     choices = ['foreground', 'background', 'background_exc'],
-                    help='Designates whether to look at foreground triggers ',
+                    help='Designates whether to look at foreground triggers '
                          'background triggers (including "little dogs") '
                          'or background triggers (with "little dogs" removed)')
 parser.add_argument('--output-file')

--- a/bin/minifollowups/pycbc_foreground_minifollowup
+++ b/bin/minifollowups/pycbc_foreground_minifollowup
@@ -166,6 +166,8 @@ while event_count < num_events and curr_idx < events_to_read:
         if int(tids[key1][curr_idx]) in event_tids[key1]:
             skipped_data.append((key1, int(tids[key1][curr_idx])))
             continue
+        event_tids[key0].append(int(tids[key0][curr_idx]))
+        event_tids[key1].append(int(tids[key1][curr_idx]))
 
     else:
         # Version used for multi-ifo coinc code
@@ -189,6 +191,8 @@ while event_count < num_events and curr_idx < events_to_read:
 
         if duplicate:
             continue
+        for ifo in times:
+            event_tids[ifo].append(int(tids[ifo][curr_idx]))
 
         ifo_times = ' '.join(ifo_times_strings)
         ifo_tids = ' '.join(ifo_tids_strings)
@@ -196,7 +200,8 @@ while event_count < num_events and curr_idx < events_to_read:
     event_count += 1
     if skipped_data:
         layouts += (mini.make_skipped_html(workflow, skipped_data,
-                                           tags='SKIP_{}'.format(event_count)),)
+                                           args.output_dir,
+                                           tags=['SKIP_{}'.format(event_count)]),)
         skipped_data = []
 
     bank_id = f['{}/template_id'.format(file_val)][:][sorting][curr_idx]

--- a/bin/minifollowups/pycbc_foreground_minifollowup
+++ b/bin/minifollowups/pycbc_foreground_minifollowup
@@ -161,7 +161,7 @@ while event_count < num_events and curr_idx < events_to_read:
         if int(tids[key0][curr_idx]) in event_tids[key0]:
             skipped_data.append((key0, int(tids[key0][curr_idx])))
             continue
-        if key1 not in events_tids:
+        if key1 not in event_tids:
             event_tids[key1] = []
         if int(tids[key1][curr_idx]) in event_tids[key1]:
             skipped_data.append((key1, int(tids[key1][curr_idx])))

--- a/bin/minifollowups/pycbc_foreground_minifollowup
+++ b/bin/minifollowups/pycbc_foreground_minifollowup
@@ -161,7 +161,7 @@ while event_count < num_events and curr_idx < events_to_read:
         if int(tids[key0][curr_idx]) in event_tids[key0]:
             skipped_data.append((key0, int(tids[key0][curr_idx])))
             continue
-        if key1 not in events_tids
+        if key1 not in events_tids:
             event_tids[key1] = []
         if int(tids[key1][curr_idx]) in event_tids[key1]:
             skipped_data.append((key1, int(tids[key1][curr_idx])))
@@ -183,7 +183,7 @@ while event_count < num_events and curr_idx < events_to_read:
             if ifo not in event_tids:
                 event_tids[ifo] = []
             if int(tids[ifo][curr_idx]) in event_tids[ifo]:
-                skipped_data.append((ifo, int(tids[ifo][curr_idx]))
+                skipped_data.append((ifo, int(tids[ifo][curr_idx])))
                 duplicate=True
                 break
 

--- a/bin/minifollowups/pycbc_foreground_minifollowup
+++ b/bin/minifollowups/pycbc_foreground_minifollowup
@@ -50,6 +50,11 @@ parser.add_argument('--inspiral-data-read-name',
 parser.add_argument('--inspiral-data-analyzed-name',
                     help="Name of inspiral segmentlist containing data "
                          "analyzed by each analysis job.")
+parser.add_argument('--background-triggers', action='store_true',
+                    default=False,
+                    help="Perform followup on background triggers (with the "
+                         "foreground coincs excluded). If not given we will "
+                         "followup foreground triggers.")
 parser.add_argument('--output-map')
 parser.add_argument('--output-file')
 parser.add_argument('--transformation-catalog')
@@ -88,7 +93,11 @@ for ifo in args.single_detector_triggers:
 
 num_events = int(workflow.cp.get_opt_tags('workflow-minifollowups', 'num-events', ''))
 f = h5py.File(args.statmap_file, 'r')
-stat = f['foreground/stat'][:]
+if args.background_triggers:
+    file_val = 'background_exc'
+else:
+    file_val = 'foreground'
+stat = f['{}/stat'.format(file_val)][:]
 
 sorting = stat.argsort()[::-1]
 
@@ -109,18 +118,18 @@ times = {}
 tids = {}
 # Check if using input files from old (2-ifo) coinc code
 if 'detector_1' in f.attrs:
-    times = {f.attrs['detector_1']: f['foreground/time1'][:][sorting][0:num_events],
-             f.attrs['detector_2']: f['foreground/time2'][:][sorting][0:num_events],
+    times = {f.attrs['detector_1']: f['{}/time1'.format(file_val)][:][sorting][0:num_events],
+             f.attrs['detector_2']: f['{}/time2'.format(file_val)][:][sorting][0:num_events],
             }
-    tids = {f.attrs['detector_1']: f['foreground/trigger_id1'][:][sorting][0:num_events],
-            f.attrs['detector_2']: f['foreground/trigger_id2'][:][sorting][0:num_events],
+    tids = {f.attrs['detector_1']: f['{}/trigger_id1'.format(file_val)][:][sorting][0:num_events],
+            f.attrs['detector_2']: f['{}/trigger_id2'.format(file_val)][:][sorting][0:num_events],
            }
 else:
     # Version used for multi-ifo coinc code
     ifo_list = f.attrs['ifos'].split(' ')
     for ifo in ifo_list:
-        times[ifo] = f['foreground/%s/time' % ifo][:][sorting][0:num_events]
-        tids[ifo] = f['foreground/%s/trigger_id' % ifo][:][sorting][0:num_events]
+        times[ifo] = f['{}/{}/time'.format(file_val,ifo)][:][sorting][0:num_events]
+        tids[ifo] = f['{}/{}/trigger_id'.format(file_val, ifo)][:][sorting][0:num_events]
 
 bank_data = h5py.File(args.bank_file, 'r')
 

--- a/bin/minifollowups/pycbc_foreground_minifollowup
+++ b/bin/minifollowups/pycbc_foreground_minifollowup
@@ -142,7 +142,7 @@ event_tids = {}
 skipped_data = []
 event_count = 0
 curr_idx = -1
-while event_count < num_events and curr_idx < events_to_read:
+while event_count < num_events and curr_idx < (events_to_read-1):
     curr_idx += 1
     files = wf.FileList([])
 

--- a/bin/minifollowups/pycbc_page_coincinfo
+++ b/bin/minifollowups/pycbc_page_coincinfo
@@ -33,9 +33,9 @@ parser.add_argument('--output-file')
 parser.add_argument('--statmap-file', required=True,
     help="HDF format clustered coincident statmap file containing the result "
          "triggers. Required")
-parser.add_argument('--statmap-file-subspace-name', default='background',
+parser.add_argument('--statmap-file-subspace-name', default='background_exc',
     help="If given look in this 'sub-directory' of the HDF file for triggers, "
-         "takes a default value of 'background'.")
+         "takes a default value of 'background_exc'.")
 trig_input = parser.add_mutually_exclusive_group(required=True)
 trig_input.add_argument('--n-loudest', type=int,
     help="Examine the n'th loudest trigger, use with statmap file")

--- a/bin/minifollowups/pycbc_page_coincinfo
+++ b/bin/minifollowups/pycbc_page_coincinfo
@@ -72,11 +72,19 @@ if 'detector_1' in f.attrs:
                "Time delay (s)"
               ]
 
+    try:
+        fap_inclusive = d['fap'][n]
+        fap_exclusive = d['fap_exc'][n]
+        ifar_exclusive = d['ifar_exc'][n]
+    except:
+        fap_inclusive = -1
+        fap_exclusive = -1
+        ifar_exclusive = -1
     table = numpy.array([['%5.2f' % d['stat'][n],
                           '%5.2f' % d['ifar'][n],
-                          '%5.2e' % d['fap'][n],
-                          '%5.2f' % d['ifar_exc'][n],
-                          '%5.2e' % d['fap_exc'][n],
+                          '%5.2e' % fap_inclusive,
+                          '%5.2f' % ifar_exclusive,
+                          '%5.2e' % fap_exclusive,
                           '%5.4f' % (d['time2'][n] - d['time1'][n])
                          ]], dtype=str)
 else:

--- a/bin/minifollowups/pycbc_page_coincinfo
+++ b/bin/minifollowups/pycbc_page_coincinfo
@@ -33,9 +33,9 @@ parser.add_argument('--output-file')
 parser.add_argument('--statmap-file', required=True,
     help="HDF format clustered coincident statmap file containing the result "
          "triggers. Required")
-parser.add_argument('--statmap-file-subspace-name', default='foreground',
+parser.add_argument('--statmap-file-subspace-name', default='background',
     help="If given look in this 'sub-directory' of the HDF file for triggers, "
-         "takes a default value of 'foreground'.")
+         "takes a default value of 'background'.")
 trig_input = parser.add_mutually_exclusive_group(required=True)
 trig_input.add_argument('--n-loudest', type=int,
     help="Examine the n'th loudest trigger, use with statmap file")

--- a/bin/workflows/pycbc_make_coinc_search_workflow
+++ b/bin/workflows/pycbc_make_coinc_search_workflow
@@ -390,6 +390,14 @@ wf.setup_foreground_minifollowups(workflow, final_bg_file,
                               rdir['open_box_result/loudest_event_followup'],
                               tags=final_bg_file.tags)
 
+curr_rdir = 'coincident_triggers/loudest_background_followup'
+wf.setup_foreground_minifollowups(workflow, final_bg_file,
+                              full_insps,  hdfbank[0], insp_files_seg_file,
+                              data_analysed_name, trig_generated_name, 'daxes',
+                              rdir[curr_rdir],
+                              tags=final_bg_file.tags + ['background'])
+
+
 for bin_file in bin_files:
     if hasattr(bin_file, 'bin_name'):
         currdir = rdir['open_box_result/loudest_in_%s_bin' % bin_file.bin_name]

--- a/bin/workflows/pycbc_make_coinc_search_workflow
+++ b/bin/workflows/pycbc_make_coinc_search_workflow
@@ -388,7 +388,7 @@ wf.setup_foreground_minifollowups(workflow, final_bg_file,
                               full_insps,  hdfbank[0], insp_files_seg_file,
                               data_analysed_name, trig_generated_name, 'daxes',
                               rdir['open_box_result/loudest_event_followup'],
-                              tags=final_bg_file.tags)
+                              tags=final_bg_file.tags + ['foreground'])
 
 curr_rdir = 'coincident_triggers/loudest_background_followup'
 wf.setup_foreground_minifollowups(workflow, final_bg_file,

--- a/pycbc/workflow/minifollowups.py
+++ b/pycbc/workflow/minifollowups.py
@@ -815,9 +815,9 @@ def make_skipped_html(workflow, skipped_data, out_dir, tags):
 
     parsed_data = {}
     for ifo, time in skipped_data:
-        if not ifo in parsed_data:
+        if ifo not in parsed_data:
             parsed_data[ifo] = {}
-        if not time in parsed_data[ifo]:
+        if time not in parsed_data[ifo]:
             parsed_data[ifo][time] = 1
         else:
             parsed_data[ifo][time] = parsed_data[ifo][time] + 1

--- a/pycbc/workflow/minifollowups.py
+++ b/pycbc/workflow/minifollowups.py
@@ -97,7 +97,7 @@ def setup_foreground_minifollowups(workflow, coinc_file, single_triggers,
     node.add_opt('--inspiral-data-read-name', insp_data_name)
     node.add_opt('--inspiral-data-analyzed-name', insp_anal_name)
     if tags:
-        node.add_input_list_opt('--tags', tags)
+        node.add_list_opt('--tags', tags)
     node.new_output_file_opt(workflow.analysis_time, '.dax', '--output-file')
     node.new_output_file_opt(workflow.analysis_time, '.dax.map', '--output-map')
     node.new_output_file_opt(workflow.analysis_time, '.tc.txt', '--transformation-catalog')

--- a/pycbc/workflow/minifollowups.py
+++ b/pycbc/workflow/minifollowups.py
@@ -86,7 +86,7 @@ def setup_foreground_minifollowups(workflow, coinc_file, single_triggers,
     config_file = wdax.File(os.path.basename(config_path))
     config_file.PFN(urljoin('file:', pathname2url(config_path)), site='local')
 
-    exe = Executable(workflow.cp, 'foreground_minifollowup', ifos=workflow.ifos, out_dir=dax_output)
+    exe = Executable(workflow.cp, 'foreground_minifollowup', ifos=workflow.ifos, out_dir=dax_output, tags=tags)
 
     node = exe.create_node()
     node.add_input_opt('--config-files', config_file)
@@ -96,9 +96,9 @@ def setup_foreground_minifollowups(workflow, coinc_file, single_triggers,
     node.add_input_opt('--inspiral-segments', insp_segs)
     node.add_opt('--inspiral-data-read-name', insp_data_name)
     node.add_opt('--inspiral-data-analyzed-name', insp_anal_name)
-    node.new_output_file_opt(workflow.analysis_time, '.dax', '--output-file', tags=tags)
-    node.new_output_file_opt(workflow.analysis_time, '.dax.map', '--output-map', tags=tags)
-    node.new_output_file_opt(workflow.analysis_time, '.tc.txt', '--transformation-catalog', tags=tags)
+    node.new_output_file_opt(workflow.analysis_time, '.dax', '--output-file')
+    node.new_output_file_opt(workflow.analysis_time, '.dax.map', '--output-map')
+    node.new_output_file_opt(workflow.analysis_time, '.tc.txt', '--transformation-catalog')
 
     name = node.output_files[0].name
     map_file = node.output_files[1]

--- a/pycbc/workflow/minifollowups.py
+++ b/pycbc/workflow/minifollowups.py
@@ -836,7 +836,7 @@ def make_skipped_html(workflow, skipped_data, out_dir, tags):
 
     html_string += '"'
 
-    node.add_opt('--html_text', html_string)
+    node.add_opt('--html-text', html_string)
     node.add_opt('--title', '"Events were skipped"')
     node.new_output_file_opt(workflow.analysis_time, '.html', '--output-file')
     workflow += node

--- a/pycbc/workflow/minifollowups.py
+++ b/pycbc/workflow/minifollowups.py
@@ -823,7 +823,7 @@ def make_skipped_html(workflow, skipped_data, out_dir, tags):
             parsed_data[ifo][time] = parsed_data[ifo][time] + 1
 
     n_events = len(skipped_data)
-    html_string = '{} background events have been skipped '.format(n_events)
+    html_string = '"{} background events have been skipped '.format(n_events)
     html_string += 'because one of their single triggers already appears '
     html_string += 'in the events followed up above. '
     html_string += 'Specifically, the following single detector triggers '
@@ -833,6 +833,8 @@ def make_skipped_html(workflow, skipped_data, out_dir, tags):
         for time in parsed_data[ifo]:
             n_occurances = parsed_data[ifo][time]
             html_string += html_template.format(ifo, time, n_occurances)
+
+    html_string += '"'
 
     node.add_opt('--html_text', html_string)
     node.add_opt('--title', 'Events were skipped')

--- a/pycbc/workflow/minifollowups.py
+++ b/pycbc/workflow/minifollowups.py
@@ -96,6 +96,8 @@ def setup_foreground_minifollowups(workflow, coinc_file, single_triggers,
     node.add_input_opt('--inspiral-segments', insp_segs)
     node.add_opt('--inspiral-data-read-name', insp_data_name)
     node.add_opt('--inspiral-data-analyzed-name', insp_anal_name)
+    if tags:
+        node.add_input_list_opt('--tags', tags)
     node.new_output_file_opt(workflow.analysis_time, '.dax', '--output-file')
     node.new_output_file_opt(workflow.analysis_time, '.dax.map', '--output-map')
     node.new_output_file_opt(workflow.analysis_time, '.tc.txt', '--transformation-catalog')

--- a/pycbc/workflow/minifollowups.py
+++ b/pycbc/workflow/minifollowups.py
@@ -837,7 +837,9 @@ def make_skipped_html(workflow, skipped_data, out_dir, tags):
     node.add_opt('--html_text', html_string)
     node.add_opt('--title', 'Events were skipped')
     node.new_output_file_opt(workflow.analysis_time, '.html', '--output-file')
-    return node
+    workflow += node
+    files = node.output_files
+    return files
 
 
 def create_noop_node():

--- a/pycbc/workflow/minifollowups.py
+++ b/pycbc/workflow/minifollowups.py
@@ -837,7 +837,7 @@ def make_skipped_html(workflow, skipped_data, out_dir, tags):
     html_string += '"'
 
     node.add_opt('--html_text', html_string)
-    node.add_opt('--title', 'Events were skipped')
+    node.add_opt('--title', '"Events were skipped"')
     node.new_output_file_opt(workflow.analysis_time, '.html', '--output-file')
     workflow += node
     files = node.output_files

--- a/pycbc/workflow/minifollowups.py
+++ b/pycbc/workflow/minifollowups.py
@@ -837,6 +837,7 @@ def make_skipped_html(workflow, skipped_data, out_dir, tags):
     node.add_opt('--html_text', html_string)
     node.add_opt('--title', 'Events were skipped')
     node.new_output_file_opt(workflow.analysis_time, '.html', '--output-file')
+    return node
 
 
 def create_noop_node():


### PR DESCRIPTION
A long-time action item from my to-do list, but one that I now think is needed:

This PR adds a new section 4.1 to the HTML results pages. This section will show minifollowups of all the loudest background events. This can be useful to see which outliers are still affecting the background after applying Denty bins. Single events will usually show up numerous times here (e.g. the loudest X background events often contain a single L1 or H1 event found in multiple time slides with different events in the other ifo). I catch this on the result page and just add a snippet of html saying "Event X was found in the next Y loudest events, but I'm not going to bother showing you the same event numerous times".

This one might be a little rough, so suggestions for cleaning up the code welcome here!