### PR TITLE
Minor improvements to relative likelihood model

### DIFF
--- a/pycbc/inference/models/relbin.py
+++ b/pycbc/inference/models/relbin.py
@@ -190,6 +190,17 @@ class Relative(BaseGaussianNoise):
         fid_hp, fid_hc = get_fd_waveform_sequence(approximant=approx,
                                                   sample_points=fpoints,
                                                   **self.fid_params)
+        # check for zeros at high frequencies
+        numzeros = list(fid_hp[::-1] != 0j).index(True)
+        n_above_fhi = (len(self.f) - 1) - kmaxs[0]
+        # make sure only nonzero samples are included in bins
+        if numzeros > n_above_fhi:
+            nremove = numzeros - n_above_fhi
+            new_kmax = kmaxs[0] - nremove
+            f_hi = new_kmax * self.df
+            logging.warn("WARNING! Fiducial waveform terminates below "
+                         "high-frequency-cutoff, final bin frequency "
+                         "will be {} Hz".format(f_hi))
         self.h00 = {}
         for ifo in self.data:
             # make copy of fiducial wfs, adding back in low frequencies
@@ -203,8 +214,7 @@ class Relative(BaseGaussianNoise):
 
         # compute frequency bins
         logging.info("Computing frequency bins")
-        nbin, fbin, fbin_ind = setup_bins(f_full=self.f, f_lo=kmins[0]*self.df,
-                                          f_hi=kmaxs[0]*self.df,
+        nbin, fbin, fbin_ind = setup_bins(f_full=self.f, f_lo=f_lo, f_hi=f_hi,
                                           eps=self.epsilon)
         logging.info("Using %s bins for this model", nbin)
         # store bins and edges in sample and frequency space

--- a/pycbc/inference/models/relbin.py
+++ b/pycbc/inference/models/relbin.py
@@ -72,7 +72,7 @@ def setup_bins(f_full, f_lo, f_hi, chi=1.0, eps=0.5, gammas=None):
     f = numpy.linspace(f_lo, f_hi, 10000)
     # f^ga power law index
     ga = gammas if gammas is not None else \
-         numpy.array([-5./3, -2./3, 1., 5./3, 7./3])
+        numpy.array([-5./3, -2./3, 1., 5./3, 7./3])
     logging.info("Using powerlaw indices: %s", ga)
     dalp = chi * 2.0 * numpy.pi / numpy.absolute((f_lo ** ga) - (f_hi ** ga))
     dphi = numpy.sum(numpy.array([numpy.sign(g) * d * (f ** g) for
@@ -190,9 +190,9 @@ class Relative(BaseGaussianNoise):
             nremove = numzeros - n_above_fhi
             new_kmax = kmaxs[0] - nremove
             f_hi = new_kmax * self.df
-            logging.warn("WARNING! Fiducial waveform terminates below "
+            logging.info("WARNING! Fiducial waveform terminates below "
                          "high-frequency-cutoff, final bin frequency "
-                         "will be {} Hz".format(f_hi))
+                         "will be %s Hz", f_hi)
         self.h00 = {}
         for ifo in self.data:
             # make copy of fiducial wfs, adding back in low frequencies

--- a/pycbc/inference/models/relbin.py
+++ b/pycbc/inference/models/relbin.py
@@ -73,6 +73,7 @@ def setup_bins(f_full, f_lo, f_hi, chi=1.0, eps=0.5, gammas=None):
     # f^ga power law index
     ga = gammas if gammas is not None else \
          numpy.array([-5./3, -2./3, 1., 5./3, 7./3])
+    logging.info("Using powerlaw indices: %s", ga)
     dalp = chi * 2.0 * numpy.pi / numpy.absolute((f_lo ** ga) - (f_hi ** ga))
     dphi = numpy.sum(numpy.array([numpy.sign(g) * d * (f ** g) for
                                   g, d in zip(ga, dalp)]), axis=0)

--- a/pycbc/inference/models/relbin.py
+++ b/pycbc/inference/models/relbin.py
@@ -57,6 +57,8 @@ def setup_bins(f_full, f_lo, f_hi, chi=1.0, eps=0.5, gammas=None):
     eps : float, optional
         Tunable parameter, see [Barak, Dai & Venumadhav 2018]. Lower values
         result in larger number of bins.
+    gammas : array, optional
+        Frequency powerlaw indices to be used in computing bins.
 
     Returns
     -------
@@ -117,25 +119,13 @@ class Relative(BaseGaussianNoise):
         A dictionary of starting frequencies, in which the keys are the
         detector names and the values are the starting frequencies for the
         respective detectors to be used for computing inner products.
-    mass1_ref : float
-        The primary mass in solar masses used for generating the fiducial
-        waveform.
-    mass2_ref : float
-        The secondary mass in solar masses used for generating the fiducial
-        waveform.
-    spin1z_ref : float
-        The component of primary dimensionless spin along the orbital angular
-        momentum used for generating the fiducial waveform.
-    spin2z_ref : float
-        The component of secondary dimensionless spin along the orbital angular
-        momentum used for generating the fiducial waveform.
-    ra_ref : float
-        The right ascension in radians used for generating the fiducial
-        waveform.
-    dec_ref : float
-        The declination in radians used for generating the fiducial waveform.
-    tc_ref : float
-        The GPS time of coalescence used for generating the fiducial waveform.
+    figucial_params : dict
+        A dictionary of waveform parameters to be used for generating the
+        fiducial waveform. Keys must be parameter names in the form
+        'PARAM_ref' where PARAM is a recognized extrinsic parameter or
+        an intrinsic parameter compatible with the chosen approximant.
+    gammas : array of floats, optional
+        Frequency powerlaw indices to be used in computing frequency bins.
     epsilon : float, optional
         Tuning parameter used in calculating the frequency bins. Lower values
         will result in higher resolution and more bins.


### PR DESCRIPTION
This patch makes two small modifications to the relative likelihood model:

 - Checks the generated fiducial waveform for zeros at high frequencies, and excludes from the binning algorithm any that exist below the chosen high frequency cutoff. This prevents divide-by-zero errors in the likelihood calculation for higher-mass waveforms
 - Adds an optional model arg `gammas` that defines the powerlaw indices used in calculating frequency bins.  These can then be set in the config file as a space-separated list, but will default to a sensible array of indices if none are supplied. Note that these should be supplied in units of 1/3, e.g.:
```
[model]
name = relative
gammas = -5 -3 -2 3
...
```
