### PR TITLE
Implement pre-cuts in fit_over_multiparam for efficiency

### DIFF
--- a/bin/all_sky_search/pycbc_fit_sngls_over_multiparam
+++ b/bin/all_sky_search/pycbc_fit_sngls_over_multiparam
@@ -138,6 +138,19 @@ def smooth(nabove, invalphan, ntotal, dists, smoothing_method, **kwargs):
     return _smooth_dist_func[smoothing_method](nabove, invalphan,
                                                ntotal, dists, **kwargs)
 
+# This is used to pre-calculate the templates which could be cut
+# before calculating distances
+# The value is used to determine the 1D-extent of the used templates;
+# number of smoothing lengths to cut anything outwith this range.
+# n_closest has no cut as it needs to contain enough
+# templates to contain n triggers, which we cannot know beforehand
+
+_smooth_cut = {
+    'smooth_tophat': 1,
+    'n_closest': numpy.inf,
+    'distance_weighted': 3,
+}
+
 
 parser = argparse.ArgumentParser(usage="",
     description="Smooth (regress) the dependence of coefficients describing "
@@ -238,15 +251,18 @@ bank = h5py.File(args.bank_file, 'r')
 m1, m2, s1z, s2z = triggers.get_mass_spin(bank, tid)
 
 parvals = []
+parnames = []
 
 for param, slog in zip(args.fit_param, args.log_param):
     data = triggers.get_param(param, args, m1, m2, s1z, s2z)
     if slog in ['false', 'False', 'FALSE']:
         logging.info('Using param: %s', param)
         parvals.append(data)
+        parnames.append(param)
     elif slog in ['true', 'True', 'TRUE']:
         logging.info('Using log param: %s', param)
         parvals.append(numpy.log(data))
+        parnames.append(f"log({param})")
     else:
         raise ValueError("invalid log param argument, use 'true', or 'false'")
 
@@ -261,8 +277,6 @@ nabove_smoothed = []
 ntotal_smoothed = []
 alpha_smoothed = []
 rang = numpy.arange(0, len(nabove))
-
-logging.info("Smoothing ...")
 
 # Handle the one-dimensional case of tophat smoothing separately
 # as it is easier to optimize computational performance.
@@ -284,13 +298,60 @@ if len(parvals) == 1 and args.smoothing_method == 'smooth_tophat':
     invsum = invalphan.cumsum()
     num = right - left
 
+    logging.info("Smoothing ...")
     ntotal_smoothed = (ntsum[right] - ntsum[left]) / num
     nabove_smoothed = (nasum[right] - nasum[left]) / num
     invmean = (invsum[right] - invsum[left]) / num
     alpha_smoothed = nabove_smoothed / invmean
 
+elif numpy.isfinite(_smooth_cut[args.smoothing_method]):
+    c = _smooth_cut[args.smoothing_method]
+    cut_lengths = [s * c for s in args.smoothing_width]
+    # Find the "longest" dimension in cut lengths
+    sort_dim = numpy.argmax([(v.max() - v.min()) / c
+                              for v, c in zip(parvals, cut_lengths)])
+    logging.info("Sorting / Cutting on dimension %s", parnames[sort_dim])
+
+    # Sort parvals by the sort dimension
+    par_sort = numpy.argsort(parvals[sort_dim])
+    parvals = [p[par_sort] for p in parvals]
+
+    # We will want this later to undo the sorting
+    unsort = numpy.argsort(par_sort)
+    # For each template, find the range of nearby templates which fall within
+    # the chosen window.
+    lefts = numpy.searchsorted(parvals[sort_dim],
+            parvals[sort_dim] - cut_lengths[sort_dim])
+    rights = numpy.searchsorted(parvals[sort_dim],
+            parvals[sort_dim] + cut_lengths[sort_dim])
+    # Sort the values to be smoothed into paramaeter's order
+    nabove = nabove[par_sort]
+    invalphan = invalphan[par_sort]
+    ntotal = ntotal[par_sort]
+    logging.info("Smoothing ...")
+    slices = [slice(l,r) for l, r in zip(lefts, rights)]
+    for i in rang:
+        slc = slices[i]
+        d = dist(i, slc, parvals, args.smoothing_width)
+
+        smoothed_tuple = smooth(nabove[slc],
+                                invalphan[slc],
+                                ntotal[slc],
+                                d,
+                                args.smoothing_method,
+                                **kwarg_dict)
+        nabove_smoothed.append(smoothed_tuple[0])
+        alpha_smoothed.append(smoothed_tuple[1])
+        ntotal_smoothed.append(smoothed_tuple[2])
+
+    # Undo the sorts
+    parvals = [p[unsort] for p in parvals]
+    nabove_smoothed = numpy.array(nabove_smoothed)[unsort]
+    alpha_smoothed = numpy.array(alpha_smoothed)[unsort]
+    ntotal_smoothed = numpy.array(ntotal_smoothed)[unsort]
+
 else:
-    for i in range(len(nabove)):
+    for i in rang:
         d = dist(i, rang, parvals, args.smoothing_width)
         smoothed_tuple = smooth(nabove, invalphan, ntotal, d,
                                 args.smoothing_method, **kwarg_dict)

--- a/bin/all_sky_search/pycbc_fit_sngls_over_multiparam
+++ b/bin/all_sky_search/pycbc_fit_sngls_over_multiparam
@@ -138,11 +138,9 @@ def smooth(nabove, invalphan, ntotal, dists, smoothing_method, **kwargs):
     return _smooth_dist_func[smoothing_method](nabove, invalphan,
                                                ntotal, dists, **kwargs)
 
-# This is used to pre-calculate the templates which could be cut
-# before calculating distances
-# The value is used to determine the 1D-extent of the used templates;
-# number of smoothing lengths to cut anything outwith this range.
-# n_closest has no cut as it needs to contain enough
+# Number of smoothing lengths around the current template where
+# distances will be calculated
+# n_closest has no limit as it needs to contain enough
 # templates to contain n triggers, which we cannot know beforehand
 
 _smooth_cut = {

--- a/bin/all_sky_search/pycbc_fit_sngls_over_multiparam
+++ b/bin/all_sky_search/pycbc_fit_sngls_over_multiparam
@@ -290,8 +290,8 @@ invalpha = 1. / fits['fit_coeff'][:]
 invalphan = invalpha * nabove
 
 nabove_smoothed = []
-ntotal_smoothed = []
 alpha_smoothed = []
+ntotal_smoothed = []
 rang = numpy.arange(0, len(nabove))
 
 # Handle the one-dimensional case of tophat smoothing separately
@@ -309,16 +309,16 @@ if len(parvals) == 1 and args.smoothing_method == 'smooth_tophat':
     del parvals_0
     # Precompute the sums so we can quickly look up differences between
     # templates
-    ntsum = ntotal.cumsum()
     nasum = nabove.cumsum()
     invsum = invalphan.cumsum()
+    ntsum = ntotal.cumsum()
     num = right - left
 
     logging.info("Smoothing ...")
-    ntotal_smoothed = (ntsum[right] - ntsum[left]) / num
     nabove_smoothed = (nasum[right] - nasum[left]) / num
     invmean = (invsum[right] - invsum[left]) / num
     alpha_smoothed = nabove_smoothed / invmean
+    ntotal_smoothed = (ntsum[right] - ntsum[left]) / num
 
 elif numpy.isfinite(_smooth_cut[args.smoothing_method]):
     c = _smooth_cut[args.smoothing_method]
@@ -332,8 +332,6 @@ elif numpy.isfinite(_smooth_cut[args.smoothing_method]):
     par_sort = numpy.argsort(parvals[sort_dim])
     parvals = [p[par_sort] for p in parvals]
 
-    # We will want this later to undo the sorting
-    unsort = numpy.argsort(par_sort)
     # For each template, find the range of nearby templates which fall within
     # the chosen window.
     lefts = numpy.searchsorted(parvals[sort_dim],
@@ -343,7 +341,7 @@ elif numpy.isfinite(_smooth_cut[args.smoothing_method]):
     n_removed = len(parvals[0]) - rights + lefts
     logging.info("Cutting between %d and %d templates for each smoothing",
                  n_removed.min(), n_removed.max())
-    # Sort the values to be smoothed into paramaeter's order
+    # Sort the values to be smoothed by parameter value
     nabove = nabove[par_sort]
     invalphan = invalphan[par_sort]
     ntotal = ntotal[par_sort]
@@ -365,6 +363,7 @@ elif numpy.isfinite(_smooth_cut[args.smoothing_method]):
         ntotal_smoothed.append(smoothed_tuple[2])
 
     # Undo the sorts
+    unsort = numpy.argsort(par_sort)
     parvals = [p[unsort] for p in parvals]
     nabove_smoothed = numpy.array(nabove_smoothed)[unsort]
     alpha_smoothed = numpy.array(alpha_smoothed)[unsort]

--- a/bin/all_sky_search/pycbc_fit_sngls_over_multiparam
+++ b/bin/all_sky_search/pycbc_fit_sngls_over_multiparam
@@ -146,11 +146,27 @@ def smooth(nabove, invalphan, ntotal, dists, smoothing_method, **kwargs):
 # templates to contain n triggers, which we cannot know beforehand
 
 _smooth_cut = {
-    'smooth_tophat': 1,
+    'smooth_tophat': 1.1,
     'n_closest': numpy.inf,
-    'distance_weighted': 3,
+    'distance_weighted': 3.1,
 }
 
+
+def report_percentage(i, length):
+    """
+    Convenience function - report how long through the loop we are.
+    Every ten percent
+    Parameters
+    ----------
+    i: integer
+        index being looped through
+    length : integer
+        number of loops we will go through in total
+    """
+    pc = int(numpy.floor(i / length * 100))
+    pc_last = int(numpy.floor((i - 1) / length * 100))
+    if not pc % 10 and pc_last % 10:
+        logging.info(f"Template {i} out of {length} ({pc:.0f}%)")
 
 parser = argparse.ArgumentParser(usage="",
     description="Smooth (regress) the dependence of coefficients describing "
@@ -331,6 +347,7 @@ elif numpy.isfinite(_smooth_cut[args.smoothing_method]):
     logging.info("Smoothing ...")
     slices = [slice(l,r) for l, r in zip(lefts, rights)]
     for i in rang:
+        report_percentage(i, rang.max())
         slc = slices[i]
         d = dist(i, slc, parvals, args.smoothing_width)
 
@@ -353,6 +370,7 @@ elif numpy.isfinite(_smooth_cut[args.smoothing_method]):
 else:
     logging.info("Smoothing ...")
     for i in rang:
+        report_percentage(i, rang.max())
         d = dist(i, rang, parvals, args.smoothing_width)
         smoothed_tuple = smooth(nabove, invalphan, ntotal, d,
                                 args.smoothing_method, **kwarg_dict)

--- a/bin/all_sky_search/pycbc_fit_sngls_over_multiparam
+++ b/bin/all_sky_search/pycbc_fit_sngls_over_multiparam
@@ -146,9 +146,9 @@ def smooth(nabove, invalphan, ntotal, dists, smoothing_method, **kwargs):
 # templates to contain n triggers, which we cannot know beforehand
 
 _smooth_cut = {
-    'smooth_tophat': 1.1,
+    'smooth_tophat': 1,
     'n_closest': numpy.inf,
-    'distance_weighted': 3.1,
+    'distance_weighted': 3,
 }
 
 
@@ -340,6 +340,9 @@ elif numpy.isfinite(_smooth_cut[args.smoothing_method]):
             parvals[sort_dim] - cut_lengths[sort_dim])
     rights = numpy.searchsorted(parvals[sort_dim],
             parvals[sort_dim] + cut_lengths[sort_dim])
+    n_removed = len(parvals[0]) - rights + lefts
+    logging.info("Cutting between %d and %d templates for each smoothing",
+                 n_removed.min(), n_removed.max())
     # Sort the values to be smoothed into paramaeter's order
     nabove = nabove[par_sort]
     invalphan = invalphan[par_sort]

--- a/bin/all_sky_search/pycbc_fit_sngls_over_multiparam
+++ b/bin/all_sky_search/pycbc_fit_sngls_over_multiparam
@@ -351,6 +351,7 @@ elif numpy.isfinite(_smooth_cut[args.smoothing_method]):
     ntotal_smoothed = numpy.array(ntotal_smoothed)[unsort]
 
 else:
+    logging.info("Smoothing ...")
     for i in rang:
         d = dist(i, rang, parvals, args.smoothing_width)
         smoothed_tuple = smooth(nabove, invalphan, ntotal, d,


### PR DESCRIPTION
Implementing @tdent's suggestion in #3585, I put in a way to pre-cut templates we are not interested in given the restrictions of each method of smoothing.

### Timing

As a quick and dirty test, I ran before/after codes on the same bank (O3 hyperbank, 428725 templates) on CIT pcdev5, with the following timing results:

|   | `tophat_smoothing`  | `distance_weighted` |
| --- | --- | --- |
| Before this change | 57 mins | 178 mins |
| After this change | 12 mins | 150 mins |
| Fraction of original | 21% | 84% |

Note that:
- `n_closest` is unaffected by this change (by design)
- It is right that there are more savings for `tophat_smoothing` than `dist_weighted`, as this cuts at 1 in weighted distance, whereas `distance_weighted` cuts at 3 (i.e. 3 times the size)

### Accuracy

- The `tophat_smoothing` outputs were compared and found to be identical to sha256 accuracy.
- The `distance_weighted` outputs were not, however all datasets matched to numpy.isclose accuracy (this is not obvious why this was not exact)