### PR TITLE
Add colorbar labels to foundmissed plots. General tidy-up of the foundmissed script

### DIFF
--- a/bin/hdfcoinc/pycbc_page_foundmissed
+++ b/bin/hdfcoinc/pycbc_page_foundmissed
@@ -1,11 +1,12 @@
 #!/usr/bin/env python
 """ Plot found and missed injections.
 """
-import h5py, numpy, logging, os.path, argparse, sys, matplotlib
+import h5py, numpy, logging, os.path, argparse, sys
 import matplotlib; matplotlib.use('Agg')
 import matplotlib.pyplot as plot
 import pycbc.results.followup, pycbc.pnutils, pycbc.results, pycbc.version
 import pycbc.pnutils
+from pycbc import init_logging
 
 parser = argparse.ArgumentParser(description=__doc__)
 parser.add_argument('--injection-file',
@@ -17,8 +18,9 @@ parser.add_argument('--distance-type', default='decisive_optimal_snr',
                     choices=['decisive_distance', 'dec_chirp_distance',
                              'chirp_distance', 'comb_optimal_snr',
                              'decisive_optimal_snr', 'redshift'],
-                    help="Variable related to injected distance. Decisive distance and dec"
-                         " chirp distance only available for 2-ifo search")
+                    help="Variable related to injected distance. Decisive "
+                         "distance and dec chirp distance only available for "
+                         "2-ifo search")
 parser.add_argument('--plot-all-distance', action='store_true', default=False,
                     help="Plot all values of distance or SNR. If not given, "
                          "the plot will be truncated below 1")
@@ -30,18 +32,18 @@ parser.add_argument('--dynamic', action='store_true', default=False)
 parser.add_argument('--gradient-far', action='store_true',
                     help="Show far of found injections as a gradient")
 parser.add_argument('--output-file', required=True)
-parser.add_argument('--far-type', choices=('inclusive', 'exclusive'), default='inclusive',
-                    help="Type of far to plot for the color. Choices are 'inclusive' or "
-                         "'exclusive'. Default = 'inclusive'")
+parser.add_argument('--far-type', choices=('inclusive', 'exclusive'),
+                    default='inclusive',
+                    help="Type of far to plot for the color. Choices are "
+                         "'inclusive' or 'exclusive'. Default = 'inclusive'")
 parser.add_argument('--missed-on-top', action='store_true',
-                    help="Plot missed injections on top of found ones and high FAR on "
-                         "top of low FAR")
-parser.add_argument('--version', action='version', version=pycbc.version.git_verbose_msg)
+                    help="Plot missed injections on top of found ones and "
+                         "high FAR on top of low FAR")
+parser.add_argument('--version', action='version',
+                    version=pycbc.version.git_verbose_msg)
 args = parser.parse_args()
 
-if args.verbose:
-    log_level = logging.INFO
-    logging.basicConfig(format='%(asctime)s : %(message)s', level=log_level)
+init_logging(args.verbose)
 
 logging.info('Read in the data')
 f = h5py.File(args.injection_file, 'r')
@@ -80,8 +82,7 @@ else:
 
 # NOTE: Effective distance is hardcoded to these values. It's also normally
 #       meaningless for precessing injections.
-eff_dist_map = {'H1': 'eff_dist_h', 'H2': 'eff_dist_h', 'L1': 'eff_dist_l',
-                'G1': 'eff_dist_g', 'T1': 'eff_dist_t', 'V1': 'eff_dist_v'}
+eff_dist_map = {ifo: 'eff_dist_%s' % ifo[0].lower() for ifo in ifos}
 
 try:
     eff_dists = [f['injections/{}'.format(eff_dist_map[ifo])][:]\
@@ -145,48 +146,56 @@ fig = plot.figure()
 zmissed = args.missed_on_top
 zfound = not args.missed_on_top
 
+mpoints = plot.scatter(vals[args.axis_type][missed], mdvals, s=16,
+                       linewidth=0.5, marker='x', color='red',
+                       label='missed', zorder=zmissed)
+
+fvals = vals[args.axis_type][found]
+
+ifsort = numpy.argsort(ifar_found)
+if args.missed_on_top:
+    ifsort = ifsort[::-1]
+
+fvals = fvals[ifsort]
+fdval = fdvals[ifsort]
+ifsorted = ifar_found[ifsort]
+
 if not args.gradient_far:
-    color = numpy.zeros(len(found))
-    ten = numpy.where(ifar_found > 10)[0]
-    hundred = numpy.where(ifar_found > 100)[0]
-    thousand = numpy.where(ifar_found > 1000)[0]
+    color = numpy.ones(len(found))
+    ten = numpy.where(ifsorted > 10)[0]
+    hundred = numpy.where(ifsorted > 100)[0]
+    thousand = numpy.where(ifsorted > 1000)[0]
     color[hundred] = 0.5
-    color[thousand] = 1.0
+    color[thousand] = 0
 
-    mpoints = plot.scatter(vals[args.axis_type][missed], mdvals, s=16, linewidth=0.5,
-                           marker='x', color='black', label='missed', zorder=zmissed)
-    points = plot.scatter(vals[args.axis_type][found], fdvals, s=16,
-                           c=color, linewidth=0, vmin=0, vmax=1,
-                           marker='o', label='found', zorder=zfound)
-    caption = (fig_title + ": Black x's are missed injections. "
-              "Blue circles are found with IFAR < 100 years, green are < 1000 years, and "
-              "red are found with IFAR >=1000 years. ")
+    norm = matplotlib.colors.Normalize()
+    caption = (fig_title + ": Red x's are missed injections. "
+              "Blue circles are found with IFAR < 100 years, gray are < "
+              "1000 years, and yellow are found with IFAR >=1000 years. ")
 else:
-    fvals = vals[args.axis_type][found]
-    color = 1.0 / ifar_found
-
-    # sort: if missed on top put high-FAR on top, if found on top vice versa
-    csort = color.argsort()
-    if not args.missed_on_top:
-        csort = csort[::-1]
-    fvals = fvals[csort]
-    fdval = fdvals[csort]
-    color = color[csort]
+    color = 1.0 / ifsorted
     if len(color) < 2:
         color=None
 
-    mpoints = plot.scatter(vals[args.axis_type][missed], mdvals, s=16, linewidth=0.5,
-                           marker='x', color='red', label='missed', zorder=zmissed)
-    points = plot.scatter(fvals, fdval, c=color, linewidth=0, s=16,
-                          norm=matplotlib.colors.LogNorm(),
-                          marker='o', label='found', zorder=zfound,cmap=args.colormap)
+    norm = matplotlib.colors.LogNorm()
     caption = (fig_title + ": Red x's are missed injections. "
-               "Circles are found injections. The color indicates the value of "
-               "the false alarm rate." )
-    plot.subplots_adjust(right=0.99)
+               "Circles are found injections. The color indicates the value "
+               "of the false alarm rate." )
+
+points = plot.scatter(fvals, fdval, c=color, linewidth=0, s=16, norm=norm,
+                      marker='o', label='found', zorder=zfound,
+                      cmap=args.colormap)
+if args.gradient_far:
     try:
         c = plot.colorbar()
         c.set_label('False Alarm Rate $(yr^{-1})$, %s' % far_title)
+
+        # Set up tick labels - there will always be 5
+        min_tick = numpy.ceil(min(numpy.log10(color)))
+        max_tick = numpy.floor(max(numpy.log10(color)))
+        tick_step = numpy.floor((max_tick - min_tick) / 5)
+        ticks = numpy.arange(min_tick, max_tick, tick_step)
+        c.set_ticks(numpy.power(10, ticks))
     except (TypeError, ZeroDivisionError):
         # Can't make colorbar if no quiet found injections
         if len(fvals):
@@ -201,6 +210,7 @@ ax = plot.gca()
 plot.xlabel(labels[args.axis_type])
 plot.ylabel(labels[args.distance_type])
 plot.grid()
+plot.tight_layout()
 
 if args.log_x:
     # log x axis may fail for some choices, eg effective spin

--- a/bin/hdfcoinc/pycbc_page_foundmissed
+++ b/bin/hdfcoinc/pycbc_page_foundmissed
@@ -210,7 +210,6 @@ ax = plot.gca()
 plot.xlabel(labels[args.axis_type])
 plot.ylabel(labels[args.distance_type])
 plot.grid()
-plot.tight_layout()
 
 if args.log_x:
     # log x axis may fail for some choices, eg effective spin
@@ -250,7 +249,7 @@ if ('.html' in args.output_file):
                                                     alpha_unsel=0.1)
     mpld3.plugins.connect(fig, legend)
 
-pycbc.results.save_fig_with_metadata\
-    (fig, args.output_file, fig_kwds=fig_kwds,
-     title='%s: %s vs %s' % (fig_title, args.axis_type, args.distance_type),
-     cmd=' '.join(sys.argv), caption=caption)
+title = '%s: %s vs %s' % (fig_title, args.axis_type, args.distance_type)
+cmd = ' '.join(sys.argv)
+pycbc.results.save_fig_with_metadata(fig, args.output_file, fig_kwds=fig_kwds,
+                                     title=title, cmd=cmd, caption=caption)


### PR DESCRIPTION
Adding colorbar tick labels to foundmissed plots - this is currently hard-coded to give 5 labels

I have also done some tidying of the code having seen that quite a bit has been repeated in various if statements. The colorblind-friendly colour scheme of #3205 also hadn't been applied to the plots which did not have --gradient-far set

Examples:
Gradient FAR - Found on top
![image](https://user-images.githubusercontent.com/44500294/79449658-edac0980-7fe3-11ea-830e-1b400c166e2d.png)

Gradient FAR - Missed on top
![image](https://user-images.githubusercontent.com/44500294/79449712-04eaf700-7fe4-11ea-9c41-0bb97d4552a3.png)

Set FAR - Found on Top
![image](https://user-images.githubusercontent.com/44500294/79449762-18965d80-7fe4-11ea-8f8a-aa586ac0fb62.png)

Set FAR - Missed on Top
![image](https://user-images.githubusercontent.com/44500294/79449792-23e98900-7fe4-11ea-89eb-439376bfda89.png)
