### PR TITLE
Add sub-sample interpolation into match function

### DIFF
--- a/pycbc/filter/matchedfilter.py
+++ b/pycbc/filter/matchedfilter.py
@@ -1315,7 +1315,8 @@ def matched_filter(template, data, psd=None, low_frequency_cutoff=None,
 
 _snr = None
 def match(vec1, vec2, psd=None, low_frequency_cutoff=None,
-          high_frequency_cutoff=None, v1_norm=None, v2_norm=None):
+          high_frequency_cutoff=None, v1_norm=None, v2_norm=None,
+          subsample_interpolation=False):
     """ Return the match between the two TimeSeries or FrequencySeries.
 
     Return the match between two waveforms. This is equivalent to the overlap
@@ -1339,6 +1340,11 @@ def match(vec1, vec2, psd=None, low_frequency_cutoff=None,
     v2_norm : {None, float}, optional
         The normalization of the second waveform. This is equivalent to its
         sigmasq value. If None, it is internally calculated.
+    subsample_interpolation : {False, bool}, optional
+        If True the peak will be interpolated between samples using a simple
+        quadratic fit. This can be important if measuring matches very close to
+        1 and can cause discontinuities if you don't use it as matches move
+        between discrete samples. If True the index returned will be a float.
 
     Returns
     -------
@@ -1355,11 +1361,29 @@ def match(vec1, vec2, psd=None, low_frequency_cutoff=None,
     global _snr
     if _snr is None or _snr.dtype != htilde.dtype or len(_snr) != N:
         _snr = zeros(N,dtype=complex_same_precision_as(vec1))
-    snr, _, snr_norm = matched_filter_core(htilde,stilde,psd,low_frequency_cutoff,
-                             high_frequency_cutoff, v1_norm, out=_snr)
+    snr, _, snr_norm = matched_filter_core(htilde, stilde, psd,
+                                           low_frequency_cutoff,
+                                           high_frequency_cutoff,
+                                           v1_norm, out=_snr)
     maxsnr, max_id = snr.abs_max_loc()
     if v2_norm is None:
-        v2_norm = sigmasq(stilde, psd, low_frequency_cutoff, high_frequency_cutoff)
+        v2_norm = sigmasq(stilde, psd, low_frequency_cutoff,
+                          high_frequency_cutoff)
+
+    if subsample_interpolation:
+        # This uses the implementation coded up in sbank. Thanks Nick!
+        # The maths for this is well summarized here:
+        # https://ccrma.stanford.edu/~jos/sasp/Quadratic_Interpolation_Spectral_Peaks.html
+        # We use adjacent points to interpolate, but wrap off the end if needed
+        left = abs(snr[-1]) if max_id == 0 else abs(snr[max_id - 1])
+        middle = maxsnr
+        right = abs(snr[0]) if max_id == (len(snr)-1) else abs(snr[max_id + 1])
+        # Get derivatives
+        dy = 0.5 * (right - left)
+        d2y = 2. * middle - left - right
+        maxsnr = middle + 0.5 * dy * dy / d2y
+        max_id = max_id + 2 * dy / d2y
+
     return maxsnr * snr_norm / sqrt(v2_norm), max_id
 
 def overlap(vec1, vec2, psd=None, low_frequency_cutoff=None,

--- a/pycbc/filter/matchedfilter.py
+++ b/pycbc/filter/matchedfilter.py
@@ -1379,10 +1379,8 @@ def match(vec1, vec2, psd=None, low_frequency_cutoff=None,
         middle = maxsnr
         right = abs(snr[0]) if max_id == (len(snr)-1) else abs(snr[max_id + 1])
         # Get derivatives
-        dy = 0.5 * (right - left)
-        d2y = 2. * middle - left - right
-        maxsnr = middle + 0.5 * dy * dy / d2y
-        max_id = max_id + 2 * dy / d2y
+        id_shift, maxsnr = quadratic_interpolate_peak(left, middle, right)
+        max_id = max_id + id_shift
 
     return maxsnr * snr_norm / sqrt(v2_norm), max_id
 
@@ -1480,7 +1478,7 @@ def quadratic_interpolate_peak(left, middle, right):
         Array of the estimated peak values at the interpolated offset
     """
     bin_offset = 1.0/2.0 * (left - right) / (left - 2 * middle + right)
-    peak_value = middle + 0.25 * (left - right) * bin_offset
+    peak_value = middle - 0.25 * (left - right) * bin_offset
     return bin_offset, peak_value
 
 

--- a/test/test_matchedfilter.py
+++ b/test/test_matchedfilter.py
@@ -36,8 +36,8 @@ import numpy
 from utils import parse_args_all_schemes, simple_exit
 
 _scheme, _context = parse_args_all_schemes("Matched Filter")
-import pycbc.fft.fftw
-pycbc.fft.fftw.set_measure_level(0)
+#import pycbc.fft.fftw
+#pycbc.fft.fftw.set_measure_level(0)
 
 class TestMatchedFilter(unittest.TestCase):
     def setUp(self,*args):
@@ -103,6 +103,12 @@ class TestMatchedFilter(unittest.TestCase):
             o,i = match(self.filtD,self.filtD)
             self.assertAlmostEqual(1,o,places=4)
             self.assertEqual(0,i)
+            o,i = match(self.filt,self.filt, subsample_interpolation=True)
+            self.assertAlmostEqual(1,o,places=4)
+            self.assertAlmostEqual(0,i,places=4)
+            o,i = match(self.filtD,self.filtD, subsample_interpolation=True)
+            self.assertAlmostEqual(1,o,places=4)
+            self.assertAlmostEqual(0,i,places=4)
 
     def test_perfect_match_offset(self):
         with self.context:
@@ -113,6 +119,17 @@ class TestMatchedFilter(unittest.TestCase):
             o,i = match(self.filtD,self.filt_offsetD)
             self.assertAlmostEqual(1,o,places=4)
             self.assertEqual(4096*32,i)
+
+            o,i = match(self.filt, self.filt_offset,
+                        subsample_interpolation=True)
+            self.assertAlmostEqual(1, o, places=4)
+            self.assertAlmostEqual(4096*32, i, places=4)
+
+            o,i = match(self.filtD, self.filt_offsetD,
+                        subsample_interpolation=True)
+            self.assertAlmostEqual(1, o, places=4)
+            self.assertAlmostEqual(4096*32, i, places=4)
+
 
     def test_imperfect_match(self):
         with self.context:
@@ -125,6 +142,17 @@ class TestMatchedFilter(unittest.TestCase):
             f2 = make_frequency_series(self.filt2D)
             o,i = match(self.filtD,self.filt2D)
             self.assertAlmostEqual(sqrt(0.5),o,places=3)
+
+            f = make_frequency_series(self.filt)
+            f2 = make_frequency_series(self.filt2)
+            o,i = match(self.filt, self.filt2, subsample_interpolation=True)
+            self.assertAlmostEqual(sqrt(0.5), o, places=3)
+
+            f = make_frequency_series(self.filtD)
+            f2 = make_frequency_series(self.filt2D)
+            o,i = match(self.filtD, self.filt2D, subsample_interpolation=True)
+            self.assertAlmostEqual(sqrt(0.5), o, places=3)
+            self.assertAlmostEqual(132327.27060, i, places=2)
 
     def test_errors(self):
         with self.context:

--- a/test/test_matchedfilter.py
+++ b/test/test_matchedfilter.py
@@ -105,10 +105,10 @@ class TestMatchedFilter(unittest.TestCase):
             self.assertEqual(0,i)
             o,i = match(self.filt,self.filt, subsample_interpolation=True)
             self.assertAlmostEqual(1,o,places=4)
-            self.assertAlmostEqual(0,i,places=4)
+            self.assertAlmostEqual(0,i,places=1)
             o,i = match(self.filtD,self.filtD, subsample_interpolation=True)
             self.assertAlmostEqual(1,o,places=4)
-            self.assertAlmostEqual(0,i,places=4)
+            self.assertAlmostEqual(0,i,places=1)
 
     def test_perfect_match_offset(self):
         with self.context:
@@ -123,12 +123,12 @@ class TestMatchedFilter(unittest.TestCase):
             o,i = match(self.filt, self.filt_offset,
                         subsample_interpolation=True)
             self.assertAlmostEqual(1, o, places=4)
-            self.assertAlmostEqual(4096*32, i, places=4)
+            self.assertAlmostEqual(4096*32, i, places=1)
 
             o,i = match(self.filtD, self.filt_offsetD,
                         subsample_interpolation=True)
             self.assertAlmostEqual(1, o, places=4)
-            self.assertAlmostEqual(4096*32, i, places=4)
+            self.assertAlmostEqual(4096*32, i, places=1)
 
 
     def test_imperfect_match(self):


### PR DESCRIPTION
This point has come up a few point with students looking into match, that I think this needs a proper fix:

The current match function only takes values at exact samples. This can cause a [small] systematic error if the peak of the match is between samples. This can cause some weird result plots and non-monotonic behaviour of the match as waveforms match at different time samples. I fix this by implementing the sbank solution of sub-sample interpolation for matches. I also link to somewhere where the [simple enough] math behind this is defined.