### PR TITLE
Make it easier to load data and models

### DIFF
--- a/pycbc/inference/io/base_hdf.py
+++ b/pycbc/inference/io/base_hdf.py
@@ -46,6 +46,7 @@ from pycbc.io import FieldArray
 from pycbc.inject import InjectionSet
 from pycbc.io import (dump_state, load_state)
 from pycbc.workflow import WorkflowConfigParser
+from pycbc.types import FrequencySeries
 
 
 def format_attr(val):
@@ -913,3 +914,44 @@ class BaseInferenceFile(h5py.File):
             cp.read_file(cf)
             return cp
         return cf
+
+    def read_data(self):
+        """Loads the data stored in the file as a FrequencySeries.
+
+        Only works for models that store data as a frequency series in
+        ``data/DET/stilde``. A ``KeyError`` will be raised if the model used
+        did not store data in that path.
+
+        Returns
+        -------
+        dict :
+            Dictionary of detector name -> FrequencySeries.
+        """
+        data = {}
+        fmt = 'data/{}/stilde'
+        for det in self['data'].keys():
+            group = self[fmt.format(det)]
+            data[det] = FrequencySeries(
+                group[()], delta_f=group.attrs['delta_f'],
+                epoch=group.attrs['epoch'])
+        return data
+
+    def read_psds(self):
+        """Loads the PSDs stored in the file as a FrequencySeries.
+
+        Only works for models that store PSDs in
+        ``data/DET/psds/0``. A ``KeyError`` will be raised if the model used
+        did not store PSDs in that path.
+
+        Returns
+        -------
+        dict :
+            Dictionary of detector name -> FrequencySeries.
+        """
+        psds = {}
+        fmt = 'data/{}/psds/0'
+        for det in self['data'].keys():
+            group = self[fmt.format(det)]
+            psds[det] = FrequencySeries(
+                group[()], delta_f=group.attrs['delta_f'])
+        return psds


### PR DESCRIPTION
Adds a couple of convenience functions, `read_data` and `read_psds` to the inference base hdf file class, to make it easier to load the data and PSDs into FrequencySeries (which I frequently find myself doing). Also makes it so that you can provide the data and psds dictionary to `BaseGaussianNoise.from_config`. If they are given, the data and PSDs will not be loaded from the frame files, which always takes a long time. Combining, you can now load the model using an inference result file by doing:
```
from pycbc.inference import (io, models)
fp = io.loadfile(inference_file, 'r')
data = fp.read_data()
psds = fp.read_psds()
cp = fp.read_config_file()
fp.close()
model = models.read_from_config(cp, data=data, psds=psds)
```

This is a step toward an executable to plot max likelihood waveforms, which has been on the To Do list for awhile.
