### PR TITLE
Add argument verification for singles

### DIFF
--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -928,7 +928,8 @@ args = parser.parse_args()
 
 scheme.verify_processing_options(args, parser)
 fft.verify_fft_options(args, parser)
-LiveSingle.verify_args(args, parser)
+ifos = set(args.channel_name.keys())
+analyze_singles = LiveSingle.verify_args(args, parser, ifos)
 
 if args.output_background is not None and len(args.output_background) != 2:
     parser.error('--output-background takes two parameters: period and path')
@@ -955,7 +956,6 @@ if bank.min_f_lower < args.low_frequency_cutoff:
                  'minimum f_lower across all templates '
                  '({} Hz)'.format(args.low_frequency_cutoff, bank.min_f_lower))
 
-ifos = set(args.channel_name.keys())
 logging.info('Analyzing data from detectors %s', ppdets(ifos))
 
 evnt = LiveEventManager(args, bank)
@@ -1030,7 +1030,7 @@ with ctx:
     evnt.data_readers = data_reader
 
     # create single-detector background "estimators"
-    if evnt.rank == 0:
+    if analyze_singles and evnt.rank == 0:
         sngl_estimator = {ifo: LiveSingle.from_cli(args, ifo)
                           for ifo in ifos}
 
@@ -1167,7 +1167,8 @@ with ctx:
                 evnt.check_coincs(list(results.keys()), best_coinc, psds)
 
             # Check for singles
-            evnt.check_singles(results, psds)
+            if analyze_singles:
+                evnt.check_singles(results, psds)
 
             gates = {ifo: data_reader[ifo].gate_params for ifo in data_reader}
 

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -867,8 +867,6 @@ parser.add_argument('--ifar-double-followup-threshold', type=float, required=Tru
 parser.add_argument('--pvalue-combination-livetime', type=float, required=True,
                     help="Livetime used for p-value combination with followup "
                          "detectors, in years")
-parser.add_argument('--enable-single-detector-background', action='store_true', default=False)
-
 parser.add_argument('--enable-gracedb-upload', action='store_true', default=False,
                     help='Upload triggers to GraceDB')
 parser.add_argument('--enable-production-gracedb-upload', action='store_true', default=False,
@@ -1032,7 +1030,7 @@ with ctx:
     evnt.data_readers = data_reader
 
     # create single-detector background "estimators"
-    if args.enable_single_detector_background and evnt.rank == 0:
+    if evnt.rank == 0:
         sngl_estimator = {ifo: LiveSingle.from_cli(args, ifo)
                           for ifo in ifos}
 
@@ -1169,8 +1167,7 @@ with ctx:
                 evnt.check_coincs(list(results.keys()), best_coinc, psds)
 
             # Check for singles
-            if args.enable_single_detector_background:
-                evnt.check_singles(results, psds)
+            evnt.check_singles(results, psds)
 
             gates = {ifo: data_reader[ifo].gate_params for ifo in data_reader}
 

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -927,8 +927,10 @@ mchirp_area.insert_args(parser)
 livepau.insert_live_pastro_option_group(parser)
 
 args = parser.parse_args()
+
 scheme.verify_processing_options(args, parser)
 fft.verify_fft_options(args, parser)
+LiveSingle.verify_args(args, parser)
 
 if args.output_background is not None and len(args.output_background) != 2:
     parser.error('--output-background takes two parameters: period and path')

--- a/examples/live/run.sh
+++ b/examples/live/run.sh
@@ -197,14 +197,13 @@ $python_version -m mpi4py $pycbc_live_version \
 --src-class-mchirp-to-delta 0.01 \
 --src-class-eff-to-lum-distance 0.74899 \
 --src-class-lum-distance-to-delta -0.51557 -0.32195 \
+--single-reduced-chisq-threshold 2 \
 --single-duration-threshold 7 \
 --single-newsnr-threshold 9 \
---single-reduced-chisq-threshold 2 \
---single-fit-file single_trigger_fits.hdf \
 --sngl-ifar-est-dist conservative \
---run-snr-optimization \
 --verbose
 
+#--run-snr-optimization \
 
 # note that, at this point, some SNR optimization processes may still be
 # running, so the checks below may ignore their results
@@ -225,6 +224,7 @@ echo -e "\\n\\n>> [`date`] Checking results"
     --injections injections.hdf \
     --detectors H1 L1 V1
 
+exit
 echo -e "\\n\\n>> [`date`] Running Bayestar"
 for XMLFIL in `find output -type f -name \*.xml\* | sort`
 do

--- a/examples/live/run.sh
+++ b/examples/live/run.sh
@@ -119,17 +119,14 @@ rm -rf ./output
 
 echo -e "\\n\\n>> [`date`] Running PyCBC Live"
 
-# -x PYTHONPATH -x LD_LIBRARY_PATH -x OMP_NUM_THREADS -x VIRTUAL_ENV -x PATH -x HDF5_USE_FILE_LOCKING \
-
-python_version=/home/gareth.cabourndavies/environments/singles_input_checking/bin/python
-pycbc_live_version=/home/gareth.cabourndavies/test_codes/pycbclive/singles_input_checking/singles_input_checking/pycbc/bin/pycbc_live
 
 mpirun \
 -host localhost,localhost \
 -n 2 \
 --bind-to none \
+ -x PYTHONPATH -x LD_LIBRARY_PATH -x OMP_NUM_THREADS -x VIRTUAL_ENV -x PATH -x HDF5_USE_FILE_LOCKING \
 \
-$python_version -m mpi4py $pycbc_live_version \
+python -m mpi4py `which pycbc_live` \
 --bank-file template_bank.hdf \
 --sample-rate 2048 \
 --enable-bank-start-frequency \
@@ -197,13 +194,13 @@ $python_version -m mpi4py $pycbc_live_version \
 --src-class-mchirp-to-delta 0.01 \
 --src-class-eff-to-lum-distance 0.74899 \
 --src-class-lum-distance-to-delta -0.51557 -0.32195 \
---single-reduced-chisq-threshold 2 \
---single-duration-threshold 7 \
---single-newsnr-threshold 9 \
+--run-snr-optimization \
 --sngl-ifar-est-dist conservative \
+--single-newsnr-threshold 9 \
+--single-duration-threshold 7 \
+--single-reduced-chisq-threshold 2 \
+--single-fit-file single_trigger_fits.hdf \
 --verbose
-
-#--run-snr-optimization \
 
 # note that, at this point, some SNR optimization processes may still be
 # running, so the checks below may ignore their results
@@ -224,7 +221,6 @@ echo -e "\\n\\n>> [`date`] Checking results"
     --injections injections.hdf \
     --detectors H1 L1 V1
 
-exit
 echo -e "\\n\\n>> [`date`] Running Bayestar"
 for XMLFIL in `find output -type f -name \*.xml\* | sort`
 do

--- a/examples/live/run.sh
+++ b/examples/live/run.sh
@@ -119,14 +119,17 @@ rm -rf ./output
 
 echo -e "\\n\\n>> [`date`] Running PyCBC Live"
 
+# -x PYTHONPATH -x LD_LIBRARY_PATH -x OMP_NUM_THREADS -x VIRTUAL_ENV -x PATH -x HDF5_USE_FILE_LOCKING \
+
+python_version=/home/gareth.cabourndavies/environments/singles_input_checking/bin/python
+pycbc_live_version=/home/gareth.cabourndavies/test_codes/pycbclive/singles_input_checking/singles_input_checking/pycbc/bin/pycbc_live
 
 mpirun \
 -host localhost,localhost \
 -n 2 \
 --bind-to none \
- -x PYTHONPATH -x LD_LIBRARY_PATH -x OMP_NUM_THREADS -x VIRTUAL_ENV -x PATH -x HDF5_USE_FILE_LOCKING \
 \
-python -m mpi4py `which pycbc_live` \
+$python_version -m mpi4py $pycbc_live_version \
 --bank-file template_bank.hdf \
 --sample-rate 2048 \
 --enable-bank-start-frequency \
@@ -194,14 +197,14 @@ python -m mpi4py `which pycbc_live` \
 --src-class-mchirp-to-delta 0.01 \
 --src-class-eff-to-lum-distance 0.74899 \
 --src-class-lum-distance-to-delta -0.51557 -0.32195 \
---run-snr-optimization \
---enable-single-detector-background \
---single-newsnr-threshold 9 \
 --single-duration-threshold 7 \
+--single-newsnr-threshold 9 \
 --single-reduced-chisq-threshold 2 \
 --single-fit-file single_trigger_fits.hdf \
 --sngl-ifar-est-dist conservative \
+--run-snr-optimization \
 --verbose
+
 
 # note that, at this point, some SNR optimization processes may still be
 # running, so the checks below may ignore their results

--- a/pycbc/events/single.py
+++ b/pycbc/events/single.py
@@ -133,7 +133,6 @@ class LiveSingle(object):
         # The checks already performed mean that all(sngl_opts) is okay
         return all(sngl_opts)
 
-
     @classmethod
     def from_cli(cls, args, ifo):
         return cls(

--- a/pycbc/events/single.py
+++ b/pycbc/events/single.py
@@ -66,20 +66,35 @@ class LiveSingle(object):
                                  'a single value or as detector-value pairs, '
                                  'e.g. H1:mean L1:mean V1:conservative')
 
+
+    @staticmethod
+    def verify_args(args, parser):
+        sngl_opts = [args.single_fit_file,
+                     args.single_reduced_chisq_threshold,
+                     args.single_duration_threshold,
+                     args.single_newsnr_threshold]
+        sngl_opts_str = ("--single-fit-file, "
+                         "--single-reduced-chisq-threshold, "
+                         "--single-duration-threshold, "
+                         "--single-newsnr-threshold")
+        if args.enable_single_detector_background and not all(sngl_opts):
+            parser.error(f"Single detector trigger options ({sngl_opts_str}) "
+                         "must ALL be given if "
+                         "--enable-single-detector-background is set.")
+        if any(sngl_opts) and not args.enable_single_detector_background:
+            parser.error(f"Single detector trigger options ({sngl_opts_str}) "
+                         "given, but --enable-single-detector-background "
+                         "is not set.")
+        if args.enable_single_detector_upload \
+                and not all([args.enable_single_detector_background,
+                             args.enable_gracedb_upload]):
+            parser.error("--enable-single-detector-upload does not make "
+                         "sense without both --enable-gracedb-upload "
+                         "and --enable-single-detector-background set.")
+
+
     @classmethod
     def from_cli(cls, args, ifo):
-        sngl_opts_required = all([args.single_fit_file,
-                                  args.single_reduced_chisq_threshold,
-                                  args.single_duration_threshold,
-                                  args.single_newsnr_threshold])
-        if args.enable_single_detector_background and not sngl_opts_required:
-            raise RuntimeError("Single detector trigger options "
-                               "(--single-fit-file, "
-                               "--single-reduced-chisq-threshold, "
-                               "--single-duration-threshold, "
-                               "--single-newsnr-threshold) "
-                               "must ALL be given if single detector "
-                               "background is enabled")
         return cls(
            ifo, newsnr_threshold=args.single_newsnr_threshold[ifo],
            reduced_chisq_threshold=args.single_reduced_chisq_threshold[ifo],

--- a/pycbc/events/single.py
+++ b/pycbc/events/single.py
@@ -8,6 +8,7 @@ from pycbc.types import MultiDetOptionAction
 from pycbc import conversions as conv
 from pycbc import bin_utils
 
+
 class LiveSingle(object):
     def __init__(self, ifo,
                  newsnr_threshold=10.0,
@@ -68,7 +69,7 @@ class LiveSingle(object):
         sngl_opts = [args.single_reduced_chisq_threshold,
                      args.single_duration_threshold,
                      args.single_newsnr_threshold,
-                     args.sngl_ifar_est_dist,]
+                     args.sngl_ifar_est_dist]
         sngl_opts_str = ("--single-reduced-chisq-threshold, "
                          "--single-duration-threshold, "
                          "--single-newsnr-threshold, "
@@ -128,8 +129,7 @@ class LiveSingle(object):
                                  "given if --single-ifar-est-dist is fixed. "
                                  f"This is true for at least {ifo}.")
 
-
-        # Return values is a boolean whether we are analysing singles or not
+        # Return value is a boolean whether we are analysing singles or not
         # The checks already performed mean that all(sngl_opts) is okay
         return all(sngl_opts)
 

--- a/pycbc/events/single.py
+++ b/pycbc/events/single.py
@@ -66,7 +66,6 @@ class LiveSingle(object):
                                  'a single value or as detector-value pairs, '
                                  'e.g. H1:mean L1:mean V1:conservative')
 
-
     @staticmethod
     def verify_args(args, parser):
         sngl_opts = [args.single_fit_file,
@@ -91,7 +90,6 @@ class LiveSingle(object):
             parser.error("--enable-single-detector-upload does not make "
                          "sense without both --enable-gracedb-upload "
                          "and --enable-single-detector-background set.")
-
 
     @classmethod
     def from_cli(cls, args, ifo):

--- a/pycbc/events/single.py
+++ b/pycbc/events/single.py
@@ -76,20 +76,13 @@ class LiveSingle(object):
                          "--single-reduced-chisq-threshold, "
                          "--single-duration-threshold, "
                          "--single-newsnr-threshold")
-        if args.enable_single_detector_background and not all(sngl_opts):
+        if any(sngl_opts) and not all(sngl_opts):
             parser.error(f"Single detector trigger options ({sngl_opts_str}) "
-                         "must ALL be given if "
-                         "--enable-single-detector-background is set.")
-        if any(sngl_opts) and not args.enable_single_detector_background:
-            parser.error(f"Single detector trigger options ({sngl_opts_str}) "
-                         "given, but --enable-single-detector-background "
-                         "is not set.")
+                         "must either all be given or none.")
         if args.enable_single_detector_upload \
-                and not all([args.enable_single_detector_background,
-                             args.enable_gracedb_upload]):
+                and not args.enable_gracedb_upload:
             parser.error("--enable-single-detector-upload does not make "
-                         "sense without both --enable-gracedb-upload "
-                         "and --enable-single-detector-background set.")
+                         "sense without --enable-gracedb-upload set.")
 
     @classmethod
     def from_cli(cls, args, ifo):


### PR DESCRIPTION
Make sure that the argument to enable single-detector events is set when setting options designed to control them. As well as the upload flag