### PR TITLE
Reorganize APIs related to GraceDB uploads

### DIFF
--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -28,7 +28,7 @@ from pycbc.strain import StrainBuffer
 from pycbc.events.ranking import newsnr
 from pycbc.events.coinc import LiveCoincTimeslideBackgroundEstimator as Coincer
 from pycbc.events.single import LiveSingle
-from pycbc.io.live import SingleCoincForGraceDB
+from pycbc.io.live import CandidateForGraceDB
 from pycbc.io.hdf import recursively_save_dict_contents_to_group
 import pycbc.waveform.bank
 from pycbc.vetoes.sgchisq import SingleDetSGChisq
@@ -378,7 +378,7 @@ class LiveEventManager(object):
 
         live_ifos = [ifo for ifo in fud if 'snr_series' in fud[ifo]]
 
-        event = SingleCoincForGraceDB(
+        event = CandidateForGraceDB(
             live_ifos,
             coinc_results,
             padata=self.padata,
@@ -456,13 +456,17 @@ class LiveEventManager(object):
 
             live_ifos = [i for i in fud if 'snr_series' in fud[i]]
 
-            event = SingleCoincForGraceDB(live_ifos, single,
-                                          padata=self.padata, bank=bank,
-                                          psds=psds, followup_data=fud,
-                                          low_frequency_cutoff=f_low,
-                                          channel_names=args.channel_name,
-                                          mc_area_args=self.mc_area_args,
-                                          )
+            event = CandidateForGraceDB(
+                live_ifos,
+                single,
+                padata=self.padata,
+                bank=bank,
+                psds=psds,
+                followup_data=fud,
+                low_frequency_cutoff=f_low,
+                channel_names=args.channel_name,
+                mc_area_args=self.mc_area_args,
+            )
 
             fname = 'single-{}-{}-{}.xml.gz'.format(ifo, event.merger_time,
                                                     pycbc.random_string(6))

--- a/bin/pycbc_make_skymap
+++ b/bin/pycbc_make_skymap
@@ -301,7 +301,7 @@ def main(trig_time, mass1, mass2, spin1z, spin2z, f_low, f_upper, sample_rate,
         coinc_results[key + 'f_lower'] = f_low
         if f_upper:
             coinc_results[key + 'f_final'] = f_upper
-        # required by SingleCoincForGraceDB
+        # required by CandidateForGraceDB
         coinc_results[key + 'template_id'] = -1
         coinc_results[key + 'snr_series'] = snr_series
         coinc_results[key + 'psd_series'] = psd_series
@@ -391,7 +391,7 @@ def main(trig_time, mass1, mass2, spin1z, spin2z, f_low, f_upper, sample_rate,
               'followup_data': followup_data,
               'channel_names': channel_names}
 
-    doc = live.SingleCoincForGraceDB(ifos, coinc_results, **kwargs)
+    doc = live.CandidateForGraceDB(ifos, coinc_results, **kwargs)
 
     ligolw_file_path = os.path.join(tmpdir, file_name_tag + '.xml')
 

--- a/bin/pycbc_optimize_snr
+++ b/bin/pycbc_optimize_snr
@@ -482,8 +482,12 @@ kwargs = {'psds': {ifo: followup_data[ifo]['psd'] for ifo in ifos},
           'channel_names': channel_names,
           'mc_area_args': mc_area_args}
 
-doc = live.SingleCoincForGraceDB(ifos, coinc_results,
-                                 upload_snr_series=True, **kwargs)
+doc = live.CandidateForGraceDB(
+    ifos,
+    coinc_results,
+    upload_snr_series=True,
+    **kwargs
+)
 
 if args.enable_gracedb_upload:
     comment = ('Automatic PyCBC followup of trigger '

--- a/pycbc/io/ligolw.py
+++ b/pycbc/io/ligolw.py
@@ -24,6 +24,8 @@ from ligo.lw.lsctables import TableByName
 from ligo.lw.table import Column, TableStream
 from ligo.lw.types import FormatFunc, FromPyType, ToPyType
 from ligo.lw.utils import process as ligolw_process
+from ligo.lw.param import Param as LIGOLWParam
+from ligo.lw.array import Array as LIGOLWArray
 import pycbc.version as pycbc_version
 
 
@@ -234,6 +236,77 @@ def legacy_row_id_converter(ContentHandler):
     ContentHandler.startStream = startStream
 
     return ContentHandler
+
+def _build_series(series, dim_names, comment, delta_name, delta_unit):
+    Attributes = ligolw.sax.xmlreader.AttributesImpl
+    elem = ligolw.LIGO_LW(
+            Attributes({'Name': str(series.__class__.__name__)}))
+    if comment is not None:
+        elem.appendChild(ligolw.Comment()).pcdata = comment
+    elem.appendChild(ligolw.Time.from_gps(series.epoch, 'epoch'))
+    elem.appendChild(LIGOLWParam.from_pyvalue('f0', series.f0, unit='s^-1'))
+    delta = getattr(series, delta_name)
+    if numpy.iscomplexobj(series.data.data):
+        data = numpy.row_stack((
+            numpy.arange(len(series.data.data)) * delta,
+            series.data.data.real,
+            series.data.data.imag
+        ))
+    else:
+        data = numpy.row_stack((
+            numpy.arange(len(series.data.data)) * delta,
+            series.data.data
+        ))
+    a = LIGOLWArray.build(series.name, data, dim_names=dim_names)
+    a.Unit = str(series.sampleUnits)
+    dim0 = a.getElementsByTagName(ligolw.Dim.tagName)[0]
+    dim0.Unit = delta_unit
+    dim0.Start = series.f0
+    dim0.Scale = delta
+    elem.appendChild(a)
+    return elem
+
+def make_psd_xmldoc(psddict, xmldoc=None):
+    """Add a set of PSDs to a LIGOLW XML document. If the document is not
+    given, a new one is created first.
+    """
+    xmldoc = ligolw.Document() if xmldoc is None else xmldoc.childNodes[0]
+
+    # the PSDs must be children of a LIGO_LW with name "psd"
+    root_name = 'psd'
+    Attributes = ligolw.sax.xmlreader.AttributesImpl
+    lw = xmldoc.appendChild(
+        ligolw.LIGO_LW(Attributes({'Name': root_name})))
+
+    for instrument, psd in psddict.items():
+        xmlseries = _build_series(
+            psd,
+            ('Frequency,Real', 'Frequency'),
+            None,
+            'deltaF',
+            's^-1'
+        )
+        fs = lw.appendChild(xmlseries)
+        fs.appendChild(LIGOLWParam.from_pyvalue('instrument', instrument))
+    return xmldoc
+
+def snr_series_to_xml(snr_series, document, sngl_inspiral_id):
+    """Save an SNR time series into an XML document, in a format compatible
+    with BAYESTAR.
+    """
+    snr_lal = snr_series.lal()
+    snr_lal.name = 'snr'
+    snr_lal.sampleUnits = ''
+    snr_xml = _build_series(
+        snr_lal,
+        ('Time', 'Time,Real,Imaginary'),
+        None,
+        'deltaT',
+        's'
+    )
+    snr_node = document.childNodes[-1].appendChild(snr_xml)
+    eid_param = LIGOLWParam.from_pyvalue('event_id', sngl_inspiral_id)
+    snr_node.appendChild(eid_param)
 
 
 @legacy_row_id_converter

--- a/pycbc/io/ligolw.py
+++ b/pycbc/io/ligolw.py
@@ -17,7 +17,9 @@
 
 import os
 import sys
+import numpy
 from ligo.lw import lsctables
+from ligo.lw import ligolw
 from ligo.lw.ligolw import Param, LIGOLWContentHandler \
     as OrigLIGOLWContentHandler
 from ligo.lw.lsctables import TableByName

--- a/pycbc/types/frequencyseries.py
+++ b/pycbc/types/frequencyseries.py
@@ -398,7 +398,7 @@ class FrequencySeries(Array):
                                         self.numpy().imag)).T
             _numpy.savetxt(path, output)
         elif ext == '.xml' or path.endswith('.xml.gz'):
-            from pycbc.io.live import make_psd_xmldoc
+            from pycbc.io.ligolw import make_psd_xmldoc
             from ligo.lw import utils
 
             if self.kind != 'real':

--- a/test/test_io_live.py
+++ b/test/test_io_live.py
@@ -23,7 +23,7 @@ import itertools
 import numpy as np
 from utils import parse_args_cpu_only, simple_exit
 from pycbc.types import TimeSeries, FrequencySeries
-from pycbc.io.live import SingleCoincForGraceDB
+from pycbc.io.live import CandidateForGraceDB
 from pycbc.io.ligolw import LIGOLWContentHandler
 from ligo.lw import lsctables
 from ligo.lw import utils as ligolw_utils
@@ -98,7 +98,7 @@ class TestIOLive(unittest.TestCase):
                   'low_frequency_cutoff': 20.,
                   'followup_data': followup_data,
                   'channel_names': channel_names}
-        coinc = SingleCoincForGraceDB(trig_ifos, results, **kwargs)
+        coinc = CandidateForGraceDB(trig_ifos, results, **kwargs)
 
         tempdir = tempfile.mkdtemp()
 


### PR DESCRIPTION
In a previous PR, @tdent proposed a better name for the `SingleCoincForGraceDB` class. I asked for that change to be made in a dedicated PR, so here it is.

This PR also moves some strictly LIGOLW-specific code (which is used by code that is more general than PyCBC Live) to `pycbc.io.ligolw`, fixes some docstrings, and does some minor code cleanup.

I am also thinking of renaming the `pycbc.io.live` module to `pycbc.io.gracedb`, as there is nothing really specific to PyCBC Live in it (in principle it could be used by `pycbc_upload_xml_to_gracedb` too). Feel free to object though.