### PR TITLE
Update __init__.py

### DIFF
--- a/pycbc/__init__.py
+++ b/pycbc/__init__.py
@@ -97,9 +97,9 @@ def init_logging(verbose=False, format='%(asctime)s %(message)s'):
 
     # See https://docs.python.org/3/library/logging.html#levels
     # for log level definitions
-    initial_level = logging.WARNING - int(verbose) * 10
     logger = logging.getLogger()
-    logger.setLevel(initial_level)
+    verbose_int = 0 if verbose is None else int(verbose)
+    logger.setLevel(logging.WARNING - verbose_int * 10)  # Initial setting
     sh = logging.StreamHandler()
     logger.addHandler(sh)
     sh.setFormatter(LogFormatter(fmt=format))

--- a/pycbc/__init__.py
+++ b/pycbc/__init__.py
@@ -94,6 +94,9 @@ def init_logging(verbose=False, format='%(asctime)s %(message)s'):
         logger.setLevel(log_level)
 
     signal.signal(signal.SIGUSR1, sig_handler)
+
+    # See https://docs.python.org/3/library/logging.html#levels
+    # for log level definitions
     initial_level = logging.WARNING - int(verbose) * 10
     logger = logging.getLogger()
     logger.setLevel(initial_level)

--- a/pycbc/__init__.py
+++ b/pycbc/__init__.py
@@ -78,8 +78,7 @@ def init_logging(verbose=False, format='%(asctime)s %(message)s'):
         What level to set the verbosity level to. Accepts either a boolean
         or an integer representing the level to set. If True/False will set to
         ``logging.INFO``/``logging.WARN``. For higher logging levels, pass
-        an integer representing the level to set (see the ``logging`` module
-        for details). Default is ``False`` (``logging.WARN``).
+        an integer representing the level to set. (1 = INFO, 2 = DEBUG).
     format : str, optional
         The format to use for logging messages.
     """
@@ -96,12 +95,9 @@ def init_logging(verbose=False, format='%(asctime)s %(message)s'):
 
     signal.signal(signal.SIGUSR1, sig_handler)
 
-    if not verbose:
-        initial_level = logging.WARN
-    elif int(verbose) == 1:
-        initial_level = logging.INFO
-    else:
-        initial_level = int(verbose)
+    initial_level = logging.WARN
+    if verbose:
+        initial_level -= int(verbose) * 10
 
     logger = logging.getLogger()
     logger.setLevel(initial_level)

--- a/pycbc/__init__.py
+++ b/pycbc/__init__.py
@@ -94,11 +94,7 @@ def init_logging(verbose=False, format='%(asctime)s %(message)s'):
         logger.setLevel(log_level)
 
     signal.signal(signal.SIGUSR1, sig_handler)
-
-    initial_level = logging.WARNING
-    if verbose:
-        initial_level -= int(verbose) * 10
-
+    initial_level = logging.WARNING - int(verbose) * 10
     logger = logging.getLogger()
     logger.setLevel(initial_level)
     sh = logging.StreamHandler()

--- a/pycbc/__init__.py
+++ b/pycbc/__init__.py
@@ -95,7 +95,7 @@ def init_logging(verbose=False, format='%(asctime)s %(message)s'):
 
     signal.signal(signal.SIGUSR1, sig_handler)
 
-    initial_level = logging.WARN
+    initial_level = logging.WARNING
     if verbose:
         initial_level -= int(verbose) * 10
 


### PR DESCRIPTION
This would modify init_logging in pycbc to work with a 'count' argument. This means if you give --verbose, the logging level is 'INFO', iv you give it twice (or -vv), it will use 'DEBUG'. 

If you keep giving (verbose) the logging level will decrease in increments in 10, but those don't have canonical names, and would be up to the user to use at their volition.