### PR TITLE
similar to PR #3922 but for splitinj

### DIFF
--- a/bin/pycbc_split_inspinj
+++ b/bin/pycbc_split_inspinj
@@ -44,7 +44,17 @@ if args.num_splits:
 else:
     num_splits = len(args.output_files)
 
-new_inj_tables = [lsctables.New(tabletype, columns=allinjs.columnnames) \
+# make a list of columns that are present in the input table.
+# The : split is needed for columns like `process:process_id`,
+# which must be listed as `process:process_id` in `lsctables.New()`,
+# but are listed as just `process_id` in the `columnnames` attribute
+used_columns = []
+for col in allinjs.validcolumns:
+    att = col.split(':')[-1]
+    if att in allinjs.columnnames:
+        used_columns.append(col)
+
+new_inj_tables = [lsctables.New(tabletype, columns=used_columns) \
                   for idx in range(num_splits)]
 
 table_cycle = cycle(new_inj_tables)

--- a/bin/pycbc_split_inspinj
+++ b/bin/pycbc_split_inspinj
@@ -54,7 +54,7 @@ for col in allinjs.validcolumns:
     if att in allinjs.columnnames:
         used_columns.append(col)
 
-new_inj_tables = [lsctables.New(tabletype, columns=used_columns) \
+new_inj_tables = [lsctables.New(tabletype, columns=used_columns) 
                   for idx in range(num_splits)]
 
 table_cycle = cycle(new_inj_tables)

--- a/bin/workflows/pycbc_make_bank_verifier_workflow
+++ b/bin/workflows/pycbc_make_bank_verifier_workflow
@@ -176,7 +176,7 @@ inp_bank = workflow.cp.get('workflow', 'input-bank')
 inp_bank = wf.resolve_url_to_file(inp_bank)
 inp_bank.tags = []
 inp_bank.description='TEMPLATEBANK'
-inp_bank.ifo_list=(['H1','L1','V1'])
+inp_bank.ifo_list = (workflow.ifos)
 inp_bank.segment = workflow.analysis_time
 
 # Inspinj job

--- a/bin/workflows/pycbc_make_bank_verifier_workflow
+++ b/bin/workflows/pycbc_make_bank_verifier_workflow
@@ -176,7 +176,7 @@ inp_bank = workflow.cp.get('workflow', 'input-bank')
 inp_bank = wf.resolve_url_to_file(inp_bank)
 inp_bank.tags = []
 inp_bank.description='TEMPLATEBANK'
-inp_bank.ifo_list = (workflow.ifos)
+inp_bank.ifo_list = workflow.ifos
 inp_bank.segment = workflow.analysis_time
 
 # Inspinj job


### PR DESCRIPTION
This PR also stops `pycbc_make_bank_verifier_workflow` from assuming the fixed list of ifos H1, L1, V1 .