### PR TITLE
Fix issue with invalid checkpoint file raising error

### DIFF
--- a/pycbc/inference/sampler/base.py
+++ b/pycbc/inference/sampler/base.py
@@ -166,6 +166,13 @@ class BaseSampler(object):
         injection_file : str, optional
             If an injection was added to the data, write its information.
         """
+        # check that the output file doesn't already exist
+        if os.path.exists(output_file):
+            if force:
+                os.remove(output_file)
+            else:
+                raise OSError("output-file already exists; use force if you "
+                              "wish to overwrite it.")
         # check for backup file(s)
         checkpoint_file = output_file + '.checkpoint'
         backup_file = output_file + '.bkup'
@@ -178,7 +185,7 @@ class BaseSampler(object):
         self.new_checkpoint = False  # keeps track if this is a new file or not
         if not checkpoint_valid:
             logging.info("Checkpoint not found or not valid")
-            create_new_output_file(self, checkpoint_file, force=force,
+            create_new_output_file(self, checkpoint_file,
                                    injection_file=injection_file)
             # now the checkpoint is valid
             self.new_checkpoint = True
@@ -203,8 +210,7 @@ class BaseSampler(object):
 # =============================================================================
 #
 
-def create_new_output_file(sampler, filename, force=False, injection_file=None,
-                           **kwargs):
+def create_new_output_file(sampler, filename, injection_file=None, **kwargs):
     """Creates a new output file.
 
     If the output file already exists, an ``OSError`` will be raised. This can
@@ -224,12 +230,6 @@ def create_new_output_file(sampler, filename, force=False, injection_file=None,
         All other keyword arguments are passed through to the file's
         ``write_metadata`` function.
     """
-    if os.path.exists(filename):
-        if force:
-            os.remove(filename)
-        else:
-            raise OSError("output-file already exists; use force if you "
-                          "wish to overwrite it.")
     logging.info("Creating file {}".format(filename))
     with sampler.io(filename, "w") as fp:
         # create the samples group and sampler info group


### PR DESCRIPTION
PyCBC Inference has a `--force` option that is supposed to check if the output file exists, and raising an error if it does (unless the user supplies `--force`). However, currently, the check is done on the checkpoint file rather than the output file. This causes two bugs. First, the output file will be overwritten even if you have not supplied `--force`. Second, if an invalid checkpoint file exists, it will cause the code to quit unless `--force` is supplied. This isn't what we want. If an invalid checkpoint file exists, it should just be overwritten. This has caused issues when running in a dax. If the job fails before the first checkpoint, then on restart the job fails again because it finds a checkpoint file without anything in it (i.e., an invalid checkpoint) then raises an error if `--force` isn't supplied. It should always just create a fresh checkpoint file in that case.

This patch fixes this by moving the check for the output file into `setup_output` so that the output file is the file that is actually being checked for. It also results in invalid checkpoint files being overwritten, as desired.