### PR TITLE
Fix precision edge-case bug in geometric template bank code

### DIFF
--- a/pycbc/tmpltbank/brute_force_methods.py
+++ b/pycbc/tmpltbank/brute_force_methods.py
@@ -320,10 +320,10 @@ def get_mass_distribution(bestMasses, scaleFactor, massRangeParams,
     # larger than any thresholds used in the functions in brute_force_utils.py
     # and will always be rejected. An unphysical value cannot be used as it
     # would result in unphysical metric distances and cause failures.
-    totmass[mass1 < massRangeParams.minMass1] = 0.0001
-    totmass[mass1 > massRangeParams.maxMass1] = 0.0001
-    totmass[mass2 < massRangeParams.minMass2] = 0.0001
-    totmass[mass2 > massRangeParams.maxMass2] = 0.0001
+    totmass[mass1 < massRangeParams.minMass1*0.9999] = 0.0001
+    totmass[mass1 > massRangeParams.maxMass1*1.0001] = 0.0001
+    totmass[mass2 < massRangeParams.minMass2*0.9999] = 0.0001
+    totmass[mass2 > massRangeParams.maxMass2*1.0001] = 0.0001
     # There is some numerical error which can push this a bit higher. We do
     # *not* want to reject the initial guide point. This error comes from
     # Masses -> totmass, eta -> masses conversion, we will have points pushing


### PR DESCRIPTION
I'm adding a test workflow for template bank generation as part of the pegasus5 patch. This workflow caught an edge case bug where numerical precision issues can cause failures in the template bank code (e.g. a point on the parameter space boundary can fall over to the other side of the boundary, and break everything). There were already some catches for this, but in this place it was missing .... This code perhaps needs an overhaul, but this fix is, I think, a simple one (see for e.g. the lines underneath where the patch is applied).