### PR TITLE
pass boundary types to dynesty

### DIFF
--- a/examples/inference/single/single.ini
+++ b/examples/inference/single/single.ini
@@ -21,10 +21,11 @@ strain-high-pass = 15
 sample-rate = 2048
 
 [sampler]
-name = emcee_pt
-ntemps = 4
-nwalkers = 100
-niterations = 300
+name = dynesty
+nlive = 100
+#ntemps = 4
+#nwalkers = 100
+#niterations = 300
 
 [sampler-burn_in]
 burn-in-test = min_iterations
@@ -62,6 +63,11 @@ max-tc = 1187008882.5
 name = uniform_radius
 min-distance = 10
 max-distance = 60
+#btype-min-distance = reflected
+#btype-max-distance = reflected
 
 [prior-inclination]
 name = sin_angle
+cyclic-inclination =
+min-inclination = 0
+max-inclination = 1

--- a/examples/inference/single/single.ini
+++ b/examples/inference/single/single.ini
@@ -21,11 +21,10 @@ strain-high-pass = 15
 sample-rate = 2048
 
 [sampler]
-name = dynesty
-nlive = 100
-#ntemps = 4
-#nwalkers = 100
-#niterations = 300
+name = emcee_pt
+ntemps = 4
+nwalkers = 100
+niterations = 300
 
 [sampler-burn_in]
 burn-in-test = min_iterations
@@ -63,11 +62,6 @@ max-tc = 1187008882.5
 name = uniform_radius
 min-distance = 10
 max-distance = 60
-#btype-min-distance = reflected
-#btype-max-distance = reflected
 
 [prior-inclination]
 name = sin_angle
-cyclic-inclination =
-min-inclination = 0
-max-inclination = 1

--- a/pycbc/boundaries.py
+++ b/pycbc/boundaries.py
@@ -311,12 +311,16 @@ class Bounds(object):
         # can be used with arrays
         if self._min.name == 'reflected' and self._max.name == 'reflected':
             self._reflect = numpy.vectorize(self._reflect_well)
+            self.reflected = 'well'
         elif self._min.name == 'reflected':
             self._reflect = numpy.vectorize(self._min.reflect_right)
+            self.reflected = 'min'
         elif self._max.name == 'reflected':
             self._reflect = numpy.vectorize(self._max.reflect_left)
+            self.reflected = 'max'
         else:
             self._reflect = _pass
+            self.reflected = False
 
     def __repr__(self):
         return str(self.__class__)[:-1] + " " + " ".join(

--- a/pycbc/distributions/joint.py
+++ b/pycbc/distributions/joint.py
@@ -205,7 +205,7 @@ class JointDistribution(object):
             if bounds[param].reflected == 'well':
                 reflect.append(param)
         return reflect
-        
+
     @property
     def cyclic(self):
         """ Get list of which parameters are cyclic
@@ -224,8 +224,8 @@ class JointDistribution(object):
         bnds = {}
         for dist in self.distributions:
             if hasattr(dist, 'bounds'):
-                bnds.update(dist.bounds) 
-        return bnds 
+                bnds.update(dist.bounds)
+        return bnds
 
     def cdfinv(self, **original):
         """ Apply the inverse cdf to the array of values [0, 1]. Every

--- a/pycbc/distributions/joint.py
+++ b/pycbc/distributions/joint.py
@@ -195,6 +195,38 @@ class JointDistribution(object):
 
         return out
 
+    @property
+    def well_reflected(self):
+        """ Get list of which parameters are well reflected
+        """
+        reflect = []
+        bounds = self.bounds
+        for param in bounds:
+            if bounds[param].reflected == 'well':
+                reflect.append(param)
+        return reflect
+        
+    @property
+    def cyclic(self):
+        """ Get list of which parameters are cyclic
+        """
+        cyclic = []
+        bounds = self.bounds
+        for param in bounds:
+            if bounds[param].cyclic:
+                cyclic.append(param)
+        return cyclic
+
+    @property
+    def bounds(self):
+        """ Get the dict of boundaries
+        """
+        bnds = {}
+        for dist in self.distributions:
+            if hasattr(dist, 'bounds'):
+                bnds.update(dist.bounds) 
+        return bnds 
+
     def cdfinv(self, **original):
         """ Apply the inverse cdf to the array of values [0, 1]. Every
         variable parameter must be given as a keyword argument.

--- a/pycbc/inference/sampler/dynesty.py
+++ b/pycbc/inference/sampler/dynesty.py
@@ -111,17 +111,17 @@ class DynestySampler(BaseSampler):
             if param in cyclic:
                 logging.info('Param: %s will be cyclic', param)
                 periodic.append(i)
-            
+
         if len(periodic) == 0:
             periodic = None
-            
+
         # Check for reflected boundaries. Dynesty only supports
         # reflection on both min and max of boundary.
         reflective = []
         reflect = self.model.prior_distribution.well_reflected
         for i, param in enumerate(self.variable_params):
             if param in reflect:
-                logging.info("Param: %s will be well reflected", param) 
+                logging.info("Param: %s will be well reflected", param)
                 reflective.append(i)
         
         if len(reflective) == 0:

--- a/pycbc/inference/sampler/dynesty.py
+++ b/pycbc/inference/sampler/dynesty.py
@@ -123,7 +123,7 @@ class DynestySampler(BaseSampler):
             if param in reflect:
                 logging.info("Param: %s will be well reflected", param)
                 reflective.append(i)
-        
+
         if len(reflective) == 0:
             reflective = None
 

--- a/pycbc/inference/sampler/dynesty.py
+++ b/pycbc/inference/sampler/dynesty.py
@@ -104,6 +104,29 @@ class DynestySampler(BaseSampler):
         else:
             self.run_with_checkpoint = False
 
+        # Check for cyclic boundaries
+        periodic = []
+        cyclic = self.model.prior_distribution.cyclic
+        for i, param in enumerate(self.variable_params):
+            if param in cyclic:
+                logging.info('Param: %s will be cyclic', param)
+                periodic.append(i)
+            
+        if len(periodic) == 0:
+            periodic = None
+            
+        # Check for reflected boundaries. Dynesty only supports
+        # reflection on both min and max of boundary.
+        reflective = []
+        reflect = self.model.prior_distribution.well_reflected
+        for i, param in enumerate(self.variable_params):
+            if param in reflect:
+                logging.info("Param: %s will be well reflected", param) 
+                reflective.append(i)
+        
+        if len(reflective) == 0:
+            reflective = None
+
         if self.nlive < 0:
             # Interpret a negative input value for the number of live points
             # (which is clearly an invalid input in all senses)
@@ -111,6 +134,8 @@ class DynestySampler(BaseSampler):
             self._sampler = dynesty.DynamicNestedSampler(log_likelihood_call,
                                                          prior_call, self.ndim,
                                                          pool=self.pool,
+                                                         reflective=reflective,
+                                                         periodic=periodic,
                                                          **kwargs)
             self.run_with_checkpoint = False
             logging.info("Checkpointing not currently supported with"
@@ -119,6 +144,8 @@ class DynestySampler(BaseSampler):
             self._sampler = dynesty.NestedSampler(log_likelihood_call,
                                                   prior_call, self.ndim,
                                                   nlive=self.nlive,
+                                                  reflective=reflective,
+                                                  periodic=periodic,
                                                   pool=self.pool, **kwargs)
 
         # properties of the internal sampler which should not be pickled


### PR DESCRIPTION
This passes the pycbc boundary types (where applicable) to dynest. Only the two-sided reflective and the cyclic boundaries are supported as those are the only ones Dynesty has. So, notable, there is no one-sided reflective boundary. 

Example of how to write the boundary in the config file. Note that if you specify the boundary type, you also need to explicitly
set the min/max of the parameter as well. I am doing so here for inclination. The units are currently radians per PI, but that will change to PI in #3355, so be careful until that patch is applied. 

```
#btype-min-distance = reflected
#btype-max-distance = reflected


[prior-inclination]	[prior-inclination]
name = sin_angle	name = sin_angle
cyclic-inclination =
min-inclination = 0
max-inclination = 3.141592653
```