### PR TITLE
Add psd var val to tables

### DIFF
--- a/bin/minifollowups/pycbc_page_coincinfo
+++ b/bin/minifollowups/pycbc_page_coincinfo
@@ -43,6 +43,10 @@ trig_input.add_argument('--n-loudest', type=int,
 trig_input.add_argument('--trigger-id', type=int,
     help="Examine the trigger with specified ID, use with statmap file. An "
          "alternative to --n-loudest. Cannot be used together")
+parser.add_argument('--include-summary-page-link', action='store_true',
+    help="If given, will include a link to the DQ summary page on the "
+         "single detector trigger tables.")
+
 
 args = parser.parse_args()
 pycbc.init_logging(args.verbose)
@@ -135,7 +139,6 @@ else:
         idx[ifo] = d['%s/trigger_id' % ifo][n]
 
 # Store the single detector trigger files keyed by ifo in a dictionary
-table = []
 files = {}
 for fname in args.single_trigger_files:
     f2 = h5py.File(fname, 'r')
@@ -145,6 +148,7 @@ for fname in args.single_trigger_files:
 
 bank = h5py.File(args.bank_file, 'r')
 statmapfile = d
+data = []
 for ifo in files.keys():
 
     # ignore ifo if coinc didn't participate (only for multi-ifo workflow)
@@ -164,27 +168,64 @@ for ifo in files.keys():
     try:
         psd_var = d['psd_var_val'][i]
     except:
-        psd_var = 0
+        psd_var = None
 
-    data = [pycbc.results.dq.get_summary_page_link(ifo, utc),
-            str(datetime.datetime(*utc)),
-            '%.3f'  % time,
-            '%5.2f' % d['snr'][i],
-            '%5.2f' % ranking.newsnr(d['snr'][i], rchisq),
-            '%5.2f' % rchisq,
-            '%i'    % d['chisq_dof'][i],
-            '%5.2f' % d['coa_phase'][i],
-            '%5.2f' % bank['mass1'][tid],
-            '%5.2f' % bank['mass2'][tid],
-            '%5.2f' % mchirp,
-            '%5.2f' % bank['spin1z'][tid],
-            '%5.2f' % bank['spin2z'][tid],
-            '%5.2f' % d['template_duration'][i],
-            '%5.2f' % psd_var
-           ]
-    table.append(data)
+    try:
+        sg_chisq = d['sg_chisq'][i]
+    except:
+        sg_chisq = None
 
-html += str(pycbc.results.static_table(table, pycbc.results.sngl_table_headers))
+    # This might involve a lot of lines, but it's clear what goes in the output
+    # and in what order.
+    headers = []
+    data.append([])
+
+    # DQ summary link
+    if args.include_summary_page_link:
+        data[-1].append(pycbc.results.dq.get_summary_page_link(ifo, utc))
+        headers.append("Detector&nbsp;status")
+
+    # End times
+    data[-1].append(str(datetime.datetime(*utc)))
+    data[-1].append('%.3f' % time)
+    headers.append("UTC")
+    headers.append("End&nbsp;time")
+
+    # SNR and phase (not showing any single-det stat here)
+    data[-1].append('%5.2f' % d['snr'][i])
+    data[-1].append('%5.2f' % d['coa_phase'][i])
+    #data[-1].append('%5.2f' % ranking.newsnr(d['snr'][i], rchisq))
+    headers.append("&rho;")
+    headers.append("Phase")
+    #headers.append("Stat")
+
+    # Signal-glitch discrimators
+    data[-1].append('%5.2f' % rchisq)
+    data[-1].append('%i' % d['chisq_dof'][i])
+    headers.append("&chi;<sup>2</sup><sub>r</sub>")
+    headers.append("&chi;<sup>2</sup>&nbsp;bins")
+    if sg_chisq is not None:
+        data[-1].append('%5.2f' % sg_chisq)
+        headers.append("sg&chi;<sup>2</sup>")
+    if psd_var is not None:
+        data[-1].append('%5.2f' % psd_var)
+        headers.append("PSD var")
+
+    # Template parameters
+    data[-1].append('%5.2f' % bank['mass1'][tid])
+    data[-1].append('%5.2f' % bank['mass2'][tid])
+    data[-1].append('%5.2f' % mchirp)
+    data[-1].append('%5.2f' % bank['spin1z'][tid])
+    data[-1].append('%5.2f' % bank['spin2z'][tid])
+    data[-1].append('%5.2f' % d['template_duration'][i])
+    headers.append("m<sub>1</sub>")
+    headers.append("m<sub>2</sub>")
+    headers.append("M<sub>c</sub>")
+    headers.append("s<sub>1z</sub>")
+    headers.append("s<sub>2z</sub>")
+    headers.append("Duration")
+
+html += str(pycbc.results.static_table(data, headers))
 ###############################################################################
 
 pycbc.results.save_fig_with_metadata(html, args.output_file, {},

--- a/bin/minifollowups/pycbc_page_coincinfo
+++ b/bin/minifollowups/pycbc_page_coincinfo
@@ -161,6 +161,10 @@ for ifo in files.keys():
 
     time = d['end_time'][:][i]
     utc = lal.GPSToUTC(int(time))[0:6]
+    try:
+        psd_var = d['psd_var_val'][i]
+    except:
+        psd_var = 0
 
     data = [pycbc.results.dq.get_summary_page_link(ifo, utc),
             str(datetime.datetime(*utc)),
@@ -175,7 +179,8 @@ for ifo in files.keys():
             '%5.2f' % mchirp,
             '%5.2f' % bank['spin1z'][tid],
             '%5.2f' % bank['spin2z'][tid],
-            '%5.2f' % d['template_duration'][i]
+            '%5.2f' % d['template_duration'][i],
+            '%5.2f' % psd_var
            ]
     table.append(data)
 

--- a/bin/minifollowups/pycbc_page_coincinfo
+++ b/bin/minifollowups/pycbc_page_coincinfo
@@ -148,6 +148,9 @@ for fname in args.single_trigger_files:
 
 bank = h5py.File(args.bank_file, 'r')
 statmapfile = d
+# Data will store the values that will appear in the resulting single-detector
+# table. Each entry in data corresponds to each row in the final table and
+# should be a list of values. So data is will be a list of lists.
 data = []
 for ifo in files.keys():
 
@@ -165,18 +168,8 @@ for ifo in files.keys():
 
     time = d['end_time'][:][i]
     utc = lal.GPSToUTC(int(time))[0:6]
-    try:
-        psd_var = d['psd_var_val'][i]
-    except:
-        psd_var = None
 
-    try:
-        sg_chisq = d['sg_chisq'][i]
-    except:
-        sg_chisq = None
-
-    # This might involve a lot of lines, but it's clear what goes in the output
-    # and in what order.
+    # Headers will store the headers that will appear in the table.
     headers = []
     data.append([])
 
@@ -204,12 +197,16 @@ for ifo in files.keys():
     data[-1].append('%i' % d['chisq_dof'][i])
     headers.append("&chi;<sup>2</sup><sub>r</sub>")
     headers.append("&chi;<sup>2</sup>&nbsp;bins")
-    if sg_chisq is not None:
-        data[-1].append('%5.2f' % sg_chisq)
+    try:
+        data[-1].append('%5.2f' % d['sg_chisq'][i])
         headers.append("sg&chi;<sup>2</sup>")
-    if psd_var is not None:
-        data[-1].append('%5.2f' % psd_var)
+    except:
+        pass
+    try:
+        data[-1].append('%5.2f' % d['psd_var_val'][i])
         headers.append("PSD var")
+    except:
+        pass
 
     # Template parameters
     data[-1].append('%5.2f' % bank['mass1'][tid])

--- a/bin/minifollowups/pycbc_page_snglinfo
+++ b/bin/minifollowups/pycbc_page_snglinfo
@@ -98,6 +98,7 @@ data = [[pycbc.results.dq.get_summary_page_link(args.instrument, utc),
         '%5.2f' % sngl_file.spin1z,
         '%5.2f' % sngl_file.spin2z,
         '%5.2f' % sngl_file.template_duration,
+        '%5.2f' % sngl_file.psd_var_val
        ]]
 
 html = pycbc.results.dq.redirect_javascript + \

--- a/bin/minifollowups/pycbc_page_snglinfo
+++ b/bin/minifollowups/pycbc_page_snglinfo
@@ -84,6 +84,10 @@ else:
 # make a table for the single detector information ############################
 time = sngl_file.end_time
 utc = lal.GPSToUTC(int(time))[0:6]
+try:
+    psd_var = sngl_file.psd_var_val
+except:
+    psd_var = 0
 data = [[pycbc.results.dq.get_summary_page_link(args.instrument, utc),
         str(datetime.datetime(*utc)),
         '%.3f'  % time,
@@ -98,7 +102,7 @@ data = [[pycbc.results.dq.get_summary_page_link(args.instrument, utc),
         '%5.2f' % sngl_file.spin1z,
         '%5.2f' % sngl_file.spin2z,
         '%5.2f' % sngl_file.template_duration,
-        '%5.2f' % sngl_file.psd_var_val
+        '%5.2f' % psd_var
        ]]
 
 html = pycbc.results.dq.redirect_javascript + \

--- a/bin/minifollowups/pycbc_page_snglinfo
+++ b/bin/minifollowups/pycbc_page_snglinfo
@@ -89,19 +89,13 @@ else:
 time = sngl_file.end_time
 utc = lal.GPSToUTC(int(time))[0:6]
 
-try:
-    psd_var = sngl_file.psd_var_val
-except:
-    psd_var = None
-
-try:
-    sg_chisq = sngl_file.sgchisq
-except:
-    sg_chisq = None
-
-# This might involve a lot of lines, but it's clear what goes in the output
-# and in what order.
+# Headers here will contain the list of headers that will appear in the
+# resulting single-detector summary table.
 headers = []
+# Data will store the list of values that will appear in the resulting
+# single-detector summary table. There will only ever be one row in this table
+# that corresponding to the selected trigger. So this will be a list of a
+# single list that will hold the values to go into the table.
 data = [[]]
 
 # DQ summary link
@@ -128,12 +122,16 @@ data[0].append('%5.2f' % sngl_file.rchisq)
 data[0].append('%i' % sngl_file.get_column('chisq_dof'))
 headers.append("&chi;<sup>2</sup><sub>r</sub>")
 headers.append("&chi;<sup>2</sup>&nbsp;bins")
-if sg_chisq is not None:
-    data[0].append('%5.2f' % sg_chisq)
+try:
+    data[0].append('%5.2f' % sngl_file.sgchisq)
     headers.append("sg&chi;<sup>2</sup>")
-if psd_var is not None:
-    data[0].append('%5.2f' % psd_var)
+except:
+    pass
+try:
+    data[0].append('%5.2f' % sngl_file.psd_var_val)
     headers.append("PSD var")
+except:
+    pass
 
 # Template parameters
 data[0].append('%5.2f' % sngl_file.mass1)

--- a/bin/minifollowups/pycbc_page_snglinfo
+++ b/bin/minifollowups/pycbc_page_snglinfo
@@ -52,6 +52,10 @@ trig_args.add_argument("--trigger-id", type=int, default=None,
 parser.add_argument('--ranking-statistic', default='newsnr',
     help="How to rank triggers when determining loudest triggers. Default "
          "'newsnr'")
+parser.add_argument('--include-summary-page-link', action='store_true',
+    help="If given, will include a link to the DQ summary page")
+
+
 
 args = parser.parse_args()
 
@@ -84,29 +88,69 @@ else:
 # make a table for the single detector information ############################
 time = sngl_file.end_time
 utc = lal.GPSToUTC(int(time))[0:6]
+
 try:
     psd_var = sngl_file.psd_var_val
 except:
-    psd_var = 0
-data = [[pycbc.results.dq.get_summary_page_link(args.instrument, utc),
-        str(datetime.datetime(*utc)),
-        '%.3f'  % time,
-        '%5.2f' % sngl_file.snr,
-        '%5.2f' % stat,
-        '%5.2f' % sngl_file.rchisq,
-        '%i'    % sngl_file.get_column('chisq_dof'),
-        '%5.2f' % sngl_file.get_column('coa_phase'),
-        '%5.2f' % sngl_file.mass1,
-        '%5.2f' % sngl_file.mass2,
-        '%5.2f' % sngl_file.mchirp,
-        '%5.2f' % sngl_file.spin1z,
-        '%5.2f' % sngl_file.spin2z,
-        '%5.2f' % sngl_file.template_duration,
-        '%5.2f' % psd_var
-       ]]
+    psd_var = None
+
+try:
+    sg_chisq = sngl_file.sgchisq
+except:
+    sg_chisq = None
+
+# This might involve a lot of lines, but it's clear what goes in the output
+# and in what order.
+headers = []
+data = [[]]
+
+# DQ summary link
+if args.include_summary_page_link:
+    data[0].append(pycbc.results.dq.get_summary_page_link(args.instrument, utc))
+    headers.append("Detector&nbsp;status")
+
+# End times
+data[0].append(str(datetime.datetime(*utc)))
+data[0].append('%.3f' % time)
+headers.append("UTC")
+headers.append("End&nbsp;time")
+
+# SNR and statistic
+data[0].append('%5.2f' % sngl_file.snr)
+data[0].append('%5.2f' % sngl_file.get_column('coa_phase'))
+data[0].append('%5.2f' % stat)
+headers.append("&rho;")
+headers.append("Phase")
+headers.append("Stat")
+
+# Signal-glitch discrimators
+data[0].append('%5.2f' % sngl_file.rchisq)
+data[0].append('%i' % sngl_file.get_column('chisq_dof'))
+headers.append("&chi;<sup>2</sup><sub>r</sub>")
+headers.append("&chi;<sup>2</sup>&nbsp;bins")
+if sg_chisq is not None:
+    data[0].append('%5.2f' % sg_chisq)
+    headers.append("sg&chi;<sup>2</sup>")
+if psd_var is not None:
+    data[0].append('%5.2f' % psd_var)
+    headers.append("PSD var")
+
+# Template parameters
+data[0].append('%5.2f' % sngl_file.mass1)
+data[0].append('%5.2f' % sngl_file.mass2)
+data[0].append('%5.2f' % sngl_file.mchirp)
+data[0].append('%5.2f' % sngl_file.spin1z)
+data[0].append('%5.2f' % sngl_file.spin2z)
+data[0].append('%5.2f' % sngl_file.template_duration)
+headers.append("m<sub>1</sub>")
+headers.append("m<sub>2</sub>")
+headers.append("M<sub>c</sub>")
+headers.append("s<sub>1z</sub>")
+headers.append("s<sub>2z</sub>")
+headers.append("Duration")
 
 html = pycbc.results.dq.redirect_javascript + \
-        str(pycbc.results.static_table(data, pycbc.results.sngl_table_headers))
+        str(pycbc.results.static_table(data, headers))
 ###############################################################################
 
 if args.n_loudest:

--- a/pycbc/results/table_utils.py
+++ b/pycbc/results/table_utils.py
@@ -142,21 +142,3 @@ def static_table(data, titles=None):
     """
     return static_table_template.render(data=data, titles=titles)
 
-sngl_table_headers = [
-    "Detector&nbsp;status",
-    "UTC",
-    "End&nbsp;time",
-    "&rho;",
-    "&rho;<sub>new</sub>",
-    "&chi;<sup>2</sup><sub>r</sub>",
-    "&chi;<sup>2</sup>&nbsp;bins",
-    "&phi;<sub>c</sub>",
-    "m<sub>1</sub>",
-    "m<sub>2</sub>",
-    "M<sub>c</sub>",
-    "s<sub>1z</sub>",
-    "s<sub>2z</sub>",
-    "Duration",
-    "PSD var"
-]
-

--- a/pycbc/results/table_utils.py
+++ b/pycbc/results/table_utils.py
@@ -156,6 +156,7 @@ sngl_table_headers = [
     "M<sub>c</sub>",
     "s<sub>1z</sub>",
     "s<sub>2z</sub>",
-    "Duration"
+    "Duration",
+    "PSD var"
 ]
 


### PR DESCRIPTION
Here is the code that I used to add `psd_var_val` to the results tables in my testing. While this can handle the case that this quantity is not computed, it will still appear in the tables (with the value of 0). As the table headers are hardcoded, I didn't see a nice way to stop this being displayed, other than moving the headers out of `pycbc/results/table_utils.py` and constructing them in the executables .... Maybe that's the correct approach anyway (or moving the entire computation *into* table_utils?? For now, this is here for comments!