### PR TITLE
Add FromFile injection type

### DIFF
--- a/pycbc/inject/inject.py
+++ b/pycbc/inject/inject.py
@@ -838,8 +838,9 @@ class FromFileHDFInjectionSet(_HDFInjectionSet):
             try:
                 channel = inj.channel
             except AttributeError as _err:
+                # Py3.XX: uncomment the "from _err" when we drop 2.7
                 raise ValueError("Must provide a channel for "
-                                 "frame files") from _err
+                                 "frame files") #from _err
             ts = frame.read_frame(inj.filename, channel)
         else:
             ts = load_timeseries(inj.filename)
@@ -854,8 +855,9 @@ class FromFileHDFInjectionSet(_HDFInjectionSet):
         try:
             ref_point = inj.ref_point
         except AttributeError as _err:
-            raise ValueError("Must provide a ref_point for fromfile "
-                             "injections") from _err
+            # Py3.XX: uncomment the "from _err" when we drop 2.7
+            raise ValueError("Must provide a ref_point for {} injections"
+                             .format(self.injtype))  #from _err
         # try to get from buffer
         if self._rtbuffer is None:
             self._rtbuffer = LimitedSizeDict(size_limit=self._buffersize)

--- a/pycbc/inject/inject.py
+++ b/pycbc/inject/inject.py
@@ -989,8 +989,8 @@ class IncoherentFromFileHDFInjectionSet(_HDFInjectionSet):
 hdfinjtypes = {
     CBCHDFInjectionSet.injtype: CBCHDFInjectionSet,
     RingdownHDFInjectionSet.injtype: RingdownHDFInjectionSet,
-    IncoherentFromFileHDFInjectionSet.injtype: \
-        IncoherentFromFileHDFInjectionSet,
+    IncoherentFromFileHDFInjectionSet.injtype:
+    IncoherentFromFileHDFInjectionSet,
 }
 
 

--- a/pycbc/inject/inject.py
+++ b/pycbc/inject/inject.py
@@ -747,7 +747,7 @@ class RingdownHDFInjectionSet(_HDFInjectionSet):
         return list(waveform.ringdown_td_approximants.keys())
 
 
-class FromFileHDFInjectionSet(_HDFInjectionSet):
+class IncoherentFromFileHDFInjectionSet(_HDFInjectionSet):
     """Manages injecting an arbitrary time series loaded from a file.
 
     The injections must have the following attributes set:
@@ -803,21 +803,21 @@ class FromFileHDFInjectionSet(_HDFInjectionSet):
     being injected into.
 
     In order to use with ``pycbc_create_injections``, set the ``approximant``
-    name to ``'fromfile'``.
+    name to ``'incoherent_from_file'``.
     """
-    injtype = 'fromfile'
+    injtype = 'incoherent_from_file'
     required_params = ('filename', 'ref_point')
     _buffersize = 10
     _buffer = None
     _rtbuffer = None
 
     def end_times(self):
-        raise NotImplementedError("FromFile times cannot be determined "
-                                  "without loading time series")
+        raise NotImplementedError("IncoherentFromFile times cannot be "
+                                  "determined without loading time series")
 
     @staticmethod
     def supported_approximants():
-        return ['fromfile']
+        return ['incoherent_from_file']
 
     def loadts(self, inj):
         """Loads an injection time series.
@@ -917,8 +917,8 @@ class FromFileHDFInjectionSet(_HDFInjectionSet):
     def apply(self, strain, detector_name, distance_scale=1,
               injection_sample_rate=None, inj_filter_rejector=None):
         if inj_filter_rejector is not None:
-            raise NotImplementedError("FromFile injections do not support "
-                                      "inj_filter_rejector")
+            raise NotImplementedError("IncoherentFromFile injections do not "
+                                      "support inj_filter_rejector")
         if injection_sample_rate is not None:
             delta_t = 1./injection_sample_rate
         else:
@@ -989,7 +989,8 @@ class FromFileHDFInjectionSet(_HDFInjectionSet):
 hdfinjtypes = {
     CBCHDFInjectionSet.injtype: CBCHDFInjectionSet,
     RingdownHDFInjectionSet.injtype: RingdownHDFInjectionSet,
-    FromFileHDFInjectionSet.injtype: FromFileHDFInjectionSet,
+    IncoherentFromFileHDFInjectionSet.injtype: \
+        IncoherentFromFileHDFInjectionSet,
 }
 
 

--- a/pycbc/types/timeseries.py
+++ b/pycbc/types/timeseries.py
@@ -886,7 +886,7 @@ class TimeSeries(Array):
         fft(tmp, f)
         return f
 
-    def inject(self, other):
+    def inject(self, other, copy=True):
         """Return copy of self with other injected into it.
 
         The other vector will be resized and time shifted with sub-sample
@@ -896,11 +896,13 @@ class TimeSeries(Array):
         # only handle equal sample rate for now.
         if not self.sample_rate_close(other):
             raise ValueError('Sample rate must be the same')
-
+        # determine if we want to inject in place or not
+        if copy:
+            self = self.copy()
         # Other is disjoint
         if ((other.start_time >= self.end_time) or
            (self.start_time > other.end_time)):
-            return self.copy()
+            return self
 
         other = other.copy()
         dt = float((other.start_time - self.start_time) * self.sample_rate)
@@ -934,9 +936,8 @@ class TimeSeries(Array):
             oright = len(other) - (right - len(self))
             right = len(self)
 
-        ts = self.copy()
-        ts[left:right] += other[oleft:oright]
-        return ts
+        self[left:right] += other[oleft:oright]
+        return self
 
     add_into = inject  # maintain backwards compatibility for now
 

--- a/pycbc/types/timeseries.py
+++ b/pycbc/types/timeseries.py
@@ -898,18 +898,20 @@ class TimeSeries(Array):
             raise ValueError('Sample rate must be the same')
         # determine if we want to inject in place or not
         if copy:
-            self = self.copy()
+            ts = self.copy()
+        else:
+            ts = self
         # Other is disjoint
-        if ((other.start_time >= self.end_time) or
-           (self.start_time > other.end_time)):
-            return self
+        if ((other.start_time >= ts.end_time) or
+           (ts.start_time > other.end_time)):
+            return ts
 
         other = other.copy()
-        dt = float((other.start_time - self.start_time) * self.sample_rate)
+        dt = float((other.start_time - ts.start_time) * ts.sample_rate)
 
         # This coaligns other to the time stepping of self
         if not dt.is_integer():
-            diff = (dt - _numpy.floor(dt)) * self.delta_t
+            diff = (dt - _numpy.floor(dt)) * ts.delta_t
 
             # insert zeros at end
             other.resize(len(other) + (len(other) + 1) % 2 + 1)
@@ -919,7 +921,7 @@ class TimeSeries(Array):
 
         # get indices of other with respect to self
         # this is already an integer to floating point precission
-        left = float(other.start_time - self.start_time) * self.sample_rate
+        left = float(other.start_time - ts.start_time) * ts.sample_rate
         left = int(round(left))
         right = left + len(other)
 
@@ -932,12 +934,12 @@ class TimeSeries(Array):
             left = 0
 
         # other overhangs on right so truncate
-        if right > len(self):
-            oright = len(other) - (right - len(self))
-            right = len(self)
+        if right > len(ts):
+            oright = len(other) - (right - len(ts))
+            right = len(ts)
 
-        self[left:right] += other[oleft:oright]
-        return self
+        ts[left:right] += other[oleft:oright]
+        return ts
 
     add_into = inject  # maintain backwards compatibility for now
 


### PR DESCRIPTION
Needed this for a project I was working on and thought it would be generally useful... this adds the ability to create arbitrary injections using a time series. You have to provide a filename containing the time series, a GPS time to inject into each detector, and a `ref_point` specifying what point in the time series corresponds to the GPS time. You can also apply a phase shift and amplitude scaling.

For example, this config file would generate glitch injections in H1 using the GW170817 glitch that was recovered by BayesWave, with random phase and amplitude:
```
[static_params]                                                                 
approximant = fromfile                                                          
# the BayesWave model of GW170817 glitch, download from:                      
# https://dcc.ligo.org/public/0144/T1700406/003/L-L1_CLEANED_HOFT_C02_T1700406_v3-1187008667-4096.gwf
filename = L-L1_CLEANED_HOFT_C02_T1700406_v3-1187008667-4096.gwf                
channel = L1:DCH-CLEAN_STRAIN_C02_glitch                                        
# the frame file is 4096s long, but we only need a couple seconds around the max
ref_point = absmax                                                              
slice_start = -2                                                                
slice_end = 2                                                                   
# apply a taper to make sure it goes to zero at the boundaries                  
left_taper_width = 1                                                            
right_taper_width = 1                                                           
                                                                                
[variable_params]                                                               
glitch_time =                                                                   
h1_phase_shift =                                                                
h1_amp_scale =                                                                  
                                                                                
[prior-h1_phase_shift]                                                          
name = uniform_angle                                                            
                                                                                
[prior-h1_amp_scale]                                                            
name = uniform                                                                  
min-h1_amp_scale = 0                                                            
max-h1_amp_scale = 1                                                            
                                                                                
[prior-glitch_time]                                                             
name = uniform                                                                  
min-glitch_time = -512                                                          
max-glitch_time = 512                                                           
                                                                                
[waveform_transforms-h1_gps_time]                                               
name = custom                                                                   
inputs = glitch_time 
# distribute around GW150914                                                                                                     
h1_gps_time = 1126259462 + glitch_time 
```
Giving this to `create_injections`:
```
pycbc_create_injections --verbose \                                         
            --config-files H1-glitches.ini \                                
            --ninjections 128 \                                                 
            --output-file H1-glitches.hdf \                                                                       
            --force
```
will create an hdf file that can be passed to `pycbc_condition_strain`.