### PR TITLE
Address error when no gating veto argument was given

### DIFF
--- a/pycbc/io/hdf.py
+++ b/pycbc/io/hdf.py
@@ -987,7 +987,7 @@ class ForegroundTriggers(object):
         ligolw_utils.write_filename(outdoc, file_name)
 
 class ReadByTemplate(object):
-    # default assignment to empty dict is OK for a variable used only in __init__
+    # default assignment to {} is OK for a variable used only in __init__
     def __init__(self, filename, bank=None, segment_name=None, veto_files=None,
                  gating_veto_windows={}):
         self.filename = filename

--- a/pycbc/io/hdf.py
+++ b/pycbc/io/hdf.py
@@ -1008,7 +1008,7 @@ class ReadByTemplate(object):
             veto_segs = veto.select_segments_by_definer(vfile, ifo=self.ifo,
                                                         segment_name=name)
             self.segs = (self.segs - veto_segs).coalesce()
-        if gating_veto_windows is not None:
+        if gating_veto_windows:
             gating_veto = gating_veto_windows[self.ifo].split(',')
             gveto_before = float(gating_veto[0])
             gveto_after = float(gating_veto[1])

--- a/pycbc/io/hdf.py
+++ b/pycbc/io/hdf.py
@@ -988,7 +988,7 @@ class ForegroundTriggers(object):
 
 class ReadByTemplate(object):
     def __init__(self, filename, bank=None, segment_name=None, veto_files=None,
-                 gating_veto_windows=None):
+                 gating_veto_windows={}):
         self.filename = filename
         self.file = h5py.File(filename, 'r')
         self.ifo = tuple(self.file.keys())[0]
@@ -1008,7 +1008,7 @@ class ReadByTemplate(object):
             veto_segs = veto.select_segments_by_definer(vfile, ifo=self.ifo,
                                                         segment_name=name)
             self.segs = (self.segs - veto_segs).coalesce()
-        if gating_veto_windows:
+        if self.ifo in gating_veto_windows:
             gating_veto = gating_veto_windows[self.ifo].split(',')
             gveto_before = float(gating_veto[0])
             gveto_after = float(gating_veto[1])

--- a/pycbc/io/hdf.py
+++ b/pycbc/io/hdf.py
@@ -987,6 +987,7 @@ class ForegroundTriggers(object):
         ligolw_utils.write_filename(outdoc, file_name)
 
 class ReadByTemplate(object):
+    # default assignment to empty dict is OK for a variable used only in __init__
     def __init__(self, filename, bank=None, segment_name=None, veto_files=None,
                  gating_veto_windows={}):
         self.filename = filename


### PR DESCRIPTION
When no --gating-veto-windows argument was given the following error arised:

`Traceback (most recent call last):
  File "/cvmfs/oasis.opensciencegrid.org/ligo/sw/pycbc/x86_64_rhel_7/virtualenv/pycbc-v1.16.11/bin/pycbc_multiifo_coinc_findtrigs", line 113, in <module>
    args.gating_veto_windows)
  File "/cvmfs/oasis.opensciencegrid.org/ligo/sw/pycbc/x86_64_rhel_7/virtualenv/pycbc-v1.16.11/lib/python2.7/site-packages/pycbc/io/hdf.py", line 1012, in __init__
    gating_veto = gating_veto_windows[self.ifo].split(',')
AttributeError: 'NoneType' object has no attribute 'split'`

This change should address the error

