### PR TITLE
Fix Workflow.save_config for python3

### DIFF
--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -822,7 +822,7 @@ class Workflow(pegasus_workflow.Workflow):
         """
         cp = self.cp if cp is None else cp
         ini_file_path = os.path.join(output_dir, fname)
-        with open(ini_file_path, "wb") as fp:
+        with open(ini_file_path, "w") as fp:
             cp.write(fp)
         ini_file = FileList([File(self.ifos, "",
                                   self.analysis_time,


### PR DESCRIPTION
Currently, `Workflow.save_config` opens the file handler to save the file in binary mode ("wb"). This causes the following error in python 3:
```
TypeError: a bytes-like object is required, not 'str'
```

This fixes this by just opening the file handler in normal write mode ("w"). I'm not certain why mode "wb" was used to begin with, but just using "w" seems to work fine.