### PR TITLE
Add maximum SNR option for injection minifollowups

### DIFF
--- a/bin/minifollowups/pycbc_injection_minifollowup
+++ b/bin/minifollowups/pycbc_injection_minifollowup
@@ -122,7 +122,7 @@ try:
     if 'optimal_snr_1' in f['injections'].keys():  # 2-ifo pipeline case
         optimal_snr = [f['injections/optimal_snr_1'][:][missed],
                        f['injections/optimal_snr_2'][:][missed]]
-        # 'decisive' opt SNR is 2nd smallest
+        # 'decisive' opt SNR is 2nd largest
         dec_snr = numpy.minimum(optimal_snr[0], optimal_snr[1])
         if args.maximum_decisive_snr is not None:
             # By setting to 0, these injections will not be considered
@@ -132,9 +132,13 @@ try:
         optstrings = [os for os in f['injections'].keys() if \
                       os.startswith('optimal_snr_')]
         optimal_snr = [f['injections/%s' % os][:][missed] for os in optstrings]
-        # 2nd smallest opt SNR
-        dec_snr = [sorted(snrs)[1] for snrs in zip(*optimal_snr)]
-        sorting = numpy.array(dec_snr).argsort()
+        # 2nd largest opt SNR
+        dec_snr = [sorted(snrs)[-2] for snrs in zip(*optimal_snr)]
+        dec_snr = numpy.array(dec_snr)
+        if args.maximum_decisive_snr is not None:
+            # By setting to 0, these injections will not be considered
+            dec_snr[dec_snr > args.maximum_decisive_snr] = 0
+        sorting = dec_snr.argsort()
 
     sorting = sorting[::-1]  # descending order of dec opt SNR
 except KeyError:

--- a/bin/minifollowups/pycbc_injection_minifollowup
+++ b/bin/minifollowups/pycbc_injection_minifollowup
@@ -61,6 +61,9 @@ parser.add_argument('--inj-window', type=int, default=0.5,
 parser.add_argument('--ifar-threshold', type=float, default=None,
                     help="If given also followup injections with ifar smaller "
                          "than this threshold.")
+parser.add_argument('--maximum-decisive-snr', type=float, default=None,
+                    help="If given, only followup injections where the "
+                         "decisive SNR is smaller than this value.")
 parser.add_argument('--output-map')
 parser.add_argument('--output-file')
 parser.add_argument('--transformation-catalog')
@@ -121,6 +124,9 @@ try:
                        f['injections/optimal_snr_2'][:][missed]]
         # 'decisive' opt SNR is 2nd smallest
         dec_snr = numpy.minimum(optimal_snr[0], optimal_snr[1])
+        if args.maximum_decisive_snr is not None:
+            # By setting to 0, these injections will not be considered
+            dec_snr[dec_snr > args.maximum_decisive_snr] = 0
         sorting = dec_snr.argsort()
     else:
         optstrings = [os for os in f['injections'].keys() if \

--- a/bin/minifollowups/pycbc_injection_minifollowup
+++ b/bin/minifollowups/pycbc_injection_minifollowup
@@ -124,10 +124,6 @@ try:
                        f['injections/optimal_snr_2'][:][missed]]
         # 'decisive' opt SNR is 2nd largest
         dec_snr = numpy.minimum(optimal_snr[0], optimal_snr[1])
-        if args.maximum_decisive_snr is not None:
-            # By setting to 0, these injections will not be considered
-            dec_snr[dec_snr > args.maximum_decisive_snr] = 0
-        sorting = dec_snr.argsort()
     else:
         optstrings = [os for os in f['injections'].keys() if \
                       os.startswith('optimal_snr_')]
@@ -135,11 +131,11 @@ try:
         # 2nd largest opt SNR
         dec_snr = [sorted(snrs)[-2] for snrs in zip(*optimal_snr)]
         dec_snr = numpy.array(dec_snr)
-        if args.maximum_decisive_snr is not None:
-            # By setting to 0, these injections will not be considered
-            dec_snr[dec_snr > args.maximum_decisive_snr] = 0
-        sorting = dec_snr.argsort()
-
+    
+    if args.maximum_decisive_snr is not None:
+        # By setting to 0, these injections will not be considered
+        dec_snr[dec_snr > args.maximum_decisive_snr] = 0
+    sorting = dec_snr.argsort()
     sorting = sorting[::-1]  # descending order of dec opt SNR
 except KeyError:
     # Fall back to effective distance if optimal SNR not available


### PR DESCRIPTION
For some injection populations the search is tuned to miss the very loudest things (e.g. IMBH because of autogating, or loud BBHs in the focused BBH search). In this case I don't want to see injection minifollowups of things I have tuned my search to miss. I want to understand why the quieter stuff was missed.

This adds an option to set a maximum decisive SNR option to the injection minifollowup code. Any injection whose decisive SNR is larger than this will not be followed up.