### PR TITLE
Use shutil.which instead of distutils.spawn.find_executable

### DIFF
--- a/bin/bank/pycbc_geom_aligned_bank
+++ b/bin/bank/pycbc_geom_aligned_bank
@@ -30,7 +30,6 @@ import argparse
 import tempfile
 import numpy
 import logging
-import distutils.spawn
 import h5py
 import configparser
 from scipy import spatial

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -14,8 +14,8 @@ import argparse, numpy, pycbc, logging, cProfile, h5py, lal, json
 import os.path
 import itertools
 import platform
-import distutils
 import subprocess
+from shutil import which
 from mpi4py import MPI as mpi
 from pycbc.pool import BroadcastPool
 from pycbc import fft, version, waveform, scheme, makedir
@@ -291,7 +291,7 @@ class LiveEventManager(object):
                 flen = int(tlen / 2 + 1)
                 delta_f = bank.sample_rate / float(tlen)
                 cmd = 'timeout {} '.format(args.snr_opt_timeout)
-                exepath = distutils.spawn.find_executable('pycbc_optimize_snr')
+                exepath = which('pycbc_optimize_snr')
                 cmd += exepath + ' '
                 data_fils_str = '--data-files '
                 psd_fils_str = '--psd-files '

--- a/pycbc/workflow/configuration.py
+++ b/pycbc/workflow/configuration.py
@@ -34,8 +34,8 @@ import string
 import shutil
 import time
 import requests
-import distutils.spawn
 import six
+from shutil import which
 from pycbc.types.config import InterpolatingConfigParser
 from six.moves.urllib.parse import urlparse
 from six.moves import http_cookiejar as cookielib
@@ -513,7 +513,7 @@ class WorkflowConfigParser(InterpolatingConfigParser):
         # Maybe we can add a few different possibilities for substitution
         if len(testList) == 2:
             if testList[0] == "which":
-                newString = distutils.spawn.find_executable(testList[1])
+                newString = which(testList[1])
                 if not newString:
                     errmsg = "Cannot find exe %s in your path " % (testList[1])
                     errmsg += "and you specified ${which:%s}." % (testList[1])

--- a/pycbc/workflow/pegasus_sites.py
+++ b/pycbc/workflow/pegasus_sites.py
@@ -14,8 +14,8 @@ possible to implement a new site, but not sure how that would work in practice.
 
 import os.path
 import tempfile
-import distutils
 import urllib.parse
+from shutil import which
 from urllib.parse import urljoin
 from urllib.request import pathname2url
 from Pegasus.api import Directory, FileServer, Site, Operation, Namespace
@@ -173,7 +173,7 @@ def add_condorpool_shared_site(sitecat, cp, local_path, local_url):
                       value="True")
     site.add_profiles(Namespace.DAGMAN, key="retry", value="2")
     # Need to set PEGASUS_HOME
-    peg_home = distutils.spawn.find_executable('pegasus-plan')
+    peg_home = which('pegasus-plan')
     assert peg_home.endswith('bin/pegasus-plan')
     peg_home = peg_home.replace('bin/pegasus-plan', '')
     site.add_profiles(Namespace.ENV, key="PEGASUS_HOME", value=peg_home)


### PR DESCRIPTION
This PR replaces all instances of `distutils.spawn.find_executable` with [`shutil.which`](https://docs.python.org/3/library/shutil.html#shutil.which), distutils is [deprecated](https://www.python.org/dev/peps/pep-0632/).