### PR TITLE
simple convenience plot method

### DIFF
--- a/pycbc/types/frequencyseries.py
+++ b/pycbc/types/frequencyseries.py
@@ -561,6 +561,13 @@ class FrequencySeries(Array):
                      low_frequency_cutoff=low_frequency_cutoff,
                      high_frequency_cutoff=high_frequency_cutoff)
 
+    def plot(self, **kwds):
+        """ Basic plot of this frequency series
+        """
+        from matplotlib import pyplot
+        plot = pyplot.plot(self.sample_frequencies, self, **kwds)
+        return plot
+
 def load_frequencyseries(path, group=None):
     """
     Load a FrequencySeries from a .hdf, .txt or .npy file. The

--- a/pycbc/types/frequencyseries.py
+++ b/pycbc/types/frequencyseries.py
@@ -565,8 +565,14 @@ class FrequencySeries(Array):
         """ Basic plot of this frequency series
         """
         from matplotlib import pyplot
-        plot = pyplot.plot(self.sample_frequencies, self, **kwds)
-        return plot
+
+        if self.kind == 'real':
+            plot = pyplot.plot(self.sample_frequencies, self, **kwds)
+            return plot
+        elif self.kind == 'complex':
+            plot1 = pyplot.plot(self.sample_frequencies, self.real(), **kwds)
+            plot2 = pyplot.plot(self.sample_frequencies, self.imag(), **kwds)
+            return plot1, plot2
 
 def load_frequencyseries(path, group=None):
     """

--- a/pycbc/types/timeseries.py
+++ b/pycbc/types/timeseries.py
@@ -1020,8 +1020,14 @@ class TimeSeries(Array):
         """ Basic plot of this time series
         """
         from matplotlib import pyplot
-        plot = pyplot.plot(self.sample_times, self, **kwds)
-        return plot
+
+        if self.kind == 'real':
+            plot = pyplot.plot(self.sample_times, self, **kwds)
+            return plot
+        elif self.kind == 'complex':
+            plot1 = pyplot.plot(self.sample_times, self.real(), **kwds)
+            plot2 = pyplot.plot(self.sample_times, self.imag(), **kwds)
+            return plot1, plot2
 
 def load_timeseries(path, group=None):
     """

--- a/pycbc/types/timeseries.py
+++ b/pycbc/types/timeseries.py
@@ -1016,6 +1016,13 @@ class TimeSeries(Array):
         from scipy.signal import detrend
         return self._return(detrend(self.numpy(), type=type))
 
+    def plot(self, **kwds):
+        """ Basic plot of this time series
+        """
+        from matplotlib import pyplot
+        plot = pyplot.plot(self.sample_times, self, **kwds)
+        return plot
+
 def load_timeseries(path, group=None):
     """
     Load a TimeSeries from a .hdf, .txt or .npy file. The


### PR DESCRIPTION
Add method to just shorten a very common use case of plotting a time or frequency series. This just wraps the matplotlib function and passes any keywords you give it to the plot command. 
```
from pycbc.waveform import get_fd_waveform, get_td_waveform
hp, hc = get_td_waveform(approximant="SEOBNRv4", mass1=10,
                         mass2=10, f_lower=30, delta_t=1.0/4096)

pylab.figure()
hp.plot()

pylab.figure()
hp.to_frequencyseries().plot(label='test')
import pylab
pylab.legend()
pylab.xscale('log')
```
Produces 
![download (63)](https://user-images.githubusercontent.com/2206534/110869564-fd52d180-82ca-11eb-8fbb-0981a530bf9d.png)
![download (62)](https://user-images.githubusercontent.com/2206534/110869568-fe83fe80-82ca-11eb-8beb-a03301b7d100.png)
