### PR TITLE
Add new marginalize time example and fixes for when few monte-carlo points are found

### DIFF
--- a/examples/inference/margtime/injection.ini
+++ b/examples/inference/margtime/injection.ini
@@ -2,14 +2,14 @@
 
 [static_params]
 tc = 1126259462.420
-mass1 = 37
-mass2 = 62
+mass1 = 80
+mass2 = 20
 ra = 2.2
 dec = -1.25
 inclination = 2.5
 coa_phase = 1.5
 polarization = 1.75
-distance = 1000
+distance = 2000
 f_ref = 20
 f_lower = 18
 approximant = IMRPhenomD

--- a/examples/inference/margtime/injection.ini
+++ b/examples/inference/margtime/injection.ini
@@ -1,0 +1,16 @@
+[variable_params]
+
+[static_params]
+tc = 1126259462.420
+mass1 = 37
+mass2 = 62
+ra = 2.2
+dec = -1.25
+inclination = 2.5
+coa_phase = 1.5
+polarization = 1.75
+distance = 1000
+f_ref = 20
+f_lower = 18
+approximant = IMRPhenomD
+taper = start

--- a/examples/inference/margtime/margtime_inj.ini
+++ b/examples/inference/margtime/margtime_inj.ini
@@ -98,7 +98,7 @@ max-tc = 1126259462.45
 #; following gives a uniform in volume
 name = uniform_radius
 min-distance = 100
-max-distance = 2500
+max-distance = 3000
 
 [prior-polarization]
 name = uniform_angle

--- a/examples/inference/margtime/margtime_inj.ini
+++ b/examples/inference/margtime/margtime_inj.ini
@@ -1,0 +1,107 @@
+
+[model]
+name = marginalized_time
+low-frequency-cutoff = 30.0
+
+marginalize_vector_params = tc, ra, dec, polarization
+marginalize_vector_samples = 500
+
+; You shouldn't use phase marginalization if the approximant has
+; higher-order modes
+marginalize_phase = True
+
+marginalize_distance = True
+marginalize_distance_param = distance
+marginalize_distance_interpolator = True
+marginalize_distance_snr_range = 5, 50
+marginalize_distance_density = 100, 100
+marginalize_distance_samples = 1000
+
+[data]
+instruments = H1 L1
+trigger-time = 1126259462.43
+; See the documentation at
+; http://pycbc.org/pycbc/latest/html/inference.html#simulated-bbh-example
+; for details on the following settings:
+analysis-start-time = -4
+analysis-end-time = 1
+psd-estimation = median-mean
+psd-start-time = -256
+psd-end-time = 256
+psd-inverse-length = 8
+psd-segment-length = 8
+psd-segment-stride = 4
+; The frame files must be downloaded from GWOSC before running. Here, we
+; assume that the files have been downloaded to the same directory. Adjust
+; the file path as necessary if not.
+injection-file = injection.hdf
+fake-strain = aLIGOZeroDetLowPower
+fake-strain-sample-rate = 2048
+channel-name = H1:GWOSC-4KHZ_R1_STRAIN L1:GWOSC-4KHZ_R1_STRAIN
+sample-rate = 2048
+; We'll use a high-pass filter so as not to get numerical errors from the large
+; amplitude low frequency noise. Here we use 15 Hz, which is safely below the
+; low frequency cutoff of our likelihood integral (20 Hz)
+strain-high-pass = 15
+; The pad-data argument is for the high-pass filter: 8s are added to the
+; beginning/end of the analysis/psd times when the data is loaded. After the
+; high pass filter is applied, the additional time is discarded. This pad is
+; *in addition to* the time added to the analysis start/end time for the PSD
+; inverse length. Since it is discarded before the data is transformed for the
+; likelihood integral, it has little affect on the run time.
+pad-data = 8
+
+[sampler]
+name = dynesty
+dlogz = 1.0
+nlive = 200
+
+[variable_params]
+; waveform parameters that will vary in MCMC
+mass1 =
+mass2 =
+inclination =
+distance =
+polarization =
+ra =
+dec =
+tc =
+
+[static_params]
+; waveform parameters that will not change in MCMC
+approximant = IMRPhenomD
+f_lower = 20
+
+[prior-mass1]
+name = uniform
+min-mass1 = 15
+max-mass1 = 90
+
+[prior-mass2]
+name = uniform
+min-mass2 = 15
+max-mass2 = 90
+
+[prior-ra]
+name = uniform_angle
+
+[prior-dec]
+name = cos_angle
+
+[prior-tc]
+#; coalescence time prior
+name = uniform
+min-tc = 1126259462.35
+max-tc = 1126259462.45
+
+[prior-distance]
+#; following gives a uniform in volume
+name = uniform_radius
+min-distance = 100
+max-distance = 2500
+
+[prior-polarization]
+name = uniform_angle
+
+[prior-inclination]
+name = sin_angle

--- a/examples/inference/margtime/run_inj.sh
+++ b/examples/inference/margtime/run_inj.sh
@@ -1,3 +1,14 @@
+pycbc_create_injections --verbose \
+        --config-files injection.ini \
+        --ninjections 1 \
+        --seed 10 \
+        --output-file injection.hdf \
+        --variable-params-section variable_params \
+        --static-params-section static_params \
+        --dist-section prior \
+        --force
+
+
 OMP_NUM_THREADS=1 pycbc_inference \
 --config-file `dirname "$0"`/margtime_inj.ini \
 --nprocesses 1 \
@@ -20,7 +31,5 @@ pycbc_inference_plot_posterior \
 --input-file demarg_inj.hdf \
 --output-file demarg_inj.png \
 --parameters \
- "primary_mass(mass1, mass2) / (1 + redshift(distance)):srcmass1" \
- "secondary_mass(mass1, mass2) / (1 + redshift(distance)):srcmass2" \
- ra dec tc inclination coa_phase polarization distance \
---z-arg snr
+ mass1 mass2 ra dec tc inclination coa_phase polarization distance \
+--z-arg snr --plot-injection-parameters

--- a/examples/inference/margtime/run_inj.sh
+++ b/examples/inference/margtime/run_inj.sh
@@ -1,0 +1,26 @@
+OMP_NUM_THREADS=1 pycbc_inference \
+--config-file `dirname "$0"`/margtime_inj.ini \
+--nprocesses 1 \
+--processing-scheme cpu \
+--output-file marg_inj.hdf \
+--seed 0 \
+--force \
+--verbose
+
+# This reconstructs any marginalized parameters
+OMP_NUM_THREADS=1 pycbc_inference_model_stats \
+--input-file marg_inj.hdf \
+--output-file demarg_inj.hdf \
+--nprocesses 2 \
+--reconstruct-parameters \
+--force \
+--verbose
+
+pycbc_inference_plot_posterior \
+--input-file demarg_inj.hdf \
+--output-file demarg_inj.png \
+--parameters \
+ "primary_mass(mass1, mass2) / (1 + redshift(distance)):srcmass1" \
+ "secondary_mass(mass1, mass2) / (1 + redshift(distance)):srcmass2" \
+ ra dec tc inclination coa_phase polarization distance \
+--z-arg snr

--- a/pycbc/inference/models/marginalized_gaussian_noise.py
+++ b/pycbc/inference/models/marginalized_gaussian_noise.py
@@ -204,10 +204,12 @@ class MarginalizedTime(DistMarg, BaseGaussianNoise):
     """
     name = 'marginalized_time'
 
-    def __init__(self, variable_params, data, low_frequency_cutoff, psds=None,
+    def __init__(self, variable_params,
+                 data, low_frequency_cutoff, psds=None,
                  high_frequency_cutoff=None, normalize=False,
                  **kwargs):
 
+        self.kwargs = kwargs
         variable_params, kwargs = self.setup_marginalization(
                                variable_params,
                                **kwargs)
@@ -317,6 +319,7 @@ class MarginalizedTime(DistMarg, BaseGaussianNoise):
                          (cplx_hcd[det] / hchc[det] ** 0.5).squared_norm())
             snr_estimate[det] = (0.5 * snr_proxy) ** 0.5
 
+        self.draw_ifos(snr_estimate, log=False, **self.kwargs)
         self.snr_draw(snr_estimate)
 
         for det in wfs:

--- a/pycbc/inference/models/tools.py
+++ b/pycbc/inference/models/tools.py
@@ -385,12 +385,12 @@ class DistMarg():
         ifos = list(snrs.keys())
         if hasattr(self, 'keep_ifos'):
             ifos = self.keep_ifos
-        ikey  = ''.join(ifos)
-        
+        ikey = ''.join(ifos)
+
         # No good SNR peaks, go with prior draw
         if len(ifos) == 0:
             return
- 
+
         def make_init():
             logging.info('pregenerating sky pointings')
             size = int(1e6)
@@ -421,15 +421,15 @@ class DistMarg():
 
             if len(ifos) == 1:
                 dmap[()] = list(zip(ra, dec, dtc))
-            return ifos, dmap, d, tcmin, tcmax
-        
+            return ifos, dmap, tcmin, tcmax
+
         if not hasattr(self, 'tinfo'):
             self.tinfo = {}
-        
-        if ikey not in self.tinfo:  
+
+        if ikey not in self.tinfo:
             self.tinfo[ikey] = make_init()
 
-        ifos, dmap, d, tcmin, tcmax = self.tinfo[ikey]
+        ifos, dmap, tcmin, tcmax = self.tinfo[ikey]
 
         # draw times from each snr time series
         # Is it worth doing this if some detector has low SNR?
@@ -490,7 +490,7 @@ class DistMarg():
 
         # fill back to fixed size with repeat samples
         # sample order is random, so this should be OK statistically
-        
+
         ra = numpy.resize(numpy.array(ra), self.vsamples)
         dec = numpy.resize(numpy.array(dec), self.vsamples)
         dtc = numpy.resize(numpy.array(dtc), self.vsamples)
@@ -629,8 +629,9 @@ class DistMarg():
             psnrs.append(psnr)
 
         if log:
-            logging.info("Ifos used for SNR based draws: %s, snrs: %s, peak_snr_threshold=%s",
-                     keep_ifos, psnrs, peak_snr_threshold)
+            logging.info("Ifos used for SNR based draws:"
+                         " %s, snrs: %s, peak_snr_threshold=%s",
+                         keep_ifos, psnrs, peak_snr_threshold)
 
         self.keep_ifos = keep_ifos
         return keep_ifos


### PR DESCRIPTION
This adds a fix to the case where no valid sky locations are identified using the SNR based draws. If only a small fraction of guessed points are valid, it reverts to prior drawn values instead of potentially producing *zero* (which of course causes an error which this patch not avoids). 

This also adds a new software injection based example of the marginalized_time model. 

Depends on #4201 

@KoustavChandra This PR should hopefully address the issue you were seeing with the marginalized_time model. Please give it a try and let me know if it helps in a case you were seeing fail. 
