### PR TITLE
allow lalsimulation to be missing, helper function for optional libraries

### DIFF
--- a/pycbc/conversions.py
+++ b/pycbc/conversions.py
@@ -31,14 +31,12 @@ one parameter given a set of inputs.
 import copy
 import numpy
 import lal
-import lalsimulation as lalsim
 from pycbc.detector import Detector
 import pycbc.cosmology
 from .coordinates import spherical_to_cartesian as _spherical_to_cartesian
-try:
-    import pykerr
-except ImportError:
-    pykerr = None
+
+pykerr = pycbc.libutils.import_optional('pykerr')
+lalsim = pycbc.libutils.import_optional('lalsimulation')
 
 #
 # =============================================================================
@@ -840,8 +838,6 @@ def get_lm_f0tau(mass, spin, l, m, n=0, which='both'):
         Returned if ``which`` is 'both' or 'tau'.
         The damping time of the QNM(s), in seconds.
     """
-    if pykerr is None:
-        raise ImportError("pykerr must be installed to get f0 or tau")
     # convert to arrays
     mass, spin, l, m, n, input_is_array = ensurearray(
         mass, spin, l, m, n)

--- a/pycbc/detector.py
+++ b/pycbc/detector.py
@@ -31,6 +31,7 @@ between observatories.
 import os
 import numpy as np
 import lal
+import pycbc.libutils
 from pycbc.types import TimeSeries
 from pycbc.types.config import InterpolatingConfigParser
 from astropy.time import Time
@@ -176,7 +177,7 @@ class Detector(object):
         self.name = str(detector_name)
 
         if detector_name in [pfx for pfx, name in get_available_detectors()]:
-            import lalsimulation as lalsim
+            lalsim = pycbc.libutils.import_optional('lalsimulation')
             self._lal = lalsim.DetectorPrefixToLALDetector(self.name)
             self.response = self._lal.response
             self.location = self._lal.location

--- a/pycbc/inject/inject.py
+++ b/pycbc/inject/inject.py
@@ -47,8 +47,8 @@ from ligo.lw import utils as ligolw_utils, ligolw, lsctables
 sim = libutils.import_optional('lalsimulation')
 
 injection_func_map = {
-    np.dtype(float32): lambda a, b, c: sim.SimAddInjectionREAL4TimeSeries(a, b, c),
-    np.dtype(float64): lambda a, b, c: sim.SimAddInjectionREAL4TimeSeries(a, b ,c),
+    np.dtype(float32): lambda *args: sim.SimAddInjectionREAL4TimeSeries(*args),
+    np.dtype(float64): lambda *args: sim.SimAddInjectionREAL8TimeSeries(*args),
 }
 
 # Map parameter names used in pycbc to names used in the sim_inspiral

--- a/pycbc/inject/inject.py
+++ b/pycbc/inject/inject.py
@@ -31,10 +31,8 @@ import lal
 import copy
 import logging
 from abc import ABCMeta, abstractmethod
-import lalsimulation as sim
 import h5py
-from pycbc import waveform
-from pycbc import frame
+from pycbc import waveform, frame, libutils
 from pycbc.opt import LimitedSizeDict
 from pycbc.waveform import get_td_waveform, utils as wfutils
 from pycbc.waveform import ringdown_td_approximants
@@ -46,12 +44,12 @@ import pycbc.io
 from pycbc.io.ligolw import LIGOLWContentHandler
 from ligo.lw import utils as ligolw_utils, ligolw, lsctables
 
+sim = libutils.import_optional('lalsimulation')
 
 injection_func_map = {
-    np.dtype(float32): sim.SimAddInjectionREAL4TimeSeries,
-    np.dtype(float64): sim.SimAddInjectionREAL8TimeSeries
+    np.dtype(float32): lambda *args: sim.SimAddInjectionREAL4TimeSeries(*args),
+    np.dtype(float64): lambda *args: sim.SimAddInjectionREAL4TimeSeries(*args),
 }
-
 
 # Map parameter names used in pycbc to names used in the sim_inspiral
 # table, if they are different

--- a/pycbc/inject/inject.py
+++ b/pycbc/inject/inject.py
@@ -47,8 +47,8 @@ from ligo.lw import utils as ligolw_utils, ligolw, lsctables
 sim = libutils.import_optional('lalsimulation')
 
 injection_func_map = {
-    np.dtype(float32): lambda *args: sim.SimAddInjectionREAL4TimeSeries(*args),
-    np.dtype(float64): lambda *args: sim.SimAddInjectionREAL4TimeSeries(*args),
+    np.dtype(float32): lambda a, b, c: sim.SimAddInjectionREAL4TimeSeries(a, b, c),
+    np.dtype(float64): lambda a, b, c: sim.SimAddInjectionREAL4TimeSeries(a, b ,c),
 }
 
 # Map parameter names used in pycbc to names used in the sim_inspiral

--- a/pycbc/noise/gaussian.py
+++ b/pycbc/noise/gaussian.py
@@ -27,7 +27,7 @@
 noise spectrum.
 """
 
-import pycbc.libutils
+from pycbc import libutils
 from pycbc.types import TimeSeries, zeros
 from pycbc.types import complex_same_precision_as, FrequencySeries
 import lal

--- a/pycbc/noise/gaussian.py
+++ b/pycbc/noise/gaussian.py
@@ -26,11 +26,14 @@
 """This module contains functions to generate gaussian noise colored with a
 noise spectrum.
 """
+
+import pycbc.libutils
 from pycbc.types import TimeSeries, zeros
 from pycbc.types import complex_same_precision_as, FrequencySeries
-from lalsimulation import SimNoise
 import lal
 import numpy.random
+
+lalsimulation = libutils.import_optional('lalsimulation')
 
 def frequency_noise_from_psd(psd, seed=None):
     """ Create noise with a given psd.
@@ -115,7 +118,7 @@ def noise_from_psd(length, delta_t, psd, seed=None):
     segment = TimeSeries(zeros(N), delta_t=delta_t).lal()
     length_generated = 0
 
-    SimNoise(segment, 0, psd, randomness)
+    lalsimulation.SimNoise(segment, 0, psd, randomness)
     while (length_generated < length):
         if (length_generated + stride) < length:
             noise_ts.data[length_generated:length_generated+stride] = segment.data.data[0:stride]
@@ -123,7 +126,7 @@ def noise_from_psd(length, delta_t, psd, seed=None):
             noise_ts.data[length_generated:length] = segment.data.data[0:length-length_generated]
 
         length_generated += stride
-        SimNoise(segment, stride, psd, randomness)
+        lalsimulation.SimNoise(segment, stride, psd, randomness)
 
     return noise_ts
 

--- a/pycbc/pnutils.py
+++ b/pycbc/pnutils.py
@@ -26,10 +26,12 @@
 """This module contains convenience pN functions. This includes calculating conversions
 between quantities.
 """
-import lal, lalsimulation
+import lal
 import numpy
 from scipy.optimize import bisect, brentq, minimize
-from pycbc import conversions
+from pycbc import conversions, libutils
+
+lalsimulation = libutils.import_optional('lalsimulation')
 
 def nearest_larger_binary_number(input_len):
     """ Return the nearest binary number larger than input_len.

--- a/pycbc/psd/analytical.py
+++ b/pycbc/psd/analytical.py
@@ -22,7 +22,6 @@ guide about :ref:`Analytic PSDs from lalsimulation`.
 import numbers
 from pycbc.types import FrequencySeries
 import lal
-import lalsimulation
 import numpy
 
 # build a list of usable PSD functions from lalsimulation
@@ -30,11 +29,17 @@ _name_prefix = 'SimNoisePSD'
 _name_suffix = 'Ptr'
 _name_blacklist = ('FromFile', 'MirrorTherm', 'Quantum', 'Seismic', 'Shot', 'SuspTherm')
 _psd_list = []
-for _name in lalsimulation.__dict__:
-    if _name != _name_prefix and _name.startswith(_name_prefix) and not _name.endswith(_name_suffix):
-        _name = _name[len(_name_prefix):]
-        if _name not in _name_blacklist:
-            _psd_list.append(_name)
+
+try:
+    import lalsimulation
+    for _name in lalsimulation.__dict__:
+        if _name != _name_prefix and _name.startswith(_name_prefix) and not _name.endswith(_name_suffix):
+            _name = _name[len(_name_prefix):]
+            if _name not in _name_blacklist:
+                _psd_list.append(_name)
+except ImportError:
+    pass
+
 _psd_list = sorted(_psd_list)
 
 # add functions wrapping lalsimulation PSDs

--- a/pycbc/results/versioning.py
+++ b/pycbc/results/versioning.py
@@ -21,7 +21,7 @@ import os
 import subprocess
 from pycbc.results import save_fig_with_metadata, html_escape
 
-import lal, lalframe, lalsimulation
+import lal, lalframe
 import pycbc.version, glue.git_version
 
 def get_library_version_info():
@@ -74,6 +74,7 @@ def get_library_version_info():
     lalsimulationinfo = {}
     lalsimulationinfo['Name'] = 'LALSimulation'
     try:
+        import lalsimulation
         lalsimulationinfo['ID'] = lalsimulation.SimulationVCSId
         lalsimulationinfo['Status'] = lalsimulation.SimulationVCSStatus
         lalsimulationinfo['Version'] = lalsimulation.SimulationVCSVersion
@@ -82,7 +83,7 @@ def get_library_version_info():
         lalsimulationinfo['Branch'] = lalsimulation.SimulationVCSBranch
         lalsimulationinfo['Committer'] = lalsimulation.SimulationVCSCommitter
         lalsimulationinfo['Date'] = lalsimulation.SimulationVCSDate
-    except AttributeError:
+    except (AttributeError, ImportError):
         add_info_new_version(lalsimulationinfo, lalsimulation, 'Simulation')
     library_list.append(lalsimulationinfo)
 
@@ -124,8 +125,8 @@ def write_library_information(path):
         kwds = {'render-function' : 'render_text',
                 'title' : '%s Version Information'%lib_name,
         }
-        
-        save_fig_with_metadata(html_escape(text), 
+
+        save_fig_with_metadata(html_escape(text),
           os.path.join(path,'%s_version_information.html' %(lib_name)), **kwds)
 
 def get_code_version_numbers(cp):
@@ -149,7 +150,7 @@ def get_code_version_numbers(cp):
                 if value.startswith('file://'):
                     value = value[7:]
                 version_string = subprocess.check_output([value, '--version'],
-                                                        stderr=subprocess.STDOUT) 
+                                                        stderr=subprocess.STDOUT)
             except subprocess.CalledProcessError:
                 version_string = "Executable fails on %s --version" % (value)
             except OSError:
@@ -173,7 +174,7 @@ def write_code_versions(path, cp):
     kwds = {'render-function' : 'render_text',
             'title' : 'Version Information from Executables',
     }
-    save_fig_with_metadata(html_escape(html_text), 
+    save_fig_with_metadata(html_escape(html_text),
         os.path.join(path,'version_information_from_executables.html'), **kwds)
 
 def create_versioning_page(path, cp):

--- a/pycbc/results/versioning.py
+++ b/pycbc/results/versioning.py
@@ -83,8 +83,10 @@ def get_library_version_info():
         lalsimulationinfo['Branch'] = lalsimulation.SimulationVCSBranch
         lalsimulationinfo['Committer'] = lalsimulation.SimulationVCSCommitter
         lalsimulationinfo['Date'] = lalsimulation.SimulationVCSDate
-    except (AttributeError, ImportError):
+    except AttributeError:
         add_info_new_version(lalsimulationinfo, lalsimulation, 'Simulation')
+    except ImportError:
+        pass
     library_list.append(lalsimulationinfo)
 
     glueinfo = {}

--- a/pycbc/tmpltbank/lambda_mapping.py
+++ b/pycbc/tmpltbank/lambda_mapping.py
@@ -15,8 +15,10 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 import re
 import numpy
+import pycbc.libutils
 from lal import MTSUN_SI, PI, CreateREAL8Vector
-import lalsimulation
+
+lalsimulation = pycbc.libutils.import_optional('lalsimulation')
 
 # PLEASE ENSURE THESE ARE KEPT UP TO DATE WITH THE REST OF THIS FILE
 pycbcValidTmpltbankOrders = ['zeroPN','onePN','onePointFivePN','twoPN',\

--- a/pycbc/waveform/spa_tmplt.py
+++ b/pycbc/waveform/spa_tmplt.py
@@ -22,10 +22,12 @@
    vectors.
 """
 from math import sqrt, log
-import numpy, lal, lalsimulation, pycbc.pnutils
+import numpy, lal, pycbc.pnutils
 from pycbc.scheme import schemed
 from pycbc.types import FrequencySeries, Array, complex64, float32, zeros
 from pycbc.waveform.utils import ceilpow2
+
+lalsimulation = pycbc.libutils.import_optional('lalsimulation')
 
 def findchirp_chirptime(m1, m2, fLower, porder):
     # variables used to compute chirp time

--- a/pycbc/waveform/utils.py
+++ b/pycbc/waveform/utils.py
@@ -26,7 +26,6 @@
 """
 from pycbc.types import TimeSeries, FrequencySeries, Array, float32, float64, complex_same_precision_as, real_same_precision_as
 import lal
-import lalsimulation as sim
 from math import frexp
 import numpy
 from pycbc.scheme import schemed
@@ -301,20 +300,26 @@ def frequency_from_polarizations(h_plus, h_cross):
 
 # map between tapering string in sim_inspiral table or inspiral
 # code option and lalsimulation constants
-taper_map = {
-    'TAPER_NONE'    : None,
-    'TAPER_START'   : sim.SIM_INSPIRAL_TAPER_START,
-    'start'         : sim.SIM_INSPIRAL_TAPER_START,
-    'TAPER_END'     : sim.SIM_INSPIRAL_TAPER_END,
-    'end'           : sim.SIM_INSPIRAL_TAPER_END,
-    'TAPER_STARTEND': sim.SIM_INSPIRAL_TAPER_STARTEND,
-    'startend'      : sim.SIM_INSPIRAL_TAPER_STARTEND
-}
+try:
+    import lalsimulation as sim
 
-taper_func_map = {
-    numpy.dtype(float32): sim.SimInspiralREAL4WaveTaper,
-    numpy.dtype(float64): sim.SimInspiralREAL8WaveTaper
-}
+    taper_map = {
+        'TAPER_NONE'    : None,
+        'TAPER_START'   : sim.SIM_INSPIRAL_TAPER_START,
+        'start'         : sim.SIM_INSPIRAL_TAPER_START,
+        'TAPER_END'     : sim.SIM_INSPIRAL_TAPER_END,
+        'end'           : sim.SIM_INSPIRAL_TAPER_END,
+        'TAPER_STARTEND': sim.SIM_INSPIRAL_TAPER_STARTEND,
+        'startend'      : sim.SIM_INSPIRAL_TAPER_STARTEND
+    }
+
+    taper_func_map = {
+        numpy.dtype(float32): sim.SimInspiralREAL4WaveTaper,
+        numpy.dtype(float64): sim.SimInspiralREAL8WaveTaper
+    }
+except ImportError:
+    taper_map = {}
+    taper_func_map = {}
 
 def taper_timeseries(tsdata, tapermethod=None, return_lal=False):
     """

--- a/pycbc/waveform/waveform.py
+++ b/pycbc/waveform/waveform.py
@@ -73,31 +73,6 @@ _lalsim_fd_approximants = {}
 _lalsim_enum = {}
 _lalsim_sgburst_approximants = {}
 
-# Populate waveform approximants from lalsimulation if the library is
-# available
-try:
-    import lalsimulation
-    for approx_enum in range(0, lalsimulation.NumApproximants):
-        if lalsimulation.SimInspiralImplementedTDApproximants(approx_enum):
-            approx_name = lalsimulation.GetStringFromApproximant(approx_enum)
-            _lalsim_enum[approx_name] = approx_enum
-            _lalsim_td_approximants[approx_name] = _lalsim_td_waveform
-
-    for approx_enum in range(0, lalsimulation.NumApproximants):
-        if lalsimulation.SimInspiralImplementedFDApproximants(approx_enum):
-            approx_name = lalsimulation.GetStringFromApproximant(approx_enum)
-            _lalsim_enum[approx_name] = approx_enum
-            _lalsim_fd_approximants[approx_name] = _lalsim_fd_waveform
-
-    # sine-Gaussian burst
-    for approx_enum in range(0, lalsimulation.NumApproximants):
-        if lalsimulation.SimInspiralImplementedFDApproximants(approx_enum):
-            approx_name = lalsimulation.GetStringFromApproximant(approx_enum)
-            _lalsim_enum[approx_name] = approx_enum
-            _lalsim_sgburst_approximants[approx_name] = _lalsim_sgburst_waveform
-except ImportError:
-    lalsimulation = libutils.import_optional('lalsimulation')
-
 def _check_lal_pars(p):
     """ Create a laldict object from the dictionary of waveform parameters
 
@@ -297,6 +272,31 @@ def _lalsim_sgburst_waveform(**p):
 
     return hp, hc
 
+# Populate waveform approximants from lalsimulation if the library is
+# available
+try:
+    import lalsimulation
+    for approx_enum in range(0, lalsimulation.NumApproximants):
+        if lalsimulation.SimInspiralImplementedTDApproximants(approx_enum):
+            approx_name = lalsimulation.GetStringFromApproximant(approx_enum)
+            _lalsim_enum[approx_name] = approx_enum
+            _lalsim_td_approximants[approx_name] = _lalsim_td_waveform
+
+    for approx_enum in range(0, lalsimulation.NumApproximants):
+        if lalsimulation.SimInspiralImplementedFDApproximants(approx_enum):
+            approx_name = lalsimulation.GetStringFromApproximant(approx_enum)
+            _lalsim_enum[approx_name] = approx_enum
+            _lalsim_fd_approximants[approx_name] = _lalsim_fd_waveform
+
+    # sine-Gaussian burst
+    for approx_enum in range(0, lalsimulation.NumApproximants):
+        if lalsimulation.SimInspiralImplementedFDApproximants(approx_enum):
+            approx_name = lalsimulation.GetStringFromApproximant(approx_enum)
+            _lalsim_enum[approx_name] = approx_enum
+            _lalsim_sgburst_approximants[approx_name] = _lalsim_sgburst_waveform
+except ImportError:
+    lalsimulation = libutils.import_optional('lalsimulation')
+
 cpu_sgburst = _lalsim_sgburst_approximants
 cpu_td = dict(_lalsim_td_approximants.items())
 cpu_fd = _lalsim_fd_approximants
@@ -313,7 +313,6 @@ if pycbc.HAVE_CUDA:
 
 cuda_td = dict(list(_lalsim_td_approximants.items()) + list(_cuda_td_approximants.items()))
 cuda_fd = dict(list(_lalsim_fd_approximants.items()) + list(_cuda_fd_approximants.items()))
-
 
 # List the various available approximants ####################################
 

--- a/pycbc/waveform/waveform_modes.py
+++ b/pycbc/waveform/waveform_modes.py
@@ -19,6 +19,7 @@
 from string import Formatter
 import lal
 
+from pycbc import libutils
 from pycbc.types import (TimeSeries, FrequencySeries)
 from .waveform import (props, _check_lal_pars, check_args)
 from . import parameters

--- a/pycbc/waveform/waveform_modes.py
+++ b/pycbc/waveform/waveform_modes.py
@@ -18,12 +18,12 @@
 
 from string import Formatter
 import lal
-import lalsimulation
 
 from pycbc.types import (TimeSeries, FrequencySeries)
 from .waveform import (props, _check_lal_pars, check_args)
 from . import parameters
 
+lalsimulation = libutils.import_optional('lalsimulation')
 
 def _formatdocstr(docstr):
     """Utility for formatting docstrings with parameter information.


### PR DESCRIPTION
This aims to allow lalsimulation to be separated from some more basic PyCBC functionality. This PR should not reduce any existing functionality. 

Where possible, this just means that some functions will have fewer options if lalsimulation is not available (i.e. waveform generation, analytic psds). In other cases, if a function which requires lalsimulation is called (injections, some detector stuff, etc), I've tried to enable a useful error message. 

Noteably, I've added a helper function which may be useful for optional functionality in other cases. It allows one to import a module and not have to add extra try / expect statements everywhere for the common case where specific methods or functions need to call the module. 

one uses this as 

```
import pycbc.libutils
lalsim = pycbc.libutils.import_optional('lalsimulation')

def my_func(something, something):
      # use lalsim
      lalsim.something(something)
```

This function will not return an error, but if the lalsimulation is not importable it will raise an importerror with a message telling which function requires this module *only* when you actually use something provided by the module. This allows a cleaner syntax where you can still "import" the module at the top-level and use within functions as normal without adding extra error handling. If you need to use the module directly within another module (and not hidden by a function definition) then error handling is still of course required. 
