### PR TITLE
add .ini support in pycbc_brute_bank

### DIFF
--- a/bin/bank/pycbc_brute_bank
+++ b/bin/bank/pycbc_brute_bank
@@ -385,6 +385,8 @@ def draw(rtype):
             l &= mc > args.min_mchirp
 
     else:
+        # Apply boundary conditions.
+        params = dists_joint.apply_boundary_conditions(**params)
         # Apply constraints.
         l = dists_joint.contains(params)
         # Apply boundaries.
@@ -465,6 +467,7 @@ while tau0s < args.tau0_end:
                          region, kloop, r, len(bank), kconv, len(bank) - blen)
             if uconv:
                 logging.info('Ratio of convergences: %2.3f' % (kconv / (uconv)))
+                logging.info('Progress: {:.0%} completed'.format(tau0s/args.tau0_end))
 
             if kloop == 1:
                 okconv = kconv

--- a/bin/bank/pycbc_brute_bank
+++ b/bin/bank/pycbc_brute_bank
@@ -1,8 +1,29 @@
 #!/usr/bin/env python
+
+# Copyright (C) 2017-2020 Alex Nitz, Duncan Macleod
+# Copyright (C) 2022 Shichao Wu, Alex Nitz
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
 """Generate a bank of templates using a brute force stochastic method.
 """
 import numpy, h5py, logging, argparse, numpy.random, sys
 import pycbc.waveform, pycbc.filter, pycbc.types, pycbc.psd, pycbc.fft, pycbc.conversions
+from pycbc.distributions import read_params_from_config
+from pycbc.distributions.utils import draw_samples_from_config
+from pycbc.distributions.bounded import get_param_bounds_from_config
 from scipy.stats import gaussian_kde
 
 parser = argparse.ArgumentParser(description=__doc__)
@@ -11,11 +32,13 @@ parser.add_argument('--output-file', required=True,
     help='Output file name for template bank.')
 parser.add_argument('--input-file',
     help='Bank to use as a starting point.')
-parser.add_argument('--params', required=True,
+parser.add_argument('--input-config',
+    help='Draw parameters from the given configure file.')
+parser.add_argument('--params',
     help='list of paramaters to use', nargs='+')
-parser.add_argument('--min', required=True,
+parser.add_argument('--min',
     help='list of the minimum parameter values', nargs='+', type=float)
-parser.add_argument('--max',  required=True,
+parser.add_argument('--max',
     help='list of the maximum parameter values', nargs='+', type=float)
 parser.add_argument('--approximant',  required=True,
     help='The waveform approximant to place')
@@ -45,6 +68,18 @@ args = parser.parse_args()
 pycbc.init_logging(args.verbose)
 numpy.random.seed(args.seed)
 
+
+# Read the .ini file if it's in the input.
+if args.input_config is not None:
+    config_parser = pycbc.types.config.InterpolatingConfigParser()
+    file = open(args.input_config, 'r')
+    config_parser.read_file(file)
+    file.close()
+
+    variable_args, static_args = read_params_from_config(
+        config_parser, prior_section='prior',
+        vargs_section='variable_params',
+        sargs_section='static_params')
 
 fdict = {}
 if args.fixed_params:
@@ -123,7 +158,6 @@ class TriangleBank(object):
             d.params = self.waveforms[c].params
             d.s = self.waveforms[c].s
             self.waveforms[c] = d
-
 
     def tau0(self):
         if not hasattr(self, 't0'):
@@ -278,8 +312,16 @@ def draw(rtype):
     params = {}
 
     if rtype == 'uniform':
-        for name, pmin, pmax in zip(args.params, args.min, args.max):
-            params[name] = numpy.random.uniform(pmin, pmax, size=size)
+        if args.input_config is None:
+            for name, pmin, pmax in zip(args.params, args.min, args.max):
+                params[name] = numpy.random.uniform(pmin, pmax, size=size)
+        else:
+            # `draw_samples_from_config` has its own fixed seed, so must overwrite it.
+            random_seed = numpy.random.randint(low=0, high=2**32-1)
+            samples = draw_samples_from_config(args.input_config, size, random_seed)
+            for name in samples.fieldnames:
+                params[name] = samples[name]
+
     elif rtype == 'kde':
         trail = 300
         if trail > len(bank):
@@ -287,6 +329,11 @@ def draw(rtype):
         p = bank.keys()
         p = [k for k in p if k not in fdict]
         p.remove('approximant')
+        if 'q' in static_args:
+            # For the fixed mass ratio, it will encounter `singular matrix` issue
+            # when calculate the covariance matrix in KDE method, so ignore it.
+            p.remove('mass1')
+            p.remove('mass2')
         bdata = numpy.array([bank.key(k)[-trail:] for k in p])
 
         kde = gaussian_kde(bdata)
@@ -294,13 +341,25 @@ def draw(rtype):
         for k, v in zip(p, points):
             params[k] = v
 
+        if 'q' in static_args:
+            params['mass1'] = pycbc.conversions.mass1_from_mtotal_q(params['total_mass'], static_args['q'])
+            params['mass2'] = pycbc.conversions.mass2_from_mtotal_q(params['total_mass'], static_args['q'])
+
     params['approximant'] = numpy.array([args.approximant]*size)
 
-    # Filter out stuff
+    # Filter out stuff (kde method may also generate samples outside boundaries).
     l = None
-    for name, pmin, pmax in zip(args.params, args.min, args.max):
-        nl = (params[name] < pmax) & (params[name] > pmin)
-        l = (nl & l) if l is not None else nl
+    if args.input_config is None:
+        for name, pmin, pmax in zip(args.params, args.min, args.max):
+            nl = (params[name] < pmax) & (params[name] > pmin)
+            l = (nl & l) if l is not None else nl
+    else:
+        for name in variable_args:
+            param_bounds = get_param_bounds_from_config(config_parser, 'prior', name, name)
+            pmin = param_bounds.min
+            pmax = param_bounds.max
+            nl = (params[name] < pmax) & (params[name] > pmin)
+            l = (nl & l) if l is not None else nl
 
     if args.max_q:
         q =  numpy.maximum(params['mass1'] / params['mass2'], params['mass2'] / params['mass1'])
@@ -336,6 +395,7 @@ def cdraw(rtype, ts, te):
 
     i = 0
     while len(p[list(p.keys())[0]]) < size:
+
         tp = draw(rtype)
         for k in p:
             p[k] = numpy.concatenate([p[k], tp[k]])
@@ -349,7 +409,6 @@ def cdraw(rtype, ts, te):
         i += 1
         if i > 1000:
             break
-
 
     if len(p[list(p.keys())[0]]) == 0:
         return None

--- a/bin/bank/pycbc_brute_bank
+++ b/bin/bank/pycbc_brute_bank
@@ -25,7 +25,6 @@ from pycbc import transforms
 from pycbc.distributions import read_params_from_config, read_distributions_from_config
 from pycbc.distributions import read_constraints_from_config, JointDistribution
 from pycbc.distributions.utils import draw_samples_from_config, prior_from_config
-from pycbc.distributions.bounded import get_param_bounds_from_config
 from scipy.stats import gaussian_kde
 
 parser = argparse.ArgumentParser(description=__doc__)
@@ -385,16 +384,7 @@ def draw(rtype):
             l &= mc > args.min_mchirp
 
     else:
-        # Apply boundary conditions.
-        params = dists_joint.apply_boundary_conditions(**params)
-        # Apply constraints.
-        l = dists_joint.contains(params)
-        # Apply boundaries.
-        for name in variable_args:
-            param_bounds = get_param_bounds_from_config(config_parser, 'prior', name, name)
-            pmin = param_bounds.min
-            pmax = param_bounds.max
-            l &= (params[name] < pmax) & (params[name] > pmin)
+        l = dists_joint.__contains__(params)
 
     for k in params:
         params[k] = params[k][l]

--- a/bin/bank/pycbc_brute_bank
+++ b/bin/bank/pycbc_brute_bank
@@ -384,7 +384,7 @@ def draw(rtype):
             l &= mc > args.min_mchirp
 
     else:
-        l = dists_joint.__contains__(params)
+        l = dists_joint.contains(params)
 
     for k in params:
         params[k] = params[k][l]

--- a/bin/bank/pycbc_brute_bank
+++ b/bin/bank/pycbc_brute_bank
@@ -329,7 +329,7 @@ def draw(rtype):
         p = bank.keys()
         p = [k for k in p if k not in fdict]
         p.remove('approximant')
-        if 'q' in static_args:
+        if args.input_config is not None and 'q' in static_args:
             # For the fixed mass ratio, it will encounter `singular matrix` issue
             # when calculate the covariance matrix in KDE method, so ignore it.
             p.remove('mass1')
@@ -341,7 +341,7 @@ def draw(rtype):
         for k, v in zip(p, points):
             params[k] = v
 
-        if 'q' in static_args:
+        if args.input_config is not None and 'q' in static_args:
             params['mass1'] = pycbc.conversions.mass1_from_mtotal_q(params['total_mass'], static_args['q'])
             params['mass2'] = pycbc.conversions.mass2_from_mtotal_q(params['total_mass'], static_args['q'])
 

--- a/bin/bank/pycbc_brute_bank
+++ b/bin/bank/pycbc_brute_bank
@@ -352,11 +352,11 @@ def draw(rtype):
             params[k] = v
 
         # Apply `waveform_transforms` defined in the .ini file to samples.
-        if waveform_transforms is not None:
+        if args.input_config is not None and waveform_transforms is not None:
             # Add `static_args` back, some transformations may need them.
             if static_args is not None:
                 for k in static_args.keys():
-                    params[k] = numpy.array(static_args[k]*size)
+                    params[k] = numpy.array([static_args[k]]*size)
             params = transforms.apply_transforms(params, waveform_transforms)
 
     params['approximant'] = numpy.array([args.approximant]*size)

--- a/bin/bank/pycbc_brute_bank
+++ b/bin/bank/pycbc_brute_bank
@@ -24,7 +24,8 @@ import pycbc.waveform, pycbc.filter, pycbc.types, pycbc.psd, pycbc.fft, pycbc.co
 from pycbc import transforms
 from pycbc.distributions import read_params_from_config, read_distributions_from_config
 from pycbc.distributions import read_constraints_from_config, JointDistribution
-from pycbc.distributions.utils import draw_samples_from_config
+from pycbc.distributions.utils import draw_samples_from_config, prior_from_config
+from pycbc.distributions.bounded import get_param_bounds_from_config
 from scipy.stats import gaussian_kde
 
 parser = argparse.ArgumentParser(description=__doc__)
@@ -86,13 +87,7 @@ if args.input_config is not None:
         waveform_transforms = transforms.read_transforms_from_config(
                 config_parser, 'waveform_transforms')
 
-    dists = read_distributions_from_config(config_parser)
-    constraints = read_constraints_from_config(
-                    cp=config_parser, transforms=waveform_transforms,
-                    static_args=static_args)
-    dists_joint = JointDistribution(
-                    variable_args, *dists,
-                    **{"constraints": constraints})
+    dists_joint = prior_from_config(cp=config_parser)
 
 fdict = {}
 if args.fixed_params:
@@ -334,6 +329,10 @@ def draw(rtype):
             samples = draw_samples_from_config(args.input_config, size, random_seed)
             for name in samples.fieldnames:
                 params[name] = samples[name]
+            # Add `static_args` back.
+            if static_args is not None:
+                for k in static_args.keys():
+                    params[k] = numpy.array([static_args[k]]*size)
 
     elif rtype == 'kde':
         trail = 300
@@ -386,7 +385,14 @@ def draw(rtype):
             l &= mc > args.min_mchirp
 
     else:
+        # Apply constraints.
         l = dists_joint.contains(params)
+        # Apply boundaries.
+        for name in variable_args:
+            param_bounds = get_param_bounds_from_config(config_parser, 'prior', name, name)
+            pmin = param_bounds.min
+            pmax = param_bounds.max
+            l &= (params[name] < pmax) & (params[name] > pmin)
 
     for k in params:
         params[k] = params[k][l]

--- a/bin/bank/pycbc_brute_bank
+++ b/bin/bank/pycbc_brute_bank
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
-# Copyright (C) 2017-2020 Alex Nitz, Duncan Macleod
-# Copyright (C) 2022 Shichao Wu, Alex Nitz
+# Copyright (C) 2017 Alex Nitz, Duncan Macleod
+#               2022 Shichao Wu
 #
 # This program is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License as published by the
@@ -21,9 +21,10 @@
 """
 import numpy, h5py, logging, argparse, numpy.random, sys
 import pycbc.waveform, pycbc.filter, pycbc.types, pycbc.psd, pycbc.fft, pycbc.conversions
-from pycbc.distributions import read_params_from_config
+from pycbc import transforms
+from pycbc.distributions import read_params_from_config, read_distributions_from_config
+from pycbc.distributions import read_constraints_from_config, JointDistribution
 from pycbc.distributions.utils import draw_samples_from_config
-from pycbc.distributions.bounded import get_param_bounds_from_config
 from scipy.stats import gaussian_kde
 
 parser = argparse.ArgumentParser(description=__doc__)
@@ -80,6 +81,18 @@ if args.input_config is not None:
         config_parser, prior_section='prior',
         vargs_section='variable_params',
         sargs_section='static_params')
+
+    if any(config_parser.get_subsections('waveform_transforms')):
+        waveform_transforms = transforms.read_transforms_from_config(
+                config_parser, 'waveform_transforms')
+
+    dists = read_distributions_from_config(config_parser)
+    constraints = read_constraints_from_config(
+                    cp=config_parser, transforms=waveform_transforms,
+                    static_args=static_args)
+    dists_joint = JointDistribution(
+                    variable_args, *dists,
+                    **{"constraints": constraints})
 
 fdict = {}
 if args.fixed_params:
@@ -329,11 +342,8 @@ def draw(rtype):
         p = bank.keys()
         p = [k for k in p if k not in fdict]
         p.remove('approximant')
-        if args.input_config is not None and 'q' in static_args:
-            # For the fixed mass ratio, it will encounter `singular matrix` issue
-            # when calculate the covariance matrix in KDE method, so ignore it.
-            p.remove('mass1')
-            p.remove('mass2')
+        if args.input_config is not None:
+            p = variable_args
         bdata = numpy.array([bank.key(k)[-trail:] for k in p])
 
         kde = gaussian_kde(bdata)
@@ -341,9 +351,13 @@ def draw(rtype):
         for k, v in zip(p, points):
             params[k] = v
 
-        if args.input_config is not None and 'q' in static_args:
-            params['mass1'] = pycbc.conversions.mass1_from_mtotal_q(params['total_mass'], static_args['q'])
-            params['mass2'] = pycbc.conversions.mass2_from_mtotal_q(params['total_mass'], static_args['q'])
+        # Apply `waveform_transforms` defined in the .ini file to samples.
+        if waveform_transforms is not None:
+            # Add `static_args` back, some transformations may need them.
+            if static_args is not None:
+                for k in static_args.keys():
+                    params[k] = numpy.array(static_args[k]*size)
+            params = transforms.apply_transforms(params, waveform_transforms)
 
     params['approximant'] = numpy.array([args.approximant]*size)
 
@@ -353,30 +367,26 @@ def draw(rtype):
         for name, pmin, pmax in zip(args.params, args.min, args.max):
             nl = (params[name] < pmax) & (params[name] > pmin)
             l = (nl & l) if l is not None else nl
+
+        if args.max_q:
+            q =  numpy.maximum(params['mass1'] / params['mass2'], params['mass2'] / params['mass1'])
+            l &= q < args.max_q
+
+        if args.max_mtotal:
+            l &= params['mass1'] + params['mass2'] < args.max_mtotal
+
+        if args.max_mchirp:
+            from pycbc.conversions import mchirp_from_mass1_mass2
+            mc = mchirp_from_mass1_mass2(params['mass1'], params['mass2'])
+            l &= mc < args.max_mchirp
+
+        if args.min_mchirp:
+            from pycbc.conversions import mchirp_from_mass1_mass2
+            mc = mchirp_from_mass1_mass2(params['mass1'], params['mass2'])
+            l &= mc > args.min_mchirp
+
     else:
-        for name in variable_args:
-            param_bounds = get_param_bounds_from_config(config_parser, 'prior', name, name)
-            pmin = param_bounds.min
-            pmax = param_bounds.max
-            nl = (params[name] < pmax) & (params[name] > pmin)
-            l = (nl & l) if l is not None else nl
-
-    if args.max_q:
-        q =  numpy.maximum(params['mass1'] / params['mass2'], params['mass2'] / params['mass1'])
-        l &= q < args.max_q
-
-    if args.max_mtotal:
-        l &= params['mass1'] + params['mass2'] < args.max_mtotal
-
-    if args.max_mchirp:
-        from pycbc.conversions import mchirp_from_mass1_mass2
-        mc = mchirp_from_mass1_mass2(params['mass1'], params['mass2'])
-        l &= mc < args.max_mchirp
-
-    if args.min_mchirp:
-        from pycbc.conversions import mchirp_from_mass1_mass2
-        mc = mchirp_from_mass1_mass2(params['mass1'], params['mass2'])
-        l &= mc > args.min_mchirp
+        l = dists_joint.contains(params)
 
     for k in params:
         params[k] = params[k][l]

--- a/bin/inference/pycbc_inference_plot_posterior
+++ b/bin/inference/pycbc_inference_plot_posterior
@@ -44,6 +44,7 @@ from pycbc import __version__
 from pycbc import conversions
 from pycbc.workflow import WorkflowConfigParser
 from pycbc.inference import (option_utils, io)
+from pycbc.distributions.utils import prior_from_config
 
 from pycbc.results.scatter_histograms import create_multidim_plot
 
@@ -161,7 +162,7 @@ if opts.plot_prior is not None:
                          "--plot-prior")
     logging.info("Loading prior")
     cp = WorkflowConfigParser(opts.plot_prior)
-    prior = option_utils.prior_from_config(cp)
+    prior = prior_from_config(cp)
     logging.info("Drawing samples from prior")
     prior_samples = prior.rvs(opts.prior_nsamples)
     # we'll just use the first file for metadata

--- a/bin/inference/pycbc_inference_plot_prior
+++ b/bin/inference/pycbc_inference_plot_prior
@@ -30,8 +30,8 @@ from matplotlib import pyplot as plt
 import pycbc
 from pycbc import __version__
 from pycbc import (distributions, results, waveform)
-from pycbc.inference.option_utils import (ParseParametersArg,
-                                          prior_from_config)
+from pycbc.inference.option_utils import ParseParametersArg
+from pycbc.distributions.utils import prior_from_config
 from pycbc.workflow import WorkflowConfigParser
 from pycbc.results.scatter_histograms import create_multidim_plot
 

--- a/bin/inference/pycbc_validate_test_posterior
+++ b/bin/inference/pycbc_validate_test_posterior
@@ -7,7 +7,7 @@ import numpy
 import argparse
 from matplotlib import use; use('Agg')
 import pylab
-from pycbc.inference.option_utils import prior_from_config
+from pycbc.distributions.utils import prior_from_config
 from pycbc.inference import models, io
 from scipy.stats import gaussian_kde, ks_2samp
 from pycbc.io import FieldArray

--- a/pycbc/distributions/joint.py
+++ b/pycbc/distributions/joint.py
@@ -247,7 +247,7 @@ class JointDistribution(object):
             conditions, boundaries, and constraints. This method is different
             from `contains`, that method only check the constraints. When you
             have a `JointDistribution` instance "joint_dist" and "params", you
-            can just use `in` operator to check, such as "params in joint_dist".
+            can use `in` operator to check, such as "params in joint_dist".
 
         Parameters
         ----------
@@ -260,20 +260,20 @@ class JointDistribution(object):
             If params was an array, or if params a dictionary and one or more
             of the parameters are arrays, will return an array of booleans.
             Otherwise, a boolean.
-        """     
+        """
         params = self.apply_boundary_conditions(**params)
-        l = True
+        result = True
         for dist in self.distributions:
             param_name = dist._params[0]
             contain_array = numpy.ones(len(params[param_name]), dtype=bool)
-            # `__contains__` in `pycbc.distributions.bounded` 
+            # `__contains__` in `pycbc.distributions.bounded`
             # can't handle array.
             for k in params[param_name]:
-                index = numpy.where(params[param_name]==k)[0][0]
-                contain_array[index] = {param_name:k} in dist
-            l &= numpy.array(contain_array)
-        l &= self.contains(params)
-        return l
+                index = numpy.where(params[param_name] == k)[0][0]
+                contain_array[index] = {param_name: k} in dist
+            result &= numpy.array(contain_array)
+        result &= self.contains(params)
+        return result
 
     def __call__(self, **params):
         """Evaluate joint distribution for parameters.

--- a/pycbc/distributions/joint.py
+++ b/pycbc/distributions/joint.py
@@ -264,8 +264,8 @@ class JointDistribution(object):
         for dist in self.distributions:
             param_name = dist._params[0]
             contain_array = numpy.ones(len(params[param_name]), dtype=bool)
-            # TODO: enable `__contains__` in `pycbc.distributions.bounded` 
-            #       to handle array-like input.
+            # note: enable `__contains__` in `pycbc.distributions.bounded`
+            # to handle array-like input, it doesn't work now.
             for k in params[param_name]:
                 index = numpy.where(params[param_name] == k)[0][0]
                 contain_array[index] = {param_name: k} in dist

--- a/pycbc/distributions/joint.py
+++ b/pycbc/distributions/joint.py
@@ -262,7 +262,7 @@ class JointDistribution(object):
         params = self.apply_boundary_conditions(**params)
         result = True
         for dist in self.distributions:
-            param_name = dist._params[0]
+            param_name = dist.params[0]
             contain_array = numpy.ones(len(params[param_name]), dtype=bool)
             # note: enable `__contains__` in `pycbc.distributions.bounded`
             # to handle array-like input, it doesn't work now.

--- a/pycbc/distributions/joint.py
+++ b/pycbc/distributions/joint.py
@@ -160,6 +160,36 @@ class JointDistribution(object):
         return params
 
     @staticmethod
+    def _return_atomic(params):
+        """Determines if an array or atomic value should be returned given a
+        set of input params.
+
+        Parameters
+        ----------
+        params : dict, numpy.record, array, or FieldArray
+            The input to evaluate.
+
+        Returns
+        -------
+        bool :
+            Whether or not functions run on the parameters should be returned
+            as atomic types or not.
+        """
+        if isinstance(params, dict):
+            return not any(isinstance(val, numpy.ndarray)
+                           for val in params.values())
+        elif isinstance(params, numpy.record):
+            return True
+        elif isinstance(params, numpy.ndarray):
+            return False
+            params = params.view(type=FieldArray)
+        elif isinstance(params, FieldArray):
+            return False
+        else:
+            raise ValueError("params must be either dict, FieldArray, "
+                             "record, or structured array")
+
+    @staticmethod
     def _ensure_fieldarray(params):
         """Ensures the given params are a ``FieldArray``.
 
@@ -171,29 +201,21 @@ class JointDistribution(object):
 
         Returns
         -------
-        params : FieldArray
+        FieldArray
             The given values as a FieldArray.
-        return_atomic : bool
-            Whether or not functions run on the parameters should be returned
-            as atomic types or not.
         """
         if isinstance(params, dict):
-            return_atomic = not any(isinstance(val, numpy.ndarray)
-                                    for val in params.values())
-            params = FieldArray.from_kwargs(**params)
+            return FieldArray.from_kwargs(**params)
         elif isinstance(params, numpy.record):
-            return_atomic = True
-            params = FieldArray.from_records(tuple(params),
-                                             names=params.dtype.names)
+            return FieldArray.from_records(tuple(params),
+                                           names=params.dtype.names)
         elif isinstance(params, numpy.ndarray):
-            return_atomic = False
-            params = params.view(type=FieldArray)
+            return params.view(type=FieldArray)
         elif isinstance(params, FieldArray):
-            return_atomic = False
+            return params
         else:
             raise ValueError("params must be either dict, FieldArray, "
                              "record, or structured array")
-        return params, return_atomic
 
     def contains(self, params):
         """Evaluates whether the given parameters satisfy the constraints.
@@ -210,7 +232,8 @@ class JointDistribution(object):
             of the parameters are arrays, will return an array of booleans.
             Otherwise, a boolean.
         """
-        params, return_atomic = self._ensure_fieldarray(params)
+        params = self._ensure_fieldarray(params)
+        return_atomic = self._return_atomic(params)
         # convert params to a field array if it isn't one
         result = numpy.ones(params.shape, dtype=bool)
         for constraint in self._constraints:
@@ -222,9 +245,10 @@ class JointDistribution(object):
     def __call__(self, **params):
         """Evaluate joint distribution for parameters.
         """
+        return_atomic = self._return_atomic(params)
         # check if statisfies constraints
         if len(self._constraints) != 0:
-            parray, return_atomic = self._ensure_fieldarray(params)
+            parray = self._ensure_fieldarray(params)
             isin = self.contains(parray)
             if not isin.any():
                 if return_atomic:
@@ -242,7 +266,7 @@ class JointDistribution(object):
         if len(self._constraints) != 0:
             logp += numpy.log(isin.astype(float))
 
-        if numpy.isscalar(logp):
+        if return_atomic:
             logp = logp.item()
 
         return logp - self._logpdf_scale

--- a/pycbc/distributions/joint.py
+++ b/pycbc/distributions/joint.py
@@ -122,7 +122,7 @@ class JointDistribution(object):
             samples = FieldArray.from_kwargs(**samples)
 
             # evaluate constraints
-            result = self.contains(samples)
+            result = self.within_constraints(samples)
 
             # set new scaling factor for prior to be
             # the fraction of acceptances in random sampling of entire space
@@ -217,7 +217,7 @@ class JointDistribution(object):
             raise ValueError("params must be either dict, FieldArray, "
                              "record, or structured array")
 
-    def contains(self, params):
+    def within_constraints(self, params):
         """Evaluates whether the given parameters satisfy the constraints.
 
         Parameters
@@ -242,12 +242,10 @@ class JointDistribution(object):
             result = result.item()
         return result
 
-    def __contains__(self, params):
+    def contains(self, params):
         """Evaluates whether the given parameters satisfy the boundary
             conditions, boundaries, and constraints. This method is different
-            from `contains`, that method only check the constraints. When you
-            have a `JointDistribution` instance "joint_dist" and "params", you
-            can use `in` operator to check, such as "params in joint_dist".
+            from `within_constraints`, that method only check the constraints.
 
         Parameters
         ----------
@@ -266,13 +264,13 @@ class JointDistribution(object):
         for dist in self.distributions:
             param_name = dist._params[0]
             contain_array = numpy.ones(len(params[param_name]), dtype=bool)
-            # `__contains__` in `pycbc.distributions.bounded`
-            # can't handle array.
+            # TODO: enable `__contains__` in `pycbc.distributions.bounded` 
+            #       to handle array-like input.
             for k in params[param_name]:
                 index = numpy.where(params[param_name] == k)[0][0]
                 contain_array[index] = {param_name: k} in dist
             result &= numpy.array(contain_array)
-        result &= self.contains(params)
+        result &= self.within_constraints(params)
         return result
 
     def __call__(self, **params):
@@ -282,7 +280,7 @@ class JointDistribution(object):
         # check if statisfies constraints
         if len(self._constraints) != 0:
             parray = self._ensure_fieldarray(params)
-            isin = self.contains(parray)
+            isin = self.within_constraints(parray)
             if not isin.any():
                 if return_atomic:
                     out = -numpy.inf
@@ -324,7 +322,7 @@ class JointDistribution(object):
                 for param in dist.params:
                     scratch[param] = draw[param]
             # apply any constraints
-            keep = self.contains(scratch)
+            keep = self.within_constraints(scratch)
             nkeep = keep.sum()
             kmin = size - remaining
             kmax = min(nkeep, remaining)

--- a/pycbc/distributions/utils.py
+++ b/pycbc/distributions/utils.py
@@ -73,6 +73,7 @@ def prior_from_config(cp, prior_section='prior'):
     return distributions.JointDistribution(variable_params, *dists,
                                            **{"constraints": constraints})
 
+
 def draw_samples_from_config(path, num=1, seed=150914):
     r""" Generate sampling points from a standalone .ini file.
 
@@ -125,11 +126,10 @@ def draw_samples_from_config(path, num=1, seed=150914):
     samples = prior_dists.rvs(size=int(num))
 
     # Read waveform_transforms to apply to priors from the config file
+    waveform_transforms = None
     if any(config_parser.get_subsections('waveform_transforms')):
         waveform_transforms = transforms.read_transforms_from_config(
                 config_parser, 'waveform_transforms')
-    else:
-        waveform_transforms = None
 
     # Apply parameter transformation.
     if waveform_transforms is not None:

--- a/pycbc/distributions/utils.py
+++ b/pycbc/distributions/utils.py
@@ -124,6 +124,13 @@ def draw_samples_from_config(path, num=1, seed=150914):
     # Draw samples from prior distribution.
     samples = prior_dists.rvs(size=int(num))
 
+    # Read waveform_transforms to apply to priors from the config file
+    if any(config_parser.get_subsections('waveform_transforms')):
+        waveform_transforms = transforms.read_transforms_from_config(
+                config_parser, 'waveform_transforms')
+    else:
+        waveform_transforms = None
+
     # Apply parameter transformation.
     if waveform_transforms is not None:
         samples = transforms.apply_transforms(samples, waveform_transforms)

--- a/pycbc/distributions/utils.py
+++ b/pycbc/distributions/utils.py
@@ -125,14 +125,10 @@ def draw_samples_from_config(path, num=1, seed=150914):
     # Draw samples from prior distribution.
     samples = prior_dists.rvs(size=int(num))
 
-    # Read waveform_transforms to apply to priors from the config file
-    waveform_transforms = None
+    # Apply parameter transformation.
     if any(config_parser.get_subsections('waveform_transforms')):
         waveform_transforms = transforms.read_transforms_from_config(
                 config_parser, 'waveform_transforms')
-
-    # Apply parameter transformation.
-    if waveform_transforms is not None:
         samples = transforms.apply_transforms(samples, waveform_transforms)
 
     return samples

--- a/pycbc/distributions/utils.py
+++ b/pycbc/distributions/utils.py
@@ -32,6 +32,47 @@ from pycbc import transforms
 from pycbc import distributions
 
 
+def prior_from_config(cp, prior_section='prior'):
+    """Loads a prior distribution from the given config file.
+
+    Parameters
+    ----------
+    cp : pycbc.workflow.WorkflowConfigParser
+        The config file to read.
+    sections : list of str, optional
+        The sections to retrieve the prior from. If ``None`` (the default),
+        will look in sections starting with 'prior'.
+
+    Returns
+    -------
+    distributions.JointDistribution
+        The prior distribution.
+    """
+
+    # Read variable and static parameters from the config file
+    variable_params, static_params = distributions.read_params_from_config(
+        cp, prior_section=prior_section, vargs_section='variable_params',
+        sargs_section='static_params')
+
+    # Read waveform_transforms to apply to priors from the config file
+    if any(cp.get_subsections('waveform_transforms')):
+        waveform_transforms = transforms.read_transforms_from_config(
+                cp, 'waveform_transforms')
+    else:
+        waveform_transforms = None
+
+    # Read constraints to apply to priors from the config file
+    constraints = distributions.read_constraints_from_config(
+        cp, transforms=waveform_transforms, static_args=static_params)
+
+    # Get PyCBC distribution instances for each variable parameter in the
+    # config file
+    dists = distributions.read_distributions_from_config(cp, prior_section)
+
+    # construct class that will return draws from the prior
+    return distributions.JointDistribution(variable_params, *dists,
+                                           **{"constraints": constraints})
+
 def draw_samples_from_config(path, num=1, seed=150914):
     r""" Generate sampling points from a standalone .ini file.
 
@@ -78,34 +119,13 @@ def draw_samples_from_config(path, num=1, seed=150914):
     config_parser.read_file(file)
     file.close()
 
-    # Get the vairable arguments from the .ini file.
-    variable_args, static_args = distributions.read_params_from_config(
-        config_parser, prior_section='prior', vargs_section='variable_params',
-        sargs_section='static_params')
-    constraints = distributions.read_constraints_from_config(
-        config_parser, static_args=static_args)
-
-    if any(config_parser.get_subsections('waveform_transforms')):
-        waveform_transforms = transforms.read_transforms_from_config(
-            config_parser, 'waveform_transforms')
-    else:
-        waveform_transforms = None
-
-    # Get prior distribution for each variable parameter.
-    dists = distributions.read_distributions_from_config(config_parser)
-
     # Construct class that will draw the samples.
-    randomsampler = distributions.JointDistribution(
-                                variable_args, *dists,
-                                **{"constraints": constraints})
-
+    prior_dists = prior_from_config(cp=config_parser)
     # Draw samples from prior distribution.
-    samples = randomsampler.rvs(size=int(num))
+    samples = prior_dists.rvs(size=int(num))
 
     # Apply parameter transformation.
     if waveform_transforms is not None:
         samples = transforms.apply_transforms(samples, waveform_transforms)
-    else:
-        pass
 
     return samples

--- a/pycbc/inference/option_utils.py
+++ b/pycbc/inference/option_utils.py
@@ -18,10 +18,7 @@
 """
 
 import argparse
-
 from pycbc import waveform
-from pycbc import distributions
-
 
 # -----------------------------------------------------------------------------
 #

--- a/pycbc/inference/option_utils.py
+++ b/pycbc/inference/option_utils.py
@@ -362,34 +362,3 @@ def add_density_option_group(parser):
         help="Pass the given argrument, value pairs to the KDE function "
              "(either scipy's or kombine's) when setting it up.")
     return density_group
-
-
-def prior_from_config(cp, prior_section='prior'):
-    """Loads a prior distribution from the given config file.
-
-    Parameters
-    ----------
-    cp : pycbc.workflow.WorkflowConfigParser
-        The config file to read.
-    sections : list of str, optional
-        The sections to retrieve the prior from. If ``None`` (the default),
-        will look in sections starting with 'prior'.
-
-    Returns
-    -------
-    distributions.JointDistribution
-        The prior distribution.
-    """
-    # Read variable and static parameters from the config file
-    variable_params, static_params = distributions.read_params_from_config(
-        cp, prior_section=prior_section, vargs_section='variable_params',
-        sargs_section='static_params')
-    # Read constraints to apply to priors from the config file
-    constraints = distributions.read_constraints_from_config(
-        cp, static_args=static_params)
-    # Get PyCBC distribution instances for each variable parameter in the
-    # config file
-    dists = distributions.read_distributions_from_config(cp, prior_section)
-    # construct class that will return draws from the prior
-    return distributions.JointDistribution(variable_params, *dists,
-                                           **{"constraints": constraints})


### PR DESCRIPTION
@ahnitz Allow `pycbc_brute_bank` to use the `.ini` file, I have run bank generation using this PR for 10 mins, no problem, when this PR is in good shape, I will test it by entire template bank generation. I will also update/clean the read config function in this PR soon.