### PR TITLE
Add second PyCBC Live paper to credit docs page

### DIFF
--- a/docs/credit.rst
+++ b/docs/credit.rst
@@ -2,30 +2,41 @@
 Use of PyCBC in Scientific Publications
 =======================================
 
-If you use any code from PyCBC in a scientific publication, then we ask that you include a citation to the software through its DOI and that you cite the publications relevant to the sections of the code that you are using, as described below.
+If you use any code from PyCBC in a scientific publication, then we ask that
+you include a citation to the software through its DOI and that you cite the
+publications relevant to the sections of the code that you are using, as
+described below.
 
 -------------------------
 Citing the PyCBC Software 
 -------------------------
 
-A bibtex key and DOI for each release is avaliable from `Zenodo <http://zenodo.org/>`__ and DOIs for releases can be found on the `PyCBC release page. <https://github.com/gwastro/pycbc/releases>`__ A key for the latest release is available at:
+A bibtex key and DOI for each release is avaliable from `Zenodo
+<http://zenodo.org/>`__ and DOIs for releases can be found on the `PyCBC
+release page <https://github.com/gwastro/pycbc/releases>`__. A key for the
+latest release is available at:
 
 .. image:: https://zenodo.org/badge/31596861.svg
    :target: https://zenodo.org/badge/latestdoi/31596861
 
-If you do not use a specific release, please cite the DOI for the latest release, or the release closest to the version that you are using.
+If you do not use a specific release, please cite the DOI for the latest
+release, or the release closest to the version that you are using.
 
 ---------------------------------------------------------------
 Citing the scientific publications that describe the algorithms
 ---------------------------------------------------------------
 
-PyCBC implements a large number of data-analysis algorithms and so it is not possible to give one single citation. To give proper scientific credit for the development of PyCBC, in addition to citing the DOI from the software, please cite the appropriate scientific publications below.
+PyCBC implements a large number of data-analysis algorithms and so it is not
+possible to give one single citation. To give proper scientific credit for the
+development of PyCBC, in addition to citing the DOI from the software, please
+cite the appropriate scientific publications below.
 
 ^^^^^^^^^^^^^^^^^^
 Bayesian Inference
 ^^^^^^^^^^^^^^^^^^
 
-If you use the Bayesian inference modules, or code derived from those modules, please cite the paper:
+If you use the Bayesian inference modules, or code derived from those modules,
+please cite the paper:
 
 -  `PyCBC Inference: A Python-based parameter estimation toolkit for compact binary coalescence signals. <https://arxiv.org/abs/1807.10312>`__ `[INSPIRES BibTeX Key] <https://inspirehep.net/record/1685555/export/hx>`__ `[ADS BibTeX key] <http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=2018arXiv180710312B&data_type=BIBTEX&db_key=PRE&nocookieset=1>`__
 
@@ -47,7 +58,8 @@ If you use the offline PyCBC search pipeline, please additionally cite:
 
 - `The PyCBC search for gravitational waves from compact binary coalescence. <http://iopscience.iop.org/article/10.1088/0264-9381/33/21/215004/meta>`__ `[INSPIRES BibTeX Key] <https://inspirehep.net/record/1387292/export/hx>`__ `[ADS BibTeX key] <http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=2016CQGra..33u5004U&data_type=BIBTEX&db_key=AST&nocookieset=1>`__
 
-If you use the low-latency PyCBC search pipeline (PyCBC Live), please additionally cite:
+If you use the low-latency PyCBC search pipeline (PyCBC Live), please
+additionally cite:
 
 - `PyCBC Live: Rapid Detection of Gravitational Waves from Compact Binary Mergers. <https://journals.aps.org/prd/abstract/10.1103/PhysRevD.98.024050>`__ `[INSPIRES BibTeX Key] <https://inspirehep.net/record/1675309/export/hx>`__ `[ADS BibTeX key] <http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=2018PhRvD..98b4050N&data_type=BIBTEX&db_key=PHY&nocookieset=1>`__
 

--- a/docs/credit.rst
+++ b/docs/credit.rst
@@ -8,7 +8,7 @@ If you use any code from PyCBC in a scientific publication, then we ask that you
 Citing the PyCBC Software 
 -------------------------
 
-A bibtex key and DOI for each release is avaliable from `Zenodo <http://zenodo.org/>`_ and DOIs for releases can be found on the `PyCBC release page. <https://github.com/gwastro/pycbc/releases>`_ A key for the latest release is available at:
+A bibtex key and DOI for each release is avaliable from `Zenodo <http://zenodo.org/>`__ and DOIs for releases can be found on the `PyCBC release page. <https://github.com/gwastro/pycbc/releases>`__ A key for the latest release is available at:
 
 .. image:: https://zenodo.org/badge/31596861.svg
    :target: https://zenodo.org/badge/latestdoi/31596861
@@ -27,7 +27,7 @@ Bayesian Inference
 
 If you use the Bayesian inference modules, or code derived from those modules, please cite the paper:
 
--  `PyCBC Inference: A Python-based parameter estimation toolkit for compact binary coalescence signals. <https://arxiv.org/abs/1807.10312>`_ `[INSPIRES BibTeX Key] <https://inspirehep.net/record/1685555/export/hx>`__ `[ADS BibTeX key] <http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=2018arXiv180710312B&data_type=BIBTEX&db_key=PRE&nocookieset=1>`__
+-  `PyCBC Inference: A Python-based parameter estimation toolkit for compact binary coalescence signals. <https://arxiv.org/abs/1807.10312>`__ `[INSPIRES BibTeX Key] <https://inspirehep.net/record/1685555/export/hx>`__ `[ADS BibTeX key] <http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=2018arXiv180710312B&data_type=BIBTEX&db_key=PRE&nocookieset=1>`__
 
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Searches for Compact Binary Coalescence
@@ -35,13 +35,13 @@ Searches for Compact Binary Coalescence
 
 If you use the PyCBC search algorithms, please cite all four of these papers:
 
-- `FINDCHIRP: an algorithm for detection of gravitational waves from inspiraling compact binaries. <https://journals.aps.org/prd/abstract/10.1103/PhysRevD.85.122006>`_ `[INSPIRES BibTeX Key] <https://inspirehep.net/record/693632/export/hx>`__ `[ADS BibTeX key] <http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=2012PhRvD..85l2006A&data_type=BIBTEX&db_key=AST&nocookieset=1>`__
+- `FINDCHIRP: an algorithm for detection of gravitational waves from inspiraling compact binaries. <https://journals.aps.org/prd/abstract/10.1103/PhysRevD.85.122006>`__ `[INSPIRES BibTeX Key] <https://inspirehep.net/record/693632/export/hx>`__ `[ADS BibTeX key] <http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=2012PhRvD..85l2006A&data_type=BIBTEX&db_key=AST&nocookieset=1>`__
 
-- `A chi-squared time-frequency discriminator for gravitational wave detection. <https://journals.aps.org/prd/abstract/10.1103/PhysRevD.71.062001>`_ `[INSPIRES BibTeX Key] <https://inspirehep.net/record/649978/export/hx>`__ `[ADS BibTeX key] <http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=2005PhRvD..71f2001A&data_type=BIBTEX&db_key=AST&nocookieset=1>`__
+- `A chi-squared time-frequency discriminator for gravitational wave detection. <https://journals.aps.org/prd/abstract/10.1103/PhysRevD.71.062001>`__ `[INSPIRES BibTeX Key] <https://inspirehep.net/record/649978/export/hx>`__ `[ADS BibTeX key] <http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=2005PhRvD..71f2001A&data_type=BIBTEX&db_key=AST&nocookieset=1>`__
 
-- `Detecting binary compact-object mergers with gravitational waves: Understanding and Improving the sensitivity of the PyCBC search. <http://iopscience.iop.org/article/10.3847/1538-4357/aa8f50/meta>`_ `[INSPIRES BibTeX Key] <https://inspirehep.net/record/1598019/export/hx>`__ `[ADS BibTeX key] <http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=2017ApJ...849..118N&data_type=BIBTEX&db_key=AST&nocookieset=1>`__
+- `Detecting binary compact-object mergers with gravitational waves: Understanding and Improving the sensitivity of the PyCBC search. <http://iopscience.iop.org/article/10.3847/1538-4357/aa8f50/meta>`__ `[INSPIRES BibTeX Key] <https://inspirehep.net/record/1598019/export/hx>`__ `[ADS BibTeX key] <http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=2017ApJ...849..118N&data_type=BIBTEX&db_key=AST&nocookieset=1>`__
 
-- `Implementing a search for aligned-spin neutron star -- black hole systems with advanced ground based gravitational wave detectors. <https://journals.aps.org/prd/abstract/10.1103/PhysRevD.90.082004>`_ `[INSPIRES BibTeX Key] <https://inspirehep.net/record/1298262/export/hx>`__ `[ADS BibTeX key] <http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=2014PhRvD..90h2004D&data_type=BIBTEX&db_key=PHY&nocookieset=1>`__
+- `Implementing a search for aligned-spin neutron star -- black hole systems with advanced ground based gravitational wave detectors. <https://journals.aps.org/prd/abstract/10.1103/PhysRevD.90.082004>`__ `[INSPIRES BibTeX Key] <https://inspirehep.net/record/1298262/export/hx>`__ `[ADS BibTeX key] <http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=2014PhRvD..90h2004D&data_type=BIBTEX&db_key=PHY&nocookieset=1>`__
 
 If you use the offline PyCBC search pipeline, please additionally cite:
 
@@ -49,6 +49,6 @@ If you use the offline PyCBC search pipeline, please additionally cite:
 
 If you use the low-latency PyCBC search pipeline (PyCBC Live), please additionally cite:
 
-- `PyCBC Live: Rapid Detection of Gravitational Waves from Compact Binary Mergers. <https://journals.aps.org/prd/abstract/10.1103/PhysRevD.98.024050>`__ `[INSPIRES BibTeX Key] <https://inspirehep.net/record/1675309/export/hx>`_ `[ADS BibTeX key] <http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=2018PhRvD..98b4050N&data_type=BIBTEX&db_key=PHY&nocookieset=1>`__
+- `PyCBC Live: Rapid Detection of Gravitational Waves from Compact Binary Mergers. <https://journals.aps.org/prd/abstract/10.1103/PhysRevD.98.024050>`__ `[INSPIRES BibTeX Key] <https://inspirehep.net/record/1675309/export/hx>`__ `[ADS BibTeX key] <http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=2018PhRvD..98b4050N&data_type=BIBTEX&db_key=PHY&nocookieset=1>`__
 
-- `Realtime search for compact binary mergers in Advanced LIGO and Virgo's third observing run using PyCBC Live. <https://doi.org/10.3847/1538-4357/ac2f9a>`__ `[INSPIRES BibTeX Key] <https://inspirehep.net/literature/1811966>`_ `[ADS BibTeX key] <https://ui.adsabs.harvard.edu/abs/2021ApJ...923..254D/exportcitation>`__
+- `Realtime search for compact binary mergers in Advanced LIGO and Virgo's third observing run using PyCBC Live. <https://doi.org/10.3847/1538-4357/ac2f9a>`__ `[INSPIRES BibTeX Key] <https://inspirehep.net/literature/1811966>`__ `[ADS BibTeX key] <https://ui.adsabs.harvard.edu/abs/2021ApJ...923..254D/exportcitation>`__

--- a/docs/credit.rst
+++ b/docs/credit.rst
@@ -51,4 +51,4 @@ If you use the low-latency PyCBC search pipeline (PyCBC Live), please additional
 
 - `PyCBC Live: Rapid Detection of Gravitational Waves from Compact Binary Mergers. <https://journals.aps.org/prd/abstract/10.1103/PhysRevD.98.024050>`__ `[INSPIRES BibTeX Key] <https://inspirehep.net/record/1675309/export/hx>`_ `[ADS BibTeX key] <http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=2018PhRvD..98b4050N&data_type=BIBTEX&db_key=PHY&nocookieset=1>`__
 
-- `Realtime search for compact binary mergers in Advanced LIGO and Virgo's third observing run using PyCBC Live. <https://doi.org/10.3847/1538-4357/ac2f9a>`__ `[INSPIRES BibTeX Key] https://inspirehep.net/literature/1811966`_ `[ADS BibTeX key] https://ui.adsabs.harvard.edu/abs/2021ApJ...923..254D/exportcitation`__
+- `Realtime search for compact binary mergers in Advanced LIGO and Virgo's third observing run using PyCBC Live. <https://doi.org/10.3847/1538-4357/ac2f9a>`__ `[INSPIRES BibTeX Key] <https://inspirehep.net/literature/1811966>`_ `[ADS BibTeX key] <https://ui.adsabs.harvard.edu/abs/2021ApJ...923..254D/exportcitation>`__

--- a/docs/credit.rst
+++ b/docs/credit.rst
@@ -47,7 +47,8 @@ If you use the offline PyCBC search pipeline, please additionally cite:
 
 - `The PyCBC search for gravitational waves from compact binary coalescence. <http://iopscience.iop.org/article/10.1088/0264-9381/33/21/215004/meta>`__ `[INSPIRES BibTeX Key] <https://inspirehep.net/record/1387292/export/hx>`__ `[ADS BibTeX key] <http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=2016CQGra..33u5004U&data_type=BIBTEX&db_key=AST&nocookieset=1>`__
 
-If you use the low-latency PyCBC search pipeline, please additionally cite:
+If you use the low-latency PyCBC search pipeline (PyCBC Live), please additionally cite:
 
 - `PyCBC Live: Rapid Detection of Gravitational Waves from Compact Binary Mergers. <https://journals.aps.org/prd/abstract/10.1103/PhysRevD.98.024050>`__ `[INSPIRES BibTeX Key] <https://inspirehep.net/record/1675309/export/hx>`_ `[ADS BibTeX key] <http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=2018PhRvD..98b4050N&data_type=BIBTEX&db_key=PHY&nocookieset=1>`__
 
+- `Realtime search for compact binary mergers in Advanced LIGO and Virgo's third observing run using PyCBC Live. <https://doi.org/10.3847/1538-4357/ac2f9a>`__ `[INSPIRES BibTeX Key] https://inspirehep.net/literature/1811966`_ `[ADS BibTeX key] https://ui.adsabs.harvard.edu/abs/2021ApJ...923..254D/exportcitation`__


### PR DESCRIPTION
This is untested as I could not get the docs to build on my systems due to the BBHx issues. I guess I can look at the artifacts though.