### PR TITLE
Several fixes to pycbc_optimal_snr

### DIFF
--- a/bin/pycbc_optimal_snr
+++ b/bin/pycbc_optimal_snr
@@ -46,13 +46,12 @@ class TimeIndependentPSD(object):
 
 class TimeVaryingPSD(object):
     def __init__(self, file_name, length=None, delta_f=None, f_low=None):
-        f = h5py.File(file_name, 'r')
-        self.file_name = file_name
-        detector = tuple(f.keys())[0]
-        self.start_times = f[detector + '/start_time'][:]
-        self.end_times = f[detector + '/end_time'][:]
-        self.file_f_low = f.attrs['low_frequency_cutoff']
-        f.close()
+        with h5py.File(file_name, 'r') as f:
+            self.file_name = file_name
+            detector = tuple(f.keys())[0]
+            self.start_times = f[detector + '/start_time'][:]
+            self.end_times = f[detector + '/end_time'][:]
+            self.file_f_low = f.attrs['low_frequency_cutoff']
         self._curr_psd = {}
         self._curr_psd_index = {}
         self.detector = detector

--- a/bin/pycbc_optimal_snr
+++ b/bin/pycbc_optimal_snr
@@ -240,7 +240,7 @@ if __name__ == '__main__':
     if opts.cores > 1:
         logging.info('Starting workers')
         pool = multiprocessing.Pool(processes=opts.cores)
-        iterator = pool.imap(compute_optimal_snr, inj_table)
+        iterator = pool.imap_unordered(compute_optimal_snr, inj_table)
     else:
         # do not bother spawning extra processes if running single-core
         iterator = (compute_optimal_snr(inj) for inj in inj_table)

--- a/bin/pycbc_optimal_snr
+++ b/bin/pycbc_optimal_snr
@@ -118,10 +118,10 @@ if __name__ == '__main__':
                         help='Data sample rate in Hz (default %(default)s)')
     parser.add_argument('--snr-columns', nargs='+', action=MultiDetOptionAction,
                         metavar='DETECTOR:COLUMN', required=True,
-                        help='Defines in which column of the sim_inspiral table' \
-                        ' the optimal SNR for each detector should be stored.' \
-                        ' COLUMN should be an existing sim_inspiral column with ' \
-                        ' no useful data in it, good candidates are usually' \
+                        help='Defines in which column of the sim_inspiral table'
+                        ' the optimal SNR for each detector should be stored.'
+                        ' COLUMN should be an existing sim_inspiral column with '
+                        ' no useful data in it, good candidates are usually'
                         ' alpha1, alpha2 etc.')
     parser.add_argument('--cores', default=1, type=int,
                         help='Parallelize the computation over the given '
@@ -188,7 +188,7 @@ if __name__ == '__main__':
         # leave 4 s of padding at the end for possible ringdown
         start_time = int(injection_time + 4. - seg_len)
         strain = TimeSeries(zeros(tlen, dtype=float32), delta_t=delta_t,
-                        epoch=start_time)
+                            epoch=start_time)
         injections.apply(strain, det, distance_scale=1./pycbc.DYN_RANGE_FAC,
                          simulation_ids=[simulation_id])
         return make_frequency_series(strain)
@@ -253,7 +253,7 @@ if __name__ == '__main__':
     llw_root = llw_doc.childNodes[0]
     llw_root.removeChild(injections.table)
     llw_root.appendChild(out_sim_inspiral)
-    ligolw_utils.write_filename\
-        (llw_doc, opts.out_file, gz=opts.out_file.endswith('gz'))
+    ligolw_utils.write_filename(llw_doc, opts.out_file,
+                                gz=opts.out_file.endswith('gz'))
 
     logging.info('Done')

--- a/bin/pycbc_optimal_snr
+++ b/bin/pycbc_optimal_snr
@@ -107,6 +107,12 @@ if __name__ == '__main__':
     parser.add_argument('--injection-f-final', type=float,
                         help='Override the f_final field of a CBC '
                              'XML injection file.')
+    parser.add_argument('--input-sort', type=str, choices=['random', 'time'],
+                        default='random',
+                        help='Sort injections by the given criterion before '
+                             'processing them. Sorting by time may speed up '
+                             'the calculation when the approximant is very '
+                             'fast and injections are tightly spaced in time')
     parser.add_argument('--output-file', '-o', dest='out_file', required=True,
                         help='Output LIGOLW file')
     parser.add_argument('--f-low', type=float, default=30.,
@@ -220,8 +226,13 @@ if __name__ == '__main__':
 
     logging.info("Loading injections")
     injections = pycbc.inject.InjectionSet.from_cli(opts)
-    np.random.seed(100)
-    inj_table = sorted(injections.table, key=lambda x: np.random.random())
+
+    if opts.input_sort == 'random':
+        np.random.seed(100)
+        sort_func = lambda x: np.random.random()
+    elif opts.input_sort == 'time':
+        sort_func = lambda x: x.geocent_end_time
+    inj_table = sorted(injections.table, key=sort_func)
 
     out_sim_inspiral = lsctables.New(lsctables.SimInspiralTable,
                                      columns=injections.table.columnnames)

--- a/bin/pycbc_optimal_snr
+++ b/bin/pycbc_optimal_snr
@@ -226,19 +226,24 @@ if __name__ == '__main__':
     out_sim_inspiral = lsctables.New(lsctables.SimInspiralTable,
                                      columns=injections.table.columnnames)
 
-    logging.info('Starting workers')
-    pool = multiprocessing.Pool(processes=opts.cores)
+    if opts.cores > 1:
+        logging.info('Starting workers')
+        pool = multiprocessing.Pool(processes=opts.cores)
+        iterator = pool.imap(compute_optimal_snr, inj_table)
+    else:
+        # do not bother spawning extra processes if running single-core
+        iterator = (compute_optimal_snr(inj) for inj in inj_table)
 
-    progress = lambda x, **kwargs: x
     if opts.progress:
         try:
-            from tqdm import tqdm as progress
+            from tqdm import tqdm
+
+            iterator = tqdm(iterator, total=len(inj_table))
         except ImportError:
             logging.warn('cannot import tqdm; not showing progress bar')
             pass
 
-    for inj in progress(pool.imap(compute_optimal_snr, inj_table),
-                        total=len(inj_table)):
+    for inj in iterator:
         out_sim_inspiral.append(inj)
 
     out_sim_inspiral.sort(key=lambda x: x.geocent_end_time)

--- a/bin/pycbc_optimal_snr
+++ b/bin/pycbc_optimal_snr
@@ -62,12 +62,11 @@ class TimeVaryingPSD(object):
     def __call__(self, time=None):
         mask = np.logical_and(self.start_times <= time,
                               self.end_times > time)
-        if np.count_nonzero(mask) >= 1:
-            center_times = (self.start_times[mask] + self.end_times[mask]) / 2.
-            closest_idx = np.argsort(abs(center_times - time))[0]
-            return self.get_psd(np.flatnonzero(mask)[closest_idx])
-        else:
+        if not mask.any():
             return None
+        center_times = (self.start_times[mask] + self.end_times[mask]) / 2.
+        closest_idx = np.argmin(abs(center_times - time))
+        return self.get_psd(np.flatnonzero(mask)[closest_idx])
 
     def get_psd(self, index):
         curr_pid = multiprocessing.current_process().pid

--- a/bin/pycbc_optimal_snr
+++ b/bin/pycbc_optimal_snr
@@ -158,7 +158,7 @@ if __name__ == '__main__':
     delta_t = 1. / sample_rate
     delta_f = 1. / seg_len
     tlen = int(seg_len * sample_rate)
-    flen = tlen / 2 + 1
+    flen = tlen // 2 + 1
     f_low = opts.f_low
 
     logging.info("Loading PSDs")

--- a/pycbc/inject/inject.py
+++ b/pycbc/inject/inject.py
@@ -485,21 +485,15 @@ class CBCHDFInjectionSet(_HDFInjectionSet):
         injections = self.table
         if simulation_ids:
             injections = injections[list(simulation_ids)]
-        for ii in range(injections.size):
-            inj = injections[ii]
-            if f_lower is None:
-                f_l = inj.f_lower
-            else:
-                f_l = f_lower
+        for ii, inj in enumerate(injections):
+            f_l = inj.f_lower if f_lower is None else f_lower
             # roughly estimate if the injection may overlap with the segment
             # Add 2s to end_time to account for ringdown and light-travel delay
             end_time = inj.tc + 2
-            inj_length = sim.SimInspiralTaylorLength(
-                strain.delta_t, inj.mass1 * lal.MSUN_SI,
-                inj.mass2 * lal.MSUN_SI, f_l, 0)
+            inj_length = tau0_from_mass1_mass2(inj.mass1, inj.mass2, f_l)
             # Start time is taken as twice approx waveform length with a 1s
             # safety buffer
-            start_time = inj.tc - 2 * (inj_length+1)
+            start_time = inj.tc - 2 * (inj_length + 1)
             if end_time < t0 or start_time > t1:
                 continue
             signal = self.make_strain_from_inj_object(inj, strain.delta_t,

--- a/pycbc/inject/inject.py
+++ b/pycbc/inject/inject.py
@@ -37,6 +37,7 @@ from pycbc.waveform import get_td_waveform, utils as wfutils
 from pycbc.waveform import ringdown_td_approximants
 from pycbc.types import float64, float32, TimeSeries
 from pycbc.detector import Detector
+from pycbc.conversions import tau0_from_mass1_mass2
 import pycbc.io
 
 from six import add_metaclass
@@ -174,12 +175,10 @@ class _XMLInjectionSet(object):
             # roughly estimate if the injection may overlap with the segment
             # Add 2s to end_time to account for ringdown and light-travel delay
             end_time = inj.get_time_geocent() + 2
-            inj_length = sim.SimInspiralTaylorLength(
-                strain.delta_t, inj.mass1 * lal.MSUN_SI,
-                inj.mass2 * lal.MSUN_SI, f_l, 0)
+            inj_length = tau0_from_mass1_mass2(inj.mass1, inj.mass2, f_l)
             # Start time is taken as twice approx waveform length with a 1s
             # safety buffer
-            start_time = inj.get_time_geocent() - 2 * (inj_length+1)
+            start_time = inj.get_time_geocent() - 2 * (inj_length + 1)
             if end_time < t0 or start_time > t1:
                 continue
             signal = self.make_strain_from_inj_object(inj, strain.delta_t,


### PR DESCRIPTION
Several little fixes to `pycbc_optimal_snr` prompted by the observation of a weird memory leak and subsequent digging into various scripts and functions.

* Add an option to choose the sorting of input injections. Sorting by time may help opening less PSD files, although it does not seem to matter much anyway.
* LALSimulation's `SimInspiralTaylorLength()` (used in the injection module) is much more complex than I thought. It does a numerical integration and seems to have a [memory leak](https://git.ligo.org/lscsoft/lalsuite/issues/224). Replace with a trivial call to `pycbc.conversions.tau0_from_mass1_mass2()`, which gives very close or systematically larger values.
* Avoid actually using multiprocessing when using a single core.
* Clean up code and fix an integer division.