### PR TITLE
Be able to read injection files written in python 2

### DIFF
--- a/pycbc/inject/inject.py
+++ b/pycbc/inject/inject.py
@@ -343,7 +343,8 @@ class _HDFInjectionSet(object):
             numinj = tuple(injvals.values())[0].size
         # add any static args in the file
         try:
-            self.static_args = group.attrs['static_args']
+            # ensure parameter names are string types
+            self.static_args = group.attrs['static_args'].astype('U')
         except KeyError:
             self.static_args = []
         parameters.extend(self.static_args)

--- a/pycbc/inject/inject.py
+++ b/pycbc/inject/inject.py
@@ -745,7 +745,17 @@ def get_hdf_injtype(sim_file):
             ftype = fp.attrs['injtype']
         except KeyError:
             ftype = CBCHDFInjectionSet.injtype
-    return hdfinjtypes[ftype]
+    try:
+        return hdfinjtypes[ftype]
+    except KeyError:
+        # may get a key error if the file type was stored as unicode instead
+        # of string; if so, try decoding it
+        try:
+            ftype = str(ftype.decode())
+        except AttributeError:
+            # not actually a byte error; passing will reraise the KeyError
+            pass
+        return hdfinjtypes[ftype]
 
 
 def hdf_injtype_from_approximant(approximant):


### PR DESCRIPTION
Fixes an issue where injection files written in python 2 could not be read in python 3. The problem was both the file type and static params names are saved as unicode in python 2.7. In python 3 this results in them being returned as bytes instead of strings, which breaks string comparisons. Fixes this by casting to string after loading from file.

@titodalcanton I think this should fix the problem you found while testing #3471 .