### PR TITLE
Use mchirp_area to include a HasMassGap probability

### DIFF
--- a/pycbc/io/live.py
+++ b/pycbc/io/live.py
@@ -261,9 +261,10 @@ class CandidateForGraceDB(object):
             kwargs['hasmassgap_args']['mass_bdary']['ns_max'] = 3.0
             kwargs['hasmassgap_args']['mass_bdary']['gap_max'] = 5.0
             self.hasmassgap = calc_probabilities(coinc_inspiral_row.mchirp,
-                                                    coinc_inspiral_row.snr,
-                                                    min(eff_distances),
-                                                    kwargs['hasmassgap_args'])['Mass Gap']
+                                                 coinc_inspiral_row.snr,
+                                                 min(eff_distances),
+                                                 kwargs['hasmassgap_args']
+                                                )['Mass Gap']
         else:
             self.probabilities = None
             self.hasmassgap = None
@@ -295,7 +296,7 @@ class CandidateForGraceDB(object):
             self.basename = fname.replace('.xml.gz', '')
 
         # Save EMBright properties info as json
-        if  self.hasmassgap is not None:
+        if self.hasmassgap is not None:
             self.embright_file = self.basename + '_em_bright.json'
             with open(self.embright_file, 'w') as embrightf:
                 json.dump({'HasMassGap': self.hasmassgap}, embrightf)
@@ -472,13 +473,13 @@ class CandidateForGraceDB(object):
             try:
                 gracedb.write_log(
                     gid, 'EM Bright properties JSON file upload',
-                    filename = self.embright_file,
+                    filename=self.embright_file,
                     tag_name=['em_follow']
                 )
                 logging.info('Uploaded em_bright properties for %s', gid)
             except Exception as exc:
-                logging.error('Failed to upload em_bright properties file for %s',
-                              gid)
+                logging.error('Failed to upload em_bright properties file '
+                              'for %s', gid)
                 logging.error(str(exc))
 
         # Upload multi-cpt p_astro JSON

--- a/pycbc/io/live.py
+++ b/pycbc/io/live.py
@@ -4,6 +4,7 @@ import pycbc
 import numpy
 import lal
 import json
+import copy
 from ligo.lw import ligolw
 from ligo.lw import lsctables
 from ligo.lw import utils as ligolw_utils
@@ -255,7 +256,7 @@ class CandidateForGraceDB(object):
                                                     coinc_inspiral_row.snr,
                                                     min(eff_distances),
                                                     kwargs['mc_area_args'])
-            kwargs['hasmassgap_args'] = numpy.copy(kwargs['mc_area_args'])
+            kwargs['hasmassgap_args'] = copy.deepcopy(kwargs['mc_area_args'])
             kwargs['hasmassgap_args']['mass_gap'] = True
             kwargs['hasmassgap_args']['mass_bdary']['ns_max'] = 3.0
             kwargs['hasmassgap_args']['mass_bdary']['gap_max'] = 5.0
@@ -293,6 +294,13 @@ class CandidateForGraceDB(object):
             # here assume compression
             self.basename = fname.replace('.xml.gz', '')
 
+        # Save EMBright properties info as json
+        if  self.hasmassgap is not None:
+            self.embright_file = self.basename + '_em_bright.json'
+            with open(self.embright_file, 'w') as embrightf:
+                json.dump({'HasMassGap': self.hasmassgap}, embrightf)
+            logging.info('EM Bright file saved as %s', self.embright_file)
+
         # Save multi-cpt p astro as json
         if self.astro_probs is not None:
             self.multipa_file = self.basename + '_p_astro.json'
@@ -317,14 +325,6 @@ class CandidateForGraceDB(object):
                 json.dump({'p_astro': self.p_astro, 'p_terr': self.p_terr},
                           pastrof)
             logging.info('P_astro file saved as %s', self.pastro_file)
-        return
-
-        # Save EMBright properties info as json
-        if  self.hasmassgap is not None:
-            self.embright_file = self.basename + '_em_bright.json'
-            with open(self.embright_file, 'w') as embrightf:
-                json.dump({'HasMassGap': self.hasmassgap}, embrightf)
-            logging.info('EM Bright file saved as %s', self.embright_file)
         return
 
     def upload(self, fname, gracedb_server=None, testing=True,

--- a/pycbc/io/live.py
+++ b/pycbc/io/live.py
@@ -260,11 +260,11 @@ class CandidateForGraceDB(object):
             kwargs['hasmassgap_args']['mass_gap'] = True
             kwargs['hasmassgap_args']['mass_bdary']['ns_max'] = 3.0
             kwargs['hasmassgap_args']['mass_bdary']['gap_max'] = 5.0
-            self.hasmassgap = calc_probabilities(coinc_inspiral_row.mchirp,
-                                                 coinc_inspiral_row.snr,
-                                                 min(eff_distances),
-                                                 kwargs['hasmassgap_args']
-                                                )['Mass Gap']
+            self.hasmassgap = calc_probabilities(
+                                  coinc_inspiral_row.mchirp,
+                                  coinc_inspiral_row.snr,
+                                  min(eff_distances),
+                                  kwargs['hasmassgap_args'])['Mass Gap']
         else:
             self.probabilities = None
             self.hasmassgap = None
@@ -469,7 +469,7 @@ class CandidateForGraceDB(object):
                 logging.error(str(exc))
 
         # Upload em_bright properties JSON
-        if  self.hasmassgap is not None:
+        if self.hasmassgap is not None:
             try:
                 gracedb.write_log(
                     gid, 'EM Bright properties JSON file upload',

--- a/pycbc/io/live.py
+++ b/pycbc/io/live.py
@@ -273,7 +273,7 @@ class CandidateForGraceDB(object):
         if self.p_astro is not None and self.probabilities is not None:
             self.astro_probs = {cl: pr * self.p_astro for
                                 cl, pr in self.probabilities.items()}
-            self.astro_probs['p_terr'] = self.p_terr
+            self.astro_probs['Terrestrial'] = self.p_terr
         else:
             self.astro_probs = None
 
@@ -291,20 +291,18 @@ class CandidateForGraceDB(object):
         """
         ligolw_utils.write_filename(self.outdoc, fname, compress='auto')
 
-        if self.basename is None:
-            # here assume compression
-            self.basename = fname.replace('.xml.gz', '')
+        save_dir = os.path.dirname(fname)
 
         # Save EMBright properties info as json
         if self.hasmassgap is not None:
-            self.embright_file = self.basename + '_em_bright.json'
+            self.embright_file = os.path.join(save_dir, 'pycbc.em_bright.json')
             with open(self.embright_file, 'w') as embrightf:
                 json.dump({'HasMassGap': self.hasmassgap}, embrightf)
             logging.info('EM Bright file saved as %s', self.embright_file)
 
         # Save multi-cpt p astro as json
         if self.astro_probs is not None:
-            self.multipa_file = self.basename + '_p_astro.json'
+            self.multipa_file = os.path.join(save_dir, 'pycbc.p_astro.json')
             with open(self.multipa_file, 'w') as multipaf:
                 json.dump(self.astro_probs, multipaf)
             logging.info('Multi p_astro file saved as %s', self.multipa_file)
@@ -313,15 +311,14 @@ class CandidateForGraceDB(object):
 
         # Save source probabilities in a json file
         if self.probabilities is not None:
-            self.prob_file = self.basename + '_probs.json'
+            self.prob_file = os.path.join(save_dir, 'src_probs.json')
             with open(self.prob_file, 'w') as probf:
                 json.dump(self.probabilities, probf)
             logging.info('Source probabilities file saved as %s', self.prob_file)
-            return
 
         # Save p astro / p terr as json
         if self.p_astro is not None:
-            self.pastro_file = self.basename + '_pa_pterr.json'
+            self.pastro_file = os.path.join(save_dir, 'pa_pterr.json')
             with open(self.pastro_file, 'w') as pastrof:
                 json.dump({'p_astro': self.p_astro, 'p_terr': self.p_terr},
                           pastrof)
@@ -474,7 +471,7 @@ class CandidateForGraceDB(object):
                 gracedb.write_log(
                     gid, 'EM Bright properties JSON file upload',
                     filename=self.embright_file,
-                    tag_name=['em_follow']
+                    tag_name=['em_bright']
                 )
                 logging.info('Uploaded em_bright properties for %s', gid)
             except Exception as exc:
@@ -488,7 +485,7 @@ class CandidateForGraceDB(object):
                 gracedb.write_log(
                     gid, 'Multi-component p_astro JSON file upload',
                     filename=self.multipa_file,
-                    tag_name=['em_follow']
+                    tag_name=['p_astro']
                 )
                 logging.info('Uploaded multi p_astro for %s', gid)
             except Exception as exc:


### PR DESCRIPTION
Work in progress to upload a separate probability for MassGap to be included in the EM Bright properties file. Related to issue #4196.