### PR TITLE
Implement 8-fold sky marginalization

### DIFF
--- a/pycbc/inference/models/__init__.py
+++ b/pycbc/inference/models/__init__.py
@@ -32,6 +32,7 @@ from .marginalized_gaussian_noise import MarginalizedPolarization
 from .marginalized_gaussian_noise import MarginalizedHMPolPhase
 from .marginalized_gaussian_noise import MarginalizedTime
 from .brute_marg import BruteParallelGaussianMarginalize
+from .brute_marg import BruteLISASkyModesMarginalize
 from .gated_gaussian_noise import (GatedGaussianNoise, GatedGaussianMargPol)
 from .single_template import SingleTemplate
 from .relbin import Relative
@@ -197,6 +198,7 @@ _models = {_cls.name: _cls for _cls in (
     MarginalizedHMPolPhase,
     MarginalizedTime,
     BruteParallelGaussianMarginalize,
+    BruteLISASkyModesMarginalize,
     GatedGaussianNoise,
     GatedGaussianMargPol,
     SingleTemplate,

--- a/pycbc/inference/models/base.py
+++ b/pycbc/inference/models/base.py
@@ -345,7 +345,7 @@ class BaseModel(metaclass=ABCMeta):
     name = None
 
     def __init__(self, variable_params, static_params=None, prior=None,
-                 sampling_transforms=None, waveform_transforms=None):
+                 sampling_transforms=None, waveform_transforms=None, **kwargs):
         # store variable and static args
         self.variable_params = variable_params
         self.static_params = static_params

--- a/pycbc/inference/models/brute_marg.py
+++ b/pycbc/inference/models/brute_marg.py
@@ -16,6 +16,7 @@
 """This module provides model classes that do brute force marginalization
 using at the likelihood level.
 """
+import math
 import numpy
 
 from multiprocessing import Pool
@@ -42,8 +43,7 @@ class BruteParallelGaussianMarginalize(BaseGaussianNoise):
                  base_model=None,
                  marginalize_phase=None,
                  **kwds):
-        super(BruteParallelGaussianMarginalize, self).__init__(variable_params,
-                                     **kwds)
+        super().__init__(variable_params, **kwds)
 
         from pycbc.inference.models import models
         self.model = models[base_model](variable_params, **kwds)
@@ -91,3 +91,96 @@ class BruteParallelGaussianMarginalize(BaseGaussianNoise):
             self._current_stats.maxl_loglr = maxl_loglrs[maxidx]
             # calculate the marginal loglr and return
             return logsumexp(loglr) - numpy.log(len(self.phase))
+
+
+class BruteLISASkyModesMarginalize(BaseGaussianNoise):
+    name = "brute_lisa_sky_modes_marginalize"
+
+    def __init__(self, variable_params,
+                 cores=1,
+                 base_model=None,
+                 **kwds):
+        super().__init__(variable_params, **kwds)
+
+        from pycbc.inference.models import models
+        kwds.update(models[base_model].extra_args_from_config(
+            kwds['config_object'],
+            "model",
+            skip_args=[])
+        )
+
+        self.model = models[base_model](variable_params, **kwds)
+
+        self.call = likelihood_wrapper(self.model)
+
+        # size of pool for each likelihood call
+        if cores > 1:
+            self.pool = Pool(int(cores))
+            self.mapfunc = self.pool.map
+        else:
+            self.pool = None
+            self.mapfunc = map
+
+
+    @property
+    def _extra_stats(self):
+        stats = self.model._extra_stats
+        return stats
+
+    def _loglr(self):
+        params = []
+        for sym_num in range(8):
+            # FIXME: Literature says this should be 8 points, but I always see
+            #        two polarization modes if I use the indicated 8. Possibly
+            #        there is some issue here, and I'm not using the *right*
+            #        8 points. Note that what I think are the right 8 points
+            #        are acheived by setting this to range(8).
+            pref = self.current_params.copy()
+            lambdal = pref['eclipticlongitude']
+            beta = pref['eclipticlatitude']
+            psi = pref['polarization']
+            inc = pref['inclination']
+
+            pol_num = sym_num // 8
+            sym_num = sym_num % 8
+            long_num = sym_num % 4
+            lat_num = sym_num // 4
+
+            # Apply latitude symmetry mode
+            if lat_num:
+                beta = - beta
+                inc = numpy.pi - inc
+                psi = numpy.pi - psi
+
+            # Apply longitudonal symmetry mode
+            lambdal = (lambdal + long_num * 0.5 * numpy.pi) % (2*numpy.pi)
+            psi = (psi + long_num * 0.5 * numpy.pi) % (2*numpy.pi)
+
+            # Apply additional polarization mode (shouldn't be needed)
+            if pol_num:
+                psi = psi + (math.pi / 2.)
+
+            pref['eclipticlongitude'] = lambdal
+            pref['eclipticlatitude'] = beta
+            pref['polarization'] = psi
+            pref['inclination'] = inc
+            params.append(pref)
+
+        vals = list(self.mapfunc(self.call, params))
+        loglr = numpy.array([v[0] for v in vals])
+
+        max_llr_idx = loglr.argmax()
+        max_llr = loglr[max_llr_idx]
+        marg_lrfac = sum([math.exp(llr - max_llr) for llr in loglr])
+        marg_llr = max_llr + math.log(marg_lrfac/8.)
+
+        # set the stats
+        for sym_num in range(8):
+            setattr(self._current_stats, f'llr_mode_{sym_num}', loglr[sym_num])
+
+        return marg_llr
+
+    @classmethod
+    def from_config(cls, cp, **kwargs):
+        kwargs['config_object'] = cp
+        return super(BruteLISASkyModesMarginalize, cls).from_config(cp, **kwargs)

--- a/pycbc/inference/models/brute_marg.py
+++ b/pycbc/inference/models/brute_marg.py
@@ -222,5 +222,10 @@ class BruteLISASkyModesMarginalize(BaseGaussianNoise):
         rec['loglr'] = loglr[xl]
         rec['loglikelihood'] = self.lognl + rec['loglr']
         self.reconstruct_sky_points = False
-        return self.model.reconstruct(seed=seed)
+        self.current_params.update(rec)
+        rec_return = self.model.reconstruct(seed=seed)
+        for val in ['polarization', 'eclipticlongitude', 'eclipticlatitude',
+                    'inclination']:
+            rec_return[val] = rec[val]
+        return rec_return
 

--- a/pycbc/inference/models/brute_marg.py
+++ b/pycbc/inference/models/brute_marg.py
@@ -214,18 +214,16 @@ class BruteLISASkyModesMarginalize(BaseGaussianNoise):
         self.reconstruct_sky_points = True
         loglr = self.loglr
         xl = draw_sample(loglr)
+        logging.info(f'Found point {xl}')
         # Undo rotations
         pref = self.current_params.copy()
         self._apply_sky_point_rotation(pref, xl)
 
-        rec.update(pref)
+        for val in ['polarization', 'eclipticlongitude', 'eclipticlatitude',
+                    'inclination']:
+            rec[val] = pref[val]
         rec['loglr'] = loglr[xl]
         rec['loglikelihood'] = self.lognl + rec['loglr']
         self.reconstruct_sky_points = False
-        self.current_params.update(rec)
-        rec_return = self.model.reconstruct(seed=seed)
-        for val in ['polarization', 'eclipticlongitude', 'eclipticlatitude',
-                    'inclination']:
-            rec_return[val] = rec[val]
-        return rec_return
+        return self.model.reconstruct(seed=seed, rec=rec)
 

--- a/pycbc/inference/models/brute_marg.py
+++ b/pycbc/inference/models/brute_marg.py
@@ -135,7 +135,6 @@ class BruteLISASkyModesMarginalize(BaseGaussianNoise):
 
         self.reconstruct_sky_points = False
 
-
     @property
     def _extra_stats(self):
         stats = self.model._extra_stats
@@ -197,11 +196,13 @@ class BruteLISASkyModesMarginalize(BaseGaussianNoise):
         pref['polarization'] = psi
         pref['inclination'] = inc
 
-
     @classmethod
     def from_config(cls, cp, **kwargs):
         kwargs['config_object'] = cp
-        return super(BruteLISASkyModesMarginalize, cls).from_config(cp, **kwargs)
+        return super(BruteLISASkyModesMarginalize, cls).from_config(
+            cp, 
+            **kwargs
+        )
 
     def reconstruct(self, seed=None):
         """ Reconstruct a point from unwrapping the 8-fold sky symmetry
@@ -214,7 +215,7 @@ class BruteLISASkyModesMarginalize(BaseGaussianNoise):
         self.reconstruct_sky_points = True
         loglr = self.loglr
         xl = draw_sample(loglr)
-        logging.info(f'Found point {xl}')
+        logging.info('Found point %d', xl)
         # Undo rotations
         pref = self.current_params.copy()
         self._apply_sky_point_rotation(pref, xl)
@@ -226,4 +227,3 @@ class BruteLISASkyModesMarginalize(BaseGaussianNoise):
         rec['loglikelihood'] = self.lognl + rec['loglr']
         self.reconstruct_sky_points = False
         return self.model.reconstruct(seed=seed, rec=rec)
-

--- a/pycbc/inference/models/brute_marg.py
+++ b/pycbc/inference/models/brute_marg.py
@@ -17,11 +17,14 @@
 using at the likelihood level.
 """
 import math
+import logging
 import numpy
 
 from multiprocessing import Pool
-from .gaussian_noise import BaseGaussianNoise
 from scipy.special import logsumexp
+
+from .gaussian_noise import BaseGaussianNoise
+from .tools import draw_sample
 
 _model = None
 class likelihood_wrapper(object):
@@ -98,6 +101,7 @@ class BruteLISASkyModesMarginalize(BaseGaussianNoise):
 
     def __init__(self, variable_params,
                  cores=1,
+                 loop_polarization=False,
                  base_model=None,
                  **kwds):
         super().__init__(variable_params, **kwds)
@@ -121,6 +125,16 @@ class BruteLISASkyModesMarginalize(BaseGaussianNoise):
             self.pool = None
             self.mapfunc = map
 
+        # Do I explicitly check the polarization + pi/2 points
+        # We could also add other arguments here, ie only check longitude
+        # or latitude symmetry points.
+        if loop_polarization:
+            self.num_sky_modes = 16
+        else:
+            self.num_sky_modes = 8
+
+        self.reconstruct_sky_points = False
+
 
     @property
     def _extra_stats(self):
@@ -129,58 +143,84 @@ class BruteLISASkyModesMarginalize(BaseGaussianNoise):
 
     def _loglr(self):
         params = []
-        for sym_num in range(8):
-            # FIXME: Literature says this should be 8 points, but I always see
-            #        two polarization modes if I use the indicated 8. Possibly
-            #        there is some issue here, and I'm not using the *right*
-            #        8 points. Note that what I think are the right 8 points
-            #        are acheived by setting this to range(8).
+        for sym_num in range(self.num_sky_modes):
             pref = self.current_params.copy()
-            lambdal = pref['eclipticlongitude']
-            beta = pref['eclipticlatitude']
-            psi = pref['polarization']
-            inc = pref['inclination']
-
-            pol_num = sym_num // 8
-            sym_num = sym_num % 8
-            long_num = sym_num % 4
-            lat_num = sym_num // 4
-
-            # Apply latitude symmetry mode
-            if lat_num:
-                beta = - beta
-                inc = numpy.pi - inc
-                psi = numpy.pi - psi
-
-            # Apply longitudonal symmetry mode
-            lambdal = (lambdal + long_num * 0.5 * numpy.pi) % (2*numpy.pi)
-            psi = (psi + long_num * 0.5 * numpy.pi) % (2*numpy.pi)
-
-            # Apply additional polarization mode (shouldn't be needed)
-            if pol_num:
-                psi = psi + (math.pi / 2.)
-
-            pref['eclipticlongitude'] = lambdal
-            pref['eclipticlatitude'] = beta
-            pref['polarization'] = psi
-            pref['inclination'] = inc
+            self._apply_sky_point_rotation(pref, sym_num)
             params.append(pref)
 
         vals = list(self.mapfunc(self.call, params))
         loglr = numpy.array([v[0] for v in vals])
 
+        if self.reconstruct_sky_points:
+            return loglr
+
         max_llr_idx = loglr.argmax()
         max_llr = loglr[max_llr_idx]
         marg_lrfac = sum([math.exp(llr - max_llr) for llr in loglr])
-        marg_llr = max_llr + math.log(marg_lrfac/8.)
+        marg_llr = max_llr + math.log(marg_lrfac/self.num_sky_modes)
 
         # set the stats
-        for sym_num in range(8):
+        for sym_num in range(self.num_sky_modes):
             setattr(self._current_stats, f'llr_mode_{sym_num}', loglr[sym_num])
 
         return marg_llr
+
+    def _apply_sky_point_rotation(self, pref, sky_num):
+        """ Apply the sky point rotation for mode sky_num to parameters pref
+        """
+        lambdal = pref['eclipticlongitude']
+        beta = pref['eclipticlatitude']
+        psi = pref['polarization']
+        inc = pref['inclination']
+
+        pol_num = sky_num // 8
+        sky_num = sky_num % 8
+        long_num = sky_num % 4
+        lat_num = sky_num // 4
+
+        # Apply latitude symmetry mode
+        if lat_num:
+            beta = - beta
+            inc = numpy.pi - inc
+            psi = numpy.pi - psi
+
+        # Apply longitudonal symmetry mode
+        lambdal = (lambdal + long_num * 0.5 * numpy.pi) % (2*numpy.pi)
+        psi = (psi + long_num * 0.5 * numpy.pi) % (2*numpy.pi)
+
+        # Apply additional polarization mode (shouldn't be needed)
+        if pol_num:
+            psi = psi + (math.pi / 2.)
+
+        pref['eclipticlongitude'] = lambdal
+        pref['eclipticlatitude'] = beta
+        pref['polarization'] = psi
+        pref['inclination'] = inc
+
 
     @classmethod
     def from_config(cls, cp, **kwargs):
         kwargs['config_object'] = cp
         return super(BruteLISASkyModesMarginalize, cls).from_config(cp, **kwargs)
+
+    def reconstruct(self, seed=None):
+        """ Reconstruct a point from unwrapping the 8-fold sky symmetry
+        """
+        if seed:
+            numpy.random.seed(seed)
+        rec = {}
+
+        logging.info('Reconstruct LISA sky mode symmetry')
+        self.reconstruct_sky_points = True
+        loglr = self.loglr
+        xl = draw_sample(loglr)
+        # Undo rotations
+        pref = self.current_params.copy()
+        self._apply_sky_point_rotation(pref, xl)
+
+        rec.update(pref)
+        rec['loglr'] = loglr[xl]
+        rec['loglikelihood'] = self.lognl + rec['loglr']
+        self.reconstruct_sky_points = False
+        return self.model.reconstruct(seed=seed)
+

--- a/pycbc/inference/models/tools.py
+++ b/pycbc/inference/models/tools.py
@@ -494,14 +494,15 @@ class DistMarg():
         self.marginalize_vector_weights = - numpy.log(self.vsamples)
         return params
 
-    def reconstruct(self, seed=None):
+    def reconstruct(self, rec=None, seed=None):
         """ Reconstruct the distance or vectored marginalized parameter
         of this class.
         """
         if seed:
             numpy.random.seed(seed)
 
-        rec = {}
+        if rec is None:
+            rec = {}
 
         def get_loglr():
             p = self.current_params.copy()


### PR DESCRIPTION
Here's an implementation of adding LISA's sky-mode symmetry into the sampler, by computing the likelihood at all 8 sky mode points, and then summing over them. There's a further symmetry of polarization + /pi/2 and phase -> phase + /pi/2 which could also be included here if setting the "8" to "16".

There's some hacks in here relating to how the brute-force model was implemented, so I think some clean-up is needed.

There's also a question of whether to have this explicitly written out in a class like this, or whether to define this symmetry in a config file.  Posting now in advance of PE hackathon for folks to see.