### PR TITLE
Add missing files to MANIFEST

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,9 +1,9 @@
-include test/*py
 include bin/*
 include tox.ini
 include pytest.ini
 include README.md
-recursive-include examples *py *sh *xml
+recursive-include examples *ini *py *sh *xml
+recursive-include test *dat *gwf *hdf *py *txt
 recursive-include tools *py
 recursive-include pycbc *cpp
 include LICENSE


### PR DESCRIPTION
This PR updates `MANIFEST.in` to include all necessary file extensions such that the code snippet from #4103 works end-to-end.

Closes #4103.

WARNING: this increases the size of the distribution from 3.3MB (https://pypi.org/project/PyCBC/2.0.5/#files), to 8.5MB, which be unacceptable.