### PR TITLE
PyCBC Live: misc improvements

### DIFF
--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -562,16 +562,17 @@ pycbc.init_logging(args.verbose, format=log_format)
 ctx = scheme.from_cli(args)
 fft.from_cli(args)
 
-sr = args.sample_rate
-flow = args.low_frequency_cutoff
-
 # Approximant guess of the total padding
 valid_pad = args.analysis_chunk
 total_pad = args.trim_padding * 2 + valid_pad
-bank = waveform.LiveFilterBank(args.bank_file, sr, total_pad,
-                       low_frequency_cutoff=None if args.enable_bank_start_frequency else flow,
-                       approximant=args.approximant,
-                       increment=args.increment)
+lfc = None if args.enable_bank_start_frequency else args.low_frequency_cutoff
+bank = waveform.LiveFilterBank(
+        args.bank_file, args.sample_rate, total_pad, low_frequency_cutoff=lfc,
+        approximant=args.approximant, increment=args.increment)
+if bank.min_f_lower < args.low_frequency_cutoff:
+    parser.error('--low-frequency-cutoff ({} Hz) must not be larger than the '
+                 'minimum f_lower across all templates '
+                 '({} Hz)'.format(args.low_frequency_cutoff, bank.min_f_lower))
 
 evnt = LiveEventManager(args.output_path,
                         use_date_prefix=args.day_hour_output_prefix,

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -596,7 +596,9 @@ if evnt.rank == 0 and args.enable_gracedb_upload:
     logging.info('Testing access to GraceDB')
     from ligo.gracedb.rest import GraceDb
     gdb_client = GraceDb(args.gracedb_server) if args.gracedb_server else GraceDb()
-    gdb_client.ping()
+    response = gdb_client.ping()
+    logging.info('GraceDB ping response: %s %d',
+                 response.status, response.reason)
     del gdb_client
 
 # I'm not the root, so do some actual filtering.

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -597,7 +597,7 @@ if evnt.rank == 0 and args.enable_gracedb_upload:
     from ligo.gracedb.rest import GraceDb
     gdb_client = GraceDb(args.gracedb_server) if args.gracedb_server else GraceDb()
     response = gdb_client.ping()
-    logging.info('GraceDB ping response: %s %d',
+    logging.info('GraceDB ping response: %s %s',
                  response.status, response.reason)
     del gdb_client
 

--- a/pycbc/frame/frame.py
+++ b/pycbc/frame/frame.py
@@ -617,7 +617,7 @@ class DataBuffer(object):
             name = '%s/%s-%s-%s.gwf' % (pattern, self.beg, s, self.dur)
             # check that file actually exists, else abort now
             if not os.path.exists(name):
-                logging.info("%s does not seem to exist yet" % name)
+                logging.info("%s not found yet", os.path.basename(name))
                 raise RuntimeError
 
             keys.append(name)

--- a/pycbc/io/live.py
+++ b/pycbc/io/live.py
@@ -299,7 +299,7 @@ class SingleCoincForGraceDB(object):
             psd_series_plot_fname = snr_series_fname.replace('.hdf',
                                                              '_psd.png')
             pylab.figure()
-            for ifo in self.snr_series:
+            for ifo in sorted(self.snr_series):
                 curr_snrs = self.snr_series[ifo]
                 curr_snrs.save(snr_series_fname, group='%s/snr' % ifo)
                 pylab.plot(curr_snrs.sample_times, abs(curr_snrs),
@@ -318,7 +318,7 @@ class SingleCoincForGraceDB(object):
             pylab.close()
 
             pylab.figure()
-            for ifo in self.snr_series:
+            for ifo in sorted(self.snr_series):
                 # Undo dynamic range factor
                 curr_psd = self.psds[ifo].astype(numpy.float64)
                 curr_psd /= pycbc.DYN_RANGE_FAC ** 2.0
@@ -327,8 +327,8 @@ class SingleCoincForGraceDB(object):
                 pylab.loglog(curr_psd.sample_frequencies[1:],
                              curr_psd[1:]**0.5, c=ifo_color(ifo), label=ifo)
             pylab.legend()
-            pylab.xlim([20, 2000])
-            pylab.ylim([1E-24, 1E-21])
+            pylab.xlim([10, 1300])
+            pylab.ylim([3E-24, 1E-20])
             pylab.xlabel('Frequency (Hz)')
             pylab.ylabel('ASD')
             pylab.savefig(psd_series_plot_fname)


### PR DESCRIPTION
* Make sure the low-frequency cutoff used to make the PSD is ok for all templates (fixes #2713).
* Improve followup plots in GraceDB (sort detectors alphabetically, show more PSD).
* Show GraceDB ping response when testing access.
* Shorten a very common log messange.