### PR TITLE
PyCBC Live: attempt to fix error due to excessive recursion depth

### DIFF
--- a/pycbc/frame/frame.py
+++ b/pycbc/frame/frame.py
@@ -628,9 +628,9 @@ class DataBuffer(object):
         data: TimeSeries
             TimeSeries containg 'blocksize' seconds of frame data
         """
+        if self.force_update_cache:
+            self.update_cache()
         while True:
-            if self.force_update_cache:
-                self.update_cache()
             try:
                 if self.increment_update_cache:
                     self.update_cache_by_increment(blocksize)


### PR DESCRIPTION
PyCBC Live occasionally crashes with a RecursionError because of the way it handles the frame reading timeout condition (a 100 s timeout with a 0.1 s retry time gives about 1000 recursions, which is Python's default limit). This rewrites that code to use a loop instead of a recursion, which should avoid the problem.