### PR TITLE
Fix error querying Virgo frame type

### DIFF
--- a/pycbc/frame/frame.py
+++ b/pycbc/frame/frame.py
@@ -18,6 +18,7 @@ This modules contains functions for reading in data from frame files or caches
 """
 
 import logging
+import warnings
 import os.path
 import glob
 import time
@@ -297,10 +298,9 @@ def frame_paths(
     if site is None:
         # this case is tolerated for backward compatibility
         site = frame_type[0]
-        logging.warn(
-            'Guessing the site from the frame type: %s -> %s',
-            frame_type,
-            site
+        warnings.warn(
+            f'Guessing site {site} from frame type {frame_type}',
+            DeprecationWarning
         )
     cache = find_frame_urls(site, frame_type, start_time, end_time,
                             urltype=url_type, host=server)
@@ -341,10 +341,9 @@ def get_site_from_type_or_channel(frame_type, channels):
     m = re.match(site_re, chan)
     if m:
         return m.groups(1)[0], frame_type
-    logging.warn(
-        'Guessing the site from the frame type: %s -> %s',
-        frame_type,
-        frame_type[0]
+    warnings.warn(
+        f'Guessing site {frame_type[0]} from frame type {frame_type}',
+        DeprecationWarning
     )
     return frame_type[0], frame_type
 

--- a/pycbc/frame/frame.py
+++ b/pycbc/frame/frame.py
@@ -349,7 +349,7 @@ def query_and_read_frame(frame_type, channels, start_time, end_time,
     # Figure out the site by assuming that the channel name starts with it.
     # In case of a list of channels, assume the first channel starts with
     # the right site.
-    if instance(channels, list):
+    if isinstance(channels, list):
         site = channels[0][0]
     else:
         site = channels[0]

--- a/pycbc/frame/frame.py
+++ b/pycbc/frame/frame.py
@@ -301,7 +301,7 @@ def query_and_read_frame(frame_type, channels, start_time, end_time,
                          sieve=None, check_integrity=False):
     """Read time series from frame data.
 
-    Query for the locatin of physical frames matching the frame type. Return
+    Query for the location of physical frames matching the frame type. Return
     a time series containing the channel between the given start and end times.
 
     Parameters

--- a/pycbc/strain/strain.py
+++ b/pycbc/strain/strain.py
@@ -504,8 +504,10 @@ def insert_strain_option_group(parser, gps_times=True):
     # Use datafind to get frame files
     data_reading_group.add_argument("--frame-type",
                             type=str,
+                            metavar="S:TYPE",
                             help="(optional), replaces frame-files. Use datafind "
-                                 "to get the needed frame file(s) of this type.")
+                                 "to get the needed frame file(s) of this type "
+                                 "from site S.")
     # Filter frame files by URL
     data_reading_group.add_argument("--frame-sieve",
                             type=str,
@@ -704,7 +706,7 @@ def insert_strain_option_group_multi_ifo(parser, gps_times=True):
                             help="Store of time series data in hdf format")
     # Use datafind to get frame files
     data_reading_group_multi.add_argument("--frame-type", type=str, nargs="+",
-                                    action=MultiDetOptionAction,
+                                    action=MultiDetOptionActionSpecial,
                                     metavar='IFO:FRAME_TYPE',
                                     help="(optional) Replaces frame-files. "
                                          "Use datafind to get the needed frame "

--- a/pycbc/strain/strain.py
+++ b/pycbc/strain/strain.py
@@ -1975,9 +1975,12 @@ class StrainBuffer(pycbc.frame.DataBuffer):
             idq_state_channel = ':'.join([ifo, args.idq_state_channel[ifo]])
 
         if args.frame_type:
-            frame_src = pycbc.frame.frame_paths(args.frame_type[ifo],
-                                                args.start_time,
-                                                args.end_time)
+            frame_src = pycbc.frame.frame_paths(
+                args.frame_type[ifo],
+                args.start_time,
+                args.end_time,
+                site=ifo[0]
+            )
         else:
             frame_src = [args.frame_src[ifo]]
         strain_channel = ':'.join([ifo, args.channel_name[ifo]])


### PR DESCRIPTION
When using gwdatafind to query for a given frame type and channel name, the pycbc.frame module assumes that the frame type starts with the letter identifying the site (H, L, V etc). However it appears that this assumption is not always valid: for example, recent Virgo data seems to have changed the frame type to HoftOnline, making it impossible to use `query_and_read_frame()` to retrieve Virgo data.

This PR changes `query_and_read_frame()` so that the frame type (and therefore the `--frame-type` CLI option) is allowed to have a "S:" or "S?:" prefix, in which case S is taken as the site. For backward compatibility, this prefix can be omitted, in which case the site will be taken from the channel name instead. If that also does not start with the right prefix, the code prints a warning and takes the site from the first letter of the frame type, as it did in the past (and this will not work for Virgo O4 data).