### PR TITLE
Flag cases when PyCBC Live's IFAR and/or followup p-values are saturated

### DIFF
--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -245,7 +245,7 @@ class LiveEventManager(object):
             triggers[f'foreground/{ifo}/{name}'] = triggers[key]
 
         # Set the detector-specific fields for which we have data
-        snr_series_peak = snr_series.at_time(
+        snr_series_peak = pvalue_info['snr_series'].at_time(
             pvalue_info['peak_time'],
             nearest_sample=True
         )

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -188,20 +188,26 @@ class LiveEventManager(object):
             if snr_series is not None:
                 out[ifo] = {'snr_series': snr_series}
 
-        # Determine if the other ifos can contribute to the coincident event
+        # Determine if the other ifos can contribute to the coincident event,
+        # if so then update the info in `triggers` appropriately
         for ifo in followup_ifos:
-            snr_series, ptime, pvalue, sigma2 = followup_event_significance(
+            pvalue_info = followup_event_significance(
                 ifo,
                 self.data_readers[ifo],
                 self.bank,
                 template_id,
                 coinc_times
             )
-            if snr_series is not None:
-                out[ifo] = {'snr_series': snr_series}
-                self.get_followup_info(ifos[0], ifo, triggers, snr_series,
-                                       ptime, pvalue, sigma2,
-                                       recalculate_ifar=recalculate_ifar)
+            if pvalue_info is None:
+                continue
+            out[ifo] = {'snr_series': pvalue_info['snr_series']}
+            self.get_followup_info(
+                ifos[0],
+                ifo,
+                triggers,
+                pvalue_info,
+                recalculate_ifar=recalculate_ifar
+            )
 
         # the SNR time series sample rate can vary slightly due to
         # rounding errors, so force all of them to be identical
@@ -216,31 +222,47 @@ class LiveEventManager(object):
 
         return out
 
-    def get_followup_info(self, coinc_ifo, ifo, triggers, snr_series, ptime,
-                          pvalue, sigma2, recalculate_ifar=False):
-        # Copy the common fields from the other detector
+    def get_followup_info(
+        self,
+        coinc_ifo,
+        ifo,
+        triggers,
+        pvalue_info,
+        recalculate_ifar=False
+    ):
+        # Copy the common fields from the other detector;
         # ignore fields that contain detector-specific data
-        fields_to_ignore = set(['end_time', 'snr', 'stat', 'coa_phase',
-                                'chisq', 'chisq_dof', 'sg_chisq', 'sigmasq'])
+        fields_to_ignore = set([
+            'end_time', 'snr', 'stat', 'coa_phase',
+            'chisq', 'chisq_dof', 'sg_chisq', 'sigmasq'
+        ])
         for key in set(triggers):
-            if 'foreground/{}/'.format(coinc_ifo) in key:
-                _, _, name = key.split('/')
-                if name in fields_to_ignore:
-                    continue
-                triggers['foreground/{}/{}'.format(ifo, name)] = triggers[key]
+            if f'foreground/{coinc_ifo}/' not in key:
+                continue
+            _, _, name = key.split('/')
+            if name in fields_to_ignore:
+                continue
+            triggers[f'foreground/{ifo}/{name}'] = triggers[key]
 
         # Set the detector-specific fields for which we have data
-        snr_series_peak = snr_series.at_time(ptime, nearest_sample=True)
-        base = 'foreground/{}/'.format(ifo)
-        triggers[base + 'end_time'] = float(ptime)
+        snr_series_peak = snr_series.at_time(
+            pvalue_info['peak_time'],
+            nearest_sample=True
+        )
+        base = f'foreground/{ifo}/'
+        triggers[base + 'end_time'] = float(pvalue_info['peak_time'])
         triggers[base + 'snr'] = triggers[base + 'stat'] = abs(snr_series_peak)
         triggers[base + 'coa_phase'] = numpy.angle(snr_series_peak)
-        triggers[base + 'sigmasq'] = sigma2
+        triggers[base + 'sigmasq'] = pvalue_info['sigma2']
         if recalculate_ifar:
             # Calculate new ifar
             triggers['foreground/ifar'] = combine_ifar_pvalue(
-                    triggers['foreground/ifar'], pvalue, self.pvalue_livetime)
-            triggers['foreground/pvalue_{}'.format(ifo)] = pvalue
+                triggers['foreground/ifar'],
+                pvalue_info['pvalue'],
+                self.pvalue_livetime
+            )
+            triggers[f'foreground/pvalue_{ifo}'] = pvalue_info['pvalue']
+            triggers[f'foreground/pvalue_{ifo}_saturated'] = pvalue_info['pvalue_saturated']
 
     def setup_optimize_snr(
         self, results, live_ifos, triggering_ifos, fname, gid

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -230,6 +230,10 @@ class LiveEventManager(object):
         pvalue_info,
         recalculate_ifar=False
     ):
+        peak_time = pvalue_info['peak_time']
+        pv = pvalue_info['pvalue']
+        pv_sat = pvalue_info['pvalue_saturated']
+
         # Copy the common fields from the other detector;
         # ignore fields that contain detector-specific data
         fields_to_ignore = set([
@@ -246,11 +250,11 @@ class LiveEventManager(object):
 
         # Set the detector-specific fields for which we have data
         snr_series_peak = pvalue_info['snr_series'].at_time(
-            pvalue_info['peak_time'],
+            peak_time,
             nearest_sample=True
         )
         base = f'foreground/{ifo}/'
-        triggers[base + 'end_time'] = float(pvalue_info['peak_time'])
+        triggers[base + 'end_time'] = float(peak_time)
         triggers[base + 'snr'] = triggers[base + 'stat'] = abs(snr_series_peak)
         triggers[base + 'coa_phase'] = numpy.angle(snr_series_peak)
         triggers[base + 'sigmasq'] = pvalue_info['sigma2']
@@ -258,11 +262,12 @@ class LiveEventManager(object):
             # Calculate new ifar
             triggers['foreground/ifar'] = combine_ifar_pvalue(
                 triggers['foreground/ifar'],
-                pvalue_info['pvalue'],
+                pv,
                 self.pvalue_livetime
             )
-            triggers[f'foreground/pvalue_{ifo}'] = pvalue_info['pvalue']
-            triggers[f'foreground/pvalue_{ifo}_saturated'] = pvalue_info['pvalue_saturated']
+            triggers['foreground/ifar_saturated'] |= pv_sat
+            triggers[f'foreground/pvalue_{ifo}'] = pv
+            triggers[f'foreground/pvalue_{ifo}_saturated'] = pv_sat
 
     def setup_optimize_snr(
         self, results, live_ifos, triggering_ifos, fname, gid

--- a/pycbc/events/coinc.py
+++ b/pycbc/events/coinc.py
@@ -997,10 +997,25 @@ class LiveCoincTimeslideBackgroundEstimator(object):
         return pickle.load(filename)
 
     def ifar(self, coinc_stat):
-        """Return the far that would be associated with the coincident given.
+        """Map a given value of the coincident ranking statistic to an inverse
+        false-alarm rate (IFAR) using the interally stored background sample.
+
+        Parameters
+        ----------
+        coinc_stat: float
+            Value of the coincident ranking statistic to be converted.
+
+        Returns
+        -------
+        ifar: float
+            Inverse false-alarm rate in unit of years.
+        ifar_saturated: bool
+            True if `coinc_stat` is larger than all the available background,
+            in which case `ifar` is to be considered an upper limit.
         """
         n = self.coincs.num_greater(coinc_stat)
-        return self.background_time / lal.YRJUL_SI / (n + 1)
+        ifar = self.background_time / lal.YRJUL_SI / (n + 1)
+        return ifar, n == 0
 
     def set_singles_buffer(self, results):
         """Create the singles buffer
@@ -1254,21 +1269,22 @@ class LiveCoincTimeslideBackgroundEstimator(object):
         coinc_results = {}
         # Save information about zerolag triggers
         if num_zerolag > 0:
-            zerolag_results = {}
             idx = cidx[zerolag_idx][0]
             zerolag_cstat = cstat[cidx][zerolag_idx]
-            zerolag_results['foreground/ifar'] = self.ifar(zerolag_cstat)
-            zerolag_results['foreground/stat'] = zerolag_cstat
+            ifar, ifar_sat = self.ifar(zerolag_cstat)
+            zerolag_results = {
+                'foreground/ifar': ifar,
+                'foreground/ifar_saturated': ifar_sat,
+                'foreground/stat': zerolag_cstat,
+                'foreground/type': '-'.join(self.ifos)
+            }
             template = template_ids[idx]
             for ifo in self.ifos:
                 trig_id = trigger_ids[ifo][idx]
                 single_data = self.singles[ifo].data(template)[trig_id]
                 for key in single_data.dtype.names:
-                    path = 'foreground/%s/%s' % (ifo, key)
+                    path = f'foreground/{ifo}/{key}'
                     zerolag_results[path] = single_data[key]
-
-            zerolag_results['foreground/type'] = '-'.join(self.ifos)
-
             coinc_results.update(zerolag_results)
 
         # Save some summary statistics about the background


### PR DESCRIPTION
Loud signals in PyCBC Live can saturate the 2-coincident IFAR and potentially saturate the p-value calculated for a followup detector, in the sense that the on-source SNR is louder than every off-source SNR. It would be useful to report this situation downstream, an immediate example being the P(astro) calculation. So this PR adds a flag that detects this occurrence and propagates the information downstream along with the IFAR and p-value themselves.

Note that most of the change is actually just code refactoring/cleanup and docstrings.

@ahnitz let me know if you think there is a better way to do this.