### PR TITLE
Communicate p_terr to snr opt event

### DIFF
--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -312,7 +312,8 @@ class LiveEventManager(object):
             hdfp['template_duration'] = \
                 self.bank.table[template_id].template_duration
             hdfp['ifar'] = results['foreground/ifar']
-            hdfp['p_terr'] = results['p_terr']
+            if 'p_terr' in results:
+                hdfp['p_terr'] = results['p_terr']
             if gid is not None:
                 hdfp['gid'] = gid
 

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -312,6 +312,7 @@ class LiveEventManager(object):
             hdfp['template_duration'] = \
                 self.bank.table[template_id].template_duration
             hdfp['ifar'] = results['foreground/ifar']
+            hdfp['p_terr'] = results['p_terr']
             if gid is not None:
                 hdfp['gid'] = gid
 
@@ -438,6 +439,9 @@ class LiveEventManager(object):
                 and self.ifar_upload_threshold < ifar:
             logging.info('Optimizing SNR for coinc above threshold ..')
             live_ifos = [ifo for ifo in sld if 'snr_series' in sld[ifo]]
+            # Tell snr optimized event about p_terr
+            if hasattr(event, 'p_terr'):
+                coinc_results['p_terr'] = event.p_terr
             self.setup_optimize_snr(
                 coinc_results,
                 live_ifos,

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -530,7 +530,7 @@ class LiveEventManager(object):
                 logging.info('Optimizing SNR for single above threshold ..')
                 live_ifos = [ifo for ifo in sld if 'snr_series' in sld[ifo]]
                 # Tell snr optimized event about p_terr
-                if hasattr(event, 'p_terr'):
+                if hasattr(event, 'p_terr') and event.p_terr is not None:
                     single['p_terr'] = event.p_terr
                 self.setup_optimize_snr(
                     single,

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -441,7 +441,7 @@ class LiveEventManager(object):
             logging.info('Optimizing SNR for coinc above threshold ..')
             live_ifos = [ifo for ifo in sld if 'snr_series' in sld[ifo]]
             # Tell snr optimized event about p_terr
-            if hasattr(event, 'p_terr'):
+            if hasattr(event, 'p_terr') and event.p_terr is not None:
                 coinc_results['p_terr'] = event.p_terr
             self.setup_optimize_snr(
                 coinc_results,

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -529,6 +529,9 @@ class LiveEventManager(object):
                     and self.run_snr_optimization:
                 logging.info('Optimizing SNR for single above threshold ..')
                 live_ifos = [ifo for ifo in sld if 'snr_series' in sld[ifo]]
+                # Tell snr optimized event about p_terr
+                if hasattr(event, 'p_terr'):
+                    single['p_terr'] = event.p_terr
                 self.setup_optimize_snr(
                     single,
                     live_ifos,

--- a/bin/pycbc_optimize_snr
+++ b/bin/pycbc_optimize_snr
@@ -482,7 +482,7 @@ kwargs = {'psds': {ifo: skyloc_data[ifo]['psd'] for ifo in ifos},
 
 # Do not recalculate p_terr/p_astro; source probabilities may be recalculated
 if 'p_terr' in fp:
-    kwargs['p_terr'] = fp['p_terr']
+    kwargs['p_terr'] = fp['p_terr'][()]
 
 # Treat all ifos as having triggers
 doc = live.CandidateForGraceDB(

--- a/bin/pycbc_optimize_snr
+++ b/bin/pycbc_optimize_snr
@@ -480,7 +480,8 @@ kwargs = {'psds': {ifo: skyloc_data[ifo]['psd'] for ifo in ifos},
           'channel_names': channel_names,
           'mc_area_args': mc_area_args}
 
-# Do not recalculate p_terr/p_astro; source probabilities may be recalculated
+# Do not recalculate p_terr/p_astro, reuse previous value if available
+# (source probabilities may be recalculated)
 if 'p_terr' in fp:
     kwargs['p_terr'] = fp['p_terr'][()]
 

--- a/bin/pycbc_optimize_snr
+++ b/bin/pycbc_optimize_snr
@@ -480,8 +480,11 @@ kwargs = {'psds': {ifo: skyloc_data[ifo]['psd'] for ifo in ifos},
           'channel_names': channel_names,
           'mc_area_args': mc_area_args}
 
+# Do not recalculate p_terr/p_astro; source probabilities may be recalculated
+if 'p_terr' in fp:
+    kwargs['p_terr'] = fp['p_terr']
+
 # Treat all ifos as having triggers
-# Do not recalculate p_astro
 doc = live.CandidateForGraceDB(
     ifos,
     ifos,

--- a/pycbc/conversions.py
+++ b/pycbc/conversions.py
@@ -1260,8 +1260,8 @@ def get_final_from_initial(mass1, mass2, spin1x=0., spin1y=0., spin1z=0.,
     final_mass = numpy.full(mass1.shape, numpy.nan)
     final_spin = numpy.full(mass1.shape, numpy.nan)
     for ii in range(final_mass.size):
-        m1 = numpy.float(mass1[ii])
-        m2 = numpy.float(mass2[ii])
+        m1 = float(mass1[ii])
+        m2 = float(mass2[ii])
         spin1 = list(map(float, [spin1x[ii], spin1y[ii], spin1z[ii]]))
         spin2 = list(map(float, [spin2x[ii], spin2y[ii], spin2z[ii]]))
         if approximant == 'NRSur7dq4':

--- a/pycbc/io/live.py
+++ b/pycbc/io/live.py
@@ -245,6 +245,8 @@ class CandidateForGraceDB(object):
             horizons = {i: self.psds[i].dist for i in self.et_ifos}
             self.p_astro, self.p_terr = \
                 kwargs['padata'].do_pastro_calc(trigger_data, horizons)
+        elif 'p_terr' in kwargs:
+            self.p_astro, self.p_terr = 1 - kwargs['p_terr'], kwargs['p_terr']
         else:
             self.p_astro, self.p_terr = None, None
 

--- a/pycbc/io/live.py
+++ b/pycbc/io/live.py
@@ -229,6 +229,10 @@ class CandidateForGraceDB(object):
 
         # P astro calculation
         if 'padata' in kwargs:
+            if 'p_terr' in kwargs:
+                raise RuntimeError("Both p_astro calculation data and a "
+                    "previously calculated p_terr value were provided, this "
+                    "doesn't make sense!")
             assert len(coinc_ifos) < 3, \
                 f"p_astro can't handle {coinc_ifos} coinc ifos!"
             trigger_data = {

--- a/pycbc/psd/variation.py
+++ b/pycbc/psd/variation.py
@@ -111,8 +111,8 @@ def calc_filt_psd_variation(strain, segment, short_segment, psd_long_segment,
         fs_dtype = numpy.float64
 
     # Convert start and end times immediately to floats
-    start_time = numpy.float(strain.start_time)
-    end_time = numpy.float(strain.end_time)
+    start_time = float(strain.start_time)
+    end_time = float(strain.end_time)
 
     # Resample the data
     strain = resample_to_delta_t(strain, 1.0 / 2048)


### PR DESCRIPTION
To address #4212 pass the p_terr from CandidateForGraceDB to the snr max setup by treating it as an extra entry in coinc_results. This allows the snr max event to 'remember' p_terr from the initial event