### PR TITLE
Update imports in pycbc_make_grb_summary_page

### DIFF
--- a/bin/pygrb/pycbc_make_grb_summary_page
+++ b/bin/pygrb/pycbc_make_grb_summary_page
@@ -22,16 +22,32 @@
 
 from __future__ import (division, print_function)
 
-import os, sys, re, glob, shutil
-from argparse import ArgumentParser
+import glob
+import os
 import random
+import shutil
 import string
-from pycbc.results.legacy_grb import *
-from pylal import git_version
+import sys
+from argparse import ArgumentParser
+
+from pycbc import version as pycbc_version
+from pycbc.results.legacy_grb import (
+    initialize_page,
+    write_antenna,
+    write_banner,
+    write_chisq,
+    write_exclusion_distances,
+    write_found_missed,
+    write_inj_snrs,
+    write_loudest_events,
+    write_offsource,
+    write_recovery,
+    write_summary,
+)
 
 __author__  = "Andrew Williamson <andrew.williamson@ligo.org>"
-__version__ = "git id %s" % git_version.id
-__date__    = git_version.date
+__version__ = pycbc_version.version
+__date__    = pycbc_version.date
 
 
 def parse_command_line():

--- a/tools/pycbc_test_suite.sh
+++ b/tools/pycbc_test_suite.sh
@@ -31,7 +31,7 @@ fi
 if [ "$PYCBC_TEST_TYPE" = "help" ] || [ -z ${PYCBC_TEST_TYPE+x} ]; then
     # check that all executables that do not require
     # special environments can return a help message
-    for prog in `find ${PATH//:/ } -maxdepth 1 -name 'pycbc*' -print 2>/dev/null | egrep -v '(pycbc_live_nagios_monitor|pycbc_make_grb_summary_page|pycbc_make_offline_grb_workflow|pycbc_mvsc_get_features|pycbc_upload_xml_to_gracedb)'`
+    for prog in `find ${PATH//:/ } -maxdepth 1 -name 'pycbc*' -print 2>/dev/null | egrep -v '(pycbc_live_nagios_monitor|pycbc_make_offline_grb_workflow|pycbc_mvsc_get_features|pycbc_upload_xml_to_gracedb)'`
     do
         echo -e ">> [`date`] running $prog --help"
         $prog --help &> $LOG_FILE


### PR DESCRIPTION
This PR fixes the imports block in `pycbc_make_grb_summary_page` by removing all unused imports, and replacing ` from blah import *` with named imports.

This script can now be tested as part of `pycbc_test_suite.sh`.