### PR TITLE
Various fixes to PyCBC Live's test

### DIFF
--- a/examples/live/check_results.py
+++ b/examples/live/check_results.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import sys
+import argparse
 import glob
 import logging as log
 import numpy as np
@@ -18,20 +19,21 @@ class LIGOLWContentHandler(ligolw.LIGOLWContentHandler):
 def close(a, b, c):
     return abs(a - b) <= c
 
-def check_single_results(tested_detectors):
+def check_single_results(args):
     single_fail = False
-    with h5py.File('template_bank.hdf', 'r') as bankf:
+    with h5py.File(args.bank, 'r') as bankf:
         temp_mass1 = bankf['mass1'][:]
         temp_mass2 = bankf['mass2'][:]
         temp_s1z = bankf['spin1z'][:]
         temp_s2z = bankf['spin2z'][:]
 
+    detectors = set(args.detectors)
     detectors_with_trigs = set()
 
     trig_paths = sorted(glob.glob('output/????_??_??/*.hdf'))
     for trigfp in trig_paths:
         with h5py.File(trigfp, 'r') as trigf:
-            for detector in tested_detectors:
+            for detector in detectors:
                 if detector not in trigf:
                     continue
                 group = trigf[detector]
@@ -44,11 +46,11 @@ def check_single_results(tested_detectors):
                 psd_df = group['psd'].attrs['delta_f']
                 psd_f = np.arange(len(psd)) * psd_df
                 psd_epoch = group['psd'].attrs['epoch']
-                in_band_asd = psd[psd_f > sim_f_lower] ** 0.5
+                in_band_asd = psd[psd_f > args.f_min] ** 0.5
                 if len(in_band_asd) == 0 or (in_band_asd < 1e-24).any() \
                         or (in_band_asd > 1e-20).any() \
                         or not np.isfinite(in_band_asd).all() \
-                        or psd_epoch < sim_gps_start or psd_epoch > sim_gps_end:
+                        or psd_epoch < args.gps_start or psd_epoch > args.gps_end:
                     log.info('Invalid PSD in %s %s', trigfp, detector)
                     single_fail = True
 
@@ -73,7 +75,7 @@ def check_single_results(tested_detectors):
 
                 # check that merger time is within the simulated time range
                 end_time = group['end_time'][:]
-                if (end_time < sim_gps_start).any() or (end_time > sim_gps_end).any():
+                if (end_time < args.gps_start).any() or (end_time > args.gps_end).any():
                     log.error('Invalid merger time in %s %s', trigfp, detector)
                     single_fail = True
 
@@ -95,8 +97,8 @@ def check_single_results(tested_detectors):
                     single_fail = True
 
     # check that triggers were produced in all detectors
-    if detectors_with_trigs != tested_detectors:
-        missing = sorted(tested_detectors - detectors_with_trigs)
+    missing = sorted(detectors - detectors_with_trigs)
+    if missing:
         log.error('No triggers found in %s', ', '.join(missing))
         single_fail = True
 
@@ -105,7 +107,7 @@ def check_single_results(tested_detectors):
     return single_fail
 
 
-def check_coinc_results():
+def check_coinc_results(args):
     coinc_fail = False
     # gather coincident triggers
     coinc_trig_paths = sorted(glob.glob('output/coinc*.xml.gz'))
@@ -119,23 +121,14 @@ def check_coinc_results():
     else:
         log.info('%d coincident trigger(s) detected', n_coincs)
 
-    injs = sorted(glob.glob('test_inj*.hdf'))
-    n_injs = len(injs)
-    inj_mass1 = np.empty(n_injs)
-    inj_mass2 = np.empty(n_injs)
-    inj_spin1z = np.empty(n_injs)
-    inj_spin2z = np.empty(n_injs)
-    inj_time = np.empty(n_injs)
+    with h5py.File(args.injections, 'r') as injfile:
+        inj_mass1 = injfile['mass1'][:]
+        inj_mass2 = injfile['mass2'][:]
+        inj_spin1z = injfile['spin1z'][:]
+        inj_spin2z = injfile['spin2z'][:]
+        inj_time = injfile['tc'][:]
 
-    for idx, inj_path in enumerate(injs):
-        with h5py.File(inj_path, 'r') as inj:
-            inj_mass1[idx] = inj['mass1'][0]
-            inj_mass2[idx] = inj['mass2'][0]
-            inj_spin1z[idx] = inj['spin1z'][0]
-            inj_spin2z[idx] = inj['spin2z'][0]
-            inj_time[idx] = inj['tc'][0]
-
-    if n_injs > n_coincs:
+    if len(inj_mass1) > n_coincs:
         log.error('More injections than coincident triggers')
         coinc_fail = True
 
@@ -170,9 +163,11 @@ def check_coinc_results():
         log.info('Spin2z: %f', trig_props['spin2z'][x])
 
     # check if injections match trigger params
-    for i in range(n_injs):
+    for i in range(len(inj_mass1)):
         has_match = False
         for j in range(n_coincs):
+            # FIXME should calculate the optimal SNRs of the injections
+            # and use those for checking net_snr
             if (close(inj_time[i], trig_props['tc'][j], 1.0)
                     and close(inj_mass1[i], trig_props['mass1'][j], 5e-7)
                     and close(inj_mass2[i], trig_props['mass2'][j], 5e-7)
@@ -191,21 +186,21 @@ def check_coinc_results():
     return coinc_fail
 
 
+parser = argparse.ArgumentParser()
+parser.add_argument('--gps-start', type=float, required=True)
+parser.add_argument('--gps-end', type=float, required=True)
+parser.add_argument('--f-min', type=float, required=True)
+parser.add_argument('--bank', type=str, required=True)
+parser.add_argument('--injections', type=str, required=True)
+parser.add_argument('--detectors', type=str, required=True, nargs='+')
+args = parser.parse_args()
+
 log.basicConfig(level=log.INFO, format='%(asctime)s %(message)s')
-
-# gps times need to match those found in run.sh
-sim_gps_start = 1272790000
-sim_gps_end = 1272790512
-
-# sim f lower needs to match the value in generate_injection.sh
-sim_f_lower = 18
 
 lsctables.use_in(LIGOLWContentHandler)
 
-tested_detectors = {'H1', 'L1', 'V1'}
-
-single_fail = check_single_results(tested_detectors)
-coinc_fail = check_coinc_results()
+single_fail = check_single_results(args)
+coinc_fail = check_coinc_results(args)
 fail = single_fail or coinc_fail
 
 if fail:

--- a/examples/live/generate_injections.py
+++ b/examples/live/generate_injections.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import sys
+import numpy as np
 from pycbc.io import FieldArray
 from pycbc.inject import InjectionSet
 
@@ -8,23 +9,32 @@ from pycbc.inject import InjectionSet
 dtype = [('mass1', float), ('mass2', float),
          ('spin1z', float), ('spin2z', float),
          ('tc', float), ('distance', float),
+         ('ra', float), ('dec', float),
          ('approximant', 'S32')]
 
-static_params = {'f_lower': 18.0, 'f_ref': 18.0,
-                 'taper': 'start', 'ra': 45.0, 'dec': 45.0,
-                 'inclination': 0.0, 'coa_phase': 0.0, 'polarization': 0.0}
+static_params = {'f_lower': 17.,
+                 'f_ref': 17.,
+                 'taper': 'start',
+                 'inclination': 0.,
+                 'coa_phase': 0.,
+                 'polarization': 0.}
 
 samples = FieldArray(2, dtype=dtype)
 
-# The following 'magic numbers' are intended to match the highest
+# masses and spins are intended to match the highest
 # and lowest mass templates in the template bank
 samples['mass1'] = [290.929321, 1.1331687]
 samples['mass2'] = [3.6755455, 1.010624]
 samples['spin1z'] = [0.9934847, 0.029544285]
 samples['spin2z'] = [0.92713535, 0.020993788]
+
+# distance and sky locations to have network SNRs ~15
 samples['tc'] = [1272790100.1, 1272790260.1]
-samples['distance'] = [301.5, 36.0]
-samples['approximant'] = ['SEOBNRv4', 'SpinTaylorT4']
+samples['distance'] = [178., 79.]
+samples['ra'] = [np.deg2rad(45), np.deg2rad(10)]
+samples['dec'] = [np.deg2rad(45), np.deg2rad(-45)]
+
+samples['approximant'] = ['SEOBNRv4_opt', 'SpinTaylorT4']
 
 InjectionSet.write('injections.hdf', samples, static_args=static_params,
                    injtype='cbc', cmd=" ".join(sys.argv))

--- a/examples/live/run.sh
+++ b/examples/live/run.sh
@@ -9,6 +9,7 @@ export HDF5_USE_FILE_LOCKING="FALSE"
 
 gps_start_time=1272790000
 gps_end_time=1272790512
+f_min=18
 
 
 # test if there is a template bank. If not, make one
@@ -116,7 +117,7 @@ python -m mpi4py `which pycbc_live` \
 --bank-file template_bank.hdf \
 --sample-rate 2048 \
 --enable-bank-start-frequency \
---low-frequency-cutoff 18 \
+--low-frequency-cutoff ${f_min} \
 --max-length 256 \
 --approximant "SPAtmplt:mtotal<4" "SEOBNRv4_ROM:else" \
 --chisq-bins "0.72*get_freq('fSEOBNRv4Peak',params.mass1,params.mass2,params.spin1z,params.spin2z)**0.7" \
@@ -180,10 +181,16 @@ python -m mpi4py `which pycbc_live` \
 --verbose
 
 echo -e "\\n\\n>> [`date`] Checking results"
-./check_results.py
+./check_results.py \
+    --gps-start ${gps_start_time} \
+    --gps-end ${gps_end_time} \
+    --f-min ${f_min} \
+    --bank template_bank.hdf \
+    --injections injections.hdf \
+    --detectors H1 L1 V1
 
 echo -e "\\n\\n>> [`date`] Running Bayestar"
 for XMLFIL in `ls output/*xml*`
 do
-  bayestar-localize-coincs ${XMLFIL} ${XMLFIL}
+    bayestar-localize-coincs --f-low ${f_min} ${XMLFIL} ${XMLFIL}
 done


### PR DESCRIPTION
* Fix the injection recovery check in PyCBC Live's test, which was effectively disabled.
* Inject the two signals at different sky locations, to make BAYESTAR's results more interesting.
* The injected right ascension and declination were given in degrees, while they take radians (not a problem per se, but it got me confused for a moment when I plotted BAYESTAR's results).
* Remove some duplication in the simulation parameters.