### PR TITLE
Delay applying waveform transforms

### DIFF
--- a/pycbc/inference/models/base.py
+++ b/pycbc/inference/models/base.py
@@ -479,7 +479,7 @@ class BaseModel(object):
         """
         return self._current_stats.getstatsdict(self.default_stats)
 
-    def _trytoget(self, statname, fallback, **kwargs):
+    def _trytoget(self, statname, fallback, apply_transforms=False, **kwargs):
         """Helper function to get a stat from ``_current_stats``.
 
         If the statistic hasn't been calculated, ``_current_stats`` will raise
@@ -493,6 +493,9 @@ class BaseModel(object):
             The stat to get from ``current_stats``.
         fallback : method of self
             The function to call if the property call fails.
+        apply_transforms : bool, optional
+            Apply waveform transforms to the current parameters before calling
+            the fallback function. Default is False.
         \**kwargs :
             Any other keyword arguments are passed through to the function.
 
@@ -504,6 +507,11 @@ class BaseModel(object):
         try:
             return getattr(self._current_stats, statname)
         except AttributeError:
+            # apply waveform transforms if requested
+            if apply_transforms and self.waveform_transforms is not None:
+                self._current_params = transforms.apply_transforms(
+                    self._current_params, self.waveform_transforms,
+                    inverse=False)
             val = fallback(**kwargs)
             setattr(self._current_stats, statname, val)
             return val
@@ -516,7 +524,8 @@ class BaseModel(object):
         If that raises an ``AttributeError``, will call `_loglikelihood`` to
         calculate it and store it to ``current_stats``.
         """
-        return self._trytoget('loglikelihood', self._loglikelihood)
+        return self._trytoget('loglikelihood', self._loglikelihood,
+                              apply_transforms=True)
 
     @abstractmethod
     def _loglikelihood(self):
@@ -612,7 +621,7 @@ class BaseModel(object):
         return p0
 
     def _transform_params(self, **params):
-        """Applies all transforms to the given params.
+        """Applies sampling transforms and boundary conditions to some params.
 
         Parameters
         ----------
@@ -628,11 +637,6 @@ class BaseModel(object):
         # variable args
         if self.sampling_transforms is not None:
             params = self.sampling_transforms.apply(params, inverse=True)
-        # apply waveform transforms
-        if self.waveform_transforms is not None:
-            params = transforms.apply_transforms(params,
-                                                 self.waveform_transforms,
-                                                 inverse=False)
         # apply boundary conditions
         params = self.prior_distribution.apply_boundary_conditions(**params)
         return params

--- a/pycbc/inference/models/base.py
+++ b/pycbc/inference/models/base.py
@@ -621,7 +621,7 @@ class BaseModel(object):
         return p0
 
     def _transform_params(self, **params):
-        """Applies sampling transforms and boundary conditions to some params.
+        """Applies sampling transforms and boundary conditions to parameters.
 
         Parameters
         ----------

--- a/pycbc/inference/models/base.py
+++ b/pycbc/inference/models/base.py
@@ -480,7 +480,7 @@ class BaseModel(object):
         return self._current_stats.getstatsdict(self.default_stats)
 
     def _trytoget(self, statname, fallback, apply_transforms=False, **kwargs):
-        """Helper function to get a stat from ``_current_stats``.
+        r"""Helper function to get a stat from ``_current_stats``.
 
         If the statistic hasn't been calculated, ``_current_stats`` will raise
         an ``AttributeError``. In that case, the ``fallback`` function will

--- a/pycbc/inference/models/base_data.py
+++ b/pycbc/inference/models/base_data.py
@@ -127,7 +127,7 @@ class BaseDataModel(BaseModel):
         If that raises an ``AttributeError``, will call `_loglr`` to
         calculate it and store it to ``current_stats``.
         """
-        return self._trytoget('loglr', self._loglr)
+        return self._trytoget('loglr', self._loglr, apply_transforms=True)
 
     @abstractmethod
     def _loglr(self):


### PR DESCRIPTION
This delays applying waveform transforms until either `loglikelihood` or `loglr` is called.

Currently, both sampling and waveform transforms are applied as soon as new parameters are set. If the sampler stepped into an unphysical region this can result in garbage parameter values. The prior should rule those points out. However, since the waveform transforms are applied before the prior is evaluated, a bunch of warning messages may be printed in the mean time. This often happens when sampling uniformly in comoving volume -- the sampler can easily step to unphysically large redshifts, resulting in a bunch of repeated messages to the user to call God if they want to know the luminosity distance (I thought it was funny when I wrote it...). Worse, if a function used in a waveform transform cannot handle the unphysical values, an error may be raised before the prior is evaluated.

This fixes that by adding a keyword argument to optionally apply the waveform transforms in `trytoget`. In `BaseModel`, this is used by the `loglikelihood` function; in `BaseData`, by the `loglr` function.