### PR TITLE
Don't do work if no triggers

### DIFF
--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -636,6 +636,8 @@ class PhaseTDStatistic(QuadratureSumStatistic):
         [Nitz et al, 2017](https://doi.org/10.3847/1538-4357/aa8f50).
         """
         rstat = sum(s[1]['snglstat'] ** 2 for s in sngls_list)
+        if len(rstat) == 0:
+            return numpy.zeros(0, dtype=numpy.float32)
         cstat = rstat + 2. * self.logsignalrate(dict(sngls_list),
                                                 slide * step,
                                                 to_shift)


### PR DESCRIPTION
I have noticed that `pycbc_live` makes many calls to the expensive `logsignalrate` function with no triggers (or at least it does in the first minutes). These calls at least can be made much quicker by bypassing them early on.

.... Not really sure this will help much once `pycbc_live` has a full buffer of background triggers, but I don't see any reason not to merge this, while I figure out how to meaningfully profile with a full buffer without having to wait 10s of hours (and hope that we are always analysing 3 detectors of mock data).