### PR TITLE
Fix for broken pycbc_make_inference_inj_workflow

### DIFF
--- a/pycbc/inject/inject.py
+++ b/pycbc/inject/inject.py
@@ -473,7 +473,7 @@ class _HDFInjectionSet(object):
             # write metadata
             if static_args is None:
                 static_args = {}
-            fp.attrs["static_args"] = list(static_args.keys())
+            fp.attrs["static_args"] = list(map(str, static_args.keys()))
             fp.attrs['injtype'] = cls.injtype
             for key, val in metadata.items():
                 fp.attrs[key] = val


### PR DESCRIPTION
`pycbc_make_inference_inj_workflow` with injection hdf file seems to be broken. While creating workflow, it was giving following error:
`TypeError: No conversion path for dtype: dtype('<U12')`
This is a quick fix suggested by @cdcapano .