### PR TITLE
Mac fixes

### DIFF
--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -111,19 +111,21 @@ class LiveEventManager(object):
         if self.run_snr_optimization:
             # preestimate the number of CPU cores that we can afford giving
             # to followup processes without slowing down the main search
-                # if the machine isn't a mac
-            if platform.system() != 'Darwin':
-                available_cores = len(os.sched_getaffinity(0))
-            else:
-                available_cores = multiprocessing.cpu_count()
             bg_cores = len(tuple(itertools.combinations(ifos, 2)))
             analysis_cores = 1 + bg_cores
-            self.fu_cores = available_cores - analysis_cores
-            if self.fu_cores <= 0:
-                logging.warning('Insufficient number of CPU cores (%d) to '
-                                'run search and trigger followups. Uploaded '
-                                'triggers will momentarily increase the lag',
-                                available_cores)
+            if platform.system() != 'Darwin':
+                available_cores = len(os.sched_getaffinity(0))
+                self.fu_cores = available_cores - analysis_cores
+                if self.fu_cores <= 0:
+                    logging.warning(
+                        'Insufficient number of CPU cores (%d) to '
+                        'run search and trigger followups. Uploaded '
+                        'triggers will momentarily increase the lag',
+                        available_cores
+                    )
+                    self.fu_cores = 1
+            else:
+                # To enable mac testing, this is just set to 1
                 self.fu_cores = 1
 
     def commit_results(self, results):

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -15,6 +15,7 @@ import os.path
 import itertools
 import platform
 import subprocess
+import multiprocessing
 from multiprocessing.dummy import threading
 from matplotlib import use
 use('agg')
@@ -109,7 +110,11 @@ class LiveEventManager(object):
         if self.run_snr_optimization:
             # preestimate the number of CPU cores that we can afford giving
             # to followup processes without slowing down the main search
-            available_cores = len(os.sched_getaffinity(0))
+                # if the machine isn't a mac
+            if platform.system() != 'Darwin':
+                available_cores = len(os.sched_getaffinity(0))
+            else:
+                available_cores = multiprocessing.cpu_count()
             bg_cores = len(tuple(itertools.combinations(ifos, 2)))
             analysis_cores = 1 + bg_cores
             self.fu_cores = available_cores - analysis_cores

--- a/pycbc/events/coinc.py
+++ b/pycbc/events/coinc.py
@@ -369,8 +369,8 @@ def cluster_coincs(stat, time1, time2, timeslide_id, slide, window, **kwargs):
     else:
         time = 0.5 * (time2 + time1)
 
-    tslide = timeslide_id.astype(numpy.float128)
-    time = time.astype(numpy.float128)
+    tslide = timeslide_id.astype(numpy.longdouble)
+    time = time.astype(numpy.longdouble)
 
     span = (time.max() - time.min()) + window * 10
     time = time + span * tslide
@@ -424,8 +424,8 @@ def cluster_coincs_multiifo(stat, time_coincs, timeslide_id, slide, window,
         nifos_minusone = (num_ifos - numpy.ones_like(num_ifos))
         time_avg = time_avg + (nifos_minusone * timeslide_id * slide)/num_ifos
 
-    tslide = timeslide_id.astype(numpy.float128)
-    time_avg = time_avg.astype(numpy.float128)
+    tslide = timeslide_id.astype(numpy.longdouble)
+    time_avg = time_avg.astype(numpy.longdouble)
 
     span = (time_avg.max() - time_avg.min()) + window * 10
     time_avg = time_avg + span * tslide


### PR DESCRIPTION
**Problem**: 
Apple silicon machines are currenly arm64 architecture, which doesn't support:

- the `numpy.float128` type,
- `os.sched_getaffinity(0)` to determine cpu count.

**Solution**:
Switching to:
- `numpy.longdouble` instead of `numpy.float128` works, however I believe we should definitely consider this note about [Extended Precision](https://numpy.org/doc/stable/user/basics.types.html#extended-precision) before merging this change,
- `multiprocessing.cpu_count() if platform.system() == 'Darwin'` gets the cpu count fine.

Cheers :-)