### PR TITLE
Update live single fits to reload file each time

### DIFF
--- a/pycbc/events/single.py
+++ b/pycbc/events/single.py
@@ -139,8 +139,6 @@ class LiveSingle(object):
         if self.fixed_ifar:
             return self.fixed_ifar[self.ifo]
 
-        fit_info = {}
-
         with h5py.File(self.fit_file, 'r') as fit_file:
             bin_edges = fit_file['bins_edges'][:]
             live_time = fit_file[self.ifo].attrs['live_time']

--- a/pycbc/events/single.py
+++ b/pycbc/events/single.py
@@ -19,7 +19,7 @@ class LiveSingle(object):
         self.fit_file = fit_file
         self.sngl_ifar_est_dist = sngl_ifar_est_dist
         self.fixed_ifar = fixed_ifar
-        
+
         self.thresholds = {
             "newsnr": newsnr_threshold,
             "reduced_chisq": reduced_chisq_threshold,
@@ -154,7 +154,7 @@ class LiveSingle(object):
         rate = rates[dur_bin]
         coeff = coeffs[dur_bin]
         rate_louder = rate * fits.cum_fit('exponential', [sngl_ranking],
-                                          coeff, 'thresh')[0]
+                                          coeff, thresh)[0]
         # apply a trials factor of the number of duration bins
         rate_louder *= len(rates)
         return conv.sec_to_year(1. / rate_louder)

--- a/pycbc/events/single.py
+++ b/pycbc/events/single.py
@@ -141,22 +141,22 @@ class LiveSingle(object):
 
         fit_info = {}
 
-￼       with h5py.File(self.fit_file, 'r') as fit_file:
-￼           bin_edges = fit_file['bins_edges'][:]
-￼           live_time = fit_file[self.ifo].attrs['live_time']
-￼           thresh = fit_file.attrs['fit_threshold']
-￼
-￼           dist_grp = fit_file[self.ifo][self.sngl_ifar_est_dist]
-￼           rates = dist_grp['counts'][:] / live_time
-￼           coeffs = dist_grp['fit_coeff'][:]
-￼
-￼       bins = bin_utils.IrregularBins(bin_edges)
-￼       dur_bin = bins[duration]
-￼
-￼       rate = rates[dur_bin]
-￼       coeff = coeffs[dur_bin]
-￼       rate_louder = rate * fits.cum_fit('exponential', [sngl_ranking],
-￼                                         coeff, fit_info['thresh'])[0]
+        with h5py.File(self.fit_file, 'r') as fit_file:
+            bin_edges = fit_file['bins_edges'][:]
+            live_time = fit_file[self.ifo].attrs['live_time']
+            thresh = fit_file.attrs['fit_threshold']
+
+            dist_grp = fit_file[self.ifo][self.sngl_ifar_est_dist]
+            rates = dist_grp['counts'][:] / live_time
+            coeffs = dist_grp['fit_coeff'][:]
+
+        bins = bin_utils.IrregularBins(bin_edges)
+        dur_bin = bins[duration]
+
+        rate = rates[dur_bin]
+        coeff = coeffs[dur_bin]
+        rate_louder = rate * fits.cum_fit('exponential', [sngl_ranking],
+                                          coeff, fit_info['thresh'])[0]
         # apply a trials factor of the number of duration bins
         rate_louder *= len(rates)
         return conv.sec_to_year(1. / rate_louder)

--- a/pycbc/events/single.py
+++ b/pycbc/events/single.py
@@ -156,7 +156,7 @@ class LiveSingle(object):
         rate = rates[dur_bin]
         coeff = coeffs[dur_bin]
         rate_louder = rate * fits.cum_fit('exponential', [sngl_ranking],
-                                          coeff, fit_info['thresh'])[0]
+                                          coeff, 'thresh')[0]
         # apply a trials factor of the number of duration bins
         rate_louder *= len(rates)
         return conv.sec_to_year(1. / rate_louder)


### PR DESCRIPTION
Move fits file reading into the check_singles function, so that the fit parameters are updated rather than loaded once and static