### PR TITLE
Plot trigger rates during dq flags

### DIFF
--- a/bin/plotting/pycbc_plot_dq_flag_likelihood
+++ b/bin/plotting/pycbc_plot_dq_flag_likelihood
@@ -1,0 +1,64 @@
+#!/usr/bin/env python
+""" Plot the log likelihood percentiles for a DQ bin
+"""
+import sys
+import argparse
+import numpy
+import pycbc
+import h5py
+from matplotlib import use; use('Agg')
+from matplotlib import pyplot
+from pycbc.version import git_verbose_msg as version
+import pycbc.results
+
+parser = argparse.ArgumentParser(description=__doc__)
+parser.add_argument('--version', action='version', version=version)
+parser.add_argument('--verbose', action="store_true")
+parser.add_argument("--dq-file", required=True)
+parser.add_argument("--ifo", type=str, required=True)
+parser.add_argument("--output-file", required=True)
+args = parser.parse_args()
+
+pycbc.init_logging(args.verbose)
+
+ifo = args.ifo
+
+f = h5py.File(args.dq_file, 'r')
+dq_name = f.attrs['stat'].split('-')[1]
+logrates_grp = f[ifo + '/dq_percentiles']
+bin_names = logrates_grp.keys()
+
+# when using a flag, times when the flag was on go to the last dq bin
+logrates = [logrates_grp[b][-1] for b in bin_names]
+x = numpy.arange(len(logrates))
+
+ymax = 1.2 * max(logrates)
+color = pycbc.results.ifo_color(ifo)
+
+fig = pyplot.figure(0)
+ax = fig.add_subplot(111)
+ax.bar(x, height=logrates, label=f'{ifo} DQ Flag Trigger Rates',
+       color=color)
+ax.set_xlabel('Template Bin Number')
+ax.set_ylabel('Data Quality Log Likelihood')
+ax.set_xticks(x)
+ax.legend(loc='upper left', markerscale=5)
+ax.set_ylim(0, ymax)
+ax.grid()
+
+yticks = ax.get_yticks()
+
+ax2 = ax.twinx()
+ax2_ymax = numpy.exp(ymax)
+ax2.set_ylim(1, ax2_ymax)
+new_ticks = range(0, int(numpy.ceil(numpy.log10(ax2_ymax))))
+ax2.set_yticks([10**t for t in new_ticks])
+ax2.set_ylabel('Relative Trigger Rate')
+ax2.set_yscale('log')
+
+# add meta data and save figure
+plot_title = f'{ifo}: {dq_name} flag log likelihood'
+plot_caption = f'The log likelihood correction during during times flagged \
+                by the {dq_name} flag'
+pycbc.results.save_fig_with_metadata(fig, args.output_file, title=plot_title,
+                                     caption=plot_caption, cmd=' '.join(sys.argv))

--- a/bin/workflows/pycbc_make_offline_search_workflow
+++ b/bin/workflows/pycbc_make_offline_search_workflow
@@ -551,23 +551,33 @@ for key in final_bg_files:
 #################### Plotting of data quality results #########################
 
 # DQ log likelihood plots
-for dqf,dql in zip(dqfiles,dqfile_labels):
-    outdir = rdir[f'data_quality/{dqf.ifo}_trigger_rates_{dql}']
-    wf.make_dq_trigger_rate_plot(workflow, [dqf], outdir, tags=[dql,'full_data'])
-
-    outdir = rdir[f'data_quality/{dqf.ifo}_percentiles_{dql}']
-    wf.make_dq_percentile_plot(workflow, [dqf], outdir, tags=[dql,'full_data'])
+for dqf, dql in zip(dqfiles, dqfile_labels):
+    dq_type = workflow.cp.get_opt_tags('workflow-data_quality', 'dq-type', tags=[dql])
+    tags = [dql, 'full_data']
+    if dq_type == 'timeseries':
+        # plot rates as function of time
+        outdir = rdir[f'data_quality/{dqf.ifo}_{dql}_trigger_rates']
+        wf.make_dq_timeseries_trigger_rate_plot(workflow, [dqf], outdir,
+                                                tags=tags)
+        # plot rates as function of dq percentile
+        outdir = rdir[f'data_quality/{dqf.ifo}_{dql}_percentiles']
+        wf.make_dq_percentile_plot(workflow, [dqf], outdir, tags=tags)
+    elif dq_type == 'flag':
+        # plot rates when flag was on
+        outdir = rdir[f'data_quality/{dqf.ifo}_{dql}_trigger_rates']
+        wf.make_dq_flag_trigger_rate_plot(workflow, [dqf], outdir, tags=[dql])
 
 # DQ background binning plot
-if workflow.cp.has_option_tags('workflow-data_quality', 'background-bins',
-                                tags=None):
+if workflow.cp.has_option_tags('bin_trigger_rates_dq', 'background-bins',
+                               tags=None):
     background_bins = workflow.cp.get_opt_tags('bin_trigger_rates_dq',
-                                               'background-bins',tags=None)
+                                               'background-bins', tags=None)
     bank_tags = workflow.cp.get_subsections('plot_bank')
-    if len(bank_tags) == 0: bank_tags=['bank']
+    if len(bank_tags) == 0:
+        bank_tags = ['bank']
     for b_tag in bank_tags:
         wf.make_template_plot(workflow, hdfbank, rdir['data_quality'],
-                              bins=background_bins, tags=['dq_bins',b_tag])
+                              bins=background_bins, tags=['dq_bins', b_tag])
 
 ############################## Setup the injection runs #######################
 

--- a/pycbc/workflow/plotting.py
+++ b/pycbc/workflow/plotting.py
@@ -271,7 +271,6 @@ def make_veto_table(workflow, out_dir, vetodef_file=None, tags=None):
 def make_seg_plot(workflow, seg_files, out_dir, seg_names=None, tags=None):
     """ Creates a node in the workflow for plotting science, and veto segments.
     """
-
     seg_files = list(seg_files)
     if tags is None: tags = []
     makedir(out_dir)
@@ -506,7 +505,7 @@ def make_singles_plot(workflow, trig_files, bank_file, veto_file, veto_name,
             files += node.output_files
     return files
 
-def make_dq_trigger_rate_plot(workflow, dq_files, out_dir, tags=None):
+def make_dq_timeseries_trigger_rate_plot(workflow, dq_files, out_dir, tags=None):
     tags = [] if tags is None else tags
     makedir(out_dir)
     files = FileList([])
@@ -558,4 +557,19 @@ def make_dq_percentile_plot(workflow, dq_files, out_dir, tags=None):
             node.new_output_file_opt(dq_file.segment, '.png', '--output-file')
             workflow += node
             files += node.output_files
+    return files
+
+def make_dq_flag_trigger_rate_plot(workflow, dq_files, out_dir, tags=None):
+    tags = [] if tags is None else tags
+    makedir(out_dir)
+    files = FileList([])
+    for dq_file in dq_files:
+        node = PlotExecutable(workflow.cp, 'plot_dq_flag_likelihood',
+                              ifos=dq_file.ifo, out_dir=out_dir,
+                              tags=tags).create_node()
+        node.add_input_opt('--dq-file', dq_file)
+        node.add_opt('--ifo', dq_file.ifo)
+        node.new_output_file_opt(dq_file.segment, '.png', '--output-file')
+        workflow += node
+        files += node.output_files
     return files


### PR DESCRIPTION
This commit adds a new executable for plotting the likelihood factor found from computing trigger rates during dq flags, and adds it to the offline workflow. This should be the last code change needed to support the use of dq flags in O4.