### PR TITLE
fix distributions import error

### DIFF
--- a/pycbc/distributions/utils.py
+++ b/pycbc/distributions/utils.py
@@ -31,6 +31,7 @@ from pycbc.types.config import InterpolatingConfigParser
 from pycbc import transforms
 from pycbc import distributions
 
+
 def draw_samples_from_config(path, num=1, seed=150914):
     r""" Generate sampling points from a standalone .ini file.
 

--- a/pycbc/distributions/utils.py
+++ b/pycbc/distributions/utils.py
@@ -29,8 +29,7 @@ in a Python script, rather than in the command line.
 import numpy as np
 from pycbc.types.config import InterpolatingConfigParser
 from pycbc import transforms
-import pycbc.distributions as distributions
-
+from pycbc import distributions
 
 def draw_samples_from_config(path, num=1, seed=150914):
     r""" Generate sampling points from a standalone .ini file.


### PR DESCRIPTION
Currently `pycbc_inference` throws an error:
`AttributeError: module 'pycbc' has no attribute 'distributions'`

Fixing how distributions is imported in distributions/utils.py.