### PR TITLE
allow pycbc plot posterior to compare parameters with the nearest injection

### DIFF
--- a/bin/inference/pycbc_inference_plot_posterior
+++ b/bin/inference/pycbc_inference_plot_posterior
@@ -167,22 +167,42 @@ for p in parameters:
 expected_parameters = {}
 if opts.plot_injection_parameters:
     injections = io.injections_from_cli(opts)
-    for p in parameters:
-        # check that all of the injections are the same
-        try:
-            vals = injections[p]
-        except (NameError, TypeError):
-            # injection doesn't have this parameter, skip
-            logging.warn("Could not find injection parameter {}".format(p))
-            continue
-        unique_vals = numpy.unique(vals)
-        if unique_vals.size != 1:
-            raise ValueError("More than one injection found! To use "
-                "plot-injection-parameters, there must be a single unique "
-                "injection in all input files. Use the expected-parameters "
-                "option to specify an expected parameter instead.")
-        # passed: use the value for the expected
-        expected_parameters[p] = unique_vals[0]
+
+    if opts.pick_injection_by_time:
+        if 'tc' not in injections:
+            raise ValueError("Couldn't determine injection time, tried tc")
+
+        inj_time = injections['tc']
+
+        if 'tc' in samples[0]:
+            pos_time = samples[0]['tc'].mean()
+        elif 'trigger_time' in fp.attrs:
+            pos_time = f.attrs['trigger_time']
+        else:
+            raise ValueError("Couldn't find posterior time, "
+                             "tried tc and trigger_time attribute")
+
+        pick = numpy.where(abs(inj_time - pos_time).min())[0][0]
+        for p in parameters:
+            expected_parameters[p] = injections[p][pick]
+    else:
+        for p in parameters:
+            # check that all of the injections are the same
+            try:
+                vals = injections[p]
+            except (NameError, TypeError):
+                # injection doesn't have this parameter, skip
+                logging.warn("Could not find injection parameter {}".format(p))
+                continue
+            unique_vals = numpy.unique(vals)
+            if unique_vals.size != 1:
+                raise ValueError("More than one injection found! To use "
+                    "plot-injection-parameters, there must be a single unique "
+                    "injection in all input files. Use the expected-parameters"
+                    " option to specify an expected parameter instead.")
+
+            # passed: use the value for the expected
+            expected_parameters[p] = unique_vals[0]
 
 # get expected parameter values from command line
 expected_parameters.update(option_utils.expected_parameters_from_cli(opts))

--- a/bin/inference/pycbc_inference_plot_posterior
+++ b/bin/inference/pycbc_inference_plot_posterior
@@ -149,10 +149,6 @@ if opts.plot_prior is not None:
         for param in fp.attrs['static_params']:
             setattr(prior_samples, param, fp.attrs[param])
 
-# close the files, we don't need them anymore
-for fp in fps:
-    fp.close()
-
 # get minimum and maximum ranges for each parameter from command line
 mins, maxs = option_utils.plot_ranges_from_cli(opts)
 
@@ -176,24 +172,27 @@ if opts.plot_injection_parameters:
 
         if 'tc' in samples[0]:
             pos_time = samples[0]['tc'].mean()
-        elif 'trigger_time' in fp.attrs:
-            pos_time = f.attrs['trigger_time']
+        elif 'trigger_time' in fps[0].attrs:
+            pos_time = fps[0].attrs['trigger_time']
+        elif 'tc_ref' in fps[0].attrs:
+            pos_time = fps[0].attrs['tc_ref']
         else:
             raise ValueError("Couldn't find posterior time, "
-                             "tried tc and trigger_time attribute")
+                             "tried tc, tc_ref, and trigger_time attribute")
+        pick = abs(inj_time - pos_time).argmin()
 
-        pick = numpy.where(abs(inj_time - pos_time).min())[0][0]
-        for p in parameters:
+    for p in parameters:
+        try:
+            vals = injections[p]
+        except (NameError, TypeError):
+            # injection doesn't have this parameter, skip
+            logging.warn("Could not find injection parameter {}".format(p))
+            continue
+
+        if opts.pick_injection_by_time:
             expected_parameters[p] = injections[p][pick]
-    else:
-        for p in parameters:
+        else:
             # check that all of the injections are the same
-            try:
-                vals = injections[p]
-            except (NameError, TypeError):
-                # injection doesn't have this parameter, skip
-                logging.warn("Could not find injection parameter {}".format(p))
-                continue
             unique_vals = numpy.unique(vals)
             if unique_vals.size != 1:
                 raise ValueError("More than one injection found! To use "
@@ -203,6 +202,10 @@ if opts.plot_injection_parameters:
 
             # passed: use the value for the expected
             expected_parameters[p] = unique_vals[0]
+
+# close the files, we don't need them anymore
+for fp in fps:
+    fp.close()
 
 # get expected parameter values from command line
 expected_parameters.update(option_utils.expected_parameters_from_cli(opts))

--- a/pycbc/inference/option_utils.py
+++ b/pycbc/inference/option_utils.py
@@ -216,6 +216,10 @@ def add_plot_posterior_option_group(parser):
                              "injection in the file to work. Any values "
                              "specified by expected-parameters will override "
                              "the values obtained for the injection.")
+    pgroup.add_argument('--pick-injection-by-time', action='store_true',
+                        default=False,
+                        help="In the case of multiple injections, pick one"
+                             "for plotting based on its proximity in time.")
     add_injsamples_map_opt(pgroup)
     return pgroup
 

--- a/pycbc/inference/option_utils.py
+++ b/pycbc/inference/option_utils.py
@@ -219,7 +219,7 @@ def add_plot_posterior_option_group(parser):
     pgroup.add_argument('--pick-injection-by-time', action='store_true',
                         default=False,
                         help="In the case of multiple injections, pick one"
-                             "for plotting based on its proximity in time.")
+                             " for plotting based on its proximity in time.")
     add_injsamples_map_opt(pgroup)
     return pgroup
 


### PR DESCRIPTION
This patch adds a new option to add in plotting injection parameters which are separated clearly by time. Instead of giving up, we add an option which allows the code to pick a single injection which is closest in time to the posterior results to compare. 