### PR TITLE
Fix bug in final_spin_from_initial

### DIFF
--- a/pycbc/conversions.py
+++ b/pycbc/conversions.py
@@ -1217,8 +1217,8 @@ def get_final_from_initial(mass1, mass2, spin1x=0., spin1y=0., spin1z=0.,
     for ii in range(final_mass.size):
         m1 = numpy.float(mass1[ii])
         m2 = numpy.float(mass2[ii])
-        spin1 = [spin1x[ii], spin1y[ii], spin1z[ii]]
-        spin2 = [spin2x[ii], spin2y[ii], spin2z[ii]]
+        spin1 = list(map(float, [spin1x[ii], spin1y[ii], spin1z[ii]]))
+        spin2 = list(map(float, [spin2x[ii], spin2y[ii], spin2z[ii]]))
         _, fm, fs = lalsim.SimIMREOBFinalMassSpin(m1, m2, spin1, spin2,
                                                   getattr(lalsim, approximant))
         final_mass[ii] = fm * (m1 + m2)

--- a/pycbc/conversions.py
+++ b/pycbc/conversions.py
@@ -1215,8 +1215,8 @@ def get_final_from_initial(mass1, mass2, spin1x=0., spin1y=0., spin1z=0.,
     final_mass = numpy.zeros(mass1.shape)
     final_spin = numpy.zeros(mass1.shape)
     for ii in range(final_mass.size):
-        m1 = mass1[ii]
-        m2 = mass2[ii]
+        m1 = numpy.float(mass1[ii])
+        m2 = numpy.float(mass2[ii])
         spin1 = [spin1x[ii], spin1y[ii], spin1z[ii]]
         spin2 = [spin2x[ii], spin2y[ii], spin2z[ii]]
         _, fm, fs = lalsim.SimIMREOBFinalMassSpin(m1, m2, spin1, spin2,


### PR DESCRIPTION
In the conversions module, the lalsim function called in final_spin_from_initial is currently giving an error
"TypeError: in method 'SimIMREOBFinalMassSpin', argument 3 of type 'REAL8'"

This PR fixes the bug by ensuring the masses are floats.