### PR TITLE
Update inference workflow

### DIFF
--- a/bin/inference/pycbc_inference_plot_samples
+++ b/bin/inference/pycbc_inference_plot_samples
@@ -122,7 +122,7 @@ fp.close()
 
 # save figure with meta-data
 caption_kwargs = {
-    "parameters" : ", ".join(labels),
+    "parameters" : ", ".join(sorted(list(labels.values()))),
 }
 caption = r"""Parameter samples from the walker chains whose indices were
 provided as inputs. Each line is a different chain of walker samples in that

--- a/bin/workflows/pycbc_make_inference_plots_workflow
+++ b/bin/workflows/pycbc_make_inference_plots_workflow
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright (C) 2016 Christopher M. Biwer, Alexander Harvey Nitz
+# Copyright (C) 2019 Collin D. Capano, Christopher M. Biwer
 #
 # This program is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License as published by the
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-"""Creates a DAX for that generates a posterior file and plots from one or more
+"""Creates a DAX that generates a posterior file and plots from one or more
 inference samples files.
 """
 

--- a/bin/workflows/pycbc_make_inference_plots_workflow
+++ b/bin/workflows/pycbc_make_inference_plots_workflow
@@ -36,6 +36,7 @@ from pycbc.types import MultiDetOptionAction
 from pycbc.types import MultiDetOptionAppendAction
 from pycbc.workflow import configuration
 from pycbc.workflow import core
+from pycbc.workflow import pegasus_workflow
 from pycbc.workflow import datafind
 from pycbc.workflow import plotting
 from pycbc import __version__
@@ -114,6 +115,18 @@ def get_plot_group(cp, section_tag):
         plot_groups[group] = cp.get_opt_tag("workflow", opt, section_tag)
     return plot_groups
 
+
+def get_posterior_params(cp, section='workflow-posterior_parameters'):
+    """Gets the posterior parameters from the given config file."""
+    params = []
+    for opt in cp.options(section):
+        val = cp.get(section, opt)
+        if val == '':
+            val = opt
+        params.append('{}:{}'.format(opt, val))
+    return params
+
+
 # command line parser
 parser = argparse.ArgumentParser(description=__doc__[1:])
 
@@ -145,9 +158,9 @@ parser.add_argument("--seed", type=int, default=0,
                          "by one for each event.")
 # input configuration file options
 parser.add_argument("--samples-file-cache", required=True,
-                    help="Text file listing a label, the samples "
-                         "file(s) to create posteriors for, and any "
-                         "additional arguments for extracting samples."
+                    help="Text file listing a label, the inference config "
+                         "file used, and the samples "
+                         "file(s) to create posteriors for."
                     )
 #parser.add_argument("--posterior-files", metavar="FILE[:LABEL]", nargs="+",
 #                    required=True,
@@ -167,6 +180,7 @@ elabels, infconfig_files, samples_files = \
 
 posterior_file_dir = 'posterior_files'
 config_file_dir = 'config_files'
+config_file_tmplt = 'inference-{}.ini'
 
 # make data output directory
 if opts.output_dir is None:
@@ -232,8 +246,7 @@ logging.info("Created log file %s" % log_file_txt.storage_path)
 
 
 # get the parameters that will be used for posterior files and plots
-posterior_params = workflow.cp.get_opt_tag('workflow', 'posterior-parameters',
-                                           'parameters')
+posterior_params = get_posterior_params(workflow.cp)
 
 # figure out what parameters user wants to plot from workflow configuration
 group_prefix = "plot-group-"
@@ -274,13 +287,16 @@ for num_event, samples_filelist in enumerate(samples_files):
     symlink_path(config_file, rdir[base])
 
     # convert the samples files to workflow File types
-    samples_filelist = core.FileList(map(core.File, samples_filelist))
+    samples_filelist = core.FileList(map(pegasus_workflow.File,
+                                         samples_filelist))
+
+    analysis_index = segments.segment(num_event, num_event+1)
 
     # make node for running extract samples
     posterior_file = inffu.create_posterior_files(
-        sub_workflow, samples_filelist, output_dir,
+        sub_workflow, samples_filelist, posterior_file_dir,
         parameters=posterior_params, analysis_seg=analysis_index,
-        tags=opts.tags+[label])
+        tags=opts.tags+[label])[0]
 
     # summary table
     summary_page += (inffu.make_inference_summary_table(
@@ -341,7 +357,7 @@ for num_event, samples_filelist in enumerate(samples_files):
             samples_plots += inffu.make_inference_samples_plot(
                 sub_workflow, sf, rdir[base],
                 analysis_seg=analysis_index,
-                tags=opts.tags+[label, group, kk])
+                tags=opts.tags+[label, group, str(kk)])
         layout.group_layout(rdir[base], samples_plots)
 
     if 'acceptance_rate' in diagnostics:
@@ -351,7 +367,7 @@ for num_event, samples_filelist in enumerate(samples_files):
             acceptance_plot = inffu.make_inference_acceptance_rate_plot(
                 sub_workflow, sf, rdir[base],
                 analysis_seg=analysis_index,
-                tags=opts.tags+[label, kk])
+                tags=opts.tags+[label, str(kk)])
         layout.single_layout(rdir[base], acceptance_plot)
 
     # add the sub workflow to the main workflow

--- a/bin/workflows/pycbc_make_inference_plots_workflow
+++ b/bin/workflows/pycbc_make_inference_plots_workflow
@@ -312,6 +312,7 @@ for num_event, samples_filelist in enumerate(samples_files):
     for group, params in summary_plot_params.items():
         summary_plots += inffu.make_inference_posterior_plot(
             workflow, posterior_file, rdir.base,
+            name='inference_posterior_summary',
             parameters=params, plot_prior_from_file=config_file,
             analysis_seg=analysis_index,
             tags=opts.tags+[label, group])

--- a/bin/workflows/pycbc_make_inference_plots_workflow
+++ b/bin/workflows/pycbc_make_inference_plots_workflow
@@ -255,6 +255,13 @@ plot_params = get_plot_group(workflow.cp, 'plot_parameters')
 # get parameters for the summary tables
 table_params = workflow.cp.get_opt_tag('workflow', 'table-parameters',
                                        'summary_table')
+# get any metadata that should be printed
+if workflow.cp.has_option('workflow-summary_table', 'print-metadata'):
+    table_metadata = workflow.cp.get_opt_tag('workflow', 'print-metadata',
+                                             'summary_table')
+else:
+    table_metadata = None
+
 psd_page = []
 config_files = {}
 for num_event, samples_filelist in enumerate(samples_files):
@@ -296,7 +303,7 @@ for num_event, samples_filelist in enumerate(samples_files):
     # summary table
     summary_page += (inffu.make_inference_summary_table(
         workflow, posterior_file, rdir.base,
-        parameters=table_params,
+        parameters=table_params, print_metadata=table_metadata,
         analysis_seg=analysis_index,
         tags=opts.tags+[label]),)
 

--- a/bin/workflows/pycbc_make_inference_plots_workflow
+++ b/bin/workflows/pycbc_make_inference_plots_workflow
@@ -15,7 +15,8 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-""" Creates a DAX for a parameter estimation workflow.
+"""Creates a DAX for that generates a posterior file and plots from one or more
+inference samples files.
 """
 
 import argparse
@@ -28,6 +29,7 @@ import pycbc.workflow.minifollowups as mini
 import pycbc.workflow.pegasus_workflow as wdax
 import socket
 import sys
+import shlex
 import numpy
 from ligo import segments
 from pycbc import results
@@ -43,55 +45,69 @@ from pycbc import __version__
 import pycbc.workflow.inference_followups as inffu
 
 
-def load_samples_cache(samples_cache):
-    """Loads samples files from the given config file.
-    
-    Each line in the cache file should be a comma-separated list of label,
-    config file(s), samples file(s). The config file(s) are needed in order to
-    plot the prior. Multiple config and samples files should be space
-    separated. For example::
+def read_events_from_config(cp):
+    """Gets events to load from a config file.
 
-        Event 1,config.ini,samples1.hdf samples2.hdf
+    Each event should have its own section with header ``[event-{{NAME}}]``,
+    where ``NAME`` is a unique identifier. The section must have a
+    ``config-files`` option which gives the configuration file(s) that were
+    used for the event, and a ``samples-files`` option which gives one or
+    more samples files from which to extract a posterior. The section may also
+    have a ``label`` option that provides a human-readable label for the
+    results page. If no ``label`` option is provided, the ``{{NAME}}``
+    will be used.
 
-    Labels must be unique across all events. Otherwise, a ``ValueError`` is
-    raised.
+    To specify multiple configuration or samples files, the files should be
+    space (or new-line) separated. Relative or absolute paths may be used.
+
+    Example:
+
+    .. code-block:: ini
+
+       [event-gw150914_09_50_45]
+       label = GW150914+09:50:45UTC
+       config-files = inference-150914_09h_50m_45UTC.ini
+       samples-files = run1/H1L1-INFERENCE_150914_09H_50M_45UTC-5-1.hdf
+                       run2/H1L1-INFERENCE_150914_09H_50M_45UTC-5-1.hdf
+                       run3/H1L1-INFERENCE_150914_09H_50M_45UTC-5-1.hdf
 
     Parameters
     ----------
-    config_cache : str
-        The name of the cache file.
+    cp : pycbc.workflow.configuration.WorkflowConfigParser
+        Configuration file giving the events.
 
     Returns
     -------
-    labels : list
-        List of strings giving a label for each event.
-    config_files : list
-        List of the config files. Each element is itself a list providing
-        all of the config files to combine.
-    samples_files : list
-        List of the samples files. Each element is itself a list providing
-        all of the samples files to combine.
+    labels : list of str
+        The labels to use for the event(s) that were given in the config file.
+    config-files : list of lists
+        List of the configuration file(s) for each event.
+    samples-files : lsit of lists
+        List of the samples file(s) for each event.
     """
+    # get the events
+    events = cp.get_subsections('event')
     labels = []
     config_files = []
     samples_files = []
-    with open(samples_cache, 'r') as fp:
-        for line in fp:
-            if line.startswith('#'):
-                continue
-            line = line.replace('\n', '')
-            lbl, cfs, smps = line.split(',')
-            cfs = list(map(os.path.abspath, cfs.strip().split()))
-            smps = list(map(os.path.abspath, smps.strip().split()))
-            labels.append(lbl.strip())
-            config_files.append(cfs)
-            samples_files.append(smps)
-    if len(samples_files) == 0:
-        raise ValueError("no samples files found in given cache")
-    # check that the labels are unique
-    if not len(set(labels)) == len(labels):
-        raise ValueError("all labels in config cache must be unique")
+    for event in events:
+        section = '-'.join(['event', event])
+        if cp.has_option(section, 'label'):
+            label = cp.get(section, 'label')
+        else:
+            label = event
+        cf = shlex.split(cp.get(section, 'config-files'))
+        sf = shlex.split(cp.get(section, 'samples-files'))
+        labels.append(label)
+        config_files.append(list(map(os.path.abspath, cf)))
+        samples_files.append(list(map(os.path.abspath, cf)))
     return labels, config_files, samples_files
+
+
+def label_slug(label):
+    """Slugifies an event label."""
+    label.replace(' ', '_').replace(':', '_').replace('+', '_')
+
 
 def symlink_path(f, path):
     """ Symlinks a path.
@@ -102,6 +118,7 @@ def symlink_path(f, path):
         os.symlink(f.storage_path, os.path.join(path, f.name))
     except OSError:
         pass
+
 
 # command line parser
 parser = argparse.ArgumentParser(description=__doc__[1:])
@@ -144,10 +161,6 @@ configuration.add_workflow_command_line_group(parser)
 # parser command line
 opts = parser.parse_args()
 
-# get posterior files and labels
-elabels, infconfig_files, samples_files = \
-    load_samples_cache(opts.samples_file_cache)
-
 posterior_file_dir = 'posterior_files'
 config_file_dir = 'config_files'
 config_file_tmplt = 'inference-{}.ini'
@@ -175,6 +188,9 @@ logging.basicConfig(format=log_format, level=logging.INFO)
 container = core.Workflow(opts, opts.workflow_name)
 workflow = core.Workflow(opts, opts.workflow_name + "-main")
 finalize_workflow = core.Workflow(opts, opts.workflow_name + "-finalization")
+
+# get the events
+elabels, infconfig_files, samples_files = read_events_from_config(workflow.cp)
 
 # change working directory to the output
 origdir = os.path.abspath(os.curdir)
@@ -214,10 +230,8 @@ logging.info("Created log file %s" % log_file_txt.storage_path)
 config_files = {}
 for num_event, samples_filelist in enumerate(samples_files):
     label = elabels[num_event]
-    if label is None:
-        label = 'Event {}'.format(num_event)
     summary_label = label
-    label = label.replace(' ', '_').replace(':', '_').replace('+', '_')
+    label = label_slug(label)
 
     config_fnames = infconfig_files[num_event]
 

--- a/bin/workflows/pycbc_make_inference_plots_workflow
+++ b/bin/workflows/pycbc_make_inference_plots_workflow
@@ -323,13 +323,10 @@ for num_event, samples_filelist in enumerate(samples_files):
 
     # files for priors summary section
     base = "priors/{}".format(label)
-    prior_plots = []
-    for group, params in plot_params.items():
-        prior_plots += inffu.make_inference_prior_plot(
-            workflow, config_file, rdir[base],
-            analysis_seg=workflow.analysis_time,
-            parameters=params,
-            tags=opts.tags+[label, group])
+    prior_plots = inffu.make_inference_prior_plot(
+        workflow, config_file, rdir[base],
+        analysis_seg=workflow.analysis_time,
+        tags=opts.tags+[label])
     layout.single_layout(rdir[base], prior_plots)
 
     # files for posteriors summary subsection

--- a/bin/workflows/pycbc_make_inference_plots_workflow
+++ b/bin/workflows/pycbc_make_inference_plots_workflow
@@ -103,30 +103,6 @@ def symlink_path(f, path):
     except OSError:
         pass
 
-def get_plot_group(cp, section_tag):
-    """Gets plotting groups from [workflow-section_tag]."""
-    group_prefix = "plot-group-"
-    # parameters for the summary plots
-    plot_groups = {}
-    opts = [opt for opt in cp.options("workflow-{}".format(section_tag))
-            if opt.startswith(group_prefix)]
-    for opt in opts:
-        group = opt.replace(group_prefix, "").replace("-", "_")
-        plot_groups[group] = cp.get_opt_tag("workflow", opt, section_tag)
-    return plot_groups
-
-
-def get_posterior_params(cp, section='workflow-posterior_parameters'):
-    """Gets the posterior parameters from the given config file."""
-    params = []
-    for opt in cp.options(section):
-        val = cp.get(section, opt)
-        if val == '':
-            val = opt
-        params.append('{}:{}'.format(val, opt))
-    return params
-
-
 # command line parser
 parser = argparse.ArgumentParser(description=__doc__[1:])
 
@@ -204,16 +180,8 @@ finalize_workflow = core.Workflow(opts, opts.workflow_name + "-finalization")
 origdir = os.path.abspath(os.curdir)
 os.chdir(opts.output_dir)
 
-# figure out if we are making a skymap
-make_skymap = ("create_fits_file" in workflow.cp.options("executables") and
-               "inference_skymap" in workflow.cp.options("executables"))
-
 # figure out what diagnostic jobs there are
-diagnostics = []
-if "inference_samples" in workflow.cp.options("executables"):
-    diagnostics.append('samples')
-if "inference_rate" in workflow.cp.options("executables"):
-    diagnostics.append('acceptance_rate')
+diagnostics = inffu.get_diagnostic_plots(workflow)
 
 # sections for output HTML pages
 rdir = layout.SectionNumber("results",
@@ -243,29 +211,8 @@ logging.getLogger("").addHandler(log_file)
 logging.info("Created log file %s" % log_file_txt.storage_path)
 
 
-# get the parameters that will be used for posterior files and plots
-posterior_params = get_posterior_params(workflow.cp)
-
-# figure out what parameters user wants to plot from workflow configuration
-group_prefix = "plot-group-"
-# parameters for the summary plots
-summary_plot_params = get_plot_group(workflow.cp, 'summary_plots')
-# parameters to plot in large corner plots
-plot_params = get_plot_group(workflow.cp, 'plot_parameters')
-# get parameters for the summary tables
-table_params = workflow.cp.get_opt_tag('workflow', 'table-parameters',
-                                       'summary_table')
-# get any metadata that should be printed
-if workflow.cp.has_option('workflow-summary_table', 'print-metadata'):
-    table_metadata = workflow.cp.get_opt_tag('workflow', 'print-metadata',
-                                             'summary_table')
-else:
-    table_metadata = None
-
-psd_page = []
 config_files = {}
 for num_event, samples_filelist in enumerate(samples_files):
-    summary_page = []
     label = elabels[num_event]
     if label is None:
         label = 'Event {}'.format(num_event)
@@ -292,105 +239,33 @@ for num_event, samples_filelist in enumerate(samples_files):
         samples_filelist[ii] = pfile
     samples_filelist = core.FileList(samples_filelist)
 
-    analysis_index = segments.segment(num_event, num_event+1)
+    # create the posterior file and plots
+    posterior_file, summary_files, _, _ = inffu.make_poseterior_workflow(
+        workflow, samples_filelist, config_file, label, rdir,
+        posterior_file_dir=posterior_file_dir, tags=opts.tags)
 
-    # make node for running extract samples
-    posterior_file = inffu.create_posterior_files(
-        workflow, samples_filelist, posterior_file_dir,
-        parameters=posterior_params, analysis_seg=analysis_index,
-        tags=opts.tags+[label])[0]
-
-    # summary table
-    summary_page += (inffu.make_inference_summary_table(
-        workflow, posterior_file, rdir.base,
-        parameters=table_params, print_metadata=table_metadata,
-        analysis_seg=analysis_index,
-        tags=opts.tags+[label]),)
-
-    # summary posteriors
-    summary_plots = []
-    for group, params in summary_plot_params.items():
-        summary_plots += inffu.make_inference_posterior_plot(
-            workflow, posterior_file, rdir.base,
-            name='inference_posterior_summary',
-            parameters=params, plot_prior_from_file=config_file,
-            analysis_seg=analysis_index,
-            tags=opts.tags+[label, group])
-
-    # sky map
-    if make_skymap:
-        # create the fits file
-        fits_file = inffu.create_fits_file(
-            workflow, posterior_file, rdir.base,
-            analysis_seg=analysis_index,
-            tags=opts.tags+[label])[0]
-        # now plot the skymap
-        skymap_plot = inffu.make_inference_skymap(
-            workflow, fits_file, rdir.base,
-            analysis_seg=analysis_index,
-            tags=opts.tags+[label])
-        summary_plots += skymap_plot
-
-    summary_page += list(layout.grouper(summary_plots, 2))
+    # create the diagnostic plots
+    _ = inffu.make_diagnostic_plots(workflow, diagnostics, samples_filelist,
+                                    label, rdir)
 
     # files for detector_sensitivity summary subsection
     base = "detector_sensitivity"
     # we'll just use the first file, and assume the rest are the same
-    psd_page.append(plotting.make_spectrum_plot(
+    psd_plot = plotting.make_spectrum_plot(
         workflow, [samples_filelist[0]], rdir[base],
         tags=opts.tags+[label],
-        hdf_group="data"))
-
-    # files for priors summary section
-    base = "priors/{}".format(label)
-    prior_plots = inffu.make_inference_prior_plot(
-        workflow, config_file, rdir[base],
-        analysis_seg=workflow.analysis_time,
-        tags=opts.tags+[label])
-    layout.single_layout(rdir[base], prior_plots)
-
-    # files for posteriors summary subsection
-    base = "posteriors/{}".format(label)
-    posterior_plots = []
-    for group, params in plot_params.items():
-        posterior_plots += inffu.make_inference_posterior_plot(
-            workflow, posterior_file, rdir[base],
-            parameters=params, plot_prior_from_file=config_file,
-            analysis_seg=analysis_index,
-            tags=opts.tags+[label, group])
-    layout.single_layout(rdir[base], posterior_plots)
-
-    # files for diagnostics section
-    # Note: all diagnositics plots use the samples files, not the posteriors
-    if 'samples' in diagnostics:
-        # files for samples summary subsection
-        base = "samples/{}".format(label)
-        samples_plots = []
-        for kk, sf in enumerate(samples_filelist):
-            samples_plots += inffu.make_inference_samples_plot(
-                workflow, sf, rdir[base],
-                analysis_seg=analysis_index,
-                tags=opts.tags+[label, group, str(kk)])
-        layout.group_layout(rdir[base], samples_plots)
-
-    if 'acceptance_rate' in diagnostics:
-        # files for samples acceptance_rate subsection
-        base = "acceptance_rate/{}".format(label)
-        for kk, sf in enumerate(samples_filelist):
-            acceptance_plot = inffu.make_inference_acceptance_rate_plot(
-                workflow, sf, rdir[base],
-                analysis_seg=analysis_index,
-                tags=opts.tags+[label, str(kk)])
-        layout.single_layout(rdir[base], acceptance_plot)
+        hdf_group="data")
 
     # build the summary page
     zpad = int(numpy.ceil(numpy.log10(len(samples_files))))
-    layout.two_column_layout(rdir.base, summary_page,
+    layout.two_column_layout(rdir.base, summary_files,
                              unique=str(num_event).zfill(zpad),
                              title=summary_label, collapse=True)
 
-# build the psd page
-layout.group_layout(rdir['detector_sensitivity'], psd_page)
+    # build the psd page
+    layout.single_layout(rdir['detector_sensitivity'], [psd_plot],
+                         unique=str(num_event).zfill(zpad),
+                         title=summary_label, collapse=True)
 
 # build the config page
 

--- a/bin/workflows/pycbc_make_inference_plots_workflow
+++ b/bin/workflows/pycbc_make_inference_plots_workflow
@@ -85,6 +85,8 @@ def load_samples_cache(samples_cache):
             labels.append(lbl.strip())
             config_files.append(cfs)
             samples_files.append(smps)
+    if len(samples_files) == 0:
+        raise ValueError("no samples files found in given cache")
     # check that the labels are unique
     if not len(set(labels)) == len(labels):
         raise ValueError("all labels in config cache must be unique")
@@ -161,29 +163,7 @@ opts = parser.parse_args()
 
 # get posterior files and labels
 elabels, infconfig_files, samples_files = \
-    load_samples_cache(samples_cache)
-
-#labels = {}
-#posterior_files = []
-#for fn in opts.posterior_files:
-#    try:
-#        fn, label = fn.split(':')
-#    except ValueError:
-#        # assume no label provided
-#        label = os.path.basename(fn).replace('.hdf', '').replace('_', ' ')
-#    labels[fn] = fn
-#    posterior_files.append(fn)
-#
-## try to get config files
-#config_files = {}
-#for fn in opts.config_files:
-#    fn, cfg = fn.split(':')
-#    # make sure the file name exists
-#    if fn not in labels:
-#        raise ValueError("config file provided for unrecognized file: {}"
-#                         .format(fn))
-#    config_files[fn] = cfg
-
+    load_samples_cache(opts.samples_file_cache)
 
 posterior_file_dir = 'posterior_files'
 config_file_dir = 'config_files'
@@ -251,6 +231,10 @@ logging.getLogger("").addHandler(log_file)
 logging.info("Created log file %s" % log_file_txt.storage_path)
 
 
+# get the parameters that will be used for posterior files and plots
+posterior_params = workflow.cp.get_opt_tag('workflow', 'posterior-parameters',
+                                           'parameters')
+
 # figure out what parameters user wants to plot from workflow configuration
 group_prefix = "plot-group-"
 # parameters for the summary plots
@@ -263,11 +247,13 @@ table_params = workflow.cp.get_opt_tag('workflow', 'table-parameters',
 summary_page = []
 psd_page = []
 config_files = {}
-for num_event, config_fnames in enumerate(infconfig_files):
+for num_event, samples_filelist in enumerate(samples_files):
     label = elabels[num_event]
     if label is None:
         label = 'Event {}'.format(num_event)
     label = label.replace(' ', '_').replace(':', '_').replace('+', '_')
+
+    config_fnames = infconfig_files[num_event]
 
     # create a sub workflow for this event
     # we need to go back to the original directory to do this for all the file
@@ -279,11 +265,7 @@ for num_event, config_fnames in enumerate(infconfig_files):
     os.chdir(opts.output_dir)
 
     # write the configuration file to the config files directory
-    overrides = infconfig_overrides[num_event]
-    deletions = infconfig_deletions[num_event]
-    cp = configuration.WorkflowConfigParser(config_fnames,
-                                            overrideTuples=overrides,
-                                            deleteTuples=deletions)
+    cp = configuration.WorkflowConfigParser(config_fnames)
     config_file = sub_workflow.save_config(config_file_tmplt.format(label),
                                            config_file_dir, cp)[0]
     # create sym links to config file for results page
@@ -291,23 +273,18 @@ for num_event, config_fnames in enumerate(infconfig_files):
     layout.single_layout(rdir[base], [config_file])
     symlink_path(config_file, rdir[base])
 
-    # make node for running sampler
-    inference_exe = core.Executable(sub_workflow.cp, "inference",
-                                    ifos=sub_workflow.ifos, out_dir=filedir)
-    node = inference_exe.create_node()
-    node.add_input_opt("--config-file", config_file)
-    node.add_opt("--seed", opts.seed+num_event)
-    analysis_index = segments.segment(num_event, num_event+1)
-    inference_file = node.new_output_file_opt(analysis_index, ".hdf",
-                                              "--output-file",
-                                              tags=opts.tags+[label])
+    # convert the samples files to workflow File types
+    samples_filelist = core.FileList(map(core.File, samples_filelist))
 
-    # add node to workflow
-    sub_workflow += node
+    # make node for running extract samples
+    posterior_file = inffu.create_posterior_files(
+        sub_workflow, samples_filelist, output_dir,
+        parameters=posterior_params, analysis_seg=analysis_index,
+        tags=opts.tags+[label])
 
     # summary table
     summary_page += (inffu.make_inference_summary_table(
-        sub_workflow, inference_file, rdir.base,
+        sub_workflow, posterior_file, rdir.base,
         parameters=table_params,
         analysis_seg=analysis_index,
         result_label=label,
@@ -317,7 +294,7 @@ for num_event, config_fnames in enumerate(infconfig_files):
     summary_plots = []
     for group, params in summary_plot_params.items():
         summary_plots += inffu.make_inference_posterior_plot(
-            sub_workflow, inference_file, rdir.base,
+            sub_workflow, posterior_file, rdir.base,
             parameters=params, plot_prior_from_file=config_file,
             analysis_seg=analysis_index,
             tags=opts.tags+[label, group])
@@ -326,8 +303,9 @@ for num_event, config_fnames in enumerate(infconfig_files):
 
     # files for detector_sensitivity summary subsection
     base = "detector_sensitivity"
+    # we'll just use the first file, and assume the rest are the same
     psd_page.append(plotting.make_spectrum_plot(
-        sub_workflow, [inference_file], rdir[base],
+        sub_workflow, [samples_filelist[0]], rdir[base],
         tags=opts.tags+[label],
         hdf_group="data"))
 
@@ -347,32 +325,33 @@ for num_event, config_fnames in enumerate(infconfig_files):
     posterior_plots = []
     for group, params in plot_params.items():
         posterior_plots += inffu.make_inference_posterior_plot(
-            sub_workflow, inference_file, rdir[base],
+            sub_workflow, posterior_file, rdir[base],
             parameters=params, plot_prior_from_file=config_file,
             analysis_seg=analysis_index,
             tags=opts.tags+[label, group])
     layout.single_layout(rdir[base], posterior_plots)
 
     # files for diagnostics section
+    # Note: all diagnositics plots use the samples files, not the posteriors
     if 'samples' in diagnostics:
         # files for samples summary subsection
         base = "samples/{}".format(label)
         samples_plots = []
-        for group, parameters in plot_params.items():
+        for kk, sf in enumerate(samples_filelist):
             samples_plots += inffu.make_inference_samples_plot(
-                sub_workflow, inference_file, rdir[base],
-                parameters=parameters,
+                sub_workflow, sf, rdir[base],
                 analysis_seg=analysis_index,
-                tags=opts.tags+[label, group])
+                tags=opts.tags+[label, group, kk])
         layout.group_layout(rdir[base], samples_plots)
 
     if 'acceptance_rate' in diagnostics:
         # files for samples acceptance_rate subsection
         base = "acceptance_rate/{}".format(label)
-        acceptance_plot = inffu.make_inference_acceptance_rate_plot(
-            sub_workflow, inference_file, rdir[base],
-            analysis_seg=analysis_index,
-            tags=opts.tags+[label])
+        for kk, sf in enumerate(samples_filelist):
+            acceptance_plot = inffu.make_inference_acceptance_rate_plot(
+                sub_workflow, sf, rdir[base],
+                analysis_seg=analysis_index,
+                tags=opts.tags+[label, kk])
         layout.single_layout(rdir[base], acceptance_plot)
 
     # add the sub workflow to the main workflow

--- a/bin/workflows/pycbc_make_inference_plots_workflow
+++ b/bin/workflows/pycbc_make_inference_plots_workflow
@@ -304,7 +304,6 @@ for num_event, samples_filelist in enumerate(samples_files):
         workflow, posterior_file, rdir.base,
         parameters=table_params,
         analysis_seg=analysis_index,
-        #result_label=label,
         tags=opts.tags+[label]),)
 
     # summary posteriors

--- a/bin/workflows/pycbc_make_inference_plots_workflow
+++ b/bin/workflows/pycbc_make_inference_plots_workflow
@@ -81,8 +81,8 @@ def load_samples_cache(samples_cache):
                 continue
             line = line.replace('\n', '')
             lbl, cfs, smps = line.split(',')
-            cfs = map(os.path.abspath, cfs.strip().split())
-            smps = map(os.path.abspath, smps.strip().split())
+            cfs = list(map(os.path.abspath, cfs.strip().split()))
+            smps = list(map(os.path.abspath, smps.strip().split()))
             labels.append(lbl.strip())
             config_files.append(cfs)
             samples_files.append(smps)
@@ -210,6 +210,10 @@ finalize_workflow = core.Workflow(opts, opts.workflow_name + "-finalization")
 origdir = os.path.abspath(os.curdir)
 os.chdir(opts.output_dir)
 
+# figure out if we are making a skymap
+make_skymap = ("create_fits_file" in workflow.cp.options("executables") and
+               "inference_skymap" in workflow.cp.options("executables"))
+
 # figure out what diagnostic jobs there are
 diagnostics = []
 if "inference_samples" in workflow.cp.options("executables"):
@@ -257,13 +261,14 @@ plot_params = get_plot_group(workflow.cp, 'plot_parameters')
 # get parameters for the summary tables
 table_params = workflow.cp.get_opt_tag('workflow', 'table-parameters',
                                        'summary_table')
-summary_page = []
 psd_page = []
 config_files = {}
 for num_event, samples_filelist in enumerate(samples_files):
+    summary_page = []
     label = elabels[num_event]
     if label is None:
         label = 'Event {}'.format(num_event)
+    summary_label = label
     label = label.replace(' ', '_').replace(':', '_').replace('+', '_')
 
     config_fnames = infconfig_files[num_event]
@@ -299,7 +304,7 @@ for num_event, samples_filelist in enumerate(samples_files):
         workflow, posterior_file, rdir.base,
         parameters=table_params,
         analysis_seg=analysis_index,
-        result_label=label,
+        #result_label=label,
         tags=opts.tags+[label]),)
 
     # summary posteriors
@@ -310,8 +315,22 @@ for num_event, samples_filelist in enumerate(samples_files):
             parameters=params, plot_prior_from_file=config_file,
             analysis_seg=analysis_index,
             tags=opts.tags+[label, group])
+
+    # sky map
+    if make_skymap:
+        # create the fits file
+        fits_file = inffu.create_fits_file(
+            workflow, posterior_file, rdir.base,
+            analysis_seg=analysis_index,
+            tags=opts.tags+[label])[0]
+        # now plot the skymap
+        skymap_plot = inffu.make_inference_skymap(
+            workflow, fits_file, rdir.base,
+            analysis_seg=analysis_index,
+            tags=opts.tags+[label])
+        summary_plots += skymap_plot
+
     summary_page += list(layout.grouper(summary_plots, 2))
-    
 
     # files for detector_sensitivity summary subsection
     base = "detector_sensitivity"
@@ -363,8 +382,11 @@ for num_event, samples_filelist in enumerate(samples_files):
                 tags=opts.tags+[label, str(kk)])
         layout.single_layout(rdir[base], acceptance_plot)
 
-# build the summary page
-layout.two_column_layout(rdir.base, summary_page)
+    # build the summary page
+    zpad = int(numpy.ceil(numpy.log10(len(samples_files))))
+    layout.two_column_layout(rdir.base, summary_page,
+                             unique=str(num_event).zfill(zpad),
+                             title=summary_label, collapse=True)
 
 # build the psd page
 layout.group_layout(rdir['detector_sensitivity'], psd_page)

--- a/bin/workflows/pycbc_make_inference_plots_workflow
+++ b/bin/workflows/pycbc_make_inference_plots_workflow
@@ -252,7 +252,7 @@ for num_event, event in enumerate(events):
 
     # create the diagnostic plots
     _ = inffu.make_diagnostic_plots(workflow, diagnostics, samples_filelist,
-                                    event, rdir)
+                                    event, rdir, tags=opts.tags)
 
     # files for detector_sensitivity summary subsection
     base = "detector_sensitivity"

--- a/bin/workflows/pycbc_make_inference_plots_workflow
+++ b/bin/workflows/pycbc_make_inference_plots_workflow
@@ -162,12 +162,6 @@ parser.add_argument("--samples-file-cache", required=True,
                          "file used, and the samples "
                          "file(s) to create posteriors for."
                     )
-#parser.add_argument("--posterior-files", metavar="FILE[:LABEL]", nargs="+",
-#                    required=True,
-#                    help="Posterior files to create plots for.")
-#parser.add_argument("--config-files", metavar="FILE:CONFIG", nargs="+",
-#                    help="Specify the config files used for each file. Needed "
-#                         "for plotting priors.")
 # add option groups
 configuration.add_workflow_command_line_group(parser)
 

--- a/bin/workflows/pycbc_make_inference_plots_workflow
+++ b/bin/workflows/pycbc_make_inference_plots_workflow
@@ -100,7 +100,7 @@ def read_events_from_config(cp):
         sf = shlex.split(cp.get(section, 'samples-files'))
         labels.append(label)
         config_files.append(list(map(os.path.abspath, cf)))
-        samples_files.append(list(map(os.path.abspath, cf)))
+        samples_files.append(list(map(os.path.abspath, sf)))
     return labels, config_files, samples_files
 
 
@@ -215,7 +215,6 @@ log_file.setFormatter(formatter)
 logging.getLogger("").addHandler(log_file)
 logging.info("Created log file %s" % log_file_txt.storage_path)
 
-
 config_files = {}
 for num_event, samples_filelist in enumerate(samples_files):
     label = elabels[num_event]
@@ -269,8 +268,6 @@ for num_event, samples_filelist in enumerate(samples_files):
     layout.single_layout(rdir['detector_sensitivity'], [psd_plot],
                          unique=str(num_event).zfill(zpad),
                          title=summary_label, collapse=True)
-
-# build the config page
 
 # create versioning HTML pages
 results.create_versioning_page(rdir["workflow/version"], container.cp)

--- a/bin/workflows/pycbc_make_inference_plots_workflow
+++ b/bin/workflows/pycbc_make_inference_plots_workflow
@@ -1,0 +1,428 @@
+#!/usr/bin/env python
+
+# Copyright (C) 2016 Christopher M. Biwer, Alexander Harvey Nitz
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+""" Creates a DAX for a parameter estimation workflow.
+"""
+
+import argparse
+import h5py
+import logging
+import os
+import Pegasus.DAX3 as dax
+import pycbc
+import pycbc.workflow.minifollowups as mini
+import pycbc.workflow.pegasus_workflow as wdax
+import socket
+import sys
+import numpy
+from ligo import segments
+from pycbc import results
+from pycbc.results import layout
+from pycbc.types import MultiDetOptionAction
+from pycbc.types import MultiDetOptionAppendAction
+from pycbc.workflow import configuration
+from pycbc.workflow import core
+from pycbc.workflow import datafind
+from pycbc.workflow import plotting
+from pycbc import __version__
+import pycbc.workflow.inference_followups as inffu
+
+
+def load_samples_cache(samples_cache):
+    """Loads samples files from the given config file.
+    
+    Each line in the cache file should be a comma-separated list of label,
+    config file(s), samples file(s). The config file(s) are needed in order to
+    plot the prior. Multiple config and samples files should be space
+    separated. For example::
+
+        Event 1,config.ini,samples1.hdf samples2.hdf
+
+    Labels must be unique across all events. Otherwise, a ``ValueError`` is
+    raised.
+
+    Parameters
+    ----------
+    config_cache : str
+        The name of the cache file.
+
+    Returns
+    -------
+    labels : list
+        List of strings giving a label for each event.
+    config_files : list
+        List of the config files. Each element is itself a list providing
+        all of the config files to combine.
+    samples_files : list
+        List of the samples files. Each element is itself a list providing
+        all of the samples files to combine.
+    """
+    labels = []
+    config_files = []
+    samples_files = []
+    with open(samples_cache, 'r') as fp:
+        for line in fp:
+            if line.startswith('#'):
+                continue
+            line = line.replace('\n', '')
+            lbl, cfs, smps = line.split(',')
+            cfs = map(os.path.abspath, cfs.strip().split())
+            smps = map(os.path.abspath, smps.strip().split())
+            labels.append(lbl.strip())
+            config_files.append(cfs)
+            samples_files.append(smps)
+    # check that the labels are unique
+    if not len(set(labels)) == len(labels):
+        raise ValueError("all labels in config cache must be unique")
+    return labels, config_files, samples_files
+
+def symlink_path(f, path):
+    """ Symlinks a path.
+    """
+    if f is None:
+        return
+    try:
+        os.symlink(f.storage_path, os.path.join(path, f.name))
+    except OSError:
+        pass
+
+def get_plot_group(cp, section_tag):
+    """Gets plotting groups from [workflow-section_tag]."""
+    group_prefix = "plot-group-"
+    # parameters for the summary plots
+    plot_groups = {}
+    opts = [opt for opt in cp.options("workflow-{}".format(section_tag))
+            if opt.startswith(group_prefix)]
+    for opt in opts:
+        group = opt.replace(group_prefix, "").replace("-", "_")
+        plot_groups[group] = cp.get_opt_tag("workflow", opt, section_tag)
+    return plot_groups
+
+# command line parser
+parser = argparse.ArgumentParser(description=__doc__[1:])
+
+# version option
+parser.add_argument("--version", action="version", version=__version__,
+                    help="Prints version information.")
+
+# workflow options
+parser.add_argument("--workflow-name", required=True,
+                    help="Name of the workflow to append in various places.")
+parser.add_argument("--tags", nargs="+", default=[],
+                    help="Tags to apend in various places.")
+parser.add_argument("--output-dir", default=None,
+                    help="Path to directory where the workflow will be "
+                         "written. Default is to use "
+                         "{workflow-name}_output.")
+parser.add_argument("--output-map", default="output.map",
+                    help="Path to an output map file. Default is "
+                         "output.map.")
+parser.add_argument("--transformation-catalog", default=None,
+                    help="Path to transformation catalog file.")
+parser.add_argument("--dax-file", default=None,
+                    help="Path to DAX file. Default is to write to the "
+                         "output directory with name {workflow-name}.dax.")
+# inference options
+parser.add_argument("--seed", type=int, default=0,
+                    help="Seed to use for inference job(s). If multiple "
+                         "events are analyzed, the seed will be incremented "
+                         "by one for each event.")
+# input configuration file options
+parser.add_argument("--samples-file-cache", required=True,
+                    help="Text file listing a label, the samples "
+                         "file(s) to create posteriors for, and any "
+                         "additional arguments for extracting samples."
+                    )
+#parser.add_argument("--posterior-files", metavar="FILE[:LABEL]", nargs="+",
+#                    required=True,
+#                    help="Posterior files to create plots for.")
+#parser.add_argument("--config-files", metavar="FILE:CONFIG", nargs="+",
+#                    help="Specify the config files used for each file. Needed "
+#                         "for plotting priors.")
+# add option groups
+configuration.add_workflow_command_line_group(parser)
+
+# parser command line
+opts = parser.parse_args()
+
+# get posterior files and labels
+elabels, infconfig_files, samples_files = \
+    load_samples_cache(samples_cache)
+
+#labels = {}
+#posterior_files = []
+#for fn in opts.posterior_files:
+#    try:
+#        fn, label = fn.split(':')
+#    except ValueError:
+#        # assume no label provided
+#        label = os.path.basename(fn).replace('.hdf', '').replace('_', ' ')
+#    labels[fn] = fn
+#    posterior_files.append(fn)
+#
+## try to get config files
+#config_files = {}
+#for fn in opts.config_files:
+#    fn, cfg = fn.split(':')
+#    # make sure the file name exists
+#    if fn not in labels:
+#        raise ValueError("config file provided for unrecognized file: {}"
+#                         .format(fn))
+#    config_files[fn] = cfg
+
+
+posterior_file_dir = 'posterior_files'
+config_file_dir = 'config_files'
+
+# make data output directory
+if opts.output_dir is None:
+    opts.output_dir = opts.workflow_name + '_output'
+core.makedir(opts.output_dir)
+core.makedir('{}/{}'.format(opts.output_dir, config_file_dir))
+core.makedir('{}/{}'.format(opts.output_dir, posterior_file_dir))
+
+# set the dax file name
+dax_file = opts.dax_file
+if dax_file is None:
+    dax_file = "{}.dax".format(opts.workflow_name)
+
+# the file we'll store all output files in
+filedir = 'output'
+
+# log to terminal until we know where the path to log output file
+log_format = "%(asctime)s:%(levelname)s : %(message)s"
+logging.basicConfig(format=log_format, level=logging.INFO)
+
+# create workflow and sub-workflows
+container = core.Workflow(opts, opts.workflow_name)
+workflow = core.Workflow(opts, opts.workflow_name + "-main")
+finalize_workflow = core.Workflow(opts, opts.workflow_name + "-finalization")
+
+# change working directory to the output
+origdir = os.path.abspath(os.curdir)
+os.chdir(opts.output_dir)
+
+# figure out what diagnostic jobs there are
+diagnostics = []
+if "inference_samples" in workflow.cp.options("executables"):
+    diagnostics.append('samples')
+if "inference_rate" in workflow.cp.options("executables"):
+    diagnostics.append('acceptance_rate')
+
+# sections for output HTML pages
+rdir = layout.SectionNumber("results",
+                            ["detector_sensitivity", "priors", "posteriors"] +
+                            diagnostics +
+                            ["config_files", "workflow"])
+
+# make results directories
+core.makedir(rdir.base)
+core.makedir(rdir["workflow"])
+core.makedir(rdir["config_files"])
+
+# create files for workflow log
+log_file_txt = core.File(workflow.ifos, "workflow-log", workflow.analysis_time,
+                      extension=".txt", directory=rdir["workflow"])
+log_file_html = core.File(workflow.ifos, "WORKFLOW-LOG", workflow.analysis_time,
+                        extension=".html", directory=rdir["workflow"])
+
+# switch saving log to file
+logging.basicConfig(format=log_format, level=logging.INFO,
+                    filename=log_file_txt.storage_path, filemode="w")
+log_file = logging.FileHandler(filename=log_file_txt.storage_path, mode="w")
+log_file.setLevel(logging.INFO)
+formatter = logging.Formatter(log_format)
+log_file.setFormatter(formatter)
+logging.getLogger("").addHandler(log_file)
+logging.info("Created log file %s" % log_file_txt.storage_path)
+
+
+# figure out what parameters user wants to plot from workflow configuration
+group_prefix = "plot-group-"
+# parameters for the summary plots
+summary_plot_params = get_plot_group(workflow.cp, 'summary_plots')
+# parameters to plot in large corner plots
+plot_params = get_plot_group(workflow.cp, 'plot_parameters')
+# get parameters for the summary tables
+table_params = workflow.cp.get_opt_tag('workflow', 'table-parameters',
+                                       'summary_table')
+summary_page = []
+psd_page = []
+config_files = {}
+for num_event, config_fnames in enumerate(infconfig_files):
+    label = elabels[num_event]
+    if label is None:
+        label = 'Event {}'.format(num_event)
+    label = label.replace(' ', '_').replace(':', '_').replace('+', '_')
+
+    # create a sub workflow for this event
+    # we need to go back to the original directory to do this for all the file
+    # references to work correctly
+    os.chdir(origdir)
+    sub_workflow = core.Workflow(opts,
+                                 "{}-{}".format(opts.workflow_name, label))
+    # now go back to the output
+    os.chdir(opts.output_dir)
+
+    # write the configuration file to the config files directory
+    overrides = infconfig_overrides[num_event]
+    deletions = infconfig_deletions[num_event]
+    cp = configuration.WorkflowConfigParser(config_fnames,
+                                            overrideTuples=overrides,
+                                            deleteTuples=deletions)
+    config_file = sub_workflow.save_config(config_file_tmplt.format(label),
+                                           config_file_dir, cp)[0]
+    # create sym links to config file for results page
+    base = "config_files/{}".format(label)
+    layout.single_layout(rdir[base], [config_file])
+    symlink_path(config_file, rdir[base])
+
+    # make node for running sampler
+    inference_exe = core.Executable(sub_workflow.cp, "inference",
+                                    ifos=sub_workflow.ifos, out_dir=filedir)
+    node = inference_exe.create_node()
+    node.add_input_opt("--config-file", config_file)
+    node.add_opt("--seed", opts.seed+num_event)
+    analysis_index = segments.segment(num_event, num_event+1)
+    inference_file = node.new_output_file_opt(analysis_index, ".hdf",
+                                              "--output-file",
+                                              tags=opts.tags+[label])
+
+    # add node to workflow
+    sub_workflow += node
+
+    # summary table
+    summary_page += (inffu.make_inference_summary_table(
+        sub_workflow, inference_file, rdir.base,
+        parameters=table_params,
+        analysis_seg=analysis_index,
+        result_label=label,
+        tags=opts.tags+[label]),)
+
+    # summary posteriors
+    summary_plots = []
+    for group, params in summary_plot_params.items():
+        summary_plots += inffu.make_inference_posterior_plot(
+            sub_workflow, inference_file, rdir.base,
+            parameters=params, plot_prior_from_file=config_file,
+            analysis_seg=analysis_index,
+            tags=opts.tags+[label, group])
+    summary_page += list(layout.grouper(summary_plots, 2))
+    
+
+    # files for detector_sensitivity summary subsection
+    base = "detector_sensitivity"
+    psd_page.append(plotting.make_spectrum_plot(
+        sub_workflow, [inference_file], rdir[base],
+        tags=opts.tags+[label],
+        hdf_group="data"))
+
+    # files for priors summary section
+    base = "priors/{}".format(label)
+    prior_plots = []
+    for group, params in plot_params.items():
+        prior_plots += inffu.make_inference_prior_plot(
+            sub_workflow, config_file, rdir[base],
+            analysis_seg=sub_workflow.analysis_time,
+            parameters=params,
+            tags=opts.tags+[label, group])
+    layout.single_layout(rdir[base], prior_plots)
+
+    # files for posteriors summary subsection
+    base = "posteriors/{}".format(label)
+    posterior_plots = []
+    for group, params in plot_params.items():
+        posterior_plots += inffu.make_inference_posterior_plot(
+            sub_workflow, inference_file, rdir[base],
+            parameters=params, plot_prior_from_file=config_file,
+            analysis_seg=analysis_index,
+            tags=opts.tags+[label, group])
+    layout.single_layout(rdir[base], posterior_plots)
+
+    # files for diagnostics section
+    if 'samples' in diagnostics:
+        # files for samples summary subsection
+        base = "samples/{}".format(label)
+        samples_plots = []
+        for group, parameters in plot_params.items():
+            samples_plots += inffu.make_inference_samples_plot(
+                sub_workflow, inference_file, rdir[base],
+                parameters=parameters,
+                analysis_seg=analysis_index,
+                tags=opts.tags+[label, group])
+        layout.group_layout(rdir[base], samples_plots)
+
+    if 'acceptance_rate' in diagnostics:
+        # files for samples acceptance_rate subsection
+        base = "acceptance_rate/{}".format(label)
+        acceptance_plot = inffu.make_inference_acceptance_rate_plot(
+            sub_workflow, inference_file, rdir[base],
+            analysis_seg=analysis_index,
+            tags=opts.tags+[label])
+        layout.single_layout(rdir[base], acceptance_plot)
+
+    # add the sub workflow to the main workflow
+    workflow += sub_workflow
+
+# build the summary page
+layout.two_column_layout(rdir.base, summary_page)
+
+# build the psd page
+layout.group_layout(rdir['detector_sensitivity'], psd_page)
+
+# build the config page
+
+# create versioning HTML pages
+results.create_versioning_page(rdir["workflow/version"], container.cp)
+
+# create node for making HTML pages
+plotting.make_results_web_page(finalize_workflow,
+    os.path.join(os.getcwd(), rdir.base))
+
+# add sub-workflows to workflow
+container += workflow
+container += finalize_workflow
+
+# make finalize sub-workflow depend on main sub-workflow
+dep = dax.Dependency(parent=workflow.as_job, child=finalize_workflow.as_job)
+container._adag.addDependency(dep)
+
+# write dax
+container.save(filename=dax_file, output_map_path=opts.output_map,
+               transformation_catalog_path=opts.transformation_catalog)
+
+# save workflow configuration file
+base = rdir["workflow/configuration"]
+core.makedir(base)
+wf_ini = workflow.save_config("workflow.ini", base, container.cp)
+layout.single_layout(base, wf_ini)
+
+# close the log and flush to the html file
+logging.shutdown()
+with open (log_file_txt.storage_path, "r") as log_file:
+    log_data = log_file.read()
+log_str = """
+<p>Workflow generation script created workflow in output directory: %s</p>
+<p>Workflow name is: %s</p>
+<p>Workflow generation script run on host: %s</p>
+<pre>%s</pre>
+""" % (os.getcwd(), opts.workflow_name, socket.gethostname(), log_data)
+kwds = {"title" : "Workflow Generation Log",
+        "caption" : "Log of the workflow script %s" % sys.argv[0],
+        "cmd" : " ".join(sys.argv)}
+results.save_fig_with_metadata(log_str, log_file_html.storage_path, **kwds)
+layout.single_layout(rdir["workflow"], ([log_file_html]))

--- a/bin/workflows/pycbc_make_inference_plots_workflow
+++ b/bin/workflows/pycbc_make_inference_plots_workflow
@@ -106,7 +106,7 @@ def read_events_from_config(cp):
 
 def label_slug(label):
     """Slugifies an event label."""
-    label.replace(' ', '_').replace(':', '_').replace('+', '_')
+    return label.replace(' ', '_').replace(':', '_').replace('+', '_')
 
 
 def symlink_path(f, path):
@@ -144,17 +144,6 @@ parser.add_argument("--transformation-catalog", default=None,
 parser.add_argument("--dax-file", default=None,
                     help="Path to DAX file. Default is to write to the "
                          "output directory with name {workflow-name}.dax.")
-# inference options
-parser.add_argument("--seed", type=int, default=0,
-                    help="Seed to use for inference job(s). If multiple "
-                         "events are analyzed, the seed will be incremented "
-                         "by one for each event.")
-# input configuration file options
-parser.add_argument("--samples-file-cache", required=True,
-                    help="Text file listing a label, the inference config "
-                         "file used, and the samples "
-                         "file(s) to create posteriors for."
-                    )
 # add option groups
 configuration.add_workflow_command_line_group(parser)
 
@@ -254,7 +243,7 @@ for num_event, samples_filelist in enumerate(samples_files):
     samples_filelist = core.FileList(samples_filelist)
 
     # create the posterior file and plots
-    posterior_file, summary_files, _, _ = inffu.make_poseterior_workflow(
+    posterior_file, summary_files, _, _ = inffu.make_posterior_workflow(
         workflow, samples_filelist, config_file, label, rdir,
         posterior_file_dir=posterior_file_dir, tags=opts.tags)
 

--- a/bin/workflows/pycbc_make_inference_plots_workflow
+++ b/bin/workflows/pycbc_make_inference_plots_workflow
@@ -78,6 +78,8 @@ def read_events_from_config(cp):
 
     Returns
     -------
+    events : list of str
+        The names of the event(s) that were given in the config file.
     labels : list of str
         The labels to use for the event(s) that were given in the config file.
     config-files : list of lists
@@ -101,10 +103,10 @@ def read_events_from_config(cp):
         labels.append(label)
         config_files.append(list(map(os.path.abspath, cf)))
         samples_files.append(list(map(os.path.abspath, sf)))
-    return labels, config_files, samples_files
+    return events, labels, config_files, samples_files
 
 
-def label_slug(label):
+def event_slug(label):
     """Slugifies an event label."""
     return label.replace(' ', '_').replace(':', '_').replace('+', '_')
 
@@ -179,7 +181,8 @@ workflow = core.Workflow(opts, opts.workflow_name + "-main")
 finalize_workflow = core.Workflow(opts, opts.workflow_name + "-finalization")
 
 # get the events
-elabels, infconfig_files, samples_files = read_events_from_config(workflow.cp)
+events, labels, infconfig_files, samples_files = \
+    read_events_from_config(workflow.cp)
 
 # change working directory to the output
 origdir = os.path.abspath(os.curdir)
@@ -216,19 +219,20 @@ logging.getLogger("").addHandler(log_file)
 logging.info("Created log file %s" % log_file_txt.storage_path)
 
 config_files = {}
-for num_event, samples_filelist in enumerate(samples_files):
-    label = elabels[num_event]
-    summary_label = label
-    label = label_slug(label)
+for num_event, event in enumerate(events):
+    # slugify the event name so it can be used in file names
+    event = event_slug(event)
+    label = labels[num_event]
+    samples_filelist = samples_files[num_event]
 
     config_fnames = infconfig_files[num_event]
 
     # write the configuration file to the config files directory
     cp = configuration.WorkflowConfigParser(config_fnames)
-    config_file = workflow.save_config(config_file_tmplt.format(label),
+    config_file = workflow.save_config(config_file_tmplt.format(event),
                                            config_file_dir, cp)[0]
     # create sym links to config file for results page
-    base = "config_files/{}".format(label)
+    base = "config_files/{}".format(event)
     layout.single_layout(rdir[base], [config_file])
     symlink_path(config_file, rdir[base])
 
@@ -243,31 +247,31 @@ for num_event, samples_filelist in enumerate(samples_files):
 
     # create the posterior file and plots
     posterior_file, summary_files, _, _ = inffu.make_posterior_workflow(
-        workflow, samples_filelist, config_file, label, rdir,
+        workflow, samples_filelist, config_file, event, rdir,
         posterior_file_dir=posterior_file_dir, tags=opts.tags)
 
     # create the diagnostic plots
     _ = inffu.make_diagnostic_plots(workflow, diagnostics, samples_filelist,
-                                    label, rdir)
+                                    event, rdir)
 
     # files for detector_sensitivity summary subsection
     base = "detector_sensitivity"
     # we'll just use the first file, and assume the rest are the same
     psd_plot = plotting.make_spectrum_plot(
         workflow, [samples_filelist[0]], rdir[base],
-        tags=opts.tags+[label],
+        tags=opts.tags+[event],
         hdf_group="data")
 
     # build the summary page
     zpad = int(numpy.ceil(numpy.log10(len(samples_files))))
     layout.two_column_layout(rdir.base, summary_files,
                              unique=str(num_event).zfill(zpad),
-                             title=summary_label, collapse=True)
+                             title=label, collapse=True)
 
     # build the psd page
     layout.single_layout(rdir['detector_sensitivity'], [psd_plot],
                          unique=str(num_event).zfill(zpad),
-                         title=summary_label, collapse=True)
+                         title=label, collapse=True)
 
 # create versioning HTML pages
 results.create_versioning_page(rdir["workflow/version"], container.cp)

--- a/bin/workflows/pycbc_make_inference_plots_workflow
+++ b/bin/workflows/pycbc_make_inference_plots_workflow
@@ -123,7 +123,7 @@ def get_posterior_params(cp, section='workflow-posterior_parameters'):
         val = cp.get(section, opt)
         if val == '':
             val = opt
-        params.append('{}:{}'.format(opt, val))
+        params.append('{}:{}'.format(val, opt))
     return params
 
 
@@ -268,18 +268,9 @@ for num_event, samples_filelist in enumerate(samples_files):
 
     config_fnames = infconfig_files[num_event]
 
-    # create a sub workflow for this event
-    # we need to go back to the original directory to do this for all the file
-    # references to work correctly
-    os.chdir(origdir)
-    sub_workflow = core.Workflow(opts,
-                                 "{}-{}".format(opts.workflow_name, label))
-    # now go back to the output
-    os.chdir(opts.output_dir)
-
     # write the configuration file to the config files directory
     cp = configuration.WorkflowConfigParser(config_fnames)
-    config_file = sub_workflow.save_config(config_file_tmplt.format(label),
+    config_file = workflow.save_config(config_file_tmplt.format(label),
                                            config_file_dir, cp)[0]
     # create sym links to config file for results page
     base = "config_files/{}".format(label)
@@ -287,20 +278,25 @@ for num_event, samples_filelist in enumerate(samples_files):
     symlink_path(config_file, rdir[base])
 
     # convert the samples files to workflow File types
-    samples_filelist = core.FileList(map(pegasus_workflow.File,
-                                         samples_filelist))
+    for ii, fname in enumerate(samples_filelist):
+        pfile = pegasus_workflow.File(fname)
+        pfile.PFN(fname, "local")
+        # set the storage path to be the same
+        pfile.storage_path = fname
+        samples_filelist[ii] = pfile
+    samples_filelist = core.FileList(samples_filelist)
 
     analysis_index = segments.segment(num_event, num_event+1)
 
     # make node for running extract samples
     posterior_file = inffu.create_posterior_files(
-        sub_workflow, samples_filelist, posterior_file_dir,
+        workflow, samples_filelist, posterior_file_dir,
         parameters=posterior_params, analysis_seg=analysis_index,
         tags=opts.tags+[label])[0]
 
     # summary table
     summary_page += (inffu.make_inference_summary_table(
-        sub_workflow, posterior_file, rdir.base,
+        workflow, posterior_file, rdir.base,
         parameters=table_params,
         analysis_seg=analysis_index,
         result_label=label,
@@ -310,7 +306,7 @@ for num_event, samples_filelist in enumerate(samples_files):
     summary_plots = []
     for group, params in summary_plot_params.items():
         summary_plots += inffu.make_inference_posterior_plot(
-            sub_workflow, posterior_file, rdir.base,
+            workflow, posterior_file, rdir.base,
             parameters=params, plot_prior_from_file=config_file,
             analysis_seg=analysis_index,
             tags=opts.tags+[label, group])
@@ -321,7 +317,7 @@ for num_event, samples_filelist in enumerate(samples_files):
     base = "detector_sensitivity"
     # we'll just use the first file, and assume the rest are the same
     psd_page.append(plotting.make_spectrum_plot(
-        sub_workflow, [samples_filelist[0]], rdir[base],
+        workflow, [samples_filelist[0]], rdir[base],
         tags=opts.tags+[label],
         hdf_group="data"))
 
@@ -330,8 +326,8 @@ for num_event, samples_filelist in enumerate(samples_files):
     prior_plots = []
     for group, params in plot_params.items():
         prior_plots += inffu.make_inference_prior_plot(
-            sub_workflow, config_file, rdir[base],
-            analysis_seg=sub_workflow.analysis_time,
+            workflow, config_file, rdir[base],
+            analysis_seg=workflow.analysis_time,
             parameters=params,
             tags=opts.tags+[label, group])
     layout.single_layout(rdir[base], prior_plots)
@@ -341,7 +337,7 @@ for num_event, samples_filelist in enumerate(samples_files):
     posterior_plots = []
     for group, params in plot_params.items():
         posterior_plots += inffu.make_inference_posterior_plot(
-            sub_workflow, posterior_file, rdir[base],
+            workflow, posterior_file, rdir[base],
             parameters=params, plot_prior_from_file=config_file,
             analysis_seg=analysis_index,
             tags=opts.tags+[label, group])
@@ -355,7 +351,7 @@ for num_event, samples_filelist in enumerate(samples_files):
         samples_plots = []
         for kk, sf in enumerate(samples_filelist):
             samples_plots += inffu.make_inference_samples_plot(
-                sub_workflow, sf, rdir[base],
+                workflow, sf, rdir[base],
                 analysis_seg=analysis_index,
                 tags=opts.tags+[label, group, str(kk)])
         layout.group_layout(rdir[base], samples_plots)
@@ -365,13 +361,10 @@ for num_event, samples_filelist in enumerate(samples_files):
         base = "acceptance_rate/{}".format(label)
         for kk, sf in enumerate(samples_filelist):
             acceptance_plot = inffu.make_inference_acceptance_rate_plot(
-                sub_workflow, sf, rdir[base],
+                workflow, sf, rdir[base],
                 analysis_seg=analysis_index,
                 tags=opts.tags+[label, str(kk)])
         layout.single_layout(rdir[base], acceptance_plot)
-
-    # add the sub workflow to the main workflow
-    workflow += sub_workflow
 
 # build the summary page
 layout.two_column_layout(rdir.base, summary_page)

--- a/bin/workflows/pycbc_make_inference_workflow
+++ b/bin/workflows/pycbc_make_inference_workflow
@@ -291,12 +291,8 @@ for num_event, config_fnames in enumerate(infconfig_files):
     cp = configuration.WorkflowConfigParser(config_fnames,
                                             overrideTuples=overrides,
                                             deleteTuples=deletions)
-    config_file = os.path.join(config_file_dir,
-                               config_file_tmplt.format(num_event))
-    with open(config_file, 'w') as cf:
-        cp.write(cf)
-    # convert to a dax File type
-    config_file = to_file(config_file)
+    config_file = workflow.save_config(config_file_tmplt.format(num_event),
+                                       config_file_dir, cp)[0]
     # create sym links to config file for results page
     base = "config_files/{}".format(label)
     layout.single_layout(rdir[base], [config_file])

--- a/bin/workflows/pycbc_make_inference_workflow
+++ b/bin/workflows/pycbc_make_inference_workflow
@@ -23,10 +23,12 @@ import h5py
 import logging
 import os
 import Pegasus.DAX3 as dax
+import pycbc
 import pycbc.workflow.minifollowups as mini
 import pycbc.workflow.pegasus_workflow as wdax
 import socket
 import sys
+import numpy
 from ligo import segments
 from pycbc import results
 from pycbc.results import layout
@@ -42,6 +44,16 @@ from pycbc import __version__
 # FIXME see https://github.com/gwastro/pycbc/issues/2349
 import pycbc.workflow.inference_followups as inffu
 
+def load_times_from_trigger_file(filename):
+    """Loads triggers from the given file.
+
+    Parameters
+    ----------
+    filename : str
+        The name of the file to load. Should be a simple text file with one
+        column listing gps times to analyze.
+    """
+    return numpy.loadtxt(filename, dtype=float)
 
 def to_file(path, ifo=None):
     """ Takes a str and returns a pycbc.workflow.pegasus_workflow.File
@@ -85,33 +97,12 @@ parser.add_argument("--output-file", default=None,
                     help="Path to DAX file.")
 
 # input workflow file options
-parser.add_argument("--bank-file", default=None,
-                    help="HDF format template bank file.")
-parser.add_argument("--statmap-file", default=None,
-                    help="HDF format clustered coincident trigger "
-                         "result file.")
-parser.add_argument("--single-detector-triggers", nargs="+", default=None,
-                    action=MultiDetOptionAction,
-                    help="HDF format merged single detector trigger files.")
-
-# analysis time option
-# only required if not using input workflow file options
-parser.add_argument("--gps-end-time", type=float, nargs="+", default=None,
-                    help="Times to analyze. If given workflow files then "
-                         "this option is ignored.")
+parser.add_argument("--trigger-file", default=None,
+                    help="Text file containing triggers to analyze.")
 
 # input configuration file options
 parser.add_argument("--inference-config-file", type=str, nargs='+', required=True,
-                    help="workflow.WorkflowConfigParser parsable file with "
-                         "prior information.")
-parser.add_argument("--prior-section", type=str, default="prior",
-                    help="Name of the section in inference configuration file "
-                         "that contains priors.")
-
-# input frame files
-parser.add_argument("--frame-files", nargs="+", default=None,
-                    action=MultiDetOptionAppendAction,
-                    help="GWF frame files to use.")
+                    help="Configuration file(s) for the inference job.")
 
 # add option groups
 configuration.add_workflow_command_line_group(parser)
@@ -162,49 +153,11 @@ log_file.setFormatter(formatter)
 logging.getLogger("").addHandler(log_file)
 logging.info("Created log file %s" % log_file_txt.storage_path)
 
-# sanity check that user is either using workflow or command line
-workflow_options = opts.bank_file != None \
-                   and opts.statmap_file != None \
-                   and opts.single_detector_triggers != None
-if not workflow_options and not (opts.gps_end_time != None):
-    raise ValueError("Must use either workflow options or --gps-end-time")
-
-# if using workflow files to find analysis times
-if workflow_options:
-
-    # typecast str from command line to File instances
-    tmpltbank_file = to_file(opts.bank_file)
-    coinc_file = to_file(opts.statmap_file)
-    single_triggers = []
-    for ifo in opts.single_detector_triggers:
-        fname = opts.single_detector_triggers[ifo]
-        single_triggers.append(to_file(fname, ifo=ifo))
-
-    # get number of events to analyze
-    num_events = int(workflow.cp.get_opt_tags("workflow-inference",
-                                              "num-events", ""))
-
-    # get detection statistic from statmap file
-    # if less events that requested to analyze in config file
-    # then analyze all events
-    f = h5py.File(opts.statmap_file, "r")
-    stat = f["foreground/stat"][:]
-    if len(stat) < num_events:
-        num_events = len(stat)
-
-    # get index for sorted detection statistic
-    sorting = stat.argsort()[::-1]
-
-    # get times for loudest events
-    times = {
-        f.attrs["detector_1"]: f["foreground/time1"][:][sorting][0:num_events],
-        f.attrs["detector_2"]: f["foreground/time2"][:][sorting][0:num_events],
-    }
-
-# else get analysis times from command line
+# if using a trigger file
+if opts.trigger_file is not None:
+    times = load_times_from_trigger_file(opts.trigger_file)
 else:
-    times = dict([(ifo,opts.gps_end_time) for ifo in workflow.ifos])
-    num_events = len(opts.gps_end_time)
+    times = [None]
 
 # construct Executable for running sampler
 inference_exe = core.Executable(workflow.cp, "inference",
@@ -217,14 +170,6 @@ with open('inference.ini', 'w') as ff:
     cp.write(ff)
 config_file = to_file('inference.ini')
 
-# get channel names
-channel_names = {}
-for ifo in workflow.ifos:
-    channel_names[ifo] = workflow.cp.get_opt_tags(
-                               "workflow", "%s-channel-name" % ifo.lower(), "")
-channel_names_str = " ".join([key + ":" + val for key, val in \
-                              channel_names.items()])
-
 # figure out what parameters user wants to plot from workflow configuration
 plot_parameters = {}
 for option in workflow.cp.options("workflow-inference"):
@@ -236,76 +181,38 @@ all_parameters = [param for group in plot_parameters.values()
                   for param in group]
 
 # loop over number of loudest events to be analyzed
-for num_event in range(num_events):
-
-    # set GPS times for reading in data around the event
-    avg_end_time = sum([end_times[num_event] \
-                          for end_times in times.values()]) / len(times.keys())
-    seconds_before_time = int(workflow.cp.get_opt_tags(
-                                            "workflow-inference",
-                                            "data-seconds-before-trigger", ""))
-    seconds_after_time = int(workflow.cp.get_opt_tags(
-                                            "workflow-inference",
-                                            "data-seconds-after-trigger", ""))
-    gps_start_time = int(avg_end_time) - seconds_before_time
-    gps_end_time = int(avg_end_time) + seconds_after_time
-
-    # get dict of segments for each IFO
-    seg_dict = {ifo : segments.segmentlist([segments.segment(
-                      gps_start_time, gps_end_time)]) for ifo in workflow.ifos}
-
-    # get frame files from command line or datafind server
-    frame_files = core.FileList([])
-    if opts.frame_files:
-        for ifo in workflow.ifos:
-            for path in opts.frame_files[ifo]:
-                frame_file = core.File(
-                                   ifo, "FRAME",
-                                   segments.segment(gps_start_time,
-                                                    gps_end_time),
-                                   file_url="file://" + path)
-                frame_file.PFN(frame_file.storage_path, site="local")
-                frame_files.append(frame_file)
-    else:
-        frame_files, _, _, _ = datafind.setup_datafind_workflow(workflow, seg_dict,
-                                                                "datafind")
+for num_event, time in enumerate(times):
 
     # make node for running sampler
     node = inference_exe.create_node()
-    node.add_opt("--instruments", " ".join(workflow.ifos))
-    node.add_opt("--gps-start-time", gps_start_time)
-    node.add_opt("--gps-end-time", gps_end_time)
-    if len(frame_files):
-        node.add_multiifo_input_list_opt("--frame-files", frame_files)
-    node.add_opt("--channel-name", channel_names_str)
     node.add_input_opt("--config-file", config_file)
-    analysis_time = segments.segment(gps_start_time, gps_end_time)
-    inference_file = node.new_output_file_opt(analysis_time, ".hdf",
-                                              "--output-file",
-                                              tags=[str(num_event)])
+    analysis_index = segments.segment(num_event, num_event+1)
+    inference_file = node.new_output_file_opt(analysis_index, ".hdf",
+                                              "--output-file")
 
     # add node to workflow
     workflow += node
 
+    # FIXME: Should we just remove this?
     # files that prints information about the search event
-    if workflow_options:
-        coinc_table_files = [mini.make_coinc_info(workflow, single_triggers,
-                                         tmpltbank_file, coinc_file,
-                                         num_event, rdir.base,
-                                         tags=opts.tags + [str(num_event)])]
+    #if workflow_options:
+    #    coinc_table_files = [mini.make_coinc_info(workflow, single_triggers,
+    #                                     tmpltbank_file, coinc_file,
+    #                                     num_event, rdir.base,
+    #                                     tags=opts.tags + [str(num_event)])]
 
     # files for posteriors summary subsection
     base = "posteriors"
     post_table_files = inffu.make_inference_summary_table(
                           workflow, inference_file, rdir[base],
                           variable_params=all_parameters,
-                          analysis_seg=analysis_time,
-                          tags=opts.tags + [str(num_event)])
+                          analysis_seg=analysis_index,
+                          tags=opts.tags)# + [str(num_event)])
     post_files = inffu.make_inference_posterior_plot(
                           workflow, inference_file, rdir[base],
                           parameters=all_parameters,
-                          analysis_seg=analysis_time,
-                          tags=opts.tags + [str(num_event)])
+                          analysis_seg=analysis_index,
+                          tags=opts.tags)# + [str(num_event)])
     layout.single_layout(rdir[base], post_table_files + post_files)
 
     # files for posteriors 1d_posteriors subsection
@@ -317,7 +224,7 @@ for num_event in range(num_events):
         post_1d_files = inffu.make_inference_1d_posterior_plots(
                           workflow, inference_file, rdir[base],
                           parameters=parameters,
-                          analysis_seg=analysis_time,
+                          analysis_seg=analysis_index,
                           tags=opts.tags + [str(num_event), group])
         layout.group_layout(rdir[base], post_1d_files)
 
@@ -328,7 +235,7 @@ for num_event in range(num_events):
         for parameter in all_parameters:
             samples_files += inffu.make_inference_samples_plot(
                               workflow, inference_file, rdir[base],
-                              parameters=[parameter], analysis_seg=analysis_time,
+                              parameters=[parameter], analysis_seg=analysis_index,
                               tags=opts.tags + [str(num_event), parameter])
         layout.group_layout(rdir[base], samples_files)
 
@@ -337,7 +244,7 @@ for num_event in range(num_events):
         base = "samples/acceptance_rate"
         acceptance_files = inffu.make_inference_acceptance_rate_plot(
                               workflow, inference_file, rdir[base],
-                              analysis_seg=analysis_time,
+                              analysis_seg=analysis_index,
                               tags=opts.tags + [str(num_event)])
         layout.single_layout(rdir[base], acceptance_files)
 
@@ -354,7 +261,7 @@ prior_files = []
 for subsection in cp.get_subsections(opts.prior_section):
     prior_files += inffu.make_inference_prior_plot(
                           workflow, config_file, rdir[base],
-                          analysis_seg=workflow.analysis_time,
+                          analysis_seg=workflow.analysis_index,
                           parameters=[subsection],
                           tags=opts.tags + [subsection])
 layout.group_layout(rdir[base], prior_files)

--- a/bin/workflows/pycbc_make_inference_workflow
+++ b/bin/workflows/pycbc_make_inference_workflow
@@ -302,6 +302,7 @@ for num_event, config_fnames in enumerate(infconfig_files):
         workflow, inference_file, rdir.base,
         parameters=table_params,
         analysis_seg=analysis_index,
+        result_label=label,
         tags=opts.tags+[str(num_event)]),)
 
     # summary posteriors

--- a/bin/workflows/pycbc_make_inference_workflow
+++ b/bin/workflows/pycbc_make_inference_workflow
@@ -251,10 +251,6 @@ logging.getLogger("").addHandler(log_file)
 logging.info("Created log file %s" % log_file_txt.storage_path)
 
 
-# construct Executable for running sampler
-inference_exe = core.Executable(workflow.cp, "inference",
-                                ifos=workflow.ifos, out_dir=filedir)
- 
 # figure out what parameters user wants to plot from workflow configuration
 group_prefix = "plot-group-"
 # parameters for the summary plots
@@ -273,20 +269,27 @@ for num_event, config_fnames in enumerate(infconfig_files):
     if label is None:
         label = 'Event {}'.format(num_event)
     label = label.replace(' ', '_').replace(':', '_').replace('+', '_')
+
+    # create a sub workflow for this event
+    sub_workflow = core.Workflow(opts,
+                                 "{}-{}".format(opts.workflow_name, label))
+
+    # write the configuration file to the config files directory
     overrides = infconfig_overrides[num_event]
     deletions = infconfig_deletions[num_event]
-    # write the configuration file to the config files directory
     cp = configuration.WorkflowConfigParser(config_fnames,
                                             overrideTuples=overrides,
                                             deleteTuples=deletions)
-    config_file = workflow.save_config(config_file_tmplt.format(label),
-                                       config_file_dir, cp)[0]
+    config_file = sub_workflow.save_config(config_file_tmplt.format(label),
+                                           config_file_dir, cp)[0]
     # create sym links to config file for results page
     base = "config_files/{}".format(label)
     layout.single_layout(rdir[base], [config_file])
     symlink_path(config_file, rdir[base])
 
     # make node for running sampler
+    inference_exe = core.Executable(sub_workflow.cp, "inference",
+                                    ifos=sub_workflow.ifos, out_dir=filedir)
     node = inference_exe.create_node()
     node.add_input_opt("--config-file", config_file)
     node.add_opt("--seed", opts.seed+num_event)
@@ -296,11 +299,11 @@ for num_event, config_fnames in enumerate(infconfig_files):
                                               tags=opts.tags+[label])
 
     # add node to workflow
-    workflow += node
+    sub_workflow += node
 
     # summary table
     summary_page += (inffu.make_inference_summary_table(
-        workflow, inference_file, rdir.base,
+        sub_workflow, inference_file, rdir.base,
         parameters=table_params,
         analysis_seg=analysis_index,
         result_label=label,
@@ -310,7 +313,7 @@ for num_event, config_fnames in enumerate(infconfig_files):
     summary_plots = []
     for group, params in summary_plot_params.items():
         summary_plots += inffu.make_inference_posterior_plot(
-            workflow, inference_file, rdir.base,
+            sub_workflow, inference_file, rdir.base,
             parameters=params, plot_prior_from_file=config_file,
             analysis_seg=analysis_index,
             tags=opts.tags+[label, group])
@@ -320,7 +323,7 @@ for num_event, config_fnames in enumerate(infconfig_files):
     # files for detector_sensitivity summary subsection
     base = "detector_sensitivity"
     psd_page.append(plotting.make_spectrum_plot(
-        workflow, [inference_file], rdir[base],
+        sub_workflow, [inference_file], rdir[base],
         tags=opts.tags+[label],
         hdf_group="data"))
 
@@ -329,8 +332,8 @@ for num_event, config_fnames in enumerate(infconfig_files):
     prior_plots = []
     for group, params in plot_params.items():
         prior_plots += inffu.make_inference_prior_plot(
-            workflow, config_file, rdir[base],
-            analysis_seg=workflow.analysis_time,
+            sub_workflow, config_file, rdir[base],
+            analysis_seg=sub_workflow.analysis_time,
             parameters=params,
             tags=opts.tags+[label, group])
     layout.single_layout(rdir[base], prior_plots)
@@ -340,7 +343,7 @@ for num_event, config_fnames in enumerate(infconfig_files):
     posterior_plots = []
     for group, params in plot_params.items():
         posterior_plots += inffu.make_inference_posterior_plot(
-            workflow, inference_file, rdir[base],
+            sub_workflow, inference_file, rdir[base],
             parameters=params, plot_prior_from_file=config_file,
             analysis_seg=analysis_index,
             tags=opts.tags+[label, group])
@@ -353,7 +356,7 @@ for num_event, config_fnames in enumerate(infconfig_files):
         samples_plots = []
         for group, parameters in plot_params.items():
             samples_plots += inffu.make_inference_samples_plot(
-                workflow, inference_file, rdir[base],
+                sub_workflow, inference_file, rdir[base],
                 parameters=parameters,
                 analysis_seg=analysis_index,
                 tags=opts.tags+[label, group])
@@ -363,10 +366,13 @@ for num_event, config_fnames in enumerate(infconfig_files):
         # files for samples acceptance_rate subsection
         base = "acceptance_rate/{}".format(label)
         acceptance_plot = inffu.make_inference_acceptance_rate_plot(
-            workflow, inference_file, rdir[base],
+            sub_workflow, inference_file, rdir[base],
             analysis_seg=analysis_index,
             tags=opts.tags+[label])
         layout.single_layout(rdir[base], acceptance_plot)
+
+    # add the sub workflow to the main workflow
+    workflow += sub_workflow
 
 # build the summary page
 layout.two_column_layout(rdir.base, summary_page)

--- a/bin/workflows/pycbc_make_inference_workflow
+++ b/bin/workflows/pycbc_make_inference_workflow
@@ -270,7 +270,6 @@ for subsection in cp.get_subsections(opts.prior_section):
 layout.group_layout(rdir[base], prior_files)
 
 # files for overall summary section
-summ_files = coinc_table_files if workflow_options else []
 summ_files = post_table_files + post_files
 for summ_file in summ_files:
     symlink_path(summ_file, rdir.base)

--- a/bin/workflows/pycbc_make_inference_workflow
+++ b/bin/workflows/pycbc_make_inference_workflow
@@ -136,18 +136,25 @@ parser.add_argument("--version", action="version", version=__version__,
                     help="Prints version information.")
 
 # workflow options
-parser.add_argument("--workflow-name", default="my_unamed_inference_run",
+parser.add_argument("--workflow-name", required=True,
                     help="Name of the workflow to append in various places.")
 parser.add_argument("--tags", nargs="+", default=[],
                     help="Tags to apend in various places.")
-parser.add_argument("--output-dir", default=None,
-                    help="Path to output directory.")
-parser.add_argument("--output-map", default=None,
-                    help="Path to output map file.")
+parser.add_argument("--output-dir", default="output",
+                    help="Path to directory where the workflow will be "
+                         "written. Default is 'output'.")
+parser.add_argument("--output-map", default="output.map",
+                    help="Path to an output map file. Default is "
+                         "'output.map'.")
 parser.add_argument("--transformation-catalog", default=None,
                     help="Path to transformation catalog file.")
 parser.add_argument("--output-file", default=None,
                     help="Path to DAX file.")
+# inference options
+parser.add_argument("--seed", type=int, default=0,
+                    help="Seed to use for inference job(s). If multiple "
+                         "events are analyzed, the seed will be incremented "
+                         "by one for each event.")
 # input configuration file options
 cgroup = parser.add_mutually_exclusive_group(required=True)
 cgroup.add_argument("--inference-config-file", type=str, nargs='+',
@@ -247,6 +254,7 @@ for num_event, config_fnames in enumerate(infconfig_files):
     label = elabels[num_event]
     if label is None:
         label = 'Event {}'.format(num_event)
+    label = label.replace(' ', '_')
     overrides = infconfig_overrides[num_event]
     deletions = infconfig_deletions[num_event]
     # write the configuration file to the config files directory
@@ -260,6 +268,7 @@ for num_event, config_fnames in enumerate(infconfig_files):
     # make node for running sampler
     node = inference_exe.create_node()
     node.add_input_opt("--config-file", config_file)
+    node.add_opt("--seed", opts.seed+num_event)
     analysis_index = segments.segment(num_event, num_event+1)
     inference_file = node.new_output_file_opt(analysis_index, ".hdf",
                                               "--output-file")
@@ -279,7 +288,7 @@ for num_event, config_fnames in enumerate(infconfig_files):
         parameters=all_parameters,
         analysis_seg=analysis_index,
         tags=opts.tags)
-    layout.single_layout(rdir[base], post_table_files + post_files)
+    layout.single_layout(rdir[base], post_table_files+post_files)
 
     # files for posteriors 1d_posteriors subsection
     groups = plot_parameters.keys()
@@ -298,11 +307,12 @@ for num_event, config_fnames in enumerate(infconfig_files):
         # files for samples summary subsection
         base = "diagnostics/samples"
         samples_files = []
-        for parameter in all_parameters:
+        for pi, parameter in enumerate(all_parameters):
             samples_files += inffu.make_inference_samples_plot(
                               workflow, inference_file, rdir[base],
-                              parameters=[parameter], analysis_seg=analysis_index,
-                              tags=opts.tags + [str(num_event), parameter])
+                              parameters=[parameter],
+                              analysis_seg=analysis_index,
+                              tags=opts.tags+[str(num_event), str(pi)])
         layout.group_layout(rdir[base], samples_files)
 
     if "inference_rate" in workflow.cp.options("executables"):
@@ -325,12 +335,12 @@ for num_event, config_fnames in enumerate(infconfig_files):
     # files for priors summary section
     base = "priors/{}".format(label)
     prior_files = []
-    for subsection in cp.get_subsections('prior'):
+    for pi, subsection in enumerate(cp.get_subsections('prior')):
         prior_files += inffu.make_inference_prior_plot(
             workflow, config_file, rdir[base],
             analysis_seg=workflow.analysis_time,
             parameters=[subsection],
-            tags=opts.tags+[str(num_event), subsection])
+            tags=opts.tags+[str(num_event), str(pi)])
     layout.group_layout(rdir[base], prior_files)
 
 # files for overall summary section

--- a/bin/workflows/pycbc_make_inference_workflow
+++ b/bin/workflows/pycbc_make_inference_workflow
@@ -311,7 +311,7 @@ for num_event, config_fnames in enumerate(infconfig_files):
     for group, params in summary_plot_params.items():
         summary_plots += inffu.make_inference_posterior_plot(
             workflow, inference_file, rdir.base,
-            parameters=params,
+            parameters=params, plot_prior_from_file=config_file,
             analysis_seg=analysis_index,
             tags=opts.tags+[label, group])
     summary_page += list(layout.grouper(summary_plots, 2))
@@ -341,7 +341,7 @@ for num_event, config_fnames in enumerate(infconfig_files):
     for group, params in plot_params.items():
         posterior_plots += inffu.make_inference_posterior_plot(
             workflow, inference_file, rdir[base],
-            parameters=params,
+            parameters=params, plot_prior_from_file=config_file,
             analysis_seg=analysis_index,
             tags=opts.tags+[label, group])
     layout.single_layout(rdir[base], posterior_plots)

--- a/bin/workflows/pycbc_make_inference_workflow
+++ b/bin/workflows/pycbc_make_inference_workflow
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-""" Creates a DAX for a parameter estimation workflow.
+"""Creates a DAX for a parameter estimation workflow.
 """
 
 import argparse
@@ -42,68 +42,99 @@ from pycbc import __version__
 import pycbc.workflow.inference_followups as inffu
 
 
-def load_inference_configs(config_cache):
-    """Loads configuration files from the given config file.
-    
-    Each line in the cache file should be a comma-separated list of label,
-    config file(s), overrides, deletions. If multiple config files are to be
-    used, they should be space separted. Likewise, if multiple overrides or
-    deletions are provided, they should be space separated. Overrides should be
-    formatted as ``SECTION:OPTION:VALUE``, deletions as ``SECTION:OPTION``.
-    For example::
+def read_events_from_config(cp):
+    """Gets events to load from a config file.
 
-        Event 1,config1.ini config2.ini,foo:bar:2 life:meaning:42,knights:ni
+    Each event should have its own section with header ``[event-{{NAME}}]``,
+    where ``NAME`` is a unique identifier. The section must have a
+    ``config-files`` option that gives the configuration file(s) to use for the
+    event. To specify multiple configuration files, the files should be
+    space (or new-line) separated. Relative or absolute paths may be used.
 
-    Labels must be unique across all events. Otherwise, a ``ValueError`` is
-    raised.
+    Overrides and deletions for the config file(s) may be provided
+    via ``config-overrides`` and ``config-delete``, respectively. These should
+    be space (or new line) separated. The overrides should have format
+    ``SECTION:OPTION:VALUE`` and the deletions ``SECTION:OPTION``.
+
+    The section may also have a ``label`` option that provides a human-readable
+    label for the results page. If no ``label`` option is provided, the
+    ``{{NAME}}`` will be used.
+
+    Multiple instances of an inference job may be invoked by adding a ``nruns``
+    option, and setting it to an integer larger than 1. In this case, multiple
+    inference analyses will be carried out on the event with the same settings,
+    only differing by the seed given to ``pycbc_inference``. The output from
+    the multiple runs will be combined into a single posterior file, with all
+    posterior plots generated from the posterior file. If the ``nruns`` option
+    isn't provided, a single inference job will run for each event.
+
+    The order that events are provided in the configuration file will be the
+    order they are presented on the results page.
+
+    Example:
+
+    .. code-block:: ini
+
+       [event-gw150914]                                                                
+       label = GW150914+09:50:45UTC                                                    
+       config-files = sampler.ini                                    
+                      gw150914_like.ini                              
+                      o1_data.ini                                    
+       config-overrides = data:trigger-time:1126259462.43                              
+       nruns = 3
 
     Parameters
     ----------
-    config_cache : str
-        The name of the cache file.
+    cp : pycbc.workflow.configuration.WorkflowConfigParser
+        Configuration file giving the events.
 
     Returns
     -------
-    labels : list
-        List of strings giving a label for each event.
-    config_files : list
-        List of the config files. Each element is itself a list providing
-        all of the config files to combine.
-    overrides : list
-        List of the overrides. Each element is itself a list of tuples giving
-        (section, option, value). If no overrides were provided for an
-        entry, that element will be ``None``.
-    deletions : list
-        List of the deletions. Each element is itself a list of tuples giving
-        (section, option). If no deletions were provided for an entry, that
-        element will be ``None``.
-        List of config files, overrides, and deletions. Config
+    events : list of str
+        The names of the event(s) that were given in the config file.
+    labels : list of str
+        The labels to use for the event(s).
+    config_opts : list
+        The options for loading the inference config file, as parsed
+        argparse.ArgumentParser options.
+    nruns : list of int
+        The number of inference jobs to create for the event.
     """
+    # get the events
+    events = cp.get_subsections('event')
+    # create a dummy command-line parser for getting the config files and
+    # options
+    cfparser = argparse.ArgumentParser()
+    configuration.add_workflow_command_line_group(cfparser)
+    # lists for storing output
     labels = []
-    config_files = []
-    overrides = []
-    deletions = []
-    with open(config_cache, 'r') as fp:
-        for line in fp:
-            if line.startswith('#'):
-                continue
-            line = line.replace('\n', '')
-            lbl, cfs, ovs, dels = line.split(',')
-            cfs = map(os.path.abspath, cfs.strip().split())
-            ovs = [tuple(o.split(':')) for o in ovs.strip().split()]
-            if ovs == []:
-                ovs = None
-            dels = [tuple(d.split(':')) for d in dels.strip().split()]
-            if dels == []:
-                dels = None
-            labels.append(lbl.strip())
-            config_files.append(cfs)
-            overrides.append(ovs)
-            deletions.append(dels)
-    # check that the labels are unique
-    if not len(set(labels)) == len(labels):
-        raise ValueError("all labels in config cache must be unique")
-    return labels, config_files, overrides, deletions
+    cpopts = []
+    nruns = []
+    for event in events:
+        section = '-'.join(['event', event])
+        # get the label
+        if cp.has_option(section, 'label'):
+            label = cp.get(section, 'label')
+        else:
+            label = event
+        labels.append(label)
+        # convert the config-file options to a command line string
+        cli = cp.section_to_cli(section, skip_opts=['label', 'nruns'])
+        cpopts.append(cfparser.parse_args(shlex.split(cli)))
+        # get the number of times to run the event
+        if cp.has_option(section, 'nruns'):
+            nruns = int(cp.get(section, 'nruns'))
+        else:
+            nruns = 1
+        if nrns < 1:
+            raise ValueError('nruns must be >= 1')
+    return events, labels, cpopts, nruns
+
+
+def event_slug(label):
+    """Slugifies an event label."""
+    return label.replace(' ', '_').replace(':', '_').replace('+', '_')
+
 
 def symlink_path(f, path):
     """ Symlinks a path.
@@ -115,17 +146,6 @@ def symlink_path(f, path):
     except OSError:
         pass
 
-def get_plot_group(cp, section_tag):
-    """Gets plotting groups from [workflow-section_tag]."""
-    group_prefix = "plot-group-"
-    # parameters for the summary plots
-    plot_groups = {}
-    opts = [opt for opt in cp.options("workflow-{}".format(section_tag))
-            if opt.startswith(group_prefix)]
-    for opt in opts:
-        group = opt.replace(group_prefix, "").replace("-", "_")
-        plot_groups[group] = cp.get_opt_tag("workflow", opt, section_tag)
-    return plot_groups
 
 # command line parser
 parser = argparse.ArgumentParser(description=__doc__[1:])
@@ -156,53 +176,31 @@ parser.add_argument("--seed", type=int, default=0,
                     help="Seed to use for inference job(s). If multiple "
                          "events are analyzed, the seed will be incremented "
                          "by one for each event.")
-# input configuration file options
-cgroup = parser.add_mutually_exclusive_group(required=True)
-cgroup.add_argument("--inference-config-file", type=str, nargs='+',
-                    help="Configuration file(s) for the inference job. Must "
-                         "provide either this, or an inference-config-cache.")
-cgroup.add_argument("--inference-config-cache", type=str,
-                    help="A cache file listing configuration files for "
-                         "multiple events. Each line in the cache represents "
-                         "a single event, and should provide a space-"
-                         "separated list of config files to use for that "
-                         "event. If provided, will a separate inference "
-                         "analysis will be created for each event. Must "
-                         "provide either this or inference-config-file.")
 # add option groups
 configuration.add_workflow_command_line_group(parser)
 
 # parser command line
 opts = parser.parse_args()
 
-# get inference configuration file(s)
-if opts.inference_config_file is not None:
-    # means we're only anlyzing a single group
-    infconfig_files = [opts.inference_config_file]
-    infconfig_overrides = [None]
-    infconfig_deletions = [None]
-    elabels = [None]
-else:
-    # load the inference config cache
-    elabels, infconfig_files, infconfig_overrides, infconfig_deletions = \
-        load_inference_configs(opts.inference_config_cache)
-
+# configuration files
 config_file_tmplt = 'inference-{}.ini'
 config_file_dir = 'config_files'
+# the directory we'll store samples files to
+samples_file_dir = 'samples_files'
+# the directory we'll store posterior files to
+posterior_file_dir = 'posterior_files'
 
 # make data output directory
 if opts.output_dir is None:
     opts.output_dir = opts.workflow_name + '_output'
 core.makedir(opts.output_dir)
 core.makedir('{}/{}'.format(opts.output_dir, config_file_dir))
+core.makedir('{}/{}'.format(opts.output_dir, posterior_file_dir))
 
 # set the dax file name
 dax_file = opts.dax_file
 if dax_file is None:
     dax_file = "{}.dax".format(opts.workflow_name)
-
-# the file we'll store all output files in
-filedir = 'output'
 
 # log to terminal until we know where the path to log output file
 log_format = "%(asctime)s:%(levelname)s : %(message)s"
@@ -213,16 +211,15 @@ container = core.Workflow(opts, opts.workflow_name)
 workflow = core.Workflow(opts, opts.workflow_name + "-main")
 finalize_workflow = core.Workflow(opts, opts.workflow_name + "-finalization")
 
+# read the events to analyze
+events, labels, cpopts, nruns = read_events_from_config(workflow.cp)
+
 # change working directory to the output
 origdir = os.path.abspath(os.curdir)
 os.chdir(opts.output_dir)
 
 # figure out what diagnostic jobs there are
-diagnostics = []
-if "inference_samples" in workflow.cp.options("executables"):
-    diagnostics.append('samples')
-if "inference_rate" in workflow.cp.options("executables"):
-    diagnostics.append('acceptance_rate')
+diagnostics = inffu.get_diagnostic_plots(workflow)
 
 # sections for output HTML pages
 rdir = layout.SectionNumber("results",
@@ -251,131 +248,85 @@ log_file.setFormatter(formatter)
 logging.getLogger("").addHandler(log_file)
 logging.info("Created log file %s" % log_file_txt.storage_path)
 
-
-# figure out what parameters user wants to plot from workflow configuration
-group_prefix = "plot-group-"
-# parameters for the summary plots
-summary_plot_params = get_plot_group(workflow.cp, 'summary_plots')
-# parameters to plot in large corner plots
-plot_params = get_plot_group(workflow.cp, 'plot_parameters')
-# get parameters for the summary tables
-table_params = workflow.cp.get_opt_tag('workflow', 'table-parameters',
-                                       'summary_table')
-psd_page = []
 config_files = {}
+seed = opts.seed
 # loop over number of loudest events to be analyzed
-for num_event, config_fnames in enumerate(infconfig_files):
-    summary_page = []
-    label = elabels[num_event]
-    if label is None:
-        label = 'Event {}'.format(num_event)
-    summary_label = label
-    label = label.replace(' ', '_').replace(':', '_').replace('+', '_')
+for num_event, event in enumerate(events):
+    # slugify the event name so it can be used in file names
+    event = event_slug(event)
+    label = labels[num_event]
+    cpopt = cpopts[num_event]
+    nrun = nruns[num_event]
 
     # create a sub workflow for this event
     # we need to go back to the original directory to do this for all the file
     # references to work correctly
     os.chdir(origdir)
     sub_workflow = core.Workflow(opts,
-                                 "{}-{}".format(opts.workflow_name, label))
+                                 "{}-{}".format(opts.workflow_name, event))
+    # load the inference config file
+    cp = configuration.WorkflowConfigParser.from_cli(cpopt)
+
     # now go back to the output
     os.chdir(opts.output_dir)
 
     # write the configuration file to the config files directory
-    overrides = infconfig_overrides[num_event]
-    deletions = infconfig_deletions[num_event]
-    cp = configuration.WorkflowConfigParser(config_fnames,
-                                            overrideTuples=overrides,
-                                            deleteTuples=deletions)
-    config_file = sub_workflow.save_config(config_file_tmplt.format(label),
+    config_file = sub_workflow.save_config(config_file_tmplt.format(event),
                                            config_file_dir, cp)[0]
+
     # create sym links to config file for results page
-    base = "config_files/{}".format(label)
+    base = "config_files/{}".format(event)
     layout.single_layout(rdir[base], [config_file])
     symlink_path(config_file, rdir[base])
 
-    # make node for running sampler
+    # make node(s) for running sampler
+    samples_files = []
     inference_exe = core.Executable(sub_workflow.cp, "inference",
-                                    ifos=sub_workflow.ifos, out_dir=filedir)
-    node = inference_exe.create_node()
-    node.add_input_opt("--config-file", config_file)
-    node.add_opt("--seed", opts.seed+num_event)
-    analysis_index = segments.segment(num_event, num_event+1)
-    inference_file = node.new_output_file_opt(analysis_index, ".hdf",
-                                              "--output-file",
-                                              tags=opts.tags+[label])
+                                    ifos=sub_workflow.ifos,
+                                    out_dir=samples_file_dir)
+    for nn in range(nrun):
+        tags = opts.tag + [event]
+        if nrun > 1:
+            tags.append(str(nn))
+        node = inference_exe.create_node()
+        node.add_input_opt("--config-file", config_file)
+        node.add_opt("--seed", seed)
+        samples_file = node.new_output_file_opt(
+            sub_workflow.analysis_time, ".hdf", "--output-file",
+            tags=tags)
+        samples_files.append(samples_file)
+        # add node to workflow
+        sub_workflow += node
+        # increment the seed
+        seed = seed + 1
 
-    # add node to workflow
-    sub_workflow += node
+    # create the posterior file and plots
+    posterior_file, summary_files, _, _ = inffu.make_posterior_workflow(
+        sub_workflow, samples_files, config_file, event, rdir,
+        posterior_file_dir=posterior_file_dir, tags=opts.tags)
 
-    # summary table
-    summary_page += (inffu.make_inference_summary_table(
-        sub_workflow, inference_file, rdir.base,
-        parameters=table_params,
-        analysis_seg=analysis_index,
-        tags=opts.tags+[label]),)
-
-    # summary posteriors
-    summary_plots = []
-    for group, params in summary_plot_params.items():
-        summary_plots += inffu.make_inference_posterior_plot(
-            sub_workflow, inference_file, rdir.base,
-            parameters=params, plot_prior_from_file=config_file,
-            analysis_seg=analysis_index,
-            tags=opts.tags+[label, group])
-    summary_page += list(layout.grouper(summary_plots, 2))
-    
+    # create the diagnostic plots
+    _ = inffu.make_diagnostic_plots(sub_workflow, diagnostics,
+                                    samples_files,
+                                    event, rdir)
 
     # files for detector_sensitivity summary subsection
     base = "detector_sensitivity"
-    psd_page.append(plotting.make_spectrum_plot(
-        sub_workflow, [inference_file], rdir[base],
-        tags=opts.tags+[label],
-        hdf_group="data"))
+    psd_plot = plotting.make_spectrum_plot(
+        sub_workflow, [samples_files[0]], rdir[base],
+        tags=opts.tags+[event],
+        hdf_group="data")
 
-    # files for priors summary section
-    base = "priors/{}".format(label)
-    prior_plots = []
-    for group, params in plot_params.items():
-        prior_plots += inffu.make_inference_prior_plot(
-            sub_workflow, config_file, rdir[base],
-            analysis_seg=sub_workflow.analysis_time,
-            parameters=params,
-            tags=opts.tags+[label, group])
-    layout.single_layout(rdir[base], prior_plots)
+    # build the summary page
+    zpad = int(numpy.ceil(numpy.log10(len(samples_files))))
+    layout.two_column_layout(rdir.base, summary_files,
+                             unique=str(num_event).zfill(zpad),
+                             title=label, collapse=True)
 
-    # files for posteriors summary subsection
-    base = "posteriors/{}".format(label)
-    posterior_plots = []
-    for group, params in plot_params.items():
-        posterior_plots += inffu.make_inference_posterior_plot(
-            sub_workflow, inference_file, rdir[base],
-            parameters=params, plot_prior_from_file=config_file,
-            analysis_seg=analysis_index,
-            tags=opts.tags+[label, group])
-    layout.single_layout(rdir[base], posterior_plots)
-
-    # files for diagnostics section
-    if 'samples' in diagnostics:
-        # files for samples summary subsection
-        base = "samples/{}".format(label)
-        samples_plots = []
-        for group, parameters in plot_params.items():
-            samples_plots += inffu.make_inference_samples_plot(
-                sub_workflow, inference_file, rdir[base],
-                parameters=parameters,
-                analysis_seg=analysis_index,
-                tags=opts.tags+[label, group])
-        layout.group_layout(rdir[base], samples_plots)
-
-    if 'acceptance_rate' in diagnostics:
-        # files for samples acceptance_rate subsection
-        base = "acceptance_rate/{}".format(label)
-        acceptance_plot = inffu.make_inference_acceptance_rate_plot(
-            sub_workflow, inference_file, rdir[base],
-            analysis_seg=analysis_index,
-            tags=opts.tags+[label])
-        layout.single_layout(rdir[base], acceptance_plot)
+    # build the psd page
+    layout.single_layout(rdir['detector_sensitivity'], [psd_plot],
+                         unique=str(num_event).zfill(zpad),
+                         title=label, collapse=True)
 
     # add the sub workflow to the main workflow
     workflow += sub_workflow
@@ -384,13 +335,11 @@ for num_event, config_fnames in enumerate(infconfig_files):
     zpad = int(numpy.ceil(numpy.log10(len(infconfig_files))))
     layout.two_column_layout(rdir.base, summary_page,
                              unique=str(num_event).zfill(zpad),
-                             title=summary_label, collapse=True)
+                             title=label, collapse=True)
 
 
 # build the psd page
 layout.group_layout(rdir['detector_sensitivity'], psd_page)
-
-# build the config page
 
 # create versioning HTML pages
 results.create_versioning_page(rdir["workflow/version"], container.cp)

--- a/bin/workflows/pycbc_make_inference_workflow
+++ b/bin/workflows/pycbc_make_inference_workflow
@@ -308,9 +308,8 @@ for num_event, event in enumerate(events):
         posterior_file_dir=posterior_file_dir, tags=opts.tags)
 
     # create the diagnostic plots
-    _ = inffu.make_diagnostic_plots(sub_workflow, diagnostics,
-                                    samples_files,
-                                    event, rdir)
+    _ = inffu.make_diagnostic_plots(sub_workflow, diagnostics, samples_files,
+                                    event, rdir, tags=opts.tags)
 
     # files for detector_sensitivity summary subsection
     base = "detector_sensitivity"

--- a/bin/workflows/pycbc_make_inference_workflow
+++ b/bin/workflows/pycbc_make_inference_workflow
@@ -114,6 +114,7 @@ def to_file(path, ifo=None):
     fil.ifo = ifo
     path = os.path.abspath(path)
     fil.PFN(path, "local")
+    fil.storage_path = path
     return fil
 
 def symlink_path(f, path):
@@ -290,8 +291,12 @@ for num_event, config_fnames in enumerate(infconfig_files):
     cp = configuration.WorkflowConfigParser(config_fnames,
                                             overrideTuples=overrides,
                                             deleteTuples=deletions)
-    config_file = workflow.save_config(config_file_tmplt.format(num_event),
-                                       os.path.abspath(config_file_dir), cp)[0]
+    config_file = os.path.join(config_file_dir,
+                               config_file_tmplt.format(num_event))
+    with open(config_file, 'w') as cf:
+        cp.write(cf)
+    # convert to a dax File type
+    config_file = to_file(config_file)
     # create sym links to config file for results page
     base = "config_files/{}".format(label)
     layout.single_layout(rdir[base], [config_file])

--- a/bin/workflows/pycbc_make_inference_workflow
+++ b/bin/workflows/pycbc_make_inference_workflow
@@ -22,6 +22,7 @@ import argparse
 import h5py
 import logging
 import os
+import shlex
 import Pegasus.DAX3 as dax
 import pycbc
 import pycbc.workflow.minifollowups as mini
@@ -123,11 +124,12 @@ def read_events_from_config(cp):
         cpopts.append(cfparser.parse_args(shlex.split(cli)))
         # get the number of times to run the event
         if cp.has_option(section, 'nruns'):
-            nruns = int(cp.get(section, 'nruns'))
+            nrun = int(cp.get(section, 'nruns'))
         else:
-            nruns = 1
-        if nrns < 1:
+            nrun = 1
+        if nrun < 1:
             raise ValueError('nruns must be >= 1')
+        nruns.append(nrun)
     return events, labels, cpopts, nruns
 
 
@@ -285,7 +287,7 @@ for num_event, event in enumerate(events):
                                     ifos=sub_workflow.ifos,
                                     out_dir=samples_file_dir)
     for nn in range(nrun):
-        tags = opts.tag + [event]
+        tags = opts.tags + [event]
         if nrun > 1:
             tags.append(str(nn))
         node = inference_exe.create_node()
@@ -331,15 +333,6 @@ for num_event, event in enumerate(events):
     # add the sub workflow to the main workflow
     workflow += sub_workflow
 
-    # build the summary page
-    zpad = int(numpy.ceil(numpy.log10(len(infconfig_files))))
-    layout.two_column_layout(rdir.base, summary_page,
-                             unique=str(num_event).zfill(zpad),
-                             title=label, collapse=True)
-
-
-# build the psd page
-layout.group_layout(rdir['detector_sensitivity'], psd_page)
 
 # create versioning HTML pages
 results.create_versioning_page(rdir["workflow/version"], container.cp)

--- a/bin/workflows/pycbc_make_inference_workflow
+++ b/bin/workflows/pycbc_make_inference_workflow
@@ -105,18 +105,6 @@ def load_inference_configs(config_cache):
         raise ValueError("all labels in config cache must be unique")
     return labels, config_files, overrides, deletions
 
-
-def to_file(path, ifo=None):
-    """ Takes a str and returns a pycbc.workflow.pegasus_workflow.File
-    instance.
-    """
-    fil = wdax.File(os.path.basename(path))
-    fil.ifo = ifo
-    path = os.path.abspath(path)
-    fil.PFN(path, "local")
-    fil.storage_path = path
-    return fil
-
 def symlink_path(f, path):
     """ Symlinks a path.
     """
@@ -312,7 +300,7 @@ for num_event, config_fnames in enumerate(infconfig_files):
     # summary table
     summary_page += (inffu.make_inference_summary_table(
         workflow, inference_file, rdir.base,
-        variable_params=table_params,
+        parameters=table_params,
         analysis_seg=analysis_index,
         tags=opts.tags+[str(num_event)]),)
 

--- a/bin/workflows/pycbc_make_inference_workflow
+++ b/bin/workflows/pycbc_make_inference_workflow
@@ -38,11 +38,9 @@ from pycbc.workflow import configuration
 from pycbc.workflow import core
 from pycbc.workflow import datafind
 from pycbc.workflow import plotting
-
 from pycbc import __version__
-
-# FIXME see https://github.com/gwastro/pycbc/issues/2349
 import pycbc.workflow.inference_followups as inffu
+
 
 def load_inference_configs(config_cache):
     """Loads configuration files from the given config file.
@@ -128,6 +126,18 @@ def symlink_path(f, path):
     except OSError:
         pass
 
+def get_plot_group(cp, section_tag):
+    """Gets plotting groups from [workflow-section_tag]."""
+    group_prefix = "plot-group-"
+    # parameters for the summary plots
+    plot_groups = {}
+    opts = [opt for opt in cp.options("workflow-{}".format(section_tag))
+            if opt.startswith(group_prefix)]
+    for opt in opts:
+        group = opt.replace(group_prefix, "").replace("-", "_")
+        plot_groups[group] = cp.get_opt_tag("workflow", opt, section_tag)
+    return plot_groups
+
 # command line parser
 parser = argparse.ArgumentParser(description=__doc__[1:])
 
@@ -188,13 +198,14 @@ else:
     elabels, infconfig_files, infconfig_overrides, infconfig_deletions = \
         load_inference_configs(opts.inference_config_cache)
 
-config_file_tmplt = 'config_files/inference-{}.ini'
+config_file_tmplt = 'inference-{}.ini'
+config_file_dir = 'config_files'
 
 # make data output directory
 if opts.output_dir is None:
     opts.output_dir = opts.workflow_name + '_output'
 core.makedir(opts.output_dir)
-core.makedir('{}/{}'.format(opts.output_dir, 'config_files'))
+core.makedir('{}/{}'.format(opts.output_dir, config_file_dir))
 
 # set the dax file name
 dax_file = opts.dax_file
@@ -216,10 +227,18 @@ finalize_workflow = core.Workflow(opts, opts.workflow_name + "-finalization")
 # change working directory to the output
 os.chdir(opts.output_dir)
 
+# figure out what diagnostic jobs there are
+diagnostics = []
+if "inference_samples" in workflow.cp.options("executables"):
+    diagnostics.append('samples')
+if "inference_rate" in workflow.cp.options("executables"):
+    diagnostics.append('acceptance_rate')
+
 # sections for output HTML pages
 rdir = layout.SectionNumber("results",
-                            ["detector_sensitivity", "priors", "posteriors",
-                             "diagnostics", "config_files", "workflow"])
+                            ["detector_sensitivity", "priors", "posteriors"] +
+                            diagnostics +
+                            ["config_files", "workflow"])
 
 # make results directories
 core.makedir(rdir.base)
@@ -248,15 +267,17 @@ inference_exe = core.Executable(workflow.cp, "inference",
                                 ifos=workflow.ifos, out_dir=filedir)
  
 # figure out what parameters user wants to plot from workflow configuration
-plot_parameters = {}
-for option in workflow.cp.options("workflow-inference"):
-    if option.startswith("plot-1d-"):
-        group = option.replace("plot-1d-", "").replace("-", "_")
-        plot_parameters[group] = workflow.cp.get_opt_tag(
-                                "workflow", option, "inference").split(" ")
-all_parameters = [param for group in plot_parameters.values()
-                  for param in group]
-
+group_prefix = "plot-group-"
+# parameters for the summary plots
+summary_plot_params = get_plot_group(workflow.cp, 'summary_plots')
+# parameters to plot in large corner plots
+plot_params = get_plot_group(workflow.cp, 'plot_parameters')
+# get parameters for the summary tables
+table_params = workflow.cp.get_opt_tag('workflow', 'table-parameters',
+                                       'summary_table')
+summary_page = []
+psd_page = []
+config_files = {}
 # loop over number of loudest events to be analyzed
 for num_event, config_fnames in enumerate(infconfig_files):
     label = elabels[num_event]
@@ -269,9 +290,12 @@ for num_event, config_fnames in enumerate(infconfig_files):
     cp = configuration.WorkflowConfigParser(config_fnames,
                                             overrideTuples=overrides,
                                             deleteTuples=deletions)
-    with open(config_file_tmplt.format(num_event), 'w') as ff:
-        cp.write(ff)
-    config_file = to_file(config_file_tmplt.format(num_event))
+    config_file = workflow.save_config(config_file_tmplt.format(num_event),
+                                       os.path.abspath(config_file_dir), cp)[0]
+    # create sym links to config file for results page
+    base = "config_files/{}".format(label)
+    layout.single_layout(rdir[base], [config_file])
+    symlink_path(config_file, rdir[base])
 
     # make node for running sampler
     node = inference_exe.create_node()
@@ -284,78 +308,82 @@ for num_event, config_fnames in enumerate(infconfig_files):
     # add node to workflow
     workflow += node
 
-    # files for posteriors summary subsection
-    base = "posteriors/{}".format(label)
-    post_table_files = inffu.make_inference_summary_table(
-        workflow, inference_file, rdir[base],
-        variable_params=all_parameters,
+    # summary table
+    summary_page += (inffu.make_inference_summary_table(
+        workflow, inference_file, rdir.base,
+        variable_params=table_params,
         analysis_seg=analysis_index,
-        tags=opts.tags)
-    post_files = inffu.make_inference_posterior_plot(
-        workflow, inference_file, rdir[base],
-        parameters=all_parameters,
-        analysis_seg=analysis_index,
-        tags=opts.tags)
-    layout.single_layout(rdir[base], post_table_files+post_files)
+        tags=opts.tags+[str(num_event)]),)
 
-    # files for posteriors 1d_posteriors subsection
-    groups = plot_parameters.keys()
-    groups.sort()
-    for group in groups:
-        parameters = plot_parameters[group]
-        base = "posteriors/1d_{}_posteriors".format(group)
-        post_1d_files = inffu.make_inference_1d_posterior_plots(
-                          workflow, inference_file, rdir[base],
-                          parameters=parameters,
-                          analysis_seg=analysis_index,
-                          tags=opts.tags + [str(num_event), group])
-        layout.group_layout(rdir[base], post_1d_files)
-
-    if "inference_samples" in workflow.cp.options("executables"):
-        # files for samples summary subsection
-        base = "diagnostics/samples"
-        samples_files = []
-        for pi, parameter in enumerate(all_parameters):
-            samples_files += inffu.make_inference_samples_plot(
-                              workflow, inference_file, rdir[base],
-                              parameters=[parameter],
-                              analysis_seg=analysis_index,
-                              tags=opts.tags+[str(num_event), str(pi)])
-        layout.group_layout(rdir[base], samples_files)
-
-    if "inference_rate" in workflow.cp.options("executables"):
-        # files for samples acceptance_rate subsection
-        base = "diagnostics/acceptance_rate"
-        acceptance_files = inffu.make_inference_acceptance_rate_plot(
-                              workflow, inference_file, rdir[base],
-                              analysis_seg=analysis_index,
-                              tags=opts.tags + [str(num_event)])
-        layout.single_layout(rdir[base], acceptance_files)
+    # summary posteriors
+    summary_plots = []
+    for group, params in summary_plot_params.items():
+        summary_plots += inffu.make_inference_posterior_plot(
+            workflow, inference_file, rdir.base,
+            parameters=params,
+            analysis_seg=analysis_index,
+            tags=opts.tags+[str(num_event), group])
+    summary_page += list(layout.grouper(summary_plots, 2))
+    
 
     # files for detector_sensitivity summary subsection
-    base = "detector_sensitivity/{}".format(label)
-    psd_file = plotting.make_spectrum_plot(
+    base = "detector_sensitivity"
+    psd_page.append(plotting.make_spectrum_plot(
         workflow, [inference_file], rdir[base],
-        tags=opts.tags + [str(num_event)],
-        hdf_group="data")
-    layout.single_layout(rdir[base], [psd_file])
+        tags=opts.tags+[str(num_event)],
+        hdf_group="data"))
 
     # files for priors summary section
     base = "priors/{}".format(label)
-    prior_files = []
-    for pi, subsection in enumerate(cp.get_subsections('prior')):
-        prior_files += inffu.make_inference_prior_plot(
+    prior_plots = []
+    for group, params in plot_params.items():
+        prior_plots += inffu.make_inference_prior_plot(
             workflow, config_file, rdir[base],
             analysis_seg=workflow.analysis_time,
-            parameters=[subsection],
-            tags=opts.tags+[str(num_event), str(pi)])
-    layout.group_layout(rdir[base], prior_files)
+            parameters=params,
+            tags=opts.tags+[str(num_event), group])
+    layout.single_layout(rdir[base], prior_plots)
 
-# files for overall summary section
-summ_files = post_table_files + post_files
-for summ_file in summ_files:
-    symlink_path(summ_file, rdir.base)
-layout.single_layout(rdir.base, summ_files)
+    # files for posteriors summary subsection
+    base = "posteriors/{}".format(label)
+    posterior_plots = []
+    for group, params in plot_params.items():
+        posterior_plots += inffu.make_inference_posterior_plot(
+            workflow, inference_file, rdir[base],
+            parameters=params,
+            analysis_seg=analysis_index,
+            tags=opts.tags+[str(num_event), group])
+    layout.single_layout(rdir[base], posterior_plots)
+
+    # files for diagnostics section
+    if 'samples' in diagnostics:
+        # files for samples summary subsection
+        base = "samples/{}".format(label)
+        samples_plots = []
+        for group, parameters in plot_params.items():
+            samples_plots += inffu.make_inference_samples_plot(
+                workflow, inference_file, rdir[base],
+                parameters=parameters,
+                analysis_seg=analysis_index,
+                tags=opts.tags+[str(num_event), group])
+        layout.group_layout(rdir[base], samples_plots)
+
+    if 'acceptance_rate' in diagnostics:
+        # files for samples acceptance_rate subsection
+        base = "acceptance_rate/{}".format(label)
+        acceptance_plot = inffu.make_inference_acceptance_rate_plot(
+            workflow, inference_file, rdir[base],
+            analysis_seg=analysis_index,
+            tags=opts.tags+[str(num_event)])
+        layout.single_layout(rdir[base], acceptance_plot)
+
+# build the summary page
+layout.two_column_layout(rdir.base, summary_page)
+
+# build the psd page
+layout.group_layout(rdir['detector_sensitivity'], psd_page)
+
+# build the config page
 
 # create versioning HTML pages
 results.create_versioning_page(rdir["workflow/version"], container.cp)

--- a/bin/workflows/pycbc_make_inference_workflow
+++ b/bin/workflows/pycbc_make_inference_workflow
@@ -272,14 +272,14 @@ for num_event, config_fnames in enumerate(infconfig_files):
     label = elabels[num_event]
     if label is None:
         label = 'Event {}'.format(num_event)
-    label = label.replace(' ', '_')
+    label = label.replace(' ', '_').replace(':', '_').replace('+', '_')
     overrides = infconfig_overrides[num_event]
     deletions = infconfig_deletions[num_event]
     # write the configuration file to the config files directory
     cp = configuration.WorkflowConfigParser(config_fnames,
                                             overrideTuples=overrides,
                                             deleteTuples=deletions)
-    config_file = workflow.save_config(config_file_tmplt.format(num_event),
+    config_file = workflow.save_config(config_file_tmplt.format(label),
                                        config_file_dir, cp)[0]
     # create sym links to config file for results page
     base = "config_files/{}".format(label)
@@ -292,7 +292,8 @@ for num_event, config_fnames in enumerate(infconfig_files):
     node.add_opt("--seed", opts.seed+num_event)
     analysis_index = segments.segment(num_event, num_event+1)
     inference_file = node.new_output_file_opt(analysis_index, ".hdf",
-                                              "--output-file")
+                                              "--output-file",
+                                              tags=opts.tags+[label])
 
     # add node to workflow
     workflow += node
@@ -303,7 +304,7 @@ for num_event, config_fnames in enumerate(infconfig_files):
         parameters=table_params,
         analysis_seg=analysis_index,
         result_label=label,
-        tags=opts.tags+[str(num_event)]),)
+        tags=opts.tags+[label]),)
 
     # summary posteriors
     summary_plots = []
@@ -312,7 +313,7 @@ for num_event, config_fnames in enumerate(infconfig_files):
             workflow, inference_file, rdir.base,
             parameters=params,
             analysis_seg=analysis_index,
-            tags=opts.tags+[str(num_event), group])
+            tags=opts.tags+[label, group])
     summary_page += list(layout.grouper(summary_plots, 2))
     
 
@@ -320,7 +321,7 @@ for num_event, config_fnames in enumerate(infconfig_files):
     base = "detector_sensitivity"
     psd_page.append(plotting.make_spectrum_plot(
         workflow, [inference_file], rdir[base],
-        tags=opts.tags+[str(num_event)],
+        tags=opts.tags+[label],
         hdf_group="data"))
 
     # files for priors summary section
@@ -331,7 +332,7 @@ for num_event, config_fnames in enumerate(infconfig_files):
             workflow, config_file, rdir[base],
             analysis_seg=workflow.analysis_time,
             parameters=params,
-            tags=opts.tags+[str(num_event), group])
+            tags=opts.tags+[label, group])
     layout.single_layout(rdir[base], prior_plots)
 
     # files for posteriors summary subsection
@@ -342,7 +343,7 @@ for num_event, config_fnames in enumerate(infconfig_files):
             workflow, inference_file, rdir[base],
             parameters=params,
             analysis_seg=analysis_index,
-            tags=opts.tags+[str(num_event), group])
+            tags=opts.tags+[label, group])
     layout.single_layout(rdir[base], posterior_plots)
 
     # files for diagnostics section
@@ -355,7 +356,7 @@ for num_event, config_fnames in enumerate(infconfig_files):
                 workflow, inference_file, rdir[base],
                 parameters=parameters,
                 analysis_seg=analysis_index,
-                tags=opts.tags+[str(num_event), group])
+                tags=opts.tags+[label, group])
         layout.group_layout(rdir[base], samples_plots)
 
     if 'acceptance_rate' in diagnostics:
@@ -364,7 +365,7 @@ for num_event, config_fnames in enumerate(infconfig_files):
         acceptance_plot = inffu.make_inference_acceptance_rate_plot(
             workflow, inference_file, rdir[base],
             analysis_seg=analysis_index,
-            tags=opts.tags+[str(num_event)])
+            tags=opts.tags+[label])
         layout.single_layout(rdir[base], acceptance_plot)
 
 # build the summary page

--- a/bin/workflows/pycbc_make_inference_workflow
+++ b/bin/workflows/pycbc_make_inference_workflow
@@ -214,6 +214,7 @@ workflow = core.Workflow(opts, opts.workflow_name + "-main")
 finalize_workflow = core.Workflow(opts, opts.workflow_name + "-finalization")
 
 # change working directory to the output
+origdir = os.path.abspath(os.curdir)
 os.chdir(opts.output_dir)
 
 # figure out what diagnostic jobs there are
@@ -271,8 +272,13 @@ for num_event, config_fnames in enumerate(infconfig_files):
     label = label.replace(' ', '_').replace(':', '_').replace('+', '_')
 
     # create a sub workflow for this event
+    # we need to go back to the original directory to do this for all the file
+    # references to work correctly
+    os.chdir(origdir)
     sub_workflow = core.Workflow(opts,
                                  "{}-{}".format(opts.workflow_name, label))
+    # now go back to the output
+    os.chdir(opts.output_dir)
 
     # write the configuration file to the config files directory
     overrides = infconfig_overrides[num_event]

--- a/bin/workflows/pycbc_make_inference_workflow
+++ b/bin/workflows/pycbc_make_inference_workflow
@@ -189,6 +189,9 @@ for num_event, time in enumerate(times):
     analysis_index = segments.segment(num_event, num_event+1)
     inference_file = node.new_output_file_opt(analysis_index, ".hdf",
                                               "--output-file")
+    if time is not None:
+        node.add_input_opt("--config-overrides",
+                           "data:trigger-time:{}".format(time))
 
     # add node to workflow
     workflow += node

--- a/bin/workflows/pycbc_make_inference_workflow
+++ b/bin/workflows/pycbc_make_inference_workflow
@@ -44,16 +44,69 @@ from pycbc import __version__
 # FIXME see https://github.com/gwastro/pycbc/issues/2349
 import pycbc.workflow.inference_followups as inffu
 
-def load_times_from_trigger_file(filename):
-    """Loads triggers from the given file.
+def load_inference_configs(config_cache):
+    """Loads configuration files from the given config file.
+    
+    Each line in the cache file should be a comma-separated list of label,
+    config file(s), overrides, deletions. If multiple config files are to be
+    used, they should be space separted. Likewise, if multiple overrides or
+    deletions are provided, they should be space separated. Overrides should be
+    formatted as ``SECTION:OPTION:VALUE``, deletions as ``SECTION:OPTION``.
+    For example::
+
+        Event 1,config1.ini config2.ini,foo:bar:2 life:meaning:42,knights:ni
+
+    Labels must be unique across all events. Otherwise, a ``ValueError`` is
+    raised.
 
     Parameters
     ----------
-    filename : str
-        The name of the file to load. Should be a simple text file with one
-        column listing gps times to analyze.
+    config_cache : str
+        The name of the cache file.
+
+    Returns
+    -------
+    labels : list
+        List of strings giving a label for each event.
+    config_files : list
+        List of the config files. Each element is itself a list providing
+        all of the config files to combine.
+    overrides : list
+        List of the overrides. Each element is itself a list of tuples giving
+        (section, option, value). If no overrides were provided for an
+        entry, that element will be ``None``.
+    deletions : list
+        List of the deletions. Each element is itself a list of tuples giving
+        (section, option). If no deletions were provided for an entry, that
+        element will be ``None``.
+        List of config files, overrides, and deletions. Config
     """
-    return numpy.loadtxt(filename, dtype=float)
+    labels = []
+    config_files = []
+    overrides = []
+    deletions = []
+    with open(config_cache, 'r') as fp:
+        for line in fp:
+            if line.startswith('#'):
+                continue
+            line = line.replace('\n', '')
+            lbl, cfs, ovs, dels = line.split(',')
+            cfs = map(os.path.abspath, cfs.strip().split())
+            ovs = [tuple(o.split(':')) for o in ovs.strip().split()]
+            if ovs == []:
+                ovs = None
+            dels = [tuple(d.split(':')) for d in dels.strip().split()]
+            if dels == []:
+                dels = None
+            labels.append(lbl.strip())
+            config_files.append(cfs)
+            overrides.append(ovs)
+            deletions.append(dels)
+    # check that the labels are unique
+    if not len(set(labels)) == len(labels):
+        raise ValueError("all labels in config cache must be unique")
+    return labels, config_files, overrides, deletions
+
 
 def to_file(path, ifo=None):
     """ Takes a str and returns a pycbc.workflow.pegasus_workflow.File
@@ -95,14 +148,19 @@ parser.add_argument("--transformation-catalog", default=None,
                     help="Path to transformation catalog file.")
 parser.add_argument("--output-file", default=None,
                     help="Path to DAX file.")
-
-# input workflow file options
-parser.add_argument("--trigger-file", default=None,
-                    help="Text file containing triggers to analyze.")
-
 # input configuration file options
-parser.add_argument("--inference-config-file", type=str, nargs='+', required=True,
-                    help="Configuration file(s) for the inference job.")
+cgroup = parser.add_mutually_exclusive_group(required=True)
+cgroup.add_argument("--inference-config-file", type=str, nargs='+',
+                    help="Configuration file(s) for the inference job. Must "
+                         "provide either this, or an inference-config-cache.")
+cgroup.add_argument("--inference-config-cache", type=str,
+                    help="A cache file listing configuration files for "
+                         "multiple events. Each line in the cache represents "
+                         "a single event, and should provide a space-"
+                         "separated list of config files to use for that "
+                         "event. If provided, will a separate inference "
+                         "analysis will be created for each event. Must "
+                         "provide either this or inference-config-file.")
 
 # add option groups
 configuration.add_workflow_command_line_group(parser)
@@ -110,8 +168,23 @@ configuration.add_workflow_command_line_group(parser)
 # parser command line
 opts = parser.parse_args()
 
+# get inference configuration file(s)
+if opts.inference_config_file is not None:
+    # means we're only anlyzing a single group
+    infconfig_files = [opts.inference_config_file]
+    infconfig_overrides = [None]
+    infconfig_deletions = [None]
+    elabels = [None]
+else:
+    # load the inference config cache
+    elabels, infconfig_files, infconfig_overrides, infconfig_deletions = \
+        load_inference_configs(opts.inference_config_cache)
+
+config_file_tmplt = 'config_files/inference-{}.ini'
+
 # make data output directory
 core.makedir(opts.output_dir)
+core.makedir('{}/{}'.format(opts.output_dir, 'config_files'))
 
 # the file we'll store all output files in
 filedir = 'output'
@@ -131,11 +204,12 @@ os.chdir(opts.output_dir)
 # sections for output HTML pages
 rdir = layout.SectionNumber("results",
                             ["detector_sensitivity", "priors", "posteriors",
-                             "samples", "workflow"])
+                             "diagnostics", "config_files", "workflow"])
 
 # make results directories
 core.makedir(rdir.base)
 core.makedir(rdir["workflow"])
+core.makedir(rdir["config_files"])
 
 # create files for workflow log
 log_file_txt = core.File(workflow.ifos, "workflow-log", workflow.analysis_time,
@@ -153,23 +227,11 @@ log_file.setFormatter(formatter)
 logging.getLogger("").addHandler(log_file)
 logging.info("Created log file %s" % log_file_txt.storage_path)
 
-# if using a trigger file
-if opts.trigger_file is not None:
-    times = load_times_from_trigger_file(opts.trigger_file)
-else:
-    times = [None]
 
 # construct Executable for running sampler
 inference_exe = core.Executable(workflow.cp, "inference",
                                 ifos=workflow.ifos, out_dir=filedir)
-
-# read inference configuration file
-# typecast str from command line to File instances
-cp = configuration.WorkflowConfigParser(opts.inference_config_file)
-with open('inference.ini', 'w') as ff:
-    cp.write(ff)
-config_file = to_file('inference.ini')
-
+ 
 # figure out what parameters user wants to plot from workflow configuration
 plot_parameters = {}
 for option in workflow.cp.options("workflow-inference"):
@@ -181,7 +243,19 @@ all_parameters = [param for group in plot_parameters.values()
                   for param in group]
 
 # loop over number of loudest events to be analyzed
-for num_event, time in enumerate(times):
+for num_event, config_fnames in enumerate(infconfig_files):
+    label = elabels[num_event]
+    if label is None:
+        label = 'Event {}'.format(num_event)
+    overrides = infconfig_overrides[num_event]
+    deletions = infconfig_deletions[num_event]
+    # write the configuration file to the config files directory
+    cp = configuration.WorkflowConfigParser(config_fnames,
+                                            overrideTuples=overrides,
+                                            deleteTuples=deletions)
+    with open(config_file_tmplt.format(num_event), 'w') as ff:
+        cp.write(ff)
+    config_file = to_file(config_file_tmplt.format(num_event))
 
     # make node for running sampler
     node = inference_exe.create_node()
@@ -189,33 +263,22 @@ for num_event, time in enumerate(times):
     analysis_index = segments.segment(num_event, num_event+1)
     inference_file = node.new_output_file_opt(analysis_index, ".hdf",
                                               "--output-file")
-    if time is not None:
-        node.add_input_opt("--config-overrides",
-                           "data:trigger-time:{}".format(time))
 
     # add node to workflow
     workflow += node
 
-    # FIXME: Should we just remove this?
-    # files that prints information about the search event
-    #if workflow_options:
-    #    coinc_table_files = [mini.make_coinc_info(workflow, single_triggers,
-    #                                     tmpltbank_file, coinc_file,
-    #                                     num_event, rdir.base,
-    #                                     tags=opts.tags + [str(num_event)])]
-
     # files for posteriors summary subsection
-    base = "posteriors"
+    base = "posteriors/{}".format(label)
     post_table_files = inffu.make_inference_summary_table(
-                          workflow, inference_file, rdir[base],
-                          variable_params=all_parameters,
-                          analysis_seg=analysis_index,
-                          tags=opts.tags)# + [str(num_event)])
+        workflow, inference_file, rdir[base],
+        variable_params=all_parameters,
+        analysis_seg=analysis_index,
+        tags=opts.tags)
     post_files = inffu.make_inference_posterior_plot(
-                          workflow, inference_file, rdir[base],
-                          parameters=all_parameters,
-                          analysis_seg=analysis_index,
-                          tags=opts.tags)# + [str(num_event)])
+        workflow, inference_file, rdir[base],
+        parameters=all_parameters,
+        analysis_seg=analysis_index,
+        tags=opts.tags)
     layout.single_layout(rdir[base], post_table_files + post_files)
 
     # files for posteriors 1d_posteriors subsection
@@ -223,7 +286,7 @@ for num_event, time in enumerate(times):
     groups.sort()
     for group in groups:
         parameters = plot_parameters[group]
-        base = "posteriors/1d_{}_posteriors".format(group)
+        base = "posteriors/{}/1d_{}_posteriors".format(label, group)
         post_1d_files = inffu.make_inference_1d_posterior_plots(
                           workflow, inference_file, rdir[base],
                           parameters=parameters,
@@ -233,7 +296,7 @@ for num_event, time in enumerate(times):
 
     if "inference_samples" in workflow.cp.options("executables"):
         # files for samples summary subsection
-        base = "samples"
+        base = "diagnostics/samples/{}".format(label)
         samples_files = []
         for parameter in all_parameters:
             samples_files += inffu.make_inference_samples_plot(
@@ -244,7 +307,7 @@ for num_event, time in enumerate(times):
 
     if "inference_rate" in workflow.cp.options("executables"):
         # files for samples acceptance_rate subsection
-        base = "samples/acceptance_rate"
+        base = "diagnostics/acceptance_rate/{}".format(label)
         acceptance_files = inffu.make_inference_acceptance_rate_plot(
                               workflow, inference_file, rdir[base],
                               analysis_seg=analysis_index,
@@ -252,22 +315,23 @@ for num_event, time in enumerate(times):
         layout.single_layout(rdir[base], acceptance_files)
 
     # files for detector_sensitivity summary subsection
-    base = "detector_sensitivity"
-    psd_file = plotting.make_spectrum_plot(workflow, [inference_file], rdir[base],
-                                     tags=opts.tags + [str(num_event)],
-                                     hdf_group="data")
+    base = "detector_sensitivity/{}".format(label)
+    psd_file = plotting.make_spectrum_plot(
+        workflow, [inference_file], rdir[base],
+        tags=opts.tags + [str(num_event)],
+        hdf_group="data")
     layout.single_layout(rdir[base], [psd_file])
 
-# files for priors summary section
-base = "priors"
-prior_files = []
-for subsection in cp.get_subsections(opts.prior_section):
-    prior_files += inffu.make_inference_prior_plot(
-                          workflow, config_file, rdir[base],
-                          analysis_seg=workflow.analysis_index,
-                          parameters=[subsection],
-                          tags=opts.tags + [subsection])
-layout.group_layout(rdir[base], prior_files)
+    # files for priors summary section
+    base = "priors/{}".format(label)
+    prior_files = []
+    for subsection in cp.get_subsections(opts.prior_section):
+        prior_files += inffu.make_inference_prior_plot(
+            workflow, config_file, rdir[base],
+            analysis_seg=workflow.analysis_index,
+            parameters=[subsection],
+            tags=opts.tags+[str(num_event), subsection])
+    layout.group_layout(rdir[base], prior_files)
 
 # files for overall summary section
 summ_files = post_table_files + post_files
@@ -280,7 +344,7 @@ results.create_versioning_page(rdir["workflow/version"], container.cp)
 
 # create node for making HTML pages
 plotting.make_results_web_page(finalize_workflow,
-                         os.path.join(os.getcwd(), rdir.base))
+    os.path.join(os.getcwd(), rdir.base))
 
 # add sub-workflows to workflow
 container += workflow
@@ -291,7 +355,8 @@ dep = dax.Dependency(parent=workflow.as_job, child=finalize_workflow.as_job)
 container._adag.addDependency(dep)
 
 # write dax
-outputfile = "{}.dax".format(opts.workflow_name) if opts.output_file == None else opts.output_file
+outputfile = "{}.dax".format(opts.workflow_name) if opts.output_file == None \
+    else opts.output_file
 container.save(filename=outputfile, output_map_path=opts.output_map,
                transformation_catalog_path=opts.transformation_catalog)
 
@@ -300,12 +365,6 @@ base = rdir["workflow/configuration"]
 core.makedir(base)
 wf_ini = workflow.save_config("workflow.ini", base, container.cp)
 layout.single_layout(base, wf_ini)
-
-# save prior configuration file
-base = rdir["priors/configuration"]
-core.makedir(base)
-prior_ini = workflow.save_config("priors.ini", base, cp)
-layout.single_layout(base, prior_ini)
 
 # close the log and flush to the html file
 logging.shutdown()

--- a/bin/workflows/pycbc_make_inference_workflow
+++ b/bin/workflows/pycbc_make_inference_workflow
@@ -261,14 +261,15 @@ plot_params = get_plot_group(workflow.cp, 'plot_parameters')
 # get parameters for the summary tables
 table_params = workflow.cp.get_opt_tag('workflow', 'table-parameters',
                                        'summary_table')
-summary_page = []
 psd_page = []
 config_files = {}
 # loop over number of loudest events to be analyzed
 for num_event, config_fnames in enumerate(infconfig_files):
+    summary_page = []
     label = elabels[num_event]
     if label is None:
         label = 'Event {}'.format(num_event)
+    summary_label = label
     label = label.replace(' ', '_').replace(':', '_').replace('+', '_')
 
     # create a sub workflow for this event
@@ -312,7 +313,6 @@ for num_event, config_fnames in enumerate(infconfig_files):
         sub_workflow, inference_file, rdir.base,
         parameters=table_params,
         analysis_seg=analysis_index,
-        result_label=label,
         tags=opts.tags+[label]),)
 
     # summary posteriors
@@ -380,8 +380,12 @@ for num_event, config_fnames in enumerate(infconfig_files):
     # add the sub workflow to the main workflow
     workflow += sub_workflow
 
-# build the summary page
-layout.two_column_layout(rdir.base, summary_page)
+    # build the summary page
+    zpad = int(numpy.ceil(numpy.log10(len(infconfig_files))))
+    layout.two_column_layout(rdir.base, summary_page,
+                             unique=str(num_event).zfill(zpad),
+                             title=summary_label, collapse=True)
+
 
 # build the psd page
 layout.group_layout(rdir['detector_sensitivity'], psd_page)

--- a/bin/workflows/pycbc_make_inference_workflow
+++ b/bin/workflows/pycbc_make_inference_workflow
@@ -140,16 +140,18 @@ parser.add_argument("--workflow-name", required=True,
                     help="Name of the workflow to append in various places.")
 parser.add_argument("--tags", nargs="+", default=[],
                     help="Tags to apend in various places.")
-parser.add_argument("--output-dir", default="output",
+parser.add_argument("--output-dir", default=None,
                     help="Path to directory where the workflow will be "
-                         "written. Default is 'output'.")
+                         "written. Default is to use "
+                         "{workflow-name}_output.")
 parser.add_argument("--output-map", default="output.map",
                     help="Path to an output map file. Default is "
-                         "'output.map'.")
+                         "output.map.")
 parser.add_argument("--transformation-catalog", default=None,
                     help="Path to transformation catalog file.")
-parser.add_argument("--output-file", default=None,
-                    help="Path to DAX file.")
+parser.add_argument("--dax-file", default=None,
+                    help="Path to DAX file. Default is to write to the "
+                         "output directory with name {workflow-name}.dax.")
 # inference options
 parser.add_argument("--seed", type=int, default=0,
                     help="Seed to use for inference job(s). If multiple "
@@ -168,7 +170,6 @@ cgroup.add_argument("--inference-config-cache", type=str,
                          "event. If provided, will a separate inference "
                          "analysis will be created for each event. Must "
                          "provide either this or inference-config-file.")
-
 # add option groups
 configuration.add_workflow_command_line_group(parser)
 
@@ -190,8 +191,15 @@ else:
 config_file_tmplt = 'config_files/inference-{}.ini'
 
 # make data output directory
+if opts.output_dir is None:
+    opts.output_dir = opts.workflow_name + '_output'
 core.makedir(opts.output_dir)
 core.makedir('{}/{}'.format(opts.output_dir, 'config_files'))
+
+# set the dax file name
+dax_file = opts.dax_file
+if dax_file is None:
+    dax_file = "{}.dax".format(opts.workflow_name)
 
 # the file we'll store all output files in
 filedir = 'output'
@@ -365,9 +373,7 @@ dep = dax.Dependency(parent=workflow.as_job, child=finalize_workflow.as_job)
 container._adag.addDependency(dep)
 
 # write dax
-outputfile = "{}.dax".format(opts.workflow_name) if opts.output_file == None \
-    else opts.output_file
-container.save(filename=outputfile, output_map_path=opts.output_map,
+container.save(filename=dax_file, output_map_path=opts.output_map,
                transformation_catalog_path=opts.transformation_catalog)
 
 # save workflow configuration file

--- a/bin/workflows/pycbc_make_inference_workflow
+++ b/bin/workflows/pycbc_make_inference_workflow
@@ -286,7 +286,7 @@ for num_event, config_fnames in enumerate(infconfig_files):
     groups.sort()
     for group in groups:
         parameters = plot_parameters[group]
-        base = "posteriors/{}/1d_{}_posteriors".format(label, group)
+        base = "posteriors/1d_{}_posteriors".format(group)
         post_1d_files = inffu.make_inference_1d_posterior_plots(
                           workflow, inference_file, rdir[base],
                           parameters=parameters,
@@ -296,7 +296,7 @@ for num_event, config_fnames in enumerate(infconfig_files):
 
     if "inference_samples" in workflow.cp.options("executables"):
         # files for samples summary subsection
-        base = "diagnostics/samples/{}".format(label)
+        base = "diagnostics/samples"
         samples_files = []
         for parameter in all_parameters:
             samples_files += inffu.make_inference_samples_plot(
@@ -307,7 +307,7 @@ for num_event, config_fnames in enumerate(infconfig_files):
 
     if "inference_rate" in workflow.cp.options("executables"):
         # files for samples acceptance_rate subsection
-        base = "diagnostics/acceptance_rate/{}".format(label)
+        base = "diagnostics/acceptance_rate"
         acceptance_files = inffu.make_inference_acceptance_rate_plot(
                               workflow, inference_file, rdir[base],
                               analysis_seg=analysis_index,
@@ -325,10 +325,10 @@ for num_event, config_fnames in enumerate(infconfig_files):
     # files for priors summary section
     base = "priors/{}".format(label)
     prior_files = []
-    for subsection in cp.get_subsections(opts.prior_section):
+    for subsection in cp.get_subsections('prior'):
         prior_files += inffu.make_inference_prior_plot(
             workflow, config_file, rdir[base],
-            analysis_seg=workflow.analysis_index,
+            analysis_seg=workflow.analysis_time,
             parameters=[subsection],
             tags=opts.tags+[str(num_event), subsection])
     layout.group_layout(rdir[base], prior_files)

--- a/pycbc/workflow/configuration.py
+++ b/pycbc/workflow/configuration.py
@@ -1044,7 +1044,7 @@ class WorkflowConfigParser(glue.pipeline.DeepCopyableConfigParser):
         except ConfigParser.Error:
             return False
 
-    def section_to_cli(self, section):
+    def section_to_cli(self, section, skip_opts=None):
         """Converts a section into a command-line string.
 
         For example:
@@ -1056,9 +1056,26 @@ class WorkflowConfigParser(glue.pipeline.DeepCopyableConfigParser):
             bar = 10
 
         yields: `'--foo --bar 10'`.
+
+        Parameters
+        ----------
+        section : str
+            The name of the section to convert.
+        skip_opts : list, optional
+            List of options to skip. Default (None) results in all options
+            in the section being converted.
+
+        Returns
+        -------
+        str :
+            The options as a command-line string.
         """
+        if skip_opts is None:
+            skip_opts = []
+        read_opts = [opt for opt in self.options(section)
+                     if opt not in skip_opts]
         opts = []
-        for opt in self.options(section):
+        for opt in read_opts:
             opts.append('--{}'.format(opt))
             val = self.get(section, opt)
             if val != '':

--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -821,13 +821,16 @@ class Workflow(pegasus_workflow.Workflow):
             The FileList object with the configuration file.
         """
         cp = self.cp if cp is None else cp
-        ini_file_path = os.path.join(output_dir, fname)
+        ini_file_path = os.path.abspath(os.path.join(output_dir, fname))
         with open(ini_file_path, "w") as fp:
             cp.write(fp)
-        ini_file = FileList([File(self.ifos, "",
-                                  self.analysis_time,
-                                  file_url="file://" + ini_file_path)])
-        return ini_file
+        ini_file = File(self.ifos, "", self.analysis_time,
+                        file_url="file://" + ini_file_path)
+        # set the physical file name
+        ini_file.PFN(ini_file_path, "local")
+        # set the storage path to be the same
+        ini_file.storage_path = ini_file_path
+        return FileList([ini_file])
 
 class Node(pegasus_workflow.Node):
     def __init__(self, executable):

--- a/pycbc/workflow/inference_followups.py
+++ b/pycbc/workflow/inference_followups.py
@@ -61,7 +61,8 @@ def setup_foreground_inference(workflow, coinc_file, single_triggers,
 
     # check if configuration file has inference section
     if not workflow.cp.has_section("workflow-inference"):
-        logging.info("There is no [workflow-inference] section in configuration file")
+        logging.info("There is no [workflow-inference] section in "
+                     "configuration file")
         logging.info("Leaving inference module")
         return
 
@@ -114,7 +115,8 @@ def setup_foreground_inference(workflow, coinc_file, single_triggers,
     # and add it to the workflow
     fil = node.output_files[0]
     job = dax.DAX(fil)
-    job.addArguments("--basename %s" % os.path.splitext(os.path.basename(name))[0])
+    job.addArguments("--basename {}".format(
+        os.path.splitext(os.path.basename(name))[0]))
     Workflow.set_job_properties(job, map_file, tc_file)
     workflow._adag.addJob(job)
 

--- a/pycbc/workflow/inference_followups.py
+++ b/pycbc/workflow/inference_followups.py
@@ -317,7 +317,8 @@ def make_inference_skymap(workflow, fits_file, output_dir,
 
 
 def make_inference_summary_table(workflow, inference_file, output_dir,
-                    parameters=None, name="inference_table",
+                    parameters=None, print_metadata=None,
+                    name="inference_table",
                     analysis_seg=None, tags=None):
     """ Sets up the corner plot of the posteriors in the workflow.
 
@@ -361,7 +362,10 @@ def make_inference_summary_table(workflow, inference_file, output_dir,
     # add command line options
     node.add_input_opt("--input-file", inference_file)
     node.new_output_file_opt(analysis_seg, ".html", "--output-file")
-    node.add_opt("--parameters", _params_for_pegasus(parameters))
+    if parameters is not None:
+        node.add_opt("--parameters", _params_for_pegasus(parameters))
+    if print_metadata is not None:
+        node.add_opt("--print-metadata", _params_for_pegasus(print_metadata))
 
     # add node to workflow
     workflow += node

--- a/pycbc/workflow/inference_followups.py
+++ b/pycbc/workflow/inference_followups.py
@@ -229,7 +229,7 @@ def create_fits_file(workflow, inference_file, output_dir,
 
 
 def make_inference_skymap(workflow, fits_file, output_dir,
-                          name="inference_skymap", analysis_seg=None,
+                          name="plot_skymap", analysis_seg=None,
                           tags=None):
     """Sets up the skymap plot.
 
@@ -244,7 +244,7 @@ def make_inference_skymap(workflow, fits_file, output_dir,
     name: str, optional
         The name in the [executables] section of the configuration file
         to use, and the section to read for additional arguments to pass to
-        the executable. Default is ``inference_skymap``.
+        the executable. Default is ``plot_skymap``.
     analysis_segs: ligo.segments.Segment, optional
        The segment this job encompasses. If None then use the total analysis
        time from the workflow.
@@ -654,7 +654,7 @@ def make_posterior_workflow(workflow, samples_files, config_file, label,
       ``plot_posterior_summary`` section; likewise, the executable used
       is read from ``plot_posterior_summary`` in the
       ``[executables]`` section.
-    * **Sky maps**: if *both* ``create_fits_file`` and ``inference_skymap``
+    * **Sky maps**: if *both* ``create_fits_file`` and ``plot_skymap``
       are listed in the ``[executables]`` section, then a ``.fits`` file and
       sky map plot will be produced. The sky map plot will be included in
       the summary plots. You must be running in a python 3 environment to
@@ -735,7 +735,7 @@ def make_posterior_workflow(workflow, samples_files, config_file, label,
 
     # figure out if we are making a skymap
     make_skymap = ("create_fits_file" in workflow.cp.options("executables") and
-                   "inference_skymap" in workflow.cp.options("executables"))
+                   "plot_skymap" in workflow.cp.options("executables"))
 
     # make node for running extract samples
     posterior_file = create_posterior_files(

--- a/pycbc/workflow/inference_followups.py
+++ b/pycbc/workflow/inference_followups.py
@@ -656,7 +656,8 @@ def get_diagnostic_plots(workflow):
     return diagnostics
 
 
-def make_diagnostic_plots(workflow, diagnostics, samples_file, label, rdir):
+def make_diagnostic_plots(workflow, diagnostics, samples_file, label, rdir,
+                          tags=None):
     """Makes diagnostic plots.
 
     Diagnostic plots are sampler-specific plots the provide information on
@@ -680,6 +681,8 @@ def make_diagnostic_plots(workflow, diagnostics, samples_file, label, rdir):
         Event label for the diagnostic plots.
     rdir : pycbc.results.layout.SectionNumber
         Results directory layout.
+    tags : list of str, optional
+        Additional tags to add to the file names.
 
     Returns
     -------
@@ -687,6 +690,9 @@ def make_diagnostic_plots(workflow, diagnostics, samples_file, label, rdir):
         Dictionary of diagnostic name -> list of files giving the plots that
         will be created.
     """
+    if tags is None:
+        tags = []
+
     out = {}
     if not isinstance(samples_file, list):
         samples_file = [samples_file]

--- a/pycbc/workflow/inference_followups.py
+++ b/pycbc/workflow/inference_followups.py
@@ -317,7 +317,6 @@ def make_inference_skymap(workflow, fits_file, output_dir,
 
 
 def make_inference_summary_table(workflow, inference_file, output_dir,
-                    result_label=None,
                     parameters=None, name="inference_table",
                     analysis_seg=None, tags=None):
     """ Sets up the corner plot of the posteriors in the workflow.
@@ -363,8 +362,6 @@ def make_inference_summary_table(workflow, inference_file, output_dir,
     node.add_input_opt("--input-file", inference_file)
     node.new_output_file_opt(analysis_seg, ".html", "--output-file")
     node.add_opt("--parameters", _params_for_pegasus(parameters))
-    if result_label is not None:
-        node.add_opt("--result-label", result_label)
 
     # add node to workflow
     workflow += node

--- a/pycbc/workflow/inference_followups.py
+++ b/pycbc/workflow/inference_followups.py
@@ -392,7 +392,7 @@ def make_inference_samples_plot(workflow, inference_file, output_dir,
 
 
 def make_inference_acceptance_rate_plot(workflow, inference_file, output_dir,
-                                        name="inference_rate",
+                                        name="inference_acceptance_rate",
                                         analysis_seg=None, tags=None):
     """Sets up a plot of the acceptance rate (for MCMC samplers).
 
@@ -407,7 +407,7 @@ def make_inference_acceptance_rate_plot(workflow, inference_file, output_dir,
     name: str, optional
         The name in the [executables] section of the configuration file
         to use, and the section to read for additional arguments to pass to
-        the executable. Default is ``inference_rate``.
+        the executable. Default is ``inference_acceptance_rate``.
     analysis_segs: ligo.segments.Segment, optional
        The segment this job encompasses. If None then use the total analysis
        time from the workflow.
@@ -542,7 +542,7 @@ def get_diagnostic_plots(workflow):
       of iteration. This will be created if ``inference_samples`` is in the
       executables section.
     * ``acceptance_rate``: For MCMC samplers, a plot of the acceptance rate.
-      This will be created if ``inference_rate`` is in the executables section.
+      This will be created if ``inference_acceptance_rate`` is in the executables section.
 
     Returns
     -------
@@ -552,7 +552,7 @@ def get_diagnostic_plots(workflow):
     diagnostics = []
     if "inference_samples" in workflow.cp.options("executables"):
         diagnostics.append('samples')
-    if "inference_rate" in workflow.cp.options("executables"):
+    if "inference_acceptance_rate" in workflow.cp.options("executables"):
         diagnostics.append('acceptance_rate')
     return diagnostics
 

--- a/pycbc/workflow/inference_followups.py
+++ b/pycbc/workflow/inference_followups.py
@@ -131,7 +131,7 @@ def make_inference_prior_plot(workflow, config_file, output_dir,
     node = make_inference_plot(workflow, config_file, output_dir,
                                name, analysis_seg=analysis_seg, tags=tags,
                                input_file_opt='config-file',
-                               add_to_worfklow=True)
+                               add_to_workflow=True)
     return node.output_files
 
 

--- a/pycbc/workflow/inference_followups.py
+++ b/pycbc/workflow/inference_followups.py
@@ -234,8 +234,8 @@ def create_posterior_files(workflow, samples_files, output_dir,
 
 
 def create_fits_file(workflow, inference_file, output_dir,
-                      name="create_fits_file",
-                      analysis_seg=None, tags=None):
+                     name="create_fits_file",
+                     analysis_seg=None, tags=None):
     """Sets up job to create fits files from some given samples files.
 
     Parameters
@@ -321,9 +321,9 @@ def make_inference_skymap(workflow, fits_file, output_dir,
 
 
 def make_inference_summary_table(workflow, inference_file, output_dir,
-                    parameters=None, print_metadata=None,
-                    name="inference_table",
-                    analysis_seg=None, tags=None):
+                                 parameters=None, print_metadata=None,
+                                 name="inference_table",
+                                 analysis_seg=None, tags=None):
     """Sets up the corner plot of the posteriors in the workflow.
 
     Parameters
@@ -512,7 +512,7 @@ def make_inference_acceptance_rate_plot(workflow, inference_file, output_dir,
 
     # make a node for plotting the acceptance rate
     node = PlotExecutable(workflow.cp, name, ifos=workflow.ifos,
-                      out_dir=output_dir, tags=tags).create_node()
+                          out_dir=output_dir, tags=tags).create_node()
 
     # add command line options
     node.add_input_opt("--input-file", inference_file)
@@ -818,7 +818,6 @@ def make_posterior_workflow(workflow, samples_files, config_file, label,
     posterior_params = get_posterior_params(workflow.cp)
 
     # figure out what parameters user wants to plot from workflow configuration
-    group_prefix = "plot-group-"
     # parameters for the summary plots
     summary_plot_params = get_plot_group(workflow.cp, 'summary_plots')
     # parameters to plot in large corner plots

--- a/pycbc/workflow/inference_followups.py
+++ b/pycbc/workflow/inference_followups.py
@@ -162,7 +162,7 @@ def make_inference_prior_plot(workflow, config_file, output_dir,
 
     # make a node for plotting the posterior as a corner plot
     node = PlotExecutable(workflow.cp, name, ifos=workflow.ifos,
-                      out_dir=output_dir, universe="local",
+                      out_dir=output_dir,
                       tags=tags).create_node()
 
     # add command line options
@@ -276,7 +276,7 @@ def make_inference_posterior_plot(
 
     # make a node for plotting the posterior as a corner plot
     node = PlotExecutable(workflow.cp, name, ifos=workflow.ifos,
-                      out_dir=output_dir, universe="local",
+                      out_dir=output_dir,
                       tags=tags).create_node()
 
     # add command line options
@@ -317,7 +317,7 @@ def make_inference_samples_plot(
 
     # make a node for plotting the posterior as a corner plot
     node = PlotExecutable(workflow.cp, name, ifos=workflow.ifos,
-                      out_dir=output_dir, universe="local",
+                      out_dir=output_dir,
                       tags=tags).create_node()
 
     # add command line options

--- a/pycbc/workflow/inference_followups.py
+++ b/pycbc/workflow/inference_followups.py
@@ -31,7 +31,7 @@ def make_inference_plot(workflow, input_file, output_dir,
                         name, analysis_seg=None,
                         tags=None, input_file_opt='input-file',
                         output_file_extension='.png',
-                        add_to_workflow=True):
+                        add_to_workflow=False):
     """Boiler-plate function for creating a standard plotting job.
 
     Parameters
@@ -57,8 +57,8 @@ def make_inference_plot(workflow, input_file, output_dir,
         What file type to create. Default is ``.png``.
     add_to_workflow : bool, optional
         If True, the node will be added to the workflow before being returned.
-        This means that no new file input or output options may be added
-        afterward. Default is True.
+        **This means that no options may be added to the node afterward.**
+        Default is ``False``.
 
     Returns
     -------
@@ -130,7 +130,8 @@ def make_inference_prior_plot(workflow, config_file, output_dir,
     """
     node = make_inference_plot(workflow, config_file, output_dir,
                                name, analysis_seg=analysis_seg, tags=tags,
-                               input_file_opt='config-file')
+                               input_file_opt='config-file',
+                               add_to_worfklow=True)
     return node.output_files
 
 
@@ -257,7 +258,8 @@ def make_inference_skymap(workflow, fits_file, output_dir,
         A list of result and output files.
     """
     node = make_inference_plot(workflow, fits_file, output_dir,
-                               name, analysis_seg=analysis_seg, tags=tags)
+                               name, analysis_seg=analysis_seg, tags=tags,
+                               add_to_workflow=True)
     return node.output_files
 
 
@@ -300,7 +302,8 @@ def make_inference_summary_table(workflow, inference_file, output_dir,
     # setup is the same, we just change the file extension
     node = make_inference_plot(workflow, inference_file, output_dir,
                                name, analysis_seg=analysis_seg, tags=tags,
-                               output_file_extension='.html')
+                               output_file_extension='.html',
+                               add_to_workflow=False)
     # now add the parameters and print metadata options; these are pulled
     # from separate sections in the workflow config file, which is why we
     # add them separately here
@@ -308,6 +311,7 @@ def make_inference_summary_table(workflow, inference_file, output_dir,
         node.add_opt("--parameters", _params_for_pegasus(parameters))
     if print_metadata is not None:
         node.add_opt("--print-metadata", _params_for_pegasus(print_metadata))
+    workflow += node
     return node.output_files
 
 
@@ -387,7 +391,8 @@ def make_inference_samples_plot(workflow, inference_file, output_dir,
         A list of output files.
     """
     node = make_inference_plot(workflow, inference_file, output_dir,
-                               name, analysis_seg=analysis_seg, tags=tags)
+                               name, analysis_seg=analysis_seg, tags=tags,
+                               add_to_workflow=True)
     return node.output_files
 
 
@@ -420,7 +425,8 @@ def make_inference_acceptance_rate_plot(workflow, inference_file, output_dir,
         A list of output files.
     """
     node = make_inference_plot(workflow, inference_file, output_dir,
-                               name, analysis_seg=analysis_seg, tags=tags)
+                               name, analysis_seg=analysis_seg, tags=tags,
+                               add_to_workflow=True)
     return node.output_files
 
 

--- a/pycbc/workflow/inference_followups.py
+++ b/pycbc/workflow/inference_followups.py
@@ -179,6 +179,7 @@ def make_inference_prior_plot(workflow, config_file, output_dir,
     return node.output_files
 
 def make_inference_summary_table(workflow, inference_file, output_dir,
+                    result_label=None,
                     parameters=None, name="inference_table",
                     analysis_seg=None, tags=None):
     """ Sets up the corner plot of the posteriors in the workflow.
@@ -224,6 +225,8 @@ def make_inference_summary_table(workflow, inference_file, output_dir,
     node.add_input_opt("--input-file", inference_file)
     node.new_output_file_opt(analysis_seg, ".html", "--output-file")
     node.add_opt("--parameters", _params_for_pegasus(parameters))
+    if result_label is not None:
+        node.add_opt("--result-label", result_label)
 
     # add node to workflow
     workflow += node

--- a/pycbc/workflow/inference_followups.py
+++ b/pycbc/workflow/inference_followups.py
@@ -210,22 +210,20 @@ def create_posterior_files(workflow, samples_files, output_dir,
     pycbc.workflow.FileList
         A list of result and output files.
     """
-    if analysis set is None:
+    if analysis_seg is None:
         analysis_seg = workflow.analysis_time
     if tags is None:
         tags = []
-    extract_posterior_exe = core.Executable(workflow.cp, name,
-                                            ifos=workflow.ifos,
-                                            out_dir=output_dir)
+    extract_posterior_exe = Executable(workflow.cp, name,
+                                       ifos=workflow.ifos,
+                                       out_dir=output_dir)
     node = extract_posterior_exe.create_node()
-    if not isinstance(sample_files, list):
-        sample_files = [sample_files]
+    if not isinstance(samples_files, list):
+        samples_files = [samples_files]
     node.add_input_list_opt("--input-file", samples_files)
     if parameters is not None:
         node.add_opt("--parameters", _params_for_pegasus(parameters))
-    posterior_file = node.new_output_file_opt(analysis_seg, ".hdf",
-                                              "--output-file",
-                                              tags=tags)
+    node.new_output_file_opt(analysis_seg, ".hdf", "--output-file", tags=tags)
     # add node to workflow
     workflow += node
     return node.output_files

--- a/pycbc/workflow/inference_followups.py
+++ b/pycbc/workflow/inference_followups.py
@@ -79,8 +79,8 @@ def make_inference_plot(workflow, input_file, output_dir,
     # properly (see _params_for_pegasus for details).
     parameters = None
     if workflow.cp.has_option(name, 'parameters'):
-        parameters = cp.get(name, 'parameters')
-        cp.remove_option(name, 'parameters')
+        parameters = workflow.cp.get(name, 'parameters')
+        workflow.cp.remove_option(name, 'parameters')
     # make a node for plotting the posterior as a corner plot
     node = PlotExecutable(workflow.cp, name, ifos=workflow.ifos,
                           out_dir=output_dir,
@@ -89,7 +89,7 @@ def make_inference_plot(workflow, input_file, output_dir,
     if parameters is not None:
         node.add_opt("--parameters", _params_for_pegasus(parameters))
         # and put the opt back in the config file in memory
-        cp.set(name, 'parameters', parameters)
+        workflow.cp.set(name, 'parameters', parameters)
     # add input and output options
     node.add_input_opt("--{}".format(input_file_opt), input_file)
     node.new_output_file_opt(analysis_seg, output_file_extension,

--- a/pycbc/workflow/inference_followups.py
+++ b/pycbc/workflow/inference_followups.py
@@ -235,6 +235,7 @@ def make_inference_summary_table(workflow, inference_file, output_dir,
 
 def make_inference_posterior_plot(
                     workflow, inference_file, output_dir, parameters=None,
+                    plot_prior_from_file=None,
                     name="inference_posterior", analysis_seg=None, tags=None):
     """ Sets up the corner plot of the posteriors in the workflow.
 
@@ -248,6 +249,8 @@ def make_inference_posterior_plot(
         The directory to store result plots and files.
     parameters : list or str
         The parameters to plot.
+    plot_prior_from_file : str, optional
+        Plot the prior from the given config file on the 1D marginal plots.
     name: str
         The name in the [executables] section of the configuration file
         to use.
@@ -281,6 +284,8 @@ def make_inference_posterior_plot(
     node.new_output_file_opt(analysis_seg, ".png", "--output-file")
     if parameters is not None:
         node.add_opt("--parameters", _params_for_pegasus(parameters))
+    if plot_prior_from_file is not None:
+        node.add_input_opt('--plot-prior', plot_prior_from_file)
 
     # add node to workflow
     workflow += node

--- a/pycbc/workflow/inference_followups.py
+++ b/pycbc/workflow/inference_followups.py
@@ -630,7 +630,7 @@ def get_plot_group(cp, section_tag):
     return plot_groups
 
 
-def get_diagnostics_plots(workflow):
+def get_diagnostic_plots(workflow):
     """Determines what diagnostic plots to create based on workflow.
 
     The plots to create are based on what executable's are specified in the
@@ -884,7 +884,7 @@ def make_posterior_workflow(workflow, samples_files, config_file, label,
             workflow, posterior_file, rdir[base],
             parameters=params, plot_prior_from_file=config_file,
             analysis_seg=analysis_seg,
-            tags=opts.tags+[label, group])
+            tags=tags+[label, group])
     layout.single_layout(rdir[base], posterior_plots)
 
     return posterior_file, summary_files, prior_plots, posterior_plots

--- a/pycbc/workflow/inference_followups.py
+++ b/pycbc/workflow/inference_followups.py
@@ -101,7 +101,7 @@ def make_inference_plot(workflow, input_file, output_dir,
 
 
 def make_inference_prior_plot(workflow, config_file, output_dir,
-                              name="inference_prior",
+                              name="plot_prior",
                               analysis_seg=None, tags=None):
     """Sets up the corner plot of the priors in the workflow.
 
@@ -116,7 +116,7 @@ def make_inference_prior_plot(workflow, config_file, output_dir,
     name: str
         The name in the [executables] section of the configuration file
         to use, and the section to read for additional arguments to pass to
-        the executable. Default is ``inference_prior``.
+        the executable. Default is ``plot_prior``.
     analysis_segs: ligo.segments.Segment, optional
        The segment this job encompasses. If None then use the total analysis
        time from the workflow.
@@ -263,7 +263,7 @@ def make_inference_skymap(workflow, fits_file, output_dir,
 
 def make_inference_summary_table(workflow, inference_file, output_dir,
                                  parameters=None, print_metadata=None,
-                                 name="inference_table",
+                                 name="table_summary",
                                  analysis_seg=None, tags=None):
     """Sets up the html table summarizing parameter estimates.
 
@@ -284,7 +284,7 @@ def make_inference_summary_table(workflow, inference_file, output_dir,
     name: str, optional
         The name in the [executables] section of the configuration file
         to use, and the section to read for additional arguments to pass to
-        the executable. Default is ``inference_table``.
+        the executable. Default is ``table_summary``.
     analysis_segs: ligo.segments.Segment, optional
        The segment this job encompasses. If None then use the total analysis
        time from the workflow.
@@ -313,7 +313,7 @@ def make_inference_summary_table(workflow, inference_file, output_dir,
 
 def make_inference_posterior_plot(workflow, inference_file, output_dir,
                                   parameters=None, plot_prior_from_file=None,
-                                  name="inference_posterior",
+                                  name="plot_posterior",
                                   analysis_seg=None, tags=None):
     """Sets up the corner plot of the posteriors in the workflow.
 
@@ -332,7 +332,7 @@ def make_inference_posterior_plot(workflow, inference_file, output_dir,
     name: str, optional
         The name in the [executables] section of the configuration file
         to use, and the section to read for additional arguments to pass to
-        the executable. Default is ``inference_posterior``.
+        the executable. Default is ``plot_posterior``.
     analysis_segs: ligo.segments.Segment, optional
        The segment this job encompasses. If None then use the total analysis
        time from the workflow.
@@ -359,7 +359,7 @@ def make_inference_posterior_plot(workflow, inference_file, output_dir,
 
 
 def make_inference_samples_plot(workflow, inference_file, output_dir,
-                                name="inference_samples",
+                                name="plot_samples",
                                 analysis_seg=None, tags=None):
     """Sets up a plot of the samples versus iteration (for MCMC samplers).
 
@@ -374,7 +374,7 @@ def make_inference_samples_plot(workflow, inference_file, output_dir,
     name: str, optional
         The name in the [executables] section of the configuration file
         to use, and the section to read for additional arguments to pass to
-        the executable. Default is ``inference_samples``.
+        the executable. Default is ``plot_samples``.
     analysis_segs: ligo.segments.Segment, optional
        The segment this job encompasses. If None then use the total analysis
        time from the workflow.
@@ -392,7 +392,7 @@ def make_inference_samples_plot(workflow, inference_file, output_dir,
 
 
 def make_inference_acceptance_rate_plot(workflow, inference_file, output_dir,
-                                        name="inference_acceptance_rate",
+                                        name="plot_acceptance_rate",
                                         analysis_seg=None, tags=None):
     """Sets up a plot of the acceptance rate (for MCMC samplers).
 
@@ -407,7 +407,7 @@ def make_inference_acceptance_rate_plot(workflow, inference_file, output_dir,
     name: str, optional
         The name in the [executables] section of the configuration file
         to use, and the section to read for additional arguments to pass to
-        the executable. Default is ``inference_acceptance_rate``.
+        the executable. Default is ``plot_acceptance_rate``.
     analysis_segs: ligo.segments.Segment, optional
        The segment this job encompasses. If None then use the total analysis
        time from the workflow.
@@ -539,10 +539,11 @@ def get_diagnostic_plots(workflow):
     plots to create. This list may contain:
 
     * ``samples``: For MCMC samplers, a plot of the sample chains as a function
-      of iteration. This will be created if ``inference_samples`` is in the
+      of iteration. This will be created if ``plot_samples`` is in the
       executables section.
     * ``acceptance_rate``: For MCMC samplers, a plot of the acceptance rate.
-      This will be created if ``inference_acceptance_rate`` is in the executables section.
+      This will be created if ``plot_acceptance_rate`` is in the executables
+      section.
 
     Returns
     -------
@@ -550,9 +551,9 @@ def get_diagnostic_plots(workflow):
         List of names of diagnostic plots.
     """
     diagnostics = []
-    if "inference_samples" in workflow.cp.options("executables"):
+    if "plot_samples" in workflow.cp.options("executables"):
         diagnostics.append('samples')
-    if "inference_acceptance_rate" in workflow.cp.options("executables"):
+    if "plot_acceptance_rate" in workflow.cp.options("executables"):
         diagnostics.append('acceptance_rate')
     return diagnostics
 
@@ -636,7 +637,7 @@ def make_posterior_workflow(workflow, samples_files, config_file, label,
     subsequent jobs use the posterior file, and so may use the parameters
     provided in ``[workflow-posterior_params]``. The following are created:
 
-    * **Summary table**: an html table created using the ``inference_table``
+    * **Summary table**: an html table created using the ``table_summary``
       executable. The parameters to print in the table are retrieved from the
       ``table-params`` option in the ``[workflow-summary_table]`` section.
       Metadata may also be printed by adding a ``print-metadata`` option to
@@ -650,8 +651,8 @@ def make_posterior_workflow(workflow, samples_files, config_file, label,
       be created for each plot group. For clarity, only one or two parameters
       should be plotted in each summary group, but this is not enforced.
       Settings for the plotting executable are read from the
-      ``inference_posterior_summary`` section; likewise, the executable used
-      is read from ``inference_posterior_summary`` in the
+      ``plot_posterior_summary`` section; likewise, the executable used
+      is read from ``plot_posterior_summary`` in the
       ``[executables]`` section.
     * **Sky maps**: if *both* ``create_fits_file`` and ``inference_skymap``
       are listed in the ``[executables]`` section, then a ``.fits`` file and
@@ -659,17 +660,17 @@ def make_posterior_workflow(workflow, samples_files, config_file, label,
       the summary plots. You must be running in a python 3 environment to
       create these.
     * **Prior plots**: plots of the prior will be created using the
-      ``inference_prior`` executable. By default, all of the variable
+      ``plot_prior`` executable. By default, all of the variable
       parameters will be plotted. The prior plots are added to
       ``priors/LALBEL/`` in the results directory, where ``LABEL`` is the
       given ``label``.
     * **Posterior plots**: additional posterior plots are created using the
-      ``inference_posterior`` executable. The parameters to plot are
+      ``plot_posterior`` executable. The parameters to plot are
       read from ``[workflow-plot_params]`` section. As with the summary
       posterior plots, parameters are grouped together by providing
       ``plot-group-NAME`` options in that section. A posterior plot will be
       created for each group, and added to the ``posteriors/LABEL/`` directory.
-      Plot settings are read from the ``[inference_posterior]`` section; this
+      Plot settings are read from the ``[plot_posterior]`` section; this
       is kept separate from the posterior summary so that different settings
       can be used. For example, you may want to make a density plot for the
       summary plots, but a scatter plot colored by SNR for the posterior plots.
@@ -754,7 +755,7 @@ def make_posterior_workflow(workflow, samples_files, config_file, label,
     for group, params in summary_plot_params.items():
         summary_plots += make_inference_posterior_plot(
             workflow, posterior_file, rdir.base,
-            name='inference_posterior_summary',
+            name='plot_posterior_summary',
             parameters=params, plot_prior_from_file=config_file,
             analysis_seg=analysis_seg,
             tags=tags+[label, group])


### PR DESCRIPTION
This updates `pycbc_make_inference_workflow` for the recent changes to `pycbc_inference` in which data is loaded from the inference config file. It also adds a number of improvements to the workflow including:
 * simplifies the options needed to be provided to `pycbc_make_inference_workflow`;
 * allows for multiple events to be analyzed at once by providing `[event]` sections in the workflow config file;
 * adds creation of posterior files from the samples files;
 * allows for multiple runs on the same event to be analyzed at once (with the results combined into a single posterior file);
 * adds jobs to create `.fits` files and sky maps (python 3 only);
 * overall cleanup of the results page;
 * fixes a number of issues with the workflow (such as how plots are named);
 * makes sampler-specific diagnositc plots (currently only `plot_samples` and `inference_rate`) optional, so the workflow can be used with both mcmc and nested samplers (to turn these off, you just remove them from the list of executables in the workflow config file);
 * adds another workflow generator, `pycbc_make_inference_plots_workflow` that just makes a posterior file and plots (i.e., everything the main workflow does except for running `pycbc_inference`).

The biggest change from a user perspective is how you specify what to analyze. Previously, you provided an `inference-config-file` on the command line to give to `pycbc_inference`; this was separate from the workflow config file. Now, you only provide a config file(s) for the workflow via the `--config-file` option. Inside of that, you provide `[event-{NAME}]` sections to specify what events to analyze. In these sections you specify the config files to give to `pycbc_inference`, using `config-files`, `config-overrides`, and `config-deletes` (same as what you would do on the command line). You can also provide an `nruns` option to have multiple inferences of `pycbc_inference` run on the same event with different starting seeds. The output from all of the instances are combined into a single posterior file for an event, with all posterior plots generated from that posterior file. You can also provide a `label` for more human-readable titles on the results page. Example:
```
[event-gw150914]
label = GW150914+09:50:45UTC
config-files = /work/cdcapano/WWW/scratch/prs/update_inference_workflow/inference_workflow_test/inference_config_files/sampler.ini
	/work/cdcapano/WWW/scratch/prs/update_inference_workflow/inference_workflow_test/inference_config_files/gw150914_like.ini
	/work/cdcapano/WWW/scratch/prs/update_inference_workflow/inference_workflow_test/inference_config_files/o1_data.ini
config-overrides = data:trigger-time:1126259462.43
nruns = 3
```
To analyze multiple events, you just provide more sections.

The `inference_plots` workflow is similar, except that you provide samples files instead of config files.

Here is the output of a test of the workflow on 3 events:
 * [with python 2.7](https://www.atlas.aei.uni-hannover.de/~work-cdcapano/scratch/prs/update_inference_workflow/inference_workflow_test/py27_inference_test_wdiag_output/html/)
 * [with python 3.6](https://www.atlas.aei.uni-hannover.de/~work-cdcapano/scratch/prs/update_inference_workflow/inference_workflow_test/py36_inference_test_wdiag_output/html/) (note the addition of the sky maps on the summary page)

These workflows were generated with the `create_workflow.sh` script[ in [this directory](https://www.atlas.aei.uni-hannover.de/~work-cdcapano/scratch/prs/update_inference_workflow/inference_workflow_test/). (The results aren't meaningful because I just ran for 100 iterations.)

A test of the `plot_samples` workflow:
 * [with python 2.7](https://www.atlas.aei.uni-hannover.de/~work-cdcapano/scratch/prs/update_inference_workflow/plots_workflow_test/py27_plots_wdiag_test_output/html/)
 * [with python 3.6](https://www.atlas.aei.uni-hannover.de/~work-cdcapano/scratch/prs/update_inference_workflow/plots_workflow_test/py36_plots_wdiag_test_output/html/)

These were generated with the `create_workflow.sh` script in [this directory](https://www.atlas.aei.uni-hannover.de/~work-cdcapano/scratch/prs/update_inference_workflow/plots_workflow_test/). (These results look better because they were generated using the samples files from 2-OGC.)

You can see how the workflow configuration files are setup in those directories, or from the results pages.

I haven't updated the PP workflow or the documentation yet. That will be done in another PR.