### PR TITLE
Live single fits combined bug

### DIFF
--- a/bin/live/pycbc_live_combine_single_fits
+++ b/bin/live/pycbc_live_combine_single_fits
@@ -165,7 +165,7 @@ for ifo in args.ifos:
         r = c / l_times[ad_order]
         cons_rate = np.percentile(r, args.conservative_percentile)
         cons_counts_out[ifo][counter] = cons_rate * l_times[ad_order].sum()
-        counts_out[ifo][counter] = np.average(r) * l_times[ad_order].sum()
+        counts_out[ifo][counter] = np.mean(r) * l_times[ad_order].sum()
 
         fout_ifo[f'separate_fits/bin_{counter:d}/fit_coeff'] = a
         fout_ifo[f'separate_fits/bin_{counter:d}/counts'] = c

--- a/bin/live/pycbc_live_combine_single_fits
+++ b/bin/live/pycbc_live_combine_single_fits
@@ -161,8 +161,10 @@ for ifo in args.ifos:
         cons_alpha = np.percentile(a, 100 - args.conservative_percentile)
         cons_alphas_out[ifo][counter] = cons_alpha
         alphas_out[ifo][counter] = mean_alpha
-        cons_count = np.percentile(c, args.conservative_percentile)
-        cons_counts_out[ifo][counter] = cons_count * len(c)
+        # To get the count values, we need to convert to rates and back again
+        r = c / l_times[ad_order]
+        cons_rate = np.percentile(r, args.conservative_percentile)
+        cons_counts_out[ifo][counter] = cons_rate * l_times[ad_order].sum()
         counts_out[ifo][counter] = c.sum()
 
         fout_ifo[f'separate_fits/bin_{counter:d}/fit_coeff'] = a

--- a/bin/live/pycbc_live_combine_single_fits
+++ b/bin/live/pycbc_live_combine_single_fits
@@ -165,7 +165,7 @@ for ifo in args.ifos:
         r = c / l_times[ad_order]
         cons_rate = np.percentile(r, args.conservative_percentile)
         cons_counts_out[ifo][counter] = cons_rate * l_times[ad_order].sum()
-        counts_out[ifo][counter] = c.sum()
+        counts_out[ifo][counter] = np.average(r) * l_times[ad_order].sum()
 
         fout_ifo[f'separate_fits/bin_{counter:d}/fit_coeff'] = a
         fout_ifo[f'separate_fits/bin_{counter:d}/counts'] = c

--- a/bin/live/pycbc_live_plot_combined_single_fits
+++ b/bin/live/pycbc_live_plot_combined_single_fits
@@ -189,7 +189,7 @@ for ifo in ifos:
     count_labels = [l.get_label() for l in count_lines]
     ax_count.legend(count_lines, count_labels, loc='lower center',
                     ncol=5, bbox_to_anchor=(0.5, 1.01))
-    ax_count.set_ylabel('Rate of triggers above fit threshold, $s^{-1}$')
+    ax_count.set_ylabel('Rate of triggers above fit threshold [s$^{-1}$]')
 
     for ax in [ax_count, ax_alpha]:
         ax.set_xticks(xtix)

--- a/bin/live/pycbc_live_plot_combined_single_fits
+++ b/bin/live/pycbc_live_plot_combined_single_fits
@@ -189,7 +189,7 @@ for ifo in ifos:
     count_labels = [l.get_label() for l in count_lines]
     ax_count.legend(count_lines, count_labels, loc='lower center',
                     ncol=5, bbox_to_anchor=(0.5, 1.01))
-    ax_count.set_ylabel('Counts per live time')
+    ax_count.set_ylabel('Rate of triggers above fit threshold, $s^{-1}$')
 
     for ax in [ax_count, ax_alpha]:
         ax.set_xticks(xtix)


### PR DESCRIPTION
Rates plot was showing percentile values above the largest rate, which makes no sense

https://ldas-jobs.ligo.caltech.edu/~gareth.cabourndavies/pycbclive/combine_average_weighting/testing/H1-2023_07_14-2023_08_02-TRIGGER_FITS_COMBINED-counts-original.png

This fix changes to use the percentile of the _rate_ rather than counts, so that we get the correct value out

https://ldas-jobs.ligo.caltech.edu/~gareth.cabourndavies/pycbclive/combine_average_weighting/testing/H1-2023_07_14-2023_08_02-TRIGGER_FITS_COMBINED-counts.png

Change made to mean as well as conservative