### PR TITLE
Add ability to turn off redshifting masses in TOV transforms

### DIFF
--- a/pycbc/transforms.py
+++ b/pycbc/transforms.py
@@ -1015,14 +1015,15 @@ class CartesianSpinToChiP(BaseTransform):
 class LambdaFromTOVFile(BaseTransform):
     """Transforms mass values corresponding to Lambda values for a given EOS
     interpolating from the mass-Lambda data for that EOS read in from an
-    external ASCII file. The interpolation of the mass-Lambda data is a
-    one-dimensional piecewise linear interpolation. The mass values to be
-    transformed are assumed to be detector frame masses, so a distance should
-    be provided along with the mass for transformation to the source frame
-    mass before the Lambda values are extracted from the interpolation. If
-    the mass value inputted is in the source frame, then provide distance=0.
-    If the transform is read in from a config file, an example code block
-    would be:
+    external ASCII file.
+
+    The interpolation of the mass-Lambda data is a one-dimensional piecewise
+    linear interpolation. If the ``redshift_mass`` keyword argument is ``True``
+    (the default), the mass values to be transformed are assumed to be detector
+    frame masses. In that case, a distance should be provided along with the
+    mass for transformation to the source frame mass before the Lambda values
+    are extracted from the interpolation. If the transform is read in from a
+    config file, an example code block would be:
 
     .. code-block:: ini
 
@@ -1045,6 +1046,20 @@ class LambdaFromTOVFile(BaseTransform):
         lambda_param = lambda1
         mass_lambda_file = filepath
 
+    If your prior is in terms of the source-frame masses (``srcmass``), then
+    you can shut off the redshifting by adding ``do-not-redshift-mass`` to the
+    config file. In this case you do not need to worry about a distance.
+    Example:
+
+    .. code-block:: ini
+
+        [{section}-lambda1]
+        name = lambda_from_tov_file
+        mass_param = srcmass1
+        lambda_param = lambda1
+        mass_lambda_file = filepath
+        do-not-redshift-mass =
+
     Parameters
     ----------
     mass_param : str
@@ -1056,8 +1071,12 @@ class LambdaFromTOVFile(BaseTransform):
         Path of the mass-Lambda data file. The first column in the data file
         should contain mass values, and the second column Lambda values.
     distance : float, optional
-        The distance (in Mpc) of the source. Used to redshift the mass. If
+        The distance (in Mpc) of the source. Used to redshift the mass. Needed
+        if ``redshift_mass`` is True and no distance parameter exists If
         None, then a distance must be provided to the transform.
+    redshift_mass : bool, optional
+        Redshift the mass parameters when computing the lambdas. Default is
+        False.
     file_columns : list of str, optional
         The names and order of columns in the ``mass_lambda_file``. Must
         contain at least 'mass' and 'lambda'. If not provided, will assume the

--- a/pycbc/transforms.py
+++ b/pycbc/transforms.py
@@ -1165,10 +1165,10 @@ class LambdaFromTOVFile(BaseTransform):
                 try:
                     d = maps['distance']
                 except KeyError as e:
-                    logging.warning("Either provide `distance` samples in the "
+                    logging.warning("Either provide distance samples in the "
                                     "list of samples to be transformed, or "
-                                    "provide a fixed `distance` value as input "
-                                    "when initializing `LambdaFromTOVFile`.")
+                                    "provide a fixed distance value as input "
+                                    "when initializing LambdaFromTOVFile.")
                     raise e
             shift = 1./(1.0 + cosmology.redshift(abs(d)))
         else:
@@ -1189,7 +1189,6 @@ class LambdaFromTOVFile(BaseTransform):
         return super(LambdaFromTOVFile, cls).from_config(
             cp, section, outputs, skip_opts=skip_opts,
             additional_opts=additional_opts)
-
 
 
 class LambdaFromMultipleTOVFiles(BaseTransform):


### PR DESCRIPTION
This adds an option to the `LambdaFromTOVFile` transform to turn off redshifting masses. This is needed if you want to use this transform with a prior that is defined in the source frame (since the masses are already redshifted). The default is to redshift, as before. To turn it off, you add `do-not-redshift-mass =` to the transform's section in the config file.

This also will check if the requested mass is larger than the maximum mass supported by the equation of state. If so, it will set lambda to 0, assuming that it is a black hole.