### PR TITLE
Fix injfind

### DIFF
--- a/bin/hdfcoinc/pycbc_coinc_hdfinjfind
+++ b/bin/hdfcoinc/pycbc_coinc_hdfinjfind
@@ -251,7 +251,7 @@ for trigger_file, injection_file in zip(args.trigger_files,
 
     if multi_ifo_style:
         for key in f['segments'].keys():
-            if 'foreground' in key:
+            if 'foreground' in key or key is 'coinc':
                 continue
             if key not in fo:
                 fo.create_group(key)

--- a/bin/hdfcoinc/pycbc_coinc_hdfinjfind
+++ b/bin/hdfcoinc/pycbc_coinc_hdfinjfind
@@ -251,7 +251,7 @@ for trigger_file, injection_file in zip(args.trigger_files,
 
     if multi_ifo_style:
         for key in f['segments'].keys():
-            if 'foreground' in key or key is 'coinc':
+            if 'foreground' in key or 'coinc' in key:
                 continue
             if key not in fo:
                 fo.create_group(key)


### PR DESCRIPTION
Fixing hdfinjfind, as the 'segments/coinc' group doesn't have any attributes so we can't copy them over.