### PR TITLE
fixes to spa for python3

### DIFF
--- a/pycbc/waveform/spa_tmplt.py
+++ b/pycbc/waveform/spa_tmplt.py
@@ -142,7 +142,7 @@ def spa_distance(psd, mass1, mass2, lower_frequency_cutoff, snr=8):
     kend = int(spa_tmplt_end(mass1=mass1, mass2=mass2) / psd.delta_f)
     norm1 = spa_tmplt_norm(psd, len(psd), psd.delta_f, lower_frequency_cutoff)
     norm2 = (spa_amplitude_factor(mass1=mass1, mass2=mass2)) ** 2.0
-    print kend, norm1, norm2
+
     if kend >= len(psd):
         kend = len(psd) - 2
     return sqrt(norm1[kend] * norm2) / snr

--- a/pycbc/waveform/spa_tmplt.py
+++ b/pycbc/waveform/spa_tmplt.py
@@ -139,12 +139,12 @@ def spa_distance(psd, mass1, mass2, lower_frequency_cutoff, snr=8):
     """ Return the distance at a given snr (default=8) of the SPA TaylorF2
     template.
     """
-    kend = spa_tmplt_end(mass1=mass1, mass2=mass2) / psd.delta_f
+    kend = int(spa_tmplt_end(mass1=mass1, mass2=mass2) / psd.delta_f)
     norm1 = spa_tmplt_norm(psd, len(psd), psd.delta_f, lower_frequency_cutoff)
     norm2 = (spa_amplitude_factor(mass1=mass1, mass2=mass2)) ** 2.0
-
+    print kend, norm1, norm2
     if kend >= len(psd):
-        kend = len(psd) - 1
+        kend = len(psd) - 2
     return sqrt(norm1[kend] * norm2) / snr
 
 @schemed("pycbc.waveform.spa_tmplt_")


### PR DESCRIPTION
Fix an instance of float value used as index (problem for python3). Also fixed index error in spa_tmplt for psds which are undefined at the nyquist (not normal use of this function, but other sources of PSDs don't provide a value here which can cause problems). 