### PR TITLE
Fix bug in redshift from comoving volume interpolator

### DIFF
--- a/pycbc/cosmology.py
+++ b/pycbc/cosmology.py
@@ -403,7 +403,7 @@ class ComovingVolInterpolator(object):
         # replace using the faraway interpolation
         replacemask = numpy.isnan(vals)
         if replacemask.any():
-            vals[replacemask] = self.faraway_interp(vals[replacemask])
+            vals[replacemask] = self.faraway_interp(logv[replacemask])
             replacemask = numpy.isnan(vals)
         # if we still have nans, means that some distances are beyond our
         # furthest default; fall back to using astropy


### PR DESCRIPTION
The cosmology module uses an interpolator to speed up comoving volume to redshift transforms. Two interpolators are used; one for nearby (z < 1) and one for farway (z > 1). The nearby interpolator is run on the comoving volume values first. Any values outside of the range return nans. Then the faraway interpolator is run on the remaining. If there are any remaining nans after the second step, it's thrown to the astropy calculator.

The faraway should be run on the input comoving volume values, but due to a typo it is currently being given the output of the nearby interpolator... i.e., it's given a bunch of nans. Since it's given a bunch of nans, it just returns nans. Consequently, all comoving volumes with z > 1 are being passed to the astropy calculator, making the interpolator useless (and leading to slow evaulation).

This fixes that by appropriately passing the comoving volume values to the far away interpolator.