### PR TITLE
Allow injection module to support mode array

### DIFF
--- a/pycbc/waveform/waveform.py
+++ b/pycbc/waveform/waveform.py
@@ -398,7 +398,7 @@ def parse_mode_array(input_params):
     the modes (e.g., ``22 33 44``), or an array of ints or floats (e.g.,
     ``[22., 33., 44.]``.
     """
-    if 'mode_array' in input_params:
+    if 'mode_array' in input_params and input_params['mode_array'] is not None:
         mode_array = input_params['mode_array']
         if isinstance(mode_array, str):
             mode_array = mode_array.split()

--- a/pycbc/waveform/waveform.py
+++ b/pycbc/waveform/waveform.py
@@ -388,17 +388,48 @@ def get_obj_attrs(obj):
 
     return pr
 
+
+def parse_mode_array(input_params):
+    """Ensures mode_array argument in a dictionary of input parameters is
+    a list of tuples of (l, m), where l and m are ints.
+
+    Accepted formats for the ``mode_array`` argument is a list of tuples of
+    ints (e.g., ``[(2, 2), (3, 3), (4, 4)]``), a space-separated string giving
+    the modes (e.g., ``22 33 44``), or an array of ints or floats (e.g.,
+    ``[22., 33., 44.]``.
+    """
+    if 'mode_array' in input_params:
+        mode_array = input_params['mode_array']
+        if isinstance(mode_array, str):
+            mode_array = mode_array.split()
+        if not isinstance(mode_array, (numpy.ndarray, list)):
+            mode_array = [mode_array]
+        for ii, ma in enumerate(mode_array):
+            # if ma is a float or int, convert to str (e.g., 22. -> '22'), so
+            # that...
+            if isinstance(ma, (float, int)):
+                ma = str(int(ma))
+            # if ma is a str convert to (int, int) (e.g., '22' -> (2, 2))
+            if isinstance(ma, str):
+                l, m = ma
+                ma = (int(l), int(m))
+            mode_array[ii] = ma
+        input_params['mode_array'] = mode_array
+    return input_params
+
+
 def props(obj, **kwargs):
     """ Return a dictionary built from the combination of defaults, kwargs,
     and the attributes of the given object.
     """
     pr = get_obj_attrs(obj)
     pr.update(kwargs)
-
     # Get the parameters to generate the waveform
     # Note that keyword arguments override values in the template object
     input_params = default_args.copy()
     input_params.update(pr)
+    # if mode array present and is a string, convert to a list of tuples
+    input_params = parse_mode_array(input_params)
     return input_params
 
 def check_args(args, required_args):
@@ -872,6 +903,7 @@ def seobnrv4hm_length_in_time(**kwargs):
     return get_hm_length_in_time('SEOBNRv4', 5, **kwargs)
 
 def get_hm_length_in_time(lor_approx, maxm_default, **kwargs):
+    kwargs = parse_mode_array(kwargs)
     if 'mode_array' in kwargs and kwargs['mode_array'] is not None:
         maxm = max(m for _, m in kwargs['mode_array'])
     else:


### PR DESCRIPTION
Currently, `pycbc_create_injections` does cannot support the mode array argument. This is because the argument needs to be provided as an array of tuples, which cannot be specified in a config file. This fixes that by allowing the waveform module to accept a space-separated string of integers indicating the modes to use, e.g., `'22 33 44'`.