### PR TITLE
Check for psd start/end times in dict values

### DIFF
--- a/pycbc/inference/models/data_utils.py
+++ b/pycbc/inference/models/data_utils.py
@@ -341,9 +341,9 @@ def data_opts_from_config(cp, section, filter_flow):
                          det, pad)
         gps_start[det] -= pad
         gps_end[det] += pad
-        if opts.psd_start_time is not None:
+        if opts.psd_start_time[det] is not None:
             opts.psd_start_time[det] += opts.trigger_time
-        if opts.psd_end_time is not None:
+        if opts.psd_end_time[det] is not None:
             opts.psd_end_time[det] += opts.trigger_time
     opts.gps_start_time = gps_start
     opts.gps_end_time = gps_end


### PR DESCRIPTION
Currently, running inference without explicitly providing `psd-start-time` and `psd-end-time` in the `[data]` section of the config file fails with the following error:
```
Traceback (most recent call last):
  File "/home/daniel.finstad/opt/pycbc-dev/bin/pycbc_inference", line 123, in <module>
    model = models.read_from_config(cp)
  File "/home/daniel.finstad/opt/pycbc-dev/lib/python2.7/site-packages/pycbc/inference/models/__init__.py", line 175, in read_from_config
    return models[name].from_config(cp, **kwargs)
  File "/home/daniel.finstad/opt/pycbc-dev/lib/python2.7/site-packages/pycbc/inference/models/gaussian_noise.py", line 706, in from_config
    opts = data_opts_from_config(cp, data_section, flow)
  File "/home/daniel.finstad/opt/pycbc-dev/lib/python2.7/site-packages/pycbc/inference/models/data_utils.py", line 348, in data_opts_from_config
    opts.psd_start_time[det] += opts.trigger_time
TypeError: unsupported operand type(s) for +=: 'NoneType' and 'int'
```
The problem seems to lie in the check for the options in `data_opts_from_config`, e.g.
```
if opts.psd_start_time is not None:
```
while it's the dict value `opts.psd_start_time[det]` that gets set to `None` when the options are not provided.

This patch changes the check for these options to the dict values.