### PR TITLE
Update at_time method to allow float / vector types and extrapolation

### DIFF
--- a/pycbc/types/timeseries.py
+++ b/pycbc/types/timeseries.py
@@ -240,7 +240,7 @@ class TimeSeries(Array):
     sample_times = property(get_sample_times,
                             doc="Array containing the sample times.")
 
-    def at_time(self, time, nearest_sample=False, interpolate=None):
+    def at_time(self, time, nearest_sample=False, interpolate=None, extrapolate=None):
         """ Return the value at the specified gps time
 
         Parameters
@@ -251,51 +251,64 @@ class TimeSeries(Array):
         interpolate: str, None
             Return the interpolated value of the time series. Choices
             are simple linear or quadratic interpolation.
+        extrapolate: str or float, None
+            Value to return if time is outsidde the range of the vector or
+            method of extrapolating the value.
         """
+        if nearest_sample:
+            time += self.delta_t / 2.0
+        vtime = _numpy.array(time, ndmin=1)
+
+        fill_value = None
+        keep_idx = None
+        size = len(vtime)
+        if extrapolate is not None:
+            if _numpy.isscalar(extrapolate) and _numpy.isreal(extrapolate):
+                fill_value = extrapolate
+                facl = facr = 0
+                if interpolate == 'quadratic':
+                    facl = facr = 1.1
+                elif interpolate == 'linear':
+                    facl, facr = 0.1, 1.1
+
+                left = (vtime >= self.start_time + self.delta_t * facl)
+                right = (vtime < self.end_time - self.delta_t * facr)
+                keep_idx = _numpy.where(left & right)[0]
+                vtime = vtime[keep_idx]
+            else:
+                raise ValueError("Unsuported extrapolate: %s", extrapolate)
+
+        fi = (vtime - float(self.start_time))*self.sample_rate
+        i = _numpy.asarray(_numpy.floor(fi)).astype(int)
+        di = fi - i
+
         if interpolate == 'linear':
-            i = (time - float(self.start_time))*self.sample_rate
-            di = i - int(i)
-            i = int(i)
             a = self[i]
             b = self[i+1]
-            return a + (b - a) * di
+            ans = a + (b - a) * di
         elif interpolate == 'quadratic':
-            ir = (time - float(self.start_time))*self.sample_rate
-            i = _numpy.floor(_numpy.asarray(ir)).astype(int)
-            di = ir - i
             c = self.data[i]
             xr = self.data[i + 1] - c
             xl = self.data[i - 1] - c
             a = 0.5 * (xr + xl)
             b = 0.5 * (xr - xl)
             ans = a * di**2.0 + b * di + c
+        else:
+            ans = self[i]
+
+        ans = _numpy.array(ans, ndmin=1)
+        if fill_value is not None:
+            old = ans
+            ans = _numpy.zeros(size) + fill_value
+            ans[keep_idx] = old
+            ans = _numpy.array(ans, ndmin=1)
+
+        if _numpy.isscalar(time):
+            return  ans[0]
+        else:
             return ans
 
-        if nearest_sample:
-            time += self.delta_t / 2.0
-        return self[int((time-self.start_time)*self.sample_rate)]
-
-    def at_times(self, times, nearest_sample = False):
-        """ Return an array of values at the specified gps times
-
-        Parameters
-        ----------
-        times: array of floats
-            The times whose values are needed
-        nearest_sample: bool
-            Return the samples at the times nearest to the chosen times rather
-            than rounded down.
-
-        Returns
-        -------
-        values: array of floats
-            The values of the timeseries at the given times
-        """
-
-        if nearest_sample:
-            times += self.delta_t / 2.0
-        elapsed_times = times - self.start_time
-        return self[(elapsed_times * self.sample_rate).astype('int')]
+    at_times = at_time
 
     def __eq__(self,other):
         """

--- a/pycbc/types/timeseries.py
+++ b/pycbc/types/timeseries.py
@@ -240,7 +240,8 @@ class TimeSeries(Array):
     sample_times = property(get_sample_times,
                             doc="Array containing the sample times.")
 
-    def at_time(self, time, nearest_sample=False, interpolate=None, extrapolate=None):
+    def at_time(self, time, nearest_sample=False,
+                interpolate=None, extrapolate=None):
         """ Return the value at the specified gps time
 
         Parameters
@@ -256,7 +257,7 @@ class TimeSeries(Array):
             method of extrapolating the value.
         """
         if nearest_sample:
-            time += self.delta_t / 2.0
+            time = time + self.delta_t / 2.0
         vtime = _numpy.array(time, ndmin=1)
 
         fill_value = None

--- a/pycbc/types/timeseries.py
+++ b/pycbc/types/timeseries.py
@@ -277,7 +277,7 @@ class TimeSeries(Array):
                 keep_idx = _numpy.where(left & right)[0]
                 vtime = vtime[keep_idx]
             else:
-                raise ValueError("Unsuported extrapolate: %s", extrapolate)
+                raise ValueError("Unsuported extrapolate: %s" % extrapolate)
 
         fi = (vtime - float(self.start_time))*self.sample_rate
         i = _numpy.asarray(_numpy.floor(fi)).astype(int)
@@ -305,7 +305,7 @@ class TimeSeries(Array):
             ans = _numpy.array(ans, ndmin=1)
 
         if _numpy.isscalar(time):
-            return  ans[0]
+            return ans[0]
         else:
             return ans
 

--- a/test/test_timeseries.py
+++ b/test/test_timeseries.py
@@ -477,6 +477,33 @@ class TestTimeSeriesBase(array_base,unittest.TestCase):
             self.assertAlmostEqual(self.b.duration, 0.3)
             self.assertAlmostEqual(self.bad3.duration, 0.6)
 
+    def test_at_time(self):
+        a = TimeSeries([0, 1, 2, 3, 4, 5, 6, 7], delta_t=1.0)
+
+        self.assertAlmostEqual(a.at_time(0.5), 0.0)
+        self.assertAlmostEqual(a.at_time(0.6,  nearest_sample=True), 1.0)
+        self.assertAlmostEqual(a.at_time(0.5, interpolate='linear'), 0.5)
+        self.assertAlmostEqual(a.at_time([2.5],
+                               interpolate='quadratic'), 2.5)
+
+        i = numpy.array([-0.2, 0.5, 1.5, 7.0])
+
+        x = a.at_time(i, extrapolate=0)
+        n = numpy.array([0, 0.0, 1.0, 7.0])
+        self.assertAlmostEqual((x-n).sum(), 0)
+
+        x = a.at_time(i, extrapolate=0, nearest_sample=True)
+        n = numpy.array([0, 1.0, 2.0, 7.0])
+        self.assertAlmostEqual((x-n).sum(), 0)
+
+        x = a.at_time(i, extrapolate=0, interpolate='linear')
+        n = numpy.array([0, 0.5, 1.5, 0.0])
+        self.assertAlmostEqual((x-n).sum(), 0)
+
+        x = a.at_time(i, extrapolate=0, interpolate='quadratic')
+        n = numpy.array([0, 0.0, 1.5, 0.0])
+        self.assertAlmostEqual((x-n).sum(), 0)
+
     def test_inject(self):
         a = TimeSeries(numpy.zeros(2**20, dtype=numpy.float32),
                                    delta_t=1.0)


### PR DESCRIPTION
This mergers the at_time and at_times which had mixed functionality previously. Some vector functionality was only in at_time for example when at_times was added. This addresses that incongruity and so at_times now points to at_time.  And extrapolation fill value is also now possible to give. 

This also adds a unittest for this function.