### PR TITLE
Cythonize logsignalrate

### DIFF
--- a/bin/all_sky_search/pycbc_coinc_findtrigs
+++ b/bin/all_sky_search/pycbc_coinc_findtrigs
@@ -173,7 +173,7 @@ if args.timeslide_interval is not None and args.timeslide_interval <= TWOEARTH:
 
 # slide = 0 means don't do timeslides
 if args.timeslide_interval is None:
-    args.timeslide_interval = 0
+    args.timeslide_interval = 0.0
 
 if args.randomize_template_order:
     seed(0)

--- a/pycbc/events/coinc.py
+++ b/pycbc/events/coinc.py
@@ -1053,8 +1053,6 @@ class LiveCoincTimeslideBackgroundEstimator(object):
             trigs = results[fixed_ifo]
             # Loop over them one trigger at a time
             for i in range(len(trigs['end_time'])):
-                # Loop over all newly added triggers in fixed_ifo. Note we do
-                # this one trigger at a time.
                 trig_stat = trigs['stat'][i]
                 trig_time = trigs['end_time'][i]
                 template = trigs['template_id'][i]

--- a/pycbc/events/coinc.py
+++ b/pycbc/events/coinc.py
@@ -1053,6 +1053,8 @@ class LiveCoincTimeslideBackgroundEstimator(object):
             trigs = results[fixed_ifo]
             # Loop over them one trigger at a time
             for i in range(len(trigs['end_time'])):
+                # Loop over all newly added triggers in fixed_ifo. Note we do
+                # this one trigger at a time.
                 trig_stat = trigs['stat'][i]
                 trig_time = trigs['end_time'][i]
                 template = trigs['template_id'][i]

--- a/pycbc/events/eventmgr_cython.pyx
+++ b/pycbc/events/eventmgr_cython.pyx
@@ -102,10 +102,10 @@ def logsignalrateinternals_compute2detrate(
         id1 = nbinned1[idx] + c1_size / 2
         id2 = nbinned2[idx] + c2_size / 2
 
-        # Long logic block. What we basically have here are 3 IDs (relating to the
-        # time, phase and sensitivity bins). If all 3 IDs are actually in the weights
-        # file provided, find that weight and apply it. Otherwise apply the
-        # "max_penalty" parameter.
+        # For bins that exist in the signal pdf histogram, apply that pdf value,
+        # otherwise apply the "max penalty" value.
+        # The bins are specified by 3 indexes (corresponding to the time
+        # difference, phase difference and relative sensitivity dimensions).
         if (id0 > 0) and (id0 < c0_size) and (id1 > 0) and (id1 < c1_size) and (id2 > 0) and (id2 < c2_size):
             rate[ridx] = two_det_weights[id0, id1, id2]
         else:

--- a/pycbc/events/eventmgr_cython.pyx
+++ b/pycbc/events/eventmgr_cython.pyx
@@ -1,6 +1,7 @@
 import numpy as np
 cimport numpy as cnp
 from cython import wraparound, boundscheck, cdivision
+from libc.math cimport M_PI, sqrt
 
 
 ctypedef fused REALTYPE:
@@ -33,25 +34,79 @@ def findchirp_cluster_over_window_cython\
 @boundscheck(False)
 @wraparound(False)
 @cdivision(True)
-def test_internal_one_three(
-    double[:] tdif,
+def logsignalrateinternals_computepsignalbins(
     double[:] pdif,
+    double[:] tdif,
     double[:] sdif,
-    int[:] tbin,
     int[:] pbin,
+    int[:] tbin,
     int[:] sbin,
+    float[:] p,
+    double[:] t,
+    float[:] s,
+    float[:] sig,
+    float[:] pref,
+    double[:] tref,
+    float[:] sref,
+    float[:] sigref,
+    double[:] shift,
+    long int[:] rtype,
+    double sense,
+    double senseref,
     double twidth,
     double pwidth,
     double swidth,
+    int to_shift_ref,
+    int to_shift_ifo,
     int length
 ):
     cdef:
-        int idx
+        int idx, ridx
+
+    for idx in range(length):
+        ridx = rtype[idx]
+        pdif[idx] = (pref[ridx] - p[ridx]) % (M_PI * 2)
+        tdif[idx] = shift[ridx] * to_shift_ref + tref[ridx] - shift[ridx] * to_shift_ifo - t[ridx]
+        sdif[idx] = (s[ridx] * sense * sqrt(sigref[ridx])) / (sref[ridx] * senseref * sqrt(sig[ridx]))
 
     for idx in range(length):
         tbin[idx] = <int>(tdif[idx] / twidth)
         pbin[idx] = <int>(pdif[idx] / pwidth)
         sbin[idx] = <int>(sdif[idx] / swidth)
 
-    return None
+@boundscheck(False)
+@wraparound(False)
+@cdivision(True)
+def logsignalrateinternals_compute2detrate(
+    int[:] nbinned0,
+    int[:] nbinned1,
+    int[:] nbinned2,
+    long int c0_size,
+    long int c1_size,
+    long int c2_size,
+    float[:] rate,
+    long int[:] rtype,
+    float[:] sref,
+    float[:,:,::1] two_det_weights, # This declares a C-contiguous array
+    float max_penalty,
+    float ref_snr,
+    int length
+):
+    cdef:
+        int idx, ridx, id0, id1, id2
+        float rescale_fac
+
+    for idx in range(length):
+        ridx = rtype[idx]
+        id0 = nbinned0[idx] + c0_size / 2
+        id1 = nbinned1[idx] + c1_size / 2
+        id2 = nbinned2[idx] + c2_size / 2
+
+        # Long logic block.
+        if (id0 > 0) and (id0 < c0_size) and (id1 > 0) and (id1 < c1_size) and (id2 > 0) and (id2 < c2_size):
+            rate[ridx] = two_det_weights[id0, id1, id2]
+        else:
+            rate[ridx] = max_penalty
+        rescale_fac = ref_snr / sref[ridx]
+        rate[ridx] *= (rescale_fac*rescale_fac*rescale_fac*rescale_fac)
 

--- a/pycbc/events/eventmgr_cython.pyx
+++ b/pycbc/events/eventmgr_cython.pyx
@@ -1,5 +1,5 @@
-import numpy
-cimport numpy
+import numpy as np
+cimport numpy as cnp
 from cython import wraparound, boundscheck, cdivision
 
 
@@ -12,9 +12,9 @@ ctypedef fused REALTYPE:
 @wraparound(False)
 @cdivision(True)
 def findchirp_cluster_over_window_cython\
-        (numpy.ndarray[numpy.int32_t, ndim=1] times,
-         numpy.ndarray[REALTYPE, ndim=1] absvalues, int window_length,
-         numpy.ndarray[numpy.int32_t, ndim=1] indices, int tlen):
+        (cnp.ndarray[cnp.int32_t, ndim=1] times,
+         cnp.ndarray[REALTYPE, ndim=1] absvalues, int window_length,
+         cnp.ndarray[cnp.int32_t, ndim=1] indices, int tlen):
     cdef int j = 0
     cdef int curr_ind = 0
     cdef int i
@@ -28,3 +28,30 @@ def findchirp_cluster_over_window_cython\
             indices[j] = i
             curr_ind = i
     return j
+
+
+@boundscheck(False)
+@wraparound(False)
+@cdivision(True)
+def test_internal_one_three(
+    double[:] tdif,
+    double[:] pdif,
+    double[:] sdif,
+    int[:] tbin,
+    int[:] pbin,
+    int[:] sbin,
+    double twidth,
+    double pwidth,
+    double swidth,
+    int length
+):
+    cdef:
+        int idx
+
+    for idx in range(length):
+        tbin[idx] = <int>(tdif[idx] / twidth)
+        pbin[idx] = <int>(pdif[idx] / pwidth)
+        sbin[idx] = <int>(sdif[idx] / swidth)
+
+    return None
+

--- a/pycbc/events/eventmgr_cython.pyx
+++ b/pycbc/events/eventmgr_cython.pyx
@@ -66,6 +66,9 @@ def logsignalrateinternals_computepsignalbins(
     for idx in range(length):
         ridx = rtype[idx]
         pdif[idx] = (pref[ridx] - p[ridx]) % (M_PI * 2)
+        if pdif[idx] < 0:
+            # C modulus operator is not same as python's, correct for this
+            pdif[idx] += (M_PI * 2)
         tdif[idx] = shift[ridx] * to_shift_ref + tref[ridx] - shift[ridx] * to_shift_ifo - t[ridx]
         sdif[idx] = (s[ridx] * sense * sqrt(sigref[ridx])) / (sref[ridx] * senseref * sqrt(sig[ridx]))
 

--- a/pycbc/events/eventmgr_cython.pyx
+++ b/pycbc/events/eventmgr_cython.pyx
@@ -102,11 +102,15 @@ def logsignalrateinternals_compute2detrate(
         id1 = nbinned1[idx] + c1_size / 2
         id2 = nbinned2[idx] + c2_size / 2
 
-        # Long logic block.
+        # Long logic block. What we basically have here are 3 IDs (relating to the
+        # time, phase and sensitivity bins). If all 3 IDs are actually in the weights
+        # file provided, find that weight and apply it. Otherwise apply the
+        # "max_penalty" parameter.
         if (id0 > 0) and (id0 < c0_size) and (id1 > 0) and (id1 < c1_size) and (id2 > 0) and (id2 < c2_size):
             rate[ridx] = two_det_weights[id0, id1, id2]
         else:
             rate[ridx] = max_penalty
+        # Scale by signal population SNR
         rescale_fac = ref_snr / sref[ridx]
         rate[ridx] *= (rescale_fac*rescale_fac*rescale_fac*rescale_fac)
 

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -485,24 +485,6 @@ class PhaseTDStatistic(QuadratureSumStatistic):
 
         self.has_hist = True
 
-    def test_internal_one(self, p, t, s, sig, sense, pref, tref, sigref, sref, senseref, shift, rtype, to_shift_ref, to_shift_ifo, twidth, pwidth, swidth):
-
-        # Assign memory - This could be cached??
-        length = len(rtype)
-        while length > len(self.pdif):
-            newlen = len(self.pdif) * 2
-            self.pdif = numpy.zeros(newlen, dtype=numpy.float64)
-            self.tdif = numpy.zeros(newlen, dtype=numpy.float64)
-            self.sdif = numpy.zeros(newlen, dtype=numpy.float64)
-            self.pbin = numpy.zeros(newlen, dtype=numpy.int32)
-            self.tbin = numpy.zeros(newlen, dtype=numpy.int32)
-            self.sbin = numpy.zeros(newlen, dtype=numpy.int32)
-
-        # Calculate differences
-        test_internal_one_two(self.pdif, self.tdif, self.sdif, self.pbin, self.tbin, self.sbin, p, t, s, sig, pref, tref, sref, sigref, shift, rtype, sense, senseref, twidth, pwidth, swidth, to_shift_ref, to_shift_ifo, length)
-
-        return [self.tbin[:length], self.pbin[:length], self.sbin[:length]]
-
     def logsignalrate(self, stats, shift, to_shift):
         """
         Calculate the normalized log rate density of signals via lookup

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -29,6 +29,8 @@ import logging
 import numpy
 from . import ranking
 from . import coinc_rate
+from .eventmgr_cython import logsignalrateinternals_computepsignalbins
+from .eventmgr_cython import logsignalrateinternals_compute2detrate
 
 
 class Stat(object):
@@ -335,6 +337,14 @@ class PhaseTDStatistic(QuadratureSumStatistic):
         self.param_bin = {}
         self.two_det_flag = (len(ifos) == 2)
         self.two_det_weights = {}
+        # Some memory
+        self.pdif = numpy.zeros(128, dtype=numpy.float64)
+        self.tdif = numpy.zeros(128, dtype=numpy.float64)
+        self.sdif = numpy.zeros(128, dtype=numpy.float64)
+        self.tbin = numpy.zeros(128, dtype=numpy.int32)
+        self.pbin = numpy.zeros(128, dtype=numpy.int32)
+        self.sbin = numpy.zeros(128, dtype=numpy.int32)
+
         if pregenerate_hist and not len(ifos) == 1:
             self.get_hist()
 
@@ -446,12 +456,15 @@ class PhaseTDStatistic(QuadratureSumStatistic):
                     self.c1_size = {}
                     self.c2_size = {}
 
-                self.c0_size[ifo] = 2 * (abs(self.param_bin[ifo]['c0']).max()
-                                         + 1)
-                self.c1_size[ifo] = 2 * (abs(self.param_bin[ifo]['c1']).max()
-                                         + 1)
-                self.c2_size[ifo] = 2 * (abs(self.param_bin[ifo]['c2']).max()
-                                         + 1)
+                self.c0_size[ifo] = numpy.int32(
+                    2 * (abs(self.param_bin[ifo]['c0']).max() + 1)
+                )
+                self.c1_size[ifo] = numpy.int32(
+                    2 * (abs(self.param_bin[ifo]['c1']).max() + 1)
+                )
+                self.c2_size[ifo] = numpy.int32(
+                    2 * (abs(self.param_bin[ifo]['c2']).max() + 1)
+                )
 
                 array_size = [self.c0_size[ifo], self.c1_size[ifo],
                               self.c2_size[ifo]]
@@ -472,49 +485,23 @@ class PhaseTDStatistic(QuadratureSumStatistic):
 
         self.has_hist = True
 
-    def test_internal_one(self, p, t, s, sig, sense, pref, tref, sigref, sref, senseref, shift, to_shift_ref, to_shift_ifo, twidth, pwidth, swidth):
-        from .eventmgr_cython import test_internal_one_three
-        sig = self.test_internal_one_one(sig)
+    def test_internal_one(self, p, t, s, sig, sense, pref, tref, sigref, sref, senseref, shift, rtype, to_shift_ref, to_shift_ifo, twidth, pwidth, swidth):
+
+        # Assign memory - This could be cached??
+        length = len(rtype)
+        while length > len(self.pdif):
+            newlen = len(self.pdif) * 2
+            self.pdif = numpy.zeros(newlen, dtype=numpy.float64)
+            self.tdif = numpy.zeros(newlen, dtype=numpy.float64)
+            self.sdif = numpy.zeros(newlen, dtype=numpy.float64)
+            self.pbin = numpy.zeros(newlen, dtype=numpy.int32)
+            self.tbin = numpy.zeros(newlen, dtype=numpy.int32)
+            self.sbin = numpy.zeros(newlen, dtype=numpy.int32)
 
         # Calculate differences
-        pdif, tdif, sdif = self.test_internal_one_two(p, t, s, sig, sense, pref, tref, sigref, sref, senseref, shift, to_shift_ref, to_shift_ifo)
+        test_internal_one_two(self.pdif, self.tdif, self.sdif, self.pbin, self.tbin, self.sbin, p, t, s, sig, pref, tref, sref, sigref, shift, rtype, sense, senseref, twidth, pwidth, swidth, to_shift_ref, to_shift_ifo, length)
 
-        # Put into bins
-        tbin = numpy.zeros(len(tdif), dtype=numpy.int32)
-        pbin = numpy.zeros(len(tdif), dtype=numpy.int32)
-        sbin = numpy.zeros(len(tdif), dtype=numpy.int32)
-
-        test_internal_one_three(tdif, pdif, sdif, tbin, pbin, sbin, twidth, pwidth, swidth, len(tdif))
-        return [tbin, pbin, sbin]
-
-    def test_internal_one_one(self, sig):
-        return sig**0.5
-
-    def test_internal_one_two(self, p, t, s, sig, sense, pref, tref, sigref, sref, senseref, shift, to_shift_ref, to_shift_ifo):
-        length = len(p)
-        pdif = (pref - p) % (numpy.pi * 2.0)
-        tdif = shift * to_shift_ref + \
-            tref - shift * to_shift_ifo - t
-        sdif = (s*sense*sigref) / (sref * senseref * sig)
-        return pdif, tdif, sdif
-
-    def test_internal_two(self, rate, rtype, nbinned, ref_ifo):
-        # High-RAM, low-CPU option for two-det
-        rate[rtype] = numpy.zeros(len(nbinned)) + self.max_penalty
-
-        id0 = nbinned['c0'] + self.c0_size[ref_ifo] // 2
-        id1 = nbinned['c1'] + self.c1_size[ref_ifo] // 2
-        id2 = nbinned['c2'] + self.c2_size[ref_ifo] // 2
-
-        # look up keys which are within boundaries
-        within = (id0 > 0) & (id0 < self.c0_size[ref_ifo])
-        within = within & (id1 > 0) & (id1 < self.c1_size[ref_ifo])
-        within = within & (id2 > 0) & (id2 < self.c2_size[ref_ifo])
-        within = numpy.where(within)[0]
-        rate[rtype[within]] = \
-            self.two_det_weights[ref_ifo][id0[within], id1[within],
-                                          id2[within]]
-
+        return [self.tbin[:length], self.pbin[:length], self.sbin[:length]]
 
     def logsignalrate(self, stats, shift, to_shift):
         """
@@ -552,39 +539,97 @@ class PhaseTDStatistic(QuadratureSumStatistic):
 
         # Get reference ifo information
         rate = numpy.zeros(len(shift), dtype=numpy.float32)
+        ps = {ifo: numpy.array(stats[ifo]['coa_phase'], ndmin=1)
+              for ifo in self.ifos}
+        ts = {ifo: numpy.array(stats[ifo]['end_time'], ndmin=1)
+              for ifo in self.ifos}
+        ss = {ifo: numpy.array(stats[ifo]['snr'], ndmin=1)
+              for ifo in self.ifos}
+        sigs = {ifo: numpy.array(stats[ifo]['sigmasq'], ndmin=1)
+                for ifo in self.ifos}
         for ref_ifo in self.ifos:
             rtype = rtypes[ref_ifo]
             ref = stats[ref_ifo]
-            pref = numpy.array(ref['coa_phase'], ndmin=1)[rtype]
-            tref = numpy.array(ref['end_time'], ndmin=1)[rtype]
-            sref = numpy.array(ref['snr'], ndmin=1)[rtype]
-            sigref = numpy.array(ref['sigmasq'], ndmin=1) ** 0.5
-            sigref = sigref[rtype]
+            pref = ps[ref_ifo]
+            tref = ts[ref_ifo]
+            sref = ss[ref_ifo]
+            sigref = sigs[ref_ifo]
             senseref = self.relsense[self.hist_ifos[0]]
 
             binned = []
             other_ifos = [ifo for ifo in self.ifos if ifo != ref_ifo]
             for ifo in other_ifos:
-                sc = stats[ifo]
-                p = numpy.array(sc['coa_phase'], ndmin=1)[rtype]
-                t = numpy.array(sc['end_time'], ndmin=1)[rtype]
-                s = numpy.array(sc['snr'], ndmin=1)[rtype]
-                sig = numpy.array(sc['sigmasq'], ndmin=1)[rtype]
+                # Assign cached memory
+                length = len(rtype)
+                while length > len(self.pdif):
+                    newlen = len(self.pdif) * 2
+                    self.pdif = numpy.zeros(newlen, dtype=numpy.float64)
+                    self.tdif = numpy.zeros(newlen, dtype=numpy.float64)
+                    self.sdif = numpy.zeros(newlen, dtype=numpy.float64)
+                    self.pbin = numpy.zeros(newlen, dtype=numpy.int32)
+                    self.tbin = numpy.zeros(newlen, dtype=numpy.int32)
+                    self.sbin = numpy.zeros(newlen, dtype=numpy.int32)
 
-                ret_lst = self.test_internal_one(p, t, s, sig, self.relsense[ifo], pref, tref, sref, sigref, senseref, shift[rtype], to_shift[ref_ifo], to_shift[ifo], self.twidth, self.pwidth, self.swidth)
-                binned += ret_lst
+                # Calculate differences
+                logsignalrateinternals_computepsignalbins(
+                    self.pdif,
+                    self.tdif,
+                    self.sdif,
+                    self.pbin,
+                    self.tbin,
+                    self.sbin,
+                    ps[ifo],
+                    ts[ifo],
+                    ss[ifo],
+                    sigs[ifo],
+                    pref,
+                    tref,
+                    sref,
+                    sigref,
+                    shift,
+                    rtype,
+                    self.relsense[ifo],
+                    senseref,
+                    self.twidth,
+                    self.pwidth,
+                    self.swidth,
+                    to_shift[ref_ifo],
+                    to_shift[ifo],
+                    length
+                )
 
-            # Convert binned to same dtype as stored in hist
-            nbinned = numpy.zeros(len(ret_lst[1]), dtype=self.pdtype)
-            for i, b in enumerate(binned):
-                nbinned['c%s' % i] = b
+                binned += [
+                    self.tbin[:length],
+                    self.pbin[:length],
+                    self.sbin[:length]
+                ]
 
             # Read signal weight from precalculated histogram
             if self.two_det_flag:
                 # High-RAM, low-CPU option for two-det
-                self.test_internal_two(rate, rtype, nbinned, ref_ifo)
+                logsignalrateinternals_compute2detrate(
+                    binned[0],
+                    binned[1],
+                    binned[2],
+                    self.c0_size[ref_ifo],
+                    self.c1_size[ref_ifo],
+                    self.c2_size[ref_ifo],
+                    rate,
+                    rtype,
+                    sref,
+                    self.two_det_weights[ref_ifo],
+                    self.max_penalty,
+                    self.ref_snr,
+                    len(rtype)
+                )
             else:
                 # Low[er]-RAM, high[er]-CPU option for >two det
+
+                # Convert binned to same dtype as stored in hist
+                nbinned = numpy.zeros(len(binned[1]), dtype=self.pdtype)
+                for i, b in enumerate(binned):
+                    nbinned['c%s' % i] = b
+
                 loc = numpy.searchsorted(self.param_bin[ref_ifo], nbinned)
                 loc[loc == len(self.weights[ref_ifo])] = 0
                 rate[rtype] = self.weights[ref_ifo][loc]
@@ -595,9 +640,8 @@ class PhaseTDStatistic(QuadratureSumStatistic):
                     self.param_bin[ref_ifo][loc] != nbinned
                 )[0]
                 rate[rtype[missed]] = self.max_penalty
-
-            # Scale by signal population SNR
-            rate[rtype] *= (sref / self.ref_snr) ** -4.0
+                # Scale by signal population SNR
+                rate[rtype] *= (sref[rtype] / self.ref_snr) ** -4.0
 
         return numpy.log(rate)
 

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -531,7 +531,6 @@ class PhaseTDStatistic(QuadratureSumStatistic):
                 for ifo in self.ifos}
         for ref_ifo in self.ifos:
             rtype = rtypes[ref_ifo]
-            ref = stats[ref_ifo]
             pref = ps[ref_ifo]
             tref = ts[ref_ifo]
             sref = ss[ref_ifo]

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -609,7 +609,7 @@ class PhaseTDStatistic(QuadratureSumStatistic):
                 # Convert binned to same dtype as stored in hist
                 nbinned = numpy.zeros(len(binned[1]), dtype=self.pdtype)
                 for i, b in enumerate(binned):
-                    nbinned['c%s' % i] = b
+                    nbinned[f'c{i}'] = b
 
                 loc = numpy.searchsorted(self.param_bin[ref_ifo], nbinned)
                 loc[loc == len(self.weights[ref_ifo])] = 0

--- a/test/test_live_coinc_compare.py
+++ b/test/test_live_coinc_compare.py
@@ -29,13 +29,16 @@ class SingleDetTrigSimulator:
     def get_trigs(self):
         trigs = {}
         for det in self.detectors:
+            rand_end = np.random.randint(
+                self.start_time*4096,
+                (self.start_time + self.analysis_chunk)*4096,
+                size=self.num_trigs
+            )
+            rand_end = (rand_end / 4096.).astype(np.float64)
+
             trigs[det] = {
                 "snr": np.random.uniform(4.5, 10, size=self.num_trigs).astype(np.float32),
-                "end_time": np.random.uniform(
-                    self.start_time,
-                    self.start_time + self.analysis_chunk,
-                    size=self.num_trigs
-                ).astype(np.float64),
+                "end_time": rand_end,
                 "chisq": np.random.uniform(0.5, 1.5, size=self.num_trigs).astype(np.float32),
                 "chisq_dof": np.ones(self.num_trigs, dtype=np.int32) * 10,
                 "coa_phase": np.random.uniform(0, 2*np.pi, size=self.num_trigs).astype(np.float32),
@@ -117,7 +120,7 @@ class TestPyCBCLiveCoinc(unittest.TestCase):
         new_coincer = self.new_coincer
         old_coincer = self.old_coincer
         self.assertTrue(len(new_coincer.coincs.data) == len(old_coincer.coincs.data))
-        self.assertTrue((new_coincer.coincs.data == old_coincer.coincs.data).all())
+        self.assertTrue(numpy.isclose(new_coincer.coincs.data, old_coincer.coincs.data, rtol=1e-06).all())
 
         for ifo in new_coincer.singles:
             lgc = True


### PR DESCRIPTION
I've been spending quite a bit of my free time in the last few weeks trying to optimize PyCBC Live so that it does better keeping up with data, and hopefully reduce latency when it is keeping up. 

One bottleneck we've noticed is the logsignalrate function. In the offline all-sky search this function is sent *many* triggers every call, and was optimized for that. However, in the online search it is called *many* more times with orders of magnitude fewer triggers. This requires some differences in how we optimize this code (while not impacting on the offline use case).

Cython seems the natural solution here. Cython is not slower when doing operations on arrays with small numbers of components, is just as fast when there's lots of components, and we can change `range` to `prange` if we want to use openmpi to speed things up further in the "lots of components" case.

Additionally I have reduced the number of numpy arrays being assigned on the fly (important in particular when being called often, with arrays containing relative few events).

This is still being tested, and I want to get a callgraph comparison of this running at scale, but wanted to post this now for any immediate comments/complaints.

(@ahnitz You may notice a difference in style for the Cython code. I read a good book on Cython practices in the last few weeks, and we do a few things suboptimally in places, in particular with regard to numpy arrays. I will try to improve the other cython code in this regard in the future)