### PR TITLE
Prior histogram efficiency

### DIFF
--- a/bin/hdfcoinc/pycbc_multiifo_dtphase
+++ b/bin/hdfcoinc/pycbc_multiifo_dtphase
@@ -20,27 +20,30 @@ parser = argparse.ArgumentParser()
 parser.add_argument('--ifos', nargs='+',
                     help="The ifos to generate a histogram for")
 parser.add_argument('--sample-size', type=int,
-                    help="Approximate number of independent samples to draw for the distribution")
+                    help="Approximate number of independent samples to draw "
+                         "for the distribution")
 parser.add_argument('--snr-ratio', type=float,
-                    help="The SNR ratio permitted between reference ifo and all others."
-                         "Ex. giving 4 permits a ratio of 0.25 -> 4")
+                    help="The SNR ratio permitted between reference ifo and "
+                         "all others. Ex. giving 4 permits a ratio of "
+                         "0.25 -> 4")
 parser.add_argument('--relative-sensitivities', nargs='+', type=float,
-                    help="Numbers proportional to horizon distance or expected SNR "
-                         "at fixed distance, one for each ifo")
+                    help="Numbers proportional to horizon distance or "
+                         "expected SNR at fixed distance, one for each ifo")
 parser.add_argument('--seed', type=int, default=124)
 parser.add_argument('--output-file')
 parser.add_argument('--verbose', action='store_true')
 parser.add_argument('--bin-density', type=int, default=1,
-                    help="Number of bins per 1 sigma uncertainty in a parameter."
-                         " Higher values increase the resolution of the histogram"
-                         " at the expense of storage.")
+                    help="Number of bins per 1 sigma uncertainty in a "
+                         "parameter. Higher values increase the resolution of "
+                         "the histogram at the expense of storage.")
 parser.add_argument('--smoothing-sigma', type=int, default=2,
                     help="Width of the smoothing kernel in sigmas")
 parser.add_argument('--timing-uncertainty', type=float, default=.001,
-                    help="Timing uncertainty to set bin size and smoothing interval"
-                         " [default=.001s]")
+                    help="Timing uncertainty to set bin size and smoothing "
+                         "interval [default=.001s]")
 parser.add_argument('--phase-uncertainty', type=float, default=0.25,
-                    help="Phase uncertainty used to set bin size and smoothing")
+                    help="Phase uncertainty used to set bin size and "
+                         "smoothing")
 parser.add_argument('--snr-reference', type=float, default=5,
                     help="Reference SNR to scale SNR uncertainty")
 parser.add_argument('--snr-uncertainty', type=float, default=1.0,
@@ -55,7 +58,8 @@ assert len(args.relative_sensitivities) == len(args.ifos)
 
 # Approximate timing error at lower SNRs
 twidth = args.timing_uncertainty / args.bin_density
-# Factor of sqrt(2) as we'll be combining two SNRs with independent uncertainties
+# Factor of sqrt(2) as we'll be combining two SNRs with independent
+# uncertainties
 serr = args.snr_uncertainty * 2 ** 0.5
 # Reference SNR for bin smoothing
 sref = args.snr_reference  
@@ -66,7 +70,8 @@ pwidth = numpy.arctan(serr / sref) / args.bin_density
 srbmax = int(args.snr_ratio / swidth)
 srbmin = int((1.0 / args.snr_ratio) / swidth)
 
-# Apply a simple smoothing to help account for measurement errors for weak signals
+# Apply a simple smoothing to help account for measurement errors for
+# weak signals
 def smooth_param(data, index):
     mref = max(data.values())
     bins = numpy.arange(-args.smoothing_sigma * args.bin_density,\
@@ -115,6 +120,7 @@ chunks = int(args.sample_size / size) + 1
 # of error uncertainties.
 f = h5py.File(args.output_file, 'w')
 for ifo0 in args.ifos:
+    logging.info('Storing results using %s as a reference', ifo0)
     other_ifos = deepcopy(args.ifos)
     other_ifos.remove(ifo0)
 
@@ -123,7 +129,7 @@ for ifo0 in args.ifos:
     weights = {}
     for k in range(chunks):
         nsamples += size
-        logging.info('generating %s samples' % size)
+        logging.info('generating %s samples', size)
 
         # Choose random sky location and polarizations from
         # an isotropic population
@@ -174,11 +180,12 @@ for ifo0 in args.ifos:
 
         ol = l
         l = len(weights.values())
-        logging.info('%s, %s, %s, %s', l, l - ol, (l - ol) / float(size), l / float(nsamples))
+        logging.info('%s, %s, %s, %s', l, l - ol, (l - ol) / float(size),
+                     l / float(nsamples))
 
     logging.info('applying smoothing')
     # apply smoothing iteratively
-    for i, ifo in enumerate(range(len(args.ifos)-1)):
+    for i in range(len(args.ifos)-1):
         logging.info('%s-phase', len(weights))
         weights = smooth_param(weights, i * 3 + 1)
         logging.info('%s-time', len(weights))
@@ -187,27 +194,18 @@ for ifo0 in args.ifos:
         weights = smooth_param(weights, i * 3 + 2)
     logging.info('smoothing done: %s', len(weights))
 
-    # Get normalizations for different amplitude ratio thresholds
-    normv = {}
-    for key in weights:
-        rvals = tuple(list(key)[2::3])
-        if rvals not in normv:
-            normv[rvals] = 0
-        m = max(normv[rvals], weights[key])
-        normv[rvals] = m
-
-    # save dict to hdf5 file as key + value array
+    logging.info('converting to numpy arrays and normalizing')
     keys = numpy.array(weights.keys())
     values = numpy.array(weights.values())
     values /= values.max()
 
-    # Threshold to keep saved bins to a reasonable amount
+    logging.info('discarding bins below threshold to limit storage')
     l = values > args.weight_threshold
     keys = keys[l].astype(numpy.int8)
     values = values[l].astype(numpy.float32)
     logging.info('Final length: %s', len(keys))
 
-    # presort the keys, helps with downstream use
+    logging.info('Presorting by keys for downstream use')
     ncol = keys.shape[1]
     pdtype = [('c%s' % i, numpy.int8) for i in range(ncol)]
     keys_bin = numpy.zeros(len(values), dtype=pdtype)
@@ -217,6 +215,7 @@ for ifo0 in args.ifos:
     keys_bin = keys_bin[lsort]
     values = values[lsort]
 
+    logging.info('Writing results to file')
     f.create_dataset('%s/param_bin' % ifo0, data=keys_bin, compression='gzip',
                      compression_opts=7)
     f.create_dataset('%s/weights' % ifo0, data=values, compression='gzip',

--- a/bin/hdfcoinc/pycbc_multiifo_dtphase
+++ b/bin/hdfcoinc/pycbc_multiifo_dtphase
@@ -208,12 +208,19 @@ for ifo0 in args.ifos:
     logging.info('Final length: %s', len(keys))
 
     # presort the keys, helps with downstream use
-    l = values.argsort()
-    keys = keys[l]
-    values = values[l]
+    ncol = keys.shape[1]
+    pdtype = [('c%s' % i, numpy.int8) for i in range(ncol)]
+    keys_bin = numpy.zeros(len(values), dtype=pdtype)
+    for i in range(ncol):
+        keys_bin['c%s' % i] = keys[:, i]
+    lsort = keys_bin.argsort()
+    keys_bin = keys_bin[lsort]
+    values = values[lsort]
 
-    f.create_dataset('%s/param_bin' % ifo0, data=keys, compression='gzip', compression_opts=7)
-    f.create_dataset('%s/weights' % ifo0, data=values, compression='gzip', compression_opts=7)
+    f.create_dataset('%s/param_bin' % ifo0, data=keys_bin, compression='gzip',
+                     compression_opts=7)
+    f.create_dataset('%s/weights' % ifo0, data=values, compression='gzip',
+                     compression_opts=7)
 
 f.attrs['sensitivity_ratios'] = args.relative_sensitivities
 f.attrs['srbmin'] = srbmin

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -279,7 +279,6 @@ class PhaseTDNewStatistic(NewSNRStatistic):
         self.relsense = {}
         self.swidth = self.pwidth = self.twidth = None
         self.max_penalty = None
-        self.pdtype = []
         self.weights = {}
         self.param_bin = {}
 
@@ -415,7 +414,9 @@ class PhaseTDNewStatistic(NewSNRStatistic):
                 binned += [tbin, pbin, sbin]
 
             # convert binned to same dtype as stored in hist
-            nbinned = numpy.zeros(len(pbin), dtype=self.pdtype)
+            ncol = len(self.param_bin[ref_ifo][1])
+            pdtype = [('c%s' % i, numpy.int8) for i in range(ncol)]
+            nbinned = numpy.zeros(len(pbin), dtype=pdtype)
             for i, b in enumerate(binned):
                 nbinned['c%s' % i] = b
 

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -279,6 +279,7 @@ class PhaseTDNewStatistic(NewSNRStatistic):
         self.relsense = {}
         self.swidth = self.pwidth = self.twidth = None
         self.max_penalty = None
+        self.pdtype = []
         self.weights = {}
         self.param_bin = {}
 
@@ -316,8 +317,24 @@ class PhaseTDNewStatistic(NewSNRStatistic):
 
         for ifo in self.hist_ifos:
             self.weights[ifo] = histfile[ifo]['weights'][:]
-            self.param_bin[ifo] = histfile[ifo]['param_bin'][:]
-            self.pdtype = self.param_bin[ifo].dtype
+            param = histfile[ifo]['param_bin'][:]
+            if param.dtype == 'int8'
+                param = histfile[ifo]['param_bin'][:]
+                # Old style, incorrectly sorted histogram file
+                self.pdtype = [('c%s' % i, param.dtype) for i in range(ncol)]
+                self.param_bin[ifo] = numpy.zeros(len(self.weights[ifo]),
+                                                  dtype=self.pdtype)
+                for i in range(ncol):
+                    self.param_bin[ifo]['c%s' % i] = param[:, i]
+
+                lsort = self.param_bin[ifo].argsort()
+                self.param_bin[ifo] = self.param_bin[ifo][lsort]
+                self.weights[ifo] = self.weights[ifo][lsort]
+            else:
+                # New style, efficient histogram file
+                # param bin and weights have already been sorted
+                self.param_bin = param
+                self.pdtype = self.param_bin[ifo].dtype
             self.max_penalty = self.weights[ifo].min()
 
         self.hist = {}

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -317,19 +317,7 @@ class PhaseTDNewStatistic(NewSNRStatistic):
 
         for ifo in self.hist_ifos:
             self.weights[ifo] = histfile[ifo]['weights'][:]
-
-            param = histfile[ifo]['param_bin'][:]
-            ncol = param.shape[1]
-            self.pdtype = [('c%s' % i, param.dtype) for i in range(ncol)]
-            self.param_bin[ifo] = numpy.zeros(len(self.weights[ifo]),
-                                              dtype=self.pdtype)
-            for i in range(ncol):
-                self.param_bin[ifo]['c%s' % i] = param[:, i]
-
-            lsort = self.param_bin[ifo].argsort()
-            self.param_bin[ifo] = self.param_bin[ifo][lsort]
-            self.weights[ifo] = self.weights[ifo][lsort]
-
+            self.param_bin[ifo] = histfile[ifo]['param_bin'][:]
             self.max_penalty = self.weights[ifo].min()
 
         self.hist = {}

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -319,8 +319,8 @@ class PhaseTDNewStatistic(NewSNRStatistic):
             self.weights[ifo] = histfile[ifo]['weights'][:]
             param = histfile[ifo]['param_bin'][:]
             if param.dtype == 'int8'
-                param = histfile[ifo]['param_bin'][:]
                 # Old style, incorrectly sorted histogram file
+                ncol = param.shape[1]
                 self.pdtype = [('c%s' % i, param.dtype) for i in range(ncol)]
                 self.param_bin[ifo] = numpy.zeros(len(self.weights[ifo]),
                                                   dtype=self.pdtype)

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -318,7 +318,7 @@ class PhaseTDNewStatistic(NewSNRStatistic):
         for ifo in self.hist_ifos:
             self.weights[ifo] = histfile[ifo]['weights'][:]
             param = histfile[ifo]['param_bin'][:]
-            if param.dtype == 'int8'
+            if param.dtype == 'int8':
                 # Old style, incorrectly sorted histogram file
                 ncol = param.shape[1]
                 self.pdtype = [('c%s' % i, param.dtype) for i in range(ncol)]
@@ -333,7 +333,7 @@ class PhaseTDNewStatistic(NewSNRStatistic):
             else:
                 # New style, efficient histogram file
                 # param bin and weights have already been sorted
-                self.param_bin = param
+                self.param_bin[ifo] = param
                 self.pdtype = self.param_bin[ifo].dtype
             self.max_penalty = self.weights[ifo].min()
 

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -317,6 +317,7 @@ class PhaseTDNewStatistic(NewSNRStatistic):
         for ifo in self.hist_ifos:
             self.weights[ifo] = histfile[ifo]['weights'][:]
             self.param_bin[ifo] = histfile[ifo]['param_bin'][:]
+            self.pdtype = self.param_bin[ifo].dtype
             self.max_penalty = self.weights[ifo].min()
 
         self.hist = {}
@@ -414,9 +415,7 @@ class PhaseTDNewStatistic(NewSNRStatistic):
                 binned += [tbin, pbin, sbin]
 
             # convert binned to same dtype as stored in hist
-            ncol = len(self.param_bin[ref_ifo][1])
-            pdtype = [('c%s' % i, numpy.int8) for i in range(ncol)]
-            nbinned = numpy.zeros(len(pbin), dtype=pdtype)
+            nbinned = numpy.zeros(len(pbin), dtype=self.pdtype)
             for i, b in enumerate(binned):
                 nbinned['c%s' % i] = b
 


### PR DESCRIPTION
Updates to multiifo_dtphase and stat.py to change the ordering in stored prior histograms and allow more efficient running of coinc_findtrigs

The new version of stat.py has been tested with equivalent histogram files with and without the new sorting (manually applied) and and example run of coinc_findtrigs run gives exactly the same outcome.

The output histogram of the new version of multiifo_dtphase has not yet been tested against these