### PR TITLE
Use compressed template bank test files

### DIFF
--- a/test/test_tmpltbank.py
+++ b/test/test_tmpltbank.py
@@ -29,6 +29,7 @@ import math
 import gzip
 import numpy
 from astropy.utils.data import download_file
+from astropy.utils.data import conf
 import pycbc.tmpltbank
 # Old LigoLW output functions are not imported at tmpltbank level
 import pycbc.tmpltbank.bank_output_utils as llw_output
@@ -52,6 +53,8 @@ import argparse
 parser = argparse.ArgumentParser()
 
 DATA_FILE_URL = 'https://github.com/gwastro/pycbc-config/raw/master/test_data_files/{}'
+# Allow astropy more time before downloads timeout
+conf.remote_timeout = 100
 
 def update_mass_parameters(tmpltbank_class):
     """

--- a/test/test_tmpltbank.py
+++ b/test/test_tmpltbank.py
@@ -432,7 +432,7 @@ class TmpltbankTestClass(unittest.TestCase):
         arrz = pycbc.tmpltbank.generate_anstar_3d_lattice(0, 10, 0, 10, 0, \
                                                           10, 0.03)
         arrz = numpy.array(arrz)
-        fname = 'stockAnstar3D.dat'
+        fname = 'stockAnstar3D.dat.gz'
         apy_fname = download_file(DATA_FILE_URL.format(fname), cache=False)
         stockGrid = numpy.loadtxt(apy_fname)
         # Uncomment this line to regenerate the data file


### PR DESCRIPTION
We've seen some failures where the test CI times out downloading this file. I tried downloading on the command line, and curl does hang for some seconds before starting this .... Presumably github is doing something to serve this to curl.

It seems easier to compress this file (much smaller) and then use that. `numpy.loadtxt` will deal with `.gz` files without issue. I've already added the `.gz` file to the place where those exist (outside of `pycbc`), so just swapping the test to use that.