### PR TITLE
Don't overwrite default numpy bindings from liglow in record.io

### DIFF
--- a/pycbc/io/record.py
+++ b/pycbc/io/record.py
@@ -46,7 +46,11 @@ _numpy_function_lib = {_x: _y for _x,_y in numpy.__dict__.items()
 # =============================================================================
 #
 # add ligolw_types to numpy sctypeDict
-numpy.sctypeDict.update(ligolw_types.ToNumPyType)
+# but don't including float -> float32 and int -> int32 bindings, so as not
+# to change numpy defaults
+numpy.sctypeDict.update({_k: _val
+                         for (_k, _val) in ligolw_types.ToNumPyType.items()
+                         if _k != 'float' and _k != 'int'})
 
 # Annoyingly, numpy has no way to store NaNs in an integer field to indicate
 # the equivalent of None. This can be problematic for fields that store ids:

--- a/pycbc/io/record.py
+++ b/pycbc/io/record.py
@@ -46,11 +46,10 @@ _numpy_function_lib = {_x: _y for _x,_y in numpy.__dict__.items()
 # =============================================================================
 #
 # add ligolw_types to numpy sctypeDict
-# but don't including float -> float32 and int -> int32 bindings, so as not
-# to change numpy defaults
+# but don't include bindings that numpy already defines
 numpy.sctypeDict.update({_k: _val
                          for (_k, _val) in ligolw_types.ToNumPyType.items()
-                         if _k != 'float' and _k != 'int'})
+                         if _k not in numpy.sctypeDict})
 
 # Annoyingly, numpy has no way to store NaNs in an integer field to indicate
 # the equivalent of None. This can be problematic for fields that store ids:


### PR DESCRIPTION
Currently, if you import the record module in `pycbc.io`, it will cause numpy to start casting `float` and `int` to `float32` and `int32` respectively. The default in numpy is to cast `float` and `int` to 64 bit scalars. The cause of this is due to the numpy `scTypeDict` being updated with ligolw bindings in `record.py`. In ligolw, `float` is cast to `float32` and `int` to `int32`.  This patch fixes that by not including the `float` and `int` mappings from ligolw. This will cause single precision values to be cast to double when reading a ligolw xml file, but that should only result in some meaningless extra digits being added to values.