### PR TITLE
Allow PE to continue if waveform fails

### DIFF
--- a/pycbc/inference/models/marginalized_gaussian_noise.py
+++ b/pycbc/inference/models/marginalized_gaussian_noise.py
@@ -155,8 +155,11 @@ class MarginalizedPhaseGaussianNoise(BaseGaussianNoise):
         params = self.current_params
         try:
             wfs = self.waveform_generator.generate(**params)
-        except NoWaveformError:
-            return self._nowaveform_loglr()
+        except NoWaveformError as e:
+            if self.allow_waveform_errors:
+                return self._nowaveform_loglr()
+            else:
+                raise e
         hh = 0.
         hd = 0j
         for det, h in wfs.items():

--- a/pycbc/inference/models/marginalized_gaussian_noise.py
+++ b/pycbc/inference/models/marginalized_gaussian_noise.py
@@ -21,7 +21,7 @@ distance.
 import numpy
 from scipy import special
 
-from pycbc.waveform import NoWaveformError
+from pycbc.waveform import (NoWaveformError, FailedWaveformError)
 
 from .gaussian_noise import (BaseGaussianNoise, create_waveform_generator)
 
@@ -155,8 +155,10 @@ class MarginalizedPhaseGaussianNoise(BaseGaussianNoise):
         params = self.current_params
         try:
             wfs = self.waveform_generator.generate(**params)
-        except NoWaveformError as e:
-            if self.allow_waveform_errors:
+        except NoWaveformError:
+            return self._nowaveform_loglr()
+        except FailedWaveformError as e:
+            if self.ignore_failed_waveforms:
                 return self._nowaveform_loglr()
             else:
                 raise e

--- a/pycbc/waveform/generator.py
+++ b/pycbc/waveform/generator.py
@@ -26,6 +26,7 @@ This modules provides classes for generating waveforms.
 """
 
 from . import waveform
+from .waveform import NoWaveformError
 from . import ringdown
 from pycbc import filter
 from pycbc import transforms
@@ -134,7 +135,14 @@ class BaseGenerator(object):
     def _generate_from_current(self):
         """Generates a waveform from the current parameters.
         """
-        return self.generator(**self.current_params)
+        try:
+            return self.generator(**self.current_params)
+        except RuntimeError as e:
+            strparams = ', '.join([p, str(val)
+                                   for p, val in self.current_params.items()])
+            raise NoWaveformError("Failed to generate waveform with "
+                                  "parameters:\n{}\nError was: {}"
+                                  .format(strparams, e))
 
 
 class BaseCBCGenerator(BaseGenerator):

--- a/pycbc/waveform/generator.py
+++ b/pycbc/waveform/generator.py
@@ -26,7 +26,7 @@ This modules provides classes for generating waveforms.
 """
 
 from . import waveform
-from .waveform import NoWaveformError
+from .waveform import (NoWaveformError, FailedWaveformError)
 from . import ringdown
 from pycbc import filter
 from pycbc import transforms
@@ -138,11 +138,13 @@ class BaseGenerator(object):
         try:
             return self.generator(**self.current_params)
         except RuntimeError as e:
-            strparams = ', '.join([p, str(val)
+            # we'll get a RuntimeError if lalsimulation failed to generate
+            # the waveform for whatever reason
+            strparams = ' | '.join(['{}: {}'.format(p, str(val))
                                    for p, val in self.current_params.items()])
-            raise NoWaveformError("Failed to generate waveform with "
-                                  "parameters:\n{}\nError was: {}"
-                                  .format(strparams, e))
+            raise FailedWaveformError("Failed to generate waveform with "
+                                      "parameters:\n{}\nError was: {}"
+                                      .format(strparams, e))
 
 
 class BaseCBCGenerator(BaseGenerator):

--- a/pycbc/waveform/waveform.py
+++ b/pycbc/waveform/waveform.py
@@ -43,9 +43,16 @@ from .spa_tmplt import spa_tmplt, spa_tmplt_norm, spa_tmplt_end, \
                       spa_length_in_time
 from six.moves import range as xrange
 
+
 class NoWaveformError(Exception):
     """This should be raised if generating a waveform would just result in all
     zeros being returned, e.g., if a requested `f_final` is <= `f_lower`.
+    """
+    pass
+
+
+class FailedWaveformError(Exception):
+    """This should be raised if a waveform fails to generate.
     """
     pass
 
@@ -492,11 +499,12 @@ def get_fd_waveform(template=None, **kwargs):
             if 'f_final' in input_params and \
                     (input_params['f_lower']+input_params['delta_f'] >=
                      input_params['f_final']):
-                raise NoWaveformError("cannot generate waveform: f_lower >= f_final")
+                raise NoWaveformError("cannot generate waveform: f_lower >= "
+                                      "f_final")
     except KeyError:
         pass
-
     return wav_gen[input_params['approximant']](**input_params)
+
 
 get_fd_waveform.__doc__ = get_fd_waveform.__doc__.format(
     params=parameters.fd_waveform_params.docstr(prefix="    ",
@@ -1090,4 +1098,4 @@ __all__ = ["get_td_waveform", "get_fd_waveform", "get_fd_waveform_sequence",
            "get_waveform_filter_length_in_time", "get_sgburst_waveform",
            "print_sgburst_approximants", "sgburst_approximants",
            "td_waveform_to_fd_waveform", "get_two_pol_waveform_filter",
-           "NoWaveformError", "get_td_waveform_from_fd"]
+           "NoWaveformError", "FailedWaveformError", "get_td_waveform_from_fd"]


### PR DESCRIPTION
This adds an `ignore_failed_waveforms` option to the `GaussianNoise` and `MarginalizedGaussianNoise` models. If turned on, the model will catch errors raised by the waveform generator and assign that point likelihood = 0. Otherwise, the error will be raised. This allows one to still do PE even if a waveform model fails in a particular (and unknown a priori) part of parameter space.

To do this, I added a new exception `FailedWaveformError` to `waveform.py`. I thought about using `NoWaveformError`, but decided to keep that separate, since that indicates a zero waveform (like you would get if you flower is beyond the ringdown frequency). I created a new exception for `FailedWaveformError` rather than just catch `RuntimeError`s so that this can also be used with non-lalsimulation waveforms in the future. Also, the `FailedWaveformError` will print out what parameters caused the failure in the traceback, which is more useful then the generic RuntimeError raised by lalsimulation.

I debated catching the `RuntimeError` and replacing it with `FailedWaveformError` inside `get_(t|f)d_waveform`. Instead, I catch it in `BaseGenerator`, making this inference specific. I did that because I don't know if other codes currently rely on catching `RuntimeError`s from those functions. 