### PR TITLE
move h_iterations check

### DIFF
--- a/bin/all_sky_search/pycbc_add_statmap
+++ b/bin/all_sky_search/pycbc_add_statmap
@@ -396,10 +396,6 @@ h_iterations = 0
 # Break out of loop if max number of removals is reached
 # or no more triggers above specified IFAR threshold
 while True:
-    if (h_iterations == args.max_hierarchical_removal):
-        logging.info("Reached hierarchical removal limit of %d" %
-                     args.max_hierarchical_removal)
-        break
     logging.info("Hierarchical iteration %d" % h_iterations)
     bg_grps = {}
 
@@ -450,6 +446,12 @@ while True:
         for key in combined_fg_data.data:
             f['foreground_h%s/%s' % (h_iterations, key)] = \
                     combined_fg_data.data[key][:]
+
+    if (h_iterations == args.max_hierarchical_removal):
+        logging.info("Reached hierarchical removal limit of %d" %
+                     args.max_hierarchical_removal)
+        break
+    logging.info("Hierarchical iteration %d" % h_iterations)
 
     max_each_combo = {combo: sep_fg_data[combo].data['ifar'][:].argmax()
                       for combo in all_ifo_combos


### PR DESCRIPTION
As identified by #3913

If --max-hierarchical-removals N is given, the pycbc_add_statmap output currently outputs N datasets, up to foreground_h(N-1), but should have output N+1 outputs, as the first (foreground_h0) is when no HR has been done.

This moves the check whether max-hierarchical-removals has been reached to after the dataset has been output, the same place where the ifar threshold check is.

Tested and fixes the ifar_catalog error