### PR TITLE
The Bank class stuff in waveform has some python3 issues

### DIFF
--- a/bin/pycbc_compress_bank
+++ b/bin/pycbc_compress_bank
@@ -127,7 +127,7 @@ logging.info("loading bank")
 # cast to single when saving the waveforms
 dtype = numpy.complex128
 
-bank = waveform.FilterBank(args.bank_file, N/2+1, df, dtype,
+bank = waveform.FilterBank(args.bank_file, N//2+1, df, dtype,
                            low_frequency_cutoff=args.low_frequency_cutoff,
                            approximant=args.approximant,
                            enable_compressed_waveforms=False)
@@ -144,7 +144,7 @@ output = bank.write_to_hdf(args.output, force=args.force,
 
 # get the psd
 logging.info("getting psd")
-psd = pycbc.psd.from_cli(args, length=N/2+1, delta_f=df,
+psd = pycbc.psd.from_cli(args, length=N//2+1, delta_f=df,
                          low_frequency_cutoff=templates.f_lower.min(),
                          dyn_range_factor=pycbc.DYN_RANGE_FAC,
                          precision='double')

--- a/pycbc/waveform/bank.py
+++ b/pycbc/waveform/bank.py
@@ -425,7 +425,6 @@ class TemplateBank(object):
         f.attrs['parameters'] = parameters
         write_tbl = self.table[start_index:stop_index]
         for p in parameters:
-            print (write_tbl[p].dtype)
             f[p] = write_tbl[p]
         if write_compressed_waveforms and self.has_compressed_waveforms:
             for tmplt_hash in write_tbl.template_hash:

--- a/pycbc/waveform/bank.py
+++ b/pycbc/waveform/bank.py
@@ -25,6 +25,7 @@
 """
 This module provides classes that describe banks of waveforms
 """
+import sys
 import types
 import logging
 import os.path
@@ -337,7 +338,13 @@ class TemplateBank(object):
         # (if anything was in the file)
         if approximant is not None:
             # get the approximant for each template
-            apprxs = self.parse_approximant(approximant)
+            # FIXME: Remove if block once python2 is retired
+            if sys.version_info >= (3, 0):
+                dtype = h5py.string_dtype(encoding='utf-8')
+                apprxs = np.array(self.parse_approximant(approximant),
+                                  dtype=dtype)
+            else:
+                apprxs = self.parse_approximant(approximant)
             if 'approximant' not in self.table.fieldnames:
                 self.table = self.table.add_fields(apprxs, 'approximant')
             else:
@@ -418,6 +425,7 @@ class TemplateBank(object):
         f.attrs['parameters'] = parameters
         write_tbl = self.table[start_index:stop_index]
         for p in parameters:
+            print (write_tbl[p].dtype)
             f[p] = write_tbl[p]
         if write_compressed_waveforms and self.has_compressed_waveforms:
             for tmplt_hash in write_tbl.template_hash:


### PR DESCRIPTION
The compress_bank code is currently not working in python3. This is because of a few python2-isms in the executable which need fixing, and an issue in the module code in waveform/bank.

The python2 fixes are trivial, the waveform/bank is the same "HDF doesn't understand how to write arrays of strings" problem. I think that use of the `h5py.string_dtype` is a neat way to resolve this, as then we continue to treat this as a `str` object in pycbc code, and HDF will encode this as needed when writing to the file. I have a feeling though that there might be numerous instances of code blocks with similar issues. I guess we will uncover them as we continue testing all the codes.

In this case I'm adding this to the unittests in #3742.