### PR TITLE
Updates to plot posterior

### DIFF
--- a/bin/inference/pycbc_inference_plot_posterior
+++ b/bin/inference/pycbc_inference_plot_posterior
@@ -293,6 +293,7 @@ for (i, s) in enumerate(samples):
                     plot_marginal_lines=not opts.no_marginal_lines,
                     plot_maxl=opts.plot_maxl,
                     marginal_percentiles=opts.marginal_percentiles,
+                    marginal_title=not opts.no_marginal_titles,
                     plot_scatter=opts.plot_scatter,
                     zvals=zvals[i] if zvals is not None else None,
                     show_colorbar=opts.z_arg is not None,

--- a/bin/inference/pycbc_inference_plot_posterior
+++ b/bin/inference/pycbc_inference_plot_posterior
@@ -70,6 +70,9 @@ option_utils.add_plot_posterior_option_group(parser)
 option_utils.add_scatter_option_group(parser)
 # density configuration
 option_utils.add_density_option_group(parser)
+parser.add_argument("--plot-maxl", action="store_true", default=False,
+                    help="Put a marker on the 2D marginal where the maxL "
+                         "point is.")
 parser.add_argument('--dpi', type=int, default=200,
                     help="Set the DPI of the plot. Default is 200.")
 # style option
@@ -81,11 +84,38 @@ opts = parser.parse_args()
 # set mpl style
 set_style_from_cli(opts)
 
+# get any kdeargs
+if opts.kde_args is not None:
+    kdeargs = {}
+    for opt in opts.kde_args:
+        opt, val = opt.split(':')
+        try:
+            val = float(val)
+            # convert to int if no remainder
+            if val % 1 == 0:
+                val = int(val)
+        except TypeError:
+            pass
+        kdeargs[opt] = val
+else:
+    kdeargs = None
+
+if opts.plot_maxl:
+    # add loglikelihood to list of parameters
+    add_logl = 'loglikelihood' not in opts.parameters
+    if add_logl:
+        opts.parameters.append('loglikelihood')
+else:
+    add_logl = False
+
 # set logging
 pycbc.init_logging(opts.verbose)
 
 # load the samples
 fps, parameters, labels, samples = io.results_from_cli(opts)
+
+if add_logl:
+    parameters = [p for p in parameters if p != 'loglikelihood']
 
 # typecast to list so the input files can be iterated over
 fps = fps if isinstance(fps, list) else [fps]
@@ -257,6 +287,8 @@ for (i, s) in enumerate(samples):
     fig, axis_dict = create_multidim_plot(
                     parameters, s, labels=labels, fig=fig, axis_dict=axis_dict,
                     plot_marginal=opts.plot_marginal,
+                    plot_marginal_lines=not opts.no_marginal_lines,
+                    plot_maxl=opts.plot_maxl,
                     marginal_percentiles=opts.marginal_percentiles,
                     plot_scatter=opts.plot_scatter,
                     zvals=zvals[i] if zvals is not None else None,
@@ -269,10 +301,13 @@ for (i, s) in enumerate(samples):
                     contour_percentiles=opts.contour_percentiles,
                     density_cmap=opts.density_cmap,
                     contour_color=contour_color,
+                    contour_linestyles=opts.contour_linestyles,
+                    label_contours=not opts.no_contour_labels,
                     hist_color=hist_color,
                     line_color=linecolor,
                     fill_color=fill_color,
                     use_kombine=opts.use_kombine_kde,
+                    kdeargs=kdeargs,
                     mins=mins, maxs=maxs,
                     expected_parameters=expected_parameters,
                     expected_parameters_color=opts.expected_parameters_color)
@@ -298,8 +333,14 @@ if len(opts.input_file) > 1:
         label = opts.input_file_labels[fn]
         handles.append(patches.Patch(color=color, label=label))
         labels.append(label)
-    fig.legend(loc="upper right", handles=handles,
-               labels=labels)
+    if len(parameters) == 2:
+        addto = axis_dict[parameters[0], parameters[1]][0]
+    elif len(parameters) == 1:
+        addto = axis_dict[parameters[0], parameters[0]][0]
+    else:
+        addto = fig
+    addto.legend(loc="upper right", handles=handles,
+                 labels=labels)
 
 # set DPI
 fig.set_dpi(opts.dpi)

--- a/bin/inference/pycbc_inference_plot_posterior
+++ b/bin/inference/pycbc_inference_plot_posterior
@@ -73,6 +73,9 @@ option_utils.add_density_option_group(parser)
 parser.add_argument("--plot-maxl", action="store_true", default=False,
                     help="Put a marker on the 2D marginal where the maxL "
                          "point is.")
+parser.add_argument('--legend-location', default='upper right',
+                    help='Where to put the legend (if multiple files are '
+                         'provided). Default is "upper right".')
 parser.add_argument('--dpi', type=int, default=200,
                     help="Set the DPI of the plot. Default is 200.")
 # style option
@@ -339,7 +342,7 @@ if len(opts.input_file) > 1:
         addto = axis_dict[parameters[0], parameters[0]][0]
     else:
         addto = fig
-    addto.legend(loc="upper right", handles=handles,
+    addto.legend(loc=opts.legend_location, handles=handles,
                  labels=labels)
 
 # set DPI

--- a/pycbc/inference/option_utils.py
+++ b/pycbc/inference/option_utils.py
@@ -173,6 +173,10 @@ def add_plot_posterior_option_group(parser):
                         default=False,
                         help="Do not add vertical lines in the 1D marginal "
                              "plots showing the marginal percentiles.")
+    pgroup.add_argument('--no-marginal-titles', action='store_true',
+                        default=False,
+                        help="Do not add titles giving the 1D credible range "
+                             "over the 1D marginal plots.")
     pgroup.add_argument("--plot-scatter", action='store_true', default=False,
                         help="Plot each sample point as a scatter plot.")
     pgroup.add_argument("--plot-density", action="store_true", default=False,

--- a/pycbc/inference/option_utils.py
+++ b/pycbc/inference/option_utils.py
@@ -170,7 +170,7 @@ def add_plot_posterior_option_group(parser):
                         help="Percentiles to draw lines at on the 1D "
                              "histograms.")
     pgroup.add_argument('--no-marginal-lines', action='store_true',
-                        default=True,
+                        default=False,
                         help="Do not add vertical lines in the 1D marginal "
                              "plots showing the marginal percentiles.")
     pgroup.add_argument("--plot-scatter", action='store_true', default=False,

--- a/pycbc/inference/option_utils.py
+++ b/pycbc/inference/option_utils.py
@@ -169,6 +169,10 @@ def add_plot_posterior_option_group(parser):
                         type=float,
                         help="Percentiles to draw lines at on the 1D "
                              "histograms.")
+    pgroup.add_argument('--no-marginal-lines', action='store_true',
+                        default=True,
+                        help="Do not add vertical lines in the 1D marginal "
+                             "plots showing the marginal percentiles.")
     pgroup.add_argument("--plot-scatter", action='store_true', default=False,
                         help="Plot each sample point as a scatter plot.")
     pgroup.add_argument("--plot-density", action="store_true", default=False,
@@ -331,10 +335,24 @@ def add_density_option_group(parser):
         help="Specify the color to use for the contour lines. Default is "
              "white for density plots and black for scatter plots.")
     density_group.add_argument(
+        "--contour-linestyles", type=str, default=None, nargs="+",
+        help="Specify the linestyles to use for the contour lines. Defaut "
+             "is solid for all.")
+    density_group.add_argument(
+        "--no-contour-labels", action="store_true", default=False,
+        help="Don't put labels on the contours.")
+    density_group.add_argument(
         '--use-kombine-kde', default=False, action="store_true",
-        help="Use kombine's KDE for determining contours. "
-             "Default is to use scipy's gaussian_kde.")
-
+        help="Use kombine's clustered KDE for determining 2D marginal "
+             "contours and density instead of scipy's gaussian_kde (the "
+             "default). This is better at distinguishing bimodal "
+             "distributions, but is much slower than the default. For speed, "
+             "suggest setting --kde-args 'max_samples:20000' or smaller if "
+             "using this. Requires kombine to be installed.")
+    density_group.add_argument(
+        '--kde-args', metavar="ARG:VALUE", nargs='+', default=None,
+        help="Pass the given argrument, value pairs to the KDE function "
+             "(either scipy's or kombine's) when setting it up.")
     return density_group
 
 

--- a/pycbc/results/scatter_histograms.py
+++ b/pycbc/results/scatter_histograms.py
@@ -676,7 +676,6 @@ def create_multidim_plot(parameters, samples, labels=None,
             continue
     samples = sd
     parameters = list(sd.keys())
-    #samples = dict([[p, samples[p]] for p in parameters])
 
     # values for axis bounds
     if mins is None:

--- a/pycbc/results/scatter_histograms.py
+++ b/pycbc/results/scatter_histograms.py
@@ -658,9 +658,25 @@ def create_multidim_plot(parameters, samples, labels=None,
             if plot_contours and contour_color is None:
                 contour_color = 'navy'
 
+    # create the axis grid
+    if fig is None and axis_dict is None:
+        fig, axis_dict = create_axes_grid(
+            parameters, labels=labels,
+            width_ratios=width_ratios, height_ratios=height_ratios,
+            no_diagonals=not plot_marginal)
+
     # convert samples to a dictionary to avoid re-computing derived parameters
     # every time they are needed
-    samples = dict([[p, samples[p]] for p in parameters])
+    # only try to plot what's available
+    sd = {}
+    for p in parameters:
+        try:
+            sd[p] = samples[p]
+        except (ValueError, TypeError, IndexError):
+            continue
+    samples = sd
+    parameters = list(sd.keys())
+    #samples = dict([[p, samples[p]] for p in parameters])
 
     # values for axis bounds
     if mins is None:
@@ -673,13 +689,6 @@ def create_multidim_plot(parameters, samples, labels=None,
     else:
         # copy the dict
         maxs = {p: val for p, val in maxs.items()}
-
-    # create the axis grid
-    if fig is None and axis_dict is None:
-        fig, axis_dict = create_axes_grid(
-            parameters, labels=labels,
-            width_ratios=width_ratios, height_ratios=height_ratios,
-            no_diagonals=not plot_marginal)
 
     # Diagonals...
     if plot_marginal:
@@ -708,7 +717,7 @@ def create_multidim_plot(parameters, samples, labels=None,
 
     # Off-diagonals...
     for px, py in axis_dict:
-        if px == py:
+        if px == py or px not in parameters or py not in parameters:
             continue
         ax, _, _ = axis_dict[px, py]
         if plot_scatter:

--- a/pycbc/results/scatter_histograms.py
+++ b/pycbc/results/scatter_histograms.py
@@ -143,27 +143,35 @@ def get_scale_fac(fig, fiducial_width=8, fiducial_height=7):
     return (width*height/(fiducial_width*fiducial_height))**0.5
 
 
-def construct_kde(samples_array, use_kombine=False):
+def construct_kde(samples_array, use_kombine=False, kdeargs=None):
     """Constructs a KDE from the given samples.
     """
+    # make sure samples are randomly sorted
+    numpy.random.seed(0)
+    numpy.random.shuffle(samples_array)
     if use_kombine:
         try:
             import kombine
         except ImportError:
             raise ImportError("kombine is not installed.")
+    if kdeargs is None:
+        kdeargs = {}
     # construct the kde
     if use_kombine:
-        kde = kombine.clustered_kde.KDE(samples_array)
+        kde = kombine.clustered_kde.optimized_kde(samples_array, **kdeargs)
     else:
-        kde = scipy.stats.gaussian_kde(samples_array.T)
+        kde = scipy.stats.gaussian_kde(samples_array.T, **kdeargs)
     return kde
 
 
 def create_density_plot(xparam, yparam, samples, plot_density=True,
                         plot_contours=True, percentiles=None, cmap='viridis',
-                        contour_color=None, xmin=None, xmax=None,
+                        contour_color=None, label_contours=True,
+                        contour_linestyles=None,
+                        xmin=None, xmax=None,
                         ymin=None, ymax=None, exclude_region=None,
-                        fig=None, ax=None, use_kombine=False):
+                        fig=None, ax=None, use_kombine=False,
+                        kdeargs=None):
     """Computes and plots posterior density and confidence intervals using the
     given samples.
 
@@ -187,6 +195,10 @@ def create_density_plot(xparam, yparam, samples, plot_density=True,
     contour_color : {None, string}
         What color to make the contours. Default is white for density
         plots and black for other plots.
+    label_contours : bool, optional
+        Whether to label the contours. Default is True.
+    contour_linestyles : list, optional
+        Linestyles to use for the contours. Default (None) will use solid.
     xmin : {None, float}
         Minimum value to plot on x-axis.
     xmax : {None, float}
@@ -211,6 +223,8 @@ def create_density_plot(xparam, yparam, samples, plot_density=True,
     use_kombine : {False, bool}
         Use kombine's KDE to calculate density. Otherwise, will use
         `scipy.stats.gaussian_kde.` Default is False.
+    kdeargs : dict, optional
+        Pass the given keyword arguments to the KDE.
 
     Returns
     -------
@@ -233,7 +247,7 @@ def create_density_plot(xparam, yparam, samples, plot_density=True,
     xsamples = samples[xparam]
     ysamples = samples[yparam]
     arr = numpy.vstack((xsamples, ysamples)).T
-    kde = construct_kde(arr, use_kombine=use_kombine)
+    kde = construct_kde(arr, use_kombine=use_kombine, kdeargs=kdeargs)
 
     # construct grid to evaluate on
     if xmin is None:
@@ -282,19 +296,20 @@ def create_density_plot(xparam, yparam, samples, plot_density=True,
         else:
             lw = 2
         ct = ax.contour(X, Y, Z, s, colors=contour_color, linewidths=lw,
-                        zorder=3)
+                        linestyles=contour_linestyles, zorder=3)
         # label contours
-        lbls = ['{p}%'.format(p=int(p)) for p in (100. - percentiles)]
-        fmt = dict(zip(ct.levels, lbls))
-        fs = 12
-        ax.clabel(ct, ct.levels, inline=True, fmt=fmt, fontsize=fs)
+        if label_contours:
+            lbls = ['{p}%'.format(p=int(p)) for p in (100. - percentiles)]
+            fmt = dict(zip(ct.levels, lbls))
+            fs = 12
+            ax.clabel(ct, ct.levels, inline=True, fmt=fmt, fontsize=fs)
 
     return fig, ax
 
 
 def create_marginalized_hist(ax, values, label, percentiles=None,
                              color='k', fillcolor='gray', linecolor='navy',
-                             linestyle='-',
+                             linestyle='-', plot_marginal_lines=True,
                              title=True, expected_value=None,
                              expected_color='red', rotated=False,
                              plot_min=None, plot_max=None):
@@ -318,6 +333,8 @@ def create_marginalized_hist(ax, values, label, percentiles=None,
     fillcolor : {'gray', string, or None}
         What color to fill the histogram with. Set to None to not fill the
         histogram. Default is 'gray'.
+    plot_marginal_lines : bool, optional
+        Put vertical lines at the marginal percentiles. Default is True.
     linestyle : str, optional
         What line style to use for the histogram. Default is '-'.
     linecolor : {'navy', string}
@@ -356,11 +373,12 @@ def create_marginalized_hist(ax, values, label, percentiles=None,
         plotp = numpy.percentile(values, percentiles)
     else:
         plotp = []
-    for val in plotp:
-        if rotated:
-            ax.axhline(y=val, ls='dashed', color=linecolor, lw=2, zorder=3)
-        else:
-            ax.axvline(x=val, ls='dashed', color=linecolor, lw=2, zorder=3)
+    if plot_marginal_lines:
+        for val in plotp:
+            if rotated:
+                ax.axhline(y=val, ls='dashed', color=linecolor, lw=2, zorder=3)
+            else:
+                ax.axvline(x=val, ls='dashed', color=linecolor, lw=2, zorder=3)
     # plot expected
     if expected_value is not None:
         if rotated:
@@ -496,15 +514,20 @@ def create_multidim_plot(parameters, samples, labels=None,
                          mins=None, maxs=None, expected_parameters=None,
                          expected_parameters_color='r',
                          plot_marginal=True, plot_scatter=True,
+                         plot_maxl=False,
+                         plot_marginal_lines=True,
                          marginal_percentiles=None, contour_percentiles=None,
                          marginal_title=True, marginal_linestyle='-',
                          zvals=None, show_colorbar=True, cbar_label=None,
                          vmin=None, vmax=None, scatter_cmap='plasma',
                          plot_density=False, plot_contours=True,
                          density_cmap='viridis',
-                         contour_color=None, hist_color='black',
+                         contour_color=None, label_contours=True,
+                         contour_linestyles=None,
+                         hist_color='black',
                          line_color=None, fill_color='gray',
-                         use_kombine=False, fig=None, axis_dict=None):
+                         use_kombine=False, kdeargs=None,
+                         fig=None, axis_dict=None):
     """Generate a figure with several plots and histograms.
 
     Parameters
@@ -576,9 +599,19 @@ def create_multidim_plot(parameters, samples, labels=None,
         The color to use for the contour lines. Defaults to white for
         density plots, navy for scatter plots without zvals, and black
         otherwise.
+    label_contours : bool, optional
+        Whether to label the contours. Default is True.
+    contour_linestyles : list, optional
+        Linestyles to use for the contours. Default (None) will use solid.
     use_kombine : {False, bool}
         Use kombine's KDE to calculate density. Otherwise, will use
         `scipy.stats.gaussian_kde.` Default is False.
+    kdeargs : dict, optional
+        Pass the given keyword arguments to the KDE.
+    fig : pyplot.figure
+        Use the given figure instead of creating one.
+    axis_dict : dict
+        Use the given dictionary of axes instead of creating one.
 
     Returns
     -------
@@ -599,6 +632,12 @@ def create_multidim_plot(parameters, samples, labels=None,
         height_ratios = [1, 3]
     else:
         width_ratios = height_ratios = None
+
+    if plot_maxl:
+        # make sure loglikelihood is provide
+        if 'loglikelihood' not in samples.fieldnames:
+            raise ValueError("plot-maxl requires loglikelihood")
+        maxidx = samples['loglikelihood'].argmax()
 
     # only plot scatter if more than one parameter
     plot_scatter = plot_scatter and nparams > 1
@@ -660,6 +699,7 @@ def create_multidim_plot(parameters, samples, labels=None,
             create_marginalized_hist(
                 ax, samples[param], label=labels[param],
                 color=hist_color, fillcolor=fill_color,
+                plot_marginal_lines=plot_marginal_lines,
                 linestyle=marginal_linestyle, linecolor=line_color,
                 title=marginal_title, expected_value=expected_value,
                 expected_color=expected_parameters_color,
@@ -692,10 +732,18 @@ def create_multidim_plot(parameters, samples, labels=None,
                 px, py, samples, plot_density=plot_density,
                 plot_contours=plot_contours, cmap=density_cmap,
                 percentiles=contour_percentiles,
-                contour_color=contour_color, xmin=mins[px], xmax=maxs[px],
+                contour_color=contour_color, label_contours=label_contours,
+                contour_linestyles=contour_linestyles,
+                xmin=mins[px], xmax=maxs[px],
                 ymin=mins[py], ymax=maxs[py],
                 exclude_region=exclude_region, ax=ax,
-                use_kombine=use_kombine)
+                use_kombine=use_kombine, kdeargs=kdeargs)
+
+        if plot_maxl:
+            maxlx = samples[px][maxidx]
+            maxly = samples[py][maxidx]
+            ax.scatter(maxlx, maxly, marker='x', s=20, c=contour_color,
+                       zorder=5)
 
         if expected_parameters is not None:
             try:


### PR DESCRIPTION
Some updates for plot posterior that I've been meaning to commit to master for awhile. Does the following:
 * Adds the ability to plot the maximum likelihood point with argument `--plot-maxl`. If turned on, an `x` is added to the 2D marginals showing where the maxL point is.
 * If `--use-kombine-kde` is turned on, will now call kombine's `optimized_kde` method. That uses Bayesian inference criteria to determine if there are multiple modes. It's slow, but can be useful for distributions that have more than one mode.
 * Adds a `--kde-args` to the command line. These are passed through to the KDE. Needed for to limit the number of points given to kombine's KDE (more than a few thousand and it will crawl to a halt), but also can be used to modify what scipy's KDE uses for bandwidths.
 * Adds the ability to turn off contour labels (`--no-contour-labels`), change the contour linestyles (`--contour-linestyles`) and turn off percentile lines in the marginal percentile plots (`--no-marginal-lines`) via the command line.
 * If 1 or 2 parameters are being plotted from multiple input files, the legend will be put in the 1D/2D axis, instead of the upper left of the figure.