### PR TITLE
Rationalize some calls to waveform properties

### DIFF
--- a/pycbc/events/coinc.py
+++ b/pycbc/events/coinc.py
@@ -40,7 +40,7 @@ def background_bin_from_string(background_bins, data):
     """ Return template ids for each bin as defined by the format string
 
     Parameters
-    ----------g
+    ----------
     bins: list of strings
         List of strings which define how a background bin is taken from the
         list of templates.

--- a/pycbc/events/coinc.py
+++ b/pycbc/events/coinc.py
@@ -40,7 +40,7 @@ def background_bin_from_string(background_bins, data):
     """ Return template ids for each bin as defined by the format string
 
     Parameters
-    ----------
+    ----------g
     bins: list of strings
         List of strings which define how a background bin is taken from the
         list of templates.
@@ -106,7 +106,7 @@ def background_bin_from_string(background_bins, data):
                 )
                 cached_values[bin_type] = vals
             elif bin_type.endswith('duration'):
-                vals = pycbc.pnutils.get_duration(
+                vals = pycbc.pnutils.get_imr_duration(
                     data['mass1'],
                     data['mass2'],
                     data['spin1z'],

--- a/pycbc/events/coinc.py
+++ b/pycbc/events/coinc.py
@@ -35,14 +35,6 @@ from .eventmgr_cython import timecoincidence_getslideint
 from .eventmgr_cython import timecoincidence_findidxlen
 from .eventmgr_cython import timecluster_cython
 
-# Mapping used in background_bin_from_string to select approximant for
-# duration function, if duration-based binning is used.
-_APPROXIMANT_DURATION_MAP = {
-    'SEOBNRv2duration': 'SEOBNRv2',
-    'SEOBNRv4duration': 'SEOBNRv4',
-    'SEOBNRv5duration': 'SEOBNRv5_ROM'
-}
-
 
 def background_bin_from_string(background_bins, data):
     """ Return template ids for each bin as defined by the format string
@@ -104,7 +96,7 @@ def background_bin_from_string(background_bins, data):
             elif bin_type == 'chi_eff':
                 vals = pycbc.conversions.chi_eff(data['mass1'], data['mass2'],
                                                  data['spin1z'], data['spin2z'])
-            elif bin_type in ['SEOBNRv2Peak', 'SEOBNRv4Peak']:
+            elif bin_type.endswith('Peak'):
                 vals = pycbc.pnutils.get_freq(
                     'f' + bin_type,
                     data['mass1'],
@@ -113,14 +105,14 @@ def background_bin_from_string(background_bins, data):
                     data['spin2z']
                 )
                 cached_values[bin_type] = vals
-            elif bin_type in _APPROXIMANT_DURATION_MAP:
-                vals = pycbc.pnutils.get_imr_duration(
+            elif bin_type.endswith('duration'):
+                vals = pycbc.pnutils.get_duration(
                     data['mass1'],
                     data['mass2'],
                     data['spin1z'],
                     data['spin2z'],
                     data['f_lower'],
-                    approximant=_APPROXIMANT_DURATION_MAP[bin_type]
+                    approximant=bin_type.replace('duration', '')
                 )
                 cached_values[bin_type] = vals
             else:

--- a/pycbc/pnutils.py
+++ b/pycbc/pnutils.py
@@ -538,11 +538,11 @@ def _get_imr_duration(m1, m2, s1z, s2z, f_low, approximant="SEOBNRv4"):
     elif approximant == "IMRPhenomD":
         time_length = lalsim.SimIMRPhenomDChirpTime(
                            m1 * lal.MSUN_SI, m2 * lal.MSUN_SI, s1z, s2z, f_low)
-    elif approximant.startswith("SEOBNRv4"):  # allow for v4_ROM also
-        # NB for no clear reason this function has f_low as first argument
+    elif approximant in ["SEOBNRv4", "SEOBNRv4_ROM"]:
+        # NB the LALSim function has f_low as first argument
         time_length = lalsim.SimIMRSEOBNRv4ROMTimeOfFrequency(
                            f_low, m1 * lal.MSUN_SI, m2 * lal.MSUN_SI, s1z, s2z)
-    elif approximant.startwith("SEOBNRv5"):  # allow for v5_ROM also
+    elif approximant in ["SEOBNRv5", "SEOBNRv5_ROM"]:
         time_length = lalsim.SimIMRSEOBNRv5ROMTimeOfFrequency(
                            f_low, m1 * lal.MSUN_SI, m2 * lal.MSUN_SI, s1z, s2z)
     elif approximant in ["SPAtmplt", "TaylorF2"]:

--- a/pycbc/pnutils.py
+++ b/pycbc/pnutils.py
@@ -521,7 +521,7 @@ def frequency_cutoff_from_name(name, m1, m2, s1z, s2z):
     f : float or numpy.array
         Frequency in Hz
     """
-    params = {"mass1":m1, "mass2":m2, "spin1z":s1z, "spin2z":s2z}
+    params = {"mass1": m1, "mass2": m2, "spin1z": s1z, "spin2z": s2z}
     return named_frequency_cutoffs[name](params)
 
 def _get_imr_duration(m1, m2, s1z, s2z, f_low, approximant="SEOBNRv4"):
@@ -532,20 +532,20 @@ def _get_imr_duration(m1, m2, s1z, s2z, f_low, approximant="SEOBNRv4"):
         chi = lalsim.SimIMRPhenomBComputeChi(m1, m2, s1z, s2z)
         time_length = lalsim.SimIMRSEOBNRv2ChirpTimeSingleSpin(
                                 m1 * lal.MSUN_SI, m2 * lal.MSUN_SI, chi, f_low)
-    elif approximant == 'IMRPhenomXAS':
+    elif approximant == "IMRPhenomXAS":
         time_length = lalsim.SimIMRPhenomXASDuration(
                            m1 * lal.MSUN_SI, m2 * lal.MSUN_SI, s1z, s2z, f_low)
     elif approximant == "IMRPhenomD":
         time_length = lalsim.SimIMRPhenomDChirpTime(
                            m1 * lal.MSUN_SI, m2 * lal.MSUN_SI, s1z, s2z, f_low)
-    elif approximant == "SEOBNRv4":
+    elif approximant.startswith("SEOBNRv4"):  # allow for v4_ROM also
         # NB for no clear reason this function has f_low as first argument
         time_length = lalsim.SimIMRSEOBNRv4ROMTimeOfFrequency(
                            f_low, m1 * lal.MSUN_SI, m2 * lal.MSUN_SI, s1z, s2z)
-    elif approximant == 'SEOBNRv5_ROM':
+    elif approximant.startwith("SEOBNRv5"):  # allow for v5_ROM also
         time_length = lalsim.SimIMRSEOBNRv5ROMTimeOfFrequency(
                            f_low, m1 * lal.MSUN_SI, m2 * lal.MSUN_SI, s1z, s2z)
-    elif approximant == 'SPAtmplt' or approximant == 'TaylorF2':
+    elif approximant in ["SPAtmplt", "TaylorF2"]:
         chi = lalsim.SimInspiralTaylorF2ReducedSpinComputeChi(
             m1, m2, s1z, s2z
         )


### PR DESCRIPTION
Allow SEOBNRvXROM durations to be used without having '_ROM' in the v5 approx name

Also simplify some calls to peak frequency etc