### PR TITLE
Fix broken bank placement code/documentation

### DIFF
--- a/bin/bank/pycbc_aligned_bank_cat
+++ b/bin/bank/pycbc_aligned_bank_cat
@@ -166,12 +166,15 @@ if options.metadata_file:
 else:
     outdoc = None
 if options.output_file.endswith(('.xml','.xml.gz','.xmlgz')):
-    llw_output.output_sngl_inspiral_table(options.output_file, temp_bank,
-        metricParams, ethincaParams, programName=__program__,
+    llw_output.output_sngl_inspiral_table(
+        options.output_file,
+        temp_bank,
+        metricParams,
+        ethincaParams,
+        programName=__program__,
         optDict=options.__dict__,
-        outdoc=outdoc, comment="", version=pycbc.version.git_hash,
-        cvs_repository='pycbc/'+pycbc.version.git_branch,
-        cvs_entry_time=pycbc.version.date)
+        outdoc=outdoc
+    )
 elif options.output_file.endswith(('.h5','.hdf','.hdf5')):
     out_fp = h5py.File(options.output_file, 'w')
     out_fp['mass1'] = temp_bank[:,0]

--- a/bin/bank/pycbc_aligned_stoch_bank
+++ b/bin/bank/pycbc_aligned_stoch_bank
@@ -20,22 +20,22 @@
 Stochastic aligned spin bank generator.
 """
 
-import sys, argparse, copy
+import argparse
 import numpy
 import logging
 import pycbc
 import pycbc.version
-from pycbc import tmpltbank, pnutils
+from pycbc import tmpltbank
 # Old ligolw output functions no longer imported at package level
 import pycbc.tmpltbank.bank_output_utils as llw_output
 from pycbc.types import positive_float
 import pycbc.psd
 import pycbc.strain
+from pycbc.pnutils import named_frequency_cutoffs
 
 
 __author__  = "Ian Harry <ian.harry@astro.cf.ac.uk>"
 __version__ = pycbc.version.git_verbose_msg
-__date__    = pycbc.version.date
 __program__ = "pycbc_aligned_stoch_bank"
 
 # Read command line option
@@ -56,7 +56,7 @@ parser.add_argument("--bank-fupper-step", type=positive_float, default=10.,
                     "--ethinca-freq-step are also given, the code will use "
                     "the smaller of the two step values. OPTIONAL. Units=Hz")
 parser.add_argument("--bank-fupper-formula", default="SchwarzISCO",
-                    choices=pnutils.named_frequency_cutoffs.keys(),
+                    choices=named_frequency_cutoffs.keys(),
                     help="Frequency cutoff formula for varying fupper. "
                     "Frequencies will be rounded to the nearest discrete "
                     "step. OPTIONAL.")
@@ -254,7 +254,7 @@ while True:
         Ns = 0
     # Then we check each point for acceptance
     if not (Np % 100000):
-        logging.info("%d seeds" % Np)
+        logging.info("%d seeds", Np)
     vs = vecs[:,Ns]
     Np = Np + 1
     # Stop if we hit break condition
@@ -287,8 +287,8 @@ while True:
                            mus=curr_mus) 
     N = N + 1
     if not (N % 100000):
-        logging.info("%d templates" % N)
-    Ns = Ns + 1  
+        logging.info("%d templates", N)
+    Ns = Ns + 1
 
 logging.info("Outputting bank")
 
@@ -298,9 +298,12 @@ tempBank = zip(mass1, mass2, spin1z, spin2z)
 
 # Output to file
 llw_output.output_sngl_inspiral_table(
-    opts.output_file, tempBank, metricParams, ethincaParams,
-    programName=__program__, optDict=opts.__dict__, comment="",
-    version=pycbc.version.git_hash,
-    cvs_repository='pycbc/'+pycbc.version.git_branch,
-    cvs_entry_time=pycbc.version.date)
+    opts.output_file,
+    tempBank,
+    metricParams,
+    ethincaParams,
+    programName=__program__,
+    optDict=opts.__dict__
+)
 
+logging.info("Done")

--- a/bin/bank/pycbc_geom_aligned_bank
+++ b/bin/bank/pycbc_geom_aligned_bank
@@ -26,17 +26,13 @@ in a workflow.
 import os
 import copy
 import argparse
-import tempfile
 import numpy
 import logging
 import h5py
 import configparser
 from scipy import spatial
 from ligo.lw import ligolw
-from ligo.lw import table
-from ligo.lw import lsctables
 from ligo.lw import utils as ligolw_utils
-from ligo.lw.utils import process as ligolw_process
 import pycbc
 import pycbc.psd
 import pycbc.strain
@@ -46,6 +42,7 @@ import pycbc.workflow as wf
 import pycbc.workflow.pegasus_workflow as pwf
 from pycbc.workflow import WorkflowConfigParser
 from pycbc.workflow.core import resolve_url_to_file
+from pycbc.io.ligolw import create_process_table
 
 __author__  = "Ian Harry <ian.harry@ligo.org>"
 __version__ = pycbc.version.git_verbose_msg
@@ -230,14 +227,10 @@ opts = parser.parse_args()
 orig_opts = copy.deepcopy(opts)
 
 # Set up the process/process_params table and output xml document
-cmds_file_name = opts.metadata_file
 outdoc = ligolw.Document()
 outdoc.appendChild(ligolw.LIGO_LW())
-ligolw_process.register_to_xmldoc(outdoc, __program__, vars(opts), comment="",
-                            instruments="", version=pycbc.version.git_hash,
-                            cvs_repository='pycbc/'+pycbc.version.git_branch,
-                            cvs_entry_time=pycbc.version.date)
-ligolw_utils.write_filename(outdoc, cmds_file_name)
+create_process_table(outdoc, __program__, options=vars(opts))
+ligolw_utils.write_filename(outdoc, opts.metadata_file)
 
 if opts.verbose:
     log_level = logging.DEBUG
@@ -334,7 +327,7 @@ else:
     chi3Min = vals[2].min()
     chi3Diff = chi3Max - chi3Min
 
-logging.info("Lattice contains %d points" % len(v1s))
+logging.info("Lattice contains %d points", len(v1s))
 
 # Now remove points that are too far from edges of parameter space
 
@@ -384,7 +377,7 @@ if opts.filter_points:
             if opts.threed_lattice:
                 newV3s.append(v3s[i])
 
-    logging.info("Filtered lattice contains %d points" % len(newV1s))
+    logging.info("Filtered lattice contains %d points", len(newV1s))
 else:
     newV1s = v1s
     newV2s = v2s
@@ -584,7 +577,7 @@ else:
 
 combine_exe = AlignedBankCatExecutable(workflow.cp, 'alignedbankcat',
                                         ifos=workflow.ifos, out_dir=curr_dir)
-metadata_file = resolve_url_to_file(cmds_file_name)
+metadata_file = resolve_url_to_file(opts.metadata_file)
 combine_node = combine_exe.create_node(all_outs, metadata_file,
                                        workflow.analysis_time,
                                        output_file_path=opts.output_file)

--- a/bin/bank/pycbc_geom_nonspinbank
+++ b/bin/bank/pycbc_geom_nonspinbank
@@ -263,7 +263,7 @@ if lower1DBoundary is not None:
 v1s = numpy.array(v1s)
 v2s = numpy.array(v2s)
 
-logging.info("%d points in the lattice" % len(v1s))
+logging.info("%d points in the lattice", len(v1s))
 
 # What follows is used to
 #   1) Check if the points are close to the physical space, if not reject
@@ -382,11 +382,12 @@ logging.info("Writing output")
 # easily changed.
 
 llw_output.output_sngl_inspiral_table(
-    opts.output_file, tempBank, metricParams, ethincaParams,
-    programName=__program__, optDict=opts.__dict__,
-    version=pycbc.version.git_hash,
-    cvs_repository='pycbc/'+pycbc.version.git_branch,
-    cvs_entry_time=pycbc.version.date)
+    opts.output_file,
+    tempBank,
+    metricParams,
+    ethincaParams,
+    programName=__program__,
+    optDict=opts.__dict__
+)
 
 logging.info("Done")
-

--- a/docs/tmpltbank.rst
+++ b/docs/tmpltbank.rst
@@ -208,6 +208,7 @@ Here is one example for making an aligned-spin template bank using a pre-generat
         --asd-file /home/spxiwh/aLIGO/BBH_template_banks/asd-T1200307v4.txt \
         --intermediate-data-file intermediate.hdf \
         --metadata-file metadata.xml \
+        --workflow-name example_geom_aligned_bank \
         --supplement-config-file supplement.ini
 
 The file ``supplement.ini`` can be used to specify extra options.  When running

--- a/docs/tmpltbank.rst
+++ b/docs/tmpltbank.rst
@@ -189,15 +189,47 @@ Here is one example for making an aligned-spin template bank using a pre-generat
 
 .. code-block:: bash
 
-    pycbc_geom_aligned_bank --pn-order threePointFivePN --f0 70 --f-low 15 --f-upper 1000 --delta-f 0.01 --min-match 0.97 --min-mass1 2.5 --min-mass2 2.5 --max-mass1 3. --max-mass2 3. --verbose --max-ns-spin-mag 0.05 --max-bh-spin-mag 0.05 --output-file testAligned.xml --split-bank-num 5 --asd-file /home/spxiwh/aLIGO/BBH_template_banks/asd-T1200307v4.txt --intermediate-data-file intermediate.hdf --metadata-file metadata.xml
+    pycbc_geom_aligned_bank \
+        --pn-order threePointFivePN \
+        --f0 70 \
+        --f-low 15 \
+        --f-upper 1000 \
+        --delta-f 0.01 \
+        --min-match 0.97 \
+        --min-mass1 2.5 \
+        --min-mass2 2.5 \
+        --max-mass1 3 \
+        --max-mass2 3 \
+        --verbose \
+        --max-ns-spin-mag 0.05 \
+        --max-bh-spin-mag 0.05 \
+        --output-file testAligned.xml \
+        --split-bank-num 5 \
+        --asd-file /home/spxiwh/aLIGO/BBH_template_banks/asd-T1200307v4.txt \
+        --intermediate-data-file intermediate.hdf \
+        --metadata-file metadata.xml \
+        --supplement-config-file supplement.ini
 
-and then submitted with something like:
+The file ``supplement.ini`` can be used to specify extra options.  When running
+on LIGO Data Grid clusters, this file should contain at least the following:
+
+.. code-block::
+
+    [pegasus_profile]
+    condor|accounting_group = accounting.tag
+    condor|request_disk = 1024
+
+where ``accounting.tag`` should be replaced with one of the valid accounting
+tags. On non-LDG clusters, ``--supplement-config-file supplement.ini`` can be
+omitted if there are no extra options to give.
+
+After running ``pycbc_geom_aligned_bank``, submit the workflow with
 
 .. code-block:: bash
 
-    pycbc_submit_dax --dax bank_gen.dax --accounting-group ligo.dev.o2.cbc.bbh.pycbcoffline
+    pycbc_submit_dax
 
-run
+Run
 
 .. code-block:: bash
 

--- a/examples/tmpltbank/make_cache.sh
+++ b/examples/tmpltbank/make_cache.sh
@@ -1,1 +1,8 @@
-gw_data_find --observatory H --type H1_NINJA2_G1000176_EARLY_RECOLORED --gps-start-time 900000024 --gps-end-time 900010677 --url-type file --lal-cache > cache/H-H1_NINJA2_G1000176_EARLY_RECOLORED_CACHE-900000024-10653.lcf
+mkdir -p cache
+gw_data_find \
+    --observatory H \
+    --type H1_NINJA2_G1000176_EARLY_RECOLORED \
+    --gps-start-time 900000024 \
+    --gps-end-time 900010677 \
+    --url-type file \
+    --lal-cache > cache/H-H1_NINJA2_G1000176_EARLY_RECOLORED_CACHE-900000024-10653.lcf

--- a/examples/tmpltbank/testAligned.sh
+++ b/examples/tmpltbank/testAligned.sh
@@ -1,1 +1,20 @@
-pycbc_geom_aligned_bank --pn-order threePointFivePN --f0 70 --f-low 15 --f-upper 1000 --delta-f 0.01 --min-match 0.97 --min-mass1 2.5 --min-mass2 2.5 --max-mass1 3. --max-mass2 3. --verbose --log-path /usr1/spxiwh/logs --max-ns-spin-mag 0.05 --max-bh-spin-mag 0.05 --output-file testAligned.xml --split-bank-num 5 --asd-file ZERO_DET_high_P.txt
+pycbc_geom_aligned_bank \
+    --workflow-name testAligned \
+    --verbose \
+    --pn-order threePointFivePN \
+    --f0 70 \
+    --f-low 15 \
+    --f-upper 1000 \
+    --delta-f 0.01 \
+    --min-match 0.97 \
+    --min-mass1 2.5 \
+    --min-mass2 2.5 \
+    --max-mass1 3 \
+    --max-mass2 3 \
+    --max-ns-spin-mag 0.05 \
+    --max-bh-spin-mag 0.05 \
+    --output-file testAligned.xml \
+    --split-bank-num 5 \
+    --asd-file ZERO_DET_high_P.txt \
+    --intermediate-data-file intermediate.hdf \
+    --metadata-file metadata.xml

--- a/examples/tmpltbank/testAligned2.sh
+++ b/examples/tmpltbank/testAligned2.sh
@@ -1,3 +1,33 @@
 # Exactly 18706 templates expected
 
-pycbc_geom_aligned_bank --pn-order threePointFivePN --f0 60 --f-low 60 --f-upper 1000 --delta-f 0.01 --min-match 0.97 --min-mass1 1. --min-mass2 1. --max-mass1 5. --max-mass2 5. --min-total-mass 2.5 --max-total-mass 6.0 --min-chirp-mass 1.2187707886145738 --max-chirp-mass 2.4375415772291475 --min-eta 0.16 --max-eta 0.24 --verbose --log-path /usr1/spxiwh/logs --max-ns-spin-mag 0.5 --max-bh-spin-mag 0.9 --ns-bh-boundary-mass 2.0 --output-file testAligned.xml --split-bank-num 50 --asd-file ZERO_DET_high_P.txt  --random-seed 20 --calculate-time-metric-components --filter-cutoff SchwarzISCO --filter-points
+pycbc_geom_aligned_bank \
+    --workflow-name testAligned2 \
+    --verbose \
+    --pn-order threePointFivePN \
+    --f0 60 \
+    --f-low 60 \
+    --f-upper 1000 \
+    --delta-f 0.01 \
+    --min-match 0.97 \
+    --min-mass1 1 \
+    --min-mass2 1 \
+    --max-mass1 5 \
+    --max-mass2 5 \
+    --min-total-mass 2.5 \
+    --max-total-mass 6 \
+    --min-chirp-mass 1.2187707886145738 \
+    --max-chirp-mass 2.4375415772291475 \
+    --min-eta 0.16 \
+    --max-eta 0.24 \
+    --max-ns-spin-mag 0.5 \
+    --max-bh-spin-mag 0.9 \
+    --ns-bh-boundary-mass 2 \
+    --output-file testAligned2.xml \
+    --split-bank-num 50 \
+    --asd-file ZERO_DET_high_P.txt \
+    --random-seed 20 \
+    --calculate-time-metric-components \
+    --filter-cutoff SchwarzISCO \
+    --filter-points \
+    --intermediate-data-file intermediate.hdf \
+    --metadata-file metadata.xml

--- a/examples/tmpltbank/testAligned3.sh
+++ b/examples/tmpltbank/testAligned3.sh
@@ -1,2 +1,21 @@
 # 3980 templates
-pycbc_geom_aligned_bank --pn-order threePointFivePN --f0 70 --f-low 15 --f-upper 1000 --delta-f 0.01 --min-match 0.97 --min-mass1 2.5 --min-mass2 2.5 --max-mass1 3. --max-mass2 3. --verbose --log-path /usr1/spxiwh/logs --max-ns-spin-mag 0.05 --max-bh-spin-mag 0.05 --output-file testAligned.xml --split-bank-num 10 --asd-file ZERO_DET_high_P.txt
+pycbc_geom_aligned_bank \
+    --workflow-name testAligned3 \
+    --verbose \
+    --pn-order threePointFivePN \
+    --f0 70 \
+    --f-low 15 \
+    --f-upper 1000 \
+    --delta-f 0.01 \
+    --min-match 0.97 \
+    --min-mass1 2.5 \
+    --min-mass2 2.5 \
+    --max-mass1 3 \
+    --max-mass2 3 \
+    --max-ns-spin-mag 0.05 \
+    --max-bh-spin-mag 0.05 \
+    --output-file testAligned3.xml \
+    --split-bank-num 10 \
+    --asd-file ZERO_DET_high_P.txt \
+    --intermediate-data-file intermediate.hdf \
+    --metadata-file metadata.xml

--- a/examples/tmpltbank/testNonspin2.sh
+++ b/examples/tmpltbank/testNonspin2.sh
@@ -1,2 +1,24 @@
 # About 482 templates
-pycbc_geom_nonspinbank --pn-order twoPN --f0 40 --f-low 40 --f-upper 2048 --delta-f 0.1 --min-match 0.97 --min-mass1 2.0 --min-mass2 2.0 --max-mass1 3. --max-mass2 3. --verbose --output-file testNonSpin2.xml --calculate-ethinca-metric --filter-cutoff SchwarzISCO --asd-file ZERO_DET_high_P.txt
+
+pycbc_geom_nonspinbank \
+    --pn-order twoPN \
+    --f0 40 \
+    --f-low 40 \
+    --f-upper 2048 \
+    --delta-f 0.1 \
+    --min-match 0.97 \
+    --min-mass1 2.0 \
+    --min-mass2 2.0 \
+    --max-mass1 3 \
+    --max-mass2 3 \
+    --verbose \
+    --output-file testNonSpin2.xml \
+    --calculate-ethinca-metric \
+    --filter-cutoff SchwarzISCO \
+    --asd-file ZERO_DET_high_P.txt
+
+ligolw_print \
+    -t sngl_inspiral \
+    -c mass1 \
+    -c mass2 \
+    testNonSpin2.xml

--- a/pycbc/io/ligolw.py
+++ b/pycbc/io/ligolw.py
@@ -126,18 +126,20 @@ def return_search_summary(start_time=0, end_time=0, nevents=0, ifos=None):
     return search_summary
 
 def create_process_table(document, program_name=None, detectors=None,
-                         comment=None):
+                         comment=None, options=None):
     """Create a LIGOLW process table with sane defaults, add it to a LIGOLW
     document, and return it.
     """
     if program_name is None:
         program_name = os.path.basename(sys.argv[0])
+    if options is None:
+        options = {}
 
     # ligo.lw does not like `cvs_entry_time` being an empty string
     cvs_entry_time = pycbc_version.date or None
 
     process = ligolw_process.register_to_xmldoc(
-            document, program_name, {}, version=pycbc_version.version,
+            document, program_name, options, version=pycbc_version.version,
             cvs_repository='pycbc/'+pycbc_version.git_branch,
             cvs_entry_time=cvs_entry_time, instruments=detectors,
             comment=comment)

--- a/pycbc/tmpltbank/bank_output_utils.py
+++ b/pycbc/tmpltbank/bank_output_utils.py
@@ -1,10 +1,11 @@
 import numpy
 from lal import PI, MTSUN_SI, TWOPI, GAMMA
 from ligo.lw import ligolw, lsctables, utils as ligolw_utils
-from ligo.lw.utils import process as ligolw_process
 from pycbc import pnutils
 from pycbc.tmpltbank.lambda_mapping import ethinca_order_from_string
-from pycbc.io.ligolw import return_empty_sngl, return_search_summary
+from pycbc.io.ligolw import (
+    return_empty_sngl, return_search_summary, create_process_table
+)
 
 
 def convert_to_sngl_inspiral_table(params, proc_id):
@@ -201,8 +202,8 @@ def output_sngl_inspiral_table(outputFile, tempBank, metricParams,
                                ethincaParams, programName="", optDict = None,
                                outdoc=None, **kwargs):
     """
-    Function that converts the information produced by the various pyCBC bank
-    generation codes into a valid LIGOLW xml file containing a sngl_inspiral
+    Function that converts the information produced by the various PyCBC bank
+    generation codes into a valid LIGOLW XML file containing a sngl_inspiral
     table and outputs to file.
 
     Parameters
@@ -228,9 +229,6 @@ def output_sngl_inspiral_table(outputFile, tempBank, metricParams,
     outdoc (key-word argument) : ligolw xml document
         If given add template bank to this representation of a xml document and
         write to disk. If not given create a new document.
-    kwargs : key-word arguments
-        All other key word arguments will be passed directly to
-        ligolw_process.register_to_xmldoc
     """
     if optDict is None:
         optDict = {}
@@ -244,9 +242,13 @@ def output_sngl_inspiral_table(outputFile, tempBank, metricParams,
         if optDict['channel_name'] is not None:
             ifos = [optDict['channel_name'][0:2]]
 
-    proc_id = ligolw_process.register_to_xmldoc(
-            outdoc, programName, optDict,
-            instruments=ifos, **kwargs).process_id
+    proc = create_process_table(
+        outdoc,
+        program_name=programName,
+        detectors=ifos,
+        options=optDict
+    )
+    proc_id = proc.process_id
     sngl_inspiral_table = convert_to_sngl_inspiral_table(tempBank, proc_id)
     # Calculate Gamma components if needed
     if ethincaParams is not None:

--- a/pycbc/tmpltbank/bank_output_utils.py
+++ b/pycbc/tmpltbank/bank_output_utils.py
@@ -200,7 +200,7 @@ def calculate_ethinca_metric_comps(metricParams, ethincaParams, mass1, mass2,
 
 def output_sngl_inspiral_table(outputFile, tempBank, metricParams,
                                ethincaParams, programName="", optDict = None,
-                               outdoc=None, **kwargs):
+                               outdoc=None):
     """
     Function that converts the information produced by the various PyCBC bank
     generation codes into a valid LIGOLW XML file containing a sngl_inspiral

--- a/tools/pycbc_test_suite.sh
+++ b/tools/pycbc_test_suite.sh
@@ -60,6 +60,18 @@ if [ "$PYCBC_TEST_TYPE" = "search" ] || [ -z ${PYCBC_TEST_TYPE+x} ]; then
     fi
     popd
 
+    # run a quick bank placement example
+    pushd examples/tmpltbank
+    bash -e testNonspin2.sh
+    if test $? -ne 0 ; then
+        RESULT=1
+        echo -e "    FAILED!"
+        echo -e "---------------------------------------------------------"
+    else
+        echo -e "    Pass."
+    fi
+    popd
+
     # run PyCBC Live test
     if ((${PYTHON_MINOR_VERSION} > 7)); then
       # ligo.skymap is only supporting python3.8+, and older releases are


### PR DESCRIPTION
This fixes a few issues with the bank placement codes.
* Most importantly, this fixes #3932.
* Fixes the scripts in `examples/tmpltbank`, which no longer work due to CLI syntax changes over the years.
* Updates the documentation page, which was also outdated by the CLI syntax changes.
* Adds one of the examples to the test suite.

Thanks to @soumenroy for help in debugging these issues and providing the modern syntax for `pycbc_geom_aligned_bank`.