### PR TITLE
Proposed fix for 4270

### DIFF
--- a/pycbc/events/coinc.py
+++ b/pycbc/events/coinc.py
@@ -1234,7 +1234,7 @@ class LiveCoincTimeslideBackgroundEstimator(object):
             logging.info("Clustering %s coincs", ppdets(self.ifos, "-"))
             cidx = cluster_coincs(cstat, ctime0, ctime1, offsets,
                                   self.timeslide_interval,
-                                  self.analysis_block,
+                                  self.analysis_block + 2*self.time_window,
                                   method='cython')
             offsets = offsets[cidx]
             zerolag_idx = (offsets == 0)


### PR DESCRIPTION
I think this implements what Alex suggests for #4270. I've also gone over how the code works here, and think that this is the correct solution (and is fair in that time-slides are treated the same as zero-lag as far as I can see).

I think that this should work with only `1*time_window`, but as we basically want the window to be "large enough that we only ever get 1 coinc in each time slide", and the safety window (https://github.com/gwastro/pycbc/blob/77e26d62994e253d3ae70937de6f0b6c5ec589b9/pycbc/events/coinc.py#L375) https://github.com/gwastro/pycbc/blob/master/pycbc/events/coinc.py#L375 is the full coinc_window *times 10* so I'd rather be safe and go to `2*time_window` to avoid any edge-edge cases.

This is not tested at all.