### PR TITLE
Change logging to indicate UTC offset

### DIFF
--- a/pycbc/__init__.py
+++ b/pycbc/__init__.py
@@ -55,7 +55,7 @@ class LogFormatter(logging.Formatter):
     def formatTime(self, record, datefmt=None):
         ct = self.converter(record.created).astimezone()
         t = ct.strftime("%Y-%m-%dT%H:%M:%S")
-        s = "%s.%03d" % (t, record.msecs)
+        s = f"{t}.{record.msecs:03d}"
         s += ct.strftime('%z')
         return s
 

--- a/pycbc/__init__.py
+++ b/pycbc/__init__.py
@@ -46,10 +46,14 @@ except:
 __version__ = pycbc_version
 
 
-_default_format = '%(asctime)s %(message)s'
-
-
 class LogFormatter(logging.Formatter):
+    """
+    Format the logging appropriately
+    This will return the log time in the ISO 6801 standard,
+    but with millisecond precision
+    https://en.wikipedia.org/wiki/ISO_8601
+    e.g. 2022-11-18T09:53:01.554+00:00
+    """
     converter = dt.fromtimestamp
 
     def formatTime(self, record, datefmt=None):
@@ -60,7 +64,7 @@ class LogFormatter(logging.Formatter):
         return s
 
 
-def init_logging(verbose=False, format=_default_format):
+def init_logging(verbose=False, format='%(asctime)s %(message)s'):
     """Common utility for setting up logging in PyCBC.
 
     Installs a signal handler such that verbosity can be activated at

--- a/pycbc/__init__.py
+++ b/pycbc/__init__.py
@@ -32,6 +32,7 @@ warnings.filterwarnings("ignore", message="numpy.ufunc size changed")
 import logging
 import random
 import string
+import time
 
 try:
     # This will fail when pycbc is imported during the build process,
@@ -45,7 +46,7 @@ except:
 __version__ = pycbc_version
 
 
-def init_logging(verbose=False, format='%(asctime)s %(message)s'):
+def init_logging(verbose=False, format='%(asctime)s UTC: %(message)s'):
     """Common utility for setting up logging in PyCBC.
 
     Installs a signal handler such that verbosity can be activated at
@@ -82,6 +83,7 @@ def init_logging(verbose=False, format='%(asctime)s %(message)s'):
     else:
         initial_level = int(verbose)
     logging.getLogger().setLevel(initial_level)
+    logging.Formatter.converter = time.gmtime
     logging.basicConfig(format=format, level=initial_level)
 
 

--- a/pycbc/__init__.py
+++ b/pycbc/__init__.py
@@ -46,7 +46,7 @@ except:
 __version__ = pycbc_version
 
 
-_default_format = '%(asctime)s %(levelname)s: %(message)s'
+_default_format = '%(asctime)s: %(message)s'
 
 class Formatter(logging.Formatter):
     converter = dt.fromtimestamp

--- a/pycbc/__init__.py
+++ b/pycbc/__init__.py
@@ -60,7 +60,9 @@ class LogFormatter(logging.Formatter):
         ct = self.converter(record.created).astimezone()
         t = ct.strftime("%Y-%m-%dT%H:%M:%S")
         s = f"{t}.{int(record.msecs):03d}"
-        s += ct.strftime('%z')
+        timezone = ct.strftime('%z')
+        timezone_colon = f"{timezone[:-2]}:{timezone[-2:]}"
+        s += timezone_colon
         return s
 
 

--- a/pycbc/__init__.py
+++ b/pycbc/__init__.py
@@ -55,7 +55,7 @@ class LogFormatter(logging.Formatter):
     def formatTime(self, record, datefmt=None):
         ct = self.converter(record.created).astimezone()
         t = ct.strftime("%Y-%m-%dT%H:%M:%S")
-        s = f"{t}.{record.msecs:03d}"
+        s = f"{t}.{record.msecs:03f}"
         s += ct.strftime('%z')
         return s
 

--- a/pycbc/__init__.py
+++ b/pycbc/__init__.py
@@ -55,7 +55,7 @@ class LogFormatter(logging.Formatter):
     def formatTime(self, record, datefmt=None):
         ct = self.converter(record.created).astimezone()
         t = ct.strftime("%Y-%m-%dT%H:%M:%S")
-        s = f"{t}.{record.msecs:03f}"
+        s = f"{t}.{int(record.msecs):03d}"
         s += ct.strftime('%z')
         return s
 

--- a/pycbc/__init__.py
+++ b/pycbc/__init__.py
@@ -46,10 +46,10 @@ except:
 __version__ = pycbc_version
 
 
-_default_format = '%(asctime)s: %(message)s'
+_default_format = '%(asctime)s %(message)s'
 
 
-class Formatter(logging.Formatter):
+class LogFormatter(logging.Formatter):
     converter = dt.fromtimestamp
 
     def formatTime(self, record, datefmt=None):
@@ -101,7 +101,7 @@ def init_logging(verbose=False, fmt=_default_format):
     logger.setLevel(initial_level)
     sh = logging.StreamHandler()
     logger.addHandler(sh)
-    sh.setFormatter(Formatter(fmt=fmt))
+    sh.setFormatter(LogFormatter(fmt=fmt))
 
 
 def makedir(path):

--- a/pycbc/__init__.py
+++ b/pycbc/__init__.py
@@ -60,7 +60,7 @@ class LogFormatter(logging.Formatter):
         return s
 
 
-def init_logging(verbose=False, fmt=_default_format):
+def init_logging(verbose=False, format=_default_format):
     """Common utility for setting up logging in PyCBC.
 
     Installs a signal handler such that verbosity can be activated at
@@ -101,7 +101,7 @@ def init_logging(verbose=False, fmt=_default_format):
     logger.setLevel(initial_level)
     sh = logging.StreamHandler()
     logger.addHandler(sh)
-    sh.setFormatter(LogFormatter(fmt=fmt))
+    sh.setFormatter(LogFormatter(fmt=format))
 
 
 def makedir(path):

--- a/pycbc/__init__.py
+++ b/pycbc/__init__.py
@@ -48,14 +48,17 @@ __version__ = pycbc_version
 
 _default_format = '%(asctime)s: %(message)s'
 
+
 class Formatter(logging.Formatter):
     converter = dt.fromtimestamp
+
     def formatTime(self, record, datefmt=None):
         ct = self.converter(record.created).astimezone()
         t = ct.strftime("%Y-%m-%dT%H:%M:%S")
         s = "%s.%03d" % (t, record.msecs)
         s += ct.strftime('%z')
         return s
+
 
 def init_logging(verbose=False, fmt=_default_format):
     """Common utility for setting up logging in PyCBC.


### PR DESCRIPTION
Update logging to be in UTC - not being in UTC causes some weirdness for logs when spanning a daylight savings change.

This should probably be advertised more generally, so I will ask for "any objection" in the pycbc-code slack channel