### PR TITLE
Formatting changes to page_coincinfo

### DIFF
--- a/bin/minifollowups/pycbc_page_coincinfo
+++ b/bin/minifollowups/pycbc_page_coincinfo
@@ -177,12 +177,15 @@ for ifo in files.keys():
     if args.include_summary_page_link:
         data[-1].append(pycbc.results.dq.get_summary_page_link(ifo, utc))
         headers.append("Detector&nbsp;status")
+    else:
+        data[-1].append(ifo)
+        headers.append("Ifo")
 
     # End times
     data[-1].append(str(datetime.datetime(*utc)))
     data[-1].append('%.3f' % time)
-    headers.append("UTC")
-    headers.append("End&nbsp;time")
+    headers.append("UTC&nbsp;End&nbsp;Time")
+    headers.append("GPS&nbsp;End&nbsp;time")
 
     # SNR and phase (not showing any single-det stat here)
     data[-1].append('%5.2f' % d['snr'][i])
@@ -199,7 +202,7 @@ for ifo in files.keys():
     headers.append("&chi;<sup>2</sup>&nbsp;bins")
     try:
         data[-1].append('%5.2f' % d['sg_chisq'][i])
-        headers.append("sg&chi;<sup>2</sup>")
+        headers.append("sg&nbsp;&chi;<sup>2</sup>")
     except:
         pass
     try:


### PR DESCRIPTION
This patch makes some improvements to the formatting of page_coincinfo. Most importantly it ensures that the IFO is listed in the case where no summary page links are given. This has been tested.

Fixes #2995