### PR TITLE
two ifo coinc should still pass ifos

### DIFF
--- a/bin/hdfcoinc/pycbc_coinc_findtrigs
+++ b/bin/hdfcoinc/pycbc_coinc_findtrigs
@@ -187,7 +187,9 @@ if args.strict_coinc_time:
     trigs1.valid = veto.segments_to_start_end(trigs1.segs)
 
 # initialize a Stat class instance to calculate the coinc ranking statistic
-rank_method = stat.get_statistic(args.ranking_statistic)(args.statistic_files)
+ifos = [trigs0.ifo, trigs1.ifo]
+rank_method = stat.get_statistic(args.ranking_statistic)(args.statistic_files,
+                                                         ifos=ifos)
 if args.use_maxalpha:
     rank_method.use_alphamax()
 det0, det1 = detector.Detector(trigs0.ifo), detector.Detector(trigs1.ifo)


### PR DESCRIPTION
Without this, some statistics can't rely on these parameters to be set in a consistent way. We should just pass it in the two ifo case, same as the multi-ifo case.