### PR TITLE
Fix setup_output calls

### DIFF
--- a/pycbc/inference/sampler/base.py
+++ b/pycbc/inference/sampler/base.py
@@ -155,15 +155,12 @@ class BaseSampler(object):
 #
 
 
-def setup_output(sampler, output_file, force=False):
+def setup_output(sampler, output_file):
     r"""Sets up the sampler's checkpoint and output files.
 
     The checkpoint file has the same name as the output file, but with
     ``.checkpoint`` appended to the name. A backup file will also be
     created.
-
-    If the output file already exists, an ``OSError`` will be raised.
-    This can be overridden by setting ``force`` to ``True``.
 
     Parameters
     ----------
@@ -171,8 +168,6 @@ def setup_output(sampler, output_file, force=False):
         Sampler
     output_file : str
         Name of the output file.
-    force : bool, optional
-        If the output file already exists, overwrite it.
     """
     # check for backup file(s)
     checkpoint_file = output_file + '.checkpoint'
@@ -203,9 +198,6 @@ def setup_output(sampler, output_file, force=False):
 
 def create_new_output_file(sampler, filename, **kwargs):
     r"""Creates a new output file.
-
-    If the output file already exists, an ``OSError`` will be raised. This can
-    be overridden by setting ``force`` to ``True``.
 
     Parameters
     ----------

--- a/pycbc/inference/sampler/cpnest.py
+++ b/pycbc/inference/sampler/cpnest.py
@@ -166,27 +166,6 @@ class CPNestSampler(BaseSampler):
     def resume_from_checkpoint(self):
         pass
 
-    def setup_output(self, output_file, force=False):
-        """Sets up the sampler's checkpoint and output files.
-
-        The checkpoint file has the same name as the output file, but with
-        ``.checkpoint`` appended to the name. A backup file will also be
-        created.
-
-        If the output file already exists, an ``OSError`` will be raised.
-        This can be overridden by setting ``force`` to ``True``.
-
-        Parameters
-        ----------
-        sampler : sampler instance
-            Sampler
-        output_file : str
-            Name of the output file.
-        force : bool, optional
-            If the output file already exists, overwrite it.
-        """
-        setup_output(self, output_file, force=force)
-
     def write_results(self, filename):
         """Writes samples, model stats, acceptance fraction, and random state
         to the given file.

--- a/pycbc/inference/sampler/dynesty.py
+++ b/pycbc/inference/sampler/dynesty.py
@@ -203,27 +203,6 @@ class DynestySampler(BaseSampler):
             fp.write_logevidence(self._sampler.results.logz[-1:][0],
                                  self._sampler.results.logzerr[-1:][0])
 
-    def setup_output(self, output_file, force=False):
-        """Sets up the sampler's checkpoint and output files.
-
-        The checkpoint file has the same name as the output file, but with
-        ``.checkpoint`` appended to the name. A backup file will also be
-        created.
-
-        If the output file already exists, an ``OSError`` will be raised.
-        This can be overridden by setting ``force`` to ``True``.
-
-        Parameters
-        ----------
-        sampler : sampler instance
-            Sampler
-        output_file : str
-            Name of the output file.
-        force : bool, optional
-            If the output file already exists, overwrite it.
-        """
-        setup_output(self, output_file, force=force)
-
     @property
     def posterior_samples(self):
         """

--- a/pycbc/inference/sampler/multinest.py
+++ b/pycbc/inference/sampler/multinest.py
@@ -340,17 +340,12 @@ class MultinestSampler(BaseSampler):
         ``.checkpoint`` appended to the name. A backup file will also be
         created.
 
-        If the output file already exists, an ``OSError`` will be raised.
-        This can be overridden by setting ``force`` to ``True``.
-
         Parameters
         ----------
         sampler : sampler instance
             Sampler
         output_file : str
             Name of the output file.
-        force : bool, optional
-            If the output file already exists, overwrite it.
         """
         if self.is_main_process:
             setup_output(self, output_file)

--- a/pycbc/inference/sampler/multinest.py
+++ b/pycbc/inference/sampler/multinest.py
@@ -333,7 +333,7 @@ class MultinestSampler(BaseSampler):
         if not checkpoint_valid:
             raise IOError("error writing to checkpoint file")
 
-    def setup_output(self, output_file, force=False):
+    def setup_output(self, output_file):
         """Sets up the sampler's checkpoint and output files.
 
         The checkpoint file has the same name as the output file, but with
@@ -353,7 +353,7 @@ class MultinestSampler(BaseSampler):
             If the output file already exists, overwrite it.
         """
         if self.is_main_process:
-            setup_output(self, output_file, force=force)
+            setup_output(self, output_file)
         else:
             # child processes just store filenames
             checkpoint_file = output_file + '.checkpoint'
@@ -402,5 +402,5 @@ class MultinestSampler(BaseSampler):
                            v is not None}
         obj = cls(model, nlivepoints, constraints=constraints,
                   **optional_kwargs)
-        obj.setup_output(obj, output_file)
+        obj.setup_output(output_file)
         return obj


### PR DESCRIPTION
As caught in Issue #3160, PR #2948 introduced a bug into setting up the multinest sampler. This fixes that. Also removes unused `setup_output` class methods in other samplers, and removes the `force` keyword argument in the `setup_output` function in `pycbc/inference/sampler/base.py`, since that isn't used by anything anymore.