### PR TITLE
Allow for single float input in format_lmns.

### DIFF
--- a/pycbc/waveform/ringdown.py
+++ b/pycbc/waveform/ringdown.py
@@ -79,6 +79,10 @@ def format_lmns(lmns):
     given, raise an error.
     """
 
+    # Catch case of lmns given as float (as int injection values are cast
+    # to float by pycbc_create_injections), cast to int, then string
+    if isinstance(lmns, float):
+        lmns = str(int(lmns))
     # Case 1: the lmns are given as a string, e.g. '221 331'
     if isinstance(lmns, str):
         lmns = lmns.split(' ')


### PR DESCRIPTION
If only a single lmns identifier is given (e.g. lmns = 220), `pycbc_create_injections` casts this to a float. This was not recognised by format_lmns.
Now a float is cast to an integer, then to a string to correct this.