### PR TITLE
add option to set detector projection method in the injection file

### DIFF
--- a/pycbc/inject/inject.py
+++ b/pycbc/inject/inject.py
@@ -98,9 +98,14 @@ def projector(inj, hp, hc, distance_scale=1):
         hp_tapered = hp
         hc_tapered = hc
 
+    projection_method = 'lal'
+    if hasattr(inj, 'detector_projection_method'):
+        projection_method = inj.detector_projection_method
+
     # compute the detector response and add it to the strain
     signal = detector.project_wave(hp_tapered, hc_tapered,
-                         inj.ra, inj.dec, inj.polarization)
+                         inj.ra, inj.dec, inj.polarization,
+                         method=projection_method)
     return signal
 
 def legacy_approximant_name(apx):

--- a/pycbc/inject/inject.py
+++ b/pycbc/inject/inject.py
@@ -93,8 +93,12 @@ def projector(detector_name, inj, hp, hc, distance_scale=1):
     hp /= distance_scale
     hc /= distance_scale
 
-    hp.start_time += inj.tc
-    hc.start_time += inj.tc
+    try:
+        hp.start_time += inj.tc
+        hc.start_time += inj.tc
+    except:
+        hp.start_time += inj.get_time_geocent()
+        hc.start_time += inj.get_time_geocent()
 
     # taper the polarizations
     try:

--- a/pycbc/inject/inject.py
+++ b/pycbc/inject/inject.py
@@ -95,9 +95,13 @@ def projector(detector_name, inj, hp, hc, distance_scale=1):
 
     try:
         tc = inj.tc
+        ra = inj.ra
+        dec = inj.dec
     except:
-        tc = inj.get_time_geocent() 
-    
+        tc = inj.get_time_geocent()
+        ra = inj.longitude
+        dec = inj.latitude
+
     hp.start_time += tc
     hc.start_time += tc
 
@@ -117,7 +121,7 @@ def projector(detector_name, inj, hp, hc, distance_scale=1):
 
     # compute the detector response and add it to the strain
     signal = detector.project_wave(hp_tapered, hc_tapered,
-                                   inj.ra, inj.dec, inj.polarization,
+                                   ra, dec, inj.polarization,
                                    method=projection_method)
     return signal
 

--- a/pycbc/inject/inject.py
+++ b/pycbc/inject/inject.py
@@ -94,11 +94,12 @@ def projector(detector_name, inj, hp, hc, distance_scale=1):
     hc /= distance_scale
 
     try:
-        hp.start_time += inj.tc
-        hc.start_time += inj.tc
+        tc = inj.tc
     except:
-        hp.start_time += inj.get_time_geocent()
-        hc.start_time += inj.get_time_geocent()
+        tc = inj.get_time_geocent() 
+    
+    hp.start_time += tc
+    hc.start_time += tc
 
     # taper the polarizations
     try:
@@ -112,7 +113,7 @@ def projector(detector_name, inj, hp, hc, distance_scale=1):
     if hasattr(inj, 'detector_projection_method'):
         projection_method = inj.detector_projection_method
 
-    logging.info('Injecting at %s, method is %s', inj.tc, projection_method)
+    logging.info('Injecting at %s, method is %s', tc, projection_method)
 
     # compute the detector response and add it to the strain
     signal = detector.project_wave(hp_tapered, hc_tapered,

--- a/pycbc/inject/inject.py
+++ b/pycbc/inject/inject.py
@@ -85,6 +85,9 @@ def set_sim_data(inj, field, data):
 
 
 def projector(detector_name, inj, hp, hc, distance_scale=1):
+    """ Use the injection row to project the polarizations into the
+    detector frame
+    """
     detector = Detector(detector_name)
 
     hp /= distance_scale
@@ -109,8 +112,8 @@ def projector(detector_name, inj, hp, hc, distance_scale=1):
 
     # compute the detector response and add it to the strain
     signal = detector.project_wave(hp_tapered, hc_tapered,
-                         inj.ra, inj.dec, inj.polarization,
-                         method=projection_method)
+                                   inj.ra, inj.dec, inj.polarization,
+                                   method=projection_method)
     return signal
 
 def legacy_approximant_name(apx):


### PR DESCRIPTION
This enables a 'detector_projection_method' option to set the option used in project wave. It can be done on an injection by injection basis as any other configuration coming from an hdf config file. 