### PR TITLE
inference: decode bytes->str for filetype from hdf

### DIFF
--- a/pycbc/inference/io/__init__.py
+++ b/pycbc/inference/io/__init__.py
@@ -69,7 +69,7 @@ def get_file_type(filename):
         if filename.endswith(ext):
             with _h5py.File(filename, 'r') as fp:
                 filetype = fp.attrs['filetype']
-            return filetypes[filetype]
+            return filetypes[filetype.decode()]
     for ext in txt_extensions:
         if filename.endswith(ext):
             return InferenceTXTFile

--- a/pycbc/inference/io/base_hdf.py
+++ b/pycbc/inference/io/base_hdf.py
@@ -74,7 +74,7 @@ class BaseInferenceFile(h5py.File):
                 self.attrs['filetype'] = filetype
             else:
                 filetype = None
-        if filetype != self.name:
+        if filetype.decode() != self.name:
             raise ValueError("This file has filetype {}, whereas this class "
                              "is named {}. This indicates that the file was "
                              "not written by this class, and so cannot be "


### PR DESCRIPTION
@spxiwh @cdcapano This seems sufficient to allow me to read posteriors with python3, but not sure if it's "the right way (tm)" to fix the issue.

Note also when cloning from current master and trying to import from within the source tree, I ran into several unrelated import issues, so I haven't tested this in any more detail yet than the simple isolated two-liner from #2944.