### PR TITLE
Fix null optimal SNRs when reading HDF injections

### DIFF
--- a/bin/pycbc_optimal_snr
+++ b/bin/pycbc_optimal_snr
@@ -222,6 +222,8 @@ if __name__ == '__main__':
         return make_frequency_series(strain)
 
     def compute_optimal_snr(inj):
+        if not ligolw:
+            inj = inj.view(np.recarray)
         for det, column in opts.snr_columns.items():
             injection_time = get_gc_end_time(inj)
             psd = psds[det](injection_time)
@@ -242,7 +244,10 @@ if __name__ == '__main__':
                     raise
             logging.info('Injection %s at %s completed', inj.simulation_id, det)
             sval = sigma(wave, psd=psd, low_frequency_cutoff=f_low)
-            setattr(inj, column, sval)
+            if ligolw:
+                setattr(inj, column, sval)
+            else:
+                inj[column] = sval
         return inj
 
     logging.info("Loading injections")


### PR DESCRIPTION
While trying to use `pycbc_optimal_snr` code and using multiple cores I rediscovered this issue  https://github.com/gwastro/pycbc/issues/3693

The `inj` variable in `compute_optimal_snr` is a numpy.record class when HDF5 injection file is used and `setattr(inj, column, sval)` didn't work for it.

So, I have added in few lines to fix it and I have tested the proposed fix. You can find a wrapper script running the fixed `pycbc_optimal_snr` code here
`/home/koustav.chandra/projects/HM_search/fix_optimal_snr/optimal.sh` in Livingston cluster.

I have tested it on both XMLs and HDF5 injection file. The output generated is correct and you can find them in the same directory. They are named `optimal.xml` and `optimal.hdf`
