### PR TITLE
Coinc snrchi multiifo

### DIFF
--- a/bin/hdfcoinc/pycbc_page_coinc_snrchi
+++ b/bin/hdfcoinc/pycbc_page_coinc_snrchi
@@ -52,6 +52,7 @@ f = h5py.File(args.coinc_statistic_file, 'r')
 b_tids = {}
 old_style_format_flag = 'detector_1' in f.attrs
 if old_style_format_flag:
+    ifos = [f.attrs['detector_1'], f.attrs['detector_2']]
     b_tids[f.attrs['detector_1']] = f['background_exc/trigger_id1']
     b_tids[f.attrs['detector_2']] = f['background_exc/trigger_id2']
 else:
@@ -83,7 +84,6 @@ if old_style_format_flag:
     inj_tids[f.attrs['detector_1']] = f['found_after_vetoes/trigger_id1']
     inj_tids[f.attrs['detector_2']] = f['found_after_vetoes/trigger_id2']
 else:
-    ifos = f.attrs['ifos'].split(' ')
     for tmpifo in ifos:
         inj_tids[tmpifo] = f['found_after_vetoes/{}/trigger_id'.format(tmpifo)]
 
@@ -175,13 +175,14 @@ pylab.legend(loc='lower right', prop={'size': 10})
 pylab.grid(which='major', ls='solid', alpha=0.7, linewidth=.5)
 pylab.grid(which='minor', ls='solid', alpha=0.7, linewidth=.1)
 
-title = '%s %s chisq vs SNR. Background with injections %s' \
-        % (ifo.upper(), args.chisq_choice,
+title = '%s %s chisq vs SNR. %s background with injections %s' \
+        % (ifo.upper(), args.chisq_choice, ''.join(ifos).upper(),
            'behind' if args.background_front else 'ontop')
 caption = """Distribution of SNR and %s chi-squared veto for single detector
-triggers. Black points are background triggers. Triangles are injection
+triggers. Black points are %s background triggers. Triangles are injection
 triggers colored by %s of the injection. Dashed lines show contours of
-constant NewSNR.""" % (args.chisq_choice, coloring[args.colorbar_choice][1])
+constant NewSNR.""" % (args.chisq_choice, ''.join(ifos).upper(),
+                       coloring[args.colorbar_choice][1])
 pycbc.results.save_fig_with_metadata(fig,
                                      args.output_file,
                                      title=title,

--- a/bin/hdfcoinc/pycbc_page_coinc_snrchi
+++ b/bin/hdfcoinc/pycbc_page_coinc_snrchi
@@ -50,7 +50,6 @@ args = parser.parse_args()
 # Add the background triggers
 f = h5py.File(args.coinc_statistic_file, 'r')
 b_tids = {}
-# FIXME: rewrite for multi-ifo case
 old_style_format_flag = 'detector_1' in f.attrs
 if old_style_format_flag:
     b_tids[f.attrs['detector_1']] = f['background_exc/trigger_id1']
@@ -80,7 +79,6 @@ pylab.scatter(bkg_snr, bkg_chisq, marker='o', color='black',
 # Add the found injection points
 f = h5py.File(args.found_injection_file, 'r')
 inj_tids = {}
-# FIXME : make compatible with multi-ifo case
 if old_style_format_flag:
     inj_tids[f.attrs['detector_1']] = f['found_after_vetoes/trigger_id1']
     inj_tids[f.attrs['detector_2']] = f['found_after_vetoes/trigger_id2']

--- a/bin/hdfcoinc/pycbc_page_coinc_snrchi
+++ b/bin/hdfcoinc/pycbc_page_coinc_snrchi
@@ -51,8 +51,14 @@ args = parser.parse_args()
 f = h5py.File(args.coinc_statistic_file, 'r')
 b_tids = {}
 # FIXME: rewrite for multi-ifo case
-b_tids[f.attrs['detector_1']] = f['background_exc/trigger_id1']
-b_tids[f.attrs['detector_2']] = f['background_exc/trigger_id2']
+old_style_format_flag = 'detector_1' in f.attrs
+if old_style_format_flag:
+    b_tids[f.attrs['detector_1']] = f['background_exc/trigger_id1']
+    b_tids[f.attrs['detector_2']] = f['background_exc/trigger_id2']
+else:
+    ifos = f.attrs['ifos'].split(' ')
+    for tmpifo in ifos:
+        b_tids[tmpifo] = f['background_exc/{}/trigger_id'.format(tmpifo)]
 
 f = h5py.File(args.single_trigger_file, 'r')
 ifo = tuple(f.keys())[0]
@@ -75,8 +81,14 @@ pylab.scatter(bkg_snr, bkg_chisq, marker='o', color='black',
 f = h5py.File(args.found_injection_file, 'r')
 inj_tids = {}
 # FIXME : make compatible with multi-ifo case
-inj_tids[f.attrs['detector_1']] = f['found_after_vetoes/trigger_id1']
-inj_tids[f.attrs['detector_2']] = f['found_after_vetoes/trigger_id2']
+if old_style_format_flag:
+    inj_tids[f.attrs['detector_1']] = f['found_after_vetoes/trigger_id1']
+    inj_tids[f.attrs['detector_2']] = f['found_after_vetoes/trigger_id2']
+else:
+    ifos = f.attrs['ifos'].split(' ')
+    for tmpifo in ifos:
+        inj_tids[tmpifo] = f['found_after_vetoes/{}/trigger_id'.format(tmpifo)]
+
 
 inj_idx = f['found_after_vetoes/injection_index'][:]
 eff_dist = f['injections'][eff_map[ifo]][:][inj_idx]

--- a/bin/workflows/pycbc_create_offline_search_workflow
+++ b/bin/workflows/pycbc_create_offline_search_workflow
@@ -651,9 +651,9 @@ for inj_file, tag in zip(inj_files, inj_tags):
         for inj_insp, trig_insp in zip(inspcomb, fdinspcmb):
             final_bg_file = final_bg_files[ordered_ifo_list]
             curr_tags = [tag, ordered_ifo_list]
-            #f += wf.make_coinc_snrchi_plot(workflow, found_inj, inj_insp,
-            #                               final_bg_file, trig_insp,
-            #                               injdir, tags=curr_tags)
+            f += wf.make_coinc_snrchi_plot(workflow, found_inj, inj_insp,
+                                           final_bg_file, trig_insp,
+                                           injdir, tags=curr_tags)
 
     # Make pages from plots
     inj_layout = list(layout.grouper(f, 2)) + [(found_table,), (missed_table,)]


### PR DESCRIPTION
Re-enable the coinc_snrchi plots in the multiifo workflow. Doing this requires adding a small amount of code to the executable to handle both old- and new-format input.