### PR TITLE
Truncate SNR/FAR for live pastro calcs

### DIFF
--- a/pycbc/population/live_pastro.py
+++ b/pycbc/population/live_pastro.py
@@ -31,6 +31,27 @@ def check_template_param_bin_data(spec_json):
     return spec_json
 
 
+def check_template_param_bin_farlim_data(spec_json):
+    """
+    Parameters
+    ----------
+    spec_json: JSON dictionary-like object
+        Result of parsing json file containing static data
+
+    Returns
+    -------
+    spec_json: dictionary
+    """
+    # Standard template param bin checks
+    check_template_param_bin_data(spec_json)
+
+    # In addition, need limiting FAR and SNR values
+    assert 'limit_far' in spec_json
+    assert 'limit_snr' in spec_json
+
+    return spec_json
+
+
 def read_template_bank_param(spec_d, bankf):
     """
     Parameters
@@ -206,7 +227,7 @@ def template_param_bin_types_pa(padata, trdata, horizons):
     else:
         expfac = padata.spec['bg_fac']
 
-    # Ifos over trigger threshold
+    # List of ifos over trigger threshold
     tr_ifos = trdata['triggered']
 
     # FAR is in Hz, therefore convert to rate per year (per SNR)
@@ -238,6 +259,29 @@ def template_param_bin_types_pa(padata, trdata, horizons):
     return p_astro, 1 - p_astro
 
 
+def template_param_bin_types_farlim_pa(padata, trdata, horizons):
+    """
+    Parameters
+    ----------
+    padata: PAstroData instance
+        Static information on p astro calculation
+    trdata: dictionary
+        Trigger properties
+    horizons: dictionary
+        BNS horizon distances keyed on ifo
+
+    Returns
+    -------
+    p_astro, p_terr: tuple of floats
+    """
+    # If the network SNR and FAR indicate saturation of the FAR estimate,
+    # set them to specified fixed values
+    trdata = padata.apply_significance_limits(trdata)
+
+    # Now perform standard calculation with event types
+    return template_param_bin_types_pa(padata, trdata, horizons)
+
+
 __all__ = [
     "check_template_param_bin_data",
     "read_template_bank_param",
@@ -247,4 +291,5 @@ __all__ = [
     "signal_rate_trig_type",
     "template_param_bin_pa",
     "template_param_bin_types_pa",
+    "template_param_bin_types_farlim_pa",
 ]

--- a/pycbc/population/live_pastro_utils.py
+++ b/pycbc/population/live_pastro_utils.py
@@ -27,18 +27,23 @@ def insert_live_pastro_option_group(parser):
 
 # Choices of p astro calc method
 _check_spec = {
-      'template_param_bins': livepa.check_template_param_bin_data,
-      'template_param_bins_types': livepa.check_template_param_bin_data
+    'template_param_bins': livepa.check_template_param_bin_data,
+    'template_param_bins_types': livepa.check_template_param_bin_data,
+    'template_param_bins_types_farlim': \
+        livepa.check_template_param_bin_farlim_data
 }
 
 _read_bank = {
-      'template_param_bins': livepa.read_template_bank_param,
-      'template_param_bins_types': livepa.read_template_bank_param
+    'template_param_bins': livepa.read_template_bank_param,
+    'template_param_bins_types': livepa.read_template_bank_param,
+    'template_param_bins_types_farlim': livepa.read_template_bank_param
 }
 
 _do_calc = {
-      'template_param_bins': livepa.template_param_bin_pa,
-      'template_param_bins_types': livepa.template_param_bin_types_pa
+    'template_param_bins': livepa.template_param_bin_pa,
+    'template_param_bins_types': livepa.template_param_bin_types_pa,
+    'template_param_bins_types_farlim': \
+        livepa.template_param_bin_types_farlim_pa
 }
 
 
@@ -70,6 +75,22 @@ class PAstroData():
             logging.info('Setting up p_astro data with method %s', self.method)
             self.spec = _check_spec[self.method](self.spec_json)
             self.bank = _read_bank[self.method](self.spec, bank)
+
+    def apply_significance_limits(self, trigger_data):
+        # If the network SNR and FAR indicate saturation of the FAR estimate,
+        # set them to the fixed values given in the specification.
+        # This only happens for double or triple events
+        if len(trigger_data['triggered']) > 1:
+            snrlim = self.spec['limit_snr']
+            farlim = self.spec['limit_far']
+            if trigger_data['far'] < farlim and \
+                    trigger_data['network_snr'] > snrlim:
+                logging.debug('Truncating FAR and SNR from %f, %f to %f, %f',
+                    trigger_data['far'], trigger_data['network_snr'],
+                    farlim, snrlim)
+                trigger_data['network_snr'] = snrlim
+                trigger_data['far'] = farlim
+        return trigger_data
 
     def do_pastro_calc(self, trigger_data, horizons):
         """ No-op, or call the despatch dictionary to evaluate p_astro """

--- a/pycbc/population/live_pastro_utils.py
+++ b/pycbc/population/live_pastro_utils.py
@@ -82,17 +82,25 @@ class PAstroData():
         set them to the fixed values given in the specification.
         """
         # This only happens for double or triple events
-        if len(trigger_data['triggered']) > 1:
+        if len(trigger_data['triggered']) == 1:
+            return trigger_data
+        
+        elif len(trigger_data['triggered']) > 1:
             farlim = self.spec['limit_far']
             snrlim = self.spec['limit_snr']
-            if trigger_data['far'] < farlim and \
-                    trigger_data['network_snr'] > snrlim:
-                logging.debug('Truncating FAR and SNR from %f, %f to %f, %f',
-                              trigger_data['far'], trigger_data['network_snr'],
-                              farlim, snrlim)
-                trigger_data['network_snr'] = snrlim
-                trigger_data['far'] = farlim
-        return trigger_data
+            # Only do anything if FAR and SNR are beyond given limits
+            if trigger_data['far'] > farlim or \
+                    trigger_data['network_snr'] < snrlim:
+                return trigger_data
+
+            logging.debug('Truncating FAR and SNR from %f, %f to %f, %f',
+                           trigger_data['far'], trigger_data['network_snr'],
+                          farlim, snrlim)
+            trigger_data['network_snr'] = snrlim
+            trigger_data['far'] = farlim
+            return trigger_data
+
+            raise RuntimeError('Number of triggered ifos must be >0 !')
 
     def do_pastro_calc(self, trigger_data, horizons):
         """ No-op, or call the despatch dictionary to evaluate p_astro """

--- a/pycbc/population/live_pastro_utils.py
+++ b/pycbc/population/live_pastro_utils.py
@@ -29,7 +29,7 @@ def insert_live_pastro_option_group(parser):
 _check_spec = {
     'template_param_bins': livepa.check_template_param_bin_data,
     'template_param_bins_types': livepa.check_template_param_bin_data,
-    'template_param_bins_types_farlim': \
+    'template_param_bins_types_farlim':
         livepa.check_template_param_bin_farlim_data
 }
 
@@ -42,7 +42,7 @@ _read_bank = {
 _do_calc = {
     'template_param_bins': livepa.template_param_bin_pa,
     'template_param_bins_types': livepa.template_param_bin_types_pa,
-    'template_param_bins_types_farlim': \
+    'template_param_bins_types_farlim':
         livepa.template_param_bin_types_farlim_pa
 }
 
@@ -77,17 +77,19 @@ class PAstroData():
             self.bank = _read_bank[self.method](self.spec, bank)
 
     def apply_significance_limits(self, trigger_data):
-        # If the network SNR and FAR indicate saturation of the FAR estimate,
-        # set them to the fixed values given in the specification.
+        """
+        If the network SNR and FAR indicate saturation of the FAR estimate,
+        set them to the fixed values given in the specification.
+        """
         # This only happens for double or triple events
         if len(trigger_data['triggered']) > 1:
-            snrlim = self.spec['limit_snr']
             farlim = self.spec['limit_far']
+            snrlim = self.spec['limit_snr']
             if trigger_data['far'] < farlim and \
                     trigger_data['network_snr'] > snrlim:
                 logging.debug('Truncating FAR and SNR from %f, %f to %f, %f',
-                    trigger_data['far'], trigger_data['network_snr'],
-                    farlim, snrlim)
+                              trigger_data['far'], trigger_data['network_snr'],
+                              farlim, snrlim)
                 trigger_data['network_snr'] = snrlim
                 trigger_data['far'] = farlim
         return trigger_data

--- a/pycbc/population/live_pastro_utils.py
+++ b/pycbc/population/live_pastro_utils.py
@@ -84,8 +84,8 @@ class PAstroData():
         # This only happens for double or triple events
         if len(trigger_data['triggered']) == 1:
             return trigger_data
-        
-        elif len(trigger_data['triggered']) > 1:
+
+        if len(trigger_data['triggered']) > 1:
             farlim = self.spec['limit_far']
             snrlim = self.spec['limit_snr']
             # Only do anything if FAR and SNR are beyond given limits
@@ -94,13 +94,13 @@ class PAstroData():
                 return trigger_data
 
             logging.debug('Truncating FAR and SNR from %f, %f to %f, %f',
-                           trigger_data['far'], trigger_data['network_snr'],
+                          trigger_data['far'], trigger_data['network_snr'],
                           farlim, snrlim)
             trigger_data['network_snr'] = snrlim
             trigger_data['far'] = farlim
             return trigger_data
 
-            raise RuntimeError('Number of triggered ifos must be >0 !')
+        raise RuntimeError('Number of triggered ifos must be >0 !')
 
     def do_pastro_calc(self, trigger_data, horizons):
         """ No-op, or call the despatch dictionary to evaluate p_astro """


### PR DESCRIPTION
This will require changes / additional info in the .json config file for the live p astro calculation, eg 
```
"method": "template_param_bins_types_farlim",
...
"limit_snr": 12.0,
"limit_far": 3.17e-10
```
for a limiting FAR of (just over) 1/100yr and SNR of 12.  