### PR TITLE
Make sure FNULL is closed properly in pycbc.libutils.pkg_config_libdirs

### DIFF
--- a/pycbc/libutils.py
+++ b/pycbc/libutils.py
@@ -93,14 +93,14 @@ def pkg_config_libdirs(packages):
         return []
 
     # if calling pkg-config failes, don't continue and don't try again.
-    try:
-        FNULL = open(os.devnull, 'w')
-        subprocess.check_call(["pkg-config", "--version"], stdout=FNULL, close_fds=True)
-    except:
-        print("PyCBC.libutils: pkg-config call failed, setting NO_PKGCONFIG=1",
-              file=sys.stderr)
-        os.environ['NO_PKGCONFIG'] = "1"
-        return []
+    with open(os.devnull, "w") as FNULL:
+        try:
+            subprocess.check_call(["pkg-config", "--version"], stdout=FNULL)
+        except:
+            print("PyCBC.libutils: pkg-config call failed, setting NO_PKGCONFIG=1",
+                  file=sys.stderr)
+            os.environ['NO_PKGCONFIG'] = "1"
+            return []
 
     # First, check that we can call pkg-config on each package in the list
     for pkg in packages:

--- a/pycbc/libutils.py
+++ b/pycbc/libutils.py
@@ -97,8 +97,11 @@ def pkg_config_libdirs(packages):
         try:
             subprocess.check_call(["pkg-config", "--version"], stdout=FNULL)
         except:
-            print("PyCBC.libutils: pkg-config call failed, setting NO_PKGCONFIG=1",
-                  file=sys.stderr)
+            print(
+                "PyCBC.libutils: pkg-config call failed, "
+                "setting NO_PKGCONFIG=1",
+                file=sys.stderr,
+            )
             os.environ['NO_PKGCONFIG'] = "1"
             return []
 


### PR DESCRIPTION
This PR modifies the way that a `/dev/null` file object is used in `pycbc.libutils.pkg_config_libdirs` to ensure that said file object actually gets closed properly, the current usage doesn't close the file.

Note that this can all be simplified by using `subprocess.DEVNULL` just as soon as python2 support is dropped.