### PR TITLE
Add try/except block around skcuda.fft import to ensure ImportError

### DIFF
--- a/pycbc/fft/cufft.py
+++ b/pycbc/fft/cufft.py
@@ -27,7 +27,15 @@ for the PyCBC package.
 """
 
 import pycbc.scheme
-import skcuda.fft as cu_fft
+# The following is a hack, to ensure that any error in importing
+# cufft is treated as the module being unavailable at runtime.
+# Ideally, the real error and its traceback would be appended to
+# the ImportError we raise here.  But the method to do that is very
+# different between python 2 and python 3.
+try:
+    import skcuda.fft as cu_fft
+except:
+    raise ImportError("Unable to import skcuda.fft; try direct import to get full traceback")
 from .core import _BaseFFT, _BaseIFFT
 
 _forward_plans = {}

--- a/pycbc/fft/cufft.py
+++ b/pycbc/fft/cufft.py
@@ -35,7 +35,8 @@ import pycbc.scheme
 try:
     import skcuda.fft as cu_fft
 except:
-    raise ImportError("Unable to import skcuda.fft; try direct import to get full traceback")
+    raise ImportError("Unable to import skcuda.fft; try direct import"
+                      " to get full traceback")
 from .core import _BaseFFT, _BaseIFFT
 
 _forward_plans = {}


### PR DESCRIPTION
This patch is a hack to work around the following set of circumstances:

1. An executable is running in a CUDA-capable install of PyCBC (i.e., `pycuda` and `scikit-cuda` are both installed)
1. That executable is running on a machine that has a GPU, and the necessary drivers, so that the logic in `pycbc.__init__.py` defines `pycbc.HAVE_CUDA` to be `True`.
1. That job does not actually need a GPU, and has been submitted without requesting one, at least to HTCondor.  It has accordingly not been granted use of the GPU, even though there is one on the system.
1. The job (directly or indirectly) imports `pycbc.fft`, which is designed to build a list of available libraries that could provide FFT implementations.

Under these circumstances, there will be an unhandled exception, because the job attempts to import `skcuda.fft` and encounters an exception, but not the `ImportError` that the code logic is designed to interpret.  There are assuredly better fixes than this, and at the very least it would be nice to propagate the original exception and traceback.  However as far as I can tell the only ways of doing this are very different between python 2 and python 3, and I don't want to implement that logic as well, especially since py2 is what we need to fix this bug now, but it will be obsolete soon.