### PR TITLE
fix pool properties upon resume for dynesty 1.2

### DIFF
--- a/pycbc/inference/sampler/dynesty.py
+++ b/pycbc/inference/sampler/dynesty.py
@@ -164,7 +164,8 @@ class DynestySampler(BaseSampler):
                           '_UPDATE', '_PROPOSE',
                           'evolve_point', 'use_pool', 'queue_size',
                           'use_pool_ptform', 'use_pool_logl',
-                          'use_pool_evolve']
+                          'use_pool_evolve', 'use_pool_update',
+                          'pool', 'M']
 
     def run(self):
         diff_niter = 1


### PR DESCRIPTION
@cnsetzer Reported that upon resuming from a checkpoint Dynesty 1.2 would limit to 1 core. I confirmed this was the case and it seems to be due to addition pool metadata that by default would be restored in 1.2. We need to add these to the "do not restore" list so that it uses the scratch made properties on restart. 