### PR TITLE
Fix issues with extracting samples from dynesty file

### DIFF
--- a/pycbc/inference/io/dynesty.py
+++ b/pycbc/inference/io/dynesty.py
@@ -71,7 +71,8 @@ class CommonNestedMetadataIO(object):
         if 'raw_samples' not in skip_args:
             act = parser.add_argument(
                 "--raw-samples", action='store_true', default=False,
-                help="Raw samples are the unweighted samples obtained from "
+                help="Extract raw samples rather than a posterior. "
+                     "Raw samples are the unweighted samples obtained from "
                      "the nested sampler. Default value is False, which means "
                      "raw samples are weighted by the log-weight array "
                      "obtained from the sampler, giving an estimate of the "
@@ -83,7 +84,8 @@ class CommonNestedMetadataIO(object):
                 help="Set the random-number seed used for extracting the "
                      "posterior samples. This is needed because the "
                      "unweighted samples are randomly shuffled to produce "
-                     "a posterior. Default is 0.")
+                     "a posterior. Default is 0. Ignored if raw-samples are "
+                     "extracted instead.")
         return parser, actions
 
 class DynestyFile(CommonNestedMetadataIO, BaseNestedSamplerFile):
@@ -130,8 +132,8 @@ class DynestyFile(CommonNestedMetadataIO, BaseNestedSamplerFile):
                     i += 1
                 else:
                     j += 1
-            numpy.random.seed(seed)
-            numpy.random.shuffle(idx)
+            rng = numpy.random.default_rng(seed)
+            rng.shuffle(idx)
             post = {'loglikelihood': loglikelihood[idx]}
             for i, param in enumerate(fields):
                 post[param] = samples[param][idx]

--- a/pycbc/inference/io/dynesty.py
+++ b/pycbc/inference/io/dynesty.py
@@ -132,7 +132,12 @@ class DynestyFile(CommonNestedMetadataIO, BaseNestedSamplerFile):
                     i += 1
                 else:
                     j += 1
-            rng = numpy.random.default_rng(seed)
+            try:
+                rng = numpy.random.default_rng(seed)
+            except AttributeError:
+                # numpy pre-1.17 uses RandomState
+                # Py27: delete this after we drop python 2.7 support
+                rng = numpy.random.RandomState(seed)
             rng.shuffle(idx)
             post = {'loglikelihood': loglikelihood[idx]}
             for i, param in enumerate(fields):


### PR DESCRIPTION
Fixes a few bugs introduced by PR #3376. First, when reading raw samples from a dynesty file, the current code tries to extract a posterior for all samples rather than just the fields requested. 

Second, and more egregious, is that the random shuffle that's done to extract the posterior means that repeated calls to `read_raw_samples` are not deterministic. This is a particular problem for `plot_posterior`. If you are plotting scatter points colored by SNR, two calls are made to `read_raw_samples`: one to get the samples and one to get the SNR. The random shuffle means that the SNRs returned will not correspond to the samples that were obtained in the first call.

This fixes that by introducing a seed argument. The random generator's seed is set to the given value just before the shuffle is called, ensuring that repeated calls to `read_raw_samples` yield the same results. So as not to interfere with any other random number generation that might happen elsewhere in the code, a custom random generator is created solely for this purpose.