### PR TITLE
allow for negation of pycbc types

### DIFF
--- a/pycbc/types/array.py
+++ b/pycbc/types/array.py
@@ -389,6 +389,13 @@ class Array(object):
     @_returntype
     @_convert
     @_checkother
+    def __neg__(self):
+        """ Return negation of self """
+        return - self._data
+
+    @_returntype
+    @_convert
+    @_checkother
     def __sub__(self,other):
         """ Subtract Array or scalar from Array and return an Array. """
         return self._data - other

--- a/pycbc/types/array.py
+++ b/pycbc/types/array.py
@@ -388,7 +388,6 @@ class Array(object):
 
     @_returntype
     @_convert
-    @_checkother
     def __neg__(self):
         """ Return negation of self """
         return - self._data


### PR DESCRIPTION
This implements the negation operator so you can do 

x = -a

instead of the obtuse

x = -1 * a