### PR TITLE
Change gzip compression level from 9 to 6 in mergetrigs

### DIFF
--- a/bin/hdfcoinc/pycbc_coinc_mergetrigs
+++ b/bin/hdfcoinc/pycbc_coinc_mergetrigs
@@ -139,7 +139,7 @@ del trigger_hashes
 
 idlen = (template_boundaries[1:] - template_boundaries[:-1])
 f.create_dataset('%s/template_id' % ifo, data=numpy.repeat(template_ids, idlen), 
-                 compression='gzip', shuffle=True, compression_opts=9)
+                 compression='gzip', shuffle=True, compression_opts=6)
 f['%s/template_boundaries' % ifo] = full_boundaries[unsort]
 
 logging.info('reading the trigger columns from the input files')
@@ -149,7 +149,7 @@ for col in trigger_columns:
     data = collect(key, args.trigger_files)[trigger_sort]
     logging.info('writing %s to file' % col)
     dset = f.create_dataset(key, data=data, compression='gzip',
-                                 compression_opts=9, shuffle=True)
+                                 compression_opts=6, shuffle=True)
     del data
     region(f, key, full_boundaries, unsort) 
 f.close()

--- a/bin/hdfcoinc/pycbc_coinc_mergetrigs
+++ b/bin/hdfcoinc/pycbc_coinc_mergetrigs
@@ -34,6 +34,9 @@ parser.add_argument('--version', action='version', version=pycbc.version.git_ver
 parser.add_argument('--trigger-files', nargs='+')
 parser.add_argument('--output-file')
 parser.add_argument('--bank-file')
+parser.add_argument('--compression-level', type=int, default=6,
+                    help='Set HDF compression level in the output file '
+                         '(default 6)')
 parser.add_argument('--verbose', '-v', action='count')
 args = parser.parse_args()
 
@@ -138,8 +141,10 @@ full_boundaries = numpy.concatenate([full_boundaries, [len(trigger_hashes)]])
 del trigger_hashes
 
 idlen = (template_boundaries[1:] - template_boundaries[:-1])
-f.create_dataset('%s/template_id' % ifo, data=numpy.repeat(template_ids, idlen), 
-                 compression='gzip', shuffle=True, compression_opts=6)
+f.create_dataset('%s/template_id' % ifo,
+                 data=numpy.repeat(template_ids, idlen),
+                 compression='gzip', shuffle=True,
+                 compression_opts=args.compression_level)
 f['%s/template_boundaries' % ifo] = full_boundaries[unsort]
 
 logging.info('reading the trigger columns from the input files')
@@ -149,7 +154,8 @@ for col in trigger_columns:
     data = collect(key, args.trigger_files)[trigger_sort]
     logging.info('writing %s to file' % col)
     dset = f.create_dataset(key, data=data, compression='gzip',
-                                 compression_opts=6, shuffle=True)
+                            compression_opts=args.compression_level,
+                            shuffle=True)
     del data
     region(f, key, full_boundaries, unsort) 
 f.close()


### PR DESCRIPTION
We have recently had several workflows that spend an inordinate amount of time in the `hdf_mergetrigs` jobs on full data.  In some cases they ran for 24 hours and got evicted. @titodalcanton noticed that these jobs were spending much more time writing some of the outputs than others, and that if he `condor_ssh'd` to the job, it was actually in the `R` state using 100% of the CPU, so it seemed that the time was spent in actual computation, and not file system issues.  On further investigation of an example file, if we ignore the datasets which correspond to statistics not actually calculated in a given workflow (e.g., bank chi-squared), then the greater the compression factor achieved, the longer it took to write that dataset, strongly suggesting that for datasets which were compressible (but not trivially compressible, like bank chi-squared---those ran quickly) the time was being spent in the compression.

Some reading around on the web suggested that our current compression level of `9` in `pycbc_coinc_mergetrigs` is very aggressive.  A more typical default is `6`, and this is what you get if you call `gzip` from the command line and don't specify a compression level.  I ran a test last night with that change, on the largest merged trigger file from several recent workflows I'd run.  With a level of 6, its size on disk was 24 G, whereas with 9, it was 23 G.  However the job completed in an order of magnitude less time.

This is marked as work in progress, because after some discussion with Tito, he's going to add a follow-up commit to actually create a command-line option to specify this level, and default it to six.  But we want to write it up so @ahnitz has a chance to give us feedback.