### PR TITLE
Apply some needed efficiency savings to pycbc_bin_trigger_rates_dq

### DIFF
--- a/bin/all_sky_search/pycbc_bin_trigger_rates_dq
+++ b/bin/all_sky_search/pycbc_bin_trigger_rates_dq
@@ -54,22 +54,13 @@ ifo = args.ifo
 # This works as a pre-filter as SNR is always greater than or equal
 # to sngl_ranking, except in the psdvar case, where it could increase.
 
-def check_snr_psdvar(snr, psd_var_val):
-    """
-    Convenience function to calculate the maximum possible ranking statistic
-    value given SNR and psd variation statistic
-    """
-    rw_snr = snr / psd_var_val ** 0.5
-    rw_snr[psd_var_val == 0] = 0
-    return rw_snr >= args.stat_threshold
-
 with HFile(args.trig_file, 'r') as trig_file:
     n_triggers_orig = trig_file[f'{ifo}/snr'].size
     logging.info("Trigger file has %d triggers", n_triggers_orig)
     logging.info('Generating trigger mask')
     if f'{ifo}/psd_var_val' in trig_file:
         idx, _, _ = trig_file.select(
-            check_snr_psdvar,
+            lambda snr, psdvar: snr / psdvar ** 0.5 >= args.stat_threshold,
             f'{ifo}/snr',
             f'{ifo}/psd_var_val',
             return_indices=True

--- a/bin/all_sky_search/pycbc_bin_trigger_rates_dq
+++ b/bin/all_sky_search/pycbc_bin_trigger_rates_dq
@@ -48,25 +48,6 @@ pycbc.init_logging(args.verbose)
 
 logging.info('Start')
 
-with h5.File(args.bank_file, 'r') as bank:
-    if args.background_bins:
-        logging.info('Sorting bank into bins')
-        data = {
-            'mass1': bank['mass1'][:],
-            'mass2': bank['mass2'][:],
-            'spin1z': bank['spin1z'][:],
-            'spin2z': bank['spin2z'][:],
-            'f_lower': np.ones_like(bank['mass1'][:]) * args.f_lower
-            }
-        locs_dict = pycbc.events.background_bin_from_string(
-                                                   args.background_bins, data)
-        del data
-        locs_names = [b.split(':')[0] for b in args.background_bins]
-    else:
-        locs_dict = {'all_bin': np.arange(0, len(bank['mass1'][:]), 1)}
-        locs_names = ['all_bin']
-
-
 ifo = args.ifo
 # Setup a data mask based on SNR - the SNR will always be greater than
 # or equal to sngl-ranking by definition
@@ -74,10 +55,10 @@ with HFile(args.trig_file, 'r') as trig_file:
     n_triggers_orig = trig_file[f'{ifo}/snr'].size
     logging.info("Trigger file has %d triggers", n_triggers_orig)
     logging.info('Generating trigger mask')
-    idx, _ = trig_file.select(
+    idx = trig_file.select(
         lambda snr: snr > args.stat_threshold,
         f'{ifo}/snr',
-        return_indices=True
+        indices_only=True
     )
     data_mask = np.zeros(n_triggers_orig, dtype=bool)
     data_mask[idx] = True
@@ -100,7 +81,7 @@ trig_times = trigs.end_time
 trig_times_int = trig_times.astype('int')
 
 n_triggers = tmplt_ids.size
-logging.info("%d triggers are have been loaded after pre-cuts", n_triggers)
+logging.info("%d triggers have been loaded after pre-cuts", n_triggers)
 
 logging.info("Applying %s > %.3f cut", args.sngl_ranking,
              args.stat_threshold)
@@ -143,6 +124,24 @@ del dq_logl
 # create a dict to look up dq percentile at any time
 dq_percentiles_time = dict(zip(dq_times, seconds_bin/n_bins))
 del dq_times
+
+with h5.File(args.bank_file, 'r') as bank:
+    if args.background_bins:
+        logging.info('Sorting bank into bins')
+        data = {
+            'mass1': bank['mass1'][:],
+            'mass2': bank['mass2'][:],
+            'spin1z': bank['spin1z'][:],
+            'spin2z': bank['spin2z'][:],
+            'f_lower': np.ones_like(bank['mass1'][:]) * args.f_lower
+            }
+        locs_dict = pycbc.events.background_bin_from_string(
+                                                   args.background_bins, data)
+        del data
+        locs_names = [b.split(':')[0] for b in args.background_bins]
+    else:
+        locs_dict = {'all_bin': np.arange(0, len(bank['mass1'][:]), 1)}
+        locs_names = ['all_bin']
 
 logging.info("Placing triggers into bins")
 bin_triggers = {}

--- a/bin/all_sky_search/pycbc_bin_trigger_rates_dq
+++ b/bin/all_sky_search/pycbc_bin_trigger_rates_dq
@@ -52,15 +52,16 @@ ifo = args.ifo
 
 # Setup a data mask to remove any triggers with SNR below threshold
 # This works as a pre-filter as SNR is always greater than or equal
-# to sngl_ranking
+# to sngl_ranking, except in the psdvar case, where it could increase.
 
 with HFile(args.trig_file, 'r') as trig_file:
     n_triggers_orig = trig_file[f'{ifo}/snr'].size
     logging.info("Trigger file has %d triggers", n_triggers_orig)
     logging.info('Generating trigger mask')
-    idx, _ = trig_file.select(
-        lambda snr: snr >= args.stat_threshold,
+    idx, _, _ = trig_file.select(
+        lambda snr, psd_var_val: (snr / psd_var_val ** 0.5) >= args.stat_threshold,
         f'{ifo}/snr',
+        f'{ifo}psd_var_val',
         return_indices=True
     )
     data_mask = np.zeros(n_triggers_orig, dtype=bool)

--- a/bin/all_sky_search/pycbc_bin_trigger_rates_dq
+++ b/bin/all_sky_search/pycbc_bin_trigger_rates_dq
@@ -59,7 +59,7 @@ with HFile(args.trig_file, 'r') as trig_file:
     logging.info("Trigger file has %d triggers", n_triggers_orig)
     logging.info('Generating trigger mask')
     idx, _ = trig_file.select(
-        lambda snr: snr > args.stat_threshold,
+        lambda snr: snr >= args.stat_threshold,
         f'{ifo}/snr',
         return_indices=True
     )
@@ -91,7 +91,7 @@ n_triggers = tmplt_ids.size
 
 logging.info("Applying %s > %.3f cut", args.sngl_ranking,
              args.stat_threshold)
-keep = stat > args.stat_threshold
+keep = stat >= args.stat_threshold
 tmplt_ids = tmplt_ids[keep]
 trig_times = trig_times[keep]
 trig_times_int = trig_times_int[keep]

--- a/bin/all_sky_search/pycbc_bin_trigger_rates_dq
+++ b/bin/all_sky_search/pycbc_bin_trigger_rates_dq
@@ -67,12 +67,20 @@ with HFile(args.trig_file, 'r') as trig_file:
     n_triggers_orig = trig_file[f'{ifo}/snr'].size
     logging.info("Trigger file has %d triggers", n_triggers_orig)
     logging.info('Generating trigger mask')
-    idx, _, _ = trig_file.select(
-        check_snr_psdvar,
-        f'{ifo}/snr',
-        f'{ifo}/psd_var_val',
-        return_indices=True
-    )
+    if f'{ifo}/psd_var_val' in trig_file:
+        idx, _, _ = trig_file.select(
+            check_snr_psdvar,
+            f'{ifo}/snr',
+            f'{ifo}/psd_var_val',
+            return_indices=True
+        )
+    else:
+        # psd_var_val may not have been calculated
+        idx, _ = trig_file.select(
+            lambda snr: snr >= args.stat_threshold,
+            f'{ifo}/snr',
+            return_indices=True
+        )
     data_mask = np.zeros(n_triggers_orig, dtype=bool)
     data_mask[idx] = True
 

--- a/bin/all_sky_search/pycbc_bin_trigger_rates_dq
+++ b/bin/all_sky_search/pycbc_bin_trigger_rates_dq
@@ -9,6 +9,7 @@ from pycbc.events import stat as pystat
 from pycbc.types.timeseries import load_timeseries
 import numpy as np
 import h5py as h5
+from pycbc.io.hdf import HFile, SingleDetTriggers
 from pycbc.version import git_verbose_msg as version
 
 parser = argparse.ArgumentParser(description=__doc__)
@@ -45,6 +46,8 @@ pystat.insert_statistic_option_group(parser,
 args = parser.parse_args()
 pycbc.init_logging(args.verbose)
 
+logging.info('Start')
+
 with h5.File(args.bank_file, 'r') as bank:
     if args.background_bins:
         logging.info('Sorting bank into bins...')
@@ -63,37 +66,46 @@ with h5.File(args.bank_file, 'r') as bank:
         locs_dict = {'all_bin': np.arange(0, len(bank['mass1'][:]), 1)}
         locs_names = ['all_bin']
 
-logging.info('Reading trigger file...')
+logging.info('Generating trigger mask')
+
 ifo = args.ifo
-with h5.File(args.trig_file, 'r') as trig_file:
-    trig_times = trig_file[ifo+'/end_time'][:]
-    trig_ids = trig_file[ifo+'/template_id'][:]
+# Setup a data mask based on SNR - the SNR will always be greater than
+# or equal to the statistic by definition
+filter_func = (lambda snr: snr > args.stat_threshold) if args.stat_threshold else None
+with HFile(args.trig_file, 'r') as trig_file:
+    idx, _ = trig_file.select(
+        filter_func,
+        f'{ifo}/snr',
+        return_indices=True
+    )
+    data_mask = np.zeros(trig_file[f'{ifo}/snr'].size, dtype=bool)
+    data_mask[idx] = True
 
-    if args.stat_threshold or args.prune_number > 0:
-        logging.info('Calculating stat and filtering...')
-        rank_method = pystat.get_statistic_from_opts(args, [ifo])
-        stat = rank_method.get_sngl_ranking(trig_file[ifo])
-        if args.stat_threshold:
-            abovethresh = stat >= args.stat_threshold
-            trig_ids = trig_ids[abovethresh]
-            trig_times = trig_times[abovethresh]
-            stat = stat[abovethresh]
-            del abovethresh
-        if args.prune_number < 1:
-            del stat
+logging.info("Getting triggers from file")
 
+trigs = SingleDetTriggers(
+    args.trig_file,
+    None,
+    None,
+    None,
+    None,
+    ifo,
+    premask=data_mask
+)
+
+tmplt_ids = trigs.template_id
+trig_times = trigs.end_time
 trig_times_int = trig_times.astype('int')
 
-dq_times = np.array([])
 dq_logl = np.array([])
+dq_times = np.array([])
 
 for filename in args.dq_file:
-    logging.info('Reading DQ file %s...', filename)
+    logging.info('Reading DQ file %s', filename)
     dq_data = load_timeseries(filename, group=args.dq_channel)
     dq_logl = np.concatenate((dq_logl, dq_data[:]))
     dq_times = np.concatenate((dq_times, dq_data.sample_times))
     del dq_data
-
 
 n_bins = args.n_time_bins
 percentiles = np.linspace(0, 100, n_bins+1)
@@ -116,12 +128,17 @@ del dq_logl
 dq_percentiles_time = dict(zip(dq_times, seconds_bin/n_bins))
 del dq_times
 
+logging.info("Placing triggers into bins")
+bin_triggers = {}
+for bin_name in locs_names:
+    bin_locs = locs_dict[bin_name]
+    bin_triggers[bin_name] = np.isin(tmplt_ids, bin_locs)
+
 if args.prune_number > 0:
     for bin_name in locs_names:
-        logging.info('Processing bin %s...', bin_name)
-        bin_locs = locs_dict[bin_name]
-        trig_times_bin = trig_times[np.isin(trig_ids, bin_locs)]
-        trig_stats_bin = stat[np.isin(trig_ids, bin_locs)]
+        logging.info('Pruning bin %s', bin_name)
+        trig_times_bin = trig_times[bin_triggers[bin_name]]
+        trig_stats_bin = stat[bin_triggers[bin_name]]
 
         for j in range(args.prune_number):
             max_stat_arg = np.argmax(trig_stats_bin)
@@ -133,7 +150,7 @@ if args.prune_number > 0:
             trig_stats_bin[remove_inbin] = 0
     keep = np.nonzero(stat)[0]
     trig_times_int = trig_times_int[keep]
-    trig_ids = trig_ids[keep]
+    tmplt_ids = tmplt_ids[keep]
     del stat
     del keep
 
@@ -141,11 +158,10 @@ del trig_times
 
 with h5.File(args.output_file, 'w') as f:
     for bin_name in locs_names:
-        bin_locs = locs_dict[bin_name]
-        trig_times_bin = trig_times_int[np.isin(trig_ids, bin_locs)]
+        trig_times_bin = trig_times_int[bin_triggers[bin_name]]
         trig_percentile = np.array([dq_percentiles_time[t]
                                     for t in trig_times_bin])
-        logging.info('Processing %d triggers...', len(trig_percentile))
+        logging.info('Processing %d triggers', len(trig_percentile))
 
         (counts, bins) = np.histogram(trig_percentile, bins=(percentiles)/100)
         counts = counts.astype('float')
@@ -155,7 +171,7 @@ with h5.File(args.output_file, 'w') as f:
         if mean_rate > 0.:
             rates = rates / mean_rate
 
-        logging.info('Writing rates to output file %s...', args.output_file)
+        logging.info('Writing rates to output file %s', args.output_file)
         grp = f.create_group(bin_name)
         grp['rates'] = rates
         grp['locs'] = locs_dict[bin_name]

--- a/bin/all_sky_search/pycbc_bin_trigger_rates_dq
+++ b/bin/all_sky_search/pycbc_bin_trigger_rates_dq
@@ -49,50 +49,53 @@ pycbc.init_logging(args.verbose)
 logging.info('Start')
 
 ifo = args.ifo
-# Setup a data mask based on SNR - the SNR will always be greater than
-# or equal to sngl-ranking by definition
+
+# Setup a data mask to remove any triggers with sngl_ranking below threshold
+
+# These are the datasets we may need to calculate sngl_ranking
+trig_stats = ['snr', 'chisq', 'chisq_dof', 'sg_chisq', 'psd_var_val']
+
+def sngl_ranking_above_threshold(*trig_vals):
+    """
+    Allow sngl_ranking to be compared to the triggers in the select function
+    """
+    # Convert the triggers into a dictionary so it can be passed straight to
+    # the ranking calculation
+    trig_dict = {k: v for k, v in zip(trig_stats, trig_vals)}
+    sngl = ranking.get_sngls_ranking_from_trigs(trig_dict, args.sngl_ranking)
+    return sngl > args.stat_threshold
+
 with HFile(args.trig_file, 'r') as trig_file:
     n_triggers_orig = trig_file[f'{ifo}/snr'].size
     logging.info("Trigger file has %d triggers", n_triggers_orig)
     logging.info('Generating trigger mask')
     idx = trig_file.select(
-        lambda snr: snr > args.stat_threshold,
-        f'{ifo}/snr',
+        sngl_ranking_above_threshold,
+        *[f'{ifo}/{trig_s}' for trig_s in trig_stats],
         indices_only=True
     )
     data_mask = np.zeros(n_triggers_orig, dtype=bool)
     data_mask[idx] = True
 
-logging.info("Getting %s triggers from file with pre-cut SNR > %.3f",
-             idx.size, args.stat_threshold)
+logging.info("Getting %s triggers from file with %s > %.3f",
+             idx.size, args.sngl_ranking, args.stat_threshold)
 
-trigs = SingleDetTriggers(
-    args.trig_file,
-    None,
-    None,
-    None,
-    None,
-    ifo,
-    premask=data_mask
-)
-
-tmplt_ids = trigs.template_id
-trig_times = trigs.end_time
+with SingleDetTriggers(
+        args.trig_file,
+        None,
+        None,
+        None,
+        None,
+        ifo,
+        premask=data_mask
+    ) as trigs:
+    # Extract the data we actually need from the data structure:
+    tmplt_ids = trigs.template_id
+    trig_times = trigs.end_time
+    stat = trigs.get_ranking(args.sngl_ranking)
 trig_times_int = trig_times.astype('int')
 
 n_triggers = tmplt_ids.size
-logging.info("%d triggers have been loaded after pre-cuts", n_triggers)
-
-logging.info("Applying %s > %.3f cut", args.sngl_ranking,
-             args.stat_threshold)
-# Calculate the sngl-ranking and apply mask based on that
-stat = ranking.get_sngls_ranking_from_trigs(trigs, args.sngl_ranking)
-keep = stat > args.stat_threshold
-tmplt_ids = tmplt_ids[keep]
-trig_times = trig_times[keep]
-trig_times_int = trig_times_int[keep]
-logging.info("Removed %d triggers, %d remain",
-             n_triggers - tmplt_ids.size, tmplt_ids.size)
 
 dq_logl = np.array([])
 dq_times = np.array([])

--- a/bin/all_sky_search/pycbc_bin_trigger_rates_dq
+++ b/bin/all_sky_search/pycbc_bin_trigger_rates_dq
@@ -54,14 +54,23 @@ ifo = args.ifo
 # This works as a pre-filter as SNR is always greater than or equal
 # to sngl_ranking, except in the psdvar case, where it could increase.
 
+def check_snr_psdvar(snr, psd_var_val):
+    """
+    Convenience function to calculate the maximum possible ranking statistic
+    value given SNR and psd variation statistic
+    """
+    rw_snr = snr / psd_var_val ** 0.5
+    rw_snr[psd_var_val == 0] = 0
+    return rw_snr >= args.stat_threshold
+
 with HFile(args.trig_file, 'r') as trig_file:
     n_triggers_orig = trig_file[f'{ifo}/snr'].size
     logging.info("Trigger file has %d triggers", n_triggers_orig)
     logging.info('Generating trigger mask')
     idx, _, _ = trig_file.select(
-        lambda snr, psd_var_val: (snr / psd_var_val ** 0.5) >= args.stat_threshold,
+        check_snr_psdvar,
         f'{ifo}/snr',
-        f'{ifo}psd_var_val',
+        f'{ifo}/psd_var_val',
         return_indices=True
     )
     data_mask = np.zeros(n_triggers_orig, dtype=bool)

--- a/bin/all_sky_search/pycbc_bin_trigger_rates_dq
+++ b/bin/all_sky_search/pycbc_bin_trigger_rates_dq
@@ -60,8 +60,8 @@ with HFile(args.trig_file, 'r') as trig_file:
     logging.info('Generating trigger mask')
     idx, _ = trig_file.select(
         lambda snr: snr > args.stat_threshold if args,
-        *[f'{ifo}/{trig_s}' for trig_s in trig_stats],
-        return_indices=True,
+        f'{ifo}/snr',
+        return_indices=True
     )
     data_mask = np.zeros(n_triggers_orig, dtype=bool)
     data_mask[idx] = True
@@ -87,15 +87,18 @@ trig_times_int = trig_times.astype('int')
 
 del trigs
 
-logging.info("Cutting triggers with --sngl-ranking below threshold")
-if not args.sngl_ranking == 'snr':
-    keep = stat > args.stat_threshold
-    tmplt_ids = tmplt_ids[keep]
-    trig_times = trig_times[keep]
-    stat = stat[keep]
-    trig_times_int = trig_times_int[keep]
-
 n_triggers = tmplt_ids.size
+
+logging.info("Applying %s > %.3f cut", args.sngl_ranking,
+        args.stat_threshold)
+# Calculate the sngl-ranking and apply mask based on that
+stat = ranking.get_sngls_ranking_from_trigs(trigs, args.sngl_ranking)
+keep = stat > args.stat_threshold
+tmplt_ids = tmplt_ids[keep]
+trig_times = trig_times[keep]
+trig_times_int = trig_times_int[keep]
+logging.info("Removed %d triggers, %d remain",
+             n_triggers - tmplt_ids.size, tmplt_ids.size)
 
 dq_logl = np.array([])
 dq_times = np.array([])

--- a/bin/all_sky_search/pycbc_bin_trigger_rates_dq
+++ b/bin/all_sky_search/pycbc_bin_trigger_rates_dq
@@ -50,7 +50,7 @@ logging.info('Start')
 
 with h5.File(args.bank_file, 'r') as bank:
     if args.background_bins:
-        logging.info('Sorting bank into bins...')
+        logging.info('Sorting bank into bins')
         data = {
             'mass1': bank['mass1'][:],
             'mass2': bank['mass2'][:],
@@ -66,22 +66,24 @@ with h5.File(args.bank_file, 'r') as bank:
         locs_dict = {'all_bin': np.arange(0, len(bank['mass1'][:]), 1)}
         locs_names = ['all_bin']
 
-logging.info('Generating trigger mask')
 
 ifo = args.ifo
 # Setup a data mask based on SNR - the SNR will always be greater than
 # or equal to sngl-ranking by definition
 with HFile(args.trig_file, 'r') as trig_file:
+    n_triggers_orig = trig_file[f'{ifo}/snr'].size
+    logging.info("Trigger file has %d triggers", n_triggers_orig)
+    logging.info('Generating trigger mask')
     idx, _ = trig_file.select(
         lambda snr: snr > args.stat_threshold,
         f'{ifo}/snr',
         return_indices=True
     )
-    data_mask = np.zeros(trig_file[f'{ifo}/snr'].size, dtype=bool)
+    data_mask = np.zeros(n_triggers_orig, dtype=bool)
     data_mask[idx] = True
 
-logging.info("Getting triggers from file with pre-cut SNR > %.3f",
-             args.stat_threshold)
+logging.info("Getting %s triggers from file with pre-cut SNR > %.3f",
+             idx.size, args.stat_threshold)
 
 trigs = SingleDetTriggers(
     args.trig_file,
@@ -108,7 +110,7 @@ keep = stat > args.stat_threshold
 tmplt_ids = tmplt_ids[keep]
 trig_times = trig_times[keep]
 trig_times_int = trig_times_int[keep]
-logging.info("Removed %d triggersi, %d remain",
+logging.info("Removed %d triggers, %d remain",
              n_triggers - tmplt_ids.size, tmplt_ids.size)
 
 dq_logl = np.array([])
@@ -163,6 +165,7 @@ if args.prune_number > 0:
             stat[remove] = 0
             trig_stats_bin[remove_inbin] = 0
     keep = np.nonzero(stat)[0]
+    logging.info("%d triggers removed through pruning", sum(keep))
     trig_times_int = trig_times_int[keep]
     tmplt_ids = tmplt_ids[keep]
     del stat
@@ -175,7 +178,8 @@ with h5.File(args.output_file, 'w') as f:
         trig_times_bin = trig_times_int[bin_triggers[bin_name]]
         trig_percentile = np.array([dq_percentiles_time[t]
                                     for t in trig_times_bin])
-        logging.info('Processing %d triggers', len(trig_percentile))
+        logging.info('Processing %d triggers in bin %s',
+                     len(trig_percentile), bin_name)
 
         (counts, bins) = np.histogram(trig_percentile, bins=(percentiles)/100)
         counts = counts.astype('float')

--- a/bin/all_sky_search/pycbc_bin_trigger_rates_dq
+++ b/bin/all_sky_search/pycbc_bin_trigger_rates_dq
@@ -59,14 +59,14 @@ with HFile(args.trig_file, 'r') as trig_file:
     logging.info("Trigger file has %d triggers", n_triggers_orig)
     logging.info('Generating trigger mask')
     idx, _ = trig_file.select(
-        lambda snr: snr > args.stat_threshold if args,
+        lambda snr: snr > args.stat_threshold,
         f'{ifo}/snr',
         return_indices=True
     )
     data_mask = np.zeros(n_triggers_orig, dtype=bool)
     data_mask[idx] = True
 
-logging.info("Getting %s triggers from file with SNR > %.3f",
+logging.info("Getting %s triggers from file with pre-cut SNR > %.3f",
              idx.size, args.stat_threshold)
 
 trigs = SingleDetTriggers(
@@ -90,9 +90,7 @@ del trigs
 n_triggers = tmplt_ids.size
 
 logging.info("Applying %s > %.3f cut", args.sngl_ranking,
-        args.stat_threshold)
-# Calculate the sngl-ranking and apply mask based on that
-stat = ranking.get_sngls_ranking_from_trigs(trigs, args.sngl_ranking)
+             args.stat_threshold)
 keep = stat > args.stat_threshold
 tmplt_ids = tmplt_ids[keep]
 trig_times = trig_times[keep]
@@ -167,7 +165,7 @@ if args.prune_number > 0:
             stat[remove] = 0
             trig_stats_bin[remove_inbin] = 0
     keep = np.flatnonzero(stat)
-    logging.info("%d triggers removed through pruning", len(keep))
+    logging.info("%d triggers removed through pruning", keep.size)
     trig_times_int = trig_times_int[keep]
     tmplt_ids = tmplt_ids[keep]
     del stat

--- a/bin/all_sky_search/pycbc_bin_trigger_rates_dq
+++ b/bin/all_sky_search/pycbc_bin_trigger_rates_dq
@@ -83,7 +83,7 @@ trigs = SingleDetTriggers(
 tmplt_ids = trigs.template_id
 trig_times = trigs.end_time
 stat = trigs.get_ranking(args.sngl_ranking)
-trig_times_int = trig_times.astype('int')
+trig_times_int = trig_times.astype(np.int64)
 
 del trigs
 
@@ -115,12 +115,12 @@ dq_percentiles = np.percentile(dq_logl, percentiles)[1:]
 
 # seconds bin tells what bin each second ends up
 seconds_bin = np.array([n_bins - np.sum(dq_percentiles >= dq_ll)
-                        for dq_ll in dq_logl]).astype('int')
+                        for dq_ll in dq_logl]).astype(np.int64)
 del dq_percentiles
 
 # bin times tells how much time ends up in each bin
 bin_times = np.array([np.sum(seconds_bin == i)
-                      for i in range(n_bins)]).astype('float')
+                      for i in range(n_bins)]).astype(np.float64)
 full_time = float(len(seconds_bin))
 times_nz = (bin_times > 0)
 del dq_logl
@@ -184,7 +184,7 @@ with h5.File(args.output_file, 'w') as f:
                      len(trig_percentile), bin_name)
 
         (counts, bins) = np.histogram(trig_percentile, bins=(percentiles)/100)
-        counts = counts.astype('float')
+        counts = counts.astype(np.float64)
         rates = np.zeros_like(bin_times)
         rates[times_nz] = counts[times_nz]/bin_times[times_nz]
         mean_rate = len(trig_percentile) / full_time

--- a/bin/all_sky_search/pycbc_bin_trigger_rates_dq
+++ b/bin/all_sky_search/pycbc_bin_trigger_rates_dq
@@ -5,7 +5,7 @@ import logging
 import argparse
 import pycbc
 import pycbc.events
-from pycbc.events import ranking, stat as pystat
+from pycbc.events import stat as pystat
 from pycbc.types.timeseries import load_timeseries
 import numpy as np
 import h5py as h5
@@ -50,50 +50,50 @@ logging.info('Start')
 
 ifo = args.ifo
 
-# Setup a data mask to remove any triggers with sngl_ranking below threshold
-
-# These are the datasets we may need to calculate sngl_ranking
-trig_stats = ['snr', 'chisq', 'chisq_dof', 'sg_chisq', 'psd_var_val']
-
-def sngl_ranking_above_threshold(*trig_vals):
-    """
-    Allow sngl_ranking to be compared to the triggers in the select function
-    """
-    # Convert the triggers into a dictionary so it can be passed straight to
-    # the ranking calculation
-    trig_dict = {k: v for k, v in zip(trig_stats, trig_vals)}
-    sngl = ranking.get_sngls_ranking_from_trigs(trig_dict, args.sngl_ranking)
-    return sngl > args.stat_threshold
+# Setup a data mask to remove any triggers with SNR below threshold
+# This works as a pre-filter as SNR is always greater than or equal
+# to sngl_ranking
 
 with HFile(args.trig_file, 'r') as trig_file:
     n_triggers_orig = trig_file[f'{ifo}/snr'].size
     logging.info("Trigger file has %d triggers", n_triggers_orig)
     logging.info('Generating trigger mask')
-    idx = trig_file.select(
-        sngl_ranking_above_threshold,
+    idx, _ = trig_file.select(
+        lambda snr: snr > args.stat_threshold if args,
         *[f'{ifo}/{trig_s}' for trig_s in trig_stats],
-        indices_only=True
+        return_indices=True,
     )
     data_mask = np.zeros(n_triggers_orig, dtype=bool)
     data_mask[idx] = True
 
-logging.info("Getting %s triggers from file with %s > %.3f",
-             idx.size, args.sngl_ranking, args.stat_threshold)
+logging.info("Getting %s triggers from file with SNR > %.3f",
+             idx.size, args.stat_threshold)
 
-with SingleDetTriggers(
-        args.trig_file,
-        None,
-        None,
-        None,
-        None,
-        ifo,
-        premask=data_mask
-    ) as trigs:
-    # Extract the data we actually need from the data structure:
-    tmplt_ids = trigs.template_id
-    trig_times = trigs.end_time
-    stat = trigs.get_ranking(args.sngl_ranking)
+trigs = SingleDetTriggers(
+    args.trig_file,
+    None,
+    None,
+    None,
+    None,
+    ifo,
+    premask=data_mask
+)
+
+# Extract the data we actually need from the data structure:
+tmplt_ids = trigs.template_id
+trig_times = trigs.end_time
+stat = trigs.get_ranking(args.sngl_ranking)
 trig_times_int = trig_times.astype('int')
+
+del trigs
+
+logging.info("Cutting triggers with --sngl-ranking below threshold")
+if not args.sngl_ranking == 'snr':
+    keep = stat > args.stat_threshold
+    tmplt_ids = tmplt_ids[keep]
+    trig_times = trig_times[keep]
+    stat = stat[keep]
+    trig_times_int = trig_times_int[keep]
 
 n_triggers = tmplt_ids.size
 
@@ -146,28 +146,25 @@ with h5.File(args.bank_file, 'r') as bank:
         locs_dict = {'all_bin': np.arange(0, len(bank['mass1'][:]), 1)}
         locs_names = ['all_bin']
 
-logging.info("Placing triggers into bins")
-bin_triggers = {}
-for bin_name in locs_names:
-    bin_locs = locs_dict[bin_name]
-    bin_triggers[bin_name] = np.isin(tmplt_ids, bin_locs)
-
 if args.prune_number > 0:
     for bin_name in locs_names:
         logging.info('Pruning bin %s', bin_name)
-        trig_times_bin = trig_times[bin_triggers[bin_name]]
-        trig_stats_bin = stat[bin_triggers[bin_name]]
+        bin_locs = locs_dict[bin_name]
+        inbin = np.isin(tmplt_ids, bin_locs)
+        trig_times_bin = trig_times[inbin]
+        trig_stats_bin = stat[inbin]
 
         for j in range(args.prune_number):
             max_stat_arg = np.argmax(trig_stats_bin)
-            remove = np.nonzero(abs(trig_times_bin[max_stat_arg] - trig_times)
-                                < args.prune_window)[0]
-            remove_inbin = np.nonzero(abs(trig_times_bin[max_stat_arg]
-                                      - trig_times_bin) < args.prune_window)[0]
+            remove = abs(trig_times_bin[max_stat_arg] - trig_times) \
+                         < args.prune_window
+            logging.info("Prune %d: pruning %d triggers", j, sum(remove))
+            remove_inbin = abs(trig_times_bin[max_stat_arg]
+                               - trig_times_bin) < args.prune_window
             stat[remove] = 0
             trig_stats_bin[remove_inbin] = 0
-    keep = np.nonzero(stat)[0]
-    logging.info("%d triggers removed through pruning", sum(keep))
+    keep = np.flatnonzero(stat)
+    logging.info("%d triggers removed through pruning", len(keep))
     trig_times_int = trig_times_int[keep]
     tmplt_ids = tmplt_ids[keep]
     del stat
@@ -177,7 +174,9 @@ del trig_times
 
 with h5.File(args.output_file, 'w') as f:
     for bin_name in locs_names:
-        trig_times_bin = trig_times_int[bin_triggers[bin_name]]
+        bin_locs = locs_dict[bin_name]
+        inbin = np.isin(tmplt_ids, bin_locs)
+        trig_times_bin = trig_times_int[inbin]
         trig_percentile = np.array([dq_percentiles_time[t]
                                     for t in trig_times_bin])
         logging.info('Processing %d triggers in bin %s',

--- a/bin/all_sky_search/pycbc_bin_trigger_rates_dq
+++ b/bin/all_sky_search/pycbc_bin_trigger_rates_dq
@@ -5,7 +5,7 @@ import logging
 import argparse
 import pycbc
 import pycbc.events
-from pycbc.events import stat as pystat
+from pycbc.events import ranking, stat as pystat
 from pycbc.types.timeseries import load_timeseries
 import numpy as np
 import h5py as h5
@@ -17,8 +17,8 @@ parser.add_argument('--version', action='version', version=version)
 parser.add_argument('--verbose', action="store_true")
 parser.add_argument("--ifo", type=str, required=True)
 parser.add_argument("--trig-file", required=True)
-parser.add_argument("--stat-threshold", type=float,
-                    help="Only consider triggers with statistic value "
+parser.add_argument("--stat-threshold", type=float, default=1.,
+                    help="Only consider triggers with --sngl-ranking value "
                     "above this threshold")
 parser.add_argument("--f-lower", type=float, default=15.,
                     help='Enforce a uniform low frequency cutoff to '
@@ -70,18 +70,18 @@ logging.info('Generating trigger mask')
 
 ifo = args.ifo
 # Setup a data mask based on SNR - the SNR will always be greater than
-# or equal to the statistic by definition
-filter_func = (lambda snr: snr > args.stat_threshold) if args.stat_threshold else None
+# or equal to sngl-ranking by definition
 with HFile(args.trig_file, 'r') as trig_file:
     idx, _ = trig_file.select(
-        filter_func,
+        lambda snr: snr > args.stat_threshold,
         f'{ifo}/snr',
         return_indices=True
     )
     data_mask = np.zeros(trig_file[f'{ifo}/snr'].size, dtype=bool)
     data_mask[idx] = True
 
-logging.info("Getting triggers from file")
+logging.info("Getting triggers from file with pre-cut SNR > %.3f",
+             args.stat_threshold)
 
 trigs = SingleDetTriggers(
     args.trig_file,
@@ -96,6 +96,20 @@ trigs = SingleDetTriggers(
 tmplt_ids = trigs.template_id
 trig_times = trigs.end_time
 trig_times_int = trig_times.astype('int')
+
+n_triggers = tmplt_ids.size
+logging.info("%d triggers are have been loaded after pre-cuts", n_triggers)
+
+logging.info("Applying %s > %.3f cut", args.sngl_ranking,
+             args.stat_threshold)
+# Calculate the sngl-ranking and apply mask based on that
+stat = ranking.get_sngls_ranking_from_trigs(trigs, args.sngl_ranking)
+keep = stat > args.stat_threshold
+tmplt_ids = tmplt_ids[keep]
+trig_times = trig_times[keep]
+trig_times_int = trig_times_int[keep]
+logging.info("Removed %d triggersi, %d remain",
+             n_triggers - tmplt_ids.size, tmplt_ids.size)
 
 dq_logl = np.array([])
 dq_times = np.array([])

--- a/pycbc/io/hdf.py
+++ b/pycbc/io/hdf.py
@@ -67,7 +67,6 @@ class HFile(h5py.File):
             data[arg] = []
 
         return_indices = kwds.get('return_indices', False)
-        indices_only = kwds.get('indices_only', False)
         indices = np.array([], dtype=np.uint64)
 
         # To conserve memory read the array in chunks
@@ -81,18 +80,15 @@ class HFile(h5py.File):
             # Read each chunk's worth of data and find where it passes the function
             partial = [refs[arg][i:r] for arg in args]
             keep = fcn(*partial)
-            if return_indices or indices_only:
+            if return_indices:
                 indices = np.concatenate([indices, np.flatnonzero(keep) + i])
 
-            if not indices_only:
-                # Store only the results that pass the function
-                for arg, part in zip(args, partial):
-                    data[arg].append(part[keep])
+            # Store only the results that pass the function
+            for arg, part in zip(args, partial):
+                data[arg].append(part[keep])
 
             i += chunksize
 
-        if indices_only:
-            return indices.astype(np.uint64)
         # Combine the partial results into full arrays
         if len(args) == 1:
             res = np.concatenate(data[args[0]])
@@ -418,7 +414,7 @@ class SingleDetTriggers(object):
             logging.info('Loading bank')
             self.bank = HFile(bank_file, 'r')
         else:
-            logging.info('No bank file given to SingleDetTriggers')
+            logging.info('No bank file given')
             # empty dict in place of non-existent hdf file
             self.bank = {}
 

--- a/pycbc/io/hdf.py
+++ b/pycbc/io/hdf.py
@@ -414,7 +414,7 @@ class SingleDetTriggers(object):
             logging.info('Loading bank')
             self.bank = HFile(bank_file, 'r')
         else:
-            logging.info('No bank file given')
+            logging.info('No bank file given to SingleDetTriggers')
             # empty dict in place of non-existent hdf file
             self.bank = {}
 

--- a/pycbc/io/hdf.py
+++ b/pycbc/io/hdf.py
@@ -84,9 +84,10 @@ class HFile(h5py.File):
             if return_indices or indices_only:
                 indices = np.concatenate([indices, np.flatnonzero(keep) + i])
 
-            # Store only the results that pass the function
-            for arg, part in zip(args, partial):
-                data[arg].append(part[keep])
+            if not indices_only:
+                # Store only the results that pass the function
+                for arg, part in zip(args, partial):
+                    data[arg].append(part[keep])
 
             i += chunksize
 

--- a/pycbc/io/hdf.py
+++ b/pycbc/io/hdf.py
@@ -67,6 +67,7 @@ class HFile(h5py.File):
             data[arg] = []
 
         return_indices = kwds.get('return_indices', False)
+        indices_only = kwds.get('indices_only', False)
         indices = np.array([], dtype=np.uint64)
 
         # To conserve memory read the array in chunks
@@ -80,7 +81,7 @@ class HFile(h5py.File):
             # Read each chunk's worth of data and find where it passes the function
             partial = [refs[arg][i:r] for arg in args]
             keep = fcn(*partial)
-            if return_indices:
+            if return_indices or indices_only:
                 indices = np.concatenate([indices, np.flatnonzero(keep) + i])
 
             # Store only the results that pass the function
@@ -89,6 +90,8 @@ class HFile(h5py.File):
 
             i += chunksize
 
+        if indices_only:
+            return indices.astype(np.uint64)
         # Combine the partial results into full arrays
         if len(args) == 1:
             res = np.concatenate(data[args[0]])


### PR DESCRIPTION
Using this meant that I was able to actually complete a run of this code using realistic analysis files!

Basically use the mechanism described in https://github.com/gwastro/pycbc/pull/4510 to pre-mask the triggers before loading, also move some repetition of the same calculation out of the loops it was repeated in.

Some increased logging as well