### PR TITLE
default bug in cluster-window in pycbc_inspiral

### DIFF
--- a/bin/pycbc_inspiral
+++ b/bin/pycbc_inspiral
@@ -91,7 +91,7 @@ parser.add_argument("--cluster-function", choices=["findchirp", "symmetric"],
                     "'findchirp' uses a forward sliding window; 'symmetric' "
                     "will compare each window to the one before and after, keeping "
                     "only a local maximum.", default="findchirp")
-parser.add_argument("--cluster-window", type=float, default = -1,
+parser.add_argument("--cluster-window", type=float, default = 0,
                     help="Length of clustering window in seconds."
                     " Set to 0 to disable clustering.")
 parser.add_argument("--bank-veto-bank-file", type=str, help="FIXME: ADD")

--- a/bin/pycbc_inspiral
+++ b/bin/pycbc_inspiral
@@ -91,7 +91,7 @@ parser.add_argument("--cluster-function", choices=["findchirp", "symmetric"],
                     "'findchirp' uses a forward sliding window; 'symmetric' "
                     "will compare each window to the one before and after, keeping "
                     "only a local maximum.", default="findchirp")
-parser.add_argument("--cluster-window", type=float, default = 0,
+parser.add_argument("--cluster-window", type=float, default=0,
                     help="Length of clustering window in seconds."
                     " Set to 0 to disable clustering.")
 parser.add_argument("--bank-veto-bank-file", type=str, help="FIXME: ADD")


### PR DESCRIPTION
pycbc_inspiral's --cluster-window option has a default of -1, but expects 0 to indicate no clustering in [this line](https://github.com/gwastro/pycbc/blob/1e360a077992d851c579d7fee3600ebe05dc07fe/bin/pycbc_inspiral#L397)

Updating to use 0 as default to fix this

Found by accident when I introduced a different bug in testing :wink: