### PR TITLE
Allow parameters to be read from py2 inference file in py3

### DIFF
--- a/pycbc/inference/io/__init__.py
+++ b/pycbc/inference/io/__init__.py
@@ -299,6 +299,12 @@ def get_common_parameters(input_files, collection=None):
     if parameters == []:
         raise ValueError("no common parameters found for collection {} in "
                          "files {}".format(collection, ', '.join(input_files)))
+    # if using python 3 to read a file created in python 2, need to convert
+    # parameters to strs
+    try:
+        parameters = [p.decode() for p in parameters]
+    except AttributeError:
+        pass
     return parameters
 
 


### PR DESCRIPTION
If you try to use an inference plotting program like `pycbc_inference_plot_samples` in python 3 on samples file that was created in python 2, you'll get an error if you do not provide any parameters. In that case, the command-line parser tries to get the parameters to load from the file's `variable_params` attribute. If the file was created in python 2, `variable_params` will return a list of bytes objects instead of a list of strings when run in python 3. This fixes that issue by trying to decode the bytes into strings before returning the parameters list. If the parameters are already strings (as they are if the file was created in python 3), then an AttributeError is raised by `decode`; in that case, the code just continues as-is.