### PR TITLE
Allow different burn-in iteration and ACL for independent MCMC chains

### DIFF
--- a/bin/inference/pycbc_inference_plot_acl
+++ b/bin/inference/pycbc_inference_plot_acl
@@ -78,14 +78,11 @@ for param_name in parameters:
     logging.info("Plotting autocorrelation times")
     plt.hist(acls, opts.bins, histtype="step", label=labels[param_name])
 
-# get the file's acl
-fpacl = fp.thinned_by * fp[fp.sampler_group].attrs['acl']
-
 plt.xlabel("Autocorrelation time")
 plt.ylabel(r'Number of walkers')
 
-# plot autocorrelation length saved in hdf file
-plt.axvline(fpacl, linestyle='--')
+# plot autocorrelation time saved in hdf file
+plt.axvline(fp.act, linestyle='--')
 plt.legend()
 
 # save figure with meta-data

--- a/pycbc/inference/burn_in.py
+++ b/pycbc/inference/burn_in.py
@@ -533,6 +533,7 @@ class MCMCBurnInTests(BaseBurnInTests):
         """Runs all of the burn-in tests."""
         # evaluate all the tests
         for tst in self.do_tests:
+            logging.info("Evaluating %s burn-in test", tst)
             getattr(self, tst)(filename)
         # evaluate each chain at a time
         for ci in range(self.nchains):
@@ -725,6 +726,7 @@ class EnsembleMCMCBurnInTests(BaseBurnInTests):
         """Runs all of the burn-in tests."""
         # evaluate all the tests
         for tst in self.do_tests:
+            logging.info("Evaluating %s burn-in test", tst)
             getattr(self, tst)(filename)
         is_burned_in, burn_in_iter = evaluate_tests(
             self.burn_in_test, self.test_is_burned_in,

--- a/pycbc/inference/burn_in.py
+++ b/pycbc/inference/burn_in.py
@@ -355,6 +355,27 @@ class BaseBurnInTests(object):
             self.sampler.raw_acls = acls
         return acls
 
+    def _getaux(test):
+        """Convenience function for getting auxilary information.
+
+        Parameters
+        ----------
+        test : str
+            The name of the test to retrieve auxilary information about.
+
+        Returns
+        -------
+        dict
+            The ``test_aux_info[test]`` dictionary. If a dictionary does
+            not exist yet for the given test, an empty dictionary will be
+            created and saved to ``test_aux_info[test]``.
+        """
+        try:
+            aux = self.test_aux_info[test]
+        except KeyError:
+            aux = self.test_aux_info[test] = {}
+        return aux
+
     def halfchain(self, filename):
         """Just uses half the chain as the burn-in iteration.
         """
@@ -645,10 +666,7 @@ class EnsembleMCMCBurnInTests(BaseBurnInTests):
         test = 'max_posterior'
         self.test_is_burned_in[test] = all_burned_in
         self.test_burn_in_iteration[test] = burn_in_iter 
-        try:
-            aux = self.test_aux_info[test]
-        except KeyError:
-            self.test_aux_info[test] = aux = {}
+        aux = self._getaux(test)
         # additional info
         aux['iteration_per_walker'] = self._index2iter(filename, burn_in_idx)
         aux['status_per_walker'] = is_burned_in
@@ -665,10 +683,7 @@ class EnsembleMCMCBurnInTests(BaseBurnInTests):
         self.test_is_burned_in[test] = True
         self.test_burn_in_iteration[test] = burn_in_iters.max()
         # store the iteration per walker as additional info
-        try:
-            aux = self.test_aux_info[test]
-        except KeyError:
-            self.test_aux_info[test] = aux = {}
+        aux = self._getaux(test)
         aux['iteration_per_walker'] = burn_in_iters
 
     def nacl(self, filename):
@@ -686,10 +701,7 @@ class EnsembleMCMCBurnInTests(BaseBurnInTests):
         self.test_is_burned_in[test] = all_burned_in
         self.test_burn_in_iteration[test] = burn_in_iter
         # store the status per parameter as additional info
-        try:
-            aux = self.test_aux_info[test]
-        except KeyError:
-            self.test_aux_info[test] = aux = {}
+        aux = self._getaux(test)
         aux['status_per_parameter'] = is_burned_in
 
     def ks_test(self, filename):
@@ -716,10 +728,7 @@ class EnsembleMCMCBurnInTests(BaseBurnInTests):
         self.test_is_burned_in[test] = is_burned_in
         self.test_burn_in_iteration[test] = burn_in_iter
         # store the test per parameter as additional info
-        try:
-            aux = self.test_aux_info[test]
-        except KeyError:
-            self.test_aux_info[test] = aux = {}
+        aux = self._getaux(test)
         aux['status_per_parameter'] = is_the_same
 
     def evaluate(self, filename):

--- a/pycbc/inference/burn_in.py
+++ b/pycbc/inference/burn_in.py
@@ -253,6 +253,8 @@ class BaseBurnInTests(object):
                        'posterior_step', 'nacl',
                        )
 
+    # pylint: disable=unnecessary-pass
+
     def __init__(self, sampler, burn_in_test, **kwargs):
         self.sampler = sampler
         # determine the burn-in tests that are going to be done

--- a/pycbc/inference/burn_in.py
+++ b/pycbc/inference/burn_in.py
@@ -29,8 +29,8 @@ have burned in.
 from __future__ import division
 
 import logging
-from six import add_metaclass
 from abc import ABCMeta, abstractmethod
+from six import add_metaclass
 import numpy
 from scipy.stats import ks_2samp
 

--- a/pycbc/inference/burn_in.py
+++ b/pycbc/inference/burn_in.py
@@ -274,7 +274,7 @@ class BaseBurnInTests(object):
     @abstractmethod
     def burn_in_index(self, filename):
         """The burn in index (retrieved from the iteration).
-        
+
         This is an abstract method because how this is evaluated depends on
         if this is an ensemble MCMC or not.
         """
@@ -395,7 +395,7 @@ class BaseBurnInTests(object):
             burn_in_iter = self._min_iterations
         else:
             burn_in_iter = NOT_BURNED_IN_ITER
-        self.test_is_burned_in['min_iterations'] = is_burned_in 
+        self.test_is_burned_in['min_iterations'] = is_burned_in
         self.test_burn_in_iteration['min_iterations'] = burn_in_iter
 
     @abstractmethod
@@ -478,7 +478,7 @@ class BaseBurnInTests(object):
 
 class MCMCBurnInTests(BaseBurnInTests):
     """Burn-in tests for collections of independent MCMC chains.
-    
+
     This differs from EnsembleMCMCBurnInTests in that chains are treated as
     being independent of each other. The ``is_burned_in`` attribute will be
     True if `any` chain passes the burn in tests (whereas in MCMCBurnInTests,
@@ -665,7 +665,7 @@ class EnsembleMCMCBurnInTests(BaseBurnInTests):
         # store
         test = 'max_posterior'
         self.test_is_burned_in[test] = all_burned_in
-        self.test_burn_in_iteration[test] = burn_in_iter 
+        self.test_burn_in_iteration[test] = burn_in_iter
         aux = self._getaux(test)
         # additional info
         aux['iteration_per_walker'] = self._index2iter(filename, burn_in_idx)
@@ -785,7 +785,7 @@ class EnsembleMultiTemperedMCMCBurnInTests(EnsembleMCMCBurnInTests):
         ``posterior_step`` function.
         """
         return _multitemper_getlogposts(self.sampler, filename)
- 
+
 
 def _multitemper_getlogposts(sampler, filename):
     """Retrieve log posteriors for multi tempered samplers."""

--- a/pycbc/inference/burn_in.py
+++ b/pycbc/inference/burn_in.py
@@ -537,7 +537,8 @@ class MCMCBurnInTests(BaseBurnInTests):
         acls = self._getacls(filename, start_index=nsamples//2)
         is_burned_in = nacl(nsamples, acls, self._nacls)
         # stack the burn in results into an nparams x nchains array
-        burn_in_per_chain = numpy.stack(is_burned_in.values()).all(axis=0)
+        burn_in_per_chain = numpy.stack(list(is_burned_in.values())).all(
+            axis=0)
         # store
         test = 'nacl'
         self.test_is_burned_in[test] = burn_in_per_chain

--- a/pycbc/inference/io/base_hdf.py
+++ b/pycbc/inference/io/base_hdf.py
@@ -347,69 +347,25 @@ class BaseInferenceFile(h5py.File):
     def thin_start(self):
         """The default start index to use when reading samples.
 
-        This tries to read from ``thin_start`` in the ``attrs``. If it isn't
-        there, just returns 0."""
-        try:
-            return self.attrs['thin_start']
-        except KeyError:
-            return 0
-
-    @thin_start.setter
-    def thin_start(self, thin_start):
-        """Sets the thin start attribute.
-
-        Parameters
-        ----------
-        thin_start : int or None
-            Value to set the thin start to.
+        Unless overridden by sub-class attribute, just returns 0.
         """
-        self.attrs['thin_start'] = thin_start
+        return 0
 
     @property
     def thin_interval(self):
         """The default interval to use when reading samples.
 
-        This tries to read from ``thin_interval`` in the ``attrs``. If it
-        isn't there, just returns 1.
+        Unless overridden by sub-class attribute, just returns 1.
         """
-        try:
-            return self.attrs['thin_interval']
-        except KeyError:
-            return 1
-
-    @thin_interval.setter
-    def thin_interval(self, thin_interval):
-        """Sets the thin start attribute.
-
-        Parameters
-        ----------
-        thin_interval : int or None
-            Value to set the thin interval to.
-        """
-        self.attrs['thin_interval'] = thin_interval
+        return 1
 
     @property
     def thin_end(self):
         """The defaut end index to use when reading samples.
 
-        This tries to read from ``thin_end`` in the ``attrs``. If it isn't
-        there, just returns None.
+        Unless overriden by sub-class attribute, just return ``None``.
         """
-        try:
-            return self.attrs['thin_end']
-        except KeyError:
-            return None
-
-    @thin_end.setter
-    def thin_end(self, thin_end):
-        """Sets the thin end attribute.
-
-        Parameters
-        ----------
-        thin_end : int or None
-            Value to set the thin end to.
-        """
-        self.attrs['thin_end'] = thin_end
+        return None
 
     @property
     def cmd(self):

--- a/pycbc/inference/io/base_hdf.py
+++ b/pycbc/inference/io/base_hdf.py
@@ -571,37 +571,29 @@ class BaseInferenceFile(h5py.File):
             previous = []
         self.attrs["cmd"] = cmd + previous
 
-    def get_slice(self, thin_start=None, thin_interval=None, thin_end=None):
-        """Formats a slice using the given arguments that can be used to
-        retrieve a thinned array from an InferenceFile.
+    @staticmethod
+    def get_slice(thin_start=None, thin_interval=None, thin_end=None):
+        """Formats a slice to retrieve a thinned array from an HDF file.
 
         Parameters
         ----------
-        thin_start : int, optional
-            The starting index to use. If None, will use the ``thin_start``
-            attribute.
-        thin_interval : int, optional
-            The interval to use. If None, will use the ``thin_interval``
-            attribute.
-        thin_end : int, optional
-            The end index to use. If None, will use the ``thin_end`` attribute.
+        thin_start : float or int, optional
+            The starting index to use. If provided, the ``int`` will be taken.
+        thin_interval : float or int, optional
+            The interval to use. If provided the ceiling of it will be taken.
+        thin_end : float or int, optional
+            The end index to use. If provided, the ``int`` will be taken.
 
         Returns
         -------
         slice :
             The slice needed.
         """
-        if thin_start is None:
-            thin_start = int(self.thin_start)
-        else:
+        if thin_start is not None:
             thin_start = int(thin_start)
-        if thin_interval is None:
-            thin_interval = self.thin_interval
-        else:
+        if thin_interval is not None:
             thin_interval = int(numpy.ceil(thin_interval))
-        if thin_end is None:
-            thin_end = self.thin_end
-        else:
+        if thin_end is not None:
             thin_end = int(thin_end)
         return slice(thin_start, thin_end, thin_interval)
 

--- a/pycbc/inference/io/base_hdf.py
+++ b/pycbc/inference/io/base_hdf.py
@@ -811,3 +811,38 @@ class BaseInferenceFile(h5py.File):
                 cls.write_kwargs_to_attrs(attrs, **val)
             else:
                 attrs[arg] = val
+
+    def write_data(self, name, data, path=None):
+        """Writes data as either a dataset or an attr.
+
+        If the given data is a numpy array or list, the data will be written
+        as a dataset. Otherwise, the data is written to the attrs using
+        :py:func:`write_kwargs_to_attrs`. When writing the data as a dataset,
+        it is assumed that the data has the same size everytime.
+
+        Parameters
+        ----------
+        name : str
+            The name to associate with the data. This will be the dataset
+            name (if data is array-like) or the key in the attrs.
+        data : object
+            The data to write. Can be of any arbitrary type.
+        path : str, optional
+            Write to the given path. Default (None) will write to the top
+            level.
+        """
+        if path is None:
+            path = '/'
+        group = self[path]
+        if isinstance(data, (numpy.ndarray, list)):
+            # write arrays as datasets
+            # Note: this assumes that the data always has the
+            # same shape.
+            try:
+                group[name][:] = data
+            except KeyError:
+                # dataset doesn't exist yet
+                group[name] = data
+        else:
+            # write all other data as attrs
+            self.write_kwargs_to_attrs(group.attrs, **{name: data})

--- a/pycbc/inference/io/base_hdf.py
+++ b/pycbc/inference/io/base_hdf.py
@@ -761,12 +761,13 @@ class BaseInferenceFile(h5py.File):
                 attrs[arg] = val
 
     def write_data(self, name, data, path=None):
-        """Writes data as either a dataset or an attr.
+        """Convenience function to write data.
 
-        If the given data is a numpy array or list, the data will be written
-        as a dataset. Otherwise, the data is written to the attrs using
-        :py:func:`write_kwargs_to_attrs`. When writing the data as a dataset,
-        it is assumed that the data has the same size everytime.
+        Given ``data`` is written as a dataset with ``name`` in ``path``.
+        If the data hasn't been written yet, the dataset will be created.
+        Otherwise, will overwrite the data that is there. If data already
+        exists in the file with the same name and path, the given data must
+        have the same shape.
 
         Parameters
         ----------
@@ -782,15 +783,8 @@ class BaseInferenceFile(h5py.File):
         if path is None:
             path = '/'
         group = self[path]
-        if isinstance(data, (numpy.ndarray, list)):
-            # write arrays as datasets
-            # Note: this assumes that the data always has the
-            # same shape.
-            try:
-                group[name][:] = data
-            except KeyError:
-                # dataset doesn't exist yet
-                group[name] = data
-        else:
-            # write all other data as attrs
-            self.write_kwargs_to_attrs(group.attrs, **{name: data})
+        try:
+            group[name][()] = data
+        except KeyError:
+            # dataset doesn't exist yet
+            group[name] = data

--- a/pycbc/inference/io/base_mcmc.py
+++ b/pycbc/inference/io/base_mcmc.py
@@ -724,13 +724,9 @@ def _get_index(fp, chains, thin_start=None, thin_interval=None, thin_end=None,
     -------
     get_index : list of slice or int
         The indices to retrieve.
-    maxiters : int
-        The maximum number of samples from a single chain that will be
-        retrieved.
     """
     nchains = len(chains)
     if iteration is not None:
-        maxiters = 1
         get_index = [int(iteration)]*nchains
     else:
         if thin_start is None:
@@ -745,22 +741,12 @@ def _get_index(fp, chains, thin_start=None, thin_interval=None, thin_end=None,
             thin_end = fp.thin_end
         if not isinstance(thin_end, (numpy.ndarray, list)):
             thin_end = numpy.repeat(thin_end, nchains)
-        # figure out the maximum number of samples we will get from all chains
-        start_iter = thin_start * fp.thinned_by
-        iter_interval = thin_interval * fp.thinned_by
-        try:
-            end_iter = thin_end * fp.thinned_by
-        except TypeError:
-            # will get this if thin end is None; in that case, we'll just be
-            # loading all the way to the end
-            end_iter = fp.niterations
-        maxiters = nsamples_in_chain(start_iter, iter_interval, end_iter).max()
         # the slices to use for each chain
         get_index = [fp.get_slice(thin_start=thin_start[ci],
                                   thin_interval=thin_interval[ci],
                                   thin_end=thin_end[ci])
                      for ci in chains]
-    return get_index, maxiters
+    return get_index
 
 
 def thin_samples_for_writing(fp, samples, parameters, last_iteration,

--- a/pycbc/inference/io/base_mcmc.py
+++ b/pycbc/inference/io/base_mcmc.py
@@ -200,7 +200,7 @@ class CommonMCMCMetadataIO(object):
         self.attrs['sampler'] = sampler.name
         try:
             self[self.sampler_group].attrs['nchains'] = sampler.nchains
-        except AttributeError:
+        except ValueError:
             self[self.sampler_group].attrs['nwalkers'] = sampler.nwalkers
         # write the model's metadata
         sampler.model.write_metadata(self)

--- a/pycbc/inference/io/base_mcmc.py
+++ b/pycbc/inference/io/base_mcmc.py
@@ -286,6 +286,20 @@ class CommonMCMCMetadataIO(object):
         for param in acls:
             self.write_data(param, acls[param], path=path)
 
+    def write_acls(self, acl, raw_acls):
+        """Writes both the acl and raw acls.
+        
+        Parameters
+        ----------
+        acl : array or int
+            The autocorrelation length. See the ``acl`` attribute for details.
+        raw_acls : dict
+            Dictionary of parameter names -> acls. See the ``raw_acls``
+            attribute for details.
+        """
+        self.acl = acl
+        self.raw_acls = raw_acls
+
     @staticmethod
     def extra_args_parser(parser=None, skip_args=None, **kwargs):
         """Create a parser to parse sampler-specific arguments for loading

--- a/pycbc/inference/io/base_mcmc.py
+++ b/pycbc/inference/io/base_mcmc.py
@@ -133,12 +133,18 @@ class CommonMCMCMetadataIO(object):
         self._thin_data(self.samples_group, params, new_interval)
         # store the interval that samples were thinned by
         self.thinned_by = thin_interval
-        # If a default thin interval and thin start exist, reduce them by the
-        # thinned interval. If the thin interval is not an integer multiple
+        # If acls exist, it by the thinned
+        # interval. If the thin interval is not an integer multiple
         # of the original, we'll round up, to avoid getting samples from
-        # before the burn in / at an interval less than the ACL.
-        self.thin_start = int(numpy.ceil(self.thin_start/new_interval))
-        self.thin_interval = int(numpy.ceil(self.thin_interval/new_interval))
+        # at an interval less than the ACL.
+        try:
+            acls = self.raw_acls
+        except ValueError:
+            acls = None
+        if acls is not None:
+            acls = {p: numpy.ceil(acls[p]/new_interval).astype(int)
+                    for p in acls}
+            self.raw_acls = acls
 
     @property
     def thinned_by(self):

--- a/pycbc/inference/io/base_mcmc.py
+++ b/pycbc/inference/io/base_mcmc.py
@@ -428,6 +428,7 @@ class MCMCMetadataIO(object):
         chains return no samples. If no burn-in tests were done, returns 0
         for all chains.
         """
+        # pylint: disable=no-member
         try:
             thin_start = self.burn_in_index
             # replace any that have not been burned in with the number
@@ -793,12 +794,12 @@ def _format_slice_arg(value, default, chains):
     if value is None and default is None:
         # no value provided, and default is None, just return Nones with the
         # same length as chains
-        return [None]*len(chains)
+        value = [None]*len(chains)
     elif value is None:
         # use the default, with the desired values extracted
         value = default[chains]
     elif isinstance(value, (int, numpy.int_)):
-        # a single integer was provided, repeat into an array 
+        # a single integer was provided, repeat into an array
         value = numpy.repeat(value, len(chains))
     elif len(value) != len(chains):
         # a list of values was provided, but the length does not match the

--- a/pycbc/inference/io/base_mcmc.py
+++ b/pycbc/inference/io/base_mcmc.py
@@ -460,7 +460,6 @@ class EnsembleMCMCMetadataIO(object):
             return 1
 
 
-
 def write_samples(fp, samples, parameters=None, last_iteration=None,
                   samples_group=None, thin_by=None):
     """Writes samples to the given file.
@@ -689,3 +688,42 @@ def thin_samples_for_writing(fp, samples, parameters, last_iteration,
     else:
         thinned_samples = samples
     return thinned_samples
+
+
+def nsamples_in_chain(start_iter, interval, niterations):
+    """Calculates the number of samples in an MCMC chain given a thinning
+    start, end, and interval.
+
+    This function will work with either python scalars, or numpy arrays.
+
+    Parameters
+    ----------
+    start_iter : (array of) int
+        Start iteration. If negative, will count as being how many iterations
+        to start before the end; otherwise, counts how many iterations to
+        start before the beginning. If this is larger than niterations, will
+        just return 0.
+    interval : (array of) int
+        Thinning interval.
+    niterations : (array of) int
+        The number of iterations.
+
+    Returns
+    -------
+    numpy.int_
+        The number of samples in a chain, >= 0.
+    """
+    # this is written in a slightly wonky way so that it will work with either
+    # python scalars or numpy arrays; it is equivalent to:
+    #    if start_iter < 0:
+    #        count = min(abs(start_iter), niterations)
+    #    else:
+    #        count = max(niterations - start_iter, 0)
+    slt0 = start_iter < 0
+    sgt0 = start_iter >= 0
+    count = slt0*abs(start_iter) + sgt0*(niterations - start_iter)
+    # ensure count is in [0, niterations]
+    cgtn = count > niterations
+    cok = (count >= 0) & (count <= niterations)
+    count = cgtn*niterations + cok*count
+    return numpy.ceil(count / interval).astype(int)

--- a/pycbc/inference/io/base_mcmc.py
+++ b/pycbc/inference/io/base_mcmc.py
@@ -460,9 +460,8 @@ class EnsembleMCMCMetadataIO(object):
             return 1
 
 
-def single_temp_write_samples(fp, samples, parameters=None,
-                              last_iteration=None,
-                              samples_group=None, thin_by=None):
+def write_samples(fp, samples, parameters=None, last_iteration=None,
+                  samples_group=None, thin_by=None):
     """Writes samples to the given file.
 
     This works for both standard MCMC and ensemble MCMC samplers without

--- a/pycbc/inference/io/base_mcmc.py
+++ b/pycbc/inference/io/base_mcmc.py
@@ -226,24 +226,6 @@ class MCMCMetadataIO(object):
         group = self[self.sampler_group]['acls']
         return {param: group[param].value for param in group.keys()}
 
-    def write_burn_in(self, burn_in):
-        """Write the given burn-in data to the given filename."""
-        group = self[self.sampler_group]
-        group.attrs['burn_in_test'] = burn_in.burn_in_test
-        group.attrs['is_burned_in'] = burn_in.is_burned_in
-        group.attrs['burn_in_iteration'] = burn_in.burn_in_iteration
-        # set the defaut thin_start to be the burn_in_index
-        self.thin_start = burn_in.burn_in_index
-        # write individual test data
-        for tst in burn_in.burn_in_data:
-            key = 'burn_in_tests/{}'.format(tst)
-            try:
-                attrs = group[key].attrs
-            except KeyError:
-                group.create_group(key)
-                attrs = group[key].attrs
-            self.write_kwargs_to_attrs(attrs, **burn_in.burn_in_data[tst])
-
     @staticmethod
     def extra_args_parser(parser=None, skip_args=None, **kwargs):
         """Create a parser to parse sampler-specific arguments for loading

--- a/pycbc/inference/io/base_mcmc.py
+++ b/pycbc/inference/io/base_mcmc.py
@@ -264,6 +264,15 @@ class CommonMCMCMetadataIO(object):
         self.write_data('acl', acl, path=self.sampler_group)
 
     @property
+    def act(self):
+        """Returns the autocorrelation time.
+
+        This is the ACL times the file's thinned by. Raises a ``ValueError``
+        if the ACL has not been calculated.
+        """
+        return self.acl * self.thinned_by
+
+    @property
     def raw_acls(self):
         """Dictionary of parameter names -> raw autocorrelation length(s).
 

--- a/pycbc/inference/io/base_mcmc.py
+++ b/pycbc/inference/io/base_mcmc.py
@@ -249,7 +249,7 @@ class CommonMCMCMetadataIO(object):
         acl : array or int
             ACL(s) to write.
         """
-        # pylint disable=no-member
+        # pylint: disable=no-member
         self.write_data('acl', acl, path=self.sampler_group)
 
     @property
@@ -264,7 +264,7 @@ class CommonMCMCMetadataIO(object):
         try:
             group = self[self.samper_group]['raw_acls']
         except KeyError:
-            raise ValueError("ACLs have not been calculated") 
+            raise ValueError("ACLs have not been calculated")
         acls = {}
         for param in group:
             acls[param] = group[param][()]
@@ -522,9 +522,9 @@ def write_samples(fp, samples, parameters=None, last_iteration=None,
             istart = 0
             istop = istart + data.shape[1]
             fp.create_dataset(dataset_name, (nwalkers, istop),
-                                maxshape=(nwalkers, None),
-                                dtype=data.dtype,
-                                fletcher32=True)
+                              maxshape=(nwalkers, None),
+                              dtype=data.dtype,
+                              fletcher32=True)
         fp[dataset_name][:, istart:istop] = data
 
 
@@ -715,8 +715,8 @@ def _get_index(fp, chains, thin_start=None, thin_interval=None, thin_end=None,
         maxiters = nsamples_in_chain(thin_start, thin_interval, thin_end).max()
         # the slices to use for each chain
         get_index = [fp.get_slice(thin_start=thin_start[ci],
-                                    thin_interval=thin_interval[ci],
-                                    thin_end=thin_end[ci])
+                                  thin_interval=thin_interval[ci],
+                                  thin_end=thin_end[ci])
                      for ci in chains]
     return get_index, maxiters
 

--- a/pycbc/inference/io/base_mcmc.py
+++ b/pycbc/inference/io/base_mcmc.py
@@ -460,6 +460,7 @@ class EnsembleMCMCMetadataIO(object):
             return 1
 
 
+
 def write_samples(fp, samples, parameters=None, last_iteration=None,
                   samples_group=None, thin_by=None):
     """Writes samples to the given file.
@@ -599,9 +600,15 @@ def ensemble_read_raw_samples(fp, fields, thin_start=None,
         get_index = int(iteration)
         niterations = 1
     else:
+        if thin_start is None:
+            thin_start = fp.thin_start
+        if thin_interval is None:
+            thin_interval = fp.thin_interval
+        if thin_end is None:
+            thin_end = fp.thin_end
         get_index = fp.get_slice(thin_start=thin_start,
-                                   thin_end=thin_end,
-                                   thin_interval=thin_interval)
+                                 thin_interval=thin_interval,
+                                 thin_end=thin_end)
         # we'll just get the number of iterations from the returned shape
         niterations = None
     # load

--- a/pycbc/inference/io/base_mcmc.py
+++ b/pycbc/inference/io/base_mcmc.py
@@ -65,7 +65,7 @@ class CommonMCMCMetadataIO(object):
     @property
     def nwalkers(self):
         """Returns the number of walkers used by the sampler.
-        
+
         Alias of ``nchains``.
         """
         try:
@@ -76,7 +76,7 @@ class CommonMCMCMetadataIO(object):
     @property
     def nchains(self):
         """Returns the number of chains used by the sampler.
-        
+
         Alias of ``nwalkers``.
         """
         try:
@@ -208,7 +208,7 @@ class CommonMCMCMetadataIO(object):
     @property
     def burn_in_iteration(self):
         """Returns the burn in iteration of all the chains.
-        
+
         Raises a ``ValueError`` if no burn in tests were done.
         """
         try:
@@ -219,7 +219,7 @@ class CommonMCMCMetadataIO(object):
     @property
     def burn_in_index(self):
         """Returns the burn in index.
-        
+
         This is the burn in iteration divided by the file's ``thinned_by``.
         Requires the class that this is used with has a ``burn_in_iteration``
         attribute.
@@ -229,7 +229,7 @@ class CommonMCMCMetadataIO(object):
     @property
     def acl(self):
         """Returns the ACL.
-        
+
         Raises a ``ValueError`` if the ACL has not been calculated.
         """
         try:
@@ -249,6 +249,7 @@ class CommonMCMCMetadataIO(object):
         acl : array or int
             ACL(s) to write.
         """
+        # pylint disable=no-member
         self.write_data('acl', acl, path=self.sampler_group)
 
     @property
@@ -288,7 +289,7 @@ class CommonMCMCMetadataIO(object):
 
     def write_acls(self, acl, raw_acls):
         """Writes both the acl and raw acls.
-        
+
         Parameters
         ----------
         acl : array or int
@@ -437,9 +438,10 @@ class EnsembleMCMCMetadataIO(object):
         except ValueError:
             acl = 1
         if numpy.isfinite(acl):
-            return int(numpy.ceil(acl))
+            acl = int(numpy.ceil(acl))
         else:
-            return 1
+            acl = 1
+        return acl
 
 
 def write_samples(fp, samples, parameters=None, last_iteration=None,
@@ -466,7 +468,7 @@ def write_samples(fp, samples, parameters=None, last_iteration=None,
     -----------
     fp : BaseInferenceFile
         Open file handler to write files to. Must be an instance of
-        BaseInferenceFile with CommonMCMCMetadataIO methods added. 
+        BaseInferenceFile with CommonMCMCMetadataIO methods added.
     samples : dict
         The samples to write. Each array in the dictionary should have
         shape nwalkers x niterations.
@@ -537,7 +539,7 @@ def ensemble_read_raw_samples(fp, fields, thin_start=None,
     -----------
     fp : BaseInferenceFile
         Open file handler to write files to. Must be an instance of
-        BaseInferenceFile with EnsembleMCMCMetadataIO methods added. 
+        BaseInferenceFile with EnsembleMCMCMetadataIO methods added.
     fields : list
         The list of field names to retrieve.
     thin_start : int, optional
@@ -597,7 +599,7 @@ def _ensemble_get_walker_index(fp, walkers=None):
     ----------
     fp : BaseInferenceFile
         Open file handler to write files to. Must be an instance of
-        BaseInferenceFile with EnsembleMCMCMetadataIO methods added. 
+        BaseInferenceFile with EnsembleMCMCMetadataIO methods added.
     walkers : (list of) int, optional
         Only read from the given walkers. Default (``None``) is to read all.
 
@@ -626,7 +628,7 @@ def _ensemble_get_index(fp, thin_start=None, thin_interval=None, thin_end=None,
     -----------
     fp : BaseInferenceFile
         Open file handler to write files to. Must be an instance of
-        BaseInferenceFile with EnsembleMCMCMetadataIO methods added. 
+        BaseInferenceFile with EnsembleMCMCMetadataIO methods added.
     thin_start : int, optional
         Start reading from the given iteration. Default is to start from
         the first iteration.
@@ -656,10 +658,10 @@ def _ensemble_get_index(fp, thin_start=None, thin_interval=None, thin_end=None,
         get_index = fp.get_slice(thin_start=thin_start,
                                  thin_interval=thin_interval,
                                  thin_end=thin_end)
-    return get_index, niterations
+    return get_index
 
 
-def _get_index(fp, nchains, thin_start=None, thin_interval=None, thin_end=None,
+def _get_index(fp, chains, thin_start=None, thin_interval=None, thin_end=None,
                iteration=None):
     """Determines the sample indices to retrieve for an MCMC with independent
     chains.
@@ -668,9 +670,9 @@ def _get_index(fp, nchains, thin_start=None, thin_interval=None, thin_end=None,
     -----------
     fp : BaseInferenceFile
         Open file handler to write files to. Must be an instance of
-        BaseInferenceFile with EnsembleMCMCMetadataIO methods added. 
-    nchains : int
-        The number of chains that will be loaded.
+        BaseInferenceFile with EnsembleMCMCMetadataIO methods added.
+    chains : array of int
+        The chains to load.
     thin_start : int, optional
         Start reading from the given iteration. Default is to start from
         the first iteration.
@@ -691,6 +693,7 @@ def _get_index(fp, nchains, thin_start=None, thin_interval=None, thin_end=None,
         The maximum number of samples from a single chain that will be
         retrieved.
     """
+    nchains = len(chains)
     if iteration is not None:
         maxiters = 1
         get_index = [int(iteration)]*nchains

--- a/pycbc/inference/io/base_mcmc.py
+++ b/pycbc/inference/io/base_mcmc.py
@@ -339,20 +339,6 @@ class CommonMCMCMetadataIO(object):
         """
         self.raw_acts = {p: acls[p] * self.thinned_by for p in acls}
 
-    def write_acts(self, act, raw_acts):
-        """Writes both the autocorrelation time and raw autcorrelation times.
-
-        Parameters
-        ----------
-        act : array or int
-            The autocorrelation time. See the ``act`` attribute for details.
-        raw_acts : dict
-            Dictionary of parameter names -> acts. See the ``raw_acts``
-            attribute for details.
-        """
-        self.act = act
-        self.raw_acts = raw_acts
-
     @staticmethod
     def extra_args_parser(parser=None, skip_args=None, **kwargs):
         """Create a parser to parse sampler-specific arguments for loading

--- a/pycbc/inference/io/base_mcmc.py
+++ b/pycbc/inference/io/base_mcmc.py
@@ -687,7 +687,7 @@ def _get_index(fp, chains, thin_start=None, thin_interval=None, thin_end=None,
 
     Returns
     -------
-    get_index : slice or int
+    get_index : list of slice or int
         The indices to retrieve.
     maxiters : int
         The maximum number of samples from a single chain that will be
@@ -701,18 +701,25 @@ def _get_index(fp, chains, thin_start=None, thin_interval=None, thin_end=None,
         if thin_start is None:
             thin_start = fp.thin_start
         if not isinstance(thin_start, (numpy.ndarray, list)):
-            thin_start = numpy.repeat(thin_start, nchains, dtype=int)
+            thin_start = numpy.repeat(thin_start, nchains)
         if thin_interval is None:
             thin_interval = fp.thin_interval
         if not isinstance(thin_interval, (numpy.ndarray, list)):
-            thin_interval = numpy.repeat(thin_interval, nchains,
-                                         dtype=int)
+            thin_interval = numpy.repeat(thin_interval, nchains)
         if thin_end is None:
             thin_end = fp.thin_end
         if not isinstance(thin_end, (numpy.ndarray, list)):
             thin_end = numpy.repeat(thin_end, nchains)
         # figure out the maximum number of samples we will get from all chains
-        maxiters = nsamples_in_chain(thin_start, thin_interval, thin_end).max()
+        start_iter = thin_start * fp.thinned_by
+        iter_interval = thin_interval * fp.thinned_by
+        try:
+            end_iter = thin_end * fp.thinned_by
+        except TypeError:
+            # will get this if thin end is None; in that case, we'll just be
+            # loading all the way to the end
+            end_iter = fp.niterations
+        maxiters = nsamples_in_chain(start_iter, iter_interval, end_iter).max()
         # the slices to use for each chain
         get_index = [fp.get_slice(thin_start=thin_start[ci],
                                   thin_interval=thin_interval[ci],

--- a/pycbc/inference/io/base_multitemper.py
+++ b/pycbc/inference/io/base_multitemper.py
@@ -262,7 +262,11 @@ def read_raw_samples(fp, fields,
     for name in fields:
         arr = numpy.full(loadshape, numpy.nan)
         for ci in chains:
-            thisarr = fp[group.format(name=name)][tidx, ci, get_index]
+            idx = get_index[ci]
+            thisarr = fp[group.format(name=name)][tidx, ci, get_index[ci]]
+            if isinstance(idx, (int, numpy.int_)):
+                # make sure the last dimension corresponds to iteration
+                thisarr = thisarr.reshape(list(thisarr.shape)+[1])
             # pull out the temperatures we need
             if selecttemps:
                 thisarr = thisarr[temps, ...]

--- a/pycbc/inference/io/base_multitemper.py
+++ b/pycbc/inference/io/base_multitemper.py
@@ -264,6 +264,9 @@ def read_raw_samples(fp, fields,
         for ci in chains:
             idx = get_index[ci]
             thisarr = fp[group.format(name=name)][tidx, ci, get_index[ci]]
+            if thisarr.size == 0:
+                # no samples were loaded; skip this chain
+                continue
             if isinstance(idx, (int, numpy.int_)):
                 # make sure the last dimension corresponds to iteration
                 thisarr = thisarr.reshape(list(thisarr.shape)+[1])

--- a/pycbc/inference/io/base_multitemper.py
+++ b/pycbc/inference/io/base_multitemper.py
@@ -248,9 +248,15 @@ def ensemble_read_raw_samples(fp, fields, thin_start=None,
         get_index = int(iteration)
         niterations = 1
     else:
+        if thin_start is None:
+            thin_start = fp.thin_start
+        if thin_interval is None:
+            thin_interval = fp.thin_interval
+        if thin_end is None:
+            thin_end = fp.thin_end
         get_index = fp.get_slice(thin_start=thin_start,
-                                   thin_end=thin_end,
-                                   thin_interval=thin_interval)
+                                 thin_interval=thin_interval,
+                                 thin_end=thin_end)
         # we'll just get the number of iterations from the returned shape
         niterations = None
     # load

--- a/pycbc/inference/io/base_multitemper.py
+++ b/pycbc/inference/io/base_multitemper.py
@@ -90,7 +90,7 @@ class CommonMultiTemperedMetadataIO(CommonMCMCMetadataIO):
         """
         if skip_args is None:
             skip_args = []
-        parser, actions = MCMCMetadataIO.extra_args_parser(
+        parser, actions = CommonMCMCMetadataIO.extra_args_parser(
             parser=parser, skip_args=skip_args, **kwargs)
         if 'temps' not in skip_args:
             act = parser.add_argument(

--- a/pycbc/inference/io/base_multitemper.py
+++ b/pycbc/inference/io/base_multitemper.py
@@ -118,7 +118,7 @@ def write_samples(fp, samples, parameters=None, last_iteration=None,
     -----------
     fp : BaseInferenceFile
         Open file handler to write files to. Must be an instance of
-        BaseInferenceFile with CommonMultiTemperedMetadataIO methods added. 
+        BaseInferenceFile with CommonMultiTemperedMetadataIO methods added.
     samples : dict
         The samples to write. Each array in the dictionary should have
         shape ntemps x nwalkers x niterations.
@@ -195,7 +195,7 @@ def read_raw_samples(fp, fields,
     -----------
     fp : BaseInferenceFile
         Open file handler to write files to. Must be an instance of
-        BaseInferenceFile with CommonMultiTemperedMetadataIO methods added. 
+        BaseInferenceFile with CommonMultiTemperedMetadataIO methods added.
     fields : list
         The list of field names to retrieve.
     thin_start : array or int, optional
@@ -255,12 +255,14 @@ def read_raw_samples(fp, fields,
     # temperatures to load
     tidx, selecttemps, ntemps = _get_temps_index(fp, temps)
     # iterations to load
-    get_index, maxiters = _get_index(fp, len(chains), thin_start,
+    get_index, maxiters = _get_index(fp, chains, thin_start,
                                      thin_interval, thin_end, iteration)
     # load the samples
+    arrays = {}
+    loadshape = (ntemps, len(chains), maxiters)  # shape of loaded arrays
     for name in fields:
-        arr = numpy.full((ntemps, nchains, maxiter), numpy.nan)
-        for ci in cidx:
+        arr = numpy.full(loadshape, numpy.nan)
+        for ci in chains:
             thisarr = fp[group.format(name=name)][tidx, ci, get_index]
             # pull out the temperatures we need
             if selecttemps:
@@ -269,7 +271,7 @@ def read_raw_samples(fp, fields,
             thisarr = thisarr.reshape(ntemps, thisarr.shape[-1])
             arr[:, ci, :thisarr.shape[-1]] = thisarr
         if flatten:
-            # flatten and remove nans 
+            # flatten and remove nans
             arr = arr.flatten()
             arr = arr[~numpy.isnan(arr)]
         arrays[name] = arr
@@ -287,7 +289,7 @@ def ensemble_read_raw_samples(fp, fields, thin_start=None,
     -----------
     fp : BaseInferenceFile
         Open file handler to write files to. Must be an instance of
-        BaseInferenceFile with CommonMultiTemperedMetadataIO methods added. 
+        BaseInferenceFile with CommonMultiTemperedMetadataIO methods added.
     fields : list
         The list of field names to retrieve.
     thin_start : int, optional
@@ -356,7 +358,7 @@ def _get_temps_index(fp, temps):
     -----------
     fp : BaseInferenceFile
         Open file handler to write files to. Must be an instance of
-        BaseInferenceFile with CommonMultiTemperedMetadataIO methods added. 
+        BaseInferenceFile with CommonMultiTemperedMetadataIO methods added.
     temps : 'all' or (list of) int
         The temperature index (or list of indices) to retrieve. To retrieve
         all temperates pass 'all', or a list of all of the temperatures.

--- a/pycbc/inference/io/base_multitemper.py
+++ b/pycbc/inference/io/base_multitemper.py
@@ -215,9 +215,8 @@ def ensemble_read_raw_samples(fp, fields, thin_start=None,
 
     Returns
     -------
-    array_class
-        An instance of the given array class populated with values
-        retrieved from the fields.
+    dict
+        A dictionary of field name -> numpy array pairs.
     """
     if isinstance(fields, string_types):
         fields = [fields]

--- a/pycbc/inference/io/base_multitemper.py
+++ b/pycbc/inference/io/base_multitemper.py
@@ -170,10 +170,9 @@ def write_samples(fp, samples, parameters=None, last_iteration=None,
             istart = 0
             istop = istart + data.shape[2]
             fp.create_dataset(dataset_name, (ntemps, nwalkers, istop),
-                                maxshape=(ntemps, nwalkers,
-                                          None),
-                                dtype=data.dtype,
-                                fletcher32=True)
+                              maxshape=(ntemps, nwalkers, None),
+                              dtype=data.dtype,
+                              fletcher32=True)
         fp[dataset_name][:, :, istart:istop] = data
 
 

--- a/pycbc/inference/io/base_multitemper.py
+++ b/pycbc/inference/io/base_multitemper.py
@@ -350,9 +350,9 @@ def ensemble_read_raw_samples(fp, fields, thin_start=None,
     arrays = {}
     for name in fields:
         dset = group.format(name=name)
-        niterations = arr.shape[-1] if iteration is None else 1
         tidx, selecttemps, ntemps = _get_temps_index(temps, fp, dset)
         arr = fp[dset][tidx, widx, get_index]
+        niterations = arr.shape[-1] if iteration is None else 1
         if selecttemps:
             # pull out the temperatures we need
             arr = arr[temps, ...]

--- a/pycbc/inference/io/base_multitemper.py
+++ b/pycbc/inference/io/base_multitemper.py
@@ -193,7 +193,7 @@ def read_raw_samples(fp, fields,
     Parameters
     -----------
     fp : BaseInferenceFile
-        Open file handler to write files to. Must be an instance of
+        Open file handler to read samples from. Must be an instance of
         BaseInferenceFile with CommonMultiTemperedMetadataIO methods added.
     fields : list
         The list of field names to retrieve.
@@ -251,7 +251,6 @@ def read_raw_samples(fp, fields,
         chains = numpy.arange(fp.nchains)
     elif not isinstance(chains, (list, numpy.ndarray)):
         chains = numpy.array([chains]).astype(int)
-    # iterations to load
     get_index = _get_index(fp, chains, thin_start, thin_interval, thin_end,
                            iteration)
     # load the samples
@@ -262,10 +261,10 @@ def read_raw_samples(fp, fields,
         tidx, selecttemps, ntemps = _get_temps_index(temps, fp, dset)
         alist = []
         maxiters = 0
-        for ci in chains:
-            idx = get_index[ci]
+        for ii, cidx in enumerate(chains):
+            idx = get_index[ii]
             # load the data
-            thisarr = fp[dset][tidx, ci, get_index[ci]]
+            thisarr = fp[dset][tidx, cidx, idx]
             if thisarr.size == 0:
                 # no samples were loaded; skip this chain
                 alist.append(None)
@@ -282,9 +281,9 @@ def read_raw_samples(fp, fields,
             maxiters = max(maxiters, thisarr.shape[-1])
         # stack into a single array
         arr = numpy.full((ntemps, len(chains), maxiters), numpy.nan)
-        for ci, thisarr in enumerate(alist):
+        for ii, thisarr in enumerate(alist):
             if thisarr is not None:
-                arr[:, ci, :thisarr.shape[-1]] = thisarr
+                arr[:, ii, :thisarr.shape[-1]] = thisarr
         if flatten:
             # flatten and remove nans
             arr = arr.flatten()

--- a/pycbc/inference/io/base_multitemper.py
+++ b/pycbc/inference/io/base_multitemper.py
@@ -27,8 +27,9 @@
 from __future__ import absolute_import
 import argparse
 from six import string_types
-from .base_mcmc import (CommonMCMCMetadataIO, thin_samples_for_writing)
 import numpy
+from .base_mcmc import (CommonMCMCMetadataIO, thin_samples_for_writing,
+                        nsamples_in_chain)
 
 class ParseTempsArg(argparse.Action):
     """Argparse action that will parse temps argument.

--- a/pycbc/inference/io/base_multitemper.py
+++ b/pycbc/inference/io/base_multitemper.py
@@ -79,7 +79,8 @@ class CommonMultiTemperedMetadataIO(CommonMCMCMetadataIO):
     def write_sampler_metadata(self, sampler):
         """Adds writing ntemps to file.
         """
-        super(MultiTemperedMetadataIO, self).write_sampler_metadata(sampler)
+        super(CommonMultiTemperedMetadataIO, self).write_sampler_metadata(
+            sampler)
         self[self.sampler_group].attrs["ntemps"] = sampler.ntemps
 
     @staticmethod

--- a/pycbc/inference/io/emcee.py
+++ b/pycbc/inference/io/emcee.py
@@ -26,11 +26,11 @@
 import numpy
 
 from .base_sampler import BaseSamplerFile
-from .base_mcmc import (EnsembleMCMCMetadataIO, single_temp_write_samples,
-                        ensemble_read_raw_samples)
+from .base_mcmc import (EnsembleMCMCMetadataIO, CommonMCMCMetadataIO,
+                        write_samples, ensemble_read_raw_samples)
 
 
-class EmceeFile(EnsembleMCMCMetadataIO, BaseSamplerFile):
+class EmceeFile(EnsembleMCMCMetadataIO, CommonMCMCMetadataIO, BaseSamplerFile):
     """Class to handle file IO for the ``emcee`` sampler."""
 
     name = 'emcee_file'
@@ -39,13 +39,12 @@ class EmceeFile(EnsembleMCMCMetadataIO, BaseSamplerFile):
                       samples_group=None, thin_by=None):
         """Writes samples to the given file.
 
-        Calls
-        :py:func:`~pycbc.inference.io.base_mcmc.single_temp_write_samples`.
-        See that function for details.
+        Calls :py:func:`base_mcmc.write_samples`. See that function for
+        details.
         """
-        single_temp_write_samples(self, samples, parameters=parameters,
-                                  last_iteration=last_iteration,
-                                  samples_group=samples_group, thin_by=thin_by)
+        write_samples(self, samples, parameters=parameters,
+                      last_iteration=last_iteration,
+                      samples_group=samples_group, thin_by=thin_by)
 
     def read_raw_samples(self, fields, thin_start=None,
                          thin_interval=None, thin_end=None,
@@ -53,9 +52,8 @@ class EmceeFile(EnsembleMCMCMetadataIO, BaseSamplerFile):
                          group=None):
         """Base function for reading samples.
 
-        Calls
-        :py:func:`~pycbc.inference.io.base_mcmc.ensemble_read_raw_samples`.
-        See that function for details.
+        Calls :py:func:`base_mcmc.ensemble_read_raw_samples`. See that function
+        for details.
         """
         return ensemble_read_raw_samples(self, fields, thin_start=thin_start,
                                          thin_interval=thin_interval,

--- a/pycbc/inference/io/emcee.py
+++ b/pycbc/inference/io/emcee.py
@@ -35,31 +35,43 @@ class EmceeFile(EnsembleMCMCMetadataIO, CommonMCMCMetadataIO, BaseSamplerFile):
 
     name = 'emcee_file'
 
-    def write_samples(self, samples, parameters=None, last_iteration=None,
-                      samples_group=None, thin_by=None):
-        """Writes samples to the given file.
+    def write_samples(self, samples, **kwargs):
+        r"""Writes samples to the given file.
 
         Calls :py:func:`base_mcmc.write_samples`. See that function for
         details.
-        """
-        write_samples(self, samples, parameters=parameters,
-                      last_iteration=last_iteration,
-                      samples_group=samples_group, thin_by=thin_by)
 
-    def read_raw_samples(self, fields, thin_start=None,
-                         thin_interval=None, thin_end=None,
-                         iteration=None, walkers=None, flatten=True,
-                         group=None):
-        """Base function for reading samples.
+        Parameters
+        ----------
+        samples : dict
+            The samples to write. Each array in the dictionary should have
+            shape nwalkers x niterations.
+        \**kwargs :
+            All other keyword arguments are passed to
+            :py:func:`base_mcmc.write_samples`.
+        """
+        write_samples(self, samples, **kwargs)
+
+    def read_raw_samples(self, fields, **kwargs):
+        r"""Base function for reading samples.
 
         Calls :py:func:`base_mcmc.ensemble_read_raw_samples`. See that function
         for details.
+
+        Parameters
+        -----------
+        fields : list
+            The list of field names to retrieve.
+        \**kwargs :
+            All other keyword arguments are passed to
+            :py:func:`base_mcmc.ensemble_read_raw_samples`.
+
+        Returns
+        -------
+        dict
+            A dictionary of field name -> numpy array pairs.
         """
-        return ensemble_read_raw_samples(self, fields, thin_start=thin_start,
-                                         thin_interval=thin_interval,
-                                         thin_end=thin_end,
-                                         iteration=iteration, walkers=walkers,
-                                         flatten=flatten, group=group)
+        return ensemble_read_raw_samples(self, fields, **kwargs)
 
     def read_acceptance_fraction(self, walkers=None):
         """Reads the acceptance fraction.

--- a/pycbc/inference/io/emcee.py
+++ b/pycbc/inference/io/emcee.py
@@ -26,13 +26,42 @@
 import numpy
 
 from .base_sampler import BaseSamplerFile
-from .base_mcmc import (MCMCMetadataIO, SingleTempMCMCIO)
+from .base_mcmc import (EnsembleMCMCMetadataIO, single_temp_write_samples,
+                        ensemble_read_raw_samples)
 
 
-class EmceeFile(SingleTempMCMCIO, MCMCMetadataIO, BaseSamplerFile):
+class EmceeFile(EnsembleMCMCMetadataIO, BaseSamplerFile):
     """Class to handle file IO for the ``emcee`` sampler."""
 
     name = 'emcee_file'
+
+    def write_samples(self, samples, parameters=None, last_iteration=None,
+                      samples_group=None, thin_by=None):
+        """Writes samples to the given file.
+
+        Calls
+        :py:func:`~pycbc.inference.io.base_mcmc.single_temp_write_samples`.
+        See that function for details.
+        """
+        single_temp_write_samples(self, samples, parameters=parameters,
+                                  last_iteration=last_iteration,
+                                  samples_group=samples_group, thin_by=thin_by)
+
+    def read_raw_samples(self, fields, thin_start=None,
+                         thin_interval=None, thin_end=None,
+                         iteration=None, walkers=None, flatten=True,
+                         group=None):
+        """Base function for reading samples.
+
+        Calls
+        :py:func:`~pycbc.inference.io.base_mcmc.ensemble_read_raw_samples`.
+        See that function for details.
+        """
+        return ensemble_read_raw_samples(self, fields, thin_start=thin_start,
+                                         thin_interval=thin_interval,
+                                         thin_end=thin_end,
+                                         iteration=iteration, walkers=walkers,
+                                         flatten=flatten, group=group)
 
     def read_acceptance_fraction(self, walkers=None):
         """Reads the acceptance fraction.

--- a/pycbc/inference/io/emcee_pt.py
+++ b/pycbc/inference/io/emcee_pt.py
@@ -39,31 +39,43 @@ class EmceePTFile(EnsembleMCMCMetadataIO, CommonMultiTemperedMetadataIO,
         """The betas that were used."""
         return self[self.sampler_group].attrs["betas"]
 
-    def write_samples(self, samples, parameters=None, last_iteration=None,
-                      samples_group=None, thin_by=None):
-        """Writes samples to the given file.
+    def write_samples(self, samples, **kwargs):
+        r"""Writes samples to the given file.
 
         Calls :py:func:`base_multitemper.write_samples`. See that function for
         details.
-        """
-        write_samples(self, samples, parameters=parameters,
-                      last_iteration=last_iteration,
-                      samples_group=samples_group, thin_by=thin_by)
 
-    def read_raw_samples(self, fields, thin_start=None, thin_interval=None,
-                         thin_end=None, iteration=None, temps='all',
-                         walkers=None, flatten=True, group=None):
-        """Base function for reading samples.
+        Parameters
+        ----------
+        samples : dict
+            The samples to write. Each array in the dictionary should have
+            shape ntemps x nwalkers x niterations.
+        \**kwargs :
+            All other keyword arguments are passed to
+            :py:func:`base_multitemper.write_samples`.
+        """
+        write_samples(self, samples, **kwargs)
+
+    def read_raw_samples(self, fields, **kwargs):
+        r"""Base function for reading samples.
 
         Calls :py:func:`base_multitemper.ensemble_read_raw_samples`. See that
         function for details.
+
+        Parameters
+        -----------
+        fields : list
+            The list of field names to retrieve.
+        \**kwargs :
+            All other keyword arguments are passed to
+            :py:func:`base_multitemper.ensemble_read_raw_samples`.
+
+        Returns
+        -------
+        dict
+            A dictionary of field name -> numpy array pairs.
         """
-        return ensemble_read_raw_samples(self, fields, thin_start=thin_start,
-                                         thin_interval=thin_interval,
-                                         thin_end=thin_end,
-                                         iteration=iteration, temps=temps,
-                                         walkers=walkers, flatten=flatten,
-                                         group=group)
+        return ensemble_read_raw_samples(self, fields, **kwargs)
 
     def write_sampler_metadata(self, sampler):
         """Adds writing betas to MultiTemperedMCMCIO.

--- a/pycbc/inference/io/emcee_pt.py
+++ b/pycbc/inference/io/emcee_pt.py
@@ -22,10 +22,13 @@ from __future__ import absolute_import
 import numpy
 
 from .base_sampler import BaseSamplerFile
-from .base_multitemper import (MultiTemperedMetadataIO, MultiTemperedMCMCIO)
+from .base_mcmc import EnsembleMCMCMetadataIO
+from .base_multitemper import (CommonMultiTemperedMetadataIO,
+                               write_samples,
+                               ensemble_read_raw_samples)
 
 
-class EmceePTFile(MultiTemperedMCMCIO, MultiTemperedMetadataIO,
+class EmceePTFile(EnsembleMCMCMetadataIO, CommonMultiTemperedMetadataIO,
                   BaseSamplerFile):
     """Class to handle file IO for the ``emcee`` sampler."""
 
@@ -35,6 +38,32 @@ class EmceePTFile(MultiTemperedMCMCIO, MultiTemperedMetadataIO,
     def betas(self):
         """The betas that were used."""
         return self[self.sampler_group].attrs["betas"]
+
+    def write_samples(self, samples, parameters=None, last_iteration=None,
+                      samples_group=None, thin_by=None):
+        """Writes samples to the given file.
+
+        Calls :py:func:`base_multitemper.write_samples`. See that function for
+        details.
+        """
+        write_samples(self, samples, parameters=parameters,
+                      last_iteration=last_iteration,
+                      samples_group=samples_group, thin_by=thin_by)
+
+    def read_raw_samples(self, fields, thin_start=None, thin_interval=None,
+                         thin_end=None, iteration=None, temps='all',
+                         walkers=None, flatten=True, group=None):
+        """Base function for reading samples.
+
+        Calls :py:func:`base_multitemper.ensemble_read_raw_samples`. See that
+        function for details.
+        """
+        return ensemble_read_raw_samples(self, fields, thin_start=thin_start,
+                                         thin_interval=thin_interval,
+                                         thin_end=thin_end,
+                                         iteration=iteration, temps=temps,
+                                         walkers=walkers, flatten=flatten,
+                                         group=group)
 
     def write_sampler_metadata(self, sampler):
         """Adds writing betas to MultiTemperedMCMCIO.

--- a/pycbc/inference/io/epsie.py
+++ b/pycbc/inference/io/epsie.py
@@ -24,10 +24,13 @@ from six import string_types
 from epsie import load_state
 
 from .base_sampler import BaseSamplerFile
-from .base_multitemper import (MultiTemperedMCMCIO, MultiTemperedMetadataIO)
+from .base_mcmc import MCMCMetadataIO
+from .base_multitemper import (CommonMultiTemperedMetadataIO,
+                               write_samples,
+                               read_raw_samples)
 
 
-class EpsieFile(MultiTemperedMCMCIO, MultiTemperedMetadataIO,
+class EpsieFile(MCMCMetadataIO, CommonMultiTemperedMetadataIO,
                 BaseSamplerFile):
     """Class to handle IO for Epsie's parallel-tempered sampler."""
 
@@ -82,6 +85,44 @@ class EpsieFile(MultiTemperedMCMCIO, MultiTemperedMetadataIO,
         if ts_thin_interval > 1:
             self._thin_data(ts_group, ['swap_index', 'acceptance_ratio'],
                             ts_thin_interval)
+
+    def write_samples(self, samples, **kwargs):
+        r"""Writes samples to the given file.
+
+        Calls :py:func:`base_multitemper.write_samples`. See that function for
+        details.
+
+        Parameters
+        ----------
+        samples : dict
+            The samples to write. Each array in the dictionary should have
+            shape ntemps x nwalkers x niterations.
+        \**kwargs :
+            All other keyword arguments are passed to
+            :py:func:`base_multitemper.write_samples`.
+        """
+        write_samples(self, samples, **kwargs)
+
+    def read_raw_samples(self, fields, **kwargs):
+        r"""Base function for reading samples.
+
+        Calls :py:func:`base_multitemper.read_raw_samples`. See that
+        function for details.
+
+        Parameters
+        -----------
+        fields : list
+            The list of field names to retrieve.
+        \**kwargs :
+            All other keyword arguments are passed to
+            :py:func:`base_multitemper.read_raw_samples`.
+
+        Returns
+        -------
+        dict
+            A dictionary of field name -> numpy array pairs.
+        """
+        return read_raw_samples(self, fields, **kwargs)
 
     def write_acceptance_ratio(self, acceptance_ratio, last_iteration=None):
         """Writes the acceptance ratios to the sampler info group.
@@ -238,119 +279,3 @@ class EpsieFile(MultiTemperedMCMCIO, MultiTemperedMetadataIO,
             acls[param] = x
         return acls 
 
-    def read_raw_samples(self, fields,
-                         thin_start=None, thin_interval=None, thin_end=None,
-                         iteration=None, temps='all', walkers=None,
-                         flatten=True, group=None):
-        """Base function for reading samples.
-
-        Parameters
-        -----------
-        fields : list
-            The list of field names to retrieve.
-        thin_start : int, optional
-            Start reading from the given iteration. Default is to start from
-            the first iteration.
-        thin_interval : int, optional
-            Only read every ``thin_interval`` -th sample. Default is to use
-            the ACL for each chain.
-        thin_end : int, optional
-            Stop reading at the given iteration. Default is to end at the last
-            iteration.
-        iteration : int, optional
-            Only read the given iteration. If this provided, it overrides
-            the ``thin_(start|interval|end)`` options.
-        temps : 'all' or (list of) int, optional
-            The temperature index (or list of indices) to retrieve. To retrieve
-            all temperates pass 'all', or a list of all of the temperatures.
-            Default is 'all'.
-        walkers : (list of) int, optional
-            Only read from the given walkers. Default is to read all.
-        flatten : bool, optional
-            Flatten the samples to 1D arrays before returning. Otherwise, the
-            returned arrays will have shape (requested temps x
-            requested walkers x requested iteration(s)). Default is True.
-        group : str, optional
-            The name of the group to read sample datasets from. Default is
-            the file's ``samples_group``.
-
-        Returns
-        -------
-        array_class
-            An instance of the given array class populated with values
-            retrieved from the fields.
-        """
-        if isinstance(fields, string_types):
-            fields = [fields]
-        if group is None:
-            group = self.samples_group
-        group = group + '/{name}'
-        # walkers to load
-        if walkers is not None:
-            nwalkers = len(walkers)
-        else:
-            nwalkers = self.nwalkers
-            widx = numpy.arange(nwalkers)
-        # temperatures to load
-        selecttemps = False
-        if isinstance(temps, (int, numpy.int32, numpy.int64)):
-            tidx = temps
-            ntemps = 1
-        else:
-            # temps is either 'all' or a list of temperatures;
-            # in either case, we'll get all of the temperatures from the file;
-            # if not 'all', then we'll pull out the ones we want
-            tidx = slice(None, None)
-            selecttemps = temps != 'all'
-            if selecttemps:
-                ntemps = len(temps)
-            else:
-                ntemps = self.ntemps
-        # get the slice to use
-        if thin_end is None:
-            thin_end = self[group.format(name=fields[0])].shape[-1]
-        if iteration is not None:
-            get_index = int(iteration)
-            niterations = 1
-        else:
-            # figure out the largest extent
-            ti = thin_interval
-            if ti is None:
-                acls = self.read_acls()
-                # maximize over all parameters
-                acls = numpy.array(list(acls.values())).max(axis=0)
-                ti = acls.min()
-            if ti == numpy.inf:
-                niterations = 1
-            else:
-                s = self.get_slice(thin_start=thin_start, thin_end=thin_end,
-                                   thin_interval=int(ti))
-            niterations = int(numpy.ceil((s.stop - s.start) / s.step))
-        arrays = {}
-        for name in fields:
-            arr = numpy.full((ntemps, nwalkers, niterations), numpy.nan)
-            for wi in widx:
-                if iteration is None:
-                    ti = thin_interval
-                    if ti is None:
-                        ti =  acls[wi]
-                    if ti == numpy.inf:
-                        # just get the last one
-                        get_index = -1
-                    else:
-                        get_index = self.get_slice(thin_start=thin_start,
-                                                   thin_end=thin_end,
-                                                   thin_interval=int(ti))
-                thisarr = self[group.format(name=name)][tidx, wi, get_index]
-                # pull out the temperatures we need
-                if selecttemps:
-                    thisarr = thisarr[temps, ...]
-                # make sure its 2D
-                thisarr = thisarr.reshape(ntemps, thisarr.shape[-1])
-                arr[:, wi, :thisarr.shape[-1]] = thisarr
-            if flatten:
-                # flatten and remove nans 
-                arr = arr.flatten()
-                arr = arr[~numpy.isnan(arr)]
-            arrays[name] = arr
-        return arrays

--- a/pycbc/inference/io/epsie.py
+++ b/pycbc/inference/io/epsie.py
@@ -61,10 +61,7 @@ class EpsieFile(MCMCMetadataIO, CommonMultiTemperedMetadataIO,
         """
         super(EpsieFile, self).write_sampler_metadata(sampler)
         self[self.sampler_group].attrs['seed'] = sampler.seed
-        try:
-            self[self.sampler_group]["betas"][:] = sampler.betas
-        except KeyError:
-            self[self.sampler_group]["betas"] = sampler.betas
+        self.write_data("betas", sampler.betas, path=self.sampler_group)
 
     def thin(self, thin_interval):
         """Thins the samples on disk to the given thinning interval.
@@ -255,27 +252,3 @@ class EpsieFile(MCMCMetadataIO, CommonMultiTemperedMetadataIO,
                 # corrupted for some reason
                 valid = False
         return valid
-
-    def read_acls(self, pertemp=False):
-        """Reads the acls of all the parameters.
-
-        Parameters
-        ----------
-        pertemp : bool, optional
-            Return the ACL for each temperature. Default (False) is to take
-            the maximum over all temperatures.
-
-        Returns
-        -------
-        dict
-            A dictionary of the ACLs, keyed by the parameter name.
-        """
-        group = self[self.sampler_group]['acls']
-        acls = {}
-        for param in group:
-            x = group[param][()]
-            if not pertemp:
-                x = x.max(axis=0)
-            acls[param] = x
-        return acls 
-

--- a/pycbc/inference/io/epsie.py
+++ b/pycbc/inference/io/epsie.py
@@ -251,3 +251,16 @@ class EpsieFile(MCMCMetadataIO, CommonMultiTemperedMetadataIO,
                 # corrupted for some reason
                 valid = False
         return valid
+
+    @staticmethod
+    def _get_optional_args(args, opts, err_on_missing=False, **kwargs):
+        # need this to make sure options called "walkers" are renamed to
+        # "chains"
+        parsed = BaseSamplerFile._get_optional_args(
+            args, opts, err_on_missing=err_on_missing, **kwargs)
+        try:
+            chains = parsed.pop('walkers')
+            parsed['chains'] = chains
+        except KeyError:
+            pass
+        return parsed

--- a/pycbc/inference/io/epsie.py
+++ b/pycbc/inference/io/epsie.py
@@ -20,7 +20,6 @@ from __future__ import (absolute_import, division)
 
 import numpy
 from pickle import UnpicklingError
-from six import string_types
 from epsie import load_state
 
 from .base_sampler import BaseSamplerFile

--- a/pycbc/inference/sampler/base_mcmc.py
+++ b/pycbc/inference/sampler/base_mcmc.py
@@ -726,10 +726,10 @@ class BaseMCMC(object):
     @property
     def raw_acls(self):
         """Dictionary of parameter names -> autocorrelation lengths.
-        
+
         Depending on the sampler, the ACLs may be an integer, or an arrray of
         values per chain and/or per temperature.
-        
+
         Returns ``None`` if no ACLs have been calculated.
         """
         return self._acls
@@ -742,7 +742,7 @@ class BaseMCMC(object):
     @abstractmethod
     def acl(self):
         """The autocorrelation length.
-        
+
         This method should convert the raw ACLs into an integer or array that
         can be used to extract independent samples from a chain.
         """
@@ -768,7 +768,7 @@ class BaseMCMC(object):
         the ``thin_interval``. It gives the number of iterations between
         independent samples. Depending on the sampler, this may either be
         a single integer or an array of values.
-        
+
         Returns ``None`` if no ACLs have been calculated.
         """
         acl = self.acl
@@ -795,13 +795,10 @@ class EnsembleSupport(object):
     @property
     def nwalkers(self):
         """The number of walkers used.
-        
+
         Alias of ``nchains``.
         """
         return self.nchains
-        if self._nchains is None:
-            raise ValueError("number of walkers not set")
-        return self._nchains
 
     @nwalkers.setter
     def nwalkers(self, value):

--- a/pycbc/inference/sampler/base_mcmc.py
+++ b/pycbc/inference/sampler/base_mcmc.py
@@ -586,7 +586,7 @@ class BaseMCMC(object):
             logging.info("No samples written due to thinning")
         else:
             # check for burn in, compute the acls
-            self.acl = None
+            self.raw_acls = None
             if self.burn_in is not None:
                 logging.info("Updating burn in")
                 self.burn_in.evaluate(self.checkpoint_file)
@@ -594,16 +594,14 @@ class BaseMCMC(object):
             # saved it, in which case we don't need to do it again.
             if self.raw_acls is None:
                 logging.info("Computing acls")
-                self.acls = self.compute_acl(self.checkpoint_file)
+                self.raw_acls = self.compute_acl(self.checkpoint_file)
             # write
             for fn in [self.checkpoint_file, self.backup_file]:
                 with self.io(fn, "a") as fp:
                     if self.burn_in is not None:
                         self.burn_in.write(fp)
-                    if self.acl is not None:
-                        fp.acl = self.acl
                     if self.raw_acls is not None:
-                        fp.raw_acls = self.raw_acls
+                        fp.write_acls(self.acl, self.raw_acls)
                     # write effective number of samples
                     fp.write_effective_nsamples(self.effective_nsamples)
         # check validity

--- a/pycbc/inference/sampler/base_mcmc.py
+++ b/pycbc/inference/sampler/base_mcmc.py
@@ -208,8 +208,10 @@ class BaseMCMC(object):
     thin_safety_factor
     burn_in
     effective_nsamples
-    acls
-    acts
+    acl
+    raw_acls
+    act
+    raw_acts
     """
     _lastclear = None  # the iteration when samples were cleared from memory
     _itercounter = None  # the number of iterations since the last clear
@@ -584,13 +586,13 @@ class BaseMCMC(object):
             logging.info("No samples written due to thinning")
         else:
             # check for burn in, compute the acls
-            self.acls = None
+            self.acl = None
             if self.burn_in is not None:
                 logging.info("Updating burn in")
                 self.burn_in.evaluate(self.checkpoint_file)
             # Compute acls; the burn_in test may have calculated an acl and
             # saved it, in which case we don't need to do it again.
-            if self.acls is None:
+            if self.raw_acls is None:
                 logging.info("Computing acls")
                 self.acls = self.compute_acl(self.checkpoint_file)
             # write
@@ -598,8 +600,10 @@ class BaseMCMC(object):
                 with self.io(fn, "a") as fp:
                     if self.burn_in is not None:
                         self.burn_in.write(fp)
-                    if self.acls is not None:
-                        fp.write_acls(self.acls)
+                    if self.acl is not None:
+                        fp.acl = self.acl
+                    if self.raw_acls is not None:
+                        fp.raw_acls = self.raw_acls
                     # write effective number of samples
                     fp.write_effective_nsamples(self.effective_nsamples)
         # check validity

--- a/pycbc/inference/sampler/base_mcmc.py
+++ b/pycbc/inference/sampler/base_mcmc.py
@@ -590,18 +590,21 @@ class BaseMCMC(object):
             if self.burn_in is not None:
                 logging.info("Updating burn in")
                 self.burn_in.evaluate(self.checkpoint_file)
+                # write
+                for fn in [self.checkpoint_file, self.backup_file]:
+                    with self.io(fn, "a") as fp:
+                        self.burn_in.write(fp)
             # Compute acls; the burn_in test may have calculated an acl and
             # saved it, in which case we don't need to do it again.
             if self.raw_acls is None:
-                logging.info("Computing acls")
+                logging.info("Computing autocorrelation time")
                 self.raw_acls = self.compute_acl(self.checkpoint_file)
-            # write
+            # write acts, effective number of samples
             for fn in [self.checkpoint_file, self.backup_file]:
                 with self.io(fn, "a") as fp:
-                    if self.burn_in is not None:
-                        self.burn_in.write(fp)
-                    if self.raw_acts is not None:
-                        fp.write_acts(self.act, self.raw_acts)
+                    if self.raw_acls is not None:
+                        fp.raw_acls = self.raw_acls
+                        fp.acl = self.acl
                     # write effective number of samples
                     fp.write_effective_nsamples(self.effective_nsamples)
         # check validity

--- a/pycbc/inference/sampler/base_mcmc.py
+++ b/pycbc/inference/sampler/base_mcmc.py
@@ -600,8 +600,8 @@ class BaseMCMC(object):
                 with self.io(fn, "a") as fp:
                     if self.burn_in is not None:
                         self.burn_in.write(fp)
-                    if self.raw_acls is not None:
-                        fp.write_acls(self.acl, self.raw_acls)
+                    if self.raw_acts is not None:
+                        fp.write_acts(self.act, self.raw_acts)
                     # write effective number of samples
                     fp.write_effective_nsamples(self.effective_nsamples)
         # check validity

--- a/pycbc/inference/sampler/base_mcmc.py
+++ b/pycbc/inference/sampler/base_mcmc.py
@@ -593,11 +593,8 @@ class BaseMCMC(object):
             if self.burn_in is not None:
                 logging.info("Updating burn in")
                 self.burn_in.evaluate(self.checkpoint_file)
-                burn_in_index = self.burn_in.burn_in_index
-                logging.info("Is burned in: %r", self.burn_in.is_burned_in)
-                if self.burn_in.is_burned_in:
-                    logging.info("Burn-in iteration: %i",
-                                 int(self.burn_in.burn_in_iteration))
+                burn_in_index = self.burn_in.burn_in_index(
+                    self.checkpoint_file)
             else:
                 burn_in_index = 0
             # Compute acls; the burn_in test may have calculated an acl and
@@ -612,7 +609,7 @@ class BaseMCMC(object):
             for fn in [self.checkpoint_file, self.backup_file]:
                 with self.io(fn, "a") as fp:
                     if self.burn_in is not None:
-                        fp.write_burn_in(self.burn_in)
+                        self.burn_in.write(fp)
                     if self.acls is not None:
                         fp.write_acls(self.acls)
                     # write effective number of samples

--- a/pycbc/inference/sampler/base_multitemper.py
+++ b/pycbc/inference/sampler/base_multitemper.py
@@ -210,7 +210,6 @@ def compute_acl(filename, start_index=None, end_index=None,
     acls = {}
     with loadfile(filename, 'r') as fp:
         tidx = numpy.arange(fp.ntemps)
-        cidx = numpy.arange(fp.nwalkers)
         for param in fp.variable_params:
             these_acls = numpy.zeros((fp.ntemps, fp.nchains))
             for tk in tidx:

--- a/pycbc/inference/sampler/base_multitemper.py
+++ b/pycbc/inference/sampler/base_multitemper.py
@@ -31,6 +31,7 @@ from six import string_types
 import numpy
 import h5py
 from pycbc.filter import autocorrelation
+from pycbc.inference.io import loadfile
 
 
 class MultiTemperedSupport(object):
@@ -96,152 +97,156 @@ class MultiTemperedSupport(object):
         return ntemps, betas
 
 
-class MultiTemperedAutocorrSupport(object):
-    """Provides class methods for calculating multi-tempered ACFs/ACLs.
+#
+# =============================================================================
+#
+#              Functions for computing autocorrelation lengths
+#
+# =============================================================================
+#
+
+
+def ensemble_compute_acf(filename, start_index=None, end_index=None,
+                         per_walker=False, walkers=None, parameters=None,
+                         temps=None):
+    """Computes the autocorrleation function for a parallel tempered, ensemble
+    MCMC.
+
+    By default, parameter values are averaged over all walkers at each
+    iteration. The ACF is then calculated over the averaged chain for each
+    temperature. An ACF per-walker will be returned instead if
+    ``per_walker=True``.
+
+    Parameters
+    -----------
+    filename : str
+        Name of a samples file to compute ACFs for.
+    start_index : int, optional
+        The start index to compute the acl from. If None (the default), will
+        try to use the number of burn-in iterations in the file; otherwise,
+        will start at the first sample.
+    end_index : int, optional
+        The end index to compute the acl to. If None (the default), will go to
+        the end of the current iteration.
+    per_walker : bool, optional
+        Return the ACF for each walker separately. Default is False.
+    walkers : int or array, optional
+        Calculate the ACF using only the given walkers. If None (the
+        default) all walkers will be used.
+    parameters : str or array, optional
+        Calculate the ACF for only the given parameters. If None (the
+        default) will calculate the ACF for all of the model params.
+    temps : (list of) int or 'all', optional
+        The temperature index (or list of indices) to retrieve. If None
+        (the default), the ACF will only be computed for the coldest (= 0)
+        temperature chain. To compute an ACF for all temperates pass 'all',
+        or a list of all of the temperatures.
+
+    Returns
+    -------
+    dict :
+        Dictionary of arrays giving the ACFs for each parameter. If
+        ``per-walker`` is True, the arrays will have shape
+        ``ntemps x nwalkers x niterations``. Otherwise, the returned array
+        will have shape ``ntemps x niterations``.
     """
-
-    @classmethod
-    def compute_acf(cls, filename, start_index=None, end_index=None,
-                    per_walker=False, walkers=None, parameters=None,
-                    temps=None):
-        """Computes the autocorrleation function of the model params in the
-        given file.
-
-        By default, parameter values are averaged over all walkers at each
-        iteration. The ACF is then calculated over the averaged chain for each
-        temperature. An ACF per-walker will be returned instead if
-        ``per_walker=True``.
-
-        Parameters
-        -----------
-        filename : str
-            Name of a samples file to compute ACFs for.
-        start_index : {None, int}
-            The start index to compute the acl from. If None, will try to use
-            the number of burn-in iterations in the file; otherwise, will start
-            at the first sample.
-        end_index : {None, int}
-            The end index to compute the acl to. If None, will go to the end
-            of the current iteration.
-        per_walker : optional, bool
-            Return the ACF for each walker separately. Default is False.
-        walkers : optional, int or array
-            Calculate the ACF using only the given walkers. If None (the
-            default) all walkers will be used.
-        parameters : optional, str or array
-            Calculate the ACF for only the given parameters. If None (the
-            default) will calculate the ACF for all of the model params.
-        temps : optional, (list of) int or 'all'
-            The temperature index (or list of indices) to retrieve. If None
-            (the default), the ACF will only be computed for the coldest (= 0)
-            temperature chain. To compute an ACF for all temperates pass 'all',
-            or a list of all of the temperatures.
-
-        Returns
-        -------
-        dict :
-            Dictionary of arrays giving the ACFs for each parameter. If
-            ``per-walker`` is True, the arrays will have shape
-            ``ntemps x nwalkers x niterations``. Otherwise, the returned array
-            will have shape ``ntemps x niterations``.
-        """
-        acfs = {}
-        with cls._io(filename, 'r') as fp:
-            if parameters is None:
-                parameters = fp.variable_params
-            if isinstance(parameters, string_types):
-                parameters = [parameters]
-            if isinstance(temps, int):
-                temps = [temps]
-            elif temps == 'all':
-                temps = numpy.arange(fp.ntemps)
-            elif temps is None:
-                temps = [0]
-            for param in parameters:
-                subacfs = []
-                for tk in temps:
-                    if per_walker:
-                        # just call myself with a single walker
-                        if walkers is None:
-                            walkers = numpy.arange(fp.nwalkers)
-                        arrays = [cls.compute_acfs(filename,
-                                                   start_index=start_index,
-                                                   end_index=end_index,
-                                                   per_walker=False,
-                                                   walkers=ii,
-                                                   parameters=param,
-                                                   temps=tk)[param][0, :]
-                                  for ii in walkers]
-                        # we'll stack all of the walker arrays to make a single
-                        # nwalkers x niterations array; when these are stacked
-                        # below, we'll get a ntemps x nwalkers x niterations
-                        # array
-                        subacfs.append(numpy.vstack(arrays))
-                    else:
-                        samples = fp.read_raw_samples(
-                            param, thin_start=start_index,
-                            thin_interval=1, thin_end=end_index,
-                            walkers=walkers, temps=tk, flatten=False)[param]
-                        # contract the walker dimension using the mean, and
-                        # flatten the (length 1) temp dimension
-                        samples = samples.mean(axis=1)[0, :]
-                        thisacf = autocorrelation.calculate_acf(
-                            samples).numpy()
-                        subacfs.append(thisacf)
-                # stack the temperatures
-                acfs[param] = numpy.stack(subacfs)
-        return acfs
-
-    @classmethod
-    def compute_acl(cls, filename, start_index=None, end_index=None,
-                    min_nsamples=10):
-        """Computes the autocorrleation length for all model params and
-        temperatures in the given file.
-
-        Parameter values are averaged over all walkers at each iteration and
-        temperature.  The ACL is then calculated over the averaged chain.
-
-        Parameters
-        -----------
-        filename : str
-            Name of a samples file to compute ACLs for.
-        start_index : {None, int}
-            The start index to compute the acl from. If None, will try to use
-            the number of burn-in iterations in the file; otherwise, will start
-            at the first sample.
-        end_index : {None, int}
-            The end index to compute the acl to. If None, will go to the end
-            of the current iteration.
-        min_nsamples : int, optional
-            Require a minimum number of samples to compute an ACL. If the
-            number of samples per walker is less than this, will just set to
-            ``inf``. Default is 10.
-
-        Returns
-        -------
-        dict
-            A dictionary of ntemps-long arrays of the ACLs of each parameter.
-        """
-        acls = {}
-        with cls._io(filename, 'r') as fp:
-            if end_index is None:
-                end_index = fp.niterations
-            tidx = numpy.arange(fp.ntemps)
-            for param in fp.variable_params:
-                these_acls = numpy.zeros(fp.ntemps)
-                for tk in tidx:
+    acfs = {}
+    with loadfile(filename, 'r') as fp:
+        if parameters is None:
+            parameters = fp.variable_params
+        if isinstance(parameters, string_types):
+            parameters = [parameters]
+        if isinstance(temps, int):
+            temps = [temps]
+        elif temps == 'all':
+            temps = numpy.arange(fp.ntemps)
+        elif temps is None:
+            temps = [0]
+        for param in parameters:
+            subacfs = []
+            for tk in temps:
+                if per_walker:
+                    # just call myself with a single walker
+                    if walkers is None:
+                        walkers = numpy.arange(fp.nwalkers)
+                    arrays = [ensemble_compute_acfs(filename,
+                                                    start_index=start_index,
+                                                    end_index=end_index,
+                                                    per_walker=False,
+                                                    walkers=ii,
+                                                    parameters=param,
+                                                    temps=tk)[param][0, :]
+                              for ii in walkers]
+                    # we'll stack all of the walker arrays to make a single
+                    # nwalkers x niterations array; when these are stacked
+                    # below, we'll get a ntemps x nwalkers x niterations
+                    # array
+                    subacfs.append(numpy.vstack(arrays))
+                else:
                     samples = fp.read_raw_samples(
-                        param, thin_start=start_index, thin_interval=1,
-                        thin_end=end_index, temps=tk, flatten=False)[param]
-                    # contract the walker dimension using the mean, and flatten
-                    # the (length 1) temp dimension
+                        param, thin_start=start_index,
+                        thin_interval=1, thin_end=end_index,
+                        walkers=walkers, temps=tk, flatten=False)[param]
+                    # contract the walker dimension using the mean, and
+                    # flatten the (length 1) temp dimension
                     samples = samples.mean(axis=1)[0, :]
-                    if samples.size < min_nsamples:
-                        acl = numpy.inf
-                    else:
-                        acl = autocorrelation.calculate_acl(samples)
-                    if acl <= 0:
-                        acl = numpy.inf
-                    these_acls[tk] = acl
-                acls[param] = these_acls
-        return acls
+                    thisacf = autocorrelation.calculate_acf(
+                        samples).numpy()
+                    subacfs.append(thisacf)
+            # stack the temperatures
+            acfs[param] = numpy.stack(subacfs)
+    return acfs
+
+
+def ensemble_compute_acl(filename, start_index=None, end_index=None,
+                         min_nsamples=10):
+    """Computes the autocorrleation length for a parallel tempered, ensemble
+    MCMC.
+
+    Parameter values are averaged over all walkers at each iteration and
+    temperature.  The ACL is then calculated over the averaged chain.
+
+    Parameters
+    -----------
+    filename : str
+        Name of a samples file to compute ACLs for.
+    start_index : int, optional
+        The start index to compute the acl from. If None (the default), will
+        try to use the number of burn-in iterations in the file; otherwise,
+        will start at the first sample.
+    end_index : int, optional
+        The end index to compute the acl to. If None, will go to the end
+        of the current iteration.
+    min_nsamples : int, optional
+        Require a minimum number of samples to compute an ACL. If the
+        number of samples per walker is less than this, will just set to
+        ``inf``. Default is 10.
+
+    Returns
+    -------
+    dict
+        A dictionary of ntemps-long arrays of the ACLs of each parameter.
+    """
+    acls = {}
+    with loadfile(filename, 'r') as fp:
+        if end_index is None:
+            end_index = fp.niterations
+        tidx = numpy.arange(fp.ntemps)
+        for param in fp.variable_params:
+            these_acls = numpy.zeros(fp.ntemps)
+            for tk in tidx:
+                samples = fp.read_raw_samples(
+                    param, thin_start=start_index, thin_interval=1,
+                    thin_end=end_index, temps=tk, flatten=False)[param]
+                # contract the walker dimension using the mean, and flatten
+                # the (length 1) temp dimension
+                samples = samples.mean(axis=1)[0, :]
+                if samples.size < min_nsamples:
+                    acl = numpy.inf
+                else:
+                    acl = autocorrelation.calculate_acl(samples)
+                if acl <= 0:
+                    acl = numpy.inf
+                these_acls[tk] = acl
+            acls[param] = these_acls
+    return acls

--- a/pycbc/inference/sampler/base_multitemper.py
+++ b/pycbc/inference/sampler/base_multitemper.py
@@ -225,10 +225,12 @@ def compute_acl(filename, start_index=None, end_index=None,
                     these_acls[tk, :] = list(map(_getacl, samples))
             acls[param] = these_acls
         # report the mean ACL: take the max over the temps and parameters
-        acl = numpy.array(list(acls.values())).max(axis=2).max(axis=0)
-        act = acl*fp.thinned_by
-        logging.info("Min, mean, max ACT: %s, %s, %s",
-                     str(act.min()), str(act.mean()), str(act.max()))
+        act = acl_from_raw_acls(acls)*fp.thinned_by
+        finite = act[numpy.isfinite(act)]
+        logging.info("ACTs: min %s, mean (of finite) %s, max %s",
+                     str(act.min()),
+                     str(finite.mean() if finite.size > 0 else numpy.inf),
+                     str(act.max()))
     return acls
 
 

--- a/pycbc/inference/sampler/base_multitemper.py
+++ b/pycbc/inference/sampler/base_multitemper.py
@@ -26,9 +26,8 @@ samplers."""
 
 from __future__ import absolute_import
 
-from six import string_types
-
 import logging
+from six import string_types
 import numpy
 import h5py
 from pycbc.filter import autocorrelation
@@ -139,7 +138,7 @@ def compute_acf(filename, start_index=None, end_index=None,
     -------
     dict :
         Dictionary parameter name -> ACF arrays. The arrays have shape
-        ``ntemps x nchains``.
+        ``ntemps x nchains x niterations``.
     """
     acfs = {}
     with loadfile(filename, 'r') as fp:
@@ -160,7 +159,7 @@ def compute_acf(filename, start_index=None, end_index=None,
                         thin_end=end_index, chains=ci, temps=tk)[param]
                     thisacf = autocorrelation.calculate_acf(samples).numpy()
                     subsubacfs.append(thisacf)
-                # stack the chains 
+                # stack the chains
                 subacfs.append(subsubacfs)
             # stack the temperatures
             acfs[param] = numpy.stack(subacfs)
@@ -231,7 +230,7 @@ def compute_acl(filename, start_index=None, end_index=None,
     return acls
 
 
-def acl_from_acls(acls):
+def acl_from_raw_acls(acls):
     """Calculates the ACL for one or more chains from a dictionary of ACLs.
 
     This is for parallel tempered MCMCs in which the chains are independent

--- a/pycbc/inference/sampler/base_multitemper.py
+++ b/pycbc/inference/sampler/base_multitemper.py
@@ -267,7 +267,7 @@ def ensemble_compute_acf(filename, start_index=None, end_index=None,
     ``per_walker=True``.
 
     Parameters
-    -----------
+    ----------
     filename : str
         Name of a samples file to compute ACFs for.
     start_index : int, optional
@@ -313,13 +313,13 @@ def ensemble_compute_acf(filename, start_index=None, end_index=None,
                     # just call myself with a single walker
                     if walkers is None:
                         walkers = numpy.arange(fp.nwalkers)
-                    arrays = [ensemble_compute_acfs(filename,
-                                                    start_index=start_index,
-                                                    end_index=end_index,
-                                                    per_walker=False,
-                                                    walkers=ii,
-                                                    parameters=param,
-                                                    temps=tk)[param][0, :]
+                    arrays = [ensemble_compute_acf(filename,
+                                                   start_index=start_index,
+                                                   end_index=end_index,
+                                                   per_walker=False,
+                                                   walkers=ii,
+                                                   parameters=param,
+                                                   temps=tk)[param][0, :]
                               for ii in walkers]
                     # we'll stack all of the walker arrays to make a single
                     # nwalkers x niterations array; when these are stacked

--- a/pycbc/inference/sampler/base_multitemper.py
+++ b/pycbc/inference/sampler/base_multitemper.py
@@ -226,7 +226,7 @@ def compute_acl(filename, start_index=None, end_index=None,
             acls[param] = these_acls
         # report the mean ACL: take the max over the temps and parameters
         acl = numpy.array(list(acls.values())).max(axis=2).max(axis=0)
-        act = acl*fp.thin_interval
+        act = acl*fp.thinned_by
         logging.info("Min, mean, max ACT: %s, %s, %s",
                      str(act.min()), str(act.mean()), str(act.max()))
     return acls

--- a/pycbc/inference/sampler/base_multitemper.py
+++ b/pycbc/inference/sampler/base_multitemper.py
@@ -147,12 +147,7 @@ def compute_acf(filename, start_index=None, end_index=None,
             parameters = fp.variable_params
         if isinstance(parameters, string_types):
             parameters = [parameters]
-        if isinstance(temps, int):
-            temps = [temps]
-        elif temps == 'all':
-            temps = numpy.arange(fp.ntemps)
-        elif temps is None:
-            temps = [0]
+        temps = _get_temps_idx(fp, temps)
         if chains is None:
             chains = numpy.arange(fp.nchains)
         for param in parameters:
@@ -308,12 +303,7 @@ def ensemble_compute_acf(filename, start_index=None, end_index=None,
             parameters = fp.variable_params
         if isinstance(parameters, string_types):
             parameters = [parameters]
-        if isinstance(temps, int):
-            temps = [temps]
-        elif temps == 'all':
-            temps = numpy.arange(fp.ntemps)
-        elif temps is None:
-            temps = [0]
+        temps = _get_temps_idx(fp, temps)
         for param in parameters:
             subacfs = []
             for tk in temps:
@@ -404,3 +394,15 @@ def ensemble_compute_acl(filename, start_index=None, end_index=None,
         maxacl = numpy.array(list(acls.values())).max()
         logging.info("ACT: %s", str(maxacl*fp.thin_interval))
     return acls
+
+
+def _get_temps_idx(fp, temps):
+    """Gets the indices of temperatures to load for computing ACF.
+    """
+    if isinstance(temps, int):
+        temps = [temps]
+    elif temps == 'all':
+        temps = numpy.arange(fp.ntemps)
+    elif temps is None:
+        temps = [0]
+    return temps

--- a/pycbc/inference/sampler/emcee.py
+++ b/pycbc/inference/sampler/emcee.py
@@ -195,7 +195,7 @@ class EmceeEnsembleSampler(EnsembleSupport, BaseMCMC, BaseSampler):
 
     @staticmethod
     def compute_acf(filename, **kwargs):
-        """Computes the autocorrelation function.
+        r"""Computes the autocorrelation function.
 
         Calls :py:func:`base_mcmc.ensemble_compute_acf`; see that
         function for details.
@@ -219,7 +219,7 @@ class EmceeEnsembleSampler(EnsembleSupport, BaseMCMC, BaseSampler):
 
     @staticmethod
     def compute_acl(filename, **kwargs):
-        """Computes the autocorrelation length.
+        r"""Computes the autocorrelation length.
 
         Calls :py:func:`base_mcmc.ensemble_compute_acl`; see that
         function for details.

--- a/pycbc/inference/sampler/emcee.py
+++ b/pycbc/inference/sampler/emcee.py
@@ -33,7 +33,8 @@ import emcee
 from pycbc.pool import choose_pool
 
 from .base import (BaseSampler, setup_output)
-from .base_mcmc import (BaseMCMC, ensemble_compute_acf, ensemble_compute_acl,
+from .base_mcmc import (BaseMCMC, EnsembleSupport,
+                        ensemble_compute_acf, ensemble_compute_acl,
                         raw_samples_to_dict,
                         blob_data_to_dict, get_optional_arg_from_config)
 from ..burn_in import EnsembleMCMCBurnInTests
@@ -88,7 +89,7 @@ class EmceeEnsembleSampler(EnsembleSupport, BaseMCMC, BaseSampler):
             pool.count = nprocesses
 
         # set up emcee
-        self._nwalkers = nwalkers
+        self.nwalkers = nwalkers
         ndim = len(model.variable_params)
         self._sampler = emcee.EnsembleSampler(nwalkers, ndim, model_call,
                                               pool=pool)
@@ -176,7 +177,8 @@ class EmceeEnsembleSampler(EnsembleSupport, BaseMCMC, BaseSampler):
         """
         with self.io(filename, 'a') as fp:
             # write samples
-            fp.write_samples(self.samples, self.model.variable_params,
+            fp.write_samples(self.samples,
+                             parameters=self.model.variable_params,
                              last_iteration=self.niterations)
             # write stats
             fp.write_samples(self.model_stats,

--- a/pycbc/inference/sampler/emcee.py
+++ b/pycbc/inference/sampler/emcee.py
@@ -49,7 +49,7 @@ from .. import models
 # =============================================================================
 #
 
-class EmceeEnsembleSampler(BaseMCMC, BaseSampler):
+class EmceeEnsembleSampler(EnsembleSupport, BaseMCMC, BaseSampler):
     """This class is used to construct an MCMC sampler from the emcee
     package's EnsembleSampler.
 

--- a/pycbc/inference/sampler/emcee.py
+++ b/pycbc/inference/sampler/emcee.py
@@ -35,7 +35,7 @@ from pycbc.pool import choose_pool
 from .base import (BaseSampler, setup_output)
 from .base_mcmc import (BaseMCMC, MCMCAutocorrSupport, raw_samples_to_dict,
                         blob_data_to_dict, get_optional_arg_from_config)
-from ..burn_in import MCMCBurnInTests
+from ..burn_in import EnsembleMCMCBurnInTests
 from pycbc.inference.io import EmceeFile
 from .. import models
 
@@ -65,7 +65,7 @@ class EmceeEnsembleSampler(MCMCAutocorrSupport, BaseMCMC, BaseSampler):
     """
     name = "emcee"
     _io = EmceeFile
-    burn_in_class = MCMCBurnInTests
+    burn_in_class = EnsembleMCMCBurnInTests
 
     def __init__(self, model, nwalkers,
                  checkpoint_interval=None, checkpoint_signal=None,

--- a/pycbc/inference/sampler/emcee.py
+++ b/pycbc/inference/sampler/emcee.py
@@ -33,7 +33,8 @@ import emcee
 from pycbc.pool import choose_pool
 
 from .base import (BaseSampler, setup_output)
-from .base_mcmc import (BaseMCMC, MCMCAutocorrSupport, raw_samples_to_dict,
+from .base_mcmc import (BaseMCMC, ensemble_compute_acf, ensemble_compute_acl,
+                        raw_samples_to_dict,
                         blob_data_to_dict, get_optional_arg_from_config)
 from ..burn_in import EnsembleMCMCBurnInTests
 from pycbc.inference.io import EmceeFile
@@ -48,7 +49,7 @@ from .. import models
 # =============================================================================
 #
 
-class EmceeEnsembleSampler(MCMCAutocorrSupport, BaseMCMC, BaseSampler):
+class EmceeEnsembleSampler(BaseMCMC, BaseSampler):
     """This class is used to construct an MCMC sampler from the emcee
     package's EnsembleSampler.
 
@@ -189,6 +190,52 @@ class EmceeEnsembleSampler(MCMCAutocorrSupport, BaseMCMC, BaseSampler):
         """All data is written by the last checkpoint in the run method, so
         this just passes."""
         pass
+
+    @staticmethod
+    def compute_acf(filename, **kwargs):
+        """Computes the autocorrelation function.
+
+        Calls :py:func:`base_mcmc.ensemble_compute_acf`; see that
+        function for details.
+
+        Parameters
+        ----------
+        filename : str
+            Name of a samples file to compute ACFs for.
+        \**kwargs :
+            All other keyword arguments are passed to
+            :py:func:`base_mcmc.ensemble_compute_acf`.
+
+        Returns
+        -------
+        dict :
+            Dictionary of arrays giving the ACFs for each parameter. If
+            ``per-walker`` is True, the arrays will have shape
+            ``nwalkers x niterations``.
+        """
+        return ensemble_compute_acf(filename, **kwargs)
+
+    @staticmethod
+    def compute_acl(filename, **kwargs):
+        """Computes the autocorrelation length.
+
+        Calls :py:func:`base_mcmc.ensemble_compute_acl`; see that
+        function for details.
+
+        Parameters
+        -----------
+        filename : str
+            Name of a samples file to compute ACLs for.
+        \**kwargs :
+            All other keyword arguments are passed to
+            :py:func:`base_mcmc.ensemble_compute_acf`.
+
+        Returns
+        -------
+        dict
+            A dictionary giving the ACL for each parameter.
+        """
+        return ensemble_compute_acl(filename, **kwargs)
 
     @classmethod
     def from_config(cls, cp, model, output_file=None, nprocesses=1,

--- a/pycbc/inference/sampler/emcee_pt.py
+++ b/pycbc/inference/sampler/emcee_pt.py
@@ -121,7 +121,7 @@ class EmceePTSampler(MultiTemperedSupport, EnsembleSupport, BaseMCMC,
 
     @staticmethod
     def compute_acf(filename, **kwargs):
-        """Computes the autocorrelation function.
+        r"""Computes the autocorrelation function.
 
         Calls :py:func:`base_multitemper.ensemble_compute_acf`; see that
         function for details.
@@ -146,7 +146,7 @@ class EmceePTSampler(MultiTemperedSupport, EnsembleSupport, BaseMCMC,
 
     @staticmethod
     def compute_acl(filename, **kwargs):
-        """Computes the autocorrelation length.
+        r"""Computes the autocorrelation length.
 
         Calls :py:func:`base_multitemper.ensemble_compute_acl`; see that
         function for details.

--- a/pycbc/inference/sampler/emcee_pt.py
+++ b/pycbc/inference/sampler/emcee_pt.py
@@ -27,7 +27,7 @@ import logging
 from pycbc.pool import choose_pool
 
 from .base import (BaseSampler, setup_output)
-from .base_mcmc import (BaseMCMC, raw_samples_to_dict,
+from .base_mcmc import (BaseMCMC, EnsembleSupport, raw_samples_to_dict,
                         get_optional_arg_from_config)
 from .base_multitemper import (MultiTemperedSupport,
                                ensemble_compute_acf, ensemble_compute_acl)
@@ -102,7 +102,7 @@ class EmceePTSampler(MultiTemperedSupport, EnsembleSupport, BaseMCMC,
         self._sampler = emcee.PTSampler(ntemps, nwalkers, ndim,
                                         model_call, prior_call, pool=pool,
                                         betas=betas)
-        self._nwalkers = nwalkers
+        self.nwalkers = nwalkers
         self._ntemps = ntemps
         self._checkpoint_interval = checkpoint_interval
         self._checkpoint_signal = checkpoint_signal
@@ -351,7 +351,8 @@ class EmceePTSampler(MultiTemperedSupport, EnsembleSupport, BaseMCMC,
         """
         with self.io(filename, 'a') as fp:
             # write samples
-            fp.write_samples(self.samples, self.model.variable_params,
+            fp.write_samples(self.samples,
+                             parameters=self.model.variable_params,
                              last_iteration=self.niterations)
             # write stats
             fp.write_samples(self.model_stats, last_iteration=self.niterations)

--- a/pycbc/inference/sampler/emcee_pt.py
+++ b/pycbc/inference/sampler/emcee_pt.py
@@ -30,14 +30,13 @@ from .base import (BaseSampler, setup_output)
 from .base_mcmc import (BaseMCMC, raw_samples_to_dict,
                         get_optional_arg_from_config)
 from .base_multitemper import (MultiTemperedSupport,
-                               MultiTemperedAutocorrSupport)
+                               ensemble_compute_acf, ensemble_compute_acl)
 from ..burn_in import EnsembleMultiTemperedMCMCBurnInTests
 from pycbc.inference.io import EmceePTFile
 from .. import models
 
 
-class EmceePTSampler(MultiTemperedAutocorrSupport, MultiTemperedSupport,
-                     BaseMCMC, BaseSampler):
+class EmceePTSampler(MultiTemperedSupport, BaseMCMC, BaseSampler):
     """This class is used to construct a parallel-tempered MCMC sampler from
     the emcee package's PTSampler.
 
@@ -118,6 +117,53 @@ class EmceePTSampler(MultiTemperedAutocorrSupport, MultiTemperedSupport,
     @property
     def betas(self):
         return self._sampler.betas
+
+    @staticmethod
+    def compute_acf(filename, **kwargs):
+        """Computes the autocorrelation function.
+
+        Calls :py:func:`base_multitemper.ensemble_compute_acf`; see that
+        function for details.
+
+        Parameters
+        ----------
+        filename : str
+            Name of a samples file to compute ACFs for.
+        \**kwargs :
+            All other keyword arguments are passed to
+            :py:func:`base_multitemper.ensemble_compute_acf`.
+
+        Returns
+        -------
+        dict :
+            Dictionary of arrays giving the ACFs for each parameter. If
+            ``per-walker=True`` is passed as a keyword argument, the arrays
+            will have shape ``ntemps x nwalkers x niterations``. Otherwise, the
+            returned array will have shape ``ntemps x niterations``.
+        """
+        return ensemble_compute_acf(filename, **kwargs)
+
+    @staticmethod
+    def compute_acl(filename, **kwargs):
+        """Computes the autocorrelation length.
+
+        Calls :py:func:`base_multitemper.ensemble_compute_acl`; see that
+        function for details.
+
+        Parameters
+        -----------
+        filename : str
+            Name of a samples file to compute ACLs for.
+        \**kwargs :
+            All other keyword arguments are passed to
+            :py:func:`base_multitemper.ensemble_compute_acf`.
+
+        Returns
+        -------
+        dict
+            A dictionary of ntemps-long arrays of the ACLs of each parameter.
+        """
+        return ensemble_compute_acl(filename, **kwargs)
 
     @classmethod
     def from_config(cls, cp, model, output_file=None, nprocesses=1,

--- a/pycbc/inference/sampler/emcee_pt.py
+++ b/pycbc/inference/sampler/emcee_pt.py
@@ -31,7 +31,7 @@ from .base_mcmc import (BaseMCMC, raw_samples_to_dict,
                         get_optional_arg_from_config)
 from .base_multitemper import (MultiTemperedSupport,
                                MultiTemperedAutocorrSupport)
-from ..burn_in import MultiTemperedMCMCBurnInTests
+from ..burn_in import EnsembleMultiTemperedMCMCBurnInTests
 from pycbc.inference.io import EmceePTFile
 from .. import models
 
@@ -66,7 +66,7 @@ class EmceePTSampler(MultiTemperedAutocorrSupport, MultiTemperedSupport,
     """
     name = "emcee_pt"
     _io = EmceePTFile
-    burn_in_class = MultiTemperedMCMCBurnInTests
+    burn_in_class = EnsembleMultiTemperedMCMCBurnInTests
 
     def __init__(self, model, ntemps, nwalkers, betas=None,
                  checkpoint_interval=None, checkpoint_signal=None,

--- a/pycbc/inference/sampler/emcee_pt.py
+++ b/pycbc/inference/sampler/emcee_pt.py
@@ -36,7 +36,8 @@ from pycbc.inference.io import EmceePTFile
 from .. import models
 
 
-class EmceePTSampler(MultiTemperedSupport, BaseMCMC, BaseSampler):
+class EmceePTSampler(MultiTemperedSupport, EnsembleSupport, BaseMCMC,
+                     BaseSampler):
     """This class is used to construct a parallel-tempered MCMC sampler from
     the emcee package's PTSampler.
 
@@ -156,7 +157,7 @@ class EmceePTSampler(MultiTemperedSupport, BaseMCMC, BaseSampler):
             Name of a samples file to compute ACLs for.
         \**kwargs :
             All other keyword arguments are passed to
-            :py:func:`base_multitemper.ensemble_compute_acf`.
+            :py:func:`base_multitemper.ensemble_compute_acl`.
 
         Returns
         -------

--- a/pycbc/inference/sampler/epsie.py
+++ b/pycbc/inference/sampler/epsie.py
@@ -197,14 +197,14 @@ class EpsieSampler(MultiTemperedSupport, BaseMCMC, BaseSampler):
         """
         return compute_acl(filename, **kwargs)
 
-    @property  # pylint: disable=invalid-overridden-method
-    def acl(self):
+    @property
+    def acl(self):  # pylint: disable=invalid-overridden-method
         """The autocorrelation lengths of the chains.
         """
         return acl_from_raw_acls(self.raw_acls)
 
-    @property  # pylint: disable=invalid-overridden-method
-    def effective_nsamples(self):
+    @property
+    def effective_nsamples(self):  # pylint: disable=invalid-overridden-method
         """The effective number of samples post burn-in that the sampler has
         acquired so far.
         """

--- a/pycbc/inference/sampler/epsie.py
+++ b/pycbc/inference/sampler/epsie.py
@@ -220,7 +220,7 @@ class EpsieSampler(MultiTemperedSupport, BaseMCMC, BaseSampler):
             # ensure that any chain not burned in has zero samples
             nperchain[~self.burn_in.is_burned_in] = 0
             # and that any chain that is burned in has at least one sample
-            nperchain[self.burn_in.is_burned_in & nperchain < 1] = 1
+            nperchain[self.burn_in.is_burned_in & (nperchain < 1)] = 1
         return int(nperchain.sum())
 
     @property

--- a/pycbc/inference/sampler/epsie.py
+++ b/pycbc/inference/sampler/epsie.py
@@ -121,7 +121,7 @@ class EpsieSampler(MultiTemperedSupport, BaseMCMC, BaseSampler):
             default_proposal_args=default_proposal_args,
             seed=seed, pool=pool)
         # set other parameters
-        self._nwalkers = nchains
+        self.nchains = nchains
         self._ntemps = ntemps
         self._checkpoint_interval = checkpoint_interval
         self._checkpoint_signal = checkpoint_signal
@@ -308,7 +308,8 @@ class EpsieSampler(MultiTemperedSupport, BaseMCMC, BaseSampler):
         """
         with self.io(filename, 'a') as fp:
             # write samples
-            fp.write_samples(self.samples, self.model.variable_params,
+            fp.write_samples(self.samples,
+                             parameters=self.model.variable_params,
                              last_iteration=self.niterations)
             # write stats
             fp.write_samples(self.model_stats, last_iteration=self.niterations)

--- a/pycbc/inference/sampler/epsie.py
+++ b/pycbc/inference/sampler/epsie.py
@@ -197,13 +197,13 @@ class EpsieSampler(MultiTemperedSupport, BaseMCMC, BaseSampler):
         """
         return compute_acl(filename, **kwargs)
 
-    @property
+    @property  # pylint: disable=invalid-overridden-method
     def acl(self):
         """The autocorrelation lengths of the chains.
         """
         return acl_from_raw_acls(self.raw_acls)
 
-    @property
+    @property  # pylint: disable=invalid-overridden-method
     def effective_nsamples(self):
         """The effective number of samples post burn-in that the sampler has
         acquired so far.


### PR DESCRIPTION
This separates ensemble MCMC (in which chains share information) methods from generic MCMC methods (in which chains are independent of each other) in the io, burn in, and sampler module. The primary purpose of this is to allow epsie (or any other future MCMC sampler) to use different burn in iterations and ACLs for different chains, resulting in a different number of effective samples being collected from different chains. This also lays ground work for implementing a transdimensional MCMC in the future.

This turned out to be way more work than I anticipated when I started it. I didn't realize how much ensemble MCMC-specific things were ingrained in the base MCMC classes. Hence the large patch. In terms of actual differences a user would notice, the output for emcee(_pt) files are largely unchanged. The only differences are burn-in information is now stored as datasets in the output file's `sampler_info` group as opposed to the `sampler_info`'s `attrs` (this is something I've been wanting to do for awhile), and the autocorrelation time is stored (again, as datasets rather than attrs) rather than autocorrleation length. I switched to the former because ACTs are independent of the thinning interval used in the file. However, both ACTs and ACLs can now be easily accessed with file attributes.

I've done several tests to check everything is working. I ran on the 1D normal likelihood with various levels of burn-in and checkpointing turned on. I did this for [epsie](https://www.atlas.aei.uni-hannover.de/~work-cdcapano/scratch/prs/epsie_separate_acls/analytic_test/), [emcee_pt](https://www.atlas.aei.uni-hannover.de/~work-cdcapano/scratch/prs/epsie_separate_acls/emcee_pt-analytic_test/), and [emcee](https://www.atlas.aei.uni-hannover.de/~work-cdcapano/scratch/prs/epsie_separate_acls/emcee-analytic_test/) (click on the links to see the results). I also ran a workflow on GW150914 using `emcee_pt`, along with various settings for epsie. Results are [here](https://www.atlas.aei.uni-hannover.de/~work-cdcapano/scratch/prs/epsie_separate_acls/py37_gw150914_8perchain/). Importantly, the `emcee_pt` results are what we expect.

Here is a summary of the changes that are made in each file:

`burn_in.py`:
 * Formerly there was a single BurnIn class for single-temperature samplers, and another one that inherited from it for parallel-tempered samplers. Now there are two separate classes for single-temperatures (and corresponding versions for parallel tempered), an `MCMCBurnInTests` for MCMCs with independent chains (epsie) and an `EnsembleMCMCBurnInTests` for ensemble MCMCs (emcee, emcee_pt). Both of these inherit from a `BaseBurnInTests` which implements the common functions. The difference between the MCMC and Ensemble classes is the former applies tests separately to each chain, returning an array of burn-in iterations and test results that can be different for each chain. The ensemble class, on the other hand, applies burn in tests to all chains, returning only a single test value and iteration for the entire ensemble (as it currently does). In other words, the ensemble test are only burned in if all the chains are burned in, whereas the independent ones may burn in separately.
 * The separate Ensemble and MCMC classes also allow different tests to be implemented for each. For example, the ensemble class has the ks-test (compares the distribution of walkers to what it was at the halfway point), but the MCMC class does not. I plan to take use this to add a Gelman-Rubin test to the MCMC class in the future, which would not be implemented for the Ensemble class.
 * The way the burn in classes store data is more simple. Previously, all data was stored to `burn_in_data` which was a dictionary keyed by tests that pointed to dictionaries. The sub-dictionaries had to have `burn_in_iteration` and `is_burned_in` in them, but could also have other test-specific things. Now, `burn_in_iteration` and `is_burned_in` for each test are separate attributes (called `test_(burn_in_iteration|is_burned_in)`) which are simple dictionaries that store test names -> result. Any extra information a test returns is stored as `test_aux_info`.
 * Writing burn-in results has been moved from a method of `BaseMCMC` io classes to methods of the burn in classes. I did this because the different burn-in classes may write different amount of information.

`io/base_hdf.py`:
 * thin start/interval/end are no longer stored to the file's attrs. Instead, these are attributes of the class. The base version just return 0, 1, None, respectively, but can be overridden by inheriting classes (which is done by the MCMC classes; see below). This was done to allow the thin attributes to be arrays, and also reduces the amount of bookkeeping that needs to be done in the file. For example, previously the burn-in index had to be copied to the thin-start attr in the file (and both needed to be updated whenver a new burn-in test was applied, or file thinning was done). Now, the class just handle that on the fly.
 * The `get_slice` method was simplified. It no longer tries to silently pull from the file's thin start/interval/end attributes. Instead, these need to be supplied to the function.
 * A `write_data` method is added to reduce code redundancy. This takes care of figuring out if a dataset already exists in a file when writing, overwriting the data if it does, and creating the dataset (along with the group) if it does not.

`io/base_mcmc.py`:
 * The `MCMCMetadataIO` class is now split into three classes: a `CommonMCMCMetadatIO`, `MCMCMetadataIO`, and `EnsembleMCMCMetadataIO`. `Common` implements all the methods common to both independent-chain MCMCs and ensemble MCMCs. `MCMCMetadataIO` implements methods specific to independent chain MCMCs; ditto for `Ensemble`.
 * Both `MCMCMetadataIO`  and `EnsembleMetadataIO` override the base file class's `thin_(start|interval|end)`. In both cases, the `thin_start` attribute returns the burn-in index if a burn-in test was done (0 otherwise), and `thin_interval` attribute returns the ACL if it was calculated (1 otherwise). This is what I meant about thinning settings handled on the fly above, removing these values being stored twice in the files. The difference between `Ensemble` and `MCMC` is the former returns integers for these values, whereas `MCMC` returns arrays giving the values for each chain. 
 * `CommonMCMCMetadataIO` now has `act`, `raw_acts`, `acl`, and `raw_acls` attributes. Setting the `*act` attributes writes the autocorrelation times to the file. The `raw_*` are the times per parameter and temperature.  The `act` is the maximum over the parameters and temperatures. For ensemble MCMCs, this is a single value for all the ensemble, whereas for independent-chain MCMCs this is an array for each chain. However, the file class doesn't need to worry about the distinction, since the results are stored as a dataset in either case. The `*acl` are derived on the fly from stored ACTs by dividing the ACTs by the file's `thinned_by` attribute.
 * `CommonMCMCMetadataIO` has both `nwalkers` and `nchains` attributes. These are just aliases of each other. Ensemble samplers call their chains "walkers" whereas a collection of MCMC chains are just "chains." Since we've coded up "walkers" in a bunch of places, I decided to just alias the two.
 * The `SingleTempMCMCIO` class has been removed. Formerly, this implemented the `write_samples` and `read_raw_samples` functions. Now, `write_samples` and `read_raw_samples` are implemented as stand-alone functions, which file classes explicitly call, rather than inheriting from a class. This was done because the `write_samples` functions are common between ensemble and independent MCMC samplers, but the `read_raw_samples` are different. Simplest to allow each sampler's file class pick which functions to use on their own.
 * The `SingleTempMCMCIO`'s `read_raw_samples` is now `ensemble_read_raw_samples`, as this is for single-temperature Ensemble MCMCs (emcee). An equivalent function for single-temperature independent-chain MCMCs is not implemented, since epsie is parallel-tempered. If a single-temperature single-chain MCMC is added in the future, it would be straight forward to add a `read_raw_samples` function for it.
 * Some of the things that were done inside of `read_raw_samples` -- getting the indices of iterations to load, getting the walker indices -- are now broken out to separate private functions, to reduce code redundancy. 
 * An `nsamples_per_chain` function is added to compute the number of samples you'll get back from an array given a thin start, thin interval, and number of iterations. The function is vectorized, so can be used with a single chain, or an array of chains.
 
`io/base_multitemper.py`:
 * `MultiTemperedMCMCMetadataIO` has been renamed`CommonMultiTemperedMCMCMetadataIO`, and inherits from `CommonMCMCMetadataIO`. This adds temps to the common MCMC metadata.
 * As was done in `base_mcmc`, `MultiTemperedMCMCIO` has been removed. That class's `write_samples ` and `read_raw_samples` for parallel-tempered MCMCs are now the stand-alone `write_samples` and `ensemble_read_raw_samples`. The former does not have the `ensemble_` prefix because it works with both types. The latter has the `ensemble_` because it is meant for ensemble parallel-tempered samplers.
 * A `read_raw_samples` stand-alone function is added for parallel-tempered MCMCs with independent chains. This is the function that epsie uses for reading samples now. It can handle chains having different burn-in iterations and ACLs. If an unflattened array is requested, it will use NaNs as fill values for chains that return fewer samples.
 * Getting the temperature indices to load is moved to a stand-alone private function, to reduce code redundancy between the two read functions.

`io/emcee.py`:
 * `EmceeFile` now inherits from `EnsembleMCMCMetadataIO`, `CommonMCMCMetadataIO`, and `BaseSamplerFile`.
 * The `write_samples` and `read_raw_samples` functions are now defined here, calling `base_mcmc.write_samples` and `base_mcmc.ensemble_read_raw_samples`, respectively.

`io/emcee_pt.py`:
 * `EmceePTFile` now inherits from `EnsembleMCMCMetadataIO`, `CommonMultiTemperedMetadataIO`, and `BaseSamplerFile`.
 * The `write_samples` and `read_raw_samples` functions are now defined here, calling `base_multitemper.write_samples` and `base_multitemper.ensemble_read_raw_samples`, respectively.

`io/epsie.py`:
 * `EpsieFile` now inherits from `MCMCMetadataIO`, `CommonMultiTemperedMetadataIO`, and `BaseSamplerFile`.
 * The `write_samples` and `read_raw_samples` functions are now defined here, calling `base_multitemper.write_samples` and `base_multitemper.read_raw_samples`, respectively.

`sampler/base_mcmc.py`:
 * Ensemble-MCMC specific attributes have been split off from the `BaseMCMC` class and into a support class called `EnsembleSupport`.
 * The `nwalkers` attribute in `BaseMCMC` has been renamed `nchains`. `EnsembleSupport` implements a `nwalkers` attribute, which is an alias of `nchains`.
 * The `acl` attribute is now an `abstractmethod` in `BaseMCMC`. The purpose of this is to convert the `raw_acls` into an ACL. `EnsembleSupport` implements this method for ensemble samplers, which is just the max over all ACLs.
 * `effective_nsamples` has been made an abstract method of `BaseMCMC` since the way this is calculated depends on if it is an ensemble (in which you have the same number of effective samples from all chains) or an independent set of chains (in which the samples from each chain can be different). The former `effective_nsamples` method has been moved to `EnsembleSupport` (although it now calls `io/base_mcmc/nsamples_in_chain` to reduce redundancy).
 * The `MCMCAutocorrSupport` class has been removed. Instead, `compute_acl` and `compute_acf` are moved to stand-alone functions. Since these were specific to Ensemble samplers, the new functions have the `ensemble_` prefix.

`sampler/base_multitemper.py`:
 * The `MultiTemperedMCMCAutocorrSupport` class has been removed. As was done in `base_mcmc`, its `compute_acl` and `compute_acf` methods have been moved to stand-alone functions, with the `ensemble_` prefix.
 * Stand-alone `compute_acl` and `compute_acf` functions are added for independent-chain MCMCs. These differ from the ensemble versions in that they do not average their chains together before computing the ACL. Instead, an ACL is calculated separately for each chain, and an array of ACLs is returned.
 * An `acl_from_raw_acls` function is added to get an ACL from a dictionary of raw ACLs for independent chains. This works by taking the maximum over the parameters and temperatures for each chain (but does not maximize over chains). An equivalent is not needed for `ensemble` samplers, since the simple taking the max over everything that is implemented in `EnsembleSupport.acl` works for both single-temperature and parallel-tempered ensemble MCMCs.

`sampler/emcee.py`:
 * The `EmceeEnsembleSampler` sampler now inherits from `EnsembleSupport`, `BaseMCMC`, and `BaseSampler`. Its `burn_in_class` is set to `EnsembleMCMCBurnInTests`.
 * Its `compute_acl` and `compute_acf` functions are implemented here, which call `sampler/base_mcmc.ensemble_compute_ac(l|f)`.

`sampler/emcee_pt.py`:
 * `EmceePTSampler` now inherits from `MultiTemperedSupport`, `EnsembleSupport`, `BaseMCMC`, and `BaseSampler`. Its `burn_in_class` is set to `EnsembleMultiTemperedMCMCBurnInTests`.
 * Its `compute_acl` and `compute_acf` functions are implemented here, which call `sampler/base_multitemper.ensemble_compute_ac(l|f)`.

`sampler/epsie.py`:
 * `EpsieSampler` now inherits from `MultiTemperedSupport`, `BaseMCMC`, and `BaseSampler`. Its `burn_in_class` is `MCMCBurnInTests` (same name as before, though different class; see changes to `burn_in.py`, above).
 * Its `compute_acl` and `compute_acf` function call `sampler/base_multitemper.compute_ac(l|f)`.
 * The `acl` property (which, because this does not use `EnsembleSupport` is inherited as an `abstractmethod` from `BaseMCMC`). Calls `base_multitemper.acl_from_acls`.
 * Implements `effective_nsamples` (again, inherited as an abstract method) which computes the total number of effective samples from all the chains.

`bin/inference/pycbc_inference_plot_acl`:
 * Update accessing the ACL from the file for emcee and emcee_pt for the new syntax. This executable will not work with epsie due to these changes (nor will plot samples or plot acf), but I'll address that in another patch.