### PR TITLE
Modify how libutils finds libraries

### DIFF
--- a/pycbc/libutils.py
+++ b/pycbc/libutils.py
@@ -167,7 +167,7 @@ def get_ctypes_library(libname, packages, mode=None):
     except ValueError:
         pass
     # We might be using conda/pip/virtualenv or some combination. This can
-    # leave lib files in a directory that LD_LIBRARY_PATH or pkg_config 
+    # leave lib files in a directory that LD_LIBRARY_PATH or pkg_config
     # can miss.
     libdirs.append(os.path.join(sys.base_prefix, "lib"))
 

--- a/pycbc/libutils.py
+++ b/pycbc/libutils.py
@@ -169,7 +169,7 @@ def get_ctypes_library(libname, packages, mode=None):
     # We might be using conda/pip/virtualenv or some combination. This can
     # leave lib files in a directory that LD_LIBRARY_PATH or pkg_config
     # can miss.
-    libdirs.append(os.path.join(sys.base_prefix, "lib"))
+    libdirs.append(os.path.join(sys.prefix, "lib"))
 
     # Note that the function below can accept an empty list for libdirs, in
     # which case it will return None

--- a/pycbc/libutils.py
+++ b/pycbc/libutils.py
@@ -136,6 +136,7 @@ def get_libpath_from_dirlist(libname, dirs):
             for libfile in os.listdir(nextdir):
                 if fnmatch.fnmatch(libfile,'lib'+libname+'.so*') or \
                         fnmatch.fnmatch(libfile,'lib'+libname+'.dylib*') or \
+                        fnmatch.fnmatch(libfile,'lib'+libname+'.*.dylib*') or \
                         fnmatch.fnmatch(libfile,libname+'.dll') or \
                         fnmatch.fnmatch(libfile,'cyg'+libname+'-*.dll'):
                     possible.append(libfile)
@@ -165,13 +166,14 @@ def get_ctypes_library(libname, packages, mode=None):
         libdirs += pkg_config_libdirs(packages)
     except ValueError:
         pass
-    # Next, if we are in a virtual environment, search inside its '/lib'
-    if "VIRTUAL_ENV" in os.environ:
-        libdirs.append(os.path.join(os.environ["VIRTUAL_ENV"], "lib"))
+    # We might be using conda/pip/virtualenv or some combination. This can
+    # leave lib files in a directory that LD_LIBRARY_PATH or pkg_config 
+    # can miss.
+    libdirs.append(os.path.join(sys.base_prefix, "lib"))
 
-    # Note that the function below can accept an empty list for libdirs, in which case
-    # it will return None
-    fullpath = get_libpath_from_dirlist(libname,libdirs)
+    # Note that the function below can accept an empty list for libdirs, in
+    # which case it will return None
+    fullpath = get_libpath_from_dirlist(libname, libdirs)
 
     if fullpath is None:
         # This won't actually return a full-path, but it should be something
@@ -185,4 +187,4 @@ def get_ctypes_library(libname, packages, mode=None):
         if mode is None:
             return ctypes.CDLL(fullpath)
         else:
-            return ctypes.CDLL(fullpath,mode=mode)
+            return ctypes.CDLL(fullpath, mode=mode)


### PR DESCRIPTION
I've been seeing some weird cases where `pip install mkl` followed by `import pycbc.fft.mkl` reports that mkl is not present in the environment. This appears to be due to how libutils is trying to find libraries, and the weirdness in how python does this, especially when conda, or venvs are in play.

The current system looks in LD_LIBRARY_PATH, pkg_config paths and an explicit path if a venv is being used. This doesn't work for conda, doesn't work if the user is doing something like spawning a venv from a conda env and doesn't work for the unittest environment (I'm not exactly sure what tox is doing!)

I tried some simple ways to patch around this, but it didn't seem to work. A more hacky solution, like the one below, does seem to work. I think we need to fix this problem because we do want `pip install mkl` to work. For e.g. a lot of users now use things like SciServer, currently the *only* workable FFT option there is numpy! The more "simple" patch covers many of the use cases, but didn't work for the test suite, so I went with this. Other options for achieving the same goal would be welcomed! Perhaps we need to explicitly ask conda/pip if it has installed the file we are looking for.

.... Also on macs the dylib files were not matching the globs being used (libmkl_rt.1.dylib didn't match), I added support for that file-naming as well.