### PR TITLE
Threading race condition bugfix for optimize_snr in pycbc_live

### DIFF
--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -425,8 +425,8 @@ class LiveEventManager(object):
         gid: str
             GraceDB ID of the candidate
         """
-        with h5py.File(attribute_fname, 'a') as hdfp:
-            if gid is not None:
+        if gid is not None:
+            with h5py.File(attribute_fname, 'a') as hdfp:
                 hdfp['gid'] = gid
         log_fname = os.path.join(out_dir_path, 'optimize_snr.log')
 

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -633,10 +633,12 @@ class LiveEventManager(object):
             comment = comment.format(ifo, ppdets(followup_ifos))
 
             # Has a coinc event at this time been uploaded recently?
-            # If so, skip upload
+            # If so, skip upload - Note that this means that we _always_
+            # prefer an uploaded coincident event over a single
             coinc_tdiffs = abs(event.merger_time -
                                numpy.array(self.last_few_coincs_uploaded))
             nearby_coincs = coinc_tdiffs < 0.1
+
             if any(nearby_coincs):
                 logging.info(
                     "Single-detector candidate at time %.3f was already "
@@ -656,14 +658,14 @@ class LiveEventManager(object):
             if not upload_checks:
                 event.save(fname)
 
-            if nearby_coincs:
-                # Don't save the snr optimization stuff for singles where
-                # there is already a coinc
-                continue
-
             # Save the event info/data and what _would_ be run for SNR optimizer,
             # even if not running it - do this before the thread so no
             # data buffers move on in a possible interim period
+
+            if nearby_coincs:
+                # Don't even save the snr optimization stuff for singles
+                # where there is already a coinc
+                continue
 
             # Which IFOs were active?
             live_ifos = [ifo for ifo in sld if 'snr_series' in sld[ifo]]

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -662,7 +662,7 @@ class LiveEventManager(object):
             # even if not running it - do this before the thread so no
             # data buffers move on in a possible interim period
 
-            if nearby_coincs:
+            if any(nearby_coincs):
                 # Don't even save the snr optimization stuff for singles
                 # where there is already a coinc
                 continue

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -284,7 +284,7 @@ class LiveEventManager(object):
             triggers[f'foreground/pvalue_{ifo}_saturated'] = pv_sat
 
     def setup_optimize_snr(
-        self, results, live_ifos, triggering_ifos, fname, gid
+        self, results, live_ifos, triggering_ifos, fname
     ):
         """Setup and start the network SNR optimization process for a
         candidate event. See arXiv:2008.07494 for details.
@@ -303,8 +303,6 @@ class LiveEventManager(object):
             File name where the candidate information has been saved.
             Used to name other files produced as part of setting up the
             SNR optimization.
-        gid : str
-            GraceDB ID of the candidate.
         """
         template_id = results[f'foreground/{live_ifos[0]}/template_id']
         p = props(self.bank.table[template_id])
@@ -360,8 +358,6 @@ class LiveEventManager(object):
             hdfp['ifar'] = results['foreground/ifar']
             if 'p_terr' in results:
                 hdfp['p_terr'] = results['p_terr']
-            if gid is not None:
-                hdfp['gid'] = gid
 
             for ifo in args.channel_name:
                 hdfp[f'channel_names/{ifo}'] = args.channel_name[ifo]
@@ -404,6 +400,13 @@ class LiveEventManager(object):
             opt_scheme = args.processing_scheme.split(':')[0]
             cmd += '--processing-scheme {}:1 '.format(opt_scheme)
 
+        return cmd, out_dir_path
+
+    def run_optimize_snr(self, cmd, out_dir_path, fname, gid):
+        curr_fname = fname.replace('.xml.gz', '_attributes.hdf')
+        with h5py.File(curr_fname, 'a') as hdfp:
+            if gid is not None:
+                hdfp['gid'] = gid
         log_fname = os.path.join(out_dir_path, 'optimize_snr.log')
 
         logging.info('running %s with log to %s', cmd, log_fname)
@@ -430,8 +433,8 @@ class LiveEventManager(object):
             gdbargs['service_url'] = self.gracedb_server
         self.gracedb = GraceDb(**gdbargs)
 
-    def upload_in_thread(self, event, fname, comment, results, live_ifos, ifos,
-                         upload_checks, optimize_snr_checks):
+    def upload_in_thread(self, event, fname, comment, cmd, out_dir_path,
+                        upload_checks, optimize_snr_checks):
         gid = None
         if upload_checks:
             gid = event.upload(
@@ -443,12 +446,11 @@ class LiveEventManager(object):
                 labels=self.gracedb_labels
             )
         if optimize_snr_checks:
-            self.setup_optimize_snr(
-                results,
-                live_ifos,
-                ifos,
-                fname,
-                gid
+            self.run_optimize_snr(
+                    cmd,
+                    out_dir_path,
+                    fname,
+                    gid
             )
 
     def check_coincs(self, ifos, coinc_results, psds):
@@ -523,14 +525,22 @@ class LiveEventManager(object):
         if not upload_checks:
             event.save(fname)
         if upload_checks or optimize_snr_checks:
+            live_ifos = [ifo for ifo in sld if 'snr_series' in sld[ifo]]
+            cmd, out_dir_path = None, None
             if optimize_snr_checks:
                 logging.info('Optimizing SNR for coinc above threshold ..')
                 # Tell snr optimized event about p_terr
                 if hasattr(event, 'p_terr') and event.p_terr is not None:
                     coinc_results['p_terr'] = event.p_terr
-            live_ifos = [ifo for ifo in sld if 'snr_series' in sld[ifo]]
+                # Run the setup to gather/save all the data before threading
+                cmd, out_dir_path = self.setup_optimize_snr(
+                    coinc_results,
+                    live_ifos,
+                    coinc_ifos,
+                    fname,
+                )
             thread_args = (
-                event, fname, comment, coinc_results, live_ifos, coinc_ifos,
+                event, fname, comment, cmd, out_dir_path,
                 upload_checks, optimize_snr_checks
             )
             gdb_upload_thread = threading.Thread(target=self.upload_in_thread,
@@ -611,14 +621,21 @@ class LiveEventManager(object):
             if not upload_checks:
                 event.save(fname)
             if upload_checks or optimize_snr_checks:
+                live_ifos = [ifo for ifo in sld if 'snr_series' in sld[ifo]]
+                cmd, out_dir_path = None, None
                 if optimize_snr_checks:
                     logging.info('Optimizing SNR for single above threshold ..')
                     # Tell snr optimized event about p_terr
                     if hasattr(event, 'p_terr') and event.p_terr is not None:
                         single['p_terr'] = event.p_terr
-                live_ifos = [ifo for ifo in sld if 'snr_series' in sld[ifo]]
+                cmd, out_dir_path = self.setup_optimize_snr(
+                    single,
+                    live_ifos,
+                    [ifo],
+                    fname,
+                )
                 thread_args = (
-                    event, fname, comment, single, live_ifos, [ifo],
+                    event, fname, comment, cmd, out_dir_path,
                     upload_checks, optimize_snr_checks
                 )
                 gdb_upload_thread = threading.Thread(target=self.upload_in_thread,

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -109,7 +109,7 @@ class LiveEventManager(object):
         # Keep track of which events have been uploaded
         self.last_few_coincs_uploaded = []
 
-        # Give this a nominal value, it is requried but not used
+        # Give this a nominal value, it is required but not used
         self.fu_cores = None
         if self.run_snr_optimization:
             # preestimate the number of CPU cores that we can afford giving
@@ -389,7 +389,9 @@ class LiveEventManager(object):
         if self.enable_gracedb_upload:
             cmd += '--enable-gracedb-upload '
 
-        cmd += '--cores {} '.format(self.fu_cores)
+        if self.fu_cores:
+            cmd += '--cores {} '.format(self.fu_cores)
+
         if args.processing_scheme:
             # we will use the cores for multiple workers of the
             # optimization routine, so we force the processing scheme
@@ -653,6 +655,11 @@ class LiveEventManager(object):
             # Save the event
             if not upload_checks:
                 event.save(fname)
+
+            if nearby_coincs:
+                # Don't save the snr optimization stuff for singles where
+                # there is already a coinc
+                continue
 
             # Save the event info/data and what _would_ be run for SNR optimizer,
             # even if not running it - do this before the thread so no

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -109,6 +109,8 @@ class LiveEventManager(object):
         # Keep track of which events have been uploaded
         self.last_few_coincs_uploaded = []
 
+        # Give this a nominal value, it is requried but not used
+        self.fu_cores = None
         if self.run_snr_optimization:
             # preestimate the number of CPU cores that we can afford giving
             # to followup processes without slowing down the main search
@@ -286,7 +288,7 @@ class LiveEventManager(object):
     def setup_optimize_snr(
         self, results, live_ifos, triggering_ifos, fname
     ):
-        """Setup and start the network SNR optimization process for a
+        """Setup the network SNR optimization process for a
         candidate event. See arXiv:2008.07494 for details.
 
         Parameters
@@ -400,11 +402,30 @@ class LiveEventManager(object):
             opt_scheme = args.processing_scheme.split(':')[0]
             cmd += '--processing-scheme {}:1 '.format(opt_scheme)
 
+        # Save the command which would be used:
+        snroc_fname = os.path.join(out_dir_path, 'snr_optimize_command.txt')
+        with open(snroc_fname,'w') as snroc_file:
+            snroc_file.write(cmd)
+
         return cmd, out_dir_path
 
-    def run_optimize_snr(self, cmd, out_dir_path, fname, gid):
-        curr_fname = fname.replace('.xml.gz', '_attributes.hdf')
-        with h5py.File(curr_fname, 'a') as hdfp:
+    def run_optimize_snr(self, cmd, out_dir_path, attribute_fname, gid):
+        """
+        Run the optimize_snr instance setup up by setup_optimize_snr
+
+        Parameters
+        ----------
+        cmd: str
+            Command to tell subprocess what to run for the
+            optimize_snr process
+        out_dir_path: os.path or str
+            Place for storing the SNR optimization results and log
+        attribute_fname: str
+            The filename of the attributes of the candidate
+        gid: str
+            GraceDB ID of the candidate
+        """
+        with h5py.File(attribute_fname, 'a') as hdfp:
             if gid is not None:
                 hdfp['gid'] = gid
         log_fname = os.path.join(out_dir_path, 'optimize_snr.log')
@@ -434,7 +455,7 @@ class LiveEventManager(object):
         self.gracedb = GraceDb(**gdbargs)
 
     def upload_in_thread(self, event, fname, comment, cmd, out_dir_path,
-                        upload_checks, optimize_snr_checks):
+                         upload_checks, optimize_snr_checks):
         gid = None
         if upload_checks:
             gid = event.upload(
@@ -445,11 +466,13 @@ class LiveEventManager(object):
                 search=self.gracedb_search,
                 labels=self.gracedb_labels
             )
+
         if optimize_snr_checks:
+            logging.info('Optimizing SNR for event above threshold ..')
             self.run_optimize_snr(
                     cmd,
                     out_dir_path,
-                    fname,
+                    fname.replace('.xml.gz', '_attributes.hdf'),
                     gid
             )
 
@@ -522,23 +545,31 @@ class LiveEventManager(object):
         self.last_few_coincs_uploaded = \
             self.last_few_coincs_uploaded[-10:]
 
+        # Save the event
         if not upload_checks:
             event.save(fname)
+
+        # Save the event info/data and what _would_ be run for SNR optimizer,
+        # even if not running it - do this before the thread so no
+        # data buffers move on in a possible interim period
+
+        # Which IFOs were active?
+        live_ifos = [ifo for ifo in sld if 'snr_series' in sld[ifo]]
+
+        # Tell SNR optimized event about p_terr
+        if hasattr(event, 'p_terr') and event.p_terr is not None:
+            coinc_results['p_terr'] = event.p_terr
+
+        # Do the optimizer setup
+        cmd, out_dir_path = self.setup_optimize_snr(
+            coinc_results,
+            live_ifos,
+            coinc_ifos,
+            fname,
+        )
+
+        # Now start the thread to run the SNR optimizer
         if upload_checks or optimize_snr_checks:
-            live_ifos = [ifo for ifo in sld if 'snr_series' in sld[ifo]]
-            cmd, out_dir_path = None, None
-            if optimize_snr_checks:
-                logging.info('Optimizing SNR for coinc above threshold ..')
-                # Tell snr optimized event about p_terr
-                if hasattr(event, 'p_terr') and event.p_terr is not None:
-                    coinc_results['p_terr'] = event.p_terr
-                # Run the setup to gather/save all the data before threading
-                cmd, out_dir_path = self.setup_optimize_snr(
-                    coinc_results,
-                    live_ifos,
-                    coinc_ifos,
-                    fname,
-                )
             thread_args = (
                 event, fname, comment, cmd, out_dir_path,
                 upload_checks, optimize_snr_checks
@@ -618,22 +649,31 @@ class LiveEventManager(object):
                 self.ifar_upload_threshold < single['foreground/ifar'] and \
                 not any(nearby_coincs) and \
                 self.run_snr_optimization
+
+            # Save the event
             if not upload_checks:
                 event.save(fname)
+
+            # Save the event info/data and what _would_ be run for SNR optimizer,
+            # even if not running it - do this before the thread so no
+            # data buffers move on in a possible interim period
+
+            # Which IFOs were active?
+            live_ifos = [ifo for ifo in sld if 'snr_series' in sld[ifo]]
+
+            # Tell SNR optimized event about p_terr
+            if hasattr(event, 'p_terr') and event.p_terr is not None:
+                single['p_terr'] = event.p_terr
+
+            # Do the optimizer setup
+            cmd, out_dir_path = self.setup_optimize_snr(
+                single,
+                live_ifos,
+                [ifo],
+                fname,
+            )
+
             if upload_checks or optimize_snr_checks:
-                live_ifos = [ifo for ifo in sld if 'snr_series' in sld[ifo]]
-                cmd, out_dir_path = None, None
-                if optimize_snr_checks:
-                    logging.info('Optimizing SNR for single above threshold ..')
-                    # Tell snr optimized event about p_terr
-                    if hasattr(event, 'p_terr') and event.p_terr is not None:
-                        single['p_terr'] = event.p_terr
-                cmd, out_dir_path = self.setup_optimize_snr(
-                    single,
-                    live_ifos,
-                    [ifo],
-                    fname,
-                )
                 thread_args = (
                     event, fname, comment, cmd, out_dir_path,
                     upload_checks, optimize_snr_checks


### PR DESCRIPTION
**Problem**: 
There was a potential race condition in `bin/pycbc_live` where:

- if a coinc or single occurs,
- `optimize_snr_checks == True`, 
- and the thread starts the optimize snr subprocess,

the main thread could have moved the analysis chunk on before the `setup_optimize_snr` function re-reads some data from self - the `event` class instance,. This causes lines like this: `curr_data = self.data_readers[ifo].overwhitened_data(delta_f)` to potentially read the wrong data.

**Solution**:
Split the `setup_optimize_snr` function, which normally accesses/modifies data in `event`, into two functions: `setup_optimize_snr`  and `run_optimize_snr`. The `setup` function reads and saves all the data in the main thread before any GraceDB uploads or optimizing ensuring the correct data is saved before the main thread moves the analysis on. It returns the command to be run as a subprocess and the output directory. The `run ` function takes these as inputs and runs after the event is uploaded.  
One extra modification I had to include is because the `setup_optimize_snr` function was dependent on the `gid` from GraceDB, the `run_optimize_snr` function has to re-open and close the attributes hdf to add the `gid` in.

Happy for any suggestions/modifications. This is the best idea I've had since I found this was happening. 