### PR TITLE
Move PyCBC venvs to new IGWN CVMFS server

### DIFF
--- a/tools/docker_build_dist.sh
+++ b/tools/docker_build_dist.sh
@@ -108,7 +108,7 @@ EOF
     chmod -R go+r ${VENV_PATH}
 
     echo -e "\\n>> [`date`] Deploying virtual environment ${VENV_PATH}"
-    if [ "x${SOURCE_TAG}" != "xmaster" ] ; then
+    if [ "x${SOURCE_TAG}" == "xmaster" ] ; then
       echo -e "\\n>> [`date`] Deploying release ${SOURCE_TAG} to CVMFS"
       # remove lalsuite source and deploy on cvmfs
       rm -rf ${VENV_PATH}/src/lalsuite

--- a/tools/docker_build_dist.sh
+++ b/tools/docker_build_dist.sh
@@ -15,7 +15,7 @@ done
 
 # set the lalsuite checkout to use
 
-if [ "x$SOURCE_TAG" == "x" ] ; then
+if [ "x$SOURCE_TAG" != "x" ] ; then
   SOURCE_TAG="master"
   RSYNC_OPTIONS="--delete"
 else

--- a/tools/docker_build_dist.sh
+++ b/tools/docker_build_dist.sh
@@ -32,8 +32,6 @@ if [ "x${DOCKER_SECURE_ENV_VARS}" == "xtrue" ] ; then
   mkdir -p ~/.ssh
   cp /pycbc/.ssh/* ~/.ssh
   chmod 600 ~/.ssh/id_rsa
-  # Uncomment this line once it works and remove "don't do host checking below"
-  #cat "@cert-authority * ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBHa03AZF3CvJ1C4Po15swSaMYI4kPszyBH/uOKHQYvu+EpehSfMZMaX5D7pUpc5cAXvMEEFzlZJQH4pOioIlqyE= IGWN_CIT_SSH_CERT_AUTHORITY" >> known_hosts
 fi
 
 if [ "x${PYCBC_CONTAINER}" == "xpycbc_rhel_virtualenv" ]; then
@@ -114,8 +112,9 @@ EOF
       echo -e "\\n>> [`date`] Deploying release ${SOURCE_TAG} to CVMFS"
       # remove lalsuite source and deploy on cvmfs
       rm -rf ${VENV_PATH}/src/lalsuite
+      export RSYNC_OPTIONS VENV_PATH ENV_OS SOURCE_TAG
       if ! bash /pycbc/tools/venv_transfer_commands.sh; then
-        ssh -o StrictHostKeyChecking=no cvmfs.pycbc@cvmfs-software.ligo.caltech.edu "sudo -u repo.software cvmfs_server publish"
+        ssh cvmfs.pycbc@cvmfs-software.ligo.caltech.edu "sudo -u repo.software cvmfs_server abort -f"
         exit 1
       fi
     fi

--- a/tools/docker_build_dist.sh
+++ b/tools/docker_build_dist.sh
@@ -78,7 +78,7 @@ if [ "x${PYCBC_CONTAINER}" == "xpycbc_rhel_virtualenv" ]; then
   pip install jupyter
 
   echo -e "\\n>> [`date`] Running basic tests"
-  #pytest
+  pytest
 
   cat << EOF >> $VIRTUAL_ENV/bin/activate
 

--- a/tools/docker_build_dist.sh
+++ b/tools/docker_build_dist.sh
@@ -78,7 +78,7 @@ if [ "x${PYCBC_CONTAINER}" == "xpycbc_rhel_virtualenv" ]; then
   pip install jupyter
 
   echo -e "\\n>> [`date`] Running basic tests"
-  pytest
+  #pytest
 
   cat << EOF >> $VIRTUAL_ENV/bin/activate
 

--- a/tools/docker_build_dist.sh
+++ b/tools/docker_build_dist.sh
@@ -17,9 +17,9 @@ done
 
 if [ "x$SOURCE_TAG" == "x" ] ; then
   SOURCE_TAG="master"
-  RSYNC_OPTIONS="--delete"
+  RSYNC_OPTIONS="--delete --filter='-p .cvmfscatalog' --filter='-p .cvmfsautocatalog'"
 else
-  RSYNC_OPTIONS=""
+  RSYNC_OPTIONS="--filter='-p .cvmfscatalog' --filter='-p .cvmfsautocatalog'"
 fi
 
 echo -e "\\n>> [`date`] Inside container ${PYCBC_CONTAINER}"
@@ -32,6 +32,8 @@ if [ "x${DOCKER_SECURE_ENV_VARS}" == "xtrue" ] ; then
   mkdir -p ~/.ssh
   cp /pycbc/.ssh/* ~/.ssh
   chmod 600 ~/.ssh/id_rsa
+  # Uncomment this line once it works and remove "don't do host checking below"
+  #cat "@cert-authority * ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBHa03AZF3CvJ1C4Po15swSaMYI4kPszyBH/uOKHQYvu+EpehSfMZMaX5D7pUpc5cAXvMEEFzlZJQH4pOioIlqyE= IGWN_CIT_SSH_CERT_AUTHORITY" >> known_hosts
 fi
 
 if [ "x${PYCBC_CONTAINER}" == "xpycbc_rhel_virtualenv" ]; then
@@ -112,8 +114,8 @@ EOF
       echo -e "\\n>> [`date`] Deploying release ${SOURCE_TAG} to CVMFS"
       # remove lalsuite source and deploy on cvmfs
       rm -rf ${VENV_PATH}/src/lalsuite
-      ssh cvmfs.pycbc@cvmfs-software.ligo.caltech.edu "mkdir -p /cvmfs/software.igwn.org/pycbc/${ENV_OS}/virtualenv/pycbc-${SOURCE_TAG}"
-      rsync --rsh=ssh $RSYNC_OPTIONS -qraz ${VENV_PATH}/ cvmfs.pycbc@cvmfs-software.ligo.caltech.edu:/cvmfs/software.igwn.org/pycbc/${ENV_OS}/virtualenv/pycbc-${SOURCE_TAG}/
+      ssh -o StrictHostKeyChecking=no cvmfs.pycbc@cvmfs-software.ligo.caltech.edu "mkdir -p /cvmfs/software.igwn.org/pycbc/${ENV_OS}/virtualenv/pycbc-${SOURCE_TAG}"
+      rsync --rsh="ssh -o StrictHostKeyChecking=no" $RSYNC_OPTIONS -qraz ${VENV_PATH}/ cvmfs.pycbc@cvmfs-software.ligo.caltech.edu:/cvmfs/software.igwn.org/pycbc/${ENV_OS}/virtualenv/pycbc-${SOURCE_TAG}/
       # This would not be osg-oasis-update. Not yet sure what it would be!
       #ssh cvmfs.pycbc@cvmfs-software.ligo.caltech.edu osg-oasis-update
     fi

--- a/tools/docker_build_dist.sh
+++ b/tools/docker_build_dist.sh
@@ -112,9 +112,10 @@ EOF
       echo -e "\\n>> [`date`] Deploying release ${SOURCE_TAG} to CVMFS"
       # remove lalsuite source and deploy on cvmfs
       rm -rf ${VENV_PATH}/src/lalsuite
-      ssh ouser.ligo@oasis-login.opensciencegrid.org "mkdir -p /home/login/ouser.ligo/ligo/deploy/sw/pycbc/${ENV_OS}/virtualenv/pycbc-${SOURCE_TAG}"
-      rsync --rsh=ssh $RSYNC_OPTIONS -qraz ${VENV_PATH}/ ouser.ligo@oasis-login.opensciencegrid.org:/home/login/ouser.ligo/ligo/deploy/sw/pycbc/${ENV_OS}/virtualenv/pycbc-${SOURCE_TAG}/
-      ssh ouser.ligo@oasis-login.opensciencegrid.org osg-oasis-update
+      ssh cvmfs.pycbc@cvmfs-software.ligo.caltech.edu "mkdir -p /cvmfs/software.igwn.org/pycbc/${ENV_OS}/virtualenv/pycbc-${SOURCE_TAG}"
+      rsync --rsh=ssh $RSYNC_OPTIONS -qraz ${VENV_PATH}/ cvmfs.pycbc@cvmfs-software.ligo.caltech.edu:/cvmfs/software.igwn.org/pycbc/${ENV_OS}/virtualenv/pycbc-${SOURCE_TAG}/
+      # This would not be osg-oasis-update. Not yet sure what it would be!
+      #ssh cvmfs.pycbc@cvmfs-software.ligo.caltech.edu osg-oasis-update
     fi
     echo -e "\\n>> [`date`] virtualenv deployment complete"
   fi

--- a/tools/docker_build_dist.sh
+++ b/tools/docker_build_dist.sh
@@ -114,10 +114,10 @@ EOF
       echo -e "\\n>> [`date`] Deploying release ${SOURCE_TAG} to CVMFS"
       # remove lalsuite source and deploy on cvmfs
       rm -rf ${VENV_PATH}/src/lalsuite
-      ssh -o StrictHostKeyChecking=no cvmfs.pycbc@cvmfs-software.ligo.caltech.edu "sudo -u repo.software cvmfs_server transaction"
-      ssh -o StrictHostKeyChecking=no cvmfs.pycbc@cvmfs-software.ligo.caltech.edu "mkdir -p /cvmfs/software.igwn.org/pycbc/${ENV_OS}/virtualenv/pycbc-${SOURCE_TAG}"
-      rsync --rsh="ssh -o StrictHostKeyChecking=no" $RSYNC_OPTIONS -qraz ${VENV_PATH}/ cvmfs.pycbc@cvmfs-software.ligo.caltech.edu:/cvmfs/software.igwn.org/pycbc/${ENV_OS}/virtualenv/pycbc-${SOURCE_TAG}/
-      ssh -o StrictHostKeyChecking=no cvmfs.pycbc@cvmfs-software.ligo.caltech.edu "sudo -u repo.software cvmfs_server publish"
+      if ! bash /pycbc/tools/venv_transfer_commands.sh; then
+        ssh -o StrictHostKeyChecking=no cvmfs.pycbc@cvmfs-software.ligo.caltech.edu "sudo -u repo.software cvmfs_server publish"
+        exit 1
+      fi
     fi
     echo -e "\\n>> [`date`] virtualenv deployment complete"
   fi

--- a/tools/docker_build_dist.sh
+++ b/tools/docker_build_dist.sh
@@ -78,7 +78,7 @@ if [ "x${PYCBC_CONTAINER}" == "xpycbc_rhel_virtualenv" ]; then
   pip install jupyter
 
   echo -e "\\n>> [`date`] Running basic tests"
-  pytest
+  #pytest
 
   cat << EOF >> $VIRTUAL_ENV/bin/activate
 
@@ -114,10 +114,10 @@ EOF
       echo -e "\\n>> [`date`] Deploying release ${SOURCE_TAG} to CVMFS"
       # remove lalsuite source and deploy on cvmfs
       rm -rf ${VENV_PATH}/src/lalsuite
+      ssh -o StrictHostKeyChecking=no cvmfs.pycbc@cvmfs-software.ligo.caltech.edu "sudo -u repo.software cvmfs_server transaction"
       ssh -o StrictHostKeyChecking=no cvmfs.pycbc@cvmfs-software.ligo.caltech.edu "mkdir -p /cvmfs/software.igwn.org/pycbc/${ENV_OS}/virtualenv/pycbc-${SOURCE_TAG}"
       rsync --rsh="ssh -o StrictHostKeyChecking=no" $RSYNC_OPTIONS -qraz ${VENV_PATH}/ cvmfs.pycbc@cvmfs-software.ligo.caltech.edu:/cvmfs/software.igwn.org/pycbc/${ENV_OS}/virtualenv/pycbc-${SOURCE_TAG}/
-      # This would not be osg-oasis-update. Not yet sure what it would be!
-      #ssh cvmfs.pycbc@cvmfs-software.ligo.caltech.edu osg-oasis-update
+      ssh -o StrictHostKeyChecking=no cvmfs.pycbc@cvmfs-software.ligo.caltech.edu "sudo -u repo.software cvmfs_server publish"
     fi
     echo -e "\\n>> [`date`] virtualenv deployment complete"
   fi

--- a/tools/docker_build_dist.sh
+++ b/tools/docker_build_dist.sh
@@ -17,9 +17,9 @@ done
 
 if [ "x$SOURCE_TAG" == "x" ] ; then
   SOURCE_TAG="master"
-  RSYNC_OPTIONS="--delete --filter='-p .cvmfscatalog' --filter='-p .cvmfsautocatalog'"
+  RSYNC_OPTIONS="--delete"
 else
-  RSYNC_OPTIONS="--filter='-p .cvmfscatalog' --filter='-p .cvmfsautocatalog'"
+  RSYNC_OPTIONS=""
 fi
 
 echo -e "\\n>> [`date`] Inside container ${PYCBC_CONTAINER}"

--- a/tools/docker_build_dist.sh
+++ b/tools/docker_build_dist.sh
@@ -15,7 +15,7 @@ done
 
 # set the lalsuite checkout to use
 
-if [ "x$SOURCE_TAG" != "x" ] ; then
+if [ "x$SOURCE_TAG" == "x" ] ; then
   SOURCE_TAG="master"
   RSYNC_OPTIONS="--delete"
 else
@@ -108,7 +108,7 @@ EOF
     chmod -R go+r ${VENV_PATH}
 
     echo -e "\\n>> [`date`] Deploying virtual environment ${VENV_PATH}"
-    if [ "x${SOURCE_TAG}" == "xmaster" ] ; then
+    if [ "x${SOURCE_TAG}" != "xmaster" ] ; then
       echo -e "\\n>> [`date`] Deploying release ${SOURCE_TAG} to CVMFS"
       # remove lalsuite source and deploy on cvmfs
       rm -rf ${VENV_PATH}/src/lalsuite

--- a/tools/docker_build_dist.sh
+++ b/tools/docker_build_dist.sh
@@ -76,7 +76,7 @@ if [ "x${PYCBC_CONTAINER}" == "xpycbc_rhel_virtualenv" ]; then
   pip install jupyter
 
   echo -e "\\n>> [`date`] Running basic tests"
-  #pytest
+  pytest
 
   cat << EOF >> $VIRTUAL_ENV/bin/activate
 

--- a/tools/docker_build_prepssh.sh
+++ b/tools/docker_build_prepssh.sh
@@ -6,4 +6,5 @@ echo -e "Host sugwg-test1.phy.syr.edu\n\tStrictHostKeyChecking no\n" >> ~/.ssh/c
 echo -e "Host sugwg-condor.phy.syr.edu\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config ;
 echo -e "Host oasis-login.opensciencegrid.org\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config ;
 echo -e "Host code.pycbc.phy.syr.edu\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config ;
+echo -e "@cert-authority * ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBHa03AZF3CvJ1C4Po15swSaMYI4kPszyBH/uOKHQYvu+EpehSfMZMaX5D7pUpc5cAXvMEEFzlZJQH4pOioIlqyE= IGWN_CIT_SSH_CERT_AUTHORITY" >> ~/.ssh/known_hosts
 chmod 600 ~/.ssh/id_rsa ~/.ssh/config ~/.ssh/ldg_user ~/.ssh/ldg_token

--- a/tools/docker_build_prepssh.sh
+++ b/tools/docker_build_prepssh.sh
@@ -7,5 +7,3 @@ echo -e "Host sugwg-condor.phy.syr.edu\n\tStrictHostKeyChecking no\n" >> ~/.ssh/
 echo -e "Host oasis-login.opensciencegrid.org\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config ;
 echo -e "Host code.pycbc.phy.syr.edu\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config ;
 chmod 600 ~/.ssh/id_rsa ~/.ssh/config ~/.ssh/ldg_user ~/.ssh/ldg_token
-n=`echo -n "${OSG_ACCESS}"|wc -c`
-echo -e "Length of hostkey is: $n"

--- a/tools/docker_build_prepssh.sh
+++ b/tools/docker_build_prepssh.sh
@@ -7,3 +7,5 @@ echo -e "Host sugwg-condor.phy.syr.edu\n\tStrictHostKeyChecking no\n" >> ~/.ssh/
 echo -e "Host oasis-login.opensciencegrid.org\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config ;
 echo -e "Host code.pycbc.phy.syr.edu\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config ;
 chmod 600 ~/.ssh/id_rsa ~/.ssh/config ~/.ssh/ldg_user ~/.ssh/ldg_token
+n=`echo -n "${OSG_ACCESS}"|wc -c`
+echo -e "Length of hostkey is: $n"

--- a/tools/venv_transfer_commands.sh
+++ b/tools/venv_transfer_commands.sh
@@ -3,9 +3,9 @@
 set -e
 
 # Please don't try and run this script directly!
-ssh -o StrictHostKeyChecking=no cvmfs.pycbc@cvmfs-software.ligo.caltech.edu <<EOF
+ssh cvmfs.pycbc@cvmfs-software.ligo.caltech.edu <<EOF
 sudo -u repo.software cvmfs_server transaction -t 300 software.igwn.org
 mkdir -p /cvmfs/software.igwn.org/pycbc/${ENV_OS}/virtualenv/pycbc-${SOURCE_TAG}
 EOF
-rsync --rsh="ssh -o StrictHostKeyChecking=no" $RSYNC_OPTIONS -qraz ${VENV_PATH}/ cvmfs.pycbc@cvmfs-software.ligo.caltech.edu:/cvmfs/software.igwn.org/pycbc/${ENV_OS}/virtualenv/pycbc-${SOURCE_TAG}/
-ssh -o StrictHostKeyChecking=no cvmfs.pycbc@cvmfs-software.ligo.caltech.edu "sudo -u repo.software cvmfs_server publish"
+rsync --rsh="ssh" $RSYNC_OPTIONS -qraz ${VENV_PATH}/ cvmfs.pycbc@cvmfs-software.ligo.caltech.edu:/cvmfs/software.igwn.org/pycbc/${ENV_OS}/virtualenv/pycbc-${SOURCE_TAG}/
+ssh cvmfs.pycbc@cvmfs-software.ligo.caltech.edu "sudo -u repo.software cvmfs_server publish"

--- a/tools/venv_transfer_commands.sh
+++ b/tools/venv_transfer_commands.sh
@@ -7,5 +7,5 @@ ssh cvmfs.pycbc@cvmfs-software.ligo.caltech.edu <<EOF
 sudo -u repo.software cvmfs_server transaction -t 300 software.igwn.org
 mkdir -p /cvmfs/software.igwn.org/pycbc/${ENV_OS}/virtualenv/pycbc-${SOURCE_TAG}
 EOF
-rsync --rsh="ssh" $RSYNC_OPTIONS -qraz ${VENV_PATH}/ cvmfs.pycbc@cvmfs-software.ligo.caltech.edu:/cvmfs/software.igwn.org/pycbc/${ENV_OS}/virtualenv/pycbc-${SOURCE_TAG}/
-ssh cvmfs.pycbc@cvmfs-software.ligo.caltech.edu "sudo -u repo.software cvmfs_server publish"
+rsync --rsh="ssh" $RSYNC_OPTIONS --filter='Pp .cvmfscatalog' --filter='Pp .cvmfsautocatalog' -qraz ${VENV_PATH}/ cvmfs.pycbc@cvmfs-software.ligo.caltech.edu:/cvmfs/software.igwn.org/pycbc/${ENV_OS}/virtualenv/pycbc-${SOURCE_TAG}/
+ssh cvmfs.pycbc@cvmfs-software.ligo.caltech.edu "sudo -u repo.software cvmfs_server abort"

--- a/tools/venv_transfer_commands.sh
+++ b/tools/venv_transfer_commands.sh
@@ -5,7 +5,8 @@ set -e
 # Please don't try and run this script directly!
 ssh cvmfs.pycbc@cvmfs-software.ligo.caltech.edu <<EOF
 sudo -u repo.software cvmfs_server transaction -t 300 software.igwn.org
+sudo -u repo.software chmod go+rx /cvmfs/software.igwn.org/
 mkdir -p /cvmfs/software.igwn.org/pycbc/${ENV_OS}/virtualenv/pycbc-${SOURCE_TAG}
 EOF
 rsync --rsh="ssh" $RSYNC_OPTIONS --filter='Pp .cvmfscatalog' --filter='Pp .cvmfsautocatalog' -qraz ${VENV_PATH}/ cvmfs.pycbc@cvmfs-software.ligo.caltech.edu:/cvmfs/software.igwn.org/pycbc/${ENV_OS}/virtualenv/pycbc-${SOURCE_TAG}/
-ssh cvmfs.pycbc@cvmfs-software.ligo.caltech.edu "sudo -u repo.software cvmfs_server abort"
+ssh cvmfs.pycbc@cvmfs-software.ligo.caltech.edu "sudo -u repo.software cvmfs_server publish"

--- a/tools/venv_transfer_commands.sh
+++ b/tools/venv_transfer_commands.sh
@@ -3,7 +3,9 @@
 set -e
 
 # Please don't try and run this script directly!
-ssh -o StrictHostKeyChecking=no cvmfs.pycbc@cvmfs-software.ligo.caltech.edu "sudo -u repo.software cvmfs_server transaction"
-ssh -o StrictHostKeyChecking=no cvmfs.pycbc@cvmfs-software.ligo.caltech.edu "mkdir -p /cvmfs/software.igwn.org/pycbc/${ENV_OS}/virtualenv/pycbc-${SOURCE_TAG}"
+ssh -o StrictHostKeyChecking=no cvmfs.pycbc@cvmfs-software.ligo.caltech.edu <<EOF
+sudo -u repo.software cvmfs_server transaction -t 300 software.igwn.org
+mkdir -p /cvmfs/software.igwn.org/pycbc/${ENV_OS}/virtualenv/pycbc-${SOURCE_TAG}
+EOF
 rsync --rsh="ssh -o StrictHostKeyChecking=no" $RSYNC_OPTIONS -qraz ${VENV_PATH}/ cvmfs.pycbc@cvmfs-software.ligo.caltech.edu:/cvmfs/software.igwn.org/pycbc/${ENV_OS}/virtualenv/pycbc-${SOURCE_TAG}/
 ssh -o StrictHostKeyChecking=no cvmfs.pycbc@cvmfs-software.ligo.caltech.edu "sudo -u repo.software cvmfs_server publish"

--- a/tools/venv_transfer_commands.sh
+++ b/tools/venv_transfer_commands.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+
+# Please don't try and run this script directly!
+ssh -o StrictHostKeyChecking=no cvmfs.pycbc@cvmfs-software.ligo.caltech.edu "sudo -u repo.software cvmfs_server transaction"
+ssh -o StrictHostKeyChecking=no cvmfs.pycbc@cvmfs-software.ligo.caltech.edu "mkdir -p /cvmfs/software.igwn.org/pycbc/${ENV_OS}/virtualenv/pycbc-${SOURCE_TAG}"
+rsync --rsh="ssh -o StrictHostKeyChecking=no" $RSYNC_OPTIONS -qraz ${VENV_PATH}/ cvmfs.pycbc@cvmfs-software.ligo.caltech.edu:/cvmfs/software.igwn.org/pycbc/${ENV_OS}/virtualenv/pycbc-${SOURCE_TAG}/
+ssh -o StrictHostKeyChecking=no cvmfs.pycbc@cvmfs-software.ligo.caltech.edu "sudo -u repo.software cvmfs_server publish"


### PR DESCRIPTION
The current CVMFS location for our venvs (and other IGWN software) /cvmfs/oasis.opensciencegrid.org/ligo has become very full, and after discussion with IGWN computing staff it was decided to set up a dedicated IGWN CVMFS server for software. Most things in here are directly managed by IGWN and so are easy to move, but PyCBC has kind of had it's own back-door to the old server.

This PR will move the PyCBC venvs to the new IGWN server. I have direct access to the machine hosting PyCBC content (and can control who accesses that machine (using SSH certificate)), so we do have the possibility (though I hope not to have to use it) to make changes if needed.

This does not [currently] affect the conda images, which are used more broadly within PyCBC and remain in /cvmfs/oasis.opensciencegrid.org/pycbc. Data files (e.g. the ROM files and the statistic files) should not be distributed through this server. A separate server for data files will be created (this is needed soon, so hopefully there will not be a long wait for this .... Discussion about what to do with the conda envs can take longer).