### PR TITLE
Fix analysis time

### DIFF
--- a/pycbc/inference/models/gaussian_noise.py
+++ b/pycbc/inference/models/gaussian_noise.py
@@ -112,6 +112,7 @@ class BaseGaussianNoise(BaseDataModel):
     normalize
     lognorm
     """
+
     def __init__(self, variable_params, data, low_frequency_cutoff, psds=None,
                  high_frequency_cutoff=None, normalize=False,
                  static_params=None, ignore_failed_waveforms=False,
@@ -146,12 +147,13 @@ class BaseGaussianNoise(BaseDataModel):
             self.all_ifodata_same_rate_length = True
         else:
             self.all_ifodata_same_rate_length = False
-            logging.info("You are using different data segment lengths or sampling rates for different IFOs")
+            logging.info(
+                "You are using different data segment lengths or sampling rates for different IFOs")
 
         # store the number of samples in the time domain
         self._N = {}
         for (det, d) in self._data.items():
-            self._N[det] = int(1./(d.delta_f*d.delta_t)) 
+            self._N[det] = int(1./(d.delta_f*d.delta_t))
 
         # set lower/upper frequency cutoff
         if high_frequency_cutoff is None:
@@ -464,7 +466,7 @@ class BaseGaussianNoise(BaseDataModel):
             # computation as an attribute if one was provided the user
             if self._f_upper[det] is not None:
                 fp.attrs['{}_likelihood_high_freq'.format(det)] = \
-                                                        self._f_upper[det]
+                    self._f_upper[det]
 
     @staticmethod
     def _fd_data_from_strain_dict(opts, strain_dict, psd_strain_dict):
@@ -580,7 +582,8 @@ class BaseGaussianNoise(BaseDataModel):
                                              _tdict[det].end_time)
             # gate overwhitened if desired
             if opts.gate_overwhitened and opts.gate is not None:
-                stilde_dict = gate_overwhitened_data(stilde_dict, psds, opts.gate)
+                stilde_dict = gate_overwhitened_data(
+                    stilde_dict, psds, opts.gate)
             data = stilde_dict
         args.update({'data': data, 'psds': psds})
         # any extra args
@@ -813,7 +816,7 @@ class GaussianNoise(BaseGaussianNoise):
             high_frequency_cutoff=high_frequency_cutoff, normalize=normalize,
             static_params=static_params, **kwargs)
         # Determine if all data have the same sampling rate and segment length
-        if self.all_ifodata_same_rate_length == True:
+        if self.all_ifodata_same_rate_length:
             # create a waveform generator for all ifos
             self.waveform_generator = create_waveform_generator(
                 self.variable_params, self.data,
@@ -825,7 +828,7 @@ class GaussianNoise(BaseGaussianNoise):
             self.waveform_generator = {}
             for det in self.data:
                 self.waveform_generator[det] = create_waveform_generator(
-                    self.variable_params, {det:self.data[det]},
+                    self.variable_params, {det: self.data[det]},
                     waveform_transforms=self.waveform_transforms,
                     recalibration=self.recalibration,
                     gates=self.gates, **self.static_params)
@@ -1070,11 +1073,12 @@ def get_values_from_injection(cp, injection_file, update_cp=True):
             cp.set(sec, opt, replace_val)
     return replace_params
 
+
 def create_waveform_generator(
-                variable_params, data, waveform_transforms=None,
-                recalibration=None, gates=None,
-                generator_class=generator.FDomainDetFrameGenerator,
-                **static_params):
+        variable_params, data, waveform_transforms=None,
+        recalibration=None, gates=None,
+        generator_class=generator.FDomainDetFrameGenerator,
+        **static_params):
     r"""Creates a waveform generator for use with a model.
 
     Parameters

--- a/pycbc/inference/models/gaussian_noise.py
+++ b/pycbc/inference/models/gaussian_noise.py
@@ -1054,6 +1054,8 @@ def get_values_from_injection(cp, injection_file, update_cp=True):
             cp.set(sec, opt, replace_val)
     return replace_params
 
+def multidf_create_waveform_generator
+
 
 def create_waveform_generator(
                 variable_params, data, waveform_transforms=None,
@@ -1128,3 +1130,6 @@ def create_waveform_generator(
         recalib=recalibration, gates=gates,
         **static_params)
     return waveform_generator
+    #Rather, return a list of waveform_generator
+    # Two sets of mapping: det --> delta_f
+                        # delta_f --> waveform_generator

--- a/pycbc/inference/models/gaussian_noise.py
+++ b/pycbc/inference/models/gaussian_noise.py
@@ -148,7 +148,8 @@ class BaseGaussianNoise(BaseDataModel):
         else:
             self.all_ifodata_same_rate_length = False
             logging.info(
-                "You are using different data segment lengths or sampling rates for different IFOs")
+                "You are using different data segment lengths or "
+                "sampling rates for different IFOs")
 
         # store the number of samples in the time domain
         self._N = {}
@@ -870,7 +871,7 @@ class GaussianNoise(BaseGaussianNoise):
         """
         params = self.current_params
         try:
-            if self.all_ifodata_same_rate_length == True:
+            if self.all_ifodata_same_rate_length:
                 wfs = self.waveform_generator.generate(**params)
             else:
                 wfs = {}

--- a/pycbc/inference/models/gaussian_noise.py
+++ b/pycbc/inference/models/gaussian_noise.py
@@ -817,9 +817,9 @@ class GaussianNoise(BaseGaussianNoise):
         dfs = numpy.array([d.delta_f for d in self.data.values()])
         startts = numpy.array([d.start_time for d in self.data.values()])
         endts = numpy.array([d.end_time for d in self.data.values()])
-        if all([dts == dts[0], dfs == dfs[0], startts == startts[0], endts == endts[0]]):
+        if all(dts == dts[0]) and all(dfs == dfs[0]) and all(startts == startts[0]) and all(endts == endts[0]):
             self.all_ifodata_same_length = True
-            # create the waveform generator
+            # create a single waveform generator for all ifos
             self.waveform_generator = create_waveform_generator(
                 self.variable_params, self.data,
                 waveform_transforms=self.waveform_transforms,
@@ -827,10 +827,11 @@ class GaussianNoise(BaseGaussianNoise):
                 gates=self.gates, **self.static_params)
         else:
             self.all_ifodata_same_length = False
-            # create the waveform generator
-            for (det, d) in self.data.items():
+            # create the waveform generator for each ifo
+            self.waveform_generator = {}
+            for det in self.data:
                 self.waveform_generator[det] = create_waveform_generator(
-                    self.variable_params, self.data[det],
+                    self.variable_params, {det:self.data[det]},
                     waveform_transforms=self.waveform_transforms,
                     recalibration=self.recalibration,
                     gates=self.gates, **self.static_params)
@@ -1149,6 +1150,3 @@ def create_waveform_generator(
         recalib=recalibration, gates=gates,
         **static_params)
     return waveform_generator
-    #Rather, return a list of waveform_generator
-    # Two sets of mapping: det --> delta_f
-                        # delta_f --> waveform_generator

--- a/pycbc/inference/models/marginalized_gaussian_noise.py
+++ b/pycbc/inference/models/marginalized_gaussian_noise.py
@@ -213,13 +213,25 @@ class MarginalizedPolarization(BaseGaussianNoise):
             variable_params, data, low_frequency_cutoff, psds=psds,
             high_frequency_cutoff=high_frequency_cutoff, normalize=normalize,
             static_params=static_params, **kwargs)
-        # create the waveform generator
-        self.waveform_generator = create_waveform_generator(
-            self.variable_params, self.data,
-            waveform_transforms=self.waveform_transforms,
-            recalibration=self.recalibration,
-            generator_class=generator.FDomainDetFrameTwoPolGenerator,
-            gates=self.gates, **self.static_params)
+        # Determine if all data have the same sampling rate and segment length
+        if self.all_ifodata_same_rate_length == True:
+            # create a waveform generator for all ifos
+            self.waveform_generator = create_waveform_generator(
+                self.variable_params, self.data,
+                waveform_transforms=self.waveform_transforms,
+                recalibration=self.recalibration,
+                generator_class=generator.FDomainDetFrameTwoPolGenerator,
+                gates=self.gates, **self.static_params)
+        else:
+            # create a waveform generator for each ifo respestively
+            self.waveform_generator = {}
+            for det in self.data:
+                self.waveform_generator[det] = create_waveform_generator(
+                    self.variable_params, {det:self.data[det]},
+                    waveform_transforms=self.waveform_transforms,
+                    recalibration=self.recalibration,
+                    generator_class=generator.FDomainDetFrameTwoPolGenerator,
+                    gates=self.gates, **self.static_params)
 
         self.polarization_samples = polarization_samples
         self.pol = numpy.linspace(0, 2*numpy.pi, self.polarization_samples)
@@ -262,7 +274,12 @@ class MarginalizedPolarization(BaseGaussianNoise):
         """
         params = self.current_params
         try:
-            wfs = self.waveform_generator.generate(**params)
+            if self.all_ifodata_same_rate_length == True:
+                wfs = self.waveform_generator.generate(**params)
+            else:
+                wfs = {}
+                for det in self.data:
+                    wfs.update(self.waveform_generator[det].generate(**params))
         except NoWaveformError:
             return self._nowaveform_loglr()
         except FailedWaveformError as e:

--- a/pycbc/inference/models/marginalized_gaussian_noise.py
+++ b/pycbc/inference/models/marginalized_gaussian_noise.py
@@ -25,7 +25,7 @@ from scipy import special
 from pycbc.waveform import generator
 from pycbc.waveform import (NoWaveformError, FailedWaveformError)
 from pycbc.detector import Detector
-from .gaussian_noise import (BaseGaussianNoise, create_waveform_generator)
+from .gaussian_noise import (BaseGaussianNoise, create_waveform_generator, GaussianNoise)
 
 
 class MarginalizedPhaseGaussianNoise(GaussianNoise):

--- a/pycbc/inference/models/marginalized_gaussian_noise.py
+++ b/pycbc/inference/models/marginalized_gaussian_noise.py
@@ -214,7 +214,7 @@ class MarginalizedPolarization(BaseGaussianNoise):
             high_frequency_cutoff=high_frequency_cutoff, normalize=normalize,
             static_params=static_params, **kwargs)
         # Determine if all data have the same sampling rate and segment length
-        if self.all_ifodata_same_rate_length == True:
+        if self.all_ifodata_same_rate_length:
             # create a waveform generator for all ifos
             self.waveform_generator = create_waveform_generator(
                 self.variable_params, self.data,

--- a/pycbc/inference/models/marginalized_gaussian_noise.py
+++ b/pycbc/inference/models/marginalized_gaussian_noise.py
@@ -25,8 +25,8 @@ from scipy import special
 from pycbc.waveform import generator
 from pycbc.waveform import (NoWaveformError, FailedWaveformError)
 from pycbc.detector import Detector
-from .gaussian_noise import (BaseGaussianNoise, 
-                             create_waveform_generator, 
+from .gaussian_noise import (BaseGaussianNoise,
+                             create_waveform_generator,
                              GaussianNoise)
 
 

--- a/pycbc/inference/models/marginalized_gaussian_noise.py
+++ b/pycbc/inference/models/marginalized_gaussian_noise.py
@@ -227,7 +227,7 @@ class MarginalizedPolarization(BaseGaussianNoise):
             self.waveform_generator = {}
             for det in self.data:
                 self.waveform_generator[det] = create_waveform_generator(
-                    self.variable_params, {det:self.data[det]},
+                    self.variable_params, {det: self.data[det]},
                     waveform_transforms=self.waveform_transforms,
                     recalibration=self.recalibration,
                     generator_class=generator.FDomainDetFrameTwoPolGenerator,
@@ -274,7 +274,7 @@ class MarginalizedPolarization(BaseGaussianNoise):
         """
         params = self.current_params
         try:
-            if self.all_ifodata_same_rate_length == True:
+            if self.all_ifodata_same_rate_length:
                 wfs = self.waveform_generator.generate(**params)
             else:
                 wfs = {}
@@ -445,7 +445,7 @@ class MarginalizedHMPolPhase(BaseGaussianNoise):
     def _extra_stats(self):
         """Adds ``maxl_polarization`` and the ``maxl_phase``
         """
-        return ['maxl_polarization', 'maxl_phase',]
+        return ['maxl_polarization', 'maxl_phase', ]
 
     def _nowaveform_loglr(self):
         """Convenience function to set loglr values if no waveform generated.

--- a/pycbc/inference/models/marginalized_gaussian_noise.py
+++ b/pycbc/inference/models/marginalized_gaussian_noise.py
@@ -25,7 +25,9 @@ from scipy import special
 from pycbc.waveform import generator
 from pycbc.waveform import (NoWaveformError, FailedWaveformError)
 from pycbc.detector import Detector
-from .gaussian_noise import (BaseGaussianNoise, create_waveform_generator, GaussianNoise)
+from .gaussian_noise import (BaseGaussianNoise, 
+                             create_waveform_generator, 
+                             GaussianNoise)
 
 
 class MarginalizedPhaseGaussianNoise(GaussianNoise):


### PR DESCRIPTION
Try to relax the constraint that data from all detectors should have the same length. Work in progress

2021.11.08 Update: This module adds support to `gaussian_noise`, `marginalized_phase` and `marginalized_polarization` for analyzing different data segment lengths and/or sampling rates for different IFOs.

Future optimization: add support for more models, handle the case when some of the IFOs use the same settings (in that case I don't need to generate a waveform generator for each one of IFO 