### PR TITLE
Fix broken pycbc_page_foreground

### DIFF
--- a/pycbc/io/hdf.py
+++ b/pycbc/io/hdf.py
@@ -757,7 +757,7 @@ class ForegroundTriggers(object):
                         curr.append(hdf_dataset[idx])
                     curr = np.array(curr)
                 else:
-                    curr = self.sngl_files[ifo].get_column(variable)
+                    curr = self.sngl_files[ifo].get_column(variable)[tid]
             except IndexError:
                 if len(self.trig_id[ifo]) == 0:
                     curr = np.array([])


### PR DESCRIPTION
It looks like I missed a bit when preparing this patch. I thought it was weird when @GarethDaviesGW asked me about something that I had remembered doing.

The patch on master was also missing the following, without which it breaks when processing > 1000 triggers. This just reproduces the previous behaviour, and is tested.