### PR TITLE
Use h5py 2.9.0 or less for PyCBC

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ matplotlib>=2.0.0
 numpy>=1.13.0,<1.15.3; python_version <= '2.7'
 numpy>=1.13.0; python_version >= '3.0'
 pillow
-h5py>=2.5
+h5py<2.10.0
 jinja2
 mpld3>=0.3
 weave>=0.16.0; python_version <= '2.7'


### PR DESCRIPTION
PyCBC is currently incompatible with h5py 2.10.0, which generates the following error when reading a template bank:
```
2019-09-10 18:44:22,896 Read in template bank
('|S18', {'h5py_encoding': 'ascii'})Traceback (most recent call last):
  File "/bin/pycbc_inspiral", line 332, in <module>
    opt.waveform_decompression_method if opt.use_compressed_waveforms else None)
  File "/usr/lib64/python2.7/site-packages/pycbc/waveform/bank.py", line 622, in __init__
    self.ensure_standard_filter_columns(low_frequency_cutoff=low_frequency_cutoff)
  File "/usr/lib64/python2.7/site-packages/pycbc/waveform/bank.py", line 455, in ensure_standard_filter_columns
    dtype=np.float32), 'template_duration')
  File "/usr/lib64/python2.7/site-packages/pycbc/io/record.py", line 1257, in add_fields
    newself = add_fields(self, arrays, names=names, assubarray=assubarray)
  File "/usr/lib64/python2.7/site-packages/pycbc/io/record.py", line 465, in add_fields
    outtype=type(input_array))
  File "/usr/lib64/python2.7/site-packages/pycbc/io/record.py", line 342, in merge_arrays
    new_dt = combine_fields([arr.dtype for arr in merge_list])
  File "/usr/lib64/python2.7/site-packages/pycbc/io/record.py", line 292, in combine_fields
    for dt in get_dtype_descr(dtype)])
ValueError: invalid shape in fixed-type tuple.
```
This pins the required version at 2.9.0 or less until we have a fix.