### PR TITLE
Optimize 2det multiifo coinc

### DIFF
--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -348,7 +348,7 @@ class PhaseTDNewStatistic(NewSNRStatistic):
                 array_size = [256,256,256]
                 dtypec = self.weights[ifo].dtype
                 self.two_det_weights[ifo] = \
-                    numpy.zeros(array_size, dtype=dtypec) + max_penalty
+                    numpy.zeros(array_size, dtype=dtypec) + self.max_penalty
                 id0 = self.param_bin[ifo]['c0'] + 128
                 id1 = self.param_bin[ifo]['c1'] + 128
                 id2 = self.param_bin[ifo]['c2'] + 128

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -283,8 +283,8 @@ class PhaseTDNewStatistic(NewSNRStatistic):
         self.weights = {}
         self.param_bin = {}
         self.two_det_flag = (len(ifos) == 2)
-        if self.two_det_flag:
-            self.two_det_weights = {}
+        self.two_det_weights = {}
+        self.pb_int_size = None
 
     def get_hist(self, ifos=None):
         """Read in a signal density file for the ifo combination"""
@@ -343,11 +343,22 @@ class PhaseTDNewStatistic(NewSNRStatistic):
             self.max_penalty = self.weights[ifo].min()
 
             if self.two_det_flag:
-                # 3bins, for "t", "p", and "s". However, we can expand the
-                # weights lookup table here, avoiding the need to not store 0
-                # values by using param_bin. This makes the lookup a O(N)
-                # rather than O(NlogN) operation. It sacrifices RAM to do this,
-                # so is a good tradeoff for 2 detectors, but not for 3!
+                # The relative weights are computed as a
+                # function of 3 binned parameters, time difference (t), phase
+                # difference (p) and sensitivity different (s). These are 
+                # computed for each combination of detectors, so for 3 detectors
+                # 6 differences are needed. However, many
+                # combinations of these parameters are highly unlikely and
+                # no instances of these combinations occurred when generating
+                # the statistic files. Rather than storing a bunch of 0s, these
+                # values are just not stored at all. This reduces the size of the
+                # statistic file, but means we have to identify the correct value
+                # to read for every trigger. For 2 detectors we can expand the
+                # weights lookup table here, basically adding in all the "0"
+                # values. This makes looking up a value in the "weights" table
+                # a O(N) rather than O(NlogN) operation. It sacrifices RAM
+                # to do this, so is a good tradeoff for 2 detectors,
+                # but not for 3!
                 pb_iinfo = numpy.iinfo(self.param_bin[ifo]['c0'].dtype)
                 self.pb_int_size = pb_iinfo.max - pb_iinfo.min + 1
 

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -346,7 +346,7 @@ class PhaseTDNewStatistic(NewSNRStatistic):
                 # The density of signals is computed as a function of 3 binned
                 # parameters: time difference (t), phase difference (p) and
                 # SNR ratio (s). These are computed for each combination of
-                # detectors, so for detectors 6 differences are needed. However,
+                # detectors, so for detectors 6 differences are needed. However
                 # many combinations of these parameters are highly unlikely and
                 # no instances of these combinations occurred when generating
                 # the statistic files. Rather than storing a bunch of 0s, these

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -456,9 +456,9 @@ class PhaseTDNewStatistic(NewSNRStatistic):
             # Read signal weight from precalculated histogram
             if self.two_det_flag:
                 # High-RAM, low-CPU option for two-det
-                id0 = nbinned['c0']
-                id1 = nbinned['c1']
-                id2 = nbinned['c2']
+                id0 = nbinned['c0'] + 128
+                id1 = nbinned['c1'] + 128
+                id2 = nbinned['c2'] + 128
                 rate[rtype] = self.two_det_weights[ref_ifo][id0, id1, id2]
             else:
                 # Low[er]-RAM, high[er]-CPU option for >two det

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -345,20 +345,20 @@ class PhaseTDNewStatistic(NewSNRStatistic):
             if self.two_det_flag:
                 # The relative weights are computed as a
                 # function of 3 binned parameters, time difference (t), phase
-                # difference (p) and sensitivity different (s). These are 
-                # computed for each combination of detectors, so for 3 detectors
-                # 6 differences are needed. However, many
+                # difference (p) and sensitivity different (s). These are
+                # computed for each combination of detectors, so for 3
+                # detectors 6 differences are needed. However, many
                 # combinations of these parameters are highly unlikely and
                 # no instances of these combinations occurred when generating
                 # the statistic files. Rather than storing a bunch of 0s, these
-                # values are just not stored at all. This reduces the size of the
-                # statistic file, but means we have to identify the correct value
-                # to read for every trigger. For 2 detectors we can expand the
-                # weights lookup table here, basically adding in all the "0"
-                # values. This makes looking up a value in the "weights" table
-                # a O(N) rather than O(NlogN) operation. It sacrifices RAM
-                # to do this, so is a good tradeoff for 2 detectors,
-                # but not for 3!
+                # values are just not stored at all. This reduces the size of
+                # the statistic file, but means we have to identify the correct
+                # value to read for every trigger. For 2 detectors we can
+                # expand the weights lookup table here, basically adding in all
+                # the "0" values. This makes looking up a value in the
+                # "weights" table a O(N) rather than O(NlogN) operation. It
+                # sacrifices RAM to do this, so is a good tradeoff for 2
+                # detectors, but not for 3!
                 pb_iinfo = numpy.iinfo(self.param_bin[ifo]['c0'].dtype)
                 self.pb_int_size = pb_iinfo.max - pb_iinfo.min + 1
 

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -321,6 +321,7 @@ class PhaseTDNewStatistic(NewSNRStatistic):
         for ifo in self.hist_ifos:
             self.weights[ifo] = histfile[ifo]['weights'][:]
             param = histfile[ifo]['param_bin'][:]
+
             if param.dtype == numpy.int8:
                 # Old style, incorrectly sorted histogram file
                 ncol = param.shape[1]
@@ -338,7 +339,9 @@ class PhaseTDNewStatistic(NewSNRStatistic):
                 # param bin and weights have already been sorted
                 self.param_bin[ifo] = param
                 self.pdtype = self.param_bin[ifo].dtype
+
             self.max_penalty = self.weights[ifo].min()
+
             if self.two_det_flag:
                 # 3bins, for "t", "p", and "s". However, we can expand the
                 # weights lookup table here, avoiding the need to not store 0
@@ -347,7 +350,7 @@ class PhaseTDNewStatistic(NewSNRStatistic):
                 # so is a good tradeoff for 2 detectors, but not for 3!
                 pb_iinfo = numpy.iinfo(self.param_bin[ifo]['c0'].dtype)
                 self.pb_int_size = pb_iinfo.max - pb_iinfo.min + 1
-                
+
                 array_size = [self.pb_int_size, self.pb_int_size,
                               self.pb_int_size]
                 dtypec = self.weights[ifo].dtype

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -323,7 +323,7 @@ class PhaseTDNewStatistic(NewSNRStatistic):
             param = histfile[ifo]['param_bin'][:]
 
             if param.dtype == numpy.int8:
-                # Old style, incorrectly sorted histogram file
+                # Older style, incorrectly sorted histogram file
                 ncol = param.shape[1]
                 self.pdtype = [('c%s' % i, param.dtype) for i in range(ncol)]
                 self.param_bin[ifo] = numpy.zeros(len(self.weights[ifo]),
@@ -343,12 +343,11 @@ class PhaseTDNewStatistic(NewSNRStatistic):
             self.max_penalty = self.weights[ifo].min()
 
             if self.two_det_flag:
-                # The relative weights are computed as a
-                # function of 3 binned parameters, time difference (t), phase
-                # difference (p) and sensitivity different (s). These are
-                # computed for each combination of detectors, so for 3
-                # detectors 6 differences are needed. However, many
-                # combinations of these parameters are highly unlikely and
+                # The density of signals is computed as a function of 3 binned
+                # parameters: time difference (t), phase difference (p) and
+                # SNR ratio (s). These are computed for each combination of
+                # detectors, so for detectors 6 differences are needed. However,
+                # many combinations of these parameters are highly unlikely and
                 # no instances of these combinations occurred when generating
                 # the statistic files. Rather than storing a bunch of 0s, these
                 # values are just not stored at all. This reduces the size of


### PR DESCRIPTION
Here's a change discussed in the SLACK channel where we can reduce the cost of the `searchsorted` operation, by storing *all* possible weights in memory, making lookup a `O(N)` operation.

This comes at the cost of RAM. For 2-det (HV or LV) this is a few hundred MB, for 3-det this is impossible. So this is hardcoded to only be used for 2-detector cases.

For 3-det the number of triggers is small enough that this isn't such of an issue.
