### PR TITLE
Adding script for plotting histograms of triggers near gates

### DIFF
--- a/bin/plotting/pycbc_plot_gate_triggers
+++ b/bin/plotting/pycbc_plot_gate_triggers
@@ -126,7 +126,7 @@ for single_file in args.single_trigger_files:
         if args.template_duration:
             if args.duration_ltgt == 'LT':
                 snr_val = snr_val[template_duration <= args.duration_cut]
-            else args.duration_ltgt == 'GT':
+            else:
                 snr_val = snr_val[template_duration >= args.duration_cut]
 
     logging.info("Starting loop over gates...")

--- a/bin/plotting/pycbc_plot_gate_triggers
+++ b/bin/plotting/pycbc_plot_gate_triggers
@@ -30,7 +30,7 @@ parser.add_argument('--verbose', action='store_true')
 parser.add_argument('--single-trigger-files', nargs='+',
                     help='HDF format single detector merged trigger file(s) path. '
                          'All triggers are combined in the histogram')
-parser.add_argument('--ifo-label', default='',
+parser.add_argument('--ifo-tag', default='',
                     help='String to label plots, eg H1, H1L1')
 parser.add_argument('--gating-type', choices=['auto', 'detchar'],
                     help='Type of gate to analyze.')

--- a/bin/plotting/pycbc_plot_gate_triggers
+++ b/bin/plotting/pycbc_plot_gate_triggers
@@ -24,19 +24,14 @@ from pycbc.events import ranking
 from matplotlib import use; use('Agg')
 import matplotlib.pyplot as plt
 
-def split_in_ifos(list, ifos):
-    """Function to split files in arrays depending on ifo.
-       Warning: relies on the name of the files to start by IFO.
-    """
-    split_list = [list[[j.split('/')[-1].startswith(ifo) for j in list]]
-                  for ifo in ifos]
-    return [list for list in split_list if len(list) > 0]
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--verbose', action='store_true')
-parser.add_argument('--single-trigger-files', nargs='+', type=str,
+parser.add_argument('--single-trigger-files', nargs='+',
                     help='HDF format single detector merged trigger file(s) path. '
-                         'A histogram is plotted for each ifo trigger file(s).')
+                         'All triggers are combined in the histogram')
+parser.add_argument('--ifo-label', default='',
+                    help='String to label plots, eg H1, H1L1')
 parser.add_argument('--gating-type', choices=['auto', 'detchar'],
                     help='Type of gate to analyze.')
 parser.add_argument('--window', default=5, type=float,
@@ -72,9 +67,6 @@ if args.gating_type:
 else:
     raise ValueError('A gating type argument must be provided.')
 
-ifos = ['H1', 'L1', 'V1']
-ifo_trigger_files = split_in_ifos(numpy.array(args.single_trigger_files), ifos)
-
 if args.snr_cut_type:
     if args.snr_cut_vals:
         snr_cut_vals = sorted(args.snr_cut_vals)
@@ -83,24 +75,28 @@ if args.snr_cut_type:
 else:
     snr_cut_vals = numpy.array([0])
 
+if args.template_duration:
+    args.duration_ltgt = args.template_duration[0]
+    assert args.duration_ltgt in ['LT', 'GT']
+    args.duration_cut = float(args.template_duration[1])
+
 # Binning along trigger time
 nbins = int(2 * args.window / args.bin_duration + 1)
 
-for ifo_files in ifo_trigger_files:
-    ifo_trigger_times = [[] for thr in snr_cut_vals]
-    n_gates = 0
-    for single_file in ifo_files:
-        logging.info("Reading trigger file %s...", single_file.split('/')[-1])
-        file_ = h5py.File(single_file, "r")
-        ifo = str(list(file_.keys())[0])
-        data = file_[ifo]
+ifo_trigger_times = [[] for thr in snr_cut_vals]
+n_gates = 0
 
-        if gating_type in data['gating'].keys():
-            logging.info("Extracting gated times...")
-            gate_time = numpy.unique(data[f'gating/{gating_type}/time'][:])
-            gate_number = len(gate_time)
-            n_gates += gate_number
-            logging.info("%i %s gates found" % (gate_number, args.gating_type))
+for single_file in args.single_trigger_files:
+    logging.info("Reading trigger file %s...", single_file.split('/')[-1])
+    file_ = h5py.File(single_file, "r")
+    ifo = str(list(file_.keys())[0])
+    data = file_[ifo]
+
+    if gating_type in data['gating'].keys():
+        logging.info("Extracting gated times...")
+        gate_time = numpy.unique(data[f'gating/{gating_type}/time'][:])
+        n_gates += len(gate_time)
+        logging.info("%i %s gates found", len(gate_time), args.gating_type)
         else:
             logging.info('Trigger file does not contain %s gates. '
                          'Skipping file...', args.gating_type)
@@ -110,13 +106,11 @@ for ifo_files in ifo_trigger_files:
 
         if args.template_duration:
             logging.info("Cutting on template duration...")
-            template_cut_type = args.template_duration[0]
-            template_cut_value = float(args.template_duration[1])
             template_duration = data['template_duration'][:]
-            if template_cut_type == 'LT':
-                times = times[template_duration <= template_cut_value]
-            elif template_cut_type == 'GT':
-                times = times[template_duration >= template_cut_value]
+            if args.duration_ltgt == 'LT':
+                times = times[template_duration <= args.duration_cut]
+            elif args.duration_ltgt == 'GT':
+                times = times[template_duration >= args.duration_cut]
 
         if args.snr_cut_type:
             logging.info("Cutting on %s...", args.snr_cut_type)
@@ -124,86 +118,90 @@ for ifo_files in ifo_trigger_files:
                 snr_val = data['snr'][:]
             if args.snr_cut_type == 'newsnr':
                 rchisq = data['chisq'][:] / (2 * data['chisq_dof'][:] - 2)
-                if len(rchisq) > 0:  # Not sure why this check is done only here, not for plain SNR cut
+                if len(rchisq) > 0:
                     snr_val = ranking.newsnr(data['snr'][:], rchisq)
                 else:
                     snr_val = numpy.array([])
                 del rchisq
             if args.template_duration:
-                if template_cut_type == 'LT':
-                    snr_val = snr_val[template_duration <= template_cut_value]
-                elif template_cut_type == 'GT':
-                    snr_val = snr_val[template_duration >= template_cut_value]
+                if args.duration_ltgt == 'LT':
+                    snr_val = snr_val[template_duration <= args.duration_cut]
+                elif args.duration_ltgt == 'GT':
+                    snr_val = snr_val[template_duration >= args.duration_cut]
 
-        time_triggers = [[] for thr in snr_cut_vals]
-
-        logging.info("Starting loop over gates...")
-        for i, thr in enumerate(snr_cut_vals):
-            if args.snr_cut_type:
-                times = times[snr_val >= thr]
-                snr_val = snr_val[snr_val >= thr]
-            for gt in gate_time:
-                idx = numpy.logical_and(times < gt + args.window,
-                                        times > gt - args.window)
-                time_trigger = times[idx] - gt
-                time_triggers[i].extend(time_trigger)
-            ifo_trigger_times[i].extend(time_triggers[i])
-
-        file_.close()
-
-    if args.output_file:
-        out_name = args.output_file
-    else:
-        window_name = (str("{:.1f}".format(args.window)).replace('.', '-') if '.' in
-                       str(args.window) else str(args.window))
-        out_name = '%s_%s' % (str(args.gating_type).upper(), ifo)
-        if args.template_duration:
-            templ_cut_name = (str("{:.1f}".format(template_cut_value)).replace('.', '-')
-                              if '.' in args.template_duration[1] else
-                              args.template_duration[1])
-            out_name = '_'.join([out_name, 'TD-%s-%s' %
-                                 (template_cut_type, templ_cut_name)])
+    logging.info("Starting loop over gates...")
+    time_triggers = [[] for thr in snr_cut_vals]
+    for i, thr in enumerate(snr_cut_vals):
         if args.snr_cut_type:
-            snr_cut_name = (args.snr_cut_type).upper()
-            snr_cuts = [str("{:.1f}".format(cut_val)).replace('.', '-')
-                        if '.' in str(cut_val) else str(cut_val) for cut_val in
-                        snr_cut_vals]
+            times = times[snr_val >= thr]
+            snr_val = snr_val[snr_val >= thr]
+        for gt in gate_time:
+            idx = numpy.logical_and(times < gt + args.window, times > gt - args.window)
+            time_trigger = times[idx] - gt
+            time_triggers[i].extend(time_trigger)
+        ifo_trigger_times[i].extend(time_triggers[i])
+
+    file_.close()
+
+if args.output_file:
+    out_name = args.output_file
+else:
+    window_name = (str("{:.1f}".format(args.window)).replace('.', '-') if '.' in
+                   str(args.window) else str(args.window))
+    out_name = '%s_%s' % (str(args.gating_type).upper(), args.ifo_tag)
+    if args.template_duration:
+        templ_cut_name = (
+            str("{:.1f}".format(args.duration_cut)).replace('.', '-') 
+                if '.' in args.template_duration[1]
+                else args.template_duration[1]
+        )
+        out_name = '_'.join([out_name, 'TD-%s-%s' % (args.duration_ltgt, templ_cut_name)])
+
+    if args.snr_cut_type:
+        snr_cut_name = (args.snr_cut_type).upper()
+        snr_cuts = [
+            str("{:.1f}".format(cut_val)).replace('.', '-') if '.' in str(cut_val)
+            else str(cut_val) for cut_val in snr_cut_vals
+        ]
             snr_cut_value = '_'.join(snr_cuts)
             out_name = '_'.join([out_name, '%s-%s' % (snr_cut_name, snr_cut_value)])
         out_name = '_'.join([out_name, 'WINDOW-%s' % window_name])
         if args.log_y:
             out_name = '_'.join([out_name, 'LOG'])
+    out_name = out_name + '.png'
 
-    if n_gates > 0:
-        for i, thr in enumerate(snr_cut_vals):
-            plt.hist(ifo_trigger_times[i],
-                     bins=numpy.linspace(-args.window, args.window, nbins),
-                     label=['%s > %.1f' % (args.snr_cut_type, thr) if args.snr_cut_type
-                            else '']
-            )
-        if args.log_y:
-            plt.yscale('log')
-        plt.grid(True)
-        plt.xlabel('Time relative to the gate (s)')
-        plt.ylabel('Number of triggers')
-        plt.title('%s - %i %s GATES %s'
-                  '%s' % (str(ifo), n_gates, str(args.gating_type).upper(),
-                          'IN %i CHUNKS' % len(ifo_files) if len(ifo_files) > 1 else '',
-                          '\n Triggers with template duration %s %s s'
-                          % ('<' if template_cut_type == 'LT' else '>',
-                             str(template_cut_value)) if args.template_duration else ''))
-        if args.snr_cut_type:
-            plt.legend()
+if n_gates > 0:
+    for i, thr in enumerate(snr_cut_vals):
+        plt.hist(
+            ifo_trigger_times[i],
+            bins=numpy.linspace(-args.window, args.window, nbins),
+            label=['%s > %.1f' % (args.snr_cut_type, thr) if args.snr_cut_type else '']
+        )
+    if args.log_y:
+        plt.yscale('log')
+    plt.grid(True)
+    plt.xlabel('Time relative to gate centre (s)')
+    plt.ylabel('Number of triggers')
+    plt.title(  # Complicated recipe
+         '%s - %i %s GATES %s %s' % 
+         (args.ifo_tag, n_gates, str(args.gating_type).upper(),
+          'IN %i CHUNKS' % len(ifo_files) if len(ifo_files) > 1 else '',
+          '\n Triggers with template duration %s %s s' % 
+          ('<' if args.duration_ltgt == 'LT' else '>', str(args.duration_cut))
+          if args.template_duration else '')
+    )
+    if args.snr_cut_type:
+        plt.legend()
 
-    else:  # Nothing to plot, make an empty figure
-        fig = plt.figure()
-        ax = fig.add_subplot(111)
-        output_message = "Sorry, no gates to plot!"
-        ax.text(0.5, 0.5, output_message, horizontalalignment='center',
-                verticalalignment='center')
+else:  # Nothing to plot, make an empty figure
+    fig = plt.figure()
+    ax = fig.add_subplot(111)
+    output_message = "Sorry, no gates to plot!"
+    ax.text(0.5, 0.5, output_message, horizontalalignment='center',
+            verticalalignment='center')
 
-    logging.info('Saving histogram for gates in %s...', ifo)
-    plt.savefig(out_name + '.png')
-    plt.close()
+logging.info('Saving histogram...')
+plt.savefig(out_name)
+plt.close()
 
 logging.info("Done")

--- a/bin/plotting/pycbc_plot_gate_triggers
+++ b/bin/plotting/pycbc_plot_gate_triggers
@@ -1,0 +1,201 @@
+#!/usr/bin/python
+
+# Copyright (C) 2023 Veronica Villa-Ortega
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
+
+"""
+Plot histograms of triggers around gated times.
+"""
+
+import os
+import h5py
+import numpy
+import random
+import logging
+import argparse
+from pycbc.events import ranking
+from matplotlib import use; use('Agg')
+import matplotlib.pyplot as plt
+
+def split_in_ifos(list, ifos):
+    """Function to split files in arrays depending on ifo.
+       Warning: relies on the name of the files to start by IFO.
+    """
+    split_list = [list[[j.split('/')[-1].startswith(ifo) for j in list]]
+                  for ifo in ifos]
+    return [list for list in split_list if len(list) > 0]
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--verbose', action='store_true')
+parser.add_argument('--single-trigger-files', nargs='+', type=str,
+                    help='HDF format single detector merged trigger file(s) path. '
+                         'A histogram is plotted for each ifo trigger file(s).')
+parser.add_argument('--gating-type', choices=['auto', 'detchar'],
+                    help='Type of gate to analyze.')
+parser.add_argument('--window', default=5, type=float,
+                    help='Time in seconds around the gate to plot (def=5s).')
+parser.add_argument('--snr-cut-type', choices=['snr', 'newsnr'],
+                    help='Type of snr cut.')
+parser.add_argument('--snr-cut-vals', nargs='+', type=float,
+                    help='Lowest snr/newsnr value(s) to be plotted.')
+parser.add_argument('--template-duration', nargs='+',
+                    help='Triggers with a template duration greater than '
+                         '(GT) or less than (LT) some time value in seconds. '
+                         '(use: --template-duration GT/LT time value)')
+parser.add_argument('--bin-duration', type=float, default=0.25,
+                    help='Time in seconds represented by each bin in the histogram. '
+                          'Default: 0.25s')
+parser.add_argument('--log-y', action='store_true',
+                    help='Set y-axis in logaritmic scale.')
+parser.add_argument('--output-file',
+                    help='Name of the file to save plot (optional).')
+args = parser.parse_args()
+
+if args.verbose:
+    log_level = logging.INFO
+else:
+    log_level = logging.WARN
+logging.basicConfig(format='%(asctime)s : %(message)s', level=log_level)
+
+if args.gating_type:
+    if args.gating_type == 'auto':
+        gating_type = 'auto'
+    elif args.gating_type == 'detchar':
+        gating_type = 'file'
+else:
+    raise ValueError('A gating type argument must be provided.')
+
+ifos = ['H1', 'L1', 'V1']
+ifo_trigger_files = split_in_ifos(numpy.array(args.single_trigger_files), ifos)
+
+nbins = int((2 * args.window * (1 / args.bin_duration)) + 1)
+
+if args.snr_cut_type:
+    if args.snr_cut_vals:
+        snr_cut_vals = sorted(args.snr_cut_vals)
+    else:
+        raise ValueError('At least one value must be provided.')
+else:
+    snr_cut_vals = numpy.array([0])
+
+for ifo_files in ifo_trigger_files:
+    ifo_trigger_times = [[] for i in range(len(snr_cut_vals))]
+    n_gates = 0
+    for single_file in ifo_files:
+        logging.info("Reading trigger file %s..." % single_file.split('/')[-1])
+        file_ = h5py.File(single_file,"r")
+        ifo = str(list(file_.keys())[0])
+        data = file_[ifo]
+
+        if gating_type in data['gating/'].keys():
+            logging.info("Extracting gated times...")
+            gate_time = numpy.unique(data['gating/' + gating_type + '/time'][:])
+            gate_number = len(gate_time)
+            n_gates += gate_number
+            logging.info("%i %s gates found" % (gate_number, args.gating_type))
+        else:
+            logging.info('Trigger file does not contain %s gates. '
+                     'Skipping file...' % args.gating_type)
+            continue
+        logging.info("Extracting trigger times...")
+        times = data['end_time'][:]
+
+        if args.template_duration:
+            logging.info("Cutting on template duration...")
+            template_cut_type = args.template_duration[0]
+            template_cut_value = float(args.template_duration[1])
+            template_duration = data['template_duration'][:]
+            if template_cut_type == 'LT':
+                times = times[template_duration<=template_cut_value]
+            elif template_cut_type == 'GT':
+                times = times[template_duration>=template_cut_value]
+
+        if args.snr_cut_type:
+            logging.info("Cutting on SNR...")
+            if args.snr_cut_type == 'snr':
+                snr_val = data['snr'][:]
+            if args.snr_cut_type == 'newsnr':
+                rchisq = data['chisq'][:] / (2 * data['chisq_dof'][:] - 2)
+                if len(rchisq) > 0:
+                    snr_val = ranking.newsnr(data['snr'][:], rchisq)
+                else:
+                    snr_val = numpy.array([])
+                del rchisq
+            if args.template_duration:
+                if template_cut_type == 'LT':
+                    snr_val = snr_val[template_duration<=template_cut_value]
+                elif template_cut_type == 'GT':
+                    snr_val = snr_val[template_duration>=template_cut_value]
+
+        time_triggers = [[] for i in range(len(snr_cut_vals))]
+
+        logging.info("Starting loop over gates...")
+        for i in range(len(snr_cut_vals)):
+            if args.snr_cut_type:
+                times = times[snr_val>=snr_cut_vals[i]]
+                snr_val = snr_val[snr_val>=snr_cut_vals[i]]
+            for j in range(0, len(gate_time)):
+                idx = numpy.logical_and(times < gate_time[j] + args.window,
+                                        times > gate_time[j] - args.window)
+                time_trigger = times[idx] - gate_time[j]
+                time_triggers[i].extend(time_trigger)
+            ifo_trigger_times[i].extend(time_triggers[i])
+    if n_gates > 0:
+        for i in range(len(snr_cut_vals)):
+            plt.hist(ifo_trigger_times[i], bins=numpy.linspace(-args.window, args.window, nbins),
+                     label=['%s > %.1f' % (args.snr_cut_type, snr_cut_vals[i])
+                                           if args.snr_cut_type else ''])
+        if args.log_y:
+           plt.yscale('log')
+
+        plt.xlabel('Time relative to the gate (s)')
+        plt.ylabel('Number of triggers')
+        plt.title('%s - %i %s GATES %s'
+                  '%s' % (str(ifo), n_gates, str(args.gating_type).upper(),
+                          'IN %i CHUNKS' % len(ifo_files) if len(ifo_files) > 1 else '',
+                          '\n Triggers with template duration %s %s s'
+                          % ('<' if template_cut_type == 'LT' else '>',
+                             str(template_cut_value)) if args.template_duration else ''))
+        if args.snr_cut_type:
+            plt.legend()
+
+        logging.info('Saving histogram for gates in %s...' % ifo)
+        if args.output_file:
+            out_name = args.output_file
+        else:
+            window_name = (str("{:.1f}".format(args.window)).replace('.', '-') if '.' in
+                          str(args.window) else str(args.window))
+            out_name = '%s_%s' % (str(args.gating_type).upper(), ifo)
+            if args.template_duration:
+                templ_cut_name = (str("{:.1f}".format(template_cut_value)).replace('.', '-')
+                                 if '.' in args.template_duration[1] else
+                                 args.template_duration[1])
+                out_name = '_'.join([out_name, 'TD-%s-%s' % (template_cut_type,
+                                                             templ_cut_name)])
+            if args.snr_cut_type:
+                snr_cut_name = (args.snr_cut_type).upper()
+                snr_cuts = [str("{:.1f}".format(cut_val)).replace('.', '-')
+                            if '.' in str(cut_val) else str(cut_val) for cut_val in
+                            snr_cut_vals]
+                snr_cut_value = '_'.join(snr_cuts)
+                out_name = '_'.join([out_name, '%s-%s' % (snr_cut_name, snr_cut_value)])
+            out_name = '_'.join([out_name, 'WINDOW-%s' % window_name])
+            if args.log_y:
+                out_name = '_'.join([out_name, 'LOG'])
+        plt.savefig(out_name + '.png')
+        plt.close()
+
+logging.info("Done")

--- a/bin/plotting/pycbc_plot_gate_triggers
+++ b/bin/plotting/pycbc_plot_gate_triggers
@@ -184,7 +184,7 @@ for ifo_files in ifo_trigger_files:
                             else '']
             )
         if args.log_y:
-           plt.yscale('log')
+            plt.yscale('log')
         plt.grid(True)
         plt.xlabel('Time relative to the gate (s)')
         plt.ylabel('Number of triggers')

--- a/bin/plotting/pycbc_plot_gate_triggers
+++ b/bin/plotting/pycbc_plot_gate_triggers
@@ -185,7 +185,8 @@ if n_gates > 0:
     plt.title(  # Complicated recipe
          '%s - %i %s GATES %s %s' % 
          (args.ifo_tag, n_gates, str(args.gating_type).upper(),
-          'IN %i CHUNKS' % len(ifo_files) if len(ifo_files) > 1 else '',
+          'IN %i CHUNKS' % len(args.single_trigger_files) if \
+          len(args.single_trigger_files) > 1 else '',
           '\n Triggers with template duration %s %s s' % 
           ('<' if args.duration_ltgt == 'LT' else '>', str(args.duration_cut))
           if args.template_duration else '')

--- a/bin/plotting/pycbc_plot_gate_triggers
+++ b/bin/plotting/pycbc_plot_gate_triggers
@@ -16,10 +16,8 @@
 Plot histograms of triggers around gated times.
 """
 
-import os
 import h5py
 import numpy
-import random
 import logging
 import argparse
 from pycbc.events import ranking

--- a/bin/plotting/pycbc_plot_gate_triggers
+++ b/bin/plotting/pycbc_plot_gate_triggers
@@ -11,10 +11,6 @@
 # WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
 # Public License for more details.
-#
-# You should have received a copy of the GNU General Public License along
-# with this program; if not, write to the Free Software Foundation, Inc.,
-# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 
 """
 Plot histograms of triggers around gated times.
@@ -46,22 +42,22 @@ parser.add_argument('--single-trigger-files', nargs='+', type=str,
 parser.add_argument('--gating-type', choices=['auto', 'detchar'],
                     help='Type of gate to analyze.')
 parser.add_argument('--window', default=5, type=float,
-                    help='Time in seconds around the gate to plot (def=5s).')
+                    help='Time in seconds around the gate to plot (default 5s).')
 parser.add_argument('--snr-cut-type', choices=['snr', 'newsnr'],
-                    help='Type of snr cut.')
+                    help='Type of snr threshold to apply.')
 parser.add_argument('--snr-cut-vals', nargs='+', type=float,
-                    help='Lowest snr/newsnr value(s) to be plotted.')
+                    help='Threshold snr/newsnr value(s) for histogram(s).')
 parser.add_argument('--template-duration', nargs='+',
                     help='Triggers with a template duration greater than '
                          '(GT) or less than (LT) some time value in seconds. '
-                         '(use: --template-duration GT/LT time value)')
+                         'Usage: --template-duration GT/LT time value')
 parser.add_argument('--bin-duration', type=float, default=0.25,
-                    help='Time in seconds represented by each bin in the histogram. '
-                          'Default: 0.25s')
+                    help='Time in seconds represented by each bin in the histogram '
+                          '(default 0.25s).')
 parser.add_argument('--log-y', action='store_true',
-                    help='Set y-axis in logaritmic scale.')
+                    help='Set y-axis scale logarithmic.')
 parser.add_argument('--output-file',
-                    help='Name of the file to save plot (optional).')
+                    help='Plot file name (optional).')
 args = parser.parse_args()
 
 if args.verbose:
@@ -81,34 +77,35 @@ else:
 ifos = ['H1', 'L1', 'V1']
 ifo_trigger_files = split_in_ifos(numpy.array(args.single_trigger_files), ifos)
 
-nbins = int((2 * args.window * (1 / args.bin_duration)) + 1)
-
 if args.snr_cut_type:
     if args.snr_cut_vals:
         snr_cut_vals = sorted(args.snr_cut_vals)
     else:
-        raise ValueError('At least one value must be provided.')
+        raise ValueError('At least one SNR cut value must be provided!')
 else:
     snr_cut_vals = numpy.array([0])
 
+# Binning along trigger time
+nbins = int((2 * args.window / args.bin_duration)) + 1)
+
 for ifo_files in ifo_trigger_files:
-    ifo_trigger_times = [[] for i in range(len(snr_cut_vals))]
+    ifo_trigger_times = [[] for thr in snr_cut_vals]
     n_gates = 0
     for single_file in ifo_files:
-        logging.info("Reading trigger file %s..." % single_file.split('/')[-1])
-        file_ = h5py.File(single_file,"r")
+        logging.info("Reading trigger file %s...", single_file.split('/')[-1])
+        file_ = h5py.File(single_file, "r")
         ifo = str(list(file_.keys())[0])
         data = file_[ifo]
 
-        if gating_type in data['gating/'].keys():
+        if gating_type in data['gating'].keys():
             logging.info("Extracting gated times...")
-            gate_time = numpy.unique(data['gating/' + gating_type + '/time'][:])
+            gate_time = numpy.unique(data[f'gating/{gating_type}/time'][:])
             gate_number = len(gate_time)
             n_gates += gate_number
             logging.info("%i %s gates found" % (gate_number, args.gating_type))
         else:
             logging.info('Trigger file does not contain %s gates. '
-                     'Skipping file...' % args.gating_type)
+                         'Skipping file...', args.gating_type)
             continue
         logging.info("Extracting trigger times...")
         times = data['end_time'][:]
@@ -119,48 +116,76 @@ for ifo_files in ifo_trigger_files:
             template_cut_value = float(args.template_duration[1])
             template_duration = data['template_duration'][:]
             if template_cut_type == 'LT':
-                times = times[template_duration<=template_cut_value]
+                times = times[template_duration <= template_cut_value]
             elif template_cut_type == 'GT':
-                times = times[template_duration>=template_cut_value]
+                times = times[template_duration >= template_cut_value]
 
         if args.snr_cut_type:
-            logging.info("Cutting on SNR...")
+            logging.info("Cutting on %s...", args.snr_cut_type)
             if args.snr_cut_type == 'snr':
                 snr_val = data['snr'][:]
             if args.snr_cut_type == 'newsnr':
                 rchisq = data['chisq'][:] / (2 * data['chisq_dof'][:] - 2)
-                if len(rchisq) > 0:
+                if len(rchisq) > 0:  # Not sure why this check is done only here, not for plain SNR cut
                     snr_val = ranking.newsnr(data['snr'][:], rchisq)
                 else:
                     snr_val = numpy.array([])
                 del rchisq
             if args.template_duration:
                 if template_cut_type == 'LT':
-                    snr_val = snr_val[template_duration<=template_cut_value]
+                    snr_val = snr_val[template_duration <= template_cut_value]
                 elif template_cut_type == 'GT':
-                    snr_val = snr_val[template_duration>=template_cut_value]
+                    snr_val = snr_val[template_duration >= template_cut_value]
 
-        time_triggers = [[] for i in range(len(snr_cut_vals))]
+        time_triggers = [[] for thr in snr_cut_vals]
 
         logging.info("Starting loop over gates...")
-        for i in range(len(snr_cut_vals)):
+        for i, thr in enumerate(snr_cut_vals):
             if args.snr_cut_type:
-                times = times[snr_val>=snr_cut_vals[i]]
-                snr_val = snr_val[snr_val>=snr_cut_vals[i]]
-            for j in range(0, len(gate_time)):
-                idx = numpy.logical_and(times < gate_time[j] + args.window,
-                                        times > gate_time[j] - args.window)
-                time_trigger = times[idx] - gate_time[j]
+                times = times[snr_val >= thr]
+                snr_val = snr_val[snr_val >= thr]
+            for gt in gate_time:
+                idx = numpy.logical_and(times < gt + args.window,
+                                        times > gt - args.window)
+                time_trigger = times[idx] - gt
                 time_triggers[i].extend(time_trigger)
             ifo_trigger_times[i].extend(time_triggers[i])
+
+        file_.close()
+
+    if args.output_file:
+        out_name = args.output_file
+    else:
+        window_name = (str("{:.1f}".format(args.window)).replace('.', '-') if '.' in
+                       str(args.window) else str(args.window))
+        out_name = '%s_%s' % (str(args.gating_type).upper(), ifo)
+        if args.template_duration:
+            templ_cut_name = (str("{:.1f}".format(template_cut_value)).replace('.', '-')
+                              if '.' in args.template_duration[1] else
+                              args.template_duration[1])
+            out_name = '_'.join([out_name, 'TD-%s-%s' %
+                                 (template_cut_type, templ_cut_name)])
+        if args.snr_cut_type:
+            snr_cut_name = (args.snr_cut_type).upper()
+            snr_cuts = [str("{:.1f}".format(cut_val)).replace('.', '-')
+                        if '.' in str(cut_val) else str(cut_val) for cut_val in
+                        snr_cut_vals]
+            snr_cut_value = '_'.join(snr_cuts)
+            out_name = '_'.join([out_name, '%s-%s' % (snr_cut_name, snr_cut_value)])
+        out_name = '_'.join([out_name, 'WINDOW-%s' % window_name])
+        if args.log_y:
+            out_name = '_'.join([out_name, 'LOG'])
+
     if n_gates > 0:
-        for i in range(len(snr_cut_vals)):
-            plt.hist(ifo_trigger_times[i], bins=numpy.linspace(-args.window, args.window, nbins),
-                     label=['%s > %.1f' % (args.snr_cut_type, snr_cut_vals[i])
-                                           if args.snr_cut_type else ''])
+        for i, thr in enumerate(snr_cut_vals):
+            plt.hist(ifo_trigger_times[i],
+                     bins=numpy.linspace(-args.window, args.window, nbins),
+                     label=['%s > %.1f' % (args.snr_cut_type, thr) if args.snr_cut_type
+                            else '']
+            )
         if args.log_y:
            plt.yscale('log')
-
+        plt.grid(True)
         plt.xlabel('Time relative to the gate (s)')
         plt.ylabel('Number of triggers')
         plt.title('%s - %i %s GATES %s'
@@ -172,30 +197,15 @@ for ifo_files in ifo_trigger_files:
         if args.snr_cut_type:
             plt.legend()
 
-        logging.info('Saving histogram for gates in %s...' % ifo)
-        if args.output_file:
-            out_name = args.output_file
-        else:
-            window_name = (str("{:.1f}".format(args.window)).replace('.', '-') if '.' in
-                          str(args.window) else str(args.window))
-            out_name = '%s_%s' % (str(args.gating_type).upper(), ifo)
-            if args.template_duration:
-                templ_cut_name = (str("{:.1f}".format(template_cut_value)).replace('.', '-')
-                                 if '.' in args.template_duration[1] else
-                                 args.template_duration[1])
-                out_name = '_'.join([out_name, 'TD-%s-%s' % (template_cut_type,
-                                                             templ_cut_name)])
-            if args.snr_cut_type:
-                snr_cut_name = (args.snr_cut_type).upper()
-                snr_cuts = [str("{:.1f}".format(cut_val)).replace('.', '-')
-                            if '.' in str(cut_val) else str(cut_val) for cut_val in
-                            snr_cut_vals]
-                snr_cut_value = '_'.join(snr_cuts)
-                out_name = '_'.join([out_name, '%s-%s' % (snr_cut_name, snr_cut_value)])
-            out_name = '_'.join([out_name, 'WINDOW-%s' % window_name])
-            if args.log_y:
-                out_name = '_'.join([out_name, 'LOG'])
-        plt.savefig(out_name + '.png')
-        plt.close()
+    else:  # Nothing to plot, make an empty figure
+        fig = plt.figure()
+        ax = fig.add_subplot(111)
+        output_message = "Sorry, no gates to plot!"
+        ax.text(0.5, 0.5, output_message, horizontalalignment='center',
+                verticalalignment='center')
+
+    logging.info('Saving histogram for gates in %s...', ifo)
+    plt.savefig(out_name + '.png')
+    plt.close()
 
 logging.info("Done")

--- a/bin/plotting/pycbc_plot_gate_triggers
+++ b/bin/plotting/pycbc_plot_gate_triggers
@@ -146,9 +146,8 @@ for single_file in args.single_trigger_files:
 if args.output_file:
     out_name = args.output_file
 else:
-    window_name = (str("{:.1f}".format(args.window)).replace('.', '-') if '.' in
-                   str(args.window) else str(args.window))
     out_name = '%s_%s' % (str(args.gating_type).upper(), args.ifo_tag)
+
     if args.template_duration:
         templ_cut_name = (
             str("{:.1f}".format(args.duration_cut)).replace('.', '-') 
@@ -163,12 +162,17 @@ else:
             str("{:.1f}".format(cut_val)).replace('.', '-') if '.' in str(cut_val)
             else str(cut_val) for cut_val in snr_cut_vals
         ]
-            snr_cut_value = '_'.join(snr_cuts)
-            out_name = '_'.join([out_name, '%s-%s' % (snr_cut_name, snr_cut_value)])
-        out_name = '_'.join([out_name, 'WINDOW-%s' % window_name])
-        if args.log_y:
-            out_name = '_'.join([out_name, 'LOG'])
-    out_name = out_name + '.png'
+        snr_cut_value = '_'.join(snr_cuts)
+        out_name = '_'.join([out_name, '%s-%s' % (snr_cut_name, snr_cut_value)])
+
+    window_name = (str("{:.1f}".format(args.window)).replace('.', '-') if '.' in
+                   str(args.window) else str(args.window))
+    out_name = '_'.join([out_name, 'WINDOW-%s' % window_name])
+
+    if args.log_y:
+        out_name = '_'.join([out_name, 'LOG'])
+
+    out_name = out_name + '.png'  # Filenames via command line may have any extension
 
 if n_gates > 0:
     for i, thr in enumerate(snr_cut_vals):

--- a/bin/plotting/pycbc_plot_gate_triggers
+++ b/bin/plotting/pycbc_plot_gate_triggers
@@ -97,37 +97,37 @@ for single_file in args.single_trigger_files:
         gate_time = numpy.unique(data[f'gating/{gating_type}/time'][:])
         n_gates += len(gate_time)
         logging.info("%i %s gates found", len(gate_time), args.gating_type)
+    else:
+        logging.info('Trigger file does not contain %s gates. '
+                     'Skipping file...', args.gating_type)
+        continue
+    logging.info("Extracting trigger times...")
+    times = data['end_time'][:]
+
+    if args.template_duration:
+        logging.info("Cutting on template duration...")
+        template_duration = data['template_duration'][:]
+        if args.duration_ltgt == 'LT':
+            times = times[template_duration <= args.duration_cut]
         else:
-            logging.info('Trigger file does not contain %s gates. '
-                         'Skipping file...', args.gating_type)
-            continue
-        logging.info("Extracting trigger times...")
-        times = data['end_time'][:]
+            times = times[template_duration >= args.duration_cut]
 
+    if args.snr_cut_type:
+        logging.info("Cutting on %s...", args.snr_cut_type)
+        if args.snr_cut_type == 'snr':
+            snr_val = data['snr'][:]
+        if args.snr_cut_type == 'newsnr':
+            rchisq = data['chisq'][:] / (2 * data['chisq_dof'][:] - 2)
+            if len(rchisq) > 0:
+                snr_val = ranking.newsnr(data['snr'][:], rchisq)
+            else:
+                snr_val = numpy.array([])
+            del rchisq
         if args.template_duration:
-            logging.info("Cutting on template duration...")
-            template_duration = data['template_duration'][:]
             if args.duration_ltgt == 'LT':
-                times = times[template_duration <= args.duration_cut]
-            elif args.duration_ltgt == 'GT':
-                times = times[template_duration >= args.duration_cut]
-
-        if args.snr_cut_type:
-            logging.info("Cutting on %s...", args.snr_cut_type)
-            if args.snr_cut_type == 'snr':
-                snr_val = data['snr'][:]
-            if args.snr_cut_type == 'newsnr':
-                rchisq = data['chisq'][:] / (2 * data['chisq_dof'][:] - 2)
-                if len(rchisq) > 0:
-                    snr_val = ranking.newsnr(data['snr'][:], rchisq)
-                else:
-                    snr_val = numpy.array([])
-                del rchisq
-            if args.template_duration:
-                if args.duration_ltgt == 'LT':
-                    snr_val = snr_val[template_duration <= args.duration_cut]
-                elif args.duration_ltgt == 'GT':
-                    snr_val = snr_val[template_duration >= args.duration_cut]
+                snr_val = snr_val[template_duration <= args.duration_cut]
+            else args.duration_ltgt == 'GT':
+                snr_val = snr_val[template_duration >= args.duration_cut]
 
     logging.info("Starting loop over gates...")
     time_triggers = [[] for thr in snr_cut_vals]

--- a/bin/plotting/pycbc_plot_gate_triggers
+++ b/bin/plotting/pycbc_plot_gate_triggers
@@ -86,7 +86,7 @@ else:
     snr_cut_vals = numpy.array([0])
 
 # Binning along trigger time
-nbins = int((2 * args.window / args.bin_duration)) + 1)
+nbins = int(2 * args.window / args.bin_duration + 1)
 
 for ifo_files in ifo_trigger_files:
     ifo_trigger_times = [[] for thr in snr_cut_vals]


### PR DESCRIPTION
New things:
- I've added a --bin-duration argument so we can control the ammount of seconds represented by each bin (previously it was hardcoded as nbins=80 for every case).
- Now --snr-cut-type and --snr-cut-vals are two different arguments because I think it's more intuitive (same thing could apply to the --template-duration cut, but I haven't changed it yet)

The major problem I see is that the split_in_ifos function relies on the single trigger files to be named as "IFO-...", but it works at the moment with the existing naming system.
