### PR TITLE
fix to ids for HDF inj in injfilterrejector, allow multiple use

### DIFF
--- a/bin/pycbc_inspiral
+++ b/bin/pycbc_inspiral
@@ -244,7 +244,7 @@ def template_triggers(t_num):
         # determine whether
         # to filter this template/segment if injections are present.
         if not inj_filter_rejector.template_segment_checker(
-                bank, t_num, stilde, opt.gps_start_time):
+                bank, t_num, stilde):
             continue
         if template is None:
             template = bank[t_num]

--- a/bin/pycbc_multi_inspiral
+++ b/bin/pycbc_multi_inspiral
@@ -495,7 +495,7 @@ with ctx:
             analyse_segment = True
             for ifo in opt.instruments:
                 if not inj_filter_rejector[ifo].template_segment_checker(
-                        bank, t_num, stilde[ifo], opt.gps_start_time[ifo]):
+                        bank, t_num, stilde[ifo]):
                     logging.info("Skipping segment %d/%d with template %d/%d"
                                  " as no detectable injection is present"
                                  % (s_num + 1, len(segments[ifo]),

--- a/pycbc/inject/inject.py
+++ b/pycbc/inject/inject.py
@@ -592,7 +592,14 @@ class CBCHDFInjectionSet(_HDFInjectionSet):
         injected = copy.copy(self)
         injected.table = injections[np.array(injected_ids).astype(int)]
         if inj_filter_rejector is not None:
+            if hasattr(inj_filter_rejector, 'injected'):
+                prev_p = inj_filter_rejector.injection_params
+                prev_id = inj_filter_rejector.injection_ids
+                injected = numpy.concatenate([prev_p, injected])
+                injected_ids = numpy.concatenate([prev_id, injected_ids])
+               
             inj_filter_rejector.injection_params = injected
+            inj_filter_rejector.injection_ids = injected_ids
         return injected
 
     def make_strain_from_inj_object(self, inj, delta_t, detector_name,

--- a/pycbc/inject/inject.py
+++ b/pycbc/inject/inject.py
@@ -595,9 +595,9 @@ class CBCHDFInjectionSet(_HDFInjectionSet):
             if hasattr(inj_filter_rejector, 'injected'):
                 prev_p = inj_filter_rejector.injection_params
                 prev_id = inj_filter_rejector.injection_ids
-                injected = numpy.concatenate([prev_p, injected])
-                injected_ids = numpy.concatenate([prev_id, injected_ids])
-               
+                injected = np.concatenate([prev_p, injected])
+                injected_ids = np.concatenate([prev_id, injected_ids])
+
             inj_filter_rejector.injection_params = injected
             inj_filter_rejector.injection_ids = injected_ids
         return injected

--- a/pycbc/inject/injfilterrejector.py
+++ b/pycbc/inject/injfilterrejector.py
@@ -293,15 +293,10 @@ class InjFilterRejector(object):
             # If disabled, always filter (ie. return True)
             return True
 
-        # Get times covered by segment analyze
-        sample_rate = 2. * (len(segment) - 1) * segment.delta_f
-        cum_ind = segment.cumulative_index
-        diff = segment.analyze.stop - segment.analyze.start
-        seg_start_time = cum_ind / sample_rate + start_time
-        seg_end_time = (cum_ind + diff) / sample_rate + start_time
-        # And add buffer
-        seg_start_time = seg_start_time - self.seg_buffer
-        seg_end_time = seg_end_time + self.seg_buffer
+        # Get times covered by segment analyze and add buffer
+        sample_rate = segment.sample_rate
+        seg_start_time = segment.start_time - self.seg_buffer
+        seg_end_time = segment.end_time + self.seg_buffer
 
         # Chirp time test
         if self.chirp_time_window is not None:
@@ -372,7 +367,7 @@ class InjFilterRejector(object):
                 if isinstance(inj, np.record):
                     # hdf format file
                     end_time = inj['tc']
-                    sim_id = ii
+                    sim_id = self.injection_ids[ii]
                 else:
                     # must be an xml file originally
                     end_time = inj.geocent_end_time + \

--- a/pycbc/inject/injfilterrejector.py
+++ b/pycbc/inject/injfilterrejector.py
@@ -294,7 +294,6 @@ class InjFilterRejector(object):
             return True
 
         # Get times covered by segment analyze and add buffer
-        sample_rate = segment.sample_rate
         seg_start_time = segment.start_time - self.seg_buffer
         seg_end_time = segment.end_time + self.seg_buffer
 

--- a/pycbc/inject/injfilterrejector.py
+++ b/pycbc/inject/injfilterrejector.py
@@ -265,7 +265,7 @@ class InjFilterRejector(object):
                                   delta_f=self.coarsematch_deltaf)
         self.short_injections[simulation_id] = new_inj
 
-    def template_segment_checker(self, bank, t_num, segment, start_time):
+    def template_segment_checker(self, bank, t_num, segment):
         """Test if injections in segment are worth filtering with template.
 
         Using the current template, current segment, and injections within that


### PR DESCRIPTION
This patch addresses a couple issues, one is a bug. 

1) I don't think the ids were used correclty (probably my fault originall) for injfliterrejector when comparing to the precalculated injection short version of the waveform. This makes it more explicit. 

2) This enables one to use the injfilterrejector multiple times (i.e. with multiple calls to the injection code) although still only if the same injection file is used. 