### PR TITLE
Fix invcdf in Gaussian distribution

### DIFF
--- a/pycbc/distributions/gaussian.py
+++ b/pycbc/distributions/gaussian.py
@@ -138,21 +138,46 @@ class Gaussian(bounded.BoundedDist):
     def var(self):
         return self._var
 
-    def cdfinv(self, param, value):
-        """Return inverse of cdf to map unit interval to parameter bounds.
-        """
-        a = self._bounds[param][0]
-        b = self._bounds[param][1]
+    def _normalcdf(self, param, value):
+        """The CDF of the normal distribution, without bounds."""
         mu = self._mean[param]
-        sigma = numpy.sqrt(self._var[param])
-        phi_a = erf((a - mu)/sigma)
-        phi_b = erf((b - mu)/sigma)
-        z = phi_b - phi_a
+        var = self._var[param]
+        return 0.5*(1. + erf((value - mu)/(2*var)**0.5))
 
-        new_value = mu + sigma * erfinv(value * z + erf((a - mu)/sigma))
+    def cdf(self, param, value):
+        """Returns the CDF of the given parameter value."""
+        a, b = self._bounds[param]
+        if a != -numpy.inf:
+            phi_a = self._normalcdf(param, a)
+        else:
+            phi_a = 0.
+        if b != numpy.inf:
+            phi_b = self._normalcdf(param, b)
+        else:
+            phi_b = 1.
+        phi_x = self._normalcdf(param, value)
+        return (phi_x - phi_a)/(phi_b - phi_a)
 
-        return new_value
+    def _normalcdfinv(self, param, p):
+        """The inverse CDF of the normal distribution, without bounds."""
+        mu = self._mean[param]
+        var = self._var[param]
+        return mu + (2*var)**0.5 * erfinv(2*p - 1.)
 
+    def cdfinv(self, param, p):
+        """Return inverse of the CDF.
+        """
+        a, b = self._bounds[param]
+        if a != -numpy.inf:
+            phi_a = self._normalcdf(param, a)
+        else:
+            phi_a = 0.
+        if b != numpy.inf:
+            phi_b = self._normalcdf(param, b)
+        else:
+            phi_b = 1.
+        adjusted_p = phi_a + p * (phi_b - phi_a)
+        return self._normalcdfinv(param, adjusted_p)
 
     def _pdf(self, **kwargs):
         """Returns the pdf at the given values. The keyword arguments must


### PR DESCRIPTION
The `invcdf` function in the `Gaussian` distribution has a bug in it. For example, with:
```
meanx = 1.3420330148091835
varx = 0.0081
minx = 1.
maxx = 2.
```
I plotted the CDF (input) vs the inverse CDF (output) from pycbc, and compared to scipy's to `scipy.stats.truncnorm`, getting [this](https://www.atlas.aei.uni-hannover.de/~work-cdcapano/scratch/prs/fix_gaussian_invcdf/gaussian_invcdf_comp-bug.png). Clearly, something is wrong. This will bug will affect both multinest and dynesty when using a Gaussian distribution for any parameter prior.

This patch fixes this, and in the process adds a cdf function to  the `Gaussian` distribution. [Here is a notebook](https://www.atlas.aei.uni-hannover.de/~work-cdcapano/scratch/prs/fix_gaussian_invcdf/GaussianDistributionCheck.html) comparing results with this patch.

