### PR TITLE
Allow precomputation of antenna factors for sky marginalization

### DIFF
--- a/pycbc/inference/models/relbin.py
+++ b/pycbc/inference/models/relbin.py
@@ -777,7 +777,7 @@ class RelativeTimeDom(RelativeTime):
         self.snr_draw(snrs)
 
         for ifo in self.sh:
-            if self.precalc_antenna_factors is not None:  
+            if self.precalc_antenna_factors:  
                 fp, fc, dt = self.get_precalc_antenna_factors(ifo)  
             else:
                 dt = self.det[ifo].time_delay_from_earth_center(p['ra'], 
@@ -785,13 +785,15 @@ class RelativeTimeDom(RelativeTime):
                                                                 p['tc'])
                 fp, fc = self.det[ifo].antenna_pattern(p['ra'], p['dec'],
                                                        0, p['tc'])
-                                                       
+            #print(fp, fc, dt, self.precalc_antenna_factors)                             
             dts = p['tc'] + dt
             f = (fp + 1.0j * fc) * pol_phase
 
             # Note, this includes complex conjugation already
             # as our stored inner products were hp* x data
             htf = (f.real * ip + 1.0j * f.imag * ic)
+            
+            #print(dts, self.sh[ifo].start_time, self.sh[ifo].end_time)
             sh = self.sh[ifo].at_time(dts, interpolate='quadratic')
             sh_total += sh * htf
             hh_total += self.hh[ifo] * abs(htf) ** 2.0

--- a/pycbc/inference/models/relbin.py
+++ b/pycbc/inference/models/relbin.py
@@ -422,7 +422,7 @@ class Relative(DistMarg, BaseGaussianNoise):
             hc = hc.numpy()
             wfs.append((hp, hc))
         wf_ret = {ifo: wfs[self.ifo_map[ifo]] for ifo in self.data}
-        
+
         self.wf_ret = wf_ret
         return wf_ret
 
@@ -777,15 +777,15 @@ class RelativeTimeDom(RelativeTime):
         self.snr_draw(snrs)
 
         for ifo in self.sh:
-            if self.precalc_antenna_factors:  
-                fp, fc, dt = self.get_precalc_antenna_factors(ifo)  
+            if self.precalc_antenna_factors:
+                fp, fc, dt = self.get_precalc_antenna_factors(ifo)
             else:
-                dt = self.det[ifo].time_delay_from_earth_center(p['ra'], 
+                dt = self.det[ifo].time_delay_from_earth_center(p['ra'],
                                                                 p['dec'],
                                                                 p['tc'])
                 fp, fc = self.det[ifo].antenna_pattern(p['ra'], p['dec'],
                                                        0, p['tc'])
-                           
+
             dts = p['tc'] + dt
             f = (fp + 1.0j * fc) * pol_phase
 

--- a/pycbc/inference/models/relbin.py
+++ b/pycbc/inference/models/relbin.py
@@ -785,15 +785,14 @@ class RelativeTimeDom(RelativeTime):
                                                                 p['tc'])
                 fp, fc = self.det[ifo].antenna_pattern(p['ra'], p['dec'],
                                                        0, p['tc'])
-            #print(fp, fc, dt, self.precalc_antenna_factors)                             
+                           
             dts = p['tc'] + dt
             f = (fp + 1.0j * fc) * pol_phase
 
             # Note, this includes complex conjugation already
             # as our stored inner products were hp* x data
             htf = (f.real * ip + 1.0j * f.imag * ic)
-            
-            #print(dts, self.sh[ifo].start_time, self.sh[ifo].end_time)
+
             sh = self.sh[ifo].at_time(dts, interpolate='quadratic')
             sh_total += sh * htf
             hh_total += self.hh[ifo] * abs(htf) ** 2.0

--- a/pycbc/inference/models/relbin.py
+++ b/pycbc/inference/models/relbin.py
@@ -422,6 +422,8 @@ class Relative(DistMarg, BaseGaussianNoise):
             hc = hc.numpy()
             wfs.append((hp, hc))
         wf_ret = {ifo: wfs[self.ifo_map[ifo]] for ifo in self.data}
+        
+        self.wf_ret = wf_ret
         return wf_ret
 
     @property
@@ -775,12 +777,16 @@ class RelativeTimeDom(RelativeTime):
         self.snr_draw(snrs)
 
         for ifo in self.sh:
-            dt = self.det[ifo].time_delay_from_earth_center(p['ra'], p['dec'],
-                                                            p['tc'])
+            if self.precalc_antenna_factors is not None:  
+                fp, fc, dt = self.get_precalc_antenna_factors(ifo)  
+            else:
+                dt = self.det[ifo].time_delay_from_earth_center(p['ra'], 
+                                                                p['dec'],
+                                                                p['tc'])
+                fp, fc = self.det[ifo].antenna_pattern(p['ra'], p['dec'],
+                                                       0, p['tc'])
+                                                       
             dts = p['tc'] + dt
-
-            fp, fc = self.det[ifo].antenna_pattern(p['ra'], p['dec'],
-                                                   0, p['tc'])
             f = (fp + 1.0j * fc) * pol_phase
 
             # Note, this includes complex conjugation already

--- a/pycbc/inference/models/tools.py
+++ b/pycbc/inference/models/tools.py
@@ -120,6 +120,7 @@ class DistMarg():
         self.reconstruct_phase = False
         self.reconstruct_distance = False
         self.reconstruct_vector = False
+        self.precalc_antennna_factors = False
 
         # Handle any requested parameter vector / brute force marginalizations
         self.marginalize_vector_params = {}
@@ -403,7 +404,7 @@ class DistMarg():
             dec = self.marginalized_vector_priors['dec'].rvs(size=size)['dec']
             tcmin, tcmax = self.marginalized_vector_priors['tc'].bounds['tc']
             tcave = (tcmax + tcmin) / 2.0
-            d = {ifo: Detector(ifo, reference_time=tcave) for ifo in ifos}
+            d = {ifo: Detector(ifo, reference_time=tcave) for ifo in self.data}
 
             # What data structure to hold times? Dict of offset -> list?
             logging.info('sorting into time delay dict')
@@ -414,18 +415,21 @@ class DistMarg():
                 dt = numpy.rint(dt / snrs[ifos[0]].delta_t)
                 dts.append(dt)
 
-            dtc = d[ifos[0]].time_delay_from_earth_center(ra, dec, tcave)
-
+            fp, fc, dtc = {}, {}, {}
+            for ifo in self.data:
+                fp[ifo], fc[ifo] = d[ifo].antenna_pattern(ra, dec, 0.0, tcave)  
+                dtc[ifo] = d[ifo].time_delay_from_earth_center(ra, dec, tcave)  
+    
             dmap = {}
             for i, t in enumerate(tqdm.tqdm(zip(*dts))):
-                v = ra[i], dec[i], dtc[i]
                 if t not in dmap:
                     dmap[t] = []
-                dmap[t].append(v)
+                dmap[t].append(i)
 
             if len(ifos) == 1:
-                dmap[()] = list(zip(ra, dec, dtc))
-            return ifos, dmap, tcmin, tcmax
+                dmap[()] = numpy.arange(0, size, 1).astype(int)
+                
+            return dmap, tcmin, tcmax, fp, fc, ra, dec, dtc
 
         if not hasattr(self, 'tinfo'):
             self.tinfo = {}
@@ -433,7 +437,8 @@ class DistMarg():
         if ikey not in self.tinfo:
             self.tinfo[ikey] = make_init()
 
-        ifos, dmap, tcmin, tcmax = self.tinfo[ikey]
+        dmap, tcmin, tcmax, fp, fc, ra, dec, dtc = self.tinfo[ikey]
+        self.antenna_factors = None
 
         # draw times from each snr time series
         # Is it worth doing this if some detector has low SNR?
@@ -470,20 +475,15 @@ class DistMarg():
             idx.append(i)
 
         # check if delay is in dict, if not, throw out
-        ra = []
-        dec = []
-        dtc = []
         ti = []
+        ix = []
         wi = []
         rand = numpy.random.uniform(0, 1, size=self.vsamples)
         for i in range(self.vsamples):
             t = tuple(x[i] for x in dx)
             if t in dmap:
                 randi = int(rand[i] * (len(dmap[t])))
-                xra, xdec, xdtc = dmap[t][randi]
-                ra.append(xra)
-                dec.append(xdec)
-                dtc.append(xdtc)
+                ix.append(dmap[t][randi])
                 wi.append(len(dmap[t]))
                 ti.append(i)
 
@@ -494,10 +494,14 @@ class DistMarg():
 
         # fill back to fixed size with repeat samples
         # sample order is random, so this should be OK statistically
+        ix = numpy.resize(numpy.array(ix, dtype=int), self.vsamples)   
+        self.sample_idx = ix
+        self.precalc_antenna_factors = fp, fc, dtc
+          
+        ra = ra[ix]
+        dec = dec[ix]
+        dtc = {ifo: dtc[ifo][ix] for ifo in dtc}     
 
-        ra = numpy.resize(numpy.array(ra), self.vsamples)
-        dec = numpy.resize(numpy.array(dec), self.vsamples)
-        dtc = numpy.resize(numpy.array(dtc), self.vsamples)
         ti = numpy.resize(numpy.array(ti, dtype=int), self.vsamples)
         wi = numpy.resize(numpy.array(wi), self.vsamples)
 
@@ -506,17 +510,24 @@ class DistMarg():
                                    snr.delta_t / 2.0,
                                    size=len(ti))
 
-        tc = tct + iref[ti] * snr.delta_t + float(sref.start_time) - dtc
+        tc = tct + iref[ti] * snr.delta_t + float(sref.start_time) - dtc[ifos[0]]
 
         # Update the current proposed times and the marginalization values
         self.marginalize_vector_params['tc'] = tc
         self.marginalize_vector_params['ra'] = ra
         self.marginalize_vector_params['dec'] = dec
+        
         self._current_params.update(self.marginalize_vector_params)
 
         # Update the importance weights for each vector sample
         logw = self.marginalize_vector_weights + mcweight[ti] + numpy.log(wi)
         self.marginalize_vector_weights = logw - logsumexp(logw)
+
+    def get_precalc_antenna_factors(self, ifo):
+        """ Get the antenna factors for marginalized samples if they exist """
+        ix = self.sample_idx
+        fp, fc, dtc = self.precalc_antenna_factors
+        return fp[ifo][ix], fc[ifo][ix], dtc[ifo][ix]   
 
     def setup_peak_lock(self,
                         sample_rate=4096,

--- a/pycbc/inference/models/tools.py
+++ b/pycbc/inference/models/tools.py
@@ -285,7 +285,6 @@ class DistMarg():
         series of each detector
         """
         p = self.current_params
-        self.precalc_antenna_factors = None
 
         if (not numpy.isscalar(p['tc']) and
             'tc' in self.marginalized_vector_priors and
@@ -300,6 +299,7 @@ class DistMarg():
         else:
             # OK, we couldn't do anything with the requested monte-carlo
             # marginalizations.
+            self.precalc_antenna_factors = None
             pass
 
     def draw_times(self, snrs):

--- a/pycbc/inference/models/tools.py
+++ b/pycbc/inference/models/tools.py
@@ -285,6 +285,7 @@ class DistMarg():
         series of each detector
         """
         p = self.current_params
+        self.precalc_antenna_factors = None
 
         if (not numpy.isscalar(p['tc']) and
             'tc' in self.marginalized_vector_priors and
@@ -438,7 +439,6 @@ class DistMarg():
             self.tinfo[ikey] = make_init()
 
         dmap, tcmin, tcmax, fp, fc, ra, dec, dtc = self.tinfo[ikey]
-        self.antenna_factors = None
 
         # draw times from each snr time series
         # Is it worth doing this if some detector has low SNR?

--- a/pycbc/inference/models/tools.py
+++ b/pycbc/inference/models/tools.py
@@ -418,9 +418,9 @@ class DistMarg():
 
             fp, fc, dtc = {}, {}, {}
             for ifo in self.data:
-                fp[ifo], fc[ifo] = d[ifo].antenna_pattern(ra, dec, 0.0, tcave)  
-                dtc[ifo] = d[ifo].time_delay_from_earth_center(ra, dec, tcave)  
-    
+                fp[ifo], fc[ifo] = d[ifo].antenna_pattern(ra, dec, 0.0, tcave)
+                dtc[ifo] = d[ifo].time_delay_from_earth_center(ra, dec, tcave)
+
             dmap = {}
             for i, t in enumerate(tqdm.tqdm(zip(*dts))):
                 if t not in dmap:
@@ -429,7 +429,7 @@ class DistMarg():
 
             if len(ifos) == 1:
                 dmap[()] = numpy.arange(0, size, 1).astype(int)
-                
+
             return dmap, tcmin, tcmax, fp, fc, ra, dec, dtc
 
         if not hasattr(self, 'tinfo'):
@@ -494,13 +494,13 @@ class DistMarg():
 
         # fill back to fixed size with repeat samples
         # sample order is random, so this should be OK statistically
-        ix = numpy.resize(numpy.array(ix, dtype=int), self.vsamples)   
+        ix = numpy.resize(numpy.array(ix, dtype=int), self.vsamples)
         self.sample_idx = ix
         self.precalc_antenna_factors = fp, fc, dtc
-          
+
         ra = ra[ix]
         dec = dec[ix]
-        dtc = {ifo: dtc[ifo][ix] for ifo in dtc}     
+        dtc = {ifo: dtc[ifo][ix] for ifo in dtc}
 
         ti = numpy.resize(numpy.array(ti, dtype=int), self.vsamples)
         wi = numpy.resize(numpy.array(wi), self.vsamples)
@@ -516,7 +516,7 @@ class DistMarg():
         self.marginalize_vector_params['tc'] = tc
         self.marginalize_vector_params['ra'] = ra
         self.marginalize_vector_params['dec'] = dec
-        
+
         self._current_params.update(self.marginalize_vector_params)
 
         # Update the importance weights for each vector sample
@@ -527,7 +527,7 @@ class DistMarg():
         """ Get the antenna factors for marginalized samples if they exist """
         ix = self.sample_idx
         fp, fc, dtc = self.precalc_antenna_factors
-        return fp[ifo][ix], fc[ifo][ix], dtc[ifo][ix]   
+        return fp[ifo][ix], fc[ifo][ix], dtc[ifo][ix]
 
     def setup_peak_lock(self,
                         sample_rate=4096,

--- a/pycbc/inference/models/tools.py
+++ b/pycbc/inference/models/tools.py
@@ -49,7 +49,7 @@ def draw_sample(loglr, size=None):
 
 
 class DistMarg():
-    """Help class to add bookkeeping for distance marginalization"""
+    """Help class to add bookkeeping for likelihood marginalization"""
 
     marginalize_phase = None
     distance_marginalization = None
@@ -66,6 +66,7 @@ class DistMarg():
                               marginalize_distance_density=None,
                               marginalize_vector_params=None,
                               marginalize_vector_samples=1e3,
+                              marginalize_sky_initial_samples=1e6,
                               **kwargs):
         """ Setup the model for use with distance marginalization
 
@@ -124,6 +125,9 @@ class DistMarg():
         self.marginalize_vector_params = {}
         self.marginalized_vector_priors = {}
         self.vsamples = int(marginalize_vector_samples)
+
+        self.marginalize_sky_initial_samples = \
+            int(float(marginalize_sky_initial_samples))
 
         for param in str_to_tuple(marginalize_vector_params, str):
             logging.info('Marginalizing over %s, %s points from prior',
@@ -393,8 +397,8 @@ class DistMarg():
 
         def make_init():
             logging.info('pregenerating sky pointings')
-            size = int(1e6)
-            logging.info('drawing samples')
+            size = self.marginalize_sky_initial_samples
+            logging.info('drawing samples: %s', size)
             ra = self.marginalized_vector_priors['ra'].rvs(size=size)['ra']
             dec = self.marginalized_vector_priors['dec'].rvs(size=size)['dec']
             tcmin, tcmax = self.marginalized_vector_priors['tc'].bounds['tc']


### PR DESCRIPTION
This somewhat simplifies the sky marginalization code and adds the option to precompute antenna factors. Likelihood functions have to access them if they want to use that, so  no changes are needed if they can't (or won't) do so. This has a 20-30% performance improvement as the antenna factor calculations were somewhat dominant. 

Depends on #4310 