### PR TITLE
Simplify effective nsamples logic and don't try to use nacl ACLs

### DIFF
--- a/pycbc/inference/burn_in.py
+++ b/pycbc/inference/burn_in.py
@@ -347,15 +347,8 @@ class BaseBurnInTests(object):
 
     def _getacls(self, filename, start_index):
         """Convenience function for calculating acls for the given filename.
-
-        Since we calculate the acls, this will also store it to the sampler.
         """
-        acls = self.sampler.compute_acl(filename, start_index=start_index)
-        # since we calculated it, save the acls to the sampler...
-        # but only do this if this is the only burn in test
-        if len(self.do_tests) == 1:
-            self.sampler.raw_acls = acls
-        return acls
+        return self.sampler.compute_acl(filename, start_index=start_index)
 
     def _getaux(self, test):
         """Convenience function for getting auxilary information.

--- a/pycbc/inference/sampler/base_mcmc.py
+++ b/pycbc/inference/sampler/base_mcmc.py
@@ -600,11 +600,8 @@ class BaseMCMC(object):
                 for fn in [self.checkpoint_file, self.backup_file]:
                     with self.io(fn, "a") as fp:
                         self.burn_in.write(fp)
-            # Compute acls; the burn_in test may have calculated an acl and
-            # saved it, in which case we don't need to do it again.
-            if self.raw_acls is None:
-                logging.info("Computing autocorrelation time")
-                self.raw_acls = self.compute_acl(self.checkpoint_file)
+            logging.info("Computing autocorrelation time")
+            self.raw_acls = self.compute_acl(self.checkpoint_file)
             # write acts, effective number of samples
             for fn in [self.checkpoint_file, self.backup_file]:
                 with self.io(fn, "a") as fp:

--- a/pycbc/inference/sampler/base_mcmc.py
+++ b/pycbc/inference/sampler/base_mcmc.py
@@ -838,15 +838,18 @@ class EnsembleSupport(object):
         """The effective number of samples post burn-in that the sampler has
         acquired so far.
         """
+        if self.burn_in is not None and not self.burn_in.is_burned_in:
+            # not burned in, so there's no effective samples
+            return 0
         act = self.act
         if act is None:
             act = numpy.inf
-        if self.burn_in is None or not self.burn_in.is_burned_in:
+        if self.burn_in is None:
             start_iter = 0
         else:
             start_iter = self.burn_in.burn_in_iteration
         nperwalker = nsamples_in_chain(start_iter, act, self.niterations)
-        if self.burn_in is not None and self.burn_in.is_burned_in:
+        if self.burn_in is not None:
             # after burn in, we always have atleast 1 sample per walker
             nperwalker = max(nperwalker, 1)
         return int(self.nwalkers * nperwalker)


### PR DESCRIPTION
There currently is a bug in pycbc inference, where, if you only use the nacl test, the sampler will exit as soon as it gets a non-zero ACL, regardless of whether the nacl test passed or not. The bug is a symptom of some of the convuluted logic used to determine when to exit when effective nsamples are requested. This patch fixes that bug, and also simplifies the logic a bit. Specifically, this does two things:

 1. Currently, the nacl test will try to save its acls as the sampler's acls, to avoid calculating ACLs twice. The problem with this is the ACLs calculated by the nacl test are rarely the actual ACLs used (since we usually run with multiple burn in tests), so this doesn't save much. It also has significant effects on the number of effective samples, which in turn affects when the sampler terminates. The disconnected logic is too easy to break.
 2. In the `effective_nsamples` function, immediately check whether burn in has passed or not. If not, just return 0, as it should.