### PR TITLE
Make normalization term optional and save data instead of whitened data

### DIFF
--- a/pycbc/inference/models/marginalized_gaussian_noise.py
+++ b/pycbc/inference/models/marginalized_gaussian_noise.py
@@ -151,7 +151,7 @@ class MarginalizedPhaseGaussianNoise(GaussianNoise):
                 # calculate inner products
                 hh_i = h[self._kmin[det]:kmax].inner(
                     h[self._kmin[det]:kmax]).real
-                hd_i = self.data[det][self._kmin[det]:kmax].inner(
+                hd_i = self._whitened_data[det][self._kmin[det]:kmax].inner(
                     h[self._kmin[det]:kmax])
             # store
             setattr(self._current_stats, '{}_optimal_snrsq'.format(det), hh_i)


### PR DESCRIPTION
This makes the normalization term that was introduced in #2795 optional, as it sometimes can cause numerical issues for nested samplers. By default, the normalization is set to False now. To turn it on, you set `normalize =` in the model part of the configuration file.

This also makes it so that the original data is stored to the output file, rather than the whitened data. It also fixes some documentation issues that were introduced in #2795.