### PR TITLE
add TDI AE PSD with confusion noise for LISA

### DIFF
--- a/pycbc/psd/analytical.py
+++ b/pycbc/psd/analytical.py
@@ -26,7 +26,7 @@ from pycbc.types import FrequencySeries
 from pycbc.psd.analytical_space import (
     analytical_psd_lisa_tdi_1p5_XYZ, analytical_psd_lisa_tdi_2p0_XYZ,
     analytical_psd_lisa_tdi_1p5_AE, analytical_psd_lisa_tdi_1p5_T,
-    sh_transformed_psd_lisa_tdi_XYZ)
+    sh_transformed_psd_lisa_tdi_XYZ, analytical_psd_lisa_tdi_AE_confusion)
 import lal
 import numpy
 
@@ -173,4 +173,5 @@ pycbc_analytical_psds = {
     'analytical_psd_lisa_tdi_1p5_AE' : analytical_psd_lisa_tdi_1p5_AE,
     'analytical_psd_lisa_tdi_1p5_T' : analytical_psd_lisa_tdi_1p5_T,
     'sh_transformed_psd_lisa_tdi_XYZ' : sh_transformed_psd_lisa_tdi_XYZ,
+    'analytical_psd_lisa_tdi_AE_confusion' : analytical_psd_lisa_tdi_AE_confusion,
 }

--- a/pycbc/psd/analytical_space.py
+++ b/pycbc/psd/analytical_space.py
@@ -370,7 +370,7 @@ def averaged_lisa_fplus_sq_approx(f, len_arm=2.5e9):
         Pease see Eq.(36) in <LISA-LCST-SGS-TN-001> for more details.
     """
     from os import getcwd, path
-    from urllib import request
+    import requests
     from scipy.interpolate import interp1d
 
     if len_arm != 2.5e9:
@@ -378,7 +378,9 @@ def averaged_lisa_fplus_sq_approx(f, len_arm=2.5e9):
     cwd = getcwd()
     if path.exists(cwd+"/AvFXp2_Raw.npy") is False:
         url = "https://zenodo.org/record/7497853/files/AvFXp2_Raw.npy"
-        request.urlretrieve(url, cwd+"/AvFXp2_Raw.npy")
+        response = requests.get(url, verify=False)
+        with open(cwd+"/AvFXp2_Raw.npy", 'wb') as f:
+            f.write(response.content)
     freqs, fp_sq = np.load(cwd+"/AvFXp2_Raw.npy")
     # Padding the end.
     freqs = np.append(freqs, 2)
@@ -565,7 +567,7 @@ def sensitivity_curve_lisa_confusion(length, delta_f, low_freq_cutoff,
         base_curve = sensitivity_curve_lisa_semi_analytical(
             length, delta_f, low_freq_cutoff,
             len_arm, acc_noise_level, oms_noise_level)
-    elif base_curve == "SciRD":
+    elif base_model == "SciRD":
         base_curve = sensitivity_curve_lisa_SciRD(
             length, delta_f, low_freq_cutoff)
     else:

--- a/pycbc/psd/analytical_space.py
+++ b/pycbc/psd/analytical_space.py
@@ -699,6 +699,7 @@ def semi_analytical_psd_lisa_confusion_noise(length, delta_f, low_freq_cutoff,
 
     return fseries
 
+
 def analytical_psd_lisa_tdi_AE_confusion(length, delta_f, low_freq_cutoff,
                                          len_arm=2.5e9, acc_noise_level=3e-15,
                                          oms_noise_level=15e-12,


### PR DESCRIPTION
@ahnitz This PR adds the semi-analytical PSD for the AE channel with DWD confusion noise, confusion noise doesn't affect the T channel very much, below is the PSD comparison with Welch PSD measured from LDC Sangria, `5` and `0.1` means the foreground noise subtraction of X years observation:

![image](https://github.com/gwastro/pycbc/assets/6574526/9608d66d-2b5a-4d43-a916-83531999e5d0)
