### PR TITLE
Modify PSD variation calculation to use numpy

### DIFF
--- a/pycbc/psd/variation.py
+++ b/pycbc/psd/variation.py
@@ -369,8 +369,8 @@ def new_find_trigger_value(psd_var, idx, start, sample_rate):
     if not hasattr(psd_var, 'cached_psd_var_interpolant'):
         from scipy import interpolate
         psd_var.cached_psd_var_interpolant = \
-            interpolate.interp1d(psd_var.sample_times.numpy(), psd_var.numpy(), fill_value=1.0,
-                                 bounds_error=False)
+            interpolate.interp1d(psd_var.sample_times.numpy(), psd_var.numpy(),
+                                 fill_value=1.0, bounds_error=False)
     vals = psd_var.cached_psd_var_interpolant(time)
 
     return vals

--- a/pycbc/psd/variation.py
+++ b/pycbc/psd/variation.py
@@ -369,7 +369,7 @@ def new_find_trigger_value(psd_var, idx, start, sample_rate):
     if not hasattr(psd_var, 'cached_psd_var_interpolant'):
         from scipy import interpolate
         psd_var.cached_psd_var_interpolant = \
-            interpolate.interp1d(psd_var.sample_times, psd_var, fill_value=1,
+            interpolate.interp1d(psd_var.sample_times.numpy(), psd_var.numpy(), fill_value=1.0,
                                  bounds_error=False)
     vals = psd_var.cached_psd_var_interpolant(time)
 


### PR DESCRIPTION
This PR changes the calculation of the PSD variation TimeSeries in the function `psd.variation.calc_filt_psd_variation` to work whenever possible with numpy arrays, rather than pycbc array types. A few corresponding compatibility changes are also introduced in other functions.  No attempt has been made to modify other, similar functions in the variation module, but as this is the function called by `pycbc_inspiral`, the priority was fixing it.

The need for the change is to allow this code to run when `pycbc_inspiral` is executed on a GPU. Because the `calc_filt_psd_variation` function is only called once, and involves calls to other functions only implemented on numpy arrays, it is both sufficient and simpler to force this function to do most of its work on the CPU, even when the matched filtering takes place on the GPU.  But because pycbc will automatically migrate its own array types to the GPU when running under a CUDA scheme, this required expressly rewriting the relevant functions to use numpy arrays.

On a simple run I've tested that comparable (within 1e-05) values for the PSD variation vector are generated between this code and the code before the change.