### PR TITLE
New search workflow cleanup 1

### DIFF
--- a/bin/workflows/pycbc_create_offline_search_workflow
+++ b/bin/workflows/pycbc_create_offline_search_workflow
@@ -187,7 +187,7 @@ no_fg_exc_files = {}
 ifo_ids = {}
 
 # Get the ifo precedence values
-ifo_precedence_list = workflow.cp.get_opt_tags('workflow-coincidence', 'timeslide-precedence', ctags)
+ifo_precedence_list = workflow.cp.get_opt_tags('workflow-coincidence', 'timeslide-precedence', ['full_data'])
 for ifo, _ in zip(*insps.categorize_by_attr('ifo')):
     ifo_ids[ifo] = ifo_precedence_list.index(ifo)
 

--- a/bin/workflows/pycbc_create_offline_search_workflow
+++ b/bin/workflows/pycbc_create_offline_search_workflow
@@ -337,35 +337,37 @@ if vetodef_table is not None:
 ##################### SINGLES plots first ###################################
 
 snrchi = wf.make_snrchi_plot(workflow, insps, censored_veto,
-                            'closed_box', rdir['single_triggers'], tags=[tag])
+                            'closed_box', rdir['single_triggers'],
+                            tags=['full_data'])
 layout.group_layout(rdir['single_triggers'], snrchi)
 
 hist_summ = []
 for insp in full_insps:
     outdir = rdir['single_triggers/%s_binned_triggers' % insp.ifo]
     wf.make_singles_plot(workflow, [insp], hdfbank[0], censored_veto,
-                         'closed_box', outdir, tags=[tag])
+                         'closed_box', outdir, tags=['full_data'])
     # make non-summary hists using the bank file
     # currently, none of these are made
     outdir = rdir['single_triggers/%s_trigger_histograms' % insp.ifo]
     wf.make_single_hist(workflow, insp, censored_veto, 'closed_box', outdir,
-                        bank_file=hdfbank[0], exclude='summ', tags=[tag])
+                        bank_file=hdfbank[0], exclude='summ',
+                        tags=['full_data')
     # make summary hists for all templates together
     # currently, 2 per ifo: snr and newsnr
     outdir = rdir['single_triggers/%s_trigger_histograms' % insp.ifo]
     allhists = wf.make_single_hist(workflow, insp, censored_veto, 'closed_box',
-                                   outdir, require='summ', tags=[tag])
+                                   outdir, require='summ', tags=['full_data'])
     # make hists of newsnr split up by parameter
     # currently, 1 per ifo split by template duration
     outdir = rdir['single_triggers/%s_binned_histograms' % insp.ifo]
     binhists = wf.make_binned_hist(workflow, insp, censored_veto,
                                    'closed_box', outdir, hdfbank[0],
-                                   tags=[tag])
+                                   tags=['full_data'])
     # put raw SNR and binned newsnr hist in summary
     hist_summ += list(layout.grouper([allhists[0], binhists[0]], 2))
 
 if workflow.cp.has_option_tags('workflow-matchedfilter',
-                                   'plot-throughput', tags=[tag]):
+                               'plot-throughput', tags=['full_data']):
     wf.make_throughput_plot(workflow, full_insps, rdir['workflow/throughput'],
                             tags=['full_data'])
 

--- a/bin/workflows/pycbc_create_offline_search_workflow
+++ b/bin/workflows/pycbc_create_offline_search_workflow
@@ -439,17 +439,18 @@ closed_page = [(bank_plot,)]
 layout.two_column_layout(rdir['coincident_triggers'], closed_page)
 
 # run minifollowups on the output of the loudest events
-mfup_dir = rdir['open_box_result/loudest_events_followup']
+mfup_dir_fg = rdir['open_box_result/loudest_events_followup']
+mfup_dir_bg = rdir['coincident_triggers/loudest_background_followup']
 wf.setup_foreground_minifollowups(workflow, combined_bg_file,
                                   full_insps, hdfbank, insp_files_seg_file,
                                   data_analysed_name, trig_generated_name,
-                                  'daxes', mfup_dir,
+                                  'daxes', mfup_dir_fg,
                                   tags=combined_bg_file.tags + ['foreground'])
 
 wf.setup_foreground_minifollowups(workflow, combined_bg_file,
                                   full_insps, hdfbank, insp_files_seg_file,
-                                  data_analysed_name, trig_generated_name, 'daxes',
-                                  rdir['coincident_triggers/loudest_background_followup'],
+                                  data_analysed_name, trig_generated_name,
+                                  'daxes', mfup_dir_bg,
                                   tags=combined_bg_file.tags + ['background'])
 
 # Sub-pages for each ifo combination

--- a/bin/workflows/pycbc_create_offline_search_workflow
+++ b/bin/workflows/pycbc_create_offline_search_workflow
@@ -351,7 +351,7 @@ for insp in full_insps:
     outdir = rdir['single_triggers/%s_trigger_histograms' % insp.ifo]
     wf.make_single_hist(workflow, insp, censored_veto, 'closed_box', outdir,
                         bank_file=hdfbank[0], exclude='summ',
-                        tags=['full_data')
+                        tags=['full_data'])
     # make summary hists for all templates together
     # currently, 2 per ifo: snr and newsnr
     outdir = rdir['single_triggers/%s_trigger_histograms' % insp.ifo]

--- a/bin/workflows/pycbc_create_offline_search_workflow
+++ b/bin/workflows/pycbc_create_offline_search_workflow
@@ -204,8 +204,8 @@ for ifocomb in ifo_combos(ifo_ids.keys()):
     ctagcomb = ['full_data', coinctag]
 
     bg_file = wf.setup_multiifo_interval_coinc(
-        workflow, hdfbank, inspcomb, statfiles, [final_veto_file],
-        [final_veto_name], output_dir, pivot_ifo, fixed_ifo, tags=ctagcomb)
+        workflow, hdfbank, inspcomb, statfiles, final_veto_file,
+        final_veto_name, output_dir, pivot_ifo, fixed_ifo, tags=ctagcomb)
 
     # Optionally perform follow-up on triggers and rerank the candidates
     # Returns the input file if not enabled.

--- a/bin/workflows/pycbc_create_offline_search_workflow
+++ b/bin/workflows/pycbc_create_offline_search_workflow
@@ -51,6 +51,14 @@ def symlink_result(f, rdir_path):
     symlink_path(f, rdir[rdir_path])
 
 
+# Generator for producing ifo combinations
+def ifo_combos(ifos):
+    for i in range(2, len(ifos)+1):
+        combinations = itertools.combinations(ifos, i)
+        for ifocomb in combinations:
+            yield ifocomb
+
+
 # Log to the screen until we know where the output file is
 logging.basicConfig(format='%(asctime)s:%(levelname)s : %(message)s',
     level=logging.INFO)
@@ -133,50 +141,48 @@ datafind_files, analyzable_file, analyzable_segs, analyzable_name = \
                                      ssegs, "datafind",
                                      seg_file=science_seg_file)
 
-final_veto_name = ['vetoes']
-final_veto_file = wf.FileList([wf.get_segments_file(workflow, final_veto_name[0],
+final_veto_name = 'vetoes'
+final_veto_file = wf.get_segments_file(workflow, final_veto_name,
                                        'segments-vetoes',
-                                       rdir['analysis_time/segment_data'])])
-
-# Precalculated PSDs
-precalc_psd_files = wf.setup_psd_workflow(workflow, analyzable_segs,
-                                            datafind_files, "psdfiles")
+                                       rdir['analysis_time/segment_data'])
 
 # Template bank stuff
 hdfbank = wf.setup_tmpltbank_workflow(workflow, analyzable_segs,
                                       datafind_files, output_dir="bank",
-                                      psd_files=precalc_psd_files,
                                       return_format='hdf')
+assert( len(hdfbank) == 1 )
+hdfbank = hdfbank[0]
 
-splitbank_files_fd = wf.setup_splittable_workflow(workflow, hdfbank,
+splitbank_files_fd = wf.setup_splittable_workflow(workflow, [hdfbank],
                                                   out_dir="bank",
                                                   tags=['full_data'])
 
-bank_plot = wf.make_template_plot(workflow, hdfbank[0],
+bank_plot = wf.make_template_plot(workflow, hdfbank,
                                   rdir['coincident_triggers'])
 
 ######################## Setup the FULL DATA run ##############################
-tag = output_dir = "full_data"
+output_dir = "full_data"
 
 # setup the matchedfilter jobs
 ind_insps = insps = wf.setup_matchedfltr_workflow(workflow, analyzable_segs,
                                    datafind_files, splitbank_files_fd,
-                                   output_dir, tags = [tag])
+                                   output_dir, tags=['full_data'])
 
-insps = wf.merge_single_detector_hdf_files(workflow, hdfbank[0],
-                                           insps, output_dir, tags=[tag])
+insps = wf.merge_single_detector_hdf_files(workflow, hdfbank,
+                                           insps, output_dir,
+                                           tags=['full_data'])
 
 # setup sngl trigger distribution fitting jobs
 # 'statfiles' is list of files used in calculating coinc statistic
 statfiles = []
 statfiles += wf.setup_trigger_fitting(workflow, insps, hdfbank,
-                                      final_veto_file, final_veto_name)
+                                      final_veto_file, final_veto_name,
+                                      tags=['full_data'])
 
 # Set up the multi-ifo coinc jobs
 # final_bg_files contains coinc results using vetoes final_veto_files
 # ifo_ids will store an (integer) index for each ifo in the precedence list
 full_insps = insps
-ctags = [tag]
 no_fg_exc_files = {}
 ifo_ids = {}
 
@@ -188,60 +194,60 @@ for ifo, _ in zip(*insps.categorize_by_attr('ifo')):
 # Generate the possible detector combinations from 2 detectors
 # up to the number of trigger files
 
-for i in range(2, len(insps)+1):
-    combinations = itertools.combinations(ifo_ids.keys(), i)
-    for ifocomb in combinations:
-        inspcomb = wf.select_files_by_ifo_combination(ifocomb, insps)
-        pivot_ifo, fixed_ifo, ordered_ifo_list = wf.get_ordered_ifo_list(ifocomb, ifo_ids)
+for ifocomb in ifo_combos(ifo_ids.keys()):
+    inspcomb = wf.select_files_by_ifo_combination(ifocomb, insps)
+    pivot_ifo, fixed_ifo, ordered_ifo_list = wf.get_ordered_ifo_list(ifocomb,
+                                                                     ifo_ids)
 
-        # Create coinc tag, and set up the coinc job for the combination
-        coinctag = '{}det'.format(len(ifocomb))
-        ctagcomb = [tag, 'full', coinctag, ordered_ifo_list]
+    # Create coinc tag, and set up the coinc job for the combination
+    coinctag = '{}det'.format(len(ifocomb))
+    ctagcomb = ['full_data', coinctag]
 
-        bg_file = wf.setup_multiifo_interval_coinc(
-            workflow, hdfbank, inspcomb, statfiles, final_veto_file,
-            final_veto_name, output_dir, pivot_ifo, fixed_ifo, tags=ctagcomb)[0][1][0]
+    bg_file = wf.setup_multiifo_interval_coinc(
+        workflow, hdfbank, inspcomb, statfiles, [final_veto_file],
+        [final_veto_name], output_dir, pivot_ifo, fixed_ifo, tags=ctagcomb)
 
-        # Optionally perform follow-up on triggers and rerank the candidates
-        no_fg_exc_files[ordered_ifo_list] = wf.rerank_coinc_followup(
-                       workflow, bg_file, hdfbank[0], output_dir,
-                       tags=ctagcomb)
+    # Optionally perform follow-up on triggers and rerank the candidates
+    # Returns the input file if not enabled.
+    no_fg_exc_files[ordered_ifo_list] = wf.rerank_coinc_followup(
+                   workflow, bg_file, hdfbank, output_dir,
+                   tags=ctagcomb)
 
 
 if len(insps) == 2:
     final_bg_files = no_fg_exc_files
 else:
     final_bg_files = {}
-    for i in range(2, len(insps)+1):
-        combinations = itertools.combinations(ifo_ids.keys(), i)
-        for ifocomb in combinations:
-            _, _, ordered_ifo_list = wf.get_ordered_ifo_list(ifocomb, ifo_ids)
-            # Create coinc tag
-            coinctag = '{}det'.format(len(ifocomb))
-            ctagcomb = [tag, 'full', coinctag, ordered_ifo_list]
-            other_ifo_keys = no_fg_exc_files.keys()
-            other_ifo_keys.remove(ordered_ifo_list)
-            other_bg_files = {ctype: no_fg_exc_files[ctype] for ctype in other_ifo_keys}
-            final_bg_files[ordered_ifo_list] = wf.setup_multiifo_exclude_zerolag(
-                                                   workflow,
-                                                   no_fg_exc_files[ordered_ifo_list],
-                                                   wf.FileList(other_bg_files.values()),
-                                                   output_dir, ordered_ifo_list,
-                                                   tags=ctagcomb)
+    for ifocomb in ifo_combos(ifo_ids.keys()):
+        _, _, ordered_ifo_list = wf.get_ordered_ifo_list(ifocomb, ifo_ids)
+        # Create coinc tag
+        coinctag = '{}det'.format(len(ifocomb))
+        ctagcomb = ['full_data', coinctag]
+        other_ifo_keys = no_fg_exc_files.keys()
+        other_ifo_keys.remove(ordered_ifo_list)
+        other_bg_files = {ctype: no_fg_exc_files[ctype]
+                          for ctype in other_ifo_keys}
+        final_bg_files[ordered_ifo_list] = wf.setup_multiifo_exclude_zerolag(
+            workflow,
+            no_fg_exc_files[ordered_ifo_list],
+            wf.FileList(other_bg_files.values()),
+            output_dir, ordered_ifo_list,
+            tags=ctagcomb
+        )
 
-combctags = [tag]
 combined_bg_file = wf.setup_multiifo_combine_statmap(
                                 workflow,
                                 wf.FileList(final_bg_files.values()),
                                 wf.FileList([]),
                                 output_dir,
-                                tags=combctags)
+                                tags=['full_data'])
 
-censored_veto_name = ['closed_box']
+censored_veto_name = 'closed_box'
 censored_veto = wf.make_foreground_censored_veto(workflow,
-                       combined_bg_file, final_veto_file[0], final_veto_name[0],
-                       censored_veto_name[0], 'segments')
-# Calculate the inspiral psds and make plots
+                       combined_bg_file, final_veto_file, final_veto_name,
+                       censored_veto_name, 'segments')
+
+# Calculate the inspiral psds
 psd_files = []
 trig_generated_name = 'TRIGGERS_GENERATED'
 trig_generated_segs = {}
@@ -278,8 +284,7 @@ insp_files_seg_file = wf.SegFile.from_segment_list_dict('INSP_SEGMENTS',
 
 ################### Range, spectrum and segments plots #######################
 
-s = wf.make_spectrum_plot(workflow, psd_files, rdir['detector_sensitivity'],
-                          precalc_psd_files=precalc_psd_files)
+s = wf.make_spectrum_plot(workflow, psd_files, rdir['detector_sensitivity'])
 r = wf.make_range_plot(workflow, psd_files, rdir['detector_sensitivity'],
                        require='summ')
 r2 = wf.make_range_plot(workflow, psd_files, rdir['detector_sensitivity'],
@@ -310,11 +315,10 @@ seg_summ_plot = wf.make_seg_plot(workflow, curr_files,
                                 rdir['analysis_time/segments'],
                                 curr_names, ['SUMMARY'])
 
-curr_files = [insp_files_seg_file] + final_veto_file
+curr_files = [insp_files_seg_file] + [final_veto_file]
 # Add in singular veto files
 curr_files = curr_files + [science_seg_file]
-curr_names = [trig_generated_name + '&' + veto_name
-              for veto_name in final_veto_name]
+curr_names = [trig_generated_name + '&' + final_veto_name]
 # And SCIENCE - CAT 1 vetoes explicitly.
 curr_names += [sci_seg_name + '&' + 'VETO_CAT1']
 
@@ -551,7 +555,7 @@ for inj_file, tag in zip(inj_files, inj_tags):
             curr_out = wf.setup_multiifo_interval_coinc_inj\
                 (workflow, hdfbank, full_insps, inspcomb, statfiles,
                  final_bg_files[ordered_ifo_list],
-                 final_veto_file[0], final_veto_name[0],
+                 final_veto_file, final_veto_name,
                  output_dir, pivot_ifo, fixed_ifo, tags=ctagcomb)
 
             # Rerank events
@@ -573,7 +577,7 @@ for inj_file, tag in zip(inj_files, inj_tags):
 
     found_inj = wf.find_injections_in_hdf_coinc\
         (workflow, [combined_inj_bg_file], [file_for_injfind],
-         censored_veto, censored_veto_name[0], output_dir, tags=combctags)
+         censored_veto, censored_veto_name, output_dir, tags=combctags)
 
     inj_coincs += [combined_inj_bg_file]
 
@@ -649,7 +653,7 @@ for inj_file, tag in zip(inj_files, inj_tags):
 if len(files_for_combined_injfind) > 0:
     found_inj_comb = wf.find_injections_in_hdf_coinc\
         (workflow, inj_coincs, files_for_combined_injfind, censored_veto,
-         censored_veto_name[0], 'allinj', tags=['ALLINJ'])
+         censored_veto_name, 'allinj', tags=['ALLINJ'])
 
     sen_all = wf.make_sensitivity_plot(workflow, found_inj_comb, rdir['search_sensitivity'],
                             require='all', tags=['ALLINJ'])

--- a/bin/workflows/pycbc_create_offline_search_workflow
+++ b/bin/workflows/pycbc_create_offline_search_workflow
@@ -344,13 +344,13 @@ layout.group_layout(rdir['single_triggers'], snrchi)
 hist_summ = []
 for insp in full_insps:
     outdir = rdir['single_triggers/%s_binned_triggers' % insp.ifo]
-    wf.make_singles_plot(workflow, [insp], hdfbank[0], censored_veto,
+    wf.make_singles_plot(workflow, [insp], hdfbank, censored_veto,
                          'closed_box', outdir, tags=['full_data'])
     # make non-summary hists using the bank file
     # currently, none of these are made
     outdir = rdir['single_triggers/%s_trigger_histograms' % insp.ifo]
     wf.make_single_hist(workflow, insp, censored_veto, 'closed_box', outdir,
-                        bank_file=hdfbank[0], exclude='summ',
+                        bank_file=hdfbank, exclude='summ',
                         tags=['full_data'])
     # make summary hists for all templates together
     # currently, 2 per ifo: snr and newsnr
@@ -361,7 +361,7 @@ for insp in full_insps:
     # currently, 1 per ifo split by template duration
     outdir = rdir['single_triggers/%s_binned_histograms' % insp.ifo]
     binhists = wf.make_binned_hist(workflow, insp, censored_veto,
-                                   'closed_box', outdir, hdfbank[0],
+                                   'closed_box', outdir, hdfbank,
                                    tags=['full_data'])
     # put raw SNR and binned newsnr hist in summary
     hist_summ += list(layout.grouper([allhists[0], binhists[0]], 2))
@@ -387,7 +387,7 @@ for insp_file in full_insps:
         dir_str = workflow.cp.get(sec_name, 'section-header')
         currdir = rdir['single_triggers/{}_{}'.format(curr_ifo, dir_str)]
         wf.setup_single_det_minifollowups\
-            (workflow, insp_file, hdfbank[0], insp_files_seg_file,
+            (workflow, insp_file, hdfbank, insp_files_seg_file,
              data_analysed_name, trig_generated_name, 'daxes', currdir,
              veto_file=censored_veto, veto_segment_name='closed_box',
              tags=insp_file.tags + [subsec])
@@ -421,7 +421,7 @@ ifar_ob = wf.make_ifar_plot(workflow, combined_bg_file,
 #                                    tags=combined_bg_file.tags + ['closed_box'],
 #                                    executable='page_ifar_catalog')
 #table = wf.make_foreground_table(workflow, combined_bg_file,
-#                                 hdfbank[0], rdir['open_box_result'],
+#                                 hdfbank, rdir['open_box_result'],
 #                                 singles=insps, extension='.html',
 #                                 tags=["html"])
 #symlink_result(snrifar, 'open_box_result/significance')
@@ -441,13 +441,13 @@ layout.two_column_layout(rdir['coincident_triggers'], closed_page)
 # run minifollowups on the output of the loudest events
 mfup_dir = rdir['open_box_result/loudest_events_followup']
 wf.setup_foreground_minifollowups(workflow, combined_bg_file,
-                                  full_insps, hdfbank[0], insp_files_seg_file,
+                                  full_insps, hdfbank, insp_files_seg_file,
                                   data_analysed_name, trig_generated_name,
                                   'daxes', mfup_dir,
                                   tags=combined_bg_file.tags + ['foreground'])
 
 wf.setup_foreground_minifollowups(workflow, combined_bg_file,
-                                  full_insps, hdfbank[0], insp_files_seg_file,
+                                  full_insps, hdfbank, insp_files_seg_file,
                                   data_analysed_name, trig_generated_name, 'daxes',
                                   rdir['coincident_triggers/loudest_background_followup'],
                                   tags=combined_bg_file.tags + ['background'])
@@ -474,7 +474,7 @@ for key in final_bg_files:
     #                            tags=bg_file.tags + ['open_box'])
     #ifar_cb = wf.make_ifar_plot(workflow, bg_file, closed_dir,
     #                            tags=bg_file.tags + ['closed_box'])
-    #table = wf.make_foreground_table(workflow, bg_file, hdfbank[0], open_dir,
+    #table = wf.make_foreground_table(workflow, bg_file, hdfbank, open_dir,
     #                                 singles=insps, extension='.html',
     #                                 tags=["html"])
 
@@ -491,7 +491,7 @@ for key in final_bg_files:
 
 ############################## Setup the injection runs #######################
 
-splitbank_files_inj = wf.setup_splittable_workflow(workflow, hdfbank,
+splitbank_files_inj = wf.setup_splittable_workflow(workflow, [hdfbank],
                                                    out_dir="bank",
                                                    tags=['injections'])
 
@@ -540,7 +540,7 @@ for inj_file, tag in zip(inj_files, inj_tags):
                                          output_dir, tags=ctags,
                                          injection_file=small_inj_file)
 
-    insps = wf.merge_single_detector_hdf_files(workflow, hdfbank[0],
+    insps = wf.merge_single_detector_hdf_files(workflow, hdfbank,
                                                insps, output_dir, tags=ctags)
     # multiifo coincidence for injections
     inj_coinc = {}
@@ -562,7 +562,7 @@ for inj_file, tag in zip(inj_files, inj_tags):
 
             # Rerank events
             curr_out = wf.rerank_coinc_followup(workflow, curr_out,
-                                     hdfbank[0],
+                                     hdfbank,
                                      output_dir, tags=ctagcomb,
                                      injection_file=small_inj_file,
                                      ranking_file=final_bg_files[ordered_ifo_list])
@@ -640,7 +640,7 @@ for inj_file, tag in zip(inj_files, inj_tags):
         curr_dir_nam += '_' + suf_str
     currdir = rdir[curr_dir_nam]
     wf.setup_injection_minifollowups(workflow, found_inj, small_inj_file,
-                                     insps, hdfbank[0], insp_files_seg_file,
+                                     insps, hdfbank, insp_files_seg_file,
                                      data_analysed_name, trig_generated_name,
                                      'daxes', currdir, tags=[tag])
 

--- a/bin/workflows/pycbc_create_offline_search_workflow
+++ b/bin/workflows/pycbc_create_offline_search_workflow
@@ -555,7 +555,7 @@ for inj_file, tag in zip(inj_files, inj_tags):
             coinctag = '{}det'.format(len(ifocomb))
             ctagcomb = [tag, 'injections', coinctag, ordered_ifo_list]
             curr_out = wf.setup_multiifo_interval_coinc_inj\
-                (workflow, hdfbank, full_insps, inspcomb, statfiles,
+                (workflow, [hdfbank], full_insps, inspcomb, statfiles,
                  final_bg_files[ordered_ifo_list],
                  final_veto_file, final_veto_name,
                  output_dir, pivot_ifo, fixed_ifo, tags=ctagcomb)

--- a/bin/workflows/pycbc_make_coinc_search_workflow
+++ b/bin/workflows/pycbc_make_coinc_search_workflow
@@ -176,8 +176,8 @@ insps = wf.merge_single_detector_hdf_files(workflow, hdfbank[0],
 # setup sngl trigger distribution fitting jobs
 # 'statfiles' is list of files used in calculating coinc statistic
 statfiles = wf.FileList([])
-statfiles += wf.setup_trigger_fitting(workflow, insps, hdfbank,
-                                      final_veto_file, final_veto_name)
+statfiles += wf.setup_trigger_fitting(workflow, insps, hdfbank[0],
+                                      final_veto_file[0], final_veto_name[0])
 
 # setup coinc for the filtering jobs
 full_insps = insps

--- a/pycbc/workflow/coincidence.py
+++ b/pycbc/workflow/coincidence.py
@@ -742,7 +742,8 @@ def setup_multiifo_interval_coinc(workflow, hdfbank, trig_files, stat_files,
 
     # Wall time knob and memory knob
     factor = int(workflow.cp.get_opt_tags('workflow-coincidence',
-                                          'parallelization-factor', tags))
+                                          'parallelization-factor',
+                                          [findcoinc_exe.ifo_string] + tags))
 
     statmap_files = []
     bg_files = FileList()

--- a/pycbc/workflow/coincidence.py
+++ b/pycbc/workflow/coincidence.py
@@ -276,9 +276,11 @@ class PyCBCMultiifoAddStatmap(PyCBCMultiifoCombineStatmap):
 
     current_retention_level = Executable.MERGED_TRIGGERS
     def create_node(self, statmap_files, background_files, tags=None):
+        if tags is None:
+            tags = []
         node = super(PyCBCMultiifoAddStatmap, self).create_node(statmap_files,
                                                             tags=tags)
-        if 'injections' in tags:
+        if 'injections' in (tags+self.tags):
             node.add_input_list_opt('--background-files', background_files)
 
         return node

--- a/pycbc/workflow/coincidence.py
+++ b/pycbc/workflow/coincidence.py
@@ -353,7 +353,7 @@ def setup_trigger_fitting(workflow, insps, hdfbank, veto_file, veto_name,
                                                      'fit_over_param', ifos=i,
                                                      tags=tags)
             smooth_node = smooth_exe.create_node(raw_node.output_file,
-                                                 hdfbank[0])
+                                                 hdfbank)
             workflow += smooth_node
             smoothed_fit_files += smooth_node.output_files
         return smoothed_fit_files

--- a/pycbc/workflow/coincidence.py
+++ b/pycbc/workflow/coincidence.py
@@ -735,10 +735,6 @@ def setup_multiifo_interval_coinc(workflow, hdfbank, trig_files, stat_files,
     make_analysis_dir(out_dir)
     logging.info('Setting up coincidence')
 
-    if len(hdfbank) != 1:
-        raise ValueError('Must use exactly 1 bank file for this coincidence '
-                         'method, I got %i !' % len(hdfbank))
-
     ifos, _ = trig_files.categorize_by_attr('ifo')
     findcoinc_exe = PyCBCFindMultiifoCoincExecutable(workflow.cp, 'multiifo_coinc',
                                              ifos=ifos,

--- a/pycbc/workflow/coincidence.py
+++ b/pycbc/workflow/coincidence.py
@@ -345,10 +345,11 @@ def setup_trigger_fitting(workflow, insps, hdfbank, veto_file, veto_name,
         for i in workflow.ifos:
             ifo_insp = [insp for insp in insps if (insp.ifo == i)]
             assert len(ifo_insp)==1
+            ifo_insp = ifo_insp[0]
             raw_exe = PyCBCFitByTemplateExecutable(workflow.cp,
                                                    'fit_by_template', ifos=i,
                                                    tags=tags)
-            raw_node = raw_exe.create_node(ifo_insp[0], hdfbank,
+            raw_node = raw_exe.create_node(ifo_insp, hdfbank,
                                            veto_file, veto_name)
             workflow += raw_node
             smooth_exe = PyCBCFitOverParamExecutable(workflow.cp,

--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -157,7 +157,7 @@ class Executable(pegasus_workflow.Executable):
         if isinstance(ifos, string_types):
             self.ifo_list = [ifos]
         else:
-            self.ifo_list = ifos
+            self.ifo_list = sorted(ifos)
         if self.ifo_list is not None:
             self.ifo_string = ''.join(self.ifo_list)
         else:

--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -157,9 +157,9 @@ class Executable(pegasus_workflow.Executable):
         if isinstance(ifos, string_types):
             self.ifo_list = [ifos]
         else:
-            self.ifo_list = sorted(ifos)
+            self.ifo_list = ifos
         if self.ifo_list is not None:
-            self.ifo_string = ''.join(self.ifo_list)
+            self.ifo_string = ''.join(sorted(self.ifo_list))
         else:
             self.ifo_string = None
         self.cp = cp

--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -261,8 +261,9 @@ class Executable(pegasus_workflow.Executable):
             else:
                 self.universe = 'vanilla'
 
-        logging.info("%s executable will run as %s universe"
-                     % (name, self.universe))
+        if not self.universe == 'vanilla':
+            logging.info("%s executable will run as %s universe"
+                         % (name, self.universe))
 
         self.set_universe(self.universe)
 

--- a/pycbc/workflow/minifollowups.py
+++ b/pycbc/workflow/minifollowups.py
@@ -86,13 +86,15 @@ def setup_foreground_minifollowups(workflow, coinc_file, single_triggers,
     config_file = wdax.File(os.path.basename(config_path))
     config_file.PFN(urljoin('file:', pathname2url(config_path)), site='local')
 
-    exe = Executable(workflow.cp, 'foreground_minifollowup', ifos=workflow.ifos, out_dir=dax_output, tags=tags)
+    exe = Executable(workflow.cp, 'foreground_minifollowup',
+                     ifos=workflow.ifos, out_dir=dax_output, tags=tags)
 
     node = exe.create_node()
     node.add_input_opt('--config-files', config_file)
     node.add_input_opt('--bank-file', tmpltbank_file)
     node.add_input_opt('--statmap-file', coinc_file)
-    node.add_multiifo_input_list_opt('--single-detector-triggers', single_triggers)
+    node.add_multiifo_input_list_opt('--single-detector-triggers',
+                                     single_triggers)
     node.add_input_opt('--inspiral-segments', insp_segs)
     node.add_opt('--inspiral-data-read-name', insp_data_name)
     node.add_opt('--inspiral-data-analyzed-name', insp_anal_name)
@@ -100,7 +102,8 @@ def setup_foreground_minifollowups(workflow, coinc_file, single_triggers,
         node.add_list_opt('--tags', tags)
     node.new_output_file_opt(workflow.analysis_time, '.dax', '--output-file')
     node.new_output_file_opt(workflow.analysis_time, '.dax.map', '--output-map')
-    node.new_output_file_opt(workflow.analysis_time, '.tc.txt', '--transformation-catalog')
+    node.new_output_file_opt(workflow.analysis_time, '.tc.txt',
+                             '--transformation-catalog')
 
     name = node.output_files[0].name
     map_file = node.output_files[1]
@@ -206,9 +209,11 @@ def setup_single_det_minifollowups(workflow, single_trig_file, tmpltbank_file,
     if statfiles:
         statfiles = statfiles.find_output_with_ifo(curr_ifo)
         node.add_input_list_opt('--statistic-files', statfiles)
-    node.new_output_file_opt(workflow.analysis_time, '.dax', '--output-file', tags=tags)
-    node.new_output_file_opt(workflow.analysis_time, '.dax.map', '--output-map', tags=tags)
-    node.new_output_file_opt(workflow.analysis_time, '.tc.txt', '--transformation-catalog', tags=tags)
+    node.new_output_file_opt(workflow.analysis_time, '.dax', '--output-file')
+    node.new_output_file_opt(workflow.analysis_time, '.dax.map',
+                             '--output-map')
+    node.new_output_file_opt(workflow.analysis_time, '.tc.txt',
+                             '--transformation-catalog')
 
     name = node.output_files[0].name
     map_file = node.output_files[1]
@@ -232,7 +237,8 @@ def setup_single_det_minifollowups(workflow, single_trig_file, tmpltbank_file,
     job = dax.DAX(fil)
     job.addArguments('--basename %s' \
                      % os.path.splitext(os.path.basename(name))[0])
-    Workflow.set_job_properties(job, map_file, tc_file, staging_site=staging_site)
+    Workflow.set_job_properties(job, map_file, tc_file,
+                                staging_site=staging_site)
     workflow._adag.addJob(job)
     dep = dax.Dependency(parent=node._dax_node, child=job)
     workflow._adag.addDependency(dep)

--- a/pycbc/workflow/plotting.py
+++ b/pycbc/workflow/plotting.py
@@ -143,7 +143,8 @@ def make_foreground_table(workflow, trig_file, bank_file, out_dir,
         tags = []
 
     makedir(out_dir)
-    exe = PlotExecutable(workflow.cp, 'page_foreground', ifos=trig_file.ifos,
+    exe = PlotExecutable(workflow.cp, 'page_foreground',
+                         ifos=trig_file.ifo_list,
                          out_dir=out_dir, tags=tags)
     node = exe.create_node()
     node.add_input_opt('--bank-file', bank_file)
@@ -180,8 +181,10 @@ def make_coinc_snrchi_plot(workflow, inj_file, inj_trig, stat_file, trig_file,
     secs = excludestr(secs, exclude)
     files = FileList([])
     for tag in secs:
-        node = PlotExecutable(workflow.cp, 'plot_coinc_snrchi', ifos=inj_trig.ifo,
-                    out_dir=out_dir, tags=[tag] + tags).create_node()
+        exe = PlotExecutable(workflow.cp, 'plot_coinc_snrchi',
+                             ifos=inj_trig.ifo_list,
+                             out_dir=out_dir, tags=[tag] + tags)
+        node = exe.create_node()
         node.add_input_opt('--found-injection-file', inj_file)
         node.add_input_opt('--single-injection-file', inj_trig)
         node.add_input_opt('--coinc-statistic-file', stat_file)
@@ -294,7 +297,7 @@ def make_ifar_plot(workflow, trigger_file, out_dir, tags=None,
         tags = []
 
     makedir(out_dir)
-    exe = PlotExecutable(workflow.cp, executable, ifos=trigger_file.ifos,
+    exe = PlotExecutable(workflow.cp, executable, ifos=trigger_file.ifo_list,
                          out_dir=out_dir, tags=tags)
     node = exe.create_node()
     node.add_input_opt('--trigger-file', trigger_file)
@@ -313,10 +316,11 @@ def make_snrchi_plot(workflow, trig_files, veto_file, veto_name,
     files = FileList([])
     for tag in secs:
         for trig_file in trig_files:
-            node = PlotExecutable(workflow.cp, 'plot_snrchi',
-                        ifos=trig_file.ifo,
-                        out_dir=out_dir,
-                        tags=[tag] + tags).create_node()
+            exe = PlotExecutable(workflow.cp, 'plot_snrchi',
+                                  ifos=trig_file.ifo_list,
+                                  out_dir=out_dir,
+                                  tags=[tag] + tags)
+            node = exe.create_node()
 
             node.set_memory(15000)
             node.add_input_opt('--trigger-file', trig_file)
@@ -357,8 +361,9 @@ def make_snrratehist_plot(workflow, bg_file, out_dir, closed_box=False,
         tags = []
 
     makedir(out_dir)
-    exe = PlotExecutable(workflow.cp, 'plot_snrratehist', ifos=bg_file.ifos,
-                          out_dir=out_dir, tags=tags)
+    exe = PlotExecutable(workflow.cp, 'plot_snrratehist',
+                         ifos=bg_file.ifo_list,
+                         out_dir=out_dir, tags=tags)
     node = exe.create_node()
     node.add_input_opt('--trigger-file', bg_file)
     if hierarchical_level is not None:
@@ -383,7 +388,7 @@ def make_snrifar_plot(workflow, bg_file, out_dir, closed_box=False,
         tags = []
 
     makedir(out_dir)
-    exe = PlotExecutable(workflow.cp, 'plot_snrifar', ifos=bg_file.ifos,
+    exe = PlotExecutable(workflow.cp, 'plot_snrifar', ifos=bg_file.ifo_list,
                          out_dir=out_dir, tags=tags)
     node = exe.create_node()
     node.add_input_opt('--trigger-file', bg_file)

--- a/pycbc/workflow/plotting.py
+++ b/pycbc/workflow/plotting.py
@@ -317,9 +317,9 @@ def make_snrchi_plot(workflow, trig_files, veto_file, veto_name,
     for tag in secs:
         for trig_file in trig_files:
             exe = PlotExecutable(workflow.cp, 'plot_snrchi',
-                                  ifos=trig_file.ifo_list,
-                                  out_dir=out_dir,
-                                  tags=[tag] + tags)
+                                 ifos=trig_file.ifo_list,
+                                 out_dir=out_dir,
+                                 tags=[tag] + tags)
             node = exe.create_node()
 
             node.set_memory(15000)

--- a/pycbc/workflow/plotting.py
+++ b/pycbc/workflow/plotting.py
@@ -143,8 +143,9 @@ def make_foreground_table(workflow, trig_file, bank_file, out_dir,
         tags = []
 
     makedir(out_dir)
-    node = PlotExecutable(workflow.cp, 'page_foreground', ifos=workflow.ifos,
-                    out_dir=out_dir, tags=tags).create_node()
+    exe = PlotExecutable(workflow.cp, 'page_foreground', ifos=trig_file.ifos,
+                         out_dir=out_dir, tags=tags)
+    node = exe.create_node()
     node.add_input_opt('--bank-file', bank_file)
     node.add_input_opt('--trigger-file', trig_file)
     if hierarchical_level is not None:
@@ -293,8 +294,9 @@ def make_ifar_plot(workflow, trigger_file, out_dir, tags=None,
         tags = []
 
     makedir(out_dir)
-    node = PlotExecutable(workflow.cp, executable, ifos=workflow.ifos,
-                    out_dir=out_dir, tags=tags).create_node()
+    exe = PlotExecutable(workflow.cp, executable, ifos=trigger_file.ifos,
+                         out_dir=out_dir, tags=tags)
+    node = exe.create_node()
     node.add_input_opt('--trigger-file', trigger_file)
     if hierarchical_level is not None:
         node.add_opt('--use-hierarchical-level', hierarchical_level)
@@ -344,7 +346,7 @@ def make_foundmissed_plot(workflow, inj_file, out_dir, exclude=None,
     return files
 
 def make_snrratehist_plot(workflow, bg_file, out_dir, closed_box=False,
-                         tags=None, hierarchical_level=None):
+                          tags=None, hierarchical_level=None):
 
     if hierarchical_level is not None and tags:
         tags = [("HIERARCHICAL_LEVEL_{:02d}".format(
@@ -355,8 +357,9 @@ def make_snrratehist_plot(workflow, bg_file, out_dir, closed_box=False,
         tags = []
 
     makedir(out_dir)
-    node = PlotExecutable(workflow.cp, 'plot_snrratehist', ifos=workflow.ifos,
-                out_dir=out_dir, tags=tags).create_node()
+    exe = PlotExecutable(workflow.cp, 'plot_snrratehist', ifos=bg_file.ifos,
+                          out_dir=out_dir, tags=tags)
+    node = exe.create_node()
     node.add_input_opt('--trigger-file', bg_file)
     if hierarchical_level is not None:
         node.add_opt('--use-hierarchical-level', hierarchical_level)
@@ -380,8 +383,9 @@ def make_snrifar_plot(workflow, bg_file, out_dir, closed_box=False,
         tags = []
 
     makedir(out_dir)
-    node = PlotExecutable(workflow.cp, 'plot_snrifar', ifos=workflow.ifos,
-                out_dir=out_dir, tags=tags).create_node()
+    exe = PlotExecutable(workflow.cp, 'plot_snrifar', ifos=bg_file.ifos,
+                         out_dir=out_dir, tags=tags)
+    node = exe.create_node()
     node.add_input_opt('--trigger-file', bg_file)
     if hierarchical_level is not None:
         node.add_opt('--use-hierarchical-level', hierarchical_level)

--- a/pycbc/workflow/psdfiles.py
+++ b/pycbc/workflow/psdfiles.py
@@ -27,6 +27,8 @@ This module is responsible for setting up the psd files used by CBC
 workflows.
 """
 
+# FIXME: Is this module still relevant for any code? Can it be removed?
+
 from __future__ import division
 
 import os


### PR DESCRIPTION
I wanted to have a pass through the new search workflow, as I was noticing from much of the file-naming that in a number of cases tags are duplicated etc. There's also some places where lists are currently being used where the new workflow demands a single file (e.g. template bank and veto files)

I just want to make a pass through and clear this up before we start thinking about removing the old workflow. I'm going to do this in stages, and show the changes for everything up to generation of the FULL_DATA STATMAP file. Please let me know if you have any feedback about doing this as I want to also keep pushing on further down the workflow code.

@ahnitz There's a couple of minor changes in `workflow.core` along with this. IFOs supplied to an `Executable` are now sorted to avoid the `H1L1` vs `L1H1` naming uncertainty (if IFO order matters, then an additional tag could be used, but not one that conflicts with the ifo-naming tags!)  I also turned off the "I am a vanilla Universe job" message as *all* jobs are that now, so it'll only print it if you try something different.