### PR TITLE
Avoid h5py 3.7.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ matplotlib>=2.0.0
 # Remove the upper bound ASAP, this is a temporary fix!!!!!!
 numpy>=1.16.0,!=1.19.0,<1.24.0
 pillow
-h5py>=3.0.0
+h5py>=3.0.0,!=3.7.0
 jinja2
 mpld3>=0.3
 beautifulsoup4>=4.6.0

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ install_requires =  setup_requires + [
                       'matplotlib>=1.5.1',
                       'mpld3>=0.3',
                       'pillow',
-                      'h5py>=3.0.0',
+                      'h5py>=3.0.0,!=3.7.0',
                       'jinja2',
                       'Mako>=1.0.1',
                       'beautifulsoup4>=4.6.0',


### PR DESCRIPTION
As discussed in https://github.com/gwastro/pycbc/pull/4253 we want to avoid h5py 3.7.0 because of https://github.com/h5py/h5py/pull/2193 and https://github.com/h5py/h5py/issues/2189 .... Note that in the discussion there arrays of 1E5 - 1E6 are discussed. We might be closer to 1E7 - 1E8 in many cases ... and the performance impact there is extreme.

Alex, did I miss anywhere?