### PR TITLE
only analyze templates which have triggers

### DIFF
--- a/bin/all_sky_search/pycbc_coinc_findtrigs
+++ b/bin/all_sky_search/pycbc_coinc_findtrigs
@@ -110,7 +110,7 @@ def exit_cleaning():
 atexit.register(exit_cleaning)
 
 # If some templates have no triggers one or more ifos, there can be no
-# coincs so we track which templates contains triggers in all ifos
+# coincs: so, track which templates contain triggers in all ifos
 tids_with_trigs = None
 
 for i in range(len(args.trigger_files)):

--- a/bin/all_sky_search/pycbc_coinc_findtrigs
+++ b/bin/all_sky_search/pycbc_coinc_findtrigs
@@ -110,7 +110,7 @@ def exit_cleaning():
 atexit.register(exit_cleaning)
 
 # Which templates might have triggers, initially we'll assume they all might
-tids_with_trigs = numpy.arange(0, num_templates)
+tids_with_trigs = None
 
 for i in range(len(args.trigger_files)):
     if args.stage_input:
@@ -174,7 +174,8 @@ else:
 
 # Only analyze templates which might have triggers based on
 # our 'tids_with_trigs'
-template_ids = numpy.intersect1d(tids_with_trigs, template_ids)
+if tids_with_trigs is not None:
+    template_ids = numpy.intersect1d(tids_with_trigs, template_ids)
 
 # 'data' will store output of coinc finding
 # in addition to these lists of coinc info, will also store trigger times and

--- a/bin/all_sky_search/pycbc_coinc_findtrigs
+++ b/bin/all_sky_search/pycbc_coinc_findtrigs
@@ -109,7 +109,8 @@ def exit_cleaning():
             pass
 atexit.register(exit_cleaning)
 
-# Which templates might have triggers, initially we'll assume they all might
+# If some templates have no triggers one or more ifos, there can be no
+# coincs so we track which templates contains triggers in all ifos
 tids_with_trigs = None
 
 for i in range(len(args.trigger_files)):
@@ -174,8 +175,7 @@ if args.randomize_template_order:
 else:
     template_ids = range(tmin, tmax)
 
-# Only analyze templates which might have triggers based on
-# our 'tids_with_trigs'
+# Only analyze templates which might have coincs
 if tids_with_trigs is not None:
     template_ids = numpy.intersect1d(tids_with_trigs, template_ids)
 

--- a/bin/all_sky_search/pycbc_coinc_findtrigs
+++ b/bin/all_sky_search/pycbc_coinc_findtrigs
@@ -109,7 +109,9 @@ def exit_cleaning():
             pass
 atexit.register(exit_cleaning)
 
-unique_tids = numpy.arange(0, num_templates)
+# Which templates might have triggers, initially we'll assume they all might
+tids_with_trigs = numpy.arange(0, num_templates)
+
 for i in range(len(args.trigger_files)):
     if args.stage_input:
         dest = os.path.join(args.stage_input_dir, str(uuid.uuid4()) + '.hdf')
@@ -129,11 +131,10 @@ for i in range(len(args.trigger_files)):
     ifo = reader.ifo
     trigs.ifos.append(ifo)
     
-    # We don't have that many triggers compared to num templates so
-    # likely many zeros which can be pre-culled
-    if len(reader.file[ifo]['template_id']) < num_templates * 10:
+    # We don't have that many triggers, see if we can skip some templates
+    if len(reader.file[ifo]['template_id']) < 2**27:
         uniq = numpy.unique(reader.file[ifo]['template_id'][:])
-        unique_tids = numpy.intersect1d(unique_tids, uniq)
+        tids_with_trigs = numpy.intersect1d(tids_with_trigs, uniq)
 
     # time shift is subtracted from pivot ifo time
     trigs.to_shift.append(-1 if ifo == args.pivot_ifo else 0)
@@ -171,7 +172,9 @@ if args.randomize_template_order:
 else:
     template_ids = range(tmin, tmax)
 
-template_ids = numpy.intersect1d(unique_tids, template_ids)
+# Only analyze templates which might have triggers based on
+# our 'tids_with_trigs'
+template_ids = numpy.intersect1d(tids_with_trigs, template_ids)
 
 # 'data' will store output of coinc finding
 # in addition to these lists of coinc info, will also store trigger times and

--- a/bin/all_sky_search/pycbc_coinc_findtrigs
+++ b/bin/all_sky_search/pycbc_coinc_findtrigs
@@ -109,6 +109,7 @@ def exit_cleaning():
             pass
 atexit.register(exit_cleaning)
 
+unique_tids = numpy.arange(0, num_templates)
 for i in range(len(args.trigger_files)):
     if args.stage_input:
         dest = os.path.join(args.stage_input_dir, str(uuid.uuid4()) + '.hdf')
@@ -127,6 +128,13 @@ for i in range(len(args.trigger_files)):
                             args.gating_veto_windows)
     ifo = reader.ifo
     trigs.ifos.append(ifo)
+    
+    # We don't have that many triggers compared to num templates so
+    # likely many zeros which can be pre-culled
+    if len(reader.file[ifo]['template_id']) < num_templates * 10:
+        uniq = numpy.unique(reader.file[ifo]['template_id'][:])
+        unique_tids = numpy.intersect1d(unique_tids, uniq)
+
     # time shift is subtracted from pivot ifo time
     trigs.to_shift.append(-1 if ifo == args.pivot_ifo else 0)
     logging.info('Applying time shift multiple %i to ifo %s' %
@@ -162,6 +170,8 @@ if args.randomize_template_order:
     template_ids = template_ids[tmin:tmax]
 else:
     template_ids = range(tmin, tmax)
+
+template_ids = numpy.intersect1d(unique_tids, template_ids)
 
 # 'data' will store output of coinc finding
 # in addition to these lists of coinc info, will also store trigger times and

--- a/bin/all_sky_search/pycbc_coinc_findtrigs
+++ b/bin/all_sky_search/pycbc_coinc_findtrigs
@@ -134,6 +134,8 @@ for i in range(len(args.trigger_files)):
     # We don't have that many triggers, see if we can skip some templates
     if len(reader.file[ifo]['template_id']) < 2**27:
         uniq = numpy.unique(reader.file[ifo]['template_id'][:])
+        if tids_with_trigs is None:
+            tids_with_trigs = numpy.arange(0, num_templates)
         tids_with_trigs = numpy.intersect1d(tids_with_trigs, uniq)
 
     # time shift is subtracted from pivot ifo time
@@ -174,8 +176,7 @@ else:
 
 # Only analyze templates which might have triggers based on
 # our 'tids_with_trigs'
-if tids_with_trigs is not None:
-    template_ids = numpy.intersect1d(tids_with_trigs, template_ids)
+template_ids = numpy.intersect1d(tids_with_trigs, template_ids)
 
 # 'data' will store output of coinc finding
 # in addition to these lists of coinc info, will also store trigger times and

--- a/bin/all_sky_search/pycbc_coinc_findtrigs
+++ b/bin/all_sky_search/pycbc_coinc_findtrigs
@@ -176,7 +176,8 @@ else:
 
 # Only analyze templates which might have triggers based on
 # our 'tids_with_trigs'
-template_ids = numpy.intersect1d(tids_with_trigs, template_ids)
+if tids_with_trigs is not None:
+    template_ids = numpy.intersect1d(tids_with_trigs, template_ids)
 
 # 'data' will store output of coinc finding
 # in addition to these lists of coinc info, will also store trigger times and


### PR DESCRIPTION
This is a speed-up to pycbc_coinc_findtrigs in the case where not all templates could even possibly produce a trigger. In other words, a template can be quickly skipped if there is zero triggers from a template in *any* of the required detectors. There is a path that could partly help with this before, but this patch pre-culls the set of templates which is much more efficient. 

 This occurs for injection sets with heavy use of injection filtering, for example. In that case, the performance improvement can be quite large (orders of magnitude if the bank is large enough and each injection set is narrow). 

