### PR TITLE
Adding optimisation for findtrigs

### DIFF
--- a/bin/hdfcoinc/pycbc_coinc_findtrigs
+++ b/bin/hdfcoinc/pycbc_coinc_findtrigs
@@ -195,6 +195,19 @@ if args.use_maxalpha:
 det0, det1 = detector.Detector(trigs0.ifo), detector.Detector(trigs1.ifo)
 time_window = det0.light_travel_time_to_detector(det1) + args.coinc_threshold
 
+total_factors = [1]
+threshes = [numpy.inf]
+for decstr in args.loudest_keep_values:
+    thresh, factor = decstr.split(':')
+    if int(factor) == 1:
+        continue
+    threshes.append(float(thresh))
+    # throws an error if 'factor' is not the string representation
+    # of an integer
+    total_factors.append(total_factors[-1] * int(factor))
+total_factors = numpy.array(total_factors[::-1])
+threshes = numpy.array(threshes[::-1])
+
 if args.timeslide_interval is not None and \
         time_window >= args.timeslide_interval:
     raise parser.error("The maximum time delay between detectors should be "
@@ -240,13 +253,6 @@ for tnum in template_ids:
     logging.info('Calculating Single Detector Statistic')
     s0g, s1g = rank_method.single(trigs0), rank_method.single(trigs1)
 
-    thresh, factor = args.loudest_keep_values[0].split(':')
-    thresh = float(thresh)
-
-    lower = rank_method.coinc_lim_for_thresh(s0g[:1], thresh)
-    upper = rank_method.coinc_lim_for_thresh(s0g[:1], thresh + 0.1)
-    ascending = upper >= lower
-
     # Loop over the single triggers and calculate the coincs they can
     # form
     start0 = 0
@@ -269,12 +275,10 @@ for tnum in template_ids:
             t0 = t0g[start0:end0]
             t1 = t1g[start1:end1]
 
-            total_factor = int(factor)
-
             # Do time coincidence for slides that will be kept after the first decimation
             i0, i1, slide = coinc.time_coincidence(t0, t1, time_window,
-                                                   args.timeslide_interval*total_factor)
-            slide *= total_factor
+                                                   args.timeslide_interval*total_factors[0])
+            slide *= total_factors[0]
 
             c = rank_method.coinc(s0[i0], s1[i1], slide, args.timeslide_interval)
 
@@ -284,95 +288,56 @@ for tnum in template_ids:
             #index values of the background triggers
             bi = numpy.where(slide != 0)[0]
 
-            bl = bi[c[bi] < thresh]
+            bl = bi[c[bi] < threshes[0]]
             ti = numpy.concatenate([fi, bl])
 
             i0 = i0[ti]
             i1 = i1[ti]
             c = c[ti]
             slide = slide[ti]
-            dec = numpy.concatenate([numpy.ones(len(fi)), numpy.repeat(total_factor, len(bl))])
+            dec = numpy.concatenate([numpy.ones(len(fi)), numpy.repeat(total_factors[0], len(bl))])
 
             try:
                 s0stat = s0['snglstat']
-                s1stat = s1['snglstat']
             except IndexError:
                 s0stat = s0.copy()
-                s1stat = s1.copy()
 
+            if not rank_method.single_increasing:
+                s0stat *= -1.
             s0sort = numpy.argsort(s0stat)
-            s1sort = numpy.argsort(s1stat)
-            s1lim = rank_method.coinc_lim_for_thresh(s0[s0sort], thresh)
+            s0sorted = s0stat[s0sort]
 
-            if ascending:
-                s1cut = numpy.searchsorted(s1stat[s1sort], s1lim, side='left')
-            else:
-                s1cut = numpy.searchsorted(s1stat[s1sort], s1lim, side='right')
-                s0sort = s0sort[::-1]
-                s1sort = s1sort[::-1]
-                s1cut = -1 * s1cut[::-1]
-                s1cut[s1cut == 0] = len(s1stat)
+            for kidx in range(1, len(threshes)):
+                s0lim = rank_method.coinc_lim_for_thresh(s1, threshes[kidx - 1])
+                if not rank_method.single_increasing:
+                    s0lim *= -1.
+                
+                s0min = s0lim.min()
+                s0cut = numpy.searchsorted(s0sorted, s0min)
 
-            loops = {}
-            s0start = 0
-            for i in range(1, len(s1cut)):
-                if s1cut[i] != s1cut[i-1]:
-                    loops[(s0start, i)] = s1cut[i-1]
-                    s0start = i
-            loops[(s0start, len(s1cut))] = s1cut[-1]
-            
-            for range0, range1 in loops.items():
-                index0, index1 = s0sort[range0[0]:range0[1]], s1sort[range1:]
-                t0tmp, t1tmp = t0[index0], t1[index1]
-                s0tmp, s1tmp = s0[index0], s1[index1]
+                test_t0 = t0[s0sort[s0cut:]]
+                test_t1 = t1.copy()
 
-                i0tmp, i1tmp, slidetmp = coinc.time_coincidence(t0tmp, t1tmp, time_window, args.timeslide_interval)
+                i0tmp, i1tmp, slidetmp = coinc.time_coincidence(test_t0, test_t1,
+                                                                time_window,
+                                                                args.timeslide_interval*total_factors[kidx])
+                slidetmp *= total_factors[kidx]
+                bitmp = slidetmp != 0
+                i0tmp = i0tmp[bitmp]
+                i1tmp = i1tmp[bitmp]
+                slidetmp = slidetmp[bitmp]
 
-                ctmp = rank_method.coinc(s0tmp[i0tmp], s1tmp[i1tmp], slidetmp, args.timeslide_interval)
+                ctmp = rank_method.coinc(s0[s0sort[s0cut:][i0tmp]], s1[i1tmp],
+                                         slidetmp, args.timeslide_interval)
 
-                bitmp = numpy.where(slidetmp != 0)[0]
+                bitmp = numpy.where(ctmp >= threshes[kidx - 1])[0]
+                bitmp = bitmp[ctmp[bitmp] < threshes[kidx]]
 
-                bu = bitmp[ctmp[bitmp] >= thresh]
-
-                i0 = numpy.concatenate([i0, index0[i0tmp][bu]])
-                i1 = numpy.concatenate([i1, index1[i1tmp][bu]])
-                c = numpy.concatenate([c, ctmp[bu]])
-                slide = numpy.concatenate([slide, slidetmp[bu]])
-                dec = numpy.concatenate([dec, numpy.ones(len(bu))])
-
-            if len(args.loudest_keep_values) > 1:
-                fi = numpy.where(slide == 0)[0]
-                bi = numpy.where(slide != 0)[0]
-                bi_dec = dec[bi]
-
-                for decstr in args.loudest_keep_values[1:]:
-                    thresh, factor = decstr.split(':')
-                    thresh = float(thresh)
-                    # throws an error if 'factor' is not the string representation
-                    # of an integer
-                    total_factor *= int(factor)
-                    
-                    # triggers not being further decimated
-                    upper = c[bi] >= thresh
-                    idxk = bi[upper]
-                    
-                    # decimate the remaining triggers
-                    idx = bi[c[bi] < thresh]
-                    idx = idx[slide[idx] % total_factor == 0]
-                    
-                    bi = numpy.concatenate([idxk, idx])
-                    bi_dec = numpy.concatenate([bi_dec[upper],
-                                                numpy.repeat(total_factor, len(idx))])
-
-                dec[bi] = bi_dec
-                ti = numpy.concatenate([fi, bi])
-                i0 = i0[ti]
-                i1 = i1[ti]
-                c = c[ti]
-                slide = slide[ti]
-                dec = dec[ti]
-
-            logging.info('%s after decimation' % len(ti))
+                i0 = numpy.concatenate([i0, s0sort[s0cut:][i0tmp][bitmp]])
+                i1 = numpy.concatenate([i1, i1tmp[bitmp]])
+                c = numpy.concatenate([c, ctmp[bitmp]])
+                slide = numpy.concatenate([slide, slidetmp[bitmp]])
+                dec = numpy.concatenate([dec, numpy.ones(len(bitmp))])
 
             data['stat'] += [c]
             data['decimation_factor'] += [dec]

--- a/bin/hdfcoinc/pycbc_coinc_findtrigs
+++ b/bin/hdfcoinc/pycbc_coinc_findtrigs
@@ -253,28 +253,53 @@ for tnum in template_ids:
 
     logging.info('Calculating Single Detector Statistic')
     s0g, s1g = rank_method.single(trigs0), rank_method.single(trigs1)
+    s0gsort = numpy.argsort(s0g)
+    s1gsort = numpy.argsort(s1g)
+    if rank_method.single_increasing:
+        s0gsort = s0gsort[::-1]
+        s1gsort = s1gsort[::-1]
 
     # Loop over the single triggers and calculate the coincs they can
     # form
     start0 = 0
     while start0 < len(s0g):
         start1 = 0
+
+        end0 = start0 + args.batch_singles
+        if end0 > len(s0g):
+            end0 = len(s0g)
+
+        s0gid = s0gsort[start0:end0]
+
+        # Set the local parts of the single information we'll use
+        tid0 = tid0g[s0gid]
+        s0 = s0g[s0gid]
+        t0 = t0g[s0gid]
+
+        s1lims = {}
+        s1lower = {}
+        for kidx in range(len(threshes) - 1):
+            # For each trigger in detector 0 get the limit in detector 1 to pass
+            # the current decimation threshold
+            s1lims[kidx] = rank_method.coinc_lim_for_thresh(s0, threshes[kidx])
+            if not rank_method.single_increasing:
+                s1lims[kidx] *= -1.
+            # Get the minimum statistic required for all triggers
+            s1lower[kidx] = s1lims[kidx].min()
+
+
         while start1 < len(s1g):
 
-            end0 = start0 + args.batch_singles
             end1 = start1 + args.batch_singles
-            if end0 > len(s0g):
-                end0 = len(s0g)
             if end1 > len(s1g):
                 end1 = len(s1g)
 
+            s1gid = s1gsort[start0:end0]
+
             # Set the local parts of the single information we'll use
-            tid0 = tid0g[start0:end0]
-            tid1 = tid1g[start1:end1]
-            s0 = s0g[start0:end0]
-            s1 = s1g[start1:end1]
-            t0 = t0g[start0:end0]
-            t1 = t1g[start1:end1]
+            tid1 = tid1g[s1gid]
+            s1 = s1g[s1gid]
+            t1 = t1g[s1gid]
 
             # Do time coincidence for slides that will be kept after all decimation
             curr_shift = args.timeslide_interval * total_factors[0]
@@ -301,33 +326,43 @@ for tnum in template_ids:
             dec = numpy.concatenate([numpy.ones(len(fi)), numpy.repeat(total_factors[0], len(bl))])
 
             try:
-                s0stat = s0['snglstat']
+                s1stat = s1['snglstat']
             except IndexError:
-                s0stat = s0.copy()
+                s1stat = s1.copy()
 
-            # Sort triggers in detector 0 in order of increasing maximum coincident statistic
+            # Sort triggers in detector 1 in order of increasing maximum coincident statistic
             if not rank_method.single_increasing:
-                s0stat *= -1.
-            s0sort = numpy.argsort(s0stat)
-            s0sorted = s0stat[s0sort]
+                s1stat *= -1.
+
+            if s1stat.min() < s1lower[0]:
+                
+                data['stat'] += [c]
+                data['decimation_factor'] += [dec]
+                data['time1'] += [t0[i0]]
+                data['time2'] += [t1[i1]]
+                data['trigger_id1'] += [tid0[i0]]
+                data['trigger_id2'] += [tid1[i1]]
+                data['timeslide_id'] += [slide]
+                data['template_id'] += [numpy.repeat(tnum, len(i0))]
+
+                start1 += args.batch_singles
+                continue
+
+            s1sort = numpy.argsort(s1stat)
+            s1sorted = s1stat[s1sort]
 
             # loop through decimation steps
             for kidx in range(1, len(threshes)):
-                # For each trigger in detector 1 get the limit in detector 0 to pass
-                # the current decimation threshold
-                s0lim = rank_method.coinc_lim_for_thresh(s1, threshes[kidx - 1])
-                if not rank_method.single_increasing:
-                    s0lim *= -1.
                 
-                # Remove triggers in detector 0 that cannot form coincidences above
+                # Remove triggers in detector 1 that cannot form coincidences above
                 # the current decimation threshold
-                s0min = s0lim.min()
-                s0cut = numpy.searchsorted(s0sorted, s0min)
+                s1min = s1lower[kidx - 1].min()
+                s1cut = numpy.searchsorted(s1sorted, s1min)
 
-                s0s = s0sorted[s0cut:]
-                s0i = s0sort[s0cut:]
-                test_t0 = t0[s0i]
-                test_t1 = t1.copy()
+                s1s = s1sorted[s1cut:]
+                s1i = s1sort[s1cut:]
+                test_t1 = t1[s1i]
+                test_t0 = t0.copy()
 
                 # Do time coincidence for current decimation
                 curr_shift = args.timeslide_interval * total_factors[kidx]
@@ -339,20 +374,20 @@ for tnum in template_ids:
                 bitmp = numpy.where(slidetmp != 0)[0]
                 # remove coincidences where detector 0 has a single detector statistic
                 # below the limit calculated above
-                bitmp = bitmp[s0s[i0tmp[bitmp]] >= s0lim[i1tmp[bitmp]]]
+                bitmp = bitmp[s1s[i1tmp[bitmp]] >= s1lims[kidx - 1][i0tmp[bitmp]]]
                 i0tmp = i0tmp[bitmp]
                 i1tmp = i1tmp[bitmp]
                 slidetmp = slidetmp[bitmp]
 
-                ctmp = rank_method.coinc(s0[s0i[i0tmp]], s1[i1tmp],
+                ctmp = rank_method.coinc(s0[i0tmp], s1[s1i[i1tmp]],
                                          slidetmp, args.timeslide_interval)
 
                 # Keep triggers in the current decimation range
                 bitmp = numpy.where(ctmp >= threshes[kidx - 1])[0]
                 bitmp = bitmp[ctmp[bitmp] < threshes[kidx]]
 
-                i0 = numpy.concatenate([i0, s0i[i0tmp[bitmp]]])
-                i1 = numpy.concatenate([i1, i1tmp[bitmp]])
+                i0 = numpy.concatenate([i0, i0tmp[bitmp]])
+                i1 = numpy.concatenate([i1, s1i[i1tmp[bitmp]]])
                 c = numpy.concatenate([c, ctmp[bitmp]])
                 slide = numpy.concatenate([slide, slidetmp[bitmp]])
                 dec = numpy.concatenate([dec, numpy.repeat(total_factors[kidx], len(bitmp))])

--- a/bin/hdfcoinc/pycbc_coinc_findtrigs
+++ b/bin/hdfcoinc/pycbc_coinc_findtrigs
@@ -324,7 +324,9 @@ for tnum in template_ids:
                 s0min = s0lim.min()
                 s0cut = numpy.searchsorted(s0sorted, s0min)
 
-                test_t0 = t0[s0sort[s0cut:]]
+                s0s = s0sorted[s0cut:]
+                s0i = s0sort[s0cut:]
+                test_t0 = t0[s0i]
                 test_t1 = t1.copy()
 
                 # Do time coincidence for current decimation
@@ -334,25 +336,22 @@ for tnum in template_ids:
                 slidetmp *= total_factors[kidx]
 
                 # Remove foreground triggers
-                bitmp = slidetmp != 0
+                bitmp = numpy.where(slidetmp != 0)[0]
+                # remove coincidences where detector 0 has a single detector statistic
+                # below the limit calculated above
+                bitmp = bitmp[s0s[i0tmp[bitmp]] >= s0lim[i1tmp[bitmp]]]
                 i0tmp = i0tmp[bitmp]
                 i1tmp = i1tmp[bitmp]
                 slidetmp = slidetmp[bitmp]
 
-                # remove coincidences where detector 0 has a single detector statistic
-                # below the limit calculated above
-                above = s0sorted[s0cut:][i0tmp] >= s0lim[i1tmp]
-                i0tmp = i0tmp[above]
-                i1tmp = i1tmp[above]
-                slidetmp = slidetmp[above]
-
-                ctmp = rank_method.coinc(s0[s0sort[s0cut:][i0tmp]], s1[i1tmp],
+                ctmp = rank_method.coinc(s0[s0i[i0tmp]], s1[i1tmp],
                                          slidetmp, args.timeslide_interval)
 
+                # Keep triggers in the current decimation range
                 bitmp = numpy.where(ctmp >= threshes[kidx - 1])[0]
                 bitmp = bitmp[ctmp[bitmp] < threshes[kidx]]
 
-                i0 = numpy.concatenate([i0, s0sort[s0cut:][i0tmp][bitmp]])
+                i0 = numpy.concatenate([i0, s0i[i0tmp[bitmp]]])
                 i1 = numpy.concatenate([i1, i1tmp[bitmp]])
                 c = numpy.concatenate([c, ctmp[bitmp]])
                 slide = numpy.concatenate([slide, slidetmp[bitmp]])

--- a/bin/hdfcoinc/pycbc_coinc_findtrigs
+++ b/bin/hdfcoinc/pycbc_coinc_findtrigs
@@ -355,7 +355,7 @@ for tnum in template_ids:
                 i1 = numpy.concatenate([i1, i1tmp[bitmp]])
                 c = numpy.concatenate([c, ctmp[bitmp]])
                 slide = numpy.concatenate([slide, slidetmp[bitmp]])
-                dec = numpy.concatenate([dec, numpy.ones(len(bitmp))])
+                dec = numpy.concatenate([dec, numpy.repeat(total_factors[kidx], len(bitmp))])
 
             data['stat'] += [c]
             data['decimation_factor'] += [dec]

--- a/bin/hdfcoinc/pycbc_coinc_findtrigs
+++ b/bin/hdfcoinc/pycbc_coinc_findtrigs
@@ -341,7 +341,7 @@ for tnum in template_ids:
             if not rank_method.single_increasing:
                 s1stat *= -1.
 
-            tidx = len(threshes) - 1
+            tidx = len(threshes)
             for i in range(1, len(threshes)):
                 if s1stat[-1] >= s1lower[kidx]:
                     tidx = i

--- a/bin/hdfcoinc/pycbc_coinc_findtrigs
+++ b/bin/hdfcoinc/pycbc_coinc_findtrigs
@@ -236,7 +236,6 @@ if args.randomize_template_order:
 else:
     template_ids = range(tmin, tmax)
 
-
 for tnum in template_ids:
     tid0g = trigs0.set_template(tnum)
     tid1g = trigs1.set_template(tnum)
@@ -252,6 +251,8 @@ for tnum in template_ids:
     logging.info('Calculating Single Detector Statistic')
     s0g, s1g = rank_method.single(trigs0), rank_method.single(trigs1)
 
+    # Test whether s0g and s1g are single arrays or record arrays
+    # this depends on the stat being used
     try:
         s0gstat = s0g['snglstat'].copy()
         s1gstat = s1g['snglstat'].copy()
@@ -293,7 +294,8 @@ for tnum in template_ids:
                 s1lims[kidx] *= -1.
             # subtract small amount to account for errors due to rounding
             s1lims[kidx] -= 1e-6
-            # Get the minimum statistic required for all triggers
+            # Get the minimum statistic required for all triggers at the
+            # current decimation threshold
             s1lower[kidx] = s1lims[kidx].min()
 
         while start1 < len(s1g):
@@ -341,13 +343,17 @@ for tnum in template_ids:
             if not rank_method.single_increasing:
                 s1stat *= -1.
 
+            # Starting from the largest decimation threshold, find the first decimation step
+            # where the loudest single detector trigger in s1 can pass the decimation threshold
+            # with any trigger in s0
             tidx = len(threshes)
             for i in range(1, len(threshes)):
                 if s1stat[-1] >= s1lower[kidx]:
                     tidx = i
                     break
 
-            # loop through decimation steps
+            # loop through decimation steps starting from the first step where passing
+            # the threshold is possible
             for kidx in range(tidx, len(threshes)):
                 
                 # Remove triggers in detector 1 that cannot form coincidences above
@@ -366,6 +372,7 @@ for tnum in template_ids:
 
                 # Remove foreground triggers
                 bitmp = numpy.where(slidetmp != 0)[0]
+
                 # remove coincidences where detector 0 has a single detector statistic
                 # below the limit calculated above
                 bitmp = bitmp[s1s[i1tmp[bitmp]] >= s1lims[kidx][i0tmp[bitmp]]]

--- a/bin/hdfcoinc/pycbc_coinc_findtrigs
+++ b/bin/hdfcoinc/pycbc_coinc_findtrigs
@@ -206,8 +206,6 @@ for decstr in args.loudest_keep_values:
     # throws an error if 'factor' is not the string representation
     # of an integer
     total_factors.append(total_factors[-1] * int(factor))
-total_factors = numpy.array(total_factors[::-1])
-threshes = numpy.array(threshes[::-1])
 
 if args.timeslide_interval is not None and \
         time_window >= args.timeslide_interval:
@@ -287,7 +285,7 @@ for tnum in template_ids:
 
         s1lims = {}
         s1lower = {}
-        for kidx in range(len(threshes) - 1):
+        for kidx in range(1, len(threshes)):
             # For each trigger in detector 0 get the limit in detector 1 to pass
             # the current decimation threshold
             s1lims[kidx] = rank_method.coinc_lim_for_thresh(s0, threshes[kidx])
@@ -312,9 +310,9 @@ for tnum in template_ids:
             t1 = t1g[s1gid]
 
             # Do time coincidence for slides that will be kept after all decimation
-            curr_shift = args.timeslide_interval * total_factors[0]
+            curr_shift = args.timeslide_interval * total_factors[-1]
             i0, i1, slide = coinc.time_coincidence(t0, t1, time_window, curr_shift)
-            slide *= total_factors[0]
+            slide *= total_factors[-1]
 
             c = rank_method.coinc(s0[i0], s1[i1], slide, args.timeslide_interval)
 
@@ -326,14 +324,14 @@ for tnum in template_ids:
 
             # keep foreground triggers and background triggers below
             # the lowest decimation threshold
-            bl = bi[c[bi] < threshes[0]]
+            bl = bi[c[bi] < threshes[-1]]
             ti = numpy.concatenate([fi, bl])
 
             i0 = i0[ti]
             i1 = i1[ti]
             c = c[ti]
             slide = slide[ti]
-            dec = numpy.concatenate([numpy.ones(len(fi)), numpy.repeat(total_factors[0], len(bl))])
+            dec = numpy.concatenate([numpy.ones(len(fi)), numpy.repeat(total_factors[-1], len(bl))])
 
             try:
                 s1stat = s1['snglstat'].copy()
@@ -345,7 +343,7 @@ for tnum in template_ids:
 
             tidx = len(threshes) - 1
             for i in range(1, len(threshes)):
-                if s1stat[-1] >= s1lower[kidx - 1]:
+                if s1stat[-1] >= s1lower[kidx]:
                     tidx = i
                     break
 
@@ -354,23 +352,23 @@ for tnum in template_ids:
                 
                 # Remove triggers in detector 1 that cannot form coincidences above
                 # the current decimation threshold
-                s1cut = numpy.searchsorted(s1stat, s1lower[kidx - 1])
+                s1cut = numpy.searchsorted(s1stat, s1lower[kidx])
 
                 s1s = s1stat[s1cut:]
                 test_t1 = t1[s1cut:]
                 test_t0 = t0.copy()
 
                 # Do time coincidence for current decimation
-                curr_shift = args.timeslide_interval * total_factors[kidx]
+                curr_shift = args.timeslide_interval * total_factors[kidx - 1]
                 i0tmp, i1tmp, slidetmp = coinc.time_coincidence(test_t0, test_t1,
                                                                 time_window, curr_shift)
-                slidetmp *= total_factors[kidx]
+                slidetmp *= total_factors[kidx - 1]
 
                 # Remove foreground triggers
                 bitmp = numpy.where(slidetmp != 0)[0]
                 # remove coincidences where detector 0 has a single detector statistic
                 # below the limit calculated above
-                bitmp = bitmp[s1s[i1tmp[bitmp]] >= s1lims[kidx - 1][i0tmp[bitmp]]]
+                bitmp = bitmp[s1s[i1tmp[bitmp]] >= s1lims[kidx][i0tmp[bitmp]]]
                 i0tmp = i0tmp[bitmp]
                 i1tmp = i1tmp[bitmp] + s1cut
                 slidetmp = slidetmp[bitmp]
@@ -379,14 +377,14 @@ for tnum in template_ids:
                                          slidetmp, args.timeslide_interval)
 
                 # Keep triggers in the current decimation range
-                bitmp = numpy.where(ctmp >= threshes[kidx - 1])[0]
-                bitmp = bitmp[ctmp[bitmp] < threshes[kidx]]
+                bitmp = numpy.where(ctmp >= threshes[kidx])[0]
+                bitmp = bitmp[ctmp[bitmp] < threshes[kidx - 1]]
 
                 i0 = numpy.concatenate([i0, i0tmp[bitmp]])
                 i1 = numpy.concatenate([i1, i1tmp[bitmp]])
                 c = numpy.concatenate([c, ctmp[bitmp]])
                 slide = numpy.concatenate([slide, slidetmp[bitmp]])
-                dec = numpy.concatenate([dec, numpy.repeat(total_factors[kidx], len(bitmp))])
+                dec = numpy.concatenate([dec, numpy.repeat(total_factors[kidx - 1], len(bitmp))])
 
             data['stat'] += [c]
             data['decimation_factor'] += [dec]

--- a/bin/hdfcoinc/pycbc_coinc_findtrigs
+++ b/bin/hdfcoinc/pycbc_coinc_findtrigs
@@ -195,6 +195,7 @@ if args.use_maxalpha:
 det0, det1 = detector.Detector(trigs0.ifo), detector.Detector(trigs1.ifo)
 time_window = det0.light_travel_time_to_detector(det1) + args.coinc_threshold
 
+# Calculate the total decimation factors for each step
 total_factors = [1]
 threshes = [numpy.inf]
 for decstr in args.loudest_keep_values:
@@ -275,19 +276,21 @@ for tnum in template_ids:
             t0 = t0g[start0:end0]
             t1 = t1g[start1:end1]
 
-            # Do time coincidence for slides that will be kept after the first decimation
-            i0, i1, slide = coinc.time_coincidence(t0, t1, time_window,
-                                                   args.timeslide_interval*total_factors[0])
+            # Do time coincidence for slides that will be kept after all decimation
+            curr_shift = args.timeslide_interval * total_factors[0]
+            i0, i1, slide = coinc.time_coincidence(t0, t1, time_window, curr_shift)
             slide *= total_factors[0]
 
             c = rank_method.coinc(s0[i0], s1[i1], slide, args.timeslide_interval)
 
-            #index values of the zerolag triggers
+            # index values of the zerolag triggers
             fi = numpy.where(slide == 0)[0]
 
-            #index values of the background triggers
+            # index values of the background triggers
             bi = numpy.where(slide != 0)[0]
 
+            # keep foreground triggers and background triggers below
+            # the lowest decimation threshold
             bl = bi[c[bi] < threshes[0]]
             ti = numpy.concatenate([fi, bl])
 
@@ -302,30 +305,46 @@ for tnum in template_ids:
             except IndexError:
                 s0stat = s0.copy()
 
+            # Sort triggers in detector 0 in order of increasing maximum coincident statistic
             if not rank_method.single_increasing:
                 s0stat *= -1.
             s0sort = numpy.argsort(s0stat)
             s0sorted = s0stat[s0sort]
 
+            # loop through decimation steps
             for kidx in range(1, len(threshes)):
+                # For each trigger in detector 1 get the limit in detector 0 to pass
+                # the current decimation threshold
                 s0lim = rank_method.coinc_lim_for_thresh(s1, threshes[kidx - 1])
                 if not rank_method.single_increasing:
                     s0lim *= -1.
                 
+                # Remove triggers in detector 0 that cannot form coincidences above
+                # the current decimation threshold
                 s0min = s0lim.min()
                 s0cut = numpy.searchsorted(s0sorted, s0min)
 
                 test_t0 = t0[s0sort[s0cut:]]
                 test_t1 = t1.copy()
 
+                # Do time coincidence for current decimation
+                curr_shift = args.timeslide_interval * total_factors[kidx]
                 i0tmp, i1tmp, slidetmp = coinc.time_coincidence(test_t0, test_t1,
-                                                                time_window,
-                                                                args.timeslide_interval*total_factors[kidx])
+                                                                time_window, curr_shift)
                 slidetmp *= total_factors[kidx]
+
+                # Remove foreground triggers
                 bitmp = slidetmp != 0
                 i0tmp = i0tmp[bitmp]
                 i1tmp = i1tmp[bitmp]
                 slidetmp = slidetmp[bitmp]
+
+                # remove coincidences where detector 0 has a single detector statistic
+                # below the limit calculated above
+                above = s0sorted[s0cut:][i0tmp] >= s0lim[i1tmp]
+                i0tmp = i0tmp[above]
+                i1tmp = i1tmp[above]
+                slidetmp = slidetmp[above]
 
                 ctmp = rank_method.coinc(s0[s0sort[s0cut:][i0tmp]], s1[i1tmp],
                                          slidetmp, args.timeslide_interval)

--- a/bin/hdfcoinc/pycbc_coinc_findtrigs
+++ b/bin/hdfcoinc/pycbc_coinc_findtrigs
@@ -253,9 +253,18 @@ for tnum in template_ids:
 
     logging.info('Calculating Single Detector Statistic')
     s0g, s1g = rank_method.single(trigs0), rank_method.single(trigs1)
-    s0gsort = numpy.argsort(s0g)
-    s1gsort = numpy.argsort(s1g)
-    if rank_method.single_increasing:
+
+    try:
+        s0gstat = s0g['snglstat'].copy()
+        s1gstat = s1g['snglstat'].copy()
+    except IndexError:
+        s0gstat = s0g.copy()
+        s1gstat = s1g.copy()
+
+    s0gsort = numpy.argsort(s0gstat)
+    s1gsort = numpy.argsort(s1gstat)
+
+    if not rank_method.single_increasing:
         s0gsort = s0gsort[::-1]
         s1gsort = s1gsort[::-1]
 
@@ -284,9 +293,10 @@ for tnum in template_ids:
             s1lims[kidx] = rank_method.coinc_lim_for_thresh(s0, threshes[kidx])
             if not rank_method.single_increasing:
                 s1lims[kidx] *= -1.
+            # subtract small amount to account for errors due to rounding
+            s1lims[kidx] -= 1e-6
             # Get the minimum statistic required for all triggers
             s1lower[kidx] = s1lims[kidx].min()
-
 
         while start1 < len(s1g):
 
@@ -294,7 +304,7 @@ for tnum in template_ids:
             if end1 > len(s1g):
                 end1 = len(s1g)
 
-            s1gid = s1gsort[start0:end0]
+            s1gid = s1gsort[start1:end1]
 
             # Set the local parts of the single information we'll use
             tid1 = tid1g[s1gid]
@@ -326,42 +336,28 @@ for tnum in template_ids:
             dec = numpy.concatenate([numpy.ones(len(fi)), numpy.repeat(total_factors[0], len(bl))])
 
             try:
-                s1stat = s1['snglstat']
+                s1stat = s1['snglstat'].copy()
             except IndexError:
                 s1stat = s1.copy()
 
-            # Sort triggers in detector 1 in order of increasing maximum coincident statistic
             if not rank_method.single_increasing:
                 s1stat *= -1.
 
-            if s1stat.min() < s1lower[0]:
-                
-                data['stat'] += [c]
-                data['decimation_factor'] += [dec]
-                data['time1'] += [t0[i0]]
-                data['time2'] += [t1[i1]]
-                data['trigger_id1'] += [tid0[i0]]
-                data['trigger_id2'] += [tid1[i1]]
-                data['timeslide_id'] += [slide]
-                data['template_id'] += [numpy.repeat(tnum, len(i0))]
-
-                start1 += args.batch_singles
-                continue
-
-            s1sort = numpy.argsort(s1stat)
-            s1sorted = s1stat[s1sort]
+            tidx = len(threshes) - 1
+            for i in range(1, len(threshes)):
+                if s1stat[-1] >= s1lower[kidx - 1]:
+                    tidx = i
+                    break
 
             # loop through decimation steps
-            for kidx in range(1, len(threshes)):
+            for kidx in range(tidx, len(threshes)):
                 
                 # Remove triggers in detector 1 that cannot form coincidences above
                 # the current decimation threshold
-                s1min = s1lower[kidx - 1].min()
-                s1cut = numpy.searchsorted(s1sorted, s1min)
+                s1cut = numpy.searchsorted(s1stat, s1lower[kidx - 1])
 
-                s1s = s1sorted[s1cut:]
-                s1i = s1sort[s1cut:]
-                test_t1 = t1[s1i]
+                s1s = s1stat[s1cut:]
+                test_t1 = t1[s1cut:]
                 test_t0 = t0.copy()
 
                 # Do time coincidence for current decimation
@@ -376,10 +372,10 @@ for tnum in template_ids:
                 # below the limit calculated above
                 bitmp = bitmp[s1s[i1tmp[bitmp]] >= s1lims[kidx - 1][i0tmp[bitmp]]]
                 i0tmp = i0tmp[bitmp]
-                i1tmp = i1tmp[bitmp]
+                i1tmp = i1tmp[bitmp] + s1cut
                 slidetmp = slidetmp[bitmp]
 
-                ctmp = rank_method.coinc(s0[i0tmp], s1[s1i[i1tmp]],
+                ctmp = rank_method.coinc(s0[i0tmp], s1[i1tmp],
                                          slidetmp, args.timeslide_interval)
 
                 # Keep triggers in the current decimation range
@@ -387,7 +383,7 @@ for tnum in template_ids:
                 bitmp = bitmp[ctmp[bitmp] < threshes[kidx]]
 
                 i0 = numpy.concatenate([i0, i0tmp[bitmp]])
-                i1 = numpy.concatenate([i1, s1i[i1tmp[bitmp]]])
+                i1 = numpy.concatenate([i1, i1tmp[bitmp]])
                 c = numpy.concatenate([c, ctmp[bitmp]])
                 slide = numpy.concatenate([slide, slidetmp[bitmp]])
                 dec = numpy.concatenate([dec, numpy.repeat(total_factors[kidx], len(bitmp))])

--- a/bin/hdfcoinc/pycbc_coinc_findtrigs
+++ b/bin/hdfcoinc/pycbc_coinc_findtrigs
@@ -224,6 +224,7 @@ if args.randomize_template_order:
 else:
     template_ids = range(tmin, tmax)
 
+
 for tnum in template_ids:
     tid0g = trigs0.set_template(tnum)
     tid1g = trigs1.set_template(tnum)
@@ -238,6 +239,13 @@ for tnum in template_ids:
 
     logging.info('Calculating Single Detector Statistic')
     s0g, s1g = rank_method.single(trigs0), rank_method.single(trigs1)
+
+    thresh, factor = args.loudest_keep_values[0].split(':')
+    thresh = float(thresh)
+
+    lower = rank_method.coinc_lim_for_thresh(s0g[:1], thresh)
+    upper = rank_method.coinc_lim_for_thresh(s0g[:1], thresh + 0.1)
+    ascending = upper >= lower
 
     # Loop over the single triggers and calculate the coincs they can
     # form
@@ -261,71 +269,123 @@ for tnum in template_ids:
             t0 = t0g[start0:end0]
             t1 = t1g[start1:end1]
 
+            total_factor = int(factor)
+
+            # Do time coincidence for slides that will be kept after the first decimation
             i0, i1, slide = coinc.time_coincidence(t0, t1, time_window,
-                                                   args.timeslide_interval)
+                                                   args.timeslide_interval*total_factor)
+            slide *= total_factor
 
-            logging.info('Coincident Trigs: %s' % (len(i1)))
-
-
-            logging.info('Calculating Multi-Detector Combined Statistic: %s, %s', end0, end1)
-            c = rank_method.coinc(s0[i0], s1[i1], slide,
-                                  args.timeslide_interval)
+            c = rank_method.coinc(s0[i0], s1[i1], slide, args.timeslide_interval)
 
             #index values of the zerolag triggers
             fi = numpy.where(slide == 0)[0]
 
             #index values of the background triggers
             bi = numpy.where(slide != 0)[0]
-            logging.info('%s foreground triggers' % len(fi))
-            logging.info('%s background triggers' % len(bi))
 
-            # coincs will be decimated by successive (multiplicative) levels
-            # tracked by 'total_factor'
-            bi_dec = bi.copy()
-            dec = numpy.ones(len(bi))
+            bl = bi[c[bi] < thresh]
+            ti = numpy.concatenate([fi, bl])
 
-            total_factor = 1
-            for decstr in args.loudest_keep_values:
-                thresh, factor = decstr.split(':')
-                thresh = float(thresh)
-                # throws an error if 'factor' is not the string representation
-                # of an integer
-                total_factor *= int(factor)
+            i0 = i0[ti]
+            i1 = i1[ti]
+            c = c[ti]
+            slide = slide[ti]
+            dec = numpy.concatenate([numpy.ones(len(fi)), numpy.repeat(total_factor, len(bl))])
 
-                # triggers not being further decimated
-                upper = c[bi_dec] >= thresh
-                idxk = bi_dec[upper]
+            try:
+                s0stat = s0['snglstat']
+                s1stat = s1['snglstat']
+            except IndexError:
+                s0stat = s0.copy()
+                s1stat = s1.copy()
 
-                # decimate the remaining triggers
-                idx = bi_dec[c[bi_dec] < thresh]
-                idx = idx[slide[idx] % total_factor == 0]
+            s0sort = numpy.argsort(s0stat)
+            s1sort = numpy.argsort(s1stat)
+            s1lim = rank_method.coinc_lim_for_thresh(s0[s0sort], thresh)
 
-                bi_dec = numpy.concatenate([idxk, idx])
-                dec = numpy.concatenate([dec[upper],
-                                         numpy.repeat(total_factor, len(idx))]
-                                       )
+            if ascending:
+                s1cut = numpy.searchsorted(s1stat[s1sort], s1lim, side='left')
+            else:
+                s1cut = numpy.searchsorted(s1stat[s1sort], s1lim, side='right')
+                s0sort = s0sort[::-1]
+                s1sort = s1sort[::-1]
+                s1cut = -1 * s1cut[::-1]
+                s1cut[s1cut == 0] = len(s1stat)
 
-            ti = numpy.concatenate([bi_dec, fi]).astype(numpy.uint32)
-            dec_fac = numpy.concatenate([dec, numpy.ones(len(fi))])
+            loops = {}
+            s0start = 0
+            for i in range(1, len(s1cut)):
+                if s1cut[i] != s1cut[i-1]:
+                    loops[(s0start, i)] = s1cut[i-1]
+                    s0start = i
+            loops[(s0start, len(s1cut))] = s1cut[-1]
+            
+            for range0, range1 in loops.items():
+                index0, index1 = s0sort[range0[0]:range0[1]], s1sort[range1:]
+                t0tmp, t1tmp = t0[index0], t1[index1]
+                s0tmp, s1tmp = s0[index0], s1[index1]
+
+                i0tmp, i1tmp, slidetmp = coinc.time_coincidence(t0tmp, t1tmp, time_window, args.timeslide_interval)
+
+                ctmp = rank_method.coinc(s0tmp[i0tmp], s1tmp[i1tmp], slidetmp, args.timeslide_interval)
+
+                bitmp = numpy.where(slidetmp != 0)[0]
+
+                bu = bitmp[ctmp[bitmp] >= thresh]
+
+                i0 = numpy.concatenate([i0, index0[i0tmp][bu]])
+                i1 = numpy.concatenate([i1, index1[i1tmp][bu]])
+                c = numpy.concatenate([c, ctmp[bu]])
+                slide = numpy.concatenate([slide, slidetmp[bu]])
+                dec = numpy.concatenate([dec, numpy.ones(len(bu))])
+
+            if len(args.loudest_keep_values) > 1:
+                fi = numpy.where(slide == 0)[0]
+                bi = numpy.where(slide != 0)[0]
+                bi_dec = dec[bi]
+
+                for decstr in args.loudest_keep_values[1:]:
+                    thresh, factor = decstr.split(':')
+                    thresh = float(thresh)
+                    # throws an error if 'factor' is not the string representation
+                    # of an integer
+                    total_factor *= int(factor)
+                    
+                    # triggers not being further decimated
+                    upper = c[bi] >= thresh
+                    idxk = bi[upper]
+                    
+                    # decimate the remaining triggers
+                    idx = bi[c[bi] < thresh]
+                    idx = idx[slide[idx] % total_factor == 0]
+                    
+                    bi = numpy.concatenate([idxk, idx])
+                    bi_dec = numpy.concatenate([bi_dec[upper],
+                                                numpy.repeat(total_factor, len(idx))])
+
+                dec[bi] = bi_dec
+                ti = numpy.concatenate([fi, bi])
+                i0 = i0[ti]
+                i1 = i1[ti]
+                c = c[ti]
+                slide = slide[ti]
+                dec = dec[ti]
+
             logging.info('%s after decimation' % len(ti))
 
-            # temporary storage for decimated trigger ids
-            g0 = i0[ti]
-            g1 = i1[ti]
-            del i0
-            del i1
-
-            data['stat'] += [c[ti]]
-            data['decimation_factor'] += [dec_fac]
-            data['time1'] += [t0[g0]]
-            data['time2'] += [t1[g1]]
-            data['trigger_id1'] += [tid0[g0]]
-            data['trigger_id2'] += [tid1[g1]]
-            data['timeslide_id'] += [slide[ti]]
-            data['template_id'] += [numpy.repeat(tnum, len(ti))]
+            data['stat'] += [c]
+            data['decimation_factor'] += [dec]
+            data['time1'] += [t0[i0]]
+            data['time2'] += [t1[i1]]
+            data['trigger_id1'] += [tid0[i0]]
+            data['trigger_id2'] += [tid1[i1]]
+            data['timeslide_id'] += [slide]
+            data['template_id'] += [numpy.repeat(tnum, len(i0))]
 
             start1 += args.batch_singles
         start0 += args.batch_singles
+
 
 if len(data['stat']) > 0:
     for key in data:

--- a/bin/hdfcoinc/pycbc_multiifo_coinc_findtrigs
+++ b/bin/hdfcoinc/pycbc_multiifo_coinc_findtrigs
@@ -163,6 +163,19 @@ for ifo in trigs.ifos:
     data['%s/time' % ifo] = []
     data['%s/trigger_id' % ifo] = []
 
+total_factors = [1]
+threshes = [numpy.inf]
+for decstr in args.loudest_keep_values:
+    thresh, factor = decstr.split(':')
+    if int(factor) == 1:
+        continue
+    threshes.append(float(thresh))
+    # throws an error if 'factor' is not the string representation
+    # of an integer
+    total_factors.append(total_factors[-1] * int(factor))
+total_factors = numpy.array(total_factors[::-1])
+threshes = numpy.array(threshes[::-1])
+
 for tnum in template_ids:
     times_full = {}
     sds_full = {}
@@ -182,32 +195,19 @@ for tnum in template_ids:
                      'skipping' % tnum)
         continue
 
-    thresh, factor = args.loudest_keep_values[0].split(':')
-    thresh = float(thresh)
-
     if type(rank_method.single_dtype) == list:
         entries = [e[0] for e in rank_method.single_dtype]
         if 'snr' in entries:
-            min_snr = numpy.min([sds_full[i]['snr'] for i in trigs.ifos])
+            min_snr = min([numpy.min(sds_full[i]['snr']) for i in trigs.ifos])
         else:
             min_snr = None
         if 'sigmasq'in entries:
-            max_sigmasq = numpy.max([sds_full[i]['sigmasq'] for i in trigs.ifos])
+            max_sigmasq = max([numpy.max(sds_full[i]['sigmasq']) for i in trigs.ifos])
         else:
             max_sigmasq = None
-
-    sds_nopivot = {k: v[:1] for k, v in sds_full.items if k != args.pivot_ifo}
-    lower = rank_method.coinc_multiifo_lim_for_thresh(sds_nopivot, thresh,
-                                                      args.pivot_ifo,
-                                                      time_addition=args.coinc_threshold,
-                                                      min_snr=min_snr,
-                                                      max_sigmasq=max_sigmasq)
-    upper = rank_method.coinc_multiifo_lim_for_thresh(sds_nopivot, thresh + 0.1,
-                                                      args.pivot_ifo,
-                                                      time_addition=args.coinc_threshold,
-                                                      min_snr=min_snr,
-                                                      max_sigmasq=max_sigmasq)
-    ascending = upper >= lower
+    else:
+        min_snr = None
+        max_sigmasq = None
 
     # Loop over the single triggers and calculate the coincs they can form
     start0 = 0
@@ -233,129 +233,133 @@ for tnum in template_ids:
             tids[args.pivot_ifo] = tids_full[args.pivot_ifo][start0:end0]
             tids[args.fixed_ifo] = tids_full[args.fixed_ifo][start1:end1]
 
-            total_factor = int(factor)
-
-            # Do time coincidence for slides that will be kept after the first decimation
+            # Do time coincidence for slides that will be kept after the last decimation
+            logging.info('Starting coinc 0')
             ids, slide = coinc.time_multi_coincidence(times,
-                                                      args.timeslide_interval*total_factor,
+                                                      args.timeslide_interval*total_factors[0],
                                                       args.coinc_threshold,
                                                       args.pivot_ifo,
                                                       args.fixed_ifo)
+            slide *= total_factors[0]
+            logging.info('Finished coinc 0')
 
-            slide *= total_factor
-
+            logging.info('Starting cstat 0')
+            single_info = [(i, sds[i][ids[i]]) for i in trigs.ifos]
             cstat = rank_method.coinc_multiifo(
                 single_info, slide, args.timeslide_interval,
                 to_shift=trigs.to_shift,
                 time_addition=args.coinc_threshold)
+            logging.info('Finished cstat 0')
 
             #index values of the zerolag triggers
             fi = numpy.where(slide == 0)[0]
 
             #index values of the background triggers
             bi = numpy.where(slide != 0)[0]
+            bl = bi[cstat[bi] < threshes[0]]
 
-            bl = bi[cstat[bi] < thresh]
             ti = numpy.concatenate([fi, bl])
 
             ids = {i: t[ti] for i, t in ids.items()}
 
             cstat = cstat[ti]
             slide = slide[ti]
-            dec = numpy.concatenate([numpy.ones(len(fi)), numpy.repeat(total_factor, len(bl))])
+            dec = numpy.concatenate([numpy.ones(len(fi)), numpy.repeat(total_factors[0], len(bl))])
 
-            time_nopivot = {k, v for k, v in times.items() if k != args.pivot_ifo}
-            ifos_nopivot = [i for i in trigs.ifos if i != args.pivot_ifo]
+            if len(threshes) > 1:
+                ifos_nopivot = [i for i in trigs.ifos if i != args.pivot_ifo]
+                time_nopivot = {i: times[i] for i in ifos_nopivot}
 
-            if len(ifos_nopivot) > 1:
-                test_ids, slide = coinc.time_multi_coincidence(times_nopivot, 0.,
-                                                               args.coinc_threshold,
-                                                               ifos_nopivot[0],
-                                                               ifos_nopivot[1])
-            else:
-                det = ifos_nopivot[0]
-                test_ids = {det: np.arange(len(times[det]))}
+                if len(ifos_nopivot) > 1:
+                    test_ids, test_slide = coinc.time_multi_coincidence(time_nopivot, 0.,
+                                                                        args.coinc_threshold,
+                                                                        ifos_nopivot[0],
+                                                                        ifos_nopivot[1])
+                    if len(test_slide) == 0:
+                        start1 += args.batch_singles
+                        continue
 
-            # list in ifo order of remaining trigger data
-            single_info = [(i, sds[i][test_ids[i]]) for i in ifos_nopivot]
-            s0lim = rank_method.coinc_multiifo_lim_for_thresh(
-                single_info, thresh,
-                args.pivot_ifo,
-                time_addition=args.coinc_threshold,
-                min_snr=min_snr,
-                max_sigmasq=max_sigmasq)
+                    # list in ifo order of remaining trigger data
+                    test_single_info = [(i, sds[i][test_ids[i]]) for i in ifos_nopivot]
+                    test_times = {i: time_nopivot[i][test_ids[i]] for i in ifos_nopivot}
 
-            s0sort = numpy.argsort(s0lim)
-            
-            if ascending:
-                s0cut = numpy.searchsorted(sds[args.pivot_ifo][s0sort], s0lim, side='left')
-            else:
-                s0cut = numpy.searchsorted(sds[args.pivot_ifo][s0sort], s0lim, side='right')
-                s0sort = s0sort[::-1]
-                s0cut = -1 * s0cut[::-1]
-                s0cut[s0cut == 0] = len(s0sort)
+                else:
+                    det = ifos_nopivot[0]
+                    test_ids = {det: numpy.arange(len(times[det]))}
+                    test_single_info = [(i, sds[i]) for i in ifos_nopivot]
+                    test_times = {i: times[i] for i in ifos_nopivot}
 
-            for idx in range(len(s0cut)):
-                tmp_ids = {i: test_ids[i][idx:idx+1] for i in ifos_nopivot}
-                tmp_ids[args.pivot_ifo] = s0sort[s0cut[idx]:]
+                try:
+                    s0stat = sds[args.pivot_ifo]['snglstat'].copy()
+                except IndexError:
+                    s0stat = sds[args.pivot_ifo].copy()
 
-                tmp_times = {i: times[tmp_ids[i]] for i in trigs.ifos}
-                tmp_sds = {i: sds[tmp_ids[i]] for i in trigs.ifos}
+                if not rank_method.single_increasing:
+                    s0stat *= -1.
+                s0sort = numpy.argsort(s0stat)
+                s0sorted = s0stat[s0sort]
 
-                tmptmp_ids, tmp_slide = coinc.time_multi_coincidence(tmp_times,
-                                                      args.timeslide_interval,
-                                                      args.coinc_threshold,
-                                                      args.pivot_ifo,
-                                                      args.fixed_ifo)
-                
-                tmp_single_info = [(i, tmp_sds[i][tmptmp_ids[i]]) for i in trigs.ifos]
+            for kidx in range(1, len(threshes)):
+                logging.info('Getting single limits {0}'.format(kidx))
+                s0lim = rank_method.coinc_multiifo_lim_for_thresh(
+                    test_single_info, threshes[kidx - 1],
+                    args.pivot_ifo,
+                    time_addition=args.coinc_threshold,
+                    min_snr=min_snr,
+                    max_sigmasq=max_sigmasq)
+                logging.info('Got single limits {0}'.format(kidx))
+
+                if not rank_method.single_increasing:
+                    s0lim *= -1.
+
+                s0min = s0lim.min()
+                s0cut = numpy.searchsorted(s0sorted, s0min)
+
+                test_times[args.pivot_ifo] = times[args.pivot_ifo][s0sort[s0cut:]]
+                test_ids[args.pivot_ifo] = s0sort[s0cut:]
+
+                logging.info('Getting coinc')
+                set_ids, set_slide = coinc.time_multi_coincidence(test_times,
+                                                                  args.timeslide_interval*total_factors[kidx],
+                                                                  args.coinc_threshold,
+                                                                  args.pivot_ifo,
+                                                                  args.fixed_ifo)
+                set_slide *= total_factors[kidx]
+                logging.info('Got coinc')
+
+                sets = set_slide != 0
+                for i in range(1, len(ifos_nopivot)):
+                    sets *= set_ids[ifos_nopivot[i-1]] == set_ids[ifos_nopivot[i]]
+
+                #lim_ids = set_ids[ifos_nopivot[0]][sets]
+                #test_ids = {i: test_ids[i][set_ids[i][sets]] for i in ifos_nopivot}
+                #test_ids[args.pivot_ifo] = set_ids[args.pivot_ifo][sets]
+                #test_slide = set_slide[sets]
+                set_ids = {i: set_ids[i][sets] for i in trigs.ifos}
+                set_slide = set_slide[sets]
+
+                logging.info('finding above {0}'.format(kidx))
+                above = s0sorted[s0cut:][set_ids[args.pivot_ifo]] >= s0lim[set_ids[ifos_nopivot[0]]]
+                logging.info('found above {0}'.format(kidx))
+
+                logging.info('Getting cstat')
+                tmp_ids = {i: test_ids[i][set_ids[i][above]] for i in trigs.ifos}
+                set_slide = set_slide[above]
+                tmp_single_info = [(i, sds[i][tmp_ids[i]]) for i in trigs.ifos]
                 tmp_cstat = rank_method.coinc_multiifo(
-                    single_info, slide, args.timeslide_interval,
+                    tmp_single_info, set_slide, args.timeslide_interval,
                     to_shift=trigs.to_shift,
                     time_addition=args.coinc_threshold)
+                logging.info('Got cstat')
 
-                tmp_bi = numpy.where(tmp_slide != 0)[0]
-                bu = tmp_bi[tmp_cstat[tmp_bi] >= thresh]
+                tmp_bi = numpy.where(tmp_cstat >= threshes[kidx - 1])[0]
+                tmp_bi = tmp_bi[tmp_cstat[tmp_bi] < threshes[kidx]]
 
                 for i in trigs.ifos:
-                    ids[i] = numpy.concatenate([ids[i], tmp_ids[i][tmptmp_ids[i]][bu]])
-                cstat = numpy.concatenate([cstat, tmp_cstat[bu]])
-                slide = numpy.concatenate([slide, tmp_slide[bu]])
-                dec = numpy.concatenate([dec, numpy.ones(len(bu))])
-
-            if len(args.loudest_keep_values) > 1:
-                fi = numpy.where(slide == 0)[0]
-                bi = numpy.where(slide != 0)[0]
-                bi_dec = dec[bi]
-
-                for decstr in args.loudest_keep_values[1:]:
-                    thresh, factor = decstr.split(':')
-                    thresh = float(thresh)
-                    # throws an error if 'factor' is not the string representation
-                    # of an integer
-                    total_factor *= int(factor)
-
-                    # triggers not being further decimated
-                    upper = cstat[bi] >= thresh
-                    idx_keep = bi[upper]
-
-                    # decimate the remaining triggers
-                    idx = bi[cstat[bi] < thresh]
-                    idx = idx[slide[idx] % total_factor == 0]
-
-                    bi = numpy.concatenate([idx_keep, idx])
-                    bi_dec = numpy.concatenate([bi_dec[upper],
-                                                numpy.repeat(total_factor, len(idx))])
-
-                dec[bi] = bi_dec
-                ti = numpy.concatenate([fi, bi])
-                for i in trigs.ifos:
-                    ids[i] = ids[i][ti]
-                cstat = cstat[ti]
-                slide = slide[ti]
-                dec = dec[ti]
-
-            logging.info('%s after decimation' % len(ti))
+                    ids[i] = numpy.concatenate([ids[i], tmp_ids[i][tmp_bi]])
+                cstat = numpy.concatenate([cstat, tmp_cstat[tmp_bi]])
+                slide = numpy.concatenate([slide, set_slide[tmp_bi]])
+                dec = numpy.concatenate([dec, numpy.repeat(total_factors[kidx], len(tmp_bi))])
 
             # temporary storage for decimated trigger ids
             for ifo in trigs.ifos:

--- a/bin/hdfcoinc/pycbc_multiifo_coinc_findtrigs
+++ b/bin/hdfcoinc/pycbc_multiifo_coinc_findtrigs
@@ -266,10 +266,15 @@ for tnum in template_ids:
 
             time_nopivot = {k, v for k, v in times.items() if k != args.pivot_ifo}
             ifos_nopivot = [i for i in trigs.ifos if i != args.pivot_ifo]
-            test_ids, slide = coinc.time_multi_coincidence(times_nopivot, 0.,
-                                                           args.coinc_threshold,
-                                                           ifos_nopivot[0],
-                                                           ifos_nopivot[1])
+
+            if len(ifos_nopivot) > 1:
+                test_ids, slide = coinc.time_multi_coincidence(times_nopivot, 0.,
+                                                               args.coinc_threshold,
+                                                               ifos_nopivot[0],
+                                                               ifos_nopivot[1])
+            else:
+                det = ifos_nopivot[0]
+                test_ids = {det: np.arange(len(times[det]))}
 
             # list in ifo order of remaining trigger data
             single_info = [(i, sds[i][test_ids[i]]) for i in ifos_nopivot]

--- a/bin/hdfcoinc/pycbc_multiifo_coinc_findtrigs
+++ b/bin/hdfcoinc/pycbc_multiifo_coinc_findtrigs
@@ -182,6 +182,33 @@ for tnum in template_ids:
                      'skipping' % tnum)
         continue
 
+    thresh, factor = args.loudest_keep_values[0].split(':')
+    thresh = float(thresh)
+
+    if type(rank_method.single_dtype) == list:
+        entries = [e[0] for e in rank_method.single_dtype]
+        if 'snr' in entries:
+            min_snr = numpy.min([sds_full[i]['snr'] for i in trigs.ifos])
+        else:
+            min_snr = None
+        if 'sigmasq'in entries:
+            max_sigmasq = numpy.max([sds_full[i]['sigmasq'] for i in trigs.ifos])
+        else:
+            max_sigmasq = None
+
+    sds_nopivot = {k: v[:1] for k, v in sds_full.items if k != args.pivot_ifo}
+    lower = rank_method.coinc_multiifo_lim_for_thresh(sds_nopivot, thresh,
+                                                      args.pivot_ifo,
+                                                      time_addition=args.coinc_threshold,
+                                                      min_snr=min_snr,
+                                                      max_sigmasq=max_sigmasq)
+    upper = rank_method.coinc_multiifo_lim_for_thresh(sds_nopivot, thresh + 0.1,
+                                                      args.pivot_ifo,
+                                                      time_addition=args.coinc_threshold,
+                                                      min_snr=min_snr,
+                                                      max_sigmasq=max_sigmasq)
+    ascending = upper >= lower
+
     # Loop over the single triggers and calculate the coincs they can form
     start0 = 0
     while start0 < len(sds_full[args.pivot_ifo]):
@@ -206,72 +233,135 @@ for tnum in template_ids:
             tids[args.pivot_ifo] = tids_full[args.pivot_ifo][start0:end0]
             tids[args.fixed_ifo] = tids_full[args.fixed_ifo][start1:end1]
 
-            # find the coincs
+            total_factor = int(factor)
+
+            # Do time coincidence for slides that will be kept after the first decimation
             ids, slide = coinc.time_multi_coincidence(times,
-                                                      args.timeslide_interval,
+                                                      args.timeslide_interval*total_factor,
                                                       args.coinc_threshold,
                                                       args.pivot_ifo,
                                                       args.fixed_ifo)
-            logging.info('Coincident trigs: %s' % (len(ids[args.pivot_ifo])))
 
-            logging.info('Calculating multi-detector combined statistic')
-            # list in ifo order of remaining trigger data
-            single_info = [(i, sds[i][ids[i]]) for i in trigs.ifos]
+            slide *= total_factor
+
             cstat = rank_method.coinc_multiifo(
                 single_info, slide, args.timeslide_interval,
                 to_shift=trigs.to_shift,
                 time_addition=args.coinc_threshold)
 
-            # index values of the zerolag triggers
+            #index values of the zerolag triggers
             fi = numpy.where(slide == 0)[0]
-            # index values of the background triggers
+
+            #index values of the background triggers
             bi = numpy.where(slide != 0)[0]
-            logging.info('%s foreground triggers' % len(fi))
-            logging.info('%s background triggers' % len(bi))
 
-            # coincs will be decimated by successive (multiplicative) levels
-            # tracked by 'total_factor'
-            bi_dec = bi.copy()
-            dec = numpy.ones(len(bi))
-            total_factor = 1
-            for decstr in args.loudest_keep_values:
-                thresh, factor = decstr.split(':')
-                thresh = float(thresh)
-                # throws an error if 'factor' is not the string representation
-                # of an integer
-                total_factor *= int(factor)
+            bl = bi[cstat[bi] < thresh]
+            ti = numpy.concatenate([fi, bl])
 
-                # triggers not being further decimated
-                upper = cstat[bi_dec] >= thresh
-                idx_keep = bi_dec[upper]
+            ids = {i: t[ti] for i, t in ids.items()}
 
-                # decimate the remaining triggers
-                idx = bi_dec[cstat[bi_dec] < thresh]
-                idx = idx[slide[idx] % total_factor == 0]
+            cstat = cstat[ti]
+            slide = slide[ti]
+            dec = numpy.concatenate([numpy.ones(len(fi)), numpy.repeat(total_factor, len(bl))])
 
-                bi_dec = numpy.concatenate([idx_keep, idx])
-                dec = numpy.concatenate([dec[upper],
-                                         numpy.repeat(total_factor, len(idx))])
+            time_nopivot = {k, v for k, v in times.items() if k != args.pivot_ifo}
+            ifos_nopivot = [i for i in trigs.ifos if i != args.pivot_ifo]
+            test_ids, slide = coinc.time_multi_coincidence(times_nopivot, 0.,
+                                                           args.coinc_threshold,
+                                                           ifos_nopivot[0],
+                                                           ifos_nopivot[1])
 
-            ti = numpy.concatenate([bi_dec, fi]).astype(numpy.uint32)
-            dec_fac = numpy.concatenate([dec, numpy.ones(len(fi))])
+            # list in ifo order of remaining trigger data
+            single_info = [(i, sds[i][test_ids[i]]) for i in ifos_nopivot]
+            s0lim = rank_method.coinc_multiifo_lim_for_thresh(
+                single_info, thresh,
+                args.pivot_ifo,
+                time_addition=args.coinc_threshold,
+                min_snr=min_snr,
+                max_sigmasq=max_sigmasq)
+
+            s0sort = numpy.argsort(s0lim)
+            
+            if ascending:
+                s0cut = numpy.searchsorted(sds[args.pivot_ifo][s0sort], s0lim, side='left')
+            else:
+                s0cut = numpy.searchsorted(sds[args.pivot_ifo][s0sort], s0lim, side='right')
+                s0sort = s0sort[::-1]
+                s0cut = -1 * s0cut[::-1]
+                s0cut[s0cut == 0] = len(s0sort)
+
+            for idx in range(len(s0cut)):
+                tmp_ids = {i: test_ids[i][idx:idx+1] for i in ifos_nopivot}
+                tmp_ids[args.pivot_ifo] = s0sort[s0cut[idx]:]
+
+                tmp_times = {i: times[tmp_ids[i]] for i in trigs.ifos}
+                tmp_sds = {i: sds[tmp_ids[i]] for i in trigs.ifos}
+
+                tmptmp_ids, tmp_slide = coinc.time_multi_coincidence(tmp_times,
+                                                      args.timeslide_interval,
+                                                      args.coinc_threshold,
+                                                      args.pivot_ifo,
+                                                      args.fixed_ifo)
+                
+                tmp_single_info = [(i, tmp_sds[i][tmptmp_ids[i]]) for i in trigs.ifos]
+                tmp_cstat = rank_method.coinc_multiifo(
+                    single_info, slide, args.timeslide_interval,
+                    to_shift=trigs.to_shift,
+                    time_addition=args.coinc_threshold)
+
+                tmp_bi = numpy.where(tmp_slide != 0)[0]
+                bu = tmp_bi[tmp_cstat[tmp_bi] >= thresh]
+
+                for i in trigs.ifos:
+                    ids[i] = numpy.concatenate([ids[i], tmp_ids[i][tmptmp_ids[i]][bu]])
+                cstat = numpy.concatenate([cstat, tmp_cstat[bu]])
+                slide = numpy.concatenate([slide, tmp_slide[bu]])
+                dec = numpy.concatenate([dec, numpy.ones(len(bu))])
+
+            if len(args.loudest_keep_values) > 1:
+                fi = numpy.where(slide == 0)[0]
+                bi = numpy.where(slide != 0)[0]
+                bi_dec = dec[bi]
+
+                for decstr in args.loudest_keep_values[1:]:
+                    thresh, factor = decstr.split(':')
+                    thresh = float(thresh)
+                    # throws an error if 'factor' is not the string representation
+                    # of an integer
+                    total_factor *= int(factor)
+
+                    # triggers not being further decimated
+                    upper = cstat[bi] >= thresh
+                    idx_keep = bi[upper]
+
+                    # decimate the remaining triggers
+                    idx = bi[cstat[bi] < thresh]
+                    idx = idx[slide[idx] % total_factor == 0]
+
+                    bi = numpy.concatenate([idx_keep, idx])
+                    bi_dec = numpy.concatenate([bi_dec[upper],
+                                                numpy.repeat(total_factor, len(idx))])
+
+                dec[bi] = bi_dec
+                ti = numpy.concatenate([fi, bi])
+                for i in trigs.ifos:
+                    ids[i] = ids[i][ti]
+                cstat = cstat[ti]
+                slide = slide[ti]
+                dec = dec[ti]
+
             logging.info('%s after decimation' % len(ti))
 
             # temporary storage for decimated trigger ids
-            decid = {}
-            for ifo in ids:
-                decid[ifo] = ids[ifo][ti]
-            del ids
-
-            for ifo in decid:
-                addtime = times[ifo][decid[ifo]]
-                addtriggerid = tids[ifo][decid[ifo]]
+            for ifo in trigs.ifos:
+                addtime = times[ifo][ids[ifo]]
+                addtriggerid = tids[ifo][ids[ifo]]
                 data['%s/time' % ifo] += [addtime]
                 data['%s/trigger_id' % ifo] += [addtriggerid]
-            data['stat'] += [cstat[ti]]
-            data['decimation_factor'] += [dec_fac]
-            data['timeslide_id'] += [slide[ti]]
-            data['template_id'] += [numpy.repeat(tnum, len(ti))]
+            data['stat'] += [cstat]
+            data['decimation_factor'] += [dec]
+            data['timeslide_id'] += [slide]
+            data['template_id'] += [numpy.repeat(tnum, len(slide))]
 
             start1 += args.batch_singles
         start0 += args.batch_singles

--- a/bin/hdfcoinc/pycbc_multiifo_coinc_findtrigs
+++ b/bin/hdfcoinc/pycbc_multiifo_coinc_findtrigs
@@ -246,7 +246,7 @@ for tnum in template_ids:
             fixed_ifos = [i for i in trigs.ifos if i != args.pivot_ifo]
             fixed_times = {i: times[i] for i in fixed_ifos}
 
-            if len(ifos_nopivot) > 1:
+            if len(fixed_ifos) > 1:
                 fixed_ids, fixed_slide = coinc.time_multi_coincidence(fixed_times, 0.,
                                                                       args.coinc_threshold,
                                                                       fixed_ifos[0],
@@ -260,7 +260,7 @@ for tnum in template_ids:
                 fixed_times = {i: fixed_times[i][fixed_ids[i]] for i in fixed_ifos}
 
             else:
-                det = ifos_nopivot[0]
+                det = fixed_ifos[0]
                 fixed_ids = {det: numpy.arange(len(times[det]))}
                 fixed_single_info = [(i, sds[i]) for i in fixed_ifos]
                 fixed_times = {i: times[i] for i in fixed_ifos}
@@ -363,7 +363,7 @@ for tnum in template_ids:
                 set_ids = {i: set_ids[i][sets] for i in trigs.ifos}
                 set_slide = set_slide[sets]
 
-                above = pivot_s[set_ids[args.pivot_ifo]] >= pivot_lim[kidx][set_ids[fixed_ifos[0]]]
+                above = pivot_s[set_ids[args.pivot_ifo]] >= pivot_lims[kidx][set_ids[fixed_ifos[0]]]
 
                 test_ids = {i: fixed_ids[i][set_ids[i][above]] for i in fixed_ifos}
                 test_ids[args.pivot_ifo] = set_ids[args.pivot_ifo][above] + pivot_cut

--- a/bin/hdfcoinc/pycbc_multiifo_coinc_findtrigs
+++ b/bin/hdfcoinc/pycbc_multiifo_coinc_findtrigs
@@ -173,8 +173,6 @@ for decstr in args.loudest_keep_values:
     # throws an error if 'factor' is not the string representation
     # of an integer
     total_factors.append(total_factors[-1] * int(factor))
-total_factors = numpy.array(total_factors[::-1])
-threshes = numpy.array(threshes[::-1])
 
 for tnum in template_ids:
     times_full = {}
@@ -209,54 +207,116 @@ for tnum in template_ids:
         min_snr = None
         max_sigmasq = None
 
+    try:
+        pivot_stat = sds_full[args.pivot_ifo]['snglstat'].copy()
+        fixed_stat = sds_full[args.fixed_ifo]['snglstat'].copy()
+    except IndexError:
+        pivot_stat = sds_full[args.pivot_ifo].copy()
+        fixed_stat = sds_full[args.fixed_ifo].copy()
+
+    pivot_sort = numpy.argsort(pivot_stat)
+    fixed_sort = numpy.argsort(fixed_stat)
+
+    if not rank_method.single_increasing:
+        pivot_sort = pivot_sort[::-1]
+        fixed_sort = fixed_sort[::-1]
+
     # Loop over the single triggers and calculate the coincs they can form
     start0 = 0
-    while start0 < len(sds_full[args.pivot_ifo]):
+    while start0 < len(sds_full[args.fixed_ifo]):
         start1 = 0
-        while start1 < len(sds_full[args.fixed_ifo]):
-            end0 = start0 + args.batch_singles
+
+        end0 = start0 + args.batch_singles
+        if end0 > len(sds_full[args.fixed_ifo]):
+            end0 = len(sds_full[args.fixed_ifo])
+
+        fixed_idxs = fixed_sort[start0:end0]
+
+        times = times_full.copy()
+        times[args.fixed_ifo] = times_full[args.fixed_ifo][fixed_idxs]
+        
+        sds = sds_full.copy()
+        sds[args.fixed_ifo] = sds_full[args.fixed_ifo][fixed_idxs]
+
+        tids = tids_full.copy()
+        tids[args.fixed_ifo] = tids_full[args.fixed_ifo][fixed_idxs]
+
+        # if decimation is being used precalculate the fixed network coincidences
+        if len(threshes) > 1:
+            fixed_ifos = [i for i in trigs.ifos if i != args.pivot_ifo]
+            fixed_times = {i: times[i] for i in fixed_ifos}
+
+            if len(ifos_nopivot) > 1:
+                fixed_ids, fixed_slide = coinc.time_multi_coincidence(fixed_times, 0.,
+                                                                      args.coinc_threshold,
+                                                                      fixed_ifos[0],
+                                                                      fixed_ifos[1])
+                if len(fixed_slide) == 0:
+                    start0 += args.batch_singles
+                    continue
+
+                # list in ifo order of remaining trigger data
+                fixed_single_info = [(i, sds[i][fixed_ids[i]]) for i in fixed_ifos]
+                fixed_times = {i: fixed_times[i][fixed_ids[i]] for i in fixed_ifos}
+
+            else:
+                det = ifos_nopivot[0]
+                fixed_ids = {det: numpy.arange(len(times[det]))}
+                fixed_single_info = [(i, sds[i]) for i in fixed_ifos]
+                fixed_times = {i: times[i] for i in fixed_ifos}
+
+        pivot_lims = {}
+        pivot_lower = {}
+        for kidx in range(1, len(threshes)):
+            # For each trigger in the fixed network calculate the limit int
+            # the pivot detector to pass the current decimation threshold
+            pivot_lims[kidx] = rank_method.coinc_multiifo_lim_for_thresh(
+                fixed_single_info, threshes[kidx],
+                args.pivot_ifo,
+                time_addition=args.coinc_threshold,
+                min_snr=min_snr,
+                max_sigmasq=max_sigmasq)
+            if not rank_method.single_increasing:
+                pivot_lims[kidx] *= -1.
+            # subtract small amount to account for errors due to rounding
+            pivot_lims[kidx] -= 1e-6
+            # Get the minimum statistic required for all triggers
+            pivot_lower[kidx] = pivot_lims[kidx].min()
+
+
+        while start1 < len(sds_full[args.pivot_ifo]):
             end1 = start1 + args.batch_singles
-            if end0 > len(sds_full[args.pivot_ifo]):
-                end0 = len(sds_full[args.pivot_ifo])
-            if end1 > len(sds_full[args.fixed_ifo]):
-                end1 = len(sds_full[args.fixed_ifo])
+            if end1 > len(sds_full[args.pivot_ifo]):
+                end1 = len(sds_full[args.pivot_ifo])
 
-            times = times_full.copy()
-            times[args.pivot_ifo] = times_full[args.pivot_ifo][start0:end0]
-            times[args.fixed_ifo] = times_full[args.fixed_ifo][start1:end1]
+            pivot_idxs = pivot_sort[start1:end1]
 
-            sds = sds_full.copy()
-            sds[args.pivot_ifo] = sds_full[args.pivot_ifo][start0:end0]
-            sds[args.fixed_ifo] = sds_full[args.fixed_ifo][start1:end1]
+            times[args.pivot_ifo] = times_full[args.pivot_ifo][pivot_idxs]
 
-            tids = tids_full.copy()
-            tids[args.pivot_ifo] = tids_full[args.pivot_ifo][start0:end0]
-            tids[args.fixed_ifo] = tids_full[args.fixed_ifo][start1:end1]
+            sds[args.pivot_ifo] = sds_full[args.pivot_ifo][pivot_idxs]
+
+            tids[args.pivot_ifo] = tids_full[args.pivot_ifo][pivot_idxs]
 
             # Do time coincidence for slides that will be kept after the last decimation
-            logging.info('Starting coinc 0')
             ids, slide = coinc.time_multi_coincidence(times,
-                                                      args.timeslide_interval*total_factors[0],
+                                                      args.timeslide_interval*total_factors[-1],
                                                       args.coinc_threshold,
                                                       args.pivot_ifo,
                                                       args.fixed_ifo)
-            slide *= total_factors[0]
-            logging.info('Finished coinc 0')
+            slide *= total_factors[-1]
 
-            logging.info('Starting cstat 0')
             single_info = [(i, sds[i][ids[i]]) for i in trigs.ifos]
             cstat = rank_method.coinc_multiifo(
                 single_info, slide, args.timeslide_interval,
                 to_shift=trigs.to_shift,
                 time_addition=args.coinc_threshold)
-            logging.info('Finished cstat 0')
 
             #index values of the zerolag triggers
             fi = numpy.where(slide == 0)[0]
 
             #index values of the background triggers
             bi = numpy.where(slide != 0)[0]
-            bl = bi[cstat[bi] < threshes[0]]
+            bl = bi[cstat[bi] < threshes[-1]]
 
             ti = numpy.concatenate([fi, bl])
 
@@ -264,102 +324,64 @@ for tnum in template_ids:
 
             cstat = cstat[ti]
             slide = slide[ti]
-            dec = numpy.concatenate([numpy.ones(len(fi)), numpy.repeat(total_factors[0], len(bl))])
+            dec = numpy.concatenate([numpy.ones(len(fi)), numpy.repeat(total_factors[-1], len(bl))])
 
-            if len(threshes) > 1:
-                ifos_nopivot = [i for i in trigs.ifos if i != args.pivot_ifo]
-                time_nopivot = {i: times[i] for i in ifos_nopivot}
+            try:
+                pivot_stat = sds[args.pivot_ifo]['snglstat'].copy()
+            except IndexError:
+                pivot_stat = sds[args.pivot_ifo].copy()
 
-                if len(ifos_nopivot) > 1:
-                    test_ids, test_slide = coinc.time_multi_coincidence(time_nopivot, 0.,
-                                                                        args.coinc_threshold,
-                                                                        ifos_nopivot[0],
-                                                                        ifos_nopivot[1])
-                    if len(test_slide) == 0:
-                        start1 += args.batch_singles
-                        continue
+            if not rank_method.single_increasing:
+                pivot_stat *= -1.
 
-                    # list in ifo order of remaining trigger data
-                    test_single_info = [(i, sds[i][test_ids[i]]) for i in ifos_nopivot]
-                    test_times = {i: time_nopivot[i][test_ids[i]] for i in ifos_nopivot}
+            tidx = len(threshes) - 1
+            for i in range(1, len(threshes)):
+                if pivot_stat[-1] >= pivot_lower[kidx]:
+                    tidx = i
+                    break
 
-                else:
-                    det = ifos_nopivot[0]
-                    test_ids = {det: numpy.arange(len(times[det]))}
-                    test_single_info = [(i, sds[i]) for i in ifos_nopivot]
-                    test_times = {i: times[i] for i in ifos_nopivot}
+            for kidx in range(tidx, len(threshes)):
 
-                try:
-                    s0stat = sds[args.pivot_ifo]['snglstat'].copy()
-                except IndexError:
-                    s0stat = sds[args.pivot_ifo].copy()
+                pivot_cut = numpy.searchsorted(pivot_stat, pivot_lower[kidx])
 
-                if not rank_method.single_increasing:
-                    s0stat *= -1.
-                s0sort = numpy.argsort(s0stat)
-                s0sorted = s0stat[s0sort]
+                pivot_s = pivot_stat[pivot_cut:]
 
-            for kidx in range(1, len(threshes)):
-                logging.info('Getting single limits {0}'.format(kidx))
-                s0lim = rank_method.coinc_multiifo_lim_for_thresh(
-                    test_single_info, threshes[kidx - 1],
-                    args.pivot_ifo,
-                    time_addition=args.coinc_threshold,
-                    min_snr=min_snr,
-                    max_sigmasq=max_sigmasq)
-                logging.info('Got single limits {0}'.format(kidx))
+                test_times = fixed_times.copy()
+                test_times[args.pivot_ifo] = times[args.pivot_ifo][pivot_cut:]
 
-                if not rank_method.single_increasing:
-                    s0lim *= -1.
-
-                s0min = s0lim.min()
-                s0cut = numpy.searchsorted(s0sorted, s0min)
-
-                test_times[args.pivot_ifo] = times[args.pivot_ifo][s0sort[s0cut:]]
-                test_ids[args.pivot_ifo] = s0sort[s0cut:]
-
-                logging.info('Getting coinc')
                 set_ids, set_slide = coinc.time_multi_coincidence(test_times,
-                                                                  args.timeslide_interval*total_factors[kidx],
+                                                                  args.timeslide_interval*total_factors[kidx - 1],
                                                                   args.coinc_threshold,
                                                                   args.pivot_ifo,
                                                                   args.fixed_ifo)
-                set_slide *= total_factors[kidx]
-                logging.info('Got coinc')
+                set_slide *= total_factors[kidx - 1]
 
                 sets = set_slide != 0
-                for i in range(1, len(ifos_nopivot)):
-                    sets *= set_ids[ifos_nopivot[i-1]] == set_ids[ifos_nopivot[i]]
+                for i in range(1, len(fixed_ifos)):
+                    sets *= set_ids[fixed_ifos[i-1]] == set_ids[fixed_ifos[i]]
 
-                #lim_ids = set_ids[ifos_nopivot[0]][sets]
-                #test_ids = {i: test_ids[i][set_ids[i][sets]] for i in ifos_nopivot}
-                #test_ids[args.pivot_ifo] = set_ids[args.pivot_ifo][sets]
-                #test_slide = set_slide[sets]
                 set_ids = {i: set_ids[i][sets] for i in trigs.ifos}
                 set_slide = set_slide[sets]
 
-                logging.info('finding above {0}'.format(kidx))
-                above = s0sorted[s0cut:][set_ids[args.pivot_ifo]] >= s0lim[set_ids[ifos_nopivot[0]]]
-                logging.info('found above {0}'.format(kidx))
+                above = pivot_s[set_ids[args.pivot_ifo]] >= pivot_lim[kidx][set_ids[fixed_ifos[0]]]
 
-                logging.info('Getting cstat')
-                tmp_ids = {i: test_ids[i][set_ids[i][above]] for i in trigs.ifos}
+                test_ids = {i: fixed_ids[i][set_ids[i][above]] for i in fixed_ifos}
+                test_ids[args.pivot_ifo] = set_ids[args.pivot_ifo][above] + pivot_cut
                 set_slide = set_slide[above]
-                tmp_single_info = [(i, sds[i][tmp_ids[i]]) for i in trigs.ifos]
-                tmp_cstat = rank_method.coinc_multiifo(
-                    tmp_single_info, set_slide, args.timeslide_interval,
+                test_single_info = [(i, sds[i][test_ids[i]]) for i in trigs.ifos]
+                test_cstat = rank_method.coinc_multiifo(
+                    test_single_info, set_slide, args.timeslide_interval,
                     to_shift=trigs.to_shift,
                     time_addition=args.coinc_threshold)
-                logging.info('Got cstat')
 
-                tmp_bi = numpy.where(tmp_cstat >= threshes[kidx - 1])[0]
-                tmp_bi = tmp_bi[tmp_cstat[tmp_bi] < threshes[kidx]]
+                test_bi = numpy.where(test_cstat >= threshes[kidx])[0]
+                test_bi = test_bi[test_cstat[test_bi] < threshes[kidx - 1]]
 
                 for i in trigs.ifos:
-                    ids[i] = numpy.concatenate([ids[i], tmp_ids[i][tmp_bi]])
-                cstat = numpy.concatenate([cstat, tmp_cstat[tmp_bi]])
-                slide = numpy.concatenate([slide, set_slide[tmp_bi]])
-                dec = numpy.concatenate([dec, numpy.repeat(total_factors[kidx], len(tmp_bi))])
+                    ids[i] = numpy.concatenate([ids[i], test_ids[i][test_bi]])
+                cstat = numpy.concatenate([cstat, test_cstat[test_bi]])
+                slide = numpy.concatenate([slide, set_slide[test_bi]])
+                dec = numpy.concatenate([dec, numpy.repeat(total_factors[kidx - 1], len(test_bi))])
 
             # temporary storage for decimated trigger ids
             for ifo in trigs.ifos:

--- a/bin/hdfcoinc/pycbc_multiifo_coinc_findtrigs
+++ b/bin/hdfcoinc/pycbc_multiifo_coinc_findtrigs
@@ -207,6 +207,8 @@ for tnum in template_ids:
         min_snr = None
         max_sigmasq = None
 
+    # Test whether sds_full contains single arrays or record arrays
+    # this depends on the stat being used
     try:
         pivot_stat = sds_full[args.pivot_ifo]['snglstat'].copy()
         fixed_stat = sds_full[args.fixed_ifo]['snglstat'].copy()
@@ -280,9 +282,9 @@ for tnum in template_ids:
                 pivot_lims[kidx] *= -1.
             # subtract small amount to account for errors due to rounding
             pivot_lims[kidx] -= 1e-6
-            # Get the minimum statistic required for all triggers
+            # Get the minimum statistic required for all triggers at the
+            # current decimation threshold
             pivot_lower[kidx] = pivot_lims[kidx].min()
-
 
         while start1 < len(sds_full[args.pivot_ifo]):
             end1 = start1 + args.batch_singles
@@ -334,14 +336,21 @@ for tnum in template_ids:
             if not rank_method.single_increasing:
                 pivot_stat *= -1.
 
+            # Starting from the largest decimation threshold, find the first decimation step
+            # where the loudest single detector trigger in pivot can pass the decimation threshold
+            # with any trigger in the fixed network
             tidx = len(threshes)
             for i in range(1, len(threshes)):
                 if pivot_stat[-1] >= pivot_lower[kidx]:
                     tidx = i
                     break
 
+            # loop through decimation steps starting from the first step where passing
+            # the threshold is possible
             for kidx in range(tidx, len(threshes)):
 
+                # Remove triggers in pivot that cannot form coincidences above
+                # the current decimation threshold
                 pivot_cut = numpy.searchsorted(pivot_stat, pivot_lower[kidx])
 
                 pivot_s = pivot_stat[pivot_cut:]
@@ -349,6 +358,7 @@ for tnum in template_ids:
                 test_times = fixed_times.copy()
                 test_times[args.pivot_ifo] = times[args.pivot_ifo][pivot_cut:]
 
+                # Do time coincidence for the current decimation factor
                 set_ids, set_slide = coinc.time_multi_coincidence(test_times,
                                                                   args.timeslide_interval*total_factors[kidx - 1],
                                                                   args.coinc_threshold,
@@ -356,24 +366,34 @@ for tnum in template_ids:
                                                                   args.fixed_ifo)
                 set_slide *= total_factors[kidx - 1]
 
+                # Remove foreground triggers
                 sets = set_slide != 0
+
+                # Each precalculated coincidence from the fixed network should
+                # be treated like a single trigger, only keep coincidences
+                # where all triggers from the fixed network coincidence are still
+                # together
                 for i in range(1, len(fixed_ifos)):
                     sets *= set_ids[fixed_ifos[i-1]] == set_ids[fixed_ifos[i]]
 
                 set_ids = {i: set_ids[i][sets] for i in trigs.ifos}
                 set_slide = set_slide[sets]
 
+                # Only keep coincidences where pivot has a single stat above the threshold
+                # calculated earlier
                 above = pivot_s[set_ids[args.pivot_ifo]] >= pivot_lims[kidx][set_ids[fixed_ifos[0]]]
 
                 test_ids = {i: fixed_ids[i][set_ids[i][above]] for i in fixed_ifos}
                 test_ids[args.pivot_ifo] = set_ids[args.pivot_ifo][above] + pivot_cut
                 set_slide = set_slide[above]
                 test_single_info = [(i, sds[i][test_ids[i]]) for i in trigs.ifos]
+
                 test_cstat = rank_method.coinc_multiifo(
                     test_single_info, set_slide, args.timeslide_interval,
                     to_shift=trigs.to_shift,
                     time_addition=args.coinc_threshold)
 
+                # Keep triggers in the current decimation range
                 test_bi = numpy.where(test_cstat >= threshes[kidx])[0]
                 test_bi = test_bi[test_cstat[test_bi] < threshes[kidx - 1]]
 

--- a/bin/hdfcoinc/pycbc_multiifo_coinc_findtrigs
+++ b/bin/hdfcoinc/pycbc_multiifo_coinc_findtrigs
@@ -200,7 +200,7 @@ for tnum in template_ids:
         else:
             min_snr = None
         if 'sigmasq'in entries:
-            max_sigmasq = max([numpy.max(sds_full[i]['sigmasq']) for i in trigs.ifos])
+            max_sigmasq = min([numpy.max(sds_full[i]['sigmasq']) for i in trigs.ifos])
         else:
             max_sigmasq = None
     else:

--- a/bin/hdfcoinc/pycbc_multiifo_coinc_findtrigs
+++ b/bin/hdfcoinc/pycbc_multiifo_coinc_findtrigs
@@ -334,7 +334,7 @@ for tnum in template_ids:
             if not rank_method.single_increasing:
                 pivot_stat *= -1.
 
-            tidx = len(threshes) - 1
+            tidx = len(threshes)
             for i in range(1, len(threshes)):
                 if pivot_stat[-1] >= pivot_lower[kidx]:
                     tidx = i

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -64,6 +64,9 @@ class Stat(object):
         # This is used by background estimation codes that need to maintain
         # a buffer of such values.
         self.single_dtype = numpy.float32
+        # True if a larger single detector statistic will produce a larger
+        # coincident statistic
+        self.single_increasing = True
 
         self.ifos = ifos or []
 
@@ -868,6 +871,7 @@ class ExpFitStatistic(NewSNRStatistic):
             self.get_ref_vals(i)
 
         self.get_newsnr = ranking.get_newsnr
+        self.single_increasing = False
 
     def assign_fits(self, ifo):
         coeff_file = self.files[ifo+'-fit_coeffs']
@@ -970,6 +974,7 @@ class ExpFitCombinedSNR(ExpFitStatistic):
         ExpFitStatistic.__init__(self, files=files, ifos=ifos, **kwargs)
         # for low-mass templates the exponential slope alpha \approx 6
         self.alpharef = 6.
+        self.single_increasing = True
 
     def use_alphamax(self):
         # take reference slope as the harmonic mean of individual ifo slopes
@@ -1251,6 +1256,7 @@ class ExpFitSGFgBgRateStatistic(PhaseTDStatistic, ExpFitSGBgRateStatistic):
         hl_net_med_sigma = numpy.amin([self.fits_by_tid[ifo]['median_sigma']
                                        for ifo in ['H1', 'L1']], axis=0)
         self.benchmark_logvol = 3.0 * numpy.log(hl_net_med_sigma)
+        self.single_increasing = False
 
     def assign_median_sigma(self, ifo):
         coeff_file = self.files[ifo + '-fit_coeffs']
@@ -1367,6 +1373,7 @@ class ExpFitSGFgBgNormNewStatistic(PhaseTDNewStatistic,
         hl_net_med_sigma = numpy.amin([self.fits_by_tid[ifo]['median_sigma']
                                        for ifo in ['H1', 'L1']], axis=0)
         self.benchmark_logvol = 3.0 * numpy.log(hl_net_med_sigma)
+        self.single_increasing = False
 
     def assign_median_sigma(self, ifo):
         coeff_file = self.files[ifo + '-fit_coeffs']

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -147,7 +147,8 @@ class NewSNRStatistic(Stat):
         """
         return sum(sngl[1] ** 2. for sngl in s) ** 0.5
 
-    def coinc_multiifo_lim_for_thresh(self, s, thresh):
+    def coinc_multiifo_lim_for_thresh(self, s, thresh,
+                                      limifo, **kwargs): # pylint:disable=unused-argument
         """Calculate the required single detector statistic to exceed thresh.
 
         Parameters

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -965,7 +965,7 @@ class ExpFitStatistic(NewSNRStatistic):
             Array of limits on the second detector single statistic to
         exceed thresh.
         """
-        s1 = - (thresh ** 2.) / 2 - s0
+        s1 = - (thresh ** 2.) / 2. - s0
         threshes = [self.fits_by_tid[i]['thresh'] for i in self.bg_ifos]
         s1 += sum([t**2. / 2. for t in threshes])
         return s1

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -106,6 +106,26 @@ class NewSNRStatistic(Stat):
         """
         return (s0 ** 2. + s1 ** 2.) ** 0.5
 
+    def coinc_lim_for_thresh(self, s0, thresh):
+        """Calculate the required single detector statistic to exceed thresh.
+
+        Parameters
+        ----------
+        s0: numpy.ndarray
+            Single detector ranking statistic for the first detector.
+        thresh: float
+            The threshold of the coincident statistic
+
+        Returns
+        -------
+        numpy.ndarray
+            Array of limits on the second detector single statistic to
+        exceed thresh
+        """
+        s1 = thresh ** 2. - s0 ** 2.
+        s1[s1 < 0] = 0
+        return s1 ** 0.5
+
     def coinc_multiifo(self, s, slide, step, to_shift,
                        **kwargs): # pylint:disable=unused-argument
         """Calculate the coincident detection statistic.
@@ -126,6 +146,26 @@ class NewSNRStatistic(Stat):
             Array of coincident ranking statistic values
         """
         return sum(sngl[1] ** 2. for sngl in s) ** 0.5
+
+    def coinc_multiifo_lim_for_thresh(self, s, thresh):
+        """Calculate the required single detector statistic to exceed thresh.
+
+        Parameters
+        ----------
+        s0: numpy.ndarray
+            Single detector ranking statistic for the first detector.
+        thresh: float
+            The threshold of the coincident statistic
+
+        Returns
+        -------
+        numpy.ndarray
+            Array of limits on the second detector single statistic to
+        exceed thresh
+        """
+        s0 = thresh ** 2. - sum(sngl[1] ** 2. for sngl in s)
+        s0[s0 < 0] = 0
+        return s0 ** 0.5
 
 
 class NewSNRSGStatistic(NewSNRStatistic):
@@ -254,6 +294,28 @@ class NewSNRCutStatistic(NewSNRStatistic):
         cstat[s1 == -1] = 0
         return cstat
 
+    def coinc_lim_for_thresh(self, s0, thresh):
+        """Calculate the required single detector statistic to exceed thresh.
+
+        Parameters
+        ----------
+        s0: numpy.ndarray
+            Single detector ranking statistic for the first detector.
+        thresh: float
+            The threshold of the coincident statistic
+
+        Returns
+        -------
+        numpy.ndarray
+            Array of limits on the second detector single statistic to
+        exceed thresh
+        """
+        s1 = thresh ** 2. - s0 ** 2.
+        s1[s0 == -1] = numpy.inf
+        s1[s1 < 0] = 0
+        return s1 ** 0.5
+
+
 
 class PhaseTDNewStatistic(NewSNRStatistic):
     """Statistic that re-weights combined newsnr using coinc parameters.
@@ -325,6 +387,7 @@ class PhaseTDNewStatistic(NewSNRStatistic):
         self.srbmax = histfile.attrs['srbmax']
 
         bin_volume = (self.twidth * self.pwidth * self.swidth) ** (n_ifos - 1)
+        self.hist_max = - 1. * numpy.inf
 
         # Read histogram for each ifo, to use if that ifo has smallest SNR in
         # the coinc
@@ -358,6 +421,7 @@ class PhaseTDNewStatistic(NewSNRStatistic):
             # histogram entries. All histograms in a given file have the same
             # min entry by design, so use the min of the last one read in.
             self.max_penalty = self.weights[ifo].min()
+            self.hist_max = max(self.hist_max, self.weights[ifo].max())
 
             if self.two_det_flag:
                 # The density of signals is computed as a function of 3 binned
@@ -599,6 +663,7 @@ class PhaseTDStatistic(NewSNRStatistic):
         self.bins['dphi'] = histfile['pbins'][:]
         self.bins['snr'] = histfile['sbins'][:]
         self.bins['sigma_ratio'] = histfile['rbins'][:]
+        self.hist_max = self.hist.max()
 
     def single(self, trigs):
         """Calculate the single detector statistic & assemble other parameters
@@ -722,7 +787,6 @@ class PhaseTDStatistic(NewSNRStatistic):
 
     def coinc(self, s0, s1, slide, step):
         """Calculate the coincident detection statistic.
-
         Parameters
         ----------
         s0: numpy.ndarray
@@ -734,7 +798,6 @@ class PhaseTDStatistic(NewSNRStatistic):
         interval to bring a pair of single detector triggers into coincidence.
         step: float
             The timeslide interval in seconds.
-
         Returns
         -------
         coinc_stat: numpy.ndarray
@@ -744,6 +807,29 @@ class PhaseTDStatistic(NewSNRStatistic):
         cstat = rstat + 2. * self.logsignalrate(s0, s1, slide * step)
         cstat[cstat < 0] = 0
         return cstat ** 0.5
+
+    def coinc_lim_for_thresh(self, s0, thresh):
+        """Calculate the required single detector statistic to exceed thresh.
+
+        Parameters
+        ----------
+        s0: numpy.ndarray
+            Single detector ranking statistic for the first detector.
+        thresh: float
+            The threshold of the coincident statistic
+
+        Returns
+        -------
+        numpy.ndarray
+            Array of limits on the second detector single statistic to
+        exceed thresh
+        """
+        if self.hist is None:
+            self.get_hist()
+        s1 = thresh ** 2. - s0['snglstat'] ** 2.
+        s1 -= 2. * self.hist_max
+        s1[s1 < 0] = 0
+        return s1 ** 0.5
 
 
 class PhaseTDSGStatistic(PhaseTDStatistic):
@@ -851,6 +937,27 @@ class ExpFitStatistic(NewSNRStatistic):
         # via log likelihood ratio \propto rho_c^2 / 2
         return (2. * loglr) ** 0.5
 
+    def coinc_lim_for_thresh(self, s0, thresh):
+        """Calculate the required single detector statistic to exceed thresh.
+
+        Parameters
+        ----------
+        s0: numpy.ndarray
+            Single detector ranking statistic for the first detector.
+        thresh: float
+            The threshold of the coincident statistic
+
+        Returns
+        -------
+        numpy.ndarray
+            Array of limits on the second detector single statistic to
+        exceed thresh
+        """
+        s1 = - (thresh ** 2.) / 2 - s0
+        threshes = [self.fits_by_tid[i]['thresh'] for i in self.bg_ifos]
+        s1 += sum([t**2. / 2. for t in threshes])
+        return s1
+
 
 class ExpFitCombinedSNR(ExpFitStatistic):
     """Reworking of ExpFitStatistic designed to resemble network SNR
@@ -882,10 +989,17 @@ class ExpFitCombinedSNR(ExpFitStatistic):
         # scale by 1/sqrt(2) to resemble network SNR
         return (s0 + s1) / 2.**0.5
 
+    def coinc_lim_for_thresh(self, s0, thresh):
+        return thresh * (2. ** 0.5) - s0
+
     def coinc_multiifo(self, s, slide, step, to_shift,
                        **kwargs): # pylint:disable=unused-argument
         # scale by 1/sqrt(number of ifos) to resemble network SNR
         return sum(sngl[1] for sngl in s) / len(s)**0.5
+
+    def coinc_multiifo_lim_for_thresh(self, s, thresh,
+                                      limifo, **kwargs): # pylint:disable=unused-argument
+        return thresh * ((len(s) + 1) ** 0.5) - sum(sngl[1] for sngl in s)
 
 
 class ExpFitSGCombinedSNR(ExpFitCombinedSNR):
@@ -941,6 +1055,13 @@ class PhaseTDExpFitStatistic(PhaseTDStatistic, ExpFitCombinedSNR):
         # scale to resemble network SNR
         return cstat / (2.**0.5)
 
+    def coinc_lim_for_thresh(self, s0, thresh):
+        if self.hist is None:
+            self.get_hist()
+        logr_s = self.hist_max
+        s1 = (2. ** 0.5) * thresh - s0['snglstat'] - logr_s / self.alpharef
+        return s1
+
 
 class PhaseTDNewExpFitStatistic(PhaseTDNewStatistic, ExpFitCombinedSNR):
     """Statistic combining exponential noise model with signal histogram PDF"""
@@ -965,13 +1086,20 @@ class PhaseTDNewExpFitStatistic(PhaseTDNewStatistic, ExpFitCombinedSNR):
 
     def coinc(self, s0, s1, slide, step):
         # logsignalrate function inherited from PhaseTDStatistic
-        logr_s = self.logsignalrate(s0, s1, slide * step)
+        logr_s = self.hist_max
         # rescale by ExpFitCombinedSNR reference slope as for sngl stat
         cstat = s0['snglstat'] + s1['snglstat'] + logr_s / self.alpharef
         # cut off underflowing and very small values
         cstat[cstat < 8.] = 8.
         # scale to resemble network SNR
         return cstat / (2.**0.5)
+
+    def coinc_lim_for_thresh(self, s0, thresh):
+        if self.hist is None:
+            self.get_hist()
+        logr_s = self.hist_max
+        s1 = (2 ** 0.5) * thresh - s0['snglstat'] - logr_s / self.alpharef
+        return s1
 
 
 class PhaseTDExpFitSGStatistic(PhaseTDExpFitStatistic):
@@ -1088,6 +1216,16 @@ class ExpFitSGBgRateStatistic(ExpFitStatistic):
         loglr = - ln_noise_rate + self.benchmark_lograte
         return loglr
 
+    def coinc_multiifo_lim_for_thresh(self, s, thresh, limifo, **kwargs):
+        # ranking statistic is -ln(expected rate density of noise triggers)
+        # plus normalization constant
+        sngl_dict = {sngl[0]: sngl[1] for sngl in s}
+        sngl_dict[limifo] = np.zeros(len(s[s.keys()[0]]))
+        ln_noise_rate = coinc_rate.combination_noise_lograte(
+                                  sngl_dict, kwargs['time_addition'])
+        loglr = - thresh - ln_noise_rate + self.benchmark_lograte
+        return loglr
+
 
 class ExpFitSGFgBgRateStatistic(PhaseTDStatistic, ExpFitSGBgRateStatistic):
 
@@ -1174,6 +1312,28 @@ class ExpFitSGFgBgRateStatistic(PhaseTDStatistic, ExpFitSGBgRateStatistic):
         loglr = logr_s + network_logvol - ln_noise_rate
         # cut off underflowing and very small values
         loglr[loglr < -30.] = -30.
+        return loglr
+
+    def coinc_multiifo_lim_for_thresh(self, s, thresh, limifo,
+                                      **kwargs): # pylint:disable=unused-argument
+        sngl_rates = {sngl[0]: sngl[1]['snglstat'] for sngl in s}
+        sngl_dict[limifo] = np.zeros(len(s[s.keys()[0]]))
+        ln_noise_rate = coinc_rate.combination_noise_lograte(
+                                  sngl_rates, kwargs['time_addition'])
+        ln_noise_rate -= self.benchmark_lograte
+
+        # Network sensitivity for a given coinc type is approximately
+        # determined by the least sensitive ifo
+        network_sigmasq = np.ones(len(s[s.keys()[0]])) * kwargs['max_sigmasq']
+        # Volume \propto sigma^3 or sigmasq^1.5
+        network_logvol = 1.5 * numpy.log(network_sigmasq)
+        # Get benchmark log volume as single-ifo information
+        # NB benchmark logvol for a given template is not ifo-dependent
+        # - choose the first ifo for convenience
+        benchmark_logvol = s[0][1]['benchmark_logvol']
+        network_logvol -= benchmark_logvol
+
+        loglr = - thresh + self.hist_max + network_logvol - ln_noise_rate
         return loglr
 
 
@@ -1309,6 +1469,54 @@ class ExpFitSGFgBgNormNewStatistic(PhaseTDNewStatistic,
 
         # cut off underflowing and very small values
         loglr[loglr < -30.] = -30.
+        return loglr
+
+    def coinc_multiifo_lim_for_thresh(self, s, thresh, limifo
+                                      **kwargs): # pylint:disable=unused-argument
+        sngl_rates = {sngl[0]: sngl[1]['snglstat'] for sngl in s}
+        sngl_dict[limifo] = np.zeros(len(s[s.keys()[0]]))
+        ln_noise_rate = coinc_rate.combination_noise_lograte(
+                                  sngl_rates, kwargs['time_addition'])
+        ln_noise_rate -= self.benchmark_lograte
+
+        # Network sensitivity for a given coinc type is approximately
+        # determined by the least sensitive ifo
+        network_sigmasq = np.ones(len(s[s.keys()[0]])) * kwargs['max_sigmasq']
+        # Volume \propto sigma^3 or sigmasq^1.5
+        network_logvol = 1.5 * numpy.log(network_sigmasq)
+        # Get benchmark log volume as single-ifo information :
+        # benchmark_logvol for a given template is not ifo-dependent, so
+        # choose the first ifo for convenience
+        benchmark_logvol = s[0][1]['benchmark_logvol']
+        network_logvol -= benchmark_logvol
+
+        # Use prior histogram to get Bayes factor for signal vs noise
+        # given the time, phase and SNR differences between IFOs
+
+        # First get signal PDF logr_s
+        logr_s = numpy.log(self.hist_max() * (kwargs['min_snr'] / self.ref_snr) ** -4.0)
+
+        # Find total volume of phase-time-amplitude space occupied by noise
+        # coincs
+        # Extent of time-difference space occupied
+        noise_twindow = coinc_rate.multiifo_noise_coincident_area(
+                            self.hist_ifos, kwargs['time_addition'])
+        # Volume is the allowed time difference window, multiplied by 2pi for
+        # each phase difference dimension and by allowed range of SNR ratio
+        # for each SNR ratio dimension : there are (n_ifos - 1) dimensions
+        # for both phase and SNR
+        n_ifos = len(self.hist_ifos)
+        hist_vol = noise_twindow * \
+            (2 * numpy.pi * (self.srbmax - self.srbmin) * self.swidth) ** \
+            (n_ifos - 1)
+        # Noise PDF is 1/volume, assuming a uniform distribution of noise
+        # coincs
+        logr_n = - numpy.log(hist_vol)
+
+        # Combine to get final statistic: log of
+        # ((rate of signals / rate of noise) * PTA Bayes factor)
+        loglr = - thresh + network_logvol - ln_noise_rate + logr_s - logr_n
+
         return loglr
 
 


### PR DESCRIPTION
While running a search for lensed images we searched all of O2 with a single template using a single detector threshold of SNR=4. This produced roughly 1,000,000 single detector triggers in each detector with the single template.
This means that there were roughly 1,000,000,000,000 coincident triggers in the background to be tested. This obviously takes a long time.

However, when decimation is included we don't need the coincident statistics for most of these as they are removed by decimation. This script can be made more efficient by not calculating a lot of these.

To avoid calculating a lot of these discarded values we can:

1) Find all foreground coincidences and the background for timeslides that will always be kept after decimation.

2) Only keep the foreground triggers and the background that is below the decimation threshold.

3) Take all the single detector triggers in the first detector and calculate the minimum/maximum (depending on the ranking statistic) single detector statistic required in the second detector to pass the decimation threshold.

4) Find the list of all the coincident triggers between the two detectors.

5) Make a list of coincident triggers where the single detector statistic from the second detector passes the maximum/minimum calculated earlier.

6) Only calculate the coincident statistic for the triggers in this list.

7) Keep all background triggers above the decimation threshold.

To extend this to multiple decimation cuts you can loop through steps 3 to 7 starting with the smallest threshold and highest decimation factor.
In step 4 only find coincidences in timeslides that will only keep triggers with coincident statistics above threshold n and below threshold n+1
Then in step 7 only keep triggers that are above threshold n and below threshold n+1

bin/hdfcoinc/pycbc_coinc_findtrigs has been changed to implement this method

bin/hdfcoinc/pycbc_multiifo_coinc_findtrigs has a couple addition changes to deal with 3+ detectors:
After step 2 above find coincidences between all but the pivot ifo with 0 timeslides.
Use the list of coincidences produced by this to find the maximum/minimum statistic needed in the pivot ifo to pass the decimation threshold.

You can then continue in the same way as before but treating these sets of triggers in all the non-pivot detectors like a single trigger.

To calculate the maximum/minimum required single detector statistic methods have been added to pycbc/events/stat.py

coinc_lim_for_thresh
This takes an array of single detector triggers from one detector and a threshold. It then returns the maximum/minimum statistic required in the second detector to pass the threshold.

coinc_multiifo_lim_for_thresh
This takes a list of single detector triggers from multiple ifos (in the same format as coinc_multiifo), a threshold, and the name of the ifo that you want to find the limit for. It then returns the maximum/minimum statistic required in the named detector to pass the threshold.

An attribute "single_increasing" has also been added that is True if a larger single detector statistic produces a larger coincident statistic, and False otherwise. This is convenient for knowing if the limit you get from the previous methods is a maximum or minimum.

So far this has produced the same results as the old scripts when tested, but I need to test for all the different statistics and test for any edge cases that might of been missed.

Also need to be cleaned up/commented properly.