### PR TITLE
Add mchirp_eta_to_mass1_mass2 to list of all transforms

### DIFF
--- a/pycbc/transforms.py
+++ b/pycbc/transforms.py
@@ -1885,6 +1885,7 @@ transforms = {
     CustomTransform.name : CustomTransform,
     MchirpQToMass1Mass2.name : MchirpQToMass1Mass2,
     Mass1Mass2ToMchirpQ.name : Mass1Mass2ToMchirpQ,
+    MchirpEtaToMass1Mass2.name : MchirpEtaToMass1Mass2,
     Mass1Mass2ToMchirpEta.name : Mass1Mass2ToMchirpEta,
     ChirpDistanceToDistance.name : ChirpDistanceToDistance,
     DistanceToChirpDistance.name : DistanceToChirpDistance,


### PR DESCRIPTION
Does what the title says, adds the existing `MchirpEtaToMass1Mass2` transform to the list of all transforms so that it can be used as a waveform transform.