### PR TITLE
fix checkpointing after recent dynesty API change

### DIFF
--- a/examples/inference/single/run.sh
+++ b/examples/inference/single/run.sh
@@ -1,6 +1,6 @@
 pycbc_inference \
 --config-file `dirname "$0"`/single.ini \
---nprocesses=4 \
+--nprocesses=1 \
 --output-file single.hdf \
 --seed 0 \
 --force \

--- a/examples/inference/single/single.ini
+++ b/examples/inference/single/single.ini
@@ -21,13 +21,13 @@ strain-high-pass = 15
 sample-rate = 2048
 
 [sampler]
-no-save-state =
 name = dynesty
-nlive = 100
-walks = 100
-maxmcmc = 500
-nact = 10
-sample = rwalk2
+sample = rwalk
+bound = multi
+dlogz = 0.01
+nlive = 1000
+checkpoint_time_interval = 10
+maxcall = 10000
 
 [variable_params]
 ; waveform parameters that will vary in MCMC

--- a/pycbc/inference/io/base_hdf.py
+++ b/pycbc/inference/io/base_hdf.py
@@ -422,6 +422,7 @@ class BaseInferenceFile(h5py.File, metaclass=ABCMeta):
             Specify the random state to write. If None, will use
             ``numpy.random.get_state()``.
         """
+        # Write out the default numpy random state
         group = self.sampler_group if group is None else group
         dataset_name = "/".join([group, "random_state"])
         if state is None:
@@ -451,6 +452,7 @@ class BaseInferenceFile(h5py.File, metaclass=ABCMeta):
         tuple
             A tuple with 5 elements that can be passed to numpy.set_state.
         """
+        # Read numpy randomstate
         group = self.sampler_group if group is None else group
         dataset_name = "/".join([group, "random_state"])
         arr = self[dataset_name][:]
@@ -458,7 +460,8 @@ class BaseInferenceFile(h5py.File, metaclass=ABCMeta):
         pos = self[dataset_name].attrs["pos"]
         has_gauss = self[dataset_name].attrs["has_gauss"]
         cached_gauss = self[dataset_name].attrs["cached_gauss"]
-        return s, arr, pos, has_gauss, cached_gauss
+        state = s, arr, pos, has_gauss, cached_gauss
+        return state
 
     def write_strain(self, strain_dict, group=None):
         """Writes strain for each IFO to file.

--- a/pycbc/inference/sampler/dynesty.py
+++ b/pycbc/inference/sampler/dynesty.py
@@ -329,8 +329,8 @@ class DynestySampler(BaseSampler):
         extra['first_update'] = first_update
 
         # populate options for checkpointing
-        checkpoint_time_interval=None
-        maxcall=None
+        checkpoint_time_interval = None
+        maxcall = None
         if cp.has_option(section, 'checkpoint_time_interval'):
             ck_time = float(cp.get(section, 'checkpoint_time_interval'))
             checkpoint_time_interval = ck_time
@@ -342,7 +342,7 @@ class DynestySampler(BaseSampler):
                   checkpoint_time_interval=checkpoint_time_interval,
                   maxcall=maxcall,
                   no_save_state=no_save_state,
-                  use_mpi=use_mpi, run_kwds=run_extra, 
+                  use_mpi=use_mpi, run_kwds=run_extra,
                   extra_kwds=extra,
                   internal_kwds=internal_extra,)
         setup_output(obj, output_file, check_nsamples=False)
@@ -491,7 +491,7 @@ def sample_rwalk_mod(args):
         # Unzipping.
         (u, loglstar, axes, scale,
         prior_transform, loglikelihood, kwargs) = args
-        
+
     except ImportError:
         # dynest >= 1.2
         from dynesty.utils import unitcheck, apply_reflect as reflect

--- a/pycbc/inference/sampler/dynesty.py
+++ b/pycbc/inference/sampler/dynesty.py
@@ -291,12 +291,10 @@ class DynestySampler(BaseSampler):
 
         # optional arguments for dynesty
         cargs = {'bound': str,
-                 'maxcall': int,
                  'bootstrap': int,
                  'enlarge': float,
                  'update_interval': float,
                  'sample': str,
-                 'checkpoint_time_interval': float,
                  'first_update_min_ncall': int,
                  'first_update_min_eff': float,
                  'walks': int,
@@ -330,8 +328,19 @@ class DynestySampler(BaseSampler):
             logging.info('First update: min_eff:%s', first_update['min_eff'])
         extra['first_update'] = first_update
 
+        # populate options for checkpointing
+        checkpoint_time_interval=None
+        maxcall=None
+        if cp.has_option(section, 'checkpoint_time_interval'):
+            ck_time = float(cp.get(section, 'checkpoint_time_interval'))
+            checkpoint_time_interval = ck_time
+        if cp.has_option(section, 'maxcall'):
+            maxcall = int(cp.get(section, 'maxcall'))
+
         obj = cls(model, nlive=nlive, nprocesses=nprocesses,
                   loglikelihood_function=loglikelihood_function,
+                  checkpoint_time_interval=checkpoint_time_interval,
+                  maxcall=maxcall,
                   no_save_state=no_save_state,
                   use_mpi=use_mpi, run_kwds=run_extra, 
                   extra_kwds=extra,
@@ -387,11 +396,10 @@ class DynestySampler(BaseSampler):
         """Sets the state of the sampler back to the instance saved in a file.
         """
         with self.io(filename, 'r') as fp:
-            numpy.random.set_state(fp.read_random_state())
-
-        self._sampler.rstate = numpy.random
-        #if self.nlive < 0:
-        #    self._sampler.sampler.rstate = numpy.random
+            state = fp.read_random_state()
+            # Dynesty handles most randomeness through rstate which is
+            # pickled along with the class instance
+            numpy.random.set_state(state)
 
     def finalize(self):
         """Finalze and write it to the results file


### PR DESCRIPTION
The recent PR to update pycbc to work with the latest Dynesty (1.2.0) API also turned off checkpointing. This was due to how the options were passed being ignored with the new method. This Patch should address the problem reported by @cnsetzer. 