### PR TITLE
Bug fix in FFTW, more fully support numpy FFTs and  update FFT tests to cover properly

### DIFF
--- a/docs/fft.rst
+++ b/docs/fft.rst
@@ -151,7 +151,7 @@ If you want to choose a specific backend, you can see what is available with::
 and then do::
 
     >>> from pycbc.fft import backend_support
-    >>> backend_support.set_backend('mkl')
+    >>> backend_support.set_backend(['mkl'])
 
 to set a specific backend. Running::
 

--- a/docs/fft.rst
+++ b/docs/fft.rst
@@ -1,0 +1,170 @@
+###################################################
+Performing FFTs in PyCBC
+###################################################
+
+============
+Introduction
+============
+
+Many applications in gravitational-wave analysis rely on Fast Fourier
+Transforms. These are often the dominant computational cost in analyses. PyCBC
+needs to balance the requirement that analyses be efficient with ease of use
+for end users. To meet this requirement PyCBC provides two different APIs to
+do FFTs:
+
+* A function based API, which is easy to use, but not optimized.
+* A class-based API, which is a little more involved to use, but allows the use
+of optimized FFT routines.
+
+These APIs offer access to a number of FFT backends. PyCBC knows how to do FFTs
+using the FFTW, MKL and numpy backends, and will enable these if they are
+present on your system. By default FFTW will be used, then MKL if FFTW is not
+and numpy will be used only if the other 2 are not present. However, you can
+override this and choose a specific backend if multiple are available.
+
+When running on GPUs, PyCBC knows how to do CUDA FFTs through the same
+interface. 
+
+=====================
+Using the function based API
+=====================
+
+The PyCBC function based API offers a simple way to Fourier transform an
+input array into an output array. This is done by::
+
+    >>> from pycbc import fft
+    >>> fft.fft(input_array, output_array)
+
+Or for an inverse FFT::
+
+    >>> from pycbc import fft
+    >>> fft.ifft(input_array, output_array)
+
+To do this requires having the output_array, which would be the Fourier
+transform of the input, already existing as an array of 0s. This output array
+must be the correct *length*, the correct *type* (complex or real) and the
+correct *precision* (double or float precision). It's also worth noting that
+fast Fourier transforms are more efficient if their lengths are 2**N where
+N is some integer. This becomes a little complicated if doing real->complex
+or complex->real transforms; in those cases the longer array should have a
+length of 2**N to be efficient.
+
+Here's a few examples::
+
+    >>> import numpy as np
+    >>> from pycbc import types
+    >>> from pycbc import fft
+    >>> inarr = types.Array(np.ones([64], dtype=np.complex64))
+    >>> outarr = types.Array(np.zeros([64], dtype=np.complex64))
+    >>> fft.fft(inarr, outarr)
+    >>> print(outarr)
+
+or (note here the length of the complex array is the length of the real array divided by 2 and then + 1)::
+
+    >>> import numpy as np
+    >>> from pycbc import types
+    >>> from pycbc import fft
+    >>> inarr = types.Array(np.ones([64], dtype=np.float32))
+    >>> outarr = types.Array(np.zeros([33], dtype=np.complex64))
+    >>> fft.fft(inarr, outarr)
+    >>> print(outarr)
+
+or (this one is an inverse FFT)::
+
+    >>> import numpy as np
+    >>> from pycbc import types
+    >>> from pycbc import fft
+    >>> inarr = types.Array(np.ones([33], dtype=np.complex64))
+    >>> outarr = types.Array(np.zeros([64], dtype=np.float32))
+    >>> fft.ifft(inarr, outarr)
+    >>> print(outarr)
+
+This will work the pycbc Timeseries and Frequencyseries as well. Except you
+must FFT a TimeSeries to a FrequencySeries or IFFT a FrequencySeries to a
+TimeSeries. In this case the time and frequency spacing must also be
+consistent. For this reason we provide convenience functions that use the
+function API, but figure out these details, and create the output array, for
+you. As an example::
+
+    >>> import numpy as np
+    >>> from pycbc import types
+    >>> inarr = types.TimeSeries(np.ones([64], dtype=np.float64), delta_t=1./64.)
+    >>> outarr = inarr.to_frequencyseries()
+
+or::
+
+    >>> import numpy as np
+    >>> from pycbc import types
+    >>> inarr = types.FrequencySeries(np.ones([33], dtype=np.complex128), delta_f=1.)
+    >>> outarr = inarr.to_timeseries()
+
+
+=====================
+Using the class-based API
+=====================
+
+The PyCBC class-based API should be used if you care about performance. If you
+are performing FFTs many times, with inputs that are the same size each time,
+using this will offer significance perfommance improvement. 
+
+Here's how to use this::
+
+    >>> from pycbc import fft
+    >>> fft_class = pycbc.fft.FFT(inarr, outarr)
+    >>> fft_class.execute()
+    >>> outarr *= inarr._delta_t # ONLY IF inarr is a TimeSeries
+    >>> outarr *= inarr._delta_f # ONLY IF inarr is a FrequencySeries
+
+Or for an inverse FFT::
+
+    >>> from pycbc import fft
+    >>> ifft_class = pycbc.fft.IFFT(inarr, outarr)
+    >>> ifft_class.execute()
+    >>> outarr *= inarr._delta_t # ONLY IF inarr is a TimeSeries
+    >>> outarr *= inarr._delta_f # ONLY IF inarr is a FrequencySeries
+
+The idea would be that the `fft_class` or `ifft_class` would only be created
+*once* and the execute command called many times. You would change the contents
+of inarr before each call and outarr will update when execute is run. After
+creating the FFT class *do not* reassign inarr, but instead set values. So::
+
+    >>> fft_class = pycbc.fft.FFT(inarr, outarr)
+    >>> inarr = types.TimeSeries(np.ones([64], dtype=np.float64), delta_t=1./64.)
+    >>> fft_class.execute()
+
+would not work! Instead do::
+
+    >>> fft_class = pycbc.fft.FFT(inarr, outarr)
+    >>> inarr[:] = np.ones([64], dtype=np.float64)[:]
+    >>> fft_class.execute()
+
+
+====================
+Choosing a specific backend
+====================
+
+If you want to choose a specific backend, you can see what is available with::
+
+    >>> from pycbc.fft import backend_support
+    >>> backend_support.get_backend_names()
+
+and then do::
+
+    >>> from pycbc.fft import backend_support
+    >>> backend_support.set_backend('mkl')
+
+to set a specific backend. Running::
+
+    >>> from pycbc.fft import backend_support
+    >>> backend_support.get_backend()
+
+will tell you what you are currently using. You can also use the
+MKL `Scheme` to default to using MKL FFTs, instead of FFTW.
+
+====================
+Method documentation
+====================
+
+.. automodule:: pycbc.fft
+    :noindex:
+    :members:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -148,6 +148,7 @@ In addition we have some examples below.
    catalog
    dataquality
    frame
+   fft
    gw150914
    detector
    psd

--- a/pycbc/fft/fftw.py
+++ b/pycbc/fft/fftw.py
@@ -381,11 +381,11 @@ plan_many_r2c_d.restype = ctypes.c_void_p
 # translate input and output dtypes into the correct planning function.
 
 _plan_funcs_dict = { ('complex64', 'complex64') : plan_many_c2c_f,
-                     ('complex64', 'float32') : plan_many_r2c_f,
-                     ('float32', 'complex64') : plan_many_c2r_f,
+                     ('float32', 'complex64') : plan_many_r2c_f,
+                     ('complex64', 'float32') : plan_many_c2r_f,
                      ('complex128', 'complex128') : plan_many_c2c_d,
-                     ('complex128', 'float64') : plan_many_r2c_d,
-                     ('float64', 'complex128') : plan_many_c2r_d }
+                     ('float64', 'complex128') : plan_many_r2c_d,
+                     ('complex128', 'float64') : plan_many_c2r_d }
 
 # To avoid multiple-inheritance, we set up a function that returns much
 # of the initialization that will need to be handled in __init__ of both

--- a/pycbc/fft/fftw.py
+++ b/pycbc/fft/fftw.py
@@ -319,6 +319,7 @@ def execute(plan, invec, outvec):
     f(plan, invec.ptr, outvec.ptr)
 
 def fft(invec, outvec, prec, itype, otype):
+    print ("FFTW FFT")
     theplan, destroy = plan(len(invec), invec.dtype, outvec.dtype, FFTW_FORWARD,
                             get_measure_level(),(check_aligned(invec.data) and check_aligned(outvec.data)),
                    _scheme.mgr.state.num_threads, (invec.ptr == outvec.ptr))
@@ -423,7 +424,7 @@ def _fftw_setup(fftobj):
         plan = plan_func(1, n.ctypes.data, fftobj.nbatch,
                          tmpin.ptr, inembed.ctypes.data, 1, fftobj.idist,
                          tmpout.ptr, onembed.ctypes.data, 1, fftobj.odist,
-                         flags)
+                         FFTW_FORWARD, flags)
     del tmpin
     del tmpout
     return plan
@@ -438,6 +439,7 @@ class FFT(_BaseFFT):
         self.plan = _fftw_setup(self)
 
     def execute(self):
+        print (self._efunc)
         self._efunc(self.plan, self.iptr, self.optr)
 
 class IFFT(_BaseIFFT):

--- a/pycbc/fft/fftw.py
+++ b/pycbc/fft/fftw.py
@@ -319,7 +319,6 @@ def execute(plan, invec, outvec):
     f(plan, invec.ptr, outvec.ptr)
 
 def fft(invec, outvec, prec, itype, otype):
-    print ("FFTW FFT")
     theplan, destroy = plan(len(invec), invec.dtype, outvec.dtype, FFTW_FORWARD,
                             get_measure_level(),(check_aligned(invec.data) and check_aligned(outvec.data)),
                    _scheme.mgr.state.num_threads, (invec.ptr == outvec.ptr))
@@ -424,7 +423,7 @@ def _fftw_setup(fftobj):
         plan = plan_func(1, n.ctypes.data, fftobj.nbatch,
                          tmpin.ptr, inembed.ctypes.data, 1, fftobj.idist,
                          tmpout.ptr, onembed.ctypes.data, 1, fftobj.odist,
-                         FFTW_FORWARD, flags)
+                         flags)
     del tmpin
     del tmpout
     return plan
@@ -439,7 +438,6 @@ class FFT(_BaseFFT):
         self.plan = _fftw_setup(self)
 
     def execute(self):
-        print (self._efunc)
         self._efunc(self.plan, self.iptr, self.optr)
 
 class IFFT(_BaseIFFT):

--- a/pycbc/fft/fftw.py
+++ b/pycbc/fft/fftw.py
@@ -1,4 +1,4 @@
-from pycbc.types import zeros, complex64, complex128
+from pycbc.types import zeros
 import numpy as _np
 import ctypes
 import pycbc.scheme as _scheme

--- a/pycbc/fft/fftw.py
+++ b/pycbc/fft/fftw.py
@@ -406,18 +406,16 @@ def _fftw_setup(fftobj):
     plan_func = _plan_funcs_dict[ (str(fftobj.invec.dtype), str(fftobj.outvec.dtype)) ]
     tmpin = zeros(len(fftobj.invec), dtype = fftobj.invec.dtype)
     tmpout = zeros(len(fftobj.outvec), dtype = fftobj.outvec.dtype)
-    # C2C, forward
-    if fftobj.forward and (fftobj.outvec.dtype in [complex64, complex128]):
+    # C2C
+    if fftobj.outvec.kind == 'complex' and fftobj.invec.kind == 'complex':
+        if fftobj.forward:
+            ffd = FFTW_FORWARD
+        else:
+            ffd = FFTW_BACKWARD
         plan = plan_func(1, n.ctypes.data, fftobj.nbatch,
                          tmpin.ptr, inembed.ctypes.data, 1, fftobj.idist,
                          tmpout.ptr, onembed.ctypes.data, 1, fftobj.odist,
-                         FFTW_FORWARD, flags)
-    # C2C, backward
-    elif not fftobj.forward and (fftobj.invec.dtype in [complex64, complex128]):
-        plan = plan_func(1, n.ctypes.data, fftobj.nbatch,
-                         tmpin.ptr, inembed.ctypes.data, 1, fftobj.idist,
-                         tmpout.ptr, onembed.ctypes.data, 1, fftobj.odist,
-                         FFTW_BACKWARD, flags)
+                         ffd, flags)
     # R2C or C2R (hence no direction argument for plan creation)
     else:
         plan = plan_func(1, n.ctypes.data, fftobj.nbatch,

--- a/pycbc/fft/mkl.py
+++ b/pycbc/fft/mkl.py
@@ -95,6 +95,7 @@ def create_descriptor(size, idtype, odtype, inplace):
     return desc
 
 def fft(invec, outvec, prec, itype, otype):
+    print ("MKL FFT")
     descr = create_descriptor(max(len(invec), len(outvec)), invec.dtype,
                               outvec.dtype, (invec.ptr == outvec.ptr))
     f = lib.DftiComputeForward
@@ -132,6 +133,8 @@ def _get_desc(fftobj):
     # The following only matters if the transform is C2R or R2C
     status = lib.DftiSetValue(desc, DFTI_CONJUGATE_EVEN_STORAGE,
                               DFTI_COMPLEX_COMPLEX)
+    #status = lib.DftiSetValue(desc, DFTI_CONJUGATE_EVEN_STORAGE,
+    #                          DFTI_CCS_FORMAT)
     check_status(status)
 
     # In-place or out-of-place:

--- a/pycbc/fft/mkl.py
+++ b/pycbc/fft/mkl.py
@@ -95,7 +95,6 @@ def create_descriptor(size, idtype, odtype, inplace):
     return desc
 
 def fft(invec, outvec, prec, itype, otype):
-    print ("MKL FFT")
     descr = create_descriptor(max(len(invec), len(outvec)), invec.dtype,
                               outvec.dtype, (invec.ptr == outvec.ptr))
     f = lib.DftiComputeForward
@@ -133,8 +132,6 @@ def _get_desc(fftobj):
     # The following only matters if the transform is C2R or R2C
     status = lib.DftiSetValue(desc, DFTI_CONJUGATE_EVEN_STORAGE,
                               DFTI_COMPLEX_COMPLEX)
-    #status = lib.DftiSetValue(desc, DFTI_CONJUGATE_EVEN_STORAGE,
-    #                          DFTI_CCS_FORMAT)
     check_status(status)
 
     # In-place or out-of-place:

--- a/pycbc/fft/npfft.py
+++ b/pycbc/fft/npfft.py
@@ -31,10 +31,10 @@ import numpy.fft
 from .core import _check_fft_args
 from .core import _BaseFFT, _BaseIFFT
 
-_inv_fft_msg = ("I cannot perform an {} between data with an input type of "
+_INV_FFT_MSG = ("I cannot perform an {} between data with an input type of "
                 "{} and an output type of {}")
 
-def fft(invec, outvec, prec, itype, otype):
+def fft(invec, outvec, _, itype, otype):
     if invec.ptr == outvec.ptr:
         raise NotImplementedError("numpy backend of pycbc.fft does not "
                                   "support in-place transforms")
@@ -45,10 +45,10 @@ def fft(invec, outvec, prec, itype, otype):
         outvec.data = numpy.asarray(numpy.fft.rfft(invec.data),
                                     dtype=outvec.dtype)
     else:
-        raise ValueError(_inv_fft_msg.format("FFT", itype, otype))
+        raise ValueError(_INV_FFT_MSG.format("FFT", itype, otype))
 
 
-def ifft(invec, outvec, prec, itype, otype):
+def ifft(invec, outvec, _, itype, otype):
     if invec.ptr == outvec.ptr:
         raise NotImplementedError("numpy backend of pycbc.fft does not "
                                   "support in-place transforms")
@@ -64,24 +64,32 @@ def ifft(invec, outvec, prec, itype, otype):
         raise ValueError(_inv_fft_msg.format("IFFT", itype, otype))
 
 
-warn_msg = ("You are using the class-based PyCBC FFT API, with the numpy "
+WARN_MSG = ("You are using the class-based PyCBC FFT API, with the numpy "
             "backed. This is provided for convenience only. If performance is "
             "important use the class-based API with one of the other backends "
             "(for e.g. MKL or FFTW)")
 
+
 class FFT(_BaseFFT):
+    """
+    Class for performing FFTs via the numpy interface.
+    """
     def __init__(self, invec, outvec, nbatch=1, size=None):
         super(FFT, self).__init__(invec, outvec, nbatch, size)
-        logging.warn(warn_msg)
+        logging.warning(warn_msg)
         self.prec, self.itype, self.otype = _check_fft_args(invec, outvec)
 
     def execute(self):
-        fft(self.invec, self.outvec, self.prec, self.itype, self.otype) 
+        fft(self.invec, self.outvec, self.prec, self.itype, self.otype)
+
 
 class IFFT(_BaseIFFT):
+    """
+    Class for performing IFFTs via the numpy interface.
+    """
     def __init__(self, invec, outvec, nbatch=1, size=None):
         super(IFFT, self).__init__(invec, outvec, nbatch, size)
-        logging.warn(warn_msg)
+        logging.warning(warn_msg)
         self.prec, self.itype, self.otype = _check_fft_args(invec, outvec)
 
     def execute(self):

--- a/pycbc/fft/npfft.py
+++ b/pycbc/fft/npfft.py
@@ -26,7 +26,9 @@ This module provides the numpy backend of the fast Fourier transform
 for the PyCBC package.
 """
 
+import logging
 import numpy.fft
+from .core import _check_fft_args
 
 def fft(invec,outvec,prec,itype,otype):
     if invec.ptr == outvec.ptr:
@@ -47,3 +49,25 @@ def ifft(invec,outvec,prec,itype,otype):
                                     dtype=outvec.dtype)
         outvec *= len(outvec)
 
+warn_msg = ("You are using the class-based PyCBC FFT API, with the numpy "
+            "backed. This is provided for convenience only. If performance is "
+            "important use the class-based API with one of the other backends "
+            "(for e.g. MKL or FFTW)")
+
+class FFT(_BaseFFT):
+    def __init__(self, invec, outvec, nbatch=1, size=None):
+        super(FFT, self).__init__(invec, outvec, nbatch, size)
+        logging.warn(warn_msg)
+        self.prec, self.itype, self.otype = _check_fft_args(invec, outvec)
+
+    def execute(self):
+        fft(self.invec, self.outvec, self.prec, self.itype, self.otype) 
+
+class IFFT(_BaseIFFT):
+    def __init__(self, invec, outvec, nbatch=1, size=None):
+        super(IFFT, self).__init__(invec, outvec, nbatch, size)
+        logging.warn(warn_msg)
+        self.prec, self.itype, self.otype = _check_fft_args(invec, outvec)
+
+    def execute(self):
+        ifft(self.invec, self.outvec, self.prec, self.itype, self.otype)

--- a/pycbc/fft/npfft.py
+++ b/pycbc/fft/npfft.py
@@ -31,24 +31,38 @@ import numpy.fft
 from .core import _check_fft_args
 from .core import _BaseFFT, _BaseIFFT
 
-def fft(invec,outvec,prec,itype,otype):
-    if invec.ptr == outvec.ptr:
-        raise NotImplementedError("numpy backend of pycbc.fft does not support in-place transforms")
-    if itype == 'complex' and otype == 'complex':
-        outvec.data = numpy.asarray(numpy.fft.fft(invec.data),dtype=outvec.dtype)
-    elif itype == 'real' and otype == 'complex':
-        outvec.data = numpy.asarray(numpy.fft.rfft(invec.data),dtype=outvec.dtype)
+_inv_fft_msg = ("I cannot perform an {} between data with an input type of "
+                "{} and an output type of {}")
 
-def ifft(invec,outvec,prec,itype,otype):
+def fft(invec, outvec, prec, itype, otype):
     if invec.ptr == outvec.ptr:
-        raise NotImplementedError("numpy backend of pycbc.fft does not support in-place transforms")
+        raise NotImplementedError("numpy backend of pycbc.fft does not "
+                                  "support in-place transforms")
     if itype == 'complex' and otype == 'complex':
-        outvec.data = numpy.asarray(numpy.fft.ifft(invec.data),dtype=outvec.dtype)
+        outvec.data = numpy.asarray(numpy.fft.fft(invec.data),
+                                    dtype=outvec.dtype)
+    elif itype == 'real' and otype == 'complex':
+        outvec.data = numpy.asarray(numpy.fft.rfft(invec.data),
+                                    dtype=outvec.dtype)
+    else:
+        raise ValueError(_inv_fft_msg.format("FFT", itype, otype))
+
+
+def ifft(invec, outvec, prec, itype, otype):
+    if invec.ptr == outvec.ptr:
+        raise NotImplementedError("numpy backend of pycbc.fft does not "
+                                  "support in-place transforms")
+    if itype == 'complex' and otype == 'complex':
+        outvec.data = numpy.asarray(numpy.fft.ifft(invec.data),
+                                    dtype=outvec.dtype)
         outvec *= len(outvec)
     elif itype == 'complex' and otype == 'real':
         outvec.data = numpy.asarray(numpy.fft.irfft(invec.data,len(outvec)),
                                     dtype=outvec.dtype)
         outvec *= len(outvec)
+    else:
+        raise ValueError(_inv_fft_msg.format("IFFT", itype, otype))
+
 
 warn_msg = ("You are using the class-based PyCBC FFT API, with the numpy "
             "backed. This is provided for convenience only. If performance is "

--- a/pycbc/fft/npfft.py
+++ b/pycbc/fft/npfft.py
@@ -29,6 +29,7 @@ for the PyCBC package.
 import numpy.fft
 
 def fft(invec,outvec,prec,itype,otype):
+    print ("NUMPY FFT")
     if invec.ptr == outvec.ptr:
         raise NotImplementedError("numpy backend of pycbc.fft does not support in-place transforms")
     if itype == 'complex' and otype == 'complex':

--- a/pycbc/fft/npfft.py
+++ b/pycbc/fft/npfft.py
@@ -29,7 +29,6 @@ for the PyCBC package.
 import numpy.fft
 
 def fft(invec,outvec,prec,itype,otype):
-    print ("NUMPY FFT")
     if invec.ptr == outvec.ptr:
         raise NotImplementedError("numpy backend of pycbc.fft does not support in-place transforms")
     if itype == 'complex' and otype == 'complex':

--- a/pycbc/fft/npfft.py
+++ b/pycbc/fft/npfft.py
@@ -76,7 +76,7 @@ class FFT(_BaseFFT):
     """
     def __init__(self, invec, outvec, nbatch=1, size=None):
         super(FFT, self).__init__(invec, outvec, nbatch, size)
-        logging.warning(warn_msg)
+        logging.warning(WARN_MSG)
         self.prec, self.itype, self.otype = _check_fft_args(invec, outvec)
 
     def execute(self):
@@ -89,7 +89,7 @@ class IFFT(_BaseIFFT):
     """
     def __init__(self, invec, outvec, nbatch=1, size=None):
         super(IFFT, self).__init__(invec, outvec, nbatch, size)
-        logging.warning(warn_msg)
+        logging.warning(WARN_MSG)
         self.prec, self.itype, self.otype = _check_fft_args(invec, outvec)
 
     def execute(self):

--- a/pycbc/fft/npfft.py
+++ b/pycbc/fft/npfft.py
@@ -29,6 +29,7 @@ for the PyCBC package.
 import logging
 import numpy.fft
 from .core import _check_fft_args
+from .core import _BaseFFT, _BaseIFFT
 
 def fft(invec,outvec,prec,itype,otype):
     if invec.ptr == outvec.ptr:

--- a/pycbc/fft/npfft.py
+++ b/pycbc/fft/npfft.py
@@ -61,7 +61,7 @@ def ifft(invec, outvec, _, itype, otype):
                                     dtype=outvec.dtype)
         outvec *= len(outvec)
     else:
-        raise ValueError(_inv_fft_msg.format("IFFT", itype, otype))
+        raise ValueError(_INV_FFT_MSG.format("IFFT", itype, otype))
 
 
 WARN_MSG = ("You are using the class-based PyCBC FFT API, with the numpy "

--- a/test/fft_base.py
+++ b/test/fft_base.py
@@ -442,6 +442,10 @@ class _BaseTestFFTClass(unittest.TestCase):
         # Dictionary to convert a dtype to a relative precision to test
         self.tdict = { float32: 1e-6, float64: 1e-14,
                        complex64: 1e-6, complex128: 1e-14}
+        if self.backends[0] == 'mkl':
+            # MKL precision is not as high
+            self.tdict = { float32: 1e-4, float64: 1e-6,
+                           complex64: 1e-4, complex128: 1e-6}
         # Next we set up various lists that are used to build our 'known'
         # test, which are repeated for a variety of different precisions
         # and basic types. All of the lists should be consistent with a

--- a/test/fft_base.py
+++ b/test/fft_base.py
@@ -133,6 +133,11 @@ def _test_fft(test_case,inarr,expec,tol):
         outarr.clear()
         fft_class = pycbc.fft.FFT(inarr, outarr)
         fft_class.execute()
+        if isinstance(inarr, ts):
+            outarr *= inarr._delta_t
+        elif isinstance(inarr, fs):
+            outarr *= inarr._delta_f
+
         # First, verify that the input hasn't been overwritten
         emsg = 'FFT overwrote input array'
         tc.assertEqual(inarr,in_pristine,emsg)
@@ -179,6 +184,10 @@ def _test_ifft(test_case,inarr,expec,tol):
 
         ifft_class = pycbc.fft.IFFT(inarr, outarr)
         ifft_class.execute()
+        if isinstance(inarr, ts):
+            outarr *= inarr._delta_t
+        elif isinstance(inarr, fs):
+            outarr *= inarr._delta_f
         # First, verify that the input hasn't been overwritten
         emsg = 'Inverse FFT overwrote input array'
         tc.assertEqual(inarr,in_pristine,emsg)

--- a/test/fft_base.py
+++ b/test/fft_base.py
@@ -299,7 +299,7 @@ def _test_raise_excep_fft(test_case,inarr,outarr,other_args=None):
         args = [in_badtype, outarr]
         tc.assertRaises(TypeError,pycbc.fft.fft,*args)
 
-def _test_raise_excep_ifft(test_case,inarr,outarr,other_args=None):
+def _test_raise_excep_ifft(test_case, inarr, outarr, other_args=None):
     # As far as can be told from the unittest module documentation, the
     # 'assertRaises' tests do not permit a custom message.  So more
     # comments than usual here, to help diagnose and test failures.
@@ -314,18 +314,23 @@ def _test_raise_excep_ifft(test_case,inarr,outarr,other_args=None):
     with tc.context:
         outty = type(outarr)
         outzer = pycbc.types.zeros(len(outarr))
-        # If we give an output array that is wrong only in length, raise ValueError:
-        out_badlen = outty(pycbc.types.zeros(len(outarr)+1),dtype=outarr.dtype,**other_args)
+        # If we give an output array that is wrong only in length,
+        # raise ValueError:
+        out_badlen = outty(pycbc.types.zeros(len(outarr)+1), 
+                           dtype=outarr.dtype, **other_args)
         args = [inarr, out_badlen]
-        tc.assertRaises(ValueError,pycbc.fft.ifft,*args)
-        # If we give an output array that has the wrong precision, raise ValueError:
-        out_badprec = outty(outzer,dtype=_other_prec[dtype(outarr).type],**other_args)
-        args = [inarr,out_badprec]
-        tc.assertRaises(ValueError,pycbc.fft.ifft,*args)
-        # If we give an output array that has the wrong kind (real or complex) but
-        # correct precision, then raise a ValueError.  Here we must adjust the kind
-        # of the *input* array, not output.  But that makes it hard, because the 'other_args'
-        # parameter will be wrong for that.  Very hacky, but oh well...
+        tc.assertRaises(ValueError, pycbc.fft.ifft, *args)
+        # If we give an output array that has the wrong precision,
+        # raise ValueError:
+        out_badprec = outty(outzer, dtype=_other_prec[dtype(outarr).type],
+                            **other_args)
+        args = [inarr, out_badprec]
+        tc.assertRaises(ValueError, pycbc.fft.ifft, *args)
+        # If we give an output array that has the wrong kind (real or complex)
+        # but correct precision, then raise a ValueError.  Here we must adjust
+        # the kind of the *input* array, not output.  But that makes it hard,
+        # because the 'other_args' parameter will be wrong for that.
+        # Very hacky, but oh well...
         new_args = other_args.copy()
         if new_args != {}:
             try:
@@ -338,7 +343,7 @@ def _test_raise_excep_ifft(test_case,inarr,outarr,other_args=None):
                                  dtype=_bad_dtype[dtype(outarr).type],
                                  **new_args)
         args = [in_badkind, outarr]
-        #pycbc.fft.ifft(in_badkind, outarr)
+        # This will run pycbc.fft.ifft(in_badkind, outarr)
         if str(outarr.dtype) not in ['complex64', 'complex128']:
             tc.assertRaises((ValueError, KeyError), pycbc.fft.ifft, *args)
         # If we give an output array that isn't a PyCBC type, raise TypeError:

--- a/test/fft_base.py
+++ b/test/fft_base.py
@@ -98,7 +98,7 @@ _bad_dtype = {float32: float32, float64: float64,
 # within the appropriate context, so they should not themselves be called inside
 # of a context block.
 
-def _test_fft(test_case,inarr,expec,tol):
+def _test_fft(test_case, inarr, expec, tol):
     # Basic test to see that the forward FFT doesn't
     # overwrite its input and computes its output to
     # within the required accuracy.
@@ -118,39 +118,38 @@ def _test_fft(test_case,inarr,expec,tol):
         outarr._delta_f *= 5*tol
     with tc.context:
         set_backend(tc.backends)
-        pycbc.fft.fft(inarr, outarr)
-        
-        # First, verify that the input hasn't been overwritten
-        emsg = 'FFT overwrote input array'
-        tc.assertEqual(inarr,in_pristine,emsg)
-        # Next, check that the output is correct to within tolerance.
-        # That will require exact equality of all other meta-data
-        emsg = 'FFT output differs by more than a factor of {0} from expected'.format(tol)
-        if isinstance(outarr,ts) or isinstance(outarr,fs):
-            tc.assertTrue(outarr.almost_equal_norm(expec,tol=tol,dtol=tol),msg=emsg)
-        else:
-            tc.assertTrue(outarr.almost_equal_norm(expec,tol=tol),msg=emsg)
-        outarr.clear()
-        fft_class = pycbc.fft.FFT(inarr, outarr)
-        fft_class.execute()
-        if isinstance(inarr, ts):
-            outarr *= inarr._delta_t
-        elif isinstance(inarr, fs):
-            outarr *= inarr._delta_f
+        for api in ['func', 'class']:
+            if api == 'func':
+                pycbc.fft.fft(inarr, outarr)
+            else:
+                fft_class = pycbc.fft.FFT(inarr, outarr)
+                fft_class.execute()
+                if isinstance(inarr, ts):
+                    outarr *= inarr._delta_t
+                elif isinstance(inarr, fs):
+                    outarr *= inarr._delta_f
 
-        # First, verify that the input hasn't been overwritten
-        emsg = 'FFT overwrote input array'
-        tc.assertEqual(inarr,in_pristine,emsg)
-        # Next, check that the output is correct to within tolerance.
-        # That will require exact equality of all other meta-data
-        emsg = 'FFT output differs by more than a factor of {0} from expected'.format(tol)
-        if isinstance(outarr,ts) or isinstance(outarr,fs):
-            tc.assertTrue(outarr.almost_equal_norm(expec,tol=tol,dtol=tol),msg=emsg)
-        else:
-            tc.assertTrue(outarr.almost_equal_norm(expec,tol=tol),msg=emsg)
+            # First, verify that the input hasn't been overwritten
+            emsg = 'FFT overwrote input array'
+            tc.assertEqual(inarr, in_pristine,emsg)
+            # Next, check that the output is correct to within tolerance.
+            # That will require exact equality of all other meta-data
+            emsg = ('FFT output differs by more than a factor of '
+                    '{0} from expected'.format(tol))
+            if isinstance(outarr, ts) or isinstance(outarr, fs):
+                tc.assertTrue(
+                    outarr.almost_equal_norm(expec, tol=tol, dtol=tol),
+                    msg=emsg
+                )
+            else:
+                tc.assertTrue(
+                    outarr.almost_equal_norm(expec, tol=tol),
+                    msg=emsg
+                )
+            outarr.clear()
 
 
-def _test_ifft(test_case,inarr,expec,tol):
+def _test_ifft(test_case, inarr, expec, tol):
     # Basic test to see that the reverse FFT doesn't
     # overwrite its input and computes its output to
     # within the required accuracy.
@@ -170,34 +169,35 @@ def _test_ifft(test_case,inarr,expec,tol):
         outarr._delta_f *= 5*tol
     with tc.context:
         set_backend(tc.backends)
-        pycbc.fft.ifft(inarr, outarr)
-        # First, verify that the input hasn't been overwritten
-        emsg = 'Inverse FFT overwrote input array'
-        tc.assertEqual(inarr,in_pristine,emsg)
-        # Next, check that the output is correct to within tolerance.
-        # That will require exact equality of all other meta-data
-        emsg = 'Inverse FFT output differs by more than a factor of {0} from expected'.format(tol)
-        if isinstance(outarr,ts) or isinstance(outarr,fs):
-            tc.assertTrue(outarr.almost_equal_norm(expec,tol=tol,dtol=tol),msg=emsg)
-        else:
-            tc.assertTrue(outarr.almost_equal_norm(expec,tol=tol),msg=emsg)
+        for api in ['func', 'class']:
+            if api == 'func':
+                pycbc.fft.ifft(inarr, outarr)
+            else:
+                ifft_class = pycbc.fft.IFFT(inarr, outarr)
+                ifft_class.execute()
+                if isinstance(inarr, ts):
+                    outarr *= inarr._delta_t
+                elif isinstance(inarr, fs):
+                    outarr *= inarr._delta_f
 
-        ifft_class = pycbc.fft.IFFT(inarr, outarr)
-        ifft_class.execute()
-        if isinstance(inarr, ts):
-            outarr *= inarr._delta_t
-        elif isinstance(inarr, fs):
-            outarr *= inarr._delta_f
-        # First, verify that the input hasn't been overwritten
-        emsg = 'Inverse FFT overwrote input array'
-        tc.assertEqual(inarr,in_pristine,emsg)
-        # Next, check that the output is correct to within tolerance.
-        # That will require exact equality of all other meta-data
-        emsg = 'Inverse FFT output differs by more than a factor of {0} from expected'.format(tol)
-        if isinstance(outarr,ts) or isinstance(outarr,fs):
-            tc.assertTrue(outarr.almost_equal_norm(expec,tol=tol,dtol=tol),msg=emsg)
-        else:
-            tc.assertTrue(outarr.almost_equal_norm(expec,tol=tol),msg=emsg)
+            # First, verify that the input hasn't been overwritten
+            emsg = 'Inverse FFT overwrote input array'
+            tc.assertEqual(inarr, in_pristine, emsg)
+            # Next, check that the output is correct to within tolerance.
+            # That will require exact equality of all other meta-data
+            emsg = ('Inverse FFT output differs by more than a factor '
+                    'of {0} from expected'.format(tol))
+            if isinstance(outarr, ts) or isinstance(outarr, fs):
+                tc.assertTrue(
+                    outarr.almost_equal_norm(expec, tol=tol, dtol=tol),
+                    msg=emsg
+                )
+            else:
+                tc.assertTrue(
+                    outarr.almost_equal_norm(expec, tol=tol),
+                    msg=emsg
+                )
+            outarr.clear()
 
 
 def _test_random(test_case,inarr,outarr,tol):

--- a/test/fft_base.py
+++ b/test/fft_base.py
@@ -165,8 +165,7 @@ def _test_ifft(test_case,inarr,expec,tol):
         outarr._delta_f *= 5*tol
     with tc.context:
         set_backend(tc.backends)
-        ifft_class = pycbc.fft.IFFT(inarr, outarr)
-        ifft_class.execute()
+        pycbc.fft.ifft(inarr, outarr)
         # First, verify that the input hasn't been overwritten
         emsg = 'Inverse FFT overwrote input array'
         tc.assertEqual(inarr,in_pristine,emsg)
@@ -178,7 +177,8 @@ def _test_ifft(test_case,inarr,expec,tol):
         else:
             tc.assertTrue(outarr.almost_equal_norm(expec,tol=tol),msg=emsg)
 
-        pycbc.fft.ifft(inarr, outarr)
+        ifft_class = pycbc.fft.IFFT(inarr, outarr)
+        ifft_class.execute()
         # First, verify that the input hasn't been overwritten
         emsg = 'Inverse FFT overwrote input array'
         tc.assertEqual(inarr,in_pristine,emsg)

--- a/test/test_fft_unthreaded.py
+++ b/test/test_fft_unthreaded.py
@@ -26,6 +26,7 @@ These are the unit-tests for the pycbc.fft subpackage, testing only unthreaded
 backends for the various schemes.
 """
 
+import logging
 import pycbc.fft
 import unittest
 from utils import parse_args_all_schemes, simple_exit
@@ -39,6 +40,9 @@ _scheme, _context = parse_args_all_schemes("FFT")
 # Get our list of backends:
 
 backends = pycbc.fft.get_backend_names()
+
+# Numpy will warn not to use its class interface, silence it.
+logging.disable(logging.WARNING) 
 
 FFTTestClasses = []
 for backend in backends:

--- a/test/test_fft_unthreaded.py
+++ b/test/test_fft_unthreaded.py
@@ -33,6 +33,8 @@ from fft_base import _BaseTestFFTClass
 
 _scheme, _context = parse_args_all_schemes("FFT")
 
+print (_scheme, _context)
+
 # Most of the work is now done in fft_base.  Below are factories for
 # creating a test for each backend of each scheme.
 
@@ -42,6 +44,8 @@ backends = pycbc.fft.get_backend_names()
 
 FFTTestClasses = []
 for backend in backends:
+    if backend == 'numpy':
+        continue
     # This creates, for each backend, a new class derived from
     # both _BaseTestFFTClass and unittest.TestCase, and with
     # the additional property 'self.backend' set to the value

--- a/test/test_fft_unthreaded.py
+++ b/test/test_fft_unthreaded.py
@@ -33,8 +33,6 @@ from fft_base import _BaseTestFFTClass
 
 _scheme, _context = parse_args_all_schemes("FFT")
 
-print (_scheme, _context)
-
 # Most of the work is now done in fft_base.  Below are factories for
 # creating a test for each backend of each scheme.
 
@@ -44,8 +42,6 @@ backends = pycbc.fft.get_backend_names()
 
 FFTTestClasses = []
 for backend in backends:
-    if backend == 'numpy':
-        continue
     # This creates, for each backend, a new class derived from
     # both _BaseTestFFTClass and unittest.TestCase, and with
     # the additional property 'self.backend' set to the value


### PR DESCRIPTION
This patch addresses some issues found in FFT library in PyCBC. After including all FFT backends in the test suite a number of failures were noted (as described below), which have been tracked down and fixed. I also update the test code to automatically test class and function APIs for all available backends. Finally, I've added a documentation FFT page to illustrate how to use both interfaces. I have *not* yet looked at multi-threaded FFTs, which have been reported as an issue (in particular MKL multi-threaded FFTs not working).

Failures that have been fixed:

 * ~~FFTW is segfaulting on the r2c FFTs when called through the class API.~~  (Fixed after resolving bugs in how plans are being called)
 * ~~MKL gives incorrect results (I think incorrectly normalized) for the class-based API.~~ (Fixed after noticing that the class-based API does not multiply by delta_t/delta_f, whereas the function-based API does).
 * ~~numpy doesn't *have* a class-based API, and so fails.~~ (Fixed by adding a basic class-based API for numpy. This is not optimal, but is useful for people running in (for e.g.) SciServer/Colab where this is the only FFT backend easily available)
 * ~~FFTW's class-based API overwrites the input for c2r FFTs. This is currently considered a failure.~~ (While I think this still happens for large FFTs, it no longer seems to happen for the small inputs used in the test once the above things were fixed)

I'm not sure which backends the tests here will have access to.