### PR TITLE
Remove exclude foreground from workflow if only one coincidence type

### DIFF
--- a/bin/workflows/pycbc_create_offline_search_workflow
+++ b/bin/workflows/pycbc_create_offline_search_workflow
@@ -210,7 +210,8 @@ for i in range(2, len(insps)+1):
 final_bg_files = {}
 for i in range(2, len(insps)+1):
     combinations = itertools.combinations(ifo_ids.keys(), i)
-    if len(combinations) == 1: continue
+    combs = combinations
+    if len([c for c in combs]) == 1: continue
     for ifocomb in combinations:
         _, _, ordered_ifo_list = wf.get_ordered_ifo_list(ifocomb, ifo_ids)
         # Create coinc tag

--- a/bin/workflows/pycbc_create_offline_search_workflow
+++ b/bin/workflows/pycbc_create_offline_search_workflow
@@ -207,27 +207,27 @@ for i in range(2, len(insps)+1):
                        workflow, bg_file, hdfbank[0], output_dir,
                        tags=ctagcomb)
 
-final_bg_files = {}
-for i in range(2, len(insps)+1):
-    combinations = itertools.combinations(ifo_ids.keys(), i)
-    combs = combinations
-    if len([c for c in combs]) == 1: continue
-    for ifocomb in combinations:
-        _, _, ordered_ifo_list = wf.get_ordered_ifo_list(ifocomb, ifo_ids)
-        # Create coinc tag
-        coinctag = '{}det_'.format(len(ifocomb)) + ordered_ifo_list
-        ctagcomb = [tag, 'full', coinctag]
-        other_ifo_keys = no_fg_exc_files.keys()
-        other_ifo_keys.remove(ordered_ifo_list)
-        other_bg_files = {ctype: no_fg_exc_files[ctype] for ctype in other_ifo_keys}
-        final_bg_files[ordered_ifo_list] = wf.setup_multiifo_exclude_zerolag(
-                                                 workflow,
-                                                 no_fg_exc_files[ordered_ifo_list],
-                                                 wf.FileList(other_bg_files.values()),
-                                                 output_dir, ordered_ifo_list,
-                                                 tags=ctagcomb)
-else:
+
+if len(insps) == 2:
     final_bg_files = no_fg_exc_files
+else:
+    final_bg_files = {}
+    for i in range(2, len(insps)+1):
+        combinations = itertools.combinations(ifo_ids.keys(), i)
+        for ifocomb in combinations:
+            _, _, ordered_ifo_list = wf.get_ordered_ifo_list(ifocomb, ifo_ids)
+            # Create coinc tag
+            coinctag = '{}det_'.format(len(ifocomb)) + ordered_ifo_list
+            ctagcomb = [tag, 'full', coinctag]
+            other_ifo_keys = no_fg_exc_files.keys()
+            other_ifo_keys.remove(ordered_ifo_list)
+            other_bg_files = {ctype: no_fg_exc_files[ctype] for ctype in other_ifo_keys}
+            final_bg_files[ordered_ifo_list] = wf.setup_multiifo_exclude_zerolag(
+                                                   workflow,
+                                                   no_fg_exc_files[ordered_ifo_list],
+                                                   wf.FileList(other_bg_files.values()),
+                                                   output_dir, ordered_ifo_list,
+                                                   tags=ctagcomb)
 
 combctags = [tag]
 combined_bg_file = wf.setup_multiifo_combine_statmap(

--- a/bin/workflows/pycbc_create_offline_search_workflow
+++ b/bin/workflows/pycbc_create_offline_search_workflow
@@ -208,7 +208,10 @@ for i in range(2, len(insps)+1):
                        tags=ctagcomb)
 
 final_bg_files = {}
+if len(ifo_ids) == 2:
+        final_bg_files = no_fg_exc_files
 for i in range(2, len(insps)+1):
+    if len(ifo_ids) == 2: continue
     combinations = itertools.combinations(ifo_ids.keys(), i)
     for ifocomb in combinations:
         _, _, ordered_ifo_list = wf.get_ordered_ifo_list(ifocomb, ifo_ids)

--- a/bin/workflows/pycbc_create_offline_search_workflow
+++ b/bin/workflows/pycbc_create_offline_search_workflow
@@ -208,11 +208,9 @@ for i in range(2, len(insps)+1):
                        tags=ctagcomb)
 
 final_bg_files = {}
-if len(ifo_ids) == 2:
-        final_bg_files = no_fg_exc_files
 for i in range(2, len(insps)+1):
-    if len(ifo_ids) == 2: continue
     combinations = itertools.combinations(ifo_ids.keys(), i)
+    if len(combinations) == 1: continue
     for ifocomb in combinations:
         _, _, ordered_ifo_list = wf.get_ordered_ifo_list(ifocomb, ifo_ids)
         # Create coinc tag
@@ -227,6 +225,8 @@ for i in range(2, len(insps)+1):
                                                  wf.FileList(other_bg_files.values()),
                                                  output_dir, ordered_ifo_list,
                                                  tags=ctagcomb)
+else:
+    final_bg_files = no_fg_exc_files
 
 combctags = [tag]
 combined_bg_file = wf.setup_multiifo_combine_statmap(


### PR DESCRIPTION
add in check that the exclude_zerolag stage is not performed if only using 2 detectors