### PR TITLE
Turn integrity checking off

### DIFF
--- a/pycbc/workflow/pegasus_files/pegasus-properties.conf
+++ b/pycbc/workflow/pegasus_files/pegasus-properties.conf
@@ -49,3 +49,5 @@ pegasus.register=True
 # Requires python package amqplib to be installed
 pegasus.monitord.encoding = json
 pegasus.catalog.workflow.amqp.url = amqp://friend:donatedata@msgs.pegasus.isi.edu:5672/prod/workflows
+
+pegasus.integrity.checking = none


### PR DESCRIPTION
Pegasus' new integrity checking is causing problems. It is checksumming all the frame files (twice) when symlinking these into the workflow directory. As these are symlinked, they cannot be different. This is also causing file system strain in other file_in or file_out jobs. I get that there is some advantage here when running on grid environments, but at the moment it seems like this feature is hurting us more than it is helping us. Therefore I want to disable this as the default (it can always be reactivated on a per-workflow basis using the features in `pycbc_submit_dax`).