### PR TITLE
pycbc_make_skymap: ability to query segment database

### DIFF
--- a/bin/pycbc_make_skymap
+++ b/bin/pycbc_make_skymap
@@ -12,6 +12,7 @@ import tempfile
 import shutil
 import numpy as np
 import h5py
+import pycbc
 from pycbc.filter import sigmasq
 from pycbc.io import live, WaveformArray
 from pycbc.types import TimeSeries, FrequencySeries, MultiDetOptionAppendAction

--- a/bin/pycbc_make_skymap
+++ b/bin/pycbc_make_skymap
@@ -453,4 +453,4 @@ if __name__ == '__main__':
          gracedb_server=opt.gracedb_server,
          test_event=not opt.enable_production_gracedb_upload,
          custom_frame_files=opt.custom_frame_file,
-         approximant=opt.approximant, opt.detector_state)
+         approximant=opt.approximant, detector_state=opt.detector_state)

--- a/bin/pycbc_make_skymap
+++ b/bin/pycbc_make_skymap
@@ -116,10 +116,14 @@ def main(trig_time, mass1, mass2, spin1z, spin2z, f_low, f_upper, sample_rate,
     # if requested, remove detectors with missing/vetoed data
     if 'detector_state':
         required_duration = gps_end_time - gps_start_time
+        science_flags = {'H1': 'DCS-ANALYSIS_READY_C01:1',
+                         'L1': 'DCS-ANALYSIS_READY_C01:1',
+                         'V1': 'ITF_SCIENCE:2'}
         for ifo in ifos:
-            on_segs = dq.query_flag(ifo, 'DATA', gps_start_time, gps_end_time)
+            on_segs = dq.query_flag(ifo, science_flags[ifo],
+                                    gps_start_time, gps_end_time)
             if abs(on_segs) < required_duration:
-                logging.info('Excluding %s due to missing or vetoed data')
+                logging.info('Excluding %s due to missing or vetoed data', ifo)
                 ifos.remove(ifo)
         if not ifos:
             raise RuntimeError('All detectors have been excluded because of '

--- a/bin/pycbc_make_skymap
+++ b/bin/pycbc_make_skymap
@@ -120,8 +120,8 @@ def main(trig_time, mass1, mass2, spin1z, spin2z, f_low, f_upper, sample_rate,
     for ifo in ifos:
         if detector_state is None or ifo not in detector_state:
             continue
-        query = detector_state[ifo][3:]
-        on_segs = dq.query_str(ifo, query, gps_start_time, gps_end_time)
+        on_segs = dq.query_str(ifo, detector_state[ifo],
+                               gps_start_time, gps_end_time)
         if abs(on_segs) < required_duration:
             logging.info('Excluding %s due to missing or vetoed data', ifo)
             ifos.remove(ifo)

--- a/bin/pycbc_make_skymap
+++ b/bin/pycbc_make_skymap
@@ -120,8 +120,8 @@ def main(trig_time, mass1, mass2, spin1z, spin2z, f_low, f_upper, sample_rate,
     for ifo in ifos:
         if detector_state is None or ifo not in detector_state:
             continue
-        on_segs = dq.query_str(ifo, detector_state[ifo],
-                               gps_start_time, gps_end_time)
+        query = detector_state[ifo][3:]
+        on_segs = dq.query_str(ifo, query, gps_start_time, gps_end_time)
         if abs(on_segs) < required_duration:
             logging.info('Excluding %s due to missing or vetoed data', ifo)
             ifos.remove(ifo)

--- a/bin/pycbc_make_skymap
+++ b/bin/pycbc_make_skymap
@@ -71,7 +71,8 @@ def main(trig_time, mass1, mass2, spin1z, spin2z, f_low, f_upper, sample_rate,
          ligolw_event_output=None, window_bins=300,
          frame_types=None, channel_names=None,
          gracedb_server=None, test_event=True,
-         custom_frame_files=None, approximant=None, detector_state=None):
+         custom_frame_files=None, approximant=None, detector_state=None,
+         veto_definer=None):
 
     if not test_event and not gracedb_server:
         raise RuntimeError('a GraceDB URL must be specified if not a test event.')
@@ -121,7 +122,8 @@ def main(trig_time, mass1, mass2, spin1z, spin2z, f_low, f_upper, sample_rate,
         if detector_state is None or ifo not in detector_state:
             continue
         on_segs = dq.query_str(ifo, detector_state[ifo],
-                               gps_start_time, gps_end_time)
+                               gps_start_time, gps_end_time,
+                               veto_definer=veto_definer)
         if abs(on_segs) < required_duration:
             logging.info('Excluding %s due to missing or vetoed data', ifo)
             ifos.remove(ifo)
@@ -428,6 +430,9 @@ if __name__ == '__main__':
                         action=MultiDetMultiColonOptionAction,
                         help='Use the segment database to exclude detectors '
                              'with missing or vetoed data')
+    parser.add_argument('--veto-definer', type=str,
+                        help='Optional path to a veto definer file to resolve '
+                             'macro flags in --detector-state')
     parser.add_argument('--ligolw-skymap-output', type=str, default='.',
                         help='Option to output sky map files to directory')
     parser.add_argument('--ligolw-event-output', type=str,
@@ -459,4 +464,5 @@ if __name__ == '__main__':
          gracedb_server=opt.gracedb_server,
          test_event=not opt.enable_production_gracedb_upload,
          custom_frame_files=opt.custom_frame_file,
-         approximant=opt.approximant, detector_state=opt.detector_state)
+         approximant=opt.approximant, detector_state=opt.detector_state,
+         veto_definer=opt.veto_definer)

--- a/bin/pycbc_make_skymap
+++ b/bin/pycbc_make_skymap
@@ -15,8 +15,8 @@ import h5py
 import pycbc
 from pycbc.filter import sigmasq
 from pycbc.io import live, WaveformArray
-from pycbc.types import TimeSeries, FrequencySeries, MultiDetOptionAction, \
-        MultiDetOptionAppendAction
+from pycbc.types import TimeSeries, FrequencySeries, \
+        MultiDetMultiColonOptionAction, MultiDetOptionAppendAction
 from pycbc.pnutils import nearest_larger_binary_number
 from pycbc.waveform.spa_tmplt import spa_length_in_time
 from pycbc import frame, waveform, dq
@@ -425,7 +425,7 @@ if __name__ == '__main__':
     parser.add_argument('--frame-type', type=str, nargs='+')
     parser.add_argument('--channel-name', type=str, nargs='+')
     parser.add_argument('--detector-state', type=str, nargs='+',
-                        action=MultiDetOptionAction,
+                        action=MultiDetMultiColonOptionAction,
                         help='Use the segment database to exclude detectors '
                              'with missing or vetoed data')
     parser.add_argument('--ligolw-skymap-output', type=str, default='.',

--- a/bin/pycbc_make_skymap
+++ b/bin/pycbc_make_skymap
@@ -5,15 +5,19 @@ Runs a single-template matched filter on strain data from a number of detectors
 and calls BAYESTAR to produce a sky localization from the resulting set of SNR
 time series."""
 
-import h5py, pycbc, subprocess, argparse, tempfile, shutil
-import numpy as np
+import argparse
 import logging
+import subprocess
+import tempfile
+import shutil
+import numpy as np
+import h5py
 from pycbc.filter import sigmasq
 from pycbc.io import live, WaveformArray
 from pycbc.types import TimeSeries, FrequencySeries, MultiDetOptionAppendAction
 from pycbc.pnutils import nearest_larger_binary_number
 from pycbc.waveform.spa_tmplt import spa_length_in_time
-from pycbc import frame, waveform
+from pycbc import frame, waveform, dq
 from pycbc.psd import interpolate
 from ligo.gracedb.rest import GraceDb
 
@@ -65,7 +69,7 @@ def main(trig_time, mass1, mass2, spin1z, spin2z, f_low, f_upper, sample_rate,
          ligolw_event_output=None, window_bins=300,
          frame_types=None, channel_names=None,
          gracedb_server=None, test_event=True,
-         custom_frame_files=None, approximant=None):
+         custom_frame_files=None, approximant=None, detector_state=False):
 
     if not test_event and not gracedb_server:
         raise RuntimeError('a GraceDB URL must be specified if not a test event.')
@@ -107,6 +111,18 @@ def main(trig_time, mass1, mass2, spin1z, spin2z, f_low, f_upper, sample_rate,
     gps_end_time = int(rough_time + pad // 2)
     gps_start_time = gps_end_time - segment_length
     logging.info("Using data: %s-%s", gps_start_time, gps_end_time)
+
+    # if requested, remove detectors with missing/vetoed data
+    if 'detector_state':
+        required_duration = gps_end_time - gps_start_time
+        for ifo in ifos:
+            on_segs = dq.query_flag(ifo, 'DATA', gps_start_time, gps_end_time)
+            if abs(on_segs) < required_duration:
+                logging.info('Excluding %s due to missing or vetoed data')
+                ifos.remove(ifo)
+        if not ifos:
+            raise RuntimeError('All detectors have been excluded because of '
+                               'missing or vetoed data')
 
     highpass_frequency = int(f_low * 0.7)
     logging.info("Setting highpass: %s Hz", highpass_frequency)
@@ -403,6 +419,9 @@ if __name__ == '__main__':
                         help='List of interferometer names, e.g. H1 L1')
     parser.add_argument('--frame-type', type=str, nargs='+')
     parser.add_argument('--channel-name', type=str, nargs='+')
+    parser.add_argument('--detector-state', action='store_true',
+                        help='Query the segment database and exclude detectors '
+                             'with missing or vetoed data')
     parser.add_argument('--ligolw-skymap-output', type=str, default='.',
                         help='Option to output sky map files to directory')
     parser.add_argument('--ligolw-event-output', type=str,
@@ -434,4 +453,4 @@ if __name__ == '__main__':
          gracedb_server=opt.gracedb_server,
          test_event=not opt.enable_production_gracedb_upload,
          custom_frame_files=opt.custom_frame_file,
-         approximant=opt.approximant)
+         approximant=opt.approximant, opt.detector_state)

--- a/bin/pycbc_make_skymap
+++ b/bin/pycbc_make_skymap
@@ -15,7 +15,8 @@ import h5py
 import pycbc
 from pycbc.filter import sigmasq
 from pycbc.io import live, WaveformArray
-from pycbc.types import TimeSeries, FrequencySeries, MultiDetOptionAppendAction
+from pycbc.types import TimeSeries, FrequencySeries, MultiDetOptionAction, \
+        MultiDetOptionAppendAction
 from pycbc.pnutils import nearest_larger_binary_number
 from pycbc.waveform.spa_tmplt import spa_length_in_time
 from pycbc import frame, waveform, dq
@@ -70,7 +71,7 @@ def main(trig_time, mass1, mass2, spin1z, spin2z, f_low, f_upper, sample_rate,
          ligolw_event_output=None, window_bins=300,
          frame_types=None, channel_names=None,
          gracedb_server=None, test_event=True,
-         custom_frame_files=None, approximant=None, detector_state=False):
+         custom_frame_files=None, approximant=None, detector_state=None):
 
     if not test_event and not gracedb_server:
         raise RuntimeError('a GraceDB URL must be specified if not a test event.')
@@ -114,20 +115,19 @@ def main(trig_time, mass1, mass2, spin1z, spin2z, f_low, f_upper, sample_rate,
     logging.info("Using data: %s-%s", gps_start_time, gps_end_time)
 
     # if requested, remove detectors with missing/vetoed data
-    if 'detector_state':
-        required_duration = gps_end_time - gps_start_time
-        science_flags = {'H1': 'DCS-ANALYSIS_READY_C01:1',
-                         'L1': 'DCS-ANALYSIS_READY_C01:1',
-                         'V1': 'ITF_SCIENCE:2'}
-        for ifo in ifos:
-            on_segs = dq.query_flag(ifo, science_flags[ifo],
-                                    gps_start_time, gps_end_time)
-            if abs(on_segs) < required_duration:
-                logging.info('Excluding %s due to missing or vetoed data', ifo)
-                ifos.remove(ifo)
-        if not ifos:
-            raise RuntimeError('All detectors have been excluded because of '
-                               'missing or vetoed data')
+    # over the required segment
+    required_duration = gps_end_time - gps_start_time
+    for ifo in ifos:
+        if detector_state is None or ifo not in detector_state:
+            continue
+        on_segs = dq.query_str(ifo, detector_state[ifo],
+                               gps_start_time, gps_end_time)
+        if abs(on_segs) < required_duration:
+            logging.info('Excluding %s due to missing or vetoed data', ifo)
+            ifos.remove(ifo)
+    if not ifos:
+        raise RuntimeError('All detectors have been excluded due to '
+                           'missing or vetoed data')
 
     highpass_frequency = int(f_low * 0.7)
     logging.info("Setting highpass: %s Hz", highpass_frequency)
@@ -424,8 +424,9 @@ if __name__ == '__main__':
                         help='List of interferometer names, e.g. H1 L1')
     parser.add_argument('--frame-type', type=str, nargs='+')
     parser.add_argument('--channel-name', type=str, nargs='+')
-    parser.add_argument('--detector-state', action='store_true',
-                        help='Query the segment database and exclude detectors '
+    parser.add_argument('--detector-state', type=str, nargs='+',
+                        action=MultiDetOptionAction,
+                        help='Use the segment database to exclude detectors '
                              'with missing or vetoed data')
     parser.add_argument('--ligolw-skymap-output', type=str, default='.',
                         help='Option to output sky map files to directory')

--- a/pycbc/dq.py
+++ b/pycbc/dq.py
@@ -342,7 +342,7 @@ def parse_flag_str(flag_str):
         # Check if the flag should add or subtract time
         if not (flag[0] == '+' or flag[0] == '-'):
             err_msg = "DQ flags must begin with a '+' or a '-' character. "
-            err_msg += "You provided {}.".format(flag)
+            err_msg += "You provided {}. ".format(flag)
             err_msg += "See http://pycbc.org/pycbc/latest/html/workflow/segments.html"
             err_msg += " for more information."
             raise ValueError(err_msg)

--- a/pycbc/dq.py
+++ b/pycbc/dq.py
@@ -164,13 +164,9 @@ def query_flag(ifo, segment_name, start_time, end_time,
                 flag_segments = data['segments']
 
         except Exception as e:
-            print(e)
             if source != 'any':
                 raise ValueError("Unable to find {} segments in GWOSC, check "
                                  "flag name or times".format(segment_name))
-            else:
-                print("Tried and failed to find {} in GWOSC, trying dqsegdb".
-                      format(segment_name))
 
             return query_flag(ifo, segment_name, start_time, end_time,
                               source='dqsegdb', server=server,

--- a/pycbc/types/optparse.py
+++ b/pycbc/types/optparse.py
@@ -52,9 +52,9 @@ class MultiDetOptionAction(argparse.Action):
                  help=None,
                  metavar=None):
         if type is not None:
-            self.internal_type=type
+            self.internal_type = type
         else:
-            self.internal_type=str
+            self.internal_type = str
         new_default = DictWithDefaultReturn(lambda: default)
         #new_default.default_value=default
         if nargs == 0:
@@ -87,7 +87,7 @@ class MultiDetOptionAction(argparse.Action):
         for value in values:
             value = value.split(':')
             if len(value) == 2:
-                # "Normal" case, all ifos supplied independetly as "H1,VALUE"
+                # "Normal" case, all ifos supplied independently as "H1,VALUE"
                 if items.default_set:
                     err_msg += "If you are supplying a value for all ifos, you "
                     err_msg += "cannot also supply values for specific ifos."
@@ -135,7 +135,7 @@ class MultiDetOptionActionSpecial(MultiDetOptionAction):
         for value in values:
             value_split = value.split(':')
             if len(value_split) == 2:
-                # "Normal" case, all ifos supplied independetly as "H1:VALUE"
+                # "Normal" case, all ifos supplied independently as "H1:VALUE"
                 if value_split[0] in items:
                     err_msg += "Multiple values supplied for ifo %s.\n" \
                                %(value_split[0],)
@@ -162,6 +162,36 @@ class MultiDetOptionActionSpecial(MultiDetOptionAction):
                 raise ValueError(err_msg)
         setattr(namespace, self.dest, items)
 
+class MultiDetMultiColonOptionAction(MultiDetOptionAction):
+    """A special case of `MultiDetOptionAction` which allows one to use
+    arguments containing colons, such as `V1:FOOBAR:1`. The first colon is
+    assumed to be the separator between the detector and the argument.
+    All subsequent colons are kept as part of the argument. Unlike
+    `MultiDetOptionAction`, all arguments must be prefixed by the
+    corresponding detector.
+    """
+    def __call__(self, parser, namespace, values, option_string=None):
+        err_msg = ('Issue with option: {}\n'
+                   'Received value: {}\n').format(self.dest, ' '.join(values))
+        if getattr(namespace, self.dest, None) is None:
+            setattr(namespace, self.dest, {})
+        items = copy.copy(getattr(namespace, self.dest))
+        for value in values:
+            value_split = value.split(':', 1) # split at most twice
+            if len(value_split) == 1:
+                err_msg += ("Each argument must contain at least one ':' "
+                            "character")
+                raise ValueError(err_msg)
+            if len(value_split[0]) != 2:
+                err_msg += 'The detector name must be 2 characters long'
+                raise ValueError(err_msg)
+            if value_split[0] in items:
+                err_msg += ('Multiple values supplied for detector {},\n'
+                            'already have {}.')
+                err_msg = err_msg.format(value_split[0], items[value_split[0]])
+                raise ValueError(err_msg)
+            items[value_split[0]] = value
+        setattr(namespace, self.dest, items)
 
 class MultiDetOptionAppendAction(MultiDetOptionAction):
     def __call__(self, parser, namespace, values, option_string=None):

--- a/pycbc/types/optparse.py
+++ b/pycbc/types/optparse.py
@@ -87,7 +87,7 @@ class MultiDetOptionAction(argparse.Action):
         for value in values:
             value = value.split(':')
             if len(value) == 2:
-                # "Normal" case, all ifos supplied independently as "H1,VALUE"
+                # "Normal" case, all ifos supplied independently as "H1:VALUE"
                 if items.default_set:
                     err_msg += "If you are supplying a value for all ifos, you "
                     err_msg += "cannot also supply values for specific ifos."
@@ -177,20 +177,20 @@ class MultiDetMultiColonOptionAction(MultiDetOptionAction):
             setattr(namespace, self.dest, {})
         items = copy.copy(getattr(namespace, self.dest))
         for value in values:
-            value_split = value.split(':', 1) # split at most twice
-            if len(value_split) == 1:
+            if ':' not in value:
                 err_msg += ("Each argument must contain at least one ':' "
                             "character")
                 raise ValueError(err_msg)
-            if len(value_split[0]) != 2:
+            detector, argument = value.split(':', 1) # split at most twice
+            if len(detector) != 2:
                 err_msg += 'The detector name must be 2 characters long'
                 raise ValueError(err_msg)
-            if value_split[0] in items:
+            if detector in items:
                 err_msg += ('Multiple values supplied for detector {},\n'
                             'already have {}.')
-                err_msg = err_msg.format(value_split[0], items[value_split[0]])
+                err_msg = err_msg.format(detector, items[detector])
                 raise ValueError(err_msg)
-            items[value_split[0]] = value
+            items[detector] = self.internal_type(argument)
         setattr(namespace, self.dest, items)
 
 class MultiDetOptionAppendAction(MultiDetOptionAction):

--- a/pycbc/types/optparse.py
+++ b/pycbc/types/optparse.py
@@ -182,9 +182,6 @@ class MultiDetMultiColonOptionAction(MultiDetOptionAction):
                             "character")
                 raise ValueError(err_msg)
             detector, argument = value.split(':', 1)
-            if len(detector) != 2:
-                err_msg += 'The detector name must be 2 characters long'
-                raise ValueError(err_msg)
             if detector in items:
                 err_msg += ('Multiple values supplied for detector {},\n'
                             'already have {}.')

--- a/pycbc/types/optparse.py
+++ b/pycbc/types/optparse.py
@@ -181,7 +181,7 @@ class MultiDetMultiColonOptionAction(MultiDetOptionAction):
                 err_msg += ("Each argument must contain at least one ':' "
                             "character")
                 raise ValueError(err_msg)
-            detector, argument = value.split(':', 1) # split at most twice
+            detector, argument = value.split(':', 1)
             if len(detector) != 2:
                 err_msg += 'The detector name must be 2 characters long'
                 raise ValueError(err_msg)


### PR DESCRIPTION
Adds an option to `pycbc_make_skymap` that queries the segment database and excludes detectors having missing or vetoed data during the requested time interval. The query is defined through the `detector:+flag,-veto` syntax already used elsewhere in PyCBC.