### PR TITLE
Unknown injections handling in offline

### DIFF
--- a/.github/workflows/search-workflow.yml
+++ b/.github/workflows/search-workflow.yml
@@ -44,6 +44,10 @@ jobs:
       run: bash -e examples/search/bank.sh
     - name: generating statistic files
       run: bash -e examples/search/stats.sh
+    - name: generating unknown injection files
+      run: |
+        cp examples/search/generate_injections.py ./
+        bash -e examples/search/generate_unknown_injections.sh
     - name: running workflow
       run: |
         cp examples/search/*.ini ./

--- a/bin/plotting/pycbc_page_foreground
+++ b/bin/plotting/pycbc_page_foreground
@@ -194,10 +194,12 @@ if args.output_file.endswith('.html'):
     save_fig_with_metadata(str(html_table), args.output_file, **kwds)
 
 elif args.output_file.endswith('.xml') or args.output_file.endswith('.xml.gz'):
-    fortrigs.to_coinc_xml_object(args.output_file)
+    fortrigs.to_coinc_xml_object(args.output_file,
+            exclusive=args.use_exclusive_ifar)
 
 elif args.output_file.endswith('.hdf'):
-    fortrigs.to_coinc_hdf_object(args.output_file)
+    fortrigs.to_coinc_hdf_object(args.output_file,
+            exclusive=args.use_exclusive_ifar)
 
 else:
     raise NotImplementedError("Output file format not recognised")

--- a/bin/plotting/pycbc_page_foreground
+++ b/bin/plotting/pycbc_page_foreground
@@ -22,6 +22,8 @@ parser.add_argument('--single-detector-triggers', nargs='+', default=None)
 parser.add_argument('--verbose', action='count')
 parser.add_argument('--output-file')
 parser.add_argument('--num-to-write', type=int)
+parser.add_argument('--table-title', default='Loudest Event Table',
+                    help="Title to use for the table.")
 parser.add_argument('--use-hierarchical-level', type=int, default=None,
                     help='Indicate which FARs to write to the table '
                          'based on the number of hierarchical removals done. '
@@ -175,8 +177,8 @@ if args.output_file.endswith('.html'):
     html_table = pycbc.results.html_table(columns, names,
                                    format_strings=format_strings, page_size=10)
 
-    kwds = { 'title' : 'Loudest Event Table',
-        'cmd' :' '.join(sys.argv), }
+    kwds = {'title' : args.table_title,
+            'cmd' :' '.join(sys.argv), }
     save_fig_with_metadata(str(html_table), args.output_file, **kwds)
 
 elif args.output_file.endswith('.xml') or args.output_file.endswith('.xml.gz'):

--- a/bin/plotting/pycbc_page_foreground
+++ b/bin/plotting/pycbc_page_foreground
@@ -24,6 +24,10 @@ parser.add_argument('--output-file')
 parser.add_argument('--num-to-write', type=int)
 parser.add_argument('--table-title', default='Loudest Event Table',
                     help="Title to use for the table.")
+parser.add_argument('--use-exclusive-ifar', action='store_true',
+                    help='Indicate to use exclusive IFAR rather than '
+                         'inclusive. Incompatible with '
+                         '--use-hierarchical-level.')
 parser.add_argument('--use-hierarchical-level', type=int, default=None,
                     help='Indicate which FARs to write to the table '
                          'based on the number of hierarchical removals done. '
@@ -36,6 +40,10 @@ parser.add_argument('--use-hierarchical-level', type=int, default=None,
                          'fail if the user selects a number above the number '
                          'of hierarchical removals done. [default=None]')
 args = parser.parse_args()
+
+if args.use_exclusive_ifar and args.use_hierarchical_level:
+    parser.error("Exclusive IFAR and hierarchical removal "
+                 "level given, this makes no sense.")
 
 f = h5py.File(args.trigger_file, 'r')
 
@@ -94,8 +102,12 @@ else :
                                       n_loudest=args.num_to_write)
 
 if args.output_file.endswith('.html'):
-    ifar = fortrigs.get_coincfile_array('ifar')
-    fap = fortrigs.get_coincfile_array('fap')
+    if args.use_exclusive_ifar:
+        ifar = fortrigs.get_coincfile_array('ifar_exc')
+        fap = fortrigs.get_coincfile_array('fap_exc')
+    else:
+        ifar = fortrigs.get_coincfile_array('ifar')
+        fap = fortrigs.get_coincfile_array('fap')
     stat = fortrigs.get_coincfile_array('stat')
     mass1 = fortrigs.get_bankfile_array('mass1')
     mass2 = fortrigs.get_bankfile_array('mass2')

--- a/bin/plotting/pycbc_page_foreground
+++ b/bin/plotting/pycbc_page_foreground
@@ -94,12 +94,14 @@ if h_num_rm is not None and h_iterations is not None \
     # independent of any removal
     fortrigs_exclusive = hdf.ForegroundTriggers(args.trigger_file, args.bank_file,
                                            sngl_files=args.single_detector_triggers,
-                                           n_loudest=args.num_to_write)
+                                           n_loudest=args.num_to_write,
+                                           has_inc=False)
 
 else :
     fortrigs = hdf.ForegroundTriggers(args.trigger_file, args.bank_file,
                                       sngl_files=args.single_detector_triggers,
-                                      n_loudest=args.num_to_write)
+                                      n_loudest=args.num_to_write,
+                                      has_inc=not args.use_exclusive_ifar)
 
 if args.output_file.endswith('.html'):
     if args.use_exclusive_ifar:
@@ -194,12 +196,10 @@ if args.output_file.endswith('.html'):
     save_fig_with_metadata(str(html_table), args.output_file, **kwds)
 
 elif args.output_file.endswith('.xml') or args.output_file.endswith('.xml.gz'):
-    fortrigs.to_coinc_xml_object(args.output_file,
-            exclusive=args.use_exclusive_ifar)
+    fortrigs.to_coinc_xml_object(args.output_file)
 
 elif args.output_file.endswith('.hdf'):
-    fortrigs.to_coinc_hdf_object(args.output_file,
-            exclusive=args.use_exclusive_ifar)
+    fortrigs.to_coinc_hdf_object(args.output_file)
 
 else:
     raise NotImplementedError("Output file format not recognised")

--- a/bin/workflows/pycbc_make_offline_search_workflow
+++ b/bin/workflows/pycbc_make_offline_search_workflow
@@ -469,6 +469,9 @@ fore_xmlall = wf.make_foreground_table(workflow, combined_bg_file,
 fore_xmlloudest = wf.make_foreground_table(workflow, combined_bg_file,
                     hdfbank, rdir['open_box_result'], singles=insps,
                     extension='.xml', tags=["xmlloudest"])
+fore_hdfall = wf.make_foreground_table(workflow, combined_bg_file,
+                    hdfbank, rdir['open_box_result'], singles=insps,
+                    extension='.hdf', tags=["hdfall"])
 
 symlink_result(table, 'open_box_result/significance')
 
@@ -563,31 +566,36 @@ splitbank_files_inj = wf.setup_splittable_workflow(workflow, [hdfbank],
 
 # setup the injection files
 inj_files_base, inj_tags = wf.setup_injection_workflow(workflow,
-                                                  output_dir="inj_files")
-
+                                                       output_dir="inj_files")
 inj_files = []
 for inj_file, tag in zip(inj_files_base, inj_tags):
-    inj_files.append(wf.inj_to_hdf(workflow, inj_file, 'inj_files', [tag]))
+    if inj_file is None:
+        # No injection file to convert
+        inj_files.append(inj_file)
+    else:
+        inj_files.append(wf.inj_to_hdf(workflow, inj_file, 'inj_files', [tag]))
 
 inj_coincs = wf.FileList()
 
 found_inj_dict ={}
 insps_dict = {}
+combined_inj_bg_files = {}
 
 files_for_combined_injfind = []
 for inj_file, tag in zip(inj_files, inj_tags):
     ctags = [tag, 'injections']
     output_dir = '%s_coinc' % tag
 
-    if workflow.cp.has_option_tags('workflow-injections',
-                                   'compute-optimal-snr', tags=ctags):
-        optimal_snr_file = wf.compute_inj_optimal_snr(
-                workflow, inj_file, psd_files, 'inj_files', tags=ctags)
-        file_for_injfind = optimal_snr_file
-    else:
-        file_for_injfind = inj_file
+    if inj_file is not None:
+        if workflow.cp.has_option_tags('workflow-injections',
+                                       'compute-optimal-snr', tags=ctags):
+            optimal_snr_file = wf.compute_inj_optimal_snr(
+                    workflow, inj_file, psd_files, 'inj_files', tags=ctags)
+            file_for_injfind = optimal_snr_file
+        else:
+            file_for_injfind = inj_file
 
-    files_for_combined_injfind.append(file_for_injfind)
+        files_for_combined_injfind.append(file_for_injfind)
 
     # setup the matchedfilter jobs
     insps = wf.setup_matchedfltr_workflow(workflow, analyzable_segs,
@@ -664,20 +672,22 @@ for inj_file, tag in zip(inj_files, inj_tags):
         output_dir,
         tags=combctags
     )
+    combined_inj_bg_files[tag] = combined_inj_bg_file
 
-    found_inj = wf.find_injections_in_hdf_coinc(
-        workflow,
-        [combined_inj_bg_file],
-        [file_for_injfind],
-        censored_veto,
-        censored_veto_name,
-        output_dir,
-        tags=combctags)
+    if inj_file is not None:
+        found_inj = wf.find_injections_in_hdf_coinc(
+            workflow,
+            [combined_inj_bg_file],
+            [file_for_injfind],
+            censored_veto,
+            censored_veto_name,
+            output_dir,
+            tags=combctags)
+        found_inj_dict[tag] = found_inj
 
     inj_coincs += [combined_inj_bg_file]
 
     # Set files for plots
-    found_inj_dict[tag] = found_inj
     insps_dict[tag] = insps
 
 # And the combined INJFIND file
@@ -695,6 +705,9 @@ if len(files_for_combined_injfind) > 0:
 ############################ Injection plots #################################
 # Per injection run plots
 for inj_file, tag in zip(inj_files, inj_tags):
+    if inj_file is None:
+        # This is an unknown injection set
+        continue
     found_inj = found_inj_dict[tag]
     insps = insps_dict[tag]
     injdir = rdir['injections/%s' % tag]
@@ -751,7 +764,7 @@ for inj_file, tag in zip(inj_files, inj_tags):
         wf.make_throughput_plot(workflow, insps, rdir['workflow/throughput'],
                                 tags=[tag])
 
-######################## Make combined injection plots ##########################
+####################### Make combined injection plots #########################
 if len(files_for_combined_injfind) > 0:
     sen_all = wf.make_sensitivity_plot(workflow, found_inj_comb,
                                        rdir['search_sensitivity'],
@@ -771,13 +784,46 @@ if len(files_for_combined_injfind) > 0:
                                      require='summ')
     inj_summ = list(layout.grouper(inj_s + sen_s, 2))
 
+###################### Results page for unknown injections ####################
+for inj_file, tag in zip(inj_files, inj_tags):
+    if inj_file is not None:
+        # This is a known injection set and we will plot in the usual way
+        continue
+    # run minifollowups on the output of the loudest events
+    mfup_dir_inj = rdir[f'open_box_result/{tag}_injection_followup']
+    wf.setup_foreground_minifollowups(workflow, combined_inj_bg_files[tag],
+                                      insps_dict[tag],
+                                      hdfbank,
+                                      insp_files_seg_file,
+                                      data_analysed_name,
+                                      trig_generated_name,
+                                      'daxes',
+                                      mfup_dir_inj,
+                                      tags=[tag])
+    table = wf.make_foreground_table(workflow,
+                                     combined_inj_bg_files[tag],
+                                     hdfbank,
+                                     rdir['open_box_result'],
+                                     singles=insps_dict[tag],
+                                     extension='.html',
+                                     tags=[tag])
+    # Make a summary hdf file
+    wf.make_foreground_table(workflow,
+                             combined_inj_bg_files[tag],
+                             hdfbank,
+                             rdir['open_box_result'],
+                             singles=insps_dict[tag],
+                             extension='.hdf',
+                             tags=[tag])
+
+
 # Make analysis time summary
 analysis_time_summ = [time_file, seg_summ_plot]
 for f in analysis_time_summ:
     symlink_result(f, 'analysis_time')
 layout.single_layout(rdir['analysis_time'], (analysis_time_summ))
 
-########################## Make full summary ####################################
+######################### Make full summary ###################################
 if len(files_for_combined_injfind) > 0:
     summ = ([(time_file,)] + [(seg_summ_plot,)] +
             [(seg_summ_table, veto_summ_table)] + det_summ + hist_summ +

--- a/bin/workflows/pycbc_make_offline_search_workflow
+++ b/bin/workflows/pycbc_make_offline_search_workflow
@@ -140,8 +140,9 @@ if 'hoft' in workflow.cp.get_subsections('workflow-datafind'):
 
 datafind_files, analyzable_file, analyzable_segs, analyzable_name = \
                                            wf.setup_datafind_workflow(workflow,
-                                     ssegs, "datafind",
-                                     seg_file=science_seg_file, tags=hoft_tags)
+                                           ssegs, "datafind",
+                                           seg_file=science_seg_file,
+                                           tags=['full_data'] + hoft_tags)
 
 final_veto_name = 'vetoes'
 final_veto_file = wf.get_segments_file(workflow, final_veto_name,
@@ -607,6 +608,7 @@ for inj_file, tag in zip(inj_files, inj_tags):
     else:
         datafind_files_inj = datafind_files
         analyzable_segs_inj = analyzable_segs
+
 
     insps = wf.setup_matchedfltr_workflow(
         workflow,

--- a/bin/workflows/pycbc_make_offline_search_workflow
+++ b/bin/workflows/pycbc_make_offline_search_workflow
@@ -142,7 +142,7 @@ datafind_files, analyzable_file, analyzable_segs, analyzable_name = \
                                            wf.setup_datafind_workflow(workflow,
                                            ssegs, "datafind",
                                            seg_file=science_seg_file,
-                                           tags=['full_data'] + hoft_tags)
+                                           tags=hoft_tags)
 
 final_veto_name = 'vetoes'
 final_veto_file = wf.get_segments_file(workflow, final_veto_name,
@@ -580,7 +580,7 @@ combined_inj_bg_files = {}
 
 files_for_combined_injfind = []
 for inj_file, tag in zip(inj_files, inj_tags):
-    ctags = [tag, 'injections']
+    ctags = [tag.lower(), 'injections']
     output_dir = '%s_coinc' % tag
 
     if inj_file is not None:
@@ -593,6 +593,8 @@ for inj_file, tag in zip(inj_files, inj_tags):
             file_for_injfind = inj_file
 
         files_for_combined_injfind.append(file_for_injfind)
+
+    print(datafind_files)
 
     # setup the matchedfilter jobs
     if inj_file is None:
@@ -609,7 +611,7 @@ for inj_file, tag in zip(inj_files, inj_tags):
         datafind_files_inj = datafind_files
         analyzable_segs_inj = analyzable_segs
 
-
+    
     insps = wf.setup_matchedfltr_workflow(
         workflow,
         analyzable_segs_inj,
@@ -706,6 +708,8 @@ for inj_file, tag in zip(inj_files, inj_tags):
 
     # Set files for plots
     insps_dict[tag] = insps
+
+exit()
 
 # And the combined INJFIND file
 if len(files_for_combined_injfind) > 0:

--- a/bin/workflows/pycbc_make_offline_search_workflow
+++ b/bin/workflows/pycbc_make_offline_search_workflow
@@ -458,7 +458,7 @@ ifar_ob = wf.make_ifar_plot(workflow, combined_bg_file,
                                     rdir['open_box_result'],
                                     tags=combined_bg_file.tags + ['open_box'],
                                     executable='page_ifar_catalog')
-table = wf.make_foreground_table(workflow, combined_bg_file,
+fore_table = wf.make_foreground_table(workflow, combined_bg_file,
                                  hdfbank, rdir['open_box_result'],
                                  singles=insps, extension='.html',
                                  tags=combined_bg_file.tags)
@@ -473,12 +473,8 @@ fore_hdfall = wf.make_foreground_table(workflow, combined_bg_file,
                     hdfbank, rdir['open_box_result'], singles=insps,
                     extension='.hdf', tags=["hdfall"])
 
-symlink_result(table, 'open_box_result/significance')
-
-# Set html pages
-main_page = [(ifar_ob,), (table, )]
-layout.two_column_layout(rdir['open_box_result'], main_page)
-
+main_page = [(ifar_ob,), (fore_table, )]
+#symlink_result(table, 'open_box_result/significance')
 #detailed_page = [(snrifar, ratehist), (snrifar_ifar, ifar_ob), (table,)]
 #layout.two_column_layout(rdir['open_box_result/significance'], detailed_page)
 
@@ -598,10 +594,29 @@ for inj_file, tag in zip(inj_files, inj_tags):
         files_for_combined_injfind.append(file_for_injfind)
 
     # setup the matchedfilter jobs
-    insps = wf.setup_matchedfltr_workflow(workflow, analyzable_segs,
-                                         datafind_files, splitbank_files_inj,
-                                         output_dir, tags=ctags,
-                                         injection_file=inj_file)
+    if inj_file is None:
+        # datafind may be different for unknown injections
+        datafind_files_inj, _, analyzable_segs_inj, _ = \
+            wf.setup_datafind_workflow(
+                workflow,
+                ssegs,
+                "datafind",
+                seg_file=science_seg_file,
+                tags=hoft_tags + ctags
+            )
+    else:
+        datafind_files_inj = datafind_files
+        analyzable_segs_inj = analyzable_segs
+
+    insps = wf.setup_matchedfltr_workflow(
+        workflow,
+        analyzable_segs_inj,
+        datafind_files_inj,
+        splitbank_files_inj,
+        output_dir,
+        tags=ctags,
+        injection_file=inj_file
+    )
 
     insps = wf.merge_single_detector_hdf_files(workflow, hdfbank,
                                                insps, output_dir, tags=ctags)
@@ -800,22 +815,29 @@ for inj_file, tag in zip(inj_files, inj_tags):
                                       'daxes',
                                       mfup_dir_inj,
                                       tags=[tag])
-    table = wf.make_foreground_table(workflow,
-                                     combined_inj_bg_files[tag],
-                                     hdfbank,
-                                     rdir['open_box_result'],
-                                     singles=insps_dict[tag],
-                                     extension='.html',
-                                     tags=[tag])
+    uk_table = wf.make_foreground_table(
+        workflow,
+        combined_inj_bg_files[tag],
+        hdfbank,
+        rdir['open_box_result'],
+        singles=insps_dict[tag],
+        extension='.html',
+        tags=[tag]
+    )
+    main_page.append((uk_table,))
     # Make a summary hdf file
-    wf.make_foreground_table(workflow,
-                             combined_inj_bg_files[tag],
-                             hdfbank,
-                             rdir['open_box_result'],
-                             singles=insps_dict[tag],
-                             extension='.hdf',
-                             tags=[tag])
+    wf.make_foreground_table(
+        workflow,
+        combined_inj_bg_files[tag],
+        hdfbank,
+        rdir['open_box_result'],
+        singles=insps_dict[tag],
+        extension='.hdf',
+        tags=[tag]
+    )
 
+# Set html pages
+layout.two_column_layout(rdir['open_box_result'], main_page)
 
 # Make analysis time summary
 analysis_time_summ = [time_file, seg_summ_plot]

--- a/bin/workflows/pycbc_make_offline_search_workflow
+++ b/bin/workflows/pycbc_make_offline_search_workflow
@@ -475,7 +475,7 @@ fore_hdfall = wf.make_foreground_table(workflow, combined_bg_file,
                     extension='.hdf', tags=["hdfall"])
 
 main_page = [(ifar_ob,), (fore_table, )]
-#symlink_result(table, 'open_box_result/significance')
+symlink_result(fore_table, 'open_box_result/significance')
 #detailed_page = [(snrifar, ratehist), (snrifar_ifar, ifar_ob), (table,)]
 #layout.two_column_layout(rdir['open_box_result/significance'], detailed_page)
 
@@ -580,7 +580,7 @@ combined_inj_bg_files = {}
 
 files_for_combined_injfind = []
 for inj_file, tag in zip(inj_files, inj_tags):
-    ctags = [tag.lower(), 'injections']
+    ctags = [tag, 'injections']
     output_dir = '%s_coinc' % tag
 
     if inj_file is not None:
@@ -603,7 +603,7 @@ for inj_file, tag in zip(inj_files, inj_tags):
                 ssegs,
                 "datafind",
                 seg_file=science_seg_file,
-                tags=hoft_tags + ctags
+                tags=hoft_tags+ctags
             )
     else:
         datafind_files_inj = datafind_files

--- a/bin/workflows/pycbc_make_offline_search_workflow
+++ b/bin/workflows/pycbc_make_offline_search_workflow
@@ -594,8 +594,6 @@ for inj_file, tag in zip(inj_files, inj_tags):
 
         files_for_combined_injfind.append(file_for_injfind)
 
-    print(datafind_files)
-
     # setup the matchedfilter jobs
     if inj_file is None:
         # datafind may be different for unknown injections
@@ -611,7 +609,6 @@ for inj_file, tag in zip(inj_files, inj_tags):
         datafind_files_inj = datafind_files
         analyzable_segs_inj = analyzable_segs
 
-    
     insps = wf.setup_matchedfltr_workflow(
         workflow,
         analyzable_segs_inj,
@@ -878,7 +875,7 @@ layout.single_layout(base, ini_file)
 
 
 # Create versioning information
-#create_versioning_page(rdir['workflow/version'], container.cp)
+create_versioning_page(rdir['workflow/version'], container.cp)
 
 
 ############################ Finalization ####################################

--- a/bin/workflows/pycbc_make_offline_search_workflow
+++ b/bin/workflows/pycbc_make_offline_search_workflow
@@ -709,8 +709,6 @@ for inj_file, tag in zip(inj_files, inj_tags):
     # Set files for plots
     insps_dict[tag] = insps
 
-exit()
-
 # And the combined INJFIND file
 if len(files_for_combined_injfind) > 0:
     found_inj_comb = wf.find_injections_in_hdf_coinc(
@@ -880,7 +878,7 @@ layout.single_layout(base, ini_file)
 
 
 # Create versioning information
-create_versioning_page(rdir['workflow/version'], container.cp)
+#create_versioning_page(rdir['workflow/version'], container.cp)
 
 
 ############################ Finalization ####################################

--- a/examples/search/analysis.ini
+++ b/examples/search/analysis.ini
@@ -114,11 +114,11 @@ finalize-events-template-rate = 500
 injection-window = 4.5
 processing-scheme = mkl
 
-[single_template-h1&plot_singles_timefreq-h1&plot_qscan-h1&inspiral-h1&calculate_psd-h1]
+[single_template-full_data-h1&plot_singles_timefreq-full_data-h1&plot_qscan-full_data-h1&inspiral-full_data-h1&calculate_psd-h1]
 frame-files = ${workflow-defaultvalues|h1-frame-file}
 channel-name = ${workflow-defaultvalues|h1-channel-name}
 
-[single_template-l1&plot_singles_timefreq-l1&plot_qscan-l1&inspiral-l1&calculate_psd-l1]
+[single_template-full_data-l1&plot_singles_timefreq-full_data-l1&plot_qscan-full_data-l1&inspiral-full_data-l1&calculate_psd-l1]
 frame-files = ${workflow-defaultvalues|l1-frame-file}
 channel-name = ${workflow-defaultvalues|l1-channel-name}
 

--- a/examples/search/analysis.ini
+++ b/examples/search/analysis.ini
@@ -15,6 +15,8 @@ l1 =
 v1 =
 
 [workflow-datafind]
+
+[workflow-datafind-full_data]
 datafind-method = AT_RUNTIME_FAKE_DATA
 datafind-check-frames-exist = no_test
 datafind-check-segment-gaps = no_test
@@ -112,15 +114,15 @@ finalize-events-template-rate = 500
 injection-window = 4.5
 processing-scheme = mkl
 
-[single_template-h1&plot_singles_timefreq-h1&plot_qscan-h1&inspiral-h1&calculate_psd-h1]
+[single_template-full_data-h1&plot_singles_timefreq-full_data-h1&plot_qscan-full_data-h1&inspiral-full_data-h1&calculate_psd-h1]
 frame-files = ${workflow|h1-frame-file}
 channel-name = ${workflow|h1-channel-name}
 
-[single_template-l1&plot_singles_timefreq-l1&plot_qscan-l1&inspiral-l1&calculate_psd-l1]
+[single_template-full_data-l1&plot_singles_timefreq-full_data-l1&plot_qscan-full_data-l1&inspiral-full_data-l1&calculate_psd-l1]
 frame-files = ${workflow|l1-frame-file}
 channel-name = ${workflow|l1-channel-name}
 
-[single_template-v1&plot_singles_timefreq-v1&plot_qscan-v1&inspiral-v1&calculate_psd-v1]
+[single_template-full_data-v1&plot_singles_timefreq-full_data-v1&plot_qscan-full_data-v1&inspiral-full_data-v1&calculate_psd-v1]
 frame-files = ${workflow|v1-frame-file}
 channel-name = ${workflow|v1-channel-name}
 

--- a/examples/search/analysis.ini
+++ b/examples/search/analysis.ini
@@ -3,7 +3,7 @@ file-retention-level = merged_triggers
 start-time = 1186740100
 end-time =   1186743500
 
-[workflow-defaultvalues]
+[workflow-commonvalues]
 h1-channel-name = H1:LOSC-STRAIN
 l1-channel-name = L1:LOSC-STRAIN
 v1-channel-name = V1:LOSC-STRAIN
@@ -115,16 +115,16 @@ injection-window = 4.5
 processing-scheme = mkl
 
 [single_template-full_data-h1&plot_singles_timefreq-full_data-h1&plot_qscan-full_data-h1&inspiral-full_data-h1&calculate_psd-h1]
-frame-files = ${workflow-defaultvalues|h1-frame-file}
-channel-name = ${workflow-defaultvalues|h1-channel-name}
+frame-files = ${workflow-commonvalues|h1-frame-file}
+channel-name = ${workflow-commonvalues|h1-channel-name}
 
 [single_template-full_data-l1&plot_singles_timefreq-full_data-l1&plot_qscan-full_data-l1&inspiral-full_data-l1&calculate_psd-l1]
-frame-files = ${workflow-defaultvalues|l1-frame-file}
-channel-name = ${workflow-defaultvalues|l1-channel-name}
+frame-files = ${workflow-commonvalues|l1-frame-file}
+channel-name = ${workflow-commonvalues|l1-channel-name}
 
 [single_template-full_data-v1&plot_singles_timefreq-full_data-v1&plot_qscan-full_data-v1&inspiral-full_data-v1&calculate_psd-v1]
-frame-files = ${workflow-defaultvalues|v1-frame-file}
-channel-name = ${workflow-defaultvalues|v1-channel-name}
+frame-files = ${workflow-commonvalues|v1-frame-file}
+channel-name = ${workflow-commonvalues|v1-channel-name}
 
 [calculate_psd]
 cores = 1

--- a/examples/search/analysis.ini
+++ b/examples/search/analysis.ini
@@ -2,6 +2,8 @@
 file-retention-level = merged_triggers
 start-time = 1186740100
 end-time =   1186743500
+
+[workflow-defaultvalues]
 h1-channel-name = H1:LOSC-STRAIN
 l1-channel-name = L1:LOSC-STRAIN
 v1-channel-name = V1:LOSC-STRAIN
@@ -15,8 +17,6 @@ l1 =
 v1 =
 
 [workflow-datafind]
-
-[workflow-datafind-full_data]
 datafind-method = AT_RUNTIME_FAKE_DATA
 datafind-check-frames-exist = no_test
 datafind-check-segment-gaps = no_test
@@ -114,17 +114,17 @@ finalize-events-template-rate = 500
 injection-window = 4.5
 processing-scheme = mkl
 
-[single_template-full_data-h1&plot_singles_timefreq-full_data-h1&plot_qscan-full_data-h1&inspiral-full_data-h1&calculate_psd-h1]
-frame-files = ${workflow|h1-frame-file}
-channel-name = ${workflow|h1-channel-name}
+[single_template-h1&plot_singles_timefreq-h1&plot_qscan-h1&inspiral-h1&calculate_psd-h1]
+frame-files = ${workflow-defaultvalues|h1-frame-file}
+channel-name = ${workflow-defaultvalues|h1-channel-name}
 
-[single_template-full_data-l1&plot_singles_timefreq-full_data-l1&plot_qscan-full_data-l1&inspiral-full_data-l1&calculate_psd-l1]
-frame-files = ${workflow|l1-frame-file}
-channel-name = ${workflow|l1-channel-name}
+[single_template-l1&plot_singles_timefreq-l1&plot_qscan-l1&inspiral-l1&calculate_psd-l1]
+frame-files = ${workflow-defaultvalues|l1-frame-file}
+channel-name = ${workflow-defaultvalues|l1-channel-name}
 
 [single_template-full_data-v1&plot_singles_timefreq-full_data-v1&plot_qscan-full_data-v1&inspiral-full_data-v1&calculate_psd-v1]
-frame-files = ${workflow|v1-frame-file}
-channel-name = ${workflow|v1-channel-name}
+frame-files = ${workflow-defaultvalues|v1-frame-file}
+channel-name = ${workflow-defaultvalues|v1-channel-name}
 
 [calculate_psd]
 cores = 1

--- a/examples/search/analysis.ini
+++ b/examples/search/analysis.ini
@@ -191,6 +191,7 @@ cluster-window = ${statmap|cluster-window}
 loudest-keep-values = 15.0:9999999999999
 
 [coinc-injinj]
+coinc-threshold = 0.0025
 
 [sngls]
 trigger-cuts = newsnr:5.5:lower traditional_chisq:12:upper sigma_multiple:10:upper

--- a/examples/search/bank.sh
+++ b/examples/search/bank.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -e
 
+if [ ! -f bank.hdf ] ; then
 pycbc_brute_bank \
 --verbose \
 --output-file bank.hdf \
@@ -19,3 +20,4 @@ pycbc_brute_bank \
 --params mass1 mass2 spin1z spin2z \
 --seed 1 \
 --low-frequency-cutoff 20.0
+fi

--- a/examples/search/gen.sh
+++ b/examples/search/gen.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-/home/gareth.cabourndavies/test_codes/pycbc/unknown_injections/env_unknown-injections/src/pycbc/bin/workflows/pycbc_make_offline_search_workflow \
+pycbc_make_offline_search_workflow \
 --workflow-name gw \
 --output-dir output \
 --config-files \

--- a/examples/search/gen.sh
+++ b/examples/search/gen.sh
@@ -4,5 +4,10 @@ set -e
 /home/gareth.cabourndavies/test_codes/pycbc/unknown_injections/env_unknown-injections/src/pycbc/bin/workflows/pycbc_make_offline_search_workflow \
 --workflow-name gw \
 --output-dir output \
---config-files analysis.ini plotting.ini executables.ini injections_minimal.ini injections_unknown.ini \
+--config-files \
+  analysis.ini \
+  plotting.ini \
+  executables.ini \
+  injections_minimal.ini \
+  injections_unknown.ini \
 --config-overrides results_page:output-path:$(pwd)/html

--- a/examples/search/gen.sh
+++ b/examples/search/gen.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -e
 
-pycbc_make_offline_search_workflow \
+/home/gareth.cabourndavies/test_codes/pycbc/unknown_injections/env_unknown-injections/src/pycbc/bin/workflows/pycbc_make_offline_search_workflow \
 --workflow-name gw \
 --output-dir output \
---config-files analysis.ini plotting.ini executables.ini injections_minimal.ini \
+--config-files analysis.ini plotting.ini executables.ini injections_minimal.ini injections_unknown.ini \
 --config-overrides results_page:output-path:$(pwd)/html

--- a/examples/search/generate_injections.py
+++ b/examples/search/generate_injections.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+
+import sys
+import numpy as np
+import h5py
+
+dtype = [('mass1', float), ('mass2', float),
+         ('spin1z', float), ('spin2z', float),
+         ('tc', float), ('distance', float),
+         ('ra', float), ('dec', float),
+         ('approximant', 'S32')]
+
+static_params = {'f_lower': 17.,
+                 'f_ref': 17.,
+                 'taper': 'start',
+                 'inclination': 0.,
+                 'coa_phase': 0.,
+                 'polarization': 0.}
+
+samples = np.array([None] * 3, dtype=dtype)
+
+# masses and spins are intended to match the highest
+# and lowest mass templates in the template bank
+# Last injection is designed to be found as an EM-bright single
+samples['mass1'] = [290.929321, 41.1331687, 2.2756491]
+samples['mass2'] = [3.6755455, 31.010624, 1.1077247]
+samples['spin1z'] = [0.9934847, 0.029544285, -0.59105825]
+samples['spin2z'] = [0.92713535, 0.020993788, 0.047548451]
+
+# Injections must be between 1186740069 and 1186743653
+samples['tc'] = [1186741000.1294786, 1186742000.91204, 1186743000.1298376]
+samples['distance'] = [178., 130., 47.]
+samples['ra'] = [np.deg2rad(45), np.deg2rad(10), np.deg2rad(-10)]
+samples['dec'] = [np.deg2rad(45), np.deg2rad(-45), np.deg2rad(45)]
+
+samples['approximant'] = ['SEOBNRv4_opt', 'SEOBNRv4_opt', 'SpinTaylorT4']
+
+
+with h5py.File('injections.hdf','w') as injout:
+    for k, dt in dtype:
+        injout[k] = samples[k]
+    for p, v in static_params.items():
+        injout.attrs[p] = v
+    injout.attrs['static_args'] = list(static_params.keys())
+    injout.attrs['cmd'] = " ".join(sys.argv)
+    injout.attrs['injtype'] = "cbc"

--- a/examples/search/generate_unknown_injections.sh
+++ b/examples/search/generate_unknown_injections.sh
@@ -29,7 +29,7 @@ then
             --channel-name $1:SIMULATED_STRAIN \
             --frame-duration 3584 \
             --injection-file injections.hdf \
-	    --fft-backends mkl
+	    --fft-backends fftw
 
 
 	echo "${1::1} ${1}_simulated 1186740069 3584 $pwd/strain/$1/$1-SIMULATED_STRAIN-$start_time-3584.gwf" >> strain/$1/$1-cache.lcf

--- a/examples/search/generate_unknown_injections.sh
+++ b/examples/search/generate_unknown_injections.sh
@@ -28,7 +28,8 @@ then
             --low-frequency-cutoff 15 \
             --channel-name $1:SIMULATED_STRAIN \
             --frame-duration 3584 \
-            --injection-file injections.hdf
+            --injection-file injections.hdf \
+	    --fft-backends mkl
 
 
 	echo "${1::1} ${1}_simulated 1186740069 3584 $pwd/strain/$1/$1-SIMULATED_STRAIN-$start_time-3584.gwf" >> strain/$1/$1-cache.lcf

--- a/examples/search/generate_unknown_injections.sh
+++ b/examples/search/generate_unknown_injections.sh
@@ -1,0 +1,41 @@
+if [[ ! -f injections.hdf ]]
+then
+    echo -e "\\n\\n>> [`date`] Generating injections"
+
+    rm -rf ./strain
+
+    ./generate_injections.py
+fi
+
+start_time=1186740069
+end_time=1186743653
+if [[ ! -d strain ]]
+then
+    echo -e "\\n\\n>> [`date`] Generating simulated strain"
+
+    function simulate_strain { # detector PSD_model random_seed
+        mkdir -p strain/$1
+
+        out_path="strain/$1/$1-SIMULATED_STRAIN-{start}-{duration}.gwf"
+
+        pycbc_condition_strain \
+            --fake-strain $2 \
+            --fake-strain-seed $3 \
+            --output-strain-file $out_path \
+            --gps-start-time $start_time \
+            --gps-end-time $end_time \
+            --sample-rate 16384 \
+            --low-frequency-cutoff 15 \
+            --channel-name $1:SIMULATED_STRAIN \
+            --frame-duration 3584 \
+            --injection-file injections.hdf
+
+
+	echo "${1::1} ${1}_simulated 1186740069 3584 $pwd/strain/$1/$1-SIMULATED_STRAIN-$start_time-3584.gwf" >> strain/$1/$1-cache.lcf
+    }
+    simulate_strain H1 aLIGOMidLowSensitivityP1200087 1234
+    simulate_strain L1 aLIGOMidLowSensitivityP1200087 2345
+    simulate_strain V1 AdVEarlyLowSensitivityP1200087 3456
+
+fi
+

--- a/examples/search/generate_unknown_injections.sh
+++ b/examples/search/generate_unknown_injections.sh
@@ -2,22 +2,20 @@ if [[ ! -f injections.hdf ]]
 then
     echo -e "\\n\\n>> [`date`] Generating injections"
 
-    rm -rf ./strain
+    rm -f ./*-SIMULATED_STRAIN-*.gwf
 
     ./generate_injections.py
 fi
 
 start_time=1186740069
 end_time=1186743653
-if [[ ! -d strain ]]
-then
-    echo -e "\\n\\n>> [`date`] Generating simulated strain"
 
-    function simulate_strain { # detector PSD_model random_seed
-        mkdir -p strain/$1
+function simulate_strain { # detector PSD_model random_seed
 
-        out_path="strain/$1/$1-SIMULATED_STRAIN-{start}-{duration}.gwf"
-
+    out_path="$1-SIMULATED_STRAIN-{start}-{duration}.gwf"
+    if [[ ! -f $1-SIMULATED_STRAIN-1186740069-3584.gwf ]]
+    then
+        echo -e "\\n\\n>> [`date`] Generating simulated strain in $1"
         pycbc_condition_strain \
             --fake-strain $2 \
             --fake-strain-seed $3 \
@@ -29,14 +27,12 @@ then
             --channel-name $1:SIMULATED_STRAIN \
             --frame-duration 3584 \
             --injection-file injections.hdf \
-	    --fft-backends fftw
+            --fft-backends fftw
+    fi
+}
 
+simulate_strain H1 aLIGOMidLowSensitivityP1200087 1234
+simulate_strain L1 aLIGOMidLowSensitivityP1200087 2345
+simulate_strain V1 AdVEarlyLowSensitivityP1200087 3456
 
-	echo "${1::1} ${1}_simulated 1186740069 3584 $pwd/strain/$1/$1-SIMULATED_STRAIN-$start_time-3584.gwf" >> strain/$1/$1-cache.lcf
-    }
-    simulate_strain H1 aLIGOMidLowSensitivityP1200087 1234
-    simulate_strain L1 aLIGOMidLowSensitivityP1200087 2345
-    simulate_strain V1 AdVEarlyLowSensitivityP1200087 3456
-
-fi
 

--- a/examples/search/get.sh
+++ b/examples/search/get.sh
@@ -1,6 +1,13 @@
 #!/bin/bash
 set -e
 
+
+if [ ! -f H-H1_LOSC_CLN_4_V1-1186740069-3584.gwf ] ; then
 wget -nv https://dcc.ligo.org/public/0146/P1700341/001/H-H1_LOSC_CLN_4_V1-1186740069-3584.gwf
+fi
+if [ ! -f L-L1_LOSC_CLN_4_V1-1186740069-3584.gwf ] ; then
 wget -nv https://dcc.ligo.org/public/0146/P1700341/001/L-L1_LOSC_CLN_4_V1-1186740069-3584.gwf
+fi
+if [ ! -f V-V1_LOSC_CLN_4_V1-1186739813-4096.gwf ] ; then
 wget -nv https://dcc.ligo.org/public/0146/P1700341/001/V-V1_LOSC_CLN_4_V1-1186739813-4096.gwf
+fi

--- a/examples/search/injections_minimal.ini
+++ b/examples/search/injections_minimal.ini
@@ -62,3 +62,6 @@ datafind-pregenerated-cache-file-v1 = ${resolve:./strain/V1/V1-cache.lcf}
 [page_foreground-unknown]
 table-title = "Loudest recovered unknown injections"
 use-exclusive-ifar =
+
+[foreground_minifollowup-unknown]
+analysis-category = foreground

--- a/examples/search/injections_minimal.ini
+++ b/examples/search/injections_minimal.ini
@@ -1,12 +1,16 @@
 [workflow-injections]
 
-#[workflow-bbh]
-#h1-channel-name = ${workflow|h1-channel-name}
-#l1-channel-name = ${workflow|l1-channel-name}
-#v1-channel-name = ${workflow|v1-channel-name}
-#h1-frame-file = ${workflow|h1-frame-file}
-#l1-frame-file = ${workflow|l1-frame-file}
-#v1-frame-file = ${workflow|v1-frame-file}
+[single_template-bbh-h1&plot_singles_timefreq-bbh-h1&plot_qscan-bbh-h1&inspiral-bbh-h1]
+frame-files = ${workflow-defaultvalues|h1-frame-file}
+channel-name = ${workflow-defaultvalues|h1-channel-name}
+
+[single_template-bbh-l1&plot_singles_timefreq-bbh-l1&plot_qscan-bbh-l1&inspiral-bbh-l1]
+frame-files = ${workflow-defaultvalues|l1-frame-file}
+channel-name = ${workflow-defaultvalues|l1-channel-name}
+
+[single_template-bbh-v1&plot_singles_timefreq-bbh-v1&plot_qscan-bbh-v1&inspiral-bbh-v1]
+frame-files = ${workflow-defaultvalues|v1-frame-file}
+channel-name = ${workflow-defaultvalues|v1-channel-name}
 
 [workflow-optimal-snr]
 parallelization-factor = 2

--- a/examples/search/injections_minimal.ini
+++ b/examples/search/injections_minimal.ini
@@ -1,7 +1,4 @@
 [workflow-injections]
-injections-method = IN_WORKFLOW
-strip-injections =
-compute-optimal-snr =
 
 [workflow-optimal-snr]
 parallelization-factor = 2
@@ -25,6 +22,9 @@ time-interval = 25
 time-step = 50
 
 [workflow-injections-bbh]
+injections-method = IN_WORKFLOW
+strip-injections =
+compute-optimal-snr =
 
 [injections-bbh]
 dchirp-distr = uniform
@@ -42,3 +42,22 @@ taper-injection = start
 seed = 123407
 f-lower = 25
 disable-spin =
+
+[workflow-injections-unknown]
+injections-method = IN_FRAME
+
+[injections-unknown]
+
+[workflow-unknown-datafind]
+datafind-method = FROM_PREGENERATED_LCF_FILES
+datafind-check-segment-gaps = update_times
+datafind-check-frames-exist = raise_error
+datafind-h1-frame-type = H1_simulated
+datafind-l1-frame-type = L1_simulated
+datafind-v1-frame-type = V1_simulated
+datafind-pregenerated-cache-file-h1 = ${resolve:./strain/H1/H1-cache.lcf}
+datafind-pregenerated-cache-file-l1 = ${resolve:./strain/L1/L1-cache.lcf}
+datafind-pregenerated-cache-file-v1 = ${resolve:./strain/V1/V1-cache.lcf}
+
+[page_foreground-unknown]
+table-title = "Loudest recovered unknown injections"

--- a/examples/search/injections_minimal.ini
+++ b/examples/search/injections_minimal.ini
@@ -48,16 +48,22 @@ injections-method = IN_FRAME
 
 [injections-unknown]
 
-[workflow-unknown-datafind]
-datafind-method = FROM_PREGENERATED_LCF_FILES
-datafind-check-segment-gaps = update_times
-datafind-check-frames-exist = raise_error
-datafind-h1-frame-type = H1_simulated
-datafind-l1-frame-type = L1_simulated
-datafind-v1-frame-type = V1_simulated
-datafind-pregenerated-cache-file-h1 = ${resolve:./strain/H1/H1-cache.lcf}
-datafind-pregenerated-cache-file-l1 = ${resolve:./strain/L1/L1-cache.lcf}
-datafind-pregenerated-cache-file-v1 = ${resolve:./strain/V1/V1-cache.lcf}
+[workflow-datafind-unknown]
+datafind-method = AT_RUNTIME_FAKE_DATA
+datafind-check-frames-exist = no_test
+datafind-check-segment-gaps = no_test
+
+[single_template-unknown-injections-h1&plot_singles_timefreq-unknown-injections-h1&plot_qscan-unknown-injections-h1&inspiral-full_data-unknown-injections-h1]
+frame-files = ${resolve:./H1-SIMULATED_STRAIN-1186740069-3584.gwf}
+channel-name = H1:SIMULATED_STRAIN
+
+[single_template-unknown-injections-l1&plot_singles_timefreq-unknown-injections-l1&plot_qscan-unknown-injections-l1&inspiral-full_data-unknown-injections-l1]
+frame-files = ${resolve:./L1-SIMULATED_STRAIN-1186740069-3584.gwf}
+channel-name = L1:SIMULATED_STRAIN
+
+[single_template-unknown-injections-v1&plot_singles_timefreq-unknown-injections-v1&plot_qscan-unknown-injections-v1&inspiral-full_data-unknown-injections-v1]
+frame-files = ${resolve:./V1-SIMULATED_STRAIN-1186740069-3584.gwf}
+channel-name = V1:SIMULATED_STRAIN
 
 [page_foreground-unknown]
 table-title = "Loudest recovered unknown injections"

--- a/examples/search/injections_minimal.ini
+++ b/examples/search/injections_minimal.ini
@@ -1,16 +1,16 @@
 [workflow-injections]
 
 [single_template-bbh-h1&plot_singles_timefreq-bbh-h1&plot_qscan-bbh-h1&inspiral-bbh-h1]
-frame-files = ${workflow-defaultvalues|h1-frame-file}
-channel-name = ${workflow-defaultvalues|h1-channel-name}
+frame-files = ${workflow-commonvalues|h1-frame-file}
+channel-name = ${workflow-commonvalues|h1-channel-name}
 
 [single_template-bbh-l1&plot_singles_timefreq-bbh-l1&plot_qscan-bbh-l1&inspiral-bbh-l1]
-frame-files = ${workflow-defaultvalues|l1-frame-file}
-channel-name = ${workflow-defaultvalues|l1-channel-name}
+frame-files = ${workflow-commonvalues|l1-frame-file}
+channel-name = ${workflow-commonvalues|l1-channel-name}
 
 [single_template-bbh-v1&plot_singles_timefreq-bbh-v1&plot_qscan-bbh-v1&inspiral-bbh-v1]
-frame-files = ${workflow-defaultvalues|v1-frame-file}
-channel-name = ${workflow-defaultvalues|v1-channel-name}
+frame-files = ${workflow-commonvalues|v1-frame-file}
+channel-name = ${workflow-commonvalues|v1-channel-name}
 
 [workflow-optimal-snr]
 parallelization-factor = 2

--- a/examples/search/injections_minimal.ini
+++ b/examples/search/injections_minimal.ini
@@ -61,3 +61,4 @@ datafind-pregenerated-cache-file-v1 = ${resolve:./strain/V1/V1-cache.lcf}
 
 [page_foreground-unknown]
 table-title = "Loudest recovered unknown injections"
+use-exclusive-ifar =

--- a/examples/search/injections_minimal.ini
+++ b/examples/search/injections_minimal.ini
@@ -65,3 +65,7 @@ use-exclusive-ifar =
 
 [foreground_minifollowup-unknown]
 analysis-category = foreground
+sort-variable = ifar_exc
+
+[page_coincinfo-unknown]
+statmap-file-subspace-name = foreground

--- a/examples/search/injections_minimal.ini
+++ b/examples/search/injections_minimal.ini
@@ -1,5 +1,13 @@
 [workflow-injections]
 
+#[workflow-bbh]
+#h1-channel-name = ${workflow|h1-channel-name}
+#l1-channel-name = ${workflow|l1-channel-name}
+#v1-channel-name = ${workflow|v1-channel-name}
+#h1-frame-file = ${workflow|h1-frame-file}
+#l1-frame-file = ${workflow|l1-frame-file}
+#v1-frame-file = ${workflow|v1-frame-file}
+
 [workflow-optimal-snr]
 parallelization-factor = 2
 
@@ -42,36 +50,3 @@ taper-injection = start
 seed = 123407
 f-lower = 25
 disable-spin =
-
-[workflow-injections-unknown]
-injections-method = IN_FRAME
-
-[injections-unknown]
-
-[workflow-datafind-unknown]
-datafind-method = AT_RUNTIME_FAKE_DATA
-datafind-check-frames-exist = no_test
-datafind-check-segment-gaps = no_test
-
-[single_template-unknown-injections-h1&plot_singles_timefreq-unknown-injections-h1&plot_qscan-unknown-injections-h1&inspiral-full_data-unknown-injections-h1]
-frame-files = ${resolve:./H1-SIMULATED_STRAIN-1186740069-3584.gwf}
-channel-name = H1:SIMULATED_STRAIN
-
-[single_template-unknown-injections-l1&plot_singles_timefreq-unknown-injections-l1&plot_qscan-unknown-injections-l1&inspiral-full_data-unknown-injections-l1]
-frame-files = ${resolve:./L1-SIMULATED_STRAIN-1186740069-3584.gwf}
-channel-name = L1:SIMULATED_STRAIN
-
-[single_template-unknown-injections-v1&plot_singles_timefreq-unknown-injections-v1&plot_qscan-unknown-injections-v1&inspiral-full_data-unknown-injections-v1]
-frame-files = ${resolve:./V1-SIMULATED_STRAIN-1186740069-3584.gwf}
-channel-name = V1:SIMULATED_STRAIN
-
-[page_foreground-unknown]
-table-title = "Loudest recovered unknown injections"
-use-exclusive-ifar =
-
-[foreground_minifollowup-unknown]
-analysis-category = foreground
-sort-variable = ifar_exc
-
-[page_coincinfo-unknown]
-statmap-file-subspace-name = foreground

--- a/examples/search/injections_unknown.ini
+++ b/examples/search/injections_unknown.ini
@@ -3,29 +3,26 @@ injections-method = IN_FRAME
 
 [injections-unknown]
 
-;[workflow-datafind-unknown]
-;datafind-method = AT_RUNTIME_FAKE_DATA
-;datafind-check-frames-exist = no_test
-;datafind-check-segment-gaps = no_test
-;h1-channel-name = H1:SIMULATED_STRAIN
-;l1-channel-name = L1:SIMULATED_STRAIN
-;v1-channel-name = V1:SIMULATED_STRAIN
-;h1-frame-file = ${resolve:./H1-SIMULATED_STRAIN-1186740069-3584.gwf}
-;l1-frame-file = ${resolve:./L1-SIMULATED_STRAIN-1186740069-3584.gwf}
-;v1-frame-file = ${resolve:./V1-SIMULATED_STRAIN-1186740069-3584.gwf}
-;
-;[single_template-unknown-h1&plot_singles_timefreq-unknown-h1&plot_qscan-unknown-h1&inspiral-unknown-h1]
-;channel-name = ${workflow-datafind-unknown|h1-channel-name}
-;frame-files = ${workflow-datafind-unknown|h1-frame-file}
-;
-;[single_template-unknown-l1&plot_singles_timefreq-unknown-l1&plot_qscan-unknown-l1&inspiral-unknown-l1]
-;channel-name = ${workflow-datafind-unknown|l1-channel-name}
-;frame-files = ${workflow-datafind-unknown|l1-frame-file}
-;
-;[single_template-unknown-v1&plot_singles_timefreq-unknown-v1&plot_qscan-unknown-v1&inspiral-unknown-v1]
-;channel-name = ${workflow-datafind-unknown|v1-channel-name}
-;frame-files = ${workflow-datafind-unknown|v1-frame-file}
-;
+[workflow-datafind-unknown]
+h1-channel-name = H1:SIMULATED_STRAIN
+l1-channel-name = L1:SIMULATED_STRAIN
+v1-channel-name = V1:SIMULATED_STRAIN
+h1-frame-file = ${resolve:./H1-SIMULATED_STRAIN-1186740069-3584.gwf}
+l1-frame-file = ${resolve:./L1-SIMULATED_STRAIN-1186740069-3584.gwf}
+v1-frame-file = ${resolve:./V1-SIMULATED_STRAIN-1186740069-3584.gwf}
+
+[single_template-unknown-h1&plot_singles_timefreq-unknown-h1&plot_qscan-unknown-h1&inspiral-unknown-h1]
+channel-name = ${workflow-datafind-unknown|h1-channel-name}
+frame-files = ${workflow-datafind-unknown|h1-frame-file}
+
+[single_template-unknown-l1&plot_singles_timefreq-unknown-l1&plot_qscan-unknown-l1&inspiral-unknown-l1]
+channel-name = ${workflow-datafind-unknown|l1-channel-name}
+frame-files = ${workflow-datafind-unknown|l1-frame-file}
+
+[single_template-unknown-v1&plot_singles_timefreq-unknown-v1&plot_qscan-unknown-v1&inspiral-unknown-v1]
+channel-name = ${workflow-datafind-unknown|v1-channel-name}
+frame-files = ${workflow-datafind-unknown|v1-frame-file}
+
 [page_foreground-unknown]
 table-title = "Loudest recovered unknown injections"
 use-exclusive-ifar =

--- a/examples/search/injections_unknown.ini
+++ b/examples/search/injections_unknown.ini
@@ -1,0 +1,38 @@
+[workflow-injections-unknown]
+injections-method = IN_FRAME
+
+[injections-unknown]
+
+;[workflow-datafind-unknown]
+;datafind-method = AT_RUNTIME_FAKE_DATA
+;datafind-check-frames-exist = no_test
+;datafind-check-segment-gaps = no_test
+;h1-channel-name = H1:SIMULATED_STRAIN
+;l1-channel-name = L1:SIMULATED_STRAIN
+;v1-channel-name = V1:SIMULATED_STRAIN
+;h1-frame-file = ${resolve:./H1-SIMULATED_STRAIN-1186740069-3584.gwf}
+;l1-frame-file = ${resolve:./L1-SIMULATED_STRAIN-1186740069-3584.gwf}
+;v1-frame-file = ${resolve:./V1-SIMULATED_STRAIN-1186740069-3584.gwf}
+;
+;[single_template-unknown-h1&plot_singles_timefreq-unknown-h1&plot_qscan-unknown-h1&inspiral-unknown-h1]
+;channel-name = ${workflow-datafind-unknown|h1-channel-name}
+;frame-files = ${workflow-datafind-unknown|h1-frame-file}
+;
+;[single_template-unknown-l1&plot_singles_timefreq-unknown-l1&plot_qscan-unknown-l1&inspiral-unknown-l1]
+;channel-name = ${workflow-datafind-unknown|l1-channel-name}
+;frame-files = ${workflow-datafind-unknown|l1-frame-file}
+;
+;[single_template-unknown-v1&plot_singles_timefreq-unknown-v1&plot_qscan-unknown-v1&inspiral-unknown-v1]
+;channel-name = ${workflow-datafind-unknown|v1-channel-name}
+;frame-files = ${workflow-datafind-unknown|v1-frame-file}
+;
+[page_foreground-unknown]
+table-title = "Loudest recovered unknown injections"
+use-exclusive-ifar =
+
+[foreground_minifollowup-unknown]
+analysis-category = foreground
+sort-variable = ifar_exc
+
+[page_coincinfo-unknown]
+statmap-file-subspace-name = foreground

--- a/examples/search/master.sh
+++ b/examples/search/master.sh
@@ -7,7 +7,7 @@ bash -e stats.sh
 bash -e generate_unknown_injections.sh
 bash -e gen.sh
 
+cp *.gwf output
 cd output
-ln -sf ../*.gwf .
 bash -e ../submit.sh
-#python ../check_job.py
+python ../check_job.py

--- a/examples/search/master.sh
+++ b/examples/search/master.sh
@@ -7,7 +7,7 @@ bash -e stats.sh
 bash -e generate_unknown_injections.sh
 bash -e gen.sh
 
-cp *.gwf output
+mv *.gwf output
 cd output
 bash -e ../submit.sh
 python ../check_job.py

--- a/examples/search/master.sh
+++ b/examples/search/master.sh
@@ -7,7 +7,7 @@ bash -e stats.sh
 bash -e generate_unknown_injections.sh
 bash -e gen.sh
 
-mv *.gwf output
 cd output
+ln -sf ../*.gwf .
 bash -e ../submit.sh
-python ../check_job.py
+#python ../check_job.py

--- a/examples/search/master.sh
+++ b/examples/search/master.sh
@@ -4,6 +4,7 @@ set -e
 bash -e get.sh
 bash -e bank.sh
 bash -e stats.sh
+bash -e generate_unknown_injections.sh
 bash -e gen.sh
 
 cp *.gwf output

--- a/examples/search/plotting.ini
+++ b/examples/search/plotting.ini
@@ -1,6 +1,6 @@
 [pycbc_ifar_catalog]
 [workflow-minifollowups]
-num-events=1
+num-events=3
 
 [workflow-sngl_minifollowups]
 num-sngl-events=1

--- a/examples/search/plotting.ini
+++ b/examples/search/plotting.ini
@@ -1,6 +1,6 @@
 [pycbc_ifar_catalog]
 [workflow-minifollowups]
-num-events=3
+num-events=1
 
 [workflow-sngl_minifollowups]
 num-sngl-events=1

--- a/examples/search/plotting.ini
+++ b/examples/search/plotting.ini
@@ -237,6 +237,8 @@ log-y =
 [page_foreground-xmlloudest]
 num-to-write = 2
 
+[page_foreground-hdfall]
+
 [page_injections]
 [plot_segments]
 [plot_gating]

--- a/examples/search/stats.sh
+++ b/examples/search/stats.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -e
 
+if [ ! -f statHL.hdf ] ; then
 pycbc_dtphase \
 --ifos H1 L1 \
 --relative-sensitivities .7 1 \
@@ -10,7 +11,9 @@ pycbc_dtphase \
 --output-file statHL.hdf \
 --smoothing-sigma 1 \
 --verbose
+fi
 
+if [ ! -f statLV.hdf ] ; then
 pycbc_dtphase \
 --ifos L1 V1 \
 --relative-sensitivities 1 0.3 \
@@ -20,7 +23,9 @@ pycbc_dtphase \
 --output-file statLV.hdf \
 --smoothing-sigma 1 \
 --verbose
+fi
 
+if [ ! -f statHV.hdf ] ; then
 pycbc_dtphase \
 --ifos H1 V1 \
 --relative-sensitivities .7 .3 \
@@ -30,8 +35,9 @@ pycbc_dtphase \
 --output-file statHV.hdf \
 --smoothing-sigma 1 \
 --verbose
+fi
 
-
+if [ ! -f statHLV.hdf ] ; then
 pycbc_dtphase \
 --ifos H1 L1 V1 \
 --relative-sensitivities .7 1 .3 \
@@ -42,3 +48,4 @@ pycbc_dtphase \
 --output-file statHLV.hdf \
 --smoothing-sigma 1 \
 --verbose
+fi

--- a/pycbc/io/hdf.py
+++ b/pycbc/io/hdf.py
@@ -853,7 +853,7 @@ class ForegroundTriggers(object):
                      for trig in iter(np.array(ifo_or_minus).T)]
         return ifos_list
 
-    def to_coinc_xml_object(self, file_name):
+    def to_coinc_xml_object(self, file_name, exclusive=False):
         outdoc = ligolw.Document()
         outdoc.appendChild(ligolw.LIGO_LW())
 
@@ -917,7 +917,11 @@ class ForegroundTriggers(object):
         for name in bank_col_names:
             bank_col_vals[name] = self.get_bankfile_array(name)
 
-        coinc_event_names = ['ifar', 'time', 'fap', 'stat']
+        coinc_event_names = ['time', 'stat']
+        if exclusive:
+            coinc_event_names += ['ifar_exc', 'fap_exc']
+        else:
+            coinc_event_names += ['ifar', 'fap']
         coinc_event_vals = {}
         for name in coinc_event_names:
             if name == 'time':
@@ -1022,7 +1026,7 @@ class ForegroundTriggers(object):
 
         ligolw_utils.write_filename(outdoc, file_name)
 
-    def to_coinc_hdf_object(self, file_name):
+    def to_coinc_hdf_object(self, file_name, exclusive=False):
         ofd = h5py.File(file_name,'w')
 
         # Some fields are special cases
@@ -1031,7 +1035,7 @@ class ForegroundTriggers(object):
         # time will be used later to determine active ifos
         ofd['time'] = time
 
-        if self._inclusive:
+        if not exclusive:
             ofd['ifar'] = self.get_coincfile_array('ifar')
             ofd['p_value'] = self.get_coincfile_array('fap')
 

--- a/pycbc/io/hdf.py
+++ b/pycbc/io/hdf.py
@@ -853,7 +853,7 @@ class ForegroundTriggers(object):
                      for trig in iter(np.array(ifo_or_minus).T)]
         return ifos_list
 
-    def to_coinc_xml_object(self, file_name, exclusive=False):
+    def to_coinc_xml_object(self, file_name):
         outdoc = ligolw.Document()
         outdoc.appendChild(ligolw.LIGO_LW())
 
@@ -918,10 +918,10 @@ class ForegroundTriggers(object):
             bank_col_vals[name] = self.get_bankfile_array(name)
 
         coinc_event_names = ['time', 'stat']
-        if exclusive:
-            coinc_event_names += ['ifar_exc', 'fap_exc']
-        else:
+        if self._inclusive:
             coinc_event_names += ['ifar', 'fap']
+        else:
+            coinc_event_names += ['ifar_exc', 'fap_exc']
         coinc_event_vals = {}
         for name in coinc_event_names:
             if name == 'time':
@@ -1007,16 +1007,16 @@ class ForegroundTriggers(object):
             coinc_inspiral_row.mass = sngl_combined_mtot
             coinc_inspiral_row.end = LIGOTimeGPS(coinc_event_vals['time'][idx])
             coinc_inspiral_row.snr = net_snrsq**0.5
-            if exclusive:
-                coinc_inspiral_row.false_alarm_rate = \
-                    coinc_event_vals['fap_exc'][idx]
-                coinc_inspiral_row.combined_far = \
-                    1./coinc_event_vals['ifar_exc'][idx]
-            else:
+            if self._inclusive:
                 coinc_inspiral_row.false_alarm_rate = \
                     coinc_event_vals['fap'][idx]
                 coinc_inspiral_row.combined_far = \
                     1./coinc_event_vals['ifar'][idx]
+            else:
+                coinc_inspiral_row.false_alarm_rate = \
+                    coinc_event_vals['fap_exc'][idx]
+                coinc_inspiral_row.combined_far = \
+                    1./coinc_event_vals['ifar_exc'][idx]
             # Transform to Hz
             coinc_inspiral_row.combined_far = \
                                     coinc_inspiral_row.combined_far / YRJUL_SI
@@ -1034,7 +1034,7 @@ class ForegroundTriggers(object):
 
         ligolw_utils.write_filename(outdoc, file_name)
 
-    def to_coinc_hdf_object(self, file_name, exclusive=False):
+    def to_coinc_hdf_object(self, file_name):
         ofd = h5py.File(file_name,'w')
 
         # Some fields are special cases
@@ -1043,7 +1043,7 @@ class ForegroundTriggers(object):
         # time will be used later to determine active ifos
         ofd['time'] = time
 
-        if not exclusive:
+        if self._inclusive:
             ofd['ifar'] = self.get_coincfile_array('ifar')
             ofd['p_value'] = self.get_coincfile_array('fap')
 

--- a/pycbc/io/hdf.py
+++ b/pycbc/io/hdf.py
@@ -1007,8 +1007,16 @@ class ForegroundTriggers(object):
             coinc_inspiral_row.mass = sngl_combined_mtot
             coinc_inspiral_row.end = LIGOTimeGPS(coinc_event_vals['time'][idx])
             coinc_inspiral_row.snr = net_snrsq**0.5
-            coinc_inspiral_row.false_alarm_rate = coinc_event_vals['fap'][idx]
-            coinc_inspiral_row.combined_far = 1./coinc_event_vals['ifar'][idx]
+            if exclusive:
+                coinc_inspiral_row.false_alarm_rate = \
+                        coinc_event_vals['fap_exc'][idx]
+                coinc_inspiral_row.combined_far = \
+                        1./coinc_event_vals['ifar_exc'][idx]
+            else:
+                coinc_inspiral_row.false_alarm_rate = \
+                        coinc_event_vals['fap'][idx]
+                coinc_inspiral_row.combined_far = \
+                        1./coinc_event_vals['ifar'][idx]
             # Transform to Hz
             coinc_inspiral_row.combined_far = \
                                     coinc_inspiral_row.combined_far / YRJUL_SI

--- a/pycbc/io/hdf.py
+++ b/pycbc/io/hdf.py
@@ -1009,14 +1009,14 @@ class ForegroundTriggers(object):
             coinc_inspiral_row.snr = net_snrsq**0.5
             if exclusive:
                 coinc_inspiral_row.false_alarm_rate = \
-                        coinc_event_vals['fap_exc'][idx]
+                    coinc_event_vals['fap_exc'][idx]
                 coinc_inspiral_row.combined_far = \
-                        1./coinc_event_vals['ifar_exc'][idx]
+                    1./coinc_event_vals['ifar_exc'][idx]
             else:
                 coinc_inspiral_row.false_alarm_rate = \
-                        coinc_event_vals['fap'][idx]
+                    coinc_event_vals['fap'][idx]
                 coinc_inspiral_row.combined_far = \
-                        1./coinc_event_vals['ifar'][idx]
+                    1./coinc_event_vals['ifar'][idx]
             # Transform to Hz
             coinc_inspiral_row.combined_far = \
                                     coinc_inspiral_row.combined_far / YRJUL_SI

--- a/pycbc/workflow/jobsetup.py
+++ b/pycbc/workflow/jobsetup.py
@@ -540,10 +540,9 @@ class PyCBCInspiralExecutable(Executable):
         data_seg = segments.segment([int(data_seg[0]), int(data_seg[1])])
         fil.add_metadata('data_seg', data_seg)
         node.add_input_opt('--bank-file', parent)
-        print(df_parents)
         if df_parents is not None:
             node.add_input_list_opt('--frame-files', df_parents)
-        print(node._options)
+
         return node
 
     def get_valid_times(self):

--- a/pycbc/workflow/jobsetup.py
+++ b/pycbc/workflow/jobsetup.py
@@ -540,9 +540,10 @@ class PyCBCInspiralExecutable(Executable):
         data_seg = segments.segment([int(data_seg[0]), int(data_seg[1])])
         fil.add_metadata('data_seg', data_seg)
         node.add_input_opt('--bank-file', parent)
+        print(df_parents)
         if df_parents is not None:
             node.add_input_list_opt('--frame-files', df_parents)
-
+        print(node._options)
         return node
 
     def get_valid_times(self):


### PR DESCRIPTION
Allow the offline search to use injections which do not have an associated injection file.

For the use-case I am thinking of, we would be provided frame files with an unknown set of injections by an external team.

We would then use the alternative datafind settings on the config for the injected data, but use the original uninjected data for the background in the same way we do for known injections.

These would then show up as an additional minifollowup in the open box results, and a `.hdf` results file is made in the open box results directory which can be used for reporting results

Draft status is due to ongoing testing, this will be removed once the testing has completed and passed sensible checks