### PR TITLE
make rounding more precise in a few places, allow read_frame be less …

### DIFF
--- a/pycbc/frame/frame.py
+++ b/pycbc/frame/frame.py
@@ -223,7 +223,7 @@ def read_frame(location, channels, start_time=None,
     series = create_series_func(first_channel, stream.epoch, 0, 0,
                                 lal.ADCCountUnit, 0)
     get_series_metadata_func(series, stream)
-    data_duration = data_length * series.deltaT
+    data_duration = (data_length + 0.5) * series.deltaT
 
     if start_time is None:
         start_time = stream.epoch*1

--- a/pycbc/noise/reproduceable.py
+++ b/pycbc/noise/reproduceable.py
@@ -174,7 +174,7 @@ def colored_noise(psd, start_time, end_time,
     # Here we color. Do not want to duplicate memory here though so use '*='
     white_noise *= asd
     del asd
-    colored = white_noise.to_timeseries()
+    colored = white_noise.to_timeseries(delta_t=1.0/sample_rate)
     del white_noise
     return colored.time_slice(start_time, end_time)
 

--- a/pycbc/strain/strain.py
+++ b/pycbc/strain/strain.py
@@ -236,8 +236,7 @@ def from_cli(opt, dyn_range_fac=1, precision='single',
         pdf = 1.0 / opt.fake_strain_filter_duration
         fake_flow = opt.fake_strain_flow
         fake_rate = opt.fake_strain_sample_rate
-        plen = int(opt.sample_rate / pdf) // 2 + 1
-
+        plen = round(opt.sample_rate / pdf) // 2 + 1
         if opt.fake_strain_from_file:
             logging.info("Reading ASD from file")
             strain_psd = pycbc.psd.from_txt(opt.fake_strain_from_file,
@@ -263,6 +262,7 @@ def from_cli(opt, dyn_range_fac=1, precision='single',
                                    seed=opt.fake_strain_seed,
                                    sample_rate=fake_rate,
                                    low_frequency_cutoff=fake_flow)
+
         if not strain.sample_rate_close(fake_rate):
             err_msg = "Actual sample rate of generated data does not match "
             err_msg += "that expected. Possible causes of this:\n"

--- a/pycbc/types/frequencyseries.py
+++ b/pycbc/types/frequencyseries.py
@@ -474,6 +474,7 @@ class FrequencySeries(Array):
                            dtype=real_same_precision_as(self)),
                            delta_t=delta_t)
         ifft(tmp, f)
+        f._delta_t = delta_t
         return f
 
     @_noreal

--- a/pycbc/types/timeseries.py
+++ b/pycbc/types/timeseries.py
@@ -890,6 +890,7 @@ class TimeSeries(Array):
                            dtype=complex_same_precision_as(self)),
                            delta_f=delta_f)
         fft(tmp, f)
+        f._delta_f = delta_f
         return f
 
     def inject(self, other, copy=True):


### PR DESCRIPTION
This updates a few locations to produce more dt / df preservation. They weren't wrong per, but if used in codes that don't allow eps rounding then this allow higher interoperability. In particular the lalframe frame reading would ignore the last sample when reading. This caused downstream issues for @maxtrevor (see https://github.com/gwastro/pycbc/pull/3992#issuecomment-1088999391)