### PR TITLE
add detectors with config file

### DIFF
--- a/pycbc/detector.py
+++ b/pycbc/detector.py
@@ -143,12 +143,15 @@ def load_detector_config(config_files):
         try:
             args = [kwds.pop(arg) for arg in arg_names]
         except KeyError as e:
-            raise ValueError("missing required detector argument") from e
+            raise ValueError("missing required detector argument"
+                             " {} are required".format(arg_names))
         method(det.upper(), *args, **kwds)
+
 
 # autoload detector config files
 if 'PYCBC_DETECTOR_CONFIG' in os.environ:
     load_detector_config(os.environ['PYCBC_DETECTOR_CONFIG'].split(':'))
+
 
 class Detector(object):
     """A gravitational wave detector


### PR DESCRIPTION
This adds the capability to expand the pycbc detector set with a config file. The config file can either be read using the 'load_detector_config' function manually (i.e. in a custom script), or it can be autoloaded using the environment variable "PYCBC_DETECTOR_CONFIG". 

I've written it in such a way that we can add other methods in the future for describing detectors. The thinking is that we may want different formats for things like space-based detectors. 

Example config file
```
[detector-r1]
method = earth_normal
longitude = -2.0840567691659397
latitude = 0.810795263791696
yangle = 4.084080696105957
```