### PR TITLE
Allow injection set to write string datatypes

### DIFF
--- a/pycbc/inject/inject.py
+++ b/pycbc/inject/inject.py
@@ -434,7 +434,15 @@ class _HDFInjectionSet(object):
                     # try decoding it and writing
                     fp.attrs[arg] = str(val)
             for field in write_params:
-                fp[field] = samples[field]
+                try:
+                    fp[field] = samples[field]
+                except TypeError as e:
+                    # can get this in python 3 if the val was a numpy.str_ type
+                    # we'll try again as a string type
+                    if samples[field].dtype.char == 'U':
+                        fp[field] = samples[field].astype('S')
+                    else:
+                        raise e
 
 
 class CBCHDFInjectionSet(_HDFInjectionSet):

--- a/pycbc/inject/inject.py
+++ b/pycbc/inject/inject.py
@@ -361,6 +361,9 @@ class _HDFInjectionSet(object):
                 # otherwise, we can just repeat the value the needed number of
                 # times
                 arr = np.repeat(val, numinj)
+            # make sure any byte strings are stored as strings instead
+            if arr.dtype.char == 'S':
+                arr = arr.astype('U')
             injvals[param] = arr
         # make sure a coalescence time is specified for injections
         if 'tc' not in injvals:


### PR DESCRIPTION
Fixes Issue #3427 

As described in there , `InjectionSet.write` fails if any of the injection parameters are strings. This can happen when writing an injection set that was loaded from another injection file. The reason is when the injections are loaded, any static arguments are expanded to fields. This is done using `numpy.repeat`. By default, numpy will store the python3 `str` as `U` type, but `h5py` doesn't know how to write that: if try to write the table back out, you'll get a `TypeError`. For example, say I have an injection file that has `approximant = IMRPhenomD` (as is the case in the example given in #3427). Since this is a static argument, it is stored in the injection file's `.attrs` as a `str`:
```
>>> injs = InjectionSet('injections.hdf')
>>> injs._injhandler.filehandler.attrs['approximant']
'IMRPhenomD'
>>> type(injs._injhandler.filehandler.attrs['approximant'])
str
```
The `InjectionSet`'s `.table` will therefore have an `approximant` field which is:
```
>>> injs.table['approximant']
array(['IMRPhenomD', 'IMRPhenomD', 'IMRPhenomD', 'IMRPhenomD',
       'IMRPhenomD'], dtype='<U10')
```
If you then try to do:
```
InjectionSet.write('test.hdf', injs.table)
```
You'll get a `TypeError`.

This fixes this by converting any arrays with `U` type to `S` types before writing. Since this means reading an injection file with strings will return byte arrays, I've also made it so that the read function converts all 'S' type arrays to 'U' type when loading. (If you don't do this, you'll get a byte type when you pull out the approximant, which will cause errors elsewhere.)