### PR TITLE
Improve float comparison in matchedfilter.py

### DIFF
--- a/pycbc/filter/matchedfilter.py
+++ b/pycbc/filter/matchedfilter.py
@@ -1088,7 +1088,7 @@ def sigmasq(htilde, psd = None, low_frequency_cutoff=None,
     if psd:
         try:
             numpy.testing.assert_almost_equal(ht.delta_f, psd.delta_f)
-        except:
+        except AssertionError:
             raise ValueError('Waveform does not have same delta_f as psd')
 
     if psd is None:
@@ -1234,10 +1234,11 @@ def matched_filter_core(template, data, psd=None, low_frequency_cutoff=None,
 
     if psd is not None:
         if isinstance(psd, FrequencySeries):
-            if psd.delta_f == stilde.delta_f :
-                qtilde[kmin:kmax] /= psd[kmin:kmax]
-            else:
-                raise TypeError("PSD delta_f does not match data")
+            try:
+                numpy.testing.assert_almost_equal(stilde.delta_f, psd.delta_f)
+            except AssertionError:
+                raise ValueError("PSD delta_f does not match data")
+            qtilde[kmin:kmax] /= psd[kmin:kmax]
         else:
             raise TypeError("PSD must be a FrequencySeries")
 
@@ -1902,4 +1903,3 @@ __all__ = ['match', 'matched_filter', 'sigmasq', 'sigma', 'get_cutoff_indices',
            'compute_u_val_for_sky_loc_stat_no_phase',
            'compute_u_val_for_sky_loc_stat',
            'followup_event_significance']
-

--- a/test/test_matchedfilter.py
+++ b/test/test_matchedfilter.py
@@ -134,7 +134,7 @@ class TestMatchedFilter(unittest.TestCase):
             #Check that an incompatible psd produces an error
             self.assertRaises(TypeError,match,self.filt,self.filt,psd=self.filt)
             psd = FrequencySeries(zeros(len(self.filt)/2+1),delta_f=100000)
-            self.assertRaises(TypeError,match,self.filt,self.filt,psd=psd)
+            self.assertRaises(ValueError,match,self.filt,self.filt,psd=psd)
 
             #Check that only TimeSeries or FrequencySeries are accepted
             self.assertRaises(TypeError,match,zeros(10),zeros(10))


### PR DESCRIPTION
stilde.delta_f and psd.delta_f were compared with the == operator.
This can produce false positives due to the finite precision of
the floating-point representation. Now, assert_almost_equal
takes care of this.

In addition, a bare except has been removed to catch the correct
exception that numpy.testing.assert_almost_equal throws.

Fixes #3226.
