### PR TITLE
add statmap doesn't work when using two ifos (in multi-ifo workflow). 

### DIFF
--- a/bin/hdfcoinc/pycbc_multiifo_add_statmap
+++ b/bin/hdfcoinc/pycbc_multiifo_add_statmap
@@ -78,7 +78,10 @@ logging.info('Combining foreground segments')
 
 # Convert segmentlistdict to a list ('seglists') of segmentlists
 # then np.sum(seglists, axis=0) does seglists[0] + seglists[1] + ...
-foreground_segs = np.sum(list(indiv_segs.values()), axis=0)
+if len(indiv_segs) > 1:
+    foreground_segs = np.sum(list(indiv_segs.values()), axis=0)
+else:
+    foreground_segs = indiv_segs.values()[0]
 f.attrs['foreground_time'] = abs(foreground_segs)
 
 # obtain list of all ifos involved in the coinc_statmap files


### PR DESCRIPTION
Small issue when running the mult-ifo workflow with two-ifos. Add statmap produces and invalid foreground_segs variable which fails later in the code. This occurs as np.sum does not guarantee output types, and in fact converts to a numpy array when you only give it one element in the original code. 