### PR TITLE
rank_stat_single was not using KDE or BBH weighting - bugfix

### DIFF
--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -1733,6 +1733,31 @@ class ExpFitFgBgNormBBHStatistic(ExpFitFgBgNormStatistic):
         logr_s += numpy.log((self.curr_mchirp / 20.) ** (11. / 3.))
         return logr_s
 
+    def rank_stat_single(self, single_info,
+                         **kwargs): # pylint:disable=unused-argument
+        """
+        Calculate the statistic for a single detector candidate
+
+        This calls back to the Parent class and then applies the chirp mass
+        weighting factor.
+
+        Parameters
+        ----------
+        single_info: tuple
+            Tuple containing two values. The first is the ifo (str) and the
+            second is the single detector triggers.
+
+        Returns
+        -------
+        numpy.ndarray
+            The array of single detector statistics
+        """
+        rank_sngl = ExpFitFgBgNormStatistic.rank_stat_single(self, single_info,
+                         **kwargs)
+        rank_sngl += numpy.log((self.curr_mchirp / 20.) ** (11. / 3.))
+        return rank_sngl
+
+
     def single(self, trigs):
         """
         Calculate the necessary single detector information

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -1752,11 +1752,12 @@ class ExpFitFgBgNormBBHStatistic(ExpFitFgBgNormStatistic):
         numpy.ndarray
             The array of single detector statistics
         """
-        rank_sngl = ExpFitFgBgNormStatistic.rank_stat_single(self, single_info,
-                         **kwargs)
+        rank_sngl = ExpFitFgBgNormStatistic.rank_stat_single(
+            self,
+            single_info,
+            **kwargs)
         rank_sngl += numpy.log((self.curr_mchirp / 20.) ** (11. / 3.))
         return rank_sngl
-
 
     def single(self, trigs):
         """
@@ -1925,8 +1926,10 @@ class ExpFitFgBgKDEStatistic(ExpFitFgBgNormStatistic):
         numpy.ndarray
             The array of single detector statistics
         """
-        rank_sngl = ExpFitFgBgNormStatistic.rank_stat_single(self, single_info,
-                         **kwargs)
+        rank_sngl = ExpFitFgBgNormStatistic.rank_stat_single(
+            self,
+            single_info,
+            **kwargs)
         rank_sngl += self.kde_logsignalrate()
         return rank_sngl
 
@@ -2155,8 +2158,10 @@ class DQExpFitFgBgKDEStatistic(DQExpFitFgBgNormStatistic):
         """
         Inherited, see docstring for ExpFitFgBgKDEStatistic.rank_stat_single
         """
-        return ExpFitFgBgKDEStatistic.rank_stat_single(self, single_info,
-                         **kwargs)
+        return ExpFitFgBgKDEStatistic.rank_stat_single(
+            self,
+            single_info,
+            **kwargs)
 
     def coinc_lim_for_thresh(self, s, thresh, limifo, **kwargs):
         """

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -1873,7 +1873,7 @@ class ExpFitFgBgKDEStatistic(ExpFitFgBgNormStatistic):
         with h5py.File(self.files[kname + '-kde_file'], 'r') as kde_file:
             self.kde_by_tid[kname + '_kdevals'] = kde_file['data_kde'][:]
 
-    def kde_logsignalrate(self):
+    def kde_ratio(self):
         """
         Calculate the weighting factor according to the ratio of the
         signal and template KDE lookup tables
@@ -1906,7 +1906,7 @@ class ExpFitFgBgKDEStatistic(ExpFitFgBgNormStatistic):
         """
         logr_s = ExpFitFgBgNormStatistic.logsignalrate(self, stats, shift,
                                                        to_shift)
-        logr_s += self.kde_logsignalrate()
+        logr_s += self.kde_ratio()
 
         return logr_s
 
@@ -1930,7 +1930,7 @@ class ExpFitFgBgKDEStatistic(ExpFitFgBgNormStatistic):
             self,
             single_info,
             **kwargs)
-        rank_sngl += self.kde_logsignalrate()
+        rank_sngl += self.kde_ratio()
         return rank_sngl
 
     def coinc_lim_for_thresh(self, s, thresh, limifo, **kwargs):
@@ -2140,11 +2140,11 @@ class DQExpFitFgBgKDEStatistic(DQExpFitFgBgNormStatistic):
         for kname in self.kde_names:
             ExpFitFgBgKDEStatistic.assign_kdes(self, kname)
 
-    def kde_logsignalrate(self):
+    def kde_ratio(self):
         """
         Inherited, see docstring for ExpFitFgBgKDEStatistic.kde_signalrate
         """
-        return ExpFitFgBgKDEStatistic.kde_logsignalrate(self)
+        return ExpFitFgBgKDEStatistic.kde_ratio(self)
 
     def logsignalrate(self, stats, shift, to_shift):
         """

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -2152,6 +2152,9 @@ class DQExpFitFgBgKDEStatistic(DQExpFitFgBgNormStatistic):
 
     def rank_stat_single(self, single_info,
                          **kwargs): # pylint:disable=unused-argument
+        """
+        Inherited, see docstring for ExpFitFgBgKDEStatistic.rank_stat_single
+        """
         return ExpFitFgBgKDEStatistic.rank_stat_single(self, single_info,
                          **kwargs)
 


### PR DESCRIPTION
The mass weighting for the BBH statistic, and the KDE weighting in the KDE statistic were not being used in the rank_stat_single.

This is as the logsignalrate function, to which these were added, is appropriate for coinc events only as it is where the PhaseTD stuff is calculated.

The sensitive volume term is directly calculated in the rank_stat_single function for ExpFitFgBgNormStatistic, so that is okay

This does show how making the statistics a bit more modular will definitely help prevent oversights like this, but that is more invasive and a long-term project