### PR TITLE
Fix bug in pycbc_inspiral

### DIFF
--- a/pycbc/vetoes/chisq.py
+++ b/pycbc/vetoes/chisq.py
@@ -335,9 +335,9 @@ class SingleDetPowerChisq(object):
             psd._chisq_cached_key[id(template.params)] = True
             num_bins = int(self.parse_option(template, self.num_bins))
 
-            kmin = int(template.f_lower / psd.delta_f)
             if hasattr(psd, 'sigmasq_vec') and \
-                    (template.approximant, kmin) in psd.sigmasq_vec:
+                    template.approximant in psd.sigmasq_vec:
+                kmin = int(template.f_lower / psd.delta_f)
                 kmax = template.end_idx
                 bins = power_chisq_bins_from_sigmasq_series(
                     psd.sigmasq_vec[(template.approximant, kmin)],

--- a/pycbc/vetoes/chisq.py
+++ b/pycbc/vetoes/chisq.py
@@ -340,7 +340,7 @@ class SingleDetPowerChisq(object):
                     (template.approximant, kmin) in psd.sigmasq_vec:
                 kmax = template.end_idx
                 bins = power_chisq_bins_from_sigmasq_series(
-                    psd.sigmasq_vec[(template.approximant,kmin)],
+                    psd.sigmasq_vec[(template.approximant, kmin)],
                     num_bins,
                     kmin,
                     kmax

--- a/pycbc/vetoes/chisq.py
+++ b/pycbc/vetoes/chisq.py
@@ -340,7 +340,7 @@ class SingleDetPowerChisq(object):
                 kmin = int(template.f_lower / psd.delta_f)
                 kmax = template.end_idx
                 bins = power_chisq_bins_from_sigmasq_series(
-                    psd.sigmasq_vec[(template.approximant, kmin)],
+                    psd.sigmasq_vec[template.approximant],
                     num_bins,
                     kmin,
                     kmax

--- a/pycbc/vetoes/chisq.py
+++ b/pycbc/vetoes/chisq.py
@@ -335,11 +335,16 @@ class SingleDetPowerChisq(object):
             psd._chisq_cached_key[id(template.params)] = True
             num_bins = int(self.parse_option(template, self.num_bins))
 
-            if hasattr(psd, 'sigmasq_vec') and template.approximant in psd.sigmasq_vec:
-                kmin = int(template.f_lower / psd.delta_f)
+            kmin = int(template.f_lower / psd.delta_f)
+            if hasattr(psd, 'sigmasq_vec') and \
+                    (template.approximant, kmin) in psd.sigmasq_vec:
                 kmax = template.end_idx
                 bins = power_chisq_bins_from_sigmasq_series(
-                    psd.sigmasq_vec[template.approximant], num_bins, kmin, kmax)
+                    psd.sigmasq_vec[(template.approximant,kmin)],
+                    num_bins,
+                    kmin,
+                    kmax
+                )
             else:
                 bins = power_chisq_bins(template, num_bins, psd, template.f_lower)
             template._bin_cache[key] = bins

--- a/pycbc/waveform/bank.py
+++ b/pycbc/waveform/bank.py
@@ -59,9 +59,16 @@ def sigma_cached(self, psd):
             if not hasattr(psd, 'sigmasq_vec'):
                 psd.sigmasq_vec = {}
 
-            if self.approximant not in psd.sigmasq_vec:
-                psd.sigmasq_vec[self.approximant] = pycbc.waveform.get_waveform_filter_norm(
-                     self.approximant, psd, len(psd), psd.delta_f, self.f_lower)
+            k_min = int(self.f_lower / psd.delta_f)
+            if (self.approximant, k_min) not in psd.sigmasq_vec:
+                psd.sigmasq_vec[(self.approximant, k_min)] = \
+                    pycbc.waveform.get_waveform_filter_norm(
+                        self.approximant,
+                        psd,
+                        len(psd),
+                        psd.delta_f,
+                        self.f_lower
+                    )
 
             if not hasattr(self, 'sigma_scale'):
                 # Get an amplitude normalization (mass dependant constant norm)
@@ -70,9 +77,8 @@ def sigma_cached(self, psd):
                 amp_norm = 1 if amp_norm is None else amp_norm
                 self.sigma_scale = (DYN_RANGE_FAC * amp_norm) ** 2.0
 
-
             self._sigmasq[key] = self.sigma_scale * \
-                psd.sigmasq_vec[self.approximant][self.end_idx-1]
+                psd.sigmasq_vec[(self.approximant, k_min)][self.end_idx-1]
 
         else:
             if not hasattr(self, 'sigma_view'):

--- a/pycbc/waveform/bank.py
+++ b/pycbc/waveform/bank.py
@@ -80,7 +80,7 @@ def sigma_cached(self, psd):
 
             kmin = int(self.f_lower / psd.delta_f)
             self._sigmasq[key] = self.sigma_scale * \
-                (curr_sigmasq[self.end_idx-1]- curr_sigmasq[kmin])
+                (curr_sigmasq[self.end_idx-1] - curr_sigmasq[kmin])
 
         else:
             if not hasattr(self, 'sigma_view'):

--- a/pycbc/waveform/bank.py
+++ b/pycbc/waveform/bank.py
@@ -78,7 +78,7 @@ def sigma_cached(self, psd):
 
             curr_sigmasq = psd.sigmasq_vec[self.approximant]
 
-            kmin = int(template.f_lower / psd.delta_f)
+            kmin = int(self.f_lower / psd.delta_f)
             self._sigmasq[key] = self.sigma_scale * \
                 (curr_sigmasq[self.end_idx-1]- curr_sigmasq[kmin])
 

--- a/pycbc/waveform/bank.py
+++ b/pycbc/waveform/bank.py
@@ -59,15 +59,14 @@ def sigma_cached(self, psd):
             if not hasattr(psd, 'sigmasq_vec'):
                 psd.sigmasq_vec = {}
 
-            k_min = int(self.f_lower / psd.delta_f)
-            if (self.approximant, k_min) not in psd.sigmasq_vec:
-                psd.sigmasq_vec[(self.approximant, k_min)] = \
+            if self.approximant not in psd.sigmasq_vec:
+                psd.sigmasq_vec[self.approximant] = \
                     pycbc.waveform.get_waveform_filter_norm(
                         self.approximant,
                         psd,
                         len(psd),
                         psd.delta_f,
-                        self.f_lower
+                        self.min_f_lower
                     )
 
             if not hasattr(self, 'sigma_scale'):
@@ -77,8 +76,11 @@ def sigma_cached(self, psd):
                 amp_norm = 1 if amp_norm is None else amp_norm
                 self.sigma_scale = (DYN_RANGE_FAC * amp_norm) ** 2.0
 
+            curr_sigmasq = psd.sigmasq_vec[self.approximant]
+
+            kmin = int(template.f_lower / psd.delta_f)
             self._sigmasq[key] = self.sigma_scale * \
-                psd.sigmasq_vec[(self.approximant, k_min)][self.end_idx-1]
+                (curr_sigmasq[self.end_idx-1]- curr_sigmasq[kmin])
 
         else:
             if not hasattr(self, 'sigma_view'):


### PR DESCRIPTION
We've been tracking down a nasty issue in pycbc_inspiral recently. The symptom we saw was a BNS trigger with SNR ~ 12 and chisq ~ 1 per DOF. Except all the SNR was coming from a really nasty glitch *right* at the start of the waveform, for which we expect chisq to be large. Running this through `pycbc_single_template` found the expected large chisq.

We expected some problem in the chisq code, or in the GPU code, or in the new compressed waveforms, which meant it took us a long time to find the *actual* problem.

There's a bug in the sigmasq calculation for SPATmplt ... Or at least in the caching of it. We are not checking if the *lower* frequency has changed. So if the first template has a f_lower of 25Hz, all subsequent templates not using that f_lower will be affected.

I suspect this has been in place for some time now (since the start of O2?). So this will be a factor in at least GWTC-1 results, and 2-ODC (and 1-ODC?). However, it looks like it's never really made a major difference until this one example, so I'm hoping this is just a weird edge-case that really emphasizes this bug! The SNR variation due to this seems small (< 1%). I'm guessing it's just very strange cases where the chisq makes a difference.

I have tested that this fixes the issue in some small examples. Might be worth also testing it in some larger jobs that Josh has handy.

@ahnitz Does this seem like the best way of resolving this? Are the memory ramifications to doing this?