### PR TITLE
Consolidate resolve url

### DIFF
--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -2013,8 +2013,8 @@ def resolve_url_to_file(curr_pfn):
     cvmfsstr = 'file:///cvmfs/oasis.opensciencegrid.org/ligo/frames'
 
     # Get LFN
-    urlp = urllib.parse.urlparse(url)
-    curr_lfn = os.path.basename(u.path)
+    urlp = urllib.parse.urlparse(curr_pfn)
+    curr_lfn = os.path.basename(urlp.path)
 
     # Does this already exist as a File?
     if curr_lfn in file_input_from_config_dict.keys():

--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -2061,6 +2061,8 @@ def resolve_url_to_file(curr_pfn, attrs=None):
             tags = []
 
         curr_file = File(ifos, exe_name, segs, local_file_path, tags=tags)
+        pfn_local = urljoin('file:', pathname2url(local_file_path))
+        curr_file.PFN(pfn_local, 'local')
         # Add other PFNs for nonlocal sites as needed.
         # This block could be extended as needed
         if curr_pfn.startswith(cvmfsstrs):

--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -2032,6 +2032,11 @@ def resolve_url_to_file(curr_pfn):
         if curr_file.url.startswith(cvmfsstr):
             curr_file.PFN(curr_pfn, site='osg')
             curr_file.PFN(curr_pfn, site='nonfsio')
+            # Also register the CVMFS PFN with the local site. We want to
+            # prefer this, and symlink from here, when possible.
+            # However, I think we need a little more to avoid it symlinking
+            # to this through an NFS mount.
+            curr_file.PFN(curr_pfn, site='local')
         # Store the file to avoid later duplication
         tuple_val = (local_file_path, curr_file, curr_pfn)
         file_input_from_config_dict[curr_lfn] = tuple_val

--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -335,7 +335,6 @@ class Executable(pegasus_workflow.Executable):
         sec : string
             The section containing options for this job.
         """
-        cvmfsstr = 'file:///cvmfs/oasis.opensciencegrid.org/ligo/frames'
         for opt in cp.options(sec):
             value = cp.get(sec, opt).strip()
             opt = '--%s' %(opt,)
@@ -366,8 +365,6 @@ class Executable(pegasus_workflow.Executable):
                             #IFO:path or IFO:URL
                             ifo = split_path[0]
                             path = split_path[1]
-
-                    curr_lfn = os.path.basename(path)
 
                     # If the file exists make sure to use the
                     # fill path as a file:// URL

--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -2024,8 +2024,8 @@ def resolve_url_to_file(curr_pfn, attrs=None):
     template banks, where ifos and valid times will be checked in the workflow
     and used in the naming of child job output files.
     """
-    cvmfsstr1 = 'file:///cvmfs/oasis.opensciencegrid.org/ligo/frames'
-    cvmfsstr2 = 'file://localhost/cvmfs/oasis.opensciencegrid.org/ligo/frames'
+    cvmfsstr1 = 'file:///cvmfs/'
+    cvmfsstr2 = 'file://localhost/cvmfs/'
     cvmfsstrs = (cvmfsstr1, cvmfsstr2)
 
     # Get LFN

--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -2044,7 +2044,7 @@ def resolve_url_to_file(curr_pfn, attrs=None):
         # Create File object with default local path
         # To do this we first need to check the attributes
         if attrs and 'ifos' in attrs:
-            ifos = attrs[ifos]
+            ifos = attrs['ifos']
         else:
             ifos = ['H1', 'K1', 'L1', 'V1']
         if attrs and 'exe_name' in attrs:

--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -2010,7 +2010,9 @@ def resolve_url_to_file(curr_pfn):
     addition to local. If the LFN is a duplicate of an existing one, but with a
     different PFN an AssertionError is raised.
     """
-    cvmfsstr = 'file:///cvmfs/oasis.opensciencegrid.org/ligo/frames'
+    cvmfsstr1 = 'file:///cvmfs/oasis.opensciencegrid.org/ligo/frames'
+    cvmfsstr2 = 'file://localhost/cvmfs/oasis.opensciencegrid.org/ligo/frames'
+    cvmfsstrs = (cvmfsstr1, cvmfsstr2)
 
     # Get LFN
     urlp = urllib.parse.urlparse(curr_pfn)
@@ -2029,7 +2031,7 @@ def resolve_url_to_file(curr_pfn):
         curr_file = File.from_path(local_file_path)
         # Add other PFNs for nonlocal sites as needed.
         # This block could be extended as needed
-        if curr_file.url.startswith(cvmfsstr):
+        if curr_pfn.startswith(cvmfsstrs):
             curr_file.PFN(curr_pfn, site='osg')
             curr_file.PFN(curr_pfn, site='nonfsio')
             # Also register the CVMFS PFN with the local site. We want to

--- a/pycbc/workflow/grb_utils.py
+++ b/pycbc/workflow/grb_utils.py
@@ -36,7 +36,7 @@ from six.moves.urllib.request import pathname2url
 from six.moves.urllib.parse import urljoin
 from ligo import segments
 from glue.ligolw import ligolw, lsctables, utils, ilwd
-from pycbc.workflow.core import File, FileList, resolve_url
+from pycbc.workflow.core import File, FileList, resolve_url_to_file
 from pycbc.workflow.jobsetup import select_generic_executable
 
 
@@ -224,11 +224,13 @@ def get_ipn_sky_files(workflow, file_url, tags=None):
         File object representing the IPN sky points file.
     '''
     tags = tags or []
-    ipn_sky_points = resolve_url(file_url)
-    sky_points_url = urljoin("file:", pathname2url(ipn_sky_points))
-    sky_points_file = File(workflow.ifos, "IPN_SKY_POINTS",
-            workflow.analysis_time, file_url=sky_points_url, tags=tags)
-    sky_points_file.PFN(sky_points_url, site="local")
+    file_attrs = {
+        'ifos' : workflow.ifos,
+        'segs' : workflow.analysis_time,
+        'exe_name' : "IPN_SKY_POINTS",
+        'tags' : tags
+    }
+    sky_points_file = resolve_url_to_file(file_url)
 
     return sky_points_file
 

--- a/pycbc/workflow/grb_utils.py
+++ b/pycbc/workflow/grb_utils.py
@@ -225,12 +225,12 @@ def get_ipn_sky_files(workflow, file_url, tags=None):
     '''
     tags = tags or []
     file_attrs = {
-        'ifos' : workflow.ifos,
-        'segs' : workflow.analysis_time,
-        'exe_name' : "IPN_SKY_POINTS",
-        'tags' : tags
+        'ifos': workflow.ifos,
+        'segs': workflow.analysis_time,
+        'exe_name': "IPN_SKY_POINTS",
+        'tags': tags
     }
-    sky_points_file = resolve_url_to_file(file_url)
+    sky_points_file = resolve_url_to_file(file_url, attrs=file_attrs)
 
     return sky_points_file
 

--- a/pycbc/workflow/injection.py
+++ b/pycbc/workflow/injection.py
@@ -30,9 +30,7 @@ https://ldas-jobs.ligo.caltech.edu/~cbc/docs/pycbc/NOTYETCREATED.html
 """
 
 import logging
-from six.moves.urllib.request import pathname2url
-from six.moves.urllib.parse import urljoin
-from pycbc.workflow.core import File, FileList, make_analysis_dir
+from pycbc.workflow.core import FileList, make_analysis_dir
 from pycbc.workflow.core import Executable, resolve_url_to_file
 from pycbc.workflow.jobsetup import (LalappsInspinjExecutable,
         LigolwCBCJitterSkylocExecutable, LigolwCBCAlignTotalSpinExecutable,
@@ -150,8 +148,8 @@ def setup_injection_workflow(workflow, output_dir=None,
         elif injection_method == "PREGENERATED":
             file_attrs = {
                 'ifos': ['HL'],
-                'segs' : full_segment,
-                'tags' : curr_tags
+                'segs': full_segment,
+                'tags': curr_tags
             }
             injection_path = workflow.cp.get_opt_tags(
                 "workflow-injections",

--- a/pycbc/workflow/injection.py
+++ b/pycbc/workflow/injection.py
@@ -32,7 +32,8 @@ https://ldas-jobs.ligo.caltech.edu/~cbc/docs/pycbc/NOTYETCREATED.html
 import logging
 from six.moves.urllib.request import pathname2url
 from six.moves.urllib.parse import urljoin
-from pycbc.workflow.core import File, FileList, make_analysis_dir, Executable, resolve_url
+from pycbc.workflow.core import File, FileList, make_analysis_dir
+from pycbc.workflow.core import Executable, resolve_url_to_file
 from pycbc.workflow.jobsetup import (LalappsInspinjExecutable,
         LigolwCBCJitterSkylocExecutable, LigolwCBCAlignTotalSpinExecutable,
         PycbcDarkVsBrightInjectionsExecutable)
@@ -147,14 +148,12 @@ def setup_injection_workflow(workflow, output_dir=None,
             inj_file = node.output_files[0]
             inj_files.append(inj_file)
         elif injection_method == "PREGENERATED":
-            injectionFilePath = workflow.cp.get_opt_tags("workflow-injections",
-                                      "injections-pregenerated-file", curr_tags)
-            injectionFilePath = resolve_url(injectionFilePath)
-            file_url = urljoin('file:', pathname2url(injectionFilePath))
-            inj_file = File('HL', 'PREGEN_inj_file', full_segment, file_url,
-                            tags=curr_tags)
-            inj_file.PFN(injectionFilePath, site='local')
-            inj_files.append(inj_file)
+            injection_path = workflow.cp.get_opt_tags(
+                "workflow-injections",
+                "injections-pregenerated-file",
+                curr_tags
+            )
+            inj_files.append(resolve_url_to_file(injection_path))
         elif injection_method in ["IN_COH_PTF_WORKFLOW", "AT_COH_PTF_RUNTIME"]:
             inj_job = LalappsInspinjExecutable(workflow.cp, inj_section_name,
                                                out_dir=output_dir, ifos=ifos,

--- a/pycbc/workflow/injection.py
+++ b/pycbc/workflow/injection.py
@@ -148,12 +148,18 @@ def setup_injection_workflow(workflow, output_dir=None,
             inj_file = node.output_files[0]
             inj_files.append(inj_file)
         elif injection_method == "PREGENERATED":
+            file_attrs = {
+                'ifos': ['HL'],
+                'segs' : full_segment,
+                'tags' : curr_tags
+            }
             injection_path = workflow.cp.get_opt_tags(
                 "workflow-injections",
                 "injections-pregenerated-file",
                 curr_tags
             )
-            inj_files.append(resolve_url_to_file(injection_path))
+            curr_file = resolve_url_to_file(injection_path, attrs=file_attrs)
+            inj_files.append(curr_file)
         elif injection_method in ["IN_COH_PTF_WORKFLOW", "AT_COH_PTF_RUNTIME"]:
             inj_job = LalappsInspinjExecutable(workflow.cp, inj_section_name,
                                                out_dir=output_dir, ifos=ifos,

--- a/pycbc/workflow/psdfiles.py
+++ b/pycbc/workflow/psdfiles.py
@@ -118,8 +118,7 @@ def setup_psd_pregenerated(workflow, tags=None):
 
     cp = workflow.cp
     global_seg = workflow.analysis_time
-    user_tag = "PREGEN_PSD"
-    file_attrs = {'segs' : global_seg, 'tags' : tags}
+    file_attrs = {'segs': global_seg, 'tags': tags}
 
     # Check for one psd for all ifos
     try:

--- a/pycbc/workflow/psdfiles.py
+++ b/pycbc/workflow/psdfiles.py
@@ -36,7 +36,8 @@ import logging
 from six.moves import configparser as ConfigParser
 from six.moves.urllib.request import pathname2url
 from six.moves.urllib.parse import urljoin
-from pycbc.workflow.core import File, FileList, make_analysis_dir, resolve_url
+from pycbc.workflow.core import File, FileList
+from pycbc.workflow.core import make_analysis_dir, resolve_url_to_file
 
 def setup_psd_workflow(workflow, science_segs, datafind_outs,
                              output_dir=None, tags=None):
@@ -123,11 +124,7 @@ def setup_psd_pregenerated(workflow, tags=None):
     try:
         pre_gen_file = cp.get_opt_tags('workflow-psd',
                         'psd-pregenerated-file', tags)
-        pre_gen_file = resolve_url(pre_gen_file)
-        file_url = urljoin('file:', pathname2url(pre_gen_file))
-        curr_file = File(workflow.ifos, user_tag, global_seg, file_url,
-                                                    tags=tags)
-        curr_file.PFN(file_url, site='local')
+        curr_file = resolve_url_to_file(pre_gen_file)
         psd_files.append(curr_file)
     except ConfigParser.Error:
         # Check for one psd per ifo
@@ -136,11 +133,7 @@ def setup_psd_pregenerated(workflow, tags=None):
                 pre_gen_file = cp.get_opt_tags('workflow-psd',
                                 'psd-pregenerated-file-%s' % ifo.lower(),
                                 tags)
-                pre_gen_file = resolve_url(pre_gen_file)
-                file_url = urljoin('file:', pathname2url(pre_gen_file))
-                curr_file = File(ifo, user_tag, global_seg, file_url,
-                                                            tags=tags)
-                curr_file.PFN(file_url, site='local')
+                curr_file = resolve_url_to_file(pre_gen_file)
                 psd_files.append(curr_file)
 
             except ConfigParser.Error:

--- a/pycbc/workflow/psdfiles.py
+++ b/pycbc/workflow/psdfiles.py
@@ -119,12 +119,14 @@ def setup_psd_pregenerated(workflow, tags=None):
     cp = workflow.cp
     global_seg = workflow.analysis_time
     user_tag = "PREGEN_PSD"
+    file_attrs = {'segs' : global_seg, 'tags' : tags}
 
     # Check for one psd for all ifos
     try:
         pre_gen_file = cp.get_opt_tags('workflow-psd',
                         'psd-pregenerated-file', tags)
-        curr_file = resolve_url_to_file(pre_gen_file)
+        file_attrs['ifos'] = workflow.ifos
+        curr_file = resolve_url_to_file(pre_gen_file, attrs=file_attrs)
         psd_files.append(curr_file)
     except ConfigParser.Error:
         # Check for one psd per ifo
@@ -133,7 +135,8 @@ def setup_psd_pregenerated(workflow, tags=None):
                 pre_gen_file = cp.get_opt_tags('workflow-psd',
                                 'psd-pregenerated-file-%s' % ifo.lower(),
                                 tags)
-                curr_file = resolve_url_to_file(pre_gen_file)
+                file_attrs['ifos'] = [ifo]
+                curr_file = resolve_url_to_file(pre_gen_file, attrs=file_attrs)
                 psd_files.append(curr_file)
 
             except ConfigParser.Error:

--- a/pycbc/workflow/tmpltbank.py
+++ b/pycbc/workflow/tmpltbank.py
@@ -33,10 +33,8 @@ from __future__ import division
 import os
 import logging
 from six.moves import configparser as ConfigParser
-from six.moves.urllib.request import pathname2url
-from six.moves.urllib.parse import urljoin
 import pycbc
-from pycbc.workflow.core import File, FileList
+from pycbc.workflow.core import FileList
 from pycbc.workflow.core import make_analysis_dir, resolve_url_to_file
 from pycbc.workflow.jobsetup import select_tmpltbank_class, select_matchedfilter_class, sngl_ifo_job_setup
 
@@ -362,9 +360,8 @@ def setup_tmpltbank_pregenerated(workflow, tags=None):
 
     cp = workflow.cp
     global_seg = workflow.analysis_time
-    user_tag = "PREGEN_TMPLTBANK"
     file_attrs = {'segs' : global_seg, 'tags' : tags}
-    
+
     try:
         # First check if we have a bank for all ifos
         pre_gen_bank = cp.get_opt_tags('workflow-tmpltbank',

--- a/pycbc/workflow/tmpltbank.py
+++ b/pycbc/workflow/tmpltbank.py
@@ -36,7 +36,8 @@ from six.moves import configparser as ConfigParser
 from six.moves.urllib.request import pathname2url
 from six.moves.urllib.parse import urljoin
 import pycbc
-from pycbc.workflow.core import File, FileList, make_analysis_dir, resolve_url
+from pycbc.workflow.core import File, FileList
+from pycbc.workflow.core import make_analysis_dir, resolve_url_to_file
 from pycbc.workflow.jobsetup import select_tmpltbank_class, select_matchedfilter_class, sngl_ifo_job_setup
 
 def setup_tmpltbank_workflow(workflow, science_segs, datafind_outs,
@@ -366,11 +367,7 @@ def setup_tmpltbank_pregenerated(workflow, tags=None):
         # First check if we have a bank for all ifos
         pre_gen_bank = cp.get_opt_tags('workflow-tmpltbank',
                                            'tmpltbank-pregenerated-bank', tags)
-        pre_gen_bank = resolve_url(pre_gen_bank)
-        file_url = urljoin('file:', pathname2url(pre_gen_bank))
-        curr_file = File(workflow.ifos, user_tag, global_seg, file_url,
-                                                                     tags=tags)
-        curr_file.PFN(file_url, site='local')
+        curr_file = resolve_url_to_file(pre_gen_bank)
         tmplt_banks.append(curr_file)
     except ConfigParser.Error:
         # Okay then I must have banks for each ifo
@@ -379,11 +376,7 @@ def setup_tmpltbank_pregenerated(workflow, tags=None):
                 pre_gen_bank = cp.get_opt_tags('workflow-tmpltbank',
                                 'tmpltbank-pregenerated-bank-%s' % ifo.lower(),
                                 tags)
-                pre_gen_bank = resolve_url(pre_gen_bank)
-                file_url = urljoin('file:', pathname2url(pre_gen_bank))
-                curr_file = File(ifo, user_tag, global_seg, file_url,
-                                                                     tags=tags)
-                curr_file.PFN(file_url, site='local')
+                curr_file = resolve_url_to_file(pre_gen_bank)
                 tmplt_banks.append(curr_file)
 
             except ConfigParser.Error:

--- a/pycbc/workflow/tmpltbank.py
+++ b/pycbc/workflow/tmpltbank.py
@@ -380,7 +380,7 @@ def setup_tmpltbank_pregenerated(workflow, tags=None):
                                 'tmpltbank-pregenerated-bank-%s' % ifo.lower(),
                                 tags)
                 file_attrs['ifos'] = [ifo]
-                curr_file = resolve_url_to_file(pre_gen_bank, attrs=file_attrs))
+                curr_file = resolve_url_to_file(pre_gen_bank, attrs=file_attrs)
                 tmplt_banks.append(curr_file)
 
             except ConfigParser.Error:

--- a/pycbc/workflow/tmpltbank.py
+++ b/pycbc/workflow/tmpltbank.py
@@ -363,11 +363,14 @@ def setup_tmpltbank_pregenerated(workflow, tags=None):
     cp = workflow.cp
     global_seg = workflow.analysis_time
     user_tag = "PREGEN_TMPLTBANK"
+    file_attrs = {'segs' : global_seg, 'tags' : tags}
+    
     try:
         # First check if we have a bank for all ifos
         pre_gen_bank = cp.get_opt_tags('workflow-tmpltbank',
                                            'tmpltbank-pregenerated-bank', tags)
-        curr_file = resolve_url_to_file(pre_gen_bank)
+        file_attrs['ifos'] = workflow.ifos
+        curr_file = resolve_url_to_file(pre_gen_bank, attrs=file_attrs)
         tmplt_banks.append(curr_file)
     except ConfigParser.Error:
         # Okay then I must have banks for each ifo
@@ -376,7 +379,8 @@ def setup_tmpltbank_pregenerated(workflow, tags=None):
                 pre_gen_bank = cp.get_opt_tags('workflow-tmpltbank',
                                 'tmpltbank-pregenerated-bank-%s' % ifo.lower(),
                                 tags)
-                curr_file = resolve_url_to_file(pre_gen_bank)
+                file_attrs['ifos'] = [ifo]
+                curr_file = resolve_url_to_file(pre_gen_bank, attrs=file_attrs))
                 tmplt_banks.append(curr_file)
 
             except ConfigParser.Error:


### PR DESCRIPTION
So this carries on from #3360 with similar motivations (or at least playing around with #3360 lead to me needing to do this).

In short we use `resolve_url` to pull in inputs in a few cases, but this always needs extra commands after it to convert to a File object. I want to create a one-shot `resolve_url_to_file` function, that will return a File object with all necessary attributes/PFNs attached to it.

As an example, if an input is on CVMFS, and I want to run on OSG (let's say an injection file on CVMFS, or a template bank) the workflow generator will pull the file to the local site, and then it will be gsiftp-ed to the OSG sites in question. It would be better if the remote site can just get that via CVMFS (as happens with frame files, which are a bit of a special case, so not touched in this patch).

Trying to duplicate this kind of stuff after all `resolve_url` calls makes no sense, but with a new combined function, we can add PFNs for this. If something comes from CVMFS, we add it's cvmfs PFN to all sites (local, osg and the new nonfsio site). If others want default behaviours here for other sites, just add it to this function.

One open question: For the local site I would prefer it if the CVMFS location is preferred over other /file locations (assumed to be NFS mounts). However, if I swap this it's swapped for all users. What are the thoughts on that? (This probably wouldn't affect frame files, as we tend not to get both CVMFS *and* local PFNs in the standard route through the workflow).