### PR TITLE
Control injection f_ref and f_final from the command line

### DIFF
--- a/pycbc/inject/inject.py
+++ b/pycbc/inject/inject.py
@@ -170,10 +170,7 @@ class _XMLInjectionSet(object):
                           if inj.simulation_id in simulation_ids]
         injection_parameters = []
         for inj in injections:
-            if f_lower is None:
-                f_l = inj.f_lower
-            else:
-                f_l = f_lower
+            f_l = inj.f_lower if f_lower is None else f_lower
             # roughly estimate if the injection may overlap with the segment
             # Add 2s to end_time to account for ringdown and light-travel delay
             end_time = inj.get_time_geocent() + 2
@@ -186,7 +183,7 @@ class _XMLInjectionSet(object):
             if end_time < t0 or start_time > t1:
                 continue
             signal = self.make_strain_from_inj_object(inj, strain.delta_t,
-                     detector_name, f_lower=f_l, distance_scale=distance_scale)
+                    detector_name, f_lower=f_l, distance_scale=distance_scale)
             if float(signal.start_time) > t1:
                 continue
 
@@ -233,10 +230,7 @@ class _XMLInjectionSet(object):
             h(t) corresponding to the injection.
         """
         detector = Detector(detector_name)
-        if f_lower is None:
-            f_l = inj.f_lower
-        else:
-            f_l = f_lower
+        f_l = inj.f_lower if f_lower is None else f_lower
 
         name, phase_order = legacy_approximant_name(inj.waveform)
 
@@ -855,6 +849,21 @@ class InjectionSet(object):
                 injcls = hdfinjtypes[injtype]
             injcls.write(filename, samples, write_params, static_args,
                          **metadata)
+
+    @staticmethod
+    def from_cli(opt):
+        """Return an instance of InjectionSet configured as specified
+        on the command line.
+        """
+        if opt.injection_file is None:
+            return None
+
+        kwa = {}
+        if opt.injection_f_ref is not None:
+            kwa['f_ref'] = opt.injection_f_ref
+        if opt.injection_f_final is not None:
+            kwa['f_final'] = opt.injection_f_final
+        return InjectionSet(opt.injection_file, **kwa)
 
 
 class SGBurstInjectionSet(object):

--- a/pycbc/strain/strain.py
+++ b/pycbc/strain/strain.py
@@ -202,6 +202,8 @@ def from_cli(opt, dyn_range_fac=1, precision='single',
     """
     gating_info = {}
 
+    injector = InjectionSet.from_cli(opt)
+
     if opt.frame_cache or opt.frame_files or opt.frame_type or opt.hdf_store:
         if opt.frame_cache:
             frame_source = opt.frame_cache
@@ -247,9 +249,8 @@ def from_cli(opt, dyn_range_fac=1, precision='single',
             l = opt.normalize_strain
             strain = strain / l
 
-        if opt.injection_file:
+        if injector is not None:
             logging.info("Applying injections")
-            injector = InjectionSet(opt.injection_file)
             injections = \
                 injector.apply(strain, opt.channel_name[0:2],
                                distance_scale=opt.injection_scale_factor,
@@ -385,9 +386,8 @@ def from_cli(opt, dyn_range_fac=1, precision='single',
                              'ifo:channel (e.g. H1:CALIB-STRAIN) to inject '
                              'simulated signals into fake strain')
 
-        if opt.injection_file:
+        if injector is not None:
             logging.info("Applying injections")
-            injector = InjectionSet(opt.injection_file)
             injections = \
                 injector.apply(strain, opt.channel_name[0:2],
                                distance_scale=opt.injection_scale_factor,
@@ -417,7 +417,7 @@ def from_cli(opt, dyn_range_fac=1, precision='single',
                              pd_taper_window) )
         gate_data(strain, gate_params)
 
-    if opt.injection_file:
+    if injector is not None:
         strain.injections = injections
     strain.gating_info = gating_info
 
@@ -538,6 +538,15 @@ def insert_strain_option_group(parser, gps_times=True):
     data_reading_group.add_argument("--injection-scale-factor", type=float,
                     default=1, help="Divide injections by this factor "
                     "before injecting into the data.")
+
+    data_reading_group.add_argument('--injection-f-ref', type=float,
+                                    help='Reference frequency in Hz for '
+                                         'creating CBC injections from an XML '
+                                         'file.')
+
+    data_reading_group.add_argument('--injection-f-final', type=float,
+                                    help='Override the f_final field of a CBC '
+                                         'XML injection file.')
 
     data_reading_group.add_argument("--gating-file", type=str,
                     help="(optional) Text file of gating segments to apply."


### PR DESCRIPTION
Here is a proposal for adding the ability to control/override f_ref and f_final when doing injections from an XML file, which carries no f_ref and which may have a bogus f_final. After reviewing the current injection code path, I decided to add two arguments `--injection-f-ref` and `--injection-f-final`, both taking frequencies in Hz. This keeps the amount of code change to a minimum.

*Needs testing*.