### PR TITLE
Move interpolation into new parent class of WorkflowConfigParser

### DIFF
--- a/pycbc/types/config.py
+++ b/pycbc/types/config.py
@@ -54,7 +54,8 @@ class InterpolatingConfigParser(DeepCopyableConfigParser):
     us add a few additional helper features that are useful in workflows.
     """
     def __init__(self, configFiles=None, overrideTuples=None,
-                 parsedFilePath=None, deleteTuples=None, copy_to_cwd=False):
+                 parsedFilePath=None, deleteTuples=None, copy_to_cwd=False,
+                 skip_extended=False):
         """
         Initialize an InterpolatingConfigParser. This reads the input configuration
         files, overrides values if necessary and performs the interpolation.
@@ -142,7 +143,8 @@ class InterpolatingConfigParser(DeepCopyableConfigParser):
                 "in configuration.", section, option, value )
 
         # Check for any substitutions that can be made
-        self.perform_extended_interpolation()
+        if not skip_extended:
+            self.perform_extended_interpolation()
 
         # Check for duplicate options in sub-sections
         self.sanity_check_subsections()

--- a/pycbc/types/config.py
+++ b/pycbc/types/config.py
@@ -1,0 +1,618 @@
+# Copyright (C) 2013,2017,2021 Ian Harry, Duncan Brown, Alex Nitz
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+#
+# =============================================================================
+#
+#                                   Preamble
+#
+# =============================================================================
+#
+"""
+This module provides a wrapper to the ConfigParser utilities for pycbc.
+This module is described in the page here:
+"""
+import os
+import re
+import StringIO
+import itertools
+import logging
+from six.moves import configparser as ConfigParser
+
+class DeepCopyableConfigParser(ConfigParser.SafeConfigParser):
+    """
+    The standard SafeConfigParser no longer supports deepcopy() as of python
+    2.7 (see http://bugs.python.org/issue16058). This subclass restores that
+    functionality.
+    """
+    def __deepcopy__(self, memo):
+        # http://stackoverflow.com/questions/23416370
+        # /manually-building-a-deep-copy-of-a-configparser-in-python-2-7
+        config_string = StringIO.StringIO()
+        self.write(config_string)
+        config_string.seek(0)
+        new_config = self.__class__()
+        new_config.readfp(config_string)
+        return new_config
+
+class InterpolatingConfigParser(DeepCopyableConfigParser):
+    """
+    This is a sub-class of DeepCopyableConfigParser, which lets
+    us add a few additional helper features that are useful in workflows.
+    """
+    def __init__(self, configFiles=None, overrideTuples=None,
+                 parsedFilePath=None, deleteTuples=None, copy_to_cwd=False):
+        """
+        Initialize an InterpolatingConfigParser. This reads the input configuration
+        files, overrides values if necessary and performs the interpolation.
+
+        Parameters
+        -----------
+        configFiles : Path to .ini file, or list of paths
+            The file(s) to be read in and parsed.
+        overrideTuples : List of (section, option, value) tuples
+            Add the (section, option, value) triplets provided
+            in this list to the provided .ini file(s). If the section, option
+            pair is already present, it will be overwritten.
+        parsedFilePath : Path, optional (default=None)
+            If given, write the parsed .ini file back to disk at this location.
+        deleteTuples : List of (section, option) tuples
+            Delete the (section, option) pairs provided
+            in this list from provided .ini file(s). If the section only
+            is provided, the entire section will be deleted.
+        copy_to_cwd : bool, optional
+            Copy the configuration files to the current working directory if
+            they are not already there, even if they already exist locally.
+            If False, files will only be copied to the current working
+            directory if they are remote. Default is False.
+
+       Returns
+        --------
+        InterpolatingConfigParser
+            Initialized InterpolatingConfigParser instance.
+        """
+        if configFiles is None:
+            configFiles = []
+        if overrideTuples is None:
+            overrideTuples = []
+        if deleteTuples is None:
+            deleteTuples = []
+        DeepCopyableConfigParser.__init__(self)
+
+        # Enable case sensitive options
+        self.optionxform = str
+
+        self.read_ini_file(configFiles)
+
+        # Split sections like [inspiral&tmplt] into [inspiral] and [tmplt]
+        self.split_multi_sections()
+
+        # Populate shared options from the [sharedoptions] section
+        self.populate_shared_sections()
+
+        # Do deletes from command line
+        for delete in deleteTuples:
+            if len(delete) == 1:
+                if self.remove_section(delete[0]) is False:
+                    raise ValueError("Cannot delete section %s, "
+                        "no such section in configuration." % delete )
+                else:
+                    logging.info("Deleting section %s from configuration",
+                                 delete[0])
+            elif len(delete) == 2:
+                if self.remove_option(delete[0],delete[1]) is False:
+                    raise ValueError("Cannot delete option %s from section %s,"
+                        " no such option in configuration." % delete )
+                else:
+                    logging.info("Deleting option %s from section %s in "
+                                 "configuration", delete[1], delete[0])
+            else:
+                raise ValueError("Deletes must be tuples of length 1 or 2. "
+                    "Got %s." % str(delete) )
+
+        # Do overrides from command line
+        for override in overrideTuples:
+            if len(override) not in [2,3]:
+                errmsg = "Overrides must be tuples of length 2 or 3."
+                errmsg = "Got %s." % (str(override) )
+                raise ValueError(errmsg)
+            section = override[0]
+            option = override[1]
+            value = ''
+            if len(override) == 3:
+                value = override[2]
+            # Check for section existence, create if needed
+            if not self.has_section(section):
+                self.add_section(section)
+            self.set(section, option, value)
+            logging.info("Overriding section %s option %s with value %s "
+                "in configuration.", section, option, value )
+
+        # Check for any substitutions that can be made
+        self.perform_extended_interpolation()
+
+        # Check for duplicate options in sub-sections
+        self.sanity_check_subsections()
+
+        # Dump parsed .ini file if needed
+        if parsedFilePath:
+            fp = open(parsedFilePath,'w')
+            self.write(fp)
+            fp.close()
+
+    @classmethod
+    def from_cli(cls, opts):
+        """Initialize the config parser using options parsed from the command
+        line.
+
+        The parsed options ``opts`` must include options provided by
+        :py:func:`add_workflow_command_line_group`.
+
+        Parameters
+        -----------
+        opts : argparse.ArgumentParser
+            The command line arguments parsed by argparse
+        """
+        # read configuration file
+        logging.info("Reading configuration file")
+        if opts.config_overrides is not None:
+            overrides = [tuple(override.split(":", 2))
+                         for override in opts.config_overrides]
+        else:
+            overrides = None
+        if opts.config_delete is not None:
+            deletes = [tuple(delete.split(":"))
+                       for delete in opts.config_delete]
+        else:
+            deletes = None
+        return cls(opts.config_files, overrides, deleteTuples=deletes)
+
+    def read_ini_file(self, cpFile):
+        """
+        Read a .ini file and return it as a ConfigParser class.
+        This function does none of the parsing/combining of sections. It simply
+        reads the file and returns it unedited
+
+        Stub awaiting more functionality - see configparser_test.py
+
+        Parameters
+        ----------
+        cpFile : Path to .ini file, or list of paths
+            The path(s) to a .ini file to be read in
+
+        Returns
+        -------
+        cp : ConfigParser
+            The ConfigParser class containing the read in .ini file
+        """
+        # Read the file
+        self.read(cpFile)
+
+    def get_subsections(self, section_name):
+        """ Return a list of subsections for the given section name
+        """
+        # Keep only subsection names
+        subsections = [sec[len(section_name)+1:] for sec in self.sections()\
+                       if sec.startswith(section_name + '-')]
+
+        for sec in subsections:
+            sp = sec.split('-')
+            # This is unusual, but a format [section-subsection-tag] is okay. Just
+            # check that [section-subsection] section exists. If not it is possible
+            # the user is trying to use an subsection name with '-' in it
+            if (len(sp) > 1) and not self.has_section('%s-%s' % (section_name,
+                                                                 sp[0])):
+                raise ValueError( "Workflow uses the '-' as a delimiter so "
+                    "this is interpreted as section-subsection-tag. "
+                    "While checking section %s, no section with "
+                    "name %s-%s was found. "
+                    "If you did not intend to use tags in an "
+                    "'advanced user' manner, or do not understand what "
+                    "this means, don't use dashes in section "
+                    "names. So [injection-nsbhinj] is good. "
+                    "[injection-nsbh-inj] is not." % (sec, sp[0], sp[1]))
+
+        if len(subsections) > 0:
+            return [sec.split('-')[0] for sec in subsections]
+        elif self.has_section(section_name):
+            return ['']
+        else:
+            return []
+
+    def perform_extended_interpolation(self):
+        """
+        Filter through an ini file and replace all examples of
+        ExtendedInterpolation formatting with the exact value. For values like
+        ${example} this is replaced with the value that corresponds to the
+        option called example ***in the same section***
+
+        For values like ${common|example} this is replaced with the value that
+        corresponds to the option example in the section [common]. Note that
+        in the python3 config parser this is ${common:example} but python2.7
+        interprets the : the same as a = and this breaks things
+
+        Nested interpolation is not supported here.
+        """
+
+        # Do not allow any interpolation of the section names
+        for section in self.sections():
+            for option,value in self.items(section):
+                # Check the option name
+                newStr = self.interpolate_string(option, section)
+                if newStr != option:
+                    self.set(section,newStr,value)
+                    self.remove_option(section,option)
+                # Check the value
+                newStr = self.interpolate_string(value, section)
+                if newStr != value:
+                    self.set(section,option,newStr)
+
+
+    def interpolate_string(self, testString, section):
+        """
+        Take a string and replace all example of ExtendedInterpolation
+        formatting within the string with the exact value.
+
+        For values like ${example} this is replaced with the value that
+        corresponds to the option called example ***in the same section***
+
+        For values like ${common|example} this is replaced with the value that
+        corresponds to the option example in the section [common]. Note that
+        in the python3 config parser this is ${common:example} but python2.7
+        interprets the : the same as a = and this breaks things
+
+        Nested interpolation is not supported here.
+
+        Parameters
+        ----------
+        testString : String
+            The string to parse and interpolate
+        section : String
+            The current section of the ConfigParser object
+
+        Returns
+        ----------
+        testString : String
+            Interpolated string
+        """
+
+        # First check if any interpolation is needed and abort if not
+        reObj = re.search(r"\$\{.*?\}", testString)
+        while reObj:
+            # Not really sure how this works, but this will obtain the first
+            # instance of a string contained within ${....}
+            repString = (reObj).group(0)[2:-1]
+            # Need to test which of the two formats we have
+            splitString = repString.split('|')
+            if len(splitString) == 1:
+                try:
+                    testString = testString.replace('${'+repString+'}',\
+                                            self.get(section,splitString[0]))
+                except ConfigParser.NoOptionError:
+                    print("Substitution failed")
+                    raise
+            if len(splitString) == 2:
+                try:
+                    testString = testString.replace('${'+repString+'}',\
+                                       self.get(splitString[0],splitString[1]))
+                except ConfigParser.NoOptionError:
+                    print("Substitution failed")
+                    raise
+            reObj = re.search(r"\$\{.*?\}", testString)
+
+        return testString
+
+
+    def split_multi_sections(self):
+        """
+        Parse through the WorkflowConfigParser instance and splits any sections
+        labelled with an "&" sign (for e.g. [inspiral&tmpltbank]) into
+        [inspiral] and [tmpltbank] sections. If these individual sections
+        already exist they  will be appended to. If an option exists in both the
+        [inspiral] and [inspiral&tmpltbank] sections an error will be thrown
+        """
+        # Begin by looping over all sections
+        for section in self.sections():
+            # Only continue if section needs splitting
+            if '&' not in section:
+                continue
+            # Get list of section names to add these options to
+            splitSections = section.split('&')
+            for newSec in splitSections:
+                # Add sections if they don't already exist
+                if not self.has_section(newSec):
+                    self.add_section(newSec)
+                self.add_options_to_section(newSec, self.items(section))
+            self.remove_section(section)
+
+    def populate_shared_sections(self):
+        """Parse the [sharedoptions] section of the ini file.
+
+        That section should contain entries according to:
+
+          * massparams = inspiral, tmpltbank
+          * dataparams = tmpltbank
+
+        This will result in all options in [sharedoptions-massparams] being
+        copied into the [inspiral] and [tmpltbank] sections and the options
+        in [sharedoptions-dataparams] being copited into [tmpltbank].
+        In the case of duplicates an error will be raised.
+        """
+        if not self.has_section('sharedoptions'):
+            # No sharedoptions, exit
+            return
+        for key, value in self.items('sharedoptions'):
+            assert(self.has_section('sharedoptions-%s' %(key)))
+            # Comma separated
+            values = value.split(',')
+            common_options = self.items('sharedoptions-%s' %(key))
+            for section in values:
+                if not self.has_section(section):
+                    self.add_section(section)
+                for arg, val in common_options:
+                    if arg in self.options(section):
+                        raise ValueError('Option exists in both original ' + \
+                               'ConfigParser section [%s] and ' %(section,) + \
+                               'sharedoptions section: %s %s' \
+                               %(arg,'sharedoptions-%s' %(key)))
+                    self.set(section, arg, val)
+            self.remove_section('sharedoptions-%s' %(key))
+        self.remove_section('sharedoptions')
+
+    def add_options_to_section(self ,section, items, overwrite_options=False):
+        """
+        Add a set of options and values to a section of a ConfigParser object.
+        Will throw an error if any of the options being added already exist,
+        this behaviour can be overridden if desired
+
+        Parameters
+        ----------
+        section : string
+            The name of the section to add options+values to
+        items : list of tuples
+            Each tuple contains (at [0]) the option and (at [1]) the value to
+            add to the section of the ini file
+        overwrite_options : Boolean, optional
+            By default this function will throw a ValueError if an option exists
+            in both the original section in the ConfigParser *and* in the
+            provided items.
+            This will override so that the options+values given in items
+            will replace the original values if the value is set to True.
+            Default = True
+        """
+        # Sanity checking
+        if not self.has_section(section):
+            raise ValueError('Section %s not present in ConfigParser.' \
+                             %(section,))
+
+        # Check for duplicate options first
+        for option,value in items:
+            if not overwrite_options:
+                if option in self.options(section):
+                    raise ValueError('Option exists in both original ' + \
+                                  'ConfigParser section [%s] and ' %(section,) + \
+                                  'input list: %s' %(option,))
+            self.set(section,option,value)
+
+
+    def sanity_check_subsections(self):
+        """
+        This function goes through the ConfigParset and checks that any options
+        given in the [SECTION_NAME] section are not also given in any
+        [SECTION_NAME-SUBSECTION] sections.
+
+        """
+        # Loop over the sections in the ini file
+        for section in self.sections():
+            # [pegasus_profile] specially is allowed to be overriden by
+            # sub-sections
+            if section == 'pegasus_profile':
+                continue
+
+            # Loop over the sections again
+            for section2 in self.sections():
+                # Check if any are subsections of section
+                if section2.startswith(section + '-'):
+                    # Check for duplicate options whenever this exists
+                    self.check_duplicate_options(section, section2,
+                                                 raise_error=True)
+
+
+    def check_duplicate_options(self, section1, section2, raise_error=False):
+        """
+        Check for duplicate options in two sections, section1 and section2.
+        Will return a list of the duplicate options.
+
+        Parameters
+        ----------
+        section1 : string
+            The name of the first section to compare
+        section2 : string
+            The name of the second section to compare
+        raise_error : Boolean, optional (default=False)
+            If True, raise an error if duplicates are present.
+
+        Returns
+        ----------
+        duplicates : List
+            List of duplicate options
+        """
+        # Sanity checking
+        if not self.has_section(section1):
+            raise ValueError('Section %s not present in ConfigParser.'\
+                             %(section1,) )
+        if not self.has_section(section2):
+            raise ValueError('Section %s not present in ConfigParser.'\
+                             %(section2,) )
+
+        items1 = self.options(section1)
+        items2 = self.options(section2)
+
+        # The list comprehension here creates a list of all duplicate items
+        duplicates = [x for x in items1 if x in items2]
+
+        if duplicates and raise_error:
+            raise ValueError('The following options appear in both section ' +\
+                             '%s and %s: %s' \
+                             %(section1,section2,' '.join(duplicates)))
+
+        return duplicates
+
+
+    def get_opt_tag(self, section, option, tag):
+        """
+        Convenience function accessing get_opt_tags() for a single tag: see
+        documentation for that function.
+        NB calling get_opt_tags() directly is preferred for simplicity.
+
+        Parameters
+        -----------
+        self : ConfigParser object
+            The ConfigParser object (automatically passed when this is appended
+            to the ConfigParser class)
+        section : string
+            The section of the ConfigParser object to read
+        option : string
+            The ConfigParser option to look for
+        tag : string
+            The name of the subsection to look in, if not found in [section]
+
+        Returns
+        --------
+        string
+            The value of the options being searched for
+        """
+        return self.get_opt_tags(section, option, [tag])
+
+
+    def get_opt_tags(self, section, option, tags):
+        """
+        Supplement to ConfigParser.ConfigParser.get(). This will search for an
+        option in [section] and if it doesn't find it will also try in
+        [section-tag] for every value of tag in tags.
+        Will raise a ConfigParser.Error if it cannot find a value.
+
+        Parameters
+        -----------
+        self : ConfigParser object
+            The ConfigParser object (automatically passed when this is appended
+            to the ConfigParser class)
+        section : string
+            The section of the ConfigParser object to read
+        option : string
+            The ConfigParser option to look for
+        tags : list of strings
+            The name of subsections to look in, if not found in [section]
+
+        Returns
+        --------
+        string
+            The value of the options being searched for
+        """
+        # Need lower case tag name; also exclude cases with tag=None
+        if tags:
+            tags = [tag.lower() for tag in tags if tag is not None]
+
+        try:
+            return self.get(section, option)
+        except ConfigParser.Error:
+            err_string = "No option '%s' in section [%s] " %(option,section)
+            if not tags:
+                raise ConfigParser.Error(err_string + ".")
+            return_vals = []
+            sub_section_list = []
+            for sec_len in range(1, len(tags)+1):
+                for tag_permutation in itertools.permutations(tags, sec_len):
+                    joined_name = '-'.join(tag_permutation)
+                    sub_section_list.append(joined_name)
+            section_list = ["%s-%s" %(section, sb) for sb in sub_section_list]
+            err_section_list = []
+            for sub in sub_section_list:
+                if self.has_section('%s-%s' %(section, sub)):
+                    if self.has_option('%s-%s' %(section, sub), option):
+                        err_section_list.append("%s-%s" %(section, sub))
+                        return_vals.append(self.get('%s-%s' %(section, sub),
+                                                    option))
+
+            # We also want to recursively go into sections
+
+            if not return_vals:
+                err_string += "or in sections [%s]." \
+                               %("] [".join(section_list))
+                raise ConfigParser.Error(err_string)
+            if len(return_vals) > 1:
+                err_string += "and multiple entries found in sections [%s]."\
+                              %("] [".join(err_section_list))
+                raise ConfigParser.Error(err_string)
+            return return_vals[0]
+
+
+    def has_option_tag(self, section, option, tag):
+        """
+        Convenience function accessing has_option_tags() for a single tag: see
+        documentation for that function.
+        NB calling has_option_tags() directly is preferred for simplicity.
+
+        Parameters
+        -----------
+        self : ConfigParser object
+            The ConfigParser object (automatically passed when this is appended
+            to the ConfigParser class)
+        section : string
+            The section of the ConfigParser object to read
+        option : string
+            The ConfigParser option to look for
+        tag : string
+            The name of the subsection to look in, if not found in [section]
+
+        Returns
+        --------
+        Boolean
+            Is the option in the section or [section-tag]
+        """
+        return self.has_option_tags(section, option, [tag])
+
+
+    def has_option_tags(self, section, option, tags):
+        """
+        Supplement to ConfigParser.ConfigParser.has_option().
+        This will search for an option in [section] and if it doesn't find it
+        will also try in [section-tag] for each value in tags.
+        Returns True if the option is found and false if not.
+
+        Parameters
+        -----------
+        self : ConfigParser object
+            The ConfigParser object (automatically passed when this is appended
+            to the ConfigParser class)
+        section : string
+            The section of the ConfigParser object to read
+        option : string
+            The ConfigParser option to look for
+        tags : list of strings
+            The names of the subsection to look in, if not found in [section]
+
+        Returns
+        --------
+        Boolean
+            Is the option in the section or [section-tag] (for tag in tags)
+        """
+        try:
+            self.get_opt_tags(section, option, tags)
+            return True
+        except ConfigParser.Error:
+            return False
+

--- a/pycbc/types/config.py
+++ b/pycbc/types/config.py
@@ -32,12 +32,14 @@ import logging
 from six.moves import StringIO
 from six.moves import configparser as ConfigParser
 
+
 class DeepCopyableConfigParser(ConfigParser.SafeConfigParser):
     """
     The standard SafeConfigParser no longer supports deepcopy() as of python
     2.7 (see http://bugs.python.org/issue16058). This subclass restores that
     functionality.
     """
+
     def __deepcopy__(self, memo):
         # http://stackoverflow.com/questions/23416370
         # /manually-building-a-deep-copy-of-a-configparser-in-python-2-7
@@ -48,42 +50,50 @@ class DeepCopyableConfigParser(ConfigParser.SafeConfigParser):
         new_config.readfp(config_string)
         return new_config
 
+
 class InterpolatingConfigParser(DeepCopyableConfigParser):
     """
     This is a sub-class of DeepCopyableConfigParser, which lets
     us add a few additional helper features that are useful in workflows.
     """
-    def __init__(self, configFiles=None, overrideTuples=None,
-                 parsedFilePath=None, deleteTuples=None, copy_to_cwd=False,
-                 skip_extended=False):
+
+    def __init__(
+        self,
+        configFiles=None,
+        overrideTuples=None,
+        parsedFilePath=None,
+        deleteTuples=None,
+        copy_to_cwd=False,
+        skip_extended=False,
+    ):
         """
-        Initialize an InterpolatingConfigParser. This reads the input configuration
-        files, overrides values if necessary and performs the interpolation.
+         Initialize an InterpolatingConfigParser. This reads the input configuration
+         files, overrides values if necessary and performs the interpolation.
 
-        Parameters
-        -----------
-        configFiles : Path to .ini file, or list of paths
-            The file(s) to be read in and parsed.
-        overrideTuples : List of (section, option, value) tuples
-            Add the (section, option, value) triplets provided
-            in this list to the provided .ini file(s). If the section, option
-            pair is already present, it will be overwritten.
-        parsedFilePath : Path, optional (default=None)
-            If given, write the parsed .ini file back to disk at this location.
-        deleteTuples : List of (section, option) tuples
-            Delete the (section, option) pairs provided
-            in this list from provided .ini file(s). If the section only
-            is provided, the entire section will be deleted.
-        copy_to_cwd : bool, optional
-            Copy the configuration files to the current working directory if
-            they are not already there, even if they already exist locally.
-            If False, files will only be copied to the current working
-            directory if they are remote. Default is False.
+         Parameters
+         -----------
+         configFiles : Path to .ini file, or list of paths
+             The file(s) to be read in and parsed.
+         overrideTuples : List of (section, option, value) tuples
+             Add the (section, option, value) triplets provided
+             in this list to the provided .ini file(s). If the section, option
+             pair is already present, it will be overwritten.
+         parsedFilePath : Path, optional (default=None)
+             If given, write the parsed .ini file back to disk at this location.
+         deleteTuples : List of (section, option) tuples
+             Delete the (section, option) pairs provided
+             in this list from provided .ini file(s). If the section only
+             is provided, the entire section will be deleted.
+         copy_to_cwd : bool, optional
+             Copy the configuration files to the current working directory if
+             they are not already there, even if they already exist locally.
+             If False, files will only be copied to the current working
+             directory if they are remote. Default is False.
 
-       Returns
-        --------
-        InterpolatingConfigParser
-            Initialized InterpolatingConfigParser instance.
+        Returns
+         --------
+         InterpolatingConfigParser
+             Initialized InterpolatingConfigParser instance.
         """
         if configFiles is None:
             configFiles = []
@@ -108,39 +118,50 @@ class InterpolatingConfigParser(DeepCopyableConfigParser):
         for delete in deleteTuples:
             if len(delete) == 1:
                 if self.remove_section(delete[0]) is False:
-                    raise ValueError("Cannot delete section %s, "
-                        "no such section in configuration." % delete )
+                    raise ValueError(
+                        "Cannot delete section %s, "
+                        "no such section in configuration." % delete
+                    )
                 else:
-                    logging.info("Deleting section %s from configuration",
-                                 delete[0])
+                    logging.info("Deleting section %s from configuration", delete[0])
             elif len(delete) == 2:
-                if self.remove_option(delete[0],delete[1]) is False:
-                    raise ValueError("Cannot delete option %s from section %s,"
-                        " no such option in configuration." % delete )
+                if self.remove_option(delete[0], delete[1]) is False:
+                    raise ValueError(
+                        "Cannot delete option %s from section %s,"
+                        " no such option in configuration." % delete
+                    )
                 else:
-                    logging.info("Deleting option %s from section %s in "
-                                 "configuration", delete[1], delete[0])
+                    logging.info(
+                        "Deleting option %s from section %s in " "configuration",
+                        delete[1],
+                        delete[0],
+                    )
             else:
-                raise ValueError("Deletes must be tuples of length 1 or 2. "
-                    "Got %s." % str(delete) )
+                raise ValueError(
+                    "Deletes must be tuples of length 1 or 2. " "Got %s." % str(delete)
+                )
 
         # Do overrides from command line
         for override in overrideTuples:
-            if len(override) not in [2,3]:
+            if len(override) not in [2, 3]:
                 errmsg = "Overrides must be tuples of length 2 or 3."
-                errmsg = "Got %s." % (str(override) )
+                errmsg = "Got %s." % (str(override))
                 raise ValueError(errmsg)
             section = override[0]
             option = override[1]
-            value = ''
+            value = ""
             if len(override) == 3:
                 value = override[2]
             # Check for section existence, create if needed
             if not self.has_section(section):
                 self.add_section(section)
             self.set(section, option, value)
-            logging.info("Overriding section %s option %s with value %s "
-                "in configuration.", section, option, value )
+            logging.info(
+                "Overriding section %s option %s with value %s " "in configuration.",
+                section,
+                option,
+                value,
+            )
 
         # Check for any substitutions that can be made
         if not skip_extended:
@@ -151,7 +172,7 @@ class InterpolatingConfigParser(DeepCopyableConfigParser):
 
         # Dump parsed .ini file if needed
         if parsedFilePath:
-            fp = open(parsedFilePath,'w')
+            fp = open(parsedFilePath, "w")
             self.write(fp)
             fp.close()
 
@@ -171,13 +192,13 @@ class InterpolatingConfigParser(DeepCopyableConfigParser):
         # read configuration file
         logging.info("Reading configuration file")
         if opts.config_overrides is not None:
-            overrides = [tuple(override.split(":", 2))
-                         for override in opts.config_overrides]
+            overrides = [
+                tuple(override.split(":", 2)) for override in opts.config_overrides
+            ]
         else:
             overrides = None
         if opts.config_delete is not None:
-            deletes = [tuple(delete.split(":"))
-                       for delete in opts.config_delete]
+            deletes = [tuple(delete.split(":")) for delete in opts.config_delete]
         else:
             deletes = None
         return cls(opts.config_files, overrides, deleteTuples=deletes)
@@ -204,20 +225,22 @@ class InterpolatingConfigParser(DeepCopyableConfigParser):
         self.read(cpFile)
 
     def get_subsections(self, section_name):
-        """ Return a list of subsections for the given section name
-        """
+        """Return a list of subsections for the given section name"""
         # Keep only subsection names
-        subsections = [sec[len(section_name)+1:] for sec in self.sections()\
-                       if sec.startswith(section_name + '-')]
+        subsections = [
+            sec[len(section_name) + 1 :]
+            for sec in self.sections()
+            if sec.startswith(section_name + "-")
+        ]
 
         for sec in subsections:
-            sp = sec.split('-')
+            sp = sec.split("-")
             # This is unusual, but a format [section-subsection-tag] is okay. Just
             # check that [section-subsection] section exists. If not it is possible
             # the user is trying to use an subsection name with '-' in it
-            if (len(sp) > 1) and not self.has_section('%s-%s' % (section_name,
-                                                                 sp[0])):
-                raise ValueError( "Workflow uses the '-' as a delimiter so "
+            if (len(sp) > 1) and not self.has_section("%s-%s" % (section_name, sp[0])):
+                raise ValueError(
+                    "Workflow uses the '-' as a delimiter so "
                     "this is interpreted as section-subsection-tag. "
                     "While checking section %s, no section with "
                     "name %s-%s was found. "
@@ -225,12 +248,13 @@ class InterpolatingConfigParser(DeepCopyableConfigParser):
                     "'advanced user' manner, or do not understand what "
                     "this means, don't use dashes in section "
                     "names. So [injection-nsbhinj] is good. "
-                    "[injection-nsbh-inj] is not." % (sec, sp[0], sp[1]))
+                    "[injection-nsbh-inj] is not." % (sec, sp[0], sp[1])
+                )
 
         if len(subsections) > 0:
-            return [sec.split('-')[0] for sec in subsections]
+            return [sec.split("-")[0] for sec in subsections]
         elif self.has_section(section_name):
-            return ['']
+            return [""]
         else:
             return []
 
@@ -251,17 +275,16 @@ class InterpolatingConfigParser(DeepCopyableConfigParser):
 
         # Do not allow any interpolation of the section names
         for section in self.sections():
-            for option,value in self.items(section):
+            for option, value in self.items(section):
                 # Check the option name
                 newStr = self.interpolate_string(option, section)
                 if newStr != option:
-                    self.set(section,newStr,value)
-                    self.remove_option(section,option)
+                    self.set(section, newStr, value)
+                    self.remove_option(section, option)
                 # Check the value
                 newStr = self.interpolate_string(value, section)
                 if newStr != value:
-                    self.set(section,option,newStr)
-
+                    self.set(section, option, newStr)
 
     def interpolate_string(self, testString, section):
         """
@@ -298,25 +321,26 @@ class InterpolatingConfigParser(DeepCopyableConfigParser):
             # instance of a string contained within ${....}
             repString = (reObj).group(0)[2:-1]
             # Need to test which of the two formats we have
-            splitString = repString.split('|')
+            splitString = repString.split("|")
             if len(splitString) == 1:
                 try:
-                    testString = testString.replace('${'+repString+'}',\
-                                            self.get(section,splitString[0]))
+                    testString = testString.replace(
+                        "${" + repString + "}", self.get(section, splitString[0])
+                    )
                 except ConfigParser.NoOptionError:
                     print("Substitution failed")
                     raise
             if len(splitString) == 2:
                 try:
-                    testString = testString.replace('${'+repString+'}',\
-                                       self.get(splitString[0],splitString[1]))
+                    testString = testString.replace(
+                        "${" + repString + "}", self.get(splitString[0], splitString[1])
+                    )
                 except ConfigParser.NoOptionError:
                     print("Substitution failed")
                     raise
             reObj = re.search(r"\$\{.*?\}", testString)
 
         return testString
-
 
     def split_multi_sections(self):
         """
@@ -329,10 +353,10 @@ class InterpolatingConfigParser(DeepCopyableConfigParser):
         # Begin by looping over all sections
         for section in self.sections():
             # Only continue if section needs splitting
-            if '&' not in section:
+            if "&" not in section:
                 continue
             # Get list of section names to add these options to
-            splitSections = section.split('&')
+            splitSections = section.split("&")
             for newSec in splitSections:
                 # Add sections if they don't already exist
                 if not self.has_section(newSec):
@@ -353,28 +377,30 @@ class InterpolatingConfigParser(DeepCopyableConfigParser):
         in [sharedoptions-dataparams] being copited into [tmpltbank].
         In the case of duplicates an error will be raised.
         """
-        if not self.has_section('sharedoptions'):
+        if not self.has_section("sharedoptions"):
             # No sharedoptions, exit
             return
-        for key, value in self.items('sharedoptions'):
-            assert(self.has_section('sharedoptions-%s' %(key)))
+        for key, value in self.items("sharedoptions"):
+            assert self.has_section("sharedoptions-%s" % (key))
             # Comma separated
-            values = value.split(',')
-            common_options = self.items('sharedoptions-%s' %(key))
+            values = value.split(",")
+            common_options = self.items("sharedoptions-%s" % (key))
             for section in values:
                 if not self.has_section(section):
                     self.add_section(section)
                 for arg, val in common_options:
                     if arg in self.options(section):
-                        raise ValueError('Option exists in both original ' + \
-                               'ConfigParser section [%s] and ' %(section,) + \
-                               'sharedoptions section: %s %s' \
-                               %(arg,'sharedoptions-%s' %(key)))
+                        raise ValueError(
+                            "Option exists in both original "
+                            + "ConfigParser section [%s] and " % (section,)
+                            + "sharedoptions section: %s %s"
+                            % (arg, "sharedoptions-%s" % (key))
+                        )
                     self.set(section, arg, val)
-            self.remove_section('sharedoptions-%s' %(key))
-        self.remove_section('sharedoptions')
+            self.remove_section("sharedoptions-%s" % (key))
+        self.remove_section("sharedoptions")
 
-    def add_options_to_section(self ,section, items, overwrite_options=False):
+    def add_options_to_section(self, section, items, overwrite_options=False):
         """
         Add a set of options and values to a section of a ConfigParser object.
         Will throw an error if any of the options being added already exist,
@@ -397,18 +423,18 @@ class InterpolatingConfigParser(DeepCopyableConfigParser):
         """
         # Sanity checking
         if not self.has_section(section):
-            raise ValueError('Section %s not present in ConfigParser.' \
-                             %(section,))
+            raise ValueError("Section %s not present in ConfigParser." % (section,))
 
         # Check for duplicate options first
-        for option,value in items:
+        for option, value in items:
             if not overwrite_options:
                 if option in self.options(section):
-                    raise ValueError('Option exists in both original ' + \
-                                  'ConfigParser section [%s] and ' %(section,) + \
-                                  'input list: %s' %(option,))
-            self.set(section,option,value)
-
+                    raise ValueError(
+                        "Option exists in both original "
+                        + "ConfigParser section [%s] and " % (section,)
+                        + "input list: %s" % (option,)
+                    )
+            self.set(section, option, value)
 
     def sanity_check_subsections(self):
         """
@@ -421,17 +447,15 @@ class InterpolatingConfigParser(DeepCopyableConfigParser):
         for section in self.sections():
             # [pegasus_profile] specially is allowed to be overriden by
             # sub-sections
-            if section == 'pegasus_profile':
+            if section == "pegasus_profile":
                 continue
 
             # Loop over the sections again
             for section2 in self.sections():
                 # Check if any are subsections of section
-                if section2.startswith(section + '-'):
+                if section2.startswith(section + "-"):
                     # Check for duplicate options whenever this exists
-                    self.check_duplicate_options(section, section2,
-                                                 raise_error=True)
-
+                    self.check_duplicate_options(section, section2, raise_error=True)
 
     def check_duplicate_options(self, section1, section2, raise_error=False):
         """
@@ -454,11 +478,9 @@ class InterpolatingConfigParser(DeepCopyableConfigParser):
         """
         # Sanity checking
         if not self.has_section(section1):
-            raise ValueError('Section %s not present in ConfigParser.'\
-                             %(section1,) )
+            raise ValueError("Section %s not present in ConfigParser." % (section1,))
         if not self.has_section(section2):
-            raise ValueError('Section %s not present in ConfigParser.'\
-                             %(section2,) )
+            raise ValueError("Section %s not present in ConfigParser." % (section2,))
 
         items1 = self.options(section1)
         items2 = self.options(section2)
@@ -467,12 +489,12 @@ class InterpolatingConfigParser(DeepCopyableConfigParser):
         duplicates = [x for x in items1 if x in items2]
 
         if duplicates and raise_error:
-            raise ValueError('The following options appear in both section ' +\
-                             '%s and %s: %s' \
-                             %(section1,section2,' '.join(duplicates)))
+            raise ValueError(
+                "The following options appear in both section "
+                + "%s and %s: %s" % (section1, section2, " ".join(duplicates))
+            )
 
         return duplicates
-
 
     def get_opt_tag(self, section, option, tag):
         """
@@ -498,7 +520,6 @@ class InterpolatingConfigParser(DeepCopyableConfigParser):
             The value of the options being searched for
         """
         return self.get_opt_tags(section, option, [tag])
-
 
     def get_opt_tags(self, section, option, tags):
         """
@@ -531,36 +552,34 @@ class InterpolatingConfigParser(DeepCopyableConfigParser):
         try:
             return self.get(section, option)
         except ConfigParser.Error:
-            err_string = "No option '%s' in section [%s] " %(option,section)
+            err_string = "No option '%s' in section [%s] " % (option, section)
             if not tags:
                 raise ConfigParser.Error(err_string + ".")
             return_vals = []
             sub_section_list = []
-            for sec_len in range(1, len(tags)+1):
+            for sec_len in range(1, len(tags) + 1):
                 for tag_permutation in itertools.permutations(tags, sec_len):
-                    joined_name = '-'.join(tag_permutation)
+                    joined_name = "-".join(tag_permutation)
                     sub_section_list.append(joined_name)
-            section_list = ["%s-%s" %(section, sb) for sb in sub_section_list]
+            section_list = ["%s-%s" % (section, sb) for sb in sub_section_list]
             err_section_list = []
             for sub in sub_section_list:
-                if self.has_section('%s-%s' %(section, sub)):
-                    if self.has_option('%s-%s' %(section, sub), option):
-                        err_section_list.append("%s-%s" %(section, sub))
-                        return_vals.append(self.get('%s-%s' %(section, sub),
-                                                    option))
+                if self.has_section("%s-%s" % (section, sub)):
+                    if self.has_option("%s-%s" % (section, sub), option):
+                        err_section_list.append("%s-%s" % (section, sub))
+                        return_vals.append(self.get("%s-%s" % (section, sub), option))
 
             # We also want to recursively go into sections
 
             if not return_vals:
-                err_string += "or in sections [%s]." \
-                               %("] [".join(section_list))
+                err_string += "or in sections [%s]." % ("] [".join(section_list))
                 raise ConfigParser.Error(err_string)
             if len(return_vals) > 1:
-                err_string += "and multiple entries found in sections [%s]."\
-                              %("] [".join(err_section_list))
+                err_string += "and multiple entries found in sections [%s]." % (
+                    "] [".join(err_section_list)
+                )
                 raise ConfigParser.Error(err_string)
             return return_vals[0]
-
 
     def has_option_tag(self, section, option, tag):
         """
@@ -586,7 +605,6 @@ class InterpolatingConfigParser(DeepCopyableConfigParser):
             Is the option in the section or [section-tag]
         """
         return self.has_option_tags(section, option, [tag])
-
 
     def has_option_tags(self, section, option, tags):
         """
@@ -617,4 +635,3 @@ class InterpolatingConfigParser(DeepCopyableConfigParser):
             return True
         except ConfigParser.Error:
             return False
-

--- a/pycbc/types/config.py
+++ b/pycbc/types/config.py
@@ -27,9 +27,9 @@ This module is described in the page here:
 """
 import os
 import re
-import StringIO
 import itertools
 import logging
+from six.moves import StringIO
 from six.moves import configparser as ConfigParser
 
 class DeepCopyableConfigParser(ConfigParser.SafeConfigParser):

--- a/pycbc/workflow/configuration.py
+++ b/pycbc/workflow/configuration.py
@@ -381,8 +381,8 @@ class WorkflowConfigParser(InterpolatingConfigParser):
         """
         configFiles = [resolve_url(cFile, copy_to_cwd=copy_to_cwd)
                for cFile in configFiles]
-        
-        super(WorkflowConfigParser, self).__init__(configFiles,
+
+        InterpolatingConfigParser.__init__(self, configFiles,
                                                    overrideTuples,
                                                    parsedFilePath,
                                                    deleteTuples,
@@ -523,7 +523,7 @@ class WorkflowConfigParser(InterpolatingConfigParser):
         parser.add_argument(name, **kwds)
         args, _ = parser.parse_known_args(optstr.split())
         return getattr(args, option_name)
-        
+
     def resolve_urls(self):
         """
         This function will look through all sections of the

--- a/pycbc/workflow/configuration.py
+++ b/pycbc/workflow/configuration.py
@@ -387,8 +387,13 @@ class WorkflowConfigParser(InterpolatingConfigParser):
                                                    overrideTuples,
                                                    parsedFilePath,
                                                    deleteTuples,
-                                                   copy_to_cwd)
+                                                   copy_to_cwd,
+                                                   skip_extended=True)
+        # expand executable which statements
         self.perform_exe_expansion()
+
+        # Check for any substitutions that can be made
+        self.perform_extended_interpolation()
 
         # Resolve any URLs needing resolving
         self.curr_resolved_files = {}

--- a/pycbc/workflow/configuration.py
+++ b/pycbc/workflow/configuration.py
@@ -379,7 +379,8 @@ class WorkflowConfigParser(InterpolatingConfigParser):
         WorkflowConfigParser
             Initialized WorkflowConfigParser instance.
         """
-        configFiles = [resolve_url(cFile, copy_to_cwd=copy_to_cwd)
+        if configFiles is not None:
+            configFiles = [resolve_url(cFile, copy_to_cwd=copy_to_cwd)
                for cFile in configFiles]
 
         InterpolatingConfigParser.__init__(self, configFiles,

--- a/pycbc/workflow/configuration.py
+++ b/pycbc/workflow/configuration.py
@@ -33,14 +33,17 @@ import stat
 import string
 import shutil
 import time
-import logging
 import requests
 import distutils.spawn
 import six
 from pycbc.types.config import InterpolatingConfigParser
 from six.moves.urllib.parse import urlparse
 from six.moves import http_cookiejar as cookielib
-from six.moves.http_cookiejar import _warn_unhandled_exception, LoadError, Cookie
+from six.moves.http_cookiejar import (
+    _warn_unhandled_exception,
+    LoadError,
+    Cookie,
+)
 from bs4 import BeautifulSoup
 
 
@@ -80,9 +83,15 @@ def _really_load(self, f, filename, ignore_discard, ignore_expires):
             elif sline.startswith(("#", "$")) or sline == "":
                 continue
 
-            domain, domain_specified, path, secure, expires, name, value = line.split(
-                "\t"
-            )
+            (
+                domain,
+                domain_specified,
+                path,
+                secure,
+                expires,
+                name,
+                value,
+            ) = line.split("\t")
             secure = secure == "TRUE"
             domain_specified = domain_specified == "TRUE"
             if name == "":
@@ -225,7 +234,9 @@ def resolve_url(url, directory=None, permissions=None, copy_to_cwd=True):
 
     elif u.scheme == "http" or u.scheme == "https":
         s = requests.Session()
-        s.mount(str(u.scheme) + "://", requests.adapters.HTTPAdapter(max_retries=5))
+        s.mount(
+            str(u.scheme) + "://", requests.adapters.HTTPAdapter(max_retries=5)
+        )
 
         # look for an ecp cookie file and load the cookies
         cookie_dict = {}
@@ -240,13 +251,19 @@ def resolve_url(url, directory=None, permissions=None, copy_to_cwd=True):
             if c.domain == u.netloc:
                 # load cookies for this server
                 cookie_dict[c.name] = c.value
-            elif u.netloc == "code.pycbc.phy.syr.edu" and c.domain == "git.ligo.org":
+            elif (
+                u.netloc == "code.pycbc.phy.syr.edu"
+                and c.domain == "git.ligo.org"
+            ):
                 # handle the redirect for code.pycbc to git.ligo.org
                 cookie_dict[c.name] = c.value
 
         r = s.get(url, cookies=cookie_dict, allow_redirects=True)
         if r.status_code != 200:
-            errmsg = "Unable to download %s\nError code = %d" % (url, r.status_code)
+            errmsg = "Unable to download %s\nError code = %d" % (
+                url,
+                r.status_code,
+            )
             raise ValueError(errmsg)
 
         # if we are downloading from git.ligo.org, check that we
@@ -258,7 +275,8 @@ def resolve_url(url, directory=None, permissions=None, copy_to_cwd=True):
                 desc = soup.findAll(attrs={"property": "og:url"})
                 if (
                     len(desc)
-                    and desc[0]["content"] == "https://git.ligo.org/users/sign_in"
+                    and desc[0]["content"]
+                    == "https://git.ligo.org/users/sign_in"
                 ):
                     raise ValueError(ecp_cookie_error.format(url))
 
@@ -413,7 +431,8 @@ class WorkflowConfigParser(InterpolatingConfigParser):
         """
         if configFiles is not None:
             configFiles = [
-                resolve_url(cFile, copy_to_cwd=copy_to_cwd) for cFile in configFiles
+                resolve_url(cFile, copy_to_cwd=copy_to_cwd)
+                for cFile in configFiles
             ]
 
         InterpolatingConfigParser.__init__(
@@ -422,7 +441,6 @@ class WorkflowConfigParser(InterpolatingConfigParser):
             overrideTuples,
             parsedFilePath,
             deleteTuples,
-            copy_to_cwd,
             skip_extended=True,
         )
         # expand executable which statements
@@ -531,7 +549,9 @@ class WorkflowConfigParser(InterpolatingConfigParser):
         """
         if skip_opts is None:
             skip_opts = []
-        read_opts = [opt for opt in self.options(section) if opt not in skip_opts]
+        read_opts = [
+            opt for opt in self.options(section) if opt not in skip_opts
+        ]
         opts = []
         for opt in read_opts:
             opts.append("--{}".format(opt))

--- a/pycbc/workflow/configuration.py
+++ b/pycbc/workflow/configuration.py
@@ -36,10 +36,8 @@ import time
 import logging
 import requests
 import distutils.spawn
-import itertools
-import StringIO
 import six
-from six.moves import configparser as ConfigParser
+from pycbc.types.config import InterpolatingConfigParser
 from six.moves.urllib.parse import urlparse
 from six.moves import http_cookiejar as cookielib
 from six.moves.http_cookiejar import (_warn_unhandled_exception,
@@ -344,667 +342,6 @@ def add_workflow_command_line_group(parser):
                            "section.")
 
 
-class DeepCopyableConfigParser(ConfigParser.SafeConfigParser):
-    """
-    The standard SafeConfigParser no longer supports deepcopy() as of python
-    2.7 (see http://bugs.python.org/issue16058). This subclass restores that
-    functionality.
-    """
-    def __deepcopy__(self, memo):
-        # http://stackoverflow.com/questions/23416370
-        # /manually-building-a-deep-copy-of-a-configparser-in-python-2-7
-        config_string = StringIO.StringIO()
-        self.write(config_string)
-        config_string.seek(0)
-        new_config = self.__class__()
-        new_config.readfp(config_string)
-        return new_config
-
-class InterpolatingConfigParser(DeepCopyableConfigParser):
-    """
-    This is a sub-class of DeepCopyableConfigParser, which lets
-    us add a few additional helper features that are useful in workflows.
-    """
-    def __init__(self, configFiles=None, overrideTuples=None,
-                 parsedFilePath=None, deleteTuples=None, copy_to_cwd=False):
-        """
-        Initialize an InterpolatingConfigParser. This reads the input configuration
-        files, overrides values if necessary and performs the interpolation.
-
-        Parameters
-        -----------
-        configFiles : Path to .ini file, or list of paths
-            The file(s) to be read in and parsed.
-        overrideTuples : List of (section, option, value) tuples
-            Add the (section, option, value) triplets provided
-            in this list to the provided .ini file(s). If the section, option
-            pair is already present, it will be overwritten.
-        parsedFilePath : Path, optional (default=None)
-            If given, write the parsed .ini file back to disk at this location.
-        deleteTuples : List of (section, option) tuples
-            Delete the (section, option) pairs provided
-            in this list from provided .ini file(s). If the section only
-            is provided, the entire section will be deleted.
-        copy_to_cwd : bool, optional
-            Copy the configuration files to the current working directory if
-            they are not already there, even if they already exist locally.
-            If False, files will only be copied to the current working
-            directory if they are remote. Default is False.
-
-       Returns
-        --------
-        InterpolatingConfigParser
-            Initialized InterpolatingConfigParser instance.
-        """
-        if configFiles is None:
-            configFiles = []
-        if overrideTuples is None:
-            overrideTuples = []
-        if deleteTuples is None:
-            deleteTuples = []
-        DeepCopyableConfigParser.__init__(self)
-
-        # Enable case sensitive options
-        self.optionxform = str
-
-        configFiles = [resolve_url(cFile, copy_to_cwd=copy_to_cwd)
-                       for cFile in configFiles]
-
-        self.read_ini_file(configFiles)
-
-        # Split sections like [inspiral&tmplt] into [inspiral] and [tmplt]
-        self.split_multi_sections()
-
-        # Populate shared options from the [sharedoptions] section
-        self.populate_shared_sections()
-
-        # Do deletes from command line
-        for delete in deleteTuples:
-            if len(delete) == 1:
-                if self.remove_section(delete[0]) is False:
-                    raise ValueError("Cannot delete section %s, "
-                        "no such section in configuration." % delete )
-                else:
-                    logging.info("Deleting section %s from configuration",
-                                 delete[0])
-            elif len(delete) == 2:
-                if self.remove_option(delete[0],delete[1]) is False:
-                    raise ValueError("Cannot delete option %s from section %s,"
-                        " no such option in configuration." % delete )
-                else:
-                    logging.info("Deleting option %s from section %s in "
-                                 "configuration", delete[1], delete[0])
-            else:
-                raise ValueError("Deletes must be tuples of length 1 or 2. "
-                    "Got %s." % str(delete) )
-
-        # Do overrides from command line
-        for override in overrideTuples:
-            if len(override) not in [2,3]:
-                errmsg = "Overrides must be tuples of length 2 or 3."
-                errmsg = "Got %s." % (str(override) )
-                raise ValueError(errmsg)
-            section = override[0]
-            option = override[1]
-            value = ''
-            if len(override) == 3:
-                value = override[2]
-            # Check for section existence, create if needed
-            if not self.has_section(section):
-                self.add_section(section)
-            self.set(section, option, value)
-            logging.info("Overriding section %s option %s with value %s "
-                "in configuration.", section, option, value )
-
-        # Resolve any URLs needing resolving
-        self.curr_resolved_files = {}
-        self.resolve_urls()
-
-        # Check for any substitutions that can be made
-        self.perform_extended_interpolation()
-
-        # Check for duplicate options in sub-sections
-        self.sanity_check_subsections()
-
-        # Dump parsed .ini file if needed
-        if parsedFilePath:
-            fp = open(parsedFilePath,'w')
-            self.write(fp)
-            fp.close()
-
-    @classmethod
-    def from_cli(cls, opts):
-        """Initialize the config parser using options parsed from the command
-        line.
-
-        The parsed options ``opts`` must include options provided by
-        :py:func:`add_workflow_command_line_group`.
-
-        Parameters
-        -----------
-        opts : argparse.ArgumentParser
-            The command line arguments parsed by argparse
-        """
-        # read configuration file
-        logging.info("Reading configuration file")
-        if opts.config_overrides is not None:
-            overrides = [tuple(override.split(":", 2))
-                         for override in opts.config_overrides]
-        else:
-            overrides = None
-        if opts.config_delete is not None:
-            deletes = [tuple(delete.split(":"))
-                       for delete in opts.config_delete]
-        else:
-            deletes = None
-        return cls(opts.config_files, overrides, deleteTuples=deletes)
-
-    def read_ini_file(self, cpFile):
-        """
-        Read a .ini file and return it as a ConfigParser class.
-        This function does none of the parsing/combining of sections. It simply
-        reads the file and returns it unedited
-
-        Stub awaiting more functionality - see configparser_test.py
-
-        Parameters
-        ----------
-        cpFile : Path to .ini file, or list of paths
-            The path(s) to a .ini file to be read in
-
-        Returns
-        -------
-        cp : ConfigParser
-            The ConfigParser class containing the read in .ini file
-        """
-        # Read the file
-        self.read(cpFile)
-
-    def resolve_urls(self):
-        """
-        This function will look through all sections of the
-        ConfigParser object and replace any URLs that are given the resolve
-        magic flag with a path on the local drive.
-
-        Specifically for any values that look like
-
-        ${resolve:https://git.ligo.org/detchar/SOME_GATING_FILE.txt}
-
-        the file will be replaced with the output of resolve_url(URL)
-
-        Otherwise values will be unchanged.
-        """
-        # Only works on executables section
-        for section in self.sections():
-            for option, value in self.items(section):
-                # Check the value
-                new_str = self.resolve_file_url(value)
-                if new_str is not None and new_str != value:
-                    self.set(section, option, new_str)
-
-    def resolve_file_url(self, test_string):
-        """
-        Replace test_string with a path to an executable based on the format.
-
-        If this looks like
-
-        ${which:lalapps_tmpltbank}
-
-        it will return the equivalent of which(lalapps_tmpltbank)
-
-        Otherwise it will return an unchanged string.
-
-        Parameters
-        -----------
-        test_string : string
-            The input string
-
-        Returns
-        --------
-        new_string : string
-            The output string.
-        """
-        # First check if any interpolation is needed and abort if not
-        test_string = test_string.strip()
-        if not (test_string.startswith('${') and test_string.endswith('}')):
-            return test_string
-
-        # This may not be a "resolve" interpolation, so even if it has
-        # ${ ... } form I may not have to do anything
-
-        # Strip the ${ and }
-        test_string = test_string[2:-1]
-
-        test_list = test_string.split(':', 1)
-
-        if len(test_list) == 2:
-            if test_list[0] == 'resolve':
-                curr_lfn = os.path.basename(test_list[1])
-                if curr_lfn in self.curr_resolved_files:
-                    return self.curr_resolved_files[curr_lfn]
-                local_url = resolve_url(test_list[1])
-                self.curr_resolved_files[curr_lfn] = local_url
-                return local_url
-
-        return None
-
-
-    def get_subsections(self, section_name):
-        """ Return a list of subsections for the given section name
-        """
-        # Keep only subsection names
-        subsections = [sec[len(section_name)+1:] for sec in self.sections()\
-                       if sec.startswith(section_name + '-')]
-
-        for sec in subsections:
-            sp = sec.split('-')
-            # This is unusual, but a format [section-subsection-tag] is okay. Just
-            # check that [section-subsection] section exists. If not it is possible
-            # the user is trying to use an subsection name with '-' in it
-            if (len(sp) > 1) and not self.has_section('%s-%s' % (section_name,
-                                                                 sp[0])):
-                raise ValueError( "Workflow uses the '-' as a delimiter so "
-                    "this is interpreted as section-subsection-tag. "
-                    "While checking section %s, no section with "
-                    "name %s-%s was found. "
-                    "If you did not intend to use tags in an "
-                    "'advanced user' manner, or do not understand what "
-                    "this means, don't use dashes in section "
-                    "names. So [injection-nsbhinj] is good. "
-                    "[injection-nsbh-inj] is not." % (sec, sp[0], sp[1]))
-
-        if len(subsections) > 0:
-            return [sec.split('-')[0] for sec in subsections]
-        elif self.has_section(section_name):
-            return ['']
-        else:
-            return []
-
-    def perform_extended_interpolation(self):
-        """
-        Filter through an ini file and replace all examples of
-        ExtendedInterpolation formatting with the exact value. For values like
-        ${example} this is replaced with the value that corresponds to the
-        option called example ***in the same section***
-
-        For values like ${common|example} this is replaced with the value that
-        corresponds to the option example in the section [common]. Note that
-        in the python3 config parser this is ${common:example} but python2.7
-        interprets the : the same as a = and this breaks things
-
-        Nested interpolation is not supported here.
-        """
-
-        # Do not allow any interpolation of the section names
-        for section in self.sections():
-            for option,value in self.items(section):
-                # Check the option name
-                newStr = self.interpolate_string(option, section)
-                if newStr != option:
-                    self.set(section,newStr,value)
-                    self.remove_option(section,option)
-                # Check the value
-                newStr = self.interpolate_string(value, section)
-                if newStr != value:
-                    self.set(section,option,newStr)
-
-
-    def interpolate_string(self, testString, section):
-        """
-        Take a string and replace all example of ExtendedInterpolation
-        formatting within the string with the exact value.
-
-        For values like ${example} this is replaced with the value that
-        corresponds to the option called example ***in the same section***
-
-        For values like ${common|example} this is replaced with the value that
-        corresponds to the option example in the section [common]. Note that
-        in the python3 config parser this is ${common:example} but python2.7
-        interprets the : the same as a = and this breaks things
-
-        Nested interpolation is not supported here.
-
-        Parameters
-        ----------
-        testString : String
-            The string to parse and interpolate
-        section : String
-            The current section of the ConfigParser object
-
-        Returns
-        ----------
-        testString : String
-            Interpolated string
-        """
-
-        # First check if any interpolation is needed and abort if not
-        reObj = re.search(r"\$\{.*?\}", testString)
-        while reObj:
-            # Not really sure how this works, but this will obtain the first
-            # instance of a string contained within ${....}
-            repString = (reObj).group(0)[2:-1]
-            # Need to test which of the two formats we have
-            splitString = repString.split('|')
-            if len(splitString) == 1:
-                try:
-                    testString = testString.replace('${'+repString+'}',\
-                                            self.get(section,splitString[0]))
-                except ConfigParser.NoOptionError:
-                    print("Substitution failed")
-                    raise
-            if len(splitString) == 2:
-                try:
-                    testString = testString.replace('${'+repString+'}',\
-                                       self.get(splitString[0],splitString[1]))
-                except ConfigParser.NoOptionError:
-                    print("Substitution failed")
-                    raise
-            reObj = re.search(r"\$\{.*?\}", testString)
-
-        return testString
-
-
-    def split_multi_sections(self):
-        """
-        Parse through the WorkflowConfigParser instance and splits any sections
-        labelled with an "&" sign (for e.g. [inspiral&tmpltbank]) into
-        [inspiral] and [tmpltbank] sections. If these individual sections
-        already exist they  will be appended to. If an option exists in both the
-        [inspiral] and [inspiral&tmpltbank] sections an error will be thrown
-        """
-        # Begin by looping over all sections
-        for section in self.sections():
-            # Only continue if section needs splitting
-            if '&' not in section:
-                continue
-            # Get list of section names to add these options to
-            splitSections = section.split('&')
-            for newSec in splitSections:
-                # Add sections if they don't already exist
-                if not self.has_section(newSec):
-                    self.add_section(newSec)
-                self.add_options_to_section(newSec, self.items(section))
-            self.remove_section(section)
-
-    def populate_shared_sections(self):
-        """Parse the [sharedoptions] section of the ini file.
-
-        That section should contain entries according to:
-
-          * massparams = inspiral, tmpltbank
-          * dataparams = tmpltbank
-
-        This will result in all options in [sharedoptions-massparams] being
-        copied into the [inspiral] and [tmpltbank] sections and the options
-        in [sharedoptions-dataparams] being copited into [tmpltbank].
-        In the case of duplicates an error will be raised.
-        """
-        if not self.has_section('sharedoptions'):
-            # No sharedoptions, exit
-            return
-        for key, value in self.items('sharedoptions'):
-            assert(self.has_section('sharedoptions-%s' %(key)))
-            # Comma separated
-            values = value.split(',')
-            common_options = self.items('sharedoptions-%s' %(key))
-            for section in values:
-                if not self.has_section(section):
-                    self.add_section(section)
-                for arg, val in common_options:
-                    if arg in self.options(section):
-                        raise ValueError('Option exists in both original ' + \
-                               'ConfigParser section [%s] and ' %(section,) + \
-                               'sharedoptions section: %s %s' \
-                               %(arg,'sharedoptions-%s' %(key)))
-                    self.set(section, arg, val)
-            self.remove_section('sharedoptions-%s' %(key))
-        self.remove_section('sharedoptions')
-
-    def add_options_to_section(self ,section, items, overwrite_options=False):
-        """
-        Add a set of options and values to a section of a ConfigParser object.
-        Will throw an error if any of the options being added already exist,
-        this behaviour can be overridden if desired
-
-        Parameters
-        ----------
-        section : string
-            The name of the section to add options+values to
-        items : list of tuples
-            Each tuple contains (at [0]) the option and (at [1]) the value to
-            add to the section of the ini file
-        overwrite_options : Boolean, optional
-            By default this function will throw a ValueError if an option exists
-            in both the original section in the ConfigParser *and* in the
-            provided items.
-            This will override so that the options+values given in items
-            will replace the original values if the value is set to True.
-            Default = True
-        """
-        # Sanity checking
-        if not self.has_section(section):
-            raise ValueError('Section %s not present in ConfigParser.' \
-                             %(section,))
-
-        # Check for duplicate options first
-        for option,value in items:
-            if not overwrite_options:
-                if option in self.options(section):
-                    raise ValueError('Option exists in both original ' + \
-                                  'ConfigParser section [%s] and ' %(section,) + \
-                                  'input list: %s' %(option,))
-            self.set(section,option,value)
-
-
-    def sanity_check_subsections(self):
-        """
-        This function goes through the ConfigParset and checks that any options
-        given in the [SECTION_NAME] section are not also given in any
-        [SECTION_NAME-SUBSECTION] sections.
-
-        """
-        # Loop over the sections in the ini file
-        for section in self.sections():
-            # [pegasus_profile] specially is allowed to be overriden by
-            # sub-sections
-            if section == 'pegasus_profile':
-                continue
-
-            # Loop over the sections again
-            for section2 in self.sections():
-                # Check if any are subsections of section
-                if section2.startswith(section + '-'):
-                    # Check for duplicate options whenever this exists
-                    self.check_duplicate_options(section, section2,
-                                                 raise_error=True)
-
-
-    def check_duplicate_options(self, section1, section2, raise_error=False):
-        """
-        Check for duplicate options in two sections, section1 and section2.
-        Will return a list of the duplicate options.
-
-        Parameters
-        ----------
-        section1 : string
-            The name of the first section to compare
-        section2 : string
-            The name of the second section to compare
-        raise_error : Boolean, optional (default=False)
-            If True, raise an error if duplicates are present.
-
-        Returns
-        ----------
-        duplicates : List
-            List of duplicate options
-        """
-        # Sanity checking
-        if not self.has_section(section1):
-            raise ValueError('Section %s not present in ConfigParser.'\
-                             %(section1,) )
-        if not self.has_section(section2):
-            raise ValueError('Section %s not present in ConfigParser.'\
-                             %(section2,) )
-
-        items1 = self.options(section1)
-        items2 = self.options(section2)
-
-        # The list comprehension here creates a list of all duplicate items
-        duplicates = [x for x in items1 if x in items2]
-
-        if duplicates and raise_error:
-            raise ValueError('The following options appear in both section ' +\
-                             '%s and %s: %s' \
-                             %(section1,section2,' '.join(duplicates)))
-
-        return duplicates
-
-
-    def get_opt_tag(self, section, option, tag):
-        """
-        Convenience function accessing get_opt_tags() for a single tag: see
-        documentation for that function.
-        NB calling get_opt_tags() directly is preferred for simplicity.
-
-        Parameters
-        -----------
-        self : ConfigParser object
-            The ConfigParser object (automatically passed when this is appended
-            to the ConfigParser class)
-        section : string
-            The section of the ConfigParser object to read
-        option : string
-            The ConfigParser option to look for
-        tag : string
-            The name of the subsection to look in, if not found in [section]
-
-        Returns
-        --------
-        string
-            The value of the options being searched for
-        """
-        return self.get_opt_tags(section, option, [tag])
-
-
-    def get_opt_tags(self, section, option, tags):
-        """
-        Supplement to ConfigParser.ConfigParser.get(). This will search for an
-        option in [section] and if it doesn't find it will also try in
-        [section-tag] for every value of tag in tags.
-        Will raise a ConfigParser.Error if it cannot find a value.
-
-        Parameters
-        -----------
-        self : ConfigParser object
-            The ConfigParser object (automatically passed when this is appended
-            to the ConfigParser class)
-        section : string
-            The section of the ConfigParser object to read
-        option : string
-            The ConfigParser option to look for
-        tags : list of strings
-            The name of subsections to look in, if not found in [section]
-
-        Returns
-        --------
-        string
-            The value of the options being searched for
-        """
-        # Need lower case tag name; also exclude cases with tag=None
-        if tags:
-            tags = [tag.lower() for tag in tags if tag is not None]
-
-        try:
-            return self.get(section, option)
-        except ConfigParser.Error:
-            err_string = "No option '%s' in section [%s] " %(option,section)
-            if not tags:
-                raise ConfigParser.Error(err_string + ".")
-            return_vals = []
-            sub_section_list = []
-            for sec_len in range(1, len(tags)+1):
-                for tag_permutation in itertools.permutations(tags, sec_len):
-                    joined_name = '-'.join(tag_permutation)
-                    sub_section_list.append(joined_name)
-            section_list = ["%s-%s" %(section, sb) for sb in sub_section_list]
-            err_section_list = []
-            for sub in sub_section_list:
-                if self.has_section('%s-%s' %(section, sub)):
-                    if self.has_option('%s-%s' %(section, sub), option):
-                        err_section_list.append("%s-%s" %(section, sub))
-                        return_vals.append(self.get('%s-%s' %(section, sub),
-                                                    option))
-
-            # We also want to recursively go into sections
-
-            if not return_vals:
-                err_string += "or in sections [%s]." \
-                               %("] [".join(section_list))
-                raise ConfigParser.Error(err_string)
-            if len(return_vals) > 1:
-                err_string += "and multiple entries found in sections [%s]."\
-                              %("] [".join(err_section_list))
-                raise ConfigParser.Error(err_string)
-            return return_vals[0]
-
-
-    def has_option_tag(self, section, option, tag):
-        """
-        Convenience function accessing has_option_tags() for a single tag: see
-        documentation for that function.
-        NB calling has_option_tags() directly is preferred for simplicity.
-
-        Parameters
-        -----------
-        self : ConfigParser object
-            The ConfigParser object (automatically passed when this is appended
-            to the ConfigParser class)
-        section : string
-            The section of the ConfigParser object to read
-        option : string
-            The ConfigParser option to look for
-        tag : string
-            The name of the subsection to look in, if not found in [section]
-
-        Returns
-        --------
-        Boolean
-            Is the option in the section or [section-tag]
-        """
-        return self.has_option_tags(section, option, [tag])
-
-
-    def has_option_tags(self, section, option, tags):
-        """
-        Supplement to ConfigParser.ConfigParser.has_option().
-        This will search for an option in [section] and if it doesn't find it
-        will also try in [section-tag] for each value in tags.
-        Returns True if the option is found and false if not.
-
-        Parameters
-        -----------
-        self : ConfigParser object
-            The ConfigParser object (automatically passed when this is appended
-            to the ConfigParser class)
-        section : string
-            The section of the ConfigParser object to read
-        option : string
-            The ConfigParser option to look for
-        tags : list of strings
-            The names of the subsection to look in, if not found in [section]
-
-        Returns
-        --------
-        Boolean
-            Is the option in the section or [section-tag] (for tag in tags)
-        """
-        try:
-            self.get_opt_tags(section, option, tags)
-            return True
-        except ConfigParser.Error:
-            return False
-
-
 class WorkflowConfigParser(InterpolatingConfigParser):
     """
     This is a sub-class of InterpolatingConfigParser, which lets
@@ -1042,12 +379,19 @@ class WorkflowConfigParser(InterpolatingConfigParser):
         WorkflowConfigParser
             Initialized WorkflowConfigParser instance.
         """
+        configFiles = [resolve_url(cFile, copy_to_cwd=copy_to_cwd)
+               for cFile in configFiles]
+        
         super(WorkflowConfigParser, self).__init__(configFiles,
                                                    overrideTuples,
                                                    parsedFilePath,
                                                    deleteTuples,
                                                    copy_to_cwd)
         self.perform_exe_expansion()
+
+        # Resolve any URLs needing resolving
+        self.curr_resolved_files = {}
+        self.resolve_urls()
 
     def perform_exe_expansion(self):
         """
@@ -1179,3 +523,71 @@ class WorkflowConfigParser(InterpolatingConfigParser):
         parser.add_argument(name, **kwds)
         args, _ = parser.parse_known_args(optstr.split())
         return getattr(args, option_name)
+        
+    def resolve_urls(self):
+        """
+        This function will look through all sections of the
+        ConfigParser object and replace any URLs that are given the resolve
+        magic flag with a path on the local drive.
+
+        Specifically for any values that look like
+
+        ${resolve:https://git.ligo.org/detchar/SOME_GATING_FILE.txt}
+
+        the file will be replaced with the output of resolve_url(URL)
+
+        Otherwise values will be unchanged.
+        """
+        # Only works on executables section
+        for section in self.sections():
+            for option, value in self.items(section):
+                # Check the value
+                new_str = self.resolve_file_url(value)
+                if new_str is not None and new_str != value:
+                    self.set(section, option, new_str)
+
+    def resolve_file_url(self, test_string):
+        """
+        Replace test_string with a path to an executable based on the format.
+
+        If this looks like
+
+        ${which:lalapps_tmpltbank}
+
+        it will return the equivalent of which(lalapps_tmpltbank)
+
+        Otherwise it will return an unchanged string.
+
+        Parameters
+        -----------
+        test_string : string
+            The input string
+
+        Returns
+        --------
+        new_string : string
+            The output string.
+        """
+        # First check if any interpolation is needed and abort if not
+        test_string = test_string.strip()
+        if not (test_string.startswith('${') and test_string.endswith('}')):
+            return test_string
+
+        # This may not be a "resolve" interpolation, so even if it has
+        # ${ ... } form I may not have to do anything
+
+        # Strip the ${ and }
+        test_string = test_string[2:-1]
+
+        test_list = test_string.split(':', 1)
+
+        if len(test_list) == 2:
+            if test_list[0] == 'resolve':
+                curr_lfn = os.path.basename(test_list[1])
+                if curr_lfn in self.curr_resolved_files:
+                    return self.curr_resolved_files[curr_lfn]
+                local_url = resolve_url(test_list[1])
+                self.curr_resolved_files[curr_lfn] = local_url
+                return local_url
+
+        return None


### PR DESCRIPTION
This moves the interpolating features added to ConfigParser to a separate class which can be called outside of a workflow context (and without partially pulling in a Pegasus dependency).  This also drops the glue.pipeline dependence within the core pycbc library (some old exes still remain). 