### PR TITLE
Support tagging for additional minifollowup jobs

### DIFF
--- a/pycbc/workflow/minifollowups.py
+++ b/pycbc/workflow/minifollowups.py
@@ -210,6 +210,8 @@ def setup_single_det_minifollowups(workflow, single_trig_file, tmpltbank_file,
     if statfiles:
         statfiles = statfiles.find_output_with_ifo(curr_ifo)
         node.add_input_list_opt('--statistic-files', statfiles)
+    if tags:
+        node.add_list_opt('--tags', tags)
     node.new_output_file_opt(workflow.analysis_time, '.dax', '--output-file')
     node.new_output_file_opt(workflow.analysis_time, '.dax.map',
                              '--output-map')
@@ -307,6 +309,8 @@ def setup_injection_minifollowups(workflow, injection_file, inj_xml_file,
     node.add_input_opt('--inspiral-segments', insp_segs)
     node.add_opt('--inspiral-data-read-name', insp_data_name)
     node.add_opt('--inspiral-data-analyzed-name', insp_anal_name)
+    if tags:
+        node.add_list_opt('--tags', tags)
     node.new_output_file_opt(workflow.analysis_time, '.dax', '--output-file', tags=tags)
     node.new_output_file_opt(workflow.analysis_time, '.dax.map', '--output-map', tags=tags)
     node.new_output_file_opt(workflow.analysis_time, '.tc.txt', '--transformation-catalog', tags=tags)


### PR DESCRIPTION
This PR fixes an inconsistency with how tags were propagated to mini followup jobs as part of the coinc workflow. Currently, tags are only propagated for foreground follow up jobs: https://github.com/gwastro/pycbc/blob/f8f57150a96439c12720961796e47e53dce2b075/pycbc/workflow/minifollowups.py#L102-L103

 This PR incorporates the same tagging code for the injection and single detector follow ups. 