### PR TITLE
Fix error with approximant strings in HDF injections

### DIFF
--- a/pycbc/inject/inject.py
+++ b/pycbc/inject/inject.py
@@ -336,6 +336,11 @@ class _HDFInjectionSet(object):
         parameters = list(group.keys())
         # get all injection parameter values
         injvals = {param: group[param][()] for param in parameters}
+        # make sure Numpy S strings are loaded as strings and not bytestrings
+        # (which could mess with approximant names, for example)
+        for k in injvals:
+            if injvals[k].dtype.kind == 'S':
+                injvals[k] = injvals[k].astype('U')
         # if there were no variable args, then we only have a single injection
         if len(parameters) == 0:
             numinj = 1


### PR DESCRIPTION
This is a proposal for fixing #3395. Apparently the HDF injection code has trouble when the approximant field (or any other string field) is not static. The fix is based on the approach already used for handling static arguments.

I am not sure if this will break existing use cases, and I have not tested it with Python 2, but opening for consideration.