### PR TITLE
unpin h5py and fix issue in descriptor usage of compund types

### DIFF
--- a/bin/all_sky_search/pycbc_fit_sngls_over_multiparam
+++ b/bin/all_sky_search/pycbc_fit_sngls_over_multiparam
@@ -177,5 +177,5 @@ if 'analysis_time' in fits.attrs:
     outfile.attrs['analysis_time'] = fits.attrs['analysis_time']
 
 # add a magic file attribute so that coinc_findtrigs can parse it
-outfile.attrs['stat'] = ifo + b'-fit_coeffs'
+outfile.attrs['stat'] = ifo + '-fit_coeffs'
 logging.info('Done!')

--- a/bin/minifollowups/pycbc_single_template_plot
+++ b/bin/minifollowups/pycbc_single_template_plot
@@ -106,11 +106,11 @@ if args.plot_caption is None:
     args.plot_caption = ''
 
 if 'command_line' in f.attrs:
-    cmd = f.attrs['command_line'].decode() + '\\n\\n' + ' '.join(sys.argv)
+    cmd = f.attrs['command_line'] + '\\n\\n' + ' '.join(sys.argv)
 else:
     cmd = ' '.join(sys.argv)
 
-pycbc.results.save_fig_with_metadata(fig, args.output_file, 
+pycbc.results.save_fig_with_metadata(fig, args.output_file,
                              cmd=cmd, fig_kwds={'dpi': 150},
                              title=args.plot_title,
                              caption=args.plot_caption)

--- a/pycbc/io/record.py
+++ b/pycbc/io/record.py
@@ -269,7 +269,17 @@ def get_dtype_descr(dtype):
     offsets specified. This function tries to fix that by not including
     fields that have no names and are void types.
     """
-    return [dt for dt in dtype.descr if not (dt[0] == '' and dt[1][1] == 'V')]
+    dts = []
+    for dt in dtype.descr:
+        if (dt[0] == '' and dt[1][1] == 'V'):
+            continue
+
+        # Downstream codes (numpy, etc) can't handle metadata in dtype
+        if isinstance(dt[1], tuple):
+            dt = (dt[0], dt[1][0])
+
+        dts.append(dt)
+    return dts
 
 
 def combine_fields(dtypes):

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ matplotlib>=2.0.0
 numpy>=1.16.0,!=1.19.0,<1.20.0; python_version >= '3.5'
 numpy>=1.16.0,<1.17.0; python_version <= '3.4'
 pillow
-h5py<2.10.0
+h5py>=2.5
 jinja2
 mpld3>=0.3
 requests>=1.2.1


### PR DESCRIPTION
Newer version of h5py return a dtype descriptor with metadata, this caused our functions for handling record arrays to fail when constructing compound types as the return product had an unexpected format. This patch attempts to coerce it to the required format for constructing a compound type with numpy. 

This should hopefully allows us to move forward with h5py and when we can drop python2.7 support enable us to use h5py > 3 as a base which has a number of useful improvements. 