### PR TITLE
set consistent phase convention for inference models / maybe bugfix? 

### DIFF
--- a/pycbc/inference/models/gaussian_noise.py
+++ b/pycbc/inference/models/gaussian_noise.py
@@ -950,7 +950,7 @@ class GaussianNoise(BaseGaussianNoise):
                 h[self._kmin[det]:kmax] *= self._weight[det][slc]
 
                 # the inner products
-                cplx_hd = self._whitened_data[det][slc].inner(h[slc])  # <h, d>
+                cplx_hd = h[slc].inner(self._whitened_data[det][slc])  # <h, d>
                 hh = h[slc].inner(h[slc]).real  # < h, h>
             cplx_loglr = cplx_hd - 0.5 * hh
             # store

--- a/pycbc/inference/models/marginalized_gaussian_noise.py
+++ b/pycbc/inference/models/marginalized_gaussian_noise.py
@@ -184,8 +184,8 @@ class MarginalizedPhaseGaussianNoise(GaussianNoise):
                 # calculate inner products
                 hh_i = h[self._kmin[det]:kmax].inner(
                     h[self._kmin[det]:kmax]).real
-                hd_i = self._whitened_data[det][self._kmin[det]:kmax].inner(
-                    h[self._kmin[det]:kmax])
+                hd_i = h[self._kmin[det]:kmax].inner(
+                    self._whitened_data[det][self._kmin[det]:kmax])
             # store
             setattr(self._current_stats, '{}_optimal_snrsq'.format(det), hh_i)
             hh += hh_i
@@ -467,8 +467,8 @@ class MarginalizedPolarization(DistMarg, BaseGaussianNoise):
             # h = fp * hp + hc * hc
             # <h, d> = fp * <hp,d> + fc * <hc,d>
             # the inner products
-            cplx_hpd = self._whitened_data[det][slc].inner(hp[slc])  # <hp, d>
-            cplx_hcd = self._whitened_data[det][slc].inner(hc[slc])  # <hc, d>
+            cplx_hpd = hp[slc].inner(self._whitened_data[det][slc])  # <hp, d>
+            cplx_hcd = hc[slc].inner(self._whitened_data[det][slc])  # <hc, d>
 
             cplx_hd = fp * cplx_hpd + fc * cplx_hcd
 

--- a/pycbc/inference/models/relbin_cpu.pyx
+++ b/pycbc/inference/models/relbin_cpu.pyx
@@ -6,8 +6,11 @@ cdef extern from "complex.h":
     double complex conj(double complex)
     double real(double complex)
 
-cimport cython
+import numpy
+cimport cython, numpy
 
+# Used for calculating the cross terms of
+# two signals when analyzing multiple signals
 cpdef likelihood_parts_multi(double [::1] freqs,
                      double fp,
                      double fc,
@@ -40,6 +43,9 @@ cpdef likelihood_parts_multi(double [::1] freqs,
         r0 = r0n
     return hd
 
+# Used for calculating the cross terms of
+# two signals when analyzing multiple signals
+# + allows for frequency-varying antenna response
 cpdef likelihood_parts_multi_v(double [::1] freqs,
                      double[::1] fp,
                      double[::1] fc,
@@ -74,6 +80,7 @@ cpdef likelihood_parts_multi_v(double [::1] freqs,
         r0 = r0n
     return hd
 
+# Standard likelihood
 cpdef likelihood_parts(double [::1] freqs,
                      double fp,
                      double fc,
@@ -105,8 +112,9 @@ cpdef likelihood_parts(double [::1] freqs,
 
         r0 = r0n
         x0 = x0n
-    return hd, hh
+    return conj(hd), hh
 
+# Likelihood where no antenna response is applied
 cpdef likelihood_parts_det(double [::1] freqs,
                      double dtc,
                      double complex[::1] hp,
@@ -136,8 +144,9 @@ cpdef likelihood_parts_det(double [::1] freqs,
 
         r0 = r0n
         x0 = x0n
-    return hd, hh
+    return conj(hd), hh
 
+# Used where the antenna response may be frequency varying
 cpdef likelihood_parts_v(double [::1] freqs,
                      double[::1] fp,
                      double[::1] fc,
@@ -169,4 +178,93 @@ cpdef likelihood_parts_v(double [::1] freqs,
 
         r0 = r0n
         x0 = x0n
-    return hd, hh
+    return conj(hd), hh
+
+# Standard likelihood but simultaneously handling multiple sky or time points
+cpdef likelihood_parts_vector(double [::1] freqs,
+                     double[::1] fp,
+                     double[::1] fc,
+                     double[::1] dtc,
+                     double complex[::1] hp,
+                     double complex[::1] hc,
+                     double complex[::1] h00,
+                     double complex[::1] a0,
+                     double complex[::1] a1,
+                     double [::1] b0,
+                     double [::1] b1,
+                     ) :
+    cdef size_t i
+    cdef double complex hd, r0, r0n, r1, x0, x0n, x1
+    cdef double hh
+    N = freqs.shape[0]
+    num_samples = fp.shape[0]
+
+    cdef numpy.ndarray[numpy.complex128_t, ndim=1] hdv = numpy.empty(num_samples, dtype=numpy.complex128)
+    cdef numpy.ndarray[numpy.float64_t, ndim=1] hhv = numpy.empty(num_samples, dtype=numpy.float64)
+
+    for j in range(num_samples):
+        hd = 0
+        hh = 0
+        for i in range(N):
+            r0n = (exp(-2.0j * 3.141592653 * dtc[j] * freqs[i])
+                   * (fp[j] * hp[i] + fc[j] * hc[i])) / h00[i]
+            r1 = r0n - r0
+
+            x0n = norm(r0n)
+            x1 = x0n - x0
+
+            if i > 0:
+                hd += a0[i-1] * r0 + a1[i-1] * r1
+                hh += real(b0[i-1] * x0 + b1[i-1] * x1)
+
+            r0 = r0n
+            x0 = x0n
+        hdv[j] = conj(hd)
+        hhv[j] = hh
+    return hdv, hhv
+
+# Like above, but if only polarization is marginalized
+# this is a slow implementation and the loop should be inverted /
+# refactored to do each pol separately and then combine
+# included as is for testing purposes
+cpdef likelihood_parts_vectorp(double [::1] freqs,
+                     double[::1] fp,
+                     double[::1] fc,
+                     double dtc,
+                     double complex[::1] hp,
+                     double complex[::1] hc,
+                     double complex[::1] h00,
+                     double complex[::1] a0,
+                     double complex[::1] a1,
+                     double [::1] b0,
+                     double [::1] b1,
+                     ) :
+    cdef size_t i
+    cdef double complex hd, r0, r0n, r1, x0, x0n, x1
+    cdef double hh
+    N = freqs.shape[0]
+    num_samples = fp.shape[0]
+
+    cdef numpy.ndarray[numpy.complex128_t, ndim=1] hdv = numpy.empty(num_samples, dtype=numpy.complex128)
+    cdef numpy.ndarray[numpy.float64_t, ndim=1] hhv = numpy.empty(num_samples, dtype=numpy.float64)
+
+    for j in range(num_samples):
+        hd = 0
+        hh = 0
+        for i in range(N):
+            r0n = (exp(-2.0j * 3.141592653 * dtc * freqs[i])
+                   * (fp[j] * hp[i] + fc[j] * hc[i])) / h00[i]
+            r1 = r0n - r0
+
+            x0n = norm(r0n)
+            x1 = x0n - x0
+
+            if i > 0:
+                hd += a0[i-1] * r0 + a1[i-1] * r1
+                hh += real(b0[i-1] * x0 + b1[i-1] * x1)
+
+            r0 = r0n
+            x0 = x0n
+        hdv[j] = conj(hd)
+        hhv[j] = hh
+    return hdv, hhv

--- a/pycbc/inference/models/single_template.py
+++ b/pycbc/inference/models/single_template.py
@@ -187,7 +187,7 @@ class SingleTemplate(DistMarg, BaseGaussianNoise):
 
         phase = 1
         if 'coa_phase' in p:
-            phase = numpy.exp(1.0j * 2 * p['coa_phase'])
+            phase = numpy.exp(-1.0j * 2 * p['coa_phase'])
 
         sh_total = hh_total = 0
 
@@ -207,7 +207,7 @@ class SingleTemplate(DistMarg, BaseGaussianNoise):
             f = (fp + 1.0j * fc) * pol_phase
 
             # Note, this includes complex conjugation already
-            # as our stored inner products were hp*xdata
+            # as our stored inner products were hp* x data
             htf = (f.real * ip + 1.0j * f.imag * ic) / p['distance'] * phase
             self.htfs[ifo] = htf
             sh = self.sh[ifo].at_time(self.dts[ifo], interpolate='quadratic')

--- a/pycbc/inference/models/tools.py
+++ b/pycbc/inference/models/tools.py
@@ -513,9 +513,8 @@ class DistMarg():
             logging.info('Reconstruct vector')
             self.reconstruct_vector = True
             self.reset_vector_params()
-            loglr = get_loglr() + self.marginalize_vector_weights
-            xl = draw_sample(loglr)
-
+            loglr = get_loglr()
+            xl = draw_sample(loglr + self.marginalize_vector_weights)
             for k in self.marginalize_vector_params:
                 rec[k] = self.marginalize_vector_params[k][xl]
             self.reconstruct_vector = False
@@ -525,8 +524,8 @@ class DistMarg():
             # call likelihood to get vector output
             self.reconstruct_distance = True
             _, weights = self.distance_marginalization
-            loglr = get_loglr() + numpy.log(weights)
-            xl = draw_sample(loglr)
+            loglr = get_loglr()
+            xl = draw_sample(loglr + numpy.log(weights))
             rec['distance'] = self.dist_locs[xl]
             self.reconstruct_distance = False
 
@@ -535,7 +534,8 @@ class DistMarg():
             self.reconstruct_phase = True
             s, h = get_loglr()
             phasev = numpy.linspace(0, numpy.pi*2.0, int(1e4))
-            loglr = (numpy.exp(2.0j * phasev) * s).real + h
+            # This assumes that the template was conjugated in inner products
+            loglr = (numpy.exp(-2.0j * phasev) * s).real + h
             xl = draw_sample(loglr)
             rec['coa_phase'] = phasev[xl]
             self.reconstruct_phase = False


### PR DESCRIPTION
I might consider this PR a bugfix. In running some simulations on the marginalized models and testing the accuracy of parameter reconstruction I noticed an inconsistency in how we were handling the phase. 

 We were inconsistent in our inner products about the use of 'coa_phase' in various models. Some of these were less obvious than others as they occur in marginalized models where this would be unobservable except when trying to use the partial terms to do phase reconstruction (i.e the complex inner products). Sometimes we would conjugate the data and other times the signal when doing the complex inner products. Either is fine, but if we want to reconstruct the phase, this introduces a sign inconsistency that I was not accounting for. I think the right solution is to use a consistent convention. I've decided to move everything (where it wasn't already) to use the convention of conjugating the template. This was the convention already established in most of the literature and also what we do in our matched filtering code. 

Some models (only relbin atm) may choose to internally use another convention for convenience, but should return the complex inner products with the right convention (you can invert one to another by conjugation). 

@cdcapano Note, the conjugation order for the 'inner' product method is that 'self' is conjugated so the instance the method is called on, so this involved switching the order in a couple places. 