### PR TITLE
Fix edge case in PyCBC Live's check for horizon distance

### DIFF
--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -1099,13 +1099,10 @@ with ctx:
             else:
                 psd_count[ifo] -= 1
 
-            if data_reader[ifo].psd is not None:
-                dist = data_reader[ifo].psd.dist
-                if dist < args.min_psd_abort_distance or dist > args.max_psd_abort_distance:
-                    logging.info("%s PSD dist %s outside acceptable range [%s, %s]",
-                                 ifo, dist, args.min_psd_abort_distance,
-                                 args.max_psd_abort_distance)
-                    status = False
+            status &= data_reader[ifo].check_psd_dist(
+                args.min_psd_abort_distance,
+                args.max_psd_abort_distance
+            )
 
             if status is True:
                 evnt.live_detectors.add(ifo)

--- a/pycbc/strain/strain.py
+++ b/pycbc/strain/strain.py
@@ -1713,14 +1713,14 @@ class StrainBuffer(pycbc.frame.DataBuffer):
 
     def check_psd_dist(self, min_dist, max_dist):
         """Check that the horizon distance of a detector is within a required
-        range.
+        range. If so, return True, otherwise log a warning and return False.
         """
         if self.psd is None:
             # ignore check
             return True
         # Note that the distance can in principle be inf or nan, e.g. if h(t)
         # is identically zero. The check must fail in those cases.  Be careful
-        # with how the logic works out!
+        # with how the logic works out when comparing inf's or nan's!
         good = self.psd.dist >= min_dist and self.psd.dist <= max_dist
         if not good:
             logging.info(
@@ -1730,8 +1730,7 @@ class StrainBuffer(pycbc.frame.DataBuffer):
                 min_dist,
                 max_dist
             )
-            return False
-        return True
+        return good
 
     def overwhitened_data(self, delta_f):
         """ Return overwhitened data

--- a/pycbc/strain/strain.py
+++ b/pycbc/strain/strain.py
@@ -1711,6 +1711,28 @@ class StrainBuffer(pycbc.frame.DataBuffer):
         logging.info("Recalculating %s PSD, %s", self.detector, psd.dist)
         return True
 
+    def check_psd_dist(self, min_dist, max_dist):
+        """Check that the horizon distance of a detector is within a required
+        range.
+        """
+        if self.psd is None:
+            # ignore check
+            return True
+        # Note that the distance can in principle be inf or nan, e.g. if h(t)
+        # is identically zero. The check must fail in those cases.  Be careful
+        # with how the logic works out!
+        good = self.psd.dist >= min_dist and self.psd.dist <= max_dist
+        if not good:
+            logging.info(
+                "%s PSD dist %s outside acceptable range [%s, %s]",
+                self.detector,
+                self.psd.dist,
+                min_dist,
+                max_dist
+            )
+            return False
+        return True
+
     def overwhitened_data(self, delta_f):
         """ Return overwhitened data
 


### PR DESCRIPTION
I just noticed the following behavior in PyCBC Live:
```
2023-05-16T13:25:43.870-07:00 node1466 77 Analyzing from 1368303948.069336
2023-05-16T13:25:47.320-07:00 node1466 77 Recalculating H1 PSD, nan
2023-05-16T13:25:47.320-07:00 node1466 77 Filtering H1
```
Here the horizon distance turned out to be nan for whatever reason (probably h(t) being identically zero, and we are not being very strict with the state vector at the moment) but PyCBC Live happily went ahead and tried to do matched filtering on the data anyway. It turns out that the check for the horizon distance does not work correctly for the case where the distance is nan. This PR changes the logic so as to produce a correct result in this case, and moves the check away from `pycbc_live` and into the StrainBuffer class.