### PR TITLE
add multiband waveform to speed up slow / long waveform approximants

### DIFF
--- a/pycbc/waveform/multiband.py
+++ b/pycbc/waveform/multiband.py
@@ -1,0 +1,111 @@
+""" Tools and functions to calculate interpolate waveforms using multi-banding
+"""
+import numpy
+
+from pycbc.types import TimeSeries, zeros, FrequencySeries
+
+def multiband_fd_waveform(bands=None, lengths=None, overlap=0, **p):
+    """ Generate a fourier domain waveform using multibanding
+
+    Speed up generation of a fouerier domain waveform using multibanding. This
+    allows for multi-rate sampling of the frequeny space. Each band is
+    smoothed and stitched together to produce the final waveform. The base
+    approximant must support 'f_ref' and 'f_final'. The other parameters
+    must be chosen carefully by the user.
+
+    Parameters
+    ----------
+    bands: list or str
+        The frequencies to split the waveform by. These should be chosen
+        so that the corresponding length include all the waveform's frequencies
+        within this band.
+    lengths: list or str
+        The corresponding length for each frequency band. This sets the
+        resolution of the subband and should be chosen carefully so that it is
+        sufficiently long to include all of the bands frequency content.
+    overlap: float
+        The frequency width to apply tapering between bands.
+    params: dict
+        The remaining keyworkd arguments passed to the base approximant
+        waveform generation.
+
+    Returns
+    -------
+    hp: pycbc.types.FrequencySeries
+        Plus polarization
+    hc: pycbc.type.TimeSeries
+        Cross polarization
+    """
+    from pycbc.waveform import get_fd_waveform
+
+    if isinstance(bands, str):
+        bands = [float(s) for s in bands.split(' ')]
+
+    if isinstance(lengths, str):
+        lengths = [float(s) for s in lengths.split(' ')]
+
+    p['approximant'] = p['base_approximant']
+    df = p['delta_f']
+    fmax = p['f_final']
+    flow = p['f_lower']
+
+    bands = [flow] + bands + [fmax]
+    dfs = [df] + [1.0 / l for l in lengths]
+
+    dt = 1.0 / (2.0 * fmax)
+    tlen = int(1.0 / dt / df)
+    flen = tlen / 2 + 1
+    wf_plus = TimeSeries(zeros(tlen, dtype=numpy.float32),
+                    copy=False, delta_t=dt, epoch=-1.0/df)
+    wf_cross = TimeSeries(zeros(tlen, dtype=numpy.float32),
+                    copy=False, delta_t=dt, epoch=-1.0/df)
+
+    # Iterate over the sub-bands
+    for i in range(len(lengths)+1):
+        taper_start = taper_end = False
+        if i != 0:
+            taper_start = True
+        if i != len(lengths):
+            taper_end = True
+
+        # Generate waveform for sub-band of full waveform
+        start = bands[i]
+        stop = bands[i+1]
+        p2 = p.copy()
+        p2['delta_f'] = dfs[i]
+        p2['f_lower'] = start
+        p2['f_final'] = stop
+
+        if taper_start:
+            p2['f_lower'] -= overlap / 2.0
+
+        if taper_end:
+            p2['f_final'] += overlap / 2.0
+
+        tlen = int(1.0 / dt / dfs[i])
+        flen = tlen / 2 + 1
+
+        hp, hc = get_fd_waveform(**p2)
+
+        # apply window function to smooth over transition regions
+        kmin = int(p2['f_lower'] / dfs[i])
+        kmax = int(p2['f_final'] / dfs[i])
+        taper = numpy.hanning(int(overlap * 2 / dfs[i]))
+
+        for wf, h in zip([wf_plus, wf_cross], [hp, hc]):
+            h = h.astype(numpy.complex64)
+
+            if taper_start:
+                h[kmin:kmin + len(taper) // 2] *= taper[:len(taper)//2]
+
+            if taper_end:
+                l, r = kmax - (len(taper) - len(taper) // 2), kmax
+                h[l:r] *= taper[len(taper)//2:]
+
+            # add frequency band of waveform to total and use fft to interpolate
+            h.resize(flen)
+            h = h.to_timeseries()
+            wf[len(wf)-len(h):] += h
+
+    return (wf_plus.to_frequencyseries().astype(hp.dtype),
+            wf_cross.to_frequencyseries().astype(hp.dtype))

--- a/pycbc/waveform/multiband.py
+++ b/pycbc/waveform/multiband.py
@@ -33,7 +33,7 @@ def multiband_fd_waveform(bands=None, lengths=None, overlap=0, **p):
     -------
     hp: pycbc.types.FrequencySeries
         Plus polarization
-    hc: pycbc.type.TimeSeries
+    hc: pycbc.type.FrequencySeries
         Cross polarization
     """
     from pycbc.waveform import get_fd_waveform

--- a/pycbc/waveform/multiband.py
+++ b/pycbc/waveform/multiband.py
@@ -2,7 +2,9 @@
 """
 import numpy
 
-from pycbc.types import TimeSeries, zeros, FrequencySeries
+from pycbc.types import TimeSeries, zeros
+from pycbc.waveform import get_fd_waveform
+
 
 def multiband_fd_waveform(bands=None, lengths=None, overlap=0, **p):
     """ Generate a fourier domain waveform using multibanding
@@ -36,8 +38,6 @@ def multiband_fd_waveform(bands=None, lengths=None, overlap=0, **p):
     hc: pycbc.type.FrequencySeries
         Cross polarization
     """
-    from pycbc.waveform import get_fd_waveform
-
     if isinstance(bands, str):
         bands = [float(s) for s in bands.split(' ')]
 
@@ -56,9 +56,9 @@ def multiband_fd_waveform(bands=None, lengths=None, overlap=0, **p):
     tlen = int(1.0 / dt / df)
     flen = tlen / 2 + 1
     wf_plus = TimeSeries(zeros(tlen, dtype=numpy.float32),
-                    copy=False, delta_t=dt, epoch=-1.0/df)
+                         copy=False, delta_t=dt, epoch=-1.0/df)
     wf_cross = TimeSeries(zeros(tlen, dtype=numpy.float32),
-                    copy=False, delta_t=dt, epoch=-1.0/df)
+                          copy=False, delta_t=dt, epoch=-1.0/df)
 
     # Iterate over the sub-bands
     for i in range(len(lengths)+1):
@@ -102,7 +102,7 @@ def multiband_fd_waveform(bands=None, lengths=None, overlap=0, **p):
                 l, r = kmax - (len(taper) - len(taper) // 2), kmax
                 h[l:r] *= taper[len(taper)//2:]
 
-            # add frequency band of waveform to total and use fft to interpolate
+            # add frequency band to total and use fft to interpolate
             h.resize(flen)
             h = h.to_timeseries()
             wf[len(wf)-len(h):] += h

--- a/pycbc/waveform/multiband.py
+++ b/pycbc/waveform/multiband.py
@@ -3,7 +3,6 @@
 import numpy
 
 from pycbc.types import TimeSeries, zeros
-from pycbc.waveform import get_fd_waveform
 
 
 def multiband_fd_waveform(bands=None, lengths=None, overlap=0, **p):
@@ -38,6 +37,8 @@ def multiband_fd_waveform(bands=None, lengths=None, overlap=0, **p):
     hc: pycbc.type.FrequencySeries
         Cross polarization
     """
+    from pycbc.waveform import get_fd_waveform
+
     if isinstance(bands, str):
         bands = [float(s) for s in bands.split(' ')]
 

--- a/pycbc/waveform/waveform.py
+++ b/pycbc/waveform/waveform.py
@@ -867,6 +867,9 @@ cpu_fd["TaylorF2NL"] = nonlinear_tidal_spa
 from .premerger import premerger_taylorf2
 cpu_fd['PreTaylorF2'] = premerger_taylorf2
 
+from .multiband import multiband_fd_waveform
+cpu_fd['multiband'] = multiband_fd_waveform
+
 # Load external waveforms #####################################################
 if 'PYCBC_WAVEFORM' in os.environ:
     mods = os.environ['PYCBC_WAVEFORM'].split(':')


### PR DESCRIPTION
This adds a 'multiband' waveform approximant which can use a base approximant which supports 'f_ref' and 'f_lower' / 'f_final' to speed up waveform generation. The waveform is generated at different delta_f's within frequency bands and then stitched back together. 

Example,
```
get_fd_waveform(approximant='multiband', base_approximant='IMRPhenomPv3', 
                            mass1=1.4, mass2=1.4,
                            f_lower=20, f_ref=20, f_final=1000,
                            delta_f=1.0/1024, spin1x=0.5, spin1z=0.5,
                            bands='50', lengths='50', overlap=1)
```
