### PR TITLE
Releases not pointing to correct singularity image

### DIFF
--- a/pycbc/workflow/pegasus_sites.py
+++ b/pycbc/workflow/pegasus_sites.py
@@ -21,7 +21,12 @@ from urllib.request import pathname2url
 from Pegasus.api import Directory, FileServer, Site, Operation, Namespace
 from Pegasus.api import Arch, OS, SiteCatalog
 
-from pycbc.version import last_release  # noqa
+from pycbc.version import last_release, version, release  # noqa
+
+if release == 'True':
+    sing_version = version
+else:
+    sing_version = last_release
 
 # NOTE urllib is weird. For some reason it only allows known schemes and will
 # give *wrong* results, rather then failing, if you use something like gsiftp
@@ -218,7 +223,7 @@ def add_osg_site(sitecat, cp):
                             "(HAS_LIGO_FRAMES =?= True) && "
                             "(IS_GLIDEIN =?= True)")
     cvmfs_loc = '"/cvmfs/singularity.opensciencegrid.org/pycbc/pycbc-el8:v'
-    cvmfs_loc += last_release + '"'
+    cvmfs_loc += sing_version + '"'
     site.add_profiles(Namespace.CONDOR, key="+SingularityImage",
                       value=cvmfs_loc)
     # On OSG failure rate is high


### PR DESCRIPTION
There's an issue with our recent CVMFS images, where the singularity image for OSG is not being correctly set. I'm not sure why the release images do not contain any of the git information (or `last_release`) now, when they used to. However, releases should explicitly use the *current* release.

I think this fixes it, but it can't really be tested unless I make a release and see!