### PR TITLE
Fix a few issues in `pycbc_optimize_snr`

### DIFF
--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -366,12 +366,13 @@ class LiveEventManager(object):
                     opt_scheme = args.processing_scheme.split(':')[0]
                     cmd += '--processing-scheme {}:1 '.format(opt_scheme)
 
-                log_fname = \
-                        fname.replace('.xml.gz', '_optimize_snr_log.dat')
+                log_fname = fname.replace('.xml.gz', '_optimize_snr.log')
 
-                cmd += '>{} 2>&1'.format(log_fname)
-                logging.info('Running %s', cmd)
-                subprocess.Popen(cmd, shell=True)
+                logging.info('Running %s with log to %s', cmd, log_fname)
+                with open(log_fname, "w") as logfile:
+                    subprocess.Popen(
+                        cmd, shell=True, stdout=logfile, stderr=logfile
+                    )
 
 
     def check_singles(self, results, data_reader, psds, f_low):

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -369,7 +369,7 @@ class LiveEventManager(object):
                 log_fname = \
                         fname.replace('.xml.gz', '_optimize_snr_log.dat')
 
-                cmd += '&> {} '.format(log_fname)
+                cmd += '>{} 2>&1'.format(log_fname)
                 logging.info('Running %s', cmd)
                 subprocess.Popen(cmd, shell=True)
 

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -353,7 +353,7 @@ class LiveEventManager(object):
                 if self.enable_gracedb_upload:
                     cmd += '--enable-gracedb-upload '
 
-                cmd += '--cores {}'.format(self.fu_cores)
+                cmd += '--cores {} '.format(self.fu_cores)
                 if args.processing_scheme:
                     # we will use the cores for multiple workers of the
                     # optimization routine, so we force the processing scheme
@@ -364,7 +364,7 @@ class LiveEventManager(object):
                     # unlikely to benefit from a processing scheme with more
                     # than 1 thread anyway.
                     opt_scheme = args.processing_scheme.split(':')[0]
-                    cmd += '--processing-scheme {}:1'.format(opt_scheme)
+                    cmd += '--processing-scheme {}:1 '.format(opt_scheme)
 
                 log_fname = \
                         fname.replace('.xml.gz', '_optimize_snr_log.dat')

--- a/bin/pycbc_optimize_snr
+++ b/bin/pycbc_optimize_snr
@@ -299,10 +299,9 @@ for ifo in ifos:
     data[ifo].psd = load_frequencyseries(args.psd_files[ifo])
 
 fp = h5py.File(args.params_file, 'r')
+original_gid = None
 if 'gid' in fp:
-    original_gid = fp['gid'][()]
-else:
-    original_gid = None
+    original_gid = fp['gid'].asstr()[()]
 if args.enable_gracedb_upload and not original_gid:
     raise RuntimeError('Params must include original gracedb ID in order '
                        'to upload followup!')
@@ -473,7 +472,7 @@ coinc_results['foreground/ifar'] = fp['ifar'][()]
 
 channel_names = {}
 for ifo in fp['channel_names'].keys():
-    channel_names[ifo] = fp['channel_names'][ifo][()]
+    channel_names[ifo] = fp['channel_names'][ifo].asstr()[()]
 
 mc_area_args = load_hdf5_to_dict(fp, 'mc_area_args/')
 


### PR DESCRIPTION
This fixes:
* Some str-vs-bytes confusion (creating problems with GraceDB) caused by h5py 3.x.
* A leftover error from #3927.
* The stdout/stderr redirect, which is Bash-specific and does not work on one of my virtual machines.