### PR TITLE
Fix effective number of samples estimate

### DIFF
--- a/pycbc/inference/sampler/base_mcmc.py
+++ b/pycbc/inference/sampler/base_mcmc.py
@@ -627,7 +627,8 @@ class BaseMCMC(object):
                 logging.info("Computing acls")
                 self.acls = self.compute_acl(self.checkpoint_file,
                                              start_index=burn_in_index)
-            logging.info("ACT: %s", str(numpy.array(self.acts.values()).max()))
+            logging.info("ACT: %s",
+                         str(numpy.array(list(self.acts.values())).max()))
             # write
             for fn in [self.checkpoint_file, self.backup_file]:
                 with self.io(fn, "a") as fp:

--- a/pycbc/inference/sampler/base_mcmc.py
+++ b/pycbc/inference/sampler/base_mcmc.py
@@ -286,6 +286,8 @@ class BaseMCMC(object):
         """
         if interval is None:
             interval = 1
+        if interval < 1:
+            raise ValueError("thin interval must be >= 1")
         self._thin_interval = interval
 
     @property
@@ -332,8 +334,11 @@ class BaseMCMC(object):
             thinfactor = max(thinfactor, 1)
             # make the new interval is a multiple of the previous, to ensure
             # that any samples currently on disk can be thinned accordingly
-            thin_interval = (thinfactor // self.thin_interval) * \
-                self.thin_interval
+            if thinfactor < self.thin_interval:
+                thin_interval = self.thin_interval
+            else:
+                thin_interval = (thinfactor // self.thin_interval) * \
+                    self.thin_interval
         else:
             thin_interval = self.thin_interval
         return thin_interval

--- a/pycbc/inference/sampler/base_mcmc.py
+++ b/pycbc/inference/sampler/base_mcmc.py
@@ -327,13 +327,13 @@ class BaseMCMC(object):
             # the extra factor of 2 is to account for the fact that the thin
             # interval will need to be at least twice as large as a previously
             # used interval
-            thinfactor = 2 * self.niterations // self.max_samples_per_chain
+            thinfactor = 2*(self.niterations // self.max_samples_per_chain)
+            # make sure it's at least 1
+            thinfactor = max(thinfactor, 1)
             # make the new interval is a multiple of the previous, to ensure
             # that any samples currently on disk can be thinned accordingly
             thin_interval = (thinfactor // self.thin_interval) * \
                 self.thin_interval
-            # make sure it's at least 1
-            thin_interval = max(thin_interval, 1)
         else:
             thin_interval = self.thin_interval
         return thin_interval
@@ -466,6 +466,7 @@ class BaseMCMC(object):
         else:
             with self.io(self.checkpoint_file, "r") as fp:
                 self._lastclear = fp.niterations
+                self.thin_interval = fp.thinned_by
         if self.target_eff_nsamples is not None:
             target_nsamples = self.target_eff_nsamples
             with self.io(self.checkpoint_file, "r") as fp:
@@ -569,28 +570,33 @@ class BaseMCMC(object):
     def checkpoint(self):
         """Dumps current samples to the checkpoint file."""
         # thin and write new samples
+        # get the updated thin interval to use
+        thin_interval = self.get_thin_interval()
         for fn in [self.checkpoint_file, self.backup_file]:
             with self.io(fn, "a") as fp:
                 # write the current number of iterations
                 fp.write_niterations(self.niterations)
-                thin_interval = self.get_thin_interval()
                 # thin samples on disk if it changed
                 if thin_interval > 1:
                     # if this is the first time writing, set the file's
                     # thinned_by
                     if fp.last_iteration() == 0:
                         fp.thinned_by = thin_interval
-                    else:
-                        # check if we need to thin the current samples on disk
-                        thin_by = thin_interval // fp.thinned_by
-                        if thin_by > 1:
-                            logging.info("Thinning samples in %s by a factor "
-                                         "of %i", fn, int(thin_by))
-                            fp.thin(thin_by)
+                    elif thin_interval < fp.thinned_by:
+                        # whatever was done previously resulted in a larger
+                        # thin interval, so we'll set it to the file's
+                        thin_interval = fp.thinned_by
+                    elif thin_interval > fp.thinned_by:
+                        # we need to thin the samples on disk
+                        logging.info("Thinning samples in %s by a factor "
+                                     "of %i", fn, int(thin_interval))
+                        fp.thin(thin_interval)
                 fp_lastiter = fp.last_iteration()
             logging.info("Writing samples to %s with thin interval %i", fn,
                          thin_interval)
             self.write_results(fn)
+        # update the running thin interval
+        self.thin_interval = thin_interval
         # see if we had anything to write after thinning; if not, don't try
         # to compute anything
         with self.io(self.checkpoint_file, "r") as fp:
@@ -765,7 +771,7 @@ class BaseMCMC(object):
         """
         if self.acls is None:
             return None
-        return {p: acl * self.get_thin_interval()
+        return {p: acl * self.thin_interval
                 for (p, acl) in self.acls.items()}
 
     @abstractmethod


### PR DESCRIPTION
Currently, the number of effective samples that exist after a checkpoint are being underestimated for MCMC samplers when max-samples-per-chain is used. This causes the sampler to run longer than it needs. The underestimation can be up to a factor of 2.

The reason for this is that the autocorrelation time (ACT)  is being overestimated. The ACT is the autocorrelation length times the thinning interval used to store samples; i.e., it's the number of iterations the sampler needs to run for to get a new independent sample (whereas the autocorrelation _length_ is the number of _thinned_ samples you need to skip, where the thinning interval is the one used for storing samples to the checkpoint file). When the ACT is calculated after a checkpoint, the method `get_thin_interval` is used to get the thinning interval. However, this function is also used to figure out what new thinning interval to use to add more samples to a file, based on the current number of iterations. This means that it can give you an interval that is a factor of 2 larger than what is currently being used.

For example, say you set max-samples-per-chain to 1000, and you just wrote the first 1000 samples to file at a checkpoint. The thinning interval will be 1 when the samples are written, since you are under the limit. The code then calculates the autocorrelation length using these samples and stores it. It then estimates the number of independent samples by multiplying the ACL times `get_thin_interval`. However, at this point, `get_thin_interval` will return 2 for the thinning interval instead of 1, since this is what you would need to use to write _more_ samples to file, not what was last used. This results in the estimated ACT being twice as large as what it actually is.

This only affects the estimated number of independent samples while the run is going on; it doesn't actually affect the results. You find that you end up with twice as many samples as you thought you had when you extract the posterior after the run is over. While this isn't terrible, it will lead to longer run times than needed, particularly for `emcee_pt`.

This patch fixes this by storing the thinning interval used as an attribute of the sampler, rather then trying to compute it on the fly. This was used in the 2-OGC results.