### PR TITLE
Add more info to offline GraceDB uploads

### DIFF
--- a/bin/pycbc_upload_xml_to_gracedb
+++ b/bin/pycbc_upload_xml_to_gracedb
@@ -49,6 +49,8 @@ parser.add_argument("--psd-files", nargs='+', required=True,
                     help='HDF file(s) containing the PSDs to upload')
 parser.add_argument('--input-file', required=True, type=str,
                     help='Input LIGOLW XML file of coincidences.')
+parser.add_argument('--log-message', type=str, metavar='MESSAGE',
+                    help='Add a log entry to each upload with the given message')
 parser.add_argument('--testing', action="store_true", default=False,
                     help="Upload event to the TEST group of gracedb.")
 parser.add_argument('--min-ifar', type=float, metavar='YEARS',
@@ -180,6 +182,10 @@ for event in coinc_table:
     input_file_str = 'Candidate uploaded from ' \
         + os.path.abspath(args.input_file)
     gracedb.writeLog(r['graceid'], input_file_str)
+
+    # add the custom log message, if provided
+    if args.log_message is not None:
+        gracedb.writeLog(r['graceid'], args.log_message)
 
     xmldoc.childNodes[-1].removeChild(coinc_event_table_curr)
     xmldoc.childNodes[-1].removeChild(coinc_inspiral_table_curr)

--- a/bin/pycbc_upload_xml_to_gracedb
+++ b/bin/pycbc_upload_xml_to_gracedb
@@ -20,6 +20,7 @@
 Take a coinc xml file containing multiple events and upload to gracedb.
 """
 
+import os
 import argparse
 import logging
 from ligo.gracedb.rest import GraceDb
@@ -33,8 +34,9 @@ from glue.ligolw import ligolw
 from glue.ligolw import table
 from glue.ligolw import lsctables
 from glue.ligolw import utils as ligolw_utils
-from glue.ligolw.utils import process as ligolw_process
 from ligo.segments import segment, segmentlist
+from pycbc import version as pycbc_version
+
 
 class LIGOLWContentHandler(ligolw.LIGOLWContentHandler):
     pass
@@ -45,8 +47,7 @@ logging.basicConfig(format='%(asctime)s:%(levelname)s : %(message)s',
 parser = argparse.ArgumentParser(description=__doc__)
 parser.add_argument("--psd-files", nargs='+', required=True,
                     help='HDF file(s) containing the PSDs to upload')
-parser.add_argument('--input-file', dest='input_file',
-                    required=True, type=str,
+parser.add_argument('--input-file', required=True, type=str,
                     help='Input LIGOLW XML file of coincidences.')
 parser.add_argument('--testing', action="store_true", default=False,
                     help="Upload event to the TEST group of gracedb.")
@@ -160,10 +161,26 @@ for event in coinc_table:
         r = gracedb.createEvent("CBC", "pycbc", "tmp_coinc_xml_file.xml",
                                 search="AllSky", offline=True).json()
     logging.info("Uploaded event %s.", r["graceid"])
+
+    # upload PSD
     gracedb.writeLog(
         r["graceid"], "PyCBC PSD estimate from the time of event",
         "psd.xml.gz", open("tmp_psd.xml.gz", "rb").read(), "psd").json()
     logging.info("Uploaded file psd.xml.gz to event %s.", r["graceid"])
+
+    # add info for tracking code version
+    version_str = 'Using PyCBC version {}{} at {}'
+    version_str = version_str.format(
+            pycbc_version.version,
+            ' (release)' if pycbc_version.release else '',
+            os.path.dirname(pycbc.__file__))
+    gracedb.writeLog(r['graceid'], version_str)
+
+    # document the absolute path to the input file
+    input_file_str = 'Candidate uploaded from ' \
+        + os.path.abspath(args.input_file)
+    gracedb.writeLog(r['graceid'], input_file_str)
+
     xmldoc.childNodes[-1].removeChild(coinc_event_table_curr)
     xmldoc.childNodes[-1].removeChild(coinc_inspiral_table_curr)
     xmldoc.childNodes[-1].removeChild(coinc_event_map_table_curr)

--- a/bin/pycbc_upload_xml_to_gracedb
+++ b/bin/pycbc_upload_xml_to_gracedb
@@ -35,7 +35,7 @@ from glue.ligolw import table
 from glue.ligolw import lsctables
 from glue.ligolw import utils as ligolw_utils
 from ligo.segments import segment, segmentlist
-from pycbc import version as pycbc_version
+from pycbc.io.live import gracedb_tag_with_version
 
 
 class LIGOLWContentHandler(ligolw.LIGOLWContentHandler):
@@ -171,12 +171,7 @@ for event in coinc_table:
     logging.info("Uploaded file psd.xml.gz to event %s.", r["graceid"])
 
     # add info for tracking code version
-    version_str = 'Using PyCBC version {}{} at {}'
-    version_str = version_str.format(
-            pycbc_version.version,
-            ' (release)' if pycbc_version.release else '',
-            os.path.dirname(pycbc.__file__))
-    gracedb.writeLog(r['graceid'], version_str)
+    gracedb_tag_with_version(gracedb, r['graceid'])
 
     # document the absolute path to the input file
     input_file_str = 'Candidate uploaded from ' \
@@ -185,7 +180,8 @@ for event in coinc_table:
 
     # add the custom log message, if provided
     if args.log_message is not None:
-        gracedb.writeLog(r['graceid'], args.log_message)
+        gracedb.writeLog(r['graceid'], args.log_message,
+                         tag_name=['analyst_comments'])
 
     xmldoc.childNodes[-1].removeChild(coinc_event_table_curr)
     xmldoc.childNodes[-1].removeChild(coinc_inspiral_table_curr)

--- a/pycbc/io/live.py
+++ b/pycbc/io/live.py
@@ -17,6 +17,7 @@ from pycbc.results import ifo_color
 from pycbc.results import source_color
 from pycbc.mchirp_area import calc_probabilities
 
+
 #FIXME Legacy build PSD xml helpers, delete me when we move away entirely from
 # xml formats
 def _build_series(series, dim_names, comment, delta_name, delta_unit):
@@ -416,12 +417,7 @@ class SingleCoincForGraceDB(object):
             logging.info("Uploaded PSDs for event %s", gid)
 
             # add info for tracking code version
-            version_str = 'Using PyCBC version {}{} at {}'
-            version_str = version_str.format(
-                    pycbc_version.version,
-                    ' (release)' if pycbc_version.release else '',
-                    os.path.dirname(pycbc.__file__))
-            gracedb.writeLog(gid, version_str)
+            gracedb_tag_with_version(gracedb, gid)
 
             extra_strings = [] if extra_strings is None else extra_strings
             for text in extra_strings:
@@ -458,4 +454,15 @@ class SingleCoincForGraceDB(object):
 
         return gid
 
-__all__ = ['SingleCoincForGraceDB', 'make_psd_xmldoc', 'snr_series_to_xml']
+def gracedb_tag_with_version(gracedb, event_id):
+    """Add a GraceDB log entry reporting PyCBC's version and install location.
+    """
+    version_str = 'Using PyCBC version {}{} at {}'
+    version_str = version_str.format(
+            pycbc_version.version,
+            ' (release)' if pycbc_version.release else '',
+            os.path.dirname(pycbc.__file__))
+    gracedb.writeLog(event_id, version_str)
+
+__all__ = ['SingleCoincForGraceDB', 'make_psd_xmldoc', 'snr_series_to_xml',
+           'gracedb_tag_with_version']


### PR DESCRIPTION
This tags each offline GraceDB upload with a PyCBC version string and install path, and the absolute path to the input file which provided the candidate. It also adds a `--log-message` option which can be used to add an extra message to the log (e.g. `--log-message 'Candidate from hyperbank search on HLV C01 data'`).

Example: https://gracedb-playground.ligo.org/events/T368754/view/