### PR TITLE
Input sanitation for live singles options

### DIFF
--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -349,10 +349,6 @@ class LiveEventManager(object):
             for ifo in active:
                 fud[ifo]['snr_series']._delta_t = fix_delta_t
 
-            fix_delta_t = fud[ifo]['snr_series'].delta_t
-            for ifo in active:
-                fud[ifo]['snr_series']._delta_t = fix_delta_t
-
             event = SingleCoincForGraceDB([ifo], single, bank=bank,
                                           psds=psds, followup_data=fud,
                                           low_frequency_cutoff=f_low,
@@ -369,7 +365,6 @@ class LiveEventManager(object):
                              testing=self.gracedb_testing)
             else:
                 event.save(fname)
-            exit()
 
     def dump(self, results, name, store_psd=False, time_index=None,
              store_loudest_index=False, raw_results=None, gates=None):

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -349,8 +349,8 @@ class LiveEventManager(object):
             for ifo in active:
                 fud[ifo]['snr_series']._delta_t = fix_delta_t
 
-            fix_delta_t = fud[coinc_ifos[0]]['snr_series'].delta_t
-            for ifo in live_ifos:
+            fix_delta_t = fud[ifo]['snr_series'].delta_t
+            for ifo in active:
                 fud[ifo]['snr_series']._delta_t = fix_delta_t
 
             event = SingleCoincForGraceDB([ifo], single, bank=bank,
@@ -369,6 +369,7 @@ class LiveEventManager(object):
                              testing=self.gracedb_testing)
             else:
                 event.save(fname)
+            exit()
 
     def dump(self, results, name, store_psd=False, time_index=None,
              store_loudest_index=False, raw_results=None, gates=None):

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -349,6 +349,10 @@ class LiveEventManager(object):
             for ifo in active:
                 fud[ifo]['snr_series']._delta_t = fix_delta_t
 
+            fix_delta_t = fud[coinc_ifos[0]]['snr_series'].delta_t
+            for ifo in live_ifos:
+                fud[ifo]['snr_series']._delta_t = fix_delta_t
+
             event = SingleCoincForGraceDB([ifo], single, bank=bank,
                                           psds=psds, followup_data=fud,
                                           low_frequency_cutoff=f_low,

--- a/pycbc/events/single.py
+++ b/pycbc/events/single.py
@@ -85,14 +85,12 @@ class LiveSingle(object):
         sngl_opts_required = all([args.single_fit_file,
                                   args.single_reduced_chisq_threshold,
                                   args.single_duration_threshold,
-                                  args.single_newsnr_threshold,
-                                  args.sngl_ifar_est_dist])
+                                  args.single_newsnr_threshold])
         if args.enable_single_detector_background and not sngl_opts_required:
             raise RuntimeError("Single detector trigger options "
                 "(--single-fit-file, --single-reduced-chisq-threshold, "
-                "--single-duration-threshold, --single-newsnr-threshold, "
-                "--sngl-ifar-est-dist) must all be given if single detector "
-                "background is enabled")
+                "--single-duration-threshold, --single-newsnr-threshold) "
+                "must ALL be given if single detector background is enabled")
         return cls(
            ifo, newsnr_threshold=args.single_newsnr_threshold[ifo],
            reduced_chisq_threshold=args.single_reduced_chisq_threshold[ifo],

--- a/pycbc/events/single.py
+++ b/pycbc/events/single.py
@@ -82,6 +82,17 @@ class LiveSingle(object):
 
     @classmethod
     def from_cli(cls, args, ifo):
+        sngl_opts_required = all([args.single_fit_file,
+                                  args.single_reduced_chisq_threshold,
+                                  args.single_duration_threshold,
+                                  args.single_newsnr_threshold,
+                                  args.sngl_ifar_est_dist])
+        if args.enable_single_detector_background and not sngl_opts_required:
+            raise RuntimeError("Single detector trigger options "
+                "(--single-fit-file, --single-reduced-chisq-threshold, "
+                "--single-duration-threshold, --single-newsnr-threshold, "
+                "--sngl-ifar-est-dist) must all be given if single detector "
+                "background is enabled")
         return cls(
            ifo, newsnr_threshold=args.single_newsnr_threshold[ifo],
            reduced_chisq_threshold=args.single_reduced_chisq_threshold[ifo],

--- a/pycbc/events/single.py
+++ b/pycbc/events/single.py
@@ -88,9 +88,12 @@ class LiveSingle(object):
                                   args.single_newsnr_threshold])
         if args.enable_single_detector_background and not sngl_opts_required:
             raise RuntimeError("Single detector trigger options "
-                "(--single-fit-file, --single-reduced-chisq-threshold, "
-                "--single-duration-threshold, --single-newsnr-threshold) "
-                "must ALL be given if single detector background is enabled")
+                               "(--single-fit-file, "
+                               "--single-reduced-chisq-threshold, "
+                               "--single-duration-threshold, "
+                               "--single-newsnr-threshold) "
+                               "must ALL be given if single detector "
+                               "background is enabled")
         return cls(
            ifo, newsnr_threshold=args.single_newsnr_threshold[ifo],
            reduced_chisq_threshold=args.single_reduced_chisq_threshold[ifo],


### PR DESCRIPTION
When single detector background is enabled, certain options are required. This change means that they are checked for before going into the main part of the live code

Another option would be to give defaults to single_reduced_chisq_threshold, single_duration_threshold and single_newsnr_threshold. But the fits file would still need checking for

I should check that we are happy to have a default value --sngl-ifar-est-dist of conservative?

(First commit can be ignored - reusing branch for previous PR)
