### PR TITLE
Fix docker build

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -18,7 +18,7 @@ jobs:
         run: "docker build -t pycbc-docker-tmp ."
       -
         name: "Installing PyCBC and dependencies"
-        run: "docker run --privileged --name pycbc_inst -v `pwd`:/scratch:ro pycbc-docker-tmp /bin/bash -c /scratch/docker/etc/docker-install.sh"
+        run: "docker run --privileged --name pycbc_inst -v `pwd`:/scratch pycbc-docker-tmp /bin/bash -c /scratch/docker/etc/docker-install.sh"
       -
         env:
           DOCKER_IMG: pycbc/pycbc-el8


### PR DESCRIPTION
The Docker build has been failing recently (curiously not for patches submitted from the gwastro repo. apparently only from forks??). I think this is because we need to mount the PyCBC checkout directory with write access to be able to create the version.py file. I'm confused by this for a few reasons:

* Why didn't it fail before?
* Why only failing on forks?
* Why is version.py written in the *source* directory when doing `pip install .` shouldn't it be written in the install directory?

Anyway, this fixes things and doesn't cause any problems ...