### PR TITLE
Inference warning when parameter repeated

### DIFF
--- a/pycbc/distributions/__init__.py
+++ b/pycbc/distributions/__init__.py
@@ -143,6 +143,12 @@ def read_params_from_config(cp, prior_section='prior',
                            for key in cp.options(sargs_section)])
     except _ConfigParser.NoSectionError:
         static_args = {}
+    # sanity check that each parameter in [variable_args] 
+    # is not repeated in [static_args]
+    for arg in variable_args:
+        if arg in static_args:
+            raise KeyError("Parameter {} found both in static_args and in "
+                           "variable_args sections.".format(arg))
     # try converting values to float
     for key in static_args:
         val = static_args[key]

--- a/pycbc/distributions/__init__.py
+++ b/pycbc/distributions/__init__.py
@@ -143,7 +143,7 @@ def read_params_from_config(cp, prior_section='prior',
                            for key in cp.options(sargs_section)])
     except _ConfigParser.NoSectionError:
         static_args = {}
-    # sanity check that each parameter in [variable_args] 
+    # sanity check that each parameter in [variable_args]
     # is not repeated in [static_args]
     for arg in variable_args:
         if arg in static_args:


### PR DESCRIPTION
pycbc_inference ignores a variable_param (even if it has a priors section) when the same parameter appears in the static_args section. This can often happen when copying config files from other runs, and one would not notice until getting a matplotlib error when trying to plot the results.

This PR raises an error when reading the config file if it finds that a parameter is repeated both in the static_args and in the variable_args sections. 