### PR TITLE
Add getitem to singledettrigs

### DIFF
--- a/bin/plotting/pycbc_plot_singles_vs_params
+++ b/bin/plotting/pycbc_plot_singles_vs_params
@@ -131,9 +131,7 @@ if opts.z_var == 'density':
     fig.colorbar(hb, ticks=LogLocator(subs=range(10)))
 elif opts.z_var in ranking.sngls_ranking_function_dict:
     cb_style = {}
-    # FIXME: This seems wrong, we probably want the SingleDetTriggers class
-    #        to autocall into the ranking. Might try to fix.
-    z = getattr(trigs, opts.z_var) 
+    z = trigs.get_ranking(opts.z_var)
 
     z = z[mask]
     min_z = z.min() if opts.min_z is None else opts.min_z

--- a/pycbc/io/hdf.py
+++ b/pycbc/io/hdf.py
@@ -10,6 +10,7 @@ import inspect
 from itertools import chain
 from six.moves import range
 from six.moves import cPickle as pickle
+from six import raise_from
 
 from io import BytesIO
 from lal import LIGOTimeGPS, YRJUL_SI
@@ -460,10 +461,9 @@ class SingleDetTriggers(object):
         try:
             self.checkbank(key)
             return self.bank[key][:][self.template_id]
-        except RuntimeError:
+        except RuntimeError as exc:
             err_msg = "Cannot find {} in input files".format(key)
-            raise ValueError(err_msg)
-
+            raise_from(ValueError(err_msg), exc)
 
     def checkbank(self, param):
         if self.bank == {}:

--- a/pycbc/io/hdf.py
+++ b/pycbc/io/hdf.py
@@ -448,6 +448,23 @@ class SingleDetTriggers(object):
             logging.info('%i triggers remain after cut on %s',
                          sum(self.mask), filter_func)
 
+    def __getitem__(self, key):
+        # Is key in the TRIGGER_MERGE file?
+        try:
+            vals = self.get_column(key)
+            return vals
+        except KeyError:
+            pass
+
+        # Is key in the bank file?
+        try:
+            self.checkbank(key)
+            return self.bank[key][:][self.template_id]
+        except RuntimeError:
+            err_msg = "Cannot find {} in input files".format(key)
+            raise ValueError(err_msg)
+        
+
     def checkbank(self, param):
         if self.bank == {}:
             return RuntimeError("Can't get %s values without a bank file"
@@ -652,6 +669,9 @@ class SingleDetTriggers(object):
         return ranking.newsnr_sgveto_psdvar_threshold(self.snr, self.rchisq,
                                            self.sgchisq, self.psd_var_val)
 
+    def get_ranking(self, rank_name, **kwargs):
+        return ranking.get_sngls_ranking_from_trigs(self, rank_name, **kwargs)
+
     def get_column(self, cname):
         # Fiducial value that seems to work, not extensively tuned.
         MFRAC = 0.3
@@ -669,6 +689,7 @@ class SingleDetTriggers(object):
             return self.trigs[cname][:][self.mask]
         else:
             return self.trigs[cname][:]
+
 
 class ForegroundTriggers(object):
     # FIXME: A lot of this is hardcoded to expect two ifos
@@ -977,6 +998,7 @@ class ForegroundTriggers(object):
         outdoc.childNodes[0].appendChild(sngl_inspiral_table)
 
         ligolw_utils.write_filename(outdoc, file_name)
+
 
 class ReadByTemplate(object):
     # default assignment to {} is OK for a variable used only in __init__

--- a/pycbc/io/hdf.py
+++ b/pycbc/io/hdf.py
@@ -463,7 +463,7 @@ class SingleDetTriggers(object):
         except RuntimeError:
             err_msg = "Cannot find {} in input files".format(key)
             raise ValueError(err_msg)
-        
+
 
     def checkbank(self, param):
         if self.bank == {}:

--- a/pycbc/io/hdf.py
+++ b/pycbc/io/hdf.py
@@ -452,8 +452,7 @@ class SingleDetTriggers(object):
     def __getitem__(self, key):
         # Is key in the TRIGGER_MERGE file?
         try:
-            vals = self.get_column(key)
-            return vals
+            return self.get_column(key)
         except KeyError:
             pass
 
@@ -461,7 +460,7 @@ class SingleDetTriggers(object):
         try:
             self.checkbank(key)
             return self.bank[key][:][self.template_id]
-        except RuntimeError as exc:
+        except (RuntimeError, KeyError) as exc:
             err_msg = "Cannot find {} in input files".format(key)
             raise_from(ValueError(err_msg), exc)
 


### PR DESCRIPTION
I left one FIXME in #3535. Here I try to resolve it. In particular I want pycbc_plot_singles_vs_params to be able to use the new `ranking.py` interface for ranking singles. This uses the `SingleDetTriggers` class, which cannot easily access this. To fix this I add a new `get_ranking` method, which calls directly to `ranking.py`. However, to ensure that `SingleDetTriggers` is in the format that `ranking.py` expects, I added a `__getitem__` method. This might be useful in other places this code is used as well (for e.g. @titodalcanton 's changes in pycbc_process_sngls).

This doesn't need any config changes, but does fix some edge cases where pycbc_plot_singles_vs_params would fail when it's help would claim it would succeed (which was also true before the changes in #3535).