### PR TITLE
Fix for joint parameter constraints for ringdown PE

### DIFF
--- a/pycbc/distributions/joint.py
+++ b/pycbc/distributions/joint.py
@@ -207,6 +207,7 @@ class JointDistribution(object):
             of the parameters are arrays, will return an array of booleans.
             Otherwise, a boolean.
         """
+        params = {p: params[p] for p in self.variable_args}
         params, return_atomic = self._ensure_fieldarray(params)
         # convert params to a field array if it isn't one
         result = numpy.ones(params.shape, dtype=bool)
@@ -219,6 +220,9 @@ class JointDistribution(object):
     def __call__(self, **params):
         """Evaluate joint distribution for parameters.
         """
+        # convert to Field array
+        params = {p: params[p] for p in self.variable_args}
+        parray, return_atomic = self._ensure_fieldarray(params)
         # check if statisfies constraints
         if len(self._constraints) != 0:
             parray, return_atomic = self._ensure_fieldarray(params)


### PR DESCRIPTION
When trying to place constraints on a `JointDistribution` while using `ringdown` models, an error occured due to the passing of the `lmns` argument (a list of strings) to initiation of a field array. Since this is a fixed parameter, this (and all other fixed params) don't need to be passed here. The fix is to only pass the variable params.