### PR TITLE
Some changes to OSG site to use condorIO

### DIFF
--- a/docs/workflow/initialization.rst
+++ b/docs/workflow/initialization.rst
@@ -187,7 +187,20 @@ Here is an example of the [workflow] section of a .ini file::
 Executable locations - the [executables] section
 =================================================
 
-This section should contain the names of each of the executables that will be used in the workflow and their locations. 
+This section should contain the names of each of the executables that will be used in the workflow and their locations.  The section might look something like::
+
+  [executables]
+  tmpltbank = /full/path/to/lalapps_tmpltbank
+  inspiral = /full/path/to/lalapps_inspiral
+
+Note that one can give gsiftp or http/https paths here and the workflow generator will download the code to the workflow directory when it is run.
+
+One can also give a URL indicating singularity as the scheme. This will indicate that the executable will be run within a singularity container, and therefore the executables would not be directly accessible from the head node::
+
+  [executables]
+  tmpltbank = https://github.com/full/url/to/lalapps_tmpltbank
+  inspiral = singularity:///full/path/to/lalapps_inspiral
+
 
 -------------------
 executable macros

--- a/pycbc/results/versioning.py
+++ b/pycbc/results/versioning.py
@@ -150,8 +150,9 @@ def get_code_version_numbers(cp):
         if value.scheme in ['gsiftp', 'http', 'https']:
             code_version_dict[exe_name] = "Using bundle downloaded from %s" % value
         elif value.scheme == 'singularity':
-            txt = "Executable run from a singularity image. See config file "
-                  "and site catalog for details of what image was used."
+            txt = ("Executable run from a singularity image. See config file "
+                   "and site catalog for details of what image was used."
+                  )
             code_version_dict[exe_name] = txt
         else:
             try:

--- a/pycbc/results/versioning.py
+++ b/pycbc/results/versioning.py
@@ -150,9 +150,10 @@ def get_code_version_numbers(cp):
         if value.scheme in ['gsiftp', 'http', 'https']:
             code_version_dict[exe_name] = "Using bundle downloaded from %s" % value
         elif value.scheme == 'singularity':
-            txt = ("Executable run from a singularity image. See config file "
-                   "and site catalog for details of what image was used."
-                  )
+            txt = (
+                "Executable run from a singularity image. See config file "
+                "and site catalog for details of what image was used."
+            )
             code_version_dict[exe_name] = txt
         else:
             try:

--- a/pycbc/results/versioning.py
+++ b/pycbc/results/versioning.py
@@ -162,7 +162,8 @@ def get_code_version_numbers(cp):
                     stderr=subprocess.STDOUT
                 )
             except subprocess.CalledProcessError:
-                version_string = "Executable fails on %s --version" % (value)
+                version_string = "Executable fails on {} --version"
+                version_string = version_string.format(value.path)
             except OSError:
                 version_string = "Executable doesn't seem to exist(!)"
             code_version_dict[exe_name] = version_string

--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -181,16 +181,18 @@ class Executable(pegasus_workflow.Executable):
 
         if exe_url.scheme in ['', 'file']:
             # NOTE: There could be a case where the exe is available at a
-            #       remote site, but not on the submit host. We could work to
-            #       allow this if it ever becomes a viable use-case. Some other
-            #       places (e.g. versioning) would have to be edited as well.
+            #       remote site, but not on the submit host. Currently allowed
+            #       for the OSG site, versioning will not work as planned if
+            #       we can't see the executable (can we perhaps run versioning
+            #       including singularity??)
 
             # Check that executables at file urls
             #  on the local site exist
-            if os.path.isfile(exe_url.path) is False:
-                raise TypeError("Failed to find %s executable "
-                                "at %s on site %s" % (name, exe_path,
-                                exe_site))
+            if not exe_site in ['osg']:
+                if os.path.isfile(exe_url.path) is False:
+                    raise TypeError("Failed to find %s executable "
+                                    "at %s on site %s" % (name, exe_path,
+                                    exe_site))
         else:
             # Could be http, gsiftp, etc. so it needs fetching if run now
             self.needs_fetching = True

--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -195,7 +195,7 @@ class Executable(pegasus_workflow.Executable):
         elif exe_url.scheme == 'singularity':
             # Will use an executable within a singularity container. Don't
             # need to do anything here, as I cannot easily check it exists.
-            pass
+            exe_path = exe_url.path
         else:
             # Could be http, gsiftp, etc. so it needs fetching if run now
             self.needs_fetching = True

--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -188,11 +188,14 @@ class Executable(pegasus_workflow.Executable):
 
             # Check that executables at file urls
             #  on the local site exist
-            if not exe_site in ['osg']:
-                if os.path.isfile(exe_url.path) is False:
-                    raise TypeError("Failed to find %s executable "
-                                    "at %s on site %s" % (name, exe_path,
-                                    exe_site))
+            if os.path.isfile(exe_url.path) is False:
+                raise TypeError("Failed to find %s executable "
+                                "at %s on site %s" % (name, exe_path,
+                                exe_site))
+        elif exe_url.scheme == 'singularity':
+            # Will use an executable within a singularity container. Don't
+            # need to do anything here, as I cannot easily check it exists.
+            pass
         else:
             # Could be http, gsiftp, etc. so it needs fetching if run now
             self.needs_fetching = True

--- a/pycbc/workflow/pegasus_sites.py
+++ b/pycbc/workflow/pegasus_sites.py
@@ -21,7 +21,7 @@ from urllib.request import pathname2url
 from Pegasus.api import Directory, FileServer, Site, Operation, Namespace
 from Pegasus.api import Arch, OS, SiteCatalog
 
-import pycbc.version
+from pycbc.version import last_version # noqa
 
 # NOTE urllib is weird. For some reason it only allows known schemes and will
 # give *wrong* results, rather then failing, if you use something like gsiftp
@@ -216,7 +216,7 @@ def add_osg_site(sitecat, cp):
                             "(HAS_LIGO_FRAMES =?= True) && "
                             "(IS_GLIDEIN =?= True)")
     cvmfs_loc = '"/cvmfs/singularity.opensciencegrid.org/pycbc/pycbc-el8:v'
-    cvmfs_loc += pycbc.version.last_release + '"'
+    cvmfs_loc += last_release + '"'
     site.add_profiles(Namespace.CONDOR, key="+SingularityImage",
                       value=cvmfs_loc)
     # On OSG failure rate is high

--- a/pycbc/workflow/pegasus_sites.py
+++ b/pycbc/workflow/pegasus_sites.py
@@ -21,6 +21,8 @@ from urllib.request import pathname2url
 from Pegasus.api import Directory, FileServer, Site, Operation, Namespace
 from Pegasus.api import Arch, OS, SiteCatalog
 
+from pycbc import version
+
 # NOTE urllib is weird. For some reason it only allows known schemes and will
 # give *wrong* results, rather then failing, if you use something like gsiftp
 # We can add schemes explicitly, as below, but be careful with this!
@@ -213,10 +215,10 @@ def add_osg_site(sitecat, cp):
                       value="(HAS_SINGULARITY =?= TRUE) && "
                             "(HAS_LIGO_FRAMES =?= True) && "
                             "(IS_GLIDEIN =?= True)")
-    # FIXME: This one should be moved to be latest release and/or chosen in the
-    #        config file.
+    cvmfs_loc = '"/cvmfs/singularity.opensciencegrid.org/pycbc/pycbc-el8:v'
+    cvmfs_loc += pycbc.version.last_release + '"'
     site.add_profiles(Namespace.CONDOR, key="+SingularityImage",
-                      value='"/cvmfs/singularity.opensciencegrid.org/pycbc/pycbc-el8:v2.0.3"')
+                      value=cvmfs_loc)
     # On OSG failure rate is high
     site.add_profiles(Namespace.DAGMAN, key="retry", value="4")
     site.add_profiles(Namespace.ENV, key="LAL_DATA_PATH",

--- a/pycbc/workflow/pegasus_sites.py
+++ b/pycbc/workflow/pegasus_sites.py
@@ -192,7 +192,7 @@ def add_osg_site(sitecat, cp):
     add_site_pegasus_profile(site, cp)
     site.add_profiles(Namespace.PEGASUS, key="style", value="condor")
     site.add_profiles(Namespace.PEGASUS, key="data.configuration",
-                      value="nonsharedfs")
+                      value="condorio")
     site.add_profiles(Namespace.PEGASUS, key='transfer.bypass.input.staging',
                       value="true")
     site.add_profiles(Namespace.CONDOR, key="should_transfer_files",
@@ -214,7 +214,7 @@ def add_osg_site(sitecat, cp):
     # FIXME: This one should be moved to be latest release and/or chosen in the
     #        config file.
     site.add_profiles(Namespace.CONDOR, key="+SingularityImage",
-                      value='"/cvmfs/singularity.opensciencegrid.org/pycbc/pycbc-el7:v1.18.0"')
+                      value='"/cvmfs/singularity.opensciencegrid.org/pycbc/pycbc-el8:v2.0.3"')
     # On OSG failure rate is high
     site.add_profiles(Namespace.DAGMAN, key="retry", value="4")
     site.add_profiles(Namespace.ENV, key="LAL_DATA_PATH",

--- a/pycbc/workflow/pegasus_sites.py
+++ b/pycbc/workflow/pegasus_sites.py
@@ -203,6 +203,8 @@ def add_osg_site(sitecat, cp):
                       value="True")
     site.add_profiles(Namespace.CONDOR, key="getenv",
                       value="False")
+    site.add_profiles(Namespace.CONDOR, key="preserve_relative_paths",
+                      value="True")
     site.add_profiles(Namespace.CONDOR, key="+InitializeModulesEnv",
                       value="False")
     site.add_profiles(Namespace.CONDOR, key="+SingularityCleanEnv",
@@ -219,6 +221,9 @@ def add_osg_site(sitecat, cp):
     site.add_profiles(Namespace.DAGMAN, key="retry", value="4")
     site.add_profiles(Namespace.ENV, key="LAL_DATA_PATH",
                       value="/cvmfs/oasis.opensciencegrid.org/ligo/sw/pycbc/lalsuite-extra/current/share/lalsimulation")
+    # Add MKL location to LD_LIBRARY_PATH for OSG
+    site.add_profiles(Namespace.ENV, key="LD_LIBRARY_PATH",
+                      value="/usr/local/lib:/.singularity.d/libs")
     sitecat.add_sites(site)
 
 

--- a/pycbc/workflow/pegasus_sites.py
+++ b/pycbc/workflow/pegasus_sites.py
@@ -21,7 +21,7 @@ from urllib.request import pathname2url
 from Pegasus.api import Directory, FileServer, Site, Operation, Namespace
 from Pegasus.api import Arch, OS, SiteCatalog
 
-from pycbc.version import last_version # noqa
+from pycbc.version import last_release  # noqa
 
 # NOTE urllib is weird. For some reason it only allows known schemes and will
 # give *wrong* results, rather then failing, if you use something like gsiftp

--- a/pycbc/workflow/pegasus_sites.py
+++ b/pycbc/workflow/pegasus_sites.py
@@ -21,7 +21,7 @@ from urllib.request import pathname2url
 from Pegasus.api import Directory, FileServer, Site, Operation, Namespace
 from Pegasus.api import Arch, OS, SiteCatalog
 
-from pycbc import version
+import pycbc.version
 
 # NOTE urllib is weird. For some reason it only allows known schemes and will
 # give *wrong* results, rather then failing, if you use something like gsiftp


### PR DESCRIPTION
We want to move to using condorIO (instead of gsiftp) for file transfers to OSG. This got stuck on pegasus not allowing it. With a small tweak to pegasus to disable this check (which I'll try and get in the next pegasus release), this now seems to work smoothly. Some small changes to work with the new docker image are also required.

I would like to merge this now as the OSG site currently doesn't work, but now it will work, if you work with a dev version og pegasus (which I can provide).
