### PR TITLE
Fix issue #3248

### DIFF
--- a/pycbc/inference/models/data_utils.py
+++ b/pycbc/inference/models/data_utils.py
@@ -339,6 +339,8 @@ def data_opts_from_config(cp, section, filter_flow):
                          "(= psd-inverse-length/2) seconds to "
                          "account for PSD wrap around effects.",
                          det, pad)
+        else:
+            pad = 0
         gps_start[det] -= pad
         gps_end[det] += pad
         if opts.psd_start_time[det] is not None:


### PR DESCRIPTION
Sets `pad` to 0 if `inverse-psd-length` is not provided in data section.

Fixes #3248