### PR TITLE
Fix case where one detector combo has no foreground triggers

### DIFF
--- a/bin/hdfcoinc/pycbc_multiifo_add_statmap
+++ b/bin/hdfcoinc/pycbc_multiifo_add_statmap
@@ -453,9 +453,11 @@ while True:
                     combined_fg_data.data[key][:]
 
     max_each_combo = {combo: sep_fg_data[combo].data['ifar'][:].argmax()
-                      for combo in all_ifo_combos}
+                      for combo in all_ifo_combos
+                      if len(sep_fg_data[combo].data['ifar'][:]) > 0}
     max_ifars = {combo: sep_fg_data[combo].data['ifar'][:][max_each_combo[combo]]
-                    for combo in all_ifo_combos}
+                 for combo in all_ifo_combos
+                 if len(sep_fg_data[combo].data['ifar'][:]) > 0}
 
     logging.info('Maximum IFAR values per combination:')
     for k in max_ifars:

--- a/bin/hdfcoinc/pycbc_multiifo_add_statmap
+++ b/bin/hdfcoinc/pycbc_multiifo_add_statmap
@@ -455,9 +455,8 @@ while True:
     max_each_combo = {combo: sep_fg_data[combo].data['ifar'][:].argmax()
                       for combo in all_ifo_combos
                       if len(sep_fg_data[combo].data['ifar'][:]) > 0}
-    max_ifars = {combo: sep_fg_data[combo].data['ifar'][:][max_each_combo[combo]]
-                 for combo in all_ifo_combos
-                 if len(sep_fg_data[combo].data['ifar'][:]) > 0}
+    max_ifars = {combo: sep_fg_data[combo].data['ifar'][:][hidx]
+                 for combo, hidx in max_each_combo.items()}
 
     logging.info('Maximum IFAR values per combination:')
     for k in max_ifars:


### PR DESCRIPTION
The add statmap code is breaking when finding the most significant trigger for hierarchical removal if there are no triggers in a given detector combination.

In the dictionary comprehension it does argmax for each detector combo, if one is empty this produces an error.
This can be fixed by including an if statement in the comprehension to test that the array is non-zero in size.