### PR TITLE
Methods preferred over top-level functions

### DIFF
--- a/pycbc/events/coinc.py
+++ b/pycbc/events/coinc.py
@@ -206,8 +206,8 @@ def time_coincidence(t1, t2, window, slide_step=0):
         fold2 = numpy.concatenate([fold2 - slide_step, fold2,
                                    fold2 + slide_step])
 
-    left = numpy.searchsorted(fold2, fold1 - window)
-    right = numpy.searchsorted(fold2, fold1 + window)
+    left = fold2.searchsorted(fold1 - window)
+    right = fold2.searchsorted(fold1 + window)
 
     lenidx = timecoincidence_findidxlen(left, right, len(left))
     idx1 = numpy.zeros(lenidx, dtype=numpy.uint32)
@@ -296,8 +296,8 @@ def time_multi_coincidence(times, slide_step=0, slop=.003,
         for ifo2 in ids:
             logging.info('added ifo %s, testing against %s' % (ifo1, ifo2))
             w = win(ifo1, ifo2)
-            left = numpy.searchsorted(time1, ctimes[ifo2] - w)
-            right = numpy.searchsorted(time1, ctimes[ifo2] + w)
+            left = time1.searchsorted(ctimes[ifo2] - w)
+            right = time2.searchsorted(ctimes[ifo2] + w)
             # Any times within time1 coincident with the time in ifo2 have
             # indices between 'left' and 'right'
             # 'nz' indexes into times in ifo2 which have coincidences with ifo1
@@ -483,8 +483,8 @@ def cluster_over_time(stat, time, window, argmax=numpy.argmax):
     stat = stat[time_sorting]
     time = time[time_sorting]
 
-    left = numpy.searchsorted(time, time - window)
-    right = numpy.searchsorted(time, time + window)
+    left = time.searchsorted(time - window)
+    right = time.searchsorted(time + window)
     indices = numpy.zeros(len(left), dtype=numpy.uint32)
 
     # i is the index we are inspecting, j is the next one to save

--- a/pycbc/events/coinc.py
+++ b/pycbc/events/coinc.py
@@ -297,7 +297,7 @@ def time_multi_coincidence(times, slide_step=0, slop=.003,
             logging.info('added ifo %s, testing against %s' % (ifo1, ifo2))
             w = win(ifo1, ifo2)
             left = time1.searchsorted(ctimes[ifo2] - w)
-            right = time2.searchsorted(ctimes[ifo2] + w)
+            right = time1.searchsorted(ctimes[ifo2] + w)
             # Any times within time1 coincident with the time in ifo2 have
             # indices between 'left' and 'right'
             # 'nz' indexes into times in ifo2 which have coincidences with ifo1

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -521,7 +521,7 @@ class PhaseTDStatistic(QuadratureSumStatistic):
         # to use as reference for choosing the signal histogram.
         snrs = numpy.array([numpy.array(stats[ifo]['snr'], ndmin=1)
                            for ifo in self.ifos])
-        smin = numpy.argmin(snrs, axis=0)
+        smin = snrs.argmin(axis=0)
         # Store a list of the triggers using each ifo as reference
         rtypes = {ifo: numpy.where(smin == j)[0]
                   for j, ifo in enumerate(self.ifos)}


### PR DESCRIPTION
This is now the final patch on my "optimize pycbc live's main process" development branch.

Hopefully this is straightforward: When dealing with relatively small arrays it is more efficient to use methods of arrays, rather than numpy functions (as then you don't have to figure out types, and decide what function to use). This changes the cases that are used most often, and are visible on a call graph.

There are then only a few functions (`searchsorted` for e.g.) which are still sped up by using `export NUMPY_EXPERIMENTAL_ARRAY_FUNCTION=0`, but I've done my best to minimize the effect of forgetting to set this (or when numpy disables it as promised in the future). 