### PR TITLE
Fixed phase space coverage

### DIFF
--- a/bin/bank/pycbc_brute_bank
+++ b/bin/bank/pycbc_brute_bank
@@ -89,6 +89,17 @@ if args.input_config is not None:
 
     dists_joint = prior_from_config(cp=config_parser)
 
+if not args.tau0_end:
+    """
+    If tau0_end is not provided, it is derived and rounded up to the
+    upper tens.
+    This is necessary to cover up all the phase space.  
+    """
+    import math
+    from pycbc.conversions import tau0_from_mass1_mass2
+    args.tau0_end = math.ceil(tau0_from_mass1_mass2(args.min[0], args.min[1],
+                                        args.low_frequency_cutoff) / 10) * 10
+
 fdict = {}
 if args.fixed_params:
     for p, v in zip(args.fixed_params, args.fixed_values):
@@ -187,11 +198,12 @@ class TriangleBank(object):
 
         msig = len(r)
 
-        #Apply tua0 threshold
+        #Apply tau0 threshold
         if args.tau0_threshold:
             hp.tau0 = pycbc.conversions.tau0_from_mass1_mass2(
                                             hp.params['mass1'],
-                                            hp.params['mass2'], 15.0)
+                                            hp.params['mass2'],
+                                            args.low_frequency_cutoff)
             hp.tbin = int(hp.tau0 / args.tau0_threshold)
 
             if hp.tbin in self.tbins:
@@ -400,7 +412,8 @@ def cdraw(rtype, ts, te):
 
     p = draw(rtype)
     if  len(p[list(p.keys())[0]]) > 0:
-        t = tau0_from_mass1_mass2(p['mass1'], p['mass2'], 15.0)
+        t = tau0_from_mass1_mass2(p['mass1'], p['mass2'],
+                                  args.low_frequency_cutoff)
         l = (t < te) & (t > ts)
         for k in p:
             p[k] = p[k][l]
@@ -413,7 +426,8 @@ def cdraw(rtype, ts, te):
             p[k] = numpy.concatenate([p[k], tp[k]])
 
         if  len(p[list(p.keys())[0]]) > 0:
-            t = tau0_from_mass1_mass2(p['mass1'], p['mass2'], 15.0)
+            t = tau0_from_mass1_mass2(p['mass1'], p['mass2'],
+                                      args.low_frequency_cutoff)
             l = (t < te) & (t > ts)
             for k in p:
                 p[k] = p[k][l]

--- a/bin/bank/pycbc_brute_bank
+++ b/bin/bank/pycbc_brute_bank
@@ -63,9 +63,6 @@ parser.add_argument('--max-q', type=float)
 parser.add_argument('--tau0-crawl', type=float)
 parser.add_argument('--tau0-start', type=float)
 parser.add_argument('--tau0-end', type=float)
-parser.add_argument('--NS-threshold', type=float)
-parser.add_argument('--remnant-mass-threshold', type=float)
-parser.add_argument('--eos', type=str)
 pycbc.psd.insert_psd_option_group(parser)
 args = parser.parse_args()
 pycbc.init_logging(args.verbose)
@@ -102,22 +99,11 @@ if not args.tau0_end:
     from pycbc.conversions import tau0_from_mass1_mass2
     args.tau0_end = math.ceil(tau0_from_mass1_mass2(args.min[0], args.min[1],
                                         args.low_frequency_cutoff) / 10) * 10
-if not args.eos:
-    args.eos = '2H'
-
-if args.remnant_mass_threshold:
-    from pycbc.conversions import \
-    remnant_mass_from_mass1_mass2_spherical_spin_eos as remnant_mass
-
-if args.remnant_mass_threshold and not args.NS_threshold:
-    from pycbc.neutron_stars.eos_utils import load_ns_sequence
-    seq, args.NS_threshold = load_ns_sequence(args.eos)
-    del seq
 
 fdict = {}
 if args.fixed_params:
-    fdict = {p: v for (p, v) in zip(args.fixed_params, args.fixed_values)}
-    
+    for p, v in zip(args.fixed_params, args.fixed_values):
+        fdict[p] = v
 
 class Shrinker(object):
     def __init__(self, data):
@@ -131,8 +117,7 @@ class Shrinker(object):
         return l
 
 class TriangleBank(object):
-    """ 
-    A bank of templates that uses the triangle inequality to estimate
+    """ A bank of templates that uses the triangle inequality to estimate
     matches based on prior ones.
     """
     def __init__(self, p=None):
@@ -213,7 +198,7 @@ class TriangleBank(object):
 
         msig = len(r)
 
-        #Apply tua0 threshold
+        #Apply tau0 threshold
         if args.tau0_threshold:
             hp.tau0 = pycbc.conversions.tau0_from_mass1_mass2(
                                             hp.params['mass1'],
@@ -346,18 +331,20 @@ if args.input_file:
 
 
 def draw(rtype):
+    params = {}
 
     if rtype == 'uniform':
         if args.input_config is None:
-            params = {name: numpy.random.uniform(pmin, pmax, size=size) 
-                      for name, pmin, pmax in zip(args.params, args.min, args.max)}
+            for name, pmin, pmax in zip(args.params, args.min, args.max):
+                params[name] = numpy.random.uniform(pmin, pmax, size=size)
         else:
             # `draw_samples_from_config` has its own fixed seed, so must overwrite it.
             random_seed = numpy.random.randint(low=0, high=2**32-1)
             samples = draw_samples_from_config(args.input_config, size, random_seed)
-            params = {name: samples[name] for name in samples.fieldnames}
+            for name in samples.fieldnames:
+                params[name] = samples[name]
             # Add `static_args` back.
-            if static_args is not None: 
+            if static_args is not None:
                 for k in static_args.keys():
                     params[k] = numpy.array([static_args[k]]*size)
 
@@ -374,7 +361,8 @@ def draw(rtype):
 
         kde = gaussian_kde(bdata)
         points = kde.resample(size=size)
-        params = {k: v for k, v in zip(p, points)}
+        for k, v in zip(p, points):
+            params[k] = v
 
         # Add `static_args` back, some transformations may need them.
         if args.input_config is not None and static_args is not None:
@@ -386,13 +374,6 @@ def draw(rtype):
             params = transforms.apply_transforms(params, waveform_transforms)
 
     params['approximant'] = numpy.array([args.approximant]*size)
-    # remnant_mass function needs m1 >= m2, therefore it is necessary to order
-    # the params
-    if args.remnant_mass_threshold:
-        params['mass1'], params['mass2'], 
-        params['spin1z'], params['spin2z'] = numpy.where(params['mass1'] > params['mass2'],
-                    (params['mass1'], params['mass2'], params['spin1z'], params['spin2z']),
-                    (params['mass2'], params['mass1'], params['spin2z'], params['spin1z']))
 
     # Filter out stuff (kde method may also generate samples outside boundaries).
     l = None
@@ -402,8 +383,7 @@ def draw(rtype):
             l = (nl & l) if l is not None else nl
 
         if args.max_q:
-            q =  numpy.maximum(params['mass1'] / params['mass2'], 
-                               params['mass2'] / params['mass1'])
+            q =  numpy.maximum(params['mass1'] / params['mass2'], params['mass2'] / params['mass1'])
             l &= q < args.max_q
 
         if args.max_mtotal:
@@ -418,20 +398,13 @@ def draw(rtype):
             from pycbc.conversions import mchirp_from_mass1_mass2
             mc = mchirp_from_mass1_mass2(params['mass1'], params['mass2'])
             l &= mc > args.min_mchirp
-        
-        if args.NS_threshold:
-            l &= (params['mass2'] <= args.NS_threshold)
-        
-        if args.remnant_mass_threshold:
-            params = {k: params[k][l] for k in params}
-            l = (remnant_mass(params['mass1'], params['mass2'], 
-                 spin1a=params['spin1z'], eos=args.eos) > args.remnant_mass_threshold) | \
-                (params['mass1'] <= args.NS_threshold)
 
     else:
         l = dists_joint.contains(params)
 
-    params = {k: params[k][l] for k in params}
+    for k in params:
+        params[k] = params[k][l]
+
     return params
 
 def cdraw(rtype, ts, te):
@@ -442,13 +415,13 @@ def cdraw(rtype, ts, te):
         t = tau0_from_mass1_mass2(p['mass1'], p['mass2'],
                                   args.low_frequency_cutoff)
         l = (t < te) & (t > ts)
-        p = {k: p[k][l] for k in p}
+        for k in p:
+            p[k] = p[k][l]
 
     i = 0
     while len(p[list(p.keys())[0]]) < size:
 
         tp = draw(rtype)
-        p = {k: numpy.concatenate([p[k], tp[k]]) for k in p}
         for k in p:
             p[k] = numpy.concatenate([p[k], tp[k]])
 
@@ -456,7 +429,8 @@ def cdraw(rtype, ts, te):
             t = tau0_from_mass1_mass2(p['mass1'], p['mass2'],
                                       args.low_frequency_cutoff)
             l = (t < te) & (t > ts)
-            p = {k: p[k][l] for k in p}
+            for k in p:
+                p[k] = p[k][l]
 
         i += 1
         if i > 1000:
@@ -464,15 +438,13 @@ def cdraw(rtype, ts, te):
 
     if len(p[list(p.keys())[0]]) == 0:
         return None
-    
-    return p
 
+    return p
 
 tau0s = args.tau0_start
 tau0e = tau0s + args.tau0_crawl
 go = True
-import time
-t0 = time.time()
+
 region = 0
 while tau0s < args.tau0_end:
     conv = 1
@@ -485,6 +457,7 @@ while tau0s < args.tau0_end:
             if len(bank) > 0:
                 go = False
             break
+
         blen = len(bank)
         bank, uconv = bank.check_params(gen, params, args.minimal_match)
         logging.info("%s: Round (U): %s Size: %s conv: %s added: %s",
@@ -516,9 +489,7 @@ while tau0s < args.tau0_end:
     region += 1
     tau0s += args.tau0_crawl / 2
     tau0e += args.tau0_crawl / 2
-time_elapsed = time.time() - t0
-time_elapsed = time.strftime("%H:%M:%S", time.gmtime(time_elapsed))
-logging.info("Elapsed time: ", time_elapsed)
+
 o = h5py.File(args.output_file, 'w')
 for k in bank.keys():
     val = bank.key(k)

--- a/bin/bank/pycbc_brute_bank
+++ b/bin/bank/pycbc_brute_bank
@@ -89,17 +89,6 @@ if args.input_config is not None:
 
     dists_joint = prior_from_config(cp=config_parser)
 
-if not args.tau0_end:
-    """
-    If tau0_end is not provided, it is derived and rounded up to the
-    upper tens.
-    This is necessary to cover up all the phase space.  
-    """
-    import math
-    from pycbc.conversions import tau0_from_mass1_mass2
-    args.tau0_end = math.ceil(tau0_from_mass1_mass2(args.min[0], args.min[1],
-                                        args.low_frequency_cutoff) / 10) * 10
-
 fdict = {}
 if args.fixed_params:
     for p, v in zip(args.fixed_params, args.fixed_values):
@@ -198,12 +187,11 @@ class TriangleBank(object):
 
         msig = len(r)
 
-        #Apply tau0 threshold
+        #Apply tua0 threshold
         if args.tau0_threshold:
             hp.tau0 = pycbc.conversions.tau0_from_mass1_mass2(
                                             hp.params['mass1'],
-                                            hp.params['mass2'],
-                                            args.low_frequency_cutoff)
+                                            hp.params['mass2'], 15.0)
             hp.tbin = int(hp.tau0 / args.tau0_threshold)
 
             if hp.tbin in self.tbins:
@@ -412,8 +400,7 @@ def cdraw(rtype, ts, te):
 
     p = draw(rtype)
     if  len(p[list(p.keys())[0]]) > 0:
-        t = tau0_from_mass1_mass2(p['mass1'], p['mass2'],
-                                  args.low_frequency_cutoff)
+        t = tau0_from_mass1_mass2(p['mass1'], p['mass2'], 15.0)
         l = (t < te) & (t > ts)
         for k in p:
             p[k] = p[k][l]
@@ -426,8 +413,7 @@ def cdraw(rtype, ts, te):
             p[k] = numpy.concatenate([p[k], tp[k]])
 
         if  len(p[list(p.keys())[0]]) > 0:
-            t = tau0_from_mass1_mass2(p['mass1'], p['mass2'],
-                                      args.low_frequency_cutoff)
+            t = tau0_from_mass1_mass2(p['mass1'], p['mass2'], 15.0)
             l = (t < te) & (t > ts)
             for k in p:
                 p[k] = p[k][l]

--- a/bin/bank/pycbc_brute_bank
+++ b/bin/bank/pycbc_brute_bank
@@ -26,7 +26,6 @@ from pycbc.distributions import read_params_from_config
 from pycbc.distributions.utils import draw_samples_from_config, prior_from_config
 from scipy.stats import gaussian_kde
 
-
 parser = argparse.ArgumentParser(description=__doc__)
 parser.add_argument('--verbose', action='store_true')
 parser.add_argument('--output-file', required=True,
@@ -94,11 +93,21 @@ if args.input_config is not None:
     dists_joint = prior_from_config(cp=config_parser)
 
 if not args.tau0_end:
+    """
+    If tau0_end is not provided, it is derived and rounded up to the
+    upper tens.
+    This is necessary to cover up all the phase space.  
+    """
     import math
-    args.tau0_end = math.ceil(pycbc.conversions.tau0_from_mass1_mass2(args.min[0], args.min[1],
-                                                                        args.low_frequency_cutoff) / 10) * 10
+    from pycbc.conversions import tau0_from_mass1_mass2
+    args.tau0_end = math.ceil(tau0_from_mass1_mass2(args.min[0], args.min[1],
+                                        args.low_frequency_cutoff) / 10) * 10
 if not args.eos:
     args.eos = '2H'
+
+if args.remnant_mass_threshold:
+    from pycbc.conversions import \
+    remnant_mass_from_mass1_mass2_spherical_spin_eos as remnant_mass
 
 if args.remnant_mass_threshold and not args.NS_threshold:
     from pycbc.neutron_stars.eos_utils import load_ns_sequence
@@ -122,7 +131,8 @@ class Shrinker(object):
         return l
 
 class TriangleBank(object):
-    """ A bank of templates that uses the triangle inequality to estimate
+    """ 
+    A bank of templates that uses the triangle inequality to estimate
     matches based on prior ones.
     """
     def __init__(self, p=None):
@@ -376,11 +386,13 @@ def draw(rtype):
             params = transforms.apply_transforms(params, waveform_transforms)
 
     params['approximant'] = numpy.array([args.approximant]*size)
-    #order params
-    params['mass1'], params['mass2'], params['spin1z'], params['spin2z'] = numpy.where(
-                            params['mass1']>params['mass2'], (params['mass1'], params['mass2'],
-                            params['spin1z'], params['spin2z']), (params['mass2'], params['mass1'], 
-                            params['spin2z'], params['spin1z']))
+    # remnant_mass function needs m1 >= m2, therefore it is necessary to order
+    # the params
+    if args.remnant_mass_threshold:
+        params['mass1'], params['mass2'], 
+        params['spin1z'], params['spin2z'] = numpy.where(params['mass1'] > params['mass2'],
+                    (params['mass1'], params['mass2'], params['spin1z'], params['spin2z']),
+                    (params['mass2'], params['mass1'], params['spin2z'], params['spin1z']))
 
     # Filter out stuff (kde method may also generate samples outside boundaries).
     l = None
@@ -390,7 +402,8 @@ def draw(rtype):
             l = (nl & l) if l is not None else nl
 
         if args.max_q:
-            q =  numpy.maximum(params['mass1'] / params['mass2'], params['mass2'] / params['mass1'])
+            q =  numpy.maximum(params['mass1'] / params['mass2'], 
+                               params['mass2'] / params['mass1'])
             l &= q < args.max_q
 
         if args.max_mtotal:
@@ -411,8 +424,8 @@ def draw(rtype):
         
         if args.remnant_mass_threshold:
             params = {k: params[k][l] for k in params}
-            l = (pycbc.conversions.remnant_mass_from_mass1_mass2_spherical_spin_eos(params['mass1'],
-                 params['mass2'], spin1a=params['spin1z'], eos=args.eos) > args.remnant_mass_threshold) | \
+            l = (remnant_mass(params['mass1'], params['mass2'], 
+                 spin1a=params['spin1z'], eos=args.eos) > args.remnant_mass_threshold) | \
                 (params['mass1'] <= args.NS_threshold)
 
     else:
@@ -503,7 +516,9 @@ while tau0s < args.tau0_end:
     region += 1
     tau0s += args.tau0_crawl / 2
     tau0e += args.tau0_crawl / 2
-logging.info("Time elapsed: %s", time.time()-t0)
+time_elapsed = time.time() - t0
+time_elapsed = time.strftime("%H:%M:%S", time.gmtime(time_elapsed))
+logging.info("Elapsed time: ", time_elapsed)
 o = h5py.File(args.output_file, 'w')
 for k in bank.keys():
     val = bank.key(k)

--- a/bin/bank/pycbc_brute_bank
+++ b/bin/bank/pycbc_brute_bank
@@ -26,6 +26,8 @@ from pycbc.distributions import read_params_from_config
 from pycbc.distributions.utils import draw_samples_from_config, prior_from_config
 from scipy.stats import gaussian_kde
 
+from pycbc.conversions import remnant_mass_from_mass1_mass2_spherical_spin_eos as rmn_mass
+
 parser = argparse.ArgumentParser(description=__doc__)
 parser.add_argument('--verbose', action='store_true')
 parser.add_argument('--output-file', required=True,
@@ -63,6 +65,9 @@ parser.add_argument('--max-q', type=float)
 parser.add_argument('--tau0-crawl', type=float)
 parser.add_argument('--tau0-start', type=float)
 parser.add_argument('--tau0-end', type=float)
+parser.add_argument('--NS-threshold', type=float)
+parser.add_argument('--remnant-mass-threshold', type=float)
+parser.add_argument('--eos', type=str)
 pycbc.psd.insert_psd_option_group(parser)
 args = parser.parse_args()
 pycbc.init_logging(args.verbose)
@@ -89,10 +94,22 @@ if args.input_config is not None:
 
     dists_joint = prior_from_config(cp=config_parser)
 
+if not args.tau0_end:
+    import math
+    args.tau0_end = math.ceil(pycbc.conversions.tau0_from_mass1_mass2(args.min[0], args.min[1],
+                                                                        args.low_frequency_cutoff) / 10) * 10
+if not args.eos:
+    args.eos = '2H'
+
+if args.remnant_mass_threshold and not args.NS_threshold:
+    from pycbc.neutron_stars.eos_utils import load_ns_sequence
+    seq, args.NS_threshold = load_ns_sequence(args.eos)
+    del seq
+
 fdict = {}
 if args.fixed_params:
-    for p, v in zip(args.fixed_params, args.fixed_values):
-        fdict[p] = v
+    fdict = {p: v for (p, v) in zip(args.fixed_params, args.fixed_values)}
+    
 
 class Shrinker(object):
     def __init__(self, data):
@@ -191,7 +208,8 @@ class TriangleBank(object):
         if args.tau0_threshold:
             hp.tau0 = pycbc.conversions.tau0_from_mass1_mass2(
                                             hp.params['mass1'],
-                                            hp.params['mass2'], 15.0)
+                                            hp.params['mass2'],
+                                            args.low_frequency_cutoff)
             hp.tbin = int(hp.tau0 / args.tau0_threshold)
 
             if hp.tbin in self.tbins:
@@ -319,20 +337,18 @@ if args.input_file:
 
 
 def draw(rtype):
-    params = {}
 
     if rtype == 'uniform':
         if args.input_config is None:
-            for name, pmin, pmax in zip(args.params, args.min, args.max):
-                params[name] = numpy.random.uniform(pmin, pmax, size=size)
+            params = {name: numpy.random.uniform(pmin, pmax, size=size) 
+                      for name, pmin, pmax in zip(args.params, args.min, args.max)}
         else:
             # `draw_samples_from_config` has its own fixed seed, so must overwrite it.
             random_seed = numpy.random.randint(low=0, high=2**32-1)
             samples = draw_samples_from_config(args.input_config, size, random_seed)
-            for name in samples.fieldnames:
-                params[name] = samples[name]
+            params = {name: samples[name] for name in samples.fieldnames}
             # Add `static_args` back.
-            if static_args is not None:
+            if static_args is not None: 
                 for k in static_args.keys():
                     params[k] = numpy.array([static_args[k]]*size)
 
@@ -349,8 +365,7 @@ def draw(rtype):
 
         kde = gaussian_kde(bdata)
         points = kde.resample(size=size)
-        for k, v in zip(p, points):
-            params[k] = v
+        params = {k: v for k, v in zip(p, points)}
 
         # Add `static_args` back, some transformations may need them.
         if args.input_config is not None and static_args is not None:
@@ -362,6 +377,11 @@ def draw(rtype):
             params = transforms.apply_transforms(params, waveform_transforms)
 
     params['approximant'] = numpy.array([args.approximant]*size)
+    #order params
+    params['mass1'], params['mass2'], params['spin1z'], params['spin2z'] = numpy.where(
+                            params['mass1']>params['mass2'], (params['mass1'], params['mass2'],
+                            params['spin1z'], params['spin2z']), (params['mass2'], params['mass1'], 
+                            params['spin2z'], params['spin1z']))
 
     # Filter out stuff (kde method may also generate samples outside boundaries).
     l = None
@@ -386,13 +406,20 @@ def draw(rtype):
             from pycbc.conversions import mchirp_from_mass1_mass2
             mc = mchirp_from_mass1_mass2(params['mass1'], params['mass2'])
             l &= mc > args.min_mchirp
+        
+        if args.NS_threshold:
+            l &= (params['mass2'] <= args.NS_threshold)
+        
+        if args.remnant_mass_threshold:
+            params = {k: params[k][l] for k in params}
+            l = (rmn_mass(params['mass1'], params['mass2'], spin1a=params['spin1z'],
+                          eos=args.eos) > args.remnant_mass_threshold) | \
+                (params['mass1'] <= args.NS_threshold)
 
     else:
         l = dists_joint.contains(params)
 
-    for k in params:
-        params[k] = params[k][l]
-
+    params = {k: params[k][l] for k in params}
     return params
 
 def cdraw(rtype, ts, te):
@@ -400,23 +427,24 @@ def cdraw(rtype, ts, te):
 
     p = draw(rtype)
     if  len(p[list(p.keys())[0]]) > 0:
-        t = tau0_from_mass1_mass2(p['mass1'], p['mass2'], 15.0)
+        t = tau0_from_mass1_mass2(p['mass1'], p['mass2'],
+                                  args.low_frequency_cutoff)
         l = (t < te) & (t > ts)
-        for k in p:
-            p[k] = p[k][l]
+        p = {k: p[k][l] for k in p}
 
     i = 0
     while len(p[list(p.keys())[0]]) < size:
 
         tp = draw(rtype)
+        p = {k: numpy.concatenate([p[k], tp[k]]) for k in p}
         for k in p:
             p[k] = numpy.concatenate([p[k], tp[k]])
 
         if  len(p[list(p.keys())[0]]) > 0:
-            t = tau0_from_mass1_mass2(p['mass1'], p['mass2'], 15.0)
+            t = tau0_from_mass1_mass2(p['mass1'], p['mass2'],
+                                      args.low_frequency_cutoff)
             l = (t < te) & (t > ts)
-            for k in p:
-                p[k] = p[k][l]
+            p = {k: p[k][l] for k in p}
 
         i += 1
         if i > 1000:
@@ -424,13 +452,15 @@ def cdraw(rtype, ts, te):
 
     if len(p[list(p.keys())[0]]) == 0:
         return None
-
+    
     return p
+
 
 tau0s = args.tau0_start
 tau0e = tau0s + args.tau0_crawl
 go = True
-
+import time
+t0 = time.time()
 region = 0
 while tau0s < args.tau0_end:
     conv = 1
@@ -443,7 +473,6 @@ while tau0s < args.tau0_end:
             if len(bank) > 0:
                 go = False
             break
-
         blen = len(bank)
         bank, uconv = bank.check_params(gen, params, args.minimal_match)
         logging.info("%s: Round (U): %s Size: %s conv: %s added: %s",
@@ -475,7 +504,7 @@ while tau0s < args.tau0_end:
     region += 1
     tau0s += args.tau0_crawl / 2
     tau0e += args.tau0_crawl / 2
-
+logging.info("Time elapsed: %s", time.time()-t0)
 o = h5py.File(args.output_file, 'w')
 for k in bank.keys():
     val = bank.key(k)

--- a/bin/bank/pycbc_brute_bank
+++ b/bin/bank/pycbc_brute_bank
@@ -63,6 +63,7 @@ parser.add_argument('--max-q', type=float)
 parser.add_argument('--tau0-crawl', type=float)
 parser.add_argument('--tau0-start', type=float)
 parser.add_argument('--tau0-end', type=float)
+parser.add_argument('--tau0-cutoff-frequency', type=float, default=15.0)
 pycbc.psd.insert_psd_option_group(parser)
 args = parser.parse_args()
 pycbc.init_logging(args.verbose)
@@ -88,17 +89,6 @@ if args.input_config is not None:
         waveform_transforms = None
 
     dists_joint = prior_from_config(cp=config_parser)
-
-if not args.tau0_end:
-    """
-    If tau0_end is not provided, it is derived and rounded up to the
-    upper tens.
-    This is necessary to cover up all the phase space.  
-    """
-    import math
-    from pycbc.conversions import tau0_from_mass1_mass2
-    args.tau0_end = math.ceil(tau0_from_mass1_mass2(args.min[0], args.min[1],
-                                        args.low_frequency_cutoff) / 10) * 10
 
 fdict = {}
 if args.fixed_params:
@@ -203,7 +193,7 @@ class TriangleBank(object):
             hp.tau0 = pycbc.conversions.tau0_from_mass1_mass2(
                                             hp.params['mass1'],
                                             hp.params['mass2'],
-                                            args.low_frequency_cutoff)
+                                            args.tau0_cutoff_frequency)
             hp.tbin = int(hp.tau0 / args.tau0_threshold)
 
             if hp.tbin in self.tbins:
@@ -413,7 +403,7 @@ def cdraw(rtype, ts, te):
     p = draw(rtype)
     if  len(p[list(p.keys())[0]]) > 0:
         t = tau0_from_mass1_mass2(p['mass1'], p['mass2'],
-                                  args.low_frequency_cutoff)
+                                  args.tau0_cutoff_frequency)
         l = (t < te) & (t > ts)
         for k in p:
             p[k] = p[k][l]
@@ -427,7 +417,7 @@ def cdraw(rtype, ts, te):
 
         if  len(p[list(p.keys())[0]]) > 0:
             t = tau0_from_mass1_mass2(p['mass1'], p['mass2'],
-                                      args.low_frequency_cutoff)
+                                      args.tau0_cutoff_frequency)
             l = (t < te) & (t > ts)
             for k in p:
                 p[k] = p[k][l]

--- a/bin/bank/pycbc_brute_bank
+++ b/bin/bank/pycbc_brute_bank
@@ -26,7 +26,6 @@ from pycbc.distributions import read_params_from_config
 from pycbc.distributions.utils import draw_samples_from_config, prior_from_config
 from scipy.stats import gaussian_kde
 
-from pycbc.conversions import remnant_mass_from_mass1_mass2_spherical_spin_eos as rmn_mass
 
 parser = argparse.ArgumentParser(description=__doc__)
 parser.add_argument('--verbose', action='store_true')
@@ -412,8 +411,8 @@ def draw(rtype):
         
         if args.remnant_mass_threshold:
             params = {k: params[k][l] for k in params}
-            l = (rmn_mass(params['mass1'], params['mass2'], spin1a=params['spin1z'],
-                          eos=args.eos) > args.remnant_mass_threshold) | \
+            l = (pycbc.conversions.remnant_mass_from_mass1_mass2_spherical_spin_eos(params['mass1'],
+                 params['mass2'], spin1a=params['spin1z'], eos=args.eos) > args.remnant_mass_threshold) | \
                 (params['mass1'] <= args.NS_threshold)
 
     else:

--- a/pycbc/neutron_stars/pg_isso_solver.py
+++ b/pycbc/neutron_stars/pg_isso_solver.py
@@ -39,7 +39,9 @@ def ISCO_solution(chi, incl):
     chi: float
         the BH dimensionless spin parameter
     incl: float
-        inclination of the orbit
+        inclination angle between the BH spin and the orbital angular
+        momentum in radians
+        
     Returns
     ----------
     float

--- a/pycbc/neutron_stars/pg_isso_solver.py
+++ b/pycbc/neutron_stars/pg_isso_solver.py
@@ -32,7 +32,7 @@ def ISCO_solution(chi, incl):
     stable circular orbit (ISCO) for the Kerr metric.
 
     ..See eq. (2.21) of
-    `Bardeen, J. M., Press, W. H., Teukolsky, S. A. (1972)
+    `Bardeen, J. M., Press, W. H., Teukolsky, S. A. (1972)`
     https://articles.adsabs.harvard.edu/pdf/1972ApJ...178..347B
 
     Parameters

--- a/pycbc/neutron_stars/pg_isso_solver.py
+++ b/pycbc/neutron_stars/pg_isso_solver.py
@@ -329,7 +329,7 @@ def PG_ISSO_solver(chi, incl):
     initial_lo = np.minimum(rISCO_limit, rISSO_at_pole_limit)
     brackets = [
         (bl, bh) if (c != 1 and PG_ISSO_eq(bl, c, inc)
-        * PG_ISSO_eq(bh, c, inc) < 0) else None
+                    * PG_ISSO_eq(bh, c, inc) < 0) else None
         for bl, bh, c, inc in zip(initial_lo, initial_hi, chi, incl)]
     solution = np.array([
         root_scalar(

--- a/pycbc/neutron_stars/pg_isso_solver.py
+++ b/pycbc/neutron_stars/pg_isso_solver.py
@@ -32,7 +32,7 @@ def ISCO_solution(chi, incl):
     stable circular orbit (ISCO) for the Kerr metric.
 
     ..See eq. (2.21) of
-    _`Bardeen, J. M., Press, W. H., Teukolsky, S. A. (1972)`_
+    Bardeen, J. M., Press, W. H., Teukolsky, S. A. (1972)`
     https://articles.adsabs.harvard.edu/pdf/1972ApJ...178..347B
 
     Parameters

--- a/pycbc/neutron_stars/pg_isso_solver.py
+++ b/pycbc/neutron_stars/pg_isso_solver.py
@@ -309,15 +309,14 @@ def PG_ISSO_solver(chi, incl):
     # Otherwise, find the ISSO radius for a generic inclination
     initial_hi = np.maximum(rISCO_limit, rISSO_at_pole_limit)
     initial_lo = np.minimum(rISCO_limit, rISSO_at_pole_limit)
-    initial_m = 0.5*(initial_hi+initial_lo)
     brackets = [
-        (bl, bh) 
-        for bl, bh in zip(initial_lo, initial_hi)]
+        (bl, bh) if c != 1 else None
+        for bl, bh, c in zip(initial_lo, initial_hi, chi)]
     solution = np.array([
         root_scalar(
             PG_ISSO_eq, x0=g0, fprime=PG_ISSO_eq_dr, bracket=bracket,
             fprime2=PG_ISSO_eq_dr2, args=(c, inc), xtol=1e-12).root
-        for g0, bracket, c, inc in zip(initial_m, brackets, chi, incl)])
+        for g0, bracket, c, inc in zip(initial_hi, brackets, chi, incl)])
     oob = (solution < 1) | (solution > 9)
     if any(oob):
         solution = np.array([

--- a/pycbc/neutron_stars/pg_isso_solver.py
+++ b/pycbc/neutron_stars/pg_isso_solver.py
@@ -32,7 +32,7 @@ def ISCO_solution(chi, incl):
     stable circular orbit (ISCO) for the Kerr metric.
 
     ..See eq. (2.21) of
-    `Bardeen, J. M., Press, W. H., Teukolsky, S. A. (1972)`
+    _`Bardeen, J. M., Press, W. H., Teukolsky, S. A. (1972)`_
     https://articles.adsabs.harvard.edu/pdf/1972ApJ...178..347B
 
     Parameters

--- a/pycbc/neutron_stars/pg_isso_solver.py
+++ b/pycbc/neutron_stars/pg_isso_solver.py
@@ -26,11 +26,12 @@ formalism. See `Stone, Loeb, Berger, PRD 87, 084053 (2013)`_.
 import numpy as np
 from scipy.optimize import root_scalar
 
+
 def ISCO_solution(chi, incl):
     r"""Analytic solution of the innermost
     stable circular orbit (ISCO) for the Kerr metric.
 
-    ..See eq. (2.21) of 
+    ..See eq. (2.21) of
     `Bardeen, J. M., Press, W. H., Teukolsky, S. A. (1972)
     https://articles.adsabs.harvard.edu/pdf/1972ApJ...178..347B
 
@@ -41,7 +42,7 @@ def ISCO_solution(chi, incl):
     incl: float
         inclination angle between the BH spin and the orbital angular
         momentum in radians
-        
+
     Returns
     ----------
     float
@@ -310,7 +311,7 @@ def PG_ISSO_solver(chi, incl):
         return rISCO_limit
 
     # ISSO radius for an inclination of pi/2
-    # Initial guess is based on the extrema of the polar ISSO radius equation, 
+    # Initial guess is based on the extrema of the polar ISSO radius equation,
     # that are: r=6 (chi=1) and r=1+sqrt(3)+sqrt(3+sqrt(12))=5.274... (chi=0)
     initial_guess = [5.27451056440629 if c > 0.5 else 6 for c in chi]
     rISSO_at_pole_limit = np.array([
@@ -327,7 +328,8 @@ def PG_ISSO_solver(chi, incl):
     initial_hi = np.maximum(rISCO_limit, rISSO_at_pole_limit)
     initial_lo = np.minimum(rISCO_limit, rISSO_at_pole_limit)
     brackets = [
-        (bl, bh) if (c != 1 and PG_ISSO_eq(bl, c, inc)*PG_ISSO_eq(bh, c, inc)<0) else None
+        (bl, bh) if (c != 1 and PG_ISSO_eq(bl, c, inc)
+        * PG_ISSO_eq(bh, c, inc) < 0) else None
         for bl, bh, c, inc in zip(initial_lo, initial_hi, chi, incl)]
     solution = np.array([
         root_scalar(

--- a/pycbc/neutron_stars/pg_isso_solver.py
+++ b/pycbc/neutron_stars/pg_isso_solver.py
@@ -28,7 +28,7 @@ from scipy.optimize import root_scalar
 
 def ISCO_solution(chi, incl):
     r"""Analytic solution of the innermost
-    stable circular orbit (ISCO).
+    stable circular orbit (ISCO) for the Kerr metric.
 
     ..See eq. (2.21) of 
     `Bardeen, J. M., Press, W. H., Teukolsky, S. A. (1972)

--- a/pycbc/neutron_stars/pg_isso_solver.py
+++ b/pycbc/neutron_stars/pg_isso_solver.py
@@ -310,6 +310,8 @@ def PG_ISSO_solver(chi, incl):
         return rISCO_limit
 
     # ISSO radius for an inclination of pi/2
+    # Initial guess is based on the extrema of the polar ISSO radius equation, 
+    # that are: r=6 (chi=1) and r=1+sqrt(3)+sqrt(3+sqrt(12))=5.274... (chi=0)
     initial_guess = [5.27451056440629 if c > 0.5 else 6 for c in chi]
     rISSO_at_pole_limit = np.array([
         root_scalar(
@@ -317,7 +319,7 @@ def PG_ISSO_solver(chi, incl):
             fprime2=ISSO_eq_at_pole_dr2, args=(c)).root
         for g0, c in zip(initial_guess, chi)])
     # If the inclination is pi/2, just output the ISSO radius at the pole(s)
-    polar = np.isclose(incl, np.pi / 2)
+    polar = np.isclose(incl, 0.5*np.pi)
     if all(polar):
         return rISSO_at_pole_limit
 

--- a/pycbc/neutron_stars/pg_isso_solver.py
+++ b/pycbc/neutron_stars/pg_isso_solver.py
@@ -329,7 +329,7 @@ def PG_ISSO_solver(chi, incl):
     initial_lo = np.minimum(rISCO_limit, rISSO_at_pole_limit)
     brackets = [
         (bl, bh) if (c != 1 and PG_ISSO_eq(bl, c, inc) *
-                                PG_ISSO_eq(bh, c, inc) < 0) else None
+                     PG_ISSO_eq(bh, c, inc) < 0) else None
         for bl, bh, c, inc in zip(initial_lo, initial_hi, chi, incl)]
     solution = np.array([
         root_scalar(

--- a/pycbc/neutron_stars/pg_isso_solver.py
+++ b/pycbc/neutron_stars/pg_isso_solver.py
@@ -328,8 +328,8 @@ def PG_ISSO_solver(chi, incl):
     initial_hi = np.maximum(rISCO_limit, rISSO_at_pole_limit)
     initial_lo = np.minimum(rISCO_limit, rISSO_at_pole_limit)
     brackets = [
-        (bl, bh) if (c != 1 and PG_ISSO_eq(bl, c, inc)
-                    * PG_ISSO_eq(bh, c, inc) < 0) else None
+        (bl, bh) if (c != 1 and PG_ISSO_eq(bl, c, inc) *
+                                PG_ISSO_eq(bh, c, inc) < 0) else None
         for bl, bh, c, inc in zip(initial_lo, initial_hi, chi, incl)]
     solution = np.array([
         root_scalar(


### PR DESCRIPTION
When calculating tau0 from the two compact object masses, the code used a fixed frequency of 15.0 Hz that prevented a uniform phase space coverage even with an arbitrarily large tau0-end (please see figures). It was also added tau0-end derivation from the lowest chirp mass, assuring total phase space coverage.
![before](https://user-images.githubusercontent.com/105977937/212978085-611735e8-c2d9-4a6d-8864-61c45c1664ab.png)
![after](https://user-images.githubusercontent.com/105977937/212978111-ceba5953-2e5f-4b71-bac8-d2b864eb6158.png)
