### PR TITLE
Move logging out of cluster_over_time function

### DIFF
--- a/bin/all_sky_search/pycbc_sngls_findtrigs
+++ b/bin/all_sky_search/pycbc_sngls_findtrigs
@@ -116,6 +116,8 @@ template_ids = cuts.apply_template_cuts(
 logging.info("%d out of %d templates kept after applying template cuts",
              len(template_ids), len(trigs.bank))
 
+logging.info('Clustering events over %s s window within each template',
+             args.cluster_window)
 for tnum in template_ids:
     tids_uncut = trigs.set_template(tnum)
 
@@ -146,7 +148,6 @@ for tnum in template_ids:
                                           **extra_kwargs)
     trigger_times = sds['end_time']
     if args.cluster_window:
-        logging.info("Clustering")
         cid = coinc.cluster_over_time(stat_t, trigger_times,
                                       args.cluster_window)
         stat_t = stat_t[cid]

--- a/bin/pycbc_process_sngls
+++ b/bin/pycbc_process_sngls
@@ -75,9 +75,10 @@ outfile = h5py.File(args.output_file, 'w')
 outgroup = outfile.create_group(args.detector)
 
 if args.cluster_window is not None:
-    logging.info('Clustering over time')
+    logging.info('Clustering events over %s s window', args.cluster_window)
     out_idx = coinc.cluster_over_time(stat, sngls.end_time,
                                       window=args.cluster_window)
+    logging.info('%d triggers remaining', len(cidx))
     outgroup['cluster_window'] = args.cluster_window
 else:
     out_idx = numpy.arange(len(sngls.end_time))

--- a/bin/pycbc_process_sngls
+++ b/bin/pycbc_process_sngls
@@ -78,7 +78,7 @@ if args.cluster_window is not None:
     logging.info('Clustering events over %s s window', args.cluster_window)
     out_idx = coinc.cluster_over_time(stat, sngls.end_time,
                                       window=args.cluster_window)
-    logging.info('%d triggers remaining', len(cidx))
+    logging.info('%d triggers remaining', len(out_idx))
     outgroup['cluster_window'] = args.cluster_window
 else:
     out_idx = numpy.arange(len(sngls.end_time))

--- a/pycbc/events/coinc.py
+++ b/pycbc/events/coinc.py
@@ -493,6 +493,8 @@ def cluster_over_time(stat, time, window, method='python',
     right = time.searchsorted(time + window)
     indices = numpy.zeros(len(left), dtype=numpy.uint32)
 
+    logging.debug('%d triggers before clustering', len(time))
+
     if method == 'cython':
         j = timecluster_cython(indices, left, right, stat, len(left))
     elif method == 'python':
@@ -531,6 +533,7 @@ def cluster_over_time(stat, time, window, method='python',
 
     indices = indices[:j]
 
+    logging.debug('%d triggers remaining', len(indices))
     return time_sorting[indices]
 
 

--- a/pycbc/events/coinc.py
+++ b/pycbc/events/coinc.py
@@ -374,7 +374,9 @@ def cluster_coincs(stat, time1, time2, timeslide_id, slide, window, **kwargs):
 
     span = (time.max() - time.min()) + window * 10
     time = time + span * tslide
+    logging.info('Clustering events over %s s window', window)
     cidx = cluster_over_time(stat, time, window, **kwargs)
+    logging.info('%d triggers remaining', len(cidx))
     return cidx
 
 
@@ -427,7 +429,9 @@ def cluster_coincs_multiifo(stat, time_coincs, timeslide_id, slide, window,
 
     span = (time_avg.max() - time_avg.min()) + window * 10
     time_avg = time_avg + span * tslide
+    logging.info('Clustering events over %s s window', window)
     cidx = cluster_over_time(stat, time_avg, window, **kwargs)
+    logging.info('%d triggers remaining', len(cidx))
 
     return cidx
 
@@ -479,7 +483,6 @@ def cluster_over_time(stat, time, window, method='python',
     cindex: numpy.ndarray
         The set of indices corresponding to the surviving coincidences.
     """
-    logging.info('Clustering events over %s s window', window)
 
     indices = []
     time_sorting = time.argsort()
@@ -528,7 +531,6 @@ def cluster_over_time(stat, time, window, method='python',
 
     indices = indices[:j]
 
-    logging.info('%d triggers remaining', len(indices))
     return time_sorting[indices]
 
 


### PR DESCRIPTION
Some codes use cluster_over_time repeatedly over many iterations, where logging is not necessarily appropriate for each clustering step, others use it in one pass-through

By moving the logging out of the function, we are able to be a bit more careful with how this is used; though I have left some logging in the function at debug level.

Any location where the function is used, I have added/altered logging.info as appropriate to keep original functionality unless it was overly verbose

(This was noted as an issue in #4259)