### PR TITLE
Use append mode when saving arrays and time/frequency series to HDF

### DIFF
--- a/pycbc/types/array.py
+++ b/pycbc/types/array.py
@@ -996,7 +996,7 @@ class Array(object):
                 _numpy.savetxt(path, output)
         elif ext == '.hdf':
             key = 'data' if group is None else group
-            with h5py.File(path, 'w') as f:
+            with h5py.File(path, 'a') as f:
                 f.create_dataset(key, data=self.numpy(), compression='gzip',
                                  compression_opts=9, shuffle=True)
         else:

--- a/pycbc/types/frequencyseries.py
+++ b/pycbc/types/frequencyseries.py
@@ -426,7 +426,7 @@ class FrequencySeries(Array):
                                  gz=path.endswith(".gz"))
         elif ext == '.hdf':
             key = 'data' if group is None else group
-            with h5py.File(path, 'w') as f:
+            with h5py.File(path, 'a') as f:
                 ds = f.create_dataset(key, data=self.numpy(),
                                       compression='gzip',
                                       compression_opts=9, shuffle=True)

--- a/pycbc/types/timeseries.py
+++ b/pycbc/types/timeseries.py
@@ -757,7 +757,7 @@ class TimeSeries(Array):
             _numpy.savetxt(path, output)
         elif ext =='.hdf':
             key = 'data' if group is None else group
-            with h5py.File(path, 'w') as f:
+            with h5py.File(path, 'a') as f:
                 ds = f.create_dataset(key, data=self.numpy(),
                                       compression='gzip',
                                       compression_opts=9, shuffle=True)


### PR DESCRIPTION
#2994 causes PyCBC Live's trigger files to be wiped when the last PSD is written to them. This change fixes that by opening the HDF file in append mode (the old default in `h5py.File()`) rather than write mode.