### PR TITLE
Sort attr arrays before comparing them in extract_samples

### DIFF
--- a/bin/inference/pycbc_inference_extract_samples
+++ b/bin/inference/pycbc_inference_extract_samples
@@ -47,6 +47,16 @@ def isthesame(current_val, val):
     """
     if isinstance(current_val, float):
         issame = numpy.isclose(current_val, val)
+    elif isinstance(current_val, numpy.ndarray):
+        # sort before comparing
+        current_val = numpy.sort(current_val)
+        val = numpy.sort(val)
+        try:
+            # in case of floats, just check that they're close
+            issame = numpy.isclose(current_val, val)
+        except TypeError:
+            # wasn't float, do direct comparison
+            issame = current_val == val
     else:
         issame = current_val == val
     if isinstance(issame, numpy.ndarray):


### PR DESCRIPTION
When `pycbc_inference_extract_samples` is used to combine multiple files, it will check that some of the top-level `attrs` are the same between the combined files. This can fail if an attr is an array in which order doesn't matter. That happens with the `sampling_params`: because the parameters are stored in memory as a dictionary, the order they are written to the file is arbitrary.

This fixes that by sorting all arrays stored in the `attrs` when comparing them.