### PR TITLE
update lalsimulation cvmfs path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN dnf -y install https://ecsft.cern.ch/dist/cvmfs/cvmfs-release/cvmfs-release-
 
 # set up environment
 RUN cd / && \
-    mkdir -p /cvmfs/config-osg.opensciencegrid.org /cvmfs/software.igwn.org /cvmfs/gwosc.osgstorage.org && echo "config-osg.opensciencegrid.org /cvmfs/config-osg.opensciencegrid.org cvmfs ro,noauto 0 0" >> /etc/fstab && echo "oasis.opensciencegrid.org /cvmfs/software.igwn.org cvmfs ro,noauto 0 0" >> /etc/fstab && echo "gwosc.osgstorage.org /cvmfs/gwosc.osgstorage.org cvmfs ro,noauto 0 0" >> /etc/fstab && mkdir -p /oasis /scratch /projects /usr/lib64/slurm /var/run/munge && \
+    mkdir -p /cvmfs/config-osg.opensciencegrid.org /cvmfs/software.igwn.org /cvmfs/gwosc.osgstorage.org && echo "config-osg.opensciencegrid.org /cvmfs/config-osg.opensciencegrid.org cvmfs ro,noauto 0 0" >> /etc/fstab && echo "software.igwn.org /cvmfs/software.igwn.org cvmfs ro,noauto 0 0" >> /etc/fstab && echo "gwosc.osgstorage.org /cvmfs/gwosc.osgstorage.org cvmfs ro,noauto 0 0" >> /etc/fstab && mkdir -p /oasis /scratch /projects /usr/lib64/slurm /var/run/munge && \
     groupadd -g 1000 pycbc && useradd -u 1000 -g 1000 -d /opt/pycbc -k /etc/skel -m -s /bin/bash pycbc
 
 # Install MPI software needed for pycbc_inference

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ ENV PATH "/usr/local/bin:/usr/bin:/bin:/lib64/openmpi/bin/bin"
 # Set the default LAL_DATA_PATH to point at CVMFS first, then the container.
 # Users wanting it to point elsewhere should start docker using:
 #   docker <cmd> -e LAL_DATA_PATH="/my/new/path"
-ENV LAL_DATA_PATH "/cvmfs/oasis.opensciencegrid.org/ligo/sw/pycbc/lalsuite-extra/current/share/lalsimulation:/opt/pycbc/pycbc-software/share/lal-data"
+ENV LAL_DATA_PATH "/cvmfs/software.igwn.org/pycbc/lalsuite-extra/current/share/lalsimulation:/opt/pycbc/pycbc-software/share/lal-data"
 
 # When the container is started with
 #   docker run -it pycbc/pycbc-el8:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN dnf -y install https://ecsft.cern.ch/dist/cvmfs/cvmfs-release/cvmfs-release-
 
 # set up environment
 RUN cd / && \
-    mkdir -p /cvmfs/config-osg.opensciencegrid.org /cvmfs/oasis.opensciencegrid.org /cvmfs/gwosc.osgstorage.org && echo "config-osg.opensciencegrid.org /cvmfs/config-osg.opensciencegrid.org cvmfs ro,noauto 0 0" >> /etc/fstab && echo "oasis.opensciencegrid.org /cvmfs/oasis.opensciencegrid.org cvmfs ro,noauto 0 0" >> /etc/fstab && echo "gwosc.osgstorage.org /cvmfs/gwosc.osgstorage.org cvmfs ro,noauto 0 0" >> /etc/fstab && mkdir -p /oasis /scratch /projects /usr/lib64/slurm /var/run/munge && \
+    mkdir -p /cvmfs/config-osg.opensciencegrid.org /cvmfs/software.igwn.org /cvmfs/gwosc.osgstorage.org && echo "config-osg.opensciencegrid.org /cvmfs/config-osg.opensciencegrid.org cvmfs ro,noauto 0 0" >> /etc/fstab && echo "oasis.opensciencegrid.org /cvmfs/software.igwn.org cvmfs ro,noauto 0 0" >> /etc/fstab && echo "gwosc.osgstorage.org /cvmfs/gwosc.osgstorage.org cvmfs ro,noauto 0 0" >> /etc/fstab && mkdir -p /oasis /scratch /projects /usr/lib64/slurm /var/run/munge && \
     groupadd -g 1000 pycbc && useradd -u 1000 -g 1000 -d /opt/pycbc -k /etc/skel -m -s /bin/bash pycbc
 
 # Install MPI software needed for pycbc_inference

--- a/docker/etc/docker-install.sh
+++ b/docker/etc/docker-install.sh
@@ -11,11 +11,11 @@ mkdir -p /opt/pycbc/src
 cp -a /scratch /opt/pycbc/src/pycbc
 chmod a+rw /dev/fuse
 mount /cvmfs/config-osg.opensciencegrid.org
-mount /cvmfs/oasis.opensciencegrid.org
+mount /cvmfs/software.igwn.org
 mkdir -p /opt/pycbc/pycbc-software/share/lal-data
 rsync --exclude='SEOBNRv1ROM*' --exclude='SEOBNRv2ROM_DS_HI_v1.0.hdf5' --exclude='NRSur4d2s_FDROM.hdf5' -ravz /cvmfs/software.igwn.org/pycbc/lalsuite-extra/current/share/lalsimulation/ /opt/pycbc/pycbc-software/share/lal-data/
 umount /cvmfs/config-osg.opensciencegrid.org
-umount /cvmfs/oasis.opensciencegrid.org
+umount /cvmfs/software.igwn.org
 chown -R 1000:1000 /opt/pycbc/src /opt/pycbc/pycbc-software
 chmod -R u=rwX,g=rX,o=rX /opt/pycbc
 exit 0

--- a/docker/etc/docker-install.sh
+++ b/docker/etc/docker-install.sh
@@ -13,7 +13,7 @@ chmod a+rw /dev/fuse
 mount /cvmfs/config-osg.opensciencegrid.org
 mount /cvmfs/oasis.opensciencegrid.org
 mkdir -p /opt/pycbc/pycbc-software/share/lal-data
-rsync --exclude='SEOBNRv1ROM*' --exclude='SEOBNRv2ROM_DS_HI_v1.0.hdf5' --exclude='NRSur4d2s_FDROM.hdf5' -ravz /cvmfs/oasis.opensciencegrid.org/ligo/sw/pycbc/lalsuite-extra/current/share/lalsimulation/ /opt/pycbc/pycbc-software/share/lal-data/
+rsync --exclude='SEOBNRv1ROM*' --exclude='SEOBNRv2ROM_DS_HI_v1.0.hdf5' --exclude='NRSur4d2s_FDROM.hdf5' -ravz /cvmfs/software.igwn.org/pycbc/lalsuite-extra/current/share/lalsimulation/ /opt/pycbc/pycbc-software/share/lal-data/
 umount /cvmfs/config-osg.opensciencegrid.org
 umount /cvmfs/oasis.opensciencegrid.org
 chown -R 1000:1000 /opt/pycbc/src /opt/pycbc/pycbc-software

--- a/docs/building_bundled_executables.rst
+++ b/docs/building_bundled_executables.rst
@@ -96,7 +96,7 @@ The script executes ``pycbc_inspiral`` as part of the build process. This may
 require LAL data at build time. The LAL data can be given with the command
 line argument::
     
-    --with-lal-data-path=/cvmfs/oasis.opensciencegrid.org/ligo/sw/pycbc/lalsuite-extra/current/share/lalsimulation
+    --with-lal-data-path=/cvmfs/software.igwn.org/pycbc/lalsuite-extra/current/share/lalsimulation
 
 The default command line arguments clone PyCBC from the standard GitHub
 repository.  If you would like to build a bundle using code from your own
@@ -130,6 +130,6 @@ Building Releases for CVMFS
 To build a release of ``pycbc_inspiral`` for installation in CVMFS, run the
 script with the arguments::
 
-    pycbc_build_eah.sh --lalsuite-commit=a3a5a476d33f169b8749e2840c306a48df63c936 --pycbc-commit=b68832784969a47fe2658abffb3888ee06cd1be4 --with-extra-libs=file:///home/pycbc/build/composer_xe_2015.0.090.tar.gz --with-lal-data-path=/cvmfs/oasis.opensciencegrid.org/ligo/sw/pycbc/lalsuite-extra/current/share/lalsimulation
+    pycbc_build_eah.sh --lalsuite-commit=a3a5a476d33f169b8749e2840c306a48df63c936 --pycbc-commit=b68832784969a47fe2658abffb3888ee06cd1be4 --with-extra-libs=file:///home/pycbc/build/composer_xe_2015.0.090.tar.gz --with-lal-data-path=/cvmfs/software.igwn.org/pycbc/lalsuite-extra/current/share/lalsimulation
 
 changing the ``--lalsuite-commit``, ``--pycbc-commit``, and ``--with-lal-data-path`` options to the values for the release.

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -70,12 +70,12 @@ available in a 'IGWN Conda' environment.  To see what environments are available
 
 This should yield ``igwn-py37`` as one choice.  The output of this command will also
 tell you the location of the environment in the file system.  Then, the location of the
-python3.7 executable is for instance ``/cvmfs/oasis.opensciencegrid.org/ligo/sw/conda/envs/igwn-py37/bin/python``
+python3.7 executable is for instance ``/cvmfs/software.igwn.org/conda/envs/igwn-py37/bin/python``
 and you will create the virtualenv via the command
 
 .. code-block:: bash
 
-    virtualenv -p /cvmfs/oasis.opensciencegrid.org/ligo/sw/conda/envs/igwn-py37/bin/python env
+    virtualenv -p /cvmfs/software.igwn.org/conda/envs/igwn-py37/bin/python env
 
 Once the virtualenv has been created you can install PyCBC from PyPI or a local
 copy with the `[igwn]` extra specifier to install the optional extra requirements

--- a/docs/install_lalsuite.rst
+++ b/docs/install_lalsuite.rst
@@ -146,7 +146,7 @@ run the command
 
 .. code-block:: bash
 
-    echo 'export LAL_DATA_PATH=/cvmfs/oasis.opensciencegrid.org/ligo/sw/pycbc/lalsuite-extra/current/share/lalsimulation' >> $VIRTUAL_ENV/bin/activate
+    echo 'export LAL_DATA_PATH=/cvmfs/software.igwn.org/pycbc/lalsuite-extra/current/share/lalsimulation' >> $VIRTUAL_ENV/bin/activate
 
 to add the appropriate path to your virtual environment's ``activate`` script.
 Then deactivate and activate your virtual environment.

--- a/docs/workflow/pycbc_make_offline_search_workflow.rst
+++ b/docs/workflow/pycbc_make_offline_search_workflow.rst
@@ -987,8 +987,8 @@ locations in CVMFS.
 You will also need to specify where the code should get the data needed to generate reduced
 order model waveforms. To do this add the following additional arguments to ``pycbc_submit_dax``::
 
-    --append-site-profile 'local:env|LAL_DATA_PATH:/cvmfs/oasis.opensciencegrid.org/ligo/sw/pycbc/lalsuite-extra/current/share/lalsimulation' \
-    --append-site-profile 'osg:env|LAL_DATA_PATH:/cvmfs/oasis.opensciencegrid.org/ligo/sw/pycbc/lalsuite-extra/current/share/lalsimulation' \
+    --append-site-profile 'local:env|LAL_DATA_PATH:/cvmfs/software.igwn.org/pycbc/lalsuite-extra/current/share/lalsimulation' \
+    --append-site-profile 'osg:env|LAL_DATA_PATH:/cvmfs/software.igwn.org/pycbc/lalsuite-extra/current/share/lalsimulation' \
 
 Here, ``current`` is a symbolic link to the latest version of the data and can be replaced with a
 specific release (e.g. ``e02dab8c``) if required.

--- a/tools/cvmfs-default.local
+++ b/tools/cvmfs-default.local
@@ -1,5 +1,5 @@
 CVMFS_USER=cvmfs
-CVMFS_REPOSITORIES=config-osg.opensciencegrid.org,oasis.opensciencegrid.org,gwosc.osgstorage.org
+CVMFS_REPOSITORIES=config-osg.opensciencegrid.org,software.igwn.org,gwosc.osgstorage.org
 CVMFS_QUOTA_LIMIT=5000
 CVMFS_HTTP_PROXY=DIRECT
 CVMFS_MAX_RETRIES=10


### PR DESCRIPTION
Some places were missed in #4440

The basic method behind finding the changes needed was:

```git grep cvmfs | grep lalsimulation | grep openscience```

followed by
```
:%s:/cvmfs/oasis.opensciencegrid.org/ligo/sw/pycbc/lalsuite-extra/current/share/lalsimulation:/cvmfs/
software.igwn.org/pycbc/lalsuite-extra/current/share/lalsimulation:g
```
(VI command) in each file it was found in to make the change