### PR TITLE
Keep groups when extracting posterior from multiple files

### DIFF
--- a/bin/inference/pycbc_inference_extract_samples
+++ b/bin/inference/pycbc_inference_extract_samples
@@ -29,7 +29,12 @@ posterior HDF file. Parameters can be renamed in the output file using the
 --parameters option.
 
 If more than one file is provided, the samples from all of the files will
-be combined.
+be combined. Some attempt is made to check that the files share common
+attributes. Sampler info (stored in the 'sampler_info' group) will not be
+written when multiple files are combined. All other groups, unless explicitly
+skipped (see the --skip-groups option), will be written using the first file.
+No attempt is made to check that the data in these other groups is the same
+across combined files.
 """
 
 import os
@@ -75,11 +80,11 @@ parser.add_argument("--force", action="store_true", default=False,
 parser.add_argument("--skip-groups", default=None, nargs="+",
                     help="Don't write the specified groups in the output "
                          "(aside from samples; samples are always written), "
-                         "for example, 'sampler_info'. If 'all' write skip "
+                         "for example, 'sampler_info'. If 'all' skip "
                          "all groups, only writing the samples. Default is "
-                         "to write all groups if only one file is provided. "
-                         "If multiple files are provided, only the samples "
-                         "will be written.")
+                         "to write all groups if only one file is provided, "
+                         "and all groups from the first file except "
+                         "sampler_info if multiple files are provided.")
 parser.add_argument("--verbose", action="store_true", default=False,
                     help="Be verbose")
 
@@ -156,14 +161,19 @@ for fp in fps:
 # store what parameters were renamed
 out.attrs['remapped_params'] = list(labels.items())
 
-# write the other groups
-if len(opts.input_file) == 1:
-    fp = fps[0]
-    skip_groups = opts.skip_groups
-    if skip_groups is not None and 'all' in opts.skip_groups:
-        skip_groups = [group for group in fp.keys()
-                       if group != fp.samples_group]
-    fp.copy_info(out, ignore=skip_groups)
+# write the other groups using the first file
+fp = fps[0]
+skip_groups = opts.skip_groups
+if skip_groups is not None and 'all' in opts.skip_groups:
+    skip_groups = [group for group in fp.keys()
+                   if group != fp.samples_group]
+# don't write the sampler info if more than one file was provided
+if len(opts.input_file) > 1:
+    if skip_groups is None:
+        skip_groups = []
+    skip_groups.append('sampler_info')
+
+fp.copy_info(out, ignore=skip_groups)
 
 # close and exit
 for fp in fps:


### PR DESCRIPTION
Currently, `pycbc_inference_extract_samples` will only write out the samples group if a posterior is extracted from multiple files. This means you lose the `data` and `injections` in the posterior file if you do a run which combines results from multiple files. That prevents you from using plotting programs (like a PP test) that need the injection data to be present in the posterior file.

This fixes that by only skipping the `sampler_info` group when multiple files are provided. The `data` and `injections` are taken from the first file. No attempt is made to check that they are the same in this case, but the user is warned about that in the help message. If someone doesn't want that, they can always explicitly not write those groups using the `--skip-groups` option.