### PR TITLE
minor fixes to enable ultranest using MPI

### DIFF
--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -27,7 +27,7 @@ import numpy
 
 import pycbc
 from pycbc import (distributions, transforms, fft,
-                   opt, scheme)
+                   opt, scheme, pool)
 from pycbc.waveform import generator
 
 from pycbc import __version__
@@ -80,9 +80,8 @@ opts = parser.parse_args()
 
 # setup log
 # If we're running in MPI mode, only allow the parent to print
-if opts.use_mpi:
-    from mpi4py import MPI
-    rank = MPI.COMM_WORLD.Get_rank()
+use_mpi, size, rank = pycbc.pool.use_mpi(opts.use_mpi, log=False)
+if use_mpi:
     opts.verbose &= rank == 0
 pycbc.init_logging(opts.verbose)
 
@@ -122,7 +121,7 @@ with ctx:
                 cp.get('sampler', 'checkpoint-signal')))
         # create an empty output file to keep condor happy
         open(opts.output_file, 'a').close()
-    
+
     logging.info("Setting up model")
 
     # construct class that will return the natural logarithm of likelihood
@@ -141,7 +140,7 @@ with ctx:
     # Run the sampler
     sampler.run()
 
-    # Finalize the output 
+    # Finalize the output
     sampler.finalize()
 
 if condor_ckpt:

--- a/pycbc/inference/sampler/base_cube.py
+++ b/pycbc/inference/sampler/base_cube.py
@@ -38,21 +38,16 @@ def call_global_logprior(cube):
     return models._global_instance.prior_transform(cube)
 
 
-def setup_calls(model, nprocesses=1,
-                loglikelihood_function=None, copy_prior=False):
+def setup_calls(model, loglikelihood_function=None, copy_prior=False):
     """ Configure calls for MPI support
     """
     model_call = CubeModel(model, loglikelihood_function,
                            copy_prior=copy_prior)
-    if nprocesses > 1:
-        # these are used to help paralleize over multiple cores / MPI
-        models._global_instance = model_call
-        log_likelihood_call = call_global_loglikelihood
-        prior_call = call_global_logprior
-    else:
-        prior_call = model_call.prior_transform
-        log_likelihood_call = model_call.log_likelihood
 
+    # these are used to help paralleize over multiple cores / MPI
+    models._global_instance = model_call
+    log_likelihood_call = call_global_loglikelihood
+    prior_call = call_global_logprior
     return log_likelihood_call, prior_call
 
 

--- a/pycbc/inference/sampler/dynesty.py
+++ b/pycbc/inference/sampler/dynesty.py
@@ -80,7 +80,6 @@ class DynestySampler(BaseSampler):
         self.model = model
         log_likelihood_call, prior_call = setup_calls(
             model,
-            nprocesses=nprocesses,
             loglikelihood_function=loglikelihood_function)
         # Set up the pool
         self.pool = choose_pool(mpi=use_mpi, processes=nprocesses)
@@ -97,7 +96,7 @@ class DynestySampler(BaseSampler):
         if self.checkpoint_time_interval:
             self.run_with_checkpoint = True
             if self.maxcall is None:
-                self.maxcall = 5000 * nprocesses
+                self.maxcall = 5000 * pool.size
             logging.info("Checkpointing enabled, will verify every %s calls"
                          " and try to checkpoint every %s seconds",
                          self.maxcall, self.checkpoint_time_interval)

--- a/pycbc/inference/sampler/dynesty.py
+++ b/pycbc/inference/sampler/dynesty.py
@@ -96,7 +96,7 @@ class DynestySampler(BaseSampler):
         if self.checkpoint_time_interval:
             self.run_with_checkpoint = True
             if self.maxcall is None:
-                self.maxcall = 5000 * pool.size
+                self.maxcall = 5000 * self.pool.size
             logging.info("Checkpointing enabled, will verify every %s calls"
                          " and try to checkpoint every %s seconds",
                          self.maxcall, self.checkpoint_time_interval)

--- a/pycbc/inference/sampler/emcee.py
+++ b/pycbc/inference/sampler/emcee.py
@@ -79,14 +79,10 @@ class EmceeEnsembleSampler(EnsembleSupport, BaseMCMC, BaseSampler):
             logpost_function = 'logposterior'
         model_call = models.CallModel(model, logpost_function)
 
-        # Set up the pool
-        if nprocesses > 1:
-            # these are used to help paralleize over multiple cores / MPI
-            models._global_instance = model_call
-            model_call = models._call_global_model
+        # these are used to help paralleize over multiple cores / MPI
+        models._global_instance = model_call
+        model_call = models._call_global_model
         pool = choose_pool(mpi=use_mpi, processes=nprocesses)
-        if pool is not None:
-            pool.count = nprocesses
 
         # set up emcee
         self.nwalkers = nwalkers

--- a/pycbc/inference/sampler/emcee_pt.py
+++ b/pycbc/inference/sampler/emcee_pt.py
@@ -83,24 +83,17 @@ class EmceePTSampler(MultiTemperedSupport, EnsembleSupport, BaseMCMC,
         model_call = models.CallModel(model, loglikelihood_function,
                                       return_all_stats=False)
 
-        # Set up the pool
-        if nprocesses > 1:
-            # these are used to help paralleize over multiple cores / MPI
-            models._global_instance = model_call
-            model_call = models._call_global_model
-            prior_call = models._call_global_model_logprior
-        else:
-            prior_call = models.CallModel(model, 'logprior',
-                                          return_all_stats=False)
-        pool = choose_pool(mpi=use_mpi, processes=nprocesses)
-        if pool is not None:
-            pool.count = nprocesses
-        self.pool = pool
+        # these are used to help paralleize over multiple cores / MPI
+        models._global_instance = model_call
+        model_call = models._call_global_model
+        prior_call = models._call_global_model_logprior
+        self.pool = choose_pool(mpi=use_mpi, processes=nprocesses)
+
         # construct the sampler: PTSampler needs the likelihood and prior
         # functions separately
         ndim = len(model.variable_params)
         self._sampler = emcee.PTSampler(ntemps, nwalkers, ndim,
-                                        model_call, prior_call, pool=pool,
+                                        model_call, prior_call, pool=self.pool,
                                         betas=betas)
         self.nwalkers = nwalkers
         self._ntemps = ntemps

--- a/pycbc/inference/sampler/epsie.py
+++ b/pycbc/inference/sampler/epsie.py
@@ -105,14 +105,14 @@ class EpsieSampler(MultiTemperedSupport, BaseMCMC, BaseSampler):
         self.model = model
         # create a wrapper for calling the model
         model_call = _EpsieCallModel(model, loglikelihood_function)
+
         # Set up the pool
-        if nprocesses > 1:
+        pool = choose_pool(mpi=use_mpi, processes=nprocesses)
+        if pool.size > 1:
             # these are used to help paralleize over multiple cores / MPI
             models._global_instance = model_call
             model_call = models._call_global_model
-        pool = choose_pool(mpi=use_mpi, processes=nprocesses)
-        if pool is not None:
-            pool.count = nprocesses
+
         # initialize the sampler
         self._sampler = ParallelTemperedSampler(
             model.sampling_params, model_call, nchains, betas=betas,

--- a/pycbc/inference/sampler/epsie.py
+++ b/pycbc/inference/sampler/epsie.py
@@ -106,12 +106,12 @@ class EpsieSampler(MultiTemperedSupport, BaseMCMC, BaseSampler):
         # create a wrapper for calling the model
         model_call = _EpsieCallModel(model, loglikelihood_function)
 
+        # these are used to help paralleize over multiple cores / MPI
+        models._global_instance = model_call
+        model_call = models._call_global_model
+
         # Set up the pool
         pool = choose_pool(mpi=use_mpi, processes=nprocesses)
-        if pool.size > 1:
-            # these are used to help paralleize over multiple cores / MPI
-            models._global_instance = model_call
-            model_call = models._call_global_model
 
         # initialize the sampler
         self._sampler = ParallelTemperedSampler(

--- a/pycbc/inference/sampler/ultranest.py
+++ b/pycbc/inference/sampler/ultranest.py
@@ -103,7 +103,7 @@ class UltranestSampler(BaseSampler):
         self.result = None
         self.kwargs = kwargs  # Keywords for the run method of ultranest
 
-        do_mpi, size, rank = use_mpi()
+        do_mpi, _, rank = use_mpi()
         self.main = (not do_mpi) or (rank == 0)
 
     def run(self):
@@ -152,7 +152,7 @@ class UltranestSampler(BaseSampler):
                 skeys[opt_name] = opts[opt_name](value)
         inst = cls(model, **skeys)
 
-        do_mpi, size, rank = use_mpi()
+        do_mpi, _, rank = use_mpi()
         if not do_mpi or (rank == 0):
             setup_output(inst, output_file)
         return inst

--- a/pycbc/pool.py
+++ b/pycbc/pool.py
@@ -155,12 +155,12 @@ def choose_pool(processes, mpi=False):
             atexit.register(pool.close)
 
             if processes:
-                logging.info('NOTE: that for MPI process size determined by MPI'
-                             ' launch size, not the processes argument')
+                logging.info('NOTE: that for MPI process size determined by '
+                             'MPI launch size, not the processes argument')
 
             if do_mpi and not mpi:
-                logging.info('NOTE: using MPI as this process was launched under'
-                             'MPI')
+                logging.info('NOTE: using MPI as this process was launched'
+                             'under MPI')
         except ImportError:
             raise ValueError("Failed to start up an MPI pool, "
                              "install mpi4py / schwimmbad")

--- a/pycbc/pool.py
+++ b/pycbc/pool.py
@@ -123,6 +123,8 @@ class SinglePool(object):
         return [f(a) for a in items]
 
 def use_mpi(require_mpi=False):
+    """ Get whether MPI is enabled and if so the current size and rank
+    """
     use_mpi = False
     size = rank = 0
     try:
@@ -139,6 +141,8 @@ def use_mpi(require_mpi=False):
     return use_mpi, size, rank
 
 def choose_pool(processes, mpi=False):
+    """ Get processing pool
+    """
     do_mpi, size, rank = use_mpi(require_mpi=mpi)
     if do_mpi:
         try:
@@ -164,5 +168,7 @@ def choose_pool(processes, mpi=False):
         pool = BroadcastPool(processes)
 
     pool.size = processes
+    if size:
+        pool.size = size
     return pool
 

--- a/pycbc/pool.py
+++ b/pycbc/pool.py
@@ -131,7 +131,7 @@ def choose_pool(processes, mpi=False):
             atexit.register(pool.close)
         except ImportError:
             raise ValueError("Failed to start up an MPI pool, "
-                             "install mpi4py / schwimmbadd")
+                             "install mpi4py / schwimmbad")
     elif processes == 1:
         pool = SinglePool()
     else:
@@ -139,5 +139,4 @@ def choose_pool(processes, mpi=False):
 
     pool.size = processes
     return pool
-
 

--- a/pycbc/pool.py
+++ b/pycbc/pool.py
@@ -132,7 +132,8 @@ def use_mpi(require_mpi=False, log=True):
         comm = MPI.COMM_WORLD
         size = comm.Get_size()
         rank = comm.Get_rank()
-        use_mpi = True
+        if size > 1:
+            use_mpi = True
         if log:
             logging.info('Running under mpi with size: %s, rank: %s',
                          size, rank)

--- a/pycbc/pool.py
+++ b/pycbc/pool.py
@@ -122,7 +122,7 @@ class SinglePool(object):
     def map(self, f, items):
         return [f(a) for a in items]
 
-def use_mpi(require_mpi=False):
+def use_mpi(require_mpi=False, log=True):
     """ Get whether MPI is enabled and if so the current size and rank
     """
     use_mpi = False
@@ -133,7 +133,9 @@ def use_mpi(require_mpi=False):
         size = comm.Get_size()
         rank = comm.Get_rank()
         use_mpi = True
-        logging.info('Running under mpi with size: %s, rank: %s', size, rank)
+        if log:
+            logging.info('Running under mpi with size: %s, rank: %s',
+                         size, rank)
     except ImportError as e:
         if require_mpi:
             print(e)

--- a/pycbc/pool.py
+++ b/pycbc/pool.py
@@ -7,6 +7,7 @@ from multiprocessing import TimeoutError
 import types
 import signal
 import atexit
+import logging
 
 def is_main_process():
     """ Check if this is the main control process and may handle one time tasks
@@ -121,14 +122,39 @@ class SinglePool(object):
     def map(self, f, items):
         return [f(a) for a in items]
 
+def use_mpi(require_mpi=False):
+    use_mpi = False
+    size = rank = 0
+    try:
+        from mpi4py import MPI
+        comm = MPI.COMM_WORLD
+        size = comm.Get_size()
+        rank = comm.Get_rank()
+        use_mpi = True
+        logging.info('Running under mpi with size: %s, rank: %s', size, rank)
+    except ImportError as e:
+        if require_mpi:
+            print(e)
+            raise ValueError("Failed to load mpi, ensure mpi4py is installed")
+    return use_mpi, size, rank
+
 def choose_pool(processes, mpi=False):
-    if mpi:
+    do_mpi, size, rank = use_mpi(require_mpi=mpi)
+    if do_mpi:
         try:
             import schwimmbad
-            pool = schwimmbad.choose_pool(mpi=mpi,
-                                          processes=processes)
+            pool = schwimmbad.choose_pool(mpi=do_mpi,
+                                          processes=(size - 1))
             pool.broadcast = types.MethodType(_dummy_broadcast, pool)
             atexit.register(pool.close)
+
+            if processes:
+                logging.info('NOTE: that for MPI process size determined by MPI'
+                             ' launch size, not the processes argument')
+
+            if do_mpi and not mpi:
+                logging.info('NOTE: using MPI as this process was launched under'
+                             'MPI')
         except ImportError:
             raise ValueError("Failed to start up an MPI pool, "
                              "install mpi4py / schwimmbad")


### PR DESCRIPTION
This puts in place the minor changes needed to run ultranest with pycbc inference under MPI. 

Requires #3373 