### PR TITLE
numpy hstack FutureWarning fix

### DIFF
--- a/pycbc/events/veto.py
+++ b/pycbc/events/veto.py
@@ -65,7 +65,7 @@ def indices_within_times(times, start, end):
     if len(left) == 0:
         return numpy.array([], dtype=numpy.uint32)
 
-    return tsort[numpy.hstack(numpy.r_[s:e] for s, e in zip(left, right))]
+    return tsort[numpy.hstack([numpy.r_[s:e] for s, e in zip(left, right)])]
 
 def indices_outside_times(times, start, end):
     """


### PR DESCRIPTION
Numpy hstack is giving a FutureWarning that generators will not be allowed as input - this changes the input to hstack from a generator to a list