### PR TITLE
Allow for more flexible substitution from injections in config file

### DIFF
--- a/pycbc/inference/models/gaussian_noise.py
+++ b/pycbc/inference/models/gaussian_noise.py
@@ -938,10 +938,11 @@ def get_values_from_injection(cp, injection_file, update_cp=True):
 
     .. code-black:: ini
 
-       mass1 = FROM_INJECTION:primary_mass(mass1, mass2)
+       mass1 = FROM_INJECTION:'primary_mass(mass1, mass2)'
 
     will cause the larger of mass1 and mass2 to be retrieved from the injection
-    file.
+    file. Note that if spaces are in the argument, it must be encased in
+    single quotes.
 
     The injection file may contain only one injection. Otherwise, a ValueError
     will be raised.

--- a/pycbc/inference/models/gaussian_noise.py
+++ b/pycbc/inference/models/gaussian_noise.py
@@ -564,10 +564,9 @@ class BaseGaussianNoise(BaseDataModel):
         else:
             injection_file = None
         args['injection_file'] = injection_file
-        # update any static params that are set to FROM_INJECTION
-        replace_params = get_static_params_from_injection(
-            args['static_params'], injection_file)
-        args['static_params'].update(replace_params)
+        # update any values that are to be retrieved from the injection
+        # Note: this does nothing if there are FROM_INJECTION values
+        get_values_from_injection(cp, injection_file, update_cp=True)
         # get ifo-specific instances of calibration model
         if cp.has_section('calibration'):
             logging.info("Initializing calibration model")
@@ -919,48 +918,88 @@ class GaussianNoise(BaseGaussianNoise):
 #
 # =============================================================================
 #
-def get_static_params_from_injection(static_params, injection_file):
-    """Gets FROM_INJECTION static params from injection.
+def get_values_from_injection(cp, injection_file, update_cp=True):
+    """Replaces all FROM_INJECTION values in a config file with the
+    corresponding value from the injection.
+
+    This looks for any options that start with ``FROM_INJECTION[:ARG]`` in
+    a config file. It then replaces that value with the corresponding value
+    from the injection file. An argument may be optionally provided, in which
+    case the argument will be retrieved from the injection file. Functions of
+    parameters in the injection file may be used; the syntax and functions
+    available is the same as the ``--parameters`` argument in executables
+    such as ``pycbc_inference_extract_samples``. If no ``ARG`` is provided,
+    then the option name will try to be retrieved from the injection.
+
+    For example,
+
+    .. code-block:: ini
+
+       mass1 = FROM_INJECTION
+
+    will cause ``mass1`` to be retrieved from the injection file, while:
+
+    .. code-black:: ini
+
+       mass1 = FROM_INJECTION:primary_mass(mass1, mass2)
+
+    will cause the larger of mass1 and mass2 to be retrieved from the injection
+    file.
+
+    The injection file may contain only one injection. Otherwise, a ValueError
+    will be raised.
 
     Parameters
     ----------
-    static_params : dict
-        Dictionary of static params.
-    injection_file : str
-        Name of the injection file to use.
+    cp : ConfigParser
+        The config file within which to replace values.
+    injection_file : str or None
+        The injection file to get values from. A ValueError will be raised
+        if there are any ``FROM_INJECTION`` values in the config file, and
+        injection file is None, or if there is more than one injection.
+    update_cp : bool, optional
+        Update the config parser with the replaced parameters. If False,
+        will just retrieve the parameter values to update, without updating
+        the config file. Default is True.
 
     Returns
     -------
-    dict :
-        A dictionary mapping parameter names to values retrieved from the
-        injection file. The dictionary will only contain parameters that were
-        set to ``"FROM_INJECTION"`` in the ``static_params``.
-        Parameter names -> values The injection parameters.
+    list
+        The parameters that were replaced, as a tuple of section name, option,
+        value.
     """
-    # pull out the parameters that need replacing
-    replace_params = {p: None for (p, val) in static_params.items()
-                      if val == 'FROM_INJECTION'}
-    if replace_params != {}:
-        # make sure there's actually an injection file
+    lookfor = 'FROM_INJECTION'
+    # figure out what parameters need to be set
+    replace_params = [(sec, opt, cp.get(sec, opt))
+                      for sec in cp.sections for opt in cp.options(sec)
+                      if opt.startswith(lookfor)]
+    if replace_params:
+        # check that we have an injection file
         if injection_file is None:
-            raise ValueError("one or more static params are set to "
-                             "FROM_INJECTION, but no injection file "
-                             "provided in data section")
+            raise ValueError("One or values are set to {}, but no injection "
+                             "file provided".format(lookfor))
+        # load the injection file
         inj = InjectionSet(injection_file)
         # make sure there's only one injection provided
         if inj.table.size > 1:
-            raise ValueError("Some static params set to FROM_INJECTION, but "
-                             "more than one injection exists in the injection "
-                             "file.")
-        for param in replace_params:
-            try:
-                injval = inj.table[param][0]
-            except NameError:
-                # means the parameter doesn't exist
-                raise ValueError("Static param {} with placeholder "
-                                 "FROM_INJECTION has no counterpart in "
-                                 "injection file.".format(param))
-            replace_params[param] = injval
+            raise ValueError("One or more values are set to {}, but more than "
+                             "one injection exists in the injection file."
+                             .format(lookfor))
+    # get the injection values to replace
+    for ii, (sec, opt, arg) in enumerate(replace_params):
+        # determine what we should retrieve from the injection
+        arg = arg.split(':', 1)
+        if len(arg) == 1:
+            arg = opt
+        else:
+            arg = arg[1]
+        # now get the injection value and set it
+        replace_val = inj[arg][0]
+        replace_params[ii] = (sec, opt, replace_val)
+    # replace in the config file
+    if update_cp:
+        for (sec, opt, val) in replace_params:
+            cp.set(sec, opt, val)
     return replace_params
 
 


### PR DESCRIPTION
This makes it so that you can substitute values taken from an injection file in an inference config file, when using a model that inherits from `BaseGaussianNoise`.

Currently, you can set `static_params` to be values pulled from the injection file (when using `BaseGaussianNoise`) by setting them to `FROM_INJECTION`. This generalizes that to allow anything to be set in the inference config file to parameters pulled from the injection file. It also allows functions of injection parameters to be used, by doing `FROM_INJECTION:ARG`. The syntax for `ARG` is the standard parameter syntax (if no `ARG` is provided, it will default to using whatever option is being set).

This is most useful for setting trigger times. For example, when doing an injection run, you can have in the `[data]` section:
```
trigger-time = FROM_INJECTION:tc
```
This will then set the trigger time to be the coalescence time in the injection file. This is necessary in order to do PP tests on real data.

Example test using the PP workflow [here](https://www.atlas.aei.uni-hannover.de/~work-cdcapano/scratch/prs/from_inj_update/py36_quick_test_from_inj_output/html/). If you look at the config files in section 7 (e.g., [this one](https://www.atlas.aei.uni-hannover.de/~work-cdcapano/scratch/prs/from_inj_update/py36_quick_test_from_inj_output/html/7._config_files/7.01_injection_1/)), you can see how `FROM_INJECTION` has been used to set the trigger time, approximant, and the masses in the `data`, `static_params`, and `waveform_transforms-tc` sections.

Aside: I thought about making this one of the variable substitutions that can be done by `WorkflowConfigParser` -- in which case you would do something more like `${FROM_INJECTION|ARG}` -- but I didn't want to mess with the current string interpolation functions. The tricky bit with this is that you would not want the substitution to happen with injections when the config file is loaded, since you would need to provide the injection file when loading the config file (and the injection file itself may be specified in the config file, as it is for inference jobs). This means you'd have to delay substituting `FROM_INJECTION`, so it could be done manually later. That seemed complicated, so I just went with this route.

Also, we may want to make this functionality available to more models than just Gaussian noise derived ones. Since that would require making the base models aware of injection files, I figured that can be done in a later patch if we think it necessary.