### PR TITLE
fix plive test

### DIFF
--- a/examples/live/check_results.py
+++ b/examples/live/check_results.py
@@ -195,7 +195,7 @@ log.basicConfig(level=log.INFO, format='%(asctime)s %(message)s')
 
 # gps times need to match those found in run.sh
 sim_gps_start = 1272790000
-sim_gps_end = 1272790500
+sim_gps_end = 1272790512
 
 # sim f lower needs to match the value in generate_injection.sh
 sim_f_lower = 18

--- a/examples/live/run.sh
+++ b/examples/live/run.sh
@@ -8,7 +8,7 @@ export OMP_NUM_THREADS=4
 export HDF5_USE_FILE_LOCKING="FALSE"
 
 gps_start_time=1272790000
-gps_end_time=1272790500
+gps_end_time=1272790512
 
 
 # test if there is a template bank. If not, make one

--- a/examples/live/run.sh
+++ b/examples/live/run.sh
@@ -163,7 +163,8 @@ python -m mpi4py `which pycbc_live` \
 --ifar-upload-threshold 0.0001 \
 --round-start-time 4 \
 --start-time $gps_start_time \
---end-time $gps_end_time
+--end-time $gps_end_time \
+--verbose
 
 echo -e "\\n\\n>> [`date`] Checking results"
 ./check_results.py

--- a/pycbc/strain/strain.py
+++ b/pycbc/strain/strain.py
@@ -1381,7 +1381,7 @@ class StrainBuffer(pycbc.frame.DataBuffer):
           self.highpass_bandwidth / self.raw_buffer.sample_rate * 2 * numpy.pi)
         self.highpass_samples =  int(highpass_samples / 2)
         resample_corruption = 10 # If using the ldas method
-        self.factor = int(1.0 / self.raw_buffer.delta_t / self.sample_rate)
+        self.factor = round(1.0 / self.raw_buffer.delta_t / self.sample_rate)
         self.corruption = self.highpass_samples // self.factor + resample_corruption
 
         self.psd_corruption =  self.psd_inverse_length * self.sample_rate

--- a/pycbc/types/timeseries.py
+++ b/pycbc/types/timeseries.py
@@ -184,6 +184,12 @@ class TimeSeries(Array):
         start_idx = float(start - self.start_time) * self.sample_rate
         end_idx = float(end - self.start_time) * self.sample_rate
 
+        if _numpy.isclose(start_idx, round(start_idx)):
+            start_idx = round(start_idx)
+
+        if _numpy.isclose(end_idx, round(end_idx)):
+            end_idx = round(end_idx)
+
         if mode == 'floor':
             start_idx = int(start_idx)
             end_idx = int(end_idx)


### PR DESCRIPTION
* set the amount of data to create to a multiple of 32 so that every file is the same size
* fix a rounding issue in time slice
    * found edge case where the index was within floating point precision of an exact index value. This occured at exactly an integer start time which causes condition strain (and write_frame) to fail due to needing to output second boundary frame files. This case is also not what was intended by the rounding mode option to time slice, whereby you might ask for a time *in between* sample rates and that's not clear we want to round to the nearest (hence the option). However, if we give the exact right time for a given index value, we do want it to use that index. 
* fix issue in rounding of factor between internal raw data sample rate and the strain data 
    * found edge case where this would round to an incorrect factor. 