### PR TITLE
Fix broken add_statmap

### DIFF
--- a/pycbc/workflow/coincidence.py
+++ b/pycbc/workflow/coincidence.py
@@ -280,7 +280,9 @@ class PyCBCMultiifoAddStatmap(PyCBCMultiifoCombineStatmap):
             tags = []
         node = super(PyCBCMultiifoAddStatmap, self).create_node(statmap_files,
                                                             tags=tags)
-        if 'injections' in (tags+self.tags):
+        # Enforce upper case
+        ctags = [t.upper for t in (tags+self.tags)]
+        if 'INJECTIONS' in ctags:
             node.add_input_list_opt('--background-files', background_files)
 
         return node

--- a/pycbc/workflow/coincidence.py
+++ b/pycbc/workflow/coincidence.py
@@ -281,7 +281,7 @@ class PyCBCMultiifoAddStatmap(PyCBCMultiifoCombineStatmap):
         node = super(PyCBCMultiifoAddStatmap, self).create_node(statmap_files,
                                                             tags=tags)
         # Enforce upper case
-        ctags = [t.upper for t in (tags+self.tags)]
+        ctags = [t.upper() for t in (tags + self.tags)]
         if 'INJECTIONS' in ctags:
             node.add_input_list_opt('--background-files', background_files)
 


### PR DESCRIPTION
`add_statmap` is currently broken on master for injections. This is due to the recent changes to the workflow generation code exposing a problem in the `Executable` class. To remove case sensitivity we always store tags as upper case internally. Therefore checking for `injections` as a tag is going to be problematic (and is broken in the current version where this arrives in upper-case).

We avoid this by explicitly casting all tags to upper-case before checking. `self.tags` already will be upper case, but the local `tags` might not be.