### PR TITLE
PyCBC Live: fix errors from SNR optimization in Python 3

### DIFF
--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -271,30 +271,30 @@ class LiveEventManager(object):
                 cmd += psd_fils_str
 
                 curr_fname = fname.replace('.xml.gz', '_attributes.hdf')
-                hdfp = h5py.File(curr_fname, 'w')
-                for ifo in coinc_ifos:
-                    curr_time = \
-                        coinc_results['foreground/{}/end_time'.format(ifo)]
-                    hdfp['coinc_times/{}'.format(ifo)] = curr_time
-                f_end = bank.end_frequency(template_id)
-                if f_end is None or f_end >= (flen * delta_f):
-                    f_end = (flen-1) * delta_f
-                hdfp['flen'] = flen
-                hdfp['delta_f'] = delta_f
-                hdfp['f_end'] = f_end
-                hdfp['sample_rate'] = bank.sample_rate
-                hdfp['flow'] = bank.table[template_id].f_lower
-                hdfp['mass1'] = bank.table[template_id].mass1
-                hdfp['mass2'] = bank.table[template_id].mass2
-                hdfp['spin1z'] = bank.table[template_id].spin1z
-                hdfp['spin2z'] = bank.table[template_id].spin2z
-                hdfp['template_duration'] = \
-                    bank.table[template_id].template_duration
-                hdfp['ifar'] = ifar
-                hdfp['gid'] = gid
-                for ifo in args.channel_name:
-                    hdfp['channel_names/{}'.format(ifo)] = \
-                        args.channel_name[ifo]
+                with h5py.File(curr_fname, 'w') as hdfp:
+                    for ifo in coinc_ifos:
+                        curr_time = \
+                            coinc_results['foreground/{}/end_time'.format(ifo)]
+                        hdfp['coinc_times/{}'.format(ifo)] = curr_time
+                    f_end = bank.end_frequency(template_id)
+                    if f_end is None or f_end >= (flen * delta_f):
+                        f_end = (flen-1) * delta_f
+                    hdfp['flen'] = flen
+                    hdfp['delta_f'] = delta_f
+                    hdfp['f_end'] = f_end
+                    hdfp['sample_rate'] = bank.sample_rate
+                    hdfp['flow'] = bank.table[template_id].f_lower
+                    hdfp['mass1'] = bank.table[template_id].mass1
+                    hdfp['mass2'] = bank.table[template_id].mass2
+                    hdfp['spin1z'] = bank.table[template_id].spin1z
+                    hdfp['spin2z'] = bank.table[template_id].spin2z
+                    hdfp['template_duration'] = \
+                        bank.table[template_id].template_duration
+                    hdfp['ifar'] = ifar
+                    hdfp['gid'] = gid
+                    for ifo in args.channel_name:
+                        hdfp['channel_names/{}'.format(ifo)] = \
+                            args.channel_name[ifo]
 
                 cmd += '--params-file {} '.format(curr_fname)
                 cmd += '--approximant {} '.format(apr)

--- a/bin/pycbc_optimize_snr
+++ b/bin/pycbc_optimize_snr
@@ -250,7 +250,7 @@ for ifo in ifos:
     snr_slice = snr_series_dict[ifo].time_slice(time_window[0], time_window[1])
     max_snr_idx = numpy.argmax(abs(snr_slice))
     idx_offset = snr_slice.start_time - snr_series_dict[ifo].start_time
-    idx_offset = int(idx_offset * sample_rate + 0.5)
+    idx_offset = int(float(idx_offset) * sample_rate + 0.5)
     max_snr_idx = max_snr_idx + idx_offset
     new_snr_slice = slice(max_snr_idx - int(sample_rate/10),
                           max_snr_idx + int(sample_rate/10)+1)

--- a/bin/pycbc_optimize_snr
+++ b/bin/pycbc_optimize_snr
@@ -140,7 +140,7 @@ for ifo in args.data_files.keys():
     data[ifo].psd = load_frequencyseries(args.psd_files[ifo])
 
 fp = h5py.File(args.params_file, 'r')
-ifos = data.keys()
+ifos = list(data.keys())
 
 coinc_times = {}
 for ifo in ifos:

--- a/pycbc/io/live.py
+++ b/pycbc/io/live.py
@@ -105,7 +105,8 @@ class SingleCoincForGraceDB(object):
             Strain channel names for each detector.
             Will be recorded in the sngl_inspiral table.
         """
-        self.template_id = coinc_results['foreground/%s/template_id' % ifos[0]]
+        self.template_id = \
+                coinc_results['foreground/%s/template_id' % next(iter(ifos))]
         self.coinc_results = coinc_results
         self.ifos = ifos
 

--- a/pycbc/io/live.py
+++ b/pycbc/io/live.py
@@ -86,7 +86,7 @@ class SingleCoincForGraceDB(object):
         Parameters
         ----------
         ifos: list of strs
-            A list of the ifos pariticipating in this trigger
+            A list of the ifos participating in this trigger.
         coinc_results: dict of values
             A dictionary of values. The format is defined in
             pycbc/events/coinc.py and matches the on disk representation
@@ -105,8 +105,7 @@ class SingleCoincForGraceDB(object):
             Strain channel names for each detector.
             Will be recorded in the sngl_inspiral table.
         """
-        self.template_id = \
-                coinc_results['foreground/%s/template_id' % next(iter(ifos))]
+        self.template_id = coinc_results['foreground/%s/template_id' % ifos[0]]
         self.coinc_results = coinc_results
         self.ifos = ifos
 


### PR DESCRIPTION
Fix a few errors coming from the PyCBC Live SNR optimization code when running in Python 3.

* [HDF5 file being left open](https://stackoverflow.com/questions/26613570/hdf5-file-created-with-h5py-cant-be-opened-by-h5py)
* `LIGOTimeGPS` being multiplied by a float.
* Another case of `dict_keys` being indexed.