### PR TITLE
fix FIR zero filter for short length coefficients

### DIFF
--- a/pycbc/filter/resample.py
+++ b/pycbc/filter/resample.py
@@ -52,7 +52,9 @@ def lfilter(coefficients, timeseries):
     # If there aren't many points just use the default scipy method
     if len(timeseries) < 2**7:
         series = scipy.signal.lfilter(coefficients, 1.0, timeseries)
-        return series
+        return TimeSeries(series,
+                          epoch=timeseries.start_time,
+                          delta_t=timeseries.delta_t)
     elif (len(timeseries) < fillen * 10) or (len(timeseries) < 2**18):
         cseries = (Array(coefficients[::-1] * 1)).astype(timeseries.dtype)
         cseries.resize(len(timeseries))

--- a/test/test_resample.py
+++ b/test/test_resample.py
@@ -82,7 +82,7 @@ class TestUtils(unittest.TestCase):
             test = test[len(c):]
 
             maxreldiff =  ((ref - test) / ref).max()
-
+            self.assertTrue(isinstance(test, TimeSeries))
             self.assertTrue(maxreldiff < 1e-7)
 
 suite = unittest.TestSuite()


### PR DESCRIPTION
This should fix #3880 . The bug was introduced in a patch to speed up the underyling lfilter function. In one case, the return type was not as expected. I've updated the unitest as well to catch this specific case.