### PR TITLE
Modernize `pycbc_losc_segment_query`

### DIFF
--- a/bin/pycbc_losc_segment_query
+++ b/bin/pycbc_losc_segment_query
@@ -1,50 +1,43 @@
 #!/usr/bin/env python
 
 import os
-import pwd
 import logging
 import json
 import argparse
 import shutil
 from urllib.request import urlopen
-
 import ligo.segments
-from glue import git_version
-from ligo.lw import ligolw
-from ligo.lw import utils
-from ligo.lw.utils import process
-from glue.segmentdb import segmentdb_utils
-from dqsegdb import clientutils
+from pycbc.workflow import SegFile
+
 
 # Logging formatting from pycbc optimal snr
 log_fmt = '%(asctime)s %(message)s'
 log_date_fmt = '%Y-%m-%d %H:%M:%S'
-logging.basicConfig(level=logging.INFO, format=log_fmt,
-                    datefmt=log_date_fmt)
+logging.basicConfig(level=logging.INFO, format=log_fmt, datefmt=log_date_fmt)
 
 
-# Function to query json segment data from LOSC
-def query_losc(ifo, segment_name, gps_start_time, duration):
+# Function to query json segment data from GWOSC
+def query_gwosc(ifo, segment_name, gps_start_time, duration):
     """
-    Function that queries the O1 LOSC data from json to xml
+    Function that queries the O1 GWOSC data from json to xml
 
     Parameters
     ----------
     ifo: string
         The interferometer to query (H1, L1).
     segment_name: string
-        The veto group or science group to query from LOSC.
+        The veto group or science group to query from GWOSC.
     gps_start_time: int / string
-        The starting gps time to begin querying from the O1 LOSC data set.
+        The starting gps time to begin querying from the O1 GWOSC data set.
     duration: int / string
         The amount of time in seconds after the gps start time.
 
     Returns
     ---------
     segment_list :  ligo.segments.segmentlist
-        The inverval returned by LOSC
+        The interval returned by GWOSC
     segment_summary :  ligo.segments.segmentlist
-        The segments returned by LOSC
+        The segments returned by GWOSC
     """
 
     response = urlopen(
@@ -63,45 +56,18 @@ def query_losc(ifo, segment_name, gps_start_time, duration):
 
     return summary_segment, segments
 
-
 def write_xml_file(ifo, summary_segment, segments, filename):
-    version = 1
-
-    PROGRAM_NAME = 'pycbc_losc_segment_query'
-    PROGRAM_PID  = os.getpid()
-    USER_NAME = pwd.getpwuid(os.getuid())[0]
-
-    __author__  = "Duncan Brown <dabrown@syr.edu>"
-    __version__ = "git id %s" % git_version.id
-    __date__ = git_version.date
-
-    doc = ligolw.Document()
-    doc.appendChild(ligolw.LIGO_LW())
-    process_id = process.register_to_xmldoc(doc, PROGRAM_NAME, {},
-                                            version = git_version.id,
-                                            cvs_entry_time = __date__,
-                                            comment='LOSC segments').process_id
-
-    seg_def_id = segmentdb_utils.add_to_segment_definer(doc, process_id, ifo,
-                                                        'RESULT', 1, comment='LOSC query result')
-
-    clientutils.add_to_segment_summary_ns(doc, process_id, seg_def_id,
-                                          summary_segment,
-                                          comment='start and end time from losc query')
-
-    clientutils.add_to_segment_ns(doc, process_id, seg_def_id, segments)
-
-    utils.write_filename(doc, filename, gz=False)
-
+    file_url = 'file://' + os.path.abspath(filename)
+    sf = SegFile.from_segment_list('GWOSC segments', segments, 'RESULT', ifo,
+                                   summary_segment, file_url=file_url)
+    sf.to_segment_xml()
 
 
 parser = argparse.ArgumentParser()
-parser.add_argument('--gps-start-time', type=int)
-parser.add_argument('--gps-end-time', type=int)
-parser.add_argument('--query-segments', action='store_true')
-parser.add_argument('--segment-url', type=str)
-parser.add_argument('--include-segments', type=str)
-parser.add_argument('--output-file', type=str)
+parser.add_argument('--gps-start-time', type=int, required=True)
+parser.add_argument('--gps-end-time', type=int, required=True)
+parser.add_argument('--include-segments', type=str, required=True)
+parser.add_argument('--output-file', type=str, required=True)
 parser.add_argument('--protract-hw-inj', type=int, default=0)
 args = parser.parse_args()
 
@@ -109,15 +75,15 @@ gps_start_time = args.gps_start_time
 gps_end_time = args.gps_end_time
 duration = gps_end_time - gps_start_time
 
-logging.info("Reading in LOSC files from {} to {}.".format(gps_start_time,
-                                                           gps_end_time))
-detector=args.include_segments.split(':')[0]
-logging.info("Querying for {}".format(detector))
+logging.info("Reading in GWOSC files from %s to %s.",
+             gps_start_time, gps_end_time)
+detector = args.include_segments.split(':')[0]
+logging.info("Querying for %s", detector)
 
 file_list = []
 
 logging.info("Querying science segments")
-sci_summ, sci_segs = query_losc(detector, "DATA", gps_start_time, duration)
+sci_summ, sci_segs = query_gwosc(detector, "DATA", gps_start_time, duration)
 sci_segs.coalesce()
 
 sci_file_name = "{}-SCIENCE_SEGMENTS.xml".format(detector)
@@ -125,7 +91,8 @@ write_xml_file(detector, sci_summ, sci_segs, sci_file_name)
 file_list.append(sci_file_name)
 
 logging.info("Calculating CAT1 veto time")
-not_cat1_summ, not_cat1_segs = query_losc(detector, "CBC_CAT1", gps_start_time, duration)
+not_cat1_summ, not_cat1_segs = query_gwosc(detector, "CBC_CAT1",
+                                           gps_start_time, duration)
 not_cat1_segs.coalesce()
 
 cat1_segs = ~not_cat1_segs
@@ -137,7 +104,8 @@ write_xml_file(detector, not_cat1_summ, cat1_segs, cat1_file_name)
 file_list.append(cat1_file_name)
 
 logging.info("Calculating CAT2 veto time")
-not_cat2_summ, not_cat2_segs = query_losc(detector, "CBC_CAT2", gps_start_time, duration)
+not_cat2_summ, not_cat2_segs = query_gwosc(detector, "CBC_CAT2",
+                                           gps_start_time, duration)
 not_cat2_segs.coalesce()
 
 cat2_segs = ~not_cat2_segs
@@ -149,7 +117,8 @@ write_xml_file(detector, not_cat2_summ, cat2_segs, cat2_file_name)
 file_list.append(cat2_file_name)
 
 logging.info("Calculating HW injection veto time")
-not_hw_inj_summ, not_hw_inj_segs = query_losc(detector, "NO_CBC_HW_INJ", gps_start_time, duration)
+not_hw_inj_summ, not_hw_inj_segs = query_gwosc(detector, "NO_CBC_HW_INJ",
+                                               gps_start_time, duration)
 not_hw_inj_segs.coalesce()
 
 hw_inj_segs = ~not_hw_inj_segs
@@ -166,8 +135,8 @@ destination_path = os.path.dirname(os.path.abspath(args.output_file))
 
 for f in file_list:
     d = os.path.join(destination_path,f)
-    logging.info("Copying {} to {}".format(f,d))
-    shutil.copy2(f, os.path.join(destination_path,f))
+    logging.info("Copying %s to %s", f, d)
+    shutil.copy2(f, os.path.join(destination_path, f))
     os.unlink(f)
 
 logging.info("Science and Veto files written. Done.")

--- a/pycbc/io/ligolw.py
+++ b/pycbc/io/ligolw.py
@@ -15,12 +15,16 @@
 
 """Tools for dealing with LIGOLW XML files."""
 
+import os
+import sys
 from ligo.lw import lsctables
 from ligo.lw.ligolw import Param, LIGOLWContentHandler \
     as OrigLIGOLWContentHandler
 from ligo.lw.lsctables import TableByName
 from ligo.lw.table import Column, TableStream
 from ligo.lw.types import FormatFunc, FromPyType, ToPyType
+from ligo.lw.utils import process as ligolw_process
+from pycbc import version as pycbc_version
 
 
 __all__ = ('default_null_value',
@@ -120,6 +124,24 @@ def return_search_summary(start_time=0, end_time=0, nevents=0, ifos=None):
         search_summary.out_end_time_ns = int(end_time % 1 * 1e9)
 
     return search_summary
+
+def create_process_table(document, program_name=None, detectors=None,
+                         comment=None):
+    """Create a LIGOLW process table with sane defaults, add it to a LIGOLW
+    document, and return it.
+    """
+    if program_name is None:
+        program_name = os.path.basename(sys.argv[0])
+
+    # ligo.lw does not like `cvs_entry_time` being an empty string
+    cvs_entry_time = pycbc_version.date or None
+
+    process = ligolw_process.register_to_xmldoc(
+            document, program_name, {}, version=pycbc_version.version,
+            cvs_repository='pycbc/'+pycbc_version.git_branch,
+            cvs_entry_time=cvs_entry_time, instruments=detectors,
+            comment=comment)
+    return process
 
 def legacy_row_id_converter(ContentHandler):
     """Convert from old-style to new-style row IDs on the fly.

--- a/pycbc/io/ligolw.py
+++ b/pycbc/io/ligolw.py
@@ -24,7 +24,7 @@ from ligo.lw.lsctables import TableByName
 from ligo.lw.table import Column, TableStream
 from ligo.lw.types import FormatFunc, FromPyType, ToPyType
 from ligo.lw.utils import process as ligolw_process
-from pycbc import version as pycbc_version
+import pycbc.version as pycbc_version
 
 
 __all__ = ('default_null_value',

--- a/pycbc/io/live.py
+++ b/pycbc/io/live.py
@@ -7,12 +7,11 @@ import json
 from ligo.lw import ligolw
 from ligo.lw import lsctables
 from ligo.lw import utils as ligolw_utils
-from ligo.lw.utils import process as ligolw_process
 from ligo.lw.param import Param as LIGOLWParam
 from ligo.lw.array import Array as LIGOLWArray
 from pycbc import version as pycbc_version
 from pycbc import pnutils
-from pycbc.io.ligolw import return_empty_sngl
+from pycbc.io.ligolw import return_empty_sngl, create_process_table
 from pycbc.results import ifo_color
 from pycbc.results import source_color
 from pycbc.mchirp_area import calc_probabilities
@@ -142,13 +141,10 @@ class SingleCoincForGraceDB(object):
         outdoc = ligolw.Document()
         outdoc.appendChild(ligolw.LIGO_LW())
 
-        # ligo.lw does not like `cvs_entry_time` being an empty string
-        cvs_entry_time = pycbc_version.date or None
-        proc_id = ligolw_process.register_to_xmldoc(
-            outdoc, 'pycbc', {}, instruments=usable_ifos, comment='',
-            version=pycbc_version.version,
-            cvs_repository='pycbc/'+pycbc_version.git_branch,
-            cvs_entry_time=cvs_entry_time).process_id
+        # FIXME is it safe (in terms of downstream operations) to let
+        # `program_name` default to the actual script name?
+        proc_id = create_process_table(outdoc, program_name='pycbc',
+                                       detectors=usable_ifos).process_id
 
         # Set up coinc_definer table
         coinc_def_table = lsctables.New(lsctables.CoincDefTable)

--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -44,9 +44,8 @@ from ligo import segments
 from ligo.lw import lsctables, ligolw
 from ligo.lw import utils as ligolw_utils
 from ligo.lw.utils import segments as ligolw_segments
-from ligo.lw.utils import process as ligolw_process
 from pycbc import makedir
-from pycbc.io.ligolw import LIGOLWContentHandler
+from pycbc.io.ligolw import LIGOLWContentHandler, create_process_table
 from . import pegasus_workflow
 from .configuration import WorkflowConfigParser, resolve_url
 from .pegasus_sites import make_catalog
@@ -1697,13 +1696,12 @@ class SegFile(File):
         """
         seglistdict = segments.segmentlistdict()
         seglistdict[ifo + ':' + name] = segmentlist
+        seg_summ_dict = None
         if seg_summ_list is not None:
             seg_summ_dict = segments.segmentlistdict()
             seg_summ_dict[ifo + ':' + name] = seg_summ_list
-        else:
-            seg_summ_dict = None
         return cls.from_segment_list_dict(description, seglistdict,
-                                          seg_summ_dict=None, **kwargs)
+                                          seg_summ_dict=seg_summ_dict, **kwargs)
 
     @classmethod
     def from_multi_segment_list(cls, description, segmentlists, names, ifos,
@@ -1898,7 +1896,7 @@ class SegFile(File):
         # create XML doc and add process table
         outdoc = ligolw.Document()
         outdoc.appendChild(ligolw.LIGO_LW())
-        process = ligolw_process.register_to_xmldoc(outdoc, sys.argv[0], {})
+        process = create_process_table(outdoc)
 
         for key, seglist in self.segment_dict.items():
             ifo, name = self.parse_segdict_key(key)

--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -26,7 +26,7 @@ This module provides the worker functions and classes that are used when
 creating a workflow. For details about the workflow module see here:
 https://ldas-jobs.ligo.caltech.edu/~cbc/docs/pycbc/ahope.html
 """
-import sys, os, stat, subprocess, logging, math, string
+import os, stat, subprocess, logging, math, string
 from six.moves import configparser as ConfigParser
 from six.moves import urllib
 from six.moves.urllib.request import pathname2url


### PR DESCRIPTION
`pycbc_losc_segment_query` has a number of issues and I suspect it is not really used nowadays. However, it is still part of the `--help` sanity tests, and it fails on Python 3.10 due to its use of the abandoned `glue.segmentdb` module. This change removes the LIGOLW writing code from the script in favor of using the SegFile class. The script functionality is more or less preserved, apart from losing the comments in the LIGOLW tables. I also do some cleanup of the script, for example turning all [LOSC](https://www.losc.fr/) references to GWOSC. I think some additional cleanup/fixing is due but I did not spend further time on it, given that I am not sure how much this is really used nowadays.

As part of this change, I created another wrapper function in `pycbc.io.ligolw` to handle the LIGOLW process table, so we can remove a few more imports and quirks from the main code. Not all calls to `register_to_xmldoc()` are removed though.

Finally, I think there was a bug in `SegFile.from_segment_list()`, so I also fix that.