### PR TITLE
Fix bug in workflow with --output-dir

### DIFF
--- a/bin/workflows/pycbc_make_uberbank_workflow
+++ b/bin/workflows/pycbc_make_uberbank_workflow
@@ -103,6 +103,7 @@ class SbankDaxGenerator(wf.Executable):
 
         node.add_opt('--workflow-name', workflow_name)
         node.add_opt('--output-dir', out_storage_path)
+        node.add_opt('--dax-file-directory', '.')
 
         if sub_wf_tags is not None:
             node.add_opt('--tags', ' '.join(sub_wf_tags))

--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -788,7 +788,6 @@ class Workflow(pegasus_workflow.Workflow):
 
         # save the configuration file
         ini_file = os.path.join(self.out_dir, self.name + '.ini')
-            
 
         # This shouldn't already exist, but just in case
         if os.path.isfile(ini_file):

--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -784,13 +784,14 @@ class Workflow(pegasus_workflow.Workflow):
             self.add_container(container)
 
         # save the configuration file
-        ini_file = os.path.abspath(self.name + '.ini')
+        ini_file = os.path.join(self.out_dir, self.name + '.ini')
+            
 
         # This shouldn't already exist, but just in case
         if os.path.isfile(ini_file):
             err_msg = "Refusing to overwrite configuration file that "
             err_msg += "shouldn't be there: "
-            err_msg += os.path.join(self.out_dir, ini_file)
+            err_msg += ini_file
             raise ValueError(err_msg)
 
         with open(ini_file, 'w') as fp:

--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -632,9 +632,12 @@ class Workflow(pegasus_workflow.Workflow):
         else:
             dax_file = None
 
+        if hasattr(args, 'dax_file_directory'):
+            output_dir = args.dax_file_directory or args.output_dir or None
+
         super(Workflow, self).__init__(
             name=name if name is not None else args.workflow_name,
-            directory=args.output_dir,
+            directory=output_dir,
             cache_file=args.cache_file,
             dax_file_name=dax_file,
         )
@@ -2165,8 +2168,8 @@ def add_workflow_settings_cli(parser, include_subdax_opts=False):
     parser : argparse.ArgumentParser
         Argument parser to add the options to.
     include_subdax_opts : bool, optional
-        If True, will add output-map, transformation-catalog, and dax-file
-        options to the parser. These can be used for workflows that are
+        If True, will add output-map and dax-file-directory options
+        to the parser. These can be used for workflows that are
         generated as a subdax of another workflow. Default is False.
     """
     wfgrp = parser.add_argument_group("Options for setting workflow files")
@@ -2196,3 +2199,11 @@ def add_workflow_settings_cli(parser, include_subdax_opts=False):
     if include_subdax_opts:
         wfgrp.add_argument("--output-map", default=None,
                            help="Path to an output map file.")
+        wfgrp.add_argument("--dax-file-directory", default=None,
+                           help="Put dax files (including output map, "
+                                "sites.yml etc. in this directory. The use "
+                                "case for this is when running a sub-workflow "
+                                "under pegasus the outputs need to be copied "
+                                "back to the appropriate directory, and "
+                                "using this as --dax-file-directory . allows "
+                                "that to be done.")

--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -634,6 +634,8 @@ class Workflow(pegasus_workflow.Workflow):
 
         if hasattr(args, 'dax_file_directory'):
             output_dir = args.dax_file_directory or args.output_dir or None
+        else:
+            output_dir = args.output_dir or None
 
         super(Workflow, self).__init__(
             name=name if name is not None else args.workflow_name,

--- a/pycbc/workflow/minifollowups.py
+++ b/pycbc/workflow/minifollowups.py
@@ -105,6 +105,7 @@ def setup_foreground_minifollowups(workflow, coinc_file, single_triggers,
 
     node.add_opt('--workflow-name', name)
     node.add_opt('--output-dir', out_dir)
+    node.add_opt('--dax-file-directory', '.')
 
     workflow += node
 
@@ -205,6 +206,7 @@ def setup_single_det_minifollowups(workflow, single_trig_file, tmpltbank_file,
 
     node.add_opt('--workflow-name', name)
     node.add_opt('--output-dir', out_dir)
+    node.add_opt('--dax-file-directory', '.')
 
     workflow += node
 
@@ -295,6 +297,7 @@ def setup_injection_minifollowups(workflow, injection_file, inj_xml_file,
 
     node.add_opt('--workflow-name', name)
     node.add_opt('--output-dir', out_dir)
+    node.add_opt('--dax-file-directory', '.')
 
     workflow += node
 

--- a/pycbc/workflow/pegasus_workflow.py
+++ b/pycbc/workflow/pegasus_workflow.py
@@ -619,6 +619,9 @@ class Workflow(object):
                     # There was no storage path
                     pass
 
+        # Pegasus requires that we write the DAX file into the local directory
+        olddir = os.getcwd()
+        os.chdir(self.out_dir)
         self._adag.write(filename)
         if not self.in_workflow:
             if submit_now or plan_now:
@@ -646,6 +649,7 @@ class Workflow(object):
                     # set this in submit_dax still?
                     f.write('-vvv ')
                     f.write('--dax {}'.format(filename))
+        os.chdir(olddir)
 
     def plan_and_submit(self, submit_now=True):
         """ Plan and submit the workflow now.


### PR DESCRIPTION
As per recent discussion in SLACK with Nathan, it seems there is an issue with most workflow generators (not the search workflow, as it explicitly does a `chdir` operation), when the `--output-dir` option is set.

It was intended that the workflow understand this, and use it when dumping outputs, but it used `output_dir` for sites.yml and output.map, but the dax file, the ini file, and the additional planner args (it using the old submit_dax) ended up in the cwd.

This puts the latter 3 also in the output_dir, not the CWD. I have tested this for Nathan's case, but would have to rely on the test case to test a bunch of different possible use cases.