### PR TITLE
add precognition to pycbc live

### DIFF
--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -242,8 +242,9 @@ class LiveEventManager(object):
             live_ifos = [ifo for ifo in fud if 'snr_series' in fud[ifo]]
 
             time_offset = 0
-            if 'foreground/time_offset' in coinc_results:
-                time_offset = coinc_results['foreground/time_offset']
+            rtoff = 'foreground/{}/time_offset'.format(coinc_ifos[0])
+            if rtoff in coinc_results:
+                time_offset = coinc_results[rtoff]
             event = SingleCoincForGraceDB(live_ifos, coinc_results, bank=bank,
                                           psds=psds, followup_data=fud,
                                           low_frequency_cutoff=f_low,

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -779,6 +779,7 @@ with ctx:
     while data_end() < args.end_time:
         t1 = time()
         logging.info('%s: Analyzing from %s', evnt.rank, data_end())
+
         results = {}
         evnt.live_detectors = set()
 

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -241,20 +241,15 @@ class LiveEventManager(object):
 
             live_ifos = [ifo for ifo in fud if 'snr_series' in fud[ifo]]
 
-            time_offset = 0
-            rtoff = 'foreground/{}/time_offset'.format(coinc_ifos[0])
-            if rtoff in coinc_results:
-                time_offset = coinc_results[rtoff]
             event = SingleCoincForGraceDB(live_ifos, coinc_results, bank=bank,
                                           psds=psds, followup_data=fud,
                                           low_frequency_cutoff=f_low,
                                           channel_names=args.channel_name,
                                           mc_area_args=self.mc_area_args,
-                                          time_offset=time_offset)
+                                          )
 
-            end_time = int(coinc_results['foreground/%s/end_time'
-                                         % coinc_ifos[0]])
-            fname = 'coinc-{}-{}.xml.gz'.format(end_time + time_offset, pycbc.random_string(6))
+            fname = 'coinc-{}-{}.xml.gz'.format(event.merger_time,
+                                                pycbc.random_string(6))
             fname = os.path.join(self.path, fname)
             logging.info('Coincident candidate! Saving as %s', fname)
 
@@ -382,19 +377,14 @@ class LiveEventManager(object):
 
             live_ifos = [i for i in fud if 'snr_series' in fud[i]]
 
-            time_offset = 0
-            rtoff = 'foreground/{}/time_offset'.format(ifo)
-            if rtoff in single:
-                time_offset = single[rtoff]
             event = SingleCoincForGraceDB(live_ifos, single, bank=bank,
                                           psds=psds, followup_data=fud,
                                           low_frequency_cutoff=f_low,
                                           channel_names=args.channel_name,
                                           mc_area_args=self.mc_area_args,
-                                          time_offset=time_offset)
+                                          )
 
-            end_time = int(single['foreground/%s/end_time' % ifo])
-            fname = 'single-%s-%s.xml.gz' % (ifo, end_time + time_offset)
+            fname = 'single-%s-%s.xml.gz' % (ifo, event.merger_time)
             fname = os.path.join(self.path, fname)
             logging.info('Single-detector candidate! Saving as %s', fname)
 

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -382,14 +382,19 @@ class LiveEventManager(object):
 
             live_ifos = [i for i in fud if 'snr_series' in fud[i]]
 
+            time_offset = 0
+            rtoff = 'foreground/{}/time_offset'.format(ifo)
+            if rtoff in single:
+                time_offset = single[rtoff]
             event = SingleCoincForGraceDB(live_ifos, single, bank=bank,
                                           psds=psds, followup_data=fud,
                                           low_frequency_cutoff=f_low,
                                           channel_names=args.channel_name,
-                                          mc_area_args=self.mc_area_args)
+                                          mc_area_args=self.mc_area_args,
+                                          time_offset=time_offset)
 
             end_time = int(single['foreground/%s/end_time' % ifo])
-            fname = 'single-%s-%s.xml.gz' % (ifo, end_time)
+            fname = 'single-%s-%s.xml.gz' % (ifo, end_time + time_offset)
             fname = os.path.join(self.path, fname)
             logging.info('Single-detector candidate! Saving as %s', fname)
 

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -241,15 +241,19 @@ class LiveEventManager(object):
 
             live_ifos = [ifo for ifo in fud if 'snr_series' in fud[ifo]]
 
+            time_offset = 0
+            if 'foreground/time_offset' in coinc_results:
+                time_offset = coinc_results['foreground/time_offset']
             event = SingleCoincForGraceDB(live_ifos, coinc_results, bank=bank,
                                           psds=psds, followup_data=fud,
                                           low_frequency_cutoff=f_low,
                                           channel_names=args.channel_name,
-                                          mc_area_args=self.mc_area_args)
+                                          mc_area_args=self.mc_area_args,
+                                          time_offset=time_offset)
 
             end_time = int(coinc_results['foreground/%s/end_time'
                                          % coinc_ifos[0]])
-            fname = 'coinc-{}-{}.xml.gz'.format(end_time, pycbc.random_string(6))
+            fname = 'coinc-{}-{}.xml.gz'.format(end_time + time_offset, pycbc.random_string(6))
             fname = os.path.join(self.path, fname)
             logging.info('Coincident candidate! Saving as %s', fname)
 

--- a/pycbc/events/single.py
+++ b/pycbc/events/single.py
@@ -72,7 +72,7 @@ class LiveSingle(object):
                                  'single trigger IFAR fitting.')
         parser.add_argument('--sngl-ifar-est-dist', nargs='+',
                             default='conservative',
-                            choices=['conservative', 'mean'],
+                            choices=['conservative', 'mean', 'fixed'],
                             action=MultiDetOptionAction,
                             help='Which trigger distribution to use when '
                                  'calculating IFAR of single triggers. '
@@ -153,7 +153,7 @@ class LiveSingle(object):
 
     def calculate_ifar(self, newsnr, duration):
         if self.fit_info['fixed_ifar']:
-            return self.fit_info['fixed_ifar']
+            return self.fit_info['fixed_ifar'][self.ifo]
         dur_bin = self.fit_info['bins'][duration]
         rate = self.fit_info['rates'][dur_bin]
         coeff = self.fit_info['coeffs'][dur_bin]

--- a/pycbc/fft/mkl.py
+++ b/pycbc/fft/mkl.py
@@ -121,7 +121,7 @@ def _get_desc(fftobj):
     desc = ctypes.c_void_p(1)
     prec = mkl_prec[fftobj.invec.precision]
     domain = mkl_domain[str(fftobj.invec.kind)][str(fftobj.outvec.kind)]
-    status = _create_descr(ctypes.byref(desc), prec, domain, 1, fftobj.size)
+    status = _create_descr(ctypes.byref(desc), prec, domain, 1, int(fftobj.size))
     check_status(status)
     # Now we set various things depending on exactly what kind of transform we're
     # performing.

--- a/pycbc/fft/mkl.py
+++ b/pycbc/fft/mkl.py
@@ -121,7 +121,8 @@ def _get_desc(fftobj):
     desc = ctypes.c_void_p(1)
     prec = mkl_prec[fftobj.invec.precision]
     domain = mkl_domain[str(fftobj.invec.kind)][str(fftobj.outvec.kind)]
-    status = _create_descr(ctypes.byref(desc), prec, domain, 1, int(fftobj.size))
+    status = _create_descr(ctypes.byref(desc), prec, domain,
+                           1, int(fftobj.size))
     check_status(status)
     # Now we set various things depending on exactly what kind of transform we're
     # performing.

--- a/pycbc/filter/matchedfilter.py
+++ b/pycbc/filter/matchedfilter.py
@@ -1680,6 +1680,10 @@ class LiveBatchMatchedFilter(object):
         # Find the peaks in our SNR times series from the various templates
         i = 0
         for htilde in tgroup:
+            if hasattr(htilde, 'time_offset'):
+                if 'time_offset' not in result:
+                    result['time_offset'] = []
+        
             l = htilde.out[seg].abs_arg_max()
 
             sgm = htilde.sigmasq(psd)
@@ -1714,13 +1718,11 @@ class LiveBatchMatchedFilter(object):
 
             for key in tkeys:
                 result[key].append(htilde.dict_params[key])
-            i += 1
 
             if hasattr(htilde, 'time_offset'):
-                if 'time_offset' not in result:
-                    result['time_offset'] = []
-                    tkeys.append('time_offset')
-                results['time_offset'].append(htilde.time_offset)
+                result['time_offset'].append(htilde.time_offset)
+
+            i += 1
 
         result['snr'] = abs(snr[0:i])
         result['coa_phase'] = numpy.angle(snr[0:i])
@@ -1730,6 +1732,9 @@ class LiveBatchMatchedFilter(object):
 
         for key in tkeys:
             result[key] = numpy.array(result[key])
+
+        if 'time_offset' in result:
+            result['time_offset'] = numpy.array(result['time_offset'])
 
         return result, veto_info
 

--- a/pycbc/filter/matchedfilter.py
+++ b/pycbc/filter/matchedfilter.py
@@ -1716,6 +1716,11 @@ class LiveBatchMatchedFilter(object):
                 result[key].append(htilde.dict_params[key])
             i += 1
 
+            if hasattr(htilde, 'time_offset'):
+                if 'time_offset' not in result:
+                    result['time_offset'] = []
+                    tkeys.append('time_offset')
+                results['time_offset'].append(htilde.time_offset)
 
         result['snr'] = abs(snr[0:i])
         result['coa_phase'] = numpy.angle(snr[0:i])

--- a/pycbc/filter/matchedfilter.py
+++ b/pycbc/filter/matchedfilter.py
@@ -1683,7 +1683,7 @@ class LiveBatchMatchedFilter(object):
             if hasattr(htilde, 'time_offset'):
                 if 'time_offset' not in result:
                     result['time_offset'] = []
-        
+
             l = htilde.out[seg].abs_arg_max()
 
             sgm = htilde.sigmasq(psd)

--- a/pycbc/io/live.py
+++ b/pycbc/io/live.py
@@ -181,6 +181,8 @@ class SingleCoincForGraceDB(object):
             for name in names:
                 val = coinc_results['foreground/%s/%s' % (ifo, name)]
                 if name == 'end_time':
+                    if 'time_offset' in kwargs:
+                        val += kwargs['time_offset']
                     sngl.set_end(lal.LIGOTimeGPS(val))
                 else:
                     try:

--- a/pycbc/io/live.py
+++ b/pycbc/io/live.py
@@ -125,6 +125,10 @@ class SingleCoincForGraceDB(object):
             self.snr_series = {ifo: fud[ifo]['snr_series'] for ifo in fud}
             usable_ifos = fud.keys()
             followup_ifos = list(set(usable_ifos) - set(ifos))
+
+            if 'time_offset' in kwargs:
+                for ifo in self.snr_series:
+                    self.snr_series[ifo].start_time += kwargs['time_offset']
         else:
             self.snr_series = None
             usable_ifos = ifos

--- a/pycbc/strain/strain.py
+++ b/pycbc/strain/strain.py
@@ -1308,7 +1308,7 @@ class StrainBuffer(pycbc.frame.DataBuffer):
             filesystem.
         """
         super(StrainBuffer, self).__init__(frame_src, channel_name, start_time,
-                                           max_buffer=max_buffer,
+                                           max_buffer=32,
                                            force_update_cache=force_update_cache,
                                            increment_update_cache=increment_update_cache)
 
@@ -1374,7 +1374,7 @@ class StrainBuffer(pycbc.frame.DataBuffer):
         self.psd = None
         self.psds = {}
 
-        strain_len = int(sample_rate * self.raw_buffer.delta_t * len(self.raw_buffer))
+        strain_len = int(max_buffer * self.sample_rate)
         self.strain = TimeSeries(zeros(strain_len, dtype=numpy.float32),
                                  delta_t=1.0/self.sample_rate,
                                  epoch=start_time-max_buffer)

--- a/pycbc/waveform/bank.py
+++ b/pycbc/waveform/bank.py
@@ -585,12 +585,19 @@ class LiveFilterBank(TemplateBank):
         # include ringdown) and the duration up to merger since they will be
         # erased by the type conversion below.
         ttotal = template_duration = -1
+        time_offset = None
         if hasattr(htilde, 'length_in_time'):
             ttotal = htilde.length_in_time
         if hasattr(htilde, 'chirp_length'):
             template_duration = htilde.chirp_length
+        if hasattr(htilde, 'time_offset'):
+            time_offset = htilde.time_offset
 
         self.table[index].template_duration = template_duration
+
+        if time_offset:
+            htilde.time_offset = time_offset
+        print(time_offset)
 
         htilde = htilde.astype(np.complex64)
         htilde.f_lower = flow

--- a/pycbc/waveform/bank.py
+++ b/pycbc/waveform/bank.py
@@ -597,7 +597,6 @@ class LiveFilterBank(TemplateBank):
 
         if time_offset:
             htilde.time_offset = time_offset
-        print(time_offset)
 
         htilde = htilde.astype(np.complex64)
         htilde.f_lower = flow

--- a/pycbc/waveform/bank.py
+++ b/pycbc/waveform/bank.py
@@ -83,9 +83,9 @@ def sigma_cached(self, psd):
                 self.sigma_view = self[self.sslice].squared_norm() * 4.0 * self.delta_f
 
             if not hasattr(psd, 'invsqrt'):
-                psd.invsqrt = 1.0 / psd[self.sslice]
+                psd.invsqrt = 1.0 / psd
 
-            self._sigmasq[key] = self.sigma_view.inner(psd.invsqrt)
+            self._sigmasq[key] = self.sigma_view.inner(psd.invsqrt[self.sslice])
     return self._sigmasq[key]
 
 # dummy class needed for loading LIGOLW files

--- a/pycbc/waveform/bank.py
+++ b/pycbc/waveform/bank.py
@@ -595,9 +595,6 @@ class LiveFilterBank(TemplateBank):
 
         self.table[index].template_duration = template_duration
 
-        if time_offset:
-            htilde.time_offset = time_offset
-
         htilde = htilde.astype(np.complex64)
         htilde.f_lower = flow
         htilde.min_f_lower = self.min_f_lower
@@ -607,6 +604,9 @@ class LiveFilterBank(TemplateBank):
         htilde.length_in_time = ttotal
         htilde.approximant = approximant
         htilde.end_frequency = f_end
+
+        if time_offset:
+            htilde.time_offset = time_offset
 
         # Add sigmasq as a method of this instance
         htilde.sigmasq = types.MethodType(sigma_cached, htilde)

--- a/pycbc/waveform/bank.py
+++ b/pycbc/waveform/bank.py
@@ -398,10 +398,8 @@ class TemplateBank(object):
         """ Return the end frequency of the waveform at the given index value
         """
         from pycbc.waveform.waveform import props
-        try:
+        if hasattr(self.table[index], 'f_final'):
             return self.table[index].f_final
-        except:
-            pass
 
         return pycbc.waveform.get_waveform_end_frequency(
                                 self.table[index],

--- a/pycbc/waveform/bank.py
+++ b/pycbc/waveform/bank.py
@@ -398,6 +398,10 @@ class TemplateBank(object):
         """ Return the end frequency of the waveform at the given index value
         """
         from pycbc.waveform.waveform import props
+        try:
+            return self.table[index].f_final
+        except:
+            pass
 
         return pycbc.waveform.get_waveform_end_frequency(
                                 self.table[index],

--- a/pycbc/waveform/premerger.py
+++ b/pycbc/waveform/premerger.py
@@ -2,10 +2,12 @@
 """
 import logging
 
+
 def premerger_taylorf2(**p):
+    """ Generate time-shifted TaylorF2"""
     from pycbc.waveform import get_fd_waveform
     from pycbc.waveform.spa_tmplt import spa_length_in_time
-    
+
     p.pop('approximant')
     hp, hc = get_fd_waveform(approximant="TaylorF2", **p)
 
@@ -16,16 +18,16 @@ def premerger_taylorf2(**p):
 
     hp = hp.cyclic_time_shift(removed)
     hp.start_time += removed
-    
+
     hc = hc.cyclic_time_shift(removed)
     hc.start_time += removed
-    
-    logging.info("Generated pre-merger waveform, m1=%.1f, m2=%.1f, fmax=%.1f, timeshift=%.1f",
+
+    logging.info("PreTaylorF2, m1=%.1f, m2=%.1f, fmax=%.1f, timeshift=%.1f",
                  p['mass1'], p['mass2'], p['f_final'], removed)
     kmin = int(p['f_lower'] / p['delta_f'])
     hp[0:kmin] = 0
     hc[0:kmin] = 0
-    
+
     hp.time_offset = removed
     hc.time_offset = removed
     return hp, hc

--- a/pycbc/waveform/premerger.py
+++ b/pycbc/waveform/premerger.py
@@ -22,5 +22,11 @@ def premerger_taylorf2(**p):
     
     logging.info("Generated pre-merger waveform, m1=%.1f, m2=%.1f, fmax=%.1f, timeshift=%.1f",
                  p['mass1'], p['mass2'], p['f_final'], removed)
+    kmin = int(p['f_lower'] / p['delta_f'])
+    hp[0:kmin] = 0
+    hc[0:kmin] = 0
     
+    hp.time_offset = removed
+    hc.time_offset = removed
+    print(hp.time_offset)
     return hp, hc

--- a/pycbc/waveform/premerger.py
+++ b/pycbc/waveform/premerger.py
@@ -1,0 +1,22 @@
+""" Waveform approximants for the pre-merger detection of gravitational waves
+"""
+
+def premerger_taylorf2(**p):
+    from pycbc.waveform import get_fd_waveform
+    from pycbc.waveform.spa_tmplt import spa_length_in_time
+    
+    p.pop('approximant')
+    hp, hc = get_fd_waveform(approximant="TaylorF2", **p)
+
+    removed = spa_length_in_time(mass1=p['mass1'],
+                                 mass2=p['mass2'],
+                                 f_lower=p['f_final'],
+                                 phase_order=-1)
+
+    hp = hp.cyclic_time_shift(removed)
+    hp.start_time += removed
+    
+    hc = hc.cyclic_time_shift(removed)
+    hc.start_time += removed
+    
+    return hp, hc

--- a/pycbc/waveform/premerger.py
+++ b/pycbc/waveform/premerger.py
@@ -20,7 +20,7 @@ def premerger_taylorf2(**p):
     hc = hc.cyclic_time_shift(removed)
     hc.start_time += removed
     
-    logging.info("Generated pre-merger waveform, fmax=%s, timeshift=%s",
-                 p['f_final'], removed)
+    logging.info("Generated pre-merger waveform, m1=%.1f, m2=%.1f, fmax=%.1f, timeshift=%.1f",
+                 p['mass1'], p['mass2'], p['f_final'], removed)
     
     return hp, hc

--- a/pycbc/waveform/premerger.py
+++ b/pycbc/waveform/premerger.py
@@ -28,5 +28,4 @@ def premerger_taylorf2(**p):
     
     hp.time_offset = removed
     hc.time_offset = removed
-    print(hp.time_offset)
     return hp, hc

--- a/pycbc/waveform/premerger.py
+++ b/pycbc/waveform/premerger.py
@@ -1,5 +1,6 @@
 """ Waveform approximants for the pre-merger detection of gravitational waves
 """
+import logging
 
 def premerger_taylorf2(**p):
     from pycbc.waveform import get_fd_waveform
@@ -18,5 +19,8 @@ def premerger_taylorf2(**p):
     
     hc = hc.cyclic_time_shift(removed)
     hc.start_time += removed
+    
+    logging.info("Generated pre-merger waveform, fmax=%s, timeshift=%s",
+                 p['f_final'], removed)
     
     return hp, hc

--- a/pycbc/waveform/waveform.py
+++ b/pycbc/waveform/waveform.py
@@ -894,7 +894,7 @@ def get_waveform_filter(out, template=None, **kwargs):
 
         hp.resize(n)
         out[0:len(hp)] = hp[:]
-        hp = FrequencySeries(out, delta_f=hp.delta_f, copy=False)
+        hp.data = out
 
         hp.length_in_time = hp.chirp_length = duration
         return hp

--- a/pycbc/waveform/waveform.py
+++ b/pycbc/waveform/waveform.py
@@ -822,6 +822,7 @@ _filter_time_lengths["IMRPhenomD_NRTidal"] = imrphenomd_length_in_time
 _filter_time_lengths["IMRPhenomPv2_NRTidal"] = imrphenomd_length_in_time
 _filter_time_lengths["SpinTaylorF2"] = spa_length_in_time
 _filter_time_lengths["TaylorF2NL"] = spa_length_in_time
+_filter_time_lengths["PreTaylorF2"] = spa_length_in_time
 
 # Also add generators for switching between approximants
 apx_name = "SpinTaylorF2_SWAPPER"
@@ -830,6 +831,9 @@ _filter_time_lengths[apx_name] = _filter_time_lengths["SpinTaylorF2"]
 
 from . nltides import nonlinear_tidal_spa
 cpu_fd["TaylorF2NL"] = nonlinear_tidal_spa
+
+from .premerger import premerger_taylorf2
+cpu_fd['PreTaylorF2'] = premerger_taylorf2
 
 # Load external waveforms #####################################################
 if 'PYCBC_WAVEFORM' in os.environ:


### PR DESCRIPTION
This implements the following features to enable pre-merger detection with pycbc live

1) A new template called 'PreTaylorF2', where the 'f_final' argument is taken as the end of the waveform and the waveform is time-shifted from this point so the end is at zero.

2) Tracking of the inccurred time offset, which is propagated to the name of the coinc file and the coinc end time. I've left the other times alone as that might be better for understanding the event (i.e. the SNR is X up to that time). 

Only testing I've done so far is on 170817, which this produces trigger for as expected ~ 10 seconds before merger (which is exactly what I build a quick test bank for, so I wouldn't expect any other time). 