### PR TITLE
Add hidden pegasus dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ gwdatafind>=1.1.3
 
 # Requirements for full pegasus env
 pegasus-wms.api >= 5.0.3
-pyyaml
+# Need GitPython: See discussion in https://github.com/gwastro/pycbc/pull/4454
 GitPython
 # need to pin until pegasus for further upstream
 # addresses incompatibility between old flask/jinja2 and latest markupsafe

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,8 @@ gwdatafind>=1.1.3
 
 # Requirements for full pegasus env
 pegasus-wms.api >= 5.0.3
+pyyaml
+GitPython
 # need to pin until pegasus for further upstream
 # addresses incompatibility between old flask/jinja2 and latest markupsafe
 markupsafe <= 2.0.1


### PR DESCRIPTION
When running `pegasus-plan` this script:

https://github.com/pegasus-isi/pegasus/blob/6b7e41d7ebfacca23d853890937e593a248e6a6a/packages/pegasus-python/src/Pegasus/cli/pegasus-preflight-check.py

will be run, and `pegasus-plan` will fail if any of its checks fail. Most commonly, we see cases where this fails because GitPython is missing.

Now, this is weird, because `pegasus-plan` lives in `/usr/bin` and `GitPython` is installed in the /usr/lib64/.../python3.6 PYTHONPATH. However, for reasons I don't understand pegasus uses the intermediate script https://github.com/pegasus-isi/pegasus/blob/master/bin/pegasus-python-wrapper before calling python codes. This will select your current environment version of pegasus, not /usr/bin/python, as one might expect.

Then if your environment doesn't have dependencies not included in `pegasus.api` we will get failures.

So as a simple example, on CIT. If one logs in without picking up any CVMFS envs, doing:

`pegasus-plan --help`

will work fine. However if we source a different enviroment, e.g.:

`source /cvmfs/software.igwn.org/pycbc/x86_64_rhel_8/virtualenv/pycbc-v2.2.1/bin/activate`

and then run:

`pegasus-plan --help`

it now fails. (Both cases use `/usr/bin/pegasus-plan`.)

This feels a bit like a bug in pegasus, but I do need this fixed quickly, and so propose this patch to put the dependencies into the environment.

.... Interestingly, only `pegasus-plan` will actually fail (as opposed to warn) if the dependencies don't exist, even though it runs a Java program, and not python at all. Other codes (e.g. `pegasus-run`) will at least generate a help message, but may fail if GitPython is needed at some stage and isn't in the local env.

