### PR TITLE
Pin tox version and fix a typo in the mac tests

### DIFF
--- a/.github/workflows/basic-tests.yml
+++ b/.github/workflows/basic-tests.yml
@@ -21,7 +21,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install *fftw3* mpi intel-mkl* git-lfs graphviz
-        pip install tox<4.0.0 pip setuptools --upgrade
+        pip install "tox<4.0.0" pip setuptools --upgrade
     - name: installing auxiliary data files
       run: |
         GIT_LFS_SKIP_SMUDGE=1 git clone https://git.ligo.org/lscsoft/lalsuite-extra

--- a/.github/workflows/basic-tests.yml
+++ b/.github/workflows/basic-tests.yml
@@ -21,7 +21,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install *fftw3* mpi intel-mkl* git-lfs graphviz
-        pip install tox pip setuptools --upgrade
+        pip install tox<4.0.0 pip setuptools --upgrade
     - name: installing auxiliary data files
       run: |
         GIT_LFS_SKIP_SMUDGE=1 git clone https://git.ligo.org/lscsoft/lalsuite-extra

--- a/.github/workflows/mac-test.yml
+++ b/.github/workflows/mac-test.yml
@@ -18,7 +18,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - run: |
         brew install fftw openssl
-        pip install --upgrade pip setuptools tox<4.0.0
+        pip install --upgrade pip setuptools "tox<4.0.0"
     - name: run basic pycbc test suite
       run: |
         sudo chmod -R 777 /usr/local/miniconda/

--- a/.github/workflows/mac-test.yml
+++ b/.github/workflows/mac-test.yml
@@ -18,8 +18,8 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - run: |
         brew install fftw openssl
-        pip install --upgrade pip setuptools tox
+        pip install --upgrade pip setuptools tox<4.0.0
     - name: run basic pycbc test suite
       run: |
         sudo chmod -R 777 /usr/local/miniconda/
-        tox py-unittest
+        tox -e py-unittest

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ pip install pycbc
 
 To test the code on your machine
 ```
-pip install pytest tox<4.0.0
+pip install pytest "tox<4.0.0"
 tox
 ```
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ pip install pycbc
 
 To test the code on your machine
 ```
-pip install pytest tox
+pip install pytest tox<4.0.0
 tox
 ```
 


### PR DESCRIPTION
The new tox 4.0.0 release has broken the unittests. Looks like tox_conda and tox 4.0.0 are not playing nicely together. I think what we have *should* work with the new tox, but it might take a bit of time for the dust to settle on the new version. For now I suggest pinning the tox release.

I also fix an issue in the mac tests that causes a genuine failure with the new tox.