### PR TITLE
calculate_psd: support for time-dependent options and stop infinite loop

### DIFF
--- a/bin/all_sky_search/pycbc_calculate_psd
+++ b/bin/all_sky_search/pycbc_calculate_psd
@@ -36,7 +36,7 @@ def grouper(n, iterable):
     args = [iter(iterable)] * n
     return list([e for e in t if e != None] for t in zip_longest(*args))
 
-def get_psd(input_tuple, rerun_count=None):
+def get_psd(input_tuple):
     """ Get the PSDs for the given data chunck. This follows the same rules
     as pycbc_inspiral for determining where to calculate PSDs
     """

--- a/bin/all_sky_search/pycbc_calculate_psd
+++ b/bin/all_sky_search/pycbc_calculate_psd
@@ -35,7 +35,7 @@ def grouper(n, iterable):
     args = [iter(iterable)] * n
     return list([e for e in t if e != None] for t in zip_longest(*args))
 
-def get_psd(input_tuple):
+def get_psd(input_tuple, rerun_count=None):
     """ Get the PSDs for the given data chunck. This follows the same rules
     as pycbc_inspiral for determining where to calculate PSDs
     """
@@ -48,15 +48,25 @@ def get_psd(input_tuple):
     argstmp.gps_start_time = int(seg[0]) + args.pad_data
     argstmp.gps_end_time = int(seg[1]) - args.pad_data
     tmp_segment = segment([argstmp.gps_start_time, argstmp.gps_end_time])
+    # There may be cases where channel name or frame type change within an
+    # analysis (noting that this could be an issue with significance
+    # computation). If so, resolve them for each PSD block. The channel or
+    # frame type *cannot* change during a lock stretch.
     argstmp.channel_name = resolve_td_option(args.channel_name, tmp_segment)
+    argstmp.frame_type = resolve_td_option(args.frame_type, tmp_segment)
 
     # This helps when the filesystem is unreliable, and gives extra retries.
     # python has an internal limit of ~100 (it is not infinite)
     try:
         gwstrain = pycbc.strain.from_cli(argstmp, pycbc.DYN_RANGE_FAC)
     except RuntimeError:
+        # Retry on failures ... but don't keep trying forever!!
+        if rerun_count is None:
+            rerun_count = 0
+        if rerun_count == 5:
+            raise
         time.sleep(10)
-        return get_psd((seg, i))
+        return get_psd((seg, i), rerun_count=rerun_count+1)
 
     logging.info('%d: determining strain segmentation', i)
     strain_segments = pycbc.strain.StrainSegments.from_cli(args, gwstrain)

--- a/bin/all_sky_search/pycbc_calculate_psd
+++ b/bin/all_sky_search/pycbc_calculate_psd
@@ -20,6 +20,7 @@ parser.add_argument("--analysis-segment-file",  required=True,
 parser.add_argument("--segment-name", help="Name of segment list to use")
 parser.add_argument("--cores", default=1, type=int)
 parser.add_argument("--output-file", required=True)
+parser.add_argument("--num-data-retries", default=10, type=int)
 
 pycbc.psd.insert_psd_option_group(parser, output=False)
 pycbc.strain.insert_strain_option_group(parser, gps_times=False)
@@ -59,18 +60,15 @@ def get_psd(input_tuple, rerun_count=None):
         # Option is often not given.
         argstmp.frame_type = resolve_td_option(args.frame_type, tmp_segment)
 
-    # This helps when the filesystem is unreliable, and gives extra retries.
-    # python has an internal limit of ~100 (it is not infinite)
-    try:
-        gwstrain = pycbc.strain.from_cli(argstmp, pycbc.DYN_RANGE_FAC)
-    except RuntimeError:
-        # Retry on failures ... but don't keep trying forever!!
-        if rerun_count is None:
-            rerun_count = 0
-        if rerun_count == 5:
-            raise
-        time.sleep(10)
-        return get_psd((seg, i), rerun_count=rerun_count+1)
+    # This helps when the filesystem is unreliable
+    for i in range(args.num_data_retries):
+        try:
+            gwstrain = pycbc.strain.from_cli(argstmp, pycbc.DYN_RANGE_FAC)
+            break
+        except RuntimeError:
+            time.sleep(10)
+            if i == (args.num_data_retries-1):
+                raise
 
     logging.info('%d: determining strain segmentation', i)
     strain_segments = pycbc.strain.StrainSegments.from_cli(args, gwstrain)

--- a/bin/all_sky_search/pycbc_calculate_psd
+++ b/bin/all_sky_search/pycbc_calculate_psd
@@ -51,8 +51,8 @@ def get_psd(input_tuple, rerun_count=None):
     tmp_segment = segment([argstmp.gps_start_time, argstmp.gps_end_time])
     # There may be cases where channel name or frame type change within an
     # analysis (noting that this could be an issue with significance
-    # computation). If so, resolve them for each PSD block. The channel or
-    # frame type *cannot* change during a lock stretch.
+    # computation). If so, resolve them for each PSD block. This still
+    # assumes that the channel and frame type are constant during a lock stretch.
     if args.channel_name:
         # Option may not have been given at all
         argstmp.channel_name = resolve_td_option(args.channel_name, tmp_segment)

--- a/bin/all_sky_search/pycbc_calculate_psd
+++ b/bin/all_sky_search/pycbc_calculate_psd
@@ -52,8 +52,12 @@ def get_psd(input_tuple, rerun_count=None):
     # analysis (noting that this could be an issue with significance
     # computation). If so, resolve them for each PSD block. The channel or
     # frame type *cannot* change during a lock stretch.
-    argstmp.channel_name = resolve_td_option(args.channel_name, tmp_segment)
-    argstmp.frame_type = resolve_td_option(args.frame_type, tmp_segment)
+    if args.channel_name:
+        # Option may not have been given at all
+        argstmp.channel_name = resolve_td_option(args.channel_name, tmp_segment)
+    if args.frame_type:
+        # Option is often not given.
+        argstmp.frame_type = resolve_td_option(args.frame_type, tmp_segment)
 
     # This helps when the filesystem is unreliable, and gives extra retries.
     # python has an internal limit of ~100 (it is not infinite)


### PR DESCRIPTION
`pycbc_calculate_psd` already has support for time-dependent *channel-name*, but if the *frame-type* is similarly time-dependent we get a problem. Fixing that is trivial. A use case for this is something like the example in O3 where Virgo had a calibration bug, which meant a short stretch of data needed reproducing, and used a different frame-type.

I also realise that any failure in this code causes it to keep retrying indefinitely. It would be good to actually make the code fail on a failure, so I added that as well.