### PR TITLE
Added an OSError exception to MKL check in __init__.py

### DIFF
--- a/pycbc/__init__.py
+++ b/pycbc/__init__.py
@@ -158,7 +158,7 @@ except ImportError:
 try:
     import pycbc.fft.mkl
     HAVE_MKL=True
-except ImportError:
+except (ImportError, OSError):
     HAVE_MKL=False
 
 # Check for openmp suppport, currently we pressume it exists, unless on


### PR DESCRIPTION
When trying to run the PyCBC Live example I was encountering the error `OSError: libmkl_rt.so.2: cannot open shared object file: No such file or directory`. This was fixed by explicitly running `conda install mkl` in my environment (although I am still getting the same error running the pycbc live o4 production environment).

Copying the error catching found [here](https://github.com/gwastro/pycbc/blob/master/pycbc/fft/core.py#LL53C16-L53C39) (thank you to Ian) to the same check in `__init__.py` clears up this error.

I can provide more information if anyone would like to figure out why this error was happening, especially when using the pycbc live env on CIT.