### PR TITLE
Do not 'yum update' when building RHEL virtualenv in Travis

### DIFF
--- a/tools/docker_build_dist.sh
+++ b/tools/docker_build_dist.sh
@@ -51,7 +51,6 @@ if [ "x${PYCBC_CONTAINER}" == "xpycbc_rhel_virtualenv" ]; then
   curl http://download.pegasus.isi.edu/wms/download/rhel/7/pegasus.repo > /etc/yum.repos.d/pegasus.repo
   yum clean all
   yum makecache
-  yum -y update
   yum -y install openssl-devel openssl-static
   yum -y install pegasus
   yum -y install ligo-proxy-utils


### PR DESCRIPTION
This aims to fix the recent Travis failures caused because the `yum -y update` command was upgrading the `ligo/lalsuite-dev:el7` environment from EPEL 7.6 to 7.7, which broke the (current) state of the lalsuite software in that container. We should probably decide if this should be just a temporary work-around or a permanent change in philosophy.