### PR TITLE
Add KDE/DQ statistic

### DIFF
--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -2093,12 +2093,6 @@ class DQExpFitFgBgKDEStatistic(DQExpFitFgBgNormStatistic):
         """
         DQExpFitFgBgNormStatistic.__init__(self, sngl_ranking, files=files,
                                            ifos=ifos, **kwargs)
-        self.find_kdes()
-
-    def find_kdes(self):
-        """
-        Inherited, see docstring for ExpFitFgBgKDEStatistic.find_kdes
-        """
         ExpFitFgBgKDEStatistic.find_kdes(self)
 
     def assign_kdes(self, kname):

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -1829,8 +1829,6 @@ class ExpFitFgBgKDEStatistic(ExpFitFgBgNormStatistic):
         """
         ExpFitFgBgNormStatistic.__init__(self, sngl_ranking, files=files,
                                          ifos=ifos, **kwargs)
-        # Initialize variable to hold event template id(s)
-        self.curr_tnum = None
         self.find_kdes()
         # Initialize variable to hold event template id(s)
         self.curr_tnum = None

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -1829,6 +1829,8 @@ class ExpFitFgBgKDEStatistic(ExpFitFgBgNormStatistic):
         """
         ExpFitFgBgNormStatistic.__init__(self, sngl_ranking, files=files,
                                          ifos=ifos, **kwargs)
+        # Initialize variable to hold event template id(s)
+        self.curr_tnum = None
         self.find_kdes()
         # Initialize variable to hold event template id(s)
         self.curr_tnum = None
@@ -2100,8 +2102,17 @@ class DQExpFitFgBgKDEStatistic(DQExpFitFgBgNormStatistic):
 
     def __init__(self, sngl_ranking, files=None, ifos=None, **kwargs):
         """
-        Inherited from DQExpFitFgBgNormStatistic, see docstring there
-        but with find_kdes fucntion from ExpFitFgBgKDEStatistic added
+        Parameters
+        ----------
+        sngl_ranking: str
+            The name of the ranking to use for the single-detector triggers.
+        files: list of strs, needed here
+            A list containing the filenames of hdf format files used to help
+            construct the coincident statistics. The files must have a 'stat'
+            attribute which is used to associate them with the appropriate
+            statistic class.
+        ifos: list of strs, not used here
+            The list of detector names
         """
         DQExpFitFgBgNormStatistic.__init__(self, sngl_ranking, files=files,
                                            ifos=ifos, **kwargs)

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -2111,7 +2111,6 @@ class DQExpFitFgBgKDEStatistic(DQExpFitFgBgNormStatistic):
         """
         Inherited, see docstring for ExpFitFgBgKDEStatistic.logsignalrate
         """
-        # Inherit the function from the KDE statistic, with no changes
         return ExpFitFgBgKDEStatistic.logsignalrate(self, stats, shift,
                                                     to_shift)
 

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -1830,6 +1830,8 @@ class ExpFitFgBgKDEStatistic(ExpFitFgBgNormStatistic):
         ExpFitFgBgNormStatistic.__init__(self, sngl_ranking, files=files,
                                          ifos=ifos, **kwargs)
         self.find_kdes()
+        # Initialize variable to hold event template id(s)
+        self.curr_tnum = None
 
     def find_kdes(self):
         """
@@ -1847,10 +1849,6 @@ class ExpFitFgBgKDEStatistic(ExpFitFgBgNormStatistic):
         self.kde_by_tid = {}
         for kname in self.kde_names:
             self.assign_kdes(kname)
-        # This will hold the template ids of the events for the statistic
-        # calculation
-        self.curr_tnum = None
-
 
     def assign_kdes(self, kname):
         """

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -1486,9 +1486,11 @@ class ExpFitFgBgNormStatistic(PhaseTDStatistic,
         singles['sigmasq'] = trigs['sigmasq'][:]
         singles['snr'] = trigs['snr'][:]
         try:
-            self.curr_tnum = trigs.template_num  # exists if accessed via coinc_findtrigs
+            # exists if accessed via coinc_findtrigs
+            self.curr_tnum = trigs.template_num
         except AttributeError:
-            self.curr_tnum = trigs['template_id']  # exists for SingleDetTriggers
+            # exists for SingleDetTriggers
+            self.curr_tnum = trigs['template_id']
             # Should only be one ifo fit file provided
             assert len(self.ifos) == 1
         # Store benchmark log volume as single-ifo information since the coinc
@@ -2091,8 +2093,19 @@ class DQExpFitFgBgKDEStatistic(DQExpFitFgBgNormStatistic):
         """
         DQExpFitFgBgNormStatistic.__init__(self, sngl_ranking, files=files,
                                            ifos=ifos, **kwargs)
+        self.find_kdes()
 
+    def find_kdes(self):
+        """
+        Inherited, see docstring for ExpFitFgBgKDEStatistic.find_kdes
+        """
         ExpFitFgBgKDEStatistic.find_kdes(self)
+
+    def assign_kdes(self, kname):
+        """
+        Inherited, see docstring for ExpFitFgBgKDEStatistic.assign_kdes
+        """
+        ExpFitFgBgKDEStatistic.assign_kdes(self, kname)
 
     def logsignalrate(self, stats, shift, to_shift):
         """

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -1833,6 +1833,7 @@ class ExpFitFgBgKDEStatistic(ExpFitFgBgNormStatistic):
         """
         ExpFitFgBgNormStatistic.__init__(self, sngl_ranking, files=files,
                                          ifos=ifos, **kwargs)
+        self.kde_names = []
         self.find_kdes()
         self.kde_by_tid = {}
         for kname in self.kde_names:
@@ -2092,6 +2093,7 @@ class DQExpFitFgBgKDEStatistic(DQExpFitFgBgNormStatistic):
         """
         DQExpFitFgBgNormStatistic.__init__(self, sngl_ranking, files=files,
                                            ifos=ifos, **kwargs)
+        self.kde_names = []
         ExpFitFgBgKDEStatistic.find_kdes(self)
         self.kde_by_tid = {}
         for kname in self.kde_names:

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -2102,17 +2102,8 @@ class DQExpFitFgBgKDEStatistic(DQExpFitFgBgNormStatistic):
 
     def __init__(self, sngl_ranking, files=None, ifos=None, **kwargs):
         """
-        Parameters
-        ----------
-        sngl_ranking: str
-            The name of the ranking to use for the single-detector triggers.
-        files: list of strs, needed here
-            A list containing the filenames of hdf format files used to help
-            construct the coincident statistics. The files must have a 'stat'
-            attribute which is used to associate them with the appropriate
-            statistic class.
-        ifos: list of strs, not used here
-            The list of detector names
+        Inherited from DQExpFitFgBgNormStatistic, see docstring there
+        but with find_kdes fucntion from ExpFitFgBgKDEStatistic added
         """
         DQExpFitFgBgNormStatistic.__init__(self, sngl_ranking, files=files,
                                            ifos=ifos, **kwargs)
@@ -2121,27 +2112,19 @@ class DQExpFitFgBgKDEStatistic(DQExpFitFgBgNormStatistic):
 
     def logsignalrate(self, stats, shift, to_shift):
         """
-        Calculate the normalized log rate density of signals via lookup.
-
-        This calls back to the KDE class
-
-        Parameters
-        ----------
-        stats: list of dicts giving single-ifo quantities, ordered as
-            self.ifos
-        shift: numpy array of float, size of the time shift vector for each
-            coinc to be ranked
-        to_shift: list of int, multiple of the time shift to apply ordered
-            as self.ifos
-
-        Returns
-        -------
-        value: log of coinc signal rate density for the given single-ifo
-            triggers and time shifts
+        Inherited, see docstring for ExpFitFgBgKDEStatistic.logsignalrate
         """
         # Inherit the function from the KDE statistic, with no changes
         return ExpFitFgBgKDEStatistic.logsignalrate(self, stats, shift,
                                                     to_shift)
+
+    def coinc_lim_for_thresh(self, s, thresh, limifo, **kwargs):
+        """
+        Inherited, see docstring for
+        ExpFitFgBgKDEStatistic.coinc_lim_for_thresh
+        """
+        return ExpFitFgBgKDEStatistic.coinc_lim_for_thresh(
+            self, s, thresh, limifo, **kwargs)
 
 
 statistic_dict = {

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -1834,6 +1834,9 @@ class ExpFitFgBgKDEStatistic(ExpFitFgBgNormStatistic):
         ExpFitFgBgNormStatistic.__init__(self, sngl_ranking, files=files,
                                          ifos=ifos, **kwargs)
         self.find_kdes()
+        self.kde_by_tid = {}
+        for kname in self.kde_names:
+            self.assign_kdes(kname)
 
     def find_kdes(self):
         """
@@ -1847,10 +1850,6 @@ class ExpFitFgBgKDEStatistic(ExpFitFgBgNormStatistic):
         assert sorted(self.kde_names) == ['signal', 'template'], \
             "Two stat files are required, they should have stat attr " \
             "'signal-kde_file' and 'template-kde_file' respectively"
-
-        self.kde_by_tid = {}
-        for kname in self.kde_names:
-            self.assign_kdes(kname)
 
     def assign_kdes(self, kname):
         """
@@ -2094,12 +2093,9 @@ class DQExpFitFgBgKDEStatistic(DQExpFitFgBgNormStatistic):
         DQExpFitFgBgNormStatistic.__init__(self, sngl_ranking, files=files,
                                            ifos=ifos, **kwargs)
         ExpFitFgBgKDEStatistic.find_kdes(self)
-
-    def assign_kdes(self, kname):
-        """
-        Inherited, see docstring for ExpFitFgBgKDEStatistic.assign_kdes
-        """
-        ExpFitFgBgKDEStatistic.assign_kdes(self, kname)
+        self.kde_by_tid = {}
+        for kname in self.kde_names:
+            ExpFitFgBgKDEStatistic.assign_kdes(self, kname)
 
     def logsignalrate(self, stats, shift, to_shift):
         """

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -2087,9 +2087,8 @@ class DQExpFitFgBgKDEStatistic(DQExpFitFgBgNormStatistic):
     """
     The ExpFitFgBgKDEStatistic with DQ-based reranking.
 
-    This is the same as the ExpFitFgBgKDEStatistic except the likelihood
-    ratio is corrected via estimating relative noise trigger rates based on
-    the DQ time series.
+    This is the same as the DQExpFitFgBgNormStatistic except the signal
+    rate is adjusted according to the KDE statistic files
     """
 
     def __init__(self, sngl_ranking, files=None, ifos=None, **kwargs):
@@ -2136,27 +2135,30 @@ class DQExpFitFgBgKDEStatistic(DQExpFitFgBgNormStatistic):
         ExpFitFgBgKDEStatistic.assign_kdes(self, kname)
 
 
-    def lognoiserate(self, trigs):
+    def logsignalrate(self, stats, shift, to_shift):
         """
-        Calculate the log noise rate density over single-ifo ranking
+        Calculate the normalized log rate density of signals via lookup.
 
-        Read in single trigger information, compute the ranking
-        and rescale by the fitted coefficients alpha and rate
+        This calls back to the parent class and then applies the ratio_kde
+        weighting factor.
 
         Parameters
-        -----------
-        trigs: dict of numpy.ndarrays, h5py group or similar dict-like object
-            Object holding single detector trigger information.
+        ----------
+        stats: list of dicts giving single-ifo quantities, ordered as
+            self.ifos
+        shift: numpy array of float, size of the time shift vector for each
+            coinc to be ranked
+        to_shift: list of int, multiple of the time shift to apply ordered
+            as self.ifos
 
         Returns
-        ---------
-        lognoisel: numpy.array
-            Array of log noise rate density for each input trigger.
+        -------
+        value: log of coinc signal rate density for the given single-ifo
+            triggers and time shifts
         """
-        logr_n = ExpFitFgBgKDEStatistic.lognoiserate(
-                    self, trigs)
-        logr_n += self.find_dq_val(trigs)
-        return logr_n
+        # Inherit the function from the KDE statistic, with no changes
+        return ExpFitFgBgKDEStatistic.logsignalrate(self, stats, shift,
+                                                    to_shift)
 
 
 statistic_dict = {


### PR DESCRIPTION
Add in a statistic which uses both KDE and DQ reweighting

Checking with @tdent and @PRAVEEN-mnl that the KDE bit has been taken in properly, and with @maxtrevor that the DQ stuff has been brought in okay.

The summary is as follows:
 - copy `__init__` from the DQ statistic, but add in the stuff needed for kde - `assign_kdes` basically, but needs to pass this through to the other class.
 - inherit `logsignalrate` from the KDE statistic - Please confirm there is no DQ reweighting here
 - inherit `lognoiserate` from the DQ statistic - Please confirm there is no KDE reweighting here