### PR TITLE
Cleanup PyCBC Live example

### DIFF
--- a/examples/live/.gitignore
+++ b/examples/live/.gitignore
@@ -1,0 +1,5 @@
+strain/
+temp_strain/
+template_bank.hdf
+test_inj1.hdf
+test_inj2.hdf

--- a/examples/live/check_results.py
+++ b/examples/live/check_results.py
@@ -6,7 +6,7 @@ import logging as log
 import numpy as np
 import h5py
 import pycbc
-from pycbc.io import record
+from pycbc.io import FieldArray
 from glue.ligolw import utils as ligolw_utils
 from glue.ligolw import ligolw, lsctables
 
@@ -143,7 +143,7 @@ def check_coinc_results():
     dtype = [('mass1', float), ('mass2', float),
              ('spin1z', float), ('spin2z', float),
              ('tc', float), ('net_snr', float)]
-    trig_props = record.FieldArray(n_coincs, dtype=dtype)
+    trig_props = FieldArray(n_coincs, dtype=dtype)
 
     # store properties of coincident triggers
     for x, ctrigfp in enumerate(coinc_trig_paths):

--- a/examples/live/check_results.py
+++ b/examples/live/check_results.py
@@ -10,13 +10,14 @@ from pycbc.io import record
 from glue.ligolw import utils as ligolw_utils
 from glue.ligolw import ligolw, lsctables
 
+
 # dummy class needed for loading LIGOLW files
 class LIGOLWContentHandler(ligolw.LIGOLWContentHandler):
     pass
-      
+
 def close(a, b, c):
     return abs(a - b) <= c
-   
+
 def check_single_results(tested_detectors):
     single_fail = False
     with h5py.File('template_bank.hdf', 'r') as bankf:
@@ -26,7 +27,7 @@ def check_single_results(tested_detectors):
         temp_s2z = bankf['spin2z'][:]
 
     detectors_with_trigs = set()
-      
+
     trig_paths = sorted(glob.glob('output/????_??_??/*.hdf'))
     for trigfp in trig_paths:
         with h5py.File(trigfp, 'r') as trigf:
@@ -87,7 +88,7 @@ def check_single_results(tested_detectors):
                 test_s1z = close(temp_s1z[trig_temp_id], trig_s1z, 1e-7)
                 test_s2z = close(temp_s2z[trig_temp_id], trig_s2z, 1e-7)
                 test_all = np.logical_and.reduce((test_mass1, test_mass2,
-                                              test_s1z, test_s2z))
+                                                  test_s1z, test_s2z))
                 if not test_all.all():
                     log.error('Invalid template parameters in %s %s',
                               trigfp, detector)
@@ -98,26 +99,26 @@ def check_single_results(tested_detectors):
         missing = sorted(tested_detectors - detectors_with_trigs)
         log.error('No triggers found in %s', ', '.join(missing))
         single_fail = True
-      
+
     if single_fail:
         log.error('Single Trigger Test Failed')
     return single_fail
 
 
 def check_coinc_results():
-    coinc_fail = False    
+    coinc_fail = False
     # gather coincident triggers
     coinc_trig_paths = sorted(glob.glob('output/coinc*.xml.gz'))
-    n_coincs=len(coinc_trig_paths)
-    if n_coincs==0:
+    n_coincs = len(coinc_trig_paths)
+    if n_coincs == 0:
         log.error('No coincident triggers detected')
         coinc_fail = True
-    elif n_coincs>=10: 
+    elif n_coincs >= 10:
         log.error('Too many coincident triggers detected')
         coinc_fail = True
-    else: 
+    else:
         log.info('%d coincident trigger(s) detected', n_coincs)
-      
+
     injs = sorted(glob.glob('test_inj*.hdf'))
     n_injs = len(injs)
     inj_mass1 = np.empty(n_injs)
@@ -125,7 +126,7 @@ def check_coinc_results():
     inj_spin1z = np.empty(n_injs)
     inj_spin2z = np.empty(n_injs)
     inj_time = np.empty(n_injs)
-    
+
     for idx, inj_path in enumerate(injs):
         with h5py.File(inj_path, 'r') as inj:
             inj_mass1[idx] = inj['mass1'][0]
@@ -133,90 +134,83 @@ def check_coinc_results():
             inj_spin1z[idx] = inj['spin1z'][0]
             inj_spin2z[idx] = inj['spin2z'][0]
             inj_time[idx] = inj['tc'][0]
-         
-    
-    if n_injs > n_coincs :
+
+    if n_injs > n_coincs:
         log.error('More injections than coincident triggers')
         coinc_fail = True
-              
-      
-    #create field array to store properties of triggers
-    trig_props = record.FieldArray(n_coincs, dtype=[('mass1', float), \
-                ('mass2', float), ('spin1z', float), ('spin2z', float), \
-                ('tc', float), ('net_snr', float)])
-      
-    #store properties of coincident triggers
+
+    # create field array to store properties of triggers
+    dtype = [('mass1', float), ('mass2', float),
+             ('spin1z', float), ('spin2z', float),
+             ('tc', float), ('net_snr', float)]
+    trig_props = record.FieldArray(n_coincs, dtype=dtype)
+
+    # store properties of coincident triggers
     for x, ctrigfp in enumerate(coinc_trig_paths):
         log.info('Checking trigger %s', ctrigfp)
         xmldoc = ligolw_utils.load_filename(
-                  ctrigfp, False, contenthandler=LIGOLWContentHandler)
+            ctrigfp, False, contenthandler=LIGOLWContentHandler)
         sngl_inspiral_table = lsctables.SnglInspiralTable.get_table(xmldoc)
-        
-        trig_props['tc'][x]=sngl_inspiral_table.get_column('end_time')[0]                   
-        trig_props['mass1'][x]=sngl_inspiral_table.get_column('mass1')[0]
-        trig_props['mass2'][x]=sngl_inspiral_table.get_column('mass2')[0]    
-        trig_props['spin1z'][x]=sngl_inspiral_table.get_column('spin1z')[0] 
-        trig_props['spin2z'][x]=sngl_inspiral_table.get_column('spin2z')[0] 
-        
-        
-        snr_list=sngl_inspiral_table.get_column('snr')
-        network_snr = sum([snr ** 2 for snr in snr_list]) ** 0.5      
-        trig_props['net_snr'][x]=network_snr
-            
-        
-        log.info('IFO SNRs: '+str(snr_list))
-        log.info('Network SNR: %f', network_snr)
-        log.info('IFO End Time: %f', trig_props['tc'][x]) 
+
+        trig_props['tc'][x] = sngl_inspiral_table.get_column('end_time')[0]
+        trig_props['mass1'][x] = sngl_inspiral_table.get_column('mass1')[0]
+        trig_props['mass2'][x] = sngl_inspiral_table.get_column('mass2')[0]
+        trig_props['spin1z'][x] = sngl_inspiral_table.get_column('spin1z')[0]
+        trig_props['spin2z'][x] = sngl_inspiral_table.get_column('spin2z')[0]
+
+        snr_list = sngl_inspiral_table.get_column('snr')
+        trig_props['net_snr'][x] = sum(snr_list ** 2) ** 0.5
+
+        log.info('IFO SNRs: %s', snr_list)
+        log.info('Network SNR: %f', trig_props['net_snr'][x])
+        log.info('IFO End Time: %f', trig_props['tc'][x])
         log.info('Mass 1: %f', trig_props['mass1'][x])
         log.info('Mass 2: %f', trig_props['mass2'][x])
         log.info('Spin1z: %f', trig_props['spin1z'][x])
         log.info('Spin2z: %f', trig_props['spin2z'][x])
-     
 
     # check if injections match trigger params
     for i in range(n_injs):
         has_match = False
         for j in range(n_coincs):
-            if (close(inj_time[i],trig_props['tc'][j],1.0) and close(inj_mass1[i], trig_props['mass1'][j], 5e-7)
-            and close(inj_mass2[i], trig_props['mass2'][j], 5e-7) and close(inj_spin1z[i], trig_props['spin1z'][j], 5e-7)
-            and close(inj_spin2z[i], trig_props['spin2z'][j], 5e-7) and close(15.0, trig_props['net_snr'][j], 1.0)):
+            if (close(inj_time[i], trig_props['tc'][j], 1.0)
+                    and close(inj_mass1[i], trig_props['mass1'][j], 5e-7)
+                    and close(inj_mass2[i], trig_props['mass2'][j], 5e-7)
+                    and close(inj_spin1z[i], trig_props['spin1z'][j], 5e-7)
+                    and close(inj_spin2z[i], trig_props['spin2z'][j], 5e-7)
+                    and close(15.0, trig_props['net_snr'][j], 1.0)):
                 has_match = True
                 break
-        
+
         if not has_match:
             coinc_fail = True
-            log.error('Injection %i has no match',i)
-            
+            log.error('Injection %i has no match', i)
+
     if coinc_fail:
         log.error('Coincident Trigger Test Failed')
     return coinc_fail
 
-      
 
 log.basicConfig(level=log.INFO, format='%(asctime)s %(message)s')
 
 # gps times need to match those found in run.sh
 sim_gps_start = 1272790000
-sim_gps_end =  1272790500
+sim_gps_end = 1272790500
 
 # sim f lower needs to match the value in generate_injection.sh
 sim_f_lower = 18
 
-
-fail = False
 lsctables.use_in(LIGOLWContentHandler)
 
-       
 tested_detectors = {'H1', 'L1', 'V1'}
-   
+
 single_fail = check_single_results(tested_detectors)
 coinc_fail = check_coinc_results()
 fail = single_fail or coinc_fail
-   
+
 if fail:
-      log.error('Test Failed')
+    log.error('Test Failed')
 else:
-      log.info('Test Passed')
- 
+    log.info('Test Passed')
 
 sys.exit(1 if fail else 0)

--- a/examples/live/generate_injections.py
+++ b/examples/live/generate_injections.py
@@ -1,26 +1,28 @@
 #!/usr/bin/env python
 
-import os, sys
-from pycbc.io import record
+import os
+import sys
+from pycbc.io import FieldArray
 from pycbc.inject import InjectionSet
+
 
 if os.path.exists('./test_inj1.hdf'):
     raise OSError("output-file 1 already exists")
-    
+
 if os.path.exists('./test_inj2.hdf'):
     raise OSError("output-file 2 already exists")
 
-    
-# injection 1    
-static_params = { 'f_lower': 18.0, 'f_ref': 18.0, 'approximant': 'SEOBNRv4', 
-               'taper': 'start', 'ra': 45.0, 'dec': 45.0, 'inclination': 0.0, 
-               'coa_phase': 0.0, 'polarization': 0.0}
+dtype = [('mass1', float), ('mass2', float),
+         ('spin1z', float), ('spin2z', float),
+         ('tc', float), ('distance', float)]
 
-samples = record.FieldArray(2, dtype=[('mass1', float), ('mass2', float), 
-                                      ('spin1z', float), ('spin2z', float), 
-                                      ('tc', float), ('distance', float)])
+# injection 1
+static_params = {'f_lower': 18.0, 'f_ref': 18.0, 'approximant': 'SEOBNRv4',
+                 'taper': 'start', 'ra': 45.0, 'dec': 45.0,
+                 'inclination': 0.0, 'coa_phase': 0.0, 'polarization': 0.0}
 
-    
+samples = FieldArray(2, dtype=dtype)
+
 # The following 'magic numbers' are intended to match the highest
 # mass injection in the template bank
 samples['mass1'] = [290.929321]
@@ -29,22 +31,15 @@ samples['spin1z'] = [0.9934847]
 samples['spin2z'] = [0.92713535]
 samples['tc'] = [1272790100.1]
 samples['distance'] = [603.0]
-     
-InjectionSet.write('test_inj1.hdf', samples, static_args = static_params,
-                   injtype = 'cbc', cmd=" ".join(sys.argv))
 
+InjectionSet.write('test_inj1.hdf', samples, static_args=static_params,
+                   injtype='cbc', cmd=" ".join(sys.argv))
 
+# injection 2
+static_params['approximant'] = 'SpinTaylorT4'
 
-#injection 2    
-static_params = { 'f_lower': 18.0, 'f_ref': 18.0, 'approximant': 'SpinTaylorT4', 
-               'taper': 'start', 'ra': 45.0, 'dec': 45.0, 'inclination': 0.0, 
-               'coa_phase': 0.0, 'polarization': 0.0}
+samples = FieldArray(2, dtype=dtype)
 
-samples = record.FieldArray(2, dtype=[('mass1', float), ('mass2', float), 
-                                      ('spin1z', float), ('spin2z', float), 
-                                      ('tc', float), ('distance', float)])
-
-    
 # The following 'magic numbers' are intended to match the lowest
 # mass injection in the template bank
 samples['mass1'] = [1.1331687]
@@ -53,6 +48,6 @@ samples['spin1z'] = [0.029544285]
 samples['spin2z'] = [0.020993788]
 samples['tc'] = [1272790260.1]
 samples['distance'] = [72.0]
-     
-InjectionSet.write('test_inj2.hdf', samples, static_args = static_params,
-                   injtype = 'cbc', cmd=" ".join(sys.argv))
+
+InjectionSet.write('test_inj2.hdf', samples, static_args=static_params,
+                   injtype='cbc', cmd=" ".join(sys.argv))

--- a/examples/live/generate_injections.py
+++ b/examples/live/generate_injections.py
@@ -21,7 +21,7 @@ static_params = {'f_lower': 18.0, 'f_ref': 18.0, 'approximant': 'SEOBNRv4',
                  'taper': 'start', 'ra': 45.0, 'dec': 45.0,
                  'inclination': 0.0, 'coa_phase': 0.0, 'polarization': 0.0}
 
-samples = FieldArray(2, dtype=dtype)
+samples = FieldArray(1, dtype=dtype)
 
 # The following 'magic numbers' are intended to match the highest
 # mass injection in the template bank
@@ -30,7 +30,7 @@ samples['mass2'] = [3.6755455]
 samples['spin1z'] = [0.9934847]
 samples['spin2z'] = [0.92713535]
 samples['tc'] = [1272790100.1]
-samples['distance'] = [603.0]
+samples['distance'] = [301.5]
 
 InjectionSet.write('test_inj1.hdf', samples, static_args=static_params,
                    injtype='cbc', cmd=" ".join(sys.argv))
@@ -38,7 +38,7 @@ InjectionSet.write('test_inj1.hdf', samples, static_args=static_params,
 # injection 2
 static_params['approximant'] = 'SpinTaylorT4'
 
-samples = FieldArray(2, dtype=dtype)
+samples = FieldArray(1, dtype=dtype)
 
 # The following 'magic numbers' are intended to match the lowest
 # mass injection in the template bank
@@ -47,7 +47,7 @@ samples['mass2'] = [1.010624]
 samples['spin1z'] = [0.029544285]
 samples['spin2z'] = [0.020993788]
 samples['tc'] = [1272790260.1]
-samples['distance'] = [72.0]
+samples['distance'] = [36.0]
 
 InjectionSet.write('test_inj2.hdf', samples, static_args=static_params,
                    injtype='cbc', cmd=" ".join(sys.argv))

--- a/examples/live/run.sh
+++ b/examples/live/run.sh
@@ -11,7 +11,6 @@ gps_start_time=1272790000
 gps_end_time=1272790500
 
 
-
 # test if there is a template bank. If not, make one
 
 if [[ ! -f template_bank.hdf ]]
@@ -38,7 +37,8 @@ then
 
     mv template_bank_0.hdf template_bank.hdf
     rm -f template_bank_*.hdf
-else echo -e "\\n\\n>> [`date`] Pre-existing template bank found"
+else
+    echo -e "\\n\\n>> [`date`] Pre-existing template bank found"
 fi
 
 
@@ -48,38 +48,30 @@ fi
 if [[ -f test_inj1.hdf && -f test_inj2.hdf ]]
 then
     echo -e "\\n\\n>> [`date`] Pre-existing Injection Found"
-else echo -e "\\n\\n>> [`date`] Generating injection"
+else
+    echo -e "\\n\\n>> [`date`] Generating injection"
 
-    if [[ -f test_inj1.hdf ]]
-    then rm test_inj1.hdf
-    fi
-    
-    if [[ -f test_inj2.hdf ]]
-    then rm test_inj2.hdf
-    fi
-    
-    if [[ -d ./strain ]]
-    then rm -r ./strain
-    fi
-    
-     ./generate_injections.py
+    rm -f test_inj1.hdf
+    rm -f test_inj2.hdf
+    rm -rf ./strain
+
+    ./generate_injections.py
 fi
-
 
 
 # test if strain files exist. If they dont, make them
 
 if [[ ! -d ./strain ]]
-then        
+then
     echo -e "\\n\\n>> [`date`] Generating simulated strain"
-    
+
     function simulate_strain { # detector PSD_model random_seed
         mkdir -p temp_strain/$1
         mkdir -p strain/$1
-        
+
         (( t1=$gps_start_time-10 ))
         (( t2=$gps_end_time+10 ))
-        
+
         pycbc_condition_strain \
             --fake-strain $2 \
             --fake-strain-seed $3 \
@@ -90,8 +82,8 @@ then
             --low-frequency-cutoff 10 \
             --channel-name $1:SIMULATED_STRAIN \
             --frame-duration 32 \
-            --injection-file 'test_inj1.hdf'
-            
+            --injection-file test_inj1.hdf
+
         pycbc_condition_strain \
             --frame-files temp_strain/$1/* \
             --output-strain-file "strain/$1/$1-SIMULATED_STRAIN-{start}-{duration}.gwf" \
@@ -101,20 +93,18 @@ then
             --low-frequency-cutoff 10 \
             --channel-name $1:SIMULATED_STRAIN \
             --frame-duration 32 \
-            --injection-file 'test_inj2.hdf'
-
+            --injection-file test_inj2.hdf
     }
     simulate_strain H1 aLIGOMidLowSensitivityP1200087 1234
     simulate_strain L1 aLIGOMidLowSensitivityP1200087 2345
     simulate_strain V1 AdVEarlyLowSensitivityP1200087 3456
-else echo -e "\\n\\n>> [`date`] Pre-existing strain data found"
+else
+    echo -e "\\n\\n>> [`date`] Pre-existing strain data found"
 fi
 
 
 # delete old outputs if they exist
-if [[ -d ./output ]]
-then rm -r ./output
-fi
+rm -rf ./output
 
 
 echo -e "\\n\\n>> [`date`] Running PyCBC Live"


### PR DESCRIPTION
This is a cleanup PR paving the way for less trivial upcoming changes to the PyCBC Live example/test. Most of the PR is just white space and formatting stuff which I did not want to mix with less trivial changes. However, I also noticed that each injection was being done twice (effectively halving its luminosity distance). I fixed that by actually doing a single injection at the right distance.