### PR TITLE
re-normalize the cumulative weights to 1 to avoid numerical issues when resampling weighted samples

### DIFF
--- a/pycbc/inference/io/dynesty.py
+++ b/pycbc/inference/io/dynesty.py
@@ -125,6 +125,7 @@ class DynestyFile(CommonNestedMetadataIO, BaseNestedSamplerFile):
             positions = (numpy.random.random() + numpy.arange(N)) / N
             idx = numpy.zeros(N, dtype=numpy.int)
             cumulative_sum = numpy.cumsum(weights)
+            cumulative_sum /= cumulative_sum[-1]
             i, j = 0, 0
             while i < N:
                 if positions[i] < cumulative_sum[j]:


### PR DESCRIPTION
@sum33it @cdcapano I encountered a case where the weight sum is nearly, but not quite 1, and where there are sufficient samples so that a point may want to access higher than this value in the distribution tail. This occurs because of numerical error in the sampler weights. The immediate problem is that this prevents resampling to an equal-weight distribution. 