### PR TITLE
Fix bug in SkyMax chisq code

### DIFF
--- a/pycbc/vetoes/chisq.py
+++ b/pycbc/vetoes/chisq.py
@@ -441,6 +441,7 @@ class SingleDetSkyMaxPowerChisq(SingleDetPowerChisq):
                 logging.info('%s above chisq activation threshold' % num_above)
                 above_indices = indices[above]
                 above_snrv = snrv[above]
+                u_vals = u_vals[above]
                 rchisq = numpy.zeros(len(indices), dtype=numpy.float32)
                 dof = -100
             else:


### PR DESCRIPTION
There is a bug in the SkyMax chi-squared code when it is used with the `chisq-snr-threshold` option (which unfortunately, we didn't use in testing previously, or didn't *exist* when we did this before .. not sure which).

In short the u_vals array must be cut down in the same as the snrv and indices array if this option is given. If it is not, the chi-squared values will be invalid. *However*, they will only actually give wrong answers if the template being used has + and x polarizations that are not orthogonal. If they are orthogonal (as in most cases) the u_val becomes degenerate and you still get the right answer.