### PR TITLE
coinc_lim_for_thresh for BBH statistics

### DIFF
--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -1621,6 +1621,14 @@ class ExpFitSGPSDFgBgNormBBHStatistic(ExpFitSGFgBgNormNewStatistic):
         logr_s += numpy.log((self.curr_mchirp / 20.0) ** (11./3.0))
         return logr_s
 
+    def coinc_multiifo_lim_for_thresh(self, s, thresh, limifo,
+                                      **kwargs): # pylint:disable=unused-argument
+        loglr = ExpFitSGFgBgNormNewStatistic.coinc_multiifo_lim_for_thresh(self, s, thresh, limifo,
+                                      **kwargs)
+        loglr += numpy.log((self.curr_mchirp / 20.0) ** (11./3.0))
+
+        return loglr
+
 
 class ExpFitSGPSDFgBgNormBBHThreshStatistic(ExpFitSGPSDFgBgNormBBHStatistic):
     def __init__(self, files=None, ifos=None, max_chirp_mass=None, **kwargs):

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -1571,7 +1571,6 @@ class ExpFitSGFgBgNormNewStatistic(PhaseTDNewStatistic,
         logr_n = - numpy.log(hist_vol)
 
         loglr = - thresh + network_logvol - ln_noise_rate + logr_s - logr_n
-
         return loglr
 
 
@@ -1626,7 +1625,6 @@ class ExpFitSGPSDFgBgNormBBHStatistic(ExpFitSGFgBgNormNewStatistic):
         loglr = ExpFitSGFgBgNormNewStatistic.coinc_multiifo_lim_for_thresh(
                     self, s, thresh, limifo, **kwargs)
         loglr += numpy.log((self.curr_mchirp / 20.0) ** (11./3.0))
-
         return loglr
 
 

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -1623,8 +1623,8 @@ class ExpFitSGPSDFgBgNormBBHStatistic(ExpFitSGFgBgNormNewStatistic):
 
     def coinc_multiifo_lim_for_thresh(self, s, thresh, limifo,
                                       **kwargs): # pylint:disable=unused-argument
-        loglr = ExpFitSGFgBgNormNewStatistic.coinc_multiifo_lim_for_thresh(self, s, thresh, limifo,
-                                      **kwargs)
+        loglr = ExpFitSGFgBgNormNewStatistic.coinc_multiifo_lim_for_thresh(
+                    self, s, thresh, limifo, **kwargs)
         loglr += numpy.log((self.curr_mchirp / 20.0) ** (11./3.0))
 
         return loglr


### PR DESCRIPTION
the mchirp weighting got missed off in the coinc_lim_for_thresh stuff, which means that some background coincs were dismissed when they shouldn't have been