### PR TITLE
PyCBC Live: fix str/bytes error related to PTA files on Python 3

### DIFF
--- a/pycbc/events/coinc.py
+++ b/pycbc/events/coinc.py
@@ -762,17 +762,8 @@ class LiveCoincTimeslideBackgroundEstimator(object):
         self.num_templates = num_templates
         self.analysis_block = analysis_block
 
-        # Only pass a valid stat file for this ifo pair
-        for fname in stat_files:
-            f = h5py.File(fname, 'r')
-            ifos_set = set([f.attrs['ifo0'], f.attrs['ifo1']])
-            f.close()
-            if ifos_set == set(ifos):
-                stat_files = [fname]
-                logging.info('Setup ifos %s-%s with file %s and stat %s',
-                             ifos[0], ifos[1], fname, background_statistic)
-
-        self.stat_calculator = stat.get_statistic(background_statistic)(stat_files)
+        stat_class = stat.get_statistic(background_statistic)
+        self.stat_calculator = stat_class(stat_files, ifos)
 
         self.timeslide_interval = timeslide_interval
         self.return_background = return_background

--- a/pycbc/events/coinc.py
+++ b/pycbc/events/coinc.py
@@ -25,7 +25,7 @@
 coincident triggers.
 """
 
-import h5py, numpy, logging, pycbc.pnutils, copy, lal
+import numpy, logging, pycbc.pnutils, copy, lal
 from pycbc.detector import Detector
 
 

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -380,8 +380,6 @@ class PhaseTDNewStatistic(NewSNRStatistic):
         # does not require ifos to be specified, only 1 p/t/a file
         if self.hist is None:
             self.get_hist()
-        else:
-            logging.info("Using pre-set signal histogram")
 
         # figure out which ifo has the smallest SNR of the contributing ifos
         # Store a list 'rtypes' by ifo of which triggers that reference ifo
@@ -577,8 +575,6 @@ class PhaseTDStatistic(NewSNRStatistic):
         # does not require ifos to be specified, only 1 p/t/a file
         if self.hist is None:
             self.get_hist()
-        else:
-            logging.info("Using pre-set signal histogram")
 
         # for 2-ifo pipeline, add time shift to 2nd ifo ('s1')
         slidevec = [0, 1]


### PR DESCRIPTION
Fixes #2983. Requires a change in the PTA histogram files such that their `stat` attribute lists the detectors to which they apply.