### PR TITLE
Make pegasus 5.0.5 work

### DIFF
--- a/.github/workflows/inference-workflow.yml
+++ b/.github/workflows/inference-workflow.yml
@@ -25,7 +25,7 @@ jobs:
         wget -qO - https://download.pegasus.isi.edu/pegasus/gpg.txt | sudo apt-key add -
         echo "deb https://download.pegasus.isi.edu/pegasus/ubuntu bionic main" | sudo tee -a /etc/apt/sources.list
         sudo apt-get -o Acquire::Retries=3 update
-        sudo apt-get -o Acquire::Retries=3 install pegasus=5.0.3-1+ubuntu18
+        sudo apt-get -o Acquire::Retries=3 install pegasus
     - run: sudo apt-get -o Acquire::Retries=3 install *fftw3* intel-mkl*
     - name: Install pycbc
       run: |

--- a/.github/workflows/search-workflow.yml
+++ b/.github/workflows/search-workflow.yml
@@ -29,7 +29,7 @@ jobs:
         wget -qO - https://download.pegasus.isi.edu/pegasus/gpg.txt | sudo apt-key add -
         echo "deb https://download.pegasus.isi.edu/pegasus/ubuntu bionic main" | sudo tee -a /etc/apt/sources.list
         sudo apt-get -o Acquire::Retries=3 update
-        sudo apt-get -o Acquire::Retries=3 install pegasus=5.0.3-1+ubuntu18
+        sudo apt-get -o Acquire::Retries=3 install pegasus
     - run: sudo apt-get -o Acquire::Retries=3 install *fftw3* intel-mkl*
     - name: Install pycbc
       run: |

--- a/.github/workflows/tmpltbank-workflow.yml
+++ b/.github/workflows/tmpltbank-workflow.yml
@@ -29,7 +29,7 @@ jobs:
         wget -qO - https://download.pegasus.isi.edu/pegasus/gpg.txt | sudo apt-key add -
         echo "deb https://download.pegasus.isi.edu/pegasus/ubuntu bionic main" | sudo tee -a /etc/apt/sources.list
         sudo apt-get -o Acquire::Retries=3 update
-        sudo apt-get -o Acquire::Retries=3 install pegasus=5.0.3-1+ubuntu18
+        sudo apt-get -o Acquire::Retries=3 install pegasus
     - run: sudo apt-get -o Acquire::Retries=3 install *fftw3* intel-mkl*
     - name: Install pycbc
       run: |

--- a/.github/workflows/workflow-tests.yml
+++ b/.github/workflows/workflow-tests.yml
@@ -34,7 +34,7 @@ jobs:
         wget -qO - https://download.pegasus.isi.edu/pegasus/gpg.txt | sudo apt-key add -
         echo "deb https://download.pegasus.isi.edu/pegasus/ubuntu bionic main" | sudo tee -a /etc/apt/sources.list
         sudo apt-get -o Acquire::Retries=3 update
-        sudo apt-get -o Acquire::Retries=3 install pegasus=5.0.3-1+ubuntu18
+        sudo apt-get -o Acquire::Retries=3 install pegasus
     - run: sudo apt-get -o Acquire::Retries=3 install *fftw3* intel-mkl*
     - name: Install pycbc
       run: |

--- a/pycbc/workflow/pegasus_workflow.py
+++ b/pycbc/workflow/pegasus_workflow.py
@@ -788,6 +788,10 @@ class SubWorkflow(dax.SubWorkflow):
 
         self.add_planner_arg('pegasus.dir.storage.mapper.replica.file',
                              os.path.basename(output_map_file.name))
+        # Ensure output_map_file has the for_planning flag set. There's no
+        # API way to set this after the File is initialized, so we have to
+        # change the attribute here.
+        output_map_file.for_planning=True
         self.add_inputs(output_map_file)
 
         # I think this is needed to deal with cases where the subworkflow file

--- a/pycbc/workflow/pegasus_workflow.py
+++ b/pycbc/workflow/pegasus_workflow.py
@@ -29,6 +29,8 @@ provides additional abstraction and argument handling.
 import os
 import shutil
 import tempfile
+import subprocess
+from packaging import version
 from urllib.request import pathname2url
 from urllib.parse import urljoin, urlsplit
 import Pegasus.api as dax
@@ -791,7 +793,12 @@ class SubWorkflow(dax.SubWorkflow):
         # Ensure output_map_file has the for_planning flag set. There's no
         # API way to set this after the File is initialized, so we have to
         # change the attribute here.
-        output_map_file.for_planning=True
+        # WORSE, we only want to set this if the pegasus *planner* is version
+        # 5.0.4 or larger
+        sproc_out = subprocess.check_output(['pegasus-version']).strip()
+        sproc_out = sproc_out.decode()
+        if version.parse(sproc_out) > version.parse('5.0.4'):
+            output_map_file.for_planning=True
         self.add_inputs(output_map_file)
 
         # I think this is needed to deal with cases where the subworkflow file

--- a/pycbc/workflow/pegasus_workflow.py
+++ b/pycbc/workflow/pegasus_workflow.py
@@ -797,7 +797,7 @@ class SubWorkflow(dax.SubWorkflow):
         # 5.0.4 or larger
         sproc_out = subprocess.check_output(['pegasus-version']).strip()
         sproc_out = sproc_out.decode()
-        if version.parse(sproc_out) > version.parse('5.0.4'):
+        if version.parse(sproc_out) >= version.parse('5.0.4'):
             output_map_file.for_planning=True
         self.add_inputs(output_map_file)
 


### PR DESCRIPTION
With Karan's help, I think we've now identified the [backwards incompatible] change in pegasus 5.0.5 that's causing us problems. I make the change here. The change itself is trivial, but I was worried about the backwards incompatibility, so I added a check to not make the change on older pegasus versions. (Note that the pegasus *executables* should be >= 5.0.4 for this to be important, not the pegasus API).

I haven't yet tested this with the 5.0.3 executables, but want to run the larger tests here.