### PR TITLE
Changing two broken imports for ConfigParser

### DIFF
--- a/pycbc/distributions/__init__.py
+++ b/pycbc/distributions/__init__.py
@@ -17,7 +17,7 @@ This modules provides classes and functions for drawing and calculating the
 probability density function of distributions.
 """
 # imports needed for functions below
-from pycbc.workflow import ConfigParser as _ConfigParser
+from six.moves import configparser as ConfigParser
 from pycbc.distributions import constraints
 from pycbc import VARARGS_DELIM as _VARARGS_DELIM
 

--- a/pycbc/distributions/__init__.py
+++ b/pycbc/distributions/__init__.py
@@ -17,7 +17,7 @@ This modules provides classes and functions for drawing and calculating the
 probability density function of distributions.
 """
 # imports needed for functions below
-from six.moves import configparser as ConfigParser
+from six.moves import configparser as _ConfigParser
 from pycbc.distributions import constraints
 from pycbc import VARARGS_DELIM as _VARARGS_DELIM
 

--- a/pycbc/inference/sampler/base_mcmc.py
+++ b/pycbc/inference/sampler/base_mcmc.py
@@ -31,10 +31,10 @@ import logging
 from abc import (ABCMeta, abstractmethod, abstractproperty)
 
 from six import (add_metaclass, string_types)
+from six.moves import configparser as ConfigParser
 
 import numpy
 
-from six.moves import configparser as ConfigParser
 from pycbc.filter import autocorrelation
 from pycbc.inference.io import (validate_checkpoint_files, loadfile)
 from pycbc.inference.io.base_mcmc import nsamples_in_chain

--- a/pycbc/inference/sampler/base_mcmc.py
+++ b/pycbc/inference/sampler/base_mcmc.py
@@ -34,7 +34,7 @@ from six import (add_metaclass, string_types)
 
 import numpy
 
-from pycbc.workflow import ConfigParser
+from six.moves import configparser as ConfigParser
 from pycbc.filter import autocorrelation
 from pycbc.inference.io import (validate_checkpoint_files, loadfile)
 from pycbc.inference.io.base_mcmc import nsamples_in_chain


### PR DESCRIPTION
These chages are intended to address the issue raised in #3619, where these imports no longer worked after #3589 