### PR TITLE
Add LAL cosmology option to mchirp_area_improved.py

### DIFF
--- a/pycbc/mchirp_area_improved.py
+++ b/pycbc/mchirp_area_improved.py
@@ -15,6 +15,7 @@ from scipy.integrate import quad
 from pycbc.cosmology import _redshift
 from astropy.cosmology import FlatLambdaCDM
 
+
 def insert_args(parser):
     mchirp_group = parser.add_argument_group("Arguments for estimating the "
                                              "source probabilities of a "

--- a/pycbc/mchirp_area_improved.py
+++ b/pycbc/mchirp_area_improved.py
@@ -75,11 +75,15 @@ def from_cli(args):
             'mass_gap': args.src_class_mass_gap_separate,
             'lal_cosmology': args.src_class_lal_cosmology}
 
+
 def redshift_estimation(distance, distance_std, lal_cosmology):
     """Takes values of distance and its uncertainty and returns a
        dictionary with estimates of the redshift and its uncertainty.
        If the argument 'lal_cosmology' is True, it uses Planck15 cosmology
        model as defined in lalsuite instead of the astropy default.
+       Constants for lal_cosmology taken from Planck15_lal_cosmology() in
+       https://git.ligo.org/lscsoft/pesummary/-/blob/master/pesummary/gw/
+       cosmology.py.
     """
     if lal_cosmology:
         cosmology = FlatLambdaCDM(H0=67.90, Om0=0.3065)
@@ -93,6 +97,7 @@ def redshift_estimation(distance, distance_std, lal_cosmology):
     z_std_estimation = 0.5 * (z_est_max - z_est_min)
     z = {'central': z_estimation, 'delta': z_std_estimation}
     return z
+
 
 def src_mass_from_z_det_mass(z, del_z, mdet, del_mdet):
     """Takes values of redshift, redshift uncertainty, detector mass and its


### PR DESCRIPTION
Since the cosmology model which is currently being use for LVC production results differs from the default cosmology of the `pycbc.cosmology.redshift` function, we need to introduce the option to use it for source probabilities estimation. 
```
pycbc_default_cosmology = astropy.cosmology.FlatLambdaCDM(H0=67.74, Om0=0.3075)

lal_default_cosmology = astropy.cosmology.FlatLambdaCDM(H0=67.90, Om0=0.3065)
```