### PR TITLE
Add support for legacy waveform strings

### DIFF
--- a/bin/pycbc_inspinj2hdf
+++ b/bin/pycbc_inspinj2hdf
@@ -27,6 +27,7 @@ import numpy
 import pycbc
 from pycbc.inject import InjectionSet, CBCHDFInjectionSet
 from pycbc.io.record import FieldArray
+from pycbc.inject import legacy_approximant_name
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--version', action='version',
@@ -51,7 +52,8 @@ for key in xinj.table[0].__slots__:
 for k in ['simulation_id', 'process_id']:
     a = data.pop(k)
 
-data['approximant'] = data['waveform']
+data['approximant'], data['phase_order'] = \
+        numpy.array([legacy_approximant_name(wf) for wf in data['waveform']]).T
 data['tc'] = data['geocent_end_time'] + 1e-9 * data['geocent_end_time_ns']
 data['dec'] = data['latitude']
 data['ra'] = data['longitude']


### PR DESCRIPTION
This PR adds support for legacy waveform strings in the `pycbc_inspinj2hdf` executable. In cases when no phase order is specificied in the waveform string, the default value of `-1` is used. 

