### PR TITLE
Fixed edge-case bug in pycbc_banksim_combine_banks.

### DIFF
--- a/bin/pycbc_banksim_combine_banks
+++ b/bin/pycbc_banksim_combine_banks
@@ -54,9 +54,15 @@ maxmatch = []
 for fil in options.input_files:
     matches.append(loadtxt(fil, dtype=dtypef))
 
-indices = array(matches, dtype=dtypef)['match'].argmax(0)
-for i, j in enumerate(indices):
-    maxmatch.append(matches[j][i])
+# It is possible for the input files to only contain a single injection
+# if the user has split the injections many times.
+if array(matches, dtype=dtypef)['match'].ndim == 1:
+    index = array(matches, dtype=dtypef)['match'].argmax()
+    maxmatch.append(matches[index])
+else:
+    indices = array(matches, dtype=dtypef)['match'].argmax(0)
+    for i, j in enumerate(indices):
+        maxmatch.append(matches[j][i])
 
 maxmatch=array(maxmatch, dtype=dtypef)
 savetxt(options.output_file, maxmatch, 


### PR DESCRIPTION
This PR is to fix an edge-case bug in pycbc_banksim_combine_banks. If the user splits the injections so many times that each BANKSIM file only contains a single injection, then the current method to find the maximum match across multiple banks fails with the error:
```
Traceback (most recent call last):
File "pycbc_banksim_combine_banks", line 58, in <module>
    for i, j in enumerate(indices):
  TypeError: 'numpy.int64' object is not iterable
```
To fix this we can check the dimensions of the `match` array and if it is only 1-dimensional we slightly alter how the `maxmatch` array is filled. If the `match` array is n-dimensional (for n > 1) then we do the same thing the code originally did.

___

The files used to test this edge case (both input and output) can be found at:
https://ldas-jobs.ligo.caltech.edu/~michael.patel/banksim_tests/single_test/

Visually this is represented as:
![single_dim](https://user-images.githubusercontent.com/46542594/87484569-81ea3480-c604-11ea-80a9-3cc7131f053c.png)

___

The files used to test the normal case (both input and output) can be found at:
https://ldas-jobs.ligo.caltech.edu/~michael.patel/banksim_tests/multi_test/

Visually this is represented as:
![multi_dim](https://user-images.githubusercontent.com/46542594/87486390-3a19dc00-c609-11ea-8d4c-a912095f59cd.png)

I also verified that the normal case was not altered from the latest realease of PyCBC (v1.16.4). An output created using the `/cvmfs` release is also in the directory above, and is identical to the output created by the revised code (as it should be 😄 ).
