### PR TITLE
generate lal detector type from pycbc detector

### DIFF
--- a/pycbc/detector.py
+++ b/pycbc/detector.py
@@ -177,9 +177,9 @@ class Detector(object):
 
         if detector_name in [pfx for pfx, name in get_available_detectors()]:
             import lalsimulation as lalsim
-            self._frDetector = lalsim.DetectorPrefixToLALDetector(self.name)
-            self.response = self._frDetector.response
-            self.location = self._frDetector.location
+            self._lal = lalsim.DetectorPrefixToLALDetector(self.name)
+            self.response = self._lal.response
+            self.location = self._lal.location
         elif detector_name in _custom_ground_detectors:
             self.info = _custom_ground_detectors[detector_name]
             self.response = self.info['response']
@@ -208,8 +208,8 @@ class Detector(object):
 
     def lal(self):
         """ Return lal data type detector instance """
-        if hasattr(self, '_frDetector'):
-            return self._frDetector
+        if hasattr(self, '_lal'):
+            return self._lal
         else:
             import lal
             d = lal.FrDetector()
@@ -229,6 +229,7 @@ class Detector(object):
 
             x = lal.Detector()
             r = lal.CreateDetector(x, d, lal.LALDETECTORTYPE_IFODIFF)
+            self._lal = r
             return r
 
     def gmst_estimate(self, gps_time):

--- a/pycbc/detector.py
+++ b/pycbc/detector.py
@@ -206,9 +206,8 @@ class Detector(object):
             raise RuntimeError("Can't get accurate sidereal time without GPS "
                                "reference time!")
 
-    def to_lal(self):
+    def lal(self):
         """ Return lal data type detector instance """
-        print("HI")
         if hasattr(self, '_frDetector'):
             return self._frDetector
         else:
@@ -439,7 +438,7 @@ class Detector(object):
             import lalsimulation
             h_lal = lalsimulation.SimDetectorStrainREAL8TimeSeries(
                     hp.astype(np.float64).lal(), hc.astype(np.float64).lal(),
-                    ra, dec, polarization, self.to_lal())
+                    ra, dec, polarization, self.lal())
             ts = TimeSeries(
                     h_lal.data.data, delta_t=h_lal.deltaT, epoch=h_lal.epoch,
                     dtype=np.float64, copy=False)

--- a/pycbc/detector.py
+++ b/pycbc/detector.py
@@ -117,6 +117,11 @@ def add_detector_on_earth(name, longitude, latitude,
                     loc.z.value])
     _custom_ground_detectors[name] = {'location': loc,
                                       'response': resp,
+                                      'yangle': yangle,
+                                      'xangle': xangle,
+                                      'height': height,
+                                      'xaltitude': 0.0,
+                                      'yaltitude': 0.0,
                                       }
 
 def load_detector_config(config_files):
@@ -172,13 +177,13 @@ class Detector(object):
 
         if detector_name in [pfx for pfx, name in get_available_detectors()]:
             import lalsimulation as lalsim
-            self.frDetector = lalsim.DetectorPrefixToLALDetector(self.name)
-            self.response = self.frDetector.response
-            self.location = self.frDetector.location
+            self._frDetector = lalsim.DetectorPrefixToLALDetector(self.name)
+            self.response = self._frDetector.response
+            self.location = self._frDetector.location
         elif detector_name in _custom_ground_detectors:
-            dinfo = _custom_ground_detectors[detector_name]
-            self.response = dinfo['response']
-            self.location = dinfo['location']
+            self.info = _custom_ground_detectors[detector_name]
+            self.response = self.info['response']
+            self.location = self.info['location']
         else:
             raise ValueError("Unkown detector {}".format(detector_name))
 
@@ -200,6 +205,32 @@ class Detector(object):
         else:
             raise RuntimeError("Can't get accurate sidereal time without GPS "
                                "reference time!")
+
+    def to_lal(self):
+        """ Return lal data type detector instance """
+        print("HI")
+        if hasattr(self, '_frDetector'):
+            return self._frDetector
+        else:
+            import lal
+            d = lal.FrDetector()
+            d.vertexLongitudeRadians = self.longitude
+            d.vertexLatitudeRadians = self.latitude
+            d.vertexElevation = self.info['height']
+            d.xArmAzimuthRadians = self.info['xangle']
+            d.yArmAzimuthRadians = self.info['yangle']
+            d.xArmAltitudeRadians = self.info['yaltitude']
+            d.xArmAltitudeRadians = self.info['xaltitude']
+
+            # This is somewhat abused by lalsimulation at the moment
+            # to determine a filter kernel size. We set this only so that
+            # value gets a similar number of samples as other detectors
+            # it is used for nothing else
+            d.yArmMidpoint = 4000.0
+
+            x = lal.Detector()
+            r = lal.CreateDetector(x, d, lal.LALDETECTORTYPE_IFODIFF)
+            return r
 
     def gmst_estimate(self, gps_time):
         if self.reference_time is None:
@@ -408,7 +439,7 @@ class Detector(object):
             import lalsimulation
             h_lal = lalsimulation.SimDetectorStrainREAL8TimeSeries(
                     hp.astype(np.float64).lal(), hc.astype(np.float64).lal(),
-                    ra, dec, polarization, self.frDetector)
+                    ra, dec, polarization, self.to_lal())
             ts = TimeSeries(
                     h_lal.data.data, delta_t=h_lal.deltaT, epoch=h_lal.epoch,
                     dtype=np.float64, copy=False)

--- a/test/test_detector.py
+++ b/test/test_detector.py
@@ -50,7 +50,7 @@ class TestDetector(unittest.TestCase):
     def test_light_time(self):
         for d1 in self.d:
             for d2 in self.d:
-                t1 = lal.LightTravelTime(d1.frDetector, d2.frDetector) * 1e-9
+                t1 = lal.LightTravelTime(d1.lal(), d2.lal()) * 1e-9
                 t2 = d1.light_travel_time_to_detector(d2)
                 self.assertAlmostEqual(t1, t2, 7)
 


### PR DESCRIPTION
This allows custom detectors in pycbc to be transformed to an instance of the lal detector struct.

There are some things to note here. First, some of the fields if you look at the lal code are unused, and the 'midpoint' ones in particular are a bit misused. I've noted this in our documentation in case this changes. I think the intention was to eventually implement code that didn't assume a long arm length, however, that does not exist in lal at the moment (I've carefully read what the code is doing). 

Depends on #3597 