### PR TITLE
Adding testingGR parameters for pycbc_inference

### DIFF
--- a/pycbc/waveform/parameters.py
+++ b/pycbc/waveform/parameters.py
@@ -564,7 +564,8 @@ testingGR_params = ParameterList\
 cbc_intrinsic_params = ParameterList\
     ([mass1, mass2, spin1x, spin1y, spin1z, spin2x, spin2y, spin2z,
       eccentricity, lambda1, lambda2, dquad_mon1, dquad_mon2, lambda_octu1,
-      lambda_octu2, quadfmode1, quadfmode2, octufmode1, octufmode2]) + testingGR_params
+      lambda_octu2, quadfmode1, quadfmode2, octufmode1, octufmode2])
+    + testingGR_params
 
 # the parameters of a cbc in the radiation frame
 cbc_rframe_params = cbc_intrinsic_params + orientation_params

--- a/pycbc/waveform/parameters.py
+++ b/pycbc/waveform/parameters.py
@@ -554,9 +554,10 @@ extrinsic_params = orientation_params + location_params
 
 
 # testing GR parameters
-testingGR_params = ParameterList([dchi0, dchi1, dchi2, dchi3, dchi4,\
-    dchi5, dchi5l, dchi6, dchi6l, dchi7, dalpha1, dalpha2, dalpha3,\
-    dalpha4, dalpha5, dbeta1, dbeta2, dbeta3])
+testingGR_params = ParameterList\
+    ([dchi0, dchi1, dchi2, dchi3, dchi4, dchi5, dchi5l, dchi6, dchi6l, 
+    dchi7, dalpha1, dalpha2, dalpha3,dalpha4, dalpha5, 
+    dbeta1, dbeta2, dbeta3])
 
 # intrinsic parameters of a CBC waveform. Some of these are not recognized
 # by every waveform model
@@ -564,7 +565,7 @@ cbc_intrinsic_params = ParameterList\
     ([mass1, mass2, spin1x, spin1y, spin1z, spin2x, spin2y, spin2z,
       eccentricity, lambda1, lambda2, dquad_mon1, dquad_mon2, lambda_octu1,
       lambda_octu2, quadfmode1, quadfmode2, octufmode1, octufmode2])\
-       + testingGR_params
+      + testingGR_params
 
 # the parameters of a cbc in the radiation frame
 cbc_rframe_params = cbc_intrinsic_params + orientation_params

--- a/pycbc/waveform/parameters.py
+++ b/pycbc/waveform/parameters.py
@@ -556,16 +556,15 @@ extrinsic_params = orientation_params + location_params
 # testing GR parameters
 testingGR_params = ParameterList\
     ([dchi0, dchi1, dchi2, dchi3, dchi4, dchi5, dchi5l, dchi6, dchi6l,
-    dchi7, dalpha1, dalpha2, dalpha3, dalpha4, dalpha5,
-    dbeta1, dbeta2, dbeta3])
+      dchi7, dalpha1, dalpha2, dalpha3, dalpha4, dalpha5,
+      dbeta1, dbeta2, dbeta3])
 
 # intrinsic parameters of a CBC waveform. Some of these are not recognized
 # by every waveform model
 cbc_intrinsic_params = ParameterList\
     ([mass1, mass2, spin1x, spin1y, spin1z, spin2x, spin2y, spin2z,
-    eccentricity, lambda1, lambda2, dquad_mon1, dquad_mon2, lambda_octu1,
-    lambda_octu2, quadfmode1, quadfmode2, octufmode1, octufmode2])\
-    + testingGR_params
+      eccentricity, lambda1, lambda2, dquad_mon1, dquad_mon2, lambda_octu1,
+      lambda_octu2, quadfmode1, quadfmode2, octufmode1, octufmode2]) + testingGR_params
 
 # the parameters of a cbc in the radiation frame
 cbc_rframe_params = cbc_intrinsic_params + orientation_params

--- a/pycbc/waveform/parameters.py
+++ b/pycbc/waveform/parameters.py
@@ -470,6 +470,68 @@ mode_array = Parameter("mode_array",
                             "By default pass None and let lalsimulation "
                             "use it's default behaviour."
                             "Example: mode_array = [ [2,2], [2,-2] ]")
+
+#
+#   Parametrized testing general relativity parameters 
+#
+dchi0 = Parameter("dchi0",
+                dtype=float, default=0., label=r"$d\chi_0$",
+                description="0PN testingGR parameter.")
+dchi1 = Parameter("dchi1",
+                dtype=float, default=0., label=r"$d\chi_1$",
+                description="0.5PN testingGR parameter.")
+dchi2 = Parameter("dchi2",
+                dtype=float, default=0., label=r"$d\chi_2$",
+                description="1PN testingGR parameter.")
+dchi3 = Parameter("dchi3",
+                dtype=float, default=0., label=r"$d\chi_3$",
+                description="1.5PN testingGR parameter.")
+dchi4 = Parameter("dchi4",
+                dtype=float, default=0., label=r"$d\chi_4$",
+                description="2PN testingGR parameter.")
+dchi5 = Parameter("dchi5",
+                dtype=float, default=0., label=r"$d\chi_5$",
+                description="2.5PN testingGR parameter.")
+dchi5l = Parameter("dchi5l",
+                dtype=float, default=0., label=r"$d\chi_5{l}$",
+                description="2.5PN logrithm testingGR parameter.")
+dchi6 = Parameter("dchi6",
+                dtype=float, default=0., label=r"$d\chi_6$",
+                description="3PN testingGR parameter.")
+dchi6l = Parameter("dchi6l",
+                dtype=float, default=0., label=r"$d\chi_{6l}$",
+                description="3PN logrithm testingGR parameter.")
+dchi7 = Parameter("dchi7",
+                dtype=float, default=0., label=r"$d\chi_7$",
+                description="3.5PN testingGR parameter.")
+dalpha1 = Parameter("dalpha1",
+                dtype=float, default=0., label=r"$d\alpha_1$",
+                description="Merger-ringdown testingGR parameter.")
+dalpha2 = Parameter("dalpha2",
+                dtype=float, default=0., label=r"$d\alpha_2$",
+                description="Merger-ringdown testingGR parameter.")
+dalpha3 = Parameter("dalpha3",
+                dtype=float, default=0., label=r"$d\alpha_3$",
+                description="Merger-ringdown testingGR parameter.")
+dalpha4 = Parameter("dalpha4",
+                dtype=float, default=0., label=r"$d\alpha_4$",
+                description="Merger-ringdown testingGR parameter.")
+dalpha5 = Parameter("dalpha5",
+                dtype=float, default=0., label=r"$d\alpha_5$",
+                description="Merger-ringdown testingGR parameter.")
+dbeta1 = Parameter("dbeta1",
+                dtype=float, default=0., label=r"$d\beta_1$",
+                description="Intermediate testingGR parameter.")
+dbeta2 = Parameter("dbeta2",
+                dtype=float, default=0., label=r"$d\beta_2$",
+                description="Intermediate testingGR parameter.")
+dbeta3 = Parameter("dbeta3",
+                dtype=float, default=0., label=r"$d\beta_3$",
+                description="Intermediate testingGR parameter.")
+
+
+
+
 #
 # =============================================================================
 #
@@ -494,12 +556,16 @@ orientation_params = ParameterList\
 # the extrinsic parameters of a waveform
 extrinsic_params = orientation_params + location_params
 
+
+#testing GR parameters
+testingGR_params = ParameterList([dchi0,dchi1,dchi2,dchi3,dchi4,dchi5,dchi5l,dchi6,dchi6l,dchi7,dalpha1,dalpha2,dalpha3,dalpha4,dalpha5,dbeta1,dbeta2,dbeta3])
+
 # intrinsic parameters of a CBC waveform. Some of these are not recognized
 # by every waveform model
 cbc_intrinsic_params = ParameterList\
     ([mass1, mass2, spin1x, spin1y, spin1z, spin2x, spin2y, spin2z,
       eccentricity, lambda1, lambda2, dquad_mon1, dquad_mon2, lambda_octu1,
-      lambda_octu2, quadfmode1, quadfmode2, octufmode1, octufmode2])
+      lambda_octu2, quadfmode1, quadfmode2, octufmode1, octufmode2]) + testingGR_params
 
 # the parameters of a cbc in the radiation frame
 cbc_rframe_params = cbc_intrinsic_params + orientation_params

--- a/pycbc/waveform/parameters.py
+++ b/pycbc/waveform/parameters.py
@@ -564,8 +564,8 @@ testingGR_params = ParameterList\
 cbc_intrinsic_params = ParameterList\
     ([mass1, mass2, spin1x, spin1y, spin1z, spin2x, spin2y, spin2z,
       eccentricity, lambda1, lambda2, dquad_mon1, dquad_mon2, lambda_octu1,
-      lambda_octu2, quadfmode1, quadfmode2, octufmode1, octufmode2])
-    + testingGR_params
+      lambda_octu2, quadfmode1, quadfmode2, octufmode1, octufmode2]) + \
+    testingGR_params
 
 # the parameters of a cbc in the radiation frame
 cbc_rframe_params = cbc_intrinsic_params + orientation_params

--- a/pycbc/waveform/parameters.py
+++ b/pycbc/waveform/parameters.py
@@ -555,17 +555,17 @@ extrinsic_params = orientation_params + location_params
 
 # testing GR parameters
 testingGR_params = ParameterList\
-    ([dchi0, dchi1, dchi2, dchi3, dchi4, dchi5, dchi5l, dchi6, dchi6l, 
-    dchi7, dalpha1, dalpha2, dalpha3,dalpha4, dalpha5, 
+    ([dchi0, dchi1, dchi2, dchi3, dchi4, dchi5, dchi5l, dchi6, dchi6l,
+    dchi7, dalpha1, dalpha2, dalpha3, dalpha4, dalpha5,
     dbeta1, dbeta2, dbeta3])
 
 # intrinsic parameters of a CBC waveform. Some of these are not recognized
 # by every waveform model
 cbc_intrinsic_params = ParameterList\
     ([mass1, mass2, spin1x, spin1y, spin1z, spin2x, spin2y, spin2z,
-      eccentricity, lambda1, lambda2, dquad_mon1, dquad_mon2, lambda_octu1,
-      lambda_octu2, quadfmode1, quadfmode2, octufmode1, octufmode2])\
-      + testingGR_params
+    eccentricity, lambda1, lambda2, dquad_mon1, dquad_mon2, lambda_octu1,
+    lambda_octu2, quadfmode1, quadfmode2, octufmode1, octufmode2])\
+    + testingGR_params
 
 # the parameters of a cbc in the radiation frame
 cbc_rframe_params = cbc_intrinsic_params + orientation_params

--- a/pycbc/waveform/parameters.py
+++ b/pycbc/waveform/parameters.py
@@ -528,10 +528,6 @@ dbeta2 = Parameter("dbeta2",
 dbeta3 = Parameter("dbeta3",
                 dtype=float, default=0., label=r"$d\beta_3$",
                 description="Intermediate testingGR parameter.")
-
-
-
-
 #
 # =============================================================================
 #
@@ -557,8 +553,10 @@ orientation_params = ParameterList\
 extrinsic_params = orientation_params + location_params
 
 
-#testing GR parameters
-testingGR_params = ParameterList([dchi0,dchi1,dchi2,dchi3,dchi4,dchi5,dchi5l,dchi6,dchi6l,dchi7,dalpha1,dalpha2,dalpha3,dalpha4,dalpha5,dbeta1,dbeta2,dbeta3])
+# testing GR parameters
+testingGR_params = ParameterList([dchi0, dchi1, dchi2, dchi3, dchi4, dchi5, \
+    dchi5l, dchi6, dchi6l, dchi7, dalpha1, dalpha2, dalpha3, dalpha4, dalpha5, \
+    dbeta1, dbeta2, dbeta3])
 
 # intrinsic parameters of a CBC waveform. Some of these are not recognized
 # by every waveform model

--- a/pycbc/waveform/parameters.py
+++ b/pycbc/waveform/parameters.py
@@ -472,7 +472,7 @@ mode_array = Parameter("mode_array",
                             "Example: mode_array = [ [2,2], [2,-2] ]")
 
 #
-#   Parametrized testing general relativity parameters 
+#   Parametrized testing general relativity parameters
 #
 dchi0 = Parameter("dchi0",
                 dtype=float, default=0., label=r"$d\chi_0$",
@@ -554,16 +554,17 @@ extrinsic_params = orientation_params + location_params
 
 
 # testing GR parameters
-testingGR_params = ParameterList([dchi0, dchi1, dchi2, dchi3, dchi4, dchi5, \
-    dchi5l, dchi6, dchi6l, dchi7, dalpha1, dalpha2, dalpha3, dalpha4, dalpha5, \
-    dbeta1, dbeta2, dbeta3])
+testingGR_params = ParameterList([dchi0, dchi1, dchi2, dchi3, dchi4,\
+    dchi5, dchi5l, dchi6, dchi6l, dchi7, dalpha1, dalpha2, dalpha3,\
+    dalpha4, dalpha5, dbeta1, dbeta2, dbeta3])
 
 # intrinsic parameters of a CBC waveform. Some of these are not recognized
 # by every waveform model
 cbc_intrinsic_params = ParameterList\
     ([mass1, mass2, spin1x, spin1y, spin1z, spin2x, spin2y, spin2z,
       eccentricity, lambda1, lambda2, dquad_mon1, dquad_mon2, lambda_octu1,
-      lambda_octu2, quadfmode1, quadfmode2, octufmode1, octufmode2]) + testingGR_params
+      lambda_octu2, quadfmode1, quadfmode2, octufmode1, octufmode2])\
+       + testingGR_params
 
 # the parameters of a cbc in the radiation frame
 cbc_rframe_params = cbc_intrinsic_params + orientation_params

--- a/pycbc/waveform/waveform.py
+++ b/pycbc/waveform/waveform.py
@@ -135,7 +135,7 @@ def _check_lal_pars(p):
             lalsimulation.SimInspiralModeArrayActivateMode(ma, l, m)
         lalsimulation.SimInspiralWaveformParamsInsertModeArray(lal_pars, ma)
 
-    # TestingGR parameters:
+    #TestingGR parameters:
     if p['dchi0'] is not None:
         lalsimulation.SimInspiralWaveformParamsInsertNonGRDChi0(lal_pars,p['dchi0'])
     if p['dchi1'] is not None:

--- a/pycbc/waveform/waveform.py
+++ b/pycbc/waveform/waveform.py
@@ -135,6 +135,43 @@ def _check_lal_pars(p):
             lalsimulation.SimInspiralModeArrayActivateMode(ma, l, m)
         lalsimulation.SimInspiralWaveformParamsInsertModeArray(lal_pars, ma)
 
+    # TestingGR parameters:
+    if p['dchi0'] is not None:
+        lalsimulation.SimInspiralWaveformParamsInsertNonGRDChi0(lal_pars,p['dchi0'])
+    if p['dchi1'] is not None:
+        lalsimulation.SimInspiralWaveformParamsInsertNonGRDChi1(lal_pars,p['dchi1'])
+    if p['dchi2'] is not None:
+        lalsimulation.SimInspiralWaveformParamsInsertNonGRDChi2(lal_pars,p['dchi2'])
+    if p['dchi3'] is not None:
+        lalsimulation.SimInspiralWaveformParamsInsertNonGRDChi3(lal_pars,p['dchi3'])
+    if p['dchi4'] is not None:
+        lalsimulation.SimInspiralWaveformParamsInsertNonGRDChi4(lal_pars,p['dchi4'])
+    if p['dchi5'] is not None:
+        lalsimulation.SimInspiralWaveformParamsInsertNonGRDChi5(lal_pars,p['dchi5'])
+    if p['dchi5l'] is not None:
+        lalsimulation.SimInspiralWaveformParamsInsertNonGRDChi5L(lal_pars,p['dchi5l'])
+    if p['dchi6'] is not None:
+        lalsimulation.SimInspiralWaveformParamsInsertNonGRDChi6(lal_pars,p['dchi6'])
+    if p['dchi6l'] is not None:
+        lalsimulation.SimInspiralWaveformParamsInsertNonGRDChi6L(lal_pars,p['dchi6l'])
+    if p['dchi7'] is not None:
+        lalsimulation.SimInspiralWaveformParamsInsertNonGRDChi7(lal_pars,p['dchi7'])
+    if p['dalpha1'] is not None:
+        lalsimulation.SimInspiralWaveformParamsInsertNonGRDAlpha1(lal_pars,p['dalpha1'])
+    if p['dalpha2'] is not None:
+        lalsimulation.SimInspiralWaveformParamsInsertNonGRDAlpha2(lal_pars,p['dalpha2'])
+    if p['dalpha3'] is not None:
+        lalsimulation.SimInspiralWaveformParamsInsertNonGRDAlpha3(lal_pars,p['dalpha3'])
+    if p['dalpha4'] is not None:
+        lalsimulation.SimInspiralWaveformParamsInsertNonGRDAlpha4(lal_pars,p['dalpha4'])
+    if p['dalpha5'] is not None:
+        lalsimulation.SimInspiralWaveformParamsInsertNonGRDAlpha5(lal_pars,p['dalpha5'])
+    if p['dbeta1'] is not None:
+        lalsimulation.SimInspiralWaveformParamsInsertNonGRDBeta1(lal_pars,p['dbeta1'])
+    if p['dbeta2'] is not None:
+        lalsimulation.SimInspiralWaveformParamsInsertNonGRDBeta2(lal_pars,p['dbeta2'])
+    if p['dbeta3'] is not None:
+        lalsimulation.SimInspiralWaveformParamsInsertNonGRDBeta3(lal_pars,p['dbeta3'])
     return lal_pars
 
 def _lalsim_td_waveform(**p):

--- a/pycbc/waveform/waveform.py
+++ b/pycbc/waveform/waveform.py
@@ -134,7 +134,6 @@ def _check_lal_pars(p):
         for l,m in p['mode_array']:
             lalsimulation.SimInspiralModeArrayActivateMode(ma, l, m)
         lalsimulation.SimInspiralWaveformParamsInsertModeArray(lal_pars, ma)
-
     #TestingGR parameters:
     if p['dchi0'] is not None:
         lalsimulation.SimInspiralWaveformParamsInsertNonGRDChi0(lal_pars,p['dchi0'])


### PR DESCRIPTION
This pull/merger request introduces 18 parametrized testingGR parameters into pycbc_inference. The parametrized TGR formalism is based on IMRPhenomD (and its successor) parametrization,  and introduces a fractional deviation for the waveform coefficients compared to its GR value. i.e. `p_nonGR = (1+delta p) * p_GR`. The GR value for those coefficients, p_GR, can be found in the IMRPhenomD [paper](https://arxiv.org/abs/1508.07253).

The `delta p` parameters introduced in this MR are `dchi0, dchi1, dchi2, dchi3, dchi4, dchi5, dchi5l, dchi6, dchi6l, dchi7`(post-Newtonian coefficients in inspiral region), `dbeta1, dbeta2, dbeta3`(intermediate region coefficients), and `dalpha1, dalpha2, dalpha3, dalpha4, dalpha5` (merger-ringdown region coefficients), see IMRPhenomD [paper](https://arxiv.org/abs/1508.07253) for details. GR waveform is consistent with GW data if these `delta p` parameters are zero. Constraints with GWTC-1 events can be found in LVC [paper ](http://arxiv.org/abs/1903.04467) (dbeta1, dalpha1, and dalpha5 are not constrained because they are determined by the smooth connection condition, neither for dchi5 because it's degenerated with coalescence phase).

Add the following to pycbc_inference configuration files to use dchi0 parameters:

> [variable_params]             
> dchi0 = 
> 
> [prior-dchi0]
> name = uniform
> min-dchi0 = -3
> max-dchi0 = 3 


An example of testing dchi0 with GW150914 and GW170814 is [here](https://www.atlas.aei.uni-hannover.de/work/yifan.wang/pycbcdoc/testingGR-example/testingGRexample_output/)