### PR TITLE
add reconstruction of phase if it has been marginalized

### DIFF
--- a/pycbc/inference/models/single_template.py
+++ b/pycbc/inference/models/single_template.py
@@ -220,7 +220,7 @@ class SingleTemplate(DistMarg, BaseGaussianNoise):
             htf = (fp * ip + 1.0j * fc * ic) / p['distance'] * phase
             self.htfs[ifo] = htf
             self.dts[ifo] = p['tc'] + dt
-            sh = self.sh[ifo].at_time(self.dts[ifo], nearest_sample=True) * htf
+            sh = self.sh[ifo].at_time(self.dts[ifo], interpolate=True) * htf
             sh_total += sh
             hh_total += self.hh[ifo] * abs(htf) ** 2.0
 

--- a/pycbc/inference/models/single_template.py
+++ b/pycbc/inference/models/single_template.py
@@ -207,13 +207,13 @@ class SingleTemplate(DistMarg, BaseGaussianNoise):
             phase = numpy.exp(1.0j * 2 * p['coa_phase'])
 
         sh_total = hh_total = 0
+        ic = numpy.cos(p['inclination'])
+        ip = 0.5 * (1.0 + ic * ic)
         for ifo in self.sh:
             fp, fc = self.det[ifo].antenna_pattern(p['ra'], p['dec'],
                                                    polarization, self.time)
             dt = self.det[ifo].time_delay_from_earth_center(p['ra'], p['dec'],
                                                             self.time)
-            ic = numpy.cos(p['inclination'])
-            ip = 0.5 * (1.0 + ic * ic)
 
             # Note, this includes complex conjugation already
             # as our stored inner products were hp*xdata

--- a/pycbc/inference/models/single_template.py
+++ b/pycbc/inference/models/single_template.py
@@ -220,8 +220,8 @@ class SingleTemplate(DistMarg, BaseGaussianNoise):
             htf = (fp * ip + 1.0j * fc * ic) / p['distance'] * phase
             self.htfs[ifo] = htf
             self.dts[ifo] = p['tc'] + dt
-            sh = self.sh[ifo].at_time(self.dts[ifo], interpolate='quadratic') * htf
-            sh_total += sh
+            sh = self.sh[ifo].at_time(self.dts[ifo], interpolate='quadratic')
+            sh_total += sh * htf
             hh_total += self.hh[ifo] * abs(htf) ** 2.0
 
         return self.marginalize_loglr(sh_total, hh_total)

--- a/pycbc/inference/models/single_template.py
+++ b/pycbc/inference/models/single_template.py
@@ -220,7 +220,7 @@ class SingleTemplate(DistMarg, BaseGaussianNoise):
             htf = (fp * ip + 1.0j * fc * ic) / p['distance'] * phase
             self.htfs[ifo] = htf
             self.dts[ifo] = p['tc'] + dt
-            sh = self.sh[ifo].at_time(self.dts[ifo], interpolate=True) * htf
+            sh = self.sh[ifo].at_time(self.dts[ifo], interpolate='quadratic') * htf
             sh_total += sh
             hh_total += self.hh[ifo] * abs(htf) ** 2.0
 

--- a/pycbc/inference/models/tools.py
+++ b/pycbc/inference/models/tools.py
@@ -259,7 +259,7 @@ class DistMarg():
             elif self.marginalize_vector:
                 s, h = s[xl2], h[xl2]
             elif self.distance_marginalization:
-                s, h = s[xl1], h[xl1]
+                s, h = s[xl], h[xl]
 
             phasev = numpy.linspace(0, numpy.pi*2.0, int(1e4))
             phasel = (numpy.exp(2.0j * phasev) * s).real + h

--- a/pycbc/inference/models/tools.py
+++ b/pycbc/inference/models/tools.py
@@ -197,7 +197,7 @@ class DistMarg():
             skip_vector = True
             interpolator = None
             if self.reconstruct_phase:
-                return_complex=True
+                return_complex = True
 
         return marginalize_likelihood(sh_total, hh_total,
                                       phase=self.marginalize_phase,
@@ -255,7 +255,7 @@ class DistMarg():
 
             s, h = self.loglr
             if self.marginalize_vector and self.distance_marginalization:
-                s, h = s[:,xl][xl2], h[:,xl][xl2]
+                s, h = s[:, xl][xl2], h[:, xl][xl2]
             elif self.marginalize_vector:
                 s, h = s[xl2], h[xl2]
             elif self.distance_marginalization:
@@ -345,7 +345,12 @@ def marginalize_likelihood(sh, hh,
                            return_peak=False,
                            return_complex=False,
                            ):
-    """ Return the marginalized likelihood
+    """ Return the marginalized likelihood.
+
+    Apply various marginalizations to the data, including phase, distance,
+    and brute-force vector marginalizations. Several options relate
+    to how the distance marginalization is approximated and others allow for
+    special return products to aid in parameter reconstruction.
 
     Parameters
     ----------
@@ -364,6 +369,13 @@ def marginalize_likelihood(sh, hh,
         If provided, internal calculation is skipped in favor of a
         precalculated interpolating function which takes in sh/hh
         and returns the likelihood.
+    return_peak: bool, False
+        Return the peak likelihood and index if using passing an array as
+        input in addition to the marginalized over the array likelihood.
+    return_complex: bool, False
+        Return the sh / hh data products before applying phase marginalization.
+        This option is intended to aid in reconstucting phase marginalization
+        and is unlikely to be useful for other purposes.
 
     Returns
     -------
@@ -378,7 +390,7 @@ def marginalize_likelihood(sh, hh,
         clogweights = numpy.log(len(sh))
 
     if return_complex:
-        sh = sh
+        pass
     elif phase:
         sh = abs(sh)
     else:
@@ -407,10 +419,10 @@ def marginalize_likelihood(sh, hh,
 
         if return_complex:
             return sh, -0.5 * hh
-        elif phase:
+
+        # Apply the phase marginalization
+        if phase:
             sh = numpy.log(i0e(sh)) + sh
-        else:
-            sh = sh.real
 
         # Calculate loglikelihood ratio
         vloglr = sh - 0.5 * hh

--- a/pycbc/inference/models/tools.py
+++ b/pycbc/inference/models/tools.py
@@ -251,16 +251,16 @@ class DistMarg():
             self.reconstruct_phase = True
             self.update(**self.current_params)
 
-            loglr_full = self.loglr
+            s, h = self.loglr
             if self.marginalize_vector and self.distance_marginalization:
-                loglr = loglr_full[:,xl][xl2]
+                s, h = s[:,xl][xl2], h[:,xl][xl2]
             elif self.marginalize_vector:
-                loglr = loglr_full[xl2]
+                s, h = s[xl2], h[xl2]
             elif self.distance_marginalization:
-                loglr = loglr_full[xl]
+                s, h = s[xl1], h[xl1]
 
             phasev = numpy.linspace(0, numpy.pi*2.0, int(1e4))
-            phasel = (numpy.exp(2.0j * phasev) * loglr).real
+            phasel = (numpy.exp(2.0j * phasev) * s).real + h
             rec['coa_phase'] = draw_sample(phasev, phasel)[0]
             self.reconstruct_phase = False
 
@@ -402,7 +402,7 @@ def marginalize_likelihood(sh, hh,
                 vweights = dist_weights
 
         if return_complex:
-            sh = sh
+            return sh, -0.5 * hh
         elif phase:
             sh = numpy.log(i0e(sh)) + sh
         else:

--- a/pycbc/inference/models/tools.py
+++ b/pycbc/inference/models/tools.py
@@ -83,7 +83,7 @@ class DistMarg():
         self.marginalize_vector = marginalize_vector
         self.marginalize_vector_params = marginalize_vector_params
 
-        self.reconstructing_distance = False
+        self.reconstructing = False
         self.marginalize_phase = str_to_bool(marginalize_phase)
         self.distance_marginalization = False
         self.distance_interpolator = None
@@ -191,7 +191,7 @@ class DistMarg():
             vector, instead return the likelihood values as a vector.
         """
         interpolator = self.distance_interpolator
-        if self.reconstructing_distance:
+        if self.reconstructing:
             skip_vector = True
             interpolator = None
 
@@ -206,6 +206,7 @@ class DistMarg():
         """ Reconstruct the distance or vectored marginalized parameter
         of this class.
         """
+        self.reconstructing = True
         rec = {}
 
         def draw_sample(params, loglr):
@@ -214,10 +215,6 @@ class DistMarg():
             cdf /= cdf[-1]
             xl = numpy.searchsorted(cdf, x)
             return params[xl], xl
-
-        if self.distance_marginalization:
-            # turn off interpolator and set to return vector output
-            self.reconstructing_distance = True
 
         loglr_full = self.loglr
         if self.marginalize_vector and self.distance_marginalization:
@@ -243,8 +240,7 @@ class DistMarg():
 
             vec_param, _ = draw_sample(self.marginalize_vector_params, vlr)
             rec[self.marginalize_vector] = vec_param
-
-        self.reconstructing_distance = False
+        self.reconstructing = False
         return rec
 
 

--- a/pycbc/inference/models/tools.py
+++ b/pycbc/inference/models/tools.py
@@ -216,7 +216,7 @@ class DistMarg():
 
         def draw_sample(params, loglr):
             x = numpy.random.uniform()
-            loglr -= loglr.max()
+            loglr = loglr - loglr.max()
             cdf = numpy.exp(loglr).cumsum()
             cdf /= cdf[-1]
             xl = numpy.searchsorted(cdf, x)
@@ -236,6 +236,7 @@ class DistMarg():
             # draw distance sample
             dist, xl = draw_sample(self.dist_locs, loglr)
             rec['distance'] = dist
+            rec['loglr'] = loglr[xl]
 
         if self.marginalize_vector:
             if self.distance_marginalization:
@@ -246,6 +247,7 @@ class DistMarg():
 
             vec_param, xl2 = draw_sample(self.marginalize_vector_params, vlr)
             rec[self.marginalize_vector] = vec_param
+            rec['loglr'] = vlr[xl2]
 
         if self.marginalize_phase:
             self.reconstruct_phase = True
@@ -261,9 +263,11 @@ class DistMarg():
 
             phasev = numpy.linspace(0, numpy.pi*2.0, int(1e4))
             phasel = (numpy.exp(2.0j * phasev) * s).real + h
-            rec['coa_phase'] = draw_sample(phasev, phasel)[0]
+            rec['coa_phase'], xl3 = draw_sample(phasev, phasel)
             self.reconstruct_phase = False
+            rec['loglr'] = phasel[xl3]
 
+        rec['loglikelihood'] = self.lognl + rec['loglr']
         self.reconstructing = False
         return rec
 

--- a/pycbc/types/timeseries.py
+++ b/pycbc/types/timeseries.py
@@ -240,7 +240,7 @@ class TimeSeries(Array):
     sample_times = property(get_sample_times,
                             doc="Array containing the sample times.")
 
-    def at_time(self, time, nearest_sample=False, interpolate=False):
+    def at_time(self, time, nearest_sample=False, interpolate=None):
         """ Return the value at the specified gps time
 
         Parameters
@@ -248,9 +248,9 @@ class TimeSeries(Array):
         nearest_sample: bool
             Return the sample at the time nearest to the chosen time rather
             than rounded down.
-        interpolate: bool
-            Return the linear interpolated value of the time series
-            at the time chosen.
+        interpolate: str, None
+            Return the interpolated value of the time series. Choices
+            are simple linear or quadratic interpolation.
         """
         if interpolate == 'linear':
             i = float(time-self.start_time)*self.sample_rate

--- a/pycbc/types/timeseries.py
+++ b/pycbc/types/timeseries.py
@@ -240,9 +240,17 @@ class TimeSeries(Array):
     sample_times = property(get_sample_times,
                             doc="Array containing the sample times.")
 
-    def at_time(self, time, nearest_sample=False):
+    def at_time(self, time, nearest_sample=False, interpolate=False):
         """ Return the value at the specified gps time
         """
+        if interpolate:
+            i = float(time-self.start_time)*self.sample_rate
+            di = i - int(i)
+            i = int(i)
+            a = self[i]
+            b = self[i+1]
+            return a + (b - a) * di
+
         if nearest_sample:
             time += self.delta_t / 2.0
         return self[int((time-self.start_time)*self.sample_rate)]

--- a/pycbc/types/timeseries.py
+++ b/pycbc/types/timeseries.py
@@ -252,13 +252,23 @@ class TimeSeries(Array):
             Return the linear interpolated value of the time series
             at the time chosen.
         """
-        if interpolate:
+        if interpolate == 'linear':
             i = float(time-self.start_time)*self.sample_rate
             di = i - int(i)
             i = int(i)
             a = self[i]
             b = self[i+1]
             return a + (b - a) * di
+        elif interpolate == 'quadratic':
+            i = float(time-self.start_time)*self.sample_rate
+            di = i - int(i)
+            i = int(i)
+            c = self[i]
+            xr = self[i + 1] - c
+            xl = self[i - 1] - c
+            a = 0.5 * (xr + xl)
+            b = 0.5 * (xr - xl)
+            return a * di**2.0 + b * di + c
 
         if nearest_sample:
             time += self.delta_t / 2.0

--- a/pycbc/types/timeseries.py
+++ b/pycbc/types/timeseries.py
@@ -242,6 +242,15 @@ class TimeSeries(Array):
 
     def at_time(self, time, nearest_sample=False, interpolate=False):
         """ Return the value at the specified gps time
+
+        Parameters
+        ----------
+        nearest_sample: bool
+            Return the sample at the time nearest to the chosen time rather
+            than rounded down.
+        interpolate: bool
+            Return the linear interpolated value of the time series
+            at the time chosen.
         """
         if interpolate:
             i = float(time-self.start_time)*self.sample_rate
@@ -253,6 +262,7 @@ class TimeSeries(Array):
 
         if nearest_sample:
             time += self.delta_t / 2.0
+
         return self[int((time-self.start_time)*self.sample_rate)]
 
     def __eq__(self,other):


### PR DESCRIPTION
This patch allows one to demarginalize the coa_phase if it has been analytically marginalized over. I also add an option to 
'at_time' to allow for simple linear interpolation instead of nearest point. This smooths over some issues in the sample rate of the single template model (there are some obvious future improvements here as well). 