### PR TITLE
Change ForegroundTriggers IFO information source

### DIFF
--- a/pycbc/io/hdf.py
+++ b/pycbc/io/hdf.py
@@ -688,19 +688,19 @@ class ForegroundTriggers(object):
                          self.coinc_file.h5file.attrs['detector_2']]
         self.sngl_files = {}
         if sngl_files is not None:
-            if len(sngl_files) < len(self.ifos):
-                raise RuntimeError("Not enough single-detector trigger files "
-                                   "given the IFOs involved in the statmap "
-                                   "file.")
-
             for sngl_file in sngl_files:
                 curr_dat = FileData(sngl_file)
                 curr_ifo = curr_dat.group_key
                 self.sngl_files[curr_ifo] = curr_dat
 
-            if not sorted(self.sngl_files.keys()) == sorted(self.ifos):
-                logging.warning("WARNING: Statmap file IFOs do not match "
-                                "single-detector trigger files.")
+        if not all([ifo in self.sngl_files.keys() for ifo in self.ifos]):
+            print("sngl_files: {}".format(sngl_files))
+            print("self.ifos: {}".format(self.ifos))
+            raise RuntimeError("IFOs in statmap file not all represented "
+                               "by single-detector trigger files.")
+        if not sorted(self.sngl_files.keys()) == sorted(self.ifos):
+            logging.warning("WARNING: Single-detector trigger files "
+                            "given for IFOs not in the statmap file")
 
         self.bank_file = HFile(bank_file, "r")
         self.n_loudest = n_loudest

--- a/pycbc/io/hdf.py
+++ b/pycbc/io/hdf.py
@@ -699,8 +699,8 @@ class ForegroundTriggers(object):
                 self.sngl_files[curr_ifo] = curr_dat
 
             if not sorted(self.sngl_files.keys()) == sorted(self.ifos):
-                logging.warn("WARNING: Statmap file IFOs do not match "
-                             "single-detector trigger files.")
+                logging.warning("WARNING: Statmap file IFOs do not match "
+                                "single-detector trigger files.")
 
         self.bank_file = HFile(bank_file, "r")
         self.n_loudest = n_loudest


### PR DESCRIPTION
read IFOs from coinc file in ForegroundTriggers rather than list of individual trigger files

This caused an issue, e.g. when using a H1L1 statmap file with H1, L1, V1 single-detector trigger files given on command line.

There are a couple of other places in the code which use `self.sngl_files.keys()` as the list of IFOs but I haven't changed these as I haven't seen issues with using them as they are