### PR TITLE
Changes to perform downsampling after injections in fake data

### DIFF
--- a/pycbc/strain/strain.py
+++ b/pycbc/strain/strain.py
@@ -780,6 +780,7 @@ def insert_strain_option_group_multi_ifo(parser, gps_times=True):
 
     return data_reading_group_multi
 
+
 ensure_one_opt_groups = []
 ensure_one_opt_groups.append(['--frame-cache','--fake-strain',
                               '--fake-strain-from-file',
@@ -790,7 +791,7 @@ required_opts_list = ['--gps-start-time', '--gps-end-time',
                       '--strain-high-pass', '--pad-data', '--sample-rate',
                       '--channel-name']
 
-                                          
+
 def verify_strain_options(opts, parser):
     """Sanity check provided strain arguments.
 
@@ -811,7 +812,7 @@ def verify_strain_options(opts, parser):
         ensure_one_opt(opts, parser, opt_group)
     required_opts(opts, parser, required_opts_list)
 
-                                          
+
 def verify_strain_options_multi_ifo(opts, parser, ifos):
     """Sanity check provided strain arguments.
 
@@ -886,7 +887,7 @@ def gate_data(data, gate_params):
 
     return data
 
-                                          
+
 class StrainSegments(object):
     """ Class for managing manipulation of strain data for the purpose of
         matched filtering. This includes methods for segmenting and
@@ -1188,7 +1189,7 @@ class StrainSegments(object):
         for ifo in ifos:
             required_opts_multi_ifo(opt, parser, ifo, cls.required_opts_list)
 
-                                          
+
 class StrainBuffer(pycbc.frame.DataBuffer):
     def __init__(self, frame_src, channel_name, start_time,
                  max_buffer=512,

--- a/pycbc/strain/strain.py
+++ b/pycbc/strain/strain.py
@@ -718,12 +718,12 @@ def insert_strain_option_group_multi_ifo(parser, gps_times=True):
                          "before injecting into the data.")
 
     # Gating options
-    data_reading_group_multi.add_argument("--gating-file", type=str,
-                      nargs="+", action=MultiDetOptionAction,
+    data_reading_group_multi.add_argument("--gating-file", nargs="+",
+                      action=MultiDetOptionAction,
                       metavar='IFO:FILE',
-                      help="(optional) Text file of gating segments to apply."
-                          " Format of each line is (all times in secs):"
-                          "  gps_time zeros_half_width pad_half_width"
+                      help='(optional) Text file of gating segments to apply."
+                           ' Format of each line (units s) :'
+                           ' gps_time zeros_half_width pad_half_width')
     data_reading_group_multi.add_argument('--autogating-threshold', type=float,
                                     nargs="+", action=MultiDetOptionAction,
                                     metavar='IFO:SIGMA',

--- a/pycbc/strain/strain.py
+++ b/pycbc/strain/strain.py
@@ -721,7 +721,7 @@ def insert_strain_option_group_multi_ifo(parser, gps_times=True):
     data_reading_group_multi.add_argument("--gating-file", nargs="+",
                       action=MultiDetOptionAction,
                       metavar='IFO:FILE',
-                      help='(optional) Text file of gating segments to apply."
+                      help='(optional) Text file of gating segments to apply.'
                            ' Format of each line (units s) :'
                            ' gps_time zeros_half_width pad_half_width')
     data_reading_group_multi.add_argument('--autogating-threshold', type=float,
@@ -766,17 +766,17 @@ def insert_strain_option_group_multi_ifo(parser, gps_times=True):
                      nargs="+", action=MultiDetOptionAppendAction,
                      metavar='IFO:VALUE',
                      help="(optional) Zero-pole-gain (zpk) filter strain. "
-                         "A list of zeros for transfer function")
+                          "A list of zeros for transfer function")
     data_reading_group_multi.add_argument("--zpk-p", type=float,
                      nargs="+", action=MultiDetOptionAppendAction,
                      metavar='IFO:VALUE',
                      help="(optional) Zero-pole-gain (zpk) filter strain. "
-                         "A list of poles for transfer function")
+                          "A list of poles for transfer function")
     data_reading_group_multi.add_argument("--zpk-k", type=float,
                      nargs="+", action=MultiDetOptionAppendAction,
                      metavar='IFO:VALUE',
                      help="(optional) Zero-pole-gain (zpk) filter strain. "
-                         "Transfer function gain")
+                          "Transfer function gain")
 
     return data_reading_group_multi
 

--- a/pycbc/strain/strain.py
+++ b/pycbc/strain/strain.py
@@ -278,7 +278,7 @@ def from_cli(opt, dyn_range_fac=1, precision='single',
         if opt.sample_rate:
             logging.info("Resampling data")
             strain = resample_to_delta_t(strain,
-                                         1.0 / opt.sample_rate,
+                                         1. / opt.sample_rate,
                                          method='ldas')
 
         if opt.gating_file is not None:
@@ -330,12 +330,12 @@ def from_cli(opt, dyn_range_fac=1, precision='single',
                 tf = pycbc.psd.interpolate(tf, stilde.delta_f)
 
                 tf_time = tf.to_timeseries()
-                window = Array(numpy.hanning(flen*2), dtype=strain.dtype)
+                window = Array(numpy.hanning(flen * 2), dtype=strain.dtype)
                 tf_time[0:flen] *= window[flen:]
                 tf_time[len(tf_time)-flen:] *= window[0:flen]
                 tf = tf_time.to_frequencyseries()
 
-                kmax = min(len(tf), len(stilde)-1)
+                kmax = min(len(tf), len(stilde) - 1)
                 stilde[:kmax] -= tf[:kmax] * witness.to_frequencyseries()[:kmax]
 
             strain = stilde.to_timeseries()
@@ -352,7 +352,7 @@ def from_cli(opt, dyn_range_fac=1, precision='single',
             raise ValueError('Please provide low frequency cutoff to '
                              'generate a fake strain')
         duration = opt.gps_end_time - opt.gps_start_time
-        pdf = 1.0/128
+        pdf = 1. / 128
         plen = int(opt.sample_rate / pdf) / 2 + 1
 
         if opt.fake_strain_from_file:
@@ -367,7 +367,7 @@ def from_cli(opt, dyn_range_fac=1, precision='single',
         if opt.fake_strain == 'zeroNoise':
             logging.info("Making zero-noise time series")
             strain = TimeSeries(pycbc.types.zeros(duration * 16384),
-                                delta_t=1.0/16384,
+                                delta_t=1. / 16384,
                                 epoch=opt.gps_start_time)
         else:
             logging.info("Making colored noise")
@@ -398,9 +398,7 @@ def from_cli(opt, dyn_range_fac=1, precision='single',
                              distance_scale=opt.injection_scale_factor)
 
         logging.info("Resampling data")
-        strain = resample_to_delta_t(strain,
-                                     1.0 / opt.sample_rate,
-                                     method='ldas')
+        strain = resample_to_delta_t(strain, 1. / opt.sample_rate)
 
         if precision == 'single':
             logging.info("Converting to float32")
@@ -413,11 +411,10 @@ def from_cli(opt, dyn_range_fac=1, precision='single',
 
     if opt.taper_data:
         logging.info("Tapering data")
-        # Use auto-gating stuff for this, a one-sided gate is a taper
+        # Use auto-gating, a one-sided gate is a taper
         pd_taper_window = opt.taper_data
         gate_params = [(strain.start_time, 0., pd_taper_window)]
-        gate_params.append( (strain.end_time, 0.,
-                             pd_taper_window) )
+        gate_params.append((strain.end_time, 0., pd_taper_window))
         gate_data(strain, gate_params)
 
     if injector is not None:
@@ -470,7 +467,6 @@ def insert_strain_option_group(parser, gps_times=True):
                   " if the --psd-estimation option is given.")
 
     # Required options
-
     if gps_times:
         data_reading_group.add_argument("--gps-start-time",
                                 help="The gps start time of the data "
@@ -478,7 +474,6 @@ def insert_strain_option_group(parser, gps_times=True):
         data_reading_group.add_argument("--gps-end-time",
                                 help="The gps end time of the data "
                                      " (integer seconds)", type=int)
-
 
     data_reading_group.add_argument("--strain-high-pass", type=float,
                             help="High pass frequency")
@@ -493,33 +488,29 @@ def insert_strain_option_group(parser, gps_times=True):
     data_reading_group.add_argument("--channel-name", type=str,
                    help="The channel containing the gravitational strain data")
 
-    #Read from cache file
+    # Read from cache file
     data_reading_group.add_argument("--frame-cache", type=str, nargs="+",
                             help="Cache file containing the frame locations.")
-
-    #Read from frame files
+    # Read from frame files
     data_reading_group.add_argument("--frame-files",
                             type=str, nargs="+",
                             help="list of frame files")
-
-    #Read from hdf store file
+    # Read from hdf store file
     data_reading_group.add_argument("--hdf-store",
                             type=str,
                             help="Store of time series data in hdf format")
-
-    #Use datafind to get frame files
+    # Use datafind to get frame files
     data_reading_group.add_argument("--frame-type",
                             type=str,
                             help="(optional), replaces frame-files. Use datafind "
                                  "to get the needed frame file(s) of this type.")
-
-    #Filter frame files by URL
+    # Filter frame files by URL
     data_reading_group.add_argument("--frame-sieve",
                             type=str,
                             help="(optional), Only use frame files where the "
                                  "URL matches the regular expression given.")
 
-    #Generate gaussian noise with given psd
+    # Generate gaussian noise with given psd
     data_reading_group.add_argument("--fake-strain",
                 help="Name of model PSD for generating fake gaussian noise.",
                      choices=pycbc.psd.get_lalsim_psd_list() + ['zeroNoise'])
@@ -529,33 +520,29 @@ def insert_strain_option_group(parser, gps_times=True):
     data_reading_group.add_argument("--fake-strain-from-file",
                 help="File containing ASD for generating fake noise from it.")
 
-    #optional
+    # Injection options
     data_reading_group.add_argument("--injection-file", type=str,
                       help="(optional) Injection file used to add "
                            "waveforms into the strain")
-
     data_reading_group.add_argument("--sgburst-injection-file", type=str,
                       help="(optional) Injection file used to add "
                       "sine-Gaussian burst waveforms into the strain")
-
     data_reading_group.add_argument("--injection-scale-factor", type=float,
                     default=1, help="Divide injections by this factor "
                     "before injecting into the data.")
-
     data_reading_group.add_argument('--injection-f-ref', type=float,
                                     help='Reference frequency in Hz for '
                                          'creating CBC injections from an XML '
                                          'file.')
-
     data_reading_group.add_argument('--injection-f-final', type=float,
                                     help='Override the f_final field of a CBC '
                                          'XML injection file.')
 
+    # Gating options
     data_reading_group.add_argument("--gating-file", type=str,
                     help="(optional) Text file of gating segments to apply."
                         " Format of each line is (all times in secs):"
                         "  gps_time zeros_half_width pad_half_width")
-
     data_reading_group.add_argument('--autogating-threshold', type=float,
                                     metavar='SIGMA',
                                     help='If given, find and gate glitches '
@@ -583,30 +570,27 @@ def insert_strain_option_group(parser, gps_times=True):
                                     help='Ignore the given length of whitened '
                                          'strain at the ends of a segment, to '
                                          'avoid filters ringing.')
-
+    # Optional
     data_reading_group.add_argument("--normalize-strain", type=float,
                     help="(optional) Divide frame data by constant.")
-
     data_reading_group.add_argument("--zpk-z", type=float, nargs="+",
                     help="(optional) Zero-pole-gain (zpk) filter strain. "
-                        "A list of zeros for transfer function")
-
+                         "A list of zeros for transfer function")
     data_reading_group.add_argument("--zpk-p", type=float, nargs="+",
                     help="(optional) Zero-pole-gain (zpk) filter strain. "
-                        "A list of poles for transfer function")
-
+                         "A list of poles for transfer function")
     data_reading_group.add_argument("--zpk-k", type=float,
                     help="(optional) Zero-pole-gain (zpk) filter strain. "
-                        "Transfer function gain")
+                         "Transfer function gain")
 
     # Options to apply to subtract noise from a witness channel and known
     # transfer function.
     data_reading_group.add_argument("--witness-frame-type", type=str,
                     help="(optional), frame type which will be use to query the"
-                         "witness channel data.")
+                         " witness channel data.")
     data_reading_group.add_argument("--witness-tf-file", type=str,
                     help="an hdf file containing the transfer"
-                         "  functions and the associated channel names")
+                         " functions and the associated channel names")
     data_reading_group.add_argument("--witness-filter-length", type=float,
                     help="filter length in seconds for the transfer function")
 
@@ -647,6 +631,7 @@ def insert_strain_option_group_multi_ifo(parser, gps_times=True):
             "--gps-end-time", nargs='+', action=MultiDetOptionAction,
             metavar='IFO:TIME', type=int,
             help="The gps end time of the data (integer seconds)")
+
     data_reading_group_multi.add_argument("--strain-high-pass", nargs='+',
                             action=MultiDetOptionAction,
                             type=float, metavar='IFO:FREQUENCY',
@@ -671,24 +656,21 @@ def insert_strain_option_group_multi_ifo(parser, gps_times=True):
                             help="The channel containing the gravitational "
                                 "strain data")
 
-    #Read from cache file
+    # Read from cache file
     data_reading_group_multi.add_argument("--frame-cache", type=str, nargs="+",
                             action=MultiDetOptionAppendAction,
                             metavar='IFO:FRAME_CACHE',
                             help="Cache file containing the frame locations.")
-
-    #Read from frame files
+    # Read from frame files
     data_reading_group_multi.add_argument("--frame-files", type=str, nargs="+",
                             action=MultiDetOptionAppendAction,
                             metavar='IFO:FRAME_FILES',
                             help="list of frame files")
-
-    #Read from hdf store file
+    # Read from hdf store file
     data_reading_group_multi.add_argument("--hdf-store", type=str, nargs='+',
                             action=MultiDetOptionAction,
                             metavar='IFO:HDF_STORE_FILE',
                             help="Store of time series data in hdf format")
-
     # Use datafind to get frame files
     data_reading_group_multi.add_argument("--frame-type", type=str, nargs="+",
                                     action=MultiDetOptionAction,
@@ -696,15 +678,13 @@ def insert_strain_option_group_multi_ifo(parser, gps_times=True):
                                     help="(optional) Replaces frame-files. "
                                          "Use datafind to get the needed frame "
                                          "file(s) of this type.")
-
-    #Filter frame files by URL
+    # Filter frame files by URL
     data_reading_group_multi.add_argument("--frame-sieve", type=str, nargs="+",
                             action=MultiDetOptionAction,
                             metavar='IFO:FRAME_SIEVE',
                             help="(optional), Only use frame files where the "
                                  "URL matches the regular expression given.")
-
-    #Generate gaussian noise with given psd
+    # Generate gaussian noise with given psd
     data_reading_group_multi.add_argument("--fake-strain", type=str, nargs="+",
                             action=MultiDetOptionAction, metavar='IFO:CHOICE',
                             help="Name of model PSD for generating fake "
@@ -720,32 +700,30 @@ def insert_strain_option_group_multi_ifo(parser, gps_times=True):
                             help="File containing ASD for generating fake "
                             "noise from it.")
 
-    #optional
+    # Injection options
     data_reading_group_multi.add_argument("--injection-file", type=str,
                             nargs="+", action=MultiDetOptionAction,
                             metavar='IFO:FILE',
                             help="(optional) Injection file used to add "
                             "waveforms into the strain")
-
     data_reading_group_multi.add_argument("--sgburst-injection-file", type=str,
                       nargs="+", action=MultiDetOptionAction,
                       metavar='IFO:FILE',
                       help="(optional) Injection file used to add "
                       "sine-Gaussian burst waveforms into the strain")
-
     data_reading_group_multi.add_argument("--injection-scale-factor",
                     type=float, nargs="+", action=MultiDetOptionAction,
                     metavar="IFO:VAL", default=1.,
                     help="Multiple injections by this factor "
                          "before injecting into the data.")
 
+    # Gating options
     data_reading_group_multi.add_argument("--gating-file", type=str,
                       nargs="+", action=MultiDetOptionAction,
                       metavar='IFO:FILE',
                       help="(optional) Text file of gating segments to apply."
                           " Format of each line is (all times in secs):"
-                          "  gps_time zeros_half_width pad_half_width")
-
+                          "  gps_time zeros_half_width pad_half_width"
     data_reading_group_multi.add_argument('--autogating-threshold', type=float,
                                     nargs="+", action=MultiDetOptionAction,
                                     metavar='IFO:SIGMA',
@@ -779,23 +757,21 @@ def insert_strain_option_group_multi_ifo(parser, gps_times=True):
                                          'strain at the ends of a segment, to '
                                          'avoid filters ringing.')
 
+    # Optional
     data_reading_group_multi.add_argument("--normalize-strain", type=float,
                      nargs="+", action=MultiDetOptionAction,
                      metavar='IFO:VALUE',
                      help="(optional) Divide frame data by constant.")
-
     data_reading_group_multi.add_argument("--zpk-z", type=float,
                      nargs="+", action=MultiDetOptionAppendAction,
                      metavar='IFO:VALUE',
                      help="(optional) Zero-pole-gain (zpk) filter strain. "
                          "A list of zeros for transfer function")
-
     data_reading_group_multi.add_argument("--zpk-p", type=float,
                      nargs="+", action=MultiDetOptionAppendAction,
                      metavar='IFO:VALUE',
                      help="(optional) Zero-pole-gain (zpk) filter strain. "
                          "A list of poles for transfer function")
-
     data_reading_group_multi.add_argument("--zpk-k", type=float,
                      nargs="+", action=MultiDetOptionAppendAction,
                      metavar='IFO:VALUE',
@@ -803,7 +779,6 @@ def insert_strain_option_group_multi_ifo(parser, gps_times=True):
                          "Transfer function gain")
 
     return data_reading_group_multi
-
 
 ensure_one_opt_groups = []
 ensure_one_opt_groups.append(['--frame-cache','--fake-strain',
@@ -815,6 +790,7 @@ required_opts_list = ['--gps-start-time', '--gps-end-time',
                       '--strain-high-pass', '--pad-data', '--sample-rate',
                       '--channel-name']
 
+                                          
 def verify_strain_options(opts, parser):
     """Sanity check provided strain arguments.
 
@@ -835,6 +811,7 @@ def verify_strain_options(opts, parser):
         ensure_one_opt(opts, parser, opt_group)
     required_opts(opts, parser, required_opts_list)
 
+                                          
 def verify_strain_options_multi_ifo(opts, parser, ifos):
     """Sanity check provided strain arguments.
 
@@ -909,6 +886,7 @@ def gate_data(data, gate_params):
 
     return data
 
+                                          
 class StrainSegments(object):
     """ Class for managing manipulation of strain data for the purpose of
         matched filtering. This includes methods for segmenting and
@@ -1210,6 +1188,7 @@ class StrainSegments(object):
         for ifo in ifos:
             required_opts_multi_ifo(opt, parser, ifo, cls.required_opts_list)
 
+                                          
 class StrainBuffer(pycbc.frame.DataBuffer):
     def __init__(self, frame_src, channel_name, start_time,
                  max_buffer=512,


### PR DESCRIPTION
Addresses problems in issue #2979 

Perform down-sampling after injections - this means that the injections can be made up to the ring-down frequency in as many cases as possible

Note that in the zeroNoise case, the frequency is now hard-coded to 16384 for injection application, and it is then down-sampled. I don't see a way to avoid this, and it is returned to the sample rate that it would have been at a later point so should not make a significant difference