### PR TITLE
Set correct dtype when reading epsie samples

### DIFF
--- a/pycbc/inference/io/base_multitemper.py
+++ b/pycbc/inference/io/base_multitemper.py
@@ -280,7 +280,8 @@ def read_raw_samples(fp, fields,
             alist.append(thisarr)
             maxiters = max(maxiters, thisarr.shape[-1])
         # stack into a single array
-        arr = numpy.full((ntemps, len(chains), maxiters), numpy.nan)
+        arr = numpy.full((ntemps, len(chains), maxiters), numpy.nan,
+                         dtype=fp[dset].dtype)
         for ii, thisarr in enumerate(alist):
             if thisarr is not None:
                 arr[:, ii, :thisarr.shape[-1]] = thisarr


### PR DESCRIPTION
Fixes a bug where complex datatypes were not being correctly loaded when reading samples from epsie. Currently, `read_raw_samples` is assuming that all data are floats. However, since epsie stores the complex log likelihood ratios, they were being forcibly cast to floats. This also caused a problem when trying to thin samples on disk.