### PR TITLE
Fixes to live combine trigger fits

### DIFF
--- a/bin/hdfcoinc/pycbc_coinc_hdfinjfind
+++ b/bin/hdfcoinc/pycbc_coinc_hdfinjfind
@@ -251,7 +251,7 @@ for trigger_file, injection_file in zip(args.trigger_files,
 
     if multi_ifo_style:
         for key in f['segments'].keys():
-            if 'foreground' in key or 'coinc' in key:
+            if 'foreground' in key:
                 continue
             if key not in fo:
                 fo.create_group(key)

--- a/bin/hdfcoinc/pycbc_coinc_hdfinjfind
+++ b/bin/hdfcoinc/pycbc_coinc_hdfinjfind
@@ -251,7 +251,7 @@ for trigger_file, injection_file in zip(args.trigger_files,
 
     if multi_ifo_style:
         for key in f['segments'].keys():
-            if 'foreground' in key:
+            if 'foreground' in key or 'coinc' in key:
                 continue
             if key not in fo:
                 fo.create_group(key)

--- a/bin/live/pycbc_live_combine_single_fits
+++ b/bin/live/pycbc_live_combine_single_fits
@@ -58,9 +58,9 @@ for f in files:
     if 'days_since_epoch' in fits_f.attrs:
         analysis_dates += [fits_f.attrs['days_since_epoch']]
     elif 'analysis_date' in fits_f.attrs:
-        analysis_year = int(fits_f.attrs['analysis_date'][:4])
-        analysis_month = int(fits_f.attrs['analysis_date'][5:7])
-        analysis_day = int(fits_f.attrs['analysis_date'][8:10])
+        analysis_year = int(fits_f.attrs['analysis_date'].split('_')[0])
+        analysis_month = int(fits_f.attrs['analysis_date'].split('_')[1])
+        analysis_day = int(fits_f.attrs['analysis_date'].split('_')[2])
         n_since_epoch = (datetime.date(analysis_year,
                                        analysis_month,
                                        analysis_day)

--- a/bin/live/pycbc_live_combine_single_fits
+++ b/bin/live/pycbc_live_combine_single_fits
@@ -68,15 +68,14 @@ for f in files:
                          - datetime.date(2000, 1, 1)).days
         analysis_dates += [n_since_epoch]
     else:
-        # This is the regex string to match a date in format YYYY_MM_DD, 
+        # This is the regex string to match a date in format YYYY_MM_DD,
         # or if MM or DD only have one character
         # FutureWarning: this will become obsolete in the year 3000
         re_string = '([12]\d{3}_(0?[1-9]|1[0-2])_(0?[1-9]|[12]\d|3[01]))'
         m = re.search(re_string, f)
-        date_array = m.group(0).split('_')
-        analysis_year = int(date_array[0])
-        analysis_month = int(date_array[1])
-        analysis_day = int(date_array[2])
+        analysis_year = int(m.group(1))
+        analysis_month = int(m.group(2))
+        analysis_day = int(m.group(3))
         n_since_epoch = (datetime.date(analysis_year, analysis_month,
                                        analysis_day)
                          - datetime.date(2000,1,1)).days

--- a/bin/live/pycbc_live_combine_single_fits
+++ b/bin/live/pycbc_live_combine_single_fits
@@ -58,22 +58,25 @@ for f in files:
     if 'days_since_epoch' in fits_f.attrs:
         analysis_dates += [fits_f.attrs['days_since_epoch']]
     elif 'analysis_date' in fits_f.attrs:
-        analysis_year = int(fits_f.attrs['analysis_date'].split('_')[0])
-        analysis_month = int(fits_f.attrs['analysis_date'].split('_')[1])
-        analysis_day = int(fits_f.attrs['analysis_date'].split('_')[2])
+        date_array = fits_f.attrs['analysis_date'].split('_')
+        analysis_year = int(date_array[0])
+        analysis_month = int(date_array[1])
+        analysis_day = int(date_array[2])
         n_since_epoch = (datetime.date(analysis_year,
                                        analysis_month,
                                        analysis_day)
                          - datetime.date(2000, 1, 1)).days
         analysis_dates += [n_since_epoch]
     else:
-        # This is the regex string to match a date in format YYYY_MM_DD
+        # This is the regex string to match a date in format YYYY_MM_DD, 
+        # or if MM or DD only have one character
         # FutureWarning: this will become obsolete in the year 3000
-        re_string = '([12]\d{3}_(0[1-9]|1[0-2])_(0[1-9]|[12]\d|3[01]))'
+        re_string = '([12]\d{3}_(0?[1-9]|1[0-2])_(0?[1-9]|[12]\d|3[01]))'
         m = re.search(re_string, f)
-        analysis_year = int(m.group(0)[:4])
-        analysis_month = int(m.group(0)[5:7])
-        analysis_day = int(m.group(0)[8:10])
+        date_array = m.group(0).split('_')
+        analysis_year = int(date_array[0])
+        analysis_month = int(date_array[1])
+        analysis_day = int(date_array[2])
         n_since_epoch = (datetime.date(analysis_year, analysis_month,
                                        analysis_day)
                          - datetime.date(2000,1,1)).days

--- a/bin/live/pycbc_live_combine_single_fits
+++ b/bin/live/pycbc_live_combine_single_fits
@@ -68,7 +68,7 @@ for f in files:
                          - datetime.date(2000, 1, 1)).days
         analysis_dates += [n_since_epoch]
     else:
-        # This is the regex string to match a date in format YYYY_MM_DD,
+        # This is the regex string to match a date in format YYYY_MM_DD
         # or if MM or DD only have one character
         # FutureWarning: this will become obsolete in the year 3000
         re_string = '([12]\d{3})_(0?[1-9]|1[0-2])_(0?[1-9]|[12]\d|3[01])'

--- a/bin/live/pycbc_live_combine_single_fits
+++ b/bin/live/pycbc_live_combine_single_fits
@@ -80,8 +80,8 @@ for f in files:
         analysis_dates += [n_since_epoch]
     for ifo in args.ifos:
         if ifo not in fits_f:
-            counts_all[ifo] += [-1 * np.ones_like(counts_all[ifo][-1])]
-            alphas_all[ifo] += [-1 * np.ones_like(alphas_all[ifo][-1])]
+            counts_all[ifo] += [-1 * np.ones(len(bl) - 1)]
+            alphas_all[ifo] += [-1 * np.ones(len(bl) - 1)]
             logging.info(f + " has no " + ifo + " triggers")
         else:
             live_times[ifo] += [fits_f[ifo].attrs['live_time']]
@@ -105,9 +105,9 @@ counts_bin = {ifo: [c for c in zip(*counts_all[ifo])] for ifo in args.ifos}
 alphas_bin = {ifo: [a for a in zip(*alphas_all[ifo])] for ifo in args.ifos}
 
 alphas_out = {ifo : np.zeros(len(alphas_bin[ifo])) for ifo in args.ifos}
-counts_out = {ifo : np.zeros(len(counts_bin[ifo])) for ifo in args.ifos}
+counts_out = {ifo : np.inf * np.ones(len(counts_bin[ifo])) for ifo in args.ifos}
 q05_alphas_out = {ifo : np.zeros(len(alphas_bin[ifo])) for ifo in args.ifos}
-q95_counts_out = {ifo : np.zeros(len(alphas_bin[ifo])) for ifo in args.ifos}
+q95_counts_out = {ifo : np.inf * np.ones(len(alphas_bin[ifo])) for ifo in args.ifos}
 
 fout = h5py.File(args.output_file, 'w')
 fout.attrs['start_date'] = ad[0]
@@ -140,7 +140,9 @@ for ifo in args.ifos:
     for a, c, u, l in zip(alphas_bin[ifo], counts_bin[ifo], bu, bl):
         a = np.array(a)
         c = np.array(c)
-        valid_alpha = np.nonzero(a > 0)
+        valid_alpha = np.logical_and(a > 0, np.isfinite(a))
+        if not any(valid_alpha):
+            continue
         a = a[valid_alpha]
         c = c[valid_alpha]
         invalphan = c / a

--- a/bin/live/pycbc_live_combine_single_fits
+++ b/bin/live/pycbc_live_combine_single_fits
@@ -71,7 +71,7 @@ for f in files:
         # This is the regex string to match a date in format YYYY_MM_DD,
         # or if MM or DD only have one character
         # FutureWarning: this will become obsolete in the year 3000
-        re_string = '([12]\d{3}_(0?[1-9]|1[0-2])_(0?[1-9]|[12]\d|3[01]))'
+        re_string = '([12]\d{3})_(0?[1-9]|1[0-2])_(0?[1-9]|[12]\d|3[01])'
         m = re.search(re_string, f)
         analysis_year = int(m.group(1))
         analysis_month = int(m.group(2))

--- a/bin/live/pycbc_live_single_trigger_fits
+++ b/bin/live/pycbc_live_single_trigger_fits
@@ -19,9 +19,6 @@ from pycbc.events import triggers, trigger_fits as trstats
 from pycbc.io import DictArray
 from pycbc.events import ranking
 import argparse, logging, operator, os, sys, re, h5py
-import matplotlib
-matplotlib.use('agg')
-from matplotlib import pyplot as plt
 
 def inequality_string_to_function(inequ):
     if inequ == "==":
@@ -99,6 +96,8 @@ parser.add_argument("--output-directory", required=True,
 args = parser.parse_args()
 
 pycbc.init_logging(args.verbose)
+
+logging.info("Finding files")
 
 files = [f for f in os.listdir(os.path.join(args.top_directory, args.analysis_date))
          if args.file_identifier in f]
@@ -264,6 +263,7 @@ if cutting_newsnr:
             events[ifo] = events[ifo].select(idx_keep)
         else:
             logging.info("Too many cuts on the data - removed everything from " + ifo)
+            events[ifo] = events[ifo].select(idx_keep)
 
 logging.info("Number of events which meet all criteria:")
 for ifo in args.ifos:


### PR DESCRIPTION
Allow date format to not be YYYY_MM_DD, but (e.g.) YYYY_M_D
fix issue which would break things if no triggers are found in the duration bin

Note that this does not affect the validity of reviews - it is mostly due to dealing with the O2 triggers