### PR TITLE
use radians consistently for setting angular bounds

### DIFF
--- a/pycbc/distributions/angular.py
+++ b/pycbc/distributions/angular.py
@@ -82,8 +82,7 @@ class UniformAngle(uniform.Uniform):
                 bnds._max = bnds._max.__class__(bnds._max)
             else:
                 # create a Bounds instance from the given tuple
-                bnds = boundaries.Bounds(
-                    bnds[0]*numpy.pi, bnds[1]*numpy.pi)
+                bnds = boundaries.Bounds(bnds[0], bnds[1])
             # check that the bounds are in the domain
             if bnds.min < self._domain.min or bnds.max > self._domain.max:
                 raise ValueError("bounds must be in [{x},{y}); "
@@ -117,7 +116,7 @@ class UniformAngle(uniform.Uniform):
         """
         # map values to be within the domain
         kwargs = dict([[p, self._domain.apply_conditions(val)]
-                      for p,val in kwargs.items()])
+                      for p,val in kwargs.items() if p in self._bounds])
         # now apply additional conditions
         return super(UniformAngle, self).apply_boundary_conditions(**kwargs)
 

--- a/pycbc/distributions/angular.py
+++ b/pycbc/distributions/angular.py
@@ -32,8 +32,7 @@ class UniformAngle(uniform.Uniform):
     `cyclic_domain` parameter.
 
     Bounds may be provided to limit the range for which the pdf has support.
-    If provided, the parameter bounds are initialized as multiples of pi,
-    while the stored bounds are in radians.
+    If provided, the parameter bounds are in radians.
 
     Parameters
     ----------
@@ -45,7 +44,7 @@ class UniformAngle(uniform.Uniform):
         The keyword arguments should provide the names of parameters and
         (optionally) their corresponding bounds, as either
         `boundaries.Bounds` instances or tuples. The bounds must be
-        in [0,2). These are converted to radians for storage. None may also
+        in [0,2PI). These are converted to radians for storage. None may also
         be passed; in that case, the domain bounds will be used.
 
     Attributes
@@ -89,8 +88,8 @@ class UniformAngle(uniform.Uniform):
             if bnds.min < self._domain.min or bnds.max > self._domain.max:
                 raise ValueError("bounds must be in [{x},{y}); "
                     "got [{a},{b})".format(x=self._domain.min,
-                    y=self._domain.max/numpy.pi, a=bnds.min,
-                    b=bnds.max/numpy.pi))
+                    y=self._domain.max, a=bnds.min,
+                    b=bnds.max))
             # update
             params[p] = bnds
         super(UniformAngle, self).__init__(**params)
@@ -187,8 +186,7 @@ class SinAngle(UniformAngle):
     The domain of this distribution is `[0, pi]`. This is accomplished by
     putting hard boundaries at `[0, pi]`. Bounds may be provided to further
     limit the range for which the pdf has support.  As with `UniformAngle`,
-    these are initizliaed as multiples of pi, while the stored bounds are in
-    radians.
+    these are initialized in radians.
 
     Parameters
     ----------
@@ -196,7 +194,7 @@ class SinAngle(UniformAngle):
         The keyword arguments should provide the names of parameters and
         (optionally) their corresponding bounds, as either
         `boundaries.Bounds` instances or tuples. The bounds must be
-        in [0,1]. These are converted to radians for storage. None may also
+        in [0,PI]. These are converted to radians for storage. None may also
         be passed; in that case, the domain bounds will be used.
 
     Attributes
@@ -300,8 +298,7 @@ class CosAngle(SinAngle):
         The keyword arguments should provide the names of parameters and
         (optionally) their corresponding bounds, as either
         `boundaries.Bounds` instances or tuples. The bounds must be
-        in [-0.5, 0.5]. These are converted to radians for storage.
-        None may also be passed; in that case, the domain bounds will be used.
+        in [-PI/2, PI/2]. 
 
     Attributes
     ----------------

--- a/pycbc/distributions/angular.py
+++ b/pycbc/distributions/angular.py
@@ -297,7 +297,7 @@ class CosAngle(SinAngle):
         The keyword arguments should provide the names of parameters and
         (optionally) their corresponding bounds, as either
         `boundaries.Bounds` instances or tuples. The bounds must be
-        in [-PI/2, PI/2]. 
+        in [-PI/2, PI/2].
 
     Attributes
     ----------------

--- a/pycbc/distributions/angular.py
+++ b/pycbc/distributions/angular.py
@@ -79,8 +79,8 @@ class UniformAngle(uniform.Uniform):
                 bnds = self._domain
             elif isinstance(bnds, boundaries.Bounds):
                 # convert to radians
-                bnds._min = bnds._min.__class__(bnds._min * numpy.pi)
-                bnds._max = bnds._max.__class__(bnds._max * numpy.pi)
+                bnds._min = bnds._min.__class__(bnds._min)
+                bnds._max = bnds._max.__class__(bnds._max)
             else:
                 # create a Bounds instance from the given tuple
                 bnds = boundaries.Bounds(
@@ -88,8 +88,8 @@ class UniformAngle(uniform.Uniform):
             # check that the bounds are in the domain
             if bnds.min < self._domain.min or bnds.max > self._domain.max:
                 raise ValueError("bounds must be in [{x},{y}); "
-                    "got [{a},{b})".format(x=self._domain.min/numpy.pi,
-                    y=self._domain.max/numpy.pi, a=bnds.min/numpy.pi,
+                    "got [{a},{b})".format(x=self._domain.min,
+                    y=self._domain.max/numpy.pi, a=bnds.min,
                     b=bnds.max/numpy.pi))
             # update
             params[p] = bnds

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -176,9 +176,9 @@ class TestDistributions(unittest.TestCase):
         n_samples = int(1e6)
 
         # create generic angular distributions for test
-        sin_dist = distributions.SinAngle(theta=(0, 1))
-        cos_dist = distributions.CosAngle(theta=(-0.5, 0.5))
-        ang_dist = distributions.UniformAngle(theta=(0, 2))
+        sin_dist = distributions.SinAngle(theta=(0, numpy.pi))
+        cos_dist = distributions.CosAngle(theta=(-numpy.pi/2.0, numpy.pi/2.0))
+        ang_dist = distributions.UniformAngle(theta=(0, numpy.pi*2.0))
 
         # step size for PDF calculation
         step = 0.1


### PR DESCRIPTION
The angular distributions produce values in radians, but the bounds are in fractions of PI. We should consistently use radians so that min/max parameters can be given in the same units. This makes it a lot easier to do bounded sky location priors. 