### PR TITLE
Add OSG tools to docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,11 +8,11 @@ ADD docker/etc/cvmfs/60-osg.conf /etc/cvmfs/60-osg.conf
 ADD docker/etc/cvmfs/config-osg.opensciencegrid.org.conf /etc/cvmfs/config-osg.opensciencegrid.org.conf
 
 # Set up extra repositories
-RUN rpm -ivh http://software.ligo.org/lscsoft/scientific/7/x86_64/production/l/lscsoft-production-config-1.3-1.el7.noarch.rpm && yum install -y https://centos7.iuscommunity.org/ius-release.rpm && yum install -y https://ecsft.cern.ch/dist/cvmfs/cvmfs-release/cvmfs-release-latest.noarch.rpm && yum install -y cvmfs cvmfs-config-default && yum clean all && yum makecache && \
+RUN rpm -ivh http://software.ligo.org/lscsoft/scientific/7/x86_64/production/l/lscsoft-production-config-1.3-1.el7.noarch.rpm && yum install -y https://centos7.iuscommunity.org/ius-release.rpm && yum install -y https://ecsft.cern.ch/dist/cvmfs/cvmfs-release/cvmfs-release-latest.noarch.rpm && yum install -y cvmfs cvmfs-config-default && yum -y install http://repo.opensciencegrid.org/osg/3.4/osg-3.4-el7-release-latest.rpm && yum clean all && yum makecache && \
     yum -y groupinstall "Compatibility Libraries" \
                         "Development Tools" \
                         "Scientific Support" && \
-    rpm -e --nodeps git perl-Git && yum -y install python2-pip python-setuptools zlib-devel libpng-devel libjpeg-devel libsqlite3-dev sqlite-devel db4-devel openssl-devel git2u-all fftw-libs-single fftw-devel fftw fftw-libs-long fftw-libs fftw-libs-double gsl gsl-devel libframe-utils libframe-devel libframe libmetaio libmetaio-devel libmetaio-utils hdf5 hdf5-devel python-devel which && pip install --upgrade pip setuptools && pip install mkl ipython jupyter
+    rpm -e --nodeps git perl-Git && yum -y install python2-pip python-setuptools zlib-devel libpng-devel libjpeg-devel libsqlite3-dev sqlite-devel db4-devel openssl-devel git2u-all fftw-libs-single fftw-devel fftw fftw-libs-long fftw-libs fftw-libs-double gsl gsl-devel libframe-utils libframe-devel libframe libmetaio libmetaio-devel libmetaio-utils hdf5 hdf5-devel python-devel which osg-wn-client osg-ca-certs && pip install --upgrade pip setuptools && pip install mkl ipython jupyter
 
 # set up environment
 RUN cd / && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,9 @@ RUN yum install -y libibverbs libibverbs-devel libibmad libibmad-devel libibumad
     pip install schwimmbad && \
     MPICC=/opt/mvapich2-2.1/bin CFLAGS='-I /opt/mvapich2-2.1/include -L /opt/mvapich2-2.1/lib -lmpi' pip install --no-cache-dir mpi4py
 
+# Now update all of our library installations
+RUN rm -f /etc/ld.so.cache && /sbin/ldconfig
+
 # When the container is started with
 #   docker run -it pycbc/pycbc-el7:latest
 # the default is to start a loging shell as the pycbc user.

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ RUN yum install -y libibverbs libibverbs-devel libibmad libibmad-devel libibumad
     cd / && rm -rf /tmp/mvapich2-2.1 && \
     pip install schwimmbad && \
     MPICC=/opt/mvapich2-2.1/bin CFLAGS='-I /opt/mvapich2-2.1/include -L /opt/mvapich2-2.1/lib -lmpi' pip install --no-cache-dir mpi4py
+RUN echo "/opt/mvapich2-2.1/lib" > /etc/ld.so.conf.d/mvaapich2-2.1.conf
 
 # Now update all of our library installations
 RUN rm -f /etc/ld.so.cache && /sbin/ldconfig

--- a/docker/.singularity.d/env/90-environment.sh
+++ b/docker/.singularity.d/env/90-environment.sh
@@ -5,13 +5,5 @@ if [ "x$LAL_DATA_PATH" == "x" ]; then
     export LAL_DATA_PATH="/cvmfs/oasis.opensciencegrid.org/ligo/sw/pycbc/lalsuite-extra/current/share/lalsimulation"
 fi
 
-# Add path to Intel MKL Libraries
-if [ "x$LD_LIBRARY_PATH" == "x" ]; then
-    LD_LIBRARY_PATH="/opt/intel/composer_xe_2015.0.090/mkl/lib/intel64:/opt/mvapich2-2.1/lib"
-else
-    LD_LIBRARY_PATH="/opt/intel/composer_xe_2015.0.090/mkl/lib/intel64:/opt/mvapich2-2.1/lib:${LD_LIBRARY_PATH}"
-fi
-export LD_LIBRARY_PATH
-
 PATH=${PATH}:/opt/mvapich2-2.1/bin
 export PATH

--- a/docker/etc/docker-install.sh
+++ b/docker/etc/docker-install.sh
@@ -13,4 +13,5 @@ rsync --exclude='SEOBNRv1ROM*' --exclude='SEOBNRv2ROM_DS_HI_v1.0.hdf5' --exclude
 umount /cvmfs/config-osg.opensciencegrid.org
 umount /cvmfs/oasis.opensciencegrid.org
 chown -R 1000:1000 /opt/pycbc/src /opt/pycbc/pycbc-software
+chmod -R u=rwX,g=rX,o=rX /opt/pycbc
 exit 0


### PR DESCRIPTION
The primary change introduced in this PR is to add the OSG repo to the Docker container, and then using that to additionally install the `osg-wn-client` and `osg-ca-certs` packages into the container. This in particular pulls in globus tools, so that the container can invoke `gfal-copy` without needing it to be present on the worker node via CVMFS or some other source. Since the worker node environments are by default present in container execution (so various directories under `/cvmfs` may have been added to `PATH`, `LD_LIBRARY_PATH`, `PYTHONPATH` and others), this new addition is intended to be invoked by adding the following three lines to the condor submit file for any OSG job desiring to ensure that the containerized versions of these tools are used:
```
+InitializeModulesEnv = False
+SingularityCleanEnv = True
getenv = False
```
Doing this will restrict the environment inside the Singularity container to contain only those variables defined by the `environment = ` line of the submit files, as well as some other, white-listed variables needed behind the scenes (such as `_CONDOR_<VARNAME>` variables, `X509_USER_PROXY`, and similar. The full white-list is in [these lines](https://github.com/opensciencegrid/osg-flock/blob/99428e261e538ae60b950a91cacf9ee55e3ea19a/job-wrappers/user-job-wrapper.sh#L371-L403)). 

If the lines above are _**not**_  added to the submit file, then the host node environment will continue to be propagated as before into the container, so users used to doing that should be able to run as before.

In addition to that primary change, this PR incorporates a few other improvements to the Docker and Singularity containers:
 1. We were [adding](https://github.com/gwastro/pycbc/blob/31de6c737ab88153b463c91c28aff2942700e259/docker/.singularity.d/env/90-environment.sh#L9-L14) `/opt/intel/composer_xe_2015.0.090/mkl/lib/intel64` to `LD_LIBRARY_PATH`, but that directory doesn't exist, and we instead now install `mkl` via `pip`. However we did [need to ensure](https://github.com/josh-willis/pycbc/commit/b978bb7c0085c1ca1145ef3894d99c3726f7f36b) that the container has run `ldconfig`, since `pip` didn't know to do that.
 1. In fact, there is also no reason to add the other directory to `LD_LIBRARY_PATH`. So [this commit](https://github.com/josh-willis/pycbc/commit/c7cce81bab259ca3ee65868e7161b73b375164a6) removes it, and adds the appropriate file to `/etc/ld.so.conf.d`. 
 1. Finally, I've [fixed the permissions](https://github.com/josh-willis/pycbc/commit/e6d8b69f1e9505c64d6097e885f84af3fdc9664f) on the `/opt/pycbc`directory in the container, since Singularity doesn't allow us to `su` to the `pycbc` user, and hence we could never access that directory.