### PR TITLE
Fix sort error on param output if single parameter

### DIFF
--- a/bin/all_sky_search/pycbc_fit_sngls_over_multiparam
+++ b/bin/all_sky_search/pycbc_fit_sngls_over_multiparam
@@ -130,8 +130,8 @@ if len(parvals) == 1:
 
     # For each template, find the range of nearby templates which fall within
     # the chosen window.
-    left = numpy.searchsorted(parvals_0, parvals_0 - args.smoothing_width[0])
-    right = numpy.searchsorted(parvals_0, parvals_0 + args.smoothing_width[0]) - 1
+    left = numpy.searchsorted(parvals_0, parvals[0] - args.smoothing_width[0])
+    right = numpy.searchsorted(parvals_0, parvals[0] + args.smoothing_width[0]) - 1
 
     del parvals_0
     # Precompute the sums so we can quickly look up differences between

--- a/bin/all_sky_search/pycbc_fit_sngls_over_multiparam
+++ b/bin/all_sky_search/pycbc_fit_sngls_over_multiparam
@@ -123,16 +123,17 @@ logging.info("Smoothing ...")
 # optimize computational performance.
 if len(parvals) == 1:
     sort = parvals[0].argsort()
-    parvals[0] = parvals[0][sort]
+    parvals_0 = parvals[0][sort]
     ntotal = ntotal[sort]
     nabove = nabove[sort]
     invalphan = invalphan[sort]
 
     # For each template, find the range of nearby templates which fall within
     # the chosen window.
-    left = numpy.searchsorted(parvals[0], parvals[0] - args.smoothing_width[0])
-    right = numpy.searchsorted(parvals[0], parvals[0] + args.smoothing_width[0]) - 1
+    left = numpy.searchsorted(parvals_0, parvals_0 - args.smoothing_width[0])
+    right = numpy.searchsorted(parvals_0, parvals_0 + args.smoothing_width[0]) - 1
 
+    del parvals_0
     # Precompute the sums so we can quickly look up differences between
     # templates
     ntsum = ntotal.cumsum()


### PR DESCRIPTION
If using pycbc_fit_sngls_over_multiparam with a single parameter for smoothing, then the parameter output will be sorted on that parameter, rather than in template id order.

I think this is a fairly rare use case so the if statement isn't used normally. The parameter value isn't used downstream in the workflow so far as I know, so don't think this affects anything downstream

This fix prevents the sorting of the original parameter array to keep it in the original order