### PR TITLE
enforce betas order required by emceept

### DIFF
--- a/pycbc/inference/sampler/emcee_pt.py
+++ b/pycbc/inference/sampler/emcee_pt.py
@@ -146,6 +146,8 @@ class EmceePTSampler(MultiTemperedAutocorrSupport, MultiTemperedSupport,
             with h5py.File(inverse_temperatures_file, "r") as fp:
                 try:
                     betas = numpy.array(fp.attrs['betas'])
+                    # betas must be in decending order
+                    betas = numpy.sort(betas)[::-1]
                     ntemps = betas.shape[0]
                 except KeyError:
                     raise AttributeError("No attribute called betas")
@@ -158,10 +160,6 @@ class EmceePTSampler(MultiTemperedAutocorrSupport, MultiTemperedSupport,
         checkpoint_signal = cls.ckpt_signal_from_config(cp, section)
         # get the loglikelihood function
         logl = get_optional_arg_from_config(cp, section, 'logl-function')
-
-        # betas must be in decending order
-        betas = betas.sort()[::-1]
-
         obj = cls(model, ntemps, nwalkers, betas=betas,
                   checkpoint_interval=checkpoint_interval,
                   checkpoint_signal=checkpoint_signal,

--- a/pycbc/inference/sampler/emcee_pt.py
+++ b/pycbc/inference/sampler/emcee_pt.py
@@ -158,6 +158,10 @@ class EmceePTSampler(MultiTemperedAutocorrSupport, MultiTemperedSupport,
         checkpoint_signal = cls.ckpt_signal_from_config(cp, section)
         # get the loglikelihood function
         logl = get_optional_arg_from_config(cp, section, 'logl-function')
+
+        # betas must be in decending order
+        betas = betas.sort()[::-1]
+
         obj = cls(model, ntemps, nwalkers, betas=betas,
                   checkpoint_interval=checkpoint_interval,
                   checkpoint_signal=checkpoint_signal,


### PR DESCRIPTION
This is a convenience modification. I've found that if you get the betas order wrong, emcee pt will happily accept it but produce nonsense results. The order it requires is always descending, so this just makes it so that we always presort to it's desired order. 