### PR TITLE
Exclude IFO sections when looping through the get_subsections

### DIFF
--- a/examples/search/plotting.ini
+++ b/examples/search/plotting.ini
@@ -206,6 +206,9 @@ log-prune-param =
 prune-bins = ${fit_by_template|prune-bins}
 prune-number = ${fit_by_template|prune-number}
 
+[plot_binnedhist-h1]
+sngl-ranking = newsnr_sgveto
+
 [plot_binnedhist-mtotal]
 bin-param = mtotal
 ; for template duration, need a starting frequency

--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -675,6 +675,7 @@ class Workflow(pegasus_workflow.Workflow):
 
         self.ifos = ifos
         self.ifos.sort(key=str.lower)
+        self.get_ifo_combinations()
         self.ifo_string = ''.join(self.ifos)
 
         # Set up input and output file lists for workflow
@@ -858,6 +859,16 @@ class Workflow(pegasus_workflow.Workflow):
         # set the storage path to be the same
         ini_file.storage_path = ini_file_path
         return FileList([ini_file])
+
+    def get_ifo_combinations(self):
+        """
+        Get a list of strings for all possible combinations of IFOs
+        in the workflow
+        """
+        self.ifo_combinations = []
+        for n in range(len(self.ifos)):
+            self.ifo_combinations += [''.join(ifos).lower() for ifos in
+                                      combinations(self.ifos, n + 1)]
 
 
 class Node(pegasus_workflow.Node):

--- a/pycbc/workflow/minifollowups.py
+++ b/pycbc/workflow/minifollowups.py
@@ -402,6 +402,7 @@ def make_single_template_plots(workflow, segs, data_read_name, analyzed_name,
     name = 'single_template_plot'
     secs = requirestr(workflow.cp.get_subsections(name), require)
     secs = excludestr(secs, exclude)
+    secs = excludestr(secs, workflow.ifo_combinations)
     files = FileList([])
     for tag in secs:
         for ifo in workflow.ifos:
@@ -485,6 +486,7 @@ def make_plot_waveform_plot(workflow, params, out_dir, ifos, exclude=None,
     name = 'single_template_plot'
     secs = requirestr(workflow.cp.get_subsections(name), require)
     secs = excludestr(secs, exclude)
+    secs = excludestr(secs, workflow.ifo_combinations)
     files = FileList([])
     for tag in secs:
         node = PlotExecutable(workflow.cp, 'plot_waveform', ifos=ifos,
@@ -577,6 +579,7 @@ def make_trigger_timeseries(workflow, singles, ifo_times, out_dir, special_tids=
     name = 'plot_trigger_timeseries'
     secs = requirestr(workflow.cp.get_subsections(name), require)
     secs = excludestr(secs, exclude)
+    secs = excludestr(secs, workflow.ifo_combinations)
     files = FileList([])
     for tag in secs:
         node = PlotExecutable(workflow.cp, name, ifos=workflow.ifos,

--- a/pycbc/workflow/plotting.py
+++ b/pycbc/workflow/plotting.py
@@ -78,6 +78,7 @@ def make_range_plot(workflow, psd_files, out_dir, exclude=None, require=None,
     makedir(out_dir)
     secs = requirestr(workflow.cp.get_subsections('plot_range'), require)
     secs = excludestr(secs, exclude)
+    secs = excludestr(secs, workflow.ifo_combinations)
     files = FileList([])
     for tag in secs:
         node = PlotExecutable(workflow.cp, 'plot_range', ifos=workflow.ifos,
@@ -165,6 +166,7 @@ def make_sensitivity_plot(workflow, inj_file, out_dir, exclude=None,
     makedir(out_dir)
     secs = requirestr(workflow.cp.get_subsections('plot_sensitivity'), require)
     secs = excludestr(secs, exclude)
+    secs = excludestr(secs, workflow.ifo_combinations)
     files = FileList([])
     for tag in secs:
         node = PlotExecutable(workflow.cp, 'plot_sensitivity', ifos=workflow.ifos,
@@ -181,6 +183,7 @@ def make_coinc_snrchi_plot(workflow, inj_file, inj_trig, stat_file, trig_file,
     makedir(out_dir)
     secs = requirestr(workflow.cp.get_subsections('plot_coinc_snrchi'), require)
     secs = excludestr(secs, exclude)
+    secs = excludestr(secs, workflow.ifo_combinations)
     files = FileList([])
     for tag in secs:
         exe = PlotExecutable(workflow.cp, 'plot_coinc_snrchi',
@@ -315,6 +318,7 @@ def make_snrchi_plot(workflow, trig_files, veto_file, veto_name,
     makedir(out_dir)
     secs = requirestr(workflow.cp.get_subsections('plot_snrchi'), require)
     secs = excludestr(secs, exclude)
+    secs = excludestr(secs, workflow.ifo_combinations)
     files = FileList([])
     for tag in secs:
         for trig_file in trig_files:
@@ -341,6 +345,7 @@ def make_foundmissed_plot(workflow, inj_file, out_dir, exclude=None,
     makedir(out_dir)
     secs = requirestr(workflow.cp.get_subsections('plot_foundmissed'), require)
     secs = excludestr(secs, exclude)
+    secs = excludestr(secs, workflow.ifo_combinations)
     files = FileList([])
     for tag in secs:
         exe = PlotExecutable(workflow.cp, 'plot_foundmissed', ifos=workflow.ifos,
@@ -431,6 +436,7 @@ def make_single_hist(workflow, trig_file, veto_file, veto_name,
     makedir(out_dir)
     secs = requirestr(workflow.cp.get_subsections('plot_hist'), require)
     secs = excludestr(secs, exclude)
+    secs = excludestr(secs, workflow.ifo_combinations)
     files = FileList([])
     for tag in secs:
         node = PlotExecutable(workflow.cp, 'plot_hist',
@@ -455,6 +461,7 @@ def make_binned_hist(workflow, trig_file, veto_file, veto_name,
     makedir(out_dir)
     secs = requirestr(workflow.cp.get_subsections('plot_binnedhist'), require)
     secs = excludestr(secs, exclude)
+    secs = excludestr(secs, workflow.ifo_combinations)
     files = FileList([])
     for tag in secs:
         node = PlotExecutable(workflow.cp, 'plot_binnedhist',
@@ -478,6 +485,7 @@ def make_singles_plot(workflow, trig_files, bank_file, veto_file, veto_name,
     makedir(out_dir)
     secs = requirestr(workflow.cp.get_subsections('plot_singles'), require)
     secs = excludestr(secs, exclude)
+    secs = excludestr(secs, workflow.ifo_combinations)
     files = FileList([])
     for tag in secs:
         for trig_file in trig_files:


### PR DESCRIPTION
`get_subsections` returns all subsections from the config files, but did so without consideration whether it is an IFO/IFO combination. This meant that if we add a config section for the IFO, it would be double-counted.

This change means that in most (all?) of the places this could be an issue, the IFO / IFO combination tags will be removed from the subsections before they are looped over.

I think this is a solution to #4381