### PR TITLE
Included an option to choose the scipy optimizer

### DIFF
--- a/bin/pycbc_optimize_snr
+++ b/bin/pycbc_optimize_snr
@@ -142,10 +142,10 @@ parser.add_argument('--cores', type=int,
 parser.add_argument('--optimizer', type=str, default='differential_evolution',
                     choices=['differential_evolution', 'shgo'],
                     help='The optimizer to use, differential_evolution or shgo')
-parser.add_argument('--DI-maxiter', type=int, default=50,
+parser.add_argument('--di-maxiter', type=int, default=50,
                     help='Only relevant for --optimizer differential_evolution: '
                     'The maximum number of generations over which the entire population is evolved.')
-parser.add_argument('--DI-popsize', type=int, default=100,
+parser.add_argument('--di-popsize', type=int, default=100,
                     help='Only relevant for --optimizer differential_evolution: '
                          'A multiplier for setting the total population size.')
 parser.add_argument('--shgo-samples', type=int, default=76,
@@ -206,8 +206,8 @@ logging.info('Starting optimization')
 
 if args.optimizer == 'differential_evolution':
     results = differential_evolution(compute_network_snr, bounds,
-                                 maxiter=args.DI_maxiter, workers=(args.cores or -1),
-                                 popsize=args.DI_popsize, mutation=(0.5,1),
+                                 maxiter=args.di_maxiter, workers=(args.cores or -1),
+                                 popsize=args.di_popsize, mutation=(0.5,1),
                                  recombination=0.7, callback=callback_func,
                                  args=extra_args)
 

--- a/bin/pycbc_optimize_snr
+++ b/bin/pycbc_optimize_snr
@@ -140,19 +140,20 @@ parser.add_argument('--output-path', required=True,
 parser.add_argument('--cores', type=int,
                     help='Restrict calculation to given number of CPU cores')
 parser.add_argument('--optimizer', type=str, default='differential_evolution',
-                    help='The optimizer to use, shgo or differential_evolution')
-parser.add_argument('--maxiter', type=int, default='50',
-                    help='Differential Evolution: The maximum number of '
-                         'generations over which the entire population is evolved.')
-parser.add_argument('--popsize', type=int, default='100',
-                    help='Differential Evolution: A multiplier for setting the '
-                         'total population size.')
-parser.add_argument('--iters', type=int, default='3',
-                    help='shgo: Number of sampling points used in the construction '
-                         'of the simplicial complex. ')
-parser.add_argument('--n', type=int, default='76',
-                    help='shgo: Number of iterations used in the construction of '
-                         'the simplicial complex.')
+                    choices=['differential_evolution', 'shgo'],
+                    help='The optimizer to use, differential_evolution or shgo')
+parser.add_argument('--DI-maxiter', type=int, default=50,
+                    help='Only relevant for --optimizer differential_evolution: '
+                    'The maximum number of generations over which the entire population is evolved.')
+parser.add_argument('--DI-popsize', type=int, default=100,
+                    help='Only relevant for --optimizer differential_evolution: '
+                         'A multiplier for setting the total population size.')
+parser.add_argument('--shgo-samples', type=int, default=76,
+                    help='Only relevant for --optimizer shgo: '
+                    'Number of sampling points used in the construction of the simplicial complex. ')
+parser.add_argument('--shgo-iters', type=int, default=3,
+                    help='Only relevant for --optimizer shgo: '
+                    'Number of iterations used in the construction of the simplicial complex.')
                     
 
 args = parser.parse_args()
@@ -203,21 +204,17 @@ bounds = [(minchirp, maxchirp), (0.01, 0.2499), (-0.9, 0.9), (-0.9, 0.9)]
 
 logging.info('Starting optimization')
 
-try:
-
-    if args.optimizer == 'differential_evolution':
-        results = differential_evolution(compute_network_snr, bounds,
-                                 maxiter=args.maxiter, workers=(args.cores or -1),
-                                 popsize=args.popsize, mutation=(0.5,1),
+if args.optimizer == 'differential_evolution':
+    results = differential_evolution(compute_network_snr, bounds,
+                                 maxiter=args.DI_maxiter, workers=(args.cores or -1),
+                                 popsize=args.DI_popsize, mutation=(0.5,1),
                                  recombination=0.7, callback=callback_func,
                                  args=extra_args)
 
-    elif args.optimizer == 'shgo':
-        results = shgo(compute_network_snr, bounds=bounds, args=extra_args, 
-                iters=args.iters, n=args.n, sampling_method="sobol")
-               
-except RuntimeError: 
-    print("You haven't specified an optimizer, either shgo or differential_evolution")
+elif args.optimizer == 'shgo':
+    results = shgo(compute_network_snr, bounds=bounds, args=extra_args, 
+                iters=args.shgo_iters, n=args.shgo_samples, sampling_method="sobol")
+                
 
 logging.info('Optimization complete')
 

--- a/bin/pycbc_optimize_snr
+++ b/bin/pycbc_optimize_snr
@@ -18,7 +18,7 @@ from pycbc.conversions import (
     mchirp_from_mass1_mass2, mtotal_from_mchirp_eta,
     mass1_from_mtotal_eta, mass2_from_mtotal_eta
 )
-from scipy.optimize import differential_evolution
+from scipy.optimize import differential_evolution, shgo
 from pycbc.io import live
 from pycbc.io.hdf import load_hdf5_to_dict
 from pycbc.detector import Detector

--- a/bin/pycbc_optimize_snr
+++ b/bin/pycbc_optimize_snr
@@ -97,6 +97,8 @@ def compute_network_snr_core(v, *argv):
     return (network_snrsq**0.5), snr_series_dict
 
 def compute_network_snr(v, *argv):
+    if len(argv) == 1:
+        argv = argv[0]
     nsnr, _ = compute_network_snr_core(v, *argv)
     return -nsnr
 
@@ -137,6 +139,21 @@ parser.add_argument('--output-path', required=True,
                     help='Path to a directory to store results in')
 parser.add_argument('--cores', type=int,
                     help='Restrict calculation to given number of CPU cores')
+parser.add_argument('--optimizer', type=str, default='differential_evolution',
+                    help='The optimizer to use, shgo or differential_evolution')
+parser.add_argument('--maxiter', type=int, default='50',
+                    help='Differential Evolution: The maximum number of '
+                         'generations over which the entire population is evolved.')
+parser.add_argument('--popsize', type=int, default='100',
+                    help='Differential Evolution: A multiplier for setting the '
+                         'total population size.')
+parser.add_argument('--iters', type=int default='3',
+                    help='shgo: Number of sampling points used in the construction '
+                         'of the simplicial complex. ')
+parser.add_argument('--n', type=int, default='76',
+                    help='shgo: Number of iterations used in the construction of '
+                         'the simplicial complex.')
+                    
 
 args = parser.parse_args()
 pycbc.init_logging(args.verbose)
@@ -186,11 +203,21 @@ bounds = [(minchirp, maxchirp), (0.01, 0.2499), (-0.9, 0.9), (-0.9, 0.9)]
 
 logging.info('Starting optimization')
 
-results = differential_evolution(compute_network_snr, bounds,
-                                 maxiter=100, workers=(args.cores or -1),
-                                 popsize=200, mutation=(0.5,1),
+try:
+
+    if args.optimizer == 'differential_evolution':
+        results = differential_evolution(compute_network_snr, bounds,
+                                 maxiter=args.maxiter, workers=(args.cores or -1),
+                                 popsize=args.popsize, mutation=(0.5,1),
                                  recombination=0.7, callback=callback_func,
                                  args=extra_args)
+
+    elif args.optimizer == 'shgo':
+        results = shgo(compute_network_snr, bounds=bounds, args=extra_args, 
+                iters=args.iters, n=args.n, sampling_method="sobol")
+               
+except RuntimeError: 
+    print("You haven't specified an optimizer, either shgo or differential_evolution")
 
 logging.info('Optimization complete')
 

--- a/bin/pycbc_optimize_snr
+++ b/bin/pycbc_optimize_snr
@@ -147,7 +147,7 @@ parser.add_argument('--maxiter', type=int, default='50',
 parser.add_argument('--popsize', type=int, default='100',
                     help='Differential Evolution: A multiplier for setting the '
                          'total population size.')
-parser.add_argument('--iters', type=int default='3',
+parser.add_argument('--iters', type=int, default='3',
                     help='shgo: Number of sampling points used in the construction '
                          'of the simplicial complex. ')
 parser.add_argument('--n', type=int, default='76',


### PR DESCRIPTION
Also includes the relevant arguments that are needed to customise the optimizers. Changed the default differential_evolution parameters from (100,200) to (50,100).

Within the compute_network_snr function, the addition was needed for the shgo optimizer.
The default optimizer is still differential_evolution, used the try & except but unsure if this is necessary.