### PR TITLE
foreground should be the default category

### DIFF
--- a/bin/minifollowups/pycbc_foreground_minifollowup
+++ b/bin/minifollowups/pycbc_foreground_minifollowup
@@ -51,7 +51,7 @@ parser.add_argument('--inspiral-data-analyzed-name',
                     help="Name of inspiral segmentlist containing data "
                          "analyzed by each analysis job.")
 parser.add_argument('--analysis-category', type=str, required=False,
-                    default='background_exc',
+                    default='foreground',
                     choices = ['foreground', 'background', 'background_exc'],
                     help='Designates whether to look at foreground triggers '
                          'background triggers (including "little dogs") '


### PR DESCRIPTION
The category default is currently 'background_exc'. This seems like a strange choice given the name of the exe. I propose setting this to the most likely expected behavior. 