### PR TITLE
Unpin numpy, but avoid 1.19.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,4 +2,4 @@
 requires = ["setuptools",
             "wheel",
             "cython>=0.29",
-            "numpy>=1.16.0,<1.19"]
+            "numpy>=1.16.0,!=1.19.0"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ decorator>=3.4.2
 scipy>=0.16.0; python_version >= '3.5'
 scipy>=0.16.0,<1.3.0; python_version <= '3.4'
 matplotlib>=2.0.0
-numpy>=1.16.0,<1.19; python_version >= '3.5'
+numpy>=1.16.0,!=1.19.0; python_version >= '3.5'
 numpy>=1.16.0,<1.17.0; python_version <= '3.4'
 pillow
 h5py<2.10.0

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup_requires = ['numpy>=1.16.0']
 install_requires =  setup_requires + ['Mako>=1.0.1',
                       'cython>=0.29',
                       'decorator>=3.4.2',
-                      'numpy>=1.16.0,<1.19; python_version >= "3.5"',
+                      'numpy>=1.16.0,!=1.19.0; python_version >= "3.5"',
                       'numpy>=1.16.0,<1.17.0; python_version <= "2.7"',
                       'scipy>=0.16.0; python_version >= "3.5"',
                       'scipy>=0.16.0,<1.3.0; python_version <= "3.4"',


### PR DESCRIPTION
The issue reported in https://github.com/numpy/numpy/issues/16660 was fixed in https://github.com/numpy/numpy/pull/16666 and released as part of numpy 1.19.1, so pycbc should now be able to use those newer versions, and just avoid 1.19.0.