### PR TITLE
Replace all references of numpy.int with int

### DIFF
--- a/bin/all_sky_search/pycbc_coinc_hdfinjfind
+++ b/bin/all_sky_search/pycbc_coinc_hdfinjfind
@@ -202,7 +202,7 @@ for trigger_file, injection_file in zip(args.trigger_files,
     found_after_vetoes = numpy.array([i for i in found_within_time
                                       if i not in vetoed_all])
     missed_after_vetoes = numpy.array([i for i in missed_within_time
-                                      if i not in vetoed_all]).astype(numpy.int)
+                                      if i not in vetoed_all]).astype(int)
 
     logging.info('Found: %s, Missed: %s' %
                  (len(found_after_vetoes), len(missed_after_vetoes)))

--- a/bin/all_sky_search/pycbc_dtphase
+++ b/bin/all_sky_search/pycbc_dtphase
@@ -186,9 +186,9 @@ for ifo0 in args.ifos:
             dt = (data[ifo0]['t'] - data[ifo1]['t'])
             dp = (data[ifo0]['p'] - data[ifo1]['p']) % (2. * np.pi)
             sr = (data[ifo1]['s'] / data[ifo0]['s'])
-            dtbin = (dt / twidth).astype(np.int)
-            dpbin = (dp / pwidth).astype(np.int)
-            srbin = (sr / swidth).astype(np.int)
+            dtbin = (dt / twidth).astype(int)
+            dpbin = (dp / pwidth).astype(int)
+            srbin = (sr / swidth).astype(int)
 
             # We'll only store a limited range of ratios
             if keep is None:

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -524,9 +524,9 @@ class PhaseTDStatistic(QuadratureSumStatistic):
                 sdif = s / sref * sense / senseref * sigref / sig
 
                 # Put into bins
-                tbin = (tdif / self.twidth).astype(numpy.int)
-                pbin = (pdif / self.pwidth).astype(numpy.int)
-                sbin = (sdif / self.swidth).astype(numpy.int)
+                tbin = (tdif / self.twidth).astype(int)
+                pbin = (pdif / self.pwidth).astype(int)
+                sbin = (sdif / self.swidth).astype(int)
                 binned += [tbin, pbin, sbin]
 
             # Convert binned to same dtype as stored in hist

--- a/pycbc/filter/matchedfilter.py
+++ b/pycbc/filter/matchedfilter.py
@@ -64,8 +64,8 @@ class BatchCorrelator(object):
         self.zs = zs
 
         # Store each pointer as in integer array
-        self.x = Array([v.ptr for v in xs], dtype=numpy.int)
-        self.z = Array([v.ptr for v in zs], dtype=numpy.int)
+        self.x = Array([v.ptr for v in xs], dtype=int)
+        self.z = Array([v.ptr for v in zs], dtype=int)
 
     @pycbc.scheme.schemed(BACKEND_PREFIX)
     def batch_correlate_execute(self, y):

--- a/pycbc/frame/frame.py
+++ b/pycbc/frame/frame.py
@@ -589,7 +589,7 @@ class DataBuffer(object):
             self.dur = int(fname[3])
 
         fstart = int(self.ref + numpy.floor((start - self.ref) / float(self.dur)) * self.dur)
-        starts = numpy.arange(fstart, end, self.dur).astype(numpy.int)
+        starts = numpy.arange(fstart, end, self.dur).astype(int)
 
         keys = []
         for s in starts:

--- a/pycbc/inference/io/dynesty.py
+++ b/pycbc/inference/io/dynesty.py
@@ -123,7 +123,7 @@ class DynestyFile(CommonNestedMetadataIO, BaseNestedSamplerFile):
             weights = numpy.exp(logwt - logz)
             N = len(weights)
             positions = (numpy.random.random() + numpy.arange(N)) / N
-            idx = numpy.zeros(N, dtype=numpy.int)
+            idx = numpy.zeros(N, dtype=int)
             cumulative_sum = numpy.cumsum(weights)
             cumulative_sum /= cumulative_sum[-1]
             i, j = 0, 0

--- a/pycbc/types/array.py
+++ b/pycbc/types/array.py
@@ -47,7 +47,7 @@ from pycbc.opt import LimitedSizeDict
 # we should restrict any functions that do not allow an
 # array of uint32 integers
 _ALLOWED_DTYPES = [_numpy.float32, _numpy.float64, _numpy.complex64,
-                   _numpy.complex128, _numpy.uint32, _numpy.int32, _numpy.int]
+                   _numpy.complex128, _numpy.uint32, _numpy.int32, int]
 try:
     _ALLOWED_SCALARS = [int, long, float, complex] + _ALLOWED_DTYPES
 except NameError:


### PR DESCRIPTION
This PR replaces all instances of `numpy.int` with the builtin `int`.

This resolves a deprecation warning from numpy 1.20, see
<https://numpy.org/devdocs/release/1.20.0-notes.html#using-the-aliases-of-builtin-types-like-np-int-is-deprecated>.