### PR TITLE
Make reference and proposal waveforms comparable, add function to test breakdown of piece-wise apx

### DIFF
--- a/pycbc/inference/models/relbin.py
+++ b/pycbc/inference/models/relbin.py
@@ -633,7 +633,7 @@ class RelativeTime(Relative):
             self._ref_snr = self.get_snr(wfs, reference=True)
         return self._ref_snr
 
-    def get_snr(self, wfs, reference=False):
+    def get_snr(self, wfs):
         """ Return hp/hc maximized SNR time series
         """
         delta_t = 1.0 / self.sample_rate
@@ -710,7 +710,7 @@ class RelativeTimeDom(RelativeTime):
     """
     name = "relative_time_dom"
 
-    def get_snr(self, wfs, reference=False):
+    def get_snr(self, wfs):
         """ Return hp/hc maximized SNR time series
         """
         delta_t = 1.0 / self.sample_rate

--- a/pycbc/inference/models/relbin.py
+++ b/pycbc/inference/models/relbin.py
@@ -239,7 +239,8 @@ class Relative(DistMarg, BaseGaussianNoise):
             else:
                 fid_hp, fid_hc = get_fd_waveform_sequence(sample_points=fpoints,
                                                           **self.fid_params)
-                # Apply detector response if not handled by the waveform generator
+                # Apply detector response if not handled by 
+                # the waveform generator
                 self.det[ifo] = Detector(ifo)
                 dt = self.det[ifo].time_delay_from_earth_center(
                     self.fid_params["ra"],

--- a/pycbc/inference/models/relbin.py
+++ b/pycbc/inference/models/relbin.py
@@ -557,6 +557,17 @@ class Relative(DistMarg, BaseGaussianNoise):
         for p, v in self.fid_params.items():
             attrs["{}_ref".format(p)] = v
 
+    def max_curvature_from_reference(self):
+        """ Return the maximum change in slope between frequency bins
+        relative to the reference waveform.
+        """
+        dmax = 0
+        for ifo in self.data:
+            r = self.wf_ret[ifo][0] / self.h00_sparse[ifo]
+            d = abs(numpy.diff(r / abs(r).min(), n=2)).max()
+            dmax = d if dmax < d else dmax
+        return dmax
+
     @staticmethod
     def extra_args_from_config(cp, section, skip_args=None, dtypes=None):
         """Adds reading fiducial waveform parameters from config file."""

--- a/pycbc/inference/models/relbin.py
+++ b/pycbc/inference/models/relbin.py
@@ -187,8 +187,8 @@ class Relative(DistMarg, BaseGaussianNoise):
             variable_params, data, low_frequency_cutoff, **kwargs
         )
 
-        # If the waveform handles the detector response internally, set
-        # self.det_response = True
+        # If the waveform needs us to apply the detector response,
+        # set flag to true (most cases for ground-based observatories).
         self.still_needs_det_response = False
         if self.static_params['approximant'] in fd_det_sequence:
             self.still_needs_det_response = True

--- a/pycbc/inference/models/relbin.py
+++ b/pycbc/inference/models/relbin.py
@@ -239,7 +239,7 @@ class Relative(DistMarg, BaseGaussianNoise):
             else:
                 fid_hp, fid_hc = get_fd_waveform_sequence(sample_points=fpoints,
                                                           **self.fid_params)
-                # Apply detector response if not handled by 
+                # Apply detector response if not handled by
                 # the waveform generator
                 self.det[ifo] = Detector(ifo)
                 dt = self.det[ifo].time_delay_from_earth_center(
@@ -278,7 +278,7 @@ class Relative(DistMarg, BaseGaussianNoise):
 
             # We'll apply this to the data, in lieu of the ref waveform
             # This makes it easier to compare target signal to reference later
-            tshift = numpy.exp(-2.0j * numpy.pi * self.f[ifo] * self.ta[ifo])            
+            tshift = numpy.exp(-2.0j * numpy.pi * self.f[ifo] * self.ta[ifo])
             self.h00[ifo] = numpy.array(curr_wav) # * tshift
             data = self.data[ifo] * numpy.conjugate(tshift)
 
@@ -291,7 +291,7 @@ class Relative(DistMarg, BaseGaussianNoise):
 
             self.fedges[ifo] = self.f[ifo][fbin_ind]
             self.edges[ifo] = fbin_ind
-            
+
             self.init_from_frequencies(data, self.h00, fbin_ind, ifo)
             self.antenna_time[ifo] = self.setup_antenna(earth_rotation,
                                                         self.fedges[ifo])

--- a/pycbc/inference/models/relbin.py
+++ b/pycbc/inference/models/relbin.py
@@ -630,7 +630,7 @@ class RelativeTime(Relative):
         if not hasattr(self, '_ref_snr'):
             wfs = {ifo: (self.h00_sparse[ifo],
                          self.h00_sparse[ifo]) for ifo in self.h00_sparse}
-            self._ref_snr = self.get_snr(wfs, reference=True)
+            self._ref_snr = self.get_snr(wfs)
         return self._ref_snr
 
     def get_snr(self, wfs):


### PR DESCRIPTION


This changes the time reference so that the reference and proposed signals in heterodyne likelihoods can be more easily compared on the fly. I also add a function to return the maximum second order relative difference. This is and indication of potential breakdown in the piece-wise linear approximation. This will hopefully make it easier to put together some diagnostics to check (or possibly refine on the fly) frequency bin choices. 

