### PR TITLE
Silence annoying matplotlib messages

### DIFF
--- a/bin/pycbc_optimal_snr
+++ b/bin/pycbc_optimal_snr
@@ -206,7 +206,7 @@ if __name__ == '__main__':
             psd = psds[det](injection_time)
             if psd is None:
                 continue
-            logging.debug('Trying injection %s', inj.simulation_id)
+            logging.info('Trying injection %s', inj.simulation_id)
             try:
                 wave = get_injection(injections, det, injection_time,
                                      simulation_id=inj.simulation_id)
@@ -219,7 +219,7 @@ if __name__ == '__main__':
                     logging.error('%s: waveform generation failed with the '
                                   'following exception', inj.simulation_id)
                     raise
-            logging.debug('Injection %s completed', inj.simulation_id)
+            logging.info('Injection %s completed', inj.simulation_id)
             sval = sigma(wave, psd=psd, low_frequency_cutoff=f_low)
             setattr(inj, column, sval)
         return inj

--- a/bin/pycbc_optimize_snr
+++ b/bin/pycbc_optimize_snr
@@ -134,7 +134,6 @@ parser.add_argument('--output-path', required=True,
 
 args = parser.parse_args()
 pycbc.init_logging(args.verbose)
-logging.getLogger('matplotlib').setLevel(logging.WARNING)
 
 logging.info('Starting optimize SNR')
 

--- a/bin/pygrb/pycbc_pygrb_pp_workflow
+++ b/bin/pygrb/pycbc_pygrb_pp_workflow
@@ -70,7 +70,7 @@ def make_pygrb_skygrid_plot(workflow, out_dir, exclude=None, require=None,
 
     # Exectuable
     exec_name = 'pygrb_plot_skygrid'
-    logging.debug("Executable name: %s" % exec_name)
+    logging.info("Executable name: %s" % exec_name)
     # Initialize job node
     grb_name = workflow.cp.get('workflow', 'trigger-name')
     node = PlotExecutable(workflow.cp, exec_name,
@@ -97,7 +97,7 @@ def make_pygrb_timeseries_or_signal_consistency_plot(workflow, exec_name,
     out_dir, injs=True, ifo=None, exclude=None, require=None, tags=[]):
     """Adds a PyGRB signal consistency plot to the workflow"""
 
-    logging.debug("Executable name: %s" % exec_name)
+    logging.info("Executable name: %s" % exec_name)
     # Initialize job node
     grb_name = workflow.cp.get('workflow', 'trigger-name')
     node = PlotExecutable(workflow.cp, exec_name, ifos=wflow.ifos,

--- a/pycbc/__init__.py
+++ b/pycbc/__init__.py
@@ -46,12 +46,22 @@ except:
 __version__ = pycbc_version
 
 
-def init_logging(verbose=False, format='%(asctime)s %(message)s',
-                 level=None):
-    """ Common utility for setting up logging in PyCBC.
+def init_logging(verbose=False, format='%(asctime)s %(message)s'):
+    """Common utility for setting up logging in PyCBC.
 
     Installs a signal handler such that verbosity can be activated at
     run-time by sending a SIGUSR1 to the process.
+
+    Parameters
+    ----------
+    verbose : bool or int, optional
+        What level to set the verbosity level to. Accepts either a boolean
+        or an integer representing the level to set. If True/False will set to 
+        ``logging.INFO``/``logging.WARN``. For higher logging levels, pass
+        an integer representing the level to set (see the ``logging`` module
+        for details). Default is ``False`` (``logging.WARN``).
+    format : str, optional
+        The format to use for logging messages.
     """
     def sig_handler(signum, frame):
         logger = logging.getLogger()
@@ -66,14 +76,15 @@ def init_logging(verbose=False, format='%(asctime)s %(message)s',
 
     signal.signal(signal.SIGUSR1, sig_handler)
 
-    if level is None:
-        level = logging.INFO
-    if verbose:
-        initial_level = level
-    else:
+    if not verbose:
         initial_level = logging.WARN
+    elif int(verbose) == 1:
+        initial_level = logging.INFO
+    else:
+        initial_level = int(verbose)
     logging.getLogger().setLevel(initial_level)
     logging.basicConfig(format=format, level=initial_level)
+
 
 def makedir(path):
     """

--- a/pycbc/__init__.py
+++ b/pycbc/__init__.py
@@ -56,7 +56,7 @@ def init_logging(verbose=False, format='%(asctime)s %(message)s'):
     ----------
     verbose : bool or int, optional
         What level to set the verbosity level to. Accepts either a boolean
-        or an integer representing the level to set. If True/False will set to 
+        or an integer representing the level to set. If True/False will set to
         ``logging.INFO``/``logging.WARN``. For higher logging levels, pass
         an integer representing the level to set (see the ``logging`` module
         for details). Default is ``False`` (``logging.WARN``).

--- a/pycbc/__init__.py
+++ b/pycbc/__init__.py
@@ -46,7 +46,8 @@ except:
 __version__ = pycbc_version
 
 
-def init_logging(verbose=False, format='%(asctime)s %(message)s'):
+def init_logging(verbose=False, format='%(asctime)s %(message)s',
+                 level=None):
     """ Common utility for setting up logging in PyCBC.
 
     Installs a signal handler such that verbosity can be activated at
@@ -65,8 +66,10 @@ def init_logging(verbose=False, format='%(asctime)s %(message)s'):
 
     signal.signal(signal.SIGUSR1, sig_handler)
 
+    if level is None:
+        level = logging.INFO
     if verbose:
-        initial_level = logging.DEBUG
+        initial_level = level
     else:
         initial_level = logging.WARN
     logging.getLogger().setLevel(initial_level)

--- a/pycbc/vetoes/bank_chisq.py
+++ b/pycbc/vetoes/bank_chisq.py
@@ -93,7 +93,7 @@ def template_overlaps(bank_filters, template, psd, low_frequency_cutoff):
             errMsg += "Masses of bank filter template: %e %e\n" \
                       %(bank_template.params.mass1, bank_template.params.mass2)
             errMsg += "Overlap: %e" %(abs(overlaps[-1]))
-            logging.debug(errMsg)
+            logging.info(errMsg)
     return overlaps
 
 def bank_chisq_from_filters(tmplt_snr, tmplt_norm, bank_snrs, bank_norms,

--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -251,7 +251,7 @@ class Executable(pegasus_workflow.Executable):
                 self.needs_fetching = True
 
             self.add_pfn(exe_path, site=exe_site)
-            logging.debug("Using %s executable "
+            logging.info("Using %s executable "
                           "at %s on site %s" % (name, exe_url.path, exe_site))
 
         # Determine the condor universe if we aren't given one
@@ -261,7 +261,7 @@ class Executable(pegasus_workflow.Executable):
             else:
                 self.universe = 'vanilla'
 
-        logging.debug("%s executable will run as %s universe"
+        logging.info("%s executable will run as %s universe"
                      % (name, self.universe))
 
         self.set_universe(self.universe)
@@ -1923,7 +1923,7 @@ def make_external_call(cmdList, out_dir=None, out_basename='external_call',
         outFP = None
 
     msg = "Making external call %s" %(' '.join(cmdList))
-    logging.debug(msg)
+    logging.info(msg)
     errCode = subprocess.call(cmdList, stderr=errFP, stdout=outFP,\
                               shell=shell)
     if errFP:
@@ -1934,7 +1934,7 @@ def make_external_call(cmdList, out_dir=None, out_basename='external_call',
     if errCode and fail_on_error:
         raise CalledProcessErrorMod(errCode, ' '.join(cmdList),
                 errFile=errFile, outFile=outFile, cmdFile=cmdFile)
-    logging.debug("Call successful, or error checking disabled.")
+    logging.info("Call successful, or error checking disabled.")
 
 class CalledProcessErrorMod(Exception):
     """

--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -252,7 +252,7 @@ class Executable(pegasus_workflow.Executable):
 
             self.add_pfn(exe_path, site=exe_site)
             logging.info("Using %s executable "
-                          "at %s on site %s" % (name, exe_url.path, exe_site))
+                         "at %s on site %s" % (name, exe_url.path, exe_site))
 
         # Determine the condor universe if we aren't given one
         if self.universe is None:

--- a/pycbc/workflow/datafind.py
+++ b/pycbc/workflow/datafind.py
@@ -416,7 +416,7 @@ def setup_datafind_runtime_cache_multi_calls_perifo(cp, scienceSegs,
         for seg in scienceSegsIfo:
             msg = "Finding data between %d and %d " %(seg[0],seg[1])
             msg += "for ifo %s" %(ifo)
-            logging.debug(msg)
+            logging.info(msg)
             # WARNING: For now the workflow will expect times to be in integer seconds
             startTime = int(seg[0])
             endTime = int(seg[1])
@@ -952,10 +952,10 @@ def run_datafind_instance(cp, outputDir, connection, observatory, frameType,
     # directory to check if this was expected.
     log_datafind_command(observatory, frameType, startTime, endTime,
                          os.path.join(outputDir,'logs'), **dfKwargs)
-    logging.debug("Asking datafind server for frames.")
+    logging.info("Asking datafind server for frames.")
     dfCache = connection.find_frame_urls(observatory, frameType,
                                         startTime, endTime, **dfKwargs)
-    logging.debug("Frames returned")
+    logging.info("Frames returned")
     # workflow format output file
     cache_file = File(ifo, 'DATAFIND', seg, extension='lcf',
                       directory=outputDir, tags=tags)


### PR DESCRIPTION
For the past year, I've been getting a bunch of annoying messages from matplotlib about finding fonts whenever I run any of the inference plotting codes with verbose on. It turns out the issue is that the `pycbc.init_logging` function sets the logging level to `DEBUG` if you pass `verbose=True`. At some point, matplotlib must of added the finding font messages at the DEBUG level. The problem goes away if you set the logging level to `INFO`.

So... this patch sets the initial logging level in `pycbc.init_logging` to `INFO` if `verbose=True` rather than `DEBUG`. I added an option `level` keyword argument if you want to set it to `DEBUG` instead. This is more sane I think, since it will result in all of our `logging.log` messages to be printed without all the extra crud.