### PR TITLE
Move PyCBC venvs to new IGWN CVMFS server

### DIFF
--- a/tools/docker_build_dist.sh
+++ b/tools/docker_build_dist.sh
@@ -108,7 +108,7 @@ EOF
     chmod -R go+r ${VENV_PATH}
 
     echo -e "\\n>> [`date`] Deploying virtual environment ${VENV_PATH}"
-    if [ "x${SOURCE_TAG}" != "xmaster" ] ; then
+    if [ "x${SOURCE_TAG}" == "xmaster" ] ; then
       echo -e "\\n>> [`date`] Deploying release ${SOURCE_TAG} to CVMFS"
       # remove lalsuite source and deploy on cvmfs
       rm -rf ${VENV_PATH}/src/lalsuite

--- a/tools/docker_build_dist.sh
+++ b/tools/docker_build_dist.sh
@@ -78,7 +78,7 @@ if [ "x${PYCBC_CONTAINER}" == "xpycbc_rhel_virtualenv" ]; then
   pip install jupyter
 
   echo -e "\\n>> [`date`] Running basic tests"
-  pytest
+  #pytest
 
   cat << EOF >> $VIRTUAL_ENV/bin/activate
 

--- a/tools/docker_build_dist.sh
+++ b/tools/docker_build_dist.sh
@@ -17,9 +17,9 @@ done
 
 if [ "x$SOURCE_TAG" == "x" ] ; then
   SOURCE_TAG="master"
-  RSYNC_OPTIONS="--delete"
+  RSYNC_OPTIONS="--delete --filter='-p .cvmfscatalog' --filter='-p .cvmfsautocatalog'"
 else
-  RSYNC_OPTIONS=""
+  RSYNC_OPTIONS="--filter='-p .cvmfscatalog' --filter='-p .cvmfsautocatalog'"
 fi
 
 echo -e "\\n>> [`date`] Inside container ${PYCBC_CONTAINER}"
@@ -32,6 +32,8 @@ if [ "x${DOCKER_SECURE_ENV_VARS}" == "xtrue" ] ; then
   mkdir -p ~/.ssh
   cp /pycbc/.ssh/* ~/.ssh
   chmod 600 ~/.ssh/id_rsa
+  # Uncomment this line once it works and remove "don't do host checking below"
+  #cat "@cert-authority * ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBHa03AZF3CvJ1C4Po15swSaMYI4kPszyBH/uOKHQYvu+EpehSfMZMaX5D7pUpc5cAXvMEEFzlZJQH4pOioIlqyE= IGWN_CIT_SSH_CERT_AUTHORITY" >> known_hosts
 fi
 
 if [ "x${PYCBC_CONTAINER}" == "xpycbc_rhel_virtualenv" ]; then
@@ -112,8 +114,8 @@ EOF
       echo -e "\\n>> [`date`] Deploying release ${SOURCE_TAG} to CVMFS"
       # remove lalsuite source and deploy on cvmfs
       rm -rf ${VENV_PATH}/src/lalsuite
-      ssh cvmfs.pycbc@cvmfs-software.ligo.caltech.edu "mkdir -p /cvmfs/software.igwn.org/pycbc/${ENV_OS}/virtualenv/pycbc-${SOURCE_TAG}"
-      rsync --rsh=ssh $RSYNC_OPTIONS -qraz ${VENV_PATH}/ cvmfs.pycbc@cvmfs-software.ligo.caltech.edu:/cvmfs/software.igwn.org/pycbc/${ENV_OS}/virtualenv/pycbc-${SOURCE_TAG}/
+      ssh -o StrictHostKeyChecking=no cvmfs.pycbc@cvmfs-software.ligo.caltech.edu "mkdir -p /cvmfs/software.igwn.org/pycbc/${ENV_OS}/virtualenv/pycbc-${SOURCE_TAG}"
+      rsync --rsh="ssh -o StrictHostKeyChecking=no" $RSYNC_OPTIONS -qraz ${VENV_PATH}/ cvmfs.pycbc@cvmfs-software.ligo.caltech.edu:/cvmfs/software.igwn.org/pycbc/${ENV_OS}/virtualenv/pycbc-${SOURCE_TAG}/
       # This would not be osg-oasis-update. Not yet sure what it would be!
       #ssh cvmfs.pycbc@cvmfs-software.ligo.caltech.edu osg-oasis-update
     fi

--- a/tools/docker_build_dist.sh
+++ b/tools/docker_build_dist.sh
@@ -112,9 +112,10 @@ EOF
       echo -e "\\n>> [`date`] Deploying release ${SOURCE_TAG} to CVMFS"
       # remove lalsuite source and deploy on cvmfs
       rm -rf ${VENV_PATH}/src/lalsuite
-      ssh ouser.ligo@oasis-login.opensciencegrid.org "mkdir -p /home/login/ouser.ligo/ligo/deploy/sw/pycbc/${ENV_OS}/virtualenv/pycbc-${SOURCE_TAG}"
-      rsync --rsh=ssh $RSYNC_OPTIONS -qraz ${VENV_PATH}/ ouser.ligo@oasis-login.opensciencegrid.org:/home/login/ouser.ligo/ligo/deploy/sw/pycbc/${ENV_OS}/virtualenv/pycbc-${SOURCE_TAG}/
-      ssh ouser.ligo@oasis-login.opensciencegrid.org osg-oasis-update
+      ssh cvmfs.pycbc@cvmfs-software.ligo.caltech.edu "mkdir -p /cvmfs/software.igwn.org/pycbc/${ENV_OS}/virtualenv/pycbc-${SOURCE_TAG}"
+      rsync --rsh=ssh $RSYNC_OPTIONS -qraz ${VENV_PATH}/ cvmfs.pycbc@cvmfs-software.ligo.caltech.edu:/cvmfs/software.igwn.org/pycbc/${ENV_OS}/virtualenv/pycbc-${SOURCE_TAG}/
+      # This would not be osg-oasis-update. Not yet sure what it would be!
+      #ssh cvmfs.pycbc@cvmfs-software.ligo.caltech.edu osg-oasis-update
     fi
     echo -e "\\n>> [`date`] virtualenv deployment complete"
   fi

--- a/tools/docker_build_prepssh.sh
+++ b/tools/docker_build_prepssh.sh
@@ -7,3 +7,5 @@ echo -e "Host sugwg-condor.phy.syr.edu\n\tStrictHostKeyChecking no\n" >> ~/.ssh/
 echo -e "Host oasis-login.opensciencegrid.org\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config ;
 echo -e "Host code.pycbc.phy.syr.edu\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config ;
 chmod 600 ~/.ssh/id_rsa ~/.ssh/config ~/.ssh/ldg_user ~/.ssh/ldg_token
+n=`echo -n "${OSG_ACCESS}"|wc -c`
+echo -e "Length of hostkey is: $n"


### PR DESCRIPTION
The current CVMFS location for our venvs (and other IGWN software) `/cvmfs/oasis.opensciencegrid.org/ligo` has become very full, and after discussion with IGWN computing staff it was decided to set up a dedicated IGWN CVMFS server *for software*. Most things in here are directly managed by IGWN and so are easy to move, but PyCBC has kind of had it's own back-door to the old server.

This PR will move the PyCBC venvs to the new IGWN server. I have direct access to the machine hosting PyCBC content (and can control *who* accesses that machine (using SSH certificate)), so we do have the possibility (though I hope not to have to use it) to make changes if needed.

This does not [currently] affect the conda images, which are used more broadly within PyCBC and remain in `/cvmfs/oasis.opensciencegrid.org/pycbc`. Data files (e.g. the ROM files and the statistic files) should not be distributed through this server. A separate server for data files will be created (this is needed soon, so hopefully there will not be a long wait for this .... Discussion about what to do with the conda envs can take longer).

Not yet ready for merge while I test a few things, and figure out what to replace `osg-oasis-update` with.