### PR TITLE
Make autogating work for the PyCBC Live early-warning search

### DIFF
--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -785,7 +785,7 @@ parser.add_argument('--autogating-taper', type=float, metavar='SECONDS',
                     help='Taper the strain before and after '
                          'each gating window over a duration '
                          'of SECONDS.')
-parser.add_arugment('--autogating-duration', type=float, default=16,
+parser.add_argument('--autogating-duration', type=float, default=16,
                     metavar='SECONDS',
                     help='Amount of data in seconds to apply autogating on.')
 parser.add_argument('--autogating-psd-segment-length', type=float, default=2,

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -785,6 +785,14 @@ parser.add_argument('--autogating-taper', type=float, metavar='SECONDS',
                     help='Taper the strain before and after '
                          'each gating window over a duration '
                          'of SECONDS.')
+parser.add_argument('--autogating-psd-duration', type=int, default=2,
+                    metavar='SECONDS',
+                    help='Length in seconds of each segment used to estimate the PSD
+                    with Welchs method and median averaging')
+parser.add_argument('--autogating-psd-stride', type=int, default=1,
+                    metavar='SECONDS',
+                    help='Length in seconds of the overlap between each segment used
+                    to estimate the PSD with Welchs method and median averaging')
 
 parser.add_argument('--sync', action='store_true',
                     help="Imposes an MPI synchronization at each transfer of"

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -787,12 +787,12 @@ parser.add_argument('--autogating-taper', type=float, metavar='SECONDS',
                          'of SECONDS.')
 parser.add_argument('--autogating-psd-duration', type=int, default=2,
                     metavar='SECONDS',
-                    help='Length in seconds of each segment used to estimate the PSD
-                    with Welchs method and median averaging')
+                    help='Length in seconds of each segment used to estimate the PSD '
+                    'with Welchs method and median averaging.')
 parser.add_argument('--autogating-psd-stride', type=int, default=1,
                     metavar='SECONDS',
-                    help='Length in seconds of the overlap between each segment used
-                    to estimate the PSD with Welchs method and median averaging')
+                    help='Length in seconds of the overlap between each segment used '
+                    'to estimate the PSD with Welchs method and median averaging.')
 
 parser.add_argument('--sync', action='store_true',
                     help="Imposes an MPI synchronization at each transfer of"

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -785,7 +785,10 @@ parser.add_argument('--autogating-taper', type=float, metavar='SECONDS',
                     help='Taper the strain before and after '
                          'each gating window over a duration '
                          'of SECONDS.')
-parser.add_argument('--autogating-psd-duration', type=float, default=2,
+parser.add_arugment('--autogating-duration', type=float, default=16,
+                    metavar='SECONDS',
+                    help='Amount of data in seconds to apply autogating on.')
+parser.add_argument('--autogating-psd-segment-length', type=float, default=2,
                     metavar='SECONDS',
                     help='Length in seconds of each segment used to estimate the PSD '
                     'with Welchs method and median averaging.')

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -785,11 +785,11 @@ parser.add_argument('--autogating-taper', type=float, metavar='SECONDS',
                     help='Taper the strain before and after '
                          'each gating window over a duration '
                          'of SECONDS.')
-parser.add_argument('--autogating-psd-duration', type=int, default=2,
+parser.add_argument('--autogating-psd-duration', type=float, default=2,
                     metavar='SECONDS',
                     help='Length in seconds of each segment used to estimate the PSD '
                     'with Welchs method and median averaging.')
-parser.add_argument('--autogating-psd-stride', type=int, default=1,
+parser.add_argument('--autogating-psd-stride', type=float, default=1,
                     metavar='SECONDS',
                     help='Length in seconds of the overlap between each segment used '
                     'to estimate the PSD with Welchs method and median averaging.')

--- a/pycbc/strain/strain.py
+++ b/pycbc/strain/strain.py
@@ -1492,6 +1492,10 @@ class StrainBuffer(pycbc.frame.DataBuffer):
             Half-duration of the zeroed-out portion of autogates.
         autogating_taper: float, Optional
             Duration of taper on either side of the gating window in seconds.
+        autogating_psd_duration: float, Optional
+            The length in seconds of each segment used to estimate the PSD with Welch's method.
+        autogating_psd_stride: float, Optional
+            The overlap in seconds between each segment used to estimate the PSD with Welch's method.
         state_channel: {str, None}, Optional
             Channel to use for state information about the strain
         data_quality_channel: {str, None}, Optional

--- a/pycbc/strain/strain.py
+++ b/pycbc/strain/strain.py
@@ -1435,6 +1435,8 @@ class StrainBuffer(pycbc.frame.DataBuffer):
                  autogating_pad=None,
                  autogating_width=None,
                  autogating_taper=None,
+                 autogating_psd_duration=None,
+                 autogating_psd_stride=None,
                  state_channel=None,
                  data_quality_channel=None,
                  idq_channel=None,
@@ -1597,6 +1599,8 @@ class StrainBuffer(pycbc.frame.DataBuffer):
         self.autogating_pad = autogating_pad
         self.autogating_width = autogating_width
         self.autogating_taper = autogating_taper
+        self.autogating_psd_duration = autogating_psd_duration
+        self.autogating_psd_stride = autogating_psd_stride
         self.gate_params = []
 
         self.sample_rate = sample_rate

--- a/pycbc/strain/strain.py
+++ b/pycbc/strain/strain.py
@@ -1901,7 +1901,7 @@ class StrainBuffer(pycbc.frame.DataBuffer):
         self.strain[len(self.strain) - csize + self.corruption:] = strain[:]
         self.strain.start_time += blocksize
 
-        # apply gating on the last 16 s of the buffer if needed
+        # apply gating if needed
         if self.autogating_threshold is not None:
             autogating_duration_length = self.autogating_duration * self.sample_rate
             autogating_start_sample = int(len(self.strain) - autogating_duration_length)

--- a/pycbc/strain/strain.py
+++ b/pycbc/strain/strain.py
@@ -170,8 +170,6 @@ def detect_loud_glitches(strain, psd_duration=4., psd_stride=2.,
     times = [idx * strain.delta_t + strain.start_time \
              for idx in indices[cluster_idx]]
 
-    print("detect loud glitches strain duration = {} s".format(strain.duration))
-
     return times
 
 def from_cli(opt, dyn_range_fac=1, precision='single',
@@ -1902,7 +1900,7 @@ class StrainBuffer(pycbc.frame.DataBuffer):
         # apply gating if needed
         if self.autogating_threshold is not None:
             glitch_times = detect_loud_glitches(
-                    strain[autogating_start_sample:-self.corruption],
+                    self.strain[autogating_start_sample:-self.corruption],
                     psd_duration=self.autogating_psd_duration, psd_stride=self.autogating_psd_stride,
                     threshold=self.autogating_threshold,
                     cluster_window=self.autogating_cluster,

--- a/pycbc/strain/strain.py
+++ b/pycbc/strain/strain.py
@@ -1979,7 +1979,7 @@ class StrainBuffer(pycbc.frame.DataBuffer):
                    autogating_pad=args.autogating_pad,
                    autogating_width=args.autogating_width,
                    autogating_taper=args.autogating_taper,
-                   autogating_duration=args.autogating_duration
+                   autogating_duration=args.autogating_duration,
                    autogating_psd_segment_length=args.autogating_psd_segment_length,
                    autogating_psd_stride=args.autogating_psd_stride,
                    psd_abort_difference=args.psd_abort_difference,


### PR DESCRIPTION
Autogating is currently used for the PyCBC Live full-bandwidth search, but it does not immediately work for the early-warning search due to the short amount of data available (1 s only).

We found that by applying autogating to the last 16 s of the internal strain circular buffer, insted of the new analysis chunk only, autogating works fairly well for the early-warning search too, without an apparent impact on latency (although we need to test this more). One reason for the effectiveness of this approach is that many O3 glitches are composed of a few short glitches in rapid succession, for a total duration of 1 s or longer. Such glitches are hard to gate properly using just 1 s of data, even when trying to use really short gates. Instead, by applying autogating to the last 16 s of the buffer, we effectively apply the same iterative autogating as used by the offline search in O3. This pull request implements this change.

This also adds two command-line arguments to `pycbc_live`: `--autogating-psd-duration` and `--autogating-psd-stride`. These are respectively the length in seconds of each segment used to estimate the PSD with Welch's method, and the overlap in seconds between each segment. Both values were previously hardcoded.