### PR TITLE
dont upload singles if coinc already uploaded

### DIFF
--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -420,7 +420,7 @@ class LiveEventManager(object):
                                 self.last_few_coincs_uploaded)
             nearby_coincs = coinc_tdiffs < 0.1
             if any(nearby_coincs):
-                logging.info("Single detetor event at time %.2f not "
+                logging.info("Single detector event at time %.2f not "
                              "uploaded due to coinc event at %.2f.",
                              event.merger_time,
                              self.last_few_coincs_uploaded[nearby_coincs])

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -87,7 +87,7 @@ class LiveEventManager(object):
         self.run_snr_optimization = run_snr_optimization
 
         # Keep track of which events have been uploaded
-        self.last_ten_coinc_events_uploaded = []
+        self.last_few_coincs_uploaded = np.zeros(10, dtype=float)
 
         if self.run_snr_optimization and self.rank == 0:
             # preestimate the number of CPU cores that we can afford giving to
@@ -270,10 +270,12 @@ class LiveEventManager(object):
                                    testing=self.gracedb_testing,
                                    extra_strings=[comment],
                                    search=args.gracedb_search)
-                self.last_ten_coinc_events_uploaded.append(event.merger_time)
-                if len(self.last_ten_coinc_events_uploaded) > 10:
-                    self.last_ten_coinc_events_uploaded = \
-                        self.last_ten_coinc_events_uploaded[-10:]
+                # Keep track of the last few coincs uploaded in order to
+                # prevent singles being uploaded as well for coinc events
+                self.last_few_coincs_uploaded.append(event.merger_time)
+                # Only need to keep a few (10) events
+                self.last_few_coincs_uploaded = \
+                    self.last_few_coincs_uploaded[-10:]
             else:
                 gid = None
                 event.save(fname)
@@ -413,12 +415,19 @@ class LiveEventManager(object):
             comment = comment.format(ifo, ppdets(followup_ifos))
 
             # Has a coinc event at this time been uploaded recently?
-            # If so, skip
-            if event.merger_time in self.last_ten_coinc_events_uploaded:
-                continue
+            # If so, skip upload
+            coinc_tdiffs =  abs(event.merger_time -
+                                self.last_few_coincs_uploaded)
+            nearby_coincs = coinc_tdiffs < 0.1
+            if any(nearby_coincs):
+                logging.info("Single detetor event at time %.2f not "
+                             "uploaded due to coinc event at %.2f.",
+                             event.merger_time,
+                             self.last_few_coincs_uploaded[nearby_coincs])
 
             if args.enable_single_detector_upload \
-                    and self.ifar_upload_threshold < ifar:
+                    and self.ifar_upload_threshold < ifar \
+                    and not any(nearby_coincs):
                 event.upload(fname, gracedb_server=args.gracedb_server,
                              testing=self.gracedb_testing,
                              extra_strings=[comment],

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -87,7 +87,7 @@ class LiveEventManager(object):
         self.run_snr_optimization = run_snr_optimization
 
         # Keep track of which events have been uploaded
-        self.last_few_coincs_uploaded = np.zeros(10, dtype=float)
+        self.last_few_coincs_uploaded = numpy.zeros(10, dtype=float)
 
         if self.run_snr_optimization and self.rank == 0:
             # preestimate the number of CPU cores that we can afford giving to

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -86,6 +86,9 @@ class LiveEventManager(object):
 
         self.run_snr_optimization = run_snr_optimization
 
+        # Keep track of which events have been uploaded
+        self.last_ten_coinc_events_uploaded = []
+
         if self.run_snr_optimization and self.rank == 0:
             # preestimate the number of CPU cores that we can afford giving to
             # followup processes without slowing down the main search
@@ -267,6 +270,10 @@ class LiveEventManager(object):
                                    testing=self.gracedb_testing,
                                    extra_strings=[comment],
                                    search=args.gracedb_search)
+                self.last_ten_coinc_events_uploaded.append(event.merger_time)
+                if len(self.last_ten_coinc_events_uploaded) > 10:
+                    self.last_ten_coinc_events_uploaded = \
+                        self.last_ten_coinc_events_uploaded[-10:]
             else:
                 gid = None
                 event.save(fname)
@@ -404,6 +411,11 @@ class LiveEventManager(object):
                        'FAR is based on {0} only.<br />'
                        'Followup detectors: {1}')
             comment = comment.format(ifo, ppdets(followup_ifos))
+
+            # Has a coinc event at this time been uploaded recently?
+            # If so, skip
+            if event.merger_time in self.last_ten_coinc_events_uploaded:
+                continue
 
             if args.enable_single_detector_upload \
                     and self.ifar_upload_threshold < ifar:


### PR DESCRIPTION
A check for if a single event had been uploaded as a coincident event already (and therefore not upload the singles) was requested - I think this should work, but am not sure on where the tests are kept at the moment