### PR TITLE
Enable tutorial tests for Python 3.11

### DIFF
--- a/.github/workflows/tut-test.yml
+++ b/.github/workflows/tut-test.yml
@@ -13,7 +13,7 @@ jobs:
       max-parallel: 60
       matrix:
         os: [ubuntu-20.04]
-        python-version: [3.7, 3.8, 3.9, '3.10']
+        python-version: [3.7, 3.8, 3.9, '3.10', '3.11']
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
Apparently we overlooked the tutorial tests in #4243.