### PR TITLE
Standardize logging in bin/inference

### DIFF
--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -40,10 +40,9 @@ from pycbc.workflow import configuration
 # command line usage
 parser = argparse.ArgumentParser(usage=__file__ + " [--options]",
                                  description=__doc__)
+pycbc.add_common_pycbc_options(parser)
 parser.add_argument("--version", action="version", version=__version__,
                     help="Prints version information.")
-parser.add_argument("--verbose", action="store_true", default=False,
-                    help="Print logging messages.")
 # output options
 parser.add_argument("--output-file", type=str, required=True,
                     help="Output file path.")

--- a/bin/inference/pycbc_inference_extract_samples
+++ b/bin/inference/pycbc_inference_extract_samples
@@ -71,7 +71,7 @@ def isthesame(current_val, val):
 
 parser = ResultsArgumentParser(defaultparams='all', autoparamlabels=False,
                                description=__doc__)
-
+pycbc.add_common_pycbc_options(parser)
 parser.add_argument("--output-file", type=str, required=True,
                     help="Output file to create.")
 parser.add_argument("--force", action="store_true", default=False,
@@ -85,8 +85,6 @@ parser.add_argument("--skip-groups", default=None, nargs="+",
                          "to write all groups if only one file is provided, "
                          "and all groups from the first file except "
                          "sampler_info if multiple files are provided.")
-parser.add_argument("--verbose", action="store_true", default=False,
-                    help="Be verbose")
 
 opts = parser.parse_args()
 

--- a/bin/inference/pycbc_inference_model_stats
+++ b/bin/inference/pycbc_inference_model_stats
@@ -37,6 +37,7 @@ from pycbc.workflow import WorkflowConfigParser
 
 
 parser = argparse.ArgumentParser(description=__doc__)
+pycbc.add_common_pycbc_options(parser)
 parser.add_argument("--input-file", type=str, required=True,
                     help="Input HDF file to read. Can be either an inference "
                          "file or a posterior file.")
@@ -51,8 +52,6 @@ parser.add_argument("--nprocesses", type=int, default=1,
 parser.add_argument("--config-file", nargs="+", type=str, default=None,
                     help="Override the config file stored in the input file "
                           "with the given file(s).")
-parser.add_argument("--verbose", action="count", default=0,
-                    help="Print logging messages.")
 parser.add_argument('--reconstruct-parameters', action="store_true",
                     help="Reconstruct marginalized parameters")
 

--- a/bin/inference/pycbc_inference_monitor
+++ b/bin/inference/pycbc_inference_monitor
@@ -6,13 +6,13 @@ import os, sys, time, glob, shutil, logging, argparse, pycbc
 import pycbc.workflow as wf
 
 parser = argparse.ArgumentParser()
+pycbc.add_common_pycbc_options(parser)
 parser.add_argument('--inference-file', help="The name of the inference file")
 parser.add_argument('--check-interval', default=10, type=int,
                     help="Polling interval to check for file changes (s)")
 parser.add_argument('--output-dir', help="Output plots / results directory")
 parser.add_argument('--allow-failure', action='store_true',
                     help="Allow for a failure in plot generation")
-parser.add_argument('--verbose', action='store_true')
 
 wf.add_workflow_command_line_group(parser)
 args = parser.parse_args()

--- a/bin/inference/pycbc_inference_plot_acceptance_rate
+++ b/bin/inference/pycbc_inference_plot_acceptance_rate
@@ -34,6 +34,7 @@ parser = argparse.ArgumentParser(
             usage="pycbc_inference_plot_acceptance_rate [--options]",
             description="Plots histogram of the fractions of steps "
                         "accepted by walkers.")
+pycbc.add_common_pycbc_options(parser)
 parser.add_argument("--input-file", type=str, required=True,
                     help="Path to input HDF file.")
 parser.add_argument('--version', action='version', version=__version__,
@@ -56,9 +57,6 @@ parser.add_argument("--temps", type=int, nargs="+", default=None,
 # add number of bins for histogram
 parser.add_argument("--bins", type=int, default=10,
                     help="Specify number of bins for the histogram plot.")
-# verbose option
-parser.add_argument("--verbose", action="store_true", default=False,
-                    help="")
 
 # parse the command line
 opts = parser.parse_args()

--- a/bin/inference/pycbc_inference_plot_acf
+++ b/bin/inference/pycbc_inference_plot_acf
@@ -38,9 +38,7 @@ from pycbc.inference.sampler import samplers
 parser = io.ResultsArgumentParser(skip_args='thin-interval',
                                   description="Plots autocorrelation function "
                                               "from inference samples.")
-# verbose option
-parser.add_argument("--verbose", action="store_true", default=False,
-    help="Print logging info.")
+pycbc.add_common_pycbc_options(parser)
 parser.add_argument('--version', action='version', version=__version__,
                     help='show version number and exit')
 # output plot options

--- a/bin/inference/pycbc_inference_plot_acl
+++ b/bin/inference/pycbc_inference_plot_acl
@@ -39,8 +39,7 @@ parser = io.ResultsArgumentParser(skip_args=['thin-interval', 'temps'],
                                   description="Histograms autocorrelation "
                                               "length per walker from an MCMC "
                                               "sampler.")
-parser.add_argument("--verbose", action="store_true", default=False,
-    help="Print logging info.")
+pycbc.add_common_pycbc_options(parser)
 parser.add_argument('--version', action='version', version=__version__,
                     help='show version number and exit')
 # output plot options

--- a/bin/inference/pycbc_inference_plot_dynesty_run
+++ b/bin/inference/pycbc_inference_plot_dynesty_run
@@ -34,6 +34,7 @@ parser = argparse.ArgumentParser(
             usage="pycbc_inference_plot_dynesty_run [--options]",
             description="Plots various figures showing evolution of "
                         "dynesty run.")
+pycbc.add_common_pycbc_options(parser)
 parser.add_argument("--input-file", type=str, required=True,
                     help="Path to input HDF file.")
 parser.add_argument('--version', action='version', version=__version__,
@@ -41,9 +42,6 @@ parser.add_argument('--version', action='version', version=__version__,
 # output plot options
 parser.add_argument("--output-file", type=str, required=True,
                     help="Path to output plot.")
-
-parser.add_argument("--verbose", action="store_true", default=False,
-                    help="")
 
 # parse the command line
 opts = parser.parse_args()

--- a/bin/inference/pycbc_inference_plot_dynesty_traceplot
+++ b/bin/inference/pycbc_inference_plot_dynesty_traceplot
@@ -36,6 +36,7 @@ parser = argparse.ArgumentParser(
             description="Plots various figures showing evolution of "
                         "dynesty run.")
 
+pycbc.add_common_pycbc_options(parser)
 parser.add_argument("--input-file", type=str, required=True,
                     help="Path to input HDF file.")
 parser.add_argument('--version', action='version', version=__version__,
@@ -44,8 +45,6 @@ parser.add_argument('--version', action='version', version=__version__,
 parser.add_argument("--output-file", type=str, required=True,
                     help="Path to output plot.")
 
-parser.add_argument("--verbose", action="store_true", default=False,
-                    help="")
 # parse the command line
 opts = parser.parse_args()
 

--- a/bin/inference/pycbc_inference_plot_gelman_rubin
+++ b/bin/inference/pycbc_inference_plot_gelman_rubin
@@ -29,7 +29,9 @@ from pycbc.inference import (gelman_rubin, io, option_utils)
 # add options to command line
 parser = io.ResultsArgumentParser(skip_args=['walkers'])
 
-pycbc.add_common_pycbc_options(parser)
+# verbose option
+parser.add_argument("--verbose", action="store_true", default=False,
+                    help="Print logging info.")
 parser.add_argument('--version', action='version', version=__version__,
                     help='show version number and exit')
 

--- a/bin/inference/pycbc_inference_plot_gelman_rubin
+++ b/bin/inference/pycbc_inference_plot_gelman_rubin
@@ -29,9 +29,7 @@ from pycbc.inference import (gelman_rubin, io, option_utils)
 # add options to command line
 parser = io.ResultsArgumentParser(skip_args=['walkers'])
 
-# verbose option
-parser.add_argument("--verbose", action="store_true", default=False,
-                    help="Print logging info.")
+pycbc.add_common_pycbc_options(parser)
 parser.add_argument('--version', action='version', version=__version__,
                     help='show version number and exit')
 

--- a/bin/inference/pycbc_inference_plot_geweke
+++ b/bin/inference/pycbc_inference_plot_geweke
@@ -32,11 +32,9 @@ from pycbc.inference import (io, geweke, option_utils)
 # add options to command line
 parser = io.ResultsArgumentParser(skip_args=['walkers'])
 
-# program-specific
+pycbc.add_common_pycbc_options(parser)
 
-# verbose option
-parser.add_argument("--verbose", action="store_true", default=False,
-    help="Print logging info.")
+# program-specific
 
 parser.add_argument('--version', action='version', version=__version__,
                     help='show version number and exit')

--- a/bin/inference/pycbc_inference_plot_inj_recovery
+++ b/bin/inference/pycbc_inference_plot_inj_recovery
@@ -21,12 +21,11 @@ from pycbc.results import save_fig_with_metadata
 # parse command line
 parser = io.ResultsArgumentParser(description=__doc__)
 
+pycbc.add_common_pycbc_options(parser)
 parser.add_argument("--version", action="version", version=__version__,
                     help="Prints version information.")
 parser.add_argument("--output-file", required=True, type=str,
                     help="Path to save output plot.")
-parser.add_argument("--verbose", action="store_true",
-                    help="Allows print statements.")
 parser.add_argument("--percentiles", nargs=2, type=float, default=[5, 95],
                     help="Percentiles to use as limits.")
 option_utils.add_scatter_option_group(parser)

--- a/bin/inference/pycbc_inference_plot_movie
+++ b/bin/inference/pycbc_inference_plot_movie
@@ -110,6 +110,7 @@ def integer_logspace(start, end, num):
 # the frame number/step options
 skip_args = ['thin-start', 'thin-interval', 'thin-end', 'iteration']
 parser = io.ResultsArgumentParser(description=__doc__, skip_args=skip_args)
+pycbc.add_common_pycbc_options(parser)
 parser.add_argument("--version", action="version", version=__version__,
                     help="show version number and exit")
 # make frame number and frame step mutually exclusive
@@ -135,7 +136,6 @@ parser.add_argument("--log-steps", action="store_true", default=False,
 parser.add_argument("--output-prefix", type=str, required=True,
                     help="Output path and prefix for the frame files "
                          "(without extension).")
-parser.add_argument('--verbose', action='store_true')
 parser.add_argument('--dpi', type=int, default=200,
                     help='Set the dpi for each frame; default is 200')
 parser.add_argument("--nprocesses", type=int, default=None,

--- a/bin/inference/pycbc_inference_plot_posterior
+++ b/bin/inference/pycbc_inference_plot_posterior
@@ -52,13 +52,12 @@ use('agg')
 
 # add options to command line
 parser = io.ResultsArgumentParser()
+pycbc.add_common_pycbc_options(parser)
 # program-specific
 parser.add_argument("--version", action="version", version=__version__,
                     help="Prints version information.")
 parser.add_argument("--output-file", type=str, required=True,
                     help="Output plot path.")
-parser.add_argument("--verbose", action="store_true", default=False,
-                    help="Be verbose")
 parser.add_argument("--plot-prior", nargs="+", type=str,
                     help="Plot the prior on the 1D marginal plots using the "
                          "given config file(s).")

--- a/bin/inference/pycbc_inference_plot_pp
+++ b/bin/inference/pycbc_inference_plot_pp
@@ -42,12 +42,11 @@ from pycbc import __version__
 
 # parse command line
 parser = io.ResultsArgumentParser(description=__doc__)
+pycbc.add_common_pycbc_options(parser)
 parser.add_argument('--version', action='version', version=__version__,
                     help='show version number and exit')
 parser.add_argument("--output-file", required=True, type=str,
                     help="Path to save output plot.")
-parser.add_argument("--verbose", action="store_true",
-                    help="Allows print statements.")
 parser.add_argument("--injection-hdf-group", default="injections",
                     help="HDF group that contains injection values. "
                          "Default is 'injections'.")

--- a/bin/inference/pycbc_inference_plot_prior
+++ b/bin/inference/pycbc_inference_plot_prior
@@ -46,6 +46,7 @@ def cartesian(arrays):
 parser = argparse.ArgumentParser(
     usage="pycbc_inference_plot_prior [--options]",
     description="Plots prior distributions.")
+pycbc.add_common_pycbc_options(parser)
 # add input options
 parser.add_argument("--config-files", type=str, nargs="+", required=True,
                     help="A file parsable by "
@@ -75,9 +76,6 @@ parser.add_argument("--nsamples", type=int, default=10000,
                          "plotting. Default is 10000.")
 parser.add_argument("--output-file", type=str, required=True,
                     help="Path to output plot.")
-# verbose option
-parser.add_argument("--verbose", action="store_true", default=False,
-                    help="")
 parser.add_argument("--version", action="version", version=__version__,
                     help="show version number and exit")
 

--- a/bin/inference/pycbc_inference_plot_samples
+++ b/bin/inference/pycbc_inference_plot_samples
@@ -34,8 +34,7 @@ import sys
 # command line usage
 parser = argparse.parser = io.ResultsArgumentParser(
     skip_args=['chains', 'iteration'])
-parser.add_argument("--verbose", action="store_true", default=False,
-                    help="Print logging info.")
+pycbc.add_common_pycbc_options(parser)
 parser.add_argument("--version", action="version", version=__version__,
                     help="show version number and exit")
 parser.add_argument("--chains", nargs='+', default=None,

--- a/bin/inference/pycbc_inference_pp_table_summary
+++ b/bin/inference/pycbc_inference_pp_table_summary
@@ -31,8 +31,7 @@ from pycbc.inference.io import (ResultsArgumentParser, results_from_cli,
                                 injections_from_cli)
 
 parser = ResultsArgumentParser(description=__doc__)
-parser.add_argument("--verbose", action="store_true", default=False,
-    help="Print logging info.")
+pycbc.add_common_pycbc_options(parser)
 parser.add_argument("--output-file", type=str, required=True,
     help="Path to output plot.")
 add_injsamples_map_opt(parser)

--- a/bin/inference/pycbc_inference_table_summary
+++ b/bin/inference/pycbc_inference_table_summary
@@ -29,8 +29,7 @@ from pycbc.inference.io import ResultsArgumentParser, results_from_cli
 
 parser = ResultsArgumentParser(
     description="Makes a table of posterior results.")
-parser.add_argument("--verbose", action="store_true", default=False,
-    help="Print logging info.")
+pycbc.add_common_pycbc_options(parser)
 parser.add_argument("--output-file", type=str, required=True,
     help="Path to output plot.")
 parser.add_argument("--print-metadata", nargs="+", metavar="PARAM[:LABEL]",


### PR DESCRIPTION
Prompted by trying to debug an inference run and following the changes made in https://github.com/gwastro/pycbc/pull/4576, standardize the logging in `bin/inference` to use the new `pycbc.add_common_pycbc_options` function.

I've only changed executables that already had a `verbose` option.