### PR TITLE
Use vetoed times followup in example

### DIFF
--- a/examples/search/plotting.ini
+++ b/examples/search/plotting.ini
@@ -47,7 +47,6 @@ sngl-ranking = newsnr_sgveto_psdvar
 
 [page_snglinfo-vetoed]
 ranking-statistic = ${sngls|ranking-statistic}
-statistic-files = ${sngls|statistic-files}
 
 [single_template_plot]
 

--- a/examples/search/plotting.ini
+++ b/examples/search/plotting.ini
@@ -11,6 +11,9 @@ section-header = loudest_noncoinc_time
 [workflow-sngl_minifollowups-all]
 section-header = all
 
+[workflow-sngl_minifollowups-vetoed]
+section-header = loudest_within_vetoes
+
 [workflow-injection_minifollowups]
 num-events=1
 subsection-suffix=with_ifar_lt_1_year
@@ -24,7 +27,6 @@ analysis-category = background_exc
 sort-variable = stat
 
 [singles_minifollowup]
-ranking-statistic = single_ranking_only
 sngl-ranking = newsnr_sgveto_psdvar
 
 [singles_minifollowup-noncoinc]
@@ -32,12 +34,20 @@ non-coinc-time-only =
 
 [singles_minifollowup-all]
 
+[singles_minifollowup-vetoed]
+vetoed-time-only =
+ranking-statistic = ${sngls|ranking-statistic}
+statistic-files = ${sngls|statistic-files}
+
 [injection_minifollowup]
 ifar-threshold = 1
 
 [page_snglinfo]
-ranking-statistic = single_ranking_only
 sngl-ranking = newsnr_sgveto_psdvar
+
+[page_snglinfo-vetoed]
+ranking-statistic = ${sngls|ranking-statistic}
+statistic-files = ${sngls|statistic-files}
 
 [single_template_plot]
 


### PR DESCRIPTION
#4549 allowed us to omit vetoed times from the singles minifollowup and separate them into vetoed vs not-vetoed times.

This change adds vetoed times minifollowup into the CI example