### PR TITLE
rvs should return array

### DIFF
--- a/pycbc/distributions/bounded.py
+++ b/pycbc/distributions/bounded.py
@@ -318,7 +318,8 @@ class BoundedDist(object):
 
     def rvs(self, size=1, **kwds):
         "Draw random value"
-        draw = {}
+        dtype = [(p, float) for p in self.params]
+        draw = numpy.zeros(size, dtype=dtype)
         for param in self.params:
             draw[param] = numpy.random.uniform(0, 1, size=size)
         return self.cdfinv(**draw)

--- a/pycbc/distributions/bounded.py
+++ b/pycbc/distributions/bounded.py
@@ -319,10 +319,14 @@ class BoundedDist(object):
     def rvs(self, size=1, **kwds):
         "Draw random value"
         dtype = [(p, float) for p in self.params]
-        draw = numpy.zeros(size, dtype=dtype)
+        arr = numpy.zeros(size, dtype=dtype)
+        draw = {}
         for param in self.params:
             draw[param] = numpy.random.uniform(0, 1, size=size)
-        return self.cdfinv(**draw)
+        exp = self.cdfinv(**draw)
+        for param in self.params:
+            arr[param] = exp[param]
+        return arr
 
     @classmethod
     def from_config(cls, cp, section, variable_args, bounds_required=False):


### PR DESCRIPTION
@sum33it I missed a bug in #3744 whereby some codes we weren't testing relied on the return being an array rather than a dict. This showed up in the failure of the tutorials in the 1.18.2 release, but otherwise the testing did not fail (it occurs if you do some manual things in the PE which doesn't as commonly occur nowadays in when we run PE, such as setting the initial positions with mcmc). 