### PR TITLE
Try to fix CI tests

### DIFF
--- a/examples/inference/lisa_smbhb_inj/run.sh
+++ b/examples/inference/lisa_smbhb_inj/run.sh
@@ -3,4 +3,9 @@ pycbc_inference \
 --config-files `dirname "$0"`/lisa_smbhb_relbin.ini \
 --output-file lisa_smbhb_inj_pe.hdf \
 --force \
+--fft-backends fftw \
 --verbose
+
+# PLEASE NOTE: This example is currently forcing a FFTW backend because MKL
+#              seems to fail for FFT lengths > 2^24. This is fine for most LIGO
+#              applications, but an issue for most LISA applications.

--- a/pycbc/fft/backend_cpu.py
+++ b/pycbc/fft/backend_cpu.py
@@ -20,7 +20,7 @@ from .core import _list_available
 _backend_dict = {'fftw' : 'fftw',
                  'mkl' : 'mkl',
                  'numpy' : 'npfft'}
-_backend_list = ['fftw','mkl','numpy']
+_backend_list = ['mkl', 'fftw', 'numpy']
 
 _alist, _adict = _list_available(_backend_list, _backend_dict)
 

--- a/pycbc/fft/fftw.py
+++ b/pycbc/fft/fftw.py
@@ -106,6 +106,10 @@ def _init_threads(backend):
         raise ValueError("Backend {0} for FFTW threading does not exist!".format(backend))
     if double_threaded_libname is not None:
         try:
+            # For reasons Ian doesn't understand we should not load libgomp
+            # first using RTLD_DEEPBIND, so force loading it here if needed
+            if double_threaded_libname.endswith('omp')::
+                get_ctypes_library('gomp', [], mode=ctypes.DEFAULT_MODE)
             # Note that the threaded libraries don't have their own pkg-config
             # files we must look for them wherever we look for double or single
             # FFTW itself.
@@ -153,7 +157,7 @@ def set_threads_backend(backend=None):
             raise RuntimeError("Could not initialize FFTW threading backend {0}".format(backend))
     else:
         # Note that we pop() from the end, so 'openmp' is the first thing tried
-        _backend_list = ['unthreaded','pthreads','openmp']
+        _backend_list = ['unthreaded','openmp', 'pthreads']
         while not _fftw_threaded_set:
             _next_backend = _backend_list.pop()
             retval = _init_threads(_next_backend)

--- a/pycbc/fft/fftw.py
+++ b/pycbc/fft/fftw.py
@@ -108,7 +108,7 @@ def _init_threads(backend):
         try:
             # For reasons Ian doesn't understand we should not load libgomp
             # first using RTLD_DEEPBIND, so force loading it here if needed
-            if double_threaded_libname.endswith('omp')::
+            if double_threaded_libname.endswith('omp'):
                 get_ctypes_library('gomp', [], mode=ctypes.DEFAULT_MODE)
             # Note that the threaded libraries don't have their own pkg-config
             # files we must look for them wherever we look for double or single

--- a/pycbc/fft/fftw.py
+++ b/pycbc/fft/fftw.py
@@ -108,7 +108,7 @@ def _init_threads(backend):
         try:
             # For reasons Ian doesn't understand we should not load libgomp
             # first using RTLD_DEEPBIND, so force loading it here if needed
-            if double_threaded_libname.endswith('omp'):
+            if backend == 'openmp':
                 get_ctypes_library('gomp', [], mode=ctypes.DEFAULT_MODE)
             # Note that the threaded libraries don't have their own pkg-config
             # files we must look for them wherever we look for double or single
@@ -156,7 +156,8 @@ def set_threads_backend(backend=None):
         if retval != 0:
             raise RuntimeError("Could not initialize FFTW threading backend {0}".format(backend))
     else:
-        # Note that we pop() from the end, so 'openmp' is the first thing tried
+        # Note that we pop() from the end, so 'pthreads'
+        # is the first thing tried
         _backend_list = ['unthreaded','openmp', 'pthreads']
         while not _fftw_threaded_set:
             _next_backend = _backend_list.pop()

--- a/pycbc/fft/mkl.py
+++ b/pycbc/fft/mkl.py
@@ -69,7 +69,7 @@ def check_status(status):
     there is an error.
     """
     if status:
-        lib.DftiErrorMessage.restype=ctypes.c_char_p
+        lib.DftiErrorMessage.restype = ctypes.c_char_p
         msg = lib.DftiErrorMessage(status)
         raise RuntimeError(msg)
 

--- a/pycbc/fft/mkl.py
+++ b/pycbc/fft/mkl.py
@@ -69,8 +69,8 @@ def check_status(status):
     there is an error.
     """
     if status:
+        lib.DftiErrorMessage.restype=ctypes.c_char_p
         msg = lib.DftiErrorMessage(status)
-        msg = ctypes.c_char_p(msg).value
         raise RuntimeError(msg)
 
 def create_descriptor(size, idtype, odtype, inplace):

--- a/tox.ini
+++ b/tox.ini
@@ -62,6 +62,7 @@ conda_deps=
     binutils_linux-64>=2.39
     gsl
     lapack==3.6.1
+    openmpi
 conda_channels=conda-forge
 setenv = PYCBC_TEST_TYPE=docs
 commands = bash tools/pycbc_test_suite.sh


### PR DESCRIPTION
Three changes. Two of which should reduce the frequency of the SegFault failures we've encountered a lot recently, one seems to make the CI tests avoid a segfault:

* To make the CI tests avoid a segfault, I ensure that libgomp is not first opened with RTLD_DEEPBIND. This seems to cause problems (in some environments). I don't know why. This seems to fix it.
* MKL becomes the preferred FFT backend over FFTW. MKL-breaking-FFTW segfaults won't occur if we aren't using FFTW.
* pthreads becomes the default FFTW threaded backend over openmp. openmp-related segfaults can't occur if we are using pthreads for threaded FFTW.

This then exposed a few extra things:

* The LISA example doesn't work with MKL because of https://github.com/gwastro/pycbc/issues/4395
* The MKL error catching code didn't work and led to a segfault. This is fixed so we catch and print the error correctly.