### PR TITLE
Removal of a manual list of trigger times

### DIFF
--- a/bin/hdfcoinc/pycbc_multiifo_coinc_statmap
+++ b/bin/hdfcoinc/pycbc_multiifo_coinc_statmap
@@ -68,6 +68,10 @@ parser.add_argument('--hierarchical-removal-against', type=str,
                          'triggers that are louder than either the "inclusive"'
                          ' (little-dogs-in) background, or the "exclusive" '
                          '(little-dogs-out) background. [default="none"]')
+parser.add_argument('--additional-event-times', type=float, nargs="+",
+                    help="Additional event times which will be removed from "
+                         "both inclusive and exclusive background "
+                          "(gps seconds)")
 parser.add_argument('--output-file')
 args = parser.parse_args()
 
@@ -99,6 +103,18 @@ if 'ifos' in all_trigs.attrs:
 else:
     ifos = args.ifos
     logging.info('using ifos from command line input')
+
+# Remove triggers from manually flagged times:
+if args.additional_event_times:
+    rm_cent_times = np.array(args.additional_event_times)
+    rm_start_times = rm_cent_times - args.veto_window
+    rm_end_times = rm_cent_times + args.veto_window
+    manual_rm_idx = []
+    for ifo in ifos:
+        rm_idx = veto.indices_within_times(all_trigs.data['%s/time' % ifo],
+                                           rm_start_times, rm_end_times)
+        manual_rm_idx += list(rm_idx)
+    all_trigs = all_trigs.remove(manual_rm_idx)
 
 logging.info("We have %s triggers" % len(all_trigs.stat))
 fore_locs = all_trigs.timeslide_id == 0

--- a/bin/hdfcoinc/pycbc_multiifo_coinc_statmap
+++ b/bin/hdfcoinc/pycbc_multiifo_coinc_statmap
@@ -104,9 +104,13 @@ else:
     ifos = args.ifos
     logging.info('using ifos from command line input')
 
+logging.info("We have %s triggers" % len(all_trigs.stat))
+
 # Remove triggers from manually flagged times:
 if args.additional_event_times:
-    rm_cent_times = np.array(args.additional_event_times)
+    logging.info("Removing triggers around times %s",
+                 " ".join([str(et) for et in args.additional_event_times]))
+    rm_cent_times = numpy.array(args.additional_event_times)
     rm_start_times = rm_cent_times - args.veto_window
     rm_end_times = rm_cent_times + args.veto_window
     manual_rm_idx = []
@@ -114,9 +118,10 @@ if args.additional_event_times:
         rm_idx = veto.indices_within_times(all_trigs.data['%s/time' % ifo],
                                            rm_start_times, rm_end_times)
         manual_rm_idx += list(rm_idx)
+    logging.info("Removing %d triggers", len(manual_rm_idx))
     all_trigs = all_trigs.remove(manual_rm_idx)
 
-logging.info("We have %s triggers" % len(all_trigs.stat))
+logging.info("%s triggers remain" % len(all_trigs.stat))
 fore_locs = all_trigs.timeslide_id == 0
 
 # Foreground trigger times for ifos

--- a/bin/hdfcoinc/pycbc_page_snrifar
+++ b/bin/hdfcoinc/pycbc_page_snrifar
@@ -47,7 +47,7 @@ parser.add_argument('--use-hierarchical-level', type=int, default=None,
                     help='Indicate which inclusive background and FARs of '
                          'foreground triggers to plot if there were any '
                          'hierarchical removals done. Choosing None plots '
-                         'the inclusive backgrounds prior to any '
+                         'the inclusive backgrounds after all '
                          'hierarchical removals with the updated FARs for '
                          'foreground triggers after hierarchical removal(s). '
                          'Choosing 0 means plotting inclusive background '


### PR DESCRIPTION
If we have signals in a single detector, it causes significant little-dog background.

This change means we can remove these triggers manually (or a bad glitch, or whatever, just pointing to a time) from all backgrounds