### PR TITLE
Add ability to threshold on psd_var and chisquared to new statistic

### DIFF
--- a/pycbc/events/ranking.py
+++ b/pycbc/events/ranking.py
@@ -75,7 +75,10 @@ def newsnr_sgveto_psdvar_threshold(snr, brchisq, sgchisq, psd_var_val,
                                    min_expected_psdvar=0.65,
                                    brchisq_threshold=10.0,
                                    psd_var_val_threshold=10.0):
-    """ newsnr_sgveto_psdvar with a chi-squared threshold applied.
+    """ newsnr_sgveto_psdvar with thresholds applied.
+    
+    This is the newsnr_sgveto_psdvar statistic with additional options
+    to threshold on chi-squared or PSD variation.
     """
     nsnr = newsnr_sgveto_psdvar(snr, brchisq, sgchisq, psd_var_val,
                                 min_expected_psdvar=min_expected_psdvar)

--- a/pycbc/events/ranking.py
+++ b/pycbc/events/ranking.py
@@ -71,12 +71,13 @@ def newsnr_sgveto_psdvar(snr, brchisq, sgchisq, psd_var_val,
     else:
         return nsnr[0]
 
+
 def newsnr_sgveto_psdvar_threshold(snr, brchisq, sgchisq, psd_var_val,
                                    min_expected_psdvar=0.65,
                                    brchisq_threshold=10.0,
                                    psd_var_val_threshold=10.0):
     """ newsnr_sgveto_psdvar with thresholds applied.
-    
+
     This is the newsnr_sgveto_psdvar statistic with additional options
     to threshold on chi-squared or PSD variation.
     """
@@ -91,6 +92,7 @@ def newsnr_sgveto_psdvar_threshold(snr, brchisq, sgchisq, psd_var_val,
         return nsnr
     else:
         return nsnr[0]
+
 
 def newsnr_sgveto_psdvar_scaled(snr, brchisq, sgchisq, psd_var_val,
                                 scaling=0.33, min_expected_psdvar=0.65):
@@ -191,6 +193,7 @@ def get_newsnr_sgveto_psdvar(trigs):
                                       trigs['psd_var_val'][:])
     return numpy.array(nsnr_sg_psd, ndmin=1, dtype=numpy.float32)
 
+
 def get_newsnr_sgveto_psdvar_threshold(trigs):
     """
     Calculate newsnr re-weighted by the sine-gaussian veto and scaled
@@ -209,9 +212,10 @@ def get_newsnr_sgveto_psdvar_threshold(trigs):
     """
     dof = 2. * trigs['chisq_dof'][:] - 2.
     nsnr_sg_psdt = newsnr_sgveto_psdvar_threshold(
-                     trigs['snr'][:], trigs['chisq'][:] / dof,
-                     trigs['sg_chisq'][:],
-                     trigs['psd_var_val'][:])
+        trigs['snr'][:], trigs['chisq'][:] / dof,
+        trigs['sg_chisq'][:],
+        trigs['psd_var_val'][:]
+    )
     return numpy.array(nsnr_sg_psdt, ndmin=1, dtype=numpy.float32)
 
 

--- a/pycbc/events/ranking.py
+++ b/pycbc/events/ranking.py
@@ -71,6 +71,20 @@ def newsnr_sgveto_psdvar(snr, brchisq, sgchisq, psd_var_val,
     else:
         return nsnr[0]
 
+def newsnr_sgveto_psdvar_threshold(snr, brchisq, sgchisq, psd_var_val,
+                                   min_expected_psdvar=0.65, threshold=2.0):
+    """ newsnr_sgveto_psdvar with a chi-squared threshold applied.
+    """
+    nsnr = newsnr_sgveto_psdvar(snr, brchisq, sgchisq, psd_var_val,
+                                min_expected_psdvar=min_expected_psdvar)
+    nsnr = numpy.array(nsnr, ndmin=1)
+    nsnr[brchisq > threshold] = 1.
+
+    # If snr input is float, return a float. Otherwise return numpy array.
+    if hasattr(snr, '__len__'):
+        return nsnr
+    else:
+        return nsnr[0]
 
 def newsnr_sgveto_psdvar_scaled(snr, brchisq, sgchisq, psd_var_val,
                                 scaling=0.33, min_expected_psdvar=0.65):

--- a/pycbc/events/ranking.py
+++ b/pycbc/events/ranking.py
@@ -188,6 +188,29 @@ def get_newsnr_sgveto_psdvar(trigs):
                                       trigs['psd_var_val'][:])
     return numpy.array(nsnr_sg_psd, ndmin=1, dtype=numpy.float32)
 
+def get_newsnr_sgveto_psdvar_threshold(trigs):
+    """
+    Calculate newsnr re-weighted by the sine-gaussian veto and scaled
+    psd variation statistic
+
+    Parameters
+    ----------
+    trigs: dict of numpy.ndarrays
+        Dictionary holding single detector trigger information.
+    'chisq_dof', 'snr', 'chisq' and 'psd_var_val' are required keys
+
+    Returns
+    -------
+     numpy.ndarray
+        Array of newsnr values
+    """
+    dof = 2. * trigs['chisq_dof'][:] - 2.
+    nsnr_sg_psdt = newsnr_sgveto_psdvar_threshold(
+                     trigs['snr'][:], trigs['chisq'][:] / dof,
+                     trigs['sg_chisq'][:],
+                     trigs['psd_var_val'][:])
+    return numpy.array(nsnr_sg_psdt, ndmin=1, dtype=numpy.float32)
+
 
 def get_newsnr_sgveto_psdvar_scaled(trigs):
     """

--- a/pycbc/events/ranking.py
+++ b/pycbc/events/ranking.py
@@ -72,13 +72,16 @@ def newsnr_sgveto_psdvar(snr, brchisq, sgchisq, psd_var_val,
         return nsnr[0]
 
 def newsnr_sgveto_psdvar_threshold(snr, brchisq, sgchisq, psd_var_val,
-                                   min_expected_psdvar=0.65, threshold=2.0):
+                                   min_expected_psdvar=0.65,
+                                   brchisq_threshold=10.0,
+                                   psd_var_val_threshold=10.0):
     """ newsnr_sgveto_psdvar with a chi-squared threshold applied.
     """
     nsnr = newsnr_sgveto_psdvar(snr, brchisq, sgchisq, psd_var_val,
                                 min_expected_psdvar=min_expected_psdvar)
     nsnr = numpy.array(nsnr, ndmin=1)
-    nsnr[brchisq > threshold] = 1.
+    nsnr[brchisq > brchisq_threshold] = 1.
+    nsnr[psd_var_val > psd_var_val_threshold] = 1.
 
     # If snr input is float, return a float. Otherwise return numpy array.
     if hasattr(snr, '__len__'):

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -214,6 +214,25 @@ class NewSNRSGPSDStatistic(NewSNRSGStatistic):
         return ranking.get_newsnr_sgveto_psdvar(trigs)
 
 
+class NewSNRSGPSDThresholdStatistic(NewSNRSGStatistic):
+    """Calculate the NewSNRSGPSD coincident detection statistic"""
+
+    def single(self, trigs):
+        """Calculate the single detector statistic, here equal to newsnr
+        combined with sgveto and psdvar statistic
+
+        Parameters
+        ----------
+        trigs: dict of numpy.ndarrays
+
+        Returns
+        -------
+        numpy.ndarray
+            The array of single detector values
+        """
+        return ranking.get_newsnr_sgveto_psdvar_threshold(trigs)
+
+
 class NewSNRSGPSDScaledStatistic(NewSNRSGStatistic):
     """Calculate the NewSNRSGPSD coincident detection statistic"""
 
@@ -1650,6 +1669,7 @@ sngl_statistic_dict = {
     'max_cont_trad_newsnr': MaxContTradNewSNRStatistic,
     'newsnr_sgveto': NewSNRSGStatistic,
     'newsnr_sgveto_psdvar': NewSNRSGPSDStatistic,
+    'newsnr_sgveto_psdvar_threshold': NewSNRSGPSDThresholdStatistic,
     'newsnr_sgveto_psdvar_scaled': NewSNRSGPSDScaledStatistic,
     'newsnr_sgveto_psdvar_scaled_threshold':
         NewSNRSGPSDScaledThresholdStatistic,

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -1602,6 +1602,12 @@ class ExpFitSGPSDSTFgBgNormBBHStatistic(ExpFitSGPSDFgBgNormBBHStatistic):
                                                  max_chirp_mass=None, **kwargs)
         self.get_newsnr = ranking.get_newsnr_sgveto_psdvar_scaled_threshold
 
+class ExpFitSGPSDFgBgNormBBHThreshStatistic(ExpFitSGPSDFgBgNormBBHStatistic):
+    def __init__(self, files=None, ifos=None, max_chirp_mass=None, **kwargs):
+        ExpFitSGPSDFgBgNormBBHStatistic.__init__(self, files=files, ifos=ifos,
+                                                 max_chirp_mass=None, **kwargs)
+        self.get_newsnr = ranking.newsnr_sgveto_psdvar_threshold
+
 
 statistic_dict = {
     'newsnr': NewSNRStatistic,
@@ -1629,6 +1635,8 @@ statistic_dict = {
     '2ogcbbh': ExpFitSGPSDSTFgBgNormBBHStatistic, # backwards compatible
     'exp_fit_sg_fgbg_norm_psdvar': ExpFitSGPSDFgBgNormStatistic,
     'exp_fit_sg_fgbg_norm_psdvar_bbh': ExpFitSGPSDFgBgNormBBHStatistic
+    'exp_fit_sg_fgbg_norm_psdvar_bbh_thresh': 
+        ExpFitSGPSDFgBgNormBBHThreshStatistic
 }
 
 sngl_statistic_dict = {

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -1606,7 +1606,7 @@ class ExpFitSGPSDFgBgNormBBHThreshStatistic(ExpFitSGPSDFgBgNormBBHStatistic):
     def __init__(self, files=None, ifos=None, max_chirp_mass=None, **kwargs):
         ExpFitSGPSDFgBgNormBBHStatistic.__init__(self, files=files, ifos=ifos,
                                                  max_chirp_mass=None, **kwargs)
-        self.get_newsnr = ranking.newsnr_sgveto_psdvar_threshold
+        self.get_newsnr = ranking.get_newsnr_sgveto_psdvar_threshold
 
 
 statistic_dict = {

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -1634,8 +1634,8 @@ statistic_dict = {
     '2ogc': ExpFitSGPSDScaledFgBgNormStatistic, # backwards compatible
     '2ogcbbh': ExpFitSGPSDSTFgBgNormBBHStatistic, # backwards compatible
     'exp_fit_sg_fgbg_norm_psdvar': ExpFitSGPSDFgBgNormStatistic,
-    'exp_fit_sg_fgbg_norm_psdvar_bbh': ExpFitSGPSDFgBgNormBBHStatistic
-    'exp_fit_sg_fgbg_norm_psdvar_bbh_thresh': 
+    'exp_fit_sg_fgbg_norm_psdvar_bbh': ExpFitSGPSDFgBgNormBBHStatistic,
+    'exp_fit_sg_fgbg_norm_psdvar_bbh_thresh':
         ExpFitSGPSDFgBgNormBBHThreshStatistic
 }
 

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -1602,6 +1602,7 @@ class ExpFitSGPSDSTFgBgNormBBHStatistic(ExpFitSGPSDFgBgNormBBHStatistic):
                                                  max_chirp_mass=None, **kwargs)
         self.get_newsnr = ranking.get_newsnr_sgveto_psdvar_scaled_threshold
 
+
 class ExpFitSGPSDFgBgNormBBHThreshStatistic(ExpFitSGPSDFgBgNormBBHStatistic):
     def __init__(self, files=None, ifos=None, max_chirp_mass=None, **kwargs):
         ExpFitSGPSDFgBgNormBBHStatistic.__init__(self, files=files, ifos=ifos,


### PR DESCRIPTION
I want to add the ability to threshold on psd_Var and chi-squared to the new statistic. The use case here is basically if one runs over "shouldn't-have-been-science-data" data. Autogating can get quiet eager in some stretches and remove massive fractions of some data stretches. Then you get triggers with ridiculous values of all statistics (e.g. huge SNR, huge chi-squared, huge PSD var). Unfortunately, these can also have decent new_snr, and decent coincident statistic.

Such triggers should never be considered for coincidence so adding a threshold.

I note that this again emphasizes the need to refactor the stat module and have this kind of thing as key-word arguments that could basically be used in any stat. In that vein I do the minimum to get this to work, and will shift this refactoring up my priority list.

Have tested this end-to-end.