### PR TITLE
set up phasetd histograms at instantiation but allow to delay

### DIFF
--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -288,7 +288,7 @@ class PhaseTDStatistic(QuadratureSumStatistic):
     """
 
     def __init__(self, sngl_ranking, files=None, ifos=None,
-                 skip_pregeneration=False, **kwargs):
+                 pregenerate_hist=True, **kwargs):
         """
         Create a statistic class instance
 
@@ -306,9 +306,9 @@ class PhaseTDStatistic(QuadratureSumStatistic):
         ifos: list of strs, needed here
             The list of detector names
 
-        skip_pregeneration: bool, optional
-            If True, do not pregenerate histogram on class instantiation.
-            Default is false.
+        pregenerate_hist: bool, optional
+            If False, do not pregenerate histogram on class instantiation.
+            Default is True.
         """
 
         QuadratureSumStatistic.__init__(self, sngl_ranking, files=files,
@@ -335,7 +335,7 @@ class PhaseTDStatistic(QuadratureSumStatistic):
         self.param_bin = {}
         self.two_det_flag = (len(ifos) == 2)
         self.two_det_weights = {}
-        if not skip_pregeneration:
+        if pregenerate_hist:
             self.get_hist()
 
     def get_hist(self, ifos=None):


### PR DESCRIPTION
I'm not sure I remember why I did it this way, but at the moment we delay setting up a histogram for the phasetd class until it is immediately needed for use. In findtrigs with multiple cores this has some serious downsides that effectively cause large memory use.

In case the old behavior is needed by someone, I've added an option to allow it.