### PR TITLE
switch to multidetoptions for low / high frequency cutoff model options

### DIFF
--- a/docs/inference/examples/bbh.rst
+++ b/docs/inference/examples/bbh.rst
@@ -63,9 +63,8 @@ Here are the model and prior settings we will use:
 
 In the ``[model]`` section we have set the model to be ``gaussian_noise``.  As
 described above, this is the standard model to use for CBC signals. It assumes
-that the noise is wide-sense stationary Gaussian noise. Notice that we had to
-provide additional arguments for the low frequency cutoff to use in each
-detector. These values are the lower cutoffs used for the likelihood integral.
+that the noise is wide-sense stationary Gaussian noise. Notice that we provide
+a low frequency argument which is the lower bound for the likelihood integral.
 (See the |GaussianNoise| docs for details.)
 
 The |GaussianNoise| model will need to generate model waveforms in order to

--- a/examples/inference/priors/gw150914_like.ini
+++ b/examples/inference/priors/gw150914_like.ini
@@ -1,7 +1,6 @@
 [model]
 name = gaussian_noise
-h1-low-frequency-cutoff = 20
-l1-low-frequency-cutoff = 20
+low-frequency-cutoff = 20.0
 
 [variable_params]
 ; waveform parameters that will vary in MCMC

--- a/examples/inference/single/single.ini
+++ b/examples/inference/single/single.ini
@@ -4,9 +4,7 @@ name = single_template
 #; This model precalculates the SNR time series at a fixed rate.
 #; If you need a higher time resolution, this may be increased 
 sample_rate = 16384 
-h1-low-frequency-cutoff = 30
-l1-low-frequency-cutoff = 30
-v1-low-frequency-cutoff = 30
+low-frequency-cutoff = 30
 
 [data]
 instruments = H1 L1 V1

--- a/examples/inference/single/single.ini
+++ b/examples/inference/single/single.ini
@@ -3,8 +3,8 @@ name = single_template
 
 #; This model precalculates the SNR time series at a fixed rate.
 #; If you need a higher time resolution, this may be increased 
-sample_rate = 16384 
-low-frequency-cutoff = 30
+sample_rate = 32768
+low-frequency-cutoff = 30.0
 
 [data]
 instruments = H1 L1 V1

--- a/pycbc/inference/models/data_utils.py
+++ b/pycbc/inference/models/data_utils.py
@@ -360,9 +360,8 @@ def data_opts_from_config(cp, section, filter_flow):
             raise ValueError("data conditioning low frequency cutoff must "
                              "be less than the filter low frequency "
                              "cutoff")
-    # have to clear to remove the random string thing in DictWithDefaultReturn
-    opts.low_frequency_cutoff.clear()
-    opts.low_frequency_cutoff.update(low_freq_cutoff)
+    opts.low_frequency_cutoff = low_freq_cutoff
+
     # verify options are sane
     verify_psd_options_multi_ifo(opts, parser, opts.instruments)
     verify_strain_options_multi_ifo(opts, parser, opts.instruments)

--- a/pycbc/inference/models/gaussian_noise.py
+++ b/pycbc/inference/models/gaussian_noise.py
@@ -112,16 +112,16 @@ class BaseGaussianNoise(BaseDataModel):
         for ifo in self.data.keys():
             if low_frequency_cutoff[ifo] is None:
                 raise ValueError(
-                       "A low-frequency-cutoff must be provided for every "
-                       "detector for which data has been provided. If "
-                       "loading the model settings from "
-                       "a config file, please provide "
-                       "`{DETECTOR}:low-frequency-cutoff` options for "
-                       "every detector in the `[model]` section, where "
-                       "`{DETECTOR} is the name of the detector,"
-                       "or provide a single low-frequency-cutoff option"
-                       "which will be used for all detectors")
- 
+                    "A low-frequency-cutoff must be provided for every "
+                    "detector for which data has been provided. If "
+                    "loading the model settings from "
+                    "a config file, please provide "
+                    "`{DETECTOR}:low-frequency-cutoff` options for "
+                    "every detector in the `[model]` section, where "
+                    "`{DETECTOR} is the name of the detector,"
+                    "or provide a single low-frequency-cutoff option"
+                    "which will be used for all detectors")
+
         # check that the data sets all have the same delta fs and delta ts
         dts = numpy.array([d.delta_t for d in self.data.values()])
         dfs = numpy.array([d.delta_f for d in self.data.values()])

--- a/pycbc/inference/models/gaussian_noise.py
+++ b/pycbc/inference/models/gaussian_noise.py
@@ -109,9 +109,9 @@ class BaseGaussianNoise(BaseDataModel):
                                                 **kwargs)
         # check if low frequency cutoff has been provided for every IFO with
         # data
-        for key in self.data.keys():
-            if key not in low_frequency_cutoff:
-                raise KeyError(
+        for ifo in self.data.keys():
+            if low_frequency_cutoff[ifo] is None:
+                raise ValueError(
                        "A low-frequency-cutoff must be provided for every "
                        "detector for which data has been provided. If "
                        "loading the model settings from "
@@ -139,10 +139,7 @@ class BaseGaussianNoise(BaseDataModel):
         # Set the cutoff indices
         self._kmin = {}
         self._kmax = {}
-        
-        print (self._f_lower)
-        print (self._f_upper)
-        
+
         for (det, d) in self._data.items():
             kmin, kmax = pyfilter.get_cutoff_indices(self._f_lower[det],
                                                      self._f_upper[det],

--- a/pycbc/inference/models/gaussian_noise.py
+++ b/pycbc/inference/models/gaussian_noise.py
@@ -132,13 +132,17 @@ class BaseGaussianNoise(BaseDataModel):
         # store the number of samples in the time domain
         self._N = int(1./(dts[0]*dfs[0]))
         # Set low frequency cutoff
-        self._f_lower = low_frequency_cutoff
+        self.low_frequency_cutoff = self._f_lower = low_frequency_cutoff
         # set upper frequency cutoff
         self._f_upper = None
         self.high_frequency_cutoff = high_frequency_cutoff
         # Set the cutoff indices
         self._kmin = {}
         self._kmax = {}
+        
+        print (self._f_lower)
+        print (self._f_upper)
+        
         for (det, d) in self._data.items():
             kmin, kmax = pyfilter.get_cutoff_indices(self._f_lower[det],
                                                      self._f_upper[det],
@@ -519,8 +523,11 @@ class BaseGaussianNoise(BaseDataModel):
                 ignore_args.append(option)
                 name = option.replace('-', '_')
                 args[name] = cp.get_cli_option('model', name,
-                                               nargs='+',
+                                               nargs='+', type=float,
                                                action=MultiDetOptionAction)
+        if 'low_frequency_cutoff' not in args:
+            raise ValueError("low-frequency-cutoff must be provided in the"
+                             " model section, but is not found!")
 
         # data args
         bool_args = ['check-for-valid-times', 'shift-psd-times-to-valid',
@@ -529,7 +536,8 @@ class BaseGaussianNoise(BaseDataModel):
                      if cp.has_option('model', arg)}
         ignore_args += bool_args
         # load the data
-        opts = data_opts_from_config(cp, data_section, flow)
+        opts = data_opts_from_config(cp, data_section,
+                                     args['low_frequency_cutoff'])
         strain_dict, psd_strain_dict = data_from_cli(opts, **data_args)
         # convert to frequency domain and get psds
         stilde_dict, psds = fd_data_from_strain_dict(opts, strain_dict,

--- a/pycbc/workflow/configuration.py
+++ b/pycbc/workflow/configuration.py
@@ -1064,3 +1064,27 @@ class WorkflowConfigParser(glue.pipeline.DeepCopyableConfigParser):
             if val != '':
                 opts.append(val)
         return ' '.join(opts)
+        
+    def get_cli_option(self, section, option_name, **kwds):
+        """Return option using CLI action parsing
+        
+        Parameters
+        ----------
+        section: str
+            Section to find option to parse
+        option_name: str
+            Name of the option to parse from the config file
+        kwds: keywords
+            Additional keywords are passed directly to the argument parser.
+        
+        Returns
+        -------
+        value: 
+            The parsed value for this option
+        """
+        import argumentparser        
+        optstr = self.section_to_cli(section)
+        parser = argumentparser.ArgumentParser()
+        parser.add_argument("--" + option_name.replace('_', '-'), **kwds)                 
+        args = parser.parse_args()
+        return getattr(args, 'option_name')

--- a/pycbc/workflow/configuration.py
+++ b/pycbc/workflow/configuration.py
@@ -1064,10 +1064,10 @@ class WorkflowConfigParser(glue.pipeline.DeepCopyableConfigParser):
             if val != '':
                 opts.append(val)
         return ' '.join(opts)
-        
+
     def get_cli_option(self, section, option_name, **kwds):
         """Return option using CLI action parsing
-        
+
         Parameters
         ----------
         section: str
@@ -1076,16 +1076,16 @@ class WorkflowConfigParser(glue.pipeline.DeepCopyableConfigParser):
             Name of the option to parse from the config file
         kwds: keywords
             Additional keywords are passed directly to the argument parser.
-        
+
         Returns
         -------
-        value: 
+        value:
             The parsed value for this option
         """
-        import argparse        
+        import argparse
         optstr = self.section_to_cli(section)
         parser = argparse.ArgumentParser()
         name = "--" + option_name.replace('_', '-')
-        parser.add_argument(name, **kwds)                 
-        args, u = parser.parse_known_args(optstr.split())
+        parser.add_argument(name, **kwds)
+        args, _ = parser.parse_known_args(optstr.split())
         return getattr(args, option_name)

--- a/pycbc/workflow/configuration.py
+++ b/pycbc/workflow/configuration.py
@@ -1082,9 +1082,10 @@ class WorkflowConfigParser(glue.pipeline.DeepCopyableConfigParser):
         value: 
             The parsed value for this option
         """
-        import argumentparser        
+        import argparse        
         optstr = self.section_to_cli(section)
-        parser = argumentparser.ArgumentParser()
-        parser.add_argument("--" + option_name.replace('_', '-'), **kwds)                 
-        args = parser.parse_args()
-        return getattr(args, 'option_name')
+        parser = argparse.ArgumentParser()
+        name = "--" + option_name.replace('_', '-')
+        parser.add_argument(name, **kwds)                 
+        args, u = parser.parse_known_args(optstr.split())
+        return getattr(args, option_name)


### PR DESCRIPTION
This switches the [model] low / high frequency cutoff options to work like multi-det options. At the moment they behave in their own special way and you can't set a global value for all ifos either. 

@spxiwh I've added a method to the configparse to return an option parsed through the cli methods. Does this make sense there? I think it does, but would like your check over. 

@cdcapano I've updated the examples, have I missed anywhere else? I've tested on the single template code to make sure it is setting the options appropriately if you are just setting a blanket for all ifos or setting each ifo separately. If you forget an ifo, but have set another, it will also produce an error. 