### PR TITLE
Allow options that depend on time

### DIFF
--- a/bin/hdfcoinc/pycbc_calculate_psd
+++ b/bin/hdfcoinc/pycbc_calculate_psd
@@ -7,7 +7,7 @@ import pycbc, pycbc.psd, pycbc.strain, pycbc.events
 from pycbc.version import git_verbose_msg as version
 from pycbc.fft.fftw import set_measure_level
 from pycbc.workflow import resolve_td_option
-from ligo.segments import segmentlist
+from ligo.segments import segmentlist, segment
 set_measure_level(0)
 
 parser = argparse.ArgumentParser(description=__doc__)
@@ -47,7 +47,8 @@ def get_psd(input_tuple):
     argstmp = copy.deepcopy(args)
     argstmp.gps_start_time = int(seg[0]) + args.pad_data
     argstmp.gps_end_time = int(seg[1]) - args.pad_data
-    argstmp.channel_name = resolve_td_option(args.channel_name)
+    tmp_segment = segment([argstmp.gps_start_time, argstmp.gps_end_time])
+    argstmp.channel_name = resolve_td_option(args.channel_name, tmp_segment)
 
     # This helps when the filesystem is unreliable, and gives extra retries.
     # python has an internal limit of ~100 (it is not infinite)

--- a/bin/hdfcoinc/pycbc_calculate_psd
+++ b/bin/hdfcoinc/pycbc_calculate_psd
@@ -1,11 +1,12 @@
 #!/usr/bin/env python
 """ Calculate psd estimates for analysis segments
 """
-import logging, argparse, numpy, h5py, multiprocessing, time
+import logging, argparse, numpy, h5py, multiprocessing, time, copy
 from six.moves import (range, zip_longest)
 import pycbc, pycbc.psd, pycbc.strain, pycbc.events
 from pycbc.version import git_verbose_msg as version
 from pycbc.fft.fftw import set_measure_level
+from pycbc.workflow import resolve_td_option
 from ligo.segments import segmentlist
 set_measure_level(0)
 
@@ -43,13 +44,15 @@ def get_psd(input_tuple):
     
     logging.info('%d: getting strain for %.1f-%.1f (%.1f s)', i, seg[0],
                  seg[1], abs(seg))
-    args.gps_start_time = int(seg[0]) + args.pad_data
-    args.gps_end_time = int(seg[1]) - args.pad_data
+    argstmp = copy.deepcopy(args)
+    argstmp.gps_start_time = int(seg[0]) + args.pad_data
+    argstmp.gps_end_time = int(seg[1]) - args.pad_data
+    argstmp.channel_name = resolve_td_option(args.channel_name)
 
     # This helps when the filesystem is unreliable, and gives extra retries.
     # python has an internal limit of ~100 (it is not infinite)
     try:
-        gwstrain = pycbc.strain.from_cli(args, pycbc.DYN_RANGE_FAC)
+        gwstrain = pycbc.strain.from_cli(argstmp, pycbc.DYN_RANGE_FAC)
     except RuntimeError:
         time.sleep(10)
         return get_psd((seg, i))

--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -1016,6 +1016,7 @@ class Node(pegasus_workflow.Node):
     def resolve_td_options(self, td_options):
         for opt in td_options:
             new_opt = resolve_td_option(td_options[opt], self.valid_seg)
+            self._options += [opt, new_opt]
 
     @property
     def output_files(self):

--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -128,8 +128,8 @@ class Executable(pegasus_workflow.Executable):
     # would be replaced with --option1 value1 if the time is within 0,1000 and
     # value2 if in 1000,2000. A failure will be replaced if the job time is
     # not fully contained in one of these windows, or if fully contained in
-    # multiple of these windows. This is resolved when creating the Job from the
-    # Executable
+    # multiple of these windows. This is resolved when creating the Job from
+    # the Executable
     time_dependent_options = []
 
     # This is the default value. It will give a warning if a class is
@@ -1016,34 +1016,6 @@ class Node(pegasus_workflow.Node):
     def resolve_td_options(self, td_options):
         for opt in td_options:
             new_opt = resolve_td_option(td_options[opt], self.valid_seg)
-            self._options += [opt, new_opt]
-            set_already = False
-            curr_vals = td_options[opt]
-            curr_vals = curr_vals.replace(' ', '').strip().split(',')
-
-            # Resolving the simple case is trivial and can be done immediately.
-            if len(curr_vals) == 1 and '[' not in curr_vals[0]:
-                self._options += [opt, curr_vals[0]]
-
-            for cval in curr_vals:
-                start = int(self.valid_seg[0])
-                end = int(self.valid_seg[1])
-                # Check for limits
-                if '[' in cval:
-                    bopt = cval.split('[')[1].split(']')[0]
-                    start, end = bopt.split(':')
-                    cval = cval.replace('[' + bopt +']', '')
-                curr_seg = segments.segment(int(start), int(end))
-                if curr_seg.intersects(self.valid_seg) and \
-                        (curr_seg & self.valid_seg == self.valid_seg):
-                    if set_already:
-                        err_msg = "Time-dependent options must be disjoint."
-                        raise ValueError(err_msg)
-                    self._options += [opt, cval]
-                    set_already = True
-            if not set_already:
-                err_msg = "Could not resolve option {}".format(opt)
-                raise ValueError(err_msg)
 
     @property
     def output_files(self):
@@ -2071,9 +2043,9 @@ def resolve_td_option(val_str, valid_seg):
     Take an option which might be time-dependent and resolve it
 
     Some options might take different values depending on the GPS time. For
-    example if you want opt_1 to take value_a if the time is between 10 and 100,
-    value_b if between 100 and 250, and value_c if between 250 and 500 you can
-    supply:
+    example if you want opt_1 to take value_a if the time is between 10 and
+    100, value_b if between 100 and 250, and value_c if between 250 and 500 you
+    can supply:
 
     value_a[10:100],value_b[100:250],value_c[250:500].
 
@@ -2102,7 +2074,7 @@ def resolve_td_option(val_str, valid_seg):
         if '[' in cval:
             bopt = cval.split('[')[1].split(']')[0]
             start, end = bopt.split(':')
-            cval = cval.replace('[' + bopt +']', '')
+            cval = cval.replace('[' + bopt + ']', '')
         curr_seg = segments.segment(int(start), int(end))
         # The segments module is a bit weird so we need to check if the two
         # overlap using the following code. If valid_seg is fully within
@@ -2114,7 +2086,7 @@ def resolve_td_option(val_str, valid_seg):
                 raise ValueError(err_msg)
             output = cval
     if not output:
-        err_msg = "Could not resolve option {}".format(opt)
+        err_msg = "Could not resolve option {}".format(val_str)
         raise ValueError
     return output
 

--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -2107,8 +2107,8 @@ def resolve_td_option(val_str, valid_seg):
         # The segments module is a bit weird so we need to check if the two
         # overlap using the following code. If valid_seg is fully within
         # curr_seg this will be true.
-        if curr_seg.intersects(self.valid_seg) and \
-                (curr_seg & self.valid_seg == self.valid_seg):
+        if curr_seg.intersects(valid_seg) and \
+                (curr_seg & valid_seg == valid_seg):
             if output:
                 err_msg = "Time-dependent options must be disjoint."
                 raise ValueError(err_msg)

--- a/pycbc/workflow/jobsetup.py
+++ b/pycbc/workflow/jobsetup.py
@@ -625,6 +625,7 @@ class PyCBCInspiralExecutable(Executable):
 
     current_retention_level = Executable.ALL_TRIGGERS
     file_input_options = ['--gating-file']
+    time_dependent_options = ['--channel-name']
 
     def __init__(self, cp, exe_name, ifo=None, out_dir=None,
                  injection_file=None, tags=None, reuse_executable=False):
@@ -653,7 +654,7 @@ class PyCBCInspiralExecutable(Executable):
     def create_node(self, data_seg, valid_seg, parent=None, dfParents=None, tags=None):
         if tags is None:
             tags = []
-        node = Node(self)
+        node = Node(self, valid_seg=valid_seg)
         if not self.has_opt('pad-data'):
             raise ValueError("The option pad-data is a required option of "
                              "%s. Please check the ini file." % self.name)

--- a/pycbc/workflow/minifollowups.py
+++ b/pycbc/workflow/minifollowups.py
@@ -18,6 +18,7 @@ import logging, os.path
 from six.moves.urllib.request import pathname2url
 from six.moves.urllib.parse import urljoin
 import distutils.spawn
+from ligo import segments
 from pycbc.workflow.core import Executable, FileList, Node, makedir, File, Workflow
 from pycbc.workflow.plotting import PlotExecutable, requirestr, excludestr
 try:
@@ -664,7 +665,7 @@ def make_qscan_plot(workflow, ifo, trig_time, out_dir, injection_file=None,
     # Begin by choosing "optimal" times
     start = trig_time - time_window
     end = trig_time + time_window
-    node = curr_exe.create_node(valid_seg=segments.segment([start,end]))
+    node = curr_exe.create_node(valid_seg=segments.segment([start, end]))
 
     # Then if data_segments is available, check against that, and move if
     # needed


### PR DESCRIPTION
This pull request continues from #3342. Here we want to solve the problem specifically of having a time-dependent `channel-name`, but in doing so add in some plumbing to allow this to be done in more general cases.

The idea here is that you want something like:

```
--channel-name CHANNEL_NAME_A[0:100000],CHANNEL_NAME_B[100000:200000],CHANNEL_NAME_C[200000:300000]
```

We put this into the config file, but we want the workflow generator to automatically figure this out, and send the appropriate channel name to the appropriate jobs.

To do this I've implemented a `time_dependent_option` class variable, similar to how file_options work. If you add `channel-name` into this list, the workflow generator will know to expect something like this and will automatically parse it.

This does require the Node object having an idea of the time it is valid for. Currently it does not. For now, and to avoid more invasive changes, I've just added this as an optional key-word argument when creating the Node. It is not optional if time_dependent_options are present. I would like to (in a future patch) swap to this being a requirement, and then not having to specify a valid time when creating output_files (unless the output file's valid time and the Node's valid time are not the same .... I don't think we have any examples of that at present, but it is possible).

Finally, `pycbc_calculate_psd` needs to be able to handle changing the channel-name internally. Here we let the code parse the option itself, using the same code as the workflow uses. This does raise the possibility that we just allow some options to be "time-dependent" and have this resolved when the job reads in the options, and not at the workflow level at all. For now, I'm sticking with having the workflow deal with this, but welcome opinions on this.

I am testing this at the moment, but as with the file_options, if you aren't using it, it won't do anything.

(Note that changes in #3342 are included here. Once that's merged, I'll rebase with those not included).