### PR TITLE
add in some alternative smoothing methods

### DIFF
--- a/bin/all_sky_search/pycbc_fit_sngls_over_multiparam
+++ b/bin/all_sky_search/pycbc_fit_sngls_over_multiparam
@@ -95,7 +95,8 @@ def smooth_n_closest(nabove, invalphan, ntotal, dists, total_trigs=500):
     n_triggers = 0
     # Count number of templates required to gather total_trigs templates,
     # start at closest
-    while n_triggers < total_trigs:
+    # total_trigs, if supplied on command line will be a str so convert to int
+    while n_triggers < int(total_trigs):
         n_triggers += nabove[dist_sort[n_triggers]]
         templates_required += 1
     logging.debug("%d templates required to obtain %d triggers",
@@ -119,7 +120,7 @@ _smooth_dist_func = {
     'distance_weighted': smooth_distance_weighted
 }
 
-def smooth(nabove, invalphan, ntotal, dists, smoothing_method):
+def smooth(nabove, invalphan, ntotal, dists, smoothing_method, **kwargs):
     """
     Wrapper for smoothing according to a function defined by smoothing_method
 
@@ -130,7 +131,7 @@ def smooth(nabove, invalphan, ntotal, dists, smoothing_method):
     template of interest
     """
     return _smooth_dist_func[smoothing_method](nabove, invalphan,
-                                               ntotal, dists)
+                                               ntotal, dists, **kwargs)
 
 parser = argparse.ArgumentParser(usage="",
     description="Smooth (regress) the dependence of coefficients describing "
@@ -190,7 +191,7 @@ parser.add_argument("--smoothing-method", default="smooth_tophat",
                          "trucated at three smoothing-widths.")
 parser.add_argument("--smoothing-keywords", nargs='*',
                     help="Keywords for the smoothing function, supplied "
-                         "as key:value pairs, e.g. n_closest:500 to define "
+                         "as key:value pairs, e.g. total_trigs:500 to define "
                          "the number of templates in the n_closest smoothing "
                          "method")
 args = parser.parse_args()

--- a/bin/all_sky_search/pycbc_fit_sngls_over_multiparam
+++ b/bin/all_sky_search/pycbc_fit_sngls_over_multiparam
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 
-# Copyright 2016 Thomas Dent, Alex Nitz
+# Copyright 2016 Thomas Dent, Alex Nitz, Gareth Cabourn Davies
 #
 # This program is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License as published by the
@@ -18,16 +18,18 @@ import sys, h5py, argparse, logging, pycbc.version, numpy
 from scipy.stats import norm
 from pycbc.events import triggers
 
+
 def dist(i1, i2, parvals, smoothing_width):
     """
-    computes the vector of parameter values at index i1 and
-    set of indices i2, and gives the Euclidean distance between
+    Computes the vector of parameter values at index/indices i1 and
+    index/indices i2, and gives the Euclidean distance between
     the two with a metric of 1/(smoothing width^2)
     """
     dsq = 0
     for v, s in zip(parvals, smoothing_width):
         dsq += (v[i2] - v[i1]) ** 2.0 / s ** 2.0
     return dsq ** 0.5
+
 
 def smooth_templates(nabove, invalphan, ntotal, template_idx,
                      weights=None):
@@ -74,6 +76,7 @@ def smooth_templates(nabove, invalphan, ntotal, template_idx,
                     ntotal_t_smoothed)
     return return_tuple
 
+
 def smooth_tophat(nabove, invalphan, ntotal, dists):
     """
     Smooth templates using a tophat function with templates within unit
@@ -84,6 +87,7 @@ def smooth_tophat(nabove, invalphan, ntotal, dists):
                             invalphan,
                             ntotal,
                             idx_within_area)
+
 
 def smooth_n_closest(nabove, invalphan, ntotal, dists, total_trigs=500):
     """
@@ -104,6 +108,7 @@ def smooth_n_closest(nabove, invalphan, ntotal, dists, total_trigs=500):
     idx_to_smooth = dist_sort[:templates_required]
     return smooth_templates(nabove, invalphan, ntotal, idx_to_smooth)
 
+
 def smooth_distance_weighted(nabove, invalphan, ntotal, dists):
     """
     Smooth templates weighted according to dists in a unit-width normal
@@ -120,6 +125,7 @@ _smooth_dist_func = {
     'distance_weighted': smooth_distance_weighted
 }
 
+
 def smooth(nabove, invalphan, ntotal, dists, smoothing_method, **kwargs):
     """
     Wrapper for smoothing according to a function defined by smoothing_method
@@ -132,6 +138,7 @@ def smooth(nabove, invalphan, ntotal, dists, smoothing_method, **kwargs):
     """
     return _smooth_dist_func[smoothing_method](nabove, invalphan,
                                                ntotal, dists, **kwargs)
+
 
 parser = argparse.ArgumentParser(usage="",
     description="Smooth (regress) the dependence of coefficients describing "
@@ -241,11 +248,10 @@ for param, slog in zip(args.fit_param, args.log_param):
     else:
         raise ValueError("invalid log param argument, use 'true', or 'false'")
 
-# for an exponential fit 1/alpha is linear in the trigger statistic values
-# so calculating weighted sums or averages of 1/alpha is appropriate
 nabove = fits['count_above_thresh'][:]
 ntotal = fits['count_in_template'][:]
-
+# For an exponential fit 1/alpha is linear in the trigger statistic values
+# so calculating weighted sums or averages of 1/alpha is appropriate
 invalpha = 1. / fits['fit_coeff'][:]
 invalphan = invalpha * nabove
 
@@ -255,6 +261,7 @@ alpha_smoothed = []
 rang = numpy.arange(0, len(nabove))
 
 logging.info("Smoothing ...")
+
 # Handle the one-dimensional case of tophat smoothing separately
 # as it is easier to optimize computational performance.
 if len(parvals) == 1 and args.smoothing_method == 'smooth_tophat':
@@ -306,12 +313,12 @@ for param, vals, slog in zip(args.fit_param, parvals, args.log_param):
     elif slog in ['true', 'True', 'TRUE']:
         outfile[param] = numpy.exp(vals)
 
-# add metadata, some is inherited from template level fit
+# Add metadata, some is inherited from template level fit
 outfile.attrs['ifo'] = ifo
 outfile.attrs['stat_threshold'] = fits.attrs['stat_threshold']
 if 'analysis_time' in fits.attrs:
     outfile.attrs['analysis_time'] = fits.attrs['analysis_time']
 
-# add a magic file attribute so that coinc_findtrigs can parse it
+# Add a magic file attribute so that coinc_findtrigs can parse it
 outfile.attrs['stat'] = ifo + '-fit_coeffs'
 logging.info('Done!')

--- a/bin/all_sky_search/pycbc_fit_sngls_over_multiparam
+++ b/bin/all_sky_search/pycbc_fit_sngls_over_multiparam
@@ -121,10 +121,13 @@ _smooth_dist_func = {
 
 def smooth(nabove, invalphan, ntotal, dists, smoothing_method):
     """
-    Wrapper for smoothign according to a function defined by smoothing_method
+    Wrapper for smoothing according to a function defined by smoothing_method
+
     nabove, invalphan, ntotal are as defined in the above smooth_templates
     function docstring
-    dists defines the distances of the templates from the template of interest
+
+    dists is an array of the distances of the templates from the
+    template of interest
     """
     return _smooth_dist_func[smoothing_method](nabove, invalphan,
                                                ntotal, dists)

--- a/bin/all_sky_search/pycbc_fit_sngls_over_multiparam
+++ b/bin/all_sky_search/pycbc_fit_sngls_over_multiparam
@@ -19,6 +19,11 @@ from scipy.stats import norm
 from pycbc.events import triggers
 
 def dist(i1, i2, parvals, smoothing_width):
+    """
+    computes the vector of parameter values at index i1 and
+    set of indices i2, and gives the Euclidean distance between
+    the two with a metric of 1/(smoothing width^2)
+    """
     dsq = 0
     for v, s in zip(parvals, smoothing_width):
         dsq += (v[i2] - v[i1]) ** 2.0 / s ** 2.0
@@ -64,7 +69,6 @@ def smooth_templates(nabove, invalphan, ntotal, template_idx,
     ntotal_t_smoothed = numpy.average(ntotal[template_idx], weights=weights)
     invalphan_mean = numpy.average(invalphan[template_idx], weights=weights)
 
-    # return nabove_smoothed, alpha_smoothed, ntotal_smoothed
     return_tuple = (nabove_t_smoothed,
                     nabove_t_smoothed / invalphan_mean,
                     ntotal_t_smoothed)
@@ -73,7 +77,7 @@ def smooth_templates(nabove, invalphan, ntotal, template_idx,
 def smooth_tophat(nabove, invalphan, ntotal, dists):
     """
     Smooth templates using a tophat function with templates within unit
-    distance, with distances normalised by --smoothing-width
+    dists
     """
     idx_within_area = numpy.flatnonzero(dists < 1.)
     return smooth_templates(nabove,
@@ -81,7 +85,7 @@ def smooth_tophat(nabove, invalphan, ntotal, dists):
                             ntotal,
                             idx_within_area)
 
-def smooth_n_closest(nabove, invalphan, ntotal, dists):
+def smooth_n_closest(nabove, invalphan, ntotal, dists, total_trigs=500):
     """
     Smooth templates according to the closest N templates
     No weighting is applied
@@ -89,9 +93,9 @@ def smooth_n_closest(nabove, invalphan, ntotal, dists):
     dist_sort = numpy.argsort(dists)
     templates_required = 0
     n_triggers = 0
-    # Count number of templates required to gather 1000 templates,
+    # Count number of templates required to gather total_trigs templates,
     # start at closest
-    while n_triggers < 500:
+    while n_triggers < total_trigs:
         n_triggers += nabove[dist_sort[n_triggers]]
         templates_required += 1
     logging.debug("%d templates required to obtain %d triggers",
@@ -101,8 +105,8 @@ def smooth_n_closest(nabove, invalphan, ntotal, dists):
 
 def smooth_distance_weighted(nabove, invalphan, ntotal, dists):
     """
-    Smooth templates weithed according to a normal distribution
-    with width given by --smoothing-width, truncated at three sigma
+    Smooth templates weighted according to dists in a unit-width normal
+    distribution, truncated at three sigma
     """
     idx_within_area = numpy.flatnonzero(dists < 3.)
     weights = norm.pdf(dists[idx_within_area])
@@ -116,6 +120,12 @@ _smooth_dist_func = {
 }
 
 def smooth(nabove, invalphan, ntotal, dists, smoothing_method):
+    """
+    Wrapper for smoothign according to a function defined by smoothing_method
+    nabove, invalphan, ntotal are as defined in the above smooth_templates
+    function docstring
+    dists defines the distances of the templates from the template of interest
+    """
     return _smooth_dist_func[smoothing_method](nabove, invalphan,
                                                ntotal, dists)
 
@@ -168,7 +178,7 @@ parser.add_argument("--smoothing-method", default="smooth_tophat",
                     choices = _smooth_dist_func.keys(),
                     help="Method used to smooth the fit parameters; "
                          "'smooth_tophat' (default) finds all templates within "
-                         "unity distance from the template of interest "
+                         "unit distance from the template of interest "
                          "(distance normalised by --smoothing-width). "
                          "'n_closest' adds the closest templates to "
                          "the smoothing until 500 triggers are reached. "

--- a/bin/all_sky_search/pycbc_fit_sngls_over_multiparam
+++ b/bin/all_sky_search/pycbc_fit_sngls_over_multiparam
@@ -25,7 +25,40 @@ def dist(i1, i2, parvals, smoothing_width):
     return dsq ** 0.5
 
 def smooth_templates(nabove, invalphan, ntotal, template_idx,
-                      weights=None):
+                     weights=None):
+    """
+    Find the smoothed values according to the specified templates,
+    weighted appropriately.
+    The max likelihood fit for 1/alpha is linear in the trigger
+    statistic values, so we perform a possibly-weighted average
+    of (n_above / alpha) over templates and then invert this
+    and multiply by (smoothed) nabove to obtain smoothed alpha.
+
+    Parameters
+    ----------
+    nabove: ndarray
+        The array of counts of triggers above threshold for all templates
+    invalphan: ndarray
+        The array of n_above / alpha values for all templates
+    ntotal: ndarray
+        The array of count of triggers in the template, both above and
+        below threshold
+    template_idx: ndarray of ints
+        The indices of the templates to be used for the smoothing
+
+    Optional Parameters
+    -------------------
+    weights: ndarray
+        Weighting factor to apply to the templates specified by template_idx
+
+    Returns
+    -------
+    tuple: 3 floats
+        First float: the smoothed count above threshold value
+        Second float: the smoothed fit coefficient (alpha) value
+        Third float: the smoothed total count in template value
+
+    """
     if weights is None: weights = numpy.ones_like(template_idx)
     nabove_t_smoothed = numpy.average(nabove[template_idx], weights=weights)
     ntotal_t_smoothed = numpy.average(ntotal[template_idx], weights=weights)
@@ -37,7 +70,11 @@ def smooth_templates(nabove, invalphan, ntotal, template_idx,
                     ntotal_t_smoothed)
     return return_tuple
 
-def smooth_area(nabove, invalphan, ntotal, dists):
+def smooth_tophat(nabove, invalphan, ntotal, dists):
+    """
+    Smooth templates using a tophat function with templates within unit
+    distance, with distances normalised by --smoothing-width
+    """
     idx_within_area = numpy.flatnonzero(dists < 1.)
     return smooth_templates(nabove,
                             invalphan,
@@ -45,6 +82,10 @@ def smooth_area(nabove, invalphan, ntotal, dists):
                             idx_within_area)
 
 def smooth_n_closest(nabove, invalphan, ntotal, dists):
+    """
+    Smooth templates according to the closest N templates
+    No weighting is applied
+    """
     dist_sort = numpy.argsort(dists)
     templates_required = 0
     n_triggers = 0
@@ -53,18 +94,23 @@ def smooth_n_closest(nabove, invalphan, ntotal, dists):
     while n_triggers < 500:
         n_triggers += nabove[dist_sort[n_triggers]]
         templates_required += 1
-    logging.debug("%d templates required to obtain %d triggers", templates_required, n_triggers)
+    logging.debug("%d templates required to obtain %d triggers",
+                  templates_required, n_triggers)
     idx_to_smooth = dist_sort[:templates_required]
     return smooth_templates(nabove, invalphan, ntotal, idx_to_smooth)
 
 def smooth_distance_weighted(nabove, invalphan, ntotal, dists):
+    """
+    Smooth templates weithed according to a normal distribution
+    with width given by --smoothing-width, truncated at three sigma
+    """
     idx_within_area = numpy.flatnonzero(dists < 3.)
     weights = norm.pdf(dists[idx_within_area])
     return smooth_templates(nabove, invalphan, ntotal,
                             idx_within_area, weights=weights)
 
 _smooth_dist_func = {
-    'smooth_area': smooth_area,
+    'smooth_tophat': smooth_tophat,
     'n_closest': smooth_n_closest,
     'distance_weighted': smooth_distance_weighted
 }
@@ -118,15 +164,39 @@ parser.add_argument("--smoothing-width", type=float, nargs='+', required=True,
                          "logs of them) to smooth over. Required. "
                          "This must be a list corresponding to the smoothing "
                          "parameters.")
-parser.add_argument("--smoothing-method", default="smooth_area",
+parser.add_argument("--smoothing-method", default="smooth_tophat",
                     choices = _smooth_dist_func.keys(),
                     help="Method used to smooth the fit parameters; "
-                         "'smooth_area' (default) finds all templates within "
+                         "'smooth_tophat' (default) finds all templates within "
                          "unity distance from the template of interest "
                          "(distance normalised by --smoothing-width). "
                          "'n_closest' adds the closest templates to "
-                         "the smoothing until 500 triggers are reached.")
+                         "the smoothing until 500 triggers are reached. "
+                         "'distance_weighted' weights the closest templates "
+                         "with a normal distribution of width smoothing-width "
+                         "trucated at three smoothing-widths.")
+parser.add_argument("--smoothing-keywords", nargs='*',
+                    help="Keywords for the smoothing function, supplied "
+                         "as key:value pairs, e.g. n_closest:500 to define "
+                         "the number of templates in the n_closest smoothing "
+                         "method")
 args = parser.parse_args()
+
+if args.smoothing_keywords:
+    smooth_kwargs = args.smoothing_keywords
+else:
+    smooth_kwargs = []
+
+kwarg_dict = {}
+for inputstr in smooth_kwargs:
+    try:
+        key, value = inputstr.split(':')
+        kwarg_dict[key] = value
+    except ValueError:
+            err_txt = "--smoothing-keywords must take input in the " \
+                      "form KWARG1:VALUE1 KWARG2:VALUE2 KWARG3:VALUE3 ... " \
+                      "Received {}".format(' '.join(args.smoothing_keywords))
+            raise ValueError(err_txt)
 
 assert len(args.log_param) == len(args.fit_param) == len(args.smoothing_width)
 
@@ -171,14 +241,12 @@ alpha_smoothed = []
 rang = numpy.arange(0, len(nabove))
 
 logging.info("Smoothing ...")
-# Handle the one-dimensional case of one dimension separately as it is easier to
-# optimize computational performance.
-if len(parvals) == 1:
+# Handle the one-dimensional case of tophat smoothing separately
+# as it is easier to optimize computational performance.
+if len(parvals) == 1 and args.smoothing_method == 'smooth_tophat':
+    logging.info("Using efficient 1D tophat smoothing")
     sort = parvals[0].argsort()
     parvals_0 = parvals[0][sort]
-    ntotal = ntotal[sort]
-    nabove = nabove[sort]
-    invalphan = invalphan[sort]
 
     # For each template, find the range of nearby templates which fall within
     # the chosen window.
@@ -201,7 +269,8 @@ if len(parvals) == 1:
 else:
     for i in range(len(nabove)):
         d = dist(i, rang, parvals, args.smoothing_width)
-        smoothed_tuple = smooth(nabove, invalphan, ntotal, d, args.smoothing_method)
+        smoothed_tuple = smooth(nabove, invalphan, ntotal, d,
+                                args.smoothing_method, **kwarg_dict)
         nabove_smoothed.append(smoothed_tuple[0])
         alpha_smoothed.append(smoothed_tuple[1])
         ntotal_smoothed.append(smoothed_tuple[2])

--- a/bin/all_sky_search/pycbc_fit_sngls_over_multiparam
+++ b/bin/all_sky_search/pycbc_fit_sngls_over_multiparam
@@ -15,7 +15,63 @@
 from __future__ import division
 
 import sys, h5py, argparse, logging, pycbc.version, numpy
+from scipy.stats import norm
 from pycbc.events import triggers
+
+def dist(i1, i2, parvals, smoothing_width):
+    dsq = 0
+    for v, s in zip(parvals, smoothing_width):
+        dsq += (v[i2] - v[i1]) ** 2.0 / s ** 2.0
+    return dsq ** 0.5
+
+def smooth_templates(nabove, invalphan, ntotal, template_idx,
+                      weights=None):
+    if weights is None: weights = numpy.ones_like(template_idx)
+    nabove_t_smoothed = numpy.average(nabove[template_idx], weights=weights)
+    ntotal_t_smoothed = numpy.average(ntotal[template_idx], weights=weights)
+    invalphan_mean = numpy.average(invalphan[template_idx], weights=weights)
+
+    # return nabove_smoothed, alpha_smoothed, ntotal_smoothed
+    return_tuple = (nabove_t_smoothed,
+                    nabove_t_smoothed / invalphan_mean,
+                    ntotal_t_smoothed)
+    return return_tuple
+
+def smooth_area(nabove, invalphan, ntotal, dists):
+    idx_within_area = numpy.flatnonzero(dists < 1.)
+    return smooth_templates(nabove,
+                            invalphan,
+                            ntotal,
+                            idx_within_area)
+
+def smooth_n_closest(nabove, invalphan, ntotal, dists):
+    dist_sort = numpy.argsort(dists)
+    templates_required = 0
+    n_triggers = 0
+    # Count number of templates required to gather 1000 templates,
+    # start at closest
+    while n_triggers < 500:
+        n_triggers += nabove[dist_sort[n_triggers]]
+        templates_required += 1
+    logging.debug("%d templates required to obtain %d triggers", templates_required, n_triggers)
+    idx_to_smooth = dist_sort[:templates_required]
+    return smooth_templates(nabove, invalphan, ntotal, idx_to_smooth)
+
+def smooth_distance_weighted(nabove, invalphan, ntotal, dists):
+    idx_within_area = numpy.flatnonzero(dists < 3.)
+    weights = norm.pdf(dists[idx_within_area])
+    return smooth_templates(nabove, invalphan, ntotal,
+                            idx_within_area, weights=weights)
+
+_smooth_dist_func = {
+    'smooth_area': smooth_area,
+    'n_closest': smooth_n_closest,
+    'distance_weighted': smooth_distance_weighted
+}
+
+def smooth(nabove, invalphan, ntotal, dists, smoothing_method):
+    return _smooth_dist_func[smoothing_method](nabove, invalphan,
+                                               ntotal, dists)
 
 parser = argparse.ArgumentParser(usage="",
     description="Smooth (regress) the dependence of coefficients describing "
@@ -62,6 +118,14 @@ parser.add_argument("--smoothing-width", type=float, nargs='+', required=True,
                          "logs of them) to smooth over. Required. "
                          "This must be a list corresponding to the smoothing "
                          "parameters.")
+parser.add_argument("--smoothing-method", default="smooth_area",
+                    choices = _smooth_dist_func.keys(),
+                    help="Method used to smooth the fit parameters; "
+                         "'smooth_area' (default) finds all templates within "
+                         "unity distance from the template of interest "
+                         "(distance normalised by --smoothing-width). "
+                         "'n_closest' adds the closest templates to "
+                         "the smoothing until 500 triggers are reached.")
 args = parser.parse_args()
 
 assert len(args.log_param) == len(args.fit_param) == len(args.smoothing_width)
@@ -93,27 +157,16 @@ for param, slog in zip(args.fit_param, args.log_param):
     else:
         raise ValueError("invalid log param argument, use 'true', or 'false'")
 
-if 'count_in_template' in fits.keys(): # older files may not have this dataset
-    tcount = True
-else:
-    tcount = False
-
 # for an exponential fit 1/alpha is linear in the trigger statistic values
 # so calculating weighted sums or averages of 1/alpha is appropriate
 nabove = fits['count_above_thresh'][:]
-if tcount: ntotal = fits['count_in_template'][:]
+ntotal = fits['count_in_template'][:]
 
 invalpha = 1. / fits['fit_coeff'][:]
 invalphan = invalpha * nabove
 
-def dist(i1, i2):
-    dsq = 0
-    for v, s in zip(parvals, args.smoothing_width):
-        dsq += (v[i2] - v[i1]) ** 2.0 / s ** 2.0
-    return dsq ** 0.5
-
 nabove_smoothed = []
-if tcount: ntotal_smoothed = []
+ntotal_smoothed = []
 alpha_smoothed = []
 rang = numpy.arange(0, len(nabove))
 
@@ -140,29 +193,29 @@ if len(parvals) == 1:
     invsum = invalphan.cumsum()
     num = right - left
 
-    if tcount: ntotal_smoothed = (ntsum[right] - ntsum[left]) / num
+    ntotal_smoothed = (ntsum[right] - ntsum[left]) / num
     nabove_smoothed = (nasum[right] - nasum[left]) / num
     invmean = (invsum[right] - invsum[left]) / num
     alpha_smoothed = nabove_smoothed / invmean
 
 else:
     for i in range(len(nabove)):
-        dsq = dist(i, rang)
-        l = (dsq < 1)
-        if tcount: ntotal_smoothed.append(ntotal[l].mean())
-        nabove_smoothed.append(nabove[l].mean())
-        alpha_smoothed.append(nabove_smoothed[i] / invalphan[l].mean())
+        d = dist(i, rang, parvals, args.smoothing_width)
+        smoothed_tuple = smooth(nabove, invalphan, ntotal, d, args.smoothing_method)
+        nabove_smoothed.append(smoothed_tuple[0])
+        alpha_smoothed.append(smoothed_tuple[1])
+        ntotal_smoothed.append(smoothed_tuple[2])
 
 logging.info("Writing output")
 outfile = h5py.File(args.output, 'w')
 outfile['template_id'] = tid
 outfile['count_above_thresh'] = nabove_smoothed
 outfile['fit_coeff'] = alpha_smoothed
+outfile['count_in_template'] = ntotal_smoothed
 try:
     outfile['median_sigma'] = fits['median_sigma'][:]
 except KeyError:
     logging.info('Median_sigma dataset not present in input file')
-if tcount: outfile['count_in_template'] = ntotal_smoothed
 
 for param, vals, slog in zip(args.fit_param, parvals, args.log_param):
     if slog in ['false', 'False', 'FALSE']:


### PR DESCRIPTION
I wrote this up a while ago, but never actually made the PR in the end.

I found that sometimes the smoothing can be a bit over-aggressive, so I've added a couple of alternative methods to fit_sngls_over_multiparam:
 - smooth_area, which is the same as the current implementation and is the default
 - smooth_distance_weighted, which finds the templates within 3 of the unit area defined as normal, and the smooths them, weighted according to a normal distribution of width 1 (distance defined by --smoothing-width)
 - n_loudest, which counts the triggers in the nearest templates to the template of interest and stops when you reach a threshold (currently hardcoded to 500). This basically takes into account the fact that we are doing this because of small number statistics, and says that we only want to smooth templates if we really need to. This should reduce the cases of templates getting lots of triggers from a specific glitch morphology having their shallow fit parameter smoothed away.