### PR TITLE
Allow non-inspinj XML files in inspinj -> HDF code

### DIFF
--- a/bin/pycbc_inspinj2hdf
+++ b/bin/pycbc_inspinj2hdf
@@ -47,7 +47,11 @@ xinj = InjectionSet(args.injection_file)
 
 data = {}
 for key in xinj.table[0].__slots__:
-    data[str(key)] = numpy.array([getattr(t, key) for t in xinj.table])
+    # Some XML files can have empty columns which are read as None in python.
+    # For these cases we ignore the columns so they do not appear in the output
+    # HDF file. I note that such XML files are invalid in C.
+    if getattr(xinj.table[0], key) is not None:
+        data[str(key)] = numpy.array([getattr(t, key) for t in xinj.table])
 
 for k in ['simulation_id', 'process_id']:
     a = data.pop(k)

--- a/bin/pycbc_inspinj2hdf
+++ b/bin/pycbc_inspinj2hdf
@@ -49,7 +49,7 @@ data = {}
 for key in xinj.table[0].__slots__:
     # Some XML files can have empty columns which are read as None in python.
     # For these cases we ignore the columns so they do not appear in the output
-    # HDF file. I note that such XML files are invalid in C.
+    # HDF file. (Such XML files cannot currently be read by LALSuite C code.)
     if getattr(xinj.table[0], key) is not None:
         data[str(key)] = numpy.array([getattr(t, key) for t in xinj.table])
 


### PR DESCRIPTION
When generating XML files with python it's possible to generate "empty" columns. These appears as `,,,` in the file rather than `0,0,0`. Technically this is invalid, and such files will not be possible to read in with the C code. However, the python interface "encourages" the user to make such files, and it's easy enough to support this, so we should.