### PR TITLE
WIP: Dynesty checkpointing: With Hdf files as checkpoint files

### DIFF
--- a/pycbc/inference/io/__init__.py
+++ b/pycbc/inference/io/__init__.py
@@ -29,7 +29,7 @@ import logging
 import h5py as _h5py
 from pycbc.io.record import (FieldArray, _numpy_function_lib)
 from pycbc import waveform as _waveform
-from pycbc.io.hdf import (dump_state,load_state)
+from pycbc.io.hdf import (dump_state, load_state)
 
 from pycbc.inference.option_utils import (ParseLabelArg, ParseParametersArg)
 from .emcee import EmceeFile
@@ -169,8 +169,8 @@ def check_integrity(filename):
     with loadfile(filename, 'r') as fp:
         if fp.name == 'dynesty_file':
             try:
-                load_state(fp,path='sampler_info/saved_state')
-            except:
+                load_state(fp, path='sampler_info/saved_state')
+            except IOError:
                 raise IOError("Could not recover pickled state")
         else:
             # check that all datasets in samples have the same shape
@@ -242,7 +242,7 @@ def validate_checkpoint_files(checkpoint_file, backup_file, sampler_name):
     if backup_valid:
         with loadfile(backup_file, 'r') as fp:
             backup_valid = fp.validate()
-    if sampler_name == 'dynesty' or sampler_name == 'cpnest':
+    if sampler_name in ['dynesty', 'cpnest']:
         pass
     else:
         # This check is not required by nested samplers

--- a/pycbc/inference/io/__init__.py
+++ b/pycbc/inference/io/__init__.py
@@ -192,7 +192,8 @@ def check_integrity(filename):
                 _ = fp[group.format(param)][lastidx]
 
 
-def validate_checkpoint_files(checkpoint_file, backup_file, sampler_name):
+def validate_checkpoint_files(checkpoint_file, backup_file,
+                              check_nsamples=True):
     """Checks if the given checkpoint and/or backup files are valid.
 
     The checkpoint file is considered valid if:
@@ -242,9 +243,7 @@ def validate_checkpoint_files(checkpoint_file, backup_file, sampler_name):
     if backup_valid:
         with loadfile(backup_file, 'r') as fp:
             backup_valid = fp.validate()
-    if sampler_name in ['dynesty', 'cpnest']:
-        pass
-    else:
+    if check_nsamples:
         # This check is not required by nested samplers
         # check that the checkpoint and backup have the same number of samples;
         # if not, assume the checkpoint has the correct number

--- a/pycbc/inference/io/__init__.py
+++ b/pycbc/inference/io/__init__.py
@@ -171,7 +171,7 @@ def check_integrity(filename):
             try:
                 load_state(fp,path='sampler_info/saved_state')
             except:
-                raise IOError("Could not recover dumped state")
+                raise IOError("Could not recover pickled state")
         else:
             # check that all datasets in samples have the same shape
             parameters = list(fp[fp.samples_group].keys())

--- a/pycbc/inference/io/dynesty.py
+++ b/pycbc/inference/io/dynesty.py
@@ -23,8 +23,8 @@
 #
 """Provides IO for the dynesty sampler.
 """
+from pycbc.io.hdf import (dump_state, load_state)
 from .base_nested_sampler import BaseNestedSamplerFile
-from pycbc.io.hdf import (dump_state,load_state)
 
 class DynestyFile(BaseNestedSamplerFile):
     """Class to handle file IO for the ``dynesty`` sampler."""
@@ -36,16 +36,16 @@ class DynestyFile(BaseNestedSamplerFile):
         """
         self.clear()
         self.create_group('sampler_info/saved_state')
-        dump_state(pickle_obj,self, path='sampler_info/saved_state')
+        dump_state(pickle_obj, self, path='sampler_info/saved_state')
 
     def read_pickled_data_from_checkpoint_file(self):
-        """Load the sampler state (pickled) from checkpoint file                           
+        """Load the sampler state (pickled) from checkpoint file
         """
-        return load_state(self,path='sampler_info/saved_state')   
+        return load_state(self, path='sampler_info/saved_state')
 
     def validate(self):
         """Runs a validation test.
-           This checks that a samples group exist, and that pickeled data can 
+           This checks that a samples group exist, and that pickeled data can
            be loaded.
         Returns
         -------
@@ -53,8 +53,8 @@ class DynestyFile(BaseNestedSamplerFile):
             Whether or not the file is valid as a checkpoint file.
         """
         try:
-            load_state(self,path='sampler_info/saved_state')
+            load_state(self, path='sampler_info/saved_state')
             checkpoint_valid = True
         except KeyError:
             checkpoint_valid = False
-        return checkpoint_valid 
+        return checkpoint_valid

--- a/pycbc/inference/io/dynesty.py
+++ b/pycbc/inference/io/dynesty.py
@@ -24,8 +24,20 @@
 """Provides IO for the dynesty sampler.
 """
 from .base_nested_sampler import BaseNestedSamplerFile
+import hickle
 
 class DynestyFile(BaseNestedSamplerFile):
     """Class to handle file IO for the ``dynesty`` sampler."""
 
     name = 'dynesty_file'
+
+    def write_pickled_data_into_checkpoint(self, pickle_obj):
+        """Dump the sampler state into checkpoint file
+        """
+        self.clear()
+        hickle.dump(pickle_obj,self, mode='r+', path='sampler_info/saved_state')
+
+    def read_pickled_data_from_checkpoint(self):
+        """Load the sampler state (pickled) from checkpoint file                           
+        """
+        return hickle.load(self,path='sampler_info/saved_state')    

--- a/pycbc/inference/io/dynesty.py
+++ b/pycbc/inference/io/dynesty.py
@@ -24,20 +24,37 @@
 """Provides IO for the dynesty sampler.
 """
 from .base_nested_sampler import BaseNestedSamplerFile
-import hickle
+from pycbc.io.hdf import (dump_state,load_state)
 
 class DynestyFile(BaseNestedSamplerFile):
     """Class to handle file IO for the ``dynesty`` sampler."""
 
     name = 'dynesty_file'
 
-    def write_pickled_data_into_checkpoint(self, pickle_obj):
+    def write_pickled_data_into_checkpoint_file(self, pickle_obj):
         """Dump the sampler state into checkpoint file
         """
         self.clear()
-        hickle.dump(pickle_obj,self, mode='r+', path='sampler_info/saved_state')
+        self.create_group('sampler_info/saved_state')
+        dump_state(pickle_obj,self, path='sampler_info/saved_state')
 
-    def read_pickled_data_from_checkpoint(self):
+    def read_pickled_data_from_checkpoint_file(self):
         """Load the sampler state (pickled) from checkpoint file                           
         """
-        return hickle.load(self,path='sampler_info/saved_state')    
+        return load_state(self,path='sampler_info/saved_state')   
+
+    def validate(self):
+        """Runs a validation test.
+           This checks that a samples group exist, and that pickeled data can 
+           be loaded.
+        Returns
+        -------
+        bool :
+            Whether or not the file is valid as a checkpoint file.
+        """
+        try:
+            load_state(self,path='sampler_info/saved_state')
+            checkpoint_valid = True
+        except KeyError:
+            checkpoint_valid = False
+        return checkpoint_valid 

--- a/pycbc/inference/sampler/base.py
+++ b/pycbc/inference/sampler/base.py
@@ -155,7 +155,7 @@ class BaseSampler(object):
 #
 
 
-def setup_output(sampler, output_file):
+def setup_output(sampler, output_file,check_nsamples=True):
     r"""Sets up the sampler's checkpoint and output files.
 
     The checkpoint file has the same name as the output file, but with
@@ -175,7 +175,8 @@ def setup_output(sampler, output_file):
     # check if we have a good checkpoint and/or backup file
     logging.info("Looking for checkpoint file")
     checkpoint_valid = validate_checkpoint_files(checkpoint_file,
-                                                 backup_file, sampler.name)
+                                                 backup_file,
+                                                 check_nsamples)
     # Create a new file if the checkpoint doesn't exist, or if it is
     # corrupted
     sampler.new_checkpoint = False  # keeps track if this is a new file or not

--- a/pycbc/inference/sampler/base.py
+++ b/pycbc/inference/sampler/base.py
@@ -175,10 +175,9 @@ def setup_output(sampler, output_file):
     # check if we have a good checkpoint and/or backup file
     logging.info("Looking for checkpoint file")
     checkpoint_valid = validate_checkpoint_files(checkpoint_file,
-                                                 backup_file,sampler.name)
+                                                 backup_file, sampler.name)
     # Create a new file if the checkpoint doesn't exist, or if it is
     # corrupted
-    print("Checkpiint valid is: %s"%checkpoint_valid)
     sampler.new_checkpoint = False  # keeps track if this is a new file or not
     if not checkpoint_valid:
         logging.info("Checkpoint not found or not valid")

--- a/pycbc/inference/sampler/base.py
+++ b/pycbc/inference/sampler/base.py
@@ -175,9 +175,10 @@ def setup_output(sampler, output_file):
     # check if we have a good checkpoint and/or backup file
     logging.info("Looking for checkpoint file")
     checkpoint_valid = validate_checkpoint_files(checkpoint_file,
-                                                 backup_file)
+                                                 backup_file,sampler.name)
     # Create a new file if the checkpoint doesn't exist, or if it is
     # corrupted
+    print("Checkpiint valid is: %s"%checkpoint_valid)
     sampler.new_checkpoint = False  # keeps track if this is a new file or not
     if not checkpoint_valid:
         logging.info("Checkpoint not found or not valid")

--- a/pycbc/inference/sampler/base_mcmc.py
+++ b/pycbc/inference/sampler/base_mcmc.py
@@ -620,7 +620,7 @@ class BaseMCMC(object):
         # check validity
         logging.info("Validating checkpoint and backup files")
         checkpoint_valid = validate_checkpoint_files(
-            self.checkpoint_file, self.backup_file)
+            self.checkpoint_file, self.backup_file, self.name)
         if not checkpoint_valid:
             raise IOError("error writing to checkpoint file")
         elif self.checkpoint_signal:

--- a/pycbc/inference/sampler/base_mcmc.py
+++ b/pycbc/inference/sampler/base_mcmc.py
@@ -620,7 +620,7 @@ class BaseMCMC(object):
         # check validity
         logging.info("Validating checkpoint and backup files")
         checkpoint_valid = validate_checkpoint_files(
-            self.checkpoint_file, self.backup_file, self.name)
+            self.checkpoint_file, self.backup_file)
         if not checkpoint_valid:
             raise IOError("error writing to checkpoint file")
         elif self.checkpoint_signal:

--- a/pycbc/inference/sampler/cpnest.py
+++ b/pycbc/inference/sampler/cpnest.py
@@ -119,7 +119,7 @@ class CPNestSampler(BaseSampler):
                   verbose=verbose,
                   loglikelihood_function=loglikelihood_function)
 
-        setup_output(obj, output_file)
+        setup_output(obj, output_file, check_nsamples=False)
         if not obj.new_checkpoint:
             obj.resume_from_checkpoint()
         return obj
@@ -139,7 +139,7 @@ class CPNestSampler(BaseSampler):
             self.write_results(fn)
         logging.info("Validating checkpoint and backup files")
         checkpoint_valid = validate_checkpoint_files(
-            self.checkpoint_file, self.backup_file, self.name)
+            self.checkpoint_file, self.backup_file, check_nsamples=False)
         if not checkpoint_valid:
             raise IOError("error writing to checkpoint file")
 

--- a/pycbc/inference/sampler/cpnest.py
+++ b/pycbc/inference/sampler/cpnest.py
@@ -139,7 +139,7 @@ class CPNestSampler(BaseSampler):
             self.write_results(fn)
         logging.info("Validating checkpoint and backup files")
         checkpoint_valid = validate_checkpoint_files(
-            self.checkpoint_file, self.backup_file)
+            self.checkpoint_file, self.backup_file, self.name)
         if not checkpoint_valid:
             raise IOError("error writing to checkpoint file")
 

--- a/pycbc/inference/sampler/dynesty.py
+++ b/pycbc/inference/sampler/dynesty.py
@@ -72,9 +72,9 @@ class DynestySampler(BaseSampler):
     _io = DynestyFile
 
     def __init__(self, model, nlive, nprocesses=1, niter = 0,
-                 checkpoint_time_interval = 1800, loglikelihood_function=None,
-                 use_mpi=False, checkpoint_on_signal=True, run_kwds=None,
-                 **kwargs):
+                 checkpoint_time_interval = 1800, maxcall = 5000,
+                 loglikelihood_function=None, use_mpi=False,
+                 checkpoint_on_signal=True, run_kwds=None, **kwargs):
         self.model = model
         log_likelihood_call, prior_call = setup_calls(
             model,
@@ -86,6 +86,7 @@ class DynestySampler(BaseSampler):
             pool.size = nprocesses
         self.use_mpi = use_mpi
         self.nprocesses = nprocesses
+        self.maxcall = maxcall
         self.checkpoint_time_interval = checkpoint_time_interval
         self.run_kwds = {} if run_kwds is None else run_kwds
         self.nlive = nlive
@@ -128,10 +129,10 @@ class DynestySampler(BaseSampler):
             n_checkpointing = 1
             t0 = time.time()
             while diff_niter != 0:
-                dt = time.time()-t0
+                delta_t = time.time()-t0
                 self._sampler.run_nested(**self.run_kwds)
                 diff_niter = self._sampler.results.niter - self.niter
-                if dt >= self.checkpoint_time_interval:
+                if delta_t >= self.checkpoint_time_interval:
                     logging.info('Checkpointing N = {}'.format(n_checkpointing))
                     self.checkpoint()
                     n_checkpointing += 1

--- a/pycbc/inference/sampler/dynesty.py
+++ b/pycbc/inference/sampler/dynesty.py
@@ -160,12 +160,18 @@ class DynestySampler(BaseSampler):
     def checkpoint(self):
         """Checkpoint function for dynesty sampler
         """
-        for fn in [self.checkpoint_file, self.backup_file]:
-            with self.io(fn, "a") as fp:
-                
+        #for fn in [self.checkpoint_file, self.backup_file]:
+        #    with self.io(fn, "a") as fp:
+        state = [item for item in self._sampler.__dict__.keys() 
+                 if item.startswith('saved_')]
+        with loadfile(self.checkpoint_file, 'a') as fp:
+            dump_state(state, fp, path=fp.sampler_group)
+
 
     def resume_from_checkpoint(self):
-        pass
+        with loadfile(self.checkpoint_file, 'r') as fp:
+            state = load_state(fp, path=fp.sampler_group)
+        
 
     def finalize(self):
         logz = self._sampler.results.logz[-1:][0]

--- a/pycbc/inference/sampler/dynesty.py
+++ b/pycbc/inference/sampler/dynesty.py
@@ -86,16 +86,12 @@ class DynestySampler(BaseSampler):
             pool.size = nprocesses
         self.use_mpi = use_mpi
         self.nprocesses = nprocesses
-        #self._sampler.pool = pool
-        #self._sampler.M = pool.map
         self.run_kwds = {} if run_kwds is None else run_kwds
         self.nlive = nlive
-        #self.checkpoint_interval = checkpoint_interval
         self.names = model.sampling_params
         self.ndim = len(model.sampling_params)
         self.checkpoint_file = None
         self.niter = niter
-        #self._checkpoint_on_signal = checkpoint_on_signal
         if ('maxcall' or 'maxiter') in self.run_kwds:
             self.run_with_checkpoint = True
         else:
@@ -118,15 +114,14 @@ class DynestySampler(BaseSampler):
 
     def run(self):
         diff_niter = 1
-        if self.run_with_checkpoint is True:# and niter == 0:
+        if self.run_with_checkpoint is True:
             if self.checkpoint_file:
                 try:
                     self.resume_from_checkpoint()
                     self.niter = self._sampler.results.niter
-                    print('Successfully read from the file')
+                    logging.info('Successfully read from the checkpoint file')
                 except: # (RuntimeError, TypeError, NameError):
                     logging.info("Could not read checkpoint file")
-                    #pass
             else:
                 self.niter = 0
 
@@ -137,9 +132,6 @@ class DynestySampler(BaseSampler):
                 self.niter = self._sampler.results.niter
         else:
             self._sampler.run_nested(**self.run_kwds)
-
-    #def run_dynesty(self):
-
 
     @property
     def io(self):
@@ -197,41 +189,14 @@ class DynestySampler(BaseSampler):
             obj.resume_from_checkpoint()
         return obj
 
-    #def checkpoint_on_signal(self, signum, frame):
-    #     """Interrupt signal handler to checkpoint the sampler.
-
-     #    Parameters
-     #    ----------
-     #    signum : int
-     #        Open config parser to retrieve the argument from.
-     #    frame : stack frame object
-     #        Name of the section to retrieve from.
-     #    """
-     #    #if self.is_main_process:
-     #    self.checkpoint()
-     #    #del frame
-     #    self._sampler.pool.close()
-     #    self._sampler.pool.terminate()
-     #    sys.exit(signum)
-
     def checkpoint(self):
         """Checkpoint function for dynesty sampler
         """
-        #for fn in [self.checkpoint_file, self.backup_file]:
-        #    with self.io(fn, "a") as fp:
-        #state = [item for item in self._sampler.__dict__.keys()
-        #         if item.startswith('saved_')]
-        #with loadfile(self.checkpoint_file, 'a') as fp:
-        #    dump_state(state, fp, path=fp.sampler_group)
         self.__getstate__ = self.getstate()
-
-        #with open(self.checkpoint_file, 'wb') as fout:
         pickle_obj = self._sampler
         for fn in [self.checkpoint_file]:
             with loadfile(fn, 'a') as fp:
                 fp.write_pickled_data_into_checkpoint_file(pickle_obj)
-        #self._sampler.pool.close()
-        #self._sampler.pool.terminate()
 
     def resume_from_checkpoint(self):
         for fn in [self.checkpoint_file]:

--- a/pycbc/inference/sampler/dynesty.py
+++ b/pycbc/inference/sampler/dynesty.py
@@ -31,7 +31,7 @@ from __future__ import absolute_import
 
 import logging
 import os
-import time 
+import time
 from pycbc.pool import choose_pool
 import numpy
 import dynesty
@@ -123,7 +123,7 @@ class DynestySampler(BaseSampler):
                     self.resume_from_checkpoint()
                     self.niter = self._sampler.results.niter
                     logging.info('Successfully read from the checkpoint file')
-                except KeyError:# (RuntimeError, TypeError, NameError):
+                except KeyError:
                     logging.info("Could not read checkpoint file")
             else:
                 self.niter = 0

--- a/pycbc/inference/sampler/dynesty.py
+++ b/pycbc/inference/sampler/dynesty.py
@@ -158,7 +158,11 @@ class DynestySampler(BaseSampler):
         return obj
 
     def checkpoint(self):
-        pass
+        """Checkpoint function for dynesty sampler
+        """
+        for fn in [self.checkpoint_file, self.backup_file]:
+            with self.io(fn, "a") as fp:
+                
 
     def resume_from_checkpoint(self):
         pass

--- a/pycbc/inference/sampler/dynesty.py
+++ b/pycbc/inference/sampler/dynesty.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2019  Collin Capano, Sumit Kumar
+# Copyright (C) 2019  Collin Capano, Sumit Kumar, Prayush Kumar
 # This program is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License as published by the
 # Free Software Foundation; either version 3 of the License, or (at your

--- a/pycbc/inference/sampler/multinest.py
+++ b/pycbc/inference/sampler/multinest.py
@@ -327,7 +327,7 @@ class MultinestSampler(BaseSampler):
                 f_p.write_niterations(self.niterations)
         logging.info("Validating checkpoint and backup files")
         checkpoint_valid = validate_checkpoint_files(
-            self.checkpoint_file, self.backup_file, self.name)
+            self.checkpoint_file, self.backup_file, check_nsamples=False)
         if not checkpoint_valid:
             raise IOError("error writing to checkpoint file")
 

--- a/pycbc/inference/sampler/multinest.py
+++ b/pycbc/inference/sampler/multinest.py
@@ -327,7 +327,7 @@ class MultinestSampler(BaseSampler):
                 f_p.write_niterations(self.niterations)
         logging.info("Validating checkpoint and backup files")
         checkpoint_valid = validate_checkpoint_files(
-            self.checkpoint_file, self.backup_file)
+            self.checkpoint_file, self.backup_file, self.name)
         if not checkpoint_valid:
             raise IOError("error writing to checkpoint file")
 


### PR DESCRIPTION
To make the checkpoint filesystem uniform across samplers, I am starting this pull request. The sampler state is dumped to existing checkpoint pdf files using 'hickle' at regular intervals. Added two functions for this purpose in `pycbc.inference.io.dynesty`. 