### PR TITLE
Standardise logging: bin/all_sky_search and pycbc/events

### DIFF
--- a/bin/all_sky_search/pycbc_add_statmap
+++ b/bin/all_sky_search/pycbc_add_statmap
@@ -25,9 +25,9 @@ def get_ifo_string(fi):
     return istring
 
 parser = argparse.ArgumentParser()
+pycbc.common_options(parser)
 parser.add_argument('--version', action="version",
                     version=pycbc.version.git_verbose_msg)
-parser.add_argument('--verbose', action='store_true')
 parser.add_argument('--statmap-files', nargs='+',
     help="List of coinc files to be combined")
 parser.add_argument('--background-files', nargs='+', default=None,

--- a/bin/all_sky_search/pycbc_add_statmap
+++ b/bin/all_sky_search/pycbc_add_statmap
@@ -25,7 +25,7 @@ def get_ifo_string(fi):
     return istring
 
 parser = argparse.ArgumentParser()
-pycbc.common_options(parser)
+pycbc.add_common_pycbc_options(parser)
 parser.add_argument('--version', action="version",
                     version=pycbc.version.git_verbose_msg)
 parser.add_argument('--statmap-files', nargs='+',

--- a/bin/all_sky_search/pycbc_apply_rerank
+++ b/bin/all_sky_search/pycbc_apply_rerank
@@ -8,7 +8,7 @@ from pycbc.events import significance
 from shutil import copyfile
 
 parser = argparse.ArgumentParser()
-pycbc.common_options(parser)
+pycbc.add_common_pycbc_options(parser)
 parser.add_argument('--version', action='version',
     version=pycbc.version.git_verbose_msg)
 parser.add_argument('--stat-files', nargs='+',

--- a/bin/all_sky_search/pycbc_apply_rerank
+++ b/bin/all_sky_search/pycbc_apply_rerank
@@ -8,9 +8,9 @@ from pycbc.events import significance
 from shutil import copyfile
 
 parser = argparse.ArgumentParser()
+pycbc.common_options(parser)
 parser.add_argument('--version', action='version',
     version=pycbc.version.git_verbose_msg)
-parser.add_argument('--verbose', action='store_true')
 parser.add_argument('--stat-files', nargs='+',
     help="Statistic files produced by candidate followup codes")
 parser.add_argument('--followup-file',

--- a/bin/all_sky_search/pycbc_average_psd
+++ b/bin/all_sky_search/pycbc_average_psd
@@ -31,7 +31,7 @@ from pycbc.types import MultiDetOptionAction, FrequencySeries
 
 
 parser = argparse.ArgumentParser(description=__doc__)
-pycbc.common_options(parser)
+pycbc.add_common_pycbc_options(parser)
 parser.add_argument('--version', action='version', version=version)
 parser.add_argument('--input-files', nargs='+', required=True, metavar='PATH',
                     help='HDF5 files from pycbc_calculate_psd (one per '

--- a/bin/all_sky_search/pycbc_average_psd
+++ b/bin/all_sky_search/pycbc_average_psd
@@ -31,8 +31,8 @@ from pycbc.types import MultiDetOptionAction, FrequencySeries
 
 
 parser = argparse.ArgumentParser(description=__doc__)
+pycbc.common_options(parser)
 parser.add_argument('--version', action='version', version=version)
-parser.add_argument('--verbose', action='store_true')
 parser.add_argument('--input-files', nargs='+', required=True, metavar='PATH',
                     help='HDF5 files from pycbc_calculate_psd (one per '
                          'detector) containing the input PSDs to average.')

--- a/bin/all_sky_search/pycbc_bin_trigger_rates_dq
+++ b/bin/all_sky_search/pycbc_bin_trigger_rates_dq
@@ -13,7 +13,7 @@ from pycbc.io.hdf import HFile, SingleDetTriggers
 from pycbc.version import git_verbose_msg as version
 
 parser = argparse.ArgumentParser(description=__doc__)
-pycbc.common_options(parser)
+pycbc.add_common_pycbc_options(parser)
 parser.add_argument('--version', action='version', version=version)
 parser.add_argument("--ifo", type=str, required=True)
 parser.add_argument("--trig-file", required=True)

--- a/bin/all_sky_search/pycbc_bin_trigger_rates_dq
+++ b/bin/all_sky_search/pycbc_bin_trigger_rates_dq
@@ -13,8 +13,8 @@ from pycbc.io.hdf import HFile, SingleDetTriggers
 from pycbc.version import git_verbose_msg as version
 
 parser = argparse.ArgumentParser(description=__doc__)
+pycbc.common_options(parser)
 parser.add_argument('--version', action='version', version=version)
-parser.add_argument('--verbose', action="store_true")
 parser.add_argument("--ifo", type=str, required=True)
 parser.add_argument("--trig-file", required=True)
 parser.add_argument("--stat-threshold", type=float, default=1.,

--- a/bin/all_sky_search/pycbc_calculate_dq
+++ b/bin/all_sky_search/pycbc_calculate_dq
@@ -14,7 +14,7 @@ from pycbc.types.timeseries import TimeSeries
 from ligo.segments import segment
 
 parser = argparse.ArgumentParser(description=__doc__)
-pycbc.common_options(parser)
+pycbc.add_common_pycbc_options(parser)
 parser.add_argument('--version', action='version', version=version)
 parser.add_argument("--dq-sample-rate", default=1, type=int,
                     help="Sample rate to calculate dq timeseries, "

--- a/bin/all_sky_search/pycbc_calculate_dq
+++ b/bin/all_sky_search/pycbc_calculate_dq
@@ -14,8 +14,8 @@ from pycbc.types.timeseries import TimeSeries
 from ligo.segments import segment
 
 parser = argparse.ArgumentParser(description=__doc__)
+pycbc.common_options(parser)
 parser.add_argument('--version', action='version', version=version)
-parser.add_argument('--verbose', action="store_true")
 parser.add_argument("--dq-sample-rate", default=1, type=int,
                     help="Sample rate to calculate dq timeseries, "
                          "in Hz [default=1Hz]")

--- a/bin/all_sky_search/pycbc_calculate_dqflag
+++ b/bin/all_sky_search/pycbc_calculate_dqflag
@@ -11,7 +11,7 @@ from pycbc.events import veto
 from pycbc.types.timeseries import TimeSeries
 
 parser = argparse.ArgumentParser(description=__doc__)
-pycbc.common_options(parser)
+pycbc.add_common_pycbc_options(parser)
 parser.add_argument('--version', action='version', version=version)
 parser.add_argument("--gps-start-time", type=int,required=True,
                     help="The gps start time of the data "

--- a/bin/all_sky_search/pycbc_calculate_dqflag
+++ b/bin/all_sky_search/pycbc_calculate_dqflag
@@ -11,8 +11,8 @@ from pycbc.events import veto
 from pycbc.types.timeseries import TimeSeries
 
 parser = argparse.ArgumentParser(description=__doc__)
+pycbc.common_options(parser)
 parser.add_argument('--version', action='version', version=version)
-parser.add_argument('--verbose', action="store_true")
 parser.add_argument("--gps-start-time", type=int,required=True,
                     help="The gps start time of the data "
                           "(integer seconds)")

--- a/bin/all_sky_search/pycbc_calculate_psd
+++ b/bin/all_sky_search/pycbc_calculate_psd
@@ -11,8 +11,8 @@ from ligo.segments import segmentlist, segment
 set_measure_level(0)
 
 parser = argparse.ArgumentParser(description=__doc__)
+pycbc.common_options(parser)
 parser.add_argument('--version', action='version', version=version)
-parser.add_argument('--verbose', action="store_true")
 parser.add_argument("--low-frequency-cutoff", type=float, required=True,
                     help="The low frequency cutoff to use for filtering (Hz)")
 parser.add_argument("--analysis-segment-file",  required=True,

--- a/bin/all_sky_search/pycbc_calculate_psd
+++ b/bin/all_sky_search/pycbc_calculate_psd
@@ -11,7 +11,7 @@ from ligo.segments import segmentlist, segment
 set_measure_level(0)
 
 parser = argparse.ArgumentParser(description=__doc__)
-pycbc.common_options(parser)
+pycbc.add_common_pycbc_options(parser)
 parser.add_argument('--version', action='version', version=version)
 parser.add_argument("--low-frequency-cutoff", type=float, required=True,
                     help="The low frequency cutoff to use for filtering (Hz)")

--- a/bin/all_sky_search/pycbc_coinc_findtrigs
+++ b/bin/all_sky_search/pycbc_coinc_findtrigs
@@ -89,10 +89,6 @@ def parse_template_range(num_templates, rangestr):
 
 logging.info('Starting...')
 
-logging.info("A code-level logging info statement")
-logging.debug("A code-level logging debug statement")
-trigger_cut_dict, template_cut_dict = cuts.ingest_cuts_option_group(args)
-logging.getLogger('pycbc.events.cuts').setLevel(logging.INFO)
 trigger_cut_dict, template_cut_dict = cuts.ingest_cuts_option_group(args)
 
 num_templates = len(h5py.File(args.template_bank, "r")['template_hash'])

--- a/bin/all_sky_search/pycbc_coinc_findtrigs
+++ b/bin/all_sky_search/pycbc_coinc_findtrigs
@@ -4,7 +4,7 @@ import shutil, uuid, os.path, atexit
 from ligo.segments import infinity
 from pycbc.events import veto, coinc, stat, ranking, cuts
 import pycbc.version
-from pycbc import pool
+from pycbc import pool, init_logging
 from numpy.random import seed, shuffle
 from pycbc.io.hdf import ReadByTemplate
 from pycbc.types.optparse import MultiDetOptionAction
@@ -78,9 +78,7 @@ args.segment_name = sum(args.segment_name, [])
 args.veto_files = sum(args.veto_files, [])
 args.trigger_files = sum(args.trigger_files, [])
 
-if args.verbose:
-    logging.basicConfig(format='%(asctime)s : %(message)s', level=logging.DEBUG)
-
+init_logging(args.verbose)
 
 def parse_template_range(num_templates, rangestr):
     part = int(rangestr.split('/')[0])
@@ -238,7 +236,7 @@ def process_template(tnum):
     times_full = {}
     sds_full = {}
     tids_full = {}
-    logging.info('Obtaining trigs for template %i ..' % (tnum))
+    logging.debug('Obtaining trigs for template %i ..' % (tnum))
     for i, sngl in zip(trigs.ifos, trigs.singles):
         # Apply cuts to triggers
         tids_uncut = sngl.set_template(tnum)
@@ -247,7 +245,7 @@ def process_template(tnum):
 
         tids_full[i] = tids_uncut[trigger_keep_ids]
         times_full[i] = sngl['end_time'][trigger_keep_ids]
-        logging.info('%s:%s', i, len(tids_uncut))
+        logging.debug('%s:%s', i, len(tids_uncut))
         if len(tids_full[i]) < len(tids_uncut):
             logging.info("%s triggers cut",
                          len(tids_uncut) - len(tids_full[i]))

--- a/bin/all_sky_search/pycbc_coinc_findtrigs
+++ b/bin/all_sky_search/pycbc_coinc_findtrigs
@@ -10,7 +10,7 @@ from pycbc.io.hdf import ReadByTemplate
 from pycbc.types.optparse import MultiDetOptionAction
 
 parser = argparse.ArgumentParser()
-pycbc.common_options(parser)
+pycbc.add_common_pycbc_options(parser)
 parser.add_argument("--version", action="version", version=pycbc.version.git_verbose_msg)
 parser.add_argument("--veto-files", nargs='*', action='append', default=[],
                     help="Optional veto file. Triggers within veto segments "

--- a/bin/all_sky_search/pycbc_coinc_findtrigs
+++ b/bin/all_sky_search/pycbc_coinc_findtrigs
@@ -10,7 +10,7 @@ from pycbc.io.hdf import ReadByTemplate
 from pycbc.types.optparse import MultiDetOptionAction
 
 parser = argparse.ArgumentParser()
-parser.add_argument("--verbose", action="count")
+pycbc.common_options(parser)
 parser.add_argument("--version", action="version", version=pycbc.version.git_verbose_msg)
 parser.add_argument("--veto-files", nargs='*', action='append', default=[],
                     help="Optional veto file. Triggers within veto segments "

--- a/bin/all_sky_search/pycbc_coinc_findtrigs
+++ b/bin/all_sky_search/pycbc_coinc_findtrigs
@@ -89,6 +89,10 @@ def parse_template_range(num_templates, rangestr):
 
 logging.info('Starting...')
 
+logging.info("A code-level logging info statement")
+logging.debug("A code-level logging debug statement")
+trigger_cut_dict, template_cut_dict = cuts.ingest_cuts_option_group(args)
+logging.getLogger('pycbc.events.cuts').setLevel(logging.INFO)
 trigger_cut_dict, template_cut_dict = cuts.ingest_cuts_option_group(args)
 
 num_templates = len(h5py.File(args.template_bank, "r")['template_hash'])

--- a/bin/all_sky_search/pycbc_coinc_hdfinjfind
+++ b/bin/all_sky_search/pycbc_coinc_hdfinjfind
@@ -6,7 +6,7 @@ files.
 import argparse, h5py, logging, types, numpy, os.path
 from ligo.lw import lsctables, utils as ligolw_utils
 from ligo import segments
-from pycbc import events
+from pycbc import events, init_logging
 from pycbc.events import indices_within_segments
 from pycbc.types import MultiDetOptionAction
 from pycbc.inject import CBCHDFInjectionSet
@@ -55,6 +55,7 @@ def xml_to_hdf(table, hdf_file, hdf_key, columns):
                                         dtype=numpy.float32))
 
 parser = argparse.ArgumentParser(description=__doc__)
+parser.add_argument('--verbose', action='count')
 parser.add_argument('--version', action='version',
                     version=pycbc.version.git_verbose_msg)
 parser.add_argument('--trigger-files', nargs='+', required=True)
@@ -73,13 +74,10 @@ parser.add_argument('--optimal-snr-column', nargs='+',
 parser.add_argument('--redshift-column', default=None,
                     help='Name of sim_inspiral column containing redshift. '
                     'Optional')
-parser.add_argument('--verbose', action='count')
 parser.add_argument('--output-file', required=True)
 args = parser.parse_args()
 
-if args.verbose:
-    log_level = logging.INFO
-    logging.basicConfig(format='%(asctime)s : %(message)s', level=log_level)
+init_logging(args.verbose)
 
 fo = h5py.File(args.output_file, 'w')
 

--- a/bin/all_sky_search/pycbc_coinc_hdfinjfind
+++ b/bin/all_sky_search/pycbc_coinc_hdfinjfind
@@ -55,7 +55,7 @@ def xml_to_hdf(table, hdf_file, hdf_key, columns):
                                         dtype=numpy.float32))
 
 parser = argparse.ArgumentParser(description=__doc__)
-parser.add_argument('--verbose', action='count')
+pycbc.common_options(parser)
 parser.add_argument('--version', action='version',
                     version=pycbc.version.git_verbose_msg)
 parser.add_argument('--trigger-files', nargs='+', required=True)

--- a/bin/all_sky_search/pycbc_coinc_hdfinjfind
+++ b/bin/all_sky_search/pycbc_coinc_hdfinjfind
@@ -55,7 +55,7 @@ def xml_to_hdf(table, hdf_file, hdf_key, columns):
                                         dtype=numpy.float32))
 
 parser = argparse.ArgumentParser(description=__doc__)
-pycbc.common_options(parser)
+pycbc.add_common_pycbc_options(parser)
 parser.add_argument('--version', action='version',
                     version=pycbc.version.git_verbose_msg)
 parser.add_argument('--trigger-files', nargs='+', required=True)

--- a/bin/all_sky_search/pycbc_coinc_mergetrigs
+++ b/bin/all_sky_search/pycbc_coinc_mergetrigs
@@ -30,6 +30,7 @@ def region(f, key, boundaries, ids):
                      dtype=h5py.special_dtype(ref=h5py.RegionReference))
 
 parser = argparse.ArgumentParser()
+pycbc.common_options(parser)
 parser.add_argument('--version', action='version',
                     version=pycbc.version.git_verbose_msg)
 parser.add_argument('--trigger-files', nargs='+')
@@ -38,7 +39,6 @@ parser.add_argument('--bank-file', required=True)
 parser.add_argument('--compression-level', type=int, default=6,
                     help='Set HDF compression level in the output file '
                          '(default 6)')
-parser.add_argument('--verbose', '-v', action='count')
 args = parser.parse_args()
 
 init_logging(args.verbose)

--- a/bin/all_sky_search/pycbc_coinc_mergetrigs
+++ b/bin/all_sky_search/pycbc_coinc_mergetrigs
@@ -30,7 +30,7 @@ def region(f, key, boundaries, ids):
                      dtype=h5py.special_dtype(ref=h5py.RegionReference))
 
 parser = argparse.ArgumentParser()
-pycbc.common_options(parser)
+pycbc.add_common_pycbc_options(parser)
 parser.add_argument('--version', action='version',
                     version=pycbc.version.git_verbose_msg)
 parser.add_argument('--trigger-files', nargs='+')

--- a/bin/all_sky_search/pycbc_coinc_mergetrigs
+++ b/bin/all_sky_search/pycbc_coinc_mergetrigs
@@ -5,7 +5,7 @@
 
 import numpy, argparse, h5py, logging
 import pycbc.version
-
+from pycbc import init_logging
 
 def changes(arr):
     l = numpy.where(arr[:-1] != arr[1:])[0]
@@ -41,7 +41,7 @@ parser.add_argument('--compression-level', type=int, default=6,
 parser.add_argument('--verbose', '-v', action='count')
 args = parser.parse_args()
 
-logging.basicConfig(format='%(asctime)s : %(message)s', level=logging.INFO)
+init_logging(args.verbose)
 
 f = h5py.File(args.output_file, 'w')
 

--- a/bin/all_sky_search/pycbc_coinc_statmap
+++ b/bin/all_sky_search/pycbc_coinc_statmap
@@ -34,6 +34,7 @@ class fw(object):
 
 parser = argparse.ArgumentParser()
 # General required options
+pycbc.common_options(parser)
 parser.add_argument('--version', action='version',
                     version=pycbc.version.git_verbose_msg)
 parser.add_argument('--coinc-files', nargs='+',
@@ -41,7 +42,6 @@ parser.add_argument('--coinc-files', nargs='+',
                          'FAP, FAR, etc.')
 parser.add_argument('--ifos', nargs='+',
                     help='List of ifos used in these coincidence files')
-parser.add_argument('--verbose', action='count')
 parser.add_argument('--cluster-window', type=float, default=10,
                     help='Length of time window in seconds to cluster coinc '
                          'events [default=10s]')

--- a/bin/all_sky_search/pycbc_coinc_statmap
+++ b/bin/all_sky_search/pycbc_coinc_statmap
@@ -34,7 +34,7 @@ class fw(object):
 
 parser = argparse.ArgumentParser()
 # General required options
-pycbc.common_options(parser)
+pycbc.add_common_pycbc_options(parser)
 parser.add_argument('--version', action='version',
                     version=pycbc.version.git_verbose_msg)
 parser.add_argument('--coinc-files', nargs='+',

--- a/bin/all_sky_search/pycbc_coinc_statmap_inj
+++ b/bin/all_sky_search/pycbc_coinc_statmap_inj
@@ -12,7 +12,7 @@ from pycbc import init_logging
 
 parser = argparse.ArgumentParser()
 # General required options
-pycbc.common_options(parser)
+pycbc.add_common_pycbc_options(parser)
 parser.add_argument('--version', action='version',
                     version=pycbc.version.git_verbose_msg)
 parser.add_argument('--cluster-window', type=float, default=10,

--- a/bin/all_sky_search/pycbc_coinc_statmap_inj
+++ b/bin/all_sky_search/pycbc_coinc_statmap_inj
@@ -8,6 +8,7 @@ import argparse, h5py, logging, itertools, copy, pycbc.io, numpy, lal
 from pycbc.events import veto, coinc, significance
 import pycbc.version
 import pycbc.conversions as conv
+from pycbc import init_logging
 
 parser = argparse.ArgumentParser()
 # General required options
@@ -31,11 +32,9 @@ significance.insert_significance_option_group(parser)
 parser.add_argument('--output-file')
 args = parser.parse_args()
 
-significance.check_significance_options(args, parser)
+init_logging(args.verbose)
 
-if args.verbose:
-    log_level = logging.INFO
-    logging.basicConfig(format='%(asctime)s : %(message)s', level=log_level)
+significance.check_significance_options(args, parser)
 
 ifo_key = ''.join(args.ifos)
 significance_dict = significance.digest_significance_options([ifo_key], args)

--- a/bin/all_sky_search/pycbc_coinc_statmap_inj
+++ b/bin/all_sky_search/pycbc_coinc_statmap_inj
@@ -12,7 +12,7 @@ from pycbc import init_logging
 
 parser = argparse.ArgumentParser()
 # General required options
-parser.add_argument('--verbose', action='count')
+pycbc.common_options(parser)
 parser.add_argument('--version', action='version',
                     version=pycbc.version.git_verbose_msg)
 parser.add_argument('--cluster-window', type=float, default=10,

--- a/bin/all_sky_search/pycbc_combine_coincident_events
+++ b/bin/all_sky_search/pycbc_combine_coincident_events
@@ -55,8 +55,8 @@ def com_with_detector_key(f, files, group):
     
 
 parser = argparse.ArgumentParser()
+pycbc.common_options(parser)
 parser.add_argument("--version", action="version", version=pycbc.version.git_verbose_msg)
-parser.add_argument('--verbose', action='store_true')
 parser.add_argument('--statmap-files', nargs='+',
                     help="List of coinc files to be redistributed")
 parser.add_argument('--output-file', help="name of output file")

--- a/bin/all_sky_search/pycbc_combine_coincident_events
+++ b/bin/all_sky_search/pycbc_combine_coincident_events
@@ -55,7 +55,7 @@ def com_with_detector_key(f, files, group):
     
 
 parser = argparse.ArgumentParser()
-pycbc.common_options(parser)
+pycbc.add_common_pycbc_options(parser)
 parser.add_argument("--version", action="version", version=pycbc.version.git_verbose_msg)
 parser.add_argument('--statmap-files', nargs='+',
                     help="List of coinc files to be redistributed")

--- a/bin/all_sky_search/pycbc_combine_statmap
+++ b/bin/all_sky_search/pycbc_combine_statmap
@@ -9,7 +9,7 @@ import pycbc.version
 from ligo import segments
 
 parser = argparse.ArgumentParser()
-pycbc.common_options(parser)
+pycbc.add_common_pycbc_options(parser)
 parser.add_argument("--version", action="version", version=pycbc.version.git_verbose_msg)
 parser.add_argument('--statmap-files', nargs='+',
                     help="List of coinc files to be redistributed")

--- a/bin/all_sky_search/pycbc_combine_statmap
+++ b/bin/all_sky_search/pycbc_combine_statmap
@@ -9,8 +9,8 @@ import pycbc.version
 from ligo import segments
 
 parser = argparse.ArgumentParser()
+pycbc.common_options(parser)
 parser.add_argument("--version", action="version", version=pycbc.version.git_verbose_msg)
-parser.add_argument('--verbose', action='store_true')
 parser.add_argument('--statmap-files', nargs='+',
                     help="List of coinc files to be redistributed")
 parser.add_argument('--cluster-window', type=float)

--- a/bin/all_sky_search/pycbc_cut_merge_triggers_to_tmpltbank
+++ b/bin/all_sky_search/pycbc_cut_merge_triggers_to_tmpltbank
@@ -29,7 +29,7 @@ import pycbc
 import pycbc.version
 
 parser = argparse.ArgumentParser(description=__doc__)
-pycbc.common_options(parser)
+pycbc.add_common_pycbc_options(parser)
 parser.add_argument("--version", action="version",
                     version=pycbc.version.git_verbose_msg)
 parser.add_argument("--input-file", required=True,

--- a/bin/all_sky_search/pycbc_cut_merge_triggers_to_tmpltbank
+++ b/bin/all_sky_search/pycbc_cut_merge_triggers_to_tmpltbank
@@ -29,10 +29,9 @@ import pycbc
 import pycbc.version
 
 parser = argparse.ArgumentParser(description=__doc__)
+pycbc.common_options(parser)
 parser.add_argument("--version", action="version",
                     version=pycbc.version.git_verbose_msg)
-parser.add_argument("-V", "--verbose", action="store_true",
-                    help="print extra debugging information", default=False)
 parser.add_argument("--input-file", required=True,
                     help="Input merge triggers HDF file.")
 parser.add_argument("--output-file", required=True,

--- a/bin/all_sky_search/pycbc_distribute_background_bins
+++ b/bin/all_sky_search/pycbc_distribute_background_bins
@@ -4,7 +4,7 @@ import pycbc.version
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--version", action=pycbc.version.Version)
-parser.add_argument('--verbose', action='store_true')
+pycbc.common_options(parser)
 parser.add_argument('--coinc-files', nargs='+',
                     help="List of coinc files to be redistributed")
 parser.add_argument('--background-bins', nargs='+',

--- a/bin/all_sky_search/pycbc_distribute_background_bins
+++ b/bin/all_sky_search/pycbc_distribute_background_bins
@@ -4,7 +4,7 @@ import pycbc.version
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--version", action=pycbc.version.Version)
-pycbc.common_options(parser)
+pycbc.add_common_pycbc_options(parser)
 parser.add_argument('--coinc-files', nargs='+',
                     help="List of coinc files to be redistributed")
 parser.add_argument('--background-bins', nargs='+',

--- a/bin/all_sky_search/pycbc_dtphase
+++ b/bin/all_sky_search/pycbc_dtphase
@@ -20,7 +20,7 @@ from copy import deepcopy
 
 
 parser = argparse.ArgumentParser(description=__doc__)
-pycbc.common_options(parser)
+pycbc.add_common_pycbc_options(parser)
 parser.add_argument('--ifos', nargs='+',
                     help="The ifos to generate a histogram for")
 parser.add_argument('--sample-size', type=int, required=True,

--- a/bin/all_sky_search/pycbc_dtphase
+++ b/bin/all_sky_search/pycbc_dtphase
@@ -20,6 +20,7 @@ from copy import deepcopy
 
 
 parser = argparse.ArgumentParser(description=__doc__)
+pycbc.common_options(parser)
 parser.add_argument('--ifos', nargs='+',
                     help="The ifos to generate a histogram for")
 parser.add_argument('--sample-size', type=int, required=True,
@@ -34,7 +35,6 @@ parser.add_argument('--relative-sensitivities', nargs='+', type=float,
                          "expected SNR at fixed distance, one for each ifo")
 parser.add_argument('--seed', type=int, default=124)
 parser.add_argument('--output-file', required=True)
-parser.add_argument('--verbose', action='store_true')
 parser.add_argument('--bin-density', type=int, default=1,
                     help="Number of bins per 1 sigma uncertainty in a "
                          "parameter. Higher values increase the resolution of "

--- a/bin/all_sky_search/pycbc_exclude_zerolag
+++ b/bin/all_sky_search/pycbc_exclude_zerolag
@@ -10,9 +10,9 @@ from pycbc.events import veto, coinc, significance
 import pycbc.conversions as conv
 
 parser = argparse.ArgumentParser()
+pycbc.common_options(parser)
 parser.add_argument("--version", action="version",
                     version=pycbc.version.git_verbose_msg)
-parser.add_argument('--verbose', action='store_true')
 parser.add_argument('--statmap-file', type=str,
     help="Coinc statmap file to be recalculated based on foreground removal")
 parser.add_argument('--other-statmap-files', nargs='+',

--- a/bin/all_sky_search/pycbc_exclude_zerolag
+++ b/bin/all_sky_search/pycbc_exclude_zerolag
@@ -10,7 +10,7 @@ from pycbc.events import veto, coinc, significance
 import pycbc.conversions as conv
 
 parser = argparse.ArgumentParser()
-pycbc.common_options(parser)
+pycbc.add_common_pycbc_options(parser)
 parser.add_argument("--version", action="version",
                     version=pycbc.version.git_verbose_msg)
 parser.add_argument('--statmap-file', type=str,

--- a/bin/all_sky_search/pycbc_fit_sngls_binned
+++ b/bin/all_sky_search/pycbc_fit_sngls_binned
@@ -33,7 +33,7 @@ import pycbc.version
 parser = argparse.ArgumentParser(usage="",
     description="Perform maximum-likelihood fits of single inspiral trigger"
                 " distributions to various functions")
-pycbc.common_options(parser)
+pycbc.add_common_pycbc_options(parser)
 parser.add_argument("--version", action=pycbc.version.Version)
 parser.add_argument("--trigger-file",
                     help="Input hdf5 file containing single triggers. "

--- a/bin/all_sky_search/pycbc_fit_sngls_binned
+++ b/bin/all_sky_search/pycbc_fit_sngls_binned
@@ -33,10 +33,8 @@ import pycbc.version
 parser = argparse.ArgumentParser(usage="",
     description="Perform maximum-likelihood fits of single inspiral trigger"
                 " distributions to various functions")
-
+pycbc.common_options(parser)
 parser.add_argument("--version", action=pycbc.version.Version)
-parser.add_argument("-V", "--verbose", action="store_true",
-                    help="Print extra debugging information", default=False)
 parser.add_argument("--trigger-file",
                     help="Input hdf5 file containing single triggers. "
                     "Required")

--- a/bin/all_sky_search/pycbc_fit_sngls_by_template
+++ b/bin/all_sky_search/pycbc_fit_sngls_by_template
@@ -59,10 +59,8 @@ def get_stat(statname, trigs, threshold):
 parser = argparse.ArgumentParser(usage="",
     description="Perform maximum-likelihood fits of single inspiral trigger"
                 " distributions to various functions")
-
+pycbc.common_options(parser)
 parser.add_argument("--version", action=pycbc.version.Version)
-parser.add_argument("-V", "--verbose", action="store_true",
-                    help="Print extra debugging information", default=False)
 parser.add_argument("--trigger-file",
                     help="Input hdf5 file containing single triggers. "
                     "Required")

--- a/bin/all_sky_search/pycbc_fit_sngls_by_template
+++ b/bin/all_sky_search/pycbc_fit_sngls_by_template
@@ -18,7 +18,7 @@ import argparse, logging
 
 import copy, numpy as np
 
-from pycbc import io, events
+from pycbc import io, events, init_logging
 from pycbc.events import triggers, trigger_fits as trstats
 from pycbc.events import stat as statsmod
 from pycbc.types.optparse import MultiDetOptionAction
@@ -124,6 +124,9 @@ statsmod.insert_statistic_option_group(parser,
     default_ranking_statistic='single_ranking_only')
 args = parser.parse_args()
 
+logging_level = 1 if args.verbose is None else args.verbose + 1
+init_logging(logging.level)
+
 args.veto_segment_name = sum(args.veto_segment_name, [])
 args.veto_file = sum(args.veto_file, [])
 
@@ -134,12 +137,6 @@ if (args.prune_param or args.prune_bins or args.prune_number) and not \
    (args.prune_param and args.prune_bins and args.prune_number):
     raise RuntimeError("To prune, need to specify param, number of bins and "
                        "nonzero number to prune in each bin!")
-
-if args.verbose:
-    log_level = logging.DEBUG
-else:
-    log_level = logging.WARN
-logging.basicConfig(format='%(asctime)s : %(message)s', level=log_level)
 
 logging.info('Fitting above threshold %f' % args.stat_threshold)
 

--- a/bin/all_sky_search/pycbc_fit_sngls_by_template
+++ b/bin/all_sky_search/pycbc_fit_sngls_by_template
@@ -124,8 +124,7 @@ statsmod.insert_statistic_option_group(parser,
     default_ranking_statistic='single_ranking_only')
 args = parser.parse_args()
 
-logging_level = 1 if args.verbose is None else args.verbose + 1
-init_logging(logging.level)
+init_logging(args.verbose)
 
 args.veto_segment_name = sum(args.veto_segment_name, [])
 args.veto_file = sum(args.veto_file, [])

--- a/bin/all_sky_search/pycbc_fit_sngls_by_template
+++ b/bin/all_sky_search/pycbc_fit_sngls_by_template
@@ -59,7 +59,7 @@ def get_stat(statname, trigs, threshold):
 parser = argparse.ArgumentParser(usage="",
     description="Perform maximum-likelihood fits of single inspiral trigger"
                 " distributions to various functions")
-pycbc.common_options(parser)
+pycbc.add_common_pycbc_options(parser)
 parser.add_argument("--version", action=pycbc.version.Version)
 parser.add_argument("--trigger-file",
                     help="Input hdf5 file containing single triggers. "

--- a/bin/all_sky_search/pycbc_fit_sngls_over_multiparam
+++ b/bin/all_sky_search/pycbc_fit_sngls_over_multiparam
@@ -250,7 +250,8 @@ for inputstr in smooth_kwargs:
 
 assert len(args.log_param) == len(args.fit_param) == len(args.smoothing_width)
 
-pycbc.init_logging(args.verbose)
+logging_level = 1 if args.verbose is None else args.verbose + 1
+init_logging(logging.level)
 
 fits = h5py.File(args.template_fit_file, 'r')
 

--- a/bin/all_sky_search/pycbc_fit_sngls_over_multiparam
+++ b/bin/all_sky_search/pycbc_fit_sngls_over_multiparam
@@ -250,8 +250,7 @@ for inputstr in smooth_kwargs:
 
 assert len(args.log_param) == len(args.fit_param) == len(args.smoothing_width)
 
-logging_level = 1 if args.verbose is None else args.verbose + 1
-init_logging(logging.level)
+init_logging(args.verbose)
 
 fits = h5py.File(args.template_fit_file, 'r')
 

--- a/bin/all_sky_search/pycbc_fit_sngls_over_multiparam
+++ b/bin/all_sky_search/pycbc_fit_sngls_over_multiparam
@@ -172,7 +172,7 @@ parser = argparse.ArgumentParser(usage="",
                 "parameter, to suppress random noise in the resulting "
                 "background model.")
 
-pycbc.common_options(parser)
+pycbc.add_common_pycbc_options(parser)
 parser.add_argument("--version", action=pycbc.version.Version)
 parser.add_argument("--template-fit-file",
                     help="hdf5 file containing fit coefficients for each"

--- a/bin/all_sky_search/pycbc_fit_sngls_over_multiparam
+++ b/bin/all_sky_search/pycbc_fit_sngls_over_multiparam
@@ -16,7 +16,7 @@
 import sys, h5py, argparse, logging, pycbc.version, numpy
 from scipy.stats import norm
 from pycbc.events import triggers
-
+from pycbc import init_logging
 
 def dist(i1, i2, parvals, smoothing_width):
     """

--- a/bin/all_sky_search/pycbc_fit_sngls_over_multiparam
+++ b/bin/all_sky_search/pycbc_fit_sngls_over_multiparam
@@ -172,9 +172,8 @@ parser = argparse.ArgumentParser(usage="",
                 "parameter, to suppress random noise in the resulting "
                 "background model.")
 
+pycbc.common_options(parser)
 parser.add_argument("--version", action=pycbc.version.Version)
-parser.add_argument("-V", "--verbose", action="store_true",
-                    help="Print extra debugging information", default=False)
 parser.add_argument("--template-fit-file",
                     help="hdf5 file containing fit coefficients for each"
                          " individual template. Required")

--- a/bin/all_sky_search/pycbc_fit_sngls_over_param
+++ b/bin/all_sky_search/pycbc_fit_sngls_over_param
@@ -79,8 +79,7 @@ args = parser.parse_args()
 if args.regression_method == 'nn' and args.num_neighbors < 1:
     raise RuntimeError("Need to give a positive number of nearest neighbors!")
 
-logging_level = 1 if args.verbose is None else args.verbose + 1
-init_logging(logging.level)
+init_logging(args.verbose)
 
 fits = h5py.File(args.template_fit_file, 'r')
 

--- a/bin/all_sky_search/pycbc_fit_sngls_over_param
+++ b/bin/all_sky_search/pycbc_fit_sngls_over_param
@@ -28,9 +28,8 @@ parser = argparse.ArgumentParser(usage="",
                 "parameter, to suppress random noise in the resulting "
                 "background model.")
 
+pycbc.common_options(parser)
 parser.add_argument("--version", action=pycbc.version.Version)
-parser.add_argument("-V", "--verbose", action="store_true",
-                    help="Print extra debugging information", default=False)
 parser.add_argument("--template-fit-file",
                     help="Input hdf5 file containing fit coefficients for each"
                          " individual template. Required")

--- a/bin/all_sky_search/pycbc_fit_sngls_over_param
+++ b/bin/all_sky_search/pycbc_fit_sngls_over_param
@@ -28,7 +28,7 @@ parser = argparse.ArgumentParser(usage="",
                 "parameter, to suppress random noise in the resulting "
                 "background model.")
 
-pycbc.common_options(parser)
+pycbc.add_common_pycbc_options(parser)
 parser.add_argument("--version", action=pycbc.version.Version)
 parser.add_argument("--template-fit-file",
                     help="Input hdf5 file containing fit coefficients for each"

--- a/bin/all_sky_search/pycbc_fit_sngls_over_param
+++ b/bin/all_sky_search/pycbc_fit_sngls_over_param
@@ -18,6 +18,7 @@ import argparse, logging
 
 import numpy as np
 
+from pycbc import init_logging
 from pycbc.events import triggers
 import pycbc.version
 
@@ -78,11 +79,8 @@ args = parser.parse_args()
 if args.regression_method == 'nn' and args.num_neighbors < 1:
     raise RuntimeError("Need to give a positive number of nearest neighbors!")
 
-if args.verbose:
-    log_level = logging.DEBUG
-else:
-    log_level = logging.WARN
-logging.basicConfig(format='%(asctime)s : %(message)s', level=log_level)
+logging_level = 1 if args.verbose is None else args.verbose + 1
+init_logging(logging.level)
 
 fits = h5py.File(args.template_fit_file, 'r')
 

--- a/bin/all_sky_search/pycbc_fit_sngls_split_binned
+++ b/bin/all_sky_search/pycbc_fit_sngls_split_binned
@@ -31,6 +31,7 @@ import pycbc.version
 
 parser = argparse.ArgumentParser(usage="",
     description="Plot histograms of triggers split over various parameters")
+pycbc.common_options(parser)
 parser.add_argument("--trigger-file", required=True,
                     help="Input hdf5 file containing single triggers. "
                          "Required")
@@ -38,7 +39,6 @@ parser.add_argument("--bank-file", default=None, required=True,
                     help="hdf file containing template parameters. Required")
 parser.add_argument('--output-file', required=True,
                     help="Output image file. Required")
-parser.add_argument('--verbose', action='store_true')
 parser.add_argument('--bin-param', default='template_duration',
                     help="Parameter for binning within plots, default "
                          "'template_duration'")

--- a/bin/all_sky_search/pycbc_fit_sngls_split_binned
+++ b/bin/all_sky_search/pycbc_fit_sngls_split_binned
@@ -31,7 +31,7 @@ import pycbc.version
 
 parser = argparse.ArgumentParser(usage="",
     description="Plot histograms of triggers split over various parameters")
-pycbc.common_options(parser)
+pycbc.add_common_pycbc_options(parser)
 parser.add_argument("--trigger-file", required=True,
                     help="Input hdf5 file containing single triggers. "
                          "Required")

--- a/bin/all_sky_search/pycbc_followup_file
+++ b/bin/all_sky_search/pycbc_followup_file
@@ -5,7 +5,7 @@ follow-up.
 import h5py, numpy, argparse, logging, pycbc
 
 parser = argparse.ArgumentParser()
-pycbc.common_options(parser)
+pycbc.add_common_pycbc_options(parser)
 parser.add_argument('--version', action='version',
     version=pycbc.version.git_verbose_msg)
 parser.add_argument('--statmap-file',

--- a/bin/all_sky_search/pycbc_followup_file
+++ b/bin/all_sky_search/pycbc_followup_file
@@ -5,9 +5,9 @@ follow-up.
 import h5py, numpy, argparse, logging, pycbc
 
 parser = argparse.ArgumentParser()
+pycbc.common_options(parser)
 parser.add_argument('--version', action='version',
     version=pycbc.version.git_verbose_msg)
-parser.add_argument('--verbose', action='store_true')
 parser.add_argument('--statmap-file',
     help="Statmap file containing the candidates/background to follow up")
 parser.add_argument('--bank-file',

--- a/bin/all_sky_search/pycbc_foreground_censor
+++ b/bin/all_sky_search/pycbc_foreground_censor
@@ -7,7 +7,7 @@ import pycbc.events
 from pycbc.workflow import SegFile
 
 parser = argparse.ArgumentParser(description=__doc__)
-pycbc.common_options(parser)
+pycbc.add_common_pycbc_options(parser)
 parser.add_argument('--version', action='version', version=pycbc.version.git_verbose_msg)
 parser.add_argument('--foreground-triggers',
                     help="HDF file containing the zerolag foreground triggers "

--- a/bin/all_sky_search/pycbc_foreground_censor
+++ b/bin/all_sky_search/pycbc_foreground_censor
@@ -7,8 +7,8 @@ import pycbc.events
 from pycbc.workflow import SegFile
 
 parser = argparse.ArgumentParser(description=__doc__)
+pycbc.common_options(parser)
 parser.add_argument('--version', action='version', version=pycbc.version.git_verbose_msg)
-parser.add_argument('--verbose', action='store_true')
 parser.add_argument('--foreground-triggers',
                     help="HDF file containing the zerolag foreground triggers "
                          "from the analysis")

--- a/bin/all_sky_search/pycbc_get_loudest_params
+++ b/bin/all_sky_search/pycbc_get_loudest_params
@@ -16,7 +16,7 @@ from pycbc.pnutils import mass1_mass2_to_mchirp_eta
 logging.basicConfig(format='%(asctime)s %(message)s', level=logging.INFO)
 
 parser = argparse.ArgumentParser(description=__doc__)
-parser.add_argument('--verbose', action='count')
+pycbc.common_options(parser)
 parser.add_argument('--single-ifo-trigs', type=str, required=True,
         help='HDF file containing single IFO CBC triggers')
 parser.add_argument('--tmpltbank-file', type=str, required=True,

--- a/bin/all_sky_search/pycbc_get_loudest_params
+++ b/bin/all_sky_search/pycbc_get_loudest_params
@@ -9,12 +9,14 @@ import numpy as np
 import h5py
 import argparse
 import logging
+from pycbc import init_logging
 import pycbc.events
 from pycbc.pnutils import mass1_mass2_to_mchirp_eta
 
 logging.basicConfig(format='%(asctime)s %(message)s', level=logging.INFO)
 
 parser = argparse.ArgumentParser(description=__doc__)
+parser.add_argument('--verbose', action='count')
 parser.add_argument('--single-ifo-trigs', type=str, required=True,
         help='HDF file containing single IFO CBC triggers')
 parser.add_argument('--tmpltbank-file', type=str, required=True,
@@ -32,6 +34,8 @@ parser.add_argument('--output-file', type=str, required=False,
 parser.add_argument('--print-params', action='store_true', required=False,
         help='Toggle printing parameters to stdout')
 args = parser.parse_args()
+
+init_logging(args.verbose)
 
 logging.info('Reading in HDF files')
 trigs = h5py.File(args.single_ifo_trigs,'r')

--- a/bin/all_sky_search/pycbc_get_loudest_params
+++ b/bin/all_sky_search/pycbc_get_loudest_params
@@ -16,7 +16,7 @@ from pycbc.pnutils import mass1_mass2_to_mchirp_eta
 logging.basicConfig(format='%(asctime)s %(message)s', level=logging.INFO)
 
 parser = argparse.ArgumentParser(description=__doc__)
-pycbc.common_options(parser)
+pycbc.add_common_pycbc_options(parser)
 parser.add_argument('--single-ifo-trigs', type=str, required=True,
         help='HDF file containing single IFO CBC triggers')
 parser.add_argument('--tmpltbank-file', type=str, required=True,

--- a/bin/all_sky_search/pycbc_merge_psds
+++ b/bin/all_sky_search/pycbc_merge_psds
@@ -21,8 +21,8 @@ import logging, argparse, numpy, h5py, pycbc.types
 from pycbc.version import git_verbose_msg as version
 
 parser = argparse.ArgumentParser(description=__doc__)
+pycbc.common_options(parser)
 parser.add_argument('--version', action='version', version=version)
-parser.add_argument('--verbose', action="store_true")
 parser.add_argument('--psd-files', nargs='+')
 parser.add_argument("--output-file", required=True)
 

--- a/bin/all_sky_search/pycbc_merge_psds
+++ b/bin/all_sky_search/pycbc_merge_psds
@@ -21,7 +21,7 @@ import logging, argparse, numpy, h5py, pycbc.types
 from pycbc.version import git_verbose_msg as version
 
 parser = argparse.ArgumentParser(description=__doc__)
-pycbc.common_options(parser)
+pycbc.add_common_pycbc_options(parser)
 parser.add_argument('--version', action='version', version=version)
 parser.add_argument('--psd-files', nargs='+')
 parser.add_argument("--output-file", required=True)

--- a/bin/all_sky_search/pycbc_plot_kde_vals
+++ b/bin/all_sky_search/pycbc_plot_kde_vals
@@ -3,8 +3,11 @@
 import numpy, h5py, argparse
 import matplotlib.pyplot as plt
 from matplotlib.colors import LogNorm
+from pycbc import init_logging
+import logging
 
 parser = argparse.ArgumentParser(description=__doc__)
+pycbc.common_options(parser)
 parser.add_argument('--signal-file')
 parser.add_argument('--template-file', required=True)
 parser.add_argument('--param', nargs='+', required=True,
@@ -21,8 +24,9 @@ parser.add_argument('--plot-order', choices=['file', 'increasing', 'decreasing']
                          ' or "decreasing"')
 parser.add_argument('--which-kde', choices=['signal_kde', 'template_kde', 'ratio_kde'])
 parser.add_argument('--plot-dir', required=True)
-parser.add_argument('--verbose', action='count')
 args = parser.parse_args()
+
+init_logging(args.verbose)
 
 if args.plot_type == 'kde_vs_param':
     if len(args.param) != 1:

--- a/bin/all_sky_search/pycbc_plot_kde_vals
+++ b/bin/all_sky_search/pycbc_plot_kde_vals
@@ -3,11 +3,11 @@
 import numpy, h5py, argparse
 import matplotlib.pyplot as plt
 from matplotlib.colors import LogNorm
-from pycbc import init_logging
+from pycbc import init_logging, common_options
 import logging
 
 parser = argparse.ArgumentParser(description=__doc__)
-pycbc.common_options(parser)
+common_options(parser)
 parser.add_argument('--signal-file')
 parser.add_argument('--template-file', required=True)
 parser.add_argument('--param', nargs='+', required=True,

--- a/bin/all_sky_search/pycbc_plot_kde_vals
+++ b/bin/all_sky_search/pycbc_plot_kde_vals
@@ -3,11 +3,11 @@
 import numpy, h5py, argparse
 import matplotlib.pyplot as plt
 from matplotlib.colors import LogNorm
-from pycbc import init_logging, common_options
+from pycbc import init_logging, add_common_pycbc_options
 import logging
 
 parser = argparse.ArgumentParser(description=__doc__)
-common_options(parser)
+add_common_pycbc_options(parser)
 parser.add_argument('--signal-file')
 parser.add_argument('--template-file', required=True)
 parser.add_argument('--param', nargs='+', required=True,

--- a/bin/all_sky_search/pycbc_reduce_template_bank
+++ b/bin/all_sky_search/pycbc_reduce_template_bank
@@ -30,10 +30,9 @@ import pycbc
 import pycbc.version
 
 parser = argparse.ArgumentParser(description=__doc__)
+pycbc.common_options(parser)
 parser.add_argument("--version", action="version",
                     version=pycbc.version.git_verbose_msg)
-parser.add_argument("-V", "--verbose", action="store_true",
-                    help="print extra debugging information", default=False)
 parser.add_argument("--input-bank", required=True,
                     help="Input template bank HDF file.")
 parser.add_argument("--output-bank", required=True,

--- a/bin/all_sky_search/pycbc_reduce_template_bank
+++ b/bin/all_sky_search/pycbc_reduce_template_bank
@@ -30,7 +30,7 @@ import pycbc
 import pycbc.version
 
 parser = argparse.ArgumentParser(description=__doc__)
-pycbc.common_options(parser)
+pycbc.add_common_pycbc_options(parser)
 parser.add_argument("--version", action="version",
                     version=pycbc.version.git_verbose_msg)
 parser.add_argument("--input-bank", required=True,

--- a/bin/all_sky_search/pycbc_rerank_dq
+++ b/bin/all_sky_search/pycbc_rerank_dq
@@ -8,8 +8,8 @@ from os import path
 from pycbc.version import git_verbose_msg as version
 
 parser = argparse.ArgumentParser(description=__doc__)
+pycbc.common_options(parser)
 parser.add_argument('--version', action='version', version=version)
-parser.add_argument('--verbose', action="store_true",default=False)
 parser.add_argument('--no-low-dq-cutoff', action="store_true",
                     help="Allow dq values less than 0. "
                          "Otherwise values less than 0 are set to 0")

--- a/bin/all_sky_search/pycbc_rerank_dq
+++ b/bin/all_sky_search/pycbc_rerank_dq
@@ -8,7 +8,7 @@ from os import path
 from pycbc.version import git_verbose_msg as version
 
 parser = argparse.ArgumentParser(description=__doc__)
-pycbc.common_options(parser)
+pycbc.add_common_pycbc_options(parser)
 parser.add_argument('--version', action='version', version=version)
 parser.add_argument('--no-low-dq-cutoff', action="store_true",
                     help="Allow dq values less than 0. "

--- a/bin/all_sky_search/pycbc_rerank_passthrough
+++ b/bin/all_sky_search/pycbc_rerank_passthrough
@@ -3,7 +3,7 @@
 import h5py, numpy, argparse, logging, pycbc
 
 parser = argparse.ArgumentParser()
-pycbc.common_options(parser)
+pycbc.add_common_pycbc_options(parser)
 parser.add_argument('--version', action='version',
     version=pycbc.version.git_verbose_msg)
 parser.add_argument('--output-file',

--- a/bin/all_sky_search/pycbc_rerank_passthrough
+++ b/bin/all_sky_search/pycbc_rerank_passthrough
@@ -3,10 +3,9 @@
 import h5py, numpy, argparse, logging, pycbc
 
 parser = argparse.ArgumentParser()
-
+pycbc.common_options(parser)
 parser.add_argument('--version', action='version',
     version=pycbc.version.git_verbose_msg)
-parser.add_argument('--verbose', action='store_true')
 parser.add_argument('--output-file',
     help="File containing the newly assigned statistic values")
 

--- a/bin/all_sky_search/pycbc_sngls_findtrigs
+++ b/bin/all_sky_search/pycbc_sngls_findtrigs
@@ -12,7 +12,7 @@ from pycbc.types.optparse import MultiDetOptionAction
 from pycbc import init_logging
 
 parser = argparse.ArgumentParser()
-parser.add_argument("--verbose", action='count')
+pycbc.common_options(parser)
 parser.add_argument("--version", action='version',
                     version=pycbc.version.git_verbose_msg)
 # Basic file input options

--- a/bin/all_sky_search/pycbc_sngls_findtrigs
+++ b/bin/all_sky_search/pycbc_sngls_findtrigs
@@ -12,7 +12,7 @@ from pycbc.types.optparse import MultiDetOptionAction
 from pycbc import init_logging
 
 parser = argparse.ArgumentParser()
-pycbc.common_options(parser)
+pycbc.add_common_pycbc_options(parser)
 parser.add_argument("--version", action='version',
                     version=pycbc.version.git_verbose_msg)
 # Basic file input options

--- a/bin/all_sky_search/pycbc_sngls_findtrigs
+++ b/bin/all_sky_search/pycbc_sngls_findtrigs
@@ -139,10 +139,10 @@ for tnum in template_ids:
     trigger_keep_ids = cuts.apply_trigger_cuts(trigs, trigger_cut_dict,
                                                statistic=rank_method)
     tids_full = tids_uncut[trigger_keep_ids]
-    logging.info('%s:%s', tnum, len(tids_uncut))
+    logging.debug('%s:%s', tnum, len(tids_uncut))
     if len(tids_full) < len(tids_uncut):
-        logging.info("%s triggers cut",
-                     len(tids_uncut) - len(tids_full))
+        logging.debug("%s triggers cut",
+                      len(tids_uncut) - len(tids_full))
 
     n_tot_trigs = tids_full.size
     if not n_tot_trigs: continue

--- a/bin/all_sky_search/pycbc_sngls_pastro
+++ b/bin/all_sky_search/pycbc_sngls_pastro
@@ -39,7 +39,7 @@ mchirp_power = {
 }
 
 parser = argparse.ArgumentParser()
-parser.add_argument("--verbose", action='count')
+pycbc.common_options(parser)
 parser.add_argument("--version", action='version',
                     version=pycbc.version.git_verbose_msg)
 parser.add_argument("--single-statmap-files", nargs='+', required=True,

--- a/bin/all_sky_search/pycbc_sngls_pastro
+++ b/bin/all_sky_search/pycbc_sngls_pastro
@@ -39,7 +39,7 @@ mchirp_power = {
 }
 
 parser = argparse.ArgumentParser()
-pycbc.common_options(parser)
+pycbc.add_common_pycbc_options(parser)
 parser.add_argument("--version", action='version',
                     version=pycbc.version.git_verbose_msg)
 parser.add_argument("--single-statmap-files", nargs='+', required=True,

--- a/bin/all_sky_search/pycbc_sngls_statmap
+++ b/bin/all_sky_search/pycbc_sngls_statmap
@@ -34,7 +34,7 @@ class fw(object):
 
 parser = argparse.ArgumentParser()
 # General required options
-pycbc.common_options(parser)
+pycbc.add_common_pycbc_options(parser)
 parser.add_argument('--version', action='version',
                     version=pycbc.version.git_verbose_msg)
 parser.add_argument('--sngls-files', nargs='+',

--- a/bin/all_sky_search/pycbc_sngls_statmap
+++ b/bin/all_sky_search/pycbc_sngls_statmap
@@ -34,6 +34,7 @@ class fw(object):
 
 parser = argparse.ArgumentParser()
 # General required options
+pycbc.common_options(parser)
 parser.add_argument('--version', action='version',
                     version=pycbc.version.git_verbose_msg)
 parser.add_argument('--sngls-files', nargs='+',
@@ -41,7 +42,6 @@ parser.add_argument('--sngls-files', nargs='+',
                          'information.')
 parser.add_argument('--ifos', nargs=1,
                     help='List of ifos used in these coincidence files')
-parser.add_argument('--verbose', action='count')
 parser.add_argument('--cluster-window', type=float, default=10,
                     help='Length of time window in seconds to cluster coinc '
                          'events [default=10s]')

--- a/bin/all_sky_search/pycbc_sngls_statmap_inj
+++ b/bin/all_sky_search/pycbc_sngls_statmap_inj
@@ -34,7 +34,7 @@ class fw(object):
 
 parser = argparse.ArgumentParser()
 # General required options
-pycbc.common_options(parser)
+pycbc.add_common_pycbc_options(parser)
 parser.add_argument('--version', action='version',
                     version=pycbc.version.git_verbose_msg)
 parser.add_argument('--sngls-files', nargs='+',

--- a/bin/all_sky_search/pycbc_sngls_statmap_inj
+++ b/bin/all_sky_search/pycbc_sngls_statmap_inj
@@ -34,6 +34,7 @@ class fw(object):
 
 parser = argparse.ArgumentParser()
 # General required options
+pycbc.common_options(parser)
 parser.add_argument('--version', action='version',
                     version=pycbc.version.git_verbose_msg)
 parser.add_argument('--sngls-files', nargs='+',
@@ -44,7 +45,6 @@ parser.add_argument('--full-data-background', required=True,
                          'injection coincs')
 parser.add_argument('--ifos', nargs=1,
                     help='List of ifos used in these coincidence files')
-parser.add_argument('--verbose', action='count')
 parser.add_argument('--cluster-window', type=float, default=10,
                     help='Length of time window in seconds to cluster coinc '
                          'events [default=10s]')

--- a/bin/all_sky_search/pycbc_strip_injections
+++ b/bin/all_sky_search/pycbc_strip_injections
@@ -12,8 +12,8 @@ def remove(l, i):
         l.remove(r)
 
 parser = argparse.ArgumentParser()
+pycbc.common_options(parser)
 parser.add_argument('--version', action='version', version=pycbc.version.git_verbose_msg)
-parser.add_argument('--verbose', action='store_true')
 parser.add_argument('--injection-file')
 parser.add_argument('--veto-file', 
                       help="File containing segments used to veto injections")

--- a/bin/all_sky_search/pycbc_strip_injections
+++ b/bin/all_sky_search/pycbc_strip_injections
@@ -12,7 +12,7 @@ def remove(l, i):
         l.remove(r)
 
 parser = argparse.ArgumentParser()
-pycbc.common_options(parser)
+pycbc.add_common_pycbc_options(parser)
 parser.add_argument('--version', action='version', version=pycbc.version.git_verbose_msg)
 parser.add_argument('--injection-file')
 parser.add_argument('--veto-file', 

--- a/bin/all_sky_search/pycbc_template_kde_calc
+++ b/bin/all_sky_search/pycbc_template_kde_calc
@@ -13,16 +13,15 @@
 # Public License for more details.
 
 import numpy, h5py, operator, argparse, logging
-from pycbc import init_logging
+from pycbc import init_logging, common_options
 import pycbc.conversions as convert
 from pycbc import libutils
 from pycbc.events import triggers
 akde = libutils.import_optional('awkde')
 kf = libutils.import_optional('sklearn.model_selection')
 
-
 parser = argparse.ArgumentParser(description=__doc__)
-pycbc.common_options(parser)
+common_options(parser)
 parser.add_argument('--signal-file', help='File with parameters of GW signals '
                     'for KDE calculation')
 parser.add_argument('--template-file', required=True, help='Hdf5 file with '

--- a/bin/all_sky_search/pycbc_template_kde_calc
+++ b/bin/all_sky_search/pycbc_template_kde_calc
@@ -22,6 +22,7 @@ kf = libutils.import_optional('sklearn.model_selection')
 
 
 parser = argparse.ArgumentParser(description=__doc__)
+pycbc.common_options(parser)
 parser.add_argument('--signal-file', help='File with parameters of GW signals '
                     'for KDE calculation')
 parser.add_argument('--template-file', required=True, help='Hdf5 file with '
@@ -64,9 +65,8 @@ parser.add_argument('--mchirp-downsample-power', type=float,
                     help='Exponent value for the power law distribution')
 parser.add_argument('--min-ratio', type=float, 
                     help='Minimum ratio for template_kde relative to the maximum')
-parser.add_argument('--verbose', action='store_true')
 args = parser.parse_args()
-init_logging(verbose=args.verbose, format='%(asctime)s %(message)s')
+init_logging(args.verbose)
 
 
 assert len(args.fit_param) == len(args.log_param)

--- a/bin/all_sky_search/pycbc_template_kde_calc
+++ b/bin/all_sky_search/pycbc_template_kde_calc
@@ -13,7 +13,7 @@
 # Public License for more details.
 
 import numpy, h5py, operator, argparse, logging
-from pycbc import init_logging, common_options
+from pycbc import init_logging, add_common_pycbc_options
 import pycbc.conversions as convert
 from pycbc import libutils
 from pycbc.events import triggers
@@ -21,7 +21,7 @@ akde = libutils.import_optional('awkde')
 kf = libutils.import_optional('sklearn.model_selection')
 
 parser = argparse.ArgumentParser(description=__doc__)
-common_options(parser)
+add_common_pycbc_options(parser)
 parser.add_argument('--signal-file', help='File with parameters of GW signals '
                     'for KDE calculation')
 parser.add_argument('--template-file', required=True, help='Hdf5 file with '

--- a/bin/all_sky_search/pycbc_template_kde_max
+++ b/bin/all_sky_search/pycbc_template_kde_max
@@ -4,14 +4,14 @@ import numpy, h5py, argparse, logging
 from pycbc import init_logging
 
 parser = argparse.ArgumentParser(description=__doc__)
+pycbc.common_options(parser)
 parser.add_argument('--kde-files', nargs='+', required=True,
                     help='HDF files with KDE values')
 parser.add_argument('--output-file', required=True, help='Name of output HDF file')
 parser.add_argument('--min-ratio', type=float,
                     help='Minimum ratio for template_kde relative to the maximum')
-parser.add_argument('--verbose', action='store_true')
 args = parser.parse_args()
-init_logging(verbose=args.verbose, format='%(asctime)s %(message)s')
+init_logging(args.verbose)
 
 
 input_kdes = [h5py.File(kfile, 'r') for kfile in args.kde_files]

--- a/bin/all_sky_search/pycbc_template_kde_max
+++ b/bin/all_sky_search/pycbc_template_kde_max
@@ -1,10 +1,10 @@
 #!/usr/bin/env python
 
 import numpy, h5py, argparse, logging
-from pycbc import init_logging
+from pycbc import init_logging, common_options
 
 parser = argparse.ArgumentParser(description=__doc__)
-pycbc.common_options(parser)
+common_options(parser)
 parser.add_argument('--kde-files', nargs='+', required=True,
                     help='HDF files with KDE values')
 parser.add_argument('--output-file', required=True, help='Name of output HDF file')

--- a/bin/all_sky_search/pycbc_template_kde_max
+++ b/bin/all_sky_search/pycbc_template_kde_max
@@ -1,10 +1,10 @@
 #!/usr/bin/env python
 
 import numpy, h5py, argparse, logging
-from pycbc import init_logging, common_options
+from pycbc import init_logging, add_common_pycbc_options
 
 parser = argparse.ArgumentParser(description=__doc__)
-common_options(parser)
+add_common_pycbc_options(parser)
 parser.add_argument('--kde-files', nargs='+', required=True,
                     help='HDF files with KDE values')
 parser.add_argument('--output-file', required=True, help='Name of output HDF file')

--- a/bin/all_sky_search/pycbc_template_recovery_hist
+++ b/bin/all_sky_search/pycbc_template_recovery_hist
@@ -6,10 +6,10 @@ from matplotlib import use
 use('Agg')
 from matplotlib import pyplot as plt
 from pycbc.events import triggers
-from pycbc import init_logging, common_options
+from pycbc import init_logging, add_common_pycbc_options
 
 parser = argparse.ArgumentParser(description=__doc__)
-common_options(parser)
+add_common_pycbc_options(parser)
 parser.add_argument('--output', required=True)
 parser.add_argument('--found-injection-files', dest='found', nargs='+',
                     help='hdf file(s) with found injections')

--- a/bin/all_sky_search/pycbc_template_recovery_hist
+++ b/bin/all_sky_search/pycbc_template_recovery_hist
@@ -6,6 +6,7 @@ from matplotlib import use
 use('Agg')
 from matplotlib import pyplot as plt
 from pycbc.events import triggers
+from pycbc import init_logging
 
 parser = argparse.ArgumentParser(description=__doc__)
 parser.add_argument('--verbose', action='count')
@@ -29,9 +30,7 @@ parser.add_argument('--min-ifar', type=float,
                     help='only plot injections above given ifar value')
 args = parser.parse_args()
 
-if args.verbose:
-    log_level = logging.INFO
-    logging.basicConfig(format='%(asctime)s : %(message)s', level=log_level)
+init_logging(args.verbose)
 
 # should be same number of inj and trig files
 # and either 0 or 1 bank files or 1 per inj file

--- a/bin/all_sky_search/pycbc_template_recovery_hist
+++ b/bin/all_sky_search/pycbc_template_recovery_hist
@@ -9,7 +9,7 @@ from pycbc.events import triggers
 from pycbc import init_logging
 
 parser = argparse.ArgumentParser(description=__doc__)
-parser.add_argument('--verbose', action='count')
+pycbc.common_options(parser)
 parser.add_argument('--output', required=True)
 parser.add_argument('--found-injection-files', dest='found', nargs='+',
                     help='hdf file(s) with found injections')

--- a/bin/all_sky_search/pycbc_template_recovery_hist
+++ b/bin/all_sky_search/pycbc_template_recovery_hist
@@ -6,10 +6,10 @@ from matplotlib import use
 use('Agg')
 from matplotlib import pyplot as plt
 from pycbc.events import triggers
-from pycbc import init_logging
+from pycbc import init_logging, common_options
 
 parser = argparse.ArgumentParser(description=__doc__)
-pycbc.common_options(parser)
+common_options(parser)
 parser.add_argument('--output', required=True)
 parser.add_argument('--found-injection-files', dest='found', nargs='+',
                     help='hdf file(s) with found injections')

--- a/pycbc/__init__.py
+++ b/pycbc/__init__.py
@@ -79,7 +79,7 @@ def common_options(parser):
         title="PyCBC common options",
         description="Common options for PyCBC executables.",
     )
-    group.add_argument('-V','--verbose', action='count', default=0,
+    group.add_argument('-V', '--verbose', action='count', default=0,
                        help='Add verbosity to logging. Adding the option '
                             'multiple times makes logging progressively '
                             'more verbose, e.g. --verbose or -V provides '

--- a/pycbc/__init__.py
+++ b/pycbc/__init__.py
@@ -66,7 +66,8 @@ class LogFormatter(logging.Formatter):
         return s
 
 
-def init_logging(verbose=False, format='%(asctime)s %(levelname)s : %(message)s'):
+def init_logging(verbose=False,
+                 format='%(asctime)s %(levelname)s : %(message)s'):
     """Common utility for setting up logging in PyCBC.
 
     Installs a signal handler such that verbosity can be activated at

--- a/pycbc/__init__.py
+++ b/pycbc/__init__.py
@@ -66,7 +66,7 @@ class LogFormatter(logging.Formatter):
         return s
 
 
-def init_logging(verbose=False, format='%(asctime)s %(message)s'):
+def init_logging(verbose=False, format='%(asctime)s %(levelname)s : %(message)s'):
     """Common utility for setting up logging in PyCBC.
 
     Installs a signal handler such that verbosity can be activated at

--- a/pycbc/__init__.py
+++ b/pycbc/__init__.py
@@ -66,7 +66,7 @@ class LogFormatter(logging.Formatter):
         return s
 
 
-def common_options(parser):
+def add_common_pycbc_options(parser):
     """
     Common utility to add standard options to each PyCBC executable.
 

--- a/pycbc/__init__.py
+++ b/pycbc/__init__.py
@@ -66,6 +66,26 @@ class LogFormatter(logging.Formatter):
         return s
 
 
+def common_options(parser):
+    """
+    Common utility to add standard options to each PyCBC executable.
+
+    Parameters
+    ----------
+    parser : argparse.ArgumentParser
+        The argument parser to which the options will be added
+    """
+    group = parser.add_argument_group(
+        title="PyCBC common options",
+        description="Common options for PyCBC executables.",
+    )
+    group.add_argument('-V','--verbose', action='count',
+                       help='Add verbosity to logging. Adding the option '
+                            'multiple times makes logging progressively '
+                            'more verbose, e.g. --verbose or -V provides '
+                            'logging at the info level, but -VV or '
+                            '--verbose --verbose provides debug logging.')
+
 def init_logging(verbose=False,
                  format='%(asctime)s %(levelname)s : %(message)s'):
     """Common utility for setting up logging in PyCBC.

--- a/pycbc/__init__.py
+++ b/pycbc/__init__.py
@@ -79,7 +79,7 @@ def common_options(parser):
         title="PyCBC common options",
         description="Common options for PyCBC executables.",
     )
-    group.add_argument('-V','--verbose', action='count',
+    group.add_argument('-V','--verbose', action='count', default=0,
                        help='Add verbosity to logging. Adding the option '
                             'multiple times makes logging progressively '
                             'more verbose, e.g. --verbose or -V provides '

--- a/pycbc/events/coinc_rate.py
+++ b/pycbc/events/coinc_rate.py
@@ -14,6 +14,8 @@ import logging
 import numpy
 import pycbc.detector
 
+logger = logging.getLogger('pycbc.events.coinc_rate')
+
 
 def multiifo_noise_lograte(log_rates, slop):
     """
@@ -82,9 +84,9 @@ def combination_noise_rate(rates, slop):
     numpy array
         Expected coincidence rate in the combination, units Hz
     """
-    logging.warning('combination_noise_rate() is liable to numerical '
-                    'underflows, use combination_noise_lograte '
-                    'instead')
+    logger.warning('combination_noise_rate() is liable to numerical '
+                   'underflows, use combination_noise_lograte '
+                   'instead')
     log_rates = {k: numpy.log(r) for (k, r) in rates.items()}
     # exp may underflow
     return numpy.exp(combination_noise_lograte(log_rates, slop))

--- a/pycbc/events/cuts.py
+++ b/pycbc/events/cuts.py
@@ -37,6 +37,8 @@ from pycbc.io import get_chisq_from_file_choice
 # Only used to check isinstance:
 from pycbc.io.hdf import ReadByTemplate
 
+logger = logging.getLogger('pycbc.events.cuts')
+
 # sngl_rank_keys are the allowed names of reweighted SNR functions
 sngl_rank_keys = ranking.sngls_ranking_function_dict.keys()
 
@@ -97,8 +99,8 @@ def convert_inputstr(inputstr, choices):
     try:
         cut_param, cut_value_str, cut_limit = inputstr.split(':')
     except ValueError as value_e:
-        logging.warning("ERROR: Cut string format not correct, please "
-                        "supply as PARAMETER:VALUE:LIMIT")
+        logger.warning("ERROR: Cut string format not correct, please "
+                       "supply as PARAMETER:VALUE:LIMIT")
         raise value_e
 
     if cut_param.lower() not in choices:
@@ -113,8 +115,8 @@ def convert_inputstr(inputstr, choices):
     try:
         cut_value = float(cut_value_str)
     except ValueError as value_e:
-        logging.warning("ERROR: Cut value must be convertible into a float, "
-                        "got '%s'.", cut_value_str)
+        logger.warning("ERROR: Cut value must be convertible into a float, "
+                       "got '%s'.", cut_value_str)
         raise value_e
 
     return {(cut_param, ineq_functions[cut_limit]): cut_value}
@@ -137,9 +139,9 @@ def check_update_cuts(cut_dict, new_cut):
     new_cut_key = list(new_cut.keys())[0]
     if new_cut_key in cut_dict:
         # The cut has already been called
-        logging.warning("WARNING: Cut parameter %s and function %s have "
-                        "already been used. Utilising the strictest cut.",
-                        new_cut_key[0], new_cut_key[1].__name__)
+        logger.warning("WARNING: Cut parameter %s and function %s have "
+                       "already been used. Utilising the strictest cut.",
+                       new_cut_key[0], new_cut_key[1].__name__)
         # Extract the function and work out which is strictest
         cut_function = new_cut_key[1]
         value_new = list(new_cut.values())[0]
@@ -148,17 +150,17 @@ def check_update_cuts(cut_dict, new_cut):
             # The new threshold would survive the cut of the
             # old threshold, therefore the new threshold is stricter
             # - update it
-            logging.warning("WARNING: New threshold of %.3f is "
-                            "stricter than old threshold %.3f, "
-                            "using cut at %.3f.",
-                            value_new, value_old, value_new)
+            logger.warning("WARNING: New threshold of %.3f is "
+                           "stricter than old threshold %.3f, "
+                           "using cut at %.3f.",
+                           value_new, value_old, value_new)
             cut_dict.update(new_cut)
         else:
             # New cut would not make a difference, ignore it
-            logging.warning("WARNING: New threshold of %.3f is less "
-                            "strict than old threshold %.3f, using "
-                            "cut at %.3f.",
-                            value_new, value_old, value_old)
+            logger.warning("WARNING: New threshold of %.3f is less "
+                           "strict than old threshold %.3f, using "
+                           "cut at %.3f.",
+                           value_new, value_old, value_old)
     else:
         # This is a new cut - add it
         cut_dict.update(new_cut)

--- a/pycbc/events/cuts.py
+++ b/pycbc/events/cuts.py
@@ -170,8 +170,6 @@ def ingest_cuts_option_group(args):
     """
     Return dictionaries for trigger and template cuts.
     """
-    logger.info("A module-level logging info statement")
-    logger.debug("A module-level logging debug statement")
     # Deal with the case where no cuts are supplied:
     if not args.trigger_cuts and not args.template_cuts:
         return {}, {}

--- a/pycbc/events/cuts.py
+++ b/pycbc/events/cuts.py
@@ -170,6 +170,8 @@ def ingest_cuts_option_group(args):
     """
     Return dictionaries for trigger and template cuts.
     """
+    logger.info("A module-level logging info statement")
+    logger.debug("A module-level logging debug statement")
     # Deal with the case where no cuts are supplied:
     if not args.trigger_cuts and not args.template_cuts:
         return {}, {}

--- a/pycbc/events/eventmgr.py
+++ b/pycbc/events/eventmgr.py
@@ -378,7 +378,7 @@ class EventManager(object):
 
         if opt.injection_window and hasattr(gwstrain, 'injections'):
             logger.info("Keeping triggers within %s seconds of injection",
-                         opt.injection_window)
+                        opt.injection_window)
             self.keep_near_injection(opt.injection_window,
                                      gwstrain.injections)
             logger.info("%d remaining triggers", len(self.events))

--- a/pycbc/events/eventmgr.py
+++ b/pycbc/events/eventmgr.py
@@ -37,6 +37,8 @@ from . import coinc, ranking
 
 from .eventmgr_cython import findchirp_cluster_over_window_cython
 
+logger = logging.getLogger('pycbc.events.eventmgr')
+
 @schemed("pycbc.events.threshold_")
 def threshold(series, value):
     """Return list of values and indices values over threshold in series.
@@ -196,7 +198,7 @@ class EventManager(object):
         from pycbc.io.hdf import dump_state
 
         self.tnum_finished = tnum_finished
-        logging.info('Writing checkpoint file at template %s', tnum_finished)
+        logger.info('Writing checkpoint file at template %s', tnum_finished)
         fp = h5py.File(filename, 'w')
         dump_state(self, fp, protocol=pickle.HIGHEST_PROTOCOL)
         fp.close()
@@ -214,7 +216,7 @@ class EventManager(object):
             raise e
         fp.close()
         next_template = mgr.tnum_finished + 1
-        logging.info('Restoring with checkpoint at template %s', next_template)
+        logger.info('Restoring with checkpoint at template %s', next_template)
         return mgr.tnum_finished + 1, mgr
 
     @classmethod
@@ -351,35 +353,35 @@ class EventManager(object):
 
     def consolidate_events(self, opt, gwstrain=None):
         self.events = numpy.concatenate(self.accumulate)
-        logging.info("We currently have %d triggers", len(self.events))
+        logger.info("We currently have %d triggers", len(self.events))
         if opt.chisq_threshold and opt.chisq_bins:
-            logging.info("Removing triggers with poor chisq")
+            logger.info("Removing triggers with poor chisq")
             self.chisq_threshold(opt.chisq_threshold, opt.chisq_bins,
                                  opt.chisq_delta)
-            logging.info("%d remaining triggers", len(self.events))
+            logger.info("%d remaining triggers", len(self.events))
 
         if opt.newsnr_threshold and opt.chisq_bins:
-            logging.info("Removing triggers with NewSNR below threshold")
+            logger.info("Removing triggers with NewSNR below threshold")
             self.newsnr_threshold(opt.newsnr_threshold)
-            logging.info("%d remaining triggers", len(self.events))
+            logger.info("%d remaining triggers", len(self.events))
 
         if opt.keep_loudest_interval:
-            logging.info("Removing triggers not within the top %s "
-                         "loudest of a %s second interval by %s",
-                         opt.keep_loudest_num, opt.keep_loudest_interval,
-                         opt.keep_loudest_stat)
+            logger.info("Removing triggers not within the top %s "
+                        "loudest of a %s second interval by %s",
+                        opt.keep_loudest_num, opt.keep_loudest_interval,
+                        opt.keep_loudest_stat)
             self.keep_loudest_in_interval\
                 (opt.keep_loudest_interval * opt.sample_rate,
                  opt.keep_loudest_num, statname=opt.keep_loudest_stat,
                  log_chirp_width=opt.keep_loudest_log_chirp_window)
-            logging.info("%d remaining triggers", len(self.events))
+            logger.info("%d remaining triggers", len(self.events))
 
         if opt.injection_window and hasattr(gwstrain, 'injections'):
-            logging.info("Keeping triggers within %s seconds of injection",
+            logger.info("Keeping triggers within %s seconds of injection",
                          opt.injection_window)
             self.keep_near_injection(opt.injection_window,
                                      gwstrain.injections)
-            logging.info("%d remaining triggers", len(self.events))
+            logger.info("%d remaining triggers", len(self.events))
 
         self.accumulate = [self.events]
 

--- a/pycbc/events/significance.py
+++ b/pycbc/events/significance.py
@@ -32,6 +32,8 @@ import lal
 import numpy as np
 from pycbc.events import trigger_fits as trstats
 
+logger = logging.getLogger('pycbc.events.significance')
+
 
 def count_n_louder(bstat, fstat, dec,
                    **kwargs):  # pylint:disable=unused-argument
@@ -280,8 +282,8 @@ def positive_float(inp):
     """
     fl_in = float(inp)
     if fl_in < 0:
-        logging.warning("Value provided to positive_float is less than zero, "
-                        "this is not allowed")
+        logger.warning("Value provided to positive_float is less than zero, "
+                       "this is not allowed")
         raise ValueError
     return fl_in
 
@@ -406,8 +408,8 @@ def digest_significance_options(combo_keys, args):
                 # Allow options for detector combos that are not actually
                 # used/required for a given job. Such options have
                 # no effect, but emit a warning for (e.g.) diagnostic checks
-                logging.warning("Key %s not used by this code, uses %s",
-                                combo, combo_keys)
+                logger.warning("Key %s not used by this code, uses %s",
+                               combo, combo_keys)
                 significance_dict[combo] = copy.deepcopy(_default_opt_dict)
             significance_dict[combo][argument_key] = conv_func(value)
 
@@ -442,8 +444,8 @@ def apply_far_limit(far, significance_dict, combo=None):
         if significance_dict[combo]['far_limit'] == 0:
             return far_out
         far_limit_str = f"{significance_dict[combo]['far_limit']:.3e}"
-        logging.info("Applying FAR limit of %s to %s events",
-                     far_limit_str, combo)
+        logger.info("Applying FAR limit of %s to %s events",
+                    far_limit_str, combo)
         far_out = np.maximum(far, significance_dict[combo]['far_limit'])
     else:
         # IFO combo supplied as an array, by e.g. pycbc_add_statmap
@@ -453,8 +455,8 @@ def apply_far_limit(far, significance_dict, combo=None):
             if significance_dict[ifo_combo]['far_limit'] == 0:
                 continue
             far_limit_str = f"{significance_dict[ifo_combo]['far_limit']:.3e}"
-            logging.info("Applying FAR limit of %s to %s events",
-                         far_limit_str, ifo_combo)
+            logger.info("Applying FAR limit of %s to %s events",
+                        far_limit_str, ifo_combo)
             this_combo_idx = combo == ifo_combo.encode('utf-8')
             far_out[this_combo_idx] = np.maximum(
                 far[this_combo_idx],

--- a/pycbc/events/single.py
+++ b/pycbc/events/single.py
@@ -8,6 +8,8 @@ from pycbc.types import MultiDetOptionAction
 from pycbc import conversions as conv
 from pycbc import bin_utils
 
+logger = logging.getLogger('pycbc.events.single')
+
 
 class LiveSingle(object):
     def __init__(self, ifo,
@@ -198,7 +200,7 @@ class LiveSingle(object):
         return candidate
 
     def calculate_ifar(self, sngl_ranking, duration):
-        logging.info("Calculating IFAR")
+        logger.info("Calculating IFAR")
         if self.fixed_ifar and self.ifo in self.fixed_ifar:
             return self.fixed_ifar[self.ifo]
 
@@ -211,7 +213,7 @@ class LiveSingle(object):
                 rates = dist_grp['counts'][:] / live_time
                 coeffs = dist_grp['fit_coeff'][:]
         except FileNotFoundError:
-            logging.error(
+            logger.error(
                 'Single fit file %s not found; '
                 'dropping a potential single-detector candidate!',
                 self.fit_file

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -33,6 +33,8 @@ from . import coinc_rate
 from .eventmgr_cython import logsignalrateinternals_computepsignalbins
 from .eventmgr_cython import logsignalrateinternals_compute2detrate
 
+logger = logging.getLogger('pycbc.events.stat')
+
 
 class Stat(object):
     """Base class which should be extended to provide a coincident statistic"""
@@ -64,7 +66,7 @@ class Stat(object):
             if stat in self.files:
                 raise RuntimeError("We already have one file with stat attr ="
                                    " %s. Can't provide more than one!" % stat)
-            logging.info("Found file %s for stat %s", filename, stat)
+            logger.info("Found file %s for stat %s", filename, stat)
             self.files[stat] = filename
 
         # Provide the dtype of the single detector method's output
@@ -381,7 +383,7 @@ class PhaseTDStatistic(QuadratureSumStatistic):
         if selected is None and len(ifos) > 1:
             raise RuntimeError("Couldn't figure out which stat file to use")
 
-        logging.info("Using signal histogram %s for ifos %s", selected, ifos)
+        logger.info("Using signal histogram %s for ifos %s", selected, ifos)
         weights = {}
         param = {}
 
@@ -390,7 +392,7 @@ class PhaseTDStatistic(QuadratureSumStatistic):
 
             # Patch for pre-hdf5=3.0 histogram files
             try:
-                logging.info("Decoding hist ifos ..")
+                logger.info("Decoding hist ifos ..")
                 self.hist_ifos = [i.decode('UTF-8') for i in self.hist_ifos]
             except (UnicodeDecodeError, AttributeError):
                 pass

--- a/pycbc/events/trigger_fits.py
+++ b/pycbc/events/trigger_fits.py
@@ -52,6 +52,8 @@ import logging
 import numpy
 from scipy.stats import kstest
 
+logger = logging.getLogger('pycbc.events.trigger_fits')
+
 def exponential_fitalpha(vals, thresh, w):
     """
     Maximum likelihood estimator for the fit factor for
@@ -127,8 +129,8 @@ def fit_above_thresh(distr, vals, thresh=None, weights=None):
         above_thresh = vals >= thresh
         if numpy.count_nonzero(above_thresh) == 0:
             # Nothing is above threshold - warn and return -1
-            logging.warning("No values are above the threshold, %.2f, "
-                            "maximum is %.2f.", thresh, vals.max())
+            logger.warning("No values are above the threshold, %.2f, "
+                           "maximum is %.2f.", thresh, vals.max())
             return -1., -1.
 
         vals = vals[above_thresh]


### PR DESCRIPTION
Some changes to how logging is handled, ~this will grow to a bigger change over the coming weeks as I start to add more executables and modules into this~. This MR contains executables in `bin/all_sky_search` and modules in `pycbc/events`:
1. The first change is to include the logging level in the default logging format
1. I plan to use `init_logging` in the executables as much as possible / where it is appropriate in order to keep logging the same throughoput the code
1. The last change is one I wanted to check, see below

I have made this PR early as I thought it best to check that my plan was agreeable to others before going through all parts of the code.

One of the things I was going to change is that each module gets its own named logger ([using this standard](https://docs.python.org/2/howto/logging-cookbook.html#using-logging-in-multiple-modules), one can then specify that logger to be more or less verbose when the module is called - this is useful for people downstream of us and is fairly standard practice from what I can see (people can even just set 'pycbc' to set things for all from pycbc which is nice). I have given an example from the cuts and significance modules.