### PR TITLE
Fix empty git info when using Python 3

### DIFF
--- a/pycbc/_version_helper.py
+++ b/pycbc/_version_helper.py
@@ -64,6 +64,8 @@ def call(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
     if p.returncode != 0 and on_error == 'raise':
         raise GitInvocationError('Failed to run "%s"' % " ".join(command))
 
+    out = out.decode('utf-8')
+
     if returncode:
         return out.strip(), p.returncode
     else:


### PR DESCRIPTION
I noticed that with Python 3 the git info is sometimes unpopulated:
```
>>> import pycbc.version
>>> pycbc.version.git_hash
''
```
This seems to happen due to a bytes/str confusion, which leads to an exception in `setup.py`. The exception is silently caught so we do not see it, and it causes the strings to be empty. This patch fixes the bytes/str confusion.