### PR TITLE
Python3 workflow fixes

### DIFF
--- a/bin/hdfcoinc/pycbc_fit_sngls_split_binned
+++ b/bin/hdfcoinc/pycbc_fit_sngls_split_binned
@@ -282,7 +282,7 @@ logging.info('setting up plotting variables')
 histcolors = ['r',(1.0,0.6,0),'y','g','c','b','m','k',(0.8,0.25,0),(0.25,0.8,0)]
 fig, axes = plt.subplots(args.split_one_nbins, args.split_two_nbins,
                          sharex=True, sharey=True,
-                         figsize=(3 * args.split_two_nbins,
+                         figsize=(3 * (args.split_two_nbins + 1),
                                   3 * args.split_one_nbins))
 
 # setting up overall legend outside the split-up plots
@@ -299,8 +299,8 @@ line_fit, = axes[0,0].plot([0,0], [0,0], linestyle='--',
                            color='k', alpha=0.6)
 lines.append(line_fit)
 labels.append(args.fit_function + ' fit to counts')
-lgd = axes[0,0].legend(lines, labels, labelspacing=0.2,
-                       bbox_to_anchor=(-0.5, 0.5), title=args.bin_param)
+fig.legend(lines, labels, labelspacing=0.2,
+           loc='upper left', title=args.bin_param)
 
 pidx = []
 for i in range(args.num_bins):
@@ -387,13 +387,11 @@ for i in range(args.split_one_nbins):
                                       sp_one_bounds.upper()[i]) + '\ncumulative number',
                                       size="large")
 
-axes[0,0].add_artist(lgd)
-
-fkwds = {'bbox_extra_artists': (lgd,), 'bbox_inches': 'tight'}
+fig.tight_layout(rect=(1./(args.split_two_nbins+1), 0, 1, 1))
 
 logging.info('saving to file ' + args.output_file)
 results.save_fig_with_metadata(
-    fig, args.output_file, fig_kwds=fkwds,
+    fig, args.output_file,
     title="{}: {} histogram of single detector triggers split by"
           " {} and {}".format(args.ifo, args.sngl_stat, args.split_param_one,
                               args.split_param_two),

--- a/bin/hdfcoinc/pycbc_page_ifar
+++ b/bin/hdfcoinc/pycbc_page_ifar
@@ -260,15 +260,13 @@ pylab.loglog(expected_ifar, expected_cumnum, linestyle='--', linewidth=2, color=
 error_plus = expected_cumnum + numpy.sqrt(expected_cumnum)
 error_minus = expected_cumnum - numpy.sqrt(expected_cumnum)
 error_minus = numpy.where(error_minus<=0, 1e-5, error_minus)
-xs, ys = pylab.poly_between(expected_ifar, error_minus, error_plus)
-pylab.fill(xs, ys, facecolor='y', alpha=0.4, label='$N^{1/2}$ Errors')
+pylab.fill_between(expected_ifar, error_minus, error_plus, facecolor='y', alpha=0.4, label='$N^{1/2}$ Errors')
 
 # plot the counting error
 error_plus = expected_cumnum + 2 * numpy.sqrt(expected_cumnum)
 error_minus = expected_cumnum - 2*numpy.sqrt(expected_cumnum)
 error_minus = numpy.where(error_minus<=0, 1e-5, error_minus)
-xs, ys = pylab.poly_between(expected_ifar, error_minus, error_plus)
-pylab.fill(xs, ys, facecolor='y', alpha=0.2, label='$2N^{1/2}$ Errors')
+pylab.fill_between(expected_ifar, error_minus, error_plus, facecolor='y', alpha=0.2, label='$2N^{1/2}$ Errors')
 
 # plot the foreground triggers
 if opts.open_box:

--- a/bin/minifollowups/pycbc_single_template_plot
+++ b/bin/minifollowups/pycbc_single_template_plot
@@ -106,7 +106,7 @@ if args.plot_caption is None:
     args.plot_caption = ''
 
 if 'command_line' in f.attrs:
-    cmd = f.attrs['command_line'] + '\\n\\n' + ' '.join(sys.argv)
+    cmd = f.attrs['command_line'].decode() + '\\n\\n' + ' '.join(sys.argv)
 else:
     cmd = ' '.join(sys.argv)
 


### PR DESCRIPTION
Three changes to fix the python3 offline workflow.

pycbc_fit_sngls_split_binned
 - The "bbox_extra_artist" option didn't work in python3
 - Changed so it is consistant in python 2 and 3

pycbc_page_far
 - poly_between is not in matplotlib 3 (fill_between is equivalent and exists in matplotlib 2)

pycbc_single_template_plot
 - convert from byte object to string