### PR TITLE
Add model with numerical marginalization of the polarization angle

### DIFF
--- a/pycbc/inference/models/__init__.py
+++ b/pycbc/inference/models/__init__.py
@@ -23,7 +23,7 @@ assuming various noise models.
 from .analytic import (TestEggbox, TestNormal, TestRosenbrock, TestVolcano,
                        TestPrior)
 from .gaussian_noise import GaussianNoise
-from .marginalized_gaussian_noise import MarginalizedPhaseGaussianNoise
+from .marginalized_gaussian_noise import MarginalizedPhaseGaussianNoise, MarginalizedPolarization
 from .single_template import SingleTemplate
 from .relbin import Relative
 
@@ -182,6 +182,7 @@ models = {_cls.name: _cls for _cls in (
     TestPrior,
     GaussianNoise,
     MarginalizedPhaseGaussianNoise,
+    MarginlizedPolarization,
     SingleTemplate,
     Relative
 )}

--- a/pycbc/inference/models/__init__.py
+++ b/pycbc/inference/models/__init__.py
@@ -22,8 +22,9 @@ assuming various noise models.
 
 from .analytic import (TestEggbox, TestNormal, TestRosenbrock, TestVolcano,
                        TestPrior)
-from .gaussian_noise import GaussianNoise, MarginalizedPolarization
+from .gaussian_noise import GaussianNoise
 from .marginalized_gaussian_noise import MarginalizedPhaseGaussianNoise
+from .marginalized_gaussian_noise import MarginalizedPolarization
 from .single_template import SingleTemplate
 from .relbin import Relative
 

--- a/pycbc/inference/models/__init__.py
+++ b/pycbc/inference/models/__init__.py
@@ -22,8 +22,8 @@ assuming various noise models.
 
 from .analytic import (TestEggbox, TestNormal, TestRosenbrock, TestVolcano,
                        TestPrior)
-from .gaussian_noise import GaussianNoise
-from .marginalized_gaussian_noise import MarginalizedPhaseGaussianNoise, MarginalizedPolarization
+from .gaussian_noise import GaussianNoise, MarginalizedPolarization
+from .marginalized_gaussian_noise import MarginalizedPhaseGaussianNoise
 from .single_template import SingleTemplate
 from .relbin import Relative
 
@@ -182,7 +182,7 @@ models = {_cls.name: _cls for _cls in (
     TestPrior,
     GaussianNoise,
     MarginalizedPhaseGaussianNoise,
-    MarginlizedPolarization,
+    MarginalizedPolarization,
     SingleTemplate,
     Relative
 )}

--- a/pycbc/inference/models/gaussian_noise.py
+++ b/pycbc/inference/models/gaussian_noise.py
@@ -31,6 +31,9 @@ from pycbc.strain.calibration import Recalibrate
 from pycbc.inject import InjectionSet
 from pycbc.io import FieldArray
 from pycbc.types.optparse import MultiDetOptionAction
+from pycbc.detector import Detector
+
+from scipy.special import logsumexp
 
 from .base import ModelStats
 from .base_data import BaseDataModel
@@ -928,6 +931,105 @@ class GaussianNoise(BaseGaussianNoise):
             # now try returning again
             return getattr(self._current_stats, '{}_optimal_snrsq'.format(det))
 
+class MarginalizedPolarization(BaseGaussianNoise):
+    r"""
+    """
+    name = 'marginalized_polarization'
+
+    def __init__(self, variable_params, data, low_frequency_cutoff, psds=None,
+                 high_frequency_cutoff=None, normalize=False,
+                 polarization_sampes=1000,
+                 static_params=None, **kwargs):
+        # set up the boiler-plate attributes
+        super(GaussianNoise, self).__init__(
+            variable_params, data, low_frequency_cutoff, psds=psds,
+            high_frequency_cutoff=high_frequency_cutoff, normalize=normalize,
+            static_params=static_params, **kwargs)
+        # create the waveform generator
+        self.waveform_generator = create_waveform_generator(
+            self.variable_params, self.data,
+            waveform_transforms=self.waveform_transforms,
+            recalibration=self.recalibration,
+            gates=self.gates, **self.static_params)
+
+        self.polarization_samples = polarization_samples
+        self.pol = numpy.linspace(0, 2*numpy.pi, self.polarization_samples)
+        self.dets = {}
+
+    def _nowaveform_loglr(self):
+        """Convenience function to set loglr values if no waveform generated.
+        """
+        return -numpy.inf
+
+    def _loglr(self):
+        r"""Computes the log likelihood ratio,
+
+        .. math::
+
+            \log \mathcal{L}(\Theta) = \sum_i
+                \left<h_i(\Theta)|d_i\right> -
+                \frac{1}{2}\left<h_i(\Theta)|h_i(\Theta)\right>,
+
+        at the current parameter values :math:`\Theta`.
+
+        Returns
+        -------
+        float
+            The value of the log likelihood ratio.
+        """
+        params = self.current_params
+        try:
+            wfs = self.waveform_generator.generate(**params)
+        except NoWaveformError:
+            return self._nowaveform_loglr()
+        except FailedWaveformError as e:
+            if self.ignore_failed_waveforms:
+                return self._nowaveform_loglr()
+            else:
+                raise e
+
+        lr = 0.
+        for det, (hp, hc) in wfs.items():
+            if det not in self.dets:
+                self.dets[det] = Detector(det)
+            det = self.dets[det]
+            fp, fc = det.antenna_pattern(self.current_params['ra'],
+                                         self.current_params['dec'],
+                                         self.pol,
+                                         self.current_params['tc'])
+
+            # the kmax of the waveforms may be different than internal kmax
+            kmax = min(len(h), self._kmax[det])
+            slc = slice(self._kmin[det], kmax)
+
+            # whiten both polarizations
+            hp[self._kmin[det]:kmax] *= self._weight[det][slc]
+            hc[self._kmin[det]:kmax] *= self._weight[det][slc]
+
+            # h = fp * hp + hc * hc
+            # <h, d> = fp * <hp,d> + fc * <hc,d>
+            # the inner products
+            cplx_hpd = self._whitened_data[det][slc].inner(hp[slc])  # <hp, d>
+            cplx_hcd = self._whitened_data[det][slc].inner(hc[slc])  # <hc, d>
+
+            cplx_hd = fp * cplx_hpd + fc * cplx_hcd
+
+            # <h, h> = <fp * hp + fc * hc, fp * hp + fc * hc>
+            # = Real(fpfp * <hp,hp> + fcfc * <hc,hc> + fphc * (<hp, hc> + <hc, hp>))
+            hphp = hp[slc].inner(hp[slc]).real  # < hp, hp>
+            hchc = hc[slc].inner(hc[slc]).real  # <hc, hc>
+
+            # Below could be combined, but too tired to figure out
+            # if there should be a sign applied if so
+            hphc = h[slc].inner(h[slc]).real  # <hp, hc>
+            hchp = h[slc].inner(h[slc]).real  # <hc, hp>
+
+            hh = fp * fp * hphp + fc * fc * hchc + fp * fc * (hphc + hchp)
+
+            cplx_loglr = cplx_hd - 0.5 * hh
+            lr += logsumexp(cplx_loglr.real)
+
+        return float(lr)
 
 #
 # =============================================================================

--- a/pycbc/inference/models/gaussian_noise.py
+++ b/pycbc/inference/models/gaussian_noise.py
@@ -950,7 +950,7 @@ class MarginalizedPolarization(BaseGaussianNoise):
             self.variable_params, self.data,
             waveform_transforms=self.waveform_transforms,
             recalibration=self.recalibration,
-            generator_class=generator.FDomainDetFrameTwoPolGenerator
+            generator_class=generator.FDomainDetFrameTwoPolGenerator,
             gates=self.gates, **self.static_params)
 
         self.polarization_samples = polarization_samples

--- a/pycbc/inference/models/gaussian_noise.py
+++ b/pycbc/inference/models/gaussian_noise.py
@@ -1028,7 +1028,7 @@ class MarginalizedPolarization(BaseGaussianNoise):
             hh = fp * fp * hphp + fc * fc * hchc + fp * fc * (hphc + hchp)
 
             cplx_loglr = cplx_hd - 0.5 * hh
-            lr += logsumexp(cplx_loglr.real)
+            lr += logsumexp(cplx_loglr.real) - numpy.log(len(self.pol))
 
         return float(lr)
 

--- a/pycbc/inference/models/gaussian_noise.py
+++ b/pycbc/inference/models/gaussian_noise.py
@@ -938,7 +938,7 @@ class MarginalizedPolarization(BaseGaussianNoise):
 
     def __init__(self, variable_params, data, low_frequency_cutoff, psds=None,
                  high_frequency_cutoff=None, normalize=False,
-                 polarization_sampes=1000,
+                 polarization_samples=1000,
                  static_params=None, **kwargs):
         # set up the boiler-plate attributes
         super(GaussianNoise, self).__init__(

--- a/pycbc/inference/models/gaussian_noise.py
+++ b/pycbc/inference/models/gaussian_noise.py
@@ -1027,10 +1027,11 @@ class MarginalizedPolarization(BaseGaussianNoise):
 
             hh = fp * fp * hphp + fc * fc * hchc + fp * fc * (hphc + hchp)
 
-            cplx_loglr = cplx_hd - 0.5 * hh
-            lr += logsumexp(cplx_loglr.real) - numpy.log(len(self.pol))
+            lr += cplx_hd.real - 0.5 * hh
 
-        return float(lr)
+        lr_total = logsumexp(lr) - numpy.log(len(self.pol))
+
+        return float(lr_total)
 
 #
 # =============================================================================

--- a/pycbc/inference/models/gaussian_noise.py
+++ b/pycbc/inference/models/gaussian_noise.py
@@ -935,6 +935,8 @@ class GaussianNoise(BaseGaussianNoise):
 #
 # =============================================================================
 #
+
+
 def get_values_from_injection(cp, injection_file, update_cp=True):
     """Replaces all FROM_INJECTION values in a config file with the
     corresponding value from the injection.
@@ -1045,10 +1047,11 @@ def get_values_from_injection(cp, injection_file, update_cp=True):
     return replace_params
 
 
-def create_waveform_generator(variable_params, data, waveform_transforms=None,
-                              recalibration=None, gates=None,
-                              generator_class=generator.FDomainDetFrameGenerator,
-                              **static_params):
+def create_waveform_generator(
+                variable_params, data, waveform_transforms=None,
+                recalibration=None, gates=None,
+                generator_class=generator.FDomainDetFrameGenerator,
+                **static_params):
     """Creates a waveform generator for use with a model.
 
     Parameters

--- a/pycbc/inference/models/gaussian_noise.py
+++ b/pycbc/inference/models/gaussian_noise.py
@@ -950,6 +950,7 @@ class MarginalizedPolarization(BaseGaussianNoise):
             self.variable_params, self.data,
             waveform_transforms=self.waveform_transforms,
             recalibration=self.recalibration,
+            generator_class=generator.FDomainDetFrameTwoPolGenerator
             gates=self.gates, **self.static_params)
 
         self.polarization_samples = polarization_samples
@@ -1150,6 +1151,7 @@ def get_values_from_injection(cp, injection_file, update_cp=True):
 
 def create_waveform_generator(variable_params, data, waveform_transforms=None,
                               recalibration=None, gates=None,
+                              generator_class=generator.FDomainDetFrameGenerator,
                               **static_params):
     """Creates a waveform generator for use with a model.
 
@@ -1191,6 +1193,7 @@ def create_waveform_generator(variable_params, data, waveform_transforms=None,
         approximant = static_params['approximant']
     except KeyError:
         raise ValueError("no approximant provided in the static args")
+
     generator_function = generator.select_waveform_generator(approximant)
     # get data parameters; we'll just use one of the data to get the
     # values, then check that all the others are the same
@@ -1205,7 +1208,7 @@ def create_waveform_generator(variable_params, data, waveform_transforms=None,
                         d.start_time == start_time]):
                 raise ValueError("data must all have the same delta_t, "
                                  "delta_f, and start_time")
-    waveform_generator = generator.FDomainDetFrameGenerator(
+    waveform_generator = generator_class(
         generator_function, epoch=start_time,
         variable_args=variable_params, detectors=list(data.keys()),
         delta_f=delta_f, delta_t=delta_t,

--- a/pycbc/inference/models/marginalized_gaussian_noise.py
+++ b/pycbc/inference/models/marginalized_gaussian_noise.py
@@ -190,6 +190,7 @@ class MarginalizedPhaseGaussianNoise(BaseGaussianNoise):
         self._current_stats.maxl_phase = numpy.angle(hd)
         return numpy.log(special.i0e(hd)) + hd - 0.5*hh
 
+
 class MarginalizedPolarization(BaseGaussianNoise):
     r""" This likelihood numerically marginalizes over polarization angle
 

--- a/pycbc/inference/models/marginalized_gaussian_noise.py
+++ b/pycbc/inference/models/marginalized_gaussian_noise.py
@@ -235,7 +235,7 @@ class MarginalizedPolarization(BaseGaussianNoise):
     def _nowaveform_loglr(self):
         """Convenience function to set loglr values if no waveform generated.
         """
-        setattr(self._current_stats, 'loglikelihood', -numpy.inf)
+        setattr(self._current_stats, 'loglr', -numpy.inf)
         # maxl phase doesn't exist, so set it to nan
         setattr(self._current_stats, 'maxl_polarization', numpy.nan)
         for det in self._data:

--- a/pycbc/inference/models/marginalized_gaussian_noise.py
+++ b/pycbc/inference/models/marginalized_gaussian_noise.py
@@ -21,8 +21,9 @@ distance.
 import numpy
 from scipy import special
 
+from pycbc.waveform import generator
 from pycbc.waveform import (NoWaveformError, FailedWaveformError)
-
+from pycbc.detector import Detector
 from .gaussian_noise import (BaseGaussianNoise, create_waveform_generator)
 
 
@@ -188,3 +189,137 @@ class MarginalizedPhaseGaussianNoise(BaseGaussianNoise):
         hd = abs(hd)
         self._current_stats.maxl_phase = numpy.angle(hd)
         return numpy.log(special.i0e(hd)) + hd - 0.5*hh
+
+class MarginalizedPolarization(BaseGaussianNoise):
+    r""" This likelihood numerically marginalizes over polarization angle
+
+    This class implements the Gaussian likelihood with an explicit numerical
+    marginalization over polarization angle. This is accomplished using
+    a fixed set of integration points distribution uniformation between
+    0 and 2pi. By default, 1000 integration points are used.
+    The 'polarization_samples' argument can be passed to set an alternate
+    number of integration points.
+    """
+    name = 'marginalized_polarization'
+
+    def __init__(self, variable_params, data, low_frequency_cutoff, psds=None,
+                 high_frequency_cutoff=None, normalize=False,
+                 polarization_samples=1000,
+                 static_params=None, **kwargs):
+        # set up the boiler-plate attributes
+        super(MarginalizedPolarization, self).__init__(
+            variable_params, data, low_frequency_cutoff, psds=psds,
+            high_frequency_cutoff=high_frequency_cutoff, normalize=normalize,
+            static_params=static_params, **kwargs)
+        # create the waveform generator
+        self.waveform_generator = create_waveform_generator(
+            self.variable_params, self.data,
+            waveform_transforms=self.waveform_transforms,
+            recalibration=self.recalibration,
+            generator_class=generator.FDomainDetFrameTwoPolGenerator,
+            gates=self.gates, **self.static_params)
+
+        self.polarization_samples = polarization_samples
+        self.pol = numpy.linspace(0, 2*numpy.pi, self.polarization_samples)
+        self.dets = {}
+
+    @property
+    def _extra_stats(self):
+        """Adds ``loglr``, ``maxl_polarization``, and the ``optimal_snrsq`` in
+        each detector.
+        """
+        return ['loglr', 'maxl_polarization'] + \
+               ['{}_optimal_snrsq'.format(det) for det in self._data]
+
+    def _nowaveform_loglr(self):
+        """Convenience function to set loglr values if no waveform generated.
+        """
+        setattr(self._current_stats, 'loglikelihood', -numpy.inf)
+        # maxl phase doesn't exist, so set it to nan
+        setattr(self._current_stats, 'maxl_polarization', numpy.nan)
+        for det in self._data:
+            # snr can't be < 0 by definition, so return 0
+            setattr(self._current_stats, '{}_optimal_snrsq'.format(det), 0.)
+        return -numpy.inf
+
+    def _loglr(self):
+        r"""Computes the log likelihood ratio,
+
+        .. math::
+
+            \log \mathcal{L}(\Theta) = \sum_i
+                \left<h_i(\Theta)|d_i\right> -
+                \frac{1}{2}\left<h_i(\Theta)|h_i(\Theta)\right>,
+
+        at the current parameter values :math:`\Theta`.
+
+        Returns
+        -------
+        float
+            The value of the log likelihood ratio.
+        """
+        params = self.current_params
+        try:
+            wfs = self.waveform_generator.generate(**params)
+        except NoWaveformError:
+            return self._nowaveform_loglr()
+        except FailedWaveformError as e:
+            if self.ignore_failed_waveforms:
+                return self._nowaveform_loglr()
+            else:
+                raise e
+
+        lr = 0.
+        for det, (hp, hc) in wfs.items():
+            if det not in self.dets:
+                self.dets[det] = Detector(det)
+            fp, fc = self.dets[det].antenna_pattern(self.current_params['ra'],
+                                                    self.current_params['dec'],
+                                                    self.pol,
+                                                    self.current_params['tc'])
+
+            # the kmax of the waveforms may be different than internal kmax
+            kmax = min(max(len(hp), len(hc)), self._kmax[det])
+            slc = slice(self._kmin[det], kmax)
+
+            # whiten both polarizations
+            hp[self._kmin[det]:kmax] *= self._weight[det][slc]
+            hc[self._kmin[det]:kmax] *= self._weight[det][slc]
+
+            # h = fp * hp + hc * hc
+            # <h, d> = fp * <hp,d> + fc * <hc,d>
+            # the inner products
+            cplx_hpd = self._whitened_data[det][slc].inner(hp[slc])  # <hp, d>
+            cplx_hcd = self._whitened_data[det][slc].inner(hc[slc])  # <hc, d>
+
+            cplx_hd = fp * cplx_hpd + fc * cplx_hcd
+
+            # <h, h> = <fp * hp + fc * hc, fp * hp + fc * hc>
+            # = Real(fpfp * <hp,hp> + fcfc * <hc,hc> + \
+            #  fphc * (<hp, hc> + <hc, hp>))
+            hphp = hp[slc].inner(hp[slc]).real  # < hp, hp>
+            hchc = hc[slc].inner(hc[slc]).real  # <hc, hc>
+
+            # Below could be combined, but too tired to figure out
+            # if there should be a sign applied if so
+            hphc = hp[slc].inner(hc[slc]).real  # <hp, hc>
+            hchp = hc[slc].inner(hp[slc]).real  # <hc, hp>
+
+            hh = fp * fp * hphp + fc * fc * hchc + fp * fc * (hphc + hchp)
+            # store
+            setattr(self._current_stats, '{}_optimal_snrsq'.format(det), hh)
+            lr += cplx_hd.real - 0.5 * hh
+
+        lr_total = special.logsumexp(lr) - numpy.log(len(self.pol))
+
+        # store the maxl polarization
+        idx = lr.argmax()
+        setattr(self._current_stats, 'maxl_polarization', self.pol[idx])
+
+        # just store the maxl optimal snrsq
+        for det in wfs:
+            p = '{}_optimal_snrsq'.format(det)
+            setattr(self._current_stats, p,
+                    getattr(self._current_stats, p)[idx])
+
+        return float(lr_total)

--- a/pycbc/waveform/generator.py
+++ b/pycbc/waveform/generator.py
@@ -562,7 +562,7 @@ class FDomainDetFrameTwoPolGenerator(object):
                         dethp, **self.current_params)
                     dethc = self.recalib[detname].map_to_adjust(
                         dethc, **self.current_params)
-                h[det] = (dethp, dethc)
+                h[detname] = (dethp, dethc)
         else:
             # no detector response, just use the + polarization
             if 'tc' in self.current_params:

--- a/pycbc/waveform/generator.py
+++ b/pycbc/waveform/generator.py
@@ -439,7 +439,6 @@ class FDomainDetFrameTwoPolGenerator(object):
           * tc: The GPS time of coalescence (should be geocentric time).
           * ra: Right ascension.
           * dec: declination
-          * polarization: polarization.
 
         All of these must be provided in either the variable args or the
         frozen params if detectors is not None. If detectors
@@ -525,8 +524,13 @@ class FDomainDetFrameTwoPolGenerator(object):
         return _lal.LIGOTimeGPS(self._epoch)
 
     def generate(self, **kwargs):
-        """Generates a waveform, applies a time shift and the detector response
-        function from the given kwargs.
+        """Generates a waveform polarizations and applies a time shift.
+
+        Returns
+        -------
+        dict :
+            Dictionary of ``detector names -> (hp, hc)``, where ``hp, hc`` are
+            the plus and cross polarization, respectively.
         """
         self.current_params.update(kwargs)
         rfparams = {param: self.current_params[param]


### PR DESCRIPTION
This adds a new model accessed by choosing 'marginalized_polarization'. It has one selectable option 'polarization_sampes' which sets how many integration points are used. It is hard coded to use a uniform in polarization prior from 0 to 2pi. 

In testing, the model seems to greatly improve convergence rate in at least some examples where the polarization angle and coa_phase had a complicated 2d histogram. 