### PR TITLE
Allow values to have colons in config overrides

### DIFF
--- a/pycbc/workflow/configuration.py
+++ b/pycbc/workflow/configuration.py
@@ -1117,12 +1117,28 @@ class WorkflowConfigParser(glue.pipeline.DeepCopyableConfigParser):
         # read configuration file
         logging.info("Reading configuration file")
         if opts.config_overrides is not None:
-            overrides = [override.split(":")
-                         for override in opts.config_overrides]
+            pattern = re.compile(
+                r'(?P<section>[^:]+):(?P<option>[^:]+):(?P<value>.+)')
+            overrides = []
+            for override in opts.config_overrides:
+                m = pattern.match(override)
+                if m is None:
+                    raise ValueError("config-overrides not formatted "
+                                     "correctly; see help")
+                overrides.append((m.group('section'), m.group('option'),
+                                  m.group('value')))
         else:
             overrides = None
         if opts.config_delete is not None:
-            deletes = [delete.split(":") for delete in opts.config_delete]
+            pattern = re.compile(
+                r'(?P<section>[^:]+):(?P<option>[^:]+)')
+            deletes = []
+            for delete in opts.config_delete:
+                m = pattern.match(delete)
+                if m is None:
+                    raise ValueError("config-delete not formatted "
+                                     "correctly; see help")
+                deletes.append((m.group('section'), m.group('option')))
         else:
             deletes = None
         return cls(opts.config_files, overrides, deleteTuples=deletes)

--- a/pycbc/workflow/configuration.py
+++ b/pycbc/workflow/configuration.py
@@ -1117,28 +1117,12 @@ class WorkflowConfigParser(glue.pipeline.DeepCopyableConfigParser):
         # read configuration file
         logging.info("Reading configuration file")
         if opts.config_overrides is not None:
-            pattern = re.compile(
-                r'(?P<section>[^:]+):(?P<option>[^:]+):(?P<value>.+)')
-            overrides = []
-            for override in opts.config_overrides:
-                m = pattern.match(override)
-                if m is None:
-                    raise ValueError("config-overrides not formatted "
-                                     "correctly; see help")
-                overrides.append((m.group('section'), m.group('option'),
-                                  m.group('value')))
+            overrides = [override.split(":", 2)
+                         for override in opts.config_overrides]
         else:
             overrides = None
         if opts.config_delete is not None:
-            pattern = re.compile(
-                r'(?P<section>[^:]+):(?P<option>[^:]+)')
-            deletes = []
-            for delete in opts.config_delete:
-                m = pattern.match(delete)
-                if m is None:
-                    raise ValueError("config-delete not formatted "
-                                     "correctly; see help")
-                deletes.append((m.group('section'), m.group('option')))
+            deletes = [delete.split(":", 2) for delete in opts.config_delete]
         else:
             deletes = None
         return cls(opts.config_files, overrides, deleteTuples=deletes)

--- a/pycbc/workflow/configuration.py
+++ b/pycbc/workflow/configuration.py
@@ -470,7 +470,7 @@ class WorkflowConfigParser(glue.pipeline.DeepCopyableConfigParser):
         # and parse them
         parsedDeletes = []
         for delete in confDeletes:
-            splitDelete = delete.split(":", 2)
+            splitDelete = delete.split(":")
             if len(splitDelete) > 2:
                 raise ValueError(
                     "Deletes must be of format section:option "
@@ -1122,7 +1122,7 @@ class WorkflowConfigParser(glue.pipeline.DeepCopyableConfigParser):
         else:
             overrides = None
         if opts.config_delete is not None:
-            deletes = [delete.split(":", 2) for delete in opts.config_delete]
+            deletes = [delete.split(":") for delete in opts.config_delete]
         else:
             deletes = None
         return cls(opts.config_files, overrides, deleteTuples=deletes)

--- a/pycbc/workflow/configuration.py
+++ b/pycbc/workflow/configuration.py
@@ -470,7 +470,7 @@ class WorkflowConfigParser(glue.pipeline.DeepCopyableConfigParser):
         # and parse them
         parsedDeletes = []
         for delete in confDeletes:
-            splitDelete = delete.split(":")
+            splitDelete = delete.split(":", 2)
             if len(splitDelete) > 2:
                 raise ValueError(
                     "Deletes must be of format section:option "
@@ -483,7 +483,7 @@ class WorkflowConfigParser(glue.pipeline.DeepCopyableConfigParser):
         # and parse them
         parsedOverrides = []
         for override in confOverrides:
-            splitOverride = override.split(":")
+            splitOverride = override.split(":", 2)
             if len(splitOverride) == 3:
                 parsedOverrides.append(tuple(splitOverride))
             elif len(splitOverride) == 2:


### PR DESCRIPTION
Currently, if you use `config-overrides` on the command line to change the value of an option in a config file, you cannot set values that have colons in them. This is problematic if you want to set a value that has colons in it; e.g., if you wanted to change the frame type used in a config file:
```
--config-overrides data:frame-type:H1:LOSC L1:LOSC
```

This is because the option uses colons to separate the section, option, and value. Using a colon is fine for splitting the section and option, since these two cannot include colons. The main issue is that `split(':')` is being used to parse the option. If the value contains a colon, the parser will split the value up before. So in the above example, `WorkflowConfigFile` gets `('data', 'frame-type', 'H1', 'LOSC L1', 'LOSC')` for the override tuple.

This patch fixes the problem by using a regular expression instead of a split. It takes everything before the first colon as the section and everything before the second colon as the option. Everything after the second colon (including other colons) is left alone and passed as the value. In the above example, `WorkflowConfigFile` now gets `['data', 'frame-type', 'H1:LOSC L1:LOSC')`, as expected.

For completeness, I also switched to using a regular expression for parsing the config-delete option, even though it was less of an issue there.
