### PR TITLE
Fix x-axis error in combined fits plotting

### DIFF
--- a/bin/live/pycbc_live_plot_combined_single_fits
+++ b/bin/live/pycbc_live_plot_combined_single_fits
@@ -136,7 +136,7 @@ for ifo in ifos:
         a = alphas[valid]
         l_times = separate_times[ifo][valid]
         rate = counts[valid] / l_times
-        ad = separate_dates[ifo][valid] / 86400.
+        ad = (separate_dates[ifo][valid] - separate_dates[ifo][0]) / 86400.
 
         ma = mean_alpha[ifo][i]
         ca = cons_alpha[ifo][i]


### PR DESCRIPTION
We noticed an error where the x-axis values were actually counting days since the zero point of GPS time, this resets zero to the first day (as reported in the x label)