### PR TITLE
Update pp workflow

### DIFF
--- a/bin/inference/pycbc_inference_plot_inj_recovery
+++ b/bin/inference/pycbc_inference_plot_inj_recovery
@@ -43,7 +43,7 @@ parameter = parameters[0]
 label = labels[parameters[0]] 
 
 # create figure
-fig = plt.figure()
+fig = plt.figure(figsize=(6,6))
 ax = fig.add_subplot(111)
 
 # typecast to list for iteratation

--- a/bin/inference/pycbc_inference_plot_inj_recovery
+++ b/bin/inference/pycbc_inference_plot_inj_recovery
@@ -3,6 +3,7 @@
 of injections.
 """
 
+import sys
 import argparse
 import logging
 import matplotlib as mpl; mpl.use("Agg")
@@ -15,6 +16,7 @@ from matplotlib import cm
 from pycbc import inject
 from pycbc import __version__
 from pycbc.inference import (option_utils, io)
+from pycbc.results import save_fig_with_metadata
 
 # parse command line
 parser = io.ResultsArgumentParser(description=__doc__)
@@ -118,7 +120,14 @@ ax.grid()
 ax.axhline(0, linestyle="dashed", color="gray", zorder=9)
 
 # save plot
-plt.savefig(opts.output_file)
+caption = ('Difference in recovered value vs injected value vs injected '
+           'value. The vertical lines show the width of the {} to {} '
+           'percentile credible interval.'
+           .format(opts.percentiles[0], opts.percentiles[1]))
+save_fig_with_metadata(fig, opts.output_file,
+                       caption=caption,
+                       cmd=' '.join(sys.argv),
+                       fig_kwds={'bbox_inches': 'tight'})
 
 # done
 logging.info("Done")

--- a/bin/pycbc_create_injections
+++ b/bin/pycbc_create_injections
@@ -140,9 +140,9 @@ parser.add_argument('--output-file', required=True,
                          'injections will be written to a sim_inspiral table '
                          'in an xml file. Otherwise, results will be written '
                          'to an hdf file.')
-parser.add_argument('--dist-section', default='distribution',
+parser.add_argument('--dist-section', default='prior',
                     help='What section in the config file to load '
-                          'distributions from. Default is distribution.')
+                          'distributions from. Default is prior.')
 parser.add_argument('--variable-params-section', default='variable_params',
                     help='What section in the config file to load the '
                          'parameters to vary. Default is variable_params.')

--- a/bin/workflows/pycbc_make_inference_inj_workflow
+++ b/bin/workflows/pycbc_make_inference_inj_workflow
@@ -170,12 +170,14 @@ diagnostics = inffu.get_diagnostic_plots(workflow)
 # figure out if we're creating PP plots
 do_pp_test = workflow.cp.has_option('executables', 'plot_pp')
 if do_pp_test:
-    # get the parameters to do the test; if none provide, we'll default to
-    # the posterior parameters
-    if workflow.cp.has_option('workflow-pp_test', 'params'):
-        pp_params = shlex.split(workflow.cp.get('workflow-pp_test', 'params'))
+    # get the parameters to do the test
+    pp_params = shlex.split(workflow.cp.get('workflow-pp_test', 'pp-params'))
+    # see if there is an injection map provided
+    if workflow.cp.has_option('workflow-pp_test', 'injection-samples-map'):
+        inj_samples_map = workflow.cp.get('workflow-pp_test',
+                                          'injection-samples-map')
     else:
-        pp_params = inffu.get_posterior_params(workflow.cp)
+        inj_samples_map = None
     pp_section = 'p-p_test'
     pp_dir = [pp_section]
 else:
@@ -320,18 +322,31 @@ for num_inj in range(num_injections):
 
 # create the PP and recovery plot
 if do_pp_test:
+    # create the pp summary table
+    pp_table = inffu.make_inference_pp_table(
+        workflow, posterior_files, rdir[pp_section], parameters=pp_params,
+        injection_samples_map=inj_samples_map,
+        analysis_seg=workflow.analysis_time, tags=opts.tags)
+    layout.single_layout(rdir[pp_section], [pp_table])
+    # now the pp plots and injection recovery
     pp_plots = []
     inj_recovery_plots = []
-    for param in pp_params:
-        pp_plots.append(inffu.make_inference_pp_plot(
+    for pi, param in enumerate(pp_params):
+        tags = opts.tags + ['PARAM_{}'.format(pi)]
+        # the pp plot
+        pp_plot = inffu.make_inference_pp_plot(
             workflow, posterior_files, rdir[pp_section], parameters=param,
-            analysis_seg=workflow.analysis_time, tags=opts.tags))
-        inj_recovery_plots.append(inffu.make_inference_inj_recovery_plot(
+            injection_samples_map=inj_samples_map,
+            analysis_seg=workflow.analysis_time, tags=tags)
+        pp_plots.append(pp_plot)
+        # the injection recovery plot
+        injrec_plot = inffu.make_inference_inj_recovery_plot(
             workflow, posterior_files, rdir[pp_section], parameters=param,
-            analysis_seg=workflow.analysis_time, tags=opts.tags))
+            injection_samples_map=inj_samples_map,
+            analysis_seg=workflow.analysis_time, tags=tags)
+        inj_recovery_plots.append(injrec_plot)
     layout.two_column_layout(rdir[pp_section],
                              list(zip(pp_plots, inj_recovery_plots)))
-
 
 # create versioning HTML pages
 results.create_versioning_page(rdir["workflow/version"], container.cp)

--- a/bin/workflows/pycbc_make_inference_inj_workflow
+++ b/bin/workflows/pycbc_make_inference_inj_workflow
@@ -1,6 +1,6 @@
 #! /usr/bin/env python
 
-# Copyright (C) 2017 Christopher M. Biwer, Alexander Harvey Nitz
+# Copyright (C) 2017 Christopher M. Biwer, Alexander Harvey Nitz, Collin Capano
 #
 # This program is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License as published by the
@@ -31,77 +31,97 @@ from pycbc.results import metadata
 from pycbc.results import versioning
 from pycbc.workflow import configuration
 from pycbc.workflow import core
-from pycbc.workflow import jobsetup
-from pycbc.workflow import inference_followups
+from pycbc.workflow.jobsetup import (PycbcCreateInjectionsExecutable,
+                                     PycbcInferenceExecutable)
+from pycbc.workflow import inference_followups as inffu
 from pycbc.workflow import plotting
 from pycbc.inject import InjectionSet
 from pycbc.io import FieldArray
+
+
+def config_from_config(cp, section, skip_opts=None):
+    """Loads a config parser from the given section."""
+    # create a dummy command-line parser for getting the config files and
+    # options
+    cfparser = argparse.ArgumentParser()
+    configuration.add_workflow_command_line_group(cfparser)
+    cli = cp.section_to_cli(section, skip_opts=skip_opts)
+    opts = cfparser.parse_args(shlex.split(cli))
+    return configuration.WorkflowConfigParser.from_cli(opts)
+
+
+def read_inference_settings_from_config(cp, section):
+    """Loads the config parser and gets the number of inference runs to do."""
+    if cp.has_option(section, 'nruns'):
+        nruns = int(cp.get(section, 'nruns'))
+    else:
+        nruns = 1
+    return config_from_config(cp, section, skip_opts=['nruns']), nruns
+    
 
 # set command line parser
 parser = argparse.ArgumentParser(description=__doc__[1:])
 
 # version option
-parser.add_argument(
-    "--version", action="version",
-    version=pycbc.version.git_verbose_msg,
-    help="Prints version information.")
+parser.add_argument("--version", action="version", version=__version__,
+                    help="Prints version information.")
 
 # workflow options
-parser.add_argument(
-    "--workflow-name",
-    default="inference_injection_run",
-    help="Name of the workflow to append in various places.")
-parser.add_argument(
-    "--output-dir",
-    default='run',
-    help="Path that will contain output data files from the workflow.")
-parser.add_argument(
-    "--output-map",
-    default="output.map",
-    help="Path to output map file.")
-parser.add_argument(
-    "--output-file",
-    required=True,
-    help="Path to DAX file.")
-
+parser.add_argument("--workflow-name", required=True,
+                    help="Name of the workflow.")
+parser.add_argument("--tags", nargs="+", default=[],
+                    help="Append the given tags to file names.")
+parser.add_argument("--output-dir", default=None,
+                    help="Path to directory where the workflow will be "
+                         "written. Default is to use "
+                         "{workflow-name}_output.")
+parser.add_argument("--output-map", default="output.map",
+                    help="Path to an output map file. Default is "
+                         "output.map.")
+parser.add_argument("--dax-file", default=None,
+                    help="Path to DAX file. Default is to write to the "
+                         "output directory with name {workflow-name}.dax.")
 # inference options
-parser.add_argument(
-    "--inference-config-file",
-    type=str, required=True,
-    help="WorkflowConfigParser parsable file with proir information.")
-
-# injections file
-parser.add_argument(
-    "--injection-files", 
-    type=str, nargs="+", 
-    help="hdf files containing injections.")
-
-# input data for workflow options
-parser.add_argument(
-    "--data-type",
-    choices=["analytical", "simulated_data", "detector_data"],
-    default="detector_data",
-    help="Set to 'analytical' to use test likelihood or set to "
-         "'simulated_data' to use simulated detector data.")
-parser.add_argument(
-    "--gps-end-time",
-    type=float, nargs="+", default=None,
-    help="Trigger time to analyze. You only need to use this option "
-         "with ``--data-type detector_data``.")
-
+parser.add_argument("--seed", type=int, default=0,
+                    help="Starting to seed to use. This will be incremented "
+                         "one for each injection analyzed. Default is 0.")
+# injection options: either specify a number to create, or use the given file
+group = parser.add_mutually_exclusive_group(required=True)
+group.add_argument("--num-injections", type=int,
+                   help="The number of injections to create.")
+group.add_argument("--injection-file", type=str, nargs="+", 
+                   help="Analyze injections in the given file(s) instead of "
+                        "creating them.")
 # add option groups
 configuration.add_workflow_command_line_group(parser)
 
 # parser command line
 opts = parser.parse_args()
 
+# configuration files
+config_file_tmplt = 'inference-{}.ini'
+config_file_dir = 'config_files'
+# the directory we'll store samples files to
+samples_file_dir = 'samples_files'
+# the directory we'll store posterior files to
+posterior_file_dir = 'posterior_files'
+# the directory we'll store the injection files to
+injection_file_dir = 'injection_files'
+
 # make data output directory
+if opts.output_dir is None:
+    opts.output_dir = opts.workflow_name + '_output'
 core.makedir(opts.output_dir)
+core.makedir('{}/{}'.format(opts.output_dir, config_file_dir))
+core.makedir('{}/{}'.format(opts.output_dir, posterior_file_dir))
+core.makedir('{}/{}'.format(opts.output_dir, injection_file_dir))
 
-# the file we'll store all output files in
-filedir = 'output'
+# set the dax file name
+dax_file = opts.dax_file
+if dax_file is None:
+    dax_file = "{}.dax".format(opts.workflow_name)
 
-# log to stdout until we know where the path to log output file
+# log to terminal until we know where the path to log output file
 log_format = "%(asctime)s:%(levelname)s : %(message)s"
 logging.basicConfig(format=log_format, level=logging.INFO)
 
@@ -110,40 +130,78 @@ container = core.Workflow(opts, opts.workflow_name)
 workflow = core.Workflow(opts, opts.workflow_name + "-main")
 finalize_workflow = core.Workflow(opts, opts.workflow_name + "-finalization")
 
-# read inference configuration file
-cp = configuration.WorkflowConfigParser([opts.inference_config_file])
-
-# read injection files
-if opts.injection_files:
-    input_injection_files = []
-    for injfile in opts.injection_files:
-        input_injection_files.append(os.path.abspath(injfile))
-else:
-    input_injection_files = None
-
-# typecast str from command line to File instances
-config_file = core.File.from_path(opts.inference_config_file)
+# load the inference config file
+inference_cp, nruns = read_inference_settings_from_config(
+    workflow.cp, 'workflow-inference_config')
 
 # change working directory to the output
+origdir = os.path.abspath(os.curdir)
 os.chdir(opts.output_dir)
+
+# if an injection file was provided, write each injection as a separate file
+# in the injections directory
+if opts.injection_file:
+    injection_files = core.FileList([])
+    n_injections = 0
+    for injection_file in opts.injection_files:
+        injections = InjectionSet('{}/{}'.format(origdir, injection_file))
+        local_numinj = len(injections.table)
+        st_args = {k: injections.table[k][0] 
+                   for k in injections._injhandler.static_args}
+        for ii in range(local_numinj):
+            samples = {f: injections.table[ii][f] 
+                       for f in injections.table.fieldnames
+                       if f not in injections._injhandler.static_args}
+            outfile = '{}/injection{}.hdf'.format(injection_file_dir,
+                                                  n_injections)
+            injections.write(
+                 outfile, FieldArray.from_kwargs(**samples),
+                 write_params=[k for k in injections.table.fieldnames 
+                               if k not in injections._injhandler.static_args],
+                 static_args=st_args)
+            injection_files.append(core.File.from_path(outfile))
+            n_injections += 1
+else:
+    n_injections = opts.num_injections
+
+# figure out what diagnostic jobs there are
+diagnostics = inffu.get_diagnostic_plots(workflow)
+
+# figure out if we're creating PP plots
+do_pp_test = workflow.cp.has_option('executables', 'plot_pp')
+if do_pp_test:
+    # get the parameters to do the test; if none provide, we'll default to
+    # the posterior parameters
+    if workflow.cp.has_option('workflow-pp_test', 'params'):
+        pp_params = shlex.split(workflow.cp.get('workflow-pp_test', 'params'))
+    else:
+        pp_params = inffu.get_posterior_params(workflow.cp)
+    pp_section = 'p-p_test'
+    pp_dir = [pp_section]
+else:
+    pp_dir = []
 
 # sections for output HTML pages
 rdir = layout.SectionNumber("results",
-                            ["posteriors", "samples", "workflow"])
+                            pp_dir +
+                            ["detector_sensitivity", "priors", "posteriors"] +
+                            diagnostics +
+                            ["config_files", "workflow"])
 
 # make results directories
 core.makedir(rdir.base)
 core.makedir(rdir["workflow"])
+core.makedir(rdir["config_files"])
 
-# create files to store workflow log
-log_file_txt = core.File(workflow.ifos, "WORKFLOW-LOG",
+# create files for workflow log
+log_file_txt = core.File(workflow.ifos, "workflow-log",
                          workflow.analysis_time,
                          extension=".txt", directory=rdir["workflow"])
 log_file_html = core.File(workflow.ifos, "WORKFLOW-LOG",
                           workflow.analysis_time,
                           extension=".html", directory=rdir["workflow"])
 
-# switch saving log from stdout to file
+# switch saving log to file
 logging.basicConfig(format=log_format, level=logging.INFO,
                     filename=log_file_txt.storage_path, filemode="w")
 log_file = logging.FileHandler(filename=log_file_txt.storage_path, mode="w")
@@ -151,200 +209,138 @@ log_file.setLevel(logging.INFO)
 formatter = logging.Formatter(log_format)
 log_file.setFormatter(formatter)
 logging.getLogger("").addHandler(log_file)
-logging.info("Created log file {}".format(log_file_txt.storage_path))
+logging.info("Created log file %s" % log_file_txt.storage_path)
 
-# construct Executable for creating injections
-create_injections_exe = jobsetup.PycbcCreateInjectionsExecutable(
-                           workflow.cp, "create_injections",
-                           ifo=workflow.ifos, out_dir=filedir)
+config_files = {}
+posterior_files = []
+seed = opts.seed
+# loop over number of injecionts to be analyzed
+for num_inj in range(num_injections):
+    zpad = int(numpy.ceil(numpy.log10(num_injections)))
+    label = 'Injection {}'.format(str(num_inj+1).zfill(zpad))
+    event = label.lower().replace(' ', '_')
 
-# construct Executable for running sampler
-inference_exe = jobsetup.PycbcInferenceExecutable(
-                           workflow.cp, "inference",
-                           ifo=workflow.ifos, out_dir=filedir)
+    # create a sub workflow for this event
+    # we need to go back to the original directory to do this for all the file
+    # references to work correctly
+    os.chdir(origdir)
+    sub_workflow = core.Workflow(opts,
+                                 "{}-{}".format(opts.workflow_name, event))
+    # now go back to the output
+    os.chdir(opts.output_dir)
 
-# get channel names from workflow configuration file
-channel_names = {}
-for ifo in workflow.ifos:
-    channel_names[ifo] = workflow.cp.get_opt_tags(
-                               "workflow", "%s-channel-name" % ifo.lower(), "")
+    # if the config file has a fake-strain-seed set, increment to get
+    # independent noise realizations
+    if inference_cp.has_option('data', 'fake-strain-seed'):
+        # get the detectors
+        detectors = shlex.split(cp.get('data', 'instruments'))
+        fake_strain_seeds = {}
+        for det in detectors:
+            fake_strain_seeds[det] = seed
+            seed = seed + 1
+        inference_cp.set('data', 'fake-strain-seed',
+                         ' '.join(['{}:{}'.format(det, seed)]))
 
-# get what parameters to plot in the PP and recovery plots
-if 'pp-plot-parameters' in  workflow.cp.options("workflow-inference"):
-    pp_plot_params = shlex.split(workflow.cp.get_opt_tag("workflow",
-        'pp-plot-parameters', 'inference'))
-else:
-    # just use the variable params
-    pp_plot_params = cp.options("variable_params")
+    # write the configuration file to the config files directory
+    config_file = sub_workflow.save_config(config_file_tmplt.format(event),
+                                           config_file_dir, inference_cp)[0]
 
-# get groups of parameters to plot in posterior and samples plots
-plot_groups = {}
-for option in workflow.cp.options("workflow-inference"):
-    if option.startswith("plot-group-"):
-        group = option.replace("plot-group-", "").replace("-", "_")
-        plot_groups[group] = shlex.split(workflow.cp.get_opt_tag(
-                                "workflow", option, "inference"))
-all_plot_parameters = sorted([param for group in plot_groups.values()
-                              for param in group])
-unique_plot_parameters = set(all_plot_parameters)
+    # create sym links to config file for results page
+    base = "config_files/{}".format(event)
+    layout.single_layout(rdir[base], [config_file])
+    symlink_path(config_file, rdir[base])
 
-# formatted strings for output dirs
-post_group_fmt = "posteriors/{}_posteriors"
-sample_group_fmt = "samples/{}_samples"
-
-# loop over number of injections
-n_injections = int(workflow.cp.get_opt_tags(
-                                "workflow-inference", "num-injections", ""))
-inference_files = core.FileList([])
-post_files = core.FileList([])
-post_group_files = {g : core.FileList([]) for g in plot_groups.keys()}
-post_table_files = core.FileList([])
-accept_files = core.FileList([])
-sample_group_files = {g : core.FileList([]) for g in plot_groups.keys()}
-
-# if injection files given, separate into individual files for each injection
-if input_injection_files:
-    injection_files = core.FileList([])
-    os.mkdir("injections")
-    
-    total_numinj = 0
-    for i_input in range(len(input_injection_files)):
-        injections = InjectionSet(input_injection_files[i_input])
-        local_numinj = len(injections.table)
-        st_args = {k: injections.table[k][0] 
-                   for k in injections._injhandler.static_args}
-                    
-        for i in range(local_numinj):
-            samples = {f: injections.table[i][f] 
-                       for f in injections.table.fieldnames
-                       if f not in injections._injhandler.static_args}
-            
-            injections.write(
-                'injections/injection%s.hdf' %(i+total_numinj), 
-                 FieldArray.from_kwargs(**samples),
-                 write_params = [k for k in injections.table.fieldnames 
-                                 if k not in injections._injhandler.static_args],
-                 static_args = st_args)
-            
-            injection_files.append(
-                    core.File.from_path(
-                        'injections/injection%s.hdf' %(i+total_numinj)))
-        total_numinj += local_numinj
-    if total_numinj != n_injections:
-        raise ValueError('Given number of injections does not match '
-                         'injections in files.')
-
-for i in range(n_injections):
-
-    # if injection files are given, use individual files
+    # add a node to create the injection if an injection file wasn't provided
     if opts.injection_files:
-        injection_file = injection_files[i]
-
-    # make node for drawing injection parameter values
-    elif not opts.data_type == "analytical":
-        node, injection_file = create_injections_exe.create_node(config_file,
-                                                                 seed=i,
-                                                                 tags=[str(i)])
+        injection_file = injection_files[num_inj]
+    else:
+        # construct Executable for creating injections
+        create_injections_exe = PycbcCreateInjectionsExecutable(
+            sub_workflow.cp, "create_injections", ifo=sub_workflow.ifos,
+            out_dir=injection_file_dir)
+        node, injection_file = create_injections_exe.create_node(
+            config_file, seed=seed, tags=opts.tags+[event])
         workflow += node
-    else:
-        injection_file = None
+        seed = seed + 1
 
-    # set fake strain seed
-    if opts.data_type == "simulated_data":
-        fake_strain_seed = {ifo : j + i * len(workflow.ifos)
-                            for j, ifo in enumerate(workflow.ifos)}
-    else:
-        fake_strain_seed = None
+    # add the injection file to the inference config file
+    cp = configuration.WorkflowConfigParser([config_file])
+    cp.set('data', 'injection', injection_file)
+    cp.close()
 
-    # make node for running sampler
-    node, inference_file = inference_exe.create_node(
-                                     channel_names,
-                                     config_file,
-                                     injection_file=injection_file,
-                                     seed=i, fake_strain_seed=fake_strain_seed,
-                                     tags=[str(i)])
-    inference_files.append(inference_file)
-    workflow += node
+    # make node(s) for running sampler
+    samples_files = []
+    inference_exe = PycbcInferenceExecutable(sub_workflow.cp, "inference",
+                                             ifos=sub_workflow.ifos,
+                                             out_dir=samples_file_dir)
+    for nn in range(nrun):
+        tags = opts.tags + [event]
+        if nrun > 1:
+            tags.append(str(nn))
+        node, samples_file = inference_exe.create_node(
+            config_file, seed=seed, tags=tags,
+            analysis_time=sub_workflow.analysis_time)
+        # declare the injection file as a needed input file
+        node.add_input(injection_file)
+        # add node to workflow
+        sub_workflow += node
+        # increment the seed
+        seed = seed + 1
 
-    # make node for writing HTML table of parameters
-    post_table_files += inference_followups.make_inference_summary_table(
-                          workflow, inference_file, rdir["posteriors"],
-                          variable_params=unique_plot_parameters,
-                          analysis_seg=workflow.analysis_time,
-                          tags=[str(i)])
+    # create the posterior file and plots
+    posterior_file, summary_files, _, _ = inffu.make_posterior_workflow(
+        sub_workflow, samples_files, config_file, event, rdir,
+        posterior_file_dir=posterior_file_dir, tags=opts.tags)
+    posterior_files.append(posterior_file)
 
-    # make node for plotting all parameters posteriors
-    post_files += inference_followups.make_inference_posterior_plot(
-                          workflow, inference_file, rdir["posteriors"],
-                          parameters=unique_plot_parameters,
-                          analysis_seg=workflow.analysis_time,
-                          tags=[str(i)])
+    # create the diagnostic plots
+    _ = inffu.make_diagnostic_plots(sub_workflow, diagnostics, samples_files,
+                                    event, rdir, tags=opts.tags)
 
-    if "inference_rate" in workflow.cp.options("executables"):
-        # make node for plotting acceptance rate
-        accept_files += inference_followups.make_inference_acceptance_rate_plot(
-                              workflow, inference_file, rdir["samples"],
-                              analysis_seg=workflow.analysis_time,
-                              tags=[str(i)])
+    # files for detector_sensitivity summary subsection
+    base = "detector_sensitivity"
+    psd_plot = plotting.make_spectrum_plot(
+        sub_workflow, [samples_files[0]], rdir[base],
+        tags=opts.tags+[event],
+        hdf_group="data")
 
-    # plot grouped parameters
-    for group in plot_groups.keys():
+    # build the summary page
+    zpad = int(numpy.ceil(numpy.log10(len(samples_files))))
+    layout.two_column_layout(rdir.base, summary_files,
+                             unique=str(num_event).zfill(zpad),
+                             title=label, collapse=True)
 
-        # make nodes for plotting grouped-parameters posteriors
-        parameters = plot_groups[group]
-        post_group_files[group] += \
-                inference_followups.make_inference_posterior_plot(
-                          workflow, inference_file,
-                          rdir[post_group_fmt.format(group)],
-                          parameters=parameters,
-                          analysis_seg=workflow.analysis_time,
-                          tags=[str(i), group])
+    # build the psd page
+    layout.single_layout(rdir['detector_sensitivity'], [psd_plot],
+                         unique=str(num_event).zfill(zpad),
+                         title=label, collapse=True)
 
-        if "inference_samples" in workflow.cp.options("executables"):
-            # make nodes for plotting sample as function of sampler iterations
-            for j, parameter in enumerate(plot_groups[group]):
-                sample_group_files[group] += \
-                        inference_followups.make_inference_samples_plot(
-                              workflow, inference_file,
-                              rdir[sample_group_fmt.format(group)],
-                              parameters=[parameter],
-                              analysis_seg=workflow.analysis_time,
-                              tags=[str(i), group, str(j)])
+    # add the sub workflow to the main workflow
+    workflow += sub_workflow
 
-# add plots to HTML pages
-layout.single_layout(rdir["posteriors"],
-                     sum(zip(post_table_files, post_files), ()))
-layout.single_layout(rdir["samples"], accept_files)
-for group in sorted(plot_groups.keys()):
-    layout.single_layout(rdir[post_group_fmt.format(group)],
-                         post_group_files[group])
-    layout.single_layout(rdir[sample_group_fmt.format(group)],
-                         sample_group_files[group])
+# create the PP and recovery plot
+if do_pp_test:
+    pp_plots = []
+    inj_recovery_plots = []
+    for param in pp_params:
+        pp_plots.append(inffu.make_inference_pp_plot(
+            workflow, posterior_files, rdir[pp_section], parameters=param,
+            analysis_seg=workflow.analysis_time, tags=opts.tags))
+        inj_recovery_plots.append(inffu.make_inference_inj_recovery_plot(
+            workflow, posterior_files, rdir[pp_section], parameters=param,
+            analysis_seg=workflow.analysis_time, tags=opts.tags))
+    layout.two_column_layout(rdir[pp_section],
+                             list(zip(pp_plots, inj_recovery_plots)))
 
-# add injection recovery plots
-if not opts.data_type == "analytical":
-    inj_int_files = inference_followups.make_inference_inj_plots(
-                                         workflow,
-                                         inference_files, rdir.base,
-                                         pp_plot_params,
-                                         name="inference_intervals")
-    inj_rec_files = inference_followups.make_inference_inj_plots(
-                                         workflow,
-                                         inference_files, rdir.base,
-                                         pp_plot_params,
-                                         name="inference_recovery")
-    layout.two_column_layout(rdir.base,
-                             [(a, b)
-                              for a, b in zip(inj_int_files, inj_rec_files)])
 
 # create versioning HTML pages
-versioning.create_versioning_page(rdir["workflow/version"], container.cp)
+results.create_versioning_page(rdir["workflow/version"], container.cp)
 
 # create node for making HTML pages
 plotting.make_results_web_page(finalize_workflow,
-                               os.path.join(os.getcwd(), rdir.base))
+    os.path.join(os.getcwd(), rdir.base))
 
-# add sub-workflows to super-workflow
+# add sub-workflows to workflow
 container += workflow
 container += finalize_workflow
 
@@ -353,19 +349,14 @@ dep = dax.Dependency(parent=workflow.as_job, child=finalize_workflow.as_job)
 container._adag.addDependency(dep)
 
 # write dax
-container.save(filename=opts.output_file, output_map_path=opts.output_map)
+container.save(filename=dax_file, output_map_path=opts.output_map,
+               transformation_catalog_path=opts.transformation_catalog)
 
 # save workflow configuration file
-base = rdir["workflow/workflow_configuration"]
+base = rdir["workflow/configuration"]
 core.makedir(base)
-workflow_ini = workflow.save_config("workflow.ini", base, container.cp)
-layout.single_layout(base, workflow_ini)
-
-# save inference configuration file
-base = rdir["workflow/inference_configuration"]
-core.makedir(base)
-prior_ini = workflow.save_config("inference.ini", base, cp)
-layout.single_layout(base, prior_ini)
+wf_ini = workflow.save_config("workflow.ini", base, container.cp)
+layout.single_layout(base, wf_ini)
 
 # close the log and flush to the html file
 logging.shutdown()
@@ -380,5 +371,5 @@ log_str = """
 kwds = {"title" : "Workflow Generation Log",
         "caption" : "Log of the workflow script %s" % sys.argv[0],
         "cmd" : " ".join(sys.argv)}
-metadata.save_fig_with_metadata(log_str, log_file_html.storage_path, **kwds)
+results.save_fig_with_metadata(log_str, log_file_html.storage_path, **kwds)
 layout.single_layout(rdir["workflow"], ([log_file_html]))

--- a/bin/workflows/pycbc_make_inference_inj_workflow
+++ b/bin/workflows/pycbc_make_inference_inj_workflow
@@ -176,7 +176,7 @@ if do_pp_test:
                                           'injection-samples-map')
     else:
         inj_samples_map = None
-    pp_section = 'p-p_test'
+    pp_section = 'percentile-percentile_test'
     pp_dir = [pp_section]
 else:
     pp_dir = []
@@ -338,8 +338,7 @@ if do_pp_test:
     pp_table = inffu.make_inference_pp_table(
         pp_workflow, posterior_files, rdir[pp_section],
         parameters=pp_params, injection_samples_map=inj_samples_map,
-        analysis_seg=workflow.analysis_time, tags=opts.tags)
-    layout.single_layout(rdir[pp_section], pp_table)
+        analysis_seg=workflow.analysis_time, tags=opts.tags)[0]
     # now the pp plots and injection recovery
     pp_plots = []
     inj_recovery_plots = []
@@ -357,8 +356,9 @@ if do_pp_test:
             injection_samples_map=inj_samples_map,
             analysis_seg=workflow.analysis_time, tags=tags)[0]
         inj_recovery_plots.append(injrec_plot)
-    layout.two_column_layout(rdir[pp_section],
-                             list(zip(pp_plots, inj_recovery_plots)))
+    # add to the results page
+    pp_files = [(pp_table,)] + list(zip(pp_plots, inj_recovery_plots))
+    layout.two_column_layout(rdir[pp_section], pp_files)
     # add to the main workflow
     workflow += pp_workflow
 

--- a/bin/workflows/pycbc_make_inference_inj_workflow
+++ b/bin/workflows/pycbc_make_inference_inj_workflow
@@ -166,8 +166,8 @@ else:
 # figure out what diagnostic jobs there are
 diagnostics = inffu.get_diagnostic_plots(workflow)
 
-# figure out if we're creating PP plots
-do_pp_test = workflow.cp.has_option('executables', 'plot_pp')
+# figure out if we're doing pp tests
+do_pp_test = workflow.cp.has_option('executables', 'pp_table_summary')
 if do_pp_test:
     # get the parameters to do the test
     pp_params = shlex.split(workflow.cp.get('workflow-pp_test', 'pp-params'))
@@ -240,7 +240,8 @@ for num_inj in range(n_injections):
             fake_strain_seeds[det] = seed
             seed = seed + 1
         inference_cp.set('data', 'fake-strain-seed',
-                         ' '.join(['{}:{}'.format(det, seed)]))
+                         ' '.join(['{}:{}'.format(d, s)
+                                   for d, s in fake_strain_seeds.items()]))
 
     # write the configuration file to the config files directory
     config_file = sub_workflow.save_config(config_file_tmplt.format(event),
@@ -329,7 +330,7 @@ if do_pp_test:
         workflow, posterior_files, rdir[pp_section], parameters=pp_params,
         injection_samples_map=inj_samples_map,
         analysis_seg=workflow.analysis_time, tags=opts.tags)
-    layout.single_layout(rdir[pp_section], [pp_table])
+    layout.single_layout(rdir[pp_section], pp_table)
     # now the pp plots and injection recovery
     pp_plots = []
     inj_recovery_plots = []
@@ -339,13 +340,13 @@ if do_pp_test:
         pp_plot = inffu.make_inference_pp_plot(
             workflow, posterior_files, rdir[pp_section], parameters=param,
             injection_samples_map=inj_samples_map,
-            analysis_seg=workflow.analysis_time, tags=tags)
+            analysis_seg=workflow.analysis_time, tags=tags)[0]
         pp_plots.append(pp_plot)
         # the injection recovery plot
         injrec_plot = inffu.make_inference_inj_recovery_plot(
-            workflow, posterior_files, rdir[pp_section], parameters=param,
+            workflow, posterior_files, rdir[pp_section], param,
             injection_samples_map=inj_samples_map,
-            analysis_seg=workflow.analysis_time, tags=tags)
+            analysis_seg=workflow.analysis_time, tags=tags)[0]
         inj_recovery_plots.append(injrec_plot)
     layout.two_column_layout(rdir[pp_section],
                              list(zip(pp_plots, inj_recovery_plots)))

--- a/bin/workflows/pycbc_make_inference_inj_workflow
+++ b/bin/workflows/pycbc_make_inference_inj_workflow
@@ -169,7 +169,8 @@ diagnostics = inffu.get_diagnostic_plots(workflow)
 do_pp_test = workflow.cp.has_option('executables', 'pp_table_summary')
 if do_pp_test:
     # get the parameters to do the test
-    pp_params = shlex.split(workflow.cp.get('workflow-pp_test', 'pp-params'))
+    pp_params = ["'"+s+"'" for s in
+                 shlex.split(workflow.cp.get('workflow-pp_test', 'pp-params'))]
     # see if there is an injection map provided
     if workflow.cp.has_option('workflow-pp_test', 'injection-samples-map'):
         inj_samples_map = workflow.cp.get('workflow-pp_test',

--- a/bin/workflows/pycbc_make_inference_inj_workflow
+++ b/bin/workflows/pycbc_make_inference_inj_workflow
@@ -86,7 +86,7 @@ group.add_argument("--injection-file", type=str, nargs="+",
 # add option groups
 configuration.add_workflow_command_line_group(parser)
 # add workflow group
-inffu.add_inference_workflow_group(parser)
+core.add_workflow_settings_cli(parser, include_subdax_opts=True)
 parser.add_argument("--seed", type=int, default=0,
                     help="Starting to seed to use. This will be incremented "
                          "one for each injection analyzed. Default is 0.")

--- a/bin/workflows/pycbc_make_inference_inj_workflow
+++ b/bin/workflows/pycbc_make_inference_inj_workflow
@@ -22,10 +22,13 @@ import argparse
 import logging
 import os
 import shlex
+import numpy
 import Pegasus.DAX3 as dax
 import pycbc.version
 import socket
 import sys
+from pycbc import __version__
+from pycbc import results
 from pycbc.results import layout
 from pycbc.results import metadata
 from pycbc.results import versioning
@@ -59,32 +62,20 @@ def read_inference_settings_from_config(cp, section):
     return config_from_config(cp, section, skip_opts=['nruns']), nruns
     
 
+def symlink_path(f, path):
+    """ Symlinks a path.
+    """
+    if f is None:
+        return
+    try:
+        os.symlink(f.storage_path, os.path.join(path, f.name))
+    except OSError:
+        pass
+
+
 # set command line parser
 parser = argparse.ArgumentParser(description=__doc__[1:])
 
-# version option
-parser.add_argument("--version", action="version", version=__version__,
-                    help="Prints version information.")
-
-# workflow options
-parser.add_argument("--workflow-name", required=True,
-                    help="Name of the workflow.")
-parser.add_argument("--tags", nargs="+", default=[],
-                    help="Append the given tags to file names.")
-parser.add_argument("--output-dir", default=None,
-                    help="Path to directory where the workflow will be "
-                         "written. Default is to use "
-                         "{workflow-name}_output.")
-parser.add_argument("--output-map", default="output.map",
-                    help="Path to an output map file. Default is "
-                         "output.map.")
-parser.add_argument("--dax-file", default=None,
-                    help="Path to DAX file. Default is to write to the "
-                         "output directory with name {workflow-name}.dax.")
-# inference options
-parser.add_argument("--seed", type=int, default=0,
-                    help="Starting to seed to use. This will be incremented "
-                         "one for each injection analyzed. Default is 0.")
 # injection options: either specify a number to create, or use the given file
 group = parser.add_mutually_exclusive_group(required=True)
 group.add_argument("--num-injections", type=int,
@@ -94,6 +85,14 @@ group.add_argument("--injection-file", type=str, nargs="+",
                         "creating them.")
 # add option groups
 configuration.add_workflow_command_line_group(parser)
+# add workflow group
+inffu.add_inference_workflow_group(parser)
+parser.add_argument("--seed", type=int, default=0,
+                    help="Starting to seed to use. This will be incremented "
+                         "one for each injection analyzed. Default is 0.")
+# version option
+parser.add_argument("--version", action="version", version=__version__,
+                    help="Prints version information.")
 
 # parser command line
 opts = parser.parse_args()
@@ -132,7 +131,7 @@ finalize_workflow = core.Workflow(opts, opts.workflow_name + "-finalization")
 
 # load the inference config file
 inference_cp, nruns = read_inference_settings_from_config(
-    workflow.cp, 'workflow-inference_config')
+    workflow.cp, 'workflow-inference')
 
 # change working directory to the output
 origdir = os.path.abspath(os.curdir)
@@ -143,7 +142,7 @@ os.chdir(opts.output_dir)
 if opts.injection_file:
     injection_files = core.FileList([])
     n_injections = 0
-    for injection_file in opts.injection_files:
+    for injection_file in opts.injection_file:
         injections = InjectionSet('{}/{}'.format(origdir, injection_file))
         local_numinj = len(injections.table)
         st_args = {k: injections.table[k][0] 
@@ -217,8 +216,8 @@ config_files = {}
 posterior_files = []
 seed = opts.seed
 # loop over number of injecionts to be analyzed
-for num_inj in range(num_injections):
-    zpad = int(numpy.ceil(numpy.log10(num_injections)))
+for num_inj in range(n_injections):
+    zpad = int(numpy.ceil(numpy.log10(n_injections)))
     label = 'Injection {}'.format(str(num_inj+1).zfill(zpad))
     event = label.lower().replace(' ', '_')
 
@@ -235,7 +234,7 @@ for num_inj in range(num_injections):
     # independent noise realizations
     if inference_cp.has_option('data', 'fake-strain-seed'):
         # get the detectors
-        detectors = shlex.split(cp.get('data', 'instruments'))
+        detectors = shlex.split(inference_cp.get('data', 'instruments'))
         fake_strain_seeds = {}
         for det in detectors:
             fake_strain_seeds[det] = seed
@@ -253,7 +252,7 @@ for num_inj in range(num_injections):
     symlink_path(config_file, rdir[base])
 
     # add a node to create the injection if an injection file wasn't provided
-    if opts.injection_files:
+    if opts.injection_file:
         injection_file = injection_files[num_inj]
     else:
         # construct Executable for creating injections
@@ -262,22 +261,24 @@ for num_inj in range(num_injections):
             out_dir=injection_file_dir)
         node, injection_file = create_injections_exe.create_node(
             config_file, seed=seed, tags=opts.tags+[event])
-        workflow += node
+        node.add_opt("--ninjections", 1)
+        sub_workflow += node
         seed = seed + 1
 
     # add the injection file to the inference config file
-    cp = configuration.WorkflowConfigParser([config_file])
-    cp.set('data', 'injection', injection_file)
-    cp.close()
+    cp = configuration.WorkflowConfigParser([config_file.storage_path])
+    cp.set('data', 'injection', injection_file.name)
+    with open(config_file.storage_path, "w") as fp:
+        cp.write(fp)
 
     # make node(s) for running sampler
     samples_files = []
     inference_exe = PycbcInferenceExecutable(sub_workflow.cp, "inference",
                                              ifos=sub_workflow.ifos,
                                              out_dir=samples_file_dir)
-    for nn in range(nrun):
+    for nn in range(nruns):
         tags = opts.tags + [event]
-        if nrun > 1:
+        if nruns > 1:
             tags.append(str(nn))
         node, samples_file = inference_exe.create_node(
             config_file, seed=seed, tags=tags,
@@ -286,6 +287,7 @@ for num_inj in range(num_injections):
         node.add_input(injection_file)
         # add node to workflow
         sub_workflow += node
+        samples_files.append(samples_file)
         # increment the seed
         seed = seed + 1
 
@@ -309,12 +311,12 @@ for num_inj in range(num_injections):
     # build the summary page
     zpad = int(numpy.ceil(numpy.log10(len(samples_files))))
     layout.two_column_layout(rdir.base, summary_files,
-                             unique=str(num_event).zfill(zpad),
+                             unique=str(num_inj).zfill(zpad),
                              title=label, collapse=True)
 
     # build the psd page
     layout.single_layout(rdir['detector_sensitivity'], [psd_plot],
-                         unique=str(num_event).zfill(zpad),
+                         unique=str(num_inj).zfill(zpad),
                          title=label, collapse=True)
 
     # add the sub workflow to the main workflow

--- a/bin/workflows/pycbc_make_inference_inj_workflow
+++ b/bin/workflows/pycbc_make_inference_inj_workflow
@@ -213,7 +213,7 @@ logging.getLogger("").addHandler(log_file)
 logging.info("Created log file %s" % log_file_txt.storage_path)
 
 config_files = {}
-posterior_files = []
+posterior_files = core.FileList([])
 seed = opts.seed
 # loop over number of injecionts to be analyzed
 for num_inj in range(n_injections):
@@ -325,10 +325,18 @@ for num_inj in range(n_injections):
 
 # create the PP and recovery plot
 if do_pp_test:
+    # create a sub workflow to do the PP test
+    # we need to go back to the original directory to do this for all the file
+    # references to work correctly
+    os.chdir(origdir)
+    pp_workflow = core.Workflow(
+        opts, "{}-{}".format(opts.workflow_name, 'pp_test'))
+    # now go back to the output
+    os.chdir(opts.output_dir)
     # create the pp summary table
     pp_table = inffu.make_inference_pp_table(
-        workflow, posterior_files, rdir[pp_section], parameters=pp_params,
-        injection_samples_map=inj_samples_map,
+        pp_workflow, posterior_files, rdir[pp_section],
+        parameters=pp_params, injection_samples_map=inj_samples_map,
         analysis_seg=workflow.analysis_time, tags=opts.tags)
     layout.single_layout(rdir[pp_section], pp_table)
     # now the pp plots and injection recovery
@@ -338,18 +346,20 @@ if do_pp_test:
         tags = opts.tags + ['PARAM_{}'.format(pi)]
         # the pp plot
         pp_plot = inffu.make_inference_pp_plot(
-            workflow, posterior_files, rdir[pp_section], parameters=param,
-            injection_samples_map=inj_samples_map,
+            pp_workflow, posterior_files, rdir[pp_section],
+            parameters=param, injection_samples_map=inj_samples_map,
             analysis_seg=workflow.analysis_time, tags=tags)[0]
         pp_plots.append(pp_plot)
         # the injection recovery plot
         injrec_plot = inffu.make_inference_inj_recovery_plot(
-            workflow, posterior_files, rdir[pp_section], param,
+            pp_workflow, posterior_files, rdir[pp_section], param,
             injection_samples_map=inj_samples_map,
             analysis_seg=workflow.analysis_time, tags=tags)[0]
         inj_recovery_plots.append(injrec_plot)
     layout.two_column_layout(rdir[pp_section],
                              list(zip(pp_plots, inj_recovery_plots)))
+    # add to the main workflow
+    workflow += pp_workflow
 
 # create versioning HTML pages
 results.create_versioning_page(rdir["workflow/version"], container.cp)

--- a/bin/workflows/pycbc_make_inference_inj_workflow
+++ b/bin/workflows/pycbc_make_inference_inj_workflow
@@ -267,7 +267,7 @@ for num_inj in range(n_injections):
 
     # add the injection file to the inference config file
     cp = configuration.WorkflowConfigParser([config_file.storage_path])
-    cp.set('data', 'injection', injection_file.name)
+    cp.set('data', 'injection-file', injection_file.name)
     with open(config_file.storage_path, "w") as fp:
         cp.write(fp)
 

--- a/bin/workflows/pycbc_make_inference_inj_workflow
+++ b/bin/workflows/pycbc_make_inference_inj_workflow
@@ -125,8 +125,7 @@ log_format = "%(asctime)s:%(levelname)s : %(message)s"
 logging.basicConfig(format=log_format, level=logging.INFO)
 
 # create workflow and sub-workflows
-container = core.Workflow(opts, opts.workflow_name)
-workflow = core.Workflow(opts, opts.workflow_name + "-main")
+workflow = core.Workflow(opts, opts.workflow_name)
 finalize_workflow = core.Workflow(opts, opts.workflow_name + "-finalization")
 
 # load the inference config file
@@ -216,6 +215,7 @@ config_files = {}
 posterior_files = core.FileList([])
 seed = opts.seed
 # loop over number of injecionts to be analyzed
+sub_workflows = []
 for num_inj in range(n_injections):
     zpad = int(numpy.ceil(numpy.log10(n_injections)))
     label = 'Injection {}'.format(str(num_inj+1).zfill(zpad))
@@ -322,6 +322,7 @@ for num_inj in range(n_injections):
 
     # add the sub workflow to the main workflow
     workflow += sub_workflow
+    sub_workflows.append(sub_workflow)
 
 # create the PP and recovery plot
 if do_pp_test:
@@ -362,28 +363,31 @@ if do_pp_test:
     workflow += pp_workflow
 
 # create versioning HTML pages
-results.create_versioning_page(rdir["workflow/version"], container.cp)
+results.create_versioning_page(rdir["workflow/version"], workflow.cp)
 
 # create node for making HTML pages
 plotting.make_results_web_page(finalize_workflow,
     os.path.join(os.getcwd(), rdir.base))
 
-# add sub-workflows to workflow
-container += workflow
-container += finalize_workflow
-
-# make finalize sub-workflow depend on main sub-workflow
-dep = dax.Dependency(parent=workflow.as_job, child=finalize_workflow.as_job)
-container._adag.addDependency(dep)
+# add finalize workflow to workflow and make it depend on the others
+workflow += finalize_workflow
+for sub_workflow in sub_workflows:
+    dep = dax.Dependency(parent=sub_workflow.as_job,
+                         child=finalize_workflow.as_job)
+    workflow._adag.addDependency(dep)
+if do_pp_test:
+    dep = dax.Dependency(parent=pp_workflow.as_job,
+                         child=finalize_workflow.as_job)
+    workflow._adag.addDependency(dep)
 
 # write dax
-container.save(filename=dax_file, output_map_path=opts.output_map,
-               transformation_catalog_path=opts.transformation_catalog)
+workflow.save(filename=dax_file, output_map_path=opts.output_map,
+              transformation_catalog_path=opts.transformation_catalog)
 
 # save workflow configuration file
 base = rdir["workflow/configuration"]
 core.makedir(base)
-wf_ini = workflow.save_config("workflow.ini", base, container.cp)
+wf_ini = workflow.save_config("workflow.ini", base, workflow.cp)
 layout.single_layout(base, wf_ini)
 
 # close the log and flush to the html file

--- a/bin/workflows/pycbc_make_inference_plots_workflow
+++ b/bin/workflows/pycbc_make_inference_plots_workflow
@@ -124,32 +124,12 @@ def symlink_path(f, path):
 
 # command line parser
 parser = argparse.ArgumentParser(description=__doc__[1:])
-
-# version option
-parser.add_argument("--version", action="version", version=__version__,
-                    help="Prints version information.")
-
-# workflow options
-parser.add_argument("--workflow-name", required=True,
-                    help="Name of the workflow to append in various places.")
-parser.add_argument("--tags", nargs="+", default=[],
-                    help="Tags to apend in various places.")
-parser.add_argument("--output-dir", default=None,
-                    help="Path to directory where the workflow will be "
-                         "written. Default is to use "
-                         "{workflow-name}_output.")
-parser.add_argument("--output-map", default="output.map",
-                    help="Path to an output map file. Default is "
-                         "output.map.")
-parser.add_argument("--transformation-catalog", default=None,
-                    help="Path to transformation catalog file.")
-parser.add_argument("--dax-file", default=None,
-                    help="Path to DAX file. Default is to write to the "
-                         "output directory with name {workflow-name}.dax.")
 # add option groups
 configuration.add_workflow_command_line_group(parser)
-
-# parser command line
+# workflow options
+inffu.add_inference_workflow_group(parser)
+parser.add_argument("--version", action="version", version=__version__,
+                    help="Prints version information.")
 opts = parser.parse_args()
 
 posterior_file_dir = 'posterior_files'

--- a/bin/workflows/pycbc_make_inference_plots_workflow
+++ b/bin/workflows/pycbc_make_inference_plots_workflow
@@ -127,7 +127,7 @@ parser = argparse.ArgumentParser(description=__doc__[1:])
 # add option groups
 configuration.add_workflow_command_line_group(parser)
 # workflow options
-inffu.add_inference_workflow_group(parser)
+core.add_workflow_settings_cli(parser, include_subdax_opts=True)
 parser.add_argument("--version", action="version", version=__version__,
                     help="Prints version information.")
 opts = parser.parse_args()

--- a/bin/workflows/pycbc_make_inference_workflow
+++ b/bin/workflows/pycbc_make_inference_workflow
@@ -152,35 +152,18 @@ def symlink_path(f, path):
 
 # command line parser
 parser = argparse.ArgumentParser(description=__doc__[1:])
-
-# version option
-parser.add_argument("--version", action="version", version=__version__,
-                    help="Prints version information.")
-
+# add option groups
+configuration.add_workflow_command_line_group(parser)
 # workflow options
-parser.add_argument("--workflow-name", required=True,
-                    help="Name of the workflow.")
-parser.add_argument("--tags", nargs="+", default=[],
-                    help="Append the given tags to file names.")
-parser.add_argument("--output-dir", default=None,
-                    help="Path to directory where the workflow will be "
-                         "written. Default is to use "
-                         "{workflow-name}_output.")
-parser.add_argument("--output-map", default="output.map",
-                    help="Path to an output map file. Default is "
-                         "output.map.")
-parser.add_argument("--transformation-catalog", default=None,
-                    help="Path to transformation catalog file.")
-parser.add_argument("--dax-file", default=None,
-                    help="Path to DAX file. Default is to write to the "
-                         "output directory with name {workflow-name}.dax.")
-# inference options
+inffu.add_inference_workflow_group(parser)
 parser.add_argument("--seed", type=int, default=0,
                     help="Seed to use for inference job(s). If multiple "
                          "events are analyzed, the seed will be incremented "
                          "by one for each event.")
-# add option groups
-configuration.add_workflow_command_line_group(parser)
+# version option
+parser.add_argument("--version", action="version", version=__version__,
+                    help="Prints version information.")
+
 
 # parser command line
 opts = parser.parse_args()

--- a/bin/workflows/pycbc_make_inference_workflow
+++ b/bin/workflows/pycbc_make_inference_workflow
@@ -155,7 +155,7 @@ parser = argparse.ArgumentParser(description=__doc__[1:])
 # add option groups
 configuration.add_workflow_command_line_group(parser)
 # workflow options
-inffu.add_inference_workflow_group(parser)
+core.add_workflow_settings_cli(parser, include_subdax_opts=True)
 parser.add_argument("--seed", type=int, default=0,
                     help="Seed to use for inference job(s). If multiple "
                          "events are analyzed, the seed will be incremented "

--- a/pycbc/inject/inject.py
+++ b/pycbc/inject/inject.py
@@ -427,7 +427,12 @@ class _HDFInjectionSet(object):
             if write_params is None:
                 write_params = samples.fieldnames
             for arg, val in static_args.items():
-                fp.attrs[arg] = val
+                try:
+                    fp.attrs[arg] = val
+                except TypeError:
+                    # can get this in python 3 if the val was numpy.str_ type
+                    # try decoding it and writing
+                    fp.attrs[arg] = str(val)
             for field in write_params:
                 fp[field] = samples[field]
 

--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -1994,3 +1994,36 @@ def get_random_label():
     """
     return ''.join(random.choice(string.ascii_uppercase + string.digits) \
                    for _ in range(15))
+
+
+def add_workflow_settings_cli(parser, include_subdax_opts=False):
+    """Adds workflow options to an argument parser.
+
+    Parameters
+    ----------
+    parser : argparse.ArgumentParser
+        Argument parser to add the options to.
+    include_subdax_opts : bool, optional
+        If True, will add output-map, transformation-catalog, and dax-file
+        options to the parser. These can be used for workflows that are
+        generated as a subdax of another workflow. Default is False.
+    """
+    wfgrp = parser.add_argument_group("Options for setting workflow files")
+    wfgrp.add_argument("--workflow-name", required=True,
+                       help="Name of the workflow.")
+    wfgrp.add_argument("--tags", nargs="+", default=[],
+                       help="Append the given tags to file names.")
+    wfgrp.add_argument("--output-dir", default=None,
+                       help="Path to directory where the workflow will be "
+                            "written. Default is to use "
+                            "{workflow-name}_output.")
+    if include_subdax_opts:
+        wfgrp.add_argument("--output-map", default="output.map",
+                           help="Path to an output map file. Default is "
+                                "output.map.")
+        wfgrp.add_argument("--transformation-catalog", default=None,
+                           help="Path to transformation catalog file.")
+        wfgrp.add_argument("--dax-file", default=None,
+                           help="Path to DAX file. Default is to write to the "
+                                "output directory with name "
+                                "{workflow-name}.dax.")

--- a/pycbc/workflow/inference_followups.py
+++ b/pycbc/workflow/inference_followups.py
@@ -579,7 +579,7 @@ def make_inference_inj_recovery_plot(workflow, posterior_files, output_dir,
     """
     # arguments are the same as plot_pp, so just call that with the
     # different executable name
-    return make_inference_inference_pp_plot(
+    return make_inference_pp_plot(
         workflow, posterior_files, output_dir, parameters=parameter,
         injection_samples_map=injection_samples_map,
         name=name, analysis_seg=analysis_seg, tags=tags)

--- a/pycbc/workflow/inference_followups.py
+++ b/pycbc/workflow/inference_followups.py
@@ -92,7 +92,7 @@ def make_inference_plot(workflow, input_file, output_dir,
         # and put the opt back in the config file in memory
         workflow.cp.set(name, 'parameters', parameters)
     # add input and output options
-    if isinstance(input_file, list): 
+    if isinstance(input_file, list):
         # list of input files are given, use input_list_opt
         node.add_input_list_opt("--{}".format(input_file_opt), input_file)
     else:

--- a/pycbc/workflow/inference_followups.py
+++ b/pycbc/workflow/inference_followups.py
@@ -862,27 +862,6 @@ def make_posterior_workflow(workflow, samples_files, config_file, label,
     return posterior_file, summary_files, prior_plots, posterior_plots
 
 
-def add_inference_workflow_group(parser):
-    """Add workflow options to an argument parser."""
-    wfgrp = parser.add_argument_group("Options for setting workflow files.")
-    wfgrp.add_argument("--workflow-name", required=True,
-                       help="Name of the workflow.")
-    wfgrp.add_argument("--tags", nargs="+", default=[],
-                       help="Append the given tags to file names.")
-    wfgrp.add_argument("--output-dir", default=None,
-                       help="Path to directory where the workflow will be "
-                            "written. Default is to use "
-                            "{workflow-name}_output.")
-    wfgrp.add_argument("--output-map", default="output.map",
-                       help="Path to an output map file. Default is "
-                            "output.map.")
-    wfgrp.add_argument("--transformation-catalog", default=None,
-                       help="Path to transformation catalog file.")
-    wfgrp.add_argument("--dax-file", default=None,
-                       help="Path to DAX file. Default is to write to the "
-                            "output directory with name {workflow-name}.dax.")
-
-
 def _params_for_pegasus(parameters):
     """Escapes $ and escapes in parameters string for pegasus.
 

--- a/pycbc/workflow/inference_followups.py
+++ b/pycbc/workflow/inference_followups.py
@@ -862,6 +862,27 @@ def make_posterior_workflow(workflow, samples_files, config_file, label,
     return posterior_file, summary_files, prior_plots, posterior_plots
 
 
+def add_inference_workflow_group(parser):
+    """Add workflow options to an argument parser."""
+    wfgrp = parser.add_argument_group("Options for setting workflow files.")
+    wfgrp.add_argument("--workflow-name", required=True,
+                       help="Name of the workflow.")
+    wfgrp.add_argument("--tags", nargs="+", default=[],
+                       help="Append the given tags to file names.")
+    wfgrp.add_argument("--output-dir", default=None,
+                       help="Path to directory where the workflow will be "
+                            "written. Default is to use "
+                            "{workflow-name}_output.")
+    wfgrp.add_argument("--output-map", default="output.map",
+                       help="Path to an output map file. Default is "
+                            "output.map.")
+    wfgrp.add_argument("--transformation-catalog", default=None,
+                       help="Path to transformation catalog file.")
+    wfgrp.add_argument("--dax-file", default=None,
+                       help="Path to DAX file. Default is to write to the "
+                            "output directory with name {workflow-name}.dax.")
+
+
 def _params_for_pegasus(parameters):
     """Escapes $ and escapes in parameters string for pegasus.
 

--- a/pycbc/workflow/jobsetup.py
+++ b/pycbc/workflow/jobsetup.py
@@ -1752,6 +1752,7 @@ class PycbcConditionStrainExecutable(Executable):
 
         return node, out_file
 
+
 class PycbcCreateInjectionsExecutable(Executable):
     """ The class responsible for creating jobs
     for ``pycbc_create_injections``.
@@ -1792,7 +1793,7 @@ class PycbcCreateInjectionsExecutable(Executable):
 
         # make node for running executable
         node = Node(self)
-        node.add_input_opt("--config-file", config_file)
+        node.add_input_opt("--config-files", config_file)
         if seed:
             node.add_opt("--seed", seed)
         injection_file = node.new_output_file_opt(analysis_time,
@@ -1800,6 +1801,7 @@ class PycbcCreateInjectionsExecutable(Executable):
                                                   tags=tags)
 
         return node, injection_file
+
 
 class PycbcInferenceExecutable(Executable):
     """ The class responsible for creating jobs for ``pycbc_inference``.

--- a/pycbc/workflow/pegasus_workflow.py
+++ b/pycbc/workflow/pegasus_workflow.py
@@ -272,7 +272,7 @@ class Workflow(object):
 
     def _make_root_dependency(self, inp):
         def root_path(v):
-            path = []
+            path = [v]
             while v.in_workflow:
                 path += [v.in_workflow]
                 v = v.in_workflow
@@ -285,7 +285,7 @@ class Workflow(object):
                 break
         dep = dax.Dependency(
             parent=input_root[input_root.index(common)-1].as_job,
-            child=self.as_job)
+            child=workflow_root[workflow_root.index(common)-1].as_job)
         common._adag.addDependency(dep)
 
     def add_workflow(self, workflow):

--- a/pycbc/workflow/pegasus_workflow.py
+++ b/pycbc/workflow/pegasus_workflow.py
@@ -277,17 +277,15 @@ class Workflow(object):
                 path += [v.in_workflow]
                 v = v.in_workflow
             return path
-
         workflow_root = root_path(self)
         input_root = root_path(inp)
-
         for step in workflow_root:
             if step in input_root:
                 common = step
                 break
-
-        dep = dax.Dependency(child=workflow_root[workflow_root.index(common)-1],
-                             parent=input_root[input_root.index(common)-1])
+        dep = dax.Dependency(
+            parent=input_root[input_root.index(common)-1].as_job,
+            child=self.as_job)
         common._adag.addDependency(dep)
 
     def add_workflow(self, workflow):
@@ -310,7 +308,7 @@ class Workflow(object):
         node.file.PFN(os.path.join(os.getcwd(), node.file.name), site='local')
         self._adag.addFile(node.file)
 
-        for inp in self._external_workflow_inputs:
+        for inp in workflow._external_workflow_inputs:
             workflow._make_root_dependency(inp.node)
 
         return self
@@ -354,7 +352,6 @@ class Workflow(object):
             elif inp.node is not None and inp.node.in_workflow != self and inp not in self._inputs:
                 self._inputs += [inp]
                 self._external_workflow_inputs += [inp]
-
 
         # Record the outputs that this node generates
         self._outputs += node._outputs

--- a/pycbc/workflow/pegasus_workflow.py
+++ b/pycbc/workflow/pegasus_workflow.py
@@ -159,6 +159,11 @@ class Node(ProfileShortcuts):
         else:
             self._options += [opt]
 
+    def add_input(self, inp):
+        """Declares an input file without adding it as a command-line option.
+        """
+        self._add_input(inp)
+
     #private functions to add input and output data sources/sinks
     def _add_input(self, inp):
         """ Add as source of input data


### PR DESCRIPTION
This updates the `inference_inj` workflow for the new inference syntax (with the data in the config file), and to bring it in line with the syntax of the inference workflow. As before, the inj workflow supports either generating injections on its own (done by setting the `--ninjections` argument) or being given an injection (done by setting `--injection-file`). The PP test is now optional; it will only be done if the `executables` section includes `pp_summary_table`. The results of the PP test go in their own tab in the results page.

Examples:
 * [injections generated from the inference config file](https://www.atlas.aei.uni-hannover.de/~work-cdcapano/scratch/prs/update_pp_workflow/py36_pp_quick_test6_output/html/)
 * [using a provided injection file](https://www.atlas.aei.uni-hannover.de/~work-cdcapano/scratch/prs/update_pp_workflow/with_injection_file/py36_pp_quick_test2_given_file_output/html/)

This also:
 * Fixes a bug in `pegasus_workflow.py`. Dependencies between sub-workflows in which one workflow depended on another were not being set correctly.
 * Changes the default section that `pycbc_create_injections` gets its prior from `distribution` to `prior`.
 * Moves common workflow options for the inference workflows to a parser group, which all of the `pycbc_make_inference_*workflow` now use.
 * Makes the plots created by `plot_inj_recovery` have the same aspect ratio as `plot_pp`, and adds metadata info to those plots.

This does not update the docs. I will do that in a separate PR.