### PR TITLE
add time range that covers o3b to be able to query gwosc segments

### DIFF
--- a/pycbc/frame/losc.py
+++ b/pycbc/frame/losc.py
@@ -39,6 +39,8 @@ def get_run(time, ifo=None):
     # the same for all ifos
     if (1180911618 <= time <= 1180982427) and (ifo == 'H1'):
         return 'BKGW170608_16KHZ_R1'
+    elif 1253977219 <= time <= 1320363336:
+        return 'O3b_16KHZ_R1'
     elif 1238166018 <= time <= 1253977218:
         return 'O3a_16KHZ_R1'
     elif 1164556817 <= time <= 1187733618:


### PR DESCRIPTION
This is needed to query the segments from O3b

* used for searches
* used in PE to verify valid data is present (when using this option)