### PR TITLE
Allow fallback in edge case in pycbc_page_snrchi

### DIFF
--- a/bin/hdfcoinc/pycbc_page_snrchi
+++ b/bin/hdfcoinc/pycbc_page_snrchi
@@ -53,7 +53,10 @@ for i, cval in enumerate(args.newsnr_contours):
         label = "$\\hat{\\rho} = %s$" % cval
     else:
         label = "$%s$" % cval
-    label_pos_idx = numpy.where(snrv > snr.max() * 0.8)[0][0]
+    try:
+        label_pos_idx = numpy.where(snrv > snr.max() * 0.8)[0][0]
+    except IndexError:
+        label_pos_idx = 0
     pylab.text(snrv[label_pos_idx], r[label_pos_idx], label, fontsize=6,
                horizontalalignment='center', verticalalignment='center',
                bbox=dict(facecolor='white', lw=0, pad=0, alpha=0.9))


### PR DESCRIPTION
I encountered an "edge-case bug" in `pycbc_page_snrchi`. Basically if you have a case where you have a set of triggers, where the maximum chi-squared is small, but the maximum SNR is not small the code to identify where best to put the plot label on the plot can fail. In this case it is better to do something than to fail, so I just choose an arbitrary location to put the plot label.

This might lead to the plot being a little obscured, but it's better than the code failing. I'll leave it to someone else to "improve" this edge case in the future if that ever becomes a problem.