### PR TITLE
Sngls results plotting

### DIFF
--- a/bin/all_sky_search/pycbc_coinc_hdfinjfind
+++ b/bin/all_sky_search/pycbc_coinc_hdfinjfind
@@ -51,7 +51,7 @@ def xml_to_hdf(table, hdf_file, hdf_key, columns):
         else:
             new_col = col
         key = os.path.join(hdf_key, new_col)
-        hdf_append(hdf_file, key, numpy.array(table.get_column(col),
+        hdf_append(hdf_file, key, numpy.array(table.getColumnByName(col),
                                         dtype=numpy.float32))
 
 parser = argparse.ArgumentParser(description=__doc__)
@@ -142,8 +142,8 @@ for trigger_file, injection_file in zip(args.trigger_files,
         indoc = ligolw_utils.load_filename(injection_file, False,
                                            contenthandler=LIGOLWContentHandler)
         sim_table = lsctables.SimInspiralTable.get_table(indoc)
-        inj_time = numpy.array(sim_table.get_column('geocent_end_time') +
-                               1e-9 * sim_table.get_column('geocent_end_time_ns'),
+        inj_time = numpy.array(sim_table.getColumnByName('geocent_end_time').asarray() +
+                               1e-9 * sim_table.getColumnByName('geocent_end_time_ns').asarray(),
                                dtype=numpy.float64)
     else:
         inj_file = CBCHDFInjectionSet(injection_file)
@@ -175,33 +175,38 @@ for trigger_file, injection_file in zip(args.trigger_files,
     logging.info('Found: %s, Missed: %s' %
                  (len(found_within_time), len(missed_within_time)))
 
-    logging.info('Removing injections in vetoed time')
+    if args.veto_file:
+        logging.info('Removing injections in vetoed time')
 
-    # Put individual detector vetoes into list of all vetoed indices, if an
-    # injection is vetoed in N ifos then its index will appear N times
-    vetoid = numpy.array([])
-    veto_dict = {}
-    for ifo in ifo_list:
-        vi, _ = indices_within_segments(inj_time, [args.veto_file], ifo=ifo,
-                                        segment_name=args.segment_name)
-        vetoid = numpy.append(vetoid, vi)
-        veto_dict[ifo] = vi
+        # Put individual detector vetoes into list of all vetoed indices, if an
+        # injection is vetoed in N ifos then its index will appear N times
+        vetoid = numpy.array([])
+        veto_dict = {}
+        for ifo in ifo_list:
+            vi, _ = indices_within_segments(inj_time, [args.veto_file], ifo=ifo,
+                                            segment_name=args.segment_name)
+            vetoid = numpy.append(vetoid, vi)
+            veto_dict[ifo] = vi
 
-    # Find out which of these indices are unique, and how many times each
-    # vetoed index occurs - this is how many detectors it is vetoed in
-    vetoid_unique, count_vetoid = numpy.unique(vetoid, return_counts=True)
+        # Find out which of these indices are unique, and how many times each
+        # vetoed index occurs - this is how many detectors it is vetoed in
+        vetoid_unique, count_vetoid = numpy.unique(vetoid, return_counts=True)
 
-    # remove injections where the number of unvetoed ifos is less than the
-    # minimum specified by the user
-    vetoed_all = vetoid_unique[(len(ifo_list) - count_vetoid)
-                               < args.min_required_ifos]
-    found_after_vetoes = numpy.array([i for i in found_within_time
-                                      if i not in vetoed_all])
-    missed_after_vetoes = numpy.array([i for i in missed_within_time
-                                      if i not in vetoed_all]).astype(int)
+        # remove injections where the number of unvetoed ifos is less than the
+        # minimum specified by the user
+        vetoed_all = vetoid_unique[(len(ifo_list) - count_vetoid)
+                                   < args.min_required_ifos]
+        found_after_vetoes = numpy.array([i for i in found_within_time
+                                          if i not in vetoed_all])
+        missed_after_vetoes = numpy.array([i for i in missed_within_time
+                                          if i not in vetoed_all]).astype(int)
+        logging.info('Found: %s, Missed: %s' %
+                     (len(found_after_vetoes), len(missed_after_vetoes)))
+    else:
+        veto_dict = {ifo: [] for ifo in ifo_list}
+        found_after_vetoes = found_within_time
+        missed_after_vetoes = missed_within_time.astype(int)
 
-    logging.info('Found: %s, Missed: %s' %
-                 (len(found_after_vetoes), len(missed_after_vetoes)))
 
     found_fore = numpy.arange(0, len(stat), 1)[left[found]]
     found_fore_v = numpy.arange(0, len(stat), 1)[left[found_after_vetoes]]
@@ -221,7 +226,7 @@ for trigger_file, injection_file in zip(args.trigger_files,
             # As a single detector being vetoed won't veto all combinations,
             # need to set optimal_snr of a vetoed ifo to zero in order
             # to later calculate decisive optimal snr
-            optimal_snr_all = numpy.array(sim_table.get_column(column))
+            optimal_snr_all = numpy.array(sim_table.getColumnByName(column))
             optimal_snr_all[veto_dict[ifo]] = 0
             hdf_append(fo, 'injections/optimal_snr_%s' % ifo,
                        optimal_snr_all)
@@ -229,7 +234,7 @@ for trigger_file, injection_file in zip(args.trigger_files,
         # pick up redshift
         if args.redshift_column:
             hdf_append(fo, 'injections/redshift',
-                       sim_table.get_column(args.redshift_column))
+                       sim_table.getColumnByName(args.redshift_column))
     else:
         # hdf injection format
         ninj = len(inj_data)
@@ -268,8 +273,10 @@ for trigger_file, injection_file in zip(args.trigger_files,
             fkey = f[key]
         else:
             fkey = f
-        fo[key].attrs['pivot'] = fkey.attrs['pivot']
-        fo[key].attrs['fixed'] = fkey.attrs['fixed']
+        if 'pivot' in fo[key].attrs:
+            # This is a coincident statmap file
+            fo[key].attrs['pivot'] = fkey.attrs['pivot']
+            fo[key].attrs['fixed'] = fkey.attrs['fixed']
         fo[key].attrs['foreground_time'] = fkey.attrs['foreground_time']
         fo[key].attrs['foreground_time_exc'] = fkey.attrs['foreground_time_exc']
 

--- a/bin/plotting/pycbc_ifar_catalog
+++ b/bin/plotting/pycbc_ifar_catalog
@@ -25,12 +25,15 @@ import pycbc.results
 import pycbc.version
 from pycbc import conversions
 from scipy.stats import norm, poisson
+import logging
+from pycbc import init_logging
 
 parser = argparse.ArgumentParser(usage='pycbc_ifar_catalog [--options]',
                     description='Plots cumulative IFAR vs count for'
-                          ' coincident foreground triggers')
+                          ' foreground triggers')
 parser.add_argument('--version', action='version',
                     version=pycbc.version.git_verbose_msg)
+parser.add_argument('--verbose', action='count')
 parser.add_argument('--trigger-files', nargs='+',
                     help='Path to coincident trigger HDF file(s)')
 parser.add_argument('--output-file', required=True,
@@ -65,6 +68,8 @@ parser.add_argument('--use-exclusive-ifar', action='store_true',
                          'IFAR calculations. Default=False.')
 opts = parser.parse_args()
 
+init_logging(opts.verbose)
+
 if opts.use_tex:
     pylab.rc('text', usetex=True)
     pylab.rc('font', **{'family': 'serif', 'serif': ['Computer Modern']})
@@ -86,7 +91,7 @@ except KeyError:
     h_iterations = 0
 
 if h_inc_back_num is None:
-    print('Using {} hierarchical removal iterations'.format(h_iterations))
+    logging.info('Using %d hierarchical removal iterations', h_iterations)
     h_inc_back_num = h_iterations
 
 if h_inc_back_num > h_iterations:
@@ -236,9 +241,10 @@ if opts.open_box:
 if opts.open_box:
     # scale the plot around the foreground
     pylab.ylim(0.7, 0.05 * len(fore_cumnum))
-    pylab.xlim(30 * min(fore_ifar), 3 * max_ifar)
+    pylab.xlim(min(expected_ifar) / 30, 3 * max_ifar)
 else:
     pylab.ylim(0.7, max(expected_cumnum))
+    pylab.xlim(min(expected_ifar) / 30, 3 * max(upper[4]))
 pylab.grid()
 pylab.legend(loc='upper right', fontsize=13)
 pylab.ylabel('Cumulative Number', size='large')
@@ -249,7 +255,7 @@ pylab.xlabel(ifar_label, size='large')
 
 # save
 caption = 'This is a cumulative histogram of triggers. The blue triangles ' \
-          + 'represent coincident foreground triggers. The dashed line ' \
+          + 'represent foreground triggers. The dashed line ' \
           + 'represents the expected background given the analysis time. ' \
           + 'The shaded regions represent counting errors.'
 pycbc.results.save_fig_with_metadata(fig, opts.output_file,

--- a/bin/plotting/pycbc_ifar_catalog
+++ b/bin/plotting/pycbc_ifar_catalog
@@ -96,7 +96,6 @@ if h_inc_back_num is None:
 
 if h_inc_back_num > h_iterations:
     # Produce a null plot saying no hierarchical removals can be plotted
-    import sys
     fig = pylab.figure()
     ax = fig.add_subplot(111)
 
@@ -244,7 +243,6 @@ if opts.open_box:
     pylab.xlim(30 * min(fore_ifar), 3 * max_ifar)
 else:
     pylab.ylim(0.7, max(expected_cumnum))
-    pylab.xlim(min(expected_ifar) / 30, 3 * max(upper[4]))
 pylab.grid()
 pylab.legend(loc='upper right', fontsize=13)
 pylab.ylabel('Cumulative Number', size='large')

--- a/bin/plotting/pycbc_ifar_catalog
+++ b/bin/plotting/pycbc_ifar_catalog
@@ -241,7 +241,7 @@ if opts.open_box:
 if opts.open_box:
     # scale the plot around the foreground
     pylab.ylim(0.7, 0.05 * len(fore_cumnum))
-    pylab.xlim(min(expected_ifar) / 30, 3 * max_ifar)
+    pylab.xlim(30 * min(fore_ifar), 3 * max_ifar)
 else:
     pylab.ylim(0.7, max(expected_cumnum))
     pylab.xlim(min(expected_ifar) / 30, 3 * max(upper[4]))

--- a/bin/plotting/pycbc_page_foreground
+++ b/bin/plotting/pycbc_page_foreground
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 """
-Make table of the foreground coincident events. Also includes ability to
+Make table of the foreground events. Also includes ability to
 write FARs and p-values for intermediary hierarchical removal steps.
 """
 import argparse
@@ -21,7 +21,7 @@ parser.add_argument('--bank-file')
 parser.add_argument('--single-detector-triggers', nargs='+', default=None)
 parser.add_argument('--verbose', action='count')
 parser.add_argument('--output-file')
-parser.add_argument('--num-coincs-to-write', type=int)
+parser.add_argument('--num-to-write', type=int)
 parser.add_argument('--use-hierarchical-level', type=int, default=None,
                     help='Indicate which FARs to write to the table '
                          'based on the number of hierarchical removals done. '
@@ -70,7 +70,7 @@ if args.output_file.endswith('.xml') or args.output_file.endswith('.xml.gz'):
         err_msg += "trigger lists with --single-detector-triggers."
         raise ValueError(err_msg)
 
-# Ensure that the user uses a coinc trigger file that is hierarchical
+# Ensure that the user uses a trigger file that is hierarchical
 # removal compatible. Also default to regular behavior if hierarchical
 # removals were not performed.
 if h_num_rm is not None and h_iterations is not None \
@@ -78,18 +78,18 @@ if h_num_rm is not None and h_iterations is not None \
     # read in the triggers from the group corresponding to the removal stage
     fortrigs = hdf.ForegroundTriggers(args.trigger_file, args.bank_file,
                                       sngl_files=args.single_detector_triggers,
-                                      n_loudest=args.num_coincs_to_write,
+                                      n_loudest=args.num_to_write,
                                       group='foreground_h%s' % h_num_rm)
     # read in the regular triggers to get the exclusive ifar which is
     # independent of any removal
     fortrigs_exclusive = hdf.ForegroundTriggers(args.trigger_file, args.bank_file,
                                            sngl_files=args.single_detector_triggers,
-                                           n_loudest=args.num_coincs_to_write)
+                                           n_loudest=args.num_to_write)
 
 else :
     fortrigs = hdf.ForegroundTriggers(args.trigger_file, args.bank_file,
                                       sngl_files=args.single_detector_triggers,
-                                      n_loudest=args.num_coincs_to_write)
+                                      n_loudest=args.num_to_write)
 
 if args.output_file.endswith('.html'):
     ifar = fortrigs.get_coincfile_array('ifar')
@@ -108,7 +108,7 @@ if args.output_file.endswith('.html'):
         #        this table for hierarchically removed triggers, we would need
         #        to change the code below to support that.
 
-        # This information is not stored at all levels of the coinc trigger file
+        # This information is not stored at all levels of the trigger file
         # so grab from the top level and populate the variables for output later
 
         ifar_exc_orig = fortrigs_exclusive.get_coincfile_array('ifar_exc')

--- a/bin/plotting/pycbc_page_foundmissed
+++ b/bin/plotting/pycbc_page_foundmissed
@@ -12,17 +12,17 @@ from pycbc.detector import Detector
 labels={'mchirp': 'Chirp Mass',
         'mtotal': 'Total Mass',
         'mass_ratio': 'Mass Ratio',
-        'decisive_distance': 'Injected Decisive Distance (Mpc)',
-        'dec_chirp_distance': 'Injected Decisive Chirp Distance (Mpc)',
-        'min_eff_distance': 'Minimum Effective Injected Distance (Mpc)',
-        'min_eff_chirp_distance': 'Minimum Effective Injected Chirp Distance (Mpc)',
+        'decisive_distance': 'Decisive Distance (Mpc)',
+        'dec_chirp_distance': 'Decisive Chirp Distance (Mpc)',
+        'min_eff_distance': 'Minimum Effective Distance (Mpc)',
+        'min_eff_chirp_distance': 'Minimum Effective Chirp Distance (Mpc)',
         'chirp_distance': 'Injected Chirp Distance (Mpc)',
         'comb_optimal_snr': 'Combined Optimal SNR',
         'decisive_optimal_snr': 'Decisive Optimal SNR',
         'max_optimal_snr': 'Maximum Optimal SNR',
         'redshift': 'Redshift',
         'time': 'Time (s)',
-        'effective_spin': 'Weighted Aligned Spin',
+        'effective_spin': 'Effective Inspiral Spin',
        }
 
 parser = argparse.ArgumentParser(description=__doc__)
@@ -32,7 +32,7 @@ parser.add_argument('--axis-type', default='mchirp', choices=['mchirp',
                     'effective_spin', 'time', 'mtotal', 'mass_ratio'])
 parser.add_argument('--log-x', action='store_true', default=False)
 parser.add_argument('--distance-type', default='decisive_optimal_snr',
-                    choices=list(labels.keys()),
+                    choices=list(labels),
                     help="Variable related to injected distance. Decisive "
                          "distance and dec chirp distance only available for "
                          "2-ifo search")
@@ -75,9 +75,7 @@ elif args.far_type == 'exclusive':
     ifar_found = f['found_after_vetoes/ifar_exc'][:]
     far_title = 'Exclusive'
 
-if args.limit_ifar:
-    ifar_above_thresh = ifar_found > args.limit_ifar
-    ifar_found[ifar_above_thresh] = args.limit_ifar
+ifar_found = numpy.minimum(ifar_found, args.limit_ifar)
 
 s1z = f['injections/spin1z'][:]
 s2z = f['injections/spin2z'][:]
@@ -121,8 +119,8 @@ try:
     dvals['dec_chirp_distance'] = \
         pycbc.pnutils.chirp_distance(dvals['decisive_distance'],
                                      vals['mchirp'])
-    # If we include single-detector triggers in the analysis, the
-    # "decisive" distance would be the minimum distance
+    # When including single-detector triggers in the analysis, the
+    # "decisive" distance is be the minimum distance
     dvals['min_eff_distance'] = numpy.min(eff_dists, axis=1)
     dvals['min_eff_chirp_distance'] = \
         pycbc.pnutils.chirp_distance(dvals['min_eff_distance'],

--- a/bin/plotting/pycbc_page_foundmissed
+++ b/bin/plotting/pycbc_page_foundmissed
@@ -75,7 +75,8 @@ elif args.far_type == 'exclusive':
     ifar_found = f['found_after_vetoes/ifar_exc'][:]
     far_title = 'Exclusive'
 
-ifar_found = numpy.minimum(ifar_found, args.limit_ifar)
+if args.limit_ifar:
+    ifar_found = numpy.minimum(ifar_found, args.limit_ifar)
 
 s1z = f['injections/spin1z'][:]
 s2z = f['injections/spin2z'][:]

--- a/bin/plotting/pycbc_page_foundmissed
+++ b/bin/plotting/pycbc_page_foundmissed
@@ -9,6 +9,22 @@ import pycbc.pnutils
 from pycbc import init_logging
 from pycbc.detector import Detector
 
+labels={'mchirp': 'Chirp Mass',
+        'mtotal': 'Total Mass',
+        'mass_ratio': 'Mass Ratio',
+        'decisive_distance': 'Injected Decisive Distance (Mpc)',
+        'dec_chirp_distance': 'Injected Decisive Chirp Distance (Mpc)',
+        'min_eff_distance': 'Minimum Effective Injected Distance (Mpc)',
+        'min_eff_chirp_distance': 'Minimum Effective Injected Chirp Distance (Mpc)',
+        'chirp_distance': 'Injected Chirp Distance (Mpc)',
+        'comb_optimal_snr': 'Combined Optimal SNR',
+        'decisive_optimal_snr': 'Decisive Optimal SNR',
+        'max_optimal_snr': 'Maximum Optimal SNR',
+        'redshift': 'Redshift',
+        'time': 'Time (s)',
+        'effective_spin': 'Weighted Aligned Spin',
+       }
+
 parser = argparse.ArgumentParser(description=__doc__)
 parser.add_argument('--injection-file',
                     help="The hdf injection file to plot", required=True)
@@ -16,9 +32,7 @@ parser.add_argument('--axis-type', default='mchirp', choices=['mchirp',
                     'effective_spin', 'time', 'mtotal', 'mass_ratio'])
 parser.add_argument('--log-x', action='store_true', default=False)
 parser.add_argument('--distance-type', default='decisive_optimal_snr',
-                    choices=['decisive_distance', 'dec_chirp_distance',
-                             'chirp_distance', 'comb_optimal_snr',
-                             'decisive_optimal_snr', 'redshift'],
+                    choices=list(labels.keys()),
                     help="Variable related to injected distance. Decisive "
                          "distance and dec chirp distance only available for "
                          "2-ifo search")
@@ -33,6 +47,8 @@ parser.add_argument('--dynamic', action='store_true', default=False)
 parser.add_argument('--gradient-far', action='store_true',
                     help="Show far of found injections as a gradient")
 parser.add_argument('--output-file', required=True)
+parser.add_argument('--limit-ifar', type=float,
+                    help="Supply a limit for IFAR colors")
 parser.add_argument('--far-type', choices=('inclusive', 'exclusive'),
                     default='inclusive',
                     help="Type of far to plot for the color. Choices are "
@@ -58,6 +74,10 @@ if args.far_type == 'inclusive':
 elif args.far_type == 'exclusive':
     ifar_found = f['found_after_vetoes/ifar_exc'][:]
     far_title = 'Exclusive'
+
+if args.limit_ifar:
+    ifar_above_thresh = ifar_found > args.limit_ifar
+    ifar_found[ifar_above_thresh] = args.limit_ifar
 
 s1z = f['injections/spin1z'][:]
 s2z = f['injections/spin2z'][:]
@@ -95,10 +115,17 @@ try:
                              f['injections/inclination'][:]))
     eff_dists = numpy.array(eff_dists).T
 
-    # "Decisive" distance is the second smallest effective distance
+    # "Decisive" distance for coincidences is the second smallest
+    # effective distance
     dvals['decisive_distance'] = numpy.sort(eff_dists)[:,1]
     dvals['dec_chirp_distance'] = \
         pycbc.pnutils.chirp_distance(dvals['decisive_distance'],
+                                     vals['mchirp'])
+    # If we include single-detector triggers in the analysis, the
+    # "decisive" distance would be the minimum distance
+    dvals['min_eff_distance'] = numpy.min(eff_dists, axis=1)
+    dvals['min_eff_chirp_distance'] = \
+        pycbc.pnutils.chirp_distance(dvals['min_eff_distance'],
                                      vals['mchirp'])
 except KeyError:
     # If the ifo isn't in the effective distance columns you can't get this.
@@ -110,39 +137,21 @@ if args.distance_type == 'redshift':
     dvals['redshift'] = f['injections/redshift'][:]
 
 if 'snr' in args.distance_type:  # only evaluate SNRs if needed
-    if 'optimal_snr_1' in f['injections']:  # old 2-ifo search behaviour
-        opt_snr_1 = f['injections/optimal_snr_1'][:]
-        opt_snr_2 = f['injections/optimal_snr_2'][:]
-        dvals['comb_optimal_snr'] = \
-            numpy.sqrt(opt_snr_1 ** 2. + opt_snr_2 ** 2.)
-        dvals['decisive_optimal_snr'] = \
-            numpy.where(opt_snr_1 < opt_snr_2, opt_snr_1, opt_snr_2)
-    else: # New workflow code syntax
-        opt_snrsq_arr = \
-            [f['injections/optimal_snr_%s' % ifo][:]**2. for ifo in ifos]
-        dvals['comb_optimal_snr'] = \
-            numpy.array([numpy.sqrt(sum(opt_snrsq))
-                         for opt_snrsq in zip(*opt_snrsq_arr)])
-        # Decisive optimal SNR is the 2nd largest optimal SNR
-        dvals['decisive_optimal_snr'] = \
-            numpy.array([numpy.sqrt(sorted(opt_snrsq)[-2])
-                         for opt_snrsq in zip(*opt_snrsq_arr)])
+    opt_snrsq_arr = \
+        [f['injections/optimal_snr_%s' % ifo][:] ** 2. for ifo in ifos]
+    dvals['comb_optimal_snr'] = \
+        numpy.array([numpy.sqrt(sum(opt_snrsq))
+                     for opt_snrsq in zip(*opt_snrsq_arr)])
+    # Decisive optimal SNR is the 2nd largest optimal SNR
+    dvals['decisive_optimal_snr'] = \
+        numpy.array([numpy.sqrt(sorted(opt_snrsq)[-2])
+                     for opt_snrsq in zip(*opt_snrsq_arr)])
+    dvals['max_optimal_snr'] = \
+        numpy.array([numpy.sqrt(max(opt_snrsq))
+                     for opt_snrsq in zip(*opt_snrsq_arr)])
 
 fdvals = dvals[args.distance_type][found]
 mdvals = dvals[args.distance_type][missed]
-
-labels={'mchirp': 'Chirp Mass',
-        'mtotal': 'Total Mass',
-        'mass_ratio': 'Mass Ratio',
-        'decisive_distance': 'Injected Decisive Distance (Mpc)',
-        'dec_chirp_distance': 'Injected Decisive Chirp Distance (Mpc)',
-        'chirp_distance': 'Injected Chirp Distance (Mpc)',
-        'comb_optimal_snr': 'Combined Optimal SNR',
-        'decisive_optimal_snr': 'Decisive Optimal SNR',
-        'redshift': 'Redshift',
-        'time': 'Time (s)',
-        'effective_spin': 'Weighted Aligned Spin',
-       }
 
 if args.missed_on_top:
   fig_title = 'Missed and Found Injections'

--- a/bin/plotting/pycbc_page_foundmissed
+++ b/bin/plotting/pycbc_page_foundmissed
@@ -16,7 +16,7 @@ labels={'mchirp': 'Chirp Mass',
         'dec_chirp_distance': 'Decisive Chirp Distance (Mpc)',
         'min_eff_distance': 'Minimum Effective Distance (Mpc)',
         'min_eff_chirp_distance': 'Minimum Effective Chirp Distance (Mpc)',
-        'chirp_distance': 'Injected Chirp Distance (Mpc)',
+        'chirp_distance': 'Chirp Distance (Mpc)',
         'comb_optimal_snr': 'Combined Optimal SNR',
         'decisive_optimal_snr': 'Decisive Optimal SNR',
         'max_optimal_snr': 'Maximum Optimal SNR',
@@ -120,8 +120,8 @@ try:
     dvals['dec_chirp_distance'] = \
         pycbc.pnutils.chirp_distance(dvals['decisive_distance'],
                                      vals['mchirp'])
-    # When including single-detector triggers in the analysis, the
-    # "decisive" distance is be the minimum distance
+    # When single-detector triggers are included in the analysis,
+    # minimum distance is the relevant quantity for injection efficiency
     dvals['min_eff_distance'] = numpy.min(eff_dists, axis=1)
     dvals['min_eff_chirp_distance'] = \
         pycbc.pnutils.chirp_distance(dvals['min_eff_distance'],

--- a/bin/plotting/pycbc_page_ifar
+++ b/bin/plotting/pycbc_page_ifar
@@ -91,11 +91,6 @@ opts = parser.parse_args()
 # read file
 fp = h5py.File(opts.trigger_file, 'r')
 
-if 'ifos' in fp.attrs:
-    legacy_smap_file = False
-else:
-    legacy_smap_file = True
-
 # Parse which inclusive background to use for the plotting
 h_inc_back_num = opts.use_hierarchical_level
 
@@ -196,31 +191,25 @@ fig = pylab.figure(1)
 
 # get a unique list of timeslide_ids and loop over them
 interval = fp.attrs['timeslide_interval']
-if legacy_smap_file:
-    pifo, fifo = fp.attrs['detector_1'], fp.attrs['detector_2']
-    p_starts = fp['segments'][pifo]['start'][:]
-    p_ends = fp['segments'][pifo]['end'][:]
-    pifo_segments = veto.start_end_to_segments(p_starts, p_ends)
-    f_starts = fp['segments'][pifo]['start'][:]
-    f_ends = fp['segments'][pifo]['end'][:]
-    fifo_segments = veto.start_end_to_segments(f_starts, f_ends)
-    min_tsid = (p_starts.min() - f_ends.max()) / interval
-    max_tsid = (p_ends.max() - f_starts.min()) / interval
+pifo, fifo = fp.attrs['pivot'], fp.attrs['fixed']
+ifo_joined = fp.attrs['ifos'].replace(' ','')
+p_starts = fp['segments'][ifo_joined]['start'][:]
+p_ends = fp['segments'][ifo_joined]['end'][:]
+pifo_segments = veto.start_end_to_segments(p_starts, p_ends)
+fifo_segments = copy.deepcopy(pifo_segments)
+min_tsid = (p_starts.min() - p_ends.max()) / interval
+max_tsid = -min_tsid
+
+if interval == 0:
+    # If this is a single-detector statmap file, there isn't a timeslide
+    # background
+    tsids = numpy.array([0])
 else:
-    pifo, fifo = fp.attrs['pivot'], fp.attrs['fixed']
-    ifo_joined = fp.attrs['ifos'].replace(' ','')
-    p_starts = fp['segments'][ifo_joined]['start'][:]
-    p_ends = fp['segments'][ifo_joined]['end'][:]
-    pifo_segments = veto.start_end_to_segments(p_starts, p_ends)
-    fifo_segments = copy.deepcopy(pifo_segments)
-    min_tsid = (p_starts.min() - p_ends.max()) / interval
-    max_tsid = -min_tsid
+    min_tsid = numpy.rint(min_tsid) // opts.decimation_factor
+    max_tsid = numpy.rint(max_tsid) // opts.decimation_factor
 
-min_tsid = numpy.rint(min_tsid) // opts.decimation_factor
-max_tsid = numpy.rint(max_tsid) // opts.decimation_factor
-
-tsids = numpy.arange(min_tsid, max_tsid, 1).astype(numpy.int64) * \
-                     opts.decimation_factor
+    tsids = numpy.arange(min_tsid, max_tsid, 1).astype(numpy.int64) * \
+                         opts.decimation_factor
 
 allbkg_dur = 0
 allbkg_ifars = []

--- a/bin/plotting/pycbc_page_snrifar
+++ b/bin/plotting/pycbc_page_snrifar
@@ -188,17 +188,6 @@ if not args.cumulative:
 
 fap_back = p_from_far(far_back, foreground_livetime)
 
-# we'll use the background far for the ylimits
-if args.ymin is None:
-    plot_ymin = far_back.min()/10.
-else:
-    plot_ymin = args.ymin
-
-if args.ymax is None:
-    plot_ymax = far_back.max()
-else:
-    plot_ymax = args.ymax
-
 logging.info('Found %s background (inclusive zerolag) triggers' % len(cstat_back))
 
 back_ifar_exc = f['background_exc/ifar'][:]
@@ -212,6 +201,22 @@ if not args.cumulative:
 
 logging.info('Found %s background (exclusive zerolag) triggers' % len(cstat_back_exc))
 
+# We'll use the background far for the ylimits if closed box, foreground
+# otherwise
+if args.ymin is not None:
+    plot_ymin = args.ymin
+elif args.closed_box or cstat_fore is None:
+    plot_ymin = far_back_exc.min()/10.
+else:
+    plot_ymin = far_back.min()/10.
+
+if args.ymax is not None:
+    plot_ymax = args.ymax
+elif args.closed_box or cstat_fore is None:
+    plot_ymax = far_back_exc.max()
+else:
+    plot_ymax = far_back.max()
+
 # We'll use the background for the xlimits if closed box, foreground
 # otherwise.
 if args.xmin is not None:
@@ -223,9 +228,10 @@ else:
 
 if args.xmax is not None:
     plot_xmax = args.xmax
-# Otherwise, make the furthest point to the right be ~1/10 of the width of the
-# plot from the right axis.
+
 else:
+    # Otherwise, make the furthest point to the right be ~1/10 of the width
+    # of the plot from the right axis.
     if args.closed_box or cstat_fore is None:
         plot_xmax = cstat_back_exc.max()
     else:

--- a/examples/search/plotting.ini
+++ b/examples/search/plotting.ini
@@ -230,7 +230,7 @@ log-y =
 [plot_snrifar]
 [page_foreground]
 [page_foreground-xmlloudest]
-num-coincs-to-write = 2
+num-to-write = 2
 
 [page_injections]
 [plot_segments]

--- a/pycbc/io/hdf.py
+++ b/pycbc/io/hdf.py
@@ -536,7 +536,7 @@ class SingleDetTriggers(object):
 
     @property
     def template_id(self):
-        return self.get_column('template_id')
+        return self.get_column('template_id').astype(int)
 
     @property
     def mass1(self):
@@ -753,7 +753,7 @@ class ForegroundTriggers(object):
     def template_id(self):
         if self._template_id is None:
             template_id = self.get_coincfile_array('template_id')
-            self._template_id = template_id
+            self._template_id = template_id.astype(int)
         return self._template_id
 
     @property


### PR DESCRIPTION
Some changes were required to allow search including single-detector events to have sensible results pages

These changes are compatible with #4050 

- hdfinjfind: add if statements as the pivot/fixed ifo doesn't make sense without timeshifts
- foundmissed plots: add maximum SNRs and minimum distances to the coloring schemes, as these are decisive in searches which include single-detector triggers
- ifar_catalog: events now may have _really_ low ifar, so using minimum ifar as a limit to the x-axis no longer makes sense
- page_foreground: changes are basically to remove the requirement to say coincs from the code
- page_ifar: change gets rid of the legacy files support
- page_snrifar: change fixes an issue where open-box values could be inferred from closed-box plot limits