### PR TITLE
mistake in example search config file

### DIFF
--- a/.github/workflows/search-workflow.yml
+++ b/.github/workflows/search-workflow.yml
@@ -9,6 +9,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-20.04
+    timeout-minutes: 90
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python

--- a/examples/search/analysis.ini
+++ b/examples/search/analysis.ini
@@ -176,18 +176,15 @@ sngl-ranking = newsnr_sgveto_psdvar
 randomize-template-order =
 statistic-files = ${resolve:./statHL.hdf} ${resolve:./statLV.hdf} ${resolve:./statHV.hdf} ${resolve:./statHLV.hdf}
 
-[coinc-defaultvalues]
-coinc-threshold = 0.002
-timeslide-interval = 0.1
-
 [coinc-full_data]
+timeslide-interval = 0.1
+coinc-threshold = 0.002
 
 [coinc-full_data-2det]
 loudest-keep-values = [-1:5,1:5]
 
 [coinc-full_data-3det]
 loudest-keep-values = [-3:5,-1:5]
-timeslide-interval = 0.11
 
 [coinc-fullinj&coinc-injfull]
 cluster-window = ${statmap|cluster-window}


### PR DESCRIPTION
@spxiwh @GarethCabournDavies 

There was a mistake in the example search configuration introduced in https://github.com/gwastro/pycbc/pull/4385

This caused the search workflow to suddenly take > 3x longer. This happened because timeslide-interval was in 'defaultvalues' for 'coinc'. The 'injinj' jobs were running timeslides! This means they'll produce a huge number of triggers for later stages due to the very large number of coincidences between different injections. 

I think the comments in #4420 related to performance are mostly due to this configuration error, although if it's not used, it's not a terrible thing to clean  up anyway.