### PR TITLE
Make logging better for pycbc_make_offline_workflow

### DIFF
--- a/bin/workflows/pycbc_make_offline_search_workflow
+++ b/bin/workflows/pycbc_make_offline_search_workflow
@@ -57,16 +57,15 @@ def ifo_combos(ifos):
         for ifocomb in combinations:
             yield ifocomb
 
-
-# Log to the screen until we know where the output file is
-logging.basicConfig(format='%(asctime)s:%(levelname)s : %(message)s',
-    level=logging.INFO)
-
 parser = argparse.ArgumentParser(description=__doc__[1:])
 parser.add_argument('--version', action='version', version=__version__)
+parser.add_argument('--verbose', action='count',
+    help="Incrementally add more verbosity")
 wf.add_workflow_command_line_group(parser)
 wf.add_workflow_settings_cli(parser)
 args = parser.parse_args()
+
+pycbc.init_logging(args.verbose + 1)
 
 container = wf.Workflow(args, args.workflow_name)
 workflow = wf.Workflow(args, args.workflow_name + '-main')

--- a/bin/workflows/pycbc_make_offline_search_workflow
+++ b/bin/workflows/pycbc_make_offline_search_workflow
@@ -66,7 +66,8 @@ wf.add_workflow_settings_cli(parser)
 args = parser.parse_args()
 
 # By default, we do logging.info, each --verbose adds a level of verbosity
-pycbc.init_logging(args.verbose + 1)
+logging_level = args.verbose + 1 if args.verbose else logging.INFO
+pycbc.init_logging(logging_level)
 
 container = wf.Workflow(args, args.workflow_name)
 workflow = wf.Workflow(args, args.workflow_name + '-main')

--- a/bin/workflows/pycbc_make_offline_search_workflow
+++ b/bin/workflows/pycbc_make_offline_search_workflow
@@ -65,6 +65,7 @@ wf.add_workflow_command_line_group(parser)
 wf.add_workflow_settings_cli(parser)
 args = parser.parse_args()
 
+# By default, we do logging.info, each --verbose adds a level of verbosity
 pycbc.init_logging(args.verbose + 1)
 
 container = wf.Workflow(args, args.workflow_name)

--- a/pycbc/workflow/configuration.py
+++ b/pycbc/workflow/configuration.py
@@ -28,6 +28,7 @@ https://ldas-jobs.ligo.caltech.edu/~cbc/docs/pycbc/ahope/initialization_inifile.
 """
 
 import os
+import logging
 import stat
 import shutil
 import subprocess
@@ -87,6 +88,9 @@ def resolve_url(url, directory=None, permissions=None, copy_to_cwd=True):
         # it needs to be available when documentation runs in the CI, and I
         # can't get it to install in the GitHub CI
         import ciecplib
+        # Make the scitokens logger a little quieter
+        # (it is called through ciecpclib)
+        logging.getLogger('scitokens').setLevel(logging.root.level + 10)
         with ciecplib.Session() as s:
             if u.netloc in ("git.ligo.org", "code.pycbc.phy.syr.edu"):
                 # authenticate with git.ligo.org using callback

--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -224,8 +224,12 @@ class Executable(pegasus_workflow.Executable):
             # being directly accessible on the execution site.
             # CVMFS is perfect for this! As is singularity.
             self.exe_pfns[exe_site] = exe_path
-        logging.debug("Using %s executable "
-                      "at %s on site %s" % (name, exe_url.path, exe_site))
+        logging.debug(
+            "Using %s executable at %s on site %s",
+            name,
+            exe_url.path,
+            exe_site
+        )
 
         # FIXME: This hasn't yet been ported to pegasus5 and won't work.
         #        Pegasus describes two ways to work with containers, and I need

--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -224,8 +224,8 @@ class Executable(pegasus_workflow.Executable):
             # being directly accessible on the execution site.
             # CVMFS is perfect for this! As is singularity.
             self.exe_pfns[exe_site] = exe_path
-        logging.info("Using %s executable "
-                     "at %s on site %s" % (name, exe_url.path, exe_site))
+        logging.debug("Using %s executable "
+                      "at %s on site %s" % (name, exe_url.path, exe_site))
 
         # FIXME: This hasn't yet been ported to pegasus5 and won't work.
         #        Pegasus describes two ways to work with containers, and I need

--- a/pycbc/workflow/pegasus_workflow.py
+++ b/pycbc/workflow/pegasus_workflow.py
@@ -319,7 +319,8 @@ class Workflow(object):
     def __init__(self, name='my_workflow', directory=None, cache_file=None,
                  dax_file_name=None):
         # Pegasus logging is fairly verbose, quieten it down a bit
-        # This sets the logger to one level less verbose than the root (pycbc) logger
+        # This sets the logger to one level less verbose than the root
+        # (pycbc) logger
         pegasus_logger.setLevel(logging.root.level + 10)
         self.name = name
         self._rc = dax.ReplicaCatalog()

--- a/pycbc/workflow/pegasus_workflow.py
+++ b/pycbc/workflow/pegasus_workflow.py
@@ -28,6 +28,7 @@ provides additional abstraction and argument handling.
 """
 import os
 import shutil
+import logging
 import tempfile
 import subprocess
 from packaging import version
@@ -38,6 +39,8 @@ import Pegasus.api as dax
 PEGASUS_FILE_DIRECTORY = os.path.join(os.path.dirname(__file__),
                                       'pegasus_files')
 
+# Get the logger associated with the Pegasus workflow import
+pegasus_logger = logging.getLogger('Pegasus')
 
 class ProfileShortcuts(object):
     """ Container of common methods for setting pegasus profile information
@@ -315,6 +318,9 @@ class Workflow(object):
     """
     def __init__(self, name='my_workflow', directory=None, cache_file=None,
                  dax_file_name=None):
+        # Pegasus logging is fairly verbose, quieten it down a bit
+        # This sets the logger to one level less verbose than the root (pycbc) logger
+        pegasus_logger.setLevel(logging.root.level + 10)
         self.name = name
         self._rc = dax.ReplicaCatalog()
         self._tc = dax.TransformationCatalog()
@@ -340,7 +346,7 @@ class Workflow(object):
             self.filename = dax_file_name
         self._adag = dax.Workflow(self.filename)
 
-        # A pegasus job version of this workflow for use if it isncluded
+        # A pegasus job version of this workflow for use if it is included
         # within a larger workflow
         self._as_job = SubWorkflow(self.filename, is_planned=False,
                                    _id=self.name)

--- a/pycbc/workflow/pegasus_workflow.py
+++ b/pycbc/workflow/pegasus_workflow.py
@@ -42,6 +42,7 @@ PEGASUS_FILE_DIRECTORY = os.path.join(os.path.dirname(__file__),
 # Get the logger associated with the Pegasus workflow import
 pegasus_logger = logging.getLogger('Pegasus')
 
+
 class ProfileShortcuts(object):
     """ Container of common methods for setting pegasus profile information
     on Executables and nodes. This class expects to be inherited from
@@ -850,10 +851,10 @@ class File(dax.File):
     @classmethod
     def from_path(cls, path):
         """Takes a path and returns a File object with the path as the PFN."""
-        logging.warn("The from_path method in pegasus_workflow is deprecated. "
-                     "Please use File.from_path (for output files) in core.py "
-                     "or resolve_url_to_file in core.py (for input files) "
-                     "instead.")
+        logging.warning("The from_path method in pegasus_workflow is "
+                        "deprecated. Please use File.from_path (for output "
+                        "files) in core.py or resolve_url_to_file in core.py "
+                        "(for input files) instead.")
         urlparts = urlsplit(path)
         site = 'nonlocal'
         if (urlparts.scheme == '' or urlparts.scheme == 'file'):

--- a/pycbc/workflow/pegasus_workflow.py
+++ b/pycbc/workflow/pegasus_workflow.py
@@ -31,6 +31,7 @@ import shutil
 import logging
 import tempfile
 import subprocess
+import warnings
 from packaging import version
 from urllib.request import pathname2url
 from urllib.parse import urljoin, urlsplit
@@ -851,10 +852,11 @@ class File(dax.File):
     @classmethod
     def from_path(cls, path):
         """Takes a path and returns a File object with the path as the PFN."""
-        DeprecationWarning("The from_path method in pegasus_workflow is "
-                           "deprecated. Please use File.from_path (for "
-                           "output files) in core.py or resolve_url_to_file "
-                           "in core.py (for input files) instead.")
+        warnings.warn("The from_path method in pegasus_workflow is "
+                      "deprecated. Please use File.from_path (for "
+                      "output files) in core.py or resolve_url_to_file "
+                      "in core.py (for input files) instead.",
+                      DeprecationWarning)
         urlparts = urlsplit(path)
         site = 'nonlocal'
         if (urlparts.scheme == '' or urlparts.scheme == 'file'):

--- a/pycbc/workflow/pegasus_workflow.py
+++ b/pycbc/workflow/pegasus_workflow.py
@@ -39,9 +39,6 @@ import Pegasus.api as dax
 PEGASUS_FILE_DIRECTORY = os.path.join(os.path.dirname(__file__),
                                       'pegasus_files')
 
-# Get the logger associated with the Pegasus workflow import
-pegasus_logger = logging.getLogger('Pegasus')
-
 
 class ProfileShortcuts(object):
     """ Container of common methods for setting pegasus profile information
@@ -322,6 +319,9 @@ class Workflow(object):
         # Pegasus logging is fairly verbose, quieten it down a bit
         # This sets the logger to one level less verbose than the root
         # (pycbc) logger
+
+        # Get the logger associated with the Pegasus workflow import
+        pegasus_logger = logging.getLogger('Pegasus')
         pegasus_logger.setLevel(logging.root.level + 10)
         self.name = name
         self._rc = dax.ReplicaCatalog()
@@ -851,10 +851,10 @@ class File(dax.File):
     @classmethod
     def from_path(cls, path):
         """Takes a path and returns a File object with the path as the PFN."""
-        logging.warning("The from_path method in pegasus_workflow is "
-                        "deprecated. Please use File.from_path (for output "
-                        "files) in core.py or resolve_url_to_file in core.py "
-                        "(for input files) instead.")
+        DeprecationWarning("The from_path method in pegasus_workflow is "
+                           "deprecated. Please use File.from_path (for "
+                           "output files) in core.py or resolve_url_to_file "
+                           "in core.py (for input files) instead.")
         urlparts = urlsplit(path)
         site = 'nonlocal'
         if (urlparts.scheme == '' or urlparts.scheme == 'file'):


### PR DESCRIPTION
We realised that the pegasus logging was getting a little out of hand in the `pycbc_make_offline_workflow code`. Here I fix this three ways:

 - The log that was overbearing was specifically [this one](https://github.com/pegasus-isi/pegasus/blob/c5fa8830081ab4fc282a5dfe6a80f981b5b394e5/packages/pegasus-api/src/Pegasus/api/workflow.py#L1715) from pegasus, so I have added a line to grab the logger for this module, and set the logger level to be one level above the default pycbc logger (so, e.g., INFO would not be shown as default in this code)
 - I also did the same trick for the scitokens warning [here](https://github.com/scitokens/scitokens/blob/4a7066527571230ca35b8bab9ffc9ea97f3da364/src/scitokens/scitokens.py#L656).
 - I have reduced the level of [this log](https://github.com/gwastro/pycbc/blob/61c9f0cc33bb0743aadbc1da69f8db10a92db701/pycbc/workflow/core.py#L227) to be logging.debug as this is called every time a new executable is set up, but this happens for every parallel instance of e.g. `pycbc_coinc_findtrigs` so was overloading the output as well.

After these three changes, the output is much more manageable (I actually noticed config warnings that I hadn't noticed before!).

**HOWEVER** we might want the info that I have silenced, so I added the call to `pycbc.init_logging` to `pycbc_make_offline_search_workflow`, so that the verbosity level can be increased if desired. It is at info by default, and will go to debug if `--verbose` is given