### PR TITLE
add very basic support for ultranest sampler

### DIFF
--- a/companion.txt
+++ b/companion.txt
@@ -1,9 +1,13 @@
 # other tools which may be useful
 gwpy>=0.8.1
+
 # HEALPix is very useful for some analysis.
 healpy
+
 # Needed for gracedb uploads
 ligo-gracedb
+
 # auxiliary samplers
 cpnest
 pymultinest
+ultranest

--- a/examples/inference/single/single.ini
+++ b/examples/inference/single/single.ini
@@ -3,7 +3,7 @@ name = single_template
 
 #; This model precalculates the SNR time series at a fixed rate.
 #; If you need a higher time resolution, this may be increased 
-sample_rate = 4096
+sample_rate = 32768
 low-frequency-cutoff = 30.0
 
 [data]
@@ -21,12 +21,10 @@ strain-high-pass = 15
 sample-rate = 2048
 
 [sampler]
-name = dynesty
-nlive = 100
-dlogz = 0.1
-#ntemps = 4
-#nwalkers = 100
-#niterations = 300
+name = emcee_pt
+ntemps = 4
+nwalkers = 100
+niterations = 300
 
 [sampler-burn_in]
 burn-in-test = min_iterations

--- a/examples/inference/single/single.ini
+++ b/examples/inference/single/single.ini
@@ -3,7 +3,7 @@ name = single_template
 
 #; This model precalculates the SNR time series at a fixed rate.
 #; If you need a higher time resolution, this may be increased 
-sample_rate = 32768
+sample_rate = 4096
 low-frequency-cutoff = 30.0
 
 [data]
@@ -21,10 +21,12 @@ strain-high-pass = 15
 sample-rate = 2048
 
 [sampler]
-name = emcee_pt
-ntemps = 4
-nwalkers = 100
-niterations = 300
+name = dynesty
+nlive = 100
+dlogz = 0.1
+#ntemps = 4
+#nwalkers = 100
+#niterations = 300
 
 [sampler-burn_in]
 burn-in-test = min_iterations

--- a/pycbc/inference/io/__init__.py
+++ b/pycbc/inference/io/__init__.py
@@ -37,6 +37,7 @@ from .epsie import EpsieFile
 from .cpnest import CPNestFile
 from .multinest import MultinestFile
 from .dynesty import DynestyFile
+from .ultranest import UltranestFile
 from .posterior import PosteriorFile
 from .txt import InferenceTXTFile
 
@@ -47,7 +48,8 @@ filetypes = {
     CPNestFile.name: CPNestFile,
     MultinestFile.name: MultinestFile,
     DynestyFile.name: DynestyFile,
-    PosteriorFile.name: PosteriorFile
+    PosteriorFile.name: PosteriorFile,
+    UltranestFile.name: UltranestFile,
 }
 
 

--- a/pycbc/inference/io/ultranest.py
+++ b/pycbc/inference/io/ultranest.py
@@ -1,0 +1,31 @@
+# Copyright (C) 2019 Collin Capano, Sumit Kumar, Alex Nitz
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# self.option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+
+#
+# =============================================================================
+#
+#                                   Preamble
+#
+# =============================================================================
+#
+"""Provides IO for the ultranest sampler.
+"""
+from .base_nested_sampler import BaseNestedSamplerFile
+
+class UltranestFile(BaseNestedSamplerFile):
+    """Class to handle file IO for the ``dynesty`` sampler."""
+
+    name = 'ultranest_file'

--- a/pycbc/inference/io/ultranest.py
+++ b/pycbc/inference/io/ultranest.py
@@ -27,6 +27,6 @@ from .base_nested_sampler import BaseNestedSamplerFile
 
 
 class UltranestFile(BaseNestedSamplerFile):
-    """Class to handle file IO for the ``dynesty`` sampler."""
+    """Class to handle file IO for the ``ultranest`` sampler."""
 
     name = 'ultranest_file'

--- a/pycbc/inference/io/ultranest.py
+++ b/pycbc/inference/io/ultranest.py
@@ -25,6 +25,7 @@
 """
 from .base_nested_sampler import BaseNestedSamplerFile
 
+
 class UltranestFile(BaseNestedSamplerFile):
     """Class to handle file IO for the ``dynesty`` sampler."""
 

--- a/pycbc/inference/sampler/__init__.py
+++ b/pycbc/inference/sampler/__init__.py
@@ -24,13 +24,15 @@ from .emcee import EmceeEnsembleSampler
 from .emcee_pt import EmceePTSampler
 from .epsie import EpsieSampler
 from .multinest import MultinestSampler
+from .ultranest import UltranestSampler
 
 # list of available samplers
 samplers = {cls.name: cls for cls in (
     EmceeEnsembleSampler,
     EmceePTSampler,
     EpsieSampler,
-    MultinestSampler
+    MultinestSampler,
+    UltranestSampler,
 )}
 
 try:

--- a/pycbc/inference/sampler/base_cube.py
+++ b/pycbc/inference/sampler/base_cube.py
@@ -78,7 +78,7 @@ class CubeModel(object):
         """
         returns log likelihood function
         """
-        params = {p: v for p, v in zip(self.model.sampling_params, cube)}
+        params = dict(zip(self.model.sampling_params, cube))
         self.model.update(**params)
         if self.model.logprior == -numpy.inf:
             return -numpy.inf

--- a/pycbc/inference/sampler/base_cube.py
+++ b/pycbc/inference/sampler/base_cube.py
@@ -1,0 +1,98 @@
+# Copyright (C) 2020 Sumit Kumar, Alex Nitz
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+
+#
+# =============================================================================
+#
+#                                   Preamble
+#
+# =============================================================================
+#
+"""
+Common utilities for samplers that rely on transforming between a unit cube
+and the prior space. This is typical of many nested sampling algorithms.
+"""
+
+from .. import models
+
+
+def call_global_loglikelihood(cube):
+    return models._global_instance.log_likelihood(cube)
+
+
+def call_global_logprior(cube):
+    return models._global_instance.prior_transform(cube)
+
+
+def setup_calls(model, nprocesses=1,
+                loglikelihood_function=None, copy_prior=False):
+    """ Configure calls for MPI support
+    """
+    model_call = CubeModel(model, loglikelihood_function)
+    if nprocesses > 1:
+        # these are used to help paralleize over multiple cores / MPI
+        models._global_instance = model_call
+        log_likelihood_call = call_global_loglikelihood
+        prior_call = call_global_logprior
+    else:
+        prior_call = model_call.prior_transform
+        log_likelihood_call = model_call.log_likelihood
+
+    return log_likelihood_call, prior_call
+
+class CubeModel(object):
+    """
+    Class for making PyCBC Inference 'model class'
+    Parameters
+    ----------
+    model : inference.BaseModel instance
+             A model instance from pycbc.
+    """
+
+    def __init__(self, model, loglikelihood_function=None, copy_prior=False):
+        if model.sampling_transforms is not None:
+            raise ValueError("Ultranest does not support sampling transforms")
+        self.model = model
+        if loglikelihood_function is None:
+            loglikelihood_function = 'loglikelihood'
+        self.loglikelihood_function = loglikelihood_function
+        self.copy_prior = copy_prior
+
+    def log_likelihood(self, cube):
+        """
+        returns log likelihood function
+        """
+        params = {p: v for p, v in zip(self.model.sampling_params, cube)}
+        self.model.update(**params)
+        if self.model.logprior == -numpy.inf:
+            return -numpy.inf
+        return getattr(self.model, self.loglikelihood_function)
+
+    def prior_transform(self, cube):
+        """
+        prior transform function for ultranest sampler
+        It takes unit cube as input parameter and apply
+        prior transforms
+        """
+        if self.copy_prior:
+            cube = cube.copy()
+        prior_dists = self.model.prior_distribution.distributions
+        dist_dict = {}
+        for dist in prior_dists:
+            dist_dict.update({param: dist for param in dist.params})
+        for i, param in enumerate(self.model.variable_params):
+            cube[i] = dist_dict[param].cdfinv(param, cube[i])
+        return cube

--- a/pycbc/inference/sampler/base_cube.py
+++ b/pycbc/inference/sampler/base_cube.py
@@ -25,6 +25,7 @@
 Common utilities for samplers that rely on transforming between a unit cube
 and the prior space. This is typical of many nested sampling algorithms.
 """
+import numpy
 
 from .. import models
 
@@ -41,7 +42,7 @@ def setup_calls(model, nprocesses=1,
                 loglikelihood_function=None, copy_prior=False):
     """ Configure calls for MPI support
     """
-    model_call = CubeModel(model, loglikelihood_function)
+    model_call = CubeModel(model, loglikelihood_function, copy_prior=copy_prior)
     if nprocesses > 1:
         # these are used to help paralleize over multiple cores / MPI
         models._global_instance = model_call
@@ -52,6 +53,7 @@ def setup_calls(model, nprocesses=1,
         log_likelihood_call = model_call.log_likelihood
 
     return log_likelihood_call, prior_call
+
 
 class CubeModel(object):
     """

--- a/pycbc/inference/sampler/base_cube.py
+++ b/pycbc/inference/sampler/base_cube.py
@@ -42,7 +42,8 @@ def setup_calls(model, nprocesses=1,
                 loglikelihood_function=None, copy_prior=False):
     """ Configure calls for MPI support
     """
-    model_call = CubeModel(model, loglikelihood_function, copy_prior=copy_prior)
+    model_call = CubeModel(model, loglikelihood_function,
+                           copy_prior=copy_prior)
     if nprocesses > 1:
         # these are used to help paralleize over multiple cores / MPI
         models._global_instance = model_call
@@ -56,8 +57,8 @@ def setup_calls(model, nprocesses=1,
 
 
 class CubeModel(object):
-    """
-    Class for making PyCBC Inference 'model class'
+    """ Class for making PyCBC Inference 'model class'
+
     Parameters
     ----------
     model : inference.BaseModel instance

--- a/pycbc/inference/sampler/dynesty.py
+++ b/pycbc/inference/sampler/dynesty.py
@@ -38,6 +38,7 @@ from pycbc.inference.io import (DynestyFile, validate_checkpoint_files)
 from pycbc.distributions import read_constraints_from_config
 from .base import (BaseSampler, setup_output)
 from .base_mcmc import get_optional_arg_from_config
+from .base_cube import setup_calls
 from .. import models
 
 
@@ -72,16 +73,11 @@ class DynestySampler(BaseSampler):
     def __init__(self, model, nlive, dlogz, nprocesses=1,
                  loglikelihood_function=None, use_mpi=False, **kwargs):
         self.model = model
+        log_likelihood_call, prior_call = setup_calls(
+            model,
+            nprocesses=nprocesses,
+            loglikelihood_function=loglikelihood_function)
         # Set up the pool
-        model_call = DynestyModel(model, loglikelihood_function)
-        if nprocesses > 1:
-            # these are used to help paralleize over multiple cores / MPI
-            models._global_instance = model_call
-            log_likelihood_call = _call_global_loglikelihood
-            prior_call = _call_global_logprior
-        else:
-            prior_call = model_call.prior_transform
-            log_likelihood_call = model_call.log_likelihood
         pool = choose_pool(mpi=use_mpi, processes=nprocesses)
         if pool is not None:
             pool.size = nprocesses
@@ -235,53 +231,3 @@ class DynestySampler(BaseSampler):
         """
 
         return self._sampler.results.logzerr[-1:][0]
-
-
-def _call_global_loglikelihood(cube):
-    return models._global_instance.log_likelihood(cube)
-
-
-def _call_global_logprior(cube):
-    return models._global_instance.prior_transform(cube)
-
-
-class DynestyModel(object):
-    """
-    Class for making PyCBC Inference 'model class'
-    Parameters
-    ----------
-    model : inference.BaseModel instance
-             A model instance from pycbc.
-    """
-
-    def __init__(self, model, loglikelihood_function=None):
-        if model.sampling_transforms is not None:
-            raise ValueError("Dinesty does not support sampling transforms")
-        self.model = model
-        if loglikelihood_function is None:
-            loglikelihood_function = 'loglikelihood'
-        self.loglikelihood_function = loglikelihood_function
-
-    def log_likelihood(self, cube):
-        """
-        returns log likelihood function
-        """
-        params = {p: v for p, v in zip(self.model.sampling_params, cube)}
-        self.model.update(**params)
-        if self.model.logprior == -numpy.inf:
-            return -numpy.inf
-        return getattr(self.model, self.loglikelihood_function)
-
-    def prior_transform(self, cube):
-        """
-        prior transform function for dynesty sampler
-        It takes unit cube as input parameter and apply
-        prior transforms
-        """
-        prior_dists = self.model.prior_distribution.distributions
-        dist_dict = {}
-        for dist in prior_dists:
-            dist_dict.update({param: dist for param in dist.params})
-        for i, param in enumerate(self.model.variable_params):
-            cube[i] = dist_dict[param].cdfinv(param, cube[i])
-        return cube

--- a/pycbc/inference/sampler/ultranest.py
+++ b/pycbc/inference/sampler/ultranest.py
@@ -107,7 +107,9 @@ class UltranestSampler(BaseSampler):
             if cp.has_option('sampler', opt_name):
                 value = cp.get('sampler', opt_name)
                 skeys[opt_name] = opts[opt_name](value)
-        return cls(model, **skeys)
+        inst = cls(model, **skeys)
+        setup_output(inst, output_file)
+        return inst
 
     def checkpoint(self):
         pass
@@ -145,27 +147,6 @@ class UltranestSampler(BaseSampler):
             fp.write_samples(self.samples, self.model.variable_params)
             # write log evidence
             fp.write_logevidence(self.logz, self.logz_err)
-
-    def setup_output(self, output_file):
-        """Sets up the sampler's checkpoint and output files.
-
-        The checkpoint file has the same name as the output file, but with
-        ``.checkpoint`` appended to the name. A backup file will also be
-        created.
-
-        If the output file already exists, an ``OSError`` will be raised.
-        This can be overridden by setting ``force`` to ``True``.
-
-        Parameters
-        ----------
-        sampler : sampler instance
-            Sampler
-        output_file : str
-            Name of the output file.
-        force : bool, optional
-            If the output file already exists, overwrite it.
-        """
-        setup_output(self, output_file)
 
     @property
     def logz(self):

--- a/pycbc/inference/sampler/ultranest.py
+++ b/pycbc/inference/sampler/ultranest.py
@@ -58,7 +58,7 @@ class UltranestSampler(BaseSampler):
 
     def __init__(self, model, **kwargs):
         super(UltranestSampler, self).__init__(model)
-    
+
         import ultranest
         log_likelihood_call, prior_call = setup_calls(model, copy_prior=True)
 

--- a/pycbc/inference/sampler/ultranest.py
+++ b/pycbc/inference/sampler/ultranest.py
@@ -78,13 +78,14 @@ class UltranestSampler(BaseSampler):
                                               list(self.model.variable_params),
                                               log_likelihood_call,
                                               prior_call)
-                                             
+
         self.nlive = 0
         self.ndim = len(self.model.variable_params)
         self.results = None
+        self.kwargs = kwargs # Keywords for the run method of ultranest
 
     def run(self):
-        self.result = self._sampler.run()
+        self.result = self._sampler.run(**self.kwargs)
 
     @property
     def io(self):
@@ -99,7 +100,27 @@ class UltranestSampler(BaseSampler):
         """
         Loads the sampler from the given config file.
         """
-        return cls(model)
+        skeys = {}
+        opts = {'update_interval_iter_fraction': float,
+                'update_interval_ncall': int,
+                'log_interval': int,
+                'show_status': bool,
+                'dlogz': float,
+                'dKL': float,
+                'frac_remain': float,
+                'Lepsilon': float,
+                'min_ess': int,
+                'max_iters': int,
+                'max_ncalls': int,
+                'max_num_improvement_loops': int,
+                'min_num_live_points': int,
+                'cluster_num_live_points:': int,
+               }
+        for opt_name in opts:
+            if cp.has_option('sampler', opt_name):
+                value = cp.get('sampler', opt_name)
+                skeys[opt_name] = opts[opt_name](value)
+        return cls(model, **skeys)
 
     def checkpoint(self):
         pass

--- a/pycbc/inference/sampler/ultranest.py
+++ b/pycbc/inference/sampler/ultranest.py
@@ -45,7 +45,7 @@ from .base_cube import setup_calls
 #
 
 class UltranestSampler(BaseSampler):
-    """This class is used to construct an Dynesty sampler from the dynesty
+    """This class is used to construct an Ultranest sampler from the ultranest
     package.
 
     Parameters

--- a/pycbc/inference/sampler/ultranest.py
+++ b/pycbc/inference/sampler/ultranest.py
@@ -30,7 +30,6 @@ packages for parameter estimation.
 from __future__ import absolute_import
 
 import logging
-import numpy
 
 from pycbc.inference.io.ultranest import UltranestFile
 from .base import (BaseSampler, setup_output)
@@ -61,7 +60,7 @@ class UltranestSampler(BaseSampler):
         super(UltranestSampler, self).__init__(model)
     
         import ultranest
-        log_likelihood_call, prior_call = setup_calls(model)
+        log_likelihood_call, prior_call = setup_calls(model, copy_prior=True)
 
         self._sampler = ultranest.ReactiveNestedSampler(
             list(self.model.variable_params),
@@ -111,6 +110,9 @@ class UltranestSampler(BaseSampler):
         return cls(model, **skeys)
 
     def checkpoint(self):
+        pass
+
+    def resume_from_checkpoint(self):
         pass
 
     def finalize(self):

--- a/pycbc/inference/sampler/ultranest.py
+++ b/pycbc/inference/sampler/ultranest.py
@@ -1,0 +1,235 @@
+# Copyright (C) 2020  Alex Nitz
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+
+#
+# =============================================================================
+#
+#                                   Preamble
+#
+# =============================================================================
+#
+"""
+This modules provides classes and functions for using the dynesty sampler
+packages for parameter estimation.
+"""
+
+
+from __future__ import absolute_import
+
+import logging
+import numpy
+
+from pycbc.distributions import read_constraints_from_config
+from .base import (BaseSampler, setup_output)
+from .base_mcmc import get_optional_arg_from_config
+from pycbc.inference.io.ultranest import UltranestFile
+from .. import models
+
+
+#
+# =============================================================================
+#
+#                                   Samplers
+#
+# =============================================================================
+#
+
+class UltranestSampler(BaseSampler):
+    """This class is used to construct an Dynesty sampler from the dynesty
+    package.
+
+    Parameters
+    ----------
+    model : model
+        A model from ``pycbc.inference.models``.
+    """
+    name = "ultranest"
+    _io = UltranestFile
+
+    def __init__(self, model, **kwargs):
+        import ultranest
+        self.model = model
+        model_call = UltranestModel(model)
+
+        nprocesses = 1
+        if nprocesses > 1:
+            # these are used to help paralleize over multiple cores / MPI
+            models._global_instance = model_call
+            log_likelihood_call = _call_global_loglikelihood
+            prior_call = _call_global_logprior
+        else:
+            prior_call = model_call.prior_transform
+            log_likelihood_call = model_call.log_likelihood
+
+        self._sampler = ultranest.ReactiveNestedSampler(
+                                              list(self.model.variable_params),
+                                              log_likelihood_call,
+                                              prior_call)
+                                             
+        self.nlive = 0
+        self.ndim = len(self.model.variable_params)
+        self.results = None
+
+    def run(self):
+        self.result = self._sampler.run()
+
+    @property
+    def io(self):
+        return self._io
+
+    @property
+    def niterations(self):
+        return sel.result['niter']
+
+    @classmethod
+    def from_config(cls, cp, model, **kwds):
+        """
+        Loads the sampler from the given config file.
+        """
+        return cls(model)
+
+    def checkpoint(self):
+        pass
+
+    def finalize(self):
+        logging.info("Writing samples to files")
+        for fn in [self.checkpoint_file, self.backup_file]:
+            self.write_results(fn)
+
+    @property
+    def model_stats(self):
+        return {}
+
+    @property
+    def samples(self):
+        samples_dict = {p: self.result['samples'][:, i] for p, i in
+                        zip(self.model.variable_params, range(self.ndim))}
+        return samples_dict
+
+    def set_initial_conditions(self, initial_distribution=None,
+                               samples_file=None):
+        """Sets up the starting point for the sampler.
+
+        Should also set the sampler's random state.
+        """
+        pass
+
+    def write_results(self, filename):
+        """Writes samples, model stats, acceptance fraction, and random state
+        to the given file.
+
+        Parameters
+        -----------
+        filename : str
+            The file to write to. The file is opened using the ``io`` class
+            in an an append state.
+        """
+        with self.io(filename, 'a') as fp:
+            # write samples
+            fp.write_samples(self.samples, self.model.variable_params)
+            # write stats
+            #fp.write_samples(self.model_stats)
+            # write log evidence
+            fp.write_logevidence(self.logz, self.logz_err)
+
+    def setup_output(self, output_file, force=False):
+        """Sets up the sampler's checkpoint and output files.
+
+        The checkpoint file has the same name as the output file, but with
+        ``.checkpoint`` appended to the name. A backup file will also be
+        created.
+
+        If the output file already exists, an ``OSError`` will be raised.
+        This can be overridden by setting ``force`` to ``True``.
+
+        Parameters
+        ----------
+        sampler : sampler instance
+            Sampler
+        output_file : str
+            Name of the output file.
+        force : bool, optional
+            If the output file already exists, overwrite it.
+        """
+        setup_output(self, output_file, force=force)
+
+    @property
+    def logz(self):
+        """
+        return bayesian evidence estimated by
+        dynesty sampler
+        """
+
+        return self.result['logz']
+
+    @property
+    def logz_err(self):
+        """
+        return error in bayesian evidence estimated by
+        dynesty sampler
+        """
+
+        return self.result['logzerr']
+
+def _call_global_loglikelihood(cube):
+    return models._global_instance.log_likelihood(cube)
+
+
+def _call_global_logprior(cube):
+    return models._global_instance.prior_transform(cube)
+
+
+class UltranestModel(object):
+    """
+    Class for making PyCBC Inference 'model class'
+    Parameters
+    ----------
+    model : inference.BaseModel instance
+             A model instance from pycbc.
+    """
+
+    def __init__(self, model, loglikelihood_function=None):
+        if model.sampling_transforms is not None:
+            raise ValueError("Ultranest does not support sampling transforms")
+        self.model = model
+        if loglikelihood_function is None:
+            loglikelihood_function = 'loglikelihood'
+        self.loglikelihood_function = loglikelihood_function
+
+    def log_likelihood(self, cube):
+        """
+        returns log likelihood function
+        """
+        params = {p: v for p, v in zip(self.model.sampling_params, cube)}
+        self.model.update(**params)
+        if self.model.logprior == -numpy.inf:
+            return -numpy.inf
+        return getattr(self.model, self.loglikelihood_function)
+
+    def prior_transform(self, cube):
+        """
+        prior transform function for ultranest sampler
+        It takes unit cube as input parameter and apply
+        prior transforms
+        """
+        cube = cube.copy()
+        prior_dists = self.model.prior_distribution.distributions
+        dist_dict = {}
+        for dist in prior_dists:
+            dist_dict.update({param: dist for param in dist.params})
+        for i, param in enumerate(self.model.variable_params):
+            cube[i] = dist_dict[param].cdfinv(param, cube[i])
+        return cube

--- a/pycbc/inference/sampler/ultranest.py
+++ b/pycbc/inference/sampler/ultranest.py
@@ -84,7 +84,7 @@ class UltranestSampler(BaseSampler):
         return self.result['niter']
 
     @classmethod
-    def from_config(cls, cp, model, **kwds):
+    def from_config(cls, cp, model, output_file=None, **kwds):
         """
         Loads the sampler from the given config file.
         """


### PR DESCRIPTION
This adds minimal support for ultranest (https://github.com/JohannesBuchner/UltraNest). 

Does not include support for checkpointing, configuring ultranest, or really much except running the sampler in default mode. 

It works similarly to dynesty, so adding support is very similar. 

Why ultranest? 

Well, see the docs https://johannesbuchner.github.io/UltraNest/. It seems to include a lot of the latest advancements in sampling (or at least more recent than many other packages) and can target final error uncertainties or desired number of independent samples (not actually supported in this patch). 

It's also by someone who has developed a version of this sampler and written papers on it for years and is the author of pymultinest as well. This seems to be his most actively developed sampler and given past history it would seem he is likely to support this for a while. 