### PR TITLE
add distance marginalization to relative model + phase options

### DIFF
--- a/pycbc/inference/models/relbin.py
+++ b/pycbc/inference/models/relbin.py
@@ -37,6 +37,7 @@ from pycbc.types import Array
 
 from .gaussian_noise import BaseGaussianNoise
 from .relbin_cpu import likelihood_parts, likelihood_parts_v
+from .tools import DistMarg
 
 
 def setup_bins(f_full, f_lo, f_hi, chi=1.0, eps=0.5, gammas=None):
@@ -102,7 +103,7 @@ def setup_bins(f_full, f_lo, f_hi, chi=1.0, eps=0.5, gammas=None):
     return nbin, fbin, fbin_ind
 
 
-class Relative(BaseGaussianNoise):
+class Relative(DistMarg, BaseGaussianNoise):
     r"""Model that assumes the likelihood in a region around the peak
     is slowly varying such that a linear approximation can be made, and
     likelihoods can be calculated at a coarser frequency resolution. For
@@ -410,9 +411,7 @@ class Relative(BaseGaussianNoise):
             hd += hdp
             hh += hhp
 
-        hd = abs(hd)
-        llr = numpy.log(special.i0e(hd)) + hd - 0.5 * hh
-        return float(llr)
+        return self.marginalize_loglr(sh_total, hh_total)
 
     def write_metadata(self, fp):
         """Adds writing the fiducial parameters and epsilon to file's attrs.

--- a/pycbc/inference/models/relbin.py
+++ b/pycbc/inference/models/relbin.py
@@ -103,7 +103,7 @@ def setup_bins(f_full, f_lo, f_hi, chi=1.0, eps=0.5, gammas=None):
     return nbin, fbin, fbin_ind
 
 
-class Relative(DistMarg, BaseGaussianNoise):
+class Relative(BaseGaussianNoise, DistMarg):
     r"""Model that assumes the likelihood in a region around the peak
     is slowly varying such that a linear approximation can be made, and
     likelihoods can be calculated at a coarser frequency resolution. For
@@ -158,8 +158,15 @@ class Relative(DistMarg, BaseGaussianNoise):
         gammas=None,
         epsilon=0.5,
         earth_rotation=False,
+        marginalize_phase=True,
         **kwargs
     ):
+
+        variable_params, kwargs = self.setup_distance_marginalization(
+                               variable_params,
+                               marginalize_phase=marginalize_phase,
+                               **kwargs)
+
         super(Relative, self).__init__(
             variable_params, data, low_frequency_cutoff, **kwargs
         )
@@ -411,7 +418,7 @@ class Relative(DistMarg, BaseGaussianNoise):
             hd += hdp
             hh += hhp
 
-        return self.marginalize_loglr(sh_total, hh_total)
+        return self.marginalize_loglr(hd, hh)
 
     def write_metadata(self, fp):
         """Adds writing the fiducial parameters and epsilon to file's attrs.

--- a/pycbc/inference/models/single_template.py
+++ b/pycbc/inference/models/single_template.py
@@ -60,11 +60,12 @@ class SingleTemplate(DistMarg, BaseGaussianNoise):
     def __init__(self, variable_params, data, low_frequency_cutoff,
                  sample_rate=32768,
                  polarization_samples=None,
+                 marginalize_phase=True,
                  **kwargs):
 
         variable_params, kwargs = self.setup_distance_marginalization(
                                        variable_params,
-                                       marginalize_phase=True,
+                                       marginalize_phase=marginalize_phase,
                                        **kwargs)
         super(SingleTemplate, self).__init__(
             variable_params, data, low_frequency_cutoff, **kwargs)

--- a/pycbc/inference/models/tools.py
+++ b/pycbc/inference/models/tools.py
@@ -5,6 +5,8 @@ import logging
 import numpy
 import tqdm
 
+from distutils.util import strtobool
+
 from scipy.special import logsumexp, i0e
 from scipy.interpolate import RectBivariateSpline, interp1d
 from pycbc.distributions import JointDistribution
@@ -14,6 +16,11 @@ def str_to_tuple(sval, ftype):
     """ Convenience parsing to convert str to tuple"""
     return tuple(ftype(x) for x in sval.split(','))
 
+def str_to_bool(sval):
+    if isinstance(sval, str):
+        return strtobool(sval)
+    else:
+        return sval
 
 class DistMarg():
     """Help class to add bookkeeping for distance marginalization"""
@@ -68,9 +75,11 @@ class DistMarg():
             The keyword arguments to the model initialization, may be modified
             from the original set by this function.
         """
-        self.marginalize_phase = marginalize_phase
+        self.marginalize_phase = str_to_bool(marginalize_phase)
         self.distance_marginalization = False
         self.distance_interpolator = None
+
+        marginalize_distance = str_to_bool(marginalize_distance)
         if not marginalize_distance:
             return variable_params, kwargs
 
@@ -271,7 +280,7 @@ def marginalize_likelihood(sh, hh,
     loglr: float
         The marginalized loglikehood ratio
     """
-    if isinstance(sh, float):
+    if isinstance(hh, float):
         clogweights = 0
     else:
         sh = sh.flatten()


### PR DESCRIPTION
This adds the option to use distance marginalization with the relative model using precalculated interpolating functions for the distance integral. This was previously added for the margphase / polmarg / single template models earlier. This also now exposes the option to turn *off* (previously was assumed on only) phase marginalization for the relative and single template models. For now the defaults are unchanged. 