### PR TITLE
add log-x option to plot_vt_ratio

### DIFF
--- a/bin/plotting/pycbc_plot_vt_ratio
+++ b/bin/plotting/pycbc_plot_vt_ratio
@@ -106,7 +106,7 @@ for idv in idxs:
 
 if args.log_x and args.log_y:
     plt.loglog()
-elif args.log_x and args.log_y:
+elif args.log_x and not args.log_y:
     plt.semilogx()
 elif args.log_y and not args.log_x:
     plt.semilogy()

--- a/bin/plotting/pycbc_plot_vt_ratio
+++ b/bin/plotting/pycbc_plot_vt_ratio
@@ -23,7 +23,8 @@ parser.add_argument('--outfile', type=str, required=True,
 parser.add_argument('--ifars', type=float, required=True, nargs='+',
                     help='IFAR values to plot VT ratio for. Note that the plotted values '
                          'will be the closest values available from the VT files')
-
+parser.add_argument('--log-x', action='store_true', default=False,
+                    help='Use logarithmic x-axis')
 args = parser.parse_args()
 
 # Load in the two datasets
@@ -54,9 +55,13 @@ x_param = r'$' + tuple(ffirst_set['data'].keys())[0].split('\\in')[0].strip('$')
 # read in the positions from the labels
 xpos = np.array([float(l.split('[')[1].split(',')[0]) for l in labels])
 
-# offset different ifars by 1/20th of the distance between one parameter value and the next
-# for the last value use the previous difference
-xpos_add_dx = 0.05 * np.append(np.diff(xpos), np.diff(xpos)[-1])
+# offset different ifars by 1/20th of the mean distance parameter value diffs
+if args.log_x:
+    xpos_logdiffmean = np.diff(np.log(xpos)).mean()
+    xpos_add_dx = 0.05 * np.ones_like(xpos) * xpos_logdiffmean
+else:
+    xpos_diffmean = np.diff(xpos).mean()
+    xpos_add_dx = 0.05 * np.ones_like(xpos) * xpos_diffmean
 
 # set the x ticks to be the positions given in the labels
 plt.xticks(xpos, labels, rotation='horizontal')
@@ -80,14 +85,27 @@ for idv in idxs:
                 np.divide(errlow2, data2)**2), ys)
     yerr_errhigh = np.multiply(np.sqrt(np.divide(errhigh1, data1)**2 +
                 np.divide(errhigh2, data2)**2), ys)
-    ax_mi.errorbar(xpos + xpos_add_dx * (colorcount - float(len(args.ifars) - 1) / 2.), ys,
+    if args.log_x:
+        xvals = np.exp(np.log(xpos) +
+                       xpos_add_dx * (colorcount -
+                                      float(len(args.ifars) - 1) / 2.))
+    else:
+        xvals = xpos + xpos_add_dx * (colorcount -
+                                      float(len(args.ifars) - 1) / 2.)
+    ax_mi.errorbar(xvals, ys,
         yerr=[yerr_errlow, yerr_errhigh], fmt='o', markersize=7, linewidth=5,
-        label='IFAR = %d yr' % ffirst_set['xvals'][idv], capsize=5, capthick=2, mec='k',
-        color=colors[colorcount % 10])
-    plt.xticks(xpos, labels, rotation='horizontal')
+        label='IFAR = %d yr' % ffirst_set['xvals'][idv], capsize=5,
+        capthick=2, mec='k', color=colors[colorcount % 10])
     colorcount += 1
 
-# get the limit of the x axes, and draw a black line in order to highlight equal comparison
+if args.log_x:
+    plt.semilogx()
+    plt.xticks(xpos, labels, rotation='horizontal')
+else:
+    plt.xticks(xpos, labels, rotation='horizontal')
+
+# get the limit of the x axes, and draw a black line in order to highlight
+# equal comparison
 xlimits = plt.xlim()
 plt.plot(xlimits, [1, 1], 'k', lw=3, zorder=0)
 plt.xlim(xlimits) # reassert the x limits so that the plot doesn't expand

--- a/bin/plotting/pycbc_plot_vt_ratio
+++ b/bin/plotting/pycbc_plot_vt_ratio
@@ -25,6 +25,8 @@ parser.add_argument('--ifars', type=float, required=True, nargs='+',
                          'will be the closest values available from the VT files')
 parser.add_argument('--log-x', action='store_true', default=False,
                     help='Use logarithmic x-axis')
+parser.add_argument('--log-y', action='store_true', default=False,
+                    help='Use logarithmic y-axis')
 args = parser.parse_args()
 
 # Load in the two datasets
@@ -55,19 +57,23 @@ x_param = r'$' + tuple(ffirst_set['data'].keys())[0].split('\\in')[0].strip('$')
 # read in the positions from the labels
 xpos = np.array([float(l.split('[')[1].split(',')[0]) for l in labels])
 
-# offset different ifars by 1/20th of the mean distance parameter value diffs
-if args.log_x:
-    xpos_logdiffmean = np.diff(np.log(xpos)).mean()
-    xpos_add_dx = 0.05 * np.ones_like(xpos) * xpos_logdiffmean
-else:
-    xpos_diffmean = np.diff(xpos).mean()
-    xpos_add_dx = 0.05 * np.ones_like(xpos) * xpos_diffmean
+# offset different ifars by 1/20th of the mean distance between parameters
+try: 
+    if args.log_x:
+        xpos_logdiffmean = np.diff(np.log(xpos)).mean()
+        xpos_add_dx = 0.05 * np.ones_like(xpos) * xpos_logdiffmean
+    else:
+        xpos_diffmean = np.diff(xpos).mean()
+        xpos_add_dx = 0.05 * np.ones_like(xpos) * xpos_diffmean
+except IndexError:
+    #If there's only one value of xpos, then diff doesnt work
+    xpos_add_dx = 0.05
 
 # set the x ticks to be the positions given in the labels
 plt.xticks(xpos, labels, rotation='horizontal')
 
 colors = ['#7b85d4', '#f37738', '#83c995', '#d7369e', '#c4c9d8', '#859795']
-colorcount = 0
+count = 0
 
 # loop through each IFAR and plot the VT ratio with error bars
 for idv in idxs:
@@ -87,22 +93,24 @@ for idv in idxs:
                 np.divide(errhigh2, data2)**2), ys)
     if args.log_x:
         xvals = np.exp(np.log(xpos) +
-                       xpos_add_dx * (colorcount -
+                       xpos_add_dx * (count -
                                       float(len(args.ifars) - 1) / 2.))
     else:
-        xvals = xpos + xpos_add_dx * (colorcount -
+        xvals = xpos + xpos_add_dx * (count -
                                       float(len(args.ifars) - 1) / 2.)
     ax_mi.errorbar(xvals, ys,
         yerr=[yerr_errlow, yerr_errhigh], fmt='o', markersize=7, linewidth=5,
         label='IFAR = %d yr' % ffirst_set['xvals'][idv], capsize=5,
-        capthick=2, mec='k', color=colors[colorcount % 10])
+        capthick=2, mec='k', color=colors[count % len(colors)])
     colorcount += 1
 
-if args.log_x:
+if args.log_x and args.log_y:
+    plt.loglog()
+elif args.log_x and args.log_y:
     plt.semilogx()
-    plt.xticks(xpos, labels, rotation='horizontal')
-else:
-    plt.xticks(xpos, labels, rotation='horizontal')
+elif args.log_y and not args.log_x:
+    plt.semilogy()
+plt.xticks(xpos, labels, rotation='horizontal')
 
 # get the limit of the x axes, and draw a black line in order to highlight
 # equal comparison
@@ -110,11 +118,13 @@ xlimits = plt.xlim()
 plt.plot(xlimits, [1, 1], 'k', lw=3, zorder=0)
 plt.xlim(xlimits) # reassert the x limits so that the plot doesn't expand
 
-ax_mi.legend(bbox_to_anchor=(0.5, 1.01), ncol=len(args.ifars), loc='lower center')
+ax_mi.legend(bbox_to_anchor=(0.5, 1.01), ncol=len(args.ifars),
+                             loc='lower center')
 ax_mi.get_legend().get_title().set_fontsize('14')
 ax_mi.get_legend().get_frame().set_alpha(0.7)
 ax_mi.set_xlabel(x_param)
-ax_mi.set_ylabel(r'$\frac{VT(\mathrm{' + args.desc_one +'})}{VT(\mathrm{' + args.desc_two +'})}$')
+ax_mi.set_ylabel(r'$\frac{VT(\mathrm{' + args.desc_one +'})}{VT(\mathrm{' +
+                 args.desc_two +'})}$')
 plt.tight_layout()
 
 # write out to file, save as pdf if requested

--- a/bin/plotting/pycbc_plot_vt_ratio
+++ b/bin/plotting/pycbc_plot_vt_ratio
@@ -119,7 +119,7 @@ plt.plot(xlimits, [1, 1], 'k', lw=3, zorder=0)
 plt.xlim(xlimits) # reassert the x limits so that the plot doesn't expand
 
 ax_mi.legend(bbox_to_anchor=(0.5, 1.01), ncol=len(args.ifars),
-                             loc='lower center')
+             loc='lower center')
 ax_mi.get_legend().get_title().set_fontsize('14')
 ax_mi.get_legend().get_frame().set_alpha(0.7)
 ax_mi.set_xlabel(x_param)

--- a/bin/plotting/pycbc_plot_vt_ratio
+++ b/bin/plotting/pycbc_plot_vt_ratio
@@ -102,7 +102,7 @@ for idv in idxs:
         yerr=[yerr_errlow, yerr_errhigh], fmt='o', markersize=7, linewidth=5,
         label='IFAR = %d yr' % ffirst_set['xvals'][idv], capsize=5,
         capthick=2, mec='k', color=colors[count % len(colors)])
-    colorcount += 1
+    count += 1
 
 if args.log_x and args.log_y:
     plt.loglog()


### PR DESCRIPTION
standard mchirp options were making the vt ratio comparison plots bunched up on one side - add in ability to use log x axis