### PR TITLE
Dont duplicate Executables [revisited]

### DIFF
--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -131,7 +131,8 @@ class Executable(pegasus_workflow.Executable):
     # file will be retained, but a warning given
     current_retention_level = KEEP_BUT_RAISE_WARNING
     def __init__(self, cp, name,
-                 universe=None, ifos=None, out_dir=None, tags=None):
+                 universe=None, ifos=None, out_dir=None, tags=None,
+                 reuse_executable=True):
         """
         Initialize the Executable class.
 
@@ -182,6 +183,12 @@ class Executable(pegasus_workflow.Executable):
         # Determine the level at which output files should be kept
         self.update_current_retention_level(self.current_retention_level)
 
+        # Should I reuse this executable?
+        if reuse_executable:
+            self.pegasus_name = self.name
+        else:
+            self.pegasus_name = self.tagged_name
+
         # Determine if this executables should be run in a container
         try:
             self.container_type = cp.get('pegasus_profile-%s' % name,
@@ -212,12 +219,12 @@ class Executable(pegasus_workflow.Executable):
                                                     imagesite=self.container_site,
                                                     mount=self.container_mount)
 
-            super(Executable, self).__init__(self.tagged_name,
+            super(Executable, self).__init__(self.pegasus_name,
                                              installed=self.installed,
                                              container=self.container_cls)
 
         else:
-            super(Executable, self).__init__(self.tagged_name,
+            super(Executable, self).__init__(self.pegasus_name,
                                              installed=self.installed)
 
         self._set_pegasus_profile_options()
@@ -833,6 +840,7 @@ class Workflow(pegasus_workflow.Workflow):
         # set the storage path to be the same
         ini_file.storage_path = ini_file_path
         return FileList([ini_file])
+
 
 class Node(pegasus_workflow.Node):
     def __init__(self, executable):

--- a/pycbc/workflow/jobsetup.py
+++ b/pycbc/workflow/jobsetup.py
@@ -631,7 +631,7 @@ class PyCBCInspiralExecutable(Executable):
         if tags is None:
             tags = []
         super(PyCBCInspiralExecutable, self).__init__(
-            cp, 
+            cp,
             exe_name,
             None,
             ifo,

--- a/pycbc/workflow/jobsetup.py
+++ b/pycbc/workflow/jobsetup.py
@@ -627,11 +627,18 @@ class PyCBCInspiralExecutable(Executable):
     file_input_options = ['--gating-file']
 
     def __init__(self, cp, exe_name, ifo=None, out_dir=None,
-                 injection_file=None, tags=None):
+                 injection_file=None, tags=None, reuse_executable=False):
         if tags is None:
             tags = []
-        super(PyCBCInspiralExecutable, self).__init__(cp, exe_name, None, ifo,
-                                                      out_dir, tags=tags)
+        super(PyCBCInspiralExecutable, self).__init__(
+            cp, 
+            exe_name,
+            None,
+            ifo,
+            out_dir,
+            tags=tags,
+            reuse_executable=reuse_executable
+        )
         self.cp = cp
         self.set_memory(2000)
         self.injection_file = injection_file

--- a/pycbc/workflow/pegasus_workflow.py
+++ b/pycbc/workflow/pegasus_workflow.py
@@ -332,7 +332,7 @@ class Workflow(object):
         for exe in self._executables:
             if exe.name == node.executable.name:
                 node.executable.in_workflow = True
-                node._dax_node.name = executable.logical_name
+                node._dax_node.name = exe.logical_name
                 break
         if not node.executable.in_workflow:
             node.executable.in_workflow = True

--- a/pycbc/workflow/pegasus_workflow.py
+++ b/pycbc/workflow/pegasus_workflow.py
@@ -362,6 +362,9 @@ class Workflow(object):
             else:
                 node.executable.in_workflow = True
                 self._executables += [node.executable]
+        else:
+            # Ensure we have the correct name
+            node._dax_node.name = node.executable.logical_name
 
         # Add the node itself
         self._adag.addJob(node._dax_node)

--- a/pycbc/workflow/pegasus_workflow.py
+++ b/pycbc/workflow/pegasus_workflow.py
@@ -357,6 +357,10 @@ class Workflow(object):
         self._outputs += node._outputs
 
         # Record the executable that this node uses
+        for exe in self._executables:
+            if exe.name == node.executable.name:
+                node.executable.in_workflow = True
+                break
         if not node.executable.in_workflow:
             node.executable.in_workflow = True
             self._executables += [node.executable]

--- a/pycbc/workflow/pegasus_workflow.py
+++ b/pycbc/workflow/pegasus_workflow.py
@@ -327,6 +327,18 @@ class Workflow(object):
         """
         node._finalize()
         node.in_workflow = self
+
+        # Record the executable that this node uses
+        for exe in self._executables:
+            if exe.name == node.executable.name:
+                node.executable.in_workflow = True
+                node._dax_node.name = executable.logical_name
+                break
+        if not node.executable.in_workflow:
+            node.executable.in_workflow = True
+            self._executables += [node.executable]
+
+        # Add the node itself
         self._adag.addJob(node._dax_node)
 
         # Determine the parent child relationships based on the inputs that
@@ -355,15 +367,6 @@ class Workflow(object):
 
         # Record the outputs that this node generates
         self._outputs += node._outputs
-
-        # Record the executable that this node uses
-        for exe in self._executables:
-            if exe.name == node.executable.name:
-                node.executable.in_workflow = True
-                break
-        if not node.executable.in_workflow:
-            node.executable.in_workflow = True
-            self._executables += [node.executable]
 
         return self
 

--- a/pycbc/workflow/pegasus_workflow.py
+++ b/pycbc/workflow/pegasus_workflow.py
@@ -330,7 +330,7 @@ class Workflow(object):
 
         # Record the executable that this node uses
         for exe in self._executables:
-            if exe.name == node.executable.name:
+            if exe.pegasus_name == node.executable.pegasus_name:
                 node.executable.in_workflow = True
                 node._dax_node.name = exe.logical_name
                 break

--- a/pycbc/workflow/pegasus_workflow.py
+++ b/pycbc/workflow/pegasus_workflow.py
@@ -358,13 +358,11 @@ class Workflow(object):
                 if node.executable.is_same_as(exe):
                     node.executable.in_workflow = True
                     node._dax_node.name = exe.logical_name
+                    node.executable.logical_name = exe.logical_name
                     break
             else:
                 node.executable.in_workflow = True
                 self._executables += [node.executable]
-        else:
-            # Ensure we have the correct name
-            node._dax_node.name = node.executable.logical_name
 
         # Add the node itself
         self._adag.addJob(node._dax_node)


### PR DESCRIPTION
In #2865 I reported a problem about duplicate Executables, which I'll copy here:

"""
I am seeing some cases where minifollowups can overload a filesystem. Especially true when one is doing a partial rerun and all the minifollowups jobs start at the same time. One way to reduce the load is to use the label clustering feature so that minifollowups jobs run in sequence in a pegasus_merge job. For this to work, the various jobs (e.g. single_template, qscan, ....) need to use the same executable in the transfer catalog. At the moment there is one executable per transfer catalog. This is also bad if running remotely, as the workflow will then copy the same executable multiple times.
"""

The solution proposed there was somewhat hacky, and would need to implemented in *any* place where this arises. Instead I want to put this in at a deeper level, and basically let the workflow ask "If this executable actually is the same as this other one, then don't duplicate". So with this in place, even if the user creates an Executable instance for *every* `plot_snrchi` call, there will only be one executable at the workflow level, *unless* there needs to be multiple Executables.

There's a few way we try to decide if there needs to be multiple Executables:

* User override: There's a flag you can give to revert to the previous behaviour. This is disabled by default, but can be activated in sub-classes. I turn this on in `pycbc_inspiral` for an example. In some cases this separation is good as the pegasus dashboard will then categorize V1-XXINJ jobs separately from L1-FULL_DATA jobs.
* Using the new `is_same_as` method. This will check if the two Executables use the same site, CPU/RAM/etc. requests and any other property that can be set at the Executable level. If there is a difference, these will be stored as separate Executables.

This is tested on my example HLV workflow and builds the expected workflow.