### PR TITLE
Improvements to pycbc_condition_strain

### DIFF
--- a/bin/pycbc_condition_strain
+++ b/bin/pycbc_condition_strain
@@ -33,6 +33,8 @@ from pycbc.types import float32, float64
 
 
 def write_strain(file_name, channel, data):
+    logging.info('Writing output strain to %s', file_name)
+
     if file_name.endswith('.gwf'):
         pycbc.frame.write_frame(file_name, channel, data)
     elif file_name.endswith(('.hdf', '.h5')):
@@ -111,10 +113,8 @@ if args.frame_duration:
     for s in range(start, stop, step):
         ts = out_strain.time_slice(s, s+step if s+step < stop else stop)
         complete_fn = filename.format(s, step if s+step < stop else stop - s)
-        logging.info('Writing output strain to %s', complete_fn)
         write_strain(complete_fn, output_channel_name, ts)
 else:
-    logging.info('Writing output strain to %s', args.output_strain_file)
     write_strain(args.output_strain_file, output_channel_name, out_strain)
 
 logging.info('Done')

--- a/bin/pycbc_condition_strain
+++ b/bin/pycbc_condition_strain
@@ -32,6 +32,15 @@ import pycbc.frame
 from pycbc.types import float32, float64
 
 
+def write_strain(file_name, channel, data):
+    if file_name.endswith('.gwf'):
+        pycbc.frame.write_frame(file_name, channel, data)
+    elif file_name.endswith(('.hdf', '.h5')):
+        data.save(file_name, group=channel)
+    else:
+        raise ValueError('Unknown extension for ' + file_name)
+
+
 parser = argparse.ArgumentParser(description=__doc__)
 parser.add_argument("--version", action="version",
                     version=pycbc.version.git_verbose_msg)
@@ -57,7 +66,8 @@ parser.add_argument('--low-frequency-cutoff', type=float,
                          'This is only needed if fake-strain or '
                          'fake-strain-from-file is used')
 parser.add_argument('--frame-duration', type=int,
-                    help='Split all data into smaller frame files of the given duration if specified.')
+                    help='Split all data into smaller frame files of the '
+                         'given duration if specified.')
 
 pycbc.strain.insert_strain_option_group(parser)
 args = parser.parse_args()
@@ -68,7 +78,8 @@ if args.frame_duration is not None and args.frame_duration <= 0:
 logging.basicConfig(format='%(asctime)s %(message)s', level=logging.INFO)
 
 # read and condition strain as pycbc_inspiral would do
-out_strain = pycbc.strain.from_cli(args, dyn_range_fac=pycbc.DYN_RANGE_FAC)
+out_strain = pycbc.strain.from_cli(args, dyn_range_fac=pycbc.DYN_RANGE_FAC,
+                                   precision=args.output_precision)
 
 # if requested, save the gates while we have them
 if args.output_gates_file:
@@ -86,28 +97,24 @@ out_strain = out_strain.astype(
 if not args.dyn_range_factor:
     out_strain /= pycbc.DYN_RANGE_FAC
 
-logging.info('Writing output strain')
 output_channel_name = args.output_channel_name or args.channel_name
-if args.output_strain_file.endswith('.gwf'):
 
-    if args.frame_duration:
-        start = args.gps_start_time
-        stop = args.gps_end_time
-        step = args.frame_duration
-        # Filename with split the given name as prefix and add `start_time-duration`
-        filename = args.output_strain_file.rsplit('.', 2)[0]
-        filename += '_{0}-{1}.'+args.output_strain_file.rsplit('.', 2)[1]
+if args.frame_duration:
+    start = args.gps_start_time
+    stop = args.gps_end_time
+    step = args.frame_duration
+    # Filename with split the given name as prefix and add `start_time-duration`
+    fn_split = args.output_strain_file.rsplit('.', 2)
+    filename = fn_split[0] + '_{0}-{1}.' + fn_split[1]
 
-        # Last frame duration can be shorter than duration if stop doesn't allow
-        for s in range(start, stop, step):
-            ts = out_strain.time_slice(s, s+step if s+step < stop else stop)
-            pycbc.frame.write_frame(filename.format(s, step if s+step < stop else stop - s),
-                                    output_channel_name, ts)
-    else:
-        pycbc.frame.write_frame(args.output_strain_file, output_channel_name,
-                                out_strain)
-
+    # Last frame duration can be shorter than duration if stop doesn't allow
+    for s in range(start, stop, step):
+        ts = out_strain.time_slice(s, s+step if s+step < stop else stop)
+        complete_fn = filename.format(s, step if s+step < stop else stop - s)
+        logging.info('Writing output strain to %s', complete_fn)
+        write_strain(complete_fn, output_channel_name, ts)
 else:
-    out_strain.save(args.output_strain_file, group=output_channel_name)
+    logging.info('Writing output strain to %s', args.output_strain_file)
+    write_strain(args.output_strain_file, output_channel_name, out_strain)
 
 logging.info('Done')


### PR DESCRIPTION
Avoid passing through single precision if double is requested. This avoids a confusing situation where, if the input data touches an unlocked segment with very high dynamic range, `resample_to_delta_t()` can produce an entirely corrupted output due to using a single-precision FFT.

Adds support for HDF output also when splitting output frames.

Some cleaup and better logging.