### PR TITLE
Make sure sampling parameters keep the same order

### DIFF
--- a/pycbc/inference/models/base.py
+++ b/pycbc/inference/models/base.py
@@ -120,6 +120,8 @@ class SamplingTransforms(object):
                                 if arg not in replace_parameters]
         # add the sampling parameters
         self.sampling_params += sampling_params
+        # sort to make sure we have a consistent order
+        self.sampling_params.sort()
         self.sampling_transforms = sampling_transforms
 
     def logjacobian(self, **params):
@@ -272,7 +274,7 @@ def read_sampling_params_from_config(cp, section_group=None,
         map_args = cp.get(section, args)
         sampling_params.update(set(map(str.strip, map_args.split(','))))
         replaced_params.update(set(map(str.strip, args.split(','))))
-    return list(sampling_params), list(replaced_params)
+    return sorted(sampling_params), sorted(replaced_params)
 
 
 #


### PR DESCRIPTION
This fixes a bug when using sampling parameters with MPI. When the parameters are loaded from the config file, they are initialized as a set, then converted to a list. However, `set` doesn't preserve order. This means that different slave nodes when running under MPI will think the sampler is giving it parameters in a different order than it is. This fixes this by sorting the sampling parameters (both when they are loaded, and when they are saved to the model's sampling_params attribute... just to be sure). This only would of effected emcee and emcee_pt, and only when running on MPI. Apparently this wasn't an issue in python 2.7, but is in 3.XX.