### PR TITLE
fix hdf injfilterrejector, speed up tau0 selection

### DIFF
--- a/pycbc/inject/inject.py
+++ b/pycbc/inject/inject.py
@@ -627,10 +627,8 @@ class CBCHDFInjectionSet(_HDFInjectionSet):
             f_l = f_lower
 
         # compute the waveform time series
-        logging.info('before waveform')
         hp, hc = get_td_waveform(inj, delta_t=delta_t, f_lower=f_l,
                                  **self.extra_args)
-        logging.info('after waveform')
         return projector(detector_name,
                          inj, hp, hc, distance_scale=distance_scale)
 

--- a/pycbc/inject/inject.py
+++ b/pycbc/inject/inject.py
@@ -560,6 +560,8 @@ class CBCHDFInjectionSet(_HDFInjectionSet):
         injections = self.table
         if simulation_ids:
             injections = injections[list(simulation_ids)]
+
+        injected_ids = []
         for ii, inj in enumerate(injections):
             f_l = inj.f_lower if f_lower is None else f_lower
             # roughly estimate if the injection may overlap with the segment
@@ -581,13 +583,14 @@ class CBCHDFInjectionSet(_HDFInjectionSet):
             signal = signal.astype(strain.dtype)
             signal_lal = signal.lal()
             add_injection(lalstrain, signal_lal, None)
+            injected_ids.append(ii)
             if inj_filter_rejector is not None:
                 inj_filter_rejector.generate_short_inj_from_inj(signal, ii)
 
         strain.data[:] = lalstrain.data.data[:]
 
         injected = copy.copy(self)
-        injected.table = injections
+        injected.table = injections[np.array(injected_ids).astype(int)]
         if inj_filter_rejector is not None:
             inj_filter_rejector.injection_params = injected
         return injected
@@ -624,8 +627,10 @@ class CBCHDFInjectionSet(_HDFInjectionSet):
             f_l = f_lower
 
         # compute the waveform time series
+        logging.info('before waveform')
         hp, hc = get_td_waveform(inj, delta_t=delta_t, f_lower=f_l,
                                  **self.extra_args)
+        logging.info('after waveform')
         return projector(detector_name,
                          inj, hp, hc, distance_scale=distance_scale)
 

--- a/pycbc/waveform/bank.py
+++ b/pycbc/waveform/bank.py
@@ -475,14 +475,19 @@ class TemplateBank(object):
         tau0_temp, _ = pycbc.pnutils.mass1_mass2_to_tau0_tau3(m1, m2, fref)
         indices = []
 
-        for inj in injection_parameters:
+        sort = tau0_temp.argsort()
+        tau0_temp = tau0_temp[sort]
+
+        for j, inj in enumerate(injection_parameters):
             tau0_inj, _ = \
                 pycbc.pnutils.mass1_mass2_to_tau0_tau3(inj.mass1, inj.mass2,
                                                        fref)
-            inj_indices = np.where(abs(tau0_temp - tau0_inj) <= threshold)[0]
+            lid = np.searchsorted(tau0_temp, tau0_inj - threshold)
+            rid = np.searchsorted(tau0_temp, tau0_inj + threshold)
+            inj_indices = sort[lid:rid]
             indices.append(inj_indices)
-            indices_combined = np.concatenate(indices)
 
+        indices_combined = np.concatenate(indices)
         indices_unique= np.unique(indices_combined)
         self.table = self.table[indices_unique]
 

--- a/pycbc/waveform/bank.py
+++ b/pycbc/waveform/bank.py
@@ -478,7 +478,7 @@ class TemplateBank(object):
         sort = tau0_temp.argsort()
         tau0_temp = tau0_temp[sort]
 
-        for j, inj in enumerate(injection_parameters):
+        for inj in injection_parameters:
             tau0_inj, _ = \
                 pycbc.pnutils.mass1_mass2_to_tau0_tau3(inj.mass1, inj.mass2,
                                                        fref)


### PR DESCRIPTION
I found that injfilterrejector was actually not enabled correctly for hdf injections. This occurs because it wasn't storing the set of actually injected ids (rather the *entire* set of injections). This also include some code to speed up the selection of templates when using a tau0 window. 