### PR TITLE
Core collapse supernovae 

### DIFF
--- a/pycbc/distributions/constraints.py
+++ b/pycbc/distributions/constraints.py
@@ -35,18 +35,17 @@ class Constraint(object):
         for kwarg in kwargs.keys():
             setattr(self, kwarg, kwargs[kwarg])
 
-
-        #For supernovae waveforms:
+        # For supernovae waveforms:
         if 'principal_components_file' in kwargs:
-            pc_file = kwargs['principal_components_file']
+            pc_filename = kwargs['principal_components_file']
             hull_dimention = numpy.array(kwargs['hull_dimention'])
             self.hull_dimention = int(hull_dimention)
-            f = h5py.File(pc_file, 'r')
-            pc_coefficients = numpy.array(f.get('coefficients'))
-            f.close()
+            pc_file = h5py.File(pc_filename, 'r')
+            pc_coefficients = numpy.array(pc_file.get('coefficients'))
+            pc_file.close()
             hull_points = []
             for dim in range(self.hull_dimention):
-                hull_points.append(pc_coefficients[:,dim])
+                hull_points.append(pc_coefficients[:, dim])
             hull_points = numpy.array(hull_points).T
             pc_coeffs_hull = Delaunay(hull_points)
             self._hull = pc_coeffs_hull
@@ -93,8 +92,8 @@ class ConvexHull(Constraint):
         points = numpy.array([params["coeff_0"],
                               params["coeff_1"],
                               params["coeff_2"]])
-        for ii in range(len(params["coeff_0"])):
-            point = points[:,ii][:self.hull_dimention]
+        for coeff_index in range(len(params["coeff_0"])):
+            point = points[:, coeff_index][:self.hull_dimention]
             output_array.append(self._hull.find_simplex(point)>=0)
         return numpy.array(output_array)
 

--- a/pycbc/distributions/constraints.py
+++ b/pycbc/distributions/constraints.py
@@ -73,7 +73,8 @@ class SupernovaeConvexHull(Constraint):
     required_parameters = ["coeff_0", "coeff_1"]
 
     def __init__(self, constraint_arg, transforms=None, **kwargs):
-        super(SupernovaeConvexHull, self).__init__(constraint_arg, transforms=transforms, **kwargs)
+        super(SupernovaeConvexHull,
+              self).__init__(constraint_arg, transforms=transforms, **kwargs)
 
         if 'principal_components_file' in kwargs:
             pc_filename = kwargs['principal_components_file']
@@ -88,7 +89,6 @@ class SupernovaeConvexHull(Constraint):
             hull_points = numpy.array(hull_points).T
             pc_coeffs_hull = scipy.spatial.Delaunay(hull_points)
             self._hull = pc_coeffs_hull
-
 
     def _constraint(self, params):
 

--- a/pycbc/distributions/constraints.py
+++ b/pycbc/distributions/constraints.py
@@ -16,11 +16,11 @@
 This modules provides classes for evaluating multi-dimensional constraints.
 """
 
-from pycbc import transforms
-from pycbc.io import record
-from scipy.spatial import Delaunay
+import scipy.spatial
 import numpy
 import h5py
+from pycbc import transforms
+from pycbc.io import record
 
 
 class Constraint(object):
@@ -35,24 +35,9 @@ class Constraint(object):
         for kwarg in kwargs.keys():
             setattr(self, kwarg, kwargs[kwarg])
 
-        # For supernovae waveforms:
-        if 'principal_components_file' in kwargs:
-            pc_filename = kwargs['principal_components_file']
-            hull_dimention = numpy.array(kwargs['hull_dimention'])
-            self.hull_dimention = int(hull_dimention)
-            pc_file = h5py.File(pc_filename, 'r')
-            pc_coefficients = numpy.array(pc_file.get('coefficients'))
-            pc_file.close()
-            hull_points = []
-            for dim in range(self.hull_dimention):
-                hull_points.append(pc_coefficients[:, dim])
-            hull_points = numpy.array(hull_points).T
-            pc_coeffs_hull = Delaunay(hull_points)
-            self._hull = pc_coeffs_hull
-
     def __call__(self, params):
         """Evaluates constraint.
-        """''
+        """
         # cast to FieldArray
         if isinstance(params, dict):
             params = record.FieldArray.from_kwargs(**params)
@@ -79,27 +64,46 @@ class Constraint(object):
         return params[self.constraint_arg]
 
 
-class ConvexHull(Constraint):
+class SupernovaeConvexHull(Constraint):
     """Pre defined constraint for core-collapse waveforms that checks
     whether a given set of coefficients lie within the convex hull of
     the coefficients of the principal component basis vectors.
     """
     name = "supernovae_convex_hull"
     required_parameters = ["coeff_0", "coeff_1"]
-    def _constraint(self, params):
-        output_array = []
 
+    def __init__(self, constraint_arg, transforms=None, **kwargs):
+        super(SupernovaeConvexHull, self).__init__(constraint_arg, transforms=transforms, **kwargs)
+
+        if 'principal_components_file' in kwargs:
+            pc_filename = kwargs['principal_components_file']
+            hull_dimention = numpy.array(kwargs['hull_dimention'])
+            self.hull_dimention = int(hull_dimention)
+            pc_file = h5py.File(pc_filename, 'r')
+            pc_coefficients = numpy.array(pc_file.get('coefficients'))
+            pc_file.close()
+            hull_points = []
+            for dim in range(self.hull_dimention):
+                hull_points.append(pc_coefficients[:, dim])
+            hull_points = numpy.array(hull_points).T
+            pc_coeffs_hull = scipy.spatial.Delaunay(hull_points)
+            self._hull = pc_coeffs_hull
+
+
+    def _constraint(self, params):
+
+        output_array = []
         points = numpy.array([params["coeff_0"],
                               params["coeff_1"],
                               params["coeff_2"]])
         for coeff_index in range(len(params["coeff_0"])):
             point = points[:, coeff_index][:self.hull_dimention]
-            output_array.append(self._hull.find_simplex(point)>=0)
+            output_array.append(self._hull.find_simplex(point) >= 0)
         return numpy.array(output_array)
 
 
 # list of all constraints
 constraints = {
     Constraint.name : Constraint,
-    ConvexHull.name : ConvexHull,
+    SupernovaeConvexHull.name : SupernovaeConvexHull,
 }

--- a/pycbc/inference/models/gaussian_noise.py
+++ b/pycbc/inference/models/gaussian_noise.py
@@ -533,7 +533,7 @@ class BaseGaussianNoise(BaseDataModel):
         # update any values that are to be retrieved from the injection
         # Note: this does nothing if there are FROM_INJECTION values
         get_values_from_injection(cp, injection_file, update_cp=True)
-        args = cls._init_args_from_config(cp)        
+        args = cls._init_args_from_config(cp)
         # add the injection file
         args['injection_file'] = injection_file
         # check if normalize is set

--- a/pycbc/inference/models/gaussian_noise.py
+++ b/pycbc/inference/models/gaussian_noise.py
@@ -176,7 +176,6 @@ class BaseGaussianNoise(BaseDataModel):
         # store the psds and whiten the data
         self.psds = psds
 
-
     @property
     def high_frequency_cutoff(self):
         """The high frequency cutoff of the inner product.
@@ -534,8 +533,7 @@ class BaseGaussianNoise(BaseDataModel):
         # update any values that are to be retrieved from the injection
         # Note: this does nothing if there are FROM_INJECTION values
         get_values_from_injection(cp, injection_file, update_cp=True)
-        args = cls._init_args_from_config(cp)
-        
+        args = cls._init_args_from_config(cp)        
         # add the injection file
         args['injection_file'] = injection_file
         # check if normalize is set
@@ -544,8 +542,7 @@ class BaseGaussianNoise(BaseDataModel):
         if cp.has_option('model', 'ignore-failed-waveforms'):
             args['ignore_failed_waveforms'] = True
         # get any other keyword arguments provided in the model section
-        ignore_args = ['name', 'normalize', 
-                       'ignore-failed-waveforms']
+        ignore_args = ['name', 'normalize', 'ignore-failed-waveforms']
         for option in cp.options("model"):
             if option in ("low-frequency-cutoff", "high-frequency-cutoff"):
                 ignore_args.append(option)
@@ -851,7 +848,6 @@ class GaussianNoise(BaseGaussianNoise):
             The value of the log likelihood ratio.
         """
         params = self.current_params
-
         try:
             wfs = self.waveform_generator.generate(**params)
         except NoWaveformError:

--- a/pycbc/inference/models/gaussian_noise.py
+++ b/pycbc/inference/models/gaussian_noise.py
@@ -115,6 +115,7 @@ class BaseGaussianNoise(BaseDataModel):
     def __init__(self, variable_params, data, low_frequency_cutoff, psds=None,
                  high_frequency_cutoff=None, normalize=False,
                  static_params=None, ignore_failed_waveforms=False,
+                 principal_components=None, pc_coefficients=None, pc_coeffs_hull=None,
                  **kwargs):
         # set up the boiler-plate attributes
         super(BaseGaussianNoise, self).__init__(variable_params, data,
@@ -175,6 +176,11 @@ class BaseGaussianNoise(BaseDataModel):
         self.normalize = normalize
         # store the psds and whiten the data
         self.psds = psds
+        # For supernovae waveforms
+        self.principal_components = principal_components
+        self.pc_coefficients = pc_coefficients
+        self.pc_coeffs_hull = pc_coeffs_hull
+
 
     @property
     def high_frequency_cutoff(self):
@@ -534,6 +540,20 @@ class BaseGaussianNoise(BaseDataModel):
         # Note: this does nothing if there are FROM_INJECTION values
         get_values_from_injection(cp, injection_file, update_cp=True)
         args = cls._init_args_from_config(cp)
+        
+        # Read in the principal components for supernovae waveforms:
+        if cp.has_option('model', 'principal_components_file'):
+            pc_file = h5py.File(cp.get('model', 'principal_components_file'), 'r')
+            principal_components = numpy.array(pc_file.get('principal_components'))
+            pc_coefficients = numpy.array(pc_file.get('coefficients'))
+            args['principal_components'] = principal_components
+            args['pc_coefficients'] = pc_coefficients
+            hull_points = numpy.array([pc_coefficients[:,0], pc_coefficients[:,1], 
+                                       pc_coefficients[:,2], pc_coefficients[:,3]]).T
+            pc_coeffs_hull = Delaunay(hull_points)
+            args['pc_coeffs_hull'] = pc_coeffs_hull
+            pc_file.close()
+
         # add the injection file
         args['injection_file'] = injection_file
         # check if normalize is set
@@ -542,7 +562,8 @@ class BaseGaussianNoise(BaseDataModel):
         if cp.has_option('model', 'ignore-failed-waveforms'):
             args['ignore_failed_waveforms'] = True
         # get any other keyword arguments provided in the model section
-        ignore_args = ['name', 'normalize', 'ignore-failed-waveforms']
+        ignore_args = ['name', 'normalize', 
+                       'ignore-failed-waveforms', 'principal_components_file']
         for option in cp.options("model"):
             if option in ("low-frequency-cutoff", "high-frequency-cutoff"):
                 ignore_args.append(option)
@@ -848,6 +869,13 @@ class GaussianNoise(BaseGaussianNoise):
             The value of the log likelihood ratio.
         """
         params = self.current_params
+
+        # Add principal components as parameters for supernovae waveforms
+        if self.principal_components is not None:
+            params['principal_components'] = self.principal_components
+            params['pc_coefficients'] = self.pc_coefficients
+            params['pc_coeffs_hull'] = self.pc_coeffs_hull
+
         try:
             wfs = self.waveform_generator.generate(**params)
         except NoWaveformError:

--- a/pycbc/waveform/generator.py
+++ b/pycbc/waveform/generator.py
@@ -637,7 +637,7 @@ class TDomainSupernovaeGenerator(BaseGenerator):
     using a set of Principal Components provided in a .hdf file.
     """
     def __init__(self, variable_args=(), **frozen_params):
-        super(TDomainSupernovaeGenerator, self).__init__(supernovae.get_td_corecollapse_bounce_signal, 
+        super(TDomainSupernovaeGenerator, self).__init__(supernovae.get_corecollapse_bounce,
            variable_args=variable_args, **frozen_params)
 
 

--- a/pycbc/waveform/generator.py
+++ b/pycbc/waveform/generator.py
@@ -30,6 +30,7 @@ import logging
 from . import waveform
 from .waveform import (NoWaveformError, FailedWaveformError)
 from . import ringdown
+from . import supernovae
 from pycbc import filter
 from pycbc import transforms
 from pycbc.types import TimeSeries
@@ -443,6 +444,7 @@ class TDomainFreqTauRingdownGenerator(BaseGenerator):
             variable_args=variable_args, **frozen_params)
 
 
+<<<<<<< HEAD
 class FDomainDetFrameTwoPolGenerator(object):
     """Generates frequency-domain waveform in a specific frame.
 
@@ -629,6 +631,15 @@ class FDomainDetFrameTwoPolGenerator(object):
             hcs = strain.apply_gates_to_fd(hps, self.gates)
             h = {det: (hps[det], hcs[det]) for det in h}
         return h
+=======
+class TDomainSupernovaeGenerator(BaseGenerator):
+    """Uses supernovae.py to create time domain core-collapse supernovae waveforms
+    using a set of Principal Components provided in a .hdf file.
+    """
+    def __init__(self, variable_args=(), **frozen_params):
+        super(TDomainSupernovaeGenerator, self).__init__(supernovae.get_td_corecollapse_bounce_signal, 
+           variable_args=variable_args, **frozen_params)
+>>>>>>> Added core bounce waveform; convex hull constraint
 
 
 class FDomainDetFrameGenerator(object):
@@ -868,6 +879,11 @@ def select_waveform_generator(approximant):
             return TDomainMassSpinRingdownGenerator
         elif approximant == 'TdQNMfromFreqTau':
             return TDomainFreqTauRingdownGenerator
+
+    # check if supernovae waveform:
+    elif approximant in supernovae.supernovae_td_approximants:
+        if approximant == 'CoreCollapseBounce':
+            return TDomainSupernovaeGenerator
 
     # otherwise waveform approximant is not supported
     else:

--- a/pycbc/waveform/generator.py
+++ b/pycbc/waveform/generator.py
@@ -444,7 +444,6 @@ class TDomainFreqTauRingdownGenerator(BaseGenerator):
             variable_args=variable_args, **frozen_params)
 
 
-<<<<<<< HEAD
 class FDomainDetFrameTwoPolGenerator(object):
     """Generates frequency-domain waveform in a specific frame.
 
@@ -631,7 +630,8 @@ class FDomainDetFrameTwoPolGenerator(object):
             hcs = strain.apply_gates_to_fd(hps, self.gates)
             h = {det: (hps[det], hcs[det]) for det in h}
         return h
-=======
+
+
 class TDomainSupernovaeGenerator(BaseGenerator):
     """Uses supernovae.py to create time domain core-collapse supernovae waveforms
     using a set of Principal Components provided in a .hdf file.
@@ -639,7 +639,6 @@ class TDomainSupernovaeGenerator(BaseGenerator):
     def __init__(self, variable_args=(), **frozen_params):
         super(TDomainSupernovaeGenerator, self).__init__(supernovae.get_td_corecollapse_bounce_signal, 
            variable_args=variable_args, **frozen_params)
->>>>>>> Added core bounce waveform; convex hull constraint
 
 
 class FDomainDetFrameGenerator(object):

--- a/pycbc/waveform/generator.py
+++ b/pycbc/waveform/generator.py
@@ -637,7 +637,8 @@ class TDomainSupernovaeGenerator(BaseGenerator):
     using a set of Principal Components provided in a .hdf file.
     """
     def __init__(self, variable_args=(), **frozen_params):
-        super(TDomainSupernovaeGenerator, self).__init__(supernovae.get_corecollapse_bounce,
+        super(TDomainSupernovaeGenerator,
+              self).__init__(supernovae.get_corecollapse_bounce,
            variable_args=variable_args, **frozen_params)
 
 

--- a/pycbc/waveform/supernovae.py
+++ b/pycbc/waveform/supernovae.py
@@ -1,21 +1,20 @@
-"""Generate core-collapse supernovae waveform for core bounce and 
-subsequent postbounce oscillations. 
+"""Generate core-collapse supernovae waveform for core bounce and
+subsequent postbounce oscillations.
 """
 
 import numpy
-import math
 import h5py
 from pycbc.types import TimeSeries, FrequencySeries
 
 _principal_components = {}
 
 def get_td_corecollapse_bounce_signal(template=None, **kwargs):
-    """ Generates core bounce and postbounce waveform by using principal 
-    component basis vectors from a .hdf file. The waveform parameters are the 
-    coefficients of the principal components and the distance. The number of 
-    principal components used can also be varied. 
+    """ Generates core bounce and postbounce waveform by using principal
+    component basis vectors from a .hdf file. The waveform parameters are the
+    coefficients of the principal components and the distance. The number of
+    principal components used can also be varied.
     """
-    
+
     try:
         principal_components = _principal_components['principal_components']
     except KeyError:
@@ -29,9 +28,8 @@ def get_td_corecollapse_bounce_signal(template=None, **kwargs):
         coeffs_keys = [x for x in kwargs if x.startswith('coeff_')]
         coeffs_keys = numpy.sort(numpy.array(coeffs_keys))
         coefficients_array = numpy.array([kwargs[x] for x in coeffs_keys])
-        
+
     no_of_pcs = int(kwargs['no_of_pcs'])
-    
     coefficients_array = coefficients_array[:no_of_pcs]
     principal_components = principal_components[:no_of_pcs]
 
@@ -43,11 +41,9 @@ def get_td_corecollapse_bounce_signal(template=None, **kwargs):
     distance *=  mpc_conversion
 
     wf = numpy.dot(coefficients_array, principal_components) / distance
-    
     delta_t = kwargs['delta_t']
     outhp = TimeSeries(wf, delta_t=delta_t)
     outhc = TimeSeries(numpy.zeros(len(wf)), delta_t=delta_t)
-    
     return outhp, outhc
 
 

--- a/pycbc/waveform/supernovae.py
+++ b/pycbc/waveform/supernovae.py
@@ -1,0 +1,73 @@
+"""Generate core-collapse supernovae waveforms
+"""
+
+import numpy
+import math
+import h5py
+from pycbc.types import TimeSeries, FrequencySeries, float64, complex128, zeros
+from pycbc.waveform.waveform import get_obj_attrs
+
+
+def get_td_corecollapse_bounce_signal(template=None, **kwargs):
+    """generates CCSNe waveform
+    """
+    
+    # eos_dict = dict({0:'SFHo', 1:'SFHx', 2:'LS180', 3:'HSIUF', 
+    #                  4:'LS220', 5:'GSHenFSU2.1', 6:'GShenFSU1.7', 
+    #                  7:'LS375', 8:'HSTMA', 9:'HSFSG', 10:'HSDD2', 
+    #                  11:'BHBL', 12:'BHBLP', 13:'all_eos'})
+
+    # eos_index = math.floor(numpy.float(kwargs['eos_index']))
+
+    # check if a hdf file with principal components is provided as an arg:
+    if 'pc_hdf_file' in kwargs:
+        pc_file = h5py.File(kwargs['pc_hdf_file'], 'r')
+        # eos_name = pc_file.get(eos_dict[eos_index])
+        # eos_data = pc_file.get(eos_name)
+        # principal_components = numpy.array(eos_data.get('principal_components'))
+        principal_components = numpy.array(pc_file.get('principal_components'))
+
+    if 'principal_components' in kwargs:
+        principal_components = kwargs['principal_components']
+
+    
+    
+    if 'coefficients_array' in kwargs:
+        coefficients_array = kwargs['coefficients_array']
+    else:
+        coeffs_keys = [x for x in kwargs if x.startswith('coeff_')]
+        coeffs_keys = numpy.sort(numpy.array(coeffs_keys))
+        coefficients_array = numpy.array([kwargs[x] for x in coeffs_keys])
+
+    if 'tc' in kwargs:
+        print('tc is being passed here')
+        t_bounce = kwargs['tc']
+        
+    no_of_pcs = int(kwargs['no_of_pcs'])
+    
+    coefficients_array = coefficients_array[:no_of_pcs]
+    principal_components = principal_components[:no_of_pcs]
+
+    pc_len = len(principal_components)
+    assert len(coefficients_array) == pc_len
+
+    distance = kwargs['distance']
+    mpc_conversion = 3.08567758128e+22
+    distance *=  mpc_conversion
+
+    wf = numpy.dot(coefficients_array, principal_components) / distance
+    
+    delta_t = kwargs['delta_t']
+    outhp = TimeSeries(wf, delta_t=delta_t)
+    outhc = TimeSeries(numpy.zeros(len(wf)), delta_t=delta_t)
+    
+#    outhp.start_time = t_bounce - 0.5
+#    print "tstart from the supernovae.py code: ", outhp.start_time
+    # returning the same output for hp, hc as 2D waveforms don't have 
+    # polarization info
+    
+    return outhp, outhc
+
+
+# Approximant names ###########################################################
+supernovae_td_approximants = {'CoreCollapseBounce' : get_td_corecollapse_bounce_signal}

--- a/pycbc/waveform/supernovae.py
+++ b/pycbc/waveform/supernovae.py
@@ -6,7 +6,7 @@ import numpy
 import h5py
 from pycbc.types import TimeSeries
 
-_principal_components = {}
+_pc_dict = {}
 
 
 def get_corecollapse_bounce(**kwargs):
@@ -17,11 +17,11 @@ def get_corecollapse_bounce(**kwargs):
     """
 
     try:
-        principal_components = _principal_components['principal_components']
+        principal_components = _pc_dict['principal_components']
     except KeyError:
         with h5py.File(kwargs['principal_components_file'], 'r') as pc_file:
             principal_components = numpy.array(pc_file['principal_components'])
-            _principal_components['principal_components'] = principal_components
+            _pc_dict['principal_components'] = principal_components
 
     if 'coefficients_array' in kwargs:
         coefficients_array = kwargs['coefficients_array']

--- a/pycbc/waveform/supernovae.py
+++ b/pycbc/waveform/supernovae.py
@@ -1,47 +1,34 @@
-"""Generate core-collapse supernovae waveforms
+"""Generate core-collapse supernovae waveform for core bounce and 
+subsequent postbounce oscillations. 
 """
 
 import numpy
 import math
 import h5py
-from pycbc.types import TimeSeries, FrequencySeries, float64, complex128, zeros
-from pycbc.waveform.waveform import get_obj_attrs
+from pycbc.types import TimeSeries, FrequencySeries
 
+_principal_components = {}
 
 def get_td_corecollapse_bounce_signal(template=None, **kwargs):
-    """generates CCSNe waveform
+    """ Generates core bounce and postbounce waveform by using principal 
+    component basis vectors from a .hdf file. The waveform parameters are the 
+    coefficients of the principal components and the distance. The number of 
+    principal components used can also be varied. 
     """
     
-    # eos_dict = dict({0:'SFHo', 1:'SFHx', 2:'LS180', 3:'HSIUF', 
-    #                  4:'LS220', 5:'GSHenFSU2.1', 6:'GShenFSU1.7', 
-    #                  7:'LS375', 8:'HSTMA', 9:'HSFSG', 10:'HSDD2', 
-    #                  11:'BHBL', 12:'BHBLP', 13:'all_eos'})
+    try:
+        principal_components = _principal_components['principal_components']
+    except KeyError:
+        pc_file = h5py.File(kwargs['principal_components_file'], 'r')
+        principal_components = pc_file['principal_components']
+        _principal_components['principal_components'] = principal_components
 
-    # eos_index = math.floor(numpy.float(kwargs['eos_index']))
-
-    # check if a hdf file with principal components is provided as an arg:
-    if 'pc_hdf_file' in kwargs:
-        pc_file = h5py.File(kwargs['pc_hdf_file'], 'r')
-        # eos_name = pc_file.get(eos_dict[eos_index])
-        # eos_data = pc_file.get(eos_name)
-        # principal_components = numpy.array(eos_data.get('principal_components'))
-        principal_components = numpy.array(pc_file.get('principal_components'))
-
-    if 'principal_components' in kwargs:
-        principal_components = kwargs['principal_components']
-
-    
-    
     if 'coefficients_array' in kwargs:
         coefficients_array = kwargs['coefficients_array']
     else:
         coeffs_keys = [x for x in kwargs if x.startswith('coeff_')]
         coeffs_keys = numpy.sort(numpy.array(coeffs_keys))
         coefficients_array = numpy.array([kwargs[x] for x in coeffs_keys])
-
-    if 'tc' in kwargs:
-        print('tc is being passed here')
-        t_bounce = kwargs['tc']
         
     no_of_pcs = int(kwargs['no_of_pcs'])
     
@@ -60,11 +47,6 @@ def get_td_corecollapse_bounce_signal(template=None, **kwargs):
     delta_t = kwargs['delta_t']
     outhp = TimeSeries(wf, delta_t=delta_t)
     outhc = TimeSeries(numpy.zeros(len(wf)), delta_t=delta_t)
-    
-#    outhp.start_time = t_bounce - 0.5
-#    print "tstart from the supernovae.py code: ", outhp.start_time
-    # returning the same output for hp, hc as 2D waveforms don't have 
-    # polarization info
     
     return outhp, outhc
 


### PR DESCRIPTION
This patch adds the core-collapse waveform model:

1. Added core bounce and post bounce waveform for core collapse supernovae. This uses a `.hdf` file containing principal component basis vectors to generate the waveforms. The principal components are generated using singular value decomposition of a catalog of numerical simulations. The waveform model is h = a_1 * x_1 + a_2 * x_2 + ... + a_n * x_n, where x_i are the principal component basis vectors and a_i are their coefficients. 

2. Added a constraint for the coefficients of the basis vectors that generate the core collapse waveform. The coefficients should be inside the two/three dimensional convex hull of the coefficients of the waveforms in a catalog.

3. For Bayesian inference, the coefficients are the variable parameters while the principal components  and the number of principal components  used are static parameters. Following is an example section of `.ini` file that would be used for inference:

```
[variable_params]
coeff_0 = 
coeff_1 = 
coeff_2 = 
coeff_3 = 

[static_params]
distance = 0.0081
no_of_pcs = 9
principal_components_file = /path/to/principal_components_file.hdf 

[constraint-hull]
name = supernovae_convex_hull
principal_components_file = ${static_params|principal_components_file}
hull_dimention = 3
constraint_arg =
```
