### PR TITLE
Update GWOSC channel name for O3 data

### DIFF
--- a/pycbc/frame/losc.py
+++ b/pycbc/frame/losc.py
@@ -53,10 +53,10 @@ def get_run(time, ifo=None):
         raise ValueError('Time %s not available in a public dataset' % time)
 
 def _get_channel(time):
-    if 1164556817 <= time <= 1187733618:
-        return 'GWOSC-16KHZ_R1_STRAIN'
-    else:
+    if time < 1164556817:
         return 'LOSC-STRAIN'
+    else:
+        return 'GWOSC-16KHZ_R1_STRAIN'
 
 def losc_frame_json(ifo, start_time, end_time):
     """ Get the information about the public data files in a duration of time


### PR DESCRIPTION
The _get_channel function in the losc module returns the O1 channel name for O3 data, but the O3 release uses the same channel name as the O2 data. This PR updates the logic in the _get_channel function.

CAVEAT: double-checking the [GWOSC O1 documentation](https://www.gw-openscience.org/O1/), I found that the LOSC_STRAIN channel name in O1 was only used for the 4KHz data. Hence, as it is now, if using this function to get the channel name for GWOSC data, one would obtain 4KHz data for O1 but 16KHz for O2 and O3. I suggest changing the function to return the same sample rate for all observing runs, i.e. either returning `GWOSC-16KHZ_R1_STRAIN` for all three observing runs, or changing O2 & O3 to return `GWOSC-4KHZ_R1_STRAIN`
Let me know which option is preferred and I can update the PR before merging.