### PR TITLE
Do not add PFNs for subworkflow input files

### DIFF
--- a/bin/bank/pycbc_geom_aligned_bank
+++ b/bin/bank/pycbc_geom_aligned_bank
@@ -561,6 +561,12 @@ opts.config_delete = []
 # Now setup the workflow
 workflow = wf.Workflow(opts)
 
+# Check if input file PFNs should be added. Not if this is a subworkflow
+if hasattr(args, 'dax_file_directory') and args.dax_file_directory:
+    add_input_file_pfns = False
+else:
+    add_input_file_pfns = True
+
 # Start with 2dstack jobs
 if opts.storage_path_base:
     curr_dir = os.path.join(opts.storage_path_base, 'stack2d')
@@ -571,8 +577,10 @@ else:
 stack_exe = GeomAligned2DStackExecutable(workflow.cp, 'aligned2dstack',
                                          ifos=workflow.ifos, out_dir=curr_dir)
 num_banks = int((len(newV1s) - 0.5)//opts.split_bank_num) + 1
-input_h5file = resolve_url_to_file(opts.intermediate_data_file)
-
+input_h5file = resolve_url_to_file(
+    opts.intermediate_data_file,
+    add_pfn=add_input_file_pfns
+)
 
 all_outs = wf.FileList([])
 
@@ -594,7 +602,10 @@ else:
 
 combine_exe = AlignedBankCatExecutable(workflow.cp, 'alignedbankcat',
                                         ifos=workflow.ifos, out_dir=curr_dir)
-metadata_file = resolve_url_to_file(opts.metadata_file)
+metadata_file = resolve_url_to_file(
+    opts.metadata_file,
+    add_pfn=add_input_file_pfns
+)
 combine_node = combine_exe.create_node(all_outs, metadata_file,
                                        workflow.analysis_time,
                                        output_file_path=opts.output_file)

--- a/bin/minifollowups/pycbc_foreground_minifollowup
+++ b/bin/minifollowups/pycbc_foreground_minifollowup
@@ -59,6 +59,12 @@ wf.add_workflow_command_line_group(parser)
 wf.add_workflow_settings_cli(parser, include_subdax_opts=True)
 args = parser.parse_args()
 
+# Check if input file PFNs should be added. Not if this is a subworkflow
+if hasattr(args, 'dax_file_directory') and args.dax_file_directory:
+    add_input_file_pfns = False
+else:
+    add_input_file_pfns = True
+
 logging.basicConfig(format='%(asctime)s:%(levelname)s : %(message)s',
                     level=logging.INFO)
 
@@ -69,9 +75,18 @@ wf.makedir(args.output_dir)
 # create a FileList that will contain all output files
 layouts = []
 
-tmpltbank_file = resolve_url_to_file(os.path.abspath(args.bank_file))
-coinc_file = resolve_url_to_file(os.path.abspath(args.statmap_file))
-insp_segs = resolve_url_to_file(os.path.abspath(args.inspiral_segments))
+tmpltbank_file = resolve_url_to_file(
+    os.path.abspath(args.bank_file),
+    add_pfn=add_input_file_pfns
+)
+coinc_file = resolve_url_to_file(
+    os.path.abspath(args.statmap_file),
+    add_pfn=add_input_file_pfns
+)
+insp_segs = resolve_url_to_file(
+    os.path.abspath(args.inspiral_segments),
+    add_pfn=add_input_file_pfns
+)
 
 single_triggers = []
 fsdt = {}
@@ -79,8 +94,11 @@ insp_data_seglists = {}
 insp_analysed_seglists = {}
 for ifo in args.single_detector_triggers:
     fname = args.single_detector_triggers[ifo]
-    strig_file = resolve_url_to_file(os.path.abspath(fname),
-                                     attrs={'ifos': ifo})
+    strig_file = resolve_url_to_file(
+        os.path.abspath(fname),
+        attrs={'ifos': ifo},
+        add_pfn=add_input_file_pfns
+    )
     single_triggers.append(strig_file)
     fsdt[ifo] = h5py.File(args.single_detector_triggers[ifo], 'r')
     insp_data_seglists[ifo] = select_segments_by_definer(

--- a/bin/minifollowups/pycbc_injection_minifollowup
+++ b/bin/minifollowups/pycbc_injection_minifollowup
@@ -158,6 +158,12 @@ wf.add_workflow_command_line_group(parser)
 wf.add_workflow_settings_cli(parser, include_subdax_opts=True)
 args = parser.parse_args()
 
+# Check if input file PFNs should be added. Not if this is a subworkflow
+if hasattr(args, 'dax_file_directory') and args.dax_file_directory:
+    add_input_file_pfns = False
+else:
+    add_input_file_pfns = True
+
 logging.basicConfig(format='%(asctime)s:%(levelname)s : %(message)s',
                     level=logging.INFO)
 
@@ -168,18 +174,33 @@ wf.makedir(args.output_dir)
 # create a FileList that will contain all output files
 layouts = []
 
-tmpltbank_file = resolve_url_to_file(os.path.abspath(args.bank_file))
-injection_file = resolve_url_to_file(os.path.abspath(args.injection_file))
-injection_xml_file = resolve_url_to_file(os.path.abspath(args.injection_xml_file))
-insp_segs = resolve_url_to_file(os.path.abspath(args.inspiral_segments))
+tmpltbank_file = resolve_url_to_file(
+    os.path.abspath(args.bank_file),
+    add_pfn=add_input_file_pfns
+)
+injection_file = resolve_url_to_file(
+    os.path.abspath(args.injection_file),
+    add_pfn=add_input_file_pfns
+)
+injection_xml_file = resolve_url_to_file(
+    os.path.abspath(args.injection_xml_file),
+    add_pfn=add_input_file_pfns
+)
+insp_segs = resolve_url_to_file(
+    os.path.abspath(args.inspiral_segments),
+    add_pfn=add_input_file_pfns
+)
 
 single_triggers = []
 insp_data_seglists = {}
 insp_analysed_seglists = {}
 for ifo in args.single_detector_triggers:
     fname = args.single_detector_triggers[ifo]
-    strig_file = resolve_url_to_file(os.path.abspath(fname),
-                                     attrs={'ifos': ifo})
+    strig_file = resolve_url_to_file(
+        os.path.abspath(fname),
+        attrs={'ifos': ifo},
+        add_pfn=add_input_file_pfns
+    )
     single_triggers.append(strig_file)
     insp_data_seglists[ifo] = select_segments_by_definer(
         args.inspiral_segments,

--- a/bin/minifollowups/pycbc_sngl_minifollowup
+++ b/bin/minifollowups/pycbc_sngl_minifollowup
@@ -89,6 +89,12 @@ stat.insert_statistic_option_group(parser,
     default_ranking_statistic='single_ranking_only')
 args = parser.parse_args()
 
+# Check if input file PFNs should be added. Not if this is a subworkflow
+if hasattr(args, 'dax_file_directory') and args.dax_file_directory:
+    add_input_file_pfns = False
+else:
+    add_input_file_pfns = True
+
 logging.basicConfig(format='%(asctime)s:%(levelname)s : %(message)s',
                     level=logging.INFO)
 
@@ -101,27 +107,40 @@ wf.makedir(args.output_dir)
 # create a FileList that will contain all output files
 layouts = []
 
-tmpltbank_file = resolve_url_to_file(os.path.abspath(args.bank_file))
+tmpltbank_file = resolve_url_to_file(
+    os.path.abspath(args.bank_file),
+    add_pfn=add_input_file_pfns
+)
 sngl_file = resolve_url_to_file(
     os.path.abspath(args.single_detector_file),
-    attrs={'ifos': args.instrument}
+    attrs={'ifos': args.instrument},
+    add_pfn=add_input_file_pfns
 )
 
 # Flatten the statistic_files option:
 statfiles = []
 for f in sum(args.statistic_files, []):
-    statfiles.append(resolve_url_to_file(os.path.abspath(f)))
+    statfiles.append(
+        resolve_url_to_file(
+            os.path.abspath(f),
+            add_pfn=add_input_file_pfns
+        )
+    )
 statfiles = wf.FileList(statfiles) if statfiles is not [] else None
 
 if args.veto_file is not None:
     veto_file = resolve_url_to_file(
         os.path.abspath(args.veto_file),
-        attrs={'ifos': args.instrument}
+        attrs={'ifos': args.instrument},
+        add_pfn=add_input_file_pfns
     )
 else:
     veto_file = None
 
-insp_segs = resolve_url_to_file(os.path.abspath(args.inspiral_segments))
+insp_segs = resolve_url_to_file(
+    os.path.abspath(args.inspiral_segments),
+    add_pfn=add_input_file_pfns
+)
 insp_data_seglists = select_segments_by_definer\
         (args.inspiral_segments, segment_name=args.inspiral_data_read_name,
          ifo=args.instrument)

--- a/bin/pygrb/pycbc_pygrb_minifollowups
+++ b/bin/pygrb/pycbc_pygrb_minifollowups
@@ -131,6 +131,12 @@ wf.add_workflow_command_line_group(parser)
 wf.add_workflow_settings_cli(parser, include_subdax_opts=True)
 args = parser.parse_args()
 
+# Check if input file PFNs should be added. Not if this is a subworkflow
+if hasattr(args, 'dax_file_directory') and args.dax_file_directory:
+    add_input_file_pfns = False
+else:
+    add_input_file_pfns = True
+
 init_logging(args.verbose, format="%(asctime)s: %(levelname)s: %(message)s")
 
 workflow = wf.Workflow(args)
@@ -155,7 +161,10 @@ num_events = int(workflow.cp.get_opt_tags('workflow-minifollowups',
 num_events = min(num_events, len(fp['BestNR'][:]))
 
 # Determine ifos used in the analysis
-trig_file = resolve_url_to_file(os.path.abspath(args.trig_file))
+trig_file = resolve_url_to_file(
+    os.path.abspath(args.trig_file),
+    add_pfn=add_input_file_pfns
+)
 ifos = extract_ifos(os.path.abspath(args.trig_file))
 num_ifos = len(ifos)
 

--- a/bin/workflows/pycbc_make_inference_inj_workflow
+++ b/bin/workflows/pycbc_make_inference_inj_workflow
@@ -86,7 +86,7 @@ group.add_argument("--injection-file", type=str, nargs="+",
 # add option groups
 configuration.add_workflow_command_line_group(parser)
 # add workflow group
-core.add_workflow_settings_cli(parser, include_subdax_opts=True)
+core.add_workflow_settings_cli(parser)
 parser.add_argument("--seed", type=int, default=0,
                     help="Starting to seed to use. This will be incremented "
                          "one for each injection analyzed. Default is 0.")

--- a/bin/workflows/pycbc_make_inference_plots_workflow
+++ b/bin/workflows/pycbc_make_inference_plots_workflow
@@ -130,7 +130,7 @@ parser = argparse.ArgumentParser(description=__doc__[1:])
 # add option groups
 configuration.add_workflow_command_line_group(parser)
 # workflow options
-core.add_workflow_settings_cli(parser, include_subdax_opts=True)
+core.add_workflow_settings_cli(parser)
 parser.add_argument("--version", action="version", version=__version__,
                     help="Prints version information.")
 opts = parser.parse_args()

--- a/bin/workflows/pycbc_make_inference_workflow
+++ b/bin/workflows/pycbc_make_inference_workflow
@@ -154,7 +154,7 @@ parser = argparse.ArgumentParser(description=__doc__[1:])
 # add option groups
 configuration.add_workflow_command_line_group(parser)
 # workflow options
-core.add_workflow_settings_cli(parser, include_subdax_opts=True)
+core.add_workflow_settings_cli(parser)
 parser.add_argument("--seed", type=int, default=0,
                     help="Seed to use for inference job(s). If multiple "
                          "events are analyzed, the seed will be incremented "

--- a/bin/workflows/pycbc_make_sbank_workflow
+++ b/bin/workflows/pycbc_make_sbank_workflow
@@ -30,6 +30,7 @@ import pycbc
 import pycbc.version
 import pycbc.workflow as wf
 import pycbc.workflow.pegasus_workflow as pwf
+from pycbc.workflow.core import resolve_url_to_file
 
 # Boiler-plate stuff
 __author__  = "Ian Harry <ian.harry@ligo.org>"
@@ -180,6 +181,12 @@ wf.add_workflow_command_line_group(parser)
 wf.add_workflow_settings_cli(parser, include_subdax_opts=True)
 args = parser.parse_args()
 
+# Check if input file PFNs should be added. Not if this is a subworkflow
+if hasattr(args, 'dax_file_directory') and args.dax_file_directory:
+    add_input_file_pfns = False
+else:
+    add_input_file_pfns = True
+
 # Create the workflow object
 workflow = wf.Workflow(args)
 wf.makedir(args.output_dir)
@@ -199,10 +206,10 @@ if workflow.cp.has_option_tags('workflow', 'seed-bank', args.tags):
         raise ValueError("No seed bank actually provided!")
     seed_files = []
     for seed_bank in seed_banks:
-        # NOTE: Be careful that the seed-file will not exist when the
-        #       dax file is generated if this is a sub-workflow.
-        #       Don't run anything that assumes it will be there
-        seed_file = wf.File.from_path(seed_bank, store_file=False)
+        seed_file = resolve_url_to_file(
+            seed_bank,
+            add_pfn=add_input_file_pfns
+        )
         seed_files.append(seed_file)
     if len(seed_files) == 1:
         seed_file = seed_files[0]


### PR DESCRIPTION
While looking over #4535 I realised that we still had some oddities in how subworkflow file inheritance worked

 In particular, consider our separate jobs (think minifollowups) that use input files generated in the main workflow (e.g. TRIGGER_MERGE). 

When these jobs run, they use tools like `resolve_url_to_file` to create file objects for the input files. This also adds a PFN into the minifollowsup dax for that file. If these tools are run standalone this is exactly what you want. However, if the minifollowups code is run within a workflow, you do not want to add a PFN because pegasus (and our own code around it) will handle the file transfer for you. Especially when the minifollowup dag creation job runs on a condor node, the PFNs it generates will be invalid and we get things like:

```
 { "type": "transfer",
   "linkage": "input",
   "lfn": "H1L1-PAGE_FOREGROUND_XMLALL-1368975466-1121610.xml",
   "id": 2,
   "src_urls": [
     { "site_label": "condorpool_symlink", "url": "file:///home/gareth.cabourndavies/test_codes/pycbc/offline_gracedb_prep_workflow/testing/output_test_chunk1_v2/local-site-scratch/work/./o4-main.dax_o4-main/./H1L1-PAGE_FOREGROUND_XMLALL-1368975466-1121610.xml", "priority": 300, "checkpoint": "false" },
     { "site_label": "condorpool_symlink", "url": "file:///local/condor/execute/dir_1600786/pegasus.2V5qg27hB/H1L1-PAGE_FOREGROUND_XMLALL-1368975466-1121610.xml", "priority": 300, "checkpoint": "false" }
   ],
   "dest_urls": [
     { "site_label": "condorpool_symlink", "url": "symlink://$PWD/H1L1-PAGE_FOREGROUND_XMLALL-1368975466-1121610.xml" }
   ] }
```

Now this doesn't break anything because the first PFN is the right one, and the one coming from pegasus, but it worries me that the second one is always there, and I want it gone.

This patch will not create for files like this that are being passed to subworkflows. resolve_url_to_file now has a new add_pfn option, which these codes set. There is also some sanity checking to avoid some illegal use cases, but hopefully people don't touch this unless they know what it does! I used the `dax-file-directory` option to decide when to set this new option to False. dax-file-directory needs to be set when running in this subworkflow mode anyway, and should never be set otherwise, so if it's set, you can assume this is a subworkflow.

I also noted that the seed option for the sbank workflow wasn't working as it should if that workflow is run as a top-level workflow. There will be cases where pegasus will not know where the actual file is. This should also use resolve_url_to_file.

