### PR TITLE
Add gate and paint function

### DIFF
--- a/pycbc/strain/gate.py
+++ b/pycbc/strain/gate.py
@@ -141,7 +141,7 @@ def add_gate_option_group(parser):
     return gate_group
 
 
-def gate_and_paint(data, lindex, rindex, invpsd):
+def gate_and_paint(data, lindex, rindex, invpsd, copy=True):
     """Gates and in-paints data.
 
     Parameters
@@ -154,6 +154,9 @@ def gate_and_paint(data, lindex, rindex, invpsd):
         The end index of the gate.
     invpsd : FrequencySeries
         The inverse of the PSD.
+    copy : bool, optional
+        Copy the data before applying the gate. Otherwise, the gate will
+        be applied in-place. Default is True.
 
     Returns
     -------
@@ -161,7 +164,10 @@ def gate_and_paint(data, lindex, rindex, invpsd):
         The gated and in-painted time series.
     """
     # Copy the data and zero inside the hole
-    gated_data = data.copy()
+    if copy:
+        gated_data = data.copy()
+    else:
+        gated_data = data
     gated_data[lindex:rindex] *= 0
     # get the over-whitened gated data
     tdfilter = invpsd.astype('complex').to_timeseries()

--- a/pycbc/strain/gate.py
+++ b/pycbc/strain/gate.py
@@ -165,15 +165,15 @@ def gate_and_paint(data, lindex, rindex, invpsd, copy=True):
     """
     # Copy the data and zero inside the hole
     if copy:
-        gated_data = data.copy()
-    else:
-        gated_data = data
-    gated_data[lindex:rindex] *= 0
+        data = data.copy()
+    data[lindex:rindex] = 0
+
     # get the over-whitened gated data
-    tdfilter = invpsd.astype('complex').to_timeseries()
-    owhgated_data = (gated_data.to_frequencyseries() * invpsd).to_timeseries()
+    tdfilter = invpsd.astype('complex').to_timeseries() * invpsd.delta_t
+    owhgated_data = (data.to_frequencyseries() * invpsd).to_timeseries()
+    
     # remove the projection into the null space
-    proj = linalg.solve_toeplitz(tdfilter.numpy()[:(rindex - lindex)],
-                                 owhgated_data.numpy()[lindex:rindex])
-    gated_data[lindex:rindex] -= proj
-    return gated_data
+    proj = linalg.solve_toeplitz(tdfilter[:(rindex - lindex)],
+                                 owhgated_data[lindex:rindex])
+    data[lindex:rindex] -= proj
+    return data


### PR DESCRIPTION
This adds the gate and in-paint function used by the IAS group to the gate module. It just takes a right index and left index. We probably will want to add another function that takes in times, but since that may require doing sub-sample shifting, I thought it might be better to add that as a separate function, which would call this function.

I've only tested that this works on a time series without failing. I haven't actually checked that it gives reasonable results.