### PR TITLE
Add in Gracedb search functionality to results page

### DIFF
--- a/bin/minifollowups/pycbc_page_coincinfo
+++ b/bin/minifollowups/pycbc_page_coincinfo
@@ -21,6 +21,7 @@ import matplotlib; matplotlib.use('Agg')
 import numpy, lal, datetime
 import pycbc.version, pycbc.results, pycbc.pnutils
 from pycbc.events import ranking
+from pycbc.results import followup
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--version', action='version',
@@ -46,6 +47,9 @@ trig_input.add_argument('--trigger-id', type=int,
 parser.add_argument('--include-summary-page-link', action='store_true',
     help="If given, will include a link to the DQ summary page on the "
          "single detector trigger tables.")
+parser.add_argument('--include-gracedb-link', action='store_true',
+    help="If given, will provide a link to search GraceDB for events "
+         "within a 3s window around the coincidence time.")
 
 
 args = parser.parse_args()
@@ -84,6 +88,19 @@ formats = ['%5.2f', '%5.2f', '%5.2e', '%5.2f', '%5.2e']
 tbl = [[h, fmt % d[dst][n]] for fmt, dst, h in zip(formats, dsets, hdrs) if dst in d]
 headers, table = zip(*tbl)
 headers = list(headers)
+table = list(table)
+if args.include_gracedb_link:
+    # Get the time from the single detectors
+    if 'detector_1' in f.attrs:
+        time = (d['time2'][n] + d['time1'][n]) / 2.0
+    else:
+        times = [d['%s/time' % ifo][n] for ifo in f.attrs['ifos'].split(' ')]
+        times = numpy.array(times)
+        time = numpy.mean(times[times > 0])
+    gdb_search_link = followup.get_gracedb_search_link(time)
+    headers.append("GraceDB Search Link")
+    table.append(gdb_search_link)
+
 table = numpy.array([table], dtype=str)
 
 if 'detector_1' in f.attrs:

--- a/bin/minifollowups/pycbc_page_snglinfo
+++ b/bin/minifollowups/pycbc_page_snglinfo
@@ -20,6 +20,7 @@ import sys, h5py, matplotlib, numpy, datetime, argparse
 matplotlib.use('Agg')
 import lal
 import pycbc.version, pycbc.events, pycbc.results, pycbc.pnutils
+from pycbc.results import followup
 from pycbc.io import hdf
 
 
@@ -54,6 +55,9 @@ parser.add_argument('--ranking-statistic', default='newsnr',
          "'newsnr'")
 parser.add_argument('--include-summary-page-link', action='store_true',
     help="If given, will include a link to the DQ summary page")
+parser.add_argument('--include-gracedb-link', action='store_true',
+    help="If given, will provide a link to search GraceDB for events "
+         "within a 3s window around the coincidence time.")
 
 
 
@@ -146,6 +150,12 @@ headers.append("M<sub>c</sub>")
 headers.append("s<sub>1z</sub>")
 headers.append("s<sub>2z</sub>")
 headers.append("Duration")
+
+# GraceDB search link
+if args.include_gracedb_link:
+    gdb_search_link = followup.get_gracedb_search_link(time)
+    headers.append("GraceDB Search Link")
+    data[0].append(gdb_search_link)
 
 html = pycbc.results.dq.redirect_javascript + \
         str(pycbc.results.static_table(data, headers))

--- a/pycbc/results/followup.py
+++ b/pycbc/results/followup.py
@@ -139,6 +139,7 @@ def get_gracedb_search_link(time):
     # Set up a search string for a 3s window around the coincidence
     gdb_search_query = '%.0f+..+%.0f' % (numpy.floor(time) - 1,
                                          numpy.ceil(time) + 1)
-    gdb_search_url = 'https://gracedb.ligo.org/search/?query={}&query_type=S'.format(gdb_search_query)
+    gdb_search_url = ('https://gracedb.ligo.org/search/?query='
+                      '{}&query_type=S'.format(gdb_search_query))
     gdb_search_link = '<a href="' + gdb_search_url + '">Search</a>'
     return gdb_search_link

--- a/pycbc/results/followup.py
+++ b/pycbc/results/followup.py
@@ -135,3 +135,10 @@ def times_to_links(times, window, tag, base=None):
         urls.append(base % (tag, start, end))
     return urls
 
+def get_gracedb_search_link(time):
+    # Set up a search string for a 3s window around the coincidence
+    gdb_search_query = '%.0f+..+%.0f' % (numpy.floor(time) - 1,
+                                         numpy.ceil(time) + 1)
+    gdb_search_url = 'https://gracedb.ligo.org/search/?query={}&query_type=S'.format(gdb_search_query)
+    gdb_search_link = '<a href="' + gdb_search_url + '">Search</a>'
+    return gdb_search_link


### PR DESCRIPTION
Add in a link to results pages which links to a search on GraceDB for superevents 3s around a single or coinc time in snglinfo and coincinfo

Note that it is possible to include this as a gracedb api search within python, but requires grid proxy credentials, so is not useful when using --no-grid with pycbc_submit_dax. I couldn't get it to work within the workflow either (standalone worked fine, within workflow didn't work) - I can add in this as an attempt to search but if the link fails then it falls back to the search, but thought this was cleaner for now