### PR TITLE
Fix the help message for stageout script

### DIFF
--- a/bin/pycbc_copy_output_map
+++ b/bin/pycbc_copy_output_map
@@ -18,7 +18,7 @@ while true
 do
     case "$1" in
 	-h|--help)
-	    echo "usage: pycbc_copy_output_map [-h] input_map output_map [optional arguments]"
+	    echo "usage: pycbc_copy_output_map [-h] -i input_map -o output_map [optional arguments]"
 	    echo
 	    echo "required arguments:"
 	    echo "  -i, --input-file        the .map file that will be copied from"

--- a/bin/pycbc_stageout_failed_workflow
+++ b/bin/pycbc_stageout_failed_workflow
@@ -14,7 +14,7 @@ while true
 do
     case "$1" in
 	-h|--help)
-	    echo "usage: pycbc_copy_output_map [-h] input_map output_map [optional arguments]"
+	    echo "usage: pycbc_copy_output_map [-h] workflow_directory [optional arguments]"
 	    echo
 	    echo "required arguments:"
 	    echo "  -d, --workflow-dir    the directory of the workflow to be staged out"

--- a/bin/pycbc_stageout_failed_workflow
+++ b/bin/pycbc_stageout_failed_workflow
@@ -14,7 +14,7 @@ while true
 do
     case "$1" in
 	-h|--help)
-	    echo "usage: pycbc_copy_output_map [-h] workflow_directory [optional arguments]"
+	    echo "usage: pycbc_copy_output_map [-h] -d workflow_directory [optional arguments]"
 	    echo
 	    echo "required arguments:"
 	    echo "  -d, --workflow-dir    the directory of the workflow to be staged out"


### PR DESCRIPTION
Just a quick change to the help message of pycbc_stageout_failed_workflow