### PR TITLE
Add function to reconstruct marginalized distance or polarization, feature added to script

### DIFF
--- a/bin/inference/pycbc_inference_model_stats
+++ b/bin/inference/pycbc_inference_model_stats
@@ -53,6 +53,8 @@ parser.add_argument("--config-file", nargs="+", type=str, default=None,
                           "with the given file(s).")
 parser.add_argument("--verbose", action="store_true", default=False,
                     help="Print logging messages.")
+parser.add_argument('--reconstruct-parameters', action="store_true",
+                    help="Reconstruct marginalized parameters")
 
 
 # parse command line
@@ -92,20 +94,24 @@ model.sampling_transforms = None
 
 # create function for calling the model to get the stats
 def callmodel(paramvals):
-    # paramvals should be a numpy record instance
-    model.update(**{p: paramvals[p] for p in model.variable_params})
     # calculate the logposterior to get all stats populated
-    _ = model.logposterior
-    return model.get_current_stats()
+    model.update(**{p: paramvals[p] for p in model.variable_params})
+    _ = model.logposterior    
+    stats = model.get_current_stats()
+    
+    rec = {}
+    if opts.reconstruct_parameters:
+        model.update(**{p: paramvals[p] for p in model.variable_params})
+        rec = model.reconstruct()
+        print(rec)
+    return stats, rec
 
-# these help for parallelization
+# these help for parallelization for MPI
 models._global_instance = callmodel
 model_call = models._call_global_model
 
-# setup the pool
 pool = choose_pool(processes=opts.nprocesses)
 
-# load the samples
 logging.info('Getting samples')
 with loadfile(opts.input_file, 'r') as fp:
     # we'll need the shape; all the arrays in the samples group should have the
@@ -114,26 +120,16 @@ with loadfile(opts.input_file, 'r') as fp:
     samples = {}
     for p in model.variable_params:
         samples[p] = fp[fp.samples_group][p][()].flatten()
+
 # convert the samples array to a FieldArray for easy iteration over
 samples = FieldArray.from_kwargs(**samples)
 logging.info("Loaded %i samples", samples.size)
 
-estsize = 100
-if samples.size > estsize:
-    logging.info("Estimating run time using first %i samples", estsize)
-    # estimate the time it will take
-    before = time.time()
-    stats = list(pool.map(model_call, samples[:estsize]))
-    now = time.time()
-    total = ((samples.size - estsize)*(now - before)/estsize)/opts.nprocesses
-    logging.info("Will take ~%.2f more minutes", total/60.)
-    samples = samples[estsize:]
-else:
-    stats = []
-
 # get the stats
 logging.info("Calculating stats")
-stats += list(pool.map(model_call, samples))
+data = list(pool.map(model_call, samples))
+stats = [x[0] for x in data]
+rec = [x[1] for x in data]
 
 # write to the output file
 logging.info("Copying input to output")
@@ -145,6 +141,12 @@ idx = range(len(stats))
 for pi, p in enumerate(model.default_stats):
     vals = numpy.array([stats[ii][pi] for ii in idx]).reshape(shape)
     out.write_data(p, vals, path=fp.samples_group, append=False)
+    
+if opts.reconstruct_parameters:
+    logging.info("Writing reconstructed parameters")
+    for p in rec[0].keys():
+        vals = numpy.array([r[p] for r in rec]).reshape(shape)
+        out.write_data(p, vals, path=fp.samples_group, append=False)
+    
 out.close()
-
 logging.info("Done")

--- a/bin/inference/pycbc_inference_model_stats
+++ b/bin/inference/pycbc_inference_model_stats
@@ -103,7 +103,6 @@ def callmodel(paramvals):
     if opts.reconstruct_parameters:
         model.update(**{p: paramvals[p] for p in model.variable_params})
         rec = model.reconstruct()
-        print(rec)
     return stats, rec
 
 # these help for parallelization for MPI

--- a/pycbc/inference/io/__init__.py
+++ b/pycbc/inference/io/__init__.py
@@ -701,7 +701,6 @@ def results_from_cli(opts, load_samples=True, **kwargs):
             # read samples from file
             samples = fp.samples_from_cli(opts, parameters=opts.parameters,
                                           **kwargs)
-
             logging.info("Loaded {} samples".format(samples.size))
 
             if input_file in constraints:

--- a/pycbc/inference/io/base_hdf.py
+++ b/pycbc/inference/io/base_hdf.py
@@ -213,6 +213,8 @@ class BaseInferenceFile(h5py.File, metaclass=ABCMeta):
         addatrs = (list(self.static_params.items()) +
                    list(self[self.samples_group].attrs.items()))
         for (p, val) in addatrs:
+            if p in loadfields:
+                continue
             setattr(samples, format_attr(p), format_attr(val))
         return samples
 

--- a/pycbc/inference/models/marginalized_gaussian_noise.py
+++ b/pycbc/inference/models/marginalized_gaussian_noise.py
@@ -210,8 +210,15 @@ class MarginalizedPolarization(BaseGaussianNoise, DistMarg):
                  high_frequency_cutoff=None, normalize=False,
                  polarization_samples=1000, **kwargs):
 
+        self.polarization_samples = int(polarization_samples)
+        self.pol = numpy.linspace(0, 2*numpy.pi, self.polarization_samples)
+
         variable_params, kwargs = self.setup_distance_marginalization(
-                               variable_params, **kwargs)
+                               variable_params, 
+                               marginalize_phase=marginalize_phase,
+                               marginalize_vector='polarization',
+                               marginalize_vector_params=self.pol,
+                               **kwargs)
 
         # set up the boiler-plate attributes
         super(MarginalizedPolarization, self).__init__(
@@ -238,8 +245,6 @@ class MarginalizedPolarization(BaseGaussianNoise, DistMarg):
                     generator_class=generator.FDomainDetFrameTwoPolGenerator,
                     gates=self.gates, **kwargs['static_params'])
 
-        self.polarization_samples = int(polarization_samples)
-        self.pol = numpy.linspace(0, 2*numpy.pi, self.polarization_samples)
         self.dets = {}
 
     @property

--- a/pycbc/inference/models/marginalized_gaussian_noise.py
+++ b/pycbc/inference/models/marginalized_gaussian_noise.py
@@ -216,7 +216,7 @@ class MarginalizedPolarization(BaseGaussianNoise, DistMarg):
         self.pol = numpy.linspace(0, 2*numpy.pi, self.polarization_samples)
 
         variable_params, kwargs = self.setup_distance_marginalization(
-                               variable_params, 
+                               variable_params,
                                marginalize_phase=marginalize_phase,
                                marginalize_vector='polarization',
                                marginalize_vector_params=self.pol,
@@ -344,7 +344,7 @@ class MarginalizedPolarization(BaseGaussianNoise, DistMarg):
 
         lr, idx, maxl = self.marginalize_loglr(sh_total, hh_total,
                   return_peak=True)
-        
+
         # store the maxl polarization
         setattr(self._current_stats, 'maxl_polarization', self.pol[idx])
         setattr(self._current_stats, 'maxl_loglr', maxl)

--- a/pycbc/inference/models/marginalized_gaussian_noise.py
+++ b/pycbc/inference/models/marginalized_gaussian_noise.py
@@ -335,13 +335,12 @@ class MarginalizedPolarization(BaseGaussianNoise, DistMarg):
             sh_total += cplx_hd
             hh_total += hh
 
-        lr = self.marginalize_loglr(sh_total, hh_total, skip_vector=True)
-        lr_total = special.logsumexp(lr) - numpy.log(len(self.pol))
-
+        lr, maxl, idx = self.marginalize_loglr(sh_total, hh_total,
+                  return_peak=True)
+        
         # store the maxl polarization
-        idx = lr.argmax()
         setattr(self._current_stats, 'maxl_polarization', self.pol[idx])
-        setattr(self._current_stats, 'maxl_loglr', lr[idx])
+        setattr(self._current_stats, 'maxl_loglr', maxl)
 
         # just store the maxl optimal snrsq
         for det in wfs:
@@ -349,7 +348,7 @@ class MarginalizedPolarization(BaseGaussianNoise, DistMarg):
             setattr(self._current_stats, p,
                     getattr(self._current_stats, p)[idx])
 
-        return float(lr_total)
+        return lr
 
 
 class MarginalizedHMPolPhase(BaseGaussianNoise):

--- a/pycbc/inference/models/marginalized_gaussian_noise.py
+++ b/pycbc/inference/models/marginalized_gaussian_noise.py
@@ -342,7 +342,7 @@ class MarginalizedPolarization(BaseGaussianNoise, DistMarg):
             sh_total += cplx_hd
             hh_total += hh
 
-        lr, maxl, idx = self.marginalize_loglr(sh_total, hh_total,
+        lr, idx, maxl = self.marginalize_loglr(sh_total, hh_total,
                   return_peak=True)
         
         # store the maxl polarization

--- a/pycbc/inference/models/marginalized_gaussian_noise.py
+++ b/pycbc/inference/models/marginalized_gaussian_noise.py
@@ -208,7 +208,9 @@ class MarginalizedPolarization(BaseGaussianNoise, DistMarg):
 
     def __init__(self, variable_params, data, low_frequency_cutoff, psds=None,
                  high_frequency_cutoff=None, normalize=False,
-                 polarization_samples=1000, **kwargs):
+                 polarization_samples=1000,
+                 marginalize_phase=False,
+                 **kwargs):
 
         self.polarization_samples = int(polarization_samples)
         self.pol = numpy.linspace(0, 2*numpy.pi, self.polarization_samples)

--- a/pycbc/inference/models/single_template.py
+++ b/pycbc/inference/models/single_template.py
@@ -63,10 +63,19 @@ class SingleTemplate(DistMarg, BaseGaussianNoise):
                  marginalize_phase=True,
                  **kwargs):
 
+        #polarization array to marginalize over if num_samples given
+        self.pflag = 0
+        if polarization_samples is not None:
+            self.polarization = numpy.linspace(0, 2*numpy.pi,
+                                               int(polarization_samples))
+            self.pflag = 1
+
         variable_params, kwargs = self.setup_distance_marginalization(
-                                       variable_params,
-                                       marginalize_phase=marginalize_phase,
-                                       **kwargs)
+                                   variable_params,
+                                   marginalize_phase=marginalize_phase,
+                                   marginalize_vector=self.pflag,
+                                   marginalize_vector_params=self.polarization,
+                                   **kwargs)
         super(SingleTemplate, self).__init__(
             variable_params, data, low_frequency_cutoff, **kwargs)
 
@@ -82,12 +91,6 @@ class SingleTemplate(DistMarg, BaseGaussianNoise):
         # Extend template to high sample rate
         flen = int(int(sample_rate) / df) / 2 + 1
         hp.resize(flen)
-        #polarization array to marginalize over if num_samples given
-        self.pflag = 0
-        if polarization_samples is not None:
-            self.polarization = numpy.linspace(0, 2*numpy.pi,
-                                               int(polarization_samples))
-            self.pflag = 1
 
         # Calculate high sample rate SNR time series
         self.sh = {}

--- a/pycbc/inference/models/single_template.py
+++ b/pycbc/inference/models/single_template.py
@@ -69,11 +69,12 @@ class SingleTemplate(DistMarg, BaseGaussianNoise):
             self.polarization = numpy.linspace(0, 2*numpy.pi,
                                                int(polarization_samples))
             self.pflag = 1
+        marg_vector = 'polarization' if self.pflag else False
 
         variable_params, kwargs = self.setup_distance_marginalization(
                                    variable_params,
                                    marginalize_phase=marginalize_phase,
-                                   marginalize_vector=self.pflag,
+                                   marginalize_vector=marg_vector,
                                    marginalize_vector_params=self.polarization,
                                    **kwargs)
         super(SingleTemplate, self).__init__(
@@ -134,6 +135,10 @@ class SingleTemplate(DistMarg, BaseGaussianNoise):
         if self.time is None:
             self.time = p['tc']
 
+        phase = 1
+        if 'coa_phase' in p:
+            phase = numpy.exp(1.0j * 2 * p['coa_phase'])
+
         sh_total = hh_total = 0
         for ifo in self.sh:
             fp, fc = self.det[ifo].antenna_pattern(p['ra'], p['dec'],
@@ -142,7 +147,7 @@ class SingleTemplate(DistMarg, BaseGaussianNoise):
                                                             self.time)
             ic = numpy.cos(p['inclination'])
             ip = 0.5 * (1.0 + ic * ic)
-            htf = (fp * ip + 1.0j * fc * ic) / p['distance']
+            htf = (fp * ip + 1.0j * fc * ic) / p['distance'] * phase
             sh = self.sh[ifo].at_time(p['tc'] + dt) * htf
             sh_total += sh
             hh_total += self.hh[ifo] * abs(htf) ** 2.0

--- a/pycbc/inference/models/single_template.py
+++ b/pycbc/inference/models/single_template.py
@@ -65,6 +65,7 @@ class SingleTemplate(DistMarg, BaseGaussianNoise):
 
         #polarization array to marginalize over if num_samples given
         self.pflag = 0
+        self.polarization = None
         if polarization_samples is not None:
             self.polarization = numpy.linspace(0, 2*numpy.pi,
                                                int(polarization_samples))

--- a/pycbc/inference/models/tools.py
+++ b/pycbc/inference/models/tools.py
@@ -176,7 +176,7 @@ class DistMarg():
         return variable_params, kwargs
 
     def marginalize_loglr(self, sh_total, hh_total,
-                          skip_vector=False):
+                          skip_vector=False, return_peak=False):
         """ Return the marginal likelihood
 
         Parameters
@@ -198,7 +198,8 @@ class DistMarg():
                                       phase=self.marginalize_phase,
                                       interpolator=interpolator,
                                       distance=self.distance_marginalization,
-                                      skip_vector=skip_vector)
+                                      skip_vector=skip_vector,
+                                      return_peak=return_peak)
 
     def reconstruct(self):
         """ Reconstruct the distance or vectored marginalized parameter

--- a/pycbc/inference/models/tools.py
+++ b/pycbc/inference/models/tools.py
@@ -82,7 +82,7 @@ class DistMarg():
         """
         self.marginalize_vector = marginalize_vector
         self.marginalize_vector_params = marginalize_vector_params
-        
+
         self.reconstructing_distance = False
         self.marginalize_phase = str_to_bool(marginalize_phase)
         self.distance_marginalization = False
@@ -193,7 +193,7 @@ class DistMarg():
         if self.reconstructing_distance:
             skip_vector = True
             interpolator = None
-        
+
         return marginalize_likelihood(sh_total, hh_total,
                                       phase=self.marginalize_phase,
                                       interpolator=interpolator,
@@ -206,14 +206,14 @@ class DistMarg():
         of this class.
         """
         rec = {}
-        
+
         def draw_sample(params, loglr):
             x = numpy.random.uniform()
             cdf = numpy.exp(loglr).cumsum()
             cdf /= cdf[-1]
             xl = numpy.searchsorted(cdf, x)
             return params[xl], xl
-        
+
         if self.distance_marginalization:
             # turn off interpolator and set to return vector output
             self.reconstructing_distance = True
@@ -223,27 +223,27 @@ class DistMarg():
             loglr = logsumexp(loglr_full, axis=0)
         else:
             loglr = loglr_full
-        
+
         if self.distance_marginalization:
             # call likelihood to get vector output
             _, weights = self.distance_marginalization
             loglr += numpy.log(weights)
-            
+
             # draw distance sample
             dist, xl = draw_sample(self.dist_locs, loglr)
             rec['distance'] = dist
-            
+
         if self.marginalize_vector:
             if self.distance_marginalization:
                 # logl along for the selected distance
                 vlr = loglr_full[:, xl]
             else:
-                vlr = loglr    
-                
-            vec_param, _ = draw_sample(self.marginalize_vector_params, vlr) 
+                vlr = loglr
+
+            vec_param, _ = draw_sample(self.marginalize_vector_params, vlr)
             rec[self.marginalize_vector] = vec_param
-              
-        self.reconstructing_distance = False          
+
+        self.reconstructing_distance = False
         return rec
 
 
@@ -387,7 +387,7 @@ def marginalize_likelihood(sh, hh,
 
     if return_peak:
         maxv = vloglr.argmax()
-        maxl = vloglr[maxv]    
+        maxl = vloglr[maxv]
 
     # Do brute-force marginalization if loglr is a vector
     if isinstance(vloglr, float):


### PR DESCRIPTION
Depends on #3996 

This adds a function to reconstruct the marginalized distance or polarization value of a model. The functionality is added to pycbc_inference_model_stats with an additional argument '--reconstruct-parameters'. 

A few fixes also in place to enable measure the phase for single / relative models. 