### PR TITLE
allow pycbc inspiral to accept multiple gps time ranges (i.e. analyze non-contiguous data)

### DIFF
--- a/bin/pycbc_inspiral
+++ b/bin/pycbc_inspiral
@@ -464,7 +464,7 @@ with ctx:
         
         if opt.finalize_events_template_rate is not None and \
                 not (tchunk[0]) % opt.finalize_events_template_rate:
-            event_mgr.consolidate_events(opt, gwstrain=gwstrain)
+            event_mgr.consolidate_events(opt, gwstrain=gwstrain[0])
 
         if opt.checkpoint_interval and \
             (time.time() - tcheckpoint > opt.checkpoint_interval):
@@ -476,7 +476,8 @@ with ctx:
             event_mgr.save_state(max(tchunk), opt.output + '.checkpoint')
             sys.exit(opt.checkpoint_exit_code)           
 
-event_mgr.consolidate_events(opt, gwstrain=gwstrain)
+# This should not need gwstrain somehow
+event_mgr.consolidate_events(opt, gwstrain=gwstrain[0])
 event_mgr.finalize_events()
 logging.info("Outputting %s triggers" % str(len(event_mgr.events)))
 

--- a/bin/pycbc_inspiral
+++ b/bin/pycbc_inspiral
@@ -205,8 +205,8 @@ parser.add_argument("--template-groupby", type=int, default=1,
 
 # Add options groups
 psd.insert_psd_option_group(parser)
-strain.insert_strain_option_group(parser)
-strain.StrainSegments.insert_segment_option_group(parser)
+strain.insert_strain_option_group(parser, multi_times=True)
+strain.StrainSegments.insert_segment_option_group(parser, multi_times=True)
 scheme.insert_processing_option_group(parser)
 fft.insert_fft_option_group(parser)
 pycbc.opt.insert_optimization_option_group(parser)
@@ -228,10 +228,9 @@ fft.from_cli(opt)
 inj_filter_rejector = pycbc.inject.InjFilterRejector.from_cli(opt)
 ctx = scheme.from_cli(opt)
 
-gwstrain = strain.from_cli(opt, dyn_range_fac=DYN_RANGE_FAC,
+gwstrain = strain.from_cli_multi_times(opt, dyn_range_fac=DYN_RANGE_FAC,
                            inj_filter_rejector=inj_filter_rejector)
-
-strain_segments = strain.StrainSegments.from_cli(opt, gwstrain)
+strain_segments = strain.StrainSegments.from_cli_multi_times(opt, gwstrain)
 
 def template_triggers(t_num):
     """ Get the triggers for a specific template
@@ -308,7 +307,7 @@ with ctx:
     flen = strain_segments.freq_len
     tlen = strain_segments.time_len
     delta_f = strain_segments.delta_f
-
+    sample_rate = strain_segments.sample_rate
 
     logging.info("Making frequency-domain data segments")
     segments = strain_segments.fourier_segments()
@@ -331,11 +330,12 @@ with ctx:
     out_vals_ref = {key: None for key in out_types}
     names = sorted(out_vals_ref.keys())
 
+    gating_info = sum([g.gating_info for g in gwstrain], start=[])
     if len(strain_segments.segment_slices) == 0:
         logging.info("--filter-inj-only specified and no injections in analysis time")
         event_mgr = events.EventManager(
               opt, names, [out_types[n] for n in names], psd=None,
-              gating_info=gwstrain.gating_info)
+              gating_info=gating_info)
         event_mgr.finalize_template_events()
         event_mgr.write_events(opt.output)
         logging.info("Finished")
@@ -376,10 +376,10 @@ with ctx:
     if not checkpoint_exists:
         event_mgr = events.EventManager(
             opt, names, [out_types[n] for n in names], psd=segments[0].psd,
-            gating_info=gwstrain.gating_info, q_trans=q_trans)
+            gating_info=gating_info, q_trans=q_trans)
 
     template_mem = zeros(tlen, dtype = complex64)
-    cluster_window = int(opt.cluster_window * gwstrain.sample_rate)
+    cluster_window = int(opt.cluster_window * sample_rate)
 
     if opt.cluster_window == 0.0:
         use_cluster = False

--- a/bin/pycbc_inspiral
+++ b/bin/pycbc_inspiral
@@ -16,7 +16,7 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-import sys, os
+import sys, os, copy
 import logging, argparse, numpy, itertools
 from six.moves import range
 import pycbc
@@ -237,6 +237,7 @@ def template_triggers(t_num):
     """ Get the triggers for a specific template
     """
     template = None
+    tparm = None
     out_vals_all = []
     for s_num, stilde in enumerate(segments):
         # Filter check checks the 'inj_filter_rejector' options to
@@ -247,6 +248,7 @@ def template_triggers(t_num):
             continue
         if template is None:
             template = bank[t_num]
+            tparam = template.params
 
         if opt.update_progress:
             update_progress((t_num + (s_num / float(len(segments))) ) / len(bank),
@@ -288,14 +290,16 @@ def template_triggers(t_num):
         out_vals['time_index'] = idx
         out_vals['snr'] = snrv * norm
         out_vals['sigmasq'] = numpy.zeros(len(snrv), dtype=float32) + sigmasq
-
         if opt.psdvar_short_segment is not None:
             out_vals['psd_var_val'] = \
                         pycbc.psd.find_trigger_value(psd_var,
                                       out_vals['time_index'],
                                       opt.gps_start_time, opt.sample_rate)
-        out_vals_all.append(out_vals)
-    return out_vals_all, template.params
+        #print(idx, out_vals['time_index'])
+        
+        out_vals_all.append(copy.deepcopy(out_vals))
+        #print(out_vals_all)
+    return out_vals_all, tparam
 
 with ctx:
     # The following FFTW specific options needed to wait until
@@ -460,15 +464,15 @@ with ctx:
 
         for elem in data:
             out_vals_all, tparam = elem
-
             if len(out_vals_all) > 0:
                 event_mgr.new_template(tmplt=tparam)
 
-                for out_vals in out_vals_all:
-                    event_mgr.add_template_events(names, [out_vals[n] for n in names])
-
+                for edata in out_vals_all:
+                    event_mgr.add_template_events(names, [edata[n] for n in names])              
+                                    
                 event_mgr.cluster_template_events("time_index", "snr", cluster_window)
                 event_mgr.finalize_template_events()
+        
         
         if opt.finalize_events_template_rate is not None and \
                 not (tchunk[0]) % opt.finalize_events_template_rate:

--- a/bin/pycbc_inspiral
+++ b/bin/pycbc_inspiral
@@ -464,7 +464,7 @@ with ctx:
         
         if opt.finalize_events_template_rate is not None and \
                 not (tchunk[0]) % opt.finalize_events_template_rate:
-            event_mgr.consolidate_events(opt, gwstrain=gwstrain)
+            event_mgr.consolidate_events(opt, injections=gwstrain[0].injections)
 
         if opt.checkpoint_interval and \
             (time.time() - tcheckpoint > opt.checkpoint_interval):
@@ -476,7 +476,7 @@ with ctx:
             event_mgr.save_state(max(tchunk), opt.output + '.checkpoint')
             sys.exit(opt.checkpoint_exit_code)           
 
-event_mgr.consolidate_events(opt, gwstrain=gwstrain)
+event_mgr.consolidate_events(opt, injections=gwstrain[0].injections))
 event_mgr.finalize_events()
 logging.info("Outputting %s triggers" % str(len(event_mgr.events)))
 

--- a/bin/pycbc_inspiral
+++ b/bin/pycbc_inspiral
@@ -196,10 +196,10 @@ parser.add_argument("--checkpoint-exit-maxtime", type=int,
                          " time is exceeded. Default is no checkpointing.")
 parser.add_argument("--checkpoint-exit-code", type=int, default=77,
                     help="Exit code returned if exiting after a checkpoint")
-parser.add_argument("--multiprocessing-nprocesses", type=int,
+parser.add_argument("--multiprocessing", type=int,
                     help="Parallelize over multiple processes, note this is"
                          "separate from threading using the proc. scheme")
-parser.add_argument("--multiprocess-groupby", type=int,
+parser.add_argument("--template-groupby", type=int, default=1,
                     help="Number of template to group together for parallel"
                          "analysis, should be multiple of nprocesses")
 
@@ -295,7 +295,7 @@ def template_triggers(t_num):
                                       out_vals['time_index'],
                                       opt.gps_start_time, opt.sample_rate)
         out_vals_all.append(out_vals)
-        return out_vals_all
+    return out_vals_all, template.params
 
 with ctx:
     # The following FFTW specific options needed to wait until
@@ -447,30 +447,41 @@ with ctx:
     tsetup = time.time() - tstart
     tcheckpoint = time.time()
     
-    for t_num in range(tnum_start, len(bank)):
-        out_vals_all = template_triggers(t_num)
-            
-        if len(out_vals_all) > 0:
-            event_mgr.new_template(tmplt=template.params)  
-            
-            for out_vals in out_vals_all:
-                event_mgr.add_template_events(names, [out_vals[n] for n in names])
+    tanalyze = list(range(tnum_start, len(bank)))
+    n = opt.template_groupby
+    tchunks = [tanalyze[i:i + n] for i in range(0, len(tanalyze), n)] 
+    
+    mmap = map
+    if opt.multiprocessing:
+        mmap = Pool(opt.multiprocessing).map
+    
+    for tchunk in tchunks:
+        data = list(mmap(template_triggers, tchunk))
 
-            event_mgr.cluster_template_events("time_index", "snr", cluster_window)
-            event_mgr.finalize_template_events()
+        for elem in data:
+            out_vals_all, tparam = elem
+
+            if len(out_vals_all) > 0:
+                event_mgr.new_template(tmplt=tparam)
+
+                for out_vals in out_vals_all:
+                    event_mgr.add_template_events(names, [out_vals[n] for n in names])
+
+                event_mgr.cluster_template_events("time_index", "snr", cluster_window)
+                event_mgr.finalize_template_events()
         
         if opt.finalize_events_template_rate is not None and \
-                not (t_num+1) % opt.finalize_events_template_rate:
+                not (tchunk[0]) % opt.finalize_events_template_rate:
             event_mgr.consolidate_events(opt, gwstrain=gwstrain)
 
         if opt.checkpoint_interval and \
             (time.time() - tcheckpoint > opt.checkpoint_interval):
-            event_mgr.save_state(t_num, opt.output + '.checkpoint')
+            event_mgr.save_state(max(tchunk), opt.output + '.checkpoint')
             tcheckpoint = time.time()
 
         if opt.checkpoint_exit_maxtime and \
             (time.time() - tstart > opt.checkpoint_exit_maxtime):
-            event_mgr.save_state(t_num, opt.output + '.checkpoint')
+            event_mgr.save_state(max(tchunk), opt.output + '.checkpoint')
             sys.exit(opt.checkpoint_exit_code)           
 
 event_mgr.consolidate_events(opt, gwstrain=gwstrain)

--- a/bin/pycbc_inspiral
+++ b/bin/pycbc_inspiral
@@ -283,7 +283,8 @@ def template_triggers(t_num):
         out_vals['sigmasq'] = numpy.zeros(len(snrv), dtype=float32) + sigmasq
         if opt.psdvar_short_segment is not None:
             out_vals['psd_var_val'] = \
-                        pycbc.psd.find_trigger_value(psd_var, out_vals['end_time'])
+                        pycbc.psd.find_trigger_value(stilde.strain.psd_var,
+                                                     out_vals['end_time'])
         
         out_vals_all.append(copy.deepcopy(out_vals))
     return out_vals_all, tparam
@@ -344,10 +345,12 @@ with ctx:
     # FIXME: Maybe we should use the PSD corresponding to each trigger
     if opt.psdvar_segment is not None:
         logging.info("Calculating PSD variation")
-        psd_var = pycbc.psd.calc_filt_psd_variation(gwstrain, opt.psdvar_segment,
+        for gws in gwstrain:
+            psd_var = pycbc.psd.calc_filt_psd_variation(gws, opt.psdvar_segment,
                 opt.psdvar_short_segment, opt.psdvar_long_segment, 
                 opt.psdvar_psd_duration, opt.psdvar_psd_stride,
                 opt.psd_estimation, opt.psdvar_low_freq, opt.psdvar_high_freq)
+            gws.psd_var = psd_var
 
     if opt.enable_q_transform:
         logging.info("Performing q-transform on analysis segments")

--- a/bin/pycbc_inspiral
+++ b/bin/pycbc_inspiral
@@ -25,6 +25,7 @@ from pycbc import vetoes, psd, waveform, strain, scheme, fft, DYN_RANGE_FAC, eve
 from pycbc.vetoes.sgchisq import SingleDetSGChisq
 from pycbc.filter import MatchedFilterControl, make_frequency_series, qtransform
 from pycbc.types import TimeSeries, FrequencySeries, zeros, float32, complex64
+from multiprocessing import Pool
 import pycbc.version
 import pycbc.opt
 import pycbc.inject
@@ -197,6 +198,12 @@ parser.add_argument("--checkpoint-exit-maxtime", type=int,
                          " time is exceeded. Default is no checkpointing.")
 parser.add_argument("--checkpoint-exit-code", type=int, default=77,
                     help="Exit code returned if exiting after a checkpoint")
+parser.add_argument("--multiprocessing-nprocesses", type=int,
+                    help="Parallelize over multiple processes, note this is"
+                         "separate from threading using the proc. scheme")
+parser.add_argument("--multiprocess-groupby", type-int,
+                    help="Number of template to group together for parallel"
+                         "analysis, should be multiple of nprocesses")
 
 # Add options groups
 psd.insert_psd_option_group(parser)
@@ -384,7 +391,7 @@ with ctx:
     # from the bank.
     for t_num in range(len(bank) - tnum_start):
         t_num += tnum_start
-        tmplt_generated = False
+        template = None
 
         for s_num, stilde in enumerate(segments):
             # Filter check checks the 'inj_filter_rejector' options to
@@ -393,11 +400,10 @@ with ctx:
             if not inj_filter_rejector.template_segment_checker(
                     bank, t_num, stilde, opt.gps_start_time):
                 continue
-            if not tmplt_generated:
+            if template is None:
                 template = bank[t_num]
                 event_mgr.new_template(tmplt=template.params,
                     sigmasq=template.sigmasq(segments[0].psd))
-                tmplt_generated = True
 
             if opt.cluster_method == "window":
                 cluster_window = int(opt.cluster_window * gwstrain.sample_rate)

--- a/bin/pycbc_inspiral
+++ b/bin/pycbc_inspiral
@@ -258,47 +258,36 @@ def template_triggers(t_num):
 
         sigmasq = template.sigmasq(stilde.psd)
         snr, norm, corr, idx, snrv = \
-           matched_filter.matched_filter_and_cluster(s_num,
-                                                     sigmasq,
+           matched_filter.matched_filter_and_cluster(s_num, sigmasq,
                                                      cluster_window,
                                                      epoch=stilde._epoch)
         if not len(idx):
             continue
 
         out_vals = out_vals_ref.copy()
+        idx_s = idx + stilde.analyze.start
         out_vals['bank_chisq'], out_vals['bank_chisq_dof'] = \
-              bank_chisq.values(template, stilde.psd, stilde, snrv, norm,
-                                idx+stilde.analyze.start)
+              bank_chisq.values(template, stilde.psd, stilde, snrv, norm, idx_s)
 
         out_vals['chisq'], out_vals['chisq_dof'] = \
-              power_chisq.values(corr, snrv, norm, stilde.psd,
-                                 idx+stilde.analyze.start, template)
+              power_chisq.values(corr, snrv, norm, stilde.psd, idx_s, template)
 
         out_vals['sg_chisq'] = sg_chisq.values(stilde, template, stilde.psd,
-                                      snrv, norm,
-                                      out_vals['chisq'],
-                                      out_vals['chisq_dof'],
-                                      idx+stilde.analyze.start)
+                                      snrv, norm, out_vals['chisq'],
+                                      out_vals['chisq_dof'], idx_s)
 
         out_vals['cont_chisq'] = \
-              autochisq.values(snr, idx+stilde.analyze.start, template,
-                               stilde.psd, norm, stilde=stilde,
-                               low_frequency_cutoff=flow)
+              autochisq.values(snr, idx_s, template, stilde.psd, norm,
+                               stilde=stilde, low_frequency_cutoff=flow)
 
-        idx += stilde.cumulative_index
-
-        out_vals['time_index'] = idx
+        out_vals['end_time'] = idx_s.astype(float64) * stilde.delta_t + stilde.start_time 
         out_vals['snr'] = snrv * norm
         out_vals['sigmasq'] = numpy.zeros(len(snrv), dtype=float32) + sigmasq
         if opt.psdvar_short_segment is not None:
             out_vals['psd_var_val'] = \
-                        pycbc.psd.find_trigger_value(psd_var,
-                                      out_vals['time_index'],
-                                      opt.gps_start_time, opt.sample_rate)
-        #print(idx, out_vals['time_index'])
+                        pycbc.psd.find_trigger_value(psd_var, out_vals['end_time'])
         
         out_vals_all.append(copy.deepcopy(out_vals))
-        #print(out_vals_all)
     return out_vals_all, tparam
 
 with ctx:
@@ -329,7 +318,7 @@ with ctx:
 
     # storage for values and types to be passed to event manager
     out_types = {
-        'time_index'     : int,
+        'end_time'     : float64,
         'snr'            : complex64,
         'chisq'          : float32,
         'chisq_dof'      : int,
@@ -470,7 +459,7 @@ with ctx:
                 for edata in out_vals_all:
                     event_mgr.add_template_events(names, [edata[n] for n in names])              
                                     
-                event_mgr.cluster_template_events("time_index", "snr", cluster_window)
+                event_mgr.cluster_template_events("end_time", "snr", opt.cluster_window)
                 event_mgr.finalize_template_events()
         
         

--- a/bin/pycbc_inspiral
+++ b/bin/pycbc_inspiral
@@ -87,8 +87,6 @@ taper_choices = ["start","end","startend"]
 parser.add_argument("--taper-template", choices=taper_choices,
                     help="For time-domain approximants, taper the start and/or"
                     " end of the waveform before FFTing.")
-parser.add_argument("--cluster-method", choices=["template", "window"],
-                    help="FIXME: ADD")
 parser.add_argument("--cluster-function", choices=["findchirp", "symmetric"],
                     help="How to cluster together triggers within a window. "
                     "'findchirp' uses a forward sliding window; 'symmetric' "
@@ -235,6 +233,69 @@ gwstrain = strain.from_cli(opt, dyn_range_fac=DYN_RANGE_FAC,
 
 strain_segments = strain.StrainSegments.from_cli(opt, gwstrain)
 
+def template_triggers(t_num):
+    """ Get the triggers for a specific template
+    """
+    template = None
+    out_vals_all = []
+    for s_num, stilde in enumerate(segments):
+        # Filter check checks the 'inj_filter_rejector' options to
+        # determine whether
+        # to filter this template/segment if injections are present.
+        if not inj_filter_rejector.template_segment_checker(
+                bank, t_num, stilde, opt.gps_start_time):
+            continue
+        if template is None:
+            template = bank[t_num]
+
+        if opt.update_progress:
+            update_progress((t_num + (s_num / float(len(segments))) ) / len(bank),
+                            opt.update_progress, opt.update_progress_file)
+        logging.info("Filtering template %d/%d segment %d/%d" %
+                     (t_num + 1, len(bank), s_num + 1, len(segments)))
+
+        sigmasq = template.sigmasq(stilde.psd)
+        snr, norm, corr, idx, snrv = \
+           matched_filter.matched_filter_and_cluster(s_num,
+                                                     sigmasq,
+                                                     cluster_window,
+                                                     epoch=stilde._epoch)
+        if not len(idx):
+            continue
+
+        out_vals = out_vals_ref.copy()
+        out_vals['bank_chisq'], out_vals['bank_chisq_dof'] = \
+              bank_chisq.values(template, stilde.psd, stilde, snrv, norm,
+                                idx+stilde.analyze.start)
+
+        out_vals['chisq'], out_vals['chisq_dof'] = \
+              power_chisq.values(corr, snrv, norm, stilde.psd,
+                                 idx+stilde.analyze.start, template)
+
+        out_vals['sg_chisq'] = sg_chisq.values(stilde, template, stilde.psd,
+                                      snrv, norm,
+                                      out_vals['chisq'],
+                                      out_vals['chisq_dof'],
+                                      idx+stilde.analyze.start)
+
+        out_vals['cont_chisq'] = \
+              autochisq.values(snr, idx+stilde.analyze.start, template,
+                               stilde.psd, norm, stilde=stilde,
+                               low_frequency_cutoff=flow)
+
+        idx += stilde.cumulative_index
+
+        out_vals['time_index'] = idx
+        out_vals['snr'] = snrv * norm
+        out_vals['sigmasq'] = numpy.zeros(len(snrv), dtype=float32) + sigmasq
+
+        if opt.psdvar_short_segment is not None:
+            out_vals['psd_var_val'] = \
+                        pycbc.psd.find_trigger_value(psd_var,
+                                      out_vals['time_index'],
+                                      opt.gps_start_time, opt.sample_rate)
+        out_vals_all.append(out_vals)
+        return out_vals_all
 
 with ctx:
     # The following FFTW specific options needed to wait until
@@ -385,88 +446,18 @@ with ctx:
 
     tsetup = time.time() - tstart
     tcheckpoint = time.time()
-
-    # Note: in the class-based approach used now, 'template' is not explicitly used
-    # within the loop.  Rather, the iteration simply fills the memory specifed in
-    # the 'template_mem' argument to MatchedFilterControl with the next template
-    # from the bank.
-    for t_num in range(len(bank) - tnum_start):
-        t_num += tnum_start
-        template = None
-
-        out_vals_all = []
-        for s_num, stilde in enumerate(segments):
-            # Filter check checks the 'inj_filter_rejector' options to
-            # determine whether
-            # to filter this template/segment if injections are present.
-            if not inj_filter_rejector.template_segment_checker(
-                    bank, t_num, stilde, opt.gps_start_time):
-                continue
-            if template is None:
-                template = bank[t_num]
-
-            if opt.cluster_method == "window":
-                cluster_window = int(opt.cluster_window * gwstrain.sample_rate)
-            if opt.cluster_method == "template":
-                cluster_window = int(template.chirp_length * gwstrain.sample_rate)
-
-            if opt.update_progress:
-                update_progress((t_num + (s_num / float(len(segments))) ) / len(bank),
-                                opt.update_progress, opt.update_progress_file)
-            logging.info("Filtering template %d/%d segment %d/%d" %
-                         (t_num + 1, len(bank), s_num + 1, len(segments)))
-
-            sigmasq = template.sigmasq(stilde.psd)
-            snr, norm, corr, idx, snrv = \
-               matched_filter.matched_filter_and_cluster(s_num,
-                                                         sigmasq,
-                                                         cluster_window,
-                                                         epoch=stilde._epoch)
-
-            if not len(idx):
-                continue
-
-            out_vals = out_vals_ref.copy()
-            out_vals['bank_chisq'], out_vals['bank_chisq_dof'] = \
-                  bank_chisq.values(template, stilde.psd, stilde, snrv, norm,
-                                    idx+stilde.analyze.start)
-
-            out_vals['chisq'], out_vals['chisq_dof'] = \
-                  power_chisq.values(corr, snrv, norm, stilde.psd,
-                                     idx+stilde.analyze.start, template)
-
-            out_vals['sg_chisq'] = sg_chisq.values(stilde, template, stilde.psd,
-                                          snrv, norm,
-                                          out_vals['chisq'],
-                                          out_vals['chisq_dof'],
-                                          idx+stilde.analyze.start)
-
-            out_vals['cont_chisq'] = \
-                  autochisq.values(snr, idx+stilde.analyze.start, template,
-                                   stilde.psd, norm, stilde=stilde,
-                                   low_frequency_cutoff=flow)
-
-            idx += stilde.cumulative_index
-
-            out_vals['time_index'] = idx
-            out_vals['snr'] = snrv * norm
-            out_vals['sigmasq'] = numpy.zeros(len(snrv), dtype=float32) + sigmasq
-
-            if opt.psdvar_short_segment is not None:
-                out_vals['psd_var_val'] = \
-                            pycbc.psd.find_trigger_value(psd_var,
-                                          out_vals['time_index'],
-                                          opt.gps_start_time, opt.sample_rate)
-            out_vals_all.append(out_vals)
+    
+    for t_num in range(tnum_start, len(bank)):
+        out_vals_all = template_triggers(t_num)
             
-        if template is not None:
+        if len(out_vals_all) > 0:
             event_mgr.new_template(tmplt=template.params)  
             
-        for out_vals in out_vals_all:
-            event_mgr.add_template_events(names, [out_vals[n] for n in names])
+            for out_vals in out_vals_all:
+                event_mgr.add_template_events(names, [out_vals[n] for n in names])
 
-        event_mgr.cluster_template_events("time_index", "snr", cluster_window)
-        event_mgr.finalize_template_events()
+            event_mgr.cluster_template_events("time_index", "snr", cluster_window)
+            event_mgr.finalize_template_events()
         
         if opt.finalize_events_template_rate is not None and \
                 not (t_num+1) % opt.finalize_events_template_rate:

--- a/bin/pycbc_inspiral
+++ b/bin/pycbc_inspiral
@@ -24,7 +24,7 @@ import pycbc.version
 from pycbc import vetoes, psd, waveform, strain, scheme, fft, DYN_RANGE_FAC, events
 from pycbc.vetoes.sgchisq import SingleDetSGChisq
 from pycbc.filter import MatchedFilterControl, make_frequency_series, qtransform
-from pycbc.types import TimeSeries, FrequencySeries, zeros, float32, complex64
+from pycbc.types import TimeSeries, FrequencySeries, zeros, float32, float64, complex64
 from multiprocessing import Pool
 import pycbc.version
 import pycbc.opt
@@ -236,8 +236,7 @@ strain_segments = strain.StrainSegments.from_cli(opt, gwstrain)
 def template_triggers(t_num):
     """ Get the triggers for a specific template
     """
-    template = None
-    tparm = None
+    template = tparam = None
     out_vals_all = []
     for s_num, stilde in enumerate(segments):
         # Filter check checks the 'inj_filter_rejector' options to

--- a/bin/pycbc_inspiral
+++ b/bin/pycbc_inspiral
@@ -464,7 +464,7 @@ with ctx:
         
         if opt.finalize_events_template_rate is not None and \
                 not (tchunk[0]) % opt.finalize_events_template_rate:
-            event_mgr.consolidate_events(opt, injections=gwstrain[0].injections)
+            event_mgr.consolidate_events(opt, gwstrain=gwstrain)
 
         if opt.checkpoint_interval and \
             (time.time() - tcheckpoint > opt.checkpoint_interval):
@@ -476,7 +476,7 @@ with ctx:
             event_mgr.save_state(max(tchunk), opt.output + '.checkpoint')
             sys.exit(opt.checkpoint_exit_code)           
 
-event_mgr.consolidate_events(opt, injections=gwstrain[0].injections))
+event_mgr.consolidate_events(opt, gwstrain=gwstrain)
 event_mgr.finalize_events()
 logging.info("Outputting %s triggers" % str(len(event_mgr.events)))
 

--- a/bin/pycbc_inspiral
+++ b/bin/pycbc_inspiral
@@ -201,7 +201,7 @@ parser.add_argument("--checkpoint-exit-code", type=int, default=77,
 parser.add_argument("--multiprocessing-nprocesses", type=int,
                     help="Parallelize over multiple processes, note this is"
                          "separate from threading using the proc. scheme")
-parser.add_argument("--multiprocess-groupby", type-int,
+parser.add_argument("--multiprocess-groupby", type=int,
                     help="Number of template to group together for parallel"
                          "analysis, should be multiple of nprocesses")
 
@@ -272,6 +272,7 @@ with ctx:
         'bank_chisq_dof' : int,
         'cont_chisq'     : float32,
         'psd_var_val'    : float32,
+        'sigmasq'        : float32,
                 }
     out_types.update(SingleDetSGChisq.returns)
     out_vals = {key: None for key in out_types}
@@ -402,8 +403,7 @@ with ctx:
                 continue
             if template is None:
                 template = bank[t_num]
-                event_mgr.new_template(tmplt=template.params,
-                    sigmasq=template.sigmasq(segments[0].psd))
+                event_mgr.new_template(tmplt=template.params)
 
             if opt.cluster_method == "window":
                 cluster_window = int(opt.cluster_window * gwstrain.sample_rate)
@@ -417,9 +417,10 @@ with ctx:
             logging.info("Filtering template %d/%d segment %d/%d" %
                          (t_num + 1, len(bank), s_num + 1, len(segments)))
 
+            sigmasq = template.sigmasq(stilde.psd)
             snr, norm, corr, idx, snrv = \
                matched_filter.matched_filter_and_cluster(s_num,
-                                                         template.sigmasq(stilde.psd),
+                                                         sigmasq,
                                                          cluster_window,
                                                          epoch=stilde._epoch)
 
@@ -449,6 +450,7 @@ with ctx:
 
             out_vals['time_index'] = idx
             out_vals['snr'] = snrv * norm
+            out_vals['sigmasq'] = numpy.zeros(len(snrv), dtype=float32) + sigmasq
 
             if opt.psdvar_short_segment is not None:
                 out_vals['psd_var_val'] = \

--- a/bin/pycbc_inspiral
+++ b/bin/pycbc_inspiral
@@ -371,13 +371,9 @@ with ctx:
 
     sg_chisq = SingleDetSGChisq.from_cli(opt, bank, opt.chisq_bins)
 
-    ntemplates = len(bank)
-    nfilters = 0
-
-    logging.info("Full template bank size: %s", ntemplates)
+    logging.info("Full template bank size: %s", len(bank))
     bank.template_thinning(inj_filter_rejector)
-    if not len(bank) == ntemplates:
-        logging.info("Template bank size after thinning: %s", len(bank))
+    logging.info("Template bank size after thinning: %s", len(bank))
 
     tsetup = time.time() - tstart
     tcheckpoint = time.time()
@@ -415,7 +411,6 @@ with ctx:
             logging.info("Filtering template %d/%d segment %d/%d" %
                          (t_num + 1, len(bank), s_num + 1, len(segments)))
 
-            nfilters = nfilters + 1
             snr, norm, corr, idx, snrv = \
                matched_filter.matched_filter_and_cluster(s_num,
                                                          template.sigmasq(stilde.psd),
@@ -459,6 +454,7 @@ with ctx:
 
         event_mgr.cluster_template_events("time_index", "snr", cluster_window)
         event_mgr.finalize_template_events()
+        
         if opt.finalize_events_template_rate is not None and \
                 not (t_num+1) % opt.finalize_events_template_rate:
             event_mgr.consolidate_events(opt, gwstrain=gwstrain)
@@ -479,7 +475,7 @@ logging.info("Outputting %s triggers" % str(len(event_mgr.events)))
 
 tstop = time.time()
 run_time = tstop - tstart
-event_mgr.save_performance(ncores, nfilters, ntemplates, run_time, tsetup)
+event_mgr.save_performance(ncores, len(segments), len(bank), run_time, tsetup)
 
 logging.info("Writing out triggers")
 event_mgr.write_events(opt.output)

--- a/bin/pycbc_inspiral
+++ b/bin/pycbc_inspiral
@@ -275,8 +275,8 @@ with ctx:
         'sigmasq'        : float32,
                 }
     out_types.update(SingleDetSGChisq.returns)
-    out_vals = {key: None for key in out_types}
-    names = sorted(out_vals.keys())
+    out_vals_ref = {key: None for key in out_types}
+    names = sorted(out_vals_ref.keys())
 
     if len(strain_segments.segment_slices) == 0:
         logging.info("--filter-inj-only specified and no injections in analysis time")
@@ -394,6 +394,7 @@ with ctx:
         t_num += tnum_start
         template = None
 
+        out_vals_all = []
         for s_num, stilde in enumerate(segments):
             # Filter check checks the 'inj_filter_rejector' options to
             # determine whether
@@ -403,13 +404,11 @@ with ctx:
                 continue
             if template is None:
                 template = bank[t_num]
-                event_mgr.new_template(tmplt=template.params)
 
             if opt.cluster_method == "window":
                 cluster_window = int(opt.cluster_window * gwstrain.sample_rate)
             if opt.cluster_method == "template":
-                cluster_window = \
-                    int(template.chirp_length * gwstrain.sample_rate)
+                cluster_window = int(template.chirp_length * gwstrain.sample_rate)
 
             if opt.update_progress:
                 update_progress((t_num + (s_num / float(len(segments))) ) / len(bank),
@@ -427,6 +426,7 @@ with ctx:
             if not len(idx):
                 continue
 
+            out_vals = out_vals_ref.copy()
             out_vals['bank_chisq'], out_vals['bank_chisq_dof'] = \
                   bank_chisq.values(template, stilde.psd, stilde, snrv, norm,
                                     idx+stilde.analyze.start)
@@ -457,7 +457,12 @@ with ctx:
                             pycbc.psd.find_trigger_value(psd_var,
                                           out_vals['time_index'],
                                           opt.gps_start_time, opt.sample_rate)
-
+            out_vals_all.append(out_vals)
+            
+        if template is not None:
+            event_mgr.new_template(tmplt=template.params)  
+            
+        for out_vals in out_vals_all:
             event_mgr.add_template_events(names, [out_vals[n] for n in names])
 
         event_mgr.cluster_template_events("time_index", "snr", cluster_window)

--- a/examples/inspiral/run.sh
+++ b/examples/inspiral/run.sh
@@ -1,16 +1,15 @@
-#!/bin/bash -e
+#!/bin/bash
+# Test pycbc inspiral by running over GW150914 with a limited template bank
+echo -e "\\n\\n>> [`date`] Getting template bank"
+wget -nc https://github.com/gwastro/pycbc-config/raw/master/test/inspiral/H1L1-SBANK_FOR_GW150914ER10.xml.gz
 
-function inspiral_run {
-echo -e "\\n\\n>> [`date`] Running pycbc inspiral $1:$3 with $2 threads"
-# Uncomment if you want profile information
-#python -m cProfile -o output_$1_$2_$3.pstats
-`which pycbc_inspiral` \
---frame-files DATA_FILE.gwf \
+echo -e "\\n\\n>> [`date`] Running pycbc inspiral"
+pycbc_inspiral \
+--frame-type LOSC \
 --sample-rate 2048 \
 --sgchisq-snr-threshold 6.0 \
 --sgchisq-locations "mtotal>40:20-30,20-45,20-60,20-75,20-90,20-105,20-120" \
 --segment-end-pad 16 \
---cluster-method window \
 --low-frequency-cutoff 30 \
 --pad-data 8 \
 --cluster-window 1 \
@@ -35,83 +34,13 @@ echo -e "\\n\\n>> [`date`] Running pycbc inspiral $1:$3 with $2 threads"
 --channel-name H1:LOSC-STRAIN \
 --gps-start-time 1126259078 \
 --gps-end-time 1126259846 \
---output H1-INSPIRAL_$1_$2_$3-OUT.hdf \
+--output H1-INSPIRAL-OUT.hdf \
+--verbose \
 --approximant "SPAtmplt:mtotal<4" "SEOBNRv4_ROM:mtotal<20" "SEOBNRv2_ROM_DoubleSpin:else" \
---fft-backends $1 \
---processing-scheme cpu:$2 \
---fftw-threads-backend $3 \
---use-compressed-waveforms \
---bank-file COMPRESSED_BANK.hdf \
-#--verbose 2> inspiral_$1_$2_$3.log
-# Uncomment above if you want logging
+--bank-file H1L1-SBANK_FOR_GW150914ER10.xml.gz 2> inspiral.log
 
-# Uncomment for profile pngs
-#gprof2dot -f pstats output_$1_$2_$3.pstats | dot -Tpng -o $1_$2_$3.png
+cat inspiral.log | head -10
+cat inspiral.log | tail -20
 
 echo -e "\\n\\n>> [`date`] test for GW150914"
-python ./check_GW150914_detection.py H1-INSPIRAL_$1_$2_$3-OUT.hdf
-}
-
-
-# Test pycbc inspiral by running over GW150914 with a limited template bank
-echo -e "\\n\\n>> [`date`] Getting template bank"
-wget -nc https://github.com/gwastro/pycbc-config/raw/master/test/inspiral/SMALLER_BANK_FOR_GW150914.hdf
-
-echo -e "\\n\\n>> [`date`] Compressing template bank"
-pycbc_compress_bank --bank-file SMALLER_BANK_FOR_GW150914.hdf --output COMPRESSED_BANK.hdf --sample-rate 4096 --segment-length 256 --compression-algorithm mchirp --psd-model aLIGOZeroDetHighPower --low-frequency-cutoff 30 --approximant "SEOBNRv4_ROM"
-
-echo -e "\\n\\n>> [`date`] Creating data file"
-pycbc_condition_strain \
---frame-type LOSC \
---sample-rate 2048 \
---pad-data 8 \
---autogating-width 0.25 \
---autogating-threshold 100 \
---autogating-cluster 0.5 \
---autogating-taper 0.25 \
---strain-high-pass 10 \
---channel-name H1:LOSC-STRAIN \
---gps-start-time 1126258578 \
---gps-end-time 1126259946 \
---output-strain-file DATA_FILE.gwf \
-
-
-start=`date +%s`
-inspiral_run fftw 16 openmp
-end=`date +%s`
-runtime_fftw_openmp_16=$((end-start))
-
-start=`date +%s`
-inspiral_run fftw 16 pthreads
-end=`date +%s`
-runtime_fftw_pthreads_16=$((end-start))
-
-# In all cases below the last argument is irrelevant
-start=`date +%s`
-inspiral_run fftw 1 openmp
-end=`date +%s`
-runtime_fftw_1=$((end-start))
-
-start=`date +%s`
-inspiral_run mkl 16 openmp
-end=`date +%s`
-runtime_mkl_16=$((end-start))
-
-start=`date +%s`
-inspiral_run mkl 1 openmp
-end=`date +%s`
-runtime_mkl_1=$((end-start))
-
-# Numpy doesn't include threading. We just want it to run, it won't be fast!
-start=`date +%s`
-inspiral_run numpy 1 openmp
-end=`date +%s`
-runtime_numpy_1=$((end-start))
-
-echo "RUN TIMES"
-echo "FFTW 16 threads with openmp " ${runtime_fftw_openmp_16}
-echo "FFTW 16 threads with pthreads" ${runtime_fftw_pthreads_16}
-echo "FFTW single core" ${runtime_fftw_1}
-echo "MKL 16 threads" ${runtime_mkl_16}
-echo "MKL 1 thread" ${runtime_mkl_1}
-echo "Numpy 1 thread" ${runtime_numpy_1}
+python ./check_GW150914_detection.py H1-INSPIRAL-OUT.hdf

--- a/examples/search/analysis.ini
+++ b/examples/search/analysis.ini
@@ -105,7 +105,6 @@ autogating-pad = 16
 low-frequency-cutoff = 20
 enable-bank-start-frequency =
 snr-threshold = 3.8
-cluster-method = window
 cluster-window = 1
 cluster-function = symmetric
 chisq-snr-threshold = 5.25

--- a/pycbc/events/eventmgr.py
+++ b/pycbc/events/eventmgr.py
@@ -348,7 +348,7 @@ class EventManager(object):
         self.accumulate.append(self.template_events)
         self.template_events = numpy.array([], dtype=self.event_dtype)
 
-    def consolidate_events(self, opt, gwstrain=None):
+    def consolidate_events(self, opt, injections=None):
         self.events = numpy.concatenate(self.accumulate)
         logging.info("We currently have %d triggers", len(self.events))
         if opt.chisq_threshold and opt.chisq_bins:
@@ -373,11 +373,10 @@ class EventManager(object):
                  log_chirp_width=opt.keep_loudest_log_chirp_window)
             logging.info("%d remaining triggers", len(self.events))
 
-        if opt.injection_window and hasattr(gwstrain, 'injections'):
+        if opt.injection_window and injections is not None:
             logging.info("Keeping triggers within %s seconds of injection",
                          opt.injection_window)
-            self.keep_near_injection(opt.injection_window,
-                                     gwstrain.injections)
+            self.keep_near_injection(opt.injection_window, injections)
             logging.info("%d remaining triggers", len(self.events))
 
         self.accumulate = [self.events]

--- a/pycbc/events/eventmgr.py
+++ b/pycbc/events/eventmgr.py
@@ -259,8 +259,7 @@ class EventManager(object):
             return
 
         inj_time = numpy.array(injections.end_times())
-        gpstime = self.events['time_index'].astype(numpy.float64)
-        gpstime = gpstime / self.opt.sample_rate + self.opt.gps_start_time
+        gpstime = self.events['end_time']
         i = indices_within_times(gpstime, inj_time - window, inj_time + window)
         self.events = self.events[i]
 
@@ -279,8 +278,7 @@ class EventManager(object):
         statv = ranking.get_sngls_ranking_from_trigs(e_copy, statname)
 
         # Convert trigger time to integer bin number
-        # NB time_index and window are in units of samples
-        wtime = (e_copy['time_index'] / window).astype(numpy.int32)
+        wtime = (e_copy['end_time'] / window).astype(numpy.int32)
         bins = numpy.unique(wtime)
 
         if log_chirp_width:
@@ -370,7 +368,7 @@ class EventManager(object):
                          opt.keep_loudest_num, opt.keep_loudest_interval,
                          opt.keep_loudest_stat)
             self.keep_loudest_in_interval\
-                (opt.keep_loudest_interval * opt.sample_rate,
+                (opt.keep_loudest_interval,
                  opt.keep_loudest_num, statname=opt.keep_loudest_stat,
                  log_chirp_width=opt.keep_loudest_log_chirp_window)
             logging.info("%d remaining triggers", len(self.events))
@@ -448,9 +446,7 @@ class EventManager(object):
             f['bank_chisq'] = self.events['bank_chisq']
             f['bank_chisq_dof'] = self.events['bank_chisq_dof']
             f['cont_chisq'] = self.events['cont_chisq']
-            f['end_time'] = self.events['time_index'] / \
-                              float(self.opt.sample_rate) \
-                            + self.opt.gps_start_time
+            f['end_time'] = self.events['end_time']
             try:
                 # Precessing
                 template_sigmasq_plus = numpy.array(

--- a/pycbc/events/eventmgr.py
+++ b/pycbc/events/eventmgr.py
@@ -468,10 +468,7 @@ class EventManager(object):
                 f['sigmasq'] = template_sigmasq_plus[tid]
             except Exception:
                 # Not precessing
-                template_sigmasq = numpy.array(
-                                  [t['sigmasq'] for t in self.template_params],
-                                               dtype=numpy.float32)
-                f['sigmasq'] = template_sigmasq[tid]
+                f['sigmasq'] = self.events['sigmasq']
 
             template_durations = [p['tmplt'].template_duration for p in
                                   self.template_params]

--- a/pycbc/events/eventmgr.py
+++ b/pycbc/events/eventmgr.py
@@ -348,7 +348,7 @@ class EventManager(object):
         self.accumulate.append(self.template_events)
         self.template_events = numpy.array([], dtype=self.event_dtype)
 
-    def consolidate_events(self, opt, injections=None):
+    def consolidate_events(self, opt, gwstrain=None):
         self.events = numpy.concatenate(self.accumulate)
         logging.info("We currently have %d triggers", len(self.events))
         if opt.chisq_threshold and opt.chisq_bins:
@@ -373,10 +373,11 @@ class EventManager(object):
                  log_chirp_width=opt.keep_loudest_log_chirp_window)
             logging.info("%d remaining triggers", len(self.events))
 
-        if opt.injection_window and injections is not None:
+        if opt.injection_window and hasattr(gwstrain, 'injections'):
             logging.info("Keeping triggers within %s seconds of injection",
                          opt.injection_window)
-            self.keep_near_injection(opt.injection_window, injections)
+            self.keep_near_injection(opt.injection_window,
+                                     gwstrain.injections)
             logging.info("%d remaining triggers", len(self.events))
 
         self.accumulate = [self.events]

--- a/pycbc/inject/inject.py
+++ b/pycbc/inject/inject.py
@@ -592,6 +592,12 @@ class CBCHDFInjectionSet(_HDFInjectionSet):
         injected = copy.copy(self)
         injected.table = injections[np.array(injected_ids).astype(int)]
         if inj_filter_rejector is not None:
+            if hasattr(inj_filter_rejector, 'injected'):
+                prev_p = inj_filter_rejector.injection_params
+                prev_id = inj_filter_rejector.injection_ids
+                injected = numpy.concatenate([prev_p, injected])
+                injected_ids = numpy.concatenate([prev_id, injected_ids])
+               
             inj_filter_rejector.injection_params = injected
             inj_filter_rejector.injection_ids = injected_ids
         return injected

--- a/pycbc/inject/inject.py
+++ b/pycbc/inject/inject.py
@@ -593,6 +593,7 @@ class CBCHDFInjectionSet(_HDFInjectionSet):
         injected.table = injections[np.array(injected_ids).astype(int)]
         if inj_filter_rejector is not None:
             inj_filter_rejector.injection_params = injected
+            inj_filter_rejector.injection_ids = injected_ids
         return injected
 
     def make_strain_from_inj_object(self, inj, delta_t, detector_name,

--- a/pycbc/inject/injfilterrejector.py
+++ b/pycbc/inject/injfilterrejector.py
@@ -293,15 +293,10 @@ class InjFilterRejector(object):
             # If disabled, always filter (ie. return True)
             return True
 
-        # Get times covered by segment analyze
-        sample_rate = 2. * (len(segment) - 1) * segment.delta_f
-        cum_ind = segment.cumulative_index
-        diff = segment.analyze.stop - segment.analyze.start
-        seg_start_time = cum_ind / sample_rate + start_time
-        seg_end_time = (cum_ind + diff) / sample_rate + start_time
-        # And add buffer
-        seg_start_time = seg_start_time - self.seg_buffer
-        seg_end_time = seg_end_time + self.seg_buffer
+        # Get times covered by segment analyze and add buffer
+        sample_rate = segment.sample_rate
+        seg_start_time = segment.start_time - self.seg_buffer
+        seg_end_time = segment.end_time + self.seg_buffer
 
         # Chirp time test
         if self.chirp_time_window is not None:
@@ -372,7 +367,7 @@ class InjFilterRejector(object):
                 if isinstance(inj, np.record):
                     # hdf format file
                     end_time = inj['tc']
-                    sim_id = ii
+                    sim_id = self.injection_ids[ii]
                 else:
                     # must be an xml file originally
                     end_time = inj.geocent_end_time + \

--- a/pycbc/psd/__init__.py
+++ b/pycbc/psd/__init__.py
@@ -484,7 +484,7 @@ def generate_overlapping_psds(opt, gwstrain, flen, delta_f, flow,
         strain_part = gwstrain[start_idx:end_idx]
         psd = from_cli(opt, flen, delta_f, flow, strain=strain_part,
                        dyn_range_factor=dyn_range_factor, precision=precision)
-        psds_and_times.append( (start_idx, end_idx, psd) )
+        psds_and_times.append( (strain_part.start_time, strain_part.end_time, psd) )
     return psds_and_times
 
 def associate_psds_to_segments(opt, fd_segments, gwstrain, flen, delta_f, flow,
@@ -520,17 +520,22 @@ def associate_psds_to_segments(opt, fd_segments, gwstrain, flen, delta_f, flow,
         that precision. If 'double' the PSD will be converted to float64, if
         not already in that precision.
     """
-    psds_and_times = generate_overlapping_psds(opt, gwstrain, flen, delta_f,
+    if not isinstance(gwstrain, list):
+        gwstrain = [gwstrain]
+        
+    psds_and_times = []
+    for gws in gwstrain:
+        psds_and_times += generate_overlapping_psds(opt, gws, flen, delta_f,
                                        flow, dyn_range_factor=dyn_range_factor,
                                        precision=precision)
 
     for fd_segment in fd_segments:
         best_psd = None
         psd_overlap = 0
-        inp_seg = segments.segment(fd_segment.seg_slice.start,
-                                   fd_segment.seg_slice.stop)
-        for start_idx, end_idx, psd in psds_and_times:
-            psd_seg = segments.segment(start_idx, end_idx)
+        inp_seg = segments.segment(fd_segment.start_time
+                                   fd_segment.end_time)
+        for start, end, psd in psds_and_times:
+            psd_seg = segments.segment(start, end)
             if psd_seg.intersects(inp_seg):
                 curr_overlap = abs(inp_seg & psd_seg)
                 if curr_overlap > psd_overlap:

--- a/pycbc/psd/variation.py
+++ b/pycbc/psd/variation.py
@@ -185,7 +185,7 @@ def calc_filt_psd_variation(strain, segment, short_segment, psd_long_segment,
     return psd_var
 
 
-def find_trigger_value(psd_var, idx, start, sample_rate):
+def find_trigger_value(psd_var, time):
     """ Find the PSD variation value at a particular time with the filter
     method. If the time is outside the timeseries bound, 1. is given.
 
@@ -205,8 +205,6 @@ def find_trigger_value(psd_var, idx, start, sample_rate):
     vals : Array
         PSD variation value at a particular time
     """
-    # Find gps time of the trigger
-    time = start + idx / sample_rate
     # Extract the PSD variation at trigger time through linear
     # interpolation
     if not hasattr(psd_var, 'cached_psd_var_interpolant'):
@@ -215,5 +213,4 @@ def find_trigger_value(psd_var, idx, start, sample_rate):
             interpolate.interp1d(psd_var.sample_times.numpy(), psd_var.numpy(),
                                  fill_value=1.0, bounds_error=False)
     vals = psd_var.cached_psd_var_interpolant(time)
-
     return vals

--- a/pycbc/strain/__init__.py
+++ b/pycbc/strain/__init__.py
@@ -1,7 +1,7 @@
 from .recalibrate import CubicSpline, PhysicalModel
 
 from .strain import detect_loud_glitches
-from .strain import from_cli, from_cli_single_ifo, from_cli_multi_ifos
+from .strain import from_cli, from_cli_single_ifo, from_cli_multi_ifos, from_cli_multi_times
 from .strain import insert_strain_option_group, insert_strain_option_group_multi_ifo
 from .strain import verify_strain_options, verify_strain_options_multi_ifo
 from .strain import gate_data, StrainSegments, StrainBuffer

--- a/pycbc/strain/strain.py
+++ b/pycbc/strain/strain.py
@@ -436,8 +436,41 @@ def from_cli_multi_ifos(opt, ifos, inj_filter_rejector_dict=None, **kwargs):
                           inj_filter_rejector_dict[ifo], **kwargs)
     return strain
 
+def from_cli_multi_times(opt, inj_filter_rejector=None, **kwargs):
+    """ Get the strain for a single ifo but at multiple disjoint times
+    """
+    opts = []
+    
+    if len(opt.gps_start_time) != len(opt.gps_end_time):
+        raise ValueError("Must get the same number of gps start/end times")
+    
+    ntimes = len(opt.gps_start_time)
+    
+    if hasattr(opt.trig_start_time):
+        if (len(opt.trig_start_time) != len(opt.trig_end_time) or
+           len(opt.trig_start_time) != ntimes):
+           raise ValueError("""Must get the same number of trig start/end times
+                            as gps start/end times""")
+    
+    for j, (start, end) in enumerate(zip(opt.gps_start_time, opt.gps_end_time)):
+        nopt = copy.deepcopy(opt)
+        nopt.gps_start_time = start
+        nopt.gps_end_time = end
+        
+        if hasattr(opt.trig_start_time):
+            nopt.trig_start_time = opt.trig_start_time[j]
+            nopt.trig_end_time = opt.trig_end_time[j]
+        
+        opts.append(nopt)
+    
+    strains = []
+    for single_opts in opts:
+        strain = from_cli(single_opts, inj_filter_rejector=inj_filter_rejector,
+                          **kwargs)
+        strains.append(strain)
+    return strains
 
-def insert_strain_option_group(parser, gps_times=True):
+def insert_strain_option_group(parser, gps_times=True, multi_times=False):
     """ Add strain-related options to the optparser object.
 
     Adds the options used to call the pycbc.strain.from_cli function to an
@@ -451,6 +484,8 @@ def insert_strain_option_group(parser, gps_times=True):
     gps_times : bool, optional
         Include ``--gps-start-time`` and ``--gps-end-time`` options. Default
         is True.
+    multi_times: bool, optional
+        Allow the gps/trigger time options to be lists. Default is False. 
     """
 
     data_reading_group = parser.add_argument_group("Options for obtaining h(t)",
@@ -463,10 +498,12 @@ def insert_strain_option_group(parser, gps_times=True):
     if gps_times:
         data_reading_group.add_argument("--gps-start-time",
                                 help="The gps start time of the data "
-                                     "(integer seconds)", type=int)
+                                     "(integer seconds)", type=int, 
+                                     nargs='+' if multi_times else None)
         data_reading_group.add_argument("--gps-end-time",
                                 help="The gps end time of the data "
-                                     "(integer seconds)", type=int)
+                                     "(integer seconds)", type=int,
+                                     nargs='+' if multi_times else None)
 
     data_reading_group.add_argument("--strain-high-pass", type=float,
               help="High pass frequency")
@@ -947,7 +984,6 @@ class StrainSegments(object):
             for analysis.
         """
         self._fourier_segments = None
-        self.strain = strain
 
         self.delta_t = strain.delta_t
         self.sample_rate = strain.sample_rate
@@ -1082,6 +1118,7 @@ class StrainSegments(object):
 
         self.segment_slices = segment_slices_red
         self.analyze_slices = analyze_slices_red
+        self.strain = [strain for s in self.segment_slices]
 
     def fourier_segments(self):
         """ Return a list of the FFT'd segments.
@@ -1093,24 +1130,25 @@ class StrainSegments(object):
         """
         if not self._fourier_segments:
             self._fourier_segments = []
-            for seg_slice, ana in zip(self.segment_slices, self.analyze_slices):
-                if seg_slice.start >= 0 and seg_slice.stop <= len(self.strain):
-                    freq_seg = make_frequency_series(self.strain[seg_slice])
+            itera =  zip(self.segment_slices, self.analyze_slices, self.strain)
+            for seg_slice, ana, strain in itera:
+                if seg_slice.start >= 0 and seg_slice.stop <= len(strain):
+                    freq_seg = make_frequency_series(strain[seg_slice])
                 # Assume that we cannot have a case where we both zero-pad on
                 # both sides
                 elif seg_slice.start < 0:
-                    strain_chunk = self.strain[:seg_slice.stop]
+                    strain_chunk = strain[:seg_slice.stop]
                     strain_chunk.prepend_zeros(-seg_slice.start)
                     freq_seg = make_frequency_series(strain_chunk)
-                elif seg_slice.stop > len(self.strain):
-                    strain_chunk = self.strain[seg_slice.start:]
-                    strain_chunk.append_zeros(seg_slice.stop - len(self.strain))
+                elif seg_slice.stop > len(strain):
+                    strain_chunk = strain[seg_slice.start:]
+                    strain_chunk.append_zeros(seg_slice.stop - len(strain))
                     freq_seg = make_frequency_series(strain_chunk)
                 freq_seg.analyze = ana
                 freq_seg.cumulative_index = seg_slice.start + ana.start
                 freq_seg.seg_slice = seg_slice
+                freq_seg.strain = strain
                 self._fourier_segments.append(freq_seg)
-
         return self._fourier_segments
 
     @classmethod
@@ -1128,7 +1166,30 @@ class StrainSegments(object):
                    allow_zero_padding=opt.allow_zero_padding)
 
     @classmethod
-    def insert_segment_option_group(cls, parser):
+    def from_cli_multitimes(cls, opt, strains):
+        """Calculate the segmentation of the strain data for analysis from
+        the command line options.
+        """
+        segs = []
+        for j in range(len(opt.gps_start_times)):
+            segmented = cls(strain, segment_length=opt.segment_length,
+                       segment_start_pad=opt.segment_start_pad,
+                       segment_end_pad=opt.segment_end_pad,
+                       trigger_start=opt.trig_start_time[j],
+                       trigger_end=opt.trig_end_time[j],
+                       filter_inj_only=opt.filter_inj_only,
+                       injection_window=opt.injection_window,
+                       allow_zero_padding=opt.allow_zero_padding)
+            segs.append(segmented)
+        combined = copy.deepcopy(segmented)
+        combined.segment_slices = sum(seg.segment_slices for seg in segs)
+        combined.analyze_slices = sum(seg.analyze_slices for seg in segs)
+        combined.full_segment_slices = sum(seg.full_segment_slices for seg in segs)
+        combined.strain = sum(seg.strain for seg in segs)
+        return combined
+        
+    @classmethod
+    def insert_segment_option_group(cls, parser, multi_times=False):
         segment_group = parser.add_argument_group(
                                   "Options for segmenting the strain",
                                   "These options are used to determine how to "
@@ -1136,8 +1197,10 @@ class StrainSegments(object):
                                   "and for determining the portion of each to "
                                   "analyze for triggers. ")
         segment_group.add_argument("--trig-start-time", type=int, default=0,
+                    nargs='+' if multi_times else None,
                     help="(optional) The gps time to start recording triggers")
         segment_group.add_argument("--trig-end-time", type=int, default=0,
+                    nargs='+' if multi_times else None,
                     help="(optional) The gps time to stop recording triggers")
         segment_group.add_argument("--segment-length", type=int,
                           help="The length of each strain segment in seconds.")


### PR DESCRIPTION
I'm posting this early just so people are aware of something I'm planning to add. The PR is not feature complete and will require patches elsewhere (i.e. in mergetrigs, in the workflow, etc) to function as intended for production use. 

The main point is to enable two things (1) ensure that jobs use a similar number of segments and (2) use many more segments to help amortize the cost of template generation (and generally improve performance). The aim would be to allow configurations where O(100) or more segments can be analyzed by a similar number of templates. 

This PR is also intended to be followed up by more invasive changes (separate PRs I'll post later) to the filtering which would re-organize the matched filter control to enable batched processing of the segements. This should allow a much easier optimization for multi-threshold, gpus, and other architectures by putting the costly operations int much few calls. 