### PR TITLE
Hierarchical removal multiifo

### DIFF
--- a/bin/hdfcoinc/pycbc_multiifo_add_statmap
+++ b/bin/hdfcoinc/pycbc_multiifo_add_statmap
@@ -425,6 +425,8 @@ while any_above_ifar_lim:
         logging.info('{}: {:.3g}'.format(k, max_ifars[k]))
     maxcombo = max(max_ifars, key=lambda key: max_ifars[key])
     max_ifar_idx = max_each_combo[maxcombo]
+    trigger_ids = {ifo: sep_fg_data[maxcombo].data['%s/trigger_id' % ifo][max_ifar_idx] for
+                          ifo in all_ifos if ifo in maxcombo}
     max_ifar = sep_fg_data[maxcombo].data['ifar'][:][max_ifar_idx]
     if not max_ifar > args.hierarchical_removal_ifar_limit:
         logging.info("Loudest Event IFAR of %.3f in %s is less than minimum of %f"
@@ -432,7 +434,8 @@ while any_above_ifar_lim:
         any_above_ifar_lim = False
         break
     #Add the highest ifar (yet to be removed) to the final output
-    final_fg_data[maxcombo] = final_fg_data[maxcombo].__add__(sep_fg_data[maxcombo].select([max_ifar_idx]))
+    final_fg_data[maxcombo] = final_fg_data[maxcombo].__add__(
+                                  sep_fg_data[maxcombo].select([max_ifar_idx]))
 
     maxtime = pycbc.events.mean_if_greater_than_zero(
         [sep_fg_data[maxcombo].data['%s/time' % ifo][:][max_ifar_idx] for 
@@ -448,28 +451,22 @@ while any_above_ifar_lim:
     n_triggers -= 1
     logging.info('Removing background triggers at time {} within window '
                  '{}s'.format(maxtime,args.hierarchical_removal_window))
-    trigger_time = np.array([sep_fg_data[maxcombo].data['%s/time' % ifo][max_ifar_idx] for
-                          ifo in all_ifos if ifo in maxcombo]).mean()
-    start = [trigger_time - args.hierarchical_removal_window]
-    end = [trigger_time + args.hierarchical_removal_window]
-    trigger_ids = {ifo: sep_fg_data[maxcombo].data['%s/trigger_id' % ifo][max_ifar_idx] for
-                          ifo in all_ifos if ifo in maxcombo}
     
     for combo in all_ifo_combos:
         all_hred_idx = []
         for ifo in all_ifos:
             if ifo in combo:
-                hred_ids = veto.indices_within_times(
-                              sep_bg_data[combo].data['%s/time' % ifo][:],
-                              start, end)
                 times = sep_bg_data[combo].data['%s/time' % ifo]
+                hred_ids = np.nonzero(abs(times - maxtime) < args.hierarchical_removal_window)[0]
             all_hred_idx += list(hred_ids)
+        logging.info('Removing {} background triggers from {}'.format(len(all_hred_idx), combo))
         sep_bg_data[combo] = sep_bg_data[combo].remove(all_hred_idx)
 
-    hred_ids = veto.indices_within_times(
-                              combined_bg_data.data['%s/time' % ifo][:],
-                              start, end)
+    hred_ids = []
+    for ifo in all_ifos:
+        hred_ids += list(np.nonzero(abs(combined_bg_data.data['%s/time' % ifo][:] - maxtime) < args.hierarchical_removal_window)[0])
     combined_bg_data = combined_bg_data.remove(hred_ids)
+    logging.info('Removing {} background triggers from combined background'.format(len(hred_ids)))
     logging.info("Recalculating individual combination IFARs")
 
     times_tuple = tuple(combined_fg_data.data[ifo + '/time'][:] for ifo in all_ifos)

--- a/bin/hdfcoinc/pycbc_multiifo_add_statmap
+++ b/bin/hdfcoinc/pycbc_multiifo_add_statmap
@@ -6,9 +6,9 @@ coincs with the highest stat value.
 import h5py, numpy as np, argparse, logging, pycbc, pycbc.events, pycbc.io
 import pycbc.version
 import pycbc.conversions as conv
-from pycbc.events import coinc
+from pycbc.events import veto, coinc
 from ligo import segments
-import sys
+import sys, copy
 
 def get_ifo_string(fi):
     # Returns a string of a space-separated list of ifos from input file.
@@ -51,9 +51,9 @@ parser.add_argument('--max-hierarchical-removal', type=int, default=0,
          'hierarchical removals.  Choose 1 to do at most 1 hierarchical '
          'removal, and so on. [default=None]')
 parser.add_argument('--hierarchical-removal-ifar-limit', type=float,
-                    default=1./365.25,
+                    default=100,
      help='Minimum IFAR for a foreground event to be removed from '
-          'background (years) [default=1/365.25]')
+          'background (years) [default=100]')
 parser.add_argument('--output-file', help="name of output file")
 parser.add_argument('--background-files', nargs='+', default=None,
     help="full data coinc_statmap files for use in background"
@@ -203,7 +203,6 @@ for key in f['foreground'].keys():
     else:  # key is an ifo
         for k in f['foreground/%s' % key].keys():
             filter_dataset(f, 'foreground/{}/{}'.format(key, k), cidx)
-del cidx
 
 n_triggers = f['foreground/ifar'].size
 logging.info('{} foreground events after clustering'.format(n_triggers))
@@ -318,39 +317,51 @@ if not args.max_hierarchical_removal:
     exit()
 
 logging.info('Performing hierarchical removal')
-all_bg_data = {}
-all_fg_data = {}
+sep_bg_data = {}
+sep_fg_data = {}
+final_fg_data = {}
 grps = ['decimation_factor', 'stat', 'template_id', 'timeslide_id', 'ifar']
 
 for ifo in all_ifos:
     grps += ['%s/time' % ifo]
     grps += ['%s/trigger_id' % ifo]
 
+combined_bg_data = pycbc.io.DictArray(data={g: f['background/%s' % g][:] for g in grps})
+combined_fg_data = pycbc.io.DictArray(data={g: f['foreground/%s' % g][:] for g in grps})
+#Get 
+fg_coinc_type = np.array([])
+bg_coinc_type = np.array([])
 for f_in in files:
-    combo = get_ifo_string(f_in).replace(' ','')
-    bg_data = {g: f_in['background/%s' % g][:] for g in grps if g in f_in['background']}
-    all_bg_data[combo] = pycbc.io.DictArray(data=bg_data)
-    fg_data = {g: f_in['foreground/%s' % g][:] for g in grps if g in f_in['foreground']}
-    all_fg_data[combo] = pycbc.io.DictArray(data=fg_data)
-    # Clustering fg events for each combination
-    n_triggers = f_in['foreground/ifar'].size
-    fg_times = (f_in['foreground/%s/time' % ifo][:] for ifo in all_ifos if ifo in combo)
-    cidx = pycbc.events.cluster_coincs_multiifo(all_fg_data[combo].data['stat'][:], fg_times,
-                                                np.zeros(n_triggers), 0,
-                                                args.cluster_window)
-    # Selecting clustered events in individual coincidences
-    all_fg_data[combo] = all_fg_data[combo].select(cidx)
+    key = get_ifo_string(f_in).replace(' ','')
+    combo_repeat = np.array(np.repeat(key.encode('utf8'),
+                            f_in['foreground/fap'].size))
+    fg_coinc_type = np.concatenate([fg_coinc_type, combo_repeat])
+    combo_repeat = np.array(np.repeat(key.encode('utf8'),
+                            f_in['background/stat'].size))
+    bg_coinc_type = np.concatenate([bg_coinc_type, combo_repeat])
+# Apply previously used clustering
+fg_coinc_type = fg_coinc_type[cidx]
 
+# Get DictArrays of the foreground and background data post-cluster
+for combo in all_ifo_combos:
+    idx_fg_ct = np.nonzero(fg_coinc_type == combo)
+    sep_fg_data[combo] = combined_fg_data.select(idx_fg_ct)
+    idx_bg_ct = np.nonzero(bg_coinc_type == combo)
+    sep_bg_data[combo] = combined_bg_data.select(idx_bg_ct)
+    final_fg_data[combo] = pycbc.io.DictArray(data={k:[] for k in sep_fg_data[combo].data})
+
+final_combined_fg = copy.deepcopy(combined_fg_data)
 #counter to count number of removals
 h_iterations = 0
-combined_fg_trig_times = {}
-combined_fg_trig_ids = {}
-combined_bg_trig_times = {}
-combined_bg_trig_ids = {}
+
 # flag to say if there are any higher statistic values in background
-any_zero = True
+any_above_ifar_lim = True
 ifos_in_combo = {}
-while any_zero:
+bg_time = {f_in.attrs['ifos'].replace(' ',''): f_in.attrs['background_time'] for f_in in files}
+fg_time = {f_in.attrs['ifos'].replace(' ',''): f_in.attrs['foreground_time'] for f_in in files}
+in_combo_time_dictarray = pycbc.io.DictArray(data=is_in_combo_time)
+#In order to separate the 
+while any_above_ifar_lim:
     if (h_iterations == args.max_hierarchical_removal):
         logging.info("Reached hierarchical removal limit of %d" %
                      args.max_hierarchical_removal)
@@ -358,20 +369,26 @@ while any_zero:
     logging.info("Hierarchical iteration %d" % h_iterations)
     bg_grps = {}
     if h_iterations == 0:
-        for combo in all_bg_data:
+        for combo in all_ifo_combos:
             bg_grps[combo] = ['ifar', 'stat', 'timeslide_id']
-            for key in all_fg_data[combo].data:
+            for key in sep_fg_data[combo].data:
                 full_fg_key = 'foreground_h0/%s/%s' % (combo, key)
-                f[full_fg_key] = all_fg_data[combo].data[key][:]
+                f[full_fg_key] = sep_fg_data[combo].data[key][:]
             for key in bg_grps[combo]:
                 f['background_h0/%s/%s' % (combo, key)] = \
-                    all_bg_data[combo].data[key][:]
+                    sep_bg_data[combo].data[key][:]
+        for key in ['stat', 'timeslide_id']:
+            f['background_h0/%s' % (key)] = \
+                combined_bg_data.data[key][:]
+        for key in combined_fg_data.data:
+            f['foreground_h0/%s' % (key)] = \
+                combined_fg_data.data[key][:]
 
     else:
-        for combo in all_bg_data:
+        for combo in all_ifo_combos:
             bg_grps[combo] = ['ifar', 'stat', 'timeslide_id',
                               'decimation_factor', 'template_id']
-            for key in all_fg_data[combo].data:
+            for key in sep_fg_data[combo].data:
                 if key.split('/')[0] in all_ifos:
                     bg_grps[combo] += [key]
                 full_fg_key = 'foreground_h%d/%s/%s' % (h_iterations, combo,
@@ -379,73 +396,116 @@ while any_zero:
                 comp_fg_key = 'foreground_h%d/%s/%s' % (h_iterations - 1,
                                                         combo, key)
                 if comp_fg_key in f \
-                    and all_fg_data[combo].data[key].size == f[comp_fg_key].size \
-                    and all(all_fg_data[combo].data[key][:] == f[comp_fg_key][:]):
+                    and sep_fg_data[combo].data[key].size == f[comp_fg_key].size \
+                    and all(sep_fg_data[combo].data[key][:] == f[comp_fg_key][:]):
                     # if the group has not changed create a hard link
                     f[full_fg_key] = f[comp_fg_key]
                 else:
-                    f[full_fg_key] = all_fg_data[combo].data[key][:]
+                    f[full_fg_key] = sep_fg_data[combo].data[key][:]
             for key in bg_grps[combo]:
                 # The background will (almost certainly) be affected, so copy as normal
                 f['background_h%s/%s/%s' % (h_iterations, combo, key)] = \
-                    all_bg_data[combo].data[key][:]
+                    sep_bg_data[combo].data[key][:]
+            f.attrs['foreground_time_h%s' % h_iterations] = fg_time[combo]
+            f.attrs['background_time_h%s' % h_iterations] = bg_time[combo]
+        for key in combined_bg_data.data:
+            f['background_h%s/%s' % (h_iterations, key)] = \
+                    combined_bg_data.data[key][:]
+        for key in combined_fg_data.data:
+            f['foreground_h%s/%s' % (h_iterations, key)] = \
+                    combined_fg_data.data[key][:]
 
     h_iterations += 1
 
-    max_each_combo = {combo: all_fg_data[combo].data['ifar'][:].argmax()
+    max_each_combo = {combo: sep_fg_data[combo].data['ifar'][:].argmax()
                       for combo in all_ifo_combos}
-    maxcombo = max({combo: all_fg_data[combo].data['ifar'][:][max_each_combo[combo]]
-                    for combo in all_ifo_combos})
+    max_ifars = {combo: sep_fg_data[combo].data['ifar'][:][max_each_combo[combo]]
+                    for combo in all_ifo_combos}
+    logging.info('Maximum IFAR values per combination:')
+    for k in max_ifars:
+        logging.info('{}: {:.3g}'.format(k, max_ifars[k]))
+    maxcombo = max(max_ifars, key=lambda key: max_ifars[key])
     max_ifar_idx = max_each_combo[maxcombo]
-    max_ifar = all_fg_data[maxcombo].data['ifar'][:][max_ifar_idx]
+    max_ifar = sep_fg_data[maxcombo].data['ifar'][:][max_ifar_idx]
     if not max_ifar > args.hierarchical_removal_ifar_limit:
-        logging.info("Loudest Event IFAR of %.4f is less than minimum of %.4f"
-                     % (max_ifar, args.hierarchical_removal_ifar_limit))
+        logging.info("Loudest Event IFAR of %.3f in %s is less than minimum of %f"
+                     % (max_ifar, maxcombo, args.hierarchical_removal_ifar_limit))
+        any_above_ifar_lim = False
         break
+    #Add the highest ifar (yet to be removed) to the final output
+    final_fg_data[maxcombo].__add__(sep_fg_data[maxcombo].select([max_ifar_idx]))
+
     maxtime = pycbc.events.mean_if_greater_than_zero(
-        [all_fg_data[maxcombo].data['%s/time' % ifo][:][max_ifar_idx] for 
+        [sep_fg_data[maxcombo].data['%s/time' % ifo][:][max_ifar_idx] for 
          ifo in all_ifos if ifo in combo])[0]
-    logging.info('Removing triggers from {} foreground at time {} with '
-                 'ifar {}'.format(maxcombo, maxtime, max_ifar))
-    all_fg_data[maxcombo] = all_fg_data[maxcombo].remove(max_ifar_idx)
+    logging.info('Removing trigger from {} foreground at time {:.2f} with '
+                 'ifar {:.3g}'.format(maxcombo, maxtime, max_ifar))
+    sep_fg_data[maxcombo] = sep_fg_data[maxcombo].remove(max_ifar_idx)
+    logging.info('Removing trigger from combined foreground')
+    where_combined = np.nonzero(combined_fg_data.data['stat'] == 
+                                sep_fg_data[maxcombo].data['stat'][:][max_ifar_idx])
+    combined_fg_data = combined_fg_data.remove(where_combined)
+    n_triggers -= 1
     logging.info('Removing background triggers at time {} within window '
                  '{}s'.format(maxtime,args.hierarchical_removal_window))
-    for combo in all_bg_data:
-        f['background'
-    #trigger_ids_to_rm
-    logging.info("Combining backgrounds and recalculating IFARs")
-    for ifo in all_ifos:
-        combined_fg_trig_times[ifo] = np.array([], dtype=np.uint32)
-        combined_fg_trig_ids[ifo] = np.array([], dtype=np.uint32)
-        combined_bg_trig_times[ifo] = np.array([], dtype=np.uint32)
-        combined_bg_trig_ids[ifo] = np.array([], dtype=np.uint32)
+    trigger_time = np.array([sep_fg_data[maxcombo].data['%s/time' % ifo][max_ifar_idx] for
+                          ifo in all_ifos if ifo in maxcombo]).mean()
+    start = [trigger_time - args.hierarchical_removal_window]
+    end = [trigger_time + args.hierarchical_removal_window]
+    trigger_ids = {ifo: sep_fg_data[maxcombo].data['%s/trigger_id' % ifo][max_ifar_idx] for
+                          ifo in all_ifos if ifo in maxcombo}
+    
     for combo in all_ifo_combos:
+        all_hred_idx = []
         for ifo in all_ifos:
             if ifo in combo:
-                combined_fg_trig_times[ifo] = np.concatenate([combined_fg_trig_times[ifo],
-                                  all_fg_data[combo].data['%s/time' % ifo]])
-                combined_fg_trig_ids[ifo] = np.concatenate([combined_fg_trig_ids[ifo],
-                                  all_fg_data[combo].data['%s/trigger_id' % ifo]])
-                combined_bg_trig_times[ifo] = np.concatenate([combined_bg_trig_times[ifo],
-                                  all_bg_data[combo].data['%s/time' % ifo]])
-                combined_bg_trig_ids[ifo] = np.concatenate([combined_bg_trig_ids[ifo],
-                                  all_bg_data[combo].data['%s/trigger_id' % ifo]])
-            else:
-                combined_fg_trig_times[ifo] = np.concatenate([combined_fg_trig_times[ifo],
-                                     -1 * np.ones_like(all_fg_data[combo].data['stat'],
-                                                       dtype=np.uint32)])
-                combined_fg_trig_ids[ifo] = np.concatenate([combined_fg_trig_ids[ifo],
-                                     -1 * np.ones_like(all_fg_data[combo].data['stat'],
-                                                       dtype=np.uint32)])
-                combined_bg_trig_times[ifo] = np.concatenate([combined_bg_trig_times[ifo],
-                                     -1 * np.ones_like(all_bg_data[combo].data['stat'],
-                                                       dtype=np.uint32)])
-                combined_bg_trig_ids[ifo] = np.concatenate([combined_bg_trig_ids[ifo],
-                                     -1 * np.ones_like(all_bg_data[combo].data['stat'],
-                                                       dtype=np.uint32)])
-    #combine and copy other datasets
+                hred_ids = veto.indices_within_times(
+                              sep_bg_data[combo].data['%s/time' % ifo][:],
+                              start, end)
+                times = sep_bg_data[combo].data['%s/time' % ifo]
+            all_hred_idx += list(hred_ids)
+        sep_bg_data[combo] = sep_bg_data[combo].remove(all_hred_idx)
+
+    hred_ids = veto.indices_within_times(
+                              combined_bg_data.data['%s/time' % ifo][:],
+                              start, end)
+    combined_bg_data = combined_bg_data.remove(hred_ids)
+    logging.info("Recalculating individual combination IFARs")
+
+    times_tuple = tuple(combined_fg_data.data[ifo + '/time'][:] for ifo in all_ifos)
+    test_times = np.array([pycbc.events.mean_if_greater_than_zero(tc)[0]
+                           for tc in zip(*times_tuple)])
+    for key in all_ifo_combos:
+        bnlouder, fnlouder = coinc.calculate_n_louder(sep_bg_data[key].data['stat'],
+                                    sep_fg_data[key].data['stat'],
+                                    sep_bg_data[key].data['decimation_factor'])
+        # In principle bg and fg time should be recalculated, but we expect
+        # this to be a very small correction and as such ignore
+        sep_bg_data[key].data['ifar'] = conv.sec_to_year(bg_time[key] / (bnlouder + 1))
+        sep_fg_data[key].data['ifar'] = conv.sec_to_year(bg_time[key] / (fnlouder + 1))
+    logging.info("Recalculating combined IFARs")
+    for key in all_ifo_combos:
+        bnlouder, fnlouder = coinc.calculate_n_louder(sep_bg_data[key].data['stat'],
+                                    combined_fg_data.data['stat'],
+                                    sep_bg_data[key].data['decimation_factor'])
+        far[key] = (fnlouder + 1) / bg_time[key]
+        # Set up variable for whether each coincidence is available in each coincidence time
+        is_in_combo_time[key] = np.zeros(n_triggers)
+        end_times = np.array(f['segments/%s/end' % key][:])
+        start_times = np.array(f['segments/%s/start' % key][:])
+        idx_within_segment = pycbc.events.indices_within_times(test_times,
+                                                               start_times,
+                                                               end_times)
+        is_in_combo_time[key][idx_within_segment] = np.ones_like(idx_within_segment)
+        
+    isincombo_mask = np.array([list(is_in_combo_time[ct]) for ct in all_ifo_combos])
+    fg_fars = np.array([list(far[ct]) for ct in all_ifo_combos])
+
+    # Combine the FARs with the mask to obtain the new ifars
+    fg_ifar = conv.sec_to_year(1. /np.sum(isincombo_mask*fg_fars, axis=0))
+    combined_fg_data.data['ifar'] = fg_ifar
+	#combine and copy other datasets
 
 f.attrs['hierarchical_removal_iterations'] = h_iterations
-
 f.close()
 logging.info('Done!')

--- a/bin/hdfcoinc/pycbc_multiifo_add_statmap
+++ b/bin/hdfcoinc/pycbc_multiifo_add_statmap
@@ -328,7 +328,7 @@ for ifo in all_ifos:
 
 combined_bg_data = pycbc.io.DictArray(data={g: f['background/%s' % g][:] for g in grps})
 combined_fg_data = pycbc.io.DictArray(data={g: f['foreground/%s' % g][:] for g in grps})
-#Get 
+#Get coincidence type for all coincidences
 fg_coinc_type = np.array([])
 bg_coinc_type = np.array([])
 for f_in in files:
@@ -359,8 +359,7 @@ any_above_ifar_lim = True
 ifos_in_combo = {}
 bg_time = {f_in.attrs['ifos'].replace(' ',''): f_in.attrs['background_time'] for f_in in files}
 fg_time = {f_in.attrs['ifos'].replace(' ',''): f_in.attrs['foreground_time'] for f_in in files}
-in_combo_time_dictarray = pycbc.io.DictArray(data=is_in_combo_time)
-#In order to separate the 
+
 while any_above_ifar_lim:
     if (h_iterations == args.max_hierarchical_removal):
         logging.info("Reached hierarchical removal limit of %d" %
@@ -433,7 +432,7 @@ while any_above_ifar_lim:
         any_above_ifar_lim = False
         break
     #Add the highest ifar (yet to be removed) to the final output
-    final_fg_data[maxcombo].__add__(sep_fg_data[maxcombo].select([max_ifar_idx]))
+    final_fg_data[maxcombo] = final_fg_data[maxcombo].__add__(sep_fg_data[maxcombo].select([max_ifar_idx]))
 
     maxtime = pycbc.events.mean_if_greater_than_zero(
         [sep_fg_data[maxcombo].data['%s/time' % ifo][:][max_ifar_idx] for 
@@ -444,6 +443,7 @@ while any_above_ifar_lim:
     logging.info('Removing trigger from combined foreground')
     where_combined = np.nonzero(combined_fg_data.data['stat'] == 
                                 sep_fg_data[maxcombo].data['stat'][:][max_ifar_idx])
+    final_combined_fg = final_combined_fg.__add__(combined_fg_data.select(where_combined))
     combined_fg_data = combined_fg_data.remove(where_combined)
     n_triggers -= 1
     logging.info('Removing background triggers at time {} within window '
@@ -502,10 +502,27 @@ while any_above_ifar_lim:
     fg_fars = np.array([list(far[ct]) for ct in all_ifo_combos])
 
     # Combine the FARs with the mask to obtain the new ifars
-    fg_ifar = conv.sec_to_year(1. /np.sum(isincombo_mask*fg_fars, axis=0))
-    combined_fg_data.data['ifar'] = fg_ifar
-	#combine and copy other datasets
+    combined_fg_data.data['ifar'] = conv.sec_to_year(1. /np.sum(isincombo_mask*fg_fars, axis=0))
 
+
+for combo in all_ifo_combos:
+    final_fg_data[combo] = final_fg_data[combo].__add__(sep_bg_data[combo])
+    for key in final_fg_data[combo].data:
+        full_key = 'foreground/%s/%s' % (combo, key)
+        if full_key in f:
+            del f[full_key]
+        f[full_key] = final_fg_data[combo].data[key]
+
+final_combined_fg = final_combined_fg.__add__(combined_fg_data)
+for key in final_combined_fg.data:
+    full_key = 'foreground/%s' % ( key)
+    if full_key in f:
+        del f[full_key]
+    f[full_key] = final_combined_fg.data[key]
+
+for key in f:
+    if 'background' in key and (key + '/ifar') in f:
+        del f[key + '/ifar']
 f.attrs['hierarchical_removal_iterations'] = h_iterations
 f.close()
 logging.info('Done!')

--- a/bin/hdfcoinc/pycbc_multiifo_add_statmap
+++ b/bin/hdfcoinc/pycbc_multiifo_add_statmap
@@ -40,11 +40,37 @@ parser.add_argument('--cluster-window', type=float,
 parser.add_argument('--output-coinc-types', action='store_true',
     help="Create additional foreground dataset recording coinc type for each"
          " event. Mainly for debugging")
+parser.add_argument('--hierarchical-removal-window', type=float, default=1.0,
+    help='Time around each trigger to window out for a very louder trigger '
+         'in the hierarchical removal procedure. [default=1.0s]')
+parser.add_argument('--max-hierarchical-removal', type=int, default=0,
+    required='--hierarchical-removal-against' in sys.argv,
+    help='Maximum amount of hierarchical removals to carry out when '
+         'hierarchical removal is desired. Choose -1 for continuous '
+         'hiearchical removal until no foreground triggers are louder '
+         'than the (inclusive/exclusive) background. Choose 0 or to do no '
+         'hierarchical removals.  Choose 1 to do at most 1 hierarchical '
+         'removal, and so on. If given, user must also give option '
+         '--hierarchical-removal-against to indicate which background to '
+         'remove triggers against. [default=None]')
+parser.add_argument('--hierarchical-removal-against', type=str, default=None,
+    required='--max-hierarchical-removal' in sys.argv,
+    choices=['inclusive', 'exclusive']
+    help='Make a choice to hierarchically remove foreground '
+         'triggers based on whether it is louder than the '
+         'inclusive (little-dogs-in) background or the '
+         'exclusive (little-dogs-out) background. Choose by '
+         'entering <inclusive> or <exclusive>. [default=None]')
 parser.add_argument('--output-file', help="name of output file")
 parser.add_argument('--background-files', nargs='+', default=None,
     help="full data coinc_statmap files for use in background"
          "calculation when used for injections")
+
 args = parser.parse_args()
+
+if args.max_hierarchical_removal and args.background_files:
+    raise NotImplementedError("Hierarchical background removal doesn't make "
+                              "sense for injections.")
 
 pycbc.init_logging(args.verbose)
 
@@ -109,41 +135,63 @@ if args.output_coinc_types:
 logging.info('Collating triggers into single structure')
 
 # Initialise arrays for filling with time and trigger ids
-all_trig_times = {}
-all_trig_ids = {}
+fg_trig_times = {}
+fg_trig_ids = {}
+bg_trig_times = {}
+bg_trig_ids = {}
+
 for ifo in all_ifos:
-    all_trig_times[ifo] = np.array([], dtype=np.uint32)
-    all_trig_ids[ifo] = np.array([], dtype=np.uint32)
+    fg_trig_times[ifo] = np.array([], dtype=np.uint32)
+    fg_trig_ids[ifo] = np.array([], dtype=np.uint32)
+    bg_trig_times[ifo] = np.array([], dtype=np.uint32)
+    bg_trig_ids[ifo] = np.array([], dtype=np.uint32)
 
 # For each file, append the trigger time and id data for each ifo
 # If an ifo does not participate in any given coinc then fill with -1 values
+combo_start_len = {}
+fg_cs = 0
 for f_in in files:
+    key = get_ifo_string(f_in).replace(' ','')
+    combo_start_len[key] = (cs, f_in['foreground/fap'].size)
+    cs += f_in['foreground/fap'].size
     for ifo in all_ifos:
         if ifo in f_in['foreground']:
-            all_trig_times[ifo] = np.concatenate([all_trig_times[ifo],
+            fg_trig_times[ifo] = np.concatenate([fg_trig_times[ifo],
                                     f_in['foreground/{}/time'.format(ifo)][:]])
-            all_trig_ids[ifo] = np.concatenate([all_trig_ids[ifo],
+            fg_trig_ids[ifo] = np.concatenate([fg_trig_ids[ifo],
                               f_in['foreground/{}/trigger_id'.format(ifo)][:]])
-        else:
-            all_trig_times[ifo] = np.concatenate([all_trig_times[ifo],
-                                 -1 * np.ones_like(f_in['foreground/fap'][:],
-                                                   dtype=np.uint32)])
-            all_trig_ids[ifo] = np.concatenate([all_trig_ids[ifo],
-                                 -1 * np.ones_like(f_in['foreground/fap'][:],
-                                                   dtype=np.uint32)])
+            bg_trig_times[ifo] = np.concatenate([bg_trig_times[ifo],
+                                    f_in['background/{}/time'.format(ifo)][:]])
+            bg_trig_ids[ifo] = np.concatenate([bg_trig_ids[ifo],
+                              f_in['background/{}/trigger_id'.format(ifo)][:]])
 
+        else:
+            fg_trig_times[ifo] = np.concatenate([fg_trig_times[ifo],
+                                 -1 * np.ones_like(f_in['foreground/fap'][:],
+                                                   dtype=np.uint32)])
+            fg_trig_ids[ifo] = np.concatenate([fg_trig_ids[ifo],
+                                 -1 * np.ones_like(f_in['foreground/fap'][:],
+                                                   dtype=np.uint32)])
+            bg_trig_times[ifo] = np.concatenate([bg_trig_times[ifo],
+                                 -1 * np.ones_like(f_in['background/stat'][:],
+                                                   dtype=np.uint32)])
+            bg_trig_ids[ifo] = np.concatenate([bg_trig_ids[ifo],
+                                 -1 * np.ones_like(f_in['background/stat'][:],
+                                                   dtype=np.uint32)])
 n_triggers = f['foreground/ifar'].size
 logging.info('{} foreground events before clustering'.format(n_triggers))
 
 for ifo in all_ifos:
-    f['foreground/{}/time'.format(ifo)] = all_trig_times[ifo]
-    f['foreground/{}/trigger_id'.format(ifo)] = all_trig_ids[ifo]
-# all_times is a tuple of trigger time arrays
-all_times = (f['foreground/%s/time' % ifo][:] for ifo in all_ifos)
+    f['foreground/{}/time'.format(ifo)] = fg_trig_times[ifo]
+    f['foreground/{}/trigger_id'.format(ifo)] = fg_trig_ids[ifo]
+    f['background/{}/time'.format(ifo)] = bg_trig_times[ifo]
+    f['background/{}/trigger_id'.format(ifo)] = bg_trig_ids[ifo]
+# fg_times is a tuple of trigger time arrays
+fg_times = (f['foreground/%s/time' % ifo][:] for ifo in all_ifos)
 
 # Cluster by statistic value. Currently only clustering zerolag,
 # i.e. foreground, so set all timeslide_ids to zero
-cidx = pycbc.events.cluster_coincs_multiifo(f['foreground/stat'][:], all_times,
+cidx = pycbc.events.cluster_coincs_multiifo(f['foreground/stat'][:], fg_times,
                                             np.zeros(n_triggers), 0,
                                             args.cluster_window)
 
@@ -187,6 +235,8 @@ logging.info('Calculating FAR over all coinc types for foreground events')
 
 far = {}
 far_exc = {}
+fnlouder = {}
+fnlouder_exc = {}
 injection_style = args.background_files != None
 if injection_style:
     # if background files are provided, this is being used for injections
@@ -194,27 +244,31 @@ if injection_style:
     for bg_fname in args.background_files:
         bg_f = h5py.File(bg_fname, 'r')
         ifo_combo_key = bg_f.attrs['ifos'].replace(' ','')
-        _, fnlouder = coinc.calculate_n_louder(bg_f['background/stat'][:],
-                                               f['foreground/stat'][:],
-                                               bg_f['background/decimation_factor'][:])
-        far[ifo_combo_key] = (fnlouder + 1) / bg_f.attrs['background_time']
-        _, fnlouder_exc = coinc.calculate_n_louder(bg_f['background_exc/stat'][:],
-                                                   f['foreground/stat'][:],
-                                                   bg_f['background_exc/decimation_factor'][:])
-        far_exc[ifo_combo_key] = (fnlouder_exc + 1) / bg_f.attrs['background_time_exc']
+        _, fnlouder[ifo_combo_key] = \
+            coinc.calculate_n_louder(bg_f['background/stat'][:],
+                                     f['foreground/stat'][:],
+                                     bg_f['background/decimation_factor'][:])
+        far[ifo_combo_key] = (fnlouder[ifo_combo_key] + 1) / bg_f.attrs['background_time']
+        _, fnlouder_exc[ifo_combo_key] = \
+            coinc.calculate_n_louder(bg_f['background_exc/stat'][:],
+                                     f['foreground/stat'][:],
+                                     bg_f['background_exc/decimation_factor'][:])
+        far_exc[ifo_combo_key] = (fnlouder_exc[ifo_combo_key] + 1) / bg_f.attrs['background_time_exc']
 else:
     # if not injection style input files, then the input files will have the
     # background included
     for f_in in files:
         ifo_combo_key = get_ifo_string(f_in).replace(' ','')
-        _, fnlouder = coinc.calculate_n_louder(f_in['background/stat'][:],
-                                               f['foreground/stat'][:],
-                                               f_in['background/decimation_factor'][:])
+        _, fnlouder[ifo_combo_key] = \
+            coinc.calculate_n_louder(f_in['background/stat'][:],
+                                     f['foreground/stat'][:],
+                                     f_in['background/decimation_factor'][:])
         far[ifo_combo_key] = (fnlouder + 1) / f_in.attrs['background_time']
-        _, fnlouder_exc = coinc.calculate_n_louder(f_in['background_exc/stat'][:],
-                                                   f['foreground/stat'][:],
-                                                   f_in['background_exc/decimation_factor'][:])
-        far_exc[ifo_combo_key] = (fnlouder_exc + 1) / f_in.attrs['background_time_exc']
+        _, fnlouder_exc[ifo_combo_key] = \
+            coinc.calculate_n_louder(f_in['background_exc/stat'][:],
+                                     f['foreground/stat'][:],
+                                     f_in['background_exc/decimation_factor'][:])
+        far_exc[ifo_combo_key] = (fnlouder_exc[ifo_combo_key] + 1) / f_in.attrs['background_time_exc']
 
 logging.info('Combining false alarm rates from all available backgrounds')
 
@@ -226,12 +280,13 @@ logging.info('Combining false alarm rates from all available backgrounds')
 isincombo_mask = np.array([list(is_in_combo_time[ct]) for ct in all_ifo_combos])
 
 # Create n_combos by n_triggers arrays of FARs
-all_fars = np.array([list(far[ct]) for ct in all_ifo_combos])
-all_fars_exc = np.array([list(far_exc[ct]) for ct in all_ifo_combos])
+fg_fars = np.array([list(far[ct]) for ct in all_ifo_combos])
+fg_fars_exc = np.array([list(far_exc[ct]) for ct in all_ifo_combos])
 
 # Combine the FARs with the mask to obtain the new ifars
-fg_ifar = conv.sec_to_year(1. /np.sum(isincombo_mask*all_fars, axis=0))
-fg_ifar_exc = conv.sec_to_year(1. /np.sum(isincombo_mask*all_fars_exc, axis=0))
+fg_ifar = conv.sec_to_year(1. /np.sum(isincombo_mask*fg_fars, axis=0))
+fg_ifar_exc = conv.sec_to_year(1. /np.sum(isincombo_mask*fg_fars_exc, axis=0))
+fg_time = conv.sec_to_year(f.attrs['foreground_time'])
 
 f.attrs['foreground_time_exc'] = f.attrs['foreground_time']
 if not injection_style:
@@ -248,7 +303,6 @@ if not injection_style:
     f['segments/foreground_veto/end'] = vend
     # Only output non-exclusive ifar/fap if it is _not_ an injection case
     f['foreground/ifar'][:] = fg_ifar
-    fg_time = conv.sec_to_year(f.attrs['foreground_time'])
     f['foreground/fap'] = 1 - np.exp(-fg_time / fg_ifar)
 else:
     del f['foreground/ifar']
@@ -256,6 +310,50 @@ else:
 f['foreground/ifar_exc'][:] = fg_ifar_exc
 fg_time_exc = conv.sec_to_year(f.attrs['foreground_time_exc'])
 f['foreground/fap_exc'] = 1 - np.exp(-fg_time_exc / fg_ifar_exc)
+
+# Hierarchical removal stage
+if not args.max_hierarchical_removal:
+    f.close()
+    logging.info('Not performing hierarchical removal. Done!')
+    exit()
+
+logging.info('Performing hierarchical removal')
+all_bg_data = {}
+all_fg_data = {}
+grps = ['decimation_factor', 'stat', 'template_id', 'timeslide_id', 'ifar']
+
+# set up dictionary to check if there are no fg triggers louder than
+# background in each detector combination
+no_louder_fg = {k: 0 for k in all_ifo_combos}
+for ifo in all_ifos:
+    grps += ['%s/time' % ifo]
+    grps += ['%s/trigger_id' % ifo]
+bg_data = {g: f['background/%s' % g] for g in grps}
+all_bg_data = DictArray(data=bg_data)
+fg_data = {g: f['foreground/%s' % g] for g in grps}
+all_fg_data = DictArray(data=fg_data)
+
+h_iterations = 0
+while numpy.any(louder_foreground == 0):
+    if (h_iterations == args.max_hierarchical_removal): 
+        break
+    if h_iterations == 0:
+        for combo in all_fg_data:
+            for key in all_bg_data[combo]:
+                f['background_h%s/%s' % (h_iterations, key)] = \
+                    all_bg_data[combo][key]
+            for key in all_fg_data[combo]:
+                f['foreground_h%d/%s' % (h_iterations, key)] = \
+                    all_fg_data[combo][key]
+    h_iterations += 1
+    max_stat_idx = all_fg_data['stat'].argmax()
+    rm_trig_idx = numpy.where(all_fg_data['stat'] == max_stat_idx)
+    orig_fore_idx = 
+    
+
+f.attrs['hierarchical_removal_iterations'] = h_iterations
+f.attrs['hierarchical_removal_method'] = \
+    numpy.string_(args.hierarchical_removal_against)
 
 f.close()
 logging.info('Done!')

--- a/bin/hdfcoinc/pycbc_multiifo_add_statmap
+++ b/bin/hdfcoinc/pycbc_multiifo_add_statmap
@@ -424,6 +424,9 @@ while any_above_ifar_lim:
     logging.info('Maximum IFAR values per combination:')
     for k in max_ifars:
         logging.info('{}: {:.3g}'.format(k, max_ifars[k]))
+    max_combd = combined_fg_data.data['ifar'].argmax()
+    max_combd_ifar = combined_fg_data.data['ifar'][max_combd]
+    logging.info('combined: {:.3g}'.format(max_combd_ifar))
     maxcombo = max(max_ifars, key=lambda key: max_ifars[key])
     max_ifar_idx = max_each_combo[maxcombo]
     trigger_ids = {ifo: sep_fg_data[maxcombo].data['%s/trigger_id' % ifo][max_ifar_idx] for
@@ -442,10 +445,10 @@ while any_above_ifar_lim:
          ifo in all_ifos if ifo in combo])[0]
     logging.info('Removing trigger from {} foreground at time {:.2f} with '
                  'ifar {:.3g}'.format(maxcombo, maxtime, max_ifar))
-    sep_fg_data[maxcombo] = sep_fg_data[maxcombo].remove(max_ifar_idx)
     logging.info('Removing trigger from combined foreground')
     where_combined = np.nonzero(combined_fg_data.data['stat'] == 
                                 sep_fg_data[maxcombo].data['stat'][:][max_ifar_idx])
+    sep_fg_data[maxcombo] = sep_fg_data[maxcombo].remove(max_ifar_idx)
     final_combined_fg = final_combined_fg + combined_fg_data.select(where_combined)
     combined_fg_data = combined_fg_data.remove(where_combined)
     n_triggers -= 1

--- a/bin/hdfcoinc/pycbc_multiifo_add_statmap
+++ b/bin/hdfcoinc/pycbc_multiifo_add_statmap
@@ -350,7 +350,8 @@ for combo in all_ifo_combos:
     sep_bg_data[combo] = combined_bg_data.select(idx_bg_ct)
     final_fg_data[combo] = pycbc.io.DictArray(data={k:[] for k in sep_fg_data[combo].data})
 
-final_combined_fg = copy.deepcopy(combined_fg_data)
+final_combined_fg = pycbc.io.DictArray(data={k:[] for k in combined_fg_data.data})
+
 #counter to count number of removals
 h_iterations = 0
 
@@ -434,8 +435,7 @@ while any_above_ifar_lim:
         any_above_ifar_lim = False
         break
     #Add the highest ifar (yet to be removed) to the final output
-    final_fg_data[maxcombo] = final_fg_data[maxcombo].__add__(
-                                  sep_fg_data[maxcombo].select([max_ifar_idx]))
+    final_fg_data[maxcombo] = final_fg_data[maxcombo] + sep_fg_data[maxcombo].select([max_ifar_idx])
 
     maxtime = pycbc.events.mean_if_greater_than_zero(
         [sep_fg_data[maxcombo].data['%s/time' % ifo][:][max_ifar_idx] for 
@@ -446,7 +446,7 @@ while any_above_ifar_lim:
     logging.info('Removing trigger from combined foreground')
     where_combined = np.nonzero(combined_fg_data.data['stat'] == 
                                 sep_fg_data[maxcombo].data['stat'][:][max_ifar_idx])
-    final_combined_fg = final_combined_fg.__add__(combined_fg_data.select(where_combined))
+    final_combined_fg = final_combined_fg + combined_fg_data.select(where_combined)
     combined_fg_data = combined_fg_data.remove(where_combined)
     n_triggers -= 1
     logging.info('Removing background triggers at time {} within window '
@@ -476,8 +476,7 @@ while any_above_ifar_lim:
         bnlouder, fnlouder = coinc.calculate_n_louder(sep_bg_data[key].data['stat'],
                                     sep_fg_data[key].data['stat'],
                                     sep_bg_data[key].data['decimation_factor'])
-        # In principle bg and fg time should be recalculated, but we expect
-        # this to be a very small correction and as such ignore
+        bg_time[key] -= 2.0 * args.hierarchical_removal_window
         sep_bg_data[key].data['ifar'] = conv.sec_to_year(bg_time[key] / (bnlouder + 1))
         sep_fg_data[key].data['ifar'] = conv.sec_to_year(bg_time[key] / (fnlouder + 1))
     logging.info("Recalculating combined IFARs")
@@ -503,14 +502,14 @@ while any_above_ifar_lim:
 
 
 for combo in all_ifo_combos:
-    final_fg_data[combo] = final_fg_data[combo].__add__(sep_bg_data[combo])
+    final_fg_data[combo] = final_fg_data[combo] + sep_fg_data[combo]
     for key in final_fg_data[combo].data:
         full_key = 'foreground/%s/%s' % (combo, key)
         if full_key in f:
             del f[full_key]
         f[full_key] = final_fg_data[combo].data[key]
 
-final_combined_fg = final_combined_fg.__add__(combined_fg_data)
+final_combined_fg = final_combined_fg + combined_fg_data
 for key in final_combined_fg.data:
     full_key = 'foreground/%s' % ( key)
     if full_key in f:

--- a/bin/hdfcoinc/pycbc_multiifo_add_statmap
+++ b/bin/hdfcoinc/pycbc_multiifo_add_statmap
@@ -3,22 +3,22 @@
 with more than one ifo combination available. Cluster to keep foreground
 coincs with the highest stat value.
 """
-
 import h5py, numpy as np, argparse, logging, pycbc, pycbc.events, pycbc.io
 import pycbc.version
 import pycbc.conversions as conv
 from pycbc.events import coinc
 from ligo import segments
+import sys
 
 def get_ifo_string(fi):
     # Returns a string of a space-separated list of ifos from input file.
-    # Can be deprecated soon, needed for older coinc_statmap files which 
+    # Can be deprecated soon, needed for older coinc_statmap files which
     # do not have 'ifos' attribute
     try:
         # input file has ifos stored as an attribute
         istring = fi.attrs['ifos']
     except KeyError:
-        # Foreground group contains the time information for each ifo so 
+        # Foreground group contains the time information for each ifo so
         # the ifos list can be reconstructed
         istring = ' '.join(sorted([k for k in fi['foreground'].keys()
                          if 'time' in fi['foreground/%s' % k]]))
@@ -44,23 +44,16 @@ parser.add_argument('--hierarchical-removal-window', type=float, default=1.0,
     help='Time around each trigger to window out for a very louder trigger '
          'in the hierarchical removal procedure. [default=1.0s]')
 parser.add_argument('--max-hierarchical-removal', type=int, default=0,
-    required='--hierarchical-removal-against' in sys.argv,
     help='Maximum amount of hierarchical removals to carry out when '
          'hierarchical removal is desired. Choose -1 for continuous '
          'hiearchical removal until no foreground triggers are louder '
          'than the (inclusive/exclusive) background. Choose 0 or to do no '
          'hierarchical removals.  Choose 1 to do at most 1 hierarchical '
-         'removal, and so on. If given, user must also give option '
-         '--hierarchical-removal-against to indicate which background to '
-         'remove triggers against. [default=None]')
-parser.add_argument('--hierarchical-removal-against', type=str, default=None,
-    required='--max-hierarchical-removal' in sys.argv,
-    choices=['inclusive', 'exclusive']
-    help='Make a choice to hierarchically remove foreground '
-         'triggers based on whether it is louder than the '
-         'inclusive (little-dogs-in) background or the '
-         'exclusive (little-dogs-out) background. Choose by '
-         'entering <inclusive> or <exclusive>. [default=None]')
+         'removal, and so on. [default=None]')
+parser.add_argument('--hierarchical-removal-ifar-limit', type=float,
+                    default=1./365.25,
+     help='Minimum IFAR for a foreground event to be removed from '
+          'background (years) [default=1/365.25]')
 parser.add_argument('--output-file', help="name of output file")
 parser.add_argument('--background-files', nargs='+', default=None,
     help="full data coinc_statmap files for use in background"
@@ -122,6 +115,12 @@ for k in files[0]['foreground']:
     if not k.startswith('fap') and k not in all_ifos:
         pycbc.io.combine_and_copy(f, files, 'foreground/' + k)
 
+logging.info('Copying background datasets')
+for k in files[0]['background']:
+    if k not in all_ifos:
+        pycbc.io.combine_and_copy(f, files, 'background/' + k)
+
+
 if args.output_coinc_types:
     # create dataset of ifo combination strings
     fg_coinc_type = np.array([])
@@ -148,12 +147,7 @@ for ifo in all_ifos:
 
 # For each file, append the trigger time and id data for each ifo
 # If an ifo does not participate in any given coinc then fill with -1 values
-combo_start_len = {}
-fg_cs = 0
 for f_in in files:
-    key = get_ifo_string(f_in).replace(' ','')
-    combo_start_len[key] = (cs, f_in['foreground/fap'].size)
-    cs += f_in['foreground/fap'].size
     for ifo in all_ifos:
         if ifo in f_in['foreground']:
             fg_trig_times[ifo] = np.concatenate([fg_trig_times[ifo],
@@ -209,6 +203,7 @@ for key in f['foreground'].keys():
     else:  # key is an ifo
         for k in f['foreground/%s' % key].keys():
             filter_dataset(f, 'foreground/{}/{}'.format(key, k), cidx)
+del cidx
 
 n_triggers = f['foreground/ifar'].size
 logging.info('{} foreground events after clustering'.format(n_triggers))
@@ -217,7 +212,7 @@ logging.info('{} foreground events after clustering'.format(n_triggers))
 times_tuple = (f['foreground/{}/time'.format(ifo)] for ifo in all_ifos)
 test_times = np.array([pycbc.events.mean_if_greater_than_zero(tc)[0]
                        for tc in zip(*times_tuple)])
-        
+
 # create a dictionary of whether the coincidence is in an available time for
 # each interferometer combination
 is_in_combo_time = {}
@@ -263,7 +258,7 @@ else:
             coinc.calculate_n_louder(f_in['background/stat'][:],
                                      f['foreground/stat'][:],
                                      f_in['background/decimation_factor'][:])
-        far[ifo_combo_key] = (fnlouder + 1) / f_in.attrs['background_time']
+        far[ifo_combo_key] = (fnlouder[ifo_combo_key] + 1) / f_in.attrs['background_time']
         _, fnlouder_exc[ifo_combo_key] = \
             coinc.calculate_n_louder(f_in['background_exc/stat'][:],
                                      f['foreground/stat'][:],
@@ -287,6 +282,7 @@ fg_fars_exc = np.array([list(far_exc[ct]) for ct in all_ifo_combos])
 fg_ifar = conv.sec_to_year(1. /np.sum(isincombo_mask*fg_fars, axis=0))
 fg_ifar_exc = conv.sec_to_year(1. /np.sum(isincombo_mask*fg_fars_exc, axis=0))
 fg_time = conv.sec_to_year(f.attrs['foreground_time'])
+del isincombo_mask, fg_fars, fg_fars_exc, _
 
 f.attrs['foreground_time_exc'] = f.attrs['foreground_time']
 if not injection_style:
@@ -307,9 +303,13 @@ if not injection_style:
 else:
     del f['foreground/ifar']
 
+del test_times
+
 f['foreground/ifar_exc'][:] = fg_ifar_exc
 fg_time_exc = conv.sec_to_year(f.attrs['foreground_time_exc'])
 f['foreground/fap_exc'] = 1 - np.exp(-fg_time_exc / fg_ifar_exc)
+
+del fg_ifar_exc, fg_ifar
 
 # Hierarchical removal stage
 if not args.max_hierarchical_removal:
@@ -322,38 +322,130 @@ all_bg_data = {}
 all_fg_data = {}
 grps = ['decimation_factor', 'stat', 'template_id', 'timeslide_id', 'ifar']
 
-# set up dictionary to check if there are no fg triggers louder than
-# background in each detector combination
-no_louder_fg = {k: 0 for k in all_ifo_combos}
 for ifo in all_ifos:
     grps += ['%s/time' % ifo]
     grps += ['%s/trigger_id' % ifo]
-bg_data = {g: f['background/%s' % g] for g in grps}
-all_bg_data = DictArray(data=bg_data)
-fg_data = {g: f['foreground/%s' % g] for g in grps}
-all_fg_data = DictArray(data=fg_data)
 
+for f_in in files:
+    combo = get_ifo_string(f_in).replace(' ','')
+    bg_data = {g: f_in['background/%s' % g][:] for g in grps if g in f_in['background']}
+    all_bg_data[combo] = pycbc.io.DictArray(data=bg_data)
+    fg_data = {g: f_in['foreground/%s' % g][:] for g in grps if g in f_in['foreground']}
+    all_fg_data[combo] = pycbc.io.DictArray(data=fg_data)
+    # Clustering fg events for each combination
+    n_triggers = f_in['foreground/ifar'].size
+    fg_times = (f_in['foreground/%s/time' % ifo][:] for ifo in all_ifos if ifo in combo)
+    cidx = pycbc.events.cluster_coincs_multiifo(all_fg_data[combo].data['stat'][:], fg_times,
+                                                np.zeros(n_triggers), 0,
+                                                args.cluster_window)
+    # Selecting clustered events in individual coincidences
+    all_fg_data[combo] = all_fg_data[combo].select(cidx)
+
+#counter to count number of removals
 h_iterations = 0
-while numpy.any(louder_foreground == 0):
-    if (h_iterations == args.max_hierarchical_removal): 
+combined_fg_trig_times = {}
+combined_fg_trig_ids = {}
+combined_bg_trig_times = {}
+combined_bg_trig_ids = {}
+# flag to say if there are any higher statistic values in background
+any_zero = True
+ifos_in_combo = {}
+while any_zero:
+    if (h_iterations == args.max_hierarchical_removal):
+        logging.info("Reached hierarchical removal limit of %d" %
+                     args.max_hierarchical_removal)
         break
+    logging.info("Hierarchical iteration %d" % h_iterations)
+    bg_grps = {}
     if h_iterations == 0:
-        for combo in all_fg_data:
-            for key in all_bg_data[combo]:
-                f['background_h%s/%s' % (h_iterations, key)] = \
-                    all_bg_data[combo][key]
-            for key in all_fg_data[combo]:
-                f['foreground_h%d/%s' % (h_iterations, key)] = \
-                    all_fg_data[combo][key]
+        for combo in all_bg_data:
+            bg_grps[combo] = ['ifar', 'stat', 'timeslide_id']
+            for key in all_fg_data[combo].data:
+                full_fg_key = 'foreground_h0/%s/%s' % (combo, key)
+                f[full_fg_key] = all_fg_data[combo].data[key][:]
+            for key in bg_grps[combo]:
+                f['background_h0/%s/%s' % (combo, key)] = \
+                    all_bg_data[combo].data[key][:]
+
+    else:
+        for combo in all_bg_data:
+            bg_grps[combo] = ['ifar', 'stat', 'timeslide_id',
+                              'decimation_factor', 'template_id']
+            for key in all_fg_data[combo].data:
+                if key.split('/')[0] in all_ifos:
+                    bg_grps[combo] += [key]
+                full_fg_key = 'foreground_h%d/%s/%s' % (h_iterations, combo,
+                                                        key)
+                comp_fg_key = 'foreground_h%d/%s/%s' % (h_iterations - 1,
+                                                        combo, key)
+                if comp_fg_key in f \
+                    and all_fg_data[combo].data[key].size == f[comp_fg_key].size \
+                    and all(all_fg_data[combo].data[key][:] == f[comp_fg_key][:]):
+                    # if the group has not changed create a hard link
+                    f[full_fg_key] = f[comp_fg_key]
+                else:
+                    f[full_fg_key] = all_fg_data[combo].data[key][:]
+            for key in bg_grps[combo]:
+                # The background will (almost certainly) be affected, so copy as normal
+                f['background_h%s/%s/%s' % (h_iterations, combo, key)] = \
+                    all_bg_data[combo].data[key][:]
+
     h_iterations += 1
-    max_stat_idx = all_fg_data['stat'].argmax()
-    rm_trig_idx = numpy.where(all_fg_data['stat'] == max_stat_idx)
-    orig_fore_idx = 
-    
+
+    max_each_combo = {combo: all_fg_data[combo].data['ifar'][:].argmax()
+                      for combo in all_ifo_combos}
+    maxcombo = max({combo: all_fg_data[combo].data['ifar'][:][max_each_combo[combo]]
+                    for combo in all_ifo_combos})
+    max_ifar_idx = max_each_combo[maxcombo]
+    max_ifar = all_fg_data[maxcombo].data['ifar'][:][max_ifar_idx]
+    if not max_ifar > args.hierarchical_removal_ifar_limit:
+        logging.info("Loudest Event IFAR of %.4f is less than minimum of %.4f"
+                     % (max_ifar, args.hierarchical_removal_ifar_limit))
+        break
+    maxtime = pycbc.events.mean_if_greater_than_zero(
+        [all_fg_data[maxcombo].data['%s/time' % ifo][:][max_ifar_idx] for 
+         ifo in all_ifos if ifo in combo])[0]
+    logging.info('Removing triggers from {} foreground at time {} with '
+                 'ifar {}'.format(maxcombo, maxtime, max_ifar))
+    all_fg_data[maxcombo] = all_fg_data[maxcombo].remove(max_ifar_idx)
+    logging.info('Removing background triggers at time {} within window '
+                 '{}s'.format(maxtime,args.hierarchical_removal_window))
+    for combo in all_bg_data:
+        f['background'
+    #trigger_ids_to_rm
+    logging.info("Combining backgrounds and recalculating IFARs")
+    for ifo in all_ifos:
+        combined_fg_trig_times[ifo] = np.array([], dtype=np.uint32)
+        combined_fg_trig_ids[ifo] = np.array([], dtype=np.uint32)
+        combined_bg_trig_times[ifo] = np.array([], dtype=np.uint32)
+        combined_bg_trig_ids[ifo] = np.array([], dtype=np.uint32)
+    for combo in all_ifo_combos:
+        for ifo in all_ifos:
+            if ifo in combo:
+                combined_fg_trig_times[ifo] = np.concatenate([combined_fg_trig_times[ifo],
+                                  all_fg_data[combo].data['%s/time' % ifo]])
+                combined_fg_trig_ids[ifo] = np.concatenate([combined_fg_trig_ids[ifo],
+                                  all_fg_data[combo].data['%s/trigger_id' % ifo]])
+                combined_bg_trig_times[ifo] = np.concatenate([combined_bg_trig_times[ifo],
+                                  all_bg_data[combo].data['%s/time' % ifo]])
+                combined_bg_trig_ids[ifo] = np.concatenate([combined_bg_trig_ids[ifo],
+                                  all_bg_data[combo].data['%s/trigger_id' % ifo]])
+            else:
+                combined_fg_trig_times[ifo] = np.concatenate([combined_fg_trig_times[ifo],
+                                     -1 * np.ones_like(all_fg_data[combo].data['stat'],
+                                                       dtype=np.uint32)])
+                combined_fg_trig_ids[ifo] = np.concatenate([combined_fg_trig_ids[ifo],
+                                     -1 * np.ones_like(all_fg_data[combo].data['stat'],
+                                                       dtype=np.uint32)])
+                combined_bg_trig_times[ifo] = np.concatenate([combined_bg_trig_times[ifo],
+                                     -1 * np.ones_like(all_bg_data[combo].data['stat'],
+                                                       dtype=np.uint32)])
+                combined_bg_trig_ids[ifo] = np.concatenate([combined_bg_trig_ids[ifo],
+                                     -1 * np.ones_like(all_bg_data[combo].data['stat'],
+                                                       dtype=np.uint32)])
+    #combine and copy other datasets
 
 f.attrs['hierarchical_removal_iterations'] = h_iterations
-f.attrs['hierarchical_removal_method'] = \
-    numpy.string_(args.hierarchical_removal_against)
 
 f.close()
 logging.info('Done!')


### PR DESCRIPTION
Adding in Hierarchical Removal to the multiifo workflow

Summary of actions:
- Use triggers clustered over different combinations
- Separate the clustered triggers back into per-combination sets
- Find highest IFAR over all IFO combinations
- removes this from foreground and any triggers within time window from background
- Recalculate IFAR in both separated and combined cases
- Output foreground and background for each combination and combined at each HR stage
- Save HRed datapoints and output as main `foreground` dataset once HR complete