### PR TITLE
Modify HasMassGap to be optional and customizable

### DIFF
--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -122,7 +122,6 @@ class LiveEventManager(object):
                 self.fu_cores = 1
 
         if args.enable_embright_has_massgap:
-            # check if HasMassGap is enabled and set mass gap max limit
             if args.embright_massgap_max < self.mc_area_args['mass_bdary']['ns_max']:
                 parser.error('MAX_GAP value cannot be lower than MAX_NS limit')
             self.mc_area_args['embright_mg_max'] = args.embright_massgap_max
@@ -894,7 +893,9 @@ parser.add_argument('--snr-opt-label', type=str, default='SNR_OPTIMIZED',
 
 
 parser.add_argument('--enable-embright-has-massgap', action='store_true', default=False,
-                    help='Estimate HasMassGap probability for EMBright info.')
+                    help='Estimate HasMassGap probability for EMBright info. Lower limit '
+                         'of the mass gap is equal to the maximum NS mass used for '
+                         'the source classification.')
 parser.add_argument('--embright-massgap-max', type=float, default=5.0, metavar='SOLAR MASSES',
                     help='Upper limit of the mass gap, used for estimating '
                          'HasMassGap probability.')

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -121,6 +121,12 @@ class LiveEventManager(object):
                                 available_cores)
                 self.fu_cores = 1
 
+        if args.enable_embright_has_massgap:
+            # check if HasMassGap is enabled and set mass gap max limit
+            if args.embright_massgap_max < self.mc_area_args['mass_bdary']['ns_max']:
+                parser.error('MAX_GAP value cannot be lower than MAX_NS limit')
+            self.mc_area_args['embright_mg_max'] = args.embright_massgap_max
+
     def commit_results(self, results):
         logging.info('Committing triggers')
         self.comm.gather(results, root=0)
@@ -886,6 +892,12 @@ parser.add_argument('--snr-opt-timeout', type=int, default=400, metavar='SECONDS
 parser.add_argument('--snr-opt-label', type=str, default='SNR_OPTIMIZED',
                     help='Label to apply to snr-optimized GraceDB uploads')
 
+
+parser.add_argument('--enable-embright-has-massgap', action='store_true', default=False,
+                    help='Estimate HasMassGap probability for EMBright info.')
+parser.add_argument('--embright-massgap-max', type=float, default=5.0, metavar='SOLAR MASSES',
+                    help='Upper limit of the mass gap, used for estimating '
+                         'HasMassGap probability.')
 
 scheme.insert_processing_option_group(parser)
 LiveSingle.insert_args(parser)

--- a/pycbc/io/live.py
+++ b/pycbc/io/live.py
@@ -261,6 +261,8 @@ class CandidateForGraceDB(object):
             self.p_astro, self.p_terr = None, None
 
         # Source probabilities and hasmassgap estimation
+        self.probabilities = None
+        self.hasmassgap = None
         if 'mc_area_args' in kwargs:
             eff_distances = [sngl.eff_distance for sngl in sngl_inspiral_table]
             self.probabilities = calc_probabilities(coinc_inspiral_row.mchirp,
@@ -268,20 +270,15 @@ class CandidateForGraceDB(object):
                                                     min(eff_distances),
                                                     kwargs['mc_area_args'])
             if 'embright_mg_max' in kwargs['mc_area_args']:
-                kwargs['hasmg_args'] = copy.deepcopy(kwargs['mc_area_args'])
-                kwargs['hasmg_args']['mass_gap'] = True
-                kwargs['hasmg_args']['mass_bdary']['gap_max'] = \
+                hasmg_args = copy.deepcopy(kwargs['mc_area_args'])
+                hasmg_args['mass_gap'] = True
+                hasmg_args['mass_bdary']['gap_max'] = \
                     kwargs['mc_area_args']['embright_mg_max']
                 self.hasmassgap = calc_probabilities(
                                       coinc_inspiral_row.mchirp,
                                       coinc_inspiral_row.snr,
                                       min(eff_distances),
-                                      kwargs['hasmg_args'])['Mass Gap']
-            else:
-                self.hasmassgap = None
-        else:
-            self.probabilities = None
-            self.hasmassgap = None
+                                      hasmg_args)['Mass Gap']
 
         # Combine p astro and source probs
         if self.p_astro is not None and self.probabilities is not None:

--- a/pycbc/io/live.py
+++ b/pycbc/io/live.py
@@ -267,15 +267,17 @@ class CandidateForGraceDB(object):
                                                     coinc_inspiral_row.snr,
                                                     min(eff_distances),
                                                     kwargs['mc_area_args'])
-            kwargs['hasmassgap_args'] = copy.deepcopy(kwargs['mc_area_args'])
-            kwargs['hasmassgap_args']['mass_gap'] = True
-            kwargs['hasmassgap_args']['mass_bdary']['ns_max'] = 3.0
-            kwargs['hasmassgap_args']['mass_bdary']['gap_max'] = 5.0
-            self.hasmassgap = calc_probabilities(
-                                  coinc_inspiral_row.mchirp,
-                                  coinc_inspiral_row.snr,
-                                  min(eff_distances),
-                                  kwargs['hasmassgap_args'])['Mass Gap']
+            if 'embright_mg_max' in kwargs['mc_area_args']:
+                kwargs['hasmassgap_args'] = copy.deepcopy(kwargs['mc_area_args'])
+                kwargs['hasmassgap_args']['mass_gap'] = True
+                kwargs['hasmassgap_args']['mass_bdary']['gap_max'] = kwargs['mc_area_args']['embright_mg_max']
+                self.hasmassgap = calc_probabilities(
+                                      coinc_inspiral_row.mchirp,
+                                      coinc_inspiral_row.snr,
+                                      min(eff_distances),
+                                      kwargs['hasmassgap_args'])['Mass Gap']
+            else:
+                self.hasmassgap = None
         else:
             self.probabilities = None
             self.hasmassgap = None

--- a/pycbc/io/live.py
+++ b/pycbc/io/live.py
@@ -268,14 +268,15 @@ class CandidateForGraceDB(object):
                                                     min(eff_distances),
                                                     kwargs['mc_area_args'])
             if 'embright_mg_max' in kwargs['mc_area_args']:
-                kwargs['hasmassgap_args'] = copy.deepcopy(kwargs['mc_area_args'])
-                kwargs['hasmassgap_args']['mass_gap'] = True
-                kwargs['hasmassgap_args']['mass_bdary']['gap_max'] = kwargs['mc_area_args']['embright_mg_max']
+                kwargs['hasmg_args'] = copy.deepcopy(kwargs['mc_area_args'])
+                kwargs['hasmg_args']['mass_gap'] = True
+                kwargs['hasmg_args']['mass_bdary']['gap_max'] = \
+                    kwargs['mc_area_args']['embright_mg_max']
                 self.hasmassgap = calc_probabilities(
                                       coinc_inspiral_row.mchirp,
                                       coinc_inspiral_row.snr,
                                       min(eff_distances),
-                                      kwargs['hasmassgap_args'])['Mass Gap']
+                                      kwargs['hasmg_args'])['Mass Gap']
             else:
                 self.hasmassgap = None
         else:


### PR DESCRIPTION
Proposal of code changes to make the HasMassGap estimation optional (`--enable-embright-has-massgap`) and controllable (`--embright-massgap-max`). I think these options should be in the `pycbc_live` module since this calculation is different to the source classification. 

In case we do not want the mass gap max limit argument to be in `pycbc_live` it can be in `mchirp_area` as `--src-class-mass-gap-max`, but we would need a `--src-class-enable-mass-gap` set to False so the source classification is done without the MG category. 

I can also work in a `src_class_arguments.ini` file as the `p_astro` one.

PR related to the #4300 issue.