### PR TITLE
Generate skymaps without sampling / enable pycbc inference to run model with only reconstructed params

### DIFF
--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -146,7 +146,7 @@ with ctx:
 
     # Run the sampler
     sampler.run()
-    
+
     if not pool.is_main_process():
         sys.exit(0)
 

--- a/bin/inference/pycbc_inference_model_stats
+++ b/bin/inference/pycbc_inference_model_stats
@@ -93,7 +93,8 @@ model = models.read_from_config(cp)
 model.sampling_transforms = None
 
 # create function for calling the model to get the stats
-def callmodel(paramvals):
+def callmodel(arg):
+    iteration, paramvals = arg
     # calculate the logposterior to get all stats populated
     model.update(**{p: paramvals[p] for p in model.variable_params})
     _ = model.logposterior
@@ -102,7 +103,8 @@ def callmodel(paramvals):
     rec = {}
     if opts.reconstruct_parameters:
         model.update(**{p: paramvals[p] for p in model.variable_params})
-        rec = model.reconstruct()
+        # Ensure unique random seed for each reconstruction
+        rec = model.reconstruct(seed=iteration)
     return stats, rec
 
 # these help for parallelization for MPI
@@ -126,7 +128,7 @@ logging.info("Loaded %i samples", samples.size)
 
 # get the stats
 logging.info("Calculating stats")
-data = list(pool.map(model_call, samples))
+data = list(pool.map(model_call, enumerate(samples)))
 stats = [x[0] for x in data]
 rec = [x[1] for x in data]
 

--- a/docs/_include/inference_example_single_marg.sh
+++ b/docs/_include/inference_example_single_marg.sh
@@ -1,2 +1,3 @@
 sh ../../examples/inference/single/get.sh
 sh ../../examples/inference/single/run_marg.sh
+sh ../../examples/inference/single/run_instant.sh

--- a/docs/inference/examples/single.rst
+++ b/docs/inference/examples/single.rst
@@ -62,7 +62,7 @@ points are colored by the log likelihood at that point, with the 50th and 90th
 percentile contours drawn.
 
 ------------------------------------------------------------
-Marginalization over parameters
+Marginalization subset of parameters
 ------------------------------------------------------------
 The single template model supports marginalization over its parameters. This
 can greatly speed up parameter estimation. The
@@ -102,6 +102,41 @@ Before demarginalization:
 After demarginalization:
 
 .. image:: ../../_include/single_demarg.png
+   :width: 400
+   :align: center
+
+-----------------------------------------------------------
+Marginalization over all parameters
+-----------------------------------------------------------
+All parameters that the single_template model supports can be marginalized over
+to do so, you would just configure the model section to include each parameter
+(minus any you choose to be static). PyCBC Inference will simply reconstruct
+the missing parameters rather than performing any sampling over the parameter
+space. The number of samples to take from the posterior is configurable.
+
+First, you'll need the configuration file. Note that in the `sampler` section
+you can set the number of samples to draw from the posterior.
+
+.. dropdown:: Configuration File
+    :animate: fade-in-slide-down
+
+    .. literalinclude:: ../../../examples/inference/single/single_instant.ini
+       :language: ini
+
+    :download:`Download <../../../examples/inference/single/single.ini>`
+
+Run this script to use this configuration file:
+
+.. literalinclude:: ../../../examples/inference/single/run_instant.sh
+   :language: bash
+
+:download:`Download <../../../examples/inference/single/run_marg.sh>`
+
+This will create the following plot:
+
+After demarginalization:
+
+.. image:: ../../_include/single_instant.png
    :width: 400
    :align: center
 

--- a/examples/inference/single/run_instant.sh
+++ b/examples/inference/single/run_instant.sh
@@ -1,0 +1,14 @@
+pycbc_inference \
+--config-file `dirname "$0"`/single.ini \
+--nprocesses=8 \
+--output-file single.hdf \
+--seed 0 \
+--force \
+--verbose
+
+pycbc_inference_plot_posterior \
+--input-file single.hdf \
+--output-file single.png \
+--parameters distance inclination polarization coa_phase tc ra dec \
+--z-arg snr --vmin 31.85 --vmax 32.15 \
+

--- a/examples/inference/single/run_instant.sh
+++ b/examples/inference/single/run_instant.sh
@@ -1,14 +1,14 @@
 pycbc_inference \
---config-file `dirname "$0"`/single.ini \
+--config-file `dirname "$0"`/single_instant.ini \
 --nprocesses=8 \
---output-file single.hdf \
+--output-file single_instant.hdf \
 --seed 0 \
 --force \
 --verbose
 
 pycbc_inference_plot_posterior \
---input-file single.hdf \
---output-file single.png \
+--input-file single_instant.hdf \
+--output-file single_instant.png \
 --parameters distance inclination polarization coa_phase tc ra dec \
 --z-arg snr --vmin 31.85 --vmax 32.15 \
 

--- a/examples/inference/single/single_instant.ini
+++ b/examples/inference/single/single_instant.ini
@@ -34,9 +34,7 @@ strain-high-pass = 15
 sample-rate = 2048
 
 [sampler]
-name = dynesty
-dlogz = 0.1
-nlive = 1000
+name = dummy
 num_samples = 5000
 
 [variable_params]

--- a/examples/inference/single/single_instant.ini
+++ b/examples/inference/single/single_instant.ini
@@ -1,0 +1,97 @@
+
+[model]
+name = single_template
+
+#; This model precalculates the SNR time series at a fixed rate.
+#; If you need a higher time resolution, this may be increased
+sample_rate = 16384
+low-frequency-cutoff = 30.0
+
+marginalize_vector_params = tc, ra, dec, polarization, inclination
+marginalize_vector_samples = 1000
+
+marginalize_phase = True
+
+marginalize_distance = True
+marginalize_distance_param = distance
+marginalize_distance_interpolator = True
+marginalize_distance_snr_range = 5, 50
+marginalize_distance_density = 200, 200
+marginalize_distance_samples = 1000
+
+[data]
+instruments = H1 L1 V1
+analysis-start-time = 1187008482
+analysis-end-time = 1187008892
+psd-estimation = median
+psd-segment-length = 16
+psd-segment-stride = 8
+psd-inverse-length = 16
+pad-data = 8
+channel-name = H1:LOSC-STRAIN L1:LOSC-STRAIN V1:LOSC-STRAIN
+frame-files = H1:H-H1_LOSC_CLN_4_V1-1187007040-2048.gwf L1:L-L1_LOSC_CLN_4_V1-1187007040-2048.gwf V1:V-V1_LOSC_CLN_4_V1-1187007040-2048.gwf
+strain-high-pass = 15
+sample-rate = 2048
+
+[sampler]
+name = dynesty
+dlogz = 0.1
+nlive = 1000
+num_samples = 5000
+
+[variable_params]
+; waveform parameters that will vary in MCMC
+#coa_phase =
+distance =
+polarization =
+inclination =
+ra =
+dec =
+tc =
+
+[static_params]
+; waveform parameters that will not change in MCMC
+approximant = TaylorF2
+f_lower = 30
+mass1 = 1.3757
+mass2 = 1.3757
+
+#; we'll choose not to sample over these, but you could
+#polarization = 0
+#ra = 3.44615914
+#dec = -0.40808407
+
+#tc = 1187008882.42825
+
+#; You could also set additional parameters if your waveform model supports / requires it.
+; spin1z = 0
+
+#[prior-coa_phase]
+#name = uniform_angle
+
+#[prior-ra+dec]
+#name = uniform_sky
+
+[prior-ra]
+name = uniform_angle
+
+[prior-dec]
+name = cos_angle
+
+[prior-tc]
+#; coalescence time prior
+name = uniform
+min-tc = 1187008882.4
+max-tc = 1187008882.5
+
+[prior-distance]
+#; following gives a uniform in volume
+name = uniform_radius
+min-distance = 10
+max-distance = 60
+
+[prior-polarization]
+name = uniform_angle
+
+[prior-inclination]
+name = sin_angle

--- a/pycbc/inference/io/posterior.py
+++ b/pycbc/inference/io/posterior.py
@@ -25,7 +25,6 @@
 """
 
 from .base_hdf import BaseInferenceFile
-from .base_sampler import BaseSamplerFile
 
 
 class PosteriorFile(BaseInferenceFile):

--- a/pycbc/inference/io/posterior.py
+++ b/pycbc/inference/io/posterior.py
@@ -25,6 +25,7 @@
 """
 
 from .base_hdf import BaseInferenceFile
+from .base_sampler import BaseSamplerFile
 
 
 class PosteriorFile(BaseInferenceFile):
@@ -37,6 +38,14 @@ class PosteriorFile(BaseInferenceFile):
 
     def write_samples(self, samples, parameters=None):
         return write_samples_to_file(self, samples, parameters=parameters)
+
+    def write_sampler_metadata(self, sampler):
+        sampler.model.write_metadata(self)
+
+    def write_resume_point(self):
+        pass
+
+    write_run_start_time = write_run_end_time = write_resume_point
 
 
 def read_raw_samples_from_file(fp, fields, **kwargs):

--- a/pycbc/inference/models/tools.py
+++ b/pycbc/inference/models/tools.py
@@ -493,10 +493,13 @@ class DistMarg():
         self.marginalize_vector_weights = - numpy.log(self.vsamples)
         return params
 
-    def reconstruct(self):
+    def reconstruct(self, seed=None):
         """ Reconstruct the distance or vectored marginalized parameter
         of this class.
         """
+        if seed:
+            numpy.random.seed(seed)
+
         rec = {}
 
         def get_loglr():

--- a/pycbc/inference/sampler/__init__.py
+++ b/pycbc/inference/sampler/__init__.py
@@ -85,7 +85,7 @@ def load_from_config(cp, model, **kwargs):
     sampler :
         The initialized sampler.
     """
-    if not len(model.variable_params):
+    if len(model.variable_params) == 0:
         logging.info('No variable params, so assuming Dummy Sampler')
         return DummySampler.from_config(cp, model, **kwargs)
 

--- a/pycbc/inference/sampler/__init__.py
+++ b/pycbc/inference/sampler/__init__.py
@@ -17,15 +17,19 @@
 This modules provides a list of implemented samplers for parameter estimation.
 """
 
+import logging
+
 # pylint: disable=unused-import
 from .base import (initial_dist_from_config, create_new_output_file)
 from .multinest import MultinestSampler
 from .ultranest import UltranestSampler
+from .dummy import DummySampler
 
 # list of available samplers
 samplers = {cls.name: cls for cls in (
     MultinestSampler,
     UltranestSampler,
+    DummySampler,
 )}
 
 try:
@@ -81,5 +85,9 @@ def load_from_config(cp, model, **kwargs):
     sampler :
         The initialized sampler.
     """
+    if not len(model.variable_params):
+        logging.info('No variable params, so assuming Dummy Sampler')
+        return DummySampler.from_config(cp, model, **kwargs)
+
     name = cp.get('sampler', 'name')
     return samplers[name].from_config(cp, model, **kwargs)

--- a/pycbc/inference/sampler/base.py
+++ b/pycbc/inference/sampler/base.py
@@ -176,8 +176,8 @@ def setup_output(sampler, output_file, check_nsamples=True, validate=True):
     checkpoint_valid = False
     if validate:
         checkpoint_valid = validate_checkpoint_files(checkpoint_file,
-                                                 backup_file,
-                                                 check_nsamples)
+                                                     backup_file,
+                                                     check_nsamples)
     # Create a new file if the checkpoint doesn't exist, or if it is
     # corrupted
     sampler.new_checkpoint = False  # keeps track if this is a new file or not

--- a/pycbc/inference/sampler/base.py
+++ b/pycbc/inference/sampler/base.py
@@ -154,7 +154,7 @@ class BaseSampler(object):
 #
 
 
-def setup_output(sampler, output_file, check_nsamples=True):
+def setup_output(sampler, output_file, check_nsamples=True, validate=True):
     r"""Sets up the sampler's checkpoint and output files.
 
     The checkpoint file has the same name as the output file, but with
@@ -173,10 +173,11 @@ def setup_output(sampler, output_file, check_nsamples=True):
     backup_file = output_file + '.bkup'
     # check if we have a good checkpoint and/or backup file
     logging.info("Looking for checkpoint file")
-    checkpoint_valid = validate_checkpoint_files(checkpoint_file,
+    checkpoint_valid = False
+    if validate:
+        checkpoint_valid = validate_checkpoint_files(checkpoint_file,
                                                  backup_file,
                                                  check_nsamples)
-
     # Create a new file if the checkpoint doesn't exist, or if it is
     # corrupted
     sampler.new_checkpoint = False  # keeps track if this is a new file or not
@@ -191,6 +192,7 @@ def setup_output(sampler, output_file, check_nsamples=True):
     for fn in [checkpoint_file, backup_file]:
         with sampler.io(fn, "a") as fp:
             fp.write_command_line()
+
             fp.write_resume_point()
             fp.write_run_start_time()
     # store

--- a/pycbc/inference/sampler/dummy.py
+++ b/pycbc/inference/sampler/dummy.py
@@ -1,4 +1,5 @@
-""" Dummy class when no actual sampling is needed
+""" Dummy class when no actual sampling is needed, but we may want to do
+some reconstruction supported by the likelihood model.
 """
 
 import numpy
@@ -9,7 +10,11 @@ from pycbc.pool import choose_pool
 
 from .base import (BaseSampler, setup_output)
 
+
 def call_reconstruct(iteration):
+    """ Accessor to update the global model and call its reconstruction
+    routine.
+    """
     models._global_instance.update()
     return models._global_instance.reconstruct(seed=iteration)
 
@@ -58,7 +63,7 @@ class DummySampler(BaseSampler):
 
     def run(self):
         samples = self.pool.map(call_reconstruct,
-                                      range(self.num_samples))
+                                range(self.num_samples))
         self._samples = {k: numpy.array([x[k] for x in samples])
                          for k in samples[0]}
 

--- a/pycbc/inference/sampler/dummy.py
+++ b/pycbc/inference/sampler/dummy.py
@@ -3,11 +3,11 @@
 
 import numpy
 
-from .base import (BaseSampler, setup_output)
 from pycbc.inference.io import PosteriorFile
 from pycbc.inference import models
-from pycbc.pool import (use_mpi, choose_pool)
+from pycbc.pool import choose_pool
 
+from .base import (BaseSampler, setup_output)
 
 def call_reconstruct(iteration):
     models._global_instance.update()
@@ -23,6 +23,7 @@ class DummySampler(BaseSampler):
         An instance of a model from ``pycbc.inference.models``.
     """
     name = 'dummy'
+
     def __init__(self, model, *args, nprocesses=1, use_mpi=False,
                  num_samples=1000, **kwargs):
         super().__init__(model, *args)

--- a/pycbc/inference/sampler/dummy.py
+++ b/pycbc/inference/sampler/dummy.py
@@ -1,0 +1,78 @@
+""" Dummy class when no actual sampling is needed
+"""
+
+import numpy
+
+from .base import (BaseSampler, setup_output)
+from pycbc.inference.io import PosteriorFile
+from pycbc.inference import models
+from pycbc.pool import (use_mpi, choose_pool)
+
+
+def call_reconstruct(iteration):
+    models._global_instance.update()
+    return models._global_instance.reconstruct(seed=iteration)
+
+
+class DummySampler(BaseSampler):
+    """Dummy sampler for not doing sampling
+
+    Parameters
+    ----------
+    model : Model
+        An instance of a model from ``pycbc.inference.models``.
+    """
+    name = 'dummy'
+    def __init__(self, model, *args, nprocesses=1, use_mpi=False,
+                 num_samples=1000, **kwargs):
+        super().__init__(model, *args)
+
+        models._global_instance = model
+        self.num_samples = int(num_samples)
+        self.pool = choose_pool(mpi=use_mpi, processes=nprocesses)
+        self._samples = {}
+
+    @classmethod
+    def from_config(cls, cp, model, output_file=None, nprocesses=1,
+                    use_mpi=False):
+        """This should initialize the sampler given a config file.
+        """
+        kwargs = {k: cp.get('sampler', k) for k in cp.options('sampler')}
+        obj = cls(model, nprocesses=nprocesses, use_mpi=use_mpi, **kwargs)
+        setup_output(obj, output_file, check_nsamples=False, validate=False)
+        return obj
+
+    @property
+    def samples(self):
+        """A dict mapping variable_params to arrays of samples currently
+        in memory. The dictionary may also contain sampling_params.
+
+        The sample arrays may have any shape, and may or may not be thinned.
+        """
+        return self._samples
+
+    @property
+    def model_stats(self):
+        pass
+
+    def run(self):
+        samples = self.pool.map(call_reconstruct,
+                                      range(self.num_samples))
+        self._samples = {k: numpy.array([x[k] for x in samples])
+                         for k in samples[0]}
+
+    def finalize(self):
+        with self.io(self.checkpoint_file, "a") as fp:
+            fp.write_samples(samples=self._samples)
+
+    checkpoint = resume_from_checkpoint = run
+
+    @property
+    def io(self):
+        """A class that inherits from ``BaseInferenceFile`` to handle IO with
+        an hdf file.
+
+        This should be a class, not an instance of class, so that the sampler
+        can initialize it when needed.
+        """
+        return PosteriorFile


### PR DESCRIPTION
Depends on #4093 

This adds a dummy sampler that enables pycbc inference to generate results without requiring the model to have any params that need to be sampled over. This is useful for most uses of the single_template model as all parameters can be effectively marginalized over. One can simply set the sampler to 'dummy' and give a 'num_samples' option. 

I've added an example config file + run script which demonstrates generating the GW170817 results for all parameters the single template model supports. 

