### PR TITLE
Speed up psd computation for PyCBC Live

### DIFF
--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -628,7 +628,7 @@ parser.add_argument('--psd-inverse-length', type=float,
                     help="Length in time for the equivalent FIR filter")
 parser.add_argument('--psd-recompute-length', type=positive_int, default=1,
                     help="If given only recompute the PSD after this number of "
-                         "data blocks. Data block length is set by the option "
+                         "analysis chunks, whose length is set by the option "
                          "--analysis-chunk.")
 parser.add_argument('--trim-padding', type=float, default=0.25,
                     help="Padding around the overwhitened analysis block")

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -37,9 +37,12 @@ from pycbc.population import live_pastro_utils as livepau
 from pycbc import mchirp_area
 from pycbc.detector import ppdets
 from pycbc.filter import resample
+from pycbc.psd import estimate
 
-# Set this to use cached class-based FFTs in the resample module
+# Use cached class-based FFTs in the resample and estimate module
 resample.USE_CACHING_FOR_LFILTER = True
+estimate.USE_CACHING_FOR_WELCH_FFTS = True
+estimate.USE_CACHING_FOR_INV_SPEC_TRUNC = True
 
 try:
     from setproctitle import setproctitle

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -30,6 +30,7 @@ from pycbc.events.coinc import LiveCoincTimeslideBackgroundEstimator as Coincer
 from pycbc.events.single import LiveSingle
 from pycbc.io.live import SingleCoincForGraceDB
 from pycbc.io.hdf import recursively_save_dict_contents_to_group
+from pycbc.types import positive_int
 import pycbc.waveform.bank
 from pycbc.vetoes.sgchisq import SingleDetSGChisq
 from pycbc.waveform.waveform import props
@@ -625,7 +626,7 @@ parser.add_argument('--psd-segment-length', type=int, required=True,
                     help="Length in seconds of each PSD segment")
 parser.add_argument('--psd-inverse-length', type=float,
                     help="Length in time for the equivalent FIR filter")
-parser.add_argument('--psd-recompute-length', type=int, default=1,
+parser.add_argument('--psd-recompute-length', type=positive_int, default=1,
                     help="If given only recompute the PSD after this number of "
                          "data blocks. Data block length is set by the option "
                          "--analysis-chunk.")

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -930,7 +930,7 @@ with ctx:
             )
             if status and psd_count[ifo] == 0:
                 status = data_reader[ifo].recalculate_psd()
-                psd_count[ifo] = opts.psd_recompute_length - 1
+                psd_count[ifo] = args.psd_recompute_length - 1
             elif not status:
                 psd_count[ifo] = 0
             else:

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -622,6 +622,10 @@ parser.add_argument('--psd-segment-length', type=int, required=True,
                     help="Length in seconds of each PSD segment")
 parser.add_argument('--psd-inverse-length', type=float,
                     help="Length in time for the equivalent FIR filter")
+parser.add_argument('--psd-recompute-length', type=int, default=1,
+                    help="If given only recompute the PSD after this number of "
+                         "data blocks. Data block length is set by the option "
+                         "--analysis-chunk.")
 parser.add_argument('--trim-padding', type=float, default=0.25,
                     help="Padding around the overwhitened analysis block")
 parser.add_argument("--enable-bank-start-frequency", action='store_true',
@@ -909,6 +913,8 @@ with ctx:
     # main analysis loop
     data_end = lambda: data_reader[tuple(data_reader.keys())[0]].end_time
     last_bg_dump_time = int(data_end())
+    psd_count = {ifo:0 for ifo in ifos}
+
     while data_end() < args.end_time:
         t1 = pycbc.gps_now()
         logging.info('Analyzing from %s', data_end())
@@ -918,10 +924,17 @@ with ctx:
 
         for ifo in ifos:
             results[ifo] = False
-            status = data_reader[ifo].advance(valid_pad, timeout=args.frame_read_timeout)
-
-            if status is True:
+            status = data_reader[ifo].advance(
+                valid_pad,
+                timeout=args.frame_read_timeout
+            )
+            if status and psd_count[ifo] == 0:
                 status = data_reader[ifo].recalculate_psd()
+                psd_count[ifo] = opts.psd_recompute_length - 1
+            elif not status:
+                psd_count[ifo] = 0
+            else:
+                psd_count[ifo] -= 1
 
             if data_reader[ifo].psd is not None:
                 dist = data_reader[ifo].psd.dist

--- a/pycbc/psd/estimate.py
+++ b/pycbc/psd/estimate.py
@@ -256,7 +256,7 @@ def inverse_spectrum_truncation(psd, max_filter_len, low_frequency_cutoff=None, 
             dtype=real_same_precision_as(psd))
         ifft(inv_asd, q)
     else:
-        q = execute_cached_fft(inv_asd, copy_output=False,
+        q = execute_cached_ifft(inv_asd, copy_output=False,
                                uid=INVSPECTRUNC_UNIQUE_ID)
 
     trunc_start = max_filter_len // 2
@@ -279,7 +279,7 @@ def inverse_spectrum_truncation(psd, max_filter_len, low_frequency_cutoff=None, 
         )
         fft(q, psd_trunc)
     else:
-        psd_trunc = execute_cached_ifft(q, copy_output=False,
+        psd_trunc = execute_cached_fft(q, copy_output=False,
                                         uid=INVSPECTRUNC_UNIQUE_ID)
     psd_trunc *= psd_trunc.conj()
     psd_out = 1. / abs(psd_trunc)

--- a/pycbc/psd/estimate.py
+++ b/pycbc/psd/estimate.py
@@ -252,8 +252,11 @@ def inverse_spectrum_truncation(psd, max_filter_len, low_frequency_cutoff=None, 
 
     inv_asd[kmin:N//2] = (1.0 / psd[kmin:N//2]) ** 0.5
     if not USE_CACHING_FOR_INV_SPEC_TRUNC:
-        q = TimeSeries(numpy.zeros(N), delta_t=(N / psd.delta_f), \
-            dtype=real_same_precision_as(psd))
+        q = TimeSeries(
+            numpy.zeros(N),
+            delta_t=(N / psd.delta_f),
+            dtype=real_same_precision_as(psd)
+        )
         ifft(inv_asd, q)
     else:
         q = execute_cached_ifft(inv_asd, copy_output=False,

--- a/pycbc/psd/estimate.py
+++ b/pycbc/psd/estimate.py
@@ -256,7 +256,8 @@ def inverse_spectrum_truncation(psd, max_filter_len, low_frequency_cutoff=None, 
             dtype=real_same_precision_as(psd))
         ifft(inv_asd, q)
     else:
-        q = execute_cached_fft(inv_asd, uid=INVSPECTRUNC_UNIQUE_ID)
+        q = execute_cached_fft(inv_asd, copy_output=False,
+                               uid=INVSPECTRUNC_UNIQUE_ID)
 
     trunc_start = max_filter_len // 2
     trunc_end = N - max_filter_len // 2
@@ -278,7 +279,8 @@ def inverse_spectrum_truncation(psd, max_filter_len, low_frequency_cutoff=None, 
         )
         fft(q, psd_trunc)
     else:
-        psd_trunc = execute_cached_ifft(q, uid=INVSPECTRUNC_UNIQUE_ID)
+        psd_trunc = execute_cached_ifft(q, copy_output=False,
+                                        uid=INVSPECTRUNC_UNIQUE_ID)
     psd_trunc *= psd_trunc.conj()
     psd_out = 1. / abs(psd_trunc)
 

--- a/pycbc/psd/estimate.py
+++ b/pycbc/psd/estimate.py
@@ -29,8 +29,8 @@ USE_CACHING_FOR_INV_SPEC_TRUNC = False
 # If using caching we want output to be unique if called at different places
 # (and if called from different modules/functions), these unique IDs acheive
 # that. The numbers are not significant, only that they are unique.
-WELCH_UNIQUE_ID=438716587
-INVSPECTRUNC_UNIQUE_ID=100257896
+WELCH_UNIQUE_ID = 438716587
+INVSPECTRUNC_UNIQUE_ID = 100257896
 
 def median_bias(n):
     """Calculate the bias of the median average PSD computed from `n` segments.
@@ -257,7 +257,7 @@ def inverse_spectrum_truncation(psd, max_filter_len, low_frequency_cutoff=None, 
         ifft(inv_asd, q)
     else:
         q = execute_cached_ifft(inv_asd, copy_output=False,
-                               uid=INVSPECTRUNC_UNIQUE_ID)
+                                uid=INVSPECTRUNC_UNIQUE_ID)
 
     trunc_start = max_filter_len // 2
     trunc_end = N - max_filter_len // 2
@@ -280,7 +280,7 @@ def inverse_spectrum_truncation(psd, max_filter_len, low_frequency_cutoff=None, 
         fft(q, psd_trunc)
     else:
         psd_trunc = execute_cached_fft(q, copy_output=False,
-                                        uid=INVSPECTRUNC_UNIQUE_ID)
+                                       uid=INVSPECTRUNC_UNIQUE_ID)
     psd_trunc *= psd_trunc.conj()
     psd_out = 1. / abs(psd_trunc)
 

--- a/pycbc/types/optparse.py
+++ b/pycbc/types/optparse.py
@@ -350,20 +350,45 @@ def convert_to_process_params_dict(opt):
             setattr(opt, arg, new_val)
     return vars(opt)
 
+def _positive_type(s, dtype=None):
+    """
+    Ensure argument is positive and convert type to dtype
+
+    This is for the functions below to wrap to avoid code duplication.
+    """
+    assert(dtype is not None)
+    err_msg = f"Input must be a positive {dtype}, not {s}"
+    try:
+        value = dtype(s)
+    except ValueError:
+        raise argparse.ArgumentTypeError(err_msg)
+    if value <= 0:
+        raise argparse.ArgumentTypeError(err_msg)
+    return value
+
+def _nonnegative_type(s, dtype=None):
+    """
+    Ensure argument is positive or zero and convert type to dtype
+
+    This is for the functions below to wrap to avoid code duplication.
+    """
+    assert(dtype is not None)
+    err_msg = f"Input must be either a positive or zero {dtype}, not {s}"
+    try:
+        value = dtype(s)
+    except ValueError:
+        raise argparse.ArgumentTypeError(err_msg)
+    if value < 0:
+        raise argparse.ArgumentTypeError(err_msg)
+    return value
+
 def positive_float(s):
     """
     Ensure argument is a positive real number and return it as float.
 
     To be used as type in argparse arguments.
     """
-    err_msg = "must be a positive number, not %r" % s
-    try:
-        value = float(s)
-    except ValueError:
-        raise argparse.ArgumentTypeError(err_msg)
-    if value <= 0:
-        raise argparse.ArgumentTypeError(err_msg)
-    return value
+    _positive_type(s, dtype=float)
 
 def nonnegative_float(s):
     """
@@ -371,11 +396,22 @@ def nonnegative_float(s):
 
     To be used as type in argparse arguments.
     """
-    err_msg = "must be either positive or zero, not %r" % s
-    try:
-        value = float(s)
-    except ValueError:
-        raise argparse.ArgumentTypeError(err_msg)
-    if value < 0:
-        raise argparse.ArgumentTypeError(err_msg)
-    return value
+    _nonnegative_type(s, dtype=float)
+
+def positive_int(s):
+    """
+    Ensure argument is a positive integer and return it as int.
+
+    To be used as type in argparse arguments.
+    """
+    _positive_type(s, dtype=int)
+
+def nonnegative_float(s):
+    """
+    Ensure argument is a positive integer or zero and return it as int.
+
+    To be used as type in argparse arguments.
+    """
+    _nonnegative_type(s, dtype=int)
+
+    

--- a/pycbc/types/optparse.py
+++ b/pycbc/types/optparse.py
@@ -356,7 +356,7 @@ def _positive_type(s, dtype=None):
 
     This is for the functions below to wrap to avoid code duplication.
     """
-    assert(dtype is not None)
+    assert dtype is not None
     err_msg = f"Input must be a positive {dtype}, not {s}"
     try:
         value = dtype(s)
@@ -372,7 +372,7 @@ def _nonnegative_type(s, dtype=None):
 
     This is for the functions below to wrap to avoid code duplication.
     """
-    assert(dtype is not None)
+    assert dtype is not None
     err_msg = f"Input must be either a positive or zero {dtype}, not {s}"
     try:
         value = dtype(s)
@@ -388,7 +388,7 @@ def positive_float(s):
 
     To be used as type in argparse arguments.
     """
-    _positive_type(s, dtype=float)
+    return _positive_type(s, dtype=float)
 
 def nonnegative_float(s):
     """
@@ -396,7 +396,7 @@ def nonnegative_float(s):
 
     To be used as type in argparse arguments.
     """
-    _nonnegative_type(s, dtype=float)
+    return _nonnegative_type(s, dtype=float)
 
 def positive_int(s):
     """
@@ -404,14 +404,13 @@ def positive_int(s):
 
     To be used as type in argparse arguments.
     """
-    _positive_type(s, dtype=int)
+    return _positive_type(s, dtype=int)
 
-def nonnegative_float(s):
+def nonnegative_int(s):
     """
     Ensure argument is a positive integer or zero and return it as int.
 
     To be used as type in argparse arguments.
     """
-    _nonnegative_type(s, dtype=int)
+    return _nonnegative_type(s, dtype=int)
 
-    

--- a/pycbc/types/optparse.py
+++ b/pycbc/types/optparse.py
@@ -413,4 +413,3 @@ def nonnegative_int(s):
     To be used as type in argparse arguments.
     """
     return _nonnegative_type(s, dtype=int)
-


### PR DESCRIPTION
One more patch to try to help with `pycbc_live` performance:

This one moves the FFTs in PSD estimation (done during inverse spectrum truncation), to the new `cached_fft` functions.

I also add an option to allow the PSD not to be recomputed every data block. For the early warning analysis, with 1 second blocks, this is especially relevant. I have set this such that if the data is "bad" the PSD must be recomputed as soon as it is "good" again. (It's still not entirely clear to me what data is used for PSD estimation, and if we should continue computing PSDs until we have X data blocks in the buffer, and then only recompute every Y data blocks).