### PR TITLE
Avoid ligo.skymap v1.1.0

### DIFF
--- a/companion.txt
+++ b/companion.txt
@@ -6,7 +6,7 @@ healpy
 
 # Needed for GraceDB uploads and skymap generation
 ligo-gracedb>=2.10.0
-ligo.skymap
+ligo.skymap!=1.1.0
 
 # auxiliary samplers
 epsie>=1.0


### PR DESCRIPTION
ligo.skymap v1.1.0 has a bug (https://github.com/lpsinger/ligo.skymap/pull/22) so it does not declare python versions correctly. This is fixed in v1.1.1 but python3.8 will pick up v1.1.0 unless it is explicitly avoided. It is possible that the pypi release can be fixed (by removing the source code from v1.1.0) to avoid this, but we'd want to avoid this release anyway, and there's a few PRs that want merging.