### PR TITLE
update gate time series method to allow selection of gating type

### DIFF
--- a/pycbc/strain/gate.py
+++ b/pycbc/strain/gate.py
@@ -16,8 +16,8 @@
 """ Functions for applying gates to data.
 """
 
-from . import strain
 from scipy import linalg
+from . import strain
 
 
 def _gates_from_cli(opts, gate_opt):
@@ -171,7 +171,7 @@ def gate_and_paint(data, lindex, rindex, invpsd, copy=True):
     # get the over-whitened gated data
     tdfilter = invpsd.astype('complex').to_timeseries() * invpsd.delta_t
     owhgated_data = (data.to_frequencyseries() * invpsd).to_timeseries()
-    
+
     # remove the projection into the null space
     proj = linalg.solve_toeplitz(tdfilter[:(rindex - lindex)],
                                  owhgated_data[lindex:rindex])

--- a/pycbc/strain/gate.py
+++ b/pycbc/strain/gate.py
@@ -163,6 +163,8 @@ def gate_and_paint(data, lindex, rindex, invpsd, copy=True):
     TimeSeries :
         The gated and in-painted time series.
     """
+    # Uses the hole-filling method of
+    # https://arxiv.org/pdf/1908.05644.pdf
     # Copy the data and zero inside the hole
     if copy:
         data = data.copy()

--- a/pycbc/types/frequencyseries.py
+++ b/pycbc/types/frequencyseries.py
@@ -437,6 +437,7 @@ class FrequencySeries(Array):
                              'or .hdf')
 
     def to_frequencyseries(self):
+        """ Return frequency series """
         return self
 
     @_noreal

--- a/pycbc/types/frequencyseries.py
+++ b/pycbc/types/frequencyseries.py
@@ -72,7 +72,7 @@ class FrequencySeries(Array):
                 else:
                     epoch = _lal.LIGOTimeGPS(0)
             elif epoch is not None:
-                try: 
+                try:
                     if isinstance(epoch, _numpy.generic):
                         # In python3 lal LIGOTimeGPS will not work on numpy
                         # types as input. A quick google on how to generically
@@ -170,7 +170,7 @@ class FrequencySeries(Array):
 
     @property
     def sample_rate(self):
-        """Return the sample rate this would have in the time domain. This 
+        """Return the sample rate this would have in the time domain. This
         assumes even length time series!
         """
         return (len(self) - 1) * self.delta_f * 2.0
@@ -382,8 +382,8 @@ class FrequencySeries(Array):
         ----------
         path: string
             Destination file path. Must end with either .hdf, .npy or .txt.
-            
-        group: string 
+
+        group: string
             Additional name for internal storage use. Ex. hdf storage uses
             this as the key value.
 
@@ -436,23 +436,26 @@ class FrequencySeries(Array):
             raise ValueError('Path must end with .npy, .txt, .xml, .xml.gz '
                              'or .hdf')
 
+    def to_frequencyseries(self):
+        return self
+
     @_noreal
     def to_timeseries(self, delta_t=None):
         """ Return the Fourier transform of this time series.
 
         Note that this assumes even length time series!
-        
+
         Parameters
         ----------
         delta_t : {None, float}, optional
-            The time resolution of the returned series. By default the 
-        resolution is determined by length and delta_f of this frequency 
+            The time resolution of the returned series. By default the
+        resolution is determined by length and delta_f of this frequency
         series.
-        
+
         Returns
-        -------        
-        TimeSeries: 
-            The inverse fourier transform of this frequency series. 
+        -------
+        TimeSeries:
+            The inverse fourier transform of this frequency series.
         """
         from pycbc.fft import ifft
         from pycbc.types import TimeSeries, real_same_precision_as
@@ -463,7 +466,7 @@ class FrequencySeries(Array):
         # add 0.5 to round integer
         tlen  = int(1.0 / self.delta_f / delta_t + 0.5)
         flen = int(tlen / 2 + 1)
-        
+
         if flen < len(self):
             raise ValueError("The value of delta_t (%s) would be "
                              "undersampled. Maximum delta_t "
@@ -471,11 +474,11 @@ class FrequencySeries(Array):
         if not delta_t:
             tmp = self
         else:
-            tmp = FrequencySeries(zeros(flen, dtype=self.dtype), 
+            tmp = FrequencySeries(zeros(flen, dtype=self.dtype),
                              delta_f=self.delta_f, epoch=self.epoch)
             tmp[:len(self)] = self[:]
-        
-        f = TimeSeries(zeros(tlen, 
+
+        f = TimeSeries(zeros(tlen,
                            dtype=real_same_precision_as(self)),
                            delta_t=delta_t)
         ifft(tmp, f)
@@ -485,11 +488,11 @@ class FrequencySeries(Array):
     def cyclic_time_shift(self, dt):
         """Shift the data and timestamps by a given number of seconds
 
-        Shift the data and timestamps in the time domain a given number of 
-        seconds. To just change the time stamps, do ts.start_time += dt. 
+        Shift the data and timestamps in the time domain a given number of
+        seconds. To just change the time stamps, do ts.start_time += dt.
         The time shift may be smaller than the intrinsic sample rate of the data.
         Note that data will be cycliclly rotated, so if you shift by 2
-        seconds, the final 2 seconds of your data will now be at the 
+        seconds, the final 2 seconds of your data will now be at the
         beginning of the data set.
 
         Parameters
@@ -544,7 +547,7 @@ class FrequencySeries(Array):
                 other.resize(int(other.sample_rate * self.duration))
 
             other = other.to_frequencyseries()
-        
+
         if len(other) != len(self):
             other = other.copy()
             other.resize(len(self))
@@ -567,7 +570,7 @@ def load_frequencyseries(path, group=None):
     path: string
         source file path. Must end with either .npy or .txt.
 
-    group: string 
+    group: string
         Additional name for internal storage use. Ex. hdf storage uses
         this as the key value.
 
@@ -575,10 +578,10 @@ def load_frequencyseries(path, group=None):
     ------
     ValueError
         If path does not end in .npy or .txt.
-    """    
+    """
     ext = _os.path.splitext(path)[1]
     if ext == '.npy':
-        data = _numpy.load(path)    
+        data = _numpy.load(path)
     elif ext == '.txt':
         data = _numpy.loadtxt(path)
     elif ext == '.hdf':
@@ -586,12 +589,12 @@ def load_frequencyseries(path, group=None):
         f = h5py.File(path, 'r')
         data = f[key][:]
         series = FrequencySeries(data, delta_f=f[key].attrs['delta_f'],
-                                       epoch=f[key].attrs['epoch']) 
+                                       epoch=f[key].attrs['epoch'])
         f.close()
         return series
     else:
         raise ValueError('Path must end with .npy, .hdf, or .txt')
-        
+
     if data.ndim == 2:
         delta_f = (data[-1][0] - data[0][0]) / (len(data)-1)
         epoch = _lal.LIGOTimeGPS(data[0][0])

--- a/pycbc/types/timeseries.py
+++ b/pycbc/types/timeseries.py
@@ -519,7 +519,7 @@ class TimeSeries(Array):
                 invpsd = 1. / self.filter_psd(self.duration/32, self.delta_f, 0)
             lindex = int((time - window - self.start_time) / self.delta_t)
             rindex = lindex + int(2 * window / self.delta_t)
-            lindex = lindex if lindex >=0 else 0
+            lindex = lindex if lindex >= 0 else 0
             rindex = rindex if rindex <= len(self) else len(self)
             return gate_and_paint(data, lindex, rindex, invpsd, copy=False)
         elif method == 'hard':
@@ -830,7 +830,7 @@ class TimeSeries(Array):
 
     def to_timeseries(self):
         """ Return time series"""
-        pass
+        return self
 
     @_nocomplex
     def to_frequencyseries(self, delta_f=None):

--- a/pycbc/types/timeseries.py
+++ b/pycbc/types/timeseries.py
@@ -824,6 +824,7 @@ class TimeSeries(Array):
             raise ValueError('Path must end with .npy, .txt or .hdf')
 
     def to_timeseries(self):
+        """ Return time series"""
         pass
 
     @_nocomplex

--- a/pycbc/types/timeseries.py
+++ b/pycbc/types/timeseries.py
@@ -478,7 +478,7 @@ class TimeSeries(Array):
                            seg_stride=seg_stride,
                            **kwds)
 
-    def gate(self, time, window=0.25, method='taper', inplace=False,
+    def gate(self, time, window=0.25, method='taper', copy=True,
              taper_width=0.25, invpsd=None):
         """ Gate out portion of time series
 
@@ -490,8 +490,8 @@ class TimeSeries(Array):
             Half-length in seconds to remove data around gate time.
         method: str
             Method to apply gate, options are 'hard', 'taper', and 'paint'.
-        inplace: bool
-            If True, do operations inplace to this time series, else return
+        copy: bool
+            If False, do operations inplace to this time series, else return
             new time series.
         taper_width: float
             Length of tapering region on either side of excized data. Only
@@ -505,7 +505,7 @@ class TimeSeries(Array):
         data: pycbc.types.TimeSeris
             Gated time series
         """
-        data = self if inplace else self.copy()
+        data = self.copy() if copy else self
         if method == 'taper':
             from pycbc.strain import gate_data
             return gate_data(data, [(time, window, taper_width)])


### PR DESCRIPTION
This should make it easier to select gate method in higher level codes in the future (i.e. pycbc inspiral / pycbc live).  This PR also addes a dummy to time/frequency series so that functions can be made generic of accepting a time or frequency series where possible. 

Depends on #3371 

'paint' method
![download (4)](https://user-images.githubusercontent.com/2206534/87246855-2bd49000-c450-11ea-8b25-e4ea0619a5f3.png)

'taper' method
![download (5)](https://user-images.githubusercontent.com/2206534/87246856-2d05bd00-c450-11ea-9cac-b98d6671c629.png)

'hard' method
![download (6)](https://user-images.githubusercontent.com/2206534/87246857-2e36ea00-c450-11ea-8078-9f5d242445fb.png)
