### PR TITLE
New search workflow cleanup 2

### DIFF
--- a/bin/workflows/pycbc_create_offline_search_workflow
+++ b/bin/workflows/pycbc_create_offline_search_workflow
@@ -545,42 +545,60 @@ for inj_file, tag in zip(inj_files, inj_tags):
                                                insps, output_dir, tags=ctags)
     # multiifo coincidence for injections
     inj_coinc = {}
-    for i in range(2, len(insps)+1):
-        combinations = itertools.combinations(ifo_ids.keys(), i)
-        for ifocomb in combinations:
-            inspcomb = wf.select_files_by_ifo_combination(ifocomb, insps)
-            pivot_ifo, fixed_ifo, ordered_ifo_list = \
-                wf.get_ordered_ifo_list(ifocomb, ifo_ids)
+    for ifocomb in ifo_combos(ifo_ids.keys()):
+        inspcomb = wf.select_files_by_ifo_combination(ifocomb, insps)
+        pivot_ifo, fixed_ifo, ordered_ifo_list = \
+            wf.get_ordered_ifo_list(ifocomb, ifo_ids)
 
-            # Create coinc tag, and set up the coinc job for the combination
-            coinctag = '{}det'.format(len(ifocomb))
-            ctagcomb = [tag, 'injections', coinctag, ordered_ifo_list]
-            curr_out = wf.setup_multiifo_interval_coinc_inj\
-                (workflow, [hdfbank], full_insps, inspcomb, statfiles,
-                 final_bg_files[ordered_ifo_list],
-                 final_veto_file, final_veto_name,
-                 output_dir, pivot_ifo, fixed_ifo, tags=ctagcomb)
+        # Create coinc tag, and set up the coinc job for the combination
+        coinctag = '{}det'.format(len(ifocomb))
+        ctagcomb = [tag, 'injections', coinctag]
+        curr_out = wf.setup_multiifo_interval_coinc_inj(
+            workflow,
+            hdfbank,
+            full_insps,
+            inspcomb,
+            statfiles,
+            final_bg_files[ordered_ifo_list],
+            final_veto_file,
+            final_veto_name,
+            output_dir,
+            pivot_ifo,
+            fixed_ifo,
+            tags=ctagcomb
+        )
 
-            # Rerank events
-            curr_out = wf.rerank_coinc_followup(workflow, curr_out,
-                                     hdfbank,
-                                     output_dir, tags=ctagcomb,
-                                     injection_file=small_inj_file,
-                                     ranking_file=final_bg_files[ordered_ifo_list])
+        # Rerank events
+        curr_out = wf.rerank_coinc_followup(
+            workflow,
+            curr_out,
+            hdfbank,
+            output_dir,
+            tags=ctagcomb,
+            injection_file=small_inj_file,
+            ranking_file=final_bg_files[ordered_ifo_list]
+        )
 
-            inj_coinc[ordered_ifo_list] = curr_out
+        inj_coinc[ordered_ifo_list] = curr_out
 
     combctags = [tag, 'injections']
     final_inj_bg_file_list = wf.FileList(inj_coinc.values())
-    combined_inj_bg_file = wf.setup_multiifo_combine_statmap(workflow,
-                                                     final_inj_bg_file_list,
-                                                     wf.FileList(final_bg_files.values()),
-                                                     output_dir,
-                                                     tags=combctags)
+    combined_inj_bg_file = wf.setup_multiifo_combine_statmap(
+        workflow,
+        final_inj_bg_file_list,
+        wf.FileList(final_bg_files.values()),
+        output_dir,
+        tags=combctags
+    )
 
-    found_inj = wf.find_injections_in_hdf_coinc\
-        (workflow, [combined_inj_bg_file], [file_for_injfind],
-         censored_veto, censored_veto_name, output_dir, tags=combctags)
+    found_inj = wf.find_injections_in_hdf_coinc(
+        workflow,
+        [combined_inj_bg_file],
+        [file_for_injfind],
+        censored_veto,
+        censored_veto_name,
+        output_dir,
+        tags=combctags)
 
     inj_coincs += [combined_inj_bg_file]
 
@@ -588,6 +606,18 @@ for inj_file, tag in zip(inj_files, inj_tags):
     found_inj_dict[tag] = found_inj
     insps_dict[tag] = insps
     small_inj_file_dict[tag] = small_inj_file
+
+# And the combined INJFIND file
+if len(files_for_combined_injfind) > 0:
+    found_inj_comb = wf.find_injections_in_hdf_coinc(
+        workflow,
+        inj_coincs,
+        files_for_combined_injfind,
+        censored_veto,
+        censored_veto_name,
+        'allinj',
+        tags=['all','injections']
+    )
 
 ############################ Injection plots #################################
 # Per injection run plots
@@ -607,23 +637,21 @@ for inj_file, tag in zip(inj_files, inj_tags):
                                  tags=[tag])
 
     found_table = wf.make_inj_table(workflow, found_inj, injdir,
-                                    singles=insps, tags=[tag + 'found'])
+                                    singles=insps, tags=[tag, 'found'])
     missed_table = wf.make_inj_table(workflow, found_inj, injdir,
-                                     missed=True, tags=[tag + 'missed'])
+                                     missed=True, tags=[tag, 'missed'])
 
-    for i in range(2, len(insps)+1):
-        combinations = itertools.combinations(ifo_ids.keys(), i)
-        for ifocomb in combinations:
-            inspcomb = wf.select_files_by_ifo_combination(ifocomb, insps)
-            fdinspcmb = wf.select_files_by_ifo_combination(ifocomb, full_insps)
-            _, _, ordered_ifo_list = wf.get_ordered_ifo_list(ifocomb, ifo_ids)
+    for ifocomb in ifo_combos(ifo_ids.keys()):
+        inspcomb = wf.select_files_by_ifo_combination(ifocomb, insps)
+        fdinspcmb = wf.select_files_by_ifo_combination(ifocomb, full_insps)
+        _, _, ordered_ifo_list = wf.get_ordered_ifo_list(ifocomb, ifo_ids)
 
-            for inj_insp, trig_insp in zip(inspcomb, fdinspcmb):
-                final_bg_file = final_bg_files[ordered_ifo_list]
-                curr_tags = [tag, ordered_ifo_list]
-                #f += wf.make_coinc_snrchi_plot(workflow, found_inj, inj_insp,
-                #                               final_bg_file, trig_insp,
-                #                               injdir, tags=curr_tags)
+        for inj_insp, trig_insp in zip(inspcomb, fdinspcmb):
+            final_bg_file = final_bg_files[ordered_ifo_list]
+            curr_tags = [tag, ordered_ifo_list]
+            #f += wf.make_coinc_snrchi_plot(workflow, found_inj, inj_insp,
+            #                               final_bg_file, trig_insp,
+            #                               injdir, tags=curr_tags)
 
     # Make pages from plots
     inj_layout = list(layout.grouper(f, 2)) + [(found_table,), (missed_table,)]
@@ -654,22 +682,22 @@ for inj_file, tag in zip(inj_files, inj_tags):
 
 ######################## Make combined injection plots ##########################
 if len(files_for_combined_injfind) > 0:
-    found_inj_comb = wf.find_injections_in_hdf_coinc\
-        (workflow, inj_coincs, files_for_combined_injfind, censored_veto,
-         censored_veto_name, 'allinj', tags=['ALLINJ'])
-
-    sen_all = wf.make_sensitivity_plot(workflow, found_inj_comb, rdir['search_sensitivity'],
-                            require='all', tags=['ALLINJ'])
+    sen_all = wf.make_sensitivity_plot(workflow, found_inj_comb,
+                                       rdir['search_sensitivity'],
+                                       require='all')
     layout.group_layout(rdir['search_sensitivity'], sen_all)
-    inj_all = wf.make_foundmissed_plot(workflow, found_inj_comb, rdir['injections'],
-                            require='all', tags=['ALLINJ'])
+    inj_all = wf.make_foundmissed_plot(workflow, found_inj_comb,
+                                       rdir['injections'],
+                                       require='all')
     layout.group_layout(rdir['injections'], inj_all)
 
     # Make summary page foundmissed and sensitivity plot
     sen_s = wf.make_sensitivity_plot(workflow, found_inj_comb,
-                rdir['search_sensitivity'], require='summ', tags=['ALLINJ'])
+                                     rdir['search_sensitivity'],
+                                     require='summ')
     inj_s = wf.make_foundmissed_plot(workflow, found_inj_comb,
-                rdir['injections'], require='summ', tags=['ALLINJ'])
+                                     rdir['injections'],
+                                     require='summ')
     inj_summ = list(layout.grouper(inj_s + sen_s, 2))
 
 
@@ -716,13 +744,11 @@ create_versioning_page(rdir['workflow/version'], container.cp)
 
 # Create the final log file
 log_file_html = wf.File(workflow.ifos, 'WORKFLOW-LOG', workflow.analysis_time,
-                                           extension='.html',
-                                           directory=rdir['workflow'])
+                        extension='.html', directory=rdir['workflow'])
 
 # Create a page to contain a dashboard link
 dashboard_file = wf.File(workflow.ifos, 'DASHBOARD', workflow.analysis_time,
-                                           extension='.html',
-                                           directory=rdir['workflow'])
+                         extension='.html', directory=rdir['workflow'])
 dashboard_str = """<center><p style="font-size:20px"><b><a href="PEGASUS_DASHBOARD_URL" target="_blank">Pegasus Dashboard Page</a></b></p></center>"""
 kwds = { 'title' : "Pegasus Dashboard",
          'caption' : "Link to Pegasus Dashboard",

--- a/pycbc/workflow/coincidence.py
+++ b/pycbc/workflow/coincidence.py
@@ -421,7 +421,8 @@ def setup_multiifo_statmap(workflow, ifos, coinc_files, out_dir, tags=None):
     workflow.add_node(stat_node)
     return stat_node.output_file
 
-def setup_multiifo_statmap_inj(workflow, ifos, coinc_files, background_file, out_dir, tags=None):
+def setup_multiifo_statmap_inj(workflow, ifos, coinc_files, background_file,
+                               out_dir, tags=None):
     tags = [] if tags is None else tags
 
     statmap_exe = PyCBCMultiifoStatMapInjExecutable(workflow.cp,
@@ -430,8 +431,11 @@ def setup_multiifo_statmap_inj(workflow, ifos, coinc_files, background_file, out
                                                     tags=tags, out_dir=out_dir)
 
     ifolist = ' '.join(ifos)
-    stat_node = statmap_exe.create_node(FileList(coinc_files['injinj']), background_file,
-                                     FileList(coinc_files['injfull']), FileList(coinc_files['fullinj']), ifolist)
+    stat_node = statmap_exe.create_node(FileList(coinc_files['injinj']),
+                                        background_file,
+                                        FileList(coinc_files['injfull']),
+                                        FileList(coinc_files['fullinj']),
+                                        ifolist)
     workflow.add_node(stat_node)
     return stat_node.output_files[0]
 

--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -159,7 +159,8 @@ class Executable(pegasus_workflow.Executable):
         else:
             self.ifo_list = ifos
         if self.ifo_list is not None:
-            self.ifo_string = ''.join(sorted(self.ifo_list))
+            self.ifo_list = sorted(self.ifo_list)
+            self.ifo_string = ''.join(self.ifo_list)
         else:
             self.ifo_string = None
         self.cp = cp

--- a/pycbc/workflow/injection.py
+++ b/pycbc/workflow/injection.py
@@ -129,14 +129,6 @@ def setup_injection_workflow(workflow, output_dir=None,
         inj_tag = section.upper()
         curr_tags = tags + [inj_tag]
 
-        # FIXME: Remove once fixed in pipedown
-        # TEMPORARILY we require inj tags to end in "INJ"
-        if not inj_tag.endswith("INJ"):
-            err_msg = "Currently workflow requires injection names to end with "
-            err_msg += "a inj suffix. Ie. bnslininj or bbhinj. "
-            err_msg += "%s is not good." %(inj_tag.lower())
-            raise ValueError(err_msg)
-
         # Parse for options in ini file
         injection_method = workflow.cp.get_opt_tags("workflow-injections",
                                                     "injections-method",

--- a/pycbc/workflow/plotting.py
+++ b/pycbc/workflow/plotting.py
@@ -334,6 +334,8 @@ def make_snrchi_plot(workflow, trig_files, veto_file, veto_name,
 
 def make_foundmissed_plot(workflow, inj_file, out_dir, exclude=None,
                          require=None, tags=None):
+    if tags is None:
+        tags = []
     makedir(out_dir)
     secs = requirestr(workflow.cp.get_subsections('plot_foundmissed'), require)
     secs = excludestr(secs, exclude)


### PR DESCRIPTION
This continues where I left off in #3193 and basically does the same thing for the injection jobs. There's not a whole bunch here really, just a bit of tag cleanup. I am trying to ensure that for any executable that might be called for injections *and* for full_data, it is sent a tag called `injections` if running injections so you can set options specific to all injections, and not have to specify an option for every injection run.

For many plotting codes this is not needed if they *only* run on injection runs. There's also some changes in ALLINJ naming.