### PR TITLE
open up nested sampling to complicated / arbitrary distributions with fixed sample distribution

### DIFF
--- a/pycbc/conversions.py
+++ b/pycbc/conversions.py
@@ -663,7 +663,7 @@ def distance_from_chirp_distance_mchirp(chirp_distance, mchirp, ref_mass=1.4):
 
 
 _detector_cache = {}
-def det_tc(detector_name, ra, dec, tc, ref_frame='geocentric'):
+def det_tc(detector_name, ra, dec, tc, ref_frame='geocentric', relative=False):
     """Returns the coalescence time of a signal in the given detector.
 
     Parameters
@@ -685,16 +685,20 @@ def det_tc(detector_name, ra, dec, tc, ref_frame='geocentric'):
     float :
         The GPS time of the coalescence in detector `detector_name`.
     """
+    ref_time = tc
+    if relative:
+        tc = 0
+
     if ref_frame == detector_name:
         return tc
     if detector_name not in _detector_cache:
         _detector_cache[detector_name] = Detector(detector_name)
     detector = _detector_cache[detector_name]
     if ref_frame == 'geocentric':
-        return tc + detector.time_delay_from_earth_center(ra, dec, tc)
+        return tc + detector.time_delay_from_earth_center(ra, dec, ref_time)
     else:
         other = Detector(ref_frame)
-        return tc + detector.time_delay_from_detector(other, ra, dec, tc)
+        return tc + detector.time_delay_from_detector(other, ra, dec, ref_time)
 
 def optimal_orientation_from_detector(detector_name, tc):
     """ Low-level function to be called from _optimal_dec_from_detector

--- a/pycbc/distributions/__init__.py
+++ b/pycbc/distributions/__init__.py
@@ -34,6 +34,7 @@ from pycbc.distributions.spins import IndependentChiPChiEff
 from pycbc.distributions.qnm import UniformF0Tau
 from pycbc.distributions.joint import JointDistribution
 from pycbc.distributions.external import External
+from pycbc.distributions.fixedsamples import FixedSamples
 
 # a dict of all available distributions
 distribs = {
@@ -51,7 +52,8 @@ distribs = {
     UniformSky.name : UniformSky,
     UniformLog10.name : UniformLog10,
     UniformF0Tau.name : UniformF0Tau,
-    External.name: External
+    External.name: External,
+    FixedSamples.name: FixedSamples
 }
 
 def read_distributions_from_config(cp, section="prior"):

--- a/pycbc/distributions/fixedsamples.py
+++ b/pycbc/distributions/fixedsamples.py
@@ -1,0 +1,134 @@
+# Copyright (C) 2020 Alexander Nitz
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+"""
+This modules provides classes for evaluating distributions based on a fixed
+set of points
+"""
+import logging, numpy
+import numpy.random
+from pycbc import VARARGS_DELIM
+
+class FixedSamples(object):
+
+    name = "fixed_samples"
+
+    def __init__(self, params, samples):
+        self.params = params
+        self.samples = samples
+
+        self.p1 = self.samples[params[0]]
+        self.frac = len(self.p1)**0.5 / len(self.p1)
+        self.sort = self.p1.argsort()
+        self.p1sorted = self.p1[self.sort]
+
+        assert(len(numpy.unique(self.p1)) == len(self.p1))
+
+        if len(params) > 2:
+            raise ValueError("Only one or two parameters supported "
+                             "for fixed sample distribution")
+
+    def rvs(self, size=1, **kwds):
+        "Draw random value"
+        i = numpy.random.randint(0, high=len(p1), size=size)
+        return {p: self.samples[p][i] for p in self.params}
+
+    def cdfinv(self, **original):
+        new = {}
+
+        #First dimension
+        u1 = original[self.params[0]]
+        i1 = int(round(u1 * len(self.p1)))
+        if i1 >= len(self.p1):
+            i1 = len(self.p1) - 1
+        if i1 < 0:
+            i1 = 0
+        new[self.params[0]] = p1v = self.p1sorted[i1]
+        if len(self.params) == 1:
+            return new
+
+        # possible second dimension, probably shouldn't
+        # do more dimensions than this
+        u2 = original[self.params[1]]
+        l = numpy.searchsorted(self.p1sorted, p1v * (1 - self.frac))
+        r = numpy.searchsorted(self.p1sorted, p1v * (1 + self.frac))
+        if r < l:
+            l, r = r, l
+
+        region = numpy.array(self.sort[l:r], ndmin=1)
+        p2 = self.samples[self.params[1]]
+        p2part = numpy.array(p2[region], ndmin=1)
+        l = p2part.argsort()
+        p2part = numpy.array(p2part[l], ndmin=1)
+
+        i2 = int(round(u2 * len(p2part)))
+        if i2 >= len(p2part):
+            i2 = len(p2part) - 1
+        if i2 < 0:
+            i2 = 0
+        new[self.params[1]] = p2part[i2]
+
+        p1part = numpy.array(self.p1[region[l]], ndmin=1)
+        new[self.params[0]] = p1part[i2]
+        return new
+
+    def apply_boundary_conditions(self, **params):
+        return params
+
+    def __call__(self, **kwds):
+        raise NotImplementedError("Fixed Sample distributions doesn't support"
+                                  "for evaluating a PDF")
+
+    @classmethod
+    def from_config(cls, cp, section, tag):
+        from pycbc.distributions import read_distributions_from_config
+        from pycbc.transforms import (read_transforms_from_config,
+                                      apply_transforms, BaseTransform)
+        from pycbc.transforms import transforms as global_transforms
+
+        params = tag.split(VARARGS_DELIM)
+        subname = cp.get_opt_tag(section, 'subname', tag)
+        size = cp.get_opt_tag(section, 'sample-size', tag)
+
+        distsec = '{}_sample'.format(subname)
+        dist = read_distributions_from_config(cp, section=distsec)
+        if len(dist) > 1:
+            raise ValueError("Fixed sample distrubtion only supports a single"
+                             " distribution to sample from.")
+
+        logging.info('Drawing samples for fixed sample distribution:{}'.format(params))
+        samples = dist[0].rvs(size=int(float(size)))
+        samples = {p: samples[p] for p in samples.dtype.names}
+
+        transec = '{}_transform'.format(subname)
+        trans = read_transforms_from_config(cp, section=transec)
+        if len(trans) > 0:
+            trans = trans[0]
+            samples = apply_transforms(samples, [trans])
+            p1 = samples[params[0]]
+            class Thook(BaseTransform):
+                name = subname
+                _inputs = trans.outputs
+                _outputs = trans.inputs
+                p1name = params[0]
+                sort = p1.argsort()
+                p1sorted = p1[sort]
+                def transform(self, maps):
+                    idx = numpy.searchsorted(self.p1sorted, maps[self.p1name])
+                    out = {p: samples[p][self.sort[idx]] for p in self.outputs}
+                    return self.format_output(maps, out)
+            global_transforms[Thook.name] = Thook
+        return cls(params, samples)
+
+__all__ = ['FixedSamples']

--- a/pycbc/distributions/fixedsamples.py
+++ b/pycbc/distributions/fixedsamples.py
@@ -109,8 +109,8 @@ class FixedSamples(object):
         return params
 
     def __call__(self, **kwds):
-        raise NotImplementedError("Fixed Sample distributions doesn't support"
-                                  "for evaluating a PDF")
+        """ Dummy function, not the actual pdf """
+        return 0
 
     @classmethod
     def from_config(cls, cp, section, tag):

--- a/pycbc/inference/sampler/base_cube.py
+++ b/pycbc/inference/sampler/base_cube.py
@@ -75,8 +75,8 @@ class CubeModel(object):
         """
         params = dict(zip(self.model.sampling_params, cube))
         self.model.update(**params)
-        #if self.model.logprior == -numpy.inf:
-        #    return -numpy.inf
+        if self.model.logprior == -numpy.inf:
+            return -numpy.inf
         return getattr(self.model, self.loglikelihood_function)
 
     def prior_transform(self, cube):

--- a/pycbc/inference/sampler/base_cube.py
+++ b/pycbc/inference/sampler/base_cube.py
@@ -75,8 +75,8 @@ class CubeModel(object):
         """
         params = dict(zip(self.model.sampling_params, cube))
         self.model.update(**params)
-        if self.model.logprior == -numpy.inf:
-            return -numpy.inf
+        #if self.model.logprior == -numpy.inf:
+        #    return -numpy.inf
         return getattr(self.model, self.loglikelihood_function)
 
     def prior_transform(self, cube):

--- a/pycbc/transforms.py
+++ b/pycbc/transforms.py
@@ -1195,7 +1195,7 @@ class LambdaFromMultipleTOVFiles(BaseTransform):
     """
 
     name = 'lambda_from_multiple_tov_files'
-    
+
     def __init__(self, mass_param, lambda_param, map_file, distance=None,
                  file_columns=None):
         self._map_file = map_file
@@ -1205,10 +1205,10 @@ class LambdaFromMultipleTOVFiles(BaseTransform):
         self._inputs = [mass_param, 'eos', 'distance']
         self._outputs = [lambda_param]
         # create a dictionary of the EOS files from the map_file
-        self._eos_files = {} 
+        self._eos_files = {}
         with open(self._map_file, 'r') as fp:
             for line in fp:
-                fname = line.rstrip('\n') 
+                fname = line.rstrip('\n')
                 eosidx = int(os.path.basename(fname).split('.')[0])
                 self._eos_files[eosidx] = os.path.abspath(fname)
         # create an eos cache for fast load later
@@ -1217,8 +1217,8 @@ class LambdaFromMultipleTOVFiles(BaseTransform):
             file_columns = ('radius', 'mass', 'lambda')
         self._file_columns = file_columns
         super(LambdaFromMultipleTOVFiles, self).__init__()
-    
-    
+
+
     @property
     def mass_param(self):
         """Returns the input mass parameter."""
@@ -1852,7 +1852,7 @@ class ChiPToCartesianSpin(CartesianSpinToChiP):
 
 class Exponent(Log):
     """Applies an exponent transform to an `inputvar` parameter.
-    
+
     This is the inverse of the log transform.
 
     Parameters
@@ -2053,7 +2053,7 @@ common_cbc_inverse_transforms.extend([
     CartesianToSpherical(parameters.spin2x, parameters.spin2y,
                          parameters.spin2z, parameters.spin2_a,
                          parameters.spin2_azimuthal, parameters.spin2_polar)])
-    
+
 common_cbc_transforms = common_cbc_forward_transforms + \
                         common_cbc_inverse_transforms
 

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -33,7 +33,7 @@ from pycbc.workflow import WorkflowConfigParser
 EXCLUDE_DIST_NAMES = ["fromfile", "arbitrary", "external",
                       "uniform_solidangle", "uniform_sky",
                       "independent_chip_chieff",
-                      "uniform_f0_tau"]
+                      "uniform_f0_tau", "fixed_samples"]
 
 # tests only need to happen on the CPU
 parse_args_cpu_only("Distributions")


### PR DESCRIPTION
### Concept

This adds a new distribution "FixedSamples" which allows for arbitrary and complicated distributions to be used within nested sampling in an approximate way. It is likely suitable for parameter estimation in many cases. Depends on #3315 

The idea is to draw a large number of points from any standard prior (even the arbitrary one) (say 10^6-10^9). These points can be transformed as one likes (using anything available for waveform transforms, including custom). The inverse CDF function is then done numerically by picking one of these points, so it can be used within nested sampling. This requires that a sufficient number of points is drawn from the prior for the parameters in question to adequately represent the space. 

### Example 
Example configuration file. In this example instead of sampling in ra and dec, we use the hanford time relative to geocentric, and the time delay between Hanford and Livingston. However, the prior is still defined in terms of ra and dec to give us an isotropic prior over the sky. 

```
[model]
name = single_template

#; This model precalculates the SNR time series at a fixed rate.
#; If you need a higher time resolution, this may be increased
sample_rate = 32768
low-frequency-cutoff = 30.0

[data]
instruments = H1 L1 V1
analysis-start-time = 1187008482
analysis-end-time = 1187008892
psd-estimation = median
psd-segment-length = 16
psd-segment-stride = 8
psd-inverse-length = 16
pad-data = 8
channel-name = H1:LOSC-STRAIN L1:LOSC-STRAIN V1:LOSC-STRAIN
frame-files = H1:H-H1_LOSC_CLN_4_V1-1187007040-2048.gwf L1:L-L1_LOSC_CLN_4_V1-1187007040-2048.gwf V1:V-V1_LOSC_CLN_4_V1-1187007040-2048.gwf
strain-high-pass = 15
sample-rate = 2048

[sampler]
name = ultranest
#nlive = 200

[sampler-burn_in]
burn-in-test = min_iterations
min-iterations = 100

[variable_params]
; waveform parameters that will vary in MCMC
tc =
distance =
inclination =
dh =
dhl =

[static_params]
; waveform parameters that will not change in MCMC
approximant = TaylorF2
f_lower = 30
mass1 = 1.3757
mass2 = 1.3757
polarization = 0

[prior-tc]
; coalescence time prior
name = uniform
min-tc = 1187008882.4
max-tc = 1187008882.5

[prior-distance]
#; following gives a uniform in volume
name = uniform_radius
min-distance = 10
max-distance = 60

[prior-inclination]
name = sin_angle

[prior-dh+dhl]
name = fixed_samples
subname = mysky        
sample-size = 1e6

[mysky_sample-ra+dec]
name = uniform_sky

[mysky_transform-dh+dhl]
name = custom
inputs = ra, dec
dh = det_tc('H1', ra, dec, 1187008882.0, relative=1)
dhl = det_tc('L1', ra, dec, 1187008882.0, relative=1) - det_tc('H1', ra, dec, 1187008882.0, relative=1)

[waveform_transforms-ra+dec]
name = mysky
```
![single](https://user-images.githubusercontent.com/2206534/87873806-c25eff00-c9c4-11ea-9d3f-92cf0edd13cb.png)


### Possible Future Improvements
(will not be included in this PR and looking for help if this is interesting to people)
 * No PDF function is provided, so it cannot be used outside of nested sampling. It may be possible to use this is other cases however where the prior is flat after transformation (such as effectively is the case for nested sampling), but the hooks are not there at the moment to enable that kind of mode for mcmc samplers. 
* Cannot at the moment return the prior-space parameters. It would be nice to have these in the output file as they may be the parameters you want to measure anyway. One would have to instantiate the distribution directly with the same random state to recover these by hand.
* Support for more than 2 dimensions. At the moment, we only support 1 or 2 dimensions. The current algorithm for providing a an invese cdf would not work well for higher dimensions and the code isn't set up to let you try at the moment.
* Increased accuracy for invcdf. We could had some minimal interpolation scheme to provide an increased accuracy result, however, that might preclude transformations that are not smooth in the original space, but are in the transformed space. At the moment this works fine as we only need smoothness in the transformed space, but interpolation may require smoothness in both simultaneously. 