### PR TITLE
Run SNR optimizer in PyCBC Live example/test

### DIFF
--- a/examples/live/.gitignore
+++ b/examples/live/.gitignore
@@ -3,3 +3,4 @@ template_bank.hdf
 injections.hdf
 stat*.hdf
 output/
+*.fits

--- a/examples/live/run.sh
+++ b/examples/live/run.sh
@@ -111,6 +111,7 @@ echo -e "\\n\\n>> [`date`] Running PyCBC Live"
 mpirun \
 -host localhost,localhost \
 -n 2 \
+--bind-to none \
 -x PYTHONPATH -x LD_LIBRARY_PATH -x OMP_NUM_THREADS -x VIRTUAL_ENV -x PATH -x HDF5_USE_FILE_LOCKING \
 \
 python -m mpi4py `which pycbc_live` \
@@ -181,7 +182,15 @@ python -m mpi4py `which pycbc_live` \
 --src-class-mchirp-to-delta 0.01 \
 --src-class-eff-to-lum-distance 0.74899 \
 --src-class-lum-distance-to-delta -0.51557 -0.32195 \
+--run-snr-optimization \
 --verbose
+
+# cat the logs of pycbc_optimize_snr so we can check them
+for opt_snr_log in `ls output/*optimize_snr.log`
+do
+    echo -e "\\n\\n>> [`date`] Showing log of SNR optimizer, ${opt_snr_log}"
+    cat ${opt_snr_log}
+done
 
 echo -e "\\n\\n>> [`date`] Checking results"
 ./check_results.py \


### PR DESCRIPTION
I found that this does not actually take a lot of time on my test machine, so why not. At the moment the SNR optimizer fails on one of the injections (see #3928) so I did not add any actual check that the SNR optimization is successful. However, if a LIGOLW file is generated, BAYESTAR will run on it, so we can spot cases where `pycbc_optimize_snr` breaks BAYESTAR.