### PR TITLE
Avoid memory leaks when one detector is down for a long time

### DIFF
--- a/pycbc/events/coinc.py
+++ b/pycbc/events/coinc.py
@@ -610,7 +610,6 @@ class MultiRingBuffer(object):
         """Add triggers in 'values' to the buffers indicated by the indices
         """
         for i, v in zip(indices, values):
-            curr_pos = self.valid_ends[i]
             # Expand ring buffer size if needed
             if self.valid_ends[i] == len(self.buffer[i]):
                 # First clear out any old triggers before resizing
@@ -632,6 +631,7 @@ class MultiRingBuffer(object):
                         self.min_buffer_size
                     )
                 )
+            curr_pos = self.valid_ends[i]
             self.buffer[i][curr_pos] = v
             self.buffer_expire[i][curr_pos] = self.time
             self.valid_ends[i] = self.valid_ends[i] + 1


### PR DESCRIPTION
@titodalcanton Has observed a condition in PyCBC Live where if one detector is down for a long time (days), the memory usage of PyCBC Live grows linearly. This seems to be because the condition for freeing memory in the single-detector trigger buffers is only activated when the `data` method is accessed. This method is only accessed when checking for coincidences against new triggers in the *other* detector. So if the other detector is never on, it never produces triggers, and this never gets called.

This refactors the class a little bit to move "clean up memory" into a separate method, and calls this from both the original location *and* when resizing the arrays in the `add` method. This would then ensure that memory is still freed if `data` is never being called, but hopefully avoiding the "we're doing this too often and it's a bottleneck" problem.

I still need to run this through some of the larger tests, but hopefully this (or this with minor tweaks) will work.