### PR TITLE
Attempt to make faster MultiRingBuffer

### DIFF
--- a/pycbc/events/coinc.py
+++ b/pycbc/events/coinc.py
@@ -303,7 +303,6 @@ def time_multi_coincidence(times, slide_step=0, slop=.003,
                 # However there are rare corner cases at starts/ends of inspiral
                 #  jobs. For these, arbitrarily keep the first trigger and
                 #  discard the second (and any subsequent ones).
-                where = right - left == rlmax
                 logging.warning('Triggers in %s are closer than coincidence '
                                 'window, 1 or more coincs will be discarded. '
                                 'This is a warning, not an error.' % ifo1)
@@ -612,7 +611,7 @@ class MultiRingBuffer(object):
             self.valid_starts[buffer_index],
             self.valid_ends[buffer_index]
         )
- 
+
         return self.buffer[buffer_index][ret_slice]
 
 

--- a/pycbc/events/coinc.py
+++ b/pycbc/events/coinc.py
@@ -541,7 +541,7 @@ class MultiRingBuffer(object):
         for _ in range(num_rings):
             self.buffer.append(numpy.zeros(128, dtype=dtype))
             self.buffer_expire.append(numpy.zeros(128, dtype=int))
-            self.valid_ends.append(1)
+            self.valid_ends.append(0)
             self.valid_starts.append(0)
         self.time = 0
 
@@ -612,6 +612,8 @@ class MultiRingBuffer(object):
             # If 30% of stored triggers are expired, free up memory
             self.buffer_expire[buffer_index] = self.buffer_expire[buffer_index][val_start:].copy()
             self.buffer[buffer_index] = self.buffer[buffer_index][val_start:].copy()
+            self.valid_ends[buffer_index] -= val_start
+            self.valid_starts[buffer_index] = 0
 
         ret_slice = slice(
             self.valid_starts[buffer_index],

--- a/test/test_live_coinc_compare.py
+++ b/test/test_live_coinc_compare.py
@@ -110,8 +110,8 @@ class TestPyCBCLiveCoinc(unittest.TestCase):
         for i in range(self.num_iterations):
             logging.info("Iteration %d", i)
             single_det_trigs = self.new_trigs[i]
-            coinc_trigs = self.new_coincer.add_singles(single_det_trigs)
-            coinc_trigs = self.old_coincer.add_singles(single_det_trigs)
+            self.new_coincer.add_singles(single_det_trigs)
+            self.old_coincer.add_singles(single_det_trigs)
 
         # Are they the same coincs now?
         new_coincer = self.new_coincer

--- a/test/test_live_coinc_compare.py
+++ b/test/test_live_coinc_compare.py
@@ -66,7 +66,7 @@ class TestPyCBCLiveCoinc(unittest.TestCase):
         args = SimpleNamespace(
             sngl_ranking="snr",
             ranking_statistic="phasetd",
-            statistic_files=stat_file_paths,
+            statistic_files=[stat_file_paths],
             statistic_keywords=None,
             timeslide_interval=0.1,
             background_ifar_limit=100,

--- a/test/test_live_coinc_compare.py
+++ b/test/test_live_coinc_compare.py
@@ -1,0 +1,137 @@
+"""Mock simulation to easily test and profile PyCBC Live's coincidence code."""
+
+import unittest
+from types import SimpleNamespace
+import numpy as np
+# Some duplicate imports, but I want to copy code without changing it!
+import numpy, logging, pycbc.pnutils, pycbc.conversions, copy, lal
+import cProfile
+from pycbc import gps_now
+from pycbc.events.coinc import LiveCoincTimeslideBackgroundEstimator as Coincer
+import pycbc.events.coinc
+from utils import simple_exit
+import validation_code.old_coinc as old_coinc
+
+OriginalCoincer = old_coinc.LiveCoincTimeslideBackgroundEstimator
+
+class SingleDetTrigSimulator:
+    """An object that simulates single-detector triggers in the same format
+    as produced by the matched-filtering processes of PyCBC Live.
+    """
+    def __init__(self, num_templates, analysis_chunk, detectors, num_trigs_per_block):
+        self.num_templates = num_templates
+        self.detectors = detectors
+        self.analysis_chunk = analysis_chunk
+        self.start_time = gps_now()
+        self.num_trigs = num_trigs_per_block
+
+    def get_trigs(self):
+        trigs = {}
+        for det in self.detectors:
+            trigs[det] = {
+                "snr": np.random.uniform(4.5, 10, size=self.num_trigs).astype(np.float32),
+                "end_time": np.random.uniform(
+                    self.start_time,
+                    self.start_time + self.analysis_chunk,
+                    size=self.num_trigs
+                ).astype(np.float64),
+                "chisq": np.random.uniform(0.5, 1.5, size=self.num_trigs).astype(np.float32),
+                "chisq_dof": np.ones(self.num_trigs, dtype=np.int32) * 10,
+                "coa_phase": np.random.uniform(0, 2*np.pi, size=self.num_trigs).astype(np.float32),
+                "sigmasq": np.ones(self.num_trigs, dtype=np.float32),  # FIXME (maybe)
+                "template_id": np.random.uniform(
+                    0,
+                    self.num_templates,
+                    size=self.num_trigs
+                ).astype(np.int32)
+            }
+        self.start_time += self.analysis_chunk
+        return trigs
+
+
+class TestPyCBCLiveCoinc(unittest.TestCase):
+    def setUp(self, *args):
+        # Uncomment for more verbosity
+        # logging.basicConfig(format="%(asctime)s %(message)s",
+        #                     level=logging.INFO)
+
+        # simulate the `args` object we normally get from the command line arguments
+        stat_file_paths = [
+            "/home/tito.canton/projects/pycbc/live/o4_preparation/pta_files/H1L1-PTA_HISTOGRAM_O4.hdf",
+            "/home/tito.canton/projects/pycbc/live/o4_preparation/pta_files/H1V1-PTA_HISTOGRAM_O4.hdf",
+            "/home/tito.canton/projects/pycbc/live/o4_preparation/pta_files/L1V1-PTA_HISTOGRAM_O4.hdf"
+        ]
+        args = SimpleNamespace(
+            sngl_ranking="snr",
+            ranking_statistic="phasetd",
+            statistic_files=[stat_file_paths],
+            statistic_keywords=None,
+            timeslide_interval=0.1,
+            background_ifar_limit=100,
+            store_background=False
+        )
+
+        # number of templates in the bank
+        self.num_templates = 500
+
+        # duration of analysis segment
+        analysis_chunk = 2000
+
+        # combination of two detectors to analyze
+        detectors = ["H1", "L1"]
+
+        # number of single-detector triggers per detector per chunk
+        num_single_trigs = 1000
+
+        self.num_iterations = 15
+
+        # create the single-detector trigger simulator
+        single_det_trig_sim = SingleDetTrigSimulator(
+            self.num_templates, analysis_chunk, detectors, num_single_trigs
+        )
+
+        self.new_trigs = [single_det_trig_sim.get_trigs()
+                          for _ in range(self.num_iterations)]
+
+        # create the current "coincer" object
+        self.new_coincer = Coincer.from_cli(args, self.num_templates,
+                                            analysis_chunk, detectors)
+
+        # create the validation "coincer" object
+        self.old_coincer = OriginalCoincer.from_cli(args, self.num_templates,
+                                                    analysis_chunk, detectors)
+
+
+    def test_coincer_runs(self):
+        # the following loop simulates the "infinite" analysis loop
+        # (though we only do a few iterations here)
+        for i in range(self.num_iterations):
+            logging.info("Iteration %d", i)
+            single_det_trigs = self.new_trigs[i]
+            coinc_trigs = self.new_coincer.add_singles(single_det_trigs)
+
+
+        for i in range(self.num_iterations):
+            logging.info("Iteration %d", i)
+            single_det_trigs = self.new_trigs[i]
+            coinc_trigs = self.old_coincer.add_singles(single_det_trigs)
+
+        # Are they the same coincs now?
+        new_coincer = self.new_coincer
+        old_coincer = self.old_coincer
+        self.assertTrue(len(new_coincer.coincs.data) == len(old_coincer.coincs.data))
+        self.assertTrue((new_coincer.coincs.data == old_coincer.coincs.data).all())
+
+        for ifo in new_coincer.singles:
+            lgc = True
+            for temp in range(self.num_templates):
+                # Check that all singles, for all templates, are identical
+                lgc = lgc & (new_coincer.singles[ifo].data(temp) == old_coincer.singles[ifo].data(temp)).all()
+            self.assertTrue(lgc)
+
+suite = unittest.TestSuite()
+suite.addTest(unittest.TestLoader().loadTestsFromTestCase(TestPyCBCLiveCoinc))
+
+if __name__ == '__main__':
+    results = unittest.TextTestRunner(verbosity=2).run(suite)
+    simple_exit(results)

--- a/test/test_live_coinc_compare.py
+++ b/test/test_live_coinc_compare.py
@@ -6,6 +6,7 @@ import numpy as np
 # Some duplicate imports, but I want to copy code without changing it!
 import numpy, logging, pycbc.pnutils, pycbc.conversions, copy, lal
 import cProfile
+from astropy.utils.data import download_file
 from pycbc import gps_now
 from pycbc.events.coinc import LiveCoincTimeslideBackgroundEstimator as Coincer
 import pycbc.events.coinc
@@ -56,10 +57,13 @@ class TestPyCBCLiveCoinc(unittest.TestCase):
         #                     level=logging.INFO)
 
         # simulate the `args` object we normally get from the command line arguments
+
+        url = 'https://github.com/gwastro/pycbc-config/raw/master/'
+        url += 'test_data_files/{}-PTA_HISTOGRAM.hdf'
         stat_file_paths = [
-            "/home/tito.canton/projects/pycbc/live/o4_preparation/pta_files/H1L1-PTA_HISTOGRAM_O4.hdf",
-            "/home/tito.canton/projects/pycbc/live/o4_preparation/pta_files/H1V1-PTA_HISTOGRAM_O4.hdf",
-            "/home/tito.canton/projects/pycbc/live/o4_preparation/pta_files/L1V1-PTA_HISTOGRAM_O4.hdf"
+            download_file(url.format("H1L1"), cache=True),
+            download_file(url.format("H1V1"), cache=True),
+            download_file(url.format("L1V1"), cache=True)
         ]
         args = SimpleNamespace(
             sngl_ranking="snr",

--- a/test/test_live_coinc_compare.py
+++ b/test/test_live_coinc_compare.py
@@ -62,13 +62,11 @@ class TestPyCBCLiveCoinc(unittest.TestCase):
         url += 'test_data_files/{}-PTA_HISTOGRAM.hdf'
         stat_file_paths = [
             download_file(url.format("H1L1"), cache=True),
-            download_file(url.format("H1V1"), cache=True),
-            download_file(url.format("L1V1"), cache=True)
         ]
         args = SimpleNamespace(
             sngl_ranking="snr",
             ranking_statistic="phasetd",
-            statistic_files=[stat_file_paths],
+            statistic_files=stat_file_paths,
             statistic_keywords=None,
             timeslide_interval=0.1,
             background_ifar_limit=100,
@@ -113,11 +111,6 @@ class TestPyCBCLiveCoinc(unittest.TestCase):
             logging.info("Iteration %d", i)
             single_det_trigs = self.new_trigs[i]
             coinc_trigs = self.new_coincer.add_singles(single_det_trigs)
-
-
-        for i in range(self.num_iterations):
-            logging.info("Iteration %d", i)
-            single_det_trigs = self.new_trigs[i]
             coinc_trigs = self.old_coincer.add_singles(single_det_trigs)
 
         # Are they the same coincs now?

--- a/test/test_live_coinc_compare.py
+++ b/test/test_live_coinc_compare.py
@@ -72,7 +72,7 @@ class TestPyCBCLiveCoinc(unittest.TestCase):
         )
 
         # number of templates in the bank
-        self.num_templates = 500
+        self.num_templates = 10
 
         # duration of analysis segment
         analysis_chunk = 2000
@@ -81,7 +81,7 @@ class TestPyCBCLiveCoinc(unittest.TestCase):
         detectors = ["H1", "L1"]
 
         # number of single-detector triggers per detector per chunk
-        num_single_trigs = 1000
+        num_single_trigs = 400
 
         self.num_iterations = 15
 

--- a/test/validation_code/old_coinc.py
+++ b/test/validation_code/old_coinc.py
@@ -993,12 +993,18 @@ class LiveCoincTimeslideBackgroundEstimator(object):
                 trig_stat = numpy.resize(trig_stat, len(i1))
                 sngls_list = [[ifo, trig_stat],
                               [oifo, stats[i1]]]
+
+                if oifo == self.ifos[0]:
+                    to_shift = [-1, 0]
+                else:
+                    to_shift = [0, -1]
+
                 # This can only use 2-det coincs at present
                 c = self.stat_calculator.rank_stat_coinc(
                     sngls_list,
                     slide,
                     self.timeslide_interval,
-                    [0, -1]
+                    to_shift
                 )
                 offsets.append(slide)
                 cstat.append(c)

--- a/test/validation_code/old_coinc.py
+++ b/test/validation_code/old_coinc.py
@@ -1,0 +1,1137 @@
+# Copyright (C) 2015 Alex Nitz
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+#
+# =============================================================================
+#
+#                                   Preamble
+#
+# =============================================================================
+#
+""" This modules contains functions for calculating and manipulating
+coincident triggers.
+"""
+
+import numpy, logging, pycbc.pnutils, pycbc.conversions, copy, lal
+from pycbc.detector import Detector, ppdets
+
+
+def background_bin_from_string(background_bins, data):
+    """ Return template ids for each bin as defined by the format string
+    Parameters
+    ----------
+    bins: list of strings
+        List of strings which define how a background bin is taken from the
+        list of templates.
+    data: dict of numpy.ndarrays
+        Dict with parameter key values and numpy.ndarray values which define
+        the parameters of the template bank to bin up.
+    Returns
+    -------
+    bins: dict
+        Dictionary of location indices indexed by a bin name
+    """
+    used = numpy.array([], dtype=numpy.uint32)
+    bins = {}
+    for mbin in background_bins:
+        locs = None
+        name, bin_type_list, boundary_list = tuple(mbin.split(':'))
+
+        bin_type_list = bin_type_list.split(',')
+        boundary_list = boundary_list.split(',')
+
+        for bin_type, boundary in zip(bin_type_list, boundary_list):
+            if boundary[0:2] == 'lt':
+                member_func = lambda vals, bd=boundary : vals < float(bd[2:])
+            elif boundary[0:2] == 'gt':
+                member_func = lambda vals, bd=boundary : vals > float(bd[2:])
+            else:
+                raise RuntimeError("Can't parse boundary condition! Must begin "
+                                   "with 'lt' or 'gt'")
+
+            if bin_type == 'component' and boundary[0:2] == 'lt':
+                # maximum component mass is less than boundary value
+                vals = numpy.maximum(data['mass1'], data['mass2'])
+            elif bin_type == 'component' and boundary[0:2] == 'gt':
+                # minimum component mass is greater than bdary
+                vals = numpy.minimum(data['mass1'], data['mass2'])
+            elif bin_type == 'total':
+                vals = data['mass1'] + data['mass2']
+            elif bin_type == 'chirp':
+                vals = pycbc.pnutils.mass1_mass2_to_mchirp_eta(
+                                                   data['mass1'], data['mass2'])[0]
+            elif bin_type == 'ratio':
+                vals = pycbc.conversions.q_from_mass1_mass2(
+                                                   data['mass1'], data['mass2'])
+            elif bin_type == 'eta':
+                vals = pycbc.pnutils.mass1_mass2_to_mchirp_eta(
+                                                   data['mass1'], data['mass2'])[1]
+            elif bin_type == 'chi_eff':
+                vals = pycbc.conversions.chi_eff(data['mass1'], data['mass2'],
+                                                 data['spin1z'], data['spin2z'])
+            elif bin_type == 'SEOBNRv2Peak':
+                vals = pycbc.pnutils.get_freq('fSEOBNRv2Peak',
+                                              data['mass1'], data['mass2'],
+                                              data['spin1z'], data['spin2z'])
+            elif bin_type == 'SEOBNRv4Peak':
+                vals = pycbc.pnutils.get_freq('fSEOBNRv4Peak', data['mass1'],
+                                              data['mass2'], data['spin1z'],
+                                              data['spin2z'])
+            elif bin_type == 'SEOBNRv2duration':
+                vals = pycbc.pnutils.get_imr_duration(
+                                   data['mass1'], data['mass2'],
+                                   data['spin1z'], data['spin2z'],
+                                   data['f_lower'], approximant='SEOBNRv2')
+            elif bin_type == 'SEOBNRv4duration':
+                vals = pycbc.pnutils.get_imr_duration(
+                                   data['mass1'][:], data['mass2'][:],
+                                   data['spin1z'][:], data['spin2z'][:],
+                                   data['f_lower'][:], approximant='SEOBNRv4')
+            else:
+                raise ValueError('Invalid bin type %s' % bin_type)
+
+            sub_locs = member_func(vals)
+            del vals
+            sub_locs = numpy.where(sub_locs)[0]
+            if locs is not None:
+                # find intersection of boundary conditions
+                locs = numpy.intersect1d(locs, sub_locs)
+            else:
+                locs = sub_locs
+
+        # make sure we don't reuse anything from an earlier bin
+        locs = numpy.delete(locs, numpy.where(numpy.in1d(locs, used))[0])
+        used = numpy.concatenate([used, locs])
+        bins[name] = locs
+
+    return bins
+
+
+def timeslide_durations(start1, start2, end1, end2, timeslide_offsets):
+    """ Find the coincident time for each timeslide.
+    Find the coincident time for each timeslide, where the first time vector
+    is slid to the right by the offset in the given timeslide_offsets vector.
+    Parameters
+    ----------
+    start1: numpy.ndarray
+        Array of the start of valid analyzed times for detector 1
+    start2: numpy.ndarray
+        Array of the start of valid analyzed times for detector 2
+    end1: numpy.ndarray
+        Array of the end of valid analyzed times for detector 1
+    end2: numpy.ndarray
+        Array of the end of valid analyzed times for detector 2
+    timseslide_offset: numpy.ndarray
+        Array of offsets (in seconds) for each timeslide
+    Returns
+    --------
+    durations: numpy.ndarray
+        Array of coincident time for each timeslide in the offset array
+    """
+    from pycbc.events import veto
+    durations = []
+    seg2 = veto.start_end_to_segments(start2, end2)
+    for offset in timeslide_offsets:
+        seg1 = veto.start_end_to_segments(start1 + offset, end1 + offset)
+        durations.append(abs((seg1 & seg2).coalesce()))
+    return numpy.array(durations)
+
+
+def time_coincidence(t1, t2, window, slide_step=0):
+    """ Find coincidences by time window
+    Parameters
+    ----------
+    t1 : numpy.ndarray
+        Array of trigger times from the first detector
+    t2 : numpy.ndarray
+        Array of trigger times from the second detector
+    window : float
+        Coincidence window maximum time difference, arbitrary units (usually s)
+    slide_step : float (default 0)
+        If calculating background coincidences, the interval between background
+        slides, arbitrary units (usually s)
+    Returns
+    -------
+    idx1 : numpy.ndarray
+        Array of indices into the t1 array for coincident triggers
+    idx2 : numpy.ndarray
+        Array of indices into the t2 array
+    slide : numpy.ndarray
+        Array of slide ids
+    """
+    if slide_step:
+        fold1 = t1 % slide_step
+        fold2 = t2 % slide_step
+    else:
+        fold1 = t1
+        fold2 = t2
+
+    sort1 = fold1.argsort()
+    sort2 = fold2.argsort()
+    fold1 = fold1[sort1]
+    fold2 = fold2[sort2]
+
+    if slide_step:
+        # FIXME explain this
+        fold2 = numpy.concatenate([fold2 - slide_step, fold2, fold2 + slide_step])
+        sort2 = numpy.concatenate([sort2, sort2, sort2])
+
+    left = numpy.searchsorted(fold2, fold1 - window)
+    right = numpy.searchsorted(fold2, fold1 + window)
+
+    idx1 = numpy.repeat(sort1, right - left)
+    idx2 = [sort2[l:r] for l, r in zip(left, right)]
+
+    if len(idx2) > 0:
+        idx2 = numpy.concatenate(idx2)
+    else:
+        idx2 = numpy.array([], dtype=numpy.int64)
+
+    if slide_step:
+        diff = ((t1 / slide_step)[idx1] - (t2 / slide_step)[idx2])
+        slide = numpy.rint(diff)
+    else:
+        slide = numpy.zeros(len(idx1))
+
+    return idx1.astype(numpy.uint32), idx2.astype(numpy.uint32), slide.astype(numpy.int32)
+
+
+def time_multi_coincidence(times, slide_step=0, slop=.003,
+                           pivot='H1', fixed='L1'):
+    """ Find multi detector coincidences.
+    Parameters
+    ----------
+    times: dict of numpy.ndarrays
+        Dictionary keyed by ifo of single ifo trigger times
+    slide_step: float
+        Interval between time slides
+    slop: float
+        The amount of time to add to the TOF between detectors for coincidence
+    pivot: str
+        The ifo to which time shifts are applied in first stage coincidence
+    fixed: str
+        The other ifo used in first stage coincidence, subsequently used as a
+        time reference for additional ifos. All other ifos are not time shifted
+        relative to this ifo
+    Returns
+    -------
+    ids: dict of arrays of int
+        Dictionary keyed by ifo with ids of trigger times forming coincidences.
+        Coincidence is tested for every pair of ifos that can be formed from
+        the input dict: only those tuples of times passing all tests are
+        recorded
+    slide: array of int
+        Slide ids of coincident triggers in pivot ifo
+    """
+    def win(ifo1, ifo2):
+        d1 = Detector(ifo1)
+        d2 = Detector(ifo2)
+        return d1.light_travel_time_to_detector(d2) + slop
+
+    # Find coincs between the 'pivot' and 'fixed' detectors as in 2-ifo case
+    pivot_id, fix_id, slide = time_coincidence(times[pivot], times[fixed],
+                                               win(pivot, fixed),
+                                               slide_step=slide_step)
+
+    # Additional detectors do not slide independently of the 'fixed' one
+    # Each trigger in an additional detector must be concident with both
+    # triggers in an existing coincidence
+
+    # Slide 'pivot' trigger times to be coincident with trigger times in
+    # 'fixed' detector
+    fixed_time = times[fixed][fix_id]
+    pivot_time = times[pivot][pivot_id] - slide_step * slide
+    ctimes = {fixed: fixed_time, pivot: pivot_time}
+    ids = {fixed: fix_id, pivot: pivot_id}
+
+    dep_ifos = [ifo for ifo in times.keys() if ifo != fixed and ifo != pivot]
+    for ifo1 in dep_ifos:
+        # FIXME - make this loop into a function?
+
+        # otime is extra ifo time in original trigger order
+        otime = times[ifo1]
+        # tsort gives ordering from original order to time sorted order
+        tsort = otime.argsort()
+        time1 = otime[tsort]
+
+        # Find coincidences between dependent ifo triggers and existing coincs
+        # - Cycle over fixed and pivot
+        # - At the 1st iteration, the fixed and pivot triggers are reduced to
+        #  those for which the first out of fixed/pivot forms a coinc with ifo1
+        # - At the 2nd iteration, we are left with triggers for which both
+        #  fixed and pivot are coincident with ifo1
+        # - If there is more than 1 dependent ifo, ones that were previously
+        #  tested against fixed and pivot are now present for testing with new
+        #  dependent ifos
+        for ifo2 in ids:
+            logging.info('added ifo %s, testing against %s' % (ifo1, ifo2))
+            w = win(ifo1, ifo2)
+            left = numpy.searchsorted(time1, ctimes[ifo2] - w)
+            right = numpy.searchsorted(time1, ctimes[ifo2] + w)
+            # Any times within time1 coincident with the time in ifo2 have
+            # indices between 'left' and 'right'
+            # 'nz' indexes into times in ifo2 which have coincidences with ifo1
+            # times
+            nz = (right - left).nonzero()
+            if len(right - left):
+                rlmax = (right - left).max()
+            if len(nz[0]) and rlmax > 1:
+                # We expect at most one coincident time in ifo1, assuming
+                #  trigger spacing in ifo1 > time window.
+                # However there are rare corner cases at starts/ends of inspiral
+                #  jobs. For these, arbitrarily keep the first trigger and
+                #  discard the second (and any subsequent ones).
+                where = right - left == rlmax
+                logging.warning('Triggers in %s are closer than coincidence '
+                                'window, 1 or more coincs will be discarded. '
+                                'This is a warning, not an error.' % ifo1)
+                print([float(ti) for ti in
+                       time1[left[where][0]:right[where][0]]])
+            # identify indices of times in ifo1 that form coincs with ifo2
+            dep_ids = left[nz]
+            # slide is array of slide ids attached to pivot ifo
+            slide = slide[nz]
+
+            for ifo in ctimes:
+                # cycle over fixed and pivot & any previous additional ifos
+                # reduce times and IDs to just those forming a coinc with ifo1
+                ctimes[ifo] = ctimes[ifo][nz]
+                ids[ifo] = ids[ifo][nz]
+
+        # undo time sorting on indices of ifo1 triggers, add ifo1 ids and times
+        # to dicts for testing against any additional detectrs
+        ids[ifo1] = tsort[dep_ids]
+        ctimes[ifo1] = otime[ids[ifo1]]
+
+    return ids, slide
+
+
+def cluster_coincs(stat, time1, time2, timeslide_id, slide, window, argmax=numpy.argmax):
+    """Cluster coincident events for each timeslide separately, across
+    templates, based on the ranking statistic
+    Parameters
+    ----------
+    stat: numpy.ndarray
+        vector of ranking values to maximize
+    time1: numpy.ndarray
+        first time vector
+    time2: numpy.ndarray
+        second time vector
+    timeslide_id: numpy.ndarray
+        vector that determines the timeslide offset
+    slide: float
+        length of the timeslides offset interval
+    window: float
+        length to cluster over
+    Returns
+    -------
+    cindex: numpy.ndarray
+        The set of indices corresponding to the surviving coincidences.
+    """
+
+    logging.info('clustering coinc triggers over %ss window' % window)
+
+    if len(time1) == 0 or len(time2) == 0:
+        logging.info('No coinc triggers in one, or both, ifos.')
+        return numpy.array([])
+
+    if numpy.isfinite(slide):
+        # for a time shifted coinc, time1 is greater than time2 by approximately timeslide_id*slide
+        # adding this quantity gives a mean coinc time located around time1
+        time = (time1 + time2 + timeslide_id * slide) / 2
+    else:
+        time = 0.5 * (time2 + time1)
+
+    tslide = timeslide_id.astype(numpy.float128)
+    time = time.astype(numpy.float128)
+
+    span = (time.max() - time.min()) + window * 10
+    time = time + span * tslide
+    cidx = cluster_over_time(stat, time, window, argmax)
+    return cidx
+
+
+def cluster_coincs_multiifo(stat, time_coincs, timeslide_id, slide, window, argmax=numpy.argmax):
+    """Cluster coincident events for each timeslide separately, across
+    templates, based on the ranking statistic
+    Parameters
+    ----------
+    stat: numpy.ndarray
+        vector of ranking values to maximize
+    time_coincs: tuple of numpy.ndarrays
+        trigger times for each ifo, or -1 if an ifo does not participate in a coinc
+    timeslide_id: numpy.ndarray
+        vector that determines the timeslide offset
+    slide: float
+        length of the timeslides offset interval
+    window: float
+        duration of clustering window in seconds
+    Returns
+    -------
+    cindex: numpy.ndarray
+        The set of indices corresponding to the surviving coincidences
+    """
+    time_coinc_zip = list(zip(*time_coincs))
+    if len(time_coinc_zip) == 0:
+        logging.info('No coincident triggers.')
+        return numpy.array([])
+
+    time_avg_num = []
+    #find number of ifos and mean time over participating ifos for each coinc
+    for tc in time_coinc_zip:
+        time_avg_num.append(mean_if_greater_than_zero(tc))
+
+    time_avg, num_ifos = zip(*time_avg_num)
+
+    time_avg = numpy.array(time_avg)
+    num_ifos = numpy.array(num_ifos)
+
+    # shift all but the pivot ifo by (num_ifos-1) * timeslide_id * slide
+    # this leads to a mean coinc time located around pivot time
+    if numpy.isfinite(slide):
+        nifos_minusone = (num_ifos - numpy.ones_like(num_ifos))
+        time_avg = time_avg + (nifos_minusone * timeslide_id * slide)/num_ifos
+
+    tslide = timeslide_id.astype(numpy.float128)
+    time_avg = time_avg.astype(numpy.float128)
+
+    span = (time_avg.max() - time_avg.min()) + window * 10
+    time_avg = time_avg + span * tslide
+    cidx = cluster_over_time(stat, time_avg, window, argmax)
+
+    return cidx
+
+
+def mean_if_greater_than_zero(vals):
+    """ Calculate mean over numerical values, ignoring values less than zero.
+    E.g. used for mean time over coincident triggers when timestamps are set
+    to -1 for ifos not included in the coincidence.
+    Parameters
+    ----------
+    vals: iterator of numerical values
+        values to be mean averaged
+    Returns
+    -------
+    mean: float
+        The mean of the values in the original vector which are
+        greater than zero
+    num_above_zero: int
+        The number of entries in the vector which are above zero
+    """
+    vals = numpy.array(vals)
+    above_zero = vals > 0
+    return vals[above_zero].mean(), above_zero.sum()
+
+
+def cluster_over_time(stat, time, window, argmax=numpy.argmax):
+    """Cluster generalized transient events over time via maximum stat over a
+    symmetric sliding window
+    Parameters
+    ----------
+    stat: numpy.ndarray
+        vector of ranking values to maximize
+    time: numpy.ndarray
+        time to use for clustering
+    window: float
+        length to cluster over
+    argmax: function
+        the function used to calculate the maximum value
+    Returns
+    -------
+    cindex: numpy.ndarray
+        The set of indices corresponding to the surviving coincidences.
+    """
+    logging.info('Clustering events over %s s window', window)
+
+    indices = []
+    time_sorting = time.argsort()
+    stat = stat[time_sorting]
+    time = time[time_sorting]
+
+    left = numpy.searchsorted(time, time - window)
+    right = numpy.searchsorted(time, time + window)
+    indices = numpy.zeros(len(left), dtype=numpy.uint32)
+
+    # i is the index we are inspecting, j is the next one to save
+    i = 0
+    j = 0
+    while i < len(left):
+        l = left[i]
+        r = right[i]
+
+        # If there are no other points to compare it is obviously the max
+        if (r - l) == 1:
+            indices[j] = i
+            j += 1
+            i += 1
+            continue
+
+        # Find the location of the maximum within the time interval around i
+        max_loc = argmax(stat[l:r]) + l
+
+        # If this point is the max, we can skip to the right boundary
+        if max_loc == i:
+            indices[j] = i
+            i = r
+            j += 1
+
+        # If the max is later than i, we can skip to it
+        elif max_loc > i:
+            i = max_loc
+
+        elif max_loc < i:
+            i += 1
+
+    indices = indices[:j]
+
+    logging.info('%d triggers remaining', len(indices))
+    return time_sorting[indices]
+
+
+class MultiRingBuffer(object):
+    """Dynamic size n-dimensional ring buffer that can expire elements."""
+
+    def __init__(self, num_rings, max_time, dtype):
+        """
+        Parameters
+        ----------
+        num_rings: int
+            The number of ring buffers to create. They all will have the same
+            intrinsic size and will expire at the same time.
+        max_time: int
+            The maximum "time" an element can exist in each ring.
+        dtype: numpy.dtype
+            The type of each element in the ring buffer.
+        """
+        self.max_time = max_time
+        self.buffer = []
+        self.buffer_expire = []
+        for _ in range(num_rings):
+            self.buffer.append(numpy.zeros(0, dtype=dtype))
+            self.buffer_expire.append(numpy.zeros(0, dtype=int))
+        self.time = 0
+
+    @property
+    def filled_time(self):
+        return min(self.time, self.max_time)
+
+    def num_elements(self):
+        return sum([len(a) for a in self.buffer])
+
+    @property
+    def nbytes(self):
+        return sum([a.nbytes for a in self.buffer])
+
+    def discard_last(self, indices):
+        """Discard the triggers added in the latest update"""
+        for i in indices:
+            self.buffer_expire[i] = self.buffer_expire[i][:-1]
+            self.buffer[i] = self.buffer[i][:-1]
+
+    def advance_time(self):
+        """Advance the internal time increment by 1, expiring any triggers that
+        are now too old.
+        """
+        self.time += 1
+
+    def add(self, indices, values):
+        """Add triggers in 'values' to the buffers indicated by the indices
+        """
+        for i, v in zip(indices, values):
+            self.buffer[i] = numpy.append(self.buffer[i], v)
+            self.buffer_expire[i] = numpy.append(self.buffer_expire[i], self.time)
+        self.advance_time()
+
+    def expire_vector(self, buffer_index):
+        """Return the expiration vector of a given ring buffer """
+        return self.buffer_expire[buffer_index]
+
+    def data(self, buffer_index):
+        """Return the data vector for a given ring buffer"""
+        # Check for expired elements and discard if they exist
+        expired = self.time - self.max_time
+        exp = self.buffer_expire[buffer_index]
+        j = 0
+        while j < len(exp):
+            # Everything before this j must be expired
+            if exp[j] >= expired:
+                self.buffer_expire[buffer_index] = exp[j:].copy()
+                self.buffer[buffer_index] = self.buffer[buffer_index][j:].copy()
+                break
+            j += 1
+        if j > 0 and j == len(exp):
+            print("Shouldn't be here!")
+            raise
+
+        return self.buffer[buffer_index]
+
+
+class CoincExpireBuffer(object):
+    """Unordered dynamic sized buffer that handles
+    multiple expiration vectors.
+    """
+
+    def __init__(self, expiration, ifos,
+                       initial_size=2**20, dtype=numpy.float32):
+        """
+        Parameters
+        ----------
+        expiration: int
+            The 'time' in arbitrary integer units to allow to pass before
+            removing an element.
+        ifos: list of strs
+            List of strings to identify the multiple data expiration times.
+        initial_size: int, optional
+            The initial size of the buffer.
+        dtype: numpy.dtype
+            The dtype of each element of the buffer.
+        """
+
+        self.expiration = expiration
+        self.buffer = numpy.zeros(initial_size, dtype=dtype)
+        self.index = 0
+        self.ifos = ifos
+
+        self.time = {}
+        self.timer = {}
+        for ifo in self.ifos:
+            self.time[ifo] = 0
+            self.timer[ifo] = numpy.zeros(initial_size, dtype=numpy.int32)
+
+    def __len__(self):
+        return self.index
+
+    @property
+    def nbytes(self):
+        """Returns the approximate memory usage of self.
+        """
+        nbs = [self.timer[ifo].nbytes for ifo in self.ifos]
+        nbs.append(self.buffer.nbytes)
+        return sum(nbs)
+
+    def increment(self, ifos):
+        """Increment without adding triggers"""
+        self.add([], [], ifos)
+
+    def remove(self, num):
+        """Remove the the last 'num' elements from the buffer"""
+        self.index -= num
+
+    def add(self, values, times, ifos):
+        """Add values to the internal buffer
+        Parameters
+        ----------
+        values: numpy.ndarray
+            Array of elements to add to the internal buffer.
+        times: dict of arrays
+            The current time to use for each element being added.
+        ifos: list of strs
+            The set of timers to be incremented.
+        """
+
+        for ifo in ifos:
+            self.time[ifo] += 1
+
+        # Resize the internal buffer if we need more space
+        if self.index + len(values) >= len(self.buffer):
+            newlen = len(self.buffer) * 2
+            for ifo in self.ifos:
+                self.timer[ifo].resize(newlen)
+            self.buffer.resize(newlen, refcheck=False)
+
+        self.buffer[self.index:self.index+len(values)] = values
+        if len(values) > 0:
+            for ifo in self.ifos:
+                self.timer[ifo][self.index:self.index+len(values)] = times[ifo]
+
+            self.index += len(values)
+
+        # Remove the expired old elements
+        keep = None
+        for ifo in ifos:
+            kt = self.timer[ifo][:self.index] >= self.time[ifo] - self.expiration
+            keep = numpy.logical_and(keep, kt) if keep is not None else kt
+
+        self.buffer[:keep.sum()] = self.buffer[:self.index][keep]
+        for ifo in self.ifos:
+            self.timer[ifo][:keep.sum()] = self.timer[ifo][:self.index][keep]
+        self.index = keep.sum()
+
+    def num_greater(self, value):
+        """Return the number of elements larger than 'value'"""
+        return (self.buffer[:self.index] > value).sum()
+
+    @property
+    def data(self):
+        """Return the array of elements"""
+        return self.buffer[:self.index]
+
+
+class LiveCoincTimeslideBackgroundEstimator(object):
+    """Rolling buffer background estimation."""
+
+    def __init__(self, num_templates, analysis_block, background_statistic,
+                 sngl_ranking, stat_files, ifos,
+                 ifar_limit=100,
+                 timeslide_interval=.035,
+                 coinc_threshold=.002,
+                 return_background=False,
+                 **kwargs):
+        """
+        Parameters
+        ----------
+        num_templates: int
+            The size of the template bank
+        analysis_block: int
+            The number of seconds in each analysis segment
+        background_statistic: str
+            The name of the statistic to rank coincident events.
+        sngl_ranking: str
+            The single detector ranking to use with the background statistic
+        stat_files: list of strs
+            List of filenames that contain information used to construct
+            various coincident statistics.
+        ifos: list of strs
+            List of ifo names that are being analyzed. At the moment this must
+            be two items such as ['H1', 'L1'].
+        ifar_limit: float
+            The largest inverse false alarm rate in years that we would like to
+            calculate.
+        timeslide_interval: float
+            The time in seconds between consecutive timeslide offsets.
+        coinc_threshold: float
+            Amount of time allowed to form a coincidence in addition to the
+            time of flight in seconds.
+        return_background: boolean
+            If true, background triggers will also be included in the file
+            output.
+        kwargs: dict
+            Additional options for the statistic to use. See stat.py
+            for more details on statistic options.
+        """
+        from . import old_stat as stat
+        self.num_templates = num_templates
+        self.analysis_block = analysis_block
+
+        stat_class = stat.get_statistic(background_statistic)
+        self.stat_calculator = stat_class(
+            sngl_ranking,
+            stat_files,
+            ifos=ifos,
+            **kwargs
+        )
+
+        self.timeslide_interval = timeslide_interval
+        self.return_background = return_background
+
+        self.ifos = ifos
+        if len(self.ifos) != 2:
+            raise ValueError("Only a two ifo analysis is supported at this time")
+
+        self.lookback_time = (ifar_limit * lal.YRJUL_SI * timeslide_interval) ** 0.5
+        self.buffer_size = int(numpy.ceil(self.lookback_time / analysis_block))
+
+        det0, det1 = Detector(ifos[0]), Detector(ifos[1])
+        self.time_window = det0.light_travel_time_to_detector(det1) + coinc_threshold
+        self.coincs = CoincExpireBuffer(self.buffer_size, self.ifos)
+
+        self.singles = {}
+
+    @classmethod
+    def pick_best_coinc(cls, coinc_results):
+        """Choose the best two-ifo coinc by ifar first, then statistic if needed.
+        This function picks which of the available double-ifo coincs to use.
+        It chooses the best (highest) ifar. The ranking statistic is used as
+        a tie-breaker.
+        A trials factor is applied if multiple types of coincs are possible
+        at this time given the active ifos.
+        Parameters
+        ----------
+        coinc_results: list of coinc result dicts
+            Dictionary by detector pair of coinc result dicts.
+        Returns
+        -------
+        best: coinc results dict
+            If there is a coinc, this will contain the 'best' one. Otherwise
+            it will return the provided dict.
+        """
+        mstat = 0
+        mifar = 0
+        mresult = None
+
+        # record the trials factor from the possible coincs we could
+        # maximize over
+        trials = 0
+        for result in coinc_results:
+            # Check that a coinc was possible. See the 'add_singles' method
+            # to see where this flag was added into the results dict
+            if 'coinc_possible' in result:
+                trials += 1
+
+                # Check that a coinc exists
+                if 'foreground/ifar' in result:
+                    ifar = result['foreground/ifar']
+                    stat = result['foreground/stat']
+                    if ifar > mifar or (ifar == mifar and stat > mstat):
+                        mifar = ifar
+                        mstat = stat
+                        mresult = result
+
+        # apply trials factor for the best coinc
+        if mresult:
+            mresult['foreground/ifar'] = mifar / float(trials)
+            logging.info('Found %s coinc with ifar %s',
+                         mresult['foreground/type'],
+                         mresult['foreground/ifar'])
+            return mresult
+        # If no coinc, just return one of the results dictionaries. They will
+        # all contain the same results (i.e. single triggers) in this case.
+        else:
+            return coinc_results[0]
+
+    @classmethod
+    def from_cli(cls, args, num_templates, analysis_chunk, ifos):
+        from . import old_stat as stat
+
+        # Allow None inputs
+        stat_files = args.statistic_files or []
+        stat_keywords = args.statistic_keywords or []
+
+        # flatten the list of lists of filenames to a single list (may be empty)
+        stat_files = sum(stat_files, [])
+
+        kwargs = stat.parse_statistic_keywords_opt(stat_keywords)
+
+        return cls(num_templates, analysis_chunk,
+                   args.ranking_statistic,
+                   args.sngl_ranking,
+                   stat_files,
+                   return_background=args.store_background,
+                   ifar_limit=args.background_ifar_limit,
+                   timeslide_interval=args.timeslide_interval,
+                   ifos=ifos,
+                   **kwargs)
+
+    @staticmethod
+    def insert_args(parser):
+        from . import old_stat as stat
+
+        stat.insert_statistic_option_group(parser)
+
+        group = parser.add_argument_group('Coincident Background Estimation')
+        group.add_argument('--store-background', action='store_true',
+            help="Return background triggers with zerolag coincidencs")
+        group.add_argument('--background-ifar-limit', type=float,
+            help="The limit on inverse false alarm rate to calculate "
+                 "background in years", default=100.0)
+        group.add_argument('--timeslide-interval', type=float,
+            help="The interval between timeslides in seconds", default=0.1)
+        group.add_argument('--ifar-remove-threshold', type=float,
+            help="NOT YET IMPLEMENTED", default=100.0)
+
+    @property
+    def background_time(self):
+        """Return the amount of background time that the buffers contain"""
+        time = 1.0 / self.timeslide_interval
+        for ifo in self.singles:
+            time *= self.singles[ifo].filled_time * self.analysis_block
+        return time
+
+    def save_state(self, filename):
+        """Save the current state of the background buffers"""
+        import pickle
+        pickle.dump(self, filename)
+
+    @staticmethod
+    def restore_state(filename):
+        """Restore state of the background buffers from a file"""
+        import pickle
+        return pickle.load(filename)
+
+    def ifar(self, coinc_stat):
+        """Return the far that would be associated with the coincident given.
+        """
+        n = self.coincs.num_greater(coinc_stat)
+        return self.background_time / lal.YRJUL_SI / (n + 1)
+
+    def set_singles_buffer(self, results):
+        """Create the singles buffer
+        This creates the singles buffer for each ifo. The dtype is determined
+        by a representative sample of the single triggers in the results.
+        Parameters
+        ----------
+        restuls: dict of dict
+            Dict indexed by ifo and then trigger column.
+        """
+        # Determine the dtype from a sample of the data.
+        self.singles_dtype = []
+        data = False
+        for ifo in self.ifos:
+            if ifo in results and results[ifo] is not False \
+                    and len(results[ifo]['snr']):
+                data = results[ifo]
+                break
+
+        if data is False:
+            return
+
+        for key in data:
+            self.singles_dtype.append((key, data[key].dtype))
+
+        if 'stat' not in data:
+            self.singles_dtype.append(('stat', self.stat_calculator.single_dtype))
+
+        # Create a ring buffer for each template ifo combination
+        for ifo in self.ifos:
+            self.singles[ifo] = MultiRingBuffer(self.num_templates,
+                                            self.buffer_size,
+                                            self.singles_dtype)
+
+    def _add_singles_to_buffer(self, results, ifos):
+        """Add single detector triggers to the internal buffer
+        Parameters
+        ----------
+        results: dict of arrays
+            Dictionary of dictionaries indexed by ifo and keys such as 'snr',
+            'chisq', etc. The specific format it determined by the
+            LiveBatchMatchedFilter class.
+        Returns
+        -------
+        updated_singles: dict of numpy.ndarrays
+            Array of indices that have been just updated in the internal
+            buffers of single detector triggers.
+        """
+        if len(self.singles.keys()) == 0:
+            self.set_singles_buffer(results)
+        # If this *still* didn't work, no triggers in first set, try next time
+        if len(self.singles.keys()) == 0:
+            return {}
+
+        # convert to single detector trigger values
+        # FIXME Currently configured to use pycbc live output
+        # where chisq is the reduced chisq and chisq_dof is the actual DOF
+        logging.info("adding singles to the background estimate...")
+        updated_indices = {}
+        for ifo in ifos:
+            trigs = results[ifo]
+
+            if len(trigs['snr'] > 0):
+                trigsc = copy.copy(trigs)
+                trigsc['chisq'] = trigs['chisq'] * trigs['chisq_dof']
+                trigsc['chisq_dof'] = (trigs['chisq_dof'] + 2) / 2
+                single_stat = self.stat_calculator.single(trigsc)
+            else:
+                single_stat = numpy.array([], ndmin=1,
+                              dtype=self.stat_calculator.single_dtype)
+            trigs['stat'] = single_stat
+
+            # add each single detector trigger to the and advance the buffer
+            data = numpy.zeros(len(single_stat), dtype=self.singles_dtype)
+            for key, value in trigs.items():
+                data[key] = value
+
+            self.singles[ifo].add(trigs['template_id'], data)
+            updated_indices[ifo] = trigs['template_id']
+        return updated_indices
+
+    def _find_coincs(self, results, ifos):
+        """Look for coincs within the set of single triggers
+        Parameters
+        ----------
+        results: dict of arrays
+            Dictionary of dictionaries indexed by ifo and keys such as 'snr',
+            'chisq', etc. The specific format it determined by the
+            LiveBatchMatchedFilter class.
+        Returns
+        -------
+        coinc_results: dict of arrays
+            A dictionary of arrays containing the coincident results.
+        """
+        # for each single detector trigger find the allowed coincidences
+        # Record which template and the index of the single trigger
+        # that forms each coincident trigger
+        cstat = [[]]
+        offsets = []
+        ctimes = {self.ifos[0]:[], self.ifos[1]:[]}
+        single_expire = {self.ifos[0]:[], self.ifos[1]:[]}
+        template_ids = [[]]
+        trigger_ids = {self.ifos[0]:[[]], self.ifos[1]:[[]]}
+
+        # Calculate all the permutations of coincident triggers for each
+        # new single detector trigger collected
+        for ifo in ifos:
+            trigs = results[ifo]
+
+            oifo = self.ifos[1] if self.ifos[0] == ifo else self.ifos[0]
+
+            for i in range(len(trigs['end_time'])):
+                trig_stat = trigs['stat'][i]
+                trig_time = trigs['end_time'][i]
+                template = trigs['template_id'][i]
+
+                times = self.singles[oifo].data(template)['end_time']
+                stats = self.singles[oifo].data(template)['stat']
+
+                i1, _, slide = time_coincidence(times,
+                                 numpy.array(trig_time, ndmin=1,
+                                 dtype=numpy.float64),
+                                 self.time_window,
+                                 self.timeslide_interval)
+                trig_stat = numpy.resize(trig_stat, len(i1))
+                sngls_list = [[ifo, trig_stat],
+                              [oifo, stats[i1]]]
+                # This can only use 2-det coincs at present
+                c = self.stat_calculator.rank_stat_coinc(
+                    sngls_list,
+                    slide,
+                    self.timeslide_interval,
+                    [0, -1]
+                )
+                offsets.append(slide)
+                cstat.append(c)
+                ctimes[oifo].append(times[i1])
+                ctimes[ifo].append(numpy.zeros(len(c), dtype=numpy.float64))
+                ctimes[ifo][-1].fill(trig_time)
+
+                single_expire[oifo].append(self.singles[oifo].expire_vector(template)[i1])
+                single_expire[ifo].append(numpy.zeros(len(c),
+                                          dtype=numpy.int32))
+                single_expire[ifo][-1].fill(self.singles[ifo].time - 1)
+
+                # save the template and trigger ids to keep association
+                # to singles. The trigger was just added so it must be in
+                # the last position we mark this with -1 so the
+                # slicing picks the right point
+                template_ids.append(numpy.zeros(len(c)) + template)
+                trigger_ids[oifo].append(i1)
+                trigger_ids[ifo].append(numpy.zeros(len(c)) - 1)
+
+        cstat = numpy.concatenate(cstat)
+        template_ids = numpy.concatenate(template_ids).astype(numpy.int32)
+        for ifo in ifos:
+            trigger_ids[ifo] = numpy.concatenate(trigger_ids[ifo]).astype(numpy.int32)
+
+        # cluster the triggers we've found
+        # (both zerolag and non handled together)
+        num_zerolag = 0
+        num_background = 0
+
+        logging.info(
+            "%s: %s background and zerolag coincs",
+            ppdets(self.ifos, "-"), len(cstat)
+        )
+        if len(cstat) > 0:
+            offsets = numpy.concatenate(offsets)
+            ctime0 = numpy.concatenate(ctimes[self.ifos[0]]).astype(numpy.float64)
+            ctime1 = numpy.concatenate(ctimes[self.ifos[1]]).astype(numpy.float64)
+
+            cidx = cluster_coincs(cstat, ctime0, ctime1, offsets,
+                                      self.timeslide_interval,
+                                      self.analysis_block)
+            offsets = offsets[cidx]
+            zerolag_idx = (offsets == 0)
+            bkg_idx = (offsets != 0)
+
+            for ifo in self.ifos:
+                single_expire[ifo] = numpy.concatenate(single_expire[ifo])
+                single_expire[ifo] = single_expire[ifo][cidx][bkg_idx]
+
+            self.coincs.add(cstat[cidx][bkg_idx], single_expire, ifos)
+            num_zerolag = zerolag_idx.sum()
+            num_background = bkg_idx.sum()
+        elif len(ifos) > 0:
+            self.coincs.increment(ifos)
+
+        ####################################Collect coinc results for saving
+        coinc_results = {}
+        # Save information about zerolag triggers
+        if num_zerolag > 0:
+            zerolag_results = {}
+            idx = cidx[zerolag_idx][0]
+            zerolag_cstat = cstat[cidx][zerolag_idx]
+            zerolag_results['foreground/ifar'] = self.ifar(zerolag_cstat)
+            zerolag_results['foreground/stat'] = zerolag_cstat
+            template = template_ids[idx]
+            for ifo in self.ifos:
+                trig_id = trigger_ids[ifo][idx]
+                single_data = self.singles[ifo].data(template)[trig_id]
+                for key in single_data.dtype.names:
+                    path = 'foreground/%s/%s' % (ifo, key)
+                    zerolag_results[path] = single_data[key]
+
+            zerolag_results['foreground/type'] = '-'.join(self.ifos)
+
+            coinc_results.update(zerolag_results)
+
+        # Save some summary statistics about the background
+        coinc_results['background/time'] = numpy.array([self.background_time])
+        coinc_results['background/count'] = len(self.coincs.data)
+
+        # Save all the background triggers
+        if self.return_background:
+            coinc_results['background/stat'] = self.coincs.data
+        return num_background, coinc_results
+
+    def backout_last(self, updated_singles, num_coincs):
+        """Remove the recently added singles and coincs
+        Parameters
+        ----------
+        updated_singles: dict of numpy.ndarrays
+            Array of indices that have been just updated in the internal
+            buffers of single detector triggers.
+        num_coincs: int
+            The number of coincs that were just added to the internal buffer
+            of coincident triggers
+        """
+        for ifo in updated_singles:
+            self.singles[ifo].discard_last(updated_singles[ifo])
+        self.coincs.remove(num_coincs)
+
+    def add_singles(self, results):
+        """Add singles to the background estimate and find candidates
+        Parameters
+        ----------
+        results: dict of arrays
+            Dictionary of dictionaries indexed by ifo and keys such as 'snr',
+            'chisq', etc. The specific format it determined by the
+            LiveBatchMatchedFilter class.
+        Returns
+        -------
+        coinc_results: dict of arrays
+            A dictionary of arrays containing the coincident results.
+        """
+        # Let's see how large everything is
+        logging.info(
+            "%s: %s coincs, %s bytes",
+            ppdets(self.ifos, "-"), len(self.coincs), self.coincs.nbytes
+        )
+
+        # If there are no results just return
+        valid_ifos = [k for k in results.keys() if results[k] and k in self.ifos]
+        if len(valid_ifos) == 0: return {}
+
+        # Add single triggers to the internal buffer
+        self._add_singles_to_buffer(results, ifos=valid_ifos)
+
+        # Calculate zerolag and background coincidences
+        _, coinc_results = self._find_coincs(results, ifos=valid_ifos)
+
+        # record if a coinc is possible in this chunk
+        if len(valid_ifos) == 2:
+            coinc_results['coinc_possible'] = True
+
+        return coinc_results
+

--- a/test/validation_code/old_coinc.py
+++ b/test/validation_code/old_coinc.py
@@ -14,6 +14,12 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
+#### NOTE #####
+# This code is a verbatim copy of the coinc.py code as of 20th August 2022.
+# It's here to verify that any changes being made to this code are not changing
+# the physical output
+###############
+
 #
 # =============================================================================
 #

--- a/test/validation_code/old_stat.py
+++ b/test/validation_code/old_stat.py
@@ -1,0 +1,2076 @@
+# Copyright (C) 2016 Alex Nitz
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+#
+# =============================================================================
+#
+#                                   Preamble
+#
+# =============================================================================
+#
+"""
+This module contains functions for calculating coincident ranking statistic
+values.
+"""
+import logging
+import numpy
+from pycbc.events import ranking
+from pycbc.events import coinc_rate
+
+
+class Stat(object):
+    """Base class which should be extended to provide a coincident statistic"""
+
+    def __init__(self, sngl_ranking, files=None, ifos=None, **kwargs):
+        """
+        Create a statistic class instance
+
+        Parameters
+        ----------
+        sngl_ranking: str
+            The name of the ranking to use for the single-detector triggers.
+        files: list of strs, needed for some statistics
+            A list containing the filenames of hdf format files used to help
+            construct the coincident statistics. The files must have a 'stat'
+            attribute which is used to associate them with the appropriate
+            statistic class.
+        ifos: list of strs, needed for some statistics
+            The list of detector names
+        """
+        import h5py
+
+        self.files = {}
+        files = files or []
+        for filename in files:
+            f = h5py.File(filename, 'r')
+            stat = f.attrs['stat']
+            if hasattr(stat, 'decode'):
+                stat = stat.decode()
+            if stat in self.files:
+                raise RuntimeError("We already have one file with stat attr ="
+                                   " %s. Can't provide more than one!" % stat)
+            logging.info("Found file %s for stat %s", filename, stat)
+            self.files[stat] = f
+
+        # Provide the dtype of the single detector method's output
+        # This is used by background estimation codes that need to maintain
+        # a buffer of such values.
+        self.single_dtype = numpy.float32
+        # True if a larger single detector statistic will produce a larger
+        # coincident statistic
+        self.single_increasing = True
+
+        self.ifos = ifos or []
+
+        self.sngl_ranking = sngl_ranking
+        self.sngl_ranking_kwargs = {}
+        for key, value in kwargs.items():
+            if key.startswith('sngl_ranking_'):
+                self.sngl_ranking_kwargs[key[13:]] = value
+
+    def get_sngl_ranking(self, trigs):
+        """
+        Returns the ranking for the single detector triggers.
+
+        Parameters
+        ----------
+        trigs: dict of numpy.ndarrays, h5py group (or similar dict-like object)
+            Dictionary-like object holding single detector trigger information.
+
+        Returns
+        -------
+        numpy.ndarray
+            The array of single detector values
+        """
+        return ranking.get_sngls_ranking_from_trigs(
+            trigs,
+            self.sngl_ranking,
+            **self.sngl_ranking_kwargs
+        )
+
+    def single(self, trigs): # pylint:disable=unused-argument
+        """
+        Calculate the necessary single detector information
+
+        Parameters
+        ----------
+        trigs: dict of numpy.ndarrays, h5py group (or similar dict-like object)
+            Dictionary-like object holding single detector trigger information.
+
+        Returns
+        -------
+        numpy.ndarray
+            The array of single detector values
+        """
+        err_msg = "This function is a stub that should be overridden by the "
+        err_msg += "sub-classes. You shouldn't be seeing this error!"
+        raise NotImplementedError(err_msg)
+
+    def rank_stat_single(self, single_info):
+        """
+        Calculate the statistic for a single detector candidate
+
+        Parameters
+        ----------
+        single_info: tuple
+            Tuple containing two values. The first is the ifo (str) and the
+            second is the single detector triggers.
+
+        Returns
+        -------
+        numpy.ndarray
+            The array of single detector statistics
+        """
+        err_msg = "This function is a stub that should be overridden by the "
+        err_msg += "sub-classes. You shouldn't be seeing this error!"
+        raise NotImplementedError(err_msg)
+
+    def rank_stat_coinc(self, s, slide, step, to_shift,
+                        **kwargs): # pylint:disable=unused-argument
+        """
+        Calculate the coincident detection statistic.
+        """
+        err_msg = "This function is a stub that should be overridden by the "
+        err_msg += "sub-classes. You shouldn't be seeing this error!"
+        raise NotImplementedError(err_msg)
+
+    def _check_coinc_lim_subclass(self, allowed_names):
+        """
+        Check that we are not using coinc_lim_for_thresh when not valid.
+
+        coinc_lim_for_thresh is only defined for the statistic it is present
+        in. If we subclass, we must check explicitly that it is still valid and
+        indicate this in the code. If the code does not have this explicit
+        check you will see the failure message here.
+
+        Parameters
+        -----------
+        allowed_names : list
+            list of allowed classes for the specific sub-classed method.
+        """
+        if type(self).__name__ not in allowed_names:
+            err_msg = "This is being called from a subclass which has not "
+            err_msg += "been checked for validity with this method. If it is "
+            err_msg += "valid for the subclass to come here, include in the "
+            err_msg += "list of allowed_names above."
+            raise NotImplementedError(err_msg)
+
+    def coinc_lim_for_thresh(self, s, thresh, limifo,
+                             **kwargs): # pylint:disable=unused-argument
+        """
+        Optimization function to identify coincs too quiet to be of interest
+
+        Calculate the required single detector statistic to exceed
+        the threshold for each of the input triggers.
+        """
+
+        err_msg = "This function is a stub that should be overridden by the "
+        err_msg += "sub-classes. You shouldn't be seeing this error!"
+        raise NotImplementedError(err_msg)
+
+
+class QuadratureSumStatistic(Stat):
+    """Calculate the quadrature sum coincident detection statistic"""
+
+    def single(self, trigs):
+        """
+        Calculate the necessary single detector information
+
+        Here just the ranking is computed and returned.
+
+        Parameters
+        ----------
+        trigs: dict of numpy.ndarrays, h5py group (or similar dict-like object)
+            Dictionary-like object holding single detector trigger information.
+
+        Returns
+        -------
+        numpy.ndarray
+            The array of single detector values
+        """
+        return self.get_sngl_ranking(trigs)
+
+    def rank_stat_single(self, single_info):
+        """
+        Calculate the statistic for a single detector candidate
+
+        Parameters
+        ----------
+        single_info: tuple
+            Tuple containing two values. The first is the ifo (str) and the
+            second is the single detector triggers.
+
+        Returns
+        -------
+        numpy.ndarray
+            The array of single detector statistics
+        """
+        return self.single(single_info[1])
+
+    def rank_stat_coinc(self, sngls_list, slide, step, to_shift,
+                        **kwargs): # pylint:disable=unused-argument
+        """
+        Calculate the coincident detection statistic.
+
+        Parameters
+        ----------
+        sngls_list: list
+            List of (ifo, single detector statistic) tuples
+        slide: (unused in this statistic)
+        step: (unused in this statistic)
+        to_shift: list
+            List of integers indicating what multiples of the time shift will
+            be applied (unused in this statistic)
+
+        Returns
+        -------
+        numpy.ndarray
+            Array of coincident ranking statistic values
+        """
+        cstat = sum(sngl[1] ** 2. for sngl in sngls_list) ** 0.5
+        # For single-detector "cuts" the single ranking is set to -1
+        for sngls in sngls_list:
+            cstat[sngls == -1] = 0
+        return cstat
+
+    def coinc_lim_for_thresh(self, s, thresh, limifo,
+                             **kwargs): # pylint:disable=unused-argument
+        """
+        Optimization function to identify coincs too quiet to be of interest
+
+        Calculate the required single detector statistic to exceed
+        the threshold for each of the input triggers.
+
+        Parameters
+        ----------
+        s: list
+            List of (ifo, single detector statistic) tuples for all detectors
+            except limifo.
+        thresh: float
+            The threshold on the coincident statistic.
+        limifo: string
+            The ifo for which the limit is to be found.
+
+        Returns
+        -------
+        numpy.ndarray
+            Array of limits on the limifo single statistic to
+            exceed thresh.
+        """
+        # Safety against subclassing and not rethinking this
+        allowed_names = ['QuadratureSumStatistic']
+        self._check_coinc_lim_subclass(allowed_names)
+
+        s0 = thresh ** 2. - sum(sngl[1] ** 2. for sngl in s)
+        s0[s0 < 0] = 0
+        return s0 ** 0.5
+
+
+class PhaseTDStatistic(QuadratureSumStatistic):
+    """
+    Statistic that re-weights combined newsnr using coinc parameters.
+
+    The weighting is based on the PDF of time delays, phase differences and
+    amplitude ratios between triggers in different ifos.
+    """
+
+    def __init__(self, sngl_ranking, files=None, ifos=None,
+                 pregenerate_hist=True, **kwargs):
+        """
+        Create a statistic class instance
+
+        Parameters
+        ----------
+        sngl_ranking: str
+            The name of the ranking to use for the single-detector triggers.
+
+        files: list of strs, unused here
+            A list containing the filenames of hdf format files used to help
+            construct the coincident statistics. The files must have a 'stat'
+            attribute which is used to associate them with the appropriate
+            statistic class.
+
+        ifos: list of strs, needed here
+            The list of detector names
+
+        pregenerate_hist: bool, optional
+            If False, do not pregenerate histogram on class instantiation.
+            Default is True.
+        """
+
+        QuadratureSumStatistic.__init__(self, sngl_ranking, files=files,
+                                        ifos=ifos, **kwargs)
+
+        self.single_dtype = [
+            ('snglstat', numpy.float32),
+            ('coa_phase', numpy.float32),
+            ('end_time', numpy.float64),
+            ('sigmasq', numpy.float32),
+            ('snr', numpy.float32)
+        ]
+
+        # Assign attribute so that it can be replaced with other functions
+        self.has_hist = False
+        self.hist_ifos = None
+        self.ref_snr = 5.0
+        self.relsense = {}
+        self.swidth = self.pwidth = self.twidth = None
+        self.srbmin = self.srbmax = None
+        self.max_penalty = None
+        self.pdtype = []
+        self.weights = {}
+        self.param_bin = {}
+        self.two_det_flag = (len(ifos) == 2)
+        self.two_det_weights = {}
+        if pregenerate_hist and not len(ifos) == 1:
+            self.get_hist()
+
+    def get_hist(self, ifos=None):
+        """
+        Read in a signal density file for the ifo combination
+
+        Parameters
+        ----------
+        ifos: list
+            The list of ifos. Needed if not given when initializing the class
+            instance.
+        """
+
+        ifos = ifos or self.ifos
+
+        selected = None
+        for name in self.files:
+            # Pick out the statistic files that provide phase / time/ amp
+            # relationships and match to the ifos in use
+            if 'phasetd_newsnr' in name:
+                ifokey = name.split('_')[2]
+                num = len(ifokey) / 2
+                if num != len(ifos):
+                    continue
+
+                match = [ifo in ifokey for ifo in ifos]
+                if False in match:
+                    continue
+                selected = name
+                break
+
+        if selected is None and len(ifos) > 1:
+            raise RuntimeError("Couldn't figure out which stat file to use")
+
+        logging.info("Using signal histogram %s for ifos %s", selected, ifos)
+        histfile = self.files[selected]
+        self.hist_ifos = histfile.attrs['ifos']
+        # Patch for pre-hdf5=3.0 histogram files
+        try:
+            logging.info("Decoding hist ifos ..")
+            self.hist_ifos = [i.decode('UTF-8') for i in self.hist_ifos]
+        except (UnicodeDecodeError, AttributeError):
+            pass
+        n_ifos = len(self.hist_ifos)
+
+        # Histogram bin attributes
+        self.twidth = histfile.attrs['twidth']
+        self.pwidth = histfile.attrs['pwidth']
+        self.swidth = histfile.attrs['swidth']
+        self.srbmin = histfile.attrs['srbmin']
+        self.srbmax = histfile.attrs['srbmax']
+
+        bin_volume = (self.twidth * self.pwidth * self.swidth) ** (n_ifos - 1)
+        self.hist_max = - 1. * numpy.inf
+
+        # Read histogram for each ifo, to use if that ifo has smallest SNR in
+        # the coinc
+        for ifo in self.hist_ifos:
+
+            weights = histfile[ifo]['weights'][:]
+            # renormalise to PDF
+            self.weights[ifo] = weights / (weights.sum() * bin_volume)
+
+            param = histfile[ifo]['param_bin'][:]
+
+            if param.dtype == numpy.int8:
+                # Older style, incorrectly sorted histogram file
+                ncol = param.shape[1]
+                self.pdtype = [('c%s' % i, param.dtype) for i in range(ncol)]
+                self.param_bin[ifo] = numpy.zeros(len(self.weights[ifo]),
+                                                  dtype=self.pdtype)
+                for i in range(ncol):
+                    self.param_bin[ifo]['c%s' % i] = param[:, i]
+
+                lsort = self.param_bin[ifo].argsort()
+                self.param_bin[ifo] = self.param_bin[ifo][lsort]
+                self.weights[ifo] = self.weights[ifo][lsort]
+            else:
+                # New style, efficient histogram file
+                # param bin and weights have already been sorted
+                self.param_bin[ifo] = param
+                self.pdtype = self.param_bin[ifo].dtype
+
+            # Max_penalty is a small number to assigned to any bins without
+            # histogram entries. All histograms in a given file have the same
+            # min entry by design, so use the min of the last one read in.
+            self.max_penalty = self.weights[ifo].min()
+            self.hist_max = max(self.hist_max, self.weights[ifo].max())
+
+            if self.two_det_flag:
+                # The density of signals is computed as a function of 3 binned
+                # parameters: time difference (t), phase difference (p) and
+                # SNR ratio (s). These are computed for each combination of
+                # detectors, so for detectors 6 differences are needed. However
+                # many combinations of these parameters are highly unlikely and
+                # no instances of these combinations occurred when generating
+                # the statistic files. Rather than storing a bunch of 0s, these
+                # values are just not stored at all. This reduces the size of
+                # the statistic file, but means we have to identify the correct
+                # value to read for every trigger. For 2 detectors we can
+                # expand the weights lookup table here, basically adding in all
+                # the "0" values. This makes looking up a value in the
+                # "weights" table a O(N) rather than O(NlogN) operation. It
+                # sacrifices RAM to do this, so is a good tradeoff for 2
+                # detectors, but not for 3!
+                if not hasattr(self, 'c0_size'):
+                    self.c0_size = {}
+                    self.c1_size = {}
+                    self.c2_size = {}
+
+                self.c0_size[ifo] = 2 * (abs(self.param_bin[ifo]['c0']).max()
+                                         + 1)
+                self.c1_size[ifo] = 2 * (abs(self.param_bin[ifo]['c1']).max()
+                                         + 1)
+                self.c2_size[ifo] = 2 * (abs(self.param_bin[ifo]['c2']).max()
+                                         + 1)
+
+                array_size = [self.c0_size[ifo], self.c1_size[ifo],
+                              self.c2_size[ifo]]
+                dtypec = self.weights[ifo].dtype
+                self.two_det_weights[ifo] = \
+                    numpy.zeros(array_size, dtype=dtypec) + self.max_penalty
+                id0 = self.param_bin[ifo]['c0'].astype(numpy.int32) \
+                    + self.c0_size[ifo] // 2
+                id1 = self.param_bin[ifo]['c1'].astype(numpy.int32) \
+                    + self.c1_size[ifo] // 2
+                id2 = self.param_bin[ifo]['c2'].astype(numpy.int32) \
+                    + self.c2_size[ifo] // 2
+                self.two_det_weights[ifo][id0, id1, id2] = self.weights[ifo]
+
+        relfac = histfile.attrs['sensitivity_ratios']
+        for ifo, sense in zip(self.hist_ifos, relfac):
+            self.relsense[ifo] = sense
+
+        self.has_hist = True
+
+    def logsignalrate(self, stats, shift, to_shift):
+        """
+        Calculate the normalized log rate density of signals via lookup
+
+        Parameters
+        ----------
+        stats: dict of dicts
+            Single-detector quantities for each detector
+        shift: numpy array of float
+            Time shift vector for each coinc to be ranked
+        to_shift: list of ints
+            Multiple of the time shift to apply, ordered as self.ifos
+
+        Returns
+        -------
+        value: log of coinc signal rate density for the given single-ifo
+            triggers and time shifts
+        """
+        # Convert time shift vector to dict, as hist ifos and self.ifos may
+        # not be in same order
+        to_shift = {ifo: s for ifo, s in zip(self.ifos, to_shift)}
+
+        if not self.has_hist:
+            self.get_hist()
+
+        # Figure out which ifo of the contributing ifos has the smallest SNR,
+        # to use as reference for choosing the signal histogram.
+        snrs = numpy.array([numpy.array(stats[ifo]['snr'], ndmin=1)
+                           for ifo in self.ifos])
+        smin = numpy.argmin(snrs, axis=0)
+        # Store a list of the triggers using each ifo as reference
+        rtypes = {ifo: numpy.where(smin == j)[0]
+                  for j, ifo in enumerate(self.ifos)}
+
+        # Get reference ifo information
+        rate = numpy.zeros(len(shift), dtype=numpy.float32)
+        for ref_ifo in self.ifos:
+            rtype = rtypes[ref_ifo]
+            ref = stats[ref_ifo]
+            pref = numpy.array(ref['coa_phase'], ndmin=1)[rtype]
+            tref = numpy.array(ref['end_time'], ndmin=1)[rtype]
+            sref = numpy.array(ref['snr'], ndmin=1)[rtype]
+            sigref = numpy.array(ref['sigmasq'], ndmin=1) ** 0.5
+            sigref = sigref[rtype]
+            senseref = self.relsense[self.hist_ifos[0]]
+
+            binned = []
+            other_ifos = [ifo for ifo in self.ifos if ifo != ref_ifo]
+            for ifo in other_ifos:
+                sc = stats[ifo]
+                p = numpy.array(sc['coa_phase'], ndmin=1)[rtype]
+                t = numpy.array(sc['end_time'], ndmin=1)[rtype]
+                s = numpy.array(sc['snr'], ndmin=1)[rtype]
+
+                sense = self.relsense[ifo]
+                sig = numpy.array(sc['sigmasq'], ndmin=1) ** 0.5
+                sig = sig[rtype]
+
+                # Calculate differences
+                pdif = (pref - p) % (numpy.pi * 2.0)
+                tdif = shift[rtype] * to_shift[ref_ifo] + \
+                    tref - shift[rtype] * to_shift[ifo] - t
+                sdif = s / sref * sense / senseref * sigref / sig
+
+                # Put into bins
+                tbin = (tdif / self.twidth).astype(int)
+                pbin = (pdif / self.pwidth).astype(int)
+                sbin = (sdif / self.swidth).astype(int)
+                binned += [tbin, pbin, sbin]
+
+            # Convert binned to same dtype as stored in hist
+            nbinned = numpy.zeros(len(pbin), dtype=self.pdtype)
+            for i, b in enumerate(binned):
+                nbinned['c%s' % i] = b
+
+            # Read signal weight from precalculated histogram
+            if self.two_det_flag:
+                # High-RAM, low-CPU option for two-det
+                rate[rtype] = numpy.zeros(len(nbinned)) + self.max_penalty
+
+                id0 = nbinned['c0'].astype(numpy.int32) \
+                    + self.c0_size[ref_ifo] // 2
+                id1 = nbinned['c1'].astype(numpy.int32) \
+                    + self.c1_size[ref_ifo] // 2
+                id2 = nbinned['c2'].astype(numpy.int32) \
+                    + self.c2_size[ref_ifo] // 2
+
+                # look up keys which are within boundaries
+                within = (id0 > 0) & (id0 < self.c0_size[ref_ifo])
+                within = within & (id1 > 0) & (id1 < self.c1_size[ref_ifo])
+                within = within & (id2 > 0) & (id2 < self.c2_size[ref_ifo])
+                within = numpy.where(within)[0]
+                rate[rtype[within]] = \
+                    self.two_det_weights[ref_ifo][id0[within], id1[within],
+                                                  id2[within]]
+            else:
+                # Low[er]-RAM, high[er]-CPU option for >two det
+                loc = numpy.searchsorted(self.param_bin[ref_ifo], nbinned)
+                loc[loc == len(self.weights[ref_ifo])] = 0
+                rate[rtype] = self.weights[ref_ifo][loc]
+
+                # These weren't in our histogram so give them max penalty
+                # instead of random value
+                missed = numpy.where(
+                    self.param_bin[ref_ifo][loc] != nbinned
+                )[0]
+                rate[rtype[missed]] = self.max_penalty
+
+            # Scale by signal population SNR
+            rate[rtype] *= (sref / self.ref_snr) ** -4.0
+
+        return numpy.log(rate)
+
+    def single(self, trigs):
+        """
+        Calculate the necessary single detector information
+
+        Here the ranking as well as phase, endtime and sigma-squared values.
+
+        Parameters
+        ----------
+        trigs: dict of numpy.ndarrays, h5py group or similar dict-like object
+            Object holding single detector trigger information. 'snr', 'chisq',
+            'chisq_dof', 'coa_phase', 'end_time', and 'sigmasq' are required
+            keys.
+
+        Returns
+        -------
+        numpy.ndarray
+            Array of single detector parameter values
+        """
+        sngl_stat = self.get_sngl_ranking(trigs)
+        singles = numpy.zeros(len(sngl_stat), dtype=self.single_dtype)
+        singles['snglstat'] = sngl_stat
+        singles['coa_phase'] = trigs['coa_phase'][:]
+        singles['end_time'] = trigs['end_time'][:]
+        singles['sigmasq'] = trigs['sigmasq'][:]
+        singles['snr'] = trigs['snr'][:]
+        return numpy.array(singles, ndmin=1)
+
+    def rank_stat_single(self, single_info):
+        """
+        Calculate the statistic for a single detector candidate
+
+        Parameters
+        ----------
+        single_info: tuple
+            Tuple containing two values. The first is the ifo (str) and the
+            second is the single detector triggers.
+
+        Returns
+        -------
+        numpy.ndarray
+            The array of single detector statistics
+        """
+        return self.single(single_info[1])
+
+    def rank_stat_coinc(self, sngls_list, slide, step, to_shift,
+                        **kwargs):  # pylint:disable=unused-argument
+        """
+        Calculate the coincident detection statistic, defined in Eq 2 of
+        [Nitz et al, 2017](https://doi.org/10.3847/1538-4357/aa8f50).
+        """
+        rstat = sum(s[1]['snglstat'] ** 2 for s in sngls_list)
+        cstat = rstat + 2. * self.logsignalrate(dict(sngls_list),
+                                                slide * step,
+                                                to_shift)
+        cstat[cstat < 0] = 0
+        return cstat ** 0.5
+
+    def coinc_lim_for_thresh(self, sngls_list, thresh, limifo,
+                             **kwargs):  # pylint:disable=unused-argument
+        """
+        Optimization function to identify coincs too quiet to be of interest.
+        Calculate the required single detector statistic to exceed the
+        threshold for each of the input triggers.
+        """
+        # Safety against subclassing and not rethinking this
+        allowed_names = ['PhaseTDStatistic']
+        self._check_coinc_lim_subclass(allowed_names)
+
+        if not self.has_hist:
+            self.get_hist()
+
+        lim_stat = [b['snglstat'] for a, b in sngls_list if a == limifo][0]
+        s1 = thresh ** 2. - lim_stat ** 2.
+        # Assume best case scenario and use maximum signal rate
+        s1 -= 2. * self.hist_max
+        s1[s1 < 0] = 0
+        return s1 ** 0.5
+
+
+class ExpFitStatistic(QuadratureSumStatistic):
+    """
+    Detection statistic using an exponential falloff noise model.
+
+    Statistic approximates the negative log noise coinc rate density per
+    template over single-ifo newsnr values.
+    """
+
+    def __init__(self, sngl_ranking, files=None, ifos=None, **kwargs):
+        """
+        Create a statistic class instance
+
+        Parameters
+        ----------
+        sngl_ranking: str
+            The name of the ranking to use for the single-detector triggers.
+
+        files: list of strs, needed here
+            A list containing the filenames of hdf format files used to help
+            construct the coincident statistics. The files must have a 'stat'
+            attribute which is used to associate them with the appropriate
+            statistic class.
+
+        ifos: list of strs, not used here
+            The list of detector names
+        """
+
+        if not files:
+            raise RuntimeError("Statistic files not specified")
+        QuadratureSumStatistic.__init__(self, sngl_ranking, files=files,
+                                        ifos=ifos, **kwargs)
+
+        # the stat file attributes are hard-coded as '%{ifo}-fit_coeffs'
+        parsed_attrs = [f.split('-') for f in self.files.keys()]
+        self.bg_ifos = [at[0] for at in parsed_attrs if
+                       (len(at) == 2 and at[1] == 'fit_coeffs')]
+        if not len(self.bg_ifos):
+            raise RuntimeError("None of the statistic files has the required "
+                               "attribute called {ifo}-fit_coeffs !")
+        self.fits_by_tid = {}
+        self.alphamax = {}
+        for i in self.bg_ifos:
+            self.fits_by_tid[i] = self.assign_fits(i)
+            self.get_ref_vals(i)
+
+        self.single_increasing = False
+
+    def assign_fits(self, ifo):
+        """
+        Extract fits from fit files
+
+        Parameters
+        -----------
+        ifo: str
+            The detector to get fits for.
+
+        Returns
+        -------
+        rate_dict: dict
+            A dictionary containing the fit information in the `alpha`, `rate`
+            and `thresh` keys/.
+        """
+        coeff_file = self.files[ifo+'-fit_coeffs']
+        template_id = coeff_file['template_id'][:]
+        # the template_ids and fit coeffs are stored in an arbitrary order
+        # create new arrays in template_id order for easier recall
+        tid_sort = numpy.argsort(template_id)
+
+        fits_by_tid_dict = {}
+        fits_by_tid_dict['smoothed_fit_coeff'] = \
+            coeff_file['fit_coeff'][:][tid_sort]
+        fits_by_tid_dict['smoothed_rate_above_thresh'] = \
+            coeff_file['count_above_thresh'][:][tid_sort].astype(float)
+        fits_by_tid_dict['smoothed_rate_in_template'] = \
+            coeff_file['count_in_template'][:][tid_sort].astype(float)
+
+        # The by-template fits may have been stored in the smoothed fits file
+        if 'fit_by_template' in coeff_file:
+            coeff_fbt = coeff_file['fit_by_template']
+            fits_by_tid_dict['fit_by_fit_coeff'] = \
+                coeff_fbt['fit_coeff'][:][tid_sort]
+            fits_by_tid_dict['fit_by_rate_above_thresh'] = \
+                coeff_fbt['count_above_thresh'][:][tid_sort].astype(float)
+            fits_by_tid_dict['fit_by_rate_in_template'] = \
+                coeff_file['count_in_template'][:][tid_sort].astype(float)
+
+        # Keep the fit threshold in fits_by_tid
+        fits_by_tid_dict['thresh'] = coeff_file.attrs['stat_threshold']
+
+        return fits_by_tid_dict
+
+    def get_ref_vals(self, ifo):
+        """
+        Get the largest `alpha` value over all templates for given ifo.
+
+        This is stored in `self.alphamax[ifo]` in the class instance.
+
+        Parameters
+        -----------
+        ifo: str
+            The detector to get fits for.
+        """
+        self.alphamax[ifo] = self.fits_by_tid[ifo]['smoothed_fit_coeff'].max()
+
+    def find_fits(self, trigs):
+        """
+        Get fit coeffs for a specific ifo and template id(s)
+
+        Parameters
+        ----------
+        trigs: dict of numpy.ndarrays, h5py group (or similar dict-like object)
+            Dictionary-like object holding single detector trigger information.
+            The coincidence executable will always call this using a bunch of
+            trigs from a single template, there template_num is stored as an
+            attribute and we just return the single value for all templates.
+            If multiple templates are in play we must return arrays.
+
+        Returns
+        --------
+        alphai: float or numpy array
+            The alpha fit value(s)
+        ratei: float or numpy array
+            The rate fit value(s)
+        thresh: float or numpy array
+            The thresh fit value(s)
+        """
+
+        try:
+            tnum = trigs.template_num  # exists if accessed via coinc_findtrigs
+            ifo = trigs.ifo
+        except AttributeError:
+            tnum = trigs['template_id']  # exists for SingleDetTriggers
+            assert len(self.ifos) == 1
+            # Should be exactly one ifo provided
+            ifo = self.ifos[0]
+        # fits_by_tid is a dictionary of dictionaries of arrays
+        # indexed by ifo / coefficient name / template_id
+        alphai = self.fits_by_tid[ifo]['smoothed_fit_coeff'][tnum]
+        ratei = self.fits_by_tid[ifo]['smoothed_rate_above_thresh'][tnum]
+        thresh = self.fits_by_tid[ifo]['thresh']
+
+        return alphai, ratei, thresh
+
+    def lognoiserate(self, trigs):
+        """
+        Calculate the log noise rate density over single-ifo ranking
+
+        Read in single trigger information, compute the ranking
+        and rescale by the fitted coefficients alpha and rate
+
+        Parameters
+        -----------
+        trigs: dict of numpy.ndarrays, h5py group (or similar dict-like object)
+            Dictionary-like object holding single detector trigger information.
+
+        Returns
+        ---------
+        lognoisel: numpy.array
+            Array of log noise rate density for each input trigger.
+
+        """
+        alphai, ratei, thresh = self.find_fits(trigs)
+        sngl_stat = self.get_sngl_ranking(trigs)
+        # alphai is constant of proportionality between single-ifo newsnr and
+        #   negative log noise likelihood in given template
+        # ratei is rate of trigs in given template compared to average
+        # thresh is stat threshold used in given ifo
+        lognoisel = - alphai * (sngl_stat - thresh) + numpy.log(alphai) + \
+                      numpy.log(ratei)
+        return numpy.array(lognoisel, ndmin=1, dtype=numpy.float32)
+
+    def single(self, trigs):
+        """
+        Calculate the necessary single detector information
+
+        In this case the ranking rescaled (see the lognoiserate method here).
+
+        Parameters
+        ----------
+        trigs: dict of numpy.ndarrays, h5py group (or similar dict-like object)
+            Dictionary-like object holding single detector trigger information.
+
+        Returns
+        -------
+        numpy.ndarray
+            The array of single detector values
+        """
+
+        return self.lognoiserate(trigs)
+
+    def rank_stat_single(self, single_info):
+        """
+        Calculate the statistic for a single detector candidate
+
+        Parameters
+        ----------
+        single_info: tuple
+            Tuple containing two values. The first is the ifo (str) and the
+            second is the single detector triggers.
+
+        Returns
+        -------
+        numpy.ndarray
+            The array of single detector statistics
+        """
+        err_msg = "Sorry! No-one has implemented this method yet! "
+        raise NotImplementedError(err_msg)
+
+    def rank_stat_coinc(self, s, slide, step, to_shift,
+                        **kwargs): # pylint:disable=unused-argument
+        """
+        Calculate the coincident detection statistic.
+        """
+        err_msg = "Sorry! No-one has implemented this method yet! "
+        raise NotImplementedError(err_msg)
+
+    def coinc_lim_for_thresh(self, s, thresh, limifo,
+                             **kwargs): # pylint:disable=unused-argument
+        """
+        Optimization function to identify coincs too quiet to be of interest
+        Calculate the required single detector statistic to exceed
+        the threshold for each of the input triggers.
+        """
+        err_msg = "Sorry! No-one has implemented this method yet! "
+        raise NotImplementedError(err_msg)
+
+    # Keeping this here to help write the new coinc method.
+    def coinc_OLD(self, s0, s1, slide, step): # pylint:disable=unused-argument
+        """Calculate the final coinc ranking statistic"""
+
+        # Approximate log likelihood ratio by summing single-ifo negative
+        # log noise likelihoods
+        loglr = - s0 - s1
+        # add squares of threshold stat values via idealized Gaussian formula
+        threshes = [self.fits_by_tid[i]['thresh'] for i in self.bg_ifos]
+        loglr += sum([t**2. / 2. for t in threshes])
+        # convert back to a coinc-SNR-like statistic
+        # via log likelihood ratio \propto rho_c^2 / 2
+        return (2. * loglr) ** 0.5
+
+    # Keeping this here to help write the new coinc_lim method
+    def coinc_lim_for_thresh_OLD(self, s0, thresh):
+        """Calculate the required single detector statistic to exceed
+        the threshold for each of the input triggers.
+
+        Parameters
+        ----------
+        s0: numpy.ndarray
+            Single detector ranking statistic for the first detector.
+        thresh: float
+            The threshold on the coincident statistic.
+
+        Returns
+        -------
+        numpy.ndarray
+            Array of limits on the second detector single statistic to
+        exceed thresh.
+        """
+        s1 = - (thresh ** 2.) / 2. - s0
+        threshes = [self.fits_by_tid[i]['thresh'] for i in self.bg_ifos]
+        s1 += sum([t**2. / 2. for t in threshes])
+        return s1
+
+
+class ExpFitCombinedSNR(ExpFitStatistic):
+    """
+    Reworking of ExpFitStatistic designed to resemble network SNR
+
+    Use a monotonic function of the negative log noise rate density which
+    approximates combined (new)snr for coincs with similar newsnr in each ifo
+    """
+
+    def __init__(self, sngl_ranking, files=None, ifos=None, **kwargs):
+        """
+        Create a statistic class instance
+
+        Parameters
+        ----------
+        sngl_ranking: str
+            The name of the ranking to use for the single-detector triggers.
+
+        files: list of strs, needed here
+            A list containing the filenames of hdf format files used to help
+            construct the coincident statistics. The files must have a 'stat'
+            attribute which is used to associate them with the appropriate
+            statistic class.
+
+        ifos: list of strs, not used here
+            The list of detector names
+        """
+
+        ExpFitStatistic.__init__(self, sngl_ranking, files=files, ifos=ifos,
+                                 **kwargs)
+        # for low-mass templates the exponential slope alpha \approx 6
+        self.alpharef = 6.
+        self.single_increasing = True
+
+    def use_alphamax(self):
+        """
+        Compute the reference alpha from the fit files.
+
+        Use the harmonic mean of the maximum individual ifo slopes as the
+        reference value of alpha.
+        """
+
+        inv_alphas = [1. / self.alphamax[i] for i in self.bg_ifos]
+        self.alpharef = 1. / (sum(inv_alphas) / len(inv_alphas))
+
+    def single(self, trigs):
+        """
+        Calculate the necessary single detector information
+
+        Parameters
+        ----------
+        trigs: dict of numpy.ndarrays, h5py group (or similar dict-like object)
+            Dictionary-like object holding single detector trigger information.
+
+        Returns
+        -------
+        numpy.ndarray
+            The array of single detector values
+        """
+
+        logr_n = self.lognoiserate(trigs)
+        _, _, thresh = self.find_fits(trigs)
+        # shift by log of reference slope alpha
+        logr_n += -1. * numpy.log(self.alpharef)
+        # add threshold and rescale by reference slope
+        stat = thresh - (logr_n / self.alpharef)
+        return numpy.array(stat, ndmin=1, dtype=numpy.float32)
+
+    def rank_stat_single(self, single_info):
+        """
+        Calculate the statistic for single detector candidates
+
+        Parameters
+        ----------
+        single_info: tuple
+            Tuple containing two values. The first is the ifo (str) and the
+            second is the single detector triggers.
+
+        Returns
+        -------
+        numpy.ndarray
+            The array of single detector statistics
+        """
+        if self.single_increasing:
+            sngl_multiifo = single_info[1]['snglstat']
+        else:
+            sngl_multiifo = -1.0 * single_info[1]['snglstat']
+        return sngl_multiifo
+
+    def rank_stat_coinc(self, s, slide, step, to_shift,
+                        **kwargs): # pylint:disable=unused-argument
+        """
+        Calculate the coincident detection statistic.
+
+        Parameters
+        ----------
+        sngls_list: list
+            List of (ifo, single detector statistic) tuples
+        slide: (unused in this statistic)
+        step: (unused in this statistic)
+        to_shift: list
+            List of integers indicating what multiples of the time shift will
+            be applied (unused in this statistic)
+
+        Returns
+        -------
+        numpy.ndarray
+            Array of coincident ranking statistic values
+        """
+
+        # scale by 1/sqrt(number of ifos) to resemble network SNR
+        return sum(sngl[1] for sngl in s) / len(s)**0.5
+
+    def coinc_lim_for_thresh(self, s, thresh, limifo,
+                             **kwargs): # pylint:disable=unused-argument
+        """
+        Optimization function to identify coincs too quiet to be of interest
+
+        Calculate the required single detector statistic to exceed
+        the threshold for each of the input triggers.
+
+        Parameters
+        ----------
+        s: list
+            List of (ifo, single detector statistic) tuples for all detectors
+            except limifo.
+        thresh: float
+            The threshold on the coincident statistic.
+        limifo: string
+            The ifo for which the limit is to be found.
+
+        Returns
+        -------
+        numpy.ndarray
+            Array of limits on the limifo single statistic to
+            exceed thresh.
+        """
+        # Safety against subclassing and not rethinking this
+        allowed_names = ['ExpFitCombinedSNR']
+        self._check_coinc_lim_subclass(allowed_names)
+
+        return thresh * ((len(s) + 1) ** 0.5) - sum(sngl[1] for sngl in s)
+
+
+class PhaseTDExpFitStatistic(PhaseTDStatistic, ExpFitCombinedSNR):
+    """
+    Statistic combining exponential noise model with signal histogram PDF
+    """
+
+    # default is 2-ifo operation with exactly 1 'phasetd' file
+    def __init__(self, sngl_ranking, files=None, ifos=None, **kwargs):
+        """
+        Create a statistic class instance
+
+        Parameters
+        ----------
+        sngl_ranking: str
+            The name of the ranking to use for the single-detector triggers.
+        files: list of strs, needed here
+            A list containing the filenames of hdf format files used to help
+            construct the coincident statistics. The files must have a 'stat'
+            attribute which is used to associate them with the appropriate
+            statistic class.
+        ifos: list of strs, needed here
+            The list of detector names
+        """
+
+        # read in both foreground PDF and background fit info
+        ExpFitCombinedSNR.__init__(self, sngl_ranking, files=files, ifos=ifos,
+                                   **kwargs)
+        # need the self.single_dtype value from PhaseTDStatistic
+        PhaseTDStatistic.__init__(self, sngl_ranking, files=files,
+                                  ifos=ifos, **kwargs)
+
+    def single(self, trigs):
+        """
+        Calculate the necessary single detector information
+
+        In this case the ranking rescaled (see the lognoiserate method here)
+        with the phase, end time, sigma and SNR values added in.
+
+        Parameters
+        ----------
+        trigs: dict of numpy.ndarrays, h5py group (or similar dict-like object)
+            Dictionary-like object holding single detector trigger information.
+
+        Returns
+        -------
+        numpy.ndarray
+            The array of single detector values
+        """
+
+        # same single-ifo stat as ExpFitCombinedSNR
+        sngl_stat = ExpFitCombinedSNR.single(self, trigs)
+        singles = numpy.zeros(len(sngl_stat), dtype=self.single_dtype)
+        singles['snglstat'] = sngl_stat
+        singles['coa_phase'] = trigs['coa_phase'][:]
+        singles['end_time'] = trigs['end_time'][:]
+        singles['sigmasq'] = trigs['sigmasq'][:]
+        singles['snr'] = trigs['snr'][:]
+        return numpy.array(singles, ndmin=1)
+
+    def rank_stat_single(self, single_info):
+        """
+        Calculate the statistic for a single detector candidate
+
+        Parameters
+        ----------
+        single_info: tuple
+            Tuple containing two values. The first is the ifo (str) and the
+            second is the single detector triggers.
+
+        Returns
+        -------
+        numpy.ndarray
+            The array of single detector statistics
+        """
+        err_msg = "Sorry! No-one has implemented this method yet! "
+        raise NotImplementedError(err_msg)
+
+    def rank_stat_coinc(self, s, slide, step, to_shift,
+                        **kwargs): # pylint:disable=unused-argument
+        """
+        Calculate the coincident detection statistic.
+        """
+        err_msg = "Sorry! No-one has implemented this method yet! "
+        raise NotImplementedError(err_msg)
+
+    def coinc_lim_for_thresh(self, s, thresh, limifo,
+                             **kwargs): # pylint:disable=unused-argument
+        """
+        Optimization function to identify coincs too quiet to be of interest
+        Calculate the required single detector statistic to exceed
+        the threshold for each of the input triggers.
+        """
+        err_msg = "Sorry! No-one has implemented this method yet! "
+        raise NotImplementedError(err_msg)
+
+    # Keeping the old statistic code here for now to help with reimplementing
+    def coinc_OLD(self, s0, s1, slide, step):
+        # logsignalrate function inherited from PhaseTDStatistic
+        logr_s = self.logsignalrate(s0, s1, slide * step)
+        # rescale by ExpFitCombinedSNR reference slope as for sngl stat
+        cstat = s0['snglstat'] + s1['snglstat'] + logr_s / self.alpharef
+        # cut off underflowing and very small values
+        cstat[cstat < 8.] = 8.
+        # scale to resemble network SNR
+        return cstat / (2.**0.5)
+
+    def coinc_lim_for_thresh_OLD(self, s0, thresh):
+        # if the threshold is below this value all triggers will
+        # pass because of rounding in the coinc method
+        if thresh <= (8. / (2.**0.5)):
+            return -1. * numpy.ones(len(s0['snglstat'])) * numpy.inf
+        if not self.has_hist:
+            self.get_hist()
+        # Assume best case scenario and use maximum signal rate
+        logr_s = self.hist_max
+        s1 = (2 ** 0.5) * thresh - s0['snglstat'] - logr_s / self.alpharef
+        return s1
+
+
+class ExpFitBgRateStatistic(ExpFitStatistic):
+    """
+    Detection statistic using an exponential falloff noise model.
+
+    Statistic calculates the log noise coinc rate for each
+    template over single-ifo newsnr values.
+    """
+
+    def __init__(self, sngl_ranking, files=None, ifos=None,
+                 benchmark_lograte=-14.6, **kwargs):
+        """
+        Create a statistic class instance
+
+        Parameters
+        ----------
+        sngl_ranking: str
+            The name of the ranking to use for the single-detector triggers.
+        files: list of strs, needed here
+            A list containing the filenames of hdf format files used to help
+            construct the coincident statistics. The files must have a 'stat'
+            attribute which is used to associate them with the appropriate
+            statistic class.
+        ifos: list of strs, not used here
+            The list of detector names
+        benchmark_lograte: float, default=-14.6
+            benchmark_lograte is log of a representative noise trigger rate.
+            The default comes from H1L1 (O2) and is 4.5e-7 Hz.
+        """
+
+        super(ExpFitBgRateStatistic, self).__init__(sngl_ranking,
+                                                    files=files, ifos=ifos,
+                                                    **kwargs)
+        self.benchmark_lograte = benchmark_lograte
+
+        # Reassign the rate to be number per time rather than an arbitrarily
+        # normalised number
+        for ifo in self.bg_ifos:
+            self.reassign_rate(ifo)
+
+    def reassign_rate(self, ifo):
+        """
+        Reassign the rate to be number per time rather
+
+        Reassign the rate to be number per time rather than an arbitrarily
+        normalised number.
+
+        Parameters
+        -----------
+        ifo: str
+            The ifo to consider.
+        """
+        coeff_file = self.files[ifo+'-fit_coeffs']
+        analysis_time = float(coeff_file.attrs['analysis_time'])
+        self.fits_by_tid[ifo]['smoothed_rate_above_thresh'] /= analysis_time
+        self.fits_by_tid[ifo]['smoothed_rate_in_template'] /= analysis_time
+        # The by-template fits may have been stored in the smoothed fits file
+        if 'fit_by_template' in coeff_file:
+            self.fits_by_tid[ifo]['fit_by_rate_above_thresh'] /= analysis_time
+            self.fits_by_tid[ifo]['fit_by_rate_in_template'] /= analysis_time
+
+    def rank_stat_coinc(self, s, slide, step, to_shift,
+                        **kwargs): # pylint:disable=unused-argument
+        """
+        Calculate the coincident detection statistic.
+
+        Parameters
+        ----------
+        sngls_list: list
+            List of (ifo, single detector statistic) tuples
+        slide: (unused in this statistic)
+        step: (unused in this statistic)
+        to_shift: list
+            List of integers indicating what multiples of the time shift will
+            be applied (unused in this statistic)
+
+        Returns
+        -------
+        numpy.ndarray
+            Array of coincident ranking statistic values
+        """
+
+        # ranking statistic is -ln(expected rate density of noise triggers)
+        # plus normalization constant
+        sngl_dict = {sngl[0]: sngl[1] for sngl in s}
+        ln_noise_rate = coinc_rate.combination_noise_lograte(
+                                  sngl_dict, kwargs['time_addition'])
+        loglr = - ln_noise_rate + self.benchmark_lograte
+        return loglr
+
+    def coinc_lim_for_thresh(self, s, thresh, limifo, **kwargs):
+        """
+        Optimization function to identify coincs too quiet to be of interest
+
+        Calculate the required single detector statistic to exceed
+        the threshold for each of the input triggers.
+
+        Parameters
+        ----------
+        s: list
+            List of (ifo, single detector statistic) tuples for all detectors
+            except limifo.
+        thresh: float
+            The threshold on the coincident statistic.
+        limifo: string
+            The ifo for which the limit is to be found.
+
+        Returns
+        -------
+        numpy.ndarray
+            Array of limits on the limifo single statistic to
+            exceed thresh.
+        """
+
+        # Safety against subclassing and not rethinking this
+        allowed_names = ['ExpFitBgRateStatistic']
+        self._check_coinc_lim_subclass(allowed_names)
+
+        sngl_dict = {sngl[0]: sngl[1] for sngl in s}
+        sngl_dict[limifo] = numpy.zeros(len(s[0][1]))
+        ln_noise_rate = coinc_rate.combination_noise_lograte(
+                                  sngl_dict, kwargs['time_addition'])
+        loglr = - thresh - ln_noise_rate + self.benchmark_lograte
+        return loglr
+
+
+class ExpFitFgBgNormStatistic(PhaseTDStatistic,
+                              ExpFitBgRateStatistic):
+    """
+    Statistic combining PhaseTD, ExpFitBg and additional foreground info.
+    """
+
+    def __init__(self, sngl_ranking, files=None, ifos=None,
+                 reference_ifos='H1,L1', **kwargs):
+        """
+        Create a statistic class instance
+
+        Parameters
+        ----------
+        sngl_ranking: str
+            The name of the ranking to use for the single-detector triggers.
+        files: list of strs, needed here
+            A list containing the filenames of hdf format files used to help
+            construct the coincident statistics. The files must have a 'stat'
+            attribute which is used to associate them with the appropriate
+            statistic class.
+        ifos: list of strs
+            The list of detector names
+        reference_ifos: string of comma separated ifo prefixes
+            Detectors to be used as the reference network for network
+            sensitivity comparisons. Each must be in fits_by_tid
+        """
+
+        # read in background fit info and store it
+        ExpFitBgRateStatistic.__init__(self, sngl_ranking, files=files,
+                                       ifos=ifos, **kwargs)
+        # if ifos not already set, determine via background fit info
+        self.ifos = self.ifos or self.bg_ifos
+        # PhaseTD statistic single_dtype plus network sensitivity benchmark
+        PhaseTDStatistic.__init__(self, sngl_ranking, files=files,
+                                  ifos=self.ifos, **kwargs)
+        self.single_dtype.append(('benchmark_logvol', numpy.float32))
+
+        for ifo in self.bg_ifos:
+            self.assign_median_sigma(ifo)
+
+        ref_ifos = reference_ifos.split(',')
+
+        # benchmark_logvol is a benchmark sensitivity array over template id
+        hl_net_med_sigma = numpy.amin([self.fits_by_tid[ifo]['median_sigma']
+                                       for ifo in ref_ifos], axis=0)
+        self.benchmark_logvol = 3.0 * numpy.log(hl_net_med_sigma)
+        self.single_increasing = False
+
+    def assign_median_sigma(self, ifo):
+        """
+        Read and sort the median_sigma values from input files.
+
+        Parameters
+        ----------
+        ifo: str
+            The ifo to consider.
+        """
+
+        coeff_file = self.files[ifo + '-fit_coeffs']
+        template_id = coeff_file['template_id'][:]
+        tid_sort = numpy.argsort(template_id)
+        self.fits_by_tid[ifo]['median_sigma'] = \
+            coeff_file['median_sigma'][:][tid_sort]
+
+    def lognoiserate(self, trigs, alphabelow=6):
+        """
+        Calculate the log noise rate density over single-ifo ranking
+
+        Read in single trigger information, make the newsnr statistic
+        and rescale by the fitted coefficients alpha and rate
+
+        Parameters
+        -----------
+        trigs: dict of numpy.ndarrays, h5py group (or similar dict-like object)
+            Dictionary-like object holding single detector trigger information.
+        alphabelow: float, default=6
+            Use this slope to fit the noise triggers below the point at which
+            fits are present in the input files.
+
+        Returns
+        ---------
+        lognoisel: numpy.array
+            Array of log noise rate density for each input trigger.
+        """
+        alphai, ratei, thresh = self.find_fits(trigs)
+        newsnr = self.get_sngl_ranking(trigs)
+        # Above the threshold we use the usual fit coefficient (alpha)
+        # below threshold use specified alphabelow
+        bt = newsnr < thresh
+        lognoisel = - alphai * (newsnr - thresh) + numpy.log(alphai) + \
+                        numpy.log(ratei)
+        lognoiselbt = - alphabelow * (newsnr - thresh) + \
+                           numpy.log(alphabelow) + numpy.log(ratei)
+        lognoisel[bt] = lognoiselbt[bt]
+        return numpy.array(lognoisel, ndmin=1, dtype=numpy.float32)
+
+    def single(self, trigs):
+        """
+        Calculate the necessary single detector information
+
+        In this case the ranking rescaled (see the lognoiserate method here)
+        with the phase, end time, sigma, SNR, template_id and the
+        benchmark_logvol values added in.
+
+        Parameters
+        ----------
+        trigs: dict of numpy.ndarrays, h5py group (or similar dict-like object)
+            Dictionary-like object holding single detector trigger information.
+        Returns
+        -------
+        numpy.ndarray
+            The array of single detector values
+        """
+
+        # single-ifo stat = log of noise rate
+        sngl_stat = self.lognoiserate(trigs)
+        # populate other fields to calculate phase/time/amp consistency
+        # and sigma comparison
+        singles = numpy.zeros(len(sngl_stat), dtype=self.single_dtype)
+        singles['snglstat'] = sngl_stat
+        singles['coa_phase'] = trigs['coa_phase'][:]
+        singles['end_time'] = trigs['end_time'][:]
+        singles['sigmasq'] = trigs['sigmasq'][:]
+        singles['snr'] = trigs['snr'][:]
+        try:
+            tnum = trigs.template_num  # exists if accessed via coinc_findtrigs
+        except AttributeError:
+            tnum = trigs['template_id']  # exists for SingleDetTriggers
+            # Should only be one ifo fit file provided
+            assert len(self.ifos) == 1
+        # Store benchmark log volume as single-ifo information since the coinc
+        # method does not have access to template id
+        singles['benchmark_logvol'] = self.benchmark_logvol[tnum]
+        return numpy.array(singles, ndmin=1)
+
+    def rank_stat_single(self, single_info):
+        """
+        Calculate the statistic for single detector candidates
+
+        Parameters
+        ----------
+        single_info: tuple
+            Tuple containing two values. The first is the ifo (str) and the
+            second is the single detector triggers.
+
+        Returns
+        -------
+        numpy.ndarray
+            The array of single detector statistics
+        """
+        sngls = single_info[1]
+
+        ln_noise_rate = sngls['snglstat']
+        ln_noise_rate -= self.benchmark_lograte
+        network_sigmasq = sngls['sigmasq']
+        network_logvol = 1.5 * numpy.log(network_sigmasq)
+        benchmark_logvol = sngls['benchmark_logvol']
+        network_logvol -= benchmark_logvol
+        ln_s = -4 * numpy.log(sngls['snr'] / self.ref_snr)
+        loglr = network_logvol - ln_noise_rate + ln_s
+        # cut off underflowing and very small values
+        loglr[loglr < -30.] = -30.
+        return loglr
+
+    def rank_stat_coinc(self, s, slide, step, to_shift,
+                        **kwargs): # pylint:disable=unused-argument
+        """
+        Calculate the coincident detection statistic.
+
+        Parameters
+        ----------
+        sngls_list: list
+            List of (ifo, single detector statistic) tuples
+        slide: (unused in this statistic)
+        step: (unused in this statistic)
+        to_shift: list
+            List of integers indicating what multiples of the time shift will
+            be applied (unused in this statistic)
+
+        Returns
+        -------
+        numpy.ndarray
+            Array of coincident ranking statistic values
+        """
+
+        sngl_rates = {sngl[0]: sngl[1]['snglstat'] for sngl in s}
+        ln_noise_rate = coinc_rate.combination_noise_lograte(
+                                  sngl_rates, kwargs['time_addition'])
+        ln_noise_rate -= self.benchmark_lograte
+
+        # Network sensitivity for a given coinc type is approximately
+        # determined by the least sensitive ifo
+        network_sigmasq = numpy.amin([sngl[1]['sigmasq'] for sngl in s],
+                                     axis=0)
+        # Volume \propto sigma^3 or sigmasq^1.5
+        network_logvol = 1.5 * numpy.log(network_sigmasq)
+        # Get benchmark log volume as single-ifo information :
+        # benchmark_logvol for a given template is not ifo-dependent, so
+        # choose the first ifo for convenience
+        benchmark_logvol = s[0][1]['benchmark_logvol']
+        network_logvol -= benchmark_logvol
+
+        # Use prior histogram to get Bayes factor for signal vs noise
+        # given the time, phase and SNR differences between IFOs
+
+        # First get signal PDF logr_s
+        stat = {ifo: st for ifo, st in s}
+        logr_s = self.logsignalrate(stat, slide * step, to_shift)
+
+        # Find total volume of phase-time-amplitude space occupied by noise
+        # coincs
+        # Extent of time-difference space occupied
+        noise_twindow = coinc_rate.multiifo_noise_coincident_area(
+                            self.hist_ifos, kwargs['time_addition'])
+        # Volume is the allowed time difference window, multiplied by 2pi for
+        # each phase difference dimension and by allowed range of SNR ratio
+        # for each SNR ratio dimension : there are (n_ifos - 1) dimensions
+        # for both phase and SNR
+        n_ifos = len(self.hist_ifos)
+        hist_vol = noise_twindow * \
+            (2 * numpy.pi * (self.srbmax - self.srbmin) * self.swidth) ** \
+            (n_ifos - 1)
+        # Noise PDF is 1/volume, assuming a uniform distribution of noise
+        # coincs
+        logr_n = - numpy.log(hist_vol)
+
+        # Combine to get final statistic: log of
+        # ((rate of signals / rate of noise) * PTA Bayes factor)
+        loglr = network_logvol - ln_noise_rate + logr_s - logr_n
+
+        # cut off underflowing and very small values
+        loglr[loglr < -30.] = -30.
+        return loglr
+
+    def coinc_lim_for_thresh(self, s, thresh, limifo,
+                             **kwargs): # pylint:disable=unused-argument
+        """
+        Optimization function to identify coincs too quiet to be of interest
+
+        Calculate the required single detector statistic to exceed
+        the threshold for each of the input triggers.
+
+        Parameters
+        ----------
+        s: list
+            List of (ifo, single detector statistic) tuples for all detectors
+            except limifo.
+        thresh: float
+            The threshold on the coincident statistic.
+        limifo: string
+            The ifo for which the limit is to be found.
+
+        Returns
+        -------
+        numpy.ndarray
+            Array of limits on the limifo single statistic to
+            exceed thresh.
+        """
+
+        # Safety against subclassing and not rethinking this
+        allowed_names = ['ExpFitFgBgNormStatistic',
+                         'ExpFitFgBgNormBBHStatistic',
+                         'DQExpFitFgBgNormStatistic']
+        self._check_coinc_lim_subclass(allowed_names)
+
+        if not self.has_hist:
+            self.get_hist()
+        # if the threshold is below this value all triggers will
+        # pass because of rounding in the coinc method
+        if thresh <= -30:
+            return numpy.ones(len(s[0][1]['snglstat'])) * numpy.inf
+        sngl_rates = {sngl[0]: sngl[1]['snglstat'] for sngl in s}
+        # Add limifo to singles dict so that overlap time is calculated correctly
+        sngl_rates[limifo] = numpy.zeros(len(s[0][1]))
+        ln_noise_rate = coinc_rate.combination_noise_lograte(
+                                  sngl_rates, kwargs['time_addition'])
+        ln_noise_rate -= self.benchmark_lograte
+
+        # Assume best case and use the maximum sigma squared from all triggers
+        network_sigmasq = numpy.ones(len(s[0][1])) * kwargs['max_sigmasq']
+        # Volume \propto sigma^3 or sigmasq^1.5
+        network_logvol = 1.5 * numpy.log(network_sigmasq)
+        # Get benchmark log volume as single-ifo information :
+        # benchmark_logvol for a given template is not ifo-dependent, so
+        # choose the first ifo for convenience
+        benchmark_logvol = s[0][1]['benchmark_logvol']
+        network_logvol -= benchmark_logvol
+
+        # Assume best case scenario and use maximum signal rate
+        logr_s = numpy.log(self.hist_max
+                           * (kwargs['min_snr'] / self.ref_snr) ** -4.0)
+
+        # Find total volume of phase-time-amplitude space occupied by noise
+        # coincs
+        # Extent of time-difference space occupied
+        noise_twindow = coinc_rate.multiifo_noise_coincident_area(
+                            self.hist_ifos, kwargs['time_addition'])
+        # Volume is the allowed time difference window, multiplied by 2pi for
+        # each phase difference dimension and by allowed range of SNR ratio
+        # for each SNR ratio dimension : there are (n_ifos - 1) dimensions
+        # for both phase and SNR
+        n_ifos = len(self.hist_ifos)
+        hist_vol = noise_twindow * \
+            (2 * numpy.pi * (self.srbmax - self.srbmin) * self.swidth) ** \
+            (n_ifos - 1)
+        # Noise PDF is 1/volume, assuming a uniform distribution of noise
+        # coincs
+        logr_n = - numpy.log(hist_vol)
+
+        loglr = - thresh + network_logvol - ln_noise_rate + logr_s - logr_n
+        return loglr
+
+
+class ExpFitFgBgNormBBHStatistic(ExpFitFgBgNormStatistic):
+    """
+    The ExpFitFgBgNormStatistic with a mass weighting factor.
+
+    This is the same as the ExpFitFgBgNormStatistic except the likelihood
+    is multiplied by a signal rate prior modelled as uniform over chirp mass.
+    As templates are distributed roughly according to mchirp^(-11/3) we
+    weight by the inverse of this. This ensures that loud events at high mass
+    where template density is sparse are not swamped by events at lower masses
+    where template density is high.
+    """
+
+    def __init__(self, sngl_ranking, files=None, ifos=None,
+                 max_chirp_mass=None, **kwargs):
+        """
+        Create a statistic class instance
+
+        Parameters
+        ----------
+        sngl_ranking: str
+            The name of the ranking to use for the single-detector triggers.
+        files: list of strs, needed here
+            A list containing the filenames of hdf format files used to help
+            construct the coincident statistics. The files must have a 'stat'
+            attribute which is used to associate them with the appropriate
+            statistic class.
+        ifos: list of strs, not used here
+            The list of detector names
+        max_chirp_mass: float, default=None
+            If given, if a template's chirp mass is above this value it will
+            be reweighted as if it had this chirp mass. This is to avoid the
+            problem where the distribution fails to be accurate at high mass
+            and we can have a case where a single highest-mass template might
+            produce *all* the loudest background (and foreground) events.
+        """
+        ExpFitFgBgNormStatistic.__init__(self, sngl_ranking, files=files,
+                                         ifos=ifos, **kwargs)
+        self.mcm = max_chirp_mass
+        self.curr_mchirp = None
+
+    def logsignalrate(self, stats, shift, to_shift):
+        """
+        Calculate the normalized log rate density of signals via lookup
+
+        This calls back to the Parent class and then applies the chirp mass
+        weighting factor.
+
+        Parameters
+        ----------
+        stats: list of dicts giving single-ifo quantities, ordered as
+            self.ifos
+        shift: numpy array of float, size of the time shift vector for each
+            coinc to be ranked
+        to_shift: list of int, multiple of the time shift to apply ordered
+            as self.ifos
+
+        Returns
+        -------
+        value: log of coinc signal rate density for the given single-ifo
+            triggers and time shifts
+        """
+
+        # model signal rate as uniform over chirp mass, background rate is
+        # proportional to mchirp^(-11/3) due to density of templates
+        logr_s = ExpFitFgBgNormStatistic.logsignalrate(
+                    self,
+                    stats,
+                    shift,
+                    to_shift
+                    )
+        logr_s += numpy.log((self.curr_mchirp / 20.0) ** (11./3.0))
+        return logr_s
+
+    def single(self, trigs):
+        """
+        Calculate the necessary single detector information
+
+        In this case the ranking rescaled (see the lognoiserate method here)
+        with the phase, end time, sigma, SNR, template_id and the
+        benchmark_logvol values added in. This also stored the current chirp
+        mass for use when computing the coinc statistic values.
+
+        Parameters
+        ----------
+        trigs: dict of numpy.ndarrays, h5py group (or similar dict-like object)
+            Dictionary-like object holding single detector trigger information.
+
+        Returns
+        -------
+        numpy.ndarray
+            The array of single detector values
+        """
+        from pycbc.conversions import mchirp_from_mass1_mass2
+        self.curr_mchirp = mchirp_from_mass1_mass2(trigs.param['mass1'],
+                                                   trigs.param['mass2'])
+        if self.mcm is not None:
+            # Careful - input might be a str, so cast to float
+            self.curr_mchirp = min(self.curr_mchirp, float(self.mcm))
+        return ExpFitFgBgNormStatistic.single(self, trigs)
+
+    def coinc_lim_for_thresh(self, s, thresh, limifo,
+                             **kwargs): # pylint:disable=unused-argument
+        """
+        Optimization function to identify coincs too quiet to be of interest
+
+        Calculate the required single detector statistic to exceed
+        the threshold for each of the input triggers.
+
+        Parameters
+        ----------
+        s: list
+            List of (ifo, single detector statistic) tuples for all detectors
+            except limifo.
+        thresh: float
+            The threshold on the coincident statistic.
+        limifo: string
+            The ifo for which the limit is to be found.
+
+        Returns
+        -------
+        numpy.ndarray
+            Array of limits on the limifo single statistic to
+            exceed thresh.
+        """
+
+        loglr = ExpFitFgBgNormStatistic.coinc_lim_for_thresh(
+                    self, s, thresh, limifo, **kwargs)
+        loglr += numpy.log((self.curr_mchirp / 20.0) ** (11./3.0))
+        return loglr
+
+
+class DQExpFitFgBgNormStatistic(ExpFitFgBgNormStatistic):
+    """
+    The ExpFitFgBgNormStatistic with DQ-based reranking.
+
+    This is the same as the ExpFitFgBgNormStatistic except the likelihood
+    is multiplied by the relative signal rate based on the relevant
+    DQ likelihood value.
+    """
+
+    def __init__(self, sngl_ranking, files=None, ifos=None,
+                 **kwargs):
+        """
+        Create a statistic class instance
+
+        Parameters
+        ----------
+        sngl_ranking: str
+            The name of the ranking to use for the single-detector triggers.
+        files: list of strs, needed here
+            A list containing the filenames of hdf format files used to help
+            construct the coincident statistics. The files must have a 'stat'
+            attribute which is used to associate them with the appropriate
+            statistic class.
+        ifos: list of strs, not used here
+            The list of detector names
+        """
+        ExpFitFgBgNormStatistic.__init__(self, sngl_ranking, files=files,
+                                         ifos=ifos, **kwargs)
+        self.dq_val_by_time = {}
+        self.dq_bin_by_id = {}
+        for k in self.files.keys():
+            parsed_attrs = k.split('-')
+            if len(parsed_attrs) < 3:
+                continue
+            if parsed_attrs[2] == 'dq_ts_reference':
+                ifo = parsed_attrs[0]
+                dq_type = parsed_attrs[1]
+                dq_vals = self.assign_dq_val(k)
+                dq_bins = self.assign_bin_id(k)
+                if ifo not in self.dq_val_by_time:
+                    self.dq_val_by_time[ifo] = {}
+                    self.dq_bin_by_id[ifo] = {}
+                self.dq_val_by_time[ifo][dq_type] = dq_vals
+                self.dq_bin_by_id[ifo][dq_type] = dq_bins
+
+    def assign_bin_id(self, key):
+        """
+        Assign bin ID values
+        Assign each template id to a bin name based on a
+        referenced statistic file.
+
+        Parameters
+        ----------
+        key: str
+            statistic file key string
+
+        Returns
+        ---------
+        bin_dict: dict of strs
+            Dictionary containing the bin name for each template id
+        """
+        ifo = key.split('-')[0]
+        dq_file = self.files[key]
+        bin_names = dq_file.attrs['names'][:]
+        locs = []
+        names = []
+        for bin_name in bin_names:
+            bin_locs = dq_file[ifo + '/locs/' + bin_name][:]
+            locs = list(locs)+list(bin_locs.astype(int))
+            names = list(names)+list([bin_name]*len(bin_locs))
+        bin_dict = dict(zip(locs, names))
+        return bin_dict
+
+    def assign_dq_val(self, key):
+        """
+        Assign dq values to each time for every bin based on a
+        referenced statistic file.
+
+        Parameters
+        ----------
+        key: str
+            statistic file key string
+
+        Returns
+        ---------
+        dq_dict: dict of {time: dq_value} dicts for each bin
+            Dictionary containing the mapping between the time
+            and the dq value for each individual bin.
+
+        """
+        ifo = key.split('-')[0]
+        dq_file = self.files[key]
+        times = dq_file[ifo+'/times'][:]
+        bin_names = dq_file.attrs['names'][:]
+        dq_dict = {}
+        for bin_name in bin_names:
+            dq_vals = dq_file[ifo+'/dq_vals/'+bin_name][:]
+            dq_dict[bin_name] = dict(zip(times, dq_vals))
+        return dq_dict
+
+    def find_dq_val(self, trigs):
+        """Get dq values for a specific ifo and times"""
+        time = trigs['end_time'].astype(int)
+        try:
+            tnum = trigs.template_num
+            ifo = trigs.ifo
+        except AttributeError:
+            tnum = trigs['template_id']
+            assert len(self.ifos) == 1
+            # Should be exactly one ifo provided
+            ifo = self.ifos[0]
+        dq_val = numpy.zeros(len(time))
+        if ifo in self.dq_val_by_time:
+            for (i, t) in enumerate(time):
+                for k in self.dq_val_by_time[ifo].keys():
+                    if isinstance(tnum, numpy.ndarray):
+                        bin_name = self.dq_bin_by_id[ifo][k][tnum[i]]
+                    else:
+                        bin_name = self.dq_bin_by_id[ifo][k][tnum]
+                    val = self.dq_val_by_time[ifo][k][bin_name][int(t)]
+                    dq_val[i] = max(dq_val[i], val)
+        return dq_val
+
+    def lognoiserate(self, trigs):
+        """
+        Calculate the log noise rate density over single-ifo ranking
+
+        Read in single trigger information, compute the ranking
+        and rescale by the fitted coefficients alpha and rate
+
+        Parameters
+        -----------
+        trigs: dict of numpy.ndarrays, h5py group (or similar dict-like object)
+            Dictionary-like object holding single detector trigger information.
+
+        Returns
+        ---------
+        lognoisel: numpy.array
+            Array of log noise rate density for each input trigger.
+        """
+        logr_n = ExpFitFgBgNormStatistic.lognoiserate(
+                    self, trigs)
+        logr_n += self.find_dq_val(trigs)
+        return logr_n
+
+
+statistic_dict = {
+    'quadsum': QuadratureSumStatistic,
+    'single_ranking_only': QuadratureSumStatistic,
+    'phasetd': PhaseTDStatistic,
+    'exp_fit_stat': ExpFitStatistic,
+    'exp_fit_csnr': ExpFitCombinedSNR,
+    'phasetd_exp_fit_stat': PhaseTDExpFitStatistic,
+    'dq_phasetd_exp_fit_fgbg_norm': DQExpFitFgBgNormStatistic,
+    'exp_fit_bg_rate': ExpFitBgRateStatistic,
+    'phasetd_exp_fit_fgbg_norm': ExpFitFgBgNormStatistic,
+    'phasetd_exp_fit_fgbg_bbh_norm': ExpFitFgBgNormBBHStatistic,
+}
+
+
+def get_statistic(stat):
+    """
+    Error-handling sugar around dict lookup for coincident statistics
+
+    Parameters
+    ----------
+    stat : string
+        Name of the coincident statistic
+
+    Returns
+    -------
+    class
+        Subclass of Stat base class
+
+    Raises
+    ------
+    RuntimeError
+        If the string is not recognized as corresponding to a Stat subclass
+    """
+    try:
+        return statistic_dict[stat]
+    except KeyError:
+        raise RuntimeError('%s is not an available detection statistic' % stat)
+
+
+def insert_statistic_option_group(parser, default_ranking_statistic=None):
+    """
+    Add ranking statistic options to the optparser object.
+
+    Adds the options used to initialize a PyCBC Stat class.
+
+    Parameters
+    -----------
+    parser : object
+        OptionParser instance.
+    default_ranking_statisic : str
+        Allows setting a default statistic for the '--ranking-statistic'
+        option. The option is no longer required if a default is provided.
+
+    Returns
+    --------
+    strain_opt_group : optparser.argument_group
+        The argument group that is added to the parser.
+    """
+
+    statistic_opt_group = parser.add_argument_group(
+        "Options needed to initialize a PyCBC Stat class for computing the "
+        "ranking of events from a PyCBC search."
+    )
+
+    statistic_opt_group.add_argument(
+        "--ranking-statistic",
+        default=default_ranking_statistic,
+        choices=statistic_dict.keys(),
+        required=True if default_ranking_statistic is None else False,
+        help="The coinc ranking statistic to calculate"
+    )
+
+    statistic_opt_group.add_argument(
+        "--sngl-ranking",
+        choices=ranking.sngls_ranking_function_dict.keys(),
+        required=True,
+        help="The single-detector trigger ranking to use."
+    )
+
+    statistic_opt_group.add_argument(
+        "--statistic-files",
+        nargs='*',
+        action='append',
+        default=[],
+        help="Files containing ranking statistic info"
+    )
+
+    statistic_opt_group.add_argument(
+        "--statistic-keywords",
+        nargs='*',
+        default=[],
+        help="Provide additional key-word arguments to be sent to "
+             "the statistic class when it is initialized. Should "
+             "be given in format --statistic-keywords "
+             "KWARG1:VALUE1 KWARG2:VALUE2 KWARG3:VALUE3 ..."
+    )
+
+    return statistic_opt_group
+
+
+def parse_statistic_keywords_opt(stat_kwarg_list):
+    """
+    Parse the list of statistic keywords into an appropriate dictionary.
+
+    Take input from the input argument ["KWARG1:VALUE1", "KWARG2:VALUE2",
+    "KWARG3:VALUE3"] and convert into a dictionary.
+
+    Parameters
+    ----------
+    stat_kwarg_list : list
+        Statistic keywords in list format
+
+    Returns
+    -------
+    stat_kwarg_dict : dict
+        Statistic keywords in dict format
+    """
+    stat_kwarg_dict = {}
+    for inputstr in stat_kwarg_list:
+        try:
+            key, value = inputstr.split(':')
+            stat_kwarg_dict[key] = value
+        except ValueError:
+            err_txt = "--statistic-keywords must take input in the " \
+                      "form KWARG1:VALUE1 KWARG2:VALUE2 KWARG3:VALUE3 ... " \
+                      "Received {}".format(' '.join(stat_kwarg_list))
+            raise ValueError(err_txt)
+
+    return stat_kwarg_dict
+
+
+def get_statistic_from_opts(opts, ifos):
+    """
+    Return a Stat class from an optparser object.
+
+    This will assume that the options in the statistic_opt_group are present
+    and will use these options to call stat.get_statistic and initialize the
+    appropriate Stat subclass with appropriate kwargs.
+
+    Parameters
+    ----------
+    opts : optparse.OptParser instance
+        The command line options
+    ifos : list
+        The list of detector names
+
+    Returns
+    -------
+    class
+        Subclass of Stat base class
+    """
+    # Allow None inputs
+    if opts.statistic_files is None:
+        opts.statistic_files = []
+    if opts.statistic_keywords is None:
+        opts.statistic_keywords = []
+
+    # flatten the list of lists of filenames to a single list (may be empty)
+    opts.statistic_files = sum(opts.statistic_files, [])
+
+    extra_kwargs = parse_statistic_keywords_opt(opts.statistic_keywords)
+
+    stat_class = get_statistic(opts.ranking_statistic)(
+        opts.sngl_ranking,
+        opts.statistic_files,
+        ifos=ifos,
+        **extra_kwargs
+    )
+
+    return stat_class

--- a/test/validation_code/old_stat.py
+++ b/test/validation_code/old_stat.py
@@ -14,6 +14,12 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
+#### NOTE #####
+# This code is a verbatim copy of the stat.py code as of 20th August 2022.
+# It's here to verify that any changes being made to this code are not changing
+# the physical output
+###############
+
 #
 # =============================================================================
 #


### PR DESCRIPTION
We are having difficulties in getting `pycbc_live` to keep up with data in real-time in its current configuration. There may be a few patches from me aimed at this (even if in some cases, we're only speeding up by 1/2%).

It does seem that the main process is becoming a problem in `pycbc_live`'s inability to keep up. One place that was non-negligible in a profile I ran was the RingBuffer used to store singles.

This does look like it is quite inefficient as the buffers are *replaced* (or resized if that is possible??) every time triggers are added (using numpy append). By using more memory, and tracking the slice of the buffer that is relevant, it is possible to greatly reduce the times we resize the buffer arrays.

At the moment this is causing failures, so I need to fix that, but @ahnitz do you have any thoughts about this change?