### PR TITLE
Fix Sphinx deprecation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,7 +11,7 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys, os
+import os
 import pycbc.version
 import subprocess
 import glob
@@ -263,9 +263,10 @@ texinfo_documents = [
 
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'http://docs.python.org/': None,
-                       'h5py': ('http://docs.h5py.org/en/stable/', None),
-                      }
+intersphinx_mapping = {
+    'python': ('http://docs.python.org/', None),
+    'h5py': ('http://docs.h5py.org/en/stable/', None),
+}
 
 napoleon_use_ivar = False
 


### PR DESCRIPTION
The CI docs is failing with this message:
```
Failed to read intersphinx_mapping[http://docs.python.org/], ignored: SphinxWarning('The pre-Sphinx 1.0 \'intersphinx_mapping\' format is deprecated and will be removed in Sphinx 8. Update to the current format as described in the documentation. Hint: "intersphinx_mapping = {\'<name>\': (\'http://docs.python.org/\', None)}".https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html#confval-intersphinx_mapping')
```
This PR should fix it.