### PR TITLE
Make single_template work with sim_inspiral tables that have no end times

### DIFF
--- a/bin/pycbc_single_template
+++ b/bin/pycbc_single_template
@@ -273,6 +273,8 @@ with ctx:
         td_template = resample_to_delta_t(td_template, gwstrain.delta_t,
                                           method='ldas')
         td_template = td_template * pycbc.DYN_RANGE_FAC
+        # apply a time shift so that the merger is at time zero,
+        # the usual convention for templates
         detector = Detector(opt.channel_name[:2])
         ltt = detector.time_delay_from_earth_center(
                 inj.longitude, inj.latitude, float(inj.get_end()))

--- a/bin/pycbc_single_template
+++ b/bin/pycbc_single_template
@@ -24,6 +24,7 @@ from pycbc import events
 from pycbc.filter import resample_to_delta_t
 from pycbc.types import zeros, complex64
 from pycbc.types import complex_same_precision_as
+from pycbc.detector import Detector
 import pycbc.waveform.utils
 import pycbc.version
 
@@ -272,7 +273,10 @@ with ctx:
         td_template = resample_to_delta_t(td_template, gwstrain.delta_t,
                                           method='ldas')
         td_template = td_template * pycbc.DYN_RANGE_FAC
-        td_template._epoch -= inj.get_end(site=opt.channel_name[0])
+        detector = Detector(opt.channel_name[:2])
+        ltt = detector.time_delay_from_earth_center(
+                inj.longitude, inj.latitude, float(inj.get_end()))
+        td_template._epoch -= inj.get_end() + ltt
         # Check if waveform is too long
         tlen = (flen-1) * 2
         # FIXME: Hardcoded 7./8. factor here, but I'm not too bothered by this.
@@ -286,7 +290,7 @@ with ctx:
         template = template.astype(complex_same_precision_as(segments[0]))
     else:
         approximant = waveform.bank.parse_approximant_arg(opt.approximant, row)[0]
-        logging.info("Making template: %s" % opt.approximant)
+        logging.info("Making template: %s", opt.approximant)
         if opt.u_val is None:
             template = waveform.get_waveform_filter(
                                     zeros(flen, dtype=complex64),
@@ -363,7 +367,7 @@ with ctx:
         if start > end_time:
             break
 
-        logging.info("Filtering segment %s" % s_num)
+        logging.info("Filtering segment %s", s_num)
         snr, corr, norm = filter.matched_filter_core(template, stilde,
                                     psd=stilde.psd,
                                     low_frequency_cutoff=flow)


### PR DESCRIPTION
When using an injection as template, `pycbc_single_template` uses the arrival time for the detector provided by the `sim_inspiral` table. Unfortunately, depending on how the injections where generated, this field is not always populated. When it is zero, `pycbc_single_template` generates a very confusing error:
```
XLALGPSSetREAL8(): overflow [a large GPS time]XLAL Error - XLALGPSSetREAL8 (XLALTime.c:83): Input domain error
XLAL Error - XLALGPSDivide (XLALTime.c:308): Internal function call failed: Input domain error
Traceback (most recent call last):
  File "/cvmfs/oasis.opensciencegrid.org/ligo/sw/pycbc/x86_64_rhel_7/virtualenv/pycbc-v1.15.0/bin/pycbc_single_template", line 285, in <module>
    template = waveform.td_waveform_to_fd_waveform(td_template, length=flen)
  File "/cvmfs/oasis.opensciencegrid.org/ligo/sw/pycbc/x86_64_rhel_7/virtualenv/pycbc-v1.15.0/lib/python2.7/site-packages/pycbc/waveform/waveform.py", line 953, in td_waveform_to_fd_waveform
    k_zero = int(waveform.start_time / waveform.delta_t)
RuntimeError: Internal function call failed: Input domain error
```
After this patch, `pycbc_single_template` calculates the time using PyCBC primitives and does not require the `sim_inspiral` end time to be populated.

I am not sure this is the optimal behavior though (although probably better than the *current* behavior) so opening for comments.  I have not done careful tests yet.