### PR TITLE
Allow FIT_BY_XXX files to be bypassed

### DIFF
--- a/pycbc/workflow/minifollowups.py
+++ b/pycbc/workflow/minifollowups.py
@@ -203,7 +203,7 @@ def setup_single_det_minifollowups(workflow, single_trig_file, tmpltbank_file,
         assert(veto_segment_name is not None)
         node.add_input_opt('--veto-file', veto_file)
         node.add_opt('--veto-segment-name', veto_segment_name)
-    if statfiles is not None:
+    if statfiles:
         statfiles = statfiles.find_output_with_ifo(curr_ifo)
         node.add_input_list_opt('--statistic-files', statfiles)
     node.new_output_file_opt(workflow.analysis_time, '.dax', '--output-file', tags=tags)


### PR DESCRIPTION
The template fitting part of the workflow allows an option to not do it at all (e.g. if using new_SNR). However, this was broken by recent changes in minifollowups. This fixes that. In particular `statfiles` being an empty list is a valid input, but should not create a command line call to the executable.

The context here is to try to stand-up a test workflow using a short amount of data, that can be run end-to-end as close to production workflows as possible. As the `FIT_BY` codes will not do useful things, we need to turn them off in this example.