### PR TITLE
Verifier with pycbc injs

### DIFF
--- a/bin/workflows/pycbc_make_bank_verifier_workflow
+++ b/bin/workflows/pycbc_make_bank_verifier_workflow
@@ -204,23 +204,15 @@ def add_banksim_set(workflow, file_tag, num_injs, curr_tags, split_banks):
     """Add a group of jobs that does a complete banksim.
     """
     t_seg = segments.segment([1000000000, 1000000000+int(num_injs)])
+    inspinj_job.update_current_tags(curr_tags)
     if 'LalappsInspinjExecutable' in str(inspinj_exe):
-        inspinj_job.update_current_tags(curr_tags)
         node = inspinj_job.create_node(t_seg)
         inj_file = node.output_file
     elif 'PycbcCreateInjectionsExecutable' in str(inspinj_exe):
-        subsection_name = ('-'.join(['injection']+curr_tags))
-        inj_conf_file_url = workflow.cp.get(subsection_name, 'config-file') 
-        inj_conf_file = wf.resolve_url_to_file(inj_conf_file_url)
-        conf_file.append(inj_conf_file)
-        shutil.copy2(inj_conf_file.storage_path, conf_dir+'/'+inj_conf_file.lfn)
-        # inspinj_job.update_current_tags is wrapped by two commands that
-        # avoid having --config-file in the call to pycbc_create_injections
-        # but preserve it in the configuration.ini written at the end
-        workflow.cp.remove_option(subsection_name, 'config-file')
-        inspinj_job.update_current_tags(curr_tags)
-        workflow.cp.add_options_to_section(subsection_name, [('config-file', inj_conf_file_url)])
-        node, inj_file = inspinj_job.create_node(inj_conf_file, tags=[])
+        # Ensure pycbc_create_injections dedicated configuration files
+        # are copied over to the results directory
+        shutil.copy2(inspinj_job.get_opt('config-files'), conf_dir)
+        node, inj_file = inspinj_job.create_node()
         node.add_opt("--gps-start-time", int_gps_time_to_str(t_seg[0]))
         node.add_opt("--gps-end-time", int_gps_time_to_str(t_seg[1]))
     else:

--- a/bin/workflows/pycbc_make_bank_verifier_workflow
+++ b/bin/workflows/pycbc_make_bank_verifier_workflow
@@ -25,13 +25,15 @@ template bank.
 #imports
 import os
 import argparse
+import shutil
 
 from ligo import segments
 
 import pycbc.version
 import pycbc.workflow as wf
-from pycbc.results import create_versioning_page, static_table, layout
-from pycbc.workflow import LalappsInspinjExecutable, PycbcDarkVsBrightInjectionsExecutable
+from pycbc.results import (create_versioning_page, static_table, layout)
+from pycbc.workflow.jobsetup import (select_generic_executable,
+                                     int_gps_time_to_str)
 from pycbc.workflow import setup_splittable_dax_generated
 
 # Boiler-plate stuff
@@ -160,7 +162,6 @@ args = parser.parse_args()
 # Create the workflow object
 workflow = wf.Workflow(args)
 
-
 wf.makedir(args.output_dir)
 os.chdir(args.output_dir)
 args.output_dir = '.'
@@ -170,6 +171,16 @@ rdir = layout.SectionNumber('results', ['point_injection_sets',
                                         'workflow'])
 wf.makedir(rdir.base)
 wf.makedir(rdir['workflow'])
+# Save config file to results directory
+conf_dir = rdir['workflow/configuration']
+wf.makedir(conf_dir)
+conf_path = os.path.join(conf_dir, 'configuration.ini')
+with open(conf_path, 'w') as conf_fh:
+    workflow.cp.write(conf_fh)
+conf_file = wf.FileList([wf.File(workflow.ifos, '', workflow.analysis_time,
+                         file_url='file://' + conf_path)])
+
+request_disk = workflow.cp.get('pegasus_profile', 'condor|request_disk')
 
 # Input bank file
 inp_bank = workflow.cp.get('workflow', 'input-bank')
@@ -179,24 +190,51 @@ inp_bank.description='TEMPLATEBANK'
 inp_bank.ifo_list = workflow.ifos
 inp_bank.segment = workflow.analysis_time
 
+# Inspinj Executable
+inspinj_exe = select_generic_executable(workflow, 'injection')
+# The output must be in xml format for pycbc_splitinj to work
+inspinj_exe.extension = ".xml"
+# The following line and the previous one are redundant for
+# lalapps_inspinj, but not for pycbc_create_injections
+inspinj_exe.current_retention_level = wf.Executable.FINAL_RESULT
+
 # Inspinj job
-inspinj_job = LalappsInspinjExecutable(workflow.cp, 'injection', out_dir='.',
-                                       ifos='HL', tags=[])
+inspinj_job = inspinj_exe(workflow.cp, 'injection', out_dir='.',
+                          ifos=workflow.ifos, tags=[])
 
 def add_banksim_set(workflow, file_tag, num_injs, curr_tags, split_banks):
     """Add a group of jobs that does a complete banksim.
     """
-    inspinj_job.update_current_tags(curr_tags)
     t_seg = segments.segment([1000000000, 1000000000+int(num_injs)])
-    node = inspinj_job.create_node(t_seg)
+    if 'LalappsInspinjExecutable' in str(inspinj_exe):
+        inspinj_job.update_current_tags(curr_tags)
+        node = inspinj_job.create_node(t_seg)
+        inj_file = node.output_file
+    elif 'PycbcCreateInjectionsExecutable' in str(inspinj_exe):
+        subsection_name = ('-'.join(['injection']+curr_tags))
+        inj_conf_file_url = workflow.cp.get(subsection_name, 'config-file') 
+        inj_conf_file = wf.resolve_url_to_file(inj_conf_file_url)
+        conf_file.append(inj_conf_file)
+        shutil.copy2(inj_conf_file.storage_path, conf_dir+'/'+inj_conf_file.lfn)
+        # inspinj_job.update_current_tags is wrapped by two commands that
+        # avoid having --config-file in the call to pycbc_create_injections
+        # but preserve it in the configuration.ini written at the end
+        workflow.cp.remove_option(subsection_name, 'config-file')
+        inspinj_job.update_current_tags(curr_tags)
+        workflow.cp.add_options_to_section(subsection_name, [('config-file', inj_conf_file_url)])
+        node, inj_file = inspinj_job.create_node(inj_conf_file, tags=[])
+        node.add_opt("--gps-start-time", int_gps_time_to_str(t_seg[0]))
+        node.add_opt("--gps-end-time", int_gps_time_to_str(t_seg[1]))
+    else:
+        raise NotImplementedError
     workflow += node
-    inj_file = node.output_file
     # Here we apply the em-bright criterion
     if workflow.cp.has_option('workflow-injections', 'em-bright-only'):
         # Job to carry on with em-bright injections only
-        em_filter_job = PycbcDarkVsBrightInjectionsExecutable(workflow.cp,
-                                       'em_bright_filter', out_dir='.',
-                                       ifos=workflow.ifos, tags=curr_tags)
+        em_filter_exe = select_generic_executable(workflow, 'em_bright_filter')
+        em_filter_job = em_filter_exe(workflow.cp, 'em_bright_filter',
+                                      out_dir='.', ifos=workflow.ifos,
+                                      tags=curr_tags)
         node = em_filter_job.create_node(inj_file, t_seg, curr_tags)
         workflow += node
         inj_file = node.output_files[0]
@@ -344,14 +382,7 @@ for tag in sorted(output_pointinjs):
     layout.two_column_layout(rdir['point_injection_sets/{}'.format(tag)],
                              curr_outs)
 
-# save global config file to results directory
-conf_dir = rdir['workflow/configuration']
-wf.makedir(conf_dir)
-conf_path = os.path.join(conf_dir, 'configuration.ini')
-with open(conf_path, 'w') as conf_fh:
-    workflow.cp.write(conf_fh)
-conf_file = wf.FileList([wf.File(workflow.ifos, '', workflow.analysis_time,
-                         file_url='file://' + conf_path)])
+# Save config file(s) to results directory
 layout.single_layout(conf_dir, conf_file)
 
 # Create versioning information

--- a/bin/workflows/pycbc_make_bank_verifier_workflow
+++ b/bin/workflows/pycbc_make_bank_verifier_workflow
@@ -212,7 +212,7 @@ def add_banksim_set(workflow, file_tag, num_injs, curr_tags, split_banks):
     if inspinj_exe is LalappsInspinjExecutable:
         node = inspinj_job.create_node(t_seg)
         inj_file = node.output_file
-    if inspinj_exe is PycbcCreateInjectionsExecutable:
+    elif inspinj_exe is PycbcCreateInjectionsExecutable:
         # Ensure pycbc_create_injections dedicated configuration files
         # are copied over to the results directory
         shutil.copy2(inspinj_job.get_opt('config-files'), conf_dir)

--- a/bin/workflows/pycbc_make_bank_verifier_workflow
+++ b/bin/workflows/pycbc_make_bank_verifier_workflow
@@ -33,7 +33,9 @@ import pycbc.version
 import pycbc.workflow as wf
 from pycbc.results import (create_versioning_page, static_table, layout)
 from pycbc.workflow.jobsetup import (select_generic_executable,
-                                     int_gps_time_to_str)
+                                     int_gps_time_to_str,
+                                     PycbcCreateInjectionsExecutable,
+                                     LalappsInspinjExecutable)
 from pycbc.workflow import setup_splittable_dax_generated
 
 # Boiler-plate stuff
@@ -190,10 +192,12 @@ inp_bank.segment = workflow.analysis_time
 
 # Inspinj Executable
 inspinj_exe = select_generic_executable(workflow, 'injection')
-# The output must be in xml format for pycbc_splitinj to work
-inspinj_exe.extension = ".xml"
-# The following line and the previous one are redundant for
-# lalapps_inspinj, but not for pycbc_create_injections
+# The output must be in xml format for pycbc_split_inspinj to work,
+# while h5 will work when splitting with pycbc_hdf5_splitbank
+splitter = workflow.cp.get('executables', 'splitinj')
+inspinj_exe.extension = ".xml" if 'pycbc_split_inspinj' in splitter else ".h5"
+# The following line is redundant for lalapps_inspinj, but not
+# for pycbc_create_injections
 inspinj_exe.current_retention_level = wf.Executable.FINAL_RESULT
 
 # Inspinj job
@@ -205,10 +209,10 @@ def add_banksim_set(workflow, file_tag, num_injs, curr_tags, split_banks):
     """
     t_seg = segments.segment([1000000000, 1000000000+int(num_injs)])
     inspinj_job.update_current_tags(curr_tags)
-    if 'LalappsInspinjExecutable' in str(inspinj_exe):
+    if inspinj_exe is LalappsInspinjExecutable:
         node = inspinj_job.create_node(t_seg)
         inj_file = node.output_file
-    elif 'PycbcCreateInjectionsExecutable' in str(inspinj_exe):
+    if inspinj_exe is PycbcCreateInjectionsExecutable:
         # Ensure pycbc_create_injections dedicated configuration files
         # are copied over to the results directory
         shutil.copy2(inspinj_job.get_opt('config-files'), conf_dir)

--- a/bin/workflows/pycbc_make_bank_verifier_workflow
+++ b/bin/workflows/pycbc_make_bank_verifier_workflow
@@ -180,8 +180,6 @@ with open(conf_path, 'w') as conf_fh:
 conf_file = wf.FileList([wf.File(workflow.ifos, '', workflow.analysis_time,
                          file_url='file://' + conf_path)])
 
-request_disk = workflow.cp.get('pegasus_profile', 'condor|request_disk')
-
 # Input bank file
 inp_bank = workflow.cp.get('workflow', 'input-bank')
 inp_bank = wf.resolve_url_to_file(inp_bank)

--- a/bin/workflows/pycbc_make_inference_inj_workflow
+++ b/bin/workflows/pycbc_make_inference_inj_workflow
@@ -252,7 +252,7 @@ for num_inj in range(n_injections):
     else:
         # construct Executable for creating injections
         create_injections_exe = PycbcCreateInjectionsExecutable(
-            sub_workflow.cp, "create_injections", ifo=sub_workflow.ifos,
+            sub_workflow.cp, "create_injections", ifos=sub_workflow.ifos,
             out_dir=injection_file_dir)
         node, injection_file = create_injections_exe.create_node(
             config_file, seed=seed, tags=opts.tags+[event])

--- a/pycbc/inject/inject.py
+++ b/pycbc/inject/inject.py
@@ -69,6 +69,9 @@ def set_sim_data(inj, field, data):
     if sim_field == 'tc':
         inj.geocent_end_time = int(data)
         inj.geocent_end_time_ns = int(1e9*(data % 1))
+    # for spin1 and spin2 we need data to be an array
+    if sim_field in ['spin1', 'spin2']:
+        setattr(inj, sim_field, [0, 0, data])
     else:
         setattr(inj, sim_field, data)
 

--- a/pycbc/workflow/jobsetup.py
+++ b/pycbc/workflow/jobsetup.py
@@ -1218,7 +1218,7 @@ class PycbcCreateInjectionsExecutable(Executable):
     current_retention_level = Executable.ALL_TRIGGERS
     extension = '.hdf'
 
-    def __init__(self, cp, exe_name, ifo=None, out_dir=None,
+    def __init__(self, cp, exe_name, ifos=None, out_dir=None,
                  universe=None, tags=None):
         super(PycbcCreateInjectionsExecutable, self).__init__(
                                cp, exe_name, universe, ifos, out_dir, tags)

--- a/pycbc/workflow/jobsetup.py
+++ b/pycbc/workflow/jobsetup.py
@@ -484,7 +484,8 @@ class PyCBCInspiralExecutable(Executable):
         if tags is None:
             tags = []
         super().__init__(cp, exe_name, None, ifo, out_dir, tags=tags,
-            reuse_executable=reuse_executable, set_submit_subdir=False)
+                         reuse_executable=reuse_executable,
+                         set_submit_subdir=False)
         self.cp = cp
         self.injection_file = injection_file
         self.ext = '.hdf'

--- a/pycbc/workflow/jobsetup.py
+++ b/pycbc/workflow/jobsetup.py
@@ -1027,13 +1027,8 @@ class PycbcDarkVsBrightInjectionsExecutable(Executable):
     current_retention_level = Executable.FINAL_RESULT
     def __init__(self, cp, exe_name, universe=None, ifos=None, out_dir=None,
                  tags=None):
-        if tags is None:
-            tags = []
-        Executable.__init__(self, cp, exe_name, universe, ifos, out_dir,
-                            tags=tags)
-        self.cp = cp
-        self.out_dir = out_dir
-        self.exe_name = exe_name
+        super(PycbcDarkVsBrightInjectionsExecutable, self).__init__(
+                               cp, exe_name, universe, ifos, out_dir, tags)
 
     def create_node(self, parent, segment, tags=None):
         if tags is None:

--- a/pycbc/workflow/jobsetup.py
+++ b/pycbc/workflow/jobsetup.py
@@ -1216,10 +1216,12 @@ class PycbcCreateInjectionsExecutable(Executable):
     """
 
     current_retention_level = Executable.ALL_TRIGGERS
+    extension = '.hdf'
+
     def __init__(self, cp, exe_name, ifo=None, out_dir=None,
                  universe=None, tags=None):
         super(PycbcCreateInjectionsExecutable, self).__init__(
-                               cp, exe_name, universe, ifo, out_dir, tags)
+                               cp, exe_name, universe, ifos, out_dir, tags)
 
     def create_node(self, config_file=None, seed=None, tags=None):
         """ Set up a CondorDagmanNode class to run ``pycbc_create_injections``.
@@ -1254,7 +1256,8 @@ class PycbcCreateInjectionsExecutable(Executable):
         if seed:
             node.add_opt("--seed", seed)
         injection_file = node.new_output_file_opt(analysis_time,
-                                                  ".hdf", "--output-file",
+                                                  self.extension,
+                                                  "--output-file",
                                                   tags=tags)
 
         return node, injection_file

--- a/pycbc/workflow/jobsetup.py
+++ b/pycbc/workflow/jobsetup.py
@@ -1218,7 +1218,8 @@ class PycbcCreateInjectionsExecutable(Executable):
 
         # make node for running executable
         node = Node(self)
-        node.add_input_opt("--config-files", config_file)
+        if config_file is not None:
+            node.add_input_opt("--config-files", config_file)
         if seed:
             node.add_opt("--seed", seed)
         injection_file = node.new_output_file_opt(analysis_time,

--- a/pycbc/workflow/jobsetup.py
+++ b/pycbc/workflow/jobsetup.py
@@ -127,7 +127,7 @@ def select_generic_executable(workflow, exe_tag):
     exe_to_class_map = {
         'ligolw_add'               : LigolwAddExecutable,
         'lalapps_inspinj'          : LalappsInspinjExecutable,
-        'pycbc_create_injections'  : PyCBCCreateInjectionsExecutable,
+        'pycbc_create_injections'  : PycbcCreateInjectionsExecutable,
         'pycbc_dark_vs_bright_injections' : PycbcDarkVsBrightInjectionsExecutable,
         "pycbc_condition_strain"         : PycbcConditionStrainExecutable
     }
@@ -946,21 +946,6 @@ class PycbcSplitInspinjExecutable(Executable):
         node.add_output_list_opt('--output-files', out_files)
         return node
 
-
-class PyCBCCreateInjectionsExecutable(Executable):
-    """
-    The class used to create jobs for the lalapps_inspinj Executable.
-    """
-    current_retention_level = Executable.FINAL_RESULT
-    def create_node(self, segment, tags=None):
-        if tags is None:
-            tags = []
-        node = Node(self)
-        node.new_output_file_opt(segment, '.hdf', '--output-file',
-                                 store_file=self.retain_files, tags=tags)
-        node.add_opt('--gps-start-time', int_gps_time_to_str(segment[0]))
-        node.add_opt('--gps-end-time', int_gps_time_to_str(segment[1]))
-        return node
 
 class LalappsInspinjExecutable(Executable):
     """

--- a/pycbc/workflow/jobsetup.py
+++ b/pycbc/workflow/jobsetup.py
@@ -967,6 +967,7 @@ class LalappsInspinjExecutable(Executable):
     The class used to create jobs for the lalapps_inspinj Executable.
     """
     current_retention_level = Executable.FINAL_RESULT
+    extension = '.xml'
     def create_node(self, segment, exttrig_file=None, tags=None):
         if tags is None:
             tags = []
@@ -977,9 +978,7 @@ class LalappsInspinjExecutable(Executable):
         # in the config file. Used for coh_PTF as segment length is unknown
         # before run time.
         if self.get_opt('write-compress') is not None:
-            ext = '.xml.gz'
-        else:
-            ext = '.xml'
+            extension = '.xml.gz'
 
         # Check if these injections are using trigger information to choose
         # sky positions for the simulated signals
@@ -1013,7 +1012,7 @@ class LalappsInspinjExecutable(Executable):
             node.add_opt('--time-interval', inj_tspace)
             node.add_opt('--time-step', inj_tspace)
 
-        node.new_output_file_opt(segment, ext, '--output',
+        node.new_output_file_opt(segment, self.extension, '--output',
                                  store_file=self.retain_files)
 
         node.add_opt('--gps-start-time', int_gps_time_to_str(segment[0]))

--- a/pycbc/workflow/jobsetup.py
+++ b/pycbc/workflow/jobsetup.py
@@ -483,16 +483,8 @@ class PyCBCInspiralExecutable(Executable):
                  injection_file=None, tags=None, reuse_executable=False):
         if tags is None:
             tags = []
-        super(PyCBCInspiralExecutable, self).__init__(
-            cp,
-            exe_name,
-            None,
-            ifo,
-            out_dir,
-            tags=tags,
-            reuse_executable=reuse_executable,
-            set_submit_subdir=False
-        )
+        super().__init__(cp, exe_name, None, ifo, out_dir, tags=tags,
+            reuse_executable=reuse_executable, set_submit_subdir=False)
         self.cp = cp
         self.injection_file = injection_file
         self.ext = '.hdf'
@@ -670,8 +662,7 @@ class PyCBCMultiInspiralExecutable(Executable):
                  gate_files=None, out_dir=None, tags=None):
         if tags is None:
             tags = []
-        super(PyCBCMultiInspiralExecutable, self).__init__(cp, name, universe,
-                ifo, out_dir=out_dir, tags=tags)
+        super().__init__(cp, name, universe, ifo, out_dir=out_dir, tags=tags)
         self.injection_file = injection_file
         self.data_seg = segments.segment(int(cp.get('workflow', 'start-time')),
                                          int(cp.get('workflow', 'end-time')))
@@ -793,7 +784,7 @@ class PyCBCTmpltbankExecutable(Executable):
                  tags=None, write_psd=False, psd_files=None):
         if tags is None:
             tags = []
-        super(PyCBCTmpltbankExecutable, self).__init__(cp, exe_name, 'vanilla', ifo, out_dir, tags=tags)
+        super().__init__(cp, exe_name, 'vanilla', ifo, out_dir, tags=tags)
         self.cp = cp
         self.write_psd = write_psd
         self.psd_files = psd_files
@@ -887,7 +878,7 @@ class LigolwAddExecutable(Executable):
 
     current_retention_level = Executable.INTERMEDIATE_PRODUCT
     def __init__(self, *args, **kwargs):
-        super(LigolwAddExecutable, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def create_node(self, jobSegment, input_files, output=None,
                     use_tmp_subdirs=True, tags=None):
@@ -918,8 +909,7 @@ class PycbcSplitInspinjExecutable(Executable):
     current_retention_level = Executable.INTERMEDIATE_PRODUCT
     def __init__(self, cp, exe_name, num_splits, universe=None, ifo=None,
                  out_dir=None):
-        super(PycbcSplitInspinjExecutable, self).__init__(cp, exe_name,
-                universe, ifo, out_dir, tags=[])
+        super().__init__(cp, exe_name, universe, ifo, out_dir, tags=[])
         self.num_splits = int(num_splits)
     def create_node(self, parent, tags=None):
         if tags is None:
@@ -963,7 +953,7 @@ class LalappsInspinjExecutable(Executable):
         # in the config file. Used for coh_PTF as segment length is unknown
         # before run time.
         if self.get_opt('write-compress') is not None:
-            extension = '.xml.gz'
+            self.extension = '.xml.gz'
 
         # Check if these injections are using trigger information to choose
         # sky positions for the simulated signals
@@ -1012,8 +1002,7 @@ class PycbcDarkVsBrightInjectionsExecutable(Executable):
     current_retention_level = Executable.FINAL_RESULT
     def __init__(self, cp, exe_name, universe=None, ifos=None, out_dir=None,
                  tags=None):
-        super(PycbcDarkVsBrightInjectionsExecutable, self).__init__(
-                               cp, exe_name, universe, ifos, out_dir, tags)
+        super().__init__(cp, exe_name, universe, ifos, out_dir, tags)
 
     def create_node(self, parent, segment, tags=None):
         if tags is None:
@@ -1110,8 +1099,7 @@ class PycbcSplitBankExecutable(Executable):
     current_retention_level = Executable.ALL_TRIGGERS
     def __init__(self, cp, exe_name, num_banks,
                  ifo=None, out_dir=None, universe=None):
-        super(PycbcSplitBankExecutable, self).__init__(cp, exe_name, universe,
-                ifo, out_dir, tags=[])
+        super().__init__(cp, exe_name, universe, ifo, out_dir, tags=[])
         self.num_banks = int(num_banks)
 
     def create_node(self, bank, tags=None):
@@ -1161,8 +1149,7 @@ class PycbcConditionStrainExecutable(Executable):
     current_retention_level = Executable.ALL_TRIGGERS
     def __init__(self, cp, exe_name, ifo=None, out_dir=None, universe=None,
             tags=None):
-        super(PycbcConditionStrainExecutable, self).__init__(cp, exe_name, universe,
-              ifo, out_dir, tags)
+        super().__init__(cp, exe_name, universe, ifo, out_dir, tags)
 
     def create_node(self, input_files, tags=None):
         if tags is None:
@@ -1200,8 +1187,7 @@ class PycbcCreateInjectionsExecutable(Executable):
 
     def __init__(self, cp, exe_name, ifos=None, out_dir=None,
                  universe=None, tags=None):
-        super(PycbcCreateInjectionsExecutable, self).__init__(
-                               cp, exe_name, universe, ifos, out_dir, tags)
+        super().__init__(cp, exe_name, universe, ifos, out_dir, tags)
 
     def create_node(self, config_file=None, seed=None, tags=None):
         """ Set up a CondorDagmanNode class to run ``pycbc_create_injections``.
@@ -1250,11 +1236,8 @@ class PycbcInferenceExecutable(Executable):
     current_retention_level = Executable.ALL_TRIGGERS
     def __init__(self, cp, exe_name, ifos=None, out_dir=None,
                  universe=None, tags=None):
-        super(PycbcInferenceExecutable, self).__init__(cp, exe_name,
-                                                       universe=universe,
-                                                       ifos=ifos,
-                                                       out_dir=out_dir,
-                                                       tags=tags)
+        super().__init__(cp, exe_name, universe=universe, ifos=ifos,
+                         out_dir=out_dir, tags=tags)
 
     def create_node(self, config_file, seed=None, tags=None,
                     analysis_time=None):

--- a/pycbc/workflow/pegasus_sites.py
+++ b/pycbc/workflow/pegasus_sites.py
@@ -54,7 +54,7 @@ def add_ini_site_profile(site, cp, sec):
 
 
 def add_local_site(sitecat, cp, local_path, local_url):
-    """Add the local site to sitecatalog"""
+    """Add the local site to site catalog"""
     # local_url must end with a '/'
     if not local_url.endswith('/'):
         local_url = local_url + '/'
@@ -223,7 +223,7 @@ def add_osg_site(sitecat, cp):
 
 
 def add_site(sitecat, sitename, cp, out_dir=None):
-    """Add site sitename to sitecatalog"""
+    """Add site sitename to site catalog"""
     # Allow local site scratch to be overriden for any site which uses it
     sec = 'pegasus_profile-{}'.format(sitename)
     opt = 'pycbc|site-scratch'


### PR DESCRIPTION
This PR allows `pycbc_make_bank_verifier_workflow` to also exploit `pycbc_create_injections` rather than just `lalapps_insp_inj`.  Doing so required some cleaning up in `pycbc/workflow/jobsetup.py`, which in turn also brought a small update to `pycbc_make_inference_inj_workflow`.  Finally, `pycbc/inject/inject.py` needed some fixing to get `pycbc_create_injections` to write aligned spin injections to xml files without errors.