### PR TITLE
Live single-trigger combined fits date order bug

### DIFF
--- a/bin/live/pycbc_live_combine_single_fits
+++ b/bin/live/pycbc_live_combine_single_fits
@@ -110,11 +110,11 @@ for f in args.trfits_files:
 
 trigger_file_starts = np.array(trigger_file_starts)
 trigger_file_ends = np.array(trigger_file_ends)
-ad_order = np.argsort(np.array(trigger_file_starts))
-start_date_n = trigger_file_starts[ad_order[0]]
-ad = trigger_file_ends[ad_order] - start_date_n
+ad_order = np.argsort(trigger_file_starts)
+start_time_n = trigger_file_starts[ad_order[0]]
+ad = trigger_file_ends[ad_order] - start_time_n
 
-# Get the counts and alphas sorted by date
+# Get the counts and alphas
 counts_bin = {ifo: [c for c in zip(*counts_all[ifo])] for ifo in args.ifos}
 alphas_bin = {ifo: [a for a in zip(*alphas_all[ifo])] for ifo in args.ifos}
 
@@ -129,7 +129,7 @@ fout.attrs['fit_threshold'] = fit_thresh
 fout.attrs['conservative_percentile'] = args.conservative_percentile
 fout.attrs['ifos'] = args.ifos
 fout['bins_edges'] = list(bl) + [bu[-1]]
-fout['fits_dates'] = ad + start_date_n
+fout['fits_dates'] = ad + start_time_n
 
 for ifo in args.ifos:
     fout.create_group(ifo)
@@ -146,7 +146,7 @@ for ifo in args.ifos:
     alpha_all = np.mean(counts_bin[ifo], axis=0) / invalphan_all
     meant = l_times.mean()
 
-    fout_ifo[f'separate_fits/live_times'] = l_times
+    fout_ifo[f'separate_fits/live_times'] = l_times[ad_order]
     fout_ifo[f'separate_fits/start_time'] = trigger_file_starts[ad_order]
     fout_ifo[f'separate_fits/end_time'] = trigger_file_ends[ad_order]
 

--- a/bin/live/pycbc_live_combine_single_fits
+++ b/bin/live/pycbc_live_combine_single_fits
@@ -60,7 +60,8 @@ with h5py.File(args.trfits_files[0], 'r') as fit_f0:
 
 live_times = {ifo : [] for ifo in args.ifos}
 
-trigger_file_times = []
+trigger_file_starts = []
+trigger_file_ends = []
 
 n_files = len(args.trfits_files)
 logging.info("Checking through %d files", n_files)
@@ -77,16 +78,18 @@ for f in args.trfits_files:
     assert all(fits_f['bins_lower'][:] == bl)
     assert all(fits_f['bins_upper'][:] == bu)
 
-    # Get the time of the last trigger in the trigger_fits file
+    # Get the time of the first/last triggers in the trigger_fits file
     gps_last = 0
+    gps_first = np.inf
     for ifo in args.ifos:
         if ifo not in fits_f:
             continue
         else:
             trig_times = fits_f[ifo]['triggers']['end_time'][:]
-            gps_last = max(gps_last,
-                           trig_times.max())
-    trigger_file_times.append(gps_last)
+            gps_last = max(gps_last, trig_times.max())
+            gps_first = min(gps_first, trig_times.min())
+    trigger_file_starts.append(gps_first)
+    trigger_file_ends.append(gps_last)
 
     for ifo in args.ifos:
         if ifo not in fits_f:
@@ -102,16 +105,16 @@ for f in args.trfits_files:
                 logging.info(fits_f[ifo + '/fit_coeff'][:])
     fits_f.close()
 
-# Set up the date array, this is stored as an offset from the start date of
-# the combination to the end of the trigger_fits file.
-# This allows for missing or empty days
+# Set up the date array, this is stored as an offset from the first trigger time of
+# the first file to the last trigger of the file
 
-trigger_file_times = np.array(trigger_file_times)
-ad_order = np.argsort(np.array(trigger_file_times))
-start_date_n = trigger_file_times[ad_order[0]]
-ad = trigger_file_times[ad_order] - start_date_n
+trigger_file_starts = np.array(trigger_file_starts)
+trigger_file_ends = np.array(trigger_file_ends)
+ad_order = np.argsort(np.array(trigger_file_starts))
+start_date_n = trigger_file_starts[ad_order[0]]
+ad = trigger_file_ends[ad_order] - start_date_n
 
-# Get the counts and alphas sorted by bin rather than by date
+# Get the counts and alphas sorted by date
 counts_bin = {ifo: [c for c in zip(*counts_all[ifo])] for ifo in args.ifos}
 alphas_bin = {ifo: [a for a in zip(*alphas_all[ifo])] for ifo in args.ifos}
 
@@ -144,12 +147,15 @@ for ifo in args.ifos:
     meant = l_times.mean()
 
     fout_ifo[f'separate_fits/live_times'] = l_times
-    fout_ifo[f'separate_fits/date'] = ad + start_date_n
+    fout_ifo[f'separate_fits/start_time'] = trigger_file_starts[ad_order]
+    fout_ifo[f'separate_fits/end_time'] = trigger_file_ends[ad_order]
+
     for counter, a_c_u_l in enumerate(zip(alphas_bin[ifo],
                                           counts_bin[ifo], bu, bl)):
         a, c, u, l = a_c_u_l
-        a = np.array(a)
-        c = np.array(c)
+        # Sort alpha and counts by date
+        a = np.array(a)[ad_order]
+        c = np.array(c)[ad_order]
         invalphan = c / a
         mean_alpha = c.mean() / invalphan.mean()
         cons_alpha = np.percentile(a, 100 - args.conservative_percentile)

--- a/bin/live/pycbc_live_plot_combined_single_fits
+++ b/bin/live/pycbc_live_plot_combined_single_fits
@@ -63,7 +63,8 @@ live_total = {}
 
 separate_alphas = {}
 separate_counts = {}
-separate_dates = {}
+separate_starts = {}
+separate_ends = {}
 separate_times = {}
 
 logging.info("Loading Data")
@@ -72,7 +73,6 @@ with h5py.File(args.combined_fits_file, 'r') as cff:
     bins_edges = cff['bins_edges'][:]
     conservative_percentile = cff.attrs['conservative_percentile']
     n_bins = len(bins_edges) - 1
-    fits_dates = cff['fits_dates'][:]
     for ifo in ifos:
         logging.info(ifo)
         live_total[ifo] = cff[ifo].attrs['live_time']
@@ -81,7 +81,8 @@ with h5py.File(args.combined_fits_file, 'r') as cff:
         cons_count[ifo] = cff[ifo]['conservative']['counts'][:]
         cons_alpha[ifo] = cff[ifo]['conservative']['fit_coeff'][:]
 
-        separate_dates[ifo] = cff[ifo]['separate_fits']['date'][:]
+        separate_starts[ifo] = cff[ifo]['separate_fits']['start_time'][:]
+        separate_ends[ifo] = cff[ifo]['separate_fits']['end_time'][:]
         separate_times[ifo] = cff[ifo]['separate_fits']['live_times'][:]
 
         separate_data = cff[ifo]['separate_fits']
@@ -108,6 +109,19 @@ def bin_proportion(upper, lower, log_spacing=False):
     else:
         return ((lower + upper) / 2. - bin_min) / (bin_max - bin_min)
 
+# Set up the x ticks - note that these are rounded to the nearest
+# midnight, so may not line up exactly with the data
+min_start = min([separate_starts[ifo].min() for ifo in ifos])
+max_end = max([separate_ends[ifo].max() for ifo in ifos])
+
+xtix = []
+xtix_labels = []
+t = min_start
+while t < max_end:
+    time_dt = gpstime.gps_to_utc(t).date()
+    xtix_labels.append(time_dt.strftime("%Y-%m-%d"))
+    xtix.append(gpstime.utc_to_gps(time_dt).gpsSeconds)
+    t += 86400
 
 logging.info("Plotting fits information")
 for ifo in ifos:
@@ -119,24 +133,25 @@ for ifo in ifos:
     alpha_lines = []
     count_lines = []
 
-    start_date_dt = gpstime.gps_to_utc(separate_dates[ifo][0])
-    start_date = start_date_dt.strftime("%Y-%m-%d %H:%M:%S")
-
     for i, bl_bu in enumerate(zip(bin_starts, bin_ends)):
         bl, bu = bl_bu
 
         alphas = separate_alphas[ifo][i]
         counts = separate_counts[ifo][i]
 
+        # replace zeros with infinity, so that it is
+        # not plotted rather than plotted as zero
         valid = np.logical_and(alphas > 0, np.isfinite(alphas))
-
+        alphas[np.logical_not(valid)] = np.inf
 
         if not any(valid):
+            logging.info("No valid fit coefficients for %s", ifo)
             continue
-        a = alphas[valid]
-        l_times = separate_times[ifo][valid]
-        rate = counts[valid] / l_times
-        ad = (separate_dates[ifo][valid] - separate_dates[ifo][0]) / 86400.
+
+        l_times = separate_times[ifo]
+        rate = counts / l_times
+
+        ad = (separate_starts[ifo] - min_start) / 86400.
 
         ma = mean_alpha[ifo][i]
         ca = cons_alpha[ifo][i]
@@ -146,20 +161,19 @@ for ifo in ifos:
         bin_prop = bin_proportion(bu, bl,
                                   log_spacing=args.log_colormap)
         bin_colour = plt.get_cmap(args.colormap)(bin_prop)
-
-        alpha_lines += ax_alpha.plot(ad, a, c=bin_colour,
-                                     label="duration %.2f-%.2f" % (bl, bu))
+        bin_label = f"duration {bl:.2f}-{bu:.2f}"
+        alpha_lines += ax_alpha.plot(ad, alphas, c=bin_colour,
+                                     label=bin_label)
         alpha_lines.append(ax_alpha.axhline(ma,
                                             label="total fit = %.2f" % ma,
-                                             c=bin_colour, linestyle='--',))
+                                            c=bin_colour, linestyle='--',))
         alpha_lab = f"{conservative_percentile:d}th %ile = {ca:.2f}"
         alpha_lines.append(ax_alpha.axhline(ca,
                                             c=bin_colour, linestyle=':',
                                             label=alpha_lab))
 
-        count_lines += ax_count.plot(ad, rate,
-                                     c=bin_colour,
-                                     label="duration %.2f-%.2f" % (bl, bu))
+        count_lines += ax_count.plot(ad, rate, c=bin_colour,
+                                     label=bin_label)
         count_lines.append(ax_count.axhline(mr,
                                             c=bin_colour, linestyle='--',
                                             label=f"mean = {mr:.3f}"))
@@ -168,21 +182,23 @@ for ifo in ifos:
                                             c=bin_colour, linestyle=':',
                                             label=count_lab))
 
-    ax_alpha.set_xlabel('Days since ' + start_date)
     ax_alpha.set_ylabel('Fit coefficient')
-    ax_alpha.set_xlim([ad[0], ad[-1]])
+    ax_alpha.set_xticks((xtix - min_start) / 86400)
+    ax_alpha.set_xticklabels(xtix_labels, rotation=90)
+    ax_alpha.set_xlim(-0.5, len(xtix) - 0.5)
     alpha_labels = [l.get_label() for l in alpha_lines]
     ax_alpha.grid(zorder=-30)
     ax_alpha.legend(alpha_lines, alpha_labels, loc='lower center',
                     ncol=3, bbox_to_anchor=(0.5, 1.01))
     fig_alpha.tight_layout()
     fig_alpha.savefig(args.output_plot_name_format.format(ifo=ifo, type='fit_coeffs'))
-    ax_count.set_xlabel('Days since ' + start_date)
     ax_count.set_ylabel('Counts per live time')
-    ax_count.set_xlim([ad[0], ad[-1]])
     count_labels = [l.get_label() for l in count_lines]
     ax_count.legend(count_lines, count_labels, loc='lower center',
                     ncol=3, bbox_to_anchor=(0.5, 1.01))
     ax_count.grid(zorder=-30)
+    ax_count.set_xticks((xtix - min_start) / 86400)
+    ax_count.set_xticklabels(xtix_labels, rotation=90)
+    ax_count.set_xlim(-0.5, len(xtix) - 0.5)
     fig_count.tight_layout()
     fig_count.savefig(args.output_plot_name_format.format(ifo=ifo, type='counts'))

--- a/bin/live/pycbc_live_plot_combined_single_fits
+++ b/bin/live/pycbc_live_plot_combined_single_fits
@@ -118,6 +118,7 @@ xtix = []
 xtix_labels = []
 t = min_start
 while t < max_end:
+    # Strip off the time information, ticks are at midnight
     time_dt = gpstime.gps_to_utc(t).date()
     xtix_labels.append(time_dt.strftime("%Y-%m-%d"))
     xtix.append(gpstime.utc_to_gps(time_dt).gpsSeconds)
@@ -151,8 +152,6 @@ for ifo in ifos:
         l_times = separate_times[ifo]
         rate = counts / l_times
 
-        ad = (separate_starts[ifo] - min_start) / 86400.
-
         ma = mean_alpha[ifo][i]
         ca = cons_alpha[ifo][i]
         mr = mean_count[ifo][i] / live_total[ifo]
@@ -162,7 +161,7 @@ for ifo in ifos:
                                   log_spacing=args.log_colormap)
         bin_colour = plt.get_cmap(args.colormap)(bin_prop)
         bin_label = f"duration {bl:.2f}-{bu:.2f}"
-        alpha_lines += ax_alpha.plot(ad, alphas, c=bin_colour,
+        alpha_lines += ax_alpha.plot(separate_starts[ifo], alphas, c=bin_colour,
                                      label=bin_label)
         alpha_lines.append(ax_alpha.axhline(ma,
                                             label="total fit = %.2f" % ma,
@@ -172,7 +171,7 @@ for ifo in ifos:
                                             c=bin_colour, linestyle=':',
                                             label=alpha_lab))
 
-        count_lines += ax_count.plot(ad, rate, c=bin_colour,
+        count_lines += ax_count.plot(separate_starts[ifo], rate, c=bin_colour,
                                      label=bin_label)
         count_lines.append(ax_count.axhline(mr,
                                             c=bin_colour, linestyle='--',
@@ -182,22 +181,24 @@ for ifo in ifos:
                                             c=bin_colour, linestyle=':',
                                             label=count_lab))
 
-    ax_alpha.set_ylabel('Fit coefficient')
     alpha_labels = [l.get_label() for l in alpha_lines]
-    ax_alpha.grid(zorder=-30)
     ax_alpha.legend(alpha_lines, alpha_labels, loc='lower center',
                     ncol=5, bbox_to_anchor=(0.5, 1.01))
-    fig_alpha.tight_layout()
-    fig_alpha.savefig(args.output_plot_name_format.format(ifo=ifo, type='fit_coeffs'))
-    ax_count.set_ylabel('Counts per live time')
+    ax_alpha.set_ylabel('Fit coefficient')
+
     count_labels = [l.get_label() for l in count_lines]
     ax_count.legend(count_lines, count_labels, loc='lower center',
                     ncol=5, bbox_to_anchor=(0.5, 1.01))
-    ax_count.grid(zorder=-30)
+    ax_count.set_ylabel('Counts per live time')
 
     for ax in [ax_count, ax_alpha]:
-        ax.set_xticks((xtix - min_start) / 86400)
+        ax.set_xticks(xtix)
         ax.set_xticklabels(xtix_labels, rotation=90)
-        ax.set_xlim(-0.5, len(xtix) - 0.5)
+        # Add 1/4 day padding either side
+        ax.set_xlim(xtix[0] - 21600, xtix[-1] + 21600)
+        ax.grid(zorder=-30)
+
     fig_count.tight_layout()
     fig_count.savefig(args.output_plot_name_format.format(ifo=ifo, type='counts'))
+    fig_alpha.tight_layout()
+    fig_alpha.savefig(args.output_plot_name_format.format(ifo=ifo, type='fit_coeffs'))

--- a/bin/live/pycbc_live_plot_combined_single_fits
+++ b/bin/live/pycbc_live_plot_combined_single_fits
@@ -145,7 +145,7 @@ for ifo in ifos:
         alphas[np.logical_not(valid)] = np.inf
 
         if not any(valid):
-            logging.info("No valid fit coefficients for %s", ifo)
+            logging.warning("No valid fit coefficients for %s", ifo)
             continue
 
         l_times = separate_times[ifo]
@@ -183,22 +183,21 @@ for ifo in ifos:
                                             label=count_lab))
 
     ax_alpha.set_ylabel('Fit coefficient')
-    ax_alpha.set_xticks((xtix - min_start) / 86400)
-    ax_alpha.set_xticklabels(xtix_labels, rotation=90)
-    ax_alpha.set_xlim(-0.5, len(xtix) - 0.5)
     alpha_labels = [l.get_label() for l in alpha_lines]
     ax_alpha.grid(zorder=-30)
     ax_alpha.legend(alpha_lines, alpha_labels, loc='lower center',
-                    ncol=3, bbox_to_anchor=(0.5, 1.01))
+                    ncol=5, bbox_to_anchor=(0.5, 1.01))
     fig_alpha.tight_layout()
     fig_alpha.savefig(args.output_plot_name_format.format(ifo=ifo, type='fit_coeffs'))
     ax_count.set_ylabel('Counts per live time')
     count_labels = [l.get_label() for l in count_lines]
     ax_count.legend(count_lines, count_labels, loc='lower center',
-                    ncol=3, bbox_to_anchor=(0.5, 1.01))
+                    ncol=5, bbox_to_anchor=(0.5, 1.01))
     ax_count.grid(zorder=-30)
-    ax_count.set_xticks((xtix - min_start) / 86400)
-    ax_count.set_xticklabels(xtix_labels, rotation=90)
-    ax_count.set_xlim(-0.5, len(xtix) - 0.5)
+
+    for ax in [ax_count, ax_alpha]:
+        ax.set_xticks((xtix - min_start) / 86400)
+        ax.set_xticklabels(xtix_labels, rotation=90)
+        ax.set_xlim(-0.5, len(xtix) - 0.5)
     fig_count.tight_layout()
     fig_count.savefig(args.output_plot_name_format.format(ifo=ifo, type='counts'))


### PR DESCRIPTION
Also use dates as xtick labels rather than "Days since X" in the plots, and align grid to date boundaries

I had a look at setting the plot to be horizontal between the start/end of each file, but it was impossible to see anything, so didn't make that change in the end