### PR TITLE
Option to map injection parameters to inference samples

### DIFF
--- a/bin/inference/pycbc_inference_plot_inj_recovery
+++ b/bin/inference/pycbc_inference_plot_inj_recovery
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-""" Plots the recovered versus injected parameter values from a population
+"""Plots the recovered versus injected parameter values from a population
 of injections.
 """
 
@@ -17,8 +17,7 @@ from pycbc import __version__
 from pycbc.inference import (option_utils, io)
 
 # parse command line
-parser = io.ResultsArgumentParser(description="Plots the recovered versus injected parameter values "
-                                               "from a population.")
+parser = io.ResultsArgumentParser(description=__doc__)
 
 parser.add_argument("--version", action="version", version=__version__,
                     help="Prints version information.")
@@ -26,9 +25,10 @@ parser.add_argument("--output-file", required=True, type=str,
                     help="Path to save output plot.")
 parser.add_argument("--verbose", action="store_true",
                     help="Allows print statements.")
-parser.add_argument("--quantiles", nargs=2, type=float, default=[0.05, 0.95],
-                    help="Quantiles to use as limits.")
+parser.add_argument("--percentiles", nargs=2, type=float, default=[5, 95],
+                    help="Percentiles to use as limits.")
 option_utils.add_scatter_option_group(parser)
+option_utils.add_injsamples_map_opt(parser)
 opts = parser.parse_args()
 
 # set logging
@@ -80,14 +80,14 @@ for i, (input_file, input_fp, input_samples) in enumerate(zip(opts.input_file,
     # get paramter values
     sampled_vals = input_samples[parameter]
     injected_vals = injs[parameter][i]
-    # compute quantiles of sampled results
-    quantiles = numpy.array([numpy.percentile(sampled_vals, 100 * q)
-                             for q in opts.quantiles])
+    # compute percentiles of sampled results
+    percentiles = numpy.array([numpy.percentile(sampled_vals, p)
+                             for p in opts.percentiles])
 
     # get median and lowest and highest quntiles for plotting
     med = numpy.median(sampled_vals)
-    high = quantiles.max()
-    low = quantiles.min()
+    high = percentiles.max()
+    low = percentiles.min()
 
     # get color
     if opts.z_arg:

--- a/bin/inference/pycbc_inference_plot_pp
+++ b/bin/inference/pycbc_inference_plot_pp
@@ -55,6 +55,7 @@ parser.add_argument("--do-ks-test", action="store_true", default=False,
                     help="Perform a KS test between the percentile-percentile "
                          "plot for each parameter and the (expected) uniform "
                          "distribution. Results are printed in the legend.")
+option_utils.add_injsamples_map_opt(parser)
 pycbc.results.plot.add_style_opt_to_parser(parser,
                                            default='seaborn-colorblind')
 opts = parser.parse_args()

--- a/bin/inference/pycbc_inference_pp_table_summary
+++ b/bin/inference/pycbc_inference_pp_table_summary
@@ -26,6 +26,7 @@ import sys
 from scipy import stats
 import pycbc
 from pycbc import results
+from pycbc.inference.option_utils import add_injsamples_map_opt
 from pycbc.inference.io import (ResultsArgumentParser, results_from_cli,
                                 injections_from_cli)
 
@@ -34,6 +35,7 @@ parser.add_argument("--verbose", action="store_true", default=False,
     help="Print logging info.")
 parser.add_argument("--output-file", type=str, required=True,
     help="Path to output plot.")
+add_injsamples_map_opt(parser)
 
 # parse the command line
 opts = parser.parse_args()

--- a/pycbc/inference/option_utils.py
+++ b/pycbc/inference/option_utils.py
@@ -136,6 +136,22 @@ class ParseParametersArg(ParseLabelArg):
                 pass
 
 
+def add_injsamples_map_opt(parser):
+    """Adds option to parser to specify a mapping between injection parameters
+    an sample parameters.
+    """
+    parser.add_argument('--injection-samples-map', nargs='+',
+                        metavar='INJECTION_PARAM:SAMPLES_PARAM',
+                        help='Rename/apply functions to the injection '
+                             'parameters and name them the same as one of the '
+                             'parameters in samples. This can be used if the '
+                             'injection parameters are not the same as the '
+                             'samples parameters. INJECTION_PARAM may be a '
+                             'function of the injection parameters; '
+                             'SAMPLES_PARAM must a name of one of the '
+                             'parameters in the samples group.')
+
+
 def add_plot_posterior_option_group(parser):
     """Adds the options needed to configure plots of posterior results.
 
@@ -200,6 +216,7 @@ def add_plot_posterior_option_group(parser):
                              "injection in the file to work. Any values "
                              "specified by expected-parameters will override "
                              "the values obtained for the injection.")
+    add_injsamples_map_opt(pgroup)
     return pgroup
 
 


### PR DESCRIPTION
In an inference file, the injection parameters may not be the same as the samples. For example, if you specified the injection's spin parameters in cartesian coordinates, but you used a prior uniform in spherical coordinates, the samples will have `spin1_(a,azimuthal,polar)` while the injection will have `spin1(x,y,z)`. Or, say you added an mchirp column to the samples in a posterior file; the injection group will still only have `mass1` and `mass2`. This is problematic for plotting results in which you want to compare the injected value to the recovered. It particularly a problem for PP tests, where you need to know which injection parameters correspond to which samples.

This adds an `--injection-samples-map` option which allows you to specify a mapping between injection and samples parameters. The option is added to `pycbc_inference_plot_posterior`, `plot_movie`, `plot_pp`, `pp_summary_table`, and `plot_inj_recovery`.

Example: here I've extracted a posterior file to have samples columns mass1, mass2, and mchirp, with mass1 >= mass2. The injection was specified with mass2 > mass1, and has no mchirp (since it isn't needed to generate the injection). If I run `plot_posterior` and ask it to show the injected parameters without providing any mapping (like it is now),
```
pycbc_inference_plot_posterior \
    --input-file posterior.hdf \
    --output-file plot_posterior_test.png \
    --plot-scatter --plot-marginal --z-arg snr \
    --parameters mass1 mass2 mchirp \
    --plot-injection-parameters
```
I get: [posterior without mapping](https://www.atlas.aei.uni-hannover.de/~work-cdcapano/scratch/prs/injsamples_map/plot_posterior_test-no_map.png)

Adding:
```
--injection-samples-map \
    'primary_mass(mass1, mass2):mass1' \
    'secondary_mass(mass1, mass2):mass2' \
    'mchirp_from_mass1_mass2(mass1, mass2):mchirp'
```
I get: [posterior with mapping](https://www.atlas.aei.uni-hannover.de/~work-cdcapano/scratch/prs/injsamples_map/plot_posterior_test.png). Note that the red lines now show mass1 > mass2, and there is a line on the expected mchirp.

Putting on hold because depends on #3148 and #3150.