### PR TITLE
Prepare for release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -122,8 +122,8 @@ def get_version_info():
         vinfo = _version_helper.generate_git_version_info()
     except:
         vinfo = vdummy()
-        vinfo.version = '2.0.dev5'
-        vinfo.release = 'False'
+        vinfo.version = '2.0.5'
+        vinfo.release = 'True'
 
     with open('pycbc/version.py', 'wb') as f:
         f.write("# coding: utf-8\n".encode('utf-8'))


### PR DESCRIPTION
We really need a new release including #4079 as 2.0.4 is broken in many use cases.