### PR TITLE
Use gwdatafind instead of glue.datafind

### DIFF
--- a/docs/workflow/datafind.rst
+++ b/docs/workflow/datafind.rst
@@ -14,7 +14,7 @@ workflow.
 
 This module is designed to be able to support multiple ways of obtaining
 data (different codes/interfaces whatever). Currently we only support datafind
-through the glue.datafind module (which is equivalent to using gw_data_find).
+through the `gwdatafind` module (which is equivalent to using gw_data_find).
 
 This module will run the necessary queries to the datafind server to obtain
 locations for frame files at the specfied times for each interferometer.
@@ -122,7 +122,7 @@ $$$$$$$$$$$$$$$
 $$$$$$$$$$$$$$$
 
 Currently no executables are needed in the datafind section. Workflow will use
-the glue.datafind module to run the calls to the datafind server.
+the `gwdatafind` module to run the calls to the datafind server.
 
 $$$$$$$$$$$$$$$$$$$
 Other sections

--- a/pycbc/frame/frame.py
+++ b/pycbc/frame/frame.py
@@ -22,6 +22,7 @@ import lal
 import numpy
 import os.path, glob, time
 import gwdatafind
+from six.moves.urllib.parse import urlparse
 from pycbc.types import TimeSeries, zeros
 
 
@@ -293,8 +294,7 @@ def frame_paths(frame_type, start_time, end_time, server=None, url_type='file'):
     connection.find_times(site, frame_type,
                           gpsstart=start_time, gpsend=end_time)
     cache = connection.find_frame_urls(site, frame_type, start_time, end_time,urltype=url_type)
-    paths = [entry.path for entry in cache]
-    return paths
+    return [urlparse(entry).path for entry in cache]
 
 def query_and_read_frame(frame_type, channels, start_time, end_time,
                          sieve=None, check_integrity=False):

--- a/pycbc/frame/frame.py
+++ b/pycbc/frame/frame.py
@@ -21,7 +21,7 @@ import lalframe, logging
 import lal
 import numpy
 import os.path, glob, time
-import glue.datafind
+import gwdatafind
 from pycbc.types import TimeSeries, zeros
 
 
@@ -259,38 +259,7 @@ def datafind_connection(server=None):
     connection
         The open connection to the datafind server.
     """
-
-    if server:
-        datafind_server = server
-    else:
-        # Get the server name from the environment
-        if 'LIGO_DATAFIND_SERVER' in os.environ:
-            datafind_server = os.environ["LIGO_DATAFIND_SERVER"]
-        else:
-            err = "Trying to obtain the ligo datafind server url from "
-            err += "the environment, ${LIGO_DATAFIND_SERVER}, but that "
-            err += "variable is not populated."
-            raise ValueError(err)
-
-    # verify authentication options
-    if not datafind_server.endswith("80"):
-        cert_file, key_file = glue.datafind.find_credential()
-    else:
-        cert_file, key_file = None, None
-
-    # Is a port specified in the server URL
-    dfs_fields = datafind_server.split(':', 1)
-    server = dfs_fields[0]
-    port = int(dfs_fields[1]) if len(dfs_fields) == 2 else None
-
-    # Open connection to the datafind server
-    if cert_file and key_file:
-        connection = glue.datafind.GWDataFindHTTPSConnection(
-                host=server, port=port, cert_file=cert_file, key_file=key_file)
-    else:
-        connection = glue.datafind.GWDataFindHTTPConnection(
-                host=server, port=port)
-    return connection
+    return gwdatafind.connect(host=server)
 
 def frame_paths(frame_type, start_time, end_time, server=None, url_type='file'):
     """Return the paths to a span of frame files

--- a/pycbc/workflow/datafind.py
+++ b/pycbc/workflow/datafind.py
@@ -358,7 +358,7 @@ def setup_datafind_workflow(workflow, scienceSegs, outputDir, seg_file=None,
 def setup_datafind_runtime_cache_multi_calls_perifo(cp, scienceSegs,
                                                     outputDir, tags=None):
     """
-    This function uses the glue.datafind library to obtain the location of all
+    This function uses the `gwdatafind` library to obtain the location of all
     the frame files that will be needed to cover the analysis of the data
     given in scienceSegs. This function will not check if the returned frames
     cover the whole time requested, such sanity checks are done in the
@@ -438,7 +438,7 @@ def setup_datafind_runtime_cache_multi_calls_perifo(cp, scienceSegs,
 def setup_datafind_runtime_cache_single_call_perifo(cp, scienceSegs, outputDir,
                                               tags=None):
     """
-    This function uses the glue.datafind library to obtain the location of all
+    This function uses the `gwdatafind` library to obtain the location of all
     the frame files that will be needed to cover the analysis of the data
     given in scienceSegs. This function will not check if the returned frames
     cover the whole time requested, such sanity checks are done in the
@@ -518,7 +518,7 @@ def setup_datafind_runtime_cache_single_call_perifo(cp, scienceSegs, outputDir,
 def setup_datafind_runtime_frames_single_call_perifo(cp, scienceSegs,
                                               outputDir, tags=None):
     """
-    This function uses the glue.datafind library to obtain the location of all
+    This function uses the `gwdatafind` library to obtain the location of all
     the frame files that will be needed to cover the analysis of the data
     given in scienceSegs. This function will not check if the returned frames
     cover the whole time requested, such sanity checks are done in the
@@ -568,7 +568,7 @@ def setup_datafind_runtime_frames_single_call_perifo(cp, scienceSegs,
 def setup_datafind_runtime_frames_multi_calls_perifo(cp, scienceSegs,
                                                      outputDir, tags=None):
     """
-    This function uses the glue.datafind library to obtain the location of all
+    This function uses the `gwdatafind` library to obtain the location of all
     the frame files that will be needed to cover the analysis of the data
     given in scienceSegs. This function will not check if the returned frames
     cover the whole time requested, such sanity checks are done in the
@@ -899,7 +899,7 @@ def run_datafind_instance(cp, outputDir, connection, observatory, frameType,
         commands for reproducing what is done in this function to this
         directory.
     connection : datafind connection object
-        Initialized through the glue.datafind module, this is the open
+        Initialized through the `gwdatafind` module, this is the open
         connection to the datafind server.
     observatory : string
         The observatory to query frames for. Ex. 'H', 'L' or 'V'.  NB: not

--- a/pycbc/workflow/datafind.py
+++ b/pycbc/workflow/datafind.py
@@ -952,10 +952,12 @@ def run_datafind_instance(cp, outputDir, connection, observatory, frameType,
     # directory to check if this was expected.
     log_datafind_command(observatory, frameType, startTime, endTime,
                          os.path.join(outputDir,'logs'), **dfKwargs)
-    logging.info("Asking datafind server for frames.")
-    dfCache = connection.find_frame_urls(observatory, frameType,
-                                        startTime, endTime, **dfKwargs)
-    logging.info("Frames returned")
+    logging.debug("Asking datafind server for frames.")
+    dfCache = lal.Cache.from_urls(
+        connection.find_frame_urls(observatory, frameType,
+                                   startTime, endTime, **dfKwargs),
+    )
+    logging.debug("Frames returned")
     # workflow format output file
     cache_file = File(ifo, 'DATAFIND', seg, extension='lcf',
                       directory=outputDir, tags=tags)

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,7 @@ lalsuite
 lscsoft-glue>=1.59.3
 ligo-segments
 tqdm
+gwdatafind
 
 # Requirements for ligoxml access needed by some workflows
 python-ligo-lw

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ install_requires =  setup_requires + ['Mako>=1.0.1',
                       'six>=1.10.0',
                       'ligo-segments',
                       'tqdm',
+                      'gwdatafind',
                       ]
 
 def find_files(dirname, relpath=None):


### PR DESCRIPTION
This PR fixes #2916 by patching `pycbc.frame.frame` to use `gwdatafind`, rather than the (long deprecated) `glue.datafind` module.