### PR TITLE
Make number of dq bins used configurable

### DIFF
--- a/bin/all_sky_search/pycbc_bin_trigger_rates_dq
+++ b/bin/all_sky_search/pycbc_bin_trigger_rates_dq
@@ -28,6 +28,8 @@ parser.add_argument('--bank-file', help='hdf format template bank file',
                     required=True)
 parser.add_argument('--background-bins', nargs='+',
                     help='list of background bin format strings')
+parser.add_argument('--n-time-bins', type=int, default=200,
+                    help='Number of time bins to use')
 parser.add_argument("--output-file", required=True)
 parser.add_argument("--prune-number", type=int, default=0,
                     help="Number of loudest events to remove from each split "
@@ -86,9 +88,7 @@ for filename in args.dq_file:
     dq_times = np.concatenate((dq_times,dq_data.sample_times))
     del dq_data
 
-# todo: make this configurable
-percent_bin = 0.5
-n_bins = int(100./percent_bin)
+n_bins = args.n_time_bins
 percentiles = np.linspace(0,100,n_bins+1)
 bin_times = np.zeros(n_bins)
 dq_percentiles = np.percentile(dq_logl,percentiles)[1:]


### PR DESCRIPTION
This small fix makes the number of dq bins used configurable.
Not having this was not causing any errors, but when using binary dq flags, the bin that flagged data would be assigned to was dependent on the flag's active time. By setting the number of bins to 2 with a config setting, a binary dq flag should always result in flagged times getting assigned to bin 1, while unflagged times are assigned to bin 0.