### PR TITLE
Only accept points that have larger logl in dynesty rwalk

### DIFF
--- a/pycbc/inference/sampler/dynesty.py
+++ b/pycbc/inference/sampler/dynesty.py
@@ -525,7 +525,7 @@ def sample_rwalk_mod(args):
         # Check proposed point.
         v_prop = prior_transform(numpy.array(u_prop))
         logl_prop = loglikelihood(numpy.array(v_prop))
-        if logl_prop >= loglstar:
+        if logl_prop > loglstar:
             u = u_prop
             v = v_prop
             logl = logl_prop


### PR DESCRIPTION
The rwalk2 method we use for dynesty will accept points if the new loglikelihood is the same or greater than the current max point. This may be causing issues with drawing bounding ellipsoids. This changes it to only accept if a new point has greater logl.