### PR TITLE
Fixes to functions that load arrays, time and frequency series from files

### DIFF
--- a/pycbc/types/array.py
+++ b/pycbc/types/array.py
@@ -1087,41 +1087,48 @@ def empty(length, dtype=float64):
     raise ValueError(err_msg)
 
 def load_array(path, group=None):
-    """
-    Load an Array from a .hdf, .txt or .npy file. The
-    default data types will be double precision floating point.
+    """Load an Array from an HDF5, ASCII or Numpy file. The file type is
+    inferred from the file extension, which must be `.hdf`, `.txt` or `.npy`.
+
+    For ASCII and Numpy files with a single column, a real array is returned.
+    For files with two columns, the columns are assumed to contain the real
+    and imaginary parts of a complex array respectively.
+
+    The default data types will be double precision floating point.
 
     Parameters
     ----------
     path : string
-        source file path. Must end with either .npy or .txt.
+        Input file path. Must end with either `.npy`, `.txt` or `.hdf`.
 
-    group: string 
-        Additional name for internal storage use. Ex. hdf storage uses
-        this as the key value.
+    group: string
+        Additional name for internal storage use. When reading HDF files, this
+        is the path to the HDF dataset to read.
 
     Raises
     ------
     ValueError
-        If path does not end in .npy or .txt.
+        If path does not end with a supported extension. For Numpy and ASCII
+        input files, this is also raised if the array does not have 1 or 2
+        dimensions.
     """
     ext = _os.path.splitext(path)[1]
     if ext == '.npy':
-        data = _numpy.load(path)    
+        data = _numpy.load(path)
     elif ext == '.txt':
         data = _numpy.loadtxt(path)
     elif ext == '.hdf':
         key = 'data' if group is None else group
-        return Array(h5py.File(path)[key]) 
+        with h5py.File(path, 'r') as f:
+            array = Array(f[key])
+        return array
     else:
         raise ValueError('Path must end with .npy, .hdf, or .txt')
-        
+
     if data.ndim == 1:
         return Array(data)
     elif data.ndim == 2:
         return Array(data[:,0] + 1j*data[:,1])
-    else:
-        raise ValueError('File has %s dimensions, cannot convert to Array, \
-                          must be 1 (real) or 2 (complex)' % data.ndim)
-    
 
+    raise ValueError('File has %s dimensions, cannot convert to Array, \
+                      must be 1 (real) or 2 (complex)' % data.ndim)

--- a/pycbc/types/frequencyseries.py
+++ b/pycbc/types/frequencyseries.py
@@ -576,7 +576,8 @@ class FrequencySeries(Array):
 
 def load_frequencyseries(path, group=None):
     """Load a FrequencySeries from an HDF5, ASCII or Numpy file. The file type
-    is inferred from the file extension, which must be `.hdf`, `.txt` or `.npy`.
+    is inferred from the file extension, which must be `.hdf`, `.txt` or
+    `.npy`.
 
     For ASCII and Numpy files, the first column of the array is assumed to
     contain the frequency. If the array has two columns, a real frequency

--- a/pycbc/types/frequencyseries.py
+++ b/pycbc/types/frequencyseries.py
@@ -575,23 +575,36 @@ class FrequencySeries(Array):
             return plot1, plot2
 
 def load_frequencyseries(path, group=None):
-    """
-    Load a FrequencySeries from a .hdf, .txt or .npy file. The
-    default data types will be double precision floating point.
+    """Load a FrequencySeries from an HDF5, ASCII or Numpy file. The file type
+    is inferred from the file extension, which must be `.hdf`, `.txt` or `.npy`.
+
+    For ASCII and Numpy files, the first column of the array is assumed to
+    contain the frequency. If the array has two columns, a real frequency
+    series is returned. If the array has three columns, the second and third
+    ones are assumed to contain the real and imaginary parts of a complex
+    frequency series.
+
+    For HDF files, the dataset is assumed to contain the attributes `delta_f`
+    and `epoch`, which should contain respectively the frequency resolution in
+    Hz and the start GPS time of the data.
+
+    The default data types will be double precision floating point.
 
     Parameters
     ----------
     path: string
-        source file path. Must end with either .npy or .txt.
+        Input file path. Must end with either `.npy`, `.txt` or `.hdf`.
 
     group: string
-        Additional name for internal storage use. Ex. hdf storage uses
-        this as the key value.
+        Additional name for internal storage use. When reading HDF files, this
+        is the path to the HDF dataset to read.
 
     Raises
     ------
     ValueError
-        If path does not end in .npy or .txt.
+        If the path does not end in a supported extension.
+        For Numpy and ASCII input files, this is also raised if the array
+        does not have 2 or 3 dimensions.
     """
     ext = _os.path.splitext(path)[1]
     if ext == '.npy':
@@ -600,24 +613,19 @@ def load_frequencyseries(path, group=None):
         data = _numpy.loadtxt(path)
     elif ext == '.hdf':
         key = 'data' if group is None else group
-        f = h5py.File(path, 'r')
-        data = f[key][:]
-        series = FrequencySeries(data, delta_f=f[key].attrs['delta_f'],
-                                       epoch=f[key].attrs['epoch'])
-        f.close()
+        with h5py.File(path, 'r') as f:
+            data = f[key][:]
+            series = FrequencySeries(data, delta_f=f[key].attrs['delta_f'],
+                                     epoch=f[key].attrs['epoch'])
         return series
     else:
         raise ValueError('Path must end with .npy, .hdf, or .txt')
 
+    delta_f = (data[-1][0] - data[0][0]) / (len(data) - 1)
     if data.ndim == 2:
-        delta_f = (data[-1][0] - data[0][0]) / (len(data)-1)
-        epoch = _lal.LIGOTimeGPS(data[0][0])
-        return FrequencySeries(data[:,1], delta_f=delta_f, epoch=epoch)
+        return FrequencySeries(data[:,1], delta_f=delta_f)
     elif data.ndim == 3:
-        delta_f = (data[-1][0] - data[0][0]) / (len(data)-1)
-        epoch = _lal.LIGOTimeGPS(data[0][0])
-        return FrequencySeries(data[:,1] + 1j*data[:,2], delta_f=delta_f,
-                               epoch=epoch)
-    else:
-        raise ValueError('File has %s dimensions, cannot convert to Array, \
-                          must be 2 (real) or 3 (complex)' % data.ndim)
+        return FrequencySeries(data[:,1] + 1j*data[:,2], delta_f=delta_f)
+
+    raise ValueError('File has %s dimensions, cannot convert to FrequencySeries, \
+                      must be 2 (real) or 3 (complex)' % data.ndim)

--- a/pycbc/types/timeseries.py
+++ b/pycbc/types/timeseries.py
@@ -1040,7 +1040,7 @@ def load_timeseries(path, group=None):
     series.
 
     For HDF files, the dataset is assumed to contain the attributes `delta_t`
-    and `epoch`, which should contain respectively the sampling period in
+    and `start_time`, which should contain respectively the sampling period in
     seconds and the start GPS time of the data.
 
     The default data types will be double precision floating point.

--- a/pycbc/types/timeseries.py
+++ b/pycbc/types/timeseries.py
@@ -1030,23 +1030,36 @@ class TimeSeries(Array):
             return plot1, plot2
 
 def load_timeseries(path, group=None):
-    """
-    Load a TimeSeries from a .hdf, .txt or .npy file. The
-    default data types will be double precision floating point.
+    """Load a TimeSeries from an HDF5, ASCII or Numpy file. The file type is
+    inferred from the file extension, which must be `.hdf`, `.txt` or `.npy`.
+
+    For ASCII and Numpy files, the first column of the array is assumed to
+    contain the sample times. If the array has two columns, a real-valued time
+    series is returned. If the array has three columns, the second and third
+    ones are assumed to contain the real and imaginary parts of a complex time
+    series.
+
+    For HDF files, the dataset is assumed to contain the attributes `delta_t`
+    and `epoch`, which should contain respectively the sampling period in
+    seconds and the start GPS time of the data.
+
+    The default data types will be double precision floating point.
 
     Parameters
     ----------
     path: string
-        source file path. Must end with either .npy or .txt.
+        Input file path. Must end with either `.npy`, `.txt` or `.hdf`.
 
     group: string
-        Additional name for internal storage use. Ex. hdf storage uses
-        this as the key value.
+        Additional name for internal storage use. When reading HDF files, this
+        is the path to the HDF dataset to read.
 
     Raises
     ------
     ValueError
-        If path does not end in .npy or .txt.
+        If path does not end in a supported extension.
+        For Numpy and ASCII input files, this is also raised if the array
+        does not have 2 or 3 dimensions.
     """
     ext = _os.path.splitext(path)[1]
     if ext == '.npy':
@@ -1055,24 +1068,21 @@ def load_timeseries(path, group=None):
         data = _numpy.loadtxt(path)
     elif ext == '.hdf':
         key = 'data' if group is None else group
-        f = h5py.File(path)
-        data = f[key][:]
-        series = TimeSeries(data, delta_t=f[key].attrs['delta_t'],
-                                  epoch=f[key].attrs['start_time'])
-        f.close()
+        with h5py.File(path, 'r') as f:
+            data = f[key][:]
+            series = TimeSeries(data, delta_t=f[key].attrs['delta_t'],
+                                epoch=f[key].attrs['start_time'])
         return series
     else:
         raise ValueError('Path must end with .npy, .hdf, or .txt')
 
+    delta_t = (data[-1][0] - data[0][0]) / (len(data) - 1)
+    epoch = _lal.LIGOTimeGPS(data[0][0])
     if data.ndim == 2:
-        delta_t = (data[-1][0] - data[0][0]) / (len(data)-1)
-        epoch = _lal.LIGOTimeGPS(data[0][0])
         return TimeSeries(data[:,1], delta_t=delta_t, epoch=epoch)
     elif data.ndim == 3:
-        delta_t = (data[-1][0] - data[0][0]) / (len(data)-1)
-        epoch = _lal.LIGOTimeGPS(data[0][0])
         return TimeSeries(data[:,1] + 1j*data[:,2],
                           delta_t=delta_t, epoch=epoch)
-    else:
-        raise ValueError('File has %s dimensions, cannot convert to Array, \
-                          must be 2 (real) or 3 (complex)' % data.ndim)
+
+    raise ValueError('File has %s dimensions, cannot convert to TimeSeries, \
+                      must be 2 (real) or 3 (complex)' % data.ndim)


### PR DESCRIPTION
The docstrings for these functions were a bit incomplete and slightly incorrect, so this PR updates them.

While doing that, I spotted a couple minor bugs which this PR also fixes:
* When reading a `FrequencySeries` from Numpy or ASCII files, its epoch was somehow set to the frequency of the first bin. This looks like an 8 year old (!!!) leftover copy-and-paste from `load_timeseries()`. Now the epoch is set to `None` instead.
* HDF files were not being open read-only in `load_array()` and `load_timeseries()`.

Finally, this PR allows one to read a `FrequencySeries` from an HDF dataset that does not have the `epoch` attribute, in which case the epoch is set to `None`.