### PR TITLE
Ensure latest version of conda compiler packages

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -57,8 +57,9 @@ deps =
     git+https://github.com/ConWea/BBHX-waveform-model.git; sys_platform == 'linux'
 conda_deps=
     mysqlclient
-    gcc_linux-64
-    gxx_linux-64
+    gcc_linux-64>=12.2.0
+    gxx_linux-64>=12.2.0
+    binutils_linux-64>=2.39
     gsl
     lapack==3.6.1
 conda_channels=conda-forge


### PR DESCRIPTION
This attempts to resolve #4355 by pinning conda versions of the compiler packages. I don't know why this would be needed .... All I can think is that some of the github runners have conda installed, and have older versions of these, which are then picked up in our builds (on certain runners).

