### PR TITLE
Emcee burnin test

### DIFF
--- a/pycbc/inference/burn_in.py
+++ b/pycbc/inference/burn_in.py
@@ -266,14 +266,14 @@ def chain_moments(sampler, estimate_len=200, sliding_len=10,
     burnin = []
     burn_in_list = {}
     for p in sampler.model.sampling_params:
-        chain_dim =len(numpy.shape(sampler.samples[p]))
+        chain_dim = len(numpy.shape(sampler.samples[p]))
         if chain_dim == 3:
-            nt,nw,nc = numpy.shape(sampler.samples[p])
+            nt, nw, nc = numpy.shape(sampler.samples[p])
             samples = sampler.samples[p][0]
         elif chain_dim == 2:
-            nw,nc = numpy.shape(sampler.samples[p])
+            nw, nc = numpy.shape(sampler.samples[p])
             samples = sampler.samples[p]
-        sigma=[]
+        sigma = []
         for item in range(int((nc-estimate_len)/sliding_len)):
             effsamp = \
                 samples[:, item:(item+1)*estimate_len].flatten()
@@ -286,7 +286,7 @@ def chain_moments(sampler, estimate_len=200, sliding_len=10,
         overrun_indices = numpy.where(abs(sigma_diff) > percent_deviation)[0]
         if len(overrun_indices) != 0:
             burnin.append(sliding_len*(len(sigma_rev)-overrun_indices.min()))
-            burn_in_list[p]=True
+            burn_in_list[p] = True
         elif len(overrun_indices) == 0:
             burn_in_iteration = 0
         else:
@@ -324,7 +324,7 @@ class BaseBurnInTests(object):
     def __init__(self, sampler, burn_in_test, **kwargs):
         self.sampler = sampler
         # determine the burn-in tests that are going to be done
-        all_tests=get_vars_from_arg(burn_in_test)
+        all_tests = get_vars_from_arg(burn_in_test)
         self.do_tests = [x for x in all_tests if x in self.available_tests]
         self.do_sampler_tests = [x for x in all_tests
                                 if x in self.available_sampler_tests]
@@ -640,7 +640,7 @@ class MCMCBurnInTests(BaseBurnInTests):
         """Applies estimate_sigma test"""
         test = 'chain_moments'
         sigmas, burn_in_iter, is_burned_in = chain_moments(self.sampler)
-        #if test is not in self.test_is_burned_in and burn_in_iter==0:
+        # if test is not in self.test_is_burned_in and burn_in_iter==0:
 
         self.test_is_burned_in[test] = is_burned_in
         self.test_aux_info[test] = sigmas
@@ -806,7 +806,7 @@ class EnsembleMCMCBurnInTests(BaseBurnInTests):
         """Applies estimate_sigma test"""
         test = 'chain_moments'
         sigmas, burn_in_iter, is_burned_in = chain_moments(self.sampler)
-        #if test is not in self.test_is_burned_in and burn_in_iter==0:
+        # if test is not in self.test_is_burned_in and burn_in_iter==0:
 
         self.test_is_burned_in[test] = is_burned_in
         self.test_aux_info[test] = sigmas
@@ -894,9 +894,6 @@ class EnsembleMultiTemperedMCMCBurnInTests(EnsembleMCMCBurnInTests):
         ``posterior_step`` function.
         """
         return _multitemper_getlogposts(self.sampler, filename)
-
-    #def chain_moments(self):
-    #    raise NotImplementedError("This Burn in test is not yet implemented")
 
 
 def _multitemper_getlogposts(sampler, filename):

--- a/pycbc/inference/burn_in.py
+++ b/pycbc/inference/burn_in.py
@@ -525,7 +525,7 @@ class BaseBurnInTests(object):
         fp.write_data('burn_in_iteration', self.burn_in_iteration, path)
         testgroup = 'burn_in_tests'
         # write individual test data
-        for tst in self.do_tests:
+        for tst in self.do_tests+self.do_sampler_tests:
             subpath = '/'.join([path, testgroup, tst])
             fp.write_data('is_burned_in', self.test_is_burned_in[tst], subpath)
             fp.write_data('burn_in_iteration',

--- a/pycbc/inference/burn_in.py
+++ b/pycbc/inference/burn_in.py
@@ -282,7 +282,7 @@ def chain_moments(sampler,estimate_len=200,sliding_len=10,percent_deviation=2):
             is_burned_in=False
     
     if len(burnin) != 0 and is_burned_in:
-        burn_in_iteration = 
+        burn_in_iteration = 0 #!FIXME 
         max(burnin)+estimate_len+sampler.iterations-nc
     else:
         burn_in_iteration = NOT_BURNED_IN_ITER
@@ -311,11 +311,11 @@ class BaseBurnInTests(object):
     def __init__(self, sampler, burn_in_test, **kwargs):
         self.sampler = sampler
         # determine the burn-in tests that are going to be done
-        all_test=get_vars_from_arg(burn_in_test)
-        self.do_test = [x for x in all_test if x in available_tests]
-        self.do_sampler_test = [x for x in all_test 
+        all_tests=get_vars_from_arg(burn_in_test)
+        self.do_tests = [x for x in all_tests if x in available_tests]
+        self.do_sampler_tests = [x for x in all_tests 
                                 if x in available_sampler_tests]
-        unrecognized_tests = (set(all_tests) - set(self.do_tests)) -
+        unrecognized_tests = (set(all_tests) - set(self.do_tests)) - \
                               set(self.do_sampler_tests)
         #Raise an error of the burn in test is not listed
         if unrecognized_tests:
@@ -627,7 +627,7 @@ class MCMCBurnInTests(BaseBurnInTests):
         """Applies estimate_sigma test"""
         test = 'chain_moments'
         sigmas,burn_in_iter,is_burned_in = chain_moments(self.sampler)
-        if test is not in self.test_is_burned_in and burn_in_iter==0:
+        #if test is not in self.test_is_burned_in and burn_in_iter==0:
             
         self.test_is_burned_in[test] = is_burned_in
         self.test_aux_info[test] = sigmas

--- a/pycbc/inference/sampler/base_mcmc.py
+++ b/pycbc/inference/sampler/base_mcmc.py
@@ -556,7 +556,7 @@ class BaseMCMC(object):
 
     def checkpoint(self):
         """Dumps current samples to the checkpoint file."""
-        #Perform the sampler burn in tests:
+        # Perform the sampler burn in tests:
         if self.burn_in is not None:
             logging.info("Updating sampler burn in")
             self.burn_in.evaluate_sampler()

--- a/pycbc/inference/sampler/base_mcmc.py
+++ b/pycbc/inference/sampler/base_mcmc.py
@@ -556,6 +556,10 @@ class BaseMCMC(object):
 
     def checkpoint(self):
         """Dumps current samples to the checkpoint file."""
+        #Perform the sampler burn in tests:
+        if self.burn_in is not None:
+            logging.info("Updating sampler burn in")
+            self.burn_in.evaluate_sampler()
         # thin and write new samples
         # get the updated thin interval to use
         thin_interval = self.get_thin_interval()


### PR DESCRIPTION
Introducing a burn in test for emcee type samplers. In this test, moments for different blocks of the chain are estimated (In this PR, only variance is introduced) for each parameter using a sliding window. When these moments become stable within a threshold for long enough, the chains are said to be converged. Based on the variation of these moments, the bun-in index is also estimated. This test, in current form, may fail for multi modal distributions though. I intend to work on this in future pull requests.