### PR TITLE
Update to pegasus 5.0.3

### DIFF
--- a/.github/workflows/inference-workflow.yml
+++ b/.github/workflows/inference-workflow.yml
@@ -23,8 +23,7 @@ jobs:
     - name: install pegasus
       run: |
         wget -qO - https://download.pegasus.isi.edu/pegasus/gpg.txt | sudo apt-key add -
-        echo "deb https://download.pegasus.isi.edu/pegasus/ubuntu bionic main" |
- sudo tee -a /etc/apt/sources.list
+        echo "deb https://download.pegasus.isi.edu/pegasus/ubuntu bionic main" | sudo tee -a /etc/apt/sources.list
         sudo apt-get update
         sudo apt-get install pegasus
     - run: sudo apt-get install *fftw3* intel-mkl*

--- a/.github/workflows/inference-workflow.yml
+++ b/.github/workflows/inference-workflow.yml
@@ -22,8 +22,11 @@ jobs:
         sudo systemctl enable condor
     - name: install pegasus
       run: |
-        wget -nv https://download.pegasus.isi.edu/pegasus/ubuntu/dists/bionic/main/binary-amd64/pegasus_5.0.3-1+ubuntu18_amd64.deb
-        sudo apt install ./pegasus_5.0.3-1+ubuntu18_amd64.deb
+        wget -qO - https://download.pegasus.isi.edu/pegasus/gpg.txt | apt-key add -
+        echo "deb https://download.pegasus.isi.edu/pegasus/ubuntu bionic main" |
+ sudo tee -a /etc/apt/sources.list
+        sudo apt-get update
+        sudo apt-get install pegasus
     - run: sudo apt-get install *fftw3* intel-mkl*
     - name: Install pycbc
       run: |

--- a/.github/workflows/inference-workflow.yml
+++ b/.github/workflows/inference-workflow.yml
@@ -22,8 +22,8 @@ jobs:
         sudo systemctl enable condor
     - name: install pegasus
       run: |
-        wget -nv https://download.pegasus.isi.edu/pegasus/ubuntu/dists/bionic/main/binary-amd64/pegasus_5.0.1-1+ubuntu18_amd64.deb
-        sudo apt install ./pegasus_5.0.1-1+ubuntu18_amd64.deb
+        wget -nv https://download.pegasus.isi.edu/pegasus/ubuntu/dists/bionic/main/binary-amd64/pegasus_5.0.3-1+ubuntu18_amd64.deb
+        sudo apt install ./pegasus_5.0.3-1+ubuntu18_amd64.deb
     - run: sudo apt-get install *fftw3* intel-mkl*
     - name: Install pycbc
       run: |

--- a/.github/workflows/inference-workflow.yml
+++ b/.github/workflows/inference-workflow.yml
@@ -30,6 +30,7 @@ jobs:
     - name: Install pycbc
       run: |
         python -m pip install --upgrade 'pip<22.0' setuptools
+        pip install GitPython # This shouldn't really be needed!
         pip install -r requirements.txt
         pip install .
     - name: retrieving data

--- a/.github/workflows/inference-workflow.yml
+++ b/.github/workflows/inference-workflow.yml
@@ -22,7 +22,7 @@ jobs:
         sudo systemctl enable condor
     - name: install pegasus
       run: |
-        wget -qO - https://download.pegasus.isi.edu/pegasus/gpg.txt | apt-key add -
+        wget -qO - https://download.pegasus.isi.edu/pegasus/gpg.txt | sudo apt-key add -
         echo "deb https://download.pegasus.isi.edu/pegasus/ubuntu bionic main" |
  sudo tee -a /etc/apt/sources.list
         sudo apt-get update

--- a/.github/workflows/search-workflow.yml
+++ b/.github/workflows/search-workflow.yml
@@ -23,8 +23,7 @@ jobs:
     - name: install pegasus
       run: |
         wget -qO - https://download.pegasus.isi.edu/pegasus/gpg.txt | sudo apt-key add -
-        echo "deb https://download.pegasus.isi.edu/pegasus/ubuntu bionic main" |
- sudo tee -a /etc/apt/sources.list
+        echo "deb https://download.pegasus.isi.edu/pegasus/ubuntu bionic main" | sudo tee -a /etc/apt/sources.list
         sudo apt-get update
         sudo apt-get install pegasus
     - run: sudo apt-get install *fftw3* intel-mkl*

--- a/.github/workflows/search-workflow.yml
+++ b/.github/workflows/search-workflow.yml
@@ -22,8 +22,11 @@ jobs:
         sudo systemctl enable condor
     - name: install pegasus
       run: |
-        wget -nv https://download.pegasus.isi.edu/pegasus/ubuntu/dists/bionic/main/binary-amd64/pegasus_5.0.3-1+ubuntu18_amd64.deb
-        sudo apt install ./pegasus_5.0.3-1+ubuntu18_amd64.deb
+        wget -qO - https://download.pegasus.isi.edu/pegasus/gpg.txt | apt-key add -
+        echo "deb https://download.pegasus.isi.edu/pegasus/ubuntu bionic main" |
+ sudo tee -a /etc/apt/sources.list
+        sudo apt-get update
+        sudo apt-get install pegasus
     - run: sudo apt-get install *fftw3* intel-mkl*
     - name: Install pycbc
       run: |

--- a/.github/workflows/search-workflow.yml
+++ b/.github/workflows/search-workflow.yml
@@ -22,8 +22,8 @@ jobs:
         sudo systemctl enable condor
     - name: install pegasus
       run: |
-        wget -nv https://download.pegasus.isi.edu/pegasus/ubuntu/dists/bionic/main/binary-amd64/pegasus_5.0.1-1+ubuntu18_amd64.deb
-        sudo apt install ./pegasus_5.0.1-1+ubuntu18_amd64.deb
+        wget -nv https://download.pegasus.isi.edu/pegasus/ubuntu/dists/bionic/main/binary-amd64/pegasus_5.0.3-1+ubuntu18_amd64.deb
+        sudo apt install ./pegasus_5.0.3-1+ubuntu18_amd64.deb
     - run: sudo apt-get install *fftw3* intel-mkl*
     - name: Install pycbc
       run: |

--- a/.github/workflows/search-workflow.yml
+++ b/.github/workflows/search-workflow.yml
@@ -22,7 +22,7 @@ jobs:
         sudo systemctl enable condor
     - name: install pegasus
       run: |
-        wget -qO - https://download.pegasus.isi.edu/pegasus/gpg.txt | apt-key add -
+        wget -qO - https://download.pegasus.isi.edu/pegasus/gpg.txt | sudo apt-key add -
         echo "deb https://download.pegasus.isi.edu/pegasus/ubuntu bionic main" |
  sudo tee -a /etc/apt/sources.list
         sudo apt-get update

--- a/.github/workflows/search-workflow.yml
+++ b/.github/workflows/search-workflow.yml
@@ -30,6 +30,7 @@ jobs:
     - name: Install pycbc
       run: |
         python -m pip install --upgrade 'pip<22.0' setuptools
+        pip install GitPython # This shouldn't really be needed!
         pip install -r requirements.txt
         pip install .
     - name: retrieving frame data

--- a/.github/workflows/tmpltbank-workflow.yml
+++ b/.github/workflows/tmpltbank-workflow.yml
@@ -30,6 +30,7 @@ jobs:
     - name: Install pycbc
       run: |
         python -m pip install --upgrade 'pip<22.0' setuptools
+        pip install GitPython # This shouldn't really be needed!
         pip install -r requirements.txt
         pip install sbank
         pip install .

--- a/.github/workflows/tmpltbank-workflow.yml
+++ b/.github/workflows/tmpltbank-workflow.yml
@@ -22,8 +22,10 @@ jobs:
         sudo systemctl enable condor
     - name: install pegasus
       run: |
-        wget -nv https://download.pegasus.isi.edu/pegasus/ubuntu/dists/bionic/main/binary-amd64/pegasus_5.0.3-1+ubuntu18_amd64.deb
-        sudo apt install ./pegasus_5.0.3-1+ubuntu18_amd64.deb
+        wget -qO - https://download.pegasus.isi.edu/pegasus/gpg.txt | apt-key add -
+        echo "deb https://download.pegasus.isi.edu/pegasus/ubuntu bionic main" | sudo tee -a /etc/apt/sources.list
+        sudo apt-get update
+        sudo apt-get install pegasus
     - run: sudo apt-get install *fftw3* intel-mkl*
     - name: Install pycbc
       run: |

--- a/.github/workflows/tmpltbank-workflow.yml
+++ b/.github/workflows/tmpltbank-workflow.yml
@@ -22,7 +22,7 @@ jobs:
         sudo systemctl enable condor
     - name: install pegasus
       run: |
-        wget -qO - https://download.pegasus.isi.edu/pegasus/gpg.txt | apt-key add -
+        wget -qO - https://download.pegasus.isi.edu/pegasus/gpg.txt | sudo apt-key add -
         echo "deb https://download.pegasus.isi.edu/pegasus/ubuntu bionic main" | sudo tee -a /etc/apt/sources.list
         sudo apt-get update
         sudo apt-get install pegasus

--- a/.github/workflows/tmpltbank-workflow.yml
+++ b/.github/workflows/tmpltbank-workflow.yml
@@ -22,8 +22,8 @@ jobs:
         sudo systemctl enable condor
     - name: install pegasus
       run: |
-        wget -nv https://download.pegasus.isi.edu/pegasus/ubuntu/dists/bionic/main/binary-amd64/pegasus_5.0.1-1+ubuntu18_amd64.deb
-        sudo apt install ./pegasus_5.0.1-1+ubuntu18_amd64.deb
+        wget -nv https://download.pegasus.isi.edu/pegasus/ubuntu/dists/bionic/main/binary-amd64/pegasus_5.0.3-1+ubuntu18_amd64.deb
+        sudo apt install ./pegasus_5.0.3-1+ubuntu18_amd64.deb
     - run: sudo apt-get install *fftw3* intel-mkl*
     - name: Install pycbc
       run: |

--- a/.github/workflows/workflow-tests.yml
+++ b/.github/workflows/workflow-tests.yml
@@ -27,7 +27,7 @@ jobs:
         sudo systemctl enable condor
     - name: install pegasus
       run: |
-        wget -qO - https://download.pegasus.isi.edu/pegasus/gpg.txt | apt-key add -
+        wget -qO - https://download.pegasus.isi.edu/pegasus/gpg.txt | sudo apt-key add -
         echo "deb https://download.pegasus.isi.edu/pegasus/ubuntu bionic main" |
  sudo tee -a /etc/apt/sources.list
         sudo apt-get update

--- a/.github/workflows/workflow-tests.yml
+++ b/.github/workflows/workflow-tests.yml
@@ -27,8 +27,8 @@ jobs:
         sudo systemctl enable condor
     - name: install pegasus
       run: |
-        wget -nv https://download.pegasus.isi.edu/pegasus/ubuntu/dists/bionic/main/binary-amd64/pegasus_5.0.1-1+ubuntu18_amd64.deb
-        sudo apt install ./pegasus_5.0.1-1+ubuntu18_amd64.deb
+        wget -nv https://download.pegasus.isi.edu/pegasus/ubuntu/dists/bionic/main/binary-amd64/pegasus_5.0.3-1+ubuntu18_amd64.deb
+        sudo apt install ./pegasus_5.0.3-1+ubuntu18_amd64.deb
     - run: sudo apt-get install *fftw3* intel-mkl*
     - name: Install pycbc
       run: |

--- a/.github/workflows/workflow-tests.yml
+++ b/.github/workflows/workflow-tests.yml
@@ -27,8 +27,11 @@ jobs:
         sudo systemctl enable condor
     - name: install pegasus
       run: |
-        wget -nv https://download.pegasus.isi.edu/pegasus/ubuntu/dists/bionic/main/binary-amd64/pegasus_5.0.3-1+ubuntu18_amd64.deb
-        sudo apt install ./pegasus_5.0.3-1+ubuntu18_amd64.deb
+        wget -qO - https://download.pegasus.isi.edu/pegasus/gpg.txt | apt-key add -
+        echo "deb https://download.pegasus.isi.edu/pegasus/ubuntu bionic main" |
+ sudo tee -a /etc/apt/sources.list
+        sudo apt-get update
+        sudo apt-get install pegasus
     - run: sudo apt-get install *fftw3* intel-mkl*
     - name: Install pycbc
       run: |

--- a/.github/workflows/workflow-tests.yml
+++ b/.github/workflows/workflow-tests.yml
@@ -28,8 +28,7 @@ jobs:
     - name: install pegasus
       run: |
         wget -qO - https://download.pegasus.isi.edu/pegasus/gpg.txt | sudo apt-key add -
-        echo "deb https://download.pegasus.isi.edu/pegasus/ubuntu bionic main" |
- sudo tee -a /etc/apt/sources.list
+        echo "deb https://download.pegasus.isi.edu/pegasus/ubuntu bionic main" | sudo tee -a /etc/apt/sources.list
         sudo apt-get update
         sudo apt-get install pegasus
     - run: sudo apt-get install *fftw3* intel-mkl*

--- a/.github/workflows/workflow-tests.yml
+++ b/.github/workflows/workflow-tests.yml
@@ -35,6 +35,7 @@ jobs:
     - name: Install pycbc
       run: |
         python -m pip install --upgrade 'pip<22.0' setuptools
+        pip install GitPython # This shouldn't really be needed!
         pip install -r requirements.txt
         pip install .
     - name: running workflow

--- a/examples/search/executables.ini
+++ b/examples/search/executables.ini
@@ -61,6 +61,7 @@ plot_waveform = ${which:pycbc_plot_waveform}
 
 [pegasus_profile]
 condor|request_memory = 1000
+condor|request_disk = 1000
 condor|accounting_group = ligo.dev.o4.cbc.bbh.pycbcoffline
 pycbc|primary_site = condorpool_symlink
 pycbc|submit-directory = ./

--- a/pycbc/workflow/datafind.py
+++ b/pycbc/workflow/datafind.py
@@ -746,27 +746,6 @@ def convert_cachelist_to_filelist(datafindcache_list):
             # Populate the PFNs for the File() we just created
             if frame.url.startswith('file://'):
                 currFile.add_pfn(frame.url, site='local')
-                if frame.url.startswith(
-                    'file:///cvmfs/oasis.opensciencegrid.org/ligo/frames'):
-                    # Datafind returned a URL valid on the osg as well
-                    # so add the additional PFNs to allow OSG access.
-                    currFile.add_pfn(frame.url, site='osg')
-                    currFile.add_pfn(frame.url.replace(
-                        'file:///cvmfs/oasis.opensciencegrid.org/',
-                        'root://xrootd-local.unl.edu/user/'), site='osg')
-                    currFile.add_pfn(frame.url.replace(
-                        'file:///cvmfs/oasis.opensciencegrid.org/',
-                        'gsiftp://red-gridftp.unl.edu/user/'), site='osg')
-                    currFile.add_pfn(frame.url.replace(
-                        'file:///cvmfs/oasis.opensciencegrid.org/',
-                        'gsiftp://ldas-grid.ligo.caltech.edu/hdfs/'), site='osg')
-                elif frame.url.startswith(
-                    'file:///cvmfs/gwosc.osgstorage.org/'):
-                    # Datafind returned a URL valid on the osg as well
-                    # so add the additional PFNs to allow OSG access.
-                    for s in ['osg', 'orangegrid', 'osgconnect']:
-                        currFile.add_pfn(frame.url, site=s)
-                        currFile.add_pfn(frame.url, site="{}-scratch".format(s))
             else:
                 currFile.add_pfn(frame.url, site='notlocal')
 

--- a/pycbc/workflow/datafind.py
+++ b/pycbc/workflow/datafind.py
@@ -746,6 +746,27 @@ def convert_cachelist_to_filelist(datafindcache_list):
             # Populate the PFNs for the File() we just created
             if frame.url.startswith('file://'):
                 currFile.add_pfn(frame.url, site='local')
+                if frame.url.startswith(
+                    'file:///cvmfs/oasis.opensciencegrid.org/ligo/frames'):
+                    # Datafind returned a URL valid on the osg as well
+                    # so add the additional PFNs to allow OSG access.
+                    currFile.add_pfn(frame.url, site='osg')
+                    currFile.add_pfn(frame.url.replace(
+                        'file:///cvmfs/oasis.opensciencegrid.org/',
+                        'root://xrootd-local.unl.edu/user/'), site='osg')
+                    currFile.add_pfn(frame.url.replace(
+                        'file:///cvmfs/oasis.opensciencegrid.org/',
+                        'gsiftp://red-gridftp.unl.edu/user/'), site='osg')
+                    currFile.add_pfn(frame.url.replace(
+                        'file:///cvmfs/oasis.opensciencegrid.org/',
+                        'gsiftp://ldas-grid.ligo.caltech.edu/hdfs/'), site='osg')
+                elif frame.url.startswith(
+                    'file:///cvmfs/gwosc.osgstorage.org/'):
+                    # Datafind returned a URL valid on the osg as well
+                    # so add the additional PFNs to allow OSG access.
+                    for s in ['osg', 'orangegrid', 'osgconnect']:
+                        currFile.add_pfn(frame.url, site=s)
+                        currFile.add_pfn(frame.url, site="{}-scratch".format(s))
             else:
                 currFile.add_pfn(frame.url, site='notlocal')
 

--- a/pycbc/workflow/pegasus_sites.py
+++ b/pycbc/workflow/pegasus_sites.py
@@ -206,8 +206,6 @@ def add_osg_site(sitecat, cp):
                       value="True")
     site.add_profiles(Namespace.CONDOR, key="getenv",
                       value="False")
-    site.add_profiles(Namespace.CONDOR, key="preserve_relative_paths",
-                      value="True")
     site.add_profiles(Namespace.CONDOR, key="+InitializeModulesEnv",
                       value="False")
     site.add_profiles(Namespace.CONDOR, key="+SingularityCleanEnv",

--- a/pycbc/workflow/pegasus_sites.py
+++ b/pycbc/workflow/pegasus_sites.py
@@ -82,8 +82,6 @@ def add_condorpool_symlink_site(sitecat, cp):
     add_site_pegasus_profile(site, cp)
 
     site.add_profiles(Namespace.PEGASUS, key="style", value="condor")
-    site.add_profiles(Namespace.PEGASUS, key="transfer.links",
-                      value="true")
     site.add_profiles(Namespace.PEGASUS, key="data.configuration",
                       value="nonsharedfs")
     site.add_profiles(Namespace.PEGASUS, key='transfer.bypass.input.staging',
@@ -117,6 +115,9 @@ def add_condorpool_copy_site(sitecat, cp):
                       value="nonsharedfs")
     site.add_profiles(Namespace.PEGASUS, key='transfer.bypass.input.staging',
                       value="true")
+    # This explicitly disables symlinking
+    site.add_profiles(Namespace.PEGASUS, key='nosymlink',
+                      value=True)
     site.add_profiles(Namespace.PEGASUS, key='auxillary.local',
                       value="true")
     site.add_profiles(Namespace.CONDOR, key="+OpenScienceGrid",

--- a/pycbc/workflow/pegasus_sites.py
+++ b/pycbc/workflow/pegasus_sites.py
@@ -182,9 +182,10 @@ def add_condorpool_shared_site(sitecat, cp, local_path, local_url):
     site.add_profiles(Namespace.ENV, key="PEGASUS_HOME", value=peg_home)
     sitecat.add_sites(site)
 
-# Would like to add this, but need to figure out some issues with copy
-# protocol. Probably condorio would be the ideal thing to use here, but that
-# doesn't work with our INSPIRAL 111111/FILENAME.xml LFN schem
+
+# NOTE: We should now be able to add a nonfs site. I'll leave this for a
+#       future patch/as demanded feature though. The setup would largely be
+#       the same as the OSG site, except without the OSG specific things.
 
 # def add_condorpool_nonfs_site(sitecat, cp):
 

--- a/pycbc/workflow/pegasus_sites.py
+++ b/pycbc/workflow/pegasus_sites.py
@@ -210,6 +210,8 @@ def add_osg_site(sitecat, cp):
                       value="False")
     site.add_profiles(Namespace.CONDOR, key="+SingularityCleanEnv",
                       value="True")
+    site.add_profiles(Namespace.CONDOR, key="use_x509userproxy",
+                      value="True")
     site.add_profiles(Namespace.CONDOR, key="Requirements",
                       value="(HAS_SINGULARITY =?= TRUE) && "
                             "(HAS_LIGO_FRAMES =?= True) && "

--- a/pycbc/workflow/pegasus_workflow.py
+++ b/pycbc/workflow/pegasus_workflow.py
@@ -647,7 +647,7 @@ class Workflow(object):
                     f.write('--relative-dir work ')
                     # --dir is not being set here because it might be easier to
                     # set this in submit_dax still?
-                    f.write('-vvv ')
+                    f.write('-q ')
                     f.write('--dax {}'.format(filename))
         os.chdir(olddir)
 
@@ -705,6 +705,10 @@ class Workflow(object):
         planner_args['cluster'] = ['label,horizontal']
         planner_args['relative_dir'] = 'work'
         planner_args['cleanup'] = 'inplace'
+        # This quietens the planner a bit. We cannot set the verbosity
+        # directly, which would be better. So be careful, if changing the
+        # pegasus.mode property, it will change the verbosity (a lot).
+        planner_args['quiet'] = 1
 
         # FIXME: The location of output.map is hardcoded in the properties
         #        file. This is overridden for subworkflows, but is not for

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,6 @@ gwdatafind
 
 # Requirements for full pegasus env
 pegasus-wms.api >= 5.0.3
-GitPython>1.0 # Required by pegasus-wms.api, but not declared as such
 # need to pin until pegasus for further upstream
 # addresses incompatibility between old flask/jinja2 and latest markupsafe
 markupsafe <= 2.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ gwdatafind
 
 # Requirements for full pegasus env
 pegasus-wms.api >= 5.0.3
+GitPython>1.0 # Required by pegasus-wms.api, but not declared as such
 # need to pin until pegasus for further upstream
 # addresses incompatibility between old flask/jinja2 and latest markupsafe
 markupsafe <= 2.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ tqdm
 gwdatafind
 
 # Requirements for full pegasus env
-pegasus-wms >= 5.0.3
+pegasus-wms.api >= 5.0.3
 # need to pin until pegasus for further upstream
 # addresses incompatibility between old flask/jinja2 and latest markupsafe
 markupsafe <= 2.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ tqdm
 gwdatafind
 
 # Requirements for full pegasus env
-pegasus-wms >= 5.0.1
+pegasus-wms >= 5.0.3
 # need to pin until pegasus for further upstream
 # addresses incompatibility between old flask/jinja2 and latest markupsafe
 markupsafe <= 2.0.1

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ install_requires =  setup_requires + [
                       'tqdm',
                       'setuptools',
                       'gwdatafind',
-                      'pegasus-wms.api >= 5.0.1',
+                      'pegasus-wms.api >= 5.0.3',
                       'python-ligo-lw >= 1.7.0',
                       'ligo-segments',
                       'lalsuite!=7.2',

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,6 @@ install_requires =  setup_requires + [
                       'setuptools',
                       'gwdatafind',
                       'pegasus-wms.api >= 5.0.3',
-                      'GitPython>1.0',
                       'python-ligo-lw >= 1.7.0',
                       'ligo-segments',
                       'lalsuite!=7.2',

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ install_requires =  setup_requires + [
                       'setuptools',
                       'gwdatafind',
                       'pegasus-wms.api >= 5.0.3',
+                      'GitPython>1.0',
                       'python-ligo-lw >= 1.7.0',
                       'ligo-segments',
                       'lalsuite!=7.2',


### PR DESCRIPTION
Pegasus 5.0.3 has been released which contains a few important fixes for PyCBC:

* It is now possible to have a condorpool_symlink and condorpool_copy site, and they'll now work (with some tweaks to the site catalog to add new options).
* We now have the setup needed for OSG running. Note that we are waiting on a condor fix (currently slated for 10.1, but we've asked for it to go in 10.0), which can cause failures when copying files *back* from OSG if the file LFN includes a relative path (e.g. 140567/H1-INSPIRAL-BLAH.hdf).  However, for use-cases that don't use this (GRB, for e.g. probably doesn't want to use GPS time prefixes) we should be fully ready to use OSG "easily".

I am also requesting this be updated on the LDG machines, I suggest folks do so on local clusters as well because you will need a `pegasus-plan` from the 5.0.3 release to work with these changes.