### PR TITLE
Add support for nessai sampler in pycbc inference

### DIFF
--- a/companion.txt
+++ b/companion.txt
@@ -14,6 +14,9 @@ cpnest
 pymultinest
 ultranest
 https://github.com/willvousden/ptemcee/archive/master.tar.gz
+# Force the cpu-only version of PyTorch
+--extra-index-url https://download.pytorch.org/whl/cpu
+torch
 nessai>=0.11.0
 
 # useful to look at PyCBC Live with htop

--- a/companion.txt
+++ b/companion.txt
@@ -14,7 +14,7 @@ cpnest
 pymultinest
 ultranest
 https://github.com/willvousden/ptemcee/archive/master.tar.gz
-nessai
+nessai>=0.11.0
 
 # useful to look at PyCBC Live with htop
 setproctitle

--- a/companion.txt
+++ b/companion.txt
@@ -14,6 +14,7 @@ cpnest
 pymultinest
 ultranest
 https://github.com/willvousden/ptemcee/archive/master.tar.gz
+nessai
 
 # useful to look at PyCBC Live with htop
 setproctitle

--- a/examples/inference/samplers/epsie_stub.ini
+++ b/examples/inference/samplers/epsie_stub.ini
@@ -14,3 +14,6 @@ ntemps = 4
 
 [jump_proposal-x]
 name = normal
+
+[jump_proposal-y]
+name = normal

--- a/examples/inference/samplers/nessai_stub.ini
+++ b/examples/inference/samplers/nessai_stub.ini
@@ -1,0 +1,3 @@
+[sampler]
+name = nessai
+nlive = 200

--- a/examples/inference/samplers/run.sh
+++ b/examples/inference/samplers/run.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-for f in cpnest_stub.ini emcee_stub.ini emcee_pt_stub.ini dynesty_stub.ini ultranest_stub.ini epsie_stub.ini; do
+for f in cpnest_stub.ini emcee_stub.ini emcee_pt_stub.ini dynesty_stub.ini ultranest_stub.ini epsie_stub.ini nessai_stub.ini; do
         echo $f
 	pycbc_inference \
         --config-files `dirname $0`/simp.ini `dirname $0`/$f \
@@ -16,4 +16,8 @@ dynesty_stub.ini.hdf:dynesty \
 ultranest_stub.ini.hdf:ultranest \
 epsie_stub.ini.hdf:espie \
 cpnest_stub.ini.hdf:cpnest \
---output-file sample.png
+nessai_stub.ini.hdf:nessai \
+--output-file sample.png \
+--plot-contours \
+--no-contour-labels \
+--no-marginal-titles

--- a/examples/inference/samplers/run.sh
+++ b/examples/inference/samplers/run.sh
@@ -19,5 +19,6 @@ cpnest_stub.ini.hdf:cpnest \
 nessai_stub.ini.hdf:nessai \
 --output-file sample.png \
 --plot-contours \
+--plot-marginal \
 --no-contour-labels \
 --no-marginal-titles

--- a/examples/inference/samplers/simp.ini
+++ b/examples/inference/samplers/simp.ini
@@ -3,8 +3,14 @@ name = test_normal
 
 [variable_params]
 x =
+y =
 
 [prior-x]
 name = uniform
 min-x = -10
 max-x = 10
+
+[prior-y]
+name = uniform
+min-y = -10
+max-y = 10

--- a/pycbc/inference/io/__init__.py
+++ b/pycbc/inference/io/__init__.py
@@ -37,6 +37,7 @@ from .cpnest import CPNestFile
 from .multinest import MultinestFile
 from .dynesty import DynestyFile
 from .ultranest import UltranestFile
+from .nessai import NessaiFile
 from .posterior import PosteriorFile
 from .txt import InferenceTXTFile
 
@@ -49,6 +50,7 @@ filetypes = {
     DynestyFile.name: DynestyFile,
     PosteriorFile.name: PosteriorFile,
     UltranestFile.name: UltranestFile,
+    NessaiFile.name : NessaiFile,
 }
 
 try:

--- a/pycbc/inference/io/__init__.py
+++ b/pycbc/inference/io/__init__.py
@@ -50,7 +50,7 @@ filetypes = {
     DynestyFile.name: DynestyFile,
     PosteriorFile.name: PosteriorFile,
     UltranestFile.name: UltranestFile,
-    NessaiFile.name : NessaiFile,
+    NessaiFile.name: NessaiFile,
 }
 
 try:

--- a/pycbc/inference/io/dynesty.py
+++ b/pycbc/inference/io/dynesty.py
@@ -90,6 +90,44 @@ class CommonNestedMetadataIO(object):
                      "extracted instead.")
         return parser, actions
 
+    def write_pickled_data_into_checkpoint_file(self, state):
+        """Dump the sampler state into checkpoint file
+        """
+        if 'sampler_info/saved_state' not in self:
+            self.create_group('sampler_info/saved_state')
+        dump_state(state, self, path='sampler_info/saved_state')
+
+    def read_pickled_data_from_checkpoint_file(self):
+        """Load the sampler state (pickled) from checkpoint file
+        """
+        return load_state(self, path='sampler_info/saved_state')
+
+    def write_raw_samples(self, data, parameters=None):
+        """Write the nested samples to the file
+        """
+        if 'samples' not in self:
+            self.create_group('samples')
+        write_samples_to_file(self, data, parameters=parameters,
+                              group='samples')
+    def validate(self):
+        """Runs a validation test.
+        This checks that a samples group exist, and that pickeled data can
+        be loaded.
+
+        Returns
+        -------
+        bool :
+            Whether or not the file is valid as a checkpoint file.
+        """
+        try:
+            if 'sampler_info/saved_state' in self:
+                load_state(self, path='sampler_info/saved_state')
+            checkpoint_valid = True
+        except KeyError:
+            checkpoint_valid = False
+        return checkpoint_valid
+
+
 class DynestyFile(CommonNestedMetadataIO, BaseNestedSamplerFile):
     """Class to handle file IO for the ``dynesty`` sampler."""
 
@@ -148,41 +186,3 @@ class DynestyFile(CommonNestedMetadataIO, BaseNestedSamplerFile):
             return post
         else:
             return samples
-
-    def write_pickled_data_into_checkpoint_file(self, state):
-        """Dump the sampler state into checkpoint file
-        """
-        if 'sampler_info/saved_state' not in self:
-            self.create_group('sampler_info/saved_state')
-        dump_state(state, self, path='sampler_info/saved_state')
-
-    def read_pickled_data_from_checkpoint_file(self):
-        """Load the sampler state (pickled) from checkpoint file
-        """
-        return load_state(self, path='sampler_info/saved_state')
-
-    def write_raw_samples(self, data, parameters=None):
-        """Write the nested samples to the file
-        """
-        if 'samples' not in self:
-            self.create_group('samples')
-        write_samples_to_file(self, data, parameters=parameters,
-                              group='samples')
-
-    def validate(self):
-        """Runs a validation test.
-        This checks that a samples group exist, and that pickeled data can
-        be loaded.
-
-        Returns
-        -------
-        bool :
-            Whether or not the file is valid as a checkpoint file.
-        """
-        try:
-            if 'sampler_info/saved_state' in self:
-                load_state(self, path='sampler_info/saved_state')
-            checkpoint_valid = True
-        except KeyError:
-            checkpoint_valid = False
-        return checkpoint_valid

--- a/pycbc/inference/io/nessai.py
+++ b/pycbc/inference/io/nessai.py
@@ -37,33 +37,14 @@ class NessaiFile(CommonNestedMetadataIO, BaseNestedSamplerFile):
         loglikelihood = read_raw_samples_from_file(
             self, ['loglikelihood'])['loglikelihood']
         if not raw_samples:
-            n = len(logwt)
+            n_samples = len(logwt)
             # Rejection sample
             rng = numpy.random.default_rng(seed)
             logwt -= logwt.max()
-            logu = numpy.log(rng.random(n))
+            logu = numpy.log(rng.random(n_samples))
             keep = logwt > logu
             post = {'loglikelihood': loglikelihood[keep]}
             for param in fields:
                 post[param] = samples[param][keep]
             return post
-        else:
-            return samples
-
-    def write_pickled_data_into_checkpoint_file(self, data):
-        """Write the pickled data into a checkpoint file"""
-        if "sampler_info/saved_state" not in self:
-            self.create_group("sampler_info/saved_state")
-        dump_state(data, self, path="sampler_info/saved_state")
-
-    def read_pickled_data_from_checkpoint_file(self):
-        """Read the pickled data from a checkpoint file"""
-        return load_state(self, path="sampler_info/saved_state")
-
-    def write_raw_samples(self, data, parameters=None):
-        """Write the nested samples to the file"""
-        if "samples" not in self:
-            self.create_group("samples")
-        write_samples_to_file(
-            self, data, parameters=parameters, group="samples"
-        )
+        return samples

--- a/pycbc/inference/io/nessai.py
+++ b/pycbc/inference/io/nessai.py
@@ -1,8 +1,30 @@
 """Provides IO for the nessai sampler"""
+
 from .base_nested_sampler import BaseNestedSamplerFile
+
+from ...io.hdf import dump_state, load_state
+from .posterior import write_samples_to_file
 
 
 class NessaiFile(BaseNestedSamplerFile):
     """Class to handle file IO for the ``nessai`` sampler."""
 
-    name = 'nessai_file'
+    name = "nessai_file"
+
+    def write_pickled_data_into_checkpoint_file(self, data):
+        """Write the pickled data into a checkpoint file"""
+        if "sampler_info/saved_state" not in self:
+            self.create_group("sampler_info/saved_state")
+        dump_state(data, self, path="sampler_info/saved_state")
+
+    def read_pickled_data_from_checkpoint_file(self):
+        """Read the pickled data from a checkpoint file"""
+        return load_state(self, path="sampler_info/saved_state")
+
+    def write_raw_samples(self, data, parameters=None):
+        """Write the nested samples to the file"""
+        if "samples" not in self:
+            self.create_group("samples")
+        write_samples_to_file(
+            self, data, parameters=parameters, group="samples"
+        )

--- a/pycbc/inference/io/nessai.py
+++ b/pycbc/inference/io/nessai.py
@@ -37,11 +37,11 @@ class NessaiFile(CommonNestedMetadataIO, BaseNestedSamplerFile):
         loglikelihood = read_raw_samples_from_file(
             self, ['loglikelihood'])['loglikelihood']
         if not raw_samples:
-            N = len(logwt)
+            n = len(logwt)
             # Rejection sample
             rng = numpy.random.default_rng(seed)
             logwt -= logwt.max()
-            logu = numpy.log(rng.rand(N))
+            logu = numpy.log(rng.rand(n))
             keep = logwt > logu
             post = {'loglikelihood': loglikelihood[keep]}
             for param in fields:

--- a/pycbc/inference/io/nessai.py
+++ b/pycbc/inference/io/nessai.py
@@ -1,15 +1,54 @@
 """Provides IO for the nessai sampler"""
+import numpy
 
 from .base_nested_sampler import BaseNestedSamplerFile
 
 from ...io.hdf import dump_state, load_state
-from .posterior import write_samples_to_file
+from .posterior import read_raw_samples_from_file, write_samples_to_file
+from .dynesty import CommonNestedMetadataIO
 
 
-class NessaiFile(BaseNestedSamplerFile):
+class NessaiFile(CommonNestedMetadataIO, BaseNestedSamplerFile):
     """Class to handle file IO for the ``nessai`` sampler."""
 
     name = "nessai_file"
+
+    def read_raw_samples(self, fields, raw_samples=False, seed=0):
+        """Reads samples from a nessai file and constructs a posterior.
+
+        Using rejection sampling to resample the nested samples
+
+        Parameters
+        ----------
+        fields : list of str
+            The names of the parameters to load. Names must correspond to
+            dataset names in the file's ``samples`` group.
+        raw_samples : bool, optional
+            Return the raw (unweighted) samples instead of the estimated
+            posterior samples. Default is False.
+
+        Returns
+        -------
+        dict :
+            Dictionary of parameter fields -> samples.
+        """
+        samples = read_raw_samples_from_file(self, fields)
+        logwt = read_raw_samples_from_file(self, ['logwt'])['logwt']
+        loglikelihood = read_raw_samples_from_file(
+            self, ['loglikelihood'])['loglikelihood']
+        if not raw_samples:
+            N = len(logwt)
+            # Rejection sample
+            rng = numpy.random.default_rng(seed)
+            logwt -= logwt.max()
+            logu = numpy.log(rng.rand(N))
+            keep = logwt > logu
+            post = {'loglikelihood': loglikelihood[keep]}
+            for param in fields:
+                post[param] = samples[param][keep]
+            return post
+        else:
+            return samples
 
     def write_pickled_data_into_checkpoint_file(self, data):
         """Write the pickled data into a checkpoint file"""

--- a/pycbc/inference/io/nessai.py
+++ b/pycbc/inference/io/nessai.py
@@ -41,7 +41,7 @@ class NessaiFile(CommonNestedMetadataIO, BaseNestedSamplerFile):
             # Rejection sample
             rng = numpy.random.default_rng(seed)
             logwt -= logwt.max()
-            logu = numpy.log(rng.rand(n))
+            logu = numpy.log(rng.random(n))
             keep = logwt > logu
             post = {'loglikelihood': loglikelihood[keep]}
             for param in fields:

--- a/pycbc/inference/io/nessai.py
+++ b/pycbc/inference/io/nessai.py
@@ -3,8 +3,7 @@ import numpy
 
 from .base_nested_sampler import BaseNestedSamplerFile
 
-from ...io.hdf import dump_state, load_state
-from .posterior import read_raw_samples_from_file, write_samples_to_file
+from .posterior import read_raw_samples_from_file
 from .dynesty import CommonNestedMetadataIO
 
 

--- a/pycbc/inference/io/nessai.py
+++ b/pycbc/inference/io/nessai.py
@@ -1,0 +1,8 @@
+"""Provides IO for the nessai sampler"""
+from .base_nested_sampler import BaseNestedSamplerFile
+
+
+class NessaiFile(BaseNestedSamplerFile):
+    """Class to handle file IO for the ``nessai`` sampler."""
+
+    name = 'nessai_file'

--- a/pycbc/inference/sampler/__init__.py
+++ b/pycbc/inference/sampler/__init__.py
@@ -66,6 +66,13 @@ try:
 except ImportError:
     pass
 
+try:
+    from .nessai import NessaiSampler
+    samplers[NessaiSampler.name] = NessaiSampler
+except ImportError:
+    pass
+
+
 def load_from_config(cp, model, **kwargs):
     """Loads a sampler from the given config file.
 

--- a/pycbc/inference/sampler/nessai.py
+++ b/pycbc/inference/sampler/nessai.py
@@ -239,7 +239,6 @@ class NessaiSampler(BaseSampler):
 
         This is not used for nessai.
         """
-        pass
 
     def checkpoint_callback(self, state):
         """Callback for checkpointing.

--- a/pycbc/inference/sampler/nessai.py
+++ b/pycbc/inference/sampler/nessai.py
@@ -126,7 +126,7 @@ class NessaiSampler(BaseSampler):
     @staticmethod
     def get_default_kwds(importance_nested_sampler=False):
         """Return lists of all allowed keyword arguments for nessai.
-        
+
         Returns
         -------
         default_kwds : list
@@ -159,7 +159,7 @@ class NessaiSampler(BaseSampler):
             )
         else:
             importance_nested_sampler = False
-        
+
         # Requires additional development work, see the model class below
         if importance_nested_sampler is True:
             raise NotImplementedError(
@@ -243,7 +243,7 @@ class NessaiSampler(BaseSampler):
 
     def checkpoint_callback(self, state):
         """Callback for checkpointing.
-        
+
         This will be called periodically by nessai.
         """
         for fn in [self.checkpoint_file, self.backup_file]:
@@ -275,7 +275,7 @@ class NessaiSampler(BaseSampler):
 
     def write_results(self, filename):
         """Write the results to a given file.
-        
+
         Writes the nested samples, log-evidence and log-evidence error.
         """
         with self.io(filename, "a") as fp:

--- a/pycbc/inference/sampler/nessai.py
+++ b/pycbc/inference/sampler/nessai.py
@@ -99,7 +99,7 @@ class NessaiSampler(BaseSampler):
         run_kwds = self.run_kwds.copy()
 
         if kwargs is not None:
-            logging.info(f"Updating keyword arguments with {kwargs}")
+            logging.info("Updating keyword arguments with %s" % kwargs)
             extra_kwds.update(
                 {k: v for k, v in kwargs.items() if k in default_kwds}
             )
@@ -125,7 +125,15 @@ class NessaiSampler(BaseSampler):
 
     @staticmethod
     def get_default_kwds(importance_nested_sampler=False):
-        # Determine all possible keyword arguments that are not hardcoded
+        """Return lists of all allowed keyword arguments for nessai.
+        
+        Returns
+        -------
+        default_kwds : list
+            List of keyword arguments that can be passed to FlowSampler
+        run_kwds: list
+            List of keyword arguments that can be passed to FlowSampler.run
+        """
         return nessai.utils.settings.get_all_kwargs(
             importance_nested_sampler=importance_nested_sampler,
             split_kwargs=True,
@@ -195,8 +203,8 @@ class NessaiSampler(BaseSampler):
             raise RuntimeError(
                 f"Config contains unknown options: {invalid_kwds}"
             )
-        logging.info(f"nessai keyword arguments: {kwds}")
-        logging.info(f"nessai run keyword arguments: {run_kwds}")
+        logging.info("nessai keyword arguments: %s" % kwds)
+        logging.info("nessai run keyword arguments: %s" % run_kwds)
 
         loglikelihood_function = get_optional_arg_from_config(
             cp, section, "loglikelihood-function"
@@ -247,16 +255,16 @@ class NessaiSampler(BaseSampler):
             with loadfile(self.checkpoint_file, "r") as fp:
                 self.resume_data = fp.read_pickled_data_from_checkpoint_file()
             logging.info(
-                f"Found valid checkpoint file: {self.checkpoint_file}"
+                "Found valid checkpoint file: %s" % self.checkpoint_file
             )
         except Exception as e:
-            logging.info("Failed to load checkpoint file with error: {e}")
+            logging.info("Failed to load checkpoint file with error: %s" % e)
 
     def finalize(self):
         """Finalize sampling"""
         logz = self._sampler.ns.log_evidence
         dlogz = self._sampler.ns.log_evidence_error
-        logging.info(f"log Z, dlog Z: {logz}, {dlogz}")
+        logging.info("log Z, dlog Z: %s, %s" % (logz, dlogz))
         self.checkpoint()
 
     def write_results(self, filename):
@@ -310,6 +318,7 @@ class NessaiModel(nessai.model.Model):
         self.parallelise_prior = True
 
     def to_dict(self, x):
+        """Convert nessai a live point array to a dictionary."""
         return {n: x[n].item() for n in self.names}
 
     def to_live_points(self, x):

--- a/pycbc/inference/sampler/nessai.py
+++ b/pycbc/inference/sampler/nessai.py
@@ -99,7 +99,7 @@ class NessaiSampler(BaseSampler):
         run_kwds = self.run_kwds.copy()
 
         if kwargs is not None:
-            logging.info("Updating keyword arguments with %s" % kwargs)
+            logging.info("Updating keyword arguments with %s", kwargs)
             extra_kwds.update(
                 {k: v for k, v in kwargs.items() if k in default_kwds}
             )
@@ -208,8 +208,8 @@ class NessaiSampler(BaseSampler):
             raise RuntimeError(
                 f"Config contains unknown options: {invalid_kwds}"
             )
-        logging.info("nessai keyword arguments: %s" % kwds)
-        logging.info("nessai run keyword arguments: %s" % run_kwds)
+        logging.info("nessai keyword arguments: %s", kwds)
+        logging.info("nessai run keyword arguments: %s", run_kwds)
 
         loglikelihood_function = get_optional_arg_from_config(
             cp, section, "loglikelihood-function"
@@ -261,16 +261,16 @@ class NessaiSampler(BaseSampler):
             with loadfile(self.checkpoint_file, "r") as fp:
                 self.resume_data = fp.read_pickled_data_from_checkpoint_file()
             logging.info(
-                "Found valid checkpoint file: %s" % self.checkpoint_file
+                "Found valid checkpoint file: %s", self.checkpoint_file
             )
         except Exception as e:
-            logging.info("Failed to load checkpoint file with error: %s" % e)
+            logging.info("Failed to load checkpoint file with error: %s", e)
 
     def finalize(self):
         """Finalize sampling"""
         logz = self._sampler.ns.log_evidence
         dlogz = self._sampler.ns.log_evidence_error
-        logging.info("log Z, dlog Z: %s, %s" % (logz, dlogz))
+        logging.info("log Z, dlog Z: %s, %s", logz, dlogz)
         self.checkpoint()
 
     def write_results(self, filename):

--- a/pycbc/inference/sampler/nessai.py
+++ b/pycbc/inference/sampler/nessai.py
@@ -44,7 +44,7 @@ class NessaiSampler(BaseSampler):
         self.run_kwds = run_kwds if run_kwds is not None else {}
 
         nessai.utils.multiprocessing.initialise_pool_variables(self.model_call)
-        self.pool = choose_pool(mpi=use_mpi, processes=nprocesses) 
+        self.pool = choose_pool(mpi=use_mpi, processes=nprocesses)
         self.nprocesses = nprocesses
 
         self._sampler = None
@@ -73,13 +73,13 @@ class NessaiSampler(BaseSampler):
             self.model.sampling_params,
         )
         samples["logwt"] = self._sampler.ns.state.log_posterior_weights
-        samples["loglikelihood"] = self._sampler.nested_samples["loglikelihood"]
+        samples["loglikelihood"] = self._sampler.nested_samples["logL"]
         return samples
 
     def run(self):
         out_dir = os.path.join(
             os.path.dirname(os.path.abspath(self.checkpoint_file)),
-            "nessai",
+            "outdir_nessai",
         )
         if self._sampler is None:
             self._sampler = nessai.flowsampler.FlowSampler(

--- a/pycbc/inference/sampler/nessai.py
+++ b/pycbc/inference/sampler/nessai.py
@@ -1,0 +1,186 @@
+"""
+This modules provides class for using the nessai sampler package for parameter
+estimation.
+"""
+import os
+
+import nessai.flowsampler
+import nessai.model
+import nessai.livepoint
+import numpy.lib.recfunctions as rfn
+
+from .base import BaseSampler, setup_output
+from .base_mcmc import get_optional_arg_from_config
+from ..io import NessaiFile
+
+
+class NessaiSampler(BaseSampler):
+    """Class to construct a FlowSampler from the nessai package."""
+
+    name = "nessai"
+    _io = NessaiFile
+
+    def __init__(self, model, nlive, loglikelihood_function, **kwargs):
+        super().__init__(model)
+
+        # TODO: add other options
+        self.nlive = nlive
+        self.model_call = NessaiModel(self.model, loglikelihood_function)
+
+        #TODO: handle multiprocessing
+
+        self._sampler = None
+        self._nested_samples = None
+        self._posterior_samples = None
+        self._logz = None
+        self._dlogz = None
+        self.checkpoint_file = None
+
+    @property
+    def io(self):
+        return self._io
+
+    @property
+    def model_stats(self):
+        return {
+            "loglikelihood": self._sampler.posterior_samples["logL"],
+            "logprior": self._sampler.posterior_samples["logP"],
+        }
+    
+    @property
+    def samples(self):
+        return nessai.livepoint.live_points_to_dict(
+            self._sampler.posterior_samples,
+            self.model.sampling_params,
+        )
+
+    def run(self, resume=False):
+        out_dir = os.path.dirname(os.path.abspath(self.checkpoint_file))
+        if self._sampler is None:
+            self._sampler = nessai.flowsampler.FlowSampler(
+                self.model_call,
+                output=out_dir,
+                nlive=self.nlive,
+                resume=resume,
+            )
+        self._sampler.run()
+
+    @classmethod
+    def from_config(cls, cp, model, output_file=None, nprocesses=1,
+                    use_mpi=False):
+        """
+        Loads the sampler from the given config file.
+        """
+        section = "sampler"
+        # check name
+        assert cp.get(section, "name") == cls.name, (
+            "name in section [sampler] must match mine")
+        # get the number of live points to use
+        # TODO: add other options
+        nlive = int(cp.get(section, "nlive"))
+
+        loglikelihood_function = \
+            get_optional_arg_from_config(cp, section, 'loglikelihood-function')
+        obj = cls(
+            model,
+            nlive=nlive,
+            loglikelihood_function=loglikelihood_function,
+        )
+
+        setup_output(obj, output_file, check_nsamples=False)
+        if not obj.new_checkpoint:
+            obj.resume_from_checkpoint()
+        return obj
+
+    def set_initial_conditions(self, initial_distribution=None,
+                               samples_file=None):
+        """Sets up the starting point for the sampler.
+
+        Should also set the sampler's random state.
+        """
+        pass
+
+    def checkpoint(self):
+        self._sampler.ns.checkpoint()
+
+    def resume_from_checkpoint(self):
+        # TODO: check this works
+        self.run(resume=True)
+
+    def finalize(self):
+        logz = self._sampler.log_evidence
+        dlogz = self._sampler.log_evidence_error
+
+        for fn in [self.checkpoint_file]:
+            with self.io(fn, "a") as fp:
+                fp.write_logevidence(logz, dlogz)
+        for fn in [self.checkpoint_file, self.backup_file]:
+            self.write_results(fn)
+
+    def write_results(self, filename):
+        with self.io(filename, "a") as fp:
+            fp.write_samples(self.samples, self.model.sampling_params)
+            fp.write_samples(self.model_stats)
+            fp.write_logevidence(
+                self._sampler.log_evidence,
+                self._sampler.log_evidence_error,
+            )
+
+
+class NessaiModel(nessai.model.Model):
+    """Wrapper for PyCBC Inference model class for use with nessai.
+    
+    Parameters
+    ----------
+    model : inference.BaseModel instance
+        A model instance from PyCBC.
+    loglikelihood_function : str
+        Name of the log-likelihood method to call.
+    """
+    def __init__(self, model, loglikelihood_function=None):
+        self.model = model
+        self.names = list(model.sampling_params)
+
+        # Configure the log-likelihood function
+        if loglikelihood_function is None:
+            loglikelihood_function = 'loglikelihood'
+        self.loglikelihood_function = loglikelihood_function
+
+        # Configure the priors bounds
+        bounds = {}
+        for dist in model.prior_distribution.distributions:
+            bounds.update(**{k: [v.min, v.max] for k, v in dist.bounds.items()})
+        self.bounds = bounds
+
+        # Prior and likelihood are not vectorised
+        self.vectorised_likelihood = False
+        self.vectorised_prior = False
+
+    def to_dict(self, x):
+        return {n: x[n].item() for n in self.names}
+    
+    def to_live_points(self, x):
+        """Convert to the structured arrays used by nessai"""
+        # TODO: could this be improved?
+        return nessai.livepoint.numpy_array_to_live_points(
+            rfn.structured_to_unstructured(x),
+            self.names,
+        )
+
+    def new_point(self, N=1):
+        """Draw a new point"""
+        return self.to_live_points(self.model.prior_rvs(size=N))
+
+    def new_point_log_prob(self, x):
+        """Log-probability for the ``new_point`` method"""
+        return self.batch_evaluate_log_prior(x)
+
+    def log_prior(self, x):
+        """Compute the log-prior"""
+        self.model.update(**self.to_dict(x))
+        return self.model.logprior
+
+    def log_likelihood(self, x):
+        """Compute the log-likelihood"""
+        self.model.update(**self.to_dict(x))
+        return getattr(self.model, self.loglikelihood_function)

--- a/pycbc/inference/sampler/nessai.py
+++ b/pycbc/inference/sampler/nessai.py
@@ -159,6 +159,8 @@ class NessaiSampler(BaseSampler):
             )
         else:
             importance_nested_sampler = False
+        
+        # Requires additional development work, see the model class below
         if importance_nested_sampler is True:
             raise NotImplementedError(
                 "Importance nested sampler is not currently supported"
@@ -184,6 +186,9 @@ class NessaiSampler(BaseSampler):
         kwds = {}
         run_kwds = {}
 
+        # ast.literal_eval is used here since specifying a dictionary with all
+        # various types would be difficult. However, one may wish to revisit
+        # this in future, e.g. if evaluating code is a concern.
         for d_out, d_defaults in zip(
             [kwds, run_kwds], [default_kwds, default_run_kwds]
         ):
@@ -219,6 +224,7 @@ class NessaiSampler(BaseSampler):
             extra_kwds=kwds,
         )
 
+        # Do not need to check number of samples for a nested sampler
         setup_output(obj, output_file, check_nsamples=False)
         if not obj.new_checkpoint:
             obj.resume_from_checkpoint()
@@ -318,12 +324,12 @@ class NessaiModel(nessai.model.Model):
         self.parallelise_prior = True
 
     def to_dict(self, x):
-        """Convert nessai a live point array to a dictionary."""
+        """Convert a nessai live point array to a dictionary"""
         return {n: x[n].item() for n in self.names}
 
     def to_live_points(self, x):
         """Convert to the structured arrays used by nessai"""
-        # TODO: could this be improved?
+        # It is possible this could be made faster
         return nessai.livepoint.numpy_array_to_live_points(
             rfn.structured_to_unstructured(x),
             self.names,
@@ -350,6 +356,7 @@ class NessaiModel(nessai.model.Model):
     def from_unit_hypercube(self, x):
         """Map from the unit-hypercube to the prior."""
         # Needs to be implemented for importance nested sampler
+        # This method is already available in pycbc but the inverse is not
         raise NotImplementedError
 
     def to_unit_hypercube(self, x):

--- a/pycbc/inference/sampler/nessai.py
+++ b/pycbc/inference/sampler/nessai.py
@@ -224,7 +224,7 @@ class NessaiModel(nessai.model.Model):
         bounds = {}
         for dist in model.prior_distribution.distributions:
             bounds.update(
-                **{k: [v.min, v.max] for k, v in dist.bounds.items()}
+                **{k: [v.min, v.max] for k, v in dist.bounds.items() if k in self.names}
             )
         self.bounds = bounds
 


### PR DESCRIPTION
This PR adds basic support for the nested sampler [nessai](https://github.com/mj-will/nessai) in pycbc inference.

This implementation is intended as a starting point that can be refined and improved upon, so there are some limitations (see below). Below I mention a few points that I think are important and/or may need some discussion/tweaks.

**Changes**
- Add `pycbc/inference/io/nessai.py` which includes two classes: the main interface and the nessai model object
- Add `pycbc/inference/sampler/nessai.py` (based on the equivalent for dynesty)
- Add `nessai` to the dictionary of samplers in `pycbc/inference/sampler/__init__.py`

**Config files**

I wanted to avoid needing to provide types for every single keyword argument nessai supports, so I opted to use `ast.literal_eval` to evaluate the arguments. I can understand wanting to avoid literal evaluations, so I can change this if folks have suggestions.

**Requirements**

I made some changes to nessai to enable easier integration with pycbc, so using nessai requires at least `nessai>=0.10`

**Limitations**

There are a few places the implementation could be improved:

- I have not included support for `i-nessai`; it requires some additional methods in model class nessai uses
- Resuming from checkpoints works, but as it stands, there is no means to automatically checkpoint the sampler. nessai supports this internally, but writes to its own file. I'm keen to hear peoples suggestions about how to handle this.
- Some of GW specific features in nessai are not supported, this may require more changes to nessai

**Testing**

I haven't added any unit or integration tests directly, but I can do if that is desired. Instead, I've been testing the implementation using the scripts in this repo: https://github.com/mj-will/nessai-pycbc-testing and the runs I've been doing as a part of other projects.