### PR TITLE
Allow frame types that change with time

### DIFF
--- a/pycbc/workflow/datafind.py
+++ b/pycbc/workflow/datafind.py
@@ -494,25 +494,61 @@ def setup_datafind_runtime_cache_single_call_perifo(cp, scienceSegs, outputDir,
     datafindouts = []
     datafindcaches = []
     logging.info("Querying datafind server for all science segments.")
+    checked_times = segments.segmentlist([])
     for ifo, scienceSegsIfo in scienceSegs.items():
         observatory = ifo[0].upper()
-        frameType = cp.get_opt_tags("workflow-datafind",
-                                "datafind-%s-frame-type" % (ifo.lower()), tags)
-        # This REQUIRES a coalesced segment list to work
-        startTime = int(scienceSegsIfo[0][0])
-        endTime = int(scienceSegsIfo[-1][1])
-        try:
-            cache, cache_file = run_datafind_instance(cp, outputDir, connection,
-                                       observatory, frameType, startTime,
-                                       endTime, ifo, tags=tags)
-        except:
-            connection = setup_datafind_server_connection(cp, tags=tags)
-            cache, cache_file = run_datafind_instance(cp, outputDir, connection,
-                                       observatory, frameType, startTime,
-                                       endTime, ifo, tags=tags)
+        frame_types = cp.get_opt_tags(
+            "workflow-datafind",
+            "datafind-%s-frame-type" % (ifo.lower()), tags
+        )
+        # Check if this is one type, or time varying
+        frame_types = frame_type.replace(' ', '').strip().split(',')
+        for ftype in frame_types:
+            # Check the times, default to full time initially
+            # This REQUIRES a coalesced segment list to work
+            start = int(scienceSegsIfo[0][0])
+            end = int(scienceSegsIfo[-1][1])
+            # Then check for limits
+            if '[' in ftype:
+                bopt = ftype.split('[')[1].split(']')[0]
+                start, end = bopt.split(':')
+                start = int(start)
+                end = int(end) 
+                ftype = ftype.replace('[' + bopt +']', '')
+            curr_times = segments.segment(start, end)
+            if checked_times.intersects_semgent(curr_times):
+                err_msg = "Different frame types cannot overlap in time."
+                raise ValueError(err_msg)
+            checked_times.append(curr_times)
+ 
+            try:
+                cache, cache_file = run_datafind_instance(
+                    cp,
+                    outputDir,
+                    connection,
+                    observatory,
+                    ftype,
+                    start,
+                    end,
+                    ifo,
+                    tags=tags
+                )
+            except:
+                connection = setup_datafind_server_connection(cp, tags=tags)
+                cache, cache_file = run_datafind_instance(
+                    cp, 
+                    outputDir, 
+                    connection,
+                    observatory, 
+                    ftype, 
+                    start,
+                    end, 
+                    ifo, 
+                    tags=tags
+                )
 
-        datafindouts.append(cache_file)
-        datafindcaches.append(cache)
+            datafindouts.append(cache_file)
+            datafindcaches.append(cache)
     return datafindcaches, datafindouts
 
 def setup_datafind_runtime_frames_single_call_perifo(cp, scienceSegs,

--- a/pycbc/workflow/datafind.py
+++ b/pycbc/workflow/datafind.py
@@ -522,7 +522,7 @@ def setup_datafind_runtime_cache_single_call_perifo(cp, scienceSegs, outputDir,
                 err_msg = "Different frame types cannot overlap in time."
                 raise ValueError(err_msg)
             checked_times.append(curr_times)
- 
+
             try:
                 cache, cache_file = run_datafind_instance(
                     cp,
@@ -538,14 +538,14 @@ def setup_datafind_runtime_cache_single_call_perifo(cp, scienceSegs, outputDir,
             except:
                 connection = setup_datafind_server_connection(cp, tags=tags)
                 cache, cache_file = run_datafind_instance(
-                    cp, 
-                    outputDir, 
+                    cp,
+                    outputDir,
                     connection,
-                    observatory, 
-                    ftype, 
+                    observatory,
+                    ftype,
                     start,
-                    end, 
-                    ifo, 
+                    end,
+                    ifo,
                     tags=tags
                 )
 

--- a/pycbc/workflow/datafind.py
+++ b/pycbc/workflow/datafind.py
@@ -508,21 +508,28 @@ def setup_datafind_runtime_cache_single_call_perifo(cp, scienceSegs, outputDir,
             # This REQUIRES a coalesced segment list to work
             start = int(scienceSegsIfo[0][0])
             end = int(scienceSegsIfo[-1][1])
-            # Then check for limits
+            # Then check for limits. We're expecting something like:
+            # value[start:end], so need to extract value, start and end
             if '[' in ftype:
+                # This gets start and end out
                 bopt = ftype.split('[')[1].split(']')[0]
                 newstart, newend = bopt.split(':')
+                # Then check if the times are within science time
                 start = max(int(newstart), start)
                 end = min(int(newend), end)
                 if end <= start:
                     continue
-                ftype = ftype.replace('[' + bopt +']', '')
+                # This extracts value
+                ftype = ftype.split('[')[0]
             curr_times = segments.segment(start, end)
+            # The times here must be distinct. We cannot have two different
+            # frame files at the same time from the same ifo.
             if checked_times.intersects_segment(curr_times):
                 err_msg = "Different frame types cannot overlap in time."
                 raise ValueError(err_msg)
             checked_times.append(curr_times)
 
+            # Ask datafind where the frames are
             try:
                 cache, cache_file = run_datafind_instance(
                     cp,

--- a/pycbc/workflow/datafind.py
+++ b/pycbc/workflow/datafind.py
@@ -494,15 +494,15 @@ def setup_datafind_runtime_cache_single_call_perifo(cp, scienceSegs, outputDir,
     datafindouts = []
     datafindcaches = []
     logging.info("Querying datafind server for all science segments.")
-    checked_times = segments.segmentlist([])
     for ifo, scienceSegsIfo in scienceSegs.items():
         observatory = ifo[0].upper()
+        checked_times = segments.segmentlist([])
         frame_types = cp.get_opt_tags(
             "workflow-datafind",
             "datafind-%s-frame-type" % (ifo.lower()), tags
         )
         # Check if this is one type, or time varying
-        frame_types = frame_type.replace(' ', '').strip().split(',')
+        frame_types = frame_types.replace(' ', '').strip().split(',')
         for ftype in frame_types:
             # Check the times, default to full time initially
             # This REQUIRES a coalesced segment list to work
@@ -511,12 +511,14 @@ def setup_datafind_runtime_cache_single_call_perifo(cp, scienceSegs, outputDir,
             # Then check for limits
             if '[' in ftype:
                 bopt = ftype.split('[')[1].split(']')[0]
-                start, end = bopt.split(':')
-                start = int(start)
-                end = int(end) 
+                newstart, newend = bopt.split(':')
+                start = max(int(newstart), start)
+                end = min(int(newend), end)
+                if end <= start:
+                    continue
                 ftype = ftype.replace('[' + bopt +']', '')
             curr_times = segments.segment(start, end)
-            if checked_times.intersects_semgent(curr_times):
+            if checked_times.intersects_segment(curr_times):
                 err_msg = "Different frame types cannot overlap in time."
                 raise ValueError(err_msg)
             checked_times.append(curr_times)


### PR DESCRIPTION
We want to be able to support a situation where the frame type varies with time. This patch implements this functionality in the `workflow` module, using the same syntax as for DQ flags. I've added a few sanity checks alongside this (e.g. we cannot have overlapping frame types).

I also did a bit of cleanup in the relevant block of code. I only implemented this in the "single_call_perifo" block, as I want to delete the "multi_call_perifo" block in the nearish future.

I will also be wanting to do the same for the `channel-name`, which is potentially a little more complicated.

I've tested that this does what is intended.