### PR TITLE
Cache FIR filters in resample.py

### DIFF
--- a/pycbc/filter/resample.py
+++ b/pycbc/filter/resample.py
@@ -34,6 +34,9 @@ _resample_func = {numpy.dtype('float32'): lal.ResampleREAL4TimeSeries,
 
 @functools.lru_cache(maxsize=20)
 def cached_firwin(*args, **kwargs):
+    """Cache the FIR filter coefficients.
+    This is mostly done for PyCBC Live, which rapidly and repeatedly resamples data.
+    """
     return scipy.signal.firwin(*args, **kwargs)
 
 def lfilter(coefficients, timeseries):

--- a/pycbc/filter/resample.py
+++ b/pycbc/filter/resample.py
@@ -21,6 +21,7 @@
 #
 # =============================================================================
 #
+import functools
 import lal
 import numpy
 import scipy.signal
@@ -30,6 +31,10 @@ from pycbc.fft import ifft, fft
 
 _resample_func = {numpy.dtype('float32'): lal.ResampleREAL4TimeSeries,
                  numpy.dtype('float64'): lal.ResampleREAL8TimeSeries}
+
+@functools.lru_cache(maxsize=20)
+def cached_firwin(*args, **kwargs):
+    return scipy.signal.firwin(*args, **kwargs)
 
 def lfilter(coefficients, timeseries):
     """ Apply filter coefficients to a time series
@@ -167,8 +172,8 @@ def resample_to_delta_t(timeseries, delta_t, method='butterworth'):
 
         # The kaiser window has been testing using the LDAS implementation
         # and is in the same configuration as used in the original lalinspiral
-        filter_coefficients = scipy.signal.firwin(numtaps, 1.0 / factor,
-                                                  window=('kaiser', 5))
+        filter_coefficients = cached_firwin(numtaps, 1.0 / factor,
+                                            window=('kaiser', 5))
 
         # apply the filter and decimate
         data = fir_zero_filter(filter_coefficients, timeseries)[::factor]
@@ -219,7 +224,7 @@ def notch_fir(timeseries, f1, f2, order, beta=5.0):
     """
     k1 = f1 / float((int(1.0 / timeseries.delta_t) / 2))
     k2 = f2 / float((int(1.0 / timeseries.delta_t) / 2))
-    coeff = scipy.signal.firwin(order * 2 + 1, [k1, k2], window=('kaiser', beta))
+    coeff = cached_firwin(order * 2 + 1, [k1, k2], window=('kaiser', beta))
     return fir_zero_filter(coeff, timeseries)
 
 def lowpass_fir(timeseries, frequency, order, beta=5.0):
@@ -238,7 +243,7 @@ def lowpass_fir(timeseries, frequency, order, beta=5.0):
         Beta parameter of the kaiser window that sets the side lobe attenuation.
     """
     k = frequency / float((int(1.0 / timeseries.delta_t) / 2))
-    coeff = scipy.signal.firwin(order * 2 + 1, k, window=('kaiser', beta))
+    coeff = cached_firwin(order * 2 + 1, k, window=('kaiser', beta))
     return fir_zero_filter(coeff, timeseries)
 
 def highpass_fir(timeseries, frequency, order, beta=5.0):
@@ -257,7 +262,7 @@ def highpass_fir(timeseries, frequency, order, beta=5.0):
         Beta parameter of the kaiser window that sets the side lobe attenuation.
     """
     k = frequency / float((int(1.0 / timeseries.delta_t) / 2))
-    coeff = scipy.signal.firwin(order * 2 + 1, k, window=('kaiser', beta), pass_zero=False)
+    coeff = cached_firwin(order * 2 + 1, k, window=('kaiser', beta), pass_zero=False)
     return fir_zero_filter(coeff, timeseries)
 
 def highpass(timeseries, frequency, filter_order=8, attenuation=0.1):


### PR DESCRIPTION
So I've been looking at the call-graph for PyCBC Live (running in early warning configuration), and am going to be proposing some changes to make the "not doing matched-filtering" bits quicker. The decorator change #4011 was the first of these (and perhaps the most impactful), but there's other things that can be done.

One issue with Live is that it keeps reading data, and this process is not quick. This involves some repetitive operations that can be avoided. Recomputing the FIR filters in resample.py is an example of that. With a few-line change, we can use python3 built-in decorators to cache these, in the case that they don't need recomputing.