### PR TITLE
Move fit_by files to the same directory

### DIFF
--- a/bin/workflows/pycbc_create_offline_search_workflow
+++ b/bin/workflows/pycbc_create_offline_search_workflow
@@ -177,6 +177,7 @@ insps = wf.merge_single_detector_hdf_files(workflow, hdfbank,
 statfiles = []
 statfiles += wf.setup_trigger_fitting(workflow, insps, hdfbank,
                                       final_veto_file, final_veto_name,
+                                      output_dir=output_dir,
                                       tags=['full_data'])
 
 # Set up the multi-ifo coinc jobs

--- a/pycbc/workflow/coincidence.py
+++ b/pycbc/workflow/coincidence.py
@@ -337,7 +337,7 @@ def merge_single_detector_hdf_files(workflow, bank_file, trigger_files, out_dir,
     return out
 
 def setup_trigger_fitting(workflow, insps, hdfbank, veto_file, veto_name,
-                          tags=None):
+                          output_dir=None, tags=None):
     if not workflow.cp.has_option('workflow-coincidence', 'do-trigger-fitting'):
         return FileList()
     else:
@@ -348,12 +348,14 @@ def setup_trigger_fitting(workflow, insps, hdfbank, veto_file, veto_name,
             ifo_insp = ifo_insp[0]
             raw_exe = PyCBCFitByTemplateExecutable(workflow.cp,
                                                    'fit_by_template', ifos=i,
+                                                   out_dir=output_dir,
                                                    tags=tags)
             raw_node = raw_exe.create_node(ifo_insp, hdfbank,
                                            veto_file, veto_name)
             workflow += raw_node
             smooth_exe = PyCBCFitOverParamExecutable(workflow.cp,
                                                      'fit_over_param', ifos=i,
+                                                     out_dir=output_dir,
                                                      tags=tags)
             smooth_node = smooth_exe.create_node(raw_node.output_file,
                                                  hdfbank)


### PR DESCRIPTION
Recent changes to clean up the workflow a little bit has exposed a small problem in the `fit_by_XXX` setup code. In particular, with the current code the directories are called:

`fit_by_template-FULL_DATA-H1  fit_over_param-FULL_DATA-H1
fit_by_template-FULL_DATA-L1  fit_over_param-FULL_DATA-L1
fit_by_template-FULL_DATA-V1  fit_over_param-FULL_DATA-V1
`

One directory for each file. This is because the output directory was never specified here, and the files are being put into a default directory name. So I just change the new code to specify this. I chose to put this in FULL_DATA, as it's a little weird that TRIGGER_MERGE and STATMAP files are in full_data, but these files, which sit in the middle, are not. 