### PR TITLE
Add spherical to cartesian transform

### DIFF
--- a/examples/inference/priors/gw150914_like.ini
+++ b/examples/inference/priors/gw150914_like.ini
@@ -71,6 +71,28 @@ name = uniform_solidangle
 polar-angle = spin2_polar
 azimuthal-angle = spin2_azimuthal
 
+; The waveform generator expects spins to be in cartesian coordinates, with
+; names spin(1|2)(x|y|z). We therefore need to provide a waveform transform
+; that converts the spherical coordinates that we have defined the spin prior
+; in to cartesian coordinates.
+[waveform_transforms-spin1x+spin1y+spin1z]
+name = spherical_to_cartesian
+x = spin1x
+y = spin1y
+z = spin1z
+radial = spin1_a
+polar = spin1_polar
+azimuthal = spin1_azimuthal
+
+[waveform_transforms-spin2x+spin2y+spin2z]
+name = spherical_to_cartesian
+x = spin2x
+y = spin2y
+z = spin2z
+radial = spin2_a
+polar = spin2_polar
+azimuthal = spin2_azimuthal
+
 [prior-distance]
 ; following gives a uniform volume prior
 name = uniform_radius

--- a/pycbc/transforms.py
+++ b/pycbc/transforms.py
@@ -660,9 +660,11 @@ class SphericalToCartesian(BaseTransform):
         >>> from pycbc import transforms
         >>> t = transforms.SphericalToCartesian('x', 'y', 'z',
                                                 'a', 'phi', 'theta')
-        >>> t.transform({'a': numpy.array([0.1]), 'phi': numpy.array([0.1]), 'theta': numpy.array([0.1])})
+        >>> t.transform({'a': numpy.array([0.1]), 'phi': numpy.array([0.1]),
+                        'theta': numpy.array([0.1])})
             {'a': array([ 0.1]), 'phi': array([ 0.1]), 'theta': array([ 0.1]),
-             'x': array([ 0.00993347]), 'y': array([ 0.00099667]), 'z': array([ 0.09950042])}
+             'x': array([ 0.00993347]), 'y': array([ 0.00099667]),
+             'z': array([ 0.09950042])}
 
         Returns
         -------
@@ -1778,6 +1780,7 @@ class CartesianSpin1ToSphericalSpin1(CartesianToSpherical):
     instead.
     """
     name = "cartesian_spin_1_to_spherical_spin_1"
+
     def __init__(self):
         logging.warning("Deprecation warning: the {} transform will be "
                         "removed in a future update. Please use {} instead, "
@@ -1797,6 +1800,7 @@ class CartesianSpin2ToSphericalSpin2(CartesianToSpherical):
     instead.
     """
     name = "cartesian_spin_2_to_spherical_spin_2"
+
     def __init__(self):
         logging.warning("Deprecation warning: the {} transform will be "
                         "removed in a future update. Please use {} instead, "

--- a/pycbc/transforms.py
+++ b/pycbc/transforms.py
@@ -625,8 +625,8 @@ class SphericalToCartesian(BaseTransform):
         The name of the y parameter.
     z : str
         The name of the z parameter.
-    magnitude : str
-        The name of the magnitude parameter.
+    radial : str
+        The name of the radial parameter.
     azimuthal : str
         The name of the azimuthal angle parameter.
     polar : str
@@ -634,14 +634,14 @@ class SphericalToCartesian(BaseTransform):
     """
     name = "spherical_to_cartesian"
 
-    def __init__(self, x, y, z, magnitude, azimuthal, polar):
+    def __init__(self, x, y, z, radial, azimuthal, polar):
         self.x = x
         self.y = y
         self.z = z
-        self.magnitude = magnitude
+        self.radial = radial
         self.polar = polar
         self.azimuthal = azimuthal
-        self._inputs = [self.magnitude, self.azimuthal, self.polar]
+        self._inputs = [self.radial, self.azimuthal, self.polar]
         self._outputs = [self.x, self.y, self.z]
         super(SphericalToCartesian, self).__init__()
 
@@ -695,7 +695,7 @@ class SphericalToCartesian(BaseTransform):
 
 
 class SphericalSpin1ToCartesianSpin1(SphericalToCartesian):
-    """Converts spherical spin parameters (magnitude and two angles) to
+    """Converts spherical spin parameters (radial and two angles) to
     catesian spin parameters. This class only transforms spsins for the first
     component mass.
 
@@ -717,7 +717,7 @@ class SphericalSpin1ToCartesianSpin1(SphericalToCartesian):
 
 
 class SphericalSpin2ToCartesianSpin2(SphericalToCartesian):
-    """Converts spherical spin parameters (magnitude and two angles) to
+    """Converts spherical spin parameters (radial and two angles) to
     catesian spin parameters. This class only transforms spsins for the first
     component mass.
 
@@ -1739,8 +1739,8 @@ class CartesianToSpherical(SphericalToCartesian):
         The name of the y parameter.
     z : str
         The name of the z parameter.
-    magnitude : str
-        The name of the magnitude parameter.
+    radial : str
+        The name of the radial parameter.
     azimuthal : str
         The name of the azimuthal angle parameter.
     polar : str
@@ -1995,6 +1995,8 @@ transforms = {
     Mass1Mass2ToMchirpEta.name : Mass1Mass2ToMchirpEta,
     ChirpDistanceToDistance.name : ChirpDistanceToDistance,
     DistanceToChirpDistance.name : DistanceToChirpDistance,
+    SphericalToCartesian.name : SphericalToCartesian,
+    CartesianToSpherical.name : CartesianToSpherical,
     SphericalSpin1ToCartesianSpin1.name : SphericalSpin1ToCartesianSpin1,
     CartesianSpin1ToSphericalSpin1.name : CartesianSpin1ToSphericalSpin1,
     SphericalSpin2ToCartesianSpin2.name : SphericalSpin2ToCartesianSpin2,
@@ -2032,7 +2034,7 @@ common_cbc_inverse_transforms = [_t.inverse()
                                  for _t in common_cbc_forward_transforms
                                  if not (_t.inverse is None or
                                          _t.name == 'spherical_to_cartesian')]
-common_cbc_inverse_transforms.append([
+common_cbc_inverse_transforms.extend([
     CartesianToSpherical(parameters.spin1x, parameters.spin1y,
                          parameters.spin1z, parameters.spin1_a,
                          parameters.spin1_azimuthal, parameters.spin1_polar),

--- a/pycbc/transforms.py
+++ b/pycbc/transforms.py
@@ -670,9 +670,12 @@ class SphericalToCartesian(BaseTransform):
             A dict with key as parameter name and value as numpy.array or float
             of transformed values.
         """
-        a, az, po = self._inputs
-        data = coordinates.spherical_to_cartesian(maps[a], maps[az], maps[po])
-        out = {param : val for param, val in zip(self._outputs, data)}
+        a = self.radial
+        az = self.azimuthal
+        po = self.polar
+        x, y, z = coordinates.spherical_to_cartesian(maps[a], maps[az],
+                                                     maps[po])
+        out = {self.x: x, self.y: y, self.z: z}
         return self.format_output(maps, out)
 
     def inverse_transform(self, maps):
@@ -688,9 +691,12 @@ class SphericalToCartesian(BaseTransform):
             A dict with key as parameter name and value as numpy.array or float
             of transformed values.
         """
-        x, y, z = self._outputs
-        data = coordinates.cartesian_to_spherical(maps[x], maps[y], maps[z])
-        out = {param : val for param, val in zip(self._outputs, data)}
+        x = self.x
+        y = self.y
+        z = self.z
+        a, az, po = coordinates.cartesian_to_spherical(maps[x], maps[y],
+                                                       maps[z])
+        out = {self.radial: a, self.azimuthal: az, self.polar: po}
         return self.format_output(maps, out)
 
 
@@ -1760,6 +1766,8 @@ class CartesianToSpherical(SphericalToCartesian):
         inputs = self._outputs
         self._inputs = inputs
         self._outputs = outputs
+        self.inputs = set(self._inputs)
+        self.outputs = set(self._outputs)
 
 
 class CartesianSpin1ToSphericalSpin1(CartesianToSpherical):

--- a/pycbc/transforms.py
+++ b/pycbc/transforms.py
@@ -634,7 +634,7 @@ class SphericalToCartesian(BaseTransform):
     """
     name = "spherical_to_cartesian"
 
-    def __init__(self, x, y, z, magnitude, azimuthal, polar)::
+    def __init__(self, x, y, z, magnitude, azimuthal, polar):
         self.x = x
         self.y = y
         self.z = z
@@ -710,7 +710,7 @@ class SphericalSpin1ToCartesianSpin1(SphericalToCartesian):
                         "removed in a future update. Please use {} instead, "
                         "passing spin1x, spin1y, spin1z, spin1_a, "
                         "spin1_azimuthal, spin1_polar as arguments."
-                        .format(self.name, SphericalToCartesian.name)
+                        .format(self.name, SphericalToCartesian.name))
         super(SphericalSpin1ToCartesianSpin1, self).__init__(
             "spin1x", "spin1y", "spin1z", "spin1_a", "spin1_azimuthal",
             "spin1_polar")
@@ -732,7 +732,7 @@ class SphericalSpin2ToCartesianSpin2(SphericalToCartesian):
                         "removed in a future update. Please use {} instead, "
                         "passing spin2x, spin2y, spin2z, spin2_a, "
                         "spin2_azimuthal, spin2_polar as arguments."
-                        .format(self.name, SphericalToCartesian.name)
+                        .format(self.name, SphericalToCartesian.name))
         super(SphericalSpin2ToCartesianSpin2, self).__init__(
             "spin2x", "spin2y", "spin2z", "spin2_a", "spin2_azimuthal",
             "spin2_polar")
@@ -1775,7 +1775,7 @@ class CartesianSpin1ToSphericalSpin1(CartesianToSpherical):
                         "removed in a future update. Please use {} instead, "
                         "passing spin1x, spin1y, spin1z, spin1_a, "
                         "spin1_azimuthal, spin1_polar as arguments."
-                        .format(self.name, CartesianToSpherical.name)
+                        .format(self.name, CartesianToSpherical.name))
         super(CartesianSpin1ToSphericalSpin1, self).__init__(
             "spin1x", "spin1y", "spin1z", "spin1_a", "spin1_azimuthal",
             "spin1_polar")
@@ -1794,7 +1794,7 @@ class CartesianSpin2ToSphericalSpin2(CartesianToSpherical):
                         "removed in a future update. Please use {} instead, "
                         "passing spin2x, spin2y, spin2z, spin2_a, "
                         "spin2_azimuthal, spin2_polar as arguments."
-                        .format(self.name, CartesianToSpherical.name)
+                        .format(self.name, CartesianToSpherical.name))
         super(CartesianSpin2ToSphericalSpin2, self).__init__(
             "spin2x", "spin2y", "spin2z", "spin2_a", "spin2_azimuthal",
             "spin2_polar")
@@ -2019,13 +2019,27 @@ transforms = {
 # to coordinates understood by the waveform generator
 common_cbc_forward_transforms = [
     MchirpQToMass1Mass2(), DistanceToRedshift(),
-    SphericalSpin1ToCartesianSpin1(), SphericalSpin2ToCartesianSpin2(),
+    SphericalToCartesian(parameters.spin1x, parameters.spin1y,
+                         parameters.spin1z, parameters.spin1_a,
+                         parameters.spin1_azimuthal, parameters.spin1_polar),
+    SphericalToCartesian(parameters.spin2x, parameters.spin2y,
+                         parameters.spin2z, parameters.spin2_a,
+                         parameters.spin2_azimuthal, parameters.spin2_polar),
     AlignedMassSpinToCartesianSpin(), PrecessionMassSpinToCartesianSpin(),
     ChiPToCartesianSpin(), ChirpDistanceToDistance()
 ]
 common_cbc_inverse_transforms = [_t.inverse()
-                                   for _t in common_cbc_forward_transforms
-                                   if _t.inverse is not None]
+                                 for _t in common_cbc_forward_transforms
+                                 if not (_t.inverse is None or
+                                         _t.name == 'spherical_to_cartesian')]
+common_cbc_inverse_transforms.append([
+    CartesianToSpherical(parameters.spin1x, parameters.spin1y,
+                         parameters.spin1z, parameters.spin1_a,
+                         parameters.spin1_azimuthal, parameters.spin1_polar),
+    CartesianToSpherical(parameters.spin2x, parameters.spin2y,
+                         parameters.spin2z, parameters.spin2_a,
+                         parameters.spin2_azimuthal, parameters.spin2_polar)])
+    
 common_cbc_transforms = common_cbc_forward_transforms + \
                         common_cbc_inverse_transforms
 

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -67,7 +67,13 @@ class TestTransforms(unittest.TestCase):
             # check if inverse exists
             if trans.name in IGNORE:
                 continue
-            inv = trans.inverse()
+            if trans.name == 'spherical_to_cartesian':
+                # spherical to cartesian requires the cartesian and spherical
+                # parameter names to be specified, which we can get from
+                # the inputs and outputs
+                inv = trans.inverse(*trans._outputs+trans._inputs)
+            else:
+                inv = trans.inverse()
 
             # generate some random points
             in_map = {p : numpy.random.uniform(*RANGES[p])


### PR DESCRIPTION
Adds a generic `SphericalToCartesian` transform and its inverse.

Currently, we have a class that does this specifically for `spin1` called `SphericalSpin1ToCartesianSpin1` (ditto for spin2). Those two classes are tied to parameters with names "spin1{X}". This makes that generic, so you can use a single transform for any spherical <-> cartesian transforms. This means you would now do:
```
[waveform_transforms-spin1x+spin1y+spin1z]
name = spherical_to_cartesian
x = spin1x
y = spin1y
z = spin1z
radial = spin1_a
azimuthal = spin1_azimuthal
polar = spin1_polar
```
And same for spin2.

I've left the `SphericalSpin(1|2)ToCartesianSpin(1|2)` classes in for now, but have added deprecation warnings to them saying they will be removed in a future update.

This still leaves in automatic transforms in the waveform models (meaning that you don't actually need to include the waveform transforms section for the spins). I will remove that in another patch.