### PR TITLE
Fix typo in ACT that's printed to screen

### DIFF
--- a/pycbc/inference/sampler/base_mcmc.py
+++ b/pycbc/inference/sampler/base_mcmc.py
@@ -971,5 +971,5 @@ def ensemble_compute_acl(filename, start_index=None, end_index=None,
                 acl = numpy.inf
             acls[param] = acl
         maxacl = numpy.array(list(acls.values())).max()
-        logging.info("ACT: %s", str(maxacl*fp.thin_interval))
+        logging.info("ACT: %s", str(maxacl*fp.thinned_by))
     return acls

--- a/pycbc/inference/sampler/base_multitemper.py
+++ b/pycbc/inference/sampler/base_multitemper.py
@@ -395,7 +395,7 @@ def ensemble_compute_acl(filename, start_index=None, end_index=None,
                 these_acls[tk] = acl
             acls[param] = these_acls
         maxacl = numpy.array(list(acls.values())).max()
-        logging.info("ACT: %s", str(maxacl*fp.thin_interval))
+        logging.info("ACT: %s", str(maxacl*fp.thinned_by))
     return acls
 
 


### PR DESCRIPTION
The ensemble samplers have a bug in the ACT that's printed to screen when the ACL is computed. They should report the acl times the file's `thinned_by` attribute (which is the thinning used when writing samples to file), but instead are printing the ACL times the file's `thin_interval` attribute (which is how many samples to skip to get a posterior). The latter is the ACL, so it's actually reporting the ACL squared rather than the ACT. This fixes that.

This bug actually affect anything, since the true ACT is calculated elsewhere (correctly), but it does make it confusing when looking at the messages being printed to screen while `pycbc_inference` is running.