### PR TITLE
Do not set matplotlib's backend in internal modules

### DIFF
--- a/bin/pycbc_make_skymap
+++ b/bin/pycbc_make_skymap
@@ -11,6 +11,12 @@ import logging
 import subprocess
 import tempfile
 import shutil
+
+# we will make plots on a likely headless machine, so make sure matplotlib's
+# backend is set appropriately
+from matplotlib import use as mpl_use_backend
+mpl_use_backend('agg')
+
 import numpy as np
 import h5py
 import pycbc

--- a/bin/pycbc_optimize_snr
+++ b/bin/pycbc_optimize_snr
@@ -3,19 +3,28 @@
 """Followup utility to optimize the SNR of a PyCBC Live trigger."""
 
 import os
-import argparse, numpy, h5py
+import argparse
 import logging
+
+# we will make plots on a likely headless machine, so make sure matplotlib's
+# backend is set appropriately
+from matplotlib import use as mpl_use_backend
+mpl_use_backend('agg')
+
+import numpy
+import h5py
 import pycbc
 from pycbc import (
     fft, scheme, version
 )
 from pycbc.types import MultiDetOptionAction, load_frequencyseries
 import pycbc.conversions as cv
-from pycbc.io import live
+from pycbc.io.live import CandidateForGraceDB
 from pycbc.io.hdf import load_hdf5_to_dict
 from pycbc.detector import Detector
 from pycbc.psd import interpolate
 from pycbc.live import snr_optimizer
+
 
 parser = argparse.ArgumentParser(description=__doc__)
 parser.add_argument('--version', action='version',
@@ -325,7 +334,7 @@ if 'p_terr' in fp:
     kwargs['p_terr'] = fp['p_terr'][()]
 
 # Treat all ifos as having triggers
-doc = live.CandidateForGraceDB(
+doc = CandidateForGraceDB(
     ifos,
     ifos,
     coinc_results,

--- a/pycbc/io/live.py
+++ b/pycbc/io/live.py
@@ -345,8 +345,6 @@ class CandidateForGraceDB(object):
         labels: list
             Optional list of labels to tag the new event with.
         """
-        import matplotlib
-        matplotlib.use('Agg')
         import pylab as pl
 
         if fname.endswith('.xml.gz'):


### PR DESCRIPTION
Discussion in #4534 highlighted another case of matplotlib's backend being set deep into a module, which can lead to problems. This PR fixes that case by making sure the backend is set at the initialization of the executable scripts which use that module.