### PR TITLE
Pin versions of setuptools and pip in Dockerfile to workaround dropped python2 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN rpm -ivh http://software.ligo.org/lscsoft/scientific/7/x86_64/production/l/l
     yum -y groupinstall "Compatibility Libraries" \
                         "Development Tools" \
                         "Scientific Support" && \
-    rpm -e --nodeps git perl-Git && yum -y install python2-pip python-setuptools zlib-devel libpng-devel libjpeg-devel libsqlite3-dev sqlite-devel db4-devel openssl-devel git2u-all fftw-libs-single fftw-devel fftw fftw-libs-long fftw-libs fftw-libs-double gsl gsl-devel libframe-utils libframe-devel libframe libmetaio libmetaio-devel libmetaio-utils hdf5 hdf5-devel python-devel which osg-wn-client osg-ca-certs && pip install --upgrade pip setuptools && pip install mkl ipython jupyter
+    rpm -e --nodeps git perl-Git && yum -y install python2-pip python-setuptools zlib-devel libpng-devel libjpeg-devel libsqlite3-dev sqlite-devel db4-devel openssl-devel git2u-all fftw-libs-single fftw-devel fftw fftw-libs-long fftw-libs fftw-libs-double gsl gsl-devel libframe-utils libframe-devel libframe libmetaio libmetaio-devel libmetaio-utils hdf5 hdf5-devel python-devel which osg-wn-client osg-ca-certs && pip install --upgrade pip==19.3.1 setuptools==44.0.0 && pip install mkl ipython jupyter
 
 # set up environment
 RUN cd / && \


### PR DESCRIPTION
Our travis tests are all failing the `PYCBC_CONTAINER=pycbc_docker DOCKER_IMG=pycbc/pycbc-el7` test because the release of `setuptools 45.0.0` dropped support for Python 2.  Thus we cannot simply upgrade pip and setuptools in the Dockerfile.  As a workaround, this PR simply pins both setuptools and pip to working versions (pip has not yet shown a problem, but I went ahead and included it in the pin).

We should of course revert this as soon as we are able to drop python2 support ourselves.