### PR TITLE
Update lalsuite-dev image reference in CI to igwn namespace

### DIFF
--- a/.github/workflows/build_venv.yml
+++ b/.github/workflows/build_venv.yml
@@ -20,7 +20,7 @@ jobs:
         run: "bash -e tools/docker_build_prepssh.sh"
       - 
         env:
-          DOCKER_IMG: ligo/lalsuite-dev:el7
+          DOCKER_IMG: igwn/lalsuite-dev:el7
           PYCBC_CONTAINER: pycbc_rhel_virtualenv
           DOCKER_SECURE_ENV_VARS: true
         name: "Creating the virtual environment"


### PR DESCRIPTION
This PR updates the `lalsuite-dev:el7` docker image reference to use the `igwn` namespace, the `ligo` namespace is dead.