### PR TITLE
Live singles in ci test

### DIFF
--- a/examples/live/check_results.py
+++ b/examples/live/check_results.py
@@ -104,8 +104,8 @@ def check_single_results(args):
     return single_fail
 
 
-def check_coinc_results(args):
-    coinc_fail = False
+def check_found_events(args):
+    found_fail = False
 
     # read injections
     with h5py.File(args.injections, 'r') as injfile:
@@ -115,26 +115,27 @@ def check_coinc_results(args):
         inj_spin2z = injfile['spin2z'][:]
         inj_time = injfile['tc'][:]
 
-    # gather coincident triggers
-    coinc_trig_paths = sorted(glob.glob('output/coinc*.xml.gz'))
-    n_coincs = len(coinc_trig_paths)
-    if n_coincs == 0:
-        log.error('No coincident triggers detected')
-        coinc_fail = True
-    elif n_coincs >= 10:
-        log.error('Too many coincident triggers detected')
-        coinc_fail = True
+    # gather found triggers
+    found_trig_paths = sorted(glob.glob('output/coinc*.xml.gz') +
+                              glob.glob('output/single*.xml.gz'))
+    n_found = len(found_trig_paths)
+    if n_found == 0:
+        log.error('No triggers detected')
+        found_fail = True
+    elif n_found >= 10:
+        log.error('Too many triggers detected')
+        found_fail = True
     else:
-        log.info('%d coincident trigger(s) detected', n_coincs)
+        log.info('%d found trigger(s) detected', n_found)
 
     # create field array to store properties of triggers
     dtype = [('mass1', float), ('mass2', float),
              ('spin1z', float), ('spin2z', float),
              ('tc', float), ('net_snr', float)]
-    trig_props = FieldArray(n_coincs, dtype=dtype)
+    trig_props = FieldArray(n_found, dtype=dtype)
 
-    # store properties of coincident triggers
-    for x, ctrigfp in enumerate(coinc_trig_paths):
+    # store properties of found triggers
+    for x, ctrigfp in enumerate(found_trig_paths):
         log.info('Checking trigger %s', ctrigfp)
         xmldoc = load_xml_doc(
             ctrigfp, False, contenthandler=LIGOLWContentHandler)
@@ -160,7 +161,7 @@ def check_coinc_results(args):
     # check if injections match trigger params
     for i in range(len(inj_mass1)):
         has_match = False
-        for j in range(n_coincs):
+        for j in range(n_found):
             # FIXME should calculate the optimal SNRs of the injections
             # and use those for checking net_snr
             if (close(inj_time[i], trig_props['tc'][j], 1.0)
@@ -173,13 +174,12 @@ def check_coinc_results(args):
                 break
 
         if not has_match:
-            coinc_fail = True
+            found_fail = True
             log.error('Injection %i was missed', i)
-            print(trig_props['net_snr'])
 
-    if coinc_fail:
-        log.error('Coincident Trigger Test Failed')
-    return coinc_fail
+    if found_fail:
+        log.error('Found Trigger Test Failed')
+    return found_fail
 
 
 parser = argparse.ArgumentParser()
@@ -194,8 +194,8 @@ args = parser.parse_args()
 log.basicConfig(level=log.INFO, format='%(asctime)s %(message)s')
 
 single_fail = check_single_results(args)
-coinc_fail = check_coinc_results(args)
-fail = single_fail or coinc_fail
+found_fail = check_found_events(args)
+fail = single_fail or found_fail
 
 if fail:
     log.error('Test Failed')

--- a/examples/live/check_results.py
+++ b/examples/live/check_results.py
@@ -175,6 +175,7 @@ def check_coinc_results(args):
         if not has_match:
             coinc_fail = True
             log.error('Injection %i was missed', i)
+            print(trig_props['net_snr'])
 
     if coinc_fail:
         log.error('Coincident Trigger Test Failed')

--- a/examples/live/generate_injections.py
+++ b/examples/live/generate_injections.py
@@ -19,22 +19,24 @@ static_params = {'f_lower': 17.,
                  'coa_phase': 0.,
                  'polarization': 0.}
 
-samples = FieldArray(2, dtype=dtype)
+samples = FieldArray(3, dtype=dtype)
 
 # masses and spins are intended to match the highest
 # and lowest mass templates in the template bank
-samples['mass1'] = [290.929321, 1.1331687]
-samples['mass2'] = [3.6755455, 1.010624]
-samples['spin1z'] = [0.9934847, 0.029544285]
-samples['spin2z'] = [0.92713535, 0.020993788]
+# Last injection is designed to be found as an EM-bright single
+samples['mass1'] = [290.929321, 1.1331687, 2.3]
+samples['mass2'] = [3.6755455, 1.010624, 1.4]
+samples['spin1z'] = [0.9934847, 0.029544285, 0]
+samples['spin2z'] = [0.92713535, 0.020993788, 0]
 
-# distance and sky locations to have network SNRs ~15
-samples['tc'] = [1272790100.1, 1272790260.1]
-samples['distance'] = [178., 79.]
-samples['ra'] = [np.deg2rad(45), np.deg2rad(10)]
-samples['dec'] = [np.deg2rad(45), np.deg2rad(-45)]
+# distance and sky locations for coincs to have network SNRs ~15
+# and for single to pass SNR cuts
+samples['tc'] = [1272790100.1, 1272790260.1, 1272790490.2]
+samples['distance'] = [178., 79., 40.]
+samples['ra'] = [np.deg2rad(45), np.deg2rad(10), np.deg2rad(45)]
+samples['dec'] = [np.deg2rad(45), np.deg2rad(-45), np.deg2rad(45)]
 
-samples['approximant'] = ['SEOBNRv4_opt', 'SpinTaylorT4']
+samples['approximant'] = ['SEOBNRv4_opt', 'SpinTaylorT4', 'SpinTaylorT4']
 
 InjectionSet.write('injections.hdf', samples, static_args=static_params,
                    injtype='cbc', cmd=" ".join(sys.argv))

--- a/examples/live/generate_injections.py
+++ b/examples/live/generate_injections.py
@@ -24,17 +24,17 @@ samples = FieldArray(3, dtype=dtype)
 # masses and spins are intended to match the highest
 # and lowest mass templates in the template bank
 # Last injection is designed to be found as an EM-bright single
-samples['mass1'] = [290.929321, 1.1331687, 2.3]
-samples['mass2'] = [3.6755455, 1.010624, 1.4]
-samples['spin1z'] = [0.9934847, 0.029544285, 0]
-samples['spin2z'] = [0.92713535, 0.020993788, 0]
+samples['mass1'] = [290.929321, 1.1331687, 2.2756491]
+samples['mass2'] = [3.6755455, 1.010624, 1.1077247]
+samples['spin1z'] = [0.9934847, 0.029544285, -0.59105825]
+samples['spin2z'] = [0.92713535, 0.020993788, 0.047548451]
 
 # distance and sky locations for coincs to have network SNRs ~15
 # and for single to pass SNR cuts
 samples['tc'] = [1272790100.1, 1272790260.1, 1272790490.2]
-samples['distance'] = [178., 79., 40.]
-samples['ra'] = [np.deg2rad(45), np.deg2rad(10), np.deg2rad(45)]
-samples['dec'] = [np.deg2rad(45), np.deg2rad(-45), np.deg2rad(45)]
+samples['distance'] = [178., 79., 47.]
+samples['ra'] = [np.deg2rad(45), np.deg2rad(10), np.deg2rad(10)]
+samples['dec'] = [np.deg2rad(45), np.deg2rad(-45), np.deg2rad(-45)]
 
 samples['approximant'] = ['SEOBNRv4_opt', 'SpinTaylorT4', 'SpinTaylorT4']
 

--- a/examples/live/make_singles_fits_file.py
+++ b/examples/live/make_singles_fits_file.py
@@ -1,6 +1,8 @@
-# This script will make a valid singles-fits file for use in the
-# pycbc_live CI tests. It doesn't have much physical meaning,
-# but will give broadly representative numbers for singles
+"""
+This script will make a valid singles-fits file for use in the
+pycbc_live CI tests. It doesn't have much physical meaning,
+but will give broadly representative numbers for singles.
+"""
 import h5py
 import numpy as np
 

--- a/examples/live/make_singles_fits_file.py
+++ b/examples/live/make_singles_fits_file.py
@@ -7,7 +7,7 @@ import numpy as np
 f = h5py.File('single_trigger_fits.hdf','w')
 
 # Some numbers to design the output
-# These are loosley based on the O3a trigger fits file
+# These are loosely based on the O3a trigger fits file
 n_days = 30
 n_bins = 5
 max_duration = 150.
@@ -16,6 +16,7 @@ duty_cycle = 0.7
 alpha = 4.
 daily_counts_per_bin = 500.
 
+# Set attributes to be something appropriate
 f.attrs['start_date'] = 0
 f.attrs['end_date'] = n_days
 f.attrs['fit_threshold'] = 6.5
@@ -24,12 +25,17 @@ f['bins_edges'] = np.logspace(np.log10(min_duration),
                               np.log10(max_duration),
                               n_bins + 1)
 
+# Create the fits groups for each ifo
 for ifo in ['H1', 'L1', 'V1']:
     f.create_group(ifo)
     ifo_group = f[ifo]
+    # Group attributes are set sensibly
     ifo_group.attrs['live_time'] = np.round(n_days * 0.7 * 86400.)
     ifo_group.attrs['mean_alpha'] = alpha
     ifo_group.attrs['total_counts'] = daily_counts_per_bin * n_days * n_bins
+
+    # Make daily fits datasets, this doesn't atually matter for the test, but
+    # means that the file format matches in case of future requirements
     ifo_group.create_group('daily_fits')
     daily_group = ifo_group['daily_fits']
     for bin_no in range(n_bins):
@@ -40,14 +46,16 @@ for ifo in ['H1', 'L1', 'V1']:
         bin_group['counts'] = np.array([daily_counts_per_bin] * n_days)
         bin_group['fit_coeff'] = np.array([alpha] * n_days)
 
+    # Again, not used for current tests, but keeps file format the same
     ifo_group.create_group('fixed')
     fixed_group = ifo_group['fixed']
     fixed_group['fit_coeff'] = np.array([0.] * n_bins)
     fixed_group['counts'] = np.array([1.] * n_bins)
+
+    # As the daily fit are all the same, the mean and 95th %ile values
+    # are the same
     for k in ['conservative', 'mean']:
         ifo_group.create_group(k)
         k_group = ifo_group[k]
         k_group['fit_coeff'] = np.array([alpha] * n_bins)
         k_group['counts'] = np.array([daily_counts_per_bin * n_days] * n_bins)
-
-

--- a/examples/live/make_singles_fits_file.py
+++ b/examples/live/make_singles_fits_file.py
@@ -1,0 +1,53 @@
+# This script will make a valid singles-fits file for use in the
+# pycbc_live CI tests. It doesn't have much physical meaning,
+# but will give broadly representative numbers for singles
+import h5py
+import numpy as np
+
+f = h5py.File('single_trigger_fits.hdf','w')
+
+# Some numbers to design the output
+# These are loosley based on the O3a trigger fits file
+n_days = 30
+n_bins = 5
+max_duration = 150.
+min_duration = 6.
+duty_cycle = 0.7
+alpha = 4.
+daily_counts_per_bin = 500.
+
+f.attrs['start_date'] = 0
+f.attrs['end_date'] = n_days
+f.attrs['fit_threshold'] = 6.5
+
+f['bins_edges'] = np.logspace(np.log10(min_duration),
+                              np.log10(max_duration),
+                              n_bins + 1)
+
+for ifo in ['H1', 'L1', 'V1']:
+    f.create_group(ifo)
+    ifo_group = f[ifo]
+    ifo_group.attrs['live_time'] = np.round(n_days * 0.7 * 86400.)
+    ifo_group.attrs['mean_alpha'] = alpha
+    ifo_group.attrs['total_counts'] = daily_counts_per_bin * n_days * n_bins
+    ifo_group.create_group('daily_fits')
+    daily_group = ifo_group['daily_fits']
+    for bin_no in range(n_bins):
+        key = "bin_%d" % bin_no
+        daily_group.create_group(key)
+        bin_group = daily_group[key]
+        bin_group['date'] = np.arange(n_days)
+        bin_group['counts'] = np.array([daily_counts_per_bin] * n_days)
+        bin_group['fit_coeff'] = np.array([alpha] * n_days)
+
+    ifo_group.create_group('fixed')
+    fixed_group = ifo_group['fixed']
+    fixed_group['fit_coeff'] = np.array([0.] * n_bins)
+    fixed_group['counts'] = np.array([1.] * n_bins)
+    for k in ['conservative', 'mean']:
+        ifo_group.create_group(k)
+        k_group = ifo_group[k]
+        k_group['fit_coeff'] = np.array([alpha] * n_bins)
+        k_group['counts'] = np.array([daily_counts_per_bin * n_days] * n_bins)
+
+

--- a/examples/live/run.sh
+++ b/examples/live/run.sh
@@ -68,7 +68,7 @@ else
 fi
 
 
-# test if strain files exist. If they dont, make them
+# test if strain files exist. If they don't, make them
 
 if [[ ! -d ./strain ]]
 then
@@ -84,17 +84,32 @@ then
             --fake-strain-seed $3 \
             --output-strain-file $out_path \
             --gps-start-time $gps_start_time \
-            --gps-end-time $gps_end_time \
+            --gps-end-time $4 \
             --sample-rate 16384 \
             --low-frequency-cutoff 10 \
             --channel-name $1:SIMULATED_STRAIN \
             --frame-duration 32 \
             --injection-file injections.hdf
     }
+    # L1 ends 64s later, so that we can inject in single-detector time
+    simulate_strain H1 aLIGOMidLowSensitivityP1200087 1234 $((gps_end_time - 64))
+    simulate_strain L1 aLIGOMidLowSensitivityP1200087 2345 $gps_end_time
+    simulate_strain V1 AdVEarlyLowSensitivityP1200087 3456 $((gps_end_time - 64))
 
-    simulate_strain H1 aLIGOMidLowSensitivityP1200087 1234
-    simulate_strain L1 aLIGOMidLowSensitivityP1200087 2345
-    simulate_strain V1 AdVEarlyLowSensitivityP1200087 3456
+    function simulate_strain_zero { # detector PSD_model random_seed
+
+        pycbc_condition_strain \
+            --fake-strain zeroNoise \
+            --output-strain-file $out_path \
+            --gps-start-time $2 \
+            --gps-end-time $gps_end_time \
+            --sample-rate 16384 \
+            --low-frequency-cutoff 10 \
+            --channel-name $1:SIMULATED_STRAIN \
+            --frame-duration 32
+    }
+    simulate_strain_zero H1 $((gps_end_time - 64))
+    simulate_strain_zero V1 $((gps_end_time - 64))
 else
     echo -e "\\n\\n>> [`date`] Pre-existing strain data found"
 fi

--- a/examples/live/run.sh
+++ b/examples/live/run.sh
@@ -165,7 +165,7 @@ python -m mpi4py `which pycbc_live` \
     H1:strain/H1/* \
     L1:strain/L1/* \
     V1:strain/V1/* \
---frame-read-timeout 100 \
+--frame-read-timeout 10 \
 --channel-name \
     H1:SIMULATED_STRAIN \
     L1:SIMULATED_STRAIN \

--- a/examples/live/run.sh
+++ b/examples/live/run.sh
@@ -43,6 +43,16 @@ else
 fi
 
 
+# test if there is a single fits file. If not, make a representative one
+if [[ ! -f single_trigger_fits.hdf ]]
+then
+    echo -e "\\n\\n>> [`date`] Making single fits file"
+    python make_singles_fits_file.py
+else
+    echo -e "\\n\\n>> [`date`] Pre-existing single fits file found"
+fi
+
+
 # test if there is a injection file.
 # If not, make one and delete any existing strain
 
@@ -183,6 +193,12 @@ python -m mpi4py `which pycbc_live` \
 --src-class-eff-to-lum-distance 0.74899 \
 --src-class-lum-distance-to-delta -0.51557 -0.32195 \
 --run-snr-optimization \
+--enable-single-detector-background \
+--single-newsnr-threshold 9 \
+--single-duration-threshold 7 \
+--single-reduced-chisq-threshold 2 \
+--single-fit-file single_trigger_fits.hdf \
+--sngl-ifar-est-dist conservative \
 --verbose
 
 # cat the logs of pycbc_optimize_snr so we can check them

--- a/examples/live/run.sh
+++ b/examples/live/run.sh
@@ -91,25 +91,11 @@ then
             --frame-duration 32 \
             --injection-file injections.hdf
     }
-    # L1 ends 64s later, so that we can inject in single-detector time
-    simulate_strain H1 aLIGOMidLowSensitivityP1200087 1234 $((gps_end_time - 64))
+    # L1 ends 32s later, so that we can inject in single-detector time
+    simulate_strain H1 aLIGOMidLowSensitivityP1200087 1234 $((gps_end_time - 32))
     simulate_strain L1 aLIGOMidLowSensitivityP1200087 2345 $gps_end_time
-    simulate_strain V1 AdVEarlyLowSensitivityP1200087 3456 $((gps_end_time - 64))
+    simulate_strain V1 AdVEarlyLowSensitivityP1200087 3456 $((gps_end_time - 32))
 
-    function simulate_strain_zero { # detector PSD_model random_seed
-
-        pycbc_condition_strain \
-            --fake-strain zeroNoise \
-            --output-strain-file $out_path \
-            --gps-start-time $2 \
-            --gps-end-time $gps_end_time \
-            --sample-rate 16384 \
-            --low-frequency-cutoff 10 \
-            --channel-name $1:SIMULATED_STRAIN \
-            --frame-duration 32
-    }
-    simulate_strain_zero H1 $((gps_end_time - 64))
-    simulate_strain_zero V1 $((gps_end_time - 64))
 else
     echo -e "\\n\\n>> [`date`] Pre-existing strain data found"
 fi
@@ -133,11 +119,12 @@ rm -rf ./output
 
 echo -e "\\n\\n>> [`date`] Running PyCBC Live"
 
+# -x PYTHONPATH -x LD_LIBRARY_PATH -x OMP_NUM_THREADS -x VIRTUAL_ENV -x PATH -x HDF5_USE_FILE_LOCKING \
+
 mpirun \
 -host localhost,localhost \
 -n 2 \
 --bind-to none \
--x PYTHONPATH -x LD_LIBRARY_PATH -x OMP_NUM_THREADS -x VIRTUAL_ENV -x PATH -x HDF5_USE_FILE_LOCKING \
 \
 python -m mpi4py `which pycbc_live` \
 --bank-file template_bank.hdf \

--- a/examples/live/run.sh
+++ b/examples/live/run.sh
@@ -119,12 +119,12 @@ rm -rf ./output
 
 echo -e "\\n\\n>> [`date`] Running PyCBC Live"
 
-# -x PYTHONPATH -x LD_LIBRARY_PATH -x OMP_NUM_THREADS -x VIRTUAL_ENV -x PATH -x HDF5_USE_FILE_LOCKING \
 
 mpirun \
 -host localhost,localhost \
 -n 2 \
 --bind-to none \
+ -x PYTHONPATH -x LD_LIBRARY_PATH -x OMP_NUM_THREADS -x VIRTUAL_ENV -x PATH -x HDF5_USE_FILE_LOCKING \
 \
 python -m mpi4py `which pycbc_live` \
 --bank-file template_bank.hdf \


### PR DESCRIPTION
Part of testing for https://github.com/gwastro/pycbc/pull/3984 is that we wanted to get the single-detector trigger into the live test

In this PR, we:
- Set the H1 and V1 strain generator to end 32s early
- Add another injection to inject an EM-bright signal into this (L1-only) time
- Make a single fits file (currently just manually filling the appropriate datasets to get something sensible)
- Add the singles to the test `run.sh` script
- Update the `check_results.py` script to know that there may be single-detector events (and call them 'found' rather than 'coinc')