### PR TITLE
PyGRB: Sky-error plot fix

### DIFF
--- a/bin/pygrb/pycbc_pygrb_plot_injs_results
+++ b/bin/pygrb/pycbc_pygrb_plot_injs_results
@@ -100,7 +100,7 @@ def load_mass_data(input_file_handle, key, tag):
     return data
 
 
-def load_sky_error_data(input_file_handle, key, tag, trig_data):
+def load_sky_error_data(input_file_handle, key, tag):
     """Extract data related to sky_error from raw injection and trigger data"""
     if tag == 'missed':
         # Missed injections are assigned null values
@@ -110,8 +110,8 @@ def load_sky_error_data(input_file_handle, key, tag, trig_data):
         inj['ra'] = input_file_handle[tag+'/ra'][:]
         inj['dec'] = input_file_handle[tag+'/dec'][:]
         trig = {}
-        trig['ra'] = np.rad2deg(trig_data['network/longitude'][:])
-        trig['dec'] = np.rad2deg(trig_data['network/latitude'][:])
+        trig['ra'] = input_file_handle['network/ra'][:]
+        trig['dec'] = input_file_handle['network/dec'][:]
         data = np.arccos(np.cos(inj['dec'] - trig['dec']) -
                          np.cos(inj['dec']) * np.cos(trig['dec']) *
                          (1 - np.cos(inj['ra'] - trig['ra'])))
@@ -128,7 +128,7 @@ easy_keys = ['distance', 'mass1', 'mass2', 'polarization',
              'spin2_azimuthal', 'spin2_polar',
              'dec', 'ra', 'phi_ref']
 # Function to extract desired data from an injection file
-def load_data(input_file_handle, keys, tag, trig_data):
+def load_data(input_file_handle, keys, tag):
     """Create a dictionary containing the data specified by the
     list of keys extracted from an injection file"""
 
@@ -148,7 +148,7 @@ def load_data(input_file_handle, keys, tag, trig_data):
                 data_dict[key] = load_incl_data(input_file_handle, key, tag)
             elif key == 'sky_error':
                 data_dict[key] = load_sky_error_data(input_file_handle, key,
-                                                 tag, trig_data)
+                                                 tag)
         except KeyError:
             #raise NotImplemented(key+' not allowed: returning empty entry')
             logging.info(key+' not allowed yet')
@@ -247,10 +247,10 @@ max_reweighted_snr = max(trig_data['network/reweighted_snr'][:])
 # Post-process injections
 # =======================
 # Extract the necessary data from the missed injections for the plot
-missed_inj = load_data(f, [x_qty, y_qty], 'missed', trig_data)
+missed_inj = load_data(f, [x_qty, y_qty], 'missed')
 
 # Extract the necessary data from the found injections for the plot
-found_inj = load_data(f, [x_qty, y_qty], 'found', trig_data)
+found_inj = load_data(f, [x_qty, y_qty], 'found')
 
 # Injections found surviving vetoes
 found_after_vetoes = found_inj if 'found_after_vetoes' not in f.keys() else f['found_after_vetoes']


### PR DESCRIPTION
This is a separate PR to fix a specific bug when generating plots of injection sky-errors in the new PyGRB workflow. There is some preliminary discussion in #4443. 

This comes down to a tricky naming issue. Injection trigger files now contain the injection information AND the associated found triggers. In the `load_sky_error_data` function, this file is referred to as `input_file_handle`. Separately, the trigger file containing background triggers is used for other calculations. This one is referred to as `trig_data`. Previously the function was trying to compare data from two different types of trigger files (i.e. comparing found injections to background triggers). This went undetected until now because in early tests, one of these arrays ended up being empty. I believe this was because our test configuration had a very limited number of injections, and none of them were being found. If you run examples with more injections that can be found, you end up with two arrays of different size (with neither being empty), and an exception is thrown.

I've put together an example on CIT here: `/home/jacob.buchanan/tests/postproc_tests/skyerror`. Using two environments you can see the code running with the fix, and failing without it.

With fix: `/home/jacob.buchanan/.conda/envs/skyerror_fix`
Without fix: `/home/jacob.buchanan/.conda/envs/skyerror_nofix`

I can delve into this more if requested.