### PR TITLE
Make pycbc_generate_hwinj not ignore an option

### DIFF
--- a/bin/hwinj/pycbc_generate_hwinj
+++ b/bin/hwinj/pycbc_generate_hwinj
@@ -367,10 +367,10 @@ sngl.spin2x = opts.spin2x
 
 # generate waveform
 logging.info('Generating waveform at %.3fMpc beginning at %.3fHz for '
-             'SNR calculation', sim.distance, opts.low_frequency_cutoff)
+             'SNR calculation', sim.distance, opts.waveform_low_frequency_cutoff)
 h_plus, h_cross = get_td_waveform(sim, approximant=name,
                                   phase_order=phase_order,
-                                  f_lower=opts.low_frequency_cutoff,
+                                  f_lower=opts.waveform_low_frequency_cutoff,
                                   delta_t=1.0 / sample_rate)
 
 # zero pad polarizations to get integer second time series
@@ -479,10 +479,10 @@ for ifo in opts.instruments:
 
 # generate waveform
 logging.info('Generating waveform at %.3fMpc beginning at %.3fHz for '
-             'SNR calculation', sim.distance, opts.low_frequency_cutoff)
+             'SNR calculation', sim.distance, opts.waveform_low_frequency_cutoff)
 h_plus, h_cross = get_td_waveform(sim, approximant=name,
                                   phase_order=phase_order,
-                                  f_lower=opts.low_frequency_cutoff,
+                                  f_lower=opts.waveform_low_frequency_cutoff,
                                   delta_t=1.0 / sample_rate)
 
 # zero pad polarizations to get integer second time series


### PR DESCRIPTION
Previously waveform_low_frequency_cutoff option was ignored when
computing the SNR. This can be a problem for example for
waveform approximants that need to start at an earlier frequency
than what is used for SNR computation. The following command is an example:

```
pycbc_generate_hwinj --network-snr 25 --ra 1.01 --dec 0.34 --polarization 1.821 --mass1 80.0 --mass2 40.0 --spin1x 0.88 --taper TAPER_STARTEND --waveform-low-frequency-cutoff 15.0 --low-frequency-cutoff 30.0 --gps-start-time 1000000000 --gps-end-time 1000000128 --approximant SEOBNRv3 --inclination 0.367 --geocentric-end-time 1000000080  --instruments H1 L1 V1 --sample-rate 4096 --psd-model H1:aLIGOZeroDetHighPowerGWINC L1:aLIGOZeroDetHighPowerGWINC V1:AdVDesignSensitivityP1200087  --order pseudoFourPN
```

This patch simply correctly replaces the option. I think that for the xml file generation the option is already being set correctly (i.e. `f_lower`) but would be good if this is checked. 