### PR TITLE
Improve error logging when querying segdb

### DIFF
--- a/pycbc/dq.py
+++ b/pycbc/dq.py
@@ -25,6 +25,7 @@
 gravitational-wave detectors from public sources and/or dqsegdb.
 """
 
+import logging
 import json
 import numpy
 from ligo.segments import segmentlist, segment
@@ -104,6 +105,25 @@ def parse_veto_definer(veto_def_filename, ifos):
 GWOSC_URL = 'https://www.gw-openscience.org/timeline/segments/json/{}/{}_{}/{}/{}/'
 
 
+def query_dqsegdb2(detector, flag_name, start_time, end_time, server):
+    """Utility function for better error reporting when calling dqsegdb2.
+    """
+    from dqsegdb2.query import query_segments
+
+    complete_flag = detector + ':' + flag_name
+    try:
+        query_res = query_segments(complete_flag,
+                                   int(start_time),
+                                   int(end_time),
+                                   host=server)
+        return query_res['active']
+    except Exception as e:
+        logging.error('Could not query segment database, check name '
+                      '(%s), times (%d-%d) and server (%s)',
+                      complete_flag, int(start_time), int(end_time),
+                      server)
+        raise e
+
 def query_flag(ifo, segment_name, start_time, end_time,
                source='any', server="https://segments.ligo.org",
                veto_definer=None, cache=False):
@@ -173,13 +193,6 @@ def query_flag(ifo, segment_name, start_time, end_time,
                               veto_definer=veto_definer)
 
     elif source == 'dqsegdb':
-        # Let's not hard require dqsegdb to be installed if we never get here.
-        try:
-            from dqsegdb2.query import query_segments as query
-        except ImportError:
-            raise ValueError("Could not query flag. Install dqsegdb2"
-                             ":'pip install dqsegdb2'")
-
         # The veto definer will allow the use of MACRO names
         # These directly correspond to the name in the veto definer file
         if veto_definer is not None:
@@ -190,9 +203,8 @@ def query_flag(ifo, segment_name, start_time, end_time,
         if veto_definer is not None and segment_name in veto_def[ifo]:
             for flag in veto_def[ifo][segment_name]:
                 partial = segmentlist([])
-                segs = query(ifo + ':' + flag['full_name'], int(start_time),
-                             int(end_time), host=server)['active']
-
+                segs = query_dqsegdb2(ifo, flag['full_name'],
+                                      start_time, end_time, server)
                 # Apply padding to each segment
                 for rseg in segs:
                     seg_start = rseg[0] + flag['start_pad']
@@ -210,16 +222,10 @@ def query_flag(ifo, segment_name, start_time, end_time,
                 flag_segments += (partial.coalesce() & send)
 
         else:  # Standard case just query directly
-            try:
-                segs = query(':'.join([ifo, segment_name]),
-                             int(start_time), int(end_time),
-                             host=server)['active']
-                for rseg in segs:
-                    flag_segments.append(segment(rseg[0], rseg[1]))
-            except Exception as e:
-                print("Could not query flag, check name "
-                      "(%s) or times" % segment_name)
-                raise e
+            segs = query_dqsegdb2(ifo, segment_name, start_time, end_time,
+                                  server)
+            for rseg in segs:
+                flag_segments.append(segment(rseg[0], rseg[1]))
 
         # dqsegdb output is not guaranteed to lie entirely within start
         # and end times, hence restrict to this range
@@ -227,7 +233,7 @@ def query_flag(ifo, segment_name, start_time, end_time,
             segmentlist([segment(int(start_time), int(end_time))])
 
     else:
-        raise ValueError("Source must be dqsegdb or GWOSC."
+        raise ValueError("Source must be `dqsegdb`, `GWOSC` or `any`."
                          " Got {}".format(source))
 
     return segmentlist(flag_segments).coalesce()

--- a/pycbc/io/__init__.py
+++ b/pycbc/io/__init__.py
@@ -1,3 +1,4 @@
+import logging
 from astropy.utils.data import download_file
 from .hdf import *
 from .record import *
@@ -10,12 +11,12 @@ def get_file(url, retry=5, **args):
     connections. See astropy for full options
     """
     i = 0
-    while 1:
+    while True:
         i += 1
         try:
             return download_file(url, **args)
         except Exception as e:
-            print("Failed on attempt {} to download {}".format(i, url))
+            logging.warning("Failed on attempt %d to download %s", i, url)
             if i >= retry:
-                print("Giving up on {}".format(url))
+                logging.error("Giving up on %s", url)
                 raise e


### PR DESCRIPTION
The code that queries the segdb was a bit inconsistent in how it printed debug info when the query fails. This makes sure all debug info goes to stderr, and does it consistently regardless of whether a veto definer file is used or not.