### PR TITLE
Raise error in conversions if unsupported (l,m)

### DIFF
--- a/pycbc/conversions.py
+++ b/pycbc/conversions.py
@@ -831,6 +831,11 @@ def _genqnmfreq(mass, spin, l, m, nmodes, qnmfreq=None):
     lal.COMPLEX16Vector
         LAL vector containing the complex QNM frequencies.
     """
+    # The function used here only supports modes 22, 21, 33, 44 and 55,
+    # but it doesn't raise an error if a different mode is selected.
+    # Raise error here to avoid returning wrong values
+    if (l,m) not in [(2,2), (2,1), (3,3), (4,4), (5,5)]:
+        raise ValueError('Selected (l,m) mode not supported')
     if qnmfreq is None:
         qnmfreq = lal.CreateCOMPLEX16Vector(int(nmodes))
     lalsim.SimIMREOBGenerateQNMFreqV2fromFinal(


### PR DESCRIPTION
In the conversions module, there is a function that calls SimIMREOBGenerateQNMFreqV2fromFinal from lalsuite to get the frequency and damping time for a given (l,m) mode. That function only supports the modes (2,2), (2,1), (3,3), (4,4), (5,5). Currently, if a different mode is selected, the function returns the wrong values instead of raising an error.

This PR adds a check in the pycbc code to ensure that only supported modes are requested, and raise an error otherwise.