### PR TITLE
Don't import bank output utils at package level

### DIFF
--- a/pycbc/tmpltbank/__init__.py
+++ b/pycbc/tmpltbank/__init__.py
@@ -5,7 +5,6 @@ from pycbc.tmpltbank.lambda_mapping import *
 from pycbc.tmpltbank.coord_utils import *
 from pycbc.tmpltbank.lattice_utils import *
 from pycbc.tmpltbank.brute_force_methods import *
-from pycbc.tmpltbank.bank_output_utils import *
 from pycbc.tmpltbank.option_utils import *
 from pycbc.tmpltbank.partitioned_bank import *
 from pycbc.tmpltbank.em_progenitors import *


### PR DESCRIPTION
Output utils is abandonware used only for ligolw compatibility, & would like to avoid mandatorily importing io code with tmpltbank