### PR TITLE
Reduce wget verbosity in tests

### DIFF
--- a/.github/workflows/inference-workflow.yml
+++ b/.github/workflows/inference-workflow.yml
@@ -22,7 +22,7 @@ jobs:
         sudo systemctl enable condor
     - name: install pegasus
       run: |
-        wget https://download.pegasus.isi.edu/pegasus/ubuntu/dists/bionic/main/binary-amd64/pegasus_5.0.1-1+ubuntu18_amd64.deb
+        wget -nv https://download.pegasus.isi.edu/pegasus/ubuntu/dists/bionic/main/binary-amd64/pegasus_5.0.1-1+ubuntu18_amd64.deb
         sudo apt install ./pegasus_5.0.1-1+ubuntu18_amd64.deb
     - run: sudo apt-get install *fftw3* intel-mkl*
     - name: Install pycbc

--- a/.github/workflows/search-workflow.yml
+++ b/.github/workflows/search-workflow.yml
@@ -22,7 +22,7 @@ jobs:
         sudo systemctl enable condor
     - name: install pegasus
       run: |
-        wget https://download.pegasus.isi.edu/pegasus/ubuntu/dists/bionic/main/binary-amd64/pegasus_5.0.1-1+ubuntu18_amd64.deb
+        wget -nv https://download.pegasus.isi.edu/pegasus/ubuntu/dists/bionic/main/binary-amd64/pegasus_5.0.1-1+ubuntu18_amd64.deb
         sudo apt install ./pegasus_5.0.1-1+ubuntu18_amd64.deb
     - run: sudo apt-get install *fftw3* intel-mkl*
     - name: Install pycbc

--- a/.github/workflows/tmpltbank-workflow.yml
+++ b/.github/workflows/tmpltbank-workflow.yml
@@ -22,7 +22,7 @@ jobs:
         sudo systemctl enable condor
     - name: install pegasus
       run: |
-        wget https://download.pegasus.isi.edu/pegasus/ubuntu/dists/bionic/main/binary-amd64/pegasus_5.0.1-1+ubuntu18_amd64.deb
+        wget -nv https://download.pegasus.isi.edu/pegasus/ubuntu/dists/bionic/main/binary-amd64/pegasus_5.0.1-1+ubuntu18_amd64.deb
         sudo apt install ./pegasus_5.0.1-1+ubuntu18_amd64.deb
     - run: sudo apt-get install *fftw3* intel-mkl*
     - name: Install pycbc

--- a/.github/workflows/workflow-tests.yml
+++ b/.github/workflows/workflow-tests.yml
@@ -27,7 +27,7 @@ jobs:
         sudo systemctl enable condor
     - name: install pegasus
       run: |
-        wget https://download.pegasus.isi.edu/pegasus/ubuntu/dists/bionic/main/binary-amd64/pegasus_5.0.1-1+ubuntu18_amd64.deb
+        wget -nv https://download.pegasus.isi.edu/pegasus/ubuntu/dists/bionic/main/binary-amd64/pegasus_5.0.1-1+ubuntu18_amd64.deb
         sudo apt install ./pegasus_5.0.1-1+ubuntu18_amd64.deb
     - run: sudo apt-get install *fftw3* intel-mkl*
     - name: Install pycbc

--- a/examples/inspiral/run.sh
+++ b/examples/inspiral/run.sh
@@ -54,7 +54,7 @@ python ./check_GW150914_detection.py H1-INSPIRAL_$1_$2_$3-OUT.hdf
 
 # Test pycbc inspiral by running over GW150914 with a limited template bank
 echo -e "\\n\\n>> [`date`] Getting template bank"
-wget -nc https://github.com/gwastro/pycbc-config/raw/master/test/inspiral/SMALLER_BANK_FOR_GW150914.hdf
+wget -nv -nc https://github.com/gwastro/pycbc-config/raw/master/test/inspiral/SMALLER_BANK_FOR_GW150914.hdf
 
 echo -e "\\n\\n>> [`date`] Compressing template bank"
 pycbc_compress_bank --bank-file SMALLER_BANK_FOR_GW150914.hdf --output COMPRESSED_BANK.hdf --sample-rate 4096 --segment-length 256 --compression-algorithm mchirp --psd-model aLIGOZeroDetHighPower --low-frequency-cutoff 30 --approximant "SEOBNRv4_ROM"

--- a/examples/multi_inspiral/faceon_faceaway.sh
+++ b/examples/multi_inspiral/faceon_faceaway.sh
@@ -11,7 +11,7 @@ CONFIG_URL=https://github.com/gwastro/pycbc-config/raw/master/test/multi_inspira
 INJ_FILE=faceon_faceaway_injs.hdf
 
 echo -e "\\n\\n>> [`date`] Getting injection file"
-wget -nc ${CONFIG_URL}/${INJ_FILE}
+wget -nv -nc ${CONFIG_URL}/${INJ_FILE}
 
 # Generate mock data
 for IFO in 'H1' 'L1' 'V1'; do
@@ -36,9 +36,9 @@ RA=5.016076270234897
 DEC=-0.408407044967
 
 echo -e "\\n\\n>> [`date`] Getting template bank"
-wget -nc ${CONFIG_URL}/${BANK_FILE}
+wget -nv -nc ${CONFIG_URL}/${BANK_FILE}
 echo -e "\\n\\n>> [`date`] Bank veto bank"
-wget -nc ${CONFIG_URL}/${BANK_VETO_FILE}
+wget -nv -nc ${CONFIG_URL}/${BANK_VETO_FILE}
 
 for POL in 'standard' 'left' 'right' 'left+right'; do
     echo -e "\\n\\n>> [`date`] Running pycbc_multi_inspiral with ${POL} projection"

--- a/examples/multi_inspiral/run.sh
+++ b/examples/multi_inspiral/run.sh
@@ -11,13 +11,13 @@ V1_FRAME=https://www.gw-openscience.org/eventapi/html/GWTC-1-confident/GW170817/
 V1_CHANNEL=GWOSC-4KHZ_R1_STRAIN
 
 echo -e "\\n\\n>> [`date`] Getting template bank"
-wget -nc ${CONFIG_URL}/${BANK_FILE}
+wget -nv -nc ${CONFIG_URL}/${BANK_FILE}
 echo -e "\\n\\n>> [`date`] Bank veto bank"
-wget -nc ${CONFIG_URL}/${BANK_VETO_FILE}
+wget -nv -nc ${CONFIG_URL}/${BANK_VETO_FILE}
 for IFO in H1 L1 V1; do
     echo -e "\\n\\n>> [`date`] Getting ${IFO} frame"
     FRAME=${IFO}_FRAME
-    wget -nc ${!FRAME}
+    wget -nv -nc ${!FRAME}
 done
 
 EVENT=1187008882

--- a/examples/search/get.sh
+++ b/examples/search/get.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 set -e
 
-wget https://dcc.ligo.org/public/0146/P1700341/001/H-H1_LOSC_CLN_4_V1-1186740069-3584.gwf
-wget https://dcc.ligo.org/public/0146/P1700341/001/L-L1_LOSC_CLN_4_V1-1186740069-3584.gwf
-wget https://dcc.ligo.org/public/0146/P1700341/001/V-V1_LOSC_CLN_4_V1-1186739813-4096.gwf
-
+wget -nv https://dcc.ligo.org/public/0146/P1700341/001/H-H1_LOSC_CLN_4_V1-1186740069-3584.gwf
+wget -nv https://dcc.ligo.org/public/0146/P1700341/001/L-L1_LOSC_CLN_4_V1-1186740069-3584.gwf
+wget -nv https://dcc.ligo.org/public/0146/P1700341/001/V-V1_LOSC_CLN_4_V1-1186739813-4096.gwf


### PR DESCRIPTION
Going through the log generated by the test suite is annoying because thousands and thousands of lines are just wget showing the progress of files being downloaded. This adds `-nv` to those wget calls, so they do not show the progress in the logs.