### PR TITLE
prep for release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -125,8 +125,8 @@ def get_version_info():
         vinfo = _version_helper.generate_git_version_info()
     except:
         vinfo = vdummy()
-        vinfo.version = '1.18.dev2'
-        vinfo.release = 'False'
+        vinfo.version = '1.18.2'
+        vinfo.release = 'True'
 
     with open('pycbc/version.py', 'wb') as f:
         f.write("# coding: utf-8\n".encode('utf-8'))


### PR DESCRIPTION
Following instructions of https://pycbc.org/pycbc/latest/html/release.html

Do we still need the pycbc-config release?