### PR TITLE
Fix in from_ligolw_table

### DIFF
--- a/pycbc/io/record.py
+++ b/pycbc/io/record.py
@@ -1181,7 +1181,7 @@ class FieldArray(numpy.recarray):
         # get the values
         if _default_types_status['ilwd_as_int']:
             input_array = \
-                [tuple(getattr(row, col) if dt != 'ilwd:char'
+                [tuple(getattr(row, col.split(':')[-1]) if dt != 'ilwd:char'
                        else int(getattr(row, col))
                        for col,dt in columns.items())
                  for row in table]

--- a/pycbc/io/record.py
+++ b/pycbc/io/record.py
@@ -1180,6 +1180,8 @@ class FieldArray(numpy.recarray):
             dtype = list(columns.items())
         # get the values
         if _default_types_status['ilwd_as_int']:
+            # columns like `process:process_id` have corresponding attributes
+            # with names that are only the part after the colon, so we split
             input_array = \
                 [tuple(getattr(row, col.split(':')[-1]) if dt != 'ilwd:char'
                        else int(getattr(row, col))


### PR DESCRIPTION
As discussed in [#3921](https://github.com/gwastro/pycbc/issues/3921#issuecomment-1023359795), changes in ligo.lw mean tables have columns like process:process_id but corresponding row attributes are only the post-colon part, e.g. process_id. This caused an error when reading in from xml via `from_ligolw_table`.

I haven't been able to find any other places where this same issue will arise, hopefully it's only here.