### PR TITLE
Fix typo in inference documentation

### DIFF
--- a/docs/inference.rst
+++ b/docs/inference.rst
@@ -389,7 +389,7 @@ constrained to be <= 4 by using a function from the conversions module.
 
    [constraint-1]
    name = custom
-   constraint_args = q_from_mass1_mass2(mass1, mass2) <= 4
+   constraint_arg = q_from_mass1_mass2(mass1, mass2) <= 4
 
 ------------------------------
 Checkpointing and output files


### PR DESCRIPTION
I ran into the error `ConfigParser.Error: No option 'constraint_arg' in section [constraint] or in sections [constraint-1].` using `constraint_args` from the documentation. Looking at [pycbc_create_injections](https://github.com/gwastro/pycbc/blob/762de53bdb094a981768700bfa87db42106f2b93/bin/pycbc_create_injections) it seems the correct way to provide constraints is `constraint_arg`. This seems to have fixed my error, so I am submitting this PR. Please let me know if I should make any changes. Cheers!