### PR TITLE
Speed up background_bin_from_string

### DIFF
--- a/pycbc/events/coinc.py
+++ b/pycbc/events/coinc.py
@@ -43,6 +43,7 @@ _APPROXIMANT_DURATION_MAP = {
     'SEOBNRv5duration': 'SEOBNRv5_ROM'
 }
 
+
 def background_bin_from_string(background_bins, data):
     """ Return template ids for each bin as defined by the format string
 

--- a/pycbc/events/coinc.py
+++ b/pycbc/events/coinc.py
@@ -55,6 +55,9 @@ def background_bin_from_string(background_bins, data):
     """
     used = numpy.array([], dtype=numpy.uint32)
     bins = {}
+    # Some duration/peak frequency functions are expensive.
+    # Do not want to recompute many times, if using lots of bins.
+    cached_values = {}
     for mbin in background_bins:
         locs = None
         name, bin_type_list, boundary_list = tuple(mbin.split(':'))
@@ -91,29 +94,32 @@ def background_bin_from_string(background_bins, data):
             elif bin_type == 'chi_eff':
                 vals = pycbc.conversions.chi_eff(data['mass1'], data['mass2'],
                                                  data['spin1z'], data['spin2z'])
-            elif bin_type == 'SEOBNRv2Peak':
-                vals = pycbc.pnutils.get_freq('fSEOBNRv2Peak',
-                                              data['mass1'], data['mass2'],
-                                              data['spin1z'], data['spin2z'])
-            elif bin_type == 'SEOBNRv4Peak':
-                vals = pycbc.pnutils.get_freq('fSEOBNRv4Peak', data['mass1'],
-                                              data['mass2'], data['spin1z'],
-                                              data['spin2z'])
-            elif bin_type == 'SEOBNRv2duration':
+            elif bin_type in ['SEOBNRv2Peak', 'SEOBNRv4Peak']:
+                if bin_type in cached_values:
+                    vals = cached_values[bin_type]
+                else:
+                    vals = pycbc.pnutils.get_freq(
+                        'f' + bin_type,
+                        data['mass1'],
+                        data['mass2'],
+                        data['spin1z'],
+                        data['spin2z']
+                    )
+                    cached_values[bin_type] = vals
+            elif bin_type in ['SEOBNRv2duration', 'SEOBNRv4duration', 'SEOBNRv5duration']:
+                approx_map = {
+                    'SEOBNRv2duration': 'SEOBNRv2',
+                    'SEOBNRv4duration': 'SEOBNRv4',
+                    'SEOBNRv5duration': 'SEOBNRv5_ROM'
+                }
                 vals = pycbc.pnutils.get_imr_duration(
-                                   data['mass1'], data['mass2'],
-                                   data['spin1z'], data['spin2z'],
-                                   data['f_lower'], approximant='SEOBNRv2')
-            elif bin_type == 'SEOBNRv4duration':
-                vals = pycbc.pnutils.get_imr_duration(
-                                   data['mass1'][:], data['mass2'][:],
-                                   data['spin1z'][:], data['spin2z'][:],
-                                   data['f_lower'][:], approximant='SEOBNRv4')
-            elif bin_type == 'SEOBNRv5duration':
-                vals = pycbc.pnutils.get_imr_duration(
-                                   data['mass1'][:], data['mass2'][:],
-                                   data['spin1z'][:], data['spin2z'][:],
-                                   data['f_lower'][:], approximant='SEOBNRv5_ROM')
+                    data['mass1'],
+                    data['mass2'],
+                    data['spin1z'],
+                    data['spin2z'],
+                    data['f_lower'],
+                    approximant=approx_map[bin_type]
+                )
             else:
                 raise ValueError('Invalid bin type %s' % bin_type)
 

--- a/pycbc/events/coinc.py
+++ b/pycbc/events/coinc.py
@@ -35,6 +35,13 @@ from .eventmgr_cython import timecoincidence_getslideint
 from .eventmgr_cython import timecoincidence_findidxlen
 from .eventmgr_cython import timecluster_cython
 
+# Mapping used in background_bin_from_string to select approximant for
+# duration function, if duration-based binning is used.
+_APPROXIMANT_DURATION_MAP = {
+    'SEOBNRv2duration': 'SEOBNRv2',
+    'SEOBNRv4duration': 'SEOBNRv4',
+    'SEOBNRv5duration': 'SEOBNRv5_ROM'
+}
 
 def background_bin_from_string(background_bins, data):
     """ Return template ids for each bin as defined by the format string
@@ -105,19 +112,14 @@ def background_bin_from_string(background_bins, data):
                     data['spin2z']
                 )
                 cached_values[bin_type] = vals
-            elif bin_type in ['SEOBNRv2duration', 'SEOBNRv4duration', 'SEOBNRv5duration']:
-                approx_map = {
-                    'SEOBNRv2duration': 'SEOBNRv2',
-                    'SEOBNRv4duration': 'SEOBNRv4',
-                    'SEOBNRv5duration': 'SEOBNRv5_ROM'
-                }
+            elif bin_type in _APPROXIMANT_DURATION_MAP:
                 vals = pycbc.pnutils.get_imr_duration(
                     data['mass1'],
                     data['mass2'],
                     data['spin1z'],
                     data['spin2z'],
                     data['f_lower'],
-                    approximant=approx_map[bin_type]
+                    approximant=_APPROXIMANT_DURATION_MAP[bin_type]
                 )
                 cached_values[bin_type] = vals
             else:


### PR DESCRIPTION
We currently call `background_bin_from_string` with a set of 10 "bins" (for DQ purposes, @maxtrevor could explain more). Each of these 10 bins uses the SEOBNRv4 duration function. Currently every template will call the SEOBNRv4 generator 10 separate times, resulting in almost 10 million calls to the duration function. The SEOBNRv4 duration function also seems to be quite slow, leading to jobs taking O(4 hours) to complete, which normally would be almost instant.

While it would be better to somehow compute and store these durations, this is complicated as this duration is distinct from the actual template duration. It is, however, easy to rewrite this function so that we don't call the exact same function 10 times for every template. I can then live with these codes taking 10s of minutes.

There's also a bit of cleanup here to avoid duplication in the PeakFrequency and IMRDuration blocks.