### PR TITLE
for pycbc_coinc_findtrigs use atexit to clear files if job fails 

### DIFF
--- a/bin/all_sky_search/pycbc_coinc_findtrigs
+++ b/bin/all_sky_search/pycbc_coinc_findtrigs
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 import h5py, copy, argparse, logging, numpy, numpy.random, multiprocessing
-import shutil, uuid, os.path
+import shutil, uuid, os.path, atexit
 from ligo.segments import infinity
 from pycbc.events import veto, coinc, stat, ranking
 import pycbc.version
@@ -120,6 +120,13 @@ for i in range(len(args.trigger_files)):
     logging.info('Applying time shift multiple %i to ifo %s' %
                  (trigs.to_shift[-1], trigs.ifos[-1]))
     trigs.singles.append(reader)
+
+def exit_cleaning():
+    for fname in cleanup_files:
+    logging.info('cleaning up %s', fname)
+    os.remove(fname)
+
+atexit.register(exit_cleaning)
 
 # Coinc_segs contains only segments where all ifos are analyzed
 coinc_segs = veto.start_end_to_segments([-infinity()], [infinity()])
@@ -470,8 +477,5 @@ else:
     nslides = 0
 f.attrs['num_slides'] = nslides
 
-for fname in cleanup_files:
-    logging.info('cleaning up %s', fname)
-    os.remove(fname)
 
 logging.info('Done')

--- a/bin/all_sky_search/pycbc_coinc_findtrigs
+++ b/bin/all_sky_search/pycbc_coinc_findtrigs
@@ -1,9 +1,10 @@
 #!/usr/bin/env python
-import h5py, copy, argparse, logging, numpy, numpy.random, multiprocessing
+import h5py, copy, argparse, logging, numpy, numpy.random
 import shutil, uuid, os.path, atexit
 from ligo.segments import infinity
 from pycbc.events import veto, coinc, stat, ranking
 import pycbc.version
+from pycbc import pool
 from numpy.random import seed, shuffle
 from pycbc.io.hdf import ReadByTemplate
 from pycbc.types.optparse import MultiDetOptionAction
@@ -97,13 +98,20 @@ class MultiifoTrigs(object):
 
 trigs = MultiifoTrigs()
 cleanup_files = []
+
+def exit_cleaning():
+    for fname in cleanup_files:
+        logging.info('cleaning up %s', fname)
+        os.remove(fname)
+atexit.register(exit_cleaning)
+
 for i in range(len(args.trigger_files)):
     if args.stage_input:
         dest = os.path.join(args.stage_input_dir, str(uuid.uuid4()) + '.hdf')
         logging.info("Moving %s to shared memory as %s",
                      args.trigger_files[i], dest)
-        shutil.copyfile(args.trigger_files[i], dest)
         cleanup_files.append(dest)
+        shutil.copyfile(args.trigger_files[i], dest)
     else:
         dest = args.trigger_files[i]
 
@@ -120,13 +128,6 @@ for i in range(len(args.trigger_files)):
     logging.info('Applying time shift multiple %i to ifo %s' %
                  (trigs.to_shift[-1], trigs.ifos[-1]))
     trigs.singles.append(reader)
-
-def exit_cleaning():
-    for fname in cleanup_files:
-    logging.info('cleaning up %s', fname)
-    os.remove(fname)
-
-atexit.register(exit_cleaning)
 
 # Coinc_segs contains only segments where all ifos are analyzed
 coinc_segs = veto.start_end_to_segments([-infinity()], [infinity()])
@@ -427,7 +428,7 @@ def process_template(tnum):
 if args.nprocesses == 1:
     ldatas = list(map(process_template, list(template_ids)))
 else:
-    p = multiprocessing.Pool(args.nprocesses)
+    p = pool.BroadcastPool(args.nprocesses)
     ldatas = p.map(process_template, list(template_ids))
 
 logging.info('merging data from the templates')


### PR DESCRIPTION
This adds a couple features to pybc_coinc_findtrigs that help with multi-core use. 

(1) use atexit for temporary file cleanup in dev/shm. It should now work so that if the job is killed or evicted anytime before completion the files should be properly cleaned up
(2) use our broadcast pool as opposed to raw multiprocessing at it cleanly exits when a single sub-process fails instead of hanging multiprocessing can do.