### PR TITLE
Fix HDF5 deprecation warning and ensure files are closed

### DIFF
--- a/pycbc/types/array.py
+++ b/pycbc/types/array.py
@@ -996,9 +996,9 @@ class Array(object):
                 _numpy.savetxt(path, output)
         elif ext == '.hdf':
             key = 'data' if group is None else group
-            f = h5py.File(path)
-            f.create_dataset(key, data=self.numpy(), compression='gzip',
-                             compression_opts=9, shuffle=True)
+            with h5py.File(path, 'w') as f:
+                f.create_dataset(key, data=self.numpy(), compression='gzip',
+                                 compression_opts=9, shuffle=True)
         else:
             raise ValueError('Path must end with .npy, .txt, or .hdf')
            

--- a/pycbc/types/frequencyseries.py
+++ b/pycbc/types/frequencyseries.py
@@ -424,13 +424,14 @@ class FrequencySeries(Array):
             psddict = {ifo: output}
             utils.write_filename(make_psd_xmldoc(psddict), path,
                                  gz=path.endswith(".gz"))
-        elif ext =='.hdf':
+        elif ext == '.hdf':
             key = 'data' if group is None else group
-            f = h5py.File(path)
-            ds = f.create_dataset(key, data=self.numpy(), compression='gzip',
-                                  compression_opts=9, shuffle=True)
-            ds.attrs['epoch'] = float(self.epoch)
-            ds.attrs['delta_f'] = float(self.delta_f)
+            with h5py.File(path, 'w') as f:
+                ds = f.create_dataset(key, data=self.numpy(),
+                                      compression='gzip',
+                                      compression_opts=9, shuffle=True)
+                ds.attrs['epoch'] = float(self.epoch)
+                ds.attrs['delta_f'] = float(self.delta_f)
         else:
             raise ValueError('Path must end with .npy, .txt, .xml, .xml.gz '
                              'or .hdf')

--- a/pycbc/types/timeseries.py
+++ b/pycbc/types/timeseries.py
@@ -757,11 +757,12 @@ class TimeSeries(Array):
             _numpy.savetxt(path, output)
         elif ext =='.hdf':
             key = 'data' if group is None else group
-            f = h5py.File(path)
-            ds = f.create_dataset(key, data=self.numpy(), compression='gzip',
-                                  compression_opts=9, shuffle=True)
-            ds.attrs['start_time'] = float(self.start_time)
-            ds.attrs['delta_t'] = float(self.delta_t)
+            with h5py.File(path, 'w') as f:
+                ds = f.create_dataset(key, data=self.numpy(),
+                                      compression='gzip',
+                                      compression_opts=9, shuffle=True)
+                ds.attrs['start_time'] = float(self.start_time)
+                ds.attrs['delta_t'] = float(self.delta_t)
         else:
             raise ValueError('Path must end with .npy, .txt or .hdf')
 


### PR DESCRIPTION
This patch gets rid of this (new?) warning from the `.save()` method of some types:
```
[...]frequencyseries.py:429: H5pyDeprecationWarning: The default file mode will change to 'r' (read-only) in h5py 3.0. To suppress this warning, pass the mode you need to h5py.File(), or set the global default h5.get_config().default_file_mode, or set the environment variable H5PY_DEFAULT_READONLY=1. Available modes are: 'r', 'r+', 'w', 'w-'/'x', 'a'. See the docs for details.
  f = h5py.File(path)
```
It also ensures HDF files are safely closed.