### PR TITLE
Changed the error-code when the code errors out.

### DIFF
--- a/bin/pycbc_make_skymap
+++ b/bin/pycbc_make_skymap
@@ -182,21 +182,21 @@ def main(trig_time, mass1, mass2, spin1z, spin2z, f_low, f_upper, sample_rate,
                     logging.info("Channel name in {} is not {}".format(custom_frame, channel_names[ifo]))
                     logging.info("Unable to open it")
                     logging.info("Exit the program")
-                    sys.exit()
+                    sys.exit(1)
                 fr_start_times.append(frame_data.start_time)
                 fr_end_times.append(frame_data.end_time)
             if gps_start_time < np.min(fr_start_times):
-                logging.info("Start time of {} should be before the required start time {}".format(frame_data.start_time, gps_start_time))
+                logging.info("Start time of {} should be before the required start time {}".format(np.min(fr_start_times), gps_start_time))
                 logging.info("Exit the program")
-                sys.exit()
+                sys.exit(1)
             if np.max(fr_end_times) < gps_end_time:
-                logging.info("End time of {} should be after the required end time {}".format(frame_data.end_time, gps_end_time))
+                logging.info("End time of {} should be after the required end time {}".format(np.max(fr_end_times), gps_end_time))
                 logging.info("Exit the program")
-                sys.exit()
+                sys.exit(1)
             if trig_time < np.min(fr_start_times) or np.max(fr_end_times) < trig_time:
                 logging.info("Trigger time should be within your frame file(s)")
                 logging.info("Exit the program")
-                sys.exit()
+                sys.exit(1)
             command.append("--frame-files")
             for custom_frame in custom_frame_files[ifo]:
                 command.append(custom_frame)
@@ -209,6 +209,8 @@ def main(trig_time, mass1, mass2, spin1z, spin2z, f_low, f_upper, sample_rate,
         
         stderr_file = open(tmpdir + '/pycbc_single_template_{}_{}_stderr.txt'.format(str(rough_time), ifo), 'w')
         
+        #TODO: This call should probably not redirect the stderr.
+        #      Makes debugging difficult.
         procs.append(subprocess.Popen(command,stdout=stderr_file, stderr=stderr_file))
 
     logging.info('Calculating SNR...')


### PR DESCRIPTION
Changes:
-Changed the error-codes on sys.exit to 1 instead of 0.
-Fixed a bug, where the wrong times were printed in error messages.

This function also redirects the stderr of the underlying `pycbc_single_template` code to a temporary file. This is difficult to find when debugging.