### PR TITLE
Add duration support for Phenom HM waveforms

### DIFF
--- a/pycbc/waveform/waveform.py
+++ b/pycbc/waveform/waveform.py
@@ -801,6 +801,18 @@ def imrphenomd_length_in_time(**kwds):
     """
     return get_imr_length("IMRPhenomD", **kwds)
 
+def imrphenomhm_length_in_time(**kwargs):
+    """Estimates the duration of IMRPhenom waveforms that include higher modes.
+    """
+    if 'mode_array' in kwargs and kwargs['mode_array'] is not None:
+        maxm = max(m for _, m in kwargs['mode_array'])
+    else:
+        # the highest m for all of these is 4 (from the 4,4 mode)
+        maxm = 4
+    # we'll use the PhenomD length, then scale it by maxm / 2
+    dur = get_imr_length("IMRPhenomD", **kwargs)
+    return dur * maxm/2.
+
 _filter_norms["SPAtmplt"] = spa_tmplt_norm
 _filter_preconditions["SPAtmplt"] = spa_tmplt_precondition
 
@@ -832,8 +844,10 @@ _filter_time_lengths["IMRPhenomD"] = imrphenomd_length_in_time
 _filter_time_lengths["IMRPhenomPv2"] = imrphenomd_length_in_time
 _filter_time_lengths["IMRPhenomD_NRTidal"] = imrphenomd_length_in_time
 _filter_time_lengths["IMRPhenomPv2_NRTidal"] = imrphenomd_length_in_time
-_filter_time_lengths["IMRPhenomHM"] = imrphenomd_length_in_time
-_filter_time_lengths["IMRPhenomPv3HM"] = imrphenomd_length_in_time
+_filter_time_lengths["IMRPhenomHM"] = imrphenomhm_length_in_time
+_filter_time_lengths["IMRPhenomPv3HM"] = imrphenomhm_length_in_time
+_filter_time_lengths["IMRPhenomXHM"] = imrphenomhm_length_in_time
+_filter_time_lengths["IMRPhenomXPHM"] = imrphenomhm_length_in_time
 _filter_time_lengths["SpinTaylorF2"] = spa_length_in_time
 _filter_time_lengths["TaylorF2NL"] = spa_length_in_time
 _filter_time_lengths["PreTaylorF2"] = spa_length_in_time

--- a/pycbc/waveform/waveform.py
+++ b/pycbc/waveform/waveform.py
@@ -809,9 +809,13 @@ def imrphenomhm_length_in_time(**kwargs):
     else:
         # the highest m for all of these is 4 (from the 4,4 mode)
         maxm = 4
-    # we'll use the PhenomD length, then scale it by maxm / 2
-    dur = get_imr_length("IMRPhenomD", **kwargs)
-    return dur * maxm/2.
+    # we'll use the PhenomD length, with the frequency scaled by 2/m
+    try:
+        flow = kwargs['f_lower']
+    except KeyError:
+        raise ValueError("must provide a f_lower")
+    kwargs['f_lower'] = flow * 2./maxm
+    return get_imr_length("IMRPhenomD", **kwargs)
 
 _filter_norms["SPAtmplt"] = spa_tmplt_norm
 _filter_preconditions["SPAtmplt"] = spa_tmplt_precondition


### PR DESCRIPTION
Adds a function `imrphenomhm_length_in_time` to `waveform.py` that estimates the duration of Phenom waveforms that include sub-dominant harmonics. The estimate is calculated by multiplying the PhenomD estimate by max m/2, where max m is the largest m in the requested modes. If no modes are provided, it uses max m = 4, since (according to their papers), the highest m mode is the (4,4). This also updates the dictionary of filter length functions to have point to this function, so that `get_waveform_filter_length_in_time` will use it.

This also means that the calling `get_td_waveform` will now default to calling our internal `get_td_waveform_from_fd`, which avoids the lalsimulation issue of truncating higher modes too soon.