### PR TITLE
Reduce complexity of finding relative binning bins

### DIFF
--- a/pycbc/inference/models/relbin.py
+++ b/pycbc/inference/models/relbin.py
@@ -97,9 +97,19 @@ def setup_bins(f_full, f_lo, f_hi, chi=1.0, eps=0.5, gammas=None):
     # frequency grid points
     fbin = dphi2f(dphi_grid)
     # indices of frequency grid points in the FFT array
-    fbin_ind = numpy.unique(
-        [numpy.argmin(numpy.absolute(f_full - ff)) for ff in fbin]
-    )
+    fbin_ind = numpy.searchsorted(f_full, fbin)
+    for idx_fbin, idx_f_full in enumerate(fbin_ind):
+        if idx_f_full == 0:
+            curr_idx = 0
+        elif idx_f_full == len(f_full):
+            curr_idx = len(f_full) - 1
+        else:
+            if abs(f_full[idx_f_full] - fbin[idx_fbin]) > abs(f_full[idx_f_full-1] - fbin[idx_fbin]):
+                curr_idx = idx_f_full - 1
+            else:
+                curr_idx = idx_f_full
+        fbin_ind[idx_fbin] = curr_idx
+    fbin_ind = numpy.unique(fbin_ind)
     return fbin_ind
 
 

--- a/pycbc/inference/models/relbin.py
+++ b/pycbc/inference/models/relbin.py
@@ -104,7 +104,9 @@ def setup_bins(f_full, f_lo, f_hi, chi=1.0, eps=0.5, gammas=None):
         elif idx_f_full == len(f_full):
             curr_idx = len(f_full) - 1
         else:
-            if abs(f_full[idx_f_full] - fbin[idx_fbin]) > abs(f_full[idx_f_full-1] - fbin[idx_fbin]):
+            abs1 = abs(f_full[idx_f_full] - fbin[idx_fbin])
+            abs2 = abs(f_full[idx_f_full-1] - fbin[idx_fbin])
+            if abs1 > abs2:
                 curr_idx = idx_f_full - 1
             else:
                 curr_idx = idx_f_full


### PR DESCRIPTION
For LISA operations we are trying to run relative binning with a small value of the `epsilon` parameter, to ensure high accuracy. This results in the code taking *forever* (hours) to get going, so while I was waiting my hour I thought I'd profile the code, and all the time was spent in one location (the one revamped by this patch).

The complexity of the old code is O(M * N) where M is the length of the input waveform, and M is the number of bins you want to keep according to the code above. The new code is (I think) roughly O(M+N) (not 100% sure what searchsorted does, but I assume it's just a running search through M and N). I did test for some example inputs that the output of the function is identical, and it is, I'm also running a larger test now.

I do suspect there's a nicer numpy way of swapping searchsorted, to "find nearest point in array", but I didn't find it after googling and stackoverflowing. I don't think that would affect runtime at this stage though, just might look neater!