### PR TITLE
PyCBC Live: add more info to GraceDB log

### DIFF
--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -175,7 +175,7 @@ class LiveEventManager(object):
         # rounding errors, so force all of them to be identical
         fix_delta_t = None
         for ifo in out:
-            if 'snr_series' not in ifo:
+            if 'snr_series' not in out[ifo]:
                 continue
             if fix_delta_t is None:
                 fix_delta_t = out[ifo]['snr_series']._delta_t

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -33,6 +33,14 @@ from pycbc.vetoes.sgchisq import SingleDetSGChisq
 from pycbc.waveform.waveform import props
 
 
+def ppdets(ifos):
+    """Pretty-print a list (or set) of detectors: return a string listing
+    the given detectors alphabetically and separated by commas.
+    """
+    if ifos:
+        return ', '.join(sorted(ifos))
+    return 'no detectors'
+
 def ptof(p, ft):
     """Convert p-value to FAR via foreground time `ft`.
     """
@@ -163,6 +171,17 @@ class LiveEventManager(object):
                                        ptime, pvalue, sigma2,
                                        recalculate_ifar=recalculate_ifar)
 
+        # FIXME the SNR time series sample rate can vary slightly due to
+        # rounding errors, so force all of them to be identical
+        fix_delta_t = None
+        for ifo in out:
+            if 'snr_series' not in ifo:
+                continue
+            if fix_delta_t is None:
+                fix_delta_t = out[ifo]['snr_series']._delta_t
+            else:
+                out[ifo]['snr_series']._delta_t = fix_delta_t
+
         return out
 
     def get_followup_info(self, coinc_ifo, ifo, triggers, snr_series, ptime,
@@ -187,8 +206,8 @@ class LiveEventManager(object):
         triggers[base + 'sigmasq'] = sigma2
         if recalculate_ifar:
             # Calculate new ifar
-            triggers['foreground/ifar'] = combine_ifar_pvalue(triggers['foreground/ifar'],
-                                                              pvalue, self.pvalue_livetime)
+            triggers['foreground/ifar'] = combine_ifar_pvalue(
+                    triggers['foreground/ifar'], pvalue, self.pvalue_livetime)
 
 
     def check_coincs(self, ifos, coinc_results, psds, f_low,
@@ -219,11 +238,6 @@ class LiveEventManager(object):
 
             live_ifos = [ifo for ifo in fud if 'snr_series' in fud[ifo]]
 
-            # FIXME delta_t can vary due to rounding errors, force them to be identical
-            fix_delta_t = fud[coinc_ifos[0]]['snr_series'].delta_t
-            for ifo in live_ifos:
-                fud[ifo]['snr_series']._delta_t = fix_delta_t
-
             event = SingleCoincForGraceDB(live_ifos, coinc_results, bank=bank,
                                           psds=psds, followup_data=fud,
                                           low_frequency_cutoff=f_low,
@@ -234,8 +248,14 @@ class LiveEventManager(object):
             fname = 'coinc-{}-{}.xml.gz'.format(end_time, pycbc.random_string(6))
             fname = os.path.join(self.path, fname)
             logging.info('Coincident candidate! Saving as %s', fname)
-            comments = ['using ranking statistic: %s'
-                        % args.background_statistic]
+
+            # add some explanatory log entries
+            comment = ['Trigger produced as a {} coincidence. '
+                       'FAR is based on all listed detectors.<br />'
+                       'Two-detector ranking statistic: {}<br />'
+                       'Followup detectors: {}'.format(ppdets(coinc_ifos),
+                                                       args.background_statistic,
+                                                       ppdets(followup_ifos))]
 
             ifar = coinc_results['foreground/ifar']
             if self.enable_gracedb_upload and self.ifar_upload_threshold < ifar:
@@ -335,19 +355,14 @@ class LiveEventManager(object):
             if single is None:
                 continue
 
-            other_ifos = [i for i in active if i is not ifo]
+            followup_ifos = [i for i in active if i is not ifo]
             fud = self.compute_followup_data([ifo], single, data_reader,
-                                             bank, followup_ifos=other_ifos,
+                                             bank, followup_ifos=followup_ifos,
                                              recalculate_ifar=False)
             ifar = single['foreground/ifar']
             # apply a trials factor of the number of active detectors
             ifar /= len(active)
             single['foreground/ifar'] = ifar
-            
-            # FIXME delta_t can vary due to rounding errors, force them to be identical
-            fix_delta_t = fud[ifo]['snr_series'].delta_t
-            for ifo in active:
-                fud[ifo]['snr_series']._delta_t = fix_delta_t
 
             event = SingleCoincForGraceDB([ifo], single, bank=bank,
                                           psds=psds, followup_data=fud,
@@ -357,12 +372,19 @@ class LiveEventManager(object):
             end_time = int(single['foreground/%s/end_time' % ifo])
             fname = 'single-%s-%s.xml.gz' % (ifo, end_time)
             fname = os.path.join(self.path, fname)
-            logging.info('Single-detector candidate! Saving as %s',
-                         fname)
+            logging.info('Single-detector candidate! Saving as %s', fname)
+
+            # add some explanatory log entries
+            comments = ['Trigger produced as a {0} single. '
+                        'FAR is based on {0} only.<br />'
+                        'Followup detectors: {1}'.format(
+                                ifo, ppdets(followup_ifos))]
+
             if args.enable_single_detector_upload \
                     and self.ifar_upload_threshold < ifar:
                 event.upload(fname, gracedb_server=args.gracedb_server,
-                             testing=self.gracedb_testing)
+                             testing=self.gracedb_testing,
+                             extra_strings=comments)
             else:
                 event.save(fname)
 
@@ -610,7 +632,7 @@ if bank.min_f_lower < args.low_frequency_cutoff:
 
 # ifos used for primary analysis
 ifos = set(args.channel_name.keys())
-logging.info('Running with %s', ', '.join(sorted(ifos)))
+logging.info('Running with %s', ppdets(ifos))
 
 evnt = LiveEventManager(args.output_path,
                         use_date_prefix=args.day_hour_output_prefix,

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -171,7 +171,7 @@ class LiveEventManager(object):
                                        ptime, pvalue, sigma2,
                                        recalculate_ifar=recalculate_ifar)
 
-        # FIXME the SNR time series sample rate can vary slightly due to
+        # the SNR time series sample rate can vary slightly due to
         # rounding errors, so force all of them to be identical
         fix_delta_t = None
         for ifo in out:

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -249,19 +249,20 @@ class LiveEventManager(object):
             fname = os.path.join(self.path, fname)
             logging.info('Coincident candidate! Saving as %s', fname)
 
-            # add some explanatory log entries
-            comment = ['Trigger produced as a {} coincidence. '
+            # verbally explain some details not obvious from the other info
+            comment = ('Trigger produced as a {} coincidence. '
                        'FAR is based on all listed detectors.<br />'
                        'Two-detector ranking statistic: {}<br />'
-                       'Followup detectors: {}'.format(ppdets(coinc_ifos),
-                                                       args.background_statistic,
-                                                       ppdets(followup_ifos))]
+                       'Followup detectors: {}')
+            comment = comment.format(ppdets(coinc_ifos),
+                                     args.background_statistic,
+                                     ppdets(followup_ifos))
 
             ifar = coinc_results['foreground/ifar']
             if self.enable_gracedb_upload and self.ifar_upload_threshold < ifar:
                 gid = event.upload(fname, gracedb_server=args.gracedb_server,
                                    testing=self.gracedb_testing,
-                                   extra_strings=comments)
+                                   extra_strings=[comment])
             else:
                 gid = None
                 event.save(fname)
@@ -374,17 +375,17 @@ class LiveEventManager(object):
             fname = os.path.join(self.path, fname)
             logging.info('Single-detector candidate! Saving as %s', fname)
 
-            # add some explanatory log entries
-            comments = ['Trigger produced as a {0} single. '
-                        'FAR is based on {0} only.<br />'
-                        'Followup detectors: {1}'.format(
-                                ifo, ppdets(followup_ifos))]
+            # verbally explain some details not obvious from the other info
+            comment = ('Trigger produced as a {0} single. '
+                       'FAR is based on {0} only.<br />'
+                       'Followup detectors: {1}')
+            comment = comment.format(ifo, ppdets(followup_ifos))
 
             if args.enable_single_detector_upload \
                     and self.ifar_upload_threshold < ifar:
                 event.upload(fname, gracedb_server=args.gracedb_server,
                              testing=self.gracedb_testing,
-                             extra_strings=comments)
+                             extra_strings=[comment])
             else:
                 event.save(fname)
 

--- a/bin/pycbc_optimize_snr
+++ b/bin/pycbc_optimize_snr
@@ -146,6 +146,7 @@ for ifo in args.data_files.keys():
 
 fp = h5py.File(args.params_file, 'r')
 ifos = list(data.keys())
+original_gid = fp['gid'][()]
 
 coinc_times = {}
 for ifo in ifos:
@@ -156,7 +157,7 @@ for ifo in ifos:
 
 coinc_ifos = list(coinc_times.keys())
 
-logging.info("Following up GID {}".format(fp['gid'][()]))
+logging.info('Following up GID %s', original_gid)
 flen = fp['flen'][()]
 approximant = args.approximant
 flow = float(fp['flow'][()])
@@ -319,27 +320,34 @@ kwargs = {'psds': {ifo: followup_data[ifo]['psd'] for ifo in ifos},
           'low_frequency_cutoff': flow,
           'followup_data': followup_data,
           'channel_names': channel_names}
-comments = ['Automatic PyCBC followup of trigger {0} to find the parameters '
-            'that maximize the SNR. The FAR of this trigger is copied from '
-            '{0} and does not reflect this triggers\' '
-            'parameters.'.format(fp['gid'][()])]
 
 doc = live.SingleCoincForGraceDB(ifos, coinc_results,
                                  upload_snr_series=True, **kwargs)
-tmpdir = tempfile.mkdtemp()
-xml_path = os.path.join(
-        tmpdir, '{:.3f}.xml.gz'.format(loudest_snr_time_allifos))
+
 if args.enable_gracedb_upload:
-    gid = doc.upload(xml_path,
-                    gracedb_server=args.gracedb_server,
-                    testing=(not args.production),
-                    extra_strings=comments)
+    comments = ['Automatic PyCBC followup of trigger '
+                '<a href="/events/{0}/view">{0}</a> to find the template '
+                'parameters that maximize the SNR. The FAR of this trigger is '
+                'copied from {0} and does not reflect this triggers\' template '
+                'parameters.'.format(original_gid)]
+
+    tmpdir = tempfile.mkdtemp()
+    xml_path = os.path.join(tmpdir,
+                            '{:.3f}.xml.gz'.format(loudest_snr_time_allifos))
+    gid = doc.upload(xml_path, gracedb_server=args.gracedb_server,
+                     testing=(not args.production), extra_strings=comments)
+    if gid is not None:
+        logging.info('Event uploaded as %s', gid)
+        shutil.rmtree(tmpdir)
+
+        # add a note to the original G event pointing to the optimized one
+        gracedb = GraceDb(args.gracedb_server) \
+                if args.gracedb_server is not None else GraceDb()
+        note = 'Result of SNR maximization uploaded as '
+               '<a href="/events/{0}/view">{0}</a>'.format(gid)
+        gracedb.writeLog(original_gid, note, tag_name=['analyst_comments'])
 else:
-    gid = None
-    fname = 'coinc-{:.3f}-{}.xml.gz'.format(loudest_snr_time_allifos, pycbc.random_string(6))
+    fname = 'coinc-{:.3f}-{}.xml.gz'.format(loudest_snr_time_allifos,
+                                            pycbc.random_string(6))
     fname = os.path.join(args.output_path, fname)
     doc.save(fname)
-
-if gid is not None:
-    logging.info('Event uploaded as %s', gid)
-    shutil.rmtree(tmpdir)

--- a/bin/pycbc_optimize_snr
+++ b/bin/pycbc_optimize_snr
@@ -329,7 +329,8 @@ if args.enable_gracedb_upload:
                '<a href="/events/{0}/view">{0}</a> to find the template '
                'parameters that maximize the SNR. The FAR of this trigger is '
                'copied from {0} and does not reflect this triggers\' template '
-               'parameters.').format(original_gid)
+               'parameters.')
+    comment = comment.format(original_gid)
 
     tmpdir = tempfile.mkdtemp()
     xml_path = os.path.join(tmpdir,

--- a/bin/pycbc_optimize_snr
+++ b/bin/pycbc_optimize_snr
@@ -22,6 +22,7 @@ from scipy.optimize import differential_evolution
 from pycbc.io import live
 from pycbc.detector import Detector
 from pycbc.psd import interpolate
+from ligo.gracedb.rest import GraceDb
 
 
 Nfeval = 0

--- a/bin/pycbc_optimize_snr
+++ b/bin/pycbc_optimize_snr
@@ -22,7 +22,6 @@ from scipy.optimize import differential_evolution
 from pycbc.io import live
 from pycbc.detector import Detector
 from pycbc.psd import interpolate
-from ligo.gracedb.rest import GraceDb
 
 
 Nfeval = 0
@@ -30,7 +29,7 @@ start_time = time.time()
 
 def callback_func(Xi, convergence=0):
     global Nfeval
-    logging.info("CURRENTLY AT {} {}".format(Nfeval, convergence))
+    logging.info("Currently at %d %s", Nfeval, convergence)
     if (time.time() - start_time) > 360:
         return True
     Nfeval += 1
@@ -343,6 +342,8 @@ if args.enable_gracedb_upload:
         shutil.rmtree(tmpdir)
 
         # add a note to the original G event pointing to the optimized one
+        from ligo.gracedb.rest import GraceDb
+
         gracedb = GraceDb(args.gracedb_server) \
                 if args.gracedb_server is not None else GraceDb()
         comment = ('Result of SNR maximization uploaded as '

--- a/bin/pycbc_optimize_snr
+++ b/bin/pycbc_optimize_snr
@@ -325,17 +325,17 @@ doc = live.SingleCoincForGraceDB(ifos, coinc_results,
                                  upload_snr_series=True, **kwargs)
 
 if args.enable_gracedb_upload:
-    comments = ['Automatic PyCBC followup of trigger '
-                '<a href="/events/{0}/view">{0}</a> to find the template '
-                'parameters that maximize the SNR. The FAR of this trigger is '
-                'copied from {0} and does not reflect this triggers\' template '
-                'parameters.'.format(original_gid)]
+    comment = ('Automatic PyCBC followup of trigger '
+               '<a href="/events/{0}/view">{0}</a> to find the template '
+               'parameters that maximize the SNR. The FAR of this trigger is '
+               'copied from {0} and does not reflect this triggers\' template '
+               'parameters.').format(original_gid)
 
     tmpdir = tempfile.mkdtemp()
     xml_path = os.path.join(tmpdir,
                             '{:.3f}.xml.gz'.format(loudest_snr_time_allifos))
     gid = doc.upload(xml_path, gracedb_server=args.gracedb_server,
-                     testing=(not args.production), extra_strings=comments)
+                     testing=(not args.production), extra_strings=[comment])
     if gid is not None:
         logging.info('Event uploaded as %s', gid)
         shutil.rmtree(tmpdir)
@@ -343,9 +343,9 @@ if args.enable_gracedb_upload:
         # add a note to the original G event pointing to the optimized one
         gracedb = GraceDb(args.gracedb_server) \
                 if args.gracedb_server is not None else GraceDb()
-        note = 'Result of SNR maximization uploaded as '
-               '<a href="/events/{0}/view">{0}</a>'.format(gid)
-        gracedb.writeLog(original_gid, note, tag_name=['analyst_comments'])
+        comment = ('Result of SNR maximization uploaded as '
+                   '<a href="/events/{0}/view">{0}</a>').format(gid)
+        gracedb.writeLog(original_gid, comment, tag_name=['analyst_comments'])
 else:
     fname = 'coinc-{:.3f}-{}.xml.gz'.format(loudest_snr_time_allifos,
                                             pycbc.random_string(6))


### PR DESCRIPTION
Some improvements to comments on the logs of uploaded G events. Add explanation of which G events result from coincidences and which ones from single detectors. Link original and SNR-optimized G events with actual anchors and both ways.

Also includes some code cleanup.

Needs testing.