### PR TITLE
Fix a waveform plugin issue that missed the waveform length estimator

### DIFF
--- a/pycbc/waveform/plugin.py
+++ b/pycbc/waveform/plugin.py
@@ -69,6 +69,7 @@ def add_length_estimator(approximant, function):
     from pycbc.waveform.waveform import td_fd_waveform_transform
     td_fd_waveform_transform(approximant)
 
+
 def retrieve_waveform_plugins():
     """ Process external waveform plugins
     """

--- a/pycbc/waveform/plugin.py
+++ b/pycbc/waveform/plugin.py
@@ -93,3 +93,12 @@ def retrieve_waveform_plugins():
     # Check for waveform length estimates
     for plugin in pkg_resources.iter_entry_points('pycbc.waveform.length'):
         add_length_estimator(plugin.name, plugin.resolve())
+
+        from pycbc.waveform.waveform import cpu_fd,cpu_td
+        fd_apx = list(cpu_fd.keys())
+        td_apx = list(cpu_td.keys())
+        if (plugin.name in fd_apx) and (plugin.name not in td_apx):
+            from pycbc.waveform.waveform import td_wav,get_td_waveform_from_fd
+            import pycbc.scheme as _scheme 
+            cpu_td[plugin.name] = get_td_waveform_from_fd
+            td_wav.update({_scheme.CPUScheme:cpu_td})

--- a/pycbc/waveform/plugin.py
+++ b/pycbc/waveform/plugin.py
@@ -66,6 +66,8 @@ def add_length_estimator(approximant, function):
                            " already in use.".format(approximant))
     _filter_time_lengths[approximant] = function
 
+    from pycbc.waveform.waveform import td_fd_waveform_transform
+    td_fd_waveform_transform(approximant)
 
 def retrieve_waveform_plugins():
     """ Process external waveform plugins
@@ -93,12 +95,4 @@ def retrieve_waveform_plugins():
     # Check for waveform length estimates
     for plugin in pkg_resources.iter_entry_points('pycbc.waveform.length'):
         add_length_estimator(plugin.name, plugin.resolve())
-
-        from pycbc.waveform.waveform import cpu_fd,cpu_td
-        fd_apx = list(cpu_fd.keys())
-        td_apx = list(cpu_td.keys())
-        if (plugin.name in fd_apx) and (plugin.name not in td_apx):
-            from pycbc.waveform.waveform import td_wav,get_td_waveform_from_fd
-            import pycbc.scheme as _scheme 
-            cpu_td[plugin.name] = get_td_waveform_from_fd
-            td_wav.update({_scheme.CPUScheme:cpu_td})
+        

--- a/pycbc/waveform/plugin.py
+++ b/pycbc/waveform/plugin.py
@@ -95,4 +95,3 @@ def retrieve_waveform_plugins():
     # Check for waveform length estimates
     for plugin in pkg_resources.iter_entry_points('pycbc.waveform.length'):
         add_length_estimator(plugin.name, plugin.resolve())
-        

--- a/pycbc/waveform/waveform.py
+++ b/pycbc/waveform/waveform.py
@@ -1020,9 +1020,9 @@ if 'PYCBC_WAVEFORM' in os.environ:
 
 def td_fd_waveform_transform(apx):
     '''If the waveform approximant is in time domain, make a frequency domain
-    version using 'get_fd_waveform_from_td'; If the waveform approximant 
-    is in frequency domain, do interpolation for waveforms with a time length
-    estimator, and make a time domain version using 'get_td_waveform_from_fd'
+    version using 'get_fd_waveform_from_td'; If the waveform approximant is in
+    frequency domain, do interpolation for waveforms with a time length estimator,
+    and make a time domain version using 'get_td_waveform_from_fd'
 
     Parameters
     ----------
@@ -1047,8 +1047,8 @@ def td_fd_waveform_transform(apx):
         # (ex. IMRPhenomXX)
         cpu_td[apx] = get_td_waveform_from_fd
 
-for apx in copy.copy(_filter_time_lengths):
-    td_fd_waveform_transform(apx)
+for waveform in copy.copy(_filter_time_lengths):
+    td_fd_waveform_transform(waveform)
 
 
 td_wav = _scheme.ChooseBySchemeDict()

--- a/pycbc/waveform/waveform.py
+++ b/pycbc/waveform/waveform.py
@@ -1018,7 +1018,17 @@ if 'PYCBC_WAVEFORM' in os.environ:
                        cpu_td=cpu_td,
                        filter_time_lengths=_filter_time_lengths)
 
-for apx in copy.copy(_filter_time_lengths):
+def td_fd_waveform_transform(apx):
+    '''If the waveform approximant is in time domain, make a frequency domain
+    version using 'get_fd_waveform_from_td'; If the waveform approximant 
+    is in frequency domain, do interpolation for waveforms with a time length
+    estimator, and make a time domain version using 'get_td_waveform_from_fd'
+
+    Parameters
+    ----------
+    apx: string
+        The name of a waveform approximant.
+    '''
     fd_apx = list(cpu_fd.keys())
     td_apx = list(cpu_td.keys())
 
@@ -1036,6 +1046,9 @@ for apx in copy.copy(_filter_time_lengths):
         # This will override any existing approximants with the same name
         # (ex. IMRPhenomXX)
         cpu_td[apx] = get_td_waveform_from_fd
+
+for apx in copy.copy(_filter_time_lengths):
+    td_fd_waveform_transform(apx)
 
 
 td_wav = _scheme.ChooseBySchemeDict()

--- a/pycbc/waveform/waveform.py
+++ b/pycbc/waveform/waveform.py
@@ -1018,7 +1018,7 @@ if 'PYCBC_WAVEFORM' in os.environ:
                        cpu_td=cpu_td,
                        filter_time_lengths=_filter_time_lengths)
 
-def td_fd_waveform_transform(apx):
+def td_fd_waveform_transform(approximant):
     '''If the waveform approximant is in time domain, make a frequency domain
     version using 'get_fd_waveform_from_td'; If the waveform approximant is in
     frequency domain, do interpolation for waveforms with a time length estimator,
@@ -1026,29 +1026,29 @@ def td_fd_waveform_transform(apx):
 
     Parameters
     ----------
-    apx: string
+    approximant: string
         The name of a waveform approximant.
     '''
     fd_apx = list(cpu_fd.keys())
     td_apx = list(cpu_td.keys())
 
-    if (apx in td_apx) and (apx not in fd_apx):
+    if (approximant in td_apx) and (approximant not in fd_apx):
         # We can make a fd version of td approximants
-        cpu_fd[apx] = get_fd_waveform_from_td
+        cpu_fd[approximant] = get_fd_waveform_from_td
 
-    if apx in fd_apx:
+    if approximant in fd_apx:
         # We can do interpolation for waveforms that have a time length
-        apx_int = apx + '_INTERP'
+        apx_int = approximant + '_INTERP'
         cpu_fd[apx_int] = get_interpolated_fd_waveform
-        _filter_time_lengths[apx_int] = _filter_time_lengths[apx]
+        _filter_time_lengths[apx_int] = _filter_time_lengths[approximant]
 
         # We can also make a td version of this
         # This will override any existing approximants with the same name
         # (ex. IMRPhenomXX)
-        cpu_td[apx] = get_td_waveform_from_fd
+        cpu_td[approximant] = get_td_waveform_from_fd
 
-for waveform in copy.copy(_filter_time_lengths):
-    td_fd_waveform_transform(waveform)
+for apx in copy.copy(_filter_time_lengths):
+    td_fd_waveform_transform(apx)
 
 
 td_wav = _scheme.ChooseBySchemeDict()


### PR DESCRIPTION
When a user provides a frequency domain (fd) waveform plugin and a waveform length estimator, PyCBC doesn't make a time domain (td) version for the waveform correctly. It seems because PyCBC calls the waveform plugin later than making the fd/td transformation for a waveform model.

This PR encapsulates the fd/td transformation in a function, and explicitly calls this function in the waveform plugin function when the user provides a waveform length estimation.