### PR TITLE
Register some more parameter labels

### DIFF
--- a/pycbc/waveform/parameters.py
+++ b/pycbc/waveform/parameters.py
@@ -409,7 +409,7 @@ tc = Parameter("tc",
                 dtype=float, default=None, label=r"$t_c$ (s)",
                 description="Coalescence time (s).")
 delta_tc = Parameter("delta_tc", dtype=float,
-                     label=r"$\Delta t_c~(s)$",
+                     label=r"$\Delta t_c~(\rm{s})$",
                      description="Coalesence time offset.")
 ra = Parameter("ra",
                 dtype=float, default=None, label=r"$\alpha$",

--- a/pycbc/waveform/parameters.py
+++ b/pycbc/waveform/parameters.py
@@ -193,7 +193,7 @@ eccentricity = Parameter("eccentricity",
                 dtype=float, default=0., label=r"$e$",
                 description="Eccentricity.")
 
-# derived parameters (these are not used for waveform generation) for masses
+# derived parameters (these are not used for waveform generation)
 mchirp = Parameter("mchirp",
                 dtype=float, label=r"$\mathcal{M}~(\mathrm{M}_\odot)$",
                 description="The chirp mass of the binary (in solar masses).")
@@ -204,8 +204,24 @@ mtotal = Parameter("mtotal",
                 dtype=float, label=r"$M~(\mathrm{M}_\odot)$",
                 description="The total mass of the binary (in solar masses).")
 q = Parameter("q",
-                dtype=float, label=r"$q$",
-                description="The mass ratio, m1/m2, where m1 >= m2.")
+              dtype=float, label=r"$q$",
+              description="The mass ratio, m1/m2, where m1 >= m2.")
+srcmass1 = Parameter("srcmass1", dtype=float,
+                     label=r"$m_1^{\rm{src}}~(\mathrm{M}_\odot)$",
+                     description="The mass of the first component object in "
+                                 "the source frame (in solar masses).")
+srcmass2 = Parameter("srcmass1", dtype=float,
+                     label=r"$m_2^{\rm{src}}~(\mathrm{M}_\odot)$",
+                     description="The mass of the second component object in "
+                                 "the source frame (in solar masses).")
+srcmchirp = Parameter("srcmchirp", dtype=float,
+                      label=r"$\mathcal{M}^{\rm{src}}~(\mathrm{M}_\odot)$",
+                      description="The chirp mass of the binary in the "
+                                  "source frame (in solar masses).")
+srcmtotal = Parameter("mtotal", dtype=float,
+                      label=r"$M^{\rm{src}}~(\mathrm{M}_\odot)$",
+                      description="The total mass of the binary in the "
+                                  "source frame (in solar masses).")
 primary_mass = Parameter("primary_mass",
                 dtype=float, label=r"$m_{1}$",
                 description="Mass of the primary object (in solar masses).")
@@ -392,6 +408,9 @@ mean_per_ano = Parameter("mean_per_ano",
 tc = Parameter("tc",
                 dtype=float, default=None, label=r"$t_c$ (s)",
                 description="Coalescence time (s).")
+delta_tc = Parameter("delta_tc", dtype=float,
+                     label=r"$\Delta t_c~(s)$",
+                     description="Coalesence time offset.")
 ra = Parameter("ra",
                 dtype=float, default=None, label=r"$\alpha$",
                 description="Right ascension (rad).")
@@ -404,6 +423,9 @@ polarization = Parameter("polarization",
 redshift = Parameter("redshift",
                 dtype=float, default=None, label=r"$z$",
                 description="Redshift.")
+comoving_volume = Parameter("comoving_volume", dtype=float,
+                            label=r"$V_C~(\rm{Mpc}^3)$",
+                            description="Comoving volume (in cubic Mpc).")
 
 #
 #   Calibration parameters


### PR DESCRIPTION
Adds `srcmass1`, `srcmass2`, `srcmchirp`, `srcmtotal`, `delta_tc`, and `comoving_volume` to `waveform/parameters`. Main purpose is to register common labels for them, so you don't have to write out the latex on the command line every time you want to plot them.

Example:
```
pycbc_inference_plot_posterior \
    --verbose \
    --input-file H1L1V1-INFERENCE_150914_09H_50M_45UTC-5-1.hdf \
    --thin-start 414 --thin-interval 39 \
    --output-file ~/WWW/scratch/prs/new_param_labels/posterior_test.png \
    --plot-scatter --plot-marginal --z-arg snr \
    --parameters srcmass1 srcmass2 \
                           'mchirp_from_mass1_mass2(srcmass1, srcmass2):srcmchirp' \
                           'srcmass1+srcmass2:srcmtotal' delta_tc comoving_volume 
```
yields: [plot](https://www.atlas.aei.uni-hannover.de/~work-cdcapano/scratch/prs/new_param_labels/posterior_test.png)

I'm not sure what happened to the marginal comoving volume plot there... but its unrelated to this patch.