### PR TITLE
JointDistribution: introduce loop for renormalization due to constraints, and improve documentation

### DIFF
--- a/pycbc/distributions/joint.py
+++ b/pycbc/distributions/joint.py
@@ -127,6 +127,10 @@ class JointDistribution(object):
             # set new scaling factor for prior to be
             # the fraction of acceptances in random sampling of entire space
             self._pdf_scale = result.sum() / float(n_test_samples)
+            if self._pdf_scale == 0.0:
+                raise ValueError("None of the random draws for pdf "
+                    "renormalization satisfied the constraints. "
+                    " You can try increasing the 'n_test_samples' keyword.")
 
         else:
             self._pdf_scale = 1.0

--- a/pycbc/distributions/joint.py
+++ b/pycbc/distributions/joint.py
@@ -36,11 +36,13 @@ class JointDistribution(object):
         (retrieved from the distributions' params attribute) must be the same
         as the set of variable_args provided.
     \*\*kwargs :
-        Valid keyword arguments include `constraints`. `constraints` is a list
-        functions that accept a dict of parameters with the parameter name as
-        the key. If the constraint is satisfied the function should return
-        True, if the constraint is violated, then the function should return
-        False.
+        Valid keyword arguments include:
+        `constraints` : a list of functions that accept a dict of parameters
+        with the parameter name as the key. If the constraint is satisfied the
+        function should return True, if the constraint is violated, then the
+        function should return False.
+        `n_test_samples` : number of random draws used to fix pdf normalization
+        factor after applying constraints.
 
     Attributes
     ----------
@@ -57,7 +59,7 @@ class JointDistribution(object):
     An example of creating a joint distribution with constraint that total mass must
     be below 30.
 
-    >>> from pycbc.distributions import uniform, JointDistribution
+    >>> from pycbc.distributions import Uniform, JointDistribution
     >>> def mtotal_lt_30(params):
         ...    return True if params["mass1"] + params["mass2"] < 30 else False
     >>> mass_lim = (2, 50)
@@ -117,12 +119,14 @@ class JointDistribution(object):
 
             # evaluate constraints
             result = numpy.ones(len(tuple(samples.values())[0]), dtype=bool)
-            for constraint in self._constraints:
-                result = constraint(samples) & result
+            for n in numpy.arange(n_test_samples):
+                sample = {param: samples[param][n] for param in distparams}
+                for constraint in self._constraints:
+                    result[n] = constraint(sample) & result[n]
 
             # set new scaling factor for prior to be
             # the fraction of acceptances in random sampling of entire space
-            self._pdf_scale = sum(result) / float(n_test_samples)
+            self._pdf_scale = result.sum() / float(n_test_samples)
 
         else:
             self._pdf_scale = 1.0
@@ -152,7 +156,7 @@ class JointDistribution(object):
         return params
 
     def __call__(self, **params):
-        """Evalualate joint distribution for parameters.
+        """Evaluate joint distribution for parameters.
         """
         for constraint in self._constraints:
             if not constraint(params):


### PR DESCRIPTION
@cdcapano @cmbiwer trying to follow the [example](https://pycbc.org/pycbc/latest/html/pycbc.distributions.html#module-pycbc.distributions.joint) for a JointDistribution with constraints, I ran into two errors, one trivial and one not:

1.  import needs to be `Uniform` not `uniform`
1. Since the example constraint function `mtotal_lt_30` is not vectorized, but evaluated internally over an array of amples for the pdf renormalization, it throws an
```
ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
```

At first I thought the right fix would be to vectorize the example function, e.g.
```
def mtotal_lt_30(params):
    return np.less(params["mass1"] + params["mass2"],30)
```
but as far as I know, the resulting JointDistribution object won't be able to be called over arrays anyway, so that seems to be a red herring. (That said, vectorizing the whole module would be an amazing overall improvement!)

Instead, this PR introduces an explicit loop over the test samples, along with additional documentation fixes.

Commit message:
```
fix renormalization due to constraints in JointDistribution, and doc

* since the resulting distribution cannot be evaluated on arrays,
  the constraint functions need not / cannot be vectorized either
  (and the given example isn't),
  so internally need to loop over the random samples
  used for pdf renormalization
* also document n_test_samples kwarg
* and minor doc fixes
```