### PR TITLE
Add option to plot waveform track on top of qscan

### DIFF
--- a/bin/plotting/pycbc_plot_qscan
+++ b/bin/plotting/pycbc_plot_qscan
@@ -43,7 +43,7 @@ def t_window(s):
         start, end = map(float, s.split(','))
         return [start, end]
     except:
-        raise argparse.ArgumentTypeError("Input must be param1,param2 param1,param2")
+        raise argparse.ArgumentTypeError("Input must be start,end start,end")
 
 parser = argparse.ArgumentParser(description=__doc__)
 parser.add_argument("--version", action="version",
@@ -98,7 +98,10 @@ parser.add_argument('--plot-caption',
                     help="If given, use this as the plot caption")
 parser.add_argument('--colormap', choices=plt.colormaps(), default='viridis',
                     help='Colormap to use (default %(default)s)')
-parser.add_argument('--masses', type=t_window, metavar='MASS1,MASS2',
+parser.add_argument('--mass1', type=float,
+                    help='Provide masses to plot the waveform track on top of '
+                         'the qscan.')
+parser.add_argument('--mass2', type=float,
                     help='Provide masses to plot the waveform track on top of '
                          'the qscan.')
 parser.add_argument('--spin1z', type=float, default=0,
@@ -208,14 +211,15 @@ plt.ylabel('Frequency (Hz)')
 cb = fig.colorbar(im, ax=(axes.ravel().tolist() if len(wins) > 1 else axes))
 cb.set_label('Normalized power')
 
-if opts.masses:
+if opts.mass1:
+    if not opts.mass2:
+        raise ValueError('mass1 provided but mass2 missing')
     from pycbc.pnutils import get_inspiral_tf
-    mass1, mass2 = opts.masses[0], opts.masses[1]
     f_low = 20.
-    approximant = 'SPAtmplt' if mass1+mass2<4 else 'SEOBNRv4_ROM'
-    track_t, track_f = get_inspiral_tf(opts.center_time, mass1, mass2,
-                                       opts.spin1z, opts.spin2z, f_low,
-                                       approximant=approximant)
+    approximant = 'SPAtmplt' if opts.mass1+opts.mass2<4 else 'SEOBNRv4_ROM'
+    track_t, track_f = get_inspiral_tf(opts.center_time, opts.mass1,
+                                       opts.mass2, opts.spin1z, opts.spin2z,
+                                       f_low, approximant=approximant)
     ax.plot(track_t - opts.center_time, track_f, 'r-', lw=1.5)
 
 if opts.plot_title is None:

--- a/bin/plotting/pycbc_plot_qscan
+++ b/bin/plotting/pycbc_plot_qscan
@@ -43,7 +43,7 @@ def t_window(s):
         start, end = map(float, s.split(','))
         return [start, end]
     except:
-        raise argparse.ArgumentTypeError("Input must be start,end start,end")
+        raise argparse.ArgumentTypeError("Input must be param1,param2 param1,param2")
 
 parser = argparse.ArgumentParser(description=__doc__)
 parser.add_argument("--version", action="version",
@@ -98,12 +98,20 @@ parser.add_argument('--plot-caption',
                     help="If given, use this as the plot caption")
 parser.add_argument('--colormap', choices=plt.colormaps(), default='viridis',
                     help='Colormap to use (default %(default)s)')
+parser.add_argument('--masses', type=t_window, metavar='MASS1,MASS2',
+                    help='Provide masses to plot the waveform track on top of '
+                         'the qscan.')
+parser.add_argument('--spin1z', type=float, default=0,
+                    help='If masses provided, provide spins to plot the '
+                         'waveform track on top of the qscan (default=0).')
+parser.add_argument('--spin2z', type=float, default=0,
+                    help='If masses provided, provide spins to plot the '
+                         'waveform track on top of the qscan (default=0).')
 
 pycbc.strain.insert_strain_option_group(parser)
 opts = parser.parse_args()
 
 logging.basicConfig(format='%(asctime)s %(message)s', level=logging.INFO)
-
 
 if opts.center_time is None:
     center_time = (opts.gps_start_time + opts.gps_end_time) / 2.
@@ -199,6 +207,16 @@ plt.ylabel('Frequency (Hz)')
 # https://stackoverflow.com/questions/13784201/matplotlib-2-subplots-1-colorbar
 cb = fig.colorbar(im, ax=(axes.ravel().tolist() if len(wins) > 1 else axes))
 cb.set_label('Normalized power')
+
+if opts.masses:
+    from pycbc.pnutils import get_inspiral_tf
+    mass1, mass2 = opts.masses[0], opts.masses[1]
+    f_low = 20.
+    approximant = 'SPAtmplt' if mass1+mass2<4 else 'SEOBNRv4_ROM'
+    track_t, track_f = get_inspiral_tf(opts.center_time, mass1, mass2,
+                                       opts.spin1z, opts.spin2z, f_low,
+                                       approximant=approximant)
+    ax.plot(track_t - opts.center_time, track_f, 'r-', lw=1.5)
 
 if opts.plot_title is None:
     opts.plot_title = 'Q-transform plot around {:.3f}'.format(opts.center_time)


### PR DESCRIPTION
This PR adds the option to plot a waveform time-freq track on top of an omega scan in pycbc_plot_qscan. To avoid having to give too many new arguments, it takes the masses in the same format as the time_window (i.e. mass1,mass2). I wanted to do the same with the spins, but it fails if the first spin is negative (if someone knows how to fix that, I'll be happy to change it).

P.S: I have an example plot in my laptop but I don't see any way to attach it here. I can send it on slack if someone wants to see it.