### PR TITLE
Optimize the PSD variation statistic

### DIFF
--- a/pycbc/psd/variation.py
+++ b/pycbc/psd/variation.py
@@ -353,7 +353,9 @@ def calc_filt_psd_variation(strain, segment, short_segment, psd_long_segment,
     return psd_var
 
 
-_CACHED_PSD_VAR_INTERPOLANT=None
+_CACHED_PSD_VAR_INTERPOLANT = None
+
+
 def new_find_trigger_value(psd_var, idx, start, sample_rate):
     """ Find the PSD variation value at a particular time with the filter
     method. If the time is outside the timeseries bound, 1. is given.

--- a/pycbc/psd/variation.py
+++ b/pycbc/psd/variation.py
@@ -377,11 +377,11 @@ def new_find_trigger_value(psd_var, idx, start, sample_rate):
     time = start + idx / sample_rate
     # Extract the PSD variation at trigger time through linear
     # interpolation
-    if not hasattr(psd_var, _CACHED_PSD_VAR_INTERPOLANT):
+    if not hasattr(psd_var, 'cached_psd_var_interpolant'):
         from scipy import interpolate
-        psd.var._CACHED_PSD_VAR_INTERPOLANT = \
+        psd_var.cached_psd_var_interpolant = \
             interpolate.interp1d(psd_var.sample_times, psd_var, fill_value=1,
                                  bounds_error=False)
-    vals = psd_var._CACHED_PSD_VAR_INTERPOLANT(time)
+    vals = psd_var.cached_psd_var_interpolant(time)
 
     return vals

--- a/pycbc/psd/variation.py
+++ b/pycbc/psd/variation.py
@@ -353,9 +353,6 @@ def calc_filt_psd_variation(strain, segment, short_segment, psd_long_segment,
     return psd_var
 
 
-_CACHED_PSD_VAR_INTERPOLANT = None
-
-
 def new_find_trigger_value(psd_var, idx, start, sample_rate):
     """ Find the PSD variation value at a particular time with the filter
     method. If the time is outside the timeseries bound, 1. is given.
@@ -376,16 +373,15 @@ def new_find_trigger_value(psd_var, idx, start, sample_rate):
     vals : Array
         PSD variation value at a particular time
     """
-    global _CACHED_PSD_VAR_INTERPOLANT
     # Find gps time of the trigger
     time = start + idx / sample_rate
     # Extract the PSD variation at trigger time through linear
     # interpolation
-    if _CACHED_PSD_VAR_INTERPOLANT is None:
+    if not hasattr(psd_var, _CACHED_PSD_VAR_INTERPOLANT):
         from scipy import interpolate
-        _CACHED_PSD_VAR_INTERPOLANT = \
+        psd.var._CACHED_PSD_VAR_INTERPOLANT = \
             interpolate.interp1d(psd_var.sample_times, psd_var, fill_value=1,
                                  bounds_error=False)
-    vals = _CACHED_PSD_VAR_INTERPOLANT(time)
+    vals = psd_var._CACHED_PSD_VAR_INTERPOLANT(time)
 
     return vals

--- a/pycbc/psd/variation.py
+++ b/pycbc/psd/variation.py
@@ -382,7 +382,8 @@ def new_find_trigger_value(psd_var, idx, start, sample_rate):
     if _CACHED_PSD_VAR_INTERPOLANT is None:
         from scipy import interpolate
         _CACHED_PSD_VAR_INTERPOLANT = \
-            interpolate.interp1d(psd_var.sample_times, psd_var, fill_value=1)
+            interpolate.interp1d(psd_var.sample_times, psd_var, fill_value=1,
+                                 bounds_error=False)
     vals = _CACHED_PSD_VAR_INTERPOLANT(time)
 
     return vals

--- a/pycbc/psd/variation.py
+++ b/pycbc/psd/variation.py
@@ -353,6 +353,7 @@ def calc_filt_psd_variation(strain, segment, short_segment, psd_long_segment,
     return psd_var
 
 
+_CACHED_PSD_VAR_INTERPOLANT=None
 def new_find_trigger_value(psd_var, idx, start, sample_rate):
     """ Find the PSD variation value at a particular time with the filter
     method. If the time is outside the timeseries bound, 1. is given.
@@ -373,11 +374,15 @@ def new_find_trigger_value(psd_var, idx, start, sample_rate):
     vals : Array
         PSD variation value at a particular time
     """
-
+    global _CACHED_PSD_VAR_INTERPOLANT
     # Find gps time of the trigger
     time = start + idx / sample_rate
     # Extract the PSD variation at trigger time through linear
     # interpolation
-    vals = numpy.interp(time, psd_var.sample_times, psd_var,
-                        left=1., right=1.)
+    if _CACHED_PSD_VAR_INTERPOLANT is None:
+        from scipy import interpolate
+        _CACHED_PSD_VAR_INTERPOLANT = \
+            interpolate.interp1d(psd_var.sample_times, psd_var, fill_value=1)
+    vals = _CACHED_PSD_VAR_INTERPOLANT(time)
+
     return vals


### PR DESCRIPTION
The PSD variation statistic at the moment is slow because its recomputing the full interpolation every time that `new_find_trigger_value` is called (and it's called a lot!) If we swap to scipy, and cache the interpolation itself, the code is no longer slow.

At the moment this results in about a factor of 6 slowdown if using PSD variation, so I would encourage people testing this to incorporate this patch.

.... Maybe for safety I should add a test to recompute the interpolation if the psd_var object changes??