### PR TITLE
add multi signal support to the single_template model

### DIFF
--- a/examples/inference/multisignal/get.sh
+++ b/examples/inference/multisignal/get.sh
@@ -1,0 +1,6 @@
+for ifo in H-H1 L-L1 V-V1
+do
+    file=${ifo}_LOSC_CLN_4_V1-1187007040-2048.gwf
+    test -f ${file} && continue
+    curl -O --silent https://dcc.ligo.org/public/0146/P1700349/001/${file}
+done

--- a/examples/inference/multisignal/single.ini
+++ b/examples/inference/multisignal/single.ini
@@ -1,0 +1,74 @@
+[model]
+name = multi_signal
+submodels = event1 event2
+
+[event1__model]
+name = single_template
+sample_rate = 32768
+low-frequency-cutoff = 30.0
+marginalize_phase = false
+
+[event2__model]
+name = single_template
+sample_rate = 32768
+low-frequency-cutoff = 30.0
+marginalize_phase = false
+
+[event1_event2__data]
+instruments = H1 L1 V1
+analysis-start-time = 1187008482
+analysis-end-time = 1187008892
+psd-estimation = median
+psd-segment-length = 16
+psd-segment-stride = 8
+psd-inverse-length = 16
+pad-data = 8
+channel-name = H1:LOSC-STRAIN L1:LOSC-STRAIN V1:LOSC-STRAIN
+frame-files = H1:H-H1_LOSC_CLN_4_V1-1187007040-2048.gwf L1:L-L1_LOSC_CLN_4_V1-1187007040-2048.gwf V1:V-V1_LOSC_CLN_4_V1-1187007040-2048.gwf
+strain-high-pass = 15
+sample-rate = 2048
+
+[sampler]
+name = dynesty
+dlogz = 0.1
+nlive = 200
+
+[variable_params]
+; waveform parameters that will vary in MCMC
+tc =
+distance =
+coa_phase =
+inclination =
+
+[static_params]
+; waveform parameters that will not change in MCMC
+approximant = TaylorF2
+f_lower = 30
+mass1 = 1.3757
+mass2 = 1.3757
+
+#; we'll choose not to sample over these, but you could
+polarization = 0
+ra = 3.44615914
+dec = -0.40808407
+
+#; You could also set additional parameters if your waveform model supports / requires it.
+; spin1z = 0
+
+[prior-coa_phase]
+name = uniform_angle
+
+[prior-tc]
+; coalescence time prior
+name = uniform
+min-tc = 1187008882.4
+max-tc = 1187008882.5
+
+[prior-distance]
+#; following gives a uniform in volume
+name = uniform_radius
+min-distance = 10
+max-distance = 120
+
+[prior-inclination]
+name = sin_angle

--- a/examples/inference/multisignal/single.sh
+++ b/examples/inference/multisignal/single.sh
@@ -1,0 +1,7 @@
+pycbc_inference \
+--config-file `dirname "$0"`/single.ini \
+--nprocesses=1 \
+--output-file single.hdf \
+--seed 0 \
+--force \
+--verbose

--- a/pycbc/inference/models/hierarchical.py
+++ b/pycbc/inference/models/hierarchical.py
@@ -284,6 +284,7 @@ class HierarchicalModel(BaseModel):
                                        submodel_lbls))
         sparam_map = map_params(hpiter(cp.options('static_params'),
                                        submodel_lbls))
+
         # we'll need any waveform transforms for the initializing sub-models,
         # as the underlying models will receive the output of those transforms
         if any(cp.get_subsections('waveform_transforms')):
@@ -334,12 +335,14 @@ class HierarchicalModel(BaseModel):
             # so that the model doesn't raise an error looking for
             # prior sections. We'll then manually set the variable
             # params after the model is initialized
+
             subcp.add_section('variable_params')
             for param in vparam_map[lbl]:
                 subcp.set('static_params', param.subname, 'REPLACE')
             # add the outputs from the waveform transforms
             for param in wfparam_map[lbl]:
                 subcp.set('static_params', param.subname, 'REPLACE')
+
             # initialize
             submodel = read_from_config(subcp)
             # move the static params back to variable

--- a/pycbc/inference/models/hierarchical.py
+++ b/pycbc/inference/models/hierarchical.py
@@ -544,8 +544,9 @@ class MultiSignalModel(HierarchicalModel):
                                "for the MultiSignal model isn't supported by"
                                "any of the constituent models.".format(ctypes))
 
-        self.other_models = self.submodels.values()
+        self.other_models = self.submodels.copy()
         self.other_models.pop(self.primary_model)
+        self.other_models = list(self.other_models.values())
 
     def _loglikelihood(self):
         for lbl, model in self.submodels.items():

--- a/pycbc/inference/models/single_template.py
+++ b/pycbc/inference/models/single_template.py
@@ -87,10 +87,14 @@ class SingleTemplate(DistMarg, BaseGaussianNoise):
         df = data[self.detectors[0]].delta_f
         self.df = df
         p = self.static_params.copy()
+        for k in self.static_params:
+            if p[k] == 'REPLACE':
+                p.pop(k)
         if 'distance' in p:
             _ = p.pop('distance')
         if 'inclination' in p:
             _ = p.pop('inclination')
+
         hp, _ = get_fd_waveform(delta_f=df, distance=1, inclination=0, **p)
 
         # Extend template to high sample rate
@@ -188,8 +192,7 @@ class SingleTemplate(DistMarg, BaseGaussianNoise):
             The value of the log likelihood ratio.
         """
         # calculate <d-h|d-h> = <h|h> - 2<h|d> + <d|d> up to a constant
-        p = self.current_params.copy()
-        p.update(self.static_params)
+        p = self.current_params
         if self.pflag == 0:
             polarization = p['polarization']
         elif self.pflag == 1:

--- a/pycbc/inference/models/single_template.py
+++ b/pycbc/inference/models/single_template.py
@@ -162,6 +162,7 @@ class SingleTemplate(DistMarg, BaseGaussianNoise):
     def multi_loglikelihood(self, models):
         """ Calculate a multi-model (signal) likelihood
         """
+        models = [self] + models
         loglr = 0
         # handle sum[<d|h_i> - 0.5 <h_i|h_i>]
         for m in models:

--- a/pycbc/inference/models/tools.py
+++ b/pycbc/inference/models/tools.py
@@ -89,6 +89,7 @@ class DistMarg():
         self.distance_interpolator = None
 
         marginalize_distance = str_to_bool(marginalize_distance)
+        self.marginalize_distance = marginalize_distance
         if not marginalize_distance:
             return variable_params, kwargs
 


### PR DESCRIPTION
This depends on #4032 and #4023 and adds multi signal support to the single template model. Similar to the gaussian noise model, at this time, it only supports the case of multiple instances of this model and not any mixed model cases. 