### PR TITLE
split_binned histogram plots dealing with low numbers of triggers

### DIFF
--- a/bin/hdfcoinc/pycbc_fit_sngls_split_binned
+++ b/bin/hdfcoinc/pycbc_fit_sngls_split_binned
@@ -128,21 +128,29 @@ usedparams = [args.split_param_two, args.split_param_one, args.bin_param]
 extparams = [par for par in ['mchirp', 'eta', 'chi_eff', 'template_duration']
              if par in usedparams]
 
+
+
 for ex_p in extparams:
     logging.info('calculating {}'.format(ex_p))
     manual_duration_calc = False
     if ex_p == 'template_duration':
-        logging.info('atempting to use duration from trigger file')
-        params[ex_p] = np.array([trigf[args.ifo + '/template_duration'][ref][0]
-                                 for ref in trigf[args.ifo + '/template_duration_template'][:]])
-        if any(params[ex_p] == 0):
-            # Some of the templates didn't get any triggers.
-            # This will produce zeros in template duration, so recalculate.
-            logging.warn('Some templates contained no triggers. This plot '
+        logging.info('attempting to use duration from trigger file')
+        durs_list = []
+        for ref in trigf[args.ifo + '/template_duration_template'][:]:
+            temp_ref_dur = trigf[args.ifo + '/template_duration'][ref][0]
+            if temp_ref_dur:
+                durs_list += [temp_ref_dur]
+            else:
+                logging.warning('Some templates contained no triggers. This plot '
                          'is only sensible for large statistics. Calculating '
                          'template duration manually.')
-            manual_duration_calc = True
+                manual_duration_calc = True
+                break
+        if not manual_duration_calc:
+            params[ex_p] = np.array(durs_list)
+
     if ex_p != 'template_duration' or manual_duration_calc:
+        logging.info("Calculating duration from template parameters")
         params[ex_p] = trigs.get_param(ex_p, args, params['mass1'],
                                        params['mass2'], params['spin1z'],
                                        params['spin2z'])

--- a/bin/hdfcoinc/pycbc_fit_sngls_split_binned
+++ b/bin/hdfcoinc/pycbc_fit_sngls_split_binned
@@ -123,7 +123,6 @@ extparams = [par for par in ['mchirp', 'eta', 'chi_eff', 'template_duration']
              if par in usedparams]
 
 for ex_p in extparams:
-    logging.info('calculating {}'.format(ex_p))
     if ex_p == 'template_duration':
         logging.info('using duration from trigger file')
         params[ex_p] = np.array([trigf[args.ifo + '/template_duration'][ref][0]
@@ -157,7 +156,11 @@ else:
 
 
 if args.bin_param == 'template_duration' and params[args.bin_param].min() == 0:
+    # If a template does not contain triggers, then the dereferencing above
+    # will return a zero for the duration
     logging.warn('WARNING: Some templates do not contain triggers')
+    # Find the lowest non-zero template duration to use as the lower limit for
+    # the bins
     pbin_lower_lim = params[args.bin_param][params[args.bin_param] > 0].min()
 else:
     pbin_lower_lim = params[args.bin_param].min()

--- a/bin/hdfcoinc/pycbc_fit_sngls_split_binned
+++ b/bin/hdfcoinc/pycbc_fit_sngls_split_binned
@@ -128,10 +128,6 @@ for ex_p in extparams:
         logging.info('using duration from trigger file')
         params[ex_p] = np.array([trigf[args.ifo + '/template_duration'][ref][0]
                                  for ref in trigf[args.ifo + '/template_duration_template'][:]])
-        if any(params[ex_p] == 0):
-            raise RuntimeError('Some templates contained no triggers. '
-                               'This plot is only sensible for large '
-                               'statistics. Run for a longer duration.')
     else:
         logging.info("Calculating " + ex_p + " from template parameters")
         params[ex_p] = trigs.get_param(ex_p, args, params['mass1'],
@@ -158,16 +154,26 @@ if args.max_bin_param:
     pbin_upper_lim = float(args.max_bin_param)
 else:
     pbin_upper_lim = params[args.bin_param].max()
-bb_input = (params[args.bin_param].min(), pbin_upper_lim, args.num_bins)
+
+
+if params[args.bin_param].min() == 0:
+    logging.warn('WARNING: Some templates do not contain triggers')
+if args.bin_param == 'template_duration' and params[args.bin_param].min() == 0:
+    pbin_lower_lim = params[args.bin_param][params[args.bin_param] > 0].min()
+else:
+    pbin_lower_lim = params[args.bin_param].min()
+
+bb_input = (pbin_lower_lim, pbin_upper_lim, args.num_bins)
 
 logging.info('splitting {} into bins'.format(args.bin_param))
 if args.bin_spacing == 'log':
-    assert params[args.bin_param].min() > 0
+    assert pbin_lower_lim > 0
     pbins = bin_utils.LogarithmicBins(*bb_input)
 else:
     pbins = bin_utils.LinearBins(*bb_input)
 # use sentinel value -1 for templates outside range
-pind = np.array([pbins[par] if par < pbin_upper_lim else -1 for par in params[args.bin_param]])
+pind = np.array([pbins[par] if pbin_lower_lim < par < pbin_upper_lim
+                 else -1 for par in params[args.bin_param]])
 
 if args.split_one_spacing == 'log':
     assert params[args.split_param_one].min() > 0

--- a/bin/hdfcoinc/pycbc_fit_sngls_split_binned
+++ b/bin/hdfcoinc/pycbc_fit_sngls_split_binned
@@ -122,26 +122,18 @@ usedparams = [args.split_param_two, args.split_param_one, args.bin_param]
 extparams = [par for par in ['mchirp', 'eta', 'chi_eff', 'template_duration']
              if par in usedparams]
 
-
-
 for ex_p in extparams:
     logging.info('calculating {}'.format(ex_p))
-    manual_duration_calc = False
     if ex_p == 'template_duration':
-        logging.info('attempting to use duration from trigger file')
-        durs_list = []
-        for ref in trigf[args.ifo + '/template_duration_template'][:]:
-            temp_ref_dur = trigf[args.ifo + '/template_duration'][ref][0]
-            if temp_ref_dur:
-                durs_list += [temp_ref_dur]
-            else:
-                raise RuntimeError('Some templates contained no triggers. '
-                                   'This plot is only sensible for large '
-                                   'statistics. Run for a longer duration.')
-        params[ex_p] = np.array(durs_list)
-
-    if ex_p != 'template_duration':
-        logging.info("Calculating duration from template parameters")
+        logging.info('using duration from trigger file')
+        params[ex_p] = np.array([trigf[args.ifo + '/template_duration'][ref][0]
+                                 for ref in trigf[args.ifo + '/template_duration_template'][:]])
+        if any(params[ex_p] == 0):
+            raise RuntimeError('Some templates contained no triggers. '
+                               'This plot is only sensible for large '
+                               'statistics. Run for a longer duration.')
+    else:
+        logging.info("Calculating " + ex_p + " from template parameters")
         params[ex_p] = trigs.get_param(ex_p, args, params['mass1'],
                                        params['mass2'], params['spin1z'],
                                        params['spin2z'])

--- a/bin/hdfcoinc/pycbc_fit_sngls_split_binned
+++ b/bin/hdfcoinc/pycbc_fit_sngls_split_binned
@@ -117,7 +117,7 @@ params = {
 }
 bank.close()
 
-# only calculate params if needed
+# Only calculate params if needed
 usedparams = [args.split_param_two, args.split_param_one, args.bin_param]
 extparams = [par for par in ['mchirp', 'eta', 'chi_eff', 'template_duration']
              if par in usedparams]
@@ -125,8 +125,8 @@ extparams = [par for par in ['mchirp', 'eta', 'chi_eff', 'template_duration']
 for ex_p in extparams:
     if ex_p == 'template_duration':
         logging.info('Reading duration from trigger file')
-        # Note that if no triggers are present in the template, the duration
-        # returned from this process will be zero.
+        # List comprehension loops over templates; if a template has no triggers, accessing
+        # the 0th entry of its region reference will return zero due to a quirk of h5py.
         params[ex_p] = np.array([trigf[args.ifo + '/template_duration'][ref][0]
                                  for ref in trigf[args.ifo + '/template_duration_template'][:]])
     else:
@@ -156,13 +156,10 @@ if args.max_bin_param:
 else:
     pbin_upper_lim = params[args.bin_param].max()
 
-
+# For templates with no triggers, the duration will be read as zero
 if args.bin_param == 'template_duration' and params[args.bin_param].min() == 0:
-    # If a template does not contain triggers, then the duration reading
-    # above will return zero
     logging.warn('WARNING: Some templates do not contain triggers')
-    # Find the lowest non-zero template duration to use as the lower limit for
-    # the bins
+    # Use the lowest nonzero template duration as lower limit for bins
     pbin_lower_lim = params[args.bin_param][params[args.bin_param] > 0].min()
 else:
     pbin_lower_lim = params[args.bin_param].min()
@@ -175,7 +172,7 @@ if args.bin_spacing == 'log':
     pbins = bin_utils.LogarithmicBins(*bb_input)
 else:
     pbins = bin_utils.LinearBins(*bb_input)
-# use sentinel value -1 for templates outside range
+# Use sentinel value -1 for templates outside range
 pind = np.array([pbins[par] if pbin_lower_lim < par < pbin_upper_lim
                  else -1 for par in params[args.bin_param]])
 

--- a/bin/hdfcoinc/pycbc_fit_sngls_split_binned
+++ b/bin/hdfcoinc/pycbc_fit_sngls_split_binned
@@ -156,9 +156,8 @@ else:
     pbin_upper_lim = params[args.bin_param].max()
 
 
-if params[args.bin_param].min() == 0:
-    logging.warn('WARNING: Some templates do not contain triggers')
 if args.bin_param == 'template_duration' and params[args.bin_param].min() == 0:
+    logging.warn('WARNING: Some templates do not contain triggers')
     pbin_lower_lim = params[args.bin_param][params[args.bin_param] > 0].min()
 else:
     pbin_lower_lim = params[args.bin_param].min()

--- a/bin/hdfcoinc/pycbc_fit_sngls_split_binned
+++ b/bin/hdfcoinc/pycbc_fit_sngls_split_binned
@@ -95,6 +95,12 @@ parser.add_argument("--prune-number", type=int, default=0,
 parser.add_argument("--prune-window", type=float, default=0.1,
                     help="Time (s) to remove all triggers around a trigger "
                          "which is loudest in each split, default 0.1s")
+parser.add_argument("--f-lower", type=float, default=20.,
+                    help="Lower bound for signal frequency when calculating "
+                         "template duration - needed if calculating duration "
+                         "from template bank parameters. Default 20Hz")
+parser.add_argument("--min-duration", type=float, default=0.1,
+                    help="Minimum template duration used. Default 0.1s")
 args = parser.parse_args()
 
 if args.verbose:
@@ -126,7 +132,7 @@ for ex_p in extparams:
     logging.info('calculating {}'.format(ex_p))
     manual_duration_calc = False
     if ex_p == 'template_duration':
-        logging.info('using duration from trigger file')
+        logging.info('atempting to use duration from trigger file')
         params[ex_p] = np.array([trigf[args.ifo + '/template_duration'][ref][0]
                                  for ref in trigf[args.ifo + '/template_duration_template'][:]])
         if any(params[ex_p] == 0):

--- a/bin/hdfcoinc/pycbc_fit_sngls_split_binned
+++ b/bin/hdfcoinc/pycbc_fit_sngls_split_binned
@@ -124,11 +124,19 @@ extparams = [par for par in ['mchirp', 'eta', 'chi_eff', 'template_duration']
 
 for ex_p in extparams:
     logging.info('calculating {}'.format(ex_p))
+    manual_duration_calc = False
     if ex_p == 'template_duration':
         logging.info('using duration from trigger file')
         params[ex_p] = np.array([trigf[args.ifo + '/template_duration'][ref][0]
                                  for ref in trigf[args.ifo + '/template_duration_template'][:]])
-    else:
+        if any(params[ex_p] == 0):
+            # Some of the templates didn't get any triggers.
+            # This will produce zeros in template duration, so recalculate.
+            logging.warn('Some templates contained no triggers. This plot '
+                         'is only sensible for large statistics. Calculating '
+                         'template duration manually.')
+            manual_duration_calc = True
+    if ex_p != 'template_duration' or manual_duration_calc:
         params[ex_p] = trigs.get_param(ex_p, args, params['mass1'],
                                        params['mass2'], params['spin1z'],
                                        params['spin2z'])

--- a/bin/hdfcoinc/pycbc_fit_sngls_split_binned
+++ b/bin/hdfcoinc/pycbc_fit_sngls_split_binned
@@ -124,7 +124,9 @@ extparams = [par for par in ['mchirp', 'eta', 'chi_eff', 'template_duration']
 
 for ex_p in extparams:
     if ex_p == 'template_duration':
-        logging.info('using duration from trigger file')
+        logging.info('Reading duration from trigger file')
+        # Note that if no triggers are present in the template, the duration
+        # returned from this process will be zero.
         params[ex_p] = np.array([trigf[args.ifo + '/template_duration'][ref][0]
                                  for ref in trigf[args.ifo + '/template_duration_template'][:]])
     else:
@@ -156,8 +158,8 @@ else:
 
 
 if args.bin_param == 'template_duration' and params[args.bin_param].min() == 0:
-    # If a template does not contain triggers, then the dereferencing above
-    # will return a zero for the duration
+    # If a template does not contain triggers, then the duration reading
+    # above will return zero
     logging.warn('WARNING: Some templates do not contain triggers')
     # Find the lowest non-zero template duration to use as the lower limit for
     # the bins

--- a/bin/hdfcoinc/pycbc_fit_sngls_split_binned
+++ b/bin/hdfcoinc/pycbc_fit_sngls_split_binned
@@ -95,12 +95,6 @@ parser.add_argument("--prune-number", type=int, default=0,
 parser.add_argument("--prune-window", type=float, default=0.1,
                     help="Time (s) to remove all triggers around a trigger "
                          "which is loudest in each split, default 0.1s")
-parser.add_argument("--f-lower", type=float, default=20.,
-                    help="Lower bound for signal frequency when calculating "
-                         "template duration - needed if calculating duration "
-                         "from template bank parameters. Default 20Hz")
-parser.add_argument("--min-duration", type=float, default=0.1,
-                    help="Minimum template duration used. Default 0.1s")
 args = parser.parse_args()
 
 if args.verbose:
@@ -141,15 +135,12 @@ for ex_p in extparams:
             if temp_ref_dur:
                 durs_list += [temp_ref_dur]
             else:
-                logging.warning('Some templates contained no triggers. This plot '
-                         'is only sensible for large statistics. Calculating '
-                         'template duration manually.')
-                manual_duration_calc = True
-                break
-        if not manual_duration_calc:
-            params[ex_p] = np.array(durs_list)
+                raise RuntimeError('Some templates contained no triggers. '
+                                   'This plot is only sensible for large '
+                                   'statistics. Run for a longer duration.')
+        params[ex_p] = np.array(durs_list)
 
-    if ex_p != 'template_duration' or manual_duration_calc:
+    if ex_p != 'template_duration':
         logging.info("Calculating duration from template parameters")
         params[ex_p] = trigs.get_param(ex_p, args, params['mass1'],
                                        params['mass2'], params['spin1z'],


### PR DESCRIPTION
As seen by @duncanmmacleod - if the number of triggers is low, then pycbc_fit_sngls_split_binned will fail

This is as there may be some templates with no triggers, in which case, we need to fall back to the original (slower) template duration calculation rather than reading it from the trigger fits file

The code now works in this case, but is slow, so the work in progress is to work out the trigger-to-template number ratio where we would expect this to happen, so that we don't do both procedures if we're likely to need this exception