### PR TITLE
add two heterodyne / relative likelihood models dedicated to sky marginalization

### DIFF
--- a/examples/inference/relmarg/get.sh
+++ b/examples/inference/relmarg/get.sh
@@ -1,0 +1,6 @@
+for ifo in H-H1 L-L1 V-V1
+do
+    file=${ifo}_LOSC_CLN_4_V1-1187007040-2048.gwf
+    test -f ${file} && continue
+    curl -O --silent https://dcc.ligo.org/public/0146/P1700349/001/${file}
+done

--- a/examples/inference/relmarg/reltime.ini
+++ b/examples/inference/relmarg/reltime.ini
@@ -14,7 +14,7 @@ epsilon = 0.05
 low-frequency-cutoff = 30.0
 
 marginalize_vector_params = polarization, tc, ra, dec, inclination
-marginalize_vector_samples = 400
+marginalize_vector_samples = 1000
 
 marginalize_phase = True
 
@@ -46,8 +46,8 @@ sample-rate = 2048
 
 [sampler]
 name = dynesty
-dlogz = 0.1
-nlive = 200
+dlogz = 1.0
+nlive = 100
 
 [variable_params]
 ; waveform parameters that will vary in MCMC

--- a/examples/inference/relmarg/reltime.ini
+++ b/examples/inference/relmarg/reltime.ini
@@ -1,0 +1,105 @@
+[model]
+name = relative_time_dom
+
+#; This model precalculates the SNR time series at a fixed rate.
+#; If you need a higher time resolution, this may be increased
+sample_rate = 8192
+peak_lock_snr = 5.0
+peak_lock_ratio = 4000
+peak_lock_region = 10
+epsilon = 0.05
+low-frequency-cutoff = 30.0
+
+marginalize_vector_params = polarization, tc, ra, dec, inclination
+marginalize_vector_samples = 400
+
+marginalize_phase = True
+
+marginalize_distance = True
+marginalize_distance_param = distance
+marginalize_distance_interpolator = True
+marginalize_distance_snr_range = 5, 50
+marginalize_distance_density = 200, 200
+marginalize_distance_samples = 1000
+tc_ref = 1187008882.42825
+mass1_ref = 1.3757
+mass2_ref = 1.3757
+
+
+[data]
+instruments = H1 L1 V1
+analysis-start-time = 1187008482
+analysis-end-time = 1187008892
+psd-estimation = median
+psd-segment-length = 16
+psd-segment-stride = 8
+psd-inverse-length = 16
+pad-data = 8
+channel-name = H1:LOSC-STRAIN L1:LOSC-STRAIN V1:LOSC-STRAIN
+frame-files = H1:H-H1_LOSC_CLN_4_V1-1187007040-2048.gwf L1:L-L1_LOSC_CLN_4_V1-1187007040-2048.gwf V1:V-V1_LOSC_CLN_4_V1-1187007040-2048.gwf
+strain-high-pass = 15
+sample-rate = 2048
+
+
+[sampler]
+name = dynesty
+dlogz = 0.1
+nlive = 200
+
+[variable_params]
+; waveform parameters that will vary in MCMC
+#coa_phase =
+distance =
+polarization =
+ra =
+dec =
+tc =
+inclination =
+
+mchirp =
+eta =
+
+[static_params]
+; waveform parameters that will not change in MCMC
+approximant = TaylorF2
+f_lower = 30
+
+[prior-mchirp]
+; chirp mass prior
+name = uniform
+min-mchirp = 1.1876
+max-mchirp = 1.2076
+
+[prior-eta]
+; symmetric mass ratio prior
+name = uniform
+min-eta = 0.23
+max-eta = 0.25
+
+[prior-ra]
+name = uniform_angle
+
+[prior-dec]
+name = cos_angle
+
+[prior-tc]
+#; coalescence time prior
+name = uniform
+min-tc = 1187008882.4
+max-tc = 1187008882.5
+
+[prior-distance]
+#; following gives a uniform in volume
+name = uniform_radius
+min-distance = 10
+max-distance = 60
+
+[prior-polarization]
+name = uniform_angle
+
+[prior-inclination]
+name = sin_angle
+
+[waveform_transforms-mass1+mass2]
+; transform from mchirp, eta to mass1, mass2 for waveform generation
+name = mchirp_eta_to_mass1_mass2

--- a/examples/inference/relmarg/reltime.ini
+++ b/examples/inference/relmarg/reltime.ini
@@ -4,9 +4,12 @@ name = relative_time_dom
 #; This model precalculates the SNR time series at a fixed rate.
 #; If you need a higher time resolution, this may be increased
 sample_rate = 8192
+
 peak_lock_snr = 5.0
+peak_min_snr = 4.0
 peak_lock_ratio = 4000
 peak_lock_region = 10
+
 epsilon = 0.05
 low-frequency-cutoff = 30.0
 
@@ -18,8 +21,8 @@ marginalize_phase = True
 marginalize_distance = True
 marginalize_distance_param = distance
 marginalize_distance_interpolator = True
-marginalize_distance_snr_range = 5, 50
-marginalize_distance_density = 200, 200
+marginalize_distance_snr_range = 20, 40
+marginalize_distance_density = 80, 80
 marginalize_distance_samples = 1000
 tc_ref = 1187008882.42825
 mass1_ref = 1.3757
@@ -28,7 +31,7 @@ mass2_ref = 1.3757
 
 [data]
 instruments = H1 L1 V1
-analysis-start-time = 1187008482
+analysis-start-time = 1187008782
 analysis-end-time = 1187008892
 psd-estimation = median
 psd-segment-length = 16

--- a/examples/inference/relmarg/reltime.ini
+++ b/examples/inference/relmarg/reltime.ini
@@ -5,8 +5,9 @@ name = relative_time_dom
 #; If you need a higher time resolution, this may be increased
 sample_rate = 8192
 
+peak_snr_threshold = 4.0
+
 peak_lock_snr = 5.0
-peak_min_snr = 4.0
 peak_lock_ratio = 4000
 peak_lock_region = 10
 

--- a/examples/inference/relmarg/run.sh
+++ b/examples/inference/relmarg/run.sh
@@ -1,0 +1,27 @@
+OMP_NUM_THREADS=1 python -m cProfile -o log `which pycbc_inference` \
+--config-file `dirname "$0"`/reltime.ini \
+--nprocesses=1 \
+--output-file reltime.hdf \
+--seed 0 \
+--force \
+--verbose
+bash p.sh
+
+# This reconstructs any marginalized parameters
+# and would be optional if you don't need them or
+# have sampled over all parameters directly (see reltime.ini)
+OMP_NUM_THREADS=1 python -m cProfile -o log2 `which pycbc_inference_model_stats` \
+--input-file reltime.hdf \
+--output-file reltime2.hdf \
+--nprocesses 8 \
+--reconstruct-parameters \
+--force \
+--verbose
+
+pycbc_inference_plot_posterior \
+--input-file reltime2.hdf \
+--output-file reltime.png \
+--parameters distance inclination polarization coa_phase tc ra dec mchirp eta \
+--z-arg snr
+
+#pycbc_inference_plot_posterior --input-file reltime.hdf --output-file reltime.png --parameters distance inclination polarization coa_phase tc ra dec --z-arg snr

--- a/examples/inference/relmarg/run.sh
+++ b/examples/inference/relmarg/run.sh
@@ -5,7 +5,6 @@ OMP_NUM_THREADS=1 python -m cProfile -o log `which pycbc_inference` \
 --seed 0 \
 --force \
 --verbose
-bash p.sh
 
 # This reconstructs any marginalized parameters
 # and would be optional if you don't need them or
@@ -13,7 +12,7 @@ bash p.sh
 OMP_NUM_THREADS=1 python -m cProfile -o log2 `which pycbc_inference_model_stats` \
 --input-file reltime.hdf \
 --output-file reltime2.hdf \
---nprocesses 8 \
+--nprocesses 2 \
 --reconstruct-parameters \
 --force \
 --verbose
@@ -23,5 +22,3 @@ pycbc_inference_plot_posterior \
 --output-file reltime.png \
 --parameters distance inclination polarization coa_phase tc ra dec mchirp eta \
 --z-arg snr
-
-#pycbc_inference_plot_posterior --input-file reltime.hdf --output-file reltime.png --parameters distance inclination polarization coa_phase tc ra dec --z-arg snr

--- a/pycbc/inference/models/__init__.py
+++ b/pycbc/inference/models/__init__.py
@@ -35,7 +35,7 @@ from .brute_marg import BruteParallelGaussianMarginalize
 from .brute_marg import BruteLISASkyModesMarginalize
 from .gated_gaussian_noise import (GatedGaussianNoise, GatedGaussianMargPol)
 from .single_template import SingleTemplate
-from .relbin import Relative
+from .relbin import Relative, RelativeTime, RelativeTimeDom
 from .hierarchical import HierarchicalModel, MultiSignalModel
 
 
@@ -203,8 +203,10 @@ _models = {_cls.name: _cls for _cls in (
     GatedGaussianMargPol,
     SingleTemplate,
     Relative,
+    RelativeTime,
     HierarchicalModel,
     MultiSignalModel,
+    RelativeTimeDom,
 )}
 
 

--- a/pycbc/inference/models/relbin.py
+++ b/pycbc/inference/models/relbin.py
@@ -528,8 +528,8 @@ class Relative(DistMarg, BaseGaussianNoise):
                 dtc = -end_time
                 channel = wfs[ifo].numpy()
                 filter_i, norm_i = lik(freqs, dtc, channel, h00,
-                                            sdat['a0'], sdat['a1'],
-                                            sdat['b0'], sdat['b1'])
+                                       sdat['a0'], sdat['a1'],
+                                       sdat['b0'], sdat['b1'])
             else:
                 hp, hc = wfs[ifo]
                 det = self.det[ifo]
@@ -539,9 +539,9 @@ class Relative(DistMarg, BaseGaussianNoise):
                 dtc = p["tc"] + dt - end_time
 
                 filter_i, norm_i = lik(freqs, fp, fc, dtc,
-                                            hp, hc, h00,
-                                            sdat['a0'], sdat['a1'],
-                                            sdat['b0'], sdat['b1'])
+                                       hp, hc, h00,
+                                       sdat['a0'], sdat['a1'],
+                                       sdat['b0'], sdat['b1'])
                 self._current_wf_parts[ifo] = (fp, fc, dtc, hp, hc, h00)
             filt += filter_i
             norm += norm_i
@@ -607,7 +607,8 @@ class Relative(DistMarg, BaseGaussianNoise):
         )
         args.update({"fiducial_params": fid_params, "gammas": gammas})
         return args
-    
+
+
 class RelativeTime(Relative):
     """ Heterodyne likelihood optimized for time marginalization
     """
@@ -619,16 +620,16 @@ class RelativeTime(Relative):
         super(RelativeTime, self).__init__(*args, **kwargs)
         self.sample_rate = float(sample_rate)
         self.setup_peak_lock(sample_rate=self.sample_rate, **kwargs)
-        self.draw_ifos(self.ref_snr)  
- 
+        self.draw_ifos(self.ref_snr)
+
     @property
     def ref_snr(self):
         if not hasattr(self, '_ref_snr'):
             wfs = {ifo: (self.h00_sparse[ifo],
-                     self.h00_sparse[ifo]) for ifo in self.h00_sparse}       
+                     self.h00_sparse[ifo]) for ifo in self.h00_sparse}
             self._ref_snr = self.get_snr(wfs, reference=True)
         return self._ref_snr
-        
+
     def get_snr(self, wfs, reference=False):
         """ Return hp/hc maximized SNR time series
         """
@@ -642,12 +643,12 @@ class RelativeTime(Relative):
                 dtc -= self.ta[ifo]
 
             snr = snr_predictor(self.fedges[ifo],
-                        dtc, delta_t,
-                        self.num_samples[ifo],
-                        wfs[ifo][0], wfs[ifo][1],
-                        self.h00_sparse[ifo],
-                        sdat['a0'], sdat['a1'],
-                        sdat['b0'], sdat['b1'])
+                                dtc, delta_t,
+                                self.num_samples[ifo],
+                                wfs[ifo][0], wfs[ifo][1],
+                                self.h00_sparse[ifo],
+                                sdat['a0'], sdat['a1'],
+                                sdat['b0'], sdat['b1'])
             snrs[ifo] = TimeSeries(snr, delta_t=delta_t,
                                    epoch=self.tstart[ifo])
         return snrs
@@ -701,6 +702,7 @@ class RelativeTime(Relative):
         loglr = self.marginalize_loglr(filt, norm)
         return loglr
 
+
 class RelativeTimeDom(RelativeTime):
     """ Heterodyne likelihood optimized for time marginalization
     """
@@ -721,16 +723,16 @@ class RelativeTimeDom(RelativeTime):
                 dtc -= self.ta[ifo]
 
             sh, hh = snr_predictor_dom(self.fedges[ifo],
-                        dtc - delta_t * 2.0, delta_t,
-                        self.num_samples[ifo] + 4,
-                        wfs[ifo][0],
-                        self.h00_sparse[ifo],
-                        sdat['a0'], sdat['a1'],
-                        sdat['b0'], sdat['b1'])
+                                       dtc - delta_t * 2.0, delta_t,
+                                       self.num_samples[ifo] + 4,
+                                       wfs[ifo][0],
+                                       self.h00_sparse[ifo],
+                                       sdat['a0'], sdat['a1'],
+                                       sdat['b0'], sdat['b1'])
             snr = TimeSeries(abs(sh[2:-2]) / hh ** 0.5, delta_t=delta_t,
-                                   epoch=self.tstart[ifo])
+                             epoch=self.tstart[ifo])
             self.sh[ifo] = TimeSeries(sh, delta_t=delta_t,
-                                   epoch=self.tstart[ifo] - delta_t * 2.0)
+                                      epoch=self.tstart[ifo] - delta_t * 2.0)
             self.hh[ifo] = hh
             snrs[ifo] = snr
 

--- a/pycbc/inference/models/relbin.py
+++ b/pycbc/inference/models/relbin.py
@@ -42,7 +42,7 @@ from .relbin_cpu import (likelihood_parts, likelihood_parts_v,
                          likelihood_parts_det, likelihood_parts_vector,
                          likelihood_parts_vectorp, snr_predictor,
                          snr_predictor_dom)
-from .tools import DistMarg, EARTH_RADIUS
+from .tools import DistMarg
 
 
 def setup_bins(f_full, f_lo, f_hi, chi=1.0,
@@ -626,7 +626,7 @@ class RelativeTime(Relative):
     def ref_snr(self):
         if not hasattr(self, '_ref_snr'):
             wfs = {ifo: (self.h00_sparse[ifo],
-                     self.h00_sparse[ifo]) for ifo in self.h00_sparse}
+                         self.h00_sparse[ifo]) for ifo in self.h00_sparse}
             self._ref_snr = self.get_snr(wfs, reference=True)
         return self._ref_snr
 

--- a/pycbc/inference/models/relbin.py
+++ b/pycbc/inference/models/relbin.py
@@ -620,7 +620,7 @@ class RelativeTime(Relative):
         super(RelativeTime, self).__init__(*args, **kwargs)
         self.sample_rate = float(sample_rate)
         self.setup_peak_lock(sample_rate=self.sample_rate, **kwargs)
-        self.draw_ifos(self.ref_snr)
+        self.draw_ifos(self.ref_snr, **kwargs)
 
     @property
     def ref_snr(self):

--- a/pycbc/inference/models/relbin.py
+++ b/pycbc/inference/models/relbin.py
@@ -34,16 +34,20 @@ from scipy.interpolate import interp1d
 from pycbc.waveform import (get_fd_waveform_sequence,
                             get_fd_det_waveform_sequence, fd_det_sequence)
 from pycbc.detector import Detector
-from pycbc.types import Array
+from pycbc.types import Array, TimeSeries
 
 from .gaussian_noise import BaseGaussianNoise
 from .relbin_cpu import (likelihood_parts, likelihood_parts_v,
                          likelihood_parts_multi, likelihood_parts_multi_v,
-                         likelihood_parts_det)
-from .tools import DistMarg
+                         likelihood_parts_det, likelihood_parts_vector,
+                         likelihood_parts_vectorp, snr_predictor,
+                         snr_predictor_dom)
+from .tools import DistMarg, EARTH_RADIUS
 
 
-def setup_bins(f_full, f_lo, f_hi, chi=1.0, eps=0.5, gammas=None):
+def setup_bins(f_full, f_lo, f_hi, chi=1.0,
+               eps=0.1, gammas=None,
+               ):
     """Construct frequency bins for use in a relative likelihood
     model. For details, see [Barak, Dai & Venumadhav 2018].
 
@@ -277,13 +281,13 @@ class Relative(DistMarg, BaseGaussianNoise):
                     self.fid_params["dec"],
                     self.fid_params["tc"],
                 )
-                self.ta = self.fid_params["tc"] + dt - self.end_time[ifo]
+                self.ta[ifo] = self.fid_params["tc"] + dt - self.end_time[ifo]
 
                 fp, fc = self.det[ifo].antenna_pattern(
                     self.fid_params["ra"], self.fid_params["dec"],
                     self.fid_params["polarization"], self.fid_params["tc"])
 
-                tshift = numpy.exp(-2.0j * numpy.pi * self.f[ifo] * self.ta)
+                tshift = numpy.exp(-2.0j * numpy.pi * self.f[ifo] * self.ta[ifo])
 
                 h00 = (hp0 * fp + hc0 * fc) * tshift
                 self.h00[ifo] = h00
@@ -364,8 +368,22 @@ class Relative(DistMarg, BaseGaussianNoise):
                 self.lik = likelihood_parts_det
             else:
                 self.lik = likelihood_parts
-            self.mlik = likelihood_parts_multi
+                self.mlik = likelihood_parts_multi
         return atimes
+
+    @property
+    def likelihood_function(self):
+        if self.marginalize_vector_params:
+            p = self.current_params
+
+            for k in ['ra', 'dec', 'tc']:
+                if k in p and not numpy.isscalar(p[k]):
+                    return likelihood_parts_vector
+
+            if 'polarization' in p and not numpy.isscalar(p['polarization']):
+                return likelihood_parts_vectorp
+
+        return self.lik
 
     def summary_product(self, h1, h2, bins, ifo):
         """ Calculate the summary values for the inner product <h1|h2>
@@ -489,15 +507,14 @@ class Relative(DistMarg, BaseGaussianNoise):
             The value of the log likelihood ratio.
         """
         # get model params
-        p = self.current_params.copy()
-        p.update(self.static_params)
+        p = self.current_params
         wfs = self.get_waveforms(p)
-
+        lik = self.likelihood_function
         norm = 0.0
         filt = 0j
         self._current_wf_parts = {}
-        for ifo in self.data:
 
+        for ifo in self.data:
             freqs = self.fedges[ifo]
             sdat = self.sdat[ifo]
             h00 = self.h00_sparse[ifo]
@@ -510,7 +527,7 @@ class Relative(DistMarg, BaseGaussianNoise):
             if self.no_det_response:
                 dtc = -end_time
                 channel = wfs[ifo].numpy()
-                filter_i, norm_i = self.lik(freqs, dtc, channel, h00,
+                filter_i, norm_i = lik(freqs, dtc, channel, h00,
                                             sdat['a0'], sdat['a1'],
                                             sdat['b0'], sdat['b1'])
             else:
@@ -521,14 +538,15 @@ class Relative(DistMarg, BaseGaussianNoise):
                 dt = det.time_delay_from_earth_center(p["ra"], p["dec"], times)
                 dtc = p["tc"] + dt - end_time
 
-                filter_i, norm_i = self.lik(freqs, fp, fc, dtc,
+                filter_i, norm_i = lik(freqs, fp, fc, dtc,
                                             hp, hc, h00,
                                             sdat['a0'], sdat['a1'],
                                             sdat['b0'], sdat['b1'])
                 self._current_wf_parts[ifo] = (fp, fc, dtc, hp, hc, h00)
             filt += filter_i
             norm += norm_i
-        return self.marginalize_loglr(filt, norm)
+        loglr = self.marginalize_loglr(filt, norm)
+        return loglr
 
     def write_metadata(self, fp, group=None):
         """Adds writing the fiducial parameters and epsilon to file's attrs.
@@ -589,3 +607,182 @@ class Relative(DistMarg, BaseGaussianNoise):
         )
         args.update({"fiducial_params": fid_params, "gammas": gammas})
         return args
+    
+class RelativeTime(Relative):
+    """ Heterodyne likelihood optimized for time marginalization
+    """
+    name = "relative_time"
+
+    def __init__(self, *args,
+                 sample_rate=4096,
+                 **kwargs):
+        super(RelativeTime, self).__init__(*args, **kwargs)
+        self.sample_rate = float(sample_rate)
+        self.setup_peak_lock(sample_rate=self.sample_rate, **kwargs)
+        self.draw_ifos(self.ref_snr)  
+ 
+    @property
+    def ref_snr(self):
+        if not self.hasattr(self, '_ref_snr'):
+            wfs = {ifo: (self.h00_sparse[ifo],
+                     self.h00_sparse[ifo]) for ifo in self.h00_sparse}       
+            self._ref_snr = self.get_snr(wfs, reference=True)
+        return self._ref_snr
+        
+    def get_snr(self, wfs, reference=False):
+        """ Return hp/hc maximized SNR time series
+        """
+        delta_t = 1.0 / self.sample_rate
+        snrs = {}
+        for ifo in wfs:
+            sdat = self.sdat[ifo]
+            dtc = self.tstart[ifo] - self.end_time[ifo]
+
+            if reference:
+                dtc -= self.ta[ifo]
+
+            snr = snr_predictor(self.fedges[ifo],
+                        dtc, delta_t,
+                        self.num_samples[ifo],
+                        wfs[ifo][0], wfs[ifo][1],
+                        self.h00_sparse[ifo],
+                        sdat['a0'], sdat['a1'],
+                        sdat['b0'], sdat['b1'])
+            snrs[ifo] = TimeSeries(snr, delta_t=delta_t,
+                                   epoch=self.tstart[ifo])
+        return snrs
+
+    def _loglr(self):
+        r"""Computes the log likelihood ratio,
+
+        .. math::
+
+            \log \mathcal{L}(\Theta) = \sum_i
+                \left<h_i(\Theta)|d_i\right> -
+                \frac{1}{2}\left<h_i(\Theta)|h_i(\Theta)\right>,
+
+        at the current parameter values :math:`\Theta`.
+
+        Returns
+        -------
+        float
+            The value of the log likelihood ratio.
+        """
+        # get model params
+        p = self.current_params
+        wfs = self.get_waveforms(p)
+        lik = self.likelihood_function
+        norm = 0.0
+        filt = 0j
+
+        self.snr_draw(self.get_snr(wfs))
+        p = self.current_params
+
+        for ifo in self.data:
+            freqs = self.fedges[ifo]
+            sdat = self.sdat[ifo]
+            h00 = self.h00_sparse[ifo]
+            end_time = self.end_time[ifo]
+            times = self.antenna_time[ifo]
+
+            hp, hc = wfs[ifo]
+            det = self.det[ifo]
+            fp, fc = det.antenna_pattern(p["ra"], p["dec"],
+                                         p["polarization"], times)
+            dt = det.time_delay_from_earth_center(p["ra"], p["dec"], times)
+            dtc = p["tc"] + dt - end_time
+
+            filter_i, norm_i = lik(freqs, fp, fc, dtc,
+                                   hp, hc, h00,
+                                   sdat['a0'], sdat['a1'],
+                                   sdat['b0'], sdat['b1'])
+            filt += filter_i
+            norm += norm_i
+        loglr = self.marginalize_loglr(filt, norm)
+        return loglr
+
+class RelativeTimeDom(RelativeTime):
+    """ Heterodyne likelihood optimized for time marginalization
+    """
+    name = "relative_time_dom"
+
+    def get_snr(self, wfs, reference=False):
+        """ Return hp/hc maximized SNR time series
+        """
+        delta_t = 1.0 / self.sample_rate
+        snrs = {}
+        self.sh = {}
+        self.hh = {}
+        for ifo in wfs:
+            sdat = self.sdat[ifo]
+            dtc = self.tstart[ifo] - self.end_time[ifo]
+
+            if reference:
+                dtc -= self.ta[ifo]
+
+            sh, hh = snr_predictor_dom(self.fedges[ifo],
+                        dtc - delta_t * 2.0, delta_t,
+                        self.num_samples[ifo] + 4,
+                        wfs[ifo][0],
+                        self.h00_sparse[ifo],
+                        sdat['a0'], sdat['a1'],
+                        sdat['b0'], sdat['b1'])
+            snr = TimeSeries(abs(sh[2:-2]) / hh ** 0.5, delta_t=delta_t,
+                                   epoch=self.tstart[ifo])
+            self.sh[ifo] = TimeSeries(sh, delta_t=delta_t,
+                                   epoch=self.tstart[ifo] - delta_t * 2.0)
+            self.hh[ifo] = hh
+            snrs[ifo] = snr
+
+        return snrs
+
+    def _loglr(self):
+        r"""Computes the log likelihood ratio,
+
+        .. math::
+
+            \log \mathcal{L}(\Theta) = \sum_i
+                \left<h_i(\Theta)|d_i\right> -
+                \frac{1}{2}\left<h_i(\Theta)|h_i(\Theta)\right>,
+
+        at the current parameter values :math:`\Theta`.
+
+        Returns
+        -------
+        float
+            The value of the log likelihood ratio.
+        """
+        # calculate <d-h|d-h> = <h|h> - 2<h|d> + <d|d> up to a constant
+        p = self.current_params
+
+        p2 = p.copy()
+        p2.pop('inclination')
+        wfs = self.get_waveforms(p2)
+        snrs = self.get_snr(wfs)
+
+        sh_total = hh_total = 0
+
+        ic = numpy.cos(p['inclination'])
+        ip = 0.5 * (1.0 + ic * ic)
+        pol_phase = numpy.exp(-2.0j * p['polarization'])
+
+        self.snr_draw(snrs)
+
+        for ifo in self.sh:
+            dt = self.det[ifo].time_delay_from_earth_center(p['ra'], p['dec'],
+                                                            p['tc'])
+            dts = p['tc'] + dt
+
+            fp, fc = self.det[ifo].antenna_pattern(p['ra'], p['dec'],
+                                                   0, p['tc'])
+            f = (fp + 1.0j * fc) * pol_phase
+
+            # Note, this includes complex conjugation already
+            # as our stored inner products were hp* x data
+            htf = (f.real * ip + 1.0j * f.imag * ic)
+            sh = self.sh[ifo].at_time(dts, interpolate='quadratic')
+            sh_total += sh * htf
+            hh_total += self.hh[ifo] * abs(htf) ** 2.0
+
+        loglr = self.marginalize_loglr(sh_total, hh_total)
+        return loglr

--- a/pycbc/inference/models/relbin.py
+++ b/pycbc/inference/models/relbin.py
@@ -610,7 +610,9 @@ class Relative(DistMarg, BaseGaussianNoise):
 
 
 class RelativeTime(Relative):
-    """ Heterodyne likelihood optimized for time marginalization
+    """ Heterodyne likelihood optimized for time marginalization. In addition
+    it supports phase (dominant-mode), sky location, and polarization
+    marginalization.
     """
     name = "relative_time"
 
@@ -704,7 +706,9 @@ class RelativeTime(Relative):
 
 
 class RelativeTimeDom(RelativeTime):
-    """ Heterodyne likelihood optimized for time marginalization
+    """ Heterodyne likelihood optimized for time marginalization and only
+    dominant-mode waveforms. This enables the ability to do inclination
+    marginalization in addition to the other forms supportedy by RelativeTime.
     """
     name = "relative_time_dom"
 

--- a/pycbc/inference/models/relbin.py
+++ b/pycbc/inference/models/relbin.py
@@ -623,7 +623,7 @@ class RelativeTime(Relative):
  
     @property
     def ref_snr(self):
-        if not self.hasattr(self, '_ref_snr'):
+        if not hasattr(self, '_ref_snr'):
             wfs = {ifo: (self.h00_sparse[ifo],
                      self.h00_sparse[ifo]) for ifo in self.h00_sparse}       
             self._ref_snr = self.get_snr(wfs, reference=True)

--- a/pycbc/inference/models/tools.py
+++ b/pycbc/inference/models/tools.py
@@ -616,6 +616,8 @@ class DistMarg():
         if 'tc' not in self.marginalized_vector_priors:
             return
 
+        peak_snr_threshold = float(peak_snr_threshold)
+
         tcmin, tcmax = self.marginalized_vector_priors['tc'].bounds['tc']
         ifos = list(snrs.keys())
         keep_ifos = []

--- a/pycbc/inference/models/tools.py
+++ b/pycbc/inference/models/tools.py
@@ -564,7 +564,9 @@ class DistMarg():
             peak_lock_region = int(peak_lock_region)
 
             for ifo in snrs:
-                z = snrs[ifo].time_slice(tstart, tstart + tmax, mode='nearest')
+                s = max(tstart, snrs[ifo].start_time)
+                e = min(tstart + tmax, snrs[ifo].end_time)
+                z = snrs[ifo].time_slice(s, e, mode='nearest')
                 peak_snr, imax = z.abs_max_loc()
                 times = z.sample_times
                 peak_time = times[imax]


### PR DESCRIPTION
This adds two new models of the heterodyne type. One is focused on 22-mode only optimizations, while the other is left more generic. An example is added for the latter (which inherits from the former). 

Depends on #4202 