### PR TITLE
Created option to set a high-frequency cutoff in pycbc_make_skymap

### DIFF
--- a/bin/pycbc_make_skymap
+++ b/bin/pycbc_make_skymap
@@ -271,6 +271,7 @@ def main(trig_time, mass1, mass2, spin1z, spin2z, f_low, f_upper, ifar, ifos, th
 
     kwargs = {'psds': {ifo: followup_data[ifo]['psd'] for ifo in ifos + follow_up},
               'low_frequency_cutoff': f_low,
+              'high_frequency_cutoff': f_upper,
               'followup_data': followup_data,
               'channel_names': channel_names}
 

--- a/bin/pycbc_make_skymap
+++ b/bin/pycbc_make_skymap
@@ -61,7 +61,7 @@ def default_channel_name(time, ifo):
     raise ValueError('Interferometer {} not supported at time {}'.format(ifo, time))
     
 
-def main(trig_time, mass1, mass2, spin1z, spin2z, f_low, ifar, ifos, thresh_SNR, ligolw_skymap_output='.', ligolw_psd_output=None, ligolw_event_output=None, window_bins=300, frame_types=None, channel_names=None, gracedb_server=None, test_event=True, custom_frame_files=None):
+def main(trig_time, mass1, mass2, spin1z, spin2z, f_low, f_upper, ifar, ifos, thresh_SNR, ligolw_skymap_output='.', ligolw_psd_output=None, ligolw_event_output=None, window_bins=300, frame_types=None, channel_names=None, gracedb_server=None, test_event=True, custom_frame_files=None):
 
     if not test_event and not gracedb_server:
         raise RuntimeError('a gracedb url must be specified if not a test event.')
@@ -143,6 +143,7 @@ def main(trig_time, mass1, mass2, spin1z, spin2z, f_low, ifar, ifos, thresh_SNR,
         command.append("--spin1z"),command.append(str(spin1z))
         command.append("--spin2z"),command.append(str(spin2z))
         command.append("--low-frequency-cutoff"),command.append(str(f_low))
+        command.append("--high-frequency-cutoff"),command.append(str(f_upper))
         command.append("--gps-start-time"),command.append(str(gps_start_time))
         command.append("--gps-end-time"),command.append(str(gps_end_time))
         command.append("--trigger-time"),command.append(str(np.round(trig_time,5)))
@@ -341,6 +342,8 @@ if __name__ == '__main__':
     parser.add_argument('--spin2z', type=float, required=True)
     parser.add_argument('--f-low', type=float,
                         help="lower frequency cut-off (float)", default=20.0)
+    parser.add_argument('--f-upper', type=float,
+                        help="upper frequency cut-off (float)", default=None)
     parser.add_argument('--ifar', type=float, help="false alarm rate (float)",
                         default=1)
     parser.add_argument('--thresh-SNR', type=float, help="Threshold SNR (float)",
@@ -374,7 +377,7 @@ if __name__ == '__main__':
     
 
     main(opt.trig_time, opt.mass1, opt.mass2,
-         opt.spin1z, opt.spin2z, opt.f_low, opt.ifar, opt.ifos,
+         opt.spin1z, opt.spin2z, opt.f_low, opt.f_upper, opt.ifar, opt.ifos,
          opt.thresh_SNR, opt.ligolw_skymap_output,
          opt.ligolw_psd_output, opt.ligolw_event_output,
          frame_types=frame_type_dict, channel_names=chan_name_dict,

--- a/bin/pycbc_make_skymap
+++ b/bin/pycbc_make_skymap
@@ -133,6 +133,8 @@ def main(trig_time, mass1, mass2, spin1z, spin2z, f_low, f_upper, ifar, ifos, th
         coinc_results['foreground/'+ifo+'/spin1z'] = spin1z
         coinc_results['foreground/'+ifo+'/spin2z'] = spin2z
         coinc_results['foreground/'+ifo+'/f_lower'] = f_low
+        if f_upper:
+            coinc_results['foreground/'+ifo+'/f_final'] = f_upper
         coinc_results['foreground/'+ifo+'/window'] = window
         coinc_results['foreground/'+ifo+'/sample_rate'] = int(sample_rate)
         coinc_results['foreground/'+ifo+'/template_id'] = i
@@ -143,7 +145,8 @@ def main(trig_time, mass1, mass2, spin1z, spin2z, f_low, f_upper, ifar, ifos, th
         command.append("--spin1z"),command.append(str(spin1z))
         command.append("--spin2z"),command.append(str(spin2z))
         command.append("--low-frequency-cutoff"),command.append(str(f_low))
-        command.append("--high-frequency-cutoff"),command.append(str(f_upper))
+        if f_upper:
+            command.append("--high-frequency-cutoff"),command.append(str(f_upper))
         command.append("--gps-start-time"),command.append(str(gps_start_time))
         command.append("--gps-end-time"),command.append(str(gps_end_time))
         command.append("--trigger-time"),command.append(str(np.round(trig_time,5)))
@@ -181,7 +184,7 @@ def main(trig_time, mass1, mass2, spin1z, spin2z, f_low, f_upper, ifar, ifos, th
 
         command.append("--psd-output"),command.append(tmpdir+"/PSD_"+str(rough_time)+"_"+ifo+".txt")
         command.append("--output-file"),command.append(tmpdir+"/SNRTS_"+str(rough_time)+"_"+ifo+".hdf")
-
+        
         stderr_file = open(tmpdir + '/pycbc_single_template_{}_{}_stderr.txt'.format(str(rough_time), ifo), 'w')
 
         procs.append(subprocess.Popen(command,stdout=subprocess.PIPE, stderr=stderr_file))
@@ -344,7 +347,7 @@ if __name__ == '__main__':
     parser.add_argument('--f-low', type=float,
                         help="lower frequency cut-off (float)", default=20.0)
     parser.add_argument('--f-upper', type=float,
-                        help="upper frequency cut-off (float)", default=None)
+                        help="upper frequency cut-off (float)")
     parser.add_argument('--ifar', type=float, help="false alarm rate (float)",
                         default=1)
     parser.add_argument('--thresh-SNR', type=float, help="Threshold SNR (float)",

--- a/pycbc/io/live.py
+++ b/pycbc/io/live.py
@@ -265,17 +265,10 @@ class SingleCoincForGraceDB(object):
         for ifo in self.psds:
             psd = self.psds[ifo]
             kmin = int(kwargs['low_frequency_cutoff'] / psd.delta_f)
-            if kwargs['high_frequency_cutoff']:
-                #Should this raise an error if
-                #high_frequency_cutoff > f_max of PSD?
-                kmax = min(int(kwargs['high_frequency_cutoff'] \
-                               / psd.delta_f), len(psd))
-            else:
-                kmax = len(psd)
             fseries = lal.CreateREAL8FrequencySeries(
                 "psd", psd.epoch, kwargs['low_frequency_cutoff'], psd.delta_f,
-                lal.StrainUnit**2 / lal.HertzUnit, kmax - kmin)
-            fseries.data.data = psd.numpy()[kmin:kmax] / pycbc.DYN_RANGE_FAC ** 2.0
+                lal.StrainUnit**2 / lal.HertzUnit, len(psd) - kmin)
+            fseries.data.data = psd.numpy()[kmin:] / pycbc.DYN_RANGE_FAC ** 2.0
             psds_lal[ifo] = fseries
         make_psd_xmldoc(psds_lal, outdoc)
 

--- a/pycbc/io/live.py
+++ b/pycbc/io/live.py
@@ -266,9 +266,10 @@ class SingleCoincForGraceDB(object):
             psd = self.psds[ifo]
             kmin = int(kwargs['low_frequency_cutoff'] / psd.delta_f)
             if kwargs['high_frequency_cutoff']:
-                #Should this raise an error if high_frequency_cutoff > f_max of PSD?
-                kmax = min(int(kwargs['high_frequency_cutoff'] / psd.delta_f),
-                           len(psd))
+                #Should this raise an error if
+                #high_frequency_cutoff > f_max of PSD?
+                kmax = min(int(kwargs['high_frequency_cutoff'] \
+                               / psd.delta_f), len(psd))
             else:
                 kmax = len(psd)
             fseries = lal.CreateREAL8FrequencySeries(


### PR DESCRIPTION
Added an optional argument to pycbc_make_skymap.
This argument is passed to pycbc_single_template and SingleCoincForGraceDB.

For SingleCoincForGraceDB to accept a high-frequency cutoff changes to pycbc/io/live.py were required. I think the place I put these changes at don't interfere with anything else. I also think that implementing the high-frequency cutoff the way done here will pass it to Baystar.