### PR TITLE
Add pruning to the live single trigger fits

### DIFF
--- a/bin/live/pycbc_live_single_trigger_fits
+++ b/bin/live/pycbc_live_single_trigger_fits
@@ -65,13 +65,12 @@ parser.add_argument('--prune-loudest', type=int,
                     help="Number of loudest triggers to remove from each "
                          "bin (and all triggers within --prune-window "
                          "seconds around it)")
-parser.add_argument("--prune-window", type=float, default=0.1,
+parser.add_argument("--prune-window", type=float,
                     help="Window (seconds) either side of the --prune-loudest "
-                         "loudest triggers in each duration bin to remove. "
-                         "Default=0.1s")
-parser.add_argument("--minimum-prune-stat", type=float, default=8,
+                         "loudest triggers in each duration bin to remove.")
+parser.add_argument("--prune-stat-threshold", type=float,
                     help="Minimum value of --sngl-ranking that a trigger must "
-                         "have before it is used for pruning. Default=8")
+                         "have before it is used for pruning.")
 parser.add_argument("--fit-threshold", type=float, default=5,
                     help="Lower threshold used in fitting the triggers."
                          "Default 5.")
@@ -90,6 +89,14 @@ cuts.insert_cuts_option_group(parser)
 
 #Add some input sanitisation
 args = parser.parse_args()
+
+# These options are mutually required or not needed
+prune_options = [args.prune_loudest, args.prune_window,
+                 args.prune_stat_threshold]
+
+if any(prune_options) and not all(prune_options):
+        parser.error("Require all or none of --prune-loudest, "
+                     "--prune-window and --prune-stat-threshold")
 
 pycbc.init_logging(args.verbose)
 
@@ -292,7 +299,7 @@ times_to_prune = {ifo: [] for ifo in args.ifos}
 logger = logging.getLogger()
 # Remember current logging level
 level = logger.level
-logger.setLevel(logging.WARN)
+logger.setLevel(logging.debug)
 
 for ifo in events.keys():
     # Sort the events into their bins
@@ -314,7 +321,7 @@ for ifo in events.keys():
 
             # Of these events, are any of them above the specified
             # minimum statistic value?
-            above_stat_min = binned_events[cidx] >= args.minimum_prune_stat
+            above_stat_min = binned_events[cidx] >= args.prune_stat_threshold
             cidx = cidx[above_stat_min]
 
             if args.prune_loudest > cidx.size:
@@ -336,7 +343,7 @@ if args.prune_loudest:
     logging.info("Pruning triggers %.2fs either side of the loudest %d "
                  "triggers in each bin if %s > %.2f", args.prune_window,
                  args.prune_loudest, args.sngl_ranking,
-                 args.minimum_prune_stat)
+                 args.prune_stat_threshold)
     for ifo in args.ifos:
         times = events[ifo].data['end_time'][:]
         outwith_window = np.ones_like(times, dtype=bool)

--- a/bin/live/pycbc_live_single_trigger_fits
+++ b/bin/live/pycbc_live_single_trigger_fits
@@ -318,7 +318,7 @@ for ifo in events.keys():
             cidx = cidx[above_stat_min]
 
             if args.prune_loudest > cidx.size:
-                # There are fewer triggers than the number specified,
+                # There are fewer clusters than the number specified,
                 # so prune them all
                 times_to_prune[ifo] += list(binned_event_times[cidx])
                 continue

--- a/bin/live/pycbc_live_single_trigger_fits
+++ b/bin/live/pycbc_live_single_trigger_fits
@@ -341,7 +341,7 @@ if args.prune_loudest:
         for t in times_to_prune[ifo]:
             outwith_window &= abs(times - t) > args.prune_window
             # Need to make an (ever-so-small) correction to the live time
-            live_time[ifo] -= args.prune_window
+            live_time[ifo] -= 2 * args.prune_window
 
         # Save the pruned events for reporting
         within_window = np.logical_not(outwith_window)

--- a/bin/live/pycbc_live_single_trigger_fits
+++ b/bin/live/pycbc_live_single_trigger_fits
@@ -62,8 +62,8 @@ parser.add_argument("--duration-bin-spacing",
                          "if using --duration-bin-start, --duration-bin-end "
                          "and --num-duration-bins.")
 parser.add_argument('--prune-loudest', type=int,
-                    help="[Maximum] number of loudest trigger clusters to "
-                         "remove from each bin."
+                    help="Maximum number of loudest trigger clusters to "
+                         "remove from each bin.")
 parser.add_argument("--prune-window", type=float,
                     help="Window (seconds) either side of the --prune-loudest "
                          "loudest triggers in each duration bin to remove.")

--- a/bin/live/pycbc_live_single_trigger_fits
+++ b/bin/live/pycbc_live_single_trigger_fits
@@ -285,10 +285,9 @@ counts = {i: np.zeros(n_bins, dtype=np.float32) for i in args.ifos}
 event_bins = {}
 times_to_prune = {ifo: [] for ifo in args.ifos}
 
-# Note: cluster_over_time has quite a lot of logigng, so turn
-# logging off temporarily
+# Note: turn off logging for cluster_over_time which is quite verbose
 logger = logging.getLogger()
-# Get current logging level
+# Remember current logging level
 level = logger.level
 logger.setLevel(logging.WARN)
 

--- a/bin/live/pycbc_live_single_trigger_fits
+++ b/bin/live/pycbc_live_single_trigger_fits
@@ -63,7 +63,7 @@ parser.add_argument("--duration-bin-spacing",
                          "and --num-duration-bins.")
 parser.add_argument('--prune-loudest', type=int,
                     help="[Maximum] number of loudest trigger clusters to "
-                         "remove from each bin."
+                         "remove from each bin.")
 parser.add_argument("--prune-window", type=float,
                     help="Window (seconds) either side of the --prune-loudest "
                          "loudest triggers in each duration bin to remove.")

--- a/bin/live/pycbc_live_single_trigger_fits
+++ b/bin/live/pycbc_live_single_trigger_fits
@@ -325,7 +325,7 @@ for ifo in events.keys():
 logger.setLevel(level)
 
 n_pruned = {ifo: [] for ifo in args.ifos}
-pruned_event_times = {}
+pruned_trigger_times = {}
 if args.prune_loudest:
     logging.info("Pruning triggers in a %.2fs window around the loudest %d "
                  "triggers in each bin", args.prune_window,
@@ -343,14 +343,14 @@ if args.prune_loudest:
         within_window = np.logical_not(outwith_window)
 
         # Save the pruned events for reporting
-        pruned_event_bins = event_bins[ifo][within_window]
-        pruned_event_times[ifo] = times[within_window]
+        pruned_trigger_bins = event_bins[ifo][within_window]
+        pruned_trigger_times[ifo] = times[within_window]
         # Cut events which have been pruned from the arrays we use
         events[ifo] = events[ifo].select(outwith_window)
         event_bins[ifo] = event_bins[ifo][outwith_window]
         for bin_num in range(n_bins):
             # Reporting the number of pruned triggers in each bin
-            pruned_inbin = pruned_event_bins == bin_num
+            pruned_inbin = pruned_trigger_bins == bin_num
             n_pruned_thisbin = np.count_nonzero(pruned_inbin)
             n_pruned[ifo].append(n_pruned_thisbin)
             logging.info("Pruned %d triggers from %s bin %d",
@@ -381,7 +381,7 @@ with h5py.File(args.output, 'w') as fout:
         fout[ifo].create_group('triggers')
         for key in events[ifo].data:
             fout[ifo]['triggers'][key] = events[ifo].data[key]
-        fout[ifo]['pruned_event_times'] = pruned_event_times[ifo]
+        fout[ifo]['pruned_trigger_times'] = pruned_trigger_times[ifo]
 
         fout[ifo]['fit_coeff'] = alphas[ifo]
         fout[ifo]['counts'] = counts[ifo]

--- a/bin/live/pycbc_live_single_trigger_fits
+++ b/bin/live/pycbc_live_single_trigger_fits
@@ -63,10 +63,10 @@ parser.add_argument("--duration-bin-spacing",
                          "and --num-duration-bins.")
 parser.add_argument('--prune-loudest', type=int,
                     help="Number of loudest triggers to remove from each "
-                         "bin (and all triggers within a --prune-window "
-                         "seconds window around it)")
+                         "bin (and all triggers within --prune-window "
+                         "seconds around it)")
 parser.add_argument("--prune-window", type=float, default=0.1,
-                    help="Window (seconds) around the --prune-loudest "
+                    help="Window (seconds) either side of the --prune-loudest "
                          "loudest triggers in each duration bin to remove. "
                          "Default=0.1s")
 parser.add_argument("--fit-threshold", type=float, default=5,
@@ -303,16 +303,15 @@ for ifo in events.keys():
             binned_events = events[ifo].data[args.sngl_ranking][inbin]
             binned_event_times = events[ifo].data['end_time'][inbin]
 
-            # Cluster the triggers in time (use 2x the pruning window)
+            # Cluster the triggers in time (use the pruning window)
             # to make sure we aren't just getting the same event N times
             # in different templates within the same bin
             cidx = cluster_over_time(binned_events, binned_event_times,
-                                     args.prune_window * 2)
+                                     args.prune_window)
 
-            # Deal with the case where there are fewer clustered triggers
-            # than we would prune
             if args.prune_loudest > cidx.size:
-                # Prune all triggers
+                # There are fewer triggers than the number specified,
+                # so prune them all
                 times_to_prune[ifo] += list(binned_event_times[cidx])
                 continue
 
@@ -333,20 +332,19 @@ if args.prune_loudest:
         times = events[ifo].data['end_time'][:]
         outwith_window = np.ones_like(times, dtype=bool)
         for t in times_to_prune[ifo]:
-            outwith_window &= abs(times - t) > (args.prune_window / 2.)
+            outwith_window &= abs(times - t) > args.prune_window
             # Need to make an (ever-so-small) correction to the live time
             live_time[ifo] -= args.prune_window
 
-        # want to get the indices of events within the window to
-        # help us with reporting
-        within_window = np.logical_not(outwith_window)
-
         # Save the pruned events for reporting
+        within_window = np.logical_not(outwith_window)
         pruned_trigger_bins = event_bins[ifo][within_window]
         pruned_trigger_times[ifo] = times[within_window]
+
         # Cut events which have been pruned from the arrays we use
         events[ifo] = events[ifo].select(outwith_window)
         event_bins[ifo] = event_bins[ifo][outwith_window]
+
         for bin_num in range(n_bins):
             # Reporting the number of pruned triggers in each bin
             pruned_inbin = pruned_trigger_bins == bin_num

--- a/bin/live/pycbc_live_single_trigger_fits
+++ b/bin/live/pycbc_live_single_trigger_fits
@@ -295,12 +295,6 @@ counts = {i: np.zeros(n_bins, dtype=np.float32) for i in args.ifos}
 event_bins = {}
 times_to_prune = {ifo: [] for ifo in args.ifos}
 
-# Note: turn off logging for cluster_over_time which is quite verbose
-logger = logging.getLogger()
-# Remember current logging level
-level = logger.level
-logger.setLevel(logging.debug)
-
 for ifo in events.keys():
     # Sort the events into their bins
     event_bins[ifo] = np.array([tbins[d]
@@ -333,9 +327,6 @@ for ifo in events.keys():
             # Find the loudest of the triggers in this bin
             argloudest = np.argsort(binned_events[cidx])[-args.prune_loudest:]
             times_to_prune[ifo] += list(binned_event_times[cidx][argloudest])
-
-# Turn logging back on
-logger.setLevel(level)
 
 n_pruned = {ifo: [] for ifo in args.ifos}
 pruned_trigger_times = {}

--- a/bin/live/pycbc_live_single_trigger_fits
+++ b/bin/live/pycbc_live_single_trigger_fits
@@ -18,6 +18,7 @@ from pycbc import bin_utils
 from pycbc.events import cuts, triggers, trigger_fits as trstats
 from pycbc.io import DictArray
 from pycbc.events import ranking
+from pycbc.events.coinc import cluster_over_time
 import argparse, logging, os, sys, h5py
 
 parser = argparse.ArgumentParser(usage="",
@@ -60,6 +61,14 @@ parser.add_argument("--duration-bin-spacing",
                     help="How to set spacing for bank split "
                          "if using --duration-bin-start, --duration-bin-end "
                          "and --num-duration-bins.")
+parser.add_argument('--prune-loudest', type=int,
+                    help="Number of loudest triggers to remove from each "
+                         "bin (and all triggers within a --prune-window "
+                         "seconds window around it)")
+parser.add_argument("--prune-window", type=float, default=0.1,
+                    help="Window (seconds) around the --prune-loudest "
+                         "loudest triggers in each duration bin to remove. "
+                         "Default=0.1s")
 parser.add_argument("--fit-threshold", type=float, default=5,
                     help="Lower threshold used in fitting the triggers."
                          "Default 5.")
@@ -273,30 +282,91 @@ logging.info('Sorting events into template duration bins')
 n_bins = duration_bin_edges.size - 1
 alphas = {i: np.zeros(n_bins, dtype=np.float32) for i in args.ifos}
 counts = {i: np.zeros(n_bins, dtype=np.float32) for i in args.ifos}
-binned_sngl_stats = {ifo: {} for ifo in args.ifos}
+event_bins = {}
+times_to_prune = {ifo: [] for ifo in args.ifos}
+
+# Note: cluster_over_time has quite a lot of logigng, so turn
+# logging off temporarily
+logger = logging.getLogger()
+# Get current logging level
+level = logger.level
+logger.setLevel(logging.WARN)
 
 for ifo in events.keys():
     # Sort the events into their bins
-    event_bin = np.array([tbins[d]
-                          for d in events[ifo].data['template_duration']])
+    event_bins[ifo] = np.array([tbins[d]
+                               for d in events[ifo].data['template_duration']])
 
+    if args.prune_loudest:
+        for bin_num in range(n_bins):
+            inbin = event_bins[ifo] == bin_num
+
+            binned_events = events[ifo].data[args.sngl_ranking][inbin]
+            binned_event_times = events[ifo].data['end_time'][inbin]
+            # Deal with the case where there are fewer triggers
+            # than we would prune
+            if args.prune_loudest > binned_events.size:
+                continue
+
+            # Cluster the triggers in time (use 2x the pruning window)
+            # to make sure we aren't just getting the same event N times
+            # in different templates
+            cidx = cluster_over_time(binned_events, binned_event_times,
+                                     args.prune_window * 2)
+
+            # Find the loudest of the triggers in this bin
+            argloudest = np.argsort(binned_events[cidx])[-args.prune_loudest:]
+            times_to_prune[ifo] += list(binned_event_times[cidx][argloudest])
+
+# Turn logging back on
+logger.setLevel(level)
+
+n_pruned = {ifo: [] for ifo in args.ifos}
+if args.prune_loudest:
+    logging.info("Pruning triggers in a %.2fs window around the loudest %d "
+                 "triggers in each bin", args.prune_window,
+                 args.prune_loudest)
+    for ifo in args.ifos:
+        times = events[ifo].data['end_time'][:]
+        outwith_window = np.ones_like(times, dtype=bool)
+        for t in times_to_prune[ifo]:
+            outwith_window &= abs(times - t) > (args.prune_window / 2.)
+            # Need to make an (ever-so-small) correction to the live time
+            live_time[ifo] -= args.prune_window
+
+        # want to get the indices of events within the window to
+        # help us with reporting
+        within_window = np.logical_not(outwith_window)
+
+        # Save the pruned events for reporting
+        pruned_event_bins = event_bins[ifo][within_window]
+        # Cut events which have been pruned from the arrays we use
+        events[ifo] = events[ifo].select(outwith_window)
+        event_bins[ifo] = event_bins[ifo][outwith_window]
+        for bin_num in range(n_bins):
+            # Reporting the number of pruned triggers in each bin
+            pruned_inbin = pruned_event_bins == bin_num
+            n_pruned_thisbin = np.count_nonzero(pruned_inbin)
+            n_pruned[ifo].append(n_pruned_thisbin)
+            logging.info("Pruned %d triggers from %s bin %d",
+                         n_pruned_thisbin, ifo, bin_num)
+
+for ifo in events.keys():
     # For each bin, do the fit
     for bin_num in range(n_bins):
-        inbin = event_bin == bin_num
+        inbin = event_bins[ifo] == bin_num
+
         if not np.count_nonzero(inbin):
             # No triggers, alpha and count are -1
             counts[ifo][bin_num] = -1
             alphas[ifo][bin_num] = -1
             continue
 
-        # For ease, keep the sngl_ranking values as this will be used later
-        binned_sngl_stats[ifo][bin_num] = \
-            events[ifo].data[args.sngl_ranking][inbin]
-
         counts[ifo][bin_num] = np.count_nonzero(inbin)
-        alphas[ifo][bin_num], _ = trstats.fit_above_thresh(args.fit_function,
-                                      binned_sngl_stats[ifo][bin_num],
-                                      args.fit_threshold)
+        alphas[ifo][bin_num], _ = trstats.fit_above_thresh(
+                args.fit_function,
+                events[ifo].data[args.sngl_ranking][inbin],
+                args.fit_threshold)
 
 logging.info("Writing results")
 with h5py.File(args.output, 'w') as fout:
@@ -310,6 +380,8 @@ with h5py.File(args.output, 'w') as fout:
         fout[ifo]['fit_coeff'] = alphas[ifo]
         fout[ifo]['counts'] = counts[ifo]
         fout[ifo].attrs['live_time'] = live_time[ifo]
+        fout[ifo].attrs['pruned_times'] = times_to_prune[ifo]
+        fout[ifo].attrs['n_pruned'] = n_pruned[ifo]
 
     fout['bins_upper'] = tbins.upper()
     fout['bins_lower'] = tbins.lower()

--- a/bin/live/pycbc_live_single_trigger_fits
+++ b/bin/live/pycbc_live_single_trigger_fits
@@ -335,7 +335,7 @@ if args.prune_loudest:
                  "triggers in each bin if %s > %.2f", args.prune_window,
                  args.prune_loudest, args.sngl_ranking,
                  args.prune_stat_threshold)
-    for ifo in args.ifos:
+    for ifo in events.keys():
         times = events[ifo].data['end_time'][:]
         outwith_window = np.ones_like(times, dtype=bool)
         for t in times_to_prune[ifo]:

--- a/bin/live/pycbc_live_single_trigger_fits
+++ b/bin/live/pycbc_live_single_trigger_fits
@@ -63,7 +63,7 @@ parser.add_argument("--duration-bin-spacing",
                          "and --num-duration-bins.")
 parser.add_argument('--prune-loudest', type=int,
                     help="[Maximum] number of loudest trigger clusters to "
-                         "remove from each bin.")
+                         "remove from each bin."
 parser.add_argument("--prune-window", type=float,
                     help="Window (seconds) either side of the --prune-loudest "
                          "loudest triggers in each duration bin to remove.")
@@ -86,10 +86,11 @@ parser.add_argument("--sngl-ranking", default="newsnr",
 
 cuts.insert_cuts_option_group(parser)
 
-#Add some input sanitisation
 args = parser.parse_args()
 
-# These options are mutually required or not needed
+# Check input options
+
+# Pruning options are mutually required or not needed
 prune_options = [args.prune_loudest, args.prune_window,
                  args.prune_stat_threshold]
 
@@ -97,13 +98,11 @@ if any(prune_options) and not all(prune_options):
         parser.error("Require all or none of --prune-loudest, "
                      "--prune-window and --prune-stat-threshold")
 
-pycbc.init_logging(args.verbose)
-
-# Check the bin inputs to see if they are sensible
+# Check the bin options
 if args.duration_bin_edges and (args.duration_bin_start or
                                 args.duration_bin_end or
                                 args.num_duration_bins):
-    # duration bin edges specified as well as the linear/logarithmi
+    # duration bin edges specified as well as linear/logarithmic
     parser.error("Cannot use --duration-bin-edges with "
                  "--duration-bin-start, --duration-bin-end or "
                  "--num-duration-bins.")
@@ -121,7 +120,9 @@ if args.duration_bin_end and \
                  "--duration-bin-start, got "
                  f"{args.duration_bin_end} and {args.duration_bin_start}")
 
-# Create the duration bins:
+pycbc.init_logging(args.verbose)
+
+# Create the duration bins
 if args.duration_bin_edges:
     duration_bin_edges = np.array(args.duration_bin_edges)
 elif args.duration_bin_spacing == 'log':
@@ -150,8 +151,7 @@ args.template_cuts.append(f"template_duration:{max(duration_bin_edges)}:upper_in
 args.trigger_cuts = args.trigger_cuts or []
 args.trigger_cuts.insert(0, f"snr:{args.fit_threshold}:lower_inc")
 
-# We can cut out all of the stuff with sngl-ranking
-# below threshold now as well
+# Cut triggers with sngl-ranking below threshold
 args.trigger_cuts.append(f"{args.sngl_ranking}:{args.fit_threshold}:lower_inc")
 
 logging.info("Setting up the cut dictionaries")
@@ -195,14 +195,14 @@ for filename in files:
 
     f = os.path.join(date_directory, filename)
     skipping_file = False
-    #If there is an IOerror with the file, don't fail, just carry on
+    # If there is an IOerror with the file, don't fail, just carry on
     try:
         h5py.File(f, 'r')
     except IOError:
         logging.info('IOError with file ' + f)
         continue
 
-    # Triggers for this file only:
+    # Triggers for this file
     triggers = {}
     with h5py.File(f, 'r') as fin:
         # Open the file: does it have the ifo group and snr dataset?
@@ -223,15 +223,15 @@ for filename in files:
                 continue
 
             # Read trigger value datasets from file
+            # Get all datasets with the same size as the trigger SNRs, 
+            # except for edge cases where the number of loudest, gates etc.
+            # happens to be the same as the trigger count
             triggers[ifo] = {k: fin[ifo][k][:] for k in fin[ifo].keys()
                              if k not in ('loudest', 'stat', 'gates', 'psd')
                              and fin[ifo][k].size == n_triggers}
-            # The n_triggers filter should be enough, but the 'not in'
-            # list is for edge cases where the number of gates/loudest etc is
-            # the same as the number of triggers
 
-            # The stored chisq is actually reduced chisq, so we need to
-            # alter the chisq_dof dataset so we can use the standard conversions.
+            # The stored chisq is actually reduced chisq, so hack the
+            # chisq_dof dataset to use the standard conversions.
             # chisq_dof of 1.5 gives the right number (2 * 1.5 - 2 = 1)
             triggers[ifo]['chisq_dof'] = \
                 1.5 * np.ones_like(triggers[ifo]['snr'])
@@ -243,19 +243,19 @@ for filename in files:
         keep_idx = cuts.apply_trigger_cuts(trigs_ifo, trigger_cut_dict)
 
         # triggers contains the datasets that we want to use for
-        # the template cuts, so it can be used as the template bank
-        # in this use case
+        # the template cuts, so here it can be used as the template bank
         keep_idx = cuts.apply_template_cuts(trigs_ifo, template_cut_dict,
                                             template_ids=keep_idx)
 
         # Skip if no triggers survive the cuts
-        if not keep_idx.size: continue
+        if not keep_idx.size:
+            continue
 
         # Apply the cuts
         triggers_cut = {k: trigs_ifo[k][keep_idx]
                         for k in trigs_ifo.keys()}
 
-        # Calculate the sngl_ranking value to be used in the fits
+        # Calculate the sngl_ranking values
         sngls_value = ranking.get_sngls_ranking_from_trigs(
                           triggers_cut, args.sngl_ranking)
 
@@ -265,7 +265,6 @@ for filename in files:
 
         # If we are clustering, take the max sngl_ranking value
         if args.cluster:
-            # Use sngls_ranking parameter for clustering
             max_idx = sngls_value.argmax()
             triggers_cut = triggers_da.select(max_idx)
 
@@ -284,10 +283,9 @@ for ifo in args.ifos:
         logging.info("%s: %d in %.2fs",
                      ifo, len(events[ifo]), live_time[ifo])
 
-# split the events into bins by template duration
 logging.info('Sorting events into template duration bins')
 
-# Fit the triggers within each bin
+# Set up bins and prune loud events in each bin
 n_bins = duration_bin_edges.size - 1
 alphas = {i: np.zeros(n_bins, dtype=np.float32) for i in args.ifos}
 counts = {i: np.zeros(n_bins, dtype=np.float32) for i in args.ifos}
@@ -306,14 +304,12 @@ for ifo in events.keys():
             binned_events = events[ifo].data[args.sngl_ranking][inbin]
             binned_event_times = events[ifo].data['end_time'][inbin]
 
-            # Cluster the triggers in time (use the pruning window)
-            # to make sure we aren't just getting the same event N times
-            # in different templates within the same bin
+            # Cluster triggers in time with the pruning window to ensure
+            # that clusters are independent
             cidx = cluster_over_time(binned_events, binned_event_times,
                                      args.prune_window)
 
-            # Of these events, are any of them above the specified
-            # minimum statistic value?
+            # Find clusters at/above the statistic threshold
             above_stat_min = binned_events[cidx] >= args.prune_stat_threshold
             cidx = cidx[above_stat_min]
 
@@ -347,21 +343,22 @@ if args.prune_loudest:
         pruned_trigger_bins = event_bins[ifo][within_window]
         pruned_trigger_times[ifo] = times[within_window]
 
-        # Cut events which have been pruned from the arrays we use
+        # Remove pruned events from the arrays we will fit
         events[ifo] = events[ifo].select(outwith_window)
         event_bins[ifo] = event_bins[ifo][outwith_window]
 
+        # Report the number of pruned triggers in each bin
         for bin_num in range(n_bins):
-            # Reporting the number of pruned triggers in each bin
             pruned_inbin = pruned_trigger_bins == bin_num
             n_pruned_thisbin = np.count_nonzero(pruned_inbin)
             n_pruned[ifo].append(n_pruned_thisbin)
             logging.info("Pruned %d triggers from %s bin %d",
                          n_pruned_thisbin, ifo, bin_num)
 
+# Do the fitting for each bin
 for ifo in events.keys():
-    # For each bin, do the fit
     for bin_num in range(n_bins):
+
         inbin = event_bins[ifo] == bin_num
 
         if not np.count_nonzero(inbin):

--- a/bin/live/pycbc_live_single_trigger_fits
+++ b/bin/live/pycbc_live_single_trigger_fits
@@ -306,7 +306,7 @@ for ifo in events.keys():
 
             # Cluster the triggers in time (use 2x the pruning window)
             # to make sure we aren't just getting the same event N times
-            # in different templates
+            # in different templates within the same bin
             cidx = cluster_over_time(binned_events, binned_event_times,
                                      args.prune_window * 2)
 
@@ -325,6 +325,7 @@ for ifo in events.keys():
 logger.setLevel(level)
 
 n_pruned = {ifo: [] for ifo in args.ifos}
+pruned_event_times = {}
 if args.prune_loudest:
     logging.info("Pruning triggers in a %.2fs window around the loudest %d "
                  "triggers in each bin", args.prune_window,
@@ -343,6 +344,7 @@ if args.prune_loudest:
 
         # Save the pruned events for reporting
         pruned_event_bins = event_bins[ifo][within_window]
+        pruned_event_times[ifo] = times[within_window]
         # Cut events which have been pruned from the arrays we use
         events[ifo] = events[ifo].select(outwith_window)
         event_bins[ifo] = event_bins[ifo][outwith_window]
@@ -379,6 +381,7 @@ with h5py.File(args.output, 'w') as fout:
         fout[ifo].create_group('triggers')
         for key in events[ifo].data:
             fout[ifo]['triggers'][key] = events[ifo].data[key]
+        fout[ifo]['pruned_event_times'] = pruned_event_times[ifo]
 
         fout[ifo]['fit_coeff'] = alphas[ifo]
         fout[ifo]['counts'] = counts[ifo]

--- a/bin/live/pycbc_live_single_trigger_fits
+++ b/bin/live/pycbc_live_single_trigger_fits
@@ -69,9 +69,9 @@ parser.add_argument("--prune-window", type=float, default=0.1,
                     help="Window (seconds) either side of the --prune-loudest "
                          "loudest triggers in each duration bin to remove. "
                          "Default=0.1s")
-parser.add_argument("--minimum-prune-stat", type=float, default=0,
+parser.add_argument("--minimum-prune-stat", type=float, default=8,
                     help="Minimum value of --sngl-ranking that a trigger must "
-                         "have before it is used for pruning. Default=No limit")
+                         "have before it is used for pruning. Default=8")
 parser.add_argument("--fit-threshold", type=float, default=5,
                     help="Lower threshold used in fitting the triggers."
                          "Default 5.")
@@ -333,9 +333,10 @@ logger.setLevel(level)
 n_pruned = {ifo: [] for ifo in args.ifos}
 pruned_trigger_times = {}
 if args.prune_loudest:
-    logging.info("Pruning triggers in a %.2fs window around the loudest %d "
-                 "triggers in each bin", args.prune_window,
-                 args.prune_loudest)
+    logging.info("Pruning triggers %.2fs either side of the loudest %d "
+                 "triggers in each bin if %s > %.2f", args.prune_window,
+                 args.prune_loudest, args.sngl_ranking,
+                 args.minimum_prune_stat)
     for ifo in args.ifos:
         times = events[ifo].data['end_time'][:]
         outwith_window = np.ones_like(times, dtype=bool)
@@ -386,7 +387,8 @@ with h5py.File(args.output, 'w') as fout:
         fout[ifo].create_group('triggers')
         for key in events[ifo].data:
             fout[ifo]['triggers'][key] = events[ifo].data[key]
-        fout[ifo]['pruned_trigger_times'] = pruned_trigger_times[ifo]
+        if ifo in pruned_trigger_times:
+            fout[ifo]['pruned_trigger_times'] = pruned_trigger_times[ifo]
 
         fout[ifo]['fit_coeff'] = alphas[ifo]
         fout[ifo]['counts'] = counts[ifo]

--- a/bin/live/pycbc_live_single_trigger_fits
+++ b/bin/live/pycbc_live_single_trigger_fits
@@ -69,6 +69,9 @@ parser.add_argument("--prune-window", type=float, default=0.1,
                     help="Window (seconds) either side of the --prune-loudest "
                          "loudest triggers in each duration bin to remove. "
                          "Default=0.1s")
+parser.add_argument("--minimum-prune-stat", type=float, default=0,
+                    help="Minimum value of --sngl-ranking that a trigger must "
+                         "have before it is used for pruning. Default=No limit")
 parser.add_argument("--fit-threshold", type=float, default=5,
                     help="Lower threshold used in fitting the triggers."
                          "Default 5.")
@@ -308,6 +311,11 @@ for ifo in events.keys():
             # in different templates within the same bin
             cidx = cluster_over_time(binned_events, binned_event_times,
                                      args.prune_window)
+
+            # Of these events, are any of them above the specified
+            # minimum statistic value?
+            above_stat_min = binned_events[cidx] >= args.minimum_prune_stat
+            cidx = cidx[above_stat_min]
 
             if args.prune_loudest > cidx.size:
                 # There are fewer triggers than the number specified,

--- a/bin/live/pycbc_live_single_trigger_fits
+++ b/bin/live/pycbc_live_single_trigger_fits
@@ -62,15 +62,14 @@ parser.add_argument("--duration-bin-spacing",
                          "if using --duration-bin-start, --duration-bin-end "
                          "and --num-duration-bins.")
 parser.add_argument('--prune-loudest', type=int,
-                    help="Number of loudest triggers to remove from each "
-                         "bin (and all triggers within --prune-window "
-                         "seconds around it)")
+                    help="[Maximum] number of loudest trigger clusters to "
+                         "remove from each bin."
 parser.add_argument("--prune-window", type=float,
                     help="Window (seconds) either side of the --prune-loudest "
                          "loudest triggers in each duration bin to remove.")
 parser.add_argument("--prune-stat-threshold", type=float,
-                    help="Minimum value of --sngl-ranking that a trigger must "
-                         "have before it is used for pruning.")
+                    help="Minimum --sngl-ranking value to consider a "
+                         "trigger for pruning.")
 parser.add_argument("--fit-threshold", type=float, default=5,
                     help="Lower threshold used in fitting the triggers."
                          "Default 5.")

--- a/bin/live/pycbc_live_single_trigger_fits
+++ b/bin/live/pycbc_live_single_trigger_fits
@@ -303,16 +303,19 @@ for ifo in events.keys():
 
             binned_events = events[ifo].data[args.sngl_ranking][inbin]
             binned_event_times = events[ifo].data['end_time'][inbin]
-            # Deal with the case where there are fewer triggers
-            # than we would prune
-            if args.prune_loudest > binned_events.size:
-                continue
 
             # Cluster the triggers in time (use 2x the pruning window)
             # to make sure we aren't just getting the same event N times
             # in different templates
             cidx = cluster_over_time(binned_events, binned_event_times,
                                      args.prune_window * 2)
+
+            # Deal with the case where there are fewer clustered triggers
+            # than we would prune
+            if args.prune_loudest > cidx.size:
+                # Prune all triggers
+                times_to_prune[ifo] += list(binned_event_times[cidx])
+                continue
 
             # Find the loudest of the triggers in this bin
             argloudest = np.argsort(binned_events[cidx])[-args.prune_loudest:]


### PR DESCRIPTION
I noticed that the trigger fits were being affected by loud signals in the data more than I thought they would be - e.g. the 3-6s and 6-11.5s bins here: 
![image](https://user-images.githubusercontent.com/44500294/217520937-9fff1ba1-7847-4ae9-9009-2ec1f126d20d.png)

This adds the ability to remove all triggers within a window of the loudest trigger(s) in each bin. This largely suppresses the excess triggers
![image](https://user-images.githubusercontent.com/44500294/217521015-bf18d1c0-9ca0-4aef-baaf-a7f2ef68d6d7.png)
