### PR TITLE
Purge fullinj / injfull analyses

### DIFF
--- a/bin/all_sky_search/pycbc_add_statmap
+++ b/bin/all_sky_search/pycbc_add_statmap
@@ -226,7 +226,7 @@ for f_in in files:
                 bg_exc_trig_ids[ifo] = np.concatenate([bg_exc_trig_ids[ifo],
                     -1 * np.ones_like(f_in['background_exc/stat'][:],
                     dtype=int)])
-n_triggers = f['foreground/ifar'].size
+n_triggers = f['foreground/stat'].size
 logging.info('{} foreground events before clustering'.format(n_triggers))
 
 for ifo in all_ifos:
@@ -266,15 +266,19 @@ def filter_dataset(h5file, name, idx):
 # multiple files
 for key in f['foreground'].keys():
     if key not in all_ifos:
+        if f['foreground/%s' % key].size == 0:
+            # This is an indicator that the column was specifically
+            # not calculated
+            logging.info('foreground/%s dataset is being ignored', key)
+            continue
         filter_dataset(f, 'foreground/%s' % key, cidx)
     else:  # key is an ifo
         for k in f['foreground/%s' % key].keys():
             filter_dataset(f, 'foreground/{}/{}'.format(key, k), cidx)
 
-fg_ifar_init = f['foreground/ifar'][:]
 fg_ifar_exc_init = f['foreground/ifar_exc'][:]
 
-n_triggers = fg_ifar_init.size
+n_triggers = fg_ifar_exc_init.size
 
 logging.info('Calculating event times to determine which types of coinc '
              'are available')

--- a/bin/all_sky_search/pycbc_add_statmap
+++ b/bin/all_sky_search/pycbc_add_statmap
@@ -378,8 +378,6 @@ if not injection_style:
     # Only output non-exclusive ifar/fap if it is _not_ an injection case
     f['foreground/ifar'][:] = fg_ifar
     f['foreground/fap'] = 1 - np.exp(-conv.sec_to_year(fg_time) / fg_ifar)
-else:
-    del f['foreground/ifar']
 
 del test_times
 

--- a/bin/all_sky_search/pycbc_add_statmap
+++ b/bin/all_sky_search/pycbc_add_statmap
@@ -266,19 +266,12 @@ def filter_dataset(h5file, name, idx):
 # multiple files
 for key in f['foreground'].keys():
     if key not in all_ifos:
-        if f['foreground/%s' % key].size == 0:
-            # This is an indicator that the column was specifically
-            # not calculated
-            logging.info('foreground/%s dataset is being ignored', key)
-            continue
         filter_dataset(f, 'foreground/%s' % key, cidx)
     else:  # key is an ifo
         for k in f['foreground/%s' % key].keys():
             filter_dataset(f, 'foreground/{}/{}'.format(key, k), cidx)
 
-fg_ifar_exc_init = f['foreground/ifar_exc'][:]
-
-n_triggers = fg_ifar_exc_init.size
+n_triggers = f['foreground/stat'].size
 
 logging.info('Calculating event times to determine which types of coinc '
              'are available')

--- a/bin/all_sky_search/pycbc_coinc_hdfinjfind
+++ b/bin/all_sky_search/pycbc_coinc_hdfinjfind
@@ -277,8 +277,10 @@ for trigger_file, injection_file in zip(args.trigger_files,
             # This is a coincident statmap file
             fo[key].attrs['pivot'] = fkey.attrs['pivot']
             fo[key].attrs['fixed'] = fkey.attrs['fixed']
-        fo[key].attrs['foreground_time'] = fkey.attrs['foreground_time']
-        fo[key].attrs['foreground_time_exc'] = fkey.attrs['foreground_time_exc']
+        if 'foreground_time' in fkey.attrs.keys():
+            fo[key].attrs['foreground_time'] = fkey.attrs['foreground_time']
+        if 'foreground_time_exc' in fkey.attrs.keys():
+            fo[key].attrs['foreground_time_exc'] = fkey.attrs['foreground_time_exc']
 
     hdf_append(fo, 'missed/all', missed + injection_index)
     hdf_append(fo, 'missed/within_analysis', missed_within_time + injection_index)

--- a/bin/all_sky_search/pycbc_coinc_statmap_inj
+++ b/bin/all_sky_search/pycbc_coinc_statmap_inj
@@ -19,21 +19,12 @@ parser.add_argument('--cluster-window', type=float, default=10,
                          'events [default=10s]')
 parser.add_argument('--zero-lag-coincs', nargs='+',
                     help='Files containing the injection zerolag coincidences')
-parser.add_argument('--mixed-coincs-inj-full', nargs='+',
-                    help='Files containing the mixed injection/clean data '
-                         'time slides')
-parser.add_argument('--mixed-coincs-full-inj', nargs='+',
-                    help='Files containing the mixed clean/injection data '
-                         'time slides')
 parser.add_argument('--full-data-background',
                     help='background file from full data for use in analyzing '
                          'injection coincs')
 parser.add_argument('--veto-window', type=float, default=.1,
                     help='Time around each zerolag trigger to window out '
                          '[default=.1s]')
-parser.add_argument('--ranking-statistic-threshold', type=float,
-                    help='Minimum value of the ranking statistic to calculate'
-                         ' a unique inclusive background.')
 parser.add_argument('--ifos', nargs='+',
                     help='List of ifos used in these coincidence files')
 significance.insert_significance_option_group(parser)
@@ -53,14 +44,6 @@ window = args.cluster_window
 logging.info("Loading coinc zerolag triggers")
 zdata = pycbc.io.MultiifoStatmapData(files=args.zero_lag_coincs, ifos=args.ifos)
 zdata = zdata.cluster(window)
-
-logging.info("Loading coinc full inj triggers")
-fidata = pycbc.io.MultiifoStatmapData(files=args.mixed_coincs_full_inj,
-                                      ifos=args.ifos).cluster(window)
-
-logging.info("Loading coinc inj full triggers")
-ifdata = pycbc.io.MultiifoStatmapData(files=args.mixed_coincs_inj_full,
-                                      ifos=args.ifos).cluster(window)
 
 f = h5py.File(args.output_file, "w")
 
@@ -118,59 +101,17 @@ if len(zdata) > 0:
     ifar = numpy.zeros(len(ftimes), dtype=numpy.float32)
     fap = numpy.zeros(len(ftimes), dtype=numpy.float32)
 
-    # We are relying on the injection data set to be the first one,
-    # this is determined
-    # by the argument order to pycbc_coinc_findtrigs
-    pivot_ifo = zdata.attrs['pivot']
-    ifsort = ifdata.data['%s/time' % pivot_ifo].argsort()
-    ifsorted = ifdata.data['%s/time' % pivot_ifo][ifsort]
-    if_start, if_end = numpy.searchsorted(ifsorted, start), \
-                       numpy.searchsorted(ifsorted, end)
-
-    fisort = fidata.data['%s/time' % pivot_ifo].argsort()
-    fisorted = fidata.data['%s/time' % pivot_ifo][fisort]
-    fi_start, fi_end = numpy.searchsorted(fisorted, start), \
-                       numpy.searchsorted(fisorted, end)
-
     # most of the triggers are here so presort to speed up later sorting
     bsort = back_stat.argsort()
     dec_fac = dec_fac[bsort]
     back_stat = back_stat[bsort]
 
-    for i, fstat in enumerate(zdata.stat):
-        # If the trigger is quiet enough, then don't calculate a separate
-        # background type, as it would not be significantly different
-        if args.ranking_statistic_threshold and \
-                    fstat < args.ranking_statistic_threshold:
-            fnlouder[i] = fnlouder_exc[i]
-            ifar[i] = ifar_exc[i]
-            fap[i] = fap_exc[i]
-            continue
-
-        v1 = fisort[fi_start[i]:fi_end[i]]
-        v2 = ifsort[if_start[i]:if_end[i]]
-
-        inj_stat = numpy.concatenate(
-                     [ifdata.stat[v2], fidata.stat[v1], back_stat])
-        inj_dec = numpy.concatenate(
-                     [numpy.repeat(1, len(v1) + len(v2)), dec_fac])
-
-        _, fnlouder[i] = significance.get_n_louder(
-            inj_stat,
-            fstat,
-            inj_dec,
-            **significance_dict[ifo_key])
-
-        ifar[i] = background_time / (fnlouder[i] + 1)
-        fap[i] = 1 - numpy.exp(- coinc_time / ifar[i])
-        logging.info('processed %s, %s' % (i, fstat))
-
-    f['foreground/ifar'] = conv.sec_to_year(ifar)
-    f['foreground/fap'] = fap
 else:
     f['foreground/ifar_exc'] = numpy.array([])
     f['foreground/fap_exc'] = numpy.array([])
-    f['foreground/ifar'] = numpy.array([])
-    f['foreground/fap'] = numpy.array([])
+
+# Indicate that inclusive IFAR is not calculated
+f['foreground/ifar'] = numpy.array([])
+f['foreground/fap'] = numpy.array([])
 
 logging.info("Done")

--- a/bin/all_sky_search/pycbc_coinc_statmap_inj
+++ b/bin/all_sky_search/pycbc_coinc_statmap_inj
@@ -82,36 +82,20 @@ f.attrs['background_time'] = background_time
 f.attrs['foreground_time'] = coinc_time
 
 if len(zdata) > 0:
+
     _, fnlouder_exc = significance.get_n_louder(
         back_stat,
         zdata.stat,
         dec_fac,
         **significance_dict[ifo_key])
+
     ifar_exc = background_time / (fnlouder_exc + 1)
     fap_exc = 1 - numpy.exp(- coinc_time / ifar_exc)
     f['foreground/ifar_exc'] = conv.sec_to_year(ifar_exc)
     f['foreground/fap_exc'] = fap_exc
 
-    logging.info('calculating injection backgrounds')
-    ifotimes = numpy.array([zdata.data['%s/time' % ifo] for ifo in args.ifos])
-    ftimes = ifotimes.mean(axis=0)
-    start, end = ftimes - args.veto_window, ftimes + args.veto_window
-
-    fnlouder = numpy.zeros(len(ftimes), dtype=numpy.float32)
-    ifar = numpy.zeros(len(ftimes), dtype=numpy.float32)
-    fap = numpy.zeros(len(ftimes), dtype=numpy.float32)
-
-    # most of the triggers are here so presort to speed up later sorting
-    bsort = back_stat.argsort()
-    dec_fac = dec_fac[bsort]
-    back_stat = back_stat[bsort]
-
 else:
     f['foreground/ifar_exc'] = numpy.array([])
     f['foreground/fap_exc'] = numpy.array([])
-
-# Indicate that inclusive IFAR is not calculated
-f['foreground/ifar'] = numpy.array([])
-f['foreground/fap'] = numpy.array([])
 
 logging.info("Done")

--- a/bin/all_sky_search/pycbc_sngls_statmap_inj
+++ b/bin/all_sky_search/pycbc_sngls_statmap_inj
@@ -108,16 +108,6 @@ fore_stat = all_trigs.stat[fore_locs]
 
 significance_dict = significance.digest_significance_options([ifo], args)
 
-# Cumulative array of inclusive background triggers and the number of
-# inclusive background triggers louder than each foreground trigger
-back_cnum, fnlouder = significance.get_n_louder(
-    back_stat,
-    fore_stat,
-    bkg_dec_facs,
-    **significance_dict[ifo])
-
-bg_ifar = fg_time / (back_cnum + 1)
-
 # Cumulative array of exclusive background triggers and the number
 # of exclusive background triggers louder than each foreground trigger
 back_cnum_exc, fnlouder_exc = significance.get_n_louder(
@@ -128,15 +118,6 @@ back_cnum_exc, fnlouder_exc = significance.get_n_louder(
 
 fg_ifar_exc = fg_time_exc / (fnlouder_exc + 1)
 bg_ifar_exc = fg_time_exc / (back_cnum_exc + 1)
-
-# Not sure if these are actually used later as we
-# don't do inclusive
-f['background/ifar'] = conv.sec_to_year(bg_ifar)
-f.attrs['background_time'] = fg_time
-f.attrs['foreground_time'] = fg_time
-# Indicate not doing inclusive IFAR/FAP
-f['foreground/ifar'] = numpy.array([])
-f['foreground/fap'] = numpy.array([])
 
 f['background_exc/ifar'] = conv.sec_to_year(bg_ifar_exc)
 f.attrs['background_time_exc'] = fg_time_exc

--- a/bin/all_sky_search/pycbc_sngls_statmap_inj
+++ b/bin/all_sky_search/pycbc_sngls_statmap_inj
@@ -51,11 +51,6 @@ parser.add_argument('--cluster-window', type=float, default=10,
 parser.add_argument('--veto-window', type=float, default=.1,
                     help='Time around each zerolag trigger to window out '
                          '[default=.1s]')
-parser.add_argument('--background-removal-statistic', type=float,
-                    default=numpy.inf,
-                    help="Remove any triggers with statistic higher "
-                         "than this from the background. "
-                          "Default=None removed")
 significance.insert_significance_option_group(parser)
 parser.add_argument('--output-file')
 args = parser.parse_args()
@@ -71,7 +66,7 @@ ifo = args.ifos[0]
 assert ifo + '/time' in all_trigs.data
 
 logging.info("We have %s triggers" % len(all_trigs.stat))
-logging.info("Clustering coinc triggers (inclusive of zerolag)")
+logging.info("Clustering triggers")
 all_trigs = all_trigs.cluster(args.cluster_window)
 
 logging.info('getting background statistics')
@@ -121,6 +116,8 @@ back_cnum, fnlouder = significance.get_n_louder(
     bkg_dec_facs,
     **significance_dict[ifo])
 
+bg_ifar = fg_time / (back_cnum + 1)
+
 # Cumulative array of exclusive background triggers and the number
 # of exclusive background triggers louder than each foreground trigger
 back_cnum_exc, fnlouder_exc = significance.get_n_louder(
@@ -129,23 +126,22 @@ back_cnum_exc, fnlouder_exc = significance.get_n_louder(
     bkg_exc_dec_facs,
     **significance_dict[ifo])
 
-fg_ifar = fg_time / (fnlouder + 1)
-bg_ifar = fg_time / (back_cnum + 1)
 fg_ifar_exc = fg_time_exc / (fnlouder_exc + 1)
 bg_ifar_exc = fg_time_exc / (back_cnum_exc + 1)
 
+# Not sure if these are actually used later as we
+# don't do inclusive
 f['background/ifar'] = conv.sec_to_year(bg_ifar)
-f['background_exc/ifar'] = conv.sec_to_year(bg_ifar_exc)
 f.attrs['background_time'] = fg_time
 f.attrs['foreground_time'] = fg_time
+# Indicate not doing inclusive IFAR/FAP
+f['foreground/ifar'] = numpy.array([])
+f['foreground/fap'] = numpy.array([])
+
+f['background_exc/ifar'] = conv.sec_to_year(bg_ifar_exc)
 f.attrs['background_time_exc'] = fg_time_exc
 f.attrs['foreground_time_exc'] = fg_time_exc
 
-logging.info("calculating foreground ifar/fap values")
-
-fap = 1 - numpy.exp(- fg_time / fg_ifar)
-f['foreground/ifar'] = conv.sec_to_year(fg_ifar)
-f['foreground/fap'] = fap
 fap_exc = 1 - numpy.exp(- fg_time_exc / fg_ifar_exc)
 f['foreground/ifar_exc'] = conv.sec_to_year(fg_ifar_exc)
 f['foreground/fap_exc'] = fap_exc

--- a/bin/workflows/pycbc_make_offline_search_workflow
+++ b/bin/workflows/pycbc_make_offline_search_workflow
@@ -610,7 +610,6 @@ for inj_file, tag in zip(inj_files, inj_tags):
         curr_out = wf.setup_interval_coinc_inj(
             workflow,
             hdfbank,
-            full_insps,
             inspcomb,
             statfiles,
             final_bg_files[ordered_ifo_list],

--- a/examples/search/analysis.ini
+++ b/examples/search/analysis.ini
@@ -186,10 +186,6 @@ loudest-keep-values = [-1:5,1:5]
 [coinc-full_data-3det]
 loudest-keep-values = [-3:5,-1:5]
 
-[coinc-fullinj&coinc-injfull]
-cluster-window = ${statmap|cluster-window}
-loudest-keep-values = 15.0:9999999999999
-
 [coinc-injinj]
 
 [sngls]

--- a/examples/search/plotting.ini
+++ b/examples/search/plotting.ini
@@ -139,14 +139,14 @@ log-dist =
 far-type = exclusive
 
 [plot_foundmissed-sub_mchirp_grad&plot_foundmissed-all_mchirp_grad&plot_foundmissed-summary]
-distance-type = max_optimal_snr
+distance-type = decisive_optimal_snr
 axis-type = mchirp
 log-x =
 log-distance =
 gradient-far =
 
 [plot_foundmissed-sub_mchirp_gradm&plot_foundmissed-all_mchirp_gradm&plot_foundmissed-summarym]
-distance-type = max_optimal_snr
+distance-type = decisive_optimal_snr
 axis-type = mchirp
 log-x =
 log-distance =

--- a/examples/search/plotting.ini
+++ b/examples/search/plotting.ini
@@ -139,14 +139,14 @@ log-dist =
 far-type = exclusive
 
 [plot_foundmissed-sub_mchirp_grad&plot_foundmissed-all_mchirp_grad&plot_foundmissed-summary]
-distance-type = decisive_optimal_snr
+distance-type = max_optimal_snr
 axis-type = mchirp
 log-x =
 log-distance =
 gradient-far =
 
 [plot_foundmissed-sub_mchirp_gradm&plot_foundmissed-all_mchirp_gradm&plot_foundmissed-summarym]
-distance-type = decisive_optimal_snr
+distance-type = max_optimal_snr
 axis-type = mchirp
 log-x =
 log-distance =


### PR DESCRIPTION
Injections do not have inclusive IFAR / FAP calculated, so we can ignore the datasets.

Why?: 
 - The injfull/fullinj coinc jobs uses a lot of computation and these are thrown away
 - the coinc_statmap_inj jobs are a bottleneck which can spend a lot of time on fullinj/injfull without any value

Proposed solution:
 - Don't run injfull/fullinj analyses (done through the workflow generator)
 - output empty arays from the statmap jobs for inclusive IFAR/FAP to indicate that this wasn't calculated on purpose

Note that I think we _may_ be able to consolidate the statmap / statmap_inj jobs in the near future because of this change, but this isn't done here.