### PR TITLE
Update pycbc_make_banksim

### DIFF
--- a/bin/pycbc_make_banksim
+++ b/bin/pycbc_make_banksim
@@ -211,7 +211,6 @@ skip_count = 0
 
 dag = CondorDAG(logfile)
 dag.set_dag_file("banksim")
-dag.set_dax_file("banksim")
 
 bsjob = BaseJob("log", "scripts/pycbc_banksim", confs, "banksim", gpu=gpu,
                 accounting_group=accounting_group)


### PR DESCRIPTION
This line shouldn't be here while this script is still using pipeline.py. It will cause a failure in python3 as that part of pipeline.py has not been updated for python3 (and probably should just be removed).

(@duncanmmacleod also a FYI to you to note that all of the pegasus stuff in pipeline.py of glue is completely broken!)