### PR TITLE
add test of pycbc tutorials to CI

### DIFF
--- a/.github/workflows/tut-test.yml
+++ b/.github/workflows/tut-test.yml
@@ -1,0 +1,31 @@
+name: basic tests
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      max-parallel: 60
+      matrix:
+        os: [ubuntu-20.04]
+        python-version: [2.7, 3.6, 3.7, 3.8, 3.9]
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: installing packages
+      run: |
+        sudo apt-get update
+        sudo apt-get install *fftw3* mpi intel-mkl*
+        pip install tox pip setuptools notebook --upgrade
+        pip install .
+    - name: retrieving pycbc tutorials
+      run: |
+        git clone https://github.com/gwastro/PyCBC-Tutorials
+    - name: running pycbc tutorials
+      run: |
+        cd PyCBC-Tutorials
+        ./test_notebooks

--- a/.github/workflows/tut-test.yml
+++ b/.github/workflows/tut-test.yml
@@ -1,4 +1,4 @@
-name: basic tests
+name: tutorial tests
 
 on: [push, pull_request]
 


### PR DESCRIPTION
This does the same test that the pycbc tutorials run themselves to ensure that any functionality used in the tutorials doesn't cause breakage there. 