### PR TITLE
use relative search for flow in get_td_waveform_from_fd

### DIFF
--- a/pycbc/waveform/waveform.py
+++ b/pycbc/waveform/waveform.py
@@ -647,14 +647,13 @@ def get_td_waveform_from_fd(rwrap=0.2, **params):
     hc: pycbc.types.TimeSeries
         Cross polarization time series
     """
-
     # determine the duration to use
     full_duration = duration = get_waveform_filter_length_in_time(**params)
     nparams = params.copy()
 
     while full_duration < duration * 1.5:
         full_duration = get_waveform_filter_length_in_time(**nparams)
-        nparams['f_lower'] -= 1
+        nparams['f_lower'] *= 0.99
 
     if 'f_ref' not in nparams:
         nparams['f_ref'] = params['f_lower']


### PR DESCRIPTION
Originally, to figure how the right flow to use for tapering fd injections, it would do an iterative search decrementing the flow by 1, this is bad once flow is small. This changes to a relative search which should be more broadly applicable. 