### PR TITLE
coinc_mergetrigs: deduplicate livetime segments

### DIFF
--- a/bin/hdfcoinc/pycbc_coinc_mergetrigs
+++ b/bin/hdfcoinc/pycbc_coinc_mergetrigs
@@ -85,8 +85,8 @@ for filename in args.trigger_files:
         logging.error('Cannot open %s', filename)
         raise e
     ifo_data = data[ifo]
-    segments.add((ifo_data['search/start_time'][:],
-                  ifo_data['search/end_time'][:]))
+    segments.add((float(ifo_data['search/start_time'][:]),
+                  float(ifo_data['search/end_time'][:])))
 
     if 'templates_per_core' in ifo_data['search'].keys():
         tpc = numpy.append(tpc, ifo_data['search/templates_per_core'][:])
@@ -108,7 +108,7 @@ for filename in args.trigger_files:
                 gating[gk] = numpy.append(gating[gk], gk_data[:])
     data.close()
 
-segments = np.array(sorted(segments), dtype=np.float64)
+segments = numpy.array(sorted(segments), dtype=numpy.float64)
 f['%s/search/start_time' % ifo] = segments[:,0]
 f['%s/search/end_time' % ifo] = segments[:,1]
 

--- a/bin/hdfcoinc/pycbc_coinc_mergetrigs
+++ b/bin/hdfcoinc/pycbc_coinc_mergetrigs
@@ -72,8 +72,7 @@ for col in trigger_columns:
     logging.info("trigger column: %s", col)
 
 logging.info('reading the metadata from the files')
-start = numpy.array([], dtype=numpy.float64)
-end = numpy.array([], dtype=numpy.float64)
+segments = set()
 tpc = numpy.array([], dtype=numpy.float64)
 frpc = numpy.array([], dtype=numpy.float64)
 stf = numpy.array([], dtype=numpy.float64)
@@ -86,8 +85,8 @@ for filename in args.trigger_files:
         logging.error('Cannot open %s', filename)
         raise e
     ifo_data = data[ifo]
-    s, e = ifo_data['search/start_time'][:], ifo_data['search/end_time'][:]
-    start, end = numpy.append(start, s), numpy.append(end, e)
+    segments.add((ifo_data['search/start_time'][:],
+                  ifo_data['search/end_time'][:]))
 
     if 'templates_per_core' in ifo_data['search'].keys():
         tpc = numpy.append(tpc, ifo_data['search/templates_per_core'][:])
@@ -107,8 +106,11 @@ for filename in args.trigger_files:
                 if not gk in gating:
                     gating[gk] = numpy.array([], dtype=numpy.float64)
                 gating[gk] = numpy.append(gating[gk], gk_data[:])
-    data.close()    
-f['%s/search/start_time' % ifo], f['%s/search/end_time' % ifo] = start, end
+    data.close()
+
+segments = np.array(sorted(segments), dtype=np.float64)
+f['%s/search/start_time' % ifo] = segments[:,0]
+f['%s/search/end_time' % ifo] = segments[:,1]
 
 if len(tpc) > 0:
     f['%s/search/templates_per_core' % ifo] = tpc

--- a/bin/hdfcoinc/pycbc_coinc_mergetrigs
+++ b/bin/hdfcoinc/pycbc_coinc_mergetrigs
@@ -85,6 +85,9 @@ for filename in args.trigger_files:
         logging.error('Cannot open %s', filename)
         raise e
     ifo_data = data[ifo]
+
+    # duplicate segments (due, for example, to bank splitting)
+    # will be deduplicated by the set here
     segments.add((float(ifo_data['search/start_time'][:]),
                   float(ifo_data['search/end_time'][:])))
 
@@ -108,6 +111,7 @@ for filename in args.trigger_files:
                 gating[gk] = numpy.append(gating[gk], gk_data[:])
     data.close()
 
+# store segments sorted by start time
 segments = numpy.array(sorted(segments), dtype=numpy.float64)
 f['%s/search/start_time' % ifo] = segments[:,0]
 f['%s/search/end_time' % ifo] = segments[:,1]


### PR DESCRIPTION
@MPillas and I noticed that `HDF_TRIGGER_MERGE` files store duplicated live time segments (datasets `search/start_time` and `search/end_time`) when the inspiral jobs use bank splitting. This appears to be correctly taken into account by some of the codes reading `HDF_TRIGGER_MERGE` files (for example `pycbc_fit_sngls_by_template`), but not all (for example `pycbc_plot_throughput`). This patch deduplicates the segments right away when creating the merged triggers, so as to avoid confusion and errors downstream.