### PR TITLE
Properly record maxl phase in HM marginalized model

### DIFF
--- a/pycbc/inference/models/marginalized_gaussian_noise.py
+++ b/pycbc/inference/models/marginalized_gaussian_noise.py
@@ -426,9 +426,9 @@ class MarginalizedHMPolPhase(BaseGaussianNoise):
 
     @property
     def _extra_stats(self):
-        """Adds ``maxl_polarization`` and the ``max_phase``
+        """Adds ``maxl_polarization`` and the ``maxl_phase``
         """
-        return ['maxl_polarization', 'max_phase',]
+        return ['maxl_polarization', 'maxl_phase',]
 
     def _nowaveform_loglr(self):
         """Convenience function to set loglr values if no waveform generated.


### PR DESCRIPTION
The `MarginalizedHMPolPhase` records the max likelihood phase as `maxl_phase`, but this isn't being included in the returned `current_stats` because the `_extra_stats` call it `max_phase`. This fixes that.