### PR TITLE
fix missing logo in docs page

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -32,6 +32,6 @@ dynesty
 
 # For building documentation
 Sphinx>=4.2.0
-sphinx-rtd-theme
+sphinx-rtd-theme>=1.0.0
 sphinxcontrib-programoutput>=0.11
 sphinx_design


### PR DESCRIPTION
If an old version of rtd theme is somehow picked up, then the logo won't properly build. This updates the reqs so the correct minimum requirement is installed. 