### PR TITLE
[pycbc live] Don't add snr options to command if they don't exist

### DIFF
--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -134,6 +134,8 @@ class LiveEventManager(object):
                 self.fu_cores = 1
             # Convert SNR optimizer options into a string
             self.snr_opt_options = snr_optimizer.args_to_string(args)
+        else:
+            self.snr_opt_options = None
 
         if args.enable_embright_has_massgap:
             if args.embright_massgap_max < self.mc_area_args['mass_bdary']['ns_max']:
@@ -327,7 +329,7 @@ class LiveEventManager(object):
         cmd += exepath + ' '
 
         # Add SNR optimization options to the command
-        if self.snr_opt_options:
+        if self.snr_opt_options is not None:
             cmd += self.snr_opt_options
 
         # Add data files according to the event we are optimizing

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -572,12 +572,13 @@ class LiveEventManager(object):
             coinc_results['p_terr'] = event.p_terr
 
         # Do the optimizer setup
-        cmd, out_dir_path = self.setup_optimize_snr(
-            coinc_results,
-            live_ifos,
-            coinc_ifos,
-            fname,
-        )
+        if self.run_snr_optimization:
+            cmd, out_dir_path = self.setup_optimize_snr(
+                coinc_results,
+                live_ifos,
+                coinc_ifos,
+                fname,
+            )
 
         # Now start the thread to run the SNR optimizer
         if upload_checks or optimize_snr_checks:

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -327,7 +327,8 @@ class LiveEventManager(object):
         cmd += exepath + ' '
 
         # Add SNR optimization options to the command
-        cmd += self.snr_opt_options
+        if self.snr_opt_options:
+            cmd += self.snr_opt_options
 
         # Add data files according to the event we are optimizing
         data_fils_str = '--data-files '
@@ -572,13 +573,12 @@ class LiveEventManager(object):
             coinc_results['p_terr'] = event.p_terr
 
         # Do the optimizer setup
-        if self.run_snr_optimization:
-            cmd, out_dir_path = self.setup_optimize_snr(
-                coinc_results,
-                live_ifos,
-                coinc_ifos,
-                fname,
-            )
+        cmd, out_dir_path = self.setup_optimize_snr(
+            coinc_results,
+            live_ifos,
+            coinc_ifos,
+            fname,
+        )
 
         # Now start the thread to run the SNR optimizer
         if upload_checks or optimize_snr_checks:


### PR DESCRIPTION
By chance I discovered this bug when a candidate event came into the MDC while I was running things.

Bug:
`setup_optimize_snr` adds the command line commands used to run the snr optimization to an object so the snr optimization can be re-run at a later time (I think). If `run_snr_optimization` is not given to `pycbc_live` (you don't want snr optimization) then presumably you won't have set snr optimization options and therefore it can't add `snr_opt_options` to the command and will crash.

Fix:
- Set the `snr_opt_options` to None if `run_snr_optimization` isn't set
- Check whether the `snr_opt_options` is not None before trying to add it to command.

Just need to do a quick test to see if this actually fixes the issue.