### PR TITLE
Allow option for workflow to end at inspiral jobs

### DIFF
--- a/bin/workflows/pycbc_make_offline_search_workflow
+++ b/bin/workflows/pycbc_make_offline_search_workflow
@@ -132,8 +132,8 @@ def finalize(container, workflow, finalize_workflow):
     sys.exit(0)
 
 def check_stop(job_name, container, workflow, finalize_workflow):
-    #This function will finalize the workflow and stop it at the job specified. 
-    #Under [workflow] supply the option stop-after = and the job you want the job to stop at. Current options are [inspiral, hdf_trigger_merge, statmap]
+    #This function will finalize the workflow and stop it at the job specified.
+    #Under [workflow] supply the option stop-after = and the job name you want the workflow to stop at. Current options are [inspiral, hdf_trigger_merge, statmap]
     if workflow.cp.has_option('workflow', 'stop-after'):
         stop_after = workflow.cp.get('workflow', 'stop-after')
         if stop_after == job_name:

--- a/bin/workflows/pycbc_make_offline_search_workflow
+++ b/bin/workflows/pycbc_make_offline_search_workflow
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/home/kkacanja/miniconda3/envs/astro2/bin/python3.8
 
 # Copyright (C) 2013-2023, Ian W. Harry, Alex Nitz, Marton Tapai,
 #     Gareth Cabourn Davies
@@ -56,6 +56,80 @@ def ifo_combos(ifos):
         combinations = itertools.combinations(ifos, i)
         for ifocomb in combinations:
             yield ifocomb
+
+def finalize(container, workflow, finalize_workflow):
+    # Create the final log file
+    log_file_html = wf.File(workflow.ifos, 'WORKFLOW-LOG', workflow.analysis_time,
+                            extension='.html', directory=rdir['workflow'])
+
+    gen_file_html = wf.File(workflow.ifos, 'WORKFLOW-GEN', workflow.analysis_time,
+                            extension='.html', directory=rdir['workflow'])
+
+    # Create a page to contain a dashboard link
+    dashboard_file = wf.File(workflow.ifos, 'DASHBOARD', workflow.analysis_time,
+                             extension='.html', directory=rdir['workflow'])
+    dashboard_str = """<center><p style="font-size:20px"><b><a href="PEGASUS_DASHBOARD_URL" target="_blank">Pegasus Dashboard Page</a></b></p></center>"""
+    kwds = {'title': "Pegasus Dashboard",
+            'caption': "Link to Pegasus Dashboard",
+            'cmd': "PYCBC_SUBMIT_DAX_ARGV", }
+    save_fig_with_metadata(dashboard_str, dashboard_file.storage_path, **kwds)
+
+    # Create pages for the submission script to write data
+    wf.makedir(rdir['workflow/dax'])
+    wf.makedir(rdir['workflow/input_map'])
+    wf.makedir(rdir['workflow/output_map'])
+    wf.makedir(rdir['workflow/planning'])
+
+    wf.make_results_web_page(finalize_workflow, os.path.join(os.getcwd(),
+                                                             rdir.base))
+
+    container += workflow
+    container += finalize_workflow
+
+    container.add_subworkflow_dependancy(workflow, finalize_workflow)
+
+    container.save()
+
+    open_box_result_path = rdir['open_box_result']
+    if os.path.exists(open_box_result_path):
+        os.chmod(open_box_result_path, 0o0700)
+    else:
+        pass
+
+    logging.info("Written dax.")
+
+    # Close the log and flush to the html file
+    logging.shutdown()
+    with open(wf_log_file.storage_path, "r") as logfile:
+        logdata = logfile.read()
+    log_str = """
+    <p>Workflow generation script created workflow in output directory: %s</p>
+    <p>Workflow name is: %s</p>
+    <p>Workflow generation script run on host: %s</p>
+    <pre>%s</pre>
+    """ % (os.getcwd(), args.workflow_name, socket.gethostname(), logdata)
+    kwds = {'title': 'Workflow Generation Log',
+            'caption': "Log of the workflow script %s" % sys.argv[0],
+            'cmd': ' '.join(sys.argv), }
+    save_fig_with_metadata(log_str, log_file_html.storage_path, **kwds)
+
+    # Add the command line used to a specific file
+    args_to_output = [sys.argv[0]]
+    for arg in sys.argv[1:]:
+        if arg.startswith('--'):
+            # This is an option, add tab
+            args_to_output.append('  ' + arg)
+        else:
+            # This is a parameter, add two tabs
+            args_to_output.append('    ' + arg)
+
+    gen_str = '<pre>' + ' \\\n'.join(args_to_output) + '</pre>'
+    kwds = {'title': 'Workflow Generation Command',
+            'caption': "Command used to generate the workflow.",
+            'cmd': ' '.join(sys.argv), }
+    save_fig_with_metadata(gen_str, gen_file_html.storage_path, **kwds)
+    layout.single_layout(rdir['workflow'], ([dashboard_file, gen_file_html, log_file_html]))
+    sys.exit(0)
 
 parser = argparse.ArgumentParser(description=__doc__[1:])
 parser.add_argument('--version', action='version', version=__version__)
@@ -183,6 +257,17 @@ ind_insps = insps = wf.setup_matchedfltr_workflow(workflow, analyzable_segs,
                                    datafind_files, splitbank_files_fd,
                                    output_dir, tags=['full_data'])
 
+
+if workflow.cp.has_option('workflow', 'stop-after-inspiral'):
+    stop_after_inspiral = workflow.cp.getboolean('workflow', 'stop-after-inspiral')
+    if stop_after_inspiral:
+        logging.info("Finalization will be stopped after inspiral.")
+        finalize(container, workflow, finalize_workflow)
+    else:
+        stop_after_inspiral = False
+else:
+    stop_after_inspiral = False
+
 insps = wf.merge_single_detector_hdf_files(workflow, hdfbank,
                                            insps, output_dir,
                                            tags=['full_data'])
@@ -263,6 +348,16 @@ for ifo in ifo_ids.keys():
     no_fg_exc_files[ifo] = wf.setup_sngls(
         workflow, hdfbank, inspcomb, statfiles, final_veto_file,
         final_veto_name, output_dir, tags=ctagsngl)
+
+if workflow.cp.has_option('workflow', 'stop-after-statmap'):
+    stop_after_statmap = workflow.cp.getboolean('workflow', 'stop-after-statmap')
+    if stop_after_statmap:
+        logging.info("Finalization will be stopped after statmap.")
+        finalize(container, workflow, finalize_workflow)
+    else:
+        stop_after_statmap = False
+else:
+    stop_after_statmap = False
 
 ifo_sets = list(ifo_combos(ifo_ids.keys()))
 if analyze_singles:
@@ -836,72 +931,4 @@ wf.make_versioning_page(
 )
 
 ############################ Finalization ####################################
-
-# Create the final log file
-log_file_html = wf.File(workflow.ifos, 'WORKFLOW-LOG', workflow.analysis_time,
-                        extension='.html', directory=rdir['workflow'])
-
-gen_file_html = wf.File(workflow.ifos, 'WORKFLOW-GEN', workflow.analysis_time,
-                        extension='.html', directory=rdir['workflow'])
-
-# Create a page to contain a dashboard link
-dashboard_file = wf.File(workflow.ifos, 'DASHBOARD', workflow.analysis_time,
-                         extension='.html', directory=rdir['workflow'])
-dashboard_str = """<center><p style="font-size:20px"><b><a href="PEGASUS_DASHBOARD_URL" target="_blank">Pegasus Dashboard Page</a></b></p></center>"""
-kwds = { 'title' : "Pegasus Dashboard",
-         'caption' : "Link to Pegasus Dashboard",
-         'cmd' : "PYCBC_SUBMIT_DAX_ARGV", }
-save_fig_with_metadata(dashboard_str, dashboard_file.storage_path, **kwds)
-
-# Create pages for the submission script to write data
-wf.makedir(rdir['workflow/dax'])
-wf.makedir(rdir['workflow/input_map'])
-wf.makedir(rdir['workflow/output_map'])
-wf.makedir(rdir['workflow/planning'])
-
-wf.make_results_web_page(finalize_workflow, os.path.join(os.getcwd(),
-                         rdir.base))
-
-container += workflow
-container += finalize_workflow
-
-container.add_subworkflow_dependancy(workflow, finalize_workflow)
-
-container.save()
-
-# Protect the open box results folder
-os.chmod(rdir['open_box_result'], 0o0700)
-
-logging.info("Written dax.")
-
-# Close the log and flush to the html file
-logging.shutdown()
-with open (wf_log_file.storage_path, "r") as logfile:
-    logdata=logfile.read()
-log_str = """
-<p>Workflow generation script created workflow in output directory: %s</p>
-<p>Workflow name is: %s</p>
-<p>Workflow generation script run on host: %s</p>
-<pre>%s</pre>
-""" % (os.getcwd(), args.workflow_name, socket.gethostname(), logdata)
-kwds = { 'title' : 'Workflow Generation Log',
-         'caption' : "Log of the workflow script %s" % sys.argv[0],
-         'cmd' :' '.join(sys.argv), }
-save_fig_with_metadata(log_str, log_file_html.storage_path, **kwds)
-
-# Add the command line used to a specific file
-args_to_output = [sys.argv[0]]
-for arg in sys.argv[1:]:
-    if arg.startswith('--'):
-        # This is an option, add tab
-        args_to_output.append('  ' + arg)
-    else:
-        # This is a parameter, add two tabs
-        args_to_output.append('    ' + arg)
-
-gen_str = '<pre>' + ' \\\n'.join(args_to_output) + '</pre>'
-kwds = { 'title' : 'Workflow Generation Command',
-         'caption' : "Command used to generate the workflow.",
-         'cmd' :' '.join(sys.argv), }
-save_fig_with_metadata(gen_str, gen_file_html.storage_path, **kwds)
-layout.single_layout(rdir['workflow'], ([dashboard_file, gen_file_html, log_file_html]))
+finalize(container, workflow, finalize_workflow)

--- a/bin/workflows/pycbc_make_offline_search_workflow
+++ b/bin/workflows/pycbc_make_offline_search_workflow
@@ -131,6 +131,16 @@ def finalize(container, workflow, finalize_workflow):
     layout.single_layout(rdir['workflow'], ([dashboard_file, gen_file_html, log_file_html]))
     sys.exit(0)
 
+def check_stop(job_name, container, workflow, finalize_workflow):
+    if workflow.cp.has_option('workflow', 'stop-after'):
+        stop_after = workflow.cp.get('workflow', 'stop-after')
+        if stop_after == job_name:
+            logging.info("Search worflow will be stopped after " + str(job_name))
+            finalize(container, workflow, finalize_workflow)
+        else: 
+            pass
+
+
 parser = argparse.ArgumentParser(description=__doc__[1:])
 parser.add_argument('--version', action='version', version=__version__)
 parser.add_argument('--verbose', action='count',
@@ -257,20 +267,14 @@ ind_insps = insps = wf.setup_matchedfltr_workflow(workflow, analyzable_segs,
                                    datafind_files, splitbank_files_fd,
                                    output_dir, tags=['full_data'])
 
-
-if workflow.cp.has_option('workflow', 'stop-after-inspiral'):
-    stop_after_inspiral = workflow.cp.getboolean('workflow', 'stop-after-inspiral')
-    if stop_after_inspiral:
-        logging.info("Finalization will be stopped after inspiral.")
-        finalize(container, workflow, finalize_workflow)
-    else:
-        stop_after_inspiral = False
-else:
-    stop_after_inspiral = False
+#check to see if workflow should stop at inspiral jobs.
+check_stop('inspiral', container, workflow, finalize_workflow)
 
 insps = wf.merge_single_detector_hdf_files(workflow, hdfbank,
                                            insps, output_dir,
                                            tags=['full_data'])
+
+check_stop('hdf_trigger_merge', container, workflow, finalize_workflow)
 
 # setup sngl trigger distribution fitting jobs
 # 'statfiles' is list of files used in calculating statistic
@@ -349,15 +353,8 @@ for ifo in ifo_ids.keys():
         workflow, hdfbank, inspcomb, statfiles, final_veto_file,
         final_veto_name, output_dir, tags=ctagsngl)
 
-if workflow.cp.has_option('workflow', 'stop-after-statmap'):
-    stop_after_statmap = workflow.cp.getboolean('workflow', 'stop-after-statmap')
-    if stop_after_statmap:
-        logging.info("Finalization will be stopped after statmap.")
-        finalize(container, workflow, finalize_workflow)
-    else:
-        stop_after_statmap = False
-else:
-    stop_after_statmap = False
+#check to see if workflow should stop at statmap jobs.
+check_stop('statmap', container, workflow, finalize_workflow)
 
 ifo_sets = list(ifo_combos(ifo_ids.keys()))
 if analyze_singles:

--- a/bin/workflows/pycbc_make_offline_search_workflow
+++ b/bin/workflows/pycbc_make_offline_search_workflow
@@ -132,6 +132,8 @@ def finalize(container, workflow, finalize_workflow):
     sys.exit(0)
 
 def check_stop(job_name, container, workflow, finalize_workflow):
+    #This function will finalize the workflow and stop it at the job specified. 
+    #Under [workflow] supply the option stop-after = and the job you want the job to stop at. Current options are [inspiral, hdf_trigger_merge, statmap]
     if workflow.cp.has_option('workflow', 'stop-after'):
         stop_after = workflow.cp.get('workflow', 'stop-after')
         if stop_after == job_name:

--- a/bin/workflows/pycbc_make_offline_search_workflow
+++ b/bin/workflows/pycbc_make_offline_search_workflow
@@ -1,4 +1,4 @@
-#!/home/kkacanja/miniconda3/envs/astro2/bin/python3.8
+#!/usr/bin/env python
 
 # Copyright (C) 2013-2023, Ian W. Harry, Alex Nitz, Marton Tapai,
 #     Gareth Cabourn Davies


### PR DESCRIPTION
Added a the option stop-after under [workflow] where you can supply the options ['inspiral', 'hdf_trigger_merge', 'statmap'] for the time being to only do the workflow up until the specified job.

This is useful for clusters such as OSG where inspiral jobs can be parallelized to one core jobs and be parallelized over many nodes. Single processing is not ideal on OSG so this option is useful for these types of clusters.

This does not take into account injection inspiral jobs. 

Also, when using these options, make sure to change the file-retention level in [workflow] such that your files do not get deleted when the workflow finishes running.