### PR TITLE
Moving multi_inspiral utils to coherent module

### DIFF
--- a/bin/pycbc_multi_inspiral
+++ b/bin/pycbc_multi_inspiral
@@ -96,6 +96,8 @@ if __name__ == '__main__':
     parser.add_argument("--coinc-threshold", type=float, default=0.0,
                         help="Triggers with coincident/coherent snr below "
                              "this value will be discarded.")
+    parser.add_argument("--do-null-cut", action='store_true',
+                        help="Apply a cut based on null SNR.")
     parser.add_argument("--null-min", type=float, default=5.25,
                         help="Triggers with null_snr above this value will be"
                              " discarded.")
@@ -455,7 +457,7 @@ if __name__ == '__main__':
                         null, rho_coh, rho_coinc, coinc_idx, coinc_triggers =\
                             coh.null_snr(
                                 rho_coh, rho_coinc, snrv=coinc_triggers,
-                                index=coinc_idx)
+                                index=coinc_idx, apply_cut=args.do_null_cut)
                         if len(coinc_idx) != 0:
                             logging.info("Max null SNR = %.2f", max(null))
                         logging.info(

--- a/bin/pycbc_multi_inspiral
+++ b/bin/pycbc_multi_inspiral
@@ -381,7 +381,7 @@ if __name__ == '__main__':
                 for ifo in args.instruments:
                     # Move on if this segment has no data
                     if len(snr_dict[ifo])==0:
-                        raise ValueError(
+                        raise RuntimeError(
                             'The SNR triggers dictionary is empty. This '
                             'should not be possible.')
                     # Time delay is applied to indices

--- a/bin/pycbc_multi_inspiral
+++ b/bin/pycbc_multi_inspiral
@@ -23,6 +23,7 @@ import argparse
 from pycbc import vetoes, psd, waveform, events, strain, scheme, fft,\
     DYN_RANGE_FAC
 from pycbc.vetoes import sgchisq
+from pycbc.events import coherent as coh, EventManagerCoherent
 from pycbc.filter import MatchedFilterControl
 from pycbc.types import TimeSeries, zeros, float32, complex64
 from pycbc.types import MultiDetOptionAction
@@ -142,213 +143,6 @@ logging.basicConfig(format='%(asctime)s : %(message)s', level=log_level)
 
 inj_filter_rejector = pycbc.inject.InjFilterRejector.from_cli_multi_ifos(opt,opt.instruments)
 ctx = scheme.from_cli(opt)
-
-def network_chisq(chisq, chisq_dof, snr_dict):
-    ifos = sorted(snr_dict.keys())
-    chisq_per_dof = {}
-    for ifo in ifos:
-        chisq_per_dof[ifo] = chisq[ifo] / chisq_dof[ifo]
-        chisq_per_dof[ifo][chisq_per_dof[ifo] < 1] = 1
-    snr2 = {ifo : np.real(np.array(snr_dict[ifo]) *
-                np.array(snr_dict[ifo]).conj()) for ifo in ifos}
-    coinc_snr2 = sum(snr2.values())
-    snr2_ratio = {ifo : snr2[ifo] / coinc_snr2 for ifo in ifos}
-    network_chisq = sum( [chisq_per_dof[ifo] * snr2_ratio[ifo] for ifo in ifos] )
-    return network_chisq
-
-
-def pycbc_reweight_snr(network_snr, network_chisq, a = 3, b = 1. / 6.):
-    """
-    Output: reweighted_snr: Reweighted SNR for each trigger
-    Input:  network_snr:  Dictionary of coincident or coherent SNR for each
-                          trigger
-            network_chisq: A chisq value for each trigger 
-    """
-    denom = (1 + (network_chisq)**a) / 2
-    reweighted_snr = network_snr / denom**b
-    return reweighted_snr
-
-def reweight_snr_by_null(network_snr, nullsnr):
-    """
-    Output: reweighted_snr: Reweighted SNR for each trigger
-    Input:  network_snr:  Dictionary of coincident, coherent, or reweighted
-                          SNR for each trigger
-            null: Null snr for each trigger
-    """
-    nullsnr = np.array(nullsnr)
-    nullsnr[nullsnr <= 4.25] = 4.25
-    reweighted_snr = network_snr / (nullsnr - 3.25)
-    return reweighted_snr
-
-
-def get_weighted_antenna_patterns(Fp_dict, Fc_dict, sigma_dict):
-    """
-    Output: wp: 1 x nifo of the weighted antenna response fuctions to plus
-                polarisation for each ifo
-            wc: 1 x nifo of the weighted antenna response fuctions to cross
-                polarisation for each ifo
-    Input:  Fp_dict: Dictionary of the antenna response fuctions to plus
-                     polarisation for each ifo
-            Fc_dict: Dictionary of the antenna response fuctions to cross
-                     polarisation for each ifo
-           sigma_dict: Sigma dictionary for each ifo (sensitivity of each ifo)
-    """
-    #Need the keys to be in alphabetical order
-    keys = sorted(sigma_dict.keys())
-    wp = np.array([sigma_dict[ifo]*Fp_dict[ifo] for ifo in keys])
-    wc = np.array([sigma_dict[ifo]*Fc_dict[ifo] for ifo in keys])
-    return wp, wc
-
-
-def get_projection_matrix(wp, wc, projection='standard'):
-    """
-    Output: projection_matrix: Projects the data onto the signal space
-    Input:  wp,wc: The weighted antenna response fuctions to plus and cross
-                   polarisations respectively
-            projection: standard, left or right
-    """
-    if projection=='standard':
-        denominator = np.dot(wp, wp) * np.dot(wc, wc) - np.dot(wp, wc)**2
-        projection_matrix = (np.dot(wc, wc)*np.outer(wp, wp) +
-                             np.dot(wp, wp)*np.outer(wc, wc) -
-                             np.dot(wp, wc)*(np.outer(wp, wc) +
-                             np.outer(wc, wp))) / denominator
-    elif projection=='left':
-        projection_matrix = ((np.outer(wp, wp) + np.outer(wc, wc) +
-                             (np.outer(wp, wc) - np.outer(wc, wp)) *1j)
-                             / (np.dot(wp, wp) + np.dot(wc, wc)))
-    elif projection=='right':
-        projection_matrix = ((np.outer(wp, wp) + np.outer(wc, wc) +
-                             (np.outer(wc, wp) - np.outer(wp, wc)) *1j)
-                             / (np.dot(wp, wp) + np.dot(wc, wc)))
-    else:
-        raise ValueError('Unknown projection type: {}'.format(projection))
-
-    return projection_matrix
-         
- 
-def coherent_snr(snr_triggers, index, threshold, projection_matrix,
-                coinc_snr=[]):
-    """
-    Output: rho_coh: an array of the coherent snr for the detector network
-            index  : Indexes that survive cuts
-            snrv   : Dictionary of individual ifo triggers that survive cuts
-            coinc_snr: The coincident snr value for triggers surviving the
-                       coherent cut
-    Inputs: snr_triggers: is a dictionary of the normalised complex snr time
-                          series for each ifo. The keys are the ifos (e.g.
-                          'L1','H1', and 'V1')
-            index  : An array of the indexes you want to analyse. Not used for
-                     calculations, just for book keeping
-            threshold: Triggers with rho_coh<threshold are cut
-            projection_matrix: Produced by get_projection_matrix.
-            coinc_snr: Optional- The coincident snr for each trigger.
-    """
-    #Calculate rho_coh
-    snr_array = np.array([snr_triggers[ifo]
-                         for ifo in sorted(snr_triggers.keys())])
-    x = np.inner(snr_array.conj().transpose(),projection_matrix)
-    rho_coh2 = sum(x.transpose()*snr_array)
-    rho_coh = np.sqrt(rho_coh2)
-    #Apply thresholds
-    index = index[rho_coh > threshold]
-    if len(coinc_snr) != 0: coinc_snr = coinc_snr[rho_coh > threshold]
-    snrv = {ifo : snr_triggers[ifo][rho_coh > threshold]
-           for ifo in snr_triggers.keys()}
-    rho_coh = rho_coh[rho_coh > threshold]
-    return rho_coh, index, snrv, coinc_snr
-
-
-def coincident_snr(snr_dict, index, threshold, time_delay_idx):
-    """
-    Output: rho_coinc: Coincident snr triggers
-            index    : The subset of input index that survive the cuts
-            coinc_triggers: Dictionary of individual detector SNRs at
-                            indexes that survive cuts
-    Input: snr_dict: Dictionary of individual detector SNRs
-           index   : Geocent indexes you want to find coinc SNR for
-           threshold: Indexes with coinc SNR below this threshold are cut
-           time_delay_idx: Dictionary of time delay in indices for each detector
-    """
-    #Restrict the snr timeseries to just the interesting points
-    coinc_triggers = {ifo : snr_dict[ifo][index+time_delay_idx[ifo]] for ifo in snr_dict.keys()}
-    #Calculate the coincident snr
-    snr_array = np.array([coinc_triggers[ifo]
-                        for ifo in coinc_triggers.keys()])
-    rho_coinc = np.sqrt(np.sum(snr_array * snr_array.conj(),axis=0))
-    # Apply threshold
-    thresh_indexes = rho_coinc > threshold
-    index = index[thresh_indexes]
-    coinc_triggers = {ifo : snr_dict[ifo][index+time_delay_idx[ifo]] for ifo in snr_dict.keys()}
-    rho_coinc = rho_coinc[thresh_indexes]
-    return rho_coinc, index, coinc_triggers
-
-
-def null_snr(rho_coh, rho_coinc, null_min=5.25, null_grad=0.2, null_step=20.,
-             index={}, snrv={}, nullcut=False):
-    """
-    Output: null: null snr for surviving triggers
-            rho_coh: Coherent snr for surviving triggers
-            rho_coinc: Coincident snr for suviving triggers
-            index: Indexes for surviving triggers
-            snrv: Single detector snr for surviving triggers
-    Input:  rho_coh: Numpy array of coherent snr triggers
-            rho_coinc: Numpy array of coincident snr triggers
-            null_min: Any trigger with null snr below this is cut
-            null_grad: Any trigger with null snr<(null_grad*rho_coh+null_min)
-                       is cut
-            null_step: The value for required for coherent snr to start
-                       increasing the null threshold
-            index: Optional- Indexes of triggers. If given, will remove
-                   triggers that fail cuts
-            snrv: Optional- Individual ifo snr for triggers. If given will
-                  remove triggers that fail cut
-    """
-    null2 = rho_coinc**2 - rho_coh**2
-    # Numerical errors may make this negative and break the sqrt, so set
-    # negative values to 0.
-    null2[null2 < 0] = 0
-    null = null2**0.5
-    # Make cut on null.
-    keep1 = np.logical_and(null < null_min, rho_coh <= null_step)
-    keep2 = np.logical_and(null < (rho_coh * null_grad + null_min),
-                          rho_coh > null_step)
-    keep = np.logical_or(keep1, keep2)
-    if nullcut==True:
-        index = index[keep]
-        rho_coh  = rho_coh[keep]
-        snrv = {ifo : snrv[ifo][keep] for ifo in snrv.keys()}
-        rho_coinc = rho_coinc[keep]
-        null = null[keep]
-    else:
-        logging.info("nullcut is not applied")
-    return null, rho_coh, rho_coinc, index, snrv
-
-
-def get_coinc_indexes(idx_dict, time_delay_idx):
-    """
-    Output: coinc_idx: list of indexes for triggers in geocent time that
-                       appear in multiple detectors
-    Input: idx_dict: Dictionary of indexes of triggers above threshold in
-                     each detector
-           time_delay_idx: Dictionary giving time delay index
-                           (time_delay*sample_rate) for each ifo
-    """
-    coinc_list = np.array([], dtype=int)
-    for ifo in idx_dict.keys():
-        """
-        Create list of indexes above threshold in single detector in
-        geocent time. Can then search for triggers that appear in multiple
-        detectors later.
-        """
-        if len(idx_dict[ifo]) != 0:
-            coinc_list = np.hstack([coinc_list,
-                                   idx_dict[ifo] - time_delay_idx[ifo]])
-    #Search through coinc_idx for repeated indexes. These must have
-    #been loud in at least 2 detectors.
-    coinc_idx = np.unique(coinc_list, return_counts=True)[0][
-                   np.unique(coinc_list, return_counts=True)[1]>1]
-    return coinc_idx
 
 strain_dict = strain.from_cli_multi_ifos(
     opt, opt.instruments, inj_filter_rejector,
@@ -478,7 +272,7 @@ with ctx:
                }
     network_names = sorted(network_out_vals.keys())
 
-    event_mgr = events.EventManagerCoherent(
+    event_mgr = EventManagerCoherent(
         opt, opt.instruments, ifo_names, [ifo_out_types[n] for n in ifo_names],
         network_names, [network_out_types[n] for n in network_names]
         )
@@ -500,10 +294,10 @@ with ctx:
     if not len(bank) == ntemplates:
         logging.info("Template bank size after thinning: %s", len(bank))
 
-    Fp = {}  # Antenna patterns
-    Fc = {}
+    fp = {}  # Antenna patterns
+    fc = {}
     for ifo in opt.instruments:
-        Fp[ifo], Fc[ifo] = pycbc.detector.Detector(ifo).antenna_pattern(
+        fp[ifo], fc[ifo] = pycbc.detector.Detector(ifo).antenna_pattern(
             opt.ra, opt.dec, polarization=0, t_gps=t_gps)
 
     for t_num, template in enumerate(bank):  # Loop over templates
@@ -585,7 +379,7 @@ with ctx:
             # Find triggers that are coincident (in geocent time) in multiple ifos.
             # If a single ifo analysis then just use the indexes from that ifo.
             if len(opt.instruments)>1:
-                coinc_idx = get_coinc_indexes(idx_dict,time_delay_idx)
+                coinc_idx = coh.get_coinc_indexes(idx_dict,time_delay_idx)
             else:
                 coinc_idx = idx_dict[opt.instruments[0]] - time_delay_idx[opt.instruments[0]]
             logging.info("Found %s coincident triggers" % str(len(coinc_idx)))
@@ -606,8 +400,8 @@ with ctx:
             # Check we have data before we try to compute the coherent snr
             if len(coinc_idx) != 0 and nifo > 1:
                 #Find coinc snr at trigger times and apply coinc snr threshold
-                rho_coinc, coinc_idx, coinc_triggers = \
-                    coincident_snr(snr, coinc_idx, opt.coinc_threshold, time_delay_idx)
+                rho_coinc, coinc_idx, coinc_triggers = coh.coincident_snr(snr,
+                        coinc_idx, opt.coinc_threshold, time_delay_idx)
                 logging.info("%s points above coincident SNR threshold" % \
                              str(len(coinc_idx)))
                 if len(coinc_idx) != 0:
@@ -626,20 +420,19 @@ with ctx:
             # If we have triggers above coinc threshold and more than 2 ifos
             # then calculate the coherent statistics
             if len(coinc_idx) != 0 and nifo > 2:
-                wp,wc=get_weighted_antenna_patterns(Fp,Fc,sigma)
                 if opt.projection=='left+right':
-                    project_l = get_projection_matrix(wp, wc,
-                                                      projection='left')
+                    project_l = coh.get_projection_matrix(fp, fc, sigma,
+                                                          projection='left')
                     rho_coh_l, coinc_idx_l, coinc_triggers_l, rho_coinc_l = \
-                            coherent_snr(coinc_triggers, coinc_idx,
-                                         opt.coinc_threshold, project_l,
-                                         rho_coinc)
-                    project_r = get_projection_matrix(wp, wc,
-                                                      projection='right')
+                            coh.coherent_snr(coinc_triggers, coinc_idx,
+                                             opt.coinc_threshold, project_l,
+                                             rho_coinc)
+                    project_r = coh.get_projection_matrix(fp, fc, sigma,
+                                                          projection='right')
                     rho_coh_r, coinc_idx_r, coinc_triggers_r, rho_coinc_r = \
-                            coherent_snr(coinc_triggers, coinc_idx,
-                                         opt.coinc_threshold, project_r,
-                                         rho_coinc)
+                            coh.coherent_snr(coinc_triggers, coinc_idx,
+                                             opt.coinc_threshold, project_r,
+                                             rho_coinc)
                     max_idx = np.argmax([rho_coh_l, rho_coh_r], axis=0)
                     rho_coh = np.where(max_idx==0, rho_coh_l, rho_coh_r)
                     coinc_idx = np.where(max_idx==0, coinc_idx_l, coinc_idx_r)
@@ -647,18 +440,19 @@ with ctx:
                                               coinc_triggers_r)
                     rho_coinc = np.where(max_idx==0, rho_coinc_l, rho_coinc_r)
                 else:
-                    project = get_projection_matrix(wp, wc, projection=opt.projection)
+                    project = coh.get_projection_matrix(fp, fc, sigma,
+                            projection=opt.projection)
                     rho_coh, coinc_idx, coinc_triggers, rho_coinc = \
-                            coherent_snr(coinc_triggers, coinc_idx,
-                                         opt.coinc_threshold, project,
-                                         rho_coinc)
+                            coh.coherent_snr(coinc_triggers, coinc_idx,
+                                             opt.coinc_threshold, project,
+                                             rho_coinc)
                 logging.info("%d points above coherent threshold", len(rho_coh))
                 if len(coinc_idx) != 0:
                     logging.info("Max coherent SNR = %s" % str(max(rho_coh)))
                     #Find the null snr
                     null, rho_coh, rho_coinc, coinc_idx, coinc_triggers =\
-                        null_snr(rho_coh, rho_coinc, snrv=coinc_triggers,
-                        index=coinc_idx)
+                        coh.null_snr(rho_coh, rho_coinc, snrv=coinc_triggers,
+                                     index=coinc_idx)
                     if len(coinc_idx) != 0:
                         logging.info("Max null SNR = %s" % str(max(null)))
                     logging.info("%s points above null threshold: "
@@ -689,20 +483,21 @@ with ctx:
                         template)
 
                 # Calculate network chisq value
-                network_chisq_dict = network_chisq(chisq, chisq_dof, 
-                                              coherent_ifo_triggers)
+                network_chisq_dict = coh.network_chisq(chisq, chisq_dof, 
+                                                       coherent_ifo_triggers)
 
                 # Calculate chisq reweighted SNR
                 if nifo > 2:
-                    reweighted_snr = pycbc_reweight_snr(rho_coh,
-                                                        network_chisq_dict)
+                    reweighted_snr = coh.pycbc_reweight_snr(rho_coh,
+                                                            network_chisq_dict)
                     # Calculate null reweighted SNR
-                    reweighted_snr = reweight_snr_by_null(reweighted_snr, null)
+                    reweighted_snr = coh.reweight_snr_by_null(reweighted_snr,
+                                                              null)
                 elif nifo == 2:
-                    reweighted_snr = pycbc_reweight_snr(rho_coinc,
-                                                        network_chisq_dict)
+                    reweighted_snr = coh.pycbc_reweight_snr(rho_coinc,
+                                                            network_chisq_dict)
                 else:
-                    reweighted_snr = pycbc_reweight_snr(
+                    reweighted_snr = coh.pycbc_reweight_snr(
                         abs(snr[opt.instruments[0]][coinc_idx_det_frame[opt.instruments[0]]]), network_chisq_dict)
 
                 # Need all out vals to be the same length. This means the

--- a/bin/pycbc_multi_inspiral
+++ b/bin/pycbc_multi_inspiral
@@ -19,6 +19,7 @@
 import logging
 import time
 from collections import defaultdict
+from copy import copy
 import argparse
 import numpy as np
 from pycbc import (
@@ -335,12 +336,12 @@ with ctx:
             if not analyse_segment: continue
             logging.info(
                 "Analyzing segment %d/%d", s_num + 1, len(segments[ifo]))
-            snrv_dict = {}
-            norm_dict = {}
-            corr_dict = {}
-            snr_ts={}
-            idx={}
-            coinc_idx = np.array([])
+            snr_dict = dict.fromkeys(args.instruments)
+            norm_dict = dict.fromkeys(args.instruments)
+            corr_dict = dict.fromkeys(args.instruments)
+            idx = dict.fromkeys(args.instruments)
+            snrv_dict = dict.fromkeys(args.instruments)
+            snr = dict.fromkeys(args.instruments)
             ifo_list = args.instruments[:]
             for ifo in args.instruments:
                 logging.info(
@@ -348,27 +349,19 @@ with ctx:
                 # No clustering in the coherent search until the end.
                 # The correlation vector is the FFT of the snr (so inverse FFT
                 # it to get the snr). 
-                (snr_ts[ifo], norm_dict[ifo], corr_dict[ifo], idx[ifo],
-                 snrv_dict[ifo]) = \
+                snr_ts, norm, corr, ind, snrv = \
                      matched_filter[ifo].matched_filter_and_cluster(
                          s_num, template.sigmasq(stilde[ifo].psd), window=0)
-
-                #List of ifos with triggers
-                if len(idx[ifo]) == 0: ifo_list.remove(ifo)
-
+                snr_dict[ifo] = (
+                        snr_ts[matched_filter[ifo].segments[s_num].analyze]
+                        * norm)
+                norm_dict[ifo] = copy(norm)
+                corr_dict[ifo] = copy(corr)
+                idx[ifo] = copy(ind)
+                snrv_dict[ifo] = copy(snrv)
+                snr[ifo] = snrv * norm
             # Move onto next segment if there are no triggers.
             if len(ifo_list)==0: continue
-
-            # Find the data we need to analyse
-            analyse_data = {
-                ifo: matched_filter[ifo].segments[s_num].analyze
-                for ifo in args.instruments}
-
-            # Restrict the snr timeseries to just this section
-            snr = {
-                ifo: snr_ts[ifo][analyse_data[ifo]] * norm_dict[ifo]
-                for ifo in args.instruments}
-
             # Save the indexes of triggers (if we have any)
             # Even if we have none, need to keep an empty dictionary.
             # Only do this is idx doesn't get time shifted out of the time
@@ -376,7 +369,7 @@ with ctx:
             idx_dict = {
                 ifo: idx[ifo][np.logical_and(
                     idx[ifo] > time_delay_idx[ifo],
-                    idx[ifo] - time_delay_idx[ifo] < len(snr[ifo])
+                    idx[ifo] - time_delay_idx[ifo] < len(snr_dict[ifo])
                     )
                 ]
                 for ifo in args.instruments}
@@ -384,38 +377,34 @@ with ctx:
             # ifos. If a single ifo analysis then just use the indexes from
             # that ifo.
             if len(args.instruments) > 1:
-                coinc_idx = coh.get_coinc_indexes(idx_dict,time_delay_idx)
+                coinc_idx = coh.get_coinc_indexes(idx_dict, time_delay_idx)
             else:
                 coinc_idx = (
                     idx_dict[args.instruments[0]]
                     - time_delay_idx[args.instruments[0]]
                     )
             logging.info("Found %d coincident triggers", len(coinc_idx))
-
             # Number of ifos
             nifo = len(args.instruments)
-
             for ifo in args.instruments:
                 # Move on if this segment has no data
-                if len(snr[ifo])==0:
+                if len(snr_dict[ifo])==0:
                     raise ValueError('The SNR triggers dictionary is empty. '
                                      'This should not be possible.')
                 # Time delay is applied to indices
                 coinc_idx_det_frame = {
                     ifo: coinc_idx + time_delay_idx[ifo]
                     for ifo in args.instruments}
-
             # Calculate the coincident and coherent snr
             # Check we have data before we try to compute the coherent snr
             if len(coinc_idx) != 0 and nifo > 1:
                 #Find coinc snr at trigger times and apply coinc snr threshold
                 rho_coinc, coinc_idx, coinc_triggers = coh.coincident_snr(
-                    snr, coinc_idx, args.coinc_threshold, time_delay_idx)
+                    snr_dict, coinc_idx, args.coinc_threshold, time_delay_idx)
                 logging.info(
                     "%d points above coincident SNR threshold", len(coinc_idx))
                 if len(coinc_idx) != 0:
                     logging.info("Max coincident SNR = %.2f", max(rho_coinc))
-
             # If there is only one ifo, then coinc_triggers is just the
             # triggers from ifo
             elif len(coinc_idx) != 0 and nifo == 1:
@@ -481,7 +470,7 @@ with ctx:
                     ifo: coinc_idx + time_delay_idx[ifo]
                     for ifo in args.instruments}
                 coherent_ifo_trigs = {
-                    ifo: snr[ifo][coinc_idx_det_frame[ifo]]
+                    ifo: snr_dict[ifo][coinc_idx_det_frame[ifo]]
                     for ifo in args.instruments}
                 # Calculate the power and autochi2 values for the coinc indexes
                 # (this uses the snr timeseries before the time delay, so we

--- a/bin/pycbc_multi_inspiral
+++ b/bin/pycbc_multi_inspiral
@@ -31,7 +31,7 @@ from pycbc import (
     detector, fft, init_logging, inject, opt, psd, scheme, strain, vetoes,
     waveform, DYN_RANGE_FAC
 )
-from pycbc.events import coherent as coh, EventManagerCoherent
+from pycbc.events import ranking, coherent as coh, EventManagerCoherent
 from pycbc.filter import MatchedFilterControl
 from pycbc.types import TimeSeries, zeros, float32, complex64
 from pycbc.types import MultiDetOptionAction
@@ -487,13 +487,13 @@ if __name__ == '__main__':
                         chisq, chisq_dof, coherent_ifo_trigs)
                     # Calculate chisq reweighted SNR
                     if nifo > 2:
-                        reweighted_snr = coh.reweighted_snr(
+                        reweighted_snr = ranking.newsnr(
                             rho_coh, network_chisq_dict)
                         # Calculate null reweighted SNR
                         reweighted_snr = coh.reweight_snr_by_null(
                             reweighted_snr, null)
                     elif nifo == 2:
-                        reweighted_snr = coh.reweighted_snr(
+                        reweighted_snr = ranking.newsnr(
                             rho_coinc, network_chisq_dict)
                     else:
                         rho_sngl = abs(
@@ -501,7 +501,7 @@ if __name__ == '__main__':
                                 coinc_idx_det_frame[args.instruments[0]]
                                 ]
                             )
-                        reweighted_snr = coh.reweighted_snr(
+                        reweighted_snr = ranking.newsnr(
                             rho_sngl, network_chisq_dict)
                     # Need all out vals to be the same length. This means the
                     # entries that are single values need to be repeated once

--- a/bin/pycbc_multi_inspiral
+++ b/bin/pycbc_multi_inspiral
@@ -28,8 +28,8 @@ from copy import copy
 import argparse
 import numpy as np
 from pycbc import (
-    detector, fft, inject, opt, psd, scheme, strain, vetoes, waveform,
-    DYN_RANGE_FAC
+    detector, fft, init_logging, inject, opt, psd, scheme, strain, vetoes,
+    waveform, DYN_RANGE_FAC
 )
 from pycbc.events import coherent as coh, EventManagerCoherent
 from pycbc.filter import MatchedFilterControl
@@ -122,8 +122,7 @@ if __name__ == '__main__':
     inject.insert_injfilterrejector_option_group_multi_ifo(parser)
     sgchisq.SingleDetSGChisq.insert_option_group(parser)
     args = parser.parse_args()
-    log_level = logging.DEBUG if args.verbose else logging.INFO
-    logging.basicConfig(format='%(asctime)s : %(message)s', level=log_level)
+    init_logging(args.verbose)
     # Set GRB time variable for convenience
     t_gps = args.trigger_time
     # Put the ifos in alphabetical order so they are always called in
@@ -414,7 +413,6 @@ if __name__ == '__main__':
                 else:
                     coinc_triggers = {}
                     logging.info("No triggers above coincident SNR threshold")
-
                 # If we have triggers above coinc threshold and more than 2
                 # ifos then calculate the coherent statistics
                 if len(coinc_idx) != 0 and nifo > 2:
@@ -459,7 +457,6 @@ if __name__ == '__main__':
                             logging.info("Max null SNR = %.2f", max(null))
                         logging.info(
                             "%d points above null threshold", len(null))
-
                 # We are now going to find the individual detector chi2 values.
                 # To do this it is useful to find the indexes of coinc triggers
                 # in the detector frame.
@@ -566,6 +563,5 @@ if __name__ == '__main__':
                 "time_index", "coherent_snr", cluster_window)
             event_mgr.finalize_template_events()
     event_mgr.write_events(args.output)
-
     logging.info("Finished")
     logging.info("Time to complete analysis: %d", int(time.time() - time_init))

--- a/bin/pycbc_multi_inspiral
+++ b/bin/pycbc_multi_inspiral
@@ -37,36 +37,35 @@ time_init = time.time()
 parser = argparse.ArgumentParser(usage='',
     description="Find multiple detector gravitational-wave triggers.")
 parser.add_argument("-V", "--verbose", action="store_true",
-                  help="print extra debugging information", default=False )
+                    help="print extra debugging information", default=False )
 parser.add_argument("--output", type=str)
 parser.add_argument("--instruments", nargs="+", type=str, required=True,
                     help="List of instruments to analyze.")
 parser.add_argument("--bank-file", type=str)
 parser.add_argument("--snr-threshold",
-                  help="SNR threshold for trigger generation", type=float)
+                    help="SNR threshold for trigger generation", type=float)
 parser.add_argument("--newsnr-threshold", type=float, metavar='THRESHOLD',
                     help="Cut triggers with NewSNR less than THRESHOLD")
 parser.add_argument("--low-frequency-cutoff", type=float,
-                  help="The low frequency cutoff to use for filtering (Hz)")
+                    help="The low frequency cutoff to use for filtering (Hz)")
 
 # add approximant arg
 waveform.bank.add_approximant_arg(parser)
 parser.add_argument("--order", type=str,
-                  help="The integer half-PN order at which to generate"
+                    help="The integer half-PN order at which to generate"
                        " the approximant.")
-taper_choices = ["start","end","startend"]
-parser.add_argument("--taper-template", choices=taper_choices,
-                  help="For time-domain approximants, taper the start and/or "
-                       "end of the waveform before FFTing.")
+parser.add_argument("--taper-template", choices=["start", "end", "startend"],
+                    help="For time-domain approximants, taper the start and/or"
+                         " end of the waveform before FFTing.")
 parser.add_argument("--cluster-method", choices=["template", "window"])
 parser.add_argument("--cluster-window", type=float, default = -1,
-                  help="Length of clustering window in seconds.")
+                    help="Length of clustering window in seconds.")
 
 parser.add_argument("--bank-veto-bank-file", type=str)
 
 parser.add_argument("--chisq-bins", default=0)
 # Chisq threshold is not implemented, as event_mgr.consolidate_events() is not 
-#  called; also, it's not clear how it should be implemented for coherent events.
+# called. It's not yet clear how it should be implemented for coherent events.
 # As the option does nothing, remove it for now.
 # parser.add_argument("--chisq-threshold", type=float, default=0) 
 # parser.add_argument("--chisq-delta", type=float, default=0)
@@ -94,24 +93,24 @@ parser.add_argument("--user-tag", type=str, metavar="TAG", help="""
 # Arguments added for the coherent stuff
 parser.add_argument("--ra", type=float, help="Right ascension, in radians")
 parser.add_argument("--dec", type=float, help="Declination, in radians")
-parser.add_argument("--coinc-threshold", type=float, default=0.0, help="""
-                    Triggers with coincident/coherent snr below this value will
-                    be discarded.""")
-parser.add_argument("--null-min", type=float, default=5.25, help="""
-                    Triggers with null_snr above this value will be
-                    discarded.""")
-parser.add_argument("--null-grad", type=float, default=0.2, help="""
-                    The gradient of the line defining the null cut after the
-                    null step.""")
-parser.add_argument("--null-step", type=float, default=20., help="""
-                    Triggers with coherent snr above null_step will be cut
-                    according to the null_grad and null_min.""")
-parser.add_argument("--trigger-time", type=int, help="""
-                    Time of the GRB, used to set the antenna patterns.""")
+parser.add_argument("--coinc-threshold", type=float, default=0.0,
+                    help="Triggers with coincident/coherent snr below this "
+                         "value will be discarded.")
+parser.add_argument("--null-min", type=float, default=5.25,
+                    help="Triggers with null_snr above this value will be"
+                         " discarded.")
+parser.add_argument("--null-grad", type=float, default=0.2,
+                    help="The gradient of the line defining the null cut after"
+                         " the null step.")
+parser.add_argument("--null-step", type=float, default=20.,
+                    help="Triggers with coherent snr above null_step will be "
+                         "cut according to the null_grad and null_min.")
+parser.add_argument("--trigger-time", type=int,
+                    help="Time of the GRB, used to set the antenna patterns.")
 parser.add_argument("--projection", default="standard",
                     choices=["standard", "left", "right", "left+right"],
-                    help="""Choice of projection matrix. 'Left' and 'Right' 
-                    corresponds to face-away and face-on""")
+                    help="Choice of projection matrix. 'left' and 'right' " 
+                         "correspond to face-away and face-on")
 
 # Add options groups
 strain.insert_strain_option_group_multi_ifo(parser)
@@ -141,7 +140,8 @@ fft.verify_fft_options(opt,parser)
 log_level = logging.DEBUG if opt.verbose else logging.INFO
 logging.basicConfig(format='%(asctime)s : %(message)s', level=log_level)
 
-inj_filter_rejector = pycbc.inject.InjFilterRejector.from_cli_multi_ifos(opt,opt.instruments)
+inj_filter_rejector = pycbc.inject.InjFilterRejector.from_cli_multi_ifos(
+    opt, opt.instruments)
 ctx = scheme.from_cli(opt)
 
 strain_dict = strain.from_cli_multi_ifos(
@@ -177,12 +177,13 @@ with ctx:
                 raise ValueError(err_msg)
 
     logging.info("Making frequency-domain data segments")
-    segments = {ifo : strain_segments_dict[ifo].fourier_segments()
-               for ifo in opt.instruments}
+    segments = {ifo: strain_segments_dict[ifo].fourier_segments()
+                for ifo in opt.instruments}
     del strain_segments_dict
     psd.associate_psds_to_multi_ifo_segments(opt, segments, strain_dict, flen,
-            delta_f, flow, opt.instruments, dyn_range_factor=DYN_RANGE_FAC,
-            precision='single')
+                                             delta_f, flow, opt.instruments,
+                                             dyn_range_factor=DYN_RANGE_FAC,
+                                             precision='single')
 
     # Currently we are using the same matched-filter parameters for all ifos.
     # Therefore only one MatchedFilterControl needed. Maybe this can change if
@@ -201,13 +202,14 @@ with ctx:
     # Clustering happens at the end of the template loop.
     # FIXME: The single detector SNR threshold should not necessarily be
     #        applied to every IFO (usually only 2 most sensitive in network)
-    matched_filter = {ifo : MatchedFilterControl(
-        opt.low_frequency_cutoff, None, opt.snr_threshold, tlen, delta_f,
-        complex64, segments[ifo], template_mem, use_cluster=False,
-        downsample_factor=opt.downsample_factor,
-        upsample_threshold=opt.upsample_threshold,
-        upsample_method=opt.upsample_method,
-        cluster_function='symmetric') for ifo in opt.instruments}
+    matched_filter = {ifo: MatchedFilterControl(
+            opt.low_frequency_cutoff, None, opt.snr_threshold, tlen, delta_f,
+            complex64, segments[ifo], template_mem, use_cluster=False,
+            downsample_factor=opt.downsample_factor,
+            upsample_threshold=opt.upsample_threshold,
+            upsample_method=opt.upsample_method,
+            cluster_function='symmetric')
+        for ifo in opt.instruments}
 
     logging.info("Initializing signal-based vetoes.")
     # The existing SingleDetPowerChisq can calculate the single detector
@@ -221,8 +223,8 @@ with ctx:
                                           approximant=opt.approximant)
     # Same here
     autochisq = vetoes.SingleDetAutoChisq(opt.autochi_stride,
-                                         opt.autochi_number_points,
-                                         onesided=opt.autochi_onesided)
+                                          opt.autochi_number_points,
+                                          onesided=opt.autochi_onesided)
 
     logging.info("Overwhitening frequency-domain data segments")
     for ifo in opt.instruments:
@@ -237,7 +239,7 @@ with ctx:
         'bank_chisq'     : float32,
         'bank_chisq_dof' : int,
         'cont_chisq'     : float32,
-                }
+        }
     ifo_out_vals = {
         'time_index'     : None,
         'ifo'            : None,
@@ -247,7 +249,7 @@ with ctx:
         'bank_chisq'     : None,
         'bank_chisq_dof' : None,
         'cont_chisq'     : None,
-               }
+        }
     ifo_names = sorted(ifo_out_vals.keys())
 
     network_out_types = {
@@ -259,7 +261,7 @@ with ctx:
         'nifo'          : int,
         'my_network_chisq':float32,
         'reweighted_snr' : float32
-               }
+        }
     network_out_vals = {
         'latitude'      : None,
         'longitude'     : None,
@@ -269,7 +271,7 @@ with ctx:
         'nifo'          : None,
         'my_network_chisq' : None, 
         'reweighted_snr' : None
-               }
+        }
     network_names = sorted(network_out_vals.keys())
 
     event_mgr = EventManagerCoherent(
@@ -279,20 +281,22 @@ with ctx:
 
     logging.info("Read in template bank")
     bank = waveform.FilterBank(opt.bank_file, flen, delta_f, complex64,
-                               low_frequency_cutoff=flow, phase_order=opt.order,
+                               low_frequency_cutoff=flow,
+                               phase_order=opt.order,
                                taper=opt.taper_template,
                                approximant=opt.approximant, out=template_mem)
 
     # Use injfilterrejector to reduce the bank to only those templates that
     # might actually find something
-    ntemplates = len(bank)
+    n_bank = len(bank)
     nfilters = 0
 
-    logging.info("Full template bank size: %s", ntemplates)
+    logging.info("Full template bank size: %d", n_bank)
     for ifo in opt.instruments:
         bank.template_thinning(inj_filter_rejector[ifo])
-    if not len(bank) == ntemplates:
-        logging.info("Template bank size after thinning: %s", len(bank))
+    if not len(bank) == n_bank:
+        n_bank = len(bank)
+        logging.info("Template bank size after thinning: %d", n_bank)
 
     fp = {}  # Antenna patterns
     fc = {}
@@ -319,10 +323,10 @@ with ctx:
             for ifo in opt.instruments:
                 if not inj_filter_rejector[ifo].template_segment_checker(
                         bank, t_num, stilde[ifo]):
-                    logging.info("Skipping segment %d/%d with template %d/%d"
-                                 " as no detectable injection is present"
-                                 % (s_num + 1, len(segments[ifo]),
-                                 t_num + 1, len(bank)))
+                    logging.info("Skipping segment %d/%d with template %d/%d "
+                                 "as no detectable injection is present",
+                                 s_num + 1, len(segments[ifo]), t_num + 1,
+                                 n_bank)
                     analyse_segment = False
             #Find detector sensitivities (sigma) and make array of normalised
             sigmasq = {ifo : template.sigmasq(segments[ifo][s_num].psd)
@@ -343,16 +347,15 @@ with ctx:
             coinc_idx = np.array([])
             ifo_list = opt.instruments[:]
             for ifo in opt.instruments:
-                logging.info("Filtering template %d/%d, ifo %s" %
-                             (t_num + 1, len(bank), ifo))
+                logging.info("Filtering template %d/%d, ifo %s", t_num + 1,
+                             n_bank, ifo)
                 # No clustering in the coherent search until the end.
                 # The correlation vector is the FFT of the snr (so inverse FFT
                 # it to get the snr). 
-                snr_ts[ifo], norm_dict[ifo], corr_dict[ifo], idx[ifo],\
-                    snrv_dict[ifo] = matched_filter[ifo].matched_filter_and_cluster(
-                            s_num, template.sigmasq(stilde[ifo].psd),
-                            window=0
-                            )
+                (snr_ts[ifo], norm_dict[ifo], corr_dict[ifo], idx[ifo],
+                 snrv_dict[ifo]) = \
+                     matched_filter[ifo].matched_filter_and_cluster(
+                         s_num, template.sigmasq(stilde[ifo].psd), window=0)
 
                 #List of ifos with triggers
                 if len(idx[ifo]) == 0: ifo_list.remove(ifo)
@@ -361,28 +364,31 @@ with ctx:
             if len(ifo_list)==0: continue
 
             # Find the data we need to analyse
-            analyse_data = {ifo : matched_filter[ifo].segments[s_num].analyze
-                           for ifo in opt.instruments}
+            analyse_data = {ifo: matched_filter[ifo].segments[s_num].analyze
+                            for ifo in opt.instruments}
 
             # Restrict the snr timeseries to just this section
-            snr = {ifo : snr_ts[ifo][analyse_data[ifo]] * norm_dict[ifo]
-                  for ifo in opt.instruments}
+            snr = {ifo: snr_ts[ifo][analyse_data[ifo]] * norm_dict[ifo]
+                   for ifo in opt.instruments}
 
             # Save the indexes of triggers (if we have any)
             # Even if we have none, need to keep an empty dictionary.
             # Only do this is idx doesn't get time shifted out of the time
             # we are looking at.
-            idx_dict = {ifo : idx[ifo][np.logical_and(
-                       idx[ifo] > time_delay_idx[ifo],idx[ifo] -
-                       time_delay_idx[ifo]  < len(snr[ifo]))]
-                       for ifo in opt.instruments}
-            # Find triggers that are coincident (in geocent time) in multiple ifos.
-            # If a single ifo analysis then just use the indexes from that ifo.
+            idx_dict = {ifo: idx[ifo][
+                np.logical_and(idx[ifo] > time_delay_idx[ifo],
+                               idx[ifo] - time_delay_idx[ifo] < len(snr[ifo]))
+                ]
+                for ifo in opt.instruments}
+            # Find triggers that are coincident (in geocent time) in multiple
+            # ifos. If a single ifo analysis then just use the indexes from
+            # that ifo.
             if len(opt.instruments)>1:
                 coinc_idx = coh.get_coinc_indexes(idx_dict,time_delay_idx)
             else:
-                coinc_idx = idx_dict[opt.instruments[0]] - time_delay_idx[opt.instruments[0]]
-            logging.info("Found %s coincident triggers" % str(len(coinc_idx)))
+                coinc_idx = idx_dict[opt.instruments[0]] \
+                    - time_delay_idx[opt.instruments[0]]
+            logging.info("Found %d coincident triggers", len(coinc_idx))
 
             # Number of ifos
             nifo = len(opt.instruments)
@@ -390,20 +396,20 @@ with ctx:
             for ifo in opt.instruments:
                 # Move on if this segment has no data
                 if len(snr[ifo])==0:
-                    raise ValueError('The SNR triggers dictionary is empty.\
-                                     This should not be possible.')
+                    raise ValueError('The SNR triggers dictionary is empty. '
+                                     'This should not be possible.')
                 # Time delay is applied to indices
                 coinc_idx_det_frame = {ifo: coinc_idx + time_delay_idx[ifo]
-                                        for ifo in opt.instruments}
+                                       for ifo in opt.instruments}
 
             # Calculate the coincident and coherent snr
             # Check we have data before we try to compute the coherent snr
             if len(coinc_idx) != 0 and nifo > 1:
                 #Find coinc snr at trigger times and apply coinc snr threshold
-                rho_coinc, coinc_idx, coinc_triggers = coh.coincident_snr(snr,
-                        coinc_idx, opt.coinc_threshold, time_delay_idx)
-                logging.info("%s points above coincident SNR threshold" % \
-                             str(len(coinc_idx)))
+                rho_coinc, coinc_idx, coinc_triggers = coh.coincident_snr(
+                    snr, coinc_idx, opt.coinc_threshold, time_delay_idx)
+                logging.info("%d points above coincident SNR threshold",
+                             len(coinc_idx))
                 if len(coinc_idx) != 0:
                     logging.info("Max coincident SNR = %.2f", max(rho_coinc))
 
@@ -424,15 +430,15 @@ with ctx:
                     project_l = coh.get_projection_matrix(fp, fc, sigma,
                                                           projection='left')
                     rho_coh_l, coinc_idx_l, coinc_triggers_l, rho_coinc_l = \
-                            coh.coherent_snr(coinc_triggers, coinc_idx,
-                                             opt.coinc_threshold, project_l,
-                                             rho_coinc)
+                        coh.coherent_snr(coinc_triggers, coinc_idx,
+                                         opt.coinc_threshold, project_l,
+                                         rho_coinc)
                     project_r = coh.get_projection_matrix(fp, fc, sigma,
                                                           projection='right')
                     rho_coh_r, coinc_idx_r, coinc_triggers_r, rho_coinc_r = \
-                            coh.coherent_snr(coinc_triggers, coinc_idx,
-                                             opt.coinc_threshold, project_r,
-                                             rho_coinc)
+                        coh.coherent_snr(coinc_triggers, coinc_idx,
+                                         opt.coinc_threshold, project_r,
+                                         rho_coinc)
                     max_idx = np.argmax([rho_coh_l, rho_coh_r], axis=0)
                     rho_coh = np.where(max_idx==0, rho_coh_l, rho_coh_r)
                     coinc_idx = np.where(max_idx==0, coinc_idx_l, coinc_idx_r)
@@ -440,33 +446,35 @@ with ctx:
                                               coinc_triggers_r)
                     rho_coinc = np.where(max_idx==0, rho_coinc_l, rho_coinc_r)
                 else:
-                    project = coh.get_projection_matrix(fp, fc, sigma,
-                            projection=opt.projection)
+                    project = coh.get_projection_matrix(
+                        fp, fc, sigma, projection=opt.projection)
                     rho_coh, coinc_idx, coinc_triggers, rho_coinc = \
-                            coh.coherent_snr(coinc_triggers, coinc_idx,
-                                             opt.coinc_threshold, project,
-                                             rho_coinc)
-                logging.info("%d points above coherent threshold", len(rho_coh))
+                        coh.coherent_snr(coinc_triggers, coinc_idx,
+                                         opt.coinc_threshold, project,
+                                         rho_coinc)
+                logging.info("%d points above coherent threshold",
+                             len(rho_coh))
                 if len(coinc_idx) != 0:
-                    logging.info("Max coherent SNR = %s" % str(max(rho_coh)))
+                    logging.info("Max coherent SNR = %.2f", max(rho_coh))
                     #Find the null snr
                     null, rho_coh, rho_coinc, coinc_idx, coinc_triggers =\
                         coh.null_snr(rho_coh, rho_coinc, snrv=coinc_triggers,
                                      index=coinc_idx)
                     if len(coinc_idx) != 0:
-                        logging.info("Max null SNR = %s" % str(max(null)))
-                    logging.info("%s points above null threshold: "
-                                % str(len(null)))
+                        logging.info("Max null SNR = %.2f", max(null))
+                    logging.info("%d points above null threshold",
+                                 len(null))
 
             # We are now going to find the individual detector chi2 values.
             # To do this it is useful to find the indexes of coinc triggers
             # in the detector frame.
             if len(coinc_idx) != 0:
-                # coinc_idx_det_frame is redefined to account for the cuts to coinc_idx above
+                # coinc_idx_det_frame is redefined to account for the cuts to
+                # coinc_idx above
                 coinc_idx_det_frame = {ifo: coinc_idx + time_delay_idx[ifo]
                                        for ifo in opt.instruments}
-                coherent_ifo_triggers = {ifo: snr[ifo][coinc_idx_det_frame[ifo]]
-                                         for ifo in opt.instruments}
+                coherent_ifo_trigs = {ifo: snr[ifo][coinc_idx_det_frame[ifo]]
+                                      for ifo in opt.instruments}
 
                 # Calculate the power and autochi2 values for the coinc indexes
                 # (this uses the snr timeseries before the time delay, so we
@@ -476,53 +484,58 @@ with ctx:
                 for ifo in opt.instruments:
                     chisq[ifo], chisq_dof[ifo] = power_chisq.values(
                         corr_dict[ifo],
-                        coherent_ifo_triggers[ifo] / norm_dict[ifo],
-                        norm_dict[ifo],
-                        stilde[ifo].psd,
+                        coherent_ifo_trigs[ifo] / norm_dict[ifo],
+                        norm_dict[ifo], stilde[ifo].psd,
                         coinc_idx_det_frame[ifo] + stilde[ifo].analyze.start,
                         template)
 
                 # Calculate network chisq value
                 network_chisq_dict = coh.network_chisq(chisq, chisq_dof, 
-                                                       coherent_ifo_triggers)
+                                                       coherent_ifo_trigs)
 
                 # Calculate chisq reweighted SNR
                 if nifo > 2:
-                    reweighted_snr = coh.pycbc_reweight_snr(rho_coh,
-                                                            network_chisq_dict)
+                    reweighted_snr = coh.reweighted_snr(rho_coh,
+                                                        network_chisq_dict)
                     # Calculate null reweighted SNR
                     reweighted_snr = coh.reweight_snr_by_null(reweighted_snr,
                                                               null)
                 elif nifo == 2:
-                    reweighted_snr = coh.pycbc_reweight_snr(rho_coinc,
-                                                            network_chisq_dict)
+                    reweighted_snr = coh.reweighted_snr(rho_coinc,
+                                                        network_chisq_dict)
                 else:
-                    reweighted_snr = coh.pycbc_reweight_snr(
-                        abs(snr[opt.instruments[0]][coinc_idx_det_frame[opt.instruments[0]]]), network_chisq_dict)
+                    rho_sngl = abs(snr[opt.instruments[0]]
+                                      [coinc_idx_det_frame[opt.instruments[0]]]
+                                      )
+                    reweighted_snr = coh.reweighted_snr(rho_sngl,
+                                                        network_chisq_dict)
 
                 # Need all out vals to be the same length. This means the
                 # entries that are single values need to be repeated once
                 # per event.
                 num_events = len(reweighted_snr)
-                # the output will only be possible if len(networkchi2) == num_events
 
+                # the output will only be possible if
+                # len(networkchi2) == num_events
                 for ifo in opt.instruments:
-                    ifo_out_vals['bank_chisq'], ifo_out_vals['bank_chisq_dof'] = \
-                        bank_chisq.values(template, stilde[ifo].psd, stilde[ifo],
-                                          coherent_ifo_triggers[ifo] /
-                                          norm_dict[ifo], norm_dict[ifo],
-                                          coinc_idx_det_frame[ifo] + stilde[ifo].analyze.start)
+                    (ifo_out_vals['bank_chisq'],
+                     ifo_out_vals['bank_chisq_dof']) = bank_chisq.values(
+                        template, stilde[ifo].psd, stilde[ifo],
+                        coherent_ifo_trigs[ifo] / norm_dict[ifo],
+                        norm_dict[ifo],
+                        coinc_idx_det_frame[ifo] + stilde[ifo].analyze.start)
                     ifo_out_vals['cont_chisq'] = autochisq.values(
                         snr[ifo] / norm_dict[ifo], coinc_idx_det_frame[ifo],
                         template, stilde[ifo].psd, norm_dict[ifo],
                         stilde=stilde[ifo], low_frequency_cutoff=flow)
                     ifo_out_vals['chisq'] = chisq[ifo]
                     ifo_out_vals['chisq_dof'] = chisq_dof[ifo]
-                    ifo_out_vals['time_index'] = coinc_idx_det_frame[ifo] + \
-                        stilde[ifo].cumulative_index
-                    ifo_out_vals['snr'] = coherent_ifo_triggers[ifo]
+                    ifo_out_vals['time_index'] = \
+                        coinc_idx_det_frame[ifo] + stilde[ifo].cumulative_index
+                    ifo_out_vals['snr'] = coherent_ifo_trigs[ifo]
                     # IFO is stored as an int
-                    ifo_out_vals['ifo'] = [event_mgr.ifo_dict[ifo]] * num_events
+                    ifo_out_vals['ifo'] = \
+                        [event_mgr.ifo_dict[ifo]] * num_events
                     event_mgr.add_template_events_to_ifo(
                         ifo, ifo_names, [ifo_out_vals[n] for n in ifo_names])
                 if nifo>2:
@@ -532,17 +545,20 @@ with ctx:
                     network_out_vals['coherent_snr'] = np.real(rho_coinc)
                 else:
                     network_out_vals['coherent_snr'] = \
-                        abs(snr[opt.instruments[0]][coinc_idx_det_frame[opt.instruments[0]]])
+                        abs(snr[opt.instruments[0]]
+                                [coinc_idx_det_frame[opt.instruments[0]]])
                 network_out_vals['reweighted_snr'] = reweighted_snr
-                network_out_vals['my_network_chisq'] = np.real(network_chisq_dict)
+                network_out_vals['my_network_chisq'] = \
+                    np.real(network_chisq_dict)
 
                 network_out_vals['time_index'] = \
                     coinc_idx+stilde[ifo].cumulative_index
                 network_out_vals['nifo'] = [nifo] * num_events
                 network_out_vals['ra'] = [opt.ra] * num_events
                 network_out_vals['dec'] = [opt.dec] * num_events
-                event_mgr.add_template_events_to_network( network_names,
-                                [network_out_vals[n] for n in network_names])
+                event_mgr.add_template_events_to_network(
+                    network_names,
+                    [network_out_vals[n] for n in network_names])
         event_mgr.cluster_template_network_events(
             "time_index",
             "coherent_snr",

--- a/bin/pycbc_multi_inspiral
+++ b/bin/pycbc_multi_inspiral
@@ -35,537 +35,516 @@ from pycbc.filter import MatchedFilterControl
 from pycbc.types import TimeSeries, zeros, float32, complex64
 from pycbc.types import MultiDetOptionAction
 from pycbc.vetoes import sgchisq
-if __name__ == '__main__':
-    time_init = time.time()
-    parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("-V", "--verbose", action="store_true",
-                        help="print extra debugging information",
-                        default=False)
-    parser.add_argument("--output", type=str)
-    parser.add_argument("--instruments", nargs="+", type=str, required=True,
-                        help="List of instruments to analyze.")
-    parser.add_argument("--bank-file", type=str)
-    parser.add_argument("--snr-threshold", type=float,
-                        help="SNR threshold for trigger generation")
-    parser.add_argument("--newsnr-threshold", type=float, metavar='THRESHOLD',
-                        help="Cut triggers with NewSNR less than THRESHOLD")
-    parser.add_argument("--low-frequency-cutoff", type=float,
-                        help="The low frequency cutoff to use for filtering "
-                             "(Hz)")
-    # add approximant arg
-    waveform.bank.add_approximant_arg(parser)
-    parser.add_argument("--order", type=str,
-                        help="The integer half-PN order at which to generate"
-                           " the approximant.")
-    parser.add_argument("--taper-template",
-                        choices=["start", "end", "startend"],
-                        help="For time-domain approximants, taper the start "
-                             "and/or end of the waveform before FFTing.")
-    parser.add_argument("--cluster-method", choices=["template", "window"])
-    parser.add_argument("--cluster-window", type=float, default = -1,
-                        help="Length of clustering window in seconds.")
-    parser.add_argument("--bank-veto-bank-file", type=str)
-    parser.add_argument("--chisq-bins", default=0)
-    # Commenting out options which are not yet implemented
-    # parser.add_argument("--chisq-threshold", type=float, default=0) 
-    # parser.add_argument("--chisq-delta", type=float, default=0)
-    parser.add_argument("--autochi-number-points", type=int, default=0)
-    parser.add_argument("--autochi-stride", type=int, default=0)
-    parser.add_argument("--autochi-onesided", action='store_true',
-                        default=False)
-    parser.add_argument("--downsample-factor", type=int, default=1,
-                        help="Factor that determines the interval between the "
-                             "initial SNR sampling. If not set (or 1) no "
-                             "sparse sample is created, and the standard full "
-                             "SNR is calculated.")
-    parser.add_argument("--upsample-threshold", type=float,
-                        help="The fraction of the SNR threshold to check the "
-                             "sparse SNR sample.")
-    parser.add_argument("--upsample-method", choices=["pruned_fft"],
-                        default='pruned_fft',
-                        help="The method to find the SNR points between the "
-                             "sparse SNR sample.")
-    parser.add_argument("--user-tag", type=str, metavar="TAG", help="""
-                        This is used to identify FULL_DATA jobs for
-                        compatibility with pipedown post-processing.
-                        Option will be removed when no longer needed.""")
-    # Arguments added for the coherent stuff
-    parser.add_argument("--ra", type=float, help="Right ascension, in radians")
-    parser.add_argument("--dec", type=float, help="Declination, in radians")
-    parser.add_argument("--coinc-threshold", type=float, default=0.0,
-                        help="Triggers with coincident/coherent snr below "
-                             "this value will be discarded.")
-    parser.add_argument("--do-null-cut", action='store_true',
-                        help="Apply a cut based on null SNR.")
-    parser.add_argument("--null-min", type=float, default=5.25,
-                        help="Triggers with null_snr above this value will be"
-                             " discarded.")
-    parser.add_argument("--null-grad", type=float, default=0.2,
-                        help="The gradient of the line defining the null cut "
-                             "after the null step.")
-    parser.add_argument("--null-step", type=float, default=20.,
-                        help="Triggers with coherent snr above null_step will "
-                             "be cut according to the null_grad and null_min.")
-    parser.add_argument("--trigger-time", type=int,
-                        help="Time of the GRB, used to set the antenna "
-                             "patterns.")
-    parser.add_argument("--projection", default="standard",
-                        choices=["standard", "left", "right", "left+right"],
-                        help="Choice of projection matrix. 'left' and 'right' " 
-                             "correspond to face-away and face-on")
-    # Add options groups
-    strain.insert_strain_option_group_multi_ifo(parser)
-    strain.StrainSegments.insert_segment_option_group_multi_ifo(parser)
-    psd.insert_psd_option_group_multi_ifo(parser)
-    scheme.insert_processing_option_group(parser)
-    fft.insert_fft_option_group(parser)
-    opt.insert_optimization_option_group(parser)
-    inject.insert_injfilterrejector_option_group_multi_ifo(parser)
-    sgchisq.SingleDetSGChisq.insert_option_group(parser)
-    args = parser.parse_args()
-    init_logging(args.verbose)
-    # Set GRB time variable for convenience
-    t_gps = args.trigger_time
-    # Put the ifos in alphabetical order so they are always called in
-    # the same order.
-    args.instruments.sort()
-    strain.verify_strain_options_multi_ifo(args, parser, args.instruments)
-    strain.StrainSegments.verify_segment_options_multi_ifo(
-            args, parser, args.instruments)
-    psd.verify_psd_options_multi_ifo(args, parser, args.instruments)
-    scheme.verify_processing_options(args, parser)
-    fft.verify_fft_options(args, parser)
-    inj_filter_rejector = inject.InjFilterRejector.from_cli_multi_ifos(
-        args, args.instruments)
-    strain_dict = strain.from_cli_multi_ifos(
-        args, args.instruments, inj_filter_rejector,
-        dyn_range_fac=DYN_RANGE_FAC)
-    strain_segments_dict = strain.StrainSegments.from_cli_multi_ifos(
-        args, strain_dict, args.instruments)
-    ctx = scheme.from_cli(args)
-    with ctx:
-        fft.from_cli(args)
-        # Set some often used variables for easy access
-        flow = args.low_frequency_cutoff
-        flow_dict = defaultdict(lambda : flow)
-        for count, ifo in enumerate(args.instruments):
-            if count == 0:
-                sample_rate = strain_dict[ifo].sample_rate
-                sample_rate_dict = defaultdict(lambda : sample_rate)
-                flen = strain_segments_dict[ifo].freq_len
-                flen_dict = defaultdict(lambda : flen)
-                tlen = strain_segments_dict[ifo].time_len
-                tlen_dict = defaultdict(lambda : tlen)
-                delta_f = strain_segments_dict[ifo].delta_f
-                delta_f_dict = defaultdict(lambda : delta_f)
-            else:
-                try:
-                    assert(sample_rate == strain_dict[ifo].sample_rate)
-                    assert(flen == strain_segments_dict[ifo].freq_len)
-                    assert(tlen == strain_segments_dict[ifo].time_len)
-                    assert(delta_f == strain_segments_dict[ifo].delta_f)
-                except:
-                    err_msg = "Sample rate, frequency length and time length "
-                    err_msg += "must all be consistent across ifos."
-                    raise ValueError(err_msg)
-        logging.info("Making frequency-domain data segments")
-        segments = {
-            ifo: strain_segments_dict[ifo].fourier_segments()
-            for ifo in args.instruments
-            }
-        del strain_segments_dict
-        psd.associate_psds_to_multi_ifo_segments(
-            args, segments, strain_dict, flen, delta_f, flow, args.instruments,
-            dyn_range_factor=DYN_RANGE_FAC, precision='single')
-        # Currently we are using the same matched-filter parameters for all
-        # ifos. Therefore only one MatchedFilterControl needed. Maybe this can
-        # change if needed. Segments is only used to get tlen etc. which is
-        # same for all ifos, so just send the first ifo
-        template_mem = zeros(tlen, dtype=complex64)
-        # Calculate time delay to each detector
-        time_delay_idx = {}
-        for ifo in args.instruments:
-            dt = detector.Detector(ifo).time_delay_from_earth_center(
-                args.ra, args.dec, t_gps)
-            time_delay_idx[ifo] = int(round(dt * sample_rate))
-        # Matched filter each ifo. Don't cluster here for a coherent search.
-        # Clustering happens at the end of the template loop.
-        # FIXME: The single detector SNR threshold should not necessarily be
-        #        applied to every IFO (usually only 2 most sensitive in
-        #        network)
-        matched_filter = {
-            ifo: MatchedFilterControl(
-                args.low_frequency_cutoff, None, args.snr_threshold, tlen,
-                delta_f, complex64, segments[ifo], template_mem,
-                use_cluster=False, downsample_factor=args.downsample_factor,
-                upsample_threshold=args.upsample_threshold,
-                upsample_method=args.upsample_method,
-                cluster_function='symmetric')
-            for ifo in args.instruments}
-        logging.info("Initializing signal-based vetoes.")
-        # The existing SingleDetPowerChisq can calculate the single detector
-        # chisq for multiple ifos, so just use that directly.
-        power_chisq = vetoes.SingleDetPowerChisq(args.chisq_bins)
-        # The existing SingleDetBankVeto can calculate the single detector
-        # bank veto for multiple ifos, so we just use it directly.
-        bank_chisq = vetoes.SingleDetBankVeto(
-            args.bank_veto_bank_file, flen, delta_f, flow, complex64,
-            phase_order=args.order, approximant=args.approximant)
-        # Same here
-        autochisq = vetoes.SingleDetAutoChisq(
-            args.autochi_stride, args.autochi_number_points,
-            onesided=args.autochi_onesided)
-        logging.info("Overwhitening frequency-domain data segments")
-        for ifo in args.instruments:
-            for seg in segments[ifo]:
-                seg /= seg.psd
-        ifo_out_types = {
-            'time_index'     : int,
-            'ifo'            : int, # IFO is stored as an int internally!
-            'snr'            : complex64,
-            'chisq'          : float32,
-            'chisq_dof'      : int,
-            'bank_chisq'     : float32,
-            'bank_chisq_dof' : int,
-            'cont_chisq'     : float32,
-            }
-        ifo_out_vals = {
-            'time_index'     : None,
-            'ifo'            : None,
-            'snr'            : None,
-            'chisq'          : None,
-            'chisq_dof'      : None,
-            'bank_chisq'     : None,
-            'bank_chisq_dof' : None,
-            'cont_chisq'     : None,
-            }
-        ifo_names = sorted(ifo_out_vals.keys())
-        network_out_types = {
-            'latitude'      : float32,
-            'longitude'     : float32,
-            'time_index'    : int,
-            'coherent_snr'   : float32,
-            'null_snr'      : float32,
-            'nifo'          : int,
-            'my_network_chisq':float32,
-            'reweighted_snr' : float32
-            }
-        network_out_vals = {
-            'latitude'      : None,
-            'longitude'     : None,
-            'time_index'    : None,
-            'coherent_snr'   : None,
-            'null_snr'      : None,
-            'nifo'          : None,
-            'my_network_chisq' : None, 
-            'reweighted_snr' : None
-            }
-        network_names = sorted(network_out_vals.keys())
-        event_mgr = EventManagerCoherent(
-            args, args.instruments, ifo_names,
-             [ifo_out_types[n] for n in ifo_names], network_names,
-             [network_out_types[n] for n in network_names])
-        logging.info("Read in template bank")
-        bank = waveform.FilterBank(
-            args.bank_file, flen, delta_f, complex64,
-            low_frequency_cutoff=flow, phase_order=args.order,
-            taper=args.taper_template, approximant=args.approximant,
-            out=template_mem)
-        # Use injfilterrejector to reduce the bank to only those templates that
-        # might actually find something
+time_init = time.time()
+parser = argparse.ArgumentParser(description=__doc__)
+parser.add_argument("-V", "--verbose", action="store_true",
+                    help="print extra debugging information",
+                    default=False)
+parser.add_argument("--output", type=str)
+parser.add_argument("--instruments", nargs="+", type=str, required=True,
+                    help="List of instruments to analyze.")
+parser.add_argument("--bank-file", type=str)
+parser.add_argument("--snr-threshold", type=float,
+                    help="SNR threshold for trigger generation")
+parser.add_argument("--newsnr-threshold", type=float, metavar='THRESHOLD',
+                    help="Cut triggers with NewSNR less than THRESHOLD")
+parser.add_argument("--low-frequency-cutoff", type=float,
+                    help="The low frequency cutoff to use for filtering "
+                         "(Hz)")
+# add approximant arg
+waveform.bank.add_approximant_arg(parser)
+parser.add_argument("--order", type=str,
+                    help="The integer half-PN order at which to generate the "
+                         "approximant.")
+parser.add_argument("--taper-template",
+                    choices=["start", "end", "startend"],
+                    help="For time-domain approximants, taper the start "
+                         "and/or end of the waveform before FFTing.")
+parser.add_argument("--cluster-method", choices=["template", "window"])
+parser.add_argument("--cluster-window", type=float, default = -1,
+                    help="Length of clustering window in seconds.")
+parser.add_argument("--bank-veto-bank-file", type=str)
+parser.add_argument("--chisq-bins", default=0)
+# Commenting out options which are not yet implemented
+# parser.add_argument("--chisq-threshold", type=float, default=0) 
+# parser.add_argument("--chisq-delta", type=float, default=0)
+parser.add_argument("--autochi-number-points", type=int, default=0)
+parser.add_argument("--autochi-stride", type=int, default=0)
+parser.add_argument("--autochi-onesided", action='store_true',
+                    default=False)
+parser.add_argument("--downsample-factor", type=int, default=1,
+                    help="Factor that determines the interval between the "
+                         "initial SNR sampling. If not set (or 1) no sparse "
+                         "sample is created, and the standard full SNR is "
+                         "calculated.")
+parser.add_argument("--upsample-threshold", type=float,
+                    help="The fraction of the SNR threshold to check the "
+                         "sparse SNR sample.")
+parser.add_argument("--upsample-method", choices=["pruned_fft"],
+                    default='pruned_fft',
+                    help="The method to find the SNR points between the "
+                         "sparse SNR sample.")
+parser.add_argument("--user-tag", type=str, metavar="TAG",
+                    help="This is used to identify FULL_DATA jobs for "
+                         "compatibility with pipedown post-processing. Option "
+                         "will be removed when no longer needed.")
+# Arguments added for the coherent stuff
+parser.add_argument("--ra", type=float, help="Right ascension, in radians")
+parser.add_argument("--dec", type=float, help="Declination, in radians")
+parser.add_argument("--coinc-threshold", type=float, default=0.0,
+                    help="Triggers with coincident/coherent snr below this "
+                         "value will be discarded.")
+parser.add_argument("--do-null-cut", action='store_true',
+                    help="Apply a cut based on null SNR.")
+parser.add_argument("--null-min", type=float, default=5.25,
+                    help="Triggers with null_snr above this value will be"
+                         " discarded.")
+parser.add_argument("--null-grad", type=float, default=0.2,
+                    help="The gradient of the line defining the null cut "
+                         "after the null step.")
+parser.add_argument("--null-step", type=float, default=20.,
+                    help="Triggers with coherent snr above null_step will "
+                         "be cut according to the null_grad and null_min.")
+parser.add_argument("--trigger-time", type=int,
+                    help="Time of the GRB, used to set the antenna patterns.")
+parser.add_argument("--projection", default="standard",
+                    choices=["standard", "left", "right", "left+right"],
+                    help="Choice of projection matrix. 'left' and 'right' " 
+                         "correspond to face-away and face-on")
+# Add options groups
+strain.insert_strain_option_group_multi_ifo(parser)
+strain.StrainSegments.insert_segment_option_group_multi_ifo(parser)
+psd.insert_psd_option_group_multi_ifo(parser)
+scheme.insert_processing_option_group(parser)
+fft.insert_fft_option_group(parser)
+opt.insert_optimization_option_group(parser)
+inject.insert_injfilterrejector_option_group_multi_ifo(parser)
+sgchisq.SingleDetSGChisq.insert_option_group(parser)
+args = parser.parse_args()
+init_logging(args.verbose)
+# Set GRB time variable for convenience
+t_gps = args.trigger_time
+# Put the ifos in alphabetical order so they are always called in
+# the same order.
+args.instruments.sort()
+strain.verify_strain_options_multi_ifo(args, parser, args.instruments)
+strain.StrainSegments.verify_segment_options_multi_ifo(
+        args, parser, args.instruments)
+psd.verify_psd_options_multi_ifo(args, parser, args.instruments)
+scheme.verify_processing_options(args, parser)
+fft.verify_fft_options(args, parser)
+inj_filter_rejector = inject.InjFilterRejector.from_cli_multi_ifos(
+    args, args.instruments)
+strain_dict = strain.from_cli_multi_ifos(
+    args, args.instruments, inj_filter_rejector, dyn_range_fac=DYN_RANGE_FAC)
+strain_segments_dict = strain.StrainSegments.from_cli_multi_ifos(
+    args, strain_dict, args.instruments)
+ctx = scheme.from_cli(args)
+with ctx:
+    fft.from_cli(args)
+    # Set some often used variables for easy access
+    flow = args.low_frequency_cutoff
+    flow_dict = defaultdict(lambda : flow)
+    for count, ifo in enumerate(args.instruments):
+        if count == 0:
+            sample_rate = strain_dict[ifo].sample_rate
+            sample_rate_dict = defaultdict(lambda : sample_rate)
+            flen = strain_segments_dict[ifo].freq_len
+            flen_dict = defaultdict(lambda : flen)
+            tlen = strain_segments_dict[ifo].time_len
+            tlen_dict = defaultdict(lambda : tlen)
+            delta_f = strain_segments_dict[ifo].delta_f
+            delta_f_dict = defaultdict(lambda : delta_f)
+        else:
+            try:
+                assert(sample_rate == strain_dict[ifo].sample_rate)
+                assert(flen == strain_segments_dict[ifo].freq_len)
+                assert(tlen == strain_segments_dict[ifo].time_len)
+                assert(delta_f == strain_segments_dict[ifo].delta_f)
+            except:
+                err_msg = "Sample rate, frequency length and time length "
+                err_msg += "must all be consistent across ifos."
+                raise ValueError(err_msg)
+    logging.info("Making frequency-domain data segments")
+    segments = {
+        ifo: strain_segments_dict[ifo].fourier_segments()
+        for ifo in args.instruments
+        }
+    del strain_segments_dict
+    psd.associate_psds_to_multi_ifo_segments(
+        args, segments, strain_dict, flen, delta_f, flow, args.instruments,
+        dyn_range_factor=DYN_RANGE_FAC, precision='single')
+    # Currently we are using the same matched-filter parameters for all
+    # ifos. Therefore only one MatchedFilterControl needed. Maybe this can
+    # change if needed. Segments is only used to get tlen etc. which is
+    # same for all ifos, so just send the first ifo
+    template_mem = zeros(tlen, dtype=complex64)
+    # Calculate time delay to each detector
+    time_delay_idx = {}
+    for ifo in args.instruments:
+        dt = detector.Detector(ifo).time_delay_from_earth_center(
+            args.ra, args.dec, t_gps)
+        time_delay_idx[ifo] = int(round(dt * sample_rate))
+    # Matched filter each ifo. Don't cluster here for a coherent search.
+    # Clustering happens at the end of the template loop.
+    # FIXME: The single detector SNR threshold should not necessarily be
+    #        applied to every IFO (usually only 2 most sensitive in
+    #        network)
+    matched_filter = {
+        ifo: MatchedFilterControl(
+            args.low_frequency_cutoff, None, args.snr_threshold, tlen, delta_f,
+            complex64, segments[ifo], template_mem, use_cluster=False,
+            downsample_factor=args.downsample_factor,
+            upsample_threshold=args.upsample_threshold,
+            upsample_method=args.upsample_method, cluster_function='symmetric')
+        for ifo in args.instruments}
+    logging.info("Initializing signal-based vetoes.")
+    # The existing SingleDetPowerChisq can calculate the single detector
+    # chisq for multiple ifos, so just use that directly.
+    power_chisq = vetoes.SingleDetPowerChisq(args.chisq_bins)
+    # The existing SingleDetBankVeto can calculate the single detector
+    # bank veto for multiple ifos, so we just use it directly.
+    bank_chisq = vetoes.SingleDetBankVeto(
+        args.bank_veto_bank_file, flen, delta_f, flow, complex64,
+        phase_order=args.order, approximant=args.approximant)
+    # Same here
+    autochisq = vetoes.SingleDetAutoChisq(
+        args.autochi_stride, args.autochi_number_points,
+        onesided=args.autochi_onesided)
+    logging.info("Overwhitening frequency-domain data segments")
+    for ifo in args.instruments:
+        for seg in segments[ifo]:
+            seg /= seg.psd
+    ifo_out_types = {
+        'time_index': int,
+        'ifo': int, # IFO is stored as an int internally!
+        'snr': complex64,
+        'chisq': float32,
+        'chisq_dof': int,
+        'bank_chisq': float32,
+        'bank_chisq_dof': int,
+        'cont_chisq': float32,
+        }
+    ifo_out_vals = {
+        'time_index': None,
+        'ifo': None,
+        'snr': None,
+        'chisq': None,
+        'chisq_dof': None,
+        'bank_chisq': None,
+        'bank_chisq_dof': None,
+        'cont_chisq': None,
+        }
+    ifo_names = sorted(ifo_out_vals.keys())
+    network_out_types = {
+        'latitude': float32,
+        'longitude': float32,
+        'time_index': int,
+        'coherent_snr': float32,
+        'null_snr': float32,
+        'nifo': int,
+        'my_network_chisq': float32,
+        'reweighted_snr': float32
+        }
+    network_out_vals = {
+        'latitude': None,
+        'longitude': None,
+        'time_index': None,
+        'coherent_snr': None,
+        'null_snr': None,
+        'nifo': None,
+        'my_network_chisq': None, 
+        'reweighted_snr': None
+        }
+    network_names = sorted(network_out_vals.keys())
+    event_mgr = EventManagerCoherent(
+        args, args.instruments, ifo_names,
+        [ifo_out_types[n] for n in ifo_names], network_names,
+        [network_out_types[n] for n in network_names])
+    logging.info("Read in template bank")
+    bank = waveform.FilterBank(
+        args.bank_file, flen, delta_f, complex64, low_frequency_cutoff=flow,
+        phase_order=args.order, taper=args.taper_template,
+        approximant=args.approximant, out=template_mem)
+    # Use injfilterrejector to reduce the bank to only those templates that
+    # might actually find something
+    n_bank = len(bank)
+    nfilters = 0
+    logging.info("Full template bank size: %d", n_bank)
+    for ifo in args.instruments:
+        bank.template_thinning(inj_filter_rejector[ifo])
+    if not len(bank) == n_bank:
         n_bank = len(bank)
-        nfilters = 0
-        logging.info("Full template bank size: %d", n_bank)
+        logging.info("Template bank size after thinning: %d", n_bank)
+    # Antenna patterns
+    fp = {}
+    fc = {}
+    for ifo in args.instruments:
+        fp[ifo], fc[ifo] = detector.Detector(ifo).antenna_pattern(
+            args.ra, args.dec, polarization=0, t_gps=t_gps)
+    # Loop over templates
+    for t_num, template in enumerate(bank):
         for ifo in args.instruments:
-            bank.template_thinning(inj_filter_rejector[ifo])
-        if not len(bank) == n_bank:
-            n_bank = len(bank)
-            logging.info("Template bank size after thinning: %d", n_bank)
-        # Antenna patterns
-        fp = {}
-        fc = {}
-        for ifo in args.instruments:
-            fp[ifo], fc[ifo] = detector.Detector(ifo).antenna_pattern(
-                args.ra, args.dec, polarization=0, t_gps=t_gps)
-        # Loop over templates
-        for t_num, template in enumerate(bank):
+            if args.cluster_method == "window":
+                cluster_window = int(args.cluster_window * sample_rate)
+            elif args.cluster_method == "template":
+                cluster_window = int(template.chirp_length * sample_rate)
+            elif args.cluster_window == 0:
+                 cluster_window = int(0)
+        # Loop over segments
+        for s_num,stilde in enumerate(segments[args.instruments[0]]):
+            stilde = {ifo : segments[ifo][s_num] for ifo in args.instruments}
+            # Filter check checks the 'inj_filter_rejector' options to
+            # determine whether to filter this template/segment 
+            # if injections are present.
+            analyse_segment = True
             for ifo in args.instruments:
-                if args.cluster_method == "window":
-                    cluster_window = int(args.cluster_window * sample_rate)
-                elif args.cluster_method == "template":
-                    cluster_window = int(template.chirp_length * sample_rate)
-                elif args.cluster_window == 0:
-                     cluster_window = int(0)
-            # Loop over segments
-            for s_num,stilde in enumerate(segments[args.instruments[0]]):
-                stilde = {
-                    ifo : segments[ifo][s_num] for ifo in args.instruments}
-                # Filter check checks the 'inj_filter_rejector' options to
-                # determine whether to filter this template/segment 
-                # if injections are present.
-                analyse_segment = True
-                for ifo in args.instruments:
-                    if not inj_filter_rejector[ifo].template_segment_checker(
-                            bank, t_num, stilde[ifo]):
-                        logging.info(
-                            "Skipping segment %d/%d with template %d/%d as no "
-                            "detectable injection is present",
-                            s_num + 1, len(segments[ifo]), t_num + 1, n_bank)
-                        analyse_segment = False
-                # Find detector sensitivities (sigma) and make array of
-                # normalised
-                sigmasq = {
-                    ifo : template.sigmasq(segments[ifo][s_num].psd)
-                    for ifo in args.instruments}
-                sigma = {
-                    ifo : np.sqrt(sigmasq[ifo]) for ifo in args.instruments}
-                # Every time s_num is zero or we skip the segment, we run new 
-                # template to increment the template index
-                if s_num==0:
-                    event_mgr.new_template(
-                        tmplt=template.params, sigmasq=sigmasq)
-                if not analyse_segment: continue
+                if not inj_filter_rejector[ifo].template_segment_checker(
+                        bank, t_num, stilde[ifo]):
+                    logging.info(
+                        "Skipping segment %d/%d with template %d/%d as no "
+                        "detectable injection is present",
+                        s_num + 1, len(segments[ifo]), t_num + 1, n_bank)
+                    analyse_segment = False
+            # Find detector sensitivities (sigma) and make array of
+            # normalised
+            sigmasq = {
+                ifo : template.sigmasq(segments[ifo][s_num].psd)
+                for ifo in args.instruments}
+            sigma = {ifo : np.sqrt(sigmasq[ifo]) for ifo in args.instruments}
+            # Every time s_num is zero or we skip the segment, we run new 
+            # template to increment the template index
+            if s_num==0:
+                event_mgr.new_template(tmplt=template.params, sigmasq=sigmasq)
+            if not analyse_segment: continue
+            logging.info(
+                "Analyzing segment %d/%d", s_num + 1, len(segments[ifo]))
+            snr_dict = dict.fromkeys(args.instruments)
+            norm_dict = dict.fromkeys(args.instruments)
+            corr_dict = dict.fromkeys(args.instruments)
+            idx = dict.fromkeys(args.instruments)
+            snrv_dict = dict.fromkeys(args.instruments)
+            snr = dict.fromkeys(args.instruments)
+            ifo_list = args.instruments[:]
+            for ifo in args.instruments:
                 logging.info(
-                    "Analyzing segment %d/%d", s_num + 1, len(segments[ifo]))
-                snr_dict = dict.fromkeys(args.instruments)
-                norm_dict = dict.fromkeys(args.instruments)
-                corr_dict = dict.fromkeys(args.instruments)
-                idx = dict.fromkeys(args.instruments)
-                snrv_dict = dict.fromkeys(args.instruments)
-                snr = dict.fromkeys(args.instruments)
-                ifo_list = args.instruments[:]
-                for ifo in args.instruments:
-                    logging.info(
-                        "Filtering template %d/%d, ifo %s", t_num + 1, n_bank,
-                        ifo)
-                    # No clustering in the coherent search until the end.
-                    # The correlation vector is the FFT of the snr (so inverse
-                    # FFT it to get the snr). 
-                    snr_ts, norm, corr, ind, snrv = \
-                         matched_filter[ifo].matched_filter_and_cluster(
-                             s_num, template.sigmasq(stilde[ifo].psd),
-                             window=0)
-                    snr_dict[ifo] = (
-                            snr_ts[matched_filter[ifo].segments[s_num].analyze]
-                            * norm)
-                    norm_dict[ifo] = norm
-                    corr_dict[ifo] = corr.copy()
-                    idx[ifo] = ind.copy()
-                    snrv_dict[ifo] = snrv.copy()
-                    snr[ifo] = snrv * norm
-                # Move onto next segment if there are no triggers.
-                if len(ifo_list)==0: continue
-                # Save the indexes of triggers (if we have any)
-                # Even if we have none, need to keep an empty dictionary.
-                # Only do this is idx doesn't get time shifted out of the time
-                # we are looking at.
-                idx_dict = {
-                    ifo: idx[ifo][np.logical_and(
-                        idx[ifo] > time_delay_idx[ifo],
-                        idx[ifo] - time_delay_idx[ifo] < len(snr_dict[ifo])
-                        )
-                    ]
+                    "Filtering template %d/%d, ifo %s", t_num + 1, n_bank, ifo)
+                # No clustering in the coherent search until the end.
+                # The correlation vector is the FFT of the snr (so inverse
+                # FFT it to get the snr). 
+                snr_ts, norm, corr, ind, snrv = \
+                     matched_filter[ifo].matched_filter_and_cluster(
+                         s_num, template.sigmasq(stilde[ifo].psd), window=0)
+                snr_dict[ifo] = (
+                        snr_ts[matched_filter[ifo].segments[s_num].analyze]
+                        * norm)
+                norm_dict[ifo] = norm
+                corr_dict[ifo] = corr.copy()
+                idx[ifo] = ind.copy()
+                snrv_dict[ifo] = snrv.copy()
+                snr[ifo] = snrv * norm
+            # Move onto next segment if there are no triggers.
+            if len(ifo_list)==0: continue
+            # Save the indexes of triggers (if we have any)
+            # Even if we have none, need to keep an empty dictionary.
+            # Only do this is idx doesn't get time shifted out of the time
+            # we are looking at.
+            idx_dict = {
+                ifo: idx[ifo][np.logical_and(
+                    idx[ifo] > time_delay_idx[ifo],
+                    idx[ifo] - time_delay_idx[ifo] < len(snr_dict[ifo])
+                    )
+                ]
+                for ifo in args.instruments}
+            # Find triggers that are coincident (in geocent time) in
+            # multiple ifos. If a single ifo analysis then just use the
+            # indexes from that ifo.
+            if len(args.instruments) > 1:
+                coinc_idx = coh.get_coinc_indexes(idx_dict, time_delay_idx)
+            else:
+                coinc_idx = (
+                    idx_dict[args.instruments[0]]
+                    - time_delay_idx[args.instruments[0]]
+                    )
+            logging.info("Found %d coincident triggers", len(coinc_idx))
+            # Number of ifos
+            nifo = len(args.instruments)
+            for ifo in args.instruments:
+                # Move on if this segment has no data
+                if len(snr_dict[ifo])==0:
+                    raise RuntimeError(
+                        'The SNR triggers dictionary is empty. This '
+                        'should not be possible.')
+                # Time delay is applied to indices
+                coinc_idx_det_frame = {
+                    ifo: coinc_idx + time_delay_idx[ifo]
                     for ifo in args.instruments}
-                # Find triggers that are coincident (in geocent time) in
-                # multiple ifos. If a single ifo analysis then just use the
-                # indexes from that ifo.
-                if len(args.instruments) > 1:
-                    coinc_idx = coh.get_coinc_indexes(idx_dict, time_delay_idx)
-                else:
-                    coinc_idx = (
-                        idx_dict[args.instruments[0]]
-                        - time_delay_idx[args.instruments[0]]
-                        )
-                logging.info("Found %d coincident triggers", len(coinc_idx))
-                # Number of ifos
-                nifo = len(args.instruments)
-                for ifo in args.instruments:
-                    # Move on if this segment has no data
-                    if len(snr_dict[ifo])==0:
-                        raise RuntimeError(
-                            'The SNR triggers dictionary is empty. This '
-                            'should not be possible.')
-                    # Time delay is applied to indices
-                    coinc_idx_det_frame = {
-                        ifo: coinc_idx + time_delay_idx[ifo]
-                        for ifo in args.instruments}
-                # Calculate the coincident and coherent snr
-                # Check we have data before we try to compute the coherent snr
-                if len(coinc_idx) != 0 and nifo > 1:
-                    # Find coinc snr at trigger times and apply coinc snr
-                    # threshold
-                    rho_coinc, coinc_idx, coinc_triggers = coh.coincident_snr(
-                        snr_dict, coinc_idx, args.coinc_threshold,
-                        time_delay_idx)
-                    logging.info(
-                        "%d points above coincident SNR threshold",
-                        len(coinc_idx))
-                    if len(coinc_idx) != 0:
-                        logging.info(
-                            "Max coincident SNR = %.2f", max(rho_coinc))
-                # If there is only one ifo, then coinc_triggers is just the
-                # triggers from ifo
-                elif len(coinc_idx) != 0 and nifo == 1:
+            # Calculate the coincident and coherent snr
+            # Check we have data before we try to compute the coherent snr
+            if len(coinc_idx) != 0 and nifo > 1:
+                # Find coinc snr at trigger times and apply coinc snr
+                # threshold
+                rho_coinc, coinc_idx, coinc_triggers = coh.coincident_snr(
+                    snr_dict, coinc_idx, args.coinc_threshold, time_delay_idx)
+                logging.info(
+                    "%d points above coincident SNR threshold", len(coinc_idx))
+                if len(coinc_idx) != 0:
+                    logging.info("Max coincident SNR = %.2f", max(rho_coinc))
+            # If there is only one ifo, then coinc_triggers is just the
+            # triggers from ifo
+            elif len(coinc_idx) != 0 and nifo == 1:
+                coinc_triggers = {
+                    args.instruments[0]: snr[args.instruments[0]][
+                        coinc_idx_det_frame[args.instruments[0]]
+                        ]
+                    }
+            else:
+                coinc_triggers = {}
+                logging.info("No triggers above coincident SNR threshold")
+            # If we have triggers above coinc threshold and more than 2
+            # ifos then calculate the coherent statistics
+            if len(coinc_idx) != 0 and nifo > 2:
+                if args.projection=='left+right':
+                    project_l = coh.get_projection_matrix(
+                        fp, fc, sigma, projection='left')
+                    rho_coh_l, coinc_idx_l, coinc_triggers_l, rho_coinc_l = \
+                        coh.coherent_snr(
+                            coinc_triggers, coinc_idx, args.coinc_threshold,
+                            project_l, rho_coinc)
+                    project_r = coh.get_projection_matrix(
+                        fp, fc, sigma, projection='right')
+                    rho_coh_r, coinc_idx_r, coinc_triggers_r, rho_coinc_r = \
+                        coh.coherent_snr(
+                            coinc_triggers, coinc_idx, args.coinc_threshold,
+                            project_r, rho_coinc)
+                    max_idx = np.argmax([rho_coh_l, rho_coh_r], axis=0)
+                    rho_coh = np.where(max_idx==0, rho_coh_l, rho_coh_r)
+                    coinc_idx = np.where(
+                        max_idx==0, coinc_idx_l, coinc_idx_r)
                     coinc_triggers = {
-                        args.instruments[0]: snr[args.instruments[0]][
+                        ifo: np.where(
+                            max_idx==0, coinc_triggers_l[ifo],
+                            coinc_triggers_r[ifo])
+                        for ifo in coinc_triggers_l}
+                    rho_coinc = np.where(
+                        max_idx==0, rho_coinc_l, rho_coinc_r)
+                else:
+                    project = coh.get_projection_matrix(
+                        fp, fc, sigma, projection=args.projection)
+                    rho_coh, coinc_idx, coinc_triggers, rho_coinc = \
+                        coh.coherent_snr(
+                            coinc_triggers, coinc_idx, args.coinc_threshold,
+                            project, rho_coinc)
+                logging.info(
+                    "%d points above coherent threshold", len(rho_coh))
+                if len(coinc_idx) != 0:
+                    logging.info("Max coherent SNR = %.2f", max(rho_coh))
+                    #Find the null snr
+                    null, rho_coh, rho_coinc, coinc_idx, coinc_triggers = \
+                        coh.null_snr(
+                            rho_coh, rho_coinc, snrv=coinc_triggers,
+                            index=coinc_idx, apply_cut=args.do_null_cut)
+                    if len(coinc_idx) != 0:
+                        logging.info("Max null SNR = %.2f", max(null))
+                    logging.info("%d points above null threshold", len(null))
+            # We are now going to find the individual detector chi2 values.
+            # To do this it is useful to find the indexes of coinc triggers
+            # in the detector frame.
+            if len(coinc_idx) != 0:
+                # coinc_idx_det_frame is redefined to account for the cuts
+                # to coinc_idx above
+                coinc_idx_det_frame = {
+                    ifo: coinc_idx + time_delay_idx[ifo]
+                    for ifo in args.instruments}
+                coherent_ifo_trigs = {
+                    ifo: snr_dict[ifo][coinc_idx_det_frame[ifo]]
+                    for ifo in args.instruments}
+                # Calculate the power and autochi2 values for the coinc
+                # indexes this uses the snr timeseries before the time
+                # delay, so we need to undo it. Same for normalisation)
+                chisq = {}
+                chisq_dof = {}
+                for ifo in args.instruments:
+                    chisq[ifo], chisq_dof[ifo] = power_chisq.values(
+                        corr_dict[ifo],
+                        coherent_ifo_trigs[ifo] / norm_dict[ifo],
+                        norm_dict[ifo], stilde[ifo].psd,
+                        coinc_idx_det_frame[ifo] + stilde[ifo].analyze.start,
+                        template)
+                # Calculate network chisq value
+                network_chisq_dict = coh.network_chisq(
+                    chisq, chisq_dof, coherent_ifo_trigs)
+                # Calculate chisq reweighted SNR
+                if nifo > 2:
+                    reweighted_snr = ranking.newsnr(
+                        rho_coh, network_chisq_dict)
+                    # Calculate null reweighted SNR
+                    reweighted_snr = coh.reweight_snr_by_null(
+                        reweighted_snr, null, rho_coh)
+                elif nifo == 2:
+                    reweighted_snr = ranking.newsnr(
+                        rho_coinc, network_chisq_dict)
+                else:
+                    rho_sngl = abs(
+                        snr[args.instruments[0]][
                             coinc_idx_det_frame[args.instruments[0]]
                             ]
-                        }
-                else:
-                    coinc_triggers = {}
-                    logging.info("No triggers above coincident SNR threshold")
-                # If we have triggers above coinc threshold and more than 2
-                # ifos then calculate the coherent statistics
-                if len(coinc_idx) != 0 and nifo > 2:
-                    if args.projection=='left+right':
-                        project_l = coh.get_projection_matrix(
-                            fp, fc, sigma, projection='left')
-                        (rho_coh_l, coinc_idx_l, coinc_triggers_l,
-                            rho_coinc_l) = coh.coherent_snr(
-                                coinc_triggers, coinc_idx,
-                                args.coinc_threshold, project_l, rho_coinc)
-                        project_r = coh.get_projection_matrix(
-                            fp, fc, sigma, projection='right')
-                        (rho_coh_r, coinc_idx_r, coinc_triggers_r,
-                            rho_coinc_r) = coh.coherent_snr(
-                                coinc_triggers, coinc_idx,
-                                args.coinc_threshold, project_r, rho_coinc)
-                        max_idx = np.argmax([rho_coh_l, rho_coh_r], axis=0)
-                        rho_coh = np.where(max_idx==0, rho_coh_l, rho_coh_r)
-                        coinc_idx = np.where(
-                            max_idx==0, coinc_idx_l, coinc_idx_r)
-                        coinc_triggers = {
-                            ifo: np.where(
-                                max_idx==0, coinc_triggers_l[ifo],
-                                coinc_triggers_r[ifo])
-                            for ifo in coinc_triggers_l}
-                        rho_coinc = np.where(
-                            max_idx==0, rho_coinc_l, rho_coinc_r)
-                    else:
-                        project = coh.get_projection_matrix(
-                            fp, fc, sigma, projection=args.projection)
-                        rho_coh, coinc_idx, coinc_triggers, rho_coinc = \
-                            coh.coherent_snr(
-                                coinc_triggers, coinc_idx,
-                                args.coinc_threshold, project, rho_coinc)
-                    logging.info(
-                        "%d points above coherent threshold", len(rho_coh))
-                    if len(coinc_idx) != 0:
-                        logging.info("Max coherent SNR = %.2f", max(rho_coh))
-                        #Find the null snr
-                        null, rho_coh, rho_coinc, coinc_idx, coinc_triggers =\
-                            coh.null_snr(
-                                rho_coh, rho_coinc, snrv=coinc_triggers,
-                                index=coinc_idx, apply_cut=args.do_null_cut)
-                        if len(coinc_idx) != 0:
-                            logging.info("Max null SNR = %.2f", max(null))
-                        logging.info(
-                            "%d points above null threshold", len(null))
-                # We are now going to find the individual detector chi2 values.
-                # To do this it is useful to find the indexes of coinc triggers
-                # in the detector frame.
-                if len(coinc_idx) != 0:
-                    # coinc_idx_det_frame is redefined to account for the cuts
-                    # to coinc_idx above
-                    coinc_idx_det_frame = {
-                        ifo: coinc_idx + time_delay_idx[ifo]
-                        for ifo in args.instruments}
-                    coherent_ifo_trigs = {
-                        ifo: snr_dict[ifo][coinc_idx_det_frame[ifo]]
-                        for ifo in args.instruments}
-                    # Calculate the power and autochi2 values for the coinc
-                    # indexes this uses the snr timeseries before the time
-                    # delay, so we need to undo it. Same for normalisation)
-                    chisq = {}
-                    chisq_dof = {}
-                    for ifo in args.instruments:
-                        chisq[ifo], chisq_dof[ifo] = power_chisq.values(
-                            corr_dict[ifo],
-                            coherent_ifo_trigs[ifo] / norm_dict[ifo],
-                            norm_dict[ifo], stilde[ifo].psd,
-                            coinc_idx_det_frame[ifo]
-                            + stilde[ifo].analyze.start,
-                            template)
-                    # Calculate network chisq value
-                    network_chisq_dict = coh.network_chisq(
-                        chisq, chisq_dof, coherent_ifo_trigs)
-                    # Calculate chisq reweighted SNR
-                    if nifo > 2:
-                        reweighted_snr = ranking.newsnr(
-                            rho_coh, network_chisq_dict)
-                        # Calculate null reweighted SNR
-                        reweighted_snr = coh.reweight_snr_by_null(
-                            reweighted_snr, null, rho_coh)
-                    elif nifo == 2:
-                        reweighted_snr = ranking.newsnr(
-                            rho_coinc, network_chisq_dict)
-                    else:
-                        rho_sngl = abs(
-                            snr[args.instruments[0]][
-                                coinc_idx_det_frame[args.instruments[0]]
-                                ]
-                            )
-                        reweighted_snr = ranking.newsnr(
-                            rho_sngl, network_chisq_dict)
-                    # Need all out vals to be the same length. This means the
-                    # entries that are single values need to be repeated once
-                    # per event.
-                    num_events = len(reweighted_snr)
-                    # the output will only be possible if
-                    # len(networkchi2) == num_events
-                    for ifo in args.instruments:
-                        (ifo_out_vals['bank_chisq'],
-                         ifo_out_vals['bank_chisq_dof']) = bank_chisq.values(
-                            template, stilde[ifo].psd, stilde[ifo],
-                            coherent_ifo_trigs[ifo] / norm_dict[ifo],
-                            norm_dict[ifo],
-                            coinc_idx_det_frame[ifo]
-                            + stilde[ifo].analyze.start)
-                        ifo_out_vals['cont_chisq'] = autochisq.values(
-                            snr[ifo] / norm_dict[ifo],
-                            coinc_idx_det_frame[ifo], template,
-                            stilde[ifo].psd, norm_dict[ifo],
-                            stilde=stilde[ifo], low_frequency_cutoff=flow)
-                        ifo_out_vals['chisq'] = chisq[ifo]
-                        ifo_out_vals['chisq_dof'] = chisq_dof[ifo]
-                        ifo_out_vals['time_index'] = (
-                            coinc_idx_det_frame[ifo]
-                            + stilde[ifo].cumulative_index
-                            )
-                        ifo_out_vals['snr'] = coherent_ifo_trigs[ifo]
-                        # IFO is stored as an int
-                        ifo_out_vals['ifo'] = (
-                            [event_mgr.ifo_dict[ifo]] * num_events
-                            )
-                        event_mgr.add_template_events_to_ifo(
-                            ifo, ifo_names,
-                            [ifo_out_vals[n] for n in ifo_names])
-                    if nifo>2:
-                        network_out_vals['coherent_snr'] = np.real(rho_coh)
-                        network_out_vals['null_snr'] = np.real(null)
-                    elif nifo==2:
-                        network_out_vals['coherent_snr'] = np.real(rho_coinc)
-                    else:
-                        network_out_vals['coherent_snr'] = (
-                            abs(snr[args.instruments[0]][
-                                coinc_idx_det_frame[args.instruments[0]]
-                                ])
-                            )
-                    network_out_vals['reweighted_snr'] = reweighted_snr
-                    network_out_vals['my_network_chisq'] = (
-                        np.real(network_chisq_dict))
-                    network_out_vals['time_index'] = (
-                        coinc_idx + stilde[ifo].cumulative_index
                         )
-                    network_out_vals['nifo'] = [nifo] * num_events
-                    network_out_vals['ra'] = [args.ra] * num_events
-                    network_out_vals['dec'] = [args.dec] * num_events
-                    event_mgr.add_template_events_to_network(
-                        network_names,
-                        [network_out_vals[n] for n in network_names])
-            event_mgr.cluster_template_network_events(
-                "time_index", "coherent_snr", cluster_window)
-            event_mgr.finalize_template_events()
-    event_mgr.write_events(args.output)
-    logging.info("Finished")
-    logging.info("Time to complete analysis: %.0f s", time.time() - time_init)
+                    reweighted_snr = ranking.newsnr(
+                        rho_sngl, network_chisq_dict)
+                # Need all out vals to be the same length. This means the
+                # entries that are single values need to be repeated once
+                # per event.
+                num_events = len(reweighted_snr)
+                # the output will only be possible if
+                # len(networkchi2) == num_events
+                for ifo in args.instruments:
+                    (ifo_out_vals['bank_chisq'],
+                     ifo_out_vals['bank_chisq_dof']) = bank_chisq.values(
+                        template, stilde[ifo].psd, stilde[ifo],
+                        coherent_ifo_trigs[ifo] / norm_dict[ifo],
+                        norm_dict[ifo],
+                        coinc_idx_det_frame[ifo] + stilde[ifo].analyze.start)
+                    ifo_out_vals['cont_chisq'] = autochisq.values(
+                        snr[ifo] / norm_dict[ifo], coinc_idx_det_frame[ifo],
+                        template, stilde[ifo].psd, norm_dict[ifo],
+                        stilde=stilde[ifo], low_frequency_cutoff=flow)
+                    ifo_out_vals['chisq'] = chisq[ifo]
+                    ifo_out_vals['chisq_dof'] = chisq_dof[ifo]
+                    ifo_out_vals['time_index'] = (
+                        coinc_idx_det_frame[ifo] + stilde[ifo].cumulative_index
+                        )
+                    ifo_out_vals['snr'] = coherent_ifo_trigs[ifo]
+                    # IFO is stored as an int
+                    ifo_out_vals['ifo'] = (
+                        [event_mgr.ifo_dict[ifo]] * num_events)
+                    event_mgr.add_template_events_to_ifo(
+                        ifo, ifo_names, [ifo_out_vals[n] for n in ifo_names])
+                if nifo>2:
+                    network_out_vals['coherent_snr'] = np.real(rho_coh)
+                    network_out_vals['null_snr'] = np.real(null)
+                elif nifo==2:
+                    network_out_vals['coherent_snr'] = np.real(rho_coinc)
+                else:
+                    network_out_vals['coherent_snr'] = (
+                        abs(snr[args.instruments[0]][
+                            coinc_idx_det_frame[args.instruments[0]]
+                            ])
+                        )
+                network_out_vals['reweighted_snr'] = reweighted_snr
+                network_out_vals['my_network_chisq'] = (
+                    np.real(network_chisq_dict))
+                network_out_vals['time_index'] = (
+                    coinc_idx + stilde[ifo].cumulative_index)
+                network_out_vals['nifo'] = [nifo] * num_events
+                network_out_vals['ra'] = [args.ra] * num_events
+                network_out_vals['dec'] = [args.dec] * num_events
+                event_mgr.add_template_events_to_network(
+                    network_names,
+                    [network_out_vals[n] for n in network_names])
+        event_mgr.cluster_template_network_events(
+            "time_index", "coherent_snr", cluster_window)
+        event_mgr.finalize_template_events()
+event_mgr.write_events(args.output)
+logging.info("Finished")
+logging.info("Time to complete analysis: %.0f s", time.time() - time_init)

--- a/bin/pycbc_multi_inspiral
+++ b/bin/pycbc_multi_inspiral
@@ -16,6 +16,11 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
+"""
+Find multi-detector gravitational wave triggers and calculate the
+coherent SNRs and related statistics.
+"""
+
 import logging
 import time
 from collections import defaultdict
@@ -31,537 +36,536 @@ from pycbc.filter import MatchedFilterControl
 from pycbc.types import TimeSeries, zeros, float32, complex64
 from pycbc.types import MultiDetOptionAction
 from pycbc.vetoes import sgchisq
-
-time_init = time.time()
-
-parser = argparse.ArgumentParser(
-    usage="", description="Find multiple detector gravitational-wave triggers."
-)
-parser.add_argument("-V", "--verbose", action="store_true",
-                    help="print extra debugging information", default=False )
-parser.add_argument("--output", type=str)
-parser.add_argument("--instruments", nargs="+", type=str, required=True,
-                    help="List of instruments to analyze.")
-parser.add_argument("--bank-file", type=str)
-parser.add_argument("--snr-threshold",
-                    help="SNR threshold for trigger generation", type=float)
-parser.add_argument("--newsnr-threshold", type=float, metavar='THRESHOLD',
-                    help="Cut triggers with NewSNR less than THRESHOLD")
-parser.add_argument("--low-frequency-cutoff", type=float,
-                    help="The low frequency cutoff to use for filtering (Hz)")
-
-# add approximant arg
-waveform.bank.add_approximant_arg(parser)
-parser.add_argument("--order", type=str,
-                    help="The integer half-PN order at which to generate"
-                       " the approximant.")
-parser.add_argument("--taper-template", choices=["start", "end", "startend"],
-                    help="For time-domain approximants, taper the start and/or"
-                         " end of the waveform before FFTing.")
-parser.add_argument("--cluster-method", choices=["template", "window"])
-parser.add_argument("--cluster-window", type=float, default = -1,
-                    help="Length of clustering window in seconds.")
-
-parser.add_argument("--bank-veto-bank-file", type=str)
-
-parser.add_argument("--chisq-bins", default=0)
-# Chisq threshold is not implemented, as event_mgr.consolidate_events() is not 
-# called. It's not yet clear how it should be implemented for coherent events.
-# As the option does nothing, remove it for now.
-# parser.add_argument("--chisq-threshold", type=float, default=0) 
-# parser.add_argument("--chisq-delta", type=float, default=0)
-
-parser.add_argument("--autochi-number-points", type=int, default=0)
-parser.add_argument("--autochi-stride", type=int, default=0)
-parser.add_argument("--autochi-onesided", action='store_true', default=False)
-parser.add_argument("--downsample-factor", type=int, default=1,
-                    help="Factor that determines the interval between the "
-                         "initial SNR sampling. If not set (or 1) no sparse "
-                         "sample is created, and the standard full SNR is "
-                         "calculated.")
-parser.add_argument("--upsample-threshold", type=float,
-                    help="The fraction of the SNR threshold to check the "
-                         "sparse SNR sample.")
-parser.add_argument("--upsample-method", choices=["pruned_fft"],
-                    default='pruned_fft',
-                    help="The method to find the SNR points between the "
-                         "sparse SNR sample.")
-parser.add_argument("--user-tag", type=str, metavar="TAG", help="""
-                    This is used to identify FULL_DATA jobs for
-                    compatibility with pipedown post-processing.
-                    Option will be removed when no longer needed.""")
-
-# Arguments added for the coherent stuff
-parser.add_argument("--ra", type=float, help="Right ascension, in radians")
-parser.add_argument("--dec", type=float, help="Declination, in radians")
-parser.add_argument("--coinc-threshold", type=float, default=0.0,
-                    help="Triggers with coincident/coherent snr below this "
-                         "value will be discarded.")
-parser.add_argument("--null-min", type=float, default=5.25,
-                    help="Triggers with null_snr above this value will be"
-                         " discarded.")
-parser.add_argument("--null-grad", type=float, default=0.2,
-                    help="The gradient of the line defining the null cut after"
-                         " the null step.")
-parser.add_argument("--null-step", type=float, default=20.,
-                    help="Triggers with coherent snr above null_step will be "
-                         "cut according to the null_grad and null_min.")
-parser.add_argument("--trigger-time", type=int,
-                    help="Time of the GRB, used to set the antenna patterns.")
-parser.add_argument("--projection", default="standard",
-                    choices=["standard", "left", "right", "left+right"],
-                    help="Choice of projection matrix. 'left' and 'right' " 
-                         "correspond to face-away and face-on")
-
-# Add options groups
-strain.insert_strain_option_group_multi_ifo(parser)
-strain.StrainSegments.insert_segment_option_group_multi_ifo(parser)
-psd.insert_psd_option_group_multi_ifo(parser)
-scheme.insert_processing_option_group(parser)
-fft.insert_fft_option_group(parser)
-opt.insert_optimization_option_group(parser)
-inject.insert_injfilterrejector_option_group_multi_ifo(parser)
-sgchisq.SingleDetSGChisq.insert_option_group(parser)
-args = parser.parse_args()
-
-log_level = logging.DEBUG if args.verbose else logging.INFO
-logging.basicConfig(format='%(asctime)s : %(message)s', level=log_level)
-
-# Use the time in the middle of the segment to calculate the antenna patterns.
-t_gps = args.trigger_time
-# Put the ifos in alphabetical order so they are always called in
-# the same order.
-args.instruments.sort()
-
-strain.verify_strain_options_multi_ifo(args, parser, args.instruments)
-strain.StrainSegments.verify_segment_options_multi_ifo(
-        args, parser, args.instruments)
-psd.verify_psd_options_multi_ifo(args, parser, args.instruments)
-scheme.verify_processing_options(args, parser)
-fft.verify_fft_options(args, parser)
-inj_filter_rejector = inject.InjFilterRejector.from_cli_multi_ifos(
-    args, args.instruments)
-strain_dict = strain.from_cli_multi_ifos(
-    args, args.instruments, inj_filter_rejector, dyn_range_fac=DYN_RANGE_FAC)
-strain_segments_dict = strain.StrainSegments.from_cli_multi_ifos(
-    args, strain_dict, args.instruments)
-ctx = scheme.from_cli(args)
-with ctx:
-    fft.from_cli(args)
-    # Set some often used variables for easy access
-    flow = args.low_frequency_cutoff
-    flow_dict = defaultdict(lambda : flow)
-    for count, ifo in enumerate(args.instruments):
-        if count == 0:
-            sample_rate = strain_dict[ifo].sample_rate
-            sample_rate_dict = defaultdict(lambda : sample_rate)
-            flen = strain_segments_dict[ifo].freq_len
-            flen_dict = defaultdict(lambda : flen)
-            tlen = strain_segments_dict[ifo].time_len
-            tlen_dict = defaultdict(lambda : tlen)
-            delta_f = strain_segments_dict[ifo].delta_f
-            delta_f_dict = defaultdict(lambda : delta_f)
-        else:
-            try:
-                assert(sample_rate == strain_dict[ifo].sample_rate)
-                assert(flen == strain_segments_dict[ifo].freq_len)
-                assert(tlen == strain_segments_dict[ifo].time_len)
-                assert(delta_f == strain_segments_dict[ifo].delta_f)
-            except:
-                err_msg = "Sample rate, frequency length and time length "
-                err_msg += "must all be consistent across ifos."
-                raise ValueError(err_msg)
-
-    logging.info("Making frequency-domain data segments")
-    segments = {
-        ifo: strain_segments_dict[ifo].fourier_segments()
-        for ifo in args.instruments
-        }
-    del strain_segments_dict
-    psd.associate_psds_to_multi_ifo_segments(
-        args, segments, strain_dict, flen, delta_f, flow, args.instruments,
-        dyn_range_factor=DYN_RANGE_FAC, precision='single')
-
-    # Currently we are using the same matched-filter parameters for all ifos.
-    # Therefore only one MatchedFilterControl needed. Maybe this can change if
-    # needed. Segments is only used to get tlen etc. which is same for all
-    # ifos, so just send the first ifo
-    template_mem = zeros(tlen, dtype=complex64)
-
-    # Calculate time delay to each detector
-    time_delay_idx = {}
-    for ifo in args.instruments:
-        dt = detector.Detector(ifo).time_delay_from_earth_center(
-            args.ra, args.dec, t_gps)
-        time_delay_idx[ifo] = int(round(dt * sample_rate))
-
-    # Matched filter each ifo. Don't cluster here for a coherent search.
-    # Clustering happens at the end of the template loop.
-    # FIXME: The single detector SNR threshold should not necessarily be
-    #        applied to every IFO (usually only 2 most sensitive in network)
-    matched_filter = {
-        ifo: MatchedFilterControl(
-            args.low_frequency_cutoff, None, args.snr_threshold, tlen, delta_f,
-            complex64, segments[ifo], template_mem, use_cluster=False,
-            downsample_factor=args.downsample_factor,
-            upsample_threshold=args.upsample_threshold,
-            upsample_method=args.upsample_method,
-            cluster_function='symmetric')
-        for ifo in args.instruments}
-
-    logging.info("Initializing signal-based vetoes.")
-    # The existing SingleDetPowerChisq can calculate the single detector
-    # chisq for multiple ifos, so just use that directly.
-    power_chisq = vetoes.SingleDetPowerChisq(args.chisq_bins)
-    # The existing SingleDetBankVeto can calculate the single detector
-    # bank veto for multiple ifos, so we just use it directly.
-    bank_chisq = vetoes.SingleDetBankVeto(
-        args.bank_veto_bank_file, flen, delta_f, flow, complex64,
-        phase_order=args.order, approximant=args.approximant)
-    # Same here
-    autochisq = vetoes.SingleDetAutoChisq(
-        args.autochi_stride, args.autochi_number_points,
-        onesided=args.autochi_onesided)
-
-    logging.info("Overwhitening frequency-domain data segments")
-    for ifo in args.instruments:
-        for seg in segments[ifo]:
-            seg /= seg.psd
-    ifo_out_types = {
-        'time_index'     : int,
-        'ifo'            : int, # IFO is stored as an int internally!
-        'snr'            : complex64,
-        'chisq'          : float32,
-        'chisq_dof'      : int,
-        'bank_chisq'     : float32,
-        'bank_chisq_dof' : int,
-        'cont_chisq'     : float32,
-        }
-    ifo_out_vals = {
-        'time_index'     : None,
-        'ifo'            : None,
-        'snr'            : None,
-        'chisq'          : None,
-        'chisq_dof'      : None,
-        'bank_chisq'     : None,
-        'bank_chisq_dof' : None,
-        'cont_chisq'     : None,
-        }
-    ifo_names = sorted(ifo_out_vals.keys())
-
-    network_out_types = {
-        'latitude'      : float32,
-        'longitude'     : float32,
-        'time_index'    : int,
-        'coherent_snr'   : float32,
-        'null_snr'      : float32,
-        'nifo'          : int,
-        'my_network_chisq':float32,
-        'reweighted_snr' : float32
-        }
-    network_out_vals = {
-        'latitude'      : None,
-        'longitude'     : None,
-        'time_index'    : None,
-        'coherent_snr'   : None,
-        'null_snr'      : None,
-        'nifo'          : None,
-        'my_network_chisq' : None, 
-        'reweighted_snr' : None
-        }
-    network_names = sorted(network_out_vals.keys())
-
-    event_mgr = EventManagerCoherent(
-        args, args.instruments, ifo_names,
-         [ifo_out_types[n] for n in ifo_names], network_names,
-         [network_out_types[n] for n in network_names])
-
-    logging.info("Read in template bank")
-    bank = waveform.FilterBank(
-        args.bank_file, flen, delta_f, complex64, low_frequency_cutoff=flow,
-        phase_order=args.order, taper=args.taper_template,
-        approximant=args.approximant, out=template_mem)
-
-    # Use injfilterrejector to reduce the bank to only those templates that
-    # might actually find something
-    n_bank = len(bank)
-    nfilters = 0
-
-    logging.info("Full template bank size: %d", n_bank)
-    for ifo in args.instruments:
-        bank.template_thinning(inj_filter_rejector[ifo])
-    if not len(bank) == n_bank:
-        n_bank = len(bank)
-        logging.info("Template bank size after thinning: %d", n_bank)
-
-    fp = {}  # Antenna patterns
-    fc = {}
-    for ifo in args.instruments:
-        fp[ifo], fc[ifo] = detector.Detector(ifo).antenna_pattern(
-            args.ra, args.dec, polarization=0, t_gps=t_gps)
-
-    for t_num, template in enumerate(bank):  # Loop over templates
+if __name__ == '__main__':
+    time_init = time.time()
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("-V", "--verbose", action="store_true",
+                        help="print extra debugging information",
+                        default=False)
+    parser.add_argument("--output", type=str)
+    parser.add_argument("--instruments", nargs="+", type=str, required=True,
+                        help="List of instruments to analyze.")
+    parser.add_argument("--bank-file", type=str)
+    parser.add_argument("--snr-threshold", type=float,
+                        help="SNR threshold for trigger generation")
+    parser.add_argument("--newsnr-threshold", type=float, metavar='THRESHOLD',
+                        help="Cut triggers with NewSNR less than THRESHOLD")
+    parser.add_argument("--low-frequency-cutoff", type=float,
+                        help="The low frequency cutoff to use for filtering "
+                             "(Hz)")
+    # add approximant arg
+    waveform.bank.add_approximant_arg(parser)
+    parser.add_argument("--order", type=str,
+                        help="The integer half-PN order at which to generate"
+                           " the approximant.")
+    parser.add_argument("--taper-template",
+                        choices=["start", "end", "startend"],
+                        help="For time-domain approximants, taper the start "
+                             "and/or end of the waveform before FFTing.")
+    parser.add_argument("--cluster-method", choices=["template", "window"])
+    parser.add_argument("--cluster-window", type=float, default = -1,
+                        help="Length of clustering window in seconds.")
+    parser.add_argument("--bank-veto-bank-file", type=str)
+    parser.add_argument("--chisq-bins", default=0)
+    # Commenting out options which are not yet implemented
+    # parser.add_argument("--chisq-threshold", type=float, default=0) 
+    # parser.add_argument("--chisq-delta", type=float, default=0)
+    parser.add_argument("--autochi-number-points", type=int, default=0)
+    parser.add_argument("--autochi-stride", type=int, default=0)
+    parser.add_argument("--autochi-onesided", action='store_true',
+                        default=False)
+    parser.add_argument("--downsample-factor", type=int, default=1,
+                        help="Factor that determines the interval between the "
+                             "initial SNR sampling. If not set (or 1) no "
+                             "sparse sample is created, and the standard full "
+                             "SNR is calculated.")
+    parser.add_argument("--upsample-threshold", type=float,
+                        help="The fraction of the SNR threshold to check the "
+                             "sparse SNR sample.")
+    parser.add_argument("--upsample-method", choices=["pruned_fft"],
+                        default='pruned_fft',
+                        help="The method to find the SNR points between the "
+                             "sparse SNR sample.")
+    parser.add_argument("--user-tag", type=str, metavar="TAG", help="""
+                        This is used to identify FULL_DATA jobs for
+                        compatibility with pipedown post-processing.
+                        Option will be removed when no longer needed.""")
+    # Arguments added for the coherent stuff
+    parser.add_argument("--ra", type=float, help="Right ascension, in radians")
+    parser.add_argument("--dec", type=float, help="Declination, in radians")
+    parser.add_argument("--coinc-threshold", type=float, default=0.0,
+                        help="Triggers with coincident/coherent snr below "
+                             "this value will be discarded.")
+    parser.add_argument("--null-min", type=float, default=5.25,
+                        help="Triggers with null_snr above this value will be"
+                             " discarded.")
+    parser.add_argument("--null-grad", type=float, default=0.2,
+                        help="The gradient of the line defining the null cut "
+                             "after the null step.")
+    parser.add_argument("--null-step", type=float, default=20.,
+                        help="Triggers with coherent snr above null_step will "
+                             "be cut according to the null_grad and null_min.")
+    parser.add_argument("--trigger-time", type=int,
+                        help="Time of the GRB, used to set the antenna "
+                             "patterns.")
+    parser.add_argument("--projection", default="standard",
+                        choices=["standard", "left", "right", "left+right"],
+                        help="Choice of projection matrix. 'left' and 'right' " 
+                             "correspond to face-away and face-on")
+    # Add options groups
+    strain.insert_strain_option_group_multi_ifo(parser)
+    strain.StrainSegments.insert_segment_option_group_multi_ifo(parser)
+    psd.insert_psd_option_group_multi_ifo(parser)
+    scheme.insert_processing_option_group(parser)
+    fft.insert_fft_option_group(parser)
+    opt.insert_optimization_option_group(parser)
+    inject.insert_injfilterrejector_option_group_multi_ifo(parser)
+    sgchisq.SingleDetSGChisq.insert_option_group(parser)
+    args = parser.parse_args()
+    log_level = logging.DEBUG if args.verbose else logging.INFO
+    logging.basicConfig(format='%(asctime)s : %(message)s', level=log_level)
+    # Set GRB time variable for convenience
+    t_gps = args.trigger_time
+    # Put the ifos in alphabetical order so they are always called in
+    # the same order.
+    args.instruments.sort()
+    strain.verify_strain_options_multi_ifo(args, parser, args.instruments)
+    strain.StrainSegments.verify_segment_options_multi_ifo(
+            args, parser, args.instruments)
+    psd.verify_psd_options_multi_ifo(args, parser, args.instruments)
+    scheme.verify_processing_options(args, parser)
+    fft.verify_fft_options(args, parser)
+    inj_filter_rejector = inject.InjFilterRejector.from_cli_multi_ifos(
+        args, args.instruments)
+    strain_dict = strain.from_cli_multi_ifos(
+        args, args.instruments, inj_filter_rejector,
+        dyn_range_fac=DYN_RANGE_FAC)
+    strain_segments_dict = strain.StrainSegments.from_cli_multi_ifos(
+        args, strain_dict, args.instruments)
+    ctx = scheme.from_cli(args)
+    with ctx:
+        fft.from_cli(args)
+        # Set some often used variables for easy access
+        flow = args.low_frequency_cutoff
+        flow_dict = defaultdict(lambda : flow)
+        for count, ifo in enumerate(args.instruments):
+            if count == 0:
+                sample_rate = strain_dict[ifo].sample_rate
+                sample_rate_dict = defaultdict(lambda : sample_rate)
+                flen = strain_segments_dict[ifo].freq_len
+                flen_dict = defaultdict(lambda : flen)
+                tlen = strain_segments_dict[ifo].time_len
+                tlen_dict = defaultdict(lambda : tlen)
+                delta_f = strain_segments_dict[ifo].delta_f
+                delta_f_dict = defaultdict(lambda : delta_f)
+            else:
+                try:
+                    assert(sample_rate == strain_dict[ifo].sample_rate)
+                    assert(flen == strain_segments_dict[ifo].freq_len)
+                    assert(tlen == strain_segments_dict[ifo].time_len)
+                    assert(delta_f == strain_segments_dict[ifo].delta_f)
+                except:
+                    err_msg = "Sample rate, frequency length and time length "
+                    err_msg += "must all be consistent across ifos."
+                    raise ValueError(err_msg)
+        logging.info("Making frequency-domain data segments")
+        segments = {
+            ifo: strain_segments_dict[ifo].fourier_segments()
+            for ifo in args.instruments
+            }
+        del strain_segments_dict
+        psd.associate_psds_to_multi_ifo_segments(
+            args, segments, strain_dict, flen, delta_f, flow, args.instruments,
+            dyn_range_factor=DYN_RANGE_FAC, precision='single')
+        # Currently we are using the same matched-filter parameters for all
+        # ifos. Therefore only one MatchedFilterControl needed. Maybe this can
+        # change if needed. Segments is only used to get tlen etc. which is
+        # same for all ifos, so just send the first ifo
+        template_mem = zeros(tlen, dtype=complex64)
+        # Calculate time delay to each detector
+        time_delay_idx = {}
         for ifo in args.instruments:
-            if args.cluster_method == "window":
-                cluster_window = int(args.cluster_window * sample_rate)
-            elif args.cluster_method == "template":
-                cluster_window = int(template.chirp_length * sample_rate)
-            elif args.cluster_window == 0:
-                 cluster_window = int(0)
-
-        # Loop over segments
-        for s_num,stilde in enumerate(segments[args.instruments[0]]):
-            stilde = {ifo : segments[ifo][s_num] for ifo in args.instruments}
-            # Filter check checks the 'inj_filter_rejector' options to
-            # determine whether to filter this template/segment 
-            # if injections are present.
-            analyse_segment = True
+            dt = detector.Detector(ifo).time_delay_from_earth_center(
+                args.ra, args.dec, t_gps)
+            time_delay_idx[ifo] = int(round(dt * sample_rate))
+        # Matched filter each ifo. Don't cluster here for a coherent search.
+        # Clustering happens at the end of the template loop.
+        # FIXME: The single detector SNR threshold should not necessarily be
+        #        applied to every IFO (usually only 2 most sensitive in
+        #        network)
+        matched_filter = {
+            ifo: MatchedFilterControl(
+                args.low_frequency_cutoff, None, args.snr_threshold, tlen,
+                delta_f, complex64, segments[ifo], template_mem,
+                use_cluster=False, downsample_factor=args.downsample_factor,
+                upsample_threshold=args.upsample_threshold,
+                upsample_method=args.upsample_method,
+                cluster_function='symmetric')
+            for ifo in args.instruments}
+        logging.info("Initializing signal-based vetoes.")
+        # The existing SingleDetPowerChisq can calculate the single detector
+        # chisq for multiple ifos, so just use that directly.
+        power_chisq = vetoes.SingleDetPowerChisq(args.chisq_bins)
+        # The existing SingleDetBankVeto can calculate the single detector
+        # bank veto for multiple ifos, so we just use it directly.
+        bank_chisq = vetoes.SingleDetBankVeto(
+            args.bank_veto_bank_file, flen, delta_f, flow, complex64,
+            phase_order=args.order, approximant=args.approximant)
+        # Same here
+        autochisq = vetoes.SingleDetAutoChisq(
+            args.autochi_stride, args.autochi_number_points,
+            onesided=args.autochi_onesided)
+        logging.info("Overwhitening frequency-domain data segments")
+        for ifo in args.instruments:
+            for seg in segments[ifo]:
+                seg /= seg.psd
+        ifo_out_types = {
+            'time_index'     : int,
+            'ifo'            : int, # IFO is stored as an int internally!
+            'snr'            : complex64,
+            'chisq'          : float32,
+            'chisq_dof'      : int,
+            'bank_chisq'     : float32,
+            'bank_chisq_dof' : int,
+            'cont_chisq'     : float32,
+            }
+        ifo_out_vals = {
+            'time_index'     : None,
+            'ifo'            : None,
+            'snr'            : None,
+            'chisq'          : None,
+            'chisq_dof'      : None,
+            'bank_chisq'     : None,
+            'bank_chisq_dof' : None,
+            'cont_chisq'     : None,
+            }
+        ifo_names = sorted(ifo_out_vals.keys())
+        network_out_types = {
+            'latitude'      : float32,
+            'longitude'     : float32,
+            'time_index'    : int,
+            'coherent_snr'   : float32,
+            'null_snr'      : float32,
+            'nifo'          : int,
+            'my_network_chisq':float32,
+            'reweighted_snr' : float32
+            }
+        network_out_vals = {
+            'latitude'      : None,
+            'longitude'     : None,
+            'time_index'    : None,
+            'coherent_snr'   : None,
+            'null_snr'      : None,
+            'nifo'          : None,
+            'my_network_chisq' : None, 
+            'reweighted_snr' : None
+            }
+        network_names = sorted(network_out_vals.keys())
+        event_mgr = EventManagerCoherent(
+            args, args.instruments, ifo_names,
+             [ifo_out_types[n] for n in ifo_names], network_names,
+             [network_out_types[n] for n in network_names])
+        logging.info("Read in template bank")
+        bank = waveform.FilterBank(
+            args.bank_file, flen, delta_f, complex64,
+            low_frequency_cutoff=flow, phase_order=args.order,
+            taper=args.taper_template, approximant=args.approximant,
+            out=template_mem)
+        # Use injfilterrejector to reduce the bank to only those templates that
+        # might actually find something
+        n_bank = len(bank)
+        nfilters = 0
+        logging.info("Full template bank size: %d", n_bank)
+        for ifo in args.instruments:
+            bank.template_thinning(inj_filter_rejector[ifo])
+        if not len(bank) == n_bank:
+            n_bank = len(bank)
+            logging.info("Template bank size after thinning: %d", n_bank)
+        # Antenna patterns
+        fp = {}
+        fc = {}
+        for ifo in args.instruments:
+            fp[ifo], fc[ifo] = detector.Detector(ifo).antenna_pattern(
+                args.ra, args.dec, polarization=0, t_gps=t_gps)
+        # Loop over templates
+        for t_num, template in enumerate(bank):
             for ifo in args.instruments:
-                if not inj_filter_rejector[ifo].template_segment_checker(
-                        bank, t_num, stilde[ifo]):
-                    logging.info(
-                        "Skipping segment %d/%d with template %d/%d as no "
-                        "detectable injection is present",
-                        s_num + 1, len(segments[ifo]), t_num + 1, n_bank)
-                    analyse_segment = False
-            #Find detector sensitivities (sigma) and make array of normalised
-            sigmasq = {
-                ifo : template.sigmasq(segments[ifo][s_num].psd)
-                for ifo in args.instruments}
-            sigma = {ifo : np.sqrt(sigmasq[ifo]) for ifo in args.instruments}
-            # Every time s_num is zero or we skip the segment, we run new 
-            # template to increment the template index
-            if s_num==0:
-                event_mgr.new_template(tmplt=template.params, sigmasq=sigmasq)
-            if not analyse_segment: continue
-            logging.info(
-                "Analyzing segment %d/%d", s_num + 1, len(segments[ifo]))
-            snr_dict = dict.fromkeys(args.instruments)
-            norm_dict = dict.fromkeys(args.instruments)
-            corr_dict = dict.fromkeys(args.instruments)
-            idx = dict.fromkeys(args.instruments)
-            snrv_dict = dict.fromkeys(args.instruments)
-            snr = dict.fromkeys(args.instruments)
-            ifo_list = args.instruments[:]
-            for ifo in args.instruments:
-                logging.info(
-                    "Filtering template %d/%d, ifo %s", t_num + 1, n_bank, ifo)
-                # No clustering in the coherent search until the end.
-                # The correlation vector is the FFT of the snr (so inverse FFT
-                # it to get the snr). 
-                snr_ts, norm, corr, ind, snrv = \
-                     matched_filter[ifo].matched_filter_and_cluster(
-                         s_num, template.sigmasq(stilde[ifo].psd), window=0)
-                snr_dict[ifo] = (
-                        snr_ts[matched_filter[ifo].segments[s_num].analyze]
-                        * norm)
-                norm_dict[ifo] = copy(norm)
-                corr_dict[ifo] = copy(corr)
-                idx[ifo] = copy(ind)
-                snrv_dict[ifo] = copy(snrv)
-                snr[ifo] = snrv * norm
-            # Move onto next segment if there are no triggers.
-            if len(ifo_list)==0: continue
-            # Save the indexes of triggers (if we have any)
-            # Even if we have none, need to keep an empty dictionary.
-            # Only do this is idx doesn't get time shifted out of the time
-            # we are looking at.
-            idx_dict = {
-                ifo: idx[ifo][np.logical_and(
-                    idx[ifo] > time_delay_idx[ifo],
-                    idx[ifo] - time_delay_idx[ifo] < len(snr_dict[ifo])
-                    )
-                ]
-                for ifo in args.instruments}
-            # Find triggers that are coincident (in geocent time) in multiple
-            # ifos. If a single ifo analysis then just use the indexes from
-            # that ifo.
-            if len(args.instruments) > 1:
-                coinc_idx = coh.get_coinc_indexes(idx_dict, time_delay_idx)
-            else:
-                coinc_idx = (
-                    idx_dict[args.instruments[0]]
-                    - time_delay_idx[args.instruments[0]]
-                    )
-            logging.info("Found %d coincident triggers", len(coinc_idx))
-            # Number of ifos
-            nifo = len(args.instruments)
-            for ifo in args.instruments:
-                # Move on if this segment has no data
-                if len(snr_dict[ifo])==0:
-                    raise ValueError('The SNR triggers dictionary is empty. '
-                                     'This should not be possible.')
-                # Time delay is applied to indices
-                coinc_idx_det_frame = {
-                    ifo: coinc_idx + time_delay_idx[ifo]
-                    for ifo in args.instruments}
-            # Calculate the coincident and coherent snr
-            # Check we have data before we try to compute the coherent snr
-            if len(coinc_idx) != 0 and nifo > 1:
-                #Find coinc snr at trigger times and apply coinc snr threshold
-                rho_coinc, coinc_idx, coinc_triggers = coh.coincident_snr(
-                    snr_dict, coinc_idx, args.coinc_threshold, time_delay_idx)
-                logging.info(
-                    "%d points above coincident SNR threshold", len(coinc_idx))
-                if len(coinc_idx) != 0:
-                    logging.info("Max coincident SNR = %.2f", max(rho_coinc))
-            # If there is only one ifo, then coinc_triggers is just the
-            # triggers from ifo
-            elif len(coinc_idx) != 0 and nifo == 1:
-                coinc_triggers = {
-                    args.instruments[0]: snr[args.instruments[0]][
-                        coinc_idx_det_frame[args.instruments[0]]
-                        ]
-                    }
-            else:
-                coinc_triggers = {}
-                logging.info("No triggers above coincident SNR threshold")
-
-            # If we have triggers above coinc threshold and more than 2 ifos
-            # then calculate the coherent statistics
-            if len(coinc_idx) != 0 and nifo > 2:
-                if args.projection=='left+right':
-                    project_l = coh.get_projection_matrix(
-                        fp, fc, sigma, projection='left')
-                    rho_coh_l, coinc_idx_l, coinc_triggers_l, rho_coinc_l = \
-                        coh.coherent_snr(
-                            coinc_triggers, coinc_idx, args.coinc_threshold,
-                            project_l, rho_coinc)
-                    project_r = coh.get_projection_matrix(
-                        fp, fc, sigma, projection='right')
-                    rho_coh_r, coinc_idx_r, coinc_triggers_r, rho_coinc_r = \
-                        coh.coherent_snr(
-                            coinc_triggers, coinc_idx, args.coinc_threshold,
-                            project_r, rho_coinc)
-                    max_idx = np.argmax([rho_coh_l, rho_coh_r], axis=0)
-                    rho_coh = np.where(max_idx==0, rho_coh_l, rho_coh_r)
-                    coinc_idx = np.where(max_idx==0, coinc_idx_l, coinc_idx_r)
-                    coinc_triggers = np.where(
-                        max_idx==0, coinc_triggers_l, coinc_triggers_r)
-                    rho_coinc = np.where(max_idx==0, rho_coinc_l, rho_coinc_r)
-                else:
-                    project = coh.get_projection_matrix(
-                        fp, fc, sigma, projection=args.projection)
-                    rho_coh, coinc_idx, coinc_triggers, rho_coinc = \
-                        coh.coherent_snr(
-                            coinc_triggers, coinc_idx, args.coinc_threshold,
-                            project, rho_coinc)
-                logging.info(
-                    "%d points above coherent threshold", len(rho_coh))
-                if len(coinc_idx) != 0:
-                    logging.info("Max coherent SNR = %.2f", max(rho_coh))
-                    #Find the null snr
-                    null, rho_coh, rho_coinc, coinc_idx, coinc_triggers =\
-                        coh.null_snr(
-                            rho_coh, rho_coinc, snrv=coinc_triggers,
-                            index=coinc_idx)
-                    if len(coinc_idx) != 0:
-                        logging.info("Max null SNR = %.2f", max(null))
-                    logging.info(
-                        "%d points above null threshold", len(null))
-
-            # We are now going to find the individual detector chi2 values.
-            # To do this it is useful to find the indexes of coinc triggers
-            # in the detector frame.
-            if len(coinc_idx) != 0:
-                # coinc_idx_det_frame is redefined to account for the cuts to
-                # coinc_idx above
-                coinc_idx_det_frame = {
-                    ifo: coinc_idx + time_delay_idx[ifo]
-                    for ifo in args.instruments}
-                coherent_ifo_trigs = {
-                    ifo: snr_dict[ifo][coinc_idx_det_frame[ifo]]
-                    for ifo in args.instruments}
-                # Calculate the power and autochi2 values for the coinc indexes
-                # (this uses the snr timeseries before the time delay, so we
-                # need to undo it. Same for normalisation)
-                chisq = {}
-                chisq_dof = {}
+                if args.cluster_method == "window":
+                    cluster_window = int(args.cluster_window * sample_rate)
+                elif args.cluster_method == "template":
+                    cluster_window = int(template.chirp_length * sample_rate)
+                elif args.cluster_window == 0:
+                     cluster_window = int(0)
+            # Loop over segments
+            for s_num,stilde in enumerate(segments[args.instruments[0]]):
+                stilde = {
+                    ifo : segments[ifo][s_num] for ifo in args.instruments}
+                # Filter check checks the 'inj_filter_rejector' options to
+                # determine whether to filter this template/segment 
+                # if injections are present.
+                analyse_segment = True
                 for ifo in args.instruments:
-                    chisq[ifo], chisq_dof[ifo] = power_chisq.values(
-                        corr_dict[ifo],
-                        coherent_ifo_trigs[ifo] / norm_dict[ifo],
-                        norm_dict[ifo], stilde[ifo].psd,
-                        coinc_idx_det_frame[ifo] + stilde[ifo].analyze.start,
-                        template)
-                # Calculate network chisq value
-                network_chisq_dict = coh.network_chisq(
-                    chisq, chisq_dof, coherent_ifo_trigs)
-                # Calculate chisq reweighted SNR
-                if nifo > 2:
-                    reweighted_snr = coh.reweighted_snr(
-                        rho_coh, network_chisq_dict)
-                    # Calculate null reweighted SNR
-                    reweighted_snr = coh.reweight_snr_by_null(
-                        reweighted_snr, null)
-                elif nifo == 2:
-                    reweighted_snr = coh.reweighted_snr(
-                        rho_coinc, network_chisq_dict)
+                    if not inj_filter_rejector[ifo].template_segment_checker(
+                            bank, t_num, stilde[ifo]):
+                        logging.info(
+                            "Skipping segment %d/%d with template %d/%d as no "
+                            "detectable injection is present",
+                            s_num + 1, len(segments[ifo]), t_num + 1, n_bank)
+                        analyse_segment = False
+                # Find detector sensitivities (sigma) and make array of
+                # normalised
+                sigmasq = {
+                    ifo : template.sigmasq(segments[ifo][s_num].psd)
+                    for ifo in args.instruments}
+                sigma = {
+                    ifo : np.sqrt(sigmasq[ifo]) for ifo in args.instruments}
+                # Every time s_num is zero or we skip the segment, we run new 
+                # template to increment the template index
+                if s_num==0:
+                    event_mgr.new_template(
+                        tmplt=template.params, sigmasq=sigmasq)
+                if not analyse_segment: continue
+                logging.info(
+                    "Analyzing segment %d/%d", s_num + 1, len(segments[ifo]))
+                snr_dict = dict.fromkeys(args.instruments)
+                norm_dict = dict.fromkeys(args.instruments)
+                corr_dict = dict.fromkeys(args.instruments)
+                idx = dict.fromkeys(args.instruments)
+                snrv_dict = dict.fromkeys(args.instruments)
+                snr = dict.fromkeys(args.instruments)
+                ifo_list = args.instruments[:]
+                for ifo in args.instruments:
+                    logging.info(
+                        "Filtering template %d/%d, ifo %s", t_num + 1, n_bank,
+                        ifo)
+                    # No clustering in the coherent search until the end.
+                    # The correlation vector is the FFT of the snr (so inverse
+                    # FFT it to get the snr). 
+                    snr_ts, norm, corr, ind, snrv = \
+                         matched_filter[ifo].matched_filter_and_cluster(
+                             s_num, template.sigmasq(stilde[ifo].psd),
+                             window=0)
+                    snr_dict[ifo] = (
+                            snr_ts[matched_filter[ifo].segments[s_num].analyze]
+                            * norm)
+                    norm_dict[ifo] = copy(norm)
+                    corr_dict[ifo] = copy(corr)
+                    idx[ifo] = copy(ind)
+                    snrv_dict[ifo] = copy(snrv)
+                    snr[ifo] = snrv * norm
+                # Move onto next segment if there are no triggers.
+                if len(ifo_list)==0: continue
+                # Save the indexes of triggers (if we have any)
+                # Even if we have none, need to keep an empty dictionary.
+                # Only do this is idx doesn't get time shifted out of the time
+                # we are looking at.
+                idx_dict = {
+                    ifo: idx[ifo][np.logical_and(
+                        idx[ifo] > time_delay_idx[ifo],
+                        idx[ifo] - time_delay_idx[ifo] < len(snr_dict[ifo])
+                        )
+                    ]
+                    for ifo in args.instruments}
+                # Find triggers that are coincident (in geocent time) in
+                # multiple ifos. If a single ifo analysis then just use the
+                # indexes from that ifo.
+                if len(args.instruments) > 1:
+                    coinc_idx = coh.get_coinc_indexes(idx_dict, time_delay_idx)
                 else:
-                    rho_sngl = abs(
-                        snr[args.instruments[0]][
+                    coinc_idx = (
+                        idx_dict[args.instruments[0]]
+                        - time_delay_idx[args.instruments[0]]
+                        )
+                logging.info("Found %d coincident triggers", len(coinc_idx))
+                # Number of ifos
+                nifo = len(args.instruments)
+                for ifo in args.instruments:
+                    # Move on if this segment has no data
+                    if len(snr_dict[ifo])==0:
+                        raise ValueError(
+                            'The SNR triggers dictionary is empty. This '
+                            'should not be possible.')
+                    # Time delay is applied to indices
+                    coinc_idx_det_frame = {
+                        ifo: coinc_idx + time_delay_idx[ifo]
+                        for ifo in args.instruments}
+                # Calculate the coincident and coherent snr
+                # Check we have data before we try to compute the coherent snr
+                if len(coinc_idx) != 0 and nifo > 1:
+                    # Find coinc snr at trigger times and apply coinc snr
+                    # threshold
+                    rho_coinc, coinc_idx, coinc_triggers = coh.coincident_snr(
+                        snr_dict, coinc_idx, args.coinc_threshold,
+                        time_delay_idx)
+                    logging.info(
+                        "%d points above coincident SNR threshold",
+                        len(coinc_idx))
+                    if len(coinc_idx) != 0:
+                        logging.info(
+                            "Max coincident SNR = %.2f", max(rho_coinc))
+                # If there is only one ifo, then coinc_triggers is just the
+                # triggers from ifo
+                elif len(coinc_idx) != 0 and nifo == 1:
+                    coinc_triggers = {
+                        args.instruments[0]: snr[args.instruments[0]][
                             coinc_idx_det_frame[args.instruments[0]]
                             ]
-                        )
-                    reweighted_snr = coh.reweighted_snr(
-                        rho_sngl, network_chisq_dict)
-                # Need all out vals to be the same length. This means the
-                # entries that are single values need to be repeated once
-                # per event.
-                num_events = len(reweighted_snr)
-                # the output will only be possible if
-                # len(networkchi2) == num_events
-                for ifo in args.instruments:
-                    (ifo_out_vals['bank_chisq'],
-                     ifo_out_vals['bank_chisq_dof']) = bank_chisq.values(
-                        template, stilde[ifo].psd, stilde[ifo],
-                        coherent_ifo_trigs[ifo] / norm_dict[ifo],
-                        norm_dict[ifo],
-                        coinc_idx_det_frame[ifo] + stilde[ifo].analyze.start)
-                    ifo_out_vals['cont_chisq'] = autochisq.values(
-                        snr[ifo] / norm_dict[ifo], coinc_idx_det_frame[ifo],
-                        template, stilde[ifo].psd, norm_dict[ifo],
-                        stilde=stilde[ifo], low_frequency_cutoff=flow)
-                    ifo_out_vals['chisq'] = chisq[ifo]
-                    ifo_out_vals['chisq_dof'] = chisq_dof[ifo]
-                    ifo_out_vals['time_index'] = (
-                        coinc_idx_det_frame[ifo]
-                        + stilde[ifo].cumulative_index
-                        )
-                    ifo_out_vals['snr'] = coherent_ifo_trigs[ifo]
-                    # IFO is stored as an int
-                    ifo_out_vals['ifo'] = (
-                        [event_mgr.ifo_dict[ifo]] * num_events
-                        )
-                    event_mgr.add_template_events_to_ifo(
-                        ifo, ifo_names, [ifo_out_vals[n] for n in ifo_names])
-                if nifo>2:
-                    network_out_vals['coherent_snr'] = np.real(rho_coh)
-                    network_out_vals['null_snr'] = np.real(null)
-                elif nifo==2:
-                    network_out_vals['coherent_snr'] = np.real(rho_coinc)
+                        }
                 else:
-                    network_out_vals['coherent_snr'] = (
-                        abs(snr[args.instruments[0]][
-                            coinc_idx_det_frame[args.instruments[0]]
-                            ])
-                        )
-                network_out_vals['reweighted_snr'] = reweighted_snr
-                network_out_vals['my_network_chisq'] = (
-                    np.real(network_chisq_dict))
-                network_out_vals['time_index'] = (
-                    coinc_idx + stilde[ifo].cumulative_index
-                    )
-                network_out_vals['nifo'] = [nifo] * num_events
-                network_out_vals['ra'] = [args.ra] * num_events
-                network_out_vals['dec'] = [args.dec] * num_events
-                event_mgr.add_template_events_to_network(
-                    network_names,
-                    [network_out_vals[n] for n in network_names])
-        event_mgr.cluster_template_network_events(
-            "time_index", "coherent_snr", cluster_window)
-        event_mgr.finalize_template_events()
-event_mgr.write_events(args.output)
+                    coinc_triggers = {}
+                    logging.info("No triggers above coincident SNR threshold")
 
-logging.info("Finished")
-logging.info("Time to complete analysis: %d", int(time.time() - time_init))
+                # If we have triggers above coinc threshold and more than 2
+                # ifos then calculate the coherent statistics
+                if len(coinc_idx) != 0 and nifo > 2:
+                    if args.projection=='left+right':
+                        project_l = coh.get_projection_matrix(
+                            fp, fc, sigma, projection='left')
+                        (rho_coh_l, coinc_idx_l, coinc_triggers_l,
+                            rho_coinc_l) = coh.coherent_snr(
+                                coinc_triggers, coinc_idx,
+                                args.coinc_threshold, project_l, rho_coinc)
+                        project_r = coh.get_projection_matrix(
+                            fp, fc, sigma, projection='right')
+                        (rho_coh_r, coinc_idx_r, coinc_triggers_r,
+                            rho_coinc_r) = coh.coherent_snr(
+                                coinc_triggers, coinc_idx,
+                                args.coinc_threshold, project_r, rho_coinc)
+                        max_idx = np.argmax([rho_coh_l, rho_coh_r], axis=0)
+                        rho_coh = np.where(max_idx==0, rho_coh_l, rho_coh_r)
+                        coinc_idx = np.where(
+                            max_idx==0, coinc_idx_l, coinc_idx_r)
+                        coinc_triggers = np.where(
+                            max_idx==0, coinc_triggers_l, coinc_triggers_r)
+                        rho_coinc = np.where(
+                            max_idx==0, rho_coinc_l, rho_coinc_r)
+                    else:
+                        project = coh.get_projection_matrix(
+                            fp, fc, sigma, projection=args.projection)
+                        rho_coh, coinc_idx, coinc_triggers, rho_coinc = \
+                            coh.coherent_snr(
+                                coinc_triggers, coinc_idx,
+                                args.coinc_threshold, project, rho_coinc)
+                    logging.info(
+                        "%d points above coherent threshold", len(rho_coh))
+                    if len(coinc_idx) != 0:
+                        logging.info("Max coherent SNR = %.2f", max(rho_coh))
+                        #Find the null snr
+                        null, rho_coh, rho_coinc, coinc_idx, coinc_triggers =\
+                            coh.null_snr(
+                                rho_coh, rho_coinc, snrv=coinc_triggers,
+                                index=coinc_idx)
+                        if len(coinc_idx) != 0:
+                            logging.info("Max null SNR = %.2f", max(null))
+                        logging.info(
+                            "%d points above null threshold", len(null))
+
+                # We are now going to find the individual detector chi2 values.
+                # To do this it is useful to find the indexes of coinc triggers
+                # in the detector frame.
+                if len(coinc_idx) != 0:
+                    # coinc_idx_det_frame is redefined to account for the cuts
+                    # to coinc_idx above
+                    coinc_idx_det_frame = {
+                        ifo: coinc_idx + time_delay_idx[ifo]
+                        for ifo in args.instruments}
+                    coherent_ifo_trigs = {
+                        ifo: snr_dict[ifo][coinc_idx_det_frame[ifo]]
+                        for ifo in args.instruments}
+                    # Calculate the power and autochi2 values for the coinc
+                    # indexes this uses the snr timeseries before the time
+                    # delay, so we need to undo it. Same for normalisation)
+                    chisq = {}
+                    chisq_dof = {}
+                    for ifo in args.instruments:
+                        chisq[ifo], chisq_dof[ifo] = power_chisq.values(
+                            corr_dict[ifo],
+                            coherent_ifo_trigs[ifo] / norm_dict[ifo],
+                            norm_dict[ifo], stilde[ifo].psd,
+                            coinc_idx_det_frame[ifo]
+                            + stilde[ifo].analyze.start,
+                            template)
+                    # Calculate network chisq value
+                    network_chisq_dict = coh.network_chisq(
+                        chisq, chisq_dof, coherent_ifo_trigs)
+                    # Calculate chisq reweighted SNR
+                    if nifo > 2:
+                        reweighted_snr = coh.reweighted_snr(
+                            rho_coh, network_chisq_dict)
+                        # Calculate null reweighted SNR
+                        reweighted_snr = coh.reweight_snr_by_null(
+                            reweighted_snr, null)
+                    elif nifo == 2:
+                        reweighted_snr = coh.reweighted_snr(
+                            rho_coinc, network_chisq_dict)
+                    else:
+                        rho_sngl = abs(
+                            snr[args.instruments[0]][
+                                coinc_idx_det_frame[args.instruments[0]]
+                                ]
+                            )
+                        reweighted_snr = coh.reweighted_snr(
+                            rho_sngl, network_chisq_dict)
+                    # Need all out vals to be the same length. This means the
+                    # entries that are single values need to be repeated once
+                    # per event.
+                    num_events = len(reweighted_snr)
+                    # the output will only be possible if
+                    # len(networkchi2) == num_events
+                    for ifo in args.instruments:
+                        (ifo_out_vals['bank_chisq'],
+                         ifo_out_vals['bank_chisq_dof']) = bank_chisq.values(
+                            template, stilde[ifo].psd, stilde[ifo],
+                            coherent_ifo_trigs[ifo] / norm_dict[ifo],
+                            norm_dict[ifo],
+                            coinc_idx_det_frame[ifo]
+                            + stilde[ifo].analyze.start)
+                        ifo_out_vals['cont_chisq'] = autochisq.values(
+                            snr[ifo] / norm_dict[ifo],
+                            coinc_idx_det_frame[ifo], template,
+                            stilde[ifo].psd, norm_dict[ifo],
+                            stilde=stilde[ifo], low_frequency_cutoff=flow)
+                        ifo_out_vals['chisq'] = chisq[ifo]
+                        ifo_out_vals['chisq_dof'] = chisq_dof[ifo]
+                        ifo_out_vals['time_index'] = (
+                            coinc_idx_det_frame[ifo]
+                            + stilde[ifo].cumulative_index
+                            )
+                        ifo_out_vals['snr'] = coherent_ifo_trigs[ifo]
+                        # IFO is stored as an int
+                        ifo_out_vals['ifo'] = (
+                            [event_mgr.ifo_dict[ifo]] * num_events
+                            )
+                        event_mgr.add_template_events_to_ifo(
+                            ifo, ifo_names,
+                            [ifo_out_vals[n] for n in ifo_names])
+                    if nifo>2:
+                        network_out_vals['coherent_snr'] = np.real(rho_coh)
+                        network_out_vals['null_snr'] = np.real(null)
+                    elif nifo==2:
+                        network_out_vals['coherent_snr'] = np.real(rho_coinc)
+                    else:
+                        network_out_vals['coherent_snr'] = (
+                            abs(snr[args.instruments[0]][
+                                coinc_idx_det_frame[args.instruments[0]]
+                                ])
+                            )
+                    network_out_vals['reweighted_snr'] = reweighted_snr
+                    network_out_vals['my_network_chisq'] = (
+                        np.real(network_chisq_dict))
+                    network_out_vals['time_index'] = (
+                        coinc_idx + stilde[ifo].cumulative_index
+                        )
+                    network_out_vals['nifo'] = [nifo] * num_events
+                    network_out_vals['ra'] = [args.ra] * num_events
+                    network_out_vals['dec'] = [args.dec] * num_events
+                    event_mgr.add_template_events_to_network(
+                        network_names,
+                        [network_out_vals[n] for n in network_names])
+            event_mgr.cluster_template_network_events(
+                "time_index", "coherent_snr", cluster_window)
+            event_mgr.finalize_template_events()
+    event_mgr.write_events(args.output)
+
+    logging.info("Finished")
+    logging.info("Time to complete analysis: %d", int(time.time() - time_init))

--- a/bin/pycbc_multi_inspiral
+++ b/bin/pycbc_multi_inspiral
@@ -16,26 +16,26 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-
 import logging
+import time
 from collections import defaultdict
 import argparse
-from pycbc import vetoes, psd, waveform, events, strain, scheme, fft,\
+import numpy as np
+from pycbc import (
+    detector, fft, inject, opt, psd, scheme, strain, vetoes, waveform,
     DYN_RANGE_FAC
-from pycbc.vetoes import sgchisq
+)
 from pycbc.events import coherent as coh, EventManagerCoherent
 from pycbc.filter import MatchedFilterControl
 from pycbc.types import TimeSeries, zeros, float32, complex64
 from pycbc.types import MultiDetOptionAction
-import pycbc.detector
-import numpy as np
-
-import time
+from pycbc.vetoes import sgchisq
 
 time_init = time.time()
 
-parser = argparse.ArgumentParser(usage='',
-    description="Find multiple detector gravitational-wave triggers.")
+parser = argparse.ArgumentParser(
+    usage="", description="Find multiple detector gravitational-wave triggers."
+)
 parser.add_argument("-V", "--verbose", action="store_true",
                     help="print extra debugging information", default=False )
 parser.add_argument("--output", type=str)
@@ -118,44 +118,39 @@ strain.StrainSegments.insert_segment_option_group_multi_ifo(parser)
 psd.insert_psd_option_group_multi_ifo(parser)
 scheme.insert_processing_option_group(parser)
 fft.insert_fft_option_group(parser)
-pycbc.opt.insert_optimization_option_group(parser)
-pycbc.inject.insert_injfilterrejector_option_group_multi_ifo(parser)
+opt.insert_optimization_option_group(parser)
+inject.insert_injfilterrejector_option_group_multi_ifo(parser)
 sgchisq.SingleDetSGChisq.insert_option_group(parser)
-opt = parser.parse_args()
+args = parser.parse_args()
 
-# Use the time in the middle of the segment to calculate the antenna patterns.
-t_gps = opt.trigger_time
-
-# Put the ifos in alphabetical order so they are always called in
-# the same order.
-opt.instruments.sort()
-
-strain.verify_strain_options_multi_ifo(opt, parser, opt.instruments)
-strain.StrainSegments.verify_segment_options_multi_ifo(opt, parser,
-                                                       opt.instruments)
-psd.verify_psd_options_multi_ifo(opt, parser, opt.instruments)
-scheme.verify_processing_options(opt, parser)
-fft.verify_fft_options(opt,parser)
-
-log_level = logging.DEBUG if opt.verbose else logging.INFO
+log_level = logging.DEBUG if args.verbose else logging.INFO
 logging.basicConfig(format='%(asctime)s : %(message)s', level=log_level)
 
-inj_filter_rejector = pycbc.inject.InjFilterRejector.from_cli_multi_ifos(
-    opt, opt.instruments)
-ctx = scheme.from_cli(opt)
+# Use the time in the middle of the segment to calculate the antenna patterns.
+t_gps = args.trigger_time
+# Put the ifos in alphabetical order so they are always called in
+# the same order.
+args.instruments.sort()
 
+strain.verify_strain_options_multi_ifo(args, parser, args.instruments)
+strain.StrainSegments.verify_segment_options_multi_ifo(
+        args, parser, args.instruments)
+psd.verify_psd_options_multi_ifo(args, parser, args.instruments)
+scheme.verify_processing_options(args, parser)
+fft.verify_fft_options(args, parser)
+inj_filter_rejector = inject.InjFilterRejector.from_cli_multi_ifos(
+    args, args.instruments)
 strain_dict = strain.from_cli_multi_ifos(
-    opt, opt.instruments, inj_filter_rejector,
-    dyn_range_fac=DYN_RANGE_FAC
-    )
+    args, args.instruments, inj_filter_rejector, dyn_range_fac=DYN_RANGE_FAC)
 strain_segments_dict = strain.StrainSegments.from_cli_multi_ifos(
-                         opt, strain_dict, opt.instruments)
+    args, strain_dict, args.instruments)
+ctx = scheme.from_cli(args)
 with ctx:
-    fft.from_cli(opt)
+    fft.from_cli(args)
     # Set some often used variables for easy access
-    flow = opt.low_frequency_cutoff
+    flow = args.low_frequency_cutoff
     flow_dict = defaultdict(lambda : flow)
-    for count, ifo in enumerate(opt.instruments):
+    for count, ifo in enumerate(args.instruments):
         if count == 0:
             sample_rate = strain_dict[ifo].sample_rate
             sample_rate_dict = defaultdict(lambda : sample_rate)
@@ -177,13 +172,14 @@ with ctx:
                 raise ValueError(err_msg)
 
     logging.info("Making frequency-domain data segments")
-    segments = {ifo: strain_segments_dict[ifo].fourier_segments()
-                for ifo in opt.instruments}
+    segments = {
+        ifo: strain_segments_dict[ifo].fourier_segments()
+        for ifo in args.instruments
+        }
     del strain_segments_dict
-    psd.associate_psds_to_multi_ifo_segments(opt, segments, strain_dict, flen,
-                                             delta_f, flow, opt.instruments,
-                                             dyn_range_factor=DYN_RANGE_FAC,
-                                             precision='single')
+    psd.associate_psds_to_multi_ifo_segments(
+        args, segments, strain_dict, flen, delta_f, flow, args.instruments,
+        dyn_range_factor=DYN_RANGE_FAC, precision='single')
 
     # Currently we are using the same matched-filter parameters for all ifos.
     # Therefore only one MatchedFilterControl needed. Maybe this can change if
@@ -193,41 +189,41 @@ with ctx:
 
     # Calculate time delay to each detector
     time_delay_idx = {}
-    for ifo in opt.instruments:
-        dt = pycbc.detector.Detector(ifo).time_delay_from_earth_center(
-            opt.ra, opt.dec, t_gps)
+    for ifo in args.instruments:
+        dt = detector.Detector(ifo).time_delay_from_earth_center(
+            args.ra, args.dec, t_gps)
         time_delay_idx[ifo] = int(round(dt * sample_rate))
 
     # Matched filter each ifo. Don't cluster here for a coherent search.
     # Clustering happens at the end of the template loop.
     # FIXME: The single detector SNR threshold should not necessarily be
     #        applied to every IFO (usually only 2 most sensitive in network)
-    matched_filter = {ifo: MatchedFilterControl(
-            opt.low_frequency_cutoff, None, opt.snr_threshold, tlen, delta_f,
+    matched_filter = {
+        ifo: MatchedFilterControl(
+            args.low_frequency_cutoff, None, args.snr_threshold, tlen, delta_f,
             complex64, segments[ifo], template_mem, use_cluster=False,
-            downsample_factor=opt.downsample_factor,
-            upsample_threshold=opt.upsample_threshold,
-            upsample_method=opt.upsample_method,
+            downsample_factor=args.downsample_factor,
+            upsample_threshold=args.upsample_threshold,
+            upsample_method=args.upsample_method,
             cluster_function='symmetric')
-        for ifo in opt.instruments}
+        for ifo in args.instruments}
 
     logging.info("Initializing signal-based vetoes.")
     # The existing SingleDetPowerChisq can calculate the single detector
     # chisq for multiple ifos, so just use that directly.
-    power_chisq = vetoes.SingleDetPowerChisq(opt.chisq_bins)
+    power_chisq = vetoes.SingleDetPowerChisq(args.chisq_bins)
     # The existing SingleDetBankVeto can calculate the single detector
     # bank veto for multiple ifos, so we just use it directly.
-    bank_chisq = vetoes.SingleDetBankVeto(opt.bank_veto_bank_file, flen,
-                                          delta_f, flow, complex64,
-                                          phase_order=opt.order,
-                                          approximant=opt.approximant)
+    bank_chisq = vetoes.SingleDetBankVeto(
+        args.bank_veto_bank_file, flen, delta_f, flow, complex64,
+        phase_order=args.order, approximant=args.approximant)
     # Same here
-    autochisq = vetoes.SingleDetAutoChisq(opt.autochi_stride,
-                                          opt.autochi_number_points,
-                                          onesided=opt.autochi_onesided)
+    autochisq = vetoes.SingleDetAutoChisq(
+        args.autochi_stride, args.autochi_number_points,
+        onesided=args.autochi_onesided)
 
     logging.info("Overwhitening frequency-domain data segments")
-    for ifo in opt.instruments:
+    for ifo in args.instruments:
         for seg in segments[ifo]:
             seg /= seg.psd
     ifo_out_types = {
@@ -275,16 +271,15 @@ with ctx:
     network_names = sorted(network_out_vals.keys())
 
     event_mgr = EventManagerCoherent(
-        opt, opt.instruments, ifo_names, [ifo_out_types[n] for n in ifo_names],
-        network_names, [network_out_types[n] for n in network_names]
-        )
+        args, args.instruments, ifo_names,
+         [ifo_out_types[n] for n in ifo_names], network_names,
+         [network_out_types[n] for n in network_names])
 
     logging.info("Read in template bank")
-    bank = waveform.FilterBank(opt.bank_file, flen, delta_f, complex64,
-                               low_frequency_cutoff=flow,
-                               phase_order=opt.order,
-                               taper=opt.taper_template,
-                               approximant=opt.approximant, out=template_mem)
+    bank = waveform.FilterBank(
+        args.bank_file, flen, delta_f, complex64, low_frequency_cutoff=flow,
+        phase_order=args.order, taper=args.taper_template,
+        approximant=args.approximant, out=template_mem)
 
     # Use injfilterrejector to reduce the bank to only those templates that
     # might actually find something
@@ -292,7 +287,7 @@ with ctx:
     nfilters = 0
 
     logging.info("Full template bank size: %d", n_bank)
-    for ifo in opt.instruments:
+    for ifo in args.instruments:
         bank.template_thinning(inj_filter_rejector[ifo])
     if not len(bank) == n_bank:
         n_bank = len(bank)
@@ -300,55 +295,56 @@ with ctx:
 
     fp = {}  # Antenna patterns
     fc = {}
-    for ifo in opt.instruments:
-        fp[ifo], fc[ifo] = pycbc.detector.Detector(ifo).antenna_pattern(
-            opt.ra, opt.dec, polarization=0, t_gps=t_gps)
+    for ifo in args.instruments:
+        fp[ifo], fc[ifo] = detector.Detector(ifo).antenna_pattern(
+            args.ra, args.dec, polarization=0, t_gps=t_gps)
 
     for t_num, template in enumerate(bank):  # Loop over templates
-        for ifo in opt.instruments:
-            if opt.cluster_method == "window":
-                cluster_window = int(opt.cluster_window * sample_rate)
-            elif opt.cluster_method == "template":
+        for ifo in args.instruments:
+            if args.cluster_method == "window":
+                cluster_window = int(args.cluster_window * sample_rate)
+            elif args.cluster_method == "template":
                 cluster_window = int(template.chirp_length * sample_rate)
-            elif opt.cluster_window == 0:
+            elif args.cluster_window == 0:
                  cluster_window = int(0)
 
         # Loop over segments
-        for s_num,stilde in enumerate(segments[opt.instruments[0]]):
-            stilde = {ifo : segments[ifo][s_num] for ifo in opt.instruments}
+        for s_num,stilde in enumerate(segments[args.instruments[0]]):
+            stilde = {ifo : segments[ifo][s_num] for ifo in args.instruments}
             # Filter check checks the 'inj_filter_rejector' options to
             # determine whether to filter this template/segment 
             # if injections are present.
             analyse_segment = True
-            for ifo in opt.instruments:
+            for ifo in args.instruments:
                 if not inj_filter_rejector[ifo].template_segment_checker(
                         bank, t_num, stilde[ifo]):
-                    logging.info("Skipping segment %d/%d with template %d/%d "
-                                 "as no detectable injection is present",
-                                 s_num + 1, len(segments[ifo]), t_num + 1,
-                                 n_bank)
+                    logging.info(
+                        "Skipping segment %d/%d with template %d/%d as no "
+                        "detectable injection is present",
+                        s_num + 1, len(segments[ifo]), t_num + 1, n_bank)
                     analyse_segment = False
             #Find detector sensitivities (sigma) and make array of normalised
-            sigmasq = {ifo : template.sigmasq(segments[ifo][s_num].psd)
-                      for ifo in opt.instruments}
-            sigma = {ifo : np.sqrt(sigmasq[ifo]) for ifo in opt.instruments}
+            sigmasq = {
+                ifo : template.sigmasq(segments[ifo][s_num].psd)
+                for ifo in args.instruments}
+            sigma = {ifo : np.sqrt(sigmasq[ifo]) for ifo in args.instruments}
             # Every time s_num is zero or we skip the segment, we run new 
             # template to increment the template index
             if s_num==0:
                 event_mgr.new_template(tmplt=template.params, sigmasq=sigmasq)
             if not analyse_segment: continue
-            logging.info("Analyzing segment %d/%d" % (s_num + 1,
-                                                     len(segments[ifo])))
+            logging.info(
+                "Analyzing segment %d/%d", s_num + 1, len(segments[ifo]))
             snrv_dict = {}
             norm_dict = {}
             corr_dict = {}
             snr_ts={}
             idx={}
             coinc_idx = np.array([])
-            ifo_list = opt.instruments[:]
-            for ifo in opt.instruments:
-                logging.info("Filtering template %d/%d, ifo %s", t_num + 1,
-                             n_bank, ifo)
+            ifo_list = args.instruments[:]
+            for ifo in args.instruments:
+                logging.info(
+                    "Filtering template %d/%d, ifo %s", t_num + 1, n_bank, ifo)
                 # No clustering in the coherent search until the end.
                 # The correlation vector is the FFT of the snr (so inverse FFT
                 # it to get the snr). 
@@ -364,61 +360,70 @@ with ctx:
             if len(ifo_list)==0: continue
 
             # Find the data we need to analyse
-            analyse_data = {ifo: matched_filter[ifo].segments[s_num].analyze
-                            for ifo in opt.instruments}
+            analyse_data = {
+                ifo: matched_filter[ifo].segments[s_num].analyze
+                for ifo in args.instruments}
 
             # Restrict the snr timeseries to just this section
-            snr = {ifo: snr_ts[ifo][analyse_data[ifo]] * norm_dict[ifo]
-                   for ifo in opt.instruments}
+            snr = {
+                ifo: snr_ts[ifo][analyse_data[ifo]] * norm_dict[ifo]
+                for ifo in args.instruments}
 
             # Save the indexes of triggers (if we have any)
             # Even if we have none, need to keep an empty dictionary.
             # Only do this is idx doesn't get time shifted out of the time
             # we are looking at.
-            idx_dict = {ifo: idx[ifo][
-                np.logical_and(idx[ifo] > time_delay_idx[ifo],
-                               idx[ifo] - time_delay_idx[ifo] < len(snr[ifo]))
+            idx_dict = {
+                ifo: idx[ifo][np.logical_and(
+                    idx[ifo] > time_delay_idx[ifo],
+                    idx[ifo] - time_delay_idx[ifo] < len(snr[ifo])
+                    )
                 ]
-                for ifo in opt.instruments}
+                for ifo in args.instruments}
             # Find triggers that are coincident (in geocent time) in multiple
             # ifos. If a single ifo analysis then just use the indexes from
             # that ifo.
-            if len(opt.instruments)>1:
+            if len(args.instruments) > 1:
                 coinc_idx = coh.get_coinc_indexes(idx_dict,time_delay_idx)
             else:
-                coinc_idx = idx_dict[opt.instruments[0]] \
-                    - time_delay_idx[opt.instruments[0]]
+                coinc_idx = (
+                    idx_dict[args.instruments[0]]
+                    - time_delay_idx[args.instruments[0]]
+                    )
             logging.info("Found %d coincident triggers", len(coinc_idx))
 
             # Number of ifos
-            nifo = len(opt.instruments)
+            nifo = len(args.instruments)
 
-            for ifo in opt.instruments:
+            for ifo in args.instruments:
                 # Move on if this segment has no data
                 if len(snr[ifo])==0:
                     raise ValueError('The SNR triggers dictionary is empty. '
                                      'This should not be possible.')
                 # Time delay is applied to indices
-                coinc_idx_det_frame = {ifo: coinc_idx + time_delay_idx[ifo]
-                                       for ifo in opt.instruments}
+                coinc_idx_det_frame = {
+                    ifo: coinc_idx + time_delay_idx[ifo]
+                    for ifo in args.instruments}
 
             # Calculate the coincident and coherent snr
             # Check we have data before we try to compute the coherent snr
             if len(coinc_idx) != 0 and nifo > 1:
                 #Find coinc snr at trigger times and apply coinc snr threshold
                 rho_coinc, coinc_idx, coinc_triggers = coh.coincident_snr(
-                    snr, coinc_idx, opt.coinc_threshold, time_delay_idx)
-                logging.info("%d points above coincident SNR threshold",
-                             len(coinc_idx))
+                    snr, coinc_idx, args.coinc_threshold, time_delay_idx)
+                logging.info(
+                    "%d points above coincident SNR threshold", len(coinc_idx))
                 if len(coinc_idx) != 0:
                     logging.info("Max coincident SNR = %.2f", max(rho_coinc))
 
             # If there is only one ifo, then coinc_triggers is just the
             # triggers from ifo
             elif len(coinc_idx) != 0 and nifo == 1:
-                coinc_triggers = {opt.instruments[0]:
-                        snr[opt.instruments[0]][\
-                                coinc_idx_det_frame[opt.instruments[0]]]}
+                coinc_triggers = {
+                    args.instruments[0]: snr[args.instruments[0]][
+                        coinc_idx_det_frame[args.instruments[0]]
+                        ]
+                    }
             else:
                 coinc_triggers = {}
                 logging.info("No triggers above coincident SNR threshold")
@@ -426,44 +431,45 @@ with ctx:
             # If we have triggers above coinc threshold and more than 2 ifos
             # then calculate the coherent statistics
             if len(coinc_idx) != 0 and nifo > 2:
-                if opt.projection=='left+right':
-                    project_l = coh.get_projection_matrix(fp, fc, sigma,
-                                                          projection='left')
+                if args.projection=='left+right':
+                    project_l = coh.get_projection_matrix(
+                        fp, fc, sigma, projection='left')
                     rho_coh_l, coinc_idx_l, coinc_triggers_l, rho_coinc_l = \
-                        coh.coherent_snr(coinc_triggers, coinc_idx,
-                                         opt.coinc_threshold, project_l,
-                                         rho_coinc)
-                    project_r = coh.get_projection_matrix(fp, fc, sigma,
-                                                          projection='right')
+                        coh.coherent_snr(
+                            coinc_triggers, coinc_idx, args.coinc_threshold,
+                            project_l, rho_coinc)
+                    project_r = coh.get_projection_matrix(
+                        fp, fc, sigma, projection='right')
                     rho_coh_r, coinc_idx_r, coinc_triggers_r, rho_coinc_r = \
-                        coh.coherent_snr(coinc_triggers, coinc_idx,
-                                         opt.coinc_threshold, project_r,
-                                         rho_coinc)
+                        coh.coherent_snr(
+                            coinc_triggers, coinc_idx, args.coinc_threshold,
+                            project_r, rho_coinc)
                     max_idx = np.argmax([rho_coh_l, rho_coh_r], axis=0)
                     rho_coh = np.where(max_idx==0, rho_coh_l, rho_coh_r)
                     coinc_idx = np.where(max_idx==0, coinc_idx_l, coinc_idx_r)
-                    coinc_triggers = np.where(max_idx==0, coinc_triggers_l,
-                                              coinc_triggers_r)
+                    coinc_triggers = np.where(
+                        max_idx==0, coinc_triggers_l, coinc_triggers_r)
                     rho_coinc = np.where(max_idx==0, rho_coinc_l, rho_coinc_r)
                 else:
                     project = coh.get_projection_matrix(
-                        fp, fc, sigma, projection=opt.projection)
+                        fp, fc, sigma, projection=args.projection)
                     rho_coh, coinc_idx, coinc_triggers, rho_coinc = \
-                        coh.coherent_snr(coinc_triggers, coinc_idx,
-                                         opt.coinc_threshold, project,
-                                         rho_coinc)
-                logging.info("%d points above coherent threshold",
-                             len(rho_coh))
+                        coh.coherent_snr(
+                            coinc_triggers, coinc_idx, args.coinc_threshold,
+                            project, rho_coinc)
+                logging.info(
+                    "%d points above coherent threshold", len(rho_coh))
                 if len(coinc_idx) != 0:
                     logging.info("Max coherent SNR = %.2f", max(rho_coh))
                     #Find the null snr
                     null, rho_coh, rho_coinc, coinc_idx, coinc_triggers =\
-                        coh.null_snr(rho_coh, rho_coinc, snrv=coinc_triggers,
-                                     index=coinc_idx)
+                        coh.null_snr(
+                            rho_coh, rho_coinc, snrv=coinc_triggers,
+                            index=coinc_idx)
                     if len(coinc_idx) != 0:
                         logging.info("Max null SNR = %.2f", max(null))
-                    logging.info("%d points above null threshold",
-                                 len(null))
+                    logging.info(
+                        "%d points above null threshold", len(null))
 
             # We are now going to find the individual detector chi2 values.
             # To do this it is useful to find the indexes of coinc triggers
@@ -471,53 +477,52 @@ with ctx:
             if len(coinc_idx) != 0:
                 # coinc_idx_det_frame is redefined to account for the cuts to
                 # coinc_idx above
-                coinc_idx_det_frame = {ifo: coinc_idx + time_delay_idx[ifo]
-                                       for ifo in opt.instruments}
-                coherent_ifo_trigs = {ifo: snr[ifo][coinc_idx_det_frame[ifo]]
-                                      for ifo in opt.instruments}
-
+                coinc_idx_det_frame = {
+                    ifo: coinc_idx + time_delay_idx[ifo]
+                    for ifo in args.instruments}
+                coherent_ifo_trigs = {
+                    ifo: snr[ifo][coinc_idx_det_frame[ifo]]
+                    for ifo in args.instruments}
                 # Calculate the power and autochi2 values for the coinc indexes
                 # (this uses the snr timeseries before the time delay, so we
                 # need to undo it. Same for normalisation)
                 chisq = {}
                 chisq_dof = {}
-                for ifo in opt.instruments:
+                for ifo in args.instruments:
                     chisq[ifo], chisq_dof[ifo] = power_chisq.values(
                         corr_dict[ifo],
                         coherent_ifo_trigs[ifo] / norm_dict[ifo],
                         norm_dict[ifo], stilde[ifo].psd,
                         coinc_idx_det_frame[ifo] + stilde[ifo].analyze.start,
                         template)
-
                 # Calculate network chisq value
-                network_chisq_dict = coh.network_chisq(chisq, chisq_dof, 
-                                                       coherent_ifo_trigs)
-
+                network_chisq_dict = coh.network_chisq(
+                    chisq, chisq_dof, coherent_ifo_trigs)
                 # Calculate chisq reweighted SNR
                 if nifo > 2:
-                    reweighted_snr = coh.reweighted_snr(rho_coh,
-                                                        network_chisq_dict)
+                    reweighted_snr = coh.reweighted_snr(
+                        rho_coh, network_chisq_dict)
                     # Calculate null reweighted SNR
-                    reweighted_snr = coh.reweight_snr_by_null(reweighted_snr,
-                                                              null)
+                    reweighted_snr = coh.reweight_snr_by_null(
+                        reweighted_snr, null)
                 elif nifo == 2:
-                    reweighted_snr = coh.reweighted_snr(rho_coinc,
-                                                        network_chisq_dict)
+                    reweighted_snr = coh.reweighted_snr(
+                        rho_coinc, network_chisq_dict)
                 else:
-                    rho_sngl = abs(snr[opt.instruments[0]]
-                                      [coinc_idx_det_frame[opt.instruments[0]]]
-                                      )
-                    reweighted_snr = coh.reweighted_snr(rho_sngl,
-                                                        network_chisq_dict)
-
+                    rho_sngl = abs(
+                        snr[args.instruments[0]][
+                            coinc_idx_det_frame[args.instruments[0]]
+                            ]
+                        )
+                    reweighted_snr = coh.reweighted_snr(
+                        rho_sngl, network_chisq_dict)
                 # Need all out vals to be the same length. This means the
                 # entries that are single values need to be repeated once
                 # per event.
                 num_events = len(reweighted_snr)
-
                 # the output will only be possible if
                 # len(networkchi2) == num_events
-                for ifo in opt.instruments:
+                for ifo in args.instruments:
                     (ifo_out_vals['bank_chisq'],
                      ifo_out_vals['bank_chisq_dof']) = bank_chisq.values(
                         template, stilde[ifo].psd, stilde[ifo],
@@ -530,12 +535,15 @@ with ctx:
                         stilde=stilde[ifo], low_frequency_cutoff=flow)
                     ifo_out_vals['chisq'] = chisq[ifo]
                     ifo_out_vals['chisq_dof'] = chisq_dof[ifo]
-                    ifo_out_vals['time_index'] = \
-                        coinc_idx_det_frame[ifo] + stilde[ifo].cumulative_index
+                    ifo_out_vals['time_index'] = (
+                        coinc_idx_det_frame[ifo]
+                        + stilde[ifo].cumulative_index
+                        )
                     ifo_out_vals['snr'] = coherent_ifo_trigs[ifo]
                     # IFO is stored as an int
-                    ifo_out_vals['ifo'] = \
+                    ifo_out_vals['ifo'] = (
                         [event_mgr.ifo_dict[ifo]] * num_events
+                        )
                     event_mgr.add_template_events_to_ifo(
                         ifo, ifo_names, [ifo_out_vals[n] for n in ifo_names])
                 if nifo>2:
@@ -544,28 +552,27 @@ with ctx:
                 elif nifo==2:
                     network_out_vals['coherent_snr'] = np.real(rho_coinc)
                 else:
-                    network_out_vals['coherent_snr'] = \
-                        abs(snr[opt.instruments[0]]
-                                [coinc_idx_det_frame[opt.instruments[0]]])
+                    network_out_vals['coherent_snr'] = (
+                        abs(snr[args.instruments[0]][
+                            coinc_idx_det_frame[args.instruments[0]]
+                            ])
+                        )
                 network_out_vals['reweighted_snr'] = reweighted_snr
-                network_out_vals['my_network_chisq'] = \
-                    np.real(network_chisq_dict)
-
-                network_out_vals['time_index'] = \
-                    coinc_idx+stilde[ifo].cumulative_index
+                network_out_vals['my_network_chisq'] = (
+                    np.real(network_chisq_dict))
+                network_out_vals['time_index'] = (
+                    coinc_idx + stilde[ifo].cumulative_index
+                    )
                 network_out_vals['nifo'] = [nifo] * num_events
-                network_out_vals['ra'] = [opt.ra] * num_events
-                network_out_vals['dec'] = [opt.dec] * num_events
+                network_out_vals['ra'] = [args.ra] * num_events
+                network_out_vals['dec'] = [args.dec] * num_events
                 event_mgr.add_template_events_to_network(
                     network_names,
                     [network_out_vals[n] for n in network_names])
         event_mgr.cluster_template_network_events(
-            "time_index",
-            "coherent_snr",
-            cluster_window
-            )
+            "time_index", "coherent_snr", cluster_window)
         event_mgr.finalize_template_events()
-event_mgr.write_events(opt.output)
+event_mgr.write_events(args.output)
 
 logging.info("Finished")
-logging.info("Time to complete analysis: %s" % str(time.time() - time_init))
+logging.info("Time to complete analysis: %d", int(time.time() - time_init))

--- a/bin/pycbc_multi_inspiral
+++ b/bin/pycbc_multi_inspiral
@@ -433,8 +433,11 @@ if __name__ == '__main__':
                         rho_coh = np.where(max_idx==0, rho_coh_l, rho_coh_r)
                         coinc_idx = np.where(
                             max_idx==0, coinc_idx_l, coinc_idx_r)
-                        coinc_triggers = np.where(
-                            max_idx==0, coinc_triggers_l, coinc_triggers_r)
+                        coinc_triggers = {
+                            ifo: np.where(
+                                max_idx==0, coinc_triggers_l[ifo],
+                                coinc_triggers_r[ifo])
+                            for ifo in coinc_triggers_l}
                         rho_coinc = np.where(
                             max_idx==0, rho_coinc_l, rho_coinc_r)
                     else:
@@ -491,7 +494,7 @@ if __name__ == '__main__':
                             rho_coh, network_chisq_dict)
                         # Calculate null reweighted SNR
                         reweighted_snr = coh.reweight_snr_by_null(
-                            reweighted_snr, null)
+                            reweighted_snr, null, rho_coh)
                     elif nifo == 2:
                         reweighted_snr = ranking.newsnr(
                             rho_coinc, network_chisq_dict)

--- a/bin/pycbc_multi_inspiral
+++ b/bin/pycbc_multi_inspiral
@@ -60,8 +60,14 @@ parser.add_argument("--taper-template",
                     choices=["start", "end", "startend"],
                     help="For time-domain approximants, taper the start "
                          "and/or end of the waveform before FFTing.")
-parser.add_argument("--cluster-method", choices=["template", "window"])
-parser.add_argument("--cluster-window", type=float, default = -1,
+parser.add_argument("--cluster-method", choices=["template", "window"],
+                    default="window",
+                    help="Method to use when clustering triggers. 'window' - "
+                         "cluster within a fixed time window defined by the "
+                         "cluster-window option (default); or 'template' - "
+                         "cluster within windows defined by each template's "
+                         "chirp length.")
+parser.add_argument("--cluster-window", type=float, default=0,
                     help="Length of clustering window in seconds.")
 parser.add_argument("--bank-veto-bank-file", type=str)
 parser.add_argument("--chisq-bins", default=0)
@@ -284,13 +290,6 @@ with ctx:
             args.ra, args.dec, polarization=0, t_gps=t_gps)
     # Loop over templates
     for t_num, template in enumerate(bank):
-        for ifo in args.instruments:
-            if args.cluster_method == "window":
-                cluster_window = int(args.cluster_window * sample_rate)
-            elif args.cluster_method == "template":
-                cluster_window = int(template.chirp_length * sample_rate)
-            elif args.cluster_window == 0:
-                 cluster_window = int(0)
         # Loop over segments
         for s_num,stilde in enumerate(segments[args.instruments[0]]):
             stilde = {ifo : segments[ifo][s_num] for ifo in args.instruments}
@@ -542,6 +541,11 @@ with ctx:
                 event_mgr.add_template_events_to_network(
                     network_names,
                     [network_out_vals[n] for n in network_names])
+        # Now cluster
+        if args.cluster_method == "window":
+            cluster_window = int(args.cluster_window * sample_rate)
+        elif args.cluster_method == "template":
+            cluster_window = int(template.chirp_length * sample_rate)
         event_mgr.cluster_template_network_events(
             "time_index", "coherent_snr", cluster_window)
         event_mgr.finalize_template_events()

--- a/bin/pycbc_multi_inspiral
+++ b/bin/pycbc_multi_inspiral
@@ -24,7 +24,6 @@ coherent SNRs and related statistics.
 import logging
 import time
 from collections import defaultdict
-from copy import copy
 import argparse
 import numpy as np
 from pycbc import (
@@ -349,10 +348,10 @@ if __name__ == '__main__':
                     snr_dict[ifo] = (
                             snr_ts[matched_filter[ifo].segments[s_num].analyze]
                             * norm)
-                    norm_dict[ifo] = copy(norm)
-                    corr_dict[ifo] = copy(corr)
-                    idx[ifo] = copy(ind)
-                    snrv_dict[ifo] = copy(snrv)
+                    norm_dict[ifo] = norm
+                    corr_dict[ifo] = corr.copy()
+                    idx[ifo] = ind.copy()
+                    snrv_dict[ifo] = snrv.copy()
                     snr[ifo] = snrv * norm
                 # Move onto next segment if there are no triggers.
                 if len(ifo_list)==0: continue

--- a/bin/pycbc_multi_inspiral
+++ b/bin/pycbc_multi_inspiral
@@ -564,4 +564,4 @@ if __name__ == '__main__':
             event_mgr.finalize_template_events()
     event_mgr.write_events(args.output)
     logging.info("Finished")
-    logging.info("Time to complete analysis: %d", int(time.time() - time_init))
+    logging.info("Time to complete analysis: %.0f s", time.time() - time_init)

--- a/pycbc/events/coherent.py
+++ b/pycbc/events/coherent.py
@@ -315,7 +315,7 @@ def null_snr(
     null2 = rho_coinc ** 2 - rho_coh ** 2
     # Numerical errors may make this negative and break the sqrt, so set
     # negative values to 0.
-    #null2[null2 < 0] = 0
+    null2[null2 < 0] = 0
     null = null2 ** 0.5
     if apply_cut:
         # Make cut on null.

--- a/pycbc/events/coherent.py
+++ b/pycbc/events/coherent.py
@@ -1,0 +1,284 @@
+# Copyright (C) 2022 Andrew Williamson
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+#
+# =============================================================================
+#
+#                                   Preamble
+#
+# =============================================================================
+#
+""" This module contains functions for calculating and manipulating coherent
+triggers.
+"""
+
+import numpy as np
+
+
+def get_coinc_indexes(idx_dict, time_delay_idx):
+    """Return the indexes corresponding to coincident triggers
+
+    Parameters
+    ----------
+    idx_dict: dict
+        Dictionary of indexes of triggers above threshold in each detector
+    time_delay_idx: dict
+        Dictionary giving time delay index (time_delay*sample_rate) for each ifo
+    
+    Returns
+    -------
+    coinc_idx: list
+        List of indexes for triggers in geocent time that appear in multiple
+        detectors
+    """
+    coinc_list = np.array([], dtype=int)
+    for ifo in idx_dict.keys():
+        """
+        Create list of indexes above threshold in single detector in
+        geocent time. Can then search for triggers that appear in multiple
+        detectors later.
+        """
+        if len(idx_dict[ifo]) != 0:
+            coinc_list = np.hstack([coinc_list,
+                                   idx_dict[ifo] - time_delay_idx[ifo]])
+    #Search through coinc_idx for repeated indexes. These must have
+    #been loud in at least 2 detectors.
+    coinc_idx = np.unique(coinc_list, return_counts=True)[0][
+                   np.unique(coinc_list, return_counts=True)[1]>1]
+    return coinc_idx
+
+
+def coincident_snr(snr_dict, index, threshold, time_delay_idx):
+    """Calculate the coincident SNR for all coinciden triggers above threshold
+
+    Parameters
+    ----------
+    snr_dict: dict
+        Dictionary of individual detector SNRs
+    index: list
+        List of indexes (geocentric) for which to calculate coincident SNR
+    threshold: float
+        Coincident SNR threshold. Triggers below this are cut
+    time_delay_idx: dict
+        Dictionary of time delay from geocenter in indexes for each detector
+    
+    Returns
+    -------
+    rho_coinc: numpy.ndarray
+        Coincident SNR values for surviving triggers
+    index: list
+        The subset of input indexes corresponding to triggers that survive the
+        cuts
+    coinc_triggers: dict
+        Dictionary of individual detector SNRs for triggers that survive cuts
+    """
+    #Restrict the snr timeseries to just the interesting points
+    coinc_triggers = {ifo : snr_dict[ifo][index + time_delay_idx[ifo]]
+                      for ifo in snr_dict.keys()}
+    #Calculate the coincident snr
+    snr_array = np.array([coinc_triggers[ifo]
+                          for ifo in coinc_triggers.keys()])
+    rho_coinc = np.sqrt(np.sum(snr_array * snr_array.conj(), axis=0))
+    # Apply threshold
+    thresh_indexes = rho_coinc > threshold
+    index = index[thresh_indexes]
+    coinc_triggers = {ifo : snr_dict[ifo][index + time_delay_idx[ifo]]
+                      for ifo in snr_dict.keys()}
+    rho_coinc = rho_coinc[thresh_indexes]
+    return rho_coinc, index, coinc_triggers
+
+
+def get_projection_matrix(fp, fc, sigma, projection='standard'):
+    """ Calculate the matrix that prjects the signal onto the network.
+    
+    Parameters
+    ----------
+    fp: dict
+        Dictionary containing the plus antenna response factors for each IFO
+    fc: dict
+        Dictionary containing the cross antenna response factors for each IFO
+    sigma: dict
+        Dictionary of the sensitivity weights for each IFO
+    projection: optional, {string, 'standard'}
+        The signal polarization to project. Choice of 'standard'
+        (unrestricted; default), 'right' or 'left' (circular polarizations)
+    
+    Returns
+    -------
+    projection_matrix: np.ndarray
+        The matrix that projects the signal onto the detector network
+    """
+    # Calculate the weighted antenna responses
+    keys = sorted(sigma.keys())
+    wp = np.array([sigma[ifo] * wp[ifo] for ifo in keys])
+    wc = np.array([sigma[ifo] * wc[ifo] for ifo in keys])
+
+    # Get the projection matrix associated with the requested projection
+    if projection=='standard':
+        denominator = np.dot(wp, wp) * np.dot(wc, wc) - np.dot(wp, wc)**2
+        projection_matrix = (np.dot(wc, wc)*np.outer(wp, wp) +
+                             np.dot(wp, wp)*np.outer(wc, wc) -
+                             np.dot(wp, wc)*(np.outer(wp, wc) +
+                             np.outer(wc, wp))) / denominator
+    elif projection=='left':
+        projection_matrix = ((np.outer(wp, wp) + np.outer(wc, wc) +
+                             (np.outer(wp, wc) - np.outer(wc, wp)) *1j)
+                             / (np.dot(wp, wp) + np.dot(wc, wc)))
+    elif projection=='right':
+        projection_matrix = ((np.outer(wp, wp) + np.outer(wc, wc) +
+                             (np.outer(wc, wp) - np.outer(wp, wc)) *1j)
+                             / (np.dot(wp, wp) + np.dot(wc, wc)))
+    else:
+        raise ValueError('Unknown projection: {}'.format(projection))
+
+    return projection_matrix
+
+
+def coherent_snr(snr_triggers, index, threshold, projection_matrix,
+                coinc_snr=[]):
+    """Calculate the coherent SNR for a given set of triggers
+    
+    Parameters
+    ----------
+    snr_triggers: dict
+        Dictionary of the normalised complex snr time series for each ifo
+    index: numpy.ndarray
+        Array of the indexes corresponding to triggers
+    threshold: float
+        Coherent SNR threshold. Triggers below this are cut
+    projection_matrix: numpy.ndarray
+        Matrix that projects the signal onto the network
+    coinc_snr: Optional- The coincident snr for each trigger.
+    
+    Returns
+    -------
+    rho_coh: numpy.ndarray
+        Array of coherent SNR for the detector network
+    index: numpy.ndarray
+        Indexes that survive cuts
+    snrv: dict
+        Dictionary of individual deector triggers that survive cuts
+    coinc_snr: list
+        The coincident SNR values for triggers surviving the coherent cut
+    """
+    #Calculate rho_coh
+    snr_array = np.array([snr_triggers[ifo]
+                         for ifo in sorted(snr_triggers.keys())])
+    x = np.inner(snr_array.conj().transpose(),projection_matrix)
+    rho_coh2 = sum(x.transpose()*snr_array)
+    rho_coh = np.sqrt(rho_coh2)
+    #Apply thresholds
+    index = index[rho_coh > threshold]
+    if len(coinc_snr) != 0: coinc_snr = coinc_snr[rho_coh > threshold]
+    snrv = {ifo : snr_triggers[ifo][rho_coh > threshold]
+           for ifo in snr_triggers.keys()}
+    rho_coh = rho_coh[rho_coh > threshold]
+    return rho_coh, index, snrv, coinc_snr
+
+
+def network_chisq(chisq, chisq_dof, snr_dict):
+    """Calculate the network chi-squared statistic
+
+    Parameters
+    ----------
+    chisq: dict
+        Dictionary of individual detector chi-squared statistics
+    chisq_dof: dict
+        Dictionary of the number of degrees of freedom of the chi-squared
+        statistic
+    snr_dict: dict
+        Dictionary of complex individual detector SNRs
+    
+    Returns
+    -------
+    network_chisq: list
+        Network chi-squared values
+    """
+    ifos = sorted(snr_dict.keys())
+    chisq_per_dof = {}
+    for ifo in ifos:
+        chisq_per_dof[ifo] = chisq[ifo] / chisq_dof[ifo]
+        chisq_per_dof[ifo][chisq_per_dof[ifo] < 1] = 1
+    snr2 = {ifo : np.real(np.array(snr_dict[ifo]) *
+                np.array(snr_dict[ifo]).conj()) for ifo in ifos}
+    coinc_snr2 = sum(snr2.values())
+    snr2_ratio = {ifo : snr2[ifo] / coinc_snr2 for ifo in ifos}
+    network_chisq = sum([chisq_per_dof[ifo] * snr2_ratio[ifo] for ifo in ifos])
+    return network_chisq
+
+
+def pycbc_reweight_snr(network_snr, network_chisq, a = 3, b = 1. / 6.):
+    """
+    Output: reweighted_snr: Reweighted SNR for each trigger
+    Input:  network_snr:  Dictionary of coincident or coherent SNR for each
+                          trigger
+            network_chisq: A chisq value for each trigger 
+    """
+    denom = ((1 + network_chisq)**a) / 2
+    reweighted_snr = network_snr / denom**b
+    return reweighted_snr
+
+
+def null_snr(rho_coh, rho_coinc, null_min=5.25, null_grad=0.2, null_step=20.,
+             index={}, snrv={}):
+    """
+    Output: null: null snr for surviving triggers
+            rho_coh: Coherent snr for surviving triggers
+            rho_coinc: Coincident snr for suviving triggers
+            index: Indexes for surviving triggers
+            snrv: Single detector snr for surviving triggers
+    Input:  rho_coh: Numpy array of coherent snr triggers
+            rho_coinc: Numpy array of coincident snr triggers
+            null_min: Any trigger with null snr below this is cut
+            null_grad: Any trigger with null snr<(null_grad*rho_coh+null_min)
+                       is cut
+            null_step: The value for required for coherent snr to start
+                       increasing the null threshold
+            index: Optional- Indexes of triggers. If given, will remove
+                   triggers that fail cuts
+            snrv: Optional- Individual ifo snr for triggers. If given will
+                  remove triggers that fail cut
+    """
+    null2 = rho_coinc**2 - rho_coh**2
+    # Numerical errors may make this negative and break the sqrt, so set
+    # negative values to 0.
+    null2[null2 < 0] = 0
+    null = null2**0.5
+    # Make cut on null.
+    keep1 = np.logical_and(null < null_min, rho_coh <= null_step)
+    keep2 = np.logical_and(null < (rho_coh * null_grad + null_min),
+                          rho_coh > null_step)
+    keep = np.logical_or(keep1, keep2)
+    index = index[keep]
+    rho_coh  = rho_coh[keep]
+    snrv = {ifo : snrv[ifo][keep] for ifo in snrv.keys()}
+    rho_coinc = rho_coinc[keep]
+    null = null[keep]
+    return null, rho_coh, rho_coinc, index, snrv
+
+
+def reweight_snr_by_null(network_snr, nullsnr):
+    """
+    Output: reweighted_snr: Reweighted SNR for each trigger
+    Input:  network_snr:  Dictionary of coincident, coherent, or reweighted
+                          SNR for each trigger
+            null: Null snr for each trigger
+    """
+    nullsnr = np.array(nullsnr)
+    nullsnr[nullsnr <= 4.25] = 4.25
+    reweighted_snr = network_snr / (nullsnr - 3.25)
+    return reweighted_snr
+

--- a/pycbc/events/coherent.py
+++ b/pycbc/events/coherent.py
@@ -222,7 +222,7 @@ def coherent_snr(
     # Apply thresholds
     index = index[rho_coh > threshold]
     coinc_snr = [] if coinc_snr is None else coinc_snr
-    if coinc_snr:
+    if len(coinc_snr) != 0:
         coinc_snr = coinc_snr[rho_coh > threshold]
     snrv = {
         ifo: snr_triggers[ifo][rho_coh > threshold]

--- a/pycbc/events/coherent.py
+++ b/pycbc/events/coherent.py
@@ -123,8 +123,8 @@ def get_projection_matrix(fp, fc, sigma, projection='standard'):
     """
     # Calculate the weighted antenna responses
     keys = sorted(sigma.keys())
-    wp = np.array([sigma[ifo] * wp[ifo] for ifo in keys])
-    wc = np.array([sigma[ifo] * wc[ifo] for ifo in keys])
+    wp = np.array([sigma[ifo] * fp[ifo] for ifo in keys])
+    wc = np.array([sigma[ifo] * fc[ifo] for ifo in keys])
 
     # Get the projection matrix associated with the requested projection
     if projection=='standard':

--- a/pycbc/events/coherent.py
+++ b/pycbc/events/coherent.py
@@ -153,29 +153,29 @@ def get_projection_matrix(f_plus, f_cross, sigma, projection="standard"):
     """
     # Calculate the weighted antenna responses
     keys = sorted(sigma.keys())
-    wp = np.array([sigma[ifo] * f_plus[ifo] for ifo in keys])
-    wc = np.array([sigma[ifo] * f_cross[ifo] for ifo in keys])
+    w_p = np.array([sigma[ifo] * f_plus[ifo] for ifo in keys])
+    w_c = np.array([sigma[ifo] * f_cross[ifo] for ifo in keys])
 
     # Get the projection matrix associated with the requested projection
     if projection == "standard":
-        denominator = np.dot(wp, wp) * np.dot(wc, wc) - np.dot(wp, wc) ** 2
+        denom = np.dot(w_p, w_p) * np.dot(w_c, w_c) - np.dot(w_p, w_c) ** 2
         projection_matrix = (
-            np.dot(wc, wc) * np.outer(wp, wp)
-            + np.dot(wp, wp) * np.outer(wc, wc)
-            - np.dot(wp, wc) * (np.outer(wp, wc) + np.outer(wc, wp))
-        ) / denominator
+            np.dot(w_c, w_c) * np.outer(w_p, w_p)
+            + np.dot(w_p, w_p) * np.outer(w_c, w_c)
+            - np.dot(w_p, w_c) * (np.outer(w_p, w_c) + np.outer(w_c, w_p))
+        ) / denom
     elif projection == "left":
         projection_matrix = (
-            np.outer(wp, wp)
-            + np.outer(wc, wc)
-            + (np.outer(wp, wc) - np.outer(wc, wp)) * 1j
-        ) / (np.dot(wp, wp) + np.dot(wc, wc))
+            np.outer(w_p, w_p)
+            + np.outer(w_c, w_c)
+            + (np.outer(w_p, w_c) - np.outer(w_c, w_p)) * 1j
+        ) / (np.dot(w_p, w_p) + np.dot(w_c, w_c))
     elif projection == "right":
         projection_matrix = (
-            np.outer(wp, wp)
-            + np.outer(wc, wc)
-            + (np.outer(wc, wp) - np.outer(wp, wc)) * 1j
-        ) / (np.dot(wp, wp) + np.dot(wc, wc))
+            np.outer(w_p, w_p)
+            + np.outer(w_c, w_c)
+            + (np.outer(w_c, w_p) - np.outer(w_p, w_c)) * 1j
+        ) / (np.dot(w_p, w_p) + np.dot(w_c, w_c))
     else:
         raise ValueError("Unknown projection: {}".format(projection))
 

--- a/pycbc/events/coherent.py
+++ b/pycbc/events/coherent.py
@@ -34,68 +34,72 @@ def get_coinc_indexes(idx_dict, time_delay_idx):
     Parameters
     ----------
     idx_dict: dict
-        Dictionary of indexes of triggers above threshold in each detector
+        Dictionary of indexes of triggers above threshold in each
+        detector
     time_delay_idx: dict
-        Dictionary giving time delay index (time_delay*sample_rate) for each ifo
-    
+        Dictionary giving time delay index (time_delay*sample_rate) for
+        each ifo
+
     Returns
     -------
     coinc_idx: list
-        List of indexes for triggers in geocent time that appear in multiple
-        detectors
+        List of indexes for triggers in geocent time that appear in
+        multiple detectors
     """
     coinc_list = np.array([], dtype=int)
     for ifo in idx_dict.keys():
-        """
-        Create list of indexes above threshold in single detector in
-        geocent time. Can then search for triggers that appear in multiple
-        detectors later.
-        """
+        # Create list of indexes above threshold in single detector in geocent
+        # time. Can then search for triggers that appear in multiple detectors
+        # later.
         if len(idx_dict[ifo]) != 0:
             coinc_list = np.hstack([coinc_list,
-                                   idx_dict[ifo] - time_delay_idx[ifo]])
-    #Search through coinc_idx for repeated indexes. These must have
-    #been loud in at least 2 detectors.
+                                    idx_dict[ifo] - time_delay_idx[ifo]])
+    # Search through coinc_idx for repeated indexes. These must have been loud
+    # in at least 2 detectors.
     coinc_idx = np.unique(coinc_list, return_counts=True)[0][
-                   np.unique(coinc_list, return_counts=True)[1]>1]
+        np.unique(coinc_list, return_counts=True)[1] > 1]
     return coinc_idx
 
 
 def coincident_snr(snr_dict, index, threshold, time_delay_idx):
-    """Calculate the coincident SNR for all coinciden triggers above threshold
+    """Calculate the coincident SNR for all coinciden triggers above
+    threshold
 
     Parameters
     ----------
     snr_dict: dict
         Dictionary of individual detector SNRs
     index: list
-        List of indexes (geocentric) for which to calculate coincident SNR
+        List of indexes (geocentric) for which to calculate coincident
+        SNR
     threshold: float
         Coincident SNR threshold. Triggers below this are cut
     time_delay_idx: dict
-        Dictionary of time delay from geocenter in indexes for each detector
-    
+        Dictionary of time delay from geocenter in indexes for each
+        detector
+
     Returns
     -------
     rho_coinc: numpy.ndarray
         Coincident SNR values for surviving triggers
     index: list
-        The subset of input indexes corresponding to triggers that survive the
-        cuts
+        The subset of input indexes corresponding to triggers that
+        survive the cuts
     coinc_triggers: dict
-        Dictionary of individual detector SNRs for triggers that survive cuts
+        Dictionary of individual detector SNRs for triggers that
+        survive cuts
     """
-    #Restrict the snr timeseries to just the interesting points
-    coinc_triggers = {ifo : snr_dict[ifo][index + time_delay_idx[ifo]]
+    # Restrict the snr timeseries to just the interesting points
+    coinc_triggers = {ifo: snr_dict[ifo][index + time_delay_idx[ifo]]
                       for ifo in snr_dict.keys()}
-    #Calculate the coincident snr
+    # Calculate the coincident snr
     snr_array = np.array([coinc_triggers[ifo]
                           for ifo in coinc_triggers.keys()])
     rho_coinc = np.sqrt(np.sum(snr_array * snr_array.conj(), axis=0))
     # Apply threshold
     thresh_indexes = rho_coinc > threshold
     index = index[thresh_indexes]
-    coinc_triggers = {ifo : snr_dict[ifo][index + time_delay_idx[ifo]]
+    coinc_triggers = {ifo: snr_dict[ifo][index + time_delay_idx[ifo]]
                       for ifo in snr_dict.keys()}
     rho_coinc = rho_coinc[thresh_indexes]
     return rho_coinc, index, coinc_triggers
@@ -103,19 +107,22 @@ def coincident_snr(snr_dict, index, threshold, time_delay_idx):
 
 def get_projection_matrix(fp, fc, sigma, projection='standard'):
     """ Calculate the matrix that prjects the signal onto the network.
-    
+
     Parameters
     ----------
     fp: dict
-        Dictionary containing the plus antenna response factors for each IFO
+        Dictionary containing the plus antenna response factors for
+        each IFO
     fc: dict
-        Dictionary containing the cross antenna response factors for each IFO
+        Dictionary containing the cross antenna response factors for
+        each IFO
     sigma: dict
         Dictionary of the sensitivity weights for each IFO
     projection: optional, {string, 'standard'}
         The signal polarization to project. Choice of 'standard'
-        (unrestricted; default), 'right' or 'left' (circular polarizations)
-    
+        (unrestricted; default), 'right' or 'left' (circular
+        polarizations)
+
     Returns
     -------
     projection_matrix: np.ndarray
@@ -127,19 +134,19 @@ def get_projection_matrix(fp, fc, sigma, projection='standard'):
     wc = np.array([sigma[ifo] * fc[ifo] for ifo in keys])
 
     # Get the projection matrix associated with the requested projection
-    if projection=='standard':
+    if projection == 'standard':
         denominator = np.dot(wp, wp) * np.dot(wc, wc) - np.dot(wp, wc)**2
         projection_matrix = (np.dot(wc, wc)*np.outer(wp, wp) +
                              np.dot(wp, wp)*np.outer(wc, wc) -
                              np.dot(wp, wc)*(np.outer(wp, wc) +
                              np.outer(wc, wp))) / denominator
-    elif projection=='left':
+    elif projection == 'left':
         projection_matrix = ((np.outer(wp, wp) + np.outer(wc, wc) +
-                             (np.outer(wp, wc) - np.outer(wc, wp)) *1j)
+                             (np.outer(wp, wc) - np.outer(wc, wp)) * 1j)
                              / (np.dot(wp, wp) + np.dot(wc, wc)))
-    elif projection=='right':
+    elif projectioni == 'right':
         projection_matrix = ((np.outer(wp, wp) + np.outer(wc, wc) +
-                             (np.outer(wc, wp) - np.outer(wp, wc)) *1j)
+                             (np.outer(wc, wp) - np.outer(wp, wc)) * 1j)
                              / (np.dot(wp, wp) + np.dot(wc, wc)))
     else:
         raise ValueError('Unknown projection: {}'.format(projection))
@@ -148,13 +155,14 @@ def get_projection_matrix(fp, fc, sigma, projection='standard'):
 
 
 def coherent_snr(snr_triggers, index, threshold, projection_matrix,
-                coinc_snr=[]):
+                 coinc_snr=[]):
     """Calculate the coherent SNR for a given set of triggers
-    
+
     Parameters
     ----------
     snr_triggers: dict
-        Dictionary of the normalised complex snr time series for each ifo
+        Dictionary of the normalised complex snr time series for each
+        ifo
     index: numpy.ndarray
         Array of the indexes corresponding to triggers
     threshold: float
@@ -162,7 +170,7 @@ def coherent_snr(snr_triggers, index, threshold, projection_matrix,
     projection_matrix: numpy.ndarray
         Matrix that projects the signal onto the network
     coinc_snr: Optional- The coincident snr for each trigger.
-    
+
     Returns
     -------
     rho_coh: numpy.ndarray
@@ -172,19 +180,21 @@ def coherent_snr(snr_triggers, index, threshold, projection_matrix,
     snrv: dict
         Dictionary of individual deector triggers that survive cuts
     coinc_snr: list
-        The coincident SNR values for triggers surviving the coherent cut
+        The coincident SNR values for triggers surviving the coherent
+        cut
     """
-    #Calculate rho_coh
+    # Calculate rho_coh
     snr_array = np.array([snr_triggers[ifo]
-                         for ifo in sorted(snr_triggers.keys())])
-    x = np.inner(snr_array.conj().transpose(),projection_matrix)
-    rho_coh2 = sum(x.transpose()*snr_array)
+                          for ifo in sorted(snr_triggers.keys())])
+    x = np.inner(snr_array.conj().transpose(), projection_matrix)
+    rho_coh2 = sum(x.transpose() * snr_array)
     rho_coh = np.sqrt(rho_coh2)
-    #Apply thresholds
+    # Apply thresholds
     index = index[rho_coh > threshold]
-    if len(coinc_snr) != 0: coinc_snr = coinc_snr[rho_coh > threshold]
-    snrv = {ifo : snr_triggers[ifo][rho_coh > threshold]
-           for ifo in snr_triggers.keys()}
+    if coinc_snr:
+        coinc_snr = coinc_snr[rho_coh > threshold]
+    snrv = {ifo: snr_triggers[ifo][rho_coh > threshold]
+            for ifo in snr_triggers.keys()}
     rho_coh = rho_coh[rho_coh > threshold]
     return rho_coh, index, snrv, coinc_snr
 
@@ -197,14 +207,14 @@ def network_chisq(chisq, chisq_dof, snr_dict):
     chisq: dict
         Dictionary of individual detector chi-squared statistics
     chisq_dof: dict
-        Dictionary of the number of degrees of freedom of the chi-squared
-        statistic
+        Dictionary of the number of degrees of freedom of the
+        chi-squared statistic
     snr_dict: dict
         Dictionary of complex individual detector SNRs
-    
+
     Returns
     -------
-    network_chisq: list
+    net_chisq: list
         Network chi-squared values
     """
     ifos = sorted(snr_dict.keys())
@@ -212,23 +222,24 @@ def network_chisq(chisq, chisq_dof, snr_dict):
     for ifo in ifos:
         chisq_per_dof[ifo] = chisq[ifo] / chisq_dof[ifo]
         chisq_per_dof[ifo][chisq_per_dof[ifo] < 1] = 1
-    snr2 = {ifo : np.real(np.array(snr_dict[ifo]) *
-                np.array(snr_dict[ifo]).conj()) for ifo in ifos}
+    snr2 = {ifo: np.real(np.array(snr_dict[ifo]) *
+                 np.array(snr_dict[ifo]).conj())
+            for ifo in ifos}
     coinc_snr2 = sum(snr2.values())
-    snr2_ratio = {ifo : snr2[ifo] / coinc_snr2 for ifo in ifos}
-    network_chisq = sum([chisq_per_dof[ifo] * snr2_ratio[ifo] for ifo in ifos])
-    return network_chisq
+    snr2_ratio = {ifo: snr2[ifo] / coinc_snr2 for ifo in ifos}
+    net_chisq = sum([chisq_per_dof[ifo] * snr2_ratio[ifo] for ifo in ifos])
+    return net_chisq
 
 
-def pycbc_reweight_snr(network_snr, network_chisq, a = 3, b = 1. / 6.):
+def reweighted_snr(netwk_snr, netwk_chisq, a=3, b=1./6.):
     """
     Output: reweighted_snr: Reweighted SNR for each trigger
-    Input:  network_snr:  Dictionary of coincident or coherent SNR for each
-                          trigger
-            network_chisq: A chisq value for each trigger 
+    Input:  netwk_snr:  Dictionary of coincident or coherent SNR for each
+                        trigger
+            netwk_chisq: A chisq value for each trigger
     """
-    denom = ((1 + network_chisq)**a) / 2
-    reweighted_snr = network_snr / denom**b
+    denom = ((1 + netwk_chisq)**a) / 2
+    reweighted_snr = netwk_snr / denom**b
     return reweighted_snr
 
 
@@ -260,11 +271,11 @@ def null_snr(rho_coh, rho_coinc, null_min=5.25, null_grad=0.2, null_step=20.,
     # Make cut on null.
     keep1 = np.logical_and(null < null_min, rho_coh <= null_step)
     keep2 = np.logical_and(null < (rho_coh * null_grad + null_min),
-                          rho_coh > null_step)
+                           rho_coh > null_step)
     keep = np.logical_or(keep1, keep2)
     index = index[keep]
-    rho_coh  = rho_coh[keep]
-    snrv = {ifo : snrv[ifo][keep] for ifo in snrv.keys()}
+    rho_coh = rho_coh[keep]
+    snrv = {ifo: snrv[ifo][keep] for ifo in snrv}
     rho_coinc = rho_coinc[keep]
     null = null[keep]
     return null, rho_coh, rho_coinc, index, snrv
@@ -281,4 +292,3 @@ def reweight_snr_by_null(network_snr, nullsnr):
     nullsnr[nullsnr <= 4.25] = 4.25
     reweighted_snr = network_snr / (nullsnr - 3.25)
     return reweighted_snr
-

--- a/pycbc/events/coherent.py
+++ b/pycbc/events/coherent.py
@@ -349,7 +349,7 @@ def null_snr(
 
 
 def reweight_snr_by_null(
-        network_snr, null_snr, coherent_snr, null_min=5.25, null_grad=0.2,
+        network_snr, null, coherent, null_min=5.25, null_grad=0.2,
         null_step=20.0):
     """Re-weight the detection statistic as a function of the null SNR.
     See Eq. 16 of Williamson et al. (2014) [arXiv:1410.6042].
@@ -358,9 +358,9 @@ def reweight_snr_by_null(
     ----------
     network_snr: numpy.ndarray
         Array containing SNR statistic to be re-weighted
-    null_snr: numpy.ndarray
+    null: numpy.ndarray
         Null SNR array
-    coherent_snr:
+    coherent:
         Coherent SNR array
 
     Returns
@@ -369,15 +369,16 @@ def reweight_snr_by_null(
         Re-weighted SNR for each trigger
     """
     downweight = (
-        ((null_snr > null_min - 1) & (coherent_snr <= null_step))
+        ((null > null_min - 1) & (coherent <= null_step))
         | (
-            (null_snr > (coherent_snr * null_grad + null_min - 1))
-            & (coherent_snr > null_step))
+            (null > (coherent * null_grad + null_min - 1))
+            & (coherent > null_step)
+            )
         )
     rw_fac = np.where(
-        coherent_snr > null_step,
-        1 + null_snr - (null_min - 1) - (coherent_snr - null_step) * null_grad,
-        1 + null_snr - (null_min - 1)
+        coherent > null_step,
+        1 + null - (null_min - 1) - (coherent - null_step) * null_grad,
+        1 + null - (null_min - 1)
         )
     rw_snr = np.where(downweight, network_snr / rw_fac, network_snr)
     return rw_snr

--- a/pycbc/events/coherent.py
+++ b/pycbc/events/coherent.py
@@ -57,9 +57,8 @@ def get_coinc_indexes(idx_dict, time_delay_idx):
             )
     # Search through coinc_idx for repeated indexes. These must have been loud
     # in at least 2 detectors.
-    coinc_idx = np.unique(coinc_list, return_counts=True)[0][
-        np.unique(coinc_list, return_counts=True)[1] > 1
-    ]
+    counts = np.unique(coinc_list, return_counts=True)
+    coinc_idx = counts[0][counts[1] > 1]
     return coinc_idx
 
 
@@ -266,7 +265,7 @@ def network_chisq(chisq, chisq_dof, snr_dict):
 
 
 def reweighted_snr(netwk_snr, netwk_chisq, idx1=3, idx2=1.0 / 6.0):
-    """Return the chi-squeared re-weighted SNR statistic
+    """Return the chi-squared re-weighted SNR statistic
 
     Parameters
     ----------

--- a/pycbc/events/coherent.py
+++ b/pycbc/events/coherent.py
@@ -367,5 +367,5 @@ def reweight_snr_by_null(network_snr, nullsnr):
     """
     nullsnr = np.array(nullsnr)
     nullsnr[nullsnr <= 4.25] = 4.25
-    reweighted_snr = network_snr / (nullsnr - 3.25)
-    return reweighted_snr
+    rw_snr = network_snr / (nullsnr - 3.25)
+    return rw_snr

--- a/pycbc/events/coherent.py
+++ b/pycbc/events/coherent.py
@@ -114,7 +114,7 @@ def coincident_snr(snr_dict, index, threshold, time_delay_idx):
         survive cuts
     """
     # Restrict the snr timeseries to just the interesting points
-    coinc_triggers = get_coinc_triggers(snr_dict, index, time_delay_index)
+    coinc_triggers = get_coinc_triggers(snr_dict, index, time_delay_idx)
     # Calculate the coincident snr
     snr_array = np.array(
         [coinc_triggers[ifo] for ifo in coinc_triggers.keys()]
@@ -123,12 +123,12 @@ def coincident_snr(snr_dict, index, threshold, time_delay_idx):
     # Apply threshold
     thresh_indexes = rho_coinc > threshold
     index = index[thresh_indexes]
-    coinc_triggers = get_coinc_triggers(snr_dict, index, time_delay_index)
+    coinc_triggers = get_coinc_triggers(snr_dict, index, time_delay_idx)
     rho_coinc = rho_coinc[thresh_indexes]
     return rho_coinc, index, coinc_triggers
 
 
-def get_projection_matrix(f_pluss, f_cross, sigma, projection="standard"):
+def get_projection_matrix(f_plus, f_cross, sigma, projection="standard"):
     """Calculate the matrix that prjects the signal onto the network.
 
     Parameters
@@ -216,8 +216,8 @@ def coherent_snr(
     snr_array = np.array(
         [snr_triggers[ifo] for ifo in sorted(snr_triggers.keys())]
     )
-    x = np.inner(snr_array.conj().transpose(), projection_matrix)
-    rho_coh2 = sum(x.transpose() * snr_array)
+    snr_proj = np.inner(snr_array.conj().transpose(), projection_matrix)
+    rho_coh2 = sum(snr_proj.transpose() * snr_array)
     rho_coh = np.sqrt(rho_coh2)
     # Apply thresholds
     index = index[rho_coh > threshold]
@@ -312,7 +312,7 @@ def null_snr(
     snrv: dict of None (optional; default None)
         Individual detector SNRs. If given will remove triggers that
         fail cut
-   
+
     Returns
     -------
     null: numpy.ndarray
@@ -351,7 +351,7 @@ def null_snr(
 
 def reweight_snr_by_null(network_snr, nullsnr):
     """Re-weight the detection statistic as a function of the null SNR
-    
+
     Parameters
     ----------
     network_snr: dict
@@ -359,7 +359,7 @@ def reweight_snr_by_null(network_snr, nullsnr):
         trigger
     null: numpy.ndarray
         Null snr for each trigger
-    
+
     Returns
     -------
     reweighted_snr: dict

--- a/pycbc/events/coherent.py
+++ b/pycbc/events/coherent.py
@@ -128,7 +128,13 @@ def coincident_snr(snr_dict, index, threshold, time_delay_idx):
 
 
 def get_projection_matrix(f_plus, f_cross, sigma, projection="standard"):
-    """Calculate the matrix that prjects the signal onto the network.
+    """Calculate the matrix that projects the signal onto the network.
+    Definitions can be found in Fairhurst (2018) [arXiv:1712.04724].
+    For the standard projection see Eq. 8, and for left/right
+    circular projections see Eq. 21, with further discussion in
+    Appendix A. See also Williamson et al. (2014) [arXiv:1410.6042]
+    for discussion in context of the GRB search with restricted
+    binary inclination angles.
 
     Parameters
     ----------
@@ -176,7 +182,9 @@ def get_projection_matrix(f_plus, f_cross, sigma, projection="standard"):
             + (np.outer(w_c, w_p) - np.outer(w_p, w_c)) * 1j
         ) / (np.dot(w_p, w_p) + np.dot(w_c, w_c))
     else:
-        raise ValueError("Unknown projection: {}".format(projection))
+        raise ValueError(
+            f'Unknown projection: {projection}. Allowed values are: '
+            '"standard", "left", and "right"')
 
     return projection_matrix
 
@@ -184,7 +192,9 @@ def get_projection_matrix(f_plus, f_cross, sigma, projection="standard"):
 def coherent_snr(
     snr_triggers, index, threshold, projection_matrix, coinc_snr=None
 ):
-    """Calculate the coherent SNR for a given set of triggers
+    """Calculate the coherent SNR for a given set of triggers. See
+    Eq. 2.26 of Harry & Fairhurst (2011) [arXiv:1012.4939].
+
 
     Parameters
     ----------
@@ -233,7 +243,9 @@ def coherent_snr(
 
 
 def network_chisq(chisq, chisq_dof, snr_dict):
-    """Calculate the network chi-squared statistic
+    """Calculate the network chi-squared statistic. This is the sum of
+    SNR-weighted individual detector chi-squared values. See Eq. 5.4
+    of Dorrington (2019) [http://orca.cardiff.ac.uk/id/eprint/128124].
 
     Parameters
     ----------
@@ -251,7 +263,7 @@ def network_chisq(chisq, chisq_dof, snr_dict):
         Network chi-squared values
     """
     ifos = sorted(snr_dict.keys())
-    chisq_per_dof = {}
+    chisq_per_dof = dict.fromkeys(ifos)
     for ifo in ifos:
         chisq_per_dof[ifo] = chisq[ifo] / chisq_dof[ifo]
         chisq_per_dof[ifo][chisq_per_dof[ifo] < 1] = 1
@@ -269,9 +281,11 @@ def null_snr(
     rho_coh, rho_coinc, apply_cut=True, null_min=5.25, null_grad=0.2,
     null_step=20.0, index=None, snrv=None
 ):
-    """Calculate the null SNR and apply threshold cut where
+    """Calculate the null SNR and optionally apply threshold cut where
     null SNR > null_min where coherent SNR < null_step
-    and null SNR > (null_grad * rho_coh + null_min) elsewhere
+    and null SNR > (null_grad * rho_coh + null_min) elsewhere. See
+    Eq. 3.1 of Harry & Fairhurst (2011) [arXiv:1012.4939] or
+    Eqs. 11 and 12 of Williamson et al. (2014) [arXiv:1410.6042]..
 
     Parameters
     ----------
@@ -337,7 +351,8 @@ def null_snr(
 def reweight_snr_by_null(
         network_snr, null_snr, coherent_snr, null_min=5.25, null_grad=0.2,
         null_step=20.0):
-    """Re-weight the detection statistic as a function of the null SNR
+    """Re-weight the detection statistic as a function of the null SNR.
+    See Eq. 16 of Williamson et al. (2014) [arXiv:1410.6042].
 
     Parameters
     ----------

--- a/pycbc/events/coherent.py
+++ b/pycbc/events/coherent.py
@@ -264,26 +264,6 @@ def network_chisq(chisq, chisq_dof, snr_dict):
     return net_chisq
 
 
-def reweighted_snr(netwk_snr, netwk_chisq, idx1=3, idx2=1.0 / 6.0):
-    """Return the chi-squared re-weighted SNR statistic
-
-    Parameters
-    ----------
-    netwk_snr: numpy.ndarray
-        Array of coherent SNRs
-    netwk_chisq: numpy.ndarray
-        Network chisq values corresponding to each trigger
-
-    Returns
-    -------
-    rw_snr: numpy.ndarray
-        Array of re-weighted SNRs
-    """
-    denom = ((1 + netwk_chisq) ** idx1) / 2
-    rw_snr = netwk_snr / denom ** idx2
-    return rw_snr
-
-
 def null_snr(
     rho_coh, rho_coinc, null_min=5.25, null_grad=0.2, null_step=20.0,
     index=None, snrv=None
@@ -361,7 +341,7 @@ def reweight_snr_by_null(network_snr, nullsnr):
 
     Returns
     -------
-    reweighted_snr: dict
+    rw_snr: dict
         Re-weighted SNR for each trigger
     """
     nullsnr = np.array(nullsnr)


### PR DESCRIPTION
As development on `pycbc_multi_inspiral` has progressed, the executable has gathered a lot of utility functions to do with trigger identification and coherent SNR calculation that would be better placed elsewhere. I suggest moving them to a coherent module.