### PR TITLE
Remove automatic transforms from waveform generator

### DIFF
--- a/docs/inference.rst
+++ b/docs/inference.rst
@@ -376,12 +376,6 @@ quadrupole moment of a neutron star ``dquad_mon1`` to its tidal deformation
    waveform generator understands. This is why in the above example we are
    able to use a custom transform without needing to provide a Jacobian.
 
-Some common transforms are pre-defined in the code. These are: the mass
-parameters ``mass1`` and ``mass2`` can be substituted with ``mchirp`` and
-``eta`` or ``mchirp`` and ``q``.  The component spin parameters ``spin1x``,
-``spin1y``, and ``spin1z`` can be substituted for polar coordinates
-``spin1_a``, ``spin1_azimuthal``, and ``spin1_polar`` (ditto for ``spin2``).
-
 ^^^^^^^^^^^^^^^^^^^^^^
 Calibration parameters
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/pycbc/inference/models/base.py
+++ b/pycbc/inference/models/base.py
@@ -832,10 +832,12 @@ def check_for_cartesian_spins(which, variable_params, static_params,
     """
     # don't do this check if the config file has the ignore section
     if cp.has_section(ignore):
+        logging.info("[{}] found in config file; not performing check for "
+                     "cartesian spin{} parameters".format(ignore, which))
         return
     errmsg = (
         "Spin parameters {sp} found in variable/static "
-        "params, but no cartesian spin parameters ({cp}) "
+        "params for component {n}, but no cartesian spin parameters ({cp}) "
         "found in either the variable/static params or "
         "the waveform transform outputs. Most waveform "
         "generators only recognize the cartesian spin "
@@ -850,13 +852,16 @@ def check_for_cartesian_spins(which, variable_params, static_params,
         "radial = spin{n}_a\n"
         "azimuthal = spin{n}_azimuthal\n"
         "polar = spin{n}_polar\n\n"
-        "If you intended to not include the cartesian spin parameters, "
-        "and do not think this is an error, add\n"
-        "[{ignore}]\n"
-        "to your config file as an empty section and rerun. This error will "
-        "no be raised in that case.")
+        "Here, spin{n}_a, spin{n}_azimuthal, and spin{n}_polar are the names "
+        "of your radial, azimuthal, and polar coordinates, respectively. "
+        "If you intentionally did not include the cartesian spin parameters, "
+        "(e.g., you are using a custom waveform model) add\n\n"
+        "[{ignore}]\n\n"
+        "to your config file as an empty section and rerun. This check will "
+        "not be performed in that case.")
     allparams = set(variable_params) | set(static_params.keys())
-    spinparams = set(p.startswith('spin{}'.format(which)) for p in allparams) 
+    spinparams = set(p for p in allparams
+                     if p.startswith('spin{}'.format(which))) 
     if any(spinparams):
         cartspins = set('spin{}{}'.format(which, coord)
                         for coord in ['x', 'y', 'z'])

--- a/pycbc/inference/models/base.py
+++ b/pycbc/inference/models/base.py
@@ -837,10 +837,10 @@ def check_for_cartesian_spins(which, variable_params, static_params,
         return
     errmsg = (
         "Spin parameters {sp} found in variable/static "
-        "params for component {n}, but no cartesian spin parameters ({cp}) "
+        "params for component {n}, but no Cartesian spin parameters ({cp}) "
         "found in either the variable/static params or "
         "the waveform transform outputs. Most waveform "
-        "generators only recognize the cartesian spin "
+        "generators only recognize Cartesian spin "
         "parameters; without them, all spins are set to "
         "zero. If you are using spherical spin coordinates, add "
         "the following waveform_transform to your config file:\n\n"
@@ -854,8 +854,8 @@ def check_for_cartesian_spins(which, variable_params, static_params,
         "polar = spin{n}_polar\n\n"
         "Here, spin{n}_a, spin{n}_azimuthal, and spin{n}_polar are the names "
         "of your radial, azimuthal, and polar coordinates, respectively. "
-        "If you intentionally did not include the cartesian spin parameters, "
-        "(e.g., you are using a custom waveform model) add\n\n"
+        "If you intentionally did not include Cartesian spin parameters, "
+        "(e.g., you are using a custom waveform or model) add\n\n"
         "[{ignore}]\n\n"
         "to your config file as an empty section and rerun. This check will "
         "not be performed in that case.")

--- a/pycbc/inference/models/base.py
+++ b/pycbc/inference/models/base.py
@@ -861,7 +861,7 @@ def check_for_cartesian_spins(which, variable_params, static_params,
         "not be performed in that case.")
     allparams = set(variable_params) | set(static_params.keys())
     spinparams = set(p for p in allparams
-                     if p.startswith('spin{}'.format(which))) 
+                     if p.startswith('spin{}'.format(which)))
     if any(spinparams):
         cartspins = set('spin{}{}'.format(which, coord)
                         for coord in ['x', 'y', 'z'])

--- a/pycbc/waveform/generator.py
+++ b/pycbc/waveform/generator.py
@@ -194,23 +194,19 @@ class BaseCBCGenerator(BaseGenerator):
         # parameters to those used by the waveform generation interface
         all_args = set(list(self.frozen_params.keys()) +
                        list(self.variable_args))
-        # compare a set of all args of the generator to the input parameters
-        # of the functions that do conversions and adds to list of pregenerate
-        # functions if it is needed
-        params_used, cs = transforms.get_common_cbc_transforms(
-                                       list(self.possible_args), variable_args)
-        for c in cs:
-            self._add_pregenerate(c)
         # check that there are no unused (non-calibration) parameters
         calib_args = set([a for a in self.variable_args if
                           a.startswith('calib_')])
         all_args = all_args - calib_args
-        unused_args = all_args.difference(params_used) \
-                              .difference(self.possible_args)
+        unused_args = all_args - self.possible_args
         if len(unused_args):
-            logging.warning("WARNING: The following args are not being used "
-                            "for waveform generation: %s",
-                            ', '.join(unused_args))
+            logging.warning("WARNING: The following parameters are generally "
+                            "not used by CBC waveform generators: %s. If you "
+                            "have provided a transform that converted these "
+                            "into known parameters (e.g., mchirp, q to "
+                            "mass1, mass2) or you are using a custom model "
+                            "that uses these parameters, you can safely "
+                            "ignore this message.", ', '.join(unused_args))
 
 
 class FDomainCBCGenerator(BaseCBCGenerator):
@@ -219,13 +215,6 @@ class FDomainCBCGenerator(BaseCBCGenerator):
     Uses `waveform.get_fd_waveform` as a generator function to create
     frequency- domain CBC waveforms in the radiation frame; i.e., with no
     detector response function applied. For more details, see `BaseGenerator`.
-
-    Derived parameters not understood by `get_fd_waveform` may be used as
-    variable args and/or frozen parameters, as long as they can be converted
-    into parameters that `get_fd_waveform` can use. For example, `mchirp` and
-    `eta` (currently, the only supported derived parameters) may be used as
-    variable/frozen params; these are converted to `mass1` and `mass2` prior to
-    calling the waveform generator function.
 
     Examples
     --------
@@ -239,26 +228,6 @@ class FDomainCBCGenerator(BaseCBCGenerator):
     >>> generator.generate(mass1=1.4, mass2=1.4)
         (<pycbc.types.frequencyseries.FrequencySeries at 0x1110c1450>,
          <pycbc.types.frequencyseries.FrequencySeries at 0x1110c1510>)
-
-    Initialize a generator using mchirp, eta as the variable args, and generate
-    a waveform:
-
-    >>> generator = FDomainCBCGenerator(variable_args=['mchirp', 'eta'], delta_f=1./32, f_lower=30., approximant='TaylorF2')
-    >>> generator.generate(mchirp=1.5, eta=0.25)
-        (<pycbc.types.frequencyseries.FrequencySeries at 0x109a104d0>,
-         <pycbc.types.frequencyseries.FrequencySeries at 0x109a10b50>)
-
-    Note that the `current_params` contains the mchirp and eta values, along
-    with the mass1 and mass2 they were converted to:
-
-    >>> generator.current_params
-        {'approximant': 'TaylorF2',
-         'delta_f': 0.03125,
-         'eta': 0.25,
-         'f_lower': 30.0,
-         'mass1': 1.7230475324955525,
-         'mass2': 1.7230475324955525,
-         'mchirp': 1.5}
 
     """
     def __init__(self, variable_args=(), **frozen_params):
@@ -288,13 +257,6 @@ class TDomainCBCGenerator(BaseCBCGenerator):
     domain CBC waveforms in the radiation frame; i.e., with no detector
     response function applied. For more details, see `BaseGenerator`.
 
-    Derived parameters not understood by `get_td_waveform` may be used as
-    variable args and/or frozen parameters, as long as they can be converted
-    into parameters that `get_td_waveform` can use. For example, `mchirp` and
-    `eta` (currently, the only supported derived parameters) may be used as
-    variable/frozen params; these are converted to `mass1` and `mass2` prior to
-    calling the waveform generator function.
-
     Examples
     --------
     Initialize a generator:
@@ -307,14 +269,6 @@ class TDomainCBCGenerator(BaseCBCGenerator):
     >>> generator.generate(mass1=2., mass2=1.3)
         (<pycbc.types.timeseries.TimeSeries at 0x10e546710>,
          <pycbc.types.timeseries.TimeSeries at 0x115f37690>)
-
-    Initialize a generator using mchirp, eta as the variable args, and generate
-    a waveform:
-
-    >>> generator = TDomainCBCGenerator(variable_args=['mchirp', 'eta'], delta_t=1./4096, f_lower=30., approximant='TaylorT4')
-    >>> generator.generate(mchirp=1.75, eta=0.2)
-        (<pycbc.types.timeseries.TimeSeries at 0x116ac6050>,
-         <pycbc.types.timeseries.TimeSeries at 0x116ac6950>)
 
     """
     def __init__(self, variable_args=(), **frozen_params):


### PR DESCRIPTION
This removes the automatic transforms that happen in the CBC waveform generators in pycbc inference. Those transforms tried to automatically figure out what transforms were needed to go from some parameters (like spherical spin coordinates and mchirp, q) to parameters understood by the waveform generators. While this meant not having to include a waveform transforms section for spherical spin parameters, the silent and difficult to follow nature of these transforms makes it easy to make mistakes. It also goes against the general philosophy we have of making analysis settings explicit in the configuration file.

Just removing the automatic transforms can be dangerous for spin parameters, however. We typically specify the prior in spherical coordinates. Removing the automatic transforms will cause an analysis that does not have the spherical -> Cartesian waveform transform in the config file to silently set all spins to zero, since lalsimulation expects Cartesian spin coordinates. Since we have not previously required people to include a waveform transform to convert the spherical coordinates to Cartesian, removing the automatic transforms could silently break many people's analyses if they update their code.

To protect against this, I've added a check for spin parameters in the base model. If any parameters are found in the variable or static params that start with `spin(1|2)` but there are no coordinates named `spin(1|2)(x|y|z)` in variable and static params, nor any in the output of the waveform transforms, an error will be raised. This test is applied separately for component 1 and component 2. The error message is:
```
ValueError: Spin parameters spin1_polar, spin1_azimuthal, spin1_a found in variable/static params for component 1, but no Cartesian spin parameters (spin1x, spin1y, spin1z) found in either the variable/static params or the waveform transform outputs. Most waveform generators only recognize Cartesian spin parameters; without them, all spins are set to zero. If you are using spherical spin coordinates, add the following waveform_transform to your config file:

[waveform_transforms-spin1x+spin1y+spin1z]
name = spherical_to_cartesian
x = spin1x
y = spin1y
z = spin1z
radial = spin1_a
azimuthal = spin1_azimuthal
polar = spin1_polar

Here, spin1_a, spin1_azimuthal, and spin1_polar are the names of your radial, azimuthal, and polar coordinates, respectively. If you intentionally did not include Cartesian spin parameters, (e.g., you are using a custom waveform or model) add

[no_err_on_missing_cartesian_spins]

to your config file as an empty section and rerun. This check will not be performed in that case.
```
As indicated in the error message, you can skip the check by adding an empty section titled `[no_err_on_missing_cartesian_spins]` to the config file.

The error will only be raised if no Cartesian spin coordinates present. If there is at least one, then it will not be triggered. I did that because you may be doing an aligned spin search, in which you only have the z components.

Depends on #3325, so putting on hold until that is merged.