### PR TITLE
revert to standard dqsegdb

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -37,8 +37,7 @@ epsie==0.7.1
 dqsegdb2>=1.0.1
 amqplib
 htchirp >= 2.0
-# use dqsegdb fork till next dqsegdb release
-https://github.com/ahnitz/dqsegdb/archive/master.tar.gz
+dqsegdb >= 2.0.0
 
 # For building documentation
 Sphinx>=1.5.0,<2.0.0


### PR DESCRIPTION
This is an attempt to go back to the standard dqsegdb which I had to fork temporarily to hack in python3 support. My understanding is the last release should support python3, so :crossed_fingers: