### PR TITLE
allow multiple cuts on same parameter

### DIFF
--- a/pycbc/events/cuts.py
+++ b/pycbc/events/cuts.py
@@ -133,7 +133,6 @@ def check_update_cuts(cut_dict, new_cut):
     new_cut_key = list(new_cut.keys())[0]
     if new_cut_key in cut_dict:
         # The cut has already been called
-        
         logging.warning("WARNING: Cut parameter %s and function %s have "
                         "already been used. Utilising the strictest cut.",
                         new_cut_key[0], new_cut_key[1].__name__)

--- a/pycbc/events/cuts.py
+++ b/pycbc/events/cuts.py
@@ -110,7 +110,7 @@ def convert_inputstr(inputstr, choices):
         cut_value = float(cut_value_str)
     except ValueError as value_e:
         logging.warning("ERROR: Cut value must be convertible into a float, "
-                        "got '%s', a %s.", cut_value, type(cut_value))
+                        "got '%s'.", cut_value_str)
         raise value_e
 
     return {(cut_param, ineq_functions[cut_limit]): float(cut_value_str)}
@@ -195,7 +195,7 @@ def apply_trigger_cuts(triggers, trigger_cut_dict):
 
     Parameters
     ----------
-    triggers: ReadByTemplate object
+    triggers: ReadByTemplate object or dictionary
         The triggers in this particular template. This
         must have the correct datasets required to calculate
         the values we cut on.
@@ -226,8 +226,10 @@ def apply_trigger_cuts(triggers, trigger_cut_dict):
             value = get_chisq_from_file_choice(triggers, chisq_choice)
             # Apply any previous cuts to the value for comparison
             value = value[idx_out]
-        elif parameter in triggers.file[triggers.ifo]:
-            # parameter can be read direct from the trigger file
+        elif (parameter in triggers
+                or (hasattr(triggers, "file")
+                    and parameter in triggers.file[triggers.ifo])):
+            # parameter can be read direct from the trigger dictionary / file
             value = triggers[parameter]
             # Apply any previous cuts to the value for comparison
             value = value[idx_out]

--- a/pycbc/events/cuts.py
+++ b/pycbc/events/cuts.py
@@ -113,7 +113,7 @@ def convert_inputstr(inputstr, choices):
                         "got '%s'.", cut_value_str)
         raise value_e
 
-    return {(cut_param, ineq_functions[cut_limit]): float(cut_value_str)}
+    return {(cut_param, ineq_functions[cut_limit]): cut_value}
 
 
 def check_update_cuts(cut_dict, new_cut):

--- a/pycbc/events/cuts.py
+++ b/pycbc/events/cuts.py
@@ -136,7 +136,7 @@ def check_update_cuts(cut_dict, new_cut):
         
         logging.warning("WARNING: Cut parameter %s and function %s have "
                         "already been used. Utilising the strictest cut.",
-                        new_cut_key[0], new_cut_key[1].func_name)
+                        new_cut_key[0], new_cut_key[1].__name__)
         # Extract the function and work out which is strictest
         cut_function = new_cut_key[1]
         value_new = list(new_cut.values())[0]

--- a/pycbc/events/cuts.py
+++ b/pycbc/events/cuts.py
@@ -152,7 +152,7 @@ def check_update_cuts(cut_dict, new_cut):
         else:
             # New cut would not make a difference, ignore it
             logging.warning("WARNING: New threshold of %.3f is less "
-                            "strict than old threshold %.3f, using  "
+                            "strict than old threshold %.3f, using "
                             "cut at %.3f.",
                             value_new, value_old, value_old)
     else:

--- a/pycbc/events/cuts.py
+++ b/pycbc/events/cuts.py
@@ -113,7 +113,8 @@ def convert_inputstr(inputstr, choices):
                         "got '%s', a %s.", cut_value, type(cut_value))
         raise value_e
 
-    return {(cut_param, ineq_functions[cut_limit]) : float(cut_value_str)}
+    return {(cut_param, ineq_functions[cut_limit]): float(cut_value_str)}
+
 
 def check_update_cuts(cut_dict, new_cut):
     """
@@ -132,9 +133,10 @@ def check_update_cuts(cut_dict, new_cut):
     new_cut_key = list(new_cut.keys())[0]
     if new_cut_key in cut_dict:
         # The cut has already been called
-        logging.warning(f"WARNING: Cut parameter {new_cut_key[0]} and "
-                        f"function {new_cut_key[1]} have already "
-                        "been used. Utilising the strictest cut.")
+        
+        logging.warning("WARNING: Cut parameter %s and function %s have "
+                        "already been used. Utilising the strictest cut.",
+                        new_cut_key[0], new_cut_key[1].func_name)
         # Extract the function and work out which is strictest
         cut_function = new_cut_key[1]
         value_new = list(new_cut.values())[0]
@@ -143,15 +145,17 @@ def check_update_cuts(cut_dict, new_cut):
             # The new threshold would survive the cut of the
             # old threshold, therefore the new threshold is stricter
             # - update it
-            logging.warning(f"WARNING: New threshold of {value_new} is "
-                            f"stricter than old threshold {value_old}, "
-                            f"discarding cut at {value_old}.")
+            logging.warning("WARNING: New threshold of %.3f is "
+                            "stricter than old threshold %.3f, "
+                            "using cut at %.3f.",
+                            value_new, value_old, value_new)
             cut_dict.update(new_cut)
         else:
             # New cut would not make a difference, ignore it
-            logging.warning(f"WARNING: New threshold of {value_new} is less "
-                            f"strict than old threshold {value_old}, using  "
-                            f"cut at {value_old}.")
+            logging.warning("WARNING: New threshold of %.3f is less "
+                            "strict than old threshold %.3f, using  "
+                            "cut at %.3f.",
+                            value_new, value_old, value_old)
     else:
         # This is a new cut - add it
         cut_dict.update(new_cut)

--- a/test/test_cuts.py
+++ b/test/test_cuts.py
@@ -79,6 +79,19 @@ tests_parser_output = []
 # No cuts: empty dicts as output
 tests_parser_output.append(([], ({}, {}), "no_cuts_given"))
 
+# Multiple cuts on the same parameter / cut type,
+# should only use the strictest cut
+tests_parser_output.append((['--trigger-cuts',
+                             'snr:4:lower', 'snr:5:lower'],
+                            ({('snr', np.greater): 5}, {}),
+                            "multiple_similar_cuts"))
+
+# Multiple cuts exactly the same, should give the warning but still complete
+tests_parser_output.append((['--trigger-cuts',
+                             'snr:5:lower', 'snr:5:lower'],
+                            ({('snr', np.greater): 5}, {}),
+                            "multiple_same_cuts"))
+
 # Dynamically add value tests for the parser
 for test_values in tests_parser_output:
     args = parse_args(test_values[0])

--- a/test/test_cuts.py
+++ b/test/test_cuts.py
@@ -1,0 +1,228 @@
+"""
+Unit tests for cuts being applied to trigger and templates
+"""
+
+import unittest
+import argparse
+import copy
+import numpy as np
+from utils import simple_exit
+from pycbc.events import cuts, ranking
+from pycbc.tmpltbank import bank_conversions
+
+
+def parse_args(args):
+    # Helper function to convert a list of flags/options into
+    # an arguments structure
+    parser = argparse.ArgumentParser()
+
+    cuts.insert_cuts_option_group(parser)
+    return parser.parse_args(args)
+
+
+class CutsErrorsTest(unittest.TestCase):
+    def setUp(self):
+        # Set up some things we will want to use in the tests:
+        self.maxDiff = None
+
+# Tuples of inputs for tests which should fail
+test_parser_raises_error = []
+
+test_parser_raises_error.append((['--template-cuts',
+                                 'this_is_not_right'],
+                                 ValueError,
+                                 'incorrect_format_template_cut'))
+
+test_parser_raises_error.append((['--trigger-cuts',
+                                 'this_is_not_right'],
+                                 ValueError,
+                                 'incorrect_format_trigger_cut'))
+
+test_parser_raises_error.append((['--trigger-cuts',
+                                 'chi_eff:0.9:upper'],
+                                 NotImplementedError,
+                                 'template_param_given_as_trigger_cut'))
+
+test_parser_raises_error.append((['--template-cuts',
+                                 'newsnr:5.5:lower'],
+                                 NotImplementedError,
+                                 'trigger_param_given_as_template_cut'))
+
+test_parser_raises_error.append((['--trigger-cuts',
+                                 'newsnr:5.5:nonsense'],
+                                 NotImplementedError,
+                                 'nonsense_limit'))
+
+test_parser_raises_error.append((['--trigger-cuts',
+                                 'newsnr:notafloat:upper'],
+                                 ValueError,
+                                 'threshold_not_a_float'))
+
+# Dynamically add sysexit tests into the class
+for test_parser_error in test_parser_raises_error:
+    args = parse_args(test_parser_error[0])
+    def check_sysexit_test(self, a=args, te=test_parser_error[1]):
+        with self.assertRaises(te):
+            cuts.ingest_cuts_option_group(a)
+    setattr(CutsErrorsTest,
+            'test_parser_error_' + test_parser_error[2],
+            check_sysexit_test)
+
+class CutsParserTest(unittest.TestCase):
+    def setUp(self):
+        # Set up some things we will want to use in the tests:
+        self.maxDiff = None
+
+# Tuples of inputs for tests where we are checking the output
+tests_parser_output = []
+
+# No cuts: empty dicts as output
+tests_parser_output.append(([], ({}, {}), "no_cuts_given"))
+
+# Dynamically add value tests for the parser
+for test_values in tests_parser_output:
+    args = parse_args(test_values[0])
+    def digest_values_test(self, a=args, tv=test_values[1]):
+        cuts_dicts = cuts.ingest_cuts_option_group(a)
+        self.assertEqual(cuts_dicts, tv)
+
+
+    setattr(CutsParserTest,
+            'test_parser_values_' + test_values[2],
+            digest_values_test)
+
+# Set up some random datasets to test the cuts:
+
+# Make this reproducible
+np.random.seed(1865)
+
+# Set values for triggers:
+n_triggers = 10000
+trigger_dset = {}
+trigger_dset['snr'] = np.random.random(n_triggers) * 10
+trigger_dset['chisq'] = np.random.random(n_triggers) * 100
+trigger_dset['chisq_dof'] = np.ceil(np.random.random(n_triggers) * 100) + 2
+trigger_dset['sg_chisq'] = np.random.random(n_triggers) * 2
+
+# Set values for templates:
+template_dset = {}
+n_templates = 10000
+
+# For one of the tests, we want to use an exact value of mass1,
+# so set it manually
+mass1 = list(np.random.random(n_templates - 1) * 100) + [59]
+mass2 = list(np.random.random(n_templates - 1) * 100) + [10]
+
+# Assert mass1 > mass2
+template_dset['mass1'] = np.maximum(mass1, mass2)
+template_dset['mass2'] = np.minimum(mass1, mass2)
+
+# Spins must be in the range -1, 1, (but not exactly 1):
+def make_random_spins(n_templates):
+    spins = np.random.normal(size=n_templates, scale=0.4)
+    spins = np.maximum(spins, -0.998)
+    spins = np.minimum(spins, 0.998)
+    return spins
+
+template_dset['spin1z'] = make_random_spins(n_templates)
+template_dset['spin2z'] = make_random_spins(n_templates)
+
+template_dset['template_duration'] = np.random.random(n_templates) * 100
+
+
+class CutsTest(unittest.TestCase):
+    def setUp(self):
+        # Set up some things we will want to use in the tests:
+        self.maxDiff = None
+
+# Set up values to be tested:
+test_cut_output = []
+
+
+# Lower limits on a trigger parameter we can read directly
+def snr_lower_test(trigs, trig_idx, **kwargs):
+    return all(trigs['snr'][trig_idx] > 4)
+
+
+test_cut_output.append((['--trigger-cuts', 'snr:4:lower'],
+                        snr_lower_test,
+                        'snr_cut_lower'))
+
+
+# Upper limits on a derived trigger parameter
+def newsnr_sgveto_upper_test(trigs, trig_idx, **kwargs):
+    rwsnr = ranking.get_newsnr_sgveto(trigs)
+    return all(rwsnr[trig_idx] < 10)
+
+test_cut_output.append((['--trigger-cuts', 'newsnr_sgveto:10:upper'],
+                        newsnr_sgveto_upper_test,
+                        'nsnr_sgveto_cut_upper'))
+
+# Lower limit on directly-read template bank parameter
+def template_duration_test(temps, temp_idx, **kwargs):
+    return all(temps['template_duration'][temp_idx] > 10)
+
+test_cut_output.append((['--template-cuts',
+                         'template_duration:10:lower'],
+                        template_duration_test,
+                        'template_duration_lower'))
+
+# make sure the "or equal to" is working properly
+def mass1_ge_test(temps, temp_idx, **kwargs):
+    return any(temps['mass1'][temp_idx] == 59)
+
+test_cut_output.append((['--template-cuts',
+                         'mass1:59:lower_inc'],
+                        mass1_ge_test,
+                        'mass1_orequal'))
+
+# Upper and lower limits on a derived parameter from the bank
+def chi_eff_upper_lower_test(temps, temp_idx, **kwargs):
+    chi_eff = bank_conversions.get_bank_property('chi_eff', temps, temp_idx)
+    return all(np.logical_and(chi_eff > -0.5,
+                              chi_eff <= 0.8))
+
+
+test_cut_output.append((['--template-cuts', 'chi_eff:0.8:upper',
+                         'chi_eff:-0.5:lower_inc'],
+                         chi_eff_upper_lower_test,
+                         'chi_eff_cut_upper_lower'))
+
+
+# FIXME: Once we can fake the statistic files, create a test
+# for template fits cuts
+
+# Dynamically add value tests for the parser
+for test_values in test_cut_output:
+    args = parse_args(test_values[0])
+    def digest_values_test(self, a=args, test_func=test_values[1]):
+        # Copy the global variables, as we need to use local in the tests
+        triggers = copy.deepcopy(trigger_dset)
+        bank = copy.deepcopy(template_dset)
+
+        # Take in the arguments which define the cuts
+        trigger_cut_dict, template_cut_dict = cuts.ingest_cuts_option_group(a)
+
+        # Get out the indices which meet the cut criteria
+        templates_idx = cuts.apply_template_cuts(bank, template_cut_dict)
+        triggers_idx = cuts.apply_trigger_cuts(triggers, trigger_cut_dict)
+
+        # Using the checks from the definition tuple, is the cut working?
+        self.assertTrue(test_func(temps=bank,
+                                  temp_idx=templates_idx,
+                                  trigs=trigger_dset,
+                                  trig_idx=triggers_idx))
+
+    setattr(CutsParserTest,
+            'test_cuts_correct_' + test_values[2],
+            digest_values_test)
+
+# create and populate unittest's test suite
+suite = unittest.TestSuite()
+test_loader = unittest.TestLoader()
+suite.addTest(test_loader.loadTestsFromTestCase(CutsErrorsTest))
+suite.addTest(test_loader.loadTestsFromTestCase(CutsParserTest))
+
+if __name__ == '__main__':
+    results = unittest.TextTestRunner(verbosity=2).run(suite)
+    simple_exit(results)

--- a/test/test_cuts.py
+++ b/test/test_cuts.py
@@ -58,7 +58,7 @@ test_parser_raises_error.append((['--trigger-cuts',
                                  ValueError,
                                  'threshold_not_a_float'))
 
-# Dynamically add sysexit tests into the class
+# Dynamically add error tests into the class
 for test_parser_error in test_parser_raises_error:
     args = parse_args(test_parser_error[0])
     def check_sysexit_test(self, a=args, te=test_parser_error[1]):
@@ -86,6 +86,11 @@ tests_parser_output.append((['--trigger-cuts',
                             ({('snr', np.greater): 5}, {}),
                             "multiple_similar_cuts"))
 
+tests_parser_output.append((['--trigger-cuts',
+                             'snr:5:lower', 'snr:4:lower'],
+                            ({('snr', np.greater): 5}, {}),
+                            "multiple_similar_cuts_2"))
+
 # Multiple cuts exactly the same, should give the warning but still complete
 tests_parser_output.append((['--trigger-cuts',
                              'snr:5:lower', 'snr:5:lower'],
@@ -95,14 +100,14 @@ tests_parser_output.append((['--trigger-cuts',
 # Dynamically add value tests for the parser
 for test_values in tests_parser_output:
     args = parse_args(test_values[0])
-    def digest_values_test(self, a=args, tv=test_values[1]):
+    def ingest_values_test(self, a=args, tv=test_values[1]):
         cuts_dicts = cuts.ingest_cuts_option_group(a)
         self.assertEqual(cuts_dicts, tv)
 
 
     setattr(CutsParserTest,
             'test_parser_values_' + test_values[2],
-            digest_values_test)
+            ingest_values_test)
 
 # Set up some random datasets to test the cuts:
 
@@ -208,7 +213,7 @@ test_cut_output.append((['--template-cuts', 'chi_eff:0.8:upper',
 # Dynamically add value tests for the parser
 for test_values in test_cut_output:
     args = parse_args(test_values[0])
-    def digest_values_test(self, a=args, test_func=test_values[1]):
+    def cut_values_test(self, a=args, test_func=test_values[1]):
         # Copy the global variables, as we need to use local in the tests
         triggers = copy.deepcopy(trigger_dset)
         bank = copy.deepcopy(template_dset)
@@ -226,15 +231,16 @@ for test_values in test_cut_output:
                                   trigs=trigger_dset,
                                   trig_idx=triggers_idx))
 
-    setattr(CutsParserTest,
+    setattr(CutsTest,
             'test_cuts_correct_' + test_values[2],
-            digest_values_test)
+            cut_values_test)
 
 # create and populate unittest's test suite
 suite = unittest.TestSuite()
 test_loader = unittest.TestLoader()
 suite.addTest(test_loader.loadTestsFromTestCase(CutsErrorsTest))
 suite.addTest(test_loader.loadTestsFromTestCase(CutsParserTest))
+suite.addTest(test_loader.loadTestsFromTestCase(CutsTest))
 
 if __name__ == '__main__':
     results = unittest.TextTestRunner(verbosity=2).run(suite)


### PR DESCRIPTION
Amend cuts module to allow multiple upper/lower cuts on the same parameter, also check and deal with duplicated cuts.

This is done by updating the cuts dictionaries to be keyed on parameter and the comparison function, rather than the parameter only.

Solves #4146 