### PR TITLE
qscans not working for fake data

### DIFF
--- a/bin/plotting/pycbc_plot_qscan
+++ b/bin/plotting/pycbc_plot_qscan
@@ -60,6 +60,8 @@ parser.add_argument('--time-windows', required=True, type=t_window,
                          'be provided as start1,end1 start2,end2 ... '
                          'where start/end times are relative to --center-time '
                          'and both positive')
+parser.add_argument("--low-frequency-cutoff", type=float,
+                    help="The low frequency cutoff to use for filtering (Hz)")
 
 parser.add_argument('--qtransform-delta-t', default=0.001, type=float,
                     help='The time resolution to interpolate to (optional)')

--- a/bin/plotting/pycbc_plot_qscan
+++ b/bin/plotting/pycbc_plot_qscan
@@ -61,7 +61,7 @@ parser.add_argument('--time-windows', required=True, type=t_window,
                          'where start/end times are relative to --center-time '
                          'and both positive')
 parser.add_argument("--low-frequency-cutoff", type=float,
-                    help="The low frequency cutoff to use for filtering (Hz)")
+                    help="The low frequency cutoff to use for fake strain generation")
 
 parser.add_argument('--qtransform-delta-t', default=0.001, type=float,
                     help='The time resolution to interpolate to (optional)')


### PR DESCRIPTION
This input argument is needed for creation of fake strain, but is not included when running `pycbc.strain.insert_strain_option_group(parser)`

The other place this strain creation/argument is used is in pycbc_inspiral, which uses the input argument in other places, hence why is is not in the stain module option group

This change does not affect normal running, but fixes for fake data