### PR TITLE
Can't generate array directly from dict keys object

### DIFF
--- a/bin/bank/pycbc_aligned_stoch_bank
+++ b/bin/bank/pycbc_aligned_stoch_bank
@@ -181,13 +181,13 @@ if opts.vary_fupper==False:
         refFreq = metricParams.fUpper
     else:
         # use the maximum frequency for which the moments were calculated
-        fs = numpy.array(metricParams.evals.keys(), dtype=float)
+        fs = numpy.array(list(metricParams.evals.keys()), dtype=float)
         fs.sort()
         refFreq = fs.max()
 else:
     # determine upper frequency cutoffs corresponding to the min and max
     # total masses
-    fs = numpy.array(metricParams.evals.keys(), dtype=float)
+    fs = numpy.array(list(metricParams.evals.keys()), dtype=float)
     fs.sort()
     lowEve, highEve = tmpltbank.find_max_and_min_frequencies(\
                               opts.bank_fupper_formula, massRangeParams, fs)

--- a/bin/bank/pycbc_bank_verification
+++ b/bin/bank/pycbc_bank_verification
@@ -159,7 +159,7 @@ if opts.vary_fupper==False:
 else:
     # determine upper frequency cutoffs corresponding to the min and max 
     # total masses
-    fs = numpy.array(metricParams.evals.keys(), dtype=float)
+    fs = numpy.array(list(metricParams.evals.keys()), dtype=float)
     fs.sort()
     lowEve, highEve = tmpltbank.find_max_and_min_frequencies(\
                               opts.bank_fupper_formula, massRangeParams, fs)

--- a/pycbc/tmpltbank/partitioned_bank.py
+++ b/pycbc/tmpltbank/partitioned_bank.py
@@ -549,7 +549,7 @@ class PartitionedTmpltbank(object):
             mass_dict['m2'] = numpy.array([mass2])
             mass_dict['s1z'] = numpy.array([spin1z])
             mass_dict['s2z'] = numpy.array([spin2z])
-            freqs = numpy.array([self.frequency_map.keys()], dtype=float)
+            freqs = numpy.array(list(self.frequency_map.keys()), dtype=float)
             freq_cutoff = coord_utils.return_nearest_cutoff(\
                                      self.upper_freq_formula, mass_dict, freqs)
             freq_cutoff = freq_cutoff[0]


### PR DESCRIPTION
A couple of place causing errors as it seems we can't make a list by using `[keys()]` or `array(keys())` any more