### PR TITLE
simplify use of rvs

### DIFF
--- a/pycbc/distributions/angular.py
+++ b/pycbc/distributions/angular.py
@@ -254,6 +254,7 @@ class SinAngle(UniformAngle):
             numpy.log(self._dfunc(
                 numpy.array([kwargs[p] for p in self._params]))).sum()
 
+
 class CosAngle(SinAngle):
     r"""A cosine distribution. This is the same thing as a sine distribution,
     but with the domain shifted to `[-pi/2, pi/2]`. See SinAngle for more

--- a/pycbc/distributions/angular.py
+++ b/pycbc/distributions/angular.py
@@ -254,39 +254,6 @@ class SinAngle(UniformAngle):
             numpy.log(self._dfunc(
                 numpy.array([kwargs[p] for p in self._params]))).sum()
 
-
-    def rvs(self, size=1, param=None):
-        """Gives a set of random values drawn from this distribution.
-
-        Parameters
-        ----------
-        size : {1, int}
-            The number of values to generate; default is 1.
-        param : {None, string}
-            If provided, will just return values for the given parameter.
-            Otherwise, returns random values for each parameter.
-
-        Returns
-        -------
-        structured array
-            The random values in a numpy structured array. If a param was
-            specified, the array will only have an element corresponding to the
-            given parameter. Otherwise, the array will have an element for each
-            parameter in self's params.
-        """
-        if param is not None:
-            dtype = [(param, float)]
-        else:
-            dtype = [(p, float) for p in self.params]
-        arr = numpy.zeros(size, dtype=dtype)
-        for (p,_) in dtype:
-            arr[p] = self._arcfunc(numpy.random.uniform(
-                                    self._func(self._bounds[p][0]),
-                                    self._func(self._bounds[p][1]),
-                                    size=size))
-        return arr
-
-
 class CosAngle(SinAngle):
     r"""A cosine distribution. This is the same thing as a sine distribution,
     but with the domain shifted to `[-pi/2, pi/2]`. See SinAngle for more
@@ -475,40 +442,6 @@ class UniformSolidAngle(bounded.BoundedDist):
         """
         return self._polardist._logpdf(**kwargs) +\
             self._azimuthaldist._logpdf(**kwargs)
-
-
-    def rvs(self, size=1, param=None):
-        """Gives a set of random values drawn from this distribution.
-
-        Parameters
-        ----------
-        size : {1, int}
-            The number of values to generate; default is 1.
-        param : {None, string}
-            If provided, will just return values for the given parameter.
-            Otherwise, returns random values for each parameter.
-
-        Returns
-        -------
-        structured array
-            The random values in a numpy structured array. If a param was
-            specified, the array will only have an element corresponding to the
-            given parameter. Otherwise, the array will have an element for each
-            parameter in self's params.
-        """
-        if param is not None:
-            dtype = [(param, float)]
-        else:
-            dtype = [(p, float) for p in self.params]
-        arr = numpy.zeros(size, dtype=dtype)
-        for (p,_) in dtype:
-            if p == self._polar_angle:
-                arr[p] = self._polardist.rvs(size=size)
-            elif p == self._azimuthal_angle:
-                arr[p] = self._azimuthaldist.rvs(size=size)
-            else:
-                raise ValueError("unrecognized parameter %s" %(p))
-        return arr
 
     @classmethod
     def from_config(cls, cp, section, variable_args):

--- a/pycbc/distributions/bounded.py
+++ b/pycbc/distributions/bounded.py
@@ -17,6 +17,7 @@ This modules provides classes for evaluating distributions with bounds.
 """
 
 import warnings
+import numpy
 from six.moves.configparser import Error
 from pycbc import boundaries
 from pycbc import VARARGS_DELIM
@@ -314,7 +315,7 @@ class BoundedDist(object):
         for param in self.params:
             updated[param] = self._cdfinv_param(param, kwds[param])
         return updated
-        
+
     def rvs(self, size=1, **kwds):
         "Draw random value"
         draw = {}

--- a/pycbc/distributions/bounded.py
+++ b/pycbc/distributions/bounded.py
@@ -314,6 +314,13 @@ class BoundedDist(object):
         for param in self.params:
             updated[param] = self._cdfinv_param(param, kwds[param])
         return updated
+        
+    def rvs(self, size=1, **kwds):
+        "Draw random value"
+        draw = {}
+        for param in self.params:
+            draw[param] = numpy.random.uniform(0, 1, size=size)
+        return self.cdfinv(**draw)
 
     @classmethod
     def from_config(cls, cp, section, variable_args, bounds_required=False):

--- a/pycbc/distributions/gaussian.py
+++ b/pycbc/distributions/gaussian.py
@@ -199,40 +199,6 @@ class Gaussian(bounded.BoundedDist):
         else:
             return -numpy.inf
 
-
-    def rvs(self, size=1, param=None):
-        """Gives a set of random values drawn from this distribution.
-
-        Parameters
-        ----------
-        size : {1, int}
-            The number of values to generate; default is 1.
-        param : {None, string}
-            If provided, will just return values for the given parameter.
-            Otherwise, returns random values for each parameter.
-
-        Returns
-        -------
-        structured array
-            The random values in a numpy structured array. If a param was
-            specified, the array will only have an element corresponding to the
-            given parameter. Otherwise, the array will have an element for each
-            parameter in self's params.
-        """
-        if param is not None:
-            dtype = [(param, float)]
-        else:
-            dtype = [(p, float) for p in self.params]
-        arr = numpy.zeros(size, dtype=dtype)
-        for (p,_) in dtype:
-            sigma = numpy.sqrt(self._var[p])
-            mu = self._mean[p]
-            a,b = self._bounds[p]
-            arr[p][:] = scipy.stats.truncnorm.rvs((a-mu)/sigma, (b-mu)/sigma,
-                loc=self._mean[p], scale=sigma, size=size)
-        return arr
-
-
     @classmethod
     def from_config(cls, cp, section, variable_args):
         """Returns a Gaussian distribution based on a configuration file. The

--- a/pycbc/distributions/power_law.py
+++ b/pycbc/distributions/power_law.py
@@ -144,38 +144,6 @@ class UniformPowerLaw(bounded.BoundedDist):
     def lognorm(self):
         return self._lognorm
 
-    def rvs(self, size=1, param=None):
-        """Gives a set of random values drawn from this distribution.
-
-        Parameters
-        ----------
-        size : {1, int}
-            The number of values to generate; default is 1.
-        param : {None, string}
-            If provided, will just return values for the given parameter.
-            Otherwise, returns random values for each parameter.
-
-        Returns
-        -------
-        structured array
-            The random values in a numpy structured array. If a param was
-            specified, the array will only have an element corresponding to the
-            given parameter. Otherwise, the array will have an element for each
-            parameter in self's params.
-        """
-        if param is not None:
-            dtype = [(param, float)]
-        else:
-            dtype = [(p, float) for p in self.params]
-        arr = numpy.zeros(size, dtype=dtype)
-        for (p,_) in dtype:
-            offset = numpy.power(self._bounds[p][0], self.dim)
-            factor = numpy.power(self._bounds[p][1], self.dim) - \
-                                      numpy.power(self._bounds[p][0], self.dim)
-            arr[p] = numpy.random.uniform(0.0, 1.0, size=size)
-            arr[p] = numpy.power(factor * arr[p] + offset, 1.0 / self.dim)
-        return arr
-
     def _cdfinv_param(self, param, value):
         """Return inverse of cdf to map unit interval to parameter bounds.
         """

--- a/pycbc/distributions/uniform.py
+++ b/pycbc/distributions/uniform.py
@@ -137,37 +137,6 @@ class Uniform(bounded.BoundedDist):
         else:
             return -numpy.inf
 
-
-    def rvs(self, size=1, param=None):
-        """Gives a set of random values drawn from this distribution.
-
-        Parameters
-        ----------
-        size : {1, int}
-            The number of values to generate; default is 1.
-        param : {None, string}
-            If provided, will just return values for the given parameter.
-            Otherwise, returns random values for each parameter.
-
-        Returns
-        -------
-        structured array
-            The random values in a numpy structured array. If a param was
-            specified, the array will only have an element corresponding to the
-            given parameter. Otherwise, the array will have an element for each
-            parameter in self's params.
-        """
-        if param is not None:
-            dtype = [(param, float)]
-        else:
-            dtype = [(p, float) for p in self.params]
-        arr = numpy.zeros(size, dtype=dtype)
-        for (p,_) in dtype:
-            arr[p] = numpy.random.uniform(self._bounds[p][0],
-                                        self._bounds[p][1],
-                                        size=size)
-        return arr
-
     @classmethod
     def from_config(cls, cp, section, variable_args):
         """Returns a distribution based on a configuration file. The parameters

--- a/pycbc/distributions/uniform_log.py
+++ b/pycbc/distributions/uniform_log.py
@@ -50,38 +50,6 @@ class UniformLog10(uniform.Uniform):
         upper_bound = numpy.log10(self._bounds[param][1])
         return 10. ** ((upper_bound - lower_bound) * value + lower_bound)
 
-    def rvs(self, size=1, param=None):
-        """Gives a set of random values drawn from this distribution.
-
-        Parameters
-        ----------
-        size : {1, int}
-            The number of values to generate; default is 1.
-        param : {None, string}
-            If provided, will just return values for the given parameter.
-            Otherwise, returns random values for each parameter.
-
-        Returns
-        -------
-        structured array
-            The random values in a numpy structured array. If a param was
-            specified, the array will only have an element corresponding to the
-            given parameter. Otherwise, the array will have an element for each
-            parameter in self's params.
-        """
-
-        if param is not None:
-            dtype = [(param, float)]
-        else:
-            dtype = [(p, float) for p in self.params]
-        arr = numpy.zeros(size, dtype=dtype)
-        for (p,_) in dtype:
-            log_high = numpy.log10(self._bounds[p][0])
-            log_low = numpy.log10(self._bounds[p][1])
-            arr[p] = 10.0**(numpy.random.uniform(log_low, log_high, size=size))
-        return arr
-
-
     def _pdf(self, **kwargs):
         """Returns the pdf at the given values. The keyword arguments must
         contain all of parameters in self's params. Unrecognized arguments are


### PR DESCRIPTION
If we have a cdfinv, then we should just use it for the rvs function rather than duplicating code. 

@cdcapano One thing I didn't touch was the qnm.py distribution however I don't understand some of the things it is doing. Why is it dealing with constraints and renormalization? The join distirbution should do both those things? What is going on there?