### PR TITLE
add ability to set fd sequence with plugin

### DIFF
--- a/pycbc/waveform/plugin.py
+++ b/pycbc/waveform/plugin.py
@@ -31,7 +31,7 @@ def add_custom_waveform(approximant, function, domain,
         if sequence:
             if not force and (approximant in fd_sequence):
                 raise used
-            cpu_fd[approximant] = function
+            fd_sequence[approximant] = function
         else:
             if not force and (approximant in cpu_fd):
                 raise used

--- a/pycbc/waveform/plugin.py
+++ b/pycbc/waveform/plugin.py
@@ -40,6 +40,7 @@ def add_custom_waveform(approximant, function, domain,
         raise ValueError("Invalid domain ({}), should be "
                          "'time' or 'frequency'".format(domain))
 
+
 def add_length_estimator(approximant, function):
     """ Add length estimator for an approximant
 
@@ -55,6 +56,7 @@ def add_length_estimator(approximant, function):
         raise RuntimeError("Can't load length estimator {}, the name is"
                            " already in use.".format(approximant))
     _filter_time_lengths[approximant] = function
+
 
 def retrieve_waveform_plugins():
     """ Process external waveform plugins

--- a/pycbc/waveform/waveform.py
+++ b/pycbc/waveform/waveform.py
@@ -490,7 +490,7 @@ def get_fd_waveform_sequence(template=None, **kwds):
         required = parameters.fd_required
     check_args(input_params, required)
     return wav_gen(**input_params)
-    
+
 
 get_fd_waveform_sequence.__doc__ = get_fd_waveform_sequence.__doc__.format(
     params=parameters.fd_waveform_sequence_params.docstr(prefix="    ",


### PR DESCRIPTION
I've run into a case where I need to modify a waveform returned by fd waveform sequence. This is a good opportunity to enable the plugin interface to enable people to provide waveforms of this format externally. 