### PR TITLE
Add ability to overwrite file retention level for specific executables from config

### DIFF
--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -493,8 +493,7 @@ class Executable(pegasus_workflow.Executable):
                                  'all_triggers' : 2,
                                  'merged_triggers' : 3,
                                  'results' : 4
-                                 }
-
+                                }
             try:
                 self.global_retention_threshold = \
                       retention_choices[global_retention_level]

--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -56,6 +56,7 @@ _retention_choices = {
     'results' : 4
 }
 
+
 def make_analysis_dir(path):
     """
     Make the analysis directory path, any parent directories that don't already

--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -147,7 +147,12 @@ class Executable(pegasus_workflow.Executable):
         self.update_output_directory(out_dir=out_dir)
 
         # Determine the level at which output files should be kept
-        self.update_current_retention_level(self.current_retention_level)
+        if cp.has_option_tags('pegasus_profile-%s' % name,
+                              'pycbc|discard_output', tags):
+            # Flag to say not to keep file, whatever the retention level
+            self.update_current_retention_level(-1)
+        else:
+            self.update_current_retention_level(self.current_retention_level)
 
         # Should I reuse this executable?
         if reuse_executable:


### PR DESCRIPTION
Use case:
 - We are reusing a large bank / phase-time-amp files for many analyses

Problem:
 - We don't want to copy the file into every run directory as it is wasting disk space, and removing the "single source of truth" by having multiple copies of the same information

Solution:
 - Add an option in the `pegasus_profile` section for the executables to overwrite the retention level with the `pycbc|retention_level` flag, i.e.:

```
[pegasus_profile-bank2hdf]
pycbc|retention_level = do_not_keep
```
 - Add an extra retention level into the choices which is 0, and therefore less than the `global_retention_threshold`, so the file is not retained ([this comparison](https://github.com/gwastro/pycbc/blob/433dfd81287dfa47683487aadd8095e6ea7e9b16/pycbc/workflow/core.py#L508) is False)

Testing:
 - File is not retained in the standard offline workflow
 - File is not retained from a `--cache-file` during generation