### PR TITLE
Switch FFTW/MKL order of preference

### DIFF
--- a/pycbc/fft/backend_cpu.py
+++ b/pycbc/fft/backend_cpu.py
@@ -20,7 +20,7 @@ from .core import _list_available
 _backend_dict = {'fftw' : 'fftw',
                  'mkl' : 'mkl',
                  'numpy' : 'npfft'}
-_backend_list = ['fftw','mkl','numpy']
+_backend_list = ['mkl', 'fftw', 'numpy']
 
 _alist, _adict = _list_available(_backend_list, _backend_dict)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # requirements for most basic library use
-astropy>=2.0.3,!=4.2.1,!=4.0.5
+astropy>=2.0.3,!=4.2.1,!=4.0.5,<=5.2.2
 Mako>=1.0.1
 scipy>=0.16.0
 matplotlib>=2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # requirements for most basic library use
-astropy>=2.0.3,!=4.2.1,!=4.0.5,<=5.2.2
+astropy>=2.0.3,!=4.2.1,!=4.0.5
 Mako>=1.0.1
 scipy>=0.16.0
 matplotlib>=2.0.0

--- a/tox.ini
+++ b/tox.ini
@@ -22,6 +22,7 @@ conda_deps=
     binutils_linux-64>=2.39
     gsl
     lapack==3.6.1
+    liblapacke==3.6.1
     openmpi
     _openmp_mutex=*=*_llvm
 conda_channels=conda-forge

--- a/tox.ini
+++ b/tox.ini
@@ -17,13 +17,6 @@ passenv=LAL_DATA_PATH
 conda_deps=
     openssl=1.1
     m2crypto
-    mkl
-    blas-devel
-    blas
-    libblas
-    libcblas
-    liblapack
-    openmp
     openmpi
     _openmp_mutex=*=*_llvm
 conda_channels=conda-forge

--- a/tox.ini
+++ b/tox.ini
@@ -25,6 +25,7 @@ conda_deps=
     lapack
     liblapack
     liblapacke
+    fftw
     openmpi
     _openmp_mutex=*=*_llvm
     mysqlclient

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,15 @@ passenv=LAL_DATA_PATH
 conda_deps=
     openssl=1.1
     m2crypto
+    mkl
+    blas-devel
+    blas
+    libblas
+    libcblas
+    liblapack
+    openmp
+    openmpi
+    _openmp_mutex=*=*_llvm
 conda_channels=conda-forge
 
 # This test should run on almost anybody's environment
@@ -62,13 +71,6 @@ conda_deps=
     binutils_linux-64>=2.39
     gsl
     lapack==3.6.1
-    mkl
-    blas-devel
-    blas
-    libblas
-    libcblas
-    liblapack
-    _openmp_mutex=*=*_llvm
 conda_channels=conda-forge
 setenv = PYCBC_TEST_TYPE=docs
 commands = bash tools/pycbc_test_suite.sh

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,11 @@ passenv=LAL_DATA_PATH
 conda_deps=
     openssl=1.1
     m2crypto
+    gcc_linux-64>=12.2.0
+    gxx_linux-64>=12.2.0
+    binutils_linux-64>=2.39
+    gsl
+    lapack==3.6.1
     openmpi
     _openmp_mutex=*=*_llvm
 conda_channels=conda-forge
@@ -59,11 +64,6 @@ deps =
     git+https://github.com/ConWea/BBHX-waveform-model.git; sys_platform == 'linux'
 conda_deps=
     mysqlclient
-    gcc_linux-64>=12.2.0
-    gxx_linux-64>=12.2.0
-    binutils_linux-64>=2.39
-    gsl
-    lapack==3.6.1
 conda_channels=conda-forge
 setenv = PYCBC_TEST_TYPE=docs
 commands = bash tools/pycbc_test_suite.sh

--- a/tox.ini
+++ b/tox.ini
@@ -62,6 +62,13 @@ conda_deps=
     binutils_linux-64>=2.39
     gsl
     lapack==3.6.1
+    mkl
+    blas-devel
+    blas
+    libblas
+    libcblas
+    liblapack
+    _openmp_mutex=*=*_llvm
 conda_channels=conda-forge
 setenv = PYCBC_TEST_TYPE=docs
 commands = bash tools/pycbc_test_suite.sh

--- a/tox.ini
+++ b/tox.ini
@@ -15,16 +15,19 @@ deps =
 allowlist_externals = bash
 passenv=LAL_DATA_PATH
 conda_deps=
+    openblas
     openssl=1.1
     m2crypto
     gcc_linux-64>=12.2.0
     gxx_linux-64>=12.2.0
     binutils_linux-64>=2.39
     gsl
-    lapack==3.6.1
-    liblapacke==3.6.1
+    lapack
+    liblapack
+    liblapacke
     openmpi
     _openmp_mutex=*=*_llvm
+    mysqlclient
 conda_channels=conda-forge
 
 # This test should run on almost anybody's environment
@@ -63,8 +66,6 @@ deps =
     ; Needed for `BBHx` package to work with PyCBC
     git+https://github.com/mikekatz04/BBHx.git; sys_platform == 'linux'
     git+https://github.com/ConWea/BBHX-waveform-model.git; sys_platform == 'linux'
-conda_deps=
-    mysqlclient
 conda_channels=conda-forge
 setenv = PYCBC_TEST_TYPE=docs
 commands = bash tools/pycbc_test_suite.sh


### PR DESCRIPTION
I'm going to propose this patch to reduce the frequency of FFTW segfault occurrences. I emphasize that this is not at all a fix to the underlying problems, but I think this will reduce the likelihood of them occurring.

Quite simply, we swap the default FFT preference order, such that if FFTW and MKL are present, MKL will be used unless FFTW is specified. We know that both don't play well together, so using MKL in such cases should be more reliable. If MKL is not present, then it's likely that you won't hit the FFTW issues (which are caused by intel/MKL).

Performance use cases should still be specifying a backend and will not be affected by this. 

I'll assign this to @ahnitz, but not sure if @josh-willis also wants to weigh in on this? I'm hoping there is no reason to prefer one order over the other.