### PR TITLE
Make merge opt inj work

### DIFF
--- a/examples/search/executables.ini
+++ b/examples/search/executables.ini
@@ -19,6 +19,7 @@ ligolw_combine_segments = ${which:ligolw_combine_segments}
 llwadd = ${which:ligolw_add}
 merge_psds = ${which:pycbc_merge_psds}
 optimal_snr = ${which:pycbc_optimal_snr}
+optimal_snr_merge = ${which:pycbc_merge_inj_hdf}
 page_foreground = ${which:pycbc_page_foreground}
 page_ifar = ${which:pycbc_page_ifar}
 page_injections = ${which:pycbc_page_injtable}

--- a/examples/search/injections_minimal.ini
+++ b/examples/search/injections_minimal.ini
@@ -3,6 +3,9 @@ injections-method = IN_WORKFLOW
 strip-injections =
 compute-optimal-snr =
 
+[workflow-optimal-snr]
+parallelization-factor = 2
+
 [strip_injections]
 [inspiral]
 injection-filter-rejector-chirp-time-window = 5
@@ -13,6 +16,8 @@ f-low = ${inspiral|low-frequency-cutoff}
 seg-length = ${inspiral|segment-length}
 sample-rate = 2048
 cores = 1
+
+[optimal_snr_merge]
 
 [inj_cut]
 snr-columns = ${hdfinjfind|optimal-snr-column}

--- a/pycbc/workflow/injection.py
+++ b/pycbc/workflow/injection.py
@@ -70,7 +70,7 @@ class PyCBCOptimalSNRExecutable(Executable):
 
 class PyCBCMergeHDFExecutable(Executable):
     """Merge HDF injection files executable class"""
-    current_retention_level = Executable.ALL_TRIGGERS
+    current_retention_level = Executable.MERGED_TRIGGERS
 
     def create_node(self, workflow, input_files):
         node = Node(self)

--- a/pycbc/workflow/injection.py
+++ b/pycbc/workflow/injection.py
@@ -129,9 +129,9 @@ def compute_inj_optimal_snr(workflow, inj_file, precalc_psd_files, out_dir,
         workflow,
         opt_snr_split_files
     )
-    workflow += merge_node
+    workflow += hdfcombine_node
 
-    return merge_node.output_files[0]
+    return hdfcombine_node.output_files[0]
 
 def cut_distant_injections(workflow, inj_file, out_dir, tags=None):
     "Set up a job for removing injections that are too distant to be seen"

--- a/pycbc/workflow/injection.py
+++ b/pycbc/workflow/injection.py
@@ -126,7 +126,7 @@ def compute_inj_optimal_snr(workflow, inj_file, precalc_psd_files, out_dir,
     )
     
     hdfcombine_node = hdfcombine_exe.create_node(
-        workflow.analysis_time,
+        workflow,
         opt_snr_split_files
     )
     workflow += merge_node

--- a/pycbc/workflow/injection.py
+++ b/pycbc/workflow/injection.py
@@ -24,8 +24,8 @@
 """
 This module is responsible for setting up the part of a pycbc workflow that
 will generate the injection files to be used for assessing the workflow's
-ability to detect predicted signals. (In ihope parlance, this sets up the
-inspinj jobs). Full documentation for this module can be found here:
+ability to detect predicted signals.
+Full documentation for this module can be found here:
 https://ldas-jobs.ligo.caltech.edu/~cbc/docs/pycbc/NOTYETCREATED.html
 """
 
@@ -36,8 +36,7 @@ from pycbc.workflow.core import FileList, make_analysis_dir, Node
 from pycbc.workflow.core import Executable, resolve_url_to_file
 from pycbc.workflow.jobsetup import (LalappsInspinjExecutable,
         LigolwCBCJitterSkylocExecutable, LigolwCBCAlignTotalSpinExecutable,
-        PycbcDarkVsBrightInjectionsExecutable, LigolwAddExecutable,
-        select_generic_executable)
+        PycbcDarkVsBrightInjectionsExecutable, select_generic_executable)
 
 def veto_injections(workflow, inj_file, veto_file, veto_name, out_dir, tags=None):
     tags = [] if tags is None else tags
@@ -68,6 +67,7 @@ class PyCBCOptimalSNRExecutable(Executable):
                                  '--output-file')
         return node
 
+
 class PyCBCMergeHDFExecutable(Executable):
     """Merge HDF injection files executable class"""
     current_retention_level = Executable.MERGED_TRIGGERS
@@ -78,6 +78,7 @@ class PyCBCMergeHDFExecutable(Executable):
         node.new_output_file_opt(workflow.analysis_time, '.hdf',
                                  '--output-file')
         return node
+
 
 def compute_inj_optimal_snr(workflow, inj_file, precalc_psd_files, out_dir,
                             tags=None):
@@ -124,7 +125,7 @@ def compute_inj_optimal_snr(workflow, inj_file, precalc_psd_files, out_dir,
         out_dir=out_dir,
         tags=tags
     )
-    
+
     hdfcombine_node = hdfcombine_exe.create_node(
         workflow,
         opt_snr_split_files


### PR DESCRIPTION
@tdent I guess you got fed up of waiting for me to do this (my bad), but I was working on this earlier today!

So here is my version of #3968, basically the same, but one or two things I prefer in here:

* I update the search example so this is tested in the automated CI tests.
* The new EXE class goes into injections.py. As it's only used here, I prefer this (jobsetup.py got overloaded, and does need some cleanup).
* create_node doesn't get options that it will never use. Note that as this only ever makes one job, all tags are sent to the Executable, and we don't need any job-level tag (that's how it knows which injection run it is).
* The relative_submit_dir thing is not relevant for a job that's only run once (not sure why that was being used before, but it's a pretty niche thing, but helps with inspiral jobs).