### PR TITLE
MNT: upgrade upload/download-artifact GitHub actions

### DIFF
--- a/.github/workflows/basic-tests.yml
+++ b/.github/workflows/basic-tests.yml
@@ -51,7 +51,7 @@ jobs:
         tox -e py-inference
     - name: store documentation page
       if: matrix.test-type == 'docs' && matrix.python-version == '3.8'
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: documentation-page
         path: _gh-pages
@@ -61,9 +61,10 @@ jobs:
     if: github.ref == 'refs/heads/master' && github.event_name == 'push'
     steps:
     - name: retrieve built documentation
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v4
       with:
-        name: documentation-page
+        pattern: documentation-page-*
+        merge-multiple: true
     - name: debug
       run: |
         mkdir _gh-pages

--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -29,8 +29,9 @@ jobs:
           CIBW_BUILD: cp38-* cp39-* cp310-* cp311-*
           CIBW_SKIP: "*musllinux*"
           CIBW_ARCHS_MACOS: x86_64 arm64
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
+          name: wheels-${{ matrix.os }}
           path: ./wheelhouse/*.whl
   deploy_pypi:
     name: Build and publish Python 🐍 distributions 📦 to PyPI
@@ -44,13 +45,14 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: 3.8
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v4
       with:
-        path: ./
+        pattern: wheels-*
+        merge-multiple: true
     - name: build pycbc for pypi
       run: |
         python setup.py sdist
-        mv artifact/* dist/
+        mv *.whl dist/
     - name: Publish distribution 📦 to PyPI
       if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
       uses: pypa/gh-action-pypi-publish@master

--- a/.github/workflows/inference-workflow.yml
+++ b/.github/workflows/inference-workflow.yml
@@ -48,12 +48,12 @@ jobs:
         find submitdir/work/ -type f -name '*.tar.gz' -delete
     - name: store log files
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: logs
         path: gw_output/submitdir/work
     - name: store result page
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: results
         path: html

--- a/.github/workflows/search-workflow.yml
+++ b/.github/workflows/search-workflow.yml
@@ -55,12 +55,12 @@ jobs:
         find submitdir/work/ -type f -name '*.tar.gz' -delete
     - name: store log files
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: logs
         path: output/submitdir/work
     - name: store result page
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: results
         path: html

--- a/.github/workflows/tmpltbank-workflow.yml
+++ b/.github/workflows/tmpltbank-workflow.yml
@@ -51,7 +51,7 @@ jobs:
         find submitdir/work/ -type f -name '*.tar.gz' -delete
     - name: store log files
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: logs
         path: output/submitdir/work

--- a/.github/workflows/workflow-tests.yml
+++ b/.github/workflows/workflow-tests.yml
@@ -50,7 +50,7 @@ jobs:
         find submitdir/work/ -type f -name '*.tar.gz' -delete
     - name: store log files
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: logs-${{matrix.test-type}}
         path: examples/workflow/generic/${{matrix.test-type}}/submitdir/work


### PR DESCRIPTION
Hi, version 4 of upload-artifact and download-artifact were recently released.
Staying on old version is not viable long term because GitHub will sooner or later drop support for the old versions of node that these depend on.
Since migration to v4 is not as straightfoward as bumping the version number, I'm helping all astropy-related packages byt manually performing the necessary changes.
