### PR TITLE
pycbc_optimize_snr: add support for particle swarm optimization

### DIFF
--- a/bin/pycbc_optimize_snr
+++ b/bin/pycbc_optimize_snr
@@ -184,6 +184,9 @@ parser.add_argument('--pso-w', type=float, default=0.01,
 args = parser.parse_args()
 pycbc.init_logging(args.verbose)
 
+if args.optimizer == 'pso' and ps == None:
+    parser.error('You need to install pyswarms to use the pso optimizer.')
+
 logging.info('Starting optimize SNR')
 
 data = {}
@@ -279,7 +282,6 @@ for ifo in fup_ifos:
 extra_args[2] = ifos
 
 _, snr_series_dict = compute_network_snr_core(opt_params, *extra_args)
-
 
 # Prepare for GraceDB upload
 coinc_results = {}

--- a/bin/pycbc_optimize_snr
+++ b/bin/pycbc_optimize_snr
@@ -216,7 +216,8 @@ f_end = float(fp['f_end'][()])
 delta_f = fp['delta_f'][()]
 sample_rate = fp['sample_rate'][()]
 
-extra_args = [data, coinc_times, coinc_ifos, flen, approximant, flow, f_end, delta_f, sample_rate]
+extra_args = [data, coinc_times, coinc_ifos, flen, 
+              approximant, flow, f_end, delta_f, sample_rate]
 extra_kwargs = {}
 extra_kwargs['args'] = extra_args
 
@@ -254,8 +255,10 @@ elif args.optimizer == 'shgo':
                 
 elif args.optimizer == 'pso':
     options = {'c1': args.pso_c1, 'c2': args.pso_c2, 'w':args.pso_w}
-    optimizer = ps.single.GlobalBestPSO(n_particles=args.pso_particles, dimensions=4, options=options, bounds=bounds)
-    cost, results = optimizer.optimize(compute_network_snr_pso, iters=args.pso_iters, n_processes=args.cores, **extra_kwargs)
+    optimizer = ps.single.GlobalBestPSO(n_particles=args.pso_particles, 
+                                        dimensions=4, options=options, bounds=bounds)
+    cost, results = optimizer.optimize(compute_network_snr_pso, iters=args.pso_iters,
+                                       n_processes=args.cores, **extra_kwargs)
                 
 
 logging.info('Optimization complete')
@@ -284,8 +287,6 @@ if args.optimizer == 'pso':
     _, snr_series_dict = compute_network_snr_core(results, *extra_args)
 else:
     _, snr_series_dict = compute_network_snr_core(results.x, *extra_args)
-    
-print(_)
 
 # Prepare for GraceDB upload
 coinc_results = {}

--- a/bin/pycbc_optimize_snr
+++ b/bin/pycbc_optimize_snr
@@ -19,7 +19,6 @@ from pycbc.conversions import (
     mass1_from_mtotal_eta, mass2_from_mtotal_eta
 )
 from scipy.optimize import differential_evolution, shgo
-import pyswarms as ps
 from pycbc.io import live
 from pycbc.io.hdf import load_hdf5_to_dict
 from pycbc.detector import Detector

--- a/bin/pycbc_optimize_snr
+++ b/bin/pycbc_optimize_snr
@@ -19,10 +19,16 @@ from pycbc.conversions import (
     mass1_from_mtotal_eta, mass2_from_mtotal_eta
 )
 from scipy.optimize import differential_evolution, shgo
+import pyswarms as ps
 from pycbc.io import live
 from pycbc.io.hdf import load_hdf5_to_dict
 from pycbc.detector import Detector
 from pycbc.psd import interpolate
+
+try: 
+    import pyswarms as ps
+except:
+    print("No pyswarms package available for pso optimization")
 
 
 Nfeval = 0
@@ -101,6 +107,14 @@ def compute_network_snr(v, *argv):
         argv = argv[0]
     nsnr, _ = compute_network_snr_core(v, *argv)
     return -nsnr
+    
+def compute_network_snr_pso(v, *argv, **kwargs):
+    argv = kwargs['args']
+    nsnr_array=numpy.zeros(len(v), dtype=float)
+    for i in range(len(v)):
+        nsnr, _ = compute_network_snr_core(v[i], *argv)
+        nsnr_array[i] = nsnr
+    return -nsnr_array
 
 
 parser = argparse.ArgumentParser(description=__doc__)
@@ -140,8 +154,8 @@ parser.add_argument('--output-path', required=True,
 parser.add_argument('--cores', type=int,
                     help='Restrict calculation to given number of CPU cores')
 parser.add_argument('--optimizer', type=str, default='differential_evolution',
-                    choices=['differential_evolution', 'shgo'],
-                    help='The optimizer to use, differential_evolution or shgo')
+                    choices=['differential_evolution', 'shgo', 'pso'],
+                    help='The optimizer to use, differential_evolution, shgo or pso')
 parser.add_argument('--di-maxiter', type=int, default=50,
                     help='Only relevant for --optimizer differential_evolution: '
                     'The maximum number of generations over which the entire population is evolved.')
@@ -154,6 +168,21 @@ parser.add_argument('--shgo-samples', type=int, default=76,
 parser.add_argument('--shgo-iters', type=int, default=3,
                     help='Only relevant for --optimizer shgo: '
                     'Number of iterations used in the construction of the simplicial complex.')
+parser.add_argument('--pso-iters', type=int, default=5,
+                    help='Only relevant for --optimizer pso: '
+                    'Number of iterations used in the particle swarm optimization.')
+parser.add_argument('--pso-particles', type=int, default=250,
+                    help='Only relevant for --optimizer pso: '
+                    'Number of particles used in the swarm.')
+parser.add_argument('--pso-c1', default=0.5,
+                    help='Only relevant for --optimizer pso: '
+                    'The hyperparameter c1: the cognitive parameter.')
+parser.add_argument('--pso-c2', default=2.0,
+                    help='Only relevant for --optimizer pso: '
+                    'The hyperparameter c2: the social parameter.')
+parser.add_argument('--pso-w', default=0.01,
+                    help='Only relevant for --optimizer pso: '
+                    'The hyperparameter w: the intertia parameter.')
                     
 
 args = parser.parse_args()
@@ -187,8 +216,9 @@ f_end = float(fp['f_end'][()])
 delta_f = fp['delta_f'][()]
 sample_rate = fp['sample_rate'][()]
 
-extra_args = [data, coinc_times, coinc_ifos, flen,
-              approximant, flow, f_end, delta_f, sample_rate]
+extra_args = [data, coinc_times, coinc_ifos, flen, approximant, flow, f_end, delta_f, sample_rate]
+extra_kwargs = {}
+extra_kwargs['args'] = extra_args
 
 mass1 = fp['mass1'][()]
 mass2 = fp['mass2'][()]
@@ -200,7 +230,14 @@ maxchirp = mchirp * (1 + mchirp / 50.0)
 minchirp = 1 if minchirp < 1 else minchirp
 maxchirp = 80 if maxchirp > 80 else maxchirp
 
-bounds = [(minchirp, maxchirp), (0.01, 0.2499), (-0.9, 0.9), (-0.9, 0.9)]
+#Different optimizers have different bound definitions
+
+if args.optimizer == 'pso': 
+    min_bound = [minchirp, 0.01, -0.9, -0.9]
+    max_bound = [maxchirp, 0.2499, 0.9, 0.9] 
+    bounds = (min_bound, max_bound)
+else:
+    bounds = [(minchirp, maxchirp), (0.01, 0.2499), (-0.9, 0.9), (-0.9, 0.9)]
 
 logging.info('Starting optimization')
 
@@ -215,14 +252,26 @@ elif args.optimizer == 'shgo':
     results = shgo(compute_network_snr, bounds=bounds, args=extra_args, 
                 iters=args.shgo_iters, n=args.shgo_samples, sampling_method="sobol")
                 
+elif args.optimizer == 'pso':
+    options = {'c1': args.pso_c1, 'c2': args.pso_c2, 'w':args.pso_w}
+    optimizer = ps.single.GlobalBestPSO(n_particles=args.pso_particles, dimensions=4, options=options, bounds=bounds)
+    cost, results = optimizer.optimize(compute_network_snr_pso, iters=args.pso_iters, n_processes=args.cores, **extra_kwargs)
+                
 
 logging.info('Optimization complete')
 
-mtotal = mtotal_from_mchirp_eta(results.x[0], results.x[1])
-mass1 = mass1_from_mtotal_eta(mtotal, results.x[1])
-mass2 = mass2_from_mtotal_eta(mtotal, results.x[1])
-spin1z = results.x[2]
-spin2z = results.x[3]
+if args.optimizer == 'pso':
+    mtotal = mtotal_from_mchirp_eta(results[0], results[1])
+    mass1 = mass1_from_mtotal_eta(mtotal, results[1])
+    mass2 = mass2_from_mtotal_eta(mtotal, results[1])
+    spin1z = results[2]
+    spin2z = results[3]
+else:
+    mtotal = mtotal_from_mchirp_eta(results.x[0], results.x[1])
+    mass1 = mass1_from_mtotal_eta(mtotal, results.x[1])
+    mass2 = mass2_from_mtotal_eta(mtotal, results.x[1])
+    spin1z = results.x[2]
+    spin2z = results.x[3]
 
 fup_ifos = set(ifos) - set(coinc_ifos)
 
@@ -231,7 +280,12 @@ for ifo in fup_ifos:
 
 extra_args[2] = ifos
 
-_, snr_series_dict = compute_network_snr_core(results.x, *extra_args)
+if args.optimizer == 'pso':
+    _, snr_series_dict = compute_network_snr_core(results, *extra_args)
+else:
+    _, snr_series_dict = compute_network_snr_core(results.x, *extra_args)
+    
+print(_)
 
 # Prepare for GraceDB upload
 coinc_results = {}

--- a/bin/pycbc_optimize_snr
+++ b/bin/pycbc_optimize_snr
@@ -109,7 +109,6 @@ def compute_network_snr(v, *argv):
  
 def compute_network_snr_pso(v, *argv, **kwargs):
     argv = kwargs['args']
-    nsnr_array=numpy.zeros(len(v), dtype=float)
     nsnr_array = [-compute_network_snr_core(v_i, *argv)[0] for v_i in v]
     return nsnr_array
 

--- a/bin/pycbc_optimize_snr
+++ b/bin/pycbc_optimize_snr
@@ -109,7 +109,7 @@ def compute_network_snr(v, *argv):
  
 def compute_network_snr_pso(v, *argv, **kwargs):
     argv = kwargs['args']
-    nsnr_array = [-compute_network_snr_core(v_i, *argv)[0] for v_i in v]
+    nsnr_array = numpy.array[-compute_network_snr_core(v_i, *argv)[0] for v_i in v]
     return nsnr_array
 
 
@@ -259,7 +259,6 @@ elif args.optimizer == 'pso':
     cost, results = optimizer.optimize(compute_network_snr_pso, iters=args.pso_iters,
                                        n_processes=args.cores, **extra_kwargs)
                 
-
 logging.info('Optimization complete')
 
 if args.optimizer == 'pso':

--- a/bin/pycbc_optimize_snr
+++ b/bin/pycbc_optimize_snr
@@ -109,7 +109,7 @@ def compute_network_snr(v, *argv):
  
 def compute_network_snr_pso(v, *argv, **kwargs):
     argv = kwargs['args']
-    nsnr_array = numpy.array[-compute_network_snr_core(v_i, *argv)[0] for v_i in v]
+    nsnr_array = numpy.array([-compute_network_snr_core(v_i, *argv)[0] for v_i in v])
     return nsnr_array
 
 

--- a/bin/pycbc_optimize_snr
+++ b/bin/pycbc_optimize_snr
@@ -27,7 +27,7 @@ from pycbc.psd import interpolate
 try: 
     import pyswarms as ps
 except:
-    print("No pyswarms package available for pso optimization")
+    ps = None
 
 
 Nfeval = 0
@@ -106,14 +106,12 @@ def compute_network_snr(v, *argv):
         argv = argv[0]
     nsnr, _ = compute_network_snr_core(v, *argv)
     return -nsnr
-    
+ 
 def compute_network_snr_pso(v, *argv, **kwargs):
     argv = kwargs['args']
     nsnr_array=numpy.zeros(len(v), dtype=float)
-    for i in range(len(v)):
-        nsnr, _ = compute_network_snr_core(v[i], *argv)
-        nsnr_array[i] = nsnr
-    return -nsnr_array
+    nsnr_array = [-compute_network_snr_core(v_i, *argv)[0] for v_i in v]
+    return nsnr_array
 
 
 parser = argparse.ArgumentParser(description=__doc__)
@@ -173,13 +171,13 @@ parser.add_argument('--pso-iters', type=int, default=5,
 parser.add_argument('--pso-particles', type=int, default=250,
                     help='Only relevant for --optimizer pso: '
                     'Number of particles used in the swarm.')
-parser.add_argument('--pso-c1', default=0.5,
+parser.add_argument('--pso-c1', type=float, default=0.5,
                     help='Only relevant for --optimizer pso: '
                     'The hyperparameter c1: the cognitive parameter.')
-parser.add_argument('--pso-c2', default=2.0,
+parser.add_argument('--pso-c2', type=float, default=2.0,
                     help='Only relevant for --optimizer pso: '
                     'The hyperparameter c2: the social parameter.')
-parser.add_argument('--pso-w', default=0.01,
+parser.add_argument('--pso-w', type=float, default=0.01,
                     help='Only relevant for --optimizer pso: '
                     'The hyperparameter w: the intertia parameter.')
                     
@@ -215,7 +213,7 @@ f_end = float(fp['f_end'][()])
 delta_f = fp['delta_f'][()]
 sample_rate = fp['sample_rate'][()]
 
-extra_args = [data, coinc_times, coinc_ifos, flen, 
+extra_args = [data, coinc_times, coinc_ifos, flen,
               approximant, flow, f_end, delta_f, sample_rate]
 extra_kwargs = {}
 extra_kwargs['args'] = extra_args
@@ -263,17 +261,16 @@ elif args.optimizer == 'pso':
 logging.info('Optimization complete')
 
 if args.optimizer == 'pso':
-    mtotal = mtotal_from_mchirp_eta(results[0], results[1])
-    mass1 = mass1_from_mtotal_eta(mtotal, results[1])
-    mass2 = mass2_from_mtotal_eta(mtotal, results[1])
-    spin1z = results[2]
-    spin2z = results[3]
+    opt_params = results
 else:
-    mtotal = mtotal_from_mchirp_eta(results.x[0], results.x[1])
-    mass1 = mass1_from_mtotal_eta(mtotal, results.x[1])
-    mass2 = mass2_from_mtotal_eta(mtotal, results.x[1])
-    spin1z = results.x[2]
-    spin2z = results.x[3]
+    opt_params = results.x
+
+mtotal = mtotal_from_mchirp_eta(opt_params[0], opt_params[1])
+mass1 = mass1_from_mtotal_eta(mtotal, opt_params[1])
+mass2 = mass2_from_mtotal_eta(mtotal, opt_params[1])
+spin1z = opt_params[2]
+spin2z = opt_params[3]
+
 
 fup_ifos = set(ifos) - set(coinc_ifos)
 
@@ -282,10 +279,8 @@ for ifo in fup_ifos:
 
 extra_args[2] = ifos
 
-if args.optimizer == 'pso':
-    _, snr_series_dict = compute_network_snr_core(results, *extra_args)
-else:
-    _, snr_series_dict = compute_network_snr_core(results.x, *extra_args)
+_, snr_series_dict = compute_network_snr_core(opt_params, *extra_args)
+
 
 # Prepare for GraceDB upload
 coinc_results = {}


### PR DESCRIPTION
Adding the necessary changes to pycbc_optimize_snr to allow for the usage of the `pyswarms` Particle Swarm Optimization optimizer.

The package is configured slightly different to scipy and so a few `if` statements are needed to ensure the right code is called. Currently this doesn't look too appealing so if there is a better way to potentially group these if statements under one umbrella then I would like to include that.

`pyswarms` isn't included in the installation of pycbc so instead of failing on the import there is a `try -> except` instead.

I'm thinking also of collecting the iteration arguments under the same argument, even if they have slightly different meanings.

Finally, if there are any formatting improvements that can be made I would be glad to hear them as well!