### PR TITLE
Add function to use only time around peaks for sky / time marginalization

### DIFF
--- a/examples/inference/single/single.ini
+++ b/examples/inference/single/single.ini
@@ -10,18 +10,24 @@ low-frequency-cutoff = 30.0
 marginalize_vector_params = tc, ra, dec, polarization
 marginalize_vector_samples = 1000
 
+# These lines enable the marginalization to only use information
+# around SNR peaks for drawing possible sky / time positions. Remove
+# if you want to use the entire prior range as possible
+peak_lock_snr = 4.0
+peak_min_snr = 4.0
+
 marginalize_phase = True
 
 marginalize_distance = True
 marginalize_distance_param = distance
 marginalize_distance_interpolator = True
 marginalize_distance_snr_range = 5, 50
-marginalize_distance_density = 200, 200
+marginalize_distance_density = 80, 80
 marginalize_distance_samples = 1000
 
 [data]
 instruments = H1 L1 V1
-analysis-start-time = 1187008482
+analysis-start-time = 1187008782
 analysis-end-time = 1187008892
 psd-estimation = median
 psd-segment-length = 16
@@ -35,8 +41,8 @@ sample-rate = 2048
 
 [sampler]
 name = dynesty
-dlogz = 0.1
-nlive = 1000
+dlogz = 0.5
+nlive = 100
 
 [variable_params]
 ; waveform parameters that will vary in MCMC

--- a/pycbc/inference/models/single_template.py
+++ b/pycbc/inference/models/single_template.py
@@ -70,6 +70,8 @@ class SingleTemplate(DistMarg, BaseGaussianNoise):
         super(SingleTemplate, self).__init__(
             variable_params, data, low_frequency_cutoff, **kwargs)
 
+        sample_rate = float(sample_rate)
+
         # Generate template waveforms
         df = data[self.detectors[0]].delta_f
         self.df = df
@@ -85,7 +87,7 @@ class SingleTemplate(DistMarg, BaseGaussianNoise):
         hp, _ = get_fd_waveform(delta_f=df, distance=1, inclination=0, **p)
 
         # Extend template to high sample rate
-        flen = int(int(sample_rate) / df) / 2 + 1
+        flen = int(round(sample_rate / df) / 2 + 1)
         hp.resize(flen)
 
         # Calculate high sample rate SNR time series
@@ -116,6 +118,13 @@ class SingleTemplate(DistMarg, BaseGaussianNoise):
         self.waveform = hp
         self.htfs = {}  # Waveform phase / distance transformation factors
         self.dts = {}
+
+        # Retrict to analyzing around peaks if chosen and choose what
+        # ifos to draw from
+        self.setup_peak_lock(snrs=self.snr,
+                             sample_rate=sample_rate,
+                             **kwargs)
+        self.draw_ifos(self.snr)
 
     @property
     def multi_signal_support(self):

--- a/pycbc/inference/models/tools.py
+++ b/pycbc/inference/models/tools.py
@@ -498,12 +498,32 @@ class DistMarg():
         self.marginalize_vector_weights = logw - logsumexp(logw)
 
     def setup_peak_lock(self,
-                 sample_rate=4096,
-                 snrs=None,
-                 peak_lock_snr=None,
-                 peak_lock_ratio=1e4,
-                 peak_lock_region=4,
-                 **kwargs):
+                        sample_rate=4096,
+                        snrs=None,
+                        peak_lock_snr=None,
+                        peak_lock_ratio=1e4,
+                        peak_lock_region=4,
+                        **kwargs):
+        """ Determine where to constrain marginalization based on 
+        the observed reference SNR peaks.
+        
+        Parameters
+        ----------
+        sample_rate : float
+            The SNR sample rate
+        snrs : Dict of SNR time series
+            Either provide this or the model needs a function
+            to get the reference SNRs.
+        peak_lock_snr: float
+            The minimum SNR to bother restricting from the prior range
+        peak_lock_ratio: float
+            The likelihood ratio (not log) relative to the peak to
+            act as a threshold bounding region.
+        peak_lock_region: int
+            Number of samples to inclue beyond the strict region
+            determined by the relative likelihood
+        """
+                
         if 'tc' not in self.marginalized_vector_priors:
             return
 
@@ -551,7 +571,8 @@ class DistMarg():
                 te = ts + self.num_samples[ifo] / sample_rate
 
                 for ifo2 in snrs:
-                    if ifo == ifo2: continue
+                    if ifo == ifo2:
+                        continue
                     ts2 = self.tstart[ifo2]
                     te2 = ts2 + self.num_samples[ifo2] / sample_rate
                     det = Detector(ifo)

--- a/pycbc/inference/models/tools.py
+++ b/pycbc/inference/models/tools.py
@@ -504,9 +504,9 @@ class DistMarg():
                         peak_lock_ratio=1e4,
                         peak_lock_region=4,
                         **kwargs):
-        """ Determine where to constrain marginalization based on 
+        """ Determine where to constrain marginalization based on
         the observed reference SNR peaks.
-        
+
         Parameters
         ----------
         sample_rate : float
@@ -523,7 +523,7 @@ class DistMarg():
             Number of samples to inclue beyond the strict region
             determined by the relative likelihood
         """
-                
+
         if 'tc' not in self.marginalized_vector_priors:
             return
 

--- a/pycbc/inference/models/tools.py
+++ b/pycbc/inference/models/tools.py
@@ -326,7 +326,7 @@ class DistMarg():
 
         starts = []
         ends = []
-        
+
         tmin, tmax = tcmin - dt, tcmax + dt
         if hasattr(self, 'tstart'):
             tmin = self.tstart[iref]
@@ -436,7 +436,7 @@ class DistMarg():
 
             start = max(tmin, snrs[ifo].start_time)
             end = min(tmax, snrs[ifo].end_time)
-            
+
             snr = snr.time_slice(start, end, mode='nearest')
 
             w = snr.squared_norm().numpy() / 2.0
@@ -506,14 +506,14 @@ class DistMarg():
                  **kwargs):
         if 'tc' not in self.marginalized_vector_priors:
             return
-        
+
         tcmin, tcmax = self.marginalized_vector_priors['tc'].bounds['tc']
         tstart = tcmin - EARTH_RADIUS
         tmax = tcmax - tcmin + EARTH_RADIUS * 2.0
         num_samples = int(tmax * sample_rate)
         self.tstart = {ifo: tstart for ifo in self.data}
         self.num_samples = {ifo: num_samples for ifo in self.data}
-        
+
         if snrs is None:
             if not hasattr(self, 'ref_snr'):
                 raise ValueError("Model didn't have a reference SNR!")
@@ -543,7 +543,7 @@ class DistMarg():
                     ts = times[region[0]] - peak_lock_region / sample_rate
                     te = times[region[-1]] + peak_lock_region / sample_rate
                     self.tstart[ifo] = ts
-                    self.num_samples[ifo] =  int((te - ts) * sample_rate)
+                    self.num_samples[ifo] = int((te - ts) * sample_rate)
 
             # Check times are commensurate with each other
             for ifo in snrs:
@@ -559,23 +559,23 @@ class DistMarg():
 
                     ts = max(ts, ts2 - dt)
                     te = min(te, te2 + dt)
-             
+
                 self.tstart[ifo] = ts
                 self.num_samples[ifo] = int((te - ts) * sample_rate) + 1
                 logging.info('%s: use region %s-%s, %s points',
                              ifo, ts, te, self.num_samples[ifo])
 
         self.tend = self.tstart.copy()
-        for ifo in snrs: 
+        for ifo in snrs:
             self.tend[ifo] += self.num_samples[ifo] / sample_rate
 
     def draw_ifos(self, snrs, peak_snr_threshold=4.0, **kwargs):
         """ Helper utility to determine which ifos we should use based on the
         reference SNR time series.
-        """ 
+        """
         if 'tc' not in self.marginalized_vector_priors:
             return
-        
+
         tcmin, tcmax = self.marginalized_vector_priors['tc'].bounds['tc']
         ifos = list(snrs.keys())
         keep_ifos = []
@@ -588,10 +588,10 @@ class DistMarg():
             if abs(snr).max() > peak_snr_threshold:
                 keep_ifos.append(ifo)
 
-        logging.info("Ifos used for SNR based draws: %s, peak_snr_threshold=%s",
+        logging.info("Ifos used for SNR draws: %s, peak_snr_threshold=%s",
                      keep_ifos, peak_snr_threshold)
         self.keep_ifos = keep_ifos
-        return keep_ifos     
+        return keep_ifos
 
     @property
     def current_params(self):


### PR DESCRIPTION
this adds a function to determine what time ranges to use for each detector based on the observed SNR peak of a reference signal's SNR time series. This speeds up marginalization over sky location. 