### PR TITLE
Improve error when strain data is not available

### DIFF
--- a/pycbc/catalog/__init__.py
+++ b/pycbc/catalog/__init__.py
@@ -123,20 +123,21 @@ class Merger(object):
         from pycbc.io import get_file
         from pycbc.frame import read_frame
 
-        if sample_rate == 4096:
-            sampling = "4KHz"
-        elif sample_rate == 16384:
-            sampling = "16KHz"
-
         for fdict in self.data['strain']:
             if (fdict['detector'] == ifo and fdict['duration'] == duration and
                     fdict['sampling_rate'] == sample_rate and
                     fdict['format'] == 'gwf'):
                 url = fdict['url']
                 break
+        else:
+            raise ValueError('no strain data is available as requested '
+                             'for ' + self.common_name)
 
         ver = url.split('/')[-1].split('-')[1].split('_')[-1]
-        channel = "{}:GWOSC-{}_{}_STRAIN".format(ifo, sampling.upper(), ver)
+        sampling_map = {4096: "4KHZ",
+                        16384: "16KHZ"}
+        channel = "{}:GWOSC-{}_{}_STRAIN".format(
+                ifo, sampling_map[sample_rate], ver)
 
         filename = get_file(url, cache=True)
         return read_frame(str(filename), str(channel))


### PR DESCRIPTION
When using `Merger(name).strain(detector)` and the strain data does not actually exist, the current code raises a rather vague error like this:
```
UnboundLocalError: local variable 'url' referenced before assignment
```
This PR makes the error clearer and cleans up the code slightly.