### PR TITLE
Add check before setting multiprocessing context to prevent the RuntimeError

### DIFF
--- a/pycbc/__init__.py
+++ b/pycbc/__init__.py
@@ -190,8 +190,9 @@ if sys.platform == 'darwin':
         if hasattr(multiprocessing, 'set_start_method'):
             multiprocessing.set_start_method('fork')
     elif multiprocessing.get_start_method() != 'fork':
-        warnings.warn("PyCBC requires the use of the 'fork' start method for multiprocessing, "
-                      "it is currently set to {}".format(multiprocessing.get_start_method()))
+        warnings.warn("PyCBC requires the use of the 'fork' start method"
+                      " for multiprocessing, it is currently set to {}"
+                      .format(multiprocessing.get_start_method()))
 else:
     HAVE_OMP = True
 

--- a/pycbc/__init__.py
+++ b/pycbc/__init__.py
@@ -190,7 +190,8 @@ if sys.platform == 'darwin':
         if hasattr(multiprocessing, 'set_start_method'):
             multiprocessing.set_start_method('fork')
     elif multiprocessing.get_start_method() != 'fork':
-        raise ValueError("PyCBC requires the use of the 'fork' start method for multiprocessing")
+        warnings.warn("PyCBC requires the use of the 'fork' start method for multiprocessing, "
+                      "it is currently set to {}".format(multiprocessing.get_start_method()))
 else:
     HAVE_OMP = True
 

--- a/pycbc/__init__.py
+++ b/pycbc/__init__.py
@@ -186,8 +186,11 @@ if sys.platform == 'darwin':
     # preserve common state information which we have relied on when using
     # multiprocessing based pools.
     import multiprocessing
-    if hasattr(multiprocessing, 'set_start_method'):
-        multiprocessing.set_start_method('fork')
+    if multiprocessing.get_start_method(allow_none=True) is None:
+        if hasattr(multiprocessing, 'set_start_method'):
+            multiprocessing.set_start_method('fork')
+    elif multiprocessing.get_start_method() != 'fork':
+        raise ValueError("PyCBC requires the use of the 'fork' start method for multiprocessing")
 else:
     HAVE_OMP = True
 


### PR DESCRIPTION
When `pycbc` is used with some multiprocessing package such as `dask`, importing `pycbc` will set the multiprocessing context repeatedly. The `RuntimeError: context has already been set` will occur. This fix will check the context before setting it, to make sure it will only be set once.

## Error message

```
  File "/Users/yumengxu/miniforge3/envs/pycbc_context_error/lib/python3.11/site-packages/pycbc/__init__.py", line 174, in <module>
    multiprocessing.set_start_method('fork')
  File "/Users/yumengxu/miniforge3/envs/pycbc_context_error/lib/python3.11/multiprocessing/context.py", line 247, in set_start_method
    raise RuntimeError('context has already been set')
RuntimeError: context has already been set
```

## Example to reproduce the error

OS: MacOS 14.2.1

Create a temporary env
```bash
conda create -n pycbc_context_error pycbc prefect 
conda activate pycbc_context_error
pip install prefect_dask
```

Simple script `test.py` to reproduce the error

```python
import pycbc

from prefect import flow, task, get_run_logger
from prefect_dask.task_runners import DaskTaskRunner


@flow(task_runner=DaskTaskRunner(), log_prints=True)
def analysis():
    print('This is a test')


if __name__ == "__main__":
    analysis()
```

```bash
python test.py
```