### PR TITLE
Minor bugfix in data opts reading from config

### DIFF
--- a/pycbc/inference/models/data_utils.py
+++ b/pycbc/inference/models/data_utils.py
@@ -333,7 +333,7 @@ def data_opts_from_config(cp, section, filter_flow):
     for det in opts.instruments:
         gps_start[det] += opts.trigger_time
         gps_end[det] += opts.trigger_time
-        if opts.psd_inverse_length is not None:
+        if opts.psd_inverse_length[det] is not None:
             pad = int(numpy.ceil(opts.psd_inverse_length[det] / 2))
             logging.info("Padding %s analysis start and end times by %d "
                          "(= psd-inverse-length/2) seconds to "


### PR DESCRIPTION
A check for psd_inverse_length was not qualified by detector name in `pycbc.models.data_utils.data_opts_from_config`, which resulted in the test always passing.

This PR fixes that.