### PR TITLE
Silence warnings from child nodes in MPI

### DIFF
--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -82,8 +82,6 @@ opts = parser.parse_args()
 # setup log
 # If we're running in MPI mode, only allow the parent to print
 use_mpi, size, rank = pycbc.pool.use_mpi(opts.use_mpi, log=False)
-if use_mpi:
-    opts.verbose &= rank == 0
 pycbc.init_logging(opts.verbose)
 if use_mpi and rank != 0:
     logging.disable(logging.WARNING)

--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -85,6 +85,8 @@ use_mpi, size, rank = pycbc.pool.use_mpi(opts.use_mpi, log=False)
 if use_mpi:
     opts.verbose &= rank == 0
 pycbc.init_logging(opts.verbose)
+if use_mpi and rank != 0:
+    logging.disable(logging.WARNING)
 
 # verify options are sane
 fft.verify_fft_options(opts, parser)


### PR DESCRIPTION
Stops child nodes from printing logging warnings to stdout, so you don't get the same warning repeated a bunch of times when running `pycbc_inference` with MPI.