### PR TITLE
Add functions to set matplotlib style

### DIFF
--- a/bin/hdfcoinc/pycbc_plot_psd_file
+++ b/bin/hdfcoinc/pycbc_plot_psd_file
@@ -132,4 +132,5 @@ pycbc.results.save_fig_with_metadata(fig, args.output_file,
     caption="Median amplitude spectral density plotted with a shaded region " 
               "between the 5th and 95th perentiles. ",
     cmd=' '.join(sys.argv),
-    fig_kwds={'dpi': 200})
+    fig_kwds={'dpi': 200,
+              'bbox_inches': 'tight'})

--- a/bin/hdfcoinc/pycbc_plot_psd_file
+++ b/bin/hdfcoinc/pycbc_plot_psd_file
@@ -38,7 +38,11 @@ parser.add_argument("--memory-limit", default=2., type=float, metavar="X GB",
                          "clusters, this defaults to 2GB if this option is "
                          "not provided explicitly.")
 pycbc.psd.insert_psd_option_group(parser, output=False)
+pycbc.results.add_style_opt_to_parser(parser)
 args = parser.parse_args()
+
+# set the matplotlib style
+pycbc.results.set_style_from_cli(args)
 
 fig = pylab.figure(0)
 ax = fig.gca()

--- a/bin/inference/pycbc_inference_plot_movie
+++ b/bin/inference/pycbc_inference_plot_movie
@@ -47,8 +47,8 @@ from multiprocessing import Pool
 
 import numpy
 
-from matplotlib import use
-use('agg')
+import matplotlib
+matplotlib.use('agg')
 from matplotlib import pyplot
 
 import pycbc.results
@@ -58,6 +58,7 @@ from pycbc.inference import (option_utils, io)
 
 from pycbc.results.scatter_histograms import (create_multidim_plot,
                                               get_scale_fac)
+from pycbc.results.plot import (add_style_opt_to_parser, set_style_from_cli)
 
 
 def integer_logspace(start, end, num):
@@ -153,8 +154,13 @@ option_utils.add_plot_posterior_option_group(parser)
 # add scatter and density configuration options
 option_utils.add_scatter_option_group(parser) 
 option_utils.add_density_option_group(parser)
+add_style_opt_to_parser(parser)
 
 opts = parser.parse_args()
+
+# set mpl style
+set_style_from_cli(opts)
+
 pycbc.init_logging(opts.verbose)
 
 if len(opts.input_file) > 1:
@@ -282,6 +288,24 @@ for p in parameters:
     if p not in maxs:
         maxs[p] = samples[p].max()
 
+# set colors:
+# the 1d marginal colors will just be the first color in the style's cycle
+linecolor = list(matplotlib.rcParams['axes.prop_cycle'])[0]['color']
+# make the hist color black or white, depending on if the
+# dark background is used
+if opts.mpl_style == 'dark_background':
+    hist_color = 'white'
+else:
+    hist_color = 'black'
+# make the default contour color white if plot density is on
+if not opts.contour_color and opts.plot_density:
+    contour_color = 'white'
+# otherwise, make the default be the same as the hist color
+elif not opts.contour_color:
+    contour_color = hist_color
+else:
+    contour_color = opts.contour_color
+
 # Make each figure
 # for sorting purposes, we will need to zero-pad the sample number with the
 # appriopriate number of 0's
@@ -302,6 +326,8 @@ def _make_frame(frame):
     fig, axis_dict = create_multidim_plot(parameters, plotargs, labels=labels,
                         mins=mins, maxs=maxs,
                         plot_marginal=opts.plot_marginal,
+                            line_color=linecolor,
+                            hist_color=hist_color,
                         plot_scatter=opts.plot_scatter,
                             zvals=z, show_colorbar=show_colorbar,
                             cbar_label=zlbl, vmin=vmin, vmax=vmax,
@@ -309,7 +335,7 @@ def _make_frame(frame):
                         plot_density=opts.plot_density,
                         plot_contours=opts.plot_contours,
                             density_cmap=opts.density_cmap,
-                            contour_color=opts.contour_color,
+                            contour_color=contour_color,
                             use_kombine=opts.use_kombine_kde,
                         expected_parameters=expected_parameters,
                         expected_parameters_color=expected_parameters_color)
@@ -328,6 +354,7 @@ def _make_frame(frame):
 
     fig.savefig(output, bbox_inches='tight', dpi=opts.dpi)
     pyplot.close()
+    return fig.get_figheight()/fig.get_figwidth()
 
 # create the pool
 if opts.nprocesses is None or opts.nprocesses > 1:
@@ -340,14 +367,16 @@ else:
     mfunc = map
 
 logging.info("Making frames")
-mfunc(make_frame, range(len(indices)))
+aspect_ratio = list(mfunc(make_frame, range(len(indices))))[0]
 
 if opts.movie_file:
     logging.info("Making movie")
     frame_files = opts.output_prefix + "*.png"
+    # set the aspect ratio
+    aspect_ratio = "1024x{}".format(int(1024*aspect_ratio))
     if os.path.isfile(opts.movie_file):
         os.remove(opts.movie_file)
-    subprocess.call(["ffmpeg", "-pix_fmt", "yuv420p", "-s", "1024x768",
+    subprocess.call(["ffmpeg", "-pix_fmt", "yuv420p", "-s", aspect_ratio,
                      "-pattern_type", "glob", "-i",
                      frame_files, opts.movie_file])
     if opts.cleanup:

--- a/bin/inference/pycbc_inference_plot_posterior
+++ b/bin/inference/pycbc_inference_plot_posterior
@@ -283,10 +283,11 @@ fig.set_dpi(opts.dpi)
 
 # save
 metadata.save_fig_with_metadata(
-                 fig, opts.output_file, {},
+                 fig, opts.output_file,
                  cmd=" ".join(sys.argv),
                  title="Posteriors",
-                 caption="Posterior probability density functions.")
+                 caption="Posterior probability density functions.",
+                 fig_kwds={'bbox_inches': 'tight'})
 
 # finish
 logging.info("Done")

--- a/bin/inference/pycbc_inference_plot_posterior
+++ b/bin/inference/pycbc_inference_plot_posterior
@@ -37,7 +37,7 @@ from matplotlib import (patches, use)
 
 import pycbc
 import pycbc.version
-from pycbc.results.plot import (add_style_opt_to_parser, set_style_from_cli) 
+from pycbc.results.plot import (add_style_opt_to_parser, set_style_from_cli)
 from pycbc.results import metadata
 from pycbc.io import FieldArray
 from pycbc import __version__

--- a/bin/inference/pycbc_inference_plot_posterior
+++ b/bin/inference/pycbc_inference_plot_posterior
@@ -32,10 +32,12 @@ import sys
 
 import numpy
 
+import matplotlib
 from matplotlib import (patches, use)
 
 import pycbc
 import pycbc.version
+from pycbc.results.plot import (add_style_opt_to_parser, set_style_from_cli) 
 from pycbc.results import metadata
 from pycbc.io import FieldArray
 from pycbc import __version__
@@ -70,9 +72,14 @@ option_utils.add_scatter_option_group(parser)
 option_utils.add_density_option_group(parser)
 parser.add_argument('--dpi', type=int, default=200,
                     help="Set the DPI of the plot. Default is 200.")
+# style option
+add_style_opt_to_parser(parser)
 
 # parse command line
 opts = parser.parse_args()
+
+# set mpl style
+set_style_from_cli(opts)
 
 # set logging
 pycbc.init_logging(opts.verbose)
@@ -180,8 +187,9 @@ if opts.plot_injection_parameters:
 # get expected parameter values from command line
 expected_parameters.update(option_utils.expected_parameters_from_cli(opts))
 
-# assign some colors
-colors = itertools.cycle(["black"] + ["C{}".format(i) for i in range(10)])
+# get the color cycle to use
+color_cycle = [c['color'] for c in matplotlib.rcParams['axes.prop_cycle']]
+colors = itertools.cycle(color_cycle)
 
 # plot each input file
 logging.info("Plotting")
@@ -193,19 +201,34 @@ for (i, s) in enumerate(samples):
         fig = None
         axis_dict = None
 
-    # loop over some contour colors
-    contour_color = next(colors) if not opts.contour_color \
-        else opts.contour_color
+    # get a default line color; this is used for the 1D marginal lines
+    linecolor = next(colors)
+    # set different colors depending on if one or more files was provided
+    if len(opts.input_file) == 1:
+        # make the hist color black or white, depending on if dark background
+        # is used
+        if opts.mpl_style == 'dark_background':
+            hist_color = 'white'
+        else:
+            hist_color = 'black'
+        # make histograms filled if only one input file to plot
+        fill_color = 'gray'
+        # make the default contour color white if plot density is on
+        if not opts.contour_color and opts.plot_density:
+            contour_color = 'white'
+        # otherwise, make the default be the same as the hist color
+        elif not opts.contour_color:
+            contour_color = hist_color
+        else:
+            contour_color = opts.contour_color
+    else:
+        # don't fill in the histograms
+        fill_color = None
+        # make the contour and hist colors the same as the 1D marginal lines
+        contour_color = hist_color = linecolor
 
-    # make histograms filled if only one input file to plot
-    fill_color = "gray" if len(opts.input_file) == 1 else None
-
-    # make histogram black lines if only one
-    hist_color = "black" if len(opts.input_file) == 1 else contour_color
+    # save the hist color for the legend, in the case of multiple files
     hist_colors.append(hist_color)
-
-    # pick a new color for each input file
-    linecolor = "navy" if len(opts.input_file) == 1 else contour_color
 
     # plot
     fig, axis_dict = create_multidim_plot(

--- a/pycbc/results/plot.py
+++ b/pycbc/results/plot.py
@@ -21,7 +21,7 @@ def hist_overflow(val, val_max, **kwds):
 
 def add_style_opt_to_parser(parser, default=None):
     """Adds an option to set the matplotlib style to a parser.
-    
+
     Parameters
     ----------
     parser : argparse.ArgumentParser
@@ -31,7 +31,7 @@ def add_style_opt_to_parser(parser, default=None):
         matplotlib style to be used.
     """
     from matplotlib import pyplot
-    parser.add_argument('--mpl-style', default=None,
+    parser.add_argument('--mpl-style', default=default,
                         choices=['default']+pyplot.style.available+['xkcd'],
                         help='Set the matplotlib style to use.')
 

--- a/pycbc/results/plot.py
+++ b/pycbc/results/plot.py
@@ -18,3 +18,32 @@ def hist_overflow(val, val_max, **kwds):
         pylab.text(rect.get_x(),
                    1.10*rect.get_height(), '%s+' % val_max)
 
+
+def add_style_opt_to_parser(parser, default=None):
+    """Adds an option to set the matplotlib style to a parser.
+    
+    Parameters
+    ----------
+    parser : argparse.ArgumentParser
+        The parser to add the option to.
+    default : str, optional
+        The default style to use. Default, None, will result in the default
+        matplotlib style to be used.
+    """
+    from matplotlib import pyplot
+    parser.add_argument('--mpl-style', default=None,
+                        choices=['default']+pyplot.style.available+['xkcd'],
+                        help='Set the matplotlib style to use.')
+
+
+def set_style_from_cli(opts):
+    """Uses the mpl-style option to set the style for plots.
+
+    Note: This will change the global rcParams.
+    """
+    from matplotlib import pyplot
+    if opts.mpl_style == 'xkcd':
+        # this is treated differently for some reason
+        pyplot.xkcd()
+    elif opts.mpl_style is not None:
+        pyplot.style.use(opts.mpl_style)


### PR DESCRIPTION
This adds functions to `pycbc.results.plot` that will allow you to set the style used by matplotlib. 

Matplotlib provides a bunch of different style settings; see [here](https://matplotlib.org/3.1.1/gallery/style_sheets/style_sheets_reference.html) for a reference. This can be useful if you'd like to make colorblind-friendly plots, or want a black background for a talk.

To add this feature to a program, you add the option to the program's argument parser via:
```
pycbc.results.add_style_opt_to_parser(parser) 
```
This will add a `--mpl-style` option. After parsing the command line, tou then add:
```
pycbc.results.set_style_from_cli(opts) 
```
That will update matplotlib's `rcParams` with the requested style. If the `mpl-style` isn't set, it will just use the default (leaving things unchanged).

In this patch, I've only added this functionality to `pycbc_inference_plot_posterior`, `pycbc_inference_plot_movie`, and `pycbc_plot_psd_files`.  If anyone wants to extend this functionality to other plotting programs in pycbc, they just need to do the above.

I've also fixed a few issues I noticed while testing this with these programs:
 * use `bbox_inches=tight` in `plot_posterior` and `plot_psd`; this prevents the plot from going off the edge of the figure for some style settings
 * fix the aspect ratio in `plot_movie` to the figure's aspect ratio, so you don't get blurry, skewed mp4s

Some examples:
 * [posterior with dark background](https://www.atlas.aei.uni-hannover.de/~work-cdcapano/scratch/prs/mpl_style/plot_posterior/scatter_test_dark_background.png)
 * [movie with dark background](https://www.atlas.aei.uni-hannover.de/~work-cdcapano/scratch/prs/mpl_style/plot_movie/test_dark_background.mp4)
 * [psd with dark background](https://www.atlas.aei.uni-hannover.de/~work-cdcapano/scratch/prs/mpl_style/plot_psd/test_dark_background.png)

Also, for no useful purpose whatsoever, matplotlib has the ability to make plots in xkcd style, so...
 * [psd in xkcd](https://www.atlas.aei.uni-hannover.de/~work-cdcapano/scratch/prs/mpl_style/plot_psd/test_xkcd.png)