### PR TITLE
Sieve times when frame reading

### DIFF
--- a/pycbc/frame/frame.py
+++ b/pycbc/frame/frame.py
@@ -193,6 +193,9 @@ def read_frame(location, channels, start_time=None,
         logging.info("Using frames that match regexp: %s", sieve)
         lal.CacheSieve(cum_cache, 0, 0, None, None, sieve)
     if start_time is not None and end_time is not None:
+        # Before sieving, check if this is sane. Otherwise it will fail later.
+        if (int(math.ceil(end_time)) - int(start_time)) <= 0:
+            raise ValueError("Negative or null duration")
         lal.CacheSieve(cum_cache, int(start_time), int(math.ceil(end_time)),
                        None, None, None)
 

--- a/pycbc/frame/frame.py
+++ b/pycbc/frame/frame.py
@@ -192,8 +192,8 @@ def read_frame(location, channels, start_time=None,
         logging.info("Using frames that match regexp: %s", sieve)
         lal.CacheSieve(cum_cache, 0, 0, None, None, sieve)
     if start_time is not None and end_time is not None:
-        lal.CacheSieve(cum_cache, lal.LIGOTimeGPS(start_time),
-                       lal.LIGOTimeGPS(end_time), None, None, None)
+        lal.CacheSieve(cum_cache, int(start_time), int(end_time),
+                       None, None, None)
 
     stream = lalframe.FrStreamCacheOpen(cum_cache)
     stream.mode = lalframe.FR_STREAM_VERBOSE_MODE

--- a/pycbc/frame/frame.py
+++ b/pycbc/frame/frame.py
@@ -20,6 +20,7 @@ This modules contains functions for reading in data from frame files or caches
 import lalframe, logging
 import lal
 import numpy
+import math
 import os.path, glob, time
 import gwdatafind
 from six.moves.urllib.parse import urlparse
@@ -192,7 +193,7 @@ def read_frame(location, channels, start_time=None,
         logging.info("Using frames that match regexp: %s", sieve)
         lal.CacheSieve(cum_cache, 0, 0, None, None, sieve)
     if start_time is not None and end_time is not None:
-        lal.CacheSieve(cum_cache, int(start_time), int(end_time),
+        lal.CacheSieve(cum_cache, int(start_time), int(math.ceil(end_time)),
                        None, None, None)
 
     stream = lalframe.FrStreamCacheOpen(cum_cache)

--- a/pycbc/frame/frame.py
+++ b/pycbc/frame/frame.py
@@ -191,6 +191,9 @@ def read_frame(location, channels, start_time=None,
     if sieve:
         logging.info("Using frames that match regexp: %s", sieve)
         lal.CacheSieve(cum_cache, 0, 0, None, None, sieve)
+    if start_time is not None and end_time is not None:
+        lal.CacheSieve(cum_cache, lal.LIGOTimeGPS(start_time),
+                       lal.LIGOTimeGPS(end_time), None, None, None)
 
     stream = lalframe.FrStreamCacheOpen(cum_cache)
     stream.mode = lalframe.FR_STREAM_VERBOSE_MODE


### PR DESCRIPTION
If dealing with a *lot* of frame files, but only reading a short amount of time, it makes sense to sieve the LALCache down before trying to read anything.

... This also helps if the frame-type changes as otherwise the code fails because the channel in some random earlier file doesn't match, even though you don't want to read that file at all!