### PR TITLE
Cache memory for trig_stat to avoid resize

### DIFF
--- a/pycbc/events/coinc.py
+++ b/pycbc/events/coinc.py
@@ -796,6 +796,8 @@ class LiveCoincTimeslideBackgroundEstimator(object):
 
         self.singles = {}
 
+        # temporary array used in `_find_coincs()` to turn `trig_stat`
+        # into an array much faster than using `numpy.resize()`
         self.trig_stat_memory = None
 
     @classmethod

--- a/pycbc/events/coinc.py
+++ b/pycbc/events/coinc.py
@@ -796,6 +796,8 @@ class LiveCoincTimeslideBackgroundEstimator(object):
 
         self.singles = {}
 
+        self.trig_stat_memory = None
+
     @classmethod
     def pick_best_coinc(cls, coinc_results):
         """Choose the best two-ifo coinc by ifar first, then statistic if needed.
@@ -1076,11 +1078,21 @@ class LiveCoincTimeslideBackgroundEstimator(object):
                 # NB for some statistics the "stat" entry holds more than just
                 # a ranking number. E.g. for the phase time consistency test,
                 # it must also contain the phase, time and sensitivity.
-                trig_stat = numpy.resize(trig_stat, len(i1))
+                if self.trig_stat_memory is None:
+                    self.trig_stat_memory = numpy.zeros(
+                        1,
+                        dtype=trig_stat.dtype
+                    )
+                while len(self.trig_stat_memory) < len(i1):
+                    self.trig_stat_memory = numpy.resize(
+                        self.trig_stat_memory,
+                        len(self.trig_stat_memory)*2
+                    )
+                self.trig_stat_memory[:len(i1)] = trig_stat
 
                 # Force data into form needed by stat.py and then compute the
                 # ranking statistic values.
-                sngls_list = [[fixed_ifo, trig_stat],
+                sngls_list = [[fixed_ifo, self.trig_stat_memory[:len(i1)]],
                               [shift_ifo, stats[i1]]]
                 c = self.stat_calculator.rank_stat_coinc(
                     sngls_list,


### PR DESCRIPTION
Another patch designed to speed up the PyCBC Live main process: The operation whereby details about the single trigger from ifo 1 is repeated with the N triggers from ifo 2 using numpy.resize is slow. If we instead cache a suitable amount of memory (which will be completely negligible compared to memory usage elsewhere) this can be done much more quickly with a direct assignment.