### PR TITLE
Injection and foreground minifollowups missing triggers/data

### DIFF
--- a/bin/minifollowups/pycbc_foreground_minifollowup
+++ b/bin/minifollowups/pycbc_foreground_minifollowup
@@ -19,7 +19,7 @@
 import os, sys, argparse, logging, h5py, pycbc.workflow as wf
 from pycbc.results import layout
 from pycbc.types import MultiDetOptionAction
-from pycbc.events import select_segments_by_definer
+from pycbc.events import select_segments_by_definer, coinc
 import pycbc.workflow.minifollowups as mini
 import pycbc.workflow.pegasus_workflow as wdax
 import pycbc.version
@@ -262,15 +262,21 @@ while event_count < num_events and curr_idx < (events_to_read - 1):
 
     for single in single_triggers:
         time = times[single.ifo][curr_idx]
-        files += mini.make_singles_timefreq(workflow, single, tmpltbank_file,
+        if time==-1:
+            time = coinc.mean_if_greater_than_zero([times[sngl.ifo][curr_idx]
+                                                    for sngl in single_triggers])[0]
+        try:
+            files += mini.make_singles_timefreq(workflow, single, tmpltbank_file,
                                 time, args.output_dir,
                                 data_segments=insp_data_seglists[single.ifo],
                                 tags=args.tags + [str(event_count)])
-
-        files += mini.make_qscan_plot\
-            (workflow, single.ifo, time, args.output_dir,
-             data_segments=insp_data_seglists[single.ifo],
-             tags=args.tags + [str(event_count)])
+            files += mini.make_qscan_plot\
+                (workflow, single.ifo, time, args.output_dir,
+                 data_segments=insp_data_seglists[single.ifo],
+                 tags=args.tags + [str(event_count)])
+        except ValueError:
+            logging.info('Trigger time {} is not valid in {}, ' \
+                         'skipping singles plots'.format(time, single.ifo))
 
     layouts += list(layout.grouper(files, 2))
 

--- a/bin/minifollowups/pycbc_foreground_minifollowup
+++ b/bin/minifollowups/pycbc_foreground_minifollowup
@@ -58,7 +58,7 @@ parser.add_argument('--analysis-category', type=str, required=False,
                          'or background triggers (with "little dogs" removed)')
 parser.add_argument('--output-map', type=str, required=False,
                     help='Supply the location of the pegasus output map file. '
-                         'Only needed if running this job within a workflow.') 
+                         'Only needed if running this job within a workflow.')
 parser.add_argument('--output-file', type=str, required=True,
                     help='Name of the output dax file to be generated.')
 parser.add_argument('--transformation-catalog', type=str, required=False,
@@ -86,6 +86,7 @@ insp_segs = to_file(args.inspiral_segments)
 single_triggers = []
 fsdt = {}
 insp_data_seglists = {}
+insp_analysed_seglists = {}
 for ifo in args.single_detector_triggers:
     fname = args.single_detector_triggers[ifo]
     single_triggers.append(to_file(fname, ifo=ifo))
@@ -94,10 +95,15 @@ for ifo in args.single_detector_triggers:
         args.inspiral_segments,
         segment_name=args.inspiral_data_read_name,
         ifo=ifo)
+    insp_analysed_seglists[ifo] = select_segments_by_definer(
+        args.inspiral_segments,
+        segment_name=args.inspiral_data_analyzed_name,
+        ifo=ifo)
     # NOTE: make_singles_timefreq needs a coalesced set of segments. If this is
     #       being used to determine command-line options for other codes,
     #       please think if that code requires coalesced, or not, segments.
     insp_data_seglists[ifo].coalesce()
+    insp_analysed_seglists[ifo].coalesce
 
 num_events = int(workflow.cp.get_opt_tags('workflow-minifollowups', 'num-events', ''))
 f = h5py.File(args.statmap_file, 'r')
@@ -265,16 +271,18 @@ while event_count < num_events and curr_idx < (events_to_read - 1):
         if time==-1:
             time = coinc.mean_if_greater_than_zero([times[sngl.ifo][curr_idx]
                                                     for sngl in single_triggers])[0]
-        try:
-            files += mini.make_singles_timefreq(workflow, single, tmpltbank_file,
+        for seg in insp_analysed_seglists[single.ifo]:
+            if time in seg:
+                files += mini.make_singles_timefreq(workflow, single, tmpltbank_file,
                                 time, args.output_dir,
                                 data_segments=insp_data_seglists[single.ifo],
                                 tags=args.tags + [str(event_count)])
-            files += mini.make_qscan_plot\
-                (workflow, single.ifo, time, args.output_dir,
-                 data_segments=insp_data_seglists[single.ifo],
-                 tags=args.tags + [str(event_count)])
-        except ValueError:
+                files += mini.make_qscan_plot\
+                    (workflow, single.ifo, time, args.output_dir,
+                     data_segments=insp_data_seglists[single.ifo],
+                     tags=args.tags + [str(event_count)])
+                break
+        else:
             logging.info('Trigger time {} is not valid in {}, ' \
                          'skipping singles plots'.format(time, single.ifo))
 

--- a/bin/minifollowups/pycbc_foreground_minifollowup
+++ b/bin/minifollowups/pycbc_foreground_minifollowup
@@ -103,7 +103,7 @@ for ifo in args.single_detector_triggers:
     #       being used to determine command-line options for other codes,
     #       please think if that code requires coalesced, or not, segments.
     insp_data_seglists[ifo].coalesce()
-    insp_analysed_seglists[ifo].coalesce
+    insp_analysed_seglists[ifo].coalesce()
 
 num_events = int(workflow.cp.get_opt_tags('workflow-minifollowups', 'num-events', ''))
 f = h5py.File(args.statmap_file, 'r')

--- a/bin/minifollowups/pycbc_injection_minifollowup
+++ b/bin/minifollowups/pycbc_injection_minifollowup
@@ -85,16 +85,21 @@ insp_segs = to_file(args.inspiral_segments)
 
 single_triggers = []
 insp_data_seglists = {}
+insp_analysed_seglists = {}
 for ifo in args.single_detector_triggers:
     fname = args.single_detector_triggers[ifo]
     single_triggers.append(to_file(fname, ifo=ifo))
     insp_data_seglists[ifo] = select_segments_by_definer\
         (args.inspiral_segments, segment_name=args.inspiral_data_read_name,
          ifo=ifo)
+    insp_analysed_seglists[ifo] = select_segments_by_definer\
+        (args.inspiral_segments, segment_name=args.inspiral_data_analyzed_name,
+         ifo=ifo)
     # NOTE: make_singles_timefreq needs a coalesced set of segments. If this is
     #       being used to determine command-line options for other codes,
     #       please think if that code requires coalesced, or not, segments.
     insp_data_seglists[ifo].coalesce()
+    insp_analysed_seglists[ifo].coalesce()
 
 f = h5py.File(args.injection_file, 'r')
 missed = f['missed/after_vetoes'][:]
@@ -181,17 +186,19 @@ for num_event in range(num_events):
         if (inj_params[single.ifo + '_end_time'] == -1.0):
             all_times = [inj_params[sngl.ifo + '_end_time'] for sngl in single_triggers]
             checkedtime = coinc.mean_if_greater_than_zero(all_times)[0]
-        try:
-            files += mini.make_singles_timefreq(workflow, single, tmpltbank_file,
+        for seg in insp_analysed_seglists[single.ifo]:
+            if checkedtime in seg:
+                files += mini.make_singles_timefreq(workflow, single, tmpltbank_file,
                                 checkedtime, args.output_dir,
                                 data_segments=insp_data_seglists[single.ifo],
                                 tags=args.tags + [str(num_event)])
-            files += mini.make_qscan_plot\
-                (workflow, single.ifo, checkedtime, args.output_dir,
-                 data_segments=insp_data_seglists[single.ifo],
-                 injection_file=injection_xml_file,
-                 tags=args.tags + [str(num_event)])
-        except ValueError:
+                files += mini.make_qscan_plot\
+                    (workflow, single.ifo, checkedtime, args.output_dir,
+                     data_segments=insp_data_seglists[single.ifo],
+                     injection_file=injection_xml_file,
+                     tags=args.tags + [str(num_event)])
+                break
+        else:
             logging.info('Trigger time {} is not valid in {}, ' \
                          'skipping singles plots'.format(checkedtime,
                                                          single.ifo))

--- a/bin/minifollowups/pycbc_injection_minifollowup
+++ b/bin/minifollowups/pycbc_injection_minifollowup
@@ -19,7 +19,7 @@
 import os, argparse, numpy, logging, h5py, copy
 import pycbc.workflow as wf
 from pycbc.types import MultiDetOptionAction
-from pycbc.events import select_segments_by_definer
+from pycbc.events import select_segments_by_definer, coinc
 from pycbc.results import layout
 from pycbc.detector import Detector
 import pycbc.workflow.minifollowups as mini
@@ -179,18 +179,22 @@ for num_event in range(num_events):
     for single in single_triggers:
         checkedtime = time
         if (inj_params[single.ifo + '_end_time'] == -1.0):
-            checkedtime = -1.0
-
-        files += mini.make_singles_timefreq(workflow, single, tmpltbank_file,
+            all_times = [inj_params[sngl.ifo + '_end_time'] for sngl in single_triggers]
+            checkedtime = coinc.mean_if_greater_than_zero(all_times)[0]
+        try:
+            files += mini.make_singles_timefreq(workflow, single, tmpltbank_file,
                                 checkedtime, args.output_dir,
                                 data_segments=insp_data_seglists[single.ifo],
                                 tags=args.tags + [str(num_event)])
-
-        files += mini.make_qscan_plot\
-            (workflow, single.ifo, checkedtime, args.output_dir,
-             data_segments=insp_data_seglists[single.ifo],
-             injection_file=injection_xml_file,
-             tags=args.tags + [str(num_event)])
+            files += mini.make_qscan_plot\
+                (workflow, single.ifo, checkedtime, args.output_dir,
+                 data_segments=insp_data_seglists[single.ifo],
+                 injection_file=injection_xml_file,
+                 tags=args.tags + [str(num_event)])
+        except ValueError:
+            logging.info('Trigger time {} is not valid in {}, ' \
+                         'skipping singles plots'.format(checkedtime,
+                                                         single.ifo))
 
     files += mini.make_single_template_plots(workflow, insp_segs,
                             args.inspiral_data_read_name,


### PR DESCRIPTION
timefreq and qscan plots were being shown as blank plots in the case where the -1 sentinel value was found, whether data was available or not

For example for a HL coinc, the V qscan and timefreq were blank, even if V was running but did not trigger

Given these changes the minifollowup workflow creation now takes the mean time from the other detectors, and tries to create the plots. If they fail, as the time is outside of analysis time in that detector, then the plot will simply not be made.

This is a point where I ask whether we would _prefer_ a blank plot to show definitively that there is no data (or a standard 'this IFO has no data" image?)

This PR helps address #2882