### PR TITLE
start work on skipping likelihoods known to be low

### DIFF
--- a/examples/inference/relative/relative.ini
+++ b/examples/inference/relative/relative.ini
@@ -6,6 +6,8 @@ epsilon = 0.03
 mass1_ref = 1.3757
 mass2_ref = 1.3757
 tc_ref = 1187008882.42
+peak_time_abort = .002
+match_abort = 0.5
 
 [data]
 instruments = H1 L1 V1
@@ -22,10 +24,8 @@ strain-high-pass = 15
 sample-rate = 2048
 
 [sampler]
-name = emcee_pt
-ntemps = 4
-nwalkers = 100
-niterations = 300
+name = dynesty
+nlive = 1000
 
 [sampler-burn_in]
 burn-in-test = min_iterations
@@ -38,6 +38,9 @@ distance =
 inclination =
 mchirp =
 eta =
+ra =
+dec =
+polarization =
 
 [static_params]
 ; waveform parameters that will not change in MCMC
@@ -45,12 +48,17 @@ approximant = TaylorF2
 f_lower = 30
 
 #; we'll choose not to sample over these, but you could
-polarization = 0.0
-ra = 3.44615914
-dec = -0.40808407
+#polarization = 0.0
+#ra = 3.44615914
+#dec = -0.40808407
 
 #; You could also set additional parameters if your waveform model supports / requires it.
 ; spin1z = 0
+[prior-ra+dec]
+name = uniform_sky
+
+[prior-polarization]
+name = uniform_angle
 
 [prior-mchirp]
 ; chirp mass prior

--- a/examples/inference/relative/run.sh
+++ b/examples/inference/relative/run.sh
@@ -1,6 +1,6 @@
-pycbc_inference \
+OMP_NUM_THREADS=1 python -m cProfile -o log `which pycbc_inference` \
 --config-file `dirname "$0"`/relative.ini \
---nprocesses=4 \
+--nprocesses=1 \
 --output-file relative.hdf \
 --seed 0 \
 --force \

--- a/pycbc/inference/models/base.py
+++ b/pycbc/inference/models/base.py
@@ -628,8 +628,8 @@ class BaseModel(metaclass=ABCMeta):
     #
     # Methods for initiating from a config file.
     #
-    @staticmethod
-    def extra_args_from_config(cp, section, skip_args=None, dtypes=None):
+    @classmethod
+    def extra_args_from_config(cls, cp, section, skip_args=None, dtypes=None):
         """Gets any additional keyword in the given config file.
 
         Parameters


### PR DESCRIPTION
This is an attempt to start speeding up certain likelihood calls where we can quickly determine it cannot return a high likelihood value. 

(1) determine where the SNR peaks are to check if the proposed parameters are at the right time in each detector
(2) estimate the match between a "known" waveform that is close to the right solution and a proposed one. This might also be sped up with some estimate of the metric directly if available. 

[PR currently in progress, I'm posting so people can comment, help with ideas / testing / implementation]