### PR TITLE
don't hard require epsie

### DIFF
--- a/pycbc/inference/sampler/__init__.py
+++ b/pycbc/inference/sampler/__init__.py
@@ -22,16 +22,20 @@ from __future__ import absolute_import
 from .base import (initial_dist_from_config, create_new_output_file)
 from .emcee import EmceeEnsembleSampler
 from .emcee_pt import EmceePTSampler
-from .epsie import EpsieSampler
 from .multinest import MultinestSampler
 
 # list of available samplers
 samplers = {cls.name: cls for cls in (
     EmceeEnsembleSampler,
     EmceePTSampler,
-    EpsieSampler,
     MultinestSampler
 )}
+
+try:
+    from .epsie import EpsieSampler
+    samplers[EpsieSampler.name] = EpsieSampler
+except ImportError:
+    pass
 
 try:
     from .cpnest import CPNestSampler


### PR DESCRIPTION
@cdcapano Sorry, I missed this before, but the changes to add epsie support added it as a hard requirement. We should try to avoid this for to many things. This adds in the minimal protection to ensure epsie isn't required just for module support. 