### PR TITLE
Bug: Turn off removing common offsets in plot posterior and correctly set 1D marginal plot limits

### DIFF
--- a/pycbc/results/scatter_histograms.py
+++ b/pycbc/results/scatter_histograms.py
@@ -635,22 +635,6 @@ def create_multidim_plot(parameters, samples, labels=None,
         # copy the dict
         maxs = {p: val for p, val in maxs.items()}
 
-    # remove common offsets
-    for pi, param in enumerate(parameters):
-        values, offset = remove_common_offset(samples[param])
-        if offset != 0:
-            # we'll add the offset removed to the label
-            labels[param] = '{} - {:d}'.format(labels[param], offset)
-            samples[param] = values
-            mins[param] = mins[param] - float(offset)
-            maxs[param] = maxs[param] - float(offset)
-        # also remove from expected parameters, if they were provided
-        if expected_parameters is not None:
-            try:
-                expected_parameters[param] -= offset
-            except KeyError:
-                pass
-
     # create the axis grid
     if fig is None and axis_dict is None:
         fig, axis_dict = create_axes_grid(

--- a/pycbc/results/scatter_histograms.py
+++ b/pycbc/results/scatter_histograms.py
@@ -385,39 +385,37 @@ def create_marginalized_hist(ax, values, label, percentiles=None,
             values_med, negerror, plus_error=poserror))
         if rotated:
             ax.yaxis.set_label_position("right")
-
             # sets colored title for marginal histogram
             set_marginal_histogram_title(ax, fmt, color,
                                          label=label, rotated=rotated)
-
-            # Remove x-ticks
-            ax.set_xticks([])
-            # turn off x-labels
-            ax.set_xlabel('')
-            # set limits
-            ymin, ymax = ax.get_ylim()
-            if plot_min is not None:
-                ymin = plot_min
-            if plot_max is not None:
-                ymax = plot_max
-            ax.set_ylim(ymin, ymax)
-
         else:
-
             # sets colored title for marginal histogram
             set_marginal_histogram_title(ax, fmt, color, label=label)
-
-            # Remove y-ticks
-            ax.set_yticks([])
-            # turn off y-label
-            ax.set_ylabel('')
-            # set limits
-            xmin, xmax = ax.get_xlim()
-            if plot_min is not None:
-                xmin = plot_min
-            if plot_max is not None:
-                xmax = plot_max
-            ax.set_xlim(xmin, xmax)
+    # remove ticks and set limits
+    if rotated:
+        # Remove x-ticks
+        ax.set_xticks([])
+        # turn off x-labels
+        ax.set_xlabel('')
+        # set limits
+        ymin, ymax = ax.get_ylim()
+        if plot_min is not None:
+            ymin = plot_min
+        if plot_max is not None:
+            ymax = plot_max
+        ax.set_ylim(ymin, ymax)
+    else:
+        # Remove y-ticks
+        ax.set_yticks([])
+        # turn off y-label
+        ax.set_ylabel('')
+        # set limits
+        xmin, xmax = ax.get_xlim()
+        if plot_min is not None:
+            xmin = plot_min
+        if plot_max is not None:
+            xmax = plot_max
+        ax.set_xlim(xmin, xmax)
 
 
 def set_marginal_histogram_title(ax, fmt, color, label=None, rotated=False):


### PR DESCRIPTION
Currently, there are two bugs in `pycbc_inference_plot_posterior` which can cause the limits in the 1D marginal plots to not be the same as the 2D plots. The first bug can also cause posteriors and values to not be plotted correctly when plotting posteriors from multiple files on single plot.

The first, and most serious bug, is that the [remove_common_offset](https://github.com/gwastro/pycbc/blob/master/pycbc/results/scatter_histograms.py#L753) function, which removes a common offset if both the min and max parameter values values are the same order of magnitude and exceed 1000, is applied separately to each file that's provided, and separately to the prior. This can cause the 1D marginal plots to not be correct. More worryingly, it can cause the posteriors and reported values to not be correct if multiple files are plotted on a single plot and one one or more of the parameter values exceed 1000. Since `remove_common_offset` is called [inside of create_multidim_plot](https://github.com/gwastro/pycbc/blob/master/pycbc/results/scatter_histograms.py#L642) (which is called separately for each file in `pycbc_inference_plot_posterior`) the offset that is removed will most likely be different for each file. However, the offset that is shown in the axes titles and labels is only for the first file. This means that the wrong value will be inferred if multiple files are plotted. (Fortunately, this would not have come up often because the min and max parameters values both had to be of the same order of magnitude and > 1000. That's also why this hasn't been noticed before.)

Second, limits on the 1D marginal plots in are only set if the `title` option is set to True. This is a bug; it causes the limits not to be set correctly when `plot-prior` is turned on, since when the prior is plotted, the `title` option is set to False.

An example of both of these bugs conspiring to make a wrong plot can be seen in the luminosity distance from @yi-fan-wang's test run [here](https://www.atlas.aei.uni-hannover.de/work/yifan.wang/parityinj/2-fiveinj/files_output/html/3._posteriors/3.01_injection_1/E1E2E3L1-PLOT_POSTERIOR_INJECTION_1_ALL-1125100817-63158401.png). Note how the distance limits on the 1D marginal does not match the 2D marginals.

This patch fixes the first bug by just not removing common offsets anymore. That was added years ago to deal with the coalescence time, which was in GPS seconds. That was before we had the ability to specify functions on the command line. Also, we generally sample in delta tc now rather than tc. If someone wants to remove a common offset, they can just do this manually (and explicitly!) via the command line now. The second bug is fixed by moving the block of code that sets the 1D marginal limits outside of the `if title` block.

Here is what I get recreating @yi-fan-wang's plot above with this patch applied: [test.png](https://www.atlas.aei.uni-hannover.de/~work-cdcapano/scratch/prs/scatter_hist_bug/test.png)