### PR TITLE
Chirp vol

### DIFF
--- a/bin/hdfcoinc/pycbc_page_sensitivity
+++ b/bin/hdfcoinc/pycbc_page_sensitivity
@@ -42,8 +42,8 @@ parser.add_argument('--min-dist', type=float,
                     help="Lower y-axis limit for sensitive distance")
 parser.add_argument('--max-dist', type=float,
                     help="Upper y-axis limit for sensitive distance")
-parser.add_argument('--integration-method', choices=['pylal', 'shell', 'mc'],
-                    default='pylal',
+parser.add_argument('--integration-method', default='pylal',
+                    choices=['pylal', 'shell', 'mc', 'vchirp_mc'],
                     help="Sensitive volume estimation method. Default 'pylal'")
 parser.add_argument('--dist-bins', type=int, default=100,
                     help="Number of distance bins for 'pylal' volume "
@@ -292,15 +292,21 @@ for j in range(len(args.bins)-1):
             elif args.integration_method == 'pylal':
                 vol, vol_err = sensitivity.volume_binned_pylal(f_dist,
                                              m_dist_full, bins=args.dist_bins)
-            elif args.integration_method == 'mc':
+            elif args.integration_method in ['mc', 'vchirp_mc']:
                 found_mchirp = found['mchirp'][binf][loud]
                 missed_mchirp = numpy.append(missed['mchirp'][binm],
                                              found['mchirp'][binf][quiet])
 
-                vol, vol_err = sensitivity.volume_montecarlo(f_dist, m_dist_full,
-                      found_mchirp, missed_mchirp, args.distance_param,
-                      args.distribution, args.limits_param,
-                      args.min_param, args.max_param)
+                if args.integration_method == 'mc':
+                    vol, vol_err = sensitivity.volume_montecarlo(f_dist,
+                      m_dist_full, found_mchirp, missed_mchirp,
+                      args.distance_param, args.distribution,
+                      args.limits_param, args.min_param, args.max_param)
+                else: # vchirp_mc
+                    vol, vol_err = sensitivity.chirp_volume_montecarlo(
+                      f_dist, m_dist_full, found_mchirp, missed_mchirp,
+                      args.distance_param, args.distribution,
+                      args.limits_param, args.min_param, args.max_param)
 
             vols.append(vol)
             vol_errors.append(vol_err)

--- a/pycbc/sensitivity.py
+++ b/pycbc/sensitivity.py
@@ -91,7 +91,7 @@ def volume_montecarlo(found_d, missed_d, found_mchirp, missed_mchirp,
     Injections should be made over a range of distances such that sensitive
     volume due to signals closer than D_min is negligible, and efficiency at
     distances above D_max is negligible
-    TODO : Replace this function by Collin's formula given in Usman et al .. ?
+    TODO : Replace this function by Collin's formula given in Usman et al. ?
     OR get that coded as a new function?
 
     Parameters
@@ -112,7 +112,7 @@ def volume_montecarlo(found_d, missed_d, found_mchirp, missed_mchirp,
         'log' (uniform in log D)
         'uniform' (uniform in D)
         'distancesquared' (uniform in D**2)
-        'volume' (uniform in D***3)
+        'volume' (uniform in D**3)
     limits_param: string
         Parameter Dlim specifying limits inside which injections were made
         may be 'distance', 'chirp distance'
@@ -233,8 +233,8 @@ def volume_montecarlo(found_d, missed_d, found_mchirp, missed_mchirp,
 
 
 def chirp_volume_montecarlo(
-    found_d, missed_d, found_mchirp, missed_mchirp,
-    distribution_param, distribution, limits_param, min_param, max_param):
+        found_d, missed_d, found_mchirp, missed_mchirp,
+        distribution_param, distribution, limits_param, min_param, max_param):
 
     assert distribution_param == 'chirp_distance'
     assert limits_param == 'chirp_distance'

--- a/pycbc/sensitivity.py
+++ b/pycbc/sensitivity.py
@@ -1,8 +1,8 @@
 """ This module contains utilities for calculating search sensitivity
 """
 import numpy
-from . import bin_utils
 from pycbc.conversions import chirp_distance
+from . import bin_utils
 
 
 def compute_search_efficiency_in_bins(

--- a/pycbc/sensitivity.py
+++ b/pycbc/sensitivity.py
@@ -2,6 +2,7 @@
 """
 import numpy
 from . import bin_utils
+from pycbc.conversions import chirp_distance
 
 
 def compute_search_efficiency_in_bins(
@@ -150,7 +151,7 @@ def volume_montecarlo(found_d, missed_d, found_mchirp, missed_mchirp,
         all_mchirp = numpy.concatenate((found_mchirp, missed_mchirp))
         max_mchirp = all_mchirp.max()
         if max_param is not None:
-            # use largest actually injected mchirp for conversion
+            # use largest injected mchirp to convert back to distance
             max_distance = max_param * \
                                   (max_mchirp / mchirp_standard_bns)**(5. / 6.)
         else:
@@ -239,10 +240,8 @@ def chirp_volume_montecarlo(
     assert distribution_param == 'chirp_distance'
     assert limits_param == 'chirp_distance'
 
-    mchirp_standard_bns = 1.4 * 2.**(-1. / 5.)
-    found_dchirp = found_d * (found_mchirp / mchirp_standard_bns) ** (5./6)
-    missed_dchirp = missed_d * (missed_mchirp / mchirp_standard_bns) ** (5./6)
-
+    found_dchirp = chirp_distance(found_d, found_mchirp)
+    missed_dchirp = chirp_distance(missed_d, missed_mchirp)
     # treat chirp distances in MC volume estimate as physical distances
     return volume_montecarlo(found_dchirp, missed_dchirp, found_mchirp,
                              missed_mchirp, 'distance', distribution,

--- a/pycbc/sensitivity.py
+++ b/pycbc/sensitivity.py
@@ -232,6 +232,23 @@ def volume_montecarlo(found_d, missed_d, found_mchirp, missed_mchirp,
     return vol, vol_err
 
 
+def chirp_volume_montecarlo(
+    found_d, missed_d, found_mchirp, missed_mchirp,
+    distribution_param, distribution, limits_param, min_param, max_param)
+
+    assert distribution_param == 'chirp_distance'
+    assert limits_param == 'chirp_distance'
+
+    mchirp_standard_bns = 1.4 * 2.**(-1. / 5.)
+    found_dchirp = found_d * (found_mchirp / mchirp_standard_bns) ** (5./6)
+    missed_dchirp = missed_d * (missed_mchirp / mchirp_standard_bns) ** (5./6)
+
+    # treat chirp distances in MC volume estimate as physical distances
+    return volume_montecarlo(found_dchirp, missed_dchirp, found_mchirp,
+                             missed_mchirp, 'distance', distribution,
+                             'distance', min_param, max_param)
+
+
 def volume_binned_pylal(f_dist, m_dist, bins=15):
     """ Compute the sensitive volume using a distance binned efficiency estimate
 

--- a/pycbc/sensitivity.py
+++ b/pycbc/sensitivity.py
@@ -234,7 +234,7 @@ def volume_montecarlo(found_d, missed_d, found_mchirp, missed_mchirp,
 
 def chirp_volume_montecarlo(
     found_d, missed_d, found_mchirp, missed_mchirp,
-    distribution_param, distribution, limits_param, min_param, max_param)
+    distribution_param, distribution, limits_param, min_param, max_param):
 
     assert distribution_param == 'chirp_distance'
     assert limits_param == 'chirp_distance'


### PR DESCRIPTION
If we do injections out to a fixed chirp distance to approximate the maximum sensitive distance for a given mass, the new calculation effectively estimates the fraction of the (mass-dependent) potential sensitive volume where we are actually able to find injections.