### PR TITLE
update for gwtc-2 catalog

### DIFF
--- a/examples/catalog/data.py
+++ b/examples/catalog/data.py
@@ -1,6 +1,6 @@
 import pycbc.catalog, pylab
 
-m = pycbc.catalog.Merger("GW170817")
+m = pycbc.catalog.Merger("GW170817", source='gwtc-1')
 
 fig, axs = pylab.subplots(2, 1, sharex=True, sharey=True)
 for ifo, ax in zip(["L1", "H1"], axs):

--- a/examples/catalog/stat.py
+++ b/examples/catalog/stat.py
@@ -1,6 +1,6 @@
 import pycbc.catalog, pylab
 
-c = pycbc.catalog.Catalog()
+c = pycbc.catalog.Catalog(source='gwtc-2')
 mchirp, elow, ehigh = c.median1d('mchirp', return_errors=True)
 spin = c.median1d('chi_eff')
 

--- a/examples/catalog/what.py
+++ b/examples/catalog/what.py
@@ -1,6 +1,6 @@
 import pycbc.catalog
 
-c = pycbc.catalog.Catalog()
+c = pycbc.catalog.Catalog(source='gwtc-2')
 
 # Names of mergers in the catalog
 print(c.names)

--- a/pycbc/catalog/catalog.py
+++ b/pycbc/catalog/catalog.py
@@ -38,7 +38,7 @@ _catalogs = {'GWTC-1-confident': 'LVC',
              'Initial_LIGO_Virgo': 'LVC',
              'O1_O2-Preliminary': 'LVC',
              'O3_Discovery_Papers': 'LVC',
-             'GWTC-2':'LVC'}
+             'GWTC-2': 'LVC'}
 
 # add some aliases
 _aliases = {}

--- a/pycbc/catalog/catalog.py
+++ b/pycbc/catalog/catalog.py
@@ -37,11 +37,13 @@ _catalogs = {'GWTC-1-confident': 'LVC',
              'GWTC-1-marginal': 'LVC',
              'Initial_LIGO_Virgo': 'LVC',
              'O1_O2-Preliminary': 'LVC',
-             'O3_Discovery_Papers': 'LVC'}
+             'O3_Discovery_Papers': 'LVC',
+             'GWTC-2':'LVC'}
 
 # add some aliases
 _aliases = {}
 _aliases['gwtc-1'] = 'GWTC-1-confident'
+_aliases['gwtc-2'] = 'GWTC-2'
 
 
 def list_catalogs():


### PR DESCRIPTION
Add name used so pycbc.catalog can pick up the gwtc-2 sources. This also modifies some of the examples to demonstrate choosing the catalog. 