### PR TITLE
add functions to get rate from redshift  or distance from rate

### DIFF
--- a/pycbc/cosmology.py
+++ b/pycbc/cosmology.py
@@ -344,12 +344,16 @@ class ComovingVolInterpolator(object):
     numpoints : int, optional
         The number of points to use in the linear interpolation between 0 to 1
         and 1 to ``default_maxz``. Default is 1000.
+    vol_func: function, optional
+        Optionally set how the volume is calculated by providing a function
     \**kwargs :
         All other keyword args are passed to :py:func:`get_cosmology` to
         select a cosmology. If none provided, will use
         :py:attr:`DEFAULT_COSMOLOGY`.
     """
-    def __init__(self, parameter, default_maxz=10., numpoints=1000, **kwargs):
+    def __init__(self, parameter, default_maxz=10., numpoints=1000,
+                 vol_func = self.cosmology.comoving_volume,
+                 **kwargs):
         self.parameter = parameter
         self.numpoints = int(numpoints)
         self.default_maxz = default_maxz
@@ -359,8 +363,8 @@ class ComovingVolInterpolator(object):
         self.nearby_interp = None
         self.faraway_interp = None
         self.default_maxvol = None
-        self.vol_func = self.cosmology.comoving_volume
-        self.vol_units = units.Mpc**3
+        self.vol_func = vol_func
+        self.vol_units = vol_fun(0.5).unit
 
     def _create_interpolant(self, minz, maxz):
         minlogv = numpy.log(self.vol_func.value)
@@ -386,8 +390,7 @@ class ComovingVolInterpolator(object):
         maxz = self.default_maxz
         self.faraway_interp = self._create_interpolant(minz, maxz)
         # store the default maximum volume
-        self.default_maxvol = \
-            numpy.log(self.cosmology.comoving_volume(maxz).value)
+        self.default_maxvol = numpy.log(self.vol_func.value)
 
     def get_value_from_logv(self, logv):
         """Returns the redshift for the given distance.

--- a/pycbc/cosmology.py
+++ b/pycbc/cosmology.py
@@ -478,6 +478,7 @@ def redshift_from_comoving_volume(vc, interp=True, **kwargs):
         z = z_at_value(cosmology.comoving_volume, vc, units.Mpc**3)
     return z
 
+
 def distance_from_comoving_volume(vc, interp=True, **kwargs):
     r"""Returns the luminosity distance from the given comoving volume.
 
@@ -515,6 +516,7 @@ def distance_from_comoving_volume(vc, interp=True, **kwargs):
         dist = cosmology.luminosity_distance(z).value
     return dist
 
+
 def madau_dickinson_2014(z):
     """ The madau-dickinson 2014 stellar-formation rate
     """
@@ -522,6 +524,7 @@ def madau_dickinson_2014(z):
     # units are M⊙ year−1 Mpc−3
     val = 0.015 * (1 + z) ** 2.7 / (1 + ((1 + z) / 2.9) ** 5.6)
     return val * units.year ** -1 * units.Mpc**3 * units.solMass
+
 
 def rate_from_redshift(z, rate_density, **kwargs):
     """Total rate of occurances out to some redshift
@@ -547,6 +550,7 @@ def rate_from_redshift(z, rate_density, **kwargs):
         dr = cosmology.differential_comoving_volume(z) / (1 + z)
         return (dr * 4 * numpy.pi * rate_density(z)).value
     return integrate.quad(diff_rate, 0, z)[0]
+
 
 def distance_from_rate(vc, rate_density, **kwargs):
     r"""Returns the luminosity distance from the given total rate value
@@ -578,6 +582,7 @@ def distance_from_rate(vc, rate_density, **kwargs):
                                         vol_func=rate_func,
                                         cosmology=cosmology)
     return rate_density.dist_interp[cosmology.name](vc)
+
 
 def cosmological_quantity_from_redshift(z, quantity, strip_unit=True,
                                         **kwargs):


### PR DESCRIPTION
As opposed to setting a cosmological volume, it would be better to set a population model explicitly and be able to transform from the resulting rate to distance horizon, etc. In this way we could use explicitly merger rate models as priors for example. 

This adds a few functions in this area along with an example function which can be used to set a rate distribution (following the stellar-formation rate). 

The key function is 'rate_from_redshift' which takes in a redshift and a 'rate_desnity' function. The rate density should take in a redshift and return the rate of occurances of something (might be merger rate, need not be though) per unit volume. The function then can integrate this over the comoving volume out to this redshift. The cosmological time dilation is also taken into account in this integral, so the assumption is that the rate_density function should be in terms of local quantities

This function is then used to provide the additional helper functions such as converting to luminosity distance (important for PE / injections / waveform generation).  