### PR TITLE
Added SPAtmplt option in _get_imr_duration

### DIFF
--- a/pycbc/pnutils.py
+++ b/pycbc/pnutils.py
@@ -518,11 +518,11 @@ def _get_imr_duration(m1, m2, s1z, s2z, f_low, approximant="SEOBNRv4"):
         # NB for no clear reason this function has f_low as first argument
         time_length = lalsimulation.SimIMRSEOBNRv4ROMTimeOfFrequency(
                            f_low, m1 * lal.MSUN_SI, m2 * lal.MSUN_SI, s1z, s2z)
-    elif approximant=='SPAtmplt' or approximant=='TaylorF2':
-        chi=lalsimulation.SimInspiralTaylorF2ReducedSpinComputeChi(m1,m2,s1z,s2z)
-        time_length=lalsimulation.SimInspiralTaylorF2ReducedSpinChirpTime(
-                           f_low, m1 * lal.MSUN_SI, m2 * lal.MSUN_SI, chi, -1)
-                       
+    elif approximant == 'SPAtmplt' or approximant == 'TaylorF2':
+        chi = lalsimulation.SimInspiralTaylorF2ReducedSpinComputeChi(
+                           m1,m2,s1z,s2z)
+        time_length = lalsimulation.SimInspiralTaylorF2ReducedSpinChirpTime(
+                           f_low, m1 * lal.MSUN_SI, m2 * lal.MSUN_SI, chi, -1)              
     else:
         raise RuntimeError("I can't calculate a duration for %s" % approximant)
     # FIXME Add an extra factor of 1.1 for 'safety' since the duration

--- a/pycbc/pnutils.py
+++ b/pycbc/pnutils.py
@@ -518,6 +518,11 @@ def _get_imr_duration(m1, m2, s1z, s2z, f_low, approximant="SEOBNRv4"):
         # NB for no clear reason this function has f_low as first argument
         time_length = lalsimulation.SimIMRSEOBNRv4ROMTimeOfFrequency(
                            f_low, m1 * lal.MSUN_SI, m2 * lal.MSUN_SI, s1z, s2z)
+    elif approximant == "SPAtmplt":
+        chi=lalsimulation.SimInspiralTaylorF2ReducedSpinComputeChi(m1,m2,s1z,s2z)
+        time_length=lalsimulation.SimInspiralTaylorF2ReducedSpinChirpTime(
+                           f_low, m1 * lal.MSUN_SI, m2 * lal.MSUN_SI, chi, -1)
+                       
     else:
         raise RuntimeError("I can't calculate a duration for %s" % approximant)
     # FIXME Add an extra factor of 1.1 for 'safety' since the duration

--- a/pycbc/pnutils.py
+++ b/pycbc/pnutils.py
@@ -519,10 +519,12 @@ def _get_imr_duration(m1, m2, s1z, s2z, f_low, approximant="SEOBNRv4"):
         time_length = lalsimulation.SimIMRSEOBNRv4ROMTimeOfFrequency(
                            f_low, m1 * lal.MSUN_SI, m2 * lal.MSUN_SI, s1z, s2z)
     elif approximant == 'SPAtmplt' or approximant == 'TaylorF2':
-        chi = lalsimulation.SimInspiralTaylorF2ReducedSpinComputeChi(m1, m2, s1z, s2z)
+        chi = lalsimulation.SimInspiralTaylorF2ReducedSpinComputeChi(
+            m1, m2, s1z, s2z
+        )
         time_length = lalsimulation.SimInspiralTaylorF2ReducedSpinChirpTime(
             f_low, m1 * lal.MSUN_SI, m2 * lal.MSUN_SI, chi, -1
-        )              
+        )
     else:
         raise RuntimeError("I can't calculate a duration for %s" % approximant)
     # FIXME Add an extra factor of 1.1 for 'safety' since the duration

--- a/pycbc/pnutils.py
+++ b/pycbc/pnutils.py
@@ -518,7 +518,7 @@ def _get_imr_duration(m1, m2, s1z, s2z, f_low, approximant="SEOBNRv4"):
         # NB for no clear reason this function has f_low as first argument
         time_length = lalsimulation.SimIMRSEOBNRv4ROMTimeOfFrequency(
                            f_low, m1 * lal.MSUN_SI, m2 * lal.MSUN_SI, s1z, s2z)
-    elif approximant == "SPAtmplt":
+    elif approximant=='SPAtmplt' or approximant=='TaylorF2':
         chi=lalsimulation.SimInspiralTaylorF2ReducedSpinComputeChi(m1,m2,s1z,s2z)
         time_length=lalsimulation.SimInspiralTaylorF2ReducedSpinChirpTime(
                            f_low, m1 * lal.MSUN_SI, m2 * lal.MSUN_SI, chi, -1)

--- a/pycbc/pnutils.py
+++ b/pycbc/pnutils.py
@@ -519,10 +519,10 @@ def _get_imr_duration(m1, m2, s1z, s2z, f_low, approximant="SEOBNRv4"):
         time_length = lalsimulation.SimIMRSEOBNRv4ROMTimeOfFrequency(
                            f_low, m1 * lal.MSUN_SI, m2 * lal.MSUN_SI, s1z, s2z)
     elif approximant == 'SPAtmplt' or approximant == 'TaylorF2':
-        chi = lalsimulation.SimInspiralTaylorF2ReducedSpinComputeChi(
-                           m1,m2,s1z,s2z)
+        chi = lalsimulation.SimInspiralTaylorF2ReducedSpinComputeChi(m1, m2, s1z, s2z)
         time_length = lalsimulation.SimInspiralTaylorF2ReducedSpinChirpTime(
-                           f_low, m1 * lal.MSUN_SI, m2 * lal.MSUN_SI, chi, -1)              
+            f_low, m1 * lal.MSUN_SI, m2 * lal.MSUN_SI, chi, -1
+        )              
     else:
         raise RuntimeError("I can't calculate a duration for %s" % approximant)
     # FIXME Add an extra factor of 1.1 for 'safety' since the duration


### PR DESCRIPTION
Modified the _get_imr_duration function inside 'pnutils' to include the approximant SPAtmplt (TaylorF2)
Thanks Tito for the help with git