### PR TITLE
Fix exception handling in inference data utils module

### DIFF
--- a/pycbc/inference/models/data_utils.py
+++ b/pycbc/inference/models/data_utils.py
@@ -53,7 +53,7 @@ def strain_from_cli_multi_ifos(*args, **kwargs):
             count += 1
             sleep(10)
     # if get to here, we've tries 3 times and still got an error, so exit
-    raise RuntimeError(exception)
+    raise exception
 
 
 #

--- a/pycbc/inference/models/data_utils.py
+++ b/pycbc/inference/models/data_utils.py
@@ -49,10 +49,11 @@ def strain_from_cli_multi_ifos(*args, **kwargs):
         try:
             return strain.from_cli_multi_ifos(*args, **kwargs)
         except RuntimeError as e:
+            exception = e
             count += 1
             sleep(10)
     # if get to here, we've tries 3 times and still got an error, so exit
-    raise RuntimeError(e)
+    raise RuntimeError(exception)
 
 
 #


### PR DESCRIPTION
While doing a local build of the documentation under Python 3, I got the following exception:
```
2020-08-12 12:22:25,564 Reading Frames
XLAL Error - XLALFrStreamFileOpen (LALFrStream.c:128): No files in stream file cache
XLAL Error - XLALFrStreamFileOpen (LALFrStream.c:128): Invalid argument
XLAL Error - XLALFrStreamCacheOpen (LALFrStream.c:233): Internal function call failed: Invalid argument
Traceback (most recent call last):
  File "somewhere/bin/pycbc_inference", line 128, in <module>
    model = models.read_from_config(cp)
  File "somewhere/lib/python3.7/site-packages/pycbc/inference/models/__init__.py", line 174, in read_from_config
    return models[name].from_config(cp, **kwargs)
  File "somewhere/lib/python3.7/site-packages/pycbc/inference/models/gaussian_noise.py", line 566, in from_config
    strain_dict, psd_strain_dict = data_from_cli(opts, **data_args)
  File "somewhere/lib/python3.7/site-packages/pycbc/inference/models/data_utils.py", line 424, in data_from_cli
    precision="double")
  File "somewhere/lib/python3.7/site-packages/pycbc/inference/models/data_utils.py", line 55, in strain_from_cli_multi_ifos
    raise RuntimeError(e)
UnboundLocalError: local variable 'e' referenced before assignment
```
It [looks like](https://docs.python.org/3/reference/compound_stmts.html#the-try-statement) the exception variable is local to the `except` block, so this patch goes around that.