### PR TITLE
fix thinko in option parsing for defaults

### DIFF
--- a/pycbc/live/snr_optimizer.py
+++ b/pycbc/live/snr_optimizer.py
@@ -393,12 +393,12 @@ def args_to_string(args):
     if optimizer_name == 'differential-evolution':
         optimizer_name = 'di'
     for opt in option_dict[args.snr_opt_method]:
+        key_name = f'snr_opt_{optimizer_name}_{opt}'
         option_value = getattr(args, key_name)
         # If the option is not given, don't pass it and use default
         if option_value is None:
             continue
         option_fullname = f'--snr-opt-{optimizer_name}-{opt}'
-        key_name = f'snr_opt_{optimizer_name}_{opt}'
         argstr += f'{option_fullname} {option_value} '
 
     return argstr

--- a/pycbc/live/snr_optimizer.py
+++ b/pycbc/live/snr_optimizer.py
@@ -393,9 +393,12 @@ def args_to_string(args):
     if optimizer_name == 'differential-evolution':
         optimizer_name = 'di'
     for opt in option_dict[args.snr_opt_method]:
+        option_value = getattr(args, key_name)
+        # If the option is not given, don't pass it and use default
+        if option_value is None:
+            continue
         option_fullname = f'--snr-opt-{optimizer_name}-{opt}'
         key_name = f'snr_opt_{optimizer_name}_{opt}'
-        option_value = getattr(args, key_name)
         argstr += f'{option_fullname} {option_value} '
 
     return argstr


### PR DESCRIPTION
When an option is not given at all getattr on the args object gives None, but we don't want to translate that into "--option-name None" on the subprocess command line.