### PR TITLE
Added IFO information to title to make result pages clearer

### DIFF
--- a/bin/hdfcoinc/pycbc_page_snrifar
+++ b/bin/hdfcoinc/pycbc_page_snrifar
@@ -116,8 +116,11 @@ if h_inc_back_num > h_iterations:
     ax.text(0.5, 0.5, output_message, horizontalalignment='center',
             verticalalignment='center')
 
+    figure_title = "%s: " % f.attrs['ifos'] if 'ifos' in f.attrs else ""
+    figure_title += "%s bin, Cumulative Rate vs Rank" % f.attrs['name'] if 'name' in f.attrs else "FAR vs Rank"
+
     pycbc.results.save_fig_with_metadata(fig, args.output_file,
-      title="%s bin, Cumulative Rate vs Rank" % f.attrs['name'] if 'name' in f.attrs else "FAR vs Rank",
+      title=figure_title,
       caption=output_message,
       cmd=' '.join(sys.argv))
 
@@ -377,6 +380,9 @@ else:
     fminorticks = far_from_p(pminorticks, foreground_livetime, far_back.max())
     ax2.set_yticks(fminorticks, minor=True)
 
+figure_title = "%s: " % f.attrs['ifos'] if 'ifos' in f.attrs else ""
+figure_title += "%s bin, Cumulative Rate vs Rank" % f.attrs['name'] if 'name' in f.attrs else "FAR vs Rank"
+
 figure_caption = figure_caption + "Orange diamonds (if present) represent triggers from the " \
 "zero-lag (foreground) analysis. Solid crosses show " \
 "the background inclusive of zerolag events, and grey crosses show the " \
@@ -384,6 +390,6 @@ figure_caption = figure_caption + "Orange diamonds (if present) represent trigge
 "coincident in the zero-lag data.",
 
 pycbc.results.save_fig_with_metadata(fig, args.output_file,
-     title="%s bin, Cumulative Rate vs Rank" % f.attrs['name'] if 'name' in f.attrs else "FAR vs Rank", 
+     title=figure_title,
      caption=figure_caption,
      cmd=' '.join(sys.argv))


### PR DESCRIPTION
This is a fix for #2966 

I assume that any changes to be made for the offline multi-ifo pipeline should be backwards compatible as well, is this correct?

For future reference, should I always request a reviewer or just leave this?