### PR TITLE
Store and allow access to environment in ConfigParser

### DIFF
--- a/docs/workflow/initialization.rst
+++ b/docs/workflow/initialization.rst
@@ -262,6 +262,15 @@ If a particular code (let's say inspiral) wants to use an option supplied in the
   [inspiral-v1]
   channel-name = ${workflow|v1-channel}
 
+We also have access to anything specified in the environment when the workflow
+is generated. Environment variables can be accessed in the configuration file
+like::
+
+  [inspiral-h1]
+  channel-name = ${OS_ENV_VAL_H1_CHANNEL_NAME}
+ 
+which would take the value from `${H1_CHANNEL_NAME}` in the environment.
+
 Similar macros can be added as needed, but these should be limited to avoid namespace confusion. 
 
 ------------------------------------

--- a/docs/workflow/initialization.rst
+++ b/docs/workflow/initialization.rst
@@ -262,18 +262,6 @@ If a particular code (let's say inspiral) wants to use an option supplied in the
   [inspiral-v1]
   channel-name = ${workflow|v1-channel}
 
-We also have access to anything specified in the environment when the workflow
-is generated. Environment variables can be accessed in the configuration file
-like::
-
-  [inspiral-h1]
-  channel-name = ${os_env_vals|H1_CHANNEL_NAME}
- 
-which would take the value from `${H1_CHANNEL_NAME}` in the environment. These
-variables will also be written out in the config file produced when generating
-a workflow, so that you can see what environment was set when the workflow was
-generated.
-
 Similar macros can be added as needed, but these should be limited to avoid namespace confusion. 
 
 ------------------------------------
@@ -281,6 +269,26 @@ Example complete workflow .ini file
 ------------------------------------
 
 Please see individual workflow documentation pages for some examples of complete .ini files and example workflows.
+
+===========================
+Other special sections
+===========================
+
+------------------------------
+[environment] section
+------------------------------
+
+We have access to environment variables present when generating the workflow (with the exception of any variable containing a `$` or a `%` as these are special characters). These are automatically accessed and stored in the `[environment]` section of the config file when creating a PyCBC ConfigParser object.
+
+Values in this section can be accessed in the configuration file like this::
+
+  [inspiral-h1]
+  channel-name = ${environment|H1_CHANNEL_NAME}
+
+which would take the value from `${H1_CHANNEL_NAME}` in the environment.
+
+These values will also be written out for later reference in the config file produced when generating a workflow.
+
 
 ========================
 [sharedoptions] section

--- a/docs/workflow/initialization.rst
+++ b/docs/workflow/initialization.rst
@@ -267,9 +267,12 @@ is generated. Environment variables can be accessed in the configuration file
 like::
 
   [inspiral-h1]
-  channel-name = ${OS_ENV_VAL_H1_CHANNEL_NAME}
+  channel-name = ${os_env_vals:H1_CHANNEL_NAME}
  
-which would take the value from `${H1_CHANNEL_NAME}` in the environment.
+which would take the value from `${H1_CHANNEL_NAME}` in the environment. These
+variables will also be written out in the config file produced when generating
+a workflow, so that you can see what environment was set when the workflow was
+generated.
 
 Similar macros can be added as needed, but these should be limited to avoid namespace confusion. 
 

--- a/docs/workflow/initialization.rst
+++ b/docs/workflow/initialization.rst
@@ -267,7 +267,7 @@ is generated. Environment variables can be accessed in the configuration file
 like::
 
   [inspiral-h1]
-  channel-name = ${os_env_vals:H1_CHANNEL_NAME}
+  channel-name = ${os_env_vals|H1_CHANNEL_NAME}
  
 which would take the value from `${H1_CHANNEL_NAME}` in the environment. These
 variables will also be written out in the config file produced when generating

--- a/pycbc/types/config.py
+++ b/pycbc/types/config.py
@@ -26,6 +26,7 @@ This module provides a wrapper to the ConfigParser utilities for pycbc.
 This module is described in the page here:
 """
 import re
+import os
 import itertools
 import logging
 from io import StringIO
@@ -95,7 +96,7 @@ class InterpolatingConfigParser(DeepCopyableConfigParser):
             overrideTuples = []
         if deleteTuples is None:
             deleteTuples = []
-        DeepCopyableConfigParser.__init__(self)
+        super().__init__(defaults=os.environ)
 
         # Enable case sensitive options
         self.optionxform = str

--- a/pycbc/types/config.py
+++ b/pycbc/types/config.py
@@ -105,15 +105,11 @@ class InterpolatingConfigParser(DeepCopyableConfigParser):
         # Add in environment
         # We allow access to environment variables by adding them into the
         # os_env_vals section of the config file.
-        # PLEASE NOTE: ConfigParser *keys* are case insensitive, whereas ENV
-        # variables are case sensitive. So if your ENV sets both $TMPDIR and
-        # $tmpdir *one* of those (randomly) will be used here, so make sure
-        # they are consistent if using something like this!
-        # We also cannot include environment variables containing characters
+        # We cannot include environment variables containing characters
         # that are special to ConfigParser. So any variable containing a % or a
         # $ is ignored.
         env_vals = {
-            key.upper(): value for key, value in os.environ.items()
+            key: value for key, value in os.environ.items()
             if '%' not in value and '$' not in value
         }
         self.read_dict({'os_env_vals': env_vals})

--- a/pycbc/types/config.py
+++ b/pycbc/types/config.py
@@ -96,25 +96,27 @@ class InterpolatingConfigParser(DeepCopyableConfigParser):
             overrideTuples = []
         if deleteTuples is None:
             deleteTuples = []
+
+        super().__init__()
+
+        # Enable case sensitive options
+        self.optionxform = str
+
+        # Add in environment
         # We allow access to environment variables by adding them into the
-        # defaults section of the config file, prepended by a OS_ENV_VAL string
-        # to avoid collision with potential section values.
-        # Based off of https://stackoverflow.com/questions/26586801
-        # PLEASE NOTE: ConfigParse values are case insensitive, whereas ENV
-        # values are case sensitive. So if your ENV sets both $TMPDIR and
+        # os_env_vals section of the config file.
+        # PLEASE NOTE: ConfigParser *keys* are case insensitive, whereas ENV
+        # variables are case sensitive. So if your ENV sets both $TMPDIR and
         # $tmpdir *one* of those (randomly) will be used here, so make sure
         # they are consistent if using something like this!
         # We also cannot include environment variables containing characters
         # that are special to ConfigParser. So any variable containing a % or a
         # $ is ignored.
         env_vals = {
-            ('OS_ENV_VAL_' + k.upper()): v for k, v in os.environ.items()
-            if '%' not in v and '$' not in v
+            key.upper(): value for key, value in os.environ.items()
+            if '%' not in value and '$' not in value
         }
-        super().__init__(defaults=env_vals)
-
-        # Enable case sensitive options
-        self.optionxform = str
+        self.read_dict({'os_env_vals': env_vals))
 
         self.read_ini_file(configFiles)
 

--- a/pycbc/types/config.py
+++ b/pycbc/types/config.py
@@ -103,8 +103,9 @@ class InterpolatingConfigParser(DeepCopyableConfigParser):
         self.optionxform = str
 
         # Add in environment
-        # We allow access to environment variables by adding them into the
-        # os_env_vals section of the config file.
+        # We allow access to environment variables by loading them into a
+        # special configparser section ([environment]) which can then
+        # be referenced by other sections.
         # We cannot include environment variables containing characters
         # that are special to ConfigParser. So any variable containing a % or a
         # $ is ignored.
@@ -112,7 +113,7 @@ class InterpolatingConfigParser(DeepCopyableConfigParser):
             key: value for key, value in os.environ.items()
             if '%' not in value and '$' not in value
         }
-        self.read_dict({'os_env_vals': env_vals})
+        self.read_dict({'environment': env_vals})
 
         self.read_ini_file(configFiles)
 

--- a/pycbc/types/config.py
+++ b/pycbc/types/config.py
@@ -96,7 +96,8 @@ class InterpolatingConfigParser(DeepCopyableConfigParser):
             overrideTuples = []
         if deleteTuples is None:
             deleteTuples = []
-        super().__init__(defaults=os.environ)
+        env_vals = {('OS_ENV_VAL_' + k): v for k, v in os.environ.items()}
+        super().__init__(defaults=env_vals)
 
         # Enable case sensitive options
         self.optionxform = str

--- a/pycbc/types/config.py
+++ b/pycbc/types/config.py
@@ -96,7 +96,17 @@ class InterpolatingConfigParser(DeepCopyableConfigParser):
             overrideTuples = []
         if deleteTuples is None:
             deleteTuples = []
-        env_vals = {('OS_ENV_VAL_' + k): v for k, v in os.environ.items()}
+        # We allow access to environment variables by adding them into the
+        # defaults section of the config file, prepended by a OS_ENV_VAL string
+        # to avoid collision with potential section values.
+        # Based off of https://stackoverflow.com/questions/26586801
+        # PLEASE NOTE: ConfigParse values are case insensitive, whereas ENV
+        # values are case sensitive. So if your ENV sets both $TMPDIR and
+        # $tmpdir *one* of those (randomly) will be used here, so make sure
+        # they are consistent if using something like this!
+        env_vals = {
+            ('OS_ENV_VAL_' + k.upper()): v for k, v in os.environ.items()
+        }
         super().__init__(defaults=env_vals)
 
         # Enable case sensitive options

--- a/pycbc/types/config.py
+++ b/pycbc/types/config.py
@@ -104,8 +104,12 @@ class InterpolatingConfigParser(DeepCopyableConfigParser):
         # values are case sensitive. So if your ENV sets both $TMPDIR and
         # $tmpdir *one* of those (randomly) will be used here, so make sure
         # they are consistent if using something like this!
+        # We also cannot include environment variables containing characters
+        # that are special to ConfigParser. So any variable containing a % or a
+        # $ is ignored.
         env_vals = {
             ('OS_ENV_VAL_' + k.upper()): v for k, v in os.environ.items()
+            if '%' not in v and '$' not in v
         }
         super().__init__(defaults=env_vals)
 

--- a/pycbc/types/config.py
+++ b/pycbc/types/config.py
@@ -116,7 +116,7 @@ class InterpolatingConfigParser(DeepCopyableConfigParser):
             key.upper(): value for key, value in os.environ.items()
             if '%' not in value and '$' not in value
         }
-        self.read_dict({'os_env_vals': env_vals))
+        self.read_dict({'os_env_vals': env_vals})
 
         self.read_ini_file(configFiles)
 


### PR DESCRIPTION
This patch stores the environment into the pycbc.types (and pycbc.workflow, which subclasses) ConfigParser object. The environment is stored directly into a new special section `os_env_vars`. This can then be directly accessed by using things like `${os_env_vars:GWDATAFIND_SERVER}`, as you would for any other section.

Motivation: Quoting Stuart """DAGMan getenv=true no longer works with HTCondor 10.4.0 and newer:
At the request of the Pegasus team recent version of Condor DAGMan, including the version installed on the LLO cluster on Aug 22 (LHO Aug 29; CIT Sep 5), no longer support "getenv=true" https://opensciencegrid.atlassian.net/browse/HTCONDOR-1580 """

This has bitten quite a few condor workflows, including PyCBC. (@ahnitz you should definitely be aware of this for when sugar/atlas picks up this upgrade). There are cases (like the DATAFIND_SERVER) where we just want to inherit the environment  value, which may be different on different clusters. This allows us to basically say "pass along this environment variable" by adding something like:
```
[pegasus_profile-condorpool_symlink]
env|GWDATAFIND_SERVER = ${os_env_vals|GWDATAFIND_SERVER}
```

In addition we also keep track of the environment used at submission time, which could help diagnose issues ... But the main motivation here is that not being able to use `getenv=True` means that we'll need to explicitly pass along a few values (probably also the path to ROM data files). Condor does allow one to do things like `getenv=GWDATAFIND_SERVER`, but it is not clear how to pass this through a dagman, with pegasus (which involves two different sites, local for the dagman, and the execution site). This seems cleaner and clearer and let's us say things like "GWDATAFIND_SERVER locally should be this, but on OSG is a different, specified, value".