### PR TITLE
Remove usetex from remaining plotting scripts

### DIFF
--- a/bin/hdfcoinc/pycbc_page_ifar
+++ b/bin/hdfcoinc/pycbc_page_ifar
@@ -40,9 +40,6 @@ def calculate_time_slide_duration(ifo1_segments, ifo2_segments, offset=0):
    return duration
 
 
-pylab.rc('text', usetex=True)
-pylab.rc('font', **{'family': 'serif', 'serif': ['Computer Modern']})
-
 # parser command line
 parser = argparse.ArgumentParser(usage='pycbc_page_ifar [--options]',
                     description='Plots a cumulative histogram of IFAR for'

--- a/bin/hdfcoinc/pycbc_page_snrifar
+++ b/bin/hdfcoinc/pycbc_page_snrifar
@@ -32,9 +32,6 @@ def _far_from_p(p, livetime, max_far):
 
 far_from_p = numpy.vectorize(_far_from_p)
 
-pylab.rc('font', **{'family': 'serif', 'serif': ['Computer Modern']})
-pylab.rc('text', usetex=True)
-
 parser = argparse.ArgumentParser()
 # General required options
 parser.add_argument('--version', action='version', version=pycbc.version.git_verbose_msg)

--- a/bin/hdfcoinc/pycbc_page_snrratehist
+++ b/bin/hdfcoinc/pycbc_page_snrratehist
@@ -14,9 +14,7 @@ def sigma_from_p(p):
 
 def p_from_sigma(sig):
     return 1 - (1 - erf(sig / 2**0.5)) / 2
-    
-pylab.rc('text', usetex=True)
-pylab.rc('font', **{'family': 'serif', 'serif': ['Computer Modern']})
+
 
 parser = argparse.ArgumentParser()
 # General required options

--- a/bin/inference/pycbc_inference_plot_thermodynamic_integrand
+++ b/bin/inference/pycbc_inference_plot_thermodynamic_integrand
@@ -34,8 +34,6 @@ import numpy
 from pycbc.inference import io
 import pycbc.version
 
-rc('text', usetex=True)
-
 parser = argparse.ArgumentParser()
 parser.add_argument("--inference-file", type=str,
                     help="The PyCBC multi-temper inference file.")

--- a/bin/plotting/pycbc_banksim_plot_fitting_factors
+++ b/bin/plotting/pycbc_banksim_plot_fitting_factors
@@ -25,8 +25,6 @@ import numpy
 import matplotlib
 matplotlib.use('Agg')
 import matplotlib.pyplot as plt
-# Ensure latex rendering
-matplotlib.rc('text', usetex=True)
 
 import pycbc.version
 from pycbc import results

--- a/bin/pycbc_make_banksim
+++ b/bin/pycbc_make_banksim
@@ -467,7 +467,6 @@ goldenratio = 2 / (1 + 5**.5)
 #	"subplots.top": 0.75,
 #        "savefig.dpi": 600,
 #        "text.verticalalignment": "center",
-#        "text.usetex": True     # render all text with TeX
 #})
 
 res = numpy.loadtxt("results.dat")

--- a/test/test_lalsim.py
+++ b/test/test_lalsim.py
@@ -87,7 +87,6 @@ import matplotlib
 if not opt.show_plots:
     matplotlib.use('Agg')
 import pylab
-matplotlib.rc('text', usetex=True)
 
 def get_waveform(p, **kwds):
     """ Given the input parameters get me the waveform, whether it is TD or


### PR DESCRIPTION
TexLive is extremely hard to build and distribute alongside other projects, and is not supported by Anaconda or Conda-forge to the level required for Matplotlib. This PR removes the remaining `rcParams['text.usetex'] = True` settings to remove the LaTeX dependency from PyCBC.