### PR TITLE
Attempt to speed up call to kind in array.pyx

### DIFF
--- a/pycbc/types/array_cpu.pyx
+++ b/pycbc/types/array_cpu.pyx
@@ -120,7 +120,7 @@ def abs_arg_max_complex(numpy.ndarray [COMPLEXTYPE, ndim=1] a):
     return idx  
 
 def abs_arg_max(self):
-    if self.dtype == np.float32 or self.dtype == np.float64:
+    if self.dtype == _np.float32 or self.dtype == _np.float64:
         return _np.argmax(abs(self.data))
     else:
         return abs_arg_max_complex(self._data)    

--- a/pycbc/types/array_cpu.pyx
+++ b/pycbc/types/array_cpu.pyx
@@ -120,7 +120,7 @@ def abs_arg_max_complex(numpy.ndarray [COMPLEXTYPE, ndim=1] a):
     return idx  
 
 def abs_arg_max(self):
-    if self.kind == 'real':
+    if self.dtype == np.float32 or self.dtype == np.float64:
         return _np.argmax(abs(self.data))
     else:
         return abs_arg_max_complex(self._data)    


### PR DESCRIPTION
Another one in the vein of #4015.

In the callgraph in #4016 about 1% of the time is spent in the "kind" property within `abs_arg_max`. This is silly, as that is just checking "is this complex or not". I think the issue is that we have to do a call back to python from Cython. It seems that I get most of the 1% back by making the change below, but probably it's better to call directly into `abs_arg_max_complex` if you know the input is complex.