### PR TITLE
Fixed bug where reweighting by null SNR inadvertently made it so the …

### DIFF
--- a/bin/pycbc_multi_inspiral
+++ b/bin/pycbc_multi_inspiral
@@ -173,6 +173,7 @@ def reweight_snr_by_null(network_snr, nullsnr):
                           SNR for each trigger
             null: Null snr for each trigger
     """
+    nullsnr = np.array(nullsnr)
     nullsnr[nullsnr <= 4.25] = 4.25
     reweighted_snr = network_snr / (nullsnr - 3.25)
     return reweighted_snr


### PR DESCRIPTION
…null SNR was never below 4.5. 

My version of PyCBC seems to have broken on Arcca so I cannot test this. However, this is a small one line change that had fixed the problem about a month ago, but I forgot to commit it. 