### PR TITLE
Write checkpoint history

### DIFF
--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -158,6 +158,10 @@ if not opts.save_backup:
     logging.info("Deleting backup file")
     os.remove(sampler.backup_file)
 
+# write the end time
+with sampler.io(opts.output_file, 'a') as fp:
+    fp.write_run_end_time()
+
 if condor_ckpt:
    # create an empty checkpoint file
    open(sampler.checkpoint_file, 'a').close()

--- a/pycbc/inference/io/base_hdf.py
+++ b/pycbc/inference/io/base_hdf.py
@@ -807,19 +807,12 @@ class BaseInferenceFile(h5py.File):
         # exist yet, create a dataset that is resizable along the last
         # dimension
         elif append:
-            # get the data type, in case we have to create a new dataset
-            try:
-                # this assumes data is a numpy array
-                dtype = data.dtype
-            except AttributeError:
-                # assume atomic type
-                dtype = type(data)
-            try:
-                # this assumes data is a numpy array
-                dshape = data.shape
-            except AttributeError:
-                # assume atomic type (i.e., data is a single value)
-                dshape = (1,)
+            # cast the data to an array if it isn't already one
+            if isinstance(data, (list, tuple)):
+                data = numpy.array(data)
+            if not isinstance(data, numpy.ndarray):
+                data = numpy.array([data])
+            dshape = data.shape
             ndata = dshape[-1]
             try:
                 startidx = group[name].shape[-1]
@@ -829,7 +822,7 @@ class BaseInferenceFile(h5py.File):
                 # dataset doesn't exist yet
                 group.create_dataset(name, dshape,
                                      maxshape=tuple(list(dshape)[:-1]+[None]),
-                                     dtype=dtype, fletcher32=True)
+                                     dtype=data.dtype, fletcher32=True)
                 startidx = 0
             group[name][..., startidx:startidx+ndata] = data[..., :]
         else:

--- a/pycbc/inference/io/base_mcmc.py
+++ b/pycbc/inference/io/base_mcmc.py
@@ -351,13 +351,24 @@ class CommonMCMCMetadataIO(object):
                         path=path, append=True)
         # write the act: we'll make sure that this is 2D, so that the acts
         # can be appened along the last dimension
-        act = self.act
-        act = act.reshape(tuple(list(act.shape)+[1]))
-        self.write_data('act', act, path=path, append=True)
+        try:
+            act = self.act
+        except ValueError:
+            # no acts were calculate
+            act = None
+        if act is not None:
+            act = act.reshape(tuple(list(act.shape)+[1]))
+            self.write_data('act', act, path=path, append=True)
         # write the burn in iteration in the same way
-        burn_in = self.burn_in_iteration
-        burn_in = burn_in.reshape(tuple(list(burn_in.shape)+[1]))
-        self.write_data('burn_in_iteration', burn_in, path=path, append=True)
+        try:
+            burn_in = self.burn_in_iteration
+        except ValueError:
+            # no burn in tests were done
+            burn_in = None
+        if burn_in is not None:
+            burn_in = burn_in.reshape(tuple(list(burn_in.shape)+[1]))
+            self.write_data('burn_in_iteration', burn_in, path=path,
+                            append=True)
 
     @staticmethod
     def extra_args_parser(parser=None, skip_args=None, **kwargs):

--- a/pycbc/inference/io/base_mcmc.py
+++ b/pycbc/inference/io/base_mcmc.py
@@ -352,11 +352,11 @@ class CommonMCMCMetadataIO(object):
         # write the act: we'll make sure that this is 2D, so that the acts
         # can be appened along the last dimension
         act = self.act
-        act = self.reshape(tuple(list(act.shape)+[1]))
+        act = act.reshape(tuple(list(act.shape)+[1]))
         self.write_data('act', act, path=path, append=True)
         # write the burn in iteration in the same way
         burn_in = self.burn_in_iteration
-        burn_in = self.reshape(tuple(list(burn_in.shape)+[1]))
+        burn_in = burn_in.reshape(tuple(list(burn_in.shape)+[1]))
         self.write_data('burn_in_iteration', burn_in, path=path, append=True)
 
     @staticmethod

--- a/pycbc/inference/io/base_mcmc.py
+++ b/pycbc/inference/io/base_mcmc.py
@@ -339,6 +339,26 @@ class CommonMCMCMetadataIO(object):
         """
         self.raw_acts = {p: acls[p] * self.thinned_by for p in acls}
 
+    def _update_sampler_history(self):
+        """Writes the number of iterations, effective number of samples,
+        autocorrelation times, and burn-in iteration to the history.
+        """
+        path = '/'.join([self.sampler_group, 'checkpoint_history'])
+        # write the current number of iterations
+        self.write_data('niterations', self.niterations, path=path,
+                        append=True)
+        self.write_data('effective_nsamples', self.effective_nsamples,
+                        path=path, append=True)
+        # write the act: we'll make sure that this is 2D, so that the acts
+        # can be appened along the last dimension
+        act = self.act
+        act = self.reshape(tuple(list(act.shape)+[1]))
+        self.write_data('act', act, path=path, append=True)
+        # write the burn in iteration in the same way
+        burn_in = self.burn_in_iteration
+        burn_in = self.reshape(tuple(list(burn_in.shape)+[1]))
+        self.write_data('burn_in_iteration', burn_in, path=path, append=True)
+
     @staticmethod
     def extra_args_parser(parser=None, skip_args=None, **kwargs):
         """Create a parser to parse sampler-specific arguments for loading

--- a/pycbc/inference/io/base_sampler.py
+++ b/pycbc/inference/io/base_sampler.py
@@ -56,6 +56,17 @@ class BaseSamplerFile(BaseInferenceFile):
         """
         return self.attrs['run_start_time'][-1]
 
+    def write_run_end_time(self):
+        """"Writes the curent (UNIX) time as the ``run_end_time`` attribute.
+        """
+        self.attrs["run_end_time"] = time.time()
+
+    @property
+    def run_end_time(self):
+        """The (UNIX) time pycbc inference finished.
+        """
+        return self.attrs["run_end_time"]
+
     @abstractmethod
     def write_resume_point(self):
         """Should write the point that a sampler starts up.

--- a/pycbc/inference/io/base_sampler.py
+++ b/pycbc/inference/io/base_sampler.py
@@ -17,6 +17,7 @@
 
 from __future__ import absolute_import
 
+import time
 from abc import (ABCMeta, abstractmethod)
 
 from six import add_metaclass
@@ -31,6 +32,21 @@ class BaseSamplerFile(BaseInferenceFile):
     This adds abstract methods ``write_resume_point`` and
     ``write_sampler_metadata`` to :py:class:`BaseInferenceFile`.
     """
+    def write_run_start_time(self):
+        """Writes the current (UNIX) time to the file.
+
+        Times are stored as a list in the file's ``attrs``, with name
+        ``run_start_time``. If the attrbute already exists, the current time
+        is appended. Otherwise, the attribute will be created and time added.
+        """
+        attrname = "run_start_time"
+        try:
+            times = self.attrs[attrname].tolist()
+        except KeyError:
+            times = []
+        times.append(time.time())
+        self.attrs[attrname] = times
+
     @abstractmethod
     def write_resume_point(self):
         """Should write the point that a sampler starts up.

--- a/pycbc/inference/io/base_sampler.py
+++ b/pycbc/inference/io/base_sampler.py
@@ -47,6 +47,15 @@ class BaseSamplerFile(BaseInferenceFile):
         times.append(time.time())
         self.attrs[attrname] = times
 
+    @property
+    def run_start_time(self):
+        """The (UNIX) time pycbc inference began running.
+
+        If the run resumed from a checkpoint, the time the last checkpoint
+        started is reported.
+        """
+        return self.attrs['run_start_time'][-1]
+
     @abstractmethod
     def write_resume_point(self):
         """Should write the point that a sampler starts up.
@@ -62,6 +71,53 @@ class BaseSamplerFile(BaseInferenceFile):
         """This should write the given sampler's metadata to the file.
 
         This should also include the model's metadata.
+        """
+        pass
+
+    def update_checkpoint_history(self):
+        """Writes a copy of relevant metadata to the file's checkpoint history.
+
+        All data are written to ``sampler_info/checkpoint_history``. If the
+        group does not exist yet, it will be created.
+
+        This function writes the current time and the time since the last
+        checkpoint to the file. It will also call
+        :py:func:`_update_sampler_history` to write sampler-specific history.
+        """
+        path = '/'.join([self.sampler_group, 'checkpoint_history'])
+        try:
+            history = self[path]
+        except KeyError:
+            # assume history doesn't exist yet
+            self.create_group(path)
+            history = self[path]
+        # write the checkpoint time
+        current_time = time.time()
+        self.write_data('checkpoint_time', current_time, path=path,
+                        append=True)
+        # get the amount of time since the last checkpoint
+        checkpoint_times = history['checkpoint_time'][()]
+        if len(checkpoint_times) == 1:
+            # this is the first checkpoint, get the run time for comparison
+            lasttime = self.run_start_time
+        else:
+            lasttime = checkpoint_times[-2]
+            # if a resume happened since the last checkpoint, use the resume
+            # time instad
+            if lasttime < self.run_start_time:
+                lasttime = self.run_start_time
+        self.write_data('checkpoint_dt', lasttime, path=path, append=True)
+        # TODO: write the dt per core (requires adding a nprocesses attribute
+        # to the base sampler and base sampler file)
+        # write any sampler-specific history
+        self._update_sampler_history()
+
+    def _update_sampler_history(self):
+        """Writes sampler-specific history to the file.
+
+        This function does nothing. Classes that inherit from it may override
+        it to add any extra information they would like written. This is
+        called by :py:func:`update_checkpoint_history`.
         """
         pass
 

--- a/pycbc/inference/io/base_sampler.py
+++ b/pycbc/inference/io/base_sampler.py
@@ -106,9 +106,8 @@ class BaseSamplerFile(BaseInferenceFile):
             # time instad
             if lasttime < self.run_start_time:
                 lasttime = self.run_start_time
-        self.write_data('checkpoint_dt', lasttime, path=path, append=True)
-        # TODO: write the dt per core (requires adding a nprocesses attribute
-        # to the base sampler and base sampler file)
+        self.write_data('checkpoint_dt', current_time-lasttime, path=path,
+                        append=True)
         # write any sampler-specific history
         self._update_sampler_history()
 

--- a/pycbc/inference/sampler/base.py
+++ b/pycbc/inference/sampler/base.py
@@ -191,6 +191,7 @@ def setup_output(sampler, output_file):
         with sampler.io(fn, "a") as fp:
             fp.write_command_line()
             fp.write_resume_point()
+            fp.write_run_start_time()
     # store
     sampler.checkpoint_file = checkpoint_file
     sampler.backup_file = backup_file

--- a/pycbc/inference/sampler/base_mcmc.py
+++ b/pycbc/inference/sampler/base_mcmc.py
@@ -607,6 +607,10 @@ class BaseMCMC(object):
                         fp.acl = self.acl
                     # write effective number of samples
                     fp.write_effective_nsamples(self.effective_nsamples)
+        # write history
+        for fn in [self.checkpoint_file, self.backup_file]:
+            with self.io(fn, "a") as fp:
+                fp.update_checkpoint_history()
         # check validity
         logging.info("Validating checkpoint and backup files")
         checkpoint_valid = validate_checkpoint_files(


### PR DESCRIPTION
This makes it so that some history is preserved in the inference checkpoint file on each checkpoint. Right now, only the MCMC samplers make use of this, but nested samplers could pick up the functionality later. This can be used for comparing performance between samplers, and to diagnose issues (like growing ACTs).

On each checkpoint, `update_checkpoint_history` is called. This is a method of `BaseSamplerFile`. It writes the current time and the time since the last checkpoint or last startup (which ever happened last). It then calls `_update_sampler_history`. This doesn't do anything in `BaseSamplerFile`, but can be overridden to write-sampler specific things. This is overriden by `CommonMCMCMetadataIO` to write the number of iterations, effective number of samples, burn-in iteration, and autocorrelation time. In the future, nested samplers could do something similar (e.g., writing the current dlogz). All information is written to `samlper_info/checkpoint_history/`.

To make this work, the ability to append data has been added to `BaseInferenceFile.write_data`. I also had to add the time that pycbc inference starts up, so that the time since the last checkpoint could be accurately computed. This is stored as `run_start_time` in the file's `attrs`. For completeness, I also added a `run_end_time`, which is written by `pycbc_inference` just before exiting.

I tested using the single template example in the docs, on emcee pt and epsie.

In another PR, I'll add an executable to plot the checkpoint history.