### PR TITLE
Fix some issues with #3344

### DIFF
--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -455,12 +455,12 @@ class Executable(pegasus_workflow.Executable):
 
         return False
 
-    def create_node(self):
+    def create_node(self, **kwargs):
         """Default node constructor.
 
         This is usually overridden by subclasses of Executable.
         """
-        return Node(self)
+        return Node(self, **kwargs)
 
     def update_current_retention_level(self, value):
         """Set a new value for the current retention level.

--- a/pycbc/workflow/minifollowups.py
+++ b/pycbc/workflow/minifollowups.py
@@ -345,7 +345,7 @@ class SingleTemplateExecutable(PlotExecutable):
     PlotExecutable but adds the file_input_options.
     """
     file_input_options = ['--gating-file']
-    time_dependent_options = ['--channel-name']
+    time_dependent_options = ['--channel-name', '--frame-type']
 
 
 class SingleTimeFreqExecutable(PlotExecutable):
@@ -354,7 +354,7 @@ class SingleTimeFreqExecutable(PlotExecutable):
     PlotExecutable but adds the file_input_options.
     """
     file_input_options = ['--gating-file']
-    time_dependent_options = ['--channel-name']
+    time_dependent_options = ['--channel-name', '--frame-type']
 
 
 class PlotQScanExecutable(PlotExecutable):
@@ -363,7 +363,7 @@ class PlotQScanExecutable(PlotExecutable):
     PlotExecutable but adds the file_input_options.
     """
     file_input_options = ['--gating-file']
-    time_dependent_options = ['--channel-name']
+    time_dependent_options = ['--channel-name', '--frame-type']
 
 
 def make_single_template_plots(workflow, segs, data_read_name, analyzed_name,

--- a/pycbc/workflow/plotting.py
+++ b/pycbc/workflow/plotting.py
@@ -50,8 +50,8 @@ class PlotExecutable(Executable):
 
     # plots and final results should get the highest priority
     # on the job queue
-    def create_node(self):
-        node = Executable.create_node(self)
+    def create_node(self, **kwargs):
+        node = Executable.create_node(self, **kwargs)
         node.set_priority(1000)
         return node
 


### PR DESCRIPTION
There were some problems from #3344, which didn't arise earlier because filesystem problems here are making tests hard to complete. These fixes correctly ensure that time-dependent options get sent through for minifollowup jobs, and also allow the valid_segment to come through.

The latter problem means that the current master is actually broken for all-sky workflows.