### PR TITLE
make grid tools / proxy checks optional in start script

### DIFF
--- a/pycbc/workflow/pegasus_workflow.py
+++ b/pycbc/workflow/pegasus_workflow.py
@@ -36,7 +36,7 @@ import Pegasus.api as dax
 PEGASUS_FILE_DIRECTORY = os.path.join(os.path.dirname(__file__),
                                       'pegasus_files')
 
-PEGASUS_START_TEMPLATE = '''#!/bin/bash
+GRID_START_TEMPLATE = '''#!/bin/bash
 
 if [ -f /tmp/x509up_u`id -u` ] ; then
   unset X509_USER_PROXY
@@ -680,8 +680,9 @@ class Workflow(object):
             fp.write('pegasus-remove {}/work $@'.format(submitdir))
 
         with open('start', 'w') as fp:
-            fp.write(PEGASUS_START_TEMPLATE)
-            fp.write('\n')
+            if self.cp.has_option('pegasus_profile', 'pycbc|check-grid'):
+                fp.write(GRID_START_TEMPLATE)
+                fp.write('\n')
             fp.write('pegasus-run {}/work $@'.format(submitdir))
 
         os.chmod('status', 0o755)

--- a/pycbc/workflow/pegasus_workflow.py
+++ b/pycbc/workflow/pegasus_workflow.py
@@ -680,7 +680,7 @@ class Workflow(object):
             fp.write('pegasus-remove {}/work $@'.format(submitdir))
 
         with open('start', 'w') as fp:
-            if self.cp.has_option('pegasus_profile', 'pycbc|check-grid'):
+            if self.cp.has_option('pegasus_profile', 'pycbc|check_grid'):
                 fp.write(GRID_START_TEMPLATE)
                 fp.write('\n')
             fp.write('pegasus-run {}/work $@'.format(submitdir))


### PR DESCRIPTION
This is one of the PRs needed for non-LDG users to use the standard shell script tools made when using the '--submit-now' options. 

The change is to only do the proxy checks if you request so in the profile information i.e. so the current behavior would be replicated by adding 

```
[pegasus_profile
pycbc|check_grid = 
```
to one's config files. Otherwise, no check is performed by default. 