### PR TITLE
Allow a force override character in config files

### DIFF
--- a/pycbc/types/config.py
+++ b/pycbc/types/config.py
@@ -33,6 +33,7 @@ import configparser as ConfigParser
 
 _force_override = "!"
 
+
 class DeepCopyableConfigParser(ConfigParser.ConfigParser):
     """
     The standard SafeConfigParser no longer supports deepcopy() as of python

--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -382,28 +382,26 @@ class Executable(pegasus_workflow.Executable):
                 # stuff later.
                 self.unresolved_td_options[opt] = value
             else:
-                existing_opt_match = [ov == opt
+                # This option comes from the config file(s)
+                existing_option_match = [ov == opt
                                       for ov in self.common_options]
-                if numpy.count_nonzero(existing_opt_match) > 1:
+                if numpy.count_nonzero(existing_option_match) > 1:
                         # Config file options cannot be given multiple times,
                         # so there should not be multiple versions of this,
                         # raise an error.
                         raise ValueError(
-                            "The option exists more than once already!"
+                            "An option exists more than once already "
+                            "- this should not happen!"
                         )
-                if not any(existing_opt_match):
+                if not any(existing_option_match):
                     # This option doesn't exist yet - add it as normal
                     self.common_options += [opt, value]
-                elif not override:
-                    # This option already exists in the list and does not have
-                    # the _force_override character set, so do not add it
-                    pass
-                else:
+                elif override:
                     # This value is already in the options, but
                     # should be overridden by the forced option
                     # There will be exactly one match given checks already
                     # performed
-                    replace_idx = numpy.flatnonzero(existing_opt_match)[0] + 1
+                    replace_idx = numpy.flatnonzero(existing_option_match)[0] + 1
                     self.common_options[replace_idx] = value
 
     def add_opt(self, opt, value=None):

--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -384,15 +384,15 @@ class Executable(pegasus_workflow.Executable):
             else:
                 # This option comes from the config file(s)
                 existing_option_match = [ov == opt
-                                      for ov in self.common_options]
+                                         for ov in self.common_options]
                 if numpy.count_nonzero(existing_option_match) > 1:
-                        # Config file options cannot be given multiple times,
-                        # so there should not be multiple versions of this,
-                        # raise an error.
-                        raise ValueError(
-                            "An option exists more than once already "
-                            "- this should not happen!"
-                        )
+                    # Config file options cannot be given multiple times,
+                    # so there should not be multiple versions of this,
+                    # raise an error.
+                    raise ValueError(
+                        "An option exists more than once already "
+                        "- this should not happen!"
+                    )
                 if not any(existing_option_match):
                     # This option doesn't exist yet - add it as normal
                     self.common_options += [opt, value]
@@ -401,8 +401,8 @@ class Executable(pegasus_workflow.Executable):
                     # should be overridden by the forced option
                     # There will be exactly one match given checks already
                     # performed
-                    replace_idx = numpy.flatnonzero(existing_option_match)[0] + 1
-                    self.common_options[replace_idx] = value
+                    option_idx = numpy.flatnonzero(existing_option_match)[0]
+                    self.common_options[option_idx + 1] = value
 
     def add_opt(self, opt, value=None):
         """Add option to job.


### PR DESCRIPTION
Allow a character to be placed (currently !), in order to tell the config to overwrite any previously-given options

Some of the changes are so that the current checks for whether there are duplicates in the config aren't applied

Tests performed/planned:
 - [x] ValueError with same option twice and no `!`
 - [x] ValueError on attempt to provide a `!` for a section with a subsection (i.e. [fit_by_template!-h1])
 - [x] ValueError if given an overriding subsection to an already-forced section
 - Interpolation:
    - [x] Can the section be used (with or without the !) for later interpolation?
    - [x] Will the interpolation be performed for a subsection with a `!`?
 - [x] Are other sections unaffected by this change when they shouldn't be?
 - [x] Is everything the same given an identical ini file with no `!` set?

(please add any that you would like to see)