### PR TITLE
Correct jacobian for emcee pt

### DIFF
--- a/pycbc/inference/sampler/emcee_pt.py
+++ b/pycbc/inference/sampler/emcee_pt.py
@@ -317,7 +317,7 @@ class EmceePTSampler(MultiTemperedAutocorrSupport, MultiTemperedSupport,
 
     def _correctjacobian(self, samples):
         """Corrects the log jacobian values stored on disk.
-        
+
         Parameters
         ----------
         samples : dict
@@ -355,7 +355,7 @@ class EmceePTSampler(MultiTemperedAutocorrSupport, MultiTemperedSupport,
                                               thin_start=0,
                                               thin_interval=1, thin_end=None,
                                               temps='all', flatten=False)
-            logjacobian = self._correctjacobian(samples) 
+            logjacobian = self._correctjacobian(samples)
             # write them back out
             for fn in [self.checkpoint_file, self.backup_file]:
                 with self.io(fn, "a") as fp:

--- a/pycbc/inference/sampler/emcee_pt.py
+++ b/pycbc/inference/sampler/emcee_pt.py
@@ -91,7 +91,7 @@ class EmceePTSampler(MultiTemperedAutocorrSupport, MultiTemperedSupport,
         pool = choose_pool(mpi=use_mpi, processes=nprocesses)
         if pool is not None:
             pool.count = nprocesses
-
+        self.pool = pool
         # construct the sampler: PTSampler needs the likelihood and prior
         # functions separately
         ndim = len(model.variable_params)
@@ -315,12 +315,60 @@ class EmceePTSampler(MultiTemperedAutocorrSupport, MultiTemperedSupport,
         return dummy_sampler.thermodynamic_integration_log_evidence(
             logls=logls, fburnin=0.)
 
+    def _correctjacobian(self, samples):
+        """Corrects the log jacobian values stored on disk.
+        
+        Parameters
+        ----------
+        samples : dict
+            Dictionary of the samples.
+        """
+        # flatten samples for evaluating
+        orig_shape = list(samples.values())[0].shape
+        flattened_samples = {p: arr.ravel()
+                             for p, arr in list(samples.items())}
+        # convert to a list of tuples so we can use map function
+        params = list(flattened_samples.keys())
+        size = flattened_samples[params[0]].size
+        samples_list = [[flattened_samples[p][ii] for p in params]
+                        for ii in range(size)]
+        # we'll parallelize calculating this to make it faster
+        if True:#self.pool is None:
+            mapfunc = map
+            model = self.model
+        else:
+            mapfunc = self.pool.map
+            model = models._global_instance.model
+        def getjacobian(these_samples):
+            these_samples = dict(zip(params, these_samples))
+            these_samples = model.sampling_transforms.apply(these_samples)
+            model.update(**these_samples)
+            return model.logjacobian
+        logj = mapfunc(getjacobian, samples_list)
+        return numpy.array(logj).reshape(orig_shape)
+
     def finalize(self):
         """Calculates the log evidence and writes to the checkpoint file.
+
+        If sampling transforms were used, this also corrects the jacobian
+        stored on disk.
 
         The thin start/interval/end for calculating the log evidence are
         retrieved from the checkpoint file's thinning attributes.
         """
+        if self.model.sampling_transforms is not None:
+            # fix the lobjacobian values stored on disk
+            logging.info("Correcting logjacobian values on disk")
+            with self.io(self.checkpoint_file, 'r') as fp:
+                samples = fp.read_raw_samples(self.variable_params,
+                                              thin_start=0,
+                                              thin_interval=1, thin_end=None,
+                                              temps='all', flatten=False)
+            logjacobian = self._correctjacobian(samples) 
+            # write them back out
+            for fn in [self.checkpoint_file, self.backup_file]:
+                with self.io(fn, "a") as fp:
+                    fp[fp.samples_group]['logjacobian'][()] = logjacobian
         logging.info("Calculating log evidence")
         # get the thinning settings
         with self.io(self.checkpoint_file, 'r') as fp:


### PR DESCRIPTION
Emcee pt does not store blob data. As a result, the only statistics that are available to be saved when an inference run finishes is the loglikelihood and logprior, as emcee pt knows them. The problem is if you used sampling transforms, the log prior will have a log jacobian included in it which is not recorded to file.  This means that when you get the maximum posterior point, it will be wrong, since you should include the log jacobian when calculating it.

This fixes that by calculating the logjacobian for all points and writing them to the output file before exiting. The step is done during the `finalize()` method, so it does not slow down checkpointing.