### PR TITLE
pycbc_make_skymap: add support for generating skymaps from simulated data & injections

### DIFF
--- a/bin/pycbc_make_skymap
+++ b/bin/pycbc_make_skymap
@@ -27,6 +27,8 @@ from ligo.gracedb.rest import GraceDb
 def default_frame_type(time, ifo):
     """Sensible defaults for frame types based on interferometer and time.
     """
+    if opt.injection_file is not None:
+        return ifo + '_FAKE_DATA'
     if time < 1137254517:
         # O1
         if ifo in ['H1', 'L1']:
@@ -48,6 +50,8 @@ def default_frame_type(time, ifo):
 def default_channel_name(time, ifo):
     """Sensible defaults for channel name based on interferometer and time.
     """
+    if opt.injection_file is not None:
+        return ifo + ':FAKE_DATA'
     if time < 1137254517:
         # O1
         if ifo in ['H1', 'L1']:
@@ -72,7 +76,7 @@ def main(trig_time, mass1, mass2, spin1z, spin2z, f_low, f_upper, sample_rate,
          frame_types=None, channel_names=None,
          gracedb_server=None, test_event=True,
          custom_frame_files=None, approximant=None, detector_state=None,
-         veto_definer=None):
+         veto_definer=None, injection_file=None):
 
     if not test_event and not gracedb_server:
         raise RuntimeError('a GraceDB URL must be specified if not a test event.')
@@ -155,7 +159,8 @@ def main(trig_time, mass1, mass2, spin1z, spin2z, f_low, f_upper, sample_rate,
         "--autogating-pad","16",
         "--strain-high-pass", str(highpass_frequency),
         "--pad-data", "8",
-        "--chisq-bins",'0.72*get_freq("fSEOBNRv4Peak",params.mass1,params.mass2,params.spin1z,params.spin2z)**0.7']
+        "--chisq-bins",'0.72*get_freq("fSEOBNRv4Peak",params.mass1,params.mass2,params.spin1z,params.spin2z)**0.7',
+        "--injection-file", str(opt.injection_file)]
 
         coinc_results['foreground/'+ifo+'/end_time'] = float(trig_time)
         coinc_results['foreground/'+ifo+'/mass1'] = mass1
@@ -168,7 +173,14 @@ def main(trig_time, mass1, mass2, spin1z, spin2z, f_low, f_upper, sample_rate,
         coinc_results['foreground/'+ifo+'/window'] = window
         coinc_results['foreground/'+ifo+'/sample_rate'] = int(sample_rate)
         coinc_results['foreground/'+ifo+'/template_id'] = i
-
+        
+        command.append("--fake-strain")
+        if ifo in ['H1', 'L1']:
+            command.append("aLIGOZeroDetHighPowerGWINC")
+        elif ifo in ['V1']:
+            command.append("AdvVirgo")
+        else:
+            print("{} can't be used for simulating data".format(ifo))
         command.append("--approximant")
         for apx in approximant:
             command.append(apx)
@@ -185,37 +197,38 @@ def main(trig_time, mass1, mass2, spin1z, spin2z, f_low, f_upper, sample_rate,
         command.append("--trigger-time"),command.append(str(np.round(trig_time,5)))
         command.append("--window"),command.append(str(window))
 
-        if custom_frame_files is None or ifo not in custom_frame_files:
-            command.append("--frame-type")
-            command.append(frame_types[ifo])
-        else:
-            logging.info("Check if the segment in the custom frame file is safe")
-            fr_start_times = []
-            fr_end_times = []
-            for custom_frame in custom_frame_files[ifo]:
-                try:
-                    frame_data = frame.read_frame(custom_frame, channel_names[ifo])
-                except RuntimeError:
-                    msg = 'Channel name in {} is not {}'.format(
-                            custom_frame, channel_names[ifo])
+        if opt.injection_file is None:
+            if custom_frame_files is None or ifo not in custom_frame_files:
+                command.append("--frame-type")
+                command.append(frame_types[ifo])
+            else:
+                logging.info("Check if the segment in the custom frame file is safe")
+                fr_start_times = []
+                fr_end_times = []
+                for custom_frame in custom_frame_files[ifo]:
+                    try:
+                        frame_data = frame.read_frame(custom_frame, channel_names[ifo])
+                    except RuntimeError:
+                        msg = 'Channel name in {} is not {}'.format(
+                                custom_frame, channel_names[ifo])
+                        raise RuntimeError(msg)
+                    fr_start_times.append(frame_data.start_time)
+                    fr_end_times.append(frame_data.end_time)
+                if gps_start_time < np.min(fr_start_times):
+                    msg = 'Start time of {} must be before the required start time {}'
+                    msg = msg.format(np.min(fr_start_times), gps_start_time)
                     raise RuntimeError(msg)
-                fr_start_times.append(frame_data.start_time)
-                fr_end_times.append(frame_data.end_time)
-            if gps_start_time < np.min(fr_start_times):
-                msg = 'Start time of {} must be before the required start time {}'
-                msg = msg.format(np.min(fr_start_times), gps_start_time)
-                raise RuntimeError(msg)
-            if np.max(fr_end_times) < gps_end_time:
-                msg = 'End time of {} must be after the required end time {}'
-                msg = msg.format(np.max(fr_end_times), gps_end_time)
-                raise RuntimeError(msg)
-            if trig_time < np.min(fr_start_times) or np.max(fr_end_times) < trig_time:
-                msg = 'Trigger time must be within your frame file(s)'
-                raise RuntimeError(msg)
+                if np.max(fr_end_times) < gps_end_time:
+                    msg = 'End time of {} must be after the required end time {}'
+                    msg = msg.format(np.max(fr_end_times), gps_end_time)
+                    raise RuntimeError(msg)
+                if trig_time < np.min(fr_start_times) or np.max(fr_end_times) < trig_time:
+                    msg = 'Trigger time must be within your frame file(s)'
+                    raise RuntimeError(msg)
 
-            command.append("--frame-files")
-            for custom_frame in custom_frame_files[ifo]:
-                command.append(custom_frame)
+                command.append("--frame-files")
+                for custom_frame in custom_frame_files[ifo]:
+                    command.append(custom_frame)
 
         command.append("--channel-name")
         command.append(channel_names[ifo])
@@ -448,6 +461,8 @@ if __name__ == '__main__':
                         action=MultiDetOptionAppendAction,
                         help='Lists of local frame files, e.g., '
                              'H1:/path/to/frame/file L1:/path/to/frame/file')
+    parser.add_argument('--injection-file', type=str,
+                        help='The injection file as an .xml.')
 
     opt = parser.parse_args()
 
@@ -465,4 +480,4 @@ if __name__ == '__main__':
          test_event=not opt.enable_production_gracedb_upload,
          custom_frame_files=opt.custom_frame_file,
          approximant=opt.approximant, detector_state=opt.detector_state,
-         veto_definer=opt.veto_definer)
+         veto_definer=opt.veto_definer, injection_file=opt.injection_file)

--- a/bin/pycbc_make_skymap
+++ b/bin/pycbc_make_skymap
@@ -191,7 +191,7 @@ def main(trig_time, mass1, mass2, spin1z, spin2z, f_low, f_upper, sample_rate,
         command.append("--window"),command.append(str(window))
         
         if opt.injection_file is not None:
-            command.append("--injection-file"),command(str(opt.injection_file))
+            command.append("--injection-file"),command.append(str(opt.injection_file))
             command.append("--fake-strain")
             if ifo in ['H1', 'L1']:
                 command.append("aLIGOZeroDetHighPowerGWINC")

--- a/bin/pycbc_make_skymap
+++ b/bin/pycbc_make_skymap
@@ -159,8 +159,7 @@ def main(trig_time, mass1, mass2, spin1z, spin2z, f_low, f_upper, sample_rate,
         "--autogating-pad","16",
         "--strain-high-pass", str(highpass_frequency),
         "--pad-data", "8",
-        "--chisq-bins",'0.72*get_freq("fSEOBNRv4Peak",params.mass1,params.mass2,params.spin1z,params.spin2z)**0.7',
-        "--injection-file", str(opt.injection_file)]
+        "--chisq-bins",'0.72*get_freq("fSEOBNRv4Peak",params.mass1,params.mass2,params.spin1z,params.spin2z)**0.7']
 
         coinc_results['foreground/'+ifo+'/end_time'] = float(trig_time)
         coinc_results['foreground/'+ifo+'/mass1'] = mass1
@@ -174,13 +173,7 @@ def main(trig_time, mass1, mass2, spin1z, spin2z, f_low, f_upper, sample_rate,
         coinc_results['foreground/'+ifo+'/sample_rate'] = int(sample_rate)
         coinc_results['foreground/'+ifo+'/template_id'] = i
         
-        command.append("--fake-strain")
-        if ifo in ['H1', 'L1']:
-            command.append("aLIGOZeroDetHighPowerGWINC")
-        elif ifo in ['V1']:
-            command.append("AdvVirgo")
-        else:
-            print("{} can't be used for simulating data".format(ifo))
+        
         command.append("--approximant")
         for apx in approximant:
             command.append(apx)
@@ -196,6 +189,16 @@ def main(trig_time, mass1, mass2, spin1z, spin2z, f_low, f_upper, sample_rate,
         command.append("--gps-end-time"),command.append(str(gps_end_time))
         command.append("--trigger-time"),command.append(str(np.round(trig_time,5)))
         command.append("--window"),command.append(str(window))
+        
+        if opt.injection_file is not None:
+            command.append("--injection-file"),command(str(opt.injection_file))
+            command.append("--fake-strain")
+            if ifo in ['H1', 'L1']:
+                command.append("aLIGOZeroDetHighPowerGWINC")
+            elif ifo in ['V1']:
+                command.append("AdvVirgo")
+            else:
+                print("{} can't be used for simulating data".format(ifo))
 
         if opt.injection_file is None:
             if custom_frame_files is None or ifo not in custom_frame_files:
@@ -462,7 +465,7 @@ if __name__ == '__main__':
                         help='Lists of local frame files, e.g., '
                              'H1:/path/to/frame/file L1:/path/to/frame/file')
     parser.add_argument('--injection-file', type=str,
-                        help='The injection file as an .xml.')
+                        help='Optional path to an injection file.')
 
     opt = parser.parse_args()
 


### PR DESCRIPTION
These changes let pycbc_make_skymap to take an injection file (in the form of an xml file) and produce a skymap using pycbc_single_template functionality for generating simulated data for an injection.

Things that need changing/improving:
- Currently only takes H1, L1, V1 as the detectors. There is a temporary print statement which tells you when you cant use an ifo you've inputted but ideally this would somehow disregard the entire pycbc_single_template subprocess that has been partially built for that ifo so far.
- I've tested this for simulated skymaps and for a single example I have locally, I can't find any examples which I can test this on to see if the functionality remains the same (the single example I have is a GWOSC set of frame files).
- Some descriptions could be updated to fit better