### PR TITLE
Setting initial conditions from checkpoint files

### DIFF
--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -134,21 +134,6 @@ with ctx:
     # set up output/checkpoint file
     sampler.setup_output(opts.output_file, force=opts.force)
 
-    # Figure out where to get the initial conditions from: a samples file,
-    # the checkpoint file, the prior, or an initial prior.
-    samples_file = opts.samples_file
-    # use the checkpoint file instead if resume from checkpoint
-    if not sampler.new_checkpoint:
-        samples_file = sampler.checkpoint_file
-    if samples_file is not None:
-        logging.info("Initial positions taken from last iteration in %s",
-                     samples_file)
-        init_prior = None
-    else:
-        # try to load an initial distribution from the config file
-        init_prior = inference.sampler.initial_dist_from_config(
-            cp, sampler.variable_params)
-
     sampler.set_initial_conditions(initial_distribution=init_prior,
                                    samples_file=samples_file)
 

--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -134,8 +134,9 @@ with ctx:
     # Note: the pool is created at this point. This means that,
     # unless you enjoy angering your cluster admins,
     # NO SAMPLES FILE IO SHOULD BE DONE PRIOR TO THIS POINT!!!
-    sampler = inference.sampler.load_from_config(
-        cp, model, output_file=opts.output_file, nprocesses=opts.nprocesses, use_mpi=opts.use_mpi)
+    sampler = inference.sampler.load_from_config(cp, model,
+        output_file=opts.output_file, nprocesses=opts.nprocesses,
+        use_mpi=opts.use_mpi)
 
     # Run the sampler
     sampler.run()

--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -91,6 +91,15 @@ fft.verify_fft_options(opts, parser)
 opt.verify_optimization_options(opts, parser)
 scheme.verify_processing_options(opts, parser)
 
+# check that the output file doesn't already exist
+if os.path.exists(opts.output_file):
+    if force:
+        pass
+        #os.remove(opts.output_file)
+    else:
+        raise OSError("output-file already exists; use force if you "
+                      "wish to overwrite it.")
+
 # set seed
 numpy.random.seed(opts.seed)
 logging.info("Using seed %i", opts.seed)
@@ -129,12 +138,7 @@ with ctx:
     # unless you enjoy angering your cluster admins,
     # NO SAMPLES FILE IO SHOULD BE DONE PRIOR TO THIS POINT!!!
     sampler = inference.sampler.load_from_config(
-        cp, model, nprocesses=opts.nprocesses, use_mpi=opts.use_mpi)
-
-    # set up output/checkpoint file
-    sampler.setup_output(opts.output_file, force=opts.force)
-
-    sampler.set_initial_conditions(cp)
+        cp, model, output_file=opts.output_file, nprocesses=opts.nprocesses, use_mpi=opts.use_mpi)
 
     # Run the sampler
     sampler.run()

--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -92,13 +92,10 @@ opt.verify_optimization_options(opts, parser)
 scheme.verify_processing_options(opts, parser)
 
 # check that the output file doesn't already exist
-if os.path.exists(opts.output_file):
-    if force:
-        pass
-        #os.remove(opts.output_file)
-    else:
-        raise OSError("output-file already exists; use force if you "
-                      "wish to overwrite it.")
+if os.path.exists(opts.output_file) and not opts.force:
+    raise OSError("output-file already exists; use force if you "
+                  "wish to overwrite it.")
+
 
 # set seed
 numpy.random.seed(opts.seed)

--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -134,8 +134,8 @@ with ctx:
     # Note: the pool is created at this point. This means that,
     # unless you enjoy angering your cluster admins,
     # NO SAMPLES FILE IO SHOULD BE DONE PRIOR TO THIS POINT!!!
-    sampler = inference.sampler.load_from_config(cp, model,
-        output_file=opts.output_file, nprocesses=opts.nprocesses,
+    sampler = inference.sampler.load_from_config(
+        cp, model, output_file=opts.output_file, nprocesses=opts.nprocesses,
         use_mpi=opts.use_mpi)
 
     # Run the sampler

--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -134,8 +134,7 @@ with ctx:
     # set up output/checkpoint file
     sampler.setup_output(opts.output_file, force=opts.force)
 
-    sampler.set_initial_conditions(initial_distribution=init_prior,
-                                   samples_file=samples_file)
+    sampler.set_initial_conditions(cp)
 
     # Run the sampler
     sampler.run()

--- a/pycbc/inference/sampler/base.py
+++ b/pycbc/inference/sampler/base.py
@@ -68,7 +68,8 @@ class BaseSampler(object):
 
     # @classmethod <--uncomment when we move to python 3.3
     @abstractmethod
-    def from_config(cls, cp, model, output_file=None, nprocesses=1, use_mpi=False):
+    def from_config(cls, cp, model, output_file=None, nprocesses=1,
+                    use_mpi=False):
         """This should initialize the sampler given a config file.
         """
         pass
@@ -162,6 +163,7 @@ class BaseSampler(object):
 # =============================================================================
 #
 
+
 def setup_output(sampler, output_file, force=False):
     r"""Sets up the sampler's checkpoint and output files.
 
@@ -206,7 +208,6 @@ def setup_output(sampler, output_file, force=False):
     # store
     sampler.checkpoint_file = checkpoint_file
     sampler.backup_file = backup_file
-    #return new_checkpoint
 
 
 def create_new_output_file(sampler, filename, **kwargs):

--- a/pycbc/inference/sampler/base.py
+++ b/pycbc/inference/sampler/base.py
@@ -28,7 +28,6 @@ Defines the base sampler class to be inherited by all samplers.
 from __future__ import absolute_import
 
 from abc import ABCMeta, abstractmethod, abstractproperty
-import os
 import shutil
 import logging
 
@@ -69,7 +68,7 @@ class BaseSampler(object):
 
     # @classmethod <--uncomment when we move to python 3.3
     @abstractmethod
-    def from_config(cls, cp, model, filename, nprocesses=1, use_mpi=False):
+    def from_config(cls, cp, model, output_file=None, nprocesses=1, use_mpi=False):
         """This should initialize the sampler given a config file.
         """
         pass
@@ -164,7 +163,7 @@ class BaseSampler(object):
 #
 
 def setup_output(sampler, output_file, force=False):
-    """Sets up the sampler's checkpoint and output files.
+    r"""Sets up the sampler's checkpoint and output files.
 
     The checkpoint file has the same name as the output file, but with
     ``.checkpoint`` appended to the name. A backup file will also be
@@ -207,7 +206,6 @@ def setup_output(sampler, output_file, force=False):
     # store
     sampler.checkpoint_file = checkpoint_file
     sampler.backup_file = backup_file
-    #sampler.checkpoint_valid = checkpoint_valid
     return new_checkpoint
 
 

--- a/pycbc/inference/sampler/base.py
+++ b/pycbc/inference/sampler/base.py
@@ -129,15 +129,6 @@ class BaseSampler(object):
         pass
 
     @abstractmethod
-    def set_initial_conditions(self, initial_distribution=None,
-                               samples_file=None):
-        """Sets up the starting point for the sampler.
-
-        Should also set the sampler's random state.
-        """
-        pass
-
-    @abstractmethod
     def checkpoint(self):
         """The sampler must have a checkpoint method for dumping raw samples
         and stats to the file type defined by ``io``.

--- a/pycbc/inference/sampler/base.py
+++ b/pycbc/inference/sampler/base.py
@@ -150,7 +150,7 @@ class BaseSampler(object):
         pass
 
     @abstractmethod
-    def resume_from_checkpoint(self):
+    def resume_from_checkpoint(self,output_file):
         """Resume the sampler from the output file.
         """
         pass

--- a/pycbc/inference/sampler/base.py
+++ b/pycbc/inference/sampler/base.py
@@ -190,12 +190,12 @@ def setup_output(sampler, output_file, force=False):
                                                  backup_file)
     # Create a new file if the checkpoint doesn't exist, or if it is
     # corrupted
-    new_checkpoint = False  # keeps track if this is a new file or not
+    sampler.new_checkpoint = False  # keeps track if this is a new file or not
     if not checkpoint_valid:
         logging.info("Checkpoint not found or not valid")
         create_new_output_file(sampler, checkpoint_file)
         # now the checkpoint is valid
-        new_checkpoint = True
+        sampler.new_checkpoint = True
         # copy to backup
         shutil.copy(checkpoint_file, backup_file)
     # write the command line, startup
@@ -206,7 +206,7 @@ def setup_output(sampler, output_file, force=False):
     # store
     sampler.checkpoint_file = checkpoint_file
     sampler.backup_file = backup_file
-    return new_checkpoint
+    #return new_checkpoint
 
 
 def create_new_output_file(sampler, filename, **kwargs):

--- a/pycbc/inference/sampler/base.py
+++ b/pycbc/inference/sampler/base.py
@@ -150,7 +150,7 @@ class BaseSampler(object):
         pass
 
     @abstractmethod
-    def resume_from_checkpoint(self,output_file):
+    def resume_from_checkpoint(self):
         """Resume the sampler from the output file.
         """
         pass

--- a/pycbc/inference/sampler/base_mcmc.py
+++ b/pycbc/inference/sampler/base_mcmc.py
@@ -457,7 +457,7 @@ class BaseMCMC(object):
             initial_distribution = initial_dist_from_config(cp,
                 self.variable_params)
 
-        self.set_p0(samples_file = samples_file, prior=initial_distribution)
+        self.set_p0(samples_file=samples_file, prior=initial_distribution)
         # if a samples file was provided, use it to set the state of the
         # sampler
         if samples_file is not None:
@@ -469,8 +469,8 @@ class BaseMCMC(object):
         """
         pass
 
-    def resume_from_checkpoint(self,filename):
-        """
+    def resume_from_checkpoint(self, filename):
+        """Resume the sampler from the checkpoint file
         """
         with self.io(self.checkpoint_file, "r") as fp:
             self._lastclear = fp.niterations

--- a/pycbc/inference/sampler/base_mcmc.py
+++ b/pycbc/inference/sampler/base_mcmc.py
@@ -455,7 +455,7 @@ class BaseMCMC(object):
         else:
             # try to load an initial distribution from the config file
             initial_distribution = initial_dist_from_config(cp,
-                self.variable_params)
+                                       self.variable_params)
 
         self.set_p0(samples_file=samples_file, prior=initial_distribution)
         # if a samples file was provided, use it to set the state of the

--- a/pycbc/inference/sampler/base_mcmc.py
+++ b/pycbc/inference/sampler/base_mcmc.py
@@ -469,7 +469,7 @@ class BaseMCMC(object):
         """
         pass
 
-    def resume_from_checkpoint(self, filename):
+    def resume_from_checkpoint(self):
         """Resume the sampler from the checkpoint file
         """
         with self.io(self.checkpoint_file, "r") as fp:
@@ -486,14 +486,6 @@ class BaseMCMC(object):
         # "nsamples" keeps track of the number of samples we've obtained (if
         # target_eff_nsamples is not None, this is the effective number of
         # samples; otherwise, this is the total number of samples).
-        # _lastclear is the number of iterations that the file already
-        # contains (either due to sampler burn-in, or a previous checkpoint)
-        if self.new_checkpoint:
-            self._lastclear = 0
-        else:
-            with self.io(self.checkpoint_file, "r") as fp:
-                self._lastclear = fp.niterations
-                self.thin_interval = fp.thinned_by
         if self.target_eff_nsamples is not None:
             target_nsamples = self.target_eff_nsamples
             with self.io(self.checkpoint_file, "r") as fp:

--- a/pycbc/inference/sampler/base_mcmc.py
+++ b/pycbc/inference/sampler/base_mcmc.py
@@ -34,14 +34,12 @@ from six import (add_metaclass, string_types)
 
 import numpy
 
-from .base import initial_dist_from_config
-
 from pycbc.workflow import ConfigParser
 from pycbc.filter import autocorrelation
 from pycbc.inference.io import validate_checkpoint_files
 
 from .base import setup_output
-
+from .base import initial_dist_from_config
 
 #
 # =============================================================================
@@ -453,10 +451,11 @@ class BaseMCMC(object):
             samples_file = self.checkpoint_file
             logging.info("Initial positions taken from last iteration in %s",
                          samples_file)
-            init_prior = None
+            initial_distribution = None
         else:
             # try to load an initial distribution from the config file
-            init_prior = initial_dist_from_config(cp, sampler.variable_params)
+            initial_distribution = initial_dist_from_config(cp,
+                sampler.variable_params)
 
         self.set_p0(samples_file=samples_file, prior=initial_distribution)
         # if a samples file was provided, use it to set the state of the

--- a/pycbc/inference/sampler/base_mcmc.py
+++ b/pycbc/inference/sampler/base_mcmc.py
@@ -469,7 +469,7 @@ class BaseMCMC(object):
         """
         pass
 
-    def resume_from_checkpoint(self):
+    def resume_from_checkpoint(self,output_file):
         """Resume the sampler from the checkpoint file
         """
         with self.io(self.checkpoint_file, "r") as fp:
@@ -564,7 +564,6 @@ class BaseMCMC(object):
     def write_results(self, filename):
         """Should write all samples currently in memory to the given file."""
         pass
-
 
     def checkpoint(self):
         """Dumps current samples to the checkpoint file."""

--- a/pycbc/inference/sampler/base_mcmc.py
+++ b/pycbc/inference/sampler/base_mcmc.py
@@ -34,6 +34,8 @@ from six import (add_metaclass, string_types)
 
 import numpy
 
+from .base import initial_dist_from_config
+
 from pycbc.workflow import ConfigParser
 from pycbc.filter import autocorrelation
 from pycbc.inference.io import validate_checkpoint_files
@@ -436,13 +438,22 @@ class BaseMCMC(object):
         self._p0 = p0
         return self.p0
 
-    def set_initial_conditions(self, initial_distribution=None,
-                               samples_file=None):
+    def set_initial_conditions(self):
         """Sets the initial starting point for the MCMC.
 
         If a starting samples file is provided, will also load the random
         state from it.
         """
+        # use the checkpoint file instead if resume from checkpoint
+        if not self.new_checkpoint:
+            samples_file = self.checkpoint_file
+            logging.info("Initial positions taken from last iteration in %s",
+                         samples_file)
+            init_prior = None
+        else:
+            # try to load an initial distribution from the config file
+            init_prior = initial_dist_from_config(cp, sampler.variable_params)
+
         self.set_p0(samples_file=samples_file, prior=initial_distribution)
         # if a samples file was provided, use it to set the state of the
         # sampler

--- a/pycbc/inference/sampler/base_mcmc.py
+++ b/pycbc/inference/sampler/base_mcmc.py
@@ -455,9 +455,9 @@ class BaseMCMC(object):
         else:
             # try to load an initial distribution from the config file
             initial_distribution = initial_dist_from_config(cp,
-                                       self.variable_params)
+                self.variable_params)
 
-        self.set_p0(samples_file=samples_file, prior=initial_distribution)
+        self.set_p0(samples_file = samples_file, prior=initial_distribution)
         # if a samples file was provided, use it to set the state of the
         # sampler
         if samples_file is not None:
@@ -468,6 +468,14 @@ class BaseMCMC(object):
         """Sets the state of the sampler to the instance saved in a file.
         """
         pass
+
+    def resume_from_checkpoint(self,filename):
+        """
+        """
+        with self.io(self.checkpoint_file, "r") as fp:
+            self._lastclear = fp.niterations
+        self.set_p0(samples_file=self.checkpoint_file)
+        self.set_state_from_file(self.checkpoint_file)
 
     def run(self):
         """Runs the sampler."""
@@ -565,26 +573,6 @@ class BaseMCMC(object):
         """Should write all samples currently in memory to the given file."""
         pass
 
-    def setup_output(self, output_file, force=False):
-        """Sets up the sampler's checkpoint and output files.
-
-        The checkpoint file has the same name as the output file, but with
-        ``.checkpoint`` appended to the name. A backup file will also be
-        created.
-
-        If the output file already exists, an ``OSError`` will be raised.
-        This can be overridden by setting ``force`` to ``True``.
-
-        Parameters
-        ----------
-        sampler : sampler instance
-            Sampler
-        output_file : str
-            Name of the output file.
-        force : bool, optional
-            If the output file already exists, overwrite it.
-        """
-        setup_output(self, output_file, force=force)
 
     def checkpoint(self):
         """Dumps current samples to the checkpoint file."""

--- a/pycbc/inference/sampler/base_mcmc.py
+++ b/pycbc/inference/sampler/base_mcmc.py
@@ -438,11 +438,15 @@ class BaseMCMC(object):
         self._p0 = p0
         return self.p0
 
-    def set_initial_conditions(self):
+    def set_initial_conditions(self,cp):
         """Sets the initial starting point for the MCMC.
 
         If a starting samples file is provided, will also load the random
         state from it.
+        Parameters:
+        ----------
+         cp : ConfigParser
+              Open config parser to retrieve the argument from.
         """
         # use the checkpoint file instead if resume from checkpoint
         if not self.new_checkpoint:

--- a/pycbc/inference/sampler/base_mcmc.py
+++ b/pycbc/inference/sampler/base_mcmc.py
@@ -469,7 +469,7 @@ class BaseMCMC(object):
         """
         pass
 
-    def resume_from_checkpoint(self,output_file):
+    def resume_from_checkpoint(self):
         """Resume the sampler from the checkpoint file
         """
         with self.io(self.checkpoint_file, "r") as fp:

--- a/pycbc/inference/sampler/base_mcmc.py
+++ b/pycbc/inference/sampler/base_mcmc.py
@@ -436,7 +436,7 @@ class BaseMCMC(object):
         self._p0 = p0
         return self.p0
 
-    def set_initial_conditions(self,cp):
+    def set_initial_conditions(self, cp):
         """Sets the initial starting point for the MCMC.
 
         If a starting samples file is provided, will also load the random
@@ -455,7 +455,7 @@ class BaseMCMC(object):
         else:
             # try to load an initial distribution from the config file
             initial_distribution = initial_dist_from_config(cp,
-                sampler.variable_params)
+                self.variable_params)
 
         self.set_p0(samples_file=samples_file, prior=initial_distribution)
         # if a samples file was provided, use it to set the state of the

--- a/pycbc/inference/sampler/cpnest.py
+++ b/pycbc/inference/sampler/cpnest.py
@@ -165,7 +165,7 @@ class CPNestSampler(BaseSampler):
         """
         pass
 
-    def resume_from_checkpoint(self,filename):
+    def resume_from_checkpoint(self):
         pass
 
     def setup_output(self, output_file, force=False):

--- a/pycbc/inference/sampler/cpnest.py
+++ b/pycbc/inference/sampler/cpnest.py
@@ -121,9 +121,7 @@ class CPNestSampler(BaseSampler):
 
         setup_output(obj, output_file)
         if not obj.new_checkpoint:
-            obj.resume_from_checkpoint(cp)
-        else:
-            init_prior = initial_dist_from_config(cp, obj.variable_params)
+            obj.resume_from_checkpoint()
         return obj
 
     def checkpoint(self):

--- a/pycbc/inference/sampler/cpnest.py
+++ b/pycbc/inference/sampler/cpnest.py
@@ -119,8 +119,8 @@ class CPNestSampler(BaseSampler):
                   verbose=verbose,
                   loglikelihood_function=loglikelihood_function)
 
-        new_checkpoint = setup_output(obj, output_file)
-        if not new_checkpoint:
+        setup_output(obj, output_file)
+        if not obj.new_checkpoint:
             obj.resume_from_checkpoint(cp)
         else:
             init_prior = initial_dist_from_config(cp, obj.variable_params)
@@ -165,7 +165,7 @@ class CPNestSampler(BaseSampler):
         """
         pass
 
-    def resume_from_checkpoint(self):
+    def resume_from_checkpoint(self,filename):
         pass
 
     def setup_output(self, output_file, force=False):

--- a/pycbc/inference/sampler/cpnest.py
+++ b/pycbc/inference/sampler/cpnest.py
@@ -33,7 +33,7 @@ import os
 import cpnest
 import cpnest.model as cpm
 from pycbc.inference.io import (CPNestFile, validate_checkpoint_files)
-from .base import (BaseSampler, setup_output)
+from .base import (BaseSampler, setup_output, initial_dist_from_config)
 from .base_mcmc import get_optional_arg_from_config
 
 
@@ -99,7 +99,7 @@ class CPNestSampler(BaseSampler):
         return len(tuple(self.samples.values())[0])
 
     @classmethod
-    def from_config(cls, cp, model, nprocesses=1, use_mpi=False):
+    def from_config(cls, cp, model, output_file=None, nprocesses=1, use_mpi=False):
         """
         Loads the sampler from the given config file.
         """
@@ -117,6 +117,13 @@ class CPNestSampler(BaseSampler):
         obj = cls(model, nlive=nlive, maxmcmc=maxmcmc, nthreads=nthreads,
                   verbose=verbose,
                   loglikelihood_function=loglikelihood_function)
+
+        new_checkpoint = setup_output(obj, output_file)
+        if not new_checkpoint:
+            objresume_from_checkpoint(cp)
+        else:
+            init_prior = initial_dist_from_config(cp,
+                obj.variable_params)
         return obj
 
     def checkpoint(self):
@@ -156,6 +163,9 @@ class CPNestSampler(BaseSampler):
 
         Should also set the sampler's random state.
         """
+        pass
+
+    def resume_from_checkpoint(self):
         pass
 
     def setup_output(self, output_file, force=False):

--- a/pycbc/inference/sampler/cpnest.py
+++ b/pycbc/inference/sampler/cpnest.py
@@ -99,7 +99,8 @@ class CPNestSampler(BaseSampler):
         return len(tuple(self.samples.values())[0])
 
     @classmethod
-    def from_config(cls, cp, model, output_file=None, nprocesses=1, use_mpi=False):
+    def from_config(cls, cp, model, output_file=None, nprocesses=1,
+                    use_mpi=False):
         """
         Loads the sampler from the given config file.
         """
@@ -120,10 +121,9 @@ class CPNestSampler(BaseSampler):
 
         new_checkpoint = setup_output(obj, output_file)
         if not new_checkpoint:
-            objresume_from_checkpoint(cp)
+            obj.resume_from_checkpoint(cp)
         else:
-            init_prior = initial_dist_from_config(cp,
-                obj.variable_params)
+            init_prior = initial_dist_from_config(cp, obj.variable_params)
         return obj
 
     def checkpoint(self):

--- a/pycbc/inference/sampler/cpnest.py
+++ b/pycbc/inference/sampler/cpnest.py
@@ -33,7 +33,7 @@ import os
 import cpnest
 import cpnest.model as cpm
 from pycbc.inference.io import (CPNestFile, validate_checkpoint_files)
-from .base import (BaseSampler, setup_output, initial_dist_from_config)
+from .base import (BaseSampler, setup_output)
 from .base_mcmc import get_optional_arg_from_config
 
 

--- a/pycbc/inference/sampler/dynesty.py
+++ b/pycbc/inference/sampler/dynesty.py
@@ -36,7 +36,7 @@ import dynesty
 from dynesty.utils import resample_equal
 from pycbc.inference.io import (DynestyFile, validate_checkpoint_files)
 from pycbc.distributions import read_constraints_from_config
-from .base import (BaseSampler, setup_output, initial_dist_from_config)
+from .base import (BaseSampler, setup_output)
 from .base_mcmc import get_optional_arg_from_config
 from .. import models
 

--- a/pycbc/inference/sampler/dynesty.py
+++ b/pycbc/inference/sampler/dynesty.py
@@ -140,9 +140,7 @@ class DynestySampler(BaseSampler):
                   use_mpi=use_mpi, **extra)
         setup_output(obj, output_file)
         if not obj.new_checkpoint:
-            obj.resume_from_checkpoint(cp)
-        else:
-            init_prior = initial_dist_from_config(cp, obj.variable_params)
+            obj.resume_from_checkpoint()
         return obj
 
     def checkpoint(self):

--- a/pycbc/inference/sampler/dynesty.py
+++ b/pycbc/inference/sampler/dynesty.py
@@ -109,8 +109,8 @@ class DynestySampler(BaseSampler):
         return len(tuple(self.samples.values())[0])
 
     @classmethod
-    def from_config(cls, cp, model, output_file=None, nprocesses=1, loglikelihood_function=None,
-                    use_mpi=False):
+    def from_config(cls, cp, model, output_file=None, nprocesses=1,
+                    use_mpi=False, loglikelihood_function=None):
         """
         Loads the sampler from the given config file.
         """
@@ -138,8 +138,8 @@ class DynestySampler(BaseSampler):
         obj = cls(model, nlive=nlive, dlogz=dlogz, nprocesses=nprocesses,
                   loglikelihood_function=loglikelihood_function,
                   use_mpi=use_mpi, **extra)
-        new_checkpoint = setup_output(obj, output_file)
-        if not new_checkpoint:
+        setup_output(obj, output_file)
+        if not obj.new_checkpoint:
             obj.resume_from_checkpoint(cp)
         else:
             init_prior = initial_dist_from_config(cp, obj.variable_params)
@@ -148,7 +148,7 @@ class DynestySampler(BaseSampler):
     def checkpoint(self):
         pass
 
-    def resume_from_checkpoint(self):
+    def resume_from_checkpoint(selfi,filename):
         pass
 
     def finalize(self):

--- a/pycbc/inference/sampler/dynesty.py
+++ b/pycbc/inference/sampler/dynesty.py
@@ -148,7 +148,7 @@ class DynestySampler(BaseSampler):
     def checkpoint(self):
         pass
 
-    def resume_from_checkpoint(selfi,filename):
+    def resume_from_checkpoint(self):
         pass
 
     def finalize(self):

--- a/pycbc/inference/sampler/dynesty.py
+++ b/pycbc/inference/sampler/dynesty.py
@@ -140,10 +140,9 @@ class DynestySampler(BaseSampler):
                   use_mpi=use_mpi, **extra)
         new_checkpoint = setup_output(obj, output_file)
         if not new_checkpoint:
-            objresume_from_checkpoint(cp)
+            obj.resume_from_checkpoint(cp)
         else:
-            init_prior = initial_dist_from_config(cp,
-                obj.variable_params)
+            init_prior = initial_dist_from_config(cp, obj.variable_params)
         return obj
 
     def checkpoint(self):

--- a/pycbc/inference/sampler/emcee.py
+++ b/pycbc/inference/sampler/emcee.py
@@ -221,7 +221,5 @@ class EmceeEnsembleSampler(MCMCAutocorrSupport, BaseMCMC, BaseSampler):
         if not obj.new_checkpoint:
             obj.resume_from_checkpoint()
         else:
-            init_prior = initial_dist_from_config(cp, obj.variable_params)
-            obj.set_p0(prior=init_prior)
-            obj._lastclear = 0
+            obj.set_start_from_config(cp)
         return obj

--- a/pycbc/inference/sampler/emcee.py
+++ b/pycbc/inference/sampler/emcee.py
@@ -219,7 +219,7 @@ class EmceeEnsembleSampler(MCMCAutocorrSupport, BaseMCMC, BaseSampler):
         # Set up the output file
         setup_output(obj, output_file)
         if not obj.new_checkpoint:
-            obj.resume_from_checkpoint(cp)
+            obj.resume_from_checkpoint()
         else:
             init_prior = initial_dist_from_config(cp, obj.variable_params)
             obj.set_p0(prior=init_prior)

--- a/pycbc/inference/sampler/emcee.py
+++ b/pycbc/inference/sampler/emcee.py
@@ -218,10 +218,9 @@ class EmceeEnsembleSampler(MCMCAutocorrSupport, BaseMCMC, BaseSampler):
         # Set up the output file
         new_checkpoint = setup_output(obj, output_file)
         if not new_checkpoint:
-            objresume_from_checkpoint(cp)
+            obj.resume_from_checkpoint(cp)
         else:
-            init_prior = initial_dist_from_config(cp,
-                obj.variable_params)
+            init_prior = initial_dist_from_config(cp, obj.variable_params)
             obj.set_p0(prior=init_prior)
             obj._lastclear = 0
         return obj

--- a/pycbc/inference/sampler/emcee.py
+++ b/pycbc/inference/sampler/emcee.py
@@ -32,7 +32,7 @@ import numpy
 import emcee
 from pycbc.pool import choose_pool
 
-from .base import BaseSampler
+from .base import (BaseSampler, setup_output, initial_dist_from_config)
 from .base_mcmc import (BaseMCMC, MCMCAutocorrSupport, raw_samples_to_dict,
                         blob_data_to_dict, get_optional_arg_from_config)
 from ..burn_in import MCMCBurnInTests
@@ -191,7 +191,7 @@ class EmceeEnsembleSampler(MCMCAutocorrSupport, BaseMCMC, BaseSampler):
         pass
 
     @classmethod
-    def from_config(cls, cp, model, nprocesses=1, use_mpi=False):
+    def from_config(cls, cp, model, output_file=None, nprocesses=1, use_mpi=False):
         """Loads the sampler from the given config file."""
         section = "sampler"
         # check name
@@ -215,4 +215,13 @@ class EmceeEnsembleSampler(MCMCAutocorrSupport, BaseMCMC, BaseSampler):
         obj.set_burn_in_from_config(cp)
         # set prethin options
         obj.set_thin_interval_from_config(cp, section)
+        # Set up the output file
+        new_checkpoint = setup_output(obj, output_file)
+        if not new_checkpoint:
+            objresume_from_checkpoint(cp)
+        else:
+            init_prior = initial_dist_from_config(cp,
+                obj.variable_params)
+            obj.set_p0(prior=init_prior)
+            obj._lastclear = 0
         return obj

--- a/pycbc/inference/sampler/emcee.py
+++ b/pycbc/inference/sampler/emcee.py
@@ -216,8 +216,8 @@ class EmceeEnsembleSampler(MCMCAutocorrSupport, BaseMCMC, BaseSampler):
         # set prethin options
         obj.set_thin_interval_from_config(cp, section)
         # Set up the output file
-        new_checkpoint = setup_output(obj, output_file)
-        if not new_checkpoint:
+        setup_output(obj, output_file)
+        if not obj.new_checkpoint:
             obj.resume_from_checkpoint(cp)
         else:
             init_prior = initial_dist_from_config(cp, obj.variable_params)

--- a/pycbc/inference/sampler/emcee.py
+++ b/pycbc/inference/sampler/emcee.py
@@ -191,7 +191,8 @@ class EmceeEnsembleSampler(MCMCAutocorrSupport, BaseMCMC, BaseSampler):
         pass
 
     @classmethod
-    def from_config(cls, cp, model, output_file=None, nprocesses=1, use_mpi=False):
+    def from_config(cls, cp, model, output_file=None, nprocesses=1,
+                    use_mpi=False):
         """Loads the sampler from the given config file."""
         section = "sampler"
         # check name

--- a/pycbc/inference/sampler/emcee.py
+++ b/pycbc/inference/sampler/emcee.py
@@ -32,7 +32,7 @@ import numpy
 import emcee
 from pycbc.pool import choose_pool
 
-from .base import (BaseSampler, setup_output, initial_dist_from_config)
+from .base import (BaseSampler, setup_output)
 from .base_mcmc import (BaseMCMC, MCMCAutocorrSupport, raw_samples_to_dict,
                         blob_data_to_dict, get_optional_arg_from_config)
 from ..burn_in import MCMCBurnInTests

--- a/pycbc/inference/sampler/emcee_pt.py
+++ b/pycbc/inference/sampler/emcee_pt.py
@@ -172,9 +172,8 @@ class EmceePTSampler(MultiTemperedAutocorrSupport, MultiTemperedSupport,
         # set prethin options
         obj.set_thin_interval_from_config(cp, section)
         # Set up the output file
-        #with obj.io(obj.io.checkpoint_file, "a") as fp:
-        new_checkpoint = setup_output(obj, output_file)
-        if not new_checkpoint:
+        setup_output(obj, output_file)
+        if not obj.new_checkpoint:
             obj.resume_from_checkpoint(cp)
         else:
             init_prior = initial_dist_from_config(cp, 

--- a/pycbc/inference/sampler/emcee_pt.py
+++ b/pycbc/inference/sampler/emcee_pt.py
@@ -177,9 +177,7 @@ class EmceePTSampler(MultiTemperedAutocorrSupport, MultiTemperedSupport,
         if not obj.new_checkpoint:
             obj.resume_from_checkpoint()
         else:
-            init_prior = initial_dist_from_config(cp, obj.variable_params)
-            obj.set_p0(prior=init_prior)
-            obj._lastclear = 0
+            obj.set_start_from_config(cp)
         return obj
 
     @property

--- a/pycbc/inference/sampler/emcee_pt.py
+++ b/pycbc/inference/sampler/emcee_pt.py
@@ -175,7 +175,7 @@ class EmceePTSampler(MultiTemperedAutocorrSupport, MultiTemperedSupport,
         # Set up the output file
         setup_output(obj, output_file)
         if not obj.new_checkpoint:
-            obj.resume_from_checkpoint(cp)
+            obj.resume_from_checkpoint()
         else:
             init_prior = initial_dist_from_config(cp, obj.variable_params)
             obj.set_p0(prior=init_prior)

--- a/pycbc/inference/sampler/emcee_pt.py
+++ b/pycbc/inference/sampler/emcee_pt.py
@@ -116,7 +116,8 @@ class EmceePTSampler(MultiTemperedAutocorrSupport, MultiTemperedSupport,
         return self._sampler.betas
 
     @classmethod
-    def from_config(cls, cp, model, output_file=None, nprocesses=1, use_mpi=False):
+    def from_config(cls, cp, model, output_file=None, nprocesses=1,
+                    use_mpi=False):
         """
         Loads the sampler from the given config file.
 
@@ -176,8 +177,7 @@ class EmceePTSampler(MultiTemperedAutocorrSupport, MultiTemperedSupport,
         if not obj.new_checkpoint:
             obj.resume_from_checkpoint(cp)
         else:
-            init_prior = initial_dist_from_config(cp, 
-                obj.variable_params)
+            init_prior = initial_dist_from_config(cp, obj.variable_params)
             obj.set_p0(prior=init_prior)
             obj._lastclear = 0
         return obj

--- a/pycbc/inference/sampler/emcee_pt.py
+++ b/pycbc/inference/sampler/emcee_pt.py
@@ -175,7 +175,7 @@ class EmceePTSampler(MultiTemperedAutocorrSupport, MultiTemperedSupport,
         #with obj.io(obj.io.checkpoint_file, "a") as fp:
         new_checkpoint = setup_output(obj, output_file)
         if not new_checkpoint:
-            objresume_from_checkpoint(cp)
+            obj.resume_from_checkpoint(cp)
         else:
             init_prior = initial_dist_from_config(cp, 
                 obj.variable_params)

--- a/pycbc/inference/sampler/emcee_pt.py
+++ b/pycbc/inference/sampler/emcee_pt.py
@@ -27,7 +27,7 @@ import h5py
 import logging
 from pycbc.pool import choose_pool
 
-from .base import (BaseSampler, setup_output, initial_dist_from_config)
+from .base import (BaseSampler, setup_output)
 from .base_mcmc import (BaseMCMC, raw_samples_to_dict,
                         get_optional_arg_from_config)
 from .base_multitemper import (MultiTemperedSupport,

--- a/pycbc/inference/sampler/multinest.py
+++ b/pycbc/inference/sampler/multinest.py
@@ -403,6 +403,4 @@ class MultinestSampler(BaseSampler):
         obj = cls(model, nlivepoints, constraints=constraints,
                   **optional_kwargs)
         obj.setup_output(obj, output_file)
-        if not obj.new_checkpoint:
-            obj.resume_from_checkpoint()
         return obj

--- a/pycbc/inference/sampler/multinest.py
+++ b/pycbc/inference/sampler/multinest.py
@@ -348,7 +348,7 @@ class MultinestSampler(BaseSampler):
             If the output file already exists, overwrite it.
         """
         if self.is_main_process:
-            self.new_checkpoint = setup_output(self, output_file, force=force)
+            setup_output(self, output_file, force=force)
         else:
             # child processes just store filenames
             checkpoint_file = output_file + '.checkpoint'
@@ -364,7 +364,8 @@ class MultinestSampler(BaseSampler):
         pass
 
     @classmethod
-    def from_config(cls, cp, model, output_file=None, nprocesses=1, use_mpi=False):
+    def from_config(cls, cp, model, output_file=None, nprocesses=1,
+                    use_mpi=False):
         """Loads the sampler from the given config file."""
         section = "sampler"
         # check name
@@ -400,6 +401,5 @@ class MultinestSampler(BaseSampler):
         if not obj.new_checkpoint:
             obj.resume_from_checkpoint(cp)
         else:
-            init_prior = initial_dist_from_config(cp,
-                obj.variable_params)
+            init_prior = initial_dist_from_config(cp, obj.variable_params)
         return obj

--- a/pycbc/inference/sampler/multinest.py
+++ b/pycbc/inference/sampler/multinest.py
@@ -201,7 +201,7 @@ class MultinestSampler(BaseSampler):
         if samples_file is not None:
             self.set_state_from_file(samples_file)
 
-    def resume_from_ceckpoint(self):
+    def resume_from_checkpoint(self):
         """Resume sampler from checkpoint
         """
         pass

--- a/pycbc/inference/sampler/multinest.py
+++ b/pycbc/inference/sampler/multinest.py
@@ -201,6 +201,9 @@ class MultinestSampler(BaseSampler):
         if samples_file is not None:
             self.set_state_from_file(samples_file)
 
+    def resume_from_ceckpoint(self):
+        pass 
+
     def set_state_from_file(self, filename):
         """Sets the state of the sampler back to the instance saved in a file.
         """
@@ -399,7 +402,5 @@ class MultinestSampler(BaseSampler):
                   **optional_kwargs)
         obj.setup_output(obj, output_file)
         if not obj.new_checkpoint:
-            obj.resume_from_checkpoint(cp)
-        else:
-            init_prior = initial_dist_from_config(cp, obj.variable_params)
+            obj.resume_from_checkpoint()
         return obj

--- a/pycbc/inference/sampler/multinest.py
+++ b/pycbc/inference/sampler/multinest.py
@@ -36,7 +36,7 @@ from pycbc.inference.io import (MultinestFile, validate_checkpoint_files)
 from pycbc.distributions import read_constraints_from_config
 from pycbc.pool import is_main_process
 from pycbc.transforms import apply_transforms
-from .base import (BaseSampler, setup_output, initial_dist_from_config)
+from .base import (BaseSampler, setup_output)
 from .base_mcmc import get_optional_arg_from_config
 
 
@@ -202,7 +202,9 @@ class MultinestSampler(BaseSampler):
             self.set_state_from_file(samples_file)
 
     def resume_from_ceckpoint(self):
-        pass 
+        """Resume sampler from checkpoint
+        """
+        pass
 
     def set_state_from_file(self, filename):
         """Sets the state of the sampler back to the instance saved in a file.

--- a/pycbc/inference/sampler/multinest.py
+++ b/pycbc/inference/sampler/multinest.py
@@ -243,8 +243,8 @@ class MultinestSampler(BaseSampler):
         """Runs the sampler until the specified evidence tolerance
         is reached.
         """
-        #if self.new_checkpoint:
-        #    self._itercount = 0
+        if self.new_checkpoint:
+            self._itercount = 0
         else:
             self.set_initial_conditions(samples_file=self.checkpoint_file)
             with self.io(self.checkpoint_file, "r") as f_p:


### PR DESCRIPTION
The initial condition for samplers at the start has been moved from pycbc_inference module to set_initial_condition function in BaseMCMC class. This will help in setting up initial condition for different samplers in their own way. 