### PR TITLE
Allow start file to be specified for mcmc samplers

### DIFF
--- a/pycbc/inference/io/base_hdf.py
+++ b/pycbc/inference/io/base_hdf.py
@@ -661,6 +661,8 @@ class BaseInferenceFile(h5py.File):
         # if list of desired parameters is different, rename
         if set(parameters) != set(self.variable_params):
             other.attrs['variable_params'] = parameters
+        if read_args is None:
+            read_args = {}
         samples = self.read_samples(parameters, **read_args)
         logging.info("Copying {} samples".format(samples.size))
         # if different parameter names are desired, get them from the samples
@@ -671,7 +673,10 @@ class BaseInferenceFile(h5py.File):
             samples = FieldArray.from_kwargs(**arrs)
             other.attrs['variable_params'] = samples.fieldnames
         logging.info("Writing samples")
-        other.write_samples(other, samples, **write_args)
+        if write_args is None:
+            write_args = {}
+        other.write_samples({p: samples[p] for p in samples.fieldnames},
+                            **write_args)
 
     def copy(self, other, ignore=None, parameters=None, parameter_names=None,
              read_args=None, write_args=None):

--- a/pycbc/inference/sampler/base_mcmc.py
+++ b/pycbc/inference/sampler/base_mcmc.py
@@ -454,8 +454,14 @@ class BaseMCMC(object):
     def set_start_from_config(self, cp):
         """Sets the initial state of the sampler from config file
         """
-        init_prior = initial_dist_from_config(cp, self.variable_params)
-        self.set_p0(prior=init_prior)
+        if cp.has_option('sampler', 'start-file'):
+            start_file = cp.get('sampler', 'start-file')
+            logging.info("Using file %s for initial positions", start_file)
+            init_prior = None
+        else:
+            start_file = None
+            init_prior = initial_dist_from_config(cp, self.variable_params)
+        self.set_p0(samples_file=start_file, prior=init_prior)
 
     def resume_from_checkpoint(self):
         """Resume the sampler from the checkpoint file


### PR DESCRIPTION
This allows a file to be provided that will be used for the starting positions of an MCMC sampler. This is different than using an initial distribution in that the file specifies exactly the points to use, rather than just an initial distribution. It's mostly equivalent to providing a checkpoint file, but it doesn't cause the random sampler to be reset. The way this is done is you provide `start-file = file/path/start.hdf` in the `[sampler]` section of the config file. The start file is assumed to be an inference file with the same number of walkers/chains. The samples are pulled from the last iteration in that file.

This also a fixes a bug in the `copy` function in `base_hdf` that I came across while testing this.