### PR TITLE
more physical rwrap for LISA SMBHB/SOBHB injection

### DIFF
--- a/companion.txt
+++ b/companion.txt
@@ -8,9 +8,6 @@ healpy
 ligo-gracedb>=2.10.0
 ligo.skymap
 
-# Needed for ringdown
-pykerr
-
 # auxiliary samplers
 epsie>=1.0
 cpnest

--- a/companion.txt
+++ b/companion.txt
@@ -18,6 +18,9 @@ https://github.com/willvousden/ptemcee/archive/master.tar.gz
 # useful to look at PyCBC Live with htop
 setproctitle
 
+# Needed for ringdown and time-domain injection (fix wrap-around issue for SMBHB)
+pykerr
+
 # Needed for `population_models` module
 sympy>=1.9
 

--- a/companion.txt
+++ b/companion.txt
@@ -18,9 +18,6 @@ https://github.com/willvousden/ptemcee/archive/master.tar.gz
 # useful to look at PyCBC Live with htop
 setproctitle
 
-# Needed for ringdown and time-domain injection (fix wrap-around issue for SMBHB)
-pykerr
-
 # Needed for `population_models` module
 sympy>=1.9
 

--- a/pycbc/waveform/waveform.py
+++ b/pycbc/waveform/waveform.py
@@ -775,8 +775,8 @@ def _base_get_td_waveform_from_fd(template=None, rwrap=0.2, **params):
         full_duration = get_waveform_filter_length_in_time(**nparams)
         nparams['f_lower'] *= 0.99
         if 't_obs_start' in nparams and \
-            full_duration >= nparams['t_obs_start']:
-                break
+           full_duration >= nparams['t_obs_start']:
+            break
 
     if 'f_ref' not in nparams:
         nparams['f_ref'] = params['f_lower']

--- a/pycbc/waveform/waveform.py
+++ b/pycbc/waveform/waveform.py
@@ -762,7 +762,7 @@ def _base_get_td_waveform_from_fd(template=None, rwrap=0.2, **params):
     m_final, spin_final = get_final_from_initial(
         mass1=nparams['mass1'], mass2=nparams['mass2'],
         spin1z=nparams['spin1z'], spin2z=nparams['spin2z'])
-    t_damping = tau_from_final_mass_spin(m_final, spin_final) * 8
+    t_damping = tau_from_final_mass_spin(m_final, spin_final) * 10
 
     if rwrap < t_damping:
         rwrap = t_damping

--- a/pycbc/waveform/waveform.py
+++ b/pycbc/waveform/waveform.py
@@ -36,6 +36,7 @@ from pycbc.fft import fft
 from pycbc import pnutils, libutils
 from pycbc.waveform import utils as wfutils
 from pycbc.waveform import parameters
+from pycbc.conversions import get_final_from_initial, tau_from_final_mass_spin
 from pycbc.filter import interpolate_complex_frequency, resample_to_delta_t
 import pycbc
 from .spa_tmplt import spa_tmplt, spa_tmplt_norm, spa_tmplt_end, \
@@ -733,8 +734,8 @@ def get_fd_det_waveform(template=None, **kwargs):
         domain. Keys are requested data channels, values are FrequencySeries.
     """
     input_params = props(template, **kwargs)
-    input_params['delta_f'] = -1
-    input_params['f_lower'] = -1
+    if 'f_lower' not in input_params:
+        input_params['f_lower'] = -1
     if input_params['approximant'] not in fd_det:
         raise ValueError("Approximant %s not available" %
                             (input_params['approximant']))
@@ -757,6 +758,13 @@ def _base_get_td_waveform_from_fd(template=None, rwrap=0.2, **params):
     """
     kwds = props(template, **params)
     nparams = kwds.copy()
+
+    if rwrap == 0.2:
+        m_final, spin_final = get_final_from_initial(
+            mass1=nparams['mass1'], mass2=nparams['mass2'],
+            spin1z=nparams['spin1z'], spin2z=nparams['spin2z'])
+        rwrap = tau_from_final_mass_spin(m_final, spin_final) * 8
+
     if nparams['approximant'] not in _filter_time_lengths:
         raise ValueError("Approximant %s _filter_time_lengths function \
                          not available" % (nparams['approximant']))
@@ -766,6 +774,9 @@ def _base_get_td_waveform_from_fd(template=None, rwrap=0.2, **params):
     while full_duration < duration * 1.5:
         full_duration = get_waveform_filter_length_in_time(**nparams)
         nparams['f_lower'] *= 0.99
+        if 't_obs_start' in nparams and \
+            full_duration >= nparams['t_obs_start']:
+                break
 
     if 'f_ref' not in nparams:
         nparams['f_ref'] = params['f_lower']

--- a/pycbc/waveform/waveform.py
+++ b/pycbc/waveform/waveform.py
@@ -759,11 +759,13 @@ def _base_get_td_waveform_from_fd(template=None, rwrap=0.2, **params):
     kwds = props(template, **params)
     nparams = kwds.copy()
 
-    if rwrap == 0.2:
-        m_final, spin_final = get_final_from_initial(
-            mass1=nparams['mass1'], mass2=nparams['mass2'],
-            spin1z=nparams['spin1z'], spin2z=nparams['spin2z'])
-        rwrap = tau_from_final_mass_spin(m_final, spin_final) * 8
+    m_final, spin_final = get_final_from_initial(
+        mass1=nparams['mass1'], mass2=nparams['mass2'],
+        spin1z=nparams['spin1z'], spin2z=nparams['spin2z'])
+    t_damping = tau_from_final_mass_spin(m_final, spin_final) * 8
+
+    if rwrap < t_damping:
+        rwrap = t_damping
 
     if nparams['approximant'] not in _filter_time_lengths:
         raise ValueError("Approximant %s _filter_time_lengths function \

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,3 +35,6 @@ Sphinx>=4.2.0
 sphinx-rtd-theme>=1.0.0
 sphinxcontrib-programoutput>=0.11
 sphinx_design
+
+# Needed for ringdown and time-domain injection (fix wrap-around issue for SMBHB)
+pykerr

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,6 +35,3 @@ Sphinx>=4.2.0
 sphinx-rtd-theme>=1.0.0
 sphinxcontrib-programoutput>=0.11
 sphinx_design
-
-# Needed for ringdown and time-domain injection (fix wrap-around issue for SMBHB)
-pykerr

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ install_requires = setup_requires + [
     'ligo-segments',
     'lalsuite!=7.2',
     'lscsoft-glue>=1.59.3',
+    'pykerr',
 ]
 
 def find_files(dirname, relpath=None):


### PR DESCRIPTION
@ahnitz This PR uses the damping time of (2,2) QNM of ringdown from the injected signal to set `rwrap`, now the time-domain injection for SMBHB and SOBHB works fine:

(1) SMBHB (and its zoom-in)
![smbhb](https://user-images.githubusercontent.com/6574526/232149877-82825c68-47fb-4706-a7fd-a1e30b7e5d10.png)
![smbhb_zoomin](https://user-images.githubusercontent.com/6574526/232150171-334a8caa-d854-44ca-8303-0feac96ca8e2.png)

(2) SOBHB:
![sobhb](https://user-images.githubusercontent.com/6574526/232149992-c5dadadc-cd3e-446e-bb56-9b5ee084047f.png)
