### PR TITLE
Set back to development

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -16,11 +16,8 @@ To create a new PyCBC release:
 #. Make sure that the setup.py file contains the correct version number, which should be in the format ``x.y.z`` (where x, y, and z are the major, minor, and patch levels of the release) in PyCBC's setup.py file.
 #. Set ``release = True`` in the PyCBC's setup.py file.
 #. Commit the changed setup.py file and push to commit to the repository.
-#. Go to the `pycbc-config release page <https://github.com/gwastro/pycbc-config/releases>`_ and click on ``Draft a new release``.
-#. Enter a tag version in the format ``vx.y.z``. Note the ``v`` in front of the major, minor, and patch numbers.
-#. Click on ``Publish release`` to create the release.
 #. Go to the `PyCBC release page <https://github.com/gwastro/pycbc/releases>`_ and click on ``Draft a new release``.
-#. Enter the same tag version used for ``pycbc-config`` above.
+#. Enter a tag version in the format ``vx.y.z``. Note the ``v`` in front of the major, minor, and patch numbers.
 #. Enter a descriptive release title and write a description of the release in the text box provided.
 #. Click on ``Publish release`` to create the release.
 #. Update the setup.py file with an incremented major or minor version number and make sure that the string ``dev`` appears in that version. For example, if you just released ``1.2.1`` then change the string to ``1.3.dev0`` or ``2.0.dev0`` as appropriate. This is needed to ensure that if someone is building from source, it always takes precedence over an older release version.

--- a/setup.py
+++ b/setup.py
@@ -125,8 +125,8 @@ def get_version_info():
         vinfo = _version_helper.generate_git_version_info()
     except:
         vinfo = vdummy()
-        vinfo.version = '1.18.2'
-        vinfo.release = 'True'
+        vinfo.version = '1.18.dev3'
+        vinfo.release = 'False'
 
     with open('pycbc/version.py', 'wb') as f:
         f.write("# coding: utf-8\n".encode('utf-8'))


### PR DESCRIPTION
Including removal of the pycbc-config instructions in the release instruction page