### PR TITLE
Add setproctitle to companion.txt

### DIFF
--- a/companion.txt
+++ b/companion.txt
@@ -16,3 +16,6 @@ cpnest; python_version >= '3.5'
 pymultinest
 ultranest
 https://github.com/willvousden/ptemcee/archive/master.tar.gz
+
+# useful to look at PyCBC Live with htop
+setproctitle


### PR DESCRIPTION
`setproctitle` can be useful when looking at a running instance of PyCBC Live with `htop`. This adds it to `companion.txt`.