### PR TITLE
Joint distribution does not respect input type

### DIFF
--- a/pycbc/distributions/joint.py
+++ b/pycbc/distributions/joint.py
@@ -161,7 +161,7 @@ class JointDistribution(object):
 
     @staticmethod
     def _return_atomic(params):
-        """Determins if an array or atomic value should be returned given a
+        """Determines if an array or atomic value should be returned given a
         set of input params.
 
         Parameters


### PR DESCRIPTION
When calling the joint distribution's logpdf, it currently always returns an array. This causes an error when trying to write to the output file when a sampler that writes blob data (like emcee) is used. The logprior is in the blob data, which currently is an array of arrays. Consequently, hdf5 sees the logprior data type as a python object, which it doesn't know how to write.

The bug was introduced when we tried to speed up the joint distribution by not converting to field arrays using `_ensure_fieldarray`. That function did two things: determine if an atomic data type should be returned based on the input, and converted to field array.

To fix, this patch breaks the atomic determination into its own function, so it can be called without the speed hit you get from converting the input to a field array. The output is then used to determine what to return.