### PR TITLE
Optimal SNR for vetoed injections

### DIFF
--- a/bin/hdfcoinc/pycbc_coinc_hdfinjfind
+++ b/bin/hdfcoinc/pycbc_coinc_hdfinjfind
@@ -222,8 +222,15 @@ for trigger_file, injection_file in zip(args.trigger_files,
     # pick up optimal SNRs
     if multi_ifo_style:
         for ifo, column in args.optimal_snr_column.items():
+            optimal_snr_all = numpy.array(sim_table.get_column(column))
+            # As a single detector being vetoed won't veto all combinations,
+            # need to set optimal_snr of a vetoed ifo to zero in order
+            # to later calculate decisive optimal snr
+            iws, _ = indices_within_segments(inj_time, [args.veto_file], ifo=ifo,
+                                             segment_name=args.segment_name)
+            optimal_snr_all[iws] = 0
             hdf_append(fo, 'injections/optimal_snr_%s' % ifo,
-                       sim_table.get_column(column))
+                       optimal_snr_all)
     else:
         ifo_map = {f.attrs['detector_1']: 1,
                    f.attrs['detector_2']: 2}


### PR DESCRIPTION
If an injection is vetoed in one detector, then its optimal SNR is still used for decisive SNR

This sets optimal_snr=0 in the given detector for any injection in vetoed times in the HDF injfind output

Compare new output:
https://ldas-jobs.ligo.caltech.edu/~gareth.davies/testoutput/decisive_opt_snr_vetos/H1L1V1-PLOT_FOUNDMISSED_ALL_MCHIRP_GRADM.png

To old output:
https://ligo.gravity.cf.ac.uk/~gareth.davies/o3/runs/hlv/c01/a22_initial/5._injections/H1L1V1-PLOT_FOUNDMISSED_ALL_MCHIRP_GRADM-1253317851-691791.png