### PR TITLE
Highpass waveforms in gated gaussian if the data were highpassed

### DIFF
--- a/pycbc/inference/models/gaussian_noise.py
+++ b/pycbc/inference/models/gaussian_noise.py
@@ -520,7 +520,7 @@ class BaseGaussianNoise(BaseDataModel):
             The name of the section to load data options from.
         \**kwargs :
             All additional keyword arguments are passed to the class. Any
-            provided keyword will over ride what is in the config file.
+            provided keyword will override what is in the config file.
         """
         # get the injection file, to replace any FROM_INJECTION settings
         if 'injection-file' in cp.options('data'):
@@ -594,6 +594,7 @@ class BaseGaussianNoise(BaseDataModel):
         gates = gates_from_cli(opts)
         if gates:
             args['gates'] = gates
+        args.update(kwargs)
         return cls(**args)
 
 


### PR DESCRIPTION
If the data were highpassed for the gated gaussian model, then you can get spurious large likelihoods for time domain waveforms if they are not also highpassed. This is due to excess large low frequency power in the waveform that's not downweighted by the PSD. This fixes that by highpass waveforms if the `strain-high-pass` is set the data section of the config file. For example, 220+221 ringdown waveform [without highpass filtering](https://www.atlas.aei.uni-hannover.de/~work-cdcapano/projects/gated_gaussian/gw190521/test_model_updates/fdomain-220_221-nohighpass.png); same [with highpass filtering](https://www.atlas.aei.uni-hannover.de/~work-cdcapano/projects/gated_gaussian/gw190521/test_model_updates/fdomain-220_221-withhighpass.png). The former gives a log likelihood ratio of 327 (much too large for the parameters and the injection considered) while the latter gives -62.

@ahnitz Right now I'm using the same IIR highpass filter that is used by the strain module. I'm not sure if it'd better to use the FIR filter instead, or just do something directly in the frequency domain. Timing this, it's 25% slower with the highpass for ringdown waveforms with a 2s gate (~300ms without highpassing, ~400ms with). Let me know if you think that'd be better.