### PR TITLE
Live combine fits missing bins bug

### DIFF
--- a/bin/live/pycbc_live_combine_single_fits
+++ b/bin/live/pycbc_live_combine_single_fits
@@ -37,7 +37,7 @@ args=parser.parse_args()
 
 pycbc.init_logging(args.verbose)
 
-colours = ['r', (1.0, 0.6, 0), 'y', 'g', 'c', 'b', 'm', 'k',
+colours = ['r', (1.0, 0.6, 0), 'y', 'g', 'c', 'b', 'm',
            (0.8, 0.25, 0), (0.25, 0.8, 0)]
 
 counts_all = {ifo:[] for ifo in args.ifos}

--- a/bin/live/pycbc_live_combine_single_fits
+++ b/bin/live/pycbc_live_combine_single_fits
@@ -134,8 +134,10 @@ for ifo in args.ifos:
     invalphan = np.array(counts_bin[ifo]) / np.array(alphas_bin[ifo])
     invalphan_all = np.mean(invalphan, axis=0)
     alpha_all = np.mean(counts_bin[ifo], axis=0) / invalphan_all
-    for a, c, u, l, t in zip(alphas_bin[ifo], counts_bin[ifo], bu, bl,
-                             live_times[ifo]):
+    l_times = np.array(live_times[ifo])
+    meant = l_times.mean()
+    fout[ifo + '/daily_fits/live_times'] = l_times
+    for a, c, u, l in zip(alphas_bin[ifo], counts_bin[ifo], bu, bl):
         a = np.array(a)
         c = np.array(c)
         valid_alpha = np.nonzero(a > 0)
@@ -159,17 +161,17 @@ for ifo in args.ifos:
             alpha_lines += ax_alpha.plot([ad[0], ad[-1]], [q05_alpha, q05_alpha],
                                          c=colours[counter], linestyle=':',
                                          label="95th %%ile = %.2f" % q05_alpha)
-            count_lines += ax_count.plot(ad[valid_alpha], c / t,
+            count_lines += ax_count.plot(ad[valid_alpha], c / l_times,
                                          c=colours[counter],
                                          label="duration %.2f-%.2f" % (l, u))
             count_lines += ax_count.plot([ad[0], ad[-1]],
-                                         [c.mean() / t, c.mean() / t],
+                                         [c.mean() / meant, c.mean() / meant],
                                          c=colours[counter], linestyle='--',
-                                         label="mean = %.3f" % (c.mean() / t))
+                                         label="mean = %.3f" % (c.mean() / meant))
             count_lines += ax_count.plot([ad[0], ad[-1]],
-                                         [q95_count / t, q95_count / t],
+                                         [q95_count / meant, q95_count / meant],
                                          c=colours[counter], linestyle=':',
-                                         label="95th %%ile = %.3f" % (q95_count / t))
+                                         label="95th %%ile = %.3f" % (q95_count / meant))
         fout[ifo + '/daily_fits/bin_%d/fit_coeff' % counter] = a
         fout[ifo + '/daily_fits/bin_%d/counts' % counter] = c
         fout[ifo + '/daily_fits/bin_%d/date' % counter] = ad[valid_alpha]

--- a/bin/live/pycbc_live_combine_single_fits
+++ b/bin/live/pycbc_live_combine_single_fits
@@ -161,7 +161,7 @@ for ifo in args.ifos:
             alpha_lines += ax_alpha.plot([ad[0], ad[-1]], [q05_alpha, q05_alpha],
                                          c=colours[counter], linestyle=':',
                                          label="95th %%ile = %.2f" % q05_alpha)
-            count_lines += ax_count.plot(ad[valid_alpha], c / l_times,
+            count_lines += ax_count.plot(ad[valid_alpha], c / l_times[valid_alpha],
                                          c=colours[counter],
                                          label="duration %.2f-%.2f" % (l, u))
             count_lines += ax_count.plot([ad[0], ad[-1]],


### PR DESCRIPTION
One of the variables being looped over was in a different dimension than the others (fit file date rather than bin)

I hadn't noticed this as the number of bins had always been less than the number of days being analysed

Also prevents the same colour being used twice in plots given a large number of bins