### PR TITLE
remove removal of downranked triggers

### DIFF
--- a/bin/minifollowups/pycbc_plot_trigger_timeseries
+++ b/bin/minifollowups/pycbc_plot_trigger_timeseries
@@ -92,21 +92,11 @@ for ifo in args.single_trigger_files.keys():
     logging.info("Getting %s", args.plot_type)
     rank = ranking.get_sngls_ranking_from_trigs(trigs, args.plot_type)
 
-    if all(rank == 1):
-        # This is the default value to say "downranked beyond consideration"
-        # so skip these events
-        pylab.scatter(-2 * args.window, 0,
-                      color=pycbc.results.ifo_color(ifo),
-                      marker='x',
-                      label=ifo)
-        continue
-
     pylab.scatter(trigs['end_time'] - t, rank,
                   color=pycbc.results.ifo_color(ifo), marker='x',
                   label=ifo)
 
-    # Minimum rank which hasn't been set to the default of 1
-    min_rank = min(min_rank, rank[rank > 1].min())
+    min_rank = min(min_rank, rank.min())
 
     if args.special_trigger_ids:
         special_idx = args.special_trigger_ids[ifo]

--- a/bin/minifollowups/pycbc_plot_trigger_timeseries
+++ b/bin/minifollowups/pycbc_plot_trigger_timeseries
@@ -128,7 +128,10 @@ logging.info("Saving figure")
 pycbc.results.save_fig_with_metadata(fig, args.output_file,
             cmd = ' '.join(sys.argv),
             title = 'Single Detector Trigger Timeseries (%s)' % args.plot_type,
-            caption = 'Time series showing the single detector triggers'
-                      ' centered around the time of the trigger of interest.',
+            caption = 'Time series showing the single-detector triggers '
+                      'centered around the time of the trigger of interest. '
+                      'Triggers with ranking 1 have been downweighted beyond '
+                      'consideration, but may still form insignificant '
+                      'events.',
          )
 logging.info("Done!")


### PR DESCRIPTION
Looking at the plots of missed loud injections in results pages, it was confusing that things had triggers with `snr` but not with `newsnr_bells_and_whistles`

This adds back in the things which were removed as they had sngl-ranking of 1

Old output:
![image](https://github.com/gwastro/pycbc/assets/44500294/8d74b348-9b48-41bc-840f-0c3b238a7bf6)


New output:
![image](https://github.com/gwastro/pycbc/assets/44500294/7e0e59a6-a3c6-4662-8fae-8338b20bc532)

SNR for good measure:
![image](https://github.com/gwastro/pycbc/assets/44500294/340daadd-ddff-4618-b65a-183d399484d0)


I've also added a brief explanation to the caption about why there are some triggers with ranking 1