### PR TITLE
Replace gw-openscience.org with gwosc.org

### DIFF
--- a/bin/pycbc_losc_segment_query
+++ b/bin/pycbc_losc_segment_query
@@ -41,8 +41,8 @@ def query_gwosc(ifo, segment_name, gps_start_time, duration):
     """
 
     response = urlopen(
-        'https://www.gw-openscience.org/timeline/segments/json/O1/{}_{}/{}/{}/'.format(
-        ifo, segment_name, gps_start_time, duration))
+        f'https://www.gwosc.org/timeline/segments/json/O1/{ifo}_{segment_name}/{gps_start_time}/{duration}/'
+    )
 
     logging.info(response.info())
     json_segment_data = json.loads(response.read())

--- a/docs/dataquality.rst
+++ b/docs/dataquality.rst
@@ -27,8 +27,8 @@ Finding times of hardware injections
 What flags can I query?
 ========================
 
-A list of many of the flags which can be quiered is `available here <https://www.gw-openscience.org/archive/dataset/O1/>`_. Instead, just give the
-raw name such as "DATA" instead of "H1_DATA".
+A list of many of the flags which can be quiered is `available here <https://www.gwosc.org/archive/dataset/O1/>`_.
+Instead, just give the raw name such as "DATA" instead of "H1_DATA".
 
 There are two additional types of flags which can be queried. These are
 the negation of the flags like "NO_CBC_HW_INJ". The flag "CBC_HW_INJ" would

--- a/docs/inference/examples/gw150914.rst
+++ b/docs/inference/examples/gw150914.rst
@@ -9,12 +9,12 @@ as was :ref:`used for the simulated BBH example<inference_example_bbh>`. We only
 data configuration file, so that we will run on real gravitational-wave data.
 
 First, we need to download the data from the `Gravitational Wave Open Science
-Center <https://www.gw-openscience.org>`_. Run:
+Center <https://www.gwosc.org>`_. Run:
 
   .. code-block:: bash
 
-     wget https://www.gw-openscience.org/eventapi/html/GWTC-1-confident/GW150914/v3/H-H1_GWOSC_16KHZ_R1-1126257415-4096.gwf
-     wget https://www.gw-openscience.org/eventapi/html/GWTC-1-confident/GW150914/v3/L-L1_GWOSC_16KHZ_R1-1126257415-4096.gwf
+     wget https://www.gwosc.org/eventapi/html/GWTC-1-confident/GW150914/v3/H-H1_GWOSC_16KHZ_R1-1126257415-4096.gwf
+     wget https://www.gwosc.org/eventapi/html/GWTC-1-confident/GW150914/v3/L-L1_GWOSC_16KHZ_R1-1126257415-4096.gwf
 
 This will download the appropriate data ("frame") files to your current working
 directory.  You can now use the following data configuration file:

--- a/docs/pycbc_condition_strain.rst
+++ b/docs/pycbc_condition_strain.rst
@@ -115,4 +115,4 @@ might read more data than what specified by the ``--gps-start-time`` and
 value that causes ``pycbc_condition_strain`` to request data outside the range
 of availability.
 
-.. _GWOSC: https://www.gw-openscience.org/about/
+.. _GWOSC: https://www.gwosc.org/about/

--- a/examples/gw150914/audio.py
+++ b/examples/gw150914/audio.py
@@ -9,7 +9,7 @@ except ImportError:  # python < 3
 
 # Read data and remove low frequency content
 fname = 'H-H1_LOSC_4_V2-1126259446-32.gwf'
-url = "https://www.gw-openscience.org/GW150914data/" + fname
+url = "https://www.gwosc.org/GW150914data/" + fname
 urlretrieve(url, filename=fname)
 h1 = highpass_fir(read_frame(fname, 'H1:LOSC-STRAIN'), 15.0, 8)
 

--- a/examples/gw150914/gw150914_h1_snr.py
+++ b/examples/gw150914/gw150914_h1_snr.py
@@ -8,7 +8,7 @@ from pycbc.psd import welch, interpolate
 
 # Read data and remove low frequency content
 fname = 'H-H1_LOSC_4_V2-1126259446-32.gwf'
-url = "https://www.gw-openscience.org/GW150914data/" + fname
+url = "https://www.gwosc.org/GW150914data/" + fname
 urlretrieve(url, filename=fname)
 h1 = read_frame('H-H1_LOSC_4_V2-1126259446-32.gwf', 'H1:LOSC-STRAIN')
 h1 = highpass_fir(h1, 15, 8)

--- a/examples/inference/data/o1.ini
+++ b/examples/inference/data/o1.ini
@@ -23,7 +23,7 @@ psd-segment-stride = 4
 ; with a ligo-data-server, you can use the frame-type argument to automatically
 ; locate the location of the frame files containing the data. If you are not
 ; running on one of those computers, download the necessary data from GWOSC
-; (gw-openscience.org), remove the frame-type argument, and uncomment
+; (gwosc.org), remove the frame-type argument, and uncomment
 ; frame-files, pointing the latter to the files you downloaded.
 ;frame-files = H1:/PATH/TO/DOWNLOADED/H1FRAME.gwf L1:/PATH/TO/DOWNLOADED/L1FRAME.gwf
 frame-type = H1:H1_LOSC_16_V1 L1:L1_LOSC_16_V1

--- a/examples/inference/data/o2.ini
+++ b/examples/inference/data/o2.ini
@@ -24,7 +24,7 @@ psd-segment-stride = 4
 ; with a ligo-data-server, you can use the frame-type argument to automatically
 ; locate the location of the frame files containing the data. If you are not
 ; running on one of those computers, download the necessary data from GWOSC
-; (gw-openscience.org), remove the frame-type argument, and uncomment
+; (gwosc.org), remove the frame-type argument, and uncomment
 ; frame-files, pointing the latter to the files you downloaded.
 frame-type = H1:H1_GWOSC_O2_16KHZ_R1 L1:L1_GWOSC_O2_16KHZ_R1 V1:V1_GWOSC_O2_16KHZ_R1
 ;frame-files = H1:/PATH/TO/DOWNLOADED/H1FRAME.gwf L1:/PATH/TO/DOWNLOADED/L1FRAME.gwf V1:/PATH/TO/DOWNLOADED/V1FRAME.gwf

--- a/examples/inference/margtime/get.sh
+++ b/examples/inference/margtime/get.sh
@@ -4,5 +4,6 @@ for ifo in H-H1 L-L1
 do
     file=${ifo}_GWOSC_4KHZ_R1-1126257415-4096.gwf
     test -f ${file} && continue
-    curl -O --show-error --silent https://www.gw-openscience.org/eventapi/html/GWTC-1-confident/GW150914/v3/${ifo}_GWOSC_4KHZ_R1-1126257415-4096.gwf
+    curl -O -L --show-error --silent \
+        https://www.gwosc.org/eventapi/html/GWTC-1-confident/GW150914/v3/${ifo}_GWOSC_4KHZ_R1-1126257415-4096.gwf
 done

--- a/examples/multi_inspiral/run.sh
+++ b/examples/multi_inspiral/run.sh
@@ -3,11 +3,11 @@
 CONFIG_URL=https://github.com/gwastro/pycbc-config/raw/master/test/multi_inspiral
 BANK_FILE=gw170817_single_template.hdf
 BANK_VETO_FILE=bank_veto_bank.xml
-H1_FRAME=https://www.gw-openscience.org/eventapi/html/GWTC-1-confident/GW170817/v3/H-H1_GWOSC_4KHZ_R1-1187006835-4096.gwf
+H1_FRAME=https://www.gwosc.org/eventapi/html/GWTC-1-confident/GW170817/v3/H-H1_GWOSC_4KHZ_R1-1187006835-4096.gwf
 H1_CHANNEL=GWOSC-4KHZ_R1_STRAIN
 L1_FRAME=https://dcc.ligo.org/public/0144/T1700406/003/L-L1_CLEANED_HOFT_C02_T1700406_v3-1187008667-4096.gwf
 L1_CHANNEL=DCH-CLEAN_STRAIN_C02_T1700406_v3
-V1_FRAME=https://www.gw-openscience.org/eventapi/html/GWTC-1-confident/GW170817/v3/V-V1_GWOSC_4KHZ_R1-1187006835-4096.gwf
+V1_FRAME=https://www.gwosc.org/eventapi/html/GWTC-1-confident/GW170817/v3/V-V1_GWOSC_4KHZ_R1-1187006835-4096.gwf
 V1_CHANNEL=GWOSC-4KHZ_R1_STRAIN
 
 echo -e "\\n\\n>> [`date`] Getting template bank"

--- a/pycbc/catalog/catalog.py
+++ b/pycbc/catalog/catalog.py
@@ -32,7 +32,7 @@ from pycbc.io import get_file
 # FIXME with posteriors when available and we can just post-process that
 
 # LVC catalogs
-base_lvc_url = "https://www.gw-openscience.org/eventapi/jsonfull/{}/"
+base_lvc_url = "https://www.gwosc.org/eventapi/jsonfull/{}/"
 _catalogs = {'GWTC-1-confident': 'LVC',
              'GWTC-1-marginal': 'LVC',
              'Initial_LIGO_Virgo': 'LVC',

--- a/pycbc/dq.py
+++ b/pycbc/dq.py
@@ -101,7 +101,7 @@ def parse_veto_definer(veto_def_filename, ifos):
     return data
 
 
-GWOSC_URL = 'https://www.gw-openscience.org/timeline/segments/json/{}/{}_{}/{}/{}/'
+GWOSC_URL = 'https://www.gwosc.org/timeline/segments/json/{}/{}_{}/{}/{}/'
 
 
 def query_dqsegdb2(detector, flag_name, start_time, end_time, server):

--- a/pycbc/frame/losc.py
+++ b/pycbc/frame/losc.py
@@ -14,11 +14,11 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 """
-This modules contains functions for getting data from the LOSC
+This modules contains functions for getting data from the GWOSC
 """
 from pycbc.io import get_file
 
-_losc_url = "https://www.gw-openscience.org/archive/links/%s/%s/%s/%s/json/"
+_gwosc_url = "https://www.gwosc.org/archive/links/%s/%s/%s/%s/json/"
 
 def get_run(time, ifo=None):
     """ Return the run name for a given time
@@ -90,7 +90,7 @@ def losc_frame_json(ifo, start_time, end_time):
                          'You have requested data that uses '
                          'both %s and %s' % (run, run2))
 
-    url = _losc_url % (run, ifo, int(start_time), int(end_time))
+    url = _gwosc_url % (run, ifo, int(start_time), int(end_time))
 
     try:
         return json.loads(urlopen(url).read().decode())
@@ -100,7 +100,7 @@ def losc_frame_json(ifo, start_time, end_time):
             'ifo=%s, run=%s, between %s-%s' % (ifo, run, start_time, end_time))
 
 def losc_frame_urls(ifo, start_time, end_time):
-    """ Get a list of urls to losc frame files
+    """ Get a list of urls to GWOSC frame files
 
     Parameters
     ----------
@@ -121,7 +121,7 @@ def losc_frame_urls(ifo, start_time, end_time):
     return [d['url'] for d in data if d['format'] == 'gwf']
 
 def read_frame_losc(channels, start_time, end_time):
-    """ Read channels from losc data
+    """ Read channels from GWOSC data
 
     Parameters
     ----------
@@ -162,7 +162,7 @@ def read_frame_losc(channels, start_time, end_time):
         return ts
 
 def read_strain_losc(ifo, start_time, end_time):
-    """ Get the strain data from the LOSC data
+    """ Get the strain data from the GWOSC data
 
     Parameters
     ----------


### PR DESCRIPTION
One of the `curl` commands we used in the docs/examples was failing to properly download a frame file because of the redirect resulting from the domain change. This fixes that error, replaces gw-openscience.org with gwosc.org throughout the repository, and updates some leftover LOSC mentions to GWOSC.