### PR TITLE
workaround for search issue and rtd theme

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -34,6 +34,7 @@ extensions = ['sphinx.ext.autodoc', 'sphinx.ext.doctest',
               'sphinx.ext.napoleon', 'sphinx.ext.mathjax',
               'matplotlib.sphinxext.plot_directive', 'sphinx.ext.autosummary',
               'sphinx.ext.inheritance_diagram', 'sphinx_design',
+              "sphinxcontrib.jquery",
               ]
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
This implements the suggested fix noted here 

https://github.com/readthedocs/sphinx_rtd_theme/issues/1452

for the issue that jQuery is not loaded correctly. This breaks the search feature as noted in our slack. 