### PR TITLE
Adding test of pycbc_multi_inspiral face-on/-away

### DIFF
--- a/examples/multi_inspiral/check_faceon_faceaway_trigs.py
+++ b/examples/multi_inspiral/check_faceon_faceaway_trigs.py
@@ -3,12 +3,13 @@
 # triggers compatible with mock GW170817-like injections
 # 2022 Andrew Williamson, Tito Dal Canton
 
-import logging
 import sys
+import logging
 import h5py
 import numpy as np
+from pycbc import init_logging
 
-logging.basicConfig(format='%(asctime)s : %(message)s', level=logging.INFO)
+init_logging(True)
 gw170817_time = 1187008882
 end_times = (np.arange(3) - 1) * 300 + gw170817_time
 pols = ['standard', 'left', 'right', 'left+right']
@@ -29,8 +30,8 @@ for pol in pols:
         snrs[1] < 1.1 * refs[pol]
         )
     n = mask.sum()
-    result = 'Pass' if n == 3 else 'Fail'
-    if result == 'Fail':
+    result = 'PASS' if n == 3 else 'FAIL'
+    if result == 'FAIL':
         status = 1
-    logging.info('%s: %d triggers found for "%s" polarization', result, n, pol)
+    logging.info('"%s" polarization: %s (%d/3 triggers found)', pol, result, n)
 sys.exit(status)

--- a/examples/multi_inspiral/check_faceon_faceaway_trigs.py
+++ b/examples/multi_inspiral/check_faceon_faceaway_trigs.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+# Read a pycbc_imulti_inspiral HDF5 trigger file and check that it contains
+# triggers compatible with mock GW170817-like injections
+# 2022 Andrew Williamson, Tito Dal Canton
+
+import logging
+import sys
+import h5py
+import numpy as np
+
+logging.basicConfig(format='%(asctime)s : %(message)s', level=logging.INFO)
+gw170817_time = 1187008882
+end_times = (np.arange(3) - 1) * 300 + gw170817_time
+pols = ['standard', 'left', 'right', 'left+right']
+refs = {
+    'standard': np.array([38.8, 18.4, 39.4]),
+    'left': np.array([23.5, 17.0, 38.9]),
+    'right': np.array([38.1, 17.1, 24.3]),
+    'left+right': np.array([38.1, 17.1, 38.9])
+    }
+status = 0
+for pol in pols:
+    with h5py.File(pol + '.hdf', 'r') as f:
+        snrs = [f['network/end_time_gc'][:], f['network/coherent_snr'][:]]
+    # search for compatible trigs
+    mask = np.logical_and(
+        abs(end_times - snrs[0]) < 0.1,
+        snrs[1] > 0.9 * refs[pol],
+        snrs[1] < 1.1 * refs[pol]
+        )
+    n = mask.sum()
+    result = 'Pass' if n == 3 else 'Fail'
+    if result == 'Fail':
+        status = 1
+    logging.info('%s: %d triggers found for "%s" polarization', result, n, pol)
+sys.exit(status)

--- a/examples/multi_inspiral/check_faceon_faceaway_trigs.py
+++ b/examples/multi_inspiral/check_faceon_faceaway_trigs.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Read a pycbc_imulti_inspiral HDF5 trigger file and check that it contains
+# Read a pycbc_multi_inspiral HDF5 trigger file and check that it contains
 # triggers compatible with mock GW170817-like injections
 # 2022 Andrew Williamson, Tito Dal Canton
 

--- a/examples/multi_inspiral/check_gw170817_trigs.py
+++ b/examples/multi_inspiral/check_gw170817_trigs.py
@@ -25,7 +25,6 @@ mask = (
     & (snrs[2] > 25)
     )
 n = mask.sum()
-status = 0
 if n > 0:
     result = 'PASS'
     status = 0

--- a/examples/multi_inspiral/check_gw170817_trigs.py
+++ b/examples/multi_inspiral/check_gw170817_trigs.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+# Read a pycbc_multi_inspiral HDF5 trigger file and check that it contains
+# triggers compatible with mock GW170817-like injections
+# 2022 Andrew Williamson, Tito Dal Canton
+
+import sys
+import logging
+import h5py
+import numpy as np
+from pycbc import init_logging
+
+init_logging(True)
+gw170817_time = 1187008882.43
+status = 0
+with h5py.File('GW170817_test_output.hdf', 'r') as f:
+    snrs = [
+        f['network/end_time_gc'][:],
+        f['network/coherent_snr'][:],
+        f['network/reweighted_snr'][:],
+        ]
+# search for compatible trigs
+mask = (abs(gw170817_time - snrs[0]) < 0.1)
+n = mask.sum()
+status = 0
+if n > 0:
+    result = 'PASS'
+    status = 0
+else:
+    result = 'FAIL'
+    status = 1
+logging.info(
+    '%s: GW170817 found with coherent SNR = %.2f; reweighted SNR %.2f', result,
+    snrs[1][mask], snrs[2][mask])
+sys.exit(status)

--- a/examples/multi_inspiral/check_gw170817_trigs.py
+++ b/examples/multi_inspiral/check_gw170817_trigs.py
@@ -19,7 +19,11 @@ with h5py.File('GW170817_test_output.hdf', 'r') as f:
         f['network/reweighted_snr'][:],
         ]
 # search for compatible trigs
-mask = (abs(gw170817_time - snrs[0]) < 0.1)
+mask = (
+    (abs(gw170817_time - snrs[0]) < 0.1)
+    & (snrs[1] > 25)
+    & (snrs[2] > 25)
+    )
 n = mask.sum()
 status = 0
 if n > 0:

--- a/examples/multi_inspiral/clean.sh
+++ b/examples/multi_inspiral/clean.sh
@@ -1,0 +1,1 @@
+rm -f bank_veto_bank.xml *.hdf *.gwf

--- a/examples/multi_inspiral/faceon_faceaway.sh
+++ b/examples/multi_inspiral/faceon_faceaway.sh
@@ -8,7 +8,6 @@ GPS_START=$((START - 32))
 GPS_END=$((END + 32))
 DUR=$((GPS_END - GPS_START))
 CONFIG_URL=https://github.com/gwastro/pycbc-config/raw/master/test/multi_inspiral
-CONFIG_URL=https://github.com/a-r-williamson/pycbc-config/raw/pycbc_multi_inspiral_tests/test/multi_inspiral
 INJ_FILE=faceon_faceaway_injs.hdf
 
 echo -e "\\n\\n>> [`date`] Getting injection file"

--- a/examples/multi_inspiral/faceon_faceaway.sh
+++ b/examples/multi_inspiral/faceon_faceaway.sh
@@ -16,8 +16,8 @@ wget -nc ${CONFIG_URL}/${INJ_FILE}
 
 # Generate mock data
 for IFO in 'H1' 'L1' 'V1'; do
-    echo -e "\\n\\n>> [`date`] generating mock data for ${IFO}"
-    `which pycbc_condition_strain` \
+    echo -e "\\n\\n>> [`date`] Generating mock data for ${IFO}"
+    pycbc_condition_strain \
         --fake-strain zeroNoise \
         --sample-rate 4096 \
         --gps-start-time ${GPS_START} \
@@ -43,7 +43,7 @@ wget -nc ${CONFIG_URL}/${BANK_VETO_FILE}
 
 for POL in 'standard' 'left' 'right' 'left+right'; do
     echo -e "\\n\\n>> [`date`] Running pycbc_multi_inspiral with ${POL} projection"
-    `which pycbc_multi_inspiral` \
+    pycbc_multi_inspiral \
         --projection ${POL} \
         --processing-scheme mkl \
         --instruments H1 L1 V1 \

--- a/examples/multi_inspiral/faceon_faceaway.sh
+++ b/examples/multi_inspiral/faceon_faceaway.sh
@@ -1,0 +1,82 @@
+#!/bin/bash -e
+
+EVENT=1187008882
+STEP=300
+START=$((EVENT - 2 * STEP))
+END=$((EVENT + STEP + 64))
+GPS_START=$((START - 32))
+GPS_END=$((END + 32))
+DUR=$((GPS_END - GPS_START))
+CONFIG_URL=https://github.com/gwastro/pycbc-config/raw/master/test/multi_inspiral
+CONFIG_URL=https://github.com/a-r-williamson/pycbc-config/raw/pycbc_multi_inspiral_tests/test/multi_inspiral
+INJ_FILE=faceon_faceaway_injs.hdf
+
+echo -e "\\n\\n>> [`date`] Getting injection file"
+wget -nc ${CONFIG_URL}/${INJ_FILE}
+
+# Generate mock data
+for IFO in 'H1' 'L1' 'V1'; do
+    echo -e "\\n\\n>> [`date`] generating mock data for ${IFO}"
+    `which pycbc_condition_strain` \
+        --fake-strain zeroNoise \
+        --sample-rate 4096 \
+        --gps-start-time ${GPS_START} \
+        --gps-end-time ${GPS_END} \
+        --channel-name ${IFO}:SIMULATED_GW170817 \
+        --injection-file ${INJ_FILE} \
+        --output-strain-file ${IFO}-SIMULATED_GW170817-${GPS_START}-${DUR}.gwf
+done
+
+TRIG_START=$((START + 256))
+TRIG_END=$((END - 32))
+PAD=8
+BANK_FILE=gw170817_single_template.hdf
+BANK_VETO_FILE=bank_veto_bank.xml
+CHANNEL=SIMULATED_GW170817
+RA=5.016076270234897
+DEC=-0.408407044967
+
+echo -e "\\n\\n>> [`date`] Getting template bank"
+wget -nc ${CONFIG_URL}/${BANK_FILE}
+echo -e "\\n\\n>> [`date`] Bank veto bank"
+wget -nc ${CONFIG_URL}/${BANK_VETO_FILE}
+
+for POL in 'standard' 'left' 'right' 'left+right'; do
+    echo -e "\\n\\n>> [`date`] Running pycbc_multi_inspiral with ${POL} projection"
+    `which pycbc_multi_inspiral` \
+        --projection ${POL} \
+        --processing-scheme mkl \
+        --instruments H1 L1 V1 \
+        --trigger-time ${EVENT} \
+        --gps-start-time $((GPS_START + PAD)) \
+        --gps-end-time $((GPS_END - PAD)) \
+        --trig-start-time ${TRIG_START} \
+        --trig-end-time ${TRIG_END} \
+        --ra ${RA} \
+        --dec ${DEC} \
+        --bank-file ${BANK_FILE} \
+        --approximant IMRPhenomD \
+        --order -1 \
+        --low-frequency-cutoff 30 \
+        --pad-data 8 \
+        --strain-high-pass 25 \
+        --sample-rate 4096 \
+        --channel-name H1:${CHANNEL} L1:${CHANNEL} V1:${CHANNEL} \
+        --frame-files \
+            H1:H1-${CHANNEL}-${GPS_START}-${DUR}.gwf \
+            L1:L1-${CHANNEL}-${GPS_START}-${DUR}.gwf \
+            V1:V1-${CHANNEL}-${GPS_START}-${DUR}.gwf \
+        --snr-threshold 4.0 \
+        --chisq-bins "0.9*get_freq('fSEOBNRv4Peak',params.mass1,params.mass2,params.spin1z,params.spin2z)**(2./3.)" \
+        --bank-veto-bank-file ${BANK_VETO_FILE} \
+        --cluster-method window \
+        --cluster-window 0.1 \
+        --segment-length 256 \
+        --segment-start-pad 111 \
+        --segment-end-pad 17 \
+        --psd-model aLIGOEarlyHighSensitivityP1200087 \
+        --output ${POL}.hdf
+done
+
+echo -e "\\n\\n>> [`date`] Checking output files"
+python ./check_faceon_faceaway_trigs.py

--- a/examples/multi_inspiral/run.sh
+++ b/examples/multi_inspiral/run.sh
@@ -1,7 +1,6 @@
 #!/bin/bash -e
 
 CONFIG_URL=https://github.com/gwastro/pycbc-config/raw/master/test/multi_inspiral
-CONFIG_URL=https://github.com/a-r-williamson/pycbc-config/raw/pycbc_multi_inspiral_tests/test/multi_inspiral
 BANK_FILE=gw170817_single_template.hdf
 BANK_VETO_FILE=bank_veto_bank.xml
 H1_FRAME=https://www.gw-openscience.org/eventapi/html/GWTC-1-confident/GW170817/v3/H-H1_GWOSC_4KHZ_R1-1187006835-4096.gwf

--- a/examples/multi_inspiral/run.sh
+++ b/examples/multi_inspiral/run.sh
@@ -1,0 +1,73 @@
+#!/bin/bash -e
+
+CONFIG_URL=https://github.com/gwastro/pycbc-config/raw/master/test/multi_inspiral
+CONFIG_URL=https://github.com/a-r-williamson/pycbc-config/raw/pycbc_multi_inspiral_tests/test/multi_inspiral
+BANK_FILE=gw170817_single_template.hdf
+BANK_VETO_FILE=bank_veto_bank.xml
+H1_FRAME=https://www.gw-openscience.org/eventapi/html/GWTC-1-confident/GW170817/v3/H-H1_GWOSC_4KHZ_R1-1187006835-4096.gwf
+H1_CHANNEL=GWOSC-4KHZ_R1_STRAIN
+L1_FRAME=https://dcc.ligo.org/public/0144/T1700406/003/L-L1_CLEANED_HOFT_C02_T1700406_v3-1187008667-4096.gwf
+L1_CHANNEL=DCH-CLEAN_STRAIN_C02_T1700406_v3
+V1_FRAME=https://www.gw-openscience.org/eventapi/html/GWTC-1-confident/GW170817/v3/V-V1_GWOSC_4KHZ_R1-1187006835-4096.gwf
+V1_CHANNEL=GWOSC-4KHZ_R1_STRAIN
+
+echo -e "\\n\\n>> [`date`] Getting template bank"
+wget -nc ${CONFIG_URL}/${BANK_FILE}
+echo -e "\\n\\n>> [`date`] Bank veto bank"
+wget -nc ${CONFIG_URL}/${BANK_VETO_FILE}
+for IFO in H1 L1 V1; do
+    echo -e "\\n\\n>> [`date`] Getting ${IFO} frame"
+    FRAME=${IFO}_FRAME
+    wget -nc ${!FRAME}
+done
+
+EVENT=1187008882
+PAD=8
+START_PAD=111
+END_PAD=17
+GPS_START=$((EVENT - 192 - PAD))
+GPS_END=$((EVENT + 192 + PAD))
+TRIG_START=$((GPS_START + START_PAD))
+TRIG_END=$((GPS_END - END_PAD))
+OUTPUT=GW170817_test_output.hdf
+
+echo -e "\\n\\n>> [`date`] Running pycbc_multi_inspiral with ${POL} projection"
+pycbc_multi_inspiral \
+    --verbose \
+    --projection left+right \
+    --processing-scheme mkl \
+    --instruments H1 L1 V1 \
+    --trigger-time ${EVENT} \
+    --gps-start-time ${GPS_START} \
+    --gps-end-time ${GPS_END} \
+    --trig-start-time ${TRIG_START} \
+    --trig-end-time ${TRIG_END} \
+    --ra 3.44527994344 \
+    --dec -0.408407044967 \
+    --bank-file ${BANK_FILE} \
+    --approximant IMRPhenomD \
+    --order -1 \
+    --low-frequency-cutoff 30 \
+    --snr-threshold 3.0 \
+    --chisq-bins "0.9*get_freq('fSEOBNRv4Peak',params.mass1,params.mass2,params.spin1z,params.spin2z)**(2./3.)" \
+    --pad-data 8 \
+    --strain-high-pass 25 \
+    --sample-rate 4096 \
+    --channel-name H1:${H1_CHANNEL} L1:${L1_CHANNEL} V1:${V1_CHANNEL} \
+    --frame-files \
+        H1:`basename ${H1_FRAME}` \
+        L1:`basename ${L1_FRAME}` \
+        V1:`basename ${V1_FRAME}` \
+    --cluster-method window \
+    --cluster-window 0.1 \
+    --segment-length 256 \
+    --segment-start-pad ${START_PAD} \
+    --segment-end-pad ${END_PAD} \
+    --psd-estimation median \
+    --psd-segment-length 32 \
+    --psd-segment-stride 8 \
+    --psd-num-segments 29 \
+    --output ${OUTPUT}
+
+echo -e "\\n\\n>> [`date`] Checking output files"
+python check_gw170817_trigs.py

--- a/pycbc/frame/frame.py
+++ b/pycbc/frame/frame.py
@@ -79,7 +79,6 @@ def _read_channel(channel, stream, start, duration):
     channel_type = lalframe.FrStreamGetTimeSeriesType(channel, stream)
     read_func = _fr_type_map[channel_type][0]
     d_type = _fr_type_map[channel_type][1]
-    print(start, duration)
     data = read_func(stream, channel, start, duration, 0)
     return TimeSeries(data.data.data, delta_t=data.deltaT, epoch=start,
                       dtype=d_type)

--- a/pycbc/frame/frame.py
+++ b/pycbc/frame/frame.py
@@ -79,6 +79,7 @@ def _read_channel(channel, stream, start, duration):
     channel_type = lalframe.FrStreamGetTimeSeriesType(channel, stream)
     read_func = _fr_type_map[channel_type][0]
     d_type = _fr_type_map[channel_type][1]
+    print(start, duration)
     data = read_func(stream, channel, start, duration, 0)
     return TimeSeries(data.data.data, delta_t=data.deltaT, epoch=start,
                       dtype=d_type)

--- a/tools/pycbc_test_suite.sh
+++ b/tools/pycbc_test_suite.sh
@@ -75,6 +75,18 @@ if [ "$PYCBC_TEST_TYPE" = "search" ] || [ -z ${PYCBC_TEST_TYPE+x} ]; then
       fi
       popd
     fi
+
+    # run pycbc_multi_inspiral (PyGRB) test
+    pushd examples/multi_inspiral
+    bash -e run.sh
+    if test $? -ne 0 ; then
+        RESULT=1
+        echo -e "    FAILED!"
+        echo -e "---------------------------------------------------------"
+    else
+        echo -e "    Pass."
+    fi
+    popd
 fi
 
 if [ "$PYCBC_TEST_TYPE" = "inference" ] || [ -z ${PYCBC_TEST_TYPE+x} ]; then


### PR DESCRIPTION
This adds an example for `pycbc_multi_inspiral` to test not only the executable, but also the implementation of the face-on/-away signal projection used in PyGRB searches. Relies on gwastro/pycbc-config#76 for inputs.