### PR TITLE
Fix pycbc_banksim for Python 3

### DIFF
--- a/bin/pycbc_banksim
+++ b/bin/pycbc_banksim
@@ -18,10 +18,9 @@
 
 from __future__ import print_function
 
-import sys
 import logging
 from tqdm import tqdm
-from numpy import complex64, float32, array
+from numpy import complex64, array
 from argparse import ArgumentParser
 from glue.ligolw import utils as ligolw_utils
 from glue.ligolw import table, lsctables
@@ -30,14 +29,14 @@ class mycontenthandler(LIGOLWContentHandler):
     pass
 lsctables.use_in(mycontenthandler)
 
-from pycbc.pnutils import mass1_mass2_to_mchirp_eta, f_SchwarzISCO
+from pycbc.pnutils import mass1_mass2_to_mchirp_eta
 from pycbc.pnutils import mass1_mass2_to_tau0_tau3
 from pycbc.pnutils import nearest_larger_binary_number
 from pycbc.waveform import get_td_waveform, get_fd_waveform, td_approximants, fd_approximants
 from pycbc.waveform.utils import taper_timeseries
 from pycbc import DYN_RANGE_FAC
-from pycbc.types import FrequencySeries, TimeSeries, zeros, real_same_precision_as, complex_same_precision_as
-from pycbc.filter import match, sigmasq, resample_to_delta_t
+from pycbc.types import FrequencySeries, TimeSeries, zeros, complex_same_precision_as
+from pycbc.filter import match, sigmasq
 from math import ceil, log
 import pycbc.psd, pycbc.scheme, pycbc.fft, pycbc.strain, pycbc.version
 from pycbc.detector import overhead_antenna_pattern as generate_fplus_fcross

--- a/bin/pycbc_banksim
+++ b/bin/pycbc_banksim
@@ -20,6 +20,7 @@ from __future__ import print_function
 
 import sys
 import logging
+from tqdm import tqdm
 from numpy import complex64, float32, array
 from argparse import ArgumentParser
 from glue.ligolw import utils as ligolw_utils
@@ -42,12 +43,6 @@ import pycbc.psd, pycbc.scheme, pycbc.fft, pycbc.strain, pycbc.version
 from pycbc.detector import overhead_antenna_pattern as generate_fplus_fcross
 from pycbc.waveform import TemplateBank
 
-def update_progress(progress):
-    bar = '#' * (int(progress*100)/2) + ' ' * (50-int(progress*100)/2)
-    print('[{0}] {1:.2%}\r\r'.format(bar, progress), end=' ')
-    if progress == 1:
-        print(('Done' + ' ' * 70))
-    sys.stdout.flush()
 
 ## Remove the need for these functions ########################################
     
@@ -128,7 +123,7 @@ def get_waveform(approximant, phase_order, amplitude_order, spin_order,
                                  phase_order=phase_order, delta_f=delta_f,
                                  spin_order=spin_order,
                                  f_lower=start_frequency,
-                                 amplitude_order=amplitude_order) 
+                                 amplitude_order=amplitude_order)
         hvec = generate_detector_strain(wf_params, hp, hc)
 
     elif approximant in td_approximants():
@@ -305,7 +300,7 @@ logging.info("  %d signal waveforms", len(signal_table))
 logging.info("Matches will be written to %s", options.out_file)
 
 filter_N = int(options.filter_signal_length * options.filter_sample_rate)
-filter_n = filter_N / 2 + 1
+filter_n = filter_N // 2 + 1
 filter_delta_f = 1.0 / float(options.filter_signal_length)
 
 logging.info("Reading and Interpolating PSD")
@@ -323,9 +318,9 @@ with ctx:
     # Used for getting mchirp/tau0 later
     sig_m1 = []
     sig_m2 = []
+    prog = tqdm(total=len(signal_table), disable=(not options.verbose))
     for index, signal_params in enumerate(signal_table):
-        if options.verbose:
-            update_progress(float(index+1)/len(signal_table))
+        prog.update(1)
         if not options.use_sky_location and hasattr(signal_params, 'latitude'):
             signal_params.latitude = 0.
             signal_params.longitude = 0.
@@ -343,6 +338,7 @@ with ctx:
         signals.append((stilde, s_norm, [], signal_params))
         sig_m1.append(signal_params.mass1)
         sig_m2.append(signal_params.mass2)
+    prog.close()
     sig_m1 = array(sig_m1)
     sig_m2 = array(sig_m2)
     sig_tau0, _ = mass1_mass2_to_tau0_tau3(sig_m1, sig_m2,
@@ -359,10 +355,9 @@ with ctx:
     logging.info("Calculating Overlaps")
 
     flow_warned = False
+    prog = tqdm(total=len(template_table), disable=(not options.verbose))
     for index, template_params in enumerate(template_table):
-        if options.verbose:
-            update_progress(float(index+1)/len(template_table))
-
+        prog.update(1)
         f_lower = template_params.f_lower
         # If not set fall back on filter low-freq cutoff
         if f_lower < 0.000001:
@@ -416,6 +411,7 @@ with ctx:
             o, i = match(htilde, stilde, v1_norm=h_norm, v2_norm=s_norm,
                          low_frequency_cutoff=f_lower)
             matches.append(o)
+    prog.close()
 
 logging.info("Determining maximum overlaps and outputting results")
 


### PR DESCRIPTION
I found a couple errors after trying `pycbc_banksim` on Python 3. This patch fixes them and removes a bunch of unused imports.