### PR TITLE
Fix error in `pycbc_optimal_snr`

### DIFF
--- a/bin/pycbc_optimal_snr
+++ b/bin/pycbc_optimal_snr
@@ -30,12 +30,13 @@ import h5py
 import pycbc
 import pycbc.inject
 import pycbc.psd
+import pycbc.version
 from ligo.lw import utils as ligolw_utils
+from ligo.lw import lsctables
 from pycbc.filter import sigma, make_frequency_series
 from pycbc.types import TimeSeries, FrequencySeries, zeros, float32, \
                         MultiDetOptionAction, load_frequencyseries
-from ligo.lw import lsctables
-import pycbc.version
+from pycbc.io.ligolw import get_table_columns
 
 
 class TimeIndependentPSD(object):
@@ -296,8 +297,10 @@ if __name__ == '__main__':
     inj_table = sorted(inj_table, key=sort_func)
 
     if ligolw:
-        new_inj_table = lsctables.New(lsctables.SimInspiralTable,
-                                      columns=injections.table.columnnames)
+        new_inj_table = lsctables.New(
+            lsctables.SimInspiralTable,
+            columns=get_table_columns(injections.table)
+        )
     else:
         new_inj_table = []
 

--- a/bin/pycbc_split_inspinj
+++ b/bin/pycbc_split_inspinj
@@ -6,7 +6,7 @@ from ligo.lw import utils as ligolw_utils
 from ligo.lw import lsctables
 from itertools import cycle
 import pycbc.version
-from pycbc.io.ligolw import LIGOLWContentHandler
+from pycbc.io.ligolw import LIGOLWContentHandler, get_table_columns
 
 
 # Parse command line
@@ -39,23 +39,12 @@ xmlroot = xmldoc.childNodes[0]
 
 xmlroot.removeChild(allinjs)
 
-if args.num_splits:
-    num_splits = args.num_splits
-else:
-    num_splits = len(args.output_files)
+num_splits = args.num_splits or len(args.output_files)
 
-# make a list of columns that are present in the input table.
-# The : split is needed for columns like `process:process_id`,
-# which must be listed as `process:process_id` in `lsctables.New()`,
-# but are listed as just `process_id` in the `columnnames` attribute
-used_columns = []
-for col in allinjs.validcolumns:
-    att = col.split(':')[-1]
-    if att in allinjs.columnnames:
-        used_columns.append(col)
-
-new_inj_tables = [lsctables.New(tabletype, columns=used_columns) 
-                  for idx in range(num_splits)]
+new_inj_tables = [
+    lsctables.New(tabletype, columns=get_table_columns(allinjs))
+    for _ in range(num_splits)
+]
 
 table_cycle = cycle(new_inj_tables)
 for inj in sorted(allinjs, key=lambda x: x.time_geocent):

--- a/pycbc/io/ligolw.py
+++ b/pycbc/io/ligolw.py
@@ -31,11 +31,14 @@ from ligo.lw.array import Array as LIGOLWArray
 import pycbc.version as pycbc_version
 
 
-__all__ = ('default_null_value',
-           'return_empty_sngl',
-           'return_search_summary',
-           'legacy_row_id_converter',
-           'LIGOLWContentHandler')
+__all__ = (
+    'default_null_value',
+    'return_empty_sngl',
+    'return_search_summary',
+    'legacy_row_id_converter',
+    'get_table_columns',
+    'LIGOLWContentHandler'
+)
 
 ROWID_PYTYPE = int
 ROWID_TYPE = FromPyType[ROWID_PYTYPE]
@@ -309,6 +312,22 @@ def snr_series_to_xml(snr_series, document, sngl_inspiral_id):
     snr_node = document.childNodes[-1].appendChild(snr_xml)
     eid_param = LIGOLWParam.from_pyvalue('event_id', sngl_inspiral_id)
     snr_node.appendChild(eid_param)
+
+def get_table_columns(table):
+    """Return a list of columns that are present in the given table, in a
+    format that can be passed to `lsctables.New()`.
+
+    The split on ":" is needed for columns like `process:process_id`, which
+    must be listed as `process:process_id` in `lsctables.New()`, but are
+    listed as just `process_id` in the `columnnames` attribute of the given
+    table.
+    """
+    columns = []
+    for col in table.validcolumns:
+        att = col.split(':')[-1]
+        if att in table.columnnames:
+            columns.append(col)
+    return columns
 
 
 @legacy_row_id_converter


### PR DESCRIPTION
Fixes the following error when using `pycbc_optimal_snr` with input and output both in XML format:
```
Traceback (most recent call last):
  File "[…]/bin/pycbc_optimal_snr", line 299, in <module>
    new_inj_table = lsctables.New(lsctables.SimInspiralTable,
  File "[…]/lib/python3.9/site-packages/ligo/lw/lsctables.py", line 153, in New
    new.appendColumn(name)
  File "[…]/lib/python3.9/site-packages/ligo/lw/table.py", line 719, in appendColumn
    raise ligolw.ElementError("invalid Column '%s' for Table '%s'" % (name, self.Name))
ligo.lw.ligolw.ElementError: invalid Column 'process_id' for Table 'sim_inspiral' 
```