### PR TITLE
Fix plot_singles and optimize memory

### DIFF
--- a/bin/plotting/pycbc_plot_singles_vs_params
+++ b/bin/plotting/pycbc_plot_singles_vs_params
@@ -98,15 +98,12 @@ if opts.min_snr > 0:
         data_mask = np.zeros(n_triggers_orig, dtype=bool)
         data_mask[idx] = True
 
-filts = [f for f in [opts.filter_string] if f is not None]
-filter_func = ' & '.join(filts) if filts else None
-
 trigs = pycbc.io.SingleDetTriggers(
     opts.single_trig_file,
     opts.bank_file,
     opts.veto_file,
     opts.segment_name,
-    filter_func,
+    opts.filter_string,
     opts.detector,
     premask=data_mask
 )

--- a/bin/plotting/pycbc_plot_singles_vs_params
+++ b/bin/plotting/pycbc_plot_singles_vs_params
@@ -161,7 +161,7 @@ elif opts.z_var in ranking.sngls_ranking_function_dict:
     max_z = z.max() if opts.max_z is None else opts.max_z
     if max_z / min_z > 10:
         cb_style['ticks'] = LogLocator(subs=range(10))
-    hb = ax.hexbin(x, y, C=z, reduce_C_function=max, **hexbin_style)
+    hb = ax.hexbin(x, y, C=z, reduce_C_function=np.max, **hexbin_style)
     fig.colorbar(hb, **cb_style)
 else:
     raise RuntimeError('z_var = %s is not recognized!' % (opts.z_var))

--- a/bin/plotting/pycbc_plot_singles_vs_params
+++ b/bin/plotting/pycbc_plot_singles_vs_params
@@ -128,11 +128,14 @@ y = y[mask]
 
 hexbin_style = {
     'gridsize': opts.grid_size,
-    # hexbin shows bins with *less* than mincnt as blank
-    # (in earlier mpl versions this was less than *or equal to* mincnt)
-    'mincnt': 1 if matplotlib.__version__ >= '3.8.1' else 0,
     'linewidths': 0.03
 }
+
+# In earlier versions mpl will try to take the max over bins with 0 triggers
+# and fail, unless we tell it to leave these blank by setting mincnt
+if matplotlib.__version__ < '3.8.1':
+    hexbin_style['mincnt'] = 0
+
 if opts.log_x:
     hexbin_style['xscale'] = 'log'
 if opts.log_y:

--- a/bin/plotting/pycbc_plot_singles_vs_params
+++ b/bin/plotting/pycbc_plot_singles_vs_params
@@ -84,12 +84,32 @@ opts = parser.parse_args()
 
 logging.basicConfig(format='%(asctime)s %(message)s', level=logging.INFO)
 
-snr_filter = '(self.snr>%f)' % (opts.min_snr) if opts.min_snr > 0. else None 
-filts = [f for f in [snr_filter, opts.filter_string] if f is not None]
+data_mask = None
+if opts.min_snr > 0:
+    with pycbc.io.HFile(opts.single_trig_file, 'r') as trig_file:
+        n_triggers_orig = trig_file[f'{opts.detector}/snr'].size
+        logging.info("Trigger file has %d triggers", n_triggers_orig)
+        logging.info('Generating trigger mask (on SNR)')
+        idx, _ = trig_file.select(
+            lambda snr: snr >= opts.min_snr,
+            f'{opts.detector}/snr',
+            return_indices=True
+        )
+        data_mask = np.zeros(n_triggers_orig, dtype=bool)
+        data_mask[idx] = True
+
+filts = [f for f in [opts.filter_string] if f is not None]
 filter_func = ' & '.join(filts) if filts else None
 
-trigs = pycbc.io.SingleDetTriggers(opts.single_trig_file, opts.bank_file,
-                  opts.veto_file, opts.segment_name, filter_func, opts.detector)
+trigs = pycbc.io.SingleDetTriggers(
+    opts.single_trig_file,
+    opts.bank_file,
+    opts.veto_file,
+    opts.segment_name,
+    filter_func,
+    opts.detector,
+    premask=data_mask
+)
 
 x = getattr(trigs, opts.x_var)
 y = getattr(trigs, opts.y_var)
@@ -109,7 +129,8 @@ y = y[mask]
 hexbin_style = {
     'gridsize': opts.grid_size,
     # hexbin shows bins with *less* than mincnt as blank
-    'mincnt': 0,
+    # (in earlier mpl versions this was less than *or equal to* mincnt)
+    'mincnt': 1 if matplotlib.__version__ >= '3.8.1' else 0,
     'linewidths': 0.03
 }
 if opts.log_x:


### PR DESCRIPTION
`pycbc_plot_singles_vs_params` was broken by recent changes in matplotlib. The note about "behaviour of hexbin" here https://matplotlib.org/stable/api/prev_api_changes/api_changes_3.8.1.html specifically broke thinks. My understanding is that before we set `mincnt = 0`, but that actually meant "minimum count is 1 trigger in that bin". Now it means "minimum count is 0 triggers in that bin", and the code fails if you try to take the maximum of 0 triggers.

I put in a version-dependent switch on the `mincnt` parameter to fix this. This resolved the problem in a single test case, I'm running a bunch more in a full workflow now.

.... It also took ages to debug this, because the code reads *way* more triggers than it needs to. I've implemented the HFile mask thing in this code as well. This makes the code run significantly faster, and with much less memory usage. The `filter_func` still uses a lot of memory, but given that we are considering #4524 #4545 I leave that to be made nicer when that change goes in.