### PR TITLE
remove explicit subworkflow dependency

### DIFF
--- a/pycbc/workflow/minifollowups.py
+++ b/pycbc/workflow/minifollowups.py
@@ -118,7 +118,7 @@ def setup_foreground_minifollowups(workflow, coinc_file, single_triggers,
     job.set_subworkflow_properties(map_file,
                                    staging_site=workflow.staging_site,
                                    cache_file=workflow.cache_file)
-    job.add_into_workflow(workflow, parents=[node])
+    job.add_into_workflow(workflow)
     logging.info('Leaving minifollowups module')
 
 def setup_single_det_minifollowups(workflow, single_trig_file, tmpltbank_file,
@@ -221,7 +221,7 @@ def setup_single_det_minifollowups(workflow, single_trig_file, tmpltbank_file,
     job.set_subworkflow_properties(map_file,
                                    staging_site=workflow.staging_site,
                                    cache_file=workflow.cache_file)
-    job.add_into_workflow(workflow, parents=[node])
+    job.add_into_workflow(workflow)
     logging.info('Leaving minifollowups module')
 
 
@@ -308,7 +308,7 @@ def setup_injection_minifollowups(workflow, injection_file, inj_xml_file,
     job.set_subworkflow_properties(map_file,
                                    staging_site=workflow.staging_site,
                                    cache_file=workflow.cache_file)
-    job.add_into_workflow(workflow, parents=[node])
+    job.add_into_workflow(workflow)
 
     logging.info('Leaving injection minifollowups module')
 

--- a/pycbc/workflow/pegasus_workflow.py
+++ b/pycbc/workflow/pegasus_workflow.py
@@ -766,10 +766,10 @@ class SubWorkflow(dax.SubWorkflow):
             # Get Pegasus objects from PyCBC objects for parent Nodes
             parents = [n._dax_node for n in parents]
         self.add_planner_args(**self.pycbc_planner_args)
+
         # Set this to None so code will fail if more planner args are added
         self.pycbc_planner_args = None
         container_wflow._adag.add_jobs(self)
-        container_wflow._adag.add_dependency(self, parents=parents)
 
     def add_planner_arg(self, value, option):
         if self.pycbc_planner_args is None:

--- a/pycbc/workflow/pegasus_workflow.py
+++ b/pycbc/workflow/pegasus_workflow.py
@@ -757,14 +757,9 @@ class SubWorkflow(dax.SubWorkflow):
         super().__init__(*args, **kwargs)
         self.pycbc_planner_args = {}
 
-    def add_into_workflow(self, container_wflow, parents=None):
+    def add_into_workflow(self, container_wflow):
         """Add this Job into a container Workflow
         """
-        if parents is None:
-            parents = []
-        else:
-            # Get Pegasus objects from PyCBC objects for parent Nodes
-            parents = [n._dax_node for n in parents]
         self.add_planner_args(**self.pycbc_planner_args)
 
         # Set this to None so code will fail if more planner args are added


### PR DESCRIPTION
This is one area I noticed as odd when I looked at the Pegasus 5 changes.

 Given that our internal method of setting sub-workflow inter-dependencies had been removed, I'm skeptical that this line here should be required. In other words, if we could remove the inter-workflow dependencies and pycbc's older code for determining dependencies base don file useage, then Pegasus must be determining this internally now.  The inputs for the workflow are already being added to the dax object directly. If that's the case, and it is doing so correctly, then this dependency line should not be required. 
 
Assuming the tests don't reveal something and I haven't misunderstood some corner case, I suggest we remove this line to remove future confusion about how dependencies are resolved. 