### PR TITLE
Swap out Singularity for PyInstaller bundles in search workflow docs

### DIFF
--- a/docs/workflow/pycbc_make_coinc_search_workflow.rst
+++ b/docs/workflow/pycbc_make_coinc_search_workflow.rst
@@ -897,9 +897,7 @@ Prerequisites
 
 There are a number of requirements on the machine on which the workflow will be started:
 
-- Pegasus version 4.7.1 or later.
-
-- The bundled executables available on the submit machine
+- Pegasus version 4.7.1 or later (at least 4.9.2 recommended).
 
 - A gridftp server running on the submit machine
 
@@ -911,60 +909,53 @@ There are a number of requirements on the machine on which the workflow will be 
 Configuring the workflow
 ------------------------
 
-.. note::
+These instructions are for the case where you plan to run all ``pycbc_inspiral`` jobs
+on the Open Science Grid, but the rest of the workflow will run on the local HTCondor pool
+attached to the submit machine.  For many clusters, including LDG clusters,
+running in this fashion may not be available from every submit machine. First,
+check with local sysadmins or other experts if there is a particular node from which
+you must plan and submit your workflow if you desire to run on the OSG.
 
-    Standard PyCBC installs build a version of ``pycbc_inspiral`` that uses weave
-    to compile code at runtime. Many OSG machines do not have all of the
-    compiler tools required to support weave compilation. In order to run on
-    the OSG, the ``pycbc_inspiral`` executable must be built as a PyInstaller
-    bundle that contains all of the weave-compiled code inside the bundle.
-    This bundle must be built on a lowest-common denominator platform so that
-    the shared libraries that it needs at runtime (e.g. glibc) are available.
-    RHEL6 (or a similar derivative) is a suitable platform. The ``/cvmfs``
-    filesystem contains ``pycbc_inspiral`` bundles that are built on the
-    ``x86_64_rhel_6`` platform and are suitable for use on the OSG. For
-    instructions on how to build PyInstaller bundled executables, see the page :ref:`building_bundled_executables`.
-
-
-In order for ``pycbc_inspiral`` to be sent to worker nodes it must be
-available via a remote protocol, either http, gsiftp, or CVMFS. Releases of
-pycbc are installed in CVMFS and the LDG head nodes run a gridftp server that
-can serve your own development copy.  Specify this path when you run
-``pycbc_make_coinc_search_workflow``. To run from a released bundle in CVMFS 
-give the following argument to the ``--config-overrides`` option (changing the
-path to point to the release that you want to use)::
-
-    'executables:inspiral:/cvmfs/oasis.opensciencegrid.org/ligo/sw/pycbc/x86_64_rhel_6/bundle/v1.6.6/pycbc_inspiral'
-
-If you are running your own build of ``pycbc_inspiral``, you will need to give
-a path to a gsiftp URL and tell Pegasus that the executable is not installed
-on the OSG with the two ``--config-overrides`` options::
-
-    "executables:inspiral:gsiftp://server.hostname/path/to/pycbc_inspiral"
-    "pegasus_profile-inspiral:pycbc|installed:False"
-
-Make sure this executable is build following the instructions on the page :ref:`building_bundled_executables`.
-
-Some of the files generated during the workflow will need to be served via gridftp from the LDG
-head node from which you submit, however the gravitational wave frame data files are too large for this.
-They are available from CVMFS and other fall-back locations, however you will need to
-ensure that your datafind server returns these locations (it may not do so on an LDG head node,
-for example, if you use the default datafind server). If you have LIGO.org credentials, you should
-execute::
+The first step in such running is to ensure that your workflow knows where to find
+all of the data it needs. While some of the files generated during the workflow will need
+to be served via gridftp from your submission head node (as detailed below), the gravitational
+wave frame data files are too large for this. They are available from CVMFS and other
+fall-back locations, but you need to make sure that your datafind server returns these
+locations (it may not do so on an LDG head node, for example, if you use the default datafind
+server). If you have LIGO.org credentials, you should execute::
 
     export LIGO_DATAFIND_SERVER="datafind.ligo.org"
 
-before you run ``pycbc_make_coinc_search_workflow``. Otherwise, contact your local system administrator for
-a valid datafind server that points to publicly available frame files.
+before you run ``pycbc_make_coinc_search_workflow``. Otherwise, contact your local system
+administrator for a valid datafind server that points to publicly available frame files.
 
-Add the following to the list of ``--config-overrides`` when running ``pycbc_make_coinc_search_workflow`` to tell Pegasus to run the inspiral code on the OSG::
-     
-    "pegasus_profile-inspiral:pycbc|site:osg"
-    "pegasus_profile-inspiral:hints|execution.site:osg"
-    "pegasus_profile-inspiral:pycbc|installed:False"
-    "inspiral:fixed-weave-cache"
+In order to run ``pycbc_inspiral`` on OSG worker nodes, it must be available
+in a Singularity container served from CVMFS. Releases of PyCBC build such containers
+and publish them to CVMFS, but the workflow needs to be told to only run on nodes that
+have Singularity available, and it needs the location of the ``pycbc_inspiral`` executable
+inside of the Singularity image. To do this, add the following to the ``--config-overrides``
+given to ``pycbc_make_coinc_search_workflow``::
 
-You also need a ``--config-overrides`` to ``pycbc_make_coinc_search_workflow`` that sets the staging site for the main workflow to the local site. To do this, add the following argument, replacing ``${WORKFLOW_NAME}`` with the string that is given as the argument to the option ``--workflow-name``::
+  "pegasus_profile-inspiral:pycbc|site:osg" \
+  "pegasus_profile-inspiral:hints|execution.site:osg" \
+  "pegasus_profile-inspiral:condor|Requirements:(HAS_SINGULARITY =?= TRUE) && (IS_GLIDEIN =?= True)" \
+  "executables:inspiral:/bin/pycbc_inspiral" \
+
+These lines tell ``pycbc_make_coinc_search_workflow`` that the inspiral jobs will
+run on the Open Science Grid, and that such jobs need to run at sites where Singularity
+is installed. They also tell them that the path to ``pycbc_inspiral`` inside the container
+is ``/bin/pycbc_inspiral``. If you are an LVK user, and you will be accessing non-public
+LVK data, then you additionally must specify that you need to run at nodes where this
+authenticated frame data is available.  To do that, change the ``Requirements`` line above
+to read instead::
+
+  "pegasus_profile-inspiral:condor|Requirements:(HAS_SINGULARITY =?= TRUE) && (HAS_LIGO_FRAMES =?= True) && (IS_GLIDEIN =?= True)" \
+
+Because the data that the inspiral jobs will need in addition to the frame files must
+come from the submit machine, you also need a ``--config-overrides`` argument to
+``pycbc_make_coinc_search_workflow`` that sets the staging site for the main workflow to be
+the local site. To do this, add the following argument, replacing ``${WORKFLOW_NAME}`` with
+the string that is given as the argument to the option ``--workflow-name``::
 
     "workflow-${WORKFLOW_NAME}-main:staging-site:osg=local"
 
@@ -990,61 +981,75 @@ follwing lines to your ``executables.ini`` file::
 Running the workflow
 --------------------
 
-Add the following additional arguments to ``pycbc_submit_dax``::
+Once you have planned the workflow as above, you must also modify the submission of the
+workflow if it is to run successfully on the OSG.  Add the following additional
+arguments to ``pycbc_submit_dax``::
 
     --no-create-proxy \
     --execution-sites osg \
     --append-pegasus-property 'pegasus.transfer.bypass.input.staging=true' \
     --local-staging-server gsiftp://`hostname -f` \
+    --remote-staging-server gsiftp://`hostname -f` \
 
-``hostname -f`` will give the correct value if there is a gsiftp server running on the submit machine.  If not, change this as needed. The remote-staging-site is the intermediary computer than can pass files between the submitting computer and the computers doing the work.  ``hostname -f`` returns the full name of the computer. The full name of the computer that ``hostname -f`` has to be one that is accessible to both the submit machine and the workers. The ``--no-create-proxy`` may be omitted if you have LIGO.org credentials and will be
-retrieving data from authenticated locations in CVMFS.
+``hostname -f`` will give the correct value if there is a gsiftp server running on the
+submit machine.  If not, change this as needed. The ``remote-staging-server`` is the
+intermediary computer than can pass files between the submitting computer and the computers
+doing the work.  ``hostname -f`` returns the full name of the computer. This full name has
+to be one that is accessible to both the submit machine and the workers. The ``--no-create-proxy``
+may be omitted if you have LIGO.org credentials and will be retrieving data from authenticated
+locations in CVMFS.
 
-You will also need to specify where the code should get the data needed to generate reduced order model waveforms. To do this add the following additional arguments to ``pycbc_submit_dax``::
+You will also need to specify where the code should get the data needed to generate reduced
+order model waveforms. To do this add the following additional arguments to ``pycbc_submit_dax``::
 
     --append-site-profile 'local:env|LAL_DATA_PATH:/cvmfs/oasis.opensciencegrid.org/ligo/sw/pycbc/lalsuite-extra/current/share/lalsimulation' \
     --append-site-profile 'osg:env|LAL_DATA_PATH:/cvmfs/oasis.opensciencegrid.org/ligo/sw/pycbc/lalsuite-extra/current/share/lalsimulation' \
 
-Here, ``current`` is a symbolic link to the latest version of the data and can be replaced with a specific release (e.g.  ``e02dab8c``) if required.
+Here, ``current`` is a symbolic link to the latest version of the data and can be replaced with a
+specific release (e.g. ``e02dab8c``) if required.
 
-If you are using the PyInstaller bundled executable, you will need to give ``pycbc_submit_dax`` the additional argument::
+It is also through arguments to ``pycbc_submit_dax`` that the workflow is made aware of which
+Singularity image to use when running ``pycbc_inspiral``. This is done by including the following
+argument to ``pycbc_submit_dax``::
 
-    --append-site-profile 'osg:env|NO_TMPDIR:1' \
+    --append-site-profile "osg:condor|+SingularityImage:\"/cvmfs/singularity.opensciencegrid.org/pycbc/pycbc-el7:latest\"" \
 
-The set of arguments above will allow ``pycbc_inspiral`` to run on any OSG machine to which you have access, as well as
-the local compute cluster. If you do not want your jobs to run on the local cluster, but only on shared resources, then add
-the argument::
+The precise line above will cause ``pycbc_inspiral`` to run using the code in the latest version of PyCBC
+as found on the ``master`` branch. You may well prefer a specific version (for example, for a production
+run) and each release will also have a corresponding Singularity image published to CVMFS.  For example,
+to use the ``1.14.3`` release of PyCBC, use instead the line::
 
-    --append-site-profile 'osg:condor|Requirements:IS_GLIDEIN=?=True' \
+    --append-site-profile "osg:condor|+SingularityImage:\"/cvmfs/singularity.opensciencegrid.org/pycbc/pycbc-el7:v1.14.3\"" \
 
-to ``pycbc_submit_dax``. If, in addition, you would like to run on an XSEDE resource on which you have an allocation, then
-add the argument::
+You may also direct the workflow to use a Singularity image of your own, if that has been published to CVMFS.
+
+When running on the OSG under Singularity, by default much of the environment of the host node where the
+job runs will be inherited inside the container.  In many cases this is desired, as some of the file-transfer
+tools that Pegasus requires can come from that environment. In other cases, however, that environment may
+interfere with what is in the container, and from release 1.14.3 onwards, the container itself includes
+any necessary file transfer tools. If you want to be sure that it is the tools installed inside the container
+that are used, then you must direct the workflow to have a clean environment inside the container, with nothing
+in it that you have not specified using lines of the form ``--append-site-profile 'osg:env|VARNAME:VALUE``
+(there will also be present in the environment a few other variables that are needed for proper running of
+Pegasus and HTCondor). To specify that you need your OSG jobs to run in a clean environment, also include
+the following lines when invoking ``pycbc_submit_dax``::
+
+    --append-site-profile "osg:condor|+InitializeModulesEnv:False" \
+    --append-site-profile "osg:condor|+SingularityCleanEnv:True" \
+    --append-site-profile "osg:condor|getenv:False" \
+
+In particular, it is recommended that LVK users run with the lines above.
+
+So far, we have described the arguments that  will allow ``pycbc_inspiral`` to run on any OSG machine to which
+you have access. If, in addition, you would like to run on an XSEDE resource on which you have an allocation,
+then add the argument::
 
     --append-site-profile 'osg:condor|+DESIRED_XSEDE_Sites:"Comet"' \
 
-where you replace the desired site (in this example the Comet cluster) with wherever you have an allocation. If you want to
-run **only** on that XSEDE cluster, then also add::
+where you replace the desired site (in this example the Comet cluster) with wherever you have an allocation. If
+you want to run **only** on that XSEDE cluster, then also add::
 
     --append-site-profile 'osg:condor|+DESIRED_SITES:"Comet"' \
 
-Summarizing, the following option will submit jobs to the local cluster, the Open Science Grid, and
-the specified XSEDE cluster::
-
-    --append-site-profile 'osg:condor|+DESIRED_XSEDE_Sites:"Comet"' \
-
-To submit to the XSEDE cluster and the OSG, but not the local cluster, use::
-
-    --append-site-profile 'osg:condor|+DESIRED_XSEDE_Sites:"Comet"' \
-    --append-site-profile 'osg:condor|Requirements:IS_GLIDEIN=?=True' \
-
-and to submit only to the specified XSEDE cluster, use::
-
-    --append-site-profile 'osg:condor|+DESIRED_XSEDE_Sites:"Comet"' \                                                                      
-    --append-site-profile 'osg:condor|Requirements:IS_GLIDEIN=?=True' \
-    --append-site-profile 'osg:condor|+DESIRED_SITES:"Comet"' \
-
-Of course, you must still give all of the other arguments necessary to ``pycbc_submit_dax``; both those other
-arguments needed to run on the Open Science Grid and specified in this section, and other standard arguments,
-such as specifying an LDG accounting group, if you will be running from an LDG cluster.
-
-Shared file system can not be used with OSG, so make sure that the ``--enable-shared-filesystem`` argument is not added to ``pycbc_submit_dax``.
+Shared file systems cannot be used with the OSG, so make sure that the ``--enable-shared-filesystem`` argument is
+not provided to ``pycbc_submit_dax`` when running on the OSG.


### PR DESCRIPTION
Per request, this MR updates the documentation for running PyCBC search workflows on the Open Science Grid.  All reference to PyInstaller bundles have now been removed (they have not existed for some time) and several other simplifications have been made. This PR also documents the arguments needed for `pycbc_submit_dax` to instruct the OSG wrapper script to start Singularity in a container with a clean environment.

The rendered version of these updated docs can be viewed [here](http://josh-willis.github.io/pycbc/latest/html/workflow/pycbc_make_coinc_search_workflow.html#running-on-the-open-science-grid).
