### PR TITLE
Adding functionalities to create calibration config files

### DIFF
--- a/bin/inference/pycbc_inference_create_calibration_config
+++ b/bin/inference/pycbc_inference_create_calibration_config
@@ -57,14 +57,20 @@ parser.add_argument('-n_nodes', '--n-nodes',
                     help='Number of frequency nodes to be used',
                     default=10, type=int)
 
-args = parser.parse_args()
-calib_env_path = args.calib_env_path
-detector_list = args.detectors
-min_freq_list = args.min_freq_list
-max_freq_list = args.max_freq_list
-gps_time = args.gps_time
-plots_dir = args.plots_dir
-n_nodes = args.n_nodes
+parser.add_argument('-plot-sanity-checks', help='Make some plots for sanity checks',
+                    default=True, type=bool)
+
+# parse the command line
+opts = parser.parse_args()
+
+#args = parser.parse_args()
+#calib_env_path = args.calib_env_path
+#detector_list = args.detectors
+#min_freq_list = args.min_freq_list
+#max_freq_list = args.max_freq_list
+#gps_time = args.gps_time
+#plots_dir = args.plots_dir
+#n_nodes = args.n_nodes
 
 input_dict = {}
 for ii in range(len(detector_list)):
@@ -140,42 +146,43 @@ else:
     print('Calibration file already present. Either delete it or rename it. Overwriting this file is not allowed!!!')
 
 # Sanity check
-for detector in detector_list:
-    calib_env_path = input_dict['calib_env_path_%s'%detector.lower()]
-    min_freq = input_dict['min_freq_%s'%detector.lower()]
-    max_freq = input_dict['max_freq_%s'%detector.lower()]
-    log_nodes = prior_dict['log_nodes_%s'%detector.lower()]
-    amp_mean_nodes = prior_dict['amplitude_mean_nodes_%s'%detector.lower()]
-    amp_sigma_nodes = prior_dict['amplitude_sigma_nodes_%s'%detector.lower()]
-    plt.figure(figsize=(8,5))
-    plt.plot(f1[calib_env_path][:][:,0],f1[calib_env_path][:][:,1],label=r'$\mu$')
-    plt.plot(f1[calib_env_path][:][:,0],f1[calib_env_path][:][:,3],label=r'$\mu-\sigma$')
-    plt.plot(f1[calib_env_path][:][:,0],f1[calib_env_path][:][:,5],label=r'$\mu+\sigma$')
-    plt.plot(np.exp(log_nodes),amp_mean_nodes+1,'.',label=r'$\mu$(Prior)')
-    plt.plot(np.exp(log_nodes),amp_mean_nodes+1-amp_sigma_nodes,'.',label=r'$\mu-\sigma$ (Prior)')
-    plt.plot(np.exp(log_nodes),amp_mean_nodes+1+amp_sigma_nodes,'.',label=r'$\mu+\sigma$ (Prior)')
-    plt.xscale('log')
-    plt.xlabel('Frequency (Hz)')
-    plt.ylabel('Amplitude')
-    plt.title('Calibration envelop (Amplitude) for %s'%detector.upper())
-    plt.legend()
-    plt.savefig('%s/calibration_envelop_amplitude_%s_%s.png'%(plots_dir,tag,detector.upper()))
-    plt.clf()
+if opts.plot_sanity_checks:
+    for detector in detector_list:
+        calib_env_path = input_dict['calib_env_path_%s'%detector.lower()]
+        min_freq = input_dict['min_freq_%s'%detector.lower()]
+        max_freq = input_dict['max_freq_%s'%detector.lower()]
+        log_nodes = prior_dict['log_nodes_%s'%detector.lower()]
+        amp_mean_nodes = prior_dict['amplitude_mean_nodes_%s'%detector.lower()]
+        amp_sigma_nodes = prior_dict['amplitude_sigma_nodes_%s'%detector.lower()]
+        plt.figure(figsize=(8,5))
+        plt.plot(f1[calib_env_path][:][:,0],f1[calib_env_path][:][:,1],label=r'$\mu$')
+        plt.plot(f1[calib_env_path][:][:,0],f1[calib_env_path][:][:,3],label=r'$\mu-\sigma$')
+        plt.plot(f1[calib_env_path][:][:,0],f1[calib_env_path][:][:,5],label=r'$\mu+\sigma$')
+        plt.plot(np.exp(log_nodes),amp_mean_nodes+1,'.',label=r'$\mu$(Prior)')
+        plt.plot(np.exp(log_nodes),amp_mean_nodes+1-amp_sigma_nodes,'.',label=r'$\mu-\sigma$ (Prior)')
+        plt.plot(np.exp(log_nodes),amp_mean_nodes+1+amp_sigma_nodes,'.',label=r'$\mu+\sigma$ (Prior)')
+        plt.xscale('log')
+        plt.xlabel('Frequency (Hz)')
+        plt.ylabel('Amplitude')
+        plt.title('Calibration envelop (Amplitude) for %s'%detector.upper())
+        plt.legend()
+        plt.savefig('%s/calibration_envelop_amplitude_%s_%s.png'%(plots_dir,tag,detector.upper()))
+        plt.clf()
 
-    phase_mean_nodes = prior_dict['phase_mean_nodes_%s'%detector.lower()]
-    phase_sigma_nodes = prior_dict['phase_sigma_nodes_%s'%detector.lower()]
-    plt.figure(figsize=(8,5))
-    plt.plot(f1[calib_env_path][:][:,0],f1[calib_env_path][:][:,2],label=r'$\mu$')
-    plt.plot(f1[calib_env_path][:][:,0],f1[calib_env_path][:][:,4],label=r'$\mu-\sigma$')
-    plt.plot(f1[calib_env_path][:][:,0],f1[calib_env_path][:][:,6],label=r'$\mu+\sigma$')
-    plt.plot(np.exp(log_nodes),phase_mean_nodes,'.',label=r'$\mu$ (Prior)')
-    plt.plot(np.exp(log_nodes),phase_mean_nodes-phase_sigma_nodes,'.',label=r'$\mu-\sigma$ (Prior)')
-    plt.plot(np.exp(log_nodes),phase_mean_nodes+phase_sigma_nodes,'.',label=r'$\mu+\sigma$')
-    plt.xscale('log')
-    plt.xlabel('Frequency (Hz)')
-    plt.ylabel('Phase')
-    plt.title('Calibration envelop (Phase) for %s'%detector.upper())
-    plt.legend()
-    plt.savefig('%s/calibration_envelop_phase_%s_%s.png'%(plots_dir,tag,detector.upper()))
-    plt.clf()
+        phase_mean_nodes = prior_dict['phase_mean_nodes_%s'%detector.lower()]
+        phase_sigma_nodes = prior_dict['phase_sigma_nodes_%s'%detector.lower()]
+        plt.figure(figsize=(8,5))
+        plt.plot(f1[calib_env_path][:][:,0],f1[calib_env_path][:][:,2],label=r'$\mu$')
+        plt.plot(f1[calib_env_path][:][:,0],f1[calib_env_path][:][:,4],label=r'$\mu-\sigma$')
+        plt.plot(f1[calib_env_path][:][:,0],f1[calib_env_path][:][:,6],label=r'$\mu+\sigma$')
+        plt.plot(np.exp(log_nodes),phase_mean_nodes,'.',label=r'$\mu$ (Prior)')
+        plt.plot(np.exp(log_nodes),phase_mean_nodes-phase_sigma_nodes,'.',label=r'$\mu-\sigma$ (Prior)')
+        plt.plot(np.exp(log_nodes),phase_mean_nodes+phase_sigma_nodes,'.',label=r'$\mu+\sigma$')
+        plt.xscale('log')
+        plt.xlabel('Frequency (Hz)')
+        plt.ylabel('Phase')
+        plt.title('Calibration envelop (Phase) for %s'%detector.upper())
+        plt.legend()
+        plt.savefig('%s/calibration_envelop_phase_%s_%s.png'%(plots_dir,tag,detector.upper()))
+        plt.clf()
 

--- a/bin/inference/pycbc_inference_create_calibration_config
+++ b/bin/inference/pycbc_inference_create_calibration_config
@@ -28,36 +28,40 @@ import matplotlib.pyplot as plt
 parser = argparse.ArgumentParser()
 
 
-parser.add_argument('-calibration_file_path', '--calibration-file-path',
+parser.add_argument('--calibration-files-path',
                     help='Calibration envelope file path. It can be pre-
                           downloaded or downloaded on the fly', required=True,
                     type=str)
-parser.add_argument('-detectors', '--detectors',  nargs='+',
+parser.add_argument('--detectors',  nargs='+',
                     help='List of detectors', required=True,
                     type=str)
 
-parser.add_argument('-min_freq_list', '--min-freq-list', nargs='+',
+parser.add_argument('--min-freq-list', nargs='+',
                     help='List of minimum frequencies for each detector',
                     required=True, type=float)
 
-parser.add_argument('-max_freq_list', '--max-freq-list', nargs='+',
+parser.add_argument('--max-freq-list', nargs='+',
                     help='List of maximum frequencies for each detector',
                     required=True, type=float)
 
-parser.add_argument('-gps_time', '--gps-time',
+parser.add_argument('--gps-time',
                     help='GPS time at which calibration configuration files 
                           are needed',
                     required=True, type=str)
 
-parser.add_argument('-plots_dir', '--plots-dir',
+parser.add_argument('--output-dir',                                 
+                    help="Path for the output calibration config files",                    
+                    default='.', type=str)
+
+parser.add_argument('--plots-dir',
                     help="Path for the 'sanity check' plots",
                     default='.', type=str)
 
-parser.add_argument('-n_nodes', '--n-nodes',
+parser.add_argument('--n-nodes',
                     help='Number of frequency nodes to be used',
                     default=10, type=int)
 
-parser.add_argument('-plot-sanity-checks', help='Make some plots for sanity checks',
+parser.add_argument('--plot-sanity-checks', help='Make some plots for sanity checks',
                     default=True, type=bool)
 
 # parse the command line
@@ -78,6 +82,10 @@ for ii in range(len(detector_list)):
     input_dict['min_freq_%s'%detector]=min_freq_list[ii]
     input_dict['max_freq_%s'%detector]=max_freq_list[ii]
 
+# Upper and Lower indices of detectors seems unnecessary
+# but they are there to make sure the correct convention
+# is followed for recalibration module in inference config
+# file as well as in detector notation.
 prior_dict = {}
 for detector in detector_list:
     detector = detector.lower()
@@ -95,7 +103,7 @@ for detector in detector_list:
     print('Done for detector %s'%detector)
 
 
-calibration_filename = 'calibration-%s.ini'%tag
+calibration_filename = '%s/calibration-%s.ini'%(output_dir, tag)
 if os.path.isfile(calibration_filename) != True:
     text_file = open(calibration_filename, "w")
     text_file.write("# Details of set up as given in the O1 Binary Black Hole Paper https://arxiv.org/abs/1606.04856 \n")
@@ -145,7 +153,7 @@ if os.path.isfile(calibration_filename) != True:
 else:
     print('Calibration file already present. Either delete it or rename it. Overwriting this file is not allowed!!!')
 
-# Sanity check
+# Sanity check plots
 if opts.plot_sanity_checks:
     for detector in detector_list:
         calib_env_path = input_dict['calib_env_path_%s'%detector.lower()]

--- a/bin/inference/pycbc_inference_create_calibration_config
+++ b/bin/inference/pycbc_inference_create_calibration_config
@@ -1,0 +1,181 @@
+#!/usr/bin/env python
+
+# Copyright (C) 2023 Sumit K.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+"""Generate the calibration configuration file for a given event/GPS time.
+Also plots the calibration envelop for each detector for sanity checks.
+"""
+
+import h5py, os, argparse
+import numpy as np
+from scipy.interpolate import InterpolatedUnivariateSpline
+import matplotlib.pyplot as plt
+
+parser = argparse.ArgumentParser()
+
+
+parser.add_argument('-calibration_file_path', '--calibration-file-path',
+                    help='Calibration envelope file path. It can be pre-
+                          downloaded or downloaded on the fly', required=True,
+                    type=str)
+parser.add_argument('-detectors', '--detectors',  nargs='+',
+                    help='List of detectors', required=True,
+                    type=str)
+
+parser.add_argument('-min_freq_list', '--min-freq-list', nargs='+',
+                    help='List of minimum frequencies for each detector',
+                    required=True, type=float)
+
+parser.add_argument('-max_freq_list', '--max-freq-list', nargs='+',
+                    help='List of maximum frequencies for each detector',
+                    required=True, type=float)
+
+parser.add_argument('-gps_time', '--gps-time',
+                    help='GPS time at which calibration configuration files 
+                          are needed',
+                    required=True, type=str)
+
+parser.add_argument('-plots_dir', '--plots-dir',
+                    help="Path for the 'sanity check' plots",
+                    default='.', type=str)
+
+parser.add_argument('-n_nodes', '--n-nodes',
+                    help='Number of frequency nodes to be used',
+                    default=10, type=int)
+
+args = parser.parse_args()
+calib_env_path = args.calib_env_path
+detector_list = args.detectors
+min_freq_list = args.min_freq_list
+max_freq_list = args.max_freq_list
+gps_time = args.gps_time
+plots_dir = args.plots_dir
+n_nodes = args.n_nodes
+
+input_dict = {}
+for ii in range(len(detector_list)):
+    detector = str(detector_list[ii]).lower()
+    input_dict['min_freq_%s'%detector]=min_freq_list[ii]
+    input_dict['max_freq_%s'%detector]=max_freq_list[ii]
+
+prior_dict = {}
+for detector in detector_list:
+    detector = detector.lower()
+    min_freq = input_dict['min_freq_%s'%detector]
+    max_freq = input_dict['max_freq_%s'%detector]
+    calib_env_path = input_dict['calib_env_path_%s'%detector]
+    log_nodes, amplitude_mean_nodes, amplitude_sigma_nodes, phase_mean_nodes, phase_sigma_nodes = \
+               read_from_envelop_file(calib_env_path, min_freq,
+                                      max_freq, n_nodes, detector.upper())
+    prior_dict['log_nodes_%s'%detector] = log_nodes
+    prior_dict['amplitude_mean_nodes_%s'%detector] = amplitude_mean_nodes
+    prior_dict['amplitude_sigma_nodes_%s'%detector] = amplitude_sigma_nodes
+    prior_dict['phase_mean_nodes_%s'%detector] = phase_mean_nodes
+    prior_dict['phase_sigma_nodes_%s'%detector] =phase_sigma_nodes
+    print('Done for detector %s'%detector)
+
+
+calibration_filename = 'calibration-%s.ini'%tag
+if os.path.isfile(calibration_filename) != True:
+    text_file = open(calibration_filename, "w")
+    text_file.write("# Details of set up as given in the O1 Binary Black Hole Paper https://arxiv.org/abs/1606.04856 \n")
+    text_file.write("[calibration] \n")
+    for detector in detector_list:
+        detector = detector.lower()
+        min_freq = input_dict['min_freq_%s'%detector]
+        max_freq = input_dict['max_freq_%s'%detector]
+        text_file.write("%s_model = cubic_spline \n"%detector)
+        text_file.write("%s_minimum_frequency = %d \n"%(detector,min_freq))
+        text_file.write("%s_maximum_frequency = %d \n"%(detector,max_freq))
+        text_file.write("%s_n_points = %d \n"%(detector,n_nodes))
+    text_file.write(" \n")
+    text_file.write("[variable_params] \n")
+    #for ii in range(n_nodes):
+    for detector in detector_list:
+        for ii in range(n_nodes):
+            detector = detector.lower()
+            text_file.write("recalib_amplitude_%s_%d = \n"%(detector,ii))
+            text_file.write("recalib_phase_%s_%d = \n"%(detector,ii))
+    text_file.write(" \n")
+   #for ii in range(n_nodes):
+    for detector in detector_list:
+        for ii in range(n_nodes):
+            detector = detector.lower()
+            amplitude_mean_nodes_l1 = prior_dict['amplitude_mean_nodes_%s'%detector][ii]
+            amplitude_sigma_nodes_l1 = prior_dict['amplitude_sigma_nodes_%s'%detector][ii]
+            text_file.write("[prior-recalib_amplitude_%s_%d] \n"%(detector,ii))
+            text_file.write("name = gaussian \n")
+            text_file.write("recalib_amplitude_%s_%d_mean = %.3g \n"%(detector,ii,amplitude_mean_nodes_l1))
+            text_file.write("recalib_amplitude_%s_%d_var = %.3g \n"%(detector,ii,amplitude_sigma_nodes_l1**2))
+            text_file.write(" \n")
+    #for ii in range(n_nodes):
+    for detector in detector_list:
+        for ii in range(n_nodes):
+            detector = detector.lower()
+            phase_mean_nodes_l1 = prior_dict['phase_mean_nodes_%s'%detector][ii]
+            phase_sigma_nodes_l1 = prior_dict['phase_sigma_nodes_%s'%detector][ii]
+            text_file.write("[prior-recalib_phase_%s_%d] \n"%(detector,ii))
+            text_file.write("name = gaussian \n")
+            text_file.write("recalib_phase_%s_%d_mean = %.3g \n"%(detector,ii,phase_mean_nodes_l1))
+            text_file.write("recalib_phase_%s_%d_var = %.3g \n"%(detector,ii,phase_sigma_nodes_l1**2))
+            text_file.write(" \n")
+    text_file.write(" \n")
+    text_file.write(" \n")
+    text_file.close()
+else:
+    print('Calibration file already present. Either delete it or rename it. Overwriting this file is not allowed!!!')
+
+# Sanity check
+for detector in detector_list:
+    calib_env_path = input_dict['calib_env_path_%s'%detector.lower()]
+    min_freq = input_dict['min_freq_%s'%detector.lower()]
+    max_freq = input_dict['max_freq_%s'%detector.lower()]
+    log_nodes = prior_dict['log_nodes_%s'%detector.lower()]
+    amp_mean_nodes = prior_dict['amplitude_mean_nodes_%s'%detector.lower()]
+    amp_sigma_nodes = prior_dict['amplitude_sigma_nodes_%s'%detector.lower()]
+    plt.figure(figsize=(8,5))
+    plt.plot(f1[calib_env_path][:][:,0],f1[calib_env_path][:][:,1],label=r'$\mu$')
+    plt.plot(f1[calib_env_path][:][:,0],f1[calib_env_path][:][:,3],label=r'$\mu-\sigma$')
+    plt.plot(f1[calib_env_path][:][:,0],f1[calib_env_path][:][:,5],label=r'$\mu+\sigma$')
+    plt.plot(np.exp(log_nodes),amp_mean_nodes+1,'.',label=r'$\mu$(Prior)')
+    plt.plot(np.exp(log_nodes),amp_mean_nodes+1-amp_sigma_nodes,'.',label=r'$\mu-\sigma$ (Prior)')
+    plt.plot(np.exp(log_nodes),amp_mean_nodes+1+amp_sigma_nodes,'.',label=r'$\mu+\sigma$ (Prior)')
+    plt.xscale('log')
+    plt.xlabel('Frequency (Hz)')
+    plt.ylabel('Amplitude')
+    plt.title('Calibration envelop (Amplitude) for %s'%detector.upper())
+    plt.legend()
+    plt.savefig('%s/calibration_envelop_amplitude_%s_%s.png'%(plots_dir,tag,detector.upper()))
+    plt.clf()
+
+    phase_mean_nodes = prior_dict['phase_mean_nodes_%s'%detector.lower()]
+    phase_sigma_nodes = prior_dict['phase_sigma_nodes_%s'%detector.lower()]
+    plt.figure(figsize=(8,5))
+    plt.plot(f1[calib_env_path][:][:,0],f1[calib_env_path][:][:,2],label=r'$\mu$')
+    plt.plot(f1[calib_env_path][:][:,0],f1[calib_env_path][:][:,4],label=r'$\mu-\sigma$')
+    plt.plot(f1[calib_env_path][:][:,0],f1[calib_env_path][:][:,6],label=r'$\mu+\sigma$')
+    plt.plot(np.exp(log_nodes),phase_mean_nodes,'.',label=r'$\mu$ (Prior)')
+    plt.plot(np.exp(log_nodes),phase_mean_nodes-phase_sigma_nodes,'.',label=r'$\mu-\sigma$ (Prior)')
+    plt.plot(np.exp(log_nodes),phase_mean_nodes+phase_sigma_nodes,'.',label=r'$\mu+\sigma$')
+    plt.xscale('log')
+    plt.xlabel('Frequency (Hz)')
+    plt.ylabel('Phase')
+    plt.title('Calibration envelop (Phase) for %s'%detector.upper())
+    plt.legend()
+    plt.savefig('%s/calibration_envelop_phase_%s_%s.png'%(plots_dir,tag,detector.upper()))
+    plt.clf()
+

--- a/bin/inference/pycbc_inference_create_calibration_config
+++ b/bin/inference/pycbc_inference_create_calibration_config
@@ -32,10 +32,11 @@ from pycbc.strain.recalibrate import get_calibration_files_O1_O2_O3, read_calibr
 parser = argparse.ArgumentParser()
 
 # command line usage
-parser = argparse.ArgumentParser(
-            usage="pycbc_inference_create_calibration_config [--options]",
-            description="Generate the calibration configuration files "
-                        "to be used woth pycbc_inference.")
+#parser = argparse.ArgumentParser(
+#            usage="pycbc_inference_create_calibration_config [--options]",
+#            description="Generate the calibration configuration files "
+#                        "to be used woth pycbc_inference.")
+
 pycbc.add_common_pycbc_options(parser)
 
 parser.add_argument('--calibration-files-path',

--- a/bin/inference/pycbc_inference_create_calibration_config
+++ b/bin/inference/pycbc_inference_create_calibration_config
@@ -25,28 +25,43 @@ import numpy as np
 from scipy.interpolate import InterpolatedUnivariateSpline
 import matplotlib.pyplot as plt
 
+import pycbc
+from pycbc.types import MultiDetOptionAction
+
 parser = argparse.ArgumentParser()
 
 
 parser.add_argument('--calibration-files-path',
-                    help='Calibration envelope file path. It can be pre-
-                          downloaded or downloaded on the fly', required=True,
-                    type=str)
-parser.add_argument('--detectors',  nargs='+',
-                    help='List of detectors', required=True,
+                    help='Calibration envelope file path. It can be pre-'
+                          'downloaded or downloaded on the fly', required=True,
                     type=str)
 
-parser.add_argument('--min-freq-list', nargs='+',
-                    help='List of minimum frequencies for each detector',
-                    required=True, type=float)
+parser.add_argument('--ifos', nargs='+',
+                        help='Specify ifos for the analysis')
 
-parser.add_argument('--max-freq-list', nargs='+',
-                    help='List of maximum frequencies for each detector',
-                    required=True, type=float)
+#parser.add_argument('--detectors',  nargs='+',
+#                    help='List of detectors', required=True,
+#                    type=str)
+
+parser.add_argument('--minimum-frequency-list', nargs='+', action=MultiDetOptionAction,
+                        metavar='DETECTOR:COLUMN',
+                        help='For each detector, provide minimum frequency for'
+                        'the analysis. The minimum frequency should be higher than'
+                        'the minimum frequency in calibration envelop file so that'
+                        'we do not extrapolate.')
+
+
+parser.add_argument('--maximum-frequency-list', nargs='+', action=MultiDetOptionAction,
+                        metavar='DETECTOR:COLUMN',
+                        help='For each detector, provide maximum frequency for'
+                        'the analysis. The minimum frequency should be lower than'
+                        'the maximum frequency in calibration envelop file so that'
+                        'we do not extrapolate.')
+
 
 parser.add_argument('--gps-time',
-                    help='GPS time at which calibration configuration files 
-                          are needed',
+                    help='GPS time at which calibration configuration files'
+                          'are needed',
                     required=True, type=str)
 
 parser.add_argument('--output-dir',                                 
@@ -61,6 +76,11 @@ parser.add_argument('--n-nodes',
                     help='Number of frequency nodes to be used',
                     default=10, type=int)
 
+parser.add_argument('--correction-type', nargs='+', action=MultiDetOptionAction, 
+                    metavar='DETECTOR:COLUMN',
+                    help="Provide the correction type for each detector",
+                    required=True)
+
 parser.add_argument('--plot-sanity-checks', help='Make some plots for sanity checks',
                     default=True, type=bool)
 
@@ -68,39 +88,39 @@ parser.add_argument('--plot-sanity-checks', help='Make some plots for sanity che
 opts = parser.parse_args()
 
 #args = parser.parse_args()
-#calib_env_path = args.calib_env_path
+calib_env_path = opts.calibration_files_path
 #detector_list = args.detectors
-#min_freq_list = args.min_freq_list
-#max_freq_list = args.max_freq_list
-#gps_time = args.gps_time
-#plots_dir = args.plots_dir
-#n_nodes = args.n_nodes
+min_freq_list = opts.minimum_frequency_list
+max_freq_list = opts.maximum_frequency_list
+gps_time = opts.gps_time
+plots_dir = opts.plots_dir
+n_nodes = opts.n_nodes
 
 input_dict = {}
-for ii in range(len(detector_list)):
-    detector = str(detector_list[ii]).lower()
-    input_dict['min_freq_%s'%detector]=min_freq_list[ii]
-    input_dict['max_freq_%s'%detector]=max_freq_list[ii]
+for ii in range(len(opts.ifos)):
+    ifo = str(opts.ifos[ii]).lower()
+    input_dict['min_freq_%s'%ifo]=min_freq_list[ii]
+    input_dict['max_freq_%s'%ifo]=max_freq_list[ii]
 
 # Upper and Lower indices of detectors seems unnecessary
 # but they are there to make sure the correct convention
 # is followed for recalibration module in inference config
 # file as well as in detector notation.
 prior_dict = {}
-for detector in detector_list:
-    detector = detector.lower()
-    min_freq = input_dict['min_freq_%s'%detector]
-    max_freq = input_dict['max_freq_%s'%detector]
-    calib_env_path = input_dict['calib_env_path_%s'%detector]
+for ifo in opts.ifos:
+    ifo = ifo.lower()
+    min_freq = input_dict['min_freq_%s'%ifo]
+    max_freq = input_dict['max_freq_%s'%ifo]
+    calib_env_path = input_dict['calib_env_path_%s'%ifo]
     log_nodes, amplitude_mean_nodes, amplitude_sigma_nodes, phase_mean_nodes, phase_sigma_nodes = \
                read_from_envelop_file(calib_env_path, min_freq,
-                                      max_freq, n_nodes, detector.upper())
-    prior_dict['log_nodes_%s'%detector] = log_nodes
-    prior_dict['amplitude_mean_nodes_%s'%detector] = amplitude_mean_nodes
-    prior_dict['amplitude_sigma_nodes_%s'%detector] = amplitude_sigma_nodes
-    prior_dict['phase_mean_nodes_%s'%detector] = phase_mean_nodes
-    prior_dict['phase_sigma_nodes_%s'%detector] =phase_sigma_nodes
-    print('Done for detector %s'%detector)
+                                      max_freq, n_nodes, ifo.upper())
+    prior_dict['log_nodes_%s'%ifo] = log_nodes
+    prior_dict['amplitude_mean_nodes_%s'%ifo] = amplitude_mean_nodes
+    prior_dict['amplitude_sigma_nodes_%s'%ifo] = amplitude_sigma_nodes
+    prior_dict['phase_mean_nodes_%s'%ifo] = phase_mean_nodes
+    prior_dict['phase_sigma_nodes_%s'%ifo] =phase_sigma_nodes
+    print('Done for detector %s'%ifo)
 
 
 calibration_filename = '%s/calibration-%s.ini'%(output_dir, tag)
@@ -108,44 +128,44 @@ if os.path.isfile(calibration_filename) != True:
     text_file = open(calibration_filename, "w")
     text_file.write("# Details of set up as given in the O1 Binary Black Hole Paper https://arxiv.org/abs/1606.04856 \n")
     text_file.write("[calibration] \n")
-    for detector in detector_list:
-        detector = detector.lower()
-        min_freq = input_dict['min_freq_%s'%detector]
-        max_freq = input_dict['max_freq_%s'%detector]
-        text_file.write("%s_model = cubic_spline \n"%detector)
-        text_file.write("%s_minimum_frequency = %d \n"%(detector,min_freq))
-        text_file.write("%s_maximum_frequency = %d \n"%(detector,max_freq))
-        text_file.write("%s_n_points = %d \n"%(detector,n_nodes))
+    for ifo in opts.ifos:
+        ifo = ifo.lower()
+        min_freq = input_dict['min_freq_%s'%ifo]
+        max_freq = input_dict['max_freq_%s'%ifo]
+        text_file.write("%s_model = cubic_spline \n"%ifo)
+        text_file.write("%s_minimum_frequency = %d \n"%(ifo,min_freq))
+        text_file.write("%s_maximum_frequency = %d \n"%(ifo,max_freq))
+        text_file.write("%s_n_points = %d \n"%(ifo,n_nodes))
     text_file.write(" \n")
     text_file.write("[variable_params] \n")
     #for ii in range(n_nodes):
-    for detector in detector_list:
+    for ifo in opts.ifos:
         for ii in range(n_nodes):
-            detector = detector.lower()
-            text_file.write("recalib_amplitude_%s_%d = \n"%(detector,ii))
-            text_file.write("recalib_phase_%s_%d = \n"%(detector,ii))
+            ifo = ifo.lower()
+            text_file.write("recalib_amplitude_%s_%d = \n"%(ifo,ii))
+            text_file.write("recalib_phase_%s_%d = \n"%(ifo,ii))
     text_file.write(" \n")
    #for ii in range(n_nodes):
-    for detector in detector_list:
+    for ifo in opts.ifos:
         for ii in range(n_nodes):
-            detector = detector.lower()
-            amplitude_mean_nodes_l1 = prior_dict['amplitude_mean_nodes_%s'%detector][ii]
-            amplitude_sigma_nodes_l1 = prior_dict['amplitude_sigma_nodes_%s'%detector][ii]
-            text_file.write("[prior-recalib_amplitude_%s_%d] \n"%(detector,ii))
+            ifo = ifo.lower()
+            amplitude_mean_nodes_l1 = prior_dict['amplitude_mean_nodes_%s'%ifo][ii]
+            amplitude_sigma_nodes_l1 = prior_dict['amplitude_sigma_nodes_%s'%ifo][ii]
+            text_file.write("[prior-recalib_amplitude_%s_%d] \n"%(ifo,ii))
             text_file.write("name = gaussian \n")
-            text_file.write("recalib_amplitude_%s_%d_mean = %.3g \n"%(detector,ii,amplitude_mean_nodes_l1))
-            text_file.write("recalib_amplitude_%s_%d_var = %.3g \n"%(detector,ii,amplitude_sigma_nodes_l1**2))
+            text_file.write("recalib_amplitude_%s_%d_mean = %.3g \n"%(ifo,ii,amplitude_mean_nodes_l1))
+            text_file.write("recalib_amplitude_%s_%d_var = %.3g \n"%(ifo,ii,amplitude_sigma_nodes_l1**2))
             text_file.write(" \n")
     #for ii in range(n_nodes):
-    for detector in detector_list:
+    for ifo in opts.ifos:
         for ii in range(n_nodes):
-            detector = detector.lower()
-            phase_mean_nodes_l1 = prior_dict['phase_mean_nodes_%s'%detector][ii]
-            phase_sigma_nodes_l1 = prior_dict['phase_sigma_nodes_%s'%detector][ii]
-            text_file.write("[prior-recalib_phase_%s_%d] \n"%(detector,ii))
+            ifo = ifo.lower()
+            phase_mean_nodes_l1 = prior_dict['phase_mean_nodes_%s'%ifo][ii]
+            phase_sigma_nodes_l1 = prior_dict['phase_sigma_nodes_%s'%ifo][ii]
+            text_file.write("[prior-recalib_phase_%s_%d] \n"%(ifo,ii))
             text_file.write("name = gaussian \n")
-            text_file.write("recalib_phase_%s_%d_mean = %.3g \n"%(detector,ii,phase_mean_nodes_l1))
-            text_file.write("recalib_phase_%s_%d_var = %.3g \n"%(detector,ii,phase_sigma_nodes_l1**2))
+            text_file.write("recalib_phase_%s_%d_mean = %.3g \n"%(ifo,ii,phase_mean_nodes_l1))
+            text_file.write("recalib_phase_%s_%d_var = %.3g \n"%(ifo,ii,phase_sigma_nodes_l1**2))
             text_file.write(" \n")
     text_file.write(" \n")
     text_file.write(" \n")
@@ -155,13 +175,13 @@ else:
 
 # Sanity check plots
 if opts.plot_sanity_checks:
-    for detector in detector_list:
-        calib_env_path = input_dict['calib_env_path_%s'%detector.lower()]
-        min_freq = input_dict['min_freq_%s'%detector.lower()]
-        max_freq = input_dict['max_freq_%s'%detector.lower()]
-        log_nodes = prior_dict['log_nodes_%s'%detector.lower()]
-        amp_mean_nodes = prior_dict['amplitude_mean_nodes_%s'%detector.lower()]
-        amp_sigma_nodes = prior_dict['amplitude_sigma_nodes_%s'%detector.lower()]
+    for ifo in opts.ifos:
+        calib_env_path = input_dict['calib_env_path_%s'%ifo.lower()]
+        min_freq = input_dict['min_freq_%s'%ifo.lower()]
+        max_freq = input_dict['max_freq_%s'%ifo.lower()]
+        log_nodes = prior_dict['log_nodes_%s'%ifo.lower()]
+        amp_mean_nodes = prior_dict['amplitude_mean_nodes_%s'%ifo.lower()]
+        amp_sigma_nodes = prior_dict['amplitude_sigma_nodes_%s'%ifo.lower()]
         plt.figure(figsize=(8,5))
         plt.plot(f1[calib_env_path][:][:,0],f1[calib_env_path][:][:,1],label=r'$\mu$')
         plt.plot(f1[calib_env_path][:][:,0],f1[calib_env_path][:][:,3],label=r'$\mu-\sigma$')
@@ -172,13 +192,13 @@ if opts.plot_sanity_checks:
         plt.xscale('log')
         plt.xlabel('Frequency (Hz)')
         plt.ylabel('Amplitude')
-        plt.title('Calibration envelop (Amplitude) for %s'%detector.upper())
+        plt.title('Calibration envelop (Amplitude) for %s'%ifo.upper())
         plt.legend()
-        plt.savefig('%s/calibration_envelop_amplitude_%s_%s.png'%(plots_dir,tag,detector.upper()))
+        plt.savefig('%s/calibration_envelop_amplitude_%s_%s.png'%(plots_dir,tag,ifo.upper()))
         plt.clf()
 
-        phase_mean_nodes = prior_dict['phase_mean_nodes_%s'%detector.lower()]
-        phase_sigma_nodes = prior_dict['phase_sigma_nodes_%s'%detector.lower()]
+        phase_mean_nodes = prior_dict['phase_mean_nodes_%s'%ifo.lower()]
+        phase_sigma_nodes = prior_dict['phase_sigma_nodes_%s'%ifo.lower()]
         plt.figure(figsize=(8,5))
         plt.plot(f1[calib_env_path][:][:,0],f1[calib_env_path][:][:,2],label=r'$\mu$')
         plt.plot(f1[calib_env_path][:][:,0],f1[calib_env_path][:][:,4],label=r'$\mu-\sigma$')
@@ -189,8 +209,8 @@ if opts.plot_sanity_checks:
         plt.xscale('log')
         plt.xlabel('Frequency (Hz)')
         plt.ylabel('Phase')
-        plt.title('Calibration envelop (Phase) for %s'%detector.upper())
+        plt.title('Calibration envelop (Phase) for %s'%ifo.upper())
         plt.legend()
-        plt.savefig('%s/calibration_envelop_phase_%s_%s.png'%(plots_dir,tag,detector.upper()))
+        plt.savefig('%s/calibration_envelop_phase_%s_%s.png'%(plots_dir,tag,ifo.upper()))
         plt.clf()
 

--- a/bin/inference/pycbc_inference_create_calibration_config
+++ b/bin/inference/pycbc_inference_create_calibration_config
@@ -20,12 +20,10 @@
 Also plots the calibration envelop for each detector for sanity checks.
 """
 
-import h5py, os, argparse
+import os, argparse
 import numpy
-from scipy.interpolate import InterpolatedUnivariateSpline
 import matplotlib.pyplot as plt
 
-import pycbc
 from pycbc.types import MultiDetOptionAction
 from pycbc.strain.recalibrate import get_calibration_files_O1_O2_O3, read_calibration_envelop_file
 

--- a/bin/inference/pycbc_inference_create_calibration_config
+++ b/bin/inference/pycbc_inference_create_calibration_config
@@ -21,6 +21,7 @@ Also plots the calibration envelop for each detector for sanity checks.
 """
 
 import os, argparse
+import pycbc
 import numpy
 import matplotlib.pyplot as plt
 
@@ -30,6 +31,10 @@ from pycbc.strain.recalibrate import get_calibration_files_O1_O2_O3, read_calibr
 
 parser = argparse.ArgumentParser()
 
+# command line usage
+parser = argparse.ArgumentParser(usage=__file__ + " [--options]",
+                                 description=__doc__)
+pycbc.add_common_pycbc_options(parser)
 
 parser.add_argument('--calibration-files-path',
                     help='Calibration envelope file path. It can be pre-'

--- a/bin/inference/pycbc_inference_create_calibration_config
+++ b/bin/inference/pycbc_inference_create_calibration_config
@@ -32,6 +32,12 @@ from pycbc.strain.recalibrate import get_calibration_files_O1_O2_O3, read_calibr
 parser = argparse.ArgumentParser()
 
 # command line usage
+parser = argparse.ArgumentParser(
+            usage="pycbc_inference_create_calibration_config [--options]",
+            description="Generate the calibration configuration files "
+                        "to be used woth pycbc_inference.")
+pycbc.add_common_pycbc_options(parser)
+
 parser = argparse.ArgumentParser(usage=__file__ + " [--options]",
                                  description=__doc__)
 pycbc.add_common_pycbc_options(parser)
@@ -48,10 +54,6 @@ parser.add_argument('--calibration-files', nargs='+', action=MultiDetOptionActio
 
 parser.add_argument('--ifos', nargs='+',
                         help='Specify ifos for the analysis')
-
-#parser.add_argument('--detectors',  nargs='+',
-#                    help='List of detectors', required=True,
-#                    type=str)
 
 parser.add_argument('--minimum-frequency', nargs='+', action=MultiDetOptionAction,
                         metavar='DETECTOR:COLUMN', type=float,
@@ -107,9 +109,7 @@ if opts.calibration_files_path and opts.calibration_files:
                     "--calibration-files-path and --calibration-files")
 
 
-#args = parser.parse_args()
 calibration_files_path = opts.calibration_files_path
-#detector_list = args.detectors
 min_freq_list = opts.minimum_frequency
 max_freq_list = opts.maximum_frequency
 correction_type_list = opts.correction_type
@@ -135,7 +135,6 @@ print(calibration_files_dict)
 
 input_dict = {}
 for ii in range(len(opts.ifos)):
-    #ifo = str(opts.ifos[ii]).lower()
     ifo = str(opts.ifos[ii])
     input_dict['min_freq_%s'%ifo]=min_freq_list[ifo]
     input_dict['max_freq_%s'%ifo]=max_freq_list[ifo]
@@ -156,8 +155,6 @@ for ifo in opts.ifos:
     log_nodes, amplitude_median_nodes, amplitude_sigma_nodes, phase_median_nodes, phase_sigma_nodes = \
                read_calibration_envelop_file(calib_env_file, correction_type, 
                                              min_freq, max_freq, n_nodes)
-               #read_from_envelop_file(calib_env_path, min_freq,
-               #                       max_freq, n_nodes, ifo.upper())
     prior_dict['log_nodes_%s'%ifo] = log_nodes
     prior_dict['amplitude_median_nodes_%s'%ifo] = amplitude_median_nodes
     prior_dict['amplitude_sigma_nodes_%s'%ifo] = amplitude_sigma_nodes
@@ -171,7 +168,6 @@ if os.path.isfile(calibration_filename) != True:
     text_file = open(calibration_filename, "w")
     text_file.write("[calibration] \n")
     for ifo in opts.ifos:
-        #ifo = ifo.lower()
         min_freq = input_dict['min_freq_%s'%ifo]
         max_freq = input_dict['max_freq_%s'%ifo]
         text_file.write("%s_model = cubic_spline \n"%ifo.lower())
@@ -180,17 +176,13 @@ if os.path.isfile(calibration_filename) != True:
         text_file.write("%s_n_points = %d \n"%(ifo.lower(),n_nodes))
     text_file.write(" \n")
     text_file.write("[variable_params] \n")
-    #for ii in range(n_nodes):
     for ifo in opts.ifos:
         for ii in range(n_nodes):
-            #ifo = ifo.lower()
             text_file.write("recalib_amplitude_%s_%d = \n"%(ifo.lower(),ii))
             text_file.write("recalib_phase_%s_%d = \n"%(ifo.lower(),ii))
     text_file.write(" \n")
-   #for ii in range(n_nodes):
     for ifo in opts.ifos:
         for ii in range(n_nodes):
-            #ifo = ifo.lower()
             amplitude_median_nodes = prior_dict['amplitude_median_nodes_%s'%ifo][ii]
             amplitude_sigma_nodes = prior_dict['amplitude_sigma_nodes_%s'%ifo][ii]
             text_file.write("[prior-recalib_amplitude_%s_%d] \n"%(ifo.lower(),ii))
@@ -198,10 +190,8 @@ if os.path.isfile(calibration_filename) != True:
             text_file.write("recalib_amplitude_%s_%d_mean = %.3g \n"%(ifo.lower(),ii,amplitude_median_nodes))
             text_file.write("recalib_amplitude_%s_%d_var = %.3g \n"%(ifo.lower(),ii,amplitude_sigma_nodes**2))
             text_file.write(" \n")
-    #for ii in range(n_nodes):
     for ifo in opts.ifos:
         for ii in range(n_nodes):
-            #ifo = ifo.lower()
             phase_median_nodes = prior_dict['phase_median_nodes_%s'%ifo][ii]
             phase_sigma_nodes = prior_dict['phase_sigma_nodes_%s'%ifo][ii]
             text_file.write("[prior-recalib_phase_%s_%d] \n"%(ifo.lower(),ii))

--- a/bin/inference/pycbc_inference_create_calibration_config
+++ b/bin/inference/pycbc_inference_create_calibration_config
@@ -158,7 +158,7 @@ for ifo in opts.ifos:
     prior_dict['amplitude_sigma_nodes_%s'%ifo] = amplitude_sigma_nodes
     prior_dict['phase_median_nodes_%s'%ifo] = phase_median_nodes
     prior_dict['phase_sigma_nodes_%s'%ifo] =phase_sigma_nodes
-    print('Done for detector %s'%ifo)
+    logging.info('Done for detector %s', ifo)
 
 
 calibration_filename = '%s/calibration-%s.ini'%(output_dir, tag)

--- a/bin/inference/pycbc_inference_create_calibration_config
+++ b/bin/inference/pycbc_inference_create_calibration_config
@@ -201,7 +201,11 @@ if os.path.isfile(calibration_filename) != True:
     text_file.write(" \n")
     text_file.close()
 else:
-    print('Calibration file already present. Either delete it or rename it. Overwriting this file is not allowed!!!')
+    raise ValueError(
+        'Calibration file already present. '
+        'Either delete it or rename it. Overwriting '
+        'this file is not allowed!!!'
+    )
 
 # Sanity check plots
 plots_dir = '%s/plots'%output_dir

--- a/bin/inference/pycbc_inference_create_calibration_config
+++ b/bin/inference/pycbc_inference_create_calibration_config
@@ -38,10 +38,6 @@ parser = argparse.ArgumentParser(
                         "to be used woth pycbc_inference.")
 pycbc.add_common_pycbc_options(parser)
 
-parser = argparse.ArgumentParser(usage=__file__ + " [--options]",
-                                 description=__doc__)
-pycbc.add_common_pycbc_options(parser)
-
 parser.add_argument('--calibration-files-path',
                     help='Calibration envelope file path. It can be pre-'
                           'downloaded or downloaded on the fly',

--- a/bin/inference/pycbc_inference_create_calibration_config
+++ b/bin/inference/pycbc_inference_create_calibration_config
@@ -118,7 +118,8 @@ if opts.tag is None:
 else:
     tag = opts.tag
 
-print(min_freq_list['H1'])
+for ifo in opts.ifos:
+  logging.info("Minimum %s frequency: %.3f", ifs, min_freq_list[ifo])
 
 # Read calibration files
 if opts.calibration_files:

--- a/bin/inference/pycbc_inference_create_calibration_config
+++ b/bin/inference/pycbc_inference_create_calibration_config
@@ -138,7 +138,7 @@ for ii in range(len(opts.ifos)):
     input_dict['max_freq_%s'%ifo]=max_freq_list[ifo]
     input_dict['correction_type_%s'%ifo]=correction_type_list[ifo]
     input_dict['calibration_envelop_file_%s'%ifo] = calibration_files_dict[ifo.upper()]
-print(input_dict)
+logging.debug("Input dictionary: %s", input_dict)
 # Upper and Lower indices of detectors seems unnecessary
 # but they are there to make sure the correct convention
 # is followed for recalibration module in inference config

--- a/bin/inference/pycbc_inference_create_calibration_config
+++ b/bin/inference/pycbc_inference_create_calibration_config
@@ -21,12 +21,14 @@ Also plots the calibration envelop for each detector for sanity checks.
 """
 
 import h5py, os, argparse
-import numpy as np
+import numpy
 from scipy.interpolate import InterpolatedUnivariateSpline
 import matplotlib.pyplot as plt
 
 import pycbc
 from pycbc.types import MultiDetOptionAction
+from pycbc.strain.recalibrate import get_calibration_files_O1_O2_O3, read_calibration_envelop_file
+
 
 parser = argparse.ArgumentParser()
 
@@ -43,16 +45,16 @@ parser.add_argument('--ifos', nargs='+',
 #                    help='List of detectors', required=True,
 #                    type=str)
 
-parser.add_argument('--minimum-frequency-list', nargs='+', action=MultiDetOptionAction,
-                        metavar='DETECTOR:COLUMN',
+parser.add_argument('--minimum-frequency', nargs='+', action=MultiDetOptionAction,
+                        metavar='DETECTOR:COLUMN', type=float,
                         help='For each detector, provide minimum frequency for'
                         'the analysis. The minimum frequency should be higher than'
                         'the minimum frequency in calibration envelop file so that'
                         'we do not extrapolate.')
 
 
-parser.add_argument('--maximum-frequency-list', nargs='+', action=MultiDetOptionAction,
-                        metavar='DETECTOR:COLUMN',
+parser.add_argument('--maximum-frequency', nargs='+', action=MultiDetOptionAction,
+                        metavar='DETECTOR:COLUMN', type=float,
                         help='For each detector, provide maximum frequency for'
                         'the analysis. The minimum frequency should be lower than'
                         'the maximum frequency in calibration envelop file so that'
@@ -62,7 +64,7 @@ parser.add_argument('--maximum-frequency-list', nargs='+', action=MultiDetOption
 parser.add_argument('--gps-time',
                     help='GPS time at which calibration configuration files'
                           'are needed',
-                    required=True, type=str)
+                    required=True, type=float)
 
 parser.add_argument('--output-dir',                                 
                     help="Path for the output calibration config files",                    
@@ -84,41 +86,62 @@ parser.add_argument('--correction-type', nargs='+', action=MultiDetOptionAction,
 parser.add_argument('--plot-sanity-checks', help='Make some plots for sanity checks',
                     default=True, type=bool)
 
+parser.add_argument('--tag', help='Provide your tag for naming calibration file',
+                    default=None)
+
 # parse the command line
 opts = parser.parse_args()
 
 #args = parser.parse_args()
-calib_env_path = opts.calibration_files_path
+calibration_files_path = opts.calibration_files_path
 #detector_list = args.detectors
-min_freq_list = opts.minimum_frequency_list
-max_freq_list = opts.maximum_frequency_list
+min_freq_list = opts.minimum_frequency
+max_freq_list = opts.maximum_frequency
+correction_type_list = opts.correction_type
 gps_time = opts.gps_time
-plots_dir = opts.plots_dir
+output_dir = opts.output_dir
 n_nodes = opts.n_nodes
+if opts.tag is None:
+    tag = int(opts.gps_time)
+else:
+    tag = opts.tag
+
+print(min_freq_list['H1'])
+
+# Read calibration files
+calibration_files_dict = get_calibration_files_O1_O2_O3(opts.ifos, gps_time, calibration_files_path)
+
+print(calibration_files_dict)
 
 input_dict = {}
 for ii in range(len(opts.ifos)):
-    ifo = str(opts.ifos[ii]).lower()
-    input_dict['min_freq_%s'%ifo]=min_freq_list[ii]
-    input_dict['max_freq_%s'%ifo]=max_freq_list[ii]
-
+    #ifo = str(opts.ifos[ii]).lower()
+    ifo = str(opts.ifos[ii])
+    input_dict['min_freq_%s'%ifo]=min_freq_list[ifo]
+    input_dict['max_freq_%s'%ifo]=max_freq_list[ifo]
+    input_dict['correction_type_%s'%ifo]=correction_type_list[ifo]
+    input_dict['calibration_envelop_file_%s'%ifo] = calibration_files_dict[ifo.upper()]
+print(input_dict)
 # Upper and Lower indices of detectors seems unnecessary
 # but they are there to make sure the correct convention
 # is followed for recalibration module in inference config
 # file as well as in detector notation.
 prior_dict = {}
 for ifo in opts.ifos:
-    ifo = ifo.lower()
+    #ifo = ifo.lower()
     min_freq = input_dict['min_freq_%s'%ifo]
     max_freq = input_dict['max_freq_%s'%ifo]
-    calib_env_path = input_dict['calib_env_path_%s'%ifo]
-    log_nodes, amplitude_mean_nodes, amplitude_sigma_nodes, phase_mean_nodes, phase_sigma_nodes = \
-               read_from_envelop_file(calib_env_path, min_freq,
-                                      max_freq, n_nodes, ifo.upper())
+    correction_type = input_dict['correction_type_%s'%ifo]
+    calib_env_file = input_dict['calibration_envelop_file_%s'%ifo]
+    log_nodes, amplitude_median_nodes, amplitude_sigma_nodes, phase_median_nodes, phase_sigma_nodes = \
+               read_calibration_envelop_file(calib_env_file, correction_type, 
+                                             min_freq, max_freq, n_nodes)
+               #read_from_envelop_file(calib_env_path, min_freq,
+               #                       max_freq, n_nodes, ifo.upper())
     prior_dict['log_nodes_%s'%ifo] = log_nodes
-    prior_dict['amplitude_mean_nodes_%s'%ifo] = amplitude_mean_nodes
+    prior_dict['amplitude_median_nodes_%s'%ifo] = amplitude_median_nodes
     prior_dict['amplitude_sigma_nodes_%s'%ifo] = amplitude_sigma_nodes
-    prior_dict['phase_mean_nodes_%s'%ifo] = phase_mean_nodes
+    prior_dict['phase_median_nodes_%s'%ifo] = phase_median_nodes
     prior_dict['phase_sigma_nodes_%s'%ifo] =phase_sigma_nodes
     print('Done for detector %s'%ifo)
 
@@ -126,46 +149,45 @@ for ifo in opts.ifos:
 calibration_filename = '%s/calibration-%s.ini'%(output_dir, tag)
 if os.path.isfile(calibration_filename) != True:
     text_file = open(calibration_filename, "w")
-    text_file.write("# Details of set up as given in the O1 Binary Black Hole Paper https://arxiv.org/abs/1606.04856 \n")
     text_file.write("[calibration] \n")
     for ifo in opts.ifos:
-        ifo = ifo.lower()
+        #ifo = ifo.lower()
         min_freq = input_dict['min_freq_%s'%ifo]
         max_freq = input_dict['max_freq_%s'%ifo]
-        text_file.write("%s_model = cubic_spline \n"%ifo)
-        text_file.write("%s_minimum_frequency = %d \n"%(ifo,min_freq))
-        text_file.write("%s_maximum_frequency = %d \n"%(ifo,max_freq))
-        text_file.write("%s_n_points = %d \n"%(ifo,n_nodes))
+        text_file.write("%s_model = cubic_spline \n"%ifo.lower())
+        text_file.write("%s_minimum_frequency = %d \n"%(ifo.lower(),min_freq))
+        text_file.write("%s_maximum_frequency = %d \n"%(ifo.lower(),max_freq))
+        text_file.write("%s_n_points = %d \n"%(ifo.lower(),n_nodes))
     text_file.write(" \n")
     text_file.write("[variable_params] \n")
     #for ii in range(n_nodes):
     for ifo in opts.ifos:
         for ii in range(n_nodes):
-            ifo = ifo.lower()
-            text_file.write("recalib_amplitude_%s_%d = \n"%(ifo,ii))
-            text_file.write("recalib_phase_%s_%d = \n"%(ifo,ii))
+            #ifo = ifo.lower()
+            text_file.write("recalib_amplitude_%s_%d = \n"%(ifo.lower(),ii))
+            text_file.write("recalib_phase_%s_%d = \n"%(ifo.lower(),ii))
     text_file.write(" \n")
    #for ii in range(n_nodes):
     for ifo in opts.ifos:
         for ii in range(n_nodes):
-            ifo = ifo.lower()
-            amplitude_mean_nodes_l1 = prior_dict['amplitude_mean_nodes_%s'%ifo][ii]
-            amplitude_sigma_nodes_l1 = prior_dict['amplitude_sigma_nodes_%s'%ifo][ii]
-            text_file.write("[prior-recalib_amplitude_%s_%d] \n"%(ifo,ii))
+            #ifo = ifo.lower()
+            amplitude_median_nodes = prior_dict['amplitude_median_nodes_%s'%ifo][ii]
+            amplitude_sigma_nodes = prior_dict['amplitude_sigma_nodes_%s'%ifo][ii]
+            text_file.write("[prior-recalib_amplitude_%s_%d] \n"%(ifo.lower(),ii))
             text_file.write("name = gaussian \n")
-            text_file.write("recalib_amplitude_%s_%d_mean = %.3g \n"%(ifo,ii,amplitude_mean_nodes_l1))
-            text_file.write("recalib_amplitude_%s_%d_var = %.3g \n"%(ifo,ii,amplitude_sigma_nodes_l1**2))
+            text_file.write("recalib_amplitude_%s_%d_mean = %.3g \n"%(ifo.lower(),ii,amplitude_median_nodes))
+            text_file.write("recalib_amplitude_%s_%d_var = %.3g \n"%(ifo.lower(),ii,amplitude_sigma_nodes**2))
             text_file.write(" \n")
     #for ii in range(n_nodes):
     for ifo in opts.ifos:
         for ii in range(n_nodes):
-            ifo = ifo.lower()
-            phase_mean_nodes_l1 = prior_dict['phase_mean_nodes_%s'%ifo][ii]
-            phase_sigma_nodes_l1 = prior_dict['phase_sigma_nodes_%s'%ifo][ii]
-            text_file.write("[prior-recalib_phase_%s_%d] \n"%(ifo,ii))
+            #ifo = ifo.lower()
+            phase_median_nodes = prior_dict['phase_median_nodes_%s'%ifo][ii]
+            phase_sigma_nodes = prior_dict['phase_sigma_nodes_%s'%ifo][ii]
+            text_file.write("[prior-recalib_phase_%s_%d] \n"%(ifo.lower(),ii))
             text_file.write("name = gaussian \n")
-            text_file.write("recalib_phase_%s_%d_mean = %.3g \n"%(ifo,ii,phase_mean_nodes_l1))
-            text_file.write("recalib_phase_%s_%d_var = %.3g \n"%(ifo,ii,phase_sigma_nodes_l1**2))
+            text_file.write("recalib_phase_%s_%d_mean = %.3g \n"%(ifo.lower(),ii,phase_median_nodes))
+            text_file.write("recalib_phase_%s_%d_var = %.3g \n"%(ifo.lower(),ii,phase_sigma_nodes**2))
             text_file.write(" \n")
     text_file.write(" \n")
     text_file.write(" \n")
@@ -174,43 +196,46 @@ else:
     print('Calibration file already present. Either delete it or rename it. Overwriting this file is not allowed!!!')
 
 # Sanity check plots
+plots_dir = '%s/plots'%output_dir
+os.system('mkdir -p %s'%plots_dir)
 if opts.plot_sanity_checks:
     for ifo in opts.ifos:
-        calib_env_path = input_dict['calib_env_path_%s'%ifo.lower()]
-        min_freq = input_dict['min_freq_%s'%ifo.lower()]
-        max_freq = input_dict['max_freq_%s'%ifo.lower()]
-        log_nodes = prior_dict['log_nodes_%s'%ifo.lower()]
-        amp_mean_nodes = prior_dict['amplitude_mean_nodes_%s'%ifo.lower()]
-        amp_sigma_nodes = prior_dict['amplitude_sigma_nodes_%s'%ifo.lower()]
+        calib_env_path = input_dict['calibration_envelop_file_%s'%ifo]
+        min_freq = input_dict['min_freq_%s'%ifo]
+        max_freq = input_dict['max_freq_%s'%ifo]
+        log_nodes = prior_dict['log_nodes_%s'%ifo]
+        amp_median_nodes = prior_dict['amplitude_median_nodes_%s'%ifo]
+        amp_sigma_nodes = prior_dict['amplitude_sigma_nodes_%s'%ifo]
+        d1 = numpy.loadtxt(calib_env_path)
         plt.figure(figsize=(8,5))
-        plt.plot(f1[calib_env_path][:][:,0],f1[calib_env_path][:][:,1],label=r'$\mu$')
-        plt.plot(f1[calib_env_path][:][:,0],f1[calib_env_path][:][:,3],label=r'$\mu-\sigma$')
-        plt.plot(f1[calib_env_path][:][:,0],f1[calib_env_path][:][:,5],label=r'$\mu+\sigma$')
-        plt.plot(np.exp(log_nodes),amp_mean_nodes+1,'.',label=r'$\mu$(Prior)')
-        plt.plot(np.exp(log_nodes),amp_mean_nodes+1-amp_sigma_nodes,'.',label=r'$\mu-\sigma$ (Prior)')
-        plt.plot(np.exp(log_nodes),amp_mean_nodes+1+amp_sigma_nodes,'.',label=r'$\mu+\sigma$ (Prior)')
+        plt.plot(d1[:,0],d1[:,1],label=r'$\mu$')
+        plt.plot(d1[:,0],d1[:,3],label=r'$\mu-\sigma$')
+        plt.plot(d1[:,0],d1[:,5],label=r'$\mu+\sigma$')
+        plt.plot(numpy.exp(log_nodes),amp_median_nodes+1,'.',label=r'$\mu$(Prior)')
+        plt.plot(numpy.exp(log_nodes),amp_median_nodes+1-amp_sigma_nodes,'.',label=r'$\mu-\sigma$ (Prior)')
+        plt.plot(numpy.exp(log_nodes),amp_median_nodes+1+amp_sigma_nodes,'.',label=r'$\mu+\sigma$ (Prior)')
         plt.xscale('log')
         plt.xlabel('Frequency (Hz)')
         plt.ylabel('Amplitude')
-        plt.title('Calibration envelop (Amplitude) for %s'%ifo.upper())
+        plt.title('Calibration envelop (Amplitude) for %s'%ifo)
         plt.legend()
-        plt.savefig('%s/calibration_envelop_amplitude_%s_%s.png'%(plots_dir,tag,ifo.upper()))
+        plt.savefig('%s/calibration_envelop_amplitude_%s_%s.png'%(plots_dir,tag,ifo))
         plt.clf()
 
-        phase_mean_nodes = prior_dict['phase_mean_nodes_%s'%ifo.lower()]
-        phase_sigma_nodes = prior_dict['phase_sigma_nodes_%s'%ifo.lower()]
+        phase_median_nodes = prior_dict['phase_median_nodes_%s'%ifo]
+        phase_sigma_nodes = prior_dict['phase_sigma_nodes_%s'%ifo]
         plt.figure(figsize=(8,5))
-        plt.plot(f1[calib_env_path][:][:,0],f1[calib_env_path][:][:,2],label=r'$\mu$')
-        plt.plot(f1[calib_env_path][:][:,0],f1[calib_env_path][:][:,4],label=r'$\mu-\sigma$')
-        plt.plot(f1[calib_env_path][:][:,0],f1[calib_env_path][:][:,6],label=r'$\mu+\sigma$')
-        plt.plot(np.exp(log_nodes),phase_mean_nodes,'.',label=r'$\mu$ (Prior)')
-        plt.plot(np.exp(log_nodes),phase_mean_nodes-phase_sigma_nodes,'.',label=r'$\mu-\sigma$ (Prior)')
-        plt.plot(np.exp(log_nodes),phase_mean_nodes+phase_sigma_nodes,'.',label=r'$\mu+\sigma$')
+        plt.plot(d1[:,0],d1[:,2],label=r'$\mu$')
+        plt.plot(d1[:,0],d1[:,4],label=r'$\mu-\sigma$')
+        plt.plot(d1[:,0],d1[:,6],label=r'$\mu+\sigma$')
+        plt.plot(numpy.exp(log_nodes),phase_median_nodes,'.',label=r'$\mu$ (Prior)')
+        plt.plot(numpy.exp(log_nodes),phase_median_nodes-phase_sigma_nodes,'.',label=r'$\mu-\sigma$ (Prior)')
+        plt.plot(numpy.exp(log_nodes),phase_median_nodes+phase_sigma_nodes,'.',label=r'$\mu+\sigma$')
         plt.xscale('log')
         plt.xlabel('Frequency (Hz)')
         plt.ylabel('Phase')
-        plt.title('Calibration envelop (Phase) for %s'%ifo.upper())
+        plt.title('Calibration envelop (Phase) for %s'%ifo)
         plt.legend()
-        plt.savefig('%s/calibration_envelop_phase_%s_%s.png'%(plots_dir,tag,ifo.upper()))
+        plt.savefig('%s/calibration_envelop_phase_%s_%s.png'%(plots_dir,tag,ifo))
         plt.clf()
 

--- a/bin/inference/pycbc_inference_create_calibration_config
+++ b/bin/inference/pycbc_inference_create_calibration_config
@@ -35,8 +35,13 @@ parser = argparse.ArgumentParser()
 
 parser.add_argument('--calibration-files-path',
                     help='Calibration envelope file path. It can be pre-'
-                          'downloaded or downloaded on the fly', required=True,
+                          'downloaded or downloaded on the fly',
                     type=str)
+
+
+parser.add_argument('--calibration-files', nargs='+', action=MultiDetOptionAction,
+                    metavar = 'DETECTOR:COLUMN', type=str,
+                    help='Calibration file for each detector',)
 
 parser.add_argument('--ifos', nargs='+',
                         help='Specify ifos for the analysis')
@@ -89,8 +94,15 @@ parser.add_argument('--plot-sanity-checks', help='Make some plots for sanity che
 parser.add_argument('--tag', help='Provide your tag for naming calibration file',
                     default=None)
 
+
 # parse the command line
 opts = parser.parse_args()
+
+
+if opts.calibration_files_path and opts.calibration_files:
+    raise ValueError("Only one of the arguments should be provided among:"
+                    "--calibration-files-path and --calibration-files")
+
 
 #args = parser.parse_args()
 calibration_files_path = opts.calibration_files_path
@@ -109,7 +121,12 @@ else:
 print(min_freq_list['H1'])
 
 # Read calibration files
-calibration_files_dict = get_calibration_files_O1_O2_O3(opts.ifos, gps_time, calibration_files_path)
+if opts.calibration_files:
+    calibration_files_dict = {}
+    for ifo in opts.ifos:
+        calibration_files_dict[ifo] = opts.calibration_files[ifo]
+else:
+    calibration_files_dict = get_calibration_files_O1_O2_O3(opts.ifos, gps_time, calibration_files_path)
 
 print(calibration_files_dict)
 

--- a/bin/inference/pycbc_inference_create_calibration_config
+++ b/bin/inference/pycbc_inference_create_calibration_config
@@ -128,7 +128,7 @@ if opts.calibration_files:
 else:
     calibration_files_dict = get_calibration_files_O1_O2_O3(opts.ifos, gps_time, calibration_files_path)
 
-print(calibration_files_dict)
+logging.debug("Calibration files dictionary: %s", calibration_files_dict)
 
 input_dict = {}
 for ii in range(len(opts.ifos)):

--- a/examples/inference/calibration_configuration_files/download_calibration_uncertainty_files_o1_o2_o3.sh
+++ b/examples/inference/calibration_configuration_files/download_calibration_uncertainty_files_o1_o2_o3.sh
@@ -1,14 +1,8 @@
 
 # Provide the path to download calibration files
 
-OUT_DIR=$1
-
-if [[ -z $OUT_DIR ]]
-  then
-    echo "ERROR: output-directory is mandatory argument. \n";
-    exit 1;
-  fi
-
+OUT_DIR=calibration_uncertainty_files
+mkdir -p $OUT_DIR
 cd $OUT_DIR
 
 # Download LIGO calibration uncertainties

--- a/examples/inference/calibration_configuration_files/download_calibration_uncertainty_files_o1_o2_o3.sh
+++ b/examples/inference/calibration_configuration_files/download_calibration_uncertainty_files_o1_o2_o3.sh
@@ -1,0 +1,29 @@
+
+# Provide the path to download calibration files
+
+OUT_DIR=$1
+
+if [[ -z $OUT_DIR ]]
+  then
+    echo "ERROR: output-directory is mandatory argument. \n";
+    exit 1;
+  fi
+
+cd $OUT_DIR
+
+# Download LIGO calibration uncertainties
+wget https://dcc.ligo.org/public/0177/T2100313/003/LIGO_O1_cal_uncertainty.tgz .
+wget https://dcc.ligo.org/public/0177/T2100313/003/LIGO_O2_cal_uncertainty.tgz .
+wget https://dcc.ligo.org/public/0177/T2100313/003/LIGO_O3_cal_uncertainty.tgz .
+
+# Download Virgo files
+wget https://dcc.ligo.org/public/0177/T2100313/003/Virgo_O2_cal_uncertainty.tgz .
+wget https://dcc.ligo.org/public/0177/T2100313/003/Virgo_O3_cal_uncertainty.tgz
+
+#
+tar -xzvf LIGO_O1_cal_uncertainty.tgz 
+tar -xzvf LIGO_O2_cal_uncertainty.tgz
+tar -xzvf LIGO_O3_cal_uncertainty.tgz
+
+tar -xzvf Virgo_O2_cal_uncertainty.tgz
+tar -xzvf Virgo_O3_cal_uncertainty.tgz

--- a/examples/inference/calibration_configuration_files/generate_calibration_config.sh
+++ b/examples/inference/calibration_configuration_files/generate_calibration_config.sh
@@ -3,7 +3,7 @@
 # These files can be downloaded from
 # https://dcc.ligo.org/T2100313/public
 
-CALIB_ENV_FILE_PATH=/holohome/sumit.kumar/data/GWOSC/calibration_uncertainty_o1_o2_o3
+CALIB_ENV_FILE_PATH=./calibration_uncertainty_files
 
 # Generate calibration configuration file for GW150914
 pycbc_inference_create_calibration_config --calibration-files-path ${CALIB_ENV_FILE_PATH} --ifos H1 L1 --minimum-frequency H1:20 L1:20 --maximum-frequency H1:1000 L1:1000  --gps-time 1126259462.43 --correction-type H1:data L1:data

--- a/examples/inference/calibration_configuration_files/generate_calibration_config.sh
+++ b/examples/inference/calibration_configuration_files/generate_calibration_config.sh
@@ -1,0 +1,9 @@
+
+# Provide a path to downloaded calibration files for O1-O2-O3 
+# These files can be downloaded from
+# https://dcc.ligo.org/T2100313/public
+
+CALIB_ENV_FILE_PATH=/holohome/sumit.kumar/data/GWOSC/calibration_uncertainty_o1_o2_o3
+
+# Generate calibration configuration file for GW150914
+pycbc_inference_create_calibration_config --calibration-files-path ${CALIB_ENV_FILE_PATH} --ifos H1 L1 --minimum-frequency H1:20 L1:20 --maximum-frequency H1:1000 L1:1000  --gps-time 1126259462.43 --correction-type H1:data L1:data

--- a/pycbc/strain/recalibrate.py
+++ b/pycbc/strain/recalibrate.py
@@ -22,6 +22,7 @@ from abc import (ABCMeta, abstractmethod)
 import numpy as np
 from scipy.interpolate import UnivariateSpline
 from pycbc.types import FrequencySeries
+from pycbc.io import get_file
 
 
 class Recalibrate(metaclass=ABCMeta):
@@ -514,18 +515,24 @@ class PhysicalModel(object):
         return strain_adjusted
 
 class ReadCalibrationEnvelop(object):
-    def __init__(self, envelop_file_path,  minimum_frequency=20, 
+    def __init__(self, envelope_file_path,  minimum_frequency=20, 
                  maximum_frequency=2048, n_nodes=10):
-        self.envelop_file_path = envelop_file_path
+        self.envelope_file_path = envelop_file_path
         self.minimum_frequency = minimum_frequency
         self.maximum_frequency = maximum_frequency
         self.n_nodes = n_nodes
         
+        # Hardcoded
+        self.public_url = 'https://dcc.ligo.org/T2100313/public'
         # Get the filelist
         self.filelist_H1 = glob.glob('%s/H1/*txt'%self.envelope_file_path)
+        if len(self.filelist_H1)==0:
+            self.download_calibration_files('%s/LIGO_O1_cal_uncertainty.tgz')
         self.filelist_L1 = glob.glob('%s/L1/*txt'%self.envelope_file_path)
         self.filelist_V1 = glob.glob('%s/V1/*txt'%self.envelope_file_path)
         
+
+
         self.gps_times_H1,self.gps_times_L1 = [],[]
         for file in self.filelist_H1:
             # Hardcoded, Check for future changes in filename
@@ -545,6 +552,10 @@ class ReadCalibrationEnvelop(object):
         
         return calibration_file_H1, calibration_file_L1
         
+    def download_calibration_files(self):
+        try
+            get_file('')
+
     def read_from_envelop_file(self, calibration_file):
         calibration_data = numpy.loadtxt(calibration_file).T
         log_frequency_array = np.log(calibration_data[0])

--- a/pycbc/strain/recalibrate.py
+++ b/pycbc/strain/recalibrate.py
@@ -512,3 +512,72 @@ class PhysicalModel(object):
                               kappa_pu_re=calib_args[6],
                               kappa_pu_im=calib_args[7])
         return strain_adjusted
+
+class ReadCalibrationEnvelop(object):
+    def __init__(self, envelop_file_path,  minimum_frequency=20, 
+                 maximum_frequency=2048, n_nodes=10):
+        self.envelop_file_path = envelop_file_path
+        self.minimum_frequency = minimum_frequency
+        self.maximum_frequency = maximum_frequency
+        self.n_nodes = n_nodes
+        
+        # Get the filelist
+        self.filelist_H1 = glob.glob('%s/H1/*txt'%self.envelope_file_path)
+        self.filelist_L1 = glob.glob('%s/L1/*txt'%self.envelope_file_path)
+        self.filelist_V1 = glob.glob('%s/V1/*txt'%self.envelope_file_path)
+        
+        self.gps_times_H1,self.gps_times_L1 = [],[]
+        for file in self.filelist_H1:
+            # Hardcoded, Check for future changes in filename
+            self.gps_times_H1.append(int(file.split('/')[-1].split('_')[4]))
+            
+        for file in self.filelist_L1:
+            # Hardcoded, Check for future changes in filename
+            self.gps_times_L1.append(int(file.split('/')[-1].split('_')[4]))
+            
+        
+    def find_calibration_file_HL(self, gps_time):
+        index_closest_time_H1 = np.argmin(gps_time-np.array(self.gps_times_H1))
+        index_closest_time_L1 = np.argmin(gps_time-np.array(self.gps_times_L1))
+            
+        calibration_file_H1 = self.filelist_H1[index_closest_time_H1]
+        calibration_file_L1 = self.filelist_L1[index_closest_time_L1]
+        
+        return calibration_file_H1, calibration_file_L1
+        
+    def read_from_envelop_file(self, calibration_file):
+        calibration_data = numpy.loadtxt(calibration_file).T
+        log_frequency_array = np.log(calibration_data[0])
+        amplitude_median = calibration_data[1] - 1
+        phase_median = calibration_data[2]
+        amplitude_sigma = (calibration_data[5] - calibration_data[3]) / 2
+        phase_sigma = (calibration_data[6] - calibration_data[4]) / 2
+        log_nodes = np.linspace(np.log(self.minimum_frequency),
+                            np.log(self.maximum_frequency), self.n_nodes)
+        # Some sanity checks
+        if calibration_data[0][-1] < maximum_frequency:
+            if self.maximum_frequency - calibration_data[0][-1] < 0.5:
+                self.maximum_frequency = calibration_data[0][-1]
+            else:
+                raise ValueError("Maximum frequency (=%d) for tc=%s is more than"
+                         "maximum frequency in calibration envelop (=%.3g)"%(self.maximum_frequency,gps_time,calibration_data[0][-1]))
+        else:
+            pass
+
+        if calibration_data[0][0] > self.minimum_frequency:
+            raise ValueError("Minimum frequency (=%d) for tc=%s is less than"
+                         "minimum frequency in calibration envelop (=%.3g)"%(self.minimum_frequency,gps_time,calibration_data[0][0]))
+        else:
+            pass
+
+        amplitude_mean_nodes = \
+                InterpolatedUnivariateSpline(log_frequency_array, amplitude_median)(self.log_nodes)
+        amplitude_sigma_nodes = \
+                InterpolatedUnivariateSpline(log_frequency_array, amplitude_sigma)(self.log_nodes)
+        phase_mean_nodes = \
+                InterpolatedUnivariateSpline(log_frequency_array, phase_median)(self.log_nodes)
+        phase_sigma_nodes = \
+                InterpolatedUnivariateSpline(log_frequency_array, phase_sigma)(self.log_nodes)
+
+        return log_nodes, amplitude_mean_nodes, amplitude_sigma_nodes, phase_mean_nodes, phase_sigma_nodes
+

--- a/pycbc/strain/recalibrate.py
+++ b/pycbc/strain/recalibrate.py
@@ -589,8 +589,6 @@ def get_calibration_files_O1_O2_O3(ifos, gps_time, calibration_file_path):
     for each IFO around a given GPS time for O1, O2, and O3 observation
     run.
 
-    For H1 and L1 detectors
-    -----------
     Input:
      ifos: List of detectors in the network
      gps_time: GPS time around which the calibration envelop is required

--- a/pycbc/strain/recalibrate.py
+++ b/pycbc/strain/recalibrate.py
@@ -20,6 +20,7 @@
 from abc import (ABCMeta, abstractmethod)
 
 import numpy as np
+import glob, os
 from scipy.interpolate import UnivariateSpline
 from pycbc.types import FrequencySeries
 from pycbc.frame.gwosc import get_run
@@ -536,11 +537,11 @@ def read_calibration_envelop_file(calibration_file, correction_type,
       phase_median_nodes: Median values of Phase correction at frequency nodal points
       phase_sigma_nodes: Standard deviation values of Phase correction at frequency nodal points
     """
-    calibration_data = numpy.loadtxt(calibration_file).T
-    log_frequency_array = numpy.log(calibration_data[0])
+    calibration_data = np.loadtxt(calibration_file).T
+    log_frequency_array = np.log(calibration_data[0])
 
-    log_nodes = numpy.linspace(numpy.log(minimum_frequency),
-                            numpy.log(maximum_frequency), n_nodes)
+    log_nodes = np.linspace(np.log(minimum_frequency),
+                            np.log(maximum_frequency), n_nodes)
 
     if correction_type.lower()=='template':
         amplitude_median = calibration_data[1] - 1
@@ -603,7 +604,8 @@ def get_calibration_files_O1_O2_O3(ifos, gps_time, calibration_file_path):
         all_calibration_files = glob.glob('%s/%s/*txt'%(calibration_file_path, ifo))
         if ifo !='V1':
             # H1 and L1 detector files are treated seperately compared to V1 detector
-            list_gpstimes = np.array([int(item.split('_')[5]) for item in all_calibration_files])
+            # This list of GPS times can be coded in a better way!!!
+            list_gpstimes = np.array([int(item.split('_')[-4]) for item in all_calibration_files])
             dt_list = abs(list_gpstimes - gps_time)
             ifo_calibration_file = '%s/%s'%(os.getcwd(), all_calibration_files[dt_list.argmin()])
         else:

--- a/pycbc/strain/recalibrate.py
+++ b/pycbc/strain/recalibrate.py
@@ -601,7 +601,7 @@ def get_calibration_files_O1_O2_O3(ifos, gps_time, calibration_file_path):
     """
     dict_calibration_file = {}
     for ifo in ifos:
-        all_calibration_files = glob.glob('%s/%s/*txt'%(calibration_file_path, ifo))
+        all_calibration_files = glob.glob('%s/%s/*FinalResults.txt'%(calibration_file_path, ifo))
         if ifo !='V1':
             # H1 and L1 detector files are treated seperately compared to V1 detector
             # This list of GPS times can be coded in a better way!!!


### PR DESCRIPTION
To incorporate calibration uncertainties in PE runs, one need to provide a calibration configuration files to `pycbc_inference` code. Although, the support for the calibration config file exist, we still do not have a way to generate these config files, within PyCBC infrastructure. In this PR, I include the full infrastructure to generate the config files for PE runs for any GPS time from the publicly available calibration envelopes provided by [LIGO-Virgo](https://dcc.ligo.org/T2100313/public).