### PR TITLE
added casting to float

### DIFF
--- a/pycbc/detector.py
+++ b/pycbc/detector.py
@@ -146,7 +146,7 @@ class Detector(object):
         fcross: float or numpy.ndarray
             The cross polarization factor for this sky location / orientation
         """
-        if np.isscalar(t_gps):
+        if isinstance(t_gps, lal.LIGOTimeGPS):
             t_gps = float(t_gps)
         gha = self.gmst_estimate(t_gps) - right_ascension
 

--- a/pycbc/detector.py
+++ b/pycbc/detector.py
@@ -146,7 +146,7 @@ class Detector(object):
         fcross: float or numpy.ndarray
             The cross polarization factor for this sky location / orientation
         """
-        gha = self.gmst_estimate(t_gps) - right_ascension
+        gha = float(self.gmst_estimate(t_gps) - right_ascension)
 
         cosgha = cos(gha)
         singha = sin(gha)

--- a/pycbc/detector.py
+++ b/pycbc/detector.py
@@ -146,7 +146,7 @@ class Detector(object):
         fcross: float or numpy.ndarray
             The cross polarization factor for this sky location / orientation
         """
-        gha = float(self.gmst_estimate(t_gps) - right_ascension)
+        gha = float(self.gmst_estimate(t_gps)) - right_ascension
 
         cosgha = cos(gha)
         singha = sin(gha)

--- a/pycbc/detector.py
+++ b/pycbc/detector.py
@@ -146,7 +146,9 @@ class Detector(object):
         fcross: float or numpy.ndarray
             The cross polarization factor for this sky location / orientation
         """
-        gha = float(self.gmst_estimate(t_gps)) - right_ascension
+        if np.isscalar(t_gps):
+            t_gps = float(t_gps)
+        gha = self.gmst_estimate(t_gps) - right_ascension
 
         cosgha = cos(gha)
         singha = sin(gha)


### PR DESCRIPTION
Without the cast, the cos can't process `lal.LIGOTimeGPS` type:
```
  File "/.../python3.7/site-packages/pycbc/detector.py", line 141, in antenna_pattern
    cosgha = cos(gha)
AttributeError: 'lal.LIGOTimeGPS' object has no attribute 'cos'
```
Error encountered working with python 3.7 conda based dist, pycbc installed from pip.