### PR TITLE
Minifollowup plot tweaks

### DIFF
--- a/bin/hdfcoinc/pycbc_plot_singles_timefreq
+++ b/bin/hdfcoinc/pycbc_plot_singles_timefreq
@@ -50,7 +50,7 @@ parser.add_argument('--output-file', required=True, help='Output plot')
 parser.add_argument('--bank-file', required=True,
                     help='HDF5 file containing template bank')
 parser.add_argument('--veto-file', help='LIGOLW file containing veto segments')
-parser.add_argument('--f-low', type=float, default=30,
+parser.add_argument('--f-low', type=float, default=20,
                     help='Low-frequency cutoff')
 parser.add_argument('--rank', choices=['snr', 'newsnr'], default='newsnr',
                     help='Ranking statistic for sorting triggers')
@@ -73,7 +73,6 @@ opts = parser.parse_args()
 
 logging.basicConfig(format='%(asctime)s %(message)s', level=logging.INFO)
 
-
 if opts.center_time is None:
     center_time = (opts.gps_start_time + opts.gps_end_time) / 2.
 else:
@@ -82,30 +81,6 @@ else:
 fig = pl.figure(figsize=(11,5.5))
 fig.subplots_adjust(left=0.06, right=0.95, bottom=0.09, top=0.95)
 ax = fig.gca()
-
-if center_time == -1.0:
-    title = '%s - no triggers' % opts.detector
-    ax.set_xlim(opts.gps_start_time - center_time, opts.gps_end_time - center_time)
-    ax.set_ylim(opts.f_low, opts.sample_rate / 2)
-    ax.set_yscale('log')
-    ax.grid(ls='solid', alpha=0.2)
-    ax.set_xlabel('Time - %.3f (s)' % center_time)
-    ax.set_ylabel('Frequency (Hz)')
-    ax.set_title(title)
-    caption = ("This plot shows the power spectrogram of the strain data, "
-               "normalized to its median over time, as a heatmap. The "
-               "time-frequency evolution of each single trigger is shown as a blue "
-               "curve. The light-blue curve is the loudest trigger by %s. Only the "
-               "loudest %d triggers by %s are shown. Green hatched areas denote "
-               "gated strain data. Red hatched areas denote vetoed time.") % \
-    (opts.rank, opts.num_loudest, opts.rank)
-    pycbc.results.save_fig_with_metadata(
-        fig, opts.output_file, cmd=' '.join(sys.argv),
-        title='Strain spectrogram and inspiral tracks for %s' % opts.detector,
-        caption=caption, fig_kwds={'dpi': 100})
-
-    logging.info('Done')
-    sys.exit(0)
 
 opts.low_frequency_cutoff = opts.f_low
 strain = pycbc.strain.from_cli(opts, pycbc.DYN_RANGE_FAC)
@@ -168,7 +143,7 @@ if len(indices) > 0:
     sorted_template_ids = template_ids[sorter]
 
     try:
-        max_rank = max([sorted_rank[i] for i in range(len(sorted_rank)) \
+        max_rank = max([sorted_rank[i] for i in range(len(sorted_rank))
                         if sorted_end_time[i] <= opts.gps_end_time])
     except ValueError:
         max_rank = None
@@ -244,7 +219,9 @@ if opts.veto_file:
         ax.axvspan(seg[0] - center_time, seg[1] - center_time,
                    hatch='x', facecolor='none', edgecolor='#ff0000')
 
-ax.set_xlim(opts.gps_start_time - center_time, opts.gps_end_time - center_time)
+half_width = max(opts.gps_end_time - center_time,
+                 center_time - opts.gps_start_time)
+ax.set_xlim(-half_width, half_width)
 ax.set_ylim(opts.f_low, opts.sample_rate / 2)
 ax.set_yscale('log')
 ax.grid(ls='solid', alpha=0.2)
@@ -253,18 +230,21 @@ ax.set_ylabel('Frequency (Hz)')
 ax.set_title(title)
 cb = fig.colorbar(pc, fraction=0.04, pad=0.01,
                   ticks=LogLocator(subs=range(10)))
-cb.set_label('Power density (normalized to its median over time)')
+cb.set_label('Power density normalized to its median over time')
 
-caption = ("This plot shows the power spectrogram of the strain data, "
-           "normalized to its median over time, as a heatmap. The "
-           "time-frequency evolution of each single trigger is shown as a blue "
-           "curve. The light-blue curve is the loudest trigger by %s. Only the "
-           "loudest %d triggers by %s are shown. Green hatched areas denote "
-           "gated strain data. Red hatched areas denote vetoed time.") % \
-        (opts.rank, opts.num_loudest, opts.rank)
+caption = ('This plot shows the power spectrogram of the strain data, '
+           'normalized to its median over time, as a heatmap. The '
+           'time-frequency evolution of each single trigger is shown as a '
+           'blue curve. The light-blue curve is the loudest trigger by {0}. '
+           'Only the loudest {1} triggers by {0} are shown. Green hatched '
+           'areas denote gated strain data (\\\\ = externally-provided '
+           'gates, // = autogates). Red hatched areas denote vetoed time.')
+caption = caption.format(opts.rank, opts.num_loudest)
+md_title = 'Strain spectrogram and inspiral tracks for ' + opts.detector
+
 pycbc.results.save_fig_with_metadata(
     fig, opts.output_file, cmd=' '.join(sys.argv),
-    title='Strain spectrogram and inspiral tracks for %s' % opts.detector,
+    title=md_title,
     caption=caption, fig_kwds={'dpi': 100})
 
 logging.info('Done')

--- a/bin/plotting/pycbc_plot_qscan
+++ b/bin/plotting/pycbc_plot_qscan
@@ -236,7 +236,14 @@ if opts.plot_title is None:
 if opts.plot_caption is None:
     # FIXME: Someone please improve!
     opts.plot_caption = ("This shows the Q-transform as a function of time and "
-                         "frequency")
+                         "frequency.")
+    if plot_chirp:
+        chirp_caption = (' The red curve is the time-frequency curve of a'
+                         ' quadrupole-order quasicircular aligned-spin'
+                         ' inspiral with mass1={:.3f}, mass2={:.3f},'
+                         ' spin1z={:.3f}, spin1z={:.3f}.')
+        opts.plot_caption += chirp_caption.format(opts.mass1, opts.mass2,
+                                                  opts.spin1z, opts.spin2z)
 
 pycbc.results.save_fig_with_metadata(
         fig, opts.output_file, cmd=' '.join(sys.argv), fig_kwds={'dpi': 150},

--- a/bin/plotting/pycbc_plot_qscan
+++ b/bin/plotting/pycbc_plot_qscan
@@ -160,7 +160,7 @@ if (center_time - strain.start_time) < 2 or (strain.end_time - center_time) < 2:
 strain = strain.whiten(4, 4, remove_corrupted=rem_corrupted)
 
 wins = opts.time_windows
-fig, axes = plt.subplots(len(wins),1)
+fig, axes = plt.subplots(len(wins), 1)
 times_all = []
 freqs_all = []
 qvals_all = []

--- a/bin/plotting/pycbc_plot_qscan
+++ b/bin/plotting/pycbc_plot_qscan
@@ -224,7 +224,9 @@ if plot_chirp:
     track_t, track_f = get_inspiral_tf(opts.center_time, opts.mass1,
                                        opts.mass2, opts.spin1z, opts.spin2z,
                                        f_low, approximant=approximant)
-    ax.plot(track_t - opts.center_time, track_f, 'r-', lw=1.5)
+    for curr_idx in range(len(wins)):
+        ax = axes[curr_idx] if len(wins) > 1 else axes
+        ax.plot(track_t - opts.center_time, track_f, 'r-', lw=1.5)
 
 if opts.channel_name is not None:
     plt.suptitle(opts.channel_name)

--- a/bin/plotting/pycbc_plot_qscan
+++ b/bin/plotting/pycbc_plot_qscan
@@ -65,16 +65,16 @@ parser.add_argument("--low-frequency-cutoff", type=float,
 
 parser.add_argument('--qtransform-delta-t', default=0.001, type=float,
                     help='The time resolution to interpolate to (optional)')
-parser.add_argument('--qtransform-delta-f', default=None, type=float,
+parser.add_argument('--qtransform-delta-f', type=float,
                     help='Frequency resolution to interpolate to (optional)')
 parser.add_argument('--qtransform-logfsteps', type=int, default=200,
                     help='Do a log interpolation (incompatible with '
                          '--qtransform-delta-f option) and set the number '
                          'of steps to take')
-parser.add_argument('--qtransform-frange-lower', default=None, type=float,
+parser.add_argument('--qtransform-frange-lower', type=float,
                     help='Lower frequency (in Hz) at which to compute '
                          'qtransform. Optional, default=20 Hz')
-parser.add_argument('--qtransform-frange-upper', default=None, type=float,
+parser.add_argument('--qtransform-frange-upper', type=float,
                     help='Upper frequency (in Hz) at which to compute '
                          'qtransform. Optional, default=Half of Nyquist')
 parser.add_argument('--qtransform-qrange-lower', default=4, type=float,
@@ -129,13 +129,17 @@ if center_time == -1.0:
     plt.grid(False)
     plt.xlabel('Time from {:.3f} (s)'.format(opts.center_time))
     plt.ylabel('Frequency (Hz)')
-    title = 'No data for this IFO'
-    pycbc.results.save_fig_with_metadata\
-    (fig, opts.output_file, cmd=' '.join(sys.argv), fig_kwds={'dpi': 150},
-     title=title, caption=opts.plot_caption)
+    title = 'No data for this detector'
+    pycbc.results.save_fig_with_metadata(
+            fig, opts.output_file, cmd=' '.join(sys.argv),
+            fig_kwds={'dpi': 150}, title=title, caption=opts.plot_caption)
     sys.exit(0)
 
-#opts.low_frequency_cutoff = opts.f_low
+if opts.mass1 is not None or opts.mass2 is not None:
+    if None in [opts.mass1, opts.mass2]:
+        parser.error('Must provide either both --mass1 and --mass2 or neither')
+    plot_chirp = True
+
 strain = pycbc.strain.from_cli(opts, pycbc.DYN_RANGE_FAC)
 
 if opts.qtransform_frange_upper is None and \
@@ -160,6 +164,8 @@ times_all = []
 freqs_all = []
 qvals_all = []
 
+qrange = (opts.qtransform_qrange_lower, opts.qtransform_qrange_upper)
+
 for curr_idx in range(len(wins)):
     curr_win = wins[curr_idx]
     # Catch the case that not enough data is available.
@@ -170,11 +176,10 @@ for curr_idx in range(len(wins)):
     strain_zoom = strain.time_slice(opts.center_time - curr_win[0],
                                     opts.center_time + curr_win[1])
 
-    times, freqs, qvals = strain_zoom.qtransform\
-        (delta_t=opts.qtransform_delta_t, delta_f = opts.qtransform_delta_f,
-         logfsteps=opts.qtransform_logfsteps, frange=curr_frange,
-         qrange=(opts.qtransform_qrange_lower, opts.qtransform_qrange_upper),
-         mismatch=opts.qtransform_mismatch)
+    times, freqs, qvals = strain_zoom.qtransform(
+            delta_t=opts.qtransform_delta_t, delta_f=opts.qtransform_delta_f,
+            logfsteps=opts.qtransform_logfsteps, frange=curr_frange,
+            qrange=qrange, mismatch=opts.qtransform_mismatch)
     times_all.append(times)
     freqs_all.append(freqs)
     qvals_all.append(qvals)
@@ -188,9 +193,9 @@ for curr_idx in range(len(wins)):
     qvals = qvals_all[curr_idx]
     curr_win = wins[curr_idx]
 
-    norm=None
+    norm = None
     if opts.log_colorbar:
-        norm=LogNorm(vmin=1, vmax=max_qval)
+        norm = LogNorm(vmin=1, vmax=max_qval)
 
     im = ax.pcolormesh(times - opts.center_time, freqs, qvals, norm=norm,
                        cmap=opts.colormap)
@@ -211,9 +216,7 @@ plt.ylabel('Frequency (Hz)')
 cb = fig.colorbar(im, ax=(axes.ravel().tolist() if len(wins) > 1 else axes))
 cb.set_label('Normalized power')
 
-if opts.mass1:
-    if not opts.mass2:
-        raise ValueError('mass1 provided but mass2 missing')
+if plot_chirp:
     from pycbc.pnutils import get_inspiral_tf
     f_low = 20.
     approximant = 'SPAtmplt' if opts.mass1+opts.mass2<4 else 'SEOBNRv4_ROM'
@@ -222,6 +225,9 @@ if opts.mass1:
                                        f_low, approximant=approximant)
     ax.plot(track_t - opts.center_time, track_f, 'r-', lw=1.5)
 
+if opts.channel_name is not None:
+    plt.suptitle(opts.channel_name)
+
 if opts.plot_title is None:
     opts.plot_title = 'Q-transform plot around {:.3f}'.format(opts.center_time)
 if opts.plot_caption is None:
@@ -229,6 +235,6 @@ if opts.plot_caption is None:
     opts.plot_caption = ("This shows the Q-transform as a function of time and "
                          "frequency")
 
-pycbc.results.save_fig_with_metadata\
-    (fig, opts.output_file, cmd=' '.join(sys.argv), fig_kwds={'dpi': 150},
-     title=opts.plot_title, caption=opts.plot_caption)
+pycbc.results.save_fig_with_metadata(
+        fig, opts.output_file, cmd=' '.join(sys.argv), fig_kwds={'dpi': 150},
+        title=opts.plot_title, caption=opts.plot_caption)

--- a/bin/plotting/pycbc_plot_qscan
+++ b/bin/plotting/pycbc_plot_qscan
@@ -135,6 +135,7 @@ if center_time == -1.0:
             fig_kwds={'dpi': 150}, title=title, caption=opts.plot_caption)
     sys.exit(0)
 
+plot_chirp = False
 if opts.mass1 is not None or opts.mass2 is not None:
     if None in [opts.mass1, opts.mass2]:
         parser.error('Must provide either both --mass1 and --mass2 or neither')

--- a/bin/plotting/pycbc_plot_qscan
+++ b/bin/plotting/pycbc_plot_qscan
@@ -234,9 +234,11 @@ if opts.channel_name is not None:
 if opts.plot_title is None:
     opts.plot_title = 'Q-transform plot around {:.3f}'.format(opts.center_time)
 if opts.plot_caption is None:
-    # FIXME: Someone please improve!
     opts.plot_caption = ("This shows the Q-transform as a function of time and "
                          "frequency.")
+    if opts.channel_name is not None:
+        opts.plot_caption += (' The strain channel is ' + opts.channel_name
+                              + '.')
     if plot_chirp:
         chirp_caption = (' The red curve is the time-frequency curve of a'
                          ' quadrupole-order quasicircular aligned-spin'

--- a/bin/plotting/pycbc_plot_qscan
+++ b/bin/plotting/pycbc_plot_qscan
@@ -124,8 +124,8 @@ else:
 if center_time == -1.0:
     fig, axes = plt.subplots(1,1)
     fig.add_subplot(111, frameon=False)
-    plt.tick_params(labelcolor='none', top='off', bottom='off', left='off',
-                    right='off')
+    plt.tick_params(labelcolor='none', top=False, bottom=False, left=False,
+                    right=False)
     plt.grid(False)
     plt.xlabel('Time from {:.3f} (s)'.format(opts.center_time))
     plt.ylabel('Frequency (Hz)')
@@ -207,8 +207,8 @@ for curr_idx in range(len(wins)):
 
 # https://stackoverflow.com/questions/6963035/pyplot-axes-labels-for-subplots
 fig.add_subplot(111, frameon=False)
-plt.tick_params(labelcolor='none', top='off', bottom='off', left='off',
-                right='off')
+plt.tick_params(labelcolor='none', top=False, bottom=False, left=False,
+                right=False)
 plt.grid(False)
 plt.xlabel('Time from {:.3f} (s)'.format(opts.center_time))
 plt.ylabel('Frequency (Hz)')


### PR DESCRIPTION
Improvements to `pycbc_plot_singles_timefreq` and `pycbc_plot_qscan` after looking at recent minifollowup pages.

`pycbc_plot_singles_timefreq` changes:
* Remove the undocumented special case `--center-time -1` which is no longer used in the workflow.
* Restore the intended behavior of `--center-time`, i.e. the x-axis is now really centered at the given time. This makes it clearer when the plot intersects the boundary of a science segment.
* Describe the visual difference between externally-provided gates and autogates in the caption.
* Code cleanup.

`pycbc_plot_qscan` changes:
* Show the strain channel name (when available) in the plot and caption. In the minifollowups, this change makes it easier to see what detector a plot refers to.
* When plotting a chirp, plot it in all panels, and describe it in the caption.
* Fix a matplotlib warning and a graphical glitch happening with Python 3.
* Code cleanup.