### PR TITLE
allow assuming science segments are valid, no need to go to server

### DIFF
--- a/pycbc/workflow/injection.py
+++ b/pycbc/workflow/injection.py
@@ -91,7 +91,7 @@ def compute_inj_optimal_snr(workflow, inj_file, precalc_psd_files, out_dir,
                                               'parallelization-factor',
                                               tags))
     except Exception as e:
-        print(e)
+        logging.warning(e)
         factor = 1
 
     if factor == 1:

--- a/pycbc/workflow/injection.py
+++ b/pycbc/workflow/injection.py
@@ -90,7 +90,8 @@ def compute_inj_optimal_snr(workflow, inj_file, precalc_psd_files, out_dir,
         factor = int(workflow.cp.get_opt_tags('workflow-optimal-snr',
                                               'parallelization-factor',
                                               tags))
-    except ConfigParser.Error:
+    except Exception as e:
+        print(e)
         factor = 1
 
     if factor == 1:

--- a/pycbc/workflow/jobsetup.py
+++ b/pycbc/workflow/jobsetup.py
@@ -37,23 +37,10 @@ def int_gps_time_to_str(t):
     """Takes an integer GPS time, either given as int or lal.LIGOTimeGPS, and
     converts it to a string. If a LIGOTimeGPS with nonzero decimal part is
     given, raises a ValueError."""
-
-    if isinstance(t, int):
-        return str(t)
-    elif isinstance(t, float):
-        # Wouldn't this just work generically?
-        int_t = int(t)
-        if abs(t - int_t) > 0.:
-            raise ValueError('Need an integer GPS time, got %s' % str(t))
-        return str(int_t)
-    elif isinstance(t, lal.LIGOTimeGPS):
-        if t.gpsNanoSeconds == 0:
-            return str(t.gpsSeconds)
-        else:
-            raise ValueError('Need an integer GPS time, got %s' % str(t))
-    else:
-        err_msg = "Didn't understand input type {}".format(type(t))
-        raise ValueError(err_msg)
+    int_t = int(t)
+    if abs(float((t - int_t)) > 0.:
+        raise ValueError('Need an integer GPS time, got %s' % str(t))
+    return str(int_t)
 
 def select_tmpltbank_class(curr_exe):
     """ This function returns a class that is appropriate for setting up

--- a/pycbc/workflow/jobsetup.py
+++ b/pycbc/workflow/jobsetup.py
@@ -38,7 +38,7 @@ def int_gps_time_to_str(t):
     converts it to a string. If a LIGOTimeGPS with nonzero decimal part is
     given, raises a ValueError."""
     int_t = int(t)
-    if abs(float((t - int_t)) > 0.:
+    if abs(float(t - int_t)) > 0.:
         raise ValueError('Need an integer GPS time, got %s' % str(t))
     return str(int_t)
 

--- a/pycbc/workflow/segment.py
+++ b/pycbc/workflow/segment.py
@@ -99,9 +99,10 @@ def get_segments_file(workflow, name, option_name, out_dir):
         server = cp.get("workflow-segments",
                                  "segments-database-url")
 
-    source = "any"
     if cp.has_option("workflow-segments", "segments-source"):
         source = cp.get("workflow-segments", "segments-source")
+    else:
+        source = "any"
 
     if source == "file":
         local_file_path = \

--- a/pycbc/workflow/segment.py
+++ b/pycbc/workflow/segment.py
@@ -115,9 +115,9 @@ def get_segments_file(workflow, name, option_name, out_dir):
         flag_str = cp.get_opt_tags("workflow-segments", option_name, [ifo])
         key = ifo + ':' + name
         
-        if source == "OFF":
+        if source.upper() == "OFF":
             segs[key] = segments.segmentlist([])
-        elif source == "ON":
+        elif source.upper() == "ON":
             all_seg = segments.segment([start, end])
             segs[key] = segments.segmentlist(all_seg)
         else:

--- a/pycbc/workflow/segment.py
+++ b/pycbc/workflow/segment.py
@@ -120,7 +120,7 @@ def get_segments_file(workflow, name, option_name, out_dir):
             segs[key] = segments.segmentlist([])
         elif flag_str.upper() == "ON":
             all_seg = segments.segment([start, end])
-            segs[key] = segments.segmentlist(all_seg)
+            segs[key] = segments.segmentlist([all_seg])
         else:
             segs[key] = query_str(ifo, flag_str, start, end,
                                   source=source, server=server,

--- a/pycbc/workflow/segment.py
+++ b/pycbc/workflow/segment.py
@@ -116,9 +116,9 @@ def get_segments_file(workflow, name, option_name, out_dir):
         flag_str = cp.get_opt_tags("workflow-segments", option_name, [ifo])
         key = ifo + ':' + name
         
-        if source.upper() == "OFF":
+        if flag_str.upper() == "OFF":
             segs[key] = segments.segmentlist([])
-        elif source.upper() == "ON":
+        elif flag_str.upper() == "ON":
             all_seg = segments.segment([start, end])
             segs[key] = segments.segmentlist(all_seg)
         else:

--- a/pycbc/workflow/segment.py
+++ b/pycbc/workflow/segment.py
@@ -102,6 +102,7 @@ def get_segments_file(workflow, name, option_name, out_dir):
     source = "any"
     if cp.has_option("workflow-segments", "segments-source"):
         source = cp.get("workflow-segments", "segments-source")
+
     if source == "file":
         local_file_path = \
             resolve_url(cp.get("workflow-segments", option_name+"-file"))
@@ -113,9 +114,16 @@ def get_segments_file(workflow, name, option_name, out_dir):
     for ifo in workflow.ifos:
         flag_str = cp.get_opt_tags("workflow-segments", option_name, [ifo])
         key = ifo + ':' + name
-        segs[key] = query_str(ifo, flag_str, start, end,
-                              source=source, server=server,
-                              veto_definer=veto_definer)
+        
+        if source == "OFF":
+            segs[key] = segments.segmentlist([])
+        elif source == "ON":
+            all_seg = segments.segment([start, end])
+            segs[key] = segments.segmentlist(all_seg)
+        else:
+            segs[key] = query_str(ifo, flag_str, start, end,
+                                  source=source, server=server,
+                                  veto_definer=veto_definer)
         logging.info("%s: got %s flags", ifo, option_name)
 
     return SegFile.from_segment_list_dict(name, segs,


### PR DESCRIPTION
This allows one to tell the search workflow that the vetos and or science segments are null and or always OK, respectively. For analyzing mock data, we often have no veto segments and the valid data should be assumed to be the same as the generated frame files. 