### PR TITLE
Apply remapped params to prior in plot posterior

### DIFF
--- a/bin/inference/pycbc_inference_plot_posterior
+++ b/bin/inference/pycbc_inference_plot_posterior
@@ -125,6 +125,8 @@ if opts.plot_prior is not None:
     prior = option_utils.prior_from_config(cp)
     logging.info("Drawing samples from prior")
     prior_samples = prior.rvs(opts.prior_nsamples)
+    # we'll just use the first file for metadata
+    fp = fps[0]
     # add the static params
     for param in fp.attrs['static_params']:
         setattr(prior_samples, param, fp.attrs[param])
@@ -134,7 +136,7 @@ if opts.plot_prior is not None:
         for func, param in fp.attrs['remapped_params']:
             try:
                 remapped_params[param] = prior_samples[func]
-            except NameError:
+            except (NameError, TypeError):
                 continue
         prior_samples = FieldArray.from_kwargs(**remapped_params)
         for param in fp.attrs['static_params']:
@@ -162,7 +164,7 @@ if opts.plot_injection_parameters:
         # check that all of the injections are the same
         try:
             vals = injections[p]
-        except NameError:
+        except (NameError, TypeError):
             # injection doesn't have this parameter, skip
             logging.warn("Could not find injection parameter {}".format(p))
             continue

--- a/bin/inference/pycbc_inference_plot_posterior
+++ b/bin/inference/pycbc_inference_plot_posterior
@@ -37,7 +37,7 @@ from matplotlib import (patches, use)
 import pycbc
 import pycbc.version
 from pycbc.results import metadata
-
+from pycbc.io import FieldArray
 from pycbc import __version__
 from pycbc import conversions
 from pycbc.workflow import WorkflowConfigParser
@@ -100,10 +100,6 @@ else:
     zvals = None
     zlbl = None
 
-# closet the files, we don't need them anymore
-for fp in fps:
-    fp.close()
-
 # if no plotting options selected, then the default options are based
 # on the number of parameters
 plot_options = [opts.plot_marginal, opts.plot_scatter, opts.plot_density]
@@ -129,6 +125,24 @@ if opts.plot_prior is not None:
     prior = option_utils.prior_from_config(cp)
     logging.info("Drawing samples from prior")
     prior_samples = prior.rvs(opts.prior_nsamples)
+    # add the static params
+    for param in fp.attrs['static_params']:
+        setattr(prior_samples, param, fp.attrs[param])
+    # remap any parameters
+    if 'remapped_params' in fp.attrs:
+        remapped_params = {}
+        for func, param in fp.attrs['remapped_params']:
+            try:
+                remapped_params[param] = prior_samples[func]
+            except NameError:
+                continue
+        prior_samples = FieldArray.from_kwargs(**remapped_params)
+        for param in fp.attrs['static_params']:
+            setattr(prior_samples, param, fp.attrs[param])
+
+# close the files, we don't need them anymore
+for fp in fps:
+    fp.close()
 
 # get minimum and maximum ranges for each parameter from command line
 mins, maxs = option_utils.plot_ranges_from_cli(opts)


### PR DESCRIPTION
Currently, if you are running `plot_posterior` on a posterior file in which some parameters have been renamed or mapped to new parameters from what they were originally, you cannot plot the prior. The problem is the prior samples are drawn from the configuration file, which will only give you samples in terms of the original variable params. This fixes this by using the `remapped_params` attribute in the posterior file's `attrs` to transform the prior samples into the same parameter space as the posterior samples.

Example: in the 2-OGC runs, the masses were called `srcmass1` and `srcmass2` in the prior. For the posterior files that were releases, these were renamed to `mass1` and `mass2`. Consequently, if you try to plot the prior using the posterior file, you get:
```
pycbc_inference_plot_posterior --input-file H1L1V1-EXTRACT_POSTERIOR_150914_09H_50M_45UTC-0-1.hdf --output-file test.png --plot-marginal --plot-density --plot-contours --plot-prior ../../pe-bbh_try8/bbh_run4_output/config_files/inference-150914_09h_50m_45UTC.ini --verbose --parameters mass1 mass2 --contour-color white
2020-01-31 10:28:45,413 Reading input file H1L1V1-EXTRACT_POSTERIOR_150914_09H_50M_45UTC-0-1.hdf
2020-01-31 10:28:45,415 Loading samples
2020-01-31 10:28:45,419 Loaded 11000 samples
2020-01-31 10:28:45,419 Loading prior
2020-01-31 10:28:45,426 Renormalizing distribution for constraints
2020-01-31 10:28:48,744 Drawing samples from prior
2020-01-31 10:29:00,999 Plotting
Traceback (most recent call last):
  File "/work/cdcapano/virtualenv/inference_data_config1/bin/pycbc_inference_plot_posterior", line 4, in <module>
    __import__('pkg_resources').run_script('PyCBC===f9b809', 'pycbc_inference_plot_posterior')
  File "/work/cdcapano/virtualenv/inference_data_config1/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 666, in run_script
    self.require(requires)[0].run_script(script_name, ns)
  File "/work/cdcapano/virtualenv/inference_data_config1/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 1462, in run_script
    exec(code, namespace, namespace)
  File "/work/cdcapano/virtualenv/inference_data_config1/lib/python2.7/site-packages/PyCBC-f9b809-py2.7-linux-x86_64.egg/EGG-INFO/scripts/pycbc_inference_plot_posterior", line 229, in <module>
    mins=mins, maxs=maxs)
  File "/work/cdcapano/virtualenv/inference_data_config1/local/lib/python2.7/site-packages/PyCBC-f9b809-py2.7-linux-x86_64.egg/pycbc/results/scatter_histograms.py", line 626, in create_multidim_plot
    samples = dict([[p, samples[p]] for p in parameters])
  File "/work/cdcapano/virtualenv/inference_data_config1/local/lib/python2.7/site-packages/PyCBC-f9b809-py2.7-linux-x86_64.egg/pycbc/io/record.py", line 895, in __getitem__
    return eval(item, {"__builtins__": None}, item_dict)
  File "<string>", line 1, in <module>
NameError: name 'mass1' is not defined
```

After this patch:
```
pycbc_inference_plot_posterior --input-file H1L1V1-EXTRACT_POSTERIOR_150914_09H_50M_45UTC-0-1.hdf --output-file test.png --plot-marginal --plot-density --plot-contours --plot-prior ../../pe-bbh_try8/bbh_run4_output/config_files/inference-150914_09h_50m_45UTC.ini --verbose --parameters mass1 mass2 --contour-color white
2020-01-31 10:27:20,218 Reading input file H1L1V1-EXTRACT_POSTERIOR_150914_09H_50M_45UTC-0-1.hdf
2020-01-31 10:27:20,220 Loading samples
2020-01-31 10:27:20,225 Loaded 11000 samples
2020-01-31 10:27:20,225 Loading prior
2020-01-31 10:27:20,232 Renormalizing distribution for constraints
2020-01-31 10:27:23,607 Drawing samples from prior
2020-01-31 10:28:16,186 Plotting
2020-01-31 10:28:23,066 Done
```
Result: [test.png](https://www.atlas.aei.uni-hannover.de/~work-cdcapano/scratch/prs/remapped_params_to_prior/test.png)