### PR TITLE
generate LISA TDI-1.5/2.0 noise in PyCBC

### DIFF
--- a/bin/bank/pycbc_geom_aligned_bank
+++ b/bin/bank/pycbc_geom_aligned_bank
@@ -163,7 +163,7 @@ def add_commands_to_cp(commands, options, cp, section_name):
                 cp.set(section_name, command[2:], '')
             elif attr:
                 if isinstance(attr, DictWithDefaultReturn):
-                    cp.set(section_name, command[2:], '')
+                    cp.set(section_name, command[2:], '{}')
                 elif isinstance(attr, dict):
                     cp.set(section_name, command[2:], dict_to_string(attr))
                 else:

--- a/bin/bank/pycbc_geom_aligned_bank
+++ b/bin/bank/pycbc_geom_aligned_bank
@@ -163,7 +163,7 @@ def add_commands_to_cp(commands, options, cp, section_name):
                 cp.set(section_name, command[2:], '')
             elif attr:
                 if isinstance(attr, DictWithDefaultReturn):
-                    cp.set(section_name, command[2:], '{}')
+                    cp.set(section_name, command[2:], '')
                 elif isinstance(attr, dict):
                     cp.set(section_name, command[2:], dict_to_string(attr))
                 else:

--- a/bin/bank/pycbc_geom_aligned_bank
+++ b/bin/bank/pycbc_geom_aligned_bank
@@ -142,7 +142,19 @@ class BankVerification(wf.Executable):
 
         return node
 
+def dict_to_string(arg_dict):
+    attr_str = ""
+    for i in arg_dict.keys():
+        if isinstance(arg_dict[i], dict):
+            for j in arg_dict[i].keys():
+                attr_str += "%s:%s:%s " % (i, j, arg_dict[i][j])
+        else:
+            attr_str += "%s:%s " % (i, arg_dict[i])
+    attr_str = attr_str[:-1]
+    return attr_str
+
 def add_commands_to_cp(commands, options, cp, section_name):
+    from pycbc.types.optparse import DictWithDefaultReturn
     for command in commands:
         command_uscore = (command.replace('-','_'))[2:]
         if hasattr(options, command_uscore):
@@ -150,7 +162,12 @@ def add_commands_to_cp(commands, options, cp, section_name):
             if attr is True:
                 cp.set(section_name, command[2:], '')
             elif attr:
-                cp.set(section_name, command[2:], str(attr))
+                if isinstance(attr, DictWithDefaultReturn):
+                    cp.set(section_name, command[2:], '{}')
+                elif isinstance(attr, dict):
+                    cp.set(section_name, command[2:], dict_to_string(attr))
+                else:
+                    cp.set(section_name, command[2:], str(attr))
 
 # Read command line options
 _desc = __doc__[1:]

--- a/bin/pycbc_condition_strain
+++ b/bin/pycbc_condition_strain
@@ -75,6 +75,7 @@ parser.add_argument('--frame-duration', metavar='SECONDS', type=int,
                          'in seconds')
 
 pycbc.strain.insert_strain_option_group(parser)
+pycbc.psd.insert_psd_option_group(parser)
 args = parser.parse_args()
 
 if args.frame_duration is not None and args.frame_duration <= 0:

--- a/bin/pycbc_condition_strain
+++ b/bin/pycbc_condition_strain
@@ -75,7 +75,6 @@ parser.add_argument('--frame-duration', metavar='SECONDS', type=int,
                          'in seconds')
 
 pycbc.strain.insert_strain_option_group(parser)
-pycbc.psd.insert_psd_option_group(parser)
 args = parser.parse_args()
 
 if args.frame_duration is not None and args.frame_duration <= 0:

--- a/pycbc/io/ligolw.py
+++ b/pycbc/io/ligolw.py
@@ -149,7 +149,7 @@ def create_process_table(document, program_name=None, detectors=None,
     opts = options.copy()
     key_del = []
     for key, value in opts.items():
-        if value not in FromPyType:
+        if type(value) not in tuple(FromPyType.keys()):
             key_del.append(key)
     if len(key_del) != 0:
         for key in key_del:

--- a/pycbc/io/ligolw.py
+++ b/pycbc/io/ligolw.py
@@ -137,6 +137,7 @@ def create_process_table(document, program_name=None, detectors=None,
     """Create a LIGOLW process table with sane defaults, add it to a LIGOLW
     document, and return it.
     """
+
     if program_name is None:
         program_name = os.path.basename(sys.argv[0])
     if options is None:
@@ -145,8 +146,13 @@ def create_process_table(document, program_name=None, detectors=None,
     # ligo.lw does not like `cvs_entry_time` being an empty string
     cvs_entry_time = pycbc_version.date or None
 
+    opts = options.copy()
+    for key, value in opts.items():
+        if value not in FromPyType:
+            opts.pop(key)
+
     process = ligolw_process.register_to_xmldoc(
-            document, program_name, options, version=pycbc_version.version,
+            document, program_name, opts, version=pycbc_version.version,
             cvs_repository='pycbc/'+pycbc_version.git_branch,
             cvs_entry_time=cvs_entry_time, instruments=detectors,
             comment=comment)

--- a/pycbc/io/ligolw.py
+++ b/pycbc/io/ligolw.py
@@ -147,8 +147,12 @@ def create_process_table(document, program_name=None, detectors=None,
     cvs_entry_time = pycbc_version.date or None
 
     opts = options.copy()
+    key_del = []
     for key, value in opts.items():
         if value not in FromPyType:
+            key_del.append(key)
+    if len(key_del) != 0:
+        for key in key_del:
             opts.pop(key)
 
     process = ligolw_process.register_to_xmldoc(

--- a/pycbc/psd/__init__.py
+++ b/pycbc/psd/__init__.py
@@ -203,7 +203,8 @@ def insert_psd_option_group(parser, output=True, include_data_options=True):
     psd_options.add_argument("--fake-strain-extra-args",
                              nargs='+', action=DictOptionAction,
                              metavar='PARAM:VALUE', default={}, type=dict,
-                             help="(optional) Extra arguments passed to the PSD models.")
+                             help="(optional) Extra arguments passed to the "
+                                  "PSD models.")
     # Options specific to XML PSD files
     psd_options.add_argument("--psd-file-xml-ifo-string",
                              help="If using an XML PSD file, use the PSD in "

--- a/pycbc/psd/__init__.py
+++ b/pycbc/psd/__init__.py
@@ -84,7 +84,7 @@ def from_cli(opt, length, delta_f, low_frequency_cutoff,
         # PSD from lalsimulation or file
         if opt.psd_model:
             psd = from_string(opt.psd_model, length, delta_f, f_low,
-                              **opt.extra_args)
+                              **opt.psd_extra_args)
         elif opt.psd_file or opt.asd_file:
             if opt.asd_file:
                 psd_file_name = opt.asd_file

--- a/pycbc/psd/__init__.py
+++ b/pycbc/psd/__init__.py
@@ -187,6 +187,11 @@ def insert_psd_option_group(parser, output=True, include_data_options=True):
     psd_options.add_argument("--psd-model",
                              help="Get PSD from given analytical model. ",
                              choices=get_psd_model_list())
+    psd_options.add_argument("--fake-strain-extra-args",
+                             nargs='+', action=DictOptionAction,
+                             metavar='PARAM:VALUE', default={}, type=float,
+                             help="(optional) Extra arguments passed to "
+                             "the PSD models.")
     psd_options.add_argument("--psd-file",
                              help="Get PSD using given PSD ASCII file")
     psd_options.add_argument("--asd-file",
@@ -283,6 +288,11 @@ def insert_psd_option_group_multi_ifo(parser):
                           action=MultiDetOptionAction, metavar='IFO:MODEL',
                           help="Get PSD from given analytical model. "
                           "Choose from %s" %(', '.join(get_psd_model_list()),))
+    psd_options.add_argument("--fake-strain-extra-args",
+                             nargs='+', action=MultiDetDictOptionAction,
+                             metavar='DETECTOR:PARAM:VALUE', default={},
+                             type=float, help="(optional) Extra arguments "
+                             "passed to the PSD models.")
     psd_options.add_argument("--psd-file", nargs="+",
                           action=MultiDetOptionAction, metavar='IFO:FILE',
                           help="Get PSD using given PSD ASCII file")

--- a/pycbc/psd/__init__.py
+++ b/pycbc/psd/__init__.py
@@ -200,11 +200,6 @@ def insert_psd_option_group(parser, output=True, include_data_options=True):
                              help="(Optional) What truncation method to use "
                                   "when applying psd-inverse-length. If not "
                                   "provided, a hard truncation will be used.")
-    psd_options.add_argument("--fake-strain-extra-args",
-                             nargs='+', action=DictOptionAction,
-                             metavar='PARAM:VALUE', default={}, type=dict,
-                             help="(optional) Extra arguments passed to the "
-                                  "PSD models.")
     # Options specific to XML PSD files
     psd_options.add_argument("--psd-file-xml-ifo-string",
                              help="If using an XML PSD file, use the PSD in "
@@ -326,12 +321,6 @@ def insert_psd_option_group_multi_ifo(parser):
                              help="(Optional) What truncation method to use "
                                   "when applying psd-inverse-length. If not "
                                   "provided, a hard truncation will be used.")
-    psd_options.add_argument("--fake-strain-extra-args",
-                             nargs='+', action=MultiDetDictOptionAction,
-                             metavar='DETECTOR:PARAM:VALUE',
-                             default={},type=dict,
-                             help="(optional) Extra arguments passed to the "
-                                  "PSD models.")
     psd_options.add_argument("--psd-output", nargs="+",
                           action=MultiDetOptionAction, metavar='IFO:FILE',
                           help="(Optional) Write PSD to specified file")

--- a/pycbc/psd/__init__.py
+++ b/pycbc/psd/__init__.py
@@ -28,7 +28,7 @@ from pycbc.types import required_opts, required_opts_multi_ifo
 from pycbc.types import ensure_one_opt, ensure_one_opt_multi_ifo
 
 def from_cli(opt, length, delta_f, low_frequency_cutoff,
-             strain=None, dyn_range_factor=1, precision=None, **kwargs):
+             strain=None, dyn_range_factor=1, precision=None):
     """Parses the CLI options related to the noise PSD and returns a
     FrequencySeries with the corresponding PSD. If necessary, the PSD is
     linearly interpolated to achieve the resolution specified in the CLI.
@@ -59,8 +59,6 @@ def from_cli(opt, length, delta_f, low_frequency_cutoff,
         If 'single' the PSD will be converted to float32, if not already in
         that precision. If 'double' the PSD will be converted to float64, if
         not already in that precision.
-    **kwargs :
-        All other keyword arguments are passed to the PSD model.
     Returns
     -------
     psd : FrequencySeries

--- a/pycbc/psd/__init__.py
+++ b/pycbc/psd/__init__.py
@@ -84,7 +84,7 @@ def from_cli(opt, length, delta_f, low_frequency_cutoff,
         # PSD from lalsimulation or file
         if opt.psd_model:
             psd = from_string(opt.psd_model, length, delta_f, f_low,
-                              **opt.fake_strain_extra_args)
+                              **opt.extra_args)
         elif opt.psd_file or opt.asd_file:
             if opt.asd_file:
                 psd_file_name = opt.asd_file
@@ -187,7 +187,7 @@ def insert_psd_option_group(parser, output=True, include_data_options=True):
     psd_options.add_argument("--psd-model",
                              help="Get PSD from given analytical model. ",
                              choices=get_psd_model_list())
-    psd_options.add_argument("--fake-strain-extra-args",
+    psd_options.add_argument("--extra-args",
                              nargs='+', action=DictOptionAction,
                              metavar='PARAM:VALUE', default={}, type=float,
                              help="(optional) Extra arguments passed to "
@@ -288,7 +288,7 @@ def insert_psd_option_group_multi_ifo(parser):
                           action=MultiDetOptionAction, metavar='IFO:MODEL',
                           help="Get PSD from given analytical model. "
                           "Choose from %s" %(', '.join(get_psd_model_list()),))
-    psd_options.add_argument("--fake-strain-extra-args",
+    psd_options.add_argument("--extra-args",
                              nargs='+', action=MultiDetDictOptionAction,
                              metavar='DETECTOR:PARAM:VALUE', default={},
                              type=float, help="(optional) Extra arguments "

--- a/pycbc/psd/__init__.py
+++ b/pycbc/psd/__init__.py
@@ -59,7 +59,7 @@ def from_cli(opt, length, delta_f, low_frequency_cutoff,
         If 'single' the PSD will be converted to float32, if not already in
         that precision. If 'double' the PSD will be converted to float64, if
         not already in that precision.
-    **kwargs : 
+    **kwargs :
         All other keyword arguments are passed to the PSD model.
     Returns
     -------

--- a/pycbc/psd/__init__.py
+++ b/pycbc/psd/__init__.py
@@ -84,7 +84,7 @@ def from_cli(opt, length, delta_f, low_frequency_cutoff,
         if opt.psd_model:
             if hasattr(opt, 'fake_strain_extra_args'):
                 psd = from_string(opt.psd_model, length, delta_f, f_low,
-                                opt.fake_strain_extra_args)
+                                  opt.fake_strain_extra_args)
             else:
                 psd = from_string(opt.psd_model, length, delta_f, f_low)
         elif opt.psd_file or opt.asd_file:

--- a/pycbc/psd/__init__.py
+++ b/pycbc/psd/__init__.py
@@ -23,7 +23,7 @@ from pycbc.psd.estimate import *
 from pycbc.psd.variation import *
 from pycbc.types import float32,float64
 from pycbc.types import MultiDetOptionAppendAction, MultiDetOptionAction
-from pycbc.types import DictOptionAction
+from pycbc.types import DictOptionAction, MultiDetDictOptionAction
 from pycbc.types import copy_opts_for_single_ifo
 from pycbc.types import required_opts, required_opts_multi_ifo
 from pycbc.types import ensure_one_opt, ensure_one_opt_multi_ifo
@@ -326,6 +326,12 @@ def insert_psd_option_group_multi_ifo(parser):
                              help="(Optional) What truncation method to use "
                                   "when applying psd-inverse-length. If not "
                                   "provided, a hard truncation will be used.")
+    psd_options.add_argument("--fake-strain-extra-args",
+                             nargs='+', action=MultiDetDictOptionAction,
+                             metavar='DETECTOR:PARAM:VALUE',
+                             default={},type=dict,
+                             help="(optional) Extra arguments passed to the "
+                                  "PSD models.")
     psd_options.add_argument("--psd-output", nargs="+",
                           action=MultiDetOptionAction, metavar='IFO:FILE',
                           help="(Optional) Write PSD to specified file")

--- a/pycbc/psd/__init__.py
+++ b/pycbc/psd/__init__.py
@@ -82,7 +82,8 @@ def from_cli(opt, length, delta_f, low_frequency_cutoff,
     if (opt.psd_model or opt.psd_file or opt.asd_file):
         # PSD from lalsimulation or file
         if opt.psd_model:
-            psd = from_string(opt.psd_model, length, delta_f, f_low, **kwargs)
+            psd = from_string(opt.psd_model, length, delta_f, f_low,
+                                opt.fake_strain_extra_args)
         elif opt.psd_file or opt.asd_file:
             if opt.asd_file:
                 psd_file_name = opt.asd_file

--- a/pycbc/psd/__init__.py
+++ b/pycbc/psd/__init__.py
@@ -82,11 +82,8 @@ def from_cli(opt, length, delta_f, low_frequency_cutoff,
     if (opt.psd_model or opt.psd_file or opt.asd_file):
         # PSD from lalsimulation or file
         if opt.psd_model:
-            if hasattr(opt, 'fake_strain_extra_args'):
-                psd = from_string(opt.psd_model, length, delta_f, f_low,
-                                  opt.fake_strain_extra_args)
-            else:
-                psd = from_string(opt.psd_model, length, delta_f, f_low)
+            psd = from_string(opt.psd_model, length, delta_f, f_low,
+                              **opt.fake_strain_extra_args)
         elif opt.psd_file or opt.asd_file:
             if opt.asd_file:
                 psd_file_name = opt.asd_file
@@ -579,4 +576,3 @@ def associate_psds_to_multi_ifo_segments(opt, fd_segments, gwstrain, flen,
         associate_psds_to_single_ifo_segments(opt, segments, strain, flen,
                 delta_f, flow, ifo, dyn_range_factor=dyn_range_factor,
                 precision=precision)
-

--- a/pycbc/psd/__init__.py
+++ b/pycbc/psd/__init__.py
@@ -23,6 +23,7 @@ from pycbc.psd.estimate import *
 from pycbc.psd.variation import *
 from pycbc.types import float32,float64
 from pycbc.types import MultiDetOptionAppendAction, MultiDetOptionAction
+from pycbc.types import DictOptionAction
 from pycbc.types import copy_opts_for_single_ifo
 from pycbc.types import required_opts, required_opts_multi_ifo
 from pycbc.types import ensure_one_opt, ensure_one_opt_multi_ifo
@@ -199,6 +200,10 @@ def insert_psd_option_group(parser, output=True, include_data_options=True):
                              help="(Optional) What truncation method to use "
                                   "when applying psd-inverse-length. If not "
                                   "provided, a hard truncation will be used.")
+    psd_options.add_argument("--fake-strain-extra-args",
+                             nargs='+', action=DictOptionAction,
+                             metavar='PARAM:VALUE', default={}, type=dict,
+                             help="(optional) Extra arguments passed to the PSD models.")
     # Options specific to XML PSD files
     psd_options.add_argument("--psd-file-xml-ifo-string",
                              help="If using an XML PSD file, use the PSD in "

--- a/pycbc/psd/__init__.py
+++ b/pycbc/psd/__init__.py
@@ -82,8 +82,11 @@ def from_cli(opt, length, delta_f, low_frequency_cutoff,
     if (opt.psd_model or opt.psd_file or opt.asd_file):
         # PSD from lalsimulation or file
         if opt.psd_model:
-            psd = from_string(opt.psd_model, length, delta_f, f_low,
+            if hasattr(opt, 'fake_strain_extra_args'):
+                psd = from_string(opt.psd_model, length, delta_f, f_low,
                                 opt.fake_strain_extra_args)
+            else:
+                psd = from_string(opt.psd_model, length, delta_f, f_low)
         elif opt.psd_file or opt.asd_file:
             if opt.asd_file:
                 psd_file_name = opt.asd_file

--- a/pycbc/psd/__init__.py
+++ b/pycbc/psd/__init__.py
@@ -187,7 +187,7 @@ def insert_psd_option_group(parser, output=True, include_data_options=True):
     psd_options.add_argument("--psd-model",
                              help="Get PSD from given analytical model. ",
                              choices=get_psd_model_list())
-    psd_options.add_argument("--extra-args",
+    psd_options.add_argument("--psd-extra-args",
                              nargs='+', action=DictOptionAction,
                              metavar='PARAM:VALUE', default={}, type=float,
                              help="(optional) Extra arguments passed to "
@@ -288,7 +288,7 @@ def insert_psd_option_group_multi_ifo(parser):
                           action=MultiDetOptionAction, metavar='IFO:MODEL',
                           help="Get PSD from given analytical model. "
                           "Choose from %s" %(', '.join(get_psd_model_list()),))
-    psd_options.add_argument("--extra-args",
+    psd_options.add_argument("--psd-extra-args",
                              nargs='+', action=MultiDetDictOptionAction,
                              metavar='DETECTOR:PARAM:VALUE', default={},
                              type=float, help="(optional) Extra arguments "

--- a/pycbc/psd/__init__.py
+++ b/pycbc/psd/__init__.py
@@ -28,7 +28,7 @@ from pycbc.types import required_opts, required_opts_multi_ifo
 from pycbc.types import ensure_one_opt, ensure_one_opt_multi_ifo
 
 def from_cli(opt, length, delta_f, low_frequency_cutoff,
-             strain=None, dyn_range_factor=1, precision=None):
+             strain=None, dyn_range_factor=1, precision=None, **kwargs):
     """Parses the CLI options related to the noise PSD and returns a
     FrequencySeries with the corresponding PSD. If necessary, the PSD is
     linearly interpolated to achieve the resolution specified in the CLI.
@@ -59,7 +59,8 @@ def from_cli(opt, length, delta_f, low_frequency_cutoff,
         If 'single' the PSD will be converted to float32, if not already in
         that precision. If 'double' the PSD will be converted to float64, if
         not already in that precision.
-
+    **kwargs : 
+        All other keyword arguments are passed to the PSD model.
     Returns
     -------
     psd : FrequencySeries
@@ -83,7 +84,7 @@ def from_cli(opt, length, delta_f, low_frequency_cutoff,
     if (opt.psd_model or opt.psd_file or opt.asd_file):
         # PSD from lalsimulation or file
         if opt.psd_model:
-            psd = from_string(opt.psd_model, length, delta_f, f_low)
+            psd = from_string(opt.psd_model, length, delta_f, f_low, **kwargs)
         elif opt.psd_file or opt.asd_file:
             if opt.asd_file:
                 psd_file_name = opt.asd_file

--- a/pycbc/psd/analytical.py
+++ b/pycbc/psd/analytical.py
@@ -18,12 +18,14 @@
 """Provides reference PSDs from LALSimulation and pycbc.psd.analytical_space.
 
 More information about how to use these ground-based detectors' PSD can be
-found in the guide about :ref:`Analytic PSDs from lalsimulation`. For space-borne
-ones, see `pycbc.psd.analytical_space` module.
+found in the guide about :ref:`Analytic PSDs from lalsimulation`. For
+space-borne ones, see `pycbc.psd.analytical_space` module.
 """
 import numbers
 from pycbc.types import FrequencySeries
-from pycbc.psd.analytical_space import *
+from pycbc.psd.analytical_space import (
+    analytical_psd_lisa_tdi_1p5_XYZ, analytical_psd_lisa_tdi_2p0_XYZ,
+    analytical_psd_lisa_tdi_1p5_AE, analytical_psd_lisa_tdi_1p5_T)
 import lal
 import numpy
 

--- a/pycbc/psd/analytical.py
+++ b/pycbc/psd/analytical.py
@@ -25,7 +25,8 @@ import numbers
 from pycbc.types import FrequencySeries
 from pycbc.psd.analytical_space import (
     analytical_psd_lisa_tdi_1p5_XYZ, analytical_psd_lisa_tdi_2p0_XYZ,
-    analytical_psd_lisa_tdi_1p5_AE, analytical_psd_lisa_tdi_1p5_T)
+    analytical_psd_lisa_tdi_1p5_AE, analytical_psd_lisa_tdi_1p5_T,
+    sh_transformed_psd_lisa_tdi_XYZ)
 import lal
 import numpy
 
@@ -171,4 +172,5 @@ pycbc_analytical_psds = {
     'analytical_psd_lisa_tdi_2p0_XYZ' : analytical_psd_lisa_tdi_2p0_XYZ,
     'analytical_psd_lisa_tdi_1p5_AE' : analytical_psd_lisa_tdi_1p5_AE,
     'analytical_psd_lisa_tdi_1p5_T' : analytical_psd_lisa_tdi_1p5_T,
+    'sh_transformed_psd_lisa_tdi_XYZ' : sh_transformed_psd_lisa_tdi_XYZ,
 }

--- a/pycbc/psd/analytical.py
+++ b/pycbc/psd/analytical.py
@@ -165,8 +165,8 @@ def flat_unity(length, delta_f, low_freq_cutoff):
 # dict of analytical PSDs coded in PyCBC
 pycbc_analytical_psds = {
     'flat_unity' : flat_unity,
-    'analytical_psd_lisa_tdi_1p5' : analytical_psd_lisa_tdi_1p5,
-    'analytical_psd_lisa_tdi_2p0' : analytical_psd_lisa_tdi_2p0,
-    'analytical_psd_lisa_tdi_A_E_1p5' : analytical_psd_lisa_tdi_A_E_1p5,
-    'analytical_psd_lisa_tdi_T_1p5' : analytical_psd_lisa_tdi_T_1p5,
+    'analytical_psd_lisa_tdi_1p5_XYZ' : analytical_psd_lisa_tdi_1p5_XYZ,
+    'analytical_psd_lisa_tdi_2p0_XYZ' : analytical_psd_lisa_tdi_2p0_XYZ,
+    'analytical_psd_lisa_tdi_1p5_AE' : analytical_psd_lisa_tdi_1p5_AE,
+    'analytical_psd_lisa_tdi_1p5_T' : analytical_psd_lisa_tdi_1p5_T,
 }

--- a/pycbc/psd/analytical_space.py
+++ b/pycbc/psd/analytical_space.py
@@ -120,8 +120,11 @@ def analytical_psd_lisa_tdi_1p5_XYZ(length, delta_f, low_freq_cutoff,
     -----
         Pease see Eq.(19) in <LISA-LCST-SGS-TN-001> for more details.
     """
+    len_arm = np.float64(len_arm)
+    acc_noise_level = np.float64(acc_noise_level)
+    oms_noise_level = np.float64(oms_noise_level)
     psd = []
-    fr = np.linspace(2e-5, 1.1, length)
+    fr = np.linspace(low_freq_cutoff, (length-1)*2*delta_f, length)
     for f in fr:
         [s_acc_nu, s_oms_nu] = lisa_psd_components(
                                 f, acc_noise_level, oms_noise_level)
@@ -157,8 +160,11 @@ def analytical_psd_lisa_tdi_2p0_XYZ(length, delta_f, low_freq_cutoff,
     -----
         Pease see Eq.(20) in <LISA-LCST-SGS-TN-001> for more details.
     """
+    len_arm = np.float64(len_arm)
+    acc_noise_level = np.float64(acc_noise_level)
+    oms_noise_level = np.float64(oms_noise_level)
     psd = []
-    fr = np.linspace(2e-5, 1.1, length)
+    fr = np.linspace(low_freq_cutoff, (length-1)*2*delta_f, length)
     for f in fr:
         [s_acc_nu, s_oms_nu] = lisa_psd_components(
                                 f, acc_noise_level, oms_noise_level)
@@ -195,8 +201,11 @@ def analytical_csd_lisa_tdi_1p5_XY(length, delta_f, low_freq_cutoff,
     -----
         Pease see Eq.(56) in <LISA-LCST-SGS-MAN-001> for more details.
     """
+    len_arm = np.float64(len_arm)
+    acc_noise_level = np.float64(acc_noise_level)
+    oms_noise_level = np.float64(oms_noise_level)
     csd = []
-    fr = np.linspace(2e-5, 1.1, length)
+    fr = np.linspace(low_freq_cutoff, (length-1)*2*delta_f, length)
     for f in fr:
         omega_len = 2*np.pi*f * len_arm/constants.c.value
         [s_acc_nu, s_oms_nu] = lisa_psd_components(
@@ -232,8 +241,11 @@ def analytical_psd_lisa_tdi_1p5_AE(length, delta_f, low_freq_cutoff,
     -----
         Pease see Eq.(58) in <LISA-LCST-SGS-MAN-001> for more details.
     """
+    len_arm = np.float64(len_arm)
+    acc_noise_level = np.float64(acc_noise_level)
+    oms_noise_level = np.float64(oms_noise_level)
     psd = []
-    fr = np.linspace(2e-5, 1.1, length)
+    fr = np.linspace(low_freq_cutoff, (length-1)*2*delta_f, length)
     for f in fr:
         [s_acc_nu, s_oms_nu] = lisa_psd_components(
                                 f, acc_noise_level, oms_noise_level)
@@ -271,8 +283,11 @@ def analytical_psd_lisa_tdi_1p5_T(length, delta_f, low_freq_cutoff,
     -----
         Pease see Eq.(59) in <LISA-LCST-SGS-MAN-001> for more details.
     """
+    len_arm = np.float64(len_arm)
+    acc_noise_level = np.float64(acc_noise_level)
+    oms_noise_level = np.float64(oms_noise_level)
     psd = []
-    fr = np.linspace(2e-5, 1.1, length)
+    fr = np.linspace(low_freq_cutoff, (length-1)*2*delta_f, length)
     for f in fr:
         [s_acc_nu, s_oms_nu] = lisa_psd_components(
                                 f, acc_noise_level, oms_noise_level)

--- a/pycbc/psd/analytical_space.py
+++ b/pycbc/psd/analytical_space.py
@@ -95,9 +95,9 @@ def lisa_psd_components(f, acc_noise_level=3e-15, oms_noise_level=15e-12):
 
     return [low_freq_component, high_freq_component]
 
-def analytical_psd_lisa_tdi_1p5(length, delta_f, low_freq_cutoff,
+def analytical_psd_lisa_tdi_1p5_XYZ(length, delta_f, low_freq_cutoff,
     len_arm=2.5e9, acc_noise_level=3e-15, oms_noise_level=15e-12):
-    r""" The TDI-1.5 analytical PSD for LISA.
+    r""" The TDI-1.5 analytical PSD (X,Y,Z channel) for LISA.
     Parameters
     ----------
     length : int
@@ -115,7 +115,7 @@ def analytical_psd_lisa_tdi_1p5(length, delta_f, low_freq_cutoff,
     Returns
     -------
     fseries : FrequencySeries
-        The TDI-1.5 PSD for LISA.
+        The TDI-1.5 PSD (X,Y,Z channel) for LISA.
     Notes
     -----
         Pease see Eq.(19) in <LISA-LCST-SGS-TN-001> for more details.
@@ -132,9 +132,9 @@ def analytical_psd_lisa_tdi_1p5(length, delta_f, low_freq_cutoff,
 
     return fseries
 
-def analytical_psd_lisa_tdi_2p0(length, delta_f, low_freq_cutoff,
+def analytical_psd_lisa_tdi_2p0_XYZ(length, delta_f, low_freq_cutoff,
     len_arm=2.5e9, acc_noise_level=3e-15, oms_noise_level=15e-12):
-    r""" The TDI-2.0 analytical PSD for LISA.
+    r""" The TDI-2.0 analytical PSD (X,Y,Z channel) for LISA.
     Parameters
     ----------
     length : int
@@ -152,7 +152,7 @@ def analytical_psd_lisa_tdi_2p0(length, delta_f, low_freq_cutoff,
     Returns
     -------
     fseries : FrequencySeries
-        The TDI-2.0 PSD for LISA.
+        The TDI-2.0 PSD (X,Y,Z channel) for LISA.
     Notes
     -----
         Pease see Eq.(20) in <LISA-LCST-SGS-TN-001> for more details.
@@ -170,7 +170,7 @@ def analytical_psd_lisa_tdi_2p0(length, delta_f, low_freq_cutoff,
 
     return fseries
 
-def analytical_csd_lisa_tdi_1p5(length, delta_f, low_freq_cutoff,
+def analytical_csd_lisa_tdi_1p5_XY(length, delta_f, low_freq_cutoff,
     len_arm=2.5e9, acc_noise_level=3e-15, oms_noise_level=15e-12):
     r""" The cross-spectrum density between LISA's TDI channel X and Y.
     Parameters
@@ -207,7 +207,7 @@ def analytical_csd_lisa_tdi_1p5(length, delta_f, low_freq_cutoff,
                 length, delta_f, low_freq_cutoff)
     return fseries
 
-def analytical_psd_lisa_tdi_A_E_1p5(length, delta_f, low_freq_cutoff,
+def analytical_psd_lisa_tdi_1p5_AE(length, delta_f, low_freq_cutoff,
     len_arm=2.5e9, acc_noise_level=3e-15, oms_noise_level=15e-12):
     r""" The PSD of LISA's TDI-1.5 channel A and E.
     Parameters
@@ -246,7 +246,7 @@ def analytical_psd_lisa_tdi_A_E_1p5(length, delta_f, low_freq_cutoff,
 
     return fseries
 
-def analytical_psd_lisa_tdi_T_1p5(length, delta_f, low_freq_cutoff,
+def analytical_psd_lisa_tdi_1p5_T(length, delta_f, low_freq_cutoff,
     len_arm=2.5e9, acc_noise_level=3e-15, oms_noise_level=15e-12):
     r""" The PSD of LISA's TDI-1.5 channel T.
     Parameters
@@ -286,7 +286,7 @@ def analytical_psd_lisa_tdi_T_1p5(length, delta_f, low_freq_cutoff,
 
 def averaged_lisa_fplus_sq_approx(f, len_arm=2.5e9):
     r""" An approximant for LISA's squared antenna response function,
-    averaged over sky and polarization.
+    averaged over sky and polarization angle.
     Parameters
     ----------
     f : float or numpy.array
@@ -296,7 +296,7 @@ def averaged_lisa_fplus_sq_approx(f, len_arm=2.5e9):
     Returns
     -------
     fp_sq_approx : float or numpy.array
-        The sky and polarization averaged squared antenna response.
+        The sky and polarization angle averaged squared antenna response.
     Notes
     -----
         Pease see Eq.(36) in <LISA-LCST-SGS-TN-001> for more details.
@@ -308,7 +308,7 @@ def averaged_lisa_fplus_sq_approx(f, len_arm=2.5e9):
 
 def averaged_response_lisa_tdi_1p5(f, len_arm=2.5e9):
     r""" LISA's TDI-1.5 response function to GW,
-    averaged over sky and polarization.
+    averaged over sky and polarization angle.
     Parameters
     ----------
     f : float or numpy.array
@@ -318,7 +318,7 @@ def averaged_response_lisa_tdi_1p5(f, len_arm=2.5e9):
     Returns
     -------
     response_tdi_1p5 : float or numpy.array
-        The sky and polarization averaged TDI-1.5 response function to GW.
+        The sky and polarization angle averaged TDI-1.5 response function to GW.
     Notes
     -----
         Pease see Eq.(39) in <LISA-LCST-SGS-TN-001> for more details.
@@ -331,7 +331,7 @@ def averaged_response_lisa_tdi_1p5(f, len_arm=2.5e9):
 
 def averaged_response_lisa_tdi_2p0(f, len_arm=2.5e9):
     r""" LISA's TDI-2.0 response function to GW,
-    averaged over sky and polarization.
+    averaged over sky and polarization angle.
     Parameters
     ----------
     f : float or numpy.array
@@ -341,7 +341,7 @@ def averaged_response_lisa_tdi_2p0(f, len_arm=2.5e9):
     Returns
     -------
     response_tdi_2p0 : float or numpy.array
-        The sky and polarization averaged TDI-2.0 response function to GW.
+        The sky and polarization angle averaged TDI-2.0 response function to GW.
     Notes
     -----
         Pease see Eq.(40) in <LISA-LCST-SGS-TN-001> for more details.
@@ -352,9 +352,10 @@ def averaged_response_lisa_tdi_2p0(f, len_arm=2.5e9):
     
     return response_tdi_2p0
 
-def semi_sensitivity_curve_lisa(f, len_arm=2.5e9, acc_noise_level=3e-15, oms_noise_level=15e-12):
+def semi_sensitivity_curve_lisa(f, len_arm=2.5e9,
+    acc_noise_level=3e-15, oms_noise_level=15e-12):
     r""" The semi-analytical LISA's sensitivity curve,
-    averaged over sky and polarization.
+    averaged over sky and polarization angle.
     Parameters
     ----------
     f : float or numpy.array
@@ -368,7 +369,7 @@ def semi_sensitivity_curve_lisa(f, len_arm=2.5e9, acc_noise_level=3e-15, oms_noi
     Returns
     -------
     sense_curve : float or numpy.array
-        The sky and polarization averaged semi-analytical
+        The sky and polarization angle averaged semi-analytical
         LISA's sensitivity curve.
     Notes
     -----
@@ -383,7 +384,7 @@ def semi_sensitivity_curve_lisa(f, len_arm=2.5e9, acc_noise_level=3e-15, oms_noi
 
 def sensitivity_curve_lisa_SciRD(f):
     r""" The analytical LISA's sensitivity curve in SciRD,
-    averaged over sky and polarization.
+    averaged over sky and polarization angle.
     Parameters
     ----------
     f : float or numpy.array
@@ -391,7 +392,7 @@ def sensitivity_curve_lisa_SciRD(f):
     Returns
     -------
     sense_curve : float or numpy.array
-        The sky and polarization averaged analytical
+        The sky and polarization angle averaged analytical
         LISA's sensitivity curve in SciRD.
     Notes
     -----

--- a/pycbc/psd/analytical_space.py
+++ b/pycbc/psd/analytical_space.py
@@ -325,8 +325,23 @@ def averaged_lisa_fplus_sq_approx(f, len_arm=2.5e9):
     -----
         Pease see Eq.(36) in <LISA-LCST-SGS-TN-001> for more details.
     """
-    omega_len = 2*np.pi*f * len_arm/constants.c.value
-    fp_sq_approx = 3/20/(1+0.6*omega_len**2)
+    from os import getcwd, path
+    from urllib import request
+    from scipy.interpolate import interp1d
+
+    if len_arm != 2.5e9:
+        raise Exception("Currently only support 'len_arm=2.5e9'.")
+    cwd = getcwd()
+    if path.exists(cwd+"/AvFXp2_Raw.npy") == False:
+        url = "https://zenodo.org/record/7497853/files/AvFXp2_Raw.npy"
+        request.urlretrieve(url, cwd+"/AvFXp2_Raw.npy")
+    freqs, fp_sq = np.load(cwd+"/AvFXp2_Raw.npy")
+    # Padding the end.
+    freqs = np.append(freqs, 2)
+    fp_sq = np.append(fp_sq, 0.0012712348970728724)
+    fp_sq_interp = interp1d(freqs, fp_sq, kind='linear',
+                            fill_value="extrapolate")
+    fp_sq_approx = fp_sq_interp(f)/16
 
     return fp_sq_approx
 
@@ -379,14 +394,18 @@ def averaged_response_lisa_tdi_2p0(f, len_arm=2.5e9):
     return response_tdi_2p0
 
 
-def semi_sensitivity_curve_lisa(f, len_arm=2.5e9,
-        acc_noise_level=3e-15, oms_noise_level=15e-12):
-    r""" The semi-analytical LISA's sensitivity curve,
+def sensitivity_curve_lisa_semi_analytical(length, delta_f, low_freq_cutoff,
+        len_arm=2.5e9, acc_noise_level=3e-15, oms_noise_level=15e-12):
+    r""" The semi-analytical LISA's sensitivity curve (6-links),
     averaged over sky and polarization angle.
     Parameters
     ----------
-    f : float or numpy.array
-        The frequency or frequency range, in the unit of "Hz".
+    length : int
+        Length of output Frequencyseries.
+    delta_f : float
+        Frequency step for output FrequencySeries.
+    low_freq_cutoff : float
+        Low-frequency cutoff for output FrequencySeries.
     len_arm : float
         The arm length of LISA, in the unit of "m".
     acc_noise_level : float
@@ -395,40 +414,117 @@ def semi_sensitivity_curve_lisa(f, len_arm=2.5e9,
         The level of OMS noise.
     Returns
     -------
-    sense_curve : float or numpy.array
+    fseries : FrequencySeries
         The sky and polarization angle averaged semi-analytical
-        LISA's sensitivity curve.
+        LISA's sensitivity curve (6-links).
     Notes
     -----
         Pease see Eq.(42) in <LISA-LCST-SGS-TN-001> for more details.
     """
-    psd = analytical_psd_lisa_tdi_2p0_XYZ(
-               f, len_arm, acc_noise_level, oms_noise_level)
-    response = averaged_response_lisa_tdi_2p0(f, len_arm)
-    sense_curve = psd / response
+    sense_curve = []
+    len_arm = np.float64(len_arm)
+    acc_noise_level = np.float64(acc_noise_level)
+    oms_noise_level = np.float64(oms_noise_level)
+    fr = np.linspace(low_freq_cutoff, (length-1)*2*delta_f, length)
+    fp_sq = averaged_lisa_fplus_sq_approx(fr, len_arm)
+    for i in range(len(fr)):
+        [s_acc_nu, s_oms_nu] = lisa_psd_components(
+                                fr[i], acc_noise_level, oms_noise_level)
+        omega_len = 2*np.pi*fr[i] * len_arm/constants.c.value
+        sense_curve.append((s_oms_nu + s_acc_nu*(3+np.cos(2*omega_len))) /\
+                            (omega_len**2*fp_sq[i]))
+    fseries = from_numpy_arrays(fr, np.array(sense_curve)/2,
+                    length, delta_f, low_freq_cutoff)
 
-    return sense_curve
+    return fseries
 
 
-def sensitivity_curve_lisa_SciRD(f):
+def sensitivity_curve_lisa_SciRD(length, delta_f, low_freq_cutoff):
     r""" The analytical LISA's sensitivity curve in SciRD,
     averaged over sky and polarization angle.
     Parameters
     ----------
-    f : float or numpy.array
-        The frequency or frequency range, in the unit of "Hz".
+    length : int
+        Length of output Frequencyseries.
+    delta_f : float
+        Frequency step for output FrequencySeries.
+    low_freq_cutoff : float
+        Low-frequency cutoff for output FrequencySeries.
     Returns
     -------
-    sense_curve : float or numpy.array
+    fseries : FrequencySeries
         The sky and polarization angle averaged analytical
         LISA's sensitivity curve in SciRD.
     Notes
     -----
         Pease see Eq.(114) in <LISA-LCST-SGS-TN-001> for more details.
     """
-    s_I = 5.76e-48 * (1+(4e-4/f)**2)
-    s_II = 3.6e-41
-    R = 1 + (f/2.5e-2)**2
-    sense_curve = 10/3 * (s_I/(2*np.pi*f)**4+s_II) * R
+    sense_curve = []
+    fr = np.linspace(low_freq_cutoff, (length-1)*2*delta_f, length)
+    for f in fr:
+        s_I = 5.76e-48 * (1+(4e-4/f)**2)
+        s_II = 3.6e-41
+        R = 1 + (f/2.5e-2)**2
+        sense_curve.append(10/3 * (s_I/(2*np.pi*f)**4+s_II) * R)
+    fseries = from_numpy_arrays(fr, sense_curve,
+                    length, delta_f, low_freq_cutoff)
 
-    return sense_curve
+    return fseries
+
+def sensitivity_curve_lisa_confusion(length, delta_f, low_freq_cutoff,
+        len_arm=2.5e9, acc_noise_level=3e-15, oms_noise_level=15e-12,
+        base_model="semi", duration=1.0):
+    r""" The LISA's sensitivity curve with Galactic confusion noise,
+    averaged over sky and polarization angle.
+    Parameters
+    ----------
+    length : int
+        Length of output Frequencyseries.
+    delta_f : float
+        Frequency step for output FrequencySeries.
+    low_freq_cutoff : float
+        Low-frequency cutoff for output FrequencySeries.
+    len_arm : float
+        The arm length of LISA, in the unit of "m".
+    acc_noise_level : float
+        The level of acceleration noise.
+    oms_noise_level : float
+        The level of OMS noise.
+    base_model : string
+        The base model of sensitivity curve, chosen from "semi" or "SciRD".
+    duration : float
+        The duration of observation, between 0 and 10, in the unit of years.
+    Returns
+    -------
+    fseries : FrequencySeries
+        The sky and polarization angle averaged semi-analytical
+        LISA's sensitivity curve with Galactic confusion noise.
+    Notes
+    -----
+        Pease see Eq.(85-86) in <LISA-LCST-SGS-TN-001> for more details.
+    """
+    if base_model == "semi":
+        base_curve = sensitivity_curve_lisa_semi_analytical(
+            length, delta_f, low_freq_cutoff,
+            len_arm, acc_noise_level, oms_noise_level)
+    elif base_curve == "SciRD":
+        base_curve = sensitivity_curve_lisa_SciRD(
+            length, delta_f, low_freq_cutoff)
+    else:
+        raise Exception("Must choose from 'semi' or 'SciRD'.")
+    if 0 > duration or duration > 10:
+        raise Exception("Must between 0 and 10.")
+    fr = np.linspace(low_freq_cutoff, (length-1)*2*delta_f, length)
+    sh_confusion = []
+    f1 = 10**(-0.25*np.log10(duration)-2.7)
+    fk = 10**(-0.27*np.log10(duration)-2.47)
+    for f in fr:
+        sh_confusion.append(0.5*1.14e-44*f**(-7/3)*np.exp(-(f/f1)**1.8) *\
+                (1.0+np.tanh((fk-f)/(0.31e-3))))
+    fseries_confusion = from_numpy_arrays(fr, np.array(sh_confusion),
+                length, delta_f, low_freq_cutoff)
+    fseries = from_numpy_arrays(base_curve.sample_frequencies,
+                base_curve+fseries_confusion,
+                length, delta_f, low_freq_cutoff)
+
+    return fseries

--- a/pycbc/psd/analytical_space.py
+++ b/pycbc/psd/analytical_space.py
@@ -117,7 +117,8 @@ def omega_length(f, len_arm=2.5e9):
 
 
 def analytical_psd_lisa_tdi_1p5_XYZ(length, delta_f, low_freq_cutoff,
-                len_arm=2.5e9, acc_noise_level=3e-15, oms_noise_level=15e-12):
+                                    len_arm=2.5e9, acc_noise_level=3e-15,
+                                    oms_noise_level=15e-12):
     r""" The TDI-1.5 analytical PSD (X,Y,Z channel) for LISA.
     Parameters
     ----------
@@ -159,7 +160,8 @@ def analytical_psd_lisa_tdi_1p5_XYZ(length, delta_f, low_freq_cutoff,
 
 
 def analytical_psd_lisa_tdi_2p0_XYZ(length, delta_f, low_freq_cutoff,
-                len_arm=2.5e9, acc_noise_level=3e-15, oms_noise_level=15e-12):
+                                    len_arm=2.5e9, acc_noise_level=3e-15,
+                                    oms_noise_level=15e-12):
     r""" The TDI-2.0 analytical PSD (X,Y,Z channel) for LISA.
     Parameters
     ----------
@@ -201,7 +203,8 @@ def analytical_psd_lisa_tdi_2p0_XYZ(length, delta_f, low_freq_cutoff,
 
 
 def analytical_csd_lisa_tdi_1p5_XY(length, delta_f, low_freq_cutoff,
-                len_arm=2.5e9, acc_noise_level=3e-15, oms_noise_level=15e-12):
+                                   len_arm=2.5e9, acc_noise_level=3e-15,
+                                   oms_noise_level=15e-12):
     r""" The cross-spectrum density between LISA's TDI channel X and Y.
     Parameters
     ----------
@@ -242,7 +245,8 @@ def analytical_csd_lisa_tdi_1p5_XY(length, delta_f, low_freq_cutoff,
 
 
 def analytical_psd_lisa_tdi_1p5_AE(length, delta_f, low_freq_cutoff,
-                len_arm=2.5e9, acc_noise_level=3e-15, oms_noise_level=15e-12):
+                                   len_arm=2.5e9, acc_noise_level=3e-15,
+                                   oms_noise_level=15e-12):
     r""" The PSD of LISA's TDI-1.5 channel A and E.
     Parameters
     ----------
@@ -285,7 +289,8 @@ def analytical_psd_lisa_tdi_1p5_AE(length, delta_f, low_freq_cutoff,
 
 
 def analytical_psd_lisa_tdi_1p5_T(length, delta_f, low_freq_cutoff,
-                len_arm=2.5e9, acc_noise_level=3e-15, oms_noise_level=15e-12):
+                                  len_arm=2.5e9, acc_noise_level=3e-15,
+                                  oms_noise_level=15e-12):
     r""" The PSD of LISA's TDI-1.5 channel T.
     Parameters
     ----------
@@ -413,7 +418,8 @@ def averaged_response_lisa_tdi_2p0(f, len_arm=2.5e9):
 
 
 def sensitivity_curve_lisa_semi_analytical(length, delta_f, low_freq_cutoff,
-                len_arm=2.5e9, acc_noise_level=3e-15, oms_noise_level=15e-12):
+                                           len_arm=2.5e9, acc_noise_level=3e-15,
+                                           oms_noise_level=15e-12):
     r""" The semi-analytical LISA's sensitivity curve (6-links),
     averaged over sky and polarization angle.
     Parameters
@@ -491,8 +497,9 @@ def sensitivity_curve_lisa_SciRD(length, delta_f, low_freq_cutoff):
 
 
 def sensitivity_curve_lisa_confusion(length, delta_f, low_freq_cutoff,
-                len_arm=2.5e9, acc_noise_level=3e-15, oms_noise_level=15e-12,
-                base_model="semi", duration=1.0):
+                                     len_arm=2.5e9, acc_noise_level=3e-15,
+                                     oms_noise_level=15e-12,
+                                     base_model="semi", duration=1.0):
     r""" The LISA's sensitivity curve with Galactic confusion noise,
     averaged over sky and polarization angle.
     Parameters
@@ -550,8 +557,9 @@ def sensitivity_curve_lisa_confusion(length, delta_f, low_freq_cutoff,
 
 
 def sh_transformed_psd_lisa_tdi_XYZ(length, delta_f, low_freq_cutoff,
-                len_arm=2.5e9, acc_noise_level=3e-15, oms_noise_level=15e-12,
-                base_model="semi", duration=1.0, tdi="1.5"):
+                                    len_arm=2.5e9, acc_noise_level=3e-15,
+                                    oms_noise_level=15e-12,
+                                    base_model="semi", duration=1.0, tdi="1.5"):
     r""" The TDI-1.5/2.0 PSD (X,Y,Z channel) for LISA
     with Galactic confusion noise, transformed from LISA sensitivity curve.
     Parameters

--- a/pycbc/psd/analytical_space.py
+++ b/pycbc/psd/analytical_space.py
@@ -50,7 +50,7 @@ def psd_lisa_acc_noise(f, acc_noise_level=3e-15):
     """
     s_acc = acc_noise_level**2 * (1+(4e-4/f)**2)*(1+(f/8e-3)**4)
     s_acc_d = s_acc * (2*np.pi*f)**(-4)
-    s_acc_nu = s_acc_d * (2*np.pi*f/constants.c.value)**2
+    s_acc_nu = (2*np.pi*f/constants.c.value)**2 * s_acc_d
 
     return s_acc_nu
 
@@ -97,6 +97,7 @@ def lisa_psd_components(f, acc_noise_level=3e-15, oms_noise_level=15e-12):
 
     return [low_freq_component, high_freq_component]
 
+
 def omega_length(f, len_arm=2.5e9):
     r""" The function to calculate 2*pi*f*LISA_arm_length.
     Parameters
@@ -114,8 +115,9 @@ def omega_length(f, len_arm=2.5e9):
 
     return omega_len
 
+
 def analytical_psd_lisa_tdi_1p5_XYZ(length, delta_f, low_freq_cutoff,
-            len_arm=2.5e9, acc_noise_level=3e-15, oms_noise_level=15e-12):
+                len_arm=2.5e9, acc_noise_level=3e-15, oms_noise_level=15e-12):
     r""" The TDI-1.5 analytical PSD (X,Y,Z channel) for LISA.
     Parameters
     ----------
@@ -149,15 +151,15 @@ def analytical_psd_lisa_tdi_1p5_XYZ(length, delta_f, low_freq_cutoff,
                                 f, acc_noise_level, oms_noise_level)
         omega_len = omega_length(f, len_arm)
         psd.append(16*(np.sin(omega_len))**2 *
-                (s_oms_nu+s_acc_nu*(3+np.cos(omega_len))))
+                   (s_oms_nu+s_acc_nu*(3+np.cos(omega_len))))
     fseries = from_numpy_arrays(fr, np.array(psd),
-                length, delta_f, low_freq_cutoff)
+                                length, delta_f, low_freq_cutoff)
 
     return fseries
 
 
 def analytical_psd_lisa_tdi_2p0_XYZ(length, delta_f, low_freq_cutoff,
-            len_arm=2.5e9, acc_noise_level=3e-15, oms_noise_level=15e-12):
+                len_arm=2.5e9, acc_noise_level=3e-15, oms_noise_level=15e-12):
     r""" The TDI-2.0 analytical PSD (X,Y,Z channel) for LISA.
     Parameters
     ----------
@@ -191,15 +193,15 @@ def analytical_psd_lisa_tdi_2p0_XYZ(length, delta_f, low_freq_cutoff,
                                 f, acc_noise_level, oms_noise_level)
         omega_len = omega_length(f, len_arm)
         psd.append(64*(np.sin(omega_len))**2 * (np.sin(2*omega_len))**2 *
-                    (s_oms_nu+s_acc_nu*(3+np.cos(2*omega_len))))
+                   (s_oms_nu+s_acc_nu*(3+np.cos(2*omega_len))))
     fseries = from_numpy_arrays(fr, np.array(psd),
-                        length, delta_f, low_freq_cutoff)
+                                length, delta_f, low_freq_cutoff)
 
     return fseries
 
 
 def analytical_csd_lisa_tdi_1p5_XY(length, delta_f, low_freq_cutoff,
-            len_arm=2.5e9, acc_noise_level=3e-15, oms_noise_level=15e-12):
+                len_arm=2.5e9, acc_noise_level=3e-15, oms_noise_level=15e-12):
     r""" The cross-spectrum density between LISA's TDI channel X and Y.
     Parameters
     ----------
@@ -233,14 +235,14 @@ def analytical_csd_lisa_tdi_1p5_XY(length, delta_f, low_freq_cutoff,
         [s_acc_nu, s_oms_nu] = lisa_psd_components(
                                 f, acc_noise_level, oms_noise_level)
         csd.append(-8*np.sin(omega_len)**2 * np.cos(omega_len) *
-                    (s_oms_nu+4*s_acc_nu))
+                   (s_oms_nu+4*s_acc_nu))
     fseries = from_numpy_arrays(fr, np.array(csd),
-                        length, delta_f, low_freq_cutoff)
+                                length, delta_f, low_freq_cutoff)
     return fseries
 
 
 def analytical_psd_lisa_tdi_1p5_AE(length, delta_f, low_freq_cutoff,
-            len_arm=2.5e9, acc_noise_level=3e-15, oms_noise_level=15e-12):
+                len_arm=2.5e9, acc_noise_level=3e-15, oms_noise_level=15e-12):
     r""" The PSD of LISA's TDI-1.5 channel A and E.
     Parameters
     ----------
@@ -274,16 +276,16 @@ def analytical_psd_lisa_tdi_1p5_AE(length, delta_f, low_freq_cutoff,
                                 f, acc_noise_level, oms_noise_level)
         omega_len = omega_length(f, len_arm)
         psd.append(8*(np.sin(omega_len))**2 *
-                    (4*(1+np.cos(omega_len)+np.cos(omega_len)**2)*s_acc_nu +
-                    (2+np.cos(omega_len))*s_oms_nu))
+                   (4*(1+np.cos(omega_len)+np.cos(omega_len)**2)*s_acc_nu +
+                   (2+np.cos(omega_len))*s_oms_nu))
     fseries = from_numpy_arrays(fr, np.array(psd),
-                        length, delta_f, low_freq_cutoff)
+                                length, delta_f, low_freq_cutoff)
 
     return fseries
 
 
 def analytical_psd_lisa_tdi_1p5_T(length, delta_f, low_freq_cutoff,
-            len_arm=2.5e9, acc_noise_level=3e-15, oms_noise_level=15e-12):
+                len_arm=2.5e9, acc_noise_level=3e-15, oms_noise_level=15e-12):
     r""" The PSD of LISA's TDI-1.5 channel T.
     Parameters
     ----------
@@ -317,9 +319,9 @@ def analytical_psd_lisa_tdi_1p5_T(length, delta_f, low_freq_cutoff,
                                 f, acc_noise_level, oms_noise_level)
         omega_len = omega_length(f, len_arm)
         psd.append(32*np.sin(omega_len)**2 * np.sin(omega_len/2)**2 *
-                    (4*s_acc_nu*np.sin(omega_len/2)**2 + s_oms_nu))
+                   (4*s_acc_nu*np.sin(omega_len/2)**2 + s_oms_nu))
     fseries = from_numpy_arrays(fr, np.array(psd),
-                        length, delta_f, low_freq_cutoff)
+                                length, delta_f, low_freq_cutoff)
 
     return fseries
 
@@ -411,7 +413,7 @@ def averaged_response_lisa_tdi_2p0(f, len_arm=2.5e9):
 
 
 def sensitivity_curve_lisa_semi_analytical(length, delta_f, low_freq_cutoff,
-            len_arm=2.5e9, acc_noise_level=3e-15, oms_noise_level=15e-12):
+                len_arm=2.5e9, acc_noise_level=3e-15, oms_noise_level=15e-12):
     r""" The semi-analytical LISA's sensitivity curve (6-links),
     averaged over sky and polarization angle.
     Parameters
@@ -450,7 +452,7 @@ def sensitivity_curve_lisa_semi_analytical(length, delta_f, low_freq_cutoff,
         sense_curve.append((s_oms_nu + s_acc_nu*(3+np.cos(2*omega_len))) /
                            (omega_len**2*fp_sq[i]))
     fseries = from_numpy_arrays(fr, np.array(sense_curve)/2,
-                            length, delta_f, low_freq_cutoff)
+                                length, delta_f, low_freq_cutoff)
 
     return fseries
 
@@ -483,14 +485,14 @@ def sensitivity_curve_lisa_SciRD(length, delta_f, low_freq_cutoff):
         R = 1 + (f/2.5e-2)**2
         sense_curve.append(10/3 * (s_I/(2*np.pi*f)**4+s_II) * R)
     fseries = from_numpy_arrays(fr, sense_curve,
-                    length, delta_f, low_freq_cutoff)
+                                length, delta_f, low_freq_cutoff)
 
     return fseries
 
 
 def sensitivity_curve_lisa_confusion(length, delta_f, low_freq_cutoff,
-            len_arm=2.5e9, acc_noise_level=3e-15, oms_noise_level=15e-12,
-            base_model="semi", duration=1.0):
+                len_arm=2.5e9, acc_noise_level=3e-15, oms_noise_level=15e-12,
+                base_model="semi", duration=1.0):
     r""" The LISA's sensitivity curve with Galactic confusion noise,
     averaged over sky and polarization angle.
     Parameters
@@ -537,19 +539,19 @@ def sensitivity_curve_lisa_confusion(length, delta_f, low_freq_cutoff,
     fk = 10**(-0.27*np.log10(duration)-2.47)
     for f in fr:
         sh_confusion.append(0.5*1.14e-44*f**(-7/3)*np.exp(-(f/f1)**1.8) *
-                    (1.0+np.tanh((fk-f)/(0.31e-3))))
+                            (1.0+np.tanh((fk-f)/(0.31e-3))))
     fseries_confusion = from_numpy_arrays(fr, np.array(sh_confusion),
-                    length, delta_f, low_freq_cutoff)
+                                          length, delta_f, low_freq_cutoff)
     fseries = from_numpy_arrays(base_curve.sample_frequencies,
-                    base_curve+fseries_confusion,
-                    length, delta_f, low_freq_cutoff)
+                                base_curve+fseries_confusion,
+                                length, delta_f, low_freq_cutoff)
 
     return fseries
 
 
 def sh_transformed_psd_lisa_tdi_XYZ(length, delta_f, low_freq_cutoff,
-            len_arm=2.5e9, acc_noise_level=3e-15, oms_noise_level=15e-12,
-            base_model="semi", duration=1.0, tdi="1.5"):
+                len_arm=2.5e9, acc_noise_level=3e-15, oms_noise_level=15e-12,
+                base_model="semi", duration=1.0, tdi="1.5"):
     r""" The TDI-1.5/2.0 PSD (X,Y,Z channel) for LISA
     with Galactic confusion noise, transformed from LISA sensitivity curve.
     Parameters
@@ -589,12 +591,13 @@ def sh_transformed_psd_lisa_tdi_XYZ(length, delta_f, low_freq_cutoff,
     else:
         raise Exception("The version of TDI, currently only for 1.5 or 2.0.")
     fseries_response = from_numpy_arrays(fr, np.array(response),
-                length, delta_f, low_freq_cutoff)
+                                         length, delta_f, low_freq_cutoff)
     sh = sensitivity_curve_lisa_confusion(length, delta_f, low_freq_cutoff,
-                len_arm, acc_noise_level,
-                oms_noise_level, base_model, duration)
+                                          len_arm, acc_noise_level,
+                                          oms_noise_level, base_model,
+                                          duration)
     psd = 2*sh.data * fseries_response.data
     fseries = from_numpy_arrays(sh.sample_frequencies, psd,
-                length, delta_f, low_freq_cutoff)
+                                length, delta_f, low_freq_cutoff)
 
     return fseries

--- a/pycbc/psd/analytical_space.py
+++ b/pycbc/psd/analytical_space.py
@@ -54,6 +54,7 @@ def psd_lisa_acc_noise(f, acc_noise_level=3e-15):
 
     return s_acc_nu
 
+
 def psd_lisa_oms_noise(f, oms_noise_level=15e-12):
     r""" The PSD of LISA's OMS noise.
     Parameters
@@ -75,6 +76,7 @@ def psd_lisa_oms_noise(f, oms_noise_level=15e-12):
 
     return s_oms_nu
 
+
 def lisa_psd_components(f, acc_noise_level=3e-15, oms_noise_level=15e-12):
     r""" The PSD of LISA's acceleration and OMS noise.
     Parameters
@@ -95,8 +97,9 @@ def lisa_psd_components(f, acc_noise_level=3e-15, oms_noise_level=15e-12):
 
     return [low_freq_component, high_freq_component]
 
+
 def analytical_psd_lisa_tdi_1p5_XYZ(length, delta_f, low_freq_cutoff,
-    len_arm=2.5e9, acc_noise_level=3e-15, oms_noise_level=15e-12):
+        len_arm=2.5e9, acc_noise_level=3e-15, oms_noise_level=15e-12):
     r""" The TDI-1.5 analytical PSD (X,Y,Z channel) for LISA.
     Parameters
     ----------
@@ -129,14 +132,16 @@ def analytical_psd_lisa_tdi_1p5_XYZ(length, delta_f, low_freq_cutoff,
         [s_acc_nu, s_oms_nu] = lisa_psd_components(
                                 f, acc_noise_level, oms_noise_level)
         omega_len = 2*np.pi*f * len_arm/constants.c.value
-        psd.append(16*(np.sin(omega_len))**2 * (s_oms_nu+s_acc_nu*(3+np.cos(omega_len))))
+        psd.append(16*(np.sin(omega_len))**2 *
+                    (s_oms_nu+s_acc_nu*(3+np.cos(omega_len))))
     fseries = from_numpy_arrays(fr, np.array(psd),
-                length, delta_f, low_freq_cutoff)
+                    length, delta_f, low_freq_cutoff)
 
     return fseries
 
+
 def analytical_psd_lisa_tdi_2p0_XYZ(length, delta_f, low_freq_cutoff,
-    len_arm=2.5e9, acc_noise_level=3e-15, oms_noise_level=15e-12):
+        len_arm=2.5e9, acc_noise_level=3e-15, oms_noise_level=15e-12):
     r""" The TDI-2.0 analytical PSD (X,Y,Z channel) for LISA.
     Parameters
     ----------
@@ -169,15 +174,16 @@ def analytical_psd_lisa_tdi_2p0_XYZ(length, delta_f, low_freq_cutoff,
         [s_acc_nu, s_oms_nu] = lisa_psd_components(
                                 f, acc_noise_level, oms_noise_level)
         omega_len = 2*np.pi*f * len_arm/constants.c.value
-        psd.append(64*(np.sin(omega_len))**2 * (np.sin(2*omega_len))**2 * \
-                    (s_oms_nu+s_acc_nu*(3+np.cos(2*omega_len))))
+        psd.append(64*(np.sin(omega_len))**2 * (np.sin(2*omega_len))**2 *
+                (s_oms_nu+s_acc_nu*(3+np.cos(2*omega_len))))
     fseries = from_numpy_arrays(fr, np.array(psd),
-                length, delta_f, low_freq_cutoff)
+                    length, delta_f, low_freq_cutoff)
 
     return fseries
 
+
 def analytical_csd_lisa_tdi_1p5_XY(length, delta_f, low_freq_cutoff,
-    len_arm=2.5e9, acc_noise_level=3e-15, oms_noise_level=15e-12):
+        len_arm=2.5e9, acc_noise_level=3e-15, oms_noise_level=15e-12):
     r""" The cross-spectrum density between LISA's TDI channel X and Y.
     Parameters
     ----------
@@ -210,14 +216,15 @@ def analytical_csd_lisa_tdi_1p5_XY(length, delta_f, low_freq_cutoff,
         omega_len = 2*np.pi*f * len_arm/constants.c.value
         [s_acc_nu, s_oms_nu] = lisa_psd_components(
                                 f, acc_noise_level, oms_noise_level)
-        csd.append(-8*np.sin(omega_len)**2 * np.cos(omega_len) * \
-                    (s_oms_nu+4*s_acc_nu))
+        csd.append(-8*np.sin(omega_len)**2 * np.cos(omega_len) *
+                (s_oms_nu+4*s_acc_nu))
     fseries = from_numpy_arrays(fr, np.array(csd),
-                length, delta_f, low_freq_cutoff)
+                    length, delta_f, low_freq_cutoff)
     return fseries
 
+
 def analytical_psd_lisa_tdi_1p5_AE(length, delta_f, low_freq_cutoff,
-    len_arm=2.5e9, acc_noise_level=3e-15, oms_noise_level=15e-12):
+        len_arm=2.5e9, acc_noise_level=3e-15, oms_noise_level=15e-12):
     r""" The PSD of LISA's TDI-1.5 channel A and E.
     Parameters
     ----------
@@ -250,16 +257,17 @@ def analytical_psd_lisa_tdi_1p5_AE(length, delta_f, low_freq_cutoff,
         [s_acc_nu, s_oms_nu] = lisa_psd_components(
                                 f, acc_noise_level, oms_noise_level)
         omega_len = 2*np.pi*f * len_arm/constants.c.value
-        psd.append(8*(np.sin(omega_len))**2 *\
-                    (4*(1+np.cos(omega_len)+np.cos(omega_len)**2)*s_acc_nu +\
-                    (2+np.cos(omega_len))*s_oms_nu))
+        psd.append(8*(np.sin(omega_len))**2 *
+                (4*(1+np.cos(omega_len)+np.cos(omega_len)**2)*s_acc_nu +
+                        (2+np.cos(omega_len))*s_oms_nu))
     fseries = from_numpy_arrays(fr, np.array(psd),
-                length, delta_f, low_freq_cutoff)
+                    length, delta_f, low_freq_cutoff)
 
     return fseries
 
+
 def analytical_psd_lisa_tdi_1p5_T(length, delta_f, low_freq_cutoff,
-    len_arm=2.5e9, acc_noise_level=3e-15, oms_noise_level=15e-12):
+        len_arm=2.5e9, acc_noise_level=3e-15, oms_noise_level=15e-12):
     r""" The PSD of LISA's TDI-1.5 channel T.
     Parameters
     ----------
@@ -292,12 +300,13 @@ def analytical_psd_lisa_tdi_1p5_T(length, delta_f, low_freq_cutoff,
         [s_acc_nu, s_oms_nu] = lisa_psd_components(
                                 f, acc_noise_level, oms_noise_level)
         omega_len = 2*np.pi*f * len_arm/constants.c.value
-        psd.append(32*np.sin(omega_len)**2 * np.sin(omega_len/2)**2 *\
-                    (4*s_acc_nu*np.sin(omega_len/2)**2 + s_oms_nu))
+        psd.append(32*np.sin(omega_len)**2 * np.sin(omega_len/2)**2 *
+                (4*s_acc_nu*np.sin(omega_len/2)**2 + s_oms_nu))
     fseries = from_numpy_arrays(fr, np.array(psd),
-                length, delta_f, low_freq_cutoff)
+                    length, delta_f, low_freq_cutoff)
 
     return fseries
+
 
 def averaged_lisa_fplus_sq_approx(f, len_arm=2.5e9):
     r""" An approximant for LISA's squared antenna response function,
@@ -321,6 +330,7 @@ def averaged_lisa_fplus_sq_approx(f, len_arm=2.5e9):
 
     return fp_sq_approx
 
+
 def averaged_response_lisa_tdi_1p5(f, len_arm=2.5e9):
     r""" LISA's TDI-1.5 response function to GW,
     averaged over sky and polarization angle.
@@ -333,7 +343,7 @@ def averaged_response_lisa_tdi_1p5(f, len_arm=2.5e9):
     Returns
     -------
     response_tdi_1p5 : float or numpy.array
-        The sky and polarization angle averaged TDI-1.5 response function to GW.
+        The sky and polarization angle averaged TDI-1.5 response to GW.
     Notes
     -----
         Pease see Eq.(39) in <LISA-LCST-SGS-TN-001> for more details.
@@ -343,6 +353,7 @@ def averaged_response_lisa_tdi_1p5(f, len_arm=2.5e9):
     response_tdi_1p5 = (4*omega_len)**2 * np.sin(omega_len)**2 * ave_fp2
 
     return response_tdi_1p5
+
 
 def averaged_response_lisa_tdi_2p0(f, len_arm=2.5e9):
     r""" LISA's TDI-2.0 response function to GW,
@@ -356,7 +367,7 @@ def averaged_response_lisa_tdi_2p0(f, len_arm=2.5e9):
     Returns
     -------
     response_tdi_2p0 : float or numpy.array
-        The sky and polarization angle averaged TDI-2.0 response function to GW.
+        The sky and polarization angle averaged TDI-2.0 response to GW.
     Notes
     -----
         Pease see Eq.(40) in <LISA-LCST-SGS-TN-001> for more details.
@@ -364,11 +375,12 @@ def averaged_response_lisa_tdi_2p0(f, len_arm=2.5e9):
     omega_len = 2*np.pi*f * len_arm/constants.c.value
     response_tdi_1p5 = averaged_response_lisa_tdi_1p5(f, len_arm)
     response_tdi_2p0 = response_tdi_1p5 * (2*np.sin(2*omega_len))**2
-    
+
     return response_tdi_2p0
 
+
 def semi_sensitivity_curve_lisa(f, len_arm=2.5e9,
-    acc_noise_level=3e-15, oms_noise_level=15e-12):
+        acc_noise_level=3e-15, oms_noise_level=15e-12):
     r""" The semi-analytical LISA's sensitivity curve,
     averaged over sky and polarization angle.
     Parameters
@@ -390,12 +402,13 @@ def semi_sensitivity_curve_lisa(f, len_arm=2.5e9,
     -----
         Pease see Eq.(42) in <LISA-LCST-SGS-TN-001> for more details.
     """
-    psd = analytical_psd_lisa_tdi_2p0(
+    psd = analytical_psd_lisa_tdi_2p0_XYZ(
                f, len_arm, acc_noise_level, oms_noise_level)
     response = averaged_response_lisa_tdi_2p0(f, len_arm)
     sense_curve = psd / response
 
     return sense_curve
+
 
 def sensitivity_curve_lisa_SciRD(f):
     r""" The analytical LISA's sensitivity curve in SciRD,

--- a/pycbc/psd/analytical_space.py
+++ b/pycbc/psd/analytical_space.py
@@ -22,9 +22,10 @@
 # =============================================================================
 #
 """
-This module provides analytical PSDs and sensitivity curves for space borne
-detectors, such as LISA. Based on LISA technical note <LISA-LCST-SGS-TN-001>,
-LDC manual <LISA-LCST-SGS-MAN-001>, and paper <10.1088/1361-6382/ab1101>.
+This module provides (semi-)analytical PSDs and sensitivity curves for space
+borne detectors, such as LISA. Based on LISA technical note
+<LISA-LCST-SGS-TN-001>, LDC manual <LISA-LCST-SGS-MAN-001>,
+and paper <10.1088/1361-6382/ab1101>.
 """
 
 import numpy as np

--- a/pycbc/psd/analytical_space.py
+++ b/pycbc/psd/analytical_space.py
@@ -97,9 +97,25 @@ def lisa_psd_components(f, acc_noise_level=3e-15, oms_noise_level=15e-12):
 
     return [low_freq_component, high_freq_component]
 
+def omega_length(f, len_arm=2.5e9):
+    r""" The function to calculate 2*pi*f*LISA_arm_length.
+    Parameters
+    ----------
+    f : float or numpy.array
+        The frequency or frequency range, in the unit of "Hz".
+    len_arm : float
+        The arm length of LISA.
+    Returns
+    -------
+    omega_len : float or numpy.array
+        The value of 2*pi*f*LISA_arm_length.
+    """
+    omega_len = 2*np.pi*f * len_arm/constants.c.value
+
+    return omega_len
 
 def analytical_psd_lisa_tdi_1p5_XYZ(length, delta_f, low_freq_cutoff,
-        len_arm=2.5e9, acc_noise_level=3e-15, oms_noise_level=15e-12):
+            len_arm=2.5e9, acc_noise_level=3e-15, oms_noise_level=15e-12):
     r""" The TDI-1.5 analytical PSD (X,Y,Z channel) for LISA.
     Parameters
     ----------
@@ -131,17 +147,17 @@ def analytical_psd_lisa_tdi_1p5_XYZ(length, delta_f, low_freq_cutoff,
     for f in fr:
         [s_acc_nu, s_oms_nu] = lisa_psd_components(
                                 f, acc_noise_level, oms_noise_level)
-        omega_len = 2*np.pi*f * len_arm/constants.c.value
+        omega_len = omega_length(f, len_arm)
         psd.append(16*(np.sin(omega_len))**2 *
-                    (s_oms_nu+s_acc_nu*(3+np.cos(omega_len))))
+                (s_oms_nu+s_acc_nu*(3+np.cos(omega_len))))
     fseries = from_numpy_arrays(fr, np.array(psd),
-                    length, delta_f, low_freq_cutoff)
+                length, delta_f, low_freq_cutoff)
 
     return fseries
 
 
 def analytical_psd_lisa_tdi_2p0_XYZ(length, delta_f, low_freq_cutoff,
-        len_arm=2.5e9, acc_noise_level=3e-15, oms_noise_level=15e-12):
+            len_arm=2.5e9, acc_noise_level=3e-15, oms_noise_level=15e-12):
     r""" The TDI-2.0 analytical PSD (X,Y,Z channel) for LISA.
     Parameters
     ----------
@@ -173,17 +189,17 @@ def analytical_psd_lisa_tdi_2p0_XYZ(length, delta_f, low_freq_cutoff,
     for f in fr:
         [s_acc_nu, s_oms_nu] = lisa_psd_components(
                                 f, acc_noise_level, oms_noise_level)
-        omega_len = 2*np.pi*f * len_arm/constants.c.value
+        omega_len = omega_length(f, len_arm)
         psd.append(64*(np.sin(omega_len))**2 * (np.sin(2*omega_len))**2 *
-                (s_oms_nu+s_acc_nu*(3+np.cos(2*omega_len))))
+                    (s_oms_nu+s_acc_nu*(3+np.cos(2*omega_len))))
     fseries = from_numpy_arrays(fr, np.array(psd),
-                    length, delta_f, low_freq_cutoff)
+                        length, delta_f, low_freq_cutoff)
 
     return fseries
 
 
 def analytical_csd_lisa_tdi_1p5_XY(length, delta_f, low_freq_cutoff,
-        len_arm=2.5e9, acc_noise_level=3e-15, oms_noise_level=15e-12):
+            len_arm=2.5e9, acc_noise_level=3e-15, oms_noise_level=15e-12):
     r""" The cross-spectrum density between LISA's TDI channel X and Y.
     Parameters
     ----------
@@ -213,18 +229,18 @@ def analytical_csd_lisa_tdi_1p5_XY(length, delta_f, low_freq_cutoff,
     csd = []
     fr = np.linspace(low_freq_cutoff, (length-1)*2*delta_f, length)
     for f in fr:
-        omega_len = 2*np.pi*f * len_arm/constants.c.value
+        omega_len = omega_length(f, len_arm)
         [s_acc_nu, s_oms_nu] = lisa_psd_components(
                                 f, acc_noise_level, oms_noise_level)
         csd.append(-8*np.sin(omega_len)**2 * np.cos(omega_len) *
-                (s_oms_nu+4*s_acc_nu))
+                    (s_oms_nu+4*s_acc_nu))
     fseries = from_numpy_arrays(fr, np.array(csd),
-                    length, delta_f, low_freq_cutoff)
+                        length, delta_f, low_freq_cutoff)
     return fseries
 
 
 def analytical_psd_lisa_tdi_1p5_AE(length, delta_f, low_freq_cutoff,
-        len_arm=2.5e9, acc_noise_level=3e-15, oms_noise_level=15e-12):
+            len_arm=2.5e9, acc_noise_level=3e-15, oms_noise_level=15e-12):
     r""" The PSD of LISA's TDI-1.5 channel A and E.
     Parameters
     ----------
@@ -256,18 +272,18 @@ def analytical_psd_lisa_tdi_1p5_AE(length, delta_f, low_freq_cutoff,
     for f in fr:
         [s_acc_nu, s_oms_nu] = lisa_psd_components(
                                 f, acc_noise_level, oms_noise_level)
-        omega_len = 2*np.pi*f * len_arm/constants.c.value
+        omega_len = omega_length(f, len_arm)
         psd.append(8*(np.sin(omega_len))**2 *
-                (4*(1+np.cos(omega_len)+np.cos(omega_len)**2)*s_acc_nu +
-                        (2+np.cos(omega_len))*s_oms_nu))
+                    (4*(1+np.cos(omega_len)+np.cos(omega_len)**2)*s_acc_nu +
+                    (2+np.cos(omega_len))*s_oms_nu))
     fseries = from_numpy_arrays(fr, np.array(psd),
-                    length, delta_f, low_freq_cutoff)
+                        length, delta_f, low_freq_cutoff)
 
     return fseries
 
 
 def analytical_psd_lisa_tdi_1p5_T(length, delta_f, low_freq_cutoff,
-        len_arm=2.5e9, acc_noise_level=3e-15, oms_noise_level=15e-12):
+            len_arm=2.5e9, acc_noise_level=3e-15, oms_noise_level=15e-12):
     r""" The PSD of LISA's TDI-1.5 channel T.
     Parameters
     ----------
@@ -299,11 +315,11 @@ def analytical_psd_lisa_tdi_1p5_T(length, delta_f, low_freq_cutoff,
     for f in fr:
         [s_acc_nu, s_oms_nu] = lisa_psd_components(
                                 f, acc_noise_level, oms_noise_level)
-        omega_len = 2*np.pi*f * len_arm/constants.c.value
+        omega_len = omega_length(f, len_arm)
         psd.append(32*np.sin(omega_len)**2 * np.sin(omega_len/2)**2 *
-                (4*s_acc_nu*np.sin(omega_len/2)**2 + s_oms_nu))
+                    (4*s_acc_nu*np.sin(omega_len/2)**2 + s_oms_nu))
     fseries = from_numpy_arrays(fr, np.array(psd),
-                    length, delta_f, low_freq_cutoff)
+                        length, delta_f, low_freq_cutoff)
 
     return fseries
 
@@ -332,7 +348,7 @@ def averaged_lisa_fplus_sq_approx(f, len_arm=2.5e9):
     if len_arm != 2.5e9:
         raise Exception("Currently only support 'len_arm=2.5e9'.")
     cwd = getcwd()
-    if path.exists(cwd+"/AvFXp2_Raw.npy") == False:
+    if path.exists(cwd+"/AvFXp2_Raw.npy") is False:
         url = "https://zenodo.org/record/7497853/files/AvFXp2_Raw.npy"
         request.urlretrieve(url, cwd+"/AvFXp2_Raw.npy")
     freqs, fp_sq = np.load(cwd+"/AvFXp2_Raw.npy")
@@ -363,7 +379,7 @@ def averaged_response_lisa_tdi_1p5(f, len_arm=2.5e9):
     -----
         Pease see Eq.(39) in <LISA-LCST-SGS-TN-001> for more details.
     """
-    omega_len = 2*np.pi*f * len_arm/constants.c.value
+    omega_len = omega_length(f, len_arm)
     ave_fp2 = averaged_lisa_fplus_sq_approx(f, len_arm)
     response_tdi_1p5 = (4*omega_len)**2 * np.sin(omega_len)**2 * ave_fp2
 
@@ -387,7 +403,7 @@ def averaged_response_lisa_tdi_2p0(f, len_arm=2.5e9):
     -----
         Pease see Eq.(40) in <LISA-LCST-SGS-TN-001> for more details.
     """
-    omega_len = 2*np.pi*f * len_arm/constants.c.value
+    omega_len = omega_length(f, len_arm)
     response_tdi_1p5 = averaged_response_lisa_tdi_1p5(f, len_arm)
     response_tdi_2p0 = response_tdi_1p5 * (2*np.sin(2*omega_len))**2
 
@@ -395,7 +411,7 @@ def averaged_response_lisa_tdi_2p0(f, len_arm=2.5e9):
 
 
 def sensitivity_curve_lisa_semi_analytical(length, delta_f, low_freq_cutoff,
-        len_arm=2.5e9, acc_noise_level=3e-15, oms_noise_level=15e-12):
+            len_arm=2.5e9, acc_noise_level=3e-15, oms_noise_level=15e-12):
     r""" The semi-analytical LISA's sensitivity curve (6-links),
     averaged over sky and polarization angle.
     Parameters
@@ -431,10 +447,10 @@ def sensitivity_curve_lisa_semi_analytical(length, delta_f, low_freq_cutoff,
         [s_acc_nu, s_oms_nu] = lisa_psd_components(
                                 fr[i], acc_noise_level, oms_noise_level)
         omega_len = 2*np.pi*fr[i] * len_arm/constants.c.value
-        sense_curve.append((s_oms_nu + s_acc_nu*(3+np.cos(2*omega_len))) /\
-                            (omega_len**2*fp_sq[i]))
+        sense_curve.append((s_oms_nu + s_acc_nu*(3+np.cos(2*omega_len))) /
+                           (omega_len**2*fp_sq[i]))
     fseries = from_numpy_arrays(fr, np.array(sense_curve)/2,
-                    length, delta_f, low_freq_cutoff)
+                            length, delta_f, low_freq_cutoff)
 
     return fseries
 
@@ -471,9 +487,10 @@ def sensitivity_curve_lisa_SciRD(length, delta_f, low_freq_cutoff):
 
     return fseries
 
+
 def sensitivity_curve_lisa_confusion(length, delta_f, low_freq_cutoff,
-        len_arm=2.5e9, acc_noise_level=3e-15, oms_noise_level=15e-12,
-        base_model="semi", duration=1.0):
+            len_arm=2.5e9, acc_noise_level=3e-15, oms_noise_level=15e-12,
+            base_model="semi", duration=1.0):
     r""" The LISA's sensitivity curve with Galactic confusion noise,
     averaged over sky and polarization angle.
     Parameters
@@ -512,26 +529,27 @@ def sensitivity_curve_lisa_confusion(length, delta_f, low_freq_cutoff,
             length, delta_f, low_freq_cutoff)
     else:
         raise Exception("Must choose from 'semi' or 'SciRD'.")
-    if 0 > duration or duration > 10:
+    if duration < 0 or duration > 10:
         raise Exception("Must between 0 and 10.")
     fr = np.linspace(low_freq_cutoff, (length-1)*2*delta_f, length)
     sh_confusion = []
     f1 = 10**(-0.25*np.log10(duration)-2.7)
     fk = 10**(-0.27*np.log10(duration)-2.47)
     for f in fr:
-        sh_confusion.append(0.5*1.14e-44*f**(-7/3)*np.exp(-(f/f1)**1.8) *\
-                (1.0+np.tanh((fk-f)/(0.31e-3))))
+        sh_confusion.append(0.5*1.14e-44*f**(-7/3)*np.exp(-(f/f1)**1.8) *
+                    (1.0+np.tanh((fk-f)/(0.31e-3))))
     fseries_confusion = from_numpy_arrays(fr, np.array(sh_confusion),
-                length, delta_f, low_freq_cutoff)
+                    length, delta_f, low_freq_cutoff)
     fseries = from_numpy_arrays(base_curve.sample_frequencies,
-                base_curve+fseries_confusion,
-                length, delta_f, low_freq_cutoff)
+                    base_curve+fseries_confusion,
+                    length, delta_f, low_freq_cutoff)
 
     return fseries
 
+
 def sh_transformed_psd_lisa_tdi_XYZ(length, delta_f, low_freq_cutoff,
-        len_arm=2.5e9, acc_noise_level=3e-15, oms_noise_level=15e-12,
-        base_model="semi", duration=1.0, tdi="1.5"):
+            len_arm=2.5e9, acc_noise_level=3e-15, oms_noise_level=15e-12,
+            base_model="semi", duration=1.0, tdi="1.5"):
     r""" The TDI-1.5/2.0 PSD (X,Y,Z channel) for LISA
     with Galactic confusion noise, transformed from LISA sensitivity curve.
     Parameters
@@ -571,9 +589,10 @@ def sh_transformed_psd_lisa_tdi_XYZ(length, delta_f, low_freq_cutoff,
     else:
         raise Exception("The version of TDI, currently only for 1.5 or 2.0.")
     fseries_response = from_numpy_arrays(fr, np.array(response),
-            length, delta_f, low_freq_cutoff)
+                length, delta_f, low_freq_cutoff)
     sh = sensitivity_curve_lisa_confusion(length, delta_f, low_freq_cutoff,
-            len_arm, acc_noise_level, oms_noise_level, base_model, duration)
+                len_arm, acc_noise_level,
+                oms_noise_level, base_model, duration)
     psd = 2*sh.data * fseries_response.data
     fseries = from_numpy_arrays(sh.sample_frequencies, psd,
                 length, delta_f, low_freq_cutoff)

--- a/pycbc/psd/analytical_space.py
+++ b/pycbc/psd/analytical_space.py
@@ -418,7 +418,8 @@ def averaged_response_lisa_tdi_2p0(f, len_arm=2.5e9):
 
 
 def sensitivity_curve_lisa_semi_analytical(length, delta_f, low_freq_cutoff,
-                                           len_arm=2.5e9, acc_noise_level=3e-15,
+                                           len_arm=2.5e9,
+                                           acc_noise_level=3e-15,
                                            oms_noise_level=15e-12):
     r""" The semi-analytical LISA's sensitivity curve (6-links),
     averaged over sky and polarization angle.
@@ -559,7 +560,8 @@ def sensitivity_curve_lisa_confusion(length, delta_f, low_freq_cutoff,
 def sh_transformed_psd_lisa_tdi_XYZ(length, delta_f, low_freq_cutoff,
                                     len_arm=2.5e9, acc_noise_level=3e-15,
                                     oms_noise_level=15e-12,
-                                    base_model="semi", duration=1.0, tdi="1.5"):
+                                    base_model="semi", duration=1.0,
+                                    tdi="1.5"):
     r""" The TDI-1.5/2.0 PSD (X,Y,Z channel) for LISA
     with Galactic confusion noise, transformed from LISA sensitivity curve.
     Parameters

--- a/pycbc/strain/strain.py
+++ b/pycbc/strain/strain.py
@@ -530,7 +530,7 @@ def insert_strain_option_group(parser, gps_times=True):
                 default=16384, type=float,
                 help="Sample rate of the fake data generation")
     data_reading_group.add_argument("--fake-strain-extra-args",
-                nargs='+', action=MultiDetOptionAction,
+                nargs='+', action=ExtraArgsOptionAction,
                 metavar='PARAM:VALUE', type=str,
                 help="Extra arguments passed to the PSD models.")
 

--- a/pycbc/strain/strain.py
+++ b/pycbc/strain/strain.py
@@ -237,7 +237,7 @@ def from_cli(opt, dyn_range_fac=1, precision='single',
         pdf = 1.0 / opt.fake_strain_filter_duration
         fake_flow = opt.fake_strain_flow
         fake_rate = opt.fake_strain_sample_rate
-        kwargs = opt.fake_strain_extra_args
+        extra_args = opt.extra_args
         plen = round(opt.sample_rate / pdf) // 2 + 1
         if opt.fake_strain_from_file:
             logging.info("Reading ASD from file")
@@ -248,7 +248,7 @@ def from_cli(opt, dyn_range_fac=1, precision='single',
         elif opt.fake_strain != 'zeroNoise':
             logging.info("Making PSD for strain")
             strain_psd = pycbc.psd.from_string(opt.fake_strain, plen, pdf,
-                                               fake_flow, **kwargs)
+                                               fake_flow, **extra_args)
 
         if opt.fake_strain == 'zeroNoise':
             logging.info("Making zero-noise time series")

--- a/pycbc/strain/strain.py
+++ b/pycbc/strain/strain.py
@@ -249,7 +249,7 @@ def from_cli(opt, dyn_range_fac=1, precision='single',
                                             is_asd_file=True)
         elif opt.fake_strain != 'zeroNoise':
             logging.info("Making PSD for strain")
-            if hasattr(opt, 'fake_strain_extra_args') and (kwargs != None):
+            if hasattr(opt,'fake_strain_extra_args') and (kwargs is not None):
                 strain_psd = pycbc.psd.from_string(opt.fake_strain, plen, pdf,
                                                    fake_flow, **kwargs)
             else:

--- a/pycbc/strain/strain.py
+++ b/pycbc/strain/strain.py
@@ -22,9 +22,9 @@ import functools
 import pycbc.types
 from pycbc.types import TimeSeries, zeros
 from pycbc.types import Array, FrequencySeries
-from pycbc.types import MultiDetOptionAppendAction
+from pycbc.types import MultiDetOptionAppendAction, MultiDetOptionAction
 from pycbc.types import MultiDetOptionActionSpecial
-from pycbc.types import DictOptionAction, MultiDetDictOptionAction
+from pycbc.types import DictOptionAction
 from pycbc.types import required_opts, required_opts_multi_ifo
 from pycbc.types import ensure_one_opt, ensure_one_opt_multi_ifo
 from pycbc.types import copy_opts_for_single_ifo, complex_same_precision_as

--- a/pycbc/strain/strain.py
+++ b/pycbc/strain/strain.py
@@ -24,6 +24,7 @@ from pycbc.types import TimeSeries, zeros
 from pycbc.types import Array, FrequencySeries
 from pycbc.types import MultiDetOptionAppendAction, MultiDetOptionAction
 from pycbc.types import MultiDetOptionActionSpecial
+from pycbc.types import DictOptionAction, MultiDetDictOptionAction
 from pycbc.types import required_opts, required_opts_multi_ifo
 from pycbc.types import ensure_one_opt, ensure_one_opt_multi_ifo
 from pycbc.types import copy_opts_for_single_ifo, complex_same_precision_as
@@ -237,7 +238,7 @@ def from_cli(opt, dyn_range_fac=1, precision='single',
         pdf = 1.0 / opt.fake_strain_filter_duration
         fake_flow = opt.fake_strain_flow
         fake_rate = opt.fake_strain_sample_rate
-        extra_args = opt.extra_args
+        fake_extra_args = opt.fake_strain_extra_args
         plen = round(opt.sample_rate / pdf) // 2 + 1
         if opt.fake_strain_from_file:
             logging.info("Reading ASD from file")
@@ -248,7 +249,7 @@ def from_cli(opt, dyn_range_fac=1, precision='single',
         elif opt.fake_strain != 'zeroNoise':
             logging.info("Making PSD for strain")
             strain_psd = pycbc.psd.from_string(opt.fake_strain, plen, pdf,
-                                               fake_flow, **extra_args)
+                                               fake_flow, **fake_extra_args)
 
         if opt.fake_strain == 'zeroNoise':
             logging.info("Making zero-noise time series")
@@ -515,6 +516,11 @@ def insert_strain_option_group(parser, gps_times=True):
     data_reading_group.add_argument("--fake-strain",
                 help="Name of model PSD for generating fake gaussian noise.",
                 choices=pycbc.psd.get_psd_model_list() + ['zeroNoise'])
+    data_reading_group.add_argument("--fake-strain-extra-args",
+                nargs='+', action=DictOptionAction,
+                metavar='PARAM:VALUE', default={}, type=float,
+                help="(optional) Extra arguments passed to "
+                "the PSD models.")
     data_reading_group.add_argument("--fake-strain-seed", type=int, default=0,
                 help="Seed value for the generation of fake colored"
                      " gaussian noise")
@@ -715,6 +721,11 @@ def insert_strain_option_group_multi_ifo(parser, gps_times=True):
                             help="Name of model PSD for generating fake "
                             "gaussian noise. Choose from %s or zeroNoise" \
                             %((', ').join(pycbc.psd.get_lalsim_psd_list()),) )
+    data_reading_group_multi.add_argument("--fake-strain-extra-args",
+                            nargs='+', action=MultiDetDictOptionAction,
+                            metavar='DETECTOR:PARAM:VALUE', default={},
+                            type=float, help="(optional) Extra arguments "
+                            "passed to the PSD models.")
     data_reading_group_multi.add_argument("--fake-strain-seed", type=int,
                             default=0, nargs="+", action=MultiDetOptionAction,
                             metavar='IFO:SEED',

--- a/pycbc/strain/strain.py
+++ b/pycbc/strain/strain.py
@@ -537,7 +537,7 @@ def insert_strain_option_group(parser, gps_times=True):
     data_reading_group.add_argument("--fake-strain-extra-args",
                 nargs='+', action=DictOptionAction,
                 metavar='PARAM:VALUE', type=str,
-                help="Extra arguments passed to the PSD models.")
+                help="(optional) Extra arguments passed to the PSD models.")
 
     # Injection options
     data_reading_group.add_argument("--injection-file", type=str,

--- a/pycbc/strain/strain.py
+++ b/pycbc/strain/strain.py
@@ -249,7 +249,7 @@ def from_cli(opt, dyn_range_fac=1, precision='single',
                                             is_asd_file=True)
         elif opt.fake_strain != 'zeroNoise':
             logging.info("Making PSD for strain")
-            if hasattr(opt, 'fake_strain_extra_args'):
+            if hasattr(opt, 'fake_strain_extra_args') and (kwargs != None):
                 strain_psd = pycbc.psd.from_string(opt.fake_strain, plen, pdf,
                                                    fake_flow, **kwargs)
             else:

--- a/pycbc/strain/strain.py
+++ b/pycbc/strain/strain.py
@@ -24,7 +24,7 @@ from pycbc.types import TimeSeries, zeros
 from pycbc.types import Array, FrequencySeries
 from pycbc.types import MultiDetOptionAppendAction, MultiDetOptionAction
 from pycbc.types import MultiDetOptionActionSpecial
-from pycbc.types import ExtraArgsOptionAction
+from pycbc.types import DictOptionAction
 from pycbc.types import required_opts, required_opts_multi_ifo
 from pycbc.types import ensure_one_opt, ensure_one_opt_multi_ifo
 from pycbc.types import copy_opts_for_single_ifo, complex_same_precision_as
@@ -535,7 +535,7 @@ def insert_strain_option_group(parser, gps_times=True):
                 default=16384, type=float,
                 help="Sample rate of the fake data generation")
     data_reading_group.add_argument("--fake-strain-extra-args",
-                nargs='+', action=ExtraArgsOptionAction,
+                nargs='+', action=DictOptionAction,
                 metavar='PARAM:VALUE', type=str,
                 help="Extra arguments passed to the PSD models.")
 

--- a/pycbc/strain/strain.py
+++ b/pycbc/strain/strain.py
@@ -24,6 +24,7 @@ from pycbc.types import TimeSeries, zeros
 from pycbc.types import Array, FrequencySeries
 from pycbc.types import MultiDetOptionAppendAction, MultiDetOptionAction
 from pycbc.types import MultiDetOptionActionSpecial
+from pycbc.types import ExtraArgsOptionAction
 from pycbc.types import required_opts, required_opts_multi_ifo
 from pycbc.types import ensure_one_opt, ensure_one_opt_multi_ifo
 from pycbc.types import copy_opts_for_single_ifo, complex_same_precision_as
@@ -528,7 +529,9 @@ def insert_strain_option_group(parser, gps_times=True):
     data_reading_group.add_argument("--fake-strain-sample-rate",
                 default=16384, type=float,
                 help="Sample rate of the fake data generation")
-    data_reading_group.add_argument("--fake-strain-extra-args", type=str,
+    data_reading_group.add_argument("--fake-strain-extra-args",
+                nargs='+', action=MultiDetOptionAction,
+                metavar='PARAM:VALUE', type=str,
                 help="Extra arguments passed to the PSD models.")
 
     # Injection options

--- a/pycbc/strain/strain.py
+++ b/pycbc/strain/strain.py
@@ -238,7 +238,8 @@ def from_cli(opt, dyn_range_fac=1, precision='single',
         pdf = 1.0 / opt.fake_strain_filter_duration
         fake_flow = opt.fake_strain_flow
         fake_rate = opt.fake_strain_sample_rate
-        kwargs = opt.fake_strain_extra_args
+        if hasattr(opt, 'fake_strain_extra_args'):
+            kwargs = opt.fake_strain_extra_args
         plen = round(opt.sample_rate / pdf) // 2 + 1
         if opt.fake_strain_from_file:
             logging.info("Reading ASD from file")

--- a/pycbc/strain/strain.py
+++ b/pycbc/strain/strain.py
@@ -270,8 +270,7 @@ def from_cli(opt, dyn_range_fac=1, precision='single',
                                    seed=opt.fake_strain_seed,
                                    sample_rate=fake_rate,
                                    low_frequency_cutoff=fake_flow,
-                                   filter_duration=\
-                                    opt.fake_strain_filter_duration)
+                                   filter_duration=1.0/pdf)
 
         if not strain.sample_rate_close(fake_rate):
             err_msg = "Actual sample rate of generated data does not match "

--- a/pycbc/strain/strain.py
+++ b/pycbc/strain/strain.py
@@ -24,7 +24,6 @@ from pycbc.types import TimeSeries, zeros
 from pycbc.types import Array, FrequencySeries
 from pycbc.types import MultiDetOptionAppendAction, MultiDetOptionAction
 from pycbc.types import MultiDetOptionActionSpecial
-from pycbc.types import DictOptionAction, MultiDetDictOptionAction
 from pycbc.types import required_opts, required_opts_multi_ifo
 from pycbc.types import ensure_one_opt, ensure_one_opt_multi_ifo
 from pycbc.types import copy_opts_for_single_ifo, complex_same_precision_as

--- a/pycbc/strain/strain.py
+++ b/pycbc/strain/strain.py
@@ -530,10 +530,6 @@ def insert_strain_option_group(parser, gps_times=True):
     data_reading_group.add_argument("--fake-strain-sample-rate",
                 default=16384, type=float,
                 help="Sample rate of the fake data generation")
-    data_reading_group.add_argument("--fake-strain-extra-args",
-                nargs='+', action=DictOptionAction,
-                metavar='PARAM:VALUE', default={}, type=float,
-                help="(optional) Extra arguments passed to the PSD models.")
 
     # Injection options
     data_reading_group.add_argument("--injection-file", type=str,
@@ -741,10 +737,6 @@ def insert_strain_option_group_multi_ifo(parser, gps_times=True):
                 default=16384, type=float,
                 nargs="+", action=MultiDetOptionAction,
                 help="Sample rate of the fake data generation")
-    data_reading_group_multi.add_argument("--fake-strain-extra-args",
-                nargs='+', action=MultiDetDictOptionAction,
-                metavar='DETECTOR:PARAM:VALUE', default={}, type=float,
-                help="(optional) Extra arguments passed to the PSD models.")
 
     # Injection options
     data_reading_group_multi.add_argument("--injection-file", type=str,

--- a/pycbc/strain/strain.py
+++ b/pycbc/strain/strain.py
@@ -741,10 +741,6 @@ def insert_strain_option_group_multi_ifo(parser, gps_times=True):
                 default=16384, type=float,
                 nargs="+", action=MultiDetOptionAction,
                 help="Sample rate of the fake data generation")
-    data_reading_group_multi.add_argument("--fake-strain-extra-args",
-                nargs='+', action=MultiDetDictOptionAction,
-                metavar='PARAM:VALUE', default={}, type=dict,
-                help="(optional) Extra arguments passed to the PSD models.")
 
     # Injection options
     data_reading_group_multi.add_argument("--injection-file", type=str,

--- a/pycbc/strain/strain.py
+++ b/pycbc/strain/strain.py
@@ -24,7 +24,7 @@ from pycbc.types import TimeSeries, zeros
 from pycbc.types import Array, FrequencySeries
 from pycbc.types import MultiDetOptionAppendAction, MultiDetOptionAction
 from pycbc.types import MultiDetOptionActionSpecial
-from pycbc.types import DictOptionAction
+from pycbc.types import DictOptionAction, MultiDetDictOptionAction
 from pycbc.types import required_opts, required_opts_multi_ifo
 from pycbc.types import ensure_one_opt, ensure_one_opt_multi_ifo
 from pycbc.types import copy_opts_for_single_ifo, complex_same_precision_as
@@ -532,7 +532,7 @@ def insert_strain_option_group(parser, gps_times=True):
                 help="Sample rate of the fake data generation")
     data_reading_group.add_argument("--fake-strain-extra-args",
                 nargs='+', action=DictOptionAction,
-                metavar='PARAM:VALUE', default={}, type=dict,
+                metavar='PARAM:VALUE', default={}, type=float,
                 help="(optional) Extra arguments passed to the PSD models.")
 
     # Injection options
@@ -741,6 +741,10 @@ def insert_strain_option_group_multi_ifo(parser, gps_times=True):
                 default=16384, type=float,
                 nargs="+", action=MultiDetOptionAction,
                 help="Sample rate of the fake data generation")
+    data_reading_group_multi.add_argument("--fake-strain-extra-args",
+                nargs='+', action=MultiDetDictOptionAction,
+                metavar='DETECTOR:PARAM:VALUE', default={}, type=float,
+                help="(optional) Extra arguments passed to the PSD models.")
 
     # Injection options
     data_reading_group_multi.add_argument("--injection-file", type=str,

--- a/pycbc/strain/strain.py
+++ b/pycbc/strain/strain.py
@@ -269,7 +269,9 @@ def from_cli(opt, dyn_range_fac=1, precision='single',
                                    opt.gps_end_time + opt.pad_data,
                                    seed=opt.fake_strain_seed,
                                    sample_rate=fake_rate,
-                                   low_frequency_cutoff=fake_flow)
+                                   low_frequency_cutoff=fake_flow,
+                                   filter_duration=\
+                                    opt.fake_strain_filter_duration)
 
         if not strain.sample_rate_close(fake_rate):
             err_msg = "Actual sample rate of generated data does not match "

--- a/pycbc/strain/strain.py
+++ b/pycbc/strain/strain.py
@@ -250,8 +250,12 @@ def from_cli(opt, dyn_range_fac=1, precision='single',
                                             is_asd_file=True)
         elif opt.fake_strain != 'zeroNoise':
             logging.info("Making PSD for strain")
-            strain_psd = pycbc.psd.from_string(opt.fake_strain, plen, pdf,
-                                               fake_flow, **kwargs)
+            if hasattr(opt, 'fake_strain_extra_args'):
+                strain_psd = pycbc.psd.from_string(opt.fake_strain, plen, pdf,
+                                                   fake_flow, **kwargs)
+            else:
+                strain_psd = pycbc.psd.from_string(opt.fake_strain, plen, pdf,
+                                                   fake_flow)
 
         if opt.fake_strain == 'zeroNoise':
             logging.info("Making zero-noise time series")

--- a/pycbc/strain/strain.py
+++ b/pycbc/strain/strain.py
@@ -22,9 +22,9 @@ import functools
 import pycbc.types
 from pycbc.types import TimeSeries, zeros
 from pycbc.types import Array, FrequencySeries
-from pycbc.types import MultiDetOptionAppendAction, MultiDetOptionAction
+from pycbc.types import MultiDetOptionAppendAction
 from pycbc.types import MultiDetOptionActionSpecial
-from pycbc.types import DictOptionAction
+from pycbc.types import DictOptionAction, MultiDetDictOptionAction
 from pycbc.types import required_opts, required_opts_multi_ifo
 from pycbc.types import ensure_one_opt, ensure_one_opt_multi_ifo
 from pycbc.types import copy_opts_for_single_ifo, complex_same_precision_as
@@ -238,8 +238,7 @@ def from_cli(opt, dyn_range_fac=1, precision='single',
         pdf = 1.0 / opt.fake_strain_filter_duration
         fake_flow = opt.fake_strain_flow
         fake_rate = opt.fake_strain_sample_rate
-        if hasattr(opt, 'fake_strain_extra_args'):
-            kwargs = opt.fake_strain_extra_args
+        kwargs = opt.fake_strain_extra_args
         plen = round(opt.sample_rate / pdf) // 2 + 1
         if opt.fake_strain_from_file:
             logging.info("Reading ASD from file")
@@ -249,12 +248,8 @@ def from_cli(opt, dyn_range_fac=1, precision='single',
                                             is_asd_file=True)
         elif opt.fake_strain != 'zeroNoise':
             logging.info("Making PSD for strain")
-            if hasattr(opt,'fake_strain_extra_args') and (kwargs is not None):
-                strain_psd = pycbc.psd.from_string(opt.fake_strain, plen, pdf,
-                                                   fake_flow, **kwargs)
-            else:
-                strain_psd = pycbc.psd.from_string(opt.fake_strain, plen, pdf,
-                                                   fake_flow)
+            strain_psd = pycbc.psd.from_string(opt.fake_strain, plen, pdf,
+                                               fake_flow, **kwargs)
 
         if opt.fake_strain == 'zeroNoise':
             logging.info("Making zero-noise time series")
@@ -314,7 +309,7 @@ def from_cli(opt, dyn_range_fac=1, precision='single',
     if injector is not None:
         logging.info("Applying injections")
         injections = \
-            injector.apply(strain, opt.channel_name[0:2],
+            injector.apply(strain, opt.channel_name.split(':')[0],
                            distance_scale=opt.injection_scale_factor,
                            injection_sample_rate=opt.injection_sample_rate,
                            inj_filter_rejector=inj_filter_rejector)
@@ -322,7 +317,7 @@ def from_cli(opt, dyn_range_fac=1, precision='single',
     if opt.sgburst_injection_file:
         logging.info("Applying sine-Gaussian burst injections")
         injector = SGBurstInjectionSet(opt.sgburst_injection_file)
-        injector.apply(strain, opt.channel_name[0:2],
+        injector.apply(strain, opt.channel_name.split(':')[0],
                          distance_scale=opt.injection_scale_factor)
 
     if precision == 'single':
@@ -537,7 +532,7 @@ def insert_strain_option_group(parser, gps_times=True):
                 help="Sample rate of the fake data generation")
     data_reading_group.add_argument("--fake-strain-extra-args",
                 nargs='+', action=DictOptionAction,
-                metavar='PARAM:VALUE', type=str,
+                metavar='PARAM:VALUE', default={}, type=dict,
                 help="(optional) Extra arguments passed to the PSD models.")
 
     # Injection options
@@ -746,6 +741,10 @@ def insert_strain_option_group_multi_ifo(parser, gps_times=True):
                 default=16384, type=float,
                 nargs="+", action=MultiDetOptionAction,
                 help="Sample rate of the fake data generation")
+    data_reading_group_multi.add_argument("--fake-strain-extra-args",
+                nargs='+', action=MultiDetDictOptionAction,
+                metavar='PARAM:VALUE', default={}, type=dict,
+                help="(optional) Extra arguments passed to the PSD models.")
 
     # Injection options
     data_reading_group_multi.add_argument("--injection-file", type=str,

--- a/pycbc/strain/strain.py
+++ b/pycbc/strain/strain.py
@@ -240,6 +240,7 @@ def from_cli(opt, dyn_range_fac=1, precision='single',
         fake_rate = opt.fake_strain_sample_rate
         if hasattr(opt, 'fake_strain_extra_args'):
             kwargs = opt.fake_strain_extra_args
+        else: kwargs = {}
         plen = round(opt.sample_rate / pdf) // 2 + 1
         if opt.fake_strain_from_file:
             logging.info("Reading ASD from file")

--- a/pycbc/strain/strain.py
+++ b/pycbc/strain/strain.py
@@ -240,7 +240,6 @@ def from_cli(opt, dyn_range_fac=1, precision='single',
         fake_rate = opt.fake_strain_sample_rate
         if hasattr(opt, 'fake_strain_extra_args'):
             kwargs = opt.fake_strain_extra_args
-        else: kwargs = {}
         plen = round(opt.sample_rate / pdf) // 2 + 1
         if opt.fake_strain_from_file:
             logging.info("Reading ASD from file")

--- a/pycbc/types/optparse.py
+++ b/pycbc/types/optparse.py
@@ -222,6 +222,7 @@ class ExtraArgsOptionAction(argparse.Action):
                  dest,
                  nargs='+',
                  const=None,
+                 default=None,
                  type=None,
                  choices=None,
                  required=False,
@@ -231,6 +232,8 @@ class ExtraArgsOptionAction(argparse.Action):
             self.internal_type = type
         else:
             self.internal_type = str
+        new_default = DictWithDefaultReturn(lambda: default)
+        #new_default.default_value=default
         if nargs == 0:
             raise ValueError('nargs for append actions must be > 0; if arg '
                              'strings are not supplying the value to append, '
@@ -243,6 +246,7 @@ class ExtraArgsOptionAction(argparse.Action):
             dest=dest,
             nargs=nargs,
             const=const,
+            default=new_default,
             type=str,
             choices=choices,
             required=required,

--- a/pycbc/types/optparse.py
+++ b/pycbc/types/optparse.py
@@ -319,7 +319,7 @@ class MultiDetDictOptionAction(DictOptionAction):
                                     detector_args[detector][param])
                     else:
                         detector_args[detector][param] = \
-                                    self.internal_type(val)          
+                                    self.internal_type(val)
             else:
                 err_msg += ("Use format `DETECTOR:PARAM:VALUE` for each "
                             "detector, or use `PARAM:VALUE` for all.")

--- a/pycbc/types/optparse.py
+++ b/pycbc/types/optparse.py
@@ -261,6 +261,8 @@ class DictOptionAction(argparse.Action):
         items = getattr(namespace, self.dest)
         items = copy.copy(items)
         for value in values:
+            if values == ['{}']:
+                break
             value = value.split(':')
             if len(value) == 2:
                 # "Normal" case, all extra arguments supplied independently
@@ -291,6 +293,8 @@ class MultiDetDictOptionAction(DictOptionAction):
         items = copy.copy(getattr(namespace, self.dest))
         detector_args = {}
         for value in values:
+            if values == ['{}']:
+                break
             if value.count(':') == 2:
                 detector, param_value = value.split(':', 1)
                 param, val = param_value.split(':')

--- a/pycbc/types/optparse.py
+++ b/pycbc/types/optparse.py
@@ -425,7 +425,7 @@ def copy_opts_for_single_ifo(opt, ifo):
     opt = copy.deepcopy(opt)
     for arg, val in vars(opt).items():
         if isinstance(val, DictWithDefaultReturn) or \
-            (isinstance(val, dict) and ifo in val):
+           (isinstance(val, dict) and ifo in val):
             setattr(opt, arg, getattr(opt, arg)[ifo])
     return opt
 

--- a/pycbc/types/optparse.py
+++ b/pycbc/types/optparse.py
@@ -215,7 +215,7 @@ class MultiDetOptionAppendAction(MultiDetOptionAction):
                 raise ValueError(err_msg)
         setattr(namespace, self.dest, items)
 
-class ExtraArgsOptionAction(argparse.Action):
+class DictOptionAction(argparse.Action):
     # Initialise the same as the standard 'append' action
     def __init__(self,
                  option_strings,
@@ -240,7 +240,7 @@ class ExtraArgsOptionAction(argparse.Action):
         if const is not None and nargs != argparse.OPTIONAL:
             raise ValueError('nargs must be %r to supply const'
                              % argparse.OPTIONAL)
-        super(ExtraArgsOptionAction, self).__init__(
+        super(DictOptionAction, self).__init__(
             option_strings=option_strings,
             dest=dest,
             nargs=nargs,
@@ -257,7 +257,7 @@ class ExtraArgsOptionAction(argparse.Action):
         err_msg = "Issue with option: %s \n" %(self.dest,)
         err_msg += "Received value: %s \n" %(' '.join(values),)
         if getattr(namespace, self.dest, None) is None:
-            setattr(namespace, self.dest, DictWithDefaultReturn())
+            setattr(namespace, self.dest, {})
         items = getattr(namespace, self.dest)
         items = copy.copy(items)
         for value in values:

--- a/pycbc/types/optparse.py
+++ b/pycbc/types/optparse.py
@@ -424,7 +424,8 @@ def copy_opts_for_single_ifo(opt, ifo):
     """
     opt = copy.deepcopy(opt)
     for arg, val in vars(opt).items():
-        if isinstance(val, DictWithDefaultReturn):
+        if isinstance(val, DictWithDefaultReturn) or \
+            (isinstance(val, dict) and ifo in val):
             setattr(opt, arg, getattr(opt, arg)[ifo])
     return opt
 

--- a/pycbc/types/optparse.py
+++ b/pycbc/types/optparse.py
@@ -269,7 +269,7 @@ class DictOptionAction(argparse.Action):
             else:
                 err_msg += "The character ':' is used to distinguish the "
                 err_msg += "parameter name and the value. Please do not "
-                err_msg += "use it more than once."
+                err_msg += "use it more than or less than once."
                 raise ValueError(err_msg)
         setattr(namespace, self.dest, items)
 

--- a/pycbc/types/optparse.py
+++ b/pycbc/types/optparse.py
@@ -307,7 +307,7 @@ class MultiDetDictOptionAction(DictOptionAction):
                                 "parameter {} under detector {},\n"
                                 "already have {}.")
                     err_msg = err_msg.format(param, detector,
-                                detector_args[detector][param])
+                                             detector_args[detector][param])
                 else:
                     detector_args[detector][param] = self.internal_type(val)
         items = detector_args

--- a/pycbc/types/optparse.py
+++ b/pycbc/types/optparse.py
@@ -222,7 +222,7 @@ class DictOptionAction(argparse.Action):
                  dest,
                  nargs='+',
                  const=None,
-                 default=None,
+                 default={},
                  type=None,
                  choices=None,
                  required=False,
@@ -232,7 +232,7 @@ class DictOptionAction(argparse.Action):
             self.internal_type = type
         else:
             self.internal_type = str
-        new_default = None
+        new_default = {}
         if nargs == 0:
             raise ValueError('nargs for append actions must be > 0; if arg '
                              'strings are not supplying the value to append, '

--- a/pycbc/types/optparse.py
+++ b/pycbc/types/optparse.py
@@ -222,7 +222,7 @@ class DictOptionAction(argparse.Action):
                  dest,
                  nargs='+',
                  const=None,
-                 default={},
+                 default=None,
                  type=None,
                  choices=None,
                  required=False,
@@ -232,7 +232,7 @@ class DictOptionAction(argparse.Action):
             self.internal_type = type
         else:
             self.internal_type = str
-        new_default = {}
+        new_default = DictWithDefaultReturn(lambda: default)
         if nargs == 0:
             raise ValueError('nargs for append actions must be > 0; if arg '
                              'strings are not supplying the value to append, '

--- a/pycbc/types/optparse.py
+++ b/pycbc/types/optparse.py
@@ -232,8 +232,7 @@ class ExtraArgsOptionAction(argparse.Action):
             self.internal_type = type
         else:
             self.internal_type = str
-        new_default = DictWithDefaultReturn(lambda: default)
-        #new_default.default_value=default
+        new_default = None
         if nargs == 0:
             raise ValueError('nargs for append actions must be > 0; if arg '
                              'strings are not supplying the value to append, '

--- a/pycbc/types/optparse.py
+++ b/pycbc/types/optparse.py
@@ -222,7 +222,6 @@ class ExtraArgsOptionAction(argparse.Action):
                  dest,
                  nargs='+',
                  const=None,
-                 default=None,
                  type=None,
                  choices=None,
                  required=False,
@@ -232,8 +231,6 @@ class ExtraArgsOptionAction(argparse.Action):
             self.internal_type = type
         else:
             self.internal_type = str
-        new_default = DictWithDefaultReturn(lambda: default)
-        #new_default.default_value=default
         if nargs == 0:
             raise ValueError('nargs for append actions must be > 0; if arg '
                              'strings are not supplying the value to append, '
@@ -246,7 +243,6 @@ class ExtraArgsOptionAction(argparse.Action):
             dest=dest,
             nargs=nargs,
             const=const,
-            default=new_default,
             type=str,
             choices=choices,
             required=required,


### PR DESCRIPTION
@ahnitz In this PR, I reimplement LISA TDI PSD for (X,Y,Z) and (A,E,T) channels, and sky/polarization averaged sensitivity curve from the LDC manual. This PR will allow PyCBC to simulate LISA noise. The signal injection is in the next PR.

Currently, I need to do 6 more things:

- [x] test this module with `pycbc.noise.noise_from_psd`
- [x] test this module with `pycbc_condition_strain`
- [x] replace `averaged_lisa_fplus_sq_approx` with a more accurate numerical fit
- [x] add analytical fit for Galatic confusion noise PSD
- [x] add sensitivity curve transformed TDI PSD (X,Y,Z)
- [x] add support for multiple channels' noise generation when using `pycbc_inference`