### PR TITLE
Improve PyCBC Live SNR followup

### DIFF
--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -77,6 +77,19 @@ class LiveEventManager(object):
 
         self.run_snr_optimization = run_snr_optimization
 
+        # preestimate the number of CPU cores that we can afford giving to
+        # followup processes without slowing down the main search noticeably
+        available_cores = len(os.sched_getaffinity(0))
+        num_triggering_ifos = len(args.channel_name.keys())
+        bg_cores = itertools.combinations(num_triggering_ifos, 2)
+        analysis_cores = 1 + bg_cores
+        self.fu_cores = available_cores - analysis_cores
+        if self.fu_cores <= 0:
+            logging.info('Insufficient number of CPU cores (%d) to run search'
+                         ' and followups. Uploads will momentarily increase lag',
+                         available_cores)
+            self.fu_cores = 1
+
     def commit_results(self, results):
         self.comm.gather(results, root=0)
 
@@ -242,7 +255,7 @@ class LiveEventManager(object):
                     * bank.sample_rate)
                 flen = int(tlen / 2 + 1)
                 delta_f = bank.sample_rate / float(tlen)
-                cmd = 'timeout 400 '
+                cmd = 'timeout {} '.format(args.snr_opt_timeout)
                 exepath = distutils.spawn.find_executable('pycbc_optimize_snr')
                 cmd += exepath + ' '
                 data_fils_str = '--data-files '
@@ -299,6 +312,9 @@ class LiveEventManager(object):
                 cmd += '--output-path {} '.format(self.path)
                 if self.enable_gracedb_upload:
                     cmd += '--enable-gracedb-upload '
+
+                cmd += '--workers {}'.format(self.fu_cores)
+
                 log_fname = \
                         fname.replace('.xml.gz', '_optimize_snr_log.dat')
 
@@ -546,6 +562,8 @@ parser.add_argument('--run-snr-optimization', action='store_true',
                     default=False,
                     help='Run spawned followup processes to maximize SNR for '
                          'any trigger uploaded to GraceDB')
+parser.add_argument('--snr-opt-timeout', type=int, default=400, metavar='SECONDS',
+                    help='Maximum allowed duration of followup process to maximize SNR')
 
 
 scheme.insert_processing_option_group(parser)
@@ -589,9 +607,9 @@ evnt = LiveEventManager(args.output_path,
 sg_chisq = SingleDetSGChisq.from_cli(args, bank, args.chisq_bins)
 
 if args.size_override:
-    evnt.size=args.size_override
+    evnt.size = args.size_override
 
-# ifos used for primary analysis (only two at the moment)
+# ifos used for primary analysis
 ifos = set(args.channel_name.keys())
 logging.info('Running with %s', ', '.join(sorted(ifos)))
 

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -85,9 +85,9 @@ class LiveEventManager(object):
         analysis_cores = 1 + bg_cores
         self.fu_cores = available_cores - analysis_cores
         if self.fu_cores <= 0:
-            logging.warn('Insufficient number of CPU cores (%d) to run search'
-                         ' and followups. Uploads will momentarily increase lag',
-                         available_cores)
+            logging.warning('Insufficient number of CPU cores (%d) to run '
+                            'search and followups. Uploads will momentarily '
+                            'increase the lag', available_cores)
             self.fu_cores = 1
 
     def commit_results(self, results):

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -85,7 +85,7 @@ class LiveEventManager(object):
         analysis_cores = 1 + bg_cores
         self.fu_cores = available_cores - analysis_cores
         if self.fu_cores <= 0:
-            logging.info('Insufficient number of CPU cores (%d) to run search'
+            logging.warn('Insufficient number of CPU cores (%d) to run search'
                          ' and followups. Uploads will momentarily increase lag',
                          available_cores)
             self.fu_cores = 1
@@ -313,7 +313,7 @@ class LiveEventManager(object):
                 if self.enable_gracedb_upload:
                     cmd += '--enable-gracedb-upload '
 
-                cmd += '--workers {}'.format(self.fu_cores)
+                cmd += '--cores {}'.format(self.fu_cores)
 
                 log_fname = \
                         fname.replace('.xml.gz', '_optimize_snr_log.dat')

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -77,18 +77,19 @@ class LiveEventManager(object):
 
         self.run_snr_optimization = run_snr_optimization
 
-        # preestimate the number of CPU cores that we can afford giving to
-        # followup processes without slowing down the main search noticeably
-        available_cores = len(os.sched_getaffinity(0))
-        num_triggering_ifos = len(args.channel_name.keys())
-        bg_cores = itertools.combinations(num_triggering_ifos, 2)
-        analysis_cores = 1 + bg_cores
-        self.fu_cores = available_cores - analysis_cores
-        if self.fu_cores <= 0:
-            logging.warning('Insufficient number of CPU cores (%d) to run '
-                            'search and followups. Uploads will momentarily '
-                            'increase the lag', available_cores)
-            self.fu_cores = 1
+        if self.rank == 0:
+            # preestimate the number of CPU cores that we can afford giving to
+            # followup processes without slowing down the main search
+            available_cores = len(os.sched_getaffinity(0))
+            bg_cores = len(tuple(itertools.combinations(ifos, 2)))
+            analysis_cores = 1 + bg_cores
+            self.fu_cores = available_cores - analysis_cores
+            if self.fu_cores <= 0:
+                logging.warning('Insufficient number of CPU cores (%d) to '
+                                'run search and trigger followups. Uploaded '
+                                'triggers will momentarily increase the lag',
+                                available_cores)
+                self.fu_cores = 1
 
     def commit_results(self, results):
         self.comm.gather(results, root=0)
@@ -596,6 +597,10 @@ if bank.min_f_lower < args.low_frequency_cutoff:
                  'minimum f_lower across all templates '
                  '({} Hz)'.format(args.low_frequency_cutoff, bank.min_f_lower))
 
+# ifos used for primary analysis
+ifos = set(args.channel_name.keys())
+logging.info('Running with %s', ', '.join(sorted(ifos)))
+
 evnt = LiveEventManager(args.output_path,
                         use_date_prefix=args.day_hour_output_prefix,
                         ifar_upload_threshold=args.ifar_upload_threshold,
@@ -608,10 +613,6 @@ sg_chisq = SingleDetSGChisq.from_cli(args, bank, args.chisq_bins)
 
 if args.size_override:
     evnt.size = args.size_override
-
-# ifos used for primary analysis
-ifos = set(args.channel_name.keys())
-logging.info('Running with %s', ', '.join(sorted(ifos)))
 
 # make sure we can talk to GraceDB
 if evnt.rank == 0 and args.enable_gracedb_upload:

--- a/bin/pycbc_optimize_snr
+++ b/bin/pycbc_optimize_snr
@@ -104,7 +104,7 @@ parser = argparse.ArgumentParser(description=__doc__)
 parser.add_argument('--version', action='version',
                     version=version.git_verbose_msg)
 parser.add_argument('--verbose', action='store_true')
-parser.add_argument('--params-file',
+parser.add_argument('--params-file', required=True,
                     help='Location of the attributes file created by PyCBC '
                          'Live')
 parser.add_argument("--data-files", type=str, nargs='+',
@@ -131,6 +131,8 @@ parser.add_argument('--enable-gracedb-upload', action='store_true', default=Fals
                     help='Upload triggers to GraceDB')
 parser.add_argument('--output-path', required=True,
                     help='Path to a directory to store results in')
+parser.add_argument('--workers', type=int, default=-1,
+                    help='Number of CPU cores to use, -1 means all')
 
 args = parser.parse_args()
 pycbc.init_logging(args.verbose)
@@ -181,7 +183,7 @@ bounds = [(minchirp, maxchirp), (0.01, 0.2499), (-0.9, 0.9), (-0.9, 0.9)]
 logging.info('Starting optimization')
 
 results = differential_evolution(compute_network_snr, bounds,
-                                 maxiter=100, workers=-1,
+                                 maxiter=100, workers=args.workers,
                                  popsize=200, mutation=(0.5,1),
                                  recombination=0.7, callback=callback_func,
                                  args=extra_args)

--- a/bin/pycbc_optimize_snr
+++ b/bin/pycbc_optimize_snr
@@ -131,8 +131,8 @@ parser.add_argument('--enable-gracedb-upload', action='store_true', default=Fals
                     help='Upload triggers to GraceDB')
 parser.add_argument('--output-path', required=True,
                     help='Path to a directory to store results in')
-parser.add_argument('--workers', type=int, default=-1,
-                    help='Number of CPU cores to use, -1 means all')
+parser.add_argument('--cores', type=int,
+                    help='Restrict calculation to given number of CPU cores')
 
 args = parser.parse_args()
 pycbc.init_logging(args.verbose)
@@ -183,7 +183,7 @@ bounds = [(minchirp, maxchirp), (0.01, 0.2499), (-0.9, 0.9), (-0.9, 0.9)]
 logging.info('Starting optimization')
 
 results = differential_evolution(compute_network_snr, bounds,
-                                 maxiter=100, workers=args.workers,
+                                 maxiter=100, workers=(args.cores or -1),
                                  popsize=200, mutation=(0.5,1),
                                  recombination=0.7, callback=callback_func,
                                  args=extra_args)


### PR DESCRIPTION
* Do not steal CPU cores from the main search when doing the SNR optimization
* SNR optimization timeout is now configurable from the command line
* Minor fixes