### PR TITLE
disable dqsegdb to fix test suite

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ dynesty
 epsie>=0.6
 
 # For LDG service access
-dqsegdb
+#dqsegdb # disabled untill next dqsegdb release which fixes setuptools issues
 dqsegdb2>=1.0.1
 https://github.com/ahnitz/pegasus-wms-python3/archive/master.tar.gz
 amqplib


### PR DESCRIPTION
The tests are broken due to dqsegdb being unable to install. See https://github.com/ligovirgo/dqsegdb/issues/79. 

We can re-enable whenever the next release is that is able to fix this issue. 