### PR TITLE
Avoid div by 0 error if magnitude is exactly 0

### DIFF
--- a/pycbc/coordinates.py
+++ b/pycbc/coordinates.py
@@ -83,7 +83,7 @@ def cartesian_to_spherical_polar(x, y, z):
         return numpy.arccos(z / rho) if rho else 0.0
     else:
         return numpy.arccos(numpy.divide(z, rho, out=numpy.ones_like(z),
-                                         where=rho!=0))
+                                         where=rho != 0))
 
 
 def cartesian_to_spherical(x, y, z):

--- a/pycbc/coordinates.py
+++ b/pycbc/coordinates.py
@@ -79,7 +79,8 @@ def cartesian_to_spherical_polar(x, y, z):
         The polar angle.
     """
     rho = cartesian_to_spherical_rho(x, y, z)
-    return numpy.arccos(z / rho) if rho else 0.0
+    return numpy.arccos(numpy.divide(z, rho, out=numpy.zeros_like(z),
+                                     where=rho!=0))
 
 
 def cartesian_to_spherical(x, y, z):

--- a/pycbc/coordinates.py
+++ b/pycbc/coordinates.py
@@ -79,8 +79,11 @@ def cartesian_to_spherical_polar(x, y, z):
         The polar angle.
     """
     rho = cartesian_to_spherical_rho(x, y, z)
-    return numpy.arccos(numpy.divide(z, rho, out=numpy.zeros_like(z),
-                                     where=rho!=0))
+    if numpy.isscalar(rho):
+        return numpy.arccos(z / rho) if rho else 0.0
+    else:
+        return numpy.arccos(numpy.divide(z, rho, out=numpy.ones_like(z),
+                                         where=rho!=0))
 
 
 def cartesian_to_spherical(x, y, z):

--- a/pycbc/coordinates.py
+++ b/pycbc/coordinates.py
@@ -78,7 +78,8 @@ def cartesian_to_spherical_polar(x, y, z):
     theta : {numpy.array, float}
         The polar angle.
     """
-    return numpy.arccos(z / cartesian_to_spherical_rho(x, y, z))
+    rho = cartesian_to_spherical_rho(x, y, z)
+    return numpy.arccos(z / rho) if rho else 0.0
 
 
 def cartesian_to_spherical(x, y, z):


### PR DESCRIPTION
Passing a spin vector that is exactly zero in cartesian components to `cartesian_to_spherical_polar` would cause a divide by zero error. This should probably just return zero components instead.