### PR TITLE
Fix error from missing https:// prefix to segments.ligo.org

### DIFF
--- a/pycbc/dq.py
+++ b/pycbc/dq.py
@@ -105,7 +105,7 @@ GWOSC_URL = 'https://www.gw-openscience.org/timeline/segments/json/{}/{}_{}/{}/{
 
 
 def query_flag(ifo, segment_name, start_time, end_time,
-               source='any', server="segments.ligo.org",
+               source='any', server="https://segments.ligo.org",
                veto_definer=None, cache=False):
     """Return the times where the flag is active
 
@@ -238,7 +238,7 @@ def query_flag(ifo, segment_name, start_time, end_time,
 
 
 def query_cumulative_flags(ifo, segment_names, start_time, end_time,
-                           source='any', server="segments.ligo.org",
+                           source='any', server="https://segments.ligo.org",
                            veto_definer=None,
                            bounds=None,
                            padding=None,
@@ -383,7 +383,7 @@ def parse_flag_str(flag_str):
 
 
 def query_str(ifo, flag_str, start_time, end_time, source='any',
-              server="segments.ligo.org", veto_definer=None):
+              server="https://segments.ligo.org", veto_definer=None):
     """ Query for flags based on a special str syntax
 
     Parameters

--- a/pycbc/inference/models/data_utils.py
+++ b/pycbc/inference/models/data_utils.py
@@ -129,7 +129,7 @@ def create_data_parser():
                          help='Where to look for DQ information. If "any" '
                               '(the default) will first try GWOSC, then '
                               'dqsegdb.')
-    dqgroup.add_argument('--dq-server', default='segments.ligo.org',
+    dqgroup.add_argument('--dq-server', default='https://segments.ligo.org',
                          help='The server to use for dqsegdb.')
     dqgroup.add_argument('--veto-definer', default=None,
                          help='Path to a veto definer file that defines '

--- a/pycbc/workflow/segment.py
+++ b/pycbc/workflow/segment.py
@@ -1423,7 +1423,7 @@ def get_segments_file(workflow, name, option_name, out_dir):
         veto_definer = save_veto_definer(workflow.cp, out_dir, [])
 
     # Check for provided server
-    server = "segments.ligo.org"
+    server = "https://segments.ligo.org"
     if cp.has_option("workflow-segments", "segments-database-url"):
         server = cp.get("workflow-segments",
                                  "segments-database-url")


### PR DESCRIPTION
Eric Sowell asked me about the following error:
```
Could not query flag, check name (DMT-ANALYSIS_READY) or times
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "[some location]/python2.7/site-packages/pycbc/dq.py", line 226, in query_flag
    raise e
ValueError: unknown url type: segments.ligo.org/dq/H1/DMT-ANALYSIS_READY
```
produced by this call:
```
dq.query_flag('H1','DMT-ANALYSIS_READY',[some GPS time],[some GPS time],source='dqsegdb')
```
After reproducing the error with the IGWN Conda env, I added the `https://` prefix to the server URL (`segments.ligo.org`), which fixes the error. I changed a few more instances with the idea that this is more general than the `dq` module. Anyone knows if `urllib` is requiring an explicit protocol prefix now?