### PR TITLE
add alternate pta maker script

### DIFF
--- a/bin/hdfcoinc/pycbc_multiifo_dtphase
+++ b/bin/hdfcoinc/pycbc_multiifo_dtphase
@@ -12,7 +12,7 @@ weight assigned to that bin.
 
 To get the signal rate this should be scaled by the local sensitivity value
 and by the SNR of the signal in the reference detector 
-(see pycbc/events/stat.py)
+(see pycbc/events/stat.py) & PhaseTDNewStatistic
 """
 import argparse, h5py, numpy.random, pycbc.detector, logging, multiprocessing
 from numpy.random import normal, uniform, power

--- a/bin/hdfcoinc/pycbc_multiifo_dtphase
+++ b/bin/hdfcoinc/pycbc_multiifo_dtphase
@@ -2,6 +2,13 @@
 """ Create a file containing the phase and amplitude, 
 correlations between two detectors by
 doing a simple monte-carlo
+
+Output is the relative SNR, time, and phase as compared to a reference
+IFO (the first one provided). 
+
+To get the noise rate this should be scaled by the local sensitivity value
+and by the SNR of the signal in the reference detector 
+(see pycbc/events/stat.py)
 """
 import argparse, h5py, numpy.random, pycbc.detector, logging, multiprocessing
 from numpy.random import normal, uniform, power

--- a/bin/hdfcoinc/pycbc_multiifo_dtphase
+++ b/bin/hdfcoinc/pycbc_multiifo_dtphase
@@ -152,9 +152,11 @@ values = numpy.array(weights.values())
 f['param_bin'] = keys
 f['weights'] = values / values.max()
 
+f.attrs['sensitivity_ratios'] = args.relative_sensitivities
 f.attrs['srbmin'] = srbmin
 f.attrs['srbmax'] = srbmax
 f.attrs['twidth'] = twidth
 f.attrs['pwidth'] = pwidth
 f.attrs['swidth'] = swidth
 f.attrs['ifos'] = args.ifos
+f.attrs['stat'] = 'phasetd_newsnr_%s' % ''.join(args.ifos)

--- a/bin/hdfcoinc/pycbc_multiifo_dtphase
+++ b/bin/hdfcoinc/pycbc_multiifo_dtphase
@@ -1,12 +1,16 @@
 #!/bin/env python
-""" Create a file containing the phase and amplitude, 
-correlations between two detectors by
+""" Create a file containing the time, phase, and amplitude 
+correlations between two or more detectors by
 doing a simple monte-carlo
 
-Output is the relative SNR, time, and phase as compared to a reference
+Output is the relative amplitude, time, and phase as compared to a reference
 IFO (the first one provided). 
 
-To get the noise rate this should be scaled by the local sensitivity value
+The data is stored as two vectors, the discrete integer bin corresponding
+to a particular 3*(Nifo-1) location in amplitude/time/phase space along with the
+weight assigned to that bin.
+
+To get the signal rate this should be scaled by the local sensitivity value
 and by the SNR of the signal in the reference detector 
 (see pycbc/events/stat.py)
 """
@@ -18,14 +22,16 @@ parser = argparse.ArgumentParser()
 parser.add_argument('--ifos', nargs='+',
                     help="The ifos to generate a histogram for")
 parser.add_argument('--sample-size', type=int, 
-                    help="Approximant number of independent samples to draw for the distribution")
+                    help="Approximate number of independent samples to draw for the distribution")
 parser.add_argument('--snr-ratio', type=float, 
-                    help="SNR ratio permitted between reference ifo and all others")
+                    help="The SNR ratio permitted between reference ifo and all others."
+                         "Ex. giving 4 permits a ratio of 0.25 -> 4")
 parser.add_argument('--relative-sensitivities', nargs='+', type=float)
 parser.add_argument('--seed', type=int, default=124)
 parser.add_argument('--output-file')
 parser.add_argument('--verbose', action='store_true')
-parser.add_argument('--smoothing-sigma', type=int, default=2)
+parser.add_argument('--smoothing-sigma', type=int, default=2,
+                    help="Half-width of smoothing kernel in samples")
 parser.add_argument('--timing-uncertainty', type=float, default=.001,
                     help="Timing uncertainty to set bin size and smoothing interval")
 parser.add_argument('--phase-uncertainty', type=float, default=0.25,
@@ -99,11 +105,11 @@ for k in range(chunks):
 
     # calculate the toa, poa, and amplitude of each sample
     data = {}
-    for r, ifo in enumerate(args.ifos):
+    for rs, ifo in enumerate(args.relative_sensitivities, args.ifos):
         data[ifo] = {}
         fp, fc = d[ifo].antenna_pattern(ra, dec, pol, 0)
         sp, sc = fp * ip, fc * ic
-        data[ifo]['s'] = ((sp)**2.0 + (sc)**2.0) ** 0.5 * args.relative_sensitivities[r]
+        data[ifo]['s'] = (sp**2.0 + sc**2.0) ** 0.5 * rs
         data[ifo]['t'] = d[ifo].time_delay_from_earth_center(ra, dec, 0)
         data[ifo]['p'] = numpy.arctan2(sc, sp)
 

--- a/bin/hdfcoinc/pycbc_multiifo_dtphase
+++ b/bin/hdfcoinc/pycbc_multiifo_dtphase
@@ -9,7 +9,7 @@ from scipy.stats import norm
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--ifos', nargs='+',
-                    help="The two ifos to generate a histogram for")
+                    help="The ifos to generate a histogram for")
 parser.add_argument('--sample-size', type=int, 
                     help="Approximant number of independent samples to draw for the distribution")
 parser.add_argument('--snr-ratio', type=float, 
@@ -19,7 +19,24 @@ parser.add_argument('--seed', type=int, default=124)
 parser.add_argument('--output-file')
 parser.add_argument('--verbose', action='store_true')
 parser.add_argument('--smoothing-sigma', type=int, default=2)
+parser.add_argument('--timing-uncertainty', type=float, default=.001,
+                    help="Timing uncertainty to set bin size and smoothing interval")
+parser.add_argument('--phase-uncertainty', type=float, default=0.25,
+                    help="Phase uncertainty used to set bin size and smoothing")
+parser.add_argument('--snr-reference', type=float, default=5, 
+                    help="Reference SNR to scale SNR uncertainty")
+parser.add_argument('--snr-uncertainty', type=float, default=1.4, 
+                    help="SNR uncertainty to set bin size and smoothing")
 args = parser.parse_args()
+
+twidth = args.timing_uncertainty  # approximate timing error at lower SNRs
+pwidth = args.phase_uncertainty   # approximate phase error at lower SNRs
+serr = args.snr_uncertainty   #
+sref = args.snr_reference     # Reference SNR for bin smoothing
+swidth = serr / sref
+
+srbmax = int((args.snr_ratio / swidth))
+srbmin = int((1.0 / args.snr_ratio) / swidth)
 
 # Apply a simple smoothing to help account for
 # measurement errors for weak signals
@@ -73,12 +90,6 @@ for k in range(chunks):
     ip = numpy.cos(inc)
     ic = 0.5 * (1.0 + ip * ip)
 
-    twidth = .001  # approximate timing error at lower SNRs
-    pwidth = .25   # approximate phase error at lower SNRs
-    serr = 1.4   #
-    sref = 5.0     # Reference SNR for bin smoothing
-    swidth = serr / sref
-
     # calculate the toa, poa, and amplitude of each sample
     data = {}
     for r, ifo in enumerate(args.ifos):
@@ -101,9 +112,6 @@ for k in range(chunks):
         dtbin = (dt / twidth).astype(numpy.int)
         dpbin = (dp / pwidth).astype(numpy.int)
         srbin = (sr / swidth).astype(numpy.int)
-        
-        srbmax = int((args.snr_ratio / swidth))
-        srbmin = int((1.0 / args.snr_ratio) / swidth)
         
         # We'll only store a limited range of ratios
         if keep is None:
@@ -129,8 +137,11 @@ for k in range(chunks):
 logging.info('applying smoothing')
 # apply smoothing iteratively
 for i, ifo in enumerate(range(len(args.ifos)-1)):
+    logging.info('%s-time', len(weights))
     weights = smooth_param(weights, twidth, i*3 + 0)
+    logging.info('%s-phase', len(weights))
     weights = smooth_param(weights, pwidth, i*3 + 1)
+    logging.info('%s-amp', len(weights))
     weights = smooth_param(weights, swidth, i*3 + 2)    
 logging.info('smoothing done: %s', len(weights))
 
@@ -138,8 +149,8 @@ logging.info('smoothing done: %s', len(weights))
 f = h5py.File(args.output_file, 'w')
 keys = numpy.array(weights.keys())
 values = numpy.array(weights.values())
-f['keys'] = keys
-f['values'] = values / values.max()
+f['param_bin'] = keys
+f['weights'] = values / values.max()
 
 f.attrs['srbmin'] = srbmin
 f.attrs['srbmax'] = srbmax

--- a/bin/hdfcoinc/pycbc_stat_dtphase2
+++ b/bin/hdfcoinc/pycbc_stat_dtphase2
@@ -1,0 +1,149 @@
+#!/bin/env python
+""" Create a file containing the phase and amplitude, 
+correlations between two detectors by
+doing a simple monte-carlo
+"""
+import argparse, h5py, numpy.random, pycbc.detector, logging, multiprocessing
+from numpy.random import normal, uniform, power
+from scipy.stats import norm
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--ifos', nargs='+',
+                    help="The two ifos to generate a histogram for")
+parser.add_argument('--sample-size', type=int, 
+                    help="Approximant number of independent samples to draw for the distribution")
+parser.add_argument('--snr-ratio', type=float, 
+                    help="SNR ratio permitted between reference ifo and all others")
+parser.add_argument('--relative-sensitivities', nargs='+', type=float)
+parser.add_argument('--seed', type=int, default=124)
+parser.add_argument('--output-file')
+parser.add_argument('--verbose', action='store_true')
+parser.add_argument('--smoothing-sigma', type=int, default=2)
+args = parser.parse_args()
+
+# Apply a simple smoothing to help account for
+# measurement errors for weak signals
+def smooth_param(data, sigma, index):
+    bins = numpy.arange(-args.smoothing_sigma, args.smoothing_sigma+1)
+    kernel = norm.pdf(bins)
+    
+    nweights = {}
+    
+    # This is massively redundant as many points may be 
+    # recalculated, but it's straightforward.
+    for key in weights:
+        for a in bins:
+            nkey = list(key)
+            nkey[index] += a
+            
+            weight = 0
+            for b, w in zip(bins, kernel):
+                wkey = list(nkey)
+                wkey[index] += b
+                wkey = tuple(wkey)
+                
+                if wkey in data:
+                    weight += data[wkey] * w
+                
+            nweights[tuple(nkey)] = weight
+            
+    return nweights
+    
+d = {ifo: pycbc.detector.Detector(ifo) for ifo in args.ifos}
+
+pycbc.init_logging(args.verbose)
+
+numpy.random.seed(args.seed)
+size = 1000000
+chunks = int(args.sample_size / size) + 1
+
+l = 0
+nsamples = 0
+weights = {}
+for k in range(chunks):
+    nsamples += size
+    logging.info('generating %s samples' % size)
+
+    # Choose random sky location and polarizations from
+    # an isotropic population
+    ra = uniform(0, 2 * numpy.pi, size=size)
+    dec = numpy.arccos(uniform(-1., 1., size=size)) - numpy.pi/2
+    inc = numpy.arccos(uniform(-1., 1., size=size))
+    pol = uniform(0, 2 * numpy.pi, size=size)
+    ip = numpy.cos(inc)
+    ic = 0.5 * (1.0 + ip * ip)
+
+    twidth = .001  # approximate timing error at lower SNRs
+    pwidth = .25   # approximate phase error at lower SNRs
+    serr = 1.4   #
+    sref = 5.0     # Reference SNR for bin smoothing
+    swidth = serr / sref
+
+    # calculate the toa, poa, and amplitude of each sample
+    data = {}
+    for r, ifo in enumerate(args.ifos):
+        data[ifo] = {}
+        fp, fc = d[ifo].antenna_pattern(ra, dec, pol, 0)
+        sp, sc = fp * ip, fc * ic
+        data[ifo]['s'] = ((sp)**2.0 + (sc)**2.0) ** 0.5 * args.relative_sensitivities[r]
+        data[ifo]['t'] = d[ifo].time_delay_from_earth_center(ra, dec, 0)
+        data[ifo]['p'] = numpy.arctan2(sc, sp)
+
+    # Bin the data
+    bind = []
+    keep = None
+    for i in range(len(args.ifos) -1):
+        ifo0 = args.ifos[0 + i]
+        ifo1 = args.ifos[1 + i]
+        dt = (data[ifo0]['t'] - data[ifo1]['t'])
+        dp = (data[ifo0]['p'] - data[ifo1]['p']) % (numpy.pi * 2.0)
+        sr = (data[ifo1]['s'] / data[args.ifos[0]]['s'])
+        dtbin = (dt / twidth).astype(numpy.int)
+        dpbin = (dp / pwidth).astype(numpy.int)
+        srbin = (sr / swidth).astype(numpy.int)
+        
+        srbmax = int((args.snr_ratio / swidth))
+        srbmin = int((1.0 / args.snr_ratio) / swidth)
+        
+        # We'll only store a limited range of ratios
+        if keep is None:
+            keep = (srbin < srbmax) & srbin > (srbmin)
+        else:
+            keep = keep & (srbin < srbmax) & srbin > (srbmin)
+        bind += [dtbin, dpbin, srbin]
+ 
+    # Calculate and sum the weights for each bin
+    # use first ifo as reference for weights
+    bind = [a[keep] for a in bind]
+    
+    w = data[args.ifos[0]]['s'][keep] ** 3            
+    for i, key in enumerate(zip(*bind)):
+        if key not in weights:
+            weights[key] = 0
+        weights[key] += w[i]
+        
+    ol = l
+    l = len(weights.values())
+    logging.info('%s, %s, %s, %s', l, l - ol, (l - ol) / float(size), l / float(nsamples))
+
+logging.info('applying smoothing')
+# apply smoothing iteratively
+for i, ifo in enumerate(range(len(args.ifos)-1)):
+    weights = smooth_param(weights, twidth, i*3 + 0)
+    weights = smooth_param(weights, pwidth, i*3 + 1)
+    weights = smooth_param(weights, swidth, i*3 + 2)    
+logging.info('smoothing done: %s', len(weights))
+
+# save dict to hdf5 file as key + value array
+f = h5py.File(args.output_file, 'w')
+keys = numpy.array(weights.keys())
+values = numpy.array(weights.values())
+f['keys'] = keys
+f['values'] = values / values.max()
+
+f.attrs['srbmin'] = srbmin
+f.attrs['srbmax'] = srbmax
+f.attrs['twidth'] = twidth
+f.attrs['pwidth'] = pwidth
+f.attrs['swidth'] = swidth
+f.attrs['ifos'] = args.ifos


### PR DESCRIPTION
This is a rewritten version of pycbc_stat_dtphase to handle multiple ifos. The storage format is different. It stores, time, phase and amplitude differences. It performs some internal smoothing of the pdf based on similar rules to the old pta. You can provide fixed relative sensitivities between the detectors. 

In the application, the intention is to rescale the SNRs based on the effective distance to also account for variation over time of the relative sensitivities. 

Example command line. 

python ./pycbc_stat_dtphase2 \
--ifos H1 L1 \
--relative-sensitivities 1 .8 \
--sample-size 2000000 \
--snr-ratio 4.0 \
--seed 10 \
--output-file statHL.hdf \
--smoothing-sigma 2 \
--verbose
