### PR TITLE
Changed the way  an array element is replaced based on condition

### DIFF
--- a/pycbc/filter/matchedfilter.py
+++ b/pycbc/filter/matchedfilter.py
@@ -812,9 +812,9 @@ def compute_u_val_for_sky_loc_stat_no_phase(hplus, hcross, hphccorr,
     # Initialize tan_kappa array
     u_val = denom * 0.
     # Catch the denominator -> 0 case
-    numpy.putmask(u_val, denom==0, 1E17)
+    numpy.putmask(u_val, denom == 0, 1E17)
     # Otherwise do normal statistic
-    numpy.putmask(u_val, denom!=0, (-rhoplusre+overlap*rhocrossre)/(-rhocrossre+overlap*rhoplusre))
+    numpy.putmask(u_val, denom != 0, (-rhoplusre+overlap*rhocrossre)/(-rhocrossre+overlap*rhoplusre))
     coa_phase = numpy.zeros(len(indices), dtype=numpy.float32)
 
     return u_val, coa_phase

--- a/pycbc/filter/matchedfilter.py
+++ b/pycbc/filter/matchedfilter.py
@@ -812,11 +812,9 @@ def compute_u_val_for_sky_loc_stat_no_phase(hplus, hcross, hphccorr,
     # Initialize tan_kappa array
     u_val = denom * 0.
     # Catch the denominator -> 0 case
-    bad_lgc = (denom == 0)
-    u_val[bad_lgc] = 1E17
+    numpy.putmask(u_val , denom ==0, 1E17)
     # Otherwise do normal statistic
-    u_val[~bad_lgc] = (-rhoplusre+overlap*rhocrossre) / \
-        (-rhocrossre+overlap*rhoplusre)
+    numpy.putmask(u_val , denom !=0, (-rhoplusre+overlap*rhocrossre)/(-rhocrossre+overlap*rhoplusre))
     coa_phase = numpy.zeros(len(indices), dtype=numpy.float32)
 
     return u_val, coa_phase

--- a/pycbc/filter/matchedfilter.py
+++ b/pycbc/filter/matchedfilter.py
@@ -812,9 +812,9 @@ def compute_u_val_for_sky_loc_stat_no_phase(hplus, hcross, hphccorr,
     # Initialize tan_kappa array
     u_val = denom * 0.
     # Catch the denominator -> 0 case
-    numpy.putmask(u_val , denom ==0, 1E17)
+    numpy.putmask(u_val, denom==0, 1E17)
     # Otherwise do normal statistic
-    numpy.putmask(u_val , denom !=0, (-rhoplusre+overlap*rhocrossre)/(-rhocrossre+overlap*rhoplusre))
+    numpy.putmask(u_val, denom!=0, (-rhoplusre+overlap*rhocrossre)/(-rhocrossre+overlap*rhoplusre))
     coa_phase = numpy.zeros(len(indices), dtype=numpy.float32)
 
     return u_val, coa_phase


### PR DESCRIPTION
Resolved the error: ValueError: NumPy boolean array indexing assignment cannot assign 80 input values to the 79 output values where the mask is true that was occurring in pycbc_inspiral_skymax workflow.