### PR TITLE
add options to pycbc_create_injections for use with offline search codes

### DIFF
--- a/bin/pycbc_create_injections
+++ b/bin/pycbc_create_injections
@@ -223,15 +223,21 @@ while True:
 
     # We are drawing until we hit a time so check if we've reached it
     if opts.gps_start_time:
+        if 'tc' in samples.fieldnames:
+            raise RuntimeError("A distribution was given for 'tc'. This is "
+                               "not compatible with providing start/end times.")
+
         if old_samples is not None:
             samples = numpy.concatenate([old_samples, samples])
+
         old_samples = samples
 
         # We have enough to cover out time span so we can fixup the times
         # and stop here
-        if samples['tc'].sum() > opts.gps_end_time - opts.gps_start_time:
-            samples = numpy.sort(samples, order='tc')
-            samples['tc'] = opts.gps_start_time + samples['tc'].cumsum()
+        if samples['time_delay'].sum() > opts.gps_end_time - opts.gps_start_time:
+            samples = numpy.sort(samples, order='time_delay')
+            tc = opts.gps_start_time + samples['time_delay'].cumsum()
+            samples = samples.add_fields([tc], ['tc'])
             samples = samples[samples['tc'] < opts.gps_end_time]
             logging.info('Total Injections: %s', len(samples))
             break

--- a/bin/pycbc_create_injections
+++ b/bin/pycbc_create_injections
@@ -122,6 +122,7 @@ from pycbc.io import record
 from pycbc.waveform import parameters
 from pycbc.workflow import configuration
 from pycbc.workflow import WorkflowConfigParser
+from numpy.random import uniform
 import h5py
 
 parser = argparse.ArgumentParser(description=__doc__,
@@ -133,13 +134,15 @@ parser.add_argument('--version', action='version',
 parser.add_argument('--ninjections', type=int,
                     help='Number of injections to create.')
 parser.add_argument('--gps-start-time', type=int, help="Alternative to "
-                    "ninjections argument. Injections will be distributed "
-                    "in time by taking the cumulative sum of the tc values. "
+                    "ninjections argument. "
                     "The number will be chosen to fill the chosen time range. ")
 parser.add_argument('--gps-end-time', type=int, help="Alternative to "
-                    "ninjections argument. Injections will be distributed "
-                    "in time by taking the cumulative sum of the tc values. "
+                    "ninjections argument. "
                     "The number will be chosen to fill the chosen time range. ")
+parser.add_argument('--time-step', type=float,
+                    help="Minimum separation between injections")
+parser.add_argument('--time-window', type=float,
+                    help="Uniform window of time to place injection into")
 parser.add_argument('--seed', type=int, default=0,
                     help='Seed to use for the random number generator. '
                          'Default is 0.')
@@ -170,8 +173,12 @@ if os.path.exists(opts.output_file) and not opts.force:
     raise OSError("output-file already exists; use --force if you wish to "
                   "overwrite it.")
 
-if opts.ninjections and (opts.gps_start_time or opts.gps_end_time):
-    raise ValueError("Cannot provide both ninjections and start/end time.")
+if opts.ninjections and (opts.gps_start_time is not None or
+                         opts.gps_end_time is not None or
+                         opts.time_step is not None or
+                         opts.time_window is not none):
+    raise ValueError("Cannot provide both ninjections and "
+                     " start/end/step/window time options.")
 
 numpy.random.seed(opts.seed)
 
@@ -222,22 +229,26 @@ while True:
         samples = transforms.apply_transforms(samples, waveform_transforms)
 
     # We are drawing until we hit a time so check if we've reached it
-    if opts.gps_start_time:
-        if 'tc' in samples.fieldnames:
-            raise RuntimeError("A distribution was given for 'tc'. This is "
-                               "not compatible with providing start/end times.")
+    if opts.gps_start_time is not None:
+        if 'tc' in samples.fieldnames or 'tc' in static_params:
+            raise RuntimeError("A value or distribution was given for 'tc'. "
+                               "This is not compatible with providing "
+                               "start/end times.")
 
+        if old_samples is None:
+            tstart = opts.gps_start_time
+        else:
+            tstart = old_samples['tc'].max()
+
+        tc = numpy.arange(0, draw_size) * opts.time_step + tstart
+        tc += uniform(0, high=opts.time_window, size=draw_size).cumsum()
+        samples = samples.add_fields([tc], ['tc'])
+        
         if old_samples is not None:
-            samples = numpy.concatenate([old_samples, samples])
-
+            samples = old_samples.append(samples)
         old_samples = samples
 
-        # We have enough to cover out time span so we can fixup the times
-        # and stop here
-        if samples['time_delay'].sum() > opts.gps_end_time - opts.gps_start_time:
-            samples = numpy.sort(samples, order='time_delay')
-            tc = opts.gps_start_time + samples['time_delay'].cumsum()
-            samples = samples.add_fields([tc], ['tc'])
+        if tc.max() >= opts.gps_end_time:
             samples = samples[samples['tc'] < opts.gps_end_time]
             logging.info('Total Injections: %s', len(samples))
             break
@@ -250,6 +261,5 @@ while True:
 logging.info("Writing results")
 write_args = [arg for arg in samples.fieldnames
               if arg not in static_params.keys()]
-
 InjectionSet.write(opts.output_file, samples, write_args, static_params,
                    cmd=" ".join(sys.argv))

--- a/bin/pycbc_create_injections
+++ b/bin/pycbc_create_injections
@@ -135,7 +135,7 @@ parser.add_argument('--ninjections', type=int,
 parser.add_argument('--gps-start-time', type=int, help="Alternative to "
                     "ninjections argument. Injections will be distributed "
                     "in time by taking the cumulative sum of the tc values. "
-                    "The number will be chosen to fill the chosen time range. "
+                    "The number will be chosen to fill the chosen time range. ")
 parser.add_argument('--gps-end-time', type=int, help="Alternative to "
                     "ninjections argument. Injections will be distributed "
                     "in time by taking the cumulative sum of the tc values. "
@@ -169,7 +169,7 @@ pycbc.init_logging(opts.verbose)
 if os.path.exists(opts.output_file) and not opts.force:
     raise OSError("output-file already exists; use --force if you wish to "
                   "overwrite it.")
-                  
+
 if opts.ninjections and (opts.gps_start_time or opts.gps_end_time):
     raise ValueError("Cannot provide both ninjections and start/end time.")
 
@@ -200,23 +200,50 @@ dists = distributions.read_distributions_from_config(cp, opts.dist_section)
 randomsampler = JointDistribution(variable_params, *dists,
                                **{"constraints" : constraints})
 
-logging.info("Drawing samples")
-samples = randomsampler.rvs(size=opts.ninjections)
+if opts.ninjections:
+    draw_size = opts.ninjections
+else:
+    draw_size = 4000 # Just a default so it's not super slow drawing large sets
+    old_samples = None
 
-if waveform_transforms is not None:
-    logging.info("Transforming to waveform transform parameters")
-    for t in waveform_transforms:
-        if not set(t.inputs).isdisjoint(set(static_params.keys())):
-            for item in list((set(t.inputs) & set(static_params.keys())
-                             - set(samples.fieldnames))):
-                samples = samples.add_fields([numpy.repeat(static_params[item],
-                                             opts.ninjections).astype(float)],
-                                             [item])
-    samples = transforms.apply_transforms(samples, waveform_transforms)
-    write_args = [arg for arg in samples.fieldnames
-                  if arg not in static_params.keys()]
+while True:
+    logging.info("Drawing samples")
+    samples = randomsampler.rvs(size=draw_size)
+
+    if waveform_transforms is not None:
+        logging.info("Transforming to waveform transform parameters")
+        for t in waveform_transforms:
+            if not set(t.inputs).isdisjoint(set(static_params.keys())):
+                for item in list((set(t.inputs) & set(static_params.keys())
+                                 - set(samples.fieldnames))):
+                    samples = samples.add_fields([numpy.repeat(static_params[item],
+                                                 draw_size).astype(float)],
+                                                 [item])
+        samples = transforms.apply_transforms(samples, waveform_transforms)
+
+    # We are drawing until we hit a time so check if we've reached it
+    if opts.gps_start_time:
+        if old_samples is not None:
+            samples = numpy.concatenate([old_samples, samples])
+        old_samples = samples
+
+        # We have enough to cover out time span so we can fixup the times
+        # and stop here
+        if samples['tc'].sum() > opts.gps_end_time - opts.gps_start_time:
+            samples = numpy.sort(samples, order='tc')
+            samples['tc'] = opts.gps_start_time + samples['tc'].cumsum()
+            samples = samples[samples['tc'] < opts.gps_end_time]
+            logging.info('Total Injections: %s', len(samples))
+            break
+
+    # We got as many samples as we needed so we can stop
+    if opts.ninjections and len(samples) >= opts.ninjections:
+        break
 
 # write results
 logging.info("Writing results")
+write_args = [arg for arg in samples.fieldnames
+              if arg not in static_params.keys()]
+
 InjectionSet.write(opts.output_file, samples, write_args, static_params,
                    cmd=" ".join(sys.argv))

--- a/bin/pycbc_create_injections
+++ b/bin/pycbc_create_injections
@@ -130,8 +130,16 @@ configuration.add_workflow_command_line_group(parser)
 parser.add_argument('--version', action='version',
                     version=pycbc.version.git_verbose_msg,
                     help='Prints version information.')
-parser.add_argument('--ninjections', required=True, type=int,
+parser.add_argument('--ninjections', type=int,
                     help='Number of injections to create.')
+parser.add_argument('--gps-start-time', type=int, help="Alternative to "
+                    "ninjections argument. Injections will be distributed "
+                    "in time by taking the cumulative sum of the tc values. "
+                    "The number will be chosen to fill the chosen time range. "
+parser.add_argument('--gps-end-time', type=int, help="Alternative to "
+                    "ninjections argument. Injections will be distributed "
+                    "in time by taking the cumulative sum of the tc values. "
+                    "The number will be chosen to fill the chosen time range. ")
 parser.add_argument('--seed', type=int, default=0,
                     help='Seed to use for the random number generator. '
                          'Default is 0.')
@@ -161,6 +169,9 @@ pycbc.init_logging(opts.verbose)
 if os.path.exists(opts.output_file) and not opts.force:
     raise OSError("output-file already exists; use --force if you wish to "
                   "overwrite it.")
+                  
+if opts.ninjections and (opts.gps_start_time or opts.gps_end_time):
+    raise ValueError("Cannot provide both ninjections and start/end time.")
 
 numpy.random.seed(opts.seed)
 

--- a/bin/pycbc_create_injections
+++ b/bin/pycbc_create_injections
@@ -176,7 +176,7 @@ if os.path.exists(opts.output_file) and not opts.force:
 if opts.ninjections and (opts.gps_start_time is not None or
                          opts.gps_end_time is not None or
                          opts.time_step is not None or
-                         opts.time_window is not none):
+                         opts.time_window is not None):
     raise ValueError("Cannot provide both ninjections and "
                      " start/end/step/window time options.")
 


### PR DESCRIPTION
This allows one to set start / end times instead of a number of injections to draw. This is the most common scenario for search workflows and is sufficient to enable pycbc_create_injections to produce reasonable files for use with the offline analysis. There may be a couple distributions that should also be added for simplicity, but I think even there most things can be done with inline transforms, etc. 

Example config file and command line
```
[variable_params]
tc =

[static_params]
mass1 = 37
mass2 = 32
ra = 2.2
dec = -1.25
inclination = 2.5
coa_phase = 1.5
polarization = 1.75
distance = 100
f_ref = 20
f_lower = 18
approximant = IMRPhenomPv2
taper = start

[prior-tc]
name = uniform
min-tc = 180
max-tc = 200
```
```
pycbc_create_injections --verbose \
        --config-files test.ini \
        --gps-start-time 1000000000 \
        --gps-end-time   1000500000 \
        --seed 10 \
        --output-file injection.hdf \
        --variable-params-section variable_params \
        --static-params-section static_params \
        --dist-section prior \
        --force
```
