### PR TITLE
Add a module for dealing with significance/FAR calculations

### DIFF
--- a/bin/all_sky_search/pycbc_add_statmap
+++ b/bin/all_sky_search/pycbc_add_statmap
@@ -276,18 +276,18 @@ if injection_style:
         ifo_combo_key = bg_f.attrs['ifos'].replace(' ','')
         _, fnlouder[ifo_combo_key] = \
             significance.get_n_louder(
-                significance_dict[ifo_combo_key],
                 bg_f['background/stat'][:],
                 f['foreground/stat'][:],
-                bg_f['background/decimation_factor'][:])
+                bg_f['background/decimation_factor'][:]
+                **significance_dict[ifo_combo_key])
 
         far[ifo_combo_key] = (fnlouder[ifo_combo_key] + 1) / bg_f.attrs['background_time']
         _, fnlouder_exc[ifo_combo_key] = \
             significance.get_n_louder(
-                significance_dict[ifo_combo_key],
                 bg_f['background_exc/stat'][:],
                 f['foreground/stat'][:],
-                bg_f['background_exc/decimation_factor'][:])
+                bg_f['background_exc/decimation_factor'][:],
+                **significance_dict[ifo_combo_key])
         far_exc[ifo_combo_key] = (fnlouder_exc[ifo_combo_key] + 1) / bg_f.attrs['background_time_exc']
 else:
     # if not injection style input files, then the input files will have the
@@ -296,17 +296,17 @@ else:
         ifo_combo_key = get_ifo_string(f_in).replace(' ','')
         _, fnlouder[ifo_combo_key] = \
             significance.get_n_louder(
-                significance_dict[ifo_combo_key],
                 f_in['background/stat'][:],
                 f['foreground/stat'][:],
-                f_in['background/decimation_factor'][:])
+                f_in['background/decimation_factor'][:],
+                **significance_dict[ifo_combo_key])
         far[ifo_combo_key] = (fnlouder[ifo_combo_key] + 1) / f_in.attrs['background_time']
         _, fnlouder_exc[ifo_combo_key] = \
             significance.get_n_louder(
-                significance_dict[ifo_combo_key],
                 f_in['background_exc/stat'][:],
                 f['foreground/stat'][:],
-                f_in['background_exc/decimation_factor'][:])
+                f_in['background_exc/decimation_factor'][:],
+                **significance_dict[ifo_combo_key])
         far_exc[ifo_combo_key] = (fnlouder_exc[ifo_combo_key] + 1) / f_in.attrs['background_time_exc']
 
 logging.info('Combining false alarm rates from all available backgrounds')

--- a/bin/all_sky_search/pycbc_add_statmap
+++ b/bin/all_sky_search/pycbc_add_statmap
@@ -74,7 +74,7 @@ files = [h5py.File(n, 'r') for n in args.statmap_files]
 
 f = h5py.File(args.output_file, "w")
 
-# For a few things, we will want singles and coinc files separated
+# Work out the combinations of detectors used by each input file
 all_ifo_combos = []
 for fi in files:
     ifo_list = get_ifo_string(fi).split(' ')

--- a/bin/all_sky_search/pycbc_add_statmap
+++ b/bin/all_sky_search/pycbc_add_statmap
@@ -6,7 +6,7 @@ coincs with the highest stat value.
 import h5py, numpy as np, argparse, logging, pycbc, pycbc.events, pycbc.io
 import pycbc.version
 import pycbc.conversions as conv
-from pycbc.events import coinc
+from pycbc.events import coinc, significance
 from ligo import segments
 import sys, copy
 
@@ -56,6 +56,7 @@ parser.add_argument('--hierarchical-removal-ifar-thresh', type=float,
     default=100.,
     help="Minimum IFAR for a foreground event to be hierarchically removed "
          "from background of quieter events (years) [default=100yr]")
+significance.insert_significance_option_group(parser)
 parser.add_argument('--output-file', help="name of output file")
 
 args = parser.parse_args()
@@ -66,11 +67,22 @@ if args.max_hierarchical_removal and injection_style:
     raise NotImplementedError("Hierarchical background removal doesn't make "
                               "sense for injections.")
 
+significance.check_significance_option_group(args)
+
 pycbc.init_logging(args.verbose)
 
 files = [h5py.File(n, 'r') for n in args.statmap_files]
 
 f = h5py.File(args.output_file, "w")
+
+# For a few things, we will want singles and coinc files separated
+all_ifo_combos = []
+for fi in files:
+    ifo_list = get_ifo_string(fi).split(' ')
+    all_ifo_combos.append(''.join(ifo_list))
+
+significance_dict = significance.digest_significance_options(all_ifo_combos,
+                                                             args, parser)
 
 logging.info('Copying segments and attributes to %s' % args.output_file)
 # Move segments information into the final file - remove some duplication
@@ -98,8 +110,8 @@ logging.info('Combining foreground segments')
 
 # combine the segment list from each ifo
 foreground_segs = segments.segmentlist([])
-for segs in indiv_segs.values():
-    foreground_segs += segs
+for k in all_ifo_combos:
+    foreground_segs += indiv_segs[k]
 
 f.attrs['foreground_time'] = abs(foreground_segs)
 
@@ -148,11 +160,11 @@ bg_exc_trig_times = {}
 bg_exc_trig_ids = {}
 
 for ifo in all_ifos:
-    fg_trig_times[ifo] = np.array([], dtype=np.uint32)
+    fg_trig_times[ifo] = np.array([], dtype=np.floast64)
     fg_trig_ids[ifo] = np.array([], dtype=np.uint32)
-    bg_trig_times[ifo] = np.array([], dtype=np.uint32)
+    bg_trig_times[ifo] = np.array([], dtype=np.float64)
     bg_trig_ids[ifo] = np.array([], dtype=np.uint32)
-    bg_exc_trig_times[ifo] = np.array([], dtype=np.uint32)
+    bg_exc_trig_times[ifo] = np.array([], dtype=np.float64)
     bg_exc_trig_ids[ifo] = np.array([], dtype=np.uint32)
 
 # For each file, append the trigger time and id data for each ifo
@@ -241,6 +253,7 @@ test_times = np.array([pycbc.events.mean_if_greater_than_zero(tc)[0]
 # each interferometer combination
 is_in_combo_time = {}
 for key in all_ifo_combos:
+    logging.info("Checking if events are in %s time", key)
     is_in_combo_time[key] = np.zeros(n_triggers)
     end_times = np.array(f['segments/%s/end' % key][:])
     start_times = np.array(f['segments/%s/start' % key][:])
@@ -263,14 +276,19 @@ if injection_style:
         bg_f = h5py.File(bg_fname, 'r')
         ifo_combo_key = bg_f.attrs['ifos'].replace(' ','')
         _, fnlouder[ifo_combo_key] = \
-            coinc.calculate_n_louder(bg_f['background/stat'][:],
-                                     f['foreground/stat'][:],
-                                     bg_f['background/decimation_factor'][:])
+            significance.calculate_n_louder(
+                significance_dict[ifo_combo_key],
+                bg_f['background/stat'][:],
+                f['foreground/stat'][:],
+                bg_f['background/decimation_factor'][:])
+
         far[ifo_combo_key] = (fnlouder[ifo_combo_key] + 1) / bg_f.attrs['background_time']
         _, fnlouder_exc[ifo_combo_key] = \
-            coinc.calculate_n_louder(bg_f['background_exc/stat'][:],
-                                     f['foreground/stat'][:],
-                                     bg_f['background_exc/decimation_factor'][:])
+            significance.calculate_n_louder(
+                significance_dict[ifo_combo_key],
+                bg_f['background_exc/stat'][:],
+                f['foreground/stat'][:],
+                bg_f['background_exc/decimation_factor'][:])
         far_exc[ifo_combo_key] = (fnlouder_exc[ifo_combo_key] + 1) / bg_f.attrs['background_time_exc']
 else:
     # if not injection style input files, then the input files will have the
@@ -278,14 +296,18 @@ else:
     for f_in in files:
         ifo_combo_key = get_ifo_string(f_in).replace(' ','')
         _, fnlouder[ifo_combo_key] = \
-            coinc.calculate_n_louder(f_in['background/stat'][:],
-                                     f['foreground/stat'][:],
-                                     f_in['background/decimation_factor'][:])
+            significance.calculate_n_louder(
+                significance_dict[ifo_combo_key],
+                f_in['background/stat'][:],
+                f['foreground/stat'][:],
+                f_in['background/decimation_factor'][:])
         far[ifo_combo_key] = (fnlouder[ifo_combo_key] + 1) / f_in.attrs['background_time']
         _, fnlouder_exc[ifo_combo_key] = \
-            coinc.calculate_n_louder(f_in['background_exc/stat'][:],
-                                     f['foreground/stat'][:],
-                                     f_in['background_exc/decimation_factor'][:])
+            significance.calculate_n_louder(
+                significance_dict[ifo_combo_key],
+                f_in['background_exc/stat'][:],
+                f['foreground/stat'][:],
+                f_in['background_exc/decimation_factor'][:])
         far_exc[ifo_combo_key] = (fnlouder_exc[ifo_combo_key] + 1) / f_in.attrs['background_time_exc']
 
 logging.info('Combining false alarm rates from all available backgrounds')
@@ -525,9 +547,11 @@ while True:
     test_times = np.array([pycbc.events.mean_if_greater_than_zero(tc)[0]
                            for tc in zip(*times_tuple)])
     for key in all_ifo_combos:
-        bnlouder, fnlouder = coinc.calculate_n_louder(sep_bg_data[key].data['stat'],
-                                    sep_fg_data[key].data['stat'],
-                                    sep_bg_data[key].data['decimation_factor'])
+        bnlouder, fnlouder = significance.calculate_n_louder(
+            significance_dict[ifo_combo_key],
+            sep_bg_data[key].data['stat'],
+            sep_fg_data[key].data['stat'],
+            sep_bg_data[key].data['decimation_factor'])
         # In principle, bg time should be adjusted, but is expected to be a
         # negligible corection
         fg_time_ct[key] -= args.cluster_window
@@ -540,9 +564,11 @@ while True:
 
     logging.info("Recalculating combined IFARs")
     for key in all_ifo_combos:
-        bnlouder, fnlouder = coinc.calculate_n_louder(sep_bg_data[key].data['stat'],
-                                    combined_fg_data.data['stat'],
-                                    sep_bg_data[key].data['decimation_factor'])
+        bnlouder, fnlouder = significance.calculate_n_louder(
+            significance_dict[ifo_combo_key],
+            sep_bg_data[key].data['stat'],
+            combined_fg_data.data['stat'],
+            sep_bg_data[key].data['decimation_factor'])
         far[key] = (fnlouder + 1) / bg_time_ct[key]
         # Set up variable for whether each coincidence is available in each coincidence time
         is_in_combo_time[key] = np.zeros(n_triggers)

--- a/bin/all_sky_search/pycbc_add_statmap
+++ b/bin/all_sky_search/pycbc_add_statmap
@@ -278,7 +278,7 @@ if injection_style:
             significance.get_n_louder(
                 bg_f['background/stat'][:],
                 f['foreground/stat'][:],
-                bg_f['background/decimation_factor'][:]
+                bg_f['background/decimation_factor'][:],
                 **significance_dict[ifo_combo_key])
 
         far[ifo_combo_key] = (fnlouder[ifo_combo_key] + 1) / bg_f.attrs['background_time']

--- a/bin/all_sky_search/pycbc_add_statmap
+++ b/bin/all_sky_search/pycbc_add_statmap
@@ -275,7 +275,7 @@ if injection_style:
         bg_f = h5py.File(bg_fname, 'r')
         ifo_combo_key = bg_f.attrs['ifos'].replace(' ','')
         _, fnlouder[ifo_combo_key] = \
-            significance.calculate_n_louder(
+            significance.get_n_louder(
                 significance_dict[ifo_combo_key],
                 bg_f['background/stat'][:],
                 f['foreground/stat'][:],
@@ -283,7 +283,7 @@ if injection_style:
 
         far[ifo_combo_key] = (fnlouder[ifo_combo_key] + 1) / bg_f.attrs['background_time']
         _, fnlouder_exc[ifo_combo_key] = \
-            significance.calculate_n_louder(
+            significance.get_n_louder(
                 significance_dict[ifo_combo_key],
                 bg_f['background_exc/stat'][:],
                 f['foreground/stat'][:],
@@ -295,14 +295,14 @@ else:
     for f_in in files:
         ifo_combo_key = get_ifo_string(f_in).replace(' ','')
         _, fnlouder[ifo_combo_key] = \
-            significance.calculate_n_louder(
+            significance.get_n_louder(
                 significance_dict[ifo_combo_key],
                 f_in['background/stat'][:],
                 f['foreground/stat'][:],
                 f_in['background/decimation_factor'][:])
         far[ifo_combo_key] = (fnlouder[ifo_combo_key] + 1) / f_in.attrs['background_time']
         _, fnlouder_exc[ifo_combo_key] = \
-            significance.calculate_n_louder(
+            significance.get_n_louder(
                 significance_dict[ifo_combo_key],
                 f_in['background_exc/stat'][:],
                 f['foreground/stat'][:],
@@ -546,7 +546,7 @@ while True:
     test_times = np.array([pycbc.events.mean_if_greater_than_zero(tc)[0]
                            for tc in zip(*times_tuple)])
     for key in all_ifo_combos:
-        bnlouder, fnlouder = significance.calculate_n_louder(
+        bnlouder, fnlouder = significance.get_n_louder(
             significance_dict[ifo_combo_key],
             sep_bg_data[key].data['stat'],
             sep_fg_data[key].data['stat'],
@@ -563,7 +563,7 @@ while True:
 
     logging.info("Recalculating combined IFARs")
     for key in all_ifo_combos:
-        bnlouder, fnlouder = significance.calculate_n_louder(
+        bnlouder, fnlouder = significance.get_n_louder(
             significance_dict[ifo_combo_key],
             sep_bg_data[key].data['stat'],
             combined_fg_data.data['stat'],

--- a/bin/all_sky_search/pycbc_add_statmap
+++ b/bin/all_sky_search/pycbc_add_statmap
@@ -67,8 +67,6 @@ if args.max_hierarchical_removal and injection_style:
     raise NotImplementedError("Hierarchical background removal doesn't make "
                               "sense for injections.")
 
-significance.check_significance_option_group(args)
-
 pycbc.init_logging(args.verbose)
 
 files = [h5py.File(n, 'r') for n in args.statmap_files]
@@ -160,12 +158,12 @@ bg_exc_trig_times = {}
 bg_exc_trig_ids = {}
 
 for ifo in all_ifos:
-    fg_trig_times[ifo] = np.array([], dtype=np.floast64)
-    fg_trig_ids[ifo] = np.array([], dtype=np.uint32)
-    bg_trig_times[ifo] = np.array([], dtype=np.float64)
-    bg_trig_ids[ifo] = np.array([], dtype=np.uint32)
-    bg_exc_trig_times[ifo] = np.array([], dtype=np.float64)
-    bg_exc_trig_ids[ifo] = np.array([], dtype=np.uint32)
+    fg_trig_times[ifo] = np.array([], dtype=float)
+    fg_trig_ids[ifo] = np.array([], dtype=int)
+    bg_trig_times[ifo] = np.array([], dtype=float)
+    bg_trig_ids[ifo] = np.array([], dtype=int)
+    bg_exc_trig_times[ifo] = np.array([], dtype=float)
+    bg_exc_trig_ids[ifo] = np.array([], dtype=int)
 
 # For each file, append the trigger time and id data for each ifo
 # If an ifo does not participate in any given coinc then fill with -1 values

--- a/bin/all_sky_search/pycbc_add_statmap
+++ b/bin/all_sky_search/pycbc_add_statmap
@@ -63,6 +63,7 @@ args = parser.parse_args()
 
 injection_style = args.background_files != None
 
+significance.check_significance_options(args, parser)
 if args.max_hierarchical_removal and injection_style:
     raise NotImplementedError("Hierarchical background removal doesn't make "
                               "sense for injections.")
@@ -80,7 +81,7 @@ for fi in files:
     all_ifo_combos.append(''.join(ifo_list))
 
 significance_dict = significance.digest_significance_options(all_ifo_combos,
-                                                             args, parser)
+                                                             args)
 
 logging.info('Copying segments and attributes to %s' % args.output_file)
 # Move segments information into the final file - remove some duplication

--- a/bin/all_sky_search/pycbc_apply_rerank
+++ b/bin/all_sky_search/pycbc_apply_rerank
@@ -80,10 +80,10 @@ if args.ranking_file:
     dec = f['background_exc/decimation_factor'][:]
 
     bnum, fnum = significance.get_n_louder(
-        significance_dict[ifo_combo],
         backstat,
         fstat,
-        dec)
+        dec,
+        **significance_dict[ifo_combo])
 
     ifar = background_time / (fnum + 1)
     fap = 1 - numpy.exp(- coinc_time / ifar)
@@ -102,16 +102,16 @@ else:
     backstat_exc = o['background_exc/stat'][:]
 
     bnum, fnum = significance.get_n_louder(
-        significance_dict[ifo_combo],
         backstat,
         fstat,
-        dec)
+        dec,
+        **significance_dict[ifo_combo])
 
     bnum_exc, fnum_exc = significance.get_n_louder(
-        significance_dict[ifo_combo],
         backstat_exc,
         fstat,
-        dec_exc)
+        dec_exc,
+        **significance_dict[ifo_combo])
 
     o['background/ifar'][...] = sec_to_year(background_time / (bnum + 1))
     o['background_exc/ifar'][...] = sec_to_year(background_time_exc / (bnum_exc + 1))

--- a/bin/all_sky_search/pycbc_apply_rerank
+++ b/bin/all_sky_search/pycbc_apply_rerank
@@ -4,7 +4,7 @@ generated from the followup of candidates.
 """
 import h5py, numpy, argparse, logging, pycbc
 from pycbc.conversions import sec_to_year
-from pycbc.events.coinc import calculate_n_louder
+from pycbc.events import significance
 from shutil import copyfile
 
 parser = argparse.ArgumentParser()
@@ -17,6 +17,7 @@ parser.add_argument('--followup-file',
     help="File containing the candidate times which were analyzed")
 parser.add_argument('--statmap-file',
     help="The statmap file containing the candidates to rerank")
+significance.insert_significance_option_group(parser)
 parser.add_argument('--ranking-file',
     help="Provided only for injection sets, use this file to provide the "
          "background to rank candidate significance")
@@ -24,6 +25,8 @@ parser.add_argument('--output-file')
 
 args = parser.parse_args()
 pycbc.init_logging(args.verbose)
+
+significance.check_significance_options(args, parser)
 
 # Reconstruct the full set of statistic values for our candidates
 f = h5py.File(args.followup_file, 'r')
@@ -51,6 +54,11 @@ stats = stats[inv]
 copyfile(args.statmap_file, args.output_file)
 o = h5py.File(args.output_file)
 
+ifo_combo = o.attrs['ifos'].replace(' ','')
+
+significance_dict = significance.digest_significance_options([ifo_combo],
+                                                             args)
+
 # Update the statistic values
 for sec in sections:
     # New stats for this section
@@ -71,7 +79,11 @@ if args.ranking_file:
     backstat = f['background_exc/stat'][:]
     dec = f['background_exc/decimation_factor'][:]
 
-    bnum, fnum = calculate_n_louder(backstat, fstat, dec)
+    bnum, fnum = significance.get_n_louder(
+        significance_dict[ifo_combo],
+        backstat,
+        fstat,
+        dec)
 
     ifar = background_time / (fnum + 1)
     fap = 1 - numpy.exp(- coinc_time / ifar)
@@ -89,8 +101,17 @@ else:
     dec_exc = o['background_exc/decimation_factor'][:]
     backstat_exc = o['background_exc/stat'][:]
 
-    bnum, fnum = calculate_n_louder(backstat, fstat, dec)
-    bnum_exc, fnum_exc = calculate_n_louder(backstat_exc, fstat, dec_exc)
+    bnum, fnum = significance.get_n_louder(
+        significance_dict[ifo_combo],
+        backstat,
+        fstat,
+        dec)
+
+    bnum_exc, fnum_exc = significance.get_n_louder(
+        significance_dict[ifo_combo],
+        backstat_exc,
+        fstat,
+        dec_exc)
 
     o['background/ifar'][...] = sec_to_year(background_time / (bnum + 1))
     o['background_exc/ifar'][...] = sec_to_year(background_time_exc / (bnum_exc + 1))

--- a/bin/all_sky_search/pycbc_coinc_statmap
+++ b/bin/all_sky_search/pycbc_coinc_statmap
@@ -411,7 +411,7 @@ while numpy.any(louder_foreground == 0):
     back_stat = all_trigs.stat[back_locs]
     fore_stat = all_trigs.stat[fore_locs]
     back_cnum, fnlouder = significance.calculate_n_louder(
-        significance_dict,
+        significance_dict[ifo_combo],
         back_stat,
         fore_stat,
         all_trigs.decimation_factor[back_locs])
@@ -425,7 +425,7 @@ while numpy.any(louder_foreground == 0):
     # So we don't have to take back_cnum_exc, jut repopulate fnlouder_exc
     else :
         _, fnlouder_exc = significance.calculate_n_louder(
-            significance_dict,
+            significance_dict[ifo_combo],
             exc_zero_trigs.stat,
             fore_stat,
             exc_zero_trigs.decimation_factor)

--- a/bin/all_sky_search/pycbc_coinc_statmap
+++ b/bin/all_sky_search/pycbc_coinc_statmap
@@ -107,7 +107,8 @@ else:
     ifos = args.ifos
     logging.info('using ifos from command line input')
 
-significance_dict = significance.digest_significance_options([''.join(ifos)],
+ifo_combo = ''.join(ifos)
+significance_dict = significance.digest_significance_options([ifo_combo],
                                                              args, parser)
 
 logging.info("We have %s triggers" % len(all_trigs.stat))
@@ -243,7 +244,7 @@ fore_stat = all_trigs.stat[fore_locs]
 # Cumulative array of inclusive background triggers and the number of
 # inclusive background triggers louder than each foreground trigger
 back_cnum, fnlouder = significance.calculate_n_louder(
-    significance_dict,
+    significance_dict[ifo_combo],
     back_stat,
     fore_stat,
     all_trigs.decimation_factor[back_locs])
@@ -251,7 +252,7 @@ back_cnum, fnlouder = significance.calculate_n_louder(
 # Cumulative array of exclusive background triggers and the number
 # of exclusive background triggers louder than each foreground trigger
 back_cnum_exc, fnlouder_exc = significance.calculate_n_louder(
-    significance_dict, 
+    significance_dict[ifo_combo],
     exc_zero_trigs.stat,
     fore_stat,
     exc_zero_trigs.decimation_factor)

--- a/bin/all_sky_search/pycbc_coinc_statmap
+++ b/bin/all_sky_search/pycbc_coinc_statmap
@@ -9,7 +9,7 @@ the FANs of any other gravitational waves in the dataset.
 """
 import argparse, h5py, itertools
 import lal, logging, numpy
-from pycbc.events import veto, coinc
+from pycbc.events import veto, coinc, significance
 import pycbc.version, pycbc.pnutils, pycbc.io
 import sys
 import pycbc.conversions as conv
@@ -72,6 +72,7 @@ parser.add_argument('--additional-event-times', type=float, nargs="+",
                     help="Additional event times which will be removed from "
                          "both inclusive and exclusive background "
                           "(gps seconds)")
+significance.insert_significance_option_group(parser)
 parser.add_argument('--output-file')
 args = parser.parse_args()
 
@@ -92,6 +93,8 @@ else :
                      "inclusive or exclusive. Use with --help for more "
                      "information.")
 
+
+
 pycbc.init_logging(args.verbose)
 
 logging.info("Loading coinc triggers")
@@ -103,6 +106,9 @@ if 'ifos' in all_trigs.attrs:
 else:
     ifos = args.ifos
     logging.info('using ifos from command line input')
+
+significance_dict = significance.digest_significance_options([''.join(ifos)],
+                                                             args, parser)
 
 logging.info("We have %s triggers" % len(all_trigs.stat))
 
@@ -236,13 +242,19 @@ fore_stat = all_trigs.stat[fore_locs]
 
 # Cumulative array of inclusive background triggers and the number of
 # inclusive background triggers louder than each foreground trigger
-back_cnum, fnlouder = coinc.calculate_n_louder(back_stat, fore_stat,
-                               all_trigs.decimation_factor[back_locs])
+back_cnum, fnlouder = significance.calculate_n_louder(
+    significance_dict,
+    back_stat,
+    fore_stat,
+    all_trigs.decimation_factor[back_locs])
 
 # Cumulative array of exclusive background triggers and the number
 # of exclusive background triggers louder than each foreground trigger
-back_cnum_exc, fnlouder_exc = coinc.calculate_n_louder(
-        exc_zero_trigs.stat, fore_stat, exc_zero_trigs.decimation_factor)
+back_cnum_exc, fnlouder_exc = significance.calculate_n_louder(
+    significance_dict, 
+    exc_zero_trigs.stat,
+    fore_stat,
+    exc_zero_trigs.decimation_factor)
 
 f['background/ifar'] = conv.sec_to_year(background_time / (back_cnum + 1))
 f['background_exc/ifar'] = conv.sec_to_year(background_time_exc /
@@ -397,8 +409,11 @@ while numpy.any(louder_foreground == 0):
     logging.info("Calculating FAN from background statistic values")
     back_stat = all_trigs.stat[back_locs]
     fore_stat = all_trigs.stat[fore_locs]
-    back_cnum, fnlouder = coinc.calculate_n_louder(back_stat, fore_stat,
-                                                   all_trigs.decimation_factor[back_locs])
+    back_cnum, fnlouder = significance.calculate_n_louder(
+        significance_dict,
+        back_stat,
+        fore_stat,
+        all_trigs.decimation_factor[back_locs])
 
     # Update the louder_foreground criteria depending on whether foreground
     # triggers are being removed via inclusive or exclusive background.
@@ -408,9 +423,11 @@ while numpy.any(louder_foreground == 0):
     # Exclusive background doesn't change when removing foreground triggers.
     # So we don't have to take back_cnum_exc, jut repopulate fnlouder_exc
     else :
-        _, fnlouder_exc = coinc.calculate_n_louder(exc_zero_trigs.stat,
-                                                   fore_stat,
-                                                   exc_zero_trigs.decimation_factor)
+        _, fnlouder_exc = significance.calculate_n_louder(
+            significance_dict,
+            exc_zero_trigs.stat,
+            fore_stat,
+            exc_zero_trigs.decimation_factor)
         louder_foreground = fnlouder_exc
     # louder_foreground has been updated and the code can continue.
 

--- a/bin/all_sky_search/pycbc_coinc_statmap
+++ b/bin/all_sky_search/pycbc_coinc_statmap
@@ -80,7 +80,7 @@ significance.check_significance_options(args, parser)
 # Check that the user chose inclusive or exclusive background to perform
 # hierarchical removals of foreground triggers against.
 if args.max_hierarchical_removal == 0:
-    if args.hierarchical_removal_against is not 'none':
+    if args.hierarchical_removal_against != 'none':
         parser.error("User Error: 0 maximum hierarchical removals chosen but "
                      "option for --hierarchical-removal-against was given. "
                      "These are conflicting options. Use with --help for more "
@@ -244,18 +244,18 @@ fore_stat = all_trigs.stat[fore_locs]
 # Cumulative array of inclusive background triggers and the number of
 # inclusive background triggers louder than each foreground trigger
 back_cnum, fnlouder = significance.get_n_louder(
-    significance_dict[ifo_combo],
     back_stat,
     fore_stat,
-    all_trigs.decimation_factor[back_locs])
+    all_trigs.decimation_factor[back_locs],
+    **significance_dict[ifo_combo])
 
 # Cumulative array of exclusive background triggers and the number
 # of exclusive background triggers louder than each foreground trigger
 back_cnum_exc, fnlouder_exc = significance.get_n_louder(
-    significance_dict[ifo_combo],
     exc_zero_trigs.stat,
     fore_stat,
-    exc_zero_trigs.decimation_factor)
+    exc_zero_trigs.decimation_factor,
+    **significance_dict[ifo_combo])
 
 f['background/ifar'] = conv.sec_to_year(background_time / (back_cnum + 1))
 f['background_exc/ifar'] = conv.sec_to_year(background_time_exc /
@@ -411,10 +411,10 @@ while numpy.any(louder_foreground == 0):
     back_stat = all_trigs.stat[back_locs]
     fore_stat = all_trigs.stat[fore_locs]
     back_cnum, fnlouder = significance.get_n_louder(
-        significance_dict[ifo_combo],
         back_stat,
         fore_stat,
-        all_trigs.decimation_factor[back_locs])
+        all_trigs.decimation_factor[back_locs],
+        **significance_dict[ifo_combo])
 
     # Update the louder_foreground criteria depending on whether foreground
     # triggers are being removed via inclusive or exclusive background.
@@ -425,10 +425,10 @@ while numpy.any(louder_foreground == 0):
     # So we don't have to take back_cnum_exc, jut repopulate fnlouder_exc
     else :
         _, fnlouder_exc = significance.get_n_louder(
-            significance_dict[ifo_combo],
             exc_zero_trigs.stat,
             fore_stat,
-            exc_zero_trigs.decimation_factor)
+            exc_zero_trigs.decimation_factor,
+            **significance_dict[ifo_combo])
         louder_foreground = fnlouder_exc
     # louder_foreground has been updated and the code can continue.
 

--- a/bin/all_sky_search/pycbc_coinc_statmap
+++ b/bin/all_sky_search/pycbc_coinc_statmap
@@ -76,6 +76,7 @@ significance.insert_significance_option_group(parser)
 parser.add_argument('--output-file')
 args = parser.parse_args()
 
+significance.check_significance_options(args, parser)
 # Check that the user chose inclusive or exclusive background to perform
 # hierarchical removals of foreground triggers against.
 if args.max_hierarchical_removal == 0:
@@ -108,8 +109,7 @@ else:
     logging.info('using ifos from command line input')
 
 ifo_combo = ''.join(ifos)
-significance_dict = significance.digest_significance_options([ifo_combo],
-                                                             args, parser)
+significance_dict = significance.digest_significance_options([ifo_combo], args)
 
 logging.info("We have %s triggers" % len(all_trigs.stat))
 

--- a/bin/all_sky_search/pycbc_coinc_statmap
+++ b/bin/all_sky_search/pycbc_coinc_statmap
@@ -243,7 +243,7 @@ fore_stat = all_trigs.stat[fore_locs]
 
 # Cumulative array of inclusive background triggers and the number of
 # inclusive background triggers louder than each foreground trigger
-back_cnum, fnlouder = significance.calculate_n_louder(
+back_cnum, fnlouder = significance.get_n_louder(
     significance_dict[ifo_combo],
     back_stat,
     fore_stat,
@@ -251,7 +251,7 @@ back_cnum, fnlouder = significance.calculate_n_louder(
 
 # Cumulative array of exclusive background triggers and the number
 # of exclusive background triggers louder than each foreground trigger
-back_cnum_exc, fnlouder_exc = significance.calculate_n_louder(
+back_cnum_exc, fnlouder_exc = significance.get_n_louder(
     significance_dict[ifo_combo],
     exc_zero_trigs.stat,
     fore_stat,
@@ -410,7 +410,7 @@ while numpy.any(louder_foreground == 0):
     logging.info("Calculating FAN from background statistic values")
     back_stat = all_trigs.stat[back_locs]
     fore_stat = all_trigs.stat[fore_locs]
-    back_cnum, fnlouder = significance.calculate_n_louder(
+    back_cnum, fnlouder = significance.get_n_louder(
         significance_dict[ifo_combo],
         back_stat,
         fore_stat,
@@ -424,7 +424,7 @@ while numpy.any(louder_foreground == 0):
     # Exclusive background doesn't change when removing foreground triggers.
     # So we don't have to take back_cnum_exc, jut repopulate fnlouder_exc
     else :
-        _, fnlouder_exc = significance.calculate_n_louder(
+        _, fnlouder_exc = significance.get_n_louder(
             significance_dict[ifo_combo],
             exc_zero_trigs.stat,
             fore_stat,

--- a/bin/all_sky_search/pycbc_coinc_statmap_inj
+++ b/bin/all_sky_search/pycbc_coinc_statmap_inj
@@ -5,7 +5,7 @@ by pycbc_coinc_findtrigs to generated a mapping between SNR and FAP, along
 with producing the combined foreground and background triggers
 """
 import argparse, h5py, logging, itertools, copy, pycbc.io, numpy, lal
-from pycbc.events import veto, coinc
+from pycbc.events import veto, coinc, significance
 import pycbc.version
 import pycbc.conversions as conv
 
@@ -44,7 +44,8 @@ if args.verbose:
     log_level = logging.INFO
     logging.basicConfig(format='%(asctime)s : %(message)s', level=log_level)
 
-significance_dict = significance.digest_significance_options([''.join(all_ifos)],
+ifo_key = ''.join(args.ifos)
+significance_dict = significance.digest_significance_options([ifo_key],
                                                              args, parser)
 
 window = args.cluster_window
@@ -151,7 +152,7 @@ if len(zdata) > 0:
                      [numpy.repeat(1, len(v1) + len(v2)), dec_fac])
 
         _, fnlouder[i] = significance.calculate_n_louder(
-            significance_dict,
+            significance_dict[ifo_key],
             inj_stat,
             fstat,
             inj_dec)

--- a/bin/all_sky_search/pycbc_coinc_statmap_inj
+++ b/bin/all_sky_search/pycbc_coinc_statmap_inj
@@ -40,13 +40,14 @@ significance.insert_significance_option_group(parser)
 parser.add_argument('--output-file')
 args = parser.parse_args()
 
+significance.check_significance_options(args, parser)
+
 if args.verbose:
     log_level = logging.INFO
     logging.basicConfig(format='%(asctime)s : %(message)s', level=log_level)
 
 ifo_key = ''.join(args.ifos)
-significance_dict = significance.digest_significance_options([ifo_key],
-                                                             args, parser)
+significance_dict = significance.digest_significance_options([ifo_key], args)
 
 window = args.cluster_window
 logging.info("Loading coinc zerolag triggers")

--- a/bin/all_sky_search/pycbc_coinc_statmap_inj
+++ b/bin/all_sky_search/pycbc_coinc_statmap_inj
@@ -99,7 +99,7 @@ f.attrs['background_time'] = background_time
 f.attrs['foreground_time'] = coinc_time
 
 if len(zdata) > 0:
-    fnlouder_exc = coinc.calculate_n_louder(back_stat, zdata.stat, dec_fac,
+    fnlouder_exc = coinc.get_n_louder(back_stat, zdata.stat, dec_fac,
                                             skip_background=True)
     ifar_exc = background_time / (fnlouder_exc + 1)
     fap_exc = 1 - numpy.exp(- coinc_time / ifar_exc)
@@ -152,7 +152,7 @@ if len(zdata) > 0:
         inj_dec = numpy.concatenate(
                      [numpy.repeat(1, len(v1) + len(v2)), dec_fac])
 
-        _, fnlouder[i] = significance.calculate_n_louder(
+        _, fnlouder[i] = significance.get_n_louder(
             significance_dict[ifo_key],
             inj_stat,
             fstat,

--- a/bin/all_sky_search/pycbc_coinc_statmap_inj
+++ b/bin/all_sky_search/pycbc_coinc_statmap_inj
@@ -99,8 +99,11 @@ f.attrs['background_time'] = background_time
 f.attrs['foreground_time'] = coinc_time
 
 if len(zdata) > 0:
-    fnlouder_exc = coinc.get_n_louder(back_stat, zdata.stat, dec_fac,
-                                            skip_background=True)
+    _, fnlouder_exc = significance.get_n_louder(
+        significance_dict[ifo_key],
+        back_stat,
+        zdata.stat,
+        dec_fac)
     ifar_exc = background_time / (fnlouder_exc + 1)
     fap_exc = 1 - numpy.exp(- coinc_time / ifar_exc)
     f['foreground/ifar_exc'] = conv.sec_to_year(ifar_exc)

--- a/bin/all_sky_search/pycbc_coinc_statmap_inj
+++ b/bin/all_sky_search/pycbc_coinc_statmap_inj
@@ -36,12 +36,16 @@ parser.add_argument('--ranking-statistic-threshold', type=float,
                          ' a unique inclusive background.')
 parser.add_argument('--ifos', nargs='+',
                     help='List of ifos used in these coincidence files')
+significance.insert_significance_option_group(parser)
 parser.add_argument('--output-file')
 args = parser.parse_args()
 
 if args.verbose:
     log_level = logging.INFO
     logging.basicConfig(format='%(asctime)s : %(message)s', level=log_level)
+
+significance_dict = significance.digest_significance_options([''.join(all_ifos)],
+                                                             args, parser)
 
 window = args.cluster_window
 logging.info("Loading coinc zerolag triggers")
@@ -146,8 +150,12 @@ if len(zdata) > 0:
         inj_dec = numpy.concatenate(
                      [numpy.repeat(1, len(v1) + len(v2)), dec_fac])
 
-        fnlouder[i] = coinc.calculate_n_louder(inj_stat, fstat, inj_dec,
-                                               skip_background=True)
+        _, fnlouder[i] = significance.calculate_n_louder(
+            significance_dict,
+            inj_stat,
+            fstat,
+            inj_dec)
+
         ifar[i] = background_time / (fnlouder[i] + 1)
         fap[i] = 1 - numpy.exp(- coinc_time / ifar[i])
         logging.info('processed %s, %s' % (i, fstat))

--- a/bin/all_sky_search/pycbc_coinc_statmap_inj
+++ b/bin/all_sky_search/pycbc_coinc_statmap_inj
@@ -100,10 +100,10 @@ f.attrs['foreground_time'] = coinc_time
 
 if len(zdata) > 0:
     _, fnlouder_exc = significance.get_n_louder(
-        significance_dict[ifo_key],
         back_stat,
         zdata.stat,
-        dec_fac)
+        dec_fac,
+        **significance_dict[ifo_key])
     ifar_exc = background_time / (fnlouder_exc + 1)
     fap_exc = 1 - numpy.exp(- coinc_time / ifar_exc)
     f['foreground/ifar_exc'] = conv.sec_to_year(ifar_exc)
@@ -156,10 +156,10 @@ if len(zdata) > 0:
                      [numpy.repeat(1, len(v1) + len(v2)), dec_fac])
 
         _, fnlouder[i] = significance.get_n_louder(
-            significance_dict[ifo_key],
             inj_stat,
             fstat,
-            inj_dec)
+            inj_dec,
+            **significance_dict[ifo_key])
 
         ifar[i] = background_time / (fnlouder[i] + 1)
         fap[i] = 1 - numpy.exp(- coinc_time / ifar[i])

--- a/bin/all_sky_search/pycbc_exclude_zerolag
+++ b/bin/all_sky_search/pycbc_exclude_zerolag
@@ -22,6 +22,7 @@ parser.add_argument('--censor-ifar-threshold', type=float, default=0.003,
          "above the threshold [default=0.003yr]")
 parser.add_argument('--veto-window', type=float, default=0.1,
     help="Time around each zerolag trigger to window out [default=.1s]")
+significance.insert_significance_option_group(parser)
 parser.add_argument('--output-file', help="name of output file")
 args = parser.parse_args()
 
@@ -32,6 +33,9 @@ f_out = h5py.File(args.output_file, "w")
 f_others = [h5py.File(fname,'r') for fname in args.other_statmap_files]
 
 all_ifos = f_in.attrs['ifos'].split(' ')
+
+significance_dict = significance.digest_significance_options([''.join(all_ifos)],
+                                                             args, parser)
 
 logging.info('Copying attributes to %s' % args.output_file)
 for attrk in f_in.attrs.keys():
@@ -88,9 +92,11 @@ for k in filtered_trigs.data:
     f_out['background_exc/%s' % k] = filtered_trigs.data[k]
 
 logging.info('Recalculating IFARs')
-bnlouder, fnlouder = coinc.calculate_n_louder(filtered_trigs.data['stat'],
-                                    f_in['foreground/stat'][:],
-                                    filtered_trigs.data['decimation_factor'])
+back_cnum, fnlouder = significance.calculate_n_louder(
+    significance_dict,
+    filtered_trigs.data['stat'],
+    f_in['foreground/stat'][:],
+    filtered_trigs.data['decimation_factor'])
 # In principle exc background time should be recalculated
 # However we expect exclude zerolag to be a (very) small correction
 fg_time_exc = conv.sec_to_year(f_in.attrs['foreground_time_exc'])

--- a/bin/all_sky_search/pycbc_exclude_zerolag
+++ b/bin/all_sky_search/pycbc_exclude_zerolag
@@ -25,6 +25,7 @@ parser.add_argument('--veto-window', type=float, default=0.1,
 significance.insert_significance_option_group(parser)
 parser.add_argument('--output-file', help="name of output file")
 args = parser.parse_args()
+significance.check_significance_options(args, parser)
 
 pycbc.init_logging(args.verbose)
 
@@ -36,7 +37,7 @@ all_ifos = f_in.attrs['ifos'].split(' ')
 all_ifo_key = ''.join(all_ifos)
 
 significance_dict = significance.digest_significance_options([all_ifo_key],
-                                                             args, parser)
+                                                             args)
 
 logging.info('Copying attributes to %s' % args.output_file)
 for attrk in f_in.attrs.keys():

--- a/bin/all_sky_search/pycbc_exclude_zerolag
+++ b/bin/all_sky_search/pycbc_exclude_zerolag
@@ -6,7 +6,7 @@ coincidences from *any* coincidence type with ifar above a certain threshold
 
 import h5py, numpy as np, argparse, logging, pycbc, pycbc.io
 import pycbc.version
-from pycbc.events import veto, coinc
+from pycbc.events import veto, coinc, significance
 import pycbc.conversions as conv
 
 parser = argparse.ArgumentParser()
@@ -33,8 +33,9 @@ f_out = h5py.File(args.output_file, "w")
 f_others = [h5py.File(fname,'r') for fname in args.other_statmap_files]
 
 all_ifos = f_in.attrs['ifos'].split(' ')
+all_ifo_key = ''.join(all_ifos)
 
-significance_dict = significance.digest_significance_options([''.join(all_ifos)],
+significance_dict = significance.digest_significance_options([all_ifo_key],
                                                              args, parser)
 
 logging.info('Copying attributes to %s' % args.output_file)
@@ -92,8 +93,8 @@ for k in filtered_trigs.data:
     f_out['background_exc/%s' % k] = filtered_trigs.data[k]
 
 logging.info('Recalculating IFARs')
-back_cnum, fnlouder = significance.calculate_n_louder(
-    significance_dict,
+bnlouder, fnlouder = significance.calculate_n_louder(
+    significance_dict[all_ifo_key],
     filtered_trigs.data['stat'],
     f_in['foreground/stat'][:],
     filtered_trigs.data['decimation_factor'])

--- a/bin/all_sky_search/pycbc_exclude_zerolag
+++ b/bin/all_sky_search/pycbc_exclude_zerolag
@@ -95,10 +95,10 @@ for k in filtered_trigs.data:
 
 logging.info('Recalculating IFARs')
 bnlouder, fnlouder = significance.get_n_louder(
-    significance_dict[all_ifo_key],
     filtered_trigs.data['stat'],
     f_in['foreground/stat'][:],
-    filtered_trigs.data['decimation_factor'])
+    filtered_trigs.data['decimation_factor'],
+    **significance_dict[all_ifo_key])
 # In principle exc background time should be recalculated
 # However we expect exclude zerolag to be a (very) small correction
 fg_time_exc = conv.sec_to_year(f_in.attrs['foreground_time_exc'])

--- a/bin/all_sky_search/pycbc_exclude_zerolag
+++ b/bin/all_sky_search/pycbc_exclude_zerolag
@@ -94,7 +94,7 @@ for k in filtered_trigs.data:
     f_out['background_exc/%s' % k] = filtered_trigs.data[k]
 
 logging.info('Recalculating IFARs')
-bnlouder, fnlouder = significance.calculate_n_louder(
+bnlouder, fnlouder = significance.get_n_louder(
     significance_dict[all_ifo_key],
     filtered_trigs.data['stat'],
     f_in['foreground/stat'][:],

--- a/pycbc/events/coinc.py
+++ b/pycbc/events/coinc.py
@@ -122,63 +122,6 @@ def background_bin_from_string(background_bins, data):
     return bins
 
 
-def calculate_n_louder(bstat, fstat, dec, skip_background=False):
-    """ Calculate for each foreground event the number of background events
-    that are louder than it.
-
-    Parameters
-    ----------
-    bstat: numpy.ndarray
-        Array of the background statistic values
-    fstat: numpy.ndarray or scalar
-        Array of the foreground statistic values or single value
-    dec: numpy.ndarray
-        Array of the decimation factors for the background statistics
-    skip_background: optional, {boolean, False}
-        Skip calculating cumulative numbers for background triggers
-
-    Returns
-    -------
-    cum_back_num: numpy.ndarray
-        The cumulative array of background triggers. Does not return this
-        argument if skip_background == True
-    fore_n_louder: numpy.ndarray
-        The number of background triggers above each foreground trigger
-    """
-    sort = bstat.argsort()
-    bstat = bstat[sort]
-    dec = dec[sort]
-
-    # calculate cumulative number of triggers louder than the trigger in
-    # a given index. We need to subtract the decimation factor, as the cumsum
-    # includes itself in the first sum (it is inclusive of the first value)
-    n_louder = dec[::-1].cumsum()[::-1] - dec
-
-    # Determine how many values are louder than the foreground ones
-    # We need to subtract one from the index, to be consistent with the definition
-    # of n_louder, as here we do want to include the background value at the
-    # found index
-    idx = numpy.searchsorted(bstat, fstat, side='left') - 1
-
-    # If the foreground are *quieter* than the background or at the same value
-    # then the search sorted algorithm will choose position -1, which does not exist
-    # We force it back to zero.
-    if isinstance(idx, numpy.ndarray):  # Case where our input is an array
-        idx[idx < 0] = 0
-    else:  # Case where our input is just a scalar value
-        if idx < 0:
-            idx = 0
-
-    fore_n_louder = n_louder[idx]
-
-    if not skip_background:
-        unsort = sort.argsort()
-        back_cum_num = n_louder[unsort]
-        return back_cum_num, fore_n_louder
-    else:
-        return fore_n_louder
-
-
 def timeslide_durations(start1, start2, end1, end2, timeslide_offsets):
     """ Find the coincident time for each timeslide.
 
@@ -1222,7 +1165,6 @@ class LiveCoincTimeslideBackgroundEstimator(object):
 
 __all__ = [
     "background_bin_from_string",
-    "calculate_n_louder",
     "timeslide_durations",
     "time_coincidence",
     "time_multi_coincidence",

--- a/pycbc/events/significance.py
+++ b/pycbc/events/significance.py
@@ -258,8 +258,7 @@ def digest_significance_options(combo_keys, args):
     ----------
 
     combo_keys: list of strings
-        list of combinations of detectors which could be used as keys
-        for the options
+        list of detector combinations for which keys are needed
 
     args: parsed arguments
         from argparse ArgumentParser parse_args()
@@ -285,10 +284,9 @@ def digest_significance_options(combo_keys, args):
         for combo_value in arg_to_unpack:
             combo, value = tuple(combo_value.split(':'))
             if combo not in significance_dict:
-                # This is a newly added combo, not actually used by the code
-                # This is a warning not an exit, so we can reuse the same
-                # settings for multiple jobs in a workflow. However we don't
-                # just want to accept this silently
+                # Allow options for detector combos that are not actually
+                # used/required for a given job. Such options have
+                # no effect, but emit a warning for (e.g.) diagnostic checks
                 logging.warning("Key %s not used by this code, uses %s",
                                 combo, combo_keys)
                 significance_dict[combo] = copy.deepcopy(_default_opt_dict)

--- a/pycbc/events/significance.py
+++ b/pycbc/events/significance.py
@@ -65,21 +65,18 @@ def trig_fit(back_stat, fore_stat, dec_facs, fit_func=None,
     back_cnum = np.zeros_like(back_stat)
     fnlouder = np.zeros_like(fore_stat)
 
-    # estimate number of louder events according to the fit
-    for cnum, stat, above in zip([back_cnum, fnlouder],
-                                 [back_stat, fore_stat],
-                                 [bg_above, fg_above]):
-        cnum[above] = trstats.cum_fit(fit_func, stat[above],
-                                      alpha, fit_thresh) * bg_above_thresh
+    # Ue the fit above the threshold
+    back_cnum[bg_above] = trstats.cum_fit(fit_func, back_stat[bg_above],
+        alpha, fit_thresh) * bg_above_thresh
+    fnlouder[fg_above] = trstats.cum_fit(fit_func, fore_stat[fg_above],
+        alpha, fit_thresh) * bg_above_thresh
 
     # below the fit threshold, we count the number of louder events,
     # as things get complicated by clustering below this point
-    below_back_cnum, below_fnlouder = n_louder(back_stat, fore_stat, dec_facs)
+    fg_below = np.logical_not(fg_above)
+    bg_below = np.logical_not(bg_above)
 
-    for cnum_all, cnum_below, above in zip([back_cnum, fnlouder],
-                                           [below_back_cnum, below_fnlouder],
-                                           [bg_above, fg_above]):
-        cnum_all[np.logical_not(above)] = cnum_below[np.logical_not(above)]
+    back_cnum[bg_below], fnlouder[fg_below] = n_louder(back_stat, fore_stat, dec_facs)
 
     return back_cnum, fnlouder
 

--- a/pycbc/events/significance.py
+++ b/pycbc/events/significance.py
@@ -168,7 +168,7 @@ def check_significance_options(args, parser):
             try:
                 type_to_convert(value)
             except ValueError:
-                err_fmat("Value {} of key {} can't be converted as appropriate"
+                err_fmat = "Value {} of key {} can't be converted"
                 parser.error(err_fmat.format(value, key))
 
             if type_to_convert(value) not in allowed_values:

--- a/pycbc/events/significance.py
+++ b/pycbc/events/significance.py
@@ -140,22 +140,24 @@ _significance_meth_dict = {
 
 _default_opt_dict = {
     'method': 'n_louder',
-    'threshold': None,
-    'function': None}
+    'fit_threshold': None,
+    'fit_function': None}
 
 
-def get_n_louder(method_dict, back_stat, fore_stat, dec_facs):
+def get_n_louder(back_stat, fore_stat, dec_facs,
+    method=_default_opt_dict['method'],
+    fit_function=_default_opt_dict['fit_function'],
+    fit_threshold=_default_opt_dict['fit_threshold'], **kwargs):  # pylint:disable=unused-argument
     """
     Wrapper to find the correct n_louder calculation method using standard
     inputs
     """
-    calculation_method = method_dict['method']
-    fit_func = method_dict['function']
-    fit_thresh = method_dict['threshold']
-    return _significance_meth_dict[calculation_method](back_stat, fore_stat,
-                                                       dec_facs,
-                                                       fit_func=fit_func,
-                                                       fit_thresh=fit_thresh)
+    return _significance_meth_dict[method](
+        back_stat,
+        fore_stat,
+        dec_facs,
+        fit_func=fit_function,
+        fit_thresh=fit_threshold, **kwargs)
 
 
 def insert_significance_option_group(parser):
@@ -272,8 +274,8 @@ def digest_significance_options(combo_keys, args):
     """
 
     lists_to_unpack = [('method', args.far_calculation_method, str),
-                       ('function', args.fit_function, str),
-                       ('threshold', args.fit_threshold, float)]
+                       ('fit_function', args.fit_function, str),
+                       ('fit_threshold', args.fit_threshold, float)]
 
     significance_dict = {}
     # Set everything as a default to start with:

--- a/pycbc/events/significance.py
+++ b/pycbc/events/significance.py
@@ -87,8 +87,7 @@ _significance_meth_dict = {
 }
 
 
-def calculate_n_louder(method_dict, back_stat, fore_stat, dec_facs,
-                       fit_func=None, fit_thresh=None):
+def calculate_n_louder(method_dict, back_stat, fore_stat, dec_facs):
     """
     Wrapper to find the correct n_louder calculation method using standard
     inputs

--- a/pycbc/events/significance.py
+++ b/pycbc/events/significance.py
@@ -27,9 +27,9 @@ This module contains functions to calculate the significance
 through different estimation methods of the background, and functions that
 read in the associated options to do so.
 """
-import logging, copy
+import logging
+import copy
 import numpy as np
-from pycbc import bin_utils
 from pycbc.events import coinc
 from pycbc.events import trigger_fits as trstats
 
@@ -162,18 +162,18 @@ def check_significance_options(args, parser):
                 parser.error("Need key:value format, got %s" % key_value)
 
             if key in key_list:
-                parser.error("Key %s duplicated in a significance option" % key)
+                parser.error("Duplicate key %s in a significance option" % key)
             key_list.append(key)
 
             try:
                 type_to_convert(value)
             except ValueError:
-                parser.error("Value %s of key %s "
-                             "cannot be converted as appropriate" % (value, key))
+                err_fmat("Value {} of key {} can't be converted as appropriate"
+                parser.error(err_fmat.format(value, key))
 
             if type_to_convert(value) not in allowed_values:
-                parser.error("Value %s of key %s is not in allowed values: %s" %
-                             (value, key, allowed_values))
+                err_fmat = "Value {} of key {} is not in allowed values: {}"
+                parser.error(err_fmat.format(value, key, allowed_values))
 
     # Are the functions/thresholds appropriate for the methods given?
     methods = {}
@@ -234,7 +234,7 @@ def digest_significance_options(combo_keys, args):
 
     # Set everything as a default to start with:
     for key in combo_keys:
-        significance_dict[key] = copy.copy(default_dict)
+        significance_dict[key] = copy.deepcopy(default_dict)
 
     # Unpack everything from the arguments into the dictionary
     for unpack_key, arg_to_unpack, conv_func in lists_to_unpack:
@@ -247,7 +247,7 @@ def digest_significance_options(combo_keys, args):
                 # just want to accept this silently
                 logging.warning("Key %s not used by this code, uses %s",
                                 key, combo_keys)
-                significance_dict[key] = copy.copy(default_dict)
+                significance_dict[key] = copy.deepcopy(default_dict)
             significance_dict[key][unpack_key] = conv_func(value)
 
     return significance_dict

--- a/pycbc/events/significance.py
+++ b/pycbc/events/significance.py
@@ -182,6 +182,11 @@ def insert_significance_option_group(parser):
                              "Default = exponential for all")
 
 
+_default_opt_dict = {
+    'method': 'n_louder',
+    'threshold': None,
+    'function': None}
+
 def check_significance_options(args, parser):
     """
     Check the significance group options
@@ -231,7 +236,7 @@ def check_significance_options(args, parser):
         combo, _ = tuple(combo_value.split(':'))
         if combo not in methods:
             # Assign the default method for use in further tests
-            methods[combo] = 'n_louder'
+            methods[combo] = _default_opt_dict['method']
         function_or_thresh_given.append(combo)
 
     for combo, value in methods.items():
@@ -270,13 +275,10 @@ def digest_significance_options(combo_keys, args):
                        ('function', args.fit_function, str),
                        ('threshold', args.fit_threshold, float)]
 
-    # Set up the defaults
-    default_dict = {'method': 'n_louder', 'threshold': None, 'function': None}
-
     significance_dict = {}
     # Set everything as a default to start with:
     for combo in combo_keys:
-        significance_dict[combo] = copy.deepcopy(default_dict)
+        significance_dict[combo] = copy.deepcopy(_default_opt_dict)
 
     # Unpack everything from the arguments into the dictionary
     for argument_key, arg_to_unpack, conv_func in lists_to_unpack:
@@ -289,7 +291,7 @@ def digest_significance_options(combo_keys, args):
                 # just want to accept this silently
                 logging.warning("Key %s not used by this code, uses %s",
                                 combo, combo_keys)
-                significance_dict[combo] = copy.deepcopy(default_dict)
+                significance_dict[combo] = copy.deepcopy(_default_opt_dict)
             significance_dict[combo][argument_key] = conv_func(value)
 
     return significance_dict

--- a/pycbc/events/significance.py
+++ b/pycbc/events/significance.py
@@ -91,12 +91,35 @@ def count_n_louder(bstat, fstat, dec, skip_background=False,
     return fore_n_louder
 
 
-def trig_fit(back_stat, fore_stat, dec_facs, fit_func='exponential',
-             fit_thresh=0):
+def n_louder_from_fit(back_stat, fore_stat, dec_facs,
+                      fit_func='exponential', fit_thresh=0):
     """
     Use a fit to events in back_stat in order to estimate the
-    distribution for use in recovering the ifars. Below the
-    fit threshold, use the n_louder method for these triggers
+    distribution for use in recovering the estimate count of louder
+    background events. Below the fit threshold, use the n_louder
+    method for these triggers
+
+    back_stat: numpy.ndarray
+        Array of the background statistic values
+    fore_stat: numpy.ndarray or scalar
+        Array of the foreground statistic values or single value
+    dec_facs: numpy.ndarray
+        Array of the decimation factors for the background statistics
+    fit_func: str
+        Name of the function to be used for the fit to background
+        statistic values
+    fit_thresh: float
+        Threshold above which triggers use the fitted value, below this
+        the counted number of louder events will be used
+
+    Returns
+    -------
+    back_cnum: numpy.ndarray
+        The estimated number of background events louder than each
+        background event
+    fn_louder: numpy.ndarray
+        The estimated number of background events louder than each
+        foreground event
     """
 
     # Calculate the fitting factor of the ranking statistic distribution
@@ -133,7 +156,7 @@ def trig_fit(back_stat, fore_stat, dec_facs, fit_func='exponential',
 
 
 _significance_meth_dict = {
-    'trigger_fit': trig_fit,
+    'trigger_fit': n_louder_from_fit,
     'n_louder': count_n_louder
 }
 

--- a/pycbc/events/significance.py
+++ b/pycbc/events/significance.py
@@ -114,7 +114,7 @@ def insert_significance_option_group(parser):
                              "combination:method pairs, i.e. "
                              "H1:trigger_fit H1L1:n_louder H1L1V1:n_louder "
                              "etc. Method options are ["
-                             + ",".join(_significance_meth_dict.keys()) + 
+                             + ",".join(_significance_meth_dict.keys()) +
                              "]. Default = n_louder for all not given")
     parser.add_argument('--fit-threshold', nargs='+', default=[],
                         help="Thresholds for the fits to statistic "
@@ -162,7 +162,7 @@ def check_significance_options(args, parser):
         key, value = tuple(key_value.split(':'))
         if value not in _significance_meth_dict.keys():
             parser.error(("--far-calculation-method value %s for key %s "
-                          "is not valid, choose from [" + 
+                          "is not valid, choose from [" +
                           ','.join(_significance_meth_dict.keys()) +
                           "].") % (value, key))
         methods[key] = value
@@ -202,6 +202,7 @@ def check_significance_options(args, parser):
                          + key + " which has method " + value)
         elif value == 'trigger_fit' and key not in thresh_given:
             parser.error("Threshold required for key " + key)
+
 
 def digest_significance_options(combo_keys, args):
     """

--- a/pycbc/events/significance.py
+++ b/pycbc/events/significance.py
@@ -9,10 +9,6 @@
 # WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
 # Public License for more details.
-#
-# You should have received a copy of the GNU General Public License along
-# with this program; if not, write to the Free Software Foundation, Inc.,
-# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 #
 # =============================================================================
@@ -144,8 +140,9 @@ def n_louder_from_fit(back_stat, fore_stat, dec_facs,
     fnlouder[fg_above] = trstats.cum_fit(fit_func, fore_stat[fg_above],
                                          alpha, fit_thresh) * bg_above_thresh
 
-    # below the fit threshold, we count the number of louder events,
-    # as things get complicated by clustering below this point
+    # Below the fit threshold, we expect there to be sufficient events
+    # to use the count_n_louder method, and the distribution may deviate
+    # from the fit function
     fg_below = np.logical_not(fg_above)
     bg_below = np.logical_not(bg_above)
 

--- a/pycbc/events/significance.py
+++ b/pycbc/events/significance.py
@@ -1,0 +1,264 @@
+# Copyright (C) 2022 Gareth Cabourn Davies
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+#
+# =============================================================================
+#
+#                                   Preamble
+#
+# =============================================================================
+#
+
+"""
+This module contains functions to calculate the significance
+through different estimation methods of the background, and functions that
+read in the associated options to do so.
+"""
+
+import numpy as np
+from pycbc.events import trigger_fits as trstats
+from pycbc.types.optparse import MultiDetOptionAction
+
+
+def n_louder(back_stat, fore_stat, dec_facs, **kwargs):  # pylint:disable=unused-argument
+    """ Calculate for each foreground event the number of background events
+    that are louder than it.
+
+    Parameters
+    ----------
+    bstat: numpy.ndarray
+        Array of the background statistic values
+    fstat: numpy.ndarray or scalar
+        Array of the foreground statistic values or single value
+    dec: numpy.ndarray
+        Array of the decimation factors for the background statistics
+
+    Returns
+    -------
+    cum_back_num: numpy.ndarray
+        The cumulative array of background triggers
+    fore_n_louder: numpy.ndarray
+        The number of background triggers above each foreground trigger
+    """
+    sort = bstat.argsort()
+    bstat = bstat[sort]
+    dec = dec[sort]
+
+    # calculate cumulative number of triggers louder than the trigger in
+    # a given index. We need to subtract the decimation factor, as the cumsum
+    # includes itself in the first sum (it is inclusive of the first value)
+    n_bg_louder = dec[::-1].cumsum()[::-1] - dec
+
+    # Determine how many values are louder than the foreground ones
+    # We need to subtract one from the index, to be consistent with the definition
+    # of n_bg_louder, as here we do want to include the background value at the
+    # found index
+    idx = np.searchsorted(bstat, fstat, side='left') - 1
+
+    # If the foreground are *quieter* than the background or at the same value
+    # then the search sorted algorithm will choose position -1, which does not exist
+    # We force it back to zero.
+    if isinstance(idx, np.ndarray):  # Case where our input is an array
+        idx[idx < 0] = 0
+    else:  # Case where our input is just a scalar value
+        if idx < 0:
+            idx = 0
+
+    fore_n_louder = n_bg_louder[idx]
+
+    # For background, need to get the number of louder events back into
+    # the original order
+    unsort = sort.argsort()
+    back_cum_num = n_bg_louder[unsort]
+
+    return back_cum_num, fore_n_louder
+
+
+def trig_fit(back_stat, fore_stat, dec_facs, fit_func=None,
+             fit_thresh=None, **kwargs):  # pylint:disable=unused-argument
+    """
+    Use a fit to events in back_stat in order to estimate the
+    distribution for use in recovering the ifars. Below the
+    fit threshold, use the n_louder method for these triggers
+    """
+    # Calculate the fitting factor of the ranking statistic distribution
+    alpha, _ = trstats.fit_above_thresh(fit_func, back_stat,
+                                        thresh=fit_thresh,
+                                        weights=dec_facs)
+
+    # Count background events above threshold as the cum_fit is
+    # normalised to 1
+    bg_above = back_stat > fit_thresh
+    bg_above_thresh = np.sum(dec_facs[bg_above])
+    fg_above = fore_stat > fit_thresh
+
+    # These will be overwritten, but just to silence a warning
+    # in the case where trstats.cum_fit returns zero
+    back_cnum = np.zeros_like(back_stat)
+    fnlouder = np.zeros_like(fore_stat)
+
+    # estimate number of louder events according to the fit
+    back_cnum[bg_above] = trstats.cum_fit(fit_func, back_stat[bg_above],
+                                        alpha, fit_thresh) * bg_above_thresh
+    fnlouder[fg_above] = trstats.cum_fit(fit_func, fore_stat[fg_above],
+                                        alpha, fit_thresh) * bg_above_thresh
+
+    # below the fit threshold, we count the number of louder events,
+    # as things get complicated by clustering below this point
+    below_back_cnum, below_fnlouder = n_louder(back_stat, fore_stat, dec_facs)
+
+    back_cnum[np.logical_not(fg_above)] = below_back_cnum[np.logical_not(fg_above)]
+    fnlouder[np.logical_not(bg_above)] = below_fnlouder[np.logical_not(bg_above)]
+
+    return back_cnum, fnlouder
+
+
+_significance_meth_dict = {
+    'trigger_fit': trig_fit,
+    'n_louder': n_louder
+}
+
+
+def calculate_n_louder(method_dict, back_stat, fore_stat, dec_facs,
+                       fit_func=None, fit_thresh=None):
+    """
+    Wrapper to find the correct n_louder calculation method using standard
+    inputs
+    """
+    calculation_method = method_dict['method']
+    fit_func = method_dict['function']
+    fit_thresh = method_dict['threshold']
+    return _significance_meth_dict[calculation_method](back_stat, fore_stat,
+                                                       dec_facs,
+                                                       fit_func=fit_func,
+                                                       fit_thresh=fit_thresh)
+
+
+def insert_significance_option_group(parser):
+    """
+    Add some options for use when a significance is being estimated from
+    events or event distributions.
+    """
+    parser.add_argument('--far-calculation-method', nargs='+',
+                        default={},
+                        help="Method used for FAR calculation in each "
+                             "detector combination, given as "
+                             "combination:method pairs, i.e. "
+                             "H1:trigger_fit H1L1:n_louder H1L1V1:n_louder "
+                             "etc. n_louder counts the rate of louder "
+                             "events, trigger_fit fits the triggers to a "
+                             "distribution and extrapolates. "
+                             "Default = n_louder for all not given")
+    parser.add_argument('--fit-threshold', nargs='+',
+                        help="Thresholds for the fits to statistic "
+                             "values for FAN approximation if "
+                             "--far-calculation-method is 'trigger_fit'. "
+                             "Given as combination-values pairs, e.g. "
+                             "H1:0 L1:0 V1:-4, for all combinations which "
+                             "have --far-calculation-method "
+                             "of trigger_fit")
+    parser.add_argument("--fit-function", default='exponential',
+                        choices=["exponential", "rayleigh", "power"],
+                        help="Functional form for the statistic slope fit if "
+                             "--far-calculation-method is 'trigger_fit'. "
+                             "Given as combination:function pairs, i.e. "
+                             "H1:exponential H1L1:n_louder H1L1V1:n_louder "
+                             "for all combinations with "
+                             "--far-calculation-method of 'trigger_fit'"
+                             "Default = exponential for all")
+
+
+def digest_significance_option_group(combo_keys, args, parser):
+    """
+    Read in information from the significance option group and ensure
+    it makes sense before putting into a dictionary
+
+    Parameters
+    ----------
+
+    combo_keys: list of strings
+        list of combinations of detectors which could be used as keys
+        for the options
+
+    args: parsed arguments
+        from argparse ArgumentParser parse_args()
+
+    parser: argparse ArgumentParser instance
+        This is just for being able to use the parser error
+
+    Returns
+    -------
+    significance_dict: dictionary
+        Dictionary containing method, threshold and function for trigger fits
+        ass appropriate
+    """
+
+    significance_dict = {}
+    # There should be an entry into the --far-calculation-method list for
+    # each detector combination:
+    for key_method in args.far_calculation_method:
+        key, method = key_method.split(':')
+        if key in significance_dict:
+            raise parser.error("key %s is duplicated", key)
+        significance_dict[key] = {}
+        significance_dict[key]['method'] = method
+
+    # Apply the default n_louder to combinations not already filled:
+    for combo_key in combo_keys:
+        if combo_key in significance_dict: continue
+        significance_dict[key] = {}
+        significance_dict[key]['method'] = 'n_louder'
+        significance_dict[key]['threshold'] = None
+        significance_dict[key]['function'] = None
+
+    # Grab the fit threshold for each key:
+    for key_thresh in args.fit_threshold:
+        key, thresh = key_thresh.split(':')
+        if significance_dict[key]['method'] == 'n_louder':
+            logging.warn("Fit threshold given for detector "
+                         "combination %s which has method "
+                         "other than trigger_fit. IGNORING",
+                         key)
+            continue
+        significance_dict[key]['threshold'] = thresh
+
+    # Grab the fit function for each key:
+    for key_function in args.fit_function:
+        key, function = key_function.split(':')
+        if not significance_dict[key]['method'] == 'trigger_fit':
+            logging.warn("Fit function given for detector "
+                         "combination %s which has method "
+                         "other than trigger_fit. IGNORING",
+                          key)
+            continue
+        if 'threshold' not in significance_dict[key]:
+            parser.error("Function given without threshold for %s", key)
+        significance_dict[key]['function'] = function
+
+    # Use the default exponential trigger fit where function not given
+    for combo_key in combo_keys:
+        if not significance_dict[key]['method'] == 'trigger_fit': continue
+        if 'function' not in significance_dict[key]:
+            significance_dict[key]['function'] = 'exponential'
+
+    # Check that the threshold and function were given for all keys where the
+    # method is trigger_fit
+    for combo_key in combo_keys:
+        if not significance_dict[key]['method'] == 'trigger_fit': continue
+        if 'threshold' not in significance_dict[key]:
+            parser.error("No threshold given for %s", key)
+
+    return significance_dict

--- a/pycbc/events/significance.py
+++ b/pycbc/events/significance.py
@@ -144,10 +144,8 @@ _default_opt_dict = {
 
 
 def get_n_louder(back_stat, fore_stat, dec_facs,
-        method=_default_opt_dict['method'],
-        fit_function=_default_opt_dict['fit_function'],
-        fit_threshold=_default_opt_dict['fit_threshold'],
-        **kwargs):  # pylint:disable=unused-argument
+                 method=_default_opt_dict['method'],
+                 **kwargs):  # pylint:disable=unused-argument
     """
     Wrapper to find the correct n_louder calculation method using standard
     inputs
@@ -156,8 +154,7 @@ def get_n_louder(back_stat, fore_stat, dec_facs,
         back_stat,
         fore_stat,
         dec_facs,
-        fit_func=fit_function,
-        fit_thresh=fit_threshold, **kwargs)
+        **kwargs)
 
 
 def insert_significance_option_group(parser):

--- a/pycbc/events/significance.py
+++ b/pycbc/events/significance.py
@@ -176,7 +176,8 @@ def digest_significance_options(combo_keys, args, parser):
             if key not in combo_keys:
                 # This is a warning not an exit, so we can reuse the same
                 # settings for multiple jobs in workflow
-                logging.warn("Key %s not in allowed list: %s", key, combo_keys)
+                logging.warn("Key %s not used by this code, uses %s",
+                             key, combo_keys)
 
 
     # Third: Unpack the arguments into a standard-format dictionary
@@ -211,8 +212,6 @@ def digest_significance_options(combo_keys, args, parser):
     # Grab the fit function for each key:
     for key_function in fit_functions:
         key, function = tuple(key_function.split(':'))
-        if key not in combo_keys:
-            parser.error("key %s not in allowed list" % key)
         if not significance_dict[key]['method'] == 'trigger_fit':
             parser.error("Fit function given for detector "
                          "combination %s which has method "

--- a/pycbc/events/significance.py
+++ b/pycbc/events/significance.py
@@ -281,7 +281,7 @@ def digest_significance_options(combo_keys, args):
     ----------
 
     combo_keys: list of strings
-        list of detector combinations for which keys are needed
+        list of detector combinations for which options are needed
 
     args: parsed arguments
         from argparse ArgumentParser parse_args()

--- a/pycbc/events/significance.py
+++ b/pycbc/events/significance.py
@@ -188,7 +188,7 @@ def check_significance_options(args, parser):
                          "cannot be converted to a float" % (value, key))
         thresh_given.append(key)
 
-    # Get places where the default method is used
+    # Get places where the threshold or function are given
     function_or_thresh_given = set(function_given + thresh_given)
 
     for key in function_or_thresh_given:
@@ -200,7 +200,7 @@ def check_significance_options(args, parser):
             # Function/Threshold given for key not using trigger_fit method
             parser.error("--fit-function or --fit-threshold given for key "
                          + key + " which has method " + value)
-        elif key not in thresh_given:
+        elif value == 'trigger_fit' and key not in thresh_given:
             parser.error("Threshold required for key " + key)
 
 def digest_significance_options(combo_keys, args):
@@ -248,11 +248,17 @@ def digest_significance_options(combo_keys, args):
     for key in list(significance_dict.keys()) + combo_keys:
         if key not in significance_dict:
             significance_dict[key] = {}
+        # If method not given, then default is n_louder
         if 'method' not in significance_dict[key]:
             significance_dict[key]['method'] = 'n_louder'
+
+        if significance_dict[key]['method'] == 'n_louder':
+            # If method is n_louder, dont need threshold or function,
+            # but they need to be given
             significance_dict[key]['threshold'] = None
             significance_dict[key]['function'] = None
         elif significance_dict[key]['method'] == 'trigger_fit':
+            # Default function with trigger_fit method is exponential
             if 'function' not in significance_dict[key]:
                 significance_dict[key]['function'] = 'exponential'
 

--- a/pycbc/events/significance.py
+++ b/pycbc/events/significance.py
@@ -138,6 +138,11 @@ _significance_meth_dict = {
     'n_louder': n_louder
 }
 
+_default_opt_dict = {
+    'method': 'n_louder',
+    'threshold': None,
+    'function': None}
+
 
 def get_n_louder(method_dict, back_stat, fore_stat, dec_facs):
     """
@@ -181,11 +186,6 @@ def insert_significance_option_group(parser):
                              + ",".join(trstats.fitalpha_dict.keys()) + "]. "
                              "Default = exponential for all")
 
-
-_default_opt_dict = {
-    'method': 'n_louder',
-    'threshold': None,
-    'function': None}
 
 def check_significance_options(args, parser):
     """

--- a/pycbc/events/trigger_fits.py
+++ b/pycbc/events/trigger_fits.py
@@ -63,7 +63,7 @@ def exponential_fitalpha(vals, thresh, w):
 def rayleigh_fitalpha(vals, thresh, w):
     """
     Maximum likelihood estimator for the fit factor for
-    a rayleigh distribution of events
+    a Rayleigh distribution of events
     """
     return 2. / (numpy.average(vals ** 2., weights=w) - thresh ** 2.)
 

--- a/pycbc/events/trigger_fits.py
+++ b/pycbc/events/trigger_fits.py
@@ -145,10 +145,10 @@ def fit_above_thresh(distr, vals, thresh=None, weights=None):
 
 
 fitfn_dict = {
-    'exponential' : lambda x, alpha, t : alpha * numpy.exp(-alpha * (x - t)),
-    'rayleigh' : lambda x, alpha, t : (alpha * x * \
-                                       numpy.exp(-alpha * (x ** 2 - t ** 2) / 2.)),
-    'power' : lambda x, alpha, t : (alpha - 1.) * x ** (-alpha) * t ** (alpha - 1.)
+    'exponential' : lambda x, a, t : a * numpy.exp(-a * (x - t)),
+    'rayleigh' : lambda x, a, t : (a * x * \
+                                       numpy.exp(-a * (x ** 2 - t ** 2) / 2.)),
+    'power' : lambda x, a, t : (a - 1.) * x ** (-a) * t ** (a - 1.)
 }
 
 def fit_fn(distr, xvals, alpha, thresh):

--- a/pycbc/events/trigger_fits.py
+++ b/pycbc/events/trigger_fits.py
@@ -48,18 +48,21 @@ ks_stat, ks_pval = KS_test('exponential', snrs, alpha, thresh)
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
 # Public License for more details.
 
-import numpy
 import logging
+import numpy
 from scipy.stats import kstest
 
 def exponential_fitalpha(vals, thresh, w):
     return 1. / (numpy.average(vals, weights=w) - thresh)
 
+
 def rayleigh_fitalpha(vals, thresh, w):
     return 2. / (numpy.average(vals**2., weights=w) - thresh**2.)
 
+
 def power_fitalpha(vals, thresh, w):
     return numpy.average(numpy.log(vals/thresh), weights=w)**-1. + 1.
+
 
 fitalpha_dict = {
     'exponential' : exponential_fitalpha,

--- a/pycbc/events/trigger_fits.py
+++ b/pycbc/events/trigger_fits.py
@@ -147,7 +147,7 @@ def fit_above_thresh(distr, vals, thresh=None, weights=None):
 fitfn_dict = {
     'exponential' : lambda x, a, t : a * numpy.exp(-a * (x - t)),
     'rayleigh' : lambda x, a, t : (a * x * \
-                                       numpy.exp(-a * (x ** 2 - t ** 2) / 2.)),
+                                   numpy.exp(-a * (x ** 2 - t ** 2) / 2.)),
     'power' : lambda x, a, t : (a - 1.) * x ** (-a) * t ** (a - 1.)
 }
 

--- a/pycbc/events/trigger_fits.py
+++ b/pycbc/events/trigger_fits.py
@@ -65,7 +65,7 @@ def rayleigh_fitalpha(vals, thresh, w):
     Maximum likelihood estimator for the fit factor for
     a rayleigh distribution of events
     """
-    return 2. / (numpy.average(vals**2., weights=w) - thresh**2.)
+    return 2. / (numpy.average(vals ** 2., weights=w) - thresh ** 2.)
 
 
 def power_fitalpha(vals, thresh, w):
@@ -73,7 +73,7 @@ def power_fitalpha(vals, thresh, w):
     Maximum likelihood estimator for the fit factor for
     a power law model
     """
-    return numpy.average(numpy.log(vals/thresh), weights=w)**-1. + 1.
+    return numpy.average(numpy.log(vals/thresh), weights=w) ** -1. + 1.
 
 
 fitalpha_dict = {
@@ -84,9 +84,9 @@ fitalpha_dict = {
 
 # measurement standard deviation = (-d^2 log L/d alpha^2)^(-1/2)
 fitstd_dict = {
-    'exponential' : lambda weights, alpha : alpha / sum(weights)**0.5,
-    'rayleigh'    : lambda weights, alpha : alpha / sum(weights)**0.5,
-    'power'       : lambda weights, alpha : (alpha - 1.) / sum(weights)**0.5
+    'exponential' : lambda weights, alpha : alpha / sum(weights) ** 0.5,
+    'rayleigh'    : lambda weights, alpha : alpha / sum(weights) ** 0.5,
+    'power'       : lambda weights, alpha : (alpha - 1.) / sum(weights) ** 0.5
 }
 
 def fit_above_thresh(distr, vals, thresh=None, weights=None):
@@ -109,7 +109,7 @@ def fit_above_thresh(distr, vals, thresh=None, weights=None):
     thresh : float
         Threshold to apply before fitting; if None, use min(vals)
     weights: sequence of floats
-        Weighting factors to use for the snrs when fitting.
+        Weighting factors to use for the values when fitting.
         Default=None - all the same
 
     Returns
@@ -147,8 +147,8 @@ def fit_above_thresh(distr, vals, thresh=None, weights=None):
 fitfn_dict = {
     'exponential' : lambda x, alpha, t : alpha * numpy.exp(-alpha * (x - t)),
     'rayleigh' : lambda x, alpha, t : (alpha * x * \
-                                       numpy.exp(-alpha * (x**2 - t**2) / 2.)),
-    'power' : lambda x, alpha, t : (alpha - 1.) * x**(-alpha) * t**(alpha - 1.)
+                                       numpy.exp(-alpha * (x ** 2 - t ** 2) / 2.)),
+    'power' : lambda x, alpha, t : (alpha - 1.) * x ** (-alpha) * t ** (alpha - 1.)
 }
 
 def fit_fn(distr, xvals, alpha, thresh):
@@ -180,8 +180,8 @@ def fit_fn(distr, xvals, alpha, thresh):
 
 cum_fndict = {
     'exponential' : lambda x, alpha, t : numpy.exp(-alpha * (x - t)),
-    'rayleigh' : lambda x, alpha, t : numpy.exp(-alpha * (x**2. - t**2.) / 2.),
-    'power' : lambda x, alpha, t : x**(1. - alpha) * t**(alpha - 1.)
+    'rayleigh' : lambda x, alpha, t : numpy.exp(-alpha * (x ** 2. - t ** 2.) / 2.),
+    'power' : lambda x, alpha, t : x ** (1. - alpha) * t ** (alpha - 1.)
 }
 
 def cum_fit(distr, xvals, alpha, thresh):

--- a/pycbc/events/trigger_fits.py
+++ b/pycbc/events/trigger_fits.py
@@ -52,10 +52,19 @@ import numpy
 import logging
 from scipy.stats import kstest
 
+def exponential_fitalpha(vals, thresh, w):
+    return 1. / (numpy.average(vals, weights=w) - thresh)
+
+def rayleigh_fitalpha(vals, thresh, w):
+    return 2. / (numpy.average(vals**2., weights=w) - thresh**2.)
+
+def power_fitalpha(vals, thresh, w):
+    return numpy.average(numpy.log(vals/thresh), weights=w)**-1. + 1.
+
 fitalpha_dict = {
-    'exponential' : lambda vals, thresh, w : 1. / (numpy.average(vals, weights=w) - thresh),
-    'rayleigh'    : lambda vals, thresh, w : 2. / (numpy.average(vals**2., weights=w) - thresh**2.),
-    'power'       : lambda vals, thresh, w : numpy.average(numpy.log(vals/thresh), weights=w)**-1. + 1.
+    'exponential' : exponential_fitalpha,
+    'rayleigh'    : rayleigh_fitalpha,
+    'power'       : power_fitalpha
 }
 
 # measurement standard deviation = (-d^2 log L/d alpha^2)^(-1/2)
@@ -118,7 +127,6 @@ def fit_above_thresh(distr, vals, thresh=None, weights=None):
 
     alpha = fitalpha_dict[distr](vals, thresh, w)
     return alpha, fitstd_dict[distr](w, alpha)
-
 
 
 fitfn_dict = {
@@ -186,7 +194,6 @@ def cum_fit(distr, xvals, alpha, thresh):
     # set fitted values below threshold to 0
     numpy.putmask(cum_fit, xvals < thresh, 0.)
     return cum_fit
-
 
 def tail_threshold(vals, N=1000):
     """Determine a threshold above which there are N louder values"""

--- a/pycbc/events/trigger_fits.py
+++ b/pycbc/events/trigger_fits.py
@@ -53,14 +53,26 @@ import numpy
 from scipy.stats import kstest
 
 def exponential_fitalpha(vals, thresh, w):
+    """
+    Maximum likelihood estimator for the fit factor for
+    an exponential decrease model
+    """
     return 1. / (numpy.average(vals, weights=w) - thresh)
 
 
 def rayleigh_fitalpha(vals, thresh, w):
+    """
+    Maximum likelihood estimator for the fit factor for
+    a rayleigh distribution of events
+    """
     return 2. / (numpy.average(vals**2., weights=w) - thresh**2.)
 
 
 def power_fitalpha(vals, thresh, w):
+    """
+    Maximum likelihood estimator for the fit factor for
+    a power law model
+    """
     return numpy.average(numpy.log(vals/thresh), weights=w)**-1. + 1.
 
 

--- a/pycbc/events/trigger_fits.py
+++ b/pycbc/events/trigger_fits.py
@@ -144,6 +144,10 @@ def fit_above_thresh(distr, vals, thresh=None, weights=None):
     return alpha, fitstd_dict[distr](w, alpha)
 
 
+# Variables:
+# x: the trigger stat value(s) at which to evaluate the function
+# a: slope parameter of the fit
+# t: lower threshold stat value
 fitfn_dict = {
     'exponential' : lambda x, a, t : a * numpy.exp(-a * (x - t)),
     'rayleigh' : lambda x, a, t : (a * x * \

--- a/test/test_significance_module.py
+++ b/test/test_significance_module.py
@@ -33,7 +33,7 @@ tests_which_sysexit = []
 
 # Try to use a caluclation method which doesn't exist
 tests_which_sysexit.append((['--far-calculation-method',
-                             'H1L1:nonexistant_method'],
+                             'H1L1:nonexistent_method'],
                             'method_doesnt_exist'))
 
 # Try to set a fit threshold when using n_louder method
@@ -87,7 +87,8 @@ tests_which_pass = []
 tests_which_pass.append(([], default_dict, 'default_vals'))
 
 # Try to add a detector combination which does not exist
-# - should return dictionary including the nonexistant combination
+# - should return dictionary including the nonexistent combination
+# as we want to be able to give combos to scripts where they aren't valid
 extra_combo_dict = copy.deepcopy(default_dict)
 extra_combo_dict['H1G1'] = {}
 extra_combo_dict['H1G1']['method'] = 'trigger_fit'

--- a/test/test_significance_module.py
+++ b/test/test_significance_module.py
@@ -90,8 +90,8 @@ tests_which_pass.append(([], default_dict, 'default_vals'))
 extra_combo_dict = copy.deepcopy(default_dict)
 extra_combo_dict['H1G1'] = {}
 extra_combo_dict['H1G1']['method'] = 'trigger_fit'
-extra_combo_dict['H1G1']['function'] = None
-extra_combo_dict['H1G1']['threshold'] = 6.
+extra_combo_dict['H1G1']['fit_function'] = None
+extra_combo_dict['H1G1']['fit_threshold'] = 6.
 tests_which_pass.append((['--far-calculation-method',
                           'H1G1:trigger_fit',
                           '--fit-threshold', 'H1G1:6'],
@@ -104,12 +104,12 @@ test_dict = copy.deepcopy(default_dict)
 test_dict['H1L1']['method'] = 'trigger_fit'
 test_dict['H1']['method'] = 'trigger_fit'
 test_dict['L1']['method'] = 'trigger_fit'
-test_dict['H1L1']['function'] = 'power'
-test_dict['H1']['function'] = 'rayleigh'
-test_dict['L1']['function'] = 'exponential'
-test_dict['H1L1']['threshold'] = 6
-test_dict['H1']['threshold'] = 5.5
-test_dict['L1']['threshold'] = 5
+test_dict['H1L1']['fit_function'] = 'power'
+test_dict['H1']['fit_function'] = 'rayleigh'
+test_dict['L1']['fit_function'] = 'exponential'
+test_dict['H1L1']['fit_threshold'] = 6
+test_dict['H1']['fit_threshold'] = 5.5
+test_dict['L1']['fit_threshold'] = 5
 
 calc_methods = ['H1L1:trigger_fit', 'H1:trigger_fit', 'L1:trigger_fit']
 functions = ['H1L1:power', 'H1:rayleigh', 'L1:exponential']
@@ -150,15 +150,15 @@ for method in significance._significance_meth_dict:
     for function in method_functions[method]:
         method_dict = {}
         method_dict['method'] = method
-        method_dict['function'] = function
-        method_dict['threshold'] = None if not function else 0
+        method_dict['fit_function'] = function
+        method_dict['fit_threshold'] = None if not function else 0
 
         def meth_test(self, md=method_dict):
             back_cnum, fnlouder = significance.get_n_louder(
-                method_dict,
                 self.test_bg_stat,
                 self.test_fg_stat,
-                self.dec_facs)
+                self.dec_facs,
+                **method_dict)
 
             back_stat_sort = np.argsort(self.test_bg_stat)
             back_far_sort = np.argsort(back_cnum)

--- a/test/test_significance_module.py
+++ b/test/test_significance_module.py
@@ -77,10 +77,7 @@ for test_sysexit in tests_which_sysexit:
 default_dict = {}
 # Default Values
 for combo in combos:
-    default_dict[combo] = {}
-    default_dict[combo]['method'] = 'n_louder'
-    default_dict[combo]['function'] = None
-    default_dict[combo]['threshold'] = None
+    default_dict[combo] = copy.deepcopy(significance._default_opt_dict)
 
 tests_which_pass = []
 

--- a/test/test_significance_module.py
+++ b/test/test_significance_module.py
@@ -1,0 +1,174 @@
+"""Unit test for converting sets of statistic values into significances."""
+
+import unittest
+import argparse
+import itertools
+import copy
+import numpy as np
+from utils import simple_exit
+from pycbc.events import significance
+
+def parse_args(args):
+    # Helper function to convert a list of flags/options into
+    # an arguments structure
+    parser = argparse.ArgumentParser()
+    significance.insert_significance_option_group(parser)
+    return parser, parser.parse_args(args)
+
+ifos = ['H1','L1','V1']
+# What combinations of the ifos can we make?
+combos = []
+for l in np.arange(len(ifos)) + 1:
+            combos += [''.join(c)
+                       for c in itertools.combinations(ifos, l)]
+
+class SignificanceParserTest(unittest.TestCase):
+    def setUp(self):
+        # Set up some things we will want to use in the tests:
+        self.ifos = copy.copy(ifos)
+        self.combos = copy.copy(combos)
+
+# Tuples of inputs and the errors they should create
+tests_which_sysexit = []
+
+# Try to add a detector combination which does not exist
+tests_which_sysexit.append((['--far-calculation-method',
+                             'H1G1:trigger_fit'],
+                            'combo_doesnt_exist'))
+
+# Try to use a caluclation method which doesn't exist
+tests_which_sysexit.append((['--far-calculation-method',
+                             'H1L1:nonexistant_method'],
+                            'method_doesnt_exist'))
+
+# Try to set a fit threshold when using n_louder method
+tests_which_sysexit.append((['--fit-threshold',
+                             'H1L1:6'],
+                            'n_louder_with_threshold'))
+
+# Try to set a fit function when using n_louder method
+tests_which_sysexit.append((['--fit-function',
+                             'H1L1:exponential'],
+                            'function_with_n_louder'))
+
+# Try to set a fit threshold which is not a number
+tests_which_sysexit.append((['--fit-threshold',
+                             'H1L1:elephant'],
+                            'threshold_not_a_number'))
+
+
+# Try to set a fit function which isnt in the list
+tests_which_sysexit.append((['--far-calculation-method',
+                             'H1L1:trigger_fit',
+                             '--fit-function',
+                             'H1L1:elephant'],
+                            'function_doesnt_exist'))
+
+# Dynamically add sysexit tests into the class
+for test_sysexit in tests_which_sysexit:
+    parser, args = parse_args(test_sysexit[0])
+    def digest_sysexit_test(self, a=args, p=parser):
+        with self.assertRaises(SystemExit):
+            method_dict = significance.digest_significance_options(
+                self.combos,a, p)
+    setattr(SignificanceParserTest,
+        'test_parser_' + test_sysexit[1],
+        digest_sysexit_test)
+
+
+# Set up the default values of the output dictionary, we will edit this
+# for each test
+default_dict = {}
+# Default Values
+for combo in combos:
+    default_dict[combo] = {}
+    default_dict[combo]['method'] = 'n_louder'
+    default_dict[combo]['function'] = None
+    default_dict[combo]['threshold'] = None
+
+tests_which_pass = []
+tests_which_pass.append(([], default_dict, 'default_vals'))
+
+# Dynamically add value tests for the parser
+for test_values in tests_which_pass:
+    parser, args = parse_args(test_values[0])
+    def digest_values_test(self, p=parser, a=args):
+        method_dict = significance.digest_significance_options(
+            self.combos, a, p)
+        self.assertEqual(method_dict, test_values[1])
+
+    setattr(SignificanceParserTest,
+            'test_parser_values_' + test_values[2],
+            digest_values_test)
+
+class SignificanceMethodTest(unittest.TestCase):
+    def setUp(self):
+        self.test_fg_stat = np.random.rand(50)
+        self.test_bg_stat = np.random.rand(500)
+        self.dec_facs = np.ones_like(self.test_bg_stat)
+
+
+method_functions = {
+    'n_louder': [None],
+    'trigger_fit': ['exponential','rayleigh']
+}
+
+# Dynamically add method tests into the class
+for method in significance._significance_meth_dict:
+    for function in method_functions[method]:
+        method_dict = {}
+        method_dict['method'] = method
+        method_dict['function'] = function
+        method_dict['threshold'] = None if not function else 0
+
+        def meth_test(self, md=method_dict):
+            back_cnum, fnlouder = significance.calculate_n_louder(
+                method_dict,
+                self.test_bg_stat,
+                self.test_fg_stat,
+                self.dec_facs)
+
+            back_stat_sort = np.argsort(self.test_bg_stat)
+            back_far_sort = np.argsort(back_cnum)
+
+            fore_stat_sort = np.argsort(self.test_fg_stat)
+            fore_far_sort = np.argsort(fnlouder)
+
+            # Basic sanity check - there should be one n_louder value
+            # per stat value
+            self.assertEqual(len(back_cnum), len(self.test_bg_stat))
+            self.assertEqual(len(fnlouder), len(self.test_fg_stat))
+
+            # None of the output should be NaN or infinite
+            self.assertTrue(np.isfinite(back_cnum).all())
+            self.assertTrue(np.isfinite(fnlouder).all())
+
+            # The background stat value order should be the reverse of the
+            # n_louder order
+            back_stat_sort = np.argsort(self.test_bg_stat)
+            back_far_sort = np.argsort(back_cnum)
+            self.assertTrue(np.array_equal(back_stat_sort,
+                                           back_far_sort[::-1]))
+
+            fore_stat_sort = np.argsort(self.test_fg_stat)
+            fore_far_sort = np.argsort(fnlouder)
+            # As fg events could have an equal number of louder bg events,
+            # argsort be the opposite way round for the far sort and stat
+            # sort. So we need to use the recovered n_louder as the equal
+            # equality test array
+            self.assertTrue(np.array_equal(fnlouder[fore_stat_sort],
+                                           fnlouder[fore_far_sort][::-1]))
+
+        setattr(SignificanceMethodTest,
+                'test_%s_%s' % (method, function),
+                meth_test)
+
+# create and populate unittest's test suite
+suite = unittest.TestSuite()
+test_loader = unittest.TestLoader()
+suite.addTest(test_loader.loadTestsFromTestCase(SignificanceMethodTest))
+suite.addTest(test_loader.loadTestsFromTestCase(SignificanceParserTest))
+
+if __name__ == '__main__':
+    results = unittest.TextTestRunner(verbosity=2).run(suite)
+    simple_exit(results)

--- a/test/test_significance_module.py
+++ b/test/test_significance_module.py
@@ -93,7 +93,7 @@ tests_which_pass.append(([], default_dict, 'default_vals'))
 extra_combo_dict = copy.deepcopy(default_dict)
 extra_combo_dict['H1G1'] = {}
 extra_combo_dict['H1G1']['method'] = 'trigger_fit'
-extra_combo_dict['H1G1']['function'] = 'exponential'
+extra_combo_dict['H1G1']['function'] = None
 extra_combo_dict['H1G1']['threshold'] = 6.
 tests_which_pass.append((['--far-calculation-method',
                           'H1G1:trigger_fit',

--- a/test/test_significance_module.py
+++ b/test/test_significance_module.py
@@ -25,6 +25,7 @@ for l in np.arange(len(ifos)) + 1:
 class SignificanceParserTest(unittest.TestCase):
     def setUp(self):
         # Set up some things we will want to use in the tests:
+        self.maxDiff = None
         self.ifos = copy.copy(ifos)
         self.combos = copy.copy(combos)
 
@@ -62,13 +63,13 @@ tests_which_sysexit.append((['--far-calculation-method',
 # Dynamically add sysexit tests into the class
 for test_sysexit in tests_which_sysexit:
     parser, args = parse_args(test_sysexit[0])
-    def digest_sysexit_test(self, a=args, p=parser):
+    def check_sysexit_test(self, a=args, p=parser):
         with self.assertRaises(SystemExit):
-            method_dict = significance.digest_significance_options(
-                self.combos,a, p)
+            significance.check_significance_options(
+                a, p)
     setattr(SignificanceParserTest,
         'test_parser_' + test_sysexit[1],
-        digest_sysexit_test)
+        check_sysexit_test)
 
 
 # Set up the default values of the output dictionary, we will edit this
@@ -125,9 +126,9 @@ tests_which_pass.append((['--far-calculation-method'] + calc_methods +
 # Dynamically add value tests for the parser
 for test_values in tests_which_pass:
     parser, args = parse_args(test_values[0])
-    def digest_values_test(self, p=parser, a=args, tv=test_values[1]):
+    def digest_values_test(self, a=args, tv=test_values[1]):
         method_dict = significance.digest_significance_options(
-            self.combos, a, p)
+            self.combos, a)
         self.assertEqual(method_dict, tv)
 
 

--- a/test/test_significance_module.py
+++ b/test/test_significance_module.py
@@ -32,7 +32,7 @@ class SignificanceParserTest(unittest.TestCase):
 # Tuples of inputs and the errors they should create
 tests_which_sysexit = []
 
-# Try to use a caluclation method which doesn't exist
+# Try to use a calculation method which doesn't exist
 tests_which_sysexit.append((['--far-calculation-method',
                              'H1L1:nonexistent_method'],
                             'method_doesnt_exist'))
@@ -49,15 +49,15 @@ tests_which_sysexit.append((['--fit-function',
 
 # Try to set a fit threshold which is not a number
 tests_which_sysexit.append((['--fit-threshold',
-                             'H1L1:elephant'],
+                             'H1L1:not_a_number'],
                             'threshold_not_a_number'))
 
 
-# Try to set a fit function which isnt in the list
+# Try to set a fit function which isn't expected
 tests_which_sysexit.append((['--far-calculation-method',
                              'H1L1:trigger_fit',
                              '--fit-function',
-                             'H1L1:elephant'],
+                             'H1L1:spanish_inquisition'],
                             'function_doesnt_exist'))
 
 # Dynamically add sysexit tests into the class

--- a/test/test_significance_module.py
+++ b/test/test_significance_module.py
@@ -157,7 +157,7 @@ for method in significance._significance_meth_dict:
         method_dict['threshold'] = None if not function else 0
 
         def meth_test(self, md=method_dict):
-            back_cnum, fnlouder = significance.calculate_n_louder(
+            back_cnum, fnlouder = significance.get_n_louder(
                 method_dict,
                 self.test_bg_stat,
                 self.test_fg_stat,


### PR DESCRIPTION
We were wanting to use more than only the count-number-of-louder background method for the FAR calculations, e.g. extrapolating estimated number of louder noise events using an exponential fit to the ranking statistic

This PR separates off calculate_n_louder to be a bit more modular, allowing either the extrapolation or the counting method to be used. We can add in other methods later if wanted.

The only place I can see that still uses the previous code directly is in the apply_rerank code, which I don't know if this is still used or not, so if that can be retired, I will move the calculate_n_louder function from coinc.py to this module

There is also a testing module (primarily to help me practice writing unit tests)
