### PR TITLE
try building wheels

### DIFF
--- a/.github/workflows/basic-tests.yml
+++ b/.github/workflows/basic-tests.yml
@@ -71,6 +71,7 @@ jobs:
         SINGLE_COMMIT: true
   build_wheel:
     name: Build manylinux wheels for later possible upload
+    runs-on: ubuntu-20.04
     steps: 
       - uses: RalfG/python-wheels-manylinux-build@v0.3.3
         with:

--- a/.github/workflows/basic-tests.yml
+++ b/.github/workflows/basic-tests.yml
@@ -70,11 +70,11 @@ jobs:
         FOLDER: _gh-pages
         SINGLE_COMMIT: true
   build_wheel:
-    runs-on: ubuntu-20.04
     name: Build manylinux wheels for later possible upload
-    uses: RalfG/python-wheels-manylinux-build@v0.3.3
-    with:
-        python-versions: 'cp36-cp36m cp37-cp37m cp38-cp38m cp39-cp39m'
+    steps: 
+      - uses: RalfG/python-wheels-manylinux-build@v0.3.3
+        with:
+          python-versions: 'cp36-cp36m cp37-cp37m cp38-cp38m cp39-cp39m'
   deploy_pypi:
     name: Build and publish Python 🐍 distributions 📦 to PyPI and TestPyPI
     needs: build

--- a/.github/workflows/basic-tests.yml
+++ b/.github/workflows/basic-tests.yml
@@ -73,6 +73,7 @@ jobs:
     name: Build manylinux wheels for later possible upload
     runs-on: ubuntu-20.04
     steps: 
+      - uses: actions/checkout@v1
       - uses: RalfG/python-wheels-manylinux-build@v0.3.3
         with:
           python-versions: 'cp36-cp36m cp37-cp37m cp38-cp38m cp39-cp39m'

--- a/.github/workflows/basic-tests.yml
+++ b/.github/workflows/basic-tests.yml
@@ -77,6 +77,10 @@ jobs:
       - uses: RalfG/python-wheels-manylinux-build@v0.3.3
         with:
           python-versions: 'cp36-cp36m cp37-cp37m cp38-cp38 cp39-cp39'
+      - uses: actions/upload-artifact@v2
+        with:
+          name: wheels
+          path: dist/*.whl
   deploy_pypi:
     name: Build and publish Python 🐍 distributions 📦 to PyPI and TestPyPI
     needs: build

--- a/.github/workflows/basic-tests.yml
+++ b/.github/workflows/basic-tests.yml
@@ -72,11 +72,11 @@ jobs:
   build_wheel:
     name: Build manylinux wheels for later possible upload
     runs-on: ubuntu-20.04
-    steps: 
+    steps:
       - uses: actions/checkout@v1
       - uses: RalfG/python-wheels-manylinux-build@v0.3.3
         with:
-          python-versions: 'cp36-cp36m cp37-cp37m cp38-cp38m cp39-cp39m'
+          python-versions: 'cp36-cp36m cp37-cp37m cp38-cp38 cp39-cp39'
   deploy_pypi:
     name: Build and publish Python 🐍 distributions 📦 to PyPI and TestPyPI
     needs: build

--- a/.github/workflows/basic-tests.yml
+++ b/.github/workflows/basic-tests.yml
@@ -69,6 +69,11 @@ jobs:
         BRANCH: gh-pages
         FOLDER: _gh-pages
         SINGLE_COMMIT: true
+  build_wheel:
+    name: Build manylinux wheels for later possible upload
+    uses: RalfG/python-wheels-manylinux-build@v0.3.3
+    with:
+        python-versions: 'cp36-cp36m cp37-cp37m cp38-cp38m cp39-cp39m'
   deploy_pypi:
     name: Build and publish Python 🐍 distributions 📦 to PyPI and TestPyPI
     needs: build

--- a/.github/workflows/basic-tests.yml
+++ b/.github/workflows/basic-tests.yml
@@ -70,6 +70,7 @@ jobs:
         FOLDER: _gh-pages
         SINGLE_COMMIT: true
   build_wheel:
+    runs-on: ubuntu-20.04
     name: Build manylinux wheels for later possible upload
     uses: RalfG/python-wheels-manylinux-build@v0.3.3
     with:

--- a/.github/workflows/basic-tests.yml
+++ b/.github/workflows/basic-tests.yml
@@ -69,39 +69,3 @@ jobs:
         BRANCH: gh-pages
         FOLDER: _gh-pages
         SINGLE_COMMIT: true
-  build_wheel:
-    name: Build manylinux wheels for later possible upload
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v1
-      - uses: RalfG/python-wheels-manylinux-build@v0.3.3
-        with:
-          python-versions: 'cp36-cp36m cp37-cp37m cp38-cp38 cp39-cp39'
-      - uses: actions/upload-artifact@v2
-        with:
-          name: wheels
-          path: dist/*.whl
-  deploy_pypi:
-    name: Build and publish Python 🐍 distributions 📦 to PyPI and TestPyPI
-    needs: build
-    runs-on: ubuntu-20.04
-    if: github.event_name == 'push'
-    steps:
-    - uses: actions/checkout@v1
-    - name: Set up Python 3.7
-      uses: actions/setup-python@v1
-      with:
-        python-version: 3.7
-    - name: build pycbc for pypi
-      run: python setup.py sdist
-    - name: Publish distribution 📦 to Test PyPI
-      if: github.ref == 'refs/heads/master'
-      uses: pypa/gh-action-pypi-publish@master
-      with:
-        password: ${{ secrets.test_pypi_password }}
-        repository_url: https://test.pypi.org/legacy/
-    - name: Publish distribution 📦 to PyPI
-      if: startsWith(github.ref, 'refs/tags')
-      uses: pypa/gh-action-pypi-publish@master
-      with:
-        password: ${{ secrets.pypi_password }}

--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -32,7 +32,7 @@ jobs:
     - name: build pycbc for pypi
       run: |
         python setup.py sdist
-        ls
+        mv *.whl dist
         ls dist
     - name: Publish distribution 📦 to Test PyPI
       if: github.event_name == 'push' && github.ref == 'refs/heads/master'

--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -42,7 +42,6 @@ jobs:
     - name: build pycbc for pypi
       run: |
         python setup.py sdist
-        mv *.whl dist
         ls dist
         ls
         ls artifact

--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -13,27 +13,34 @@ jobs:
           python-versions: 'cp36-cp36m cp37-cp37m cp38-cp38 cp39-cp39'
       - uses: actions/upload-artifact@v2
         with:
-          name: wheels
+          name: linux_wheels
           path: dist/*.whl
+          retention-days: 7
   deploy_pypi:
     name: Build and publish Python 🐍 distributions 📦 to PyPI and TestPyPI
     runs-on: ubuntu-20.04
-    if: github.event_name == 'push'
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python 3.7
       uses: actions/setup-python@v1
       with:
         python-version: 3.7
+    - uses: actions/download-artifact@v2
+      with:
+        name: linux_wheels
     - name: build pycbc for pypi
-      run: python setup.py sdist
+      run: |
+        python setup.py sdist
+        ls dist
     - name: Publish distribution 📦 to Test PyPI
+      if: github.event_name == 'push'
       if: github.ref == 'refs/heads/master'
       uses: pypa/gh-action-pypi-publish@master
       with:
         password: ${{ secrets.test_pypi_password }}
         repository_url: https://test.pypi.org/legacy/
     - name: Publish distribution 📦 to PyPI
+      if: github.event_name == 'push'
       if: startsWith(github.ref, 'refs/tags')
       uses: pypa/gh-action-pypi-publish@master
       with:

--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -42,9 +42,7 @@ jobs:
     - name: build pycbc for pypi
       run: |
         python setup.py sdist
-        ls dist
-        ls
-        ls artifact
+        mv artifact/* dist/
     - name: Publish distribution 📦 to Test PyPI
       if: github.event_name == 'push' && github.ref == 'refs/heads/master'
       uses: pypa/gh-action-pypi-publish@master

--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -33,15 +33,13 @@ jobs:
         python setup.py sdist
         ls dist
     - name: Publish distribution 📦 to Test PyPI
-      if: github.event_name == 'push'
-      if: github.ref == 'refs/heads/master'
+      if: github.event_name == 'push' && github.ref == 'refs/heads/master'
       uses: pypa/gh-action-pypi-publish@master
       with:
         password: ${{ secrets.test_pypi_password }}
         repository_url: https://test.pypi.org/legacy/
     - name: Publish distribution 📦 to PyPI
-      if: github.event_name == 'push'
-      if: startsWith(github.ref, 'refs/tags')
+      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
       uses: pypa/gh-action-pypi-publish@master
       with:
         password: ${{ secrets.pypi_password }}

--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -1,21 +1,33 @@
-name: build pypi release packages
+name: Build Wheels
 
 on: [push, pull_request]
 
 jobs:
-  build_linux_wheel:
-    name: Build manylinux wheels for later possible upload
-    runs-on: ubuntu-20.04
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, macos-10.15]
+
     steps:
-      - uses: actions/checkout@v1
-      - uses: RalfG/python-wheels-manylinux-build@v0.3.3
-        with:
-          python-versions: 'cp36-cp36m cp37-cp37m cp38-cp38 cp39-cp39'
+      - uses: actions/checkout@v2
+
+      # Used to host cibuildwheel
+      - uses: actions/setup-python@v2
+
+      - name: Install cibuildwheel
+        run: python -m pip install cibuildwheel==1.9.0
+
+      - name: Build wheels
+        run: python -m cibuildwheel --output-dir wheelhouse
+        # to supply options, put them in 'env', like:
+        # env:
+        #   CIBW_SOME_OPTION: value
+
       - uses: actions/upload-artifact@v2
         with:
-          name: linux_wheels
-          path: dist
-          retention-days: 7
+          path: ./wheelhouse/*.whl
   deploy_pypi:
     name: Build and publish Python 🐍 distributions 📦 to PyPI and TestPyPI
     runs-on: ubuntu-20.04
@@ -28,7 +40,7 @@ jobs:
         python-version: 3.7
     - uses: actions/download-artifact@v2
       with:
-        name: linux_wheels
+        path: ./
     - name: build pycbc for pypi
       run: |
         python setup.py sdist

--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -21,10 +21,8 @@ jobs:
 
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
-        # to supply options, put them in 'env', like:
-        # env:
-        #   CIBW_SOME_OPTION: value
-
+        env:
+          CIBW_BUILD: cp27-* cp36-* cp37-* cp38-*
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl

--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -44,6 +44,8 @@ jobs:
         python setup.py sdist
         mv *.whl dist
         ls dist
+        ls
+        ls artifact
     - name: Publish distribution 📦 to Test PyPI
       if: github.event_name == 'push' && github.ref == 'refs/heads/master'
       uses: pypa/gh-action-pypi-publish@master

--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -1,0 +1,40 @@
+name: build pypi release packages
+
+on: [push, pull_request]
+
+jobs:
+  build_linux_wheel:
+    name: Build manylinux wheels for later possible upload
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v1
+      - uses: RalfG/python-wheels-manylinux-build@v0.3.3
+        with:
+          python-versions: 'cp36-cp36m cp37-cp37m cp38-cp38 cp39-cp39'
+      - uses: actions/upload-artifact@v2
+        with:
+          name: wheels
+          path: dist/*.whl
+  deploy_pypi:
+    name: Build and publish Python 🐍 distributions 📦 to PyPI and TestPyPI
+    runs-on: ubuntu-20.04
+    if: github.event_name == 'push'
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+    - name: build pycbc for pypi
+      run: python setup.py sdist
+    - name: Publish distribution 📦 to Test PyPI
+      if: github.ref == 'refs/heads/master'
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        password: ${{ secrets.test_pypi_password }}
+        repository_url: https://test.pypi.org/legacy/
+    - name: Publish distribution 📦 to PyPI
+      if: startsWith(github.ref, 'refs/tags')
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        password: ${{ secrets.pypi_password }}

--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -19,6 +19,7 @@ jobs:
   deploy_pypi:
     name: Build and publish Python 🐍 distributions 📦 to PyPI and TestPyPI
     runs-on: ubuntu-20.04
+    needs: build_linux_wheel
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python 3.7

--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -32,6 +32,7 @@ jobs:
     - name: build pycbc for pypi
       run: |
         python setup.py sdist
+        ls
         ls dist
     - name: Publish distribution 📦 to Test PyPI
       if: github.event_name == 'push' && github.ref == 'refs/heads/master'

--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           name: linux_wheels
-          path: dist/*.whl
+          path: dist
           retention-days: 7
   deploy_pypi:
     name: Build and publish Python 🐍 distributions 📦 to PyPI and TestPyPI

--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -31,7 +31,7 @@ jobs:
   deploy_pypi:
     name: Build and publish Python 🐍 distributions 📦 to PyPI and TestPyPI
     runs-on: ubuntu-20.04
-    needs: build_linux_wheel
+    needs: build_wheels
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python 3.7


### PR DESCRIPTION
This PR is an attempt to start building PyCBC binary wheel files. It would be nice for many users not to have to build pycbc directly but to be able to install a pre-built binary. This is an attempt to create those binaries using the 'manylinux' container which is the standard for redistributable linux wheels. 