### PR TITLE
Add BaseGaussianNoise model to fix SingleTemplate and RelativeSPA

### DIFF
--- a/pycbc/inference/models/base_data.py
+++ b/pycbc/inference/models/base_data.py
@@ -69,6 +69,8 @@ class BaseDataModel(BaseModel):
     ----------
     data : dict
         The data that the class was initialized with.
+    detectors : list
+        List of detector names used.
     lognl :
         Returns the log likelihood of the noise.
     loglr :

--- a/pycbc/inference/models/gaussian_noise.py
+++ b/pycbc/inference/models/gaussian_noise.py
@@ -18,6 +18,8 @@
 
 import logging
 import numpy
+from abc import ABCMeta
+from six import add_metaclass
 
 from pycbc import filter as pyfilter
 from pycbc.waveform import NoWaveformError
@@ -33,6 +35,7 @@ from .data_utils import (data_opts_from_config, data_from_cli,
                          fd_data_from_strain_dict, gate_overwhitened_data)
 
 
+@add_metaclass(ABCMeta)
 class BaseGaussianNoise(BaseDataModel):
     r"""Model for analyzing GW data with assuming a wide-sense stationary
     Gaussian noise model.
@@ -333,19 +336,18 @@ class BaseGaussianNoise(BaseDataModel):
         """
         if not self.normalize:
             return 0.
-        else:
-            try:
-                return self._lognorm[det]
-            except KeyError:
-                # hasn't been calculated yet
-                p = self._psds[det]
-                dt = self._whitened_data[det].delta_t
-                kmin = self._kmin[det]
-                kmax = self._kmax[det]
-                lognorm = -float(self._N*numpy.log(numpy.pi*self._N*dt)/2.
-                                 + numpy.log(p[kmin:kmax]).sum())
-                self._lognorm[det] = lognorm
-                return self._lognorm[det]
+        try:
+            return self._lognorm[det]
+        except KeyError:
+            # hasn't been calculated yet
+            p = self._psds[det]
+            dt = self._whitened_data[det].delta_t
+            kmin = self._kmin[det]
+            kmax = self._kmax[det]
+            lognorm = -float(self._N*numpy.log(numpy.pi*self._N*dt)/2.
+                             + numpy.log(p[kmin:kmax]).sum())
+            self._lognorm[det] = lognorm
+            return self._lognorm[det]
 
     @property
     def normalize(self):
@@ -920,7 +922,6 @@ class GaussianNoise(BaseGaussianNoise):
             self._loglr()
             # now try returning again
             return getattr(self._current_stats, '{}_optimal_snrsq'.format(det))
-
 
 
 #

--- a/pycbc/inference/models/gaussian_noise.py
+++ b/pycbc/inference/models/gaussian_noise.py
@@ -17,9 +17,9 @@
 """
 
 import logging
-import numpy
 from abc import ABCMeta
 from six import add_metaclass
+import numpy
 
 from pycbc import filter as pyfilter
 from pycbc.waveform import NoWaveformError

--- a/pycbc/inference/models/gaussian_noise.py
+++ b/pycbc/inference/models/gaussian_noise.py
@@ -177,7 +177,11 @@ class BaseGaussianNoise(BaseDataModel):
 
     @property
     def high_frequency_cutoff(self):
-        """The high frequency cutoff of the inner product."""
+        """The high frequency cutoff of the inner product.
+
+        If a high frequency cutoff was not provided for a detector, it will
+        be ``None``.
+        """
         return self._f_upper
 
     @high_frequency_cutoff.setter

--- a/pycbc/inference/models/gaussian_noise.py
+++ b/pycbc/inference/models/gaussian_noise.py
@@ -374,7 +374,7 @@ class BaseGaussianNoise(BaseDataModel):
         fp : pycbc.inference.io.BaseInferenceFile instance
             The inference file to write to.
         """
-        super(GaussianNoise, self).write_metadata(fp)
+        super(BaseGaussianNoise, self).write_metadata(fp)
         # write the analyzed detectors and times
         fp.attrs['analyzed_detectors'] = self.detectors
         for det, data in self.data.items():
@@ -780,7 +780,7 @@ class GaussianNoise(BaseGaussianNoise):
         """
         params = self.current_params
         try:
-            wfs = self._waveform_generator.generate(**params)
+            wfs = self.waveform_generator.generate(**params)
         except NoWaveformError:
             return self._nowaveform_loglr()
         lr = 0.

--- a/pycbc/inference/models/marginalized_gaussian_noise.py
+++ b/pycbc/inference/models/marginalized_gaussian_noise.py
@@ -132,6 +132,17 @@ class MarginalizedPhaseGaussianNoise(BaseGaussianNoise):
         return ['loglr', 'maxl_phase'] + \
                ['{}_optimal_snrsq'.format(det) for det in self._data]
 
+    def _nowaveform_loglr(self):
+        """Convenience function to set loglr values if no waveform generated.
+        """
+        setattr(self._current_stats, 'loglikelihood', -numpy.inf)
+        # maxl phase doesn't exist, so set it to nan
+        setattr(self._current_stats, 'maxl_phase', numpy.nan)
+        for det in self._data:
+            # snr can't be < 0 by definition, so return 0
+            setattr(self._current_stats, '{}_optimal_snrsq'.format(det), 0.)
+        return -numpy.inf
+
     def _loglr(self):
         r"""Computes the log likelihood ratio,
         .. math::

--- a/pycbc/inference/models/marginalized_gaussian_noise.py
+++ b/pycbc/inference/models/marginalized_gaussian_noise.py
@@ -146,7 +146,7 @@ class MarginalizedPhaseGaussianNoise(BaseGaussianNoise):
         """
         params = self.current_params
         try:
-            wfs = self._waveform_generator.generate(**params)
+            wfs = self.waveform_generator.generate(**params)
         except NoWaveformError:
             return self._nowaveform_loglr()
         hh = 0.
@@ -177,7 +177,7 @@ class MarginalizedPhaseGaussianNoise(BaseGaussianNoise):
         return numpy.log(special.i0e(hd)) + hd - 0.5*hh
 
 
-class MarginalizedGaussianNoise(GaussianNoise):
+class MarginalizedGaussianNoise(BaseGaussianNoise):
     r"""The likelihood is analytically marginalized over phase and/or time
     and/or distance.
 
@@ -617,7 +617,7 @@ class MarginalizedGaussianNoise(GaussianNoise):
         """
         params = self.current_params
         try:
-            wfs = self._waveform_generator.generate(**params)
+            wfs = self.waveform_generator.generate(**params)
         except NoWaveformError:
             return self._nowaveform_loglr()
         opt_snr = 0.

--- a/pycbc/inference/models/marginalized_gaussian_noise.py
+++ b/pycbc/inference/models/marginalized_gaussian_noise.py
@@ -26,10 +26,10 @@ from pycbc.filter.matchedfilter import matched_filter_core
 from pycbc.distributions import read_distributions_from_config
 from pycbc.waveform import generator
 
-from .gaussian_noise import GaussianNoise
+from .gaussian_noise import (BaseGaussianNoise, create_waveform_generator)
 
 
-class MarginalizedPhaseGaussianNoise(GaussianNoise):
+class MarginalizedPhaseGaussianNoise(BaseGaussianNoise):
     r"""The likelihood is analytically marginalized over phase.
 
     This class can be used with signal models that can be written as:
@@ -109,6 +109,21 @@ class MarginalizedPhaseGaussianNoise(GaussianNoise):
                                     \left<d_i, d_i\right> \right]
     """
     name = 'marginalized_phase'
+
+    def __init__(self, variable_params, data, low_frequency_cutoff, psds=None,
+                 high_frequency_cutoff=None, normalize=False,
+                 static_params=None, **kwargs):
+        # set up the boiler-plate attributes
+        super(MarginalizedPhaseGaussianNoise, self).__init__(
+            variable_params, data, low_frequency_cutoff, psds=psds,
+            high_frequency_cutoff=high_frequency_cutoff, normalize=normalize,
+            static_params=static_params, **kwargs)
+        # create the waveform generator
+        self.waveform_generator = create_waveform_generator(
+            self.variable_params, self.data,
+            waveform_transforms=self.waveform_transforms,
+            recalibration=self.recalibration,
+            gates=self.gates, **self.static_params)
 
     @property
     def _extra_stats(self):

--- a/pycbc/inference/models/relbin.py
+++ b/pycbc/inference/models/relbin.py
@@ -322,29 +322,6 @@ class RelativeSPA(BaseGaussianNoise):
             llr += (hd - 0.5 * hh)
         return float(llr)
 
-    def _loglikelihood(self):
-        r"""Computes the log likelihood of the parameters,
-
-        .. math::
-
-            \log p(d|\Theta, h) = \log \alpha -\frac{1}{2}\sum_i
-                \left<d_i - h_i(\Theta) | d_i - h_i(\Theta)\right>,
-
-        at the current parameter values :math:`\Theta`.
-
-        Returns
-        -------
-        float
-            The value of the log likelihood evaluated at the given point.
-        """
-        return self.loglr + self.lognl
-
-    def _lognl(self):
-        """Calculate the log of the noise likelihood. Currently not
-        implemented, so just returns zero.
-        """
-        return 0.
-
     def write_metadata(self, fp):
         """Adds writing the fiducial parameters and epsilon to file's attrs.
 

--- a/pycbc/inference/models/relbin.py
+++ b/pycbc/inference/models/relbin.py
@@ -147,22 +147,16 @@ class RelativeSPA(BaseGaussianNoise):
                  ra_ref, dec_ref, tc_ref,
                  epsilon=0.5,
                  **kwargs):
-        super(SingleTemplate, self).__init__(
+        super(RelativeSPA, self).__init__(
             variable_params, data, low_frequency_cutoff, **kwargs)
         # check that all of the frequency cutoffs are the same
         # FIXME: this can probably be loosened at some point
         kmins = list(self.kmin.values())
         kmaxs = list(self.kmax.values())
-        if any(kk ! = kmins[0] for kk in kmins):
+        if any(kk != kmins[0] for kk in kmins):
             raise ValueError("All lower frequency cutoffs must be the same")
         if any(kk != kmaxs[0] for kk in kmaxs):
             raise ValueError("All high frequency cutoffs must be the same")
-        #f_lows = list(self.low_frequency_cutoff.values())
-        #if any(f_ ! = f_lows[0] for f_ in f_lows):
-        #    raise ValueError("All lower frequency cutoffs must be the same")
-        #f_highs = list(self.high_frequency_cutoff.values())
-        #if any(f_ != f_highs[0] for f_ in f_highs):
-        #    raise ValueError("All high frequency cutoffs must be the same")
         # store data and frequencies
         d0 = list(self.data.values())[0]
         self.f = numpy.array(d0.sample_frequencies)
@@ -183,10 +177,13 @@ class RelativeSPA(BaseGaussianNoise):
         self.tc_ref = float(tc_ref)
 
         # get detector-specific arrival times relative to end of data
-        dt = {ifo: self.det[ifo].time_delay_from_earth_center(ra_ref, dec_ref,
-                                                              tc_ref)
+        dt = {ifo:
+              self.det[ifo].time_delay_from_earth_center(self.ra_ref,
+                                                         self.dec_ref,
+                                                         self.tc_ref)
               for ifo in self.data}
-        self.ta = {ifo: tc_ref + dt[ifo] - self.end_time for ifo in data}
+        self.ta = {ifo: self.tc_ref + dt[ifo] - self.end_time
+                   for ifo in self.data}
 
         # generate fiducial waveform
         logging.info("Generating fiducial waveform")
@@ -359,7 +356,7 @@ class RelativeSPA(BaseGaussianNoise):
         super(RelativeSPA, self).write_metadata(fp)
         fp.attrs['mass1_ref'] = self.mass1_ref
         fp.attrs['mass2_ref'] = self.mass2_ref
-        fp.attrs['spin1z_ref'] self.spin1z_ref
+        fp.attrs['spin1z_ref'] = self.spin1z_ref
         fp.attrs['spin2z_ref'] = self.spin2z_ref
         fp.attrs['ra_ref'] = self.ra_ref
         fp.attrs['dec_ref'] = self.dec_ref

--- a/pycbc/inference/models/relbin.py
+++ b/pycbc/inference/models/relbin.py
@@ -34,7 +34,7 @@ from scipy import special
 from pycbc.waveform.spa_tmplt import spa_tmplt
 from pycbc.detector import Detector
 
-from .base_data import BaseDataModel
+from .gaussian_noise import BaseGaussianNoise
 
 
 def setup_bins(f_full, f_lo, f_hi, chi=1.0, eps=0.5):
@@ -88,7 +88,7 @@ def setup_bins(f_full, f_lo, f_hi, chi=1.0, eps=0.5):
     return nbin, fbin, fbin_ind
 
 
-class RelativeSPA(BaseDataModel):
+class RelativeSPA(BaseGaussianNoise):
     r"""Model that assumes the likelihood in a region around the peak
     is slowly varying such that a linear approximation can be made, and
     likelihoods can be calculated at a coarser frequency resolution. For

--- a/pycbc/inference/models/relbin.py
+++ b/pycbc/inference/models/relbin.py
@@ -100,98 +100,109 @@ class RelativeSPA(BaseGaussianNoise):
     the SPAtmplt approximant.
 
     For more details on initialization parameters and definition of terms, see
-    :py:class:`models.BaseDataModel`.
+    :py:class:`BaseGaussianNoise`.
+
     Parameters
     ----------
+    variable_params : (tuple of) string(s)
+        A tuple of parameter names that will be varied.
     data : dict
         A dictionary of data, in which the keys are the detector names and the
-        values are the data (assumed to be unwhitened).
-    psds : dict
-        A dictionary of FrequencySeries keyed by the detector names. The
-        dictionary must have a psd for each detector specified in the data
-        dictionary. The inner products in each detector will be
-        weighted by 1/psd of that detector.
-    mass1 : float
+        values are the data (assumed to be unwhitened). All data must have the
+        same frequency resolution.
+    low_frequency_cutoff : dict
+        A dictionary of starting frequencies, in which the keys are the
+        detector names and the values are the starting frequencies for the
+        respective detectors to be used for computing inner products.
+    mass1_ref : float
         The primary mass in solar masses used for generating the fiducial
         waveform.
-    mass2 : float
+    mass2_ref : float
         The secondary mass in solar masses used for generating the fiducial
         waveform.
-    spin1z : float
+    spin1z_ref : float
         The component of primary dimensionless spin along the orbital angular
         momentum used for generating the fiducial waveform.
-    spin2z : float
+    spin2z_ref : float
         The component of secondary dimensionless spin along the orbital angular
         momentum used for generating the fiducial waveform.
-    ra : float
+    ra_ref : float
         The right ascension in radians used for generating the fiducial
         waveform.
-    dec : float
+    dec_ref : float
         The declination in radians used for generating the fiducial waveform.
-    tc : float
+    tc_ref : float
         The GPS time of coalescence used for generating the fiducial waveform.
-    low_frequency_cutoff : float
-        The starting frequency used in computing inner products. This will be
-        the same for all detectors.
-    high_frequency_cutoff : float
-        The ending frequency used in computing inner products. This will be
-        the same for all detectors. Note that no checks are made to ensure
-        that a template waveform does not end below this frequency, so
-        choose this value to be lower than any expected final frequency
-        for template waveforms.
     epsilon : float, optional
         Tuning parameter used in calculating the frequency bins. Lower values
         will result in higher resolution and more bins.
     \**kwargs :
-        All other keyword arguments are passed to ``BaseDataModel``.
+        All other keyword arguments are passed to
+        :py:class:`BaseGaussianNoise`.
     """
     name = "relative_spa"
 
-    def __init__(self, data, psds, mass1, mass2, spin1z, spin2z,
-                 ra, dec, tc, low_frequency_cutoff,
-                 high_frequency_cutoff, epsilon=0.5, **kwargs):
-        super(RelativeSPA, self).__init__(data=data, **kwargs)
+    def __init__(self, variable_params, data, low_frequency_cutoff,
+                 mass1_ref, mass2_ref, spin1z_ref, spin2z_ref,
+                 ra_ref, dec_ref, tc_ref,
+                 epsilon=0.5,
+                 **kwargs):
+        super(SingleTemplate, self).__init__(
+            variable_params, data, low_frequency_cutoff, **kwargs)
+        # check that all of the frequency cutoffs are the same
+        # FIXME: this can probably be loosened at some point
+        kmins = list(self.kmin.values())
+        kmaxs = list(self.kmax.values())
+        if any(kk ! = kmins[0] for kk in kmins):
+            raise ValueError("All lower frequency cutoffs must be the same")
+        if any(kk != kmaxs[0] for kk in kmaxs):
+            raise ValueError("All high frequency cutoffs must be the same")
+        #f_lows = list(self.low_frequency_cutoff.values())
+        #if any(f_ ! = f_lows[0] for f_ in f_lows):
+        #    raise ValueError("All lower frequency cutoffs must be the same")
+        #f_highs = list(self.high_frequency_cutoff.values())
+        #if any(f_ != f_highs[0] for f_ in f_highs):
+        #    raise ValueError("All high frequency cutoffs must be the same")
         # store data and frequencies
-        f_lo = float(low_frequency_cutoff)
-        f_hi = float(high_frequency_cutoff)
-        self.f = numpy.array(data[data.keys()[0]].sample_frequencies)
-        self.df = data[data.keys()[0]].delta_f
-        self.data = data
-        self.end_time = float(data[data.keys()[0]].end_time)
-        self.det = {ifo: Detector(ifo) for ifo in data}
-        epsilon = float(epsilon)
+        d0 = list(self.data.values())[0]
+        self.f = numpy.array(d0.sample_frequencies)
+        self.df = d0.delta_f
+        self.end_time = float(d0.end_time)
+        self.det = {ifo: Detector(ifo) for ifo in self.data}
+        self.epsilon = float(epsilon)
         # store data and psds as arrays for faster computation
-        self.comp_data = {ifo: numpy.array(data[ifo].data) for ifo in data}
-        self.comp_psds = {ifo: numpy.array(psds[ifo].data) for ifo in data}
-        self._psds = psds
+        self.comp_data = {ifo: d.numpy() for ifo, d in self.data.items()}
+        self.comp_psds = {ifo: p.numpy() for ifo, p in self.psds.items()}
         # store fiducial waveform params
-        mass1 = float(mass1)
-        mass2 = float(mass2)
-        spin1z = float(spin1z)
-        spin2z = float(spin2z)
-        ra = float(ra)
-        dec = float(dec)
-        tc = float(tc)
+        self.mass1_ref = float(mass1_ref)
+        self.mass2_ref = float(mass2_ref)
+        self.spin1z_ref = float(spin1z_ref)
+        self.spin2z_ref = float(spin2z_ref)
+        self.ra_ref = float(ra_ref)
+        self.dec_ref = float(dec_ref)
+        self.tc_ref = float(tc_ref)
 
         # get detector-specific arrival times relative to end of data
-        dt = {ifo: self.det[ifo].time_delay_from_earth_center(ra, dec, tc) for
-              ifo in data}
-        self.ta = {ifo: tc + dt[ifo] - self.end_time for ifo in data}
+        dt = {ifo: self.det[ifo].time_delay_from_earth_center(ra_ref, dec_ref,
+                                                              tc_ref)
+              for ifo in self.data}
+        self.ta = {ifo: tc_ref + dt[ifo] - self.end_time for ifo in data}
 
         # generate fiducial waveform
         logging.info("Generating fiducial waveform")
-        hp = spa_tmplt(f_lower=f_lo, f_upper=f_hi+self.df,
-                       delta_f=self.df, mass1=mass1,
-                       mass2=mass2, spin1z=spin1z,
-                       spin2z=spin2z, distance=1.,
+        hp = spa_tmplt(f_lower=kmins[0]*self.df, f_upper=(kmaxs[0]+1)*self.df,
+                       delta_f=self.df, mass1=self.mass1_ref,
+                       mass2=self.mass2_ref, spin1z=self.spin1z_ref,
+                       spin2z=self.spin2z_ref, distance=1.,
                        spin_order=-1, phase_order=-1)
         hp.resize(len(self.f))
         self.h00 = numpy.array(hp)
 
         # compute frequency bins
         logging.info("Computing frequency bins")
-        nbin, fbin, fbin_ind = setup_bins(f_full=self.f, f_lo=f_lo, f_hi=f_hi,
-                                          eps=epsilon)
+        nbin, fbin, fbin_ind = setup_bins(f_full=self.f, f_lo=kmins[0]*self.df,
+                                          f_hi=kmaxs[0]*self.df,
+                                          eps=self.epsilon)
         logging.info("Using %s bins for this model", nbin)
         # store bins and edges in sample and frequency space
         self.edges = fbin_ind
@@ -338,9 +349,7 @@ class RelativeSPA(BaseGaussianNoise):
         return 0.
 
     def write_metadata(self, fp):
-        """Adds writing the psds and lognl, since it's a constant.
-
-        The lognl is written to the sample group's ``attrs``.
+        """Adds writing the fiducial parameters and epsilon to file's attrs.
 
         Parameters
         ----------
@@ -348,12 +357,11 @@ class RelativeSPA(BaseGaussianNoise):
             The inference file to write to.
         """
         super(RelativeSPA, self).write_metadata(fp)
-        if self._psds is not None:
-            fp.write_psd(self._psds)
-        try:
-            attrs = fp[fp.samples_group].attrs
-        except KeyError:
-            # group doesn't exist, create it
-            fp.create_group(fp.samples_group)
-            attrs = fp[fp.samples_group].attrs
-        attrs['lognl'] = self.lognl
+        fp.attrs['mass1_ref'] = self.mass1_ref
+        fp.attrs['mass2_ref'] = self.mass2_ref
+        fp.attrs['spin1z_ref'] self.spin1z_ref
+        fp.attrs['spin2z_ref'] = self.spin2z_ref
+        fp.attrs['ra_ref'] = self.ra_ref
+        fp.attrs['dec_ref'] = self.dec_ref
+        fp.attrs['tc_ref'] = self.tc_ref
+        fp.attrs['epsilon'] = self.epsilon

--- a/pycbc/inference/models/single_template.py
+++ b/pycbc/inference/models/single_template.py
@@ -35,66 +35,65 @@ class SingleTemplate(BaseGaussianNoise):
     This model assumes we know all the intrinsic parameters, and are only
     maximizing over the extrinsic ones. We also assume a dominant mode waveform
     approximant only and non-precessing.
+
+
+    Parameters
+    ----------
+    variable_params : (tuple of) string(s)
+        A tuple of parameter names that will be varied.
+    data : dict
+        A dictionary of data, in which the keys are the detector names and the
+        values are the data (assumed to be unwhitened). All data must have the
+        same frequency resolution.
+    low_frequency_cutoff : dict
+        A dictionary of starting frequencies, in which the keys are the
+        detector names and the values are the starting frequencies for the
+        respective detectors to be used for computing inner products.
+    sample_rate : int, optional
+        The sample rate to use. Default is 32768.
+    \**kwargs :
+        All other keyword arguments are passed to
+        :py:class:`BaseGaussianNoise`; see that class for details.
     """
     name = 'single_template'
 
-    def __init__(self, data, psds,
-                 low_frequency_cutoff=None,
-                 high_frequency_cutoff=None,
-                 sample_rate=32768,
-                 **kwargs):
-
-        super(SingleTemplate, self).__init__(data=data, **kwargs)
-
-        if low_frequency_cutoff is not None:
-            low_frequency_cutoff = float(low_frequency_cutoff)
-
-        if high_frequency_cutoff is not None:
-            high_frequency_cutoff = float(high_frequency_cutoff)
-
+    def __init__(self, variable_params, data, low_frequency_cutoff,
+                 sample_rate=32768, **kwargs)::
+        super(SingleTemplate, self).__init__(
+            variable_params, data, low_frequency_cutoff, **kwargs)
         # Generate template waveforms
-        df = data[tuple(data.keys())[0]].delta_f
+        df = data[self.detectors[0]].delta_f
         p = self.static_params.copy()
         if 'distance' in p:
-            p.pop('distance')
+            _ = p.pop('distance')
         if 'inclination' in p:
-            p.pop('inclination')
-
+            _ = p.pop('inclination')
         hp, _ = get_fd_waveform(delta_f=df, distance=1, inclination=0, **p)
-
-        if high_frequency_cutoff is None:
-            high_frequency_cutoff = len(data[tuple(data.keys())[0]]-1) * df
-
-        # Extend data and template to high sample rate
+        # Extend template to high sample rate
         flen = int(sample_rate / df) / 2 + 1
         hp.resize(flen)
-        for ifo in data:
-            data[ifo].resize(flen)
-
         # Calculate high sample rate SNR time series
         self.sh = {}
         self.hh = {}
         self.det = {}
-        for ifo in data:
+        for ifo in self.data:
+            flow = self.kmin * df
+            fhigh = self.kmax * df
+            # Extend data to high sample rate
+            self.data[ifo].resize(flen) 
             self.det[ifo] = Detector(ifo)
             snr, _, _ = pyfilter.matched_filter_core(
-                hp, data[ifo],
-                psd=psds[ifo],
-                low_frequency_cutoff=low_frequency_cutoff,
-                high_frequency_cutoff=high_frequency_cutoff)
+                hp, self.data[ifo],
+                psd=self.psds[ifo],
+                low_frequency_cutoff=flow,
+                high_frequency_cutoff=fhigh)
 
             self.sh[ifo] = 4 * df * snr
             self.hh[ifo] = -0.5 * pyfilter.sigmasq(
-                hp, psd=psds[ifo],
-                low_frequency_cutoff=low_frequency_cutoff,
-                high_frequency_cutoff=high_frequency_cutoff)
+                hp, psd=self.psds[ifo],
+                low_frequency_cutoff=flow,
+                high_frequency_cutoff=fhigh)
         self.time = None
-
-    def _loglikelihood(self):
-        return self.loglr
-
-    def _lognl(self):
-        return 0
 
     def _loglr(self):
         r"""Computes the log likelihood ratio

--- a/pycbc/inference/models/single_template.py
+++ b/pycbc/inference/models/single_template.py
@@ -58,7 +58,7 @@ class SingleTemplate(BaseGaussianNoise):
     name = 'single_template'
 
     def __init__(self, variable_params, data, low_frequency_cutoff,
-                 sample_rate=32768, **kwargs)::
+                 sample_rate=32768, **kwargs):
         super(SingleTemplate, self).__init__(
             variable_params, data, low_frequency_cutoff, **kwargs)
         # Generate template waveforms
@@ -77,8 +77,8 @@ class SingleTemplate(BaseGaussianNoise):
         self.hh = {}
         self.det = {}
         for ifo in self.data:
-            flow = self.kmin * df
-            fhigh = self.kmax * df
+            flow = self.kmin[ifo] * df
+            fhigh = self.kmax[ifo] * df
             # Extend data to high sample rate
             self.data[ifo].resize(flen) 
             self.det[ifo] = Detector(ifo)

--- a/pycbc/inference/models/single_template.py
+++ b/pycbc/inference/models/single_template.py
@@ -23,13 +23,13 @@ from pycbc import filter as pyfilter
 from pycbc.waveform import get_fd_waveform
 from pycbc.detector import Detector
 
-from .base_data import BaseDataModel
+from .gaussian_noise import BaseGaussianNoise
 
 # In this model we only calculate terms up to a constant.
 # We are primarily interested in the posterior result
 
 
-class SingleTemplate(BaseDataModel):
+class SingleTemplate(BaseGaussianNoise):
     r"""Model that assumes we know all the intrinsic parameters.
 
     This model assumes we know all the intrinsic parameters, and are only

--- a/pycbc/inference/models/single_template.py
+++ b/pycbc/inference/models/single_template.py
@@ -80,7 +80,7 @@ class SingleTemplate(BaseGaussianNoise):
             flow = self.kmin[ifo] * df
             fhigh = self.kmax[ifo] * df
             # Extend data to high sample rate
-            self.data[ifo].resize(flen) 
+            self.data[ifo].resize(flen)
             self.det[ifo] = Detector(ifo)
             snr, _, _ = pyfilter.matched_filter_core(
                 hp, self.data[ifo],


### PR DESCRIPTION
Fixes the `SingleTemplate` and `RelativeSPA` models for the recent changes to how data is loaded. A `BaseGaussianNoise` class is introduced.

The `from_config` (which includes loading data) and everything related to setting up the inner product weight and calculation of the noise log likelihood is moved to `BaseGaussianNoise`. The `_loglikelihood` function is also implemented, as the difference between `_loglr` and `lognl`. A `_loglr` function is not implemented. The idea is that anything that assumes stationary Gaussian noise for the noise model of the (GW) data should inherit from this class, and implement there own `_loglr` function (since that is dependent on the signal model). `GaussianNoise`, `MarginalizedPhaseGaussianNoise`, `SingleTemplate`, and `RelativeSPA` now inherit from `BaseGaussianNoise`.

In the process, I've introduced some fixes to `SingleTemplate`. By virtue of inheriting from `BaseGaussianNoise`, it now has the correct `loglikelihood`. It can also accept different frequency cutoffs for different detectors.

For `RelativeSPA`, I changed the names of the fiducial parameters, adding `_ref` at the end of their names so as not to confuse them with the variable parameters. These are also now written to the `attrs` of the output file. I didn't change anything else though; the class will just raise a `ValueError` if you try to provide different frequency cutoffs. @dfinstad you can change that if you like in a future update.

I only did a quick test to make sure that these ran without error. I didn't check that they give sensible posteriors. @dfinstad @ahnitz It would be good if you guys added some example scripts for each of these (maybe using GW170817?), and some corresponding documentation on the doc page. Since both of these are runs you can do on a laptop, it'd be a real nice example to have for users.

Putting on hold for now because this depends on #2887.