### PR TITLE
add checkpointing for Dynesty

### DIFF
--- a/pycbc/inference/io/__init__.py
+++ b/pycbc/inference/io/__init__.py
@@ -167,29 +167,23 @@ def check_integrity(filename):
     # if the file is corrupted such that it cannot be opened, the next line
     # will raise an IOError
     with loadfile(filename, 'r') as fp:
-        if fp.name == 'dynesty_file':
-            try:
-                load_state(fp, path='sampler_info/saved_state')
-            except IOError:
-                raise IOError("Could not recover pickled state")
-        else:
-            # check that all datasets in samples have the same shape
-            parameters = list(fp[fp.samples_group].keys())
-            # but only do the check if parameters have been written
-            if len(parameters) > 0:
-                group = fp.samples_group + '/{}'
-                # use the first parameter as a reference shape
-                ref_shape = fp[group.format(parameters[0])].shape
-                if not all(fp[group.format(param)].shape == ref_shape
-                           for param in parameters):
-                    raise IOError("not all datasets in the samples group have "
-                                  "the same shape")
+        # check that all datasets in samples have the same shape
+        parameters = list(fp[fp.samples_group].keys())
+        # but only do the check if parameters have been written
+        if len(parameters) > 0:
+            group = fp.samples_group + '/{}'
+            # use the first parameter as a reference shape
+            ref_shape = fp[group.format(parameters[0])].shape
+            if not all(fp[group.format(param)].shape == ref_shape
+                       for param in parameters):
+                raise IOError("not all datasets in the samples group have "
+                              "the same shape")
             # check that we can read the first/last sample
             firstidx = tuple([0]*len(ref_shape))
             lastidx = tuple([-1]*len(ref_shape))
-            for param in parameters:
-                _ = fp[group.format(param)][firstidx]
-                _ = fp[group.format(param)][lastidx]
+        for param in parameters:
+            _ = fp[group.format(param)][firstidx]
+            _ = fp[group.format(param)][lastidx]
 
 
 def validate_checkpoint_files(checkpoint_file, backup_file,
@@ -230,12 +224,14 @@ def validate_checkpoint_files(checkpoint_file, backup_file,
         checkpoint_valid = True
     except (ValueError, KeyError, IOError):
         checkpoint_valid = False
+
     # backup file
     try:
         check_integrity(backup_file)
         backup_valid = True
     except (ValueError, KeyError, IOError):
         backup_valid = False
+
     # since we can open the file, run self diagnostics
     if checkpoint_valid:
         with loadfile(checkpoint_file, 'r') as fp:

--- a/pycbc/inference/io/__init__.py
+++ b/pycbc/inference/io/__init__.py
@@ -29,6 +29,7 @@ import logging
 import h5py as _h5py
 from pycbc.io.record import (FieldArray, _numpy_function_lib)
 from pycbc import waveform as _waveform
+from pycbc.io.hdf import (dump_state, load_state)
 
 from pycbc.inference.option_utils import (ParseLabelArg, ParseParametersArg)
 from .emcee import EmceeFile
@@ -166,17 +167,23 @@ def check_integrity(filename):
     # if the file is corrupted such that it cannot be opened, the next line
     # will raise an IOError
     with loadfile(filename, 'r') as fp:
-        # check that all datasets in samples have the same shape
-        parameters = list(fp[fp.samples_group].keys())
-        # but only do the check if parameters have been written
-        if len(parameters) > 0:
-            group = fp.samples_group + '/{}'
-            # use the first parameter as a reference shape
-            ref_shape = fp[group.format(parameters[0])].shape
-            if not all(fp[group.format(param)].shape == ref_shape
-                       for param in parameters):
-                raise IOError("not all datasets in the samples group have the "
-                              "same shape")
+        if fp.name == 'dynesty_file':
+            try:
+                load_state(fp, path='sampler_info/saved_state')
+            except IOError:
+                raise IOError("Could not recover pickled state")
+        else:
+            # check that all datasets in samples have the same shape
+            parameters = list(fp[fp.samples_group].keys())
+            # but only do the check if parameters have been written
+            if len(parameters) > 0:
+                group = fp.samples_group + '/{}'
+                # use the first parameter as a reference shape
+                ref_shape = fp[group.format(parameters[0])].shape
+                if not all(fp[group.format(param)].shape == ref_shape
+                           for param in parameters):
+                    raise IOError("not all datasets in the samples group have "
+                                  "the same shape")
             # check that we can read the first/last sample
             firstidx = tuple([0]*len(ref_shape))
             lastidx = tuple([-1]*len(ref_shape))
@@ -185,7 +192,8 @@ def check_integrity(filename):
                 _ = fp[group.format(param)][lastidx]
 
 
-def validate_checkpoint_files(checkpoint_file, backup_file):
+def validate_checkpoint_files(checkpoint_file, backup_file,
+                              check_nsamples=True):
     """Checks if the given checkpoint and/or backup files are valid.
 
     The checkpoint file is considered valid if:
@@ -235,17 +243,19 @@ def validate_checkpoint_files(checkpoint_file, backup_file):
     if backup_valid:
         with loadfile(backup_file, 'r') as fp:
             backup_valid = fp.validate()
-    # check that the checkpoint and backup have the same number of samples;
-    # if not, assume the checkpoint has the correct number
-    if checkpoint_valid and backup_valid:
-        with loadfile(checkpoint_file, 'r') as fp:
-            group = list(fp[fp.samples_group].keys())[0]
-            nsamples = fp[fp.samples_group][group].size
-        with loadfile(backup_file, 'r') as fp:
-            group = list(fp[fp.samples_group].keys())[0]
-            backup_nsamples = fp[fp.samples_group][group].size
-        backup_valid = nsamples == backup_nsamples
-    # decide what to do based on the files' statuses
+    if check_nsamples:
+        # This check is not required by nested samplers
+        # check that the checkpoint and backup have the same number of samples;
+        # if not, assume the checkpoint has the correct number
+        if checkpoint_valid and backup_valid:
+            with loadfile(checkpoint_file, 'r') as fp:
+                group = list(fp[fp.samples_group].keys())[0]
+                nsamples = fp[fp.samples_group][group].size
+            with loadfile(backup_file, 'r') as fp:
+                group = list(fp[fp.samples_group].keys())[0]
+                backup_nsamples = fp[fp.samples_group][group].size
+            backup_valid = nsamples == backup_nsamples
+        # decide what to do based on the files' statuses
     if checkpoint_valid and not backup_valid:
         # copy the checkpoint to the backup
         logging.info("Backup invalid; copying checkpoint file")

--- a/pycbc/inference/io/dynesty.py
+++ b/pycbc/inference/io/dynesty.py
@@ -31,12 +31,12 @@ class DynestyFile(BaseNestedSamplerFile):
 
     name = 'dynesty_file'
 
-    def write_pickled_data_into_checkpoint_file(self, pickle_obj):
+    def write_pickled_data_into_checkpoint_file(self, state):
         """Dump the sampler state into checkpoint file
         """
-        self.clear()
-        self.create_group('sampler_info/saved_state')
-        dump_state(pickle_obj, self, path='sampler_info/saved_state')
+        if 'sampler_info/saved_state' not in self:
+            self.create_group('sampler_info/saved_state')
+        dump_state(state, self, path='sampler_info/saved_state')
 
     def read_pickled_data_from_checkpoint_file(self):
         """Load the sampler state (pickled) from checkpoint file
@@ -53,7 +53,8 @@ class DynestyFile(BaseNestedSamplerFile):
             Whether or not the file is valid as a checkpoint file.
         """
         try:
-            load_state(self, path='sampler_info/saved_state')
+            if 'sampler_info/saved_state' in self:
+                load_state(self, path='sampler_info/saved_state')
             checkpoint_valid = True
         except KeyError:
             checkpoint_valid = False

--- a/pycbc/inference/io/dynesty.py
+++ b/pycbc/inference/io/dynesty.py
@@ -23,9 +23,38 @@
 #
 """Provides IO for the dynesty sampler.
 """
+from pycbc.io.hdf import (dump_state, load_state)
 from .base_nested_sampler import BaseNestedSamplerFile
 
 class DynestyFile(BaseNestedSamplerFile):
     """Class to handle file IO for the ``dynesty`` sampler."""
 
     name = 'dynesty_file'
+
+    def write_pickled_data_into_checkpoint_file(self, pickle_obj):
+        """Dump the sampler state into checkpoint file
+        """
+        self.clear()
+        self.create_group('sampler_info/saved_state')
+        dump_state(pickle_obj, self, path='sampler_info/saved_state')
+
+    def read_pickled_data_from_checkpoint_file(self):
+        """Load the sampler state (pickled) from checkpoint file
+        """
+        return load_state(self, path='sampler_info/saved_state')
+
+    def validate(self):
+        """Runs a validation test.
+           This checks that a samples group exist, and that pickeled data can
+           be loaded.
+        Returns
+        -------
+        bool :
+            Whether or not the file is valid as a checkpoint file.
+        """
+        try:
+            load_state(self, path='sampler_info/saved_state')
+            checkpoint_valid = True
+        except KeyError:
+            checkpoint_valid = False
+        return checkpoint_valid

--- a/pycbc/inference/sampler/base.py
+++ b/pycbc/inference/sampler/base.py
@@ -155,7 +155,7 @@ class BaseSampler(object):
 #
 
 
-def setup_output(sampler, output_file):
+def setup_output(sampler, output_file,check_nsamples=True):
     r"""Sets up the sampler's checkpoint and output files.
 
     The checkpoint file has the same name as the output file, but with
@@ -175,7 +175,8 @@ def setup_output(sampler, output_file):
     # check if we have a good checkpoint and/or backup file
     logging.info("Looking for checkpoint file")
     checkpoint_valid = validate_checkpoint_files(checkpoint_file,
-                                                 backup_file)
+                                                 backup_file,
+                                                 check_nsamples)
     # Create a new file if the checkpoint doesn't exist, or if it is
     # corrupted
     sampler.new_checkpoint = False  # keeps track if this is a new file or not

--- a/pycbc/inference/sampler/base.py
+++ b/pycbc/inference/sampler/base.py
@@ -155,7 +155,7 @@ class BaseSampler(object):
 #
 
 
-def setup_output(sampler, output_file,check_nsamples=True):
+def setup_output(sampler, output_file, check_nsamples=True):
     r"""Sets up the sampler's checkpoint and output files.
 
     The checkpoint file has the same name as the output file, but with

--- a/pycbc/inference/sampler/base.py
+++ b/pycbc/inference/sampler/base.py
@@ -177,6 +177,7 @@ def setup_output(sampler, output_file,check_nsamples=True):
     checkpoint_valid = validate_checkpoint_files(checkpoint_file,
                                                  backup_file,
                                                  check_nsamples)
+
     # Create a new file if the checkpoint doesn't exist, or if it is
     # corrupted
     sampler.new_checkpoint = False  # keeps track if this is a new file or not

--- a/pycbc/inference/sampler/cpnest.py
+++ b/pycbc/inference/sampler/cpnest.py
@@ -119,7 +119,7 @@ class CPNestSampler(BaseSampler):
                   verbose=verbose,
                   loglikelihood_function=loglikelihood_function)
 
-        setup_output(obj, output_file)
+        setup_output(obj, output_file, check_nsamples=False)
         if not obj.new_checkpoint:
             obj.resume_from_checkpoint()
         return obj
@@ -139,7 +139,7 @@ class CPNestSampler(BaseSampler):
             self.write_results(fn)
         logging.info("Validating checkpoint and backup files")
         checkpoint_valid = validate_checkpoint_files(
-            self.checkpoint_file, self.backup_file)
+            self.checkpoint_file, self.backup_file, check_nsamples=False)
         if not checkpoint_valid:
             raise IOError("error writing to checkpoint file")
 

--- a/pycbc/inference/sampler/dynesty.py
+++ b/pycbc/inference/sampler/dynesty.py
@@ -123,11 +123,11 @@ class DynestySampler(BaseSampler):
 
         # properties of the internal sampler which should not be pickled
         self.no_pickle = ['loglikelihood',
-                        'prior_transform',
-                        'propose_point',
-                        'update_proposal',
-                        '_UPDATE', '_PROPOSE',
-                        'evolve_point']
+                          'prior_transform',
+                          'propose_point',
+                          'update_proposal',
+                          '_UPDATE', '_PROPOSE',
+                          'evolve_point']
 
     def run(self):
         diff_niter = 1
@@ -321,7 +321,7 @@ class DynestySampler(BaseSampler):
         numpy.random.shuffle(idx)
         post = {'loglikelihood': self._sampler.results.logl[idx]}
         for i, param in enumerate(self.variable_params):
-            post[param] = samples[:,i][idx]
+            post[param] = samples[:, i][idx]
         return post
 
     def set_initial_conditions(self, initial_distribution=None,

--- a/pycbc/inference/sampler/multinest.py
+++ b/pycbc/inference/sampler/multinest.py
@@ -327,7 +327,7 @@ class MultinestSampler(BaseSampler):
                 f_p.write_niterations(self.niterations)
         logging.info("Validating checkpoint and backup files")
         checkpoint_valid = validate_checkpoint_files(
-            self.checkpoint_file, self.backup_file)
+            self.checkpoint_file, self.backup_file, check_nsamples=False)
         if not checkpoint_valid:
             raise IOError("error writing to checkpoint file")
 

--- a/pycbc/io/hdf.py
+++ b/pycbc/io/hdf.py
@@ -1206,7 +1206,8 @@ def get_all_subkeys(grp, key):
 #
 
 
-def dump_state(state, fp, path=None, dsetname='state', protocol=None):
+def dump_state(state, fp, path=None, dsetname='state',
+               protocol=pickle.HIGHEST_PROTOCOL):
     """Dumps the given state to an hdf5 file handler.
 
     The state is stored as a raw binary array to ``{path}/{dsetname}`` in the

--- a/pycbc/pool.py
+++ b/pycbc/pool.py
@@ -136,6 +136,8 @@ def choose_pool(processes, mpi=False):
         pool = SinglePool()
     else:
         pool = BroadcastPool(processes)
+        
+    pool.size=processes
     return pool
 
 

--- a/pycbc/pool.py
+++ b/pycbc/pool.py
@@ -136,8 +136,8 @@ def choose_pool(processes, mpi=False):
         pool = SinglePool()
     else:
         pool = BroadcastPool(processes)
-        
-    pool.size=processes
+
+    pool.size = processes
     return pool
 
 


### PR DESCRIPTION
This supersedes #3330 and #3316. 

This addes support for checkpointing the dynesty sampler when using a fixed number of live points. Checkpointing the Dynamic sampler is not currently enabled and will require the open PRs https://github.com/joshspeagle/dynesty/pull/192 and https://github.com/joshspeagle/dynesty/pull/188 for dynesty to be first merged and included in a release. 


```
[sampler]
maxcall = 5000 # number of calls before we can check if we need to checkpoint, optional set to 5000 * ncores if not set
checkpoint_time_interval = 1000 # seconds between checkpoints
```