### PR TITLE
Sngls findtrigs update

### DIFF
--- a/bin/all_sky_search/pycbc_sngls_findtrigs
+++ b/bin/all_sky_search/pycbc_sngls_findtrigs
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-import argparse, logging, numpy as np
+import argparse, logging, h5py, numpy as np
 from ligo.segments import infinity
 from numpy.random import seed, shuffle
 from pycbc.events import veto, coinc, stat
@@ -94,17 +94,11 @@ trigs = ReadByTemplate(trigger_file,
                        args.gating_veto_windows)
 logging.info("%d triggers in file", trigf[ifo + '/snr'].size)
 
-data_init = {}
-#FIXME - this feels like it should be easier to define
-all_dsets = ['sigmasq', 'chisq', 'chisq_dof', 'coa_phase', 'end_time',
-             'snr', 'template_id', 'sg_chisq', 'psd_var_val']
-
-for ds in all_dsets:
-    data_init[ds] = []
-data_init['trigger_id'] = []
-
-trigs_out = io.DictArray(data=data_init)
 stat_all = []
+trigger_ids_all = []
+template_ids_all = []
+trigger_times_all = []
+
 
 rank_method = stat.get_statistic_from_opts(args, [ifo])
 
@@ -113,18 +107,7 @@ for tnum in template_ids:
     tids_full = trigs.set_template(tnum)
     logging.info("%d triggers in this template", len(tids_full))
 
-    t_data_init = {}
-    for ds in all_dsets:
-        if not ds == "template_id":
-            t_data_init[ds] = trigs[ds]
-    t_data_init['template_id'] = np.repeat(tnum, len(tids_full))
-    t_data_init['trigger_id'] = tids_full
-
-    logging.info("Putting data into DictArray")
-    t_trigs = io.DictArray(data=t_data_init)
-
-    snr = t_trigs.data['snr']
-    n_tot_trigs = len(snr)
+    n_tot_trigs = tids_full.size
     if not n_tot_trigs: continue
 
     logging.info('Setting up ranking method')
@@ -140,25 +123,30 @@ for tnum in template_ids:
                       "Received {}".format(args.statistic_keywords)
             raise ValueError(err_txt)
 
-
+    sds = rank_method.single(trigs)
     logging.info("Calculating single-detector statistic")
-    stat_t = rank_method.rank_stat_single((ifo, t_trigs.data),
+    stat_t = rank_method.rank_stat_single((ifo, sds),
                                           **extra_kwargs)
+    trigger_times = sds['end_time']
     if args.cluster_window:
         logging.info("Clustering")
-        cid = coinc.cluster_over_time(stat_t, t_trigs.data['end_time'],
+        cid = coinc.cluster_over_time(stat_t, trigger_times,
                                       args.cluster_window)
-        t_trigs = t_trigs.select(cid)
         stat_t = stat_t[cid]
-    trigs_out += t_trigs
+        tids_full = tids_full[cid]
+        trigger_times = trigger_times[cid]
+
+    trigger_ids_all += list(tids_full)
+    template_ids_all += list(tnum * np.ones_like(tids_full))
+    trigger_times_all += list(trigger_times)
     stat_all += list(stat_t)
 
 data = {"stat": stat_all,
         "decimation_factor": np.ones_like(stat_all),
         "timeslide_id": np.zeros_like(stat_all),
-        "template_id": trigs_out.data['template_id'],
-        "%s/time" % ifo : trigs_out.data['end_time'],
-        "%s/trigger_id" % ifo: trigs_out.data['trigger_id']}
+        "template_id": template_ids_all,
+        "%s/time" % ifo : trigger_times_all,
+        "%s/trigger_id" % ifo: trigger_ids_all}
 
 logging.info("saving triggers")
 f = io.HFile(args.output_file, 'w')

--- a/bin/all_sky_search/pycbc_sngls_findtrigs
+++ b/bin/all_sky_search/pycbc_sngls_findtrigs
@@ -1,152 +1,164 @@
 #!/usr/bin/env python
 import argparse, logging, numpy as np
 from ligo.segments import infinity
+from numpy.random import seed, shuffle
 from pycbc.events import veto, coinc, stat
 import pycbc.conversions as conv
 import pycbc.version
 from pycbc import io
 from pycbc.events import trigger_fits as trfits
+from pycbc.events.veto import indices_outside_times
+from pycbc.types.optparse import MultiDetOptionAction
 from pycbc import init_logging
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--verbose", action='count')
 parser.add_argument("--version", action='version',
                     version=pycbc.version.git_verbose_msg)
-parser.add_argument("--veto-files", nargs='+',
-                    help="Optional veto file. Triggers within veto segments "
-                         "contained in the file are ignored. Required if "
-                         "--segment-names given.")
-parser.add_argument("--segment-names", nargs='+',
-                    help="Optional, name of veto segment in veto file. "
-                         "Required if --veto-files given.")
-parser.add_argument("--trigger-file",type=str,
+# Basic file input options
+parser.add_argument("--trigger-files", type=str, nargs=1,
                     help="File containing single-detector triggers")
 parser.add_argument("--template-bank", required=True,
                     help="Template bank file in HDF format")
+parser.add_argument("--template-fraction-range", default="0/1",
+                    help="Optional, analyze only part of template bank. Format"
+                         " PART/NUM_PARTS")
+parser.add_argument("--randomize-template-order", action="store_true",
+                    help="Random shuffle templates with fixed seed "
+                         "before selecting range to analyze")
+# Options to define the vetoes
+parser.add_argument("--veto-files", nargs='*', action='append', default=[],
+                    help="Optional veto file. Triggers within veto segments "
+                         "contained in the file are ignored")
+parser.add_argument("--segment-name", nargs='*', action='append', default=[],
+                    help="Optional, name of veto segment in veto file")
+parser.add_argument("--gating-veto-windows", nargs='+',
+                    action=MultiDetOptionAction,
+                    help="Seconds to be vetoed before and after the central time "
+                         "of each gate. Given as detector-values pairs, e.g. "
+                         "H1:-1,2.5 L1:-1,2.5 V1:0,0")
+# additional veto options
 # produces a list of lists to allow multiple invocations and multiple args
-parser.add_argument('--trigger-snr-cut',  type=float,
-                    help='Only consider triggers above the given SNR.')
 parser.add_argument('--cluster-window', type=float,
                     help='Window (seconds) during which to keep the trigger '
                          'with the loudest statistic value. '
                          'Default=do not cluster')
-parser.add_argument('--reduced-chisq-cut', type=float,
-                    help='Only consider triggers below given reduced '
-                         'chisquared.')
 parser.add_argument("--output-file",
                     help="File to store the candidate triggers")
 stat.insert_statistic_option_group(parser)
 args = parser.parse_args()
 
-if (args.veto_files and not args.segment_names) or \
-    (args.segment_names and not args.veto_files):
-    raise RuntimeError('--veto-files and --segment-names are mutually required')
+trigger_file = args.trigger_files[0]
 
-if not len(args.veto_files) == len(args.segment_names):
-    raise RuntimeError('--segment-names are required for each --veto-files')
+if (args.veto_files and not args.segment_name) or \
+    (args.segment_name and not args.veto_files):
+    raise RuntimeError('--veto-files and --segment-name are mutually required')
+
+if not len(args.veto_files) == len(args.segment_name):
+    raise RuntimeError('--segment-name optionss are required for each --veto-files')
+
+args.segment_name = sum(args.segment_name, [])
+args.veto_files = sum(args.veto_files, [])
 
 init_logging(args.verbose)
 
-logging.info('Opening trigger file: %s', args.trigger_file)
-trigf = io.HFile(args.trigger_file, 'r')
-ifo = trigf.keys()[0]
+logging.info('Opening trigger file: %s', trigger_file)
+trigf = io.HFile(trigger_file, 'r')
+ifo = list(trigf.keys())[0]
 
-starts = trigf[ifo + '/search/start_time'][:]
-ends = trigf[ifo + '/search/end_time'][:]
-segments = veto.start_end_to_segments(starts, ends)
+# Set up to only load triggers from the templates of interest
 
-n_tot_trigs = trigf[ifo + '/snr'].size
-logging.info("%d triggers in file", n_tot_trigs)
+def parse_template_range(num_templates, rangestr):
+    part = int(rangestr.split('/')[0])
+    pieces = int(rangestr.split('/')[1])
+    tmin = int(num_templates / float(pieces) * part)
+    tmax = int(num_templates / float(pieces) * (part+1))
+    return tmin, tmax
 
-if args.trigger_snr_cut:
-    keep_idx = np.flatnonzero(trigf[ifo + '/snr'][:] >= args.trigger_snr_cut)
-    snr_cut_f = ("%f" % args.trigger_snr_cut).rstrip("0").rstrip(".")
-    logging.info("Cutting %d triggers with SNR < %s (%.2f%%)",
-                 n_tot_trigs - keep_idx.size, snr_cut_f,
-                 float(n_tot_trigs - keep_idx.size) / n_tot_trigs * 100)
-if args.reduced_chisq_cut:
-    n_skp_trigs = float(keep_idx.size)
-    chisq = trigf[ifo + '/chisq'][:][keep_idx]
-    chisq_dof = trigf[ifo + '/chisq_dof'][:][keep_idx]
-    reduced_chisq = chisq / (2 * chisq_dof - 2)
-    chisq_keep_idx = np.flatnonzero(reduced_chisq <= args.reduced_chisq_cut)
-    chisq_cut_f = ("%f" % args.reduced_chisq_cut).rstrip("0").rstrip(".")
-    logging.info("Cutting %d triggers with \chi^2 > %.f (%.2f%%)",
-                 n_skp_trigs - chisq_keep_idx.size, chisq_cut_f,
-                 float(n_skp_trigs - chisq_keep_idx.size) / n_skp_trigs * 100)
-    # Select chisq-cut-kept idx from keep_idx
-    keep_idx = keep_idx[chisq_keep_idx]
+num_templates = io.HFile(args.template_bank, "r")['template_hash'].size
+tmin, tmax = parse_template_range(num_templates, args.template_fraction_range)
+logging.info('Analyzing template %s - %s' % (tmin, tmax-1))
 
-if args.veto_files:
-    for veto_file, segment_name in zip(args.veto_files, args.segment_names):
-        logging.info("Getting vetoed indices from file %s", veto_file)
-        end_time = trigf[ifo + '/end_time'][:][keep_idx]
-        veto_keep_idx, _ = veto.indices_outside_segments(end_time,
-                                                         [veto_file],
-                                                         segment_name=segment_name,
-                                                         ifo=ifo)
-        logging.info("Cutting %d triggers in vetoed segments (%.2f%%)",
-                     keep_idx.size - veto_keep_idx.size,
-                     float(keep_idx.size - veto_keep_idx.size) / float(keep_idx.size) * 100.)
-        # Select unvetoed idx from keep_idx
-        keep_idx = keep_idx[veto_keep_idx]
-        veto_segs = veto.select_segments_by_definer(veto_file, ifo=ifo,
-                                                    segment_name=segment_name)
-        fg_segs = segments - veto_segs
+if args.randomize_template_order:
+    seed(0)
+    template_ids = np.arange(0, num_templates)
+    shuffle(template_ids)
+    template_ids = template_ids[tmin:tmax]
 else:
-    fg_segs = segments
-
-if not len(keep_idx):
-    raise RuntimeError("All triggers removed by vetoes or cuts")
-
-logging.info("Loading %d triggers", len(keep_idx))
+    template_ids = range(tmin, tmax)
+from pycbc.io.hdf import ReadByTemplate
+trigs = ReadByTemplate(trigger_file,
+                       args.template_bank,
+                       args.segment_name,
+                       args.veto_files,
+                       args.gating_veto_windows)
+logging.info("%d triggers in file", trigf[ifo + '/snr'].size)
 
 data_init = {}
+#FIXME - this feels like it should be easier to define
 all_dsets = ['sigmasq', 'chisq', 'chisq_dof', 'coa_phase', 'end_time',
-             'snr', 'template_id', 'sg_chisq']
+             'snr', 'template_id', 'sg_chisq', 'psd_var_val']
 
 for ds in all_dsets:
-    data_init[ds] = trigf[ifo + "/" + ds][:][keep_idx]
-data_init['trigger_id'] = np.arange(trigf[ifo + '/snr'].size)[keep_idx]
+    data_init[ds] = []
+data_init['trigger_id'] = []
 
-logging.info("Putting data into DictArray")
-trigs = io.DictArray(data=data_init)
-trigf.close()
-
-logging.info('Setting up ranking method')
-# Stat class instance to calculate the ranking statistic
-extra_kwargs = {}
-for inputstr in args.statistic_keywords:
-    try:
-        key, value = inputstr.split(':')
-        extra_kwargs[key] = value
-    except ValueError:
-        err_txt = "--statistic-keywords must take input in the " \
-                  "form KWARG1:VALUE1 KWARG2:VALUE2 KWARG3:VALUE3 ... " \
-                  "Received {}".format(args.statistic_keywords)
-        raise ValueError(err_txt)
+trigs_out = io.DictArray(data=data_init)
+stat_all = []
 
 rank_method = stat.get_statistic_from_opts(args, [ifo])
 
-logging.info("Computing single-detector statistic")
-stat = rank_method.rank_stat_single((ifo, trigs.data))
+for tnum in template_ids:
+    logging.info("checking template %s", tnum)
+    tids_full = trigs.set_template(tnum)
+    logging.info("%d triggers in this template", len(tids_full))
 
-logging.info("Clustering")
-if args.cluster_window:
-    cid = coinc.cluster_over_time(stat, trigs.data['end_time'],
-                                  args.cluster_window)
-    trigs = trigs.select(cid)
-    stat = stat[cid]
-    logging.info("%d triggers after clustering", stat.size)
+    t_data_init = {}
+    for ds in all_dsets:
+        if not ds == "template_id":
+            t_data_init[ds] = trigs[ds]
+    t_data_init['template_id'] = np.repeat(tnum, len(tids_full))
+    t_data_init['trigger_id'] = tids_full
 
-fg_time = abs(fg_segs)
+    logging.info("Putting data into DictArray")
+    t_trigs = io.DictArray(data=t_data_init)
 
-data = {"stat": stat,
-        "decimation_factor": np.ones_like(stat),
-        "timeslide_id": np.zeros_like(stat),
-        "template_id": trigs.data['template_id'],
-        "%s/time" % ifo : trigs.data['end_time'],
-        "%s/trigger_id" % ifo: trigs.data['trigger_id']}
+    snr = t_trigs.data['snr']
+    n_tot_trigs = len(snr)
+    if not n_tot_trigs: continue
+
+    logging.info('Setting up ranking method')
+    # Stat class instance to calculate the ranking statistic
+    extra_kwargs = {}
+    for inputstr in args.statistic_keywords:
+        try:
+            key, value = inputstr.split(':')
+            extra_kwargs[key] = value
+        except ValueError:
+            err_txt = "--statistic-keywords must take input in the " \
+                      "form KWARG1:VALUE1 KWARG2:VALUE2 KWARG3:VALUE3 ... " \
+                      "Received {}".format(args.statistic_keywords)
+            raise ValueError(err_txt)
+
+
+    logging.info("Calculating single-detector statistic")
+    stat_t = rank_method.rank_stat_single((ifo, t_trigs.data),
+                                          **extra_kwargs)
+    if args.cluster_window:
+        logging.info("Clustering")
+        cid = coinc.cluster_over_time(stat_t, t_trigs.data['end_time'],
+                                      args.cluster_window)
+        t_trigs = t_trigs.select(cid)
+        stat_t = stat_t[cid]
+    trigs_out += t_trigs
+    stat_all += list(stat_t)
+
+data = {"stat": stat_all,
+        "decimation_factor": np.ones_like(stat_all),
+        "timeslide_id": np.zeros_like(stat_all),
+        "template_id": trigs_out.data['template_id'],
+        "%s/time" % ifo : trigs_out.data['end_time'],
+        "%s/trigger_id" % ifo: trigs_out.data['trigger_id']}
 
 logging.info("saving triggers")
 f = io.HFile(args.output_file, 'w')
@@ -155,16 +167,17 @@ for key in data:
                      compression="gzip",
                      compression_opts=9,
                      shuffle=True)
-
 # Store segments
-f['segments/%s/start' % ifo], f['segments/%s/end' % ifo] = \
-    veto.segments_to_start_end(fg_segs)
+f['segments/%s/start' % ifo], f['segments/%s/end' % ifo] = trigs.valid
+fg_segs = veto.start_end_to_segments(*trigs.valid)
+fg_time = abs(fg_segs)
 f.attrs['foreground_time'] = fg_time
 f.attrs['background_time'] = fg_time
 f.attrs['num_of_ifos'] = 1
 f.attrs['pivot'] = ifo
 f.attrs['fixed'] = ifo
 f.attrs['ifos'] = ifo
+f.attrs['timeslide_interval'] = 0
 
 # Do hierarchical removal
 # h_iterations = 0

--- a/bin/all_sky_search/pycbc_sngls_findtrigs
+++ b/bin/all_sky_search/pycbc_sngls_findtrigs
@@ -6,7 +6,7 @@ from pycbc.events import veto, coinc, stat
 import pycbc.conversions as conv
 import pycbc.version
 from pycbc import io
-from pycbc.events import trigger_fits as trfits
+from pycbc.events import cuts, trigger_fits as trfits
 from pycbc.events.veto import indices_outside_times
 from pycbc.types.optparse import MultiDetOptionAction
 from pycbc import init_logging
@@ -46,6 +46,7 @@ parser.add_argument('--cluster-window', type=float,
 parser.add_argument("--output-file",
                     help="File to store the candidate triggers")
 stat.insert_statistic_option_group(parser)
+cuts.insert_cuts_option_group(parser)
 args = parser.parse_args()
 
 trigger_file = args.trigger_files[0]
@@ -61,6 +62,8 @@ args.segment_name = sum(args.segment_name, [])
 args.veto_files = sum(args.veto_files, [])
 
 init_logging(args.verbose)
+
+trigger_cut_dict, template_cut_dict = cuts.ingest_cuts_option_group(args)
 
 logging.info('Opening trigger file: %s', trigger_file)
 trigf = io.HFile(trigger_file, 'r')
@@ -85,7 +88,8 @@ if args.randomize_template_order:
     shuffle(template_ids)
     template_ids = template_ids[tmin:tmax]
 else:
-    template_ids = range(tmin, tmax)
+    template_ids = np.array(range(tmin, tmax))
+
 from pycbc.io.hdf import ReadByTemplate
 trigs = ReadByTemplate(trigger_file,
                        args.template_bank,
@@ -99,18 +103,29 @@ trigger_ids_all = []
 template_ids_all = []
 trigger_times_all = []
 
-
 rank_method = stat.get_statistic_from_opts(args, [ifo])
 
+# Apply cuts to templates
+template_ids = cuts.apply_template_cuts(
+    trigs.bank,
+    template_cut_dict,
+    statistic=rank_method,
+    ifos=[ifo],
+    template_ids=template_ids)
+
 for tnum in template_ids:
-    logging.info("checking template %s", tnum)
-    tids_full = trigs.set_template(tnum)
-    logging.info("%d triggers in this template", len(tids_full))
+    tids_uncut = trigs.set_template(tnum)
+
+    trigger_keep_ids = cuts.apply_trigger_cuts(trigs, trigger_cut_dict)
+    tids_full = tids_uncut[trigger_keep_ids]
+    logging.info('%s:%s', tnum, len(tids_uncut))
+    if len(tids_full) < len(tids_uncut):
+        logging.info("%s triggers cut",
+                     len(tids_uncut) - len(tids_full))
 
     n_tot_trigs = tids_full.size
     if not n_tot_trigs: continue
 
-    logging.info('Setting up ranking method')
     # Stat class instance to calculate the ranking statistic
     extra_kwargs = {}
     for inputstr in args.statistic_keywords:
@@ -124,7 +139,6 @@ for tnum in template_ids:
             raise ValueError(err_txt)
 
     sds = rank_method.single(trigs)
-    logging.info("Calculating single-detector statistic")
     stat_t = rank_method.rank_stat_single((ifo, sds),
                                           **extra_kwargs)
     trigger_times = sds['end_time']

--- a/pycbc/events/cuts.py
+++ b/pycbc/events/cuts.py
@@ -301,6 +301,7 @@ def apply_template_cuts(bank, template_cut_dict, template_ids=None,
         Templates must pass cuts in all IFOs. This is important
         e.g. for template fit parameter cuts.
 
+
     Returns
     -------
     tids_out: numpy array

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -1010,11 +1010,10 @@ class ExpFitCombinedSNR(ExpFitStatistic):
         numpy.ndarray
             The array of single detector statistics
         """
-        sngl_rnk = self.single(single_info[1])
         if self.single_increasing:
-            sngl_multiifo = sngl_rnk['snglstat']
+            sngl_multiifo = single_info[1]['snglstat']
         else:
-            sngl_multiifo = -1.0 * sngl_rnk['snglstat']
+            sngl_multiifo = -1.0 * single_info[1]['snglstat']
         return sngl_multiifo
 
     def rank_stat_coinc(self, s, slide, step, to_shift,
@@ -1465,7 +1464,7 @@ class ExpFitFgBgNormStatistic(PhaseTDStatistic,
         numpy.ndarray
             The array of single detector statistics
         """
-        sngls = self.single(single_info[1])
+        sngls = single_info[1]
 
         ln_noise_rate = sngls['snglstat']
         ln_noise_rate -= self.benchmark_lograte

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -335,7 +335,7 @@ class PhaseTDStatistic(QuadratureSumStatistic):
         self.param_bin = {}
         self.two_det_flag = (len(ifos) == 2)
         self.two_det_weights = {}
-        if pregenerate_hist:
+        if pregenerate_hist and not len(ifos) == 1:
             self.get_hist()
 
     def get_hist(self, ifos=None):
@@ -367,7 +367,7 @@ class PhaseTDStatistic(QuadratureSumStatistic):
                 selected = name
                 break
 
-        if selected is None:
+        if selected is None and len(ifos) > 1:
             raise RuntimeError("Couldn't figure out which stat file to use")
 
         logging.info("Using signal histogram %s for ifos %s", selected, ifos)
@@ -493,6 +493,10 @@ class PhaseTDStatistic(QuadratureSumStatistic):
         # Convert time shift vector to dict, as hist ifos and self.ifos may
         # not be in same order
         to_shift = {ifo: s for ifo, s in zip(self.ifos, to_shift)}
+
+        # This is a workaround for single-detector work
+        if len(self.ifos) == 1:
+            return np.zeros_like(stats[self.ifos[0]]['snr'])
 
         if not self.has_hist:
             self.get_hist()
@@ -804,6 +808,7 @@ class ExpFitStatistic(QuadratureSumStatistic):
         alphai = self.fits_by_tid[ifo]['smoothed_fit_coeff'][tnum]
         ratei = self.fits_by_tid[ifo]['smoothed_rate_above_thresh'][tnum]
         thresh = self.fits_by_tid[ifo]['thresh']
+
         return alphai, ratei, thresh
 
     def lognoiserate(self, trigs):

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -494,10 +494,6 @@ class PhaseTDStatistic(QuadratureSumStatistic):
         # not be in same order
         to_shift = {ifo: s for ifo, s in zip(self.ifos, to_shift)}
 
-        # This is a workaround for single-detector work
-        if len(self.ifos) == 1:
-            return np.zeros_like(stats[self.ifos[0]]['snr'])
-
         if not self.has_hist:
             self.get_hist()
 


### PR DESCRIPTION
Separating out the updates to sngls_findtrigs from the offline singles PR, as it makes things a little easier to digest

- Update the sngls_findtrigs code to be more in line with coinc_findtrigs, and therefore more obvious to implement similar things to both codes
- The clustering was previously performed over all triggers, this is now done only on a per-template basis.
- The output files are then the same except for a couple of things:
   - The order of triggers changes, as we move from trigger_id order to template_id order
   - trigger_id is now a float64 rather than int64: no real reason why or why not to do this
   - The attribute timeslide_interval is now given (always zero)
