### PR TITLE
Add utility scripts to stage out a failed workflow and copy the output map

### DIFF
--- a/bin/pycbc_copy_output_map
+++ b/bin/pycbc_copy_output_map
@@ -74,6 +74,10 @@ do
 	echo "A line contained ${#ARRAY[@]} space seperated entries."
 	echo "A map file should contain 3 per line"
 	exit 1
+    elif [[ "${ARRAY[1]}" == *.dax ]] || [[ "${ARRAY[1]}" == *.dax.map ]] || [[ "${ARRAY[1]}" == *.tc.txt ]]
+    then
+	echo "Skipping subdax file: ${ARRAY[1]}"
+	continue
     elif [ -s "${ARRAY[1]}" ]
     then
 	echo "$LINE" >> "$OUTPUT_FILE"

--- a/bin/pycbc_copy_output_map
+++ b/bin/pycbc_copy_output_map
@@ -2,10 +2,13 @@
 
 INPUT_FILE=""
 OUTPUT_FILE=""
+KEEP_ALL=1
+FILE_REGEX=()
+CHECK_FILES=0
 
 CMD_OPTS=$(getopt \
-    -o hi:o: \
-    -l help,input-file:,output-file: \
+    -o hi:o:Imc \
+    -l help,input-file:,output-file:,inspirals,merged-triggers,check-files \
     -n pycbc_copy_output_map \
     -- "$@")
 
@@ -18,11 +21,16 @@ do
 	    echo "usage: pycbc_copy_output_map [-h] input_map output_map [optional arguments]"
 	    echo
 	    echo "required arguments:"
-	    echo "  -i, --input-file      the .map file that will be copied from"
-	    echo "  -o, --output-file     the name of the output file to be created"
+	    echo "  -i, --input-file        the .map file that will be copied from"
+	    echo "  -o, --output-file       the name of the output file to be created"
 	    echo
 	    echo "optional arguments:"
-	    echo "  -h, --help            show this help message and exit"
+	    echo "  -h, --help              show this help message and exit"
+	    echo "  -I, --inspirals         if given all entries will no longer be copied,"
+	    echo "                            only inspirals and any other specified file types."
+	    echo "  -m, --merged-triggers   if given all entries will no longer be copied,"
+	    echo "                            only merged-triggers and any other specified file types."
+	    echo "  -c, --check-files       check if the files exist with non-zero size before copying."
 	    echo
 	    exit 0 ;;
 	-i|--input-file)
@@ -31,6 +39,17 @@ do
 	-o|--output-file)
 	    OUTPUT_FILE=$(readlink -f "$2")
 	    shift 2 ;;
+	-I|--inspirals)
+	    KEEP_ALL=0
+	    FILE_REGEX+=("1-INSPIRAL")
+	    shift 1 ;;
+	-m|--merged-triggers)
+	    KEEP_ALL=0
+	    FILE_REGEX+=("1-HDF_TRIGGER_MERGE")
+	    shift 1 ;;
+	-c|--check-files)
+	    CHECK_FILES=1
+	    shift 1 ;;
 	--)
 	    break ;;
     esac
@@ -65,21 +84,57 @@ then
 fi
 
 touch "$OUTPUT_FILE"
+ERROR=""
+MESSAGE=""
 
 while read -r LINE
 do
-    read -ra ARRAY <<< "$LINE"
+    KEEP_FILE=0
+    ARRAY=($LINE)
     if (( ${#ARRAY[@]} != 3 ))
     then
-	echo "A line contained ${#ARRAY[@]} space seperated entries."
-	echo "A map file should contain 3 per line"
-	exit 1
-    elif [[ "${ARRAY[1]}" == *.dax ]] || [[ "${ARRAY[1]}" == *.dax.map ]] || [[ "${ARRAY[1]}" == *.tc.txt ]]
+	ERROR="${ERROR}A line contained ${#ARRAY[@]} space seperated entries.\n" 
+	ERROR="${ERROR}A map file should contain 3 per line.\n"
+	break
+    elif [[ "${ARRAY[1]}" =~ \.dax$ ]] || [[ "${ARRAY[1]}" =~ \.dax\.map$ ]] || [[ "${ARRAY[1]}" =~ \.tc\.txt$ ]]
     then
-	echo "Skipping subdax file: ${ARRAY[1]}"
+	MESSAGE="${MESSAGE}Skipping subdax file: ${ARRAY[1]}\n"
+	continue
+    elif (( KEEP_ALL == 1 ))
+    then
+	KEEP_FILE=1
+    fi
+
+    for REGEX in ${FILE_REGEX[@]}
+    do
+	if [[ "${ARRAY[0]}" =~ $REGEX ]]
+	then
+	    KEEP_FILE=1
+	    break
+	fi
+    done
+
+    if (( KEEP_FILE != 1 ))
+    then
+	continue
+    elif (( CHECK_FILES == 0 ))
+    then
+	echo "$LINE"
 	continue
     elif [ -s "${ARRAY[1]}" ]
     then
-	echo "$LINE" >> "$OUTPUT_FILE"
+	echo "$LINE"
     fi
-done < "$INPUT_FILE"
+
+done < "$INPUT_FILE" >> $OUTPUT_FILE
+
+if [ "x${MESSAGE}" != "x" ]
+then
+    printf "$MESSAGE"
+fi
+
+if [ "x${ERROR}" != "x" ]
+then
+    printf "$ERROR"
+    exit 1
+fi

--- a/bin/pycbc_copy_output_map
+++ b/bin/pycbc_copy_output_map
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+INPUT_FILE=""
+OUTPUT_FILE=""
+
+CMD_OPTS=$(getopt \
+    -o hi:o: \
+    -l help,input-file:,output-file: \
+    -n pycbc_copy_output_map \
+    -- "$@")
+
+eval set -- "$CMD_OPTS"
+
+while true
+do
+    case "$1" in
+	-h|--help)
+	    echo "usage: pycbc_copy_output_map [-h] input_map output_map [optional arguments]"
+	    echo
+	    echo "required arguments:"
+	    echo "  -i, --input-file      the .map file that will be copied from"
+	    echo "  -o, --output-file     the name of the output file to be created"
+	    echo
+	    echo "optional arguments:"
+	    echo "  -h, --help            show this help message and exit"
+	    echo
+	    exit 0 ;;
+	-i|--input-file)
+	    INPUT_FILE=$(readlink -f "$2")
+	    shift 2 ;;
+	-o|--output-file)
+	    OUTPUT_FILE=$(readlink -f "$2")
+	    shift 2 ;;
+	--)
+	    break ;;
+    esac
+done
+
+if [ "x$INPUT_FILE" == "x" ]
+then
+    echo "-i, --input-file must be specified, see -h, --help for options"
+    exit 1
+fi
+
+if [ "x$OUTPUT_FILE" == "x" ]
+then
+    echo "-o, --output-file must be specified, see -h, --help for options"
+    exit 1
+fi
+
+if [ ! -s "$INPUT_FILE" ]
+then
+    echo "$INPUT_FILE does not exist or is empty."
+    exit 1
+elif [[ "$INPUT_FILE" != *.map ]]
+then
+    echo "$INPUT_FILE is not a .map file."
+    exit 1
+fi
+
+if [ -f "$OUTPUT_FILE" ]
+then
+    echo "$OUTPUT_FILE already exists."
+    exit 1
+fi
+
+touch "$OUTPUT_FILE"
+
+while read -r LINE
+do
+    read -ra ARRAY <<< "$LINE"
+    if (( ${#ARRAY[@]} != 3 ))
+    then
+	echo "A line contained ${#ARRAY[@]} space seperated entries."
+	echo "A map file should contain 3 per line"
+	exit 1
+    elif [ -s "${ARRAY[1]}" ]
+    then
+	echo "$LINE" >> "$OUTPUT_FILE"
+    fi
+done < "$INPUT_FILE"

--- a/bin/pycbc_stageout_failed_workflow
+++ b/bin/pycbc_stageout_failed_workflow
@@ -1,0 +1,115 @@
+#!/bin/bash
+
+WORKFLOW_DIR=""
+
+CMD_OPTS=$(getopt \
+    -o hd: \
+    -l help,workflow-dir: \
+    -n pycbc_stageout_failed_worflow \
+    -- "$@")
+
+eval set -- "$CMD_OPTS"
+
+while true
+do
+    case "$1" in
+	-h|--help)
+	    echo "usage: pycbc_copy_output_map [-h] input_map output_map [optional arguments]"
+	    echo
+	    echo "required arguments:"
+	    echo "  -d, --workflow-dir    the directory of the workflow to be staged out"
+	    echo
+	    echo "optional arguments:"
+	    echo "  -h, --help            show this help message and exit"
+	    echo
+	    exit 0 ;;
+	-d|--workflow-dir)
+	    WORKFLOW_DIR="$2"
+	    shift 2
+	    if [ ! -d "$WORKFLOW_DIR" ]
+	    then
+		echo "--workflow-dir must be given a directory"
+		exit 1
+	    fi
+	    WORKFLOW_DIR=$(readlink -f "$WORKFLOW_DIR") ;;
+	--)
+	    break ;;
+    esac
+done
+
+if [ "x$WORKFLOW_DIR" == "x" ]
+then
+    echo "-d, --workflow-dir must be specified, see -h, --help for options"
+    exit 1
+fi
+
+# Find the main map file and the workflow name
+# If multiple files are given then the workflow must be called *-main *-main-main etc.
+MAINS_STRING="-main.dax"
+WORKFLOW_DAX=($(ls "${WORKFLOW_DIR}/"*"$MAINS_STRING"))
+
+while (( ${#WORKFLOW_DAX[@]} > 1 ))
+do
+    MAINS_STRING="-main$MAINS_STRING"
+    WORKFLOW_DAX=($(ls "${WORKFLOW_DIR}/"*"$MAINS_STRING"))
+done
+
+if (( ${#WORKFLOW_DAX[@]} == 0 ))
+then
+    echo "Can't find the *-main.dax file in the workflow"
+    exit 1
+fi
+
+WORKFLOW_DAX=${WORKFLOW_DAX[0]}
+
+NAME_START=$(( ${#WORKFLOW_DIR} + 1 ))
+NAME_LENGTH=$(( ${#WORKFLOW_DAX} - $NAME_START - ${#MAINS_STRING} ))
+WORKFLOW_NAME=${WORKFLOW_DAX:$NAME_START:$NAME_LENGTH}
+WORKFLOW_MAP="${WORKFLOW_DIR}/${WORKFLOW_NAME}-main.map"
+
+echo "Workflow name:        $WORKFLOW_NAME"
+echo "Workflow map file:    $WORKFLOW_MAP"
+
+WORKING_DIRS=($(ls -d "${WORKFLOW_DIR}/local-site-scratch/work/${WORKFLOW_NAME}-main_ID"???????))
+
+echo "Working directories to be searched:"
+echo "${WORKING_DIRS[@]}"
+echo
+
+while true
+do
+    read -p "Do you wish to continue? [y/n]" YN
+    case $YN in
+	[Yy] )
+	    break ;;
+	[Nn] )
+	    exit 0 ;;
+	* )
+	    echo "Please enter y/n."
+    esac
+done
+
+while read -r LINE
+do
+    read -ra ARRAY <<< "$LINE"
+    if (( ${#ARRAY[@]} != 3 ))
+    then
+	echo "A line in the *-main.map file contained ${#ARRAY[@]} space seperated entries."
+	echo "A map file should contain 3 per line."
+	exit 1
+    elif [ ! -d $(dirname "${ARRAY[1]}") ]
+    then
+	DESTINATION_DIR=$(dirname "${ARRAY[1]}")
+	echo "$DESTINATION_DIR doesn't exist, skipping files going to this dir."
+    elif [ ! -s "${ARRAY[1]}" ]
+    then
+	for WORKING_DIR in "${WORKING_DIRS[@]}"
+	do
+	    if [ -s "${WORKING_DIR}/${ARRAY[0]}" ]
+	    then
+		cp "${WORKING_DIR}/${ARRAY[0]}" "${ARRAY[1]}"
+		break
+	    fi
+	done
+    fi
+done < "$WORKFLOW_MAP"


### PR DESCRIPTION
### pycbc_stageout_failed_workflow

Given a workflow directory look at the main map file and stage-out any files that exist with non-zero size.
This is useful if one type of injection fails (as was the case recently with SpinTaylorT2) and many of the completed inspiral jobs are therefore never staged out.

### pycbc_copy_output_map

Copy the output map of a workflow to a new file, with options to copy subsets of files (eg. inspirals) and to check that the files exist.