### PR TITLE
Fix qscan default (and set to 20 Hz)

### DIFF
--- a/bin/plotting/pycbc_plot_qscan
+++ b/bin/plotting/pycbc_plot_qscan
@@ -79,12 +79,12 @@ parser.add_argument('--qtransform-frange-upper', default=None, type=float,
                          'qtransform. Optional, default=Half of Nyquist')
 parser.add_argument('--qtransform-qrange-lower', default=4, type=float,
                     help='Lower limit of the range of q to consider, '
-                         'default=4')
+                         'default=%(default)f')
 parser.add_argument('--qtransform-qrange-upper', default=64, type=float,
                     help='Upper limit of the range of q to consider, '
-                         'default=64')
+                         'default=%(default)f')
 parser.add_argument('--qtransform-mismatch', default=0.2, type=float,
-                    help='Mismatch between frequency tiles, default=0.2')
+                    help='Mismatch between frequency tiles, default=%(default)f')
 
 parser.add_argument('--linear-y-axis', dest='log_y', default=True,
                     action='store_false',
@@ -97,7 +97,7 @@ parser.add_argument('--plot-title',
 parser.add_argument('--plot-caption',
                     help="If given, use this as the plot caption")
 parser.add_argument('--colormap', choices=plt.colormaps(), default='viridis',
-                    help='Colormap to use (default viridis)')
+                    help='Colormap to use (default %(default)s)')
 
 pycbc.strain.insert_strain_option_group(parser)
 opts = parser.parse_args()

--- a/bin/plotting/pycbc_plot_qscan
+++ b/bin/plotting/pycbc_plot_qscan
@@ -72,11 +72,11 @@ parser.add_argument('--qtransform-logfsteps', type=int, default=200,
                          '--qtransform-delta-f option) and set the number '
                          'of steps to take')
 parser.add_argument('--qtransform-frange-lower', default=None, type=float,
-                    help='Lower frequency at which to compute qtransform. '
-                         'Optional, default=10')
+                    help='Lower frequency (in Hz) at which to compute '
+                         'qtransform. Optional, default=20 Hz')
 parser.add_argument('--qtransform-frange-upper', default=None, type=float,
-                    help='Upper frequency at which to compute qtransform. '
-                         'Optional, default=Half of Nyquist')
+                    help='Upper frequency (in Hz) at which to compute '
+                         'qtransform. Optional, default=Half of Nyquist')
 parser.add_argument('--qtransform-qrange-lower', default=4, type=float,
                     help='Lower limit of the range of q to consider, '
                          'default=4')
@@ -129,7 +129,7 @@ strain = pycbc.strain.from_cli(opts, pycbc.DYN_RANGE_FAC)
 
 if opts.qtransform_frange_upper is None and \
         opts.qtransform_frange_lower is None:
-    curr_frange = (30, opts.sample_rate / 4.)
+    curr_frange = (20, opts.sample_rate / 4.)
 elif opts.qtransform_frange_upper is None or \
           opts.qtransform_frange_lower is None:
     parser.error('Must provide either both --qtransform-frange-upper and '


### PR DESCRIPTION
`pycbc_plot_qscan --help` currently says that the default low-frequency bound is "10", but it is actually 30 Hz. Given that modern template banks go quite below that, I am also lowering the actual default to 20 Hz.