### PR TITLE
Run conversion on all hdf injection files, allowing LVK injection format hdf files to be used

### DIFF
--- a/bin/pycbc_convertinjfiletohdf
+++ b/bin/pycbc_convertinjfiletohdf
@@ -174,7 +174,7 @@ if args.injection_file.endswith(('.xml', '.xml.gz', '.xmlgz')):
 else:
     # Assume a HDF file - check if new LVK format first
     inj_file = h5py.File(args.injection_file, 'r')
-    if 'file_format' in inj_file.attrs:
+    if 'file_format' in inj_file.attrs or b'file_format' in inj_file.attrs:
         # Assume LVK as PyCBC doesn't have this attribute
         injclass = LVKNewStyleInjectionSet(args.injection_file)
     inj_file.close()

--- a/pycbc/workflow/injection.py
+++ b/pycbc/workflow/injection.py
@@ -147,8 +147,9 @@ def cut_distant_injections(workflow, inj_file, out_dir, tags=None):
     return node.output_files[0]
 
 def inj_to_hdf(workflow, inj_file, out_dir, tags=None):
-    """ Convert injection file to hdf format, if it is already one,
-    this just makes a copy
+    """ Convert injection file to hdf format.
+
+    If the file is already PyCBC HDF format, this will just make a copy.
     """
     if tags is None:
         tags = []

--- a/pycbc/workflow/injection.py
+++ b/pycbc/workflow/injection.py
@@ -147,12 +147,9 @@ def cut_distant_injections(workflow, inj_file, out_dir, tags=None):
     return node.output_files[0]
 
 def inj_to_hdf(workflow, inj_file, out_dir, tags=None):
-    """ Convert injection file to hdf format if not already one
+    """ Convert injection file to hdf format, if it is already one,
+    this just makes a copy
     """
-    _, ext = os.path.splitext(inj_file.name)
-    if ext == '.hdf':
-        return inj_file
-
     if tags is None:
         tags = []
 


### PR DESCRIPTION
I don't know if the file specification changed, or if someone changed from py2 to py3 without thinking, but this attribute is bytes in some of the examples we have been given