### PR TITLE
Reorganizing stat.py

### DIFF
--- a/bin/all_sky_search/pycbc_coinc_findtrigs
+++ b/bin/all_sky_search/pycbc_coinc_findtrigs
@@ -287,7 +287,7 @@ for tnum in template_ids:
             slide *= total_factors[-1]
 
             single_info = [(i, sds[i][ids[i]]) for i in trigs.ifos]
-            cstat = rank_method.coinc(
+            cstat = rank_method.rank_stat_coinc(
                 single_info, slide, args.timeslide_interval,
                 to_shift=trigs.to_shift,
                 time_addition=args.coinc_threshold
@@ -368,7 +368,7 @@ for tnum in template_ids:
                 set_slide = set_slide[above]
                 test_single_info = [(i, sds[i][test_ids[i]]) for i in trigs.ifos]
 
-                test_cstat = rank_method.coinc(
+                test_cstat = rank_method.rank_stat_coinc(
                     test_single_info, set_slide, args.timeslide_interval,
                     to_shift=trigs.to_shift,
                     time_addition=args.coinc_threshold)

--- a/bin/all_sky_search/pycbc_coinc_findtrigs
+++ b/bin/all_sky_search/pycbc_coinc_findtrigs
@@ -112,7 +112,7 @@ for sngl in trigs.singles:
     sngl.valid = veto.segments_to_start_end(sngl.segs)
 
 # Stat class instance to calculate the coinc ranking statistic
-rank_method = stat.get_statistic_from_opts(args, trigs,ifos)
+rank_method = stat.get_statistic_from_opts(args, trigs.ifos)
 
 # Sanity check, time slide interval should be larger than twice the
 # Earth crossing time, which is approximately 0.085 seconds.

--- a/bin/all_sky_search/pycbc_coinc_findtrigs
+++ b/bin/all_sky_search/pycbc_coinc_findtrigs
@@ -31,21 +31,6 @@ parser.add_argument("--fixed-ifo", required=True,
                     help="Add the ifo to use as the fixed ifo for "
                          "multi detector coincidence")
 # produces a list of lists to allow multiple invocations and multiple args
-parser.add_argument("--statistic-files", nargs='*', action='append', default=[],
-                    help="Files containing ranking statistic info")
-parser.add_argument("--ranking-statistic", choices=stat.statistic_dict.keys(),
-                    required=True,
-                    help="The coinc ranking statistic to calculate")
-parser.add_argument("--sngl-ranking",
-                    choices=ranking.sngls_ranking_function_dict.keys(),
-                    required=True,
-                    help="The single-detector trigger ranking to use.")
-parser.add_argument("--statistic-keywords", nargs='*',
-                    default=[],
-                    help="Provide additional key-word arguments to be sent to "
-                         "the statistic class when it is initialized. Should "
-                         "be given in format --statistic-keywords "
-                         "KWARG1:VALUE1 KWARG2:VALUE2 KWARG3:VALUE3 ...")
 parser.add_argument("--use-maxalpha", action="store_true")
 parser.add_argument("--coinc-threshold", type=float, default=0.0,
                     help="Seconds to add to time-of-flight coincidence window")
@@ -70,10 +55,10 @@ parser.add_argument("--output-file",
                     help="File to store the coincident triggers")
 parser.add_argument("--batch-singles", default=5000, type=int,
                     help="Number of single triggers to process at once")
+stat.insert_statistic_option_group(parser)
 args = parser.parse_args()
 
 # flatten the list of lists of filenames to a single list (may be empty)
-args.statistic_files = sum(args.statistic_files, [])
 args.segment_name = sum(args.segment_name, [])
 args.veto_files = sum(args.veto_files, [])
 args.trigger_files = sum(args.trigger_files, [])
@@ -127,21 +112,7 @@ for sngl in trigs.singles:
     sngl.valid = veto.segments_to_start_end(sngl.segs)
 
 # Stat class instance to calculate the coinc ranking statistic
-extra_kwargs = {}
-for inputstr in args.statistic_keywords:
-    try:
-        key, value = inputstr.split(':')
-        extra_kwargs[key] = value
-    except ValueError:
-        err_txt = "--statistic-keywords must take input in the " \
-                  "form KWARG1:VALUE1 KWARG2:VALUE2 KWARG3:VALUE3 ... " \
-                  "Received {}".format(args.statistic_keywords)
-        raise ValueError(err_txt)
-
-rank_method = stat.get_statistic(args.ranking_statistic)(args.sngl_ranking,
-                                                         args.statistic_files,
-                                                         ifos=trigs.ifos,
-                                                         **extra_kwargs)
+rank_method = stat.get_statistic_from_opts(args, trigs,ifos)
 
 # Sanity check, time slide interval should be larger than twice the
 # Earth crossing time, which is approximately 0.085 seconds.

--- a/bin/all_sky_search/pycbc_coinc_findtrigs
+++ b/bin/all_sky_search/pycbc_coinc_findtrigs
@@ -37,7 +37,7 @@ parser.add_argument("--ranking-statistic", choices=stat.statistic_dict.keys(),
                     required=True,
                     help="The coinc ranking statistic to calculate")
 parser.add_argument("--sngl-ranking",
-                    choices=ranking._sngls_ranking_function_dict.keys(),
+                    choices=ranking.sngls_ranking_function_dict.keys(),
                     required=True,
                     help="The single-detector trigger ranking to use.")
 parser.add_argument("--statistic-keywords", nargs='*',

--- a/bin/all_sky_search/pycbc_coinc_findtrigs
+++ b/bin/all_sky_search/pycbc_coinc_findtrigs
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 import h5py, argparse, logging, numpy, numpy.random
 from ligo.segments import infinity
-from pycbc.events import veto, coinc, stat
+from pycbc.events import veto, coinc, stat, ranking
 import pycbc.version
 from numpy.random import seed, shuffle
 from pycbc.io.hdf import ReadByTemplate
@@ -34,8 +34,12 @@ parser.add_argument("--fixed-ifo", required=True,
 parser.add_argument("--statistic-files", nargs='*', action='append', default=[],
                     help="Files containing ranking statistic info")
 parser.add_argument("--ranking-statistic", choices=stat.statistic_dict.keys(),
-                    default='newsnr',
+                    required=True,
                     help="The coinc ranking statistic to calculate")
+parser.add_argument("--sngl-ranking",
+                    choices=ranking._sngls_ranking_function_dict.keys(),
+                    required=True,
+                    help="The single-detector trigger ranking to use.")
 parser.add_argument("--statistic-keywords", nargs='*',
                     default=[],
                     help="Provide additional key-word arguments to be sent to "
@@ -134,7 +138,8 @@ for inputstr in args.statistic_keywords:
                   "Received {}".format(args.statistic_keywords)
         raise ValueError(err_txt)
 
-rank_method = stat.get_statistic(args.ranking_statistic)(args.statistic_files,
+rank_method = stat.get_statistic(args.ranking_statistic)(args.sngl_ranking,
+                                                         args.statistic_files,
                                                          ifos=trigs.ifos,
                                                          **extra_kwargs)
 
@@ -274,12 +279,13 @@ for tnum in template_ids:
         for kidx in range(1, len(threshes)):
             # For each trigger in the fixed network calculate the limit int
             # the pivot detector to pass the current decimation threshold
-            pivot_lims[kidx] = rank_method.coinc_multiifo_lim_for_thresh(
+            pivot_lims[kidx] = rank_method.coinc_lim_for_thresh(
                 fixed_single_info, threshes[kidx],
                 args.pivot_ifo,
                 time_addition=args.coinc_threshold,
                 min_snr=min_snr,
-                max_sigmasq=max_sigmasq)
+                max_sigmasq=max_sigmasq
+            )
             if not rank_method.single_increasing:
                 pivot_lims[kidx] *= -1.
             # subtract small amount to account for errors due to rounding
@@ -310,10 +316,11 @@ for tnum in template_ids:
             slide *= total_factors[-1]
 
             single_info = [(i, sds[i][ids[i]]) for i in trigs.ifos]
-            cstat = rank_method.coinc_multiifo(
+            cstat = rank_method.coinc(
                 single_info, slide, args.timeslide_interval,
                 to_shift=trigs.to_shift,
-                time_addition=args.coinc_threshold)
+                time_addition=args.coinc_threshold
+            )
 
             #index values of the zerolag triggers
             fi = numpy.where(slide == 0)[0]

--- a/bin/all_sky_search/pycbc_coinc_findtrigs
+++ b/bin/all_sky_search/pycbc_coinc_findtrigs
@@ -397,7 +397,7 @@ for tnum in template_ids:
                 set_slide = set_slide[above]
                 test_single_info = [(i, sds[i][test_ids[i]]) for i in trigs.ifos]
 
-                test_cstat = rank_method.coinc_multiifo(
+                test_cstat = rank_method.coinc(
                     test_single_info, set_slide, args.timeslide_interval,
                     to_shift=trigs.to_shift,
                     time_addition=args.coinc_threshold)

--- a/bin/all_sky_search/pycbc_fit_sngls_binned
+++ b/bin/all_sky_search/pycbc_fit_sngls_binned
@@ -35,7 +35,7 @@ def get_stat(statchoice, trigs):
     # For now this is using the single detector ranking. If we want, this
     # could use the Stat classes in stat.py using similar code as in hdf/io.py
     # This requires additional options, so only change this if it's useful!
-    return ranking.get_sngls_ranking_from_trigs(trigs, statname)
+    return ranking.get_sngls_ranking_from_trigs(trigs, statchoice)
 
 
 #### MAIN ####

--- a/bin/all_sky_search/pycbc_fit_sngls_binned
+++ b/bin/all_sky_search/pycbc_fit_sngls_binned
@@ -26,16 +26,17 @@ import copy, numpy as np
 from pycbc import events, bin_utils, results
 from pycbc.events import triggers
 from pycbc.events import trigger_fits as trstats
-from pycbc.events.stat import sngl_statistic_dict
+from pycbc.events import ranking
 import pycbc.version
 
 #### DEFINITIONS AND FUNCTIONS ####
 
 def get_stat(statchoice, trigs):
-    # Initialize statclass with an empty file list. In general could feed it
-    # files here for statistics which need that.
-    stat_instance = sngl_statistic_dict[statchoice]([])
-    return stat_instance.single(trigs)
+    # For now this is using the single detector ranking. If we want, this
+    # could use the Stat classes in stat.py using similar code as in hdf/io.py
+    # This requires additional options, so only change this if it's useful!
+    return ranking.get_sngls_ranking_from_trigs(trigs, statname)
+
 
 #### MAIN ####
 
@@ -63,7 +64,7 @@ parser.add_argument("--fit-function",
                     choices=["exponential", "rayleigh", "power"],
                     help="Functional form for the maximum likelihood fit")
 parser.add_argument("--sngl-stat", default="new_snr",
-                    choices=sngl_statistic_dict.keys(),
+                    choices=ranking.sngls_ranking_function_dict.keys(),
                     help="Function of SNR and chisq to perform fits with")
 parser.add_argument("--stat-factor", type=float,
                     help="Adjustable magic number used in some sngl "

--- a/bin/all_sky_search/pycbc_fit_sngls_by_template
+++ b/bin/all_sky_search/pycbc_fit_sngls_by_template
@@ -27,7 +27,7 @@ import pycbc.version
 
 #### DEFINITIONS AND FUNCTIONS ####
 
-def get_stat(statchoice, trigs, threshold):
+def get_stat(statname, trigs, threshold):
     # For now this is using the single detector ranking. If we want, this
     # could use the Stat classes in stat.py using similar code as in hdf/io.py
     # This requires additional options, so only change this if it's useful!

--- a/bin/all_sky_search/pycbc_fit_sngls_by_template
+++ b/bin/all_sky_search/pycbc_fit_sngls_by_template
@@ -21,16 +21,16 @@ import copy, numpy as np
 
 from pycbc import io, events
 from pycbc.events import triggers, trigger_fits as trstats
-from pycbc.events.stat import sngl_statistic_dict
+from pycbc.events import ranking
 from pycbc.types.optparse import MultiDetOptionAction
 import pycbc.version
 
 #### DEFINITIONS AND FUNCTIONS ####
 
 def get_stat(statchoice, trigs, threshold):
-    # Initialize statclass with an empty file list. In general could feed it
-    # files here for statistics which need that.
-    stat_instance = sngl_statistic_dict[statchoice]([])
+    # For now this is using the single detector ranking. If we want, this
+    # could use the Stat classes in stat.py using similar code as in hdf/io.py
+    # This requires additional options, so only change this if it's useful!
     chunk_size = 2**23
     stat = []
     select = []
@@ -42,7 +42,7 @@ def get_stat(statchoice, trigs, threshold):
         # read and format chunk of data so it can be read by key
         # as the stat classes expect.
         chunk = {k: trigs[k][s:e] for k in trigs if len(trigs[k]) == size}
-        chunk_stat = stat_instance.single(chunk)
+        chunk_stat = ranking.get_sngls_ranking_from_trigs(chunk, statname)
         above = chunk_stat >= threshold
         stat.append(chunk_stat[above])
         select.append(above)
@@ -89,7 +89,7 @@ parser.add_argument("--fit-function",
                     choices=["exponential", "rayleigh", "power"],
                     help="Functional form for the maximum likelihood fit")
 parser.add_argument("--sngl-stat", default="new_snr",
-                    choices=sngl_statistic_dict.keys(),
+                    choices=ranking.sngls_ranking_function_dict.keys(),
                     help="Function of SNR and chisq to perform fits with")
 parser.add_argument("--stat-threshold", type=float,
                     help="Only fit triggers with statistic value above this "

--- a/bin/all_sky_search/pycbc_fit_sngls_split_binned
+++ b/bin/all_sky_search/pycbc_fit_sngls_split_binned
@@ -25,15 +25,16 @@ import numpy as np
 from pycbc import events, bin_utils, results
 from pycbc.events import triggers as trigs
 from pycbc.events import trigger_fits as trstats
-from pycbc.events.stat import sngl_statistic_dict
+from pycbc.events import ranking
 from pycbc.types.optparse import MultiDetOptionAction
 import pycbc.version
 
 def get_stat(statchoice, trigs):
-    # Initialize statclass with an empty file list. In general could feed it
-    # files here for statistics which need that.
-    stat_instance = sngl_statistic_dict[statchoice]([])
-    return stat_instance.single(trigs)
+    # For now this is using the single detector ranking. If we want, this
+    # could use the Stat classes in stat.py using similar code as in hdf/io.py
+    # This requires additional options, so only change this if it's useful!
+    return ranking.get_sngls_ranking_from_trigs(trigs, statchoice)
+
 
 parser = argparse.ArgumentParser(usage="",
     description="Plot histograms of triggers split over various parameters")
@@ -72,7 +73,7 @@ parser.add_argument('--split-two-spacing', choices=['linear', 'log'], default='l
                     help="How to space split-param-two bin edges. "
                          "Choices=[linear, log], default=linear")
 parser.add_argument("--sngl-stat", default="new_snr",
-                    choices=sngl_statistic_dict.keys(),
+                    choices=ranking.sngls_ranking_function_dict.keys(),
                     help="Function of SNR and chisq to perform fits with")
 parser.add_argument('--ifo', help="Detector. Required")
 parser.add_argument('--plot-max-x', type=float, default=None,

--- a/bin/all_sky_search/pycbc_sngls_findtrigs
+++ b/bin/all_sky_search/pycbc_sngls_findtrigs
@@ -24,17 +24,6 @@ parser.add_argument("--trigger-file",type=str,
 parser.add_argument("--template-bank", required=True,
                     help="Template bank file in HDF format")
 # produces a list of lists to allow multiple invocations and multiple args
-parser.add_argument("--statistic-files", nargs='*', action='append', default=[],
-                    help="Files containing ranking statistic info")
-parser.add_argument("--ranking-statistic", choices=stat.statistic_dict.keys(),
-                    default='newsnr',
-                    help="The single-detector ranking statistic to calculate")
-parser.add_argument("--statistic-keywords", nargs='*',
-                    default=[],
-                    help="Provide additional key-word arguments to be sent to "
-                         "the statistic class when it is initialized. Should "
-                         "be given in format --statistic-keywords "
-                         "KWARG1:VALUE1 KWARG2:VALUE2 KWARG3:VALUE3 ...")
 parser.add_argument('--trigger-snr-cut',  type=float,
                     help='Only consider triggers above the given SNR.')
 parser.add_argument('--cluster-window', type=float,
@@ -46,6 +35,7 @@ parser.add_argument('--reduced-chisq-cut', type=float,
                          'chisquared.')
 parser.add_argument("--output-file",
                     help="File to store the candidate triggers")
+stat.insert_statistic_option_group(parser)
 args = parser.parse_args()
 
 if (args.veto_files and not args.segment_names) or \
@@ -54,8 +44,6 @@ if (args.veto_files and not args.segment_names) or \
 
 if not len(args.veto_files) == len(args.segment_names):
     raise RuntimeError('--segment-names are required for each --veto-files')
-
-args.statistic_files = sum(args.statistic_files, [])
 
 init_logging(args.verbose)
 
@@ -138,9 +126,8 @@ for inputstr in args.statistic_keywords:
                   "Received {}".format(args.statistic_keywords)
         raise ValueError(err_txt)
 
-rank_stat_class = stat.get_statistic(args.ranking_statistic)
-rank_method = rank_stat_class(args.statistic_files, ifos=[ifo],
-                              **extra_kwargs)
+rank_method = stat.get_statistic_from_opts(args, [ifo])
+
 logging.info("Computing single-detector statistic")
 stat = rank_method.single_multiifo((ifo, trigs.data))
 

--- a/bin/all_sky_search/pycbc_sngls_findtrigs
+++ b/bin/all_sky_search/pycbc_sngls_findtrigs
@@ -129,7 +129,7 @@ for inputstr in args.statistic_keywords:
 rank_method = stat.get_statistic_from_opts(args, [ifo])
 
 logging.info("Computing single-detector statistic")
-stat = rank_method.single_multiifo((ifo, trigs.data))
+stat = rank_method.rank_stat_single((ifo, trigs.data))
 
 logging.info("Clustering")
 if args.cluster_window:

--- a/bin/all_sky_search/pycbc_sngls_findtrigs
+++ b/bin/all_sky_search/pycbc_sngls_findtrigs
@@ -141,11 +141,8 @@ for inputstr in args.statistic_keywords:
 rank_stat_class = stat.get_statistic(args.ranking_statistic)
 rank_method = rank_stat_class(args.statistic_files, ifos=[ifo],
                               **extra_kwargs)
-logging.info("Single-detector initial statistic")
-sds_full = rank_method.single(trigs.data)
-logging.info("Applying changes to make statistic comparable with coincs")
-single_info = (ifo, sds_full)
-stat = rank_method.single_multiifo(single_info)
+logging.info("Computing single-detector statistic")
+stat = rank_method.single_multiifo((ifo, trigs.data))
 
 logging.info("Clustering")
 if args.cluster_window:

--- a/bin/minifollowups/pycbc_page_snglinfo
+++ b/bin/minifollowups/pycbc_page_snglinfo
@@ -21,6 +21,7 @@ matplotlib.use('Agg')
 import lal
 import pycbc.version, pycbc.events, pycbc.results, pycbc.pnutils
 from pycbc.results import followup
+from pycbc.events import stat
 from pycbc.io import hdf
 
 
@@ -50,9 +51,6 @@ trig_args.add_argument("--n-loudest", type=int, default=None,
 trig_args.add_argument("--trigger-id", type=int, default=None,
     help="Use the trigger with this ID in the HDF file. Must supply either "
          "this option or --n-loudest.")
-parser.add_argument('--ranking-statistic', default='newsnr',
-    help="How to rank triggers when determining loudest triggers. Default "
-         "'newsnr'")
 parser.add_argument('--include-summary-page-link', action='store_true',
     help="If given, will include a link to the DQ summary page")
 parser.add_argument('--include-gracedb-link', action='store_true',
@@ -61,6 +59,7 @@ parser.add_argument('--include-gracedb-link', action='store_true',
 parser.add_argument('--significance-file',
     help="If given, will search for this trigger's id in the file to see if "
          "stat and p_astro values exists for this trigger.")
+stat.insert_statistic_option_group(parser)
 
 
 args = parser.parse_args()
@@ -71,17 +70,17 @@ pycbc.init_logging(args.verbose)
 sngl_file = hdf.SingleDetTriggers(args.single_trigger_file, args.bank_file,
                 args.veto_file, args.veto_segment_name, None, args.instrument)
 
+rank_method = stat.get_statistic_from_opts(args, [args.instrument])
 if args.trigger_id is not None:
     sngl_file.mask = [args.trigger_id]
     trig_id = args.trigger_id
-    sngl_file.mask_to_n_loudest_clustered_events(n_loudest=1,
-                                      ranking_statistic=args.ranking_statistic)
+    sngl_file.mask_to_n_loudest_clustered_events(rank_method, n_loudest=1)
     stat = sngl_file.stat[0]
 elif args.n_loudest is not None:
     # Cluster by a ranking statistic and retain only the loudest n clustered
     # triggers
-    sngl_file.mask_to_n_loudest_clustered_events(n_loudest=args.n_loudest+1,
-                                      ranking_statistic=args.ranking_statistic)
+    sngl_file.mask_to_n_loudest_clustered_events(rank_method,
+                                                 n_loudest=args.n_loudest+1)
     # Restrict to only the nth loudest, instead of all triggers up to nth
     # loudest
     stat = sngl_file.stat
@@ -121,7 +120,24 @@ data[0].append('%5.2f' % sngl_file.get_column('coa_phase'))
 data[0].append('%5.2f' % stat)
 headers.append("&rho;")
 headers.append("Phase")
-headers.append(sngl_file.stat_name)
+# Determine statistic naming
+if args.sngl_ranking == "newsnr":
+    sngl_stat_name = "Reweighted SNR"
+elif args.sngl_ranking == "newsnr_sgveto":
+    sngl_stat_name = "Reweighted SNR (+sgveto)"
+elif args.sngl_ranking == "newsnr_sgveto_psdvar":
+    sngl_stat_name = "Reweighted SNR (+sgveto+psdvar)"
+elif args.sngl_ranking == "snr":
+    sngl_stat_name = "SNR"
+else:
+    sngl_stat_name = ranking_statistic
+ 
+if args.ranking_statistic in ["quadsum", "single_ranking_only"]:
+    stat_name = sngl_stat_name
+else:
+    stat_name = '_with_'.join(ranking_statistic, sngl_ranking)
+
+headers.append(stat_name)
 
 # Signal-glitch discrimators
 data[0].append('%5.2f' % sngl_file.rchisq)
@@ -180,7 +196,7 @@ html = pycbc.results.dq.redirect_javascript + \
 if args.n_loudest:
     title = 'Parameters of single-detector event ranked %s' \
         % (args.n_loudest + 1)
-    caption = 'Parameters of the single-detector event ranked number %s by %s. The figures below show the mini-followup data for this event.' % (args.n_loudest + 1, sngl_file.stat_name)
+    caption = 'Parameters of the single-detector event ranked number %s by %s. The figures below show the mini-followup data for this event.' % (args.n_loudest + 1, stat_name)
 else:
     title = 'Parameters of single-detector event'
     caption = 'Parameters of the single-detector event. The figures below show the mini-followup data for this event.'

--- a/bin/minifollowups/pycbc_sngl_minifollowup
+++ b/bin/minifollowups/pycbc_sngl_minifollowup
@@ -28,7 +28,7 @@ import pycbc.workflow.pegasus_workflow as wdax
 import pycbc.version
 import pycbc.workflow as wf
 import pycbc.events
-from pycbc.events import ranking, stat
+from pycbc.events import stat
 from pycbc.io import hdf
 
 def to_file(path, ifo=None):
@@ -71,18 +71,6 @@ parser.add_argument('--inspiral-data-analyzed-name',
                          "analyzed by each analysis job.")
 parser.add_argument('--min-snr', type=float, default=6.5,
                     help="Minimum SNR to consider for loudest triggers")
-parser.add_argument("--ranking-statistic", choices=stat.statistic_dict.keys(),
-                    required=True,
-                    help="The ranking statistic to calculate")
-parser.add_argument("--sngl-ranking",
-                    choices=ranking.sngls_ranking_function_dict.keys(),
-                    required=True,
-                    help="The single-detector trigger ranking to use.")
-parser.add_argument('--statistic-files', nargs='+',
-                    action='append', default=[],
-                    help='Use this to supply supplementary files that are '
-                         'necessary for computing the ranking statistic. For '
-                         'example the phase-time consistency file.')
 parser.add_argument('--non-coinc-time-only', default=False,
                     action='store_true',
                     help="If given remove (veto) single-detector triggers "
@@ -101,9 +89,8 @@ parser.add_argument('--transformation-catalog')
 parser.add_argument('--output-file')
 parser.add_argument('--tags', nargs='+', default=[])
 wf.add_workflow_command_line_group(parser)
+stat.insert_statistic_option_group(parser)
 args = parser.parse_args()
-# args.statistic_files might be a list of lists. This will flatten this to a single list.
-args.statistic_files = sum(args.statistic_files, [])
 
 logging.basicConfig(format='%(asctime)s:%(levelname)s : %(message)s',
                     level=logging.INFO)
@@ -195,9 +182,9 @@ if len(trigs.snr) == 0:
     sys.exit(0)
 
 logging.info('finding loudest clustered events')
-trigs.mask_to_n_loudest_clustered_events\
-    (args.ranking_statistic, args.sngl_ranking,
-     n_loudest=num_events, statistic_files=args.statistic_files)
+rank_method = stat.get_statistic_from_opts(args, [ifo])
+trigs.mask_to_n_loudest_clustered_events(rank_method, n_loudest=num_events)
+
 if len(trigs.stat) < num_events:
     num_events = len(trigs.stat)
 

--- a/bin/minifollowups/pycbc_sngl_minifollowup
+++ b/bin/minifollowups/pycbc_sngl_minifollowup
@@ -182,7 +182,7 @@ if len(trigs.snr) == 0:
     sys.exit(0)
 
 logging.info('finding loudest clustered events')
-rank_method = stat.get_statistic_from_opts(args, [ifo])
+rank_method = stat.get_statistic_from_opts(args, [args.instrument])
 trigs.mask_to_n_loudest_clustered_events(rank_method, n_loudest=num_events)
 
 if len(trigs.stat) < num_events:

--- a/bin/minifollowups/pycbc_sngl_minifollowup
+++ b/bin/minifollowups/pycbc_sngl_minifollowup
@@ -28,6 +28,7 @@ import pycbc.workflow.pegasus_workflow as wdax
 import pycbc.version
 import pycbc.workflow as wf
 import pycbc.events
+from pycbc.events import ranking, stat
 from pycbc.io import hdf
 
 def to_file(path, ifo=None):
@@ -70,8 +71,13 @@ parser.add_argument('--inspiral-data-analyzed-name',
                          "analyzed by each analysis job.")
 parser.add_argument('--min-snr', type=float, default=6.5,
                     help="Minimum SNR to consider for loudest triggers")
-parser.add_argument('--ranking-statistic',
-                help="How to rank triggers when determining loudest triggers.")
+parser.add_argument("--ranking-statistic", choices=stat.statistic_dict.keys(),
+                    required=True,
+                    help="The ranking statistic to calculate")
+parser.add_argument("--sngl-ranking",
+                    choices=ranking.sngls_ranking_function_dict.keys(),
+                    required=True,
+                    help="The single-detector trigger ranking to use.")
 parser.add_argument('--statistic-files', nargs='+',
                     action='append', default=[],
                     help='Use this to supply supplementary files that are '
@@ -190,8 +196,8 @@ if len(trigs.snr) == 0:
 
 logging.info('finding loudest clustered events')
 trigs.mask_to_n_loudest_clustered_events\
-    (n_loudest=num_events, ranking_statistic=args.ranking_statistic,
-     statistic_files=args.statistic_files)
+    (args.ranking_statistic, args.sngl_ranking,
+     n_loudest=num_events, statistic_files=args.statistic_files)
 if len(trigs.stat) < num_events:
     num_events = len(trigs.stat)
 

--- a/bin/plotting/pycbc_plot_singles_vs_params
+++ b/bin/plotting/pycbc_plot_singles_vs_params
@@ -35,7 +35,7 @@ import pycbc.results
 import pycbc.io
 import sys
 import pycbc.version
-from pycbc.events.stat import sngl_statistic_dict
+from pycbc.events import ranking
 
 parser = argparse.ArgumentParser(description=__doc__)
 parser.add_argument("--version", action="version",
@@ -62,8 +62,9 @@ parser.add_argument('--x-var', required=True,
 parser.add_argument('--y-var', required=True,
                     choices=pycbc.io.SingleDetTriggers.get_param_names(),
                     help='Parameter to plot on the y-axis. Required')
+ranking_keys = list(ranking.sngls_ranking_function_dict.keys())
 parser.add_argument('--z-var', required=True,
-                    choices=['density'] + list(sngl_statistic_dict.keys()),
+                    choices=['density'] + ranking_keys,
                     help='Quantity to plot on the color scale. Required')
 parser.add_argument('--detector', required=True,
                     help='Detector. Required')
@@ -128,8 +129,10 @@ if opts.z_var == 'density':
     norm = LogNorm()
     hb = ax.hexbin(x, y, norm=norm, vmin=1, **hexbin_style)
     fig.colorbar(hb, ticks=LogLocator(subs=range(10)))
-elif opts.z_var in sngl_statistic_dict:
+elif opts.z_var in sngls_ranking_function_dict:
     cb_style = {}
+    # FIXME: This seems wrong, we probably want the SingleDetTriggers class
+    #        to autocall into the ranking. Might try to fix.
     z = getattr(trigs, opts.z_var) 
 
     z = z[mask]

--- a/bin/plotting/pycbc_plot_singles_vs_params
+++ b/bin/plotting/pycbc_plot_singles_vs_params
@@ -129,7 +129,7 @@ if opts.z_var == 'density':
     norm = LogNorm()
     hb = ax.hexbin(x, y, norm=norm, vmin=1, **hexbin_style)
     fig.colorbar(hb, ticks=LogLocator(subs=range(10)))
-elif opts.z_var in sngls_ranking_function_dict:
+elif opts.z_var in ranking.sngls_ranking_function_dict:
     cb_style = {}
     # FIXME: This seems wrong, we probably want the SingleDetTriggers class
     #        to autocall into the ranking. Might try to fix.

--- a/bin/plotting/pycbc_plot_trigrate
+++ b/bin/plotting/pycbc_plot_trigrate
@@ -26,16 +26,16 @@ from scipy import stats as scistats
 
 from pycbc import io, events, bin_utils, results
 from pycbc.events import triggers
-from pycbc.events.stat import sngl_statistic_dict
+from pycbc.events import ranking
 import pycbc.version
 
 #### DEFINITIONS AND FUNCTIONS ####
 
 def get_stat(statchoice, trigs):
-    # Initialize statclass with an empty file list. In general could feed it
-    # files here for statistics which need that.
-    stat_instance = sngl_statistic_dict[statchoice]([])
-    return stat_instance.single(trigs)
+    # For now this is using the single detector ranking. If we want, this
+    # could use the Stat classes in stat.py using similar code as in hdf/io.py
+    # This requires additional options, so only change this if it's useful!
+    return ranking.get_sngls_ranking_from_trigs(trigs, statname)
 
 #### MAIN ####
 
@@ -62,7 +62,7 @@ parser.add_argument("--gps-start-time", type=float,
 parser.add_argument("--gps-end-time", type=float,
                     help="End time up to which to load/plot triggers")
 parser.add_argument("--sngl-stat", default="new_snr",
-                    choices=sngl_statistic_dict.keys(),
+                    choices=ranking.sngls_ranking_function_dict.keys(),
                     help="Function of SNR and chisq to threshold on")
 parser.add_argument("--stat-factor", type=float,
                     help="Adjustable magic number used in some sngl "

--- a/bin/pycbc_inspiral
+++ b/bin/pycbc_inspiral
@@ -168,7 +168,7 @@ parser.add_argument("--keep-loudest-interval", type=float,
 parser.add_argument("--keep-loudest-num", type=int,
                     help="Number of triggers to keep from each maximization interval")
 parser.add_argument("--keep-loudest-stat", default="newsnr",
-                    choices=events.stat.sngl_statistic_dict.keys(),
+                    choices=events.ranking.sngls_ranking_function_dict.keys(),
                     help="Statistic used to determine loudest to keep")
 parser.add_argument("--finalize-events-template-rate", default=None,
                     type=int, metavar="NUM TEMPLATES",

--- a/bin/pycbc_inspiral_skymax
+++ b/bin/pycbc_inspiral_skymax
@@ -141,7 +141,7 @@ parser.add_argument("--keep-loudest-interval", type=float,
 parser.add_argument("--keep-loudest-num", type=int,
                     help="Number of triggers to keep from each maximization interval")
 parser.add_argument("--keep-loudest-stat", default="newsnr",
-                    choices=events.stat.sngl_statistic_dict.keys(),
+                    choices=events.ranking.sngls_ranking_function_dict.keys(),
                     help="Statistic used to determine loudest to keep")
 parser.add_argument("--finalize-events-template-rate", default=None,
                     type=int, metavar="NUM TEMPLATES",

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -264,7 +264,7 @@ class LiveEventManager(object):
                        'Two-detector ranking statistic: {}<br />'
                        'Followup detectors: {}')
             comment = comment.format(ppdets(coinc_ifos),
-                                     args.background_statistic,
+                                     args.ranking_statistic,
                                      ppdets(followup_ifos))
 
             ifar = coinc_results['foreground/ifar']

--- a/bin/pycbc_process_sngls
+++ b/bin/pycbc_process_sngls
@@ -59,12 +59,12 @@ sngls = hdf.SingleDetTriggers(args.single_trig_file, args.bank_file,
                               args.detector)
 
 logging.info('Calculating stat')
-statengine = stat.get_statistic_from_opts(args, [args.instrument])
+rank_method = stat.get_statistic_from_opts(args, [args.instrument])
 #  NOTE: inefficient, as we are calculating the stat on all
 #  triggers. Might need to do something complicated to fix this.
 #  Or just use files with fewer triggers :P
 sngl_info = ([args.instrument], sngls.trigs)
-stat = statengine.rank_stat_single(sngl_info)[sngls.mask]
+stat = rank_method.rank_stat_single(sngl_info)[sngls.mask]
 
 logging.info('%i stat values found', len(stat))
 

--- a/bin/pycbc_process_sngls
+++ b/bin/pycbc_process_sngls
@@ -65,7 +65,7 @@ if args.statname is not None:
     #  triggers. Might need to do something complicated to fix this.
     #  Or just use files with fewer triggers :P
     sngl_info = ([args.instrument], sngls.trigs)
-    stat = statengine.single_multiifo(sngl_info)[sngls.mask]
+    stat = statengine.rank_stat_single(sngl_info)[sngls.mask]
 else:
     logging.info('Using SNR for clustering, if requested')
     stat = sngls.snr

--- a/bin/pycbc_process_sngls
+++ b/bin/pycbc_process_sngls
@@ -26,16 +26,6 @@ parser.add_argument('--filter-string', default=None,
                          'e.g. "self.mchirp>5."')
 parser.add_argument('--min-snr', default=0., type=float,
                     help='Only keep triggers above the given SNR')
-parser.add_argument('--statistic-name', dest='statname',
-                    choices=stat.statistic_dict.keys(),
-                    help='Name of statistic to evaluate and cluster on. '
-                    'If not supplied, SNR will be used')
-parser.add_argument('--sngl-ranking',
-                    choices=ranking.sngls_ranking_function_dict.keys(),
-                    help='Name of statistic to evaluate and cluster on. '
-                    'If not supplied, SNR will be used')
-parser.add_argument('--statistic-files', nargs='*', default=[],
-                    help='Files containing ranking statistic info')
 parser.add_argument('--cluster-window', type=float,
                     help='If supplied, cluster singles by symmetrical time '
                          'window method, specify window extent from maximum'
@@ -44,6 +34,7 @@ parser.add_argument('--store-bank-values', default=False, action='store_true',
                     help='If given also add the template bank parameters into '
                          'the output file.')
 parser.add_argument('--output-file', required=True)
+stat.insert_statistic_option_group(parser)
 
 args = parser.parse_args()
 
@@ -69,12 +60,12 @@ sngls = hdf.SingleDetTriggers(args.single_trig_file, args.bank_file,
 
 if args.statname is not None:
     logging.info('Calculating stat')
-    statengine = stat.statistic_dict[args.statname](args.sngl_ranking,
-                                                    args.statistic_files)
-    #  FIXME: inefficient, as we are calculating the stat on all
+    statengine = = stat.get_statistic_from_opts(args, [args.instrument])
+    #  NOTE: inefficient, as we are calculating the stat on all
     #  triggers. Might need to do something complicated to fix this.
     #  Or just use files with fewer triggers :P
-    stat = statengine.single_multiifo(sngls.trigs)[sngls.mask]
+    sngl_info = ([args.instrument], sngls.trigs)
+    stat = statengine.single_multiifo(sngl_info)[sngls.mask]
 else:
     logging.info('Using SNR for clustering, if requested')
     stat = sngls.snr
@@ -130,7 +121,7 @@ outgroup.attrs['cluster_window'] = args.cluster_window or 'None'
 
 if args.statname is not None:
     outgroup['stat'] = stat[out_idx]
-    outgroup.attrs['statname'] = args.statname
+    outgroup.attrs['statname'] = args.ranking_statistic
     outgroup.arrgs['sngl_ranking'] = args.sngl_ranking
     outgroup.attrs['statistic_files'] = args.statistic_files
 

--- a/bin/pycbc_process_sngls
+++ b/bin/pycbc_process_sngls
@@ -58,17 +58,13 @@ sngls = hdf.SingleDetTriggers(args.single_trig_file, args.bank_file,
                               args.veto_file, args.segment_name, filter_func,
                               args.detector)
 
-if args.statname is not None:
-    logging.info('Calculating stat')
-    statengine = stat.get_statistic_from_opts(args, [args.instrument])
-    #  NOTE: inefficient, as we are calculating the stat on all
-    #  triggers. Might need to do something complicated to fix this.
-    #  Or just use files with fewer triggers :P
-    sngl_info = ([args.instrument], sngls.trigs)
-    stat = statengine.rank_stat_single(sngl_info)[sngls.mask]
-else:
-    logging.info('Using SNR for clustering, if requested')
-    stat = sngls.snr
+logging.info('Calculating stat')
+statengine = stat.get_statistic_from_opts(args, [args.instrument])
+#  NOTE: inefficient, as we are calculating the stat on all
+#  triggers. Might need to do something complicated to fix this.
+#  Or just use files with fewer triggers :P
+sngl_info = ([args.instrument], sngls.trigs)
+stat = statengine.rank_stat_single(sngl_info)[sngls.mask]
 
 logging.info('%i stat values found', len(stat))
 
@@ -119,11 +115,10 @@ outgroup['search/end_time'] = sngls.trigs['search/end_time'][:]
 outgroup.attrs['filter'] = filter_func or 'None'
 outgroup.attrs['cluster_window'] = args.cluster_window or 'None'
 
-if args.statname is not None:
-    outgroup['stat'] = stat[out_idx]
-    outgroup.attrs['statname'] = args.ranking_statistic
-    outgroup.arrgs['sngl_ranking'] = args.sngl_ranking
-    outgroup.attrs['statistic_files'] = args.statistic_files
+outgroup['stat'] = stat[out_idx]
+outgroup.attrs['ranking_statistic'] = args.ranking_statistic
+outgroup.arrgs['sngl_ranking'] = args.sngl_ranking
+outgroup.attrs['statistic_files'] = args.statistic_files
 
 outfile.close()
 logging.info('Done!')

--- a/bin/pycbc_process_sngls
+++ b/bin/pycbc_process_sngls
@@ -60,7 +60,7 @@ sngls = hdf.SingleDetTriggers(args.single_trig_file, args.bank_file,
 
 if args.statname is not None:
     logging.info('Calculating stat')
-    statengine = = stat.get_statistic_from_opts(args, [args.instrument])
+    statengine = stat.get_statistic_from_opts(args, [args.instrument])
     #  NOTE: inefficient, as we are calculating the stat on all
     #  triggers. Might need to do something complicated to fix this.
     #  Or just use files with fewer triggers :P

--- a/bin/pycbc_process_sngls
+++ b/bin/pycbc_process_sngls
@@ -4,7 +4,7 @@
 
 import h5py, numpy, argparse, logging
 from pycbc.io import hdf
-from pycbc.events import stat, coinc
+from pycbc.events import stat, coinc, ranking
 
 
 parser = argparse.ArgumentParser(description=__doc__)
@@ -27,7 +27,11 @@ parser.add_argument('--filter-string', default=None,
 parser.add_argument('--min-snr', default=0., type=float,
                     help='Only keep triggers above the given SNR')
 parser.add_argument('--statistic-name', dest='statname',
-                    choices=stat.sngl_statistic_dict.keys(),
+                    choices=stat.statistic_dict.keys(),
+                    help='Name of statistic to evaluate and cluster on. '
+                    'If not supplied, SNR will be used')
+parser.add_argument('--sngl-ranking',
+                    choices=ranking.sngls_ranking_function_dict.keys(),
                     help='Name of statistic to evaluate and cluster on. '
                     'If not supplied, SNR will be used')
 parser.add_argument('--statistic-files', nargs='*', default=[],
@@ -65,11 +69,12 @@ sngls = hdf.SingleDetTriggers(args.single_trig_file, args.bank_file,
 
 if args.statname is not None:
     logging.info('Calculating stat')
-    statengine = stat.sngl_statistic_dict[args.statname](args.statistic_files)
+    statengine = stat.statistic_dict[args.statname](args.sngl_ranking,
+                                                    args.statistic_files)
     #  FIXME: inefficient, as we are calculating the stat on all
     #  triggers. Might need to do something complicated to fix this.
     #  Or just use files with fewer triggers :P
-    stat = statengine.single(sngls.trigs)[sngls.mask]
+    stat = statengine.single_multiifo(sngls.trigs)[sngls.mask]
 else:
     logging.info('Using SNR for clustering, if requested')
     stat = sngls.snr
@@ -126,6 +131,7 @@ outgroup.attrs['cluster_window'] = args.cluster_window or 'None'
 if args.statname is not None:
     outgroup['stat'] = stat[out_idx]
     outgroup.attrs['statname'] = args.statname
+    outgroup.arrgs['sngl_ranking'] = args.sngl_ranking
     outgroup.attrs['statistic_files'] = args.statistic_files
 
 outfile.close()

--- a/bin/workflow_comparisons/offline_search/pycbc_injection_set_comparison
+++ b/bin/workflow_comparisons/offline_search/pycbc_injection_set_comparison
@@ -20,7 +20,7 @@ from os import path
 import argparse
 import numpy as np
 from h5py import File
-from pycbc.events import stat
+from pycbc.events import ranking
 import pycbc
 import logging
 
@@ -180,10 +180,12 @@ class RunInjectionResults(object):
                             vals = vals / 2 + 1
                         fdict[ifo].update({param: vals})
                 # Initialize statclass with an empty file list
-                statinst = \
-                        stat.sngl_statistic_dict[single_detector_statistic]([])
+                curr_rank = ranking.get_sngls_ranking_from_trigs(
+                    fdict[ifo],
+                    single_detector_statistic
+                )
                 fdict[ifo].update({single_detector_statistic:
-                                   statinst.single(fdict[ifo])})
+                                   curr_rank})
             statname = self.single_detector_statistic
             fdict.update({'minimum_single_detector_statistic': 
                           np.minimum(fdict[self.inj_dets[0]][statname],
@@ -385,7 +387,7 @@ parser.add_argument('--ifar-threshold', type=float, default=None,
                     help="If given, also followup injections with ifar smaller "
                          "than this threshold.")
 parser.add_argument("--single-detector-statistic", type=str, default='newsnr',
-                    choices=stat.sngl_statistic_dict.keys(),
+                    choices=ranking.sngls_ranking_function_dict.keys(),
                     help="Which single-detector statistic to calculate for"
                     " found injections")
 parser.add_argument("--verbose", action="store_true", default=False,

--- a/examples/live/run.sh
+++ b/examples/live/run.sh
@@ -176,7 +176,7 @@ python -m mpi4py `which pycbc_live` \
 --output-path output \
 --day-hour-output-prefix \
 --ranking-statistic quadsum \
---sngl-ranking newsnr_sgveto
+--sngl-ranking newsnr_sgveto \
 --sgchisq-snr-threshold 4 \
 --sgchisq-locations "mtotal>40:20-30,20-45,20-60,20-75,20-90,20-105,20-120" \
 --enable-background-estimation \

--- a/examples/live/run.sh
+++ b/examples/live/run.sh
@@ -175,7 +175,8 @@ python -m mpi4py `which pycbc_live` \
 --max-batch-size 16777216 \
 --output-path output \
 --day-hour-output-prefix \
---background-statistic newsnr_sgveto \
+--ranking-statistic quadsum \
+--sngl-ranking newsnr_sgveto
 --sgchisq-snr-threshold 4 \
 --sgchisq-locations "mtotal>40:20-30,20-45,20-60,20-75,20-90,20-105,20-120" \
 --enable-background-estimation \

--- a/examples/search/analysis.ini
+++ b/examples/search/analysis.ini
@@ -171,7 +171,8 @@ smoothing-width = 0.4
 [distribute_background_bins]
 [coinc]
 coinc-threshold = 0.002
-ranking-statistic = 2ogc
+ranking-statistic = phasetd_exp_fit_sg_fgbg_norm
+sngl-ranking = newsnr_sgveto_psdvar
 randomize-template-order =
 statistic-files = ../statHL.hdf ../statLV.hdf ../statHV.hdf ../statHLV.hdf
 

--- a/examples/search/plotting.ini
+++ b/examples/search/plotting.ini
@@ -23,7 +23,8 @@ analysis-category = foreground
 analysis-category = background_exc
 
 [singles_minifollowup]
-ranking-statistic = newsnr_sgveto
+ranking-statistic = quadsum
+sngl-ranking = newsnr_sgveto_psdvar
 
 [singles_minifollowup-noncoinc]
 non-coinc-time-only =
@@ -34,7 +35,8 @@ non-coinc-time-only =
 ifar-threshold = 1
 
 [page_snglinfo]
-ranking-statistic = newsnr_sgveto
+ranking-statistic = quadsum
+sngl-ranking = newsnr_sgveto_psdvar
 
 [single_template_plot]
 

--- a/pycbc/events/coinc.py
+++ b/pycbc/events/coinc.py
@@ -1038,7 +1038,7 @@ class LiveCoincTimeslideBackgroundEstimator(object):
                               [oifo, stats[i1]]]
                 # This can only use 2-det coincs at present
                 c = self.stat_calculator.rank_stat_coinc(
-                    sngls_list
+                    sngls_list,
                     slide,
                     self.timeslide_interval,
                     [0, -1]

--- a/pycbc/events/coinc.py
+++ b/pycbc/events/coinc.py
@@ -762,6 +762,7 @@ class LiveCoincTimeslideBackgroundEstimator(object):
         self.num_templates = num_templates
         self.analysis_block = analysis_block
 
+        # FIXME: Need to discuss how to hook up Live correctly!
         stat_class = stat.get_statistic(background_statistic)
         self.stat_calculator = stat_class(stat_files, ifos)
 

--- a/pycbc/events/coinc.py
+++ b/pycbc/events/coinc.py
@@ -1035,7 +1035,7 @@ class LiveCoincTimeslideBackgroundEstimator(object):
                                  self.timeslide_interval)
                 trig_stat = numpy.resize(trig_stat, len(i1))
                 sngls_list = [[ifo, trig_stat],
-                              [oifo, stats[i1]]
+                              [oifo, stats[i1]]]
                 # This can only use 2-det coincs at present
                 c = self.stat_calculator.rank_stat_coinc(
                     sngls_list

--- a/pycbc/events/coinc.py
+++ b/pycbc/events/coinc.py
@@ -726,11 +726,12 @@ class LiveCoincTimeslideBackgroundEstimator(object):
     """Rolling buffer background estimation."""
 
     def __init__(self, num_templates, analysis_block, background_statistic,
-                 stat_files, ifos,
+                 sngl_ranking, stat_files, ifos,
                  ifar_limit=100,
                  timeslide_interval=.035,
                  coinc_threshold=.002,
-                 return_background=False):
+                 return_background=False,
+                 **kwargs):
         """
         Parameters
         ----------
@@ -740,6 +741,8 @@ class LiveCoincTimeslideBackgroundEstimator(object):
             The number of seconds in each analysis segment
         background_statistic: str
             The name of the statistic to rank coincident events.
+        sngl_ranking: str
+            The single detector ranking to use with the background statistic
         stat_files: list of strs
             List of filenames that contain information used to construct
             various coincident statistics.
@@ -757,14 +760,21 @@ class LiveCoincTimeslideBackgroundEstimator(object):
         return_background: boolean
             If true, background triggers will also be included in the file
             output.
+        kwargs: dict
+            Additional options for the statistic to use. See stat.py
+            for more details on statistic options.
         """
         from . import stat
         self.num_templates = num_templates
         self.analysis_block = analysis_block
 
-        # FIXME: Need to discuss how to hook up Live correctly!
         stat_class = stat.get_statistic(background_statistic)
-        self.stat_calculator = stat_class(stat_files, ifos)
+        self.stat_calculator = stat_class(
+            sngl_ranking,
+            stat_files,
+            ifos=ifos,
+            **kwargs
+        )
 
         self.timeslide_interval = timeslide_interval
         self.return_background = return_background
@@ -839,25 +849,26 @@ class LiveCoincTimeslideBackgroundEstimator(object):
 
     @classmethod
     def from_cli(cls, args, num_templates, analysis_chunk, ifos):
+        from . import stat
+        kwargs = stat.parse_statistic_keywords_opt(args.statistic_keywords)
+
         return cls(num_templates, analysis_chunk,
-                   args.background_statistic,
-                   args.background_statistic_files,
+                   args.ranking_statistic,
+                   args.sngl_ranking,
+                   args.statistic_files,
                    return_background=args.store_background,
                    ifar_limit=args.background_ifar_limit,
                    timeslide_interval=args.timeslide_interval,
-                   ifos=ifos)
+                   ifos=ifos,
+                   **kwargs)
 
     @staticmethod
     def insert_args(parser):
         from . import stat
 
+        stat.insert_statistic_option_group(parser)
+
         group = parser.add_argument_group('Coincident Background Estimation')
-        group.add_argument('--background-statistic', default='newsnr',
-            choices=sorted(stat.statistic_dict.keys()),
-            help="Ranking statistic to use for candidate coincident events")
-        group.add_argument('--background-statistic-files', nargs='+',
-            help="Files containing precalculate values to calculate ranking"
-                 " statistic values", default=[])
         group.add_argument('--store-background', action='store_true',
             help="Return background triggers with zerolag coincidencs")
         group.add_argument('--background-ifar-limit', type=float,

--- a/pycbc/events/coinc.py
+++ b/pycbc/events/coinc.py
@@ -850,6 +850,15 @@ class LiveCoincTimeslideBackgroundEstimator(object):
     @classmethod
     def from_cli(cls, args, num_templates, analysis_chunk, ifos):
         from . import stat
+        # Allow None inputs
+        if args.statistic_files is None:
+            args.statistic_files = []
+        if args.statistic_keywords is None:
+            args.statistic_keywords = []
+
+        # flatten the list of lists of filenames to a single list (may be empty)
+        args.statistic_files = sum(args.statistic_files, [])
+
         kwargs = stat.parse_statistic_keywords_opt(args.statistic_keywords)
 
         return cls(num_templates, analysis_chunk,

--- a/pycbc/events/coinc.py
+++ b/pycbc/events/coinc.py
@@ -1034,8 +1034,12 @@ class LiveCoincTimeslideBackgroundEstimator(object):
                                  self.time_window,
                                  self.timeslide_interval)
                 trig_stat = numpy.resize(trig_stat, len(i1))
-                c = self.stat_calculator.coinc(stats[i1], trig_stat,
-                                               slide, self.timeslide_interval)
+                c = self.stat_calculator.rank_stat_coinc(
+                    stats[i1],
+                    trig_stat,
+                    slide,
+                    self.timeslide_interval
+                )
                 offsets.append(slide)
                 cstat.append(c)
                 ctimes[oifo].append(times[i1])

--- a/pycbc/events/coinc.py
+++ b/pycbc/events/coinc.py
@@ -1034,11 +1034,14 @@ class LiveCoincTimeslideBackgroundEstimator(object):
                                  self.time_window,
                                  self.timeslide_interval)
                 trig_stat = numpy.resize(trig_stat, len(i1))
+                sngls_list = [[ifo, trig_stat],
+                              [oifo, stats[i1]]
+                # This can only use 2-det coincs at present
                 c = self.stat_calculator.rank_stat_coinc(
-                    stats[i1],
-                    trig_stat,
+                    sngls_list
                     slide,
-                    self.timeslide_interval
+                    self.timeslide_interval,
+                    [0, -1]
                 )
                 offsets.append(slide)
                 cstat.append(c)

--- a/pycbc/events/eventmgr.py
+++ b/pycbc/events/eventmgr.py
@@ -269,7 +269,6 @@ class EventManager(object):
         if len(self.events) == 0:
             return
 
-        from pycbc.events import stat
         e_copy = self.events.copy()
 
         # Here self.events['snr'] is the complex SNR
@@ -277,9 +276,7 @@ class EventManager(object):
         # Messy step because pycbc inspiral's internal 'chisq_dof' is 2p-2
         # but stat.py / ranking.py functions use 'chisq_dof' = p
         e_copy['chisq_dof'] = e_copy['chisq_dof'] / 2 + 1
-        # Initialize statclass with an empty file list
-        stat_instance = stat.sngl_statistic_dict[statname]([])
-        statv = stat_instance.single(e_copy)
+        statv = ranking.get_sngls_ranking_from_trigs(e_copy, statname)
 
         # Convert trigger time to integer bin number
         # NB time_index and window are in units of samples

--- a/pycbc/events/ranking.py
+++ b/pycbc/events/ranking.py
@@ -316,7 +316,7 @@ def get_sngls_ranking_from_trigs(trigs, statname, **kwargs):
     """
     # Identify correct function
     try:
-        sngl_func = _sngls_ranking_function_dict[statname]
+        sngl_func = sngls_ranking_function_dict[statname]
     except KeyError:
         err_msg = 'Single-detector ranking {} not recognized'.format(statname)
         raise ValueError(err_msg)

--- a/pycbc/events/ranking.py
+++ b/pycbc/events/ranking.py
@@ -127,6 +127,23 @@ def newsnr_sgveto_psdvar_scaled_threshold(snr, bchisq, sgchisq, psd_var_val,
     else:
         return nsnr[0]
 
+def get_snr(trigs):
+    """
+    Return SNR from a trigs/dictionary object
+
+    Parameters
+    ----------
+    trigs: dict of numpy.ndarrays, h5py group (or similar dict-like object)
+        Dictionary-like object holding single detector trigger information.
+        'snr' is a required key
+
+    Returns
+    -------
+    numpy.ndarray
+        Array of snr values
+    """
+    return numpy.array(trigs['snr'][:], ndmin=1, dtype=numpy.float32)
+
 
 def get_newsnr(trigs):
     """
@@ -268,3 +285,78 @@ def get_newsnr_sgveto_psdvar_scaled_threshold(trigs):
                      trigs['sg_chisq'][:],
                      trigs['psd_var_val'][:])
     return numpy.array(nsnr_sg_psdt, ndmin=1, dtype=numpy.float32)
+
+_sngls_ranking_function_dict = {
+    'snr': get_snr,
+    'newsnr': get_newsnr,
+    'new_snr': get_newsnr,
+    'newsnr_sgveto': get_newsnr_sgveto,
+    'newsnr_sgveto_psdvar', get_newsnr_sgveto_psdvar,
+    'newsnr_sgveto_psdvar_threshold', get_newsnr_sgveto_psdvar_threshold,
+    'newsnr_sgveto_psdvar_scaled', get_newsnr_sgveto_psdvar_scaled,
+    'newsnr_sgveto_psdvar_scaled_threshold', get_newsnr_sgveto_psdvar_scaled_threshold,
+} 
+
+# FIXME: I have not implemented the `NewSNRCutStatistic` here. That is a single
+#        ranking where if NEWSNR < 10 and rchisq > 2 triggers are cut. This is the
+#        kind of thing that would be better in the function underneath. Or perhaps
+#        as kwargs in here?
+def get_sngls_ranking_from_trigs(trigs, statname, **kwargs):
+    """
+    Return ranking for all trigs given a statname.
+
+    Compute the single-detector ranking for a list of input triggers for a
+    specific statname. 
+
+    Parameters
+    -----------
+    trigs: dict of numpy.ndarrays
+        Dictionary holding single detector trigger information.
+    statname: 
+        The statistic to use.
+    """
+    # Identify correct function
+    try:
+        sngl_func = _sngls_ranking_function_dict[statname]
+    except KeyError:
+        err_msg = 'Single-detector ranking {} not recognized'.format(statname)
+        raise ValueError(err_msg)
+
+    # NOTE: In the sngl_funcs all the kwargs are explicitly stated, so any kwargs
+    #       sent here must be known to the function.
+    return sngl_func(trigs, **kwargs)
+    
+
+def get_sngls_ranking_from_trigs_A(trigs, statname, **kwargs):
+    """
+    Return ranking for all trigs given a statname.
+
+    Compute the single-detector ranking for a list of input triggers for a
+    specific statname. 
+
+    Parameters
+    -----------
+    trigs: dict of numpy.ndarrays
+        Dictionary holding single detector trigger information.
+    statname: 
+        The statistic to use. This is constructed from a basename and then
+        additional options. e.g. newsnr_sg_psdvar would compute newsnr with
+        the sgveto and psd variation applied to it.
+        Valid basenames here are:
+        * snr (or network_snr): Just take the SNR
+        * newsnr (or new_snr): The SNR and chisq combination defined in  
+          http://arxiv.org/abs/1208.3491.
+        * effsnr: The SNR and chisq combination defined in   
+          http://arxiv.org/abs/0901.0302
+        * max_cont_trad_newsnr: As NewSNR but the chisq used is the largest  
+          of the traditional and cont chisquared values.
+        Valid options here are:
+        * _sg (or _sgveto): Apply the SGVeto to downweight the ranking, as  
+          described in http://arxiv.org/abs/1709.08974. 
+        * _psdvarA
+        * _psdvarB
+    DESCRIBE THE VALID KWARGS AS WELL.
+    """
+    pass
+
+

--- a/pycbc/events/ranking.py
+++ b/pycbc/events/ranking.py
@@ -296,8 +296,7 @@ _sngls_ranking_function_dict = {
     'newsnr_sgveto_psdvar': get_newsnr_sgveto_psdvar,
     'newsnr_sgveto_psdvar_threshold': get_newsnr_sgveto_psdvar_threshold,
     'newsnr_sgveto_psdvar_scaled': get_newsnr_sgveto_psdvar_scaled,
-    'newsnr_sgveto_psdvar_scaled_threshold':\
-        get_newsnr_sgveto_psdvar_scaled_threshold,
+    'newsnr_sgveto_psdvar_scaled_threshold': get_newsnr_sgveto_psdvar_scaled_threshold,
 }
 
 
@@ -331,34 +330,34 @@ def get_sngls_ranking_from_trigs(trigs, statname, **kwargs):
     return sngl_func(trigs, **kwargs)
 
 
-def get_sngls_ranking_from_trigs_A(trigs, statname, **kwargs):
-    """
-    Return ranking for all trigs given a statname.
-
-    Compute the single-detector ranking for a list of input triggers for a
-    specific statname.
-
-    Parameters
-    -----------
-    trigs: dict of numpy.ndarrays
-        Dictionary holding single detector trigger information.
-    statname:
-        The statistic to use. This is constructed from a basename and then
-        additional options. e.g. newsnr_sg_psdvar would compute newsnr with
-        the sgveto and psd variation applied to it.
-        Valid basenames here are:
-        * snr (or network_snr): Just take the SNR
-        * newsnr (or new_snr): The SNR and chisq combination defined in  
-          http://arxiv.org/abs/1208.3491.
-        * effsnr: The SNR and chisq combination defined in   
-          http://arxiv.org/abs/0901.0302
-        * max_cont_trad_newsnr: As NewSNR but the chisq used is the largest  
-          of the traditional and cont chisquared values.
-        Valid options here are:
-        * _sg (or _sgveto): Apply the SGVeto to downweight the ranking, as  
-          described in http://arxiv.org/abs/1709.08974. 
-        * _psdvarA
-        * _psdvarB
-    DESCRIBE THE VALID KWARGS AS WELL.
-    """
-    pass
+# def get_sngls_ranking_from_trigs_A(trigs, statname, **kwargs):
+#     """
+#     Return ranking for all trigs given a statname.
+# 
+#     Compute the single-detector ranking for a list of input triggers for a
+#     specific statname.
+# 
+#     Parameters
+#     -----------
+#     trigs: dict of numpy.ndarrays
+#         Dictionary holding single detector trigger information.
+#     statname:
+#         The statistic to use. This is constructed from a basename and then
+#         additional options. e.g. newsnr_sg_psdvar would compute newsnr with
+#         the sgveto and psd variation applied to it.
+#         Valid basenames here are:
+#         * snr (or network_snr): Just take the SNR
+#         * newsnr (or new_snr): The SNR and chisq combination defined in
+#           http://arxiv.org/abs/1208.3491.
+#         * effsnr: The SNR and chisq combination defined in
+#           http://arxiv.org/abs/0901.0302
+#         * max_cont_trad_newsnr: As NewSNR but the chisq used is the largest
+#           of the traditional and cont chisquared values.
+#         Valid options here are:
+#         * _sg (or _sgveto): Apply the SGVeto to downweight the ranking, as
+#           described in http://arxiv.org/abs/1709.08974.
+#         * _psdvarA
+#         * _psdvarB
+#     DESCRIBE THE VALID KWARGS AS WELL.
+#     """
+#     pass

--- a/pycbc/events/ranking.py
+++ b/pycbc/events/ranking.py
@@ -1,6 +1,7 @@
 """ This module contains functions for calculating single-ifo ranking
 statistic values
 """
+from six import raise_from
 import numpy
 
 
@@ -317,9 +318,9 @@ def get_sngls_ranking_from_trigs(trigs, statname, **kwargs):
     # Identify correct function
     try:
         sngl_func = sngls_ranking_function_dict[statname]
-    except KeyError:
+    except KeyError as exc:
         err_msg = 'Single-detector ranking {} not recognized'.format(statname)
-        raise ValueError(err_msg)
+        raise_from(ValueError(err_msg), exc)
 
     # NOTE: In the sngl_funcs all the kwargs are explicitly stated, so any
     #       kwargs sent here must be known to the function.

--- a/pycbc/events/ranking.py
+++ b/pycbc/events/ranking.py
@@ -127,6 +127,7 @@ def newsnr_sgveto_psdvar_scaled_threshold(snr, bchisq, sgchisq, psd_var_val,
     else:
         return nsnr[0]
 
+
 def get_snr(trigs):
     """
     Return SNR from a trigs/dictionary object
@@ -286,33 +287,36 @@ def get_newsnr_sgveto_psdvar_scaled_threshold(trigs):
                      trigs['psd_var_val'][:])
     return numpy.array(nsnr_sg_psdt, ndmin=1, dtype=numpy.float32)
 
+
 _sngls_ranking_function_dict = {
     'snr': get_snr,
     'newsnr': get_newsnr,
     'new_snr': get_newsnr,
     'newsnr_sgveto': get_newsnr_sgveto,
-    'newsnr_sgveto_psdvar', get_newsnr_sgveto_psdvar,
-    'newsnr_sgveto_psdvar_threshold', get_newsnr_sgveto_psdvar_threshold,
-    'newsnr_sgveto_psdvar_scaled', get_newsnr_sgveto_psdvar_scaled,
-    'newsnr_sgveto_psdvar_scaled_threshold', get_newsnr_sgveto_psdvar_scaled_threshold,
-} 
+    'newsnr_sgveto_psdvar': get_newsnr_sgveto_psdvar,
+    'newsnr_sgveto_psdvar_threshold': get_newsnr_sgveto_psdvar_threshold,
+    'newsnr_sgveto_psdvar_scaled': get_newsnr_sgveto_psdvar_scaled,
+    'newsnr_sgveto_psdvar_scaled_threshold':\
+        get_newsnr_sgveto_psdvar_scaled_threshold,
+}
+
 
 # FIXME: I have not implemented the `NewSNRCutStatistic` here. That is a single
-#        ranking where if NEWSNR < 10 and rchisq > 2 triggers are cut. This is the
-#        kind of thing that would be better in the function underneath. Or perhaps
-#        as kwargs in here?
+#        ranking where if NEWSNR < 10 and rchisq > 2 triggers are cut. This is
+#        the kind of thing that would be better in the function underneath. Or
+#        perhaps as kwargs in here?
 def get_sngls_ranking_from_trigs(trigs, statname, **kwargs):
     """
     Return ranking for all trigs given a statname.
 
     Compute the single-detector ranking for a list of input triggers for a
-    specific statname. 
+    specific statname.
 
     Parameters
     -----------
     trigs: dict of numpy.ndarrays
         Dictionary holding single detector trigger information.
-    statname: 
+    statname:
         The statistic to use.
     """
     # Identify correct function
@@ -322,23 +326,23 @@ def get_sngls_ranking_from_trigs(trigs, statname, **kwargs):
         err_msg = 'Single-detector ranking {} not recognized'.format(statname)
         raise ValueError(err_msg)
 
-    # NOTE: In the sngl_funcs all the kwargs are explicitly stated, so any kwargs
-    #       sent here must be known to the function.
+    # NOTE: In the sngl_funcs all the kwargs are explicitly stated, so any
+    #       kwargs sent here must be known to the function.
     return sngl_func(trigs, **kwargs)
-    
+
 
 def get_sngls_ranking_from_trigs_A(trigs, statname, **kwargs):
     """
     Return ranking for all trigs given a statname.
 
     Compute the single-detector ranking for a list of input triggers for a
-    specific statname. 
+    specific statname.
 
     Parameters
     -----------
     trigs: dict of numpy.ndarrays
         Dictionary holding single detector trigger information.
-    statname: 
+    statname:
         The statistic to use. This is constructed from a basename and then
         additional options. e.g. newsnr_sg_psdvar would compute newsnr with
         the sgveto and psd variation applied to it.
@@ -358,5 +362,3 @@ def get_sngls_ranking_from_trigs_A(trigs, statname, **kwargs):
     DESCRIBE THE VALID KWARGS AS WELL.
     """
     pass
-
-

--- a/pycbc/events/ranking.py
+++ b/pycbc/events/ranking.py
@@ -333,10 +333,10 @@ def get_sngls_ranking_from_trigs(trigs, statname, **kwargs):
 # def get_sngls_ranking_from_trigs_A(trigs, statname, **kwargs):
 #     """
 #     Return ranking for all trigs given a statname.
-# 
+#
 #     Compute the single-detector ranking for a list of input triggers for a
 #     specific statname.
-# 
+#
 #     Parameters
 #     -----------
 #     trigs: dict of numpy.ndarrays

--- a/pycbc/events/ranking.py
+++ b/pycbc/events/ranking.py
@@ -288,7 +288,7 @@ def get_newsnr_sgveto_psdvar_scaled_threshold(trigs):
     return numpy.array(nsnr_sg_psdt, ndmin=1, dtype=numpy.float32)
 
 
-_sngls_ranking_function_dict = {
+sngls_ranking_function_dict = {
     'snr': get_snr,
     'newsnr': get_newsnr,
     'new_snr': get_newsnr,
@@ -300,10 +300,6 @@ _sngls_ranking_function_dict = {
 }
 
 
-# FIXME: I have not implemented the `NewSNRCutStatistic` here. That is a single
-#        ranking where if NEWSNR < 10 and rchisq > 2 triggers are cut. This is
-#        the kind of thing that would be better in the function underneath. Or
-#        perhaps as kwargs in here?
 def get_sngls_ranking_from_trigs(trigs, statname, **kwargs):
     """
     Return ranking for all trigs given a statname.
@@ -328,36 +324,3 @@ def get_sngls_ranking_from_trigs(trigs, statname, **kwargs):
     # NOTE: In the sngl_funcs all the kwargs are explicitly stated, so any
     #       kwargs sent here must be known to the function.
     return sngl_func(trigs, **kwargs)
-
-
-# def get_sngls_ranking_from_trigs_A(trigs, statname, **kwargs):
-#     """
-#     Return ranking for all trigs given a statname.
-#
-#     Compute the single-detector ranking for a list of input triggers for a
-#     specific statname.
-#
-#     Parameters
-#     -----------
-#     trigs: dict of numpy.ndarrays
-#         Dictionary holding single detector trigger information.
-#     statname:
-#         The statistic to use. This is constructed from a basename and then
-#         additional options. e.g. newsnr_sg_psdvar would compute newsnr with
-#         the sgveto and psd variation applied to it.
-#         Valid basenames here are:
-#         * snr (or network_snr): Just take the SNR
-#         * newsnr (or new_snr): The SNR and chisq combination defined in
-#           http://arxiv.org/abs/1208.3491.
-#         * effsnr: The SNR and chisq combination defined in
-#           http://arxiv.org/abs/0901.0302
-#         * max_cont_trad_newsnr: As NewSNR but the chisq used is the largest
-#           of the traditional and cont chisquared values.
-#         Valid options here are:
-#         * _sg (or _sgveto): Apply the SGVeto to downweight the ranking, as
-#           described in http://arxiv.org/abs/1709.08974.
-#         * _psdvarA
-#         * _psdvarB
-#     DESCRIBE THE VALID KWARGS AS WELL.
-#     """
-#     pass

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -1803,6 +1803,7 @@ def insert_statistic_option_group(parser):
 
     return statistic_opt_group
 
+
 def parse_statistic_keywords_opt(stat_kwarg_list):
     """
     Parse the list of statistic keywords into an appropriate dictionary.
@@ -1828,10 +1829,11 @@ def parse_statistic_keywords_opt(stat_kwarg_list):
         except ValueError:
             err_txt = "--statistic-keywords must take input in the " \
                       "form KWARG1:VALUE1 KWARG2:VALUE2 KWARG3:VALUE3 ... " \
-                      "Received {}".format(opts.statistic_keywords)
+                      "Received {}".format(' '.join(stat_kwarg_list))
             raise ValueError(err_txt)
 
     return stat_kwarg_dict
+
 
 def get_statistic_from_opts(opts, ifos):
     """

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -42,13 +42,11 @@ class Stat(object):
         ----------
         sngl_ranking: str
             The name of the ranking to use for the single-detector triggers.
-
         files: list of strs, needed for some statistics
             A list containing the filenames of hdf format files used to help
             construct the coincident statistics. The files must have a 'stat'
             attribute which is used to associate them with the appropriate
             statistic class.
-
         ifos: list of strs, needed for some statistics
             The list of detector names
         """
@@ -102,6 +100,7 @@ class Stat(object):
         raise ValueError(err_msg)
 
     # FIXME: Why does this function not just call straight into single?
+    # FIXME: Should this be renamed for clarity if multiifo is being removed?
     def single_multiifo(self, single_info):
         """
         Calculate the statistic for a single detector candidate
@@ -186,6 +185,24 @@ class QuadratureSumStatistic(Stat):
         """
         return self.sngl_ranking(trigs)
 
+    def single_multiifo(self, single_info):
+        """
+        Calculate the statistic for a single detector candidate
+
+        Parameters
+        ----------
+        single_info: tuple
+            Tuple containing two values. The first is the ifo (str) and the
+            second is the output from self.single()
+
+        Returns
+        -------
+        numpy.ndarray
+            The array of single detector statistics
+        """
+        return single_info[1]
+
+
     def coinc(self, sngls_list, slide, step, to_shift,
               **kwargs): # pylint:disable=unused-argument
         """
@@ -236,6 +253,15 @@ class QuadratureSumStatistic(Stat):
             Array of limits on the limifo single statistic to
             exceed thresh.
         """
+        # Safety against subclassing and not rethinking this
+        allowed_names = ['QuadratureSumStatistic']
+        if type(self).__name__ not in ['QuadratureSumStatistic']:
+            err_msg = "This is being called from a subclass which has not "
+            err_msg += "been checked for validity with this method. If it is "
+            err_msg += "valid for the subclass to come here, include in the "
+            err_msg += "list of allowed_names above."
+            raise ValueError(err_msg)
+
         s0 = thresh ** 2. - sum(sngl[1] ** 2. for sngl in s)
         s0[s0 < 0] = 0
         return s0 ** 0.5

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -1700,6 +1700,7 @@ class ExpFitSGPSDFgBgNormBBHStatistic(ExpFitSGFgBgNormNewStatistic):
 
 statistic_dict = {
     'quadsum': QuadratureSumStatistic,
+    'single_ranking_only': QuadratureSumStatistic,
     'phasetd_newsnr': PhaseTDNewStatistic,
     'exp_fit_stat': ExpFitStatistic,
     'exp_fit_csnr': ExpFitCombinedSNR,
@@ -1708,25 +1709,6 @@ statistic_dict = {
     'phasetd_exp_fit_sg_fgbg_norm': ExpFitSGFgBgNormNewStatistic,
     'phasetd_exp_fit_sg_fgbg_bbh_norm': ExpFitSGPSDFgBgNormBBHStatistic,
 }
-
-# FIXME: Likely I would remove this. The ranking function, and the
-#        single_multiifo method, would fulfill needs here. (Possibly!)
-# sngl_statistic_dict = {
-#     'newsnr': NewSNRStatistic,
-#     'new_snr': NewSNRStatistic, # For backwards compatibility
-#     'snr': NetworkSNRStatistic,
-#     'newsnr_cut': NewSNRCutStatistic,
-#     'exp_fit_csnr': ExpFitCombinedSNR,
-#     'exp_fit_sg_csnr': ExpFitSGCombinedSNR,
-#     'max_cont_trad_newsnr': MaxContTradNewSNRStatistic,
-#     'newsnr_sgveto': NewSNRSGStatistic,
-#     'newsnr_sgveto_psdvar': NewSNRSGPSDStatistic,
-#     'newsnr_sgveto_psdvar_threshold': NewSNRSGPSDThresholdStatistic,
-#     'newsnr_sgveto_psdvar_scaled': NewSNRSGPSDScaledStatistic,
-#     'newsnr_sgveto_psdvar_scaled_threshold':
-#         NewSNRSGPSDScaledThresholdStatistic,
-#     'exp_fit_sg_csnr_psdvar': ExpFitSGPSDCombinedSNR
-# }
 
 
 def get_statistic(stat):
@@ -1752,28 +1734,3 @@ def get_statistic(stat):
         return statistic_dict[stat]
     except KeyError:
         raise RuntimeError('%s is not an available detection statistic' % stat)
-
-
-# def get_sngl_statistic(stat):
-#    """
-#    Error-handling sugar around dict lookup for single-detector statistics
-#
-#    Parameters
-#    ----------
-#    stat : string
-#        Name of the single-detector statistic
-#
-#    Returns
-#    -------
-#    class
-#        Subclass of Stat base class
-#
-#    Raises
-#    ------
-#    RuntimeError
-#        If the string is not recognized as corresponding to a Stat subclass
-#    """
-#    try:
-#        return sngl_statistic_dict[stat]
-#    except KeyError:
-#       raise RuntimeError('%s is not an available detection statistic' % stat)

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -119,8 +119,7 @@ class Stat(object):
         err_msg += "sub-classes. You shouldn't be seeing this error!"
         raise ValueError(err_msg)
 
-    # FIXME: Should this be renamed for clarity if multiifo is being removed?
-    def single_multiifo(self, single_info):
+    def rank_stat_single(self, single_info):
         """
         Calculate the statistic for a single detector candidate
 
@@ -139,8 +138,8 @@ class Stat(object):
         err_msg += "sub-classes. You shouldn't be seeing this error!"
         raise ValueError(err_msg)
 
-    def coinc(self, s, slide, step, to_shift,
-              **kwargs): # pylint:disable=unused-argument
+    def rank_stat_coinc(self, s, slide, step, to_shift,
+                        **kwargs): # pylint:disable=unused-argument
         """
         Calculate the coincident detection statistic.
         """
@@ -204,7 +203,7 @@ class QuadratureSumStatistic(Stat):
         """
         return self.get_sngl_ranking(trigs)
 
-    def single_multiifo(self, single_info):
+    def rank_stat_single(self, single_info):
         """
         Calculate the statistic for a single detector candidate
 
@@ -221,8 +220,8 @@ class QuadratureSumStatistic(Stat):
         """
         return self.single(single_info[1])
 
-    def coinc(self, sngls_list, slide, step, to_shift,
-              **kwargs): # pylint:disable=unused-argument
+    def rank_stat_coinc(self, sngls_list, slide, step, to_shift,
+                        **kwargs): # pylint:disable=unused-argument
         """
         Calculate the coincident detection statistic.
 
@@ -602,7 +601,7 @@ class PhaseTDNewStatistic(QuadratureSumStatistic):
         singles['snr'] = trigs['snr'][:]
         return numpy.array(singles, ndmin=1)
 
-    def single_multiifo(self, single_info):
+    def rank_stat_single(self, single_info):
         """
         Calculate the statistic for a single detector candidate
 
@@ -620,8 +619,8 @@ class PhaseTDNewStatistic(QuadratureSumStatistic):
         err_msg = "Sorry! No-one has implemented this method yet! "
         raise ValueError(err_msg)
 
-    def coinc(self, s, slide, step, to_shift,
-              **kwargs): # pylint:disable=unused-argument
+    def rank_stat_coinc(self, s, slide, step, to_shift,
+                        **kwargs): # pylint:disable=unused-argument
         """
         Calculate the coincident detection statistic.
         """
@@ -811,7 +810,7 @@ class ExpFitStatistic(QuadratureSumStatistic):
 
         return self.lognoiserate(trigs)
 
-    def single_multiifo(self, single_info):
+    def rank_stat_single(self, single_info):
         """
         Calculate the statistic for a single detector candidate
 
@@ -829,8 +828,8 @@ class ExpFitStatistic(QuadratureSumStatistic):
         err_msg = "Sorry! No-one has implemented this method yet! "
         raise ValueError(err_msg)
 
-    def coinc(self, s, slide, step, to_shift,
-              **kwargs): # pylint:disable=unused-argument
+    def rank_stat_coinc(self, s, slide, step, to_shift,
+                        **kwargs): # pylint:disable=unused-argument
         """
         Calculate the coincident detection statistic.
         """
@@ -952,7 +951,7 @@ class ExpFitCombinedSNR(ExpFitStatistic):
         stat = thresh - (logr_n / self.alpharef)
         return numpy.array(stat, ndmin=1, dtype=numpy.float32)
 
-    def single_multiifo(self, single_info):
+    def rank_stat_single(self, single_info):
         """
         Calculate the statistic for single detector candidates
 
@@ -974,8 +973,8 @@ class ExpFitCombinedSNR(ExpFitStatistic):
             sngl_multiifo = -1.0 * sngl_rnk['snglstat']
         return sngl_multiifo
 
-    def coinc(self, s, slide, step, to_shift,
-              **kwargs): # pylint:disable=unused-argument
+    def rank_stat_coinc(self, s, slide, step, to_shift,
+                        **kwargs): # pylint:disable=unused-argument
         """
         Calculate the coincident detection statistic.
 
@@ -1087,7 +1086,7 @@ class PhaseTDNewExpFitStatistic(PhaseTDNewStatistic, ExpFitCombinedSNR):
         singles['snr'] = trigs['snr'][:]
         return numpy.array(singles, ndmin=1)
 
-    def single_multiifo(self, single_info):
+    def rank_stat_single(self, single_info):
         """
         Calculate the statistic for a single detector candidate
 
@@ -1105,8 +1104,8 @@ class PhaseTDNewExpFitStatistic(PhaseTDNewStatistic, ExpFitCombinedSNR):
         err_msg = "Sorry! No-one has implemented this method yet! "
         raise ValueError(err_msg)
 
-    def coinc(self, s, slide, step, to_shift,
-              **kwargs): # pylint:disable=unused-argument
+    def rank_stat_coinc(self, s, slide, step, to_shift,
+                        **kwargs): # pylint:disable=unused-argument
         """
         Calculate the coincident detection statistic.
         """
@@ -1207,8 +1206,8 @@ class ExpFitSGBgRateStatistic(ExpFitStatistic):
             coeff_file['count_above_thresh'][:][tid_sort] / \
             float(coeff_file.attrs['analysis_time'])
 
-    def coinc(self, s, slide, step, to_shift,
-              **kwargs): # pylint:disable=unused-argument
+    def rank_stat_coinc(self, s, slide, step, to_shift,
+                        **kwargs): # pylint:disable=unused-argument
         """
         Calculate the coincident detection statistic.
 
@@ -1402,7 +1401,7 @@ class ExpFitSGFgBgNormNewStatistic(PhaseTDNewStatistic,
         singles['benchmark_logvol'] = self.benchmark_logvol[tnum]
         return numpy.array(singles, ndmin=1)
 
-    def single_multiifo(self, single_info):
+    def rank_stat_single(self, single_info):
         """
         Calculate the statistic for single detector candidates
 
@@ -1431,8 +1430,8 @@ class ExpFitSGFgBgNormNewStatistic(PhaseTDNewStatistic,
         loglr[loglr < -30.] = -30.
         return loglr
 
-    def coinc(self, s, slide, step, to_shift,
-              **kwargs): # pylint:disable=unused-argument
+    def rank_stat_coinc(self, s, slide, step, to_shift,
+                        **kwargs): # pylint:disable=unused-argument
         """
         Calculate the coincident detection statistic.
 

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -1706,7 +1706,7 @@ statistic_dict = {
     'phasetd_exp_fit_stat': PhaseTDNewExpFitStatistic,
     'exp_fit_sg_bg_rate': ExpFitSGBgRateStatistic,
     'phasetd_exp_fit_sg_fgbg_norm': ExpFitSGFgBgNormNewStatistic,
-    'phasetd_exp_fit_sg_fgbg_bbh_norm' : ExpFitSGPSDFgBgNormBBHStatistic,
+    'phasetd_exp_fit_sg_fgbg_bbh_norm': ExpFitSGPSDFgBgNormBBHStatistic,
 }
 
 # FIXME: Likely I would remove this. The ranking function, and the

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -85,7 +85,7 @@ class Stat(object):
 
     def single(self, trigs): # pylint:disable=unused-argument
         """
-        Calculate the single detector statistic, here equal to newsnr
+        Calculate the necessary single detector information
 
         Parameters
         ----------
@@ -150,7 +150,10 @@ class QuadratureSumStatistic(Stat):
     """Calculate the NewSNR coincident detection statistic"""
 
     def single(self, trigs):
-        """Calculate the single detector statistic, here equal to newsnr
+        """
+        Calculate the necessary single detector information
+
+        Here just the ranking is computed and returned.
 
         Parameters
         ----------
@@ -166,7 +169,8 @@ class QuadratureSumStatistic(Stat):
 
     def coinc(self, sngls_list, slide, step, to_shift,
               **kwargs): # pylint:disable=unused-argument
-        """Calculate the coincident detection statistic.
+        """
+        Calculate the coincident detection statistic.
 
         Parameters
         ----------
@@ -191,7 +195,10 @@ class QuadratureSumStatistic(Stat):
 
     def coinc_lim_for_thresh(self, s, thresh, limifo,
                              **kwargs): # pylint:disable=unused-argument
-        """Calculate the required single detector statistic to exceed
+        """
+        Optimization function to identify coincs too quiet to be of interest
+
+        Calculate the required single detector statistic to exceed
         the threshold for each of the input triggers.
 
         Parameters

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -1261,7 +1261,7 @@ class ExpFitSGFgBgNormNewStatistic(PhaseTDNewStatistic,
     Statistic combining PhaseTD, ExpFitSGBg and additional foreground info.
     """
 
-    def __init__(self, files=None, ifos=None, **kwargs):
+    def __init__(self, sngl_ranking, files=None, ifos=None, **kwargs):
         """
         Create a statistic class instance
 

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -1824,7 +1824,7 @@ def parse_statistic_keywords_opt(stat_kwarg_list):
     for inputstr in stat_kwarg_list:
         try:
             key, value = inputstr.split(':')
-            extra_kwargs[key] = value
+            stat_kwarg_dict[key] = value
         except ValueError:
             err_txt = "--statistic-keywords must take input in the " \
                       "form KWARG1:VALUE1 KWARG2:VALUE2 KWARG3:VALUE3 ... " \

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -1841,7 +1841,7 @@ def get_statistic_from_opts(opts, ifos):
     stat_class = get_statistic(opts.ranking_statistic)(
         opts.sngl_ranking,
         opts.statistic_files,
-        ifos=trigs.ifos,
+        ifos=ifos,
         **extra_kwargs
     )
 

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -1056,7 +1056,7 @@ class PhaseTDExpFitStatistic(PhaseTDStatistic, ExpFitCombinedSNR):
                                    **kwargs)
         # need the self.single_dtype value from PhaseTDStatistic
         PhaseTDStatistic.__init__(self, sngl_ranking, files=files,
-                                     ifos=ifos, **kwargs)
+                                  ifos=ifos, **kwargs)
 
     def single(self, trigs):
         """
@@ -1613,7 +1613,7 @@ class ExpFitSGPSDFgBgNormBBHStatistic(ExpFitSGFgBgNormStatistic):
             produce *all* the loudest background (and foreground) events.
         """
         ExpFitSGFgBgNormStatistic.__init__(self, sngl_ranking, files=files,
-                                              ifos=ifos, **kwargs)
+                                           ifos=ifos, **kwargs)
         self.get_newsnr = ranking.get_newsnr_sgveto_psdvar
         self.mcm = max_chirp_mass
         self.curr_mchirp = None

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -117,7 +117,7 @@ class Stat(object):
         """
         err_msg = "This function is a stub that should be overridden by the "
         err_msg += "sub-classes. You shouldn't be seeing this error!"
-        raise ValueError(err_msg)
+        raise NotImplementedError(err_msg)
 
     def rank_stat_single(self, single_info):
         """
@@ -136,7 +136,7 @@ class Stat(object):
         """
         err_msg = "This function is a stub that should be overridden by the "
         err_msg += "sub-classes. You shouldn't be seeing this error!"
-        raise ValueError(err_msg)
+        raise NotImplementedError(err_msg)
 
     def rank_stat_coinc(self, s, slide, step, to_shift,
                         **kwargs): # pylint:disable=unused-argument
@@ -145,7 +145,7 @@ class Stat(object):
         """
         err_msg = "This function is a stub that should be overridden by the "
         err_msg += "sub-classes. You shouldn't be seeing this error!"
-        raise ValueError(err_msg)
+        raise NotImplementedError(err_msg)
 
     def _check_coinc_lim_subclass(self, allowed_names):
         """
@@ -166,7 +166,7 @@ class Stat(object):
             err_msg += "been checked for validity with this method. If it is "
             err_msg += "valid for the subclass to come here, include in the "
             err_msg += "list of allowed_names above."
-            raise ValueError(err_msg)
+            raise NotImplementedError(err_msg)
 
     def coinc_lim_for_thresh(self, s, thresh, limifo,
                              **kwargs): # pylint:disable=unused-argument
@@ -179,7 +179,7 @@ class Stat(object):
 
         err_msg = "This function is a stub that should be overridden by the "
         err_msg += "sub-classes. You shouldn't be seeing this error!"
-        raise ValueError(err_msg)
+        raise NotImplementedError(err_msg)
 
 
 class QuadratureSumStatistic(Stat):
@@ -617,7 +617,7 @@ class PhaseTDStatistic(QuadratureSumStatistic):
             The array of single detector statistics
         """
         err_msg = "Sorry! No-one has implemented this method yet! "
-        raise ValueError(err_msg)
+        raise NotImplementedError(err_msg)
 
     def rank_stat_coinc(self, s, slide, step, to_shift,
                         **kwargs): # pylint:disable=unused-argument
@@ -625,7 +625,7 @@ class PhaseTDStatistic(QuadratureSumStatistic):
         Calculate the coincident detection statistic.
         """
         err_msg = "Sorry! No-one has implemented this method yet! "
-        raise ValueError(err_msg)
+        raise NotImplementedError(err_msg)
 
     def coinc_lim_for_thresh(self, s, thresh, limifo,
                              **kwargs): # pylint:disable=unused-argument
@@ -635,7 +635,7 @@ class PhaseTDStatistic(QuadratureSumStatistic):
         the threshold for each of the input triggers.
         """
         err_msg = "Sorry! No-one has implemented this method yet! "
-        raise ValueError(err_msg)
+        raise NotImplementedError(err_msg)
 
 
 class ExpFitStatistic(QuadratureSumStatistic):
@@ -826,7 +826,7 @@ class ExpFitStatistic(QuadratureSumStatistic):
             The array of single detector statistics
         """
         err_msg = "Sorry! No-one has implemented this method yet! "
-        raise ValueError(err_msg)
+        raise NotImplementedError(err_msg)
 
     def rank_stat_coinc(self, s, slide, step, to_shift,
                         **kwargs): # pylint:disable=unused-argument
@@ -834,7 +834,7 @@ class ExpFitStatistic(QuadratureSumStatistic):
         Calculate the coincident detection statistic.
         """
         err_msg = "Sorry! No-one has implemented this method yet! "
-        raise ValueError(err_msg)
+        raise NotImplementedError(err_msg)
 
     def coinc_lim_for_thresh(self, s, thresh, limifo,
                              **kwargs): # pylint:disable=unused-argument
@@ -844,7 +844,7 @@ class ExpFitStatistic(QuadratureSumStatistic):
         the threshold for each of the input triggers.
         """
         err_msg = "Sorry! No-one has implemented this method yet! "
-        raise ValueError(err_msg)
+        raise NotImplementedError(err_msg)
 
     # Keeping this here to help write the new coinc method.
     def coinc_OLD(self, s0, s1, slide, step): # pylint:disable=unused-argument
@@ -1102,7 +1102,7 @@ class PhaseTDExpFitStatistic(PhaseTDStatistic, ExpFitCombinedSNR):
             The array of single detector statistics
         """
         err_msg = "Sorry! No-one has implemented this method yet! "
-        raise ValueError(err_msg)
+        raise NotImplementedError(err_msg)
 
     def rank_stat_coinc(self, s, slide, step, to_shift,
                         **kwargs): # pylint:disable=unused-argument
@@ -1110,7 +1110,7 @@ class PhaseTDExpFitStatistic(PhaseTDStatistic, ExpFitCombinedSNR):
         Calculate the coincident detection statistic.
         """
         err_msg = "Sorry! No-one has implemented this method yet! "
-        raise ValueError(err_msg)
+        raise NotImplementedError(err_msg)
 
     def coinc_lim_for_thresh(self, s, thresh, limifo,
                              **kwargs): # pylint:disable=unused-argument
@@ -1120,7 +1120,7 @@ class PhaseTDExpFitStatistic(PhaseTDStatistic, ExpFitCombinedSNR):
         the threshold for each of the input triggers.
         """
         err_msg = "Sorry! No-one has implemented this method yet! "
-        raise ValueError(err_msg)
+        raise NotImplementedError(err_msg)
 
     # Keeping the old statistic code here for now to help with reimplementing
     def coinc_OLD(self, s0, s1, slide, step):

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -30,6 +30,7 @@ import numpy
 from . import ranking
 from . import coinc_rate
 
+
 class Stat(object):
     """Base class which should be extended to provide a coincident statistic"""
 
@@ -151,10 +152,10 @@ class Stat(object):
         """
         Check that we are not using coinc_lim_for_thresh when not valid.
 
-        coinc_lim_for_thresh is only defined for the statistic it is present in.
-        If we subclass, we must check explicitly that it is still valid and indicate
-        this in the code. If the code does not have this explicit check you will
-        see the failure message here.
+        coinc_lim_for_thresh is only defined for the statistic it is present
+        in. If we subclass, we must check explicitly that it is still valid and
+        inidicate this in the code. If the code does not have this explicit
+        check you will see the failure message here.
 
         Parameters
         -----------
@@ -700,7 +701,6 @@ class ExpFitStatistic(QuadratureSumStatistic):
             A dictionary containing the fit information in the `alpha`, `rate`
             and `thresh` keys/.
         """
-        # FIXME: Is this called lots of times? If so should it be cached?
         coeff_file = self.files[ifo+'-fit_coeffs']
         template_id = coeff_file['template_id'][:]
         alphas = coeff_file['fit_coeff'][:]
@@ -1791,7 +1791,7 @@ def insert_statistic_option_group(parser):
         default=[],
         help="Files containing ranking statistic info"
     )
-    
+
     statistic_opt_group.add_argument(
         "--statistic-keywords",
         nargs='*',

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -147,7 +147,7 @@ class Stat(object):
 
 
 class QuadratureSumStatistic(Stat):
-    """Calculate the NewSNR coincident detection statistic"""
+    """Calculate the quadrature sum coincident detection statistic"""
 
     def single(self, trigs):
         """
@@ -223,13 +223,32 @@ class QuadratureSumStatistic(Stat):
 
 
 class PhaseTDNewStatistic(QuadratureSumStatistic):
-    """Statistic that re-weights combined newsnr using coinc parameters.
+    """
+    Statistic that re-weights combined newsnr using coinc parameters.
 
     The weighting is based on the PDF of time delays, phase differences and
     amplitude ratios between triggers in different ifos.
     """
 
-    def __init__(self, files=None, ifos=None, **kwargs):
+    def __init__(self, sngl_ranking, files=None, ifos=None, **kwargs):
+        """
+        Create a statistic class instance
+
+        Parameters
+        ----------
+        sngl_ranking: str
+            The name of the ranking to use for the single-detector triggers.
+
+        files: list of strs, needed for some statistics
+            A list containing the filenames of hdf format files used to help
+            construct the coincident statistics. The files must have a 'stat'
+            attribute which is used to associate them with the appropriate
+            statistic class.
+
+        ifos: list of strs, needed for some statistics
+            The list of detector names
+        """
+
         NewSNRStatistic.__init__(self, files=files, ifos=ifos, **kwargs)
 
         self.single_dtype = [('snglstat', numpy.float32),
@@ -237,7 +256,7 @@ class PhaseTDNewStatistic(QuadratureSumStatistic):
                              ('end_time', numpy.float64),
                              ('sigmasq', numpy.float32),
                              ('snr', numpy.float32)
-                             ]
+                            ]
 
         # Assign attribute so that it can be replaced with other functions
         self.has_hist = False
@@ -254,7 +273,16 @@ class PhaseTDNewStatistic(QuadratureSumStatistic):
         self.two_det_weights = {}
 
     def get_hist(self, ifos=None):
-        """Read in a signal density file for the ifo combination"""
+        """
+        Read in a signal density file for the ifo combination
+
+
+        Parameters
+        ----------
+        ifos: list
+            The list of ifos. Needed if not given when initializing the class
+            instance.
+        """
 
         ifos = ifos or self.ifos
 
@@ -375,13 +403,17 @@ class PhaseTDNewStatistic(QuadratureSumStatistic):
         self.has_hist = True
 
     def single(self, trigs):
-        """Calculate the single detector statistic & assemble other parameters
+        """
+        Calculate the necessary single detector information
+
+        Here the ranking as well as phase, endtime and sigma-squared values.
 
         Parameters
         ----------
         trigs: dict of numpy.ndarrays, h5py group or similar dict-like object
             Object holding single detector trigger information. 'snr', 'chisq',
-        'chisq_dof', 'coa_phase', 'end_time', and 'sigmasq' are required keys.
+            'chisq_dof', 'coa_phase', 'end_time', and 'sigmasq' are required
+            keys.
 
         Returns
         -------
@@ -398,7 +430,8 @@ class PhaseTDNewStatistic(QuadratureSumStatistic):
         return numpy.array(singles, ndmin=1)
 
     def logsignalrate(self, stats, shift, to_shift):
-        """Calculate the normalized log rate density of signals via lookup
+        """
+        Calculate the normalized log rate density of signals via lookup
 
         Parameters
         ----------
@@ -511,7 +544,8 @@ class PhaseTDNewStatistic(QuadratureSumStatistic):
 
 
 class ExpFitStatistic(NewSNRStatistic):
-    """Detection statistic using an exponential falloff noise model.
+    """
+    Detection statistic using an exponential falloff noise model.
 
     Statistic approximates the negative log noise coinc rate density per
     template over single-ifo newsnr values.

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -1692,7 +1692,7 @@ class ExpFitSGPSDFgBgNormBBHStatistic(ExpFitSGFgBgNormNewStatistic):
             exceed thresh.
         """
 
-        loglr = ExpFitSGFgBgNormNewStatistic.coinc_multiifo_lim_for_thresh(
+        loglr = ExpFitSGFgBgNormNewStatistic.coinc_lim_for_thresh(
                     self, s, thresh, limifo, **kwargs)
         loglr += numpy.log((self.curr_mchirp / 20.0) ** (11./3.0))
         return loglr
@@ -1705,7 +1705,6 @@ statistic_dict = {
     'exp_fit_csnr': ExpFitCombinedSNR,
     'phasetd_exp_fit_stat': PhaseTDNewExpFitStatistic,
     'exp_fit_sg_bg_rate': ExpFitSGBgRateStatistic,
-    'exp_fit_sg_fgbg_rate': ExpFitSGFgBgRateStatistic,
     'phasetd_exp_fit_sg_fgbg_norm': ExpFitSGFgBgNormNewStatistic,
     'phasetd_exp_fit_sg_fgbg_bbh_norm' : ExpFitSGPSDFgBgNormBBHStatistic,
 }

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -35,17 +35,22 @@ class Stat(object):
     """Base class which should be extended to provide a coincident statistic"""
 
     def __init__(self, sngl_ranking, files=None, ifos=None, **kwargs):
-        """Create a statistic class instance
+        """
+        Create a statistic class instance
 
         Parameters
         ----------
-        files: list of strs
-            A list containing the filenames of hdf format files used to help
-        construct the coincident statistics. The files must have a 'stat'
-        attribute which is used to associate them with the appropriate
-        statistic class.
+        sngl_ranking: str
+            The name of the ranking to use for the single-detector triggers.
 
-        ifos: list of detector names, optional
+        files: list of strs, needed for some statistics
+            A list containing the filenames of hdf format files used to help
+            construct the coincident statistics. The files must have a 'stat'
+            attribute which is used to associate them with the appropriate
+            statistic class.
+
+        ifos: list of strs, needed for some statistics
+            The list of detector names
         """
         import h5py
 
@@ -78,6 +83,25 @@ class Stat(object):
             if key.startswith('sngl_ranking_'):
                 self.sngl_ranking_kwargs[key[13:]] = value            
 
+    def single(self, trigs): # pylint:disable=unused-argument
+        """
+        Calculate the single detector statistic, here equal to newsnr
+
+        Parameters
+        ----------
+        trigs: dict of numpy.ndarrays, h5py group (or similar dict-like object)
+            Dictionary-like object holding single detector trigger information.
+
+        Returns
+        -------
+        numpy.ndarray
+            The array of single detector values
+        """
+        err_msg = "This function is a stub that should be overridden by the "
+        err_msg += "sub-classes. You shouldn't be seeing this error!"
+        raise ValueError(err_msg)
+
+
     def sngl_ranking(self, trigs):
         """
         Returns the ranking for the single detector triggers.
@@ -99,13 +123,24 @@ class Stat(object):
         )
 
     def coinc(self, s, slide, step, to_shift,
-              **kwargs): # pylint:disable=unused-argument)
+              **kwargs): # pylint:disable=unused-argument
+        """
+        Calculate the coincident detection statistic.
+        """
         err_msg = "This function is a stub that should be overridden by the "
         err_msg += "sub-classes. You shouldn't be seeing this error!"
         raise ValueError(err_msg)
 
     def coinc_lim_for_thresh(self, s, thresh, limifo,
                              **kwargs): # pylint:disable=unused-argument
+        """
+        Optimization function to identify coincs too quiet to be of interest
+
+        Calculate the required single detector statistic to exceed
+        the threshold for each of the input triggers.
+        """
+
+
         err_msg = "This function is a stub that should be overridden by the "
         err_msg += "sub-classes. You shouldn't be seeing this error!"
         raise ValueError(err_msg)
@@ -153,7 +188,6 @@ class QuadratureSumStatistic(Stat):
         for idx in range(len(sngls_list)):
             cstat[sngls_list[idx] == -1] = 0
         return cstat
-
 
     def coinc_lim_for_thresh(self, s, thresh, limifo,
                              **kwargs): # pylint:disable=unused-argument

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -1804,6 +1804,35 @@ def insert_statistic_option_group(parser):
 
     return statistic_opt_group
 
+def parse_statistic_keywords_opt(stat_kwarg_list):
+    """
+    Parse the list of statistic keywords into an appropriate dictionary.
+
+    Take input from the input argument ["KWARG1:VALUE1", "KWARG2:VALUE2",
+    "KWARG3:VALUE3"] and convert into a dictionary.
+
+    Parameters
+    ----------
+    stat_kwarg_list : list
+        Statistic keywords in list format
+
+    Returns
+    -------
+    stat_kwarg_dict : dict
+        Statistic keywords in dict format
+    """
+    stat_kwarg_dict = {}
+    for inputstr in stat_kwarg_list:
+        try:
+            key, value = inputstr.split(':')
+            extra_kwargs[key] = value
+        except ValueError:
+            err_txt = "--statistic-keywords must take input in the " \
+                      "form KWARG1:VALUE1 KWARG2:VALUE2 KWARG3:VALUE3 ... " \
+                      "Received {}".format(opts.statistic_keywords)
+            raise ValueError(err_txt)
+
+    return stat_kwarg_dict
 
 def get_statistic_from_opts(opts, ifos):
     """
@@ -1825,19 +1854,16 @@ def get_statistic_from_opts(opts, ifos):
     class
         Subclass of Stat base class
     """
+    # Allow None inputs
+    if opts.statistic_files is None:
+        opts.statistic_files = []
+    if opts.statistic_keywords is None:
+        opts.statistic_keywords = []
+
     # flatten the list of lists of filenames to a single list (may be empty)
     opts.statistic_files = sum(opts.statistic_files, [])
 
-    extra_kwargs = {}
-    for inputstr in opts.statistic_keywords:
-        try:
-            key, value = inputstr.split(':')
-            extra_kwargs[key] = value
-        except ValueError:
-            err_txt = "--statistic-keywords must take input in the " \
-                      "form KWARG1:VALUE1 KWARG2:VALUE2 KWARG3:VALUE3 ... " \
-                      "Received {}".format(opts.statistic_keywords)
-            raise ValueError(err_txt)
+    extra_kwargs = parse_statistic_keywords_opt(opts.statistic_keywords)
 
     stat_class = get_statistic(opts.ranking_statistic)(
         opts.sngl_ranking,

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -292,7 +292,8 @@ class PhaseTDNewStatistic(QuadratureSumStatistic):
             The list of detector names
         """
 
-        QuadratureSumStatistic.__init__(self, files=files, ifos=ifos, **kwargs)
+        QuadratureSumStatistic.__init__(self, sngl_ranking, files=files,
+                                        ifos=ifos, **kwargs)
 
         self.single_dtype = [
             ('snglstat', numpy.float32),
@@ -650,7 +651,8 @@ class ExpFitStatistic(QuadratureSumStatistic):
 
         if not len(files):
             raise RuntimeError("Can't find any statistic files !")
-        QuadratureSumStatistic.__init__(self, files=files, ifos=ifos, **kwargs)
+        QuadratureSumStatistic.__init__(self, sngl_ranking, files=files,
+                                        ifos=ifos, **kwargs)
 
         # the stat file attributes are hard-coded as '%{ifo}-fit_coeffs'
         parsed_attrs = [f.split('-') for f in self.files.keys()]
@@ -892,7 +894,8 @@ class ExpFitCombinedSNR(ExpFitStatistic):
             The list of detector names
         """
 
-        ExpFitStatistic.__init__(self, files=files, ifos=ifos, **kwargs)
+        ExpFitStatistic.__init__(self, sngl_ranking, files=files, ifos=ifos,
+                                 **kwargs)
         # for low-mass templates the exponential slope alpha \approx 6
         self.alpharef = 6.
         self.single_increasing = True
@@ -1036,9 +1039,11 @@ class PhaseTDNewExpFitStatistic(PhaseTDNewStatistic, ExpFitCombinedSNR):
         """
 
         # read in both foreground PDF and background fit info
-        ExpFitCombinedSNR.__init__(self, files=files, ifos=ifos, **kwargs)
+        ExpFitCombinedSNR.__init__(self, sngl_ranking, files=files, ifos=ifos,
+                                   **kwargs)
         # need the self.single_dtype value from PhaseTDStatistic
-        PhaseTDNewStatistic.__init__(self, files=files, ifos=ifos, **kwargs)
+        PhaseTDNewStatistic.__init__(self, sngl_ranking, files=files,
+                                     ifos=ifos, **kwargs)
 
     def single(self, trigs):
         """
@@ -1155,7 +1160,8 @@ class ExpFitSGBgRateStatistic(ExpFitStatistic):
             The default comes from H1L1 (O2) and is 4.5e-7 Hz.
         """
 
-        super(ExpFitSGBgRateStatistic, self).__init__(files=files, ifos=ifos,
+        super(ExpFitSGBgRateStatistic, self).__init__(sngl_ranking,
+                                                      files=files, ifos=ifos,
                                                       **kwargs)
         self.benchmark_lograte = benchmark_lograte
         self.get_newsnr = ranking.get_newsnr_sgveto
@@ -1279,13 +1285,13 @@ class ExpFitSGFgBgNormNewStatistic(PhaseTDNewStatistic,
         """
 
         # read in background fit info and store it
-        ExpFitSGBgRateStatistic.__init__(self, files=files, ifos=ifos,
-                                         **kwargs)
+        ExpFitSGBgRateStatistic.__init__(self, sngl_ranking, files=files,
+                                         ifos=ifos, **kwargs)
         # if ifos not already set, determine via background fit info
         self.ifos = self.ifos or self.bg_ifos
         # PhaseTD statistic single_dtype plus network sensitivity benchmark
-        PhaseTDNewStatistic.__init__(self, files=files, ifos=self.ifos,
-                                     **kwargs)
+        PhaseTDNewStatistic.__init__(self, sngl_ranking, files=files,
+                                     ifos=self.ifos, **kwargs)
         self.single_dtype.append(('benchmark_logvol', numpy.float32))
 
         self.get_newsnr = ranking.get_newsnr_sgveto
@@ -1600,9 +1606,8 @@ class ExpFitSGPSDFgBgNormBBHStatistic(ExpFitSGFgBgNormNewStatistic):
             and we can have a case where a single highest-mass template might
             produce *all* the loudest background (and foreground) events.
         """
-
-        ExpFitSGFgBgNormNewStatistic.__init__(self, files=files, ifos=ifos,
-                                              **kwargs)
+        ExpFitSGFgBgNormNewStatistic.__init__(self, sngl_ranking, files=files,
+                                              ifos=ifos, **kwargs)
         self.get_newsnr = ranking.get_newsnr_sgveto_psdvar
         self.mcm = max_chirp_mass
         self.curr_mchirp = None

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -255,7 +255,7 @@ class QuadratureSumStatistic(Stat):
         """
         # Safety against subclassing and not rethinking this
         allowed_names = ['QuadratureSumStatistic']
-        if type(self).__name__ not in ['QuadratureSumStatistic']:
+        if type(self).__name__ not in allowed_names:
             err_msg = "This is being called from a subclass which has not "
             err_msg += "been checked for validity with this method. If it is "
             err_msg += "valid for the subclass to come here, include in the "
@@ -630,7 +630,7 @@ class ExpFitStatistic(NewSNRStatistic):
     template over single-ifo newsnr values.
     """
 
-    def __init__(self, files=None, ifos=None, **kwargs):
+    def __init__(self, sngl_ranking, files=None, ifos=None, **kwargs):
         """
         Create a statistic class instance
 
@@ -794,6 +794,40 @@ class ExpFitStatistic(NewSNRStatistic):
 
         return self.lognoiserate(trigs)
 
+    def single_multiifo(self, single_info):
+        """
+        Calculate the statistic for a single detector candidate
+        Parameters
+        ----------
+        single_info: tuple
+            Tuple containing two values. The first is the ifo (str) and the
+            second is the output from self.single()
+        Returns
+        -------
+        numpy.ndarray
+            The array of single detector statistics
+        """
+        err_msg = "Sorry! No-one has implemented this method yet! "
+        raise ValueError(err_msg)
+
+    def coinc(self, s, slide, step, to_shift,
+              **kwargs): # pylint:disable=unused-argument
+        """
+        Calculate the coincident detection statistic.
+        """
+        err_msg = "Sorry! No-one has implemented this method yet! "
+        raise ValueError(err_msg)
+
+    def coinc_lim_for_thresh(self, s, thresh, limifo,
+                             **kwargs): # pylint:disable=unused-argument
+        """
+        Optimization function to identify coincs too quiet to be of interest
+        Calculate the required single detector statistic to exceed
+        the threshold for each of the input triggers.
+        """
+        err_msg = "Sorry! No-one has implemented this method yet! "
+        raise ValueError(err_msg)
+
     # Keeping this here to help write the new coinc method.
     def coinc_OLD(self, s0, s1, slide, step): # pylint:disable=unused-argument
         """Calculate the final coinc ranking statistic"""
@@ -840,7 +874,7 @@ class ExpFitCombinedSNR(ExpFitStatistic):
     approximates combined (new)snr for coincs with similar newsnr in each ifo
     """
 
-    def __init__(self, files=None, ifos=None, **kwargs):
+    def __init__(self, sngl_ranking, files=None, ifos=None, **kwargs):
         """
         Create a statistic class instance
 
@@ -967,6 +1001,14 @@ class ExpFitCombinedSNR(ExpFitStatistic):
             Array of limits on the limifo single statistic to
             exceed thresh.
         """
+        # Safety against subclassing and not rethinking this
+        allowed_names = ['ExpFitCombinedSNR']
+        if type(self).__name__ not in allowed_names:
+            err_msg = "This is being called from a subclass which has not "
+            err_msg += "been checked for validity with this method. If it is "
+            err_msg += "valid for the subclass to come here, include in the "
+            err_msg += "list of allowed_names above."
+            raise ValueError(err_msg)
 
         return thresh * ((len(s) + 1) ** 0.5) - sum(sngl[1] for sngl in s)
 
@@ -977,7 +1019,7 @@ class PhaseTDNewExpFitStatistic(PhaseTDNewStatistic, ExpFitCombinedSNR):
     """
 
     # default is 2-ifo operation with exactly 1 'phasetd' file
-    def __init__(self, files=None, ifos=None, **kwargs):
+    def __init__(self, sngl_ranking, files=None, ifos=None, **kwargs):
         """
         Create a statistic class instance
 
@@ -1027,8 +1069,41 @@ class PhaseTDNewExpFitStatistic(PhaseTDNewStatistic, ExpFitCombinedSNR):
         singles['snr'] = trigs['snr'][:]
         return numpy.array(singles, ndmin=1)
 
-    # FIXME: Add new-style coinc functions here. I think currently this would
-    #        use parent classes and ignore the PhaseTD bit.
+    def single_multiifo(self, single_info):
+        """
+        Calculate the statistic for a single detector candidate
+        Parameters
+        ----------
+        single_info: tuple
+            Tuple containing two values. The first is the ifo (str) and the
+            second is the output from self.single()
+        Returns
+        -------
+        numpy.ndarray
+            The array of single detector statistics
+        """
+        err_msg = "Sorry! No-one has implemented this method yet! "
+        raise ValueError(err_msg)
+
+    def coinc(self, s, slide, step, to_shift,
+              **kwargs): # pylint:disable=unused-argument
+        """
+        Calculate the coincident detection statistic.
+        """
+        err_msg = "Sorry! No-one has implemented this method yet! "
+        raise ValueError(err_msg)
+
+    def coinc_lim_for_thresh(self, s, thresh, limifo,
+                             **kwargs): # pylint:disable=unused-argument
+        """
+        Optimization function to identify coincs too quiet to be of interest
+        Calculate the required single detector statistic to exceed
+        the threshold for each of the input triggers.
+        """
+        err_msg = "Sorry! No-one has implemented this method yet! "
+        raise ValueError(err_msg)
+
+    # Keeping the old statistic code here for now to help with reimplementing
     def coinc_OLD(self, s0, s1, slide, step):
         # logsignalrate function inherited from PhaseTDStatistic
         logr_s = self.logsignalrate(s0, s1, slide * step)
@@ -1060,9 +1135,8 @@ class ExpFitSGBgRateStatistic(ExpFitStatistic):
     template over single-ifo newsnr values.
     """
 
-    # FIXME: benchmark lograte is not used here, but time_addition is required
-    def __init__(self, files=None, ifos=None, benchmark_lograte=-14.6,
-                 **kwargs):
+    def __init__(self, sngl_ranking, files=None, ifos=None,
+                 benchmark_lograte=-14.6, **kwargs):
         """
         Create a statistic class instance
 
@@ -1077,10 +1151,11 @@ class ExpFitSGBgRateStatistic(ExpFitStatistic):
             statistic class.
         ifos: list of strs, not used here
             The list of detector names
+        benchmark_lograte: float, default=-14.6
+            benchmark_lograte is log of a representative noise trigger rate.
+            The default comes from H1L1 (O2) and is 4.5e-7 Hz.
         """
 
-        # benchmark_lograte is log of a representative noise trigger rate
-        # This comes from H1L1 (O2) and is 4.5e-7 Hz
         super(ExpFitSGBgRateStatistic, self).__init__(files=files, ifos=ifos,
                                                       **kwargs)
         self.benchmark_lograte = benchmark_lograte
@@ -1163,6 +1238,15 @@ class ExpFitSGBgRateStatistic(ExpFitStatistic):
             Array of limits on the limifo single statistic to
             exceed thresh.
         """
+
+        # Safety against subclassing and not rethinking this
+        allowed_names = ['ExpFitSGBgRateStatistic']
+        if type(self).__name__ not in allowed_names:
+            err_msg = "This is being called from a subclass which has not "
+            err_msg += "been checked for validity with this method. If it is "
+            err_msg += "valid for the subclass to come here, include in the "
+            err_msg += "list of allowed_names above."
+            raise ValueError(err_msg)
 
         sngl_dict = {sngl[0]: sngl[1] for sngl in s}
         sngl_dict[limifo] = numpy.zeros(len(s[0][1]))
@@ -1425,6 +1509,16 @@ class ExpFitSGFgBgNormNewStatistic(PhaseTDNewStatistic,
             exceed thresh.
         """
 
+        # Safety against subclassing and not rethinking this
+        allowed_names = ['ExpFitSGFgBgNormNewStatistic']
+        if type(self).__name__ not in allowed_names:
+            err_msg = "This is being called from a subclass which has not "
+            err_msg += "been checked for validity with this method. If it is "
+            err_msg += "valid for the subclass to come here, include in the "
+            err_msg += "list of allowed_names above."
+            raise ValueError(err_msg)
+
+
         if not self.has_hist:
             self.get_hist()
         # if the threshold is below this value all triggers will
@@ -1515,33 +1609,6 @@ class ExpFitSGPSDFgBgNormBBHStatistic(ExpFitSGFgBgNormNewStatistic):
         self.mcm = max_chirp_mass
         self.curr_mchirp = None
 
-    def single(self, trigs):
-        """
-        Calculate the necessary single detector information
-
-        In this case the ranking rescaled (see the lognoiserate method here)
-        with the phase, end time, sigma, SNR, template_id and the
-        benchmark_logvol values added in. This also stored the current chirp
-        mass for use when computing the coinc statistic values.
-
-        Parameters
-        ----------
-        trigs: dict of numpy.ndarrays, h5py group (or similar dict-like object)
-            Dictionary-like object holding single detector trigger information.
-
-        Returns
-        -------
-        numpy.ndarray
-            The array of single detector values
-        """
-        from pycbc.conversions import mchirp_from_mass1_mass2
-        self.curr_mchirp = mchirp_from_mass1_mass2(trigs.param['mass1'],
-                                                   trigs.param['mass2'])
-        if self.mcm is not None:
-            # Careful - input might be a str, so cast to float
-            self.curr_mchirp = min(self.curr_mchirp, float(self.mcm))
-        return ExpFitSGFgBgNormNewStatistic.single(self, trigs)
-
     def logsignalrate(self, stats, shift, to_shift):
         """
         Calculate the normalized log rate density of signals via lookup
@@ -1574,6 +1641,33 @@ class ExpFitSGPSDFgBgNormBBHStatistic(ExpFitSGFgBgNormNewStatistic):
                     )
         logr_s += numpy.log((self.curr_mchirp / 20.0) ** (11./3.0))
         return logr_s
+
+    def single(self, trigs):
+        """
+        Calculate the necessary single detector information
+
+        In this case the ranking rescaled (see the lognoiserate method here)
+        with the phase, end time, sigma, SNR, template_id and the
+        benchmark_logvol values added in. This also stored the current chirp
+        mass for use when computing the coinc statistic values.
+
+        Parameters
+        ----------
+        trigs: dict of numpy.ndarrays, h5py group (or similar dict-like object)
+            Dictionary-like object holding single detector trigger information.
+
+        Returns
+        -------
+        numpy.ndarray
+            The array of single detector values
+        """
+        from pycbc.conversions import mchirp_from_mass1_mass2
+        self.curr_mchirp = mchirp_from_mass1_mass2(trigs.param['mass1'],
+                                                   trigs.param['mass2'])
+        if self.mcm is not None:
+            # Careful - input might be a str, so cast to float
+            self.curr_mchirp = min(self.curr_mchirp, float(self.mcm))
+        return ExpFitSGFgBgNormNewStatistic.single(self, trigs)
 
     def coinc_lim_for_thresh(self, s, thresh, limifo,
                              **kwargs): # pylint:disable=unused-argument

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -147,6 +147,27 @@ class Stat(object):
         err_msg += "sub-classes. You shouldn't be seeing this error!"
         raise ValueError(err_msg)
 
+    def _check_coinc_lim_subclass(self, allowed_names):
+        """
+        Check that we are not using coinc_lim_for_thresh when not valid.
+
+        coinc_lim_for_thresh is only defined for the statistic it is present in.
+        If we subclass, we must check explicitly that it is still valid and indicate
+        this in the code. If the code does not have this explicit check you will
+        see the failure message here.
+
+        Parameters
+        -----------
+        allowed_names : list
+            list of allowed classes for the specific sub-classed method.
+        """
+        if type(self).__name__ not in allowed_names:
+            err_msg = "This is being called from a subclass which has not "
+            err_msg += "been checked for validity with this method. If it is "
+            err_msg += "valid for the subclass to come here, include in the "
+            err_msg += "list of allowed_names above."
+            raise ValueError(err_msg)
+
     def coinc_lim_for_thresh(self, s, thresh, limifo,
                              **kwargs): # pylint:disable=unused-argument
         """
@@ -251,12 +272,7 @@ class QuadratureSumStatistic(Stat):
         """
         # Safety against subclassing and not rethinking this
         allowed_names = ['QuadratureSumStatistic']
-        if type(self).__name__ not in allowed_names:
-            err_msg = "This is being called from a subclass which has not "
-            err_msg += "been checked for validity with this method. If it is "
-            err_msg += "valid for the subclass to come here, include in the "
-            err_msg += "list of allowed_names above."
-            raise ValueError(err_msg)
+        self._check_coinc_lim_subclass(allowed_names)
 
         s0 = thresh ** 2. - sum(sngl[1] ** 2. for sngl in s)
         s0[s0 < 0] = 0
@@ -1008,12 +1024,7 @@ class ExpFitCombinedSNR(ExpFitStatistic):
         """
         # Safety against subclassing and not rethinking this
         allowed_names = ['ExpFitCombinedSNR']
-        if type(self).__name__ not in allowed_names:
-            err_msg = "This is being called from a subclass which has not "
-            err_msg += "been checked for validity with this method. If it is "
-            err_msg += "valid for the subclass to come here, include in the "
-            err_msg += "list of allowed_names above."
-            raise ValueError(err_msg)
+        self._check_coinc_lim_subclass(allowed_names)
 
         return thresh * ((len(s) + 1) ** 0.5) - sum(sngl[1] for sngl in s)
 
@@ -1251,12 +1262,7 @@ class ExpFitSGBgRateStatistic(ExpFitStatistic):
 
         # Safety against subclassing and not rethinking this
         allowed_names = ['ExpFitSGBgRateStatistic']
-        if type(self).__name__ not in allowed_names:
-            err_msg = "This is being called from a subclass which has not "
-            err_msg += "been checked for validity with this method. If it is "
-            err_msg += "valid for the subclass to come here, include in the "
-            err_msg += "list of allowed_names above."
-            raise ValueError(err_msg)
+        self._check_coinc_lim_subclass(allowed_names)
 
         sngl_dict = {sngl[0]: sngl[1] for sngl in s}
         sngl_dict[limifo] = numpy.zeros(len(s[0][1]))
@@ -1522,12 +1528,7 @@ class ExpFitSGFgBgNormNewStatistic(PhaseTDNewStatistic,
 
         # Safety against subclassing and not rethinking this
         allowed_names = ['ExpFitSGFgBgNormNewStatistic']
-        if type(self).__name__ not in allowed_names:
-            err_msg = "This is being called from a subclass which has not "
-            err_msg += "been checked for validity with this method. If it is "
-            err_msg += "valid for the subclass to come here, include in the "
-            err_msg += "list of allowed_names above."
-            raise ValueError(err_msg)
+        self._check_coinc_lim_subclass(allowed_names)
 
         if not self.has_hist:
             self.get_hist()

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -101,6 +101,24 @@ class Stat(object):
         err_msg += "sub-classes. You shouldn't be seeing this error!"
         raise ValueError(err_msg)
 
+    def single_multiifo(self, single_info):
+        """
+        Calculate the statistic for a single detector candidate
+
+        Parameters
+        ----------
+        single_info: tuple
+            Tuple containing two values. The first is the ifo (str) and the
+            second is the output from self.single()
+
+        Returns
+        -------
+        numpy.ndarray
+            The array of single detector statistics
+        """
+        err_msg = "This function is a stub that should be overridden by the "
+        err_msg += "sub-classes. You shouldn't be seeing this error!"
+        raise ValueError(err_msg)
 
     def sngl_ranking(self, trigs):
         """
@@ -746,13 +764,32 @@ class ExpFitStatistic(NewSNRStatistic):
 
 
 class ExpFitCombinedSNR(ExpFitStatistic):
-    """Reworking of ExpFitStatistic designed to resemble network SNR
+    """
+    Reworking of ExpFitStatistic designed to resemble network SNR
 
     Use a monotonic function of the negative log noise rate density which
     approximates combined (new)snr for coincs with similar newsnr in each ifo
     """
 
     def __init__(self, files=None, ifos=None, **kwargs):
+        """
+        Create a statistic class instance
+
+        Parameters
+        ----------
+        sngl_ranking: str
+            The name of the ranking to use for the single-detector triggers.
+
+        files: list of strs, needed here
+            A list containing the filenames of hdf format files used to help
+            construct the coincident statistics. The files must have a 'stat'
+            attribute which is used to associate them with the appropriate
+            statistic class.
+
+        ifos: list of strs, not used here
+            The list of detector names
+        """
+
         ExpFitStatistic.__init__(self, files=files, ifos=ifos, **kwargs)
         # for low-mass templates the exponential slope alpha \approx 6
         self.alpharef = 6.

--- a/pycbc/io/hdf.py
+++ b/pycbc/io/hdf.py
@@ -493,7 +493,7 @@ class SingleDetTriggers(object):
             statistic_files = []
         # If this becomes memory intensive we can optimize
         stat_instance = statistic_dict[ranking_statistic](
-            sngl_ranking
+            sngl_ranking,
             statistic_files
         )
         stat = stat_instance.single_multiifo(self.trig_dict())

--- a/pycbc/io/hdf.py
+++ b/pycbc/io/hdf.py
@@ -496,7 +496,7 @@ class SingleDetTriggers(object):
             sngl_ranking,
             statistic_files
         )
-        stat = stat_instance.single_multiifo(self.trig_dict())
+        stat = stat_instance.single_multiifo((self.ifo, self.trig_dict()))
 
         # Used for naming in plots ... Seems an odd place for this to live!
         if sngl_ranking == "newsnr":

--- a/pycbc/io/hdf.py
+++ b/pycbc/io/hdf.py
@@ -488,7 +488,7 @@ class SingleDetTriggers(object):
         be considered."""
 
         # If this becomes memory intensive we can optimize
-        stat = rank_method.single_multiifo((self.ifo, self.trig_dict()))
+        stat = rank_method.rank_stat_single((self.ifo, self.trig_dict()))
 
         times = self.end_time
         index = stat.argsort()[::-1]


### PR DESCRIPTION
`stat.py` has become a little bit difficult to work with due to the large amount of classes now being needed to implement even minor changes. I want to rework this according to the pasted image. So far I've implemented this basically as illustrated below, with only those classes. It's possible this could be compressed further, but perhaps this is better? Clearly this PR will not work alone as we will need to remove completely the old stat executables, and hook the new ones up to the renamed methods here. However, I think it's worth seeing first if this is how we want this to look. I think there are some design choices here (most of the questions in red/green in the image) which are not obviously clear.

There's also the question of how to handle singles. At the moment, as I am removing the "sngl_statistic" concept from `stat.py` there are two places singles can get information. Either via the `single_multiifo` method for getting a full ranking statistic, or via the `get_ranking` function in `ranking.py` to access anything that can be computed from the trigger alone. Are these two places sufficient? If *only* `pycbc_multiifo_sngls_findtrigs` uses the `single_multiifo` method, is it okay that the plotting codes cannot get to exp_fitted singles ranking? Is a requirement to hook that up in some way?

When implementing `get_sngls_ranking_from_trigs` I first thought of doing something complicated allowing arbitrary extensions to the statistic name (or kwargs) to turn off/on things like sgveto, cuts, psdvar etc. However as the PSDvar affects the chi-squared these things are not all nicely orthogonal. As there are only a small enough number of these rankings at the moment anyway, I did not do the more involved thing. Perhaps at some point we would need to swap over, but I think that could be done ... Or maybe it needs doing now??

![IMG_20201124_142120](https://user-images.githubusercontent.com/11438929/100247905-c1217e00-2f32-11eb-9d82-15a48d1a001b.jpg)
