### PR TITLE
Fix an issue of pycbc_page_injtable

### DIFF
--- a/pycbc/results/table_utils.py
+++ b/pycbc/results/table_utils.py
@@ -83,7 +83,7 @@ def html_table(columns, names, page_size=None, format_strings=None):
 
     column_descriptions = []
     for column, name in zip(columns, names):
-        if column.dtype.kind == 'S':
+        if column.dtype.kind == 'S' or column.dtype.kind == 'U':
             ctype = 'string'
         else:
             ctype = 'number'


### PR DESCRIPTION
The table generated by `pycbc_page_injtable` for found injections can't be displayed. I think it's due to an issue of formatting inconsistency. 

See for example [this line](https://github.com/gwastro/pycbc/blob/master/bin/plotting/pycbc_page_injtable#L49), we store numbers between quotation marks. Later it's converted to a numpy array, the data type is unicode not string (see the following). However `pycbc.results.table_utils.html_table` will assign 'string' to ctype for a string type numpy array and assign 'number' for all else formats. I think this causes an issue. The ctype in the google table template should be 'string' for those numbers in quotation marks otherwise the page can't be displayed.

Some codes for illustration

> In [1]: import numpy as np
> 
> In [2]: a = ['123']
> 
> In [3]: b = np.array(a)
> 
> In [4]: b
> Out[4]: array(['123'], dtype='<U3')
> 
> In [5]: b.dtype.kind
> Out[5]: 'U'