### PR TITLE
Change `setup.py` for 2.1.0 release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -122,8 +122,8 @@ def get_version_info():
         vinfo = _version_helper.generate_git_version_info()
     except:
         vinfo = vdummy()
-        vinfo.version = '2.0.7dev'
-        vinfo.release = 'False'
+        vinfo.version = '2.1.0'
+        vinfo.release = 'True'
 
     with open('pycbc/version.py', 'wb') as f:
         f.write("# coding: utf-8\n".encode('utf-8'))


### PR DESCRIPTION
v2.1.0 starts the release line for PyCBC Live to start O4 with.