### PR TITLE
PSD: don't try to set low frequency values if cutoff is 0Hz

### DIFF
--- a/pycbc/psd/__init__.py
+++ b/pycbc/psd/__init__.py
@@ -99,9 +99,10 @@ def from_cli(opt, length, delta_f, low_frequency_cutoff,
                 psd = from_xml(psd_file_name, length, delta_f, f_low,
                                ifo_string=opt.psd_file_xml_ifo_string,
                                root_name=opt.psd_file_xml_root_name)
-        # Set values < flow to the value at flow
+        # Set values < flow to the value at flow (if flow > 0)
         kmin = int(low_frequency_cutoff / psd.delta_f)
-        psd[0:kmin] = psd[kmin]
+        if kmin > 0:
+            psd[0:kmin] = psd[kmin]
 
         psd *= dyn_range_factor ** 2
 


### PR DESCRIPTION
`psd.from_cli` always tries to set the low frequency values of an analytic PSD to the value at the low frequency cutoff. This causes an IndexError if the low frequency cutoff is set to 0. This prevents being able to use analytic PSDs with the gated gaussian model, for which the PSD is always taken to 0Hz. Patch fixes this by only doing the setting if the low frequency cutoff is not zero.