### PR TITLE
Fix incorrect data generation for simulated noise

### DIFF
--- a/bin/hwinj/pycbc_insert_frame_hwinj
+++ b/bin/hwinj/pycbc_insert_frame_hwinj
@@ -67,7 +67,8 @@ initial_array = numpy.loadtxt(opts.hwinj_file)
 initial_array *= opts.scale_factor
 
 # figure out how much to pad
-start_pad = (opts.hwinj_start_time-opts.gps_start_time) * opts.sample_rate
+start_pad = (opts.hwinj_start_time-strain.start_time) * opts.sample_rate
+start_pad = int(start_pad + 0.5)
 
 # add the two time series
 logging.info('Summing the two time series')

--- a/pycbc/strain/strain.py
+++ b/pycbc/strain/strain.py
@@ -233,6 +233,7 @@ def from_cli(opt, dyn_range_fac=1, precision='single',
     elif opt.fake_strain or opt.fake_strain_from_file:
         logging.info("Generating Fake Strain")
         duration = opt.gps_end_time - opt.gps_start_time
+        duration += 2 * opt.pad_data
         pdf = 1.0 / opt.fake_strain_filter_duration
         fake_flow = opt.fake_strain_flow
         fake_rate = opt.fake_strain_sample_rate
@@ -253,7 +254,7 @@ def from_cli(opt, dyn_range_fac=1, precision='single',
             logging.info("Making zero-noise time series")
             strain = TimeSeries(pycbc.types.zeros(duration * fake_rate),
                                 delta_t=1.0 / fake_rate,
-                                epoch=opt.gps_start_time)
+                                epoch=opt.gps_start_time - opt.pad_data)
         else:
             logging.info("Making colored noise")
             from pycbc.noise.reproduceable import colored_noise


### PR DESCRIPTION
@SergeiOssokine reported some strange behaviour in the `hwinj` code where it would inject an injection at the wrong time.

This was diagnosed to be an issue in how pad-data is handled after the recent consolidation of code in the strain module. In particular at the moment if somebody uses any of the simulated data options, and does not explicitly set `pad-data` to 0, they will not get the correct amount of data as the padded data will be removed even though it was never added!

I'm proposing to fix this by correctly adding pad-data into the simulated options. I think this *is* needed as one might still try to high-pass filter this data (even if it isn't really adding anything to do that). 

I'm also a bit confused by having the default pad-data be 8. I guess here the sane default for simulated data and real data disagrees! I might think about changing this to 0, but don't feel too strongly (simulating 16s we don't need and then cutting it isn't *too* bad).

I also fix a line in the `hwinj` code to ensure that even if it doesn't return the length of data requested, the hwinj still goes in the correct place.