### PR TITLE
pass splitbank tags to inspiral jobs

### DIFF
--- a/pycbc/workflow/jobsetup.py
+++ b/pycbc/workflow/jobsetup.py
@@ -251,6 +251,9 @@ def sngl_ifo_job_setup(workflow, ifo, out_files, curr_exe_job, science_segs,
             for pnum, parent in enumerate(sorted_parents):
                 if len(curr_parent) != 1:
                     tag = ["JOB%d" %(pnum,)]
+                    bank_tag = [t for t in parent.tags if 'bank' in t]
+                    # add splitbank tags into the current executable
+                    curr_exe_job.update_current_tags(bank_tag)
                 else:
                     tag = []
                 # To ensure output file uniqueness I add a tag

--- a/pycbc/workflow/jobsetup.py
+++ b/pycbc/workflow/jobsetup.py
@@ -250,7 +250,6 @@ def sngl_ifo_job_setup(workflow, ifo, out_files, curr_exe_job, science_segs,
                 if len(curr_parent) != 1:
                     bank_tag = [t for t in parent.tags if 'bank' in t.lower()]
                     curr_exe_job.update_current_tags(bank_tag + exe_tags)
-                # To ensure output file uniqueness I add a tag
                 # We should generate unique names automatically, but it is a
                 # pain until we can set the output names for all Executables
                 node = curr_exe_job.create_node(job_data_seg, job_valid_seg,

--- a/pycbc/workflow/jobsetup.py
+++ b/pycbc/workflow/jobsetup.py
@@ -194,6 +194,7 @@ def sngl_ifo_job_setup(workflow, ifo, out_files, curr_exe_job, science_segs,
     # Get the times that can be analysed and needed data lengths
     data_length, valid_chunk, valid_length = identify_needed_data(curr_exe_job)
 
+    exe_tags = curr_exe_job.tags
     # Loop over science segments and set up jobs
     for curr_seg in science_segs:
         ########### (2) ############
@@ -246,23 +247,16 @@ def sngl_ifo_job_setup(workflow, ifo, out_files, curr_exe_job, science_segs,
             # where I run a number of jobs to cover a single range of time.
 
             # Sort parent jobs to ensure predictable order
-            sorted_parents = sorted(curr_parent,
-                                    key=lambda fobj: fobj.tagged_description)
-            for pnum, parent in enumerate(sorted_parents):
+            for parent in curr_parent:
                 if len(curr_parent) != 1:
-                    tag = ["JOB%d" %(pnum,)]
-                    bank_tag = [t for t in parent.tags if 'bank' in t]
-                    # add splitbank tags into the current executable
-                    curr_exe_job.update_current_tags(bank_tag)
-                else:
-                    tag = []
+                    bank_tag = [t for t in parent.tags if 'bank' in t.lower()]
+                    curr_exe_job.update_current_tags(bank_tag + exe_tags)
                 # To ensure output file uniqueness I add a tag
                 # We should generate unique names automatically, but it is a
                 # pain until we can set the output names for all Executables
                 node = curr_exe_job.create_node(job_data_seg, job_valid_seg,
                                                 parent=parent,
-                                                df_parents=curr_dfouts,
-                                                tags=tag)
+                                                df_parents=curr_dfouts)
                 workflow.add_node(node)
                 curr_out_files = node.output_files
                 # FIXME: Here we remove PSD files if they are coming through.

--- a/pycbc/workflow/jobsetup.py
+++ b/pycbc/workflow/jobsetup.py
@@ -246,7 +246,6 @@ def sngl_ifo_job_setup(workflow, ifo, out_files, curr_exe_job, science_segs,
             # make a single job. This catches the case of a split template bank
             # where I run a number of jobs to cover a single range of time.
 
-            # Sort parent jobs to ensure predictable order
             for parent in curr_parent:
                 if len(curr_parent) != 1:
                     bank_tag = [t for t in parent.tags if 'bank' in t.lower()]


### PR DESCRIPTION
So that we can vary inspiral settings over different parts of the bank, we would like to use splitbank tags in the inspiral jobs and do this via config, in the config files, this would look something like:

```
[inspiral-bank0]
cluster-window = 0.5

[inspiral-bank1]
cluster-window = 1
```