### PR TITLE
Allow constraints to include fixed parameters

### DIFF
--- a/bin/pycbc_create_injections
+++ b/bin/pycbc_create_injections
@@ -190,7 +190,8 @@ variable_params, static_params = distributions.read_params_from_config(cp,
     prior_section=opts.dist_section,
     vargs_section=opts.variable_params_section,
     sargs_section=opts.static_params_section)
-constraints = distributions.read_constraints_from_config(cp)
+constraints = distributions.read_constraints_from_config(
+    cp, static_args=static_params)
 
 if any(cp.get_subsections('waveform_transforms')):
     waveform_transforms = transforms.read_transforms_from_config(cp,

--- a/pycbc/distributions/__init__.py
+++ b/pycbc/distributions/__init__.py
@@ -174,7 +174,7 @@ def read_params_from_config(cp, prior_section='prior',
     return variable_args, static_args
 
 
-def read_constraints_from_config(cp, transforms=None,
+def read_constraints_from_config(cp, transforms=None, static_args=None,
                                  constraint_section='constraint'):
     """Loads parameter constraints from a configuration file.
 
@@ -212,8 +212,8 @@ def read_constraints_from_config(cp, transforms=None,
                 except ValueError:
                     pass
             kwargs[key] = val
-        cons.append(constraints.constraints[name](constraint_arg,
-                                                  transforms=transforms,
-                                                  **kwargs))
+        cons.append(constraints.constraints[name](
+            constraint_arg, static_args=static_args, transforms=transforms,
+            **kwargs))
 
     return cons

--- a/pycbc/distributions/__init__.py
+++ b/pycbc/distributions/__init__.py
@@ -184,6 +184,9 @@ def read_constraints_from_config(cp, transforms=None, static_args=None,
         An open config parser to read from.
     transforms : list, optional
         List of transforms to apply to parameters before applying constraints.
+    static_args : dict, optional
+        Dictionary of static parameters and their values to be applied
+        to constraints.
     constraint_section : str, optional
         The section to get the constraints from. Default is 'constraint'.
 

--- a/pycbc/distributions/constraints.py
+++ b/pycbc/distributions/constraints.py
@@ -22,14 +22,21 @@ import h5py
 from pycbc import transforms
 from pycbc.io import record
 
-
 class Constraint(object):
     """Creates a constraint that evaluates to True if parameters obey
     the constraint and False if they do not.
     """
     name = "custom"
 
-    def __init__(self, constraint_arg, transforms=None, **kwargs):
+    def __init__(self, constraint_arg, static_args=None, transforms=None,
+            **kwargs):
+        static_args = (
+            {} if static_args is None
+            else dict(sorted(
+                static_args.items(), key=lambda x: len(x[0]), reverse=True))
+            )
+        for k, v in static_args.items():
+            constraint_arg = constraint_arg.replace(k, str(v))
         self.constraint_arg = constraint_arg
         self.transforms = transforms
         for kwarg in kwargs.keys():

--- a/pycbc/distributions/constraints.py
+++ b/pycbc/distributions/constraints.py
@@ -22,6 +22,7 @@ import h5py
 from pycbc import transforms
 from pycbc.io import record
 
+
 class Constraint(object):
     """Creates a constraint that evaluates to True if parameters obey
     the constraint and False if they do not.
@@ -29,14 +30,14 @@ class Constraint(object):
     name = "custom"
 
     def __init__(self, constraint_arg, static_args=None, transforms=None,
-            **kwargs):
+                 **kwargs):
         static_args = (
             {} if static_args is None
             else dict(sorted(
                 static_args.items(), key=lambda x: len(x[0]), reverse=True))
             )
-        for k, v in static_args.items():
-            constraint_arg = constraint_arg.replace(k, str(v))
+        for arg, val in static_args.items():
+            constraint_arg = constraint_arg.replace(arg, str(val))
         self.constraint_arg = constraint_arg
         self.transforms = transforms
         for kwarg in kwargs.keys():

--- a/pycbc/distributions/utils.py
+++ b/pycbc/distributions/utils.py
@@ -79,10 +79,11 @@ def draw_samples_from_config(path, num=1, seed=150914):
     file.close()
 
     # Get the vairable arguments from the .ini file.
-    variable_args, _ = distributions.read_params_from_config(
-                            config_parser, prior_section='prior',
-                            vargs_section='variable_params')
-    constraints = distributions.read_constraints_from_config(config_parser)
+    variable_args, static_args = distributions.read_params_from_config(
+        config_parser, prior_section='prior', vargs_section='variable_params',
+        sargs_section='static_params')
+    constraints = distributions.read_constraints_from_config(
+        config_parser, static_args=static_args)
 
     if any(config_parser.get_subsections('waveform_transforms')):
         waveform_transforms = transforms.read_transforms_from_config(

--- a/pycbc/inference/models/base.py
+++ b/pycbc/inference/models/base.py
@@ -671,7 +671,7 @@ class BaseModel(object):
         return kwargs
 
     @staticmethod
-    def prior_from_config(cp, variable_params, prior_section,
+    def prior_from_config(cp, variable_params, static_params, prior_section,
                           constraint_section):
         """Gets arguments and keyword arguments from a config file.
 
@@ -695,7 +695,7 @@ class BaseModel(object):
         logging.info("Setting up priors for each parameter")
         dists = distributions.read_distributions_from_config(cp, prior_section)
         constraints = distributions.read_constraints_from_config(
-            cp, constraint_section)
+            cp, constraint_section, static_args=static_params)
         return distributions.JointDistribution(variable_params, *dists,
                                                constraints=constraints)
 
@@ -735,8 +735,9 @@ class BaseModel(object):
             cp, prior_section=prior_section, vargs_section=vparams_section,
             sargs_section=sparams_section)
         # get prior
-        prior = cls.prior_from_config(cp, variable_params, prior_section,
-                                      constraint_section)
+        prior = cls.prior_from_config(
+            cp, variable_params, static_params, prior_section,
+            constraint_section)
         args = {'variable_params': variable_params,
                 'static_params': static_params,
                 'prior': prior}

--- a/pycbc/inference/models/base.py
+++ b/pycbc/inference/models/base.py
@@ -680,7 +680,9 @@ class BaseModel(object):
         cp : WorkflowConfigParser
             Config file parser to read.
         variable_params : list
-            List of of model parameter names.
+            List of variable model parameter names.
+        static_params : dict
+            Dictionary of static model parameters and their values.
         prior_section : str
             Section to read prior(s) from.
         constraint_section : str

--- a/pycbc/inference/option_utils.py
+++ b/pycbc/inference/option_utils.py
@@ -381,11 +381,12 @@ def prior_from_config(cp, prior_section='prior'):
         The prior distribution.
     """
     # Read variable and static parameters from the config file
-    variable_params, _ = distributions.read_params_from_config(
+    variable_params, static_params = distributions.read_params_from_config(
         cp, prior_section=prior_section, vargs_section='variable_params',
         sargs_section='static_params')
     # Read constraints to apply to priors from the config file
-    constraints = distributions.read_constraints_from_config(cp)
+    constraints = distributions.read_constraints_from_config(
+        cp, static_args=static_params)
     # Get PyCBC distribution instances for each variable parameter in the
     # config file
     dists = distributions.read_distributions_from_config(cp, prior_section)

--- a/pycbc/inference/sampler/base.py
+++ b/pycbc/inference/sampler/base.py
@@ -221,7 +221,7 @@ def create_new_output_file(sampler, filename, **kwargs):
         fp.write_sampler_metadata(sampler)
 
 
-def initial_dist_from_config(cp, variable_params):
+def initial_dist_from_config(cp, variable_params, static_params):
     r"""Loads a distribution for the sampler start from the given config file.
 
     A distribution will only be loaded if the config file has a [initial-\*]
@@ -246,7 +246,8 @@ def initial_dist_from_config(cp, variable_params):
         initial_dists = distributions.read_distributions_from_config(
             cp, section="initial")
         constraints = distributions.read_constraints_from_config(
-            cp, constraint_section="initial_constraint")
+            cp, constraint_section="initial_constraint",
+            static_args=static_params)
         init_dist = distributions.JointDistribution(
             variable_params, *initial_dists,
             **{"constraints": constraints})

--- a/pycbc/inference/sampler/base.py
+++ b/pycbc/inference/sampler/base.py
@@ -221,7 +221,7 @@ def create_new_output_file(sampler, filename, **kwargs):
         fp.write_sampler_metadata(sampler)
 
 
-def initial_dist_from_config(cp, variable_params, static_params):
+def initial_dist_from_config(cp, variable_params, static_params=None):
     r"""Loads a distribution for the sampler start from the given config file.
 
     A distribution will only be loaded if the config file has a [initial-\*]
@@ -233,6 +233,9 @@ def initial_dist_from_config(cp, variable_params, static_params):
         The config parser to try to load from.
     variable_params : list of str
         The variable parameters for the distribution.
+    static_params : dict, optional
+        The static parameters used to place constraints on the
+        distribution.
 
     Returns
     -------

--- a/pycbc/inference/sampler/base_mcmc.py
+++ b/pycbc/inference/sampler/base_mcmc.py
@@ -435,7 +435,8 @@ class BaseMCMC(object):
             init_prior = None
         else:
             start_file = None
-            init_prior = initial_dist_from_config(cp, self.variable_params)
+            init_prior = initial_dist_from_config(
+                cp, self.variable_params, self.static_params)
         self.set_p0(samples_file=start_file, prior=init_prior)
 
     def resume_from_checkpoint(self):

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -68,7 +68,8 @@ class TestDistributions(unittest.TestCase):
         self.cp = WorkflowConfigParser.from_cli(self.opts)
         self.variable_args, self.static_args = \
             distributions.read_params_from_config(self.cp)
-        self.constraints = distributions.read_constraints_from_config(self.cp)
+        self.constraints = distributions.read_constraints_from_config(
+            self.cp, static_args=self.static_args)
 
         # read distributions
         self.dists = distributions.read_distributions_from_config(self.cp)


### PR DESCRIPTION
When generating samples from distributions with constraints imposed the constraints can't depend on any fixed parameters. Allowing for this will be useful for e.g. generating EM-bright populations.