### PR TITLE
Add numerical phimarg model

### DIFF
--- a/pycbc/inference/models/__init__.py
+++ b/pycbc/inference/models/__init__.py
@@ -25,6 +25,7 @@ from .analytic import (TestEggbox, TestNormal, TestRosenbrock, TestVolcano,
 from .gaussian_noise import GaussianNoise
 from .marginalized_gaussian_noise import MarginalizedPhaseGaussianNoise
 from .marginalized_gaussian_noise import MarginalizedPolarization
+from .marginalized_gaussian_noise import MarginalizedHMPolPhase
 from .brute_marg import BruteParallelGaussianMarginalize
 from .single_template import SingleTemplate
 from .relbin import Relative
@@ -185,6 +186,7 @@ models = {_cls.name: _cls for _cls in (
     GaussianNoise,
     MarginalizedPhaseGaussianNoise,
     MarginalizedPolarization,
+    MarginalizedHMPolPhase,
     BruteParallelGaussianMarginalize,
     SingleTemplate,
     Relative

--- a/pycbc/inference/models/gaussian_noise.py
+++ b/pycbc/inference/models/gaussian_noise.py
@@ -1052,7 +1052,7 @@ def create_waveform_generator(
                 recalibration=None, gates=None,
                 generator_class=generator.FDomainDetFrameGenerator,
                 **static_params):
-    """Creates a waveform generator for use with a model.
+    r"""Creates a waveform generator for use with a model.
 
     Parameters
     ----------
@@ -1072,6 +1072,12 @@ def create_waveform_generator(
     gates : dict of tuples, optional
         Dictionary of detectors -> tuples of specifying gate times. The
         sort of thing returned by :py:func:`pycbc.gate.gates_from_cli`.
+    generator_class : detector-frame fdomain generator, optional
+        Class to use for generating waveforms. Default is
+        :py:class:`waveform.generator.FDomainDetFrameGenerator`.
+    \**static_params :
+        All other keyword arguments are passed as static parameters to the
+        waveform generator.
 
     Returns
     -------
@@ -1093,7 +1099,7 @@ def create_waveform_generator(
     except KeyError:
         raise ValueError("no approximant provided in the static args")
 
-    generator_function = generator.select_waveform_generator(approximant)
+    generator_function = generator_class.select_rframe_generator(approximant)
     # get data parameters; we'll just use one of the data to get the
     # values, then check that all the others are the same
     delta_f = None


### PR DESCRIPTION
This is part 3 of 3 to replace #3456. This adds a model to numerical marginalize waveforms with sub-dominant modes over both phase and polarization. Similar to the polarization model, this is done by creating a grid of points in phase and in polarization. The loglr function generates the waveforms once, then cycles over the polarization and phase grid and applies the appropriate multiplicative factors. For higher mode waveforms, this requires generating the waveforms mode-by-mode, and so uses the FDomainDetFrameModesGenerator described in #3483 . 

At the moment this only works with the NRSurrogate waveforms. Extending support to other waveforms with sub-dominant modes will require some work on the lalsimulation side and/or the `waveform_modes` module (see #3482). This could be extended to single-mode waveforms fairly easily though (not in this PR).

Not making @ahnitz a reviewer since he contributed to this.

Putting on hold since depends on #3482 and #3483.