### PR TITLE
Switch to minimal pegasus api requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,12 @@ lscsoft-glue>=1.59.3
 ligo-segments
 tqdm
 gwdatafind
-pegasus-wms.api >= 5.0.1
+
+# Requirements for full pegasus env
+pegasus-wms >= 5.0.1
+# need to pin until pegasus for further upstream
+# addresses incompatibility between old flask/jinja2 and latest markupsafe
+markupsafe <= 2.0.1
 
 # Requirements for ligoxml access needed by some workflows
 python-ligo-lw >= 1.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ lscsoft-glue>=1.59.3
 ligo-segments
 tqdm
 gwdatafind
-pegasus-wms >= 5.0.1
+pegasus-wms.api >= 5.0.1
 
 # Requirements for ligoxml access needed by some workflows
 python-ligo-lw >= 1.7.0

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ install_requires =  setup_requires + ['Mako>=1.0.1',
                       'ligo-segments',
                       'tqdm',
                       'gwdatafind',
-                      'pegasus-wms >= 5.0.1',
+                      'pegasus-wms.api >= 5.0.1',
                       'python-ligo-lw >= 1.7.0'
                       ]
 


### PR DESCRIPTION
This is an attempt to address the immediate issue of Pegasus having a hard requirement on flask which no longer works due to #3942. In general, it's probably a good idea to keep our dependencies as lean as possible as well.

Assuming this passes tests, is there any reason we don't *just* depend on the API? Doe we actually need anything else for the PyCBC library directly?