### PR TITLE
Fix bug that can break dynesty parallelization

### DIFF
--- a/pycbc/inference/sampler/dynesty.py
+++ b/pycbc/inference/sampler/dynesty.py
@@ -162,7 +162,9 @@ class DynestySampler(BaseSampler):
                           'propose_point',
                           'update_proposal',
                           '_UPDATE', '_PROPOSE',
-                          'evolve_point']
+                          'evolve_point', 'use_pool', 'queue_size',
+                          'use_pool_ptform', 'use_pool_logl',
+                          'use_pool_evolve']
 
     def run(self):
         diff_niter = 1

--- a/pycbc/pool.py
+++ b/pycbc/pool.py
@@ -126,7 +126,6 @@ def use_mpi(require_mpi=False, log=True):
     """ Get whether MPI is enabled and if so the current size and rank
     """
     use_mpi = False
-    size = rank = 0
     try:
         from mpi4py import MPI
         comm = MPI.COMM_WORLD
@@ -141,6 +140,8 @@ def use_mpi(require_mpi=False, log=True):
         if require_mpi:
             print(e)
             raise ValueError("Failed to load mpi, ensure mpi4py is installed")
+    if not use_mpi:
+        size = rank = 0
     return use_mpi, size, rank
 
 def choose_pool(processes, mpi=False):


### PR DESCRIPTION
Currently, `choose_pool` will incorrectly set `pool.size = 1` if you use python multiprocessing instead of MPI and you have `mpi4py` installed in your environment. This is a serious problem if you are using dynesty: `pool.size` is used by dynesty to determine how many parallel proposal points to generate (it sets the sampler's `queue_size`; see [this function](https://github.com/joshspeagle/dynesty/blob/master/py/dynesty/sampler.py#L340)). If pool.size is 1, it will only ever generate one proposal point at a time, rather than a batch. The result is that the pool is setup, but then only one process in that pool is only used, making it no faster than just running on a single core. This fixes this by appropriately setting `pool.size` if `use_mpi` is False.

This also ensures that `queue_size` and other pool-related sampler attributes are not included in dynesty's checkpoint. Without this, dynesty will continue to use whatever was used in the checkpoint, regardless of how many cores you are currently using. This can be a problem if, e.g., you start a run using a smaller set of cores, then increase it at a later point.