### PR TITLE
Remove redundant functions in workflow config

### DIFF
--- a/pycbc/workflow/configuration.py
+++ b/pycbc/workflow/configuration.py
@@ -451,12 +451,13 @@ class WorkflowConfigParser(glue.pipeline.DeepCopyableConfigParser):
         # read configuration file
         logging.info("Reading configuration file")
         if opts.config_overrides is not None:
-            overrides = [override.split(":", 2)
+            overrides = [tuple(override.split(":", 2))
                          for override in opts.config_overrides]
         else:
             overrides = None
         if opts.config_delete is not None:
-            deletes = [delete.split(":") for delete in opts.config_delete]
+            deletes = [tuple(delete.split(":"))
+                       for delete in opts.config_delete]
         else:
             deletes = None
         return cls(opts.config_files, overrides, deleteTuples=deletes)

--- a/pycbc/workflow/configuration.py
+++ b/pycbc/workflow/configuration.py
@@ -445,8 +445,16 @@ class WorkflowConfigParser(glue.pipeline.DeepCopyableConfigParser):
 
     @classmethod
     def from_cli(cls, opts):
-        """Loads a config file from the given options, with overrides and
-        deletes applied.
+        """Initialize the config parser using options parsed from the command
+        line.
+
+        The parsed options ``opts`` must include options provided by
+        :py:func:`add_workflow_command_line_group`.
+
+        Parameters
+        -----------
+        opts : argparse.ArgumentParser
+            The command line arguments parsed by argparse
         """
         # read configuration file
         logging.info("Reading configuration file")

--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -622,7 +622,7 @@ class Workflow(pegasus_workflow.Workflow):
         super(Workflow, self).__init__(name)
 
         # Parse ini file
-        self.cp = WorkflowConfigParser.from_args(args)
+        self.cp = WorkflowConfigParser.from_cli(args)
 
         # Set global values
         start_time = int(self.cp.get("workflow", "start-time"))


### PR DESCRIPTION
As discussed in #3101, the `WorkflowConfigFile` class currently has two methods (`from_args` and `from_cli`) that do the same thing: parse command-line options. There is also a method (`add_config_opts_to_parser`) that is partial copy of `add_workflow_command_line_group`. This patch removes `from_args` in favor of `from_cli`. Although `from_args` is the older function, it isn't consistent with PEP8, and it does checks that are already done in the `__init__` function. This patch also gets rid of the `add_config_opts_to_parser`, which isn't being used by anything.

@spxiwh I know you had suggested renaming `from_cli` to `from_args`. However, grepping the repository, I found that `from_args` is only used in one place (in `workflow.core`), which I've updated. Calling it `from_cli` is more consistent with the rest of pycbc.