### PR TITLE
Fixed a minor issue with frame file names in documentation

### DIFF
--- a/docs/inference.rst
+++ b/docs/inference.rst
@@ -763,8 +763,8 @@ Center <https://www.gw-openscience.org>`_. Run:
 
   .. code-block:: bash
 
-     wget https://www.gw-openscience.org/catalog/GWTC-1-confident/data/GW150914/H-H1_GWOSC_4KHZ_R1-1126257415-4096.gwf
-     wget https://www.gw-openscience.org/catalog/GWTC-1-confident/data/GW150914/L-L1_GWOSC_4KHZ_R1-1126257415-4096.gwf
+     wget https://www.gw-openscience.org/catalog/GWTC-1-confident/data/GW150914/H-H1_GWOSC_16KHZ_R1-1126257415-4096.gwf
+     wget https://www.gw-openscience.org/catalog/GWTC-1-confident/data/GW150914/L-L1_GWOSC_16KHZ_R1-1126257415-4096.gwf
 
 This will download the appropriate data ("frame") files to your current working
 directory.  You can now use the following data configuration file:

--- a/examples/inference/gw150914/data.ini
+++ b/examples/inference/gw150914/data.ini
@@ -15,7 +15,7 @@ psd-segment-stride = 4
 ; The frame files must be downloaded from GWOSC before running. Here, we
 ; assume that the files have been downloaded to the same directory. Adjust
 ; the file path as necessary if not.
-frame-files = H1:H-H1_GWOSC_4KHZ_R1-1126257415-4096.gwf L1:L-L1_GWOSC_4KHZ_R1-1126257415-4096.gwf
+frame-files = H1:H-H1_GWOSC_16KHZ_R1-1126257415-4096.gwf L1:L-L1_GWOSC_16KHZ_R1-1126257415-4096.gwf
 channel-name = H1:GWOSC-16KHZ_R1_STRAIN L1:GWOSC-16KHZ_R1_STRAIN
 ; this will cause the data to be resampled to 2048 Hz:
 sample-rate = 2048


### PR DESCRIPTION
This is a minor fix in inference documentation for GW150914 example. The downloaded frame files and channel names were not in sync.