### PR TITLE
Single events to require both upload options

### DIFF
--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -488,6 +488,7 @@ class LiveEventManager(object):
                 )
 
             if args.enable_single_detector_upload \
+                    and self.enable_gracedb_upload \
                     and self.ifar_upload_threshold < ifar \
                     and not any(nearby_coincs):
                 gid = event.upload(fname, gracedb_server=args.gracedb_server,


### PR DESCRIPTION
@spxiwh found an issue where single-detector events were attempted to upload to gracedb even when `--enable-gracedb-upload` was not in place, this is as `--enable-single-detector-upload` was still enabled.

This patch means both are required, for extra safety