### PR TITLE
Remove M2Crypto dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -203,7 +203,7 @@ extras_require = {
         'scikit-cuda',
     ],
     'igwn': [
-        'ciecplib>=0.4.4',
+        'ciecplib>=0.7.0',
     ],
 }
 

--- a/tox.ini
+++ b/tox.ini
@@ -14,9 +14,7 @@ deps =
 [testenv]
 allowlist_externals = bash
 passenv=LAL_DATA_PATH
-conda_deps=
-    openssl=1.1
-    m2crypto
+conda_deps=openssl=1.1
 conda_channels=conda-forge
 platform = lin: linux
            mac: darwin


### PR DESCRIPTION
Looking at https://github.com/gwastro/pycbc/pull/3997, it seems like `M2Crypto` was added to the conda environment due to being a transitive dependency ([via `ciecplib`](https://github.com/gwastro/pycbc/pull/3997#issuecomment-1092842815)). Since `ciecplib` has removed its dependency to `M2Crypto` on version `0.7.0` [(src)](https://github.com/duncanmmacleod/ciecplib/blob/5ee4a251b347c41ede9f77060c72df4f8c34b6b9/debian/changelog#L4), this PR attempts to bump the minimum required version for `ciecplib` and remove the `M2Crypto` dependency.