### PR TITLE
BUGFIX to sky marginalization, fixes to weights, helper function to turn off ifos

### DIFF
--- a/bin/inference/pycbc_inference_model_stats
+++ b/bin/inference/pycbc_inference_model_stats
@@ -116,7 +116,7 @@ pool = choose_pool(processes=opts.nprocesses)
 logging.info('Getting samples')
 with loadfile(opts.input_file, 'r') as fp:
     # we'll need the shape; all the arrays in the samples group should have the
-    # same shape, so we'll just use the first one
+    # same shape
     shape = fp[fp.samples_group]['loglikelihood'].shape
     samples = {}
     for p in model.variable_params:

--- a/bin/inference/pycbc_inference_model_stats
+++ b/bin/inference/pycbc_inference_model_stats
@@ -117,7 +117,7 @@ logging.info('Getting samples')
 with loadfile(opts.input_file, 'r') as fp:
     # we'll need the shape; all the arrays in the samples group should have the
     # same shape, so we'll just use the first one
-    shape = fp[fp.samples_group][model.variable_params[0]].shape
+    shape = fp[fp.samples_group]['loglikelihood'].shape
     samples = {}
     for p in model.variable_params:
         samples[p] = fp[fp.samples_group][p][()].flatten()


### PR DESCRIPTION
This fixes two bugs in the the monte-carlo weights. They were being assigned from the wrong sample due to an index error and for some detectors with the wrong sign! This showed up in p-p testing, but surprisingly not so obvious in individual examples.

This also adds a function that determines what ifos to be enabled based on the observed SNR. 