### PR TITLE
add method option to project wave to use alternate approximations

### DIFF
--- a/pycbc/detector.py
+++ b/pycbc/detector.py
@@ -290,7 +290,7 @@ class Detector(object):
             Declination of source location
         polarization: float
             Polarization angle of the source
-        method: str, Optional
+        method: {'lal', 'constant', 'vary_polarization'}
             The method to use for projecting the polarizations into the
             detector frame. Default is 'lal'.
         reference_time: float, Optional
@@ -326,9 +326,10 @@ class Detector(object):
             if method == 'constant':
                 time = rtime
             elif method == 'vary_polarization':
-                if not isinstance(hp, TimeSeries):
-                    raise TypeError('Polarizations must be given as time'
-                                    ' series for this method')
+                if (not isinstance(hp, TimeSeries) or
+                    not isinstance(hc, TimeSeries)):
+                    raise TypeError('Waveform polarizations must be given'
+                                    ' as time series for this method')
 
                 # this is more granular than needed, may be optimized later
                 # assume earth rotation in ~30 ms needed for earth ceneter

--- a/pycbc/detector.py
+++ b/pycbc/detector.py
@@ -277,6 +277,26 @@ class Detector(object):
         Apply the time shift for the given detector relative to the assumed
         geocentric frame and apply the antenna patterns to the plus and cross
         polarizations.
+
+        Parameters
+        ----------
+        hp: pycbc.types.TimeSeries
+            Plus polarization of the GW
+        hc: pycbc.types.TimeSeries
+            Cross polarization of the GW
+        ra: float
+            Right ascension of source location
+        dec: float
+            Declination of source location
+        polarization: float
+            Polarization angle of the source
+        method: str, Optional
+            The method to use for projecting the polarizations into the
+            detector frame. Default is 'lal'.
+        reference_time: float, Optional
+            The time to use as, a reference for some methods of projection.
+            Used by 'constant' and 'vary_polarization' methods. Uses average
+            time if not provided.
         """
         # The robust and most fefature rich method which includes
         # time changing antenna patterns and doppler shifts due to the

--- a/pycbc/detector.py
+++ b/pycbc/detector.py
@@ -327,7 +327,7 @@ class Detector(object):
                 time = rtime
             elif method == 'vary_polarization':
                 if (not isinstance(hp, TimeSeries) or
-                    not isinstance(hc, TimeSeries)):
+                   not isinstance(hc, TimeSeries)):
                     raise TypeError('Waveform polarizations must be given'
                                     ' as time series for this method')
 


### PR DESCRIPTION
This adds two additional methods to the 'project_wave' method of the Detector class. These allow for more approximant ways to project the polarizations into the detector frame. The purpose is for testing different approximations in likelihoods and like-for-like cross comparisons. The two methods are (1) a basic apply constant factor for the polarizations (2) allow fp/fc to vary over time. Neither includes doppler corrections like the default 'lal' method does.

 For reference (1) seems to be the dominant correction for signals of length several hours. I am seeing the mismatch between the result from the 'lal' method and the 'constant' decreased by an order of magnitude when applying only the time varying polarization corrections. 

I am not doing so now, but I may consider adding in another version with some doppler corrections for the earth rotation, if it turns out interesting to include in likelihoods. 