### PR TITLE
Remove automatic transforms when loading results

### DIFF
--- a/bin/inference/pycbc_inference_plot_inj_recovery
+++ b/bin/inference/pycbc_inference_plot_inj_recovery
@@ -13,7 +13,6 @@ import pycbc
 import pycbc.version
 from matplotlib import cm
 from pycbc import inject
-from pycbc import transforms
 from pycbc import __version__
 from pycbc.inference import (option_utils, io)
 
@@ -51,12 +50,6 @@ ax = fig.add_subplot(111)
 samples = [samples] if not isinstance(samples, list) else samples
 fp = [fp] if not isinstance(fp, list) else fp
 injs = io.injections_from_cli(opts)
-_, ts = transforms.get_common_cbc_transforms(opts.parameters,
-                                                 injs.fieldnames)
-
-# add parameters not included in injection file
-inj_parameters = transforms.apply_transforms(injs, ts)
-
 
 # if user wants a colorbar
 
@@ -86,7 +79,7 @@ for i, (input_file, input_fp, input_samples) in enumerate(zip(opts.input_file,
                                                               fp, samples)):
     # get paramter values
     sampled_vals = input_samples[parameter]
-    injected_vals = inj_parameters[parameter][i]
+    injected_vals = injs[parameter][i]
     # compute quantiles of sampled results
     quantiles = numpy.array([numpy.percentile(sampled_vals, 100 * q)
                              for q in opts.quantiles])

--- a/bin/inference/pycbc_inference_plot_movie
+++ b/bin/inference/pycbc_inference_plot_movie
@@ -39,7 +39,6 @@ use('agg')
 from matplotlib import pyplot
 
 import pycbc.results
-from pycbc import transforms
 
 from pycbc import __version__
 from pycbc.inference import (option_utils, io)
@@ -191,12 +190,9 @@ else:
                      "provided.")
 
 # get the samples
-file_parameters, trans = transforms.get_common_cbc_transforms(
-                                         parameters, fp.variable_params)
-samples = fp.samples_from_cli(opts, file_parameters, thin_start=thin_start,
+samples = fp.samples_from_cli(opts, parameters, thin_start=thin_start,
                               thin_interval=thinint, thin_end=thin_end,
                               iteration=itermask, flatten=False)
-samples = transforms.apply_transforms(samples, trans)
 if samples.ndim > 2:
     # multi-tempered samplers will return 3 dims, so flatten
     _, ii, jj = samples.shape

--- a/bin/inference/pycbc_inference_plot_posterior
+++ b/bin/inference/pycbc_inference_plot_posterior
@@ -130,10 +130,6 @@ if opts.plot_prior is not None:
     prior = option_utils.prior_from_config(cp)
     logging.info("Drawing samples from prior")
     prior_samples = prior.rvs(opts.prior_nsamples)
-    _, ts = transforms.get_common_cbc_transforms(
-        opts.parameters, prior_samples.fieldnames)
-    # add parameters not included in file
-    prior_samples = transforms.apply_transforms(prior_samples, ts)
 
 # get minimum and maximum ranges for each parameter from command line
 mins, maxs = option_utils.plot_ranges_from_cli(opts)

--- a/bin/inference/pycbc_inference_plot_posterior
+++ b/bin/inference/pycbc_inference_plot_posterior
@@ -42,7 +42,6 @@ from pycbc import __version__
 from pycbc import conversions
 from pycbc.workflow import WorkflowConfigParser
 from pycbc.inference import (option_utils, io)
-from pycbc import transforms
 
 from pycbc.results.scatter_histograms import create_multidim_plot
 

--- a/bin/inference/pycbc_inference_plot_samples
+++ b/bin/inference/pycbc_inference_plot_samples
@@ -26,7 +26,7 @@ from matplotlib import pyplot as plt
 from matplotlib import rc
 import numpy
 import pycbc
-from pycbc import (results, transforms)
+from pycbc import results
 from pycbc import __version__
 from pycbc.inference import (option_utils, io)
 import sys
@@ -72,9 +72,6 @@ plt.xlabel("Iteration")
 # loop over parameters
 axs = [axs] if not hasattr(axs, "__iter__") else axs
 
-file_parameters, cs = transforms.get_common_cbc_transforms(
-                                            parameters, fp.variable_params)
-
 if opts.thin_start is not None:
     xmin = opts.thin_start
 else:
@@ -104,11 +101,10 @@ except AttributeError:
 for i, arg in enumerate(parameters):
     chains_arg = []
     for widx in walkers:
-        chain = fp.read_samples(file_parameters, walkers=widx,
+        chain = fp.read_samples(parameters, walkers=widx,
                                 thin_start=opts.thin_start,
                                 thin_interval=opts.thin_interval,
                                 thin_end=opts.thin_end, **additional_args)
-        chain = transforms.apply_transforms(chain, cs)
         chains_arg.append(chain[arg])
     if opts.walkers is not None:
         for chain in chains_arg:

--- a/pycbc/inference/io/__init__.py
+++ b/pycbc/inference/io/__init__.py
@@ -649,7 +649,7 @@ def results_from_cli(opts, load_samples=True, **kwargs):
             logging.info("Loading samples")
 
             # read samples from file
-            samples = fp.samples_from_cli(opts, parameters=file_parameters,
+            samples = fp.samples_from_cli(opts, parameters=opts.parameters,
                                           **kwargs)
 
             logging.info("Loaded {} samples".format(samples.size))

--- a/pycbc/inference/io/__init__.py
+++ b/pycbc/inference/io/__init__.py
@@ -28,7 +28,6 @@ import numpy
 import logging
 import h5py as _h5py
 from pycbc.io.record import FieldArray, _numpy_function_lib
-from pycbc import transforms as _transforms
 from pycbc import waveform as _waveform
 
 from pycbc.inference.option_utils import (ParseLabelArg, ParseParametersArg)
@@ -649,18 +648,11 @@ def results_from_cli(opts, load_samples=True, **kwargs):
         if load_samples:
             logging.info("Loading samples")
 
-            # check if need extra parameters for a non-sampling parameter
-            file_parameters, ts = _transforms.get_common_cbc_transforms(
-                opts.parameters, fp.variable_params)
-
             # read samples from file
             samples = fp.samples_from_cli(opts, parameters=file_parameters,
                                           **kwargs)
 
             logging.info("Loaded {} samples".format(samples.size))
-
-            # add parameters not included in file
-            samples = _transforms.apply_transforms(samples, ts)
 
             if input_file in constraints:
                 logging.info("Applying constraints")


### PR DESCRIPTION
Currently, some of the plotting codes in the inference module try to apply transforms automatically to add some common cbc parameters if they do not exist in an input file, such as `mchirp` and `chi_eff`. The original intent was to save on having to write out functions on the command line when creating plots. However, this has led to a number of issues if you use anything but a standard CBC analysis. It's also impossible to know what transforms have been applied and what haven't, leading to confusion as to what should be called as a function and what should be called as an array. 

For example, the `--file-help` message in `pycbc_inference_plot_posterior` tells you that you can use functions in the conversions module on any of the parameters in your file. One of the functions is `chi_eff`. If you had `mass1`, `mass2`, `spin1z`, `spin2z` in your file, you might think you could do `--parameters chi_eff(mass1, mass2, spin1z, spin2z)`. But if the automatic transform was applied (and it's difficult to tell if it has or not), you'd get an error, since in that case `chi_eff` is an array that has silently been created, not a function (meaning you should have done`--parameters chi_eff`).

To clear this up, this patch removes the attempt at automatic transforms from the functions that load the results and all of the plotting executables. If a user gets tired retyping functions on the command line, they can use `pycbc_inference_extract_samples` to add the derived parameter to a file instead.