### PR TITLE
zero out dc for lalsim method

### DIFF
--- a/pycbc/noise/gaussian.py
+++ b/pycbc/noise/gaussian.py
@@ -110,6 +110,7 @@ def noise_from_psd(length, delta_t, psd, seed=None):
 
     psd = (psd[0:n]).lal()
     psd.data.data[n-1] = 0
+    psd.data.data[0] = 0
 
     segment = TimeSeries(zeros(N), delta_t=delta_t).lal()
     length_generated = 0


### PR DESCRIPTION
The lalsimulation noise generation now requires that the dc be zero'd out (instead of being implicitly ignored downstream). Otherwise it will produce an error when someone tries to generated noise based on a psd. Our reproduceable methods are unaffected. 