### PR TITLE
Add option for segment server when making sky maps

### DIFF
--- a/bin/pycbc_make_skymap
+++ b/bin/pycbc_make_skymap
@@ -73,6 +73,7 @@ def main(trig_time, mass1, mass2, spin1z, spin2z, f_low, f_upper, sample_rate,
          ifar, ifos, thresh_SNR, ligolw_skymap_output='.',
          ligolw_event_output=None, window_bins=300,
          frame_types=None, channel_names=None,
+         segment_server=None,
          gracedb_server=None, test_event=True,
          custom_frame_files=None, approximant=None, detector_state=None,
          veto_definer=None, injection_file=None, fake_strain=None, fake_strain_seed=None):
@@ -126,7 +127,8 @@ def main(trig_time, mass1, mass2, spin1z, spin2z, f_low, f_upper, sample_rate,
             continue
         on_segs = dq.query_str(ifo, detector_state[ifo],
                                gps_start_time, gps_end_time,
-                               veto_definer=veto_definer)
+                               veto_definer=veto_definer,
+                               server=segment_server)
         if abs(on_segs) < required_duration:
             logging.info('Excluding %s due to missing or vetoed data', ifo)
             ifos.remove(ifo)
@@ -447,6 +449,10 @@ if __name__ == '__main__':
     parser.add_argument('--veto-definer', type=str,
                         help='Optional path to a veto definer file to resolve '
                              'macro flags in --detector-state')
+    parser.add_argument('--segment-server', metavar='URL',
+                        help='URL of segment server to query regarding the '
+                             'detector state',
+                        default='https://segments.ligo.org')
     parser.add_argument('--ligolw-skymap-output', type=str, default='.',
                         help='Option to output sky map files to directory')
     parser.add_argument('--ligolw-event-output', type=str,
@@ -487,5 +493,6 @@ if __name__ == '__main__':
          test_event=not opt.enable_production_gracedb_upload,
          custom_frame_files=opt.custom_frame_file,
          approximant=opt.approximant, detector_state=opt.detector_state,
+         segment_server=opt.segment_server,
          veto_definer=opt.veto_definer, injection_file=opt.injection_file, 
          fake_strain=opt.fake_strain, fake_strain_seed=opt.fake_strain_seed)


### PR DESCRIPTION
This came as a request from admins at the Livingston cluster and @titodalcanton to reduce the queries on the standard segments server (https://segments.ligo.org), and instead to use the backup server (https://segments-backup.ligo.org) which has a higher bandwith. This change allows us to choose this server natively.