### PR TITLE
allow to pass initialization args to dynesty

### DIFF
--- a/pycbc/inference/sampler/dynesty.py
+++ b/pycbc/inference/sampler/dynesty.py
@@ -125,17 +125,16 @@ class DynestySampler(BaseSampler):
             get_optional_arg_from_config(cp, section, 'loglikelihood-function')
             
         # optional arguments for dynesty
-        cargs = {'bound': str, 
+        cargs = {'bound': str,
                  'bootstrap': int,
                  'enlarge': float,
                  'update_interval': float,
-                 'sample': str,
-                }
+                 'sample': str}
         extra = {}
-        for karg in nargs:
+        for karg in cargs:
             if cp.has_option(section, karg):
-                extra[karg] = cargs[karg](cp.get(section, karg))   
-            
+                extra[karg] = cargs[karg](cp.get(section, karg))
+
         obj = cls(model, nlive=nlive, dlogz=dlogz, nprocesses=nprocesses,
                   loglikelihood_function=loglikelihood_function,
                   use_mpi=use_mpi, **extra)

--- a/pycbc/inference/sampler/dynesty.py
+++ b/pycbc/inference/sampler/dynesty.py
@@ -123,9 +123,22 @@ class DynestySampler(BaseSampler):
         dlogz = float(cp.get(section, "dlogz"))
         loglikelihood_function = \
             get_optional_arg_from_config(cp, section, 'loglikelihood-function')
+            
+        # optional arguments for dynesty
+        cargs = {'bound': str, 
+                 'bootstrap': int,
+                 'enlarge': float,
+                 'update_interval': float,
+                 'sample': str,
+                }
+        extra = {}
+        for karg in nargs:
+            if cp.has_option(section, karg):
+                extra[karg] = cargs[karg](cp.get(section, karg))   
+            
         obj = cls(model, nlive=nlive, dlogz=dlogz, nprocesses=nprocesses,
                   loglikelihood_function=loglikelihood_function,
-                  use_mpi=use_mpi)
+                  use_mpi=use_mpi, **extra)
         return obj
 
     def checkpoint(self):

--- a/pycbc/inference/sampler/dynesty.py
+++ b/pycbc/inference/sampler/dynesty.py
@@ -123,7 +123,7 @@ class DynestySampler(BaseSampler):
         dlogz = float(cp.get(section, "dlogz"))
         loglikelihood_function = \
             get_optional_arg_from_config(cp, section, 'loglikelihood-function')
-            
+
         # optional arguments for dynesty
         cargs = {'bound': str,
                  'bootstrap': int,


### PR DESCRIPTION
This adds the ability to pass additional arguments from the config file to dynesty to help configure how it will run. 