### PR TITLE
pycbc_process_sngls: fix error when using `--store-bank-values`

### DIFF
--- a/bin/pycbc_process_sngls
+++ b/bin/pycbc_process_sngls
@@ -116,7 +116,6 @@ if args.store_bank_values:
         outgroup[n] = getattr(sngls, n)[out_idx]
 
 # copy the live time segments to enable the calculation of trigger rates
-# FIXME should we change these when vetoes are applied?
 outgroup['search/start_time'] = sngls.trigs['search/start_time'][:]
 outgroup['search/end_time'] = sngls.trigs['search/end_time'][:]
 

--- a/bin/pycbc_process_sngls
+++ b/bin/pycbc_process_sngls
@@ -6,6 +6,7 @@ import h5py, numpy, argparse, logging
 from pycbc.io import hdf
 from pycbc.events import stat, coinc
 
+
 parser = argparse.ArgumentParser(description=__doc__)
 
 parser.add_argument('--single-trig-file', required=True,
@@ -44,9 +45,6 @@ args = parser.parse_args()
 
 logging.basicConfig(format='%(asctime)s %(message)s', level=logging.INFO)
 
-outfile = h5py.File(args.output_file, 'w')
-outgroup = outfile.create_group(args.detector)
-
 # Munge together SNR cut and any other filter specified
 snr_filter = 'self.snr>%f' % (args.min_snr) if args.min_snr > 0. else None 
 filts = [f for f in [snr_filter, args.filter_string] if f is not None]
@@ -59,10 +57,10 @@ else:
     filter_func = None
 
 if filter_func is not None:
-    logging.info('Will filter trigs using %s' % filter_func)
+    logging.info('Will filter trigs using %s', filter_func)
 # Filter will be stored as self.mask attribute of sngls instance
-sngls = hdf.SingleDetTriggers(args.single_trig_file, args.bank_file,\
-                              args.veto_file, args.segment_name, filter_func,\
+sngls = hdf.SingleDetTriggers(args.single_trig_file, args.bank_file,
+                              args.veto_file, args.segment_name, filter_func,
                               args.detector)
 
 if args.statname is not None:
@@ -76,7 +74,10 @@ else:
     logging.info('Using SNR for clustering, if requested')
     stat = sngls.snr
 
-logging.info('%i stat values found' % len(stat))
+logging.info('%i stat values found', len(stat))
+
+outfile = h5py.File(args.output_file, 'w')
+outgroup = outfile.create_group(args.detector)
 
 if args.cluster_window is not None:
     logging.info('Clustering over time')
@@ -86,15 +87,15 @@ if args.cluster_window is not None:
 else:
     out_idx = numpy.arange(len(sngls.end_time))
 
-logging.info('Writing %i triggers' % len(out_idx))
+logging.info('Writing %i triggers', len(out_idx))
 
 # get the columns to copy over
 with h5py.File(args.single_trig_file, 'r') as trigfile:
     cnames = []
     # only keep datasets parallel to the original trigger list
     for n, col in trigfile[args.detector].items():
-        if n.endswith('_template') or isinstance(col, h5py.Group) or\
-                                                   n == u'template_boundaries':
+        if n.endswith('_template') or isinstance(col, h5py.Group) \
+                or n == u'template_boundaries':
             continue
         cnames.append(n)
 for n in cnames:
@@ -103,6 +104,10 @@ for n in cnames:
 if args.store_bank_values:
     for n in sngls.bank:
         if n == 'template_hash':
+            continue
+        if not hasattr(sngls, n):
+            logging.warn("Bank's %s dataset or group is not supported "
+                         "by SingleDetTriggers, ignoring it", n)
             continue
         outgroup[n] = sngls.get_column(n)[out_idx]
 

--- a/bin/pycbc_process_sngls
+++ b/bin/pycbc_process_sngls
@@ -109,7 +109,11 @@ if args.store_bank_values:
             logging.warn("Bank's %s dataset or group is not supported "
                          "by SingleDetTriggers, ignoring it", n)
             continue
-        outgroup[n] = sngls.get_column(n)[out_idx]
+        # don't repeat things that already came from the trigger file
+        # (e.g. template_duration)
+        if n in cnames:
+            continue
+        outgroup[n] = getattr(sngls, n)[out_idx]
 
 # cannot store None in a h5py attr
 outgroup.attrs['filter'] = filter_func or 'None'

--- a/bin/pycbc_process_sngls
+++ b/bin/pycbc_process_sngls
@@ -115,6 +115,11 @@ if args.store_bank_values:
             continue
         outgroup[n] = getattr(sngls, n)[out_idx]
 
+# copy the live time segments to enable the calculation of trigger rates
+# FIXME should we change these when vetoes are applied?
+outgroup['search/start_time'] = sngls.trigs['search/start_time'][:]
+outgroup['search/end_time'] = sngls.trigs['search/end_time'][:]
+
 # cannot store None in a h5py attr
 outgroup.attrs['filter'] = filter_func or 'None'
 outgroup.attrs['cluster_window'] = args.cluster_window or 'None'

--- a/pycbc/io/hdf.py
+++ b/pycbc/io/hdf.py
@@ -586,6 +586,11 @@ class SingleDetTriggers(object):
         return self.bank['f_lower'][:][self.template_id]
 
     @property
+    def approximant(self):
+        self.checkbank('approximant')
+        return self.bank['approximant'][:][self.template_id]
+
+    @property
     def mtotal(self):
         return self.mass1 + self.mass2
 


### PR DESCRIPTION
`pycbc_process_sngls` can crash when called with `--store-bank-values`. It tries to call `SingleDetTriggers.get_column()` for every dataset in the bank file, however not all possible bank datasets are accessible as properties of `SingleDetTriggers`. In particular, the error I got happened because of the `approximant` dataset.

This PR adds a check to `pycbc_process_sngls` so that unsupported bank datasets just print a warning and are ignored, instead of producing an exception. In addition, it:
* Adds the `approximant` property to `SingleDetTriggers`, which seems useful to have.
* Postpones the creation of the output file to reduce the chance of creating bogus empty files in case of early errors.
* Carries over the `search/start_time` and `search/end_time` datasets, which makes it easier to calculate trigger rates using only the output file.
* Cleans up the code a bit.