### PR TITLE
Remove unused sections from example ini

### DIFF
--- a/examples/search/injections_minimal.ini
+++ b/examples/search/injections_minimal.ini
@@ -6,7 +6,6 @@ compute-optimal-snr =
 [workflow-optimal-snr]
 parallelization-factor = 2
 
-[strip_injections]
 [inspiral]
 injection-filter-rejector-chirp-time-window = 5
 
@@ -19,10 +18,6 @@ cores = 1
 
 [optimal_snr_merge]
 
-[inj_cut]
-snr-columns = ${hdfinjfind|optimal-snr-column}
-snr-threshold = 3.0
-
 [injections]
 i-distr = uniform
 l-distr = random
@@ -30,6 +25,7 @@ time-interval = 25
 time-step = 50
 
 [workflow-injections-bbh]
+
 [injections-bbh]
 dchirp-distr = uniform
 min-distance = 1000


### PR DESCRIPTION
Neither 'strip_injections' nor 'inj_cut' seem to be used in the current standard injection workflow. Remove their sections to avoid confusion