### PR TITLE
No longer round sample rate

### DIFF
--- a/pycbc/strain/strain.py
+++ b/pycbc/strain/strain.py
@@ -342,8 +342,8 @@ def from_cli(opt, dyn_range_fac=1, precision='single',
 
         if opt.pad_data:
             logging.info("Remove Padding")
-            start = opt.pad_data * strain.sample_rate
-            end = len(strain) - strain.sample_rate * opt.pad_data
+            start = int(opt.pad_data * strain.sample_rate)
+            end = int(len(strain) - strain.sample_rate * opt.pad_data)
             strain = strain[start:end]
 
     if opt.fake_strain or opt.fake_strain_from_file:

--- a/pycbc/strain/strain.py
+++ b/pycbc/strain/strain.py
@@ -930,7 +930,7 @@ class StrainSegments(object):
             seg_len = strain.duration
 
         self.delta_f = 1.0 / seg_len
-        self.time_len = seg_len * self.sample_rate
+        self.time_len = int(seg_len * self.sample_rate)
         self.freq_len = self.time_len // 2 + 1
 
         seg_end_pad = segment_end_pad

--- a/pycbc/types/timeseries.py
+++ b/pycbc/types/timeseries.py
@@ -155,7 +155,7 @@ class TimeSeries(Array):
     def get_sample_rate(self):
         """Return the sample rate of the time series.
         """
-        return int(round(1.0/self.delta_t))
+        return 1.0/self.delta_t
     sample_rate = property(get_sample_rate,
                            doc="The sample rate of the time series.")
 

--- a/test/test_chisq.py
+++ b/test/test_chisq.py
@@ -69,7 +69,7 @@ class TestChisq(unittest.TestCase):
             data[ifo] = resample_to_delta_t(ts, 1.0/2048).crop(2, 2)
             p = data[ifo].psd(2)
             p = interpolate(p, data[ifo].delta_f)
-            p = inverse_spectrum_truncation(p, 2 * data[ifo].sample_rate,
+            p = inverse_spectrum_truncation(p, int(2 * data[ifo].sample_rate),
                                             low_frequency_cutoff=15.0)
             psd[ifo] = p
         hp, _ = get_fd_waveform(approximant="IMRPhenomD",


### PR DESCRIPTION
I've run into an issue caused by the previous sample rate rounding we put it. For once of my problems I have a non-integer sample rate. This situation will happen again and again in the future. At the moment, if you try to do this, things will silently work, but you'll get unexpected results for some operations (like time slice). 

@titodalcanton I know we put this in for something related to pycbc live. Can you remind me what the issue was? I no longer think requiring an integer sample rate (or dt for that matter) is a good idea.

DO NOT MERGE UNTIL IMPLICATIONS ARE SORTED OUT