### PR TITLE
Fix missing bits from #3057

### DIFF
--- a/pycbc/strain/strain.py
+++ b/pycbc/strain/strain.py
@@ -728,11 +728,11 @@ def insert_strain_option_group_multi_ifo(parser, gps_times=True):
                          "used")
 
     data_reading_group_multi.add_argument("--injection-f-ref", type=float,
-                    action=MultiDetOptionAction, metavar='IFO:VALUE',
+                    nargs='+', action=MultiDetOptionAction, metavar='IFO:VALUE',
                     help="Reference frequency in Hz for creating CBC "
                          "injections from an XML file")
     data_reading_group_multi.add_argument('--injection-f-final', type=float,
-                    action=MultiDetOptionAction, metavar='IFO:VALUE',
+                    nargs='+', action=MultiDetOptionAction, metavar='IFO:VALUE',
                     help="Override the f_final field of a CBC XML "
                          "injection file (frequency in Hz)")
 

--- a/pycbc/strain/strain.py
+++ b/pycbc/strain/strain.py
@@ -728,11 +728,11 @@ def insert_strain_option_group_multi_ifo(parser, gps_times=True):
                          "used")
 
     data_reading_group_multi.add_argument("--injection-f-ref", type=float,
-                    nargs='+', action=MultiDetOptionAction, metavar='IFO:VALUE',
+                    action=MultiDetOptionAction, metavar='IFO:VALUE',
                     help="Reference frequency in Hz for creating CBC "
                          "injections from an XML file")
     data_reading_group_multi.add_argument('--injection-f-final', type=float,
-                    nargs='+', action=MultiDetOptionAction, metavar='IFO:VALUE',
+                    action=MultiDetOptionAction, metavar='IFO:VALUE',
                     help="Override the f_final field of a CBC XML "
                          "injection file (frequency in Hz)")
 

--- a/pycbc/types/optparse.py
+++ b/pycbc/types/optparse.py
@@ -43,7 +43,7 @@ class MultiDetOptionAction(argparse.Action):
     def __init__(self,
                  option_strings,
                  dest,
-                 nargs=None,
+                 nargs='+',
                  const=None,
                  default=None,
                  type=None,


### PR DESCRIPTION
#3057 forgot to include the `nargs='+'` kwargs, creating problems when the `--injection-f-ref` and `--injection-f-final` multidetector options are given a single parameter like `10`.

Fixes #3662.