### PR TITLE
Fix declaration of input files in pycbc_geom_aligned_bank

### DIFF
--- a/bin/bank/pycbc_geom_aligned_bank
+++ b/bin/bank/pycbc_geom_aligned_bank
@@ -554,7 +554,7 @@ else:
 stack_exe = GeomAligned2DStackExecutable(workflow.cp, 'aligned2dstack',
                                          ifos=workflow.ifos, out_dir=curr_dir)
 num_banks = int((len(newV1s) - 0.5)//opts.split_bank_num) + 1
-input_h5file = resolve_url_to_file(opts.intermediate_data_file)
+input_h5file = pycbc.workflow.core.resolve_url_to_file(opts.intermediate_data_file)
 
 
 all_outs = wf.FileList([])
@@ -577,7 +577,7 @@ else:
 
 combine_exe = AlignedBankCatExecutable(workflow.cp, 'alignedbankcat',
                                         ifos=workflow.ifos, out_dir=curr_dir)
-metadata_file = resolve_url_to_file(opts.metadata_file)
+metadata_file = pycbc.workflow.core.resolve_url_to_file(opts.metadata_file)
 combine_node = combine_exe.create_node(all_outs, metadata_file,
                                        workflow.analysis_time,
                                        output_file_path=opts.output_file)


### PR DESCRIPTION
Small change to fix error when submitting with pycbc_submit_dax daxfile.dax :

```
2022.08.05 09:11:15.937 PDT: [FATAL ERROR] java.lang.RuntimeException: TransferEngine.java: Can't determine a location to transfer input file for lfn intermediate.hdf for job aligned2dstack_ID0_ID0003029
	at edu.isi.pegasus.planner.transfer.generator.StageIn.constructFileTX(StageIn.java:427)
	at edu.isi.pegasus.planner.refiner.TransferEngine.processParents(TransferEngine.java:426)
	at edu.isi.pegasus.planner.refiner.TransferEngine.addTransferNodes(TransferEngine.java:267)
	at edu.isi.pegasus.planner.refiner.MainEngine.runPlanner(MainEngine.java:219)
	at edu.isi.pegasus.planner.client.CPlanner.executeCommand(CPlanner.java:611)
	at edu.isi.pegasus.planner.client.CPlanner.executeCommand(CPlanner.java:322)
	at edu.isi.pegasus.planner.client.CPlanner.main(CPlanner.java:209)
 
2022.08.05 09:11:15.942 PDT: [DEBUG] Sending Planner Metrics to [1 of 1] http://metrics.pegasus.isi.edu/metrics 
2022.08.05 09:11:17.045 PDT: [DEBUG] Metrics succesfully sent to the server 
2022.08.05 09:11:17.045 PDT: [DEBUG] Exiting with non-zero exit-code 1 
2022.08.05 09:11:17.045 PDT: [INFO] event.pegasus.generate.transfer-nodes dax.id HFb_O4ssm.dax-0 (1.968 seconds) - FINISHED
```