### PR TITLE
Add standard newsnr fitting below fit threshold

### DIFF
--- a/bin/hdfcoinc/pycbc_fit_sngls_split_binned
+++ b/bin/hdfcoinc/pycbc_fit_sngls_split_binned
@@ -97,11 +97,7 @@ parser.add_argument("--prune-window", type=float, default=0.1,
                          "which is loudest in each split, default 0.1s")
 args = parser.parse_args()
 
-if args.verbose:
-    log_level = logging.DEBUG
-else:
-    log_level = logging.WARN
-logging.basicConfig(format='%(asctime)s : %(message)s', level=log_level)
+pycbc.init_logging(args.verbose)
 
 logging.info('Opening trigger file: %s' % args.trigger_file)
 trigf = h5py.File(args.trigger_file, 'r')
@@ -218,17 +214,18 @@ for idx, idx_start in enumerate(boundaries):
 logging.info('calculating single stat values from trigger file')
 stat = get_stat(args.sngl_stat, trigf[args.ifo])
 
-logging.info('applying DQ vetoes')
-time = trigf[args.ifo + '/end_time'][:]
-remove, junk = events.veto.indices_within_segments(time, [args.veto_file],
-                     ifo=args.ifo, segment_name=args.veto_segment_name)
-# Set stat to zero for triggers being vetoed: given that the fit threshold is
-# >0 these will not be fitted or plotted.  Avoids complications from changing
-# the number of triggers, ie changes of template boundary.
-stat[remove] = np.zeros_like(remove)
-time[remove] = np.zeros_like(remove)
-logging.info('{} out of {} trigs removed after vetoing with {} from {}'.format(
-                  remove.size, stat.size, args.veto_segment_name, args.veto_file))
+if args.veto_file:
+    logging.info('applying DQ vetoes')
+    time = trigf[args.ifo + '/end_time'][:]
+    remove, junk = events.veto.indices_within_segments(time, [args.veto_file],
+                         ifo=args.ifo, segment_name=args.veto_segment_name)
+    # Set stat to zero for triggers being vetoed: given that the fit threshold is
+    # >0 these will not be fitted or plotted.  Avoids complications from changing
+    # the number of triggers, ie changes of template boundary.
+    stat[remove] = np.zeros_like(remove)
+    time[remove] = np.zeros_like(remove)
+    logging.info('{} out of {} trigs removed after vetoing with {} from {}'.format(
+                      remove.size, stat.size, args.veto_segment_name, args.veto_file))
 
 for x in range(args.split_one_nbins):
     if not args.prune_number:

--- a/bin/hdfcoinc/pycbc_fit_sngls_split_binned
+++ b/bin/hdfcoinc/pycbc_fit_sngls_split_binned
@@ -279,7 +279,7 @@ trigf.close()
 
 logging.info('setting up plotting and fitting limit values')
 minplot = max(stat[np.nonzero(stat)].min(), args.stat_fit_threshold - 1)
-min_fit = minplot#max(minplot, args.stat_fit_threshold)
+min_fit = max(minplot, args.stat_fit_threshold)
 max_fit = 1.05 * stat.max()
 if args.plot_max_x:
     maxplot = args.plot_max_x
@@ -345,17 +345,9 @@ for x in range(args.split_one_nbins):
                              len(vals_above_thresh), len(vals_inbin)))
             alpha, sig_alpha = trstats.fit_above_thresh(args.fit_function,
                                  vals_above_thresh, args.stat_fit_threshold)
-#            fitted_cum_counts = len(vals_above_thresh) * \
-#                                trstats.cum_fit(args.fit_function, fitrange,
-#                                                alpha, args.stat_fit_threshold)
-            lognoisel = - alpha * (fitrange - args.stat_fit_threshold) + \
-                            np.log(len(vals_above_thresh))
-            fitted_cum_counts = np.exp(lognoisel)
-            bt = fitrange < args.stat_fit_threshold
-            lognoisel = - 6.0 * (fitrange[bt] - args.stat_fit_threshold) + \
-                            np.log(len(vals_above_thresh))
-            fitted_cum_counts[bt] = np.exp(lognoisel)
- 
+            fitted_cum_counts = len(vals_above_thresh) * \
+                                trstats.cum_fit(args.fit_function, fitrange,
+                                                alpha, args.stat_fit_threshold)
             # upper and lower 1-sigma bounds on fit are not currently plotted
             #fitted_cum_counts_plus = len(vals_above_thresh) * \
             #                             trstats.cum_fit(args.fit_function,

--- a/bin/hdfcoinc/pycbc_fit_sngls_split_binned
+++ b/bin/hdfcoinc/pycbc_fit_sngls_split_binned
@@ -279,7 +279,7 @@ trigf.close()
 
 logging.info('setting up plotting and fitting limit values')
 minplot = max(stat[np.nonzero(stat)].min(), args.stat_fit_threshold - 1)
-min_fit = max(minplot, args.stat_fit_threshold)
+min_fit = minplot#max(minplot, args.stat_fit_threshold)
 max_fit = 1.05 * stat.max()
 if args.plot_max_x:
     maxplot = args.plot_max_x
@@ -290,7 +290,7 @@ fitrange = np.linspace(min_fit, max_fit, 100)
 logging.info('setting up plotting variables')
 histcolors = ['r',(1.0,0.6,0),'y','g','c','b','m','k',(0.8,0.25,0),(0.25,0.8,0)]
 fig, axes = plt.subplots(args.split_one_nbins, args.split_two_nbins,
-                         sharex=True, sharey=True,
+                         sharex=True, sharey=True, squeeze=False,
                          figsize=(3 * (args.split_two_nbins + 1),
                                   3 * args.split_one_nbins))
 
@@ -345,9 +345,17 @@ for x in range(args.split_one_nbins):
                              len(vals_above_thresh), len(vals_inbin)))
             alpha, sig_alpha = trstats.fit_above_thresh(args.fit_function,
                                  vals_above_thresh, args.stat_fit_threshold)
-            fitted_cum_counts = len(vals_above_thresh) * \
-                                trstats.cum_fit(args.fit_function, fitrange,
-                                                alpha, args.stat_fit_threshold)
+#            fitted_cum_counts = len(vals_above_thresh) * \
+#                                trstats.cum_fit(args.fit_function, fitrange,
+#                                                alpha, args.stat_fit_threshold)
+            lognoisel = - alpha * (fitrange - args.stat_fit_threshold) + \
+                            np.log(len(vals_above_thresh))
+            fitted_cum_counts = np.exp(lognoisel)
+            bt = fitrange < args.stat_fit_threshold
+            lognoisel = - 6.0 * (fitrange[bt] - args.stat_fit_threshold) + \
+                            np.log(len(vals_above_thresh))
+            fitted_cum_counts[bt] = np.exp(lognoisel)
+ 
             # upper and lower 1-sigma bounds on fit are not currently plotted
             #fitted_cum_counts_plus = len(vals_above_thresh) * \
             #                             trstats.cum_fit(args.fit_function,
@@ -382,14 +390,19 @@ axes[0,0].set_ylim(1, 5 * maxyval)
 axes[0,0].set_xlim(minplot, maxplot)
 
 for j in range(args.split_two_nbins):
+    axes[args.split_one_nbins - 1, j].set_xlabel(args.sngl_stat, size="large")
+    if args.split_two_nbins == 1:
+        break
     axes[0, j].set_xlabel(args.split_param_two + ': ' +
                           (formats[args.split_param_two] + ' to ' +
                            formats[args.split_param_two]).format(sp_two_bounds.lower()[j],
                                      sp_two_bounds.upper()[j]), size="large")
     axes[0, j].xaxis.set_label_position("top")
-    axes[args.split_one_nbins - 1, j].set_xlabel(args.sngl_stat, size="large")
 
 for i in range(args.split_one_nbins):
+    if args.split_one_nbins == 1:
+        axes[0, 0].set_ylabel('cumulative number', size='large')
+        break
     axes[i, 0].set_ylabel(args.split_param_one + ': ' +
                           (formats[args.split_param_one] + ' to ' +
                            formats[args.split_param_one]).format(sp_one_bounds.lower()[i],

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -1213,20 +1213,14 @@ class ExpFitSGFgBgNormNewStatistic(PhaseTDNewStatistic,
         Read in single trigger information, make the newsnr statistic
         and rescale by the fitted coefficients alpha and rate
         """
-        alphai, ratei, thresh = self.find_fits(trigs)
+        lognoisel = ExpFitStatistic.lognoiserate(trigs)
+        _, ratei, thresh = self.find_fits(trigs)
         newsnr = self.get_newsnr(trigs)
-        # alphai is constant of proportionality between single-ifo newsnr and
-        #   negative log noise likelihood in given template
-        # ratei is rate of trigs in given template compared to average
-        # thresh is stat threshold used in given ifo
-        lognoisel = - alphai * (newsnr - thresh) + numpy.log(alphai) + \
-                      numpy.log(ratei)
         # When newsnr is below threshold, we want to set the log noise rate
         # to be a fit to a newsnr ** -6 distribution
         bt = newsnr < thresh
-        alphasix = 6.0 + numpy.zeros_like(bt)
-        lognoisel[bt] = - alphasix * (newsnr[bt] - thresh) + \
-                          numpy.log(alphasix) + numpy.log(ratei[bt])
+        lognoisel[bt] = - 6.0 * (newsnr[bt] - thresh) + \
+                          numpy.log(6.0) + numpy.log(ratei[bt])
         return numpy.array(lognoisel, ndmin=1, dtype=numpy.float32)
 
     def single(self, trigs):

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -1215,7 +1215,7 @@ class ExpFitSGFgBgNormNewStatistic(PhaseTDNewStatistic,
         """
         alphai, ratei, thresh = self.find_fits(trigs)
         newsnr = self.get_newsnr(trigs)
-        bt = newsnr > thresh
+        bt = newsnr < thresh
         lognoisel = - alphai * (newsnr - thresh) + numpy.log(alphai) + \
                         numpy.log(ratei)
         lognoiselbt = - alphabelow * (newsnr - thresh) + \

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -1215,13 +1215,13 @@ class ExpFitSGFgBgNormNewStatistic(PhaseTDNewStatistic,
         """
         alphai, ratei, thresh = self.find_fits(trigs)
         newsnr = self.get_newsnr(trigs)
+        # Above the threshold we use the usual fit coefficient (alpha)
+        # below threshold use specified alphabelow
         bt = newsnr < thresh
         lognoisel = - alphai * (newsnr - thresh) + numpy.log(alphai) + \
                         numpy.log(ratei)
         lognoiselbt = - alphabelow * (newsnr - thresh) + \
                            numpy.log(alphabelow) + numpy.log(ratei)
-        # Above the threshold we use the usual alpha
-        # below threshold use specified alphabelow
         lognoisel[bt] = lognoiselbt[bt]
         return numpy.array(lognoisel, ndmin=1, dtype=numpy.float32)
 

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -1207,7 +1207,7 @@ class ExpFitSGFgBgNormNewStatistic(PhaseTDNewStatistic,
         self.fits_by_tid[ifo]['median_sigma'] = \
             coeff_file['median_sigma'][:][tid_sort]
 
-    def lognoiserate(self, trigs):
+    def lognoiserate(self, trigs, alphabelow=6):
         """Calculate the log noise rate density over single-ifo newsnr
 
         Read in single trigger information, make the newsnr statistic
@@ -1215,14 +1215,14 @@ class ExpFitSGFgBgNormNewStatistic(PhaseTDNewStatistic,
         """
         alphai, ratei, thresh = self.find_fits(trigs)
         newsnr = self.get_newsnr(trigs)
-        # When newsnr is below threshold, we want to set the log noise rate
-        # to be a fit to a newsnr ** -6 distribution
         bt = newsnr > thresh
-        normvalue = numpy.log(alphai) + numpy.log(ratei)
-        lognoisel = - alphai * (newsnr - thresh) + normvalue
-        lognoiselsix = - 6.0 * (newsnr - thresh) + normvalue
-        # Above the threshold we use the usual alpha - below use six
-        lognoisel[bt] = lognoiselsix[bt]
+        lognoisel = - alphai * (newsnr - thresh) + numpy.log(alphai) + \
+                        numpy.log(ratei)
+        lognoiselbt = - alphabelow * (newsnr - thresh) + \
+                           numpy.log(alphabelow) + numpy.log(ratei)
+        # Above the threshold we use the usual alpha
+        # below threshold use specified alphabelow
+        lognoisel[bt] = lognoiselbt[bt]
         return numpy.array(lognoisel, ndmin=1, dtype=numpy.float32)
 
     def single(self, trigs):

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -1213,14 +1213,16 @@ class ExpFitSGFgBgNormNewStatistic(PhaseTDNewStatistic,
         Read in single trigger information, make the newsnr statistic
         and rescale by the fitted coefficients alpha and rate
         """
-        lognoisel = ExpFitStatistic.lognoiserate(trigs)
-        _, ratei, thresh = self.find_fits(trigs)
+        alphai, ratei, thresh = self.find_fits(trigs)
         newsnr = self.get_newsnr(trigs)
         # When newsnr is below threshold, we want to set the log noise rate
         # to be a fit to a newsnr ** -6 distribution
-        bt = newsnr < thresh
-        lognoisel[bt] = - 6.0 * (newsnr[bt] - thresh) + \
-                          numpy.log(6.0) + numpy.log(ratei[bt])
+        at = newsnr < thresh
+        normvalue = numpy.log(alphai) + numpy.log(ratei)
+        lognoisel = - 6.0 * (newsnr - thresh) + normvalue
+        #Above the threhsold we use the usual alpha
+        lognoisel[at] = - alphai[at] * (newsnr[at] - thresh) + normvalue[at]
+
         return numpy.array(lognoisel, ndmin=1, dtype=numpy.float32)
 
     def single(self, trigs):

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -1217,12 +1217,12 @@ class ExpFitSGFgBgNormNewStatistic(PhaseTDNewStatistic,
         newsnr = self.get_newsnr(trigs)
         # When newsnr is below threshold, we want to set the log noise rate
         # to be a fit to a newsnr ** -6 distribution
-        at = newsnr < thresh
+        bt = newsnr > thresh
         normvalue = numpy.log(alphai) + numpy.log(ratei)
-        lognoisel = - 6.0 * (newsnr - thresh) + normvalue
-        #Above the threhsold we use the usual alpha
-        lognoisel[at] = - alphai[at] * (newsnr[at] - thresh) + normvalue[at]
-
+        lognoisel = - alphai * (newsnr - thresh) + normvalue
+        lognoiselsix = - 6.0 * (newsnr - thresh) + normvalue
+        # Above the threshold we use the usual alpha - below use six
+        lognoisel[bt] = lognoiselsix[bt]
         return numpy.array(lognoisel, ndmin=1, dtype=numpy.float32)
 
     def single(self, trigs):


### PR DESCRIPTION
Change the single-ifo fit distribution to use a exp(-6 (newsnr - thresh)) below threshold

This is particularly an issue with high mass templates which are susceptible to glitches --> shallower distribution --> over-ranking these events

I've snuck in some useful but unimportant changes in fit_sngls_split_binned which were wanted before but flagged up when testing this