### PR TITLE
Add required arguments to source classification

### DIFF
--- a/examples/live/run.sh
+++ b/examples/live/run.sh
@@ -178,6 +178,9 @@ python -m mpi4py `which pycbc_live` \
 --round-start-time 4 \
 --start-time $gps_start_time \
 --end-time $gps_end_time \
+--src-class-mchirp-to-delta 0.01 \
+--src-class-eff-to-lum-distance 0.74899 \
+--src-class-lum-distance-to-delta -0.51557 -0.32195 \
 --verbose
 
 echo -e "\\n\\n>> [`date`] Checking results"

--- a/pycbc/mchirp_area.py
+++ b/pycbc/mchirp_area.py
@@ -36,17 +36,17 @@ def insert_args(parser):
                                    "Used as limits of integration of the "
                                    "different CBC regions.")
     mchirp_group.add_argument('--src-class-mchirp-to-delta', type=float,
-                              metavar='m0',
+                              metavar='m0', required=True,
                               help='Coefficient to estimate the value of the '
                                    'mchirp uncertainty by mchirp_delta = '
                                    'm0 * mchirp.')
     mchirp_group.add_argument('--src-class-eff-to-lum-distance', type=float,
-                              metavar='a0',
+                              metavar='a0', required=True,
                               help='Coefficient to estimate the value of the '
                                    'luminosity distance from the minimum '
                                    'eff distance by D_lum = a0 * min(D_eff).')
     mchirp_group.add_argument('--src-class-lum-distance-to-delta', type=float,
-                              nargs=2, metavar=('b0', 'b1'),
+                              nargs=2, metavar=('b0', 'b1'), required=True,
                               help='Coefficients to estimate the value of the '
                                    'uncertainty on the luminosity distance '
                                    'from the estimated luminosity distance and'


### PR DESCRIPTION
As noted in #3807,  some required arguments for running `mchirp_area.py` were not added to the pycbc-live test script (`/examples/live/run.sh`). I added the required flag for the arguments to the module, and their latest values to the script.