### PR TITLE
Update docker build to use python3.8 and el8

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -3,30 +3,30 @@ name: docker build
 on: [push]
 
 jobs:
-  build: 
+  build:
     runs-on: ubuntu-20.04
-    steps: 
-      - 
+    steps:
+      -
         uses: actions/checkout@v1
-      - 
+      -
         name: "Set up Python"
         uses: actions/setup-python@v1
-        with: 
-          python-version: 2.7
-      - 
+        with:
+          python-version: 3.8
+      -
         name: "Preparing a host container"
         run: "docker build -t pycbc-docker-tmp ."
-      - 
+      -
         name: "Installing PyCBC and dependencies"
         run: "docker run --privileged --name pycbc_inst -v `pwd`:/scratch:ro pycbc-docker-tmp /bin/bash -c /scratch/docker/etc/docker-install.sh"
-      - 
+      -
         env:
-          DOCKER_IMG: pycbc/pycbc-el7
+          DOCKER_IMG: pycbc/pycbc-el8
         name: "Running docker commit"
         run: "bash -e docker/etc/docker_commit.sh"
-      - 
-        env: 
-          DOCKER_IMG: pycbc/pycbc-el7
+      -
+        env:
+          DOCKER_IMG: pycbc/pycbc-el8
           DOCKER_PASSWORD: "${{secrets.DOCKERHUB_PASSWORD}}"
           DOCKER_USERNAME: "${{secrets.DOCKERHUB_USERNAME}}"
         name: "Pushing docker image"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:centos7
+FROM igwn/base:el8
 
 ADD docker/etc/profile.d/pycbc.sh /etc/profile.d/pycbc.sh
 ADD docker/etc/profile.d/pycbc.csh /etc/profile.d/pycbc.csh
@@ -7,11 +7,11 @@ ADD docker/etc/cvmfs/60-osg.conf /etc/cvmfs/60-osg.conf
 ADD docker/etc/cvmfs/config-osg.opensciencegrid.org.conf /etc/cvmfs/config-osg.opensciencegrid.org.conf
 
 # Set up extra repositories
-RUN rpm -ivh http://software.ligo.org/lscsoft/scientific/7/x86_64/production/l/lscsoft-production-config-1.3-1.el7.noarch.rpm && yum install -y https://repo.ius.io/ius-release-el7.rpm && yum install -y https://ecsft.cern.ch/dist/cvmfs/cvmfs-release/cvmfs-release-latest.noarch.rpm && yum install -y cvmfs cvmfs-config-default && yum -y install http://repo.opensciencegrid.org/osg/3.4/osg-3.4-el7-release-latest.rpm && yum clean all && yum makecache && \
+RUN rpm -ivh https://software.igwn.org/lscsoft/rocky/8/production/x86_64/os/l/lscsoft-production-config-8-5.el8.noarch.rpm && yum install -y https://ecsft.cern.ch/dist/cvmfs/cvmfs-release/cvmfs-release-latest.noarch.rpm && yum install -y cvmfs cvmfs-config-default && yum -y install http://repo.opensciencegrid.org/osg/3.6/osg-3.6-el8-release-latest.rpm && yum clean all && yum makecache && \
     yum -y groupinstall "Compatibility Libraries" \
                         "Development Tools" \
                         "Scientific Support" && \
-    rpm -e --nodeps git perl-Git && yum -y install python2-pip python-setuptools zlib-devel libpng-devel libjpeg-devel libsqlite3-dev sqlite-devel db4-devel openssl-devel git2u-all fftw-libs-single fftw-devel fftw fftw-libs-long fftw-libs fftw-libs-double gsl gsl-devel libframe-utils libframe-devel libframe libmetaio libmetaio-devel libmetaio-utils hdf5 hdf5-devel python-devel which osg-wn-client osg-ca-certs && pip install --upgrade pip==19.3.1 setuptools==44.0.0 && pip install mkl==2019.0 ipython jupyter
+    rpm -e --nodeps git perl-Git && yum -y install @python38 zlib-devel libpng-devel libjpeg-devel libsqlite3-dev sqlite-devel db4-devel openssl-devel git2u-all fftw-libs-single fftw-devel fftw fftw-libs-long fftw-libs fftw-libs-double gsl gsl-devel libframe-utils libframe-devel libframe libmetaio libmetaio-devel libmetaio-utils hdf5 hdf5-devel python38-devel which osg-wn-client osg-ca-certs && python3.8 -m pip install --upgrade pip setuptools && python3.8 -m pip install mkl ipython jupyter
 
 # set up environment
 RUN cd / && \
@@ -22,8 +22,8 @@ RUN cd / && \
 RUN yum install -y libibverbs libibverbs-devel libibmad libibmad-devel libibumad libibumad-devel librdmacm librdmacm-devel libmlx5 libmlx4 && curl http://mvapich.cse.ohio-state.edu/download/mvapich/mv2/mvapich2-2.1.tar.gz | tar -C /tmp -zxf - && \
     cd /tmp/mvapich2-2.1 && ./configure --prefix=/opt/mvapich2-2.1 && make install && \
     cd / && rm -rf /tmp/mvapich2-2.1 && \
-    pip install schwimmbad && \
-    MPICC=/opt/mvapich2-2.1/bin CFLAGS='-I /opt/mvapich2-2.1/include -L /opt/mvapich2-2.1/lib -lmpi' pip install --no-cache-dir mpi4py
+    python3.8 -m pip install schwimmbad && \
+    MPICC=/opt/mvapich2-2.1/bin CFLAGS='-I /opt/mvapich2-2.1/include -L /opt/mvapich2-2.1/lib -lmpi' python3.8 -m pip install --no-cache-dir mpi4py
 RUN echo "/opt/mvapich2-2.1/lib" > /etc/ld.so.conf.d/mvapich2-2.1.conf
 
 # Now update all of our library installations
@@ -32,14 +32,17 @@ RUN rm -f /etc/ld.so.cache && /sbin/ldconfig
 # Explicitly set the path so that it is not inherited from build the environment
 ENV PATH "/usr/local/bin:/usr/bin:/bin:/opt/mvapich2-2.1/bin"
 
+# Make python be what we want
+RUN alternatives --set python /usr/bin/python3.8
+
 # Set the default LAL_DATA_PATH to point at CVMFS first, then the container.
 # Users wanting it to point elsewhere should start docker using:
 #   docker <cmd> -e LAL_DATA_PATH="/my/new/path"
 ENV LAL_DATA_PATH "/cvmfs/oasis.opensciencegrid.org/ligo/sw/pycbc/lalsuite-extra/current/share/lalsimulation:/opt/pycbc/pycbc-software/share/lal-data"
 
 # When the container is started with
-#   docker run -it pycbc/pycbc-el7:latest
+#   docker run -it pycbc/pycbc-el8:latest
 # the default is to start a loging shell as the pycbc user.
 # This can be overridden to log in as root with
-#   docker run -it pycbc/pycbc-el7:latest /bin/bash -l
+#   docker run -it pycbc/pycbc-el8:latest /bin/bash -l
 CMD ["/bin/su", "-l", "pycbc"]

--- a/docker/etc/docker-install.sh
+++ b/docker/etc/docker-install.sh
@@ -1,8 +1,8 @@
 #!/bin/bash -v
 set -e
 cd /scratch
-pip install -r requirements.txt
-pip install .
+python3.8 -m pip install -r requirements.txt
+python3.8 -m pip install .
 cd /
 mkdir -p /opt/pycbc/src
 cp -a /scratch /opt/pycbc/src/pycbc

--- a/docs/docker.rst
+++ b/docs/docker.rst
@@ -7,12 +7,12 @@ The easiest way to start using PyCBC is to install one of our `Docker containers
 
 To start a Docker container with no graphics, type the commands::
 
-    docker pull pycbc/pycbc-el7:latest
-    docker run -it pycbc/pycbc-el7:latest
+    docker pull pycbc/pycbc-el8:latest
+    docker run -it pycbc/pycbc-el8:latest
 
 This example downloads current version of the code from the `GitHub master branch. <https://github.com/ligo-cbc/pycbc>`_ Replace the string ``latest`` with one of the `PyCBC release tags <https://github.com/ligo-cbc/pycbc/releases>`_ (e.g. ``v1.7.0``) to install a container containing a released version of PyCBC. The container includes all of the required software and dependencies to run PyCBC, including a compatible version of LALSuite installed into the root filesystem. The command above starts a login shell as the pycbc user. To override this and log in as root, run the command::
 
-   docker run -it pycbc/pycbc-el7:latest /bin/bash -l
+   docker run -it pycbc/pycbc-el8:latest /bin/bash -l
 
 -------------------------------------
 Using jupyter notebook within docker
@@ -21,7 +21,7 @@ Using jupyter notebook within docker
 One can start a jupyter notebook within docker and then port forward to your
 computer's environment.::
 
-    docker run -it -p 8888:8888 --name pycbc_test pycbc/pycbc-el7:latest /bin/su -l pycbc -c "jupyter notebook --no-browser --ip 0.0.0.0"
+    docker run -it -p 8888:8888 --name pycbc_test pycbc/pycbc-el8:latest /bin/su -l pycbc -c "jupyter notebook --no-browser --ip 0.0.0.0"
 
 Once the image is running, you can connect from your computer's web browser to the address printed to the screen by jupyter. This is typically the local host adddress, e.g. ``127.0.0.1``
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,7 +29,7 @@ Getting Started
         <script type="text/javascript">
             document.addEventListener("DOMContentLoaded", function(){
                 Typed.new(".element", {
-                    strings: ["^500<strong>docker pull pycbc/pycbc-el7:latest</strong><br>$ ^500<strong>docker run -it pycbc/pycbc-el7:latest</strong><br>&#40;pycbc-software&#41;&#91;pycbc@37184573e664 &#126;&#93;$ ^500<strong>python</strong><br>Python 2.7.5 &#40;default, Nov  6 2016, 00:28:07&#41;<br>&#91;GCC 4.8.5 20150623 &#40;Red Hat 4.8.5-11&#41;&#93; on linux2<br>&gt;&gt;&gt; ^500<strong>execfile&#40;&quot;/opt/pycbc/src/pycbc/examples/waveform/match_waveform.py&quot;&#41;</strong><br>^1000The match is: 0.953<br>&gt;&gt;&gt; ^500<strong>from pycbc.waveform import td_approximants</strong><br>&gt;&gt;&gt; ^500<strong>print td_approximants&#40;&#41;&#91;20:24&#93;</strong><br>['SEOBNRv3', 'SEOBNRv2', 'SpinTaylorT1', 'SEOBNRv4']<br>&gt;&gt;&gt; "],
+                    strings: ["^500<strong>docker pull pycbc/pycbc-el8:latest</strong><br>$ ^500<strong>docker run -it pycbc/pycbc-el8:latest</strong><br>&#40;pycbc-software&#41;&#91;pycbc@37184573e664 &#126;&#93;$ ^500<strong>python</strong><br>Python 2.7.5 &#40;default, Nov  6 2016, 00:28:07&#41;<br>&#91;GCC 4.8.5 20150623 &#40;Red Hat 4.8.5-11&#41;&#93; on linux2<br>&gt;&gt;&gt; ^500<strong>execfile&#40;&quot;/opt/pycbc/src/pycbc/examples/waveform/match_waveform.py&quot;&#41;</strong><br>^1000The match is: 0.953<br>&gt;&gt;&gt; ^500<strong>from pycbc.waveform import td_approximants</strong><br>&gt;&gt;&gt; ^500<strong>print td_approximants&#40;&#41;&#91;20:24&#93;</strong><br>['SEOBNRv3', 'SEOBNRv2', 'SpinTaylorT1', 'SEOBNRv4']<br>&gt;&gt;&gt; "],
                     typeSpeed: 0
                 });
             });

--- a/docs/workflow/pycbc_make_coinc_search_workflow.rst
+++ b/docs/workflow/pycbc_make_coinc_search_workflow.rst
@@ -1012,14 +1012,14 @@ It is also through arguments to ``pycbc_submit_dax`` that the workflow is made a
 Singularity image to use when running ``pycbc_inspiral``. This is done by including the following
 argument to ``pycbc_submit_dax``::
 
-    --append-site-profile "osg:condor|+SingularityImage:\"/cvmfs/singularity.opensciencegrid.org/pycbc/pycbc-el7:latest\"" \
+    --append-site-profile "osg:condor|+SingularityImage:\"/cvmfs/singularity.opensciencegrid.org/pycbc/pycbc-el8:latest\"" \
 
 The precise line above will cause ``pycbc_inspiral`` to run using the code in the latest version of PyCBC
 as found on the ``master`` branch. You may well prefer a specific version (for example, for a production
 run) and each release will also have a corresponding Singularity image published to CVMFS.  For example,
 to use the ``1.14.3`` release of PyCBC, use instead the line::
 
-    --append-site-profile "osg:condor|+SingularityImage:\"/cvmfs/singularity.opensciencegrid.org/pycbc/pycbc-el7:v1.14.3\"" \
+    --append-site-profile "osg:condor|+SingularityImage:\"/cvmfs/singularity.opensciencegrid.org/pycbc/pycbc-el8:v1.14.3\"" \
 
 You may also direct the workflow to use a Singularity image of your own, if that has been published to CVMFS.
 


### PR DESCRIPTION
As discuss in our Slack channel we want to update our Docker build to use python3.8 and el8. This will mean the `pycbc-el7` image will no longer be updated and `pycbc-el8` should now be used instead. I've searched for any other instances of `el7` that need updating, without trying to update containing docs, which may also be out of date.