### PR TITLE
add checkpointing to pycbc inspiral

### DIFF
--- a/bin/pycbc_inspiral
+++ b/bin/pycbc_inspiral
@@ -299,8 +299,9 @@ with ctx:
         try:
             tnum_start, event_mgr = events.EventManager.restore_state(checkpoint_file)
             checkpoint_exists = True
-        except:
+        except Exception as e:
             logging.info('Failed to load checkpoint file, starting anew')
+            logging.info(e)
 
     if not checkpoint_exists:
         event_mgr = events.EventManager(

--- a/bin/pycbc_inspiral
+++ b/bin/pycbc_inspiral
@@ -186,7 +186,12 @@ parser.add_argument("--use-compressed-waveforms", action="store_true", default=F
 parser.add_argument("--waveform-decompression-method", action='store', default=None,
                     help='Method to be used decompress waveforms from the bank file.')
 parser.add_argument("--checkpoint-interval", type=int,
-                    help="Save results to checkpoint file every X template")
+                    help="Save results to checkpoint file every X seconds")
+parser.add_argument("--checkpoint-exit-maxtime", type=int,
+                    help="Checkpoint and exit if X seconds of execution"
+                         " time is exceeded.")
+parser.add_argument("--checkpoint-exit-code", type=int, default=77,
+                    help="Exit code returned if existing after a checkpoint")
 
 # Add options groups
 psd.insert_psd_option_group(parser)
@@ -365,6 +370,7 @@ with ctx:
         logging.info("Template bank size after thinning: %s", len(bank))
 
     tsetup = time.time() - tstart
+    tcheckpoint = time.time()
 
     # Note: in the class-based approach used now, 'template' is not explicitly used
     # within the loop.  Rather, the iteration simply fills the memory specifed in
@@ -446,9 +452,16 @@ with ctx:
         if opt.finalize_events_template_rate is not None and \
                 not (t_num+1) % opt.finalize_events_template_rate:
             event_mgr.consolidate_events(opt, gwstrain=gwstrain)
-            
-        if opt.checkpoint_interval and (t_num % opt.checkpoint_interval == 0):
+
+        if opt.checkpoint_interval and \
+            (time.time() - tcheckpoint > opt.checkpoint_interval):
             event_mgr.save_state(t_num, opt.output + '.checkpoint')
+            tcheckpoint = time.time()
+
+        if opt.checkpoint_exit_maxtime and \
+            (time.time() - tstart > opt.checkpoint_exit_maxtime):
+            event_mgr.save_state(t_num, opt.output + '.checkpoint')
+            sys.exit(opt.checkpoint_exit_code)           
 
 event_mgr.consolidate_events(opt, gwstrain=gwstrain)
 event_mgr.finalize_events()

--- a/bin/pycbc_inspiral
+++ b/bin/pycbc_inspiral
@@ -186,12 +186,17 @@ parser.add_argument("--use-compressed-waveforms", action="store_true", default=F
 parser.add_argument("--waveform-decompression-method", action='store', default=None,
                     help='Method to be used decompress waveforms from the bank file.')
 parser.add_argument("--checkpoint-interval", type=int,
-                    help="Save results to checkpoint file every X seconds")
+                    help="Save results to checkpoint file every X seconds. "
+                         "Default is no checkpointing.")
+parser.add_argument('--require-valid-checkpoint', default=False, action="store_true",
+                    help="If the checkpoint file is invalid, raise an error. "
+                         "Default is to ignore invalid checkpoint files and to "
+                         "delete the broken file.")
 parser.add_argument("--checkpoint-exit-maxtime", type=int,
                     help="Checkpoint and exit if X seconds of execution"
-                         " time is exceeded.")
+                         " time is exceeded. Default is no checkpointing.")
 parser.add_argument("--checkpoint-exit-code", type=int, default=77,
-                    help="Exit code returned if existing after a checkpoint")
+                    help="Exit code returned if exiting after a checkpoint")
 
 # Add options groups
 psd.insert_psd_option_group(parser)
@@ -275,6 +280,7 @@ with ctx:
         logging.info("Finished")
         sys.exit(0)
 
+    # FIXME: Maybe we should use the PSD corresponding to each trigger
     if opt.psdvar_segment is not None:
         logging.info("Calculating PSD variation")
         psd_var = pycbc.psd.calc_filt_psd_variation(gwstrain, opt.psdvar_segment,
@@ -289,7 +295,6 @@ with ctx:
     else:
         q_trans = {}
 
-    # FIXME: Maybe we should use the PSD corresponding to each trigger
     if opt.checkpoint_interval:
         checkpoint_file = opt.output + '.checkpoint'
 
@@ -300,6 +305,10 @@ with ctx:
             tnum_start, event_mgr = events.EventManager.restore_state(checkpoint_file)
             checkpoint_exists = True
         except Exception as e:
+            if args.require_valid_checkpoint:
+                logging.info("Failed to load checkpoint file")
+                raise(e)
+
             logging.info('Failed to load checkpoint file, starting anew')
             logging.info(e)
 

--- a/bin/pycbc_inspiral
+++ b/bin/pycbc_inspiral
@@ -16,7 +16,7 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-import sys
+import sys, os
 import logging, argparse, numpy, itertools
 from six.moves import range
 import pycbc
@@ -185,6 +185,8 @@ parser.add_argument("--use-compressed-waveforms", action="store_true", default=F
                     help='Use compressed waveforms from the bank file.')
 parser.add_argument("--waveform-decompression-method", action='store', default=None,
                     help='Method to be used decompress waveforms from the bank file.')
+parser.add_argument("--checkpoint-interval", type=int,
+                    help="Save results to checkpoint file every X template")
 
 # Add options groups
 psd.insert_psd_option_group(parser)
@@ -283,7 +285,20 @@ with ctx:
         q_trans = {}
 
     # FIXME: Maybe we should use the PSD corresponding to each trigger
-    event_mgr = events.EventManager(
+    if opt.checkpoint_interval:
+        checkpoint_file = opt.output + '.checkpoint'
+
+    checkpoint_exists = False
+    tnum_start = 0
+    if (opt.checkpoint_interval and os.path.isfile(checkpoint_file)):
+        try:
+            tnum_start, event_mgr = events.EventManager.restore_state(checkpoint_file)
+            checkpoint_exists = True
+        except:
+            logging.info('Failed to load checkpoint file, starting anew')
+
+    if not checkpoint_exists:
+        event_mgr = events.EventManager(
             opt, names, [out_types[n] for n in names], psd=segments[0].psd,
             gating_info=gwstrain.gating_info, q_trans=q_trans)
 
@@ -355,7 +370,8 @@ with ctx:
     # within the loop.  Rather, the iteration simply fills the memory specifed in
     # the 'template_mem' argument to MatchedFilterControl with the next template
     # from the bank.
-    for t_num in range(len(bank)):
+    for t_num in range(len(bank) - tnum_start):
+        t_num += tnum_start
         tmplt_generated = False
 
         for s_num, stilde in enumerate(segments):
@@ -430,6 +446,9 @@ with ctx:
         if opt.finalize_events_template_rate is not None and \
                 not (t_num+1) % opt.finalize_events_template_rate:
             event_mgr.consolidate_events(opt, gwstrain=gwstrain)
+            
+        if opt.checkpoint_interval and (t_num % opt.checkpoint_interval == 0):
+            event_mgr.save_state(t_num, opt.output + '.checkpoint')
 
 event_mgr.consolidate_events(opt, gwstrain=gwstrain)
 event_mgr.finalize_events()

--- a/examples/inspiral/run.sh
+++ b/examples/inspiral/run.sh
@@ -37,9 +37,11 @@ pycbc_inspiral \
 --gps-end-time 1126259846 \
 --output H1-INSPIRAL-OUT.hdf \
 --verbose \
---approximant SPAtmplt \
---bank-file H1L1-SBANK_FOR_GW150914ER10.xml.gz
+--approximant "SPAtmplt:mtotal<4" "SEOBNRv4_ROM:mtotal<20" "SEOBNRv2_ROM_DoubleSpin:else" \
+--bank-file H1L1-SBANK_FOR_GW150914ER10.xml.gz 2> inspiral.log
 
+cat inspiral.log | head -10
+cat inspiral.log | tail -20
 
 echo -e "\\n\\n>> [`date`] test for GW150914"
 python ./check_GW150914_detection.py H1-INSPIRAL-OUT.hdf

--- a/examples/inspiral/run.sh
+++ b/examples/inspiral/run.sh
@@ -37,11 +37,9 @@ pycbc_inspiral \
 --gps-end-time 1126259846 \
 --output H1-INSPIRAL-OUT.hdf \
 --verbose \
---approximant "SPAtmplt:mtotal<4" "SEOBNRv4_ROM:mtotal<20" "SEOBNRv2_ROM_DoubleSpin:else" \
---bank-file H1L1-SBANK_FOR_GW150914ER10.xml.gz 2> inspiral.log
+--approximant SPAtmplt \
+--bank-file H1L1-SBANK_FOR_GW150914ER10.xml.gz
 
-cat inspiral.log | head -10
-cat inspiral.log | tail -20
 
 echo -e "\\n\\n>> [`date`] test for GW150914"
 python ./check_GW150914_detection.py H1-INSPIRAL-OUT.hdf

--- a/pycbc/events/eventmgr.py
+++ b/pycbc/events/eventmgr.py
@@ -190,6 +190,23 @@ class EventManager(object):
         self.template_events = numpy.array([], dtype=self.event_dtype)
         self.write_performance = False
 
+    def save_state(self, tnum_finished, filename):
+        """Save the current state of the background buffers"""
+        from six.moves import cPickle
+        self.tnum_finished = tnum_finished
+        logging.info('Writing checkpoint file at template {}'.format(tnum_finished))
+        cPickle.dump(self, open(filename, 'wb'), 
+                     protocol=cPickle.HIGHEST_PROTOCOL)
+
+    @staticmethod
+    def restore_state(filename):
+        """Restore state of the background buffers from a file"""
+        from six.moves import cPickle
+        mgr = cPickle.load(open(filename, 'rb'))
+        next_template = mgr.tnum_finished + 1
+        logging.info('Restarting with checkpoint at template {}'.format(next_template))
+        return mgr.tnum_finished + 1, mgr
+
     @classmethod
     def from_multi_ifo_interface(cls, opt, ifo, column, column_types, **kwds):
         """

--- a/pycbc/events/eventmgr.py
+++ b/pycbc/events/eventmgr.py
@@ -28,6 +28,7 @@ from __future__ import absolute_import
 import numpy, copy, os.path
 import logging
 import h5py
+from six.moves import cPickle
 
 from pycbc.types import Array
 from pycbc.scheme import schemed
@@ -193,7 +194,6 @@ class EventManager(object):
 
     def save_state(self, tnum_finished, filename):
         """Save the current state of the background buffers"""
-        from six.moves import cPickle
         from pycbc.io.hdf import dump_state
 
         self.tnum_finished = tnum_finished

--- a/pycbc/events/eventmgr.py
+++ b/pycbc/events/eventmgr.py
@@ -193,7 +193,7 @@ class EventManager(object):
 
     def save_state(self, tnum_finished, filename):
         """Save the current state of the background buffers"""
-        import cPickle
+        from six.moves import cPickle
         from pycbc.io.hdf import dump_state
 
         self.tnum_finished = tnum_finished

--- a/pycbc/events/eventmgr.py
+++ b/pycbc/events/eventmgr.py
@@ -421,7 +421,6 @@ class EventManager(object):
     def write_to_hdf(self, outname):
         class fw(object):
             def __init__(self, name, prefix):
-                import h5py
                 self.f = h5py.File(name, 'w')
                 self.prefix = prefix
 
@@ -663,7 +662,6 @@ class EventManagerCoherent(EventManagerMultiDetBase):
     def write_to_hdf(self, outname):
         class fw(object):
             def __init__(self, name):
-                import h5py
                 self.f = h5py.File(name, 'w')
 
             def __setitem__(self, name, data):
@@ -958,7 +956,6 @@ class EventManagerMultiDet(EventManagerMultiDetBase):
     def write_to_hdf(self, outname):
         class fw(object):
             def __init__(self, name):
-                import h5py
                 self.f = h5py.File(name, 'w')
 
             def __setitem__(self, name, data):

--- a/pycbc/inference/io/__init__.py
+++ b/pycbc/inference/io/__init__.py
@@ -39,8 +39,6 @@ from .dynesty import DynestyFile
 from .ultranest import UltranestFile
 from .posterior import PosteriorFile
 from .txt import InferenceTXTFile
-# add the dump/load state functions to the io namespace
-from .base_hdf import (load_state, dump_state)
 
 filetypes = {
     EmceeFile.name: EmceeFile,
@@ -682,7 +680,7 @@ def results_from_cli(opts, load_samples=True, **kwargs):
                 # this means no file, only one constraint, apply to all
                 # files
                 constraints = {fn: constraint for fn in input_files}
-                
+
     # loop over all input files
     for input_file in input_files:
         logging.info("Reading input file %s", input_file)
@@ -703,7 +701,7 @@ def results_from_cli(opts, load_samples=True, **kwargs):
             if input_file in constraints:
                 logging.info("Applying constraints")
                 mask = samples[constraints[input_file]]
-                samples = samples[mask] 
+                samples = samples[mask]
                 if samples.size == 0:
                     raise ValueError("No samples remain after constraint {} "
                                      "applied".format(constraints[input_file]))

--- a/pycbc/inference/io/base_hdf.py
+++ b/pycbc/inference/io/base_hdf.py
@@ -29,14 +29,11 @@ from __future__ import absolute_import
 
 import sys
 import logging
-import pickle
-from io import BytesIO
-from abc import (ABCMeta, abstractmethod)
 
+from abc import (ABCMeta, abstractmethod)
 from six import (add_metaclass, string_types)
 
 import numpy
-
 import h5py
 
 from pycbc.io import FieldArray
@@ -814,94 +811,3 @@ class BaseInferenceFile(h5py.File):
                 cls.write_kwargs_to_attrs(attrs, **val)
             else:
                 attrs[arg] = val
-
-
-#
-# =============================================================================
-#
-#                          Checkpointing utilities
-#
-# =============================================================================
-#
-
-
-def dump_state(state, fp, path=None, dsetname='sampler_state', protocol=None):
-    """Dumps the given state to an hdf5 file handler.
-
-    The state is stored as a raw binary array to ``{path}/{dsetname}`` in the
-    given hdf5 file handler. If a dataset with the same name and path is
-    already in the file, the dataset will be resized and overwritten with the
-    new state data.
-
-    Parameters
-    ----------
-    state : any picklable object
-        The sampler state to dump to file. Can be the object returned by
-        any of the samplers' `.state` attribute (a dictionary of dictionaries),
-        or any picklable object.
-    fp : h5py.File
-        An open hdf5 file handler. Must have write capability enabled.
-    path : str, optional
-        The path (group name) to store the state dataset to. Default (None)
-        will result in the array being stored to the top level.
-    dsetname : str, optional
-        The name of the dataset to store the binary array to. Default is
-        ``sampler_state``.
-    protocol : int, optional
-        The protocol version to use for pickling. See the :py:mod:`pickle`
-        module for more details.
-    """
-    memfp = BytesIO()
-    pickle.dump(state, memfp, protocol=protocol)
-    dump_pickle_to_hdf(memfp, fp, path=path, dsetname=dsetname)
-
-
-def dump_pickle_to_hdf(memfp, fp, path=None, dsetname='sampler_state'):
-    """Dumps pickled data to an hdf5 file object.
-
-    Parameters
-    ----------
-    memfp : file object
-        Bytes stream of pickled data.
-    fp : h5py.File
-        An open hdf5 file handler. Must have write capability enabled.
-    path : str, optional
-        The path (group name) to store the state dataset to. Default (None)
-        will result in the array being stored to the top level.
-    dsetname : str, optional
-        The name of the dataset to store the binary array to. Default is
-        ``sampler_state``.
-    """
-    memfp.seek(0)
-    bdata = numpy.frombuffer(memfp.read(), dtype='S1')
-    if path is not None:
-        fp = fp[path]
-    if dsetname not in fp:
-        fp.create_dataset(dsetname, shape=bdata.shape, maxshape=(None,),
-                          dtype=bdata.dtype)
-    elif bdata.size != fp[dsetname].shape[0]:
-        fp[dsetname].resize((bdata.size,))
-    fp[dsetname][:] = bdata
-
-
-def load_state(fp, path=None, dsetname='sampler_state'):
-    """Loads a sampler state from the given hdf5 file object.
-
-    The sampler state is expected to be stored as a raw bytes array which can
-    be loaded by pickle.
-
-    Parameters
-    ----------
-    fp : h5py.File
-        An open hdf5 file handler.
-    path : str, optional
-        The path (group name) that the state data is stored to. Default (None)
-        is to read from the top level.
-    dsetname : str, optional
-        The name of the dataset that the state data is stored to. Default is
-        ``sampler_state``.
-    """
-    if path is not None:
-        fp = fp[path]
-    bdata = fp[dsetname][()].tobytes()
-    return pickle.load(BytesIO(bdata))

--- a/pycbc/io/hdf.py
+++ b/pycbc/io/hdf.py
@@ -6,10 +6,10 @@ import h5py
 import numpy as np
 import logging
 import inspect
-import cPickle as pickle
 
 from itertools import chain
 from six.moves import range
+from six.moves import cPickle as pickle
 
 from io import BytesIO
 from lal import LIGOTimeGPS, YRJUL_SI

--- a/pycbc/io/hdf.py
+++ b/pycbc/io/hdf.py
@@ -6,9 +6,12 @@ import h5py
 import numpy as np
 import logging
 import inspect
+import cPickle as pickle
+
 from itertools import chain
 from six.moves import range
 
+from io import BytesIO
 from lal import LIGOTimeGPS, YRJUL_SI
 
 from glue.ligolw import ligolw
@@ -1123,3 +1126,93 @@ def get_all_subkeys(grp, key):
             subkey_list += get_all_subkeys(grp, path)
     # returns an empty list if there is no dataset or subgroup within the group
     return subkey_list
+    
+#
+# =============================================================================
+#
+#                          Checkpointing utilities
+#
+# =============================================================================
+#
+
+
+def dump_state(state, fp, path=None, dsetname='state', protocol=None):
+    """Dumps the given state to an hdf5 file handler.
+
+    The state is stored as a raw binary array to ``{path}/{dsetname}`` in the
+    given hdf5 file handler. If a dataset with the same name and path is
+    already in the file, the dataset will be resized and overwritten with the
+    new state data.
+
+    Parameters
+    ----------
+    state : any picklable object
+        The sampler state to dump to file. Can be the object returned by
+        any of the samplers' `.state` attribute (a dictionary of dictionaries),
+        or any picklable object.
+    fp : h5py.File
+        An open hdf5 file handler. Must have write capability enabled.
+    path : str, optional
+        The path (group name) to store the state dataset to. Default (None)
+        will result in the array being stored to the top level.
+    dsetname : str, optional
+        The name of the dataset to store the binary array to. Default is
+        ``state``.
+    protocol : int, optional
+        The protocol version to use for pickling. See the :py:mod:`pickle`
+        module for more details.
+    """
+    memfp = BytesIO()
+    pickle.dump(state, memfp, protocol=protocol)
+    dump_pickle_to_hdf(memfp, fp, path=path, dsetname=dsetname)
+
+
+def dump_pickle_to_hdf(memfp, fp, path=None, dsetname='state'):
+    """Dumps pickled data to an hdf5 file object.
+
+    Parameters
+    ----------
+    memfp : file object
+        Bytes stream of pickled data.
+    fp : h5py.File
+        An open hdf5 file handler. Must have write capability enabled.
+    path : str, optional
+        The path (group name) to store the state dataset to. Default (None)
+        will result in the array being stored to the top level.
+    dsetname : str, optional
+        The name of the dataset to store the binary array to. Default is
+        ``state``.
+    """
+    memfp.seek(0)
+    bdata = np.frombuffer(memfp.read(), dtype='S1')
+    if path is not None:
+        fp = fp[path]
+    if dsetname not in fp:
+        fp.create_dataset(dsetname, shape=bdata.shape, maxshape=(None,),
+                          dtype=bdata.dtype)
+    elif bdata.size != fp[dsetname].shape[0]:
+        fp[dsetname].resize((bdata.size,))
+    fp[dsetname][:] = bdata
+
+
+def load_state(fp, path=None, dsetname='state'):
+    """Loads a sampler state from the given hdf5 file object.
+
+    The sampler state is expected to be stored as a raw bytes array which can
+    be loaded by pickle.
+
+    Parameters
+    ----------
+    fp : h5py.File
+        An open hdf5 file handler.
+    path : str, optional
+        The path (group name) that the state data is stored to. Default (None)
+        is to read from the top level.
+    dsetname : str, optional
+        The name of the dataset that the state data is stored to. Default is
+        ``state``.
+    """
+    if path is not None:
+        fp = fp[path]
+    bdata = fp[dsetname][()].tobytes()
+    return pickle.load(BytesIO(bdata))

--- a/pycbc/io/hdf.py
+++ b/pycbc/io/hdf.py
@@ -1126,7 +1126,7 @@ def get_all_subkeys(grp, key):
             subkey_list += get_all_subkeys(grp, path)
     # returns an empty list if there is no dataset or subgroup within the group
     return subkey_list
-    
+
 #
 # =============================================================================
 #


### PR DESCRIPTION
This adds basic checkpointing to pycbc inspiral using the cPickle module to save the EventManager to disk. 

A new option '--checkpoint-interval' is added to pycbc inspiral. If provided, you give the number of templates between checkpoints. These happen automatically, and are not triggered by condor atm. 

Some things to note
(1) XML format template banks don't work with this. I think there is a bug in numpy at the moment in regards to pickling of object dtypes (it should throw an error when you try to pickle instead it decides to segfault when you load from the pickle file). Only use HDF format files if you have checkpointing enabled. I have no plans to support XML format. 
(2) This patch does not include any updates for the workflow to handle these checkpoints for you, so you should only turn this on if you run in shared filesystem mode at the moment. 

Possible future improvements (but not in this PR)
1) condor hooks in workflow for nonsharedfs management (I think we just need to set a variable with the checkpoint filename)
2) higher density format for saving to disk. Pickle works, but the files are much larger than need be. This may cause issues with filesystems if checkpoints are too often. (i.e. checkpoint file may be order of magnitude larger than the final output file or more). 