### PR TITLE
Injections are optional, fix inj_summ var

### DIFF
--- a/bin/workflows/pycbc_create_offline_search_workflow
+++ b/bin/workflows/pycbc_create_offline_search_workflow
@@ -672,9 +672,16 @@ layout.single_layout(rdir['analysis_time'], (analysis_time_summ))
 
 
 ########################## Make full summary ####################################
-summ = ([(time_file,)] + [(seg_summ_plot,)] +
-        [(seg_summ_table, veto_summ_table)] + det_summ + hist_summ +
-        [(bank_plot,)] + inj_summ + snrifar_summ)
+if len(files_for_combined_injfind) > 0:
+    summ = ([(time_file,)] + [(seg_summ_plot,)] +
+            [(seg_summ_table, veto_summ_table)] + det_summ + hist_summ +
+            [(bank_plot,)] + inj_summ + snrifar_summ)
+
+else:
+    summ = ([(time_file,)] + [(seg_summ_plot,)] +
+            [(seg_summ_table, veto_summ_table)] + det_summ + hist_summ +
+            [(bank_plot,)] + snrifar_summ)
+
 for row in summ:
     for f in row:
         symlink_path(f, rdir.base)


### PR DESCRIPTION
The issue comes from the assignment of the `inj_summ` variable in an if statement for handling injection files. If there aren't any injections then the workflow will try to give the injection summary list to the summary list when `inj_summ` hasn't been created.

Patch is just to add an if-else statement. Not the most elegant solution to fixing `pycbc_create_offline_search_workflow`. But now the workflow generates and passes with this small patch.