### PR TITLE
guess channel name from version

### DIFF
--- a/pycbc/catalog/__init__.py
+++ b/pycbc/catalog/__init__.py
@@ -25,6 +25,8 @@
 """ This package provides information about LIGO/Virgo detections of
 compact binary mergers
 """
+
+import os
 import numpy
 from . import catalog
 
@@ -128,15 +130,15 @@ class Merger(object):
         elif sample_rate == 16384:
             sampling = "16KHz"
 
-        ver = int(self.data['version'])
-        channel = "{}:GWOSC-{}_R{}_STRAIN".format(ifo, sampling.upper(), ver)
-
         for fdict in self.data['strain']:
             if (fdict['detector'] == ifo and fdict['duration'] == duration and
                     fdict['sampling_rate'] == sample_rate and
                     fdict['format'] == 'gwf'):
                 url = fdict['url']
                 break
+
+        ver = url.split('/')[-1].split('-')[1].split('_')[-1]
+        channel = "{}:GWOSC-{}_{}_STRAIN".format(ifo, sampling.upper(), ver)
 
         filename = download_file(url, cache=True)
         return read_frame(str(filename), str(channel))

--- a/pycbc/catalog/__init__.py
+++ b/pycbc/catalog/__init__.py
@@ -128,7 +128,8 @@ class Merger(object):
         elif sample_rate == 16384:
             sampling = "16KHz"
 
-        channel = "{}:GWOSC-{}_R1_STRAIN".format(ifo, sampling.upper())
+        ver = int(self.data['version'])
+        channel = "{}:GWOSC-{}_R{}_STRAIN".format(ifo, sampling.upper(), ver)
 
         for fdict in self.data['strain']:
             if (fdict['detector'] == ifo and fdict['duration'] == duration and


### PR DESCRIPTION
Allows the catalog interface to read whatever version frame that gwosc presents (assuming the channel name convention holds true). For the longer term, I've asked Jonah if the channel name can be put in the metadata. 

Enables this to work, since one frame is V1 and the other is V2

```
from pycbc.catalog.catalog import list_catalogs
from pycbc.catalog import Merger

sources = ["GW190412", "GW190814"]
ifos = ['H1', 'L1', 'V1']

for source in sources:
    m = Merger(source, source='O3_Discovery_Papers')
    data = {ifo: m.strain(ifo) for ifo in ifos}
    psd = {ifo: data[ifo].psd(2) for ifo in ifos}
```