### PR TITLE
Remove matplotlib.use('Agg') from library code

### DIFF
--- a/pycbc/population/fgmc_functions.py
+++ b/pycbc/population/fgmc_functions.py
@@ -17,24 +17,12 @@ import bisect
 from itertools import chain as it_chain, combinations as it_comb
 import numpy as np
 
-from matplotlib import use
-use('Agg')
-from matplotlib import rcParams
 from matplotlib import pyplot as plt
 
 from pycbc import conversions as conv
 from pycbc import events
 from pycbc.events.coinc import mean_if_greater_than_zero as coinc_meanigz
 from pycbc.events import triggers
-
-rcParams.update({'axes.labelsize': 12,
-                 'font.size': 12,
-                 'legend.fontsize': 12,
-                 'xtick.labelsize': 12,
-                 'ytick.labelsize': 12,
-                 'text.usetex': False,
-                })
-
 
 def filter_bin_lo_hi(values, lo, hi):
     in_bin = np.sign((values - lo) * (hi - values))

--- a/pycbc/population/fgmc_functions.py
+++ b/pycbc/population/fgmc_functions.py
@@ -24,6 +24,7 @@ from pycbc import events
 from pycbc.events.coinc import mean_if_greater_than_zero as coinc_meanigz
 from pycbc.events import triggers
 
+
 def filter_bin_lo_hi(values, lo, hi):
     in_bin = np.sign((values - lo) * (hi - values))
     if np.any(in_bin == 0):


### PR DESCRIPTION
Having `matplotlib.use('Agg')` in library code is not a good idea. As this library is loaded in many use cases, it will mean that matplotlib will likely be using the 'Agg' module when you don't want it to, and then when you are expecting to see plots in Jupyter, you do not see plots.

I think the way this is handled in the `fgmc_plots` module seems very nice. If this is not the best way to do this here, this could be put into the two plotting methods (with a note that it will do this in the function docs). In general though we leave it to executables to see things like this, where this solution is the right thing to do.

Similar with the rcParams.
