### PR TITLE
fix for injection file created from pycbc_create_injections

### DIFF
--- a/bin/pycbc_convertinjfiletohdf
+++ b/bin/pycbc_convertinjfiletohdf
@@ -181,7 +181,7 @@ else:
     inj_file.close()
 
 if injclass is not None:
-    # Assume the injection is a XML file or HDF file (LVK format)
+    # The injection file is of known type
     data = injclass.pack_data_into_pycbc_format_input()
     samples = FieldArray.from_kwargs(**data)
     CBCHDFInjectionSet.write(args.output_file, samples)

--- a/bin/pycbc_convertinjfiletohdf
+++ b/bin/pycbc_convertinjfiletohdf
@@ -23,6 +23,7 @@ or the LIGO HDF format) into a PyCBC hdf injection format
 import argparse
 import numpy
 import h5py
+import shutil
 
 import pycbc
 from pycbc.inject import InjectionSet, CBCHDFInjectionSet
@@ -179,14 +180,11 @@ else:
         injclass = LVKNewStyleInjectionSet(args.injection_file)
     inj_file.close()
 
-if injclass is None:
-    # Assume this is a PyCBC format
-    injclass = InjectionSet(args.injection_file)
-    data = {}
-    for key in xinj.table[0].__slots__:
-        data[str(key)] = numpy.array([getattr(t, key) for t in xinj.table])
-else:
+if injclass is not None:
+    # Assume the injection is a XML file or HDF file (LVK format)
     data = injclass.pack_data_into_pycbc_format_input()
-
-samples = FieldArray.from_kwargs(**data)
-CBCHDFInjectionSet.write(args.output_file, samples)
+    samples = FieldArray.from_kwargs(**data)
+    CBCHDFInjectionSet.write(args.output_file, samples)
+else:
+    # Assume the injection is a HDF file (PyCBC format), only make a copy
+    shutil.copy(args.injection_file, args.output_file)


### PR DESCRIPTION
After introducing the LVK format for injections, there are three kinds of injection files right now:  `*.xml`, `*.hdf` with LVK format and `*.hdf` with PyCBC format (which is generated from `pycbc_create_injections`). 

This PR adds an operation to deal with PyCBC format: don't do anything and just make an copy. 

I slightly change the order of the `if...else...` in the last few lines, as the current logic appears clearer for me. 

I tested this PR with a PyCBC format injection file, and it indeed got copied and seems to work fine.