### PR TITLE
redo indexing in 'add into' method

### DIFF
--- a/pycbc/types/timeseries.py
+++ b/pycbc/types/timeseries.py
@@ -837,8 +837,8 @@ class TimeSeries(Array):
         fft(tmp, f)
         return f
 
-    def insert(self, other):
-        """Return copy of self with other inserted into it.
+    def inject(self, other):
+        """Return copy of self with other injected into it.
 
         The other vector will be resized and time shifted with sub-sample
         precision before adding. This assumes that one can assume zeros
@@ -888,7 +888,8 @@ class TimeSeries(Array):
         ts = self.copy()
         ts[left:right] += other[oleft:oright]
         return ts
-    add_into = insert # maintain backwards compatibility for now
+
+    add_into = inject  # maintain backwards compatibility for now
 
     @_nocomplex
     def cyclic_time_shift(self, dt):

--- a/pycbc/types/timeseries.py
+++ b/pycbc/types/timeseries.py
@@ -837,7 +837,7 @@ class TimeSeries(Array):
         fft(tmp, f)
         return f
 
-    def add_into(self, other):
+    def insert(self, other):
         """Return copy of self with other inserted into it.
 
         The other vector will be resized and time shifted with sub-sample
@@ -888,6 +888,7 @@ class TimeSeries(Array):
         ts = self.copy()
         ts[left:right] += other[oleft:oright]
         return ts
+    add_into = insert # maintain backwards compatibility for now
 
     @_nocomplex
     def cyclic_time_shift(self, dt):

--- a/pycbc/types/timeseries.py
+++ b/pycbc/types/timeseries.py
@@ -869,7 +869,7 @@ class TimeSeries(Array):
         # get indices of other with respect to self
         # this is already an integer to floating point precission
         left = float(other.start_time - self.start_time) * self.sample_rate
-        left = int(round(left))  
+        left = int(round(left))
         right = left + len(other)
 
         oleft = 0
@@ -877,7 +877,7 @@ class TimeSeries(Array):
 
         # other overhangs on left so truncate
         if left < 0:
-            oleft = -left 
+            oleft = -left
             left = 0
 
         # other overhangs on right so truncate

--- a/pycbc/types/timeseries.py
+++ b/pycbc/types/timeseries.py
@@ -838,7 +838,7 @@ class TimeSeries(Array):
         return f
 
     def add_into(self, other):
-        """Add another time series into this one where they overlap.
+        """Return the sum of selfand other where other overlaps with self
 
         The other vector will be resized and time shifted with sub-sample
         precision before adding. This assumes that one can assume zeros

--- a/pycbc/types/timeseries.py
+++ b/pycbc/types/timeseries.py
@@ -838,7 +838,7 @@ class TimeSeries(Array):
         return f
 
     def add_into(self, other):
-        """Return the sum of selfand other where other overlaps with self
+        """Return copy of self with other inserted into it.
 
         The other vector will be resized and time shifted with sub-sample
         precision before adding. This assumes that one can assume zeros

--- a/test/test_timeseries.py
+++ b/test/test_timeseries.py
@@ -476,6 +476,25 @@ class TestTimeSeriesBase(array_base,unittest.TestCase):
             self.assertAlmostEqual(self.b.duration, 0.3)
             self.assertAlmostEqual(self.bad3.duration, 0.6)
 
+    def test_inject(self):
+        a = TimeSeries(numpy.zeros(2**20, dtype=numpy.float32),
+                                   delta_t=1.0)
+        a[2**19] = 1
+
+        # Check that the obvious case reduces to an add operation
+        r = a.inject(a)
+        self.assertAlmostEqual(r.max(), 2.0, places=7)
+
+        # Check adding an offset vector
+        b = a.cyclic_time_shift(-0.21)
+        r = a.inject(b)
+        self.assertAlmostEqual(r.max(), 2.0, places=5)
+
+        # check adding shoter offset vector
+        c = a.time_slice(2**19-5000, 2**19+5000).cyclic_time_shift(32.12)
+        r = a.inject(c)
+        self.assertAlmostEqual(r.max(), 2.0, places=4)
+
     def test_sample_times(self):
         with self.context:
             # Moving these to the current scheme


### PR DESCRIPTION
@lpsinger Pointed out the current indexing will produce off by one errors. This patch redoes the indexing to avoid the time_slice method. 