### PR TITLE
Remove ArrayWithAligned

### DIFF
--- a/pycbc/fft/fftw.py
+++ b/pycbc/fft/fftw.py
@@ -320,14 +320,14 @@ def execute(plan, invec, outvec):
 
 def fft(invec, outvec, prec, itype, otype):
     theplan, destroy = plan(len(invec), invec.dtype, outvec.dtype, FFTW_FORWARD,
-                            get_measure_level(),(check_aligned(invec._data) and check_aligned(outvec._data)),
+                            get_measure_level(),(check_aligned(invec.data) and check_aligned(outvec.data)),
                    _scheme.mgr.state.num_threads, (invec.ptr == outvec.ptr))
     execute(theplan, invec, outvec)
     destroy(theplan)
 
 def ifft(invec, outvec, prec, itype, otype):
     theplan, destroy = plan(len(outvec), invec.dtype, outvec.dtype, FFTW_BACKWARD,
-                            get_measure_level(),(check_aligned(invec._data) and check_aligned(outvec._data)),
+                            get_measure_level(),(check_aligned(invec.data) and check_aligned(outvec.data)),
                    _scheme.mgr.state.num_threads, (invec.ptr == outvec.ptr))
     execute(theplan, invec, outvec)
     destroy(theplan)

--- a/pycbc/fft/fftw.py
+++ b/pycbc/fft/fftw.py
@@ -4,6 +4,7 @@ import ctypes
 import pycbc.scheme as _scheme
 from pycbc.libutils import get_ctypes_library
 from .core import _BaseFFT, _BaseIFFT
+from ..types import check_aligned
 
 # IMPORTANT NOTE TO PYCBC DEVELOPERS:
 # Because this module is loaded automatically when present, and because
@@ -319,14 +320,14 @@ def execute(plan, invec, outvec):
 
 def fft(invec, outvec, prec, itype, otype):
     theplan, destroy = plan(len(invec), invec.dtype, outvec.dtype, FFTW_FORWARD,
-                   get_measure_level(),(invec._data.isaligned and outvec._data.isaligned),
+                            get_measure_level(),(check_aligned(invec._data) and check_aligned(outvec._data)),
                    _scheme.mgr.state.num_threads, (invec.ptr == outvec.ptr))
     execute(theplan, invec, outvec)
     destroy(theplan)
 
 def ifft(invec, outvec, prec, itype, otype):
     theplan, destroy = plan(len(outvec), invec.dtype, outvec.dtype, FFTW_BACKWARD,
-                   get_measure_level(),(invec._data.isaligned and outvec._data.isaligned),
+                            get_measure_level(),(check_aligned(invec._data) and check_aligned(outvec._data)),
                    _scheme.mgr.state.num_threads, (invec.ptr == outvec.ptr))
     execute(theplan, invec, outvec)
     destroy(theplan)
@@ -400,7 +401,7 @@ def _fftw_setup(fftobj):
     if nthreads != _fftw_current_nthreads:
         _fftw_plan_with_nthreads(nthreads)
     mlvl = get_measure_level()
-    aligned = fftobj.invec.data.isaligned and fftobj.outvec.data.isaligned
+    aligned = check_aligned(fftobj.invec.data) and check_aligned(fftobj.outvec.data)
     flags = get_flag(mlvl, aligned)
     plan_func = _plan_funcs_dict[ (str(fftobj.invec.dtype), str(fftobj.outvec.dtype)) ]
     tmpin = zeros(len(fftobj.invec), dtype = fftobj.invec.dtype)

--- a/pycbc/types/__init__.py
+++ b/pycbc/types/__init__.py
@@ -2,3 +2,4 @@ from .array import *
 from .timeseries import *
 from .frequencyseries import *
 from .optparse import *
+from .aligned import check_aligned

--- a/pycbc/types/aligned.py
+++ b/pycbc/types/aligned.py
@@ -33,31 +33,15 @@ from pycbc import PYCBC_ALIGNMENT
 def check_aligned(ndarr):
     return ((ndarr.ctypes.data % PYCBC_ALIGNMENT) == 0)
 
-class ArrayWithAligned(_np.ndarray):
-    def __new__(cls, input_array):
-        obj = _np.asarray(input_array).view(cls)
-        return obj
-
-    def __array_wrap__(self, obj):
-        if obj.shape == ():
-            return obj[()]    # if ufunc output is scalar, return it
-        else:
-            return _np.ndarray.__array_wrap__(self, obj)
-
-    @property
-    def isaligned(self):
-        return check_aligned(self)
-
-    def __array_finalize__(self, obj):
-        if obj is None: return
-
 def zeros(n, dtype):
     d = _np.dtype(dtype)
     nbytes = (d.itemsize)*int(n)
     tmp = _np.zeros(nbytes+PYCBC_ALIGNMENT, dtype=_np.uint8)
     address = tmp.__array_interface__['data'][0]
     offset = (PYCBC_ALIGNMENT - address%PYCBC_ALIGNMENT)%PYCBC_ALIGNMENT
-    return ArrayWithAligned(tmp[offset:offset+nbytes].view(dtype=_np.dtype(dtype)))
+    ret_ary =  tmp[offset:offset+nbytes].view(dtype=d)
+    del tmp
+    return ret_ary
 
 def empty(n, dtype):
     d = _np.dtype(dtype)
@@ -65,4 +49,6 @@ def empty(n, dtype):
     tmp = _np.empty(nbytes+PYCBC_ALIGNMENT, dtype=_np.uint8)
     address = tmp.__array_interface__['data'][0]
     offset = (PYCBC_ALIGNMENT - address%PYCBC_ALIGNMENT)%PYCBC_ALIGNMENT
-    return ArrayWithAligned(tmp[offset:offset+nbytes].view(dtype=d))
+    ret_ary = tmp[offset:offset+nbytes].view(dtype=d)
+    del tmp
+    return ret_ary

--- a/pycbc/types/aligned.py
+++ b/pycbc/types/aligned.py
@@ -39,7 +39,7 @@ def zeros(n, dtype):
     tmp = _np.zeros(nbytes+PYCBC_ALIGNMENT, dtype=_np.uint8)
     address = tmp.__array_interface__['data'][0]
     offset = (PYCBC_ALIGNMENT - address%PYCBC_ALIGNMENT)%PYCBC_ALIGNMENT
-    ret_ary =  tmp[offset:offset+nbytes].view(dtype=d)
+    ret_ary = tmp[offset:offset+nbytes].view(dtype=d)
     del tmp
     return ret_ary
 

--- a/pycbc/types/array.py
+++ b/pycbc/types/array.py
@@ -41,7 +41,6 @@ from numpy.linalg import norm
 
 import pycbc.scheme as _scheme
 from pycbc.scheme import schemed, cpuonly
-from pycbc.types.aligned import ArrayWithAligned
 from pycbc.opt import LimitedSizeDict
 
 #! FIXME: the uint32 datatype has not been fully tested,
@@ -149,11 +148,6 @@ class Array(object):
         if not copy:
             if not _scheme_matches_base_array(initial_array):
                 raise TypeError("Cannot avoid a copy of this array")
-            elif issubclass(type(self._scheme), _scheme.CPUScheme):
-                # ArrayWithAligned does not copy its memory; all 
-                # the following does is add the 'isaligned' flag
-                # in case initial_array was a true numpy array
-                self._data = ArrayWithAligned(initial_array)
             else:
                 self._data = initial_array
 
@@ -192,10 +186,9 @@ class Array(object):
             #Create new instance with initial_array as initialization.
             if issubclass(type(self._scheme), _scheme.CPUScheme):
                 if hasattr(initial_array, 'get'):
-                    self._data = ArrayWithAligned(_numpy.array(initial_array.get()))
+                    self._data = _numpy.array(initial_array.get())
                 else:
-                    self._data = ArrayWithAligned(_numpy.array(initial_array, 
-                                                               dtype=dtype, ndmin=1))
+                    self._data = _numpy.array(initial_array, dtype=dtype, ndmin=1)
             elif _scheme_matches_base_array(initial_array):
                 self._data = _copy_base_array(initial_array) # pylint:disable=assignment-from-no-return
             else:

--- a/pycbc/types/array.py
+++ b/pycbc/types/array.py
@@ -1070,6 +1070,15 @@ def zeros(length, dtype=float64):
     err_msg += "the scheme. You shouldn't be seeing this error!"
     raise ValueError(err_msg)
 
+@_return_array
+@schemed(BACKEND_PREFIX)
+def empty(length, dtype=float64):
+    """ Return an empty Array (no initialization)
+    """
+    err_msg = "This function is a stub that should be overridden using "
+    err_msg += "the scheme. You shouldn't be seeing this error!"
+    raise ValueError(err_msg)
+
 def load_array(path, group=None):
     """
     Load an Array from a .hdf, .txt or .npy file. The

--- a/pycbc/types/array_cpu.pyx
+++ b/pycbc/types/array_cpu.pyx
@@ -187,9 +187,6 @@ def clear(self):
     self[:] = 0 
     
 def _scheme_matches_base_array(array):
-    # Since ArrayWithAligned is a subclass of ndarray,
-    # and since converting to ArrayWithAligned will
-    # *not* copy 'array', the following is the way to go:
     if isinstance(array, _np.ndarray):
         return True
     else:

--- a/test/test_array.py
+++ b/test/test_array.py
@@ -46,9 +46,9 @@ if _scheme == 'cuda':
     import pycuda.gpuarray
     from pycuda.gpuarray import GPUArray as SchemeArray
 elif _scheme == 'cpu':
-    from pycbc.types.aligned import ArrayWithAligned as SchemeArray
+    from numpy import ndarray as SchemeArray
 
-from pycbc.types.aligned import ArrayWithAligned as CPUArray
+from numpy import ndarray as CPUArray
 
 # ********************GENERIC ARRAY TESTS ***********************
 

--- a/test/test_frequencyseries.py
+++ b/test/test_frequencyseries.py
@@ -45,9 +45,9 @@ if _scheme == 'cuda':
     import pycuda.gpuarray
     from pycuda.gpuarray import GPUArray as SchemeArray
 elif _scheme == 'cpu':
-    from pycbc.types.aligned import ArrayWithAligned as SchemeArray
+    from numpy import ndarray as SchemeArray
 
-from pycbc.types.aligned import ArrayWithAligned as CPUArray
+from numpy import ndarray as CPUArray
 
 class TestFrequencySeriesBase(array_base,unittest.TestCase):
     def setUp(self):

--- a/test/test_schemes.py
+++ b/test/test_schemes.py
@@ -48,9 +48,9 @@ if isinstance(_context,CUDAScheme):
     import pycuda.gpuarray
     from pycuda.gpuarray import GPUArray as SchemeArray
 elif isinstance(_context,CPUScheme):
-    from pycbc.types.aligned import ArrayWithAligned as SchemeArray
+    from numpy import ndarray as SchemeArray
 
-from pycbc.types.aligned import ArrayWithAligned as CPUArray
+from numpy import ndarray as CPUArray
 
 
 class SchemeTestBase(unittest.TestCase):

--- a/test/test_timeseries.py
+++ b/test/test_timeseries.py
@@ -45,9 +45,9 @@ if _scheme == 'cuda':
     import pycuda.gpuarray
     from pycuda.gpuarray import GPUArray as SchemeArray
 elif _scheme == 'cpu':
-    from pycbc.types.aligned import ArrayWithAligned as SchemeArray
+    from numpy import ndarray as SchemeArray
 
-from pycbc.types.aligned import ArrayWithAligned as CPUArray
+from numpy import ndarray as CPUArray
 
 class TestTimeSeriesBase(array_base,unittest.TestCase):
     def setUp(self):

--- a/tools/timing/fft_perf.py
+++ b/tools/timing/fft_perf.py
@@ -59,7 +59,7 @@ N = 2**options.size
 
 vecin = zeros(N, dtype=complex64)
 vecout = zeros(N, dtype=complex64)
-print("ALIGNMENT:", vecin.data.isaligned)
+print("ALIGNMENT:", check_aligned(vecin.data))
 
 if options.import_float_wisdom:
     print("Loading a wisdom file")


### PR DESCRIPTION
The original motivation for sub-classing `ndarray` in this way was to allow checking that an array had sufficient alignment for SIMD vectorized operations without incurring the overhead of performing that calculation over and over.

Since we have moved to providing classes to implement our time-critical operations (e.g. FFT, correlation, peak-finding) we avoid this overhead simply by using the same arrays over and over, and only checking alignment at class instantiation. In the meantime, it is often inconvenient to have a subclass of ndarray, though arguably this is because other packages don't properly check class types via `isinstance`. However, we have no control over what other packages do, so I think for us it is better to eliminate this subclass.

I noted that at some point our SIMD vectorized version of correlation got decoupled from our class types (e.g. `CPUCorrelator`). That should be plugged back in at some point, at which point a check for alignment should be added, as that function will fail if its arguments are not aligned.