### PR TITLE
Limit the number of samples used for KDEs in plot posterior

### DIFF
--- a/bin/inference/pycbc_inference_plot_posterior
+++ b/bin/inference/pycbc_inference_plot_posterior
@@ -87,9 +87,10 @@ opts = parser.parse_args()
 # set mpl style
 set_style_from_cli(opts)
 
-# get any kdeargs
+# get any kdeargs; we'll always pass through the kde max samples
+kdeargs = {'max_kde_samples': opts.max_kde_samples}
+# add any other options that were specified
 if opts.kde_args is not None:
-    kdeargs = {}
     for opt in opts.kde_args:
         opt, val = opt.split(':')
         try:
@@ -100,8 +101,6 @@ if opts.kde_args is not None:
         except TypeError:
             pass
         kdeargs[opt] = val
-else:
-    kdeargs = None
 
 if opts.plot_maxl:
     # add loglikelihood to list of parameters

--- a/pycbc/inference/option_utils.py
+++ b/pycbc/inference/option_utils.py
@@ -352,6 +352,12 @@ def add_density_option_group(parser):
              "suggest setting --kde-args 'max_samples:20000' or smaller if "
              "using this. Requires kombine to be installed.")
     density_group.add_argument(
+        '--max-kde-samples', type=int, default=None,
+        help="Limit the number of samples used for KDE construction to the "
+             "given value. This can substantially speed up plot generation "
+             "(particularly when plotting multiple parameters). Suggested "
+             "values: 5000 to 10000.")
+    density_group.add_argument(
         '--kde-args', metavar="ARG:VALUE", nargs='+', default=None,
         help="Pass the given argrument, value pairs to the KDE function "
              "(either scipy's or kombine's) when setting it up.")

--- a/pycbc/results/scatter_histograms.py
+++ b/pycbc/results/scatter_histograms.py
@@ -145,10 +145,32 @@ def get_scale_fac(fig, fiducial_width=8, fiducial_height=7):
 
 def construct_kde(samples_array, use_kombine=False, kdeargs=None):
     """Constructs a KDE from the given samples.
+
+    Parameters
+    ----------
+    samples_array : array
+        Array of values to construct the KDE for.
+    use_kombine : bool, optional
+        Use kombine's clustered KDE instead of scipy's. Default is False.
+    kdeargs : dict, optional
+        Additional arguments to pass to the KDE. Can be any argument recognized
+        by :py:func:`scipy.stats.gaussian_kde` or
+        :py:func:`kombine.clustered_kde.optimized_kde`. In either case, you can
+        also set ``max_kde_samples`` to limit the number of samples that are
+        used for KDE construction.
+
+    Returns
+    -------
+    kde :
+        The KDE.
     """
     # make sure samples are randomly sorted
     numpy.random.seed(0)
     numpy.random.shuffle(samples_array)
+    # if kde arg specifies a maximum number of samples, limit them
+    kdeargs = kdeargs.copy()
+    max_nsamples = kdeargs.pop('max_kde_samples', None)
+    samples_array = samples_array[:max_nsamples]
     if use_kombine:
         try:
             import kombine

--- a/pycbc/results/scatter_histograms.py
+++ b/pycbc/results/scatter_histograms.py
@@ -168,7 +168,10 @@ def construct_kde(samples_array, use_kombine=False, kdeargs=None):
     numpy.random.seed(0)
     numpy.random.shuffle(samples_array)
     # if kde arg specifies a maximum number of samples, limit them
-    kdeargs = kdeargs.copy()
+    if kdeargs is None:
+        kdeargs = {}
+    else:
+        kdeargs = kdeargs.copy()
     max_nsamples = kdeargs.pop('max_kde_samples', None)
     samples_array = samples_array[:max_nsamples]
     if use_kombine:


### PR DESCRIPTION
This adds a `--max-kde-samples` argument to `pycbc_inference_plot_posterior` so that the user can optionally limit the number of samples used for KDE construction. KDEs are used to make the 2D density plots and draw contours. If there are more than ~10000 samples in a file, this can be extremely slow if plotting more than a few parameters. Limiting the number can substantially speed up plotting without making any noticable changes in the plots. For example, in testing, I found that it takes ~4mins to plot six parameters using a posterior file with ~80000 samples. Adding `--max-kde-samples 5000` took only ~18s for the same plot.