### PR TITLE
avoid contains or conversions when not needed in joint dist

### DIFF
--- a/pycbc/distributions/joint.py
+++ b/pycbc/distributions/joint.py
@@ -221,10 +221,10 @@ class JointDistribution(object):
         """
         # check if statisfies constraints
         if len(self._constraints) != 0:
-            parray, _ = self._ensure_fieldarray(params)
+            parray, return_atomic = self._ensure_fieldarray(params)
             isin = self.contains(parray)
             if not isin.any():
-                if numpy.isscalar(isin):
+                if return_atomic:
                     out = -numpy.inf
                 else:
                     out = numpy.full(parray.shape, -numpy.inf)

--- a/pycbc/distributions/joint.py
+++ b/pycbc/distributions/joint.py
@@ -233,7 +233,7 @@ class JointDistribution(object):
         # note: this step may fail if arrays of values were provided, as
         # not all distributions are vectorized currently
         logps = numpy.array([d(**params) for d in self.distributions])
-        logp = logps.sum(axis=0)
+        logp = logps.sum(axis=0) + numpy.log(isin.astype(float))
         if numpy.isscalar(logp):
             logp = logp.item()
         return logp - self._logpdf_scale

--- a/pycbc/distributions/joint.py
+++ b/pycbc/distributions/joint.py
@@ -219,22 +219,22 @@ class JointDistribution(object):
     def __call__(self, **params):
         """Evaluate joint distribution for parameters.
         """
-        # convert to Field array
-        parray, return_atomic = self._ensure_fieldarray(params)
         # check if statisfies constraints
-        isin = self.contains(parray)
-        if not isin.any():
-            if return_atomic:
-                out = -numpy.inf
-            else:
-                out = numpy.full(parray.shape, -numpy.inf)
-            return out
-        # evaulate
+        if len(self._constraints) != 0:
+            isin = self.contains(parray)
+            if not isin.any():
+                if numpy.isscalar(isin):
+                    out = -numpy.inf
+                else:
+                    out = numpy.full(parray.shape, -numpy.inf)
+                return out
+
+        # evaluate
         # note: this step may fail if arrays of values were provided, as
         # not all distributions are vectorized currently
         logps = numpy.array([d(**params) for d in self.distributions])
-        logp = logps.sum(axis=0) + numpy.log(isin.astype(float))
-        if return_atomic:
+        logp = logps.sum(axis=0)
+        if numpy.isscalar(logp):
             logp = logp.item()
         return logp - self._logpdf_scale
 

--- a/pycbc/distributions/joint.py
+++ b/pycbc/distributions/joint.py
@@ -221,6 +221,7 @@ class JointDistribution(object):
         """
         # check if statisfies constraints
         if len(self._constraints) != 0:
+            parray, _ = self._ensure_fieldarray(params)
             isin = self.contains(parray)
             if not isin.any():
                 if numpy.isscalar(isin):

--- a/pycbc/distributions/joint.py
+++ b/pycbc/distributions/joint.py
@@ -233,9 +233,14 @@ class JointDistribution(object):
         # note: this step may fail if arrays of values were provided, as
         # not all distributions are vectorized currently
         logps = numpy.array([d(**params) for d in self.distributions])
-        logp = logps.sum(axis=0) + numpy.log(isin.astype(float))
+        logp = logps.sum(axis=0)
+
+        if len(self._constraints) != 0:
+            logp += numpy.log(isin.astype(float))
+
         if numpy.isscalar(logp):
             logp = logp.item()
+
         return logp - self._logpdf_scale
 
     def rvs(self, size=1):


### PR DESCRIPTION
The ensure field array is a *very* slow function and should be avoided when possible to not bog down fast likelihoods where we don't have constraints.
