### PR TITLE
Fix warning when generating fake noise

### DIFF
--- a/pycbc/psd/analytical.py
+++ b/pycbc/psd/analytical.py
@@ -99,8 +99,8 @@ def from_string(psd_name, length, delta_f, low_freq_cutoff):
                          'PSD functions.')
 
     # make sure length has the right type for CreateREAL8FrequencySeries
-    if not isinstance(length, numbers.Integral):
-        warnings.warn('forcing length argument to int', RuntimeWarning)
+    if not isinstance(length, numbers.Integral) or length <= 0:
+        raise TypeError('length must be a positive integer')
     length = int(length)
 
     # if PSD model is in LALSimulation

--- a/pycbc/psd/estimate.py
+++ b/pycbc/psd/estimate.py
@@ -50,7 +50,7 @@ def median_bias(n):
     if n >= 1000:
         return numpy.log(2)
     ans = 1
-    for i in range(1, int((n - 1) / 2 + 1)):
+    for i in range(1, (n - 1) // 2 + 1):
         ans += 1.0 / (2*i + 1) - 1.0 / (2*i)
     return ans
 

--- a/pycbc/strain/strain.py
+++ b/pycbc/strain/strain.py
@@ -353,7 +353,7 @@ def from_cli(opt, dyn_range_fac=1, precision='single',
                              'generate a fake strain')
         duration = opt.gps_end_time - opt.gps_start_time
         pdf = 1. / 128
-        plen = int(opt.sample_rate / pdf) / 2 + 1
+        plen = int(opt.sample_rate / pdf) // 2 + 1
 
         if opt.fake_strain_from_file:
             logging.info("Reading ASD from file")


### PR DESCRIPTION
The strain module calls `psd.analytical.from_string()` with a float `length` in Python 3, which raises a warning. This patch fixes it and turns the warning into an error, consistently with other PSD modules. Another harmless case of non-floor division in the PSD module is fixed.