### PR TITLE
only deploy python3.6 webpage to gh-pages, overwrite history

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -114,7 +114,7 @@ deploy:
   on:
     branch: master
     condition: $PYCBC_CONTAINER = build_and_test
-    python: 2.7
+    python: 3.6
 - provider: pypi
   user: $PYPI_USER
   password: $PYPI_TOKEN

--- a/.travis.yml
+++ b/.travis.yml
@@ -110,10 +110,11 @@ deploy:
   skip_cleanup: true
   github_token: $GITHUB_TOKEN
   local_dir: _gh-pages
-  keep-history: true
+  keep-history: false
   on:
     branch: master
     condition: $PYCBC_CONTAINER = build_and_test
+    python: 2.7
 - provider: pypi
   user: $PYPI_USER
   password: $PYPI_TOKEN

--- a/companion.txt
+++ b/companion.txt
@@ -4,4 +4,6 @@ gwpy>=0.8.1
 healpy
 # Needed for gracedb uploads
 ligo-gracedb
-
+# auxiliary samplers
+cpnest
+pymultinest

--- a/docs/Makefile.gh_pages
+++ b/docs/Makefile.gh_pages
@@ -5,7 +5,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    = -W
+SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = ../_gh-pages/latest

--- a/docs/_include/_dict_to_rst.py
+++ b/docs/_include/_dict_to_rst.py
@@ -59,12 +59,12 @@ def rst_dict_table(dict_, key_format=str, val_format=str, header=None,
     keys, values = zip(*dict_.items())
 
     # apply formatting
-    keys = map(key_format, keys)
-    values = map(val_format, values)
+    keys = list(map(key_format, keys))
+    values = list(map(val_format, values))
 
     # work out longest elements in each column
-    nckey = max(map(len, keys))
-    ncval = max(map(len, values))
+    nckey = max(list(map(len, keys)))
+    ncval = max(list(map(len, values)))
     if header:
         khead, vhead = header
         nckey = max(nckey, len(khead))
@@ -82,8 +82,10 @@ def rst_dict_table(dict_, key_format=str, val_format=str, header=None,
     if header:
         lines.extend((row(*header), divider))
     params = zip(keys, values)
+    
     if sort:
         params = sorted(params)
+        
     for key, val in params:
         fmt = '{{0:{0}s}}  {{1}}'.format(nckey, ncval)
         lines.append(fmt.format(key, val))

--- a/docs/_include/sampler_inheritance_diagrams.py
+++ b/docs/_include/sampler_inheritance_diagrams.py
@@ -15,7 +15,6 @@ tmplt = """.. _inheritance-{name}:
 
 """
 fp = open(fname, 'w')
-
 for sampler, cls in sorted(samplers.items()):
     out = tmplt.format(name=sampler, clsname=cls.__name__,
                        module=cls.__module__)


### PR DESCRIPTION
This should solve two issues we've had. Namely

1) Race condition between python3 and python2.7 pushing to gh-pages, prefer 2.7 one for now (both will still be built as part of testing, just not deployed).
2) Overwrite gh-pages history. This will keep the branch from blowing up to high diskspace requirements like we've seen in the past.