### PR TITLE
Adding per-event-type live pastro

### DIFF
--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -366,7 +366,6 @@ class LiveEventManager(object):
             return
 
         logging.info('computing followup data for coinc')
-
         coinc_ifos = coinc_results['foreground/type'].split('-')
         followup_ifos = list(set(ifos) - set(coinc_ifos))
 
@@ -375,7 +374,7 @@ class LiveEventManager(object):
             coinc_results['foreground/NO_FOLLOWUP'] = True
             return
 
-        fud = self.compute_followup_data(
+        sld = self.compute_followup_data(
             coinc_ifos,
             coinc_results,
             followup_ifos=followup_ifos,
@@ -384,11 +383,12 @@ class LiveEventManager(object):
 
         event = CandidateForGraceDB(
             coinc_ifos,
+            ifos,
             coinc_results,
             padata=self.padata,
             bank=self.bank,
             psds=psds,
-            followup_data=fud,
+            skyloc_data=sld,
             low_frequency_cutoff=self.low_frequency_cutoff,
             channel_names=args.channel_name,
             mc_area_args=self.mc_area_args,
@@ -453,7 +453,7 @@ class LiveEventManager(object):
                 continue
 
             followup_ifos = [i for i in active if i is not ifo]
-            fud = self.compute_followup_data(
+            sld = self.compute_followup_data(
                 [ifo],
                 single,
                 followup_ifos=followup_ifos,
@@ -466,11 +466,12 @@ class LiveEventManager(object):
 
             event = CandidateForGraceDB(
                 [ifo],
+                active,
                 single,
                 padata=self.padata,
                 bank=self.bank,
                 psds=psds,
-                followup_data=fud,
+                skyloc_data=sld,
                 low_frequency_cutoff=self.low_frequency_cutoff,
                 channel_names=args.channel_name,
                 mc_area_args=self.mc_area_args,

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -432,7 +432,7 @@ class LiveEventManager(object):
         if self.run_snr_optimization \
                 and self.ifar_upload_threshold < ifar:
             logging.info('Optimizing SNR for coinc above threshold ..')
-            live_ifos = [ifo for ifo in fud if 'snr_series' in fud[ifo]]
+            live_ifos = [ifo for ifo in sld if 'snr_series' in sld[ifo]]
             self.setup_optimize_snr(
                 coinc_results,
                 live_ifos,
@@ -452,17 +452,19 @@ class LiveEventManager(object):
             if single is None:
                 continue
 
+            sifar = single['foreground/ifar']
+            logging.info(f'Found {ifo} single with ifar {sifar}')
+
             followup_ifos = [i for i in active if i is not ifo]
+            # Don't recompute ifar considering other ifos
             sld = self.compute_followup_data(
                 [ifo],
                 single,
                 followup_ifos=followup_ifos,
                 recalculate_ifar=False
             )
-            ifar = single['foreground/ifar']
             # Apply a trials factor of the number of active detectors
-            ifar /= len(active)
-            single['foreground/ifar'] = ifar
+            single['foreground/ifar'] = sifar / len(active)
 
             event = CandidateForGraceDB(
                 [ifo],
@@ -501,7 +503,7 @@ class LiveEventManager(object):
                 )
 
             if args.enable_single_detector_upload \
-                    and self.ifar_upload_threshold < ifar \
+                    and self.ifar_upload_threshold < single['foreground/ifar'] \
                     and not any(nearby_coincs):
                 gid = event.upload(fname, gracedb_server=args.gracedb_server,
                                    testing=self.gracedb_testing,
@@ -511,11 +513,11 @@ class LiveEventManager(object):
                 gid = None
                 event.save(fname)
 
-            if self.ifar_upload_threshold < ifar \
+            if self.ifar_upload_threshold < single['foreground/ifar'] \
                     and not any(nearby_coincs) \
                     and self.run_snr_optimization:
-                logging.info('Optimizing SNR for coinc above threshold ..')
-                live_ifos = [ifo for ifo in fud if 'snr_series' in fud[ifo]]
+                logging.info('Optimizing SNR for single above threshold ..')
+                live_ifos = [ifo for ifo in sld if 'snr_series' in sld[ifo]]
                 self.setup_optimize_snr(
                     single,
                     live_ifos,

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -382,10 +382,8 @@ class LiveEventManager(object):
             recalculate_ifar=True
         )
 
-        live_ifos = [ifo for ifo in fud if 'snr_series' in fud[ifo]]
-
         event = CandidateForGraceDB(
-            live_ifos,
+            coinc_ifos,
             coinc_results,
             padata=self.padata,
             bank=self.bank,
@@ -433,6 +431,7 @@ class LiveEventManager(object):
 
         if self.run_snr_optimization \
                 and self.ifar_upload_threshold < ifar:
+            logging.info('Optimizing SNR for coinc above threshold ..')
             self.setup_optimize_snr(
                 coinc_results,
                 live_ifos,
@@ -464,10 +463,8 @@ class LiveEventManager(object):
             ifar /= len(active)
             single['foreground/ifar'] = ifar
 
-            live_ifos = [i for i in fud if 'snr_series' in fud[i]]
-
             event = CandidateForGraceDB(
-                live_ifos,
+                [ifo],
                 single,
                 padata=self.padata,
                 bank=self.bank,
@@ -515,6 +512,7 @@ class LiveEventManager(object):
             if self.ifar_upload_threshold < ifar \
                     and not any(nearby_coincs) \
                     and self.run_snr_optimization:
+                logging.info('Optimizing SNR for coinc above threshold ..')
                 self.setup_optimize_snr(
                     single,
                     live_ifos,
@@ -1047,16 +1045,15 @@ with ctx:
                         ds.attrs['background_time'] = bg_time
                     bgf.attrs['gps_time'] = last_bg_dump_time
 
-            logging.info('Finished Analyzing up to %s', data_end())
+            logging.info('Finished analyzing up to %s', data_end())
 
         if args.sync:
             evnt.barrier()
         tdiff = pycbc.gps_now() - t1
         lag = float(pycbc.gps_now() - data_end())
-        logging.info('Took %1.2f, duty factor of %.2f, '
-                     'lag %.2f s, %d live detectors',
-                     tdiff, tdiff / valid_pad, lag,
-                     len(evnt.live_detectors))
+        logging.info('Took %1.2f, duty factor of %.2f, lag %.2f s, %d live detectors',
+                     tdiff, tdiff / valid_pad, lag, len(evnt.live_detectors)
+        )
 
         if args.output_status is not None and evnt.rank == 0:
             if lag > 120:
@@ -1081,8 +1078,7 @@ with ctx:
                 with open(args.output_status, 'w') as status_fp:
                     json.dump(status, status_fp)
             except IOError:
-                logging.error('I/O error writing status JSON file! '
-                              'Hopefully it works next time')
+                logging.error('I/O error writing status JSON file!')
 
 if evnt.rank == 1:
     if args.fftw_output_float_wisdom_file:

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -432,6 +432,7 @@ class LiveEventManager(object):
         if self.run_snr_optimization \
                 and self.ifar_upload_threshold < ifar:
             logging.info('Optimizing SNR for coinc above threshold ..')
+            live_ifos = [ifo for ifo in fud if 'snr_series' in fud[ifo]]
             self.setup_optimize_snr(
                 coinc_results,
                 live_ifos,
@@ -513,6 +514,7 @@ class LiveEventManager(object):
                     and not any(nearby_coincs) \
                     and self.run_snr_optimization:
                 logging.info('Optimizing SNR for coinc above threshold ..')
+                live_ifos = [ifo for ifo in fud if 'snr_series' in fud[ifo]]
                 self.setup_optimize_snr(
                     single,
                     live_ifos,

--- a/bin/pycbc_make_skymap
+++ b/bin/pycbc_make_skymap
@@ -340,32 +340,32 @@ def main(trig_time, mass1, mass2, spin1z, spin2z, f_low, f_upper, sample_rate,
 
         network_snr2 += snr ** 2
 
-    ifos = sorted(set(ifos) - set(subthreshold_ifos))
-    if not ifos:
-        raise RuntimeError('all interferometers have SNR below threshold.'
-                           ' Is this really a candidate event?')
+    trig_ifos = sorted(set(ifos) - set(subthreshold_ifos))
+    if not trig_ifos:
+        raise RuntimeError(f'All interferometers have SNR below threshold '
+                           '{thresh_SNR}. Is this really a candidate event?')
 
     coinc_results['foreground/stat'] = network_snr2 ** 0.5
     coinc_results['foreground/ifar'] = ifar
 
     # BAYESTAR's convention for end time of subthreshold detectors
-    subthreshold_sngl_time = np.mean(
-            [coinc_results['foreground/%s/end_time' % ifo] for ifo in ifos])
+    subthreshold_sngl_time = np.mean([
+        coinc_results['foreground/%s/end_time' % ifo] for ifo in trig_ifos])
 
     window_bins = int(snr_series_duration * sample_rate)
-    followup_data = {}
-    for ifo in ifos + subthreshold_ifos:
+    skyloc_data = {}
+    for ifo in ifos:
         key = 'foreground/{}/'.format(ifo)
 
         if ifo in subthreshold_ifos:
             coinc_results[key + 'end_time'] = subthreshold_sngl_time
 
-        followup_data[ifo] = {
+        skyloc_data[ifo] = {
             'psd': interpolate(coinc_results[key + 'psd_series'], 0.25)
         }
 
-        # now go back to the SNR time series and cut out
-        # a shorter piece centered on the end time
+        # Go back to the SNR time series and select a piece centered on the
+        # end time
         time = coinc_results[key + 'end_time']
         snr_series = coinc_results[key + 'snr_series']
         peak_bin = int((time - snr_series.start_time) / snr_series.delta_t)
@@ -381,22 +381,26 @@ def main(trig_time, mass1, mass2, spin1z, spin2z, f_low, f_upper, sample_rate,
             max_bin = peak_bin + window_bins + 1
             min_bin = peak_bin - window_bins
 
-        followup_data[ifo]['snr_series'] = \
+        skyloc_data[ifo]['snr_series'] = \
                 snr_series[min_bin:max_bin].astype(np.complex64)
 
-    kwargs = {'psds': {ifo: followup_data[ifo]['psd']
-                       for ifo in ifos + subthreshold_ifos},
+    kwargs = {'psds': {ifo: skyloc_data[ifo]['psd'] for ifo in ifos},
               'low_frequency_cutoff': f_low,
               'high_frequency_cutoff': f_upper,
-              'followup_data': followup_data,
+              'skyloc_data': skyloc_data,
               'channel_names': channel_names}
 
-    doc = live.CandidateForGraceDB(ifos, coinc_results, **kwargs)
+    doc = live.CandidateForGraceDB(
+        trig_ifos,
+        trig_ifos,
+        coinc_results,
+        **kwargs
+    )
 
     ligolw_file_path = os.path.join(tmpdir, file_name_tag + '.xml')
 
     if gracedb_server:
-        comments = ['Manual followup up from PyCBC']
+        comments = ['Manual followup from PyCBC']
         gid = doc.upload(ligolw_file_path,
                          gracedb_server=gracedb_server,
                          testing=test_event,
@@ -406,13 +410,11 @@ def main(trig_time, mass1, mass2, spin1z, spin2z, f_low, f_upper, sample_rate,
         doc.save(ligolw_file_path)
 
     # Defining the approximant to feed into BAYESTAR
-
     row = WaveformArray.from_kwargs(
         mass1=mass1,
         mass2=mass2,
         spin1z=spin1z,
         spin2z=spin2z)
-
     bs_approximant = waveform.bank.parse_approximant_arg(approximant, row)[0]
 
     # BAYESTAR uses TaylorF2 instead of SPAtmplt

--- a/bin/pycbc_optimize_snr
+++ b/bin/pycbc_optimize_snr
@@ -367,7 +367,7 @@ spin2z = opt_params[3]
 
 # Prepare for GraceDB upload
 coinc_results = {}
-followup_data = {}
+skyloc_data = {}
 
 loudest_ifo = None
 loudest_snr_allifos = 0
@@ -437,9 +437,9 @@ for idx, ifo in enumerate(ifos):
     coinc_results['foreground/'+ifo+'/chisq_dof'] = 1
     coinc_results['foreground/'+ifo+'/template_duration'] = \
         fp['template_duration'][()]
-    followup_data[ifo] = {}
-    followup_data[ifo]['psd'] = interpolate(data[ifo].psd, 0.25)
-    followup_data[ifo]['snr_series'] = snr_series_dict[ifo]
+    skyloc_data[ifo] = {}
+    skyloc_data[ifo]['psd'] = interpolate(data[ifo].psd, 0.25)
+    skyloc_data[ifo]['snr_series'] = snr_series_dict[ifo]
 
     # Find loudest SNR within coincidence window of the largest peak
     snr_peak = abs(loudest_snrs[ifo])
@@ -448,8 +448,8 @@ for idx, ifo in enumerate(ifos):
     # Add small buffer
     lttbd += 0.005
 
-    time_window = [loudest_snr_time_allifos-lttbd,
-                   loudest_snr_time_allifos+lttbd]
+    time_window = [loudest_snr_time_allifos - lttbd,
+                   loudest_snr_time_allifos + lttbd]
 
     snr_slice = snr_series_dict[ifo].time_slice(time_window[0], time_window[1])
     max_snr_idx = numpy.argmax(abs(snr_slice))
@@ -476,13 +476,16 @@ for ifo in fp['channel_names'].keys():
 
 mc_area_args = load_hdf5_to_dict(fp, 'mc_area_args/')
 
-kwargs = {'psds': {ifo: followup_data[ifo]['psd'] for ifo in ifos},
+kwargs = {'psds': {ifo: skyloc_data[ifo]['psd'] for ifo in ifos},
           'low_frequency_cutoff': flow,
-          'followup_data': followup_data,
+          'skyloc_data': skyloc_data,
           'channel_names': channel_names,
           'mc_area_args': mc_area_args}
 
+# Treat all ifos as having triggers
+# Do not recalculate p_astro
 doc = live.CandidateForGraceDB(
+    ifos,
     ifos,
     coinc_results,
     upload_snr_series=True,
@@ -493,7 +496,7 @@ if args.enable_gracedb_upload:
     comment = ('Automatic PyCBC followup of trigger '
                '<a href="/events/{0}/view">{0}</a> to find the template '
                'parameters that maximize the SNR. The FAR of this trigger is '
-               'copied from {0} and does not reflect this triggers\' template '
+               'copied from {0} and does not reflect this trigger\'s template '
                'parameters.')
     comment = comment.format(original_gid)
 

--- a/pycbc/events/coinc.py
+++ b/pycbc/events/coinc.py
@@ -1209,7 +1209,7 @@ class LiveCoincTimeslideBackgroundEstimator(object):
             offsets = numpy.concatenate(offsets)
             ctime0 = numpy.concatenate(ctimes[self.ifos[0]]).astype(numpy.float64)
             ctime1 = numpy.concatenate(ctimes[self.ifos[1]]).astype(numpy.float64)
-            logging.info("Clustering %s-%s coincs", self.ifos[0], self.ifos[1])
+            logging.info("Clustering %s coincs", ppdets(self.ifos, "-"))
             cidx = cluster_coincs(cstat, ctime0, ctime1, offsets,
                                   self.timeslide_interval,
                                   self.analysis_block,

--- a/pycbc/events/coinc.py
+++ b/pycbc/events/coinc.py
@@ -358,9 +358,6 @@ def cluster_coincs(stat, time1, time2, timeslide_id, slide, window, **kwargs):
     cindex: numpy.ndarray
         The set of indices corresponding to the surviving coincidences.
     """
-
-    logging.info('clustering coinc triggers over %ss window' % window)
-
     if len(time1) == 0 or len(time2) == 0:
         logging.info('No coinc triggers in one, or both, ifos.')
         return numpy.array([])
@@ -1212,7 +1209,7 @@ class LiveCoincTimeslideBackgroundEstimator(object):
             offsets = numpy.concatenate(offsets)
             ctime0 = numpy.concatenate(ctimes[self.ifos[0]]).astype(numpy.float64)
             ctime1 = numpy.concatenate(ctimes[self.ifos[1]]).astype(numpy.float64)
-
+            logging.info("Clustering %s-%s coincs", self.ifos[0], self.ifos[1])
             cidx = cluster_coincs(cstat, ctime0, ctime1, offsets,
                                   self.timeslide_interval,
                                   self.analysis_block,

--- a/pycbc/io/live.py
+++ b/pycbc/io/live.py
@@ -229,7 +229,7 @@ class CandidateForGraceDB(object):
                 'active': usable_ifos}
             horizons = {i: self.psds[i].dist for i in usable_ifos}
             self.p_astro, self.p_terr = \
-                        kwargs['padata'].do_pastro_calc(trigger_data, horizons)
+                kwargs['padata'].do_pastro_calc(trigger_data, horizons)
         else:
             self.p_astro, self.p_terr = None, None
 

--- a/pycbc/io/live.py
+++ b/pycbc/io/live.py
@@ -236,9 +236,9 @@ class CandidateForGraceDB(object):
                 'network_snr': network_snrsq ** 0.5,
                 'far': far,
                 'triggered': coinc_ifos,
-                # Active = potentially contributing to significance:
-                # ignore ifos that only contribute to sky loc
-                'active': ifos}
+                # Consider all ifos potentially relevant to detection,
+                # ignore those that only contribute to sky loc
+                'sensitive': ifos}
             horizons = {i: self.psds[i].dist for i in ifos}
             self.p_astro, self.p_terr = \
                 kwargs['padata'].do_pastro_calc(trigger_data, horizons)

--- a/pycbc/io/live.py
+++ b/pycbc/io/live.py
@@ -176,7 +176,7 @@ class CandidateForGraceDB(object):
             if self.snr_series is not None:
                 snr_series_to_xml(self.snr_series[ifo], outdoc, sngl.event_id)
 
-        # Set merger time to the average of trigger peaks from coinc_results ifos
+        # Set merger time to the mean of trigger peaks over coinc_results ifos
         self.merger_time = numpy.mean(
             [coinc_results[f'foreground/{ifo}/end_time'] for ifo in ifos]) \
             + self.time_offset

--- a/pycbc/io/live.py
+++ b/pycbc/io/live.py
@@ -133,7 +133,7 @@ class CandidateForGraceDB(object):
         sngl_inspiral_table = lsctables.New(lsctables.SnglInspiralTable)
         coinc_event_map_table = lsctables.New(lsctables.CoincMapTable)
 
-        # Marker variable to collect template info from a valid sngl trigger
+        # Marker variable recording template info from a valid sngl trigger
         sngl_populated = None
         network_snrsq = 0
         for sngl_id, ifo in enumerate(snr_ifos):
@@ -143,14 +143,13 @@ class CandidateForGraceDB(object):
             sngl.ifo = ifo
             names = [n.split('/')[-1] for n in coinc_results
                      if f'foreground/{ifo}' in n]
-            print(names)
             for name in names:
                 val = coinc_results[f'foreground/{ifo}/{name}']
                 if name == 'end_time':
                     val += self.time_offset
                     sngl.end = lal.LIGOTimeGPS(val)
                 else:
-                    # Explain why this might fail with an AttributeError ???
+                    # Sngl inspirals have a restricted set of attributes
                     try:
                         setattr(sngl, name, val)
                     except AttributeError:

--- a/pycbc/io/live.py
+++ b/pycbc/io/live.py
@@ -63,7 +63,6 @@ class CandidateForGraceDB(object):
         self.template_id = coinc_results[f'foreground/{ifos[0]}/template_id']
         self.coinc_results = coinc_results
         self.ifos = ifos
-        assert len(coinc_ifos) < 3, f"I can't handle {coinc_ifos} coinc ifos!"
         self.psds = kwargs['psds']
         self.basename = None
 

--- a/pycbc/population/live_pastro.py
+++ b/pycbc/population/live_pastro.py
@@ -84,7 +84,7 @@ def trials_type(ntriggered, nactive):
         return 1
     if ntriggered == 2 and nactive == 3:
         return 6
-    # All valid inputs are exhausted, throw an error if we reach this point
+    # All valid inputs are exhausted, throw an error
     raise ValueError(f"I don't know what to do with {ntriggered} triggered and"
                      f" {nactive} active ifos!")
 
@@ -196,7 +196,7 @@ def template_param_bin_types_pa(padata, trdata, horizons):
     dnoise *= padata.bank['tcounts'][bind] / padata.bank['num_t']
     logging.debug('Noise density in bin %.3g', dnoise)
     # Back out trials factor to give noise density for triggered event type
-    dnoise /= float(trials_type(len(tr_ifos), len(trdata['active'])))
+    dnoise /= float(trials_type(len(tr_ifos), len(trdata['sensitive'])))
     logging.debug('Divide by previously applied trials factor: %.3g', dnoise)
 
     # Get signal rate density per year at given SNR

--- a/pycbc/population/live_pastro.py
+++ b/pycbc/population/live_pastro.py
@@ -70,6 +70,25 @@ def noise_density_from_far(far, exp_fac):
     return exp_fac * far
 
 
+def trials_type(ntriggered, nactive):
+    """
+    The trials factor previously applied to an individual event type FAR
+    For single triggers, the factor is the number of active ifos
+    For coincs, the factor is either 1 (in double time) or 6 (in triple time)
+    6 accounts for both the trials over coinc type and pvalue (non-)followup 
+    %%% NOTE - ONLY VALID FOR 2- OR 3-IFO SEARCH %%%
+    """
+    if ntriggered == 1:
+        return nactive
+    elif ntriggered == 2 and nactive == 2:
+        return 1
+    elif ntriggered == 2 and nactive == 3:
+        return 6
+    else:
+        raise ValueError(f"I don't know what to do with {ntriggered} triggered"
+                          " and {nactive} active ifos!")
+
+
 def signal_pdf_from_snr(netsnr, thresh):
     """ FGMC approximate signal distribution ~ SNR ** -4
     """
@@ -123,7 +142,7 @@ def template_param_bin_calc(padata, trdata, horizons):
     dnoise *= padata.bank['tcounts'][bind] / padata.bank['num_t']
     logging.debug('Noise density in bin %.3g', dnoise)
 
-    # Get signal rate density at given SNR
+    # Get signal rate density per year at given SNR
     dsig = signal_pdf_from_snr(trdata['network_snr'],
                                padata.spec['netsnr_thresh'])
     logging.debug('SNR %.3g, signal pdf %.3g', trdata['network_snr'], dsig)
@@ -138,11 +157,70 @@ def template_param_bin_calc(padata, trdata, horizons):
     return p_astro, 1 - p_astro
 
 
+def template_param_bin_types_pa(padata, trdata, horizons):
+    """
+    Parameters
+    ----------
+    padata: PAstroData instance
+        Static information on p astro calculation
+    trdata: dictionary
+        Trigger properties
+    horizons: dictionary
+        BNS horizon distances keyed on ifo
+
+    Returns
+    -------
+    p_astro, p_terr: tuple of floats
+    """
+    massspin = (trdata['mass1'], trdata['mass2'],
+                trdata['spin1z'], trdata['spin2z'])
+    trig_param = triggers.get_param(padata.spec['param'], None, *massspin)
+    # NB digitize gives '1' for first bin, '2' for second etc.
+    bind = numpy.digitize(trig_param, padata.bank['bin_edges']) - 1
+    logging.debug('Trigger %s is in bin %i', padata.spec['param'], bind)
+
+    # Get noise rate density
+    if 'bg_fac' not in padata.spec:
+        expfac = 6.
+    else:
+        expfac = padata.spec['bg_fac']
+
+    # Ifos over trigger threshold
+    tr_ifos = trdata['triggered']
+
+    # FAR is in Hz, therefore convert to rate per year (per SNR)
+    dnoise = noise_density_from_far(trdata['far'], expfac) * lal_s_per_yr
+    logging.debug('FAR %.3g, noise density per yr per SNR %.3g',
+                  trdata['far'], dnoise)
+    # Scale by fraction of templates in bin
+    dnoise *= padata.bank['tcounts'][bind] / padata.bank['num_t']
+    logging.debug('Noise density in bin %.3g', dnoise)
+    # Back out trials factor to give noise density for triggered event type
+    dnoise /= float(trials_type(len(tr_ifos), len(trdata['active'])))
+    logging.debug('Divide by previously applied trials factor: %.3g', dnoise)
+
+    # Get signal rate density per year at given SNR
+    dsig = signal_pdf_from_snr(trdata['network_snr'],
+                               padata.spec['netsnr_thresh'])
+    logging.debug('SNR %.3g, signal pdf %.3g', trdata['network_snr'], dsig)
+    dsig *= padata.spec['sig_per_yr_binned'][bind]
+    logging.debug('Signal density per yr per SNR in bin %.3g', dsig)
+    # Scale by triggered network sensitivity accounting for BNS horizons
+    trig_hor = {i: horizons[i] for i in tr_ifos}
+    dsig *= signal_rate_rescale(trig_hor, padata.spec['ref_bns_horizon'])
+    logging.debug('After triggered network horizon rescaling %.3g', dsig)
+
+    p_astro = dsig / (dsig + dnoise)
+    logging.debug('p_astro %.4g', p_astro)
+    return p_astro, 1 - p_astro
+
+
 __all__ = [
     "check_template_param_bin_data",
     "read_template_bank_param",
     "noise_density_from_far",
     "signal_pdf_from_snr",
     "signal_rate_rescale",
-    "template_param_bin_calc"
+    "template_param_bin_pa"
+    "template_param_bin_types_pa",
 ]

--- a/pycbc/population/live_pastro.py
+++ b/pycbc/population/live_pastro.py
@@ -106,7 +106,7 @@ def signal_rate_rescale(horizons, ref_dhor):
     return net_horizon ** 3. / ref_dhor ** 3.
 
 
-def template_param_bin_calc(padata, trdata, horizons):
+def template_param_bin_pa(padata, trdata, horizons):
     """
     Parameters
     ----------

--- a/pycbc/population/live_pastro.py
+++ b/pycbc/population/live_pastro.py
@@ -227,7 +227,6 @@ def template_param_bin_types_pa(padata, trdata, horizons):
     dsig *= padata.spec['sig_per_yr_binned'][bind]
     logging.debug('Total signal density per yr per SNR in bin %.3g', dsig)
     # Scale by network sensitivity accounting for BNS horizons
-    trig_hor = {i: horizons[i] for i in tr_ifos}
     dsig *= signal_rate_rescale(horizons, padata.spec['ref_bns_horizon'])
     logging.debug('After network horizon rescaling %.3g', dsig)
     # Scale by relative signal rate in triggered ifos

--- a/pycbc/population/live_pastro.py
+++ b/pycbc/population/live_pastro.py
@@ -80,9 +80,9 @@ def trials_type(ntriggered, nactive):
     """
     if ntriggered == 1:
         return nactive
-    elif ntriggered == 2 and nactive == 2:
+    if ntriggered == 2 and nactive == 2:
         return 1
-    elif ntriggered == 2 and nactive == 3:
+    if ntriggered == 2 and nactive == 3:
         return 6
     # All valid inputs are exhausted, throw an error if we reach this point
     raise ValueError(f"I don't know what to do with {ntriggered} triggered and"

--- a/pycbc/population/live_pastro.py
+++ b/pycbc/population/live_pastro.py
@@ -75,7 +75,7 @@ def trials_type(ntriggered, nactive):
     The trials factor previously applied to an individual event type FAR
     For single triggers, the factor is the number of active ifos
     For coincs, the factor is either 1 (in double time) or 6 (in triple time)
-    6 accounts for both the trials over coinc type and pvalue (non-)followup 
+    6 accounts for both the trials over coinc type and pvalue (non-)followup
     %%% NOTE - ONLY VALID FOR 2- OR 3-IFO SEARCH %%%
     """
     if ntriggered == 1:
@@ -84,9 +84,9 @@ def trials_type(ntriggered, nactive):
         return 1
     elif ntriggered == 2 and nactive == 3:
         return 6
-    else:
-        raise ValueError(f"I don't know what to do with {ntriggered} triggered"
-                          " and {nactive} active ifos!")
+    # All valid inputs are exhausted, throw an error if we reach this point
+    raise ValueError(f"I don't know what to do with {ntriggered} triggered and"
+                     f" {nactive} active ifos!")
 
 
 def signal_pdf_from_snr(netsnr, thresh):

--- a/pycbc/population/live_pastro.py
+++ b/pycbc/population/live_pastro.py
@@ -221,6 +221,6 @@ __all__ = [
     "noise_density_from_far",
     "signal_pdf_from_snr",
     "signal_rate_rescale",
-    "template_param_bin_pa"
+    "template_param_bin_pa",
     "template_param_bin_types_pa",
 ]

--- a/pycbc/population/live_pastro_utils.py
+++ b/pycbc/population/live_pastro_utils.py
@@ -27,17 +27,17 @@ def insert_live_pastro_option_group(parser):
 
 # Choices of p astro calc method
 _check_spec = {
-      'template_param_bins': livepa.check_template_param_bin_data
+      'template_param_bins': livepa.check_template_param_bin_data,
       'template_param_bins_types': livepa.check_template_param_bin_data
 }
 
 _read_bank = {
-      'template_param_bins': livepa.read_template_bank_param
+      'template_param_bins': livepa.read_template_bank_param,
       'template_param_bins_types': livepa.read_template_bank_param
 }
 
 _do_calc = {
-      'template_param_bins': livepa.template_param_bin_pa
+      'template_param_bins': livepa.template_param_bin_pa,
       'template_param_bins_types': livepa.template_param_bin_types_pa
 }
 

--- a/pycbc/population/live_pastro_utils.py
+++ b/pycbc/population/live_pastro_utils.py
@@ -25,17 +25,20 @@ def insert_live_pastro_option_group(parser):
     return live_pastro_group
 
 
-# Only one choice so far, allow for more later
+# Choices of p astro calc method
 _check_spec = {
       'template_param_bins': livepa.check_template_param_bin_data
+      'template_param_bins_types': livepa.check_template_param_bin_data
 }
 
 _read_bank = {
       'template_param_bins': livepa.read_template_bank_param
+      'template_param_bins_types': livepa.read_template_bank_param
 }
 
 _do_calc = {
-      'template_param_bins': livepa.template_param_bin_calc
+      'template_param_bins': livepa.template_param_bin_pa
+      'template_param_bins_types': livepa.template_param_bin_types_pa
 }
 
 


### PR DESCRIPTION
To get a better estimate of per-event-type noise and signal densities, remove the current FAR trials factor and account for the triggered detectors in the horizon based sensitivity scaling.