### PR TITLE
Use floor division where integers are expected

### DIFF
--- a/bin/plotting/pycbc_plot_waveform
+++ b/bin/plotting/pycbc_plot_waveform
@@ -92,7 +92,7 @@ opt = parser.parse_args()
 delta_f = 1. / opt.waveform_length
 delta_t = 1. / opt.sample_rate
 tlen = int(opt.waveform_length * opt.sample_rate)
-flen = tlen / 2 + 1
+flen = tlen // 2 + 1
 
 tmp_params = io.WaveformArray.from_kwargs(
                     mass1=opt.mass1,

--- a/bin/pycbc_banksim
+++ b/bin/pycbc_banksim
@@ -73,7 +73,7 @@ def make_padded_frequency_series(vec, filter_N=None, delta_f=None):
         N = 2 ** power
     else:
         N = filter_N
-    n = N / 2 + 1
+    n = N // 2 + 1
 
     if isinstance(vec, FrequencySeries):
         vectilde = FrequencySeries(zeros(n, dtype=complex_same_precision_as(vec)),

--- a/examples/overlap.py
+++ b/examples/overlap.py
@@ -11,7 +11,7 @@ sample_rate = 4096
 
 # Length of corresponding time series and frequency series
 tlen = sample_rate * time_buffer
-flen = tlen / 2 + 1
+flen = tlen // 2 + 1
 
 delta_t = 1.0 / sample_rate
 delta_f = 1.0 / time_buffer

--- a/pycbc/filter/matchedfilter.py
+++ b/pycbc/filter/matchedfilter.py
@@ -1003,7 +1003,7 @@ def make_frequency_series(vec):
         return vec
     if isinstance(vec, TimeSeries):
         N = len(vec)
-        n = N/2+1
+        n = N // 2 + 1
         delta_f = 1.0 / N / vec.delta_t
         vectilde =  FrequencySeries(zeros(n, dtype=complex_same_precision_as(vec)),
                                     delta_f=delta_f, copy=False)

--- a/pycbc/filter/resample.py
+++ b/pycbc/filter/resample.py
@@ -60,7 +60,7 @@ def lfilter(coefficients, timeseries):
         cseries.roll(len(timeseries) - len(coefficients) + 1)
         timeseries = Array(timeseries, copy=False)
 
-        flen = len(cseries) / 2 + 1
+        flen = len(cseries) // 2 + 1
         ftype = complex_same_precision_as(timeseries)
 
         cfreq = zeros(flen, dtype=ftype)

--- a/pycbc/noise/reproduceable.py
+++ b/pycbc/noise/reproduceable.py
@@ -106,7 +106,7 @@ def colored_noise(psd, start_time, end_time, seed=0, low_frequency_cutoff=1.0):
     """
     psd = psd.copy()
 
-    flen = int(SAMPLE_RATE / psd.delta_f) / 2 + 1
+    flen = int(SAMPLE_RATE / psd.delta_f) // 2 + 1
     oldlen = len(psd)
     psd.resize(flen)
 
@@ -187,7 +187,7 @@ def noise_from_string(psd_name, start_time, end_time, seed=0, low_frequency_cuto
         A TimeSeries containing gaussian noise colored by the given psd.
     """
     delta_f = 1.0 / FILTER_LENGTH
-    flen = int(SAMPLE_RATE / delta_f) / 2 + 1
+    flen = int(SAMPLE_RATE / delta_f) // 2 + 1
     psd = pycbc.psd.from_string(psd_name, flen, delta_f, low_frequency_cutoff)
     return colored_noise(psd, start_time, end_time,
                          seed=seed,

--- a/pycbc/strain/strain.py
+++ b/pycbc/strain/strain.py
@@ -1511,7 +1511,7 @@ class StrainBuffer(pycbc.frame.DataBuffer):
                 gate_params = [(overwhite2.start_time, 0., taper_window),
                                (overwhite2.end_time, 0., taper_window)]
                 gate_data(overwhite2, gate_params)
-                fseries_trimmed = FrequencySeries(zeros(len(overwhite2) / 2 + 1,
+                fseries_trimmed = FrequencySeries(zeros(len(overwhite2) // 2 + 1,
                                                   dtype=fseries.dtype), delta_f=delta_f)
                 pycbc.fft.fft(overwhite2, fseries_trimmed)
                 fseries_trimmed.start_time = fseries.start_time + self.reduced_pad * self.strain.delta_t

--- a/test/test_matchedfilter.py
+++ b/test/test_matchedfilter.py
@@ -133,7 +133,7 @@ class TestMatchedFilter(unittest.TestCase):
 
             #Check that an incompatible psd produces an error
             self.assertRaises(TypeError,match,self.filt,self.filt,psd=self.filt)
-            psd = FrequencySeries(zeros(len(self.filt)/2+1),delta_f=100000)
+            psd = FrequencySeries(zeros(len(self.filt) // 2 + 1), delta_f=100000)
             self.assertRaises(ValueError,match,self.filt,self.filt,psd=psd)
 
             #Check that only TimeSeries or FrequencySeries are accepted


### PR DESCRIPTION
As expected, #3277 revealed some cases of floats being used as integers. @SumeetKul found such a case in the `noise` module, which this patch should fix.

I took the chance to have a wider look at the repository and fix a few other cases where I suspect floor division should be used.