### PR TITLE
handle 170608 in a nicer way

### DIFF
--- a/pycbc/dq.py
+++ b/pycbc/dq.py
@@ -174,7 +174,7 @@ def query_flag(ifo, segment_name, start_time, end_time,
 
         duration = end_time - start_time
         try:
-            url = GWOSC_URL.format(get_run(start_time + duration/2),
+            url = GWOSC_URL.format(get_run(start_time + duration/2, ifo),
                                    ifo, segment_name,
                                    int(start_time), int(duration))
 

--- a/pycbc/frame/losc.py
+++ b/pycbc/frame/losc.py
@@ -37,7 +37,7 @@ def get_run(time, ifo=None):
 
     # ifo is only needed in this special case, otherwise, the run name is
     # the same for all ifos
-    if (<= time <=) and ifo == 'H1':
+    if (1180911618 <= time <= 1180982427) and ifo == 'H1':
         return 'BKGW170608_16KHZ_R1'
 
     if 1164556817 <= time <= 1187733618:

--- a/pycbc/frame/losc.py
+++ b/pycbc/frame/losc.py
@@ -37,7 +37,7 @@ def get_run(time, ifo=None):
 
     # ifo is only needed in this special case, otherwise, the run name is
     # the same for all ifos
-    if (1180911618 <= time <= 1180982427) and ifo == 'H1':
+    if (1180911618 <= time <= 1180982427) and (ifo == 'H1'):
         return 'BKGW170608_16KHZ_R1'
 
     if 1164556817 <= time <= 1187733618:

--- a/pycbc/frame/losc.py
+++ b/pycbc/frame/losc.py
@@ -20,7 +20,26 @@ from pycbc.io import get_file
 
 _losc_url = "https://www.gw-openscience.org/archive/links/%s/%s/%s/%s/json/"
 
-def get_run(time):
+def get_run(time, ifo=None):
+    """ Return the run name for a given time
+
+    Parameters
+    ----------
+    time: int
+        The gps time
+    ifo: str
+        The ifo prefix string. Optional and normally unused,
+        except for some special times where data releases
+        were made for a single detector under
+        unusual circumstances. For example, to get the data around GW170608
+        in the Hanford detector.
+    """
+
+    # ifo is only needed in this special case, otherwise, the run name is
+    # the same for all ifos
+    if (<= time <=) and ifo == 'H1':
+        return 'BKGW170608_16KHZ_R1'
+
     if 1164556817 <= time <= 1187733618:
         return 'O2_16KHZ_R1'
     if 1126051217 <= time <= 1137254417:


### PR DESCRIPTION
This pulls in a hack I used for O2, but mainlines it in a nicer way. The idea is to allow for the analysis of the 170608 time in a more uniform way as the other runs. The key factor is that the Hanford data was released as a separate run name by GWOSC so we need to be able to retrieve this name. 