### PR TITLE
Cythonize main part of ifar function

### DIFF
--- a/pycbc/events/coinc.py
+++ b/pycbc/events/coinc.py
@@ -28,6 +28,7 @@ coincident triggers.
 import numpy, logging, pycbc.pnutils, pycbc.conversions, copy, lal
 from pycbc.detector import Detector, ppdets
 from .eventmgr_cython import coincbuffer_expireelements
+from .eventmgr_cython import coincbuffer_numgreater
 
 
 def background_bin_from_string(background_bins, data):
@@ -738,7 +739,7 @@ class CoincExpireBuffer(object):
 
     def num_greater(self, value):
         """Return the number of elements larger than 'value'"""
-        return (self.buffer[:self.index] > value).sum()
+        return coincbuffer_numgreater(self.buffer, self.index, value)
 
     @property
     def data(self):

--- a/pycbc/events/eventmgr_cython.pyx
+++ b/pycbc/events/eventmgr_cython.pyx
@@ -142,3 +142,21 @@ def coincbuffer_expireelements(
             keep_count += 1
 
     return keep_count
+
+
+@boundscheck(False)
+@wraparound(False)
+@cdivision(True)
+def coincbuffer_numgreater(
+    float[:] cbuffer,
+    int length,
+    float value
+):
+    cdef:
+        int idx, count
+
+    count = 0
+    for idx in range(length):
+        if cbuffer[idx] > value:
+            count += 1
+    return count

--- a/pycbc/events/eventmgr_cython.pyx
+++ b/pycbc/events/eventmgr_cython.pyx
@@ -157,6 +157,5 @@ def coincbuffer_numgreater(
 
     count = 0
     for idx in range(length):
-        if cbuffer[idx] > value:
-            count += 1
+        count += cbuffer[idx] > value
     return count


### PR DESCRIPTION
Guess what? Another optimization patch for the PyCBC Live main function.

In this case we target the `ifar` function. This is not as impactful as some of the others (the function is about 6-8% of total runtime, and this speeds it up by about a factor of 2). But in terms of "we really want this to be as fast as possible", and "this patch doesn't change anything functionally", it's worth doing.