### PR TITLE
Add modes generator

### DIFF
--- a/pycbc/waveform/generator.py
+++ b/pycbc/waveform/generator.py
@@ -47,14 +47,6 @@ import lal as _lal
 from pycbc import strain
 
 
-#
-# =============================================================================
-#
-#                     Radiation/inertial-frame generators
-#
-# =============================================================================
-#
-
 # utility functions/class
 failed_counter = 0
 

--- a/pycbc/waveform/generator.py
+++ b/pycbc/waveform/generator.py
@@ -50,7 +50,7 @@ from pycbc import strain
 #
 # =============================================================================
 #
-#                        Radiation-frame generators
+#                     Radiation/inertial-frame generators
 #
 # =============================================================================
 #
@@ -286,9 +286,10 @@ class FDomainCBCModesGenerator(BaseCBCGenerator):
     """Generates frequency-domain CBC waveform modes in the radiation frame.
 
     Uses :py:func:`waveform_modes.get_fd_waveform_modes` as a generator
-    function to create frequency-domain CBC waveforms in the radiation frame;
-    i.e., with no detector response function applied. For more details, see
-    :py:class:`BaseGenerator`.
+    function to create frequency-domain CBC waveforms mode-by-mode, without
+    applying spherical harmonics.
+
+    For details, on methods and arguments, see :py:class:`BaseGenerator`.
     """
     def __init__(self, variable_args=(), **frozen_params):
         super(FDomainCBCModesGenerator, self).__init__(
@@ -352,9 +353,10 @@ class TDomainCBCModesGenerator(BaseCBCGenerator):
     """Generates time domain CBC waveform modes in the radiation frame.
 
     Uses :py:func:`waveform_modes.get_td_waveform_modes` as a generator
-    function to create time-domain CBC waveforms in the radiation frame; i.e.,
-    with no detector response function applied. For more details, see
-    :py:class:`BaseGenerator`.
+    function to create time-domain CBC waveforms mode-by-mode, without applying
+    spherical harmonics.
+
+    For details, on methods and arguments, see :py:class:`BaseGenerator`.
     """
     def __init__(self, variable_args=(), **frozen_params):
         super(TDomainCBCModesGenerator, self).__init__(
@@ -367,10 +369,10 @@ class TDomainCBCModesGenerator(BaseCBCGenerator):
         if 'taper' in self.current_params:
             tapermethod = self.current_params['taper']
             for mode in res:
-                hp, hc = res[mode]
-                hp = taper_timeseries(hp, tapermethod=tapermethod)
-                hc = taper_timeseries(hc, tapermethod=tapermethod)
-                res[mode] = (hp, hc)
+                ulm, vlm = res[mode]
+                ulm = taper_timeseries(ulm, tapermethod=tapermethod)
+                vlm = taper_timeseries(vlm, tapermethod=tapermethod)
+                res[mode] = (ulm, vlm)
         return res
 
 

--- a/pycbc/waveform/generator.py
+++ b/pycbc/waveform/generator.py
@@ -27,10 +27,14 @@ This modules provides classes for generating waveforms.
 import os
 import logging
 
+from abc import (ABCMeta, abstractmethod)
+from six import add_metaclass
+
 from . import waveform
 from .waveform import (NoWaveformError, FailedWaveformError)
 from . import ringdown
 from . import supernovae
+from . import waveform_modes
 from pycbc import filter
 from pycbc import transforms
 from pycbc.types import TimeSeries
@@ -44,7 +48,11 @@ from pycbc import strain
 
 
 #
-#   Generator for CBC waveforms
+# =============================================================================
+#
+#                        Radiation-frame generators
+#
+# =============================================================================
 #
 
 # utility functions/class
@@ -274,6 +282,20 @@ class FDomainCBCGenerator(BaseCBCGenerator):
             variable_args=variable_args, **frozen_params)
 
 
+class FDomainCBCModesGenerator(BaseCBCGenerator):
+    """Generates frequency-domain CBC waveform modes in the radiation frame.
+
+    Uses :py:func:`waveform_modes.get_fd_waveform_modes` as a generator
+    function to create frequency-domain CBC waveforms in the radiation frame;
+    i.e., with no detector response function applied. For more details, see
+    :py:class:`BaseGenerator`.
+    """
+    def __init__(self, variable_args=(), **frozen_params):
+        super(FDomainCBCModesGenerator, self).__init__(
+            waveform_modes.get_fd_waveform_modes,
+            variable_args=variable_args, **frozen_params)
+
+
 class TDomainCBCGenerator(BaseCBCGenerator):
     """Create time domain CBC waveforms in the radiation frame.
 
@@ -326,6 +348,32 @@ class TDomainCBCGenerator(BaseCBCGenerator):
         return hp, hc
 
 
+class TDomainCBCModesGenerator(BaseCBCGenerator):
+    """Generates time domain CBC waveform modes in the radiation frame.
+
+    Uses :py:func:`waveform_modes.get_td_waveform_modes` as a generator
+    function to create time-domain CBC waveforms in the radiation frame; i.e.,
+    with no detector response function applied. For more details, see
+    :py:class:`BaseGenerator`.
+    """
+    def __init__(self, variable_args=(), **frozen_params):
+        super(TDomainCBCModesGenerator, self).__init__(
+            waveform_modes.get_td_waveform_modes,
+            variable_args=variable_args, **frozen_params)
+
+    def _postgenerate(self, res):
+        """Applies a taper if it is in current params.
+        """
+        if 'taper' in self.current_params:
+            tapermethod = self.current_params['taper']
+            for mode in res:
+                hp, hc = res[mode]
+                hp = taper_timeseries(hp, tapermethod=tapermethod)
+                hc = taper_timeseries(hc, tapermethod=tapermethod)
+                res[mode] = (hp, hc)
+        return res
+
+
 class FDomainMassSpinRingdownGenerator(BaseGenerator):
     """Uses ringdown.get_fd_from_final_mass_spin as a generator function to
     create frequency-domain ringdown waveforms with higher modes in the
@@ -352,6 +400,7 @@ class FDomainMassSpinRingdownGenerator(BaseGenerator):
     def __init__(self, variable_args=(), **frozen_params):
         super(FDomainMassSpinRingdownGenerator, self).__init__(ringdown.get_fd_from_final_mass_spin,
             variable_args=variable_args, **frozen_params)
+
 
 class FDomainFreqTauRingdownGenerator(BaseGenerator):
     """Uses ringdown.get_fd_from_freqtau as a generator function to
@@ -380,6 +429,7 @@ class FDomainFreqTauRingdownGenerator(BaseGenerator):
         super(FDomainFreqTauRingdownGenerator, self).__init__(ringdown.get_fd_from_freqtau,
             variable_args=variable_args, **frozen_params)
 
+
 class TDomainMassSpinRingdownGenerator(BaseGenerator):
     """Uses ringdown.get_td_from_final_mass_spin as a generator function to
     create time-domain ringdown waveforms with higher modes in the
@@ -406,6 +456,7 @@ class TDomainMassSpinRingdownGenerator(BaseGenerator):
     def __init__(self, variable_args=(), **frozen_params):
         super(TDomainMassSpinRingdownGenerator, self).__init__(ringdown.get_td_from_final_mass_spin,
             variable_args=variable_args, **frozen_params)
+
 
 class TDomainFreqTauRingdownGenerator(BaseGenerator):
     """Uses ringdown.get_td_from_freqtau as a generator function to
@@ -435,12 +486,28 @@ class TDomainFreqTauRingdownGenerator(BaseGenerator):
             variable_args=variable_args, **frozen_params)
 
 
-class FDomainDetFrameTwoPolGenerator(object):
-    """Generates frequency-domain waveform in a specific frame.
+class TDomainSupernovaeGenerator(BaseGenerator):
+    """Uses supernovae.py to create time domain core-collapse supernovae waveforms
+    using a set of Principal Components provided in a .hdf file.
+    """
+    def __init__(self, variable_args=(), **frozen_params):
+        super(TDomainSupernovaeGenerator,
+              self).__init__(supernovae.get_corecollapse_bounce,
+           variable_args=variable_args, **frozen_params)
 
-    Generates both polarizations of a waveform using the given radiation frame
-    generator class, and applies the time shift. Detector response functions
-    are not applied.
+
+#
+# =============================================================================
+#
+#                        Detector-frame generators
+#
+# =============================================================================
+#
+
+
+@add_metaclass(ABCMeta)
+class BaseFDomainDetFrameGenerator(object):
+    """Base generator for frquency-domain waveforms in a detector frame.
 
     Parameters
     ----------
@@ -466,18 +533,9 @@ class FDomainDetFrameTwoPolGenerator(object):
 
     Attributes
     ----------
-    location_args : set(['tc', 'ra', 'dec'])
-        The set of location parameters. These are not passed to the rFrame
-        generator class; instead, they are used to apply the detector response
-        function and/or shift the waveform in time. The parameters are:
-
-          * tc: The GPS time of coalescence (should be geocentric time).
-          * ra: Right ascension.
-          * dec: declination
-
-        All of these must be provided in either the variable args or the
-        frozen params if detectors is not None. If detectors
-        is None, tc may optionally be provided.
+    location_args : set([])
+        Should be overriden by childern classes with a set of parameters
+        that set the binary's location.
 
     Attributes
     ----------
@@ -506,7 +564,7 @@ class FDomainDetFrameTwoPolGenerator(object):
         function.
 
     """
-    location_args = set(['tc', 'ra', 'dec'])
+    location_args = set([])
 
     def __init__(self, rFrameGeneratorClass, epoch, detectors=None,
                  variable_args=(), recalib=None, gates=None, **frozen_params):
@@ -558,82 +616,20 @@ class FDomainDetFrameTwoPolGenerator(object):
     def epoch(self):
         return _lal.LIGOTimeGPS(self._epoch)
 
+    @abstractmethod
     def generate(self, **kwargs):
-        """Generates a waveform polarizations and applies a time shift.
-
-        Returns
-        -------
-        dict :
-            Dictionary of ``detector names -> (hp, hc)``, where ``hp, hc`` are
-            the plus and cross polarization, respectively.
+        """The function that generates the waveforms.
         """
-        self.current_params.update(kwargs)
-        rfparams = {param: self.current_params[param]
-            for param in kwargs if param not in self.location_args}
-        hp, hc = self.rframe_generator.generate(**rfparams)
-        if isinstance(hp, TimeSeries):
-            df = self.current_params['delta_f']
-            hp = hp.to_frequencyseries(delta_f=df)
-            hc = hc.to_frequencyseries(delta_f=df)
-            # time-domain waveforms will not be shifted so that the peak amp
-            # happens at the end of the time series (as they are for f-domain),
-            # so we add an additional shift to account for it
-            tshift = 1./df - abs(hp._epoch)
-        else:
-            tshift = 0.
-        hp._epoch = hc._epoch = self._epoch
-        h = {}
-        if self.detector_names != ['RF']:
-            for detname, det in self.detectors.items():
-                # apply the time shift
-                tc = self.current_params['tc'] + \
-                    det.time_delay_from_earth_center(self.current_params['ra'],
-                         self.current_params['dec'], self.current_params['tc'])
-                dethp = apply_fd_time_shift(hp, tc+tshift, copy=True)
-                dethc = apply_fd_time_shift(hc, tc+tshift, copy=True)
-                if self.recalib:
-                    # recalibrate with given calibration model
-                    dethp = self.recalib[detname].map_to_adjust(
-                        dethp, **self.current_params)
-                    dethc = self.recalib[detname].map_to_adjust(
-                        dethc, **self.current_params)
-                h[detname] = (dethp, dethc)
-        else:
-            # no detector response, just use the + polarization
-            if 'tc' in self.current_params:
-                hp = apply_fd_time_shift(hp, self.current_params['tc']+tshift,
-                                         copy=False)
-                hc = apply_fd_time_shift(hc, self.current_params['tc']+tshift,
-                                         copy=False)
-            h['RF'] = (hp, hc)
-        if self.gates is not None:
-            # resize all to nearest power of 2
-            hps = {}
-            hcs = {}
-            for det in h:
-                hp = h[det]
-                hc = h[det]
-                hp.resize(ceilpow2(len(hp)-1) + 1)
-                hc.resize(ceilpow2(len(hc)-1) + 1)
-                hps[det] = hp
-                hcs[det] = hc
-            hps = strain.apply_gates_to_fd(hps, self.gates)
-            hcs = strain.apply_gates_to_fd(hps, self.gates)
-            h = {det: (hps[det], hcs[det]) for det in h}
-        return h
+        pass
+
+    @abstractmethod
+    def select_rframe_generator(self, approximant):
+        """Method to select waveform generator based on an approximant."""
+        pass
 
 
-class TDomainSupernovaeGenerator(BaseGenerator):
-    """Uses supernovae.py to create time domain core-collapse supernovae waveforms
-    using a set of Principal Components provided in a .hdf file.
-    """
-    def __init__(self, variable_args=(), **frozen_params):
-        super(TDomainSupernovaeGenerator,
-              self).__init__(supernovae.get_corecollapse_bounce,
-           variable_args=variable_args, **frozen_params)
 
-
-class FDomainDetFrameGenerator(object):
+class FDomainDetFrameGenerator(BaseFDomainDetFrameGenerator):
     """Generates frequency-domain waveform in a specific frame.
 
     Generates a waveform using the given radiation frame generator class,
@@ -719,56 +715,6 @@ class FDomainDetFrameGenerator(object):
     """
     location_args = set(['tc', 'ra', 'dec', 'polarization'])
 
-    def __init__(self, rFrameGeneratorClass, epoch, detectors=None,
-                 variable_args=(), recalib=None, gates=None, **frozen_params):
-        # initialize frozen & current parameters:
-        self.current_params = frozen_params.copy()
-        self._static_args = frozen_params.copy()
-        # we'll separate out frozen location parameters from the frozen
-        # parameters that are sent to the rframe generator
-        self.frozen_location_args = {}
-        loc_params = set(frozen_params.keys()) & self.location_args
-        for param in loc_params:
-            self.frozen_location_args[param] = frozen_params.pop(param)
-        # set the order of the variable parameters
-        self.variable_args = tuple(variable_args)
-        # variables that are sent to the rFrame generator
-        rframe_variables = list(set(self.variable_args) - self.location_args)
-        # initialize the radiation frame generator
-        self.rframe_generator = rFrameGeneratorClass(
-            variable_args=rframe_variables, **frozen_params)
-        self.set_epoch(epoch)
-        # set calibration model
-        self.recalib = recalib
-        # if detectors are provided, convert to detector type; also ensure that
-        # location variables are specified
-        if detectors is not None:
-            self.detectors = {det: Detector(det) for det in detectors}
-            missing_args = [arg for arg in self.location_args if not
-                (arg in self.current_params or arg in self.variable_args)]
-            if any(missing_args):
-                raise ValueError("detectors provided, but missing location "
-                    "parameters %s. " %(', '.join(missing_args)) +
-                    "These must be either in the frozen params or the "
-                    "variable args.")
-        else:
-            self.detectors = {'RF': None}
-        self.detector_names = sorted(self.detectors.keys())
-        self.gates = gates
-
-    def set_epoch(self, epoch):
-        """Sets the epoch; epoch should be a float or a LIGOTimeGPS."""
-        self._epoch = float(epoch)
-
-    @property
-    def static_args(self):
-        """Returns a dictionary of the static arguments."""
-        return self._static_args
-
-    @property
-    def epoch(self):
-        return _lal.LIGOTimeGPS(self._epoch)
-
     def generate(self, **kwargs):
         """Generates a waveform, applies a time shift and the detector response
         function from the given kwargs.
@@ -820,6 +766,321 @@ class FDomainDetFrameGenerator(object):
             h = strain.apply_gates_to_fd(h, self.gates)
         return h
 
+    @staticmethod
+    def select_rframe_generator(approximant):
+        """Returns a radiation frame generator class based on the approximant
+        string.
+        """
+        return select_waveform_generator(approximant)
+
+
+class FDomainDetFrameTwoPolGenerator(BaseFDomainDetFrameGenerator):
+    """Generates frequency-domain waveform in a specific frame.
+
+    Generates both polarizations of a waveform using the given radiation frame
+    generator class, and applies the time shift. Detector response functions
+    are not applied.
+
+    Parameters
+    ----------
+    rFrameGeneratorClass : class
+        The class to use for generating the waveform in the radiation frame,
+        e.g., FDomainCBCGenerator. This should be the class, not an
+        instance of the class (the class will be initialized with the
+        appropriate arguments internally).
+    detectors : {None, list of strings}
+        The names of the detectors to use. If provided, all location parameters
+        must be included in either the variable args or the frozen params. If
+        None, the generate function will just return the plus polarization
+        returned by the rFrameGeneratorClass shifted by any desired time shift.
+    epoch : {float, lal.LIGOTimeGPS
+        The epoch start time to set the waveform to. A time shift = tc - epoch is
+        applied to waveforms before returning.
+    variable_args : {(), list or tuple}
+        A list or tuple of strings giving the names and order of parameters
+        that will be passed to the generate function.
+    \**frozen_params
+        Keyword arguments setting the parameters that will not be changed from
+        call-to-call of the generate function.
+
+    Attributes
+    ----------
+    location_args : set(['tc', 'ra', 'dec'])
+        The set of location parameters. These are not passed to the rFrame
+        generator class; instead, they are used to apply the detector response
+        function and/or shift the waveform in time. The parameters are:
+
+          * tc: The GPS time of coalescence (should be geocentric time).
+          * ra: Right ascension.
+          * dec: declination
+
+        All of these must be provided in either the variable args or the
+        frozen params if detectors is not None. If detectors
+        is None, tc may optionally be provided.
+
+    Attributes
+    ----------
+    detectors : dict
+        The dictionary of detectors that antenna patterns are calculated for
+        on each call of generate. If no detectors were provided, will be
+        ``{'RF': None}``, where "RF" means "radiation frame".
+    detector_names : list
+        The list of detector names. If no detectors were provided, then this
+        will be ['RF'] for "radiation frame".
+    epoch : lal.LIGOTimeGPS
+        The GPS start time of the frequency series returned by the generate function.
+        A time shift is applied to the waveform equal to tc-epoch. Update by using
+        ``set_epoch``.
+    current_params : dict
+        A dictionary of name, value pairs of the arguments that were last
+        used by the generate function.
+    rframe_generator : instance of rFrameGeneratorClass
+        The instance of the radiation-frame generator that is used for waveform
+        generation. All parameters in current_params except for the
+        location params are passed to this class's generate function.
+    frozen_location_args : dict
+        Any location parameters that were included in the frozen_params.
+    variable_args : tuple
+        The list of names of arguments that are passed to the generate
+        function.
+
+    """
+    location_args = set(['tc', 'ra', 'dec'])
+
+    def generate(self, **kwargs):
+        """Generates a waveform polarizations and applies a time shift.
+
+        Returns
+        -------
+        dict :
+            Dictionary of ``detector names -> (hp, hc)``, where ``hp, hc`` are
+            the plus and cross polarization, respectively.
+        """
+        self.current_params.update(kwargs)
+        rfparams = {param: self.current_params[param]
+            for param in kwargs if param not in self.location_args}
+        hp, hc = self.rframe_generator.generate(**rfparams)
+        if isinstance(hp, TimeSeries):
+            df = self.current_params['delta_f']
+            hp = hp.to_frequencyseries(delta_f=df)
+            hc = hc.to_frequencyseries(delta_f=df)
+            # time-domain waveforms will not be shifted so that the peak amp
+            # happens at the end of the time series (as they are for f-domain),
+            # so we add an additional shift to account for it
+            tshift = 1./df - abs(hp._epoch)
+        else:
+            tshift = 0.
+        hp._epoch = hc._epoch = self._epoch
+        h = {}
+        if self.detector_names != ['RF']:
+            for detname, det in self.detectors.items():
+                # apply the time shift
+                tc = self.current_params['tc'] + \
+                    det.time_delay_from_earth_center(self.current_params['ra'],
+                         self.current_params['dec'], self.current_params['tc'])
+                dethp = apply_fd_time_shift(hp, tc+tshift, copy=True)
+                dethc = apply_fd_time_shift(hc, tc+tshift, copy=True)
+                if self.recalib:
+                    # recalibrate with given calibration model
+                    dethp = self.recalib[detname].map_to_adjust(
+                        dethp, **self.current_params)
+                    dethc = self.recalib[detname].map_to_adjust(
+                        dethc, **self.current_params)
+                h[detname] = (dethp, dethc)
+        else:
+            # no detector response, just use the + polarization
+            if 'tc' in self.current_params:
+                hp = apply_fd_time_shift(hp, self.current_params['tc']+tshift,
+                                         copy=False)
+                hc = apply_fd_time_shift(hc, self.current_params['tc']+tshift,
+                                         copy=False)
+            h['RF'] = (hp, hc)
+        if self.gates is not None:
+            # resize all to nearest power of 2
+            hps = {}
+            hcs = {}
+            for det in h:
+                hp = h[det]
+                hc = h[det]
+                hp.resize(ceilpow2(len(hp)-1) + 1)
+                hc.resize(ceilpow2(len(hc)-1) + 1)
+                hps[det] = hp
+                hcs[det] = hc
+            hps = strain.apply_gates_to_fd(hps, self.gates)
+            hcs = strain.apply_gates_to_fd(hps, self.gates)
+            h = {det: (hps[det], hcs[det]) for det in h}
+        return h
+
+    @staticmethod
+    def select_rframe_generator(approximant):
+        """Returns a radiation frame generator class based on the approximant
+        string.
+        """
+        return select_waveform_generator(approximant)
+
+
+class FDomainDetFrameModesGenerator(BaseFDomainDetFrameGenerator):
+    """Generates frequency-domain waveform modes in a specific frame.
+
+    Generates both polarizations of every waveform mode using the given
+    radiation frame generator class, and applies the time shift. Detector
+    response functions are not applied.
+
+    Parameters
+    ----------
+    rFrameGeneratorClass : class
+        The class to use for generating the waveform modes in the radiation
+        frame, e.g., :py:class:`FDomainCBCModesGenerator`. This should be the
+        class, not an instance of the class (the class will be initialized with
+        the appropriate arguments internally). The class should have a generate
+        function that returns a dictionary of waveforms keyed by the modes.
+    detectors : {None, list of strings}
+        The names of the detectors to use. If provided, all location parameters
+        must be included in either the variable args or the frozen params. If
+        None, the generate function will just return the plus polarization
+        returned by the rFrameGeneratorClass shifted by any desired time shift.
+    epoch : {float, lal.LIGOTimeGPS
+        The epoch start time to set the waveform to. A time shift = tc - epoch is
+        applied to waveforms before returning.
+    variable_args : {(), list or tuple}
+        A list or tuple of strings giving the names and order of parameters
+        that will be passed to the generate function.
+    \**frozen_params
+        Keyword arguments setting the parameters that will not be changed from
+        call-to-call of the generate function.
+
+    Attributes
+    ----------
+    location_args : set(['tc', 'ra', 'dec'])
+        The set of location parameters. These are not passed to the rFrame
+        generator class; instead, they are used to apply the detector response
+        function and/or shift the waveform in time. The parameters are:
+
+          * tc: The GPS time of coalescence (should be geocentric time).
+          * ra: Right ascension.
+          * dec: declination
+
+        All of these must be provided in either the variable args or the
+        frozen params if detectors is not None. If detectors
+        is None, tc may optionally be provided.
+
+    Attributes
+    ----------
+    detectors : dict
+        The dictionary of detectors that antenna patterns are calculated for
+        on each call of generate. If no detectors were provided, will be
+        ``{'RF': None}``, where "RF" means "radiation frame".
+    detector_names : list
+        The list of detector names. If no detectors were provided, then this
+        will be ['RF'] for "radiation frame".
+    epoch : lal.LIGOTimeGPS
+        The GPS start time of the frequency series returned by the generate
+        function. A time shift is applied to the waveform equal to tc-epoch.
+        Update by using ``set_epoch``.
+    current_params : dict
+        A dictionary of name, value pairs of the arguments that were last
+        used by the generate function.
+    rframe_generator : instance of rFrameGeneratorClass
+        The instance of the radiation-frame generator that is used for waveform
+        generation. All parameters in current_params except for the
+        location params are passed to this class's generate function.
+    frozen_location_args : dict
+        Any location parameters that were included in the frozen_params.
+    variable_args : tuple
+        The list of names of arguments that are passed to the generate
+        function.
+
+    """
+    location_args = set(['tc', 'ra', 'dec'])
+
+    def generate(self, **kwargs):
+        """Generates and returns a waveform decompsed into separate modes.
+
+        Returns
+        -------
+        dict :
+            Dictionary of ``detector names -> modes -> (ulm, vlm)``, where
+            ``ulm, vlm`` are the frequency-domain representations of the real
+            and imaginary parts, respectively, of the complex time series
+            representation of the ``hlm``.
+        """
+        self.current_params.update(kwargs)
+        rfparams = {param: self.current_params[param]
+            for param in kwargs if param not in self.location_args}
+        hlms = self.rframe_generator.generate(**rfparams)
+        h = {det: {} for det in self.detectors}
+        for mode in hlms:
+            ulm, vlm = hlms[mode]
+            if isinstance(ulm, TimeSeries):
+                df = self.current_params['delta_f']
+                ulm = ulm.to_frequencyseries(delta_f=df)
+                vlm = vlm.to_frequencyseries(delta_f=df)
+                # time-domain waveforms will not be shifted so that the peak
+                # amplitude happens at the end of the time series (as they are
+                # for f-domain), so we add an additional shift to account for
+                # it
+                tshift = 1./df - abs(ulm._epoch)
+            else:
+                tshift = 0.
+            ulm._epoch = vlm._epoch = self._epoch
+            if self.detector_names != ['RF']:
+                for detname, det in self.detectors.items():
+                    # apply the time shift
+                    tc = self.current_params['tc'] + \
+                        det.time_delay_from_earth_center(
+                            self.current_params['ra'],
+                            self.current_params['dec'],
+                            self.current_params['tc'])
+                    detulm = apply_fd_time_shift(ulm, tc+tshift, copy=True)
+                    detvlm = apply_fd_time_shift(vlm, tc+tshift, copy=True)
+                    if self.recalib:
+                        # recalibrate with given calibration model
+                        detulm = self.recalib[detname].map_to_adjust(
+                            detulm, **self.current_params)
+                        detvlm = self.recalib[detname].map_to_adjust(
+                            detvlm, **self.current_params)
+                    h[detname][mode] = (detulm, detvlm)
+            else:
+                # no detector response, just apply time shift
+                if 'tc' in self.current_params:
+                    ulm = apply_fd_time_shift(ulm,
+                                              self.current_params['tc']+tshift,
+                                              copy=False)
+                    vlm = apply_fd_time_shift(vlm,
+                                              self.current_params['tc']+tshift,
+                                              copy=False)
+                h['RF'][mode] = (ulm, vlm)
+            if self.gates is not None:
+                # resize all to nearest power of 2
+                ulms = {}
+                vlms = {}
+                for det in h:
+                    ulm, vlm = h[det][mode]
+                    ulm.resize(ceilpow2(len(ulm)-1) + 1)
+                    vlm.resize(ceilpow2(len(vlm)-1) + 1)
+                    ulms[det] = ulm
+                    vlms[det] = vlm
+                ulms = strain.apply_gates_to_fd(ulms, self.gates)
+                vlms = strain.apply_gates_to_fd(ulms, self.gates)
+                for det in ulms:
+                    h[det][mode] = (ulms[det], vlms[det])
+        return h
+
+    @staticmethod
+    def select_rframe_generator(approximant):
+        """Returns a radiation frame generator class based on the approximant
+        string.
+        """
+        return select_waveform_modes_generator(approximant)
+
+
+#
+# =============================================================================
+#
+#                        Helper functions
+#
+# =============================================================================
+#
 
 
 def select_waveform_generator(approximant):
@@ -849,33 +1110,51 @@ def select_waveform_generator(approximant):
     >>> from pycbc.waveform.generator import select_waveform_generator
     >>> select_waveform_generator(waveform.fd_approximants()[0])
     """
-
     # check if frequency-domain CBC waveform
     if approximant in waveform.fd_approximants():
         return FDomainCBCGenerator
-
     # check if time-domain CBC waveform
     elif approximant in waveform.td_approximants():
         return TDomainCBCGenerator
-
     # check if frequency-domain ringdown waveform
     elif approximant in ringdown.ringdown_fd_approximants:
         if approximant == 'FdQNMfromFinalMassSpin':
             return FDomainMassSpinRingdownGenerator
         elif approximant == 'FdQNMfromFreqTau':
             return FDomainFreqTauRingdownGenerator
-
     elif approximant in ringdown.ringdown_td_approximants:
         if approximant == 'TdQNMfromFinalMassSpin':
             return TDomainMassSpinRingdownGenerator
         elif approximant == 'TdQNMfromFreqTau':
             return TDomainFreqTauRingdownGenerator
-
     # check if supernovae waveform:
     elif approximant in supernovae.supernovae_td_approximants:
         if approximant == 'CoreCollapseBounce':
             return TDomainSupernovaeGenerator
-
     # otherwise waveform approximant is not supported
     else:
         raise ValueError("%s is not a valid approximant." % approximant)
+
+
+def select_waveform_modes_generator(approximant):
+    """Returns the single-IFO modes generator for the approximant.
+
+    Parameters
+    ----------
+    approximant : str
+        Name of waveform approximant. Valid names can be found using
+        ``pycbc.waveform`` methods.
+
+    Returns
+    -------
+    generator : (PyCBC generator instance)
+        A waveform generator object.
+    """
+    # check if frequency-domain CBC waveform
+    if approximant in waveform.fd_approximants():
+        return FDomainCBCModesGenerator
+    # check if time-domain CBC waveform
+    elif approximant in waveform.td_approximants():
+        return TDomainCBCModesGenerator
+    # otherwise waveform approximant is not supported
+    raise ValueError("%s is not a valid approximant." % approximant)

--- a/pycbc/waveform/generator.py
+++ b/pycbc/waveform/generator.py
@@ -275,7 +275,7 @@ class FDomainCBCGenerator(BaseCBCGenerator):
 
 
 class FDomainCBCModesGenerator(BaseCBCGenerator):
-    """Generates frequency-domain CBC waveform modes in the radiation frame.
+    """Generates frequency-domain CBC waveform modes.
 
     Uses :py:func:`waveform_modes.get_fd_waveform_modes` as a generator
     function to create frequency-domain CBC waveforms mode-by-mode, without
@@ -342,11 +342,12 @@ class TDomainCBCGenerator(BaseCBCGenerator):
 
 
 class TDomainCBCModesGenerator(BaseCBCGenerator):
-    """Generates time domain CBC waveform modes in the radiation frame.
+    """Generates time domain CBC waveform modes.
 
     Uses :py:func:`waveform_modes.get_td_waveform_modes` as a generator
     function to create time-domain CBC waveforms mode-by-mode, without applying
-    spherical harmonics.
+    spherical harmonics. The ``generate`` function returns a dictionary of
+    modes -> (real, imag) part of the complex time series.
 
     For details, on methods and arguments, see :py:class:`BaseGenerator`.
     """


### PR DESCRIPTION
This is part 2 of 3 patches to replace #3456. This adds a radiation and detector frame generators to generate waveforms one mode at a time. This can be used by a model (next patch) to numerically marginalize over phase.

The radiation frame generators are the same as the standard CBC TD and FD generators, it's just that they call `get_(t|f)d_waveform_modes` rather than `get_(t|f)d_waveform`.

The detector frame generator then generates the waveforms and returns a dictonary of detector names -> mode -> frequency domain versions of ulm and vlm. The ulm and vlm are the real and (-) imaginary parts of the complex waveform time series.

Since much of the functionality between this new detector frame generator, the polarization generator, and the standard generator are the same, I've create a new base class for the frequency-domain detector frame generators. The required method for this is the `generator` method, which each sub-class implements. Since selecting which radiation frame generator to use is depends on the type of generation being done, I've also added a `select_rframe_generator` static method to these classes. For the standard FDomainDetFrameGenerator and the polarization, this just calls the usual `select_waveform_generator` while the `FDomainDetFrameModesGenerator` calls `select_waveform_modes_generator`.

Putting on hold since it depends on #3482.