### PR TITLE
Reduce pycbc_plot_trigger_timeseries memory usage

### DIFF
--- a/bin/minifollowups/pycbc_plot_trigger_timeseries
+++ b/bin/minifollowups/pycbc_plot_trigger_timeseries
@@ -57,12 +57,13 @@ for ifo in args.single_trigger_files.keys():
     if args.special_trigger_ids:
         id_loud = args.special_trigger_ids[ifo]
 
-    data = HFile(args.single_trigger_files[ifo], 'r')[ifo]
+    data = HFile(args.single_trigger_files[ifo], 'r')
 
     # Identify trigger indices within window
     select_func = lambda times: ((times < (t + args.window)) & 
                                  (times > (t - args.window)))
-    _, idx = data.select(select_func, 'end_time', return_indices=True)
+    _, idx = data.select(select_func, ifo+'/end_time', return_indices=True)
+    data = data[ifo]
                                  
     # center times on the trigger/chosen time
     times = data['end_time'][idx] - t

--- a/bin/minifollowups/pycbc_plot_trigger_timeseries
+++ b/bin/minifollowups/pycbc_plot_trigger_timeseries
@@ -85,8 +85,8 @@ for ifo in args.single_trigger_files.keys():
         # Get the newnsr of the loudest trigger so we can plot a star there
         if args.special_trigger_ids:
             rchisq = data[ifo]['chisq'][id_loud] / \
-                (data['chisq_dof'][id_loud] * 2 - 2)
-            top = ranking.newsnr(data['snr'][id_loud], rchisq)
+                (data[ifo]['chisq_dof'][id_loud] * 2 - 2)
+            top = ranking.newsnr(data[ifo]['snr'][id_loud], rchisq)
 
     if type(val) in [numpy.float32, numpy.float64] or len(val) > 0:
         any_data = True

--- a/bin/minifollowups/pycbc_plot_trigger_timeseries
+++ b/bin/minifollowups/pycbc_plot_trigger_timeseries
@@ -63,6 +63,7 @@ for ifo in args.single_trigger_files.keys():
     select_func = lambda times: ((times < (t + args.window)) & 
                                  (times > (t - args.window)))
     _, idx = data.select(select_func, ifo+'/end_time', return_indices=True)
+    idx = list(idx)
     data = data[ifo]
                                  
     # center times on the trigger/chosen time

--- a/bin/minifollowups/pycbc_plot_trigger_timeseries
+++ b/bin/minifollowups/pycbc_plot_trigger_timeseries
@@ -57,11 +57,25 @@ for ifo in args.single_trigger_files.keys():
         id_loud = args.special_trigger_ids[ifo]
 
     data = h5py.File(args.single_trigger_files[ifo], 'r')[ifo]
-    times = data['end_time'][:]
-    idx = numpy.logical_and(times < t + args.window, times > t - args.window)
+    data_len = len(data['end_time'])
+    data_start = 0
+    idx_arr = []
+    while data_start < data_len:
+        # Hardcode dataread size of 10 million
+        read_size = 10000000
+        curr_read_end = min(data_len, data_start+read_size)
+        times = data['end_time'][data_start:curr_read_end]
+        #idx_arr.append(numpy.logical_and(times < (t + args.window),
+        #                                 times > (t - args.window)))
+        lgc = numpy.logical_and(times < (t + args.window),
+                                         times > (t - args.window))
+        idxes = numpy.where(lgc)[0] + data_start
+        idx_arr.append(idxes)
+        data_start += read_size
+    idx = list(numpy.concatenate(idx_arr))
 
     # center times on the trigger/chosen time
-    times = times[idx] - t
+    times = data['end_time'][idx] - t
 
     if args.plot_type == 'snr':
         val = data['snr'][idx]

--- a/bin/minifollowups/pycbc_plot_trigger_timeseries
+++ b/bin/minifollowups/pycbc_plot_trigger_timeseries
@@ -62,30 +62,30 @@ for ifo in args.single_trigger_files.keys():
     # Identify trigger indices within window
     select_func = lambda times: ((times < (t + args.window)) & 
                                  (times > (t - args.window)))
-    _, idx = data.select(select_func, ifo+'/end_time', return_indices=True)
-    idx = list(idx)
-    data = data[ifo]
+    times, snr, chisq, chisq_dof = data.select(select_func, ifo + '/end_time',
+                                               ifo + '/snr', ifo + '/chisq',
+                                               ifo + '/chisq_dof')
                                  
     # center times on the trigger/chosen time
-    times = data['end_time'][idx] - t
+    times = times - t
 
     if args.plot_type == 'snr':
-        val = data['snr'][idx]
+        val = snr
 
         if args.special_trigger_ids:
-            top = data['snr'][id_loud]
+            top = data[ifo]['snr'][id_loud]
 
     if args.plot_type == 'newsnr':
-        rchisq = data['chisq'][idx] / (2 * data['chisq_dof'][idx] - 2)
+        rchisq = chisq / (2 * chisq_dof - 2)
         if len(rchisq) > 0:
-            val = ranking.newsnr(data['snr'][idx], rchisq)
+            val = ranking.newsnr(snr, rchisq)
         else:
             val = numpy.array([])
-        del rchisq
 
         # Get the newnsr of the loudest trigger so we can plot a star there
         if args.special_trigger_ids:
-            rchisq = data['chisq'][id_loud] / (data['chisq_dof'][id_loud] * 2 - 2)
+            rchisq = data[ifo]['chisq'][id_loud] / \
+                (data['chisq_dof'][id_loud] * 2 - 2)
             top = ranking.newsnr(data['snr'][id_loud], rchisq)
 
     if type(val) in [numpy.float32, numpy.float64] or len(val) > 0:

--- a/bin/minifollowups/pycbc_plot_trigger_timeseries
+++ b/bin/minifollowups/pycbc_plot_trigger_timeseries
@@ -60,8 +60,8 @@ for ifo in args.single_trigger_files.keys():
     data = HFile(args.single_trigger_files[ifo], 'r')
 
     # Identify trigger indices within window
-    select_func = lambda inputs: ((inputs[0] < (t + args.window)) & 
-                                  (inputs[0] > (t - args.window)))
+    select_func = lambda *inputs: ((inputs[0] < (t + args.window)) & 
+                                   (inputs[0] > (t - args.window)))
     times, snr, chisq, chisq_dof = data.select(select_func, ifo + '/end_time',
                                                ifo + '/snr', ifo + '/chisq',
                                                ifo + '/chisq_dof')

--- a/bin/minifollowups/pycbc_plot_trigger_timeseries
+++ b/bin/minifollowups/pycbc_plot_trigger_timeseries
@@ -15,9 +15,10 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 """ Plot the single detector trigger timeseries """
-import h5py, argparse, logging, pycbc.version, pycbc.results, sys
+import argparse, logging, pycbc.version, pycbc.results, sys
 from pycbc.types import MultiDetOptionAction
 from pycbc.events import ranking
+from pycbc.io import HFile
 import matplotlib; matplotlib.use('Agg'); import pylab
 import numpy
 
@@ -56,24 +57,13 @@ for ifo in args.single_trigger_files.keys():
     if args.special_trigger_ids:
         id_loud = args.special_trigger_ids[ifo]
 
-    data = h5py.File(args.single_trigger_files[ifo], 'r')[ifo]
-    data_len = len(data['end_time'])
-    data_start = 0
-    idx_arr = []
-    while data_start < data_len:
-        # Hardcode dataread size of 10 million
-        read_size = 10000000
-        curr_read_end = min(data_len, data_start+read_size)
-        times = data['end_time'][data_start:curr_read_end]
-        #idx_arr.append(numpy.logical_and(times < (t + args.window),
-        #                                 times > (t - args.window)))
-        lgc = numpy.logical_and(times < (t + args.window),
-                                         times > (t - args.window))
-        idxes = numpy.where(lgc)[0] + data_start
-        idx_arr.append(idxes)
-        data_start += read_size
-    idx = list(numpy.concatenate(idx_arr))
+    data = HFile(args.single_trigger_files[ifo], 'r')[ifo]
 
+    # Identify trigger indices within window
+    select_func = lambda times: ((times < (t + args.window)) & 
+                                 (times > (t - args.window)))
+    _, idx = data.select(select_func, 'end_time', return_indices=True)
+                                 
     # center times on the trigger/chosen time
     times = data['end_time'][idx] - t
 

--- a/bin/minifollowups/pycbc_plot_trigger_timeseries
+++ b/bin/minifollowups/pycbc_plot_trigger_timeseries
@@ -60,8 +60,8 @@ for ifo in args.single_trigger_files.keys():
     data = HFile(args.single_trigger_files[ifo], 'r')
 
     # Identify trigger indices within window
-    select_func = lambda times: ((times < (t + args.window)) & 
-                                 (times > (t - args.window)))
+    select_func = lambda inputs: ((inputs[0] < (t + args.window)) & 
+                                  (inputs[0] > (t - args.window)))
     times, snr, chisq, chisq_dof = data.select(select_func, ifo + '/end_time',
                                                ifo + '/snr', ifo + '/chisq',
                                                ifo + '/chisq_dof')

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -1313,6 +1313,10 @@ class ExpFitSGPSDFgBgNormBBHStatistic(ExpFitSGFgBgNormNewStatistic):
         from pycbc.conversions import mchirp_from_mass1_mass2
         self.curr_mchirp = mchirp_from_mass1_mass2(trigs.param['mass1'],
                                                    trigs.param['mass2'])
+
+        if self.curr_mchirp > 75.:
+            self.curr_mchirp = 0.01
+
         if self.mcm is not None:
             # Careful - input might be a str, so cast to float
             self.curr_mchirp = min(self.curr_mchirp, float(self.mcm))

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -1314,9 +1314,6 @@ class ExpFitSGPSDFgBgNormBBHStatistic(ExpFitSGFgBgNormNewStatistic):
         self.curr_mchirp = mchirp_from_mass1_mass2(trigs.param['mass1'],
                                                    trigs.param['mass2'])
 
-        if self.curr_mchirp > 75.:
-            self.curr_mchirp = 0.01
-
         if self.mcm is not None:
             # Careful - input might be a str, so cast to float
             self.curr_mchirp = min(self.curr_mchirp, float(self.mcm))

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -1313,7 +1313,6 @@ class ExpFitSGPSDFgBgNormBBHStatistic(ExpFitSGFgBgNormNewStatistic):
         from pycbc.conversions import mchirp_from_mass1_mass2
         self.curr_mchirp = mchirp_from_mass1_mass2(trigs.param['mass1'],
                                                    trigs.param['mass2'])
-
         if self.mcm is not None:
             # Careful - input might be a str, so cast to float
             self.curr_mchirp = min(self.curr_mchirp, float(self.mcm))


### PR DESCRIPTION
I've seen some problems recently with the aforementioned code using lots of memory if using a large HDF_TRIGGER_MERGE file. As the code only plots a small number of triggers it doesn't really have to use much memory at all. Here we reduce memory usage by only reading chunks of the input file at one time. It does slow the code down a little bit, but run time is not really a concern in this executable.