### PR TITLE
Adding helper message for 'psd-abort-distance' used by PyCBC Live.

### DIFF
--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -576,7 +576,7 @@ parser.add_argument('--max-batch-size', type=int, default=2**27)
 parser.add_argument('--store-loudest-index', type=int, default=0)
 parser.add_argument('--max-psd-abort-distance', type=float, default=numpy.inf,
                     help="Safety BNS horizon distance (in Mpc) above which a "
-                    "detector's data is discarded.".)
+                    "detector's data is discarded.")
 parser.add_argument('--min-psd-abort-distance', type=float, default=-numpy.inf,
                     help="Safety BNS horizon distance (in Mpc) below which a "
                     "detector's data is discarded.")

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -574,8 +574,12 @@ parser.add_argument('--output-background-n-loudest', type=int, default=10000,
 parser.add_argument('--newsnr-threshold', type=float, default=0)
 parser.add_argument('--max-batch-size', type=int, default=2**27)
 parser.add_argument('--store-loudest-index', type=int, default=0)
-parser.add_argument('--max-psd-abort-distance', type=float, default=numpy.inf)
-parser.add_argument('--min-psd-abort-distance', type=float, default=-numpy.inf)
+parser.add_argument('--max-psd-abort-distance', type=float, default=numpy.inf,
+                    help="Safety BNS horizon distance (in Mpc) above which a "
+                    "detector's data is discarded.".)
+parser.add_argument('--min-psd-abort-distance', type=float, default=-numpy.inf,
+                    help="Safety BNS horizon distance (in Mpc) below which a "
+                    "detector's data is discarded.")
 parser.add_argument('--max-triggers-in-batch', type=int)
 parser.add_argument('--max-length', type=float,
                     help='Maximum duration of templates, used to set the data buffer size')


### PR DESCRIPTION
Improving PyCBC Live arg `max/min-psd-abort-distance` helper message as per @titodalcanton request.

Added explanation for `max/min-psd-abort-distance` as follows:

> Safety BNS horizon distance (in Mpc) above/below which a detector's data is discarded.

