### PR TITLE
Correct the way PyCBC Live inits p_astro

### DIFF
--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -71,8 +71,18 @@ def combine_ifar_pvalue(ifar, pvalue, livetime):
 
 class LiveEventManager(object):
     def __init__(self, args, bank):
-        # pick relevant arguments from CLI options
         self.low_frequency_cutoff = args.low_frequency_cutoff
+        self.bank = bank
+
+        # Figure out what we are supposed to process within the pool of MPI processes
+        self.comm = mpi.COMM_WORLD
+        self.size = self.comm.Get_size()
+        self.rank = self.comm.Get_rank()
+
+        if self.rank > 0:
+            # We are a matched-filtering process, so nothing else is needed
+            return
+
         self.path = args.output_path
         self.mc_area_args = mchirp_area.from_cli(args)
         self.padata = livepau.PAstroData(args.p_astro_spec, args.bank_file)
@@ -83,19 +93,12 @@ class LiveEventManager(object):
         self.enable_gracedb_upload = args.enable_gracedb_upload
         self.run_snr_optimization = args.run_snr_optimization
 
-        self.bank = bank
-
-        # Figure out what we are supposed to process within the pool of MPI processes
-        self.comm = mpi.COMM_WORLD
-        self.size = self.comm.Get_size()
-        self.rank = self.comm.Get_rank()
-
         # Keep track of which events have been uploaded
         self.last_few_coincs_uploaded = []
 
-        if self.run_snr_optimization and self.rank == 0:
-            # preestimate the number of CPU cores that we can afford giving to
-            # followup processes without slowing down the main search
+        if self.run_snr_optimization:
+            # preestimate the number of CPU cores that we can afford giving
+            # to followup processes without slowing down the main search
             available_cores = len(os.sched_getaffinity(0))
             bg_cores = len(tuple(itertools.combinations(ifos, 2)))
             analysis_cores = 1 + bg_cores

--- a/pycbc/population/live_pastro.py
+++ b/pycbc/population/live_pastro.py
@@ -49,12 +49,11 @@ def read_template_bank_param(spec_d, bankf):
         # All the templates
         tids = numpy.arange(len(bank['mass1']))
         # Get param vals
-        logging.debug('Getting %s values from bank', spec_d['param'])
+        logging.info('Getting %s values from bank', spec_d['param'])
         parvals = bankconv.get_bank_property(spec_d['param'], bank, tids)
     counts, edges = numpy.histogram(parvals, bins=spec_d['bin_edges'])
     bank_data = {'bin_edges': edges, 'tcounts': counts, 'num_t': counts.sum()}
-    logging.debug('Binned template counts:')
-    logging.debug(counts)
+    logging.info('Binned template counts: %s', counts)
 
     return bank_data
 


### PR DESCRIPTION
Only initialize p_astro (and source classification, and a bunch of other attributes) for the root process, and do print p_astro details at initialization when `--verbose` is used.