### PR TITLE
Need to create .cvmfscatalog file

### DIFF
--- a/tools/venv_transfer_commands.sh
+++ b/tools/venv_transfer_commands.sh
@@ -7,6 +7,7 @@ ssh cvmfs.pycbc@cvmfs-software.ligo.caltech.edu <<EOF
 sudo -u repo.software cvmfs_server transaction -t 300 software.igwn.org
 sudo -u repo.software chmod go+rx /cvmfs/software.igwn.org/
 mkdir -p /cvmfs/software.igwn.org/pycbc/${ENV_OS}/virtualenv/pycbc-${SOURCE_TAG}
+touch /cvmfs/software.igwn.org/pycbc/${ENV_OS}/virtualenv/pycbc-${SOURCE_TAG}/.cvmfscatalog
 EOF
 rsync --rsh="ssh" $RSYNC_OPTIONS --filter='Pp .cvmfscatalog' --filter='Pp .cvmfsautocatalog' -qraz ${VENV_PATH}/ cvmfs.pycbc@cvmfs-software.ligo.caltech.edu:/cvmfs/software.igwn.org/pycbc/${ENV_OS}/virtualenv/pycbc-${SOURCE_TAG}/
 ssh cvmfs.pycbc@cvmfs-software.ligo.caltech.edu "sudo -u repo.software cvmfs_server publish"


### PR DESCRIPTION
There has been some restructuring in the LVK CVMFS repo to split into "nested catalogs" to avoid the error:
```
`FATAL: catalog at / has more than 200000 entries (204463). Large catalogs stress the CernVM-FS transport infrastructure. Please split it into nested catalogs or increase the limit.`
```
This fix broke our deployment code, but the fix is minor. Following discussion with Stuart/Duncan within LVK (https://git.ligo.org/computing/helpdesk/-/issues/4886) this seems to be what is required.

I've tested that creating this file allows us to deploy the 2.3.4 release. There's the normal caveat with patches on the deployment code that we can only deploy new code on an actual release, so this code will only get properly tested when the next release is made ... I can always fix this if something isn't quite right.