### PR TITLE
Use single stat class everywhere

### DIFF
--- a/bin/all_sky_search/pycbc_fit_sngls_binned
+++ b/bin/all_sky_search/pycbc_fit_sngls_binned
@@ -26,17 +26,8 @@ import copy, numpy as np
 from pycbc import events, bin_utils, results
 from pycbc.events import triggers
 from pycbc.events import trigger_fits as trstats
-from pycbc.events import ranking
+from pycbc.events import stat as pystat
 import pycbc.version
-
-#### DEFINITIONS AND FUNCTIONS ####
-
-def get_stat(statchoice, trigs):
-    # For now this is using the single detector ranking. If we want, this
-    # could use the Stat classes in stat.py using similar code as in hdf/io.py
-    # This requires additional options, so only change this if it's useful!
-    return ranking.get_sngls_ranking_from_trigs(trigs, statchoice)
-
 
 #### MAIN ####
 
@@ -63,13 +54,6 @@ parser.add_argument("--ifo", required=True,
 parser.add_argument("--fit-function",
                     choices=["exponential", "rayleigh", "power"],
                     help="Functional form for the maximum likelihood fit")
-parser.add_argument("--sngl-stat", default="new_snr",
-                    choices=ranking.sngls_ranking_function_dict.keys(),
-                    help="Function of SNR and chisq to perform fits with")
-parser.add_argument("--stat-factor", type=float,
-                    help="Adjustable magic number used in some sngl "
-                    "statistics. Values commonly used: 6 for new_snr, 250 "
-                    "or 50 for effective_snr")
 parser.add_argument("--stat-threshold", nargs="+", type=float,
                     help="Only fit triggers with statistic value above this "
                     "threshold : can be a space-separated list, then a fit "
@@ -126,6 +110,8 @@ parser.add_argument("--user-tag", default="",
                     help="Put a possibly informative string in the names of "
                     "plot files")
 
+pystat.insert_statistic_option_group(parser,
+    default_ranking_statistic='single_ranking_only')
 args = parser.parse_args()
 
 args.veto_segment_name = sum(args.veto_segment_name, [])
@@ -149,8 +135,8 @@ else:
     log_level = logging.WARN
 logging.basicConfig(format='%(asctime)s : %(message)s', level=log_level)
 
-statname = "reweighted SNR" if args.sngl_stat == "new_snr" else \
-           args.sngl_stat.replace("_", " ").replace("snr", "SNR")
+statname = "reweighted SNR" if args.sngl_ranking == "new_snr" else \
+           args.sngl_ranking.replace("_", " ").replace("snr", "SNR")
 paramname = args.bin_param.replace("_", " ")
 paramtag = args.bin_param.replace("_", "")
 if args.plot_dir:
@@ -171,7 +157,8 @@ logging.info('Opening template file: %s' % args.bank_file)
 templatef = h5py.File(args.bank_file, 'r')
 
 # get the stat values
-stat = get_stat(args.sngl_stat, trigf[args.ifo])
+rank_method = pystat.get_statistic_from_opts(args, [args.ifo])
+stat = rank_method.get_sngl_ranking(trigf[args.ifo])
 
 # get the duration values if needed
 if args.bin_param == 'template_duration' and not args.f_lower:

--- a/bin/all_sky_search/pycbc_fit_sngls_by_template
+++ b/bin/all_sky_search/pycbc_fit_sngls_by_template
@@ -21,7 +21,7 @@ import copy, numpy as np
 
 from pycbc import io, events
 from pycbc.events import triggers, trigger_fits as trstats
-from pycbc.events import ranking
+from pycbc.events import stat as statsmod
 from pycbc.types.optparse import MultiDetOptionAction
 import pycbc.version
 
@@ -42,7 +42,10 @@ def get_stat(statname, trigs, threshold):
         # read and format chunk of data so it can be read by key
         # as the stat classes expect.
         chunk = {k: trigs[k][s:e] for k in trigs if len(trigs[k]) == size}
-        chunk_stat = ranking.get_sngls_ranking_from_trigs(chunk, statname)
+        
+        rank_method = statsmod.get_statistic_from_opts(args, [args.ifo])
+        chunk_stat = rank_method.get_sngl_ranking(chunk)
+
         above = chunk_stat >= threshold
         stat.append(chunk_stat[above])
         select.append(above)
@@ -88,9 +91,6 @@ parser.add_argument("--ifo", required=True,
 parser.add_argument("--fit-function",
                     choices=["exponential", "rayleigh", "power"],
                     help="Functional form for the maximum likelihood fit")
-parser.add_argument("--sngl-stat", default="new_snr",
-                    choices=ranking.sngls_ranking_function_dict.keys(),
-                    help="Function of SNR and chisq to perform fits with")
 parser.add_argument("--stat-threshold", type=float,
                     help="Only fit triggers with statistic value above this "
                     "threshold.  Required.  Typically 6-6.5")
@@ -121,6 +121,8 @@ parser.add_argument("--min-duration", default=0.,
 parser.add_argument("--approximant", default="SEOBNRv4",
                     help="Approximant for template duration. Default SEOBNRv4")
 
+statsmod.insert_statistic_option_group(parser,
+    default_ranking_statistic='single_ranking_only')
 args = parser.parse_args()
 
 args.veto_segment_name = sum(args.veto_segment_name, [])
@@ -169,8 +171,8 @@ count_in_template = count_in_template_hashorder[tid_sort]
 
 # get the stat values
 logging.info('Calculating stat values')
-abovethresh, stat = get_stat(args.sngl_stat, trigf[args.ifo],
-                                 args.stat_threshold)
+abovethresh, stat = get_stat(args, trigf[args.ifo], args.stat_threshold)
+
 tid = trigf[args.ifo + '/template_id'][abovethresh]
 time = trigf[args.ifo + '/end_time'][abovethresh]
 if args.save_trig_param:
@@ -366,7 +368,7 @@ outfile.create_dataset("median_sigma", data=median_sigma)
 # add some metadata
 outfile.attrs.create("ifo", data=args.ifo.encode())
 outfile.attrs.create("fit_function", data=args.fit_function.encode())
-outfile.attrs.create("sngl_stat", data=args.sngl_stat.encode())
+outfile.attrs.create("sngl_stat", data=args.sngl_ranking)
 if args.save_trig_param:
     outfile.attrs.create("save_trig_param", data=args.save_trig_param.encode())
 outfile.attrs.create("stat_threshold", data=args.stat_threshold)

--- a/bin/all_sky_search/pycbc_fit_sngls_split_binned
+++ b/bin/all_sky_search/pycbc_fit_sngls_split_binned
@@ -25,16 +25,9 @@ import numpy as np
 from pycbc import events, bin_utils, results
 from pycbc.events import triggers as trigs
 from pycbc.events import trigger_fits as trstats
-from pycbc.events import ranking
+from pycbc.events import stat as pystat
 from pycbc.types.optparse import MultiDetOptionAction
 import pycbc.version
-
-def get_stat(statchoice, trigs):
-    # For now this is using the single detector ranking. If we want, this
-    # could use the Stat classes in stat.py using similar code as in hdf/io.py
-    # This requires additional options, so only change this if it's useful!
-    return ranking.get_sngls_ranking_from_trigs(trigs, statchoice)
-
 
 parser = argparse.ArgumentParser(usage="",
     description="Plot histograms of triggers split over various parameters")
@@ -72,9 +65,6 @@ parser.add_argument('--split-one-spacing', choices=['linear', 'log'], default='l
 parser.add_argument('--split-two-spacing', choices=['linear', 'log'], default='linear',
                     help="How to space split-param-two bin edges. "
                          "Choices=[linear, log], default=linear")
-parser.add_argument("--sngl-stat", default="new_snr",
-                    choices=ranking.sngls_ranking_function_dict.keys(),
-                    help="Function of SNR and chisq to perform fits with")
 parser.add_argument('--ifo', help="Detector. Required")
 parser.add_argument('--plot-max-x', type=float, default=None,
                     help="Maximum stat value to plot, if not given "
@@ -102,6 +92,9 @@ parser.add_argument("--prune-number", type=int, default=0,
 parser.add_argument("--prune-window", type=float, default=0.1,
                     help="Time (s) to remove all triggers around a trigger "
                          "which is loudest in each split, default 0.1s")
+
+pystat.insert_statistic_option_group(parser,
+    default_ranking_statistic='single_ranking_only')
 args = parser.parse_args()
 
 pycbc.init_logging(args.verbose)
@@ -219,7 +212,8 @@ for idx, idx_start in enumerate(boundaries):
             np.argmax(sorted_boundary_list == idx_start) + 1]
 
 logging.info('calculating single stat values from trigger file')
-stat = get_stat(args.sngl_stat, trigf[args.ifo])
+rank_method = pystat.get_statistic_from_opts(args, [args.ifo])
+stat = rank_method.get_sngl_ranking(trigf[args.ifo])
 
 if args.veto_file:
     logging.info('applying DQ vetoes')

--- a/bin/minifollowups/pycbc_injection_minifollowup
+++ b/bin/minifollowups/pycbc_injection_minifollowup
@@ -131,6 +131,7 @@ try:
         dec_snr[dec_snr > args.maximum_decisive_snr] = 0
     sorting = dec_snr.argsort()
     sorting = sorting[::-1]  # descending order of dec opt SNR
+    print('SNR', sorting)
 except KeyError:
     # Fall back to effective distance if optimal SNR not available
     eff_dist = {}
@@ -151,6 +152,8 @@ except KeyError:
                                               f['injections/mass2'][:][missed])
     dec_chirp_dist = pycbc.pnutils.chirp_distance(dec_dist, mchirp)
     sorting = dec_chirp_dist.argsort()  # ascending order of dec chirp distance
+    print('dec', sorting)
+    print(dec_dist)
 
 if len(missed) < num_events:
     num_events = len(missed)
@@ -160,6 +163,7 @@ found_inj_idxes = f['found_after_vetoes/injection_index'][:]
 for num_event in range(num_events):
     files = wf.FileList([])
 
+    print(sorting, num_event)
     injection_index = missed[sorting][num_event]
     time = f['injections/tc'][injection_index]
     lon = f['injections/ra'][injection_index]

--- a/bin/minifollowups/pycbc_page_snglinfo
+++ b/bin/minifollowups/pycbc_page_snglinfo
@@ -130,8 +130,8 @@ elif args.sngl_ranking == "newsnr_sgveto_psdvar":
 elif args.sngl_ranking == "snr":
     sngl_stat_name = "SNR"
 else:
-    sngl_stat_name = ranking_statistic
- 
+    sngl_stat_name = args.sngl_ranking
+
 if args.ranking_statistic in ["quadsum", "single_ranking_only"]:
     stat_name = sngl_stat_name
 else:

--- a/bin/minifollowups/pycbc_sngl_minifollowup
+++ b/bin/minifollowups/pycbc_sngl_minifollowup
@@ -89,7 +89,8 @@ parser.add_argument('--transformation-catalog')
 parser.add_argument('--output-file')
 parser.add_argument('--tags', nargs='+', default=[])
 wf.add_workflow_command_line_group(parser)
-stat.insert_statistic_option_group(parser)
+stat.insert_statistic_option_group(parser,
+    default_ranking_statistic='single_ranking_only')
 args = parser.parse_args()
 
 logging.basicConfig(format='%(asctime)s:%(levelname)s : %(message)s',

--- a/examples/search/analysis.ini
+++ b/examples/search/analysis.ini
@@ -155,7 +155,7 @@ autogating-pad = ${inspiral|autogating-pad}
 [bank2hdf]
 [fit_by_template]
 fit-function = exponential
-sngl-stat = newsnr_sgveto_psdvar_scaled_threshold
+sngl-ranking = newsnr_sgveto_psdvar_scaled_threshold
 stat-threshold = 4.0
 prune-param = mtotal
 log-prune-param =

--- a/examples/search/plotting.ini
+++ b/examples/search/plotting.ini
@@ -193,7 +193,7 @@ x-min = 6
 x-max = 15
 
 [plot_binnedhist]
-sngl-stat = ${fit_by_template|sngl-stat}
+sngl-ranking = ${fit_by_template|sngl-ranking}
 fit-function = ${fit_by_template|fit-function}
 ; limit the number of triggers for which duration is calculated
 stat-threshold = 5.0


### PR DESCRIPTION
@spxiwh Added a nice feature to allow sending options to single statistics, however, this was not used in the fitting codes. This udpate the fitting and minifollowup codes to all use this path so one can use a consistent single-detector statistic and also have minifollowups sort by that order. 