### PR TITLE
Restore interactive plotting

### DIFF
--- a/bin/plotting/pycbc_page_segplot
+++ b/bin/plotting/pycbc_page_segplot
@@ -197,7 +197,7 @@ fig.subplots_adjust(left=0.0, right=0.6, top=0.9, bottom=0.1)
 # add plugins to the plot
 mpld3.plugins.connect(fig, mpld3.plugins.MousePosition(fontsize=14, fmt='10f'))
 mpld3.plugins.connect(fig, mpld3.plugins.BoxZoom())
-mpld3.plugins.connect(fig, MPLSlide())
+mpld3.plugins.connect(fig, mpld3.plugins.Zoom())
 mpld3.plugins.connect(fig, mpld3.plugins.Reset())
 
 # save the plot as an interactive HTML

--- a/bin/plotting/pycbc_plot_gating
+++ b/bin/plotting/pycbc_plot_gating
@@ -96,6 +96,6 @@ else:
 
 mpld3.plugins.connect(fig, mpld3.plugins.MousePosition(fontsize=14, fmt='10.1f'))
 mpld3.plugins.connect(fig, mpld3.plugins.BoxZoom())
-mpld3.plugins.connect(fig, MPLSlide())
+mpld3.plugins.connect(fig, mpld3.plugins.Zoom())
 mpld3.plugins.connect(fig, mpld3.plugins.Reset())
 mpld3.save_html(fig, open(args.output_file, 'w'))


### PR DESCRIPTION
This PR resolves the issue noted in #3698 by removing use of a custom `mpld3` plugin that is no longer functional with the most recent version of `mpld3`. An example output plot is [uploaded here](https://github.com/gwastro/pycbc/files/6417353/H1L1-PAGE_SEGPLOT_SUMMARY-EXAMPLE.zip)

Note that not all of the original functionality is restored with this PR. This plot original supported an interactive feature where the user could hover over a specific segment to display information (such as the start and end times) for that segment and used a custom plugin to only zoom and move on the x-axis. 

