### PR TITLE
CVMFS files have moved - Treat them properly

### DIFF
--- a/pycbc/workflow/datafind.py
+++ b/pycbc/workflow/datafind.py
@@ -745,19 +745,15 @@ def convert_cachelist_to_filelist(datafindcache_list):
 
             # Populate the PFNs for the File() we just created
             if frame.url.startswith('file://'):
-                currFile.add_pfn(frame.url, site='local')
-                if frame.url.startswith(
-                    'file:///cvmfs/oasis.opensciencegrid.org/ligo/frames'):
-                    # Datafind returned a URL valid on the osg as well
-                    # so add the additional PFNs to allow OSG access.
-                    currFile.add_pfn(frame.url, site='osg')
-                elif frame.url.startswith(
-                    'file:///cvmfs/gwosc.osgstorage.org/'):
-                    # Datafind returned a URL valid on the osg as well
-                    # so add the additional PFNs to allow OSG access.
-                    for s in ['osg', 'orangegrid', 'osgconnect']:
-                        currFile.add_pfn(frame.url, site=s)
-                        currFile.add_pfn(frame.url, site="{}-scratch".format(s))
+                if frame.url.startswith('file:///cvmfs/'):
+                    # Frame is on CVMFS, so let all sites read it directly.
+                    currFile.add_pfn(frame.url, site='all')
+                else:
+                    # Frame not on CVMFS, so may need transferring.
+                    # Be careful here! If all your frames files are on site
+                    # = local and you try to run on OSG, it will likely
+                    # overwhelm the condor file transfer process!
+                    currFile.add_pfn(frame.url, site='local')
             else:
                 currFile.add_pfn(frame.url, site='notlocal')
 

--- a/pycbc/workflow/pegasus_sites.py
+++ b/pycbc/workflow/pegasus_sites.py
@@ -224,7 +224,7 @@ def add_osg_site(sitecat, cp):
     # On OSG failure rate is high
     site.add_profiles(Namespace.DAGMAN, key="retry", value="4")
     site.add_profiles(Namespace.ENV, key="LAL_DATA_PATH",
-                      value="/cvmfs/oasis.opensciencegrid.org/ligo/sw/pycbc/lalsuite-extra/current/share/lalsimulation")
+                      value="/cvmfs/software.igwn.org/pycbc/lalsuite-extra/current/share/lalsimulation")
     # Add MKL location to LD_LIBRARY_PATH for OSG
     site.add_profiles(Namespace.ENV, key="LD_LIBRARY_PATH",
                       value="/usr/local/lib:/.singularity.d/libs")


### PR DESCRIPTION
The LVK CVMFS server has moved from oasis to a LVK-hosted server. This means a few hooks need updating. I also want to be more generic, because basically if we get any URL starting CVMFS, we should treat it consistently. One CVMFS server is not different to others.

This was being handled correctly in `core.py` for files coming from the config files, but not for the special case of frame files. .... This resulted in me transmitting 2GB frame files to around 60000 jobs running on OSG, and bringing down an OSG submit machine (again!)

I've also updated the pointer to lalsuite-extra, although this may move again soon. The old link does symlink to the new, but this avoid the symlink.