### PR TITLE
Add wildcard to parameters option

### DIFF
--- a/bin/inference/pycbc_inference_extract_samples
+++ b/bin/inference/pycbc_inference_extract_samples
@@ -69,6 +69,15 @@ parser = ResultsArgumentParser(defaultparams='all', autoparamlabels=False,
 
 parser.add_argument("--output-file", type=str, required=True,
                     help="Output file to create.")
+parser.add_argument("-g", "--greedy", action="store_true", default=False,
+                    help="Add any parameters not used in the parameters "
+                         "option to the output. For example, if the file "
+                         "contains mass1, mass2, and distance and "
+                         "--parameters is set to "
+                         "'primary_mass(mass1, mass2):mass1', then the output "
+                         "will contain mass1 and distance if this flag is "
+                         "turned on. Otherwise, the output would just contain "
+                         "mass1.")
 parser.add_argument("--force", action="store_true", default=False,
                     help="If the output-file already exists, overwrite it. "
                          "Otherwise, an IOError is raised.")

--- a/bin/inference/pycbc_inference_extract_samples
+++ b/bin/inference/pycbc_inference_extract_samples
@@ -69,15 +69,6 @@ parser = ResultsArgumentParser(defaultparams='all', autoparamlabels=False,
 
 parser.add_argument("--output-file", type=str, required=True,
                     help="Output file to create.")
-parser.add_argument("-g", "--greedy", action="store_true", default=False,
-                    help="Add any parameters not used in the parameters "
-                         "option to the output. For example, if the file "
-                         "contains mass1, mass2, and distance and "
-                         "--parameters is set to "
-                         "'primary_mass(mass1, mass2):mass1', then the output "
-                         "will contain mass1 and distance if this flag is "
-                         "turned on. Otherwise, the output would just contain "
-                         "mass1.")
 parser.add_argument("--force", action="store_true", default=False,
                     help="If the output-file already exists, overwrite it. "
                          "Otherwise, an IOError is raised.")

--- a/pycbc/inference/io/__init__.py
+++ b/pycbc/inference/io/__init__.py
@@ -600,7 +600,7 @@ class ResultsArgumentParser(argparse.ArgumentParser):
                  "If '*' is provided in addition to other parameters names, "
                  "then parameters will be loaded in a greedy fashion; i.e., "
                  "all other parameters that exist in the file(s) that are not "
-                 "explicitly mentioned will also be loaded. For example,"
+                 "explicitly mentioned will also be loaded. For example, "
                  "if the input-file(s) contains 'srcmass1', "
                  "'srcmass2', and 'distance', and  "
                  "\"'primary_mass(srcmass1, srcmass2):mass1' '*'\", is given "

--- a/pycbc/inference/io/__init__.py
+++ b/pycbc/inference/io/__init__.py
@@ -508,8 +508,11 @@ class ResultsArgumentParser(argparse.ArgumentParser):
             used_params = FieldArray.parse_parameters(opts.parameters,
                                                       all_params)
             add_params = set(all_params) - set(used_params)
-            # add them
-            opts.parameters += list(add_params)
+            # repopulate the name space with the additional parameters
+            if add_params:
+                opts.parameters += list(add_params)
+                # update the labels
+                opts.parameters_labels.update({p: p for p in add_params})
         # parse the sampler-specific options and check for any unknowns
         unknown = []
         for fn in opts.input_file:


### PR DESCRIPTION
Currently, if you provide a `--parameters` option to programs that use `pycbc.inference.io.ResultsArgumentParser`, then only the parameters that are listed will be loaded. This patch adds the ability to also pass a wildcard (`'*'`). If that is given, then all other parameters not listed will also be loaded. This is particularly useful for extracting posteriors, since you may want to make mass1 bigger than mass2, or add mchirp and q, and don't want to remember all the other parameters to list.

Example, given this samples file:
```
[cdcapano@atlas8 bbh-injection]$ h5ls inference.hdf/samples
coa_phase                Dataset {2, 1000, 6/Inf}
dec                      Dataset {2, 1000, 6/Inf}
delta_tc                 Dataset {2, 1000, 6/Inf}
distance                 Dataset {2, 1000, 6/Inf}
inclination              Dataset {2, 1000, 6/Inf}
logjacobian              Dataset {2, 1000, 6/Inf}
loglikelihood            Dataset {2, 1000, 6/Inf}
logprior                 Dataset {2, 1000, 6/Inf}
mass1                    Dataset {2, 1000, 6/Inf}
mass2                    Dataset {2, 1000, 6/Inf}
polarization             Dataset {2, 1000, 6/Inf}
ra                       Dataset {2, 1000, 6/Inf}
spin1_a                  Dataset {2, 1000, 6/Inf}
spin1_azimuthal          Dataset {2, 1000, 6/Inf}
spin1_polar              Dataset {2, 1000, 6/Inf}
spin2_a                  Dataset {2, 1000, 6/Inf}
spin2_azimuthal          Dataset {2, 1000, 6/Inf}
spin2_polar              Dataset {2, 1000, 6/Inf}
```
If you run `extract_samples` in normal mode:
```
[cdcapano@atlas8 bbh-injection]$ pycbc_inference_extract_samples \
    --input-file inference.hdf \
    --output-file posterior.hdf \
    --parameters 'primary_mass(mass1, mass2)/secondary_mass(mass1, mass2):q' \
                 'mchirp_from_mass1_mass2(mass1, mass2):mchirp' \
    --force --verbose
```
You get:
```
[cdcapano@atlas8 bbh-injection]$ h5ls posterior.hdf/samples
mchirp                   Dataset {1000/Inf}
q                        Dataset {1000/Inf}
```
Adding the `'*'`:
```
[cdcapano@atlas8 bbh-injection]$ pycbc_inference_extract_samples \
    --input-file inference.hdf \
    --output-file posterior.hdf \
    --parameters 'primary_mass(mass1, mass2)/secondary_mass(mass1, mass2):q' \
                 'mchirp_from_mass1_mass2(mass1, mass2):mchirp' \
                 '*'
    --force --verbose
```
Gives:
```
[cdcapano@atlas8 bbh-injection]$ h5ls posterior.hdf/samples
coa_phase                Dataset {1000/Inf}
dec                      Dataset {1000/Inf}
delta_tc                 Dataset {1000/Inf}
distance                 Dataset {1000/Inf}
inclination              Dataset {1000/Inf}
logjacobian              Dataset {1000/Inf}
loglikelihood            Dataset {1000/Inf}
logprior                 Dataset {1000/Inf}
mchirp                   Dataset {1000/Inf}
polarization             Dataset {1000/Inf}
q                        Dataset {1000/Inf}
ra                       Dataset {1000/Inf}
spin1_a                  Dataset {1000/Inf}
spin1_azimuthal          Dataset {1000/Inf}
spin1_polar              Dataset {1000/Inf}
spin2_a                  Dataset {1000/Inf}
spin2_azimuthal          Dataset {1000/Inf}
spin2_polar              Dataset {1000/Inf}
```
Notice that mass1 and mass2 were not included in the output, since they were used in the functions for `mchirp` and `q`. To add them, you would need to explicitly list them.