### PR TITLE
simplify strain from cli, move injections after resample

### DIFF
--- a/examples/live/run.sh
+++ b/examples/live/run.sh
@@ -101,6 +101,7 @@ mpirun \
 -x PYTHONPATH -x LD_LIBRARY_PATH -x OMP_NUM_THREADS -x VIRTUAL_ENV -x PATH -x HDF5_USE_FILE_LOCKING \
 \
 python -m mpi4py `which pycbc_live` \
+--verbose \
 --bank-file template_bank.hdf \
 --sample-rate 2048 \
 --enable-bank-start-frequency \

--- a/examples/live/run.sh
+++ b/examples/live/run.sh
@@ -41,7 +41,6 @@ else
     echo -e "\\n\\n>> [`date`] Pre-existing template bank found"
 fi
 
-
 # test if there is a injection file.
 # If not, make one and delete any existing strain
 
@@ -87,7 +86,6 @@ then
 else
     echo -e "\\n\\n>> [`date`] Pre-existing strain data found"
 fi
-
 
 # delete old outputs if they exist
 rm -rf ./output

--- a/examples/live/run.sh
+++ b/examples/live/run.sh
@@ -41,6 +41,7 @@ else
     echo -e "\\n\\n>> [`date`] Pre-existing template bank found"
 fi
 
+
 # test if there is a injection file.
 # If not, make one and delete any existing strain
 
@@ -87,6 +88,7 @@ else
     echo -e "\\n\\n>> [`date`] Pre-existing strain data found"
 fi
 
+
 # delete old outputs if they exist
 rm -rf ./output
 
@@ -99,7 +101,6 @@ mpirun \
 -x PYTHONPATH -x LD_LIBRARY_PATH -x OMP_NUM_THREADS -x VIRTUAL_ENV -x PATH -x HDF5_USE_FILE_LOCKING \
 \
 python -m mpi4py `which pycbc_live` \
---verbose \
 --bank-file template_bank.hdf \
 --sample-rate 2048 \
 --enable-bank-start-frequency \

--- a/pycbc/filter/resample.py
+++ b/pycbc/filter/resample.py
@@ -151,7 +151,7 @@ def resample_to_delta_t(timeseries, delta_t, method='butterworth'):
         data = lal_data.data.data
 
     elif method == 'ldas':
-        factor = int(delta_t / timeseries.delta_t)
+        factor = int(round(delta_t / timeseries.delta_t))
         numtaps = factor * 20 + 1
 
         # The kaiser window has been testing using the LDAS implementation

--- a/pycbc/filter/resample.py
+++ b/pycbc/filter/resample.py
@@ -142,7 +142,7 @@ def resample_to_delta_t(timeseries, delta_t, method='butterworth'):
     if timeseries.kind is not 'real':
         raise TypeError("Time series must be real")
 
-    if timeseries.delta_t == delta_t:
+    if timeseries.sample_rate_close(1.0 / delta_t):
         return timeseries * 1
 
     if method == 'butterworth':

--- a/pycbc/strain/strain.py
+++ b/pycbc/strain/strain.py
@@ -234,7 +234,7 @@ def from_cli(opt, dyn_range_fac=1, precision='single',
                                             opt.gps_start_time - opt.pad_data,
                                             opt.gps_end_time + opt.pad_data)
 
-    if opt.fake_strain or opt.fake_strain_from_file:
+    elif opt.fake_strain or opt.fake_strain_from_file:
         logging.info("Generating Fake Strain")
         if not opt.low_frequency_cutoff:
             raise ValueError('Please provide low frequency cutoff to '
@@ -245,7 +245,8 @@ def from_cli(opt, dyn_range_fac=1, precision='single',
 
         if opt.fake_strain_from_file:
             logging.info("Reading ASD from file")
-            strain_psd = pycbc.psd.from_txt(opt.fake_strain_from_file, plen, pdf,
+            strain_psd = pycbc.psd.from_txt(opt.fake_strain_from_file,
+                                            plen, pdf,
                                             opt.low_frequency_cutoff,
                                             is_asd_file=True)
         elif opt.fake_strain != 'zeroNoise':
@@ -360,10 +361,13 @@ def from_cli(opt, dyn_range_fac=1, precision='single',
         import h5py
         tf_file = h5py.File(opt.witness_tf_file)
         for key in tf_file:
-            witness = pycbc.frame.query_and_read_frame(opt.witness_frame_type, str(key),
-                   start_time=strain.start_time, end_time=strain.end_time)
+            witness = pycbc.frame.query_and_read_frame(opt.witness_frame_type,
+                   str(key),
+                   start_time=strain.start_time,
+                   end_time=strain.end_time)
             witness = (witness * dyn_range_fac).astype(strain.dtype)
-            tf = pycbc.types.load_frequencyseries(opt.witness_tf_file, group=key)
+            tf = pycbc.types.load_frequencyseries(opt.witness_tf_file,
+                                                  group=key)
             tf = tf.astype(stilde.dtype)
 
             flen = int(opt.witness_filter_length * strain.sample_rate)

--- a/pycbc/strain/strain.py
+++ b/pycbc/strain/strain.py
@@ -305,6 +305,7 @@ def from_cli(opt, dyn_range_fac=1, precision='single',
         injections = \
             injector.apply(strain, opt.channel_name[0:2],
                            distance_scale=opt.injection_scale_factor,
+                           injection_sample_rate=opt.injection_sample_rate,
                            inj_filter_rejector=inj_filter_rejector)
 
     if opt.sgburst_injection_file:
@@ -511,6 +512,8 @@ def insert_strain_option_group(parser, gps_times=True):
     data_reading_group.add_argument("--injection-scale-factor", type=float,
                     default=1, help="Divide injections by this factor "
                     "before injecting into the data.")
+    data_reading_group.add_argument("--injection-sample-rate", type=float,
+                    help="Sample rate for injections")
     data_reading_group.add_argument('--injection-f-ref', type=float,
                                     help='Reference frequency in Hz for '
                                          'creating CBC injections from an XML '
@@ -697,6 +700,10 @@ def insert_strain_option_group_multi_ifo(parser, gps_times=True):
                     metavar="IFO:VAL", default=1.,
                     help="Multiple injections by this factor "
                          "before injecting into the data.")
+    data_reading_group_multi.add_argument("--injection-sample-rate",
+                    type=float, nargs="+", action=MultiDetOptionAction,
+                    metavar="IFO:VAL",
+                    help="Sample rate to generate injection with")
 
     data_reading_group_multi.add_argument('--injection-f-ref', type=float,
                                action=MultiDetOptionAction, metavar='IFO:VALUE',

--- a/pycbc/strain/strain.py
+++ b/pycbc/strain/strain.py
@@ -234,118 +234,6 @@ def from_cli(opt, dyn_range_fac=1, precision='single',
                                             opt.gps_start_time - opt.pad_data,
                                             opt.gps_end_time + opt.pad_data)
 
-        if opt.zpk_z and opt.zpk_p and opt.zpk_k:
-            logging.info("Highpass Filtering")
-            strain = highpass(strain, frequency=opt.strain_high_pass)
-
-            logging.info("Applying zpk filter")
-            z = numpy.array(opt.zpk_z)
-            p = numpy.array(opt.zpk_p)
-            k = float(opt.zpk_k)
-            strain = filter_zpk(strain.astype(numpy.float64), z, p, k)
-
-        if opt.normalize_strain:
-            logging.info("Dividing strain by constant")
-            l = opt.normalize_strain
-            strain = strain / l
-
-        if injector is not None:
-            logging.info("Applying injections")
-            injections = \
-                injector.apply(strain, opt.channel_name[0:2],
-                               distance_scale=opt.injection_scale_factor,
-                               inj_filter_rejector=inj_filter_rejector)
-
-        if opt.sgburst_injection_file:
-            logging.info("Applying sine-Gaussian burst injections")
-            injector = SGBurstInjectionSet(opt.sgburst_injection_file)
-            injector.apply(strain, opt.channel_name[0:2],
-                             distance_scale=opt.injection_scale_factor)
-
-        if opt.strain_high_pass:
-            logging.info("Highpass Filtering")
-            strain = highpass(strain, frequency=opt.strain_high_pass)
-
-        if precision == 'single':
-            logging.info("Converting to float32")
-            strain = (strain * dyn_range_fac).astype(pycbc.types.float32)
-        elif precision == "double":
-            logging.info("Converting to float64")
-            strain = (strain * dyn_range_fac).astype(pycbc.types.float64)
-        else:
-            raise ValueError("Unrecognized precision {}".format(precision))
-
-        if opt.sample_rate:
-            logging.info("Resampling data")
-            strain = resample_to_delta_t(strain,
-                                         1. / opt.sample_rate,
-                                         method='ldas')
-
-        if opt.gating_file is not None:
-            logging.info("Gating times contained in gating file")
-            gate_params = numpy.loadtxt(opt.gating_file)
-            if len(gate_params.shape) == 1:
-                gate_params = [gate_params]
-            strain = gate_data(strain, gate_params)
-            gating_info['file'] = \
-                    [gp for gp in gate_params \
-                     if (gp[0] + gp[1] + gp[2] >= strain.start_time) \
-                     and (gp[0] - gp[1] - gp[2] <= strain.end_time)]
-
-        if opt.autogating_threshold is not None:
-            gating_info['auto'] = []
-            for _ in range(opt.autogating_max_iterations):
-                glitch_times = detect_loud_glitches(
-                        strain, threshold=opt.autogating_threshold,
-                        cluster_window=opt.autogating_cluster,
-                        low_freq_cutoff=opt.strain_high_pass,
-                        corrupt_time=opt.pad_data + opt.autogating_pad)
-                gate_params = [[gt, opt.autogating_width, opt.autogating_taper]
-                               for gt in glitch_times]
-                gating_info['auto'] += gate_params
-                strain = gate_data(strain, gate_params)
-                if len(glitch_times) > 0:
-                    logging.info('Autogating at %s',
-                                 ', '.join(['%.3f' % gt
-                                            for gt in glitch_times]))
-                else:
-                    break
-
-        if opt.strain_high_pass:
-            logging.info("Highpass Filtering")
-            strain = highpass(strain, frequency=opt.strain_high_pass)
-
-        if hasattr(opt, 'witness_frame_type') and opt.witness_frame_type:
-            stilde = strain.to_frequencyseries()
-            import h5py
-            tf_file = h5py.File(opt.witness_tf_file)
-            for key in tf_file:
-                witness = pycbc.frame.query_and_read_frame(opt.witness_frame_type, str(key),
-                       start_time=strain.start_time, end_time=strain.end_time)
-                witness = (witness * dyn_range_fac).astype(strain.dtype)
-                tf = pycbc.types.load_frequencyseries(opt.witness_tf_file, group=key)
-                tf = tf.astype(stilde.dtype)
-
-                flen = int(opt.witness_filter_length * strain.sample_rate)
-                tf = pycbc.psd.interpolate(tf, stilde.delta_f)
-
-                tf_time = tf.to_timeseries()
-                window = Array(numpy.hanning(flen * 2), dtype=strain.dtype)
-                tf_time[0:flen] *= window[flen:]
-                tf_time[len(tf_time)-flen:] *= window[0:flen]
-                tf = tf_time.to_frequencyseries()
-
-                kmax = min(len(tf), len(stilde) - 1)
-                stilde[:kmax] -= tf[:kmax] * witness.to_frequencyseries()[:kmax]
-
-            strain = stilde.to_timeseries()
-
-        if opt.pad_data:
-            logging.info("Remove Padding")
-            start = int(opt.pad_data * strain.sample_rate)
-            end = int(len(strain) - strain.sample_rate * opt.pad_data)
-            strain = strain[start:end]
-
     if opt.fake_strain or opt.fake_strain_from_file:
         logging.info("Generating Fake Strain")
         if not opt.low_frequency_cutoff:
@@ -358,7 +246,8 @@ def from_cli(opt, dyn_range_fac=1, precision='single',
         if opt.fake_strain_from_file:
             logging.info("Reading ASD from file")
             strain_psd = pycbc.psd.from_txt(opt.fake_strain_from_file, plen, pdf,
-                                            opt.low_frequency_cutoff, is_asd_file=True)
+                                            opt.low_frequency_cutoff,
+                                            is_asd_file=True)
         elif opt.fake_strain != 'zeroNoise':
             logging.info("Making PSD for strain")
             strain_psd = pycbc.psd.from_string(opt.fake_strain, plen, pdf,
@@ -373,49 +262,129 @@ def from_cli(opt, dyn_range_fac=1, precision='single',
             logging.info("Making colored noise")
             from pycbc.noise.reproduceable import colored_noise
             lowfreq = opt.low_frequency_cutoff / 2.
-            strain = colored_noise(strain_psd, opt.gps_start_time,
-                                          opt.gps_end_time,
-                                          seed=opt.fake_strain_seed,
-                                          low_frequency_cutoff=lowfreq)
+            strain = colored_noise(strain_psd,
+                                   opt.gps_start_time - opt.pad_data,
+                                   opt.gps_end_time + opt.pad_data,
+                                   seed=opt.fake_strain_seed,
+                                   low_frequency_cutoff=lowfreq)
 
-        if not opt.channel_name and (opt.injection_file \
-                                     or opt.sgburst_injection_file):
-            raise ValueError('Please provide channel names with the format '
-                             'ifo:channel (e.g. H1:CALIB-STRAIN) to inject '
-                             'simulated signals into fake strain')
+    if not opt.channel_name and (opt.injection_file \
+                                 or opt.sgburst_injection_file):
+        raise ValueError('Please provide channel names with the format '
+                         'ifo:channel (e.g. H1:CALIB-STRAIN) to inject '
+                         'simulated signals into fake strain')
 
-        if injector is not None:
-            logging.info("Applying injections")
-            injections = \
-                injector.apply(strain, opt.channel_name[0:2],
-                               distance_scale=opt.injection_scale_factor,
-                               inj_filter_rejector=inj_filter_rejector)
+    if opt.zpk_z and opt.zpk_p and opt.zpk_k:
+        logging.info("Highpass Filtering")
+        strain = highpass(strain, frequency=opt.strain_high_pass)
 
-        if opt.sgburst_injection_file:
-            logging.info("Applying sine-Gaussian burst injections")
-            injector =  SGBurstInjectionSet(opt.sgburst_injection_file)
-            injector.apply(strain, opt.channel_name[0:2],
-                             distance_scale=opt.injection_scale_factor)
+        logging.info("Applying zpk filter")
+        z = numpy.array(opt.zpk_z)
+        p = numpy.array(opt.zpk_p)
+        k = float(opt.zpk_k)
+        strain = filter_zpk(strain.astype(numpy.float64), z, p, k)
 
-        if opt.strain_high_pass:
-            logging.info("Highpass Filtering")
-            strain = highpass(strain, frequency=opt.strain_high_pass)
+    if opt.normalize_strain:
+        logging.info("Dividing strain by constant")
+        l = opt.normalize_strain
+        strain = strain / l
 
+    if opt.strain_high_pass:
+        logging.info("Highpass Filtering")
+        strain = highpass(strain, frequency=opt.strain_high_pass)
+
+    if precision == 'single':
+        logging.info("Converting to float32")
+        strain = (strain * dyn_range_fac).astype(pycbc.types.float32)
+    elif precision == "double":
+        logging.info("Converting to float64")
+        strain = (strain * dyn_range_fac).astype(pycbc.types.float64)
+    else:
+        raise ValueError("Unrecognized precision {}".format(precision))
+
+    if opt.sample_rate:
         logging.info("Resampling data")
-        strain = resample_to_delta_t(strain, 1. / opt.sample_rate)
+        strain = resample_to_delta_t(strain,
+                                     1. / opt.sample_rate,
+                                     method='ldas')
 
-        if precision == 'single':
-            logging.info("Converting to float32")
-            strain = (dyn_range_fac * strain).astype(pycbc.types.float32)
-        elif precision == 'double':
-            logging.info("Converting to float64")
-            strain = (dyn_range_fac * strain).astype(pycbc.types.float64)
-        else:
-            raise ValueError("Unrecognized precision {}".format(precision))
+    if injector is not None:
+        logging.info("Applying injections")
+        injections = \
+            injector.apply(strain, opt.channel_name[0:2],
+                           distance_scale=opt.injection_scale_factor,
+                           inj_filter_rejector=inj_filter_rejector)
 
-        if opt.strain_high_pass:
-            logging.info("Highpass Filtering")
-            strain = highpass(strain, frequency=opt.strain_high_pass)
+    if opt.sgburst_injection_file:
+        logging.info("Applying sine-Gaussian burst injections")
+        injector = SGBurstInjectionSet(opt.sgburst_injection_file)
+        injector.apply(strain, opt.channel_name[0:2],
+                         distance_scale=opt.injection_scale_factor)
+
+    if opt.gating_file is not None:
+        logging.info("Gating times contained in gating file")
+        gate_params = numpy.loadtxt(opt.gating_file)
+        if len(gate_params.shape) == 1:
+            gate_params = [gate_params]
+        strain = gate_data(strain, gate_params)
+        gating_info['file'] = \
+                [gp for gp in gate_params \
+                 if (gp[0] + gp[1] + gp[2] >= strain.start_time) \
+                 and (gp[0] - gp[1] - gp[2] <= strain.end_time)]
+
+    if opt.autogating_threshold is not None:
+        gating_info['auto'] = []
+        for _ in range(opt.autogating_max_iterations):
+            glitch_times = detect_loud_glitches(
+                    strain, threshold=opt.autogating_threshold,
+                    cluster_window=opt.autogating_cluster,
+                    low_freq_cutoff=opt.strain_high_pass,
+                    corrupt_time=opt.pad_data + opt.autogating_pad)
+            gate_params = [[gt, opt.autogating_width, opt.autogating_taper]
+                           for gt in glitch_times]
+            gating_info['auto'] += gate_params
+            strain = gate_data(strain, gate_params)
+            if len(glitch_times) > 0:
+                logging.info('Autogating at %s',
+                             ', '.join(['%.3f' % gt
+                                        for gt in glitch_times]))
+            else:
+                break
+
+    if opt.strain_high_pass:
+        logging.info("Highpass Filtering")
+        strain = highpass(strain, frequency=opt.strain_high_pass)
+
+    if hasattr(opt, 'witness_frame_type') and opt.witness_frame_type:
+        stilde = strain.to_frequencyseries()
+        import h5py
+        tf_file = h5py.File(opt.witness_tf_file)
+        for key in tf_file:
+            witness = pycbc.frame.query_and_read_frame(opt.witness_frame_type, str(key),
+                   start_time=strain.start_time, end_time=strain.end_time)
+            witness = (witness * dyn_range_fac).astype(strain.dtype)
+            tf = pycbc.types.load_frequencyseries(opt.witness_tf_file, group=key)
+            tf = tf.astype(stilde.dtype)
+
+            flen = int(opt.witness_filter_length * strain.sample_rate)
+            tf = pycbc.psd.interpolate(tf, stilde.delta_f)
+
+            tf_time = tf.to_timeseries()
+            window = Array(numpy.hanning(flen * 2), dtype=strain.dtype)
+            tf_time[0:flen] *= window[flen:]
+            tf_time[len(tf_time)-flen:] *= window[0:flen]
+            tf = tf_time.to_frequencyseries()
+
+            kmax = min(len(tf), len(stilde) - 1)
+            stilde[:kmax] -= tf[:kmax] * witness.to_frequencyseries()[:kmax]
+
+        strain = stilde.to_timeseries()
+
+    if opt.pad_data:
+        logging.info("Remove Padding")
+        start = int(opt.pad_data * strain.sample_rate)
+        end = int(len(strain) - strain.sample_rate * opt.pad_data)
+        strain = strain[start:end]
 
     if opt.taper_data:
         logging.info("Tapering data")

--- a/pycbc/strain/strain.py
+++ b/pycbc/strain/strain.py
@@ -294,15 +294,6 @@ def from_cli(opt, dyn_range_fac=1, precision='single',
         logging.info("Highpass Filtering")
         strain = highpass(strain, frequency=opt.strain_high_pass)
 
-    if precision == 'single':
-        logging.info("Converting to float32")
-        strain = (strain * dyn_range_fac).astype(pycbc.types.float32)
-    elif precision == "double":
-        logging.info("Converting to float64")
-        strain = (strain * dyn_range_fac).astype(pycbc.types.float64)
-    else:
-        raise ValueError("Unrecognized precision {}".format(precision))
-
     if opt.sample_rate:
         logging.info("Resampling data")
         strain = resample_to_delta_t(strain,
@@ -321,6 +312,15 @@ def from_cli(opt, dyn_range_fac=1, precision='single',
         injector = SGBurstInjectionSet(opt.sgburst_injection_file)
         injector.apply(strain, opt.channel_name[0:2],
                          distance_scale=opt.injection_scale_factor)
+
+    if precision == 'single':
+        logging.info("Converting to float32")
+        strain = (strain * dyn_range_fac).astype(pycbc.types.float32)
+    elif precision == "double":
+        logging.info("Converting to float64")
+        strain = (strain * dyn_range_fac).astype(pycbc.types.float64)
+    else:
+        raise ValueError("Unrecognized precision {}".format(precision))
 
     if opt.gating_file is not None:
         logging.info("Gating times contained in gating file")

--- a/pycbc/types/timeseries.py
+++ b/pycbc/types/timeseries.py
@@ -93,7 +93,7 @@ class TimeSeries(Array):
         if isinstance(other, TimeSeries):
             odelta_t = other.delta_t
         else:
-            odelta_t = other
+            odelta_t = 1.0/other
 
         if (odelta_t - self.delta_t) / self.delta_t > 1e-4:
             return False

--- a/pycbc/types/timeseries.py
+++ b/pycbc/types/timeseries.py
@@ -90,10 +90,15 @@ class TimeSeries(Array):
 
     def sample_rate_close(self, other):
         """ Check if the sample rate is close enough to allow operations """
-        if (other.delta_t - self.delta_t) / self.delta_t > 1e-4:
+        if isinstance(other, TimeSeries):
+            odelta_t = other.delta_t
+        else:
+            odelta_t = other
+
+        if (odelta_t - self.delta_t) / self.delta_t > 1e-4:
             return False
 
-        if abs(1 - other.delta_t / self.delta_t) * len(self) > 0.5:
+        if abs(1 - odelta_t / self.delta_t) * len(self) > 0.5:
             return False
 
         return True

--- a/pycbc/types/timeseries.py
+++ b/pycbc/types/timeseries.py
@@ -90,6 +90,9 @@ class TimeSeries(Array):
 
     def sample_rate_close(self, other):
         """ Check if the sample rate is close enough to allow operations """
+
+        # compare our delta_t either to a another time series' or
+        # to a given sample rate (float)
         if isinstance(other, TimeSeries):
             odelta_t = other.delta_t
         else:


### PR DESCRIPTION
This consolidates some of the from_cli function in strain.py between the fake data and read-from-file data paths. I'm not sure anymore why there was so much duplication, but it seems like we can remove it now. One change to the path which will cause results to differ is that injections are done *after* resampling. This significantly improves the ability to inject long waveforms for CE / ET studies without memory becoming unmanageable. 