### PR TITLE
Results page artefact location

### DIFF
--- a/examples/search/analysis.ini
+++ b/examples/search/analysis.ini
@@ -204,4 +204,3 @@ cluster-window = ${statmap|cluster-window}
 [results_page]
 analysis-title = "PyCBC search"
 analysis-subtitle = "Small Test Search"
-output-path = ../../../../html

--- a/examples/search/gen.sh
+++ b/examples/search/gen.sh
@@ -4,4 +4,5 @@ set -e
 pycbc_make_coinc_search_workflow \
 --workflow-name gw \
 --output-dir output \
---config-files analysis.ini plotting.ini executables.ini injections_minimal.ini
+--config-files analysis.ini plotting.ini executables.ini injections_minimal.ini \
+--config-overrides results_page:output-path:$(pwd)/html


### PR DESCRIPTION
The artefact for the results page wasn't being uploaded from the test search, but it also looked like it wasn't being put into the folder where it was expected to be.

This fixes the issue, but I'm not sure where the results page was being made originally