### PR TITLE
Update to new coordinate frame

### DIFF
--- a/examples/inference/lisa_smbhb/lisa_smbhb_relbin.ini
+++ b/examples/inference/lisa_smbhb/lisa_smbhb_relbin.ini
@@ -18,7 +18,7 @@ mass1_ref = 1015522.4376
 mass2_ref = 796849.1091
 mchirp_ref = 781969.693924104
 q_ref = 1.2744225048415756
-tc_ref = 4800021.15572853
+tc_ref = 4799624.274911478
 distance_ref = 17758.367941273442
 spin1z_ref = 0.597755394865021
 spin2z_ref = 0.36905807298613247
@@ -32,9 +32,9 @@ tc =
 [static_params]
 approximant = BBHX_PhenomD
 coa_phase = 4.275929308696054
-eclipticlongitude = 0.6109268516130327
-eclipticlatitude = -0.5641023936335077
-polarization = -1.3904477899667156
+eclipticlongitude = -0.8400769299810702
+eclipticlatitude = -1.2734504596198182
+polarization = 0.22558110042980073
 spin1z = 0.597755394865021
 spin2z = 0.36905807298613247
 distance = 17758.367941273442
@@ -63,3 +63,11 @@ name = mchirp_q_to_mass1_mass2
 name = dynesty
 dlogz = 0.1
 nlive = 150
+
+; NOTE: While this example doesn't sample in polarization, if doing this we
+; recommend the following transformation, and then sampling in this coordinate
+;
+; [waveform_transforms-polarization]
+; name = custom
+; inputs = better_pol, eclipticlongitude
+; polarization = better_pol + eclipticlongitude


### PR DESCRIPTION
@WuShichao @ConWea This change follows up on the change to the BBHX waveform interface to move to the LISA frame, by default. Now the example needs parameters specified in that frame, or it won't work!