### PR TITLE
Only deploy 3.6 version to pypi

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -124,6 +124,7 @@ deploy:
   on:
     tags: true
     condition: $PYCBC_CONTAINER = build_and_test
+    python: 3.6
 before_cache:
 - rm -rf $HOME/build/pycbc-sources/lalsuite
 - rm -rf $HOME/build/pycbc-sources/pycbc


### PR DESCRIPTION
Allow release builds to work by only pushing the 3.6 build to PyPi