### PR TITLE
Restore condor checkpointing in inference

### DIFF
--- a/bin/workflows/pycbc_make_inference_workflow
+++ b/bin/workflows/pycbc_make_inference_workflow
@@ -237,9 +237,10 @@ core.makedir(rdir["config_files"])
 
 # create files for workflow log
 log_file_txt = core.File(workflow.ifos, "workflow-log", workflow.analysis_time,
-                      extension=".txt", directory=rdir["workflow"])
-log_file_html = core.File(workflow.ifos, "WORKFLOW-LOG", workflow.analysis_time,
-                        extension=".html", directory=rdir["workflow"])
+                         extension=".txt", directory=rdir["workflow"])
+log_file_html = core.File(workflow.ifos, "WORKFLOW-LOG",
+                          workflow.analysis_time,
+                          extension=".html", directory=rdir["workflow"])
 
 # switch saving log to file
 logging.basicConfig(format=log_format, level=logging.INFO,
@@ -286,7 +287,7 @@ for num_event, event in enumerate(events):
     samples_files = []
     inference_exe = PycbcInferenceExecutable(sub_workflow.cp, "inference",
                                              ifos=sub_workflow.ifos,
-                                             out_dir=samples_file_dir
+                                             out_dir=samples_file_dir)
     for nn in range(nrun):
         tags = opts.tags + [event]
         if nrun > 1:

--- a/bin/workflows/pycbc_make_inference_workflow
+++ b/bin/workflows/pycbc_make_inference_workflow
@@ -295,6 +295,7 @@ for num_event, event in enumerate(events):
         node, samples_file = inference_exe.create_node(
             config_file, seed=seed, tags=tags,
             analysis_time=sub_workflow.analysis_time)
+        samples_files.append(samples_file)
         # add node to workflow
         sub_workflow += node
         # increment the seed

--- a/bin/workflows/pycbc_make_inference_workflow
+++ b/bin/workflows/pycbc_make_inference_workflow
@@ -158,9 +158,9 @@ parser.add_argument("--version", action="version", version=__version__,
 
 # workflow options
 parser.add_argument("--workflow-name", required=True,
-                    help="Name of the workflow to append in various places.")
+                    help="Name of the workflow.")
 parser.add_argument("--tags", nargs="+", default=[],
-                    help="Tags to apend in various places.")
+                    help="Append the given tags to file names.")
 parser.add_argument("--output-dir", default=None,
                     help="Path to directory where the workflow will be "
                          "written. Default is to use "
@@ -252,7 +252,7 @@ logging.info("Created log file %s" % log_file_txt.storage_path)
 
 config_files = {}
 seed = opts.seed
-# loop over number of loudest events to be analyzed
+# loop over the events to be analyzed
 for num_event, event in enumerate(events):
     # slugify the event name so it can be used in file names
     event = event_slug(event)
@@ -283,20 +283,16 @@ for num_event, event in enumerate(events):
 
     # make node(s) for running sampler
     samples_files = []
-    inference_exe = core.Executable(sub_workflow.cp, "inference",
-                                    ifos=sub_workflow.ifos,
-                                    out_dir=samples_file_dir)
+    inference_exe = PycbcInferenceExecutable(sub_workflow.cp, "inference",
+                                             ifos=sub_workflow.ifos,
+                                             out_dir=samples_file_dir
     for nn in range(nrun):
         tags = opts.tags + [event]
         if nrun > 1:
             tags.append(str(nn))
-        node = inference_exe.create_node()
-        node.add_input_opt("--config-file", config_file)
-        node.add_opt("--seed", seed)
-        samples_file = node.new_output_file_opt(
-            sub_workflow.analysis_time, ".hdf", "--output-file",
-            tags=tags)
-        samples_files.append(samples_file)
+        node, samples_file = inference_exe.create_node(
+            config_file, seed=seed, tags=tags,
+            analysis_time=sub_workflow.analysis_time)
         # add node to workflow
         sub_workflow += node
         # increment the seed

--- a/bin/workflows/pycbc_make_inference_workflow
+++ b/bin/workflows/pycbc_make_inference_workflow
@@ -41,6 +41,7 @@ from pycbc.workflow import datafind
 from pycbc.workflow import plotting
 from pycbc import __version__
 import pycbc.workflow.inference_followups as inffu
+from pycbc.workflow.jobsetup import PycbcInferenceExecutable
 
 
 def read_events_from_config(cp):

--- a/pycbc/workflow/jobsetup.py
+++ b/pycbc/workflow/jobsetup.py
@@ -1806,29 +1806,25 @@ class PycbcInferenceExecutable(Executable):
     """
 
     current_retention_level = Executable.ALL_TRIGGERS
-    def __init__(self, cp, exe_name, ifo=None, out_dir=None,
+    def __init__(self, cp, exe_name, ifos=None, out_dir=None,
                  universe=None, tags=None):
-        super(PycbcInferenceExecutable, self).__init__(cp, exe_name, universe,
-                                                       ifo, out_dir, tags)
+        super(PycbcInferenceExecutable, self).__init__(cp, exe_name,
+                                                       universe=universe,
+                                                       ifos=ifos,
+                                                       out_dir=out_dir,
+                                                       tags=tags)
 
-    def create_node(self, channel_names, config_file, injection_file=None,
-                    seed=None, fake_strain_seed=None, tags=None):
+    def create_node(self, config_file, seed=None, tags=None,
+                    analysis_time=None):
         """ Set up a CondorDagmanNode class to run ``pycbc_inference``.
 
         Parameters
         ----------
-        channel_names : dict
-            A ``dict`` of ``str`` to use for ``--channel-name`` option.
         config_file : pycbc.workflow.core.File
             A ``pycbc.workflow.core.File`` for inference configuration file
             to be used with ``--config-files`` option.
-        injection_file : pycbc.workflow.core.File
-            A ``pycbc.workflow.core.File`` for injection file to be used
-            with ``--injection-file`` option.
         seed : int
             An ``int`` to be used with ``--seed`` option.
-        fake_strain_seed : dict
-            An ``int`` to be used with ``--fake-strain-seed`` option.
         tags : list
             A list of tags to include in filenames.
 
@@ -1837,40 +1833,21 @@ class PycbcInferenceExecutable(Executable):
         node : pycbc.workflow.core.Node
             The node to run the job.
         """
-
         # default for tags is empty list
         tags = [] if tags is None else tags
-
-        # get analysis start and end time
-        start_time = self.cp.get("workflow", "start-time")
-        end_time = self.cp.get("workflow", "end-time")
-        analysis_time = segments.segment(int(start_time), int(end_time))
-
-        # get multi-IFO opts
-        channel_names_opt = " ".join(["{}:{}".format(k, v)
-                                      for k, v in channel_names.items()])
-        if fake_strain_seed is not None:
-            fake_strain_seed_opt = " ".join([
-                                    "{}:{}".format(k, v)
-                                    for k, v in fake_strain_seed.items()])
-
+        # if analysis time not provided, try to get it from the config file
+        if analysis_time is None:
+            start_time = self.cp.get("workflow", "start-time")
+            end_time = self.cp.get("workflow", "end-time")
+            analysis_time = segments.segment(int(start_time), int(end_time))
         # make node for running executable
         node = Node(self)
-        node.add_opt("--instruments", " ".join(self.ifo_list))
-        node.add_opt("--gps-start-time", start_time)
-        node.add_opt("--gps-end-time", end_time)
-        node.add_opt("--channel-name", channel_names_opt)
         node.add_input_opt("--config-file", config_file)
-        if fake_strain_seed is not None:
-            node.add_opt("--fake-strain-seed", fake_strain_seed_opt)
-        if injection_file:
-            node.add_input_opt("--injection-file", injection_file)
-        if seed:
+        if seed is not None:
             node.add_opt("--seed", seed)
         inference_file = node.new_output_file_opt(analysis_time,
                                                   ".hdf", "--output-file",
                                                   tags=tags)
-
         if self.cp.has_option("pegasus_profile-inference",
                               "condor|+CheckpointSig"):
             ckpt_file_name = "{}.checkpoint".format(inference_file.name)


### PR DESCRIPTION
In #3140, I inadvertently removed the condor checkpointing for inference jobs that was implemented in #2596. When setting up the inference nodes, I used `core.Executable`. I didn't realize there was a `PycbcInferenceExecutable` class in `jobsetup.py` that had extra things added to its `create_node` function to alert condor about the checkpoint file. This switches back to using that class in `jobsetup.py`, and updates that class to remove data-related things that are no longer set on the command line.