### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ADD docker/etc/cvmfs/config-osg.opensciencegrid.org.conf /etc/cvmfs/config-osg.o
 RUN dnf -y install https://ecsft.cern.ch/dist/cvmfs/cvmfs-release/cvmfs-release-latest.noarch.rpm && dnf -y install cvmfs cvmfs-config-default && dnf clean all && dnf makecache && \
     dnf -y groupinstall "Development Tools" \
                         "Scientific Support" && \
-    rpm -e --nodeps git perl-Git && dnf -y install @python38 rsync zlib-devel libpng-devel libjpeg-devel sqlite-devel openssl-devel fftw-libs-single fftw-devel fftw fftw-libs-long fftw-libs fftw-libs-double gsl gsl-devel hdf5 hdf5-devel python38-devel which osg-ca-certs && python3.8 -m pip install --upgrade pip setuptools wheel cython && python3.8 -m pip install mkl ipython jupyter lalsuite && \
+    rpm -e --nodeps git perl-Git && dnf -y install @python38 rsync zlib-devel libpng-devel libjpeg-devel sqlite-devel openssl-devel fftw-libs-single fftw-devel fftw fftw-libs-long fftw-libs fftw-libs-double gsl gsl-devel hdf5 hdf5-devel python38-devel which osg-ca-certs && python3.8 -m pip install --upgrade pip setuptools wheel cython && python3.8 -m pip install mkl ipython jupyter jupyterhub jupyterlab lalsuite && \
     dnf -y install https://repo.opensciencegrid.org/osg/3.5/el8/testing/x86_64/osg-wn-client-3.5-5.osg35.el8.noarch.rpm && dnf clean all
 
 # set up environment


### PR DESCRIPTION
LIGO hosts Jupyterlab instances which are really useful. These run on underlying kernels, and the PyCBC releases should be one of those. Running these kernels from this Docker image (or using a conda/CVMFS build) seems to be the preferred solution. Adding in two additional dependencies to facilitate this as requested. (I'll check with with Philippe Grassia who requested this before wanting to merge).