### PR TITLE
Stop testing on Python 3.7

### DIFF
--- a/.github/workflows/basic-tests.yml
+++ b/.github/workflows/basic-tests.yml
@@ -13,7 +13,7 @@ jobs:
       max-parallel: 60
       matrix:
         os: [ubuntu-20.04]
-        python-version: [3.7, 3.8, 3.9, '3.10', '3.11']
+        python-version: [3.8, 3.9, '3.10', '3.11']
         test-type: [unittest, search, docs]
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -20,13 +20,13 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.7      
+          python-version: 3.8
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel==2.3.1
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
-          CIBW_BUILD: cp37-* cp38-* cp39-* cp310-* cp311-*
+          CIBW_BUILD: cp38-* cp39-* cp310-* cp311-*
           CIBW_SKIP: "*musllinux*"
           CIBW_ARCHS_MACOS: x86_64 arm64
       - uses: actions/upload-artifact@v2
@@ -40,10 +40,10 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - name: Set up Python 3.7
+    - name: Set up Python 3.8
       uses: actions/setup-python@v4
       with:
-        python-version: 3.7
+        python-version: 3.8
     - uses: actions/download-artifact@v2
       with:
         path: ./

--- a/.github/workflows/mac-test.yml
+++ b/.github/workflows/mac-test.yml
@@ -13,7 +13,7 @@ jobs:
       max-parallel: 4
       matrix:
         os: [macos-latest]
-        python-version: [3.7, 3.8, 3.9, '3.10', '3.11']
+        python-version: [3.8, 3.9, '3.10', '3.11']
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/tut-test.yml
+++ b/.github/workflows/tut-test.yml
@@ -13,7 +13,7 @@ jobs:
       max-parallel: 60
       matrix:
         os: [ubuntu-20.04]
-        python-version: [3.7, 3.8, 3.9, '3.10', '3.11']
+        python-version: [3.8, 3.9, '3.10', '3.11']
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
Python 3.7 reached end of life 2 months ago. This stops testing under it and changes the distribution action to use Python 3.8.