### PR TITLE
Fix gelman rubin test for python 3

### DIFF
--- a/pycbc/inference/gelman_rubin.py
+++ b/pycbc/inference/gelman_rubin.py
@@ -16,6 +16,7 @@
 diagnostic statistic.
 """
 
+from __future__ import division
 import numpy
 
 
@@ -94,7 +95,7 @@ def gelman_rubin(chains, auto_burn_in=True):
     # this will have shape (nchains, nparameters, niterations)
     if auto_burn_in:
         _, _, niterations = numpy.array(chains).shape
-        chains = numpy.array([chain[:, niterations / 2 + 1:]
+        chains = numpy.array([chain[:, niterations // 2 + 1:]
                               for chain in chains])
 
     # get number of chains, parameters, and iterations


### PR DESCRIPTION
There is a float division of an array index in `gelman_rubin.py`. That causes in an error in python 3, since the index is converted to a float in the process. Fixes that by using integer division. Tested with emcee_pt, [here](https://www.atlas.aei.uni-hannover.de/~work-cdcapano/scratch/prs/epsie_separate_acls/plot_acls/gelman_rubin-gw150914_8perchain-emcee_pt.png). The gelman-rubin plotting code needs some other updates (like fixing the x-axis to account for thinning), but at least this will let it run without error.