### PR TITLE
Add lowpass filter option to strain generation

### DIFF
--- a/pycbc/filter/resample.py
+++ b/pycbc/filter/resample.py
@@ -388,8 +388,7 @@ def interpolate_complex_frequency(series, delta_f, zeros_offset=0, side='right')
 
     return out_series
 
-__all__ = ['resample_to_delta_t', 'highpass', 'lowpass', 
-           'interpolate_complex_frequency', 'highpass_fir', 
-           'lowpass_fir', 'notch_fir', 'fir_zero_filter',
-          ]
+__all__ = ['resample_to_delta_t', 'highpass', 'lowpass',
+           'interpolate_complex_frequency', 'highpass_fir',
+           'lowpass_fir', 'notch_fir', 'fir_zero_filter']
 

--- a/pycbc/filter/resample.py
+++ b/pycbc/filter/resample.py
@@ -311,7 +311,7 @@ def lowpass(timeseries, frequency, filter_order=8, attenuation=0.1):
     Time Series: TimeSeries
         The time series to be low-passed.
     frequency: float
-        The frequency below which is suppressed.
+        The frequency above which is suppressed.
     filter_order: {8, int}, optional
         The order of the filter to use when low-passing the time series.
     attenuation: {0.1, float}, optional
@@ -320,7 +320,7 @@ def lowpass(timeseries, frequency, filter_order=8, attenuation=0.1):
     Returns
     -------
     Time Series: TimeSeries
-        A  new TimeSeries that has been high-passed.
+        A  new TimeSeries that has been low-passed.
 
     Raises
     ------
@@ -328,7 +328,6 @@ def lowpass(timeseries, frequency, filter_order=8, attenuation=0.1):
         time_series is not an instance of TimeSeries.
     TypeError:
         time_series is not real valued
-
     """
 
     if not isinstance(timeseries, TimeSeries):
@@ -389,5 +388,8 @@ def interpolate_complex_frequency(series, delta_f, zeros_offset=0, side='right')
 
     return out_series
 
-__all__ = ['resample_to_delta_t', 'highpass', 'lowpass', 'interpolate_complex_frequency', 'highpass_fir', 'lowpass_fir', 'notch_fir', 'fir_zero_filter']
+__all__ = ['resample_to_delta_t', 'highpass', 'lowpass', 
+           'interpolate_complex_frequency', 'highpass_fir', 
+           'lowpass_fir', 'notch_fir', 'fir_zero_filter',
+          ]
 

--- a/pycbc/filter/resample.py
+++ b/pycbc/filter/resample.py
@@ -186,6 +186,9 @@ def resample_to_delta_t(timeseries, delta_t, method='butterworth'):
 
 _highpass_func = {numpy.dtype('float32'): lal.HighPassREAL4TimeSeries,
                  numpy.dtype('float64'): lal.HighPassREAL8TimeSeries}
+_lowpass_func = {numpy.dtype('float32'): lal.LowPassREAL4TimeSeries,
+                 numpy.dtype('float64'): lal.LowPassREAL8TimeSeries}
+
 
 def notch_fir(timeseries, f1, f2, order, beta=5.0):
     """ notch filter the time series using an FIR filtered generated from
@@ -298,6 +301,50 @@ def highpass(timeseries, frequency, filter_order=8, attenuation=0.1):
     return TimeSeries(lal_data.data.data, delta_t = lal_data.deltaT,
                       dtype=timeseries.dtype, epoch=timeseries._epoch)
 
+def lowpass(timeseries, frequency, filter_order=8, attenuation=0.1):
+    """Return a new timeseries that is lowpassed.
+
+    Return a new time series that is lowpassed below the `frequency`.
+
+    Parameters
+    ----------
+    Time Series: TimeSeries
+        The time series to be low-passed.
+    frequency: float
+        The frequency below which is suppressed.
+    filter_order: {8, int}, optional
+        The order of the filter to use when low-passing the time series.
+    attenuation: {0.1, float}, optional
+        The attenuation of the filter.
+
+    Returns
+    -------
+    Time Series: TimeSeries
+        A  new TimeSeries that has been high-passed.
+
+    Raises
+    ------
+    TypeError:
+        time_series is not an instance of TimeSeries.
+    TypeError:
+        time_series is not real valued
+
+    """
+
+    if not isinstance(timeseries, TimeSeries):
+        raise TypeError("Can only resample time series")
+
+    if timeseries.kind is not 'real':
+        raise TypeError("Time series must be real")
+
+    lal_data = timeseries.lal()
+    _lowpass_func[timeseries.dtype](lal_data, frequency,
+                                    1-attenuation, filter_order)
+
+    return TimeSeries(lal_data.data.data, delta_t = lal_data.deltaT,
+                      dtype=timeseries.dtype, epoch=timeseries._epoch)
+
+
 def interpolate_complex_frequency(series, delta_f, zeros_offset=0, side='right'):
     """Interpolate complex frequency series to desired delta_f.
 
@@ -342,5 +389,5 @@ def interpolate_complex_frequency(series, delta_f, zeros_offset=0, side='right')
 
     return out_series
 
-__all__ = ['resample_to_delta_t', 'highpass', 'interpolate_complex_frequency', 'highpass_fir', 'lowpass_fir', 'notch_fir', 'fir_zero_filter']
+__all__ = ['resample_to_delta_t', 'highpass', 'lowpass', 'interpolate_complex_frequency', 'highpass_fir', 'lowpass_fir', 'notch_fir', 'fir_zero_filter']
 

--- a/pycbc/strain/strain.py
+++ b/pycbc/strain/strain.py
@@ -28,7 +28,7 @@ from pycbc.types import required_opts, required_opts_multi_ifo
 from pycbc.types import ensure_one_opt, ensure_one_opt_multi_ifo
 from pycbc.types import copy_opts_for_single_ifo
 from pycbc.inject import InjectionSet, SGBurstInjectionSet
-from pycbc.filter import resample_to_delta_t, highpass, make_frequency_series
+from pycbc.filter import resample_to_delta_t, lowpass, highpass, make_frequency_series
 from pycbc.filter.zpk import filter_zpk
 from pycbc.waveform.spa_tmplt import spa_distance
 import pycbc.psd
@@ -297,6 +297,10 @@ def from_cli(opt, dyn_range_fac=1, precision='single',
         logging.info("Highpass Filtering")
         strain = highpass(strain, frequency=opt.strain_high_pass)
 
+    if opt.strain_low_pass:
+        logging.info("Lowpass Filtering")
+        strain = lowpass(strain, frequency=opt.strain_low_pass)
+
     if opt.sample_rate:
         logging.info("Resampling data")
         strain = resample_to_delta_t(strain,
@@ -470,6 +474,8 @@ def insert_strain_option_group(parser, gps_times=True):
 
     data_reading_group.add_argument("--strain-high-pass", type=float,
               help="High pass frequency")
+    data_reading_group.add_argument("--strain-low-pass", type=float,
+              help="Low pass frequency")
     data_reading_group.add_argument("--pad-data", default=8,
               help="Extra padding to remove highpass corruption "
                    "(integer seconds)", type=int)

--- a/pycbc/strain/strain.py
+++ b/pycbc/strain/strain.py
@@ -297,10 +297,6 @@ def from_cli(opt, dyn_range_fac=1, precision='single',
         logging.info("Highpass Filtering")
         strain = highpass(strain, frequency=opt.strain_high_pass)
 
-    if opt.strain_low_pass:
-        logging.info("Lowpass Filtering")
-        strain = lowpass(strain, frequency=opt.strain_low_pass)
-
     if opt.sample_rate:
         logging.info("Resampling data")
         strain = resample_to_delta_t(strain,
@@ -371,6 +367,10 @@ def from_cli(opt, dyn_range_fac=1, precision='single',
     if opt.strain_high_pass:
         logging.info("Highpass Filtering")
         strain = highpass(strain, frequency=opt.strain_high_pass)
+
+    if opt.strain_low_pass:
+        logging.info("Lowpass Filtering")
+        strain = lowpass(strain, frequency=opt.strain_low_pass)
 
     if hasattr(opt, 'witness_frame_type') and opt.witness_frame_type:
         stilde = strain.to_frequencyseries()

--- a/pycbc/strain/strain.py
+++ b/pycbc/strain/strain.py
@@ -654,6 +654,10 @@ def insert_strain_option_group_multi_ifo(parser, gps_times=True):
                             action=MultiDetOptionAction,
                             type=float, metavar='IFO:FREQUENCY',
                             help="High pass frequency")
+    data_reading_group_multi.add_argument("--strain-low-pass", nargs='+',
+                            action=MultiDetOptionAction,
+                            type=float, metavar='IFO:FREQUENCY',
+                            help="Low pass frequency")
     data_reading_group_multi.add_argument("--pad-data", nargs='+', default=8,
                             action=MultiDetOptionAction,
                             type=int, metavar='IFO:LENGTH',


### PR DESCRIPTION
This PR adds the option to lowpass strain data as part of `strain.from_cli`. The lowpass method is based on the lal lowpass function, and mirrors the method used for high passing as part of the current strain generation process. 

This PR was originally part of #3804, but is now a separate PR based on the suggestion of @titodalcanton. 