### PR TITLE
Added Injection f-ref option to multi-ifo strain function

### DIFF
--- a/pycbc/strain/strain.py
+++ b/pycbc/strain/strain.py
@@ -726,12 +726,14 @@ def insert_strain_option_group_multi_ifo(parser, gps_times=True):
                          "before injecting into the data.")
 
     data_reading_group_multi.add_argument('--injection-f-ref', type=float,
-                                    help='Reference frequency in Hz for '
-                                         'creating CBC injections from an XML '
-                                         'file.')
+                               action=MultiDetOptionAction, metavar='IFO:VALUE'
+                               help='Reference frequency in Hz for '
+                                    'creating CBC injections from an XML '
+                                    'file.')
     data_reading_group_multi.add_argument('--injection-f-final', type=float,
-                                    help='Override the f_final field of a CBC '
-                                         'XML injection file.')
+                               action=MultiDetOptionAction, metavar='IFO:VALUE'
+                               help='Override the f_final field of a CBC '
+                                    'XML injection file.')
 
     # Gating options
     data_reading_group_multi.add_argument("--gating-file", nargs="+",

--- a/pycbc/strain/strain.py
+++ b/pycbc/strain/strain.py
@@ -725,6 +725,14 @@ def insert_strain_option_group_multi_ifo(parser, gps_times=True):
                     help="Multiple injections by this factor "
                          "before injecting into the data.")
 
+    data_reading_group_multi.add_argument('--injection-f-ref', type=float,
+                                    help='Reference frequency in Hz for '
+                                         'creating CBC injections from an XML '
+                                         'file.')
+    data_reading_group_multi.add_argument('--injection-f-final', type=float,
+                                    help='Override the f_final field of a CBC '
+                                         'XML injection file.')
+
     # Gating options
     data_reading_group_multi.add_argument("--gating-file", nargs="+",
                       action=MultiDetOptionAction,

--- a/pycbc/strain/strain.py
+++ b/pycbc/strain/strain.py
@@ -726,12 +726,12 @@ def insert_strain_option_group_multi_ifo(parser, gps_times=True):
                          "before injecting into the data.")
 
     data_reading_group_multi.add_argument('--injection-f-ref', type=float,
-                               action=MultiDetOptionAction, metavar='IFO:VALUE'
+                               action=MultiDetOptionAction, metavar='IFO:VALUE',
                                help='Reference frequency in Hz for '
                                     'creating CBC injections from an XML '
                                     'file.')
     data_reading_group_multi.add_argument('--injection-f-final', type=float,
-                               action=MultiDetOptionAction, metavar='IFO:VALUE'
+                               action=MultiDetOptionAction, metavar='IFO:VALUE',
                                help='Override the f_final field of a CBC '
                                     'XML injection file.')
 


### PR DESCRIPTION
It seems that the injection strain module was broken from this commit:
https://github.com/gwastro/pycbc/commit/84e8c92167f77f19bc83e08724b67492550911a9#diff-33e2f03c191ff5208a6cbe46ee68fad7

As I ran into following error while running pycbc_inference with a simulated BBH injection:

  File "/work/sumit.kumar/src/ve/python3.6/pycbc_inference_dev/lib/python3.6/site-packages/PyCBC-1e0583-py3.6-linux-x86_64.egg/pycbc/inject/inject.py", line 855, in from_cli
    if opt.injection_f_ref is not None:

I have fixed it as suggested by @cdcapano and tested with a simulated BBH injection. 