### PR TITLE
add method to add custom detector

### DIFF
--- a/pycbc/detector.py
+++ b/pycbc/detector.py
@@ -107,6 +107,7 @@ def add_detector_on_earth(name, longitude, latitude, orientation=0, height=0):
                                       'response': response,
                                       }
 
+
 class Detector(object):
     """A gravitational wave detector
     """
@@ -125,8 +126,8 @@ class Detector(object):
         self.name = str(detector_name)
 
         if detector_name in [pfx for pfx, name in get_available_detectors()]:
-            import lalsimulation
-            self.frDetector = lalsimulation.DetectorPrefixToLALDetector(self.name)
+            import lalsimulation as lalsim
+            self.frDetector = lalsim.DetectorPrefixToLALDetector(self.name)
             self.response = self.frDetector.response
             self.location = self.frDetector.location
         elif detector_name in _custom_ground_detectors:

--- a/pycbc/detector.py
+++ b/pycbc/detector.py
@@ -28,7 +28,6 @@
 """This module provides utilities for calculating detector responses and timing
 between observatories.
 """
-import lalsimulation
 import numpy as np
 import lal
 from pycbc.types import TimeSeries
@@ -79,12 +78,16 @@ class Detector(object):
         calculate the time for each gps time requested explicitly
         using a slower but higher precision method.
         """
-        self.name = str(detector_name)
-        self.frDetector = lalsimulation.DetectorPrefixToLALDetector(self.name)
-        self.response = self.frDetector.response
-        self.location = self.frDetector.location
-        self.latitude = self.frDetector.frDetector.vertexLatitudeRadians
-        self.longitude = self.frDetector.frDetector.vertexLongitudeRadians
+        if detector_name in [pfx for pfx, name in get_available_detectors()]:
+            import lalsimulation
+            self.name = str(detector_name)
+            self.frDetector = lalsimulation.DetectorPrefixToLALDetector(self.name)
+            self.response = self.frDetector.response
+            self.location = self.frDetector.location
+            self.latitude = self.frDetector.frDetector.vertexLatitudeRadians
+            self.longitude = self.frDetector.frDetector.vertexLongitudeRadians
+        else:
+            raise ValueError("Unkown detector {}".format(detector_name))
 
         self.reference_time = reference_time
         self.sday = None
@@ -302,6 +305,7 @@ class Detector(object):
         # time changing antenna patterns and doppler shifts due to the
         # earth rotation and orbit
         if method == 'lal':
+            import lalsimulation
             h_lal = lalsimulation.SimDetectorStrainREAL8TimeSeries(
                     hp.astype(np.float64).lal(), hc.astype(np.float64).lal(),
                     ra, dec, polarization, self.frDetector)

--- a/pycbc/detector.py
+++ b/pycbc/detector.py
@@ -151,8 +151,8 @@ class Detector(object):
                                         self.location[1],
                                         self.location[2],
                                         unit=meter)
-        self.latitude = loc.latitude.rad
-        self.longitude = loc.longitude.rad
+        self.latitude = loc.lat.rad
+        self.longitude = loc.lon.rad
 
         self.reference_time = reference_time
         self.sday = None


### PR DESCRIPTION
This adds a method to add a custom detector on the earth defined by its lat/lon and the orientation defined as the azimuthal angle of the y-arm (so 0 is y-arm pointing due north). The patch also makes lalsimulation optional for this module. 