### PR TITLE
Cache calls to FrOpen(XX).cache to avoid calculate_psd being incredibly slow

### DIFF
--- a/pycbc/frame/frame.py
+++ b/pycbc/frame/frame.py
@@ -17,6 +17,7 @@
 This modules contains functions for reading in data from frame files or caches
 """
 
+import functools
 import lalframe, logging
 import lal
 import numpy
@@ -95,6 +96,9 @@ def _is_gwf(file_path):
         pass
     return False
 
+@functools.lru_cache(maxsize=1000)
+def _cached_lal_cache_from_frame(dir_name, file_name):
+    return lalframe.FrStreamOpen(str(dir_name), str(file_name)).cache
 
 def locations_to_cache(locations, latest=False):
     """ Return a cumulative cache file build from the list of locations
@@ -137,7 +141,7 @@ def locations_to_cache(locations, latest=False):
             if file_extension in [".lcf", ".cache"]:
                 cache = lal.CacheImport(file_path)
             elif file_extension == ".gwf" or _is_gwf(file_path):
-                cache = lalframe.FrOpen(str(dir_name), str(file_name)).cache
+                cache = _cached_lal_cache_from_frame(str(dir_name), str(file_name))
             else:
                 raise TypeError("Invalid location name")
 


### PR DESCRIPTION
PROBLEM BEING SOLVED HERE: The calculate_psd jobs are normally run with a large list (a week of data) of frame files. Every time a PSD segment is calculated a call to the `from_cli` frame reading code is made. As this only reads frame files at the specific times, this shouldn't be an issue right? Well, not quite, because we don't assert the LVK frame file naming convention, so explicitly check what times each frame file covers. Which means that we need to do a quick file stat operation on *every* frame file, for *every* PSD segment. If you're doing an OSG run, you're likely pointing to frame files in a CVMFS location, which basically means that there's also a transfer process going on in the background as we need the entire frame file before we can read parts of it.

HOW ARE WE SOLVING IT: Cache the output of the `FrStreamOpen` command. calculate_psd is split over multiple cores, and so this is cached for each of the multiprocessing processes, but that's not really a problem. Having each process do this O(50) times for all the frame files in a chunk over CVMFS is a problem.

I want to run this in a CVMFS workflow and have had some issues with authentication etc., which should now be resolved, but this up for review anyway in case there are comments or objections.