### PR TITLE
Analytic Kerr ISCO calculation for EM-bright code

### DIFF
--- a/pycbc/neutron_stars/pg_isso_solver.py
+++ b/pycbc/neutron_stars/pg_isso_solver.py
@@ -39,7 +39,9 @@ def ISCO_solution(chi, incl):
     chi: float
         the BH dimensionless spin parameter
     incl: float
-        inclination of the orbit
+        inclination angle between the BH spin and the orbital angular
+        momentum in radians
+        
     Returns
     ----------
     float

--- a/pycbc/neutron_stars/pg_isso_solver.py
+++ b/pycbc/neutron_stars/pg_isso_solver.py
@@ -32,7 +32,7 @@ def ISCO_solution(chi, incl):
     stable circular orbit (ISCO) for the Kerr metric.
 
     ..See eq. (2.21) of
-    `Bardeen, J. M., Press, W. H., Teukolsky, S. A. (1972)
+    `Bardeen, J. M., Press, W. H., Teukolsky, S. A. (1972)`
     https://articles.adsabs.harvard.edu/pdf/1972ApJ...178..347B
 
     Parameters

--- a/pycbc/neutron_stars/pg_isso_solver.py
+++ b/pycbc/neutron_stars/pg_isso_solver.py
@@ -329,7 +329,7 @@ def PG_ISSO_solver(chi, incl):
     initial_lo = np.minimum(rISCO_limit, rISSO_at_pole_limit)
     brackets = [
         (bl, bh) if (c != 1 and PG_ISSO_eq(bl, c, inc)
-        * PG_ISSO_eq(bh, c, inc) < 0) else None
+                    * PG_ISSO_eq(bh, c, inc) < 0) else None
         for bl, bh, c, inc in zip(initial_lo, initial_hi, chi, incl)]
     solution = np.array([
         root_scalar(

--- a/pycbc/neutron_stars/pg_isso_solver.py
+++ b/pycbc/neutron_stars/pg_isso_solver.py
@@ -32,7 +32,7 @@ def ISCO_solution(chi, incl):
     stable circular orbit (ISCO) for the Kerr metric.
 
     ..See eq. (2.21) of
-    _`Bardeen, J. M., Press, W. H., Teukolsky, S. A. (1972)`_
+    Bardeen, J. M., Press, W. H., Teukolsky, S. A. (1972)`
     https://articles.adsabs.harvard.edu/pdf/1972ApJ...178..347B
 
     Parameters

--- a/pycbc/neutron_stars/pg_isso_solver.py
+++ b/pycbc/neutron_stars/pg_isso_solver.py
@@ -309,15 +309,14 @@ def PG_ISSO_solver(chi, incl):
     # Otherwise, find the ISSO radius for a generic inclination
     initial_hi = np.maximum(rISCO_limit, rISSO_at_pole_limit)
     initial_lo = np.minimum(rISCO_limit, rISSO_at_pole_limit)
-    initial_m = 0.5*(initial_hi+initial_lo)
     brackets = [
-        (bl, bh) 
-        for bl, bh in zip(initial_lo, initial_hi)]
+        (bl, bh) if c != 1 else None
+        for bl, bh, c in zip(initial_lo, initial_hi, chi)]
     solution = np.array([
         root_scalar(
             PG_ISSO_eq, x0=g0, fprime=PG_ISSO_eq_dr, bracket=bracket,
             fprime2=PG_ISSO_eq_dr2, args=(c, inc), xtol=1e-12).root
-        for g0, bracket, c, inc in zip(initial_m, brackets, chi, incl)])
+        for g0, bracket, c, inc in zip(initial_hi, brackets, chi, incl)])
     oob = (solution < 1) | (solution > 9)
     if any(oob):
         solution = np.array([

--- a/pycbc/neutron_stars/pg_isso_solver.py
+++ b/pycbc/neutron_stars/pg_isso_solver.py
@@ -32,7 +32,7 @@ def ISCO_solution(chi, incl):
     stable circular orbit (ISCO) for the Kerr metric.
 
     ..See eq. (2.21) of
-    `Bardeen, J. M., Press, W. H., Teukolsky, S. A. (1972)`
+    _`Bardeen, J. M., Press, W. H., Teukolsky, S. A. (1972)`_
     https://articles.adsabs.harvard.edu/pdf/1972ApJ...178..347B
 
     Parameters

--- a/pycbc/neutron_stars/pg_isso_solver.py
+++ b/pycbc/neutron_stars/pg_isso_solver.py
@@ -26,11 +26,12 @@ formalism. See `Stone, Loeb, Berger, PRD 87, 084053 (2013)`_.
 import numpy as np
 from scipy.optimize import root_scalar
 
+
 def ISCO_solution(chi, incl):
     r"""Analytic solution of the innermost
     stable circular orbit (ISCO) for the Kerr metric.
 
-    ..See eq. (2.21) of 
+    ..See eq. (2.21) of
     `Bardeen, J. M., Press, W. H., Teukolsky, S. A. (1972)
     https://articles.adsabs.harvard.edu/pdf/1972ApJ...178..347B
 
@@ -41,7 +42,7 @@ def ISCO_solution(chi, incl):
     incl: float
         inclination angle between the BH spin and the orbital angular
         momentum in radians
-        
+
     Returns
     ----------
     float
@@ -310,7 +311,7 @@ def PG_ISSO_solver(chi, incl):
         return rISCO_limit
 
     # ISSO radius for an inclination of pi/2
-    # Initial guess is based on the extrema of the polar ISSO radius equation, 
+    # Initial guess is based on the extrema of the polar ISSO radius equation,
     # that are: r=6 (chi=1) and r=1+sqrt(3)+sqrt(3+sqrt(12))=5.274... (chi=0)
     initial_guess = [5.27451056440629 if c > 0.5 else 6 for c in chi]
     rISSO_at_pole_limit = np.array([
@@ -327,7 +328,8 @@ def PG_ISSO_solver(chi, incl):
     initial_hi = np.maximum(rISCO_limit, rISSO_at_pole_limit)
     initial_lo = np.minimum(rISCO_limit, rISSO_at_pole_limit)
     brackets = [
-        (bl, bh) if (c != 1 and PG_ISSO_eq(bl, c, inc)*PG_ISSO_eq(bh, c, inc)<0) else None
+        (bl, bh) if (c != 1 and PG_ISSO_eq(bl, c, inc)
+        * PG_ISSO_eq(bh, c, inc) < 0) else None
         for bl, bh, c, inc in zip(initial_lo, initial_hi, chi, incl)]
     solution = np.array([
         root_scalar(

--- a/pycbc/neutron_stars/pg_isso_solver.py
+++ b/pycbc/neutron_stars/pg_isso_solver.py
@@ -28,7 +28,7 @@ from scipy.optimize import root_scalar
 
 def ISCO_solution(chi, incl):
     r"""Analytic solution of the innermost
-    stable circular orbit (ISCO).
+    stable circular orbit (ISCO) for the Kerr metric.
 
     ..See eq. (2.21) of 
     `Bardeen, J. M., Press, W. H., Teukolsky, S. A. (1972)

--- a/pycbc/neutron_stars/pg_isso_solver.py
+++ b/pycbc/neutron_stars/pg_isso_solver.py
@@ -310,6 +310,8 @@ def PG_ISSO_solver(chi, incl):
         return rISCO_limit
 
     # ISSO radius for an inclination of pi/2
+    # Initial guess is based on the extrema of the polar ISSO radius equation, 
+    # that are: r=6 (chi=1) and r=1+sqrt(3)+sqrt(3+sqrt(12))=5.274... (chi=0)
     initial_guess = [5.27451056440629 if c > 0.5 else 6 for c in chi]
     rISSO_at_pole_limit = np.array([
         root_scalar(
@@ -317,7 +319,7 @@ def PG_ISSO_solver(chi, incl):
             fprime2=ISSO_eq_at_pole_dr2, args=(c)).root
         for g0, c in zip(initial_guess, chi)])
     # If the inclination is pi/2, just output the ISSO radius at the pole(s)
-    polar = np.isclose(incl, np.pi / 2)
+    polar = np.isclose(incl, 0.5*np.pi)
     if all(polar):
         return rISSO_at_pole_limit
 

--- a/pycbc/neutron_stars/pg_isso_solver.py
+++ b/pycbc/neutron_stars/pg_isso_solver.py
@@ -329,7 +329,7 @@ def PG_ISSO_solver(chi, incl):
     initial_lo = np.minimum(rISCO_limit, rISSO_at_pole_limit)
     brackets = [
         (bl, bh) if (c != 1 and PG_ISSO_eq(bl, c, inc) *
-                                PG_ISSO_eq(bh, c, inc) < 0) else None
+                     PG_ISSO_eq(bh, c, inc) < 0) else None
         for bl, bh, c, inc in zip(initial_lo, initial_hi, chi, incl)]
     solution = np.array([
         root_scalar(

--- a/pycbc/neutron_stars/pg_isso_solver.py
+++ b/pycbc/neutron_stars/pg_isso_solver.py
@@ -328,8 +328,8 @@ def PG_ISSO_solver(chi, incl):
     initial_hi = np.maximum(rISCO_limit, rISSO_at_pole_limit)
     initial_lo = np.minimum(rISCO_limit, rISSO_at_pole_limit)
     brackets = [
-        (bl, bh) if (c != 1 and PG_ISSO_eq(bl, c, inc)
-                    * PG_ISSO_eq(bh, c, inc) < 0) else None
+        (bl, bh) if (c != 1 and PG_ISSO_eq(bl, c, inc) *
+                                PG_ISSO_eq(bh, c, inc) < 0) else None
         for bl, bh, c, inc in zip(initial_lo, initial_hi, chi, incl)]
     solution = np.array([
         root_scalar(


### PR DESCRIPTION
Optimization and correct handling of corner cases.
Running the code for 10^5 values of dimensionless black hole spin and spin inclination 30 times and averaging the results, we obtained a speedup of 3 times (from 52s to 17s), which is the same reported on the attached plots (run for a single 10^5 points cycle on a different machine).
The high spin case (\chi=1) has also been fixed (see chi1.png).
![chi_inc_isso_new](https://user-images.githubusercontent.com/105977937/200587988-3bb6c4ad-6473-4974-bb0e-6ed136c8d4a1.png)
![chi_inc_isso_old](https://user-images.githubusercontent.com/105977937/200587995-538d1323-eb4b-40f3-af14-00d35547231e.png)
![chi_inc_isso_rel_err](https://user-images.githubusercontent.com/105977937/200588000-1f04d3f3-576a-416e-9ca0-019b2cbdb71e.png)
![chi_inc_isso_rel_err_hist](https://user-images.githubusercontent.com/105977937/200588003-0c6525ab-9077-4bd7-abdc-7ba2bbc29d55.png)
![chi1](https://user-images.githubusercontent.com/105977937/200588006-74f5781b-cf6e-4363-b58f-eda413d9f77b.png)

