### PR TITLE
v23_RELEASE_BRANCH: Use lalsim for TD_from_FD

### DIFF
--- a/pycbc/waveform/waveform.py
+++ b/pycbc/waveform/waveform.py
@@ -1160,7 +1160,7 @@ def td_fd_waveform_transform(approximant):
         # We can also make a td version of this
         # This will override any existing approximants with the same name
         # (ex. IMRPhenomXX)
-        cpu_td[approximant] = get_td_waveform_from_fd
+        # cpu_td[approximant] = get_td_waveform_from_fd
 
 for apx in copy.copy(_filter_time_lengths):
     td_fd_waveform_transform(apx)


### PR DESCRIPTION
For consistency with other groups, on the v23 release branch (and only on this branch) we change the lalsimulation interface to use lalsimulation directly for "TD_from_FD" waveforms. Normally on PyCBC we generate the FD waveform and condition ourselves.

Noting that a discussion at the lalsimulation level of how to do this "right" and consistently between different waveform models (especially consistency between directly-TD models and TD_from_FD models) is probably needed, in particular when higher-order modes is in play.