### PR TITLE
Restrict SSE 4.2 flag to x86_64

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ from __future__ import print_function
 
 import sys
 import os, subprocess, shutil
+import platform
 
 from distutils.errors import DistutilsError
 from distutils.command.clean import clean as _clean
@@ -208,8 +209,10 @@ cythonext = ['waveform.spa_tmplt',
              'filter.matchedfilter',
              'vetoes.chisq']
 ext = []
-cython_compile_args = ['-O3', '-w', '-msse4.2', '-ffast-math',
+cython_compile_args = ['-O3', '-w', '-ffast-math',
                        '-ffinite-math-only']
+if platform.machine() == 'x86_64':
+    cython_compile_args.append('-msse4.2')
 cython_link_args = []
 # Mac's clang compiler doesn't have openMP support by default. Therefore
 # disable openmp builds on MacOSX. Optimization should never really be a


### PR DESCRIPTION
An attempt at fixing #2927. Not tested; comments welcome.