### PR TITLE
Idq workflow times

### DIFF
--- a/pycbc/workflow/dq.py
+++ b/pycbc/workflow/dq.py
@@ -38,8 +38,7 @@ class PyCBCCalculateDQExecutable(Executable):
         node.add_input_list_opt('--frame-files', frames)
         node.add_opt('--gps-start-time', start)
         node.add_opt('--gps-end-time', end)
-        fil = node.new_output_file_opt(segment, '.hdf', '--output-file')
-        fil.add_metadata('data_seg', segment)
+        node.new_output_file_opt(segment, '.hdf', '--output-file')
         return node
 
 class PyCBCRerankDQExecutable(Executable):
@@ -80,9 +79,8 @@ class PyCBCCalculateDQFlagExecutable(Executable):
         node.add_opt('--gps-start-time', start)
         node.add_opt('--gps-end-time', end)
         node.add_input_opt('--dq-segments', dq_file)
-        fil = node.new_output_file_opt(workflow.analysis_time, '.hdf',
+        node.new_output_file_opt(segment, '.hdf',
                                  '--output-file')
-        fil.add_metadata('data_seg', segment)
         return node
 
 def setup_dq_reranking(workflow, dq_label, insps, bank,

--- a/pycbc/workflow/dq.py
+++ b/pycbc/workflow/dq.py
@@ -38,7 +38,8 @@ class PyCBCCalculateDQExecutable(Executable):
         node.add_input_list_opt('--frame-files', frames)
         node.add_opt('--gps-start-time', start)
         node.add_opt('--gps-end-time', end)
-        node.new_output_file_opt(segment, '.hdf', '--output-file')
+        fil = node.new_output_file_opt(segment, '.hdf', '--output-file')
+        fil.add_metadata('data_seg', segment)
         return node
 
 class PyCBCRerankDQExecutable(Executable):
@@ -79,8 +80,9 @@ class PyCBCCalculateDQFlagExecutable(Executable):
         node.add_opt('--gps-start-time', start)
         node.add_opt('--gps-end-time', end)
         node.add_input_opt('--dq-segments', dq_file)
-        node.new_output_file_opt(workflow.analysis_time, '.hdf',
+        fil = node.new_output_file_opt(workflow.analysis_time, '.hdf',
                                  '--output-file')
+        fil.add_metadata('data_seg', segment)
         return node
 
 def setup_dq_reranking(workflow, dq_label, insps, bank,


### PR DESCRIPTION
The PyCBCCalculateDQFlagExecutable output file was initialised with the workflow analysis times.

This meant that the outputs from each segment were all named the same as each other, so the run would not start.

This seems to fix things, but will wait for @maxtrevor to confirm that his run is working