### PR TITLE
Cache FFTW plans in function API

### DIFF
--- a/pycbc/fft/fftw.py
+++ b/pycbc/fft/fftw.py
@@ -1,5 +1,6 @@
 from pycbc.types import zeros
 import numpy as _np
+import functools
 import ctypes
 import pycbc.scheme as _scheme
 from pycbc.libutils import get_ctypes_library
@@ -239,6 +240,7 @@ execute_function = {'float32': {'complex64': float_lib.fftwf_execute_dft_r2c},
                                    'complex128': double_lib.fftw_execute_dft}
                    }
 
+@functools.lru_cache
 def plan(size, idtype, odtype, direction, mlvl, aligned, nthreads, inplace):
     if not _fftw_threaded_set:
         set_threads_backend()
@@ -323,14 +325,14 @@ def fft(invec, outvec, prec, itype, otype):
                             get_measure_level(),(check_aligned(invec.data) and check_aligned(outvec.data)),
                    _scheme.mgr.state.num_threads, (invec.ptr == outvec.ptr))
     execute(theplan, invec, outvec)
-    destroy(theplan)
+    #destroy(theplan)
 
 def ifft(invec, outvec, prec, itype, otype):
     theplan, destroy = plan(len(outvec), invec.dtype, outvec.dtype, FFTW_BACKWARD,
                             get_measure_level(),(check_aligned(invec.data) and check_aligned(outvec.data)),
                    _scheme.mgr.state.num_threads, (invec.ptr == outvec.ptr))
     execute(theplan, invec, outvec)
-    destroy(theplan)
+    #destroy(theplan)
 
 # Class based API
 


### PR DESCRIPTION
Similar to #4015. 

Recomputing FFTW plans (for data reading/high-pass filtering etc.) can be expensive. I know that the class-based API would be more efficient (expect that PR later), but it feels like not caching FFTW plans makes FFTW much slower than it needs to be, when using the function API. I don't really see any reason *not* to cache these.

For reference here is the callgraph I am working off of:

![image](https://user-images.githubusercontent.com/11438929/166454905-d889020b-b9ad-4eaf-b192-fabe875379bc.png)

and we spend almost 7% of the time recomputing FFTW plans here.

I include @josh-willis here, as I'm not sure if I'm missing some reason why this would be a bad idea!