### PR TITLE
Allow for mutiple wells in pycbc results pages and allow them to be collapsable

### DIFF
--- a/pycbc/results/layout.py
+++ b/pycbc/results/layout.py
@@ -18,19 +18,21 @@
 import os.path
 from six.moves import zip_longest
 
-def two_column_layout(path, cols, **kwargs):
+def two_column_layout(path, cols, unique='', **kwargs):
     """ Make a well layout in a two column format
 
     Parameters
     ----------
     path: str
         Location to make the well html file
+    unique: str
+        String to add to end of well name. Used if you want more than one well.
     cols: list of tuples
         The format of the items on the well result section. Each tuple
         contains the two files that are shown in the left and right hand
         side of a row in the well.html page.
     """
-    path = os.path.join(os.getcwd(), path, 'well.html')
+    path = os.path.join(os.getcwd(), path, 'well{}.html'.format(unique))
     from pycbc.results.render import render_workflow_html_template
     render_workflow_html_template(path, 'two_column.html', cols, **kwargs)
 

--- a/pycbc/results/render.py
+++ b/pycbc/results/render.py
@@ -58,6 +58,10 @@ def render_workflow_html_template(filename, subtemplate, filelists, **kwargs):
     kwds = {'render-function' : 'render_tmplt',
             'filenames' : ','.join(filenames)}
     kwds.update(kwargs)
+    
+    for key in kwds:
+        kwds[key] = str(kwds[key])
+    
     save_html_with_metadata(str(output), filename, None, kwds)
 
 def get_embedded_config(filename):

--- a/pycbc/results/render.py
+++ b/pycbc/results/render.py
@@ -58,10 +58,10 @@ def render_workflow_html_template(filename, subtemplate, filelists, **kwargs):
     kwds = {'render-function' : 'render_tmplt',
             'filenames' : ','.join(filenames)}
     kwds.update(kwargs)
-    
+
     for key in kwds:
         kwds[key] = str(kwds[key])
-    
+
     save_html_with_metadata(str(output), filename, None, kwds)
 
 def get_embedded_config(filename):

--- a/pycbc/results/render.py
+++ b/pycbc/results/render.py
@@ -57,6 +57,7 @@ def render_workflow_html_template(filename, subtemplate, filelists, **kwargs):
     # save as html page
     kwds = {'render-function' : 'render_tmplt',
             'filenames' : ','.join(filenames)}
+    kwds.update(kwargs)
     save_html_with_metadata(str(output), filename, None, kwds)
 
 def get_embedded_config(filename):

--- a/pycbc/results/templates/orange.html
+++ b/pycbc/results/templates/orange.html
@@ -162,22 +162,23 @@
                 
                 {% set wellnames = [] %}
                 {% for wellname in dir.files %}
-                    {% if wellname.filename().find('well') == -1 %}
-                        {% set wellnames = wellnames + [wellname] %}
+                    {% if wellname.filename().find('well') == 0 %}
+                        {% set _ = wellnames.append(wellname) %}
                     {% endif %}
                 {% endfor %}
                 
                 <!-- include well if it exists and check meta-data if well renders any files inside it -->
                 {% for wellname in wellnames %}
-                    {% set well_path = plots_dir + dir.path + '/' + wellname %}
-                    {% set well_filenames = well_filenames + [wellname] %}
+                    {{wellname.filename()}}
+                    {% set well_path = plots_dir + dir.path + '/' + wellname.filename() %}
+                    {% set _ = well_filenames.append(wellname.filename()) %}
                     {% if path_exists(well_path) %}
                     
                         {% set cp = get_embedded_config(well_path) %}
                         {{ setup_template_render(well_path, None) }}            
                         
                         {% if get_embedded_config(well_path).has_option(wellname, 'filenames') %}
-                            {% set well_filenames = well_filenames + get_embedded_config(well_path).get(wellname, 'filenames').split(',') %}
+                            {% set _ = well_filenames.extend(get_embedded_config(well_path).get(wellname, 'filenames').split(',')) %}
                         {% endif %}
                         
                     {% endif %}

--- a/pycbc/results/templates/orange.html
+++ b/pycbc/results/templates/orange.html
@@ -162,16 +162,20 @@
                 
                 <!-- set list of files which are handled in wells -->
                 {% set well_filenames = []%}
+                
+                {% set wells = [fname for fname in dir.files if 'well' in fname] %}
 
                 <!-- include well if it exists and check meta-data if well renders any files inside it -->
-                {% set well_path = plots_dir+dir.path+'/well.html' %}
-                {% set well_filenames += ['well.html'] %}
-                {% if path_exists(well_path) %}
-                    {{ setup_template_render(well_path, None) }}
-                    {% if get_embedded_config(well_path).has_option('well.html', 'filenames') %}
-                        {% set well_filenames += get_embedded_config(well_path).get('well.html', 'filenames').split(',') %}
+                {% for wellname in wells %}
+                    {% set well_path = plots_dir + dir.path + '/' + wellname %}
+                    {% set well_filenames += ['well.html'] %}
+                    {% if path_exists(well_path) %}
+                        {{ setup_template_render(well_path, None) }}
+                        {% if get_embedded_config(well_path).has_option(wellname, 'filenames') %}
+                            {% set well_filenames += get_embedded_config(well_path).get(wellname, 'filenames').split(',') %}
+                        {% endif %}
                     {% endif %}
-                {% endif %}
+                {% endfor %}
 
                 <hr class="row-divider">
 

--- a/pycbc/results/templates/orange.html
+++ b/pycbc/results/templates/orange.html
@@ -182,7 +182,7 @@
                         {% if not cp.check_option(wellname.filename(), 'collapse') %}
                             {{ setup_template_render(well_path, None) }}     
                         {% else %}
-                            <div class="panel-group" id="accordion">
+                            <div class="panel-group" id="accordion1">
                                 <div class="panel panel-default">
                                     <div class="panel-heading">
                                         <h4 class="panel-title" data-toggle="collapse" data-target="#collapse{{loop.index}}well">
@@ -217,6 +217,7 @@
                             <div class="row" style="padding:15px">
                                 <button id="collapse-init" class="btn btn-xs btn-primary">Expand All</button>
                             </div>
+                            {% set count = [1] %}
                             {% for file in dir.files %}
                                 {% if path_exists(file.path) %}
 
@@ -229,9 +230,9 @@
                                                 <div class="panel-heading">
                                                     <h4 class="panel-title" data-toggle="collapse" data-target="#collapseorange{{loop.index}}">
                                                         {% if cp.check_option(file.filename(), 'title') %}
-                                                            B{{loop.index}}. {{cp.get(file.filename(), 'title')}}
+                                                            B{{count|length}}. {{cp.get(file.filename(), 'title')}}
                                                         {% else %}
-                                                            B{{loop.index}}. {{file.filename()}}
+                                                            B{{count|length}}. {{file.filename()}}
                                                         {% endif %}
                                                     </h4>
                                                 </div>
@@ -242,7 +243,7 @@
                                                 </div>
                                             </div>
                                         </div>
-
+                                    {% set _ = count.append(1) %}
                                     {% endif %}
                                 {% endif %}
                             {% endfor %}

--- a/pycbc/results/templates/orange.html
+++ b/pycbc/results/templates/orange.html
@@ -165,12 +165,40 @@
                 
                 {% set wells = [fname for fname in dir.files if 'well' in fname] %}
 
+                {% set j = 0 %}
                 <!-- include well if it exists and check meta-data if well renders any files inside it -->
                 {% for wellname in wells %}
                     {% set well_path = plots_dir + dir.path + '/' + wellname %}
                     {% set well_filenames += ['well.html'] %}
                     {% if path_exists(well_path) %}
-                        {{ setup_template_render(well_path, None) }}
+                    
+                        {% set cp = get_embedded_config(well_path) %}
+                        {% if not cp.has_option(wellname, 'collapse') %}
+                            <!-- regular well -->
+                            {{ setup_template_render(well_path, None) }}
+                        {% else %}
+                            <!-- well within a collapseable box -->
+                            <div class="panel-group" id="accordion">
+                                <div class="panel panel-default">
+                                    <div class="panel-heading">
+                                        <h4 class="panel-title" data-toggle="collapse" data-target="#collapse{{i}}">
+                                            {% if cp.check_option(wellname, 'title') %}
+                                                {{cp.get(wellname, 'title')}}
+                                            {% else %}
+                                                {{wellname}}
+                                            {% endif %}
+                                        </h4>
+                                    </div>
+                                    <div id="collapse{{i}}" class="panel-collapse collapse">
+                                        <div class="panel-body">
+                                            {{ setup_template_render(well_path, None) }}
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>    
+                            {% set j = j + 1 %}                 
+                        {% endif %}
+
                         {% if get_embedded_config(well_path).has_option(wellname, 'filenames') %}
                             {% set well_filenames += get_embedded_config(well_path).get(wellname, 'filenames').split(',') %}
                         {% endif %}

--- a/pycbc/results/templates/orange.html
+++ b/pycbc/results/templates/orange.html
@@ -159,15 +159,17 @@
 
                 <!-- set file counter integer -->
                 {% set i = 1 %}
+                
+                <!-- set list of files which are handled in wells -->
+                {% set well_filenames = []%}
 
                 <!-- include well if it exists and check meta-data if well renders any files inside it -->
                 {% set well_path = plots_dir+dir.path+'/well.html' %}
+                {% set well_filenames += ['well.html'] %}
                 {% if path_exists(well_path) %}
                     {{ setup_template_render(well_path, None) }}
                     {% if get_embedded_config(well_path).has_option('well.html', 'filenames') %}
-                        {% set well_filenames = get_embedded_config(well_path).get('well.html', 'filenames').split(',') %}
-                    {% else %}
-                        {% set well_filenames = [] %}
+                        {% set well_filenames += get_embedded_config(well_path).get('well.html', 'filenames').split(',') %}
                     {% endif %}
                 {% endif %}
 
@@ -191,7 +193,7 @@
                                     {% set cp = get_embedded_config(file.path) %}
 
                                     <!-- do not show well.html -->
-                                    {% if not file.filename() == 'well.html' and file.filename() not in well_filenames %}
+                                    {% if file.filename() not in well_filenames %}
                                         <div class="panel-group" id="accordion">
                                             <div class="panel panel-default">
                                                 <div class="panel-heading">

--- a/pycbc/results/templates/orange.html
+++ b/pycbc/results/templates/orange.html
@@ -157,51 +157,29 @@
                      </div>
                 </div>
 
-                <!-- set file counter integer -->
-                {% set i = 1 %}
-                
                 <!-- set list of files which are handled in wells -->
                 {% set well_filenames = []%}
                 
-                {% set wells = [fname for fname in dir.files if 'well' in fname] %}
-
-                {% set j = 0 %}
+                {% set wellnames = [] %}
+                {% for wellname in dir.files %}
+                    {% if wellname.filename().find('well') == -1 %}
+                        {% set wellnames = wellnames + [wellname] %}
+                    {% endif %}
+                {% endfor %}
+                
                 <!-- include well if it exists and check meta-data if well renders any files inside it -->
-                {% for wellname in wells %}
+                {% for wellname in wellnames %}
                     {% set well_path = plots_dir + dir.path + '/' + wellname %}
-                    {% set well_filenames += ['well.html'] %}
+                    {% set well_filenames = well_filenames + [wellname] %}
                     {% if path_exists(well_path) %}
                     
                         {% set cp = get_embedded_config(well_path) %}
-                        {% if not cp.has_option(wellname, 'collapse') %}
-                            <!-- regular well -->
-                            {{ setup_template_render(well_path, None) }}
-                        {% else %}
-                            <!-- well within a collapseable box -->
-                            <div class="panel-group" id="accordion">
-                                <div class="panel panel-default">
-                                    <div class="panel-heading">
-                                        <h4 class="panel-title" data-toggle="collapse" data-target="#collapse{{i}}">
-                                            {% if cp.check_option(wellname, 'title') %}
-                                                {{cp.get(wellname, 'title')}}
-                                            {% else %}
-                                                {{wellname}}
-                                            {% endif %}
-                                        </h4>
-                                    </div>
-                                    <div id="collapse{{i}}" class="panel-collapse collapse">
-                                        <div class="panel-body">
-                                            {{ setup_template_render(well_path, None) }}
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>    
-                            {% set j = j + 1 %}                 
-                        {% endif %}
-
+                        {{ setup_template_render(well_path, None) }}            
+                        
                         {% if get_embedded_config(well_path).has_option(wellname, 'filenames') %}
-                            {% set well_filenames += get_embedded_config(well_path).get(wellname, 'filenames').split(',') %}
+                            {% set well_filenames = well_filenames + get_embedded_config(well_path).get(wellname, 'filenames').split(',') %}
                         {% endif %}
+                        
                     {% endif %}
                 {% endfor %}
 
@@ -223,30 +201,28 @@
 
                                     <!-- get config file -->
                                     {% set cp = get_embedded_config(file.path) %}
-
                                     <!-- do not show well.html -->
-                                    {% if file.filename() not in well_filenames %}
+                                    {% if not file.filename() in well_filenames %}
                                         <div class="panel-group" id="accordion">
                                             <div class="panel panel-default">
                                                 <div class="panel-heading">
-                                                    <h4 class="panel-title" data-toggle="collapse" data-target="#collapse{{i}}">
+                                                    <h4 class="panel-title" data-toggle="collapse" data-target="#collapseorange{{loop.index}}">
                                                         {% if cp.check_option(file.filename(), 'title') %}
-                                                            B{{i}}. {{cp.get(file.filename(), 'title')}}
+                                                            B{{loop.index}}. {{cp.get(file.filename(), 'title')}}
                                                         {% else %}
-                                                            B{{i}}. {{file.filename()}}
+                                                            B{{loop.index}}. {{file.filename()}}
                                                         {% endif %}
                                                     </h4>
                                                 </div>
-                                                <div id="collapse{{i}}" class="panel-collapse collapse">
+                                                <div id="collapseorange{{loop.index}}" class="panel-collapse collapse">
                                                     <div class="panel-body">
                                                         {{file.render()}}
                                                     </div>
                                                 </div>
                                             </div>
                                         </div>
-                                        {% set i = i + 1 %}
-                                    {% endif %}
 
+                                    {% endif %}
                                 {% endif %}
                             {% endfor %}
                     </div>

--- a/pycbc/results/templates/orange.html
+++ b/pycbc/results/templates/orange.html
@@ -169,18 +169,38 @@
                 
                 <!-- include well if it exists and check meta-data if well renders any files inside it -->
                 {% for wellname in wellnames %}
-                    {{wellname.filename()}}
                     {% set well_path = plots_dir + dir.path + '/' + wellname.filename() %}
                     {% set _ = well_filenames.append(wellname.filename()) %}
                     {% if path_exists(well_path) %}
                     
                         {% set cp = get_embedded_config(well_path) %}
-                        {{ setup_template_render(well_path, None) }}            
                         
-                        {% if get_embedded_config(well_path).has_option(wellname, 'filenames') %}
-                            {% set _ = well_filenames.extend(get_embedded_config(well_path).get(wellname, 'filenames').split(',')) %}
+                        {% if cp.check_option(wellname.filename(), 'filenames') %}
+                            {% set _ = well_filenames.extend(get_embedded_config(well_path).get(wellname.filename(), 'filenames').split(',')) %}
                         {% endif %}
                         
+                        {% if not cp.check_option(wellname.filename(), 'collapse') %}
+                            {{ setup_template_render(well_path, None) }}     
+                        {% else %}
+                            <div class="panel-group" id="accordion">
+                                <div class="panel panel-default">
+                                    <div class="panel-heading">
+                                        <h4 class="panel-title" data-toggle="collapse" data-target="#collapse{{loop.index}}well">
+                                            {% if cp.check_option(wellname.filename(), 'title') %}
+                                                W{{loop.index}}. {{cp.get(wellname.filename(), 'title')}}
+                                            {% else %}
+                                                W{{loop.index}}. {{wellname.filename()}}
+                                            {% endif %}
+                                        </h4>
+                                    </div>
+                                    <div id="collapse{{loop.index}}well" class="panel-collapse collapse">
+                                        <div class="panel-body">
+                                            {{setup_template_render(well_path, None) }}     
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        {% endif %}                               
                     {% endif %}
                 {% endfor %}
 


### PR DESCRIPTION
To invoke multiple wells you need to use the 'unique' keyword argument with your layout command. Add  any string so it can make a new one.  To make collapseable, add the collapse=True keyword. 