### PR TITLE
silence annoying warning messages in upload script

### DIFF
--- a/bin/pycbc_upload_xml_to_gracedb
+++ b/bin/pycbc_upload_xml_to_gracedb
@@ -195,8 +195,8 @@ for event in coinc_table:
 
             fseries = lal.CreateREAL8FrequencySeries(
                 "psd", psd.attrs["epoch"], kmin * df, df,
-                lal.StrainUnit**2 / lal.HertzUnit, len(psd.value) - kmin)
-            fseries.data.data = psd.value[kmin:] / np.square(pycbc.DYN_RANGE_FAC)
+                lal.StrainUnit**2 / lal.HertzUnit, len(psd) - kmin)
+            fseries.data.data = psd[kmin:] / np.square(pycbc.DYN_RANGE_FAC)
             psddict[sngl.ifo] = fseries
 
     xmldoc.childNodes[-1].appendChild(coinc_event_table_curr)


### PR DESCRIPTION
This warning kept coming up:
```
python2.7/site-packages/h5py/_hl/dataset.py:313: H5pyDeprecationWarning: dataset.value has been deprecated. Use dataset[()] instead.
  "Use dataset[()] instead.", H5pyDeprecationWarning)
```
it was annoying

This removes the deprecated bit