### PR TITLE
Summary plots must use closed_box veto

### DIFF
--- a/bin/workflows/pycbc_create_offline_search_workflow
+++ b/bin/workflows/pycbc_create_offline_search_workflow
@@ -354,7 +354,7 @@ for insp in full_insps:
     # make hists of newsnr split up by parameter
     # currently, 1 per ifo split by template duration
     outdir = rdir['single_triggers/%s_binned_histograms' % insp.ifo]
-    binhists = wf.make_binned_hist(workflow, insp, final_veto_file[0],
+    binhists = wf.make_binned_hist(workflow, insp, censored_veto,
                                    'closed_box', outdir, hdfbank[0],
                                    tags=[tag])
     # put raw SNR and binned newsnr hist in summary

--- a/bin/workflows/pycbc_make_coinc_search_workflow
+++ b/bin/workflows/pycbc_make_coinc_search_workflow
@@ -331,8 +331,8 @@ for insp in full_insps:
            require='summ', tags=[tag])
     # make hists of newsnr split up by parameter
     # currently, 1 per ifo split by template duration
-    binhists = wf.make_binned_hist(workflow, insp, final_veto_file[0],
-           final_veto_name[0], rdir['single_triggers/%s_binned_histograms' %
+    binhists = wf.make_binned_hist(workflow, insp, censored_veto,
+           'closed_box', rdir['single_triggers/%s_binned_histograms' %
            insp.ifo], hdfbank[0], tags=[tag])
     # put raw SNR and binned newsnr hist in summary
     hist_summ += list(layout.grouper([allhists[0], binhists[0]], 2))


### PR DESCRIPTION
The binned_hist (Denty Bins) on the summary pages are currently reading in all triggers after CAT_2. The "pruning" settings are used to try to prevent this plot from considering actual detections (as with the codes used to produce the actual fits). However, this can be dangerous, leading to cases where real coincident events show on the summary pages.

I'm going to enforce the rule here that all closed_box plots must use the closed_box veto if considering single-detector triggers. Single-detector detections might still show up on this plot (as they show elsewhere in the closed box), and the pruning settings might be used to remove those. But I think we must remove the chance of coincident triggers appearing here.