### PR TITLE
pycbc_multi_inspiral time delay change

### DIFF
--- a/bin/pycbc_multi_inspiral
+++ b/bin/pycbc_multi_inspiral
@@ -664,11 +664,8 @@ with ctx:
                                          coherent_ifo_triggers[ifo] /
                                          norm_dict[ifo], norm_dict[ifo],
                                          coinc_idx_det_frame[ifo]+stilde[ifo].analyze.start)
-                    # snr_ts[ifo] (the SNR timeseries directly from matched filtering)
-                    # is used here because autochisq runs into index error with snr[ifo] padded
-                    # by segment padding options
                     ifo_out_vals['cont_chisq'] = autochisq.values(
-                        snr_ts[ifo], coinc_idx_det_frame[ifo]+stilde[ifo].analyze.start,
+                        snr[ifo] / norm_dict[ifo], coinc_idx_det_frame[ifo],
                         template, stilde[ifo].psd, norm_dict[ifo],
                         stilde=stilde[ifo], low_frequency_cutoff=flow)
                     ifo_out_vals['chisq'] = chisq[ifo]

--- a/bin/pycbc_multi_inspiral
+++ b/bin/pycbc_multi_inspiral
@@ -653,7 +653,7 @@ with ctx:
                                                         network_chisq_dict)
                 else:
                     reweighted_snr = pycbc_reweight_snr(
-                        abs(snr[opt.instruments[0]][coinc_idx]), network_chisq_dict)
+                        abs(snr[opt.instruments[0]][coinc_idx_det_frame[opt.instruments[0]]]), network_chisq_dict)
 
                 # Need all out vals to be the same length. This means the
                 # entries that are single values need to be repeated once
@@ -665,9 +665,11 @@ with ctx:
                         bank_chisq.values(template, stilde[ifo].psd, stilde[ifo],
                                          coherent_ifo_triggers[ifo] /
                                          norm_dict[ifo], norm_dict[ifo],
-                                         coinc_idx+stilde[ifo].analyze.start)
+                                         coinc_idx_det_frame[ifo]+stilde[ifo].analyze.start)
+                    # snr_ts[ifo] is used here because autochisq runs into index error with snr[ifo] padded
+                    # by segment padding options
                     ifo_out_vals['cont_chisq'] = autochisq.values(
-                        snr[ifo], coinc_idx+stilde[ifo].analyze.start,
+                        snr_ts[ifo], coinc_idx_det_frame[ifo]+stilde[ifo].analyze.start,
                         template, stilde[ifo].psd, norm_dict[ifo],
                         stilde=stilde[ifo], low_frequency_cutoff=flow)
                     ifo_out_vals['chisq'] = chisq[ifo]
@@ -686,7 +688,7 @@ with ctx:
                     network_out_vals['coherent_snr'] = np.real(rho_coinc)
                 else:
                     network_out_vals['coherent_snr'] = \
-                        abs(snr[opt.instruments[0]][coinc_idx])
+                        abs(snr[opt.instruments[0]][coinc_idx_det_frame[opt.instruments[0]]])
                 network_out_vals['reweighted_snr'] = reweighted_snr
                 network_out_vals['time_index'] = \
                     coinc_idx+stilde[ifo].cumulative_index

--- a/bin/pycbc_multi_inspiral
+++ b/bin/pycbc_multi_inspiral
@@ -241,7 +241,7 @@ def coherent_snr(snr_triggers, index, threshold, projection_matrix,
     rho_coh = rho_coh[rho_coh > threshold]
     return rho_coh, index, snrv, coinc_snr
 
-def coincident_snr(snr_dict, index, threshold, time_delay):
+def coincident_snr(snr_dict, index, threshold, time_delay_idx):
     """
     Output: rho_coinc: Coincident snr triggers
             index    : The subset of input index that survive the cuts
@@ -250,10 +250,10 @@ def coincident_snr(snr_dict, index, threshold, time_delay):
     Input: snr_dict: Dictionary of individual detector SNRs
            index   : Geocent indexes you want to find coinc SNR for
            threshold: Indexes with coinc SNR below this threshold are cut
-           time_delay: Dictionary of time delay for each detector
+           time_delay_idx: Dictionary of time delay in indices for each detector
     """
     #Restrict the snr timeseries to just the interesting points
-    coinc_triggers = {ifo : snr_dict[ifo][index+time_delay[ifo]] for ifo in snr_dict.keys()}
+    coinc_triggers = {ifo : snr_dict[ifo][index+time_delay_idx[ifo]] for ifo in snr_dict.keys()}
     #Calculate the coincident snr
     snr_array = np.array([coinc_triggers[ifo]
                         for ifo in coinc_triggers.keys()])
@@ -261,7 +261,7 @@ def coincident_snr(snr_dict, index, threshold, time_delay):
     #Apply threshold
     thresh_indexes = rho_coinc > threshold
     index = index[thresh_indexes]
-    coinc_triggers = {ifo : snr_dict[ifo][index+time_delay[ifo]] for ifo in snr_dict.keys()}
+    coinc_triggers = {ifo : snr_dict[ifo][index+time_delay_idx[ifo]] for ifo in snr_dict.keys()}
     rho_coinc = rho_coinc[thresh_indexes]
     return rho_coinc, index, coinc_triggers
 
@@ -570,10 +570,10 @@ with ctx:
                 if len(snr[ifo])==0:
                     raise ValueError('The SNR triggers dictionary is empty.\
                                      This should not be possible.')
-                #Apply time delay
-                # This operation is expensive and was causing incorrect chisq values
-                # Time delay will be applied by adding it to indices instead
-                # snr[ifo].roll(-time_delay_idx[ifo])
+
+            # Time delay is applied to indices
+            coinc_idx_det_frame = {ifo: coinc_idx + time_delay_idx[ifo]
+                                   for ifo in opt.instruments}
 
             #Calculate the coincident and coherent snr
             #Check we have data before we try to compute the coherent snr
@@ -590,7 +590,7 @@ with ctx:
             # triggers from ifo
             elif len(coinc_idx) != 0 and nifo==1:
                 coinc_triggers = {opt.instruments[0] :
-                                      snr[opt.instruments[0]][coinc_idx+time_delay_idx[opt.instruments[0]]]}
+                                      snr[opt.instruments[0]][coinc_idx_det_frame[opt.instruments[0]]]}
             else:
                 coinc_triggers = {}
                 logging.info("No triggers above coincident SNR threshold")
@@ -619,8 +619,6 @@ with ctx:
             # To do this it is useful to find the indexes of coinc triggers
             # in the detector frame.
             if len(coinc_idx) != 0:
-                coinc_idx_det_frame = {ifo : coinc_idx + time_delay_idx[ifo]
-                                      for ifo in opt.instruments}
                 coherent_ifo_triggers = {ifo : snr[ifo][coinc_idx_det_frame[ifo]]
                                         for ifo in opt.instruments}
 
@@ -666,7 +664,8 @@ with ctx:
                                          coherent_ifo_triggers[ifo] /
                                          norm_dict[ifo], norm_dict[ifo],
                                          coinc_idx_det_frame[ifo]+stilde[ifo].analyze.start)
-                    # snr_ts[ifo] is used here because autochisq runs into index error with snr[ifo] padded
+                    # snr_ts[ifo] (the SNR timeseries directly from matched filtering)
+                    # is used here because autochisq runs into index error with snr[ifo] padded
                     # by segment padding options
                     ifo_out_vals['cont_chisq'] = autochisq.values(
                         snr_ts[ifo], coinc_idx_det_frame[ifo]+stilde[ifo].analyze.start,

--- a/bin/pycbc_multi_inspiral
+++ b/bin/pycbc_multi_inspiral
@@ -241,7 +241,7 @@ def coherent_snr(snr_triggers, index, threshold, projection_matrix,
     rho_coh = rho_coh[rho_coh > threshold]
     return rho_coh, index, snrv, coinc_snr
 
-def coincident_snr(snr_dict, index, threshold):
+def coincident_snr(snr_dict, index, threshold, time_delay):
     """
     Output: rho_coinc: Coincident snr triggers
             index    : The subset of input index that survive the cuts
@@ -252,7 +252,7 @@ def coincident_snr(snr_dict, index, threshold):
            threshold: Indexes with coinc SNR below this threshold are cut
     """
     #Restrict the snr timeseries to just the interesting points
-    coinc_triggers = {ifo : snr_dict[ifo][index] for ifo in snr_dict.keys()}
+    coinc_triggers = {ifo : snr_dict[ifo][index+time_delay[ifo]] for ifo in snr_dict.keys()}
     #Calculate the coincident snr
     snr_array = np.array([coinc_triggers[ifo]
                         for ifo in coinc_triggers.keys()])
@@ -260,7 +260,7 @@ def coincident_snr(snr_dict, index, threshold):
     #Apply threshold
     thresh_indexes = rho_coinc > threshold
     index = index[thresh_indexes]
-    coinc_triggers = {ifo : snr_dict[ifo][index] for ifo in snr_dict.keys()}
+    coinc_triggers = {ifo : snr_dict[ifo][index+time_delay[ifo]] for ifo in snr_dict.keys()}
     rho_coinc = rho_coinc[thresh_indexes]
     return rho_coinc, index, coinc_triggers
 
@@ -570,14 +570,16 @@ with ctx:
                     raise ValueError('The SNR triggers dictionary is empty.\
                                      This should not be possible.')
                 #Apply time delay
-                snr[ifo].roll(-time_delay_idx[ifo])
+                # This operation is expensive and was causing incorrect chisq values
+                # Time delay will be applied by adding it to indices instead
+                # snr[ifo].roll(-time_delay_idx[ifo])
 
             #Calculate the coincident and coherent snr
             #Check we have data before we try to compute the coherent snr
             if len(coinc_idx) != 0 and nifo > 1:
                 #Find coinc snr at trigger times and apply coinc snr threshold
                 rho_coinc, coinc_idx, coinc_triggers =\
-                    coincident_snr(snr, coinc_idx, opt.coinc_threshold)
+                    coincident_snr(snr, coinc_idx, opt.coinc_threshold, time_delay_idx)
                 logging.info("%s points above coincident SNR threshold" % \
                              str(len(coinc_idx)))
                 if len(coinc_idx) != 0:

--- a/bin/pycbc_multi_inspiral
+++ b/bin/pycbc_multi_inspiral
@@ -247,9 +247,10 @@ def coincident_snr(snr_dict, index, threshold, time_delay):
             index    : The subset of input index that survive the cuts
             coinc_triggers: Dictionary of individual detector SNRs at
                             indexes that survive cuts
-    Input: snr_dict: Dictionary of individual detector SNRs in geocent time
+    Input: snr_dict: Dictionary of individual detector SNRs
            index   : Geocent indexes you want to find coinc SNR for
            threshold: Indexes with coinc SNR below this threshold are cut
+           time_delay: Dictionary of time delay for each detector
     """
     #Restrict the snr timeseries to just the interesting points
     coinc_triggers = {ifo : snr_dict[ifo][index+time_delay[ifo]] for ifo in snr_dict.keys()}
@@ -588,7 +589,8 @@ with ctx:
             # If there is only one ifo, then coinc_triggers is just the
             # triggers from ifo
             elif len(coinc_idx) != 0 and nifo==1:
-                coinc_triggers = {opt.instruments[0] : snr[opt.instruments[0]][coinc_idx]}
+                coinc_triggers = {opt.instruments[0] :
+                                      snr[opt.instruments[0]][coinc_idx+time_delay_idx[opt.instruments[0]]]}
             else:
                 coinc_triggers = {}
                 logging.info("No triggers above coincident SNR threshold")
@@ -619,7 +621,7 @@ with ctx:
             if len(coinc_idx) != 0:
                 coinc_idx_det_frame = {ifo : coinc_idx + time_delay_idx[ifo]
                                       for ifo in opt.instruments}
-                coherent_ifo_triggers = {ifo : snr[ifo][coinc_idx]
+                coherent_ifo_triggers = {ifo : snr[ifo][coinc_idx_det_frame[ifo]]
                                         for ifo in opt.instruments}
 
                 # Calculate the power and autochi2 values for the coinc indexes
@@ -633,7 +635,7 @@ with ctx:
                         coherent_ifo_triggers[ifo] / norm_dict[ifo],
                         norm_dict[ifo],
                         stilde[ifo].psd,
-                        coinc_idx + stilde[ifo].analyze.start,
+                        coinc_idx_det_frame[ifo] + stilde[ifo].analyze.start,
                         template)
 
                 # Calculate network chisq value


### PR DESCRIPTION
This is my attempt at resolving #3753. My testing has shown that these changes produce the same results for the functions that should give the same results (i.e. coincident SNR, coherent SNR, null SNR) and that the chisq tests give similar values to coh_ptf.

This also fixes an error with the auto chisq test. When segment padding options are greater than 0 and auto chisq is used, it will hit an index error because the length of the SNR array is not long enough for the indices that are being passed. I believe I have fixed that by using the SNR array without padding.

I would like to provide some results to prove that this works, but am not sure what sort of tests to run to properly do so. If there are any issues or improvements I can make, I am happy to hear them.