### PR TITLE
Fix over-verbose offline workflow generator after init_logging change

### DIFF
--- a/bin/workflows/pycbc_make_offline_search_workflow
+++ b/bin/workflows/pycbc_make_offline_search_workflow
@@ -66,7 +66,7 @@ wf.add_workflow_settings_cli(parser)
 args = parser.parse_args()
 
 # By default, we do logging.info, each --verbose adds a level of verbosity
-logging_level = args.verbose + 1 if args.verbose else logging.INFO
+logging_level = args.verbose + 1 if args.verbose else 1
 pycbc.init_logging(logging_level)
 
 container = wf.Workflow(args, args.workflow_name)


### PR DESCRIPTION
After #4564, the offline workflow generator became super-verbose with nothing set.

This fixes it back to be info by default