### PR TITLE
Slight tweak to example in frame documentation

### DIFF
--- a/docs/frame.rst
+++ b/docs/frame.rst
@@ -33,7 +33,7 @@ Reading a frame file
 The ``pycbc.frame`` module provides methods for reading these files into ``TimeSeries`` objects as follows::
 
     >>> from pycbc import frame
-    >>> data = frame.read_frame('G-G1_RDS_C01_L3-1049587200-60.gwf', 'G1:DER_DATA_H')
+    >>> data = frame.read_frame('G-G1_RDS_C01_L3-1049587200-60.gwf', 'G1:DER_DATA_H', 1049587200, 1049587200 + 60)
 
 Here the first argument is the path to the frame file of interest, while the second lists the `data channel` of interest whose data exist within the file.
 


### PR DESCRIPTION
The frame documentation gives read_frame example without start/end times, whereas the search query above it uses these times.

Its not actually clear what happens without the options given, as I would have thought it would read the whole file, but if there are multiple frames within the file, only the first seems to be read, unless the start/end time are given.