### PR TITLE
Don't automatically copy config files

### DIFF
--- a/pycbc/workflow/configuration.py
+++ b/pycbc/workflow/configuration.py
@@ -172,12 +172,13 @@ def istext(s, text_characters=None, threshold=0.3):
     # s is 'text' if less than 30% of its characters are non-text ones:
     return len(t)/float(len(s)) <= threshold
 
-def resolve_url(url, directory=None, permissions=None, copy_to_cwd=False):
+def resolve_url(url, directory=None, permissions=None, copy_to_cwd=True):
     """Resolves a URL to a local file, and returns the path to that file.
 
     If a URL is given, the file will be copied to the current working
     directory. If a local file path is given, the file will only be copied
-    to the current working directory if ``copy_to_cwd`` is ``True``.
+    to the current working directory if ``copy_to_cwd`` is ``True``
+    (the default).
     """
 
     u = urlparse(url)

--- a/pycbc/workflow/configuration.py
+++ b/pycbc/workflow/configuration.py
@@ -182,12 +182,18 @@ def resolve_url(url, directory=None, permissions=None, copy_to_cwd=False):
 
     u = urlparse(url)
 
-    # create the name of the destination file
-    if directory is None:
-        directory = os.getcwd()
-    filename = os.path.join(directory, os.path.basename(u.path))
+    # determine whether the file exists locally
+    islocal = u.scheme == '' or u.scheme == 'file'
 
-    if u.scheme == '' or u.scheme == 'file':
+    if not islocal or copy_to_cwd:
+        # create the name of the destination file
+        if directory is None:
+            directory = os.getcwd()
+        filename = os.path.join(directory, os.path.basename(u.path))
+    else:
+        filename = u.path
+
+    if islocal:
         # check that the file exists
         if not os.path.isfile(u.path):
             errmsg  = "Cannot open file %s from URL %s" % (u.path, url)


### PR DESCRIPTION
Currently, when you initialize a `WorkflowConfigParser` it will automatically (and silently) copy the config file to the current working directory. This is done by the call to `resolve_url` that occurs in the `__init__`. While this make sense for remote files, it can lead to unexpected files getting created if the file exists locally.

This can be problematic when doing inference-related things. `WorkflowConfigParser` is used extensively throughout the inference package for specifying priors, models, samplers, etc. If you run `pycbc_inference` and point it to a configuration file not in the CWD, you'll get a copy of the file in your CWD which is never used for anything. That can be confusing. For example, it's happened to me where I edited the CWD copy after an initial inference run, forgetting that the run script was pointing to another file. The edits where then immediately deleted when I re-ran.

`WorkflowConfigParser` is also used by `pycbc_inference_plot_(posterior|prior)` in order to plot priors, and by `pycbc_create_injections` to create a set of injections. All of these lead to spurious copies of the configuration file.

This patch fixes this by adding a `copy_to_cwd` keyword argument to `resolve_url` and `WorkflowConfigParser.__init__`. A copy of a local file will only be created if this is set to True (it is False by default). If the file is a remote file, it will still create a copy.

I've tested this with pycbc inference. I'm not sure how important this feature is for the other workflows though.