### PR TITLE
Update GitHub actions to fix Node.js 16 warning

### DIFF
--- a/.github/workflows/basic-tests.yml
+++ b/.github/workflows/basic-tests.yml
@@ -12,9 +12,9 @@ jobs:
         python-version: [3.7, 3.8, 3.9, '3.10', '3.11']
         test-type: [help, unittest, search, inference, docs]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: installing system packages

--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -11,10 +11,10 @@ jobs:
         os: [ubuntu-20.04, macos-latest]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel==2.3.1
 
@@ -32,11 +32,11 @@ jobs:
     runs-on: ubuntu-20.04
     needs: build_wheels
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
     - name: Set up Python 3.7
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - uses: actions/download-artifact@v2

--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -15,9 +15,10 @@ jobs:
         with:
           fetch-depth: 0
       - uses: actions/setup-python@v4
+        with:
+          python-version: 3.7      
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel==2.3.1
-
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
         env:

--- a/.github/workflows/tut-test.yml
+++ b/.github/workflows/tut-test.yml
@@ -11,9 +11,9 @@ jobs:
         os: [ubuntu-20.04]
         python-version: [3.7, 3.8, 3.9, '3.10']
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: installing packages


### PR DESCRIPTION
I see this warning on one of the Actions pages:

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2, actions/setup-python@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

I think this PR does what is needed to fix it.