### PR TITLE
Make DEEPBIND only used for FFTW

### DIFF
--- a/pycbc/fft/fftw.py
+++ b/pycbc/fft/fftw.py
@@ -1,3 +1,4 @@
+import os
 from pycbc.types import zeros
 import numpy as _np
 import ctypes
@@ -11,6 +12,10 @@ from ..types import check_aligned
 # no FFTW function should be called until the user has had the chance
 # to set the threading backend, it is ESSENTIAL that simply loading this
 # module should not actually *call* ANY functions.
+
+# NOTE:
+# When loading FFTW we use os.RTLD_DEEPBIND to avoid potential segfaults due
+# to conflicts with MKL if both are present.
 
 #FFTW constants, these are pulled from fftw3.h
 FFTW_FORWARD = -1
@@ -30,8 +35,8 @@ FFTW_WISDOM_ONLY = 1 << 21
 # We need to construct them directly with CDLL so
 # we can give the RTLD_GLOBAL mode, which we must do
 # in order to use the threaded libraries as well.
-double_lib = get_ctypes_library('fftw3',['fftw3'])
-float_lib = get_ctypes_library('fftw3f',['fftw3f'])
+double_lib = get_ctypes_library('fftw3', ['fftw3'], mode=os.RTLD_DEEPBIND)
+float_lib = get_ctypes_library('fftw3f', ['fftw3f'], mode=os.RTLD_DEEPBIND)
 if (double_lib is None) or (float_lib is None):
     raise ImportError("Unable to find FFTW libraries")
 
@@ -97,15 +102,22 @@ def _init_threads(backend):
         raise ValueError("Backend {0} for FFTW threading does not exist!".format(backend))
     if double_threaded_libname is not None:
         try:
-            # Note that the threaded libraries don't have their own pkg-config files;
-            # we must look for them wherever we look for double or single FFTW itself
-            _double_threaded_lib = get_ctypes_library(double_threaded_libname,
-                                                      ['fftw3'])
-            _float_threaded_lib =  get_ctypes_library(float_threaded_libname,
-                                                      ['fftw3f'])
+            # Note that the threaded libraries don't have their own pkg-config
+            # files we must look for them wherever we look for double or single
+            # FFTW itself.
+            _double_threaded_lib = get_ctypes_library(
+                double_threaded_libname,
+                ['fftw3']
+            )
+            _float_threaded_lib =  get_ctypes_library(
+                float_threaded_libname,
+                ['fftw3f']
+            )
             if (_double_threaded_lib is None) or (_float_threaded_lib is None):
-                raise RuntimeError("Unable to load threaded libraries {0} or {1}".format(double_threaded_libname,
-                                                                                         float_threaded_libname))
+                err_str = 'Unable to load threaded libraries'
+                err_str += f'{double_threaded_libname} or '
+                err_str += f'{float_threaded_libname}'
+                raise RuntimeError(err_str)
             dret = _double_threaded_lib.fftw_init_threads()
             fret = _float_threaded_lib.fftwf_init_threads()
             # FFTW for some reason uses *0* to indicate failure.  In C.

--- a/pycbc/fft/fftw.py
+++ b/pycbc/fft/fftw.py
@@ -111,11 +111,13 @@ def _init_threads(backend):
             # FFTW itself.
             _double_threaded_lib = get_ctypes_library(
                 double_threaded_libname,
-                ['fftw3']
+                ['fftw3'],
+                mode=FFTW_RTLD_MODE
             )
             _float_threaded_lib =  get_ctypes_library(
                 float_threaded_libname,
-                ['fftw3f']
+                ['fftw3f'],
+                mode=FFTW_RTLD_MODE
             )
             if (_double_threaded_lib is None) or (_float_threaded_lib is None):
                 err_str = 'Unable to load threaded libraries'

--- a/pycbc/fft/fftw.py
+++ b/pycbc/fft/fftw.py
@@ -16,6 +16,10 @@ from ..types import check_aligned
 # NOTE:
 # When loading FFTW we use os.RTLD_DEEPBIND to avoid potential segfaults due
 # to conflicts with MKL if both are present.
+if hasattr(os, 'RTLD_DEEPBIND'):
+    FFTW_RTLD_MODE = os.RTLD_DEEPBIND
+else:
+    FFTW_RTLD_MODE = ctypes.DEFAULT_MODE
 
 #FFTW constants, these are pulled from fftw3.h
 FFTW_FORWARD = -1
@@ -35,8 +39,8 @@ FFTW_WISDOM_ONLY = 1 << 21
 # We need to construct them directly with CDLL so
 # we can give the RTLD_GLOBAL mode, which we must do
 # in order to use the threaded libraries as well.
-double_lib = get_ctypes_library('fftw3', ['fftw3'], mode=os.RTLD_DEEPBIND)
-float_lib = get_ctypes_library('fftw3f', ['fftw3f'], mode=os.RTLD_DEEPBIND)
+double_lib = get_ctypes_library('fftw3', ['fftw3'], mode=FFTW_RTLD_MODE)
+float_lib = get_ctypes_library('fftw3f', ['fftw3f'], mode=FFTW_RTLD_MODE)
 if (double_lib is None) or (float_lib is None):
     raise ImportError("Unable to find FFTW libraries")
 

--- a/pycbc/libutils.py
+++ b/pycbc/libutils.py
@@ -27,17 +27,11 @@ from collections import deque
 from subprocess import getoutput
 
 
-# DLOPEN mode that requies symbols to first look up locally to this
-# library rather than first going to the global symbol table
-# This should be used when multiple libraries may export incompatible
-# symbols
-#
-# This is only defined for linux systems, on macosx, the default behavior
-# is similar
-if hasattr(os, 'RTLD_DEEPBIND'):
-    DEFAULT_RTLD_MODE = os.RTLD_DEEPBIND
-else:
-    DEFAULT_RTLD_MODE = ctypes.DEFAULT_MODE
+# Be careful setting the mode for opening libraries! Some libraries (e.g.
+# libgomp) seem to require the DEFAULT_MODE is used. Others (e.g. FFTW when
+# MKL is also present) require that os.RTLD_DEEPBIND is used. If seeing
+# segfaults around this code, play about this this!
+DEFAULT_RTLD_MODE = ctypes.DEFAULT_MODE
 
 
 def pkg_config(pkg_libraries):


### PR DESCRIPTION
From discussion in #4076. This should stop the reported segfaults by making DEEPBIND *not* the default, but only used when loading FFTW. I leave it to @josh-willis to explore whether we should always be loading libgomp to make thread settings.