### PR TITLE
Update pegasus template for 'local' site 

### DIFF
--- a/pycbc/workflow/pegasus_files/local-site-template.xml
+++ b/pycbc/workflow/pegasus_files/local-site-template.xml
@@ -13,3 +13,4 @@
     <profile namespace="condor" key="when_to_transfer_output">ON_EXIT_OR_EVICT</profile>
     <profile namespace="condor" key="+DESIRED_Sites">&quot;nogrid&quot;</profile>
     <profile namespace="condor" key="+IS_GLIDEIN">&quot;False&quot;</profile>
+    <profile namespace="condor" key="+flock_local">True</profile>


### PR DESCRIPTION
There will shortly be changes to some LDG HTCondor configurations where jobs will no longer match to the local pool (even if the grid site is 'nogrid' and `+IS_GLIDEIN` is `False`) unless they also set `+flock_local = True` in their submit files.  This PR makes the necessary change. It should be safe to use even on sites that do not have that requirement, as they will ignore the setting of that optional condor variable.

@spxiwh @GarethDaviesGW This change will likely be needed during at least some of the upcoming offline runs, so in relatively short order it should be incorporated into a release.  But it can wait on any other changes that might be needed if there will be another point release before the production runs start.  Otherwise, we will probably need a point release just for this.

