### PR TITLE
[WIP] Make minifollowup executables the same for all jobs

### DIFF
--- a/pycbc/workflow/minifollowups.py
+++ b/pycbc/workflow/minifollowups.py
@@ -431,9 +431,9 @@ def make_single_template_plots(workflow, segs, data_read_name, analyzed_name,
                 _MAKE_SINGLE_TEMPLATE_EXE = curr_exe
             else:
                 curr_exe = _MAKE_SINGLE_TEMPLATE_EXE
-                curr_exe.update_current_tags([tag] + tags)
                 curr_exe.ifo_list = [ifo]
                 curr_exe.ifo_string = ifo
+                curr_exe.update_current_tags([tag] + tags)
             node = curr_exe.create_node()
             if use_exact_inj_params:
                 node.add_opt('--use-params-of-closest-injection')

--- a/pycbc/workflow/minifollowups.py
+++ b/pycbc/workflow/minifollowups.py
@@ -575,7 +575,7 @@ def make_coinc_info(workflow, singles, bank, coinc, out_dir,
         _MAKE_COINC_INFO_EXE = curr_exe
     else:
         curr_exe = _MAKE_COINC_INFO_EXE
-        curr_exe.update_current_tags(out_dir)
+        curr_exe.update_current_tags(tags)
     node = curr_exe.create_node()
     node.add_input_list_opt('--single-trigger-files', singles)
     node.add_input_opt('--statmap-file', coinc)

--- a/pycbc/workflow/minifollowups.py
+++ b/pycbc/workflow/minifollowups.py
@@ -354,6 +354,7 @@ class PlotQScanExecutable(PlotExecutable):
 
 
 _MAKE_SINGLE_TEMPLATE_EXE = None
+_MAKE_SINGLE_TEMPLATE_PLOT_EXE = None
 def make_single_template_plots(workflow, segs, data_read_name, analyzed_name,
                                   params, out_dir, inj_file=None, exclude=None,
                                   require=None, tags=None, params_str=None,
@@ -412,6 +413,7 @@ def make_single_template_plots(workflow, segs, data_read_name, analyzed_name,
         The list of workflow.Files created in this function.
     """
     global _MAKE_SINGLE_TEMPLATE_EXE
+    global _MAKE_SINGLE_TEMPLATE_PLOT_EXE
     tags = [] if tags is None else tags
     makedir(out_dir)
     name = 'single_template_plot'
@@ -470,8 +472,17 @@ def make_single_template_plots(workflow, segs, data_read_name, analyzed_name,
             data = node.output_files[0]
             workflow += node
             # Make the plot for this trigger and detector
-            node = PlotExecutable(workflow.cp, name, ifos=[ifo],
-                              out_dir=out_dir, tags=[tag] + tags).create_node()
+            if _MAKE_SINGLE_TEMPLATE_PLOT_EXE is None:
+                curr_exe = PlotExecutable(workflow.cp, name, ifos=[ifo],
+                                          out_dir=out_dir, tags=[tag] + tags)
+                _MAKE_SINGLE_TEMPLATE_PLOT_EXE = curr_exe
+            else:
+                curr_exe = _MAKE_SINGLE_TEMPLATE_PLOT_EXE
+                curr_exe.ifo_list = [ifo]
+                curr_exe.ifo_string = ifo
+                curr_exe.update_current_tags([tag] + tags)
+
+            node = curr_exe.create_node()
             node.add_input_opt('--single-template-file', data)
             node.new_output_file_opt(workflow.analysis_time, '.png',
                                      '--output-file')

--- a/pycbc/workflow/minifollowups.py
+++ b/pycbc/workflow/minifollowups.py
@@ -424,7 +424,7 @@ def make_single_template_plots(workflow, segs, data_read_name, analyzed_name,
                 continue
             # Reanalyze the time around the trigger in each detector
             if _MAKE_SINGLE_TEMPLATE_EXE is None:
-                curr_exe = SingleTemplateExecutable
+                curr_exe = SingleTemplateExecutable\
                     (workflow.cp, 'single_template',
                      ifos=[ifo], out_dir=out_dir,
                      tags=[tag] + tags)


### PR DESCRIPTION
I am seeing some cases where minifollowups can overload a filesystem. Especially true when one is doing a partial rerun and *all* the minifollowups jobs start at the same time. One way to reduce the load is to use the `label` clustering feature so that minifollowups jobs run in sequence in a `pegasus_merge` job. For this to work, the various jobs (e.g. single_template, qscan, ....) need to use the same executable in the transfer catalog. At the moment there is one executable per transfer catalog. This is also bad if running remotely, as the workflow will then copy the same executable multiple times.

This PR addresses this by globally defining the Executables used in `minifollowup.py` so that from the user's perspective nothing changes, but from pegasus' perspective these are now multiple instances of the same kind of job, which is needed for label clustering to work. (The functionality to do this was added when putting in some of the template bank workflows, so it's just a case of using the "change tags without changing executable" functions that are now there).