### PR TITLE
significance.py license fix

### DIFF
--- a/pycbc/events/significance.py
+++ b/pycbc/events/significance.py
@@ -9,6 +9,9 @@
 # WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
 # Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #
 # =============================================================================


### PR DESCRIPTION
As pointed out by @spxiwh on #4004, the license was truncated incorrectly.