### PR TITLE
Update install instructions: swap setup.py for pip install

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -53,7 +53,7 @@ as follows.
     cd pycbc
     pip install -r requirements.txt
     pip install -r companion.txt
-    python setup.py install
+    pip install .
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 Other scenarios


### PR DESCRIPTION
Update https://pycbc.org/pycbc/latest/html/install.html#full-virtualenv-for-development-and-production install instructions to build pycbc using `pip install .` instead of `python setup.py install`, which was causing version conflicts.