### PR TITLE
Undo renormalize loop in JointDistribution

### DIFF
--- a/pycbc/distributions/constraints.py
+++ b/pycbc/distributions/constraints.py
@@ -28,37 +28,15 @@ class Constraint(object):
     def __init__(self, constraint_arg, transforms=None, **kwargs):
         self.constraint_arg = constraint_arg
         self.transforms = transforms
-        self._scratch = None
         for kwarg in kwargs.keys():
             setattr(self, kwarg, kwargs[kwarg])
-
-    def _getscratch(self, params):
-        """Gets FieldArray scratch space.
-
-        FieldArray creation can be slow. This tries to speed up successive
-        calls by creating a scratch FieldArray space based on the given
-        parameters.
-        """
-        if self._scratch is None or (set(params.keys()) != 
-                                     set(self._scratch.fieldnames)):
-            self._scratch = record.FieldArray.from_kwargs(**params)
-        else:
-            for p in params:
-                try:
-                    self._scratch[p][:] = params[p]
-                except ValueError:
-                    # can happen if there is a size mismatch, just
-                    # create a new one
-                    self._scratch = record.FieldArray.from_kwargs(**params)
-                    break
-        return self._scratch
 
     def __call__(self, params):
         """Evaluates constraint.
         """
         # cast to FieldArray
         if isinstance(params, dict):
-            params = self._getscratch(params)
+            params = record.FieldArray.from_kwargs(**params)
         elif not isinstance(params, record.FieldArray):
            raise ValueError("params must be dict or FieldArray instance")
 

--- a/pycbc/distributions/constraints.py
+++ b/pycbc/distributions/constraints.py
@@ -20,23 +20,45 @@ from pycbc import transforms
 from pycbc.io import record
 
 class Constraint(object):
-    """ Creates a constraint that evaluates to True if parameters obey
+    """Creates a constraint that evaluates to True if parameters obey
     the constraint and False if they do not.
     """
     name = "custom"
-    required_parameters = []
+
     def __init__(self, constraint_arg, transforms=None, **kwargs):
         self.constraint_arg = constraint_arg
         self.transforms = transforms
+        self._scratch = None
         for kwarg in kwargs.keys():
             setattr(self, kwarg, kwargs[kwarg])
 
+    def _getscratch(self, params):
+        """Gets FieldArray scratch space.
+
+        FieldArray creation can be slow. This tries to speed up successive
+        calls by creating a scratch FieldArray space based on the given
+        parameters.
+        """
+        if self._scratch is None or (set(params.keys()) != 
+                                     set(self._scratch.fieldnames)):
+            self._scratch = record.FieldArray.from_kwargs(**params)
+        else:
+            for p in params:
+                try:
+                    self._scratch[p][:] = params[p]
+                except ValueError:
+                    # can happen if there is a size mismatch, just
+                    # create a new one
+                    self._scratch = record.FieldArray.from_kwargs(**params)
+                    break
+        return self._scratch
+
     def __call__(self, params):
-        """ Evaluates constraint.
+        """Evaluates constraint.
         """
         # cast to FieldArray
         if isinstance(params, dict):
-            params = record.FieldArray.from_kwargs(**params)
+            params = self._getscratch(params)
         elif not isinstance(params, record.FieldArray):
            raise ValueError("params must be dict or FieldArray instance")
 
@@ -59,74 +81,8 @@ class Constraint(object):
         """
         return params[self.constraint_arg]
 
-class MtotalLT(Constraint):
-    """ Pre-defined constraint that check if total mass is less than a value.
-    """
-    name = "mtotal_lt"
-    required_parameters = ["mass1", "mass2"]
-
-    def _constraint(self, params):
-        """ Evaluates constraint function.
-        """
-        return params["mass1"] + params["mass2"] < self.mtotal
-
-class CartesianSpinSpace(Constraint):
-    """ Pre-defined constraint that check if Cartesian parameters
-    are within acceptable values.
-    """
-    name = "cartesian_spin_space"
-    required_parameters = ["mass1", "mass2", "spin1x", "spin1y", "spin1z",
-                           "spin2x", "spin2y", "spin2z"]
-
-    def _constraint(self, params):
-        """ Evaluates constraint function.
-        """
-        if (params["spin1x"]**2 + params["spin1y"]**2 +
-                params["spin1z"]**2)**2 > 1:
-            return False
-        elif (params["spin2x"]**2 + params["spin2y"]**2 +
-                  params["spin2z"]**2)**2 > 1:
-            return False
-        else:
-            return True
-
-class EffectiveSpinSpace(Constraint):
-    """ Pre-defined constraint that check if effective spin parameters
-    are within acceptable values.
-    """
-    name = "effective_spin_space"
-    required_parameters = ["mass1", "mass2", "q", "xi1", "xi2",
-                           "chi_eff", "chi_a"]
-
-    def _constraint(self, params):
-        """ Evaluates constraint function.
-        """
-
-        # ensure that mass1 > mass2
-        if params["mass1"] < params["mass2"]:
-            return False
-
-        # constraint for secondary mass
-        a = ((4.0 * params["q"]**2 + 3.0 * params["q"])
-                 / (4.0 + 3.0 * params["q"]) * params["xi2"])**2
-        b = ((1.0 + params["q"]**2) / 4.0
-                 * (params["chi_eff"] + params["chi_a"])**2)
-        if a + b > 1:
-            return False
-
-        # constraint for primary mass
-        a = params["xi1"]**2
-        b = ((1.0 + params["q"])**2 / (4.0 * params["q"]**2)
-                 * (params["chi_eff"] - params["chi_a"])**2)
-        if a + b > 1:
-            return False
-
-        return True
 
 # list of all constraints
 constraints = {
     Constraint.name : Constraint,
-    MtotalLT.name : MtotalLT,
-    CartesianSpinSpace.name : CartesianSpinSpace,
-    EffectiveSpinSpace.name : EffectiveSpinSpace,
 }


### PR DESCRIPTION
The changes in PR #3214 made initializing the `JointDistribution` class incredibly slow if any constraints are used.  A renormalization constant is estimated by evaluating the constraints over 1 million points when the distribution is initialized. Previously, this was done by applying the constraints to a vector of samples. In #3214, that was changed to looping over each point, evaluating the constraints one point at a time. This has made initializing the joint distribution go from taking less than a second, to several minutes, if not hours, if any constraints are used. This makes using constraints in PE jobs or when creating injections virtually impossible.

This patch fixes that by going back to evaluating the constraints on the vector of samples (see lines 122-124 of `distributions/joint.py` in this patch). The joint distribution now initializes in under a second with constraints included.

The basic issue that @dbkeitel  pointed out in #3214  was that many of the distributions are not vectorized. This is still an issue that should be fixed. However, the custom constraint class was vectorized as long as the function passed to it as the constraint arg was. The example constraint function in the `JointDistribution` docs is not, which led to the `ValueError` that @dbkeitel described in #3214. The fix for the example function is that it should just return `params['mass1'] + params['mass2'] < 30.` rather than `True if params['mass1'] + params['mass2'] < 30. else False`. I've updated the doc string to reflect this.

The other constraint classes in `distributions/constraints.py` are not vectorized, which would lead to a `ValueError` if they are passed to the `JointDistribution` with the changes in this patch. However, those classes really aren't used for anything. They also have awkward initialization syntax (you need to pass them a `constraint_arg` since they inherit from the `Constraint`, but that isn't used for anything) as they had been written prior to when the custom constraint class was introduced. The custom constraint class is really the only thing that's used, so I've removed the other classes. If someone wants to reintroduce more complicated constraints that would require a class, they can do so in the future.