### PR TITLE
Change decisive to network optimal snr in foundmissed

### DIFF
--- a/examples/search/plotting.ini
+++ b/examples/search/plotting.ini
@@ -139,14 +139,14 @@ log-dist =
 far-type = exclusive
 
 [plot_foundmissed-sub_mchirp_grad&plot_foundmissed-all_mchirp_grad&plot_foundmissed-summary]
-distance-type = max_optimal_snr
+distance-type = comb_optimal_snr
 axis-type = mchirp
 log-x =
 log-distance =
 gradient-far =
 
 [plot_foundmissed-sub_mchirp_gradm&plot_foundmissed-all_mchirp_gradm&plot_foundmissed-summarym]
-distance-type = max_optimal_snr
+distance-type = comb_optimal_snr
 axis-type = mchirp
 log-x =
 log-distance =

--- a/examples/search/plotting.ini
+++ b/examples/search/plotting.ini
@@ -139,14 +139,14 @@ log-dist =
 far-type = exclusive
 
 [plot_foundmissed-sub_mchirp_grad&plot_foundmissed-all_mchirp_grad&plot_foundmissed-summary]
-distance-type = decisive_optimal_snr
+distance-type = max_optimal_snr
 axis-type = mchirp
 log-x =
 log-distance =
 gradient-far =
 
 [plot_foundmissed-sub_mchirp_gradm&plot_foundmissed-all_mchirp_gradm&plot_foundmissed-summarym]
-distance-type = decisive_optimal_snr
+distance-type = max_optimal_snr
 axis-type = mchirp
 log-x =
 log-distance =


### PR DESCRIPTION
For a search including single-detector events, the decisive SNR for whether a signal is detected is actually the maximum SNR

See e.g. [comment here](https://github.com/gwastro/pycbc/blob/4488619e969fd36142a9a4f9fe6bc93d15fbcb6b/bin/plotting/pycbc_page_foundmissed#L123)