### PR TITLE
Install ciecplib[kerberos] for igwn

### DIFF
--- a/requirements-igwn.txt
+++ b/requirements-igwn.txt
@@ -1,5 +1,5 @@
 # For LDG service access
-ciecplib>=0.4.4
+ciecplib[kerberos]>=0.7.0
 dqsegdb2>=1.0.1
 amqplib
 htchirp >= 2.0


### PR DESCRIPTION
This PR patches the `requirements-igwn.txt` list to include `ciecplib[kerberos]`. This will enable automatic discovery and use of existing Kerberos TGTs for LIGO.ORG authentication.

This relates to the IGWN-internal ticket https://git.ligo.org/computing/helpdesk/-/issues/3216.