### PR TITLE
Change invspec default truncation to Hann

### DIFF
--- a/pycbc/psd/estimate.py
+++ b/pycbc/psd/estimate.py
@@ -200,7 +200,7 @@ def welch(timeseries, seg_len=4096, seg_stride=2048, window='hann',
     return FrequencySeries(psd, delta_f=delta_f, dtype=timeseries.dtype,
                            epoch=timeseries.start_time)
 
-def inverse_spectrum_truncation(psd, max_filter_len, low_frequency_cutoff=None, trunc_method=None):
+def inverse_spectrum_truncation(psd, max_filter_len, low_frequency_cutoff=None, trunc_method='hann'):
     """Modify a PSD such that the impulse response associated with its inverse
     square root is no longer than `max_filter_len` time samples. In practice
     this corresponds to a coarse graining or smoothing of the PSD.


### PR DESCRIPTION
`inverse_spectrum_truncation` uses boxcar truncation by default. This works OK in the tutorials because the data isn't very long, but it gives a bad filter when used to whiten longer blocks of data. For instance, when whitening 30 minutes of data the PSD is corrupted and gives a bad SNR timeseries. Hann window would be a more sensible default.

In most places in the code, it seems to use Hann window already. The main place where it's used without is lines 1714 and 1720 of [strain.py](https://github.com/gwastro/pycbc/blob/master/pycbc/strain/strain.py#L1714). I'm not sure if this is intentional. It's also used as default in some tests, but I think they're testing length and not default
