### PR TITLE
Pycbc_live must make output that Bayestar can use

### DIFF
--- a/.github/workflows/basic-tests.yml
+++ b/.github/workflows/basic-tests.yml
@@ -36,7 +36,6 @@ jobs:
         pip install -r requirements.txt
         pip install -r companion.txt
         pip install mpi4py
-        pip install ligo.skymap
         pip install .
     - name: run pycbc test suite
       env:

--- a/.github/workflows/basic-tests.yml
+++ b/.github/workflows/basic-tests.yml
@@ -36,6 +36,7 @@ jobs:
         pip install -r requirements.txt
         pip install -r companion.txt
         pip install mpi4py
+        pip install ligo.skymap
         pip install .
     - name: run pycbc test suite
       env:

--- a/companion.txt
+++ b/companion.txt
@@ -4,11 +4,13 @@ gwpy>=0.8.1
 # HEALPix is very useful for some analysis.
 healpy
 
-# Needed for gracedb uploads
+# Needed for gracedb uploads and skymap generation
 ligo-gracedb
+ligo.skymap
 
 # auxiliary samplers
 cpnest
 pymultinest
 ultranest
 https://github.com/willvousden/ptemcee/archive/master.tar.gz
+

--- a/companion.txt
+++ b/companion.txt
@@ -6,7 +6,7 @@ healpy
 
 # Needed for gracedb uploads and skymap generation
 ligo-gracedb
-ligo.skymap
+ligo.skymap; python_version >= '3.5'
 
 # auxiliary samplers
 cpnest

--- a/examples/live/run.sh
+++ b/examples/live/run.sh
@@ -168,3 +168,9 @@ python -m mpi4py `which pycbc_live` \
 
 echo -e "\\n\\n>> [`date`] Checking results"
 ./check_results.py
+
+echo -e "\\n\\n>> [`date`] Running Bayestar"
+for XMLFIL in `ls output/*xml*`
+do
+  bayestar-localize-coincs ${XMLFIL} ${XMLFIL}
+done

--- a/examples/live/run.sh
+++ b/examples/live/run.sh
@@ -170,10 +170,7 @@ echo -e "\\n\\n>> [`date`] Checking results"
 ./check_results.py
 
 echo -e "\\n\\n>> [`date`] Running Bayestar"
-if python -c 'import sys; assert sys.version_info >= (3,6)' &> /dev/null;
-then
-  for XMLFIL in `ls output/*xml*`
-  do
-    bayestar-localize-coincs ${XMLFIL} ${XMLFIL}
-  done
-fi
+for XMLFIL in `ls output/*xml*`
+do
+  bayestar-localize-coincs ${XMLFIL} ${XMLFIL}
+done

--- a/examples/live/run.sh
+++ b/examples/live/run.sh
@@ -170,7 +170,10 @@ echo -e "\\n\\n>> [`date`] Checking results"
 ./check_results.py
 
 echo -e "\\n\\n>> [`date`] Running Bayestar"
-for XMLFIL in `ls output/*xml*`
-do
-  bayestar-localize-coincs ${XMLFIL} ${XMLFIL}
-done
+if python -c 'import sys; assert sys.version_info >= (3,6)' &> /dev/null;
+then
+  for XMLFIL in `ls output/*xml*`
+  do
+    bayestar-localize-coincs ${XMLFIL} ${XMLFIL}
+  done
+fi

--- a/pycbc/filter/matchedfilter.py
+++ b/pycbc/filter/matchedfilter.py
@@ -1812,8 +1812,13 @@ def followup_event_significance(ifo, data_reader, bank,
     pvalue = (1 + (peaks >= peak_value).sum()) / float(1 + nsamples)
 
     # Return recentered source SNR for bayestar, along with p-value, and trig
+    # Ensure duration/2 is an integer number of samples
+    half_num_samps = int(duration / (snr.delta_t*2))
+    duration = half_num_samps * 2 * snr.delta_t
+    # Need an extra sample on "end" to ensure that we get the same number
+    # of samples on each side of the peak
     baysnr = snr.time_slice(peak_time - duration / 2.0,
-                            peak_time + duration / 2.0)
+                            peak_time + duration / 2.0 + snr.delta_t)
 
     logging.info('Adding %s to candidate, pvalue %s, %s samples', ifo,
                  pvalue, nsamples)

--- a/pycbc/filter/matchedfilter.py
+++ b/pycbc/filter/matchedfilter.py
@@ -1812,13 +1812,11 @@ def followup_event_significance(ifo, data_reader, bank,
     pvalue = (1 + (peaks >= peak_value).sum()) / float(1 + nsamples)
 
     # Return recentered source SNR for bayestar, along with p-value, and trig
-    # Ensure duration/2 is an integer number of samples
-    half_num_samps = int(duration / (snr.delta_t*2))
-    duration = half_num_samps * 2 * snr.delta_t
-    # Need an extra sample on "end" to ensure that we get the same number
-    # of samples on each side of the peak
-    baysnr = snr.time_slice(peak_time - duration / 2.0,
-                            peak_time + duration / 2.0 + snr.delta_t)
+    peak_full = int((peak_time - snr.start_time) / snr.delta_t)
+    half_dur_samples = int(snr.sample_rate * duration / 2)
+    snr_slice = slice(peak_full - half_dur_samples,
+                      peak_full + half_dur_samples + 1)
+    baysnr = snr[snr_slice]
 
     logging.info('Adding %s to candidate, pvalue %s, %s samples', ifo,
                  pvalue, nsamples)


### PR DESCRIPTION
Patch #3603 broke pycbc_live's ability to interface with Bayestar by making the SNR timeseries in the XML files 1 sample too short when it is obtained using the followup-ifo path.

Here I match how the followup SNR timeseries is sliced (which was wrong in two places before #3603, but somehow cancelling out), with the normal SNR timeseries (which was always correct).