### PR TITLE
add plugin handling for waveforms

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -72,16 +72,28 @@ your own build.
 
    pip install lalsuite pycbc
 
-Full detailed installation instructions for users who want to use and develop PyCBC are available at:
+Full detailed installation instructions which covers other installation cases:
 
 .. toctree::
    :maxdepth: 1
 
    install
 
-=======================
-Documentation for Users
-=======================
+====================================================
+Parameter Estimation of Gravitational-wave Sources
+====================================================
+
+Users who want to create and run parameter estimation workflows should read the
+documentation at:
+
+.. toctree::
+   :maxdepth: 2
+
+   inference
+   
+==========================================
+Searching for Gravitational-wave Signals
+==========================================
 
 Users who want to create and run scientific workflows to search for compact
 binaries should read the documentation in the links at:
@@ -93,13 +105,9 @@ binaries should read the documentation in the links at:
    workflow/pycbc_make_coinc_search_workflow
    workflow/pygrb.rst
 
-Users who want to create and run parameter estimation workflows should read the
-documentation at:
-
-.. toctree::
-   :maxdepth: 2
-
-   inference
+===================================================
+Template Banks, Hardware Injections, and more...
+===================================================
 
 Users who are interested in tools that PyCBC provides for various other
 analysis tasks (e.g. template bank generation, hardware injections, and testing
@@ -113,6 +121,19 @@ template banks) should read the documentation at:
    banksim
    faithsim
    upload_to_gracedb
+
+==========================================
+Extending PyCBC with external plugins
+==========================================
+
+Would you like to use a waveform model that PyCBC doesn't have? Or maybe
+you have your own waveform you'd like to use for a search, parameter estimation
+, etc. PyCBC supports a plug-in archictecture for external waveform models. 
+
+.. toctree::
+   :maxdepth: 1
+    
+   waveform_plugin
 
 ==========================================
 Library Examples and Interactive Tutorials

--- a/docs/inference.rst
+++ b/docs/inference.rst
@@ -250,6 +250,11 @@ will remain fixed throughout the run. For example:
    approximant = IMRPhenomPv2
    f_lower = 18
 
+In the example above, we choose the waveform model 'IMRPhenomPv2'. PyCBC comes
+with access to waveforms provided by the lalsimulation package. If you'd like
+to use a custom waveform outside of what PyCBC currently supports,
+see :ref:`documentation on creating a plugin for PyCBC<waveform_plugin>`
+
 ^^^^^^^^^^^^
 Setting data
 ^^^^^^^^^^^^

--- a/docs/waveform_plugin.rst
+++ b/docs/waveform_plugin.rst
@@ -1,0 +1,91 @@
+.. _waveform_plugin:
+
+------------------------------------------------------
+Making new waveform approximants available to PyCBC
+------------------------------------------------------
+
+=================================================
+Adding a custom waveform model within a script
+=================================================
+
+By example, the following script shows how to write a waveform model
+in the form required for PyCBC. We can also make this new waveform directly
+accessible by using the `pycbc.waveform.plugin.add_custom_waveform` function.
+If you are developing in a notebook or self-contained script, this may be
+what you want to do. However, if you want to make your waveform available
+to pycbc-based executables such as PyCBC Inference, also read the next
+section. 
+
+Ther are two kinds of models you can make. In the example below, we
+make a time-domain model. You can also make a freuqency-domain model. The only
+difference is that your function should return pycbc FrequencySeries and
+the required sample step option is 'delta_f' instead of 'delta_t'. 
+
+Each waveform generation function must take only keyword arguments, and
+should be able to take an arbitrary number of them. You may add new parameters
+as you like. These will be automatically useable by PyCBC Inference and
+other pycbc codes.
+
+Each waveform model must have an associate 'approximant' name, which identifies
+the model and distinguishes it from any other. If the name has already been
+used, you may need to select a different name. 
+
+.. plot:: ../examples/waveform/add_waveform.py
+   :include-source:
+
+=================================================
+Creating a plugin for PyCBC
+=================================================
+
+To make a waveform model universally available to PyCBC so it can be called
+from PyCBC Inference, or the pycbc-based searched codes, you can create
+a plugin package which advertises your model. PyCBC will automatically
+detects your package and makes your waveform model available for use.
+
+The steps are:
+
+ * Create a waveform model just like as in the above example
+ * Create a python package for your module
+ * In your packages setup.py advertise that it contains a PyCBC compatible
+   waveform model in it's 'entry_points' option. 
+  
+The setup.py would like the following, the key addition being the 'entry_points'
+parameter passed to setup.py. 
+
+.. code-block:: python
+
+    setup (
+        name = 'pycbc-revchirp',
+        version = VERSION,
+        description = 'An example waveform plugin for PyCBC',
+        long_description = open('descr.rst').read(),
+        author = 'The PyCBC team',
+        author_email = 'alex.nitz@gmail.org',
+        url = 'http://www.pycbc.org/',
+        download_url = 'https://github.com/gwastro/revchirp/tarball/v%s' % VERSION,
+        keywords = ['pycbc', 'signal processing', 'gravitational waves'],
+        install_requires = ['pycbc'],
+        py_modules = ['revchirp'],
+        entry_points = {"pycbc.waveform.td":"revchirp = revchirp:reverse_chirp_td",
+                        "pycbc.waveform.fd":"revchirp = revchirp:reverse_chirp_fd"},
+        classifiers=[
+            'Programming Language :: Python',
+            'Programming Language :: Python :: 2.7',
+            'Programming Language :: Python :: 3.6',
+            'Intended Audience :: Science/Research',
+            'Natural Language :: English',
+            'Topic :: Scientific/Engineering',
+            'Topic :: Scientific/Engineering :: Astronomy',
+            'Topic :: Scientific/Engineering :: Physics',
+            'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
+        ],
+    )
+
+The format is "capability":"approximant_name = module_path:function_name".
+The module path may include dots if the module is within a package or sub-package. The
+valid 'capbility' is 'pycbc.waveform.td' and 'pycbc.waveform.fd' for time and frequency
+domain waveform models,  respectively.
+  
+For a complete working minimal example of a PyCBC waveform plugin, see the 
+example package on github to 
+`make a reversed-chirp waveform <https://github.com/gwastro/example-waveform-plugin>`_ .

--- a/docs/waveform_plugin.rst
+++ b/docs/waveform_plugin.rst
@@ -10,25 +10,26 @@ Adding a custom waveform model within a script
 
 By example, the following script shows how to write a waveform model
 in the form required for PyCBC. We can also make this new waveform directly
-accessible by using the `pycbc.waveform.plugin.add_custom_waveform` function.
+accessible by using the :py:func:`~pycbc.waveform.plugin.add_custom_waveform` function.
 If you are developing in a notebook or self-contained script, this may be
 what you want to do. However, if you want to make your waveform available
 to pycbc-based executables such as PyCBC Inference, also read the next
-section. 
+section.
 
-Ther are two kinds of models you can make. In the example below, we
+There are two kinds of models you can make. In the example below, we
 make a time-domain model. You can also make a freuqency-domain model. The only
-difference is that your function should return pycbc FrequencySeries and
-the required sample step option is 'delta_f' instead of 'delta_t'. 
+difference is that your function should return an instance of :py:class:`~pycbc.types.frequencyseries.FrequencySeries` and
+the required sample step option is `delta_f` instead of `delta_t`.
 
 Each waveform generation function must take only keyword arguments, and
 should be able to take an arbitrary number of them. You may add new parameters
 as you like. These will be automatically useable by PyCBC Inference and
 other pycbc codes.
 
-Each waveform model must have an associate 'approximant' name, which identifies
+Each waveform model must have an associate `approximant` name, which identifies
 the model and distinguishes it from any other. If the name has already been
-used, you may need to select a different name. 
+used, you should select a different name. By default, an error will be raised
+unless overridden.
 
 .. plot:: ../examples/waveform/add_waveform.py
    :include-source:
@@ -40,17 +41,17 @@ Creating a plugin for PyCBC
 To make a waveform model universally available to PyCBC so it can be called
 from PyCBC Inference, or the pycbc-based searched codes, you can create
 a plugin package which advertises your model. PyCBC will automatically
-detects your package and makes your waveform model available for use.
+detect your package and make your waveform model available for use.
 
 The steps are:
 
  * Create a waveform model just like as in the above example
  * Create a python package for your module
  * In your packages setup.py advertise that it contains a PyCBC compatible
-   waveform model in it's 'entry_points' option. 
-  
-The setup.py would like the following, the key addition being the 'entry_points'
-parameter passed to setup.py. 
+   waveform model in it's `entry_points` option.
+
+Your `setup.py` should look like the following, the key addition being the `entry_points`
+parameter passed to setup.py.
 
 .. code-block:: python
 
@@ -81,11 +82,11 @@ parameter passed to setup.py.
         ],
     )
 
-The format is "capability":"approximant_name = module_path:function_name".
+The format for the `entry_points` is `"capability":"approximant_name = module_path:function_name"`.
 The module path may include dots if the module is within a package or sub-package. The
-valid 'capbility' is 'pycbc.waveform.td' and 'pycbc.waveform.fd' for time and frequency
+valid `capbility` is `pycbc.waveform.td` and `pycbc.waveform.fd` for time and frequency
 domain waveform models,  respectively.
-  
-For a complete working minimal example of a PyCBC waveform plugin, see the 
-example package on github to 
+
+For a complete working minimal example of a PyCBC waveform plugin, see the
+example package on github to
 `make a reversed-chirp waveform <https://github.com/gwastro/example-waveform-plugin>`_ .

--- a/examples/waveform/add_waveform.py
+++ b/examples/waveform/add_waveform.py
@@ -1,0 +1,47 @@
+def test_waveform(**args):
+    import numpy
+    from pycbc.types import TimeSeries
+
+    flow = args['f_lower'] # Required parameter
+    dt = args['delta_t']   # Required parameter
+    fpeak = args['fpeak']  # A new parameter for my model
+
+    t = numpy.arange(0, 10, dt)
+    f = t/t.max() * (fpeak - flow) + flow
+    a = t
+
+    wf = numpy.exp(2.0j * numpy.pi * f * t) * a
+
+    # Return product should be a pycbc time series in this case for
+    # each GW polarization
+    #
+    #
+    # Note that by convention, the time at 0 is a fiducial reference.
+    # For CBC waveforms, this would be set to where the merger occurs
+    offset = - len(t) * dt
+    wf = TimeSeries(wf, delta_t=dt, epoch=offset)
+    return wf.real(), wf.imag()
+
+import pylab
+import pycbc.waveform
+
+# This tells pycbc about our new waveform so we can call it from standard
+# pycbc functions. If this were a frequency-domain model, select 'frequency'
+# instead of 'time' to this function call.
+pycbc.waveform.add_custom_waveform('test', test_waveform, 'time', force=True)
+
+# Let's plot what our new waveform looks like
+hp, hc = pycbc.waveform.get_td_waveform(approximant="test",
+                                        f_lower=20, fpeak=50,
+                                        delta_t=1.0/4096)
+pylab.figure(0)
+pylab.plot(hp.sample_times, hp)
+pylab.xlabel('Time (s)')
+
+pylab.figure(1)
+hf = hp.to_frequencyseries()
+pylab.plot(hf.sample_frequencies, hf.real())
+pylab.xlabel('Frequency (Hz)')
+pylab.xscale('log')
+pylab.xlim(20, 100)
+pylab.show()

--- a/pycbc/waveform/__init__.py
+++ b/pycbc/waveform/__init__.py
@@ -3,3 +3,8 @@ from pycbc.waveform.utils import *
 from pycbc.waveform.bank import *
 from pycbc.waveform.ringdown import *
 from pycbc.waveform.parameters import *
+
+from pycbc.waveform.plugin import (retrieve_waveform_plugins,
+                                   add_custom_waveform,
+                                   add_length_estimator)
+retrieve_waveform_plugins()

--- a/pycbc/waveform/parameters.py
+++ b/pycbc/waveform/parameters.py
@@ -515,6 +515,10 @@ td_waveform_params = cbc_rframe_params + ParameterList([delta_t]) + \
 # defined above. Defaults of None simply mean that the value is not passed into
 # the lal_dict structure and the waveform generator will take whatever default
 # behaviour
+td_required = ParameterList([f_lower, delta_t, approximant])
+fd_required = ParameterList([f_lower, delta_f, approximant])
+
+####
 cbc_td_required = ParameterList([mass1, mass2, f_lower, delta_t, approximant])
 cbc_fd_required = ParameterList([mass1, mass2, f_lower, delta_f, approximant])
 

--- a/pycbc/waveform/plugin.py
+++ b/pycbc/waveform/plugin.py
@@ -1,6 +1,7 @@
 """ Utilities for handling waveform plugins
 """
 
+
 def add_custom_waveform(approximant, function, domain):
     """ Make custom waveform available to pycbc
 
@@ -23,11 +24,24 @@ def add_custom_waveform(approximant, function, domain):
         raise ValueError("Invalid domain ({}), should be "
                          "'time' or 'frequency'".format(domain))
 
+
 def add_length_estimator(approximant, function):
+    """ Add length estimator for an approximant
+
+    Parameters
+    ----------
+    approximant : str
+        Name of approximant
+    function : function
+        A function which takes kwargs and returns the waveform length
+    """
     from pycbc.waveform.waveform import _filter_time_lengths
     _filter_time_lengths[approximant] = function
 
+
 def retrieve_waveform_plugins():
+    """ Process external waveform plugins
+    """
     import pkg_resources
 
     # Check for fd waveforms

--- a/pycbc/waveform/plugin.py
+++ b/pycbc/waveform/plugin.py
@@ -3,7 +3,7 @@
 
 def add_custom_waveform(approximant, function, domain):
     """ Make custom waveform available to pycbc
-    
+
     Parameters
     ----------
     approximant : str
@@ -26,18 +26,18 @@ def add_custom_waveform(approximant, function, domain):
 def add_length_estimator(approximant, function):
     from pycbc.waveform.waveform import _filter_time_lengths
     _filter_time_lengths[approximant] = function
-   
+
 def retrieve_waveform_plugins():
     import pkg_resources
-    
+
     # Check for fd waveforms
     for plugin in pkg_resources.iter_entry_points('pycbc.waveform.fd'):
         add_custom_waveform(plugin.name, plugin.resolve(), 'frequency')
-    
+
     # Check for td waveforms
     for plugin in pkg_resources.iter_entry_points('pycbc.waveform.td'):
         add_custom_waveform(plugin.name, plugin.resolve(), 'time')
-    
+
     # Check for wavveform length estimates
     for plugin in pkg_resources.iter_entry_points('pycbc.waveform.length'):
         add_length_estimator(plugin.name, plugin.resolve())

--- a/pycbc/waveform/plugin.py
+++ b/pycbc/waveform/plugin.py
@@ -1,0 +1,43 @@
+""" Utilities for handling waveform plugins
+"""
+
+def add_custom_waveform(approximant, function, domain):
+    """ Make custom waveform available to pycbc
+    
+    Parameters
+    ----------
+    approximant : str
+        The name of the waveform
+    function : function
+        The function to generate the waveform
+     domain : str
+        Either 'frequency' or 'time' to indicate the domain of the waveform.
+    """
+    from pycbc.waveform.waveform import cpu_fd, cpu_td
+
+    if domain == 'time':
+        cpu_td[approximant] = function
+    elif domain == 'frequency':
+        cpu_fd[approximant] = function
+    else:
+        raise ValueError("Invalid domain ({}), should be "
+                         "'time' or 'frequency'".format(domain))
+
+def add_length_estimator(approximant, function):
+    from pycbc.waveform.waveform import _filter_time_lengths
+    _filter_time_lengths[approximant] = function
+   
+def retrieve_waveform_plugins():
+    import pkg_resources
+    
+    # Check for fd waveforms
+    for plugin in pkg_resources.iter_entry_points('pycbc.waveform.fd'):
+        add_custom_waveform(plugin.name, plugin.resolve(), 'frequency')
+    
+    # Check for td waveforms
+    for plugin in pkg_resources.iter_entry_points('pycbc.waveform.td'):
+        add_custom_waveform(plugin.name, plugin.resolve(), 'time')
+    
+    # Check for wavveform length estimates
+    for plugin in pkg_resources.iter_entry_points('pycbc.waveform.length'):
+        add_length_estimator(plugin.name, plugin.resolve())

--- a/pycbc/waveform/plugin.py
+++ b/pycbc/waveform/plugin.py
@@ -2,7 +2,7 @@
 """
 
 
-def add_custom_waveform(approximant, function, domain):
+def add_custom_waveform(approximant, function, domain, force=False):
     """ Make custom waveform available to pycbc
 
     Parameters
@@ -17,12 +17,12 @@ def add_custom_waveform(approximant, function, domain):
     from pycbc.waveform.waveform import cpu_fd, cpu_td
 
     if domain == 'time':
-        if approximant in cpu_td:
+        if not force and (approximant in cpu_td):
             raise RuntimeError("Can't load plugin waveform {}, the name is"
                                " already in use.".format(approximant))
         cpu_td[approximant] = function
     elif domain == 'frequency':
-        if approximant in cpu_fd:
+        if not force and (approximant in cpu_fd):
             raise RuntimeError("Can't load plugin waveform {}, the name is"
                                " already in use.".format(approximant))
         cpu_fd[approximant] = function

--- a/pycbc/waveform/plugin.py
+++ b/pycbc/waveform/plugin.py
@@ -17,8 +17,14 @@ def add_custom_waveform(approximant, function, domain):
     from pycbc.waveform.waveform import cpu_fd, cpu_td
 
     if domain == 'time':
+        if approximant in cpu_td:
+            raise RuntimeError("Can't load plugin waveform {}, the name is"
+                               " already in use.".format(approximant))
         cpu_td[approximant] = function
     elif domain == 'frequency':
+        if approximant in cpu_fd:
+            raise RuntimeError("Can't load plugin waveform {}, the name is"
+                               " already in use.".format(approximant))
         cpu_fd[approximant] = function
     else:
         raise ValueError("Invalid domain ({}), should be "
@@ -36,6 +42,9 @@ def add_length_estimator(approximant, function):
         A function which takes kwargs and returns the waveform length
     """
     from pycbc.waveform.waveform import _filter_time_lengths
+    if approximant in _filter_time_lengths:
+        raise RuntimeError("Can't load length estimator {}, the name is"
+                           " already in use.".format(approximant))
     _filter_time_lengths[approximant] = function
 
 

--- a/pycbc/waveform/waveform.py
+++ b/pycbc/waveform/waveform.py
@@ -35,7 +35,7 @@ import inspect
 from pycbc.fft import fft
 from pycbc import pnutils
 from pycbc.waveform import utils as wfutils
-from pycbc.waveform import parameters
+from pycbc.waveform import parameters, plugin
 from pycbc.filter import interpolate_complex_frequency, resample_to_delta_t
 import pycbc
 from .spa_tmplt import spa_tmplt, spa_tmplt_norm, spa_tmplt_end, \
@@ -1102,4 +1102,5 @@ __all__ = ["get_td_waveform", "get_fd_waveform", "get_fd_waveform_sequence",
            "get_waveform_filter_length_in_time", "get_sgburst_waveform",
            "print_sgburst_approximants", "sgburst_approximants",
            "td_waveform_to_fd_waveform", "get_two_pol_waveform_filter",
-           "NoWaveformError", "FailedWaveformError", "get_td_waveform_from_fd"]
+           "NoWaveformError", "FailedWaveformError", "get_td_waveform_from_fd",
+           'cpu_fd', 'cpu_td', '_filter_time_lengths']

--- a/pycbc/waveform/waveform.py
+++ b/pycbc/waveform/waveform.py
@@ -179,7 +179,7 @@ def _lalsim_td_waveform(**p):
     hc = TimeSeries(hc1.data.data[:], delta_t=hc1.deltaT, epoch=hc1.epoch)
 
     return hp, hc
-    
+
 _lalsim_td_waveform.required = parameters.cbc_td_required
 
 def _spintaylor_aligned_prec_swapper(**p):
@@ -364,13 +364,13 @@ def props(obj, **kwargs):
     input_params = default_args.copy()
     input_params.update(pr)
     return input_params
-    
+
 def check_args(args, required_args):
     """ check that required args are given """
     missing = []
     for arg in required_args:
         if (arg not in args) or (args[arg] is None):
-            missing.append(arg)    
+            missing.append(arg)
 
     if len(missing) != 0:
         raise ValueError("Please provide {}".format(', '.join(missing)))
@@ -465,7 +465,7 @@ def get_td_waveform(template=None, **kwargs):
     if hasattr(wav_gen, 'required'):
         required = wav_gen.required
     else:
-        required = parameters.td_required    
+        required = parameters.td_required
     check_args(input_params, required)
     return wav_gen(**input_params)
 
@@ -513,7 +513,7 @@ def get_fd_waveform(template=None, **kwargs):
     if hasattr(wav_gen, 'required'):
         required = wav_gen.required
     else:
-        required = parameters.fd_required    
+        required = parameters.fd_required
     check_args(input_params, required)
     return wav_gen(**input_params)
 

--- a/pycbc/waveform/waveform.py
+++ b/pycbc/waveform/waveform.py
@@ -35,7 +35,7 @@ import inspect
 from pycbc.fft import fft
 from pycbc import pnutils
 from pycbc.waveform import utils as wfutils
-from pycbc.waveform import parameters, plugin
+from pycbc.waveform import parameters
 from pycbc.filter import interpolate_complex_frequency, resample_to_delta_t
 import pycbc
 from .spa_tmplt import spa_tmplt, spa_tmplt_norm, spa_tmplt_end, \

--- a/pycbc/waveform/waveform.py
+++ b/pycbc/waveform/waveform.py
@@ -67,9 +67,6 @@ default_args = \
      parameters.td_waveform_params).default_dict()
 
 default_sgburst_args = {'eccentricity':0, 'polarization':0}
-
-td_required_args = parameters.cbc_td_required
-fd_required_args = parameters.cbc_fd_required
 sgburst_required_args = ['q','frequency','hrss']
 
 # td, fd, filter waveforms generated on the CPU
@@ -141,7 +138,6 @@ def _check_lal_pars(p):
     return lal_pars
 
 def _lalsim_td_waveform(**p):
-    fail_tolerant_waveform_generation
     lal_pars = _check_lal_pars(p)
     #nonGRparams can be straightforwardly added if needed, however they have to
     # be invoked one by one
@@ -183,6 +179,8 @@ def _lalsim_td_waveform(**p):
     hc = TimeSeries(hc1.data.data[:], delta_t=hc1.deltaT, epoch=hc1.epoch)
 
     return hp, hc
+    
+_lalsim_td_waveform.required = parameters.cbc_td_required
 
 def _spintaylor_aligned_prec_swapper(**p):
     """
@@ -224,6 +222,8 @@ def _lalsim_fd_waveform(**p):
                             epoch=hc1.epoch)
     #lal.DestroyDict(lal_pars)
     return hp, hc
+
+_lalsim_fd_waveform.required = parameters.cbc_fd_required
 
 def _lalsim_sgburst_waveform(**p):
     hp, hc = lalsimulation.SimBurstSineGaussian(float(p['q']),
@@ -352,27 +352,28 @@ def get_obj_attrs(obj):
 
     return pr
 
-def props(obj, required_args=None, **kwargs):
+def props(obj, **kwargs):
     """ Return a dictionary built from the combination of defaults, kwargs,
     and the attributes of the given object.
     """
     pr = get_obj_attrs(obj)
     pr.update(kwargs)
 
-    if required_args is None:
-        required_args = []
-
-    # check that required args are given
-    missing = set(required_args) - set(pr.keys())
-    if any(missing):
-        raise ValueError("Please provide {}".format(', '.join(missing)))
-
     # Get the parameters to generate the waveform
     # Note that keyword arguments override values in the template object
     input_params = default_args.copy()
     input_params.update(pr)
-
     return input_params
+    
+def check_args(args, required_args):
+    """ check that required args are given """
+    missing = []
+    for arg in required_args:
+        if (arg not in args) or (args[arg] is None):
+            missing.append(arg)    
+
+    if len(missing) != 0:
+        raise ValueError("Please provide {}".format(', '.join(missing)))
 
 # Input parameter handling for bursts ########################################
 
@@ -418,7 +419,7 @@ def get_fd_waveform_sequence(template=None, **kwds):
     """
     kwds['delta_f'] = -1
     kwds['f_lower'] = -1
-    p = props(template, required_args=fd_required_args, **kwds)
+    p = props(template, required_args=parameters.cbc_fd_required, **kwds)
     lal_pars = _check_lal_pars(p)
 
     hp, hc = lalsimulation.SimInspiralChooseFDWaveformSequence(float(p['coa_phase']),
@@ -455,12 +456,18 @@ def get_td_waveform(template=None, **kwargs):
     hcross: TimeSeries
         The cross polarization of the waveform.
     """
-    input_params = props(template, required_args=td_required_args, **kwargs)
+    input_params = props(template, **kwargs)
     wav_gen = td_wav[type(_scheme.mgr.state)]
     if input_params['approximant'] not in wav_gen:
         raise ValueError("Approximant %s not available" %
                             (input_params['approximant']))
-    return wav_gen[input_params['approximant']](**input_params)
+    wav_gen = wav_gen[input_params['approximant']]
+    if hasattr(wav_gen, 'required'):
+        required = wav_gen.required
+    else:
+        required = parameters.td_required    
+    check_args(input_params, required)
+    return wav_gen(**input_params)
 
 get_td_waveform.__doc__ = get_td_waveform.__doc__.format(
     params=parameters.td_waveform_params.docstr(prefix="    ",
@@ -483,8 +490,7 @@ def get_fd_waveform(template=None, **kwargs):
     hcrosstilde: FrequencySeries
         The cross phase of the waveform in frequency domain.
     """
-
-    input_params = props(template, required_args=fd_required_args, **kwargs)
+    input_params = props(template, **kwargs)
     wav_gen = fd_wav[type(_scheme.mgr.state)]
     if input_params['approximant'] not in wav_gen:
         raise ValueError("Approximant %s not available" %
@@ -503,7 +509,13 @@ def get_fd_waveform(template=None, **kwargs):
                                       "f_final")
     except KeyError:
         pass
-    return wav_gen[input_params['approximant']](**input_params)
+    wav_gen = wav_gen[input_params['approximant']]
+    if hasattr(wav_gen, 'required'):
+        required = wav_gen.required
+    else:
+        required = parameters.fd_required    
+    check_args(input_params, required)
+    return wav_gen(**input_params)
 
 
 get_fd_waveform.__doc__ = get_fd_waveform.__doc__.format(

--- a/tools/docker_build_dist.sh
+++ b/tools/docker_build_dist.sh
@@ -56,7 +56,7 @@ if [ "x${PYCBC_CONTAINER}" == "xpycbc_rhel_virtualenv" ]; then
   yum -y install ligo-proxy-utils
   yum -y install ecp-cookie-init
   yum -y install python-virtualenv
-  yum -y install hdf5-static libxml2-static zlib-static libstdc++-static cfitsio-static glibc-static fftw-static gsl-static
+  yum -y install hdf5-static libxml2-static zlib-static libstdc++-static cfitsio-static glibc-static fftw-static gsl-static --skip-broken
 
   CVMFS_PATH=/cvmfs/oasis.opensciencegrid.org/ligo/sw/pycbc/${ENV_OS}/virtualenv
   mkdir -p ${CVMFS_PATH}


### PR DESCRIPTION
* This allows pycbc to properly find external packages which *advertise* a plugin for pycbc without relying on environment variables.
* An example plugin package is provided in https://github.com/gwastro/example-waveform-plugin

If the plugin is simply installed, pycbc will automatically pick it up and its waveform models will be available from PyCBC. I think this is the behavior we would like for external packages. The hook is the standard Python mechanism using the 'entrypoint' system of 'pkg_resources', which was explicitly designed for this purpose. 

* (this will eventually deprecated the older undocumented interface, but I'm not removing in this PR yet). "


It would be good if you all could sign off on the generic interface and merge this first. In the next PR, I'll add documentation to main pages on how to use this both from the package level and how to add a waveform within a single script (by calling pycbc.waveform.add_custom_waveform). That will be followed up by the corresponding tutorial example (which we want for the workshop next week). 