### PR TITLE
Simplify injections in PyCBC Live's example

### DIFF
--- a/examples/live/.gitignore
+++ b/examples/live/.gitignore
@@ -1,5 +1,4 @@
 strain/
-temp_strain/
 template_bank.hdf
-test_inj1.hdf
-test_inj2.hdf
+injections.hdf
+output/

--- a/examples/live/generate_injections.py
+++ b/examples/live/generate_injections.py
@@ -1,53 +1,30 @@
 #!/usr/bin/env python
 
-import os
 import sys
 from pycbc.io import FieldArray
 from pycbc.inject import InjectionSet
 
 
-if os.path.exists('./test_inj1.hdf'):
-    raise OSError("output-file 1 already exists")
-
-if os.path.exists('./test_inj2.hdf'):
-    raise OSError("output-file 2 already exists")
-
 dtype = [('mass1', float), ('mass2', float),
          ('spin1z', float), ('spin2z', float),
-         ('tc', float), ('distance', float)]
+         ('tc', float), ('distance', float),
+         ('approximant', 'S32')]
 
-# injection 1
-static_params = {'f_lower': 18.0, 'f_ref': 18.0, 'approximant': 'SEOBNRv4',
+static_params = {'f_lower': 18.0, 'f_ref': 18.0,
                  'taper': 'start', 'ra': 45.0, 'dec': 45.0,
                  'inclination': 0.0, 'coa_phase': 0.0, 'polarization': 0.0}
 
-samples = FieldArray(1, dtype=dtype)
+samples = FieldArray(2, dtype=dtype)
 
 # The following 'magic numbers' are intended to match the highest
-# mass injection in the template bank
-samples['mass1'] = [290.929321]
-samples['mass2'] = [3.6755455]
-samples['spin1z'] = [0.9934847]
-samples['spin2z'] = [0.92713535]
-samples['tc'] = [1272790100.1]
-samples['distance'] = [301.5]
+# and lowest mass templates in the template bank
+samples['mass1'] = [290.929321, 1.1331687]
+samples['mass2'] = [3.6755455, 1.010624]
+samples['spin1z'] = [0.9934847, 0.029544285]
+samples['spin2z'] = [0.92713535, 0.020993788]
+samples['tc'] = [1272790100.1, 1272790260.1]
+samples['distance'] = [301.5, 36.0]
+samples['approximant'] = ['SEOBNRv4', 'SpinTaylorT4']
 
-InjectionSet.write('test_inj1.hdf', samples, static_args=static_params,
-                   injtype='cbc', cmd=" ".join(sys.argv))
-
-# injection 2
-static_params['approximant'] = 'SpinTaylorT4'
-
-samples = FieldArray(1, dtype=dtype)
-
-# The following 'magic numbers' are intended to match the lowest
-# mass injection in the template bank
-samples['mass1'] = [1.1331687]
-samples['mass2'] = [1.010624]
-samples['spin1z'] = [0.029544285]
-samples['spin2z'] = [0.020993788]
-samples['tc'] = [1272790260.1]
-samples['distance'] = [36.0]
-
-InjectionSet.write('test_inj2.hdf', samples, static_args=static_params,
+InjectionSet.write('injections.hdf', samples, static_args=static_params,
                    injtype='cbc', cmd=" ".join(sys.argv))

--- a/examples/live/run.sh
+++ b/examples/live/run.sh
@@ -42,17 +42,15 @@ else
 fi
 
 
-# test if there is a inj file. If not, make one.
-# if a new inj is made, delete old strain
+# test if there is a injection file.
+# If not, make one and delete any existing strain
 
-if [[ -f test_inj1.hdf && -f test_inj2.hdf ]]
+if [[ -f injections.hdf ]]
 then
-    echo -e "\\n\\n>> [`date`] Pre-existing Injection Found"
+    echo -e "\\n\\n>> [`date`] Pre-existing injections found"
 else
-    echo -e "\\n\\n>> [`date`] Generating injection"
+    echo -e "\\n\\n>> [`date`] Generating injections"
 
-    rm -f test_inj1.hdf
-    rm -f test_inj2.hdf
     rm -rf ./strain
 
     ./generate_injections.py
@@ -66,35 +64,23 @@ then
     echo -e "\\n\\n>> [`date`] Generating simulated strain"
 
     function simulate_strain { # detector PSD_model random_seed
-        mkdir -p temp_strain/$1
         mkdir -p strain/$1
 
-        (( t1=$gps_start_time-10 ))
-        (( t2=$gps_end_time+10 ))
+        out_path="strain/$1/$1-SIMULATED_STRAIN-{start}-{duration}.gwf"
 
         pycbc_condition_strain \
             --fake-strain $2 \
             --fake-strain-seed $3 \
-            --output-strain-file "temp_strain/$1/$1-TEMP-{start}-{duration}.gwf" \
-            --gps-start-time $t1 \
-            --gps-end-time $t2 \
-            --sample-rate 16384 \
-            --low-frequency-cutoff 10 \
-            --channel-name $1:SIMULATED_STRAIN \
-            --frame-duration 32 \
-            --injection-file test_inj1.hdf
-
-        pycbc_condition_strain \
-            --frame-files temp_strain/$1/* \
-            --output-strain-file "strain/$1/$1-SIMULATED_STRAIN-{start}-{duration}.gwf" \
-            --gps-start-time $gps_start_time  \
+            --output-strain-file $out_path \
+            --gps-start-time $gps_start_time \
             --gps-end-time $gps_end_time \
             --sample-rate 16384 \
             --low-frequency-cutoff 10 \
             --channel-name $1:SIMULATED_STRAIN \
             --frame-duration 32 \
-            --injection-file test_inj2.hdf
+            --injection-file injections.hdf
     }
+
     simulate_strain H1 aLIGOMidLowSensitivityP1200087 1234
     simulate_strain L1 aLIGOMidLowSensitivityP1200087 2345
     simulate_strain V1 AdVEarlyLowSensitivityP1200087 3456


### PR DESCRIPTION
Due to previous limitations of the HDF injection code, which have been addressed a while ago, the PyCBC Live example used to make two injections in two separate rounds, calling `pycbc_condition_strain` twice and slowing down the test. This is no longer necessary, the injections can be done in a single round.

Note that I am using `S32` as the dtype for the approximant field, which is a bit annoying. If I use `str`, the injection code is unable to read the approximant.

Fixes #3395.