### PR TITLE
Fix generate_hwinj

### DIFF
--- a/bin/hwinj/pycbc_generate_hwinj
+++ b/bin/hwinj/pycbc_generate_hwinj
@@ -19,6 +19,7 @@
 import argparse
 from ligo.lw import ligolw
 from ligo.lw import lsctables
+from ligo.lw import table
 from ligo.lw import utils
 import logging
 import numpy
@@ -60,7 +61,7 @@ def _empty_row(obj):
             setattr(row,entry,0)
         elif cols[entry] == 'lstring':
             setattr(row,entry,'')
-        elif entry == 'process_id':
+        elif entry in ['process_id', 'process:process_id']:
             row.process_id = 0
         elif entry == 'simulation_id':
             row.simulation_id = 0
@@ -297,7 +298,8 @@ if opts.dquad_mon2 is not None:
 # You'd think that would it to redefine the table columns, but wait, it gets
 # worse!
 class SimInspiralNew(lsctables.SimInspiral):
-    __slots__ = lsctables.SimInspiralTable.validcolumns.keys()
+    __slots__ = tuple(map(table.Column.ColumnName,
+                          lsctables.SimInspiralTable.validcolumns))
 lsctables.SimInspiral = SimInspiralNew
 lsctables.SimInspiralTable.RowType = SimInspiralNew
 
@@ -499,7 +501,7 @@ pad_seconds = 5
 template_duration_seconds = int( len(h_plus) / sample_rate ) + 1
 start_time = int(sim.geocent_end_time) - template_duration_seconds - pad_seconds
 end_time = int(sim.geocent_end_time) + 1 + pad_seconds
-num_samples = (end_time - start_time) * sample_rate
+num_samples = int((end_time - start_time) * sample_rate)
 
 # append rows to XML tables
 sim_table.append(sim)
@@ -516,7 +518,7 @@ if os.path.exists(xml_filename):
                  xml_filename)
     sys.exit()
 else:
-    utils.write_filename(outdoc, xml_filename, gz=xml_filename.endswith('gz'))
+    utils.write_filename(outdoc, xml_filename)
 
 # loop over IFOs for writing waveforms to file
 for ifo in opts.instruments:

--- a/bin/hwinj/pycbc_generate_hwinj
+++ b/bin/hwinj/pycbc_generate_hwinj
@@ -35,7 +35,9 @@ from pycbc.inject import InjectionSet, legacy_approximant_name
 from pycbc.filter import make_frequency_series
 from pycbc.filter import sigmasq
 from pycbc.types import Array, FrequencySeries, TimeSeries, zeros
-from pycbc.types.optparse import MultiDetOptionAppendAction, convert_to_process_params_dict
+from pycbc.types.optparse import MultiDetOptionAppendAction
+from pycbc.types.optparse import convert_to_process_params_dict
+from pycbc.io.ligolw import create_process_table
 from pycbc.waveform import FilterBank, get_td_waveform, td_approximants, taper_timeseries
 import os
 import sys
@@ -271,16 +273,10 @@ logging.info('Creating XML file')
 outdoc = ligolw.Document()
 outdoc.appendChild(ligolw.LIGO_LW())
 
-# put opts into a dict for the process table
-opts_dict = convert_to_process_params_dict(opts)
-
 # create process table
-proc_id = utils.process.register_to_xmldoc(
-                    outdoc, sys.argv[0], opts_dict,
-                    comment="", instruments=[''.join(opts.instruments)],
-                    version=pycbc.version.git_hash,
-                    cvs_repository='pycbc/'+pycbc.version.git_branch,
-                    cvs_entry_time=pycbc.version.date).process_id
+llw_opts = convert_to_process_params_dict(opts)
+create_process_table(outdoc, sys.argv[0], options=llw_opts,
+                     detectors=[''.join(opts.instruments)])
 
 # create sim_inspiral row for injection
 # and populate non-IFO-specific columns in XML output file

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ pegasus-wms >= 5.0.1
 markupsafe <= 2.0.1
 
 # Requirements for ligoxml access needed by some workflows
-python-ligo-lw >= 1.7.0
+python-ligo-lw >= 1.8.1
 
 # Needed for Parameter Estimation Tasks
 emcee==2.2.1


### PR DESCRIPTION
As reported in #4089, `pycbc_generate_hwinj` is not working on master. This should fix it, but I think it probably does pin us to the most recent ligo.lw version, so I updated that (I don't think that will affect anything).

I also note that this would already be broken with the current main of ligo.lw, so changes will be needed again when 1.8.2 / 1.9.0 comes out. 

I wouldn't be surprised if other executables are similarly broken, but as I was testing this anyway following up on #4089 it would be remiss of me not to push this upstream!