### PR TITLE
MultiIFO workflow singles development

### DIFF
--- a/bin/hdfcoinc/pycbc_multiifo_sngls_findtrigs
+++ b/bin/hdfcoinc/pycbc_multiifo_sngls_findtrigs
@@ -1,20 +1,25 @@
 #!/usr/bin/env python
-import h5py, argparse, logging, numpy, numpy.random
+import argparse, logging, numpy as np
 from ligo.segments import infinity
 from pycbc.events import veto, coinc, stat
 import pycbc.conversions as conv
 import pycbc.version
-from numpy.random import seed, shuffle
-from pycbc.io.hdf import ReadByTemplate
+from pycbc import io
+from pycbc.events import trigger_fits as trfits
+
+ifar_model_options = ['n_louder', 'exp_fit', 'gaussian_kde']
 
 parser = argparse.ArgumentParser()
-parser.add_argument("--verbose", action="count")
-parser.add_argument("--version", action="version", version=pycbc.version.git_verbose_msg)
-parser.add_argument("--veto-files", nargs='*', action='append', default=[],
+parser.add_argument("--verbose", action='count')
+parser.add_argument("--version", action='version',
+                    version=pycbc.version.git_verbose_msg)
+parser.add_argument("--veto-file", default=None,
                     help="Optional veto file. Triggers within veto segments "
-                         "contained in the file are ignored")
-parser.add_argument("--segment-name", nargs='*', action='append', default=[],
-                    help="Optional, name of veto segment in veto file")
+                         "contained in the file are ignored. Required if "
+                         "--segment-name given.")
+parser.add_argument("--segment-name", default=None,
+                    help="Optional, name of veto segment in veto file. "
+                         "Required if --veto-file given.")
 parser.add_argument("--trigger-file",type=str,
                     help="File containing single-detector triggers")
 parser.add_argument("--template-bank", required=True,
@@ -31,58 +36,40 @@ parser.add_argument("--statistic-keywords", nargs='*',
                          "the statistic class when it is initialized. Should "
                          "be given in format --statistic-keywords "
                          "KWARG1:VALUE1 KWARG2:VALUE2 KWARG3:VALUE3 ...")
-parser.add_argument("--template-fraction-range", default="0/1",
-                    help="Optional, analyze only part of template bank. Format"
-                         " PART/NUM_PARTS")
-parser.add_argument("--randomize-template-order", action="store_true",
-                    help="Random shuffle templates with fixed seed "
-                         "before selecting range to analyze")
+parser.add_argument("--trigger-snr-cut", type=float, default=6,
+                    help="Apply a cut on snr to triggers before processing. "
+                         "Default = 6")
+parser.add_argument("--reduced-chisq-cut", type=float, default=None,
+                    help="Apply a cut on reduced chisquared to triggers "
+                         "before processing. Default = None")
+parser.add_argument("--chieff-upper-limit", type=float, default=None,
+                    help="Apply an upper limit cut on chi_eff to triggers "
+                         "before processing. Default = None")
 parser.add_argument("--cluster-window", type=float,
                     help="Optional, window size in seconds to cluster "
                          "over the bank")
+parser.add_argument("--ifar-model", default='n_louder',
+                    choices=ifar_model_options,
+                    help="Which model t use for calculating IFAR. "
+                         "Choices=" + ", ".join(ifar_model_options) + ". "
+                         "Default = n_louder.")
 parser.add_argument("--output-file",
                     help="File to store the candidate triggers")
-parser.add_argument("--batch-singles", default=5000, type=int,
-                    help="Number of single triggers to process at once")
 args = parser.parse_args()
 
+if (args.veto_file and not args.segment_name) or \
+    (args.segment_name and not args.veto_file):
+    raise RuntimeError('--veto-file and --segment-name are mutually required')
+
 args.statistic_files = sum(args.statistic_files, [])
-args.segment_name = sum(args.segment_name, [])
-args.veto_files = sum(args.veto_files, [])
 
 if args.verbose:
     logging.basicConfig(format='%(asctime)s : %(message)s', level=logging.DEBUG)
 
 
-def parse_template_range(num_templates, rangestr):
-    part = int(rangestr.split('/')[0])
-    pieces = int(rangestr.split('/')[1])
-    tmin = int(num_templates / float(pieces) * part)
-    tmax = int(num_templates / float(pieces) * (part+1))
-    return tmin, tmax
-
-logging.info('Starting...')
-
-num_templates = len(h5py.File(args.template_bank, "r")['template_hash'])
-tmin, tmax = parse_template_range(num_templates, args.template_fraction_range)
-logging.info('Analyzing template %s - %s' % (tmin, tmax-1))
-
-class Trigs(object):
-    """store trigger info in parallel with ifo name and shift vector"""
-    def __init__(self):
-        self.singles = []
-
-trigs = Trigs()
-logging.info('Opening trigger file : %s' % args.trigger_file)
-reader = ReadByTemplate(args.trigger_file,
-                        args.template_bank,
-                        args.segment_name,
-                        args.veto_files)
-ifo = reader.ifo
-trigs.singles.append(reader)
-
-fg_segs = reader.segs
-valid = veto.segments_to_start_end(reader.segs)
+logging.info('Opening trigger file: %s', args.trigger_file)
+trigf = io.HFile(args.trigger_file, 'r')
+ifo = trigf.keys()[0]
 
 # Stat class instance to calculate the ranking statistic
 extra_kwargs = {}
@@ -96,97 +83,169 @@ for inputstr in args.statistic_keywords:
                   "Received {}".format(args.statistic_keywords)
         raise ValueError(err_txt)
 
-rank_method = stat.get_statistic(args.ranking_statistic)(args.statistic_files,
-                                                         ifos=[ifo],
-                                                         **extra_kwargs)
+starts = trigf[ifo + '/search/start_time'][:]
+ends = trigf[ifo + '/search/end_time'][:]
+segments = veto.start_end_to_segments(starts, ends)
 
-if args.randomize_template_order:
-    seed(0)
-    template_ids = numpy.arange(0, num_templates)
-    shuffle(template_ids)
-    template_ids = template_ids[tmin:tmax]
+n_tot_trigs = trigf[ifo + '/snr'].size
+logging.info("%d triggers in file", n_tot_trigs)
+keep_idx = np.flatnonzero(trigf[ifo + '/snr'][:] >= args.trigger_snr_cut)
+snr_cut_f = ("%f" % args.trigger_snr_cut).rstrip("0").rstrip(".")
+logging.info("Cutting %d triggers with SNR < %s (%.2f%%)",
+             n_tot_trigs - keep_idx.size, snr_cut_f,
+             float(n_tot_trigs - keep_idx.size) / n_tot_trigs * 100)
+
+if args.reduced_chisq_cut:
+    n_skp_trigs = keep_idx.size
+    chisq = trigf[ifo + '/chisq'][:][keep_idx]
+    chisq_dof = trigf[ifo + '/chisq_dof'][:][keep_idx]
+    reduced_chisq = chisq / (2 * chisq_dof - 2)
+    chisq_keep_idx = np.flatnonzero(reduced_chisq <= args.reduced_chisq_cut)
+    chisq_cut_f = ("%f" % args.reduced_chisq_cut).rstrip("0").rstrip(".")
+    logging.info("Cutting %d triggers with \chi^2 > %.f (%.2f%%)",
+                 n_skp_trigs - chisq_keep_idx.size, chisq_cut_f,
+                 float(n_skp_trigs - chisq_keep_idx.size) / n_skp_trigs * 100)
+    # Select chisq-cut-kept idx from keep_idx
+    keep_idx = keep_idx[chisq_keep_idx]
+
+if args.veto_file:
+    logging.info("Getting vetoed indices from file %s", args.veto_file)
+    end_time = trigf[ifo + '/end_time'][:][keep_idx]
+    veto_keep_idx, _ = veto.indices_outside_segments(end_time,
+                                                [args.veto_file],
+                                                segment_name=args.segment_name,
+                                                ifo=ifo)
+    logging.info("Cutting %d triggers in vetoed segments (%.2f%%)",
+                 keep_idx.size - veto_keep_idx.size,
+                 float(keep_idx.size - veto_keep_idx.size) / keep_idx.size * 100)
+    # Select unvetoed idx from keep_idx
+    keep_idx = keep_idx[veto_keep_idx]
+    veto_segs = veto.select_segments_by_definer(args.veto_file, ifo=ifo,
+                                                segment_name=args.segment_name)
+    fg_segs = segments - veto_segs
 else:
-    template_ids = range(tmin, tmax)
+    fg_segs = segments
 
-# 'data' will store candidate triggers
-# in addition to these lists of info, will also store trigger times and
-# ids in ifo-specific datasets
-data = {'stat': [], 'decimation_factor': [], 'timeslide_id': [],
-        'template_id': [], '%s/time' % ifo : [], '%s/trigger_id' % ifo: []}
+logging.info("Loading %d triggers", len(keep_idx))
 
-tid_counter = 0
-for tnum in template_ids:
-    if not tid_counter % 500:
-        logging.info('Obtaining trigs for template %i out of %i',
-                     tid_counter, len(template_ids))
-    tid_counter += 1
-    sngl = reader
-    tids_full = sngl.set_template(tnum)
-    times_full = sngl['end_time']
-    sds_full = rank_method.single(sngl)
+data_init = {}
+all_dsets = ['sigmasq', 'chisq', 'chisq_dof', 'coa_phase', 'end_time',
+             'snr', 'template_id', 'sg_chisq']
 
-    if len(tids_full) == 0:
-        logging.info('No triggers in template %i, skipping', tnum)
-        continue
+for ds in all_dsets:
+    data_init[ds] = trigf[ifo + "/" + ds][:][keep_idx]
+data_init['trigger_id'] = np.arange(trigf[ifo + '/snr'].size)
 
-    # list in ifo order of remaining trigger data
-    single_info = (ifo, sds_full)
-    data['stat'] += [rank_method.single_multiifo(single_info)]
-    # All triggers are foreground and therefore not decimated
-    data['decimation_factor'] += [numpy.repeat(1, len(sds_full))]
-    # No timeslides performed - all zeros
-    data['timeslide_id'] += [numpy.repeat(0, len(sds_full))]
-    data['template_id'] += [numpy.repeat(tnum, len(sds_full))]
-    data['%s/time' % ifo] += [times_full]
-    data['%s/trigger_id' % ifo] += [tids_full]
+logging.info("Putting data into DictArray")
+trigs = io.DictArray(data=data_init)
+trigf.close()
 
-if len(data['stat']) > 0:
-    for key in data:
-        data[key] = numpy.concatenate(data[key])
-else:
-    raise RuntimeError("No triggers in any of the templates - expand template "
-                       "range or run for longer")
-    
+if not len(trigs):
+    raise RuntimeError("All triggers removed by vetoes or snr cut")
 
-if args.cluster_window and len(data['stat']) > 0:
-    cid = coinc.cluster_over_time(data['stat'], data['%s/time' % ifo],
+logging.info('Setting up ranking method')
+rank_stat_class = stat.get_statistic(args.ranking_statistic)
+rank_method = rank_stat_class(args.statistic_files, ifos=[ifo],
+                              **extra_kwargs)
+logging.info("Single-detector initial statistic")
+sds_full = rank_method.single(trigs.data)
+logging.info("Applying changes to make statistic comparable with coincs")
+single_info = (ifo, sds_full)
+stat = rank_method.single_multiifo(single_info)
+
+logging.info("Clustering")
+if args.cluster_window:
+    cid = coinc.cluster_over_time(stat, trigs.data['end_time'],
                                   args.cluster_window)
+    trigs = trigs.select(cid)
+    stat = stat[cid]
 
-logging.info('saving clustered triggers')
-f = h5py.File(args.output_file, 'w')
-if len(data['stat']) > 0:
-    for key in data:
-        var = data[key][cid] if args.cluster_window else data[key]
-        f.create_dataset('foreground/' + key, data=var,
-                         compression='gzip',
-                         compression_opts=9,
-                         shuffle=True)
+
+fg_time = abs(fg_segs)
+
+logging.info("Assigning IFARs according to %s model", args.ifar_model)
+
+if args.ifar_model == "n_louder":
+    # This is a "count N louder and divide by live time" model as it's the
+    # most basic - it is a bit crap and doesn't give FAR below 1 per live time
+    _, fnlouder = coinc.calculate_n_louder(stat, stat, np.ones_like(stat))
+    ifar_sec = fg_time / (fnlouder + 1)
+    ifar = conv.sec_to_year(ifar_sec)
+    fap = 1 - np.exp(-fg_time / ifar_sec)
+elif args.ifar_model == "exp_fit":
+    # Basic (overly optimistic) method of IFAR calculation - fits to an
+    # exponential above a threshold. Threshold should be above the point
+    # where clustering affects the distribution - 3 seems to be about right
+    # with the current statistic & 10s window
+    stat_threshold = 3.0
+    stat_above = stat[stat > stat_threshold]
+    alpha, _ = trfits.fit_above_thresh("exponential", stat_above,
+                                       stat_threshold)
+    cum_fit = stat_above.size * trfits.cum_fit("exponential", stat, alpha,
+                                               stat_threshold)
+    # cum_fit returns zero if below threshold - change so that IFAR will be
+    # equal to the n_louder method
+    stat_below = stat[stat < stat_threshold]
+    _, fnlouder_below = coinc.calculate_n_louder(stat_below, stat_below,
+                                                 np.ones_like(stat_below))
+    cum_fit[stat < stat_threshold] = fnlouder_below + 1 + stat_above.size
+    ifar_sec = fg_time / cum_fit
+    ifar = conv.sec_to_year(ifar_sec)
+    fap = 1 - np.exp(-fg_time / ifar_sec)
+elif args.ifar_model == "gaussian_kde":
+    #This is crap - ignore it
+    from scipy.stats import gaussian_kde
+    stat_fit_threshold = 3.0
+    stat_above = stat[stat >= stat_fit_threshold]
+    stat_below = stat[stat < stat_fit_threshold]
+    statsort = stat_above.argsort()
+    unsort = statsort.argsort()
+    kernel = gaussian_kde(stat_above)
+    dens = kernel(stat_above)
+    dens *= stat_above.size / dens.sum()
+    dens_above = dens[statsort][::-1].cumsum()[::-1][unsort]
+    cum_fit = np.zeros(stat.size)
+    cum_fit[stat > stat_fit_threshold] = dens_above
+    # Below stat threshold use n louder method
+    _, fnlouder_below = coinc.calculate_n_louder(stat_below, stat_below,
+                                                 np.ones_like(stat_below))
+    cum_fit[stat < stat_fit_threshold] = fnlouder_below + 1 + stat_above.size
+    ifar_sec = fg_time / cum_fit
+    ifar = conv.sec_to_year(ifar_sec)
+    fap = 1 - np.exp(-fg_time / ifar_sec)
+else:
+    # Prefer to use method from arxiv.org/abs/2004.10015 or similar
+    raise NotImplementedError("Currently only supporting IFAR models: " +
+                              ", ".join(ifar_model_options) + ".")
+
+data = {"stat": stat,
+        "decimation_factor": np.ones_like(stat),
+        "timeslide_id": np.zeros_like(stat),
+        "template_id": trigs.data['template_id'],
+        "%s/time" % ifo : trigs.data['end_time'],
+        "%s/trigger_id" % ifo: trigs.data['trigger_id'],
+        "ifar": ifar, "fap": fap}
+
+logging.info("saving triggers")
+f = io.HFile(args.output_file, 'w')
+for key in data:
+    f.create_dataset("foreground/" + key, data=data[key],
+                     compression="gzip",
+                     compression_opts=9,
+                     shuffle=True)
 
 # Store segments
-f['segments/%s/start' % ifo], f['segments/%s/end' % ifo] = reader.valid
-
-f.attrs['foreground_time'] = abs(fg_segs)
+f['segments/%s/start' % ifo], f['segments/%s/end' % ifo] = \
+    veto.segments_to_start_end(fg_segs)
+f.attrs['foreground_time'] = fg_time
+f.attrs['background_time'] = fg_time
 f.attrs['num_of_ifos'] = 1
 f.attrs['pivot'] = ifo
 f.attrs['fixed'] = ifo
 f.attrs['ifos'] = ifo
 
-fore_stat = data['stat'][cid]
+# Do hierarchical removal
+# h_iterations = 0
+# if args.max_hierarchical_removal != 0:
 
-logging.info('Assigning IFARs according to X model')
-# Currently just using a "Count N louder" model as it's easy to code - 
-# which is a bit crap and doesnt give far below 1 per live time
-_, fnlouder = coinc.calculate_n_louder(fore_stat, fore_stat,
-                                       numpy.ones_like(fore_stat))
-fg_time = abs(fg_segs)
-ifar = fg_time / (fnlouder + 1)
-fap = 1 - numpy.exp(-fg_time / ifar)
-
-f['foreground/ifar'] = conv.sec_to_year(ifar)
-f['foreground/fap'] = fap
-
-#Do hierarchical removal
-#h_iterations = 0
-#if args.max_hierarchical_removal != 0:
-
-logging.info('Done')
+logging.info("Done")

--- a/bin/hdfcoinc/pycbc_multiifo_sngls_findtrigs
+++ b/bin/hdfcoinc/pycbc_multiifo_sngls_findtrigs
@@ -12,13 +12,13 @@ parser = argparse.ArgumentParser()
 parser.add_argument("--verbose", action='count')
 parser.add_argument("--version", action='version',
                     version=pycbc.version.git_verbose_msg)
-parser.add_argument("--veto-file", default=None,
+parser.add_argument("--veto-files", nargs='+',
                     help="Optional veto file. Triggers within veto segments "
                          "contained in the file are ignored. Required if "
-                         "--segment-name given.")
-parser.add_argument("--segment-name", default=None,
+                         "--segment-names given.")
+parser.add_argument("--segment-names", nargs='+',
                     help="Optional, name of veto segment in veto file. "
-                         "Required if --veto-file given.")
+                         "Required if --veto-files given.")
 parser.add_argument("--trigger-file",type=str,
                     help="File containing single-detector triggers")
 parser.add_argument("--template-bank", required=True,
@@ -48,9 +48,12 @@ parser.add_argument("--output-file",
                     help="File to store the candidate triggers")
 args = parser.parse_args()
 
-if (args.veto_file and not args.segment_name) or \
-    (args.segment_name and not args.veto_file):
-    raise RuntimeError('--veto-file and --segment-name are mutually required')
+if (args.veto_files and not args.segment_names) or \
+    (args.segment_names and not args.veto_files):
+    raise RuntimeError('--veto-files and --segment-names are mutually required')
+
+if not len(args.veto_files) == len(args.segment_names):
+    raise RuntimeError('--segment-names are required for each --veto-files')
 
 args.statistic_files = sum(args.statistic_files, [])
 
@@ -86,21 +89,22 @@ if args.reduced_chisq_cut:
     # Select chisq-cut-kept idx from keep_idx
     keep_idx = keep_idx[chisq_keep_idx]
 
-if args.veto_file:
-    logging.info("Getting vetoed indices from file %s", args.veto_file)
-    end_time = trigf[ifo + '/end_time'][:][keep_idx]
-    veto_keep_idx, _ = veto.indices_outside_segments(end_time,
-                                                     [args.veto_file],
-                                                     segment_name=args.segment_name,
-                                                     ifo=ifo)
-    logging.info("Cutting %d triggers in vetoed segments (%.2f%%)",
-                 keep_idx.size - veto_keep_idx.size,
-                 float(keep_idx.size - veto_keep_idx.size) / float(keep_idx.size) * 100.)
-    # Select unvetoed idx from keep_idx
-    keep_idx = keep_idx[veto_keep_idx]
-    veto_segs = veto.select_segments_by_definer(args.veto_file, ifo=ifo,
-                                                segment_name=args.segment_name)
-    fg_segs = segments - veto_segs
+if args.veto_files:
+    for veto_file, segment_name in zip(args.veto_files, args.segment_names):
+        logging.info("Getting vetoed indices from file %s", veto_file)
+        end_time = trigf[ifo + '/end_time'][:][keep_idx]
+        veto_keep_idx, _ = veto.indices_outside_segments(end_time,
+                                                         [veto_file],
+                                                         segment_name=segment_name,
+                                                         ifo=ifo)
+        logging.info("Cutting %d triggers in vetoed segments (%.2f%%)",
+                     keep_idx.size - veto_keep_idx.size,
+                     float(keep_idx.size - veto_keep_idx.size) / float(keep_idx.size) * 100.)
+        # Select unvetoed idx from keep_idx
+        keep_idx = keep_idx[veto_keep_idx]
+        veto_segs = veto.select_segments_by_definer(veto_file, ifo=ifo,
+                                                    segment_name=segment_name)
+        fg_segs = segments - veto_segs
 else:
     fg_segs = segments
 

--- a/bin/hdfcoinc/pycbc_multiifo_sngls_findtrigs
+++ b/bin/hdfcoinc/pycbc_multiifo_sngls_findtrigs
@@ -6,8 +6,7 @@ import pycbc.conversions as conv
 import pycbc.version
 from pycbc import io
 from pycbc.events import trigger_fits as trfits
-
-ifar_model_options = ['n_louder', 'exp_fit', 'gaussian_kde']
+from pycbc import init_logging
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--verbose", action='count')
@@ -36,23 +35,15 @@ parser.add_argument("--statistic-keywords", nargs='*',
                          "the statistic class when it is initialized. Should "
                          "be given in format --statistic-keywords "
                          "KWARG1:VALUE1 KWARG2:VALUE2 KWARG3:VALUE3 ...")
-parser.add_argument("--trigger-snr-cut", type=float, default=6,
-                    help="Apply a cut on snr to triggers before processing. "
-                         "Default = 6")
-parser.add_argument("--reduced-chisq-cut", type=float, default=None,
-                    help="Apply a cut on reduced chisquared to triggers "
-                         "before processing. Default = None")
-parser.add_argument("--chieff-upper-limit", type=float, default=None,
-                    help="Apply an upper limit cut on chi_eff to triggers "
-                         "before processing. Default = None")
-parser.add_argument("--cluster-window", type=float,
-                    help="Optional, window size in seconds to cluster "
-                         "over the bank")
-parser.add_argument("--ifar-model", default='n_louder',
-                    choices=ifar_model_options,
-                    help="Which model t use for calculating IFAR. "
-                         "Choices=" + ", ".join(ifar_model_options) + ". "
-                         "Default = n_louder.")
+parser.add_argument('--trigger-snr-cut',  type=float,
+                    help='Only consider triggers above the given SNR.')
+parser.add_argument('--cluster-window', type=float,
+                    help='Window (seconds) during which to keep the trigger '
+                         'with the loudest statistic value. '
+                         'Default=do not cluster')
+parser.add_argument('--reduced-chisq-cut', type=float,
+                    help='Only consider triggers below given reduced '
+                         'chisquared.')
 parser.add_argument("--output-file",
                     help="File to store the candidate triggers")
 args = parser.parse_args()
@@ -63,25 +54,11 @@ if (args.veto_file and not args.segment_name) or \
 
 args.statistic_files = sum(args.statistic_files, [])
 
-if args.verbose:
-    logging.basicConfig(format='%(asctime)s : %(message)s', level=logging.DEBUG)
-
+init_logging(args.verbose)
 
 logging.info('Opening trigger file: %s', args.trigger_file)
 trigf = io.HFile(args.trigger_file, 'r')
 ifo = trigf.keys()[0]
-
-# Stat class instance to calculate the ranking statistic
-extra_kwargs = {}
-for inputstr in args.statistic_keywords:
-    try:
-        key, value = inputstr.split(':')
-        extra_kwargs[key] = value
-    except ValueError:
-        err_txt = "--statistic-keywords must take input in the " \
-                  "form KWARG1:VALUE1 KWARG2:VALUE2 KWARG3:VALUE3 ... " \
-                  "Received {}".format(args.statistic_keywords)
-        raise ValueError(err_txt)
 
 starts = trigf[ifo + '/search/start_time'][:]
 ends = trigf[ifo + '/search/end_time'][:]
@@ -89,14 +66,15 @@ segments = veto.start_end_to_segments(starts, ends)
 
 n_tot_trigs = trigf[ifo + '/snr'].size
 logging.info("%d triggers in file", n_tot_trigs)
-keep_idx = np.flatnonzero(trigf[ifo + '/snr'][:] >= args.trigger_snr_cut)
-snr_cut_f = ("%f" % args.trigger_snr_cut).rstrip("0").rstrip(".")
-logging.info("Cutting %d triggers with SNR < %s (%.2f%%)",
-             n_tot_trigs - keep_idx.size, snr_cut_f,
-             float(n_tot_trigs - keep_idx.size) / n_tot_trigs * 100)
 
+if args.trigger_snr_cut:
+    keep_idx = np.flatnonzero(trigf[ifo + '/snr'][:] >= args.trigger_snr_cut)
+    snr_cut_f = ("%f" % args.trigger_snr_cut).rstrip("0").rstrip(".")
+    logging.info("Cutting %d triggers with SNR < %s (%.2f%%)",
+                 n_tot_trigs - keep_idx.size, snr_cut_f,
+                 float(n_tot_trigs - keep_idx.size) / n_tot_trigs * 100)
 if args.reduced_chisq_cut:
-    n_skp_trigs = keep_idx.size
+    n_skp_trigs = float(keep_idx.size)
     chisq = trigf[ifo + '/chisq'][:][keep_idx]
     chisq_dof = trigf[ifo + '/chisq_dof'][:][keep_idx]
     reduced_chisq = chisq / (2 * chisq_dof - 2)
@@ -112,12 +90,12 @@ if args.veto_file:
     logging.info("Getting vetoed indices from file %s", args.veto_file)
     end_time = trigf[ifo + '/end_time'][:][keep_idx]
     veto_keep_idx, _ = veto.indices_outside_segments(end_time,
-                                                [args.veto_file],
-                                                segment_name=args.segment_name,
-                                                ifo=ifo)
+                                                     [args.veto_file],
+                                                     segment_name=args.segment_name,
+                                                     ifo=ifo)
     logging.info("Cutting %d triggers in vetoed segments (%.2f%%)",
                  keep_idx.size - veto_keep_idx.size,
-                 float(keep_idx.size - veto_keep_idx.size) / keep_idx.size * 100)
+                 float(keep_idx.size - veto_keep_idx.size) / float(keep_idx.size) * 100.)
     # Select unvetoed idx from keep_idx
     keep_idx = keep_idx[veto_keep_idx]
     veto_segs = veto.select_segments_by_definer(args.veto_file, ifo=ifo,
@@ -125,6 +103,9 @@ if args.veto_file:
     fg_segs = segments - veto_segs
 else:
     fg_segs = segments
+
+if not len(keep_idx):
+    raise RuntimeError("All triggers removed by vetoes or cuts")
 
 logging.info("Loading %d triggers", len(keep_idx))
 
@@ -134,16 +115,25 @@ all_dsets = ['sigmasq', 'chisq', 'chisq_dof', 'coa_phase', 'end_time',
 
 for ds in all_dsets:
     data_init[ds] = trigf[ifo + "/" + ds][:][keep_idx]
-data_init['trigger_id'] = np.arange(trigf[ifo + '/snr'].size)
+data_init['trigger_id'] = np.arange(trigf[ifo + '/snr'].size)[keep_idx]
 
 logging.info("Putting data into DictArray")
 trigs = io.DictArray(data=data_init)
 trigf.close()
 
-if not len(trigs):
-    raise RuntimeError("All triggers removed by vetoes or snr cut")
-
 logging.info('Setting up ranking method')
+# Stat class instance to calculate the ranking statistic
+extra_kwargs = {}
+for inputstr in args.statistic_keywords:
+    try:
+        key, value = inputstr.split(':')
+        extra_kwargs[key] = value
+    except ValueError:
+        err_txt = "--statistic-keywords must take input in the " \
+                  "form KWARG1:VALUE1 KWARG2:VALUE2 KWARG3:VALUE3 ... " \
+                  "Received {}".format(args.statistic_keywords)
+        raise ValueError(err_txt)
+
 rank_stat_class = stat.get_statistic(args.ranking_statistic)
 rank_method = rank_stat_class(args.statistic_files, ifos=[ifo],
                               **extra_kwargs)
@@ -159,77 +149,21 @@ if args.cluster_window:
                                   args.cluster_window)
     trigs = trigs.select(cid)
     stat = stat[cid]
-
+    logging.info("%d triggers after clustering", stat.size)
 
 fg_time = abs(fg_segs)
-
-logging.info("Assigning IFARs according to %s model", args.ifar_model)
-
-if args.ifar_model == "n_louder":
-    # This is a "count N louder and divide by live time" model as it's the
-    # most basic - it is a bit crap and doesn't give FAR below 1 per live time
-    _, fnlouder = coinc.calculate_n_louder(stat, stat, np.ones_like(stat))
-    ifar_sec = fg_time / (fnlouder + 1)
-    ifar = conv.sec_to_year(ifar_sec)
-    fap = 1 - np.exp(-fg_time / ifar_sec)
-elif args.ifar_model == "exp_fit":
-    # Basic (overly optimistic) method of IFAR calculation - fits to an
-    # exponential above a threshold. Threshold should be above the point
-    # where clustering affects the distribution - 3 seems to be about right
-    # with the current statistic & 10s window
-    stat_threshold = 3.0
-    stat_above = stat[stat > stat_threshold]
-    alpha, _ = trfits.fit_above_thresh("exponential", stat_above,
-                                       stat_threshold)
-    cum_fit = stat_above.size * trfits.cum_fit("exponential", stat, alpha,
-                                               stat_threshold)
-    # cum_fit returns zero if below threshold - change so that IFAR will be
-    # equal to the n_louder method
-    stat_below = stat[stat < stat_threshold]
-    _, fnlouder_below = coinc.calculate_n_louder(stat_below, stat_below,
-                                                 np.ones_like(stat_below))
-    cum_fit[stat < stat_threshold] = fnlouder_below + 1 + stat_above.size
-    ifar_sec = fg_time / cum_fit
-    ifar = conv.sec_to_year(ifar_sec)
-    fap = 1 - np.exp(-fg_time / ifar_sec)
-elif args.ifar_model == "gaussian_kde":
-    #This is crap - ignore it
-    from scipy.stats import gaussian_kde
-    stat_fit_threshold = 3.0
-    stat_above = stat[stat >= stat_fit_threshold]
-    stat_below = stat[stat < stat_fit_threshold]
-    statsort = stat_above.argsort()
-    unsort = statsort.argsort()
-    kernel = gaussian_kde(stat_above)
-    dens = kernel(stat_above)
-    dens *= stat_above.size / dens.sum()
-    dens_above = dens[statsort][::-1].cumsum()[::-1][unsort]
-    cum_fit = np.zeros(stat.size)
-    cum_fit[stat > stat_fit_threshold] = dens_above
-    # Below stat threshold use n louder method
-    _, fnlouder_below = coinc.calculate_n_louder(stat_below, stat_below,
-                                                 np.ones_like(stat_below))
-    cum_fit[stat < stat_fit_threshold] = fnlouder_below + 1 + stat_above.size
-    ifar_sec = fg_time / cum_fit
-    ifar = conv.sec_to_year(ifar_sec)
-    fap = 1 - np.exp(-fg_time / ifar_sec)
-else:
-    # Prefer to use method from arxiv.org/abs/2004.10015 or similar
-    raise NotImplementedError("Currently only supporting IFAR models: " +
-                              ", ".join(ifar_model_options) + ".")
 
 data = {"stat": stat,
         "decimation_factor": np.ones_like(stat),
         "timeslide_id": np.zeros_like(stat),
         "template_id": trigs.data['template_id'],
         "%s/time" % ifo : trigs.data['end_time'],
-        "%s/trigger_id" % ifo: trigs.data['trigger_id'],
-        "ifar": ifar, "fap": fap}
+        "%s/trigger_id" % ifo: trigs.data['trigger_id']}
 
 logging.info("saving triggers")
 f = io.HFile(args.output_file, 'w')
 for key in data:
-    f.create_dataset("foreground/" + key, data=data[key],
+    f.create_dataset(key, data=data[key],
                      compression="gzip",
                      compression_opts=9,
                      shuffle=True)

--- a/bin/hdfcoinc/pycbc_multiifo_sngls_pastro
+++ b/bin/hdfcoinc/pycbc_multiifo_sngls_pastro
@@ -12,6 +12,7 @@ coincidences.
 
 import pycbc, pycbc.io, copy
 import argparse, logging, numpy as np
+from glue.ligolw import ligolw, table, lsctables, utils as ligolw_utils
 from pycbc import conversions as conv
 from pycbc.events import veto, stat, ranking, coinc, single as sngl
 from ligo.segments import segment, segmentlist
@@ -20,6 +21,11 @@ import matplotlib
 matplotlib.use('agg')
 from matplotlib import pyplot as plt
 from scipy.stats import gaussian_kde as gk
+
+# dummy class for loading LIGOLW files
+class LIGOLWContentHandler(ligolw.LIGOLWContentHandler):
+    pass
+lsctables.use_in(LIGOLWContentHandler)
 
 d_power = {
     'log': 3.,
@@ -57,12 +63,14 @@ parser.add_argument("--remove-n-loudest", type=int,
 # Arguments for dealing with the injection trigger files for signal population
 parser.add_argument('--inj-single-statmap-files', nargs='+', required=True,
                     help="Single statmap files for the injections. "
-                         "Must be in same injection set order as "
-                         "--injfind-files")
-parser.add_argument('--injfind-files', nargs='+', required=True,
-                    help="File which associates single-detector triggers "
-                         "with injections. Must be in same injection set "
+                         "Must be in same order as --inj-files")
+parser.add_argument('--inj-files', nargs='+', required=True,
+                    help="File which define injections. Must be in same "
                          "order as --inj-single-trigger-files")
+parser.add_argument('--injection-window', type=float, default=1,
+                    help="Window for how close a trigger is to an "
+                         "injection to be considered to be associated "
+                         "with it (seconds). Default=1.")
 
 # Arguments to decide the weighting of the injection distribution
 parser.add_argument('--distance-param', choices=['distance', 'chirp_distance'],
@@ -175,49 +183,52 @@ if args.remove_n_loudest:
 
 logging.info("Getting injected signal triggers and information.")
 
-signal_stat = []
-signal_weights = []
-# This method requires injfind files and injection single statmap files to be
+signal_stat = np.array([])
+signal_weights = np.array([])
+# This method requires injection definition files and injection single statmap files to be
 # in the same order - would prefer to not have to do this
-for injfind_filename, trigger_filename in zip(args.injfind_files,
+for inj_filename, inj_trigger_filename in zip(args.inj_files,
                                               args.inj_single_statmap_files):
-    with pycbc.io.HFile(injfind_filename,'r') as injfind_f:
-        # deal with injfind file groups according to new or old style files
-        if sngl_ifo in injfind_f['found']:
-            tid_key = sngl_ifo + '/trigger_id'
-        elif sngl_ifo == injfind_f.attrs['detector_1']:
-            tid_key = 'trigger_id1'
-        else:
-            tid_key = 'trigger_id2'
-        found_tid = injfind_f['found'][tid_key][:]
-        found_ifar = injfind_f['found/ifar_exc'][:]
-        found_injid = injfind_f['found/injection_index'][:]
-        found_d = injfind_f['injections/distance'][:]
-        found_m1 = injfind_f['injections/mass1'][:]
-        found_m2 = injfind_f['injections/mass2'][:]
-    valid_idx = np.logical_and(found_tid > -1,
-                               found_ifar > args.signal_ifar_threshold)
-    found_tid = found_tid[valid_idx]
-    found_injid = found_injid[valid_idx]
+
+    logging.info('Read in injection statistic file')
+    with pycbc.io.HFile(inj_trigger_filename, 'r') as inj_trig_f:
+        inj_trig_id = inj_trig_f[sngl_ifo]['trigger_id'][:]
+        inj_trig_time = inj_trig_f[sngl_ifo]['time'][:]
+        inj_stat = inj_trig_f['stat'][:]
+
+    time_sort = inj_trig_time.argsort()
+
+    logging.info('Read in the injection file')
+    indoc = ligolw_utils.load_filename(inj_filename, False,
+                                       contenthandler=LIGOLWContentHandler)
+    sim_table = table.get_table(indoc, lsctables.SimInspiralTable.tableName)
+    inj_time = np.array(sim_table.get_column('geocent_end_time') +
+                        1e-9 * sim_table.get_column('geocent_end_time_ns'),
+                        dtype=np.float64)
+
+    left = np.searchsorted(inj_trig_time[time_sort],
+                           inj_time - args.injection_window, side='left')
+    right = np.searchsorted(inj_trig_time[time_sort],
+                            inj_time + args.injection_window, side='right')
+    found = np.flatnonzero((right - left) == 1)
+
+    found_d = np.array(sim_table.get_column('distance'),
+                       dtype=np.float32)[found]
+    found_m1 = np.array(sim_table.get_column('mass1'),
+                        dtype=np.float32)[found]
+    found_m2 = np.array(sim_table.get_column('mass2'),
+                        dtype=np.float32)[found]
+
+    signal_stat = np.append(signal_stat, inj_stat[left[found]])
+
     found_mchirp = conv.mchirp_from_mass1_mass2(found_m1, found_m2)
     if args.distance_param == 'chirp_distance':
         found_d = conv.chirp_distance(found_d, found_mchirp)
 
     weights = found_mchirp ** mchirp_power * found_d ** d_power
-    weights = weights[found_injid]
-    signal_weights.append(list(weights)[0])
-    with pycbc.io.HFile(trigger_filename, 'r') as trig_f:
-        _, stat_idx, _ = np.intersect1d(trig_f[sngl_ifo]['trigger_id'][:],
-                                        found_tid,
-                                        assume_unique=True,
-                                        return_indices=True)
-        if not stat_idx.size:
-            continue
-        signal_stat.append(list(trig_f['stat'][:][stat_idx])[0])
+    signal_weights = np.append(signal_weights, weights)
 
 
-signal_stat = np.array(signal_stat)
-signal_weights = np.array(signal_weights)
 bg_stat = bg_trigs.data['stat']
 fg_stat = fg_trigs.data['stat']
 

--- a/bin/hdfcoinc/pycbc_multiifo_sngls_pastro
+++ b/bin/hdfcoinc/pycbc_multiifo_sngls_pastro
@@ -53,6 +53,12 @@ parser.add_argument("--single-statmap-files", nargs='+', required=True,
 parser.add_argument('--coinc-statmap-files', nargs='+', required=True,
                     help="Coincident statmap files, containing coincident "
                          "events to be removed from the background.")
+parser.add_argument('--coinc-veto-ifar-threshold', type=float, default=1.0,
+                    help="Censor triggers around coincidences with "
+                         "IFAR (years) above the threshold [default=1 yr")
+parser.add_argument('--coinc-veto-window', type=float, default=0.1,
+                    help="Time around each coincident event above threshold "
+                         "to window out. Default = 0.1s")
 parser.add_argument("--remove-n-loudest", type=int,
                     help="If given, will remove this number of triggers from "
                          "the background after applying foreground censor. "
@@ -136,32 +142,47 @@ for smap_file in args.single_statmap_files:
     sngl_detector_segs += veto.start_end_to_segments(sngl_starts, sngl_ends)
 
 fg_time = abs(sngl_detector_segs)
-fg_trigs = copy.deepcopy(sngl_trigs)
-
 coinc_segs = segmentlist([segment(0, 0)])
 fgveto_segs = segmentlist([segment(0, 0)])
 logging.info('Getting coinc segments and foreground vetoes')
 for cfilename in args.coinc_statmap_files:
     with pycbc.io.HFile(cfilename, 'r') as cfile:
-        if 'ifos' in cfile.attrs:
+        # Coinc segments are different depending on statmap file
+        if 'coinc' in cfile['segments']:
+            c_starts = cfile['segments/coinc/start'][:]
+            c_ends = cfile['segments/coinc/end'][:]
+        else:
             ctype = cfile.attrs['ifos'].replace(' ','')
             c_starts = cfile['segments/' + ctype + '/start'][:]
             c_ends = cfile['segments/' + ctype + '/end'][:]
+        # Test if the ifo is actually in this statmap file
+        if 'ifos' in cfile.attrs.keys():
+            ifolist = cfile.attrs['ifos'].split(' ')
+            time_key = sngl_ifo + '/time'
         else:
-            ctype = ''.join([cfile.attrs['detector_1'],
-                             cfile.attrs['detector_2']])
-            c_starts = cfile['segments/coinc/start'][:]
-            c_ends = cfile['segments/coinc/end'][:]
-        if sngl_ifo not in ctype:
+            ifolist = [cfile.attrs['detector_1'],
+                       cfile.attrs['detector_2']]
+            if sngl_ifo == cfile.attrs['detector_1']:
+                time_key = 'time1'
+            else:
+                time_key = 'time2'
+
+        if sngl_ifo not in ifolist:
             logging.warning("IFO %s is not in file %s", sngl_ifo, cfilename)
             continue
-        c_fgv_starts = cfile['segments/foreground_veto/start'][:]
-        c_fgv_ends = cfile['segments/foreground_veto/end'][:]
+
+        # Find the coinc events above a threshold IFAR
+        cifar = cfile['foreground/ifar'][:]
+        c_above = cifar > args.coinc_veto_ifar_threshold
+        ctime = cfile['foreground'][time_key][:][c_above]
+        c_fgv_starts = ctime - args.coinc_veto_window
+        c_fgv_ends = ctime + args.coinc_veto_window
     coinc_segs = coinc_segs + veto.start_end_to_segments(c_starts, c_ends)
     fgveto_segs = fgveto_segs + veto.start_end_to_segments(c_fgv_starts,
                                                            c_fgv_ends)
     coinc_segs.coalesce()
     fgveto_segs.coalesce()
+
 
 logging.info("Removing triggers in single-detector time from background.")
 bg_bool = np.array([t in coinc_segs
@@ -170,13 +191,13 @@ bg_idx = np.flatnonzero(bg_bool)
 bg_trigs = sngl_trigs.select(bg_idx)
 
 logging.info("Removing triggers in foreground vetoed time from background.")
-fg_veto_bool = np.array([t not in fgveto_segs
+fg_veto_bool_bg = np.array([t not in fgveto_segs
                          for t in bg_trigs.data[sngl_ifo + '/time']])
-bg_trigs = bg_trigs.select(np.flatnonzero(fg_veto_bool))
+bg_trigs = bg_trigs.select(np.flatnonzero(fg_veto_bool_bg))
 bg_time = abs(coinc_segs - fgveto_segs)
 
 if args.remove_n_loudest:
-    logging.info("Removing %d loudest remaining triggers",
+    logging.info("Removing %d loudest remaining triggers from background",
                  args.remove_n_loudest)
     loudest_idx = np.argsort(bg_trigs.data['stat'])[-args.remove_n_loudest:]
     bg_trigs = bg_trigs.remove(loudest_idx)
@@ -190,7 +211,7 @@ signal_weights = np.array([])
 for inj_filename, inj_trigger_filename in zip(args.inj_files,
                                               args.inj_single_statmap_files):
 
-    logging.info('Read in injection statistic file')
+    logging.info('Reading injection statistic file')
     with pycbc.io.HFile(inj_trigger_filename, 'r') as inj_trig_f:
         inj_trig_id = inj_trig_f[sngl_ifo]['trigger_id'][:]
         inj_trig_time = inj_trig_f[sngl_ifo]['time'][:]
@@ -198,7 +219,7 @@ for inj_filename, inj_trigger_filename in zip(args.inj_files,
 
     time_sort = inj_trig_time.argsort()
 
-    logging.info('Read in the injection file')
+    logging.info('Reading injection file')
     indoc = ligolw_utils.load_filename(inj_filename, False,
                                        contenthandler=LIGOLWContentHandler)
     sim_table = table.get_table(indoc, lsctables.SimInspiralTable.tableName)
@@ -230,7 +251,7 @@ for inj_filename, inj_trigger_filename in zip(args.inj_files,
 
 
 bg_stat = bg_trigs.data['stat']
-fg_stat = fg_trigs.data['stat']
+fg_stat = sngl_trigs.data['stat']
 
 n_sig_exp = args.expected_signal_rate * conv.sec_to_year(fg_time)
 logging.info("%.3f signals are expected in this amount of data", n_sig_exp)
@@ -343,9 +364,9 @@ if args.plot_distribution:
     fig.savefig(args.plot_distribution)
 
 f_out = pycbc.io.HFile(args.output_file, 'w')
-for k in fg_trigs.data:
+for k in sngl_trigs.data:
     f_out.create_dataset('foreground/' + k,
-                         data=fg_trigs.data[k],
+                         data=sngl_trigs.data[k],
                          compression='gzip',
                          compression_opts=9,
                          shuffle=True)

--- a/bin/hdfcoinc/pycbc_multiifo_sngls_pastro
+++ b/bin/hdfcoinc/pycbc_multiifo_sngls_pastro
@@ -1,0 +1,363 @@
+#!/usr/bin/env python
+
+"""
+This executable is used to get the output of pycbc_multiifo_sngls_findtrigs
+and separate the triggers into foreground - times when coincs are not
+possible - and background - times when coincs are possible. It also performs
+foreground removal, and creates background_exc which is a background that
+contains no triggers within a certain window of those which form foreground
+coincidences.
+
+"""
+
+import pycbc, pycbc.io, copy
+import argparse, logging, numpy as np
+from pycbc import conversions as conv
+from pycbc.events import veto, stat, ranking, coinc, single as sngl
+from ligo.segments import segment, segmentlist
+import pycbc.version
+import matplotlib
+matplotlib.use('agg')
+from matplotlib import pyplot as plt
+from scipy.stats import gaussian_kde as gk
+
+d_power = {
+    'log': 3.,
+    'uniform': 2.,
+    'distancesquared': 1.,
+    'volume': 0.
+}
+
+mchirp_power = {
+    'log': 0.,
+    'uniform': 5. / 6.,
+    'distancesquared': 5. / 3.,
+    'volume': 15. / 6.
+}
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--verbose", action='count')
+parser.add_argument("--version", action='version',
+                    version=pycbc.version.git_verbose_msg)
+parser.add_argument("--single-statmap-files", nargs='+', required=True,
+                    help="Single statmap files for which p_astro is "
+                         "calculated.")
+
+# Files to help remove foreground events
+parser.add_argument('--coinc-statmap-files', nargs='+', required=True,
+                    help="Coincident statmap files, containing coincident "
+                         "events to be removed from the background.")
+parser.add_argument("--remove-n-loudest", type=int,
+                    help="If given, will remove this number of triggers from "
+                         "the background after applying foreground censor. "
+                         "This helps prevent signal contamination, but too "
+                         "many removals can adversely affect background "
+                         "estimate.")
+
+# Arguments for dealing with the injection trigger files for signal population
+parser.add_argument('--inj-single-statmap-files', nargs='+', required=True,
+                    help="Single statmap files for the injections. "
+                         "Must be in same injection set order as "
+                         "--injfind-files")
+parser.add_argument('--injfind-files', nargs='+', required=True,
+                    help="File which associates single-detector triggers "
+                         "with injections. Must be in same injection set "
+                         "order as --inj-single-trigger-files")
+
+# Arguments to decide the weighting of the injection distribution
+parser.add_argument('--distance-param', choices=['distance', 'chirp_distance'],
+                    help="Parameter used to calculate injection distribution "
+                         "for weighting. Default='distance'")
+parser.add_argument('--distribution', default='uniform',
+                    choices=['log', 'uniform', 'distancesquared', 'volume'],
+                    help="Form of distribution over --distance-param. "
+                         "Default='uniform'")
+parser.add_argument('--expected-signal-rate', type=float, required=True,
+                    help="Expected rate of signals (per year) with stat "
+                         "value above --stat-threshold for use in p_astro "
+                         "calcation.")
+parser.add_argument('--signal-ifar-threshold', type=float, default=1,
+                    help="Coincident IFAR threshold to consider an injection "
+                         "as 'found' (years). Default=1")
+
+# produces a list of lists to allow multiple invocations and multiple args
+parser.add_argument('--pastro-method', required=True,
+                    choices=['truncated_shelf', 'callister', 'background_kde'],
+                    help="Which method to use for calculating p_astro. ")
+parser.add_argument("--bg-distribution-limit", type=float, default=8,
+                    help="The point at which the noise model will change from "
+                         "the background distribution to --pastro-method")
+
+parser.add_argument('--plot-distribution',
+                    help="If given, will plot the distribution of rate "
+                         "densities and p_astro given ranking statistic.")
+parser.add_argument('--output-file', required=True,
+                    help="name of output file")
+args = parser.parse_args()
+
+d_power = {
+    'log': 3.,
+    'uniform': 2.,
+    'distancesquared': 1.,
+    'volume': 0.
+}[args.distribution]
+
+mchirp_power = {
+    'log': 0.,
+    'uniform': 5. / 6.,
+    'distancesquared': 5. / 3.,
+    'volume': 15. / 6.
+}[args.distribution]
+
+
+pycbc.init_logging(args.verbose)
+
+sngl_ifo = pycbc.io.HFile(args.single_statmap_files[0], 'r').attrs['ifos']
+groups = ['decimation_factor', 'stat', 'template_id', 'timeslide_id',
+          sngl_ifo + '/time', sngl_ifo + '/trigger_id']
+empty_darray = {g: np.array([]) for g in groups}
+sngl_trigs = pycbc.io.DictArray(data=empty_darray)
+
+logging.info('Getting single-detector triggers and segments')
+sngl_detector_segs = segmentlist([segment(0, 0)])
+for smap_file in args.single_statmap_files:
+    with pycbc.io.HFile(smap_file, 'r') as f_in:
+        sngl_starts = f_in['segments/' + sngl_ifo + '/start'][:]
+        sngl_ends = f_in['segments/' + sngl_ifo + '/end'][:]
+        sngl_trigs += pycbc.io.DictArray(data={g: f_in[g][:] for g in groups})
+    sngl_detector_segs += veto.start_end_to_segments(sngl_starts, sngl_ends)
+
+fg_time = abs(sngl_detector_segs)
+fg_trigs = copy.deepcopy(sngl_trigs)
+
+coinc_segs = segmentlist([segment(0, 0)])
+fgveto_segs = segmentlist([segment(0, 0)])
+logging.info('Getting coinc segments and foreground vetoes')
+for cfilename in args.coinc_statmap_files:
+    with pycbc.io.HFile(cfilename, 'r') as cfile:
+        if 'ifos' in cfile.attrs:
+            ctype = cfile.attrs['ifos'].replace(' ','')
+            c_starts = cfile['segments/' + ctype + '/start'][:]
+            c_ends = cfile['segments/' + ctype + '/end'][:]
+        else:
+            ctype = ''.join([cfile.attrs['detector_1'],
+                             cfile.attrs['detector_2']])
+            c_starts = cfile['segments/coinc/start'][:]
+            c_ends = cfile['segments/coinc/end'][:]
+        if sngl_ifo not in ctype:
+            logging.warning("IFO %s is not in file %s", sngl_ifo, cfilename)
+            continue
+        c_fgv_starts = cfile['segments/foreground_veto/start'][:]
+        c_fgv_ends = cfile['segments/foreground_veto/end'][:]
+    coinc_segs = coinc_segs + veto.start_end_to_segments(c_starts, c_ends)
+    fgveto_segs = fgveto_segs + veto.start_end_to_segments(c_fgv_starts,
+                                                           c_fgv_ends)
+    coinc_segs.coalesce()
+    fgveto_segs.coalesce()
+
+logging.info("Removing triggers in single-detector time from background.")
+bg_bool = np.array([t in coinc_segs
+                    for t in sngl_trigs.data[sngl_ifo + '/time']])
+bg_idx = np.flatnonzero(bg_bool)
+bg_trigs = sngl_trigs.select(bg_idx)
+
+logging.info("Removing triggers in foreground vetoed time from background.")
+fg_veto_bool = np.array([t not in fgveto_segs
+                         for t in bg_trigs.data[sngl_ifo + '/time']])
+bg_trigs = bg_trigs.select(np.flatnonzero(fg_veto_bool))
+bg_time = abs(coinc_segs - fgveto_segs)
+
+if args.remove_n_loudest:
+    logging.info("Removing %d loudest remaining triggers",
+                 args.remove_n_loudest)
+    loudest_idx = np.argsort(bg_trigs.data['stat'])[-args.remove_n_loudest:]
+    bg_trigs = bg_trigs.remove(loudest_idx)
+
+logging.info("Getting injected signal triggers and information.")
+
+signal_stat = []
+signal_weights = []
+# This method requires injfind files and injection single statmap files to be
+# in the same order - would prefer to not have to do this
+for injfind_filename, trigger_filename in zip(args.injfind_files,
+                                              args.inj_single_statmap_files):
+    with pycbc.io.HFile(injfind_filename,'r') as injfind_f:
+        # deal with injfind file groups according to new or old style files
+        if sngl_ifo in injfind_f['found']:
+            tid_key = sngl_ifo + '/trigger_id'
+        elif sngl_ifo == injfind_f.attrs['detector_1']:
+            tid_key = 'trigger_id1'
+        else:
+            tid_key = 'trigger_id2'
+        found_tid = injfind_f['found'][tid_key][:]
+        found_ifar = injfind_f['found/ifar_exc'][:]
+        found_injid = injfind_f['found/injection_index'][:]
+        found_d = injfind_f['injections/distance'][:]
+        found_m1 = injfind_f['injections/mass1'][:]
+        found_m2 = injfind_f['injections/mass2'][:]
+    valid_idx = np.logical_and(found_tid > -1,
+                               found_ifar > args.signal_ifar_threshold)
+    found_tid = found_tid[valid_idx]
+    found_injid = found_injid[valid_idx]
+    found_mchirp = conv.mchirp_from_mass1_mass2(found_m1, found_m2)
+    if args.distance_param == 'chirp_distance':
+        found_d = conv.chirp_distance(found_d, found_mchirp)
+
+    weights = found_mchirp ** mchirp_power * found_d ** d_power
+    weights = weights[found_injid]
+    signal_weights.append(list(weights)[0])
+    with pycbc.io.HFile(trigger_filename, 'r') as trig_f:
+        _, stat_idx, _ = np.intersect1d(trig_f[sngl_ifo]['trigger_id'][:],
+                                        found_tid,
+                                        assume_unique=True,
+                                        return_indices=True)
+        if not stat_idx.size:
+            continue
+        signal_stat.append(list(trig_f['stat'][:][stat_idx])[0])
+
+
+signal_stat = np.array(signal_stat)
+signal_weights = np.array(signal_weights)
+bg_stat = bg_trigs.data['stat']
+fg_stat = fg_trigs.data['stat']
+
+n_sig_exp = args.expected_signal_rate * conv.sec_to_year(fg_time)
+logging.info("%.3f signals are expected in this amount of data", n_sig_exp)
+
+max_bg = bg_stat.max()
+min_bg = bg_stat.min()
+
+logging.info('Getting Gaussian kernel density estimates of signal '
+             'distribution')
+sig_kern = gk(signal_stat, weights=signal_weights, bw_method=1)
+sig_norm = sig_kern.integrate_box_1d(max_bg, np.inf)
+sig_dens = sig_kern(fg_stat) / sig_norm
+
+logging.info('Getting Gaussian kernel density estimates of background '
+             'distribution')
+bg_kern = gk(bg_stat, bw_method=1)
+bg_rate_dens = bg_kern(fg_stat) * bg_stat.size
+
+# Find the peak of the background distribution:
+# anything with statistic below this gets p_astro zero, this prevents
+# problems with the background distribution reducing as triggers are
+# clustered away
+bg_dens_max_idx = bg_rate_dens.argmax()
+bg_dens_max_stat = fg_stat[bg_dens_max_idx]
+fg_stat_below_peak = fg_stat < bg_dens_max_stat
+
+logging.info('Getting noise distribution of %s method.', args.pastro_method)
+# If the foreground statistic value is quieter than X
+# then use background density for noise
+pastro_noise_valid = fg_stat >= args.bg_distribution_limit
+noise_model = copy.deepcopy(bg_rate_dens)
+
+if args.pastro_method == 'callister':
+    noise_model[pastro_noise_valid] = sig_dens[pastro_noise_valid]
+elif args.pastro_method == 'truncated_shelf':
+    fgs = fg_stat[pastro_noise_valid]
+    stat_below = np.array([max(bg_stat[bg_stat < fs])
+                           if fs > min_bg else -np.inf for fs in fgs])
+    ts_norm = np.array([sig_kern.integrate_box_1d(sbel, fs)
+                        for sbel, fs in zip(stat_below, fgs)])
+    noise_model[pastro_noise_valid] = sig_kern(fgs) / ts_norm
+
+logging.info("Calculating pastro for foreground events")
+p_astro = n_sig_exp * sig_dens / (noise_model + n_sig_exp * sig_dens)
+p_astro[fg_stat_below_peak] = 0
+
+if args.plot_distribution:
+    logging.info("Making distribution plot")
+    max_bin_c =  min(signal_stat.max(), bg_stat.max() * 4)
+    stat_bins = np.linspace(min_bg, max_bin_c, 201)
+    stat_bin_c = (stat_bins[1:] + stat_bins[:-1]) / 2
+
+    fig = plt.figure(figsize=[6, 6])
+    ax0 = fig.add_subplot(211)
+    ax1 = fig.add_subplot(212)
+
+    # Plot background trigger rate density
+    bg_rate_dens_plt = bg_kern(stat_bin_c) * bg_stat.size
+    ax0.plot(stat_bin_c, bg_rate_dens_plt, linestyle="--",
+             label="Background KDE")
+
+    # Plot signal trigger rate density (from injections)
+    sig_rate_dens_plt = sig_kern(stat_bin_c) / sig_norm
+    ax0.plot(stat_bin_c, sig_rate_dens_plt, linestyle=":",
+             label="Signals KDE")
+
+    # Calculate noise model according to chosen method
+    if args.pastro_method == 'callister':
+        noise_mod_plt = sig_rate_dens_plt
+    elif args.pastro_method == 'truncated_shelf':
+        stat_below_plt = [max(bg_stat[sbc >= bg_stat])
+                          if sbc >= min_bg else -np.inf for sbc in stat_bin_c]
+        ts_norm = np.array([sig_kern.integrate_box_1d(sbel, sbc)
+                           for sbel, sbc in zip(stat_below_plt, stat_bin_c)])
+        noise_mod_plt = sig_kern(stat_bin_c) / ts_norm
+    elif args.pastro_method == 'background_kde':
+        noise_mod_plt = bg_rate_dens_plt
+
+    # triggers below the chosen distribution limit use the background
+    # distribution for noise model
+    past_noise_idx_plt = stat_bin_c < args.bg_distribution_limit
+    noise_mod_plt[past_noise_idx_plt] = bg_rate_dens_plt[past_noise_idx_plt]
+    ax0.plot(stat_bin_c, noise_mod_plt, linestyle='-', c='k',
+             label=args.pastro_method)
+
+    ax0.semilogy()
+    ax0.grid()
+    # Set axis limits according to the highest point of the background
+    # distribution
+    ax0.set_xlim([bg_dens_max_stat, max_bin_c])
+    ax0.set_ylim([sig_kern(max_bin_c) / sig_norm / 1.5,
+                  bg_rate_dens[bg_dens_max_idx] * 1.5])
+    ax0.legend()
+    ax0.set_xlabel("Ranking Statistic")
+    ax0.set_ylabel("Rate Density")
+
+    # Calculate p_astro for the plotted statistic values
+    p_astro_plt = \
+        n_sig_exp * sig_rate_dens_plt / (noise_mod_plt + n_sig_exp * sig_rate_dens_plt)
+
+    ax1.plot(stat_bin_c, p_astro_plt, c='k', label="p_astro distribution")
+    ax1.scatter(fg_stat, p_astro, c='k', marker='x', label='foreground events')
+    ax1.grid()
+    ax1.legend()
+    ax1.set_xlim([bg_dens_max_stat, max_bin_c])
+    ax1.set_ylim([0, 1])
+    ax1.set_xlabel("Ranking Statistic")
+    ax1.set_ylabel("p_astro (%s)" % args.pastro_method)
+
+    fig.savefig(args.plot_distribution)
+
+f_out = pycbc.io.HFile(args.output_file, 'w')
+for k in fg_trigs.data:
+    f_out.create_dataset('foreground/' + k,
+                         data=fg_trigs.data[k],
+                         compression='gzip',
+                         compression_opts=9,
+                         shuffle=True)
+    f_out.create_dataset('background/' + k,
+                         data=bg_trigs.data[k],
+                         compression='gzip',
+                         compression_opts=9,
+                         shuffle=True)
+
+f_out.create_dataset('foreground/p_astro',
+                     data=p_astro,
+                     compression='gzip',
+                     compression_opts=9,
+                     shuffle=True)
+
+# Store segments
+f_out['segments/%s/start' % sngl_ifo], f_out['segments/%s/end' % sngl_ifo] = \
+    veto.segments_to_start_end(sngl_detector_segs)
+f_out.attrs['foreground_time'] = fg_time
+f_out.attrs['background_time'] = bg_time
+f_out.attrs['num_of_ifos'] = 1
+f_out.attrs['pivot'] = sngl_ifo
+f_out.attrs['fixed'] = sngl_ifo
+f_out.attrs['ifos'] = sngl_ifo
+f_out.attrs['pastro_method'] = args.pastro_method
+logging.info('Done')

--- a/bin/live/pycbc_live_combine_single_fits
+++ b/bin/live/pycbc_live_combine_single_fits
@@ -58,9 +58,10 @@ for f in files:
     if 'days_since_epoch' in fits_f.attrs:
         analysis_dates += [fits_f.attrs['days_since_epoch']]
     elif 'analysis_date' in fits_f.attrs:
-        analysis_year = int(fits_f.attrs['analysis_date'][:4])
-        analysis_month = int(fits_f.attrs['analysis_date'][5:7])
-        analysis_day = int(fits_f.attrs['analysis_date'][8:10])
+        date_list = fits_f.attrs['analysis_date'].split('_')
+        analysis_year = int(date_list[0])
+        analysis_month = int(date_list[1])
+        analysis_day = int(date_list[2])
         n_since_epoch = (datetime.date(analysis_year,
                                        analysis_month,
                                        analysis_day)

--- a/bin/live/pycbc_live_combine_single_fits
+++ b/bin/live/pycbc_live_combine_single_fits
@@ -58,10 +58,9 @@ for f in files:
     if 'days_since_epoch' in fits_f.attrs:
         analysis_dates += [fits_f.attrs['days_since_epoch']]
     elif 'analysis_date' in fits_f.attrs:
-        date_list = fits_f.attrs['analysis_date'].split('_')
-        analysis_year = int(date_list[0])
-        analysis_month = int(date_list[1])
-        analysis_day = int(date_list[2])
+        analysis_year = int(fits_f.attrs['analysis_date'][:4])
+        analysis_month = int(fits_f.attrs['analysis_date'][5:7])
+        analysis_day = int(fits_f.attrs['analysis_date'][8:10])
         n_since_epoch = (datetime.date(analysis_year,
                                        analysis_month,
                                        analysis_day)

--- a/bin/minifollowups/pycbc_page_snglinfo
+++ b/bin/minifollowups/pycbc_page_snglinfo
@@ -119,7 +119,7 @@ headers.append("End&nbsp;time")
 data[0].append('%5.2f' % sngl_file.snr)
 data[0].append('%5.2f' % sngl_file.get_column('coa_phase'))
 data[0].append('%5.2f' % stat)
-headers.append("SNR")
+headers.append("&rho;")
 headers.append("Phase")
 headers.append(sngl_file.stat_name)
 

--- a/bin/minifollowups/pycbc_page_snglinfo
+++ b/bin/minifollowups/pycbc_page_snglinfo
@@ -58,7 +58,9 @@ parser.add_argument('--include-summary-page-link', action='store_true',
 parser.add_argument('--include-gracedb-link', action='store_true',
     help="If given, will provide a link to search GraceDB for events "
          "within a 3s window around the coincidence time.")
-
+parser.add_argument('--significance-file',
+    help="If given, will search for this trigger's id in the file to see if "
+         "stat and p_astro values exists for this trigger.")
 
 
 args = parser.parse_args()
@@ -69,9 +71,9 @@ pycbc.init_logging(args.verbose)
 sngl_file = hdf.SingleDetTriggers(args.single_trigger_file, args.bank_file,
                 args.veto_file, args.veto_segment_name, None, args.instrument)
 
-
 if args.trigger_id is not None:
     sngl_file.mask = [args.trigger_id]
+    trig_id = args.trigger_id
     sngl_file.mask_to_n_loudest_clustered_events(n_loudest=1,
                                       ranking_statistic=args.ranking_statistic)
     stat = sngl_file.stat[0]
@@ -117,9 +119,9 @@ headers.append("End&nbsp;time")
 data[0].append('%5.2f' % sngl_file.snr)
 data[0].append('%5.2f' % sngl_file.get_column('coa_phase'))
 data[0].append('%5.2f' % stat)
-headers.append("&rho;")
+headers.append("SNR")
 headers.append("Phase")
-headers.append("Stat")
+headers.append(sngl_file.stat_name)
 
 # Signal-glitch discrimators
 data[0].append('%5.2f' % sngl_file.rchisq)
@@ -150,6 +152,20 @@ headers.append("M<sub>c</sub>")
 headers.append("s<sub>1z</sub>")
 headers.append("s<sub>2z</sub>")
 headers.append("Duration")
+
+if args.significance_file and not args.n_loudest:
+    with hdf.HFile(args.significance_file, 'r') as sig_f:
+        trigger_ids = sig_f['foreground'][args.instrument]['trigger_id'][:]
+        sngl_stat = sig_f['foreground/stat'][:]
+        sngl_pastro = sig_f['foreground/p_astro_exc'][:]
+
+    if trig_id in trigger_ids:
+        trig_idx = numpy.nonzero(trigger_ids == trig_id)[0][0]
+        headers.append("Single-detector statistic")
+        data[0].append("%.2f" % sngl_stat[trig_idx])
+        headers.append("Single-detector p_astro")
+        pastro_form = "%.3f" if sngl_pastro[trig_idx] >= 0.001 else "%.3e"
+        data[0].append(pastro_form % sngl_pastro[trig_idx])
 
 # GraceDB search link
 if args.include_gracedb_link:

--- a/pycbc/events/coinc.py
+++ b/pycbc/events/coinc.py
@@ -1123,7 +1123,7 @@ class LiveCoincTimeslideBackgroundEstimator(object):
         self.coincs.remove(num_coincs)
 
     def add_singles(self, results):
-        """Add singles to the bacckground estimate and find candidates
+        """Add singles to the background estimate and find candidates
 
         Parameters
         ----------

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -901,7 +901,7 @@ class ExpFitStatistic(NewSNRStatistic):
             tnum = trigs.template_num  # exists if accessed via coinc_findtrigs
             ifo = trigs.ifo
         except AttributeError:
-            tnum = trigs['template_id']  # exists for SingleDetTriggers
+`            tnum = trigs['template_id']  # exists for SingleDetTriggers
             assert len(self.ifos) == 1
             # Should be exactly one ifo provided
             ifo = self.ifos[0]
@@ -997,7 +997,11 @@ class ExpFitCombinedSNR(ExpFitStatistic):
         return numpy.array(stat, ndmin=1, dtype=numpy.float32)
 
     def single_multiifo(self, s):
-        return s[1]['snglstat']
+        if self.single_increasing:
+            sngl_multiifo = s[1]['snglstat']
+        else:
+            sngl_multiifo = -1.0 *  s[1]['snglstat']
+        return sngl_multiifo
 
     def coinc(self, s0, s1, slide, step): # pylint:disable=unused-argument
         # scale by 1/sqrt(2) to resemble network SNR

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -1000,7 +1000,7 @@ class ExpFitCombinedSNR(ExpFitStatistic):
         if self.single_increasing:
             sngl_multiifo = s[1]['snglstat']
         else:
-            sngl_multiifo = -1.0 *  s[1]['snglstat']
+            sngl_multiifo = -1.0 * s[1]['snglstat']
         return sngl_multiifo
 
     def coinc(self, s0, s1, slide, step): # pylint:disable=unused-argument

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -996,6 +996,9 @@ class ExpFitCombinedSNR(ExpFitStatistic):
         stat = thresh - (logr_n / self.alpharef)
         return numpy.array(stat, ndmin=1, dtype=numpy.float32)
 
+    def single_multiifo(self, s):
+        return s[1]['snglstat']
+
     def coinc(self, s0, s1, slide, step): # pylint:disable=unused-argument
         # scale by 1/sqrt(2) to resemble network SNR
         return (s0 + s1) / 2.**0.5
@@ -1440,7 +1443,7 @@ class ExpFitSGFgBgNormNewStatistic(PhaseTDNewStatistic,
         network_logvol = 1.5 * numpy.log(network_sigmasq)
         benchmark_logvol = s[1]['benchmark_logvol']
         network_logvol -= benchmark_logvol
-        ln_s = (s[1]['snr'] / self.ref_snr) ** -4.0
+        ln_s = -4 * numpy.log(s[1]['snr'] / self.ref_snr)
         loglr = network_logvol - ln_noise_rate + ln_s
         # cut off underflowing and very small values
         loglr[loglr < -30.] = -30.

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -588,9 +588,7 @@ class PhaseTDNewStatistic(NewSNRStatistic):
                 within = within & (id1 > 0) & (id1 < self.c1_size[ref_ifo])
                 within = within & (id2 > 0) & (id2 < self.c2_size[ref_ifo])
                 within = numpy.where(within)[0]
-
                 rate[rtype[within]] = self.two_det_weights[ref_ifo][id0[within], id1[within], id2[within]]
-
             else:
                 # Low[er]-RAM, high[er]-CPU option for >two det
                 loc = numpy.searchsorted(self.param_bin[ref_ifo], nbinned)
@@ -904,9 +902,9 @@ class ExpFitStatistic(NewSNRStatistic):
             ifo = trigs.ifo
         except AttributeError:
             tnum = trigs['template_id']  # exists for SingleDetTriggers
-            # Should be exactly one ifo fit file provided
-            assert len(self.bg_ifos) == 1
-            ifo = self.bg_ifos[0]
+            assert len(self.ifos) == 1
+            # Should be exactly one ifo provided
+            ifo = self.ifos[0]
         # fits_by_tid is a dictionary of dictionaries of arrays
         # indexed by ifo / coefficient name / template_id
         alphai = self.fits_by_tid[ifo]['alpha'][tnum]
@@ -1442,7 +1440,8 @@ class ExpFitSGFgBgNormNewStatistic(PhaseTDNewStatistic,
         network_logvol = 1.5 * numpy.log(network_sigmasq)
         benchmark_logvol = s[1]['benchmark_logvol']
         network_logvol -= benchmark_logvol
-        loglr = network_logvol - ln_noise_rate
+        ln_s = (s[1]['snr'] / self.ref_snr) ** -4.0
+        loglr = network_logvol - ln_noise_rate + ln_s
         # cut off underflowing and very small values
         loglr[loglr < -30.] = -30.
         return loglr

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -901,7 +901,7 @@ class ExpFitStatistic(NewSNRStatistic):
             tnum = trigs.template_num  # exists if accessed via coinc_findtrigs
             ifo = trigs.ifo
         except AttributeError:
-`            tnum = trigs['template_id']  # exists for SingleDetTriggers
+            tnum = trigs['template_id']  # exists for SingleDetTriggers
             assert len(self.ifos) == 1
             # Should be exactly one ifo provided
             ifo = self.ifos[0]


### PR DESCRIPTION
Various changes for development of the multiifo singles search (this has been edited from when the PR was first put up)

Complete rework of `pycbc_multiifo_sngls_findtrigs`:
- not to use ReadByTemplate and behaves more efficiently
- Add ability to cut on SNR and reduced chisq before dealing with triggers (add other cut options?)
- Remove IFAR calculation
- Basically, this code now simply calculates the ranking statistic of triggers which meet the cuts above

New executable, `pycbc_multiifo_sngls_pastro`:
- Used after findtrigs statistic calculation
- Takes in triggers from full_data sngls_statmap files and calculate p_astro according to either callister or truncated_shelf methods
  - It is possible to give multiple files here in order to analyse multiple chunks at the same time
  - takes in single-detector statistic of injection triggers and calculates the signal distribution in order to allow the callister/truncated_shelf calculation
  - also possible to give multiple files here
  - requires hdfinjfind file to also be given in order to calculate weightings for the injection triggers
- Outputs "foreground" and "background":
  - foreground is all triggers from the sngls_statmap files
  - background contains only triggers in coincident time which are not in foreground veto time. So the background triggers are also entirely within the foreground
  - The N loudest triggers can be removed from the background using --remove-n-loudest (after cutting down to coinc time and removing foreground ttriggers). This prevents any signals from coinc time which were not seen as coincs from affecting the background estimate
    - This is something under discussion, as it removes triggers from signals in non-coinc time so may cause a bias

Change to pycbc_page_snglinfo:
- Allow a pastro file to be given in order to report a p_astro on the results pages for single triggers (not when using n_loudest, mostly because this was taking a long time to test)
- Change headings from ("Stat")  to the full name (e.g. newsnr_sgveto), and the newly calculated single-detector statistic is called "Single-detector statistic". These needed some more clarity in order to distinguish them from one another

Changes in stat.py:
 - Provide a default for single_multiifo, to use the single-detector statistic as used in the generation of the coinc statistic
 - Add in SNR ** - 4 rescaling to single-detector statistic
 - allow more than one fits file to be given when only one ifo is under consideration (means that all fits files can be given but then not necessarily used)

I envision that this will be implemented by performing an initial pastro calculation during a standard offline run, which gives a bit more info in results pages. This analysis would then be re-run using a longer period of time (e.g. a full analysis run) in order to get better background estimates and a larger number of expected signals