### PR TITLE
[bug] Enforcing int types in pycbc_coinc_findtrigs

### DIFF
--- a/bin/all_sky_search/pycbc_coinc_findtrigs
+++ b/bin/all_sky_search/pycbc_coinc_findtrigs
@@ -142,9 +142,9 @@ for i in range(len(args.trigger_files)):
 
     # We don't have that many triggers, see if we can skip some templates
     if len(reader.file[ifo]['template_id']) < 2**27:
-        uniq = numpy.unique(reader.file[ifo]['template_id'][:])
+        uniq = numpy.unique(reader.file[ifo]['template_id'][:]).astype(numpy.int64)
         if tids_with_trigs is None:
-            tids_with_trigs = numpy.arange(0, num_templates)
+            tids_with_trigs = numpy.arange(0, num_templates, dtype=numpy.int64)
         tids_with_trigs = numpy.intersect1d(tids_with_trigs, uniq)
 
     # time shift is subtracted from pivot ifo time


### PR DESCRIPTION
When using `pycbc_coinc_findtrigs` with results from the PyCBC online search I found a bug when using two different integer typed objects in numpy's `intersect1d`. 

The Bug:
- `template_id`s for the live triggers are stored as unsigned integers of type uint64
- `numpy.arange` creates an array of integers which are of type int64
- When intersect1d is called on two objects of the same type it returns an object of the same type
- When intersect1d is called on two objects of different type (uint64 and int64) it returns an object of the type float64

This is a problem because the outputs of intersect1d are using to index an array and float values are not allowed for indexing.

I have enforced the type int64 on the output of the `numpy.uniq` function to match what should be produced by `numpy.arange` and I also enforced this on `numpy.arange` just to make sure it uses the correct types in the future. If this is overkill then let me know and I can remove it.

---
```
>>> a = np.arange(100, dtype=np.int64)
>>> b = np.arange(100, dtype=np.uint64)
>>> np.intersect1d(a,b)
array([ 0.,  1.,  2.,  3.,  4.,  5.,  6.,  7.,  8.,  9., 10., 11., 12.,
       13., 14., 15., 16., 17., 18., 19., 20., 21., 22., 23., 24., 25.,
       26., 27., 28., 29., 30., 31., 32., 33., 34., 35., 36., 37., 38.,
       39., 40., 41., 42., 43., 44., 45., 46., 47., 48., 49., 50., 51.,
       52., 53., 54., 55., 56., 57., 58., 59., 60., 61., 62., 63., 64.,
       65., 66., 67., 68., 69., 70., 71., 72., 73., 74., 75., 76., 77.,
       78., 79., 80., 81., 82., 83., 84., 85., 86., 87., 88., 89., 90.,
       91., 92., 93., 94., 95., 96., 97., 98., 99.])
>>> np.intersect1d(a,a)
array([ 0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16,
       17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33,
       34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50,
       51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67,
       68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84,
       85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99])
>>> np.intersect1d(b,b)
array([ 0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16,
       17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33,
       34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50,
       51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67,
       68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84,
       85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99],
      dtype=uint64)
```