### PR TITLE
ForegroundTrigger in io/hdf now outputs ifos of triggers

### DIFF
--- a/pycbc/io/hdf.py
+++ b/pycbc/io/hdf.py
@@ -799,6 +799,17 @@ class ForegroundTriggers(object):
             ref_times = self.get_coincfile_array('time1')
         return ref_times
 
+    def get_ifos(self):
+        ifo_list = []
+        try:
+            ifos = self.coinc_file.h5file.attrs['ifos'].split(' ')
+            for ifo in ifos:
+                ifo_list.append(np.where(self.get_coincfile_array('{}/time'.format(ifo))<0,'-',ifo))
+            ifo_list = np.array([','.join(trig[trig!='-']) for trig in np.array(ifo_list).T])
+        except KeyError:  # Else fall back on old two-det format
+            ifo_list = np.tile('H1,L1',len(self.get_coincfile_array('template_id')))
+        return ifo_list
+
     def to_coinc_xml_object(self, file_name):
         outdoc = ligolw.Document()
         outdoc.appendChild(ligolw.LIGO_LW())

--- a/pycbc/io/hdf.py
+++ b/pycbc/io/hdf.py
@@ -801,17 +801,18 @@ class ForegroundTriggers(object):
 
     def get_ifos(self):
         ifo_list = []
-        N_trigs = len(self.get_coincfile_array('template_id'))
+        n_trigs = len(self.get_coincfile_array('template_id'))
         try:  # First try new-style format
             ifos = self.coinc_file.h5file.attrs['ifos'].split(' ')
             for ifo in ifos:
                 ifo_trigs = np.where(self.get_coincfile_array(ifo+'/time') < 0,
                                      '-', ifo)
                 ifo_list.append(ifo_trigs)
-            ifo_list = np.array([','.join(trig[trig != '-']) \
-                          for trig in iter(np.array(ifo_list).T)])
+            ifo_list = [list(trig[trig != '-']) \
+                        for trig in iter(np.array(ifo_list).T)]
         except KeyError:  # Else fall back on old two-det format
-            ifo_list = np.tile('H1,L1', N_trigs)
+            # Currently assumes two-det is Hanford and Livingston
+            ifo_list = [['H1', 'L1'] for i in range(n_trigs)]
         return ifo_list
 
     def to_coinc_xml_object(self, file_name):

--- a/pycbc/io/hdf.py
+++ b/pycbc/io/hdf.py
@@ -801,13 +801,17 @@ class ForegroundTriggers(object):
 
     def get_ifos(self):
         ifo_list = []
-        try:
+        N_trigs = len(self.get_coincfile_array('template_id'))
+        try:  # First try new-style format
             ifos = self.coinc_file.h5file.attrs['ifos'].split(' ')
             for ifo in ifos:
-                ifo_list.append(np.where(self.get_coincfile_array('{}/time'.format(ifo))<0,'-',ifo))
-            ifo_list = np.array([','.join(trig[trig!='-']) for trig in np.array(ifo_list).T])
+                ifo_trigs = np.where(self.get_coincfile_array(ifo+'/time') < 0,
+                                     '-', ifo)
+                ifo_list.append(ifo_trigs)
+            ifo_list = np.array([','.join(trig[trig != '-']) \
+                          for trig in iter(np.array(ifo_list).T)])
         except KeyError:  # Else fall back on old two-det format
-            ifo_list = np.tile('H1,L1',len(self.get_coincfile_array('template_id')))
+            ifo_list = np.tile('H1,L1', N_trigs)
         return ifo_list
 
     def to_coinc_xml_object(self, file_name):


### PR DESCRIPTION
Added inbuilt function that searches through the triggers for positive time entries for each detector and returns a list of ifos used for each trigger separated by a comma. If the coinc file is in the old 2 detector format then it returns 'H1,L1'.