### PR TITLE
Results page plot changes

### DIFF
--- a/bin/hdfcoinc/pycbc_page_snrchi
+++ b/bin/hdfcoinc/pycbc_page_snrchi
@@ -75,7 +75,7 @@ pylab.xlabel('Signal-to-Noise Ratio')
 pylab.ylabel('Reduced $\\chi^2$')
 pycbc.results.save_fig_with_metadata(fig, args.output_file, 
      title="%s :SNR vs Reduced %s &chi;<sup>2</sup>" % (ifo, args.chisq_choice),
-     caption="Distribution of SNR and %s &chi; squared for single detector triggers: "
+     caption="Distribution of SNR and %s &chi;&sup2; for single detector triggers: "
              "Black lines show contours of constant NewSNR." \
               %(args.chisq_choice,),
      cmd=' '.join(sys.argv),

--- a/bin/hdfcoinc/pycbc_page_snrchi
+++ b/bin/hdfcoinc/pycbc_page_snrchi
@@ -74,8 +74,8 @@ cb.set_label('Trigger Density')
 pylab.xlabel('Signal-to-Noise Ratio')
 pylab.ylabel('Reduced $\\chi^2$')
 pycbc.results.save_fig_with_metadata(fig, args.output_file, 
-     title="%s :SNR vs Reduced %s Chisq" % (ifo, args.chisq_choice),
-     caption="Distribution of SNR and %s Chisq for single detector triggers: "
+     title="%s :SNR vs Reduced %s &chi;<sup>2</sup>" % (ifo, args.chisq_choice),
+     caption="Distribution of SNR and %s &chi; squared for single detector triggers: "
              "Black lines show contours of constant NewSNR." \
               %(args.chisq_choice,),
      cmd=' '.join(sys.argv),


### PR DESCRIPTION
Updated the file `bin/hdfcoinc/pycbc_page_snrchi` to include χ2 in both the header and caption of the plot on the results page.
Example: https://ldas-jobs.gw.iucaa.in/~arthur.tolley/snrchi_test_page/ 