### PR TITLE
Update nonfsio pegasus site template to prevent grid running

### DIFF
--- a/pycbc/workflow/pegasus_files/nonfsio-site-template.xml
+++ b/pycbc/workflow/pegasus_files/nonfsio-site-template.xml
@@ -12,3 +12,6 @@
     <profile namespace="condor" key="accounting_group">$ACCOUNTING_GROUP</profile>
     <profile namespace="condor" key="should_transfer_files">YES</profile>
     <profile namespace="condor" key="when_to_transfer_output">ON_EXIT_OR_EVICT</profile>
+    <profile namespace="condor" key="+DESIRED_Sites">&quot;nogrid&quot;</profile>
+    <profile namespace="condor" key="+IS_GLIDEIN">&quot;False&quot;</profile>
+    <profile namespace="condor" key="+flock_local">True</profile>


### PR DESCRIPTION
This adds the lines needed to the `nonfsio` site template so that jobs marked for that will not attempt to run on the grid, if submitted from a condor pool where such running is available.

The one remaining difference in condor configuration between the `nonfsio` site and the `local` site are that the latter also adds `getenv = True` to the condor submit files.  I would think we want the same behavior here, but I haven't added that change (yet).