### PR TITLE
MCMC history in workflow

### DIFF
--- a/bin/inference/pycbc_inference_plot_mcmc_history
+++ b/bin/inference/pycbc_inference_plot_mcmc_history
@@ -17,6 +17,7 @@
 
 """Makes a plot of MCMC parameters saved over checkpoint history.."""
 
+import sys
 import logging
 import argparse
 
@@ -27,6 +28,7 @@ from matplotlib import pyplot
 
 import pycbc
 from pycbc.inference import io
+from pycbc.results import metadata
 
 parser = argparse.ArgumentParser(description=__doc__)
 parser.add_argument('--input-file', type=str, required=True,
@@ -103,20 +105,28 @@ fig, axes = pyplot.subplots(nrows=nplots, figsize=(8, 3*nplots))
 if nplots == 1:
     axes = [axes]
 pi = -1
-xmin = iterations.min() - 1
-xmax = iterations.max() + 1
+dx = iterations.max() - iterations.min()
+if dx == 0:
+    dx = 1
+xmin = iterations.min() - 0.025*dx
+xmax = iterations.max() + 0.025*dx
+
+caption = ("Status of the sampler at each checkpoint iteration (indicated by "
+           "the x markers). Shown are:")
 
 if opts.plot_checkpoint_dt:
     pi += 1
     ax = axes[pi]
-    ax.plot(iterations, checkpoint_dt/60., lw=2)
+    ax.plot(iterations, checkpoint_dt/60., lw=2, marker='x')
     ax.set_ylabel('wallclock dt (m)')
     ax.set_xlim(xmin, xmax)
+    caption += (" ({}) the amount of wall-clock time between checkpoints "
+                "(in minutes);".format(pi+1))
 
 if opts.plot_act:
     pi += 1
     ax = axes[pi]
-    ax.plot(iterations, acts, lw=2, zorder=1)
+    ax.plot(iterations, acts, lw=2, marker='x', zorder=1)
     if raw_acts.ndim == 2:
         # plot each of the chains separately
         for ii in range(raw_acts.shape[0]):
@@ -125,24 +135,35 @@ if opts.plot_act:
                     zorder=0)
     ax.set_ylabel('ACT')
     ax.set_xlim(xmin, xmax)
+    caption += (" ({}) the autocorrelation time (ACT) as computed from the "
+                "estimated burn-in iteration to the end of the chain(s) at "
+                "the checkpoint;".format(pi+1))
 
 if opts.plot_effective_nsamples:
     pi += 1
     ax = axes[pi]
-    ax.plot(iterations, nsamples, lw=2, zorder=1)
+    ax.plot(iterations, nsamples, lw=2, marker='x', zorder=1)
     ax.set_ylabel(r'eff. N samples')
     ax.set_xlim(xmin, xmax)
+    caption += (" ({}) the estimateed effective number of samples post "
+                "burn-in at that checkpoint;".format(pi+1))
 
 if opts.plot_nchains_burned_in:
     pi += 1
     ax = axes[pi]
-    ax.plot(iterations, nchains_burned_in, lw=2, zorder=1)
+    ax.plot(iterations, nchains_burned_in, lw=2, marker='x', zorder=1)
     # put a horizontal line at the total number of chains
     ax.axhline(nchains, ls='--', color='C3', zorder=0)
     ax.set_ylabel(r'N chains burned in')
     ax.set_xlim(xmin, xmax)
+    caption += (" ({}) the number of chains that are burned in at the  "
+                "checkpoint (for ensemble samplers, this will either be all "
+                "or nothing), and the total number of chains (red dashed "
+                "line);".format(pi+1))
 
 ax.set_xlabel('iteration')
+# replace the traling semicolon with a period
+caption = caption[:-1] + "."
 
 # common settings
 for ii, ax in enumerate(axes):
@@ -151,4 +172,10 @@ for ii, ax in enumerate(axes):
     if ii < len(axes) - 1:
         ax.set_xticklabels([])
 
-fig.savefig(opts.output_file, bbox_inches='tight')
+# save
+metadata.save_fig_with_metadata(
+    fig, opts.output_file,
+    cmd=" ".join(sys.argv),
+    title="MCMC history",
+    caption=caption,
+    fig_kwds={'bbox_inches': 'tight'})

--- a/pycbc/workflow/inference_followups.py
+++ b/pycbc/workflow/inference_followups.py
@@ -444,6 +444,40 @@ def make_inference_acceptance_rate_plot(workflow, inference_file, output_dir,
     return node.output_files
 
 
+def make_inference_plot_mcmc_history(workflow, inference_file, output_dir,
+                                     name="plot_mcmc_history",
+                                     analysis_seg=None, tags=None):
+    """Sets up a plot showing the checkpoint history of an MCMC sampler.
+
+    Parameters
+    ----------
+    workflow: pycbc.workflow.Workflow
+        The core workflow instance we are populating
+    inference_file: pycbc.workflow.File
+        The file with posterior samples.
+    output_dir: str
+        The directory to store result plots and files.
+    name: str, optional
+        The name in the [executables] section of the configuration file
+        to use, and the section to read for additional arguments to pass to
+        the executable. Default is ``plot_mcmc_history``.
+    analysis_segs: ligo.segments.Segment, optional
+       The segment this job encompasses. If None then use the total analysis
+       time from the workflow.
+    tags: list, optional
+        Tags to add to the inference executables.
+
+    Returns
+    -------
+    pycbc.workflow.FileList
+        A list of output files.
+    """
+    node = make_inference_plot(workflow, inference_file, output_dir,
+                               name, analysis_seg=analysis_seg, tags=tags,
+                               add_to_workflow=True)
+    return node.output_files
+
+
 def make_inference_dynesty_run_plot(workflow, inference_file, output_dir,
                                     name="plot_dynesty_run",
                                     analysis_seg=None, tags=None):
@@ -460,7 +494,7 @@ def make_inference_dynesty_run_plot(workflow, inference_file, output_dir,
     name: str, optional
         The name in the [executables] section of the configuration file
         to use, and the section to read for additional arguments to pass to
-        the executable. Default is ``plot_acceptance_rate``.
+        the executable. Default is ``plot_dynesty_run``.
     analysis_segs: ligo.segments.Segment, optional
        The segment this job encompasses. If None then use the total analysis
        time from the workflow.
@@ -494,7 +528,7 @@ def make_inference_dynesty_trace_plot(workflow, inference_file, output_dir,
     name: str, optional
         The name in the [executables] section of the configuration file
         to use, and the section to read for additional arguments to pass to
-        the executable. Default is ``plot_acceptance_rate``.
+        the executable. Default is ``plot_dynesty_traceplot``.
     analysis_segs: ligo.segments.Segment, optional
        The segment this job encompasses. If None then use the total analysis
        time from the workflow.
@@ -690,6 +724,8 @@ def get_diagnostic_plots(workflow):
         diagnostics.append('samples')
     if "plot_acceptance_rate" in workflow.cp.options("executables"):
         diagnostics.append('acceptance_rate')
+    if "plot_mcmc_history" in workflow.cp.options("executable"):
+        diagnostics.append('mcmc_history')
     if "plot_dynesty_run" in workflow.cp.options("executables"):
         diagnostics.append('dynesty_run')
     if "plot_dynesty_traceplot" in workflow.cp.options("executables"):
@@ -759,6 +795,18 @@ def make_diagnostic_plots(workflow, diagnostics, samples_file, label, rdir,
                 tags=tags+[label, str(kk)])
         out['acceptance_rate'] = acceptance_plots
         layout.single_layout(rdir[base], acceptance_plots)
+
+    if 'mcmc_history' in diagnostics:
+        # files for samples mcmc history subsection
+        base = "mcmc_history/{}".format(label)
+        acceptance_plots = []
+        for kk, sf in enumerate(samples_file):
+            history_plots += make_inference_plot_mcmc_history(
+                workflow, sf, rdir[base],
+                analysis_seg=workflow.analysis_time,
+                tags=tags+[label, str(kk)])
+        out['mcmc_history'] = history_plots
+        layout.single_layout(rdir[base], history_plots)
 
     if 'dynesty_run' in diagnostics:
         # files for dynesty run subsection

--- a/pycbc/workflow/inference_followups.py
+++ b/pycbc/workflow/inference_followups.py
@@ -724,7 +724,7 @@ def get_diagnostic_plots(workflow):
         diagnostics.append('samples')
     if "plot_acceptance_rate" in workflow.cp.options("executables"):
         diagnostics.append('acceptance_rate')
-    if "plot_mcmc_history" in workflow.cp.options("executable"):
+    if "plot_mcmc_history" in workflow.cp.options("executables"):
         diagnostics.append('mcmc_history')
     if "plot_dynesty_run" in workflow.cp.options("executables"):
         diagnostics.append('dynesty_run')
@@ -799,7 +799,7 @@ def make_diagnostic_plots(workflow, diagnostics, samples_file, label, rdir,
     if 'mcmc_history' in diagnostics:
         # files for samples mcmc history subsection
         base = "mcmc_history/{}".format(label)
-        acceptance_plots = []
+        history_plots = []
         for kk, sf in enumerate(samples_file):
             history_plots += make_inference_plot_mcmc_history(
                 workflow, sf, rdir[base],


### PR DESCRIPTION
Adds MCMC history plots as an optional diagnostic in the inference workflow. Adds caption to the plots for displaying on results page. Also adds markers to the plots to make them more legible when they are only 1 or fewer points. Example can be found in section 6, [here](https://www.atlas.aei.uni-hannover.de/~work-cdcapano/projects/pycbc_inference/gw150914_example/gw150914_test-emcee/).