### PR TITLE
speed up trigger fitting 

### DIFF
--- a/bin/hdfcoinc/pycbc_fit_sngls_by_template
+++ b/bin/hdfcoinc/pycbc_fit_sngls_by_template
@@ -289,8 +289,15 @@ counts_above = []
 fits = []
 tpars = []
 
-for tnum in trange:
-    stat_in_template = stat[tid == tnum]
+tsort = tid.argsort()
+tid = tid[tsort]
+stat = stat[tsort]
+
+left = np.searchsorted(tid, trange, side='left')
+right = np.searchsorted(tid, trange, side='right')
+
+for j, tnum in enumerate(trange):
+    stat_in_template = stat[left[j]:right[j]]
     count_above = len(stat_in_template)
     count_total = count_in_template[tnum]
     if count_above == 0:
@@ -311,8 +318,12 @@ for tnum in trange:
                                                     (tnum - tmin, tmax - tmin))
 
 logging.info("Calculating median sigma for each template")
-median_sigma = [np.sqrt(np.median(trigf[args.ifo + '/sigmasq'][reg])) for reg in
-                    trigf[args.ifo + '/sigmasq_template'][:]]
+
+sigma_regions = trigf[args.ifo + '/sigmasq_template'][:]
+median_sigma = []
+for i, reg in enumerate(sigma_regions):
+    strigs = trigf[args.ifo + '/sigmasq'][reg]
+    median_sigma.append(np.median(strigs)**0.5)
 
 outfile = h5py.File(args.output, 'w')
 # store template-dependent fit output

--- a/bin/hdfcoinc/pycbc_fit_sngls_by_template
+++ b/bin/hdfcoinc/pycbc_fit_sngls_by_template
@@ -297,12 +297,13 @@ stat = stat[tsort]
 left = np.searchsorted(tid, trange, side='left')
 right = np.searchsorted(tid, trange, side='right')
 
+logging.info("Fitting ...")
 for j, tnum in enumerate(trange):
     stat_in_template = stat[left[j]:right[j]]
     count_above = len(stat_in_template)
     count_total = count_in_template[tnum]
     if count_above == 0:
-        # 'stupid' value to indicate no data, shouldn't hurt if 1/alpha is averaged
+        # default/sentinel value to indicate no data, shouldn't hurt if 1/alpha is averaged
         alpha = -100.
     else:
         alpha, sig_alpha = trstats.fit_above_thresh(
@@ -319,15 +320,13 @@ for j, tnum in enumerate(trange):
                                                     (tnum - tmin, tmax - tmin))
 
 logging.info("Calculating median sigma for each template")
-
 sigma_regions = trigf[args.ifo + '/sigmasq_template'][:]
 median_sigma = []
 for reg in sigma_regions:
     strigs = trigf[args.ifo + '/sigmasq'][reg]
-    median_sigma.append(np.median(strigs)**0.5)
+    median_sigma.append(np.median(strigs) ** 0.5)
 
 outfile = h5py.File(args.output, 'w')
-# store template-dependent fit output
 outfile.create_dataset("template_id", data=trange)
 outfile.create_dataset("count_above_thresh", data=counts_above)
 outfile.create_dataset("fit_coeff", data=fits)
@@ -346,4 +345,3 @@ outfile.attrs.create("analysis_time", data=total_time)
 
 outfile.close()
 logging.info('Done!')
-

--- a/bin/hdfcoinc/pycbc_fit_sngls_by_template
+++ b/bin/hdfcoinc/pycbc_fit_sngls_by_template
@@ -293,6 +293,7 @@ tsort = tid.argsort()
 tid = tid[tsort]
 stat = stat[tsort]
 
+# Get range of tid values which are the same
 left = np.searchsorted(tid, trange, side='left')
 right = np.searchsorted(tid, trange, side='right')
 

--- a/bin/hdfcoinc/pycbc_fit_sngls_by_template
+++ b/bin/hdfcoinc/pycbc_fit_sngls_by_template
@@ -321,7 +321,7 @@ logging.info("Calculating median sigma for each template")
 
 sigma_regions = trigf[args.ifo + '/sigmasq_template'][:]
 median_sigma = []
-for i, reg in enumerate(sigma_regions):
+for reg in sigma_regions:
     strigs = trigf[args.ifo + '/sigmasq'][reg]
     median_sigma.append(np.median(strigs)**0.5)
 

--- a/bin/hdfcoinc/pycbc_fit_sngls_over_multiparam
+++ b/bin/hdfcoinc/pycbc_fit_sngls_over_multiparam
@@ -117,13 +117,36 @@ nabove_smoothed = []
 if tcount: ntotal_smoothed = []
 alpha_smoothed = []
 rang = numpy.arange(0, len(nabove))
-for i in range(len(nabove)):
-    dsq = dist(i, rang)
-    l = (dsq < 1)
-    
-    if tcount: ntotal_smoothed.append(ntotal[l].mean())
-    nabove_smoothed.append(nabove[l].mean())
-    alpha_smoothed.append(nabove_smoothed[i] / invalphan[l].mean())
+
+if len(parvals) == 1:
+    sort = parvals[0].argsort()
+    parvals[0] = parvals[0][sort]
+    ntotal = ntotal[sort]
+    nabove = nabove[sort]
+    invalphan = invalphan[sort]
+
+    left = numpy.searchsorted(parvals[0], parvals[0] - args.smoothing_width[0])
+    right = numpy.searchsorted(parvals[0], parvals[0] + args.smoothing_width[0]) - 1
+
+    ntsum = ntotal.cumsum()
+    nasum = nabove.cumsum()
+    invsum = invalphan.cumsum()
+    num = right - left
+
+    if tcount: ntotal_smoothed = (ntsum[right] - ntsum[left]) / num
+    nabove_smoothed = (nasum[right] - nasum[left]) / num
+    invmean = (invsum[right] - invsum[left]) / num
+    alpha_smoothed = nabove_smoothed / invmean
+
+else:
+    for i in range(len(nabove)):
+        if len(parvals) > 1:
+            dsq = dist(i, rang)
+            l = (dsq < 1)
+            if tcount: ntotal_smoothed.append(ntotal[l].mean())
+            nabove_smoothed.append(nabove[l].mean())
+            alpha_smoothed.append(nabove_smoothed[i] / invalphan[l].mean())
+
 
 # store template-dependent fit output
 outfile = h5py.File(args.output, 'w')

--- a/bin/hdfcoinc/pycbc_fit_sngls_over_multiparam
+++ b/bin/hdfcoinc/pycbc_fit_sngls_over_multiparam
@@ -140,12 +140,11 @@ if len(parvals) == 1:
 
 else:
     for i in range(len(nabove)):
-        if len(parvals) > 1:
-            dsq = dist(i, rang)
-            l = (dsq < 1)
-            if tcount: ntotal_smoothed.append(ntotal[l].mean())
-            nabove_smoothed.append(nabove[l].mean())
-            alpha_smoothed.append(nabove_smoothed[i] / invalphan[l].mean())
+        dsq = dist(i, rang)
+        l = (dsq < 1)
+        if tcount: ntotal_smoothed.append(ntotal[l].mean())
+        nabove_smoothed.append(nabove[l].mean())
+        alpha_smoothed.append(nabove_smoothed[i] / invalphan[l].mean())
 
 
 # store template-dependent fit output

--- a/bin/hdfcoinc/pycbc_fit_sngls_over_multiparam
+++ b/bin/hdfcoinc/pycbc_fit_sngls_over_multiparam
@@ -99,7 +99,7 @@ else:
     tcount = False
 
 # for an exponential fit 1/alpha is linear in the trigger statistic values
-# so taking weighted sums/averages of 1/alpha is appropriate
+# so calculating weighted sums or averages of 1/alpha is appropriate
 nabove = fits['count_above_thresh'][:]
 nabove = nabove / numpy.mean(nabove)
 if tcount: ntotal = fits['count_in_template'][:]
@@ -118,8 +118,9 @@ if tcount: ntotal_smoothed = []
 alpha_smoothed = []
 rang = numpy.arange(0, len(nabove))
 
-# We handle the case of one-dimension specifically as it is easier to
-# increase computational peformance.
+logging.info("Smoothing ...")
+# Handle the one-dimensional case of one dimension separately as it is easier to
+# optimize computational performance.
 if len(parvals) == 1:
     sort = parvals[0].argsort()
     parvals[0] = parvals[0][sort]
@@ -132,7 +133,7 @@ if len(parvals) == 1:
     left = numpy.searchsorted(parvals[0], parvals[0] - args.smoothing_width[0])
     right = numpy.searchsorted(parvals[0], parvals[0] + args.smoothing_width[0]) - 1
 
-    # precompute the sums so we can quickly look up differences between
+    # Precompute the sums so we can quickly look up differences between
     # templates
     ntsum = ntotal.cumsum()
     nasum = nabove.cumsum()
@@ -152,8 +153,7 @@ else:
         nabove_smoothed.append(nabove[l].mean())
         alpha_smoothed.append(nabove_smoothed[i] / invalphan[l].mean())
 
-
-# store template-dependent fit output
+logging.info("Writing output")
 outfile = h5py.File(args.output, 'w')
 outfile['template_id'] = tid
 outfile['count_above_thresh'] = nabove_smoothed

--- a/bin/hdfcoinc/pycbc_fit_sngls_over_multiparam
+++ b/bin/hdfcoinc/pycbc_fit_sngls_over_multiparam
@@ -118,6 +118,8 @@ if tcount: ntotal_smoothed = []
 alpha_smoothed = []
 rang = numpy.arange(0, len(nabove))
 
+# We handle the case of one-dimension specifically as it is easier to
+# increase computational peformance.
 if len(parvals) == 1:
     sort = parvals[0].argsort()
     parvals[0] = parvals[0][sort]

--- a/bin/hdfcoinc/pycbc_fit_sngls_over_multiparam
+++ b/bin/hdfcoinc/pycbc_fit_sngls_over_multiparam
@@ -104,7 +104,7 @@ nabove = fits['count_above_thresh'][:]
 nabove = nabove / numpy.mean(nabove)
 if tcount: ntotal = fits['count_in_template'][:]
 
-invalpha = 1. / fits['fit_coeff'][:] 
+invalpha = 1. / fits['fit_coeff'][:]
 invalphan = invalpha * nabove
 
 def dist(i1, i2):
@@ -125,9 +125,13 @@ if len(parvals) == 1:
     nabove = nabove[sort]
     invalphan = invalphan[sort]
 
+    # For each template, find the range of nearby templates which fall within
+    # the chosen window.
     left = numpy.searchsorted(parvals[0], parvals[0] - args.smoothing_width[0])
     right = numpy.searchsorted(parvals[0], parvals[0] + args.smoothing_width[0]) - 1
 
+    # precompute the sums so we can quickly look up differences between
+    # templates
     ntsum = ntotal.cumsum()
     nasum = nabove.cumsum()
     invsum = invalphan.cumsum()


### PR DESCRIPTION
@GarethDaviesGW @tdent I've gotten around to pushing upstream some changes I made locally for the high mass ratio search I did. Due to the large number of templates the fit code was pretty slow in default configuration.  

This patch
* Speeds up fit_by_template generally by switching to faster versions of the same calls
* speeds up fit_over_param by many orders of magnitude in the specific case of a single dimension