### PR TITLE
Pin to epsie 0.4.1 for now

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ python-ligo-lw
 # Needed for Parameter Estimation Tasks
 emcee==2.2.1
 dynesty
-epsie>=0.3
+epsie==0.4.1
 
 # For LDG service access
 dqsegdb


### PR DESCRIPTION
The current version of epsie (0.5) changes some syntax that is causing the inference travis test to break. I'm working on a proper fix, but until then, this pins the version of espie to the pervious version (0.4.1) so that travis can pass.