### PR TITLE
Fix serious bug(?) in PyCBC Live background estimate

### DIFF
--- a/pycbc/events/coinc.py
+++ b/pycbc/events/coinc.py
@@ -1049,7 +1049,7 @@ class LiveCoincTimeslideBackgroundEstimator(object):
                     sngls_list,
                     slide,
                     self.timeslide_interval,
-                    to_shift
+                    shift_vec
                 )
                 # Store data about new triggers: slide index, stat value and
                 # times.

--- a/pycbc/events/coinc.py
+++ b/pycbc/events/coinc.py
@@ -1005,11 +1005,11 @@ class LiveCoincTimeslideBackgroundEstimator(object):
         # Calculate all the permutations of coincident triggers for each
         # new single detector trigger collected
         # Currently only two detectors are supported.
-        # For each ifo, check its newly added triggers for (zerolag and time 
-        # shift) coincs with all currently stored triggers in the other ifo. 
+        # For each ifo, check its newly added triggers for (zerolag and time
+        # shift) coincs with all currently stored triggers in the other ifo.
         # Do this by keeping the ifo with new triggers fixed and time shifting
         # the other ifo. The list 'shift_vec' must be in the same order as
-        # self.ifos and contain -1 for the shift_ifo / 0 for the fixed_ifo. 
+        # self.ifos and contain -1 for the shift_ifo / 0 for the fixed_ifo.
         for fixed_ifo, shift_ifo, shift_vec in zip(
             [self.ifos[0], self.ifos[1]],
             [self.ifos[1], self.ifos[0]],
@@ -1026,14 +1026,14 @@ class LiveCoincTimeslideBackgroundEstimator(object):
                 trig_time = trigs['end_time'][i]
                 template = trigs['template_id'][i]
 
-                # Get current shift_ifo triggers in the same template 
+                # Get current shift_ifo triggers in the same template
                 times = self.singles[shift_ifo].data(template)['end_time']
                 stats = self.singles[shift_ifo].data(template)['stat']
 
                 # Perform coincidence. i1 is the list of trigger indices in the
                 # shift_ifo which make coincs, slide is the corresponding slide
                 # index.
-                # (The second output would just be a list of zeroes as we only 
+                # (The second output would just be a list of zeroes as we only
                 # have one trigger in the fixed_ifo.)
                 i1, _, slide = time_coincidence(times,
                                  numpy.array(trig_time, ndmin=1,
@@ -1042,9 +1042,9 @@ class LiveCoincTimeslideBackgroundEstimator(object):
                                  self.timeslide_interval)
 
                 # Make a copy of the fixed ifo trig_stat for each coinc.
-                # NB for some statistics the "stat" entry holds more than just a 
-                # ranking number. E.g. for the phase time consistency test, it
-                # must also contain the phase, time and sensitivity.
+                # NB for some statistics the "stat" entry holds more than just
+                # a ranking number. E.g. for the phase time consistency test,
+                # it must also contain the phase, time and sensitivity.
                 trig_stat = numpy.resize(trig_stat, len(i1))
 
                 # Force data into form needed by stat.py and then compute the
@@ -1198,7 +1198,7 @@ class LiveCoincTimeslideBackgroundEstimator(object):
         self._add_singles_to_buffer(results, ifos=valid_ifos)
 
         # Calculate zerolag and background coincidences
-        _, coinc_results = self._find_coincs(results, ifos=valid_ifos)
+        _, coinc_results = self._find_coincs(results, valid_ifos=valid_ifos)
 
         # record if a coinc is possible in this chunk
         if len(valid_ifos) == 2:

--- a/pycbc/events/coinc.py
+++ b/pycbc/events/coinc.py
@@ -998,7 +998,7 @@ class LiveCoincTimeslideBackgroundEstimator(object):
         # new single detector trigger collected
         # For now only two-detectors are permitted, alterations would be needed
         # to support > two detectors.
-        # We need to check all newly added triggers against previously added 
+        # We need to check all newly added triggers against previously added
         # background. So first check new triggers in ifo[0] against ifo[1]
         # background and then vice-versa. fixed_ifo is the one we don't slide
         # (the one where the new triggers come from), shift_ifo is the slid one

--- a/pycbc/events/coinc.py
+++ b/pycbc/events/coinc.py
@@ -1010,6 +1010,10 @@ class LiveCoincTimeslideBackgroundEstimator(object):
             [self.ifos[1], self.ifos[0]],
             [[0, -1], [-1, 0]]
         ):
+            if fixed_ifo not in ifos:
+                # This ifo is not online right now, so no new triggers to add
+                # involving fixed_ifo
+                continue
             # Find newly added triggers in fixed_ifo
             trigs = results[fixed_ifo]
             for i in range(len(trigs['end_time'])):

--- a/pycbc/events/coinc.py
+++ b/pycbc/events/coinc.py
@@ -1018,11 +1018,16 @@ class LiveCoincTimeslideBackgroundEstimator(object):
                 sngls_list = [[ifo, trig_stat],
                               [oifo, stats[i1]]]
                 # This can only use 2-det coincs at present
+                if oifo == self.ifos[0]:
+                    to_shift = [-1, 0]
+                else:
+                    to_shift = [0, -1]
+
                 c = self.stat_calculator.rank_stat_coinc(
                     sngls_list,
                     slide,
                     self.timeslide_interval,
-                    [0, -1]
+                    to_shift
                 )
                 offsets.append(slide)
                 cstat.append(c)

--- a/pycbc/events/coinc.py
+++ b/pycbc/events/coinc.py
@@ -1009,7 +1009,7 @@ class LiveCoincTimeslideBackgroundEstimator(object):
         # shift) coincs with all currently stored triggers in the other ifo. 
         # Do this by keeping the ifo with new triggers fixed and time shifting
         # the other ifo. The list 'shift_vec' must be in the same order as
-        # self.ifos and contain -1 for the shifted ifo / 0 for the fixed_ifo. 
+        # self.ifos and contain -1 for the shift_ifo / 0 for the fixed_ifo. 
         for fixed_ifo, shift_ifo, shift_vec in zip(
             [self.ifos[0], self.ifos[1]],
             [self.ifos[1], self.ifos[0]],
@@ -1026,7 +1026,7 @@ class LiveCoincTimeslideBackgroundEstimator(object):
                 trig_time = trigs['end_time'][i]
                 template = trigs['template_id'][i]
 
-                # Background triggers in shift_ifo
+                # Get current shift_ifo triggers in the same template 
                 times = self.singles[shift_ifo].data(template)['end_time']
                 stats = self.singles[shift_ifo].data(template)['stat']
 

--- a/pycbc/events/coinc.py
+++ b/pycbc/events/coinc.py
@@ -1058,7 +1058,7 @@ class LiveCoincTimeslideBackgroundEstimator(object):
                 ctimes[shift_ifo].append(times[i1])
                 ctimes[fixed_ifo].append(numpy.zeros(len(c),
                                          dtype=numpy.float64))
-                ctimes[ifo][-1].fill(trig_time)
+                ctimes[fixed_ifo][-1].fill(trig_time)
 
                 # As background triggers are removed after a certain time, we
                 # need to log when this will be for new background triggers.


### PR DESCRIPTION
While debugging an issue in some development cythonizing I noticed that the time differences being used in the phase-time statistic were sometimes of the order of thousands of seconds, not the O(0.1s) times we expect.

After some hour(s) of tracking this back, I think a serious bug was introduced to pycbc_live in #3535 (thankfully never used in production). The issue is in the new "to_shift" vector, which was added to rank_stat_coinc. This is *not* locked to the order of ifos in the "sngls_list" sent to the function, but is locked to the order of ifos in the `self.ifos` attribute of the class. Therefore, if the shifted ifo is the *first* ifo, this is wrong. The fix is very short, and I have checked that now the time differences are sane again. (Further motivation for a proper unit test as I include in #4105 ... although I would need to fix the validation code in there after this is merged + rebased!)