### PR TITLE
Add link to relative model documentation page

### DIFF
--- a/docs/inference.rst
+++ b/docs/inference.rst
@@ -487,6 +487,7 @@ Examples
     inference/examples/bbh.rst
     inference/examples/gw150914.rst
     inference/examples/single.rst
+    inference/examples/relative.rst
 
 ===============================================
 Visualizing the Posteriors


### PR DESCRIPTION
#3224 added a documentation page with example for the relative likelihood model, but did not add a link to the new page in `inference.rst`. This patch adds that link, and an example of the documentation with link included is here:
https://dfinstad.github.io/pycbc/latest/html/inference/examples/relative.html