### PR TITLE
PyCBC Live: fix issue in how the detector state is reported

### DIFF
--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -176,7 +176,7 @@ class LiveEventManager(object):
         """
         #check for hardware injection
         for ifo in ifos:
-            if data_reader[ifo].near_hwinj():
+            if data_readers[ifo].near_hwinj():
                 coinc_results['HWINJ'] = True
                 break    
 
@@ -634,9 +634,11 @@ with ctx:
             if evnt.size > 1:
                 results, valid_end = evnt.gather_results()
 
-            # protect from situations where master and worker nodes disagree
-            # on the status of detectors: the master process has the last word
-            for ifo in set(results.keys()) - evnt.live_detectors:
+            # veto detectors with different state between the master
+            # and worker nodes (e.g. late frame files on one node only)
+            detectors_with_results = set(results.keys())
+            evnt.live_detectors.intersection_update(detectors_with_results)
+            for ifo in detectors_with_results - evnt.live_detectors:
                 results.pop(ifo)
 
             # Veto single detector triggers that fail the DQ vector

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -344,8 +344,6 @@ class PhaseTDStatistic(NewSNRStatistic):
         # does not require ifos to be specified, only 1 p/t/a file
         if self.hist is None:
             self.get_hist()
-        else:
-            logging.info("Using pre-set signal histogram")
 
         # for 2-ifo pipeline, add time shift to 2nd ifo ('s1')
         slidevec = [0, 1]


### PR DESCRIPTION
When (some of) the worker nodes think a detector is unusable, but the master node thinks the opposite, the detector is still reported as being active despite no triggers are produced from it. This patch ensures that the detector is reported as inactive when there are no (or partial) results from it.

Also fixes a harmless confusion between objects in different namespaces.