### PR TITLE
Retire decorator

### DIFF
--- a/pycbc.spec
+++ b/pycbc.spec
@@ -7,7 +7,7 @@ Group:          Development/Libraries
 Source:         %{name}-%{version}.tar.gz
 Url:            http://www.lsc-group.phys.uwm.edu/daswg/projects/pycbc.html
 BuildRoot:      %{_tmppath}/%{name}-%{version}-root
-Requires:       python python-decorator lal lal-python lalframe lalframe-python lalsimulation lalsimulation-python lalinspiral lalinspiral-python numpy scipy
+Requires:       python lal lal-python lalframe lalframe-python lalsimulation lalsimulation-python lalinspiral lalinspiral-python numpy scipy
 BuildRequires:  python-devel lal-devel lalmetaio-devel lalframe-devel lalsimulation-devel lalinspiral-devel numpy pkgconfig
 %description
 PyCBC is a python toolkit for analysis of data from gravitational-wave

--- a/pycbc/scheme.py
+++ b/pycbc/scheme.py
@@ -28,7 +28,7 @@ objects.
 """
 import os
 import pycbc
-from decorator import decorator
+from functools import wraps
 import logging
 from .libutils import get_ctypes_library
 
@@ -183,42 +183,48 @@ def current_prefix():
 
 _import_cache = {}
 def schemed(prefix):
-    @decorator
-    def scheming_function(fn, *args, **kwds):
-        try:
-            return _import_cache[mgr.state][fn](*args, **kwds)
-        except KeyError:
-            exc_errors = []
-            for sch in mgr.state.__class__.__mro__[0:-2]:
-                try:
-                    backend = __import__(prefix + scheme_prefix[sch], fromlist=[fn.__name__])
-                    schemed_fn = getattr(backend, fn.__name__)
-                except (ImportError, AttributeError) as e:
-                    exc_errors += [e]
-                    continue
 
-                if mgr.state not in _import_cache:
-                    _import_cache[mgr.state] = {}
+    def scheming_function(func):
+        @wraps
+        def _scheming_function(*args, **kwds):
+            try:
+                return _import_cache[mgr.state][func](*args, **kwds)
+            except KeyError:
+                exc_errors = []
+                for sch in mgr.state.__class__.__mro__[0:-2]:
+                    try:
+                        backend = __import__(prefix + scheme_prefix[sch],
+                                             fromlist=[func.__name__])
+                        schemed_fn = getattr(backend, func.__name__)
+                    except (ImportError, AttributeError) as e:
+                        exc_errors += [e]
+                        continue
 
-                _import_cache[mgr.state][fn] = schemed_fn
+                    if mgr.state not in _import_cache:
+                        _import_cache[mgr.state] = {}
 
-                return schemed_fn(*args, **kwds)
+                    _import_cache[mgr.state][func] = schemed_fn
 
-            err = """Failed to find implementation of (%s)
-                  for %s scheme." % (str(fn), current_prefix())"""
-            for emsg in exc_errors:
-                err += print(emsg)
-            raise RuntimeError(err)
+                    return schemed_fn(*args, **kwds)
+
+                err = """Failed to find implementation of (%s)
+                      for %s scheme." % (str(fn), current_prefix())"""
+                for emsg in exc_errors:
+                    err += print(emsg)
+                raise RuntimeError(err)
+        return _scheming_function
 
     return scheming_function
 
-@decorator
-def cpuonly(fn, *args, **kwds):
-    if not issubclass(type(mgr.state), CPUScheme):
-        raise TypeError(fn.__name__ +
-                        " can only be called from a CPU processing scheme.")
-    else:
-        return fn(*args, **kwds)
+def cpuonly(func):
+    @wraps
+    def _cpuonly(*args, **kwds):
+        if not issubclass(type(mgr.state), CPUScheme):
+            raise TypeError(fn.__name__ +
+                            " can only be called from a CPU processing scheme.")
+        else:
+            return func(*args, **kwds)
+    return _cpuonly
 
 def insert_processing_option_group(parser):
     """

--- a/pycbc/scheme.py
+++ b/pycbc/scheme.py
@@ -185,7 +185,7 @@ _import_cache = {}
 def schemed(prefix):
 
     def scheming_function(func):
-        @wraps
+        @wraps(func)
         def _scheming_function(*args, **kwds):
             try:
                 return _import_cache[mgr.state][func](*args, **kwds)
@@ -217,7 +217,7 @@ def schemed(prefix):
     return scheming_function
 
 def cpuonly(func):
-    @wraps
+    @wraps(func)
     def _cpuonly(*args, **kwds):
         if not issubclass(type(mgr.state), CPUScheme):
             raise TypeError(fn.__name__ +

--- a/pycbc/types/array.py
+++ b/pycbc/types/array.py
@@ -60,25 +60,25 @@ def _convert_to_scheme(ary):
       
 def _convert(func):
     @wraps(func)
-    def convert(self, *args):
+    def convert(self, *args, **kwargs):
         _convert_to_scheme(self)
-        return func(self, *args)
+        return func(self, *args, **kwargs)
     return convert
     
 def _nocomplex(func):
     @wraps(func)
-    def nocomplex(self, *args):
+    def nocomplex(self, *args, **kwargs):
         if self.kind == 'real':
-            return func(self, *args)
+            return func(self, *args, **kwargs)
         else:
             raise TypeError( func.__name__ + " does not support complex types")
     return nocomplex
 
 def _noreal(func):
     @wraps(func)
-    def noreal(self, *args):
+    def noreal(self, *args, **kwargs):
         if self.kind == 'complex':
-            return func(self, *args)
+            return func(self, *args, **kwargs)
         else:
             raise TypeError( func.__name__ + " does not support real types")
     return noreal
@@ -244,14 +244,14 @@ class Array(object):
 
     def _returnarray(func):
         @wraps(func)
-        def returnarray(self, *args):
-            return Array(func(self, *args), copy=False) 
+        def returnarray(self, *args, **kwargs):
+            return Array(func(self, *args, **kwargs), copy=False) 
         return returnarray
 
     def _returntype(func):
         @wraps(func)
-        def returntype(self, *args):
-            ary = func(self, *args) # pylint:disable=not-callable
+        def returntype(self, *args, **kwargs):
+            ary = func(self, *args, **kwargs) # pylint:disable=not-callable
             if ary is NotImplemented:
                 return NotImplemented
             return self._return(ary)
@@ -295,7 +295,7 @@ class Array(object):
                 else:
                     raise TypeError('array argument required')
 
-            return func(self,*nargs) # pylint:disable=not-callable
+            return func(self, *nargs) # pylint:disable=not-callable
         return vcheckother
         
     def _vrcheckother(func):

--- a/pycbc/types/array.py
+++ b/pycbc/types/array.py
@@ -245,7 +245,7 @@ class Array(object):
     def _returnarray(func):
         @wraps(func)
         def returnarray(self, *args, **kwargs):
-            return Array(func(self, *args, **kwargs), copy=False) 
+            return Array(func(self, *args, **kwargs), copy=False) # pylint:disable=not-callable
         return returnarray
 
     def _returntype(func):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 # requirements for most basic library use
 astropy>=2.0.3,!=4.2.1,!=4.0.5
 Mako>=1.0.1
-decorator>=3.4.2
 scipy>=0.16.0
 matplotlib>=2.0.0
 numpy>=1.16.0,!=1.19.0

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,6 @@ requires = []
 setup_requires = ['numpy>=1.16.0']
 install_requires =  setup_requires + [
                       'cython>=0.29',
-                      'decorator>=3.4.2',
                       'numpy>=1.16.0,!=1.19.0',
                       'scipy>=0.16.0',
                       'astropy>=2.0.3,!=4.2.1,!=4.0.5',


### PR DESCRIPTION
I've seen some issues recently where decorator is taken reasonably significant time to call the functions it is wrapping.

The easiest solution to this seems to be: don't use decorator. From reading around it seems like `functools.wraps` is more widely used. The syntax for this is a little different (and more like "normal" decorators), but after making this change I don't see any time spent within functools ... I actually don't see functools.wrap *at all* in the profile, which does make it easier to read the profile .. and I hope means it is still accurate!