### PR TITLE
Add site to avoid NFS symlinks

### DIFF
--- a/pycbc/workflow/pegasus_files/nonfsio-site-template.xml
+++ b/pycbc/workflow/pegasus_files/nonfsio-site-template.xml
@@ -1,0 +1,14 @@
+  <!-- a separate staging site is added else, the intermediate files are symlinked from the home
+       directory since symlinking is turned on -->
+  <site handle="nonfsio-scratch" arch="x86_64" os="LINUX">
+   <directory  path="${REMOTE_SITE_SCRATCH_PATH}/osg-scratch" type="shared-scratch" free-size="null" total-size="null">
+        <file-server  operation="all" url="${REMOTE_SITE_SCRATCH_URL}/nonfsio-scratch">
+        </file-server>
+    </directory>
+  </site>
+
+  <site handle="nonfsio" arch="x86_64" os="LINUX">
+    <profile namespace="pegasus" key="style">condor</profile>
+    <profile namespace="condor" key="accounting_group">$ACCOUNTING_GROUP</profile>
+    <profile namespace="condor" key="should_transfer_files">YES</profile>
+    <profile namespace="condor" key="when_to_transfer_output">ON_EXIT_OR_EVICT</profile>


### PR DESCRIPTION
We are currently seeing severe issues on one of our clusters during the coincidence stage because the repeated, small, I/O on the HDF_TRIGGER_MERGE files becomes too much. It seems more efficient to have the input files staged to local disk before starting the job in this case (yes, I know that's a larger *total* I/O, but in one large block it seems faster).

This also might be useful for other jobs. So the idea here is to add a site "nonfsio". If you use config overrides and options to submit_dax you can ensure that any specific executable will always run in this mode and not use symlinked input files.

I don't know if there is an easier way to do this? I know I can make *all* jobs use copied inputs, but I don't think that's what I want. Some jobs do a tiny amount of I/O on quite large inputs, and copying those over is not desired. I want to be able to say "Executable X uses symlinked inputs, Executable Y uses copied inputs". This approach still requires quite a number of overrides to get it working, so something more optimal would be preferred (e.g. with a single config option to say "run on nonfsio")