### PR TITLE
Allow cuts on a multiple of the median sigma value

### DIFF
--- a/bin/all_sky_search/pycbc_coinc_findtrigs
+++ b/bin/all_sky_search/pycbc_coinc_findtrigs
@@ -181,7 +181,9 @@ if args.randomize_template_order:
     shuffle(template_ids)
     template_ids = template_ids[tmin:tmax]
 else:
-    template_ids = range(tmin, tmax)
+    template_ids = np.array([range(tmin, tmax)])
+
+original_bank_len = len(template_ids)
 
 # Only analyze templates which might have coincs
 if tids_with_trigs is not None:
@@ -196,7 +198,7 @@ template_ids = cuts.apply_template_cuts(
     template_ids=template_ids)
 
 logging.info("%d out of %d templates kept after applying template cuts",
-             len(template_ids), len(trigs.singles[0].bank))
+             len(template_ids), original_bank_len)
 
 # 'data' will store output of coinc finding
 # in addition to these lists of coinc info, will also store trigger times and
@@ -240,7 +242,8 @@ def process_template(tnum):
     for i, sngl in zip(trigs.ifos, trigs.singles):
         # Apply cuts to triggers
         tids_uncut = sngl.set_template(tnum)
-        trigger_keep_ids = cuts.apply_trigger_cuts(sngl, trigger_cut_dict)
+        trigger_keep_ids = cuts.apply_trigger_cuts(sngl, trigger_cut_dict,
+                                                   statistic=rank_method)
 
         tids_full[i] = tids_uncut[trigger_keep_ids]
         times_full[i] = sngl['end_time'][trigger_keep_ids]

--- a/bin/all_sky_search/pycbc_sngls_findtrigs
+++ b/bin/all_sky_search/pycbc_sngls_findtrigs
@@ -90,6 +90,8 @@ if args.randomize_template_order:
 else:
     template_ids = np.array(range(tmin, tmax))
 
+original_bank_len = len(template_ids)
+
 from pycbc.io.hdf import ReadByTemplate
 trigs = ReadByTemplate(trigger_file,
                        args.template_bank,
@@ -114,14 +116,29 @@ template_ids = cuts.apply_template_cuts(
     template_ids=template_ids)
 
 logging.info("%d out of %d templates kept after applying template cuts",
-             len(template_ids), len(trigs.bank))
+             len(template_ids), original_bank_len)
 
 logging.info('Clustering events over %s s window within each template',
              args.cluster_window)
+
+# Stat class instance to calculate the ranking statistic
+extra_kwargs = {}
+for inputstr in args.statistic_keywords:
+    try:
+        key, value = inputstr.split(':')
+        extra_kwargs[key] = value
+    except ValueError:
+        err_txt = "--statistic-keywords must take input in the " \
+                  "form KWARG1:VALUE1 KWARG2:VALUE2 KWARG3:VALUE3 ... " \
+                  "Received {}".format(args.statistic_keywords)
+        raise ValueError(err_txt)
+
+
 for tnum in template_ids:
     tids_uncut = trigs.set_template(tnum)
 
-    trigger_keep_ids = cuts.apply_trigger_cuts(trigs, trigger_cut_dict)
+    trigger_keep_ids = cuts.apply_trigger_cuts(trigs, trigger_cut_dict,
+                                               statistic=rank_method)
     tids_full = tids_uncut[trigger_keep_ids]
     logging.info('%s:%s', tnum, len(tids_uncut))
     if len(tids_full) < len(tids_uncut):
@@ -130,18 +147,6 @@ for tnum in template_ids:
 
     n_tot_trigs = tids_full.size
     if not n_tot_trigs: continue
-
-    # Stat class instance to calculate the ranking statistic
-    extra_kwargs = {}
-    for inputstr in args.statistic_keywords:
-        try:
-            key, value = inputstr.split(':')
-            extra_kwargs[key] = value
-        except ValueError:
-            err_txt = "--statistic-keywords must take input in the " \
-                      "form KWARG1:VALUE1 KWARG2:VALUE2 KWARG3:VALUE3 ... " \
-                      "Received {}".format(args.statistic_keywords)
-            raise ValueError(err_txt)
 
     sds = rank_method.single(trigs)[trigger_keep_ids]
     stat_t = rank_method.rank_stat_single((ifo, sds),

--- a/bin/all_sky_search/pycbc_sngls_findtrigs
+++ b/bin/all_sky_search/pycbc_sngls_findtrigs
@@ -121,7 +121,6 @@ logging.info("%d out of %d templates kept after applying template cuts",
 logging.info('Clustering events over %s s window within each template',
              args.cluster_window)
 
-# Stat class instance to calculate the ranking statistic
 extra_kwargs = {}
 for inputstr in args.statistic_keywords:
     try:
@@ -148,6 +147,7 @@ for tnum in template_ids:
     n_tot_trigs = tids_full.size
     if not n_tot_trigs: continue
 
+    # Stat class instance to calculate the ranking statistic
     sds = rank_method.single(trigs)[trigger_keep_ids]
     stat_t = rank_method.rank_stat_single((ifo, sds),
                                           **extra_kwargs)

--- a/pycbc/events/cuts.py
+++ b/pycbc/events/cuts.py
@@ -34,12 +34,15 @@ from pycbc.io import hdf
 from pycbc.tmpltbank import bank_conversions as bank_conv
 from pycbc.io import get_chisq_from_file_choice
 
+# Only used to check isinstance:
+from pycbc.io.hdf import ReadByTemplate
+
 # sngl_rank_keys are the allowed names of reweighted SNR functions
 sngl_rank_keys = ranking.sngls_ranking_function_dict.keys()
 
 trigger_param_choices = list(sngl_rank_keys)
 trigger_param_choices += [cc + '_chisq' for cc in hdf.chisq_choices]
-trigger_param_choices += ['end_time', 'psd_var_val', 'sigmasq']
+trigger_param_choices += ['end_time', 'psd_var_val', 'sigmasq', "sigma_multiple"]
 
 template_fit_param_choices = ['fit_by_fit_coeff', 'smoothed_fit_coeff',
                               'fit_by_count_above_thresh',
@@ -188,7 +191,42 @@ def ingest_cuts_option_group(args):
     return trigger_cut_dict, template_cut_dict
 
 
-def apply_trigger_cuts(triggers, trigger_cut_dict):
+def sigma_multiple_cut_thresh(template_ids, statistic,
+                             cut_thresh, ifo):
+    """
+    Apply cuts based on a multiple of the median sigma value for the template
+
+    Parameters
+    ----------
+
+    template_ids:
+        template_id values for each of the triggers to be considered,
+        this will be used to associate a sigma threshold for each trigger
+    statistic:
+        A PyCBC ranking statistic instance. Used to get the median_sigma
+        value for the cuts. If fits_by_tid does not exist for the specified
+        ifo (where median_sigma lives), an error will be raised.
+    ifo:
+        The IFO for which we want to read median_sigma
+    cut_thresh: int or float
+        The multiple of median_sigma to compare triggers to
+
+    Returns
+    -------
+    idx_out: numpy array
+        An array of the indices of triggers which meet the criteria
+        set by the dictionary
+    """
+    if not hasattr(statistic, 'fits_by_tid'):
+        raise ValueError("Cut parameter " + parameter + " cannot "
+                 "be used when the ranking statistic " +
+                 statistic_classname + " does not use "
+                 "template fitting.")
+    tid_med_sigma = statistic.fits_by_tid[ifo]['median_sigma']
+    return cut_thresh * tid_med_sigma[template_ids]
+
+
+def apply_trigger_cuts(triggers, trigger_cut_dict, statistic=None):
     """
     Fetch/Calculate the parameter for triggers, and then
     apply the cuts defined in template_cut_dict
@@ -204,6 +242,7 @@ def apply_trigger_cuts(triggers, trigger_cut_dict):
         Dictionary with tuples of (parameter, cut_function)
         as keys, cut_thresholds as values
         made using ingest_cuts_option_group function
+
 
     Returns
     -------
@@ -226,11 +265,24 @@ def apply_trigger_cuts(triggers, trigger_cut_dict):
             value = get_chisq_from_file_choice(triggers, chisq_choice)
             # Apply any previous cuts to the value for comparison
             value = value[idx_out]
+        elif parameter == "sigma_multiple":
+            if isinstance(triggers, ReadByTemplate):
+                value = np.sqrt(triggers.file[triggers.ifo]['sigmasq'][idx_out])
+                template_ids = triggers.file[triggers.ifo]['template_id'][idx_out]
+                # Get a cut threshold value, this will be different depending on the
+                # template ID, so we rewrite cut_thresh as a value for each trigger
+                cut_thresh = sigma_multiple_cut_thresh(template_ids, statistic,
+                                                       cut_thresh, triggers.ifo)
+            else:
+                err_msg = "Cuts on 'sigma_multiple' are only implemented for "
+                err_msg += "triggers in a ReadByTemplate format. This code "
+                err_msg += f"uses a {type(triggers).__name__} format."
+                raise NotImplementedError(err_msg)
         elif ((not hasattr(triggers, "file") and parameter in triggers)
                 or (hasattr(triggers, "file")
                     and parameter in triggers.file[triggers.ifo])):
             # parameter can be read direct from the trigger dictionary / file
-            if parameter in triggers:
+            if not hasattr(triggers, 'file') and parameter in triggers:
                 value = triggers[parameter]
             else:
                 value = triggers.file[triggers.ifo][parameter]
@@ -270,7 +322,7 @@ def apply_template_fit_cut(statistic, ifos, parameter_cut_function, cut_thresh,
         List of IFOS used in this findtrigs instance.
         Templates must pass cuts in all IFOs.
 
-    parameter_cut_function: thresh
+    parameter_cut_function: tuple
         First entry: Which parameter is being used for the cut?
         Second entry: Cut function
 


### PR DESCRIPTION
When running analyses for https://arxiv.org/abs/2203.08545, we saw some times with furious autogating, which destroyed most of the PSD and so the instantaneous sensitive distance was measured to be huge, meaning the statistic blew up.

This cut allows us to discard any triggers at the findtrigs stage where the measured sensitive distance at the time is unphysical, e.g. 50 times the median sigma from triggers in the trigger_merge file.

The check for ReadByTemplate is because we also use the cuts module in the pycbc_live_single_trigger_fits code, but use a dictionary there