### PR TITLE
Write logevidence and dloz at the 'finalize' step

### DIFF
--- a/pycbc/inference/sampler/dynesty.py
+++ b/pycbc/inference/sampler/dynesty.py
@@ -372,6 +372,11 @@ class DynestySampler(BaseSampler):
         #    self._sampler.sampler.rstate = numpy.random
 
     def finalize(self):
+        """Finalze and write it to the results file
+        """
+        logz = self._sampler.results.logz[-1:][0]
+        dlogz = self._sampler.results.logzerr[-1:][0]
+        logging.info("log Z, dlog Z: {}, {}".format(logz, dlogz))
         self.checkpoint()
         logging.info("Validating checkpoint and backup files")
         checkpoint_valid = validate_checkpoint_files(


### PR DESCRIPTION
In this PR, I restore the functionality of writing logZ and dlogZ values at the 'finalize' step of dynesty sampler. It was lost in one of the earlier PR. It is a minor change.