### PR TITLE
Fix error in page_foreground and cleanup

### DIFF
--- a/bin/plotting/pycbc_page_foreground
+++ b/bin/plotting/pycbc_page_foreground
@@ -1,28 +1,31 @@
 #!/usr/bin/env python
-"""
-Make table of the foreground events. Also includes ability to
-write FARs and p-values for intermediary hierarchical removal steps.
-"""
-import argparse
-import h5py, logging, numpy
-from pycbc.io import hdf
-import h5py, logging
-from pycbc.pnutils import mass1_mass2_to_mchirp_eta
-import pycbc.results, pycbc.results.followup
-from pycbc.results import save_fig_with_metadata
-import pycbc.version
-import sys
 
-parser = argparse.ArgumentParser()
-# General required options
-parser.add_argument("--version", action="version", version=pycbc.version.git_verbose_msg)
-parser.add_argument('--trigger-file')
-parser.add_argument('--bank-file')
-parser.add_argument('--single-detector-triggers', nargs='+', default=None)
+"""Make table of the foreground events. Also includes ability to write FARs and
+p-values for intermediary hierarchical removal steps.
+"""
+
+import sys
+import argparse
+import logging
+import numpy
+import h5py
+import pycbc
+import pycbc.results
+import pycbc.version
+from pycbc.io import hdf
+from pycbc.pnutils import mass1_mass2_to_mchirp_eta
+
+
+parser = argparse.ArgumentParser(description=__doc__)
+parser.add_argument("--version", action="version",
+                    version=pycbc.version.git_verbose_msg)
+parser.add_argument('--trigger-file', required=True)
+parser.add_argument('--bank-file', required=True)
+parser.add_argument('--single-detector-triggers', nargs='+')
 parser.add_argument('--verbose', action='count')
-parser.add_argument('--output-file')
+parser.add_argument('--output-file', required=True)
 parser.add_argument('--num-to-write', type=int)
-parser.add_argument('--use-hierarchical-level', type=int, default=None,
+parser.add_argument('--use-hierarchical-level', type=int,
                     help='Indicate which FARs to write to the table '
                          'based on the number of hierarchical removals done. '
                          'Choosing None defaults to giving the FARs after '
@@ -35,15 +38,16 @@ parser.add_argument('--use-hierarchical-level', type=int, default=None,
                          'of hierarchical removals done. [default=None]')
 args = parser.parse_args()
 
-f = h5py.File(args.trigger_file, 'r')
+pycbc.init_logging(args.verbose)
+
+with h5py.File(args.trigger_file, 'r') as f:
+    try:
+        h_iterations = f.attrs['hierarchical_removal_iterations']
+    except KeyError:
+        h_iterations = None
 
 # Parse which inclusive background to use for the plotting
 h_num_rm = args.use_hierarchical_level
-
-try:
-    h_iterations = f.attrs['hierarchical_removal_iterations']
-except KeyError:
-    h_iterations = None
 
 if h_num_rm is not None and (h_iterations is None or h_num_rm > h_iterations):
     col_one = numpy.array([h_num_rm])
@@ -57,12 +61,12 @@ if h_num_rm is not None and (h_iterations is None or h_num_rm > h_iterations):
     kwds = { 'title' :
         'No more events louder than all background at this removal level.',
         'cmd' :' '.join(sys.argv), }
-    save_fig_with_metadata(str(html_table), args.output_file, **kwds)
+    pycbc.results.save_fig_with_metadata(
+        str(html_table),
+        args.output_file,
+        **kwds
+    )
     sys.exit(0)
-
-if args.verbose:
-    log_level = logging.INFO
-    logging.basicConfig(format='%(asctime)s : %(message)s', level=log_level)
 
 if args.output_file.endswith('.xml') or args.output_file.endswith('.xml.gz'):
     if args.single_detector_triggers is None:
@@ -177,7 +181,11 @@ if args.output_file.endswith('.html'):
 
     kwds = { 'title' : 'Loudest Event Table',
         'cmd' :' '.join(sys.argv), }
-    save_fig_with_metadata(str(html_table), args.output_file, **kwds)
+    pycbc.results.save_fig_with_metadata(
+        str(html_table),
+        args.output_file,
+        **kwds
+    )
 
 elif args.output_file.endswith('.xml') or args.output_file.endswith('.xml.gz'):
     fortrigs.to_coinc_xml_object(args.output_file)

--- a/pycbc/io/hdf.py
+++ b/pycbc/io/hdf.py
@@ -857,11 +857,13 @@ class ForegroundTriggers(object):
         outdoc = ligolw.Document()
         outdoc.appendChild(ligolw.LIGO_LW())
 
-        ifos = list(self.sngl_files.keys())
-        proc_id = ligolw_process.register_to_xmldoc(outdoc, 'pycbc',
-                     {}, instruments=ifos, comment='', version=pycbc_version.git_hash,
-                     cvs_repository='pycbc/'+pycbc_version.git_branch,
-                     cvs_entry_time=pycbc_version.date).process_id
+        ifos = sorted(self.sngl_files)
+        proc_table = create_process_table(
+            outdoc,
+            program_name='pycbc',
+            detectors=ifos
+        )
+        proc_id = proc_table.process_id
 
         search_summ_table = lsctables.New(lsctables.SearchSummaryTable)
         coinc_h5file = self.coinc_file.h5file

--- a/pycbc/io/hdf.py
+++ b/pycbc/io/hdf.py
@@ -15,14 +15,16 @@ from lal import LIGOTimeGPS, YRJUL_SI
 from ligo.lw import ligolw
 from ligo.lw import lsctables
 from ligo.lw import utils as ligolw_utils
-from ligo.lw.utils import process as ligolw_process
 
 from pycbc import version as pycbc_version
-from pycbc.io.ligolw import return_search_summary, return_empty_sngl
+from pycbc.io.ligolw import (
+    return_search_summary,
+    return_empty_sngl,
+    create_process_table
+)
 from pycbc import events, conversions, pnutils
 from pycbc.events import ranking, veto
 from pycbc.events import mean_if_greater_than_zero
-from pycbc.pnutils import mass1_mass2_to_mchirp_eta
 
 
 class HFile(h5py.File):
@@ -1051,7 +1053,7 @@ class ForegroundTriggers(object):
 
         mass1 = self.get_bankfile_array('mass1')
         mass2 = self.get_bankfile_array('mass2')
-        ofd['chirp_mass'], _ = mass1_mass2_to_mchirp_eta(mass1, mass2)
+        ofd['chirp_mass'], _ = pnutils.mass1_mass2_to_mchirp_eta(mass1, mass2)
 
         logging.info("Outputting single-trigger information")
         logging.info("reduced chisquared")

--- a/pycbc/io/hdf.py
+++ b/pycbc/io/hdf.py
@@ -16,7 +16,6 @@ from ligo.lw import ligolw
 from ligo.lw import lsctables
 from ligo.lw import utils as ligolw_utils
 
-from pycbc import version as pycbc_version
 from pycbc.io.ligolw import (
     return_search_summary,
     return_empty_sngl,

--- a/pycbc/io/ligolw.py
+++ b/pycbc/io/ligolw.py
@@ -157,10 +157,15 @@ def create_process_table(document, program_name=None, detectors=None,
             opts.pop(key)
 
     process = ligolw_process.register_to_xmldoc(
-            document, program_name, opts, version=pycbc_version.version,
-            cvs_repository='pycbc/'+pycbc_version.git_branch,
-            cvs_entry_time=cvs_entry_time, instruments=detectors,
-            comment=comment)
+        document,
+        program_name,
+        opts,
+        version=pycbc_version.version,
+        cvs_repository='pycbc/'+pycbc_version.git_branch,
+        cvs_entry_time=cvs_entry_time,
+        instruments=detectors,
+        comment=comment
+    )
     return process
 
 def legacy_row_id_converter(ContentHandler):


### PR DESCRIPTION
Fixes this error reported by Sunil:
```
Traceback (most recent call last):
  File "/home/sunil.choudhary/39_max/bin/pycbc_page_foreground", line 183, in <module>
    fortrigs.to_coinc_xml_object(args.output_file)
  File "/home/sunil.choudhary/39_max/lib/python3.9/site-packages/pycbc/io/hdf.py", line 861, in to_coinc_xml_object
    proc_id = ligolw_process.register_to_xmldoc(outdoc, 'pycbc',
  File "/home/sunil.choudhary/39_max/lib/python3.9/site-packages/ligo/lw/utils/process.py", line 100, in register_to_xmldoc
    process = proctable.RowType.initialized(program = program, process_id = proctable.get_next_id(), **kwargs)
  File "/home/sunil.choudhary/39_max/lib/python3.9/site-packages/ligo/lw/lsctables.py", line 586, in initialized
    cvs_entry_time = lal.UTCToGPS(time.strptime(cvs_entry_time, "%Y-%m-%d %H:%M:%S +0000")) if cvs_entry_time is not None else None,
  File "/cvmfs/oasis.opensciencegrid.org/ligo/sw/conda/envs/igwn-py39/lib/python3.9/_strptime.py", line 562, in _strptime_time
    tt = _strptime(data_string, format)[0]
  File "/cvmfs/oasis.opensciencegrid.org/ligo/sw/conda/envs/igwn-py39/lib/python3.9/_strptime.py", line 349, in _strptime
    raise ValueError("time data %r does not match format %r" %
ValueError: time data '' does not match format '%Y-%m-%d %H:%M:%S +0000'
```
and cleans up the executable script.

Not tested.