### PR TITLE
Offline hash handling

### DIFF
--- a/bin/hdfcoinc/pycbc_multiifo_coinc_statmap_inj
+++ b/bin/hdfcoinc/pycbc_multiifo_coinc_statmap_inj
@@ -101,8 +101,8 @@ if len(zdata) > 0:
     f['foreground/fap_exc'] = fap_exc
 
     logging.info('calculating injection backgrounds')
-    ifotimes = zip(zdata.data['%s/time' % ifo] for ifo in args.ifos)
-    ftimes = numpy.concatenate(ifotimes).mean(axis=0)
+    ifotimes = numpy.array([zdata.data['%s/time' % ifo] for ifo in args.ifos])
+    ftimes = ifotimes.mean(axis=0)
     start, end = ftimes - args.veto_window, ftimes + args.veto_window
 
     fnlouder = numpy.zeros(len(ftimes), dtype=numpy.float32)

--- a/bin/plotting/pycbc_ifar_catalog
+++ b/bin/plotting/pycbc_ifar_catalog
@@ -133,7 +133,7 @@ if h_inc_back_num >= 0 and h_iterations is not None and h_iterations != 0:
 else:
     fore_ifar = numpy.array([])
     for f in trigf:
-        fore_ifar = numpy.append(f['foreground/' + ifar_str][:], fore_ifar)
+        fore_ifar = numpy.append(fore_ifar, f['foreground/' + ifar_str][:])
 
 if opts.remove_threshold is not None and opts.truncate_threshold is not None:
     raise RuntimeError("Can't both remove and truncate foreground events!")

--- a/bin/plotting/pycbc_ifar_catalog
+++ b/bin/plotting/pycbc_ifar_catalog
@@ -131,7 +131,9 @@ if h_inc_back_num >= 0 and h_iterations is not None and h_iterations != 0:
     h_rm_ifar = hrm_sorted[idx_start:]
     h_rm_cumnum = numpy.arange(len(h_rm_ifar), 0, -1)
 else:
-    fore_ifar = f['foreground/' + ifar_str][:]
+    fore_ifar = numpy.array([])
+    for f in trigf:
+        fore_ifar = numpy.append(f['foreground/' + ifar_str][:], fore_ifar)
 
 if opts.remove_threshold is not None and opts.truncate_threshold is not None:
     raise RuntimeError("Can't both remove and truncate foreground events!")

--- a/bin/workflows/pycbc_create_offline_search_workflow
+++ b/bin/workflows/pycbc_create_offline_search_workflow
@@ -224,7 +224,7 @@ else:
         # Create coinc tag
         coinctag = '{}det'.format(len(ifocomb))
         ctagcomb = ['full_data', coinctag]
-        other_ifo_keys = no_fg_exc_files.keys()
+        other_ifo_keys = list(no_fg_exc_files.keys())
         other_ifo_keys.remove(ordered_ifo_list)
         other_bg_files = {ctype: no_fg_exc_files[ctype]
                           for ctype in other_ifo_keys}

--- a/pycbc/events/coinc.py
+++ b/pycbc/events/coinc.py
@@ -428,7 +428,7 @@ def cluster_coincs_multiifo(stat, time_coincs, timeslide_id, slide, window, argm
     cindex: numpy.ndarray
         The set of indices corresponding to the surviving coincidences
     """
-    time_coinc_zip = zip(*time_coincs)
+    time_coinc_zip = list(zip(*time_coincs))
     if len(time_coinc_zip) == 0:
         logging.info('No coincident triggers.')
         return numpy.array([])

--- a/pycbc/waveform/bank.py
+++ b/pycbc/waveform/bank.py
@@ -38,6 +38,7 @@ import pycbc.waveform.compress
 from pycbc import DYN_RANGE_FAC
 from pycbc.types import FrequencySeries, zeros
 import pycbc.io
+import six, hashlib
 
 def sigma_cached(self, psd):
     """ Cache sigma calculate for use in tandem with the FilterBank class
@@ -178,6 +179,26 @@ def parse_approximant_arg(approximant_arg, warray):
     """
     return warray.parse_boolargs(boolargs_from_apprxstr(approximant_arg))[0]
 
+def list_to_hash(list_to_be_hashed):
+    """
+    Return a hash for a numpy array, avoids native (unsafe) python3 hash function
+
+    Parameters
+    ----------
+    list_to_be_hashed: list
+        The list which is being hashed
+        Must be convertable to a numpy array
+
+    Returns
+    -------
+    int
+        an integer representation of the hashed array
+    """
+    if six.PY2:
+        return hash(list_to_be_hashed)
+    h = hashlib.sha256()
+    h.update(np.array(list_to_be_hashed).tobytes('C'))
+    return int.from_bytes(h.digest(), 'big')
 
 class TemplateBank(object):
     """Class to provide some basic helper functions and information
@@ -335,7 +356,7 @@ class TemplateBank(object):
                        'spin2x', 'spin2y', 'spin2z',]
 
         fields = [f for f in hash_fields if f in fields]
-        template_hash = np.array([hash(v) for v in zip(*[self.table[p]
+        template_hash = np.array([list_to_hash(v) for v in zip(*[self.table[p]
                                   for p in fields])])
         self.table = self.table.add_fields(template_hash, 'template_hash')
 

--- a/pycbc/waveform/bank.py
+++ b/pycbc/waveform/bank.py
@@ -179,13 +179,13 @@ def parse_approximant_arg(approximant_arg, warray):
     """
     return warray.parse_boolargs(boolargs_from_apprxstr(approximant_arg))[0]
 
-def list_to_hash(list_to_be_hashed):
+def tuple_to_hash(tuple_to_be_hashed):
     """
     Return a hash for a numpy array, avoids native (unsafe) python3 hash function
 
     Parameters
     ----------
-    list_to_be_hashed: list
+    tuple_to_be_hashed: tuple
         The list which is being hashed
         Must be convertable to a numpy array
 
@@ -195,10 +195,10 @@ def list_to_hash(list_to_be_hashed):
         an integer representation of the hashed array
     """
     if six.PY2:
-        return hash(list_to_be_hashed)
-    h = hashlib.sha256()
-    h.update(np.array(list_to_be_hashed).tobytes('C'))
-    return int.from_bytes(h.digest(), 'big')
+        return hash(tuple_to_be_hashed)
+    h = hashlib.blake2b(np.array(tuple_to_be_hashed).tobytes('C'),
+                        digest_size=8)
+    return np.fromstring(h.digest(), dtype=int)[0]
 
 class TemplateBank(object):
     """Class to provide some basic helper functions and information
@@ -356,8 +356,11 @@ class TemplateBank(object):
                        'spin2x', 'spin2y', 'spin2z',]
 
         fields = [f for f in hash_fields if f in fields]
-        template_hash = np.array([list_to_hash(v) for v in zip(*[self.table[p]
+        template_hash = np.array([tuple_to_hash(v) for v in zip(*[self.table[p]
                                   for p in fields])])
+        if not np.unique(template_hash).size == template_hash.size:
+            raise RuntimeError("Some template hashes clash. This should not "
+                               "happen.")
         self.table = self.table.add_fields(template_hash, 'template_hash')
 
     def write_to_hdf(self, filename, start_index=None, stop_index=None,

--- a/pycbc/waveform/bank.py
+++ b/pycbc/waveform/bank.py
@@ -38,7 +38,8 @@ import pycbc.waveform.compress
 from pycbc import DYN_RANGE_FAC
 from pycbc.types import FrequencySeries, zeros
 import pycbc.io
-import six, hashlib
+import six
+import hashlib
 
 def sigma_cached(self, psd):
     """ Cache sigma calculate for use in tandem with the FilterBank class

--- a/pycbc/waveform/bank.py
+++ b/pycbc/waveform/bank.py
@@ -187,8 +187,8 @@ def tuple_to_hash(tuple_to_be_hashed):
     Parameters
     ----------
     tuple_to_be_hashed: tuple
-        The list which is being hashed
-        Must be convertable to a numpy array
+        The tuple which is being hashed
+        Must be convertible to a numpy array
 
     Returns
     -------


### PR DESCRIPTION
Makes a function which detects whether using python 2 or python 3 and decides whether to use native hash (unsafe in python 3) or hashlib module (utilises int.to_bytes which is unavailable in python2)

Solves issue #3302

Note that I haven't been able to test using bank2hdf, as I haven't been able to get that to work even with the original function! However this works with Tito's test script