### PR TITLE
Speed up fit_sngls_by_template

### DIFF
--- a/bin/all_sky_search/pycbc_fit_sngls_by_template
+++ b/bin/all_sky_search/pycbc_fit_sngls_by_template
@@ -173,8 +173,8 @@ logging.info('Calculating stat values')
 abovethresh, stat = get_stat(args, trigf[args.ifo], args.stat_threshold)
 logging.info('%i trigs left after thresholding' % len(stat))
 
-tid = trigf[args.ifo + '/template_id'][abovethresh]
-time = trigf[args.ifo + '/end_time'][abovethresh]
+tid = trigf[args.ifo + '/template_id'][:][abovethresh]
+time = trigf[args.ifo + '/end_time'][:][abovethresh]
 if args.save_trig_param:
     tparam_region = trigf[args.ifo][args.save_trig_param + '_template'][:]
     tparam = []


### PR DESCRIPTION
In recent tests, especially when there's a lot of triggers, I've noticed fit_sngls_by_template taking a very long time.

After some investigation I tracked this down to the lines that are being changed. The code would normally be unresponsive while running this, and only respond to CTRL + / command. What I think was happening in the old code is that the code would read the HDF file N times (where N is the number of triggers above threshold) each time seeking to and only reading the appropriate entry from the file. But if N is large (millions) this is very slow .... This is still slow when N is hundreds of thousands, as is typical for O3 configuration.

However, it's much faster/more efficient to just read the entire HDF array *once* and then index into the points you need in memory. This doesn't affect the memory profile of the code. Before the commands I am changing the code has to compute the stat for all points, which involves reading in the entire SNR and chisq arrays. These arrays have been released from memory by the time we get here so I'm using less memory here than what was used 3 lines above.

I am surprised by this behaviour in h5py. One would think that if doing an operation like this, with many points, it would choose to read the entire array into memory, or figure out which points it needs to read and do it all in one pass ... But I didn't look into that, I just did an empirical test and this makes the code run *much* faster (minutes, rather than hours or even longer).