### PR TITLE
FFT tests for multi-threading

### DIFF
--- a/.github/workflows/mac-test.yml
+++ b/.github/workflows/mac-test.yml
@@ -18,7 +18,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - run: |
         brew install fftw
-        sudo conda install mkl
+        pip install mkl
         pip install --upgrade pip setuptools tox
     - name: run basic pycbc test suite
       run: |

--- a/.github/workflows/mac-test.yml
+++ b/.github/workflows/mac-test.yml
@@ -18,6 +18,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - run: |
         brew install fftw
+        conda install mkl
         pip install --upgrade pip setuptools tox
     - name: run basic pycbc test suite
       run: |

--- a/.github/workflows/mac-test.yml
+++ b/.github/workflows/mac-test.yml
@@ -18,7 +18,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - run: |
         brew install fftw
-        conda install mkl
+        sudo conda install mkl
         pip install --upgrade pip setuptools tox
     - name: run basic pycbc test suite
       run: |

--- a/.github/workflows/mac-test.yml
+++ b/.github/workflows/mac-test.yml
@@ -18,7 +18,6 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - run: |
         brew install fftw
-        pip install mkl
         pip install --upgrade pip setuptools tox
     - name: run basic pycbc test suite
       run: |

--- a/examples/inspiral/clean.sh
+++ b/examples/inspiral/clean.sh
@@ -1,0 +1,1 @@
+rm -f H1-INSPIRAL_* output_*pstats inspiral_*log *png DATA_FILE.gwf COMPRESSED_BANK.hdf SMALLER_BANK_FOR_GW150914.hdf

--- a/examples/inspiral/run.sh
+++ b/examples/inspiral/run.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
-# Test pycbc inspiral by running over GW150914 with a limited template bank
-echo -e "\\n\\n>> [`date`] Getting template bank"
-wget -nc https://github.com/gwastro/pycbc-config/raw/master/test/inspiral/H1L1-SBANK_FOR_GW150914ER10.xml.gz
 
-echo -e "\\n\\n>> [`date`] Running pycbc inspiral"
-pycbc_inspiral \
---frame-type LOSC \
+function inspiral_run {
+echo -e "\\n\\n>> [`date`] Running pycbc inspiral $1:$3 with $2 threads"
+# Uncomment if you want profile information
+#python -m cProfile -o output_$1_$2_$3.pstats
+`which pycbc_inspiral` \
+--frame-files DATA_FILE.gwf \
 --sample-rate 2048 \
 --sgchisq-snr-threshold 6.0 \
 --sgchisq-locations "mtotal>40:20-30,20-45,20-60,20-75,20-90,20-105,20-120" \
@@ -35,13 +35,83 @@ pycbc_inspiral \
 --channel-name H1:LOSC-STRAIN \
 --gps-start-time 1126259078 \
 --gps-end-time 1126259846 \
---output H1-INSPIRAL-OUT.hdf \
---verbose \
+--output H1-INSPIRAL_$1_$2_$3-OUT.hdf \
 --approximant "SPAtmplt:mtotal<4" "SEOBNRv4_ROM:mtotal<20" "SEOBNRv2_ROM_DoubleSpin:else" \
---bank-file H1L1-SBANK_FOR_GW150914ER10.xml.gz 2> inspiral.log
+--fft-backends $1 \
+--processing-scheme cpu:$2 \
+--fftw-threads-backend $3 \
+--use-compressed-waveforms \
+--bank-file COMPRESSED_BANK.hdf \
+#--verbose 2> inspiral_$1_$2_$3.log
+# Uncomment above if you want logging
 
-cat inspiral.log | head -10
-cat inspiral.log | tail -20
+# Uncomment for profile pngs
+#gprof2dot -f pstats output_$1_$2_$3.pstats | dot -Tpng -o $1_$2_$3.png
 
 echo -e "\\n\\n>> [`date`] test for GW150914"
-python ./check_GW150914_detection.py H1-INSPIRAL-OUT.hdf
+python ./check_GW150914_detection.py H1-INSPIRAL_$1_$2_$3-OUT.hdf
+}
+
+
+# Test pycbc inspiral by running over GW150914 with a limited template bank
+echo -e "\\n\\n>> [`date`] Getting template bank"
+wget -nc https://github.com/gwastro/pycbc-config/raw/master/test/inspiral/SMALLER_BANK_FOR_GW150914.hdf
+
+echo -e "\\n\\n>> [`date`] Compressing template bank"
+pycbc_compress_bank --bank-file SMALLER_BANK_FOR_GW150914.hdf --output COMPRESSED_BANK.hdf --sample-rate 4096 --segment-length 256 --compression-algorithm mchirp --psd-model aLIGOZeroDetHighPower --low-frequency-cutoff 30 --approximant "SEOBNRv4_ROM"
+
+echo -e "\\n\\n>> [`date`] Creating data file"
+pycbc_condition_strain \
+--frame-type LOSC \
+--sample-rate 2048 \
+--pad-data 8 \
+--autogating-width 0.25 \
+--autogating-threshold 100 \
+--autogating-cluster 0.5 \
+--autogating-taper 0.25 \
+--strain-high-pass 10 \
+--channel-name H1:LOSC-STRAIN \
+--gps-start-time 1126258578 \
+--gps-end-time 1126259946 \
+--output-strain-file DATA_FILE.gwf \
+
+
+start=`date +%s`
+inspiral_run fftw 16 openmp
+end=`date +%s`
+runtime_fftw_openmp_16=$((end-start))
+
+start=`date +%s`
+inspiral_run fftw 16 pthreads
+end=`date +%s`
+runtime_fftw_pthreads_16=$((end-start))
+
+# In all cases below the last argument is irrelevant
+start=`date +%s`
+inspiral_run fftw 1 openmp
+end=`date +%s`
+runtime_fftw_1=$((end-start))
+
+start=`date +%s`
+inspiral_run mkl 16 openmp
+end=`date +%s`
+runtime_mkl_16=$((end-start))
+
+start=`date +%s`
+inspiral_run mkl 1 openmp
+end=`date +%s`
+runtime_mkl_1=$((end-start))
+
+# Numpy doesn't include threading. We just want it to run, it won't be fast!
+start=`date +%s`
+inspiral_run numpy 1 openmp
+end=`date +%s`
+runtime_numpy_1=$((end-start))
+
+echo "RUN TIMES"
+echo "FFTW 16 threads with openmp " ${runtime_fftw_openmp_16}
+echo "FFTW 16 threads with pthreads" ${runtime_fftw_pthreads_16}
+echo "FFTW single core" ${runtime_fftw_1}
+echo "MKL 16 threads" ${runtime_mkl_16}
+echo "MKL 1 thread" ${runtime_mkl_1}
+echo "Numpy 1 thread" ${runtime_numpy_1}

--- a/examples/inspiral/run.sh
+++ b/examples/inspiral/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 
 function inspiral_run {
 echo -e "\\n\\n>> [`date`] Running pycbc inspiral $1:$3 with $2 threads"

--- a/pycbc/fft/mkl.py
+++ b/pycbc/fft/mkl.py
@@ -89,9 +89,15 @@ def create_descriptor(size, idtype, odtype, inplace):
         lib.DftiSetValue(desc, DFTI_PLACEMENT, DFTI_INPLACE)
     else:
         lib.DftiSetValue(desc, DFTI_PLACEMENT, DFTI_NOT_INPLACE)
+
+    nthreads = _scheme.mgr.state.num_threads
+    status = lib.DftiSetValue(desc, DFTI_THREAD_LIMIT, nthreads)
+    check_status(status)
+
     lib.DftiSetValue(desc, DFTI_CONJUGATE_EVEN_STORAGE, DFTI_CCS_FORMAT)
     lib.DftiCommitDescriptor(desc)
     check_status(status)
+
     return desc
 
 def fft(invec, outvec, prec, itype, otype):

--- a/pycbc/fft/npfft.py
+++ b/pycbc/fft/npfft.py
@@ -39,11 +39,11 @@ def fft(invec, outvec, _, itype, otype):
         raise NotImplementedError("numpy backend of pycbc.fft does not "
                                   "support in-place transforms")
     if itype == 'complex' and otype == 'complex':
-        outvec.data = numpy.asarray(numpy.fft.fft(invec.data),
-                                    dtype=outvec.dtype)
+        outvec.data[:] = numpy.asarray(numpy.fft.fft(invec.data),
+                                       dtype=outvec.dtype)
     elif itype == 'real' and otype == 'complex':
-        outvec.data = numpy.asarray(numpy.fft.rfft(invec.data),
-                                    dtype=outvec.dtype)
+        outvec.data[:] = numpy.asarray(numpy.fft.rfft(invec.data),
+                                       dtype=outvec.dtype)
     else:
         raise ValueError(_INV_FFT_MSG.format("FFT", itype, otype))
 
@@ -53,12 +53,12 @@ def ifft(invec, outvec, _, itype, otype):
         raise NotImplementedError("numpy backend of pycbc.fft does not "
                                   "support in-place transforms")
     if itype == 'complex' and otype == 'complex':
-        outvec.data = numpy.asarray(numpy.fft.ifft(invec.data),
-                                    dtype=outvec.dtype)
+        outvec.data[:] = numpy.asarray(numpy.fft.ifft(invec.data),
+                                       dtype=outvec.dtype)
         outvec *= len(outvec)
     elif itype == 'complex' and otype == 'real':
-        outvec.data = numpy.asarray(numpy.fft.irfft(invec.data,len(outvec)),
-                                    dtype=outvec.dtype)
+        outvec.data[:] = numpy.asarray(numpy.fft.irfft(invec.data,len(outvec)),
+                                       dtype=outvec.dtype)
         outvec *= len(outvec)
     else:
         raise ValueError(_INV_FFT_MSG.format("IFFT", itype, otype))

--- a/test/test_fft_mkl_threaded.py
+++ b/test/test_fft_mkl_threaded.py
@@ -33,19 +33,12 @@ from sys import exit as _exit
 from utils import parse_args_cpu_only, simple_exit
 from fft_base import _BaseTestFFTClass
 
-parse_args_cpu_only("FFTW openmp backend")
+parse_args_cpu_only("MKL threaded backend")
 
 # See if we can get set the FFTW backend to 'openmp'; if not, say so and exit.
 
-if 'fftw' in pycbc.fft.get_backend_names():
-    import pycbc.fft.fftw
-    try:
-        pycbc.fft.fftw.set_threads_backend('openmp')
-    except:
-        print("Unable to import openmp threads backend to FFTW; skipping openmp thread tests")
-        _exit(0)
-else:
-    print("FFTW does not seem to be an available CPU backend; skipping openmp thread tests")
+if not 'mkl' in pycbc.fft.get_backend_names():
+    print("MKL does not seem to be available; skipping MKL tests")
     _exit(0)
 
 # Now set the number of threads to something nontrivial
@@ -54,7 +47,7 @@ else:
 
 FFTTestClasses = []
 for num_threads in [2,4,6,8]:
-    kdict = {'backends' : ['fftw'],
+    kdict = {'backends' : ['mkl'],
              'scheme' : 'cpu',
              'context' : CPUScheme(num_threads=num_threads)}
     klass = type('FFTW_OpenMP_test',

--- a/test/test_fftw_pthreads.py
+++ b/test/test_fftw_pthreads.py
@@ -51,13 +51,14 @@ else:
 # Most of the work is now done in fft_base.
 
 FFTTestClasses = []
-kdict = {'backends' : ['fftw'],
-         'scheme' : 'cpu',
-         'context' : CPUScheme(num_threads=2)}
-klass = type('FFTW_pthreads_test',
-             (_BaseTestFFTClass,),kdict)
-klass.__test__ = True
-FFTTestClasses.append(klass)
+for num_threads in [2,4,6,8]:
+    kdict = {'backends' : ['fftw'],
+             'scheme' : 'cpu',
+             'context' : CPUScheme(num_threads=num_threads)}
+    klass = type('FFTW_OpenMP_test',
+                 (_BaseTestFFTClass,),kdict)
+    klass.__test__ = True
+    FFTTestClasses.append(klass)
 
 # Finally, we create suites and run them
 

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ indexserver =
 deps =
     :preinstall: -rrequirements.txt
     -rcompanion.txt
+    mkl
 
 [testenv]
 allowlist_externals = bash


### PR DESCRIPTION
Continuing on from #3734, here I update the multi-threaded FFT tests to test MKL, FFTW+openmp and FFTW+pthreads (if available).

I've also revamped the inspiral test case to run on all possible backends (with 1 thread, and with 16 threads). (First time I've seen pycbc_inspiral run correctly with MKL threaded).

I have updated the MKL FFTs (through the function interface) to allow multi-threading and fixed an issue with the class-based API for numpy I added in #3734.

Doing this has raised some questions:

 * The performance (which you can see from running the new inspiral test) of the different FFT backend options is not what I expect. I've changed the test to use compressed waveforms so it should now be FFT limited. FFTW multi-threaded is giving me the best performance (on ldas-pcdev1 on LHO ... Possibly not the best test machine). MKL performance is very poor in comparison (2 or 3 times slower!) Profile information suggests that the cluster_and_threshold code is much slower when MKL is used.
 
 * The compressed waveform code is broken on python3 (and so this PR will not pass the tests yet, but the fix for that should be a separate PR that I rebase this on to). The problem is in writing and reading the approximant column in the HDF bank file. I know @cdcapano has looked into this, but it still seems like things are broken here. The compressed waveforms code correctly calls the Bank API, so I think the problem is with the classes in waveform/bank.py. 