### PR TITLE
Stop changing dtype for stat file

### DIFF
--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -320,7 +320,7 @@ class PhaseTDNewStatistic(NewSNRStatistic):
 
             param = histfile[ifo]['param_bin'][:]
             ncol = param.shape[1]
-            self.pdtype = [('c%s' % i, int) for i in range(ncol)]
+            self.pdtype = [('c%s' % i, param.dtype) for i in range(ncol)]
             self.param_bin[ifo] = numpy.zeros(len(self.weights[ifo]),
                                               dtype=self.pdtype)
             for i in range(ncol):


### PR DESCRIPTION
We currently have an issue where the HLV statistic file is using 30G of RAM. It seems a major part of the problem is that the `param_bin` information is cast to a python `int`. An `int` is apparently a 24-byte object, whereas in the current HDF file it's stored as a 1-byte integer. So we can reduce the memory usage there by not changing the dtype and just using the dtype from the input file.

We will still need to go further to manage memory better, and avoid doing the sort operation here. So a subsequent patch should enable the ability to provide a pre-sorted file in the same format as this code needs it. But for now getting this in is useful for being able to run this code!