### PR TITLE
stat module: fix API inconsistency, add basic test

### DIFF
--- a/pycbc/events/coinc.py
+++ b/pycbc/events/coinc.py
@@ -1043,8 +1043,8 @@ class LiveCoincTimeslideBackgroundEstimator(object):
                                  self.time_window,
                                  self.timeslide_interval)
                 trig_stat = numpy.resize(trig_stat, len(i1))
-                sngls_list = [[ifo, trig_stat],
-                              [oifo, stats[i1]]]
+                sngls_list = [(ifo, {'snglstat': trig_stat}),
+                              (oifo, {'snglstat': stats[i1]})]
                 # This can only use 2-det coincs at present
                 c = self.stat_calculator.rank_stat_coinc(
                     sngls_list,

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -240,7 +240,7 @@ class QuadratureSumStatistic(Stat):
         numpy.ndarray
             Array of coincident ranking statistic values
         """
-        cstat = sum(sngl[1] ** 2. for sngl in sngls_list) ** 0.5
+        cstat = sum(sngl[1]['snglstat'] ** 2. for sngl in sngls_list) ** 0.5
         # For single-detector "cuts" the single ranking is set to -1
         for sngls in sngls_list:
             cstat[sngls == -1] = 0
@@ -274,7 +274,7 @@ class QuadratureSumStatistic(Stat):
         allowed_names = ['QuadratureSumStatistic']
         self._check_coinc_lim_subclass(allowed_names)
 
-        s0 = thresh ** 2. - sum(sngl[1] ** 2. for sngl in s)
+        s0 = thresh ** 2. - sum(sngl[1]['snglstat'] ** 2. for sngl in s)
         s0[s0 < 0] = 0
         return s0 ** 0.5
 
@@ -665,8 +665,8 @@ class ExpFitStatistic(QuadratureSumStatistic):
             The list of detector names
         """
 
-        if not len(files):
-            raise RuntimeError("Can't find any statistic files !")
+        if not files:
+            raise RuntimeError("Statistic files not specified")
         QuadratureSumStatistic.__init__(self, sngl_ranking, files=files,
                                         ifos=ifos, **kwargs)
 
@@ -995,7 +995,7 @@ class ExpFitCombinedSNR(ExpFitStatistic):
         """
 
         # scale by 1/sqrt(number of ifos) to resemble network SNR
-        return sum(sngl[1] for sngl in s) / len(s)**0.5
+        return sum(sngl[1]['snglstat'] for sngl in s) / len(s)**0.5
 
     def coinc_lim_for_thresh(self, s, thresh, limifo,
                              **kwargs): # pylint:disable=unused-argument
@@ -1025,7 +1025,7 @@ class ExpFitCombinedSNR(ExpFitStatistic):
         allowed_names = ['ExpFitCombinedSNR']
         self._check_coinc_lim_subclass(allowed_names)
 
-        return thresh * ((len(s) + 1) ** 0.5) - sum(sngl[1] for sngl in s)
+        return thresh * ((len(s) + 1) ** 0.5) - sum(sngl[1]['snglstat'] for sngl in s)
 
 
 class PhaseTDExpFitStatistic(PhaseTDStatistic, ExpFitCombinedSNR):
@@ -1229,7 +1229,7 @@ class ExpFitSGBgRateStatistic(ExpFitStatistic):
 
         # ranking statistic is -ln(expected rate density of noise triggers)
         # plus normalization constant
-        sngl_dict = {sngl[0]: sngl[1] for sngl in s}
+        sngl_dict = {sngl[0]: sngl[1]['snglstat'] for sngl in s}
         ln_noise_rate = coinc_rate.combination_noise_lograte(
                                   sngl_dict, kwargs['time_addition'])
         loglr = - ln_noise_rate + self.benchmark_lograte
@@ -1263,7 +1263,7 @@ class ExpFitSGBgRateStatistic(ExpFitStatistic):
         allowed_names = ['ExpFitSGBgRateStatistic']
         self._check_coinc_lim_subclass(allowed_names)
 
-        sngl_dict = {sngl[0]: sngl[1] for sngl in s}
+        sngl_dict = {sngl[0]: sngl[1]['snglstat'] for sngl in s}
         sngl_dict[limifo] = numpy.zeros(len(s[0][1]))
         ln_noise_rate = coinc_rate.combination_noise_lograte(
                                   sngl_dict, kwargs['time_addition'])

--- a/test/test_coinc_stat.py
+++ b/test/test_coinc_stat.py
@@ -1,0 +1,64 @@
+"""Unit test for coincident ranking statistic implementations."""
+
+import unittest
+import numpy as np
+from utils import parse_args_cpu_only, simple_exit
+from pycbc.events.stat import statistic_dict
+
+
+# this test only needs to happen on the CPU
+parse_args_cpu_only('coinc stats')
+
+class CoincStatTest(unittest.TestCase):
+    def setUp(self):
+        # one could loop over all single rankings
+        # and detector combinations for a complete test
+        self.sngl_rank = 'snr'
+        self.detectors = ['H1', 'L1']
+
+        # fake single-detector triggers
+        self.sngl_trigs = [(d, {'snglstat': np.random.uniform(0.1, 100, size=10)})
+                           for d in self.detectors]
+
+        # here we should also prepare some files needed by some stats,
+        # like the PTA histograms or fake trigger fits
+
+    def test_stats(self):
+        # FIXME it seems this is only necessary on Python 2
+        if not hasattr(self, 'subTest'):
+            class DummyCM:
+                def __init__(self, msg=''):
+                    print('Testing ' + msg)
+                def __enter__(self):
+                    return self
+                def __exit__(self, ex_type, ex_value, ex_tb):
+                    return False
+            self.subTest = DummyCM
+
+        for stat in statistic_dict:
+            # FIXME until we can fake the required files,
+            # do not test stats that require them
+            if 'phasetd' in stat or 'exp_fit' in stat or 'ExpFit' in stat:
+                continue
+
+            with self.subTest(msg=stat):
+                # instantiate an object for this stat
+                instance = statistic_dict[stat](self.sngl_rank,
+                                                ifos=self.detectors)
+
+                # try to rank the fake single triggers
+                ranks = instance.rank_stat_coinc(self.sngl_trigs,
+                                                 None, None, None)
+
+                # basic sanity check on the produced ranks
+                self.assertFalse(np.isnan(ranks).any())
+
+
+suite = unittest.TestSuite()
+
+# it would be nicer to add each stat as a separate test here
+suite.addTest(unittest.TestLoader().loadTestsFromTestCase(CoincStatTest))
+
+if __name__ == '__main__':
+    results = unittest.TextTestRunner(verbosity=2).run(suite)
+    simple_exit(results)


### PR DESCRIPTION
@MPillas and I noticed that one of the simple coinc ranking stats are not usable with the multi-ifo workflow. When we tried using the `phasetd_newsnr_sgveto` stat, we got this error from some of the coinc jobs:
```
 Traceback (most recent call last):
  File "somewhere/pycbc-v1.16.13/bin/pycbc_multiifo_coinc_findtrigs", line 321, in 
    time_addition=args.coinc_threshold)
  File "somewhere/pycbc-v1.16.13/lib/python2.7/site-packages/pycbc/events/stat.py", line 151, in coinc_multiifo
    return sum(sngl[1] ** 2. for sngl in s) ** 0.5
  File "somewhere/pycbc-v1.16.13/lib/python2.7/site-packages/pycbc/events/stat.py", line 151, in 
    return sum(sngl[1] ** 2. for sngl in s) ** 0.5
TypeError: ufunc 'square' not supported for the input types, and the inputs could not be safely coerced to any supported types according to the casting rule ''safe''
```

I *think* I spotted where this is coming from. Basically it seems that some of the stats expect the single-detector triggers to come in this format:
```
[(ifo, iterable of single-detector ranks),
 (ifo, iterable of single-detector ranks)]
```
while others expect this:
```
[(ifo, {'snglstat': iterable of single-detector ranks}),
 (ifo, {'snglstat': iterable of single-detector ranks})]
```
The error was observed with PyCBC 1.16.13, prior to the stat reorganization, but it seems the issue is still present on master.

This PR changes all stats to take input in the latter format. Since PyCBC Live was actually using the former format, I also changed it to be consistent with the latter. Note that I only changed the `rank_stat_coinc()` methods, and I am not sure if other places need the same change.

In addition, given that we should start working on #3584 soon, I added a basic unit test file for the stat module to hopefully make that easier. It is currently failing due to the various unimplemented stats, and the need for some stats to have their files passed to them, so those are explicitly excluded from the test for now.

Edit: made explanation hopefully clearer.