### PR TITLE
Write analysis and psd segments to inference file

### DIFF
--- a/pycbc/inference/models/data_utils.py
+++ b/pycbc/inference/models/data_utils.py
@@ -394,11 +394,11 @@ def data_from_cli(opts, check_for_valid_times=False,
     Returns
     -------
     strain_dict : dict
-        Dictionary of instruments -> `TimeSeries` strain.
-    stilde_dict : dict
-        Dictionary of instruments -> `FrequencySeries` strain.
-    psd_dict : dict
-        Dictionary of instruments -> `FrequencySeries` psds.
+        Dictionary of detectors -> time series strain.
+    psd_strain_dict : dict or None
+        If ``opts.psd_(start|end)_time`` were set, a dctionary of
+        detectors -> time series data to use for PSD estimation. Otherwise,
+        ``None``.
     """
     # get gates to apply
     gates = gates_from_cli(opts)
@@ -460,43 +460,93 @@ def data_from_cli(opts, check_for_valid_times=False,
         # apply any gates
         logging.info("Applying gates to PSD data")
         psd_strain_dict = apply_gates_to_td(psd_strain_dict, psd_gates)
+        # check that there aren't nans in the psd data
+        check_for_nans(psd_strain_dict)
     elif opts.psd_start_time or opts.psd_end_time:
         raise ValueError("Must give psd-start-time and psd-end-time")
     else:
-        psd_strain_dict = strain_dict
+        psd_strain_dict = None
 
     # check that we have data left to analyze
     if instruments == []:
         raise NoValidDataError("No valid data could be found in any of the "
                                "requested instruments.")
 
-    # check that there aren't nans in the psd data
-    check_for_nans(psd_strain_dict)
+    return strain_dict, psd_strain_dict
 
+
+def fd_data_from_strain_dict(opts, strain_dict, psd_strain_dict=None):
+    """Converts a dictionary of time series to the frequency domain, and gets
+    the PSDs.
+
+    Parameters
+    ----------
+    opts : ArgumentParser parsed args
+        Argument options parsed from a command line string (the sort of thing
+        returned by `parser.parse_args`).
+    strain_dict : dict
+        Dictionary of detectors -> time series data.
+    psd_strain_dict : dict, optional
+        Dictionary of detectors -> time series data to use for PSD estimation.
+        If not provided, will use the ``strain_dict``. This is
+        ignored if ``opts.psd_estimation`` is not set. See
+        :py:func:`pycbc.psd.psd_from_cli_multi_ifos` for details.
+
+    Returns
+    -------
+    stilde_dict : dict
+        Dictionary of detectors -> frequency series data.
+    psd_dict : dict
+        Dictionary of detectors -> frequency-domain PSDs.
+    """
     # FFT strain and save each of the length of the FFT, delta_f, and
     # low frequency cutoff to a dict
     stilde_dict = {}
     length_dict = {}
     delta_f_dict = {}
-    for ifo in instruments:
-        stilde_dict[ifo] = strain_dict[ifo].to_frequencyseries()
-        length_dict[ifo] = len(stilde_dict[ifo])
-        delta_f_dict[ifo] = stilde_dict[ifo].delta_f
+    for det, tsdata in strain_dict.items():
+        stilde_dict[det] = tsdata.to_frequencyseries()
+        length_dict[det] = len(stilde_dict[det])
+        delta_f_dict[det] = stilde_dict[det].delta_f
+
+    if psd_strain_dict is None:
+        psd_strain_dict = strain_dict
 
     # get PSD as frequency series
     psd_dict = psd_from_cli_multi_ifos(
         opts, length_dict, delta_f_dict, opts.low_frequency_cutoff,
-        instruments, strain_dict=psd_strain_dict, precision="double")
+        list(psd_strain_dict.keys()), strain_dict=psd_strain_dict,
+        precision="double")
 
-    # apply any gates to overwhitened data, if desired
-    if opts.gate_overwhitened and opts.gate is not None:
-        logging.info("Applying gates to overwhitened data")
-        # overwhiten the data
-        for ifo in gates:
-            stilde_dict[ifo] /= psd_dict[ifo]
-        stilde_dict = apply_gates_to_fd(stilde_dict, gates)
-        # unwhiten the data for the model
-        for ifo in gates:
-            stilde_dict[ifo] *= psd_dict[ifo]
+    return stilde_dict, psd_dict
 
-    return strain_dict, stilde_dict, psd_dict
+
+def gate_overwhitened_data(stilde_dict, psd_dict, gates):
+    """Applies gates to overwhitened data.
+    
+    Parameters
+    ----------
+    stilde_dict : dict
+        Dictionary of detectors -> frequency series data to apply the gates to.
+    psd_dict : dict
+        Dictionary of detectors -> PSD to use for overwhitening.
+    gates : dict
+        Dictionary of detectors -> gates.
+
+    Returns
+    -------
+    dict :
+        Dictionary of detectors -> frequency series data with the gates
+        applied after overwhitening. The returned data is not overwhitened.
+    """
+    logging.info("Applying gates to overwhitened data")
+    # overwhiten the data
+    out = {}
+    for det in gates:
+        out[det] = stilde_dict[det] / psd_dict[det]
+    # now apply the gate
+    out = apply_gates_to_fd(out, gates)
+    # now unwhiten
+    for det in gates:
+        out[ifo] *= psd_dict[ifo]
+    return out

--- a/pycbc/inference/models/data_utils.py
+++ b/pycbc/inference/models/data_utils.py
@@ -523,7 +523,7 @@ def fd_data_from_strain_dict(opts, strain_dict, psd_strain_dict=None):
 
 def gate_overwhitened_data(stilde_dict, psd_dict, gates):
     """Applies gates to overwhitened data.
-    
+
     Parameters
     ----------
     stilde_dict : dict
@@ -548,5 +548,5 @@ def gate_overwhitened_data(stilde_dict, psd_dict, gates):
     out = apply_gates_to_fd(out, gates)
     # now unwhiten
     for det in gates:
-        out[ifo] *= psd_dict[ifo]
+        out[det] *= psd_dict[det]
     return out

--- a/pycbc/inference/models/gaussian_noise.py
+++ b/pycbc/inference/models/gaussian_noise.py
@@ -649,7 +649,7 @@ class GaussianNoise(BaseDataModel):
 
         The following options are read from the ``[model]`` section, in
         addition to ``name`` (which must be set):
-        
+
         * ``{{DET}}-low-frequency-cutoff = FLOAT`` :
           The low frequency cutoff to use for each detector {{DET}}. A cutoff
           must be provided for every detector that may be analyzed (any


### PR DESCRIPTION
Following up #3091: this writes the analyzed detectors, analysis segment, and PSD segment to the inference output file's `attrs`. Currently, this information isn't being saved anywhere, making it difficult to know if the PSD times were shifted or not, and if so, to where. Also, without the the analyzed detectors in the attrs, it is impossible to know which detectors were used if a posterior file is created with the `data` group.

In the process, I had to break up the `data_from_config` function into a few different functions. That should make code climate more happy anyway.

I've also added more documentation to the `GaussianNoise.from_config` function.