### PR TITLE
add the new phase time statistics and boiler plate for 2ogc / 2ogc bbh statistics

### DIFF
--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -288,6 +288,7 @@ class PhaseTDNewStatistic(NewSNRStatistic):
 
         ifos = ifos or self.ifos
 
+        selected = None
         for name in self.files:
             # Pick out the statistic files that provide phase / time/ amp
             # relationships and match to the ifos in use
@@ -301,10 +302,13 @@ class PhaseTDNewStatistic(NewSNRStatistic):
                 if False in match:
                     continue
                 else:
+                    selected = name
                     break
-        else:
+
+        if selected is None:
             raise RuntimeError("Couldn't figure out which stat file to use")
-        logging.info("Using signal histogram %s for ifos %s", name, ifos)
+
+        logging.info("Using signal histogram %s for ifos %s", selected, ifos)
         histfile = self.files[name]
 
         # This order matters, we need to retrieve the order used to

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -1211,8 +1211,8 @@ statistic_dict = {
     'exp_fit_sg_bg_rate': ExpFitSGBgRateStatistic,
     'exp_fit_sg_fgbg_rate': ExpFitSGFgBgRateStatistic,
     'exp_fit_sg_fgbg_rate_new': ExpFitSGFgBgRateNewStatistic,
-    '2gc':TwoGCStatistic,
-    '2gcbbh':TwoGCBBHStatistic,
+    '2gc': TwoGCStatistic,
+    '2gcbbh': TwoGCBBHStatistic,
 }
 
 sngl_statistic_dict = {

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -276,9 +276,8 @@ class PhaseTDNewStatistic(NewSNRStatistic):
         self.get_newsnr = ranking.get_newsnr
         self.hist = None
 
-    def get_hist(self, ifos=None, norm='max'):
+    def get_hist(self, ifos=None):
         """Read in a signal density file for the ifo combination"""
-
 
         ifos = ifos or self.ifos
 
@@ -420,7 +419,7 @@ class PhaseTDNewStatistic(NewSNRStatistic):
                 # Calculate differences
                 pdif = (pref - p) % (numpy.pi * 2.0)
                 tdif = shift[rtype] * to_shift[ref_ifo] + \
-                                      tref - shift[rtype] * to_shift[ifo] - t
+                           tref - shift[rtype] * to_shift[ifo] - t
                 sdif = s / sref * sense / senseref * sigref / sig
 
                 # Put into bins
@@ -431,8 +430,8 @@ class PhaseTDNewStatistic(NewSNRStatistic):
 
             # convert binned to same dtype as stored in hist
             nbinned = numpy.zeros(len(pbin), dtype=self.pdtype)
-            for i in range(len(binned)):
-                nbinned['c%s' % i] = binned[i]
+            for i, b in enumerate(binned):
+                nbinned['c%s' % i] = b
 
             # Read signal weight from precalculated histogram
             l = numpy.searchsorted(self.param_bin[ref_ifo], nbinned)
@@ -997,6 +996,7 @@ class ExpFitSGBgRateStatistic(ExpFitStatistic):
         loglr = - ln_noise_rate + self.benchmark_lograte
         return loglr
 
+
 class ExpFitSGFgBgRateStatistic(PhaseTDStatistic, ExpFitSGBgRateStatistic):
 
     def __init__(self, files, ifos=None):
@@ -1084,7 +1084,8 @@ class ExpFitSGFgBgRateStatistic(PhaseTDStatistic, ExpFitSGBgRateStatistic):
         return loglr
 
 
-class ExpFitSGFgBgRateNewStatistic(PhaseTDNewStatistic, ExpFitSGBgRateStatistic):
+class ExpFitSGFgBgRateNewStatistic(PhaseTDNewStatistic,
+                                   ExpFitSGBgRateStatistic):
 
     def __init__(self, files, ifos=None):
         # read in background fit info and store it
@@ -1183,7 +1184,7 @@ class TwoOGCBBHStatistic(ExpFitSGFgBgRateNewStatistic):
         # model signal rate as uniform over chirp mass, background rate is
         # proportional to mchirp^(-11/3) due to density of templates
         logr_s = ExpFitSGFgBgRateNewStatistic.logsignalrate_multiifo(
-                                                   self, stats, shift, to_shift)
+                                                  self, stats, shift, to_shift)
         logr_s += numpy.log((self.mchirp / 20.0) ** (11./3.0))
         return logr_s
 
@@ -1227,7 +1228,6 @@ sngl_statistic_dict = {
     'newsnr_sgveto_psdvar_scaled': NewSNRSGPSDScaledStatistic,
     'newsnr_sgveto_psdvar_scaled_threshold':
         NewSNRSGPSDScaledThresholdStatistic,
-    'newsnr_sgveto_psdvar_com': NewSNRSGPSDComStatistic,
     'exp_fit_sg_csnr_psdvar': ExpFitSGPSDCombinedSNR
 }
 

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -1188,8 +1188,6 @@ class TwoGCBBHStatistic(ExpFitSGFgBgRateNewStatistic):
     def logsignalrate_multiifo(self, stats, shift, to_shift):
         logr_s = ExpFitSGFgBgRateNewStatistic.logsignalrate_multiifo(self, stats, shift, to_shift)
         logr_s += numpy.log((self.mchirp / 20.0) ** (11./3.0))
-        if self.mchirp > 60.0:
-            logr_s[:] = -20
         return logr_s
 
 statistic_dict = {

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -300,7 +300,6 @@ class PhaseTDNewStatistic(NewSNRStatistic):
         logging.info("Using signal histogram %s for ifos %s", name, ifos)
         histfile = self.files[name]
 
-
         # This order matters, we need to retrieve the order used to
         # generate the histogram as the first ifos if the reference
         self.hist_ifos = histfile.attrs['ifos']
@@ -318,9 +317,9 @@ class PhaseTDNewStatistic(NewSNRStatistic):
             for i in range(ncol):
                 self.param_bin[ifo]['c%s' % i] = param[:, i]
 
-            l = self.param_bin[ifo].argsort()
-            self.param_bin[ifo] = self.param_bin[ifo][l]
-            self.weights[ifo] = self.weights[ifo][l]
+            lsort = self.param_bin[ifo].argsort()
+            self.param_bin[ifo] = self.param_bin[ifo][lsort]
+            self.weights[ifo] = self.weights[ifo][lsort]
 
             self.max_penalty = self.weights[ifo].min()
 
@@ -390,7 +389,7 @@ class PhaseTDNewStatistic(NewSNRStatistic):
                            for ifo in self.ifos])
         smin = numpy.argmin(snrs, axis=0)
         rtypes = {ifo: numpy.where(smin == j)[0]
-                       for j, ifo in enumerate(self.ifos)}
+                  for j, ifo in enumerate(self.ifos)}
 
         # Get reference ifo information
         rate = numpy.zeros(len(shift), dtype=numpy.float32)
@@ -434,13 +433,13 @@ class PhaseTDNewStatistic(NewSNRStatistic):
                 nbinned['c%s' % i] = b
 
             # Read signal weight from precalculated histogram
-            l = numpy.searchsorted(self.param_bin[ref_ifo], nbinned)
-            l[l == len(self.weights[ref_ifo])] = 0
-            rate[rtype] = self.weights[ref_ifo][l]
+            loc = numpy.searchsorted(self.param_bin[ref_ifo], nbinned)
+            loc[loc == len(self.weights[ref_ifo])] = 0
+            rate[rtype] = self.weights[ref_ifo][loc]
 
             # These weren't in our histogram so give them max penalty instead
             # of random value
-            missed = numpy.where(self.param_bin[ref_ifo][l] != nbinned)[0]
+            missed = numpy.where(self.param_bin[ref_ifo][loc] != nbinned)[0]
             rate[rtype][missed] = self.max_penalty
 
             # Scale by signal population SNR

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -403,7 +403,6 @@ class PhaseTDNewStatistic(NewSNRStatistic):
         snrs = numpy.array([numpy.array(stats[ifo]['snr'], ndmin=1) for ifo in self.ifos])
         smin = numpy.argmin(snrs, axis=0)
         rtypes = {ifo:numpy.where(smin == j)[0] for j, ifo in enumerate(self.ifos)}
-        print smin, rtypes        
         
         # Get reference ifo information 
         rate = numpy.zeros(len(shift), dtype=numpy.float32)
@@ -448,7 +447,6 @@ class PhaseTDNewStatistic(NewSNRStatistic):
             # Read signal weight from precalculated histogram
             l = numpy.searchsorted(self.param_bin[ref_ifo], nbinned)
             l[l == len(self.weights[ref_ifo])] = 0
-            print len(l), len(rtype)
             rate[rtype] = self.weights[ref_ifo][l]
             
             # These weren't in our histogram so give them max penalty instead
@@ -1057,7 +1055,6 @@ class ExpFitSGFgBgRateStatistic(PhaseTDStatistic, ExpFitSGBgRateStatistic):
 
     def coinc_multiifo(self, s, slide, step, to_shift,
                        **kwargs): # pylint:disable=unused-argument
-        print s
         sngl_rates = {sngl[0]: sngl[1]['snglstat'] for sngl in s}
 
         ln_noise_rate = coinc_rate.combination_noise_lograte(

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -309,7 +309,7 @@ class PhaseTDNewStatistic(NewSNRStatistic):
             raise RuntimeError("Couldn't figure out which stat file to use")
 
         logging.info("Using signal histogram %s for ifos %s", selected, ifos)
-        histfile = self.files[name]
+        histfile = self.files[selected]
 
         # This order matters, we need to retrieve the order used to
         # generate the histogram as the first ifos if the reference
@@ -419,7 +419,7 @@ class PhaseTDNewStatistic(NewSNRStatistic):
                 # Calculate differences
                 pdif = (pref - p) % (numpy.pi * 2.0)
                 tdif = shift[rtype] * to_shift[ref_ifo] + \
-                       tref - shift[rtype] * to_shift[ifo] - t
+                    tref - shift[rtype] * to_shift[ifo] - t
                 sdif = s / sref * sense / senseref * sigref / sig
 
                 # Put into bins

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -165,6 +165,7 @@ class NewSNRSGPSDStatistic(NewSNRSGStatistic):
         """
         return ranking.get_newsnr_sgveto_psdvar(trigs)
 
+
 class NewSNRSGPSDScaledStatistic(NewSNRSGStatistic):
     """Calculate the NewSNRSGPSD coincident detection statistic"""
 
@@ -202,6 +203,7 @@ class NewSNRSGPSDScaledThresholdStatistic(NewSNRSGStatistic):
         """
         return ranking.get_newsnr_sgveto_psdvar_scaled_threshold(trigs)
 
+
 class NewSNRSGPSDComStatistic(NewSNRSGStatistic):
     """Calculate the NewSNRSGPSD coincident detection statistic"""
 
@@ -219,7 +221,6 @@ class NewSNRSGPSDComStatistic(NewSNRSGStatistic):
             The array of single detector values
         """
         return ranking.get_newsnr_sgveto_psdvar_com(trigs)
-
 
 
 class NetworkSNRStatistic(NewSNRStatistic):
@@ -332,7 +333,7 @@ class PhaseTDNewStatistic(NewSNRStatistic):
             self.pdtype = [('c%s' % i, int) for i in range(ncol)]
             self.param_bin[ifo] = numpy.zeros(len(self.weights[ifo]), dtype=self.pdtype)
             for i in range(ncol):
-                self.param_bin[ifo]['c%s' % i] = param[:,i]
+                self.param_bin[ifo]['c%s' % i] = param[:, i]
 
             l = self.param_bin[ifo].argsort()
             self.param_bin[ifo] = self.param_bin[ifo][l]
@@ -384,7 +385,7 @@ class PhaseTDNewStatistic(NewSNRStatistic):
 
     def logsignalrate(self, s0, s1, shift):
         to_shift = [-1, 0]
-        stats = {self.ifos[0]:s0, self.ifos[1]:s1}
+        stats = {self.ifos[0]: s0, self.ifos[1]: s1}
         return self.logsignalrate_multiifo(stats, shift, to_shift)
 
     def logsignalrate_multiifo(self, stats, shift, to_shift):
@@ -402,7 +403,7 @@ class PhaseTDNewStatistic(NewSNRStatistic):
         # Figure out which weights each trigger will use
         snrs = numpy.array([numpy.array(stats[ifo]['snr'], ndmin=1) for ifo in self.ifos])
         smin = numpy.argmin(snrs, axis=0)
-        rtypes = {ifo:numpy.where(smin == j)[0] for j, ifo in enumerate(self.ifos)}
+        rtypes = {ifo: numpy.where(smin == j)[0] for j, ifo in enumerate(self.ifos)}
 
         # Get reference ifo information
         rate = numpy.zeros(len(shift), dtype=numpy.float32)
@@ -458,6 +459,7 @@ class PhaseTDNewStatistic(NewSNRStatistic):
             rate[rtype] *= (sref / self.ref_snr) ** -4.0
 
         return numpy.log(rate)
+
 
 class PhaseTDStatistic(NewSNRStatistic):
     """Statistic that re-weights combined newsnr using coinc parameters.
@@ -905,6 +907,7 @@ class PhaseTDExpFitSGStatistic(PhaseTDExpFitStatistic):
     def __init__(self, files, ifos=None):
         PhaseTDExpFitStatistic.__init__(self, files, ifos=ifos)
         self.get_newsnr = ranking.get_newsnr_sgveto
+
 
 class PhaseTDNewExpFitSGStatistic(PhaseTDNewExpFitStatistic):
     """Statistic combining exponential noise model with signal histogram PDF


### PR DESCRIPTION
This requires #2942, and adds the statistics needed for the 2-ogc analysis for both the full and bbh sub-space. In includes handling of the new pta statistic files. 