### PR TITLE
Move custom LIGOLW content handler classes to `pycbc.io.ligolw`

### DIFF
--- a/bin/all_sky_search/pycbc_coinc_hdfinjfind
+++ b/bin/all_sky_search/pycbc_coinc_hdfinjfind
@@ -4,19 +4,15 @@ files.
 """
 
 import argparse, h5py, logging, types, numpy, os.path
-from ligo.lw import ligolw, table, lsctables, utils as ligolw_utils
+from ligo.lw import table, lsctables, utils as ligolw_utils
 from ligo import segments
 from pycbc import events
 from pycbc.events import indices_within_segments
 from pycbc.types import MultiDetOptionAction
 from pycbc.inject import CBCHDFInjectionSet
 import pycbc.version
+from pycbc.io.ligolw import LIGOLWContentHandler
 
-
-# dummy class needed for loading LIGOLW files
-class LIGOLWContentHandler(ligolw.LIGOLWContentHandler):
-    pass
-lsctables.use_in(LIGOLWContentHandler)
 
 def hdf_append(f, key, value):
     if key in f:

--- a/bin/all_sky_search/pycbc_sngls_pastro
+++ b/bin/all_sky_search/pycbc_sngls_pastro
@@ -12,9 +12,10 @@ coincidences.
 
 import pycbc, pycbc.io, copy
 import argparse, logging, numpy as np
-from ligo.lw import ligolw, table, lsctables, utils as ligolw_utils
+from ligo.lw import table, lsctables, utils as ligolw_utils
 from pycbc import conversions as conv
 from pycbc.events import veto, stat, ranking, coinc, single as sngl
+from pycbc.io.ligolw import LIGOLWContentHandler
 from ligo.segments import segment, segmentlist
 import pycbc.version
 import matplotlib
@@ -22,10 +23,6 @@ matplotlib.use('agg')
 from matplotlib import pyplot as plt
 from scipy.stats import gaussian_kde as gk
 
-# dummy class for loading LIGOLW files
-class LIGOLWContentHandler(ligolw.LIGOLWContentHandler):
-    pass
-lsctables.use_in(LIGOLWContentHandler)
 
 d_power = {
     'log': 3.,

--- a/bin/all_sky_search/pycbc_strip_injections
+++ b/bin/all_sky_search/pycbc_strip_injections
@@ -1,18 +1,15 @@
 #!/bin/env python
 import numpy, argparse, pycbc.version, pycbc.pnutils, logging
 from pycbc.events import veto
-from ligo.lw import ligolw, table, lsctables, utils as ligolw_utils
+from pycbc.io.ligolw import LIGOLWContentHandler
+from ligo.lw import ligolw, table, utils as ligolw_utils
+
 
 effd = {"H1":"eff_dist_h", "L1":"eff_dist_l", "V1":"eff_dist_v"}
 def remove(l, i):
     to_remove = [l[t] for t in i]
     for r in to_remove:
         l.remove(r)
-
-# dummy class needed for loading LIGOLW files
-class LIGOLWContentHandler(ligolw.LIGOLWContentHandler):
-    pass
-lsctables.use_in(LIGOLWContentHandler)
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--version', action='version', version=pycbc.version.git_verbose_msg)

--- a/bin/bank/pycbc_aligned_bank_cat
+++ b/bin/bank/pycbc_aligned_bank_cat
@@ -17,28 +17,25 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 """
-Programe for concatenating the output of the geometric aligned bank dagman.
+Program for concatenating the output of the geometric aligned bank dagman.
 This will gather all the meta-output files and create a valid template bank
 xml file.
 """
 import logging
-import fileinput
 import glob
 import argparse
 import numpy
 import pycbc.version
 import h5py
-from ligo.lw import ligolw
-from ligo.lw import lsctables
 from ligo.lw import utils
 from pycbc import tmpltbank
-from numpy import loadtxt
 import pycbc
 import pycbc.psd
 import pycbc.strain
 import pycbc.version
-import pycbc.tmpltbank
 from pycbc.waveform import get_waveform_filter_length_in_time
+from pycbc.io.ligolw import LIGOLWContentHandler
+
 
 __author__  = "Ian Harry <ian.harry@astro.cf.ac.uk>"
 __version__ = pycbc.version.git_verbose_msg
@@ -46,9 +43,7 @@ __date__    = pycbc.version.date
 __program__ = "pycbc_aligned_bank_cat"
 
 # Read command line options
-usage = """usage: %prog [options]"""
-_desc = __doc__[1:]
-parser = argparse.ArgumentParser(description=_desc,
+parser = argparse.ArgumentParser(description=__doc__,
            formatter_class=tmpltbank.IndentedHelpFormatterWithNL)
 
 parser.add_argument("--version", action="version", version=__version__)
@@ -163,12 +158,9 @@ temp_bank = numpy.array([mass1,mass2,spin1z,spin2z]).T
 # needed for any reason, this code would have to be able to recalculate the
 # moments (or read them in) and use the correct value of f0 and pn-order
 if options.metadata_file:
-    class LIGOLWContentHandler(ligolw.LIGOLWContentHandler):
-        pass
-    lsctables.use_in(LIGOLWContentHandler)
-    outdoc = utils.load_filename(options.metadata_file,\
-                                     gz = options.metadata_file.endswith("gz"),
-                                     contenthandler=LIGOLWContentHandler)
+    outdoc = utils.load_filename(options.metadata_file,
+                                 compress='auto',
+                                 contenthandler=LIGOLWContentHandler)
 else:
     outdoc = None
 if options.output_file.endswith(('.xml','.xml.gz','.xmlgz')):

--- a/bin/bank/pycbc_bank_verification
+++ b/bin/bank/pycbc_bank_verification
@@ -23,29 +23,28 @@ metric approximation to the parameter space.
 
 from __future__ import division
 
+import argparse
+import logging
+import numpy
+import h5py
+from ligo.lw import table, lsctables, utils as ligolw_utils
 import pycbc
 import pycbc.version
+from pycbc import tmpltbank, psd, strain
+from pycbc.io.ligolw import LIGOLWContentHandler
+import matplotlib
+matplotlib.use('Agg')
+import pylab
+
 
 __author__  = "Ian Harry <ian.harry@astro.cf.ac.uk>"
 __version__ = pycbc.version.git_verbose_msg
 __date__    = pycbc.version.date
 __program__ = "pycbc_bank_verification"
 
-import argparse
-import os, sys
-import copy
-import logging
-import numpy
-import h5py
-from ligo.lw import ligolw, table, lsctables, utils as ligolw_utils
-from pycbc import tmpltbank, psd, strain, pnutils
-import matplotlib
-matplotlib.use('Agg')
-import pylab
 
 # Read command line option
-_desc = __doc__[1:]
-parser = argparse.ArgumentParser(description=_desc,
+parser = argparse.ArgumentParser(description=__doc__,
            formatter_class=tmpltbank.IndentedHelpFormatterWithNL)
 
 # Begin with code specific options
@@ -195,12 +194,6 @@ logging.info("Reading template bank.")
 
 
 if opts.input_bank.endswith(('.xml','.xml.gz','.xmlgz')):
-    # dummy class needed for loading LIGOLW files
-    class LIGOLWContentHandler(ligolw.LIGOLWContentHandler):
-        pass
-
-    lsctables.use_in(LIGOLWContentHandler)
-
     indoc = ligolw_utils.load_filename(opts.input_bank,
                                        contenthandler=LIGOLWContentHandler)
     template_list = table.get_table(indoc,

--- a/bin/bank/pycbc_tmpltbank_to_chi_params
+++ b/bin/bank/pycbc_tmpltbank_to_chi_params
@@ -34,14 +34,13 @@ import argparse
 import logging
 import numpy
 import h5py
-from ligo.lw import ligolw, table, lsctables, utils as ligolw_utils
+from ligo.lw import table, lsctables, utils as ligolw_utils
 from pycbc import tmpltbank, psd, strain
-import matplotlib
-matplotlib.use('Agg')
+from pycbc.io.ligolw import LIGOLWContentHandler
+
 
 # Read command line option
-_desc = __doc__[1:]
-parser = argparse.ArgumentParser(description=_desc,
+parser = argparse.ArgumentParser(description=__doc__,
            formatter_class=tmpltbank.IndentedHelpFormatterWithNL)
 
 # Begin with code specific options
@@ -146,12 +145,6 @@ metricParams.evecsCV[refFreq] = evecsCV
 
 logging.info("Reading template bank.")
 if opts.input_bank.endswith(('.xml','.xml.gz','.xmlgz')):
-    # dummy class needed for loading LIGOLW files
-    class LIGOLWContentHandler(ligolw.LIGOLWContentHandler):
-        pass
-
-    lsctables.use_in(LIGOLWContentHandler)
-
     indoc = ligolw_utils.load_filename(opts.input_bank,
                                        contenthandler=LIGOLWContentHandler)
     template_list = table.get_table(indoc,

--- a/bin/plotting/pycbc_page_segments
+++ b/bin/plotting/pycbc_page_segments
@@ -3,6 +3,12 @@
 """
 import argparse, pycbc.version
 from itertools import cycle
+import matplotlib
+matplotlib.use('Agg')
+import numpy, pylab, pycbc.events, mpld3, mpld3.plugins
+from matplotlib.patches import Rectangle
+from pycbc.results.mpld3_utils import MPLSlide, Tooltip
+
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--version', action='version', version=pycbc.version.git_verbose_msg)
@@ -10,11 +16,6 @@ parser.add_argument('--segment-files', nargs='+', help="List of segment files to
 parser.add_argument('--output-file', help="output html file")
 args = parser.parse_args()
 
-import matplotlib
-matplotlib.use('Agg')
-import numpy, pylab, pycbc.events, mpld3, mpld3.plugins
-from matplotlib.patches import Rectangle
-from pycbc.results.mpld3_utils import MPLSlide, Tooltip
 
 def timestr(s):
     t = ""
@@ -32,12 +33,11 @@ def timestr(s):
     return t
 
 def get_name(segment_file):
-    from ligo.lw import ligolw, table, lsctables, utils as ligolw_utils
-    # dummy class needed for loading LIGOLW files
-    class KF(ligolw.LIGOLWContentHandler):
-        pass
-    lsctables.use_in(KF)
-    indoc = ligolw_utils.load_filename(segment_file, False, contenthandler=KF)
+    from ligo.lw import table, utils as ligolw_utils
+    from pycbc.io.ligolw import LIGOLWContentHandler
+
+    indoc = ligolw_utils.load_filename(
+            segment_file, False, contenthandler=LIGOLWContentHandler)
     n = table.get_table(indoc, 'segment_definer')[0]
     return "%s:%s:%s" % (n.ifos, n.name, n.version)
 

--- a/bin/plotting/pycbc_page_vetotable
+++ b/bin/plotting/pycbc_page_vetotable
@@ -16,26 +16,22 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
+"Writes veto_definer table contents to HTML table."
+
 import argparse
 import logging
 import numpy
 import pycbc.results
 import sys
-from ligo.lw import ligolw
 from ligo.lw import lsctables
 from ligo.lw import table
 from ligo.lw import utils
 from pycbc.results import save_fig_with_metadata
 import pycbc.version
+from pycbc.io.ligolw import LIGOLWContentHandler
 
-class DefaultContentHandler(lsctables.ligolw.LIGOLWContentHandler):
-    pass
-lsctables.use_in(DefaultContentHandler)
 
-# usage
-parser = argparse.ArgumentParser(usage='pycbc_page_vetotable [--options]',
-             description="Writes veto_definer table contents to HTML table."
-)
+parser = argparse.ArgumentParser(description=__doc__)
 
 # add command line options
 parser.add_argument("--version", action="version", version=pycbc.version.git_verbose_msg)
@@ -69,7 +65,7 @@ caption = "This table shows each veto in the veto definer table."
 # read input file
 logging.info('Reading veto definer XML file')
 vetodef_xml = utils.load_filename(opts.veto_definer_file,
-                                   contenthandler=DefaultContentHandler)
+                                   contenthandler=LIGOLWContentHandler)
 
 # get veto_definer table
 vetodef_table = table.get_table(vetodef_xml,

--- a/bin/plotting/pycbc_plot_Nth_loudest_coinc_omicron.py
+++ b/bin/plotting/pycbc_plot_Nth_loudest_coinc_omicron.py
@@ -9,19 +9,16 @@ import h5py
 import numpy as np
 import argparse
 import glob
-from ligo.lw import ligolw, lsctables, table, utils
+from ligo.lw import lsctables, table, utils
 import matplotlib
 matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 import pycbc.events
 from pycbc.waveform import get_td_waveform, frequency_from_polarizations, amplitude_from_polarizations
+from pycbc.io.ligolw import LIGOLWContentHandler
 
 
 logging.basicConfig(format='%(asctime)s %(message)s', level=logging.INFO)
-
-class DefaultContentHandler(ligolw.LIGOLWContentHandler):
-    pass
-lsctables.use_in(DefaultContentHandler)
 
 parser = argparse.ArgumentParser(description=__doc__)
 parser.add_argument('--coinc-file', type=str, required=True,
@@ -106,7 +103,7 @@ for era in eras:
 
     # Parse trigger files into SNR, time, and frequency for Omicron triggers
     for file_name in file_list:
-        omicron_xml = utils.load_filename(file_name, contenthandler=DefaultContentHandler)
+        omicron_xml = utils.load_filename(file_name, contenthandler=LIGOLWContentHandler)
         snglburst_table = table.get_table(omicron_xml, lsctables.SnglBurstTable.tableName)
 
         for row in snglburst_table:

--- a/bin/pycbc_banksim
+++ b/bin/pycbc_banksim
@@ -24,11 +24,6 @@ from numpy import complex64, array
 from argparse import ArgumentParser
 from ligo.lw import utils as ligolw_utils
 from ligo.lw import table, lsctables
-from ligo.lw.ligolw import LIGOLWContentHandler
-class mycontenthandler(LIGOLWContentHandler):
-    pass
-lsctables.use_in(mycontenthandler)
-
 from pycbc.pnutils import mass1_mass2_to_mchirp_eta
 from pycbc.pnutils import mass1_mass2_to_tau0_tau3
 from pycbc.pnutils import nearest_larger_binary_number
@@ -37,6 +32,7 @@ from pycbc.waveform.utils import taper_timeseries
 from pycbc import DYN_RANGE_FAC
 from pycbc.types import FrequencySeries, TimeSeries, zeros, complex_same_precision_as
 from pycbc.filter import match, sigmasq
+from pycbc.io.ligolw import LIGOLWContentHandler
 from math import ceil, log
 import pycbc.psd, pycbc.scheme, pycbc.fft, pycbc.strain, pycbc.version
 from pycbc.detector import overhead_antenna_pattern as generate_fplus_fcross
@@ -289,7 +285,7 @@ logging.info("  %d templates", len(template_table))
 
 logging.info('Reading simulation list')
 indoc = ligolw_utils.load_filename(options.sim_file, False,
-                                   contenthandler=mycontenthandler)
+                                   contenthandler=LIGOLWContentHandler)
 try:
     signal_table = table.get_table(indoc, lsctables.SimInspiralTable.tableName) 
 except ValueError:

--- a/bin/pycbc_banksim_match_combine
+++ b/bin/pycbc_banksim_match_combine
@@ -30,21 +30,17 @@ from ligo.lw import utils, table
 import pycbc
 from pycbc import pnutils
 from pycbc.waveform import TemplateBank
+from pycbc.io.ligolw import LIGOLWContentHandler
+
 
 __author__  = "Ian Harry <ian.harry@astro.cf.ac.uk>"
 __version__ = pycbc.version.git_verbose_msg
 __date__    = pycbc.version.date
 __program__ = "pycbc_banksim_match_combine"
 
-from ligo.lw.ligolw import LIGOLWContentHandler
-from ligo.lw import lsctables
-class mycontenthandler(LIGOLWContentHandler):
-    pass
-lsctables.use_in(mycontenthandler)
 
 # Read command line options
-_desc = __doc__[1:]
-parser = argparse.ArgumentParser(description=_desc)
+parser = argparse.ArgumentParser(description=__doc__)
 
 parser.add_argument("--version", action="version", version=__version__)
 parser.add_argument("--verbose", action="store_true", default=False,
@@ -112,7 +108,8 @@ for idx, row in enumerate(res):
         btables[row['bank']] = temp_bank.table
 
     if row['sim'] not in itables:
-        indoc = utils.load_filename(row['sim'], False, contenthandler=mycontenthandler)
+        indoc = utils.load_filename(row['sim'], False,
+                                    contenthandler=LIGOLWContentHandler)
         itables[row['sim']] = table.get_table(indoc, "sim_inspiral") 
     
     bt = btables[row['bank']][row['bank_i']]     

--- a/bin/pycbc_banksim_skymax
+++ b/bin/pycbc_banksim_skymax
@@ -24,11 +24,6 @@ from numpy import complex64, float32, sqrt, argmax, real, array
 from argparse import ArgumentParser
 from ligo.lw import utils as ligolw_utils
 from ligo.lw import table, lsctables
-from ligo.lw.ligolw import LIGOLWContentHandler
-class mycontenthandler(LIGOLWContentHandler):
-    pass
-lsctables.use_in(mycontenthandler)
-
 from pycbc.pnutils import mass1_mass2_to_mchirp_eta, f_SchwarzISCO
 from pycbc.pnutils import nearest_larger_binary_number
 from pycbc.pnutils import mass1_mass2_to_tau0_tau3
@@ -40,6 +35,7 @@ from pycbc.filter import match, sigmasq, resample_to_delta_t
 from pycbc.filter import overlap_cplx, matched_filter
 from pycbc.filter import compute_max_snr_over_sky_loc_stat
 from pycbc.filter import compute_max_snr_over_sky_loc_stat_no_phase
+from pycbc.io.ligolw import LIGOLWContentHandler
 from math import ceil, log
 import pycbc.psd, pycbc.scheme, pycbc.fft, pycbc.strain, pycbc.version
 from pycbc.detector import overhead_antenna_pattern as generate_fplus_fcross
@@ -313,7 +309,7 @@ logging.info("  %d templates", len(template_table))
 
 logging.info('Reading simulation list')
 indoc = ligolw_utils.load_filename(options.sim_file, False,
-                                   contenthandler=mycontenthandler)
+                                   contenthandler=LIGOLWContentHandler)
 try:
     signal_table = table.get_table(indoc, lsctables.SimInspiralTable.tableName) 
 except ValueError:

--- a/bin/pycbc_faithsim
+++ b/bin/pycbc_faithsim
@@ -24,27 +24,23 @@
 #
 
 from __future__ import print_function
-import sys
 import logging
-from numpy import loadtxt,complex64,float32
+from numpy import complex64
 import argparse
 from ligo.lw import utils as ligolw_utils
-from ligo.lw import table, lsctables, ligolw
+from ligo.lw import table, lsctables
 
 import pycbc.version
 import pycbc.strain
 import pycbc.psd
-from pycbc.pnutils import mass1_mass2_to_mchirp_eta
 from pycbc.waveform import td_approximants, fd_approximants
 from pycbc.waveform import get_two_pol_waveform_filter
 from pycbc import DYN_RANGE_FAC
 from pycbc.types import FrequencySeries, zeros
 from pycbc.filter import match, overlap, sigma
 from pycbc.scheme import CPUScheme, CUDAScheme
+from pycbc.io.ligolw import LIGOLWContentHandler
 
-class ContentHandler(ligolw.LIGOLWContentHandler):
-    pass
-lsctables.use_in(ContentHandler)
 
 def update_progress(progress):
     print('\r\r[{0}] {1}%'.format('#'*(progress/2)+' '*(50-progress/2), progress), end=' ')
@@ -164,7 +160,8 @@ else:
     ctx = CPUScheme()
 
 # Load in the waveform1 bank file
-indoc = ligolw_utils.load_filename(options.bank_file, False, contenthandler=ContentHandler)
+indoc = ligolw_utils.load_filename(options.bank_file, False,
+                                   contenthandler=LIGOLWContentHandler)
 try :
     waveform_table = table.get_table(indoc, lsctables.SnglInspiralTable.tableName) 
 except ValueError:

--- a/bin/pycbc_make_banksim
+++ b/bin/pycbc_make_banksim
@@ -91,18 +91,16 @@ def mkdir(dir_name):
         pass
         
 def mc_min_max_from_sorted_file(fname):
-    from ligo.lw import lsctables
-    from ligo.lw.ligolw import LIGOLWContentHandler
-    class mycontenthandler(LIGOLWContentHandler):
-        pass
-    lsctables.use_in(mycontenthandler)
     from ligo.lw.utils import load_filename
     from ligo.lw.table import get_table
     from pycbc.pnutils import mass1_mass2_to_mchirp_eta
+    from pycbc.io.ligolw import LIGOLWContentHandler
+
+    doc = load_filename(fname, False, contenthandler=LIGOLWContentHandler)
     try:
-        t = get_table(load_filename(fname, False, contenthandler=mycontenthandler), "sngl_inspiral")
+        t = get_table(doc, "sngl_inspiral")
     except:
-        t = get_table(load_filename(fname, False, contenthandler=mycontenthandler), "sim_inspiral")
+        t = get_table(doc, "sim_inspiral")
     mc_max, et = mass1_mass2_to_mchirp_eta(t[0].mass1, t[0].mass2)
     mc_min, et = mass1_mass2_to_mchirp_eta(t[-1].mass1, t[-1].mass2)
     return mc_min, mc_max
@@ -293,11 +291,7 @@ from numpy import *
 from ligo.lw import utils, table
 import glob
 
-from ligo.lw.ligolw import LIGOLWContentHandler
-from ligo.lw import lsctables
-class mycontenthandler(LIGOLWContentHandler):
-    pass
-lsctables.use_in(mycontenthandler)
+from pycbc.io.ligolw import LIGOLWContentHandler
 
 fils = glob.glob("match/match*.dat")
 
@@ -318,11 +312,13 @@ f = open("results.dat", "w")
 for row in res: 
     outstr = ""
     if row['bank'] not in btables:
-        indoc = utils.load_filename(row['bank'], False, contenthandler=mycontenthandler)
+        indoc = utils.load_filename(row['bank'], False,
+                                    contenthandler=LIGOLWContentHandler)
         btables[row['bank']] = table.get_table(indoc, "sngl_inspiral") 
 
     if row['sim'] not in itables:
-        indoc = utils.load_filename(row['sim'], False, contenthandler=mycontenthandler)
+        indoc = utils.load_filename(row['sim'], False,
+                                    contenthandler=LIGOLWContentHandler)
         itables[row['sim']] = table.get_table(indoc, "sim_inspiral") 
     
     bt = btables[row['bank']][row['bank_i']]     

--- a/bin/pycbc_make_faithsim
+++ b/bin/pycbc_make_faithsim
@@ -144,14 +144,11 @@ dag.add_node(pnode)
 
 f = open("scripts/pycbc_faithsim_collect_results", "w")
 f.write("""#!/usr/bin/env python
-from os.path import isfile
 from numpy import *
-from ligo.lw import utils, table, lsctables, ligolw
+from ligo.lw import utils, table, lsctables
 import glob
+from pycbc.io.ligolw import LIGOLWContentHandler
 
-class ContentHandler(ligolw.LIGOLWContentHandler):
-    pass
-lsctables.use_in(ContentHandler)
 
 fils = glob.glob("match/match*.dat")
 mfields = ('match', 'overlap', 'time_offset', 'sigma1', 'sigma2')
@@ -178,7 +175,7 @@ if __name__ == "__main__":
             btag = part.split('-')[2].split('.')[0]
             bname = "bank/bank" + btag + ".xml"
             if bname not in btables:
-                indoc = utils.load_filename(bname, False, contenthandler=ContentHandler)
+                indoc = utils.load_filename(bname, False, contenthandler=LIGOLWContentHandler)
                 btables[bname] = table.get_table(indoc, lsctables.SimInspiralTable.tableName) 
             bt = btables[bname]
             try:      
@@ -218,7 +215,6 @@ import matplotlib
 matplotlib.use('Agg')
 import matplotlib.cm
 import pylab
-from os.path import isfile
 from numpy import *
 from ligo.lw import utils, table, lsctables
 from matplotlib.ticker import MultipleLocator, FormatStrFormatter

--- a/examples/live/check_results.py
+++ b/examples/live/check_results.py
@@ -8,13 +8,10 @@ import numpy as np
 import h5py
 import pycbc
 from pycbc.io import FieldArray
+from pycbc.io.ligolw import LIGOLWContentHandler
 from ligo.lw.utils import load_filename as load_xml_doc
-from ligo.lw import ligolw, lsctables
+from ligo.lw import lsctables
 
-
-# dummy class needed for loading LIGOLW files
-class LIGOLWContentHandler(ligolw.LIGOLWContentHandler):
-    pass
 
 def close(a, b, c):
     return abs(a - b) <= c
@@ -194,8 +191,6 @@ parser.add_argument('--detectors', type=str, required=True, nargs='+')
 args = parser.parse_args()
 
 log.basicConfig(level=log.INFO, format='%(asctime)s %(message)s')
-
-lsctables.use_in(LIGOLWContentHandler)
 
 single_fail = check_single_results(args)
 coinc_fail = check_coinc_results(args)

--- a/pycbc/inject/inject.py
+++ b/pycbc/inject/inject.py
@@ -30,6 +30,7 @@ import numpy as np
 import lal
 import copy
 import logging
+from six import add_metaclass
 from abc import ABCMeta, abstractmethod
 import lalsimulation as sim
 import h5py
@@ -43,29 +44,14 @@ from pycbc.detector import Detector
 from pycbc.conversions import tau0_from_mass1_mass2
 from pycbc.filter import resample_to_delta_t
 import pycbc.io
-from pycbc.io.ligolw import legacy_row_id_converter \
-        as legacy_ligolw_row_id_converter
+from pycbc.io.ligolw import LIGOLWContentHandler
+from ligo.lw import utils as ligolw_utils, ligolw, table, lsctables
 
-from six import add_metaclass
 
 injection_func_map = {
     np.dtype(float32): sim.SimAddInjectionREAL4TimeSeries,
     np.dtype(float64): sim.SimAddInjectionREAL8TimeSeries
 }
-
-
-#
-# Remove everything between the dashed lines once we get rid of xml
-# -----------------------------------------------------------------------------
-#
-from ligo.lw import utils as ligolw_utils
-from ligo.lw import ligolw, table, lsctables
-
-# dummy class needed for loading LIGOLW files
-@legacy_ligolw_row_id_converter
-@lsctables.use_in
-class LIGOLWContentHandler(ligolw.LIGOLWContentHandler):
-    pass
 
 
 # Map parameter names used in pycbc to names used in the sim_inspiral

--- a/pycbc/io/ligolw.py
+++ b/pycbc/io/ligolw.py
@@ -16,15 +16,18 @@
 """Tools for dealing with LIGOLW XML files."""
 
 from ligo.lw import lsctables
-from ligo.lw.ligolw import Param
+from ligo.lw.ligolw import Param, LIGOLWContentHandler \
+    as OrigLIGOLWContentHandler
 from ligo.lw.lsctables import TableByName
 from ligo.lw.table import Column, TableStream
 from ligo.lw.types import FormatFunc, FromPyType, IDTypes, ToPyType
 
+
 __all__ = ('default_null_value',
            'return_empty_sngl',
            'return_search_summary',
-           'legacy_row_id_converter')
+           'legacy_row_id_converter',
+           'LIGOLWContentHandler')
 
 ROWID_PYTYPE = int
 ROWID_TYPE = FromPyType[ROWID_PYTYPE]
@@ -205,3 +208,10 @@ def legacy_row_id_converter(ContentHandler):
     ContentHandler.startStream = startStream
 
     return ContentHandler
+
+
+@legacy_row_id_converter
+@lsctables.use_in
+class LIGOLWContentHandler(OrigLIGOLWContentHandler):
+    "Dummy class needed for loading LIGOLW files"
+    pass

--- a/pycbc/waveform/bank.py
+++ b/pycbc/waveform/bank.py
@@ -31,16 +31,16 @@ import os.path
 import h5py
 from copy import copy
 import numpy as np
-from ligo.lw import ligolw, table, lsctables, utils as ligolw_utils
+from ligo.lw import table, lsctables, utils as ligolw_utils
 import pycbc.waveform
 import pycbc.pnutils
 import pycbc.waveform.compress
 from pycbc import DYN_RANGE_FAC
 from pycbc.types import FrequencySeries, zeros
 import pycbc.io
-from pycbc.io.ligolw import legacy_row_id_converter \
-        as legacy_ligolw_row_id_converter
+from pycbc.io.ligolw import LIGOLWContentHandler
 import hashlib
+
 
 def sigma_cached(self, psd):
     """ Cache sigma calculate for use in tandem with the FilterBank class
@@ -99,11 +99,6 @@ def sigma_cached(self, psd):
             self._sigmasq[key] = self.sigma_view.inner(psd.invsqrt[self.sslice])
     return self._sigmasq[key]
 
-# dummy class needed for loading LIGOLW files
-@legacy_ligolw_row_id_converter
-@lsctables.use_in
-class LIGOLWContentHandler(ligolw.LIGOLWContentHandler):
-    pass
 
 # helper function for parsing approximant strings
 def boolargs_from_apprxstr(approximant_strs):

--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -46,17 +46,10 @@ from ligo.lw import utils as ligolw_utils
 from ligo.lw.utils import segments as ligolw_segments
 from ligo.lw.utils import process as ligolw_process
 from pycbc import makedir
-from pycbc.io.ligolw import legacy_row_id_converter \
-        as legacy_ligolw_row_id_converter
+from pycbc.io.ligolw import LIGOLWContentHandler
 from . import pegasus_workflow
 from .configuration import WorkflowConfigParser, resolve_url
 from .pegasus_sites import make_catalog
-
-
-@legacy_ligolw_row_id_converter
-@lsctables.use_in
-class ContentHandler(ligolw.LIGOLWContentHandler):
-    pass
 
 
 def make_analysis_dir(path):
@@ -1818,8 +1811,8 @@ class SegFile(File):
         """
         # load xmldocument and SegmentDefTable and SegmentTables
         fp = open(xml_file, 'rb')
-        xmldoc = ligolw_utils.load_fileobj(fp, compress='auto',
-                                           contenthandler=ContentHandler)
+        xmldoc = ligolw_utils.load_fileobj(
+                fp, compress='auto', contenthandler=LIGOLWContentHandler)
 
         seg_def_table = table.get_table(xmldoc,
                                         lsctables.SegmentDefTable.tableName)

--- a/pycbc/workflow/datafind.py
+++ b/pycbc/workflow/datafind.py
@@ -33,15 +33,12 @@ from __future__ import print_function
 import os, copy
 import logging
 from ligo import segments
-from ligo.lw import utils, table, lsctables, ligolw
+from ligo.lw import utils, table
 from glue import lal
 from pycbc.workflow.core import SegFile, File, FileList, make_analysis_dir
 from pycbc.frame import datafind_connection
+from pycbc.io.ligolw import LIGOLWContentHandler
 
-class ContentHandler(ligolw.LIGOLWContentHandler):
-    pass
-
-lsctables.use_in(ContentHandler)
 
 def setup_datafind_workflow(workflow, scienceSegs, outputDir, seg_file=None,
                             tags=None):
@@ -906,7 +903,7 @@ def get_segment_summary_times(scienceFile, segmentName):
     # Load the filename
     xmldoc = utils.load_filename(scienceFile.cache_entry.path,
                              gz=scienceFile.cache_entry.path.endswith("gz"),
-                             contenthandler=ContentHandler)
+                             contenthandler=LIGOLWContentHandler)
 
     # Get the segment_def_id for the segmentName
     segmentDefTable = table.get_table(xmldoc, "segment_definer")

--- a/test/test_io_live.py
+++ b/test/test_io_live.py
@@ -24,7 +24,7 @@ import numpy as np
 from utils import parse_args_cpu_only, simple_exit
 from pycbc.types import TimeSeries, FrequencySeries
 from pycbc.io.live import SingleCoincForGraceDB
-from ligo.lw import ligolw
+from pycbc.io.ligolw import LIGOLWContentHandler
 from ligo.lw import lsctables
 from ligo.lw import table
 from ligo.lw import utils as ligolw_utils
@@ -40,9 +40,6 @@ except ImportError:
 
 parse_args_cpu_only("io.live")
 
-class ContentHandler(ligolw.LIGOLWContentHandler):
-    pass
-lsctables.use_in(ContentHandler)
 
 class TestIOLive(unittest.TestCase):
     def setUp(self):
@@ -120,7 +117,8 @@ class TestIOLive(unittest.TestCase):
 
         # read back and check the coinc document
         read_coinc = ligolw_utils.load_filename(
-                coinc_file_name, verbose=False, contenthandler=ContentHandler)
+                coinc_file_name, verbose=False,
+                contenthandler=LIGOLWContentHandler)
         single_table = table.get_table(
                 read_coinc, lsctables.SnglInspiralTable.tableName)
         self.assertEqual(len(single_table), len(all_ifos))


### PR DESCRIPTION
In many places throughout the code base, we have code like this:
```python
class ContentHandler(ligolw.LIGOLWContentHandler):
    pass
lsctables.use_in(ContentHandler)
```
This PR moves the definition of this class to a single place (`pycbc.io.ligolw`), so that it can be just imported where needed. This should make it easier to maintain the code that uses the `ligo.lw` module.