### PR TITLE
add verbose flag to inference workflow_config.ini example

### DIFF
--- a/examples/workflow/inference/workflow_config.ini
+++ b/examples/workflow/inference/workflow_config.ini
@@ -44,6 +44,7 @@ urltype = file
 
 [inference]
 ; command line options use --help for more information
+verbose =
 sample-rate = 2048
 strain-high-pass = 20
 pad-data = 8


### PR DESCRIPTION
can be quite useful especially for new users who start by copying the example files

(as suggested by @cmbiwer in #2856 instead of my initially suggested extra commandline option)