### PR TITLE
Generalize relative model to all frequency domain approximants

### DIFF
--- a/docs/_include/inference_example_relative.sh
+++ b/docs/_include/inference_example_relative.sh
@@ -1,0 +1,3 @@
+sh ../../examples/inference/relative/get.sh
+sh ../../examples/inference/relative/run.sh
+sh ../../examples/inference/relative/plot.sh

--- a/docs/inference/examples/relative.rst
+++ b/docs/inference/examples/relative.rst
@@ -1,0 +1,54 @@
+-----------------------------------
+Using the relative model
+-----------------------------------
+
+The relative model is useful for when you know the parameters of your signal
+(say the masses, spins, etc of a merger) that are near the peak of the
+likelihood. In this case, we don't need to calculate the likelihood at the full
+frequency resolution in order to accurately sample the neighborhood of the
+maximum likelihood. This can greatly speed up the calculation of the likelihood.
+To use this model you provide the near-peak parameters as fixed arguments as in
+the configuration file below.
+
+This example demonstrates using the ``relative`` model with the
+``emcee_pt`` sampler. First, we create the following configuration file:
+
+.. literalinclude:: ../../../examples/inference/relative/relative.ini
+   :language: ini
+
+:download:`Download <../../../examples/inference/relative/relative.ini>`
+
+For this example, we'll need to download gravitational-wave data for GW170817:
+
+.. literalinclude:: ../../../examples/inference/relative/get.sh
+   :language: bash
+
+By setting the model name to ``relative`` we are using
+:py:class:`Relative <pycbc.inference.models.relbin.Relative>`.
+
+Now run:
+
+.. literalinclude:: ../../../examples/inference/relative/run.sh
+   :language: bash
+
+:download:`Download <../../../examples/inference/relative/run.sh>`
+
+This will run the ``emcee_pt`` sampler. When it is done, you will have a file called
+``relative.hdf`` which contains the results. It should take about a minute or two to
+run.
+
+To plot the posterior distribution after the last iteration, run:
+
+.. literalinclude:: ../../../examples/inference/relative/plot.sh
+   :language: bash
+
+:download:`Download <../../../examples/inference/relative/plot.sh>`
+
+This will create the following plot:
+
+.. image:: ../../_include/relative.png
+   :scale: 30
+   :align: center
+
+The scatter points show each walker's position after the last iteration. The
+points are colored by the signal-to-noise ratio at that point.

--- a/examples/inference/relative/get.sh
+++ b/examples/inference/relative/get.sh
@@ -1,0 +1,3 @@
+wget -nc https://dcc.ligo.org/public/0146/P1700349/001/H-H1_LOSC_CLN_4_V1-1187007040-2048.gwf
+wget -nc https://dcc.ligo.org/public/0146/P1700349/001/L-L1_LOSC_CLN_4_V1-1187007040-2048.gwf
+wget -nc https://dcc.ligo.org/public/0146/P1700349/001/V-V1_LOSC_CLN_4_V1-1187007040-2048.gwf

--- a/examples/inference/relative/plot.sh
+++ b/examples/inference/relative/plot.sh
@@ -1,0 +1,4 @@
+pycbc_inference_plot_posterior \
+--input-file relative.hdf \
+--output-file relative.png \
+--z-arg snr

--- a/examples/inference/relative/relative.ini
+++ b/examples/inference/relative/relative.ini
@@ -1,0 +1,85 @@
+[model]
+name = relative
+low-frequency-cutoff = 30.0
+high-frequency-cutoff = 1024.0
+epsilon = 0.03
+mass1_ref = 1.3757
+mass2_ref = 1.3757
+tc_ref = 1187008882.42
+
+[data]
+instruments = H1 L1 V1
+analysis-start-time = 1187008482
+analysis-end-time = 1187008892
+psd-estimation = median
+psd-segment-length = 16
+psd-segment-stride = 8
+psd-inverse-length = 16
+pad-data = 8
+channel-name = H1:LOSC-STRAIN L1:LOSC-STRAIN V1:LOSC-STRAIN
+frame-files = H1:H-H1_LOSC_CLN_4_V1-1187007040-2048.gwf L1:L-L1_LOSC_CLN_4_V1-1187007040-2048.gwf V1:V-V1_LOSC_CLN_4_V1-1187007040-2048.gwf
+strain-high-pass = 15
+sample-rate = 2048
+
+[sampler]
+name = emcee_pt
+ntemps = 4
+nwalkers = 100
+niterations = 300
+
+[sampler-burn_in]
+burn-in-test = min_iterations
+min-iterations = 100
+
+[variable_params]
+; waveform parameters that will vary in MCMC
+tc =
+distance =
+inclination =
+mchirp =
+eta =
+
+[static_params]
+; waveform parameters that will not change in MCMC
+approximant = TaylorF2
+f_lower = 30
+
+#; we'll choose not to sample over these, but you could
+polarization = 0.0
+ra = 3.44615914
+dec = -0.40808407
+
+#; You could also set additional parameters if your waveform model supports / requires it.
+; spin1z = 0
+
+[prior-mchirp]
+; chirp mass prior
+name = uniform
+min-mchirp = 1.1876
+max-mchirp = 1.2076
+
+[prior-eta]
+; symmetric mass ratio prior
+name = uniform
+min-eta = 0.23
+max-eta = 0.25
+
+[prior-tc]
+; coalescence time prior
+name = uniform
+min-tc = 1187008882.4
+max-tc = 1187008882.5
+
+[prior-distance]
+#; following gives a uniform in volume
+name = uniform_radius
+min-distance = 10
+max-distance = 60
+
+[prior-inclination]
+name = sin_angle
+
+[waveform_transforms-mass1+mass2]
+; transform from mchirp, eta to mass1, mass2 for waveform generation
+name = mchirp_eta_to_mass1_mass2
+

--- a/examples/inference/relative/run.sh
+++ b/examples/inference/relative/run.sh
@@ -1,0 +1,7 @@
+pycbc_inference \
+--config-file `dirname "$0"`/relative.ini \
+--nprocesses=4 \
+--output-file relative.hdf \
+--seed 0 \
+--force \
+--verbose

--- a/pycbc/inference/models/__init__.py
+++ b/pycbc/inference/models/__init__.py
@@ -25,7 +25,7 @@ from .analytic import (TestEggbox, TestNormal, TestRosenbrock, TestVolcano,
 from .gaussian_noise import GaussianNoise
 from .marginalized_gaussian_noise import MarginalizedPhaseGaussianNoise
 from .single_template import SingleTemplate
-from .relbin import RelativeSPA
+from .relbin import Relative
 
 
 # Used to manage a model instance across multiple cores or MPI
@@ -183,5 +183,5 @@ models = {_cls.name: _cls for _cls in (
     GaussianNoise,
     MarginalizedPhaseGaussianNoise,
     SingleTemplate,
-    RelativeSPA
+    Relative
 )}

--- a/pycbc/inference/models/relbin.py
+++ b/pycbc/inference/models/relbin.py
@@ -81,10 +81,11 @@ def setup_bins(f_full, f_lo, f_hi, chi=1.0, eps=0.5):
     # frequency grid points
     fbin = dphi2f(dphi_grid)
     # indices of frequency grid points in the FFT array
-    fbin_ind = numpy.array([numpy.argmin(numpy.absolute(f_full - ff)) for
-                            ff in fbin])
+    fbin_ind = numpy.unique([numpy.argmin(numpy.absolute(f_full - ff)) for
+                             ff in fbin])
     # make sure grid points are precise
     fbin = numpy.array([f_full[i] for i in fbin_ind])
+    nbin = len(fbin)
     return nbin, fbin, fbin_ind
 
 

--- a/pycbc/inference/models/relbin.py
+++ b/pycbc/inference/models/relbin.py
@@ -181,8 +181,8 @@ class Relative(BaseGaussianNoise):
         # generate fiducial waveform
         f_lo = kmins[0] * self.df
         f_hi = kmaxs[0] * self.df
-        logging.info("Generating fiducial waveform from %s to %s Hz" %
-                     (f_lo, f_hi))
+        logging.info("Generating fiducial waveform from %s to %s Hz",
+                     f_lo, f_hi)
         # prune low frequency samples to avoid waveform errors
         nbelow = sum(self.f < 10)
         fpoints = Array(self.f.astype(numpy.float64))[nbelow:]
@@ -303,8 +303,8 @@ class Relative(BaseGaussianNoise):
                             + self.sdat[ifo]['a1'] * r1)
             # <h, h> is sum over bins of B0|r0|^2 + 2B1Re(r1r0*)
             hh += numpy.sum(self.sdat[ifo]['b0'] * numpy.absolute(r0) ** 2.
-                           + 2. * self.sdat[ifo]['b1']
-                           * (r1 * numpy.conjugate(r0)).real)
+                            + 2. * self.sdat[ifo]['b1']
+                            * (r1 * numpy.conjugate(r0)).real)
         hd = abs(hd)
         llr = numpy.log(special.i0e(hd)) + hd - 0.5 * hh
         return float(llr)
@@ -321,7 +321,6 @@ class Relative(BaseGaussianNoise):
         fp.attrs['epsilon'] = self.epsilon
         for p, v in self.fid_params.items():
             fp.attrs['{}_ref'.format(p)] = v
-
 
     @staticmethod
     def extra_args_from_config(cp, section, skip_args=None, dtypes=None):

--- a/pycbc/inference/models/relbin.py
+++ b/pycbc/inference/models/relbin.py
@@ -90,7 +90,7 @@ def setup_bins(f_full, f_lo, f_hi, chi=1.0, eps=0.5):
     return nbin, fbin, fbin_ind
 
 
-class RelativeSPA(BaseGaussianNoise):
+class Relative(BaseGaussianNoise):
     r"""Model that assumes the likelihood in a region around the peak
     is slowly varying such that a linear approximation can be made, and
     likelihoods can be calculated at a coarser frequency resolution. For
@@ -142,14 +142,14 @@ class RelativeSPA(BaseGaussianNoise):
         All other keyword arguments are passed to
         :py:class:`BaseGaussianNoise`.
     """
-    name = "relative_spa"
+    name = "relative"
 
     def __init__(self, variable_params, data, low_frequency_cutoff,
                  mass1_ref, mass2_ref, spin1z_ref, spin2z_ref,
                  ra_ref, dec_ref, tc_ref,
                  epsilon=0.5,
                  **kwargs):
-        super(RelativeSPA, self).__init__(
+        super(Relative, self).__init__(
             variable_params, data, low_frequency_cutoff, **kwargs)
         # check that all of the frequency cutoffs are the same
         # FIXME: this can probably be loosened at some point
@@ -331,7 +331,7 @@ class RelativeSPA(BaseGaussianNoise):
         fp : pycbc.inference.io.BaseInferenceFile instance
             The inference file to write to.
         """
-        super(RelativeSPA, self).write_metadata(fp)
+        super(Relative, self).write_metadata(fp)
         fp.attrs['mass1_ref'] = self.mass1_ref
         fp.attrs['mass2_ref'] = self.mass2_ref
         fp.attrs['spin1z_ref'] = self.spin1z_ref

--- a/pycbc/inference/models/relbin.py
+++ b/pycbc/inference/models/relbin.py
@@ -260,13 +260,13 @@ class RelativeSPA(BaseGaussianNoise):
             b0 = numpy.array([4. * self.df * numpy.sum(hh[l:h]) for
                               l, h in self.bins])
             # linear terms
-            bin_centers = [0.5 * (fl + fh) for fl, fh in self.fbins]
+            bin_lefts = [fl for fl, fh in self.fbins]
             a1 = numpy.array([4. * self.df
-                              * numpy.sum(hd[l:h] * (self.f[l:h] - bc)) for
-                              (l, h), bc in zip(self.bins, bin_centers)])
+                              * numpy.sum(hd[l:h] * (self.f[l:h] - bl)) for
+                              (l, h), bl in zip(self.bins, bin_lefts)])
             b1 = numpy.array([4. * self.df
-                              * numpy.sum(hh[l:h] * (self.f[l:h] - bc)) for
-                              (l, h), bc in zip(self.bins, bin_centers)])
+                              * numpy.sum(hh[l:h] * (self.f[l:h] - bl)) for
+                              (l, h), bl in zip(self.bins, bin_lefts)])
 
             sdat[ifo] = {'a0': a0, 'a1': a1,
                          'b0': b0, 'b1': b1}
@@ -305,8 +305,8 @@ class RelativeSPA(BaseGaussianNoise):
             dtc = p['tc'] + dt - self.end_time
             tshift = numpy.exp(-2.0j * numpy.pi * self.fedges * dtc)
             # generate template and calculate waveform ratio
-            hp, hc = get_fd_waveform_sequence(
-                sample_points=Array(self.fedges), **p)
+            hp, hc = get_fd_waveform_sequence(sample_points=Array(self.fedges),
+                                              **p)
             htilde = numpy.array(fp * hp + fc * hc) * tshift
             r = (htilde / self.h00_sparse[ifo]).astype(numpy.complex128)
             r0 = r[:-1]

--- a/pycbc/inference/models/relbin.py
+++ b/pycbc/inference/models/relbin.py
@@ -171,11 +171,11 @@ class Relative(BaseGaussianNoise):
 
         # get detector-specific arrival times relative to end of data
         dt = {ifo:
-              self.det[ifo].time_delay_from_earth_center(self.ra_ref,
-                                                         self.dec_ref,
-                                                         self.tc_ref)
+              self.det[ifo].time_delay_from_earth_center(
+                  self.fid_params['ra'], self.fid_params['dec'],
+                  self.fid_params['tc'])
               for ifo in self.data}
-        self.ta = {ifo: self.tc_ref + dt[ifo] - self.end_time
+        self.ta = {ifo: self.fid_params['tc'] + dt[ifo] - self.end_time
                    for ifo in self.data}
 
         # generate fiducial waveform
@@ -238,7 +238,7 @@ class Relative(BaseGaussianNoise):
         for ifo in self.data:
             hd = numpy.conjugate(self.comp_data[ifo]) * self.h00[ifo]
             hd /= self.comp_psds[ifo]
-            hh = (numpy.absolute(h0[ifo]) ** 2.0) / self.comp_psds[ifo]
+            hh = (numpy.absolute(self.h00[ifo]) ** 2.0) / self.comp_psds[ifo]
             # constant terms
             a0 = numpy.array([4. * self.df * numpy.sum(hd[l:h]) for
                               l, h in self.bins])

--- a/tools/pycbc_test_suite.sh
+++ b/tools/pycbc_test_suite.sh
@@ -117,6 +117,19 @@ else
 fi
 popd
 
+## Run inference using relative model
+pushd examples/inference/relative
+bash -e get.sh
+bash -e run.sh
+if test $? -ne 0 ; then
+    RESULT=1
+    echo -e "    FAILED!"
+    echo -e "---------------------------------------------------------"
+else
+    echo -e "    Pass."
+fi
+popd
+
 ## Run inference samplers
 pushd examples/inference/samplers
 bash -e run.sh


### PR DESCRIPTION
This patch generalizes the relative likelihood model to be able to use any available frequency domain approximant, by switching the waveform generation from `spa_tmplt` to `get_fd_waveform_sequence`. This has been tested and confirmed to work for `TaylorF2`, `IMRPhenomD`, and `SEOBNRv4_ROM`.

To enable the use of different approximants, the fiducial waveform parameters required by the model are no longer provided explicitly to the `__init__` method. Instead these parameters are processed by `extra_args_from_config` into a single kwarg `fiducial_parameters`, using the same `{PARAM}_ref = {VALUE}` convention in the `[model]` section of the config file.

Other minor changes include:
 - restructure the loglr calculation to more closely match that done by `MarginalizedPhaseGuassianNoise`
 - optimize the binning algorithm to prevent edge cases where bins could be repeated or incorrectly ordered
 - change the linear approximation to anchor each bin at the left edge instead of the center, which ensures this model reduces to the non-relative likelihood in the limit of large number of bins

