### PR TITLE
make it easier to conver to ndarray from pycbc array: speeds up a bunch of things!

### DIFF
--- a/pycbc/types/array.py
+++ b/pycbc/types/array.py
@@ -202,8 +202,11 @@ class Array(object):
             ret = self._return(ret)
         return ret
 
-    def __array__(self):
-        return self.numpy()
+    def __array__(self, dtype=None):
+        arr = self.numpy()
+        if dtype is not None:
+            arr = arr.astype(dtype)
+        return arr
 
     @property
     def shape(self):

--- a/pycbc/types/array.py
+++ b/pycbc/types/array.py
@@ -202,6 +202,9 @@ class Array(object):
             ret = self._return(ret)
         return ret
 
+    def __array__(self):
+        return self.numpy()
+
     @property
     def shape(self):
         return self._data.shape


### PR DESCRIPTION
I was investigating some slow parts of pycbc inference during the initialization. 

There was a code that did this

```
f = h5py.File('./file.hdf')

f['something'] = MY_PYCBC_TYPE
```

This looks like a good patter, and we *want* people to do it this way as opposed to constantly converting types. Turns out the issue it was falling back to getitem to convert it to a numpy array. However, there is a way to avoid this by further hooking into numpy's support with an __array__ method. 

Speeds up part of pycbc inferences initialization by two orders of magnitude (the part where it is writing data / psds to the output file). 