### PR TITLE
Use MarkupPy.markup instead of glue.markup

### DIFF
--- a/pycbc/results/legacy_grb.py
+++ b/pycbc/results/legacy_grb.py
@@ -26,7 +26,7 @@ import re
 import os
 from argparse import ArgumentParser
 from ligo import segments
-from glue import markup
+from MarkupPy import markup
 
 def initialize_page(title, style, script, header=None):
     """


### PR DESCRIPTION
This PR modifies the `legacy_grb.py` module to use the 'official' release of the `markup.py` module, instead of the one that @duncan-brown copied over to `glue`.

This adds a new runtime requirement on [`MarkupPy`](https://pypi.org/project/MarkupPy/) but I'm not sure where to declare that since it's only used in this one 'legacy' module.