### PR TITLE
Add VIRTUAL_ENV/lib to default ctypes search paths

### DIFF
--- a/pycbc/libutils.py
+++ b/pycbc/libutils.py
@@ -162,6 +162,9 @@ def get_ctypes_library(libname, packages, mode=None):
         libdirs += pkg_config_libdirs(packages)
     except ValueError:
         pass
+    # Next, if we are in a virtual environment, search inside its '/lib'
+    if "VIRTUAL_ENV" in os.environ:
+        libdirs.append(os.path.join(os.environ["VIRTUAL_ENV"], "lib"))
 
     # Note that the function below can accept an empty list for libdirs, in which case
     # it will return None


### PR DESCRIPTION
This updates the PyCBC code that searches for compiled libraries to load via `ctypes`. It will now also look inside of `$VIRTUAL_ENV/lib`.  Hence if library code is installed into that directory of a virtual environment, it will be findable.

In particular, to get MKL support, it should now be sufficient to just `pip install mkl` inside the virtual environment, without needing to modify any paths inside of the activate script of the environment.

However, locations of that (or any other) library found along `LD_LIBRARY_PATH` or by calling `pkg-config` will still take precedence over this location, so users can override an installation in the virtual environment by appropriately setting either `LD_LIBRARY_PATH` or `PKG_CONFIG_PATH`.