### PR TITLE
Fix deprecated `pcolormesh()` call and pin epsie to 0.7.1 for now

### DIFF
--- a/bin/plotting/pycbc_plot_singles_timefreq
+++ b/bin/plotting/pycbc_plot_singles_timefreq
@@ -92,7 +92,7 @@ median_psd_tile = np.tile(np.array([median_psd]).T, (1, len(t)))
 del median_psd
 Pxx /= median_psd_tile
 del median_psd_tile
-norm = LogNorm(vmin=1, vmax=100)
+norm = LogNorm(vmin=1, vmax=1000)
 pc = ax.pcolormesh(t + opts.gps_start_time - center_time, freq, Pxx,
                    norm=norm, cmap='afmhot_r')
 del freq, Pxx

--- a/bin/plotting/pycbc_plot_singles_timefreq
+++ b/bin/plotting/pycbc_plot_singles_timefreq
@@ -92,9 +92,9 @@ median_psd_tile = np.tile(np.array([median_psd]).T, (1, len(t)))
 del median_psd
 Pxx /= median_psd_tile
 del median_psd_tile
-norm = LogNorm()
+norm = LogNorm(vmin=1, vmax=100)
 pc = ax.pcolormesh(t + opts.gps_start_time - center_time, freq, Pxx,
-                   vmin=1, vmax=1000, norm=norm, cmap='afmhot_r')
+                   norm=norm, cmap='afmhot_r')
 del freq, Pxx
 
 logging.info('Loading trigs')

--- a/bin/plotting/pycbc_plot_singles_timefreq
+++ b/bin/plotting/pycbc_plot_singles_timefreq
@@ -94,7 +94,7 @@ Pxx /= median_psd_tile
 del median_psd_tile
 norm = LogNorm(vmin=1, vmax=1000)
 pc = ax.pcolormesh(t + opts.gps_start_time - center_time, freq, Pxx,
-                   norm=norm, cmap='afmhot_r')
+                   norm=norm, cmap='afmhot_r', shading='gouraud')
 del freq, Pxx
 
 logging.info('Loading trigs')

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ python-ligo-lw >= 1.7.0
 # Needed for Parameter Estimation Tasks
 emcee==2.2.1
 dynesty
-epsie>=0.6
+epsie==0.7.1
 
 # For LDG service access
 dqsegdb2>=1.0.1


### PR DESCRIPTION
Matplotlib's `pcolormesh()` no longer accepts the `vmin`/`vmax` kwargs when given a `norm` kwarg. Fixes #3869. It also fixes another deprecation warning related to the `shading` kwarg.

Edit: Version 1.0 of epsie is incompatible with pycbc, which is breaking the CI tests. So this also pins the version to 0.7.1 for now while this is being fixed.