### PR TITLE
Fix three deprecation warnings coming from the tox tests

### DIFF
--- a/pycbc/io/live.py
+++ b/pycbc/io/live.py
@@ -291,8 +291,7 @@ class SingleCoincForGraceDB(object):
         filename: str
             Name of file to write to disk.
         """
-        gz = filename.endswith('.gz')
-        ligolw_utils.write_filename(self.outdoc, filename, gz=gz)
+        ligolw_utils.write_filename(self.outdoc, filename, compress='auto')
 
         # save source probabilities in a json file
         if self.probabilities is not None:

--- a/pycbc/io/record.py
+++ b/pycbc/io/record.py
@@ -44,8 +44,8 @@ _numpy_function_lib = {_x: _y for _x,_y in numpy.__dict__.items()
 #
 # =============================================================================
 #
-# add ligolw_types to numpy typeDict
-numpy.typeDict.update(ligolw_types.ToNumPyType)
+# add ligolw_types to numpy sctypeDict
+numpy.sctypeDict.update(ligolw_types.ToNumPyType)
 
 # Annoyingly, numpy has no way to store NaNs in an integer field to indicate
 # the equivalent of None. This can be problematic for fields that store ids:
@@ -118,8 +118,8 @@ def lstring_as_obj(true_or_false=None):
     """
     if true_or_false is not None:
         _default_types_status['lstring_as_obj'] = true_or_false
-        # update the typeDict
-        numpy.typeDict[u'lstring'] = numpy.object_ \
+        # update the sctypeDict
+        numpy.sctypeDict[u'lstring'] = numpy.object_ \
             if _default_types_status['lstring_as_obj'] \
             else 'S%i' % _default_types_status['default_strlen']
     return _default_types_status['lstring_as_obj']
@@ -130,7 +130,7 @@ def ilwd_as_int(true_or_false=None):
     """
     if true_or_false is not None:
         _default_types_status['ilwd_as_int'] = true_or_false
-        numpy.typeDict[u'ilwd:char'] = int \
+        numpy.sctypeDict[u'ilwd:char'] = int \
             if _default_types_status['ilwd_as_int'] \
             else 'S%i' % default_strlen
     return _default_types_status['ilwd_as_int']
@@ -141,7 +141,7 @@ def default_strlen(strlen=None):
     """
     if strlen is not None:
         _default_types_status['default_strlen'] = strlen
-        # update the typeDicts as needed
+        # update the sctypeDicts as needed
         lstring_as_obj(_default_types_status['lstring_as_obj'])
         ilwd_as_int(_default_types_status['ilwd_as_int'])
     return _default_types_status['default_strlen']

--- a/pycbc/types/config.py
+++ b/pycbc/types/config.py
@@ -32,7 +32,7 @@ from six.moves import StringIO
 from six.moves import configparser as ConfigParser
 
 
-class DeepCopyableConfigParser(ConfigParser.SafeConfigParser):
+class DeepCopyableConfigParser(ConfigParser.ConfigParser):
     """
     The standard SafeConfigParser no longer supports deepcopy() as of python
     2.7 (see http://bugs.python.org/issue16058). This subclass restores that


### PR DESCRIPTION
```
  […]/pycbc/.tox/py-unittest/lib/python3.7/site-packages/pycbc/io/record.py:48: DeprecationWarning: `np.typeDict` is a deprecated alias for `np.sctypeDict`.
    numpy.typeDict.update(ligolw_types.ToNumPyType)

  […]/pycbc/.tox/py-unittest/lib/python3.7/site-packages/pycbc/io/record.py:124: DeprecationWarning: `np.typeDict` is a deprecated alias for `np.sctypeDict`.
    else 'S%i' % _default_types_status['default_strlen']

  […]/pycbc/.tox/py-unittest/lib/python3.7/site-packages/pycbc/io/record.py:135: DeprecationWarning: `np.typeDict` is a deprecated alias for `np.sctypeDict`.
    else 'S%i' % default_strlen

  […]/pycbc/.tox/py-unittest/lib/python3.7/site-packages/pycbc/types/config.py:97: DeprecationWarning: The SafeConfigParser class has been renamed to ConfigParser in Python 3.2. This alias will be removed in future versions. Use ConfigParser directly instead.
    DeepCopyableConfigParser.__init__(self)

  […]/pycbc/.tox/py-unittest/lib/python3.7/site-packages/pycbc/io/live.py:295: DeprecationWarning: The gz keyword argument is deprecated. Use the compress keyword argument instead.
    ligolw_utils.write_filename(self.outdoc, filename, gz=gz)
```