### PR TITLE
Allow multinest to work with mpi

### DIFF
--- a/pycbc/inference/sampler/base.py
+++ b/pycbc/inference/sampler/base.py
@@ -62,6 +62,10 @@ class BaseSampler(object):
 
     def __init__(self, model):
         self.model = model
+        self.checkpoint_file = None
+        self.backup_file = None
+        self.checkpoint_valid = None
+        self.new_checkpoint = None
 
     # @classmethod <--uncomment when we move to python 3.3
     @abstractmethod

--- a/pycbc/inference/sampler/base.py
+++ b/pycbc/inference/sampler/base.py
@@ -212,6 +212,7 @@ def setup_output(sampler, output_file, force=False):
     sampler.backup_file = backup_file
     sampler.checkpoint_valid = checkpoint_valid
 
+
 def create_new_output_file(sampler, filename, **kwargs):
     r"""Creates a new output file.
 

--- a/pycbc/inference/sampler/base_mcmc.py
+++ b/pycbc/inference/sampler/base_mcmc.py
@@ -38,6 +38,8 @@ from pycbc.workflow import ConfigParser
 from pycbc.filter import autocorrelation
 from pycbc.inference.io import validate_checkpoint_files
 
+from .base import setup_output
+
 
 #
 # =============================================================================
@@ -542,6 +544,27 @@ class BaseMCMC(object):
     def write_results(self, filename):
         """Should write all samples currently in memory to the given file."""
         pass
+
+    def setup_output(self, output_file, force=False):
+        """Sets up the sampler's checkpoint and output files.
+
+        The checkpoint file has the same name as the output file, but with
+        ``.checkpoint`` appended to the name. A backup file will also be
+        created.
+
+        If the output file already exists, an ``OSError`` will be raised.
+        This can be overridden by setting ``force`` to ``True``.
+
+        Parameters
+        ----------
+        sampler : sampler instance
+            Sampler
+        output_file : str
+            Name of the output file.
+        force : bool, optional
+            If the output file already exists, overwrite it.
+        """
+        setup_output(self, output_file, force=force)
 
     def checkpoint(self):
         """Dumps current samples to the checkpoint file."""

--- a/pycbc/inference/sampler/cpnest.py
+++ b/pycbc/inference/sampler/cpnest.py
@@ -33,7 +33,7 @@ import os
 import cpnest
 import cpnest.model as cpm
 from pycbc.inference.io import (CPNestFile, validate_checkpoint_files)
-from .base import BaseSampler
+from .base import (BaseSampler, setup_output)
 from .base_mcmc import get_optional_arg_from_config
 
 
@@ -157,6 +157,27 @@ class CPNestSampler(BaseSampler):
         Should also set the sampler's random state.
         """
         pass
+
+    def setup_output(self, output_file, force=False):
+        """Sets up the sampler's checkpoint and output files.
+
+        The checkpoint file has the same name as the output file, but with
+        ``.checkpoint`` appended to the name. A backup file will also be
+        created.
+
+        If the output file already exists, an ``OSError`` will be raised.
+        This can be overridden by setting ``force`` to ``True``.
+
+        Parameters
+        ----------
+        sampler : sampler instance
+            Sampler
+        output_file : str
+            Name of the output file.
+        force : bool, optional
+            If the output file already exists, overwrite it.
+        """
+        setup_output(self, output_file, force=force)
 
     def write_results(self, filename):
         """Writes samples, model stats, acceptance fraction, and random state

--- a/pycbc/inference/sampler/dynesty.py
+++ b/pycbc/inference/sampler/dynesty.py
@@ -36,7 +36,7 @@ import dynesty
 from dynesty.utils import resample_equal
 from pycbc.inference.io import (DynestyFile, validate_checkpoint_files)
 from pycbc.distributions import read_constraints_from_config
-from .base import BaseSampler
+from .base import (BaseSampler, setup_output)
 from .base_mcmc import get_optional_arg_from_config
 from .. import models
 
@@ -196,6 +196,27 @@ class DynestySampler(BaseSampler):
             # write log evidence
             fp.write_logevidence(self._sampler.results.logz[-1:][0],
                                  self._sampler.results.logzerr[-1:][0])
+
+    def setup_output(self, output_file, force=False):
+        """Sets up the sampler's checkpoint and output files.
+
+        The checkpoint file has the same name as the output file, but with
+        ``.checkpoint`` appended to the name. A backup file will also be
+        created.
+
+        If the output file already exists, an ``OSError`` will be raised.
+        This can be overridden by setting ``force`` to ``True``.
+
+        Parameters
+        ----------
+        sampler : sampler instance
+            Sampler
+        output_file : str
+            Name of the output file.
+        force : bool, optional
+            If the output file already exists, overwrite it.
+        """
+        setup_output(self, output_file, force=force)
 
     @property
     def posterior_samples(self):

--- a/pycbc/inference/sampler/multinest.py
+++ b/pycbc/inference/sampler/multinest.py
@@ -35,7 +35,7 @@ import sys
 
 from pycbc.inference.io import (MultinestFile, validate_checkpoint_files)
 from pycbc.distributions import read_constraints_from_config
-from pycbc.pool import is_main_processs
+from pycbc.pool import is_main_process
 from pycbc.transforms import apply_transforms
 from .base import (BaseSampler, create_new_output_file)
 from .base_mcmc import get_optional_arg_from_config

--- a/pycbc/inference/sampler/multinest.py
+++ b/pycbc/inference/sampler/multinest.py
@@ -29,7 +29,6 @@ packages for parameter estimation.
 from __future__ import absolute_import
 
 import logging
-import shutil
 import sys
 import numpy
 
@@ -37,7 +36,7 @@ from pycbc.inference.io import (MultinestFile, validate_checkpoint_files)
 from pycbc.distributions import read_constraints_from_config
 from pycbc.pool import is_main_process
 from pycbc.transforms import apply_transforms
-from .base import (BaseSampler, setup_output, create_new_output_file)
+from .base import (BaseSampler, setup_output)
 from .base_mcmc import get_optional_arg_from_config
 
 

--- a/pycbc/inference/sampler/multinest.py
+++ b/pycbc/inference/sampler/multinest.py
@@ -29,9 +29,9 @@ packages for parameter estimation.
 from __future__ import absolute_import
 
 import logging
-import numpy
 import shutil
 import sys
+import numpy
 
 from pycbc.inference.io import (MultinestFile, validate_checkpoint_files)
 from pycbc.distributions import read_constraints_from_config
@@ -365,7 +365,7 @@ class MultinestSampler(BaseSampler):
                                                          backup_file)
             # Create a new file if the checkpoint doesn't exist, or if it is
             # corrupted
-            self.new_checkpoint = False  # keeps track if this is a new file or not
+            self.new_checkpoint = False  # tracks whether this is a new file
             if not checkpoint_valid:
                 logging.info("Checkpoint not found or not valid")
                 create_new_output_file(self, checkpoint_file, force=force,
@@ -375,10 +375,10 @@ class MultinestSampler(BaseSampler):
                 # copy to backup
                 shutil.copy(checkpoint_file, backup_file)
             # write the command line, startup
-            for fn in [checkpoint_file, backup_file]:
-                with self.io(fn, "a") as fp:
-                    fp.write_command_line()
-                    fp.write_resume_point()
+            for f_n in [checkpoint_file, backup_file]:
+                with self.io(f_n, "a") as f_p:
+                    f_p.write_command_line()
+                    f_p.write_resume_point()
             # store
             self.checkpoint_file = checkpoint_file
             self.backup_file = backup_file

--- a/pycbc/inference/sampler/multinest.py
+++ b/pycbc/inference/sampler/multinest.py
@@ -268,6 +268,7 @@ class MultinestSampler(BaseSampler):
                                sampling_efficiency=self._eff,
                                importance_nested_sampling=self._ins,
                                max_iter=iterinterval,
+                               n_iter_before_update=iterinterval,
                                seed=numpy.random.randint(0, 1e6),
                                outputfiles_basename=outputfiles_basename,
                                multimodal=False, verbose=True)


### PR DESCRIPTION
This patch is reviving #2836 which I'm not able to re-open for some reason. Additional changes made here address the comments by @cdcapano on that PR:

- `setup_output` has been made an abstract method of `BaseSampler` and its current functionality moved to a standalone convenience function in `base.py`
- `setup_output` methods have been added to `BaseMCMC`, `CPNestSampler`, and `DynestySampler` which call the new standalone function
- the `setup_output` method of `MultinestSampler` now manages the master process check and references the standalone function