### PR TITLE
bugfix - allow non-running of singles

### DIFF
--- a/pycbc/events/single.py
+++ b/pycbc/events/single.py
@@ -108,7 +108,10 @@ class LiveSingle(object):
                 parser.error("All IFOs required in --single-ifar-est-dist "
                              "if IFO-specific options are given.")
 
-            if not args.sngl_ifar_est_dist[ifo] == 'fixed':
+            if args.sngl_ifar_est_dist[ifo] is None:
+                #Default - no singles being used
+                continue
+            elif not args.sngl_ifar_est_dist[ifo] == 'fixed':
                 if not args.single_fit_file:
                     # Fixed IFAR option doesnt need the fits file
                     parser.error(f"Single detector trigger fits file must be "


### PR DESCRIPTION
Somehow missed that fixed-ifar could be None if it is not given

This should allow early warning MDC to work now @hoangstephanie @titodalcanton 