### PR TITLE
PyCBC Live: stop uploading PSDs to GraceDB as separate files

### DIFF
--- a/pycbc/io/live.py
+++ b/pycbc/io/live.py
@@ -400,15 +400,6 @@ class SingleCoincForGraceDB(object):
                 gracedb.writeLabel(gid, 'INJ')
                 logging.info("Tagging event %s as an injection", gid)
 
-            # upload PSDs. Note that the PSDs are already stored in the
-            # original event file and we just upload a copy of that same file
-            # here. This keeps things as they were in O2 and can be removed
-            # after updating the follow-up infrastructure
-            psd_fname = 'psd.xml.gz' if fname.endswith('.gz') else 'psd.xml'
-            gracedb.writeLog(gid, "PyCBC PSD estimate from the time of event",
-                             psd_fname, open(fname, "rb").read(), "psd")
-            logging.info("Uploaded PSDs for event %s", gid)
-
             # add info for tracking code version
             gracedb_tag_with_version(gracedb, gid)
 


### PR DESCRIPTION
In the past, the low-latency alert system required the noise PSD estimates associated with a candidate event to be uploaded to GraceDB as a separate LIGOLW file. As described in https://lscsoft.docs.ligo.org/ligo.skymap/interface.html and https://git.ligo.org/emfollow/gwcelery/-/merge_requests/850, we are now transitioning to the assumption that the noise PSDs are part of the original LIGOLW upload, and the second upload is no longer necessary.

This PR removes the code that does the separate PSD upload. It also reorganizes the operations that happen when a candidate is uploaded, so that the first operation is the upload, and the diagnostic plots are done as a second step.

Needs testing.