### PR TITLE
Add example and test for `pycbc_optimal_snr`

### DIFF
--- a/examples/optimal_snr/hdf_injection_definition.ini
+++ b/examples/optimal_snr/hdf_injection_definition.ini
@@ -1,0 +1,51 @@
+[variable_params]
+tc =
+mass1 =
+mass2 =
+ra =
+dec =
+inclination =
+coa_phase =
+polarization =
+distance =
+
+[static_params]
+approximant = IMRPhenomD
+f_lower = 12
+
+[prior-tc]
+name = uniform
+min-tc = 1276524000
+max-tc = 1276525000
+
+[prior-mass1]
+name = uniform
+min-mass1 = 3
+max-mass1 = 30
+
+[prior-mass2]
+name = uniform
+min-mass2 = 3
+max-mass2 = 30
+
+[prior-ra+dec]
+name = uniform_sky
+
+[prior-inclination]
+name = sin_angle
+
+[prior-coa_phase]
+name = uniform_angle
+
+[prior-polarization]
+name = uniform_angle
+
+[prior-distance]
+name = uniform_radius
+min-distance = 20
+max-distance = 500
+
+[constraint-1]
+name = custom
+constraint_arg = q_from_mass1_mass2(mass1, mass2) <= 8
+

--- a/examples/optimal_snr/optimal_snr.sh
+++ b/examples/optimal_snr/optimal_snr.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+# This example shows how to draw a small population of simulated merger signals
+# and calculate their optimal SNRs using the `pycbc_create_injections` and
+# `pycbc_optimal_snr` commands. It also includes variants that employ the
+# `lalapps_inspinj` command and/or the LIGOLW XML format.
+
+set -e
+
+echo Creating some injections in HDF format
+
+pycbc_create_injections \
+    --config-files hdf_injection_definition.ini \
+    --variable-params-section variable_params \
+    --static-params-section static_params \
+    --dist-section prior \
+    --ninjections 5 \
+    --output-file injections.hdf \
+    --force \
+    --verbose
+
+echo Creating some injections in LIGOLW XML format
+
+lalapps_inspinj \
+    --gps-start-time 1276524000 \
+    --gps-end-time 1276525000 \
+    --time-step 100 \
+    --time-interval 0 \
+    --l-distr random \
+    --i-distr uniform \
+    --d-distr uniform \
+    --min-distance 10000 \
+    --max-distance 500000 \
+    --f-lower 15 \
+    --m-distr componentMass \
+    --min-mass1 10 \
+    --max-mass1 40 \
+    --min-mass2 10 \
+    --max-mass2 40 \
+    --waveform IMRPhenomDpseudoFourPN \
+    --disable-spin
+
+echo Calculating optimal SNR for HDF injections, saving to LIGOLW XML
+
+pycbc_optimal_snr \
+    --input-file injections.hdf \
+    --output-file injections_optimal_snr_hdf2xml.xml.gz \
+    --snr-columns \
+        H1:alpha1 \
+        L1:alpha2 \
+        V1:alpha3 \
+    --psd-model aLIGOZeroDetHighPower
+
+echo Calculating optimal SNR for HDF injections, saving to HDF
+
+pycbc_optimal_snr \
+    --input-file injections.hdf \
+    --output-file injections_optimal_snr_hdf2hdf.hdf \
+    --snr-columns \
+        H1:optimal_snr_lho \
+        L1:optimal_snr_llo \
+        V1:optimal_snr_virgo \
+    --psd-model aLIGOZeroDetHighPower
+
+echo Calculating optimal SNR for LIGOLW XML injections, saving to LIGOLW XML
+
+pycbc_optimal_snr \
+    --input-file HL-INJECTIONS_1-1276524000-1000.xml \
+    --output-file injections_optimal_snr_xml2xml.xml.gz \
+    --snr-columns \
+        H1:alpha1 \
+        L1:alpha2 \
+        V1:alpha3 \
+    --psd-model aLIGOZeroDetHighPower

--- a/tools/pycbc_test_suite.sh
+++ b/tools/pycbc_test_suite.sh
@@ -99,6 +99,18 @@ if [ "$PYCBC_TEST_TYPE" = "search" ] || [ -z ${PYCBC_TEST_TYPE+x} ]; then
         echo -e "    Pass."
     fi
     popd
+
+    # run pycbc_optimal_snr example
+    pushd examples/optimal_snr
+    bash -e optimal_snr.sh
+    if test $? -ne 0 ; then
+        RESULT=1
+        echo -e "    FAILED!"
+        echo -e "---------------------------------------------------------"
+    else
+        echo -e "    Pass."
+    fi
+    popd
 fi
 
 if [ "$PYCBC_TEST_TYPE" = "inference" ] || [ -z ${PYCBC_TEST_TYPE+x} ]; then


### PR DESCRIPTION
Apparently `pycbc_optimal_snr` is still being used with LIGOLW XML input, and I am sometimes told about failures due to changes in python-ligo-lw.

So here is a more direct example and test for `pycbc_optimal_snr` based on some test material I had around from tests of previous PRs. This tests `pycbc_optimal_snr` with all possible combinations of input and output formats, and hopefully will catch problems right away in the future.

I took the opportunity to include a more explicit example of how to use `pycbc_create_injections` to draw a small population of injections.

~~I actually expect the example to fail with the current upstream, because of the errors which will be fixed by #4181 and #4182.~~