### PR TITLE
Allow extract samples to handles nans

### DIFF
--- a/bin/inference/pycbc_inference_extract_samples
+++ b/bin/inference/pycbc_inference_extract_samples
@@ -51,14 +51,14 @@ def isthesame(current_val, val):
     """Checks that attrs values from two hdf files are the same (or nearly so).
     """
     if isinstance(current_val, float):
-        issame = numpy.isclose(current_val, val)
+        issame = numpy.isclose(current_val, val, equal_nan=True)
     elif isinstance(current_val, numpy.ndarray):
         # sort before comparing
         current_val = numpy.sort(current_val)
         val = numpy.sort(val)
         try:
             # in case of floats, just check that they're close
-            issame = numpy.isclose(current_val, val)
+            issame = numpy.isclose(current_val, val, equal_nan=True)
         except TypeError:
             # wasn't float, do direct comparison
             issame = current_val == val


### PR DESCRIPTION
When extracting posteriors, `pycbc_extract_samples` will do some checks on the metadata to make sure the two files can be merged. This check will even happen when a single file is given, in which case it's just checking values against itself.

An issue that arises is that if a one or more values are nans, `numpy.isclose` will by default return False. This causes extract samples to fail when working on some dynesty files, in which the dlogz is nan. This sometimes happens when constraints are used; I'm not certain why. In any event, this patch allows extract samples to still work in this case by telling `numpy.isclose` to treat two nans as being equal.