### PR TITLE
Don't generate short injections when not needed

### DIFF
--- a/pycbc/inject/injfilterrejector.py
+++ b/pycbc/inject/injfilterrejector.py
@@ -233,7 +233,7 @@ class InjFilterRejector(object):
 
     def generate_short_inj_from_inj(self, inj_waveform, simulation_id):
         """Generate and a store a truncated representation of inj_waveform."""
-        if not self.enabled:
+        if not self.enabled or not self.match_threshold:
             # Do nothing!
             return
         if simulation_id in self.short_injections:


### PR DESCRIPTION
Following up an unrelated error report made me realise that `injfilterrejector` will generate the "short" injections (injections with a compressed representation) regardless of whether or not these are actually needed.

For instance if using the chirp-time window, you will not need the "short" injections, but these will be generated anyway. A small fix will stop this happening. Probably not important for anything, but it seems cleaner.