### PR TITLE
Prevent duplicates of the HLV page_ifar plot on the summary page

### DIFF
--- a/bin/workflows/pycbc_make_offline_search_workflow
+++ b/bin/workflows/pycbc_make_offline_search_workflow
@@ -521,6 +521,9 @@ for key in final_bg_files:
         # as it is just blank
         ifar_cb = wf.make_ifar_plot(workflow, bg_file, closed_dir,
                                     tags=bg_file.tags + ['closed_box'])
+        closed_page = [(snrifar_cb, ifar_cb)]
+    else:
+        closed_page = [(snrifar_cb,)]
     table = wf.make_foreground_table(workflow, bg_file, hdfbank, open_dir,
                                      singles=insps, extension='.html',
                                      tags=bg_file.tags)
@@ -528,7 +531,6 @@ for key in final_bg_files:
     detailed_page = [(snrifar, ratehist), (snrifar_ifar, ifar_ob), (table,)]
     layout.two_column_layout(open_dir, detailed_page)
 
-    closed_page = [(snrifar_cb, ifar_cb)]
     snrifar_summ += closed_page
     layout.two_column_layout(closed_dir, closed_page)
 

--- a/bin/workflows/pycbc_make_offline_search_workflow
+++ b/bin/workflows/pycbc_make_offline_search_workflow
@@ -80,7 +80,7 @@ rdir = layout.SectionNumber('results', ['analysis_time',
                                  'detector_sensitivity',
                                  'data_quality',
                                  'single_triggers',
-                                 'coincident_triggers',
+                                 'background_triggers',
                                  'injections',
                                  'search_sensitivity',
                                  'open_box_result',
@@ -169,7 +169,7 @@ bank_tags = []
 if 'mass1_mass2' in workflow.cp.get_subsections('plot_bank'):
     bank_tags=['mass1_mass2']
 bank_plot = wf.make_template_plot(workflow, hdfbank,
-                                  rdir['coincident_triggers'],
+                                  rdir['background_triggers'],
                                   tags=bank_tags)
 
 ######################## Setup the FULL DATA run ##############################
@@ -480,11 +480,11 @@ layout.two_column_layout(rdir['open_box_result'], main_page)
 #layout.two_column_layout(rdir['open_box_result/significance'], detailed_page)
 
 closed_page = [(bank_plot,)]
-layout.two_column_layout(rdir['coincident_triggers'], closed_page)
+layout.two_column_layout(rdir['background_triggers'], closed_page)
 
 # run minifollowups on the output of the loudest events
 mfup_dir_fg = rdir['open_box_result/loudest_events_followup']
-mfup_dir_bg = rdir['coincident_triggers/loudest_background_followup']
+mfup_dir_bg = rdir['background_triggers/loudest_background_followup']
 wf.setup_foreground_minifollowups(workflow, combined_bg_file,
                                   full_insps, hdfbank, insp_files_seg_file,
                                   data_analysed_name, trig_generated_name,
@@ -502,8 +502,8 @@ wf.setup_foreground_minifollowups(workflow, combined_bg_file,
 snrifar_summ = []
 for key in final_bg_files:
     bg_file = final_bg_files[key]
-    open_dir = rdir['open_box_result/{}_coincidences'.format(key)]
-    closed_dir = rdir['coincident_triggers/{}_coincidences'.format(key)]
+    open_dir = rdir['open_box_result/{}_candidates'.format(key)]
+    closed_dir = rdir['background_triggers/{}_background'.format(key)]
     snrifar = wf.make_snrifar_plot(workflow, bg_file, open_dir,
                                    tags=bg_file.tags)
     snrifar_cb = wf.make_snrifar_plot(workflow, bg_file, closed_dir,


### PR DESCRIPTION
On the summary page, the snrifar / page_ifar plots are given for each detector combination, but the page_ifar plot for singles was never made.

So the workflow was grabbing the page_ifar plot from the last coincidence (HLV)