### PR TITLE
Remove more pre-Python-3.7 stuff

### DIFF
--- a/bin/all_sky_search/pycbc_calculate_psd
+++ b/bin/all_sky_search/pycbc_calculate_psd
@@ -2,7 +2,7 @@
 """ Calculate psd estimates for analysis segments
 """
 import logging, argparse, numpy, h5py, multiprocessing, time, copy
-from six.moves import (range, zip_longest)
+from six.moves import zip_longest
 import pycbc, pycbc.psd, pycbc.strain, pycbc.events
 from pycbc.version import git_verbose_msg as version
 from pycbc.fft.fftw import set_measure_level

--- a/bin/bank/pycbc_aligned_bank_cat
+++ b/bin/bank/pycbc_aligned_bank_cat
@@ -28,7 +28,6 @@ import argparse
 import numpy
 import pycbc.version
 import h5py
-from six.moves import range
 from glue.ligolw import ligolw
 from glue.ligolw import lsctables
 from glue.ligolw import utils

--- a/bin/bank/pycbc_bank_verification
+++ b/bin/bank/pycbc_bank_verification
@@ -37,7 +37,6 @@ import copy
 import logging
 import numpy
 import h5py
-from six.moves import range
 from glue.ligolw import ligolw, table, lsctables, utils as ligolw_utils
 from pycbc import tmpltbank, psd, strain, pnutils
 import matplotlib

--- a/bin/bank/pycbc_geom_aligned_2dstack
+++ b/bin/bank/pycbc_geom_aligned_2dstack
@@ -32,7 +32,6 @@ import copy
 import numpy
 import logging
 import h5py
-from six.moves import range
 import pycbc.tmpltbank
 import pycbc.version
 from pycbc import pnutils

--- a/bin/bank/pycbc_geom_aligned_bank
+++ b/bin/bank/pycbc_geom_aligned_bank
@@ -34,7 +34,6 @@ import logging
 import distutils.spawn
 import h5py
 from scipy import spatial
-from six.moves import range
 from glue.ligolw import ligolw
 from glue.ligolw import table
 from glue.ligolw import lsctables

--- a/bin/bank/pycbc_geom_nonspinbank
+++ b/bin/bank/pycbc_geom_nonspinbank
@@ -26,7 +26,6 @@ import math
 import copy
 import numpy
 import logging
-from six.moves import range
 import pycbc
 import pycbc.version
 import pycbc.psd

--- a/bin/bank/pycbc_tmpltbank_to_chi_params
+++ b/bin/bank/pycbc_tmpltbank_to_chi_params
@@ -36,12 +36,10 @@ import copy
 import logging
 import numpy
 import h5py
-from six.moves import range
 from glue.ligolw import ligolw, table, lsctables, utils as ligolw_utils
 from pycbc import tmpltbank, psd, strain, pnutils
 import matplotlib
 matplotlib.use('Agg')
-import pylab
 
 # Read command line option
 _desc = __doc__[1:]

--- a/bin/plotting/pycbc_plot_psd_file
+++ b/bin/plotting/pycbc_plot_psd_file
@@ -3,7 +3,6 @@
 """
 import matplotlib
 matplotlib.use('Agg')
-from six.moves import range
 import h5py, numpy, argparse, pylab, pycbc.results, sys
 import pycbc.psd
 import pycbc.version

--- a/bin/plotting/pycbc_plot_psd_timefreq
+++ b/bin/plotting/pycbc_plot_psd_timefreq
@@ -26,7 +26,6 @@ import argparse
 import numpy
 import h5py
 import sys
-from six.moves import range
 import matplotlib
 matplotlib.use('agg')
 import pylab

--- a/bin/plotting/pycbc_plot_singles_timefreq
+++ b/bin/plotting/pycbc_plot_singles_timefreq
@@ -27,7 +27,6 @@ import argparse
 import numpy as np
 import matplotlib
 matplotlib.use('agg')
-from six.moves import range
 import pylab as pl
 import matplotlib.mlab as mlab
 from matplotlib.colors import LogNorm

--- a/bin/pycbc_inspiral
+++ b/bin/pycbc_inspiral
@@ -18,7 +18,6 @@
 
 import sys, os, copy
 import logging, argparse, numpy, itertools
-from six.moves import range
 import pycbc
 import pycbc.version
 from pycbc import vetoes, psd, waveform, strain, scheme, fft, DYN_RANGE_FAC, events

--- a/bin/pycbc_split_inspinj
+++ b/bin/pycbc_split_inspinj
@@ -1,9 +1,7 @@
-#!/usr/bin/env /usr/bin/python
+#!/usr/bin/env python
 
 # Copyright (C) 2014 Andrew Lundgren
-import sys
 import argparse
-from six.moves import range
 from glue.ligolw import utils as ligolw_utils
 from glue.ligolw import ligolw, lsctables
 from itertools import cycle

--- a/companion.txt
+++ b/companion.txt
@@ -6,13 +6,13 @@ healpy
 
 # Needed for gracedb uploads and skymap generation
 ligo-gracedb
-ligo.skymap; python_version >= '3.5'
+ligo.skymap
 
 # Needed for ringdown
 pykerr
 
 # auxiliary samplers
-cpnest; python_version >= '3.5'
+cpnest
 pymultinest
 ultranest
 https://github.com/willvousden/ptemcee/archive/master.tar.gz

--- a/pycbc/filter/qtransform.py
+++ b/pycbc/filter/qtransform.py
@@ -29,7 +29,6 @@ This module retrives a timeseries and then calculates
 the q-transform of that time series
 """
 
-from six.moves import range
 import numpy
 from numpy import ceil, log, exp
 from pycbc.types.timeseries import FrequencySeries, TimeSeries

--- a/pycbc/io/hdf.py
+++ b/pycbc/io/hdf.py
@@ -8,7 +8,6 @@ import logging
 import inspect
 
 from itertools import chain
-from six.moves import range
 from six.moves import cPickle as pickle
 from six import raise_from
 

--- a/pycbc/io/live.py
+++ b/pycbc/io/live.py
@@ -4,7 +4,6 @@ import pycbc
 import numpy
 import lal
 import json
-from six import u as unicode
 from glue.ligolw import ligolw
 from glue.ligolw import lsctables
 from glue.ligolw import utils as ligolw_utils
@@ -24,11 +23,11 @@ from pycbc.mchirp_area import calc_probabilities
 def _build_series(series, dim_names, comment, delta_name, delta_unit):
     Attributes = ligolw.sax.xmlreader.AttributesImpl
     elem = ligolw.LIGO_LW(
-            Attributes({u"Name": unicode(series.__class__.__name__)}))
+            Attributes({'Name': str(series.__class__.__name__)}))
     if comment is not None:
         elem.appendChild(ligolw.Comment()).pcdata = comment
-    elem.appendChild(ligolw.Time.from_gps(series.epoch, u"epoch"))
-    elem.appendChild(LIGOLWParam.from_pyvalue(u'f0', series.f0, unit=u's^-1'))
+    elem.appendChild(ligolw.Time.from_gps(series.epoch, 'epoch'))
+    elem.appendChild(LIGOLWParam.from_pyvalue('f0', series.f0, unit='s^-1'))
     delta = getattr(series, delta_name)
     if numpy.iscomplexobj(series.data.data):
         data = numpy.row_stack((numpy.arange(len(series.data.data)) * delta,
@@ -52,10 +51,10 @@ def snr_series_to_xml(snr_series, document, sngl_inspiral_id):
     snr_lal = snr_series.lal()
     snr_lal.name = 'snr'
     snr_lal.sampleUnits = ''
-    snr_xml = _build_series(snr_lal, (u'Time', u'Time,Real,Imaginary'), None,
+    snr_xml = _build_series(snr_lal, ('Time', 'Time,Real,Imaginary'), None,
                             'deltaT', 's')
     snr_node = document.childNodes[-1].appendChild(snr_xml)
-    eid_param = LIGOLWParam.from_pyvalue(u'event_id', sngl_inspiral_id)
+    eid_param = LIGOLWParam.from_pyvalue('event_id', sngl_inspiral_id)
     snr_node.appendChild(eid_param)
 
 def make_psd_xmldoc(psddict, xmldoc=None):
@@ -65,16 +64,16 @@ def make_psd_xmldoc(psddict, xmldoc=None):
     xmldoc = ligolw.Document() if xmldoc is None else xmldoc.childNodes[0]
 
     # the PSDs must be children of a LIGO_LW with name "psd"
-    root_name = u"psd"
+    root_name = 'psd'
     Attributes = ligolw.sax.xmlreader.AttributesImpl
     lw = xmldoc.appendChild(
-        ligolw.LIGO_LW(Attributes({u"Name": root_name})))
+        ligolw.LIGO_LW(Attributes({'Name': root_name})))
 
     for instrument, psd in psddict.items():
-        xmlseries = _build_series(psd, (u"Frequency,Real", u"Frequency"),
+        xmlseries = _build_series(psd, ('Frequency,Real', 'Frequency'),
                                   None, 'deltaF', 's^-1')
         fs = lw.appendChild(xmlseries)
-        fs.appendChild(LIGOLWParam.from_pyvalue(u'instrument', instrument))
+        fs.appendChild(LIGOLWParam.from_pyvalue('instrument', instrument))
     return xmldoc
 
 class SingleCoincForGraceDB(object):

--- a/pycbc/noise/reproduceable.py
+++ b/pycbc/noise/reproduceable.py
@@ -21,7 +21,6 @@
 #
 # =============================================================================
 #
-from six.moves import range
 import numpy, pycbc.psd
 from pycbc.types import TimeSeries, FrequencySeries, complex_same_precision_as
 from numpy.random import RandomState

--- a/pycbc/psd/estimate.py
+++ b/pycbc/psd/estimate.py
@@ -16,8 +16,6 @@
 """Utilites to estimate PSDs from data.
 """
 
-from six.moves import range
-
 import numpy
 from pycbc.types import Array, FrequencySeries, TimeSeries, zeros
 from pycbc.types import real_same_precision_as, complex_same_precision_as

--- a/pycbc/tmpltbank/bank_output_utils.py
+++ b/pycbc/tmpltbank/bank_output_utils.py
@@ -1,5 +1,4 @@
 from __future__ import division
-from six.moves import range
 import numpy
 from lal import PI, MTSUN_SI, TWOPI, GAMMA
 from glue.ligolw import ligolw, lsctables, ilwd, utils as ligolw_utils

--- a/pycbc/tmpltbank/brute_force_methods.py
+++ b/pycbc/tmpltbank/brute_force_methods.py
@@ -1,7 +1,6 @@
 from __future__ import division
 import copy
 import numpy
-from six.moves import range
 from pycbc.tmpltbank.coord_utils import get_cov_params
 
 

--- a/pycbc/tmpltbank/calc_moments.py
+++ b/pycbc/tmpltbank/calc_moments.py
@@ -16,7 +16,6 @@
 
 from __future__ import division
 import numpy
-from six.moves import range
 from pycbc.tmpltbank.lambda_mapping import generate_mapping
 
 

--- a/pycbc/tmpltbank/coord_utils.py
+++ b/pycbc/tmpltbank/coord_utils.py
@@ -17,7 +17,6 @@
 from __future__ import division
 import logging
 import numpy
-from six.moves import range
 from pycbc.tmpltbank.lambda_mapping import get_chirp_params
 from pycbc import conversions
 from pycbc import pnutils

--- a/pycbc/tmpltbank/lambda_mapping.py
+++ b/pycbc/tmpltbank/lambda_mapping.py
@@ -16,7 +16,6 @@
 from __future__ import division
 import re
 import numpy
-from six.moves import range
 from lal import MTSUN_SI, PI, CreateREAL8Vector
 import lalsimulation
 

--- a/pycbc/tmpltbank/lattice_utils.py
+++ b/pycbc/tmpltbank/lattice_utils.py
@@ -16,7 +16,6 @@
 
 from __future__ import division
 import copy
-from six.moves import range
 import numpy
 import lal
 

--- a/pycbc/tmpltbank/partitioned_bank.py
+++ b/pycbc/tmpltbank/partitioned_bank.py
@@ -17,7 +17,6 @@
 import copy
 import numpy
 import logging
-from six.moves import range
 from pycbc.tmpltbank import coord_utils
 
 class PartitionedTmpltbank(object):

--- a/pycbc/waveform/waveform.py
+++ b/pycbc/waveform/waveform.py
@@ -41,7 +41,6 @@ import pycbc
 from .spa_tmplt import spa_tmplt, spa_tmplt_norm, spa_tmplt_end, \
                       spa_tmplt_precondition, spa_amplitude_factor, \
                       spa_length_in_time
-from six.moves import range as xrange
 
 
 class NoWaveformError(Exception):
@@ -274,20 +273,20 @@ def _lalsim_sgburst_waveform(**p):
 
     return hp, hc
 
-for approx_enum in xrange(0, lalsimulation.NumApproximants):
+for approx_enum in range(0, lalsimulation.NumApproximants):
     if lalsimulation.SimInspiralImplementedTDApproximants(approx_enum):
         approx_name = lalsimulation.GetStringFromApproximant(approx_enum)
         _lalsim_enum[approx_name] = approx_enum
         _lalsim_td_approximants[approx_name] = _lalsim_td_waveform
 
-for approx_enum in xrange(0, lalsimulation.NumApproximants):
+for approx_enum in range(0, lalsimulation.NumApproximants):
     if lalsimulation.SimInspiralImplementedFDApproximants(approx_enum):
         approx_name = lalsimulation.GetStringFromApproximant(approx_enum)
         _lalsim_enum[approx_name] = approx_enum
         _lalsim_fd_approximants[approx_name] = _lalsim_fd_waveform
 
 # sine-Gaussian burst
-for approx_enum in xrange(0, lalsimulation.NumApproximants):
+for approx_enum in range(0, lalsimulation.NumApproximants):
     if lalsimulation.SimInspiralImplementedFDApproximants(approx_enum):
         approx_name = lalsimulation.GetStringFromApproximant(approx_enum)
         _lalsim_enum[approx_name] = approx_enum

--- a/pycbc/workflow/psd.py
+++ b/pycbc/workflow/psd.py
@@ -17,7 +17,6 @@
 """This module is responsible for setting up PSD-related jobs in workflows.
 """
 
-from six.moves import range
 from pycbc.workflow.core import FileList, make_analysis_dir, Executable, File
 from pycbc.workflow.core import SegFile
 from ligo.segments import segmentlist

--- a/test/test_autochisq.py
+++ b/test/test_autochisq.py
@@ -1,16 +1,13 @@
-import sys
-from six.moves import range
 import pycbc
 from pycbc.fft.fftw import set_measure_level
 set_measure_level(0)
 from pycbc.filter import  matched_filter_core
-from pycbc.types import Array, TimeSeries, FrequencySeries, float32, complex64, zeros
-from pycbc.types import complex_same_precision_as,real_same_precision_as
+from pycbc.types import Array, TimeSeries, FrequencySeries
 import pycbc.waveform
 from pycbc.waveform import *
 from pycbc.vetoes import *
 import numpy as np
-from math import cos, sin, sqrt, pi, atan2, exp
+from math import cos, sin, sqrt, pi, exp
 import unittest
 from utils import parse_args_all_schemes, simple_exit
 import time

--- a/test/test_coinc_stat.py
+++ b/test/test_coinc_stat.py
@@ -11,17 +11,6 @@ parse_args_cpu_only('coinc stats')
 
 class CoincStatTest(unittest.TestCase):
     def setUp(self):
-        # FIXME this is only necessary on Python 2, remove at some point
-        if not hasattr(self, 'subTest'):
-            class DummyCM:
-                def __init__(self, msg=''):
-                    print('Testing ' + msg)
-                def __enter__(self):
-                    return self
-                def __exit__(self, ex_type, ex_value, ex_tb):
-                    return False
-            self.subTest = DummyCM
-
         # one could loop over all single rankings
         # and detector combinations for a complete test
         self.single_rank = 'snr'

--- a/test/test_tmpltbank.py
+++ b/test/test_tmpltbank.py
@@ -35,12 +35,8 @@ from pycbc import pnutils
 from pycbc.types import Array
 from pycbc.filter import match
 from pycbc.waveform import get_fd_waveform
-from six.moves import range
-import difflib
-import sys
 import matplotlib
 matplotlib.use('Agg')
-import pylab
 
 import unittest
 from utils import parse_args_cpu_only, simple_exit

--- a/tools/pycbc_test_suite.sh
+++ b/tools/pycbc_test_suite.sh
@@ -48,7 +48,7 @@ if [ "$PYCBC_TEST_TYPE" = "help" ] || [ -z ${PYCBC_TEST_TYPE+x} ]; then
 fi
 
 if [ "$PYCBC_TEST_TYPE" = "search" ] || [ -z ${PYCBC_TEST_TYPE+x} ]; then
-    #run pycbc inspiral test
+    # run pycbc inspiral test
     pushd examples/inspiral
     bash -e run.sh
     if test $? -ne 0 ; then
@@ -60,20 +60,17 @@ if [ "$PYCBC_TEST_TYPE" = "search" ] || [ -z ${PYCBC_TEST_TYPE+x} ]; then
     fi
     popd
 
-    # run PyCBC Live test if running in Python > 3.6
-    if [ "$PYTHON_VERSION" = "3" && "$PYTHON_MINOR_VERSION" -ge "7" ]
-    then
-        pushd examples/live
-        bash -e run.sh
-        if test $? -ne 0 ; then
-            RESULT=1
-            echo -e "    FAILED!"
-            echo -e "---------------------------------------------------------"
-        else
-            echo -e "    Pass."
-        fi
-        popd
+    # run PyCBC Live test
+    pushd examples/live
+    bash -e run.sh
+    if test $? -ne 0 ; then
+        RESULT=1
+        echo -e "    FAILED!"
+        echo -e "---------------------------------------------------------"
+    else
+        echo -e "    Pass."
     fi
+    popd
 fi
 
 if [ "$PYCBC_TEST_TYPE" = "inference" ] || [ -z ${PYCBC_TEST_TYPE+x} ]; then
@@ -162,20 +159,17 @@ if [ "$PYCBC_TEST_TYPE" = "inference" ] || [ -z ${PYCBC_TEST_TYPE+x} ]; then
     fi
     popd
 
-    ## Run pycbc_make_skymap example (requires Python > 3.6)
-    if [ "$PYTHON_VERSION" = "3" && "$PYTHON_MINOR_VERSION" -ge "7" ]
-    then
-        pushd examples/make_skymap
-        bash -e simulated_data.sh
-        if test $? -ne 0 ; then
-            RESULT=1
-            echo -e "    FAILED!"
-            echo -e "---------------------------------------------------------"
-        else
-            echo -e "    Pass."
-        fi
-        popd
+    ## Run pycbc_make_skymap example
+    pushd examples/make_skymap
+    bash -e simulated_data.sh
+    if test $? -ne 0 ; then
+        RESULT=1
+        echo -e "    FAILED!"
+        echo -e "---------------------------------------------------------"
+    else
+        echo -e "    Pass."
     fi
+    popd
 fi
 
 if [ "$PYCBC_TEST_TYPE" = "docs" ] || [ -z ${PYCBC_TEST_TYPE+x} ]; then


### PR DESCRIPTION
Remove more pre-Python-3.7 stuff, in particular `from six.moves import range`. Also removes a few unused imports.

Edit: it also re-enables the tests for PyCBC Live and `pycbc_make_skymap`, which were accidentally disabled in #3719.