### PR TITLE
Use cython to expire pycbc live coinc buffer

### DIFF
--- a/pycbc/events/coinc.py
+++ b/pycbc/events/coinc.py
@@ -730,7 +730,6 @@ class CoincExpireBuffer(object):
                 self.timer[ifo][:keep.sum()] = self.timer[ifo][:self.index][keep]
             self.index = keep.sum()
 
-
     def num_greater(self, value):
         """Return the number of elements larger than 'value'"""
         return (self.buffer[:self.index] > value).sum()

--- a/pycbc/events/eventmgr_cython.pyx
+++ b/pycbc/events/eventmgr_cython.pyx
@@ -117,3 +117,25 @@ def logsignalrateinternals_compute2detrate(
         rescale_fac = ref_snr / sref[ridx]
         rate[ridx] *= (rescale_fac*rescale_fac*rescale_fac*rescale_fac)
 
+
+@boundscheck(False)
+@wraparound(False)
+@cdivision(True)
+def coincbuffer_expireelements(
+    float[:] cbuffer,
+    int[:] timer,
+    int time,
+    int expiration,
+    int length,
+):
+    cdef:
+        int idx, keep_count
+
+    keep_count = 0
+    for idx in range(length):
+        if timer[idx] > time - expiration:
+            cbuffer[keep_count] = cbuffer[idx]
+            timer[keep_count] = timer[idx]
+            keep_count += 1
+
+    return keep_count

--- a/pycbc/events/eventmgr_cython.pyx
+++ b/pycbc/events/eventmgr_cython.pyx
@@ -133,7 +133,7 @@ def coincbuffer_expireelements(
 
     keep_count = 0
     for idx in range(length):
-        if timer[idx] > time - expiration:
+        if timer[idx] >= time - expiration:
             cbuffer[keep_count] = cbuffer[idx]
             timer[keep_count] = timer[idx]
             keep_count += 1

--- a/pycbc/events/eventmgr_cython.pyx
+++ b/pycbc/events/eventmgr_cython.pyx
@@ -123,8 +123,10 @@ def logsignalrateinternals_compute2detrate(
 @cdivision(True)
 def coincbuffer_expireelements(
     float[:] cbuffer,
-    int[:] timer,
-    int time,
+    int[:] timer1,
+    int[:] timer2,
+    int time1,
+    int time2,
     int expiration,
     int length,
 ):
@@ -133,9 +135,10 @@ def coincbuffer_expireelements(
 
     keep_count = 0
     for idx in range(length):
-        if timer[idx] >= time - expiration:
+        if (timer1[idx] >= (time1 - expiration)) and (timer2[idx] >= (time2 - expiration)):
             cbuffer[keep_count] = cbuffer[idx]
-            timer[keep_count] = timer[idx]
+            timer1[keep_count] = timer1[idx]
+            timer2[keep_count] = timer2[idx]
             keep_count += 1
 
     return keep_count


### PR DESCRIPTION
Another pycbc_live optimization patch.

In this case I have rewritten the code for expiring old coincident triggers in cython. Not entirely sure why this helps, but it seems to provide a factor of about 4 speedup (when comparing after the buffer has accrued 12000s worth of triggers). My suspicion is that the C code is quicker because it does less work in the case that a trigger is not expired, which will be by far the most common outcome.