### PR TITLE
Swap around arguments inside of inline_linear_interp

### DIFF
--- a/pycbc/waveform/decompress_cpu.py
+++ b/pycbc/waveform/decompress_cpu.py
@@ -43,10 +43,10 @@ def inline_linear_interp(amp, phase, sample_frequencies, output,
     hlen = len(output)
     delta_f = float(df)
     if output.precision == 'single':
-        decomp_ccode_float(h, delta_f, hlen, start_index, sample_frequencies, amp,
-                           phase, sflen, imin)
+        decomp_ccode_float(h, delta_f, hlen, start_index, sample_frequencies,
+                           amp, phase, sflen, imin)
     else:
-        decomp_ccode_double(h, delta_f, hlen, start_index, sample_frequencies, amp,
-                           phase, sflen, imin)
+        decomp_ccode_double(h, delta_f, hlen, start_index, sample_frequencies,
+                            amp, phase, sflen, imin)
 
     return output

--- a/pycbc/waveform/decompress_cpu.py
+++ b/pycbc/waveform/decompress_cpu.py
@@ -43,10 +43,10 @@ def inline_linear_interp(amp, phase, sample_frequencies, output,
     hlen = len(output)
     delta_f = float(df)
     if output.precision == 'single':
-        decomp_ccode_float(h, hlen, sflen, delta_f, sample_frequencies, amp,
-                           phase, start_index, imin)
+        decomp_ccode_float(h, delta_f, hlen, start_index, sample_frequencies, amp,
+                           phase, sflen, imin)
     else:
-        decomp_ccode_double(h, hlen, sflen, delta_f, sample_frequencies, amp,
-                            phase, start_index, imin)
+        decomp_ccode_double(h, delta_f, hlen, start_index, sample_frequencies, amp,
+                           phase, sflen, imin)
 
     return output


### PR DESCRIPTION
The arguments were being handed off in the incorrect order, causing CPU waveform decompression to fail.  This should fix that.

Assuming this causes no other problems, I will also want to make a point release after it is merged. Without it waveform compression and decompression are completely broken.