### PR TITLE
Allow option to reuse SCIENCE/VETOES xml files

### DIFF
--- a/pycbc/workflow/segment.py
+++ b/pycbc/workflow/segment.py
@@ -1434,6 +1434,7 @@ def get_segments_file(workflow, name, option_name, out_dir):
     if source == "file":
         local_file_path = \
             resolve_url(cp.get("workflow-segments", option_name+"-file"))
+        print local_file_path, out_dir
         return SegFile.from_segment_xml(local_file_path)
 
     segs = {}

--- a/pycbc/workflow/segment.py
+++ b/pycbc/workflow/segment.py
@@ -1433,8 +1433,8 @@ def get_segments_file(workflow, name, option_name, out_dir):
         source = cp.get("workflow-segments", "segments-source")
     if source == "file":
         local_file_path = \
-            resolve_url(cp.get_opt_tags("workflow-segments",
-                                        option_name+"-file")
+            resolve_url(cp.get_opt("workflow-segments",
+                                   option_name+"-file"))
         return SegFile.from_segment_xml(local_file_path)
 
     segs = {}

--- a/pycbc/workflow/segment.py
+++ b/pycbc/workflow/segment.py
@@ -1431,6 +1431,11 @@ def get_segments_file(workflow, name, option_name, out_dir):
     source = "any"
     if cp.has_option("workflow-segments", "segments-source"):
         source = cp.get("workflow-segments", "segments-source")
+    if source == "file":
+        local_file_path = \
+            resolve_url(cp.get_opt_tags("workflow-segments",
+                                        option_name+"-file")
+        return SegFile.from_segment_xml(local_file_path)
 
     segs = {}
     for ifo in workflow.ifos:

--- a/pycbc/workflow/segment.py
+++ b/pycbc/workflow/segment.py
@@ -1434,8 +1434,9 @@ def get_segments_file(workflow, name, option_name, out_dir):
     if source == "file":
         local_file_path = \
             resolve_url(cp.get("workflow-segments", option_name+"-file"))
-        print local_file_path, out_dir
-        return SegFile.from_segment_xml(local_file_path)
+        pfn = os.path.join(out_dir, os.path.basename(local_file_path))
+        shutil.move(local_file_path, pfn)
+        return SegFile.from_segment_xml(pfn)
 
     segs = {}
     for ifo in workflow.ifos:

--- a/pycbc/workflow/segment.py
+++ b/pycbc/workflow/segment.py
@@ -1433,8 +1433,7 @@ def get_segments_file(workflow, name, option_name, out_dir):
         source = cp.get("workflow-segments", "segments-source")
     if source == "file":
         local_file_path = \
-            resolve_url(cp.get_opt("workflow-segments",
-                                   option_name+"-file"))
+            resolve_url(cp.get("workflow-segments", option_name+"-file"))
         return SegFile.from_segment_xml(local_file_path)
 
     segs = {}


### PR DESCRIPTION
The new segment interface needs a way to reuse existing SCIENCE / VETOES xml files and not to try to reproduce them from inputs, either a veto-definer or from LOSC. (Rerunning these might not always give you what you expect, so direct reuse of output files is the best way to ensure reproducibility). 

This has been tested and works. If you choose the source of this information to be `file` it will access for that location/URL and copy to the expected output location.