### PR TITLE
set reference time for injections, used for some projection methods

### DIFF
--- a/pycbc/inject/inject.py
+++ b/pycbc/inject/inject.py
@@ -123,7 +123,8 @@ def projector(detector_name, inj, hp, hc, distance_scale=1):
     # compute the detector response and add it to the strain
     signal = detector.project_wave(hp_tapered, hc_tapered,
                                    ra, dec, inj.polarization,
-                                   method=projection_method)
+                                   method=projection_method,
+                                   reference_time=tc,)
     return signal
 
 def legacy_approximant_name(apx):


### PR DESCRIPTION
This fixes an issue for very long injections when using one of the non-lal injection methods. They assume a constant time shift, which may be OK, but only towards the end of the waveform. This sets the reference time for this calculation to the geocentric time of coalescence (provided by keyword argument from the injection code) rather then rely on an guess internally which will be inaccurate for long signals. 