### PR TITLE
Change foundmissed tick step

### DIFF
--- a/bin/plotting/pycbc_page_foundmissed
+++ b/bin/plotting/pycbc_page_foundmissed
@@ -200,7 +200,7 @@ if args.gradient_far:
         # Set up tick labels - there will be 5 if possible
         min_tick = numpy.ceil(min(numpy.log10(color)))
         max_tick = numpy.floor(max(numpy.log10(color)))
-        tick_step = max(1,numpy.floor((max_tick - min_tick) / 5))
+        tick_step = max(1, numpy.floor((max_tick - min_tick) / 5))
         ticks = numpy.arange(min_tick, max_tick, tick_step)
         c.set_ticks(numpy.power(10, ticks))
     except (TypeError, ZeroDivisionError):

--- a/bin/plotting/pycbc_page_foundmissed
+++ b/bin/plotting/pycbc_page_foundmissed
@@ -197,10 +197,10 @@ if args.gradient_far:
         c = plot.colorbar()
         c.set_label('False Alarm Rate $(yr^{-1})$, %s' % far_title)
 
-        # Set up tick labels - there will always be 5
+        # Set up tick labels - there will be 5 if possible
         min_tick = numpy.ceil(min(numpy.log10(color)))
         max_tick = numpy.floor(max(numpy.log10(color)))
-        tick_step = numpy.floor((max_tick - min_tick) / 5)
+        tick_step = max(1,numpy.floor((max_tick - min_tick) / 5))
         ticks = numpy.arange(min_tick, max_tick, tick_step)
         c.set_ticks(numpy.power(10, ticks))
     except (TypeError, ZeroDivisionError):


### PR DESCRIPTION
This MR addresses the case where the range of recovered injection FARs covers less than 5 orders of magnitude. This scenario can arise when a small number of injections are recovered (likely due to analyzing a small amount of time).  Rather than return an error, tick marks are now placed on every order of magnitude. 