### PR TITLE
bug in choosing the far calculation method

### DIFF
--- a/bin/all_sky_search/pycbc_add_statmap
+++ b/bin/all_sky_search/pycbc_add_statmap
@@ -345,6 +345,8 @@ else:
                 f_in.attrs['background_time_exc'],
                 **significance_dict[ifo_combo_key])
 
+del ifo_combo_key
+
 logging.info('Combining false alarm rates from all available backgrounds')
 
 # Convert dictionary of whether the ifo combination is available at trigger

--- a/bin/all_sky_search/pycbc_add_statmap
+++ b/bin/all_sky_search/pycbc_add_statmap
@@ -611,7 +611,7 @@ while True:
             sep_fg_data[key].data['stat'],
             sep_bg_data[key].data['decimation_factor'],
             bg_t_y,
-            **significance_dict[ifo_combo_key])
+            **significance_dict[key])
         fg_far = significance.apply_far_limit(
             fg_far,
             significance_dict,
@@ -635,7 +635,7 @@ while True:
             combined_fg_data.data['stat'],
             sep_bg_data[key].data['decimation_factor'],
             bg_time_ct[key],
-            **significance_dict[ifo_combo_key])
+            **significance_dict[key])
         # Set up variable for whether each coincidence is available in each coincidence time
         is_in_combo_time[key] = np.zeros(n_triggers)
         end_times = np.array(f['segments/%s/end' % key][:])


### PR DESCRIPTION
The wrong IFO combo was being passed to the significance dictionary to decide the method used for calculating the FAR in each combination during hierarchical removal

This led to events using the exponential method of FAR calculation when they should have used the counting method, and having very extrapolated IFARs!