### PR TITLE
add intended python requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -294,7 +294,7 @@ setup (
                     'pycbc.results': find_files('pycbc/results'),
                     'pycbc.tmpltbank': find_files('pycbc/tmpltbank')},
     ext_modules = ext,
-    python_requires='2.7, >=3.6',
+    python_requires='==2.7, >=3.6',
     classifiers=[
         'Programming Language :: Python',
         'Programming Language :: Python :: 2.7',

--- a/setup.py
+++ b/setup.py
@@ -294,7 +294,7 @@ setup (
                     'pycbc.results': find_files('pycbc/results'),
                     'pycbc.tmpltbank': find_files('pycbc/tmpltbank')},
     ext_modules = ext,
-    python_requires='==2.7, >=3.6',
+    python_requires='>=2.7',
     classifiers=[
         'Programming Language :: Python',
         'Programming Language :: Python :: 2.7',

--- a/setup.py
+++ b/setup.py
@@ -294,6 +294,7 @@ setup (
                     'pycbc.results': find_files('pycbc/results'),
                     'pycbc.tmpltbank': find_files('pycbc/tmpltbank')},
     ext_modules = ext,
+    python_requires='2.7, >=3.6',
     classifiers=[
         'Programming Language :: Python',
         'Programming Language :: Python :: 2.7',


### PR DESCRIPTION
We should be in the habit of proactively declaring the python version supported so that incompatible version are not installed through pypi. Currently, this is 2.7, and >=3.6. 

