### PR TITLE
Fix typo in marginalized phase docs

### DIFF
--- a/pycbc/inference/models/marginalized_gaussian_noise.py
+++ b/pycbc/inference/models/marginalized_gaussian_noise.py
@@ -56,7 +56,7 @@ class MarginalizedPhaseGaussianNoise(GaussianNoise):
 
     Here, the sum is over the number of detectors :math:`N_D`, :math:`d_i`
     and :math:`h_i` are the data and signal in detector :math:`i`,
-    respectively, and we have assumed a uniform prior on :math:`phi \in [0,
+    respectively, and we have assumed a uniform prior on :math:`\phi \in [0,
     2\pi)`. With the form of the signal model given above, the inner product
     in the exponent can be written as:
 
@@ -101,14 +101,14 @@ class MarginalizedPhaseGaussianNoise(GaussianNoise):
 
     The integral in the last line is equal to :math:`2\pi I_0(\sqrt{x^2+y^2})`,
     where :math:`I_0` is the modified Bessel function of the first kind. Thus
-    the marginalized log posterior is:
+    the marginalized posterior is:
 
     .. math::
 
-        \log p(\Theta|d) \propto \log p(\Theta) +
-            I_0\left(\left|\sum_i O(h^0_i, d_i)\right|\right) -
-            \frac{1}{2}\sum_i\left[ \left<h^0_i, h^0_i\right> -
-                                    \left<d_i, d_i\right> \right]
+        p(\Theta|d) \propto
+            I_0\left(\left|\sum_i O(h^0_i, d_i)\right|\right)
+             p(\Theta)\exp\left[\frac{1}{2}\sum_i\left( \left<h^0_i, h^0_i\right> -
+                                    \left<d_i, d_i\right> \right)\right]
     """
     name = 'marginalized_phase'
 


### PR DESCRIPTION
There's a typo in the doc string for the marginalized phase gaussian noise model. It currently has that the log posterior is proportional to the modified Bessel function (I0). This is incorrect; the *posterior* is proportional to modified Bessel function, not the log of the posterior. This fixes this, and also a missing `\` before a `phi`.