### PR TITLE
fix reproducible noise bug

### DIFF
--- a/examples/live/check_results.py
+++ b/examples/live/check_results.py
@@ -173,7 +173,7 @@ def check_coinc_results(args):
                     and close(inj_mass2[i], trig_props['mass2'][j], 5e-7)
                     and close(inj_spin1z[i], trig_props['spin1z'][j], 5e-7)
                     and close(inj_spin2z[i], trig_props['spin2z'][j], 5e-7)
-                    and close(15.0, trig_props['net_snr'][j], 1.0)):
+                    and close(15.0, trig_props['net_snr'][j], 2.0)):
                 has_match = True
                 break
 

--- a/pycbc/noise/reproduceable.py
+++ b/pycbc/noise/reproduceable.py
@@ -72,7 +72,7 @@ def normal(start, end, sample_rate=16384, seed=0):
     # This is reproduceable because we used fixed seeds from known values
     block_dur = BLOCK_SAMPLES / sample_rate
     s = int(start / block_dur)
-    e = numpy.floor(end / block_dur)
+    e = int(numpy.floor(end / block_dur))
 
     # The data evenly divides so the last block would be superfluous
     if end % block_dur == 0:

--- a/pycbc/noise/reproduceable.py
+++ b/pycbc/noise/reproduceable.py
@@ -72,7 +72,7 @@ def normal(start, end, sample_rate=16384, seed=0):
     # This is reproduceable because we used fixed seeds from known values
     block_dur = BLOCK_SAMPLES / sample_rate
     s = int(start / block_dur)
-    e = int(end / block_dur)
+    e = numpy.floor(end / block_dur)
 
     # The data evenly divides so the last block would be superfluous
     if end % block_dur == 0:

--- a/pycbc/noise/reproduceable.py
+++ b/pycbc/noise/reproduceable.py
@@ -71,7 +71,7 @@ def normal(start, end, sample_rate=16384, seed=0):
     """
     # This is reproduceable because we used fixed seeds from known values
     block_dur = BLOCK_SAMPLES / sample_rate
-    s = int(start / block_dur)
+    s = int(numpy.floor(start / block_dur))
     e = int(numpy.floor(end / block_dur))
 
     # The data evenly divides so the last block would be superfluous

--- a/pycbc/noise/reproduceable.py
+++ b/pycbc/noise/reproduceable.py
@@ -81,7 +81,7 @@ def normal(start, end, sample_rate=16384, seed=0):
     sv = RandomState(seed).randint(-2**50, 2**50)
     data = numpy.concatenate([block(i + sv, sample_rate)
                               for i in numpy.arange(s, e + 1, 1)])
-    ts = TimeSeries(data, delta_t=1.0 / sample_rate, epoch=start)
+    ts = TimeSeries(data, delta_t=1.0 / sample_rate, epoch=(s * block_dur))
     return ts.time_slice(start, end)
 
 def colored_noise(psd, start_time, end_time,

--- a/test/test_noise.py
+++ b/test/test_noise.py
@@ -49,9 +49,10 @@ class TestNoise(unittest.TestCase):
         # you should find out why
         summ = self.ts.sum()
         if sys.version_info[0] < 3:
-            comp = 4.597515648402546e-19
+            comp = 4.265258573533564e-18
         else:
             comp = 2.967112629328407e-20
+
         diff = abs(summ - comp)
         self.assertTrue(diff < 1e-30)
 

--- a/test/test_noise.py
+++ b/test/test_noise.py
@@ -51,7 +51,7 @@ class TestNoise(unittest.TestCase):
         if sys.version_info[0] < 3:
             comp = 4.265258573533564e-18
         else:
-            comp = 2.967112629328407e-20
+            comp = 4.265258573533567e-18
 
         diff = abs(summ - comp)
         self.assertTrue(diff < 1e-30)

--- a/test/test_noise.py
+++ b/test/test_noise.py
@@ -38,7 +38,7 @@ set_measure_level(0)
 class TestNoise(unittest.TestCase):
     def setUp(self,*args):
         self.ts = noise_from_string('aLIGOZeroDetHighPower',
-                                    0, 100,
+                                    100, 200,
                                     sample_rate=1024,
                                     seed=0,
                                     low_frequency_cutoff=1.0,

--- a/test/test_noise.py
+++ b/test/test_noise.py
@@ -32,6 +32,7 @@ from utils import simple_exit
 from pycbc.noise.reproduceable import noise_from_string
 from pycbc.fft.fftw import set_measure_level
 from hashlib import md5
+from pycbc.noise.reproduceable import normal
 set_measure_level(0)
 
 class TestNoise(unittest.TestCase):
@@ -42,7 +43,6 @@ class TestNoise(unittest.TestCase):
                                     seed=0,
                                     low_frequency_cutoff=1.0,
                                     filter_duration=64)
-        print(self.ts[0:100])
 
     def test_consistent_result(self):
         # This just checks that the result hasn't changed. If it has
@@ -64,6 +64,11 @@ class TestNoise(unittest.TestCase):
         ratio = p[kmin:kmax] / p2[kmin:kmax]
         ave = ratio.numpy().mean()
         self.assertAlmostEqual(ave, 1, 1)
+
+    def test_noise_reproducible(self):
+        ts1 = normal(20, 30, sample_rate=16384, seed=87693)
+        ts2 = normal(25, 35, sample_rate=16384, seed=87693)
+        self.assertEqual(ts1.time_slice(25, 30), ts2.time_slice(25, 30))
 
 suite = unittest.TestSuite()
 suite.addTest(unittest.TestLoader().loadTestsFromTestCase(TestNoise))


### PR DESCRIPTION
Timeseries with different epochs (+ 10s difference) before bugfix:
![image](https://user-images.githubusercontent.com/44500294/107366466-1a329400-6ad6-11eb-9b05-94290d99a460.png)

Timeseries with different epochs after bugfix:
![image](https://user-images.githubusercontent.com/44500294/107366591-3e8e7080-6ad6-11eb-9f44-920f2c5ea58e.png)

(Bug found by me, fix as suggested by @spxiwh)