### PR TITLE
Implement cython version of cluster_over_time

### DIFF
--- a/bin/all_sky_search/pycbc_combine_statmap
+++ b/bin/all_sky_search/pycbc_combine_statmap
@@ -118,11 +118,14 @@ ifar_stat = numpy.core.records.fromarrays([f['foreground/ifar'][:],
 # all_times is a tuple of trigger time arrays
 all_times = (f['foreground/%s/time' % ifo][:] for ifo in all_ifos)
 
+def argmax(v):
+    return numpy.argsort(v)[-1]
+
 # Currently only clustering zerolag, i.e. foreground, so set all timeslide_ids
 # to zero
 cidx = pycbc.events.cluster_coincs_multiifo(ifar_stat, all_times,
                                             numpy.zeros(len(ifar_stat)), 0,
-                                            args.cluster_window)
+                                            args.cluster_window, argmax)
 
 def filter_dataset(h5file, name, idx):
     # Dataset needs to be deleted and remade as it is a different size

--- a/bin/all_sky_search/pycbc_combine_statmap
+++ b/bin/all_sky_search/pycbc_combine_statmap
@@ -118,14 +118,11 @@ ifar_stat = numpy.core.records.fromarrays([f['foreground/ifar'][:],
 # all_times is a tuple of trigger time arrays
 all_times = (f['foreground/%s/time' % ifo][:] for ifo in all_ifos)
 
-def argmax(v):
-    return numpy.argsort(v)[-1]
-
 # Currently only clustering zerolag, i.e. foreground, so set all timeslide_ids
 # to zero
 cidx = pycbc.events.cluster_coincs_multiifo(ifar_stat, all_times,
                                             numpy.zeros(len(ifar_stat)), 0,
-                                            args.cluster_window, argmax)
+                                            args.cluster_window)
 
 def filter_dataset(h5file, name, idx):
     # Dataset needs to be deleted and remade as it is a different size

--- a/pycbc/events/coinc.py
+++ b/pycbc/events/coinc.py
@@ -429,7 +429,7 @@ def cluster_coincs_multiifo(stat, time_coincs, timeslide_id, slide, window, argm
 
     span = (time_avg.max() - time_avg.min()) + window * 10
     time_avg = time_avg + span * tslide
-    cidx = cluster_over_time(stat, time_avg, window, argmax)
+    cidx = cluster_over_time(stat, time_avg, window, argmax=argmax)
 
     return cidx
 

--- a/pycbc/events/coinc.py
+++ b/pycbc/events/coinc.py
@@ -509,7 +509,8 @@ def cluster_over_time(stat, time, window, method='python',
                 i += 1
                 continue
 
-            # Find the location of the maximum within the time interval around i
+            # Find the location of the maximum within the time interval
+            # around i
             max_loc = argmax(stat[l:r]) + l
 
             # If this point is the max, we can skip to the right boundary

--- a/pycbc/events/coinc.py
+++ b/pycbc/events/coinc.py
@@ -381,7 +381,8 @@ def cluster_coincs(stat, time1, time2, timeslide_id, slide, window, **kwargs):
     return cidx
 
 
-def cluster_coincs_multiifo(stat, time_coincs, timeslide_id, slide, window, argmax=numpy.argmax):
+def cluster_coincs_multiifo(stat, time_coincs, timeslide_id, slide, window,
+                            **kwargs):
     """Cluster coincident events for each timeslide separately, across
     templates, based on the ranking statistic
 
@@ -429,7 +430,7 @@ def cluster_coincs_multiifo(stat, time_coincs, timeslide_id, slide, window, argm
 
     span = (time_avg.max() - time_avg.min()) + window * 10
     time_avg = time_avg + span * tslide
-    cidx = cluster_over_time(stat, time_avg, window, argmax=argmax)
+    cidx = cluster_over_time(stat, time_avg, window, **kwargs)
 
     return cidx
 

--- a/pycbc/events/coinc.py
+++ b/pycbc/events/coinc.py
@@ -334,7 +334,7 @@ def time_multi_coincidence(times, slide_step=0, slop=.003,
     return ids, slide
 
 
-def cluster_coincs(stat, time1, time2, timeslide_id, slide, window):
+def cluster_coincs(stat, time1, time2, timeslide_id, slide, window, **kwargs):
     """Cluster coincident events for each timeslide separately, across
     templates, based on the ranking statistic
 
@@ -377,7 +377,7 @@ def cluster_coincs(stat, time1, time2, timeslide_id, slide, window):
 
     span = (time.max() - time.min()) + window * 10
     time = time + span * tslide
-    cidx = cluster_over_time(stat, time, window)
+    cidx = cluster_over_time(stat, time, window, **kwargs)
     return cidx
 
 
@@ -429,7 +429,7 @@ def cluster_coincs_multiifo(stat, time_coincs, timeslide_id, slide, window, argm
 
     span = (time_avg.max() - time_avg.min()) + window * 10
     time_avg = time_avg + span * tslide
-    cidx = cluster_over_time(stat, time_avg, window)
+    cidx = cluster_over_time(stat, time_avg, window, argmax=argmax)
 
     return cidx
 
@@ -457,7 +457,8 @@ def mean_if_greater_than_zero(vals):
     return vals[above_zero].mean(), above_zero.sum()
 
 
-def cluster_over_time(stat, time, window):
+def cluster_over_time(stat, time, window, method='python',
+                      argmax=numpy.argmax):
     """Cluster generalized transient events over time via maximum stat over a
     symmetric sliding window
 
@@ -469,6 +470,11 @@ def cluster_over_time(stat, time, window):
         time to use for clustering
     window: float
         length to cluster over
+    method: string
+        Either "cython" to use the cython implementation, or "python" to use
+        the pure python version.
+    argmax: function
+        the function used to calculate the maximum value
 
     Returns
     -------
@@ -486,9 +492,41 @@ def cluster_over_time(stat, time, window):
     right = numpy.searchsorted(time, time + window)
     indices = numpy.zeros(len(left), dtype=numpy.uint32)
 
-    # The clustered events are stored in indices. j is the number of
-    # clustered events.
-    j = timecluster_cython(indices, left, right, stat, len(left))
+    if method == 'cython':
+        j = timecluster_cython(indices, left, right, stat, len(left))
+    elif method == 'python':
+        # i is the index we are inspecting, j is the next one to save
+        i = 0
+        j = 0
+        while i < len(left):
+            l = left[i]
+            r = right[i]
+
+            # If there are no other points to compare it is obviously the max
+            if (r - l) == 1:
+                indices[j] = i
+                j += 1
+                i += 1
+                continue
+
+            # Find the location of the maximum within the time interval
+            # around i
+            max_loc = argmax(stat[l:r]) + l
+
+            # If this point is the max, we can skip to the right boundary
+            if max_loc == i:
+                indices[j] = i
+                i = r
+                j += 1
+
+            # If the max is later than i, we can skip to it
+            elif max_loc > i:
+                i = max_loc
+
+            elif max_loc < i:
+                i += 1
+    else:
+        raise ValueError(f'Do not recognize method {method}')
 
     indices = indices[:j]
 
@@ -1152,7 +1190,8 @@ class LiveCoincTimeslideBackgroundEstimator(object):
 
             cidx = cluster_coincs(cstat, ctime0, ctime1, offsets,
                                   self.timeslide_interval,
-                                  self.analysis_block)
+                                  self.analysis_block,
+                                  method='cython')
             offsets = offsets[cidx]
             zerolag_idx = (offsets == 0)
             bkg_idx = (offsets != 0)

--- a/pycbc/events/coinc.py
+++ b/pycbc/events/coinc.py
@@ -381,7 +381,7 @@ def cluster_coincs(stat, time1, time2, timeslide_id, slide, window):
     return cidx
 
 
-def cluster_coincs_multiifo(stat, time_coincs, timeslide_id, slide, window):
+def cluster_coincs_multiifo(stat, time_coincs, timeslide_id, slide, window, argmax=numpy.argmax):
     """Cluster coincident events for each timeslide separately, across
     templates, based on the ranking statistic
 

--- a/pycbc/events/coinc.py
+++ b/pycbc/events/coinc.py
@@ -381,7 +381,7 @@ def cluster_coincs(stat, time1, time2, timeslide_id, slide, window):
     return cidx
 
 
-def cluster_coincs_multiifo(stat, time_coincs, timeslide_id, slide, window, argmax=numpy.argmax):
+def cluster_coincs_multiifo(stat, time_coincs, timeslide_id, slide, window):
     """Cluster coincident events for each timeslide separately, across
     templates, based on the ranking statistic
 

--- a/pycbc/events/coinc.py
+++ b/pycbc/events/coinc.py
@@ -33,6 +33,7 @@ from .eventmgr_cython import timecoincidence_constructidxs
 from .eventmgr_cython import timecoincidence_constructfold
 from .eventmgr_cython import timecoincidence_getslideint
 from .eventmgr_cython import timecoincidence_findidxlen
+from .eventmgr_cython import timecluster_cython
 
 
 def background_bin_from_string(background_bins, data):
@@ -333,7 +334,7 @@ def time_multi_coincidence(times, slide_step=0, slop=.003,
     return ids, slide
 
 
-def cluster_coincs(stat, time1, time2, timeslide_id, slide, window, argmax=numpy.argmax):
+def cluster_coincs(stat, time1, time2, timeslide_id, slide, window, **kwargs):
     """Cluster coincident events for each timeslide separately, across
     templates, based on the ranking statistic
 
@@ -376,7 +377,7 @@ def cluster_coincs(stat, time1, time2, timeslide_id, slide, window, argmax=numpy
 
     span = (time.max() - time.min()) + window * 10
     time = time + span * tslide
-    cidx = cluster_over_time(stat, time, window, argmax)
+    cidx = cluster_over_time(stat, time, window, **kwargs)
     return cidx
 
 
@@ -456,7 +457,8 @@ def mean_if_greater_than_zero(vals):
     return vals[above_zero].mean(), above_zero.sum()
 
 
-def cluster_over_time(stat, time, window, argmax=numpy.argmax):
+def cluster_over_time(stat, time, window, method='python',
+                      argmax=numpy.argmax):
     """Cluster generalized transient events over time via maximum stat over a
     symmetric sliding window
 
@@ -468,6 +470,9 @@ def cluster_over_time(stat, time, window, argmax=numpy.argmax):
         time to use for clustering
     window: float
         length to cluster over
+    method: string
+        Either "cython" to use the cython implementation, or "python" to use
+        the pure python version.
     argmax: function
         the function used to calculate the maximum value
 
@@ -487,35 +492,40 @@ def cluster_over_time(stat, time, window, argmax=numpy.argmax):
     right = numpy.searchsorted(time, time + window)
     indices = numpy.zeros(len(left), dtype=numpy.uint32)
 
-    # i is the index we are inspecting, j is the next one to save
-    i = 0
-    j = 0
-    while i < len(left):
-        l = left[i]
-        r = right[i]
+    if method == 'cython':
+        j = timecluster_cython(indices, left, right, stat, len(left))
+    elif method == 'python':
+        # i is the index we are inspecting, j is the next one to save
+        i = 0
+        j = 0
+        while i < len(left):
+            l = left[i]
+            r = right[i]
 
-        # If there are no other points to compare it is obviously the max
-        if (r - l) == 1:
-            indices[j] = i
-            j += 1
-            i += 1
-            continue
+            # If there are no other points to compare it is obviously the max
+            if (r - l) == 1:
+                indices[j] = i
+                j += 1
+                i += 1
+                continue
 
-        # Find the location of the maximum within the time interval around i
-        max_loc = argmax(stat[l:r]) + l
+            # Find the location of the maximum within the time interval around i
+            max_loc = argmax(stat[l:r]) + l
 
-        # If this point is the max, we can skip to the right boundary
-        if max_loc == i:
-            indices[j] = i
-            i = r
-            j += 1
+            # If this point is the max, we can skip to the right boundary
+            if max_loc == i:
+                indices[j] = i
+                i = r
+                j += 1
 
-        # If the max is later than i, we can skip to it
-        elif max_loc > i:
-            i = max_loc
+            # If the max is later than i, we can skip to it
+            elif max_loc > i:
+                i = max_loc
 
-        elif max_loc < i:
-            i += 1
+            elif max_loc < i:
+                i += 1
+    else:
+        raise ValueError(f'Do not recognize method {method}')
 
     indices = indices[:j]
 
@@ -1178,8 +1188,9 @@ class LiveCoincTimeslideBackgroundEstimator(object):
             ctime1 = numpy.concatenate(ctimes[self.ifos[1]]).astype(numpy.float64)
 
             cidx = cluster_coincs(cstat, ctime0, ctime1, offsets,
-                                      self.timeslide_interval,
-                                      self.analysis_block)
+                                  self.timeslide_interval,
+                                  self.analysis_block,
+                                  method='cython')
             offsets = offsets[cidx]
             zerolag_idx = (offsets == 0)
             bkg_idx = (offsets != 0)

--- a/pycbc/events/eventmgr_cython.pyx
+++ b/pycbc/events/eventmgr_cython.pyx
@@ -253,3 +253,55 @@ def coincbuffer_numgreater(
     for idx in range(length):
         count += cbuffer[idx] > value
     return count
+
+
+@boundscheck(False)
+@wraparound(False)
+@cdivision(True)
+def timecluster_cython(
+    unsigned int[:] indices,
+    long int[:] left,
+    long int[:] right,
+    double[:] stat,
+    int leftlen,
+):
+    cdef:
+        int i, j, k, max_loc
+        long int l, r
+        double max_val
+
+    # i is the index we are inspecting, j is the next one to save
+    i = 0
+    j = 0
+    while i < leftlen:
+        l = left[i]
+        r = right[i]
+
+        # If there are no other points to compare it is obviously the max
+        if (r - l) == 1:
+            indices[j] = i
+            j += 1
+            i += 1
+            continue
+
+        # Find the location of the maximum within the time interval around i
+        # Following block replaces max_loc = argmax(stat[l:r]) + l
+        max_val = -99999999999
+        for k in range(l, r):
+            if stat[k] > max_val:
+                max_val = stat[k]
+                max_loc = k
+
+        # If this point is the max, we can skip to the right boundary
+        if max_loc == i:
+            indices[j] = i
+            i = r
+            j += 1
+
+        # If the max is later than i, we can skip to it
+        elif max_loc > i:
+            i = max_loc
+
+        elif max_loc < i:
+            i += 1
+    return j

--- a/pycbc/events/eventmgr_cython.pyx
+++ b/pycbc/events/eventmgr_cython.pyx
@@ -262,13 +262,13 @@ def timecluster_cython(
     unsigned int[:] indices,
     long int[:] left,
     long int[:] right,
-    double[:] stat,
+    REALTYPE[:] stat,
     int leftlen,
 ):
     cdef:
         int i, j, k, max_loc
         long int l, r
-        double max_val
+        REALTYPE max_val
 
     # i is the index we are inspecting, j is the next one to save
     i = 0


### PR DESCRIPTION
Yet another patch to speed up the PyCBC Live main process.

`cluster_over_time` is a contributing factor to the latency. Both the while/for loops and the repeated `argmax` calls are contributing. Here, I rewrite all of it in cython. The loops are just copies of the python code, I then just replaced `argmax` with a basic version of that in cython. Currently I do *not* delete the old code, and the offline code would use the python implementation by default. @ahnitz is there any reason not to just use the cython code everywhere? I'm concerned about the GPU use case (ie. why was there an option not to use `numpy.argmax` in the first place ... That only makes sense if this has been optimized for GPUs (?)). I don't think continuing to use the python code will impact the offline search, it's again a case of the online search making repeated calls with small array sizes, that makes these things a problem.