### PR TITLE
Some fixes to test suite - focused on MACOS usage

### DIFF
--- a/.github/workflows/basic-tests.yml
+++ b/.github/workflows/basic-tests.yml
@@ -34,7 +34,7 @@ jobs:
     - name: run pycbc test suite
       run: |
         export LAL_DATA_PATH=$PWD
-        sudo tox -e py-${{matrix.test-type}}
+       tox -e py-${{matrix.test-type}}
     - name: store documentation page
       if: matrix.test-type == 'docs' && matrix.python-version == '3.8'
       uses: actions/upload-artifact@v2

--- a/.github/workflows/basic-tests.yml
+++ b/.github/workflows/basic-tests.yml
@@ -34,6 +34,7 @@ jobs:
     - name: run pycbc test suite
       run: |
         export LAL_DATA_PATH=$PWD
+        sudo chmod 777 /usr/local/miniconda/pkgs/cache
         tox -e py-${{matrix.test-type}}
     - name: store documentation page
       if: matrix.test-type == 'docs' && matrix.python-version == '3.8'

--- a/.github/workflows/basic-tests.yml
+++ b/.github/workflows/basic-tests.yml
@@ -34,9 +34,7 @@ jobs:
     - name: run pycbc test suite
       run: |
         export LAL_DATA_PATH=$PWD
-        sudo chmod -R 777 /usr/local/miniconda/pkgs/cache
-        sudo chown 501:20 /usr/local/miniconda/pkgs/cache/b89cf7bf.json
-        tox -e py-${{matrix.test-type}}
+        sudo tox -e py-${{matrix.test-type}}
     - name: store documentation page
       if: matrix.test-type == 'docs' && matrix.python-version == '3.8'
       uses: actions/upload-artifact@v2

--- a/.github/workflows/basic-tests.yml
+++ b/.github/workflows/basic-tests.yml
@@ -34,10 +34,6 @@ jobs:
     - name: run pycbc test suite
       run: |
         export LAL_DATA_PATH=$PWD
-        miniconda_global_cache <- "/usr/local/miniconda/"
-        if (dir.exists(miniconda_global_cache)) {
-          unlink(miniconda_global_cache, recursive = TRUE)
-        }
         tox -e py-${{matrix.test-type}}
     - name: store documentation page
       if: matrix.test-type == 'docs' && matrix.python-version == '3.8'

--- a/.github/workflows/basic-tests.yml
+++ b/.github/workflows/basic-tests.yml
@@ -34,7 +34,7 @@ jobs:
     - name: run pycbc test suite
       run: |
         export LAL_DATA_PATH=$PWD
-        sudo chmod 777 /usr/local/miniconda/pkgs/cache
+        sudo chmod -R 777 /usr/local/miniconda/pkgs/cache
         tox -e py-${{matrix.test-type}}
     - name: store documentation page
       if: matrix.test-type == 'docs' && matrix.python-version == '3.8'

--- a/.github/workflows/basic-tests.yml
+++ b/.github/workflows/basic-tests.yml
@@ -35,6 +35,7 @@ jobs:
       run: |
         export LAL_DATA_PATH=$PWD
         sudo chmod -R 777 /usr/local/miniconda/pkgs/cache
+        sudo chown 501:20 /usr/local/miniconda/pkgs/cache/b89cf7bf.json
         tox -e py-${{matrix.test-type}}
     - name: store documentation page
       if: matrix.test-type == 'docs' && matrix.python-version == '3.8'

--- a/.github/workflows/basic-tests.yml
+++ b/.github/workflows/basic-tests.yml
@@ -34,7 +34,11 @@ jobs:
     - name: run pycbc test suite
       run: |
         export LAL_DATA_PATH=$PWD
-       tox -e py-${{matrix.test-type}}
+        miniconda_global_cache <- "/usr/local/miniconda/"
+        if (dir.exists(miniconda_global_cache)) {
+          unlink(miniconda_global_cache, recursive = TRUE)
+        }
+        tox -e py-${{matrix.test-type}}
     - name: store documentation page
       if: matrix.test-type == 'docs' && matrix.python-version == '3.8'
       uses: actions/upload-artifact@v2

--- a/.github/workflows/mac-test.yml
+++ b/.github/workflows/mac-test.yml
@@ -21,4 +21,5 @@ jobs:
         pip install --upgrade pip setuptools tox
     - name: run basic pycbc test suite
       run: |
+        sudo chmod -R 777 /usr/local/miniconda/pkgs/cache
         tox py-unittest

--- a/.github/workflows/mac-test.yml
+++ b/.github/workflows/mac-test.yml
@@ -21,5 +21,5 @@ jobs:
         pip install --upgrade pip setuptools tox
     - name: run basic pycbc test suite
       run: |
-        sudo chmod -R 777 /usr/local/miniconda/pkgs/cache
+        sudo chmod -R 777 /usr/local/miniconda/
         tox py-unittest

--- a/pycbc/conversions.py
+++ b/pycbc/conversions.py
@@ -797,9 +797,8 @@ def snr_from_loglr(loglr):
         loglr = numpy.array([loglr])
     # temporarily quiet sqrt(-1) warnings
     orig_settings = numpy.geterr()
-    numpy.seterr(invalid='ignore')
-    snrs = numpy.sqrt(2*loglr)
-    numpy.seterr(**orig_settings)
+    with numpy.errstate(invalid="ignore"):
+        snrs = numpy.sqrt(2*loglr)
     snrs[numpy.isnan(snrs)] = 0.
     if singleval:
         snrs = snrs[0]

--- a/pycbc/conversions.py
+++ b/pycbc/conversions.py
@@ -796,9 +796,10 @@ def snr_from_loglr(loglr):
     if singleval:
         loglr = numpy.array([loglr])
     # temporarily quiet sqrt(-1) warnings
-    numpysettings = numpy.seterr(invalid='ignore')
+    orig_settings = numpy.geterr()
+    numpy.seterr(invalid='ignore')
     snrs = numpy.sqrt(2*loglr)
-    numpy.seterr(**numpysettings)
+    numpy.seterr(**orig_settings)
     snrs[numpy.isnan(snrs)] = 0.
     if singleval:
         snrs = snrs[0]

--- a/pycbc/conversions.py
+++ b/pycbc/conversions.py
@@ -796,7 +796,6 @@ def snr_from_loglr(loglr):
     if singleval:
         loglr = numpy.array([loglr])
     # temporarily quiet sqrt(-1) warnings
-    orig_settings = numpy.geterr()
     with numpy.errstate(invalid="ignore"):
         snrs = numpy.sqrt(2*loglr)
     snrs[numpy.isnan(snrs)] = 0.

--- a/pycbc/distributions/qnm.py
+++ b/pycbc/distributions/qnm.py
@@ -155,7 +155,6 @@ class UniformF0Tau(uniform.Uniform):
             l, m = 2, 2
         # temporarily silence invalid warnings... these will just be ruled out
         # automatically
-        orig = numpy.geterr()
         with numpy.errstate(invalid="ignore"):
             mf = conversions.final_mass_from_f0_tau(f0, tau, l=l, m=m)
             sf = conversions.final_spin_from_f0_tau(f0, tau, l=l, m=m)

--- a/pycbc/distributions/qnm.py
+++ b/pycbc/distributions/qnm.py
@@ -156,12 +156,11 @@ class UniformF0Tau(uniform.Uniform):
         # temporarily silence invalid warnings... these will just be ruled out
         # automatically
         orig = numpy.geterr()
-        numpy.seterr(invalid='ignore')
-        mf = conversions.final_mass_from_f0_tau(f0, tau, l=l, m=m)
-        sf = conversions.final_spin_from_f0_tau(f0, tau, l=l, m=m)
-        isin = (self.final_mass_bounds.__contains__(mf)) & (
-                self.final_spin_bounds.__contains__(sf))
-        numpy.seterr(**orig)
+        with numpy.errstate(invalid="ignore"):
+            mf = conversions.final_mass_from_f0_tau(f0, tau, l=l, m=m)
+            sf = conversions.final_spin_from_f0_tau(f0, tau, l=l, m=m)
+            isin = (self.final_mass_bounds.__contains__(mf)) & (
+                    self.final_spin_bounds.__contains__(sf))
         return isin
 
     def rvs(self, size=1):

--- a/pycbc/distributions/qnm.py
+++ b/pycbc/distributions/qnm.py
@@ -155,7 +155,8 @@ class UniformF0Tau(uniform.Uniform):
             l, m = 2, 2
         # temporarily silence invalid warnings... these will just be ruled out
         # automatically
-        orig = numpy.seterr(invalid='ignore')
+        orig = numpy.geterr()
+        numpy.seterr(invalid='ignore')
         mf = conversions.final_mass_from_f0_tau(f0, tau, l=l, m=m)
         sf = conversions.final_spin_from_f0_tau(f0, tau, l=l, m=m)
         isin = (self.final_mass_bounds.__contains__(mf)) & (

--- a/pycbc/distributions/uniform.py
+++ b/pycbc/distributions/uniform.py
@@ -96,11 +96,12 @@ class Uniform(bounded.BoundedDist):
         super(Uniform, self).__init__(**params)
         # compute the norm and save
         # temporarily suppress numpy divide by 0 warning
+        old_settings = numpy.geterr()
         numpy.seterr(divide='ignore')
         self._lognorm = -sum([numpy.log(abs(bnd[1]-bnd[0]))
                                     for bnd in self._bounds.values()])
         self._norm = numpy.exp(self._lognorm)
-        numpy.seterr(divide='warn')
+        numpy.seterr(**old_settings)
 
     @property
     def norm(self):

--- a/pycbc/distributions/uniform.py
+++ b/pycbc/distributions/uniform.py
@@ -97,11 +97,10 @@ class Uniform(bounded.BoundedDist):
         # compute the norm and save
         # temporarily suppress numpy divide by 0 warning
         old_settings = numpy.geterr()
-        numpy.seterr(divide='ignore')
-        self._lognorm = -sum([numpy.log(abs(bnd[1]-bnd[0]))
-                                    for bnd in self._bounds.values()])
-        self._norm = numpy.exp(self._lognorm)
-        numpy.seterr(**old_settings)
+        with numpy.errstate(divide="ignore"):
+            self._lognorm = -sum([numpy.log(abs(bnd[1]-bnd[0]))
+                                  for bnd in self._bounds.values()])
+            self._norm = numpy.exp(self._lognorm)
 
     @property
     def norm(self):

--- a/pycbc/distributions/uniform.py
+++ b/pycbc/distributions/uniform.py
@@ -96,7 +96,6 @@ class Uniform(bounded.BoundedDist):
         super(Uniform, self).__init__(**params)
         # compute the norm and save
         # temporarily suppress numpy divide by 0 warning
-        old_settings = numpy.geterr()
         with numpy.errstate(divide="ignore"):
             self._lognorm = -sum([numpy.log(abs(bnd[1]-bnd[0]))
                                   for bnd in self._bounds.values()])

--- a/pycbc/tmpltbank/calc_moments.py
+++ b/pycbc/tmpltbank/calc_moments.py
@@ -121,11 +121,11 @@ def determine_eigen_directions(metricParams, preserveMoments=False,
         # Calculate the metric
         gs, unmax_metric_curr = calculate_metric(Js, logJs, loglogJs,
                                           logloglogJs, loglogloglogJs, mapping)
-        metric[item] = numpy.matrix(gs)
+        metric[item] = gs
         unmax_metric[item] = unmax_metric_curr
 
         # And the eigenvalues
-        evals[item],evecs[item] = numpy.linalg.eig(gs)
+        evals[item], evecs[item] = numpy.linalg.eig(gs)
 
         # Numerical error can lead to small negative eigenvalues.
         for i in range(len(evals[item])):
@@ -430,9 +430,8 @@ def calculate_metric(Js, logJs, loglogJs, logloglogJs, loglogloglogJs, \
     # How many dimensions in the parameter space?
     maxLen = len(mapping.keys())
 
-    metric = numpy.matrix(numpy.zeros(shape=(maxLen,maxLen),dtype=float))
-    unmax_metric = numpy.matrix(numpy.zeros(shape=(maxLen+1,maxLen+1),
-                                                                  dtype=float))
+    metric = numpy.zeros(shape=(maxLen,maxLen), dtype=float)
+    unmax_metric = numpy.zeros(shape=(maxLen+1,maxLen+1), dtype=float)
 
     for i in range(16):
         for j in range(16):

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -209,6 +209,10 @@ class TestDistributions(unittest.TestCase):
             pdf_2 = numpy.array([polar_dist.pdf(**{"theta" : p})
                                  * ang_dist.pdf(**{"theta" : a})
                                  for p, a in cart_sin])
+
+            # Catch and silence warnings here
+            old_settings = numpy.geterr()
+            numpy.seterr(invalid='ignore', divide='ignore')
             if not (numpy.all(numpy.nan_to_num(abs(1.0 - pdf_1 / pdf_2))
                        < tolerance)):
                 raise ValueError("The {} distribution PDF does not match its "
@@ -225,6 +229,7 @@ class TestDistributions(unittest.TestCase):
                        < tolerance)):
                 raise ValueError("The {} distribution PDF does not match its "
                                  "component distriubtions.".format(dist.name))
+            numpy.seterr(**old_settings)
 
             # check random draws from polar angle equilvalent
             ang_1 = dist.rvs(n_samples)[dist.polar_angle]

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -211,25 +211,25 @@ class TestDistributions(unittest.TestCase):
                                  for p, a in cart_sin])
 
             # Catch and silence warnings here
-            old_settings = numpy.geterr()
-            numpy.seterr(invalid='ignore', divide='ignore')
-            if not (numpy.all(numpy.nan_to_num(abs(1.0 - pdf_1 / pdf_2))
-                       < tolerance)):
-                raise ValueError("The {} distribution PDF does not match its "
-                                 "component distriubtions.".format(dist.name))
+            with numpy.errstate(invalid="ignore", divide='ignore'):
+                if not (numpy.all(numpy.nan_to_num(abs(1.0 - pdf_1 / pdf_2))
+                                  < tolerance)):
+                    raise ValueError("The {} distribution PDF does not match "
+                                     "its component "
+                                     "distributions.".format(dist.name))
 
-            # check logarithm of PDF equilvalent
-            pdf_1 = numpy.array([dist.logpdf(**{dist.polar_angle : p,
-                                                dist.azimuthal_angle : a})
-                                 for p, a in cart_sin])
-            pdf_2 = numpy.array([polar_dist.logpdf(**{"theta" : p})
-                                 + ang_dist.logpdf(**{"theta" : a})
-                                 for p, a in cart_sin])
-            if not (numpy.all(numpy.nan_to_num(abs(1.0 - pdf_1 / pdf_2))
-                       < tolerance)):
-                raise ValueError("The {} distribution PDF does not match its "
-                                 "component distriubtions.".format(dist.name))
-            numpy.seterr(**old_settings)
+                # check logarithm of PDF equivalent
+                pdf_1 = numpy.array([dist.logpdf(**{dist.polar_angle : p,
+                                                    dist.azimuthal_angle : a})
+                                     for p, a in cart_sin])
+                pdf_2 = numpy.array([polar_dist.logpdf(**{"theta" : p})
+                                     + ang_dist.logpdf(**{"theta" : a})
+                                     for p, a in cart_sin])
+                if not (numpy.all(numpy.nan_to_num(abs(1.0 - pdf_1 / pdf_2))
+                           < tolerance)):
+                    raise ValueError("The {} distribution PDF does not match "
+                                     "its component "
+                                     "distriubtions.".format(dist.name))
 
             # check random draws from polar angle equilvalent
             ang_1 = dist.rvs(n_samples)[dist.polar_angle]

--- a/test/test_skymax.py
+++ b/test/test_skymax.py
@@ -370,12 +370,10 @@ class TestChisq(unittest.TestCase):
         uvals_prec, _ = compute_u_val_for_sky_loc_stat\
             (I_plus.data, I_cross.data, hpc_corr_R, indices=[idx_max_prec],
              hpnorm=1., hcnorm=1.)
-        old_settings = numpy.geterr()
-        numpy.seterr(divide='ignore')
-        uvals_hom, _ = compute_u_val_for_sky_loc_stat_no_phase\
-            (I_plus.data, I_cross.data, hpc_corr_R, indices=[idx_max_hom],
-             hpnorm=1., hcnorm=1.)
-        numpy.seterr(**old_settings)
+        with numpy.errstate(divide="ignore"):
+            uvals_hom, _ = compute_u_val_for_sky_loc_stat_no_phase\
+                (I_plus.data, I_cross.data, hpc_corr_R, indices=[idx_max_hom],
+                 hpnorm=1., hcnorm=1.)
 
         ht = hplus * uvals_hom[0] + hcross
         ht_norm = sigmasq(ht, psd=self.psd,
@@ -408,12 +406,10 @@ class TestChisq(unittest.TestCase):
              low_frequency_cutoff=self.low_freq_filter, h_norm=1.)
         I_t = I_t * n_t
 
-        old_vals = numpy.geterr()
-        numpy.seterr(invalid='ignore', divide='ignore')
-        chisq, _ = self.power_chisq.values\
-            (corr_t, array([max_ds_prec]) / n_plus, n_t, self.psd,
-             array([idx_max_prec]), ht)
-        numpy.seterr(**old_vals)
+        with numpy.errstate(divide="ignore", invalid='ignore'):
+            chisq, _ = self.power_chisq.values\
+                (corr_t, array([max_ds_prec]) / n_plus, n_t, self.psd,
+                 array([idx_max_prec]), ht)
 
         self.assertAlmostEqual(abs(I_t.data[idx_max_prec]), max_ds_prec)
         self.assertEqual(idx_max_prec, abs(I_t.data).argmax())

--- a/test/test_skymax.py
+++ b/test/test_skymax.py
@@ -2,6 +2,7 @@ import copy
 import unittest
 import random
 import os
+import numpy
 from numpy import complex128, real, sqrt, sin, cos, angle, ceil, log
 from numpy import zeros, argmax, array
 from pycbc import DYN_RANGE_FAC
@@ -369,9 +370,12 @@ class TestChisq(unittest.TestCase):
         uvals_prec, _ = compute_u_val_for_sky_loc_stat\
             (I_plus.data, I_cross.data, hpc_corr_R, indices=[idx_max_prec],
              hpnorm=1., hcnorm=1.)
+        old_settings = numpy.geterr()
+        numpy.seterr(divide='ignore')
         uvals_hom, _ = compute_u_val_for_sky_loc_stat_no_phase\
             (I_plus.data, I_cross.data, hpc_corr_R, indices=[idx_max_hom],
              hpnorm=1., hcnorm=1.)
+        numpy.seterr(**old_settings)
 
         ht = hplus * uvals_hom[0] + hcross
         ht_norm = sigmasq(ht, psd=self.psd,
@@ -386,9 +390,12 @@ class TestChisq(unittest.TestCase):
         self.assertAlmostEqual(abs(real(I_t.data[idx_max_hom])), max_ds_hom)
         self.assertEqual(abs(real(I_t.data[idx_max_hom])),
                          max(abs(real(I_t.data))))
+        old_vals = numpy.geterr()
+        numpy.seterr(invalid='ignore', divide='ignore')
         chisq, _ = self.power_chisq.values\
             (corr_t, array([max_ds_hom]) / n_plus, n_t, self.psd,
              array([idx_max_hom]), ht)
+        numpy.seterr(**old_vals)
 
         ht = hplus * uvals_prec[0] + hcross
         ht_norm = sigmasq(ht, psd=self.psd,
@@ -401,9 +408,12 @@ class TestChisq(unittest.TestCase):
              low_frequency_cutoff=self.low_freq_filter, h_norm=1.)
         I_t = I_t * n_t
 
+        old_vals = numpy.geterr()
+        numpy.seterr(invalid='ignore', divide='ignore')
         chisq, _ = self.power_chisq.values\
             (corr_t, array([max_ds_prec]) / n_plus, n_t, self.psd,
              array([idx_max_prec]), ht)
+        numpy.seterr(**old_vals)
 
         self.assertAlmostEqual(abs(I_t.data[idx_max_prec]), max_ds_prec)
         self.assertEqual(idx_max_prec, abs(I_t.data).argmax())

--- a/test/test_skymax.py
+++ b/test/test_skymax.py
@@ -388,12 +388,10 @@ class TestChisq(unittest.TestCase):
         self.assertAlmostEqual(abs(real(I_t.data[idx_max_hom])), max_ds_hom)
         self.assertEqual(abs(real(I_t.data[idx_max_hom])),
                          max(abs(real(I_t.data))))
-        old_vals = numpy.geterr()
-        numpy.seterr(invalid='ignore', divide='ignore')
-        chisq, _ = self.power_chisq.values\
-            (corr_t, array([max_ds_hom]) / n_plus, n_t, self.psd,
-             array([idx_max_hom]), ht)
-        numpy.seterr(**old_vals)
+        with numpy.errstate(invalid='ignore', divide='ignore'):
+            chisq, _ = self.power_chisq.values\
+                (corr_t, array([max_ds_hom]) / n_plus, n_t,
+                 self.psd, array([idx_max_hom]), ht)
 
         ht = hplus * uvals_prec[0] + hcross
         ht_norm = sigmasq(ht, psd=self.psd,

--- a/test/test_tmpltbank.py
+++ b/test/test_tmpltbank.py
@@ -27,6 +27,7 @@ These are the unittests for the pycbc.tmpltbank module
 
 from __future__ import division
 import os
+import math
 import numpy
 import pycbc.tmpltbank
 import pycbc.psd
@@ -238,41 +239,47 @@ class TmpltbankTestClass(unittest.TestCase):
 
             # Check that if the mass limits have changed, it was right to do so
             # This is not exhaustive, but gets most things
-            if not self.min_total_mass == curr_min_mass:
+            if (curr_min_mass is None) or \
+                    not math.isclose(self.min_total_mass, curr_min_mass,
+                                     rel_tol=1e-06):
                 min_comp_mass = self.min_mass1 + self.min_mass2
                 min_eta = self.min_mass1 * self.min_mass2 /\
                            (min_comp_mass * min_comp_mass)
                 min_chirp_mass = min_comp_mass * min_eta**(3./5.)
-                if self.min_total_mass == min_comp_mass:
+                if (min_comp_mass is not None) and \
+                        math.isclose(self.min_total_mass, min_comp_mass,
+                                     rel_tol=1e-06):
                     # Okay, the total mass is changed by the components
                     pass
                 elif (self.min_eta and min_eta < self.min_eta) or \
                         (self.max_eta and min_eta > self.max_eta):
                     # Okay, not possible from eta
                     pass
-                elif min_chirp_mass < self.min_chirp_mass:
+                elif self.min_chirp_mass and \
+                        min_chirp_mass < self.min_chirp_mass:
                     # Okay, not possible from chirp mass
                     pass
                 else:
                     err_msg = "Minimum total mass changed unexpectedly."
-                    print(self.min_total_mass, curr_min_mass)
-                    print(self.min_mass1, self.min_mass2, min_comp_mass)
-                    print(min_eta, self.min_eta, self.max_eta)
-                    print(min_chirp_mass, self.min_chirp_mass)
                     self.fail(err_msg)
-            if not self.max_total_mass == curr_max_mass:
+            if (curr_max_mass is None) or \
+                    not math.isclose(self.max_total_mass, curr_max_mass,
+                                 rel_tol=1e-06):
                 max_comp_mass = self.max_mass1 + self.max_mass2
                 max_eta = self.max_mass1 * self.max_mass2 /\
                            (max_comp_mass * max_comp_mass)
                 max_chirp_mass = max_comp_mass * max_eta**(3./5.)
-                if self.max_total_mass == max_comp_mass:
+                if (max_comp_mass is not None) and \
+                        math.isclose(self.max_total_mass, max_comp_mass,
+                                     rel_tol=1e-06):
                     # Okay, the total mass is changed by the components
                     pass
                 elif (self.min_eta and max_eta < self.min_eta) or\
                         (self.max_eta and max_eta > self.max_eta):
                     # Okay, not possible from eta
                     pass
-                elif max_chirp_mass > self.max_chirp_mass:
+                elif self.max_chirp_mass and \
+                        max_chirp_mass > self.max_chirp_mass:
                     # Okay, not possible from chirp mass
                     pass
                 else:

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,7 @@ deps =
 allowlist_externals = bash
 passenv=LAL_DATA_PATH
 conda_deps=lalsuite
+conda_channels=conda-forge
 
 # This test should run on almost anybody's environment
 [testenv:py-unittest]

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ requires=tox-conda
 deps =
     :preinstall: -rrequirements.txt
     -rcompanion.txt
-    mkl;sys_platform!='darwin'
+    mkl;'arm' not in platform_machine
 
 [testenv]
 allowlist_externals = bash

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,9 @@ deps =
 [testenv]
 allowlist_externals = bash
 passenv=LAL_DATA_PATH
-conda_deps=lalsuite
+conda_deps=
+    lalsuite
+    openssl=1.1
 conda_channels=conda-forge
 
 # This test should run on almost anybody's environment

--- a/tox.ini
+++ b/tox.ini
@@ -3,16 +3,18 @@ recreate = true
 envlist = py-unittest
 indexserver =
     preinstall = https://pypi.python.org/simple
+requires=tox-conda
 
 [base]
 deps =
     :preinstall: -rrequirements.txt
     -rcompanion.txt
-    mkl
+    mkl;sys_platform!='darwin'
 
 [testenv]
 allowlist_externals = bash
-passenv:LAL_DATA_PATH
+passenv=LAL_DATA_PATH
+conda_deps=lalsuite
 
 # This test should run on almost anybody's environment
 [testenv:py-unittest]


### PR DESCRIPTION
My goal here is to make `tox` run properly on mac (in particular ARM macs). I do this by moving to tox-conda for the most part.

There's also some warning fixes, and one failure in python3.9.7 where `None < 2` now raises an error rather than giving some output.

Finally, `numpy.seterr` was being used slightly incorrectly in some of the PE code, so that the original settings were not restored. This fixes that, and I add it to some of the tests where numpy warnings are expected.