### PR TITLE
Make combine statmap options more like actual usage

### DIFF
--- a/examples/search/analysis.ini
+++ b/examples/search/analysis.ini
@@ -197,9 +197,11 @@ veto-window = 0.100
 cluster-window = 10.0
 
 [combine_statmap]
+cluster-window = ${statmap|cluster-window}
+
+[combine_statmap-full_data]
 max-hierarchical-removal = ${workflow-results|max-hierarchical-removal}
 hierarchical-removal-against = inclusive
-cluster-window = ${statmap|cluster-window}
 
 [foreground_censor]
 

--- a/examples/search/analysis.ini
+++ b/examples/search/analysis.ini
@@ -197,6 +197,8 @@ veto-window = 0.100
 cluster-window = 10.0
 
 [combine_statmap]
+max-hierarchical-removal = ${workflow-results|max-hierarchical-removal}
+hierarchical-removal-against = inclusive
 cluster-window = ${statmap|cluster-window}
 
 [foreground_censor]

--- a/examples/search/plotting.ini
+++ b/examples/search/plotting.ini
@@ -21,9 +21,10 @@ analysis-category = foreground
 
 [foreground_minifollowup-background]
 analysis-category = background_exc
+sort-variable = stat
 
 [singles_minifollowup]
-ranking-statistic = quadsum
+ranking-statistic = single_ranking_only
 sngl-ranking = newsnr_sgveto_psdvar
 
 [singles_minifollowup-noncoinc]
@@ -35,7 +36,7 @@ non-coinc-time-only =
 ifar-threshold = 1
 
 [page_snglinfo]
-ranking-statistic = quadsum
+ranking-statistic = single_ranking_only
 sngl-ranking = newsnr_sgveto_psdvar
 
 [single_template_plot]


### PR DESCRIPTION
Previous default behaviour (before #4053) was to remove against inclusive FAR at the combine statmap stage, so add this option in order to test HR in this stage going forwards