### PR TITLE
Fix bug with numpy import in pycbc_coinc_findtrigs

### DIFF
--- a/bin/all_sky_search/pycbc_coinc_findtrigs
+++ b/bin/all_sky_search/pycbc_coinc_findtrigs
@@ -181,7 +181,7 @@ if args.randomize_template_order:
     shuffle(template_ids)
     template_ids = template_ids[tmin:tmax]
 else:
-    template_ids = np.array([range(tmin, tmax)])
+    template_ids = numpy.array([range(tmin, tmax)])
 
 original_bank_len = len(template_ids)
 


### PR DESCRIPTION
Numpy is imported simply as `import numpy` in `pycbc_coinc_findtrigs`. There is a single call of `np.array` which will cause a name error:

`NameError: name 'np' is not defined`.

This is a simple fix to replace `np.array` with `numpy.array`.