### PR TITLE
add option for the 'from_path' method of workflow.core.File to also set a PFN

### DIFF
--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -1262,6 +1262,17 @@ class File(pegasus_workflow.File):
     def from_path(cls, path, attrs=None, set_pfn=False, **kwargs):
         """
         Create an output File object from path, with optional attributes.
+
+        Parameters
+        ----------
+        path: str
+            The path to the file.
+        attrs: dict
+            Set of attributes to associate with the file
+        set_pfn: bool or string, default=False
+            Assume the path is also a currently valid physical path to the
+            file. If True, the PFN is set for the 'local' site. Otherwise,
+            a string may be provided to indicate the site.
         """
         if attrs is None:
             attrs = {}

--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -1259,7 +1259,7 @@ class File(pegasus_workflow.File):
                                    duration, extension)
 
     @classmethod
-    def from_path(cls, path, attrs=None, **kwargs):
+    def from_path(cls, path, attrs=None, set_pfn=False, **kwargs):
         """
         Create an output File object from path, with optional attributes.
         """
@@ -1283,6 +1283,12 @@ class File(pegasus_workflow.File):
             tags = []
 
         curr_file = cls(ifos, exe_name, segs, path, tags=tags, **kwargs)
+
+        # assume the given path is also a valid pfn
+        if set_pfn:
+            site = 'local' if set_pfn == True else set_pfn
+            curr_file.add_pfn(os.path.abspath(path), site)
+
         return curr_file
 
 class FileList(list):

--- a/pycbc/workflow/pegasus_workflow.py
+++ b/pycbc/workflow/pegasus_workflow.py
@@ -670,7 +670,7 @@ class Workflow(object):
         except FileNotFoundError:
             pass
         os.symlink(submitdir, 'submitdir')
-        planner_args['dir'] = submitdir
+        planner_args['dir'] = os.path.abspath(submitdir)
 
         # Other options
         planner_args['cluster'] = ['label,horizontal']


### PR DESCRIPTION
This is a convenience option so that when one creates a File object directly from a path, they can immediately choose that this path is also a valid PFN.