### PR TITLE
Make no-mass-gap default option for online source classification 

### DIFF
--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -88,7 +88,7 @@ class LiveEventManager(object):
             return
 
         self.path = args.output_path
-        self.mc_area_args = mchirp_area.from_cli(args)
+        self.mc_area_args = mchirp_area.from_cli(args, parser)
         self.padata = livepau.PAstroData(args.p_astro_spec, args.bank_file)
         self.use_date_prefix = args.day_hour_output_prefix
         self.ifar_upload_threshold = args.ifar_upload_threshold

--- a/pycbc/mchirp_area.py
+++ b/pycbc/mchirp_area.py
@@ -31,8 +31,8 @@ def insert_args(parser):
                                    "to different CBC sources.")
     mchirp_group.add_argument('--src-class-mass-gap-max', type=float,
                               metavar=('MAX_GAP'),
-                              help="Upper limit of the mass gap, that corresponds "
-                                   "to the minimum mass of a black hole. "
+                              help="Upper limit of the mass gap, corresponding"
+                                   " to the minimum mass of a black hole. "
                                    "Used as limit of integration of the "
                                    "different CBC regions when considering "
                                    "the MassGap category.")
@@ -69,25 +69,31 @@ def from_cli(args, parser):
     if args.src_class_mass_gap_max:
         if args.src_class_mass_gap_max < mass_limits_sorted[1]:
             parser.error('MAX_GAP value cannot be lower than MAX_NS limit')
-        return {'mass_limits': {'max_m1': mass_limits_sorted[2],
-                                'min_m2': mass_limits_sorted[0]},
-                'mass_bdary': {'ns_max': mass_limits_sorted[1],
-                               'gap_max': args.src_class_mass_gap_max},
-                'estimation_coeff': {'a0': args.src_class_eff_to_lum_distance,
-                                     'b0': args.src_class_lum_distance_to_delta[0],
-                                     'b1': args.src_class_lum_distance_to_delta[1],
-                                     'm0': args.src_class_mchirp_to_delta},
+        return {'mass_limits':
+                 {'max_m1': mass_limits_sorted[2],
+                  'min_m2': mass_limits_sorted[0]},
+                'mass_bdary':
+                 {'ns_max': mass_limits_sorted[1],
+                  'gap_max': args.src_class_mass_gap_max},
+                'estimation_coeff':
+                 {'a0': args.src_class_eff_to_lum_distance,
+                  'b0': args.src_class_lum_distance_to_delta[0],
+                  'b1': args.src_class_lum_distance_to_delta[1],
+                  'm0': args.src_class_mchirp_to_delta},
                 'mass_gap': True,
                 'mass_gap_separate': args.src_class_mass_gap_separate,
                 'lal_cosmology': args.src_class_lal_cosmology}
-    return {'mass_limits': {'max_m1': mass_limits_sorted[2],
-                            'min_m2': mass_limits_sorted[0]},
-            'mass_bdary': {'ns_max': mass_limits_sorted[1],
-                           'gap_max': mass_limits_sorted[1]},
-            'estimation_coeff': {'a0': args.src_class_eff_to_lum_distance,
-                                 'b0': args.src_class_lum_distance_to_delta[0],
-                                 'b1': args.src_class_lum_distance_to_delta[1],
-                                 'm0': args.src_class_mchirp_to_delta},
+    return {'mass_limits':
+             {'max_m1': mass_limits_sorted[2],
+              'min_m2': mass_limits_sorted[0]},
+            'mass_bdary':
+             {'ns_max': mass_limits_sorted[1],
+              'gap_max': mass_limits_sorted[1]},
+            'estimation_coeff':
+             {'a0': args.src_class_eff_to_lum_distance,
+              'b0': args.src_class_lum_distance_to_delta[0],
+              'b1': args.src_class_lum_distance_to_delta[1],
+              'm0': args.src_class_mchirp_to_delta},
             'mass_gap': False,
             'mass_gap_separate': args.src_class_mass_gap_separate,
             'lal_cosmology': args.src_class_lal_cosmology}
@@ -185,7 +191,13 @@ def get_area(trig_mc, lim_h1, lim_h2, lim_v1, lim_v2):
     return area
 
 
-def calc_areas(trig_mc_det, mass_limits, mass_bdary, z, mass_gap, mass_gap_separate):
+def calc_areas(
+        trig_mc_det,
+        mass_limits,
+        mass_bdary,
+        z,
+        mass_gap,
+        mass_gap_separate):
     """Computes the area inside the lines of the second component mass as a
     function of the first component mass for the two extreme values
     of mchirp: mchirp +/- mchirp_uncertainty, for each region of the source
@@ -259,8 +271,8 @@ def calc_probabilities(mchirp, snr, eff_distance, src_args):
     if trig_mc_det['central'] > mc_max * (1 + z['central']):
         if mass_gap:
             if mass_gap_separate:
-                probabilities = {"BNS": 0.0, "GNS": 0.0, "NSBH": 0.0, "GG": 0.0,
-                                 "BHG": 0.0, "BBH": 1.0}
+                probabilities = {"BNS": 0.0, "GNS": 0.0, "NSBH": 0.0,
+                                 "GG": 0.0, "BHG": 0.0, "BBH": 1.0}
             else:
                 probabilities = {"BNS": 0.0, "NSBH": 0.0, "BBH": 1.0,
                                  "Mass Gap": 0.0}
@@ -270,8 +282,8 @@ def calc_probabilities(mchirp, snr, eff_distance, src_args):
     elif trig_mc_det['central'] < mc_min * (1 + z['central']):
         if mass_gap:
             if mass_gap_separate:
-                probabilities = {"BNS": 1.0, "GNS": 0.0, "NSBH": 0.0, "GG": 0.0,
-                                 "BHG": 0.0, "BBH": 0.0}
+                probabilities = {"BNS": 1.0, "GNS": 0.0, "NSBH": 0.0,
+                                 "GG": 0.0, "BHG": 0.0, "BBH": 0.0}
             else:
                 probabilities = {"BNS": 1.0, "NSBH": 0.0, "BBH": 0.0,
                                  "Mass Gap": 0.0}
@@ -279,7 +291,8 @@ def calc_probabilities(mchirp, snr, eff_distance, src_args):
             probabilities = {"BNS": 1.0, "NSBH": 0.0, "BBH": 0.0}
 
     else:
-        areas = calc_areas(trig_mc_det, mass_limits, mass_bdary, z, mass_gap, mass_gap_separate)
+        areas = calc_areas(trig_mc_det, mass_limits, mass_bdary, z,
+            mass_gap, mass_gap_separate)
         total_area = sum(areas.values())
         probabilities = {key: areas[key] / total_area for key in areas}
 

--- a/pycbc/mchirp_area.py
+++ b/pycbc/mchirp_area.py
@@ -277,7 +277,7 @@ def calc_probabilities(mchirp, snr, eff_distance, src_args):
             probabilities = {"BNS": 1.0, "NSBH": 0.0, "BBH": 0.0}
 
     else:
-        areas = calc_areas(trig_mc_det, mass_limits, mass_bdary, z, mass_gap)
+        areas = calc_areas(trig_mc_det, mass_limits, mass_bdary, z, mass_gap, mass_gap_separate)
         total_area = sum(areas.values())
         probabilities = {key: areas[key]/total_area for key in areas}
 

--- a/pycbc/mchirp_area.py
+++ b/pycbc/mchirp_area.py
@@ -64,9 +64,11 @@ def insert_args(parser):
                                    'default model.')
 
 
-def from_cli(args):
+def from_cli(args, parser):
     mass_limits_sorted = sorted(args.src_class_mass_limits)
     if args.src_class_mass_gap_max:
+        if args.src_class_mass_gap_max < mass_limits_sorted[1]:
+            parser.error('MAX_GAP value cannot be lower than MAX_NS limit')
         return {'mass_limits': {'max_m1': mass_limits_sorted[2],
                                 'min_m2': mass_limits_sorted[0]},
                 'mass_bdary': {'ns_max': mass_limits_sorted[1],

--- a/pycbc/mchirp_area.py
+++ b/pycbc/mchirp_area.py
@@ -21,11 +21,11 @@ def insert_args(parser):
                                              "source probabilities of a "
                                              "candidate event using the snr, "
                                              "mchirp, and effective distance.")
-    mchirp_group.add_argument('--src-class-mass-ranges', type=float, nargs=3,
-                              metavar=('MIN_M2', 'MAX_M1', 'MAX_NS'),
+    mchirp_group.add_argument('--src-class-mass-limits', type=float, nargs=3,
+                              metavar=('MIN_M2', 'MAX_NS', 'MAX_M1'),
                               default=[1.0, 3.0, 45.0],
                               help="Minimum and maximum values for the mass "
-                                   "of the binary components, and maximum mass "
+                                   "of the binary components and maximum mass "
                                    "of a neutron star, used as limits "
                                    "when computing the area corresponding"
                                    "to different CBC sources.")
@@ -65,10 +65,11 @@ def insert_args(parser):
 
 
 def from_cli(args):
+    mass_limits_sorted = sorted(args.src_class_mass_limits)
     if args.src_class_mass_gap_max:
-        return {'mass_limits': {'max_m1': args.src_class_mass_ranges[1],
-                                'min_m2': args.src_class_mass_ranges[0]},
-                'mass_bdary': {'ns_max': args.src_class_mass_ranges[2],
+        return {'mass_limits': {'max_m1': mass_limits_sorted[2],
+                                'min_m2': mass_limits_sorted[0]},
+                'mass_bdary': {'ns_max': mass_limits_sorted[1],
                                'gap_max': args.src_class_mass_gap_max},
                 'estimation_coeff': {'a0': args.src_class_eff_to_lum_distance,
                                      'b0': args.src_class_lum_distance_to_delta[0],
@@ -77,10 +78,10 @@ def from_cli(args):
                 'mass_gap': True,
                 'mass_gap_separate': args.src_class_mass_gap_separate,
                 'lal_cosmology': args.src_class_lal_cosmology}
-    return {'mass_limits': {'max_m1': args.src_class_mass_ranges[1],
-                            'min_m2': args.src_class_mass_ranges[0]},
-            'mass_bdary': {'ns_max': args.src_class_mass_ranges[2],
-                           'gap_max': args.src_class_mass_ranges[2]},
+    return {'mass_limits': {'max_m1': mass_limits_sorted[2],
+                            'min_m2': mass_limits_sorted[0]},
+            'mass_bdary': {'ns_max': mass_limits_sorted[1],
+                           'gap_max': mass_limits_sorted[1]},
             'estimation_coeff': {'a0': args.src_class_eff_to_lum_distance,
                                  'b0': args.src_class_lum_distance_to_delta[0],
                                  'b1': args.src_class_lum_distance_to_delta[1],
@@ -88,7 +89,6 @@ def from_cli(args):
             'mass_gap': False,
             'mass_gap_separate': args.src_class_mass_gap_separate,
             'lal_cosmology': args.src_class_lal_cosmology}
-    
 
 
 def redshift_estimation(distance, distance_std, lal_cosmology):

--- a/pycbc/mchirp_area.py
+++ b/pycbc/mchirp_area.py
@@ -279,6 +279,6 @@ def calc_probabilities(mchirp, snr, eff_distance, src_args):
     else:
         areas = calc_areas(trig_mc_det, mass_limits, mass_bdary, z, mass_gap, mass_gap_separate)
         total_area = sum(areas.values())
-        probabilities = {key: areas[key]/total_area for key in areas}
+        probabilities = {key: areas[key] / total_area for key in areas}
 
     return probabilities

--- a/pycbc/mchirp_area.py
+++ b/pycbc/mchirp_area.py
@@ -203,16 +203,16 @@ def calc_areas(trig_mc_det, mass_limits, mass_bdary, z, mass_gap, mass_gap_separ
     agns = get_area(trig_mc, ns_max, m2_min, ns_max, gap_max)
     abns = get_area(trig_mc, 'diagonal', m2_min, m2_min, ns_max)
 
-    if mass_gap_separate:
-        return {
-            "BNS": abns,
-            "GNS": agns,
-            "NSBH": ansbh,
-            "GG": agg,
-            "BHG": abhg,
-            "BBH": abbh
-            }
     if mass_gap:
+        if mass_gap_separate:
+            return {
+                "BNS": abns,
+                "GNS": agns,
+                "NSBH": ansbh,
+                "GG": agg,
+                "BHG": abhg,
+                "BBH": abbh
+                }
         return {
             "BNS": abns,
             "NSBH": ansbh,
@@ -254,22 +254,24 @@ def calc_probabilities(mchirp, snr, eff_distance, src_args):
     mc_min = mass_limits['min_m2'] / (2 ** 0.2)
 
     if trig_mc_det['central'] > mc_max * (1 + z['central']):
-        if mass_gap_separate:
-            probabilities = {"BNS": 0.0, "GNS": 0.0, "NSBH": 0.0, "GG": 0.0,
-                             "BHG": 0.0, "BBH": 1.0}
-        elif mass_gap:
-            probabilities = {"BNS": 0.0, "NSBH": 0.0, "BBH": 1.0,
-                             "Mass Gap": 0.0}
+        if mass_gap:
+            if mass_gap_separate:
+                probabilities = {"BNS": 0.0, "GNS": 0.0, "NSBH": 0.0, "GG": 0.0,
+                                 "BHG": 0.0, "BBH": 1.0}
+            else:
+                probabilities = {"BNS": 0.0, "NSBH": 0.0, "BBH": 1.0,
+                                 "Mass Gap": 0.0}
         else:
             probabilities = {"BNS": 0.0, "NSBH": 0.0, "BBH": 1.0}
 
     elif trig_mc_det['central'] < mc_min * (1 + z['central']):
-        if mass_gap_separate:
-            probabilities = {"BNS": 1.0, "GNS": 0.0, "NSBH": 0.0, "GG": 0.0,
-                             "BHG": 0.0, "BBH": 0.0}
-        elif mass_gap:
-            probabilities = {"BNS": 1.0, "NSBH": 0.0, "BBH": 0.0,
-                             "Mass Gap": 0.0}
+        if mass_gap:
+            if mass_gap_separate:
+                probabilities = {"BNS": 1.0, "GNS": 0.0, "NSBH": 0.0, "GG": 0.0,
+                                 "BHG": 0.0, "BBH": 0.0}
+            else:
+                probabilities = {"BNS": 1.0, "NSBH": 0.0, "BBH": 0.0,
+                                 "Mass Gap": 0.0}
         else:
             probabilities = {"BNS": 1.0, "NSBH": 0.0, "BBH": 0.0}
 

--- a/pycbc/mchirp_area.py
+++ b/pycbc/mchirp_area.py
@@ -22,19 +22,20 @@ def insert_args(parser):
                                              "candidate event using the snr, "
                                              "mchirp, and effective distance.")
     mchirp_group.add_argument('--src-class-mass-ranges', type=float, nargs=3,
-                              metavar=('MIN_M2', 'MAX_NS', 'MAX_M1'),
+                              metavar=('MIN_M2', 'MAX_M1', 'MAX_NS'),
                               default=[1.0, 3.0, 45.0],
                               help="Minimum and maximum values for the mass "
-                                   "of the binary components, used as limits "
-                                   "of the mass plane when computing the area "
-                                   "corresponding to different CBC sources.")
-    mchirp_group.add_argument('--src-class-mass-gap', type=float, nargs=2,
-                              metavar=('MAX_NS', 'MIN_BH'), default=[3.0, 5.0],
-                              help="Limits of the mass gap, that correspond "
-                                   "to the maximum mass of a neutron star "
-                                   "and the minimum mass of a black hole. "
-                                   "Used as limits of integration of the "
-                                   "different CBC regions.")
+                                   "of the binary components, and maximum mass "
+                                   "of a neutron star, used as limits "
+                                   "when computing the area corresponding"
+                                   "to different CBC sources.")
+    mchirp_group.add_argument('--src-class-mass-gap-max', type=float,
+                              metavar=('MAX_GAP'),
+                              help="Upper limit of the mass gap, that corresponds "
+                                   "to the minimum mass of a black hole. "
+                                   "Used as limit of integration of the "
+                                   "different CBC regions when considering "
+                                   "the MassGap category.")
     mchirp_group.add_argument('--src-class-mchirp-to-delta', type=float,
                               metavar='m0', required=True,
                               help='Coefficient to estimate the value of the '
@@ -64,11 +65,11 @@ def insert_args(parser):
 
 
 def from_cli(args):
-    if args.src_class_mass_gap:
-        return {'mass_limits': {'max_m1': args.src_class_mass_ranges[2],
+    if args.src_class_mass_gap_max:
+        return {'mass_limits': {'max_m1': args.src_class_mass_ranges[1],
                                 'min_m2': args.src_class_mass_ranges[0]},
-                'mass_bdary': {'ns_max': args.src_class_mass_gap[0],
-                               'gap_max': args.src_class_mass_gap[1]},
+                'mass_bdary': {'ns_max': args.src_class_mass_ranges[2],
+                               'gap_max': args.src_class_mass_gap_max},
                 'estimation_coeff': {'a0': args.src_class_eff_to_lum_distance,
                                      'b0': args.src_class_lum_distance_to_delta[0],
                                      'b1': args.src_class_lum_distance_to_delta[1],
@@ -76,10 +77,10 @@ def from_cli(args):
                 'mass_gap': True,
                 'mass_gap_separate': args.src_class_mass_gap_separate,
                 'lal_cosmology': args.src_class_lal_cosmology}
-    return {'mass_limits': {'max_m1': args.src_class_mass_ranges[2],
+    return {'mass_limits': {'max_m1': args.src_class_mass_ranges[1],
                             'min_m2': args.src_class_mass_ranges[0]},
-            'mass_bdary': {'ns_max': args.src_class_mass_ranges[1],
-                           'gap_max': args.src_class_mass_ranges[1]},
+            'mass_bdary': {'ns_max': args.src_class_mass_ranges[2],
+                           'gap_max': args.src_class_mass_ranges[2]},
             'estimation_coeff': {'a0': args.src_class_eff_to_lum_distance,
                                  'b0': args.src_class_lum_distance_to_delta[0],
                                  'b1': args.src_class_lum_distance_to_delta[1],

--- a/pycbc/mchirp_area.py
+++ b/pycbc/mchirp_area.py
@@ -67,8 +67,6 @@ def insert_args(parser):
 def from_cli(args):
     mass_limits_sorted = sorted(args.src_class_mass_limits)
     if args.src_class_mass_gap_max:
-        if args.src_class_mass_gap_max < mass_limits_sorted[1]:
-            parser.error('MAX_GAP value cannot be lower than MAX_NS limit')
         return {'mass_limits': {'max_m1': mass_limits_sorted[2],
                                 'min_m2': mass_limits_sorted[0]},
                 'mass_bdary': {'ns_max': mass_limits_sorted[1],

--- a/pycbc/mchirp_area.py
+++ b/pycbc/mchirp_area.py
@@ -67,6 +67,8 @@ def insert_args(parser):
 def from_cli(args):
     mass_limits_sorted = sorted(args.src_class_mass_limits)
     if args.src_class_mass_gap_max:
+        if args.src_class_mass_gap_max < mass_limits_sorted[1]:
+            parser.error('MAX_GAP value cannot be lower than MAX_NS limit')
         return {'mass_limits': {'max_m1': mass_limits_sorted[2],
                                 'min_m2': mass_limits_sorted[0]},
                 'mass_bdary': {'ns_max': mass_limits_sorted[1],


### PR DESCRIPTION
Given the removal of MassGap as a source category in O4 we set the no-mass-gap option as the default behaviour of the code, resulting in a {p(BNS), p(NSBH), p(BBH)} output. 