### PR TITLE
Cythonization of time_coincidence

### DIFF
--- a/pycbc/events/eventmgr_cython.pyx
+++ b/pycbc/events/eventmgr_cython.pyx
@@ -82,28 +82,6 @@ def logsignalrateinternals_computepsignalbins(
 @boundscheck(False)
 @wraparound(False)
 @cdivision(True)
-def timecoincidence_constructfold(
-    double[:] fold1,
-    double[:] fold2,
-    double[:] t1,
-    double[:] t2,
-    double slide_step,
-    int length1,
-    int length2
-):
-    cdef:
-        int idx
-
-    for idx in range(length1):
-        fold1[idx] = t1[idx] % slide_step
-
-    for idx in range(length2):
-        fold2[idx] = t2[idx] % slide_step
-
-
-@boundscheck(False)
-@wraparound(False)
-@cdivision(True)
 def logsignalrateinternals_compute2detrate(
     int[:] nbinned0,
     int[:] nbinned1,
@@ -140,6 +118,28 @@ def logsignalrateinternals_compute2detrate(
         # Scale by signal population SNR
         rescale_fac = ref_snr / sref[ridx]
         rate[ridx] *= (rescale_fac*rescale_fac*rescale_fac*rescale_fac)
+
+
+@boundscheck(False)
+@wraparound(False)
+@cdivision(True)
+def timecoincidence_constructfold(
+    double[:] fold1,
+    double[:] fold2,
+    double[:] t1,
+    double[:] t2,
+    double slide_step,
+    int length1,
+    int length2
+):
+    cdef:
+        int idx
+
+    for idx in range(length1):
+        fold1[idx] = t1[idx] % slide_step
+
+    for idx in range(length2):
+        fold2[idx] = t2[idx] % slide_step
 
 
 @boundscheck(False)

--- a/pycbc/events/eventmgr_cython.pyx
+++ b/pycbc/events/eventmgr_cython.pyx
@@ -209,7 +209,7 @@ def timecoincidence_getslideint(
     length = idx1.shape[0]
 
     for idx in range(length):
-        diff = (t1[idx1[idx]] / slide_step) - (t2[idx2[idx]] / slide_step)
+        diff = (t1[idx1[idx]] - t2[idx2[idx]]) / slide_step
         slide[idx] = <int>(cround(diff))
 
 

--- a/pycbc/events/eventmgr_cython.pyx
+++ b/pycbc/events/eventmgr_cython.pyx
@@ -2,6 +2,7 @@ import numpy as np
 cimport numpy as cnp
 from cython import wraparound, boundscheck, cdivision
 from libc.math cimport M_PI, sqrt
+from libc.math cimport round as cround
 
 
 ctypedef fused REALTYPE:
@@ -193,6 +194,7 @@ def timecoincidence_constructidxs(
 @boundscheck(False)
 @wraparound(False)
 @cdivision(True)
+def timecoincidence_getslideint(
 def timecoincidence_getslideint(
     int [:] slide,
     double[:] t1,

--- a/pycbc/events/eventmgr_cython.pyx
+++ b/pycbc/events/eventmgr_cython.pyx
@@ -195,7 +195,6 @@ def timecoincidence_constructidxs(
 @wraparound(False)
 @cdivision(True)
 def timecoincidence_getslideint(
-def timecoincidence_getslideint(
     int [:] slide,
     double[:] t1,
     double[:] t2,


### PR DESCRIPTION
Another optimization patch. This moves a number of elements of `time_coincidence` into cython to speed up calls into this code from pycbc_live (probably this won't make any difference to the offline use case, but the online use case of "call this lots of times with reasonably small inputs" is impacted by this, which impacts latency for alerts).

This is passing the test case (when I uploaded this), and doesn't change anything functionally, it's just moving a bunch of stuff into cython.