### PR TITLE
Switch throughput templates-per-core to show harmonic mean

### DIFF
--- a/bin/hdfcoinc/pycbc_plot_throughput
+++ b/bin/hdfcoinc/pycbc_plot_throughput
@@ -8,6 +8,7 @@ import matplotlib; matplotlib.use('Agg')
 import pylab as pl
 from pycbc.results.color import ifo_color
 import pycbc.version
+from scipy.stats import hmean
 
 parser = argparse.ArgumentParser(description=__doc__)
 parser.add_argument("--version", action="version",
@@ -37,7 +38,7 @@ for pa in args.input_file:
     else:
         stf = None
     if tpc is not None:
-        label = str(ifo) + ': Mean average - ' + str(tpc.mean())
+        label = str(ifo) + ': Harmonic mean - ' + str(hmean(tpc))
         ax1.hist(tpc, 100, color=ifo_color(ifo), alpha = 0.65, label = label)
         #ax1.set_title('Templates per Core')
         ax1.set_xlabel('Templates per Core')


### PR DESCRIPTION
This PR changes the summary in the throughput legend to show the harmonic mean of the templates per core for each IFO, rather than the arithmetic mean.  In general, for this measure of performance, the harmonic mean is more useful, as it better predicts the overall computing usage (estimated as the product of the total detector livetime and the number of templates in the bank, and then divided by the "average" templates per core). However, the difference has become much more pronounced in O3 for injection runs, now that we are sorting the bank by mchirp, as the injection rejector setting can cause some of the inspiral jobs to be very quick, and the mean templates per core can be more than an order of magnitude larger than the harmonic mean.