### PR TITLE
Set a minimal verson of BBHx

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -53,7 +53,7 @@ commands = bash tools/pycbc_test_suite.sh
 deps =
     {[base]deps}
     ; Needed for `BBHx` package to work with PyCBC
-    git+https://github.com/mikekatz04/BBHx.git; sys_platform == 'linux'
+    git+https://github.com/mikekatz04/BBHx.git#1.0.5; sys_platform == 'linux'
     git+https://github.com/ConWea/BBHX-waveform-model.git; sys_platform == 'linux'
 conda_deps=
     mysqlclient

--- a/tox.ini
+++ b/tox.ini
@@ -53,7 +53,7 @@ commands = bash tools/pycbc_test_suite.sh
 deps =
     {[base]deps}
     ; Needed for `BBHx` package to work with PyCBC
-    git+https://github.com/mikekatz04/BBHx.git@>=1.0.5; sys_platform == 'linux'
+    git+https://github.com/mikekatz04/BBHx.git@">=1.0.5"; sys_platform == 'linux'
     git+https://github.com/ConWea/BBHX-waveform-model.git; sys_platform == 'linux'
 conda_deps=
     mysqlclient

--- a/tox.ini
+++ b/tox.ini
@@ -53,7 +53,7 @@ commands = bash tools/pycbc_test_suite.sh
 deps =
     {[base]deps}
     ; Needed for `BBHx` package to work with PyCBC
-    git+https://github.com/mikekatz04/BBHx.git@">=1.0.5"; sys_platform == 'linux'
+    git+https://github.com/mikekatz04/BBHx.git@latest; sys_platform == 'linux'
     git+https://github.com/ConWea/BBHX-waveform-model.git; sys_platform == 'linux'
 conda_deps=
     mysqlclient

--- a/tox.ini
+++ b/tox.ini
@@ -53,7 +53,7 @@ commands = bash tools/pycbc_test_suite.sh
 deps =
     {[base]deps}
     ; Needed for `BBHx` package to work with PyCBC
-    git+https://github.com/mikekatz04/BBHx.git; sys_platform == 'linux'
+    git+https://github.com/mikekatz04/BBHx.git>=1.0.5; sys_platform == 'linux'
     git+https://github.com/ConWea/BBHX-waveform-model.git; sys_platform == 'linux'
 conda_deps=
     mysqlclient

--- a/tox.ini
+++ b/tox.ini
@@ -53,7 +53,7 @@ commands = bash tools/pycbc_test_suite.sh
 deps =
     {[base]deps}
     ; Needed for `BBHx` package to work with PyCBC
-    git+https://github.com/mikekatz04/BBHx.git@latest; sys_platform == 'linux'
+    git+https://github.com/mikekatz04/BBHx.git; sys_platform == 'linux'
     git+https://github.com/ConWea/BBHX-waveform-model.git; sys_platform == 'linux'
 conda_deps=
     mysqlclient

--- a/tox.ini
+++ b/tox.ini
@@ -53,7 +53,7 @@ commands = bash tools/pycbc_test_suite.sh
 deps =
     {[base]deps}
     ; Needed for `BBHx` package to work with PyCBC
-    git+https://github.com/mikekatz04/BBHx.git#>=1.0.5; sys_platform == 'linux'
+    git+https://github.com/mikekatz04/BBHx.git@>=1.0.5; sys_platform == 'linux'
     git+https://github.com/ConWea/BBHX-waveform-model.git; sys_platform == 'linux'
 conda_deps=
     mysqlclient

--- a/tox.ini
+++ b/tox.ini
@@ -53,7 +53,7 @@ commands = bash tools/pycbc_test_suite.sh
 deps =
     {[base]deps}
     ; Needed for `BBHx` package to work with PyCBC
-    git+https://github.com/mikekatz04/BBHx.git#1.0.5; sys_platform == 'linux'
+    git+https://github.com/mikekatz04/BBHx.git#>=1.0.5; sys_platform == 'linux'
     git+https://github.com/ConWea/BBHX-waveform-model.git; sys_platform == 'linux'
 conda_deps=
     mysqlclient


### PR DESCRIPTION
@ahnitz This PR uses a fixed version number for BBHx, so any changes in its main branch will not affect PyCBC build tests. I contacted Katz, and he released a new release (v1.0.5) for PyCBC https://github.com/mikekatz04/BBHx/releases/tag/v1.0.5