### PR TITLE
Fix broken --version option

### DIFF
--- a/pycbc/_version.py
+++ b/pycbc/_version.py
@@ -53,9 +53,27 @@ def print_link(library):
     return link
 
 
+def get_lal_info(module, lib_glob):
+    """Return a string reporting the version and runtime library information
+    for a LAL Python import.
+    """
+    module_path = inspect.getfile(module)
+    version_str = (
+        module.git_version.verbose_msg +
+        "\n\nImported from: " + module_path +
+        "\n\nRuntime libraries:\n"
+    )
+    possible_lib_paths = glob.glob(
+        os.path.join(os.path.dirname(module_path), lib_glob)
+    )
+    for lib_path in possible_paths:
+        version_str += print_link(lib_path)
+    return version_str
+
+
 class Version(argparse.Action):
-    """Subclass of argparse.Action that prints the pycbc, lal and lalsimulation
-    versions.
+    """Subclass of argparse.Action that prints version information for PyCBC,
+    LAL and LALSimulation.
     """
     def __init__(self, nargs=0, **kw):
         super(Version, self).__init__(nargs=nargs, **kw)
@@ -75,13 +93,7 @@ class Version(argparse.Action):
         except ImportError:
             version_str += "\nLAL not installed in environment\n"
         else:
-            lal_module = inspect.getfile(lal)
-            lal_library = os.path.join(os.path.dirname(lal_module), '_lal.so')
-            version_str += (
-                lal.git_version.verbose_msg +
-                "\n\nImported from: " + lal_module +
-                "\n\nRuntime libraries:\n" + print_link(lal_library)
-            )
+            version_str += get_lal_info(lal, '_lal*.so')
 
         version_str += "\n\n--- LALSimulation Version-------------------\n"
         try:
@@ -89,16 +101,10 @@ class Version(argparse.Action):
         except ImportError:
             version_str += "\nLALSimulation not installed in environment\n"
         else:
-            lalsim_module = inspect.getfile(lalsimulation)
-            lalsim_library = os.path.join(
-                os.path.dirname(lalsim_module),
-                '_lalsimulation.so'
-            )
-            version_str += (
-                lalsimulation.git_version.verbose_msg +
-                "\n\nImported from: " + lalsim_module +
-                "\n\nRuntime libraries:\n" + print_link(lalsim_library)
-            )
+            version_str += get_lal_info(lalsimulation, '_lalsimulation*.so')
 
         print(version_str)
         sys.exit(0)
+
+
+__all__ = ['Version']

--- a/pycbc/_version.py
+++ b/pycbc/_version.py
@@ -21,6 +21,7 @@ extremely verbose version information for PyCBC, lal, and lalsimulation.
 
 import os
 import sys
+import glob
 import argparse
 import inspect
 import subprocess
@@ -66,7 +67,7 @@ def get_lal_info(module, lib_glob):
     possible_lib_paths = glob.glob(
         os.path.join(os.path.dirname(module_path), lib_glob)
     )
-    for lib_path in possible_paths:
+    for lib_path in possible_lib_paths:
         version_str += print_link(lib_path)
     return version_str
 

--- a/pycbc/_version_helper.py
+++ b/pycbc/_version_helper.py
@@ -86,7 +86,7 @@ def get_build_name(git_path='git'):
 def get_build_date():
     """Returns the current datetime as the git build date
     """
-    return time.strftime('%Y-%m-%d %H:%M:%S +0000', time.gmtime())
+    return time.strftime(r'%Y-%m-%d %H:%M:%S +0000', time.gmtime())
 
 
 def get_last_commit(git_path='git'):
@@ -95,10 +95,13 @@ def get_last_commit(git_path='git'):
     Returns a tuple (hash, date, author name, author e-mail,
     committer name, committer e-mail).
     """
-    hash_, udate, aname, amail, cname, cmail = (
-        call((git_path, 'log', '-1',
-              '--pretty=format:%H,%ct,%an,%ae,%cn,%ce')).split(","))
-    date = time.strftime('%Y-%m-%d %H:%M:%S +0000', time.gmtime(float(udate)))
+    hash_, udate, aname, amail, cname, cmail = call((
+        git_path,
+        'log',
+        '-1',
+        r'--pretty=format:%H,%ct,%an,%ae,%cn,%ce'
+    )).split(",")
+    date = time.strftime(r'%Y-%m-%d %H:%M:%S +0000', time.gmtime(float(udate)))
     author = f'{aname} <{amail}>'
     committer = f'{cname} <{cmail}>'
     return hash_, date, author, committer

--- a/tools/pycbc_test_suite.sh
+++ b/tools/pycbc_test_suite.sh
@@ -31,7 +31,7 @@ fi
 if [ "$PYCBC_TEST_TYPE" = "help" ] || [ -z ${PYCBC_TEST_TYPE+x} ]; then
     # check that all executables that do not require
     # special environments can return a help message
-    for prog in `find ${PATH//:/ } -maxdepth 1 -name 'pycbc*' -print 2>/dev/null | egrep -v '(pycbc_live_nagios_monitor|pycbc_make_offline_grb_workflow|pycbc_mvsc_get_features|pycbc_upload_xml_to_gracedb)' | sort`
+    for prog in `find ${PATH//:/ } -maxdepth 1 -name 'pycbc*' -print 2>/dev/null | egrep -v '(pycbc_live_nagios_monitor|pycbc_make_offline_grb_workflow|pycbc_mvsc_get_features|pycbc_upload_xml_to_gracedb|pycbc_coinc_time)' | sort | uniq`
     do
         echo -e ">> [`date`] running $prog --help"
         $prog --help &> $LOG_FILE

--- a/tools/pycbc_test_suite.sh
+++ b/tools/pycbc_test_suite.sh
@@ -31,7 +31,7 @@ fi
 if [ "$PYCBC_TEST_TYPE" = "help" ] || [ -z ${PYCBC_TEST_TYPE+x} ]; then
     # check that all executables that do not require
     # special environments can return a help message
-    for prog in `find ${PATH//:/ } -maxdepth 1 -name 'pycbc*' -print 2>/dev/null | egrep -v '(pycbc_live_nagios_monitor|pycbc_make_offline_grb_workflow|pycbc_mvsc_get_features|pycbc_upload_xml_to_gracedb|pycbc_coinc_time)'`
+    for prog in `find ${PATH//:/ } -maxdepth 1 -name 'pycbc*' -print 2>/dev/null | egrep -v '(pycbc_live_nagios_monitor|pycbc_make_offline_grb_workflow|pycbc_mvsc_get_features|pycbc_upload_xml_to_gracedb)' | sort`
     do
         echo -e ">> [`date`] running $prog --help"
         $prog --help &> $LOG_FILE
@@ -45,6 +45,18 @@ if [ "$PYCBC_TEST_TYPE" = "help" ] || [ -z ${PYCBC_TEST_TYPE+x} ]; then
             echo -e "    Pass."
         fi
     done
+    # also check that --version works for one executable
+    echo -e ">> [`date`] running pycbc_inspiral --version"
+    pycbc_inspiral --version &> $LOG_FILE
+    if test $? -ne 0 ; then
+        RESULT=1
+        echo -e "    FAILED!"
+        echo -e "---------------------------------------------------------"
+        cat $LOG_FILE
+        echo -e "---------------------------------------------------------"
+    else
+        echo -e "    Pass."
+    fi
 fi
 
 if [ "$PYCBC_TEST_TYPE" = "search" ] || [ -z ${PYCBC_TEST_TYPE+x} ]; then


### PR DESCRIPTION
I noticed that `pycbc_inspiral --version` fails with the following error:
```
Traceback (most recent call last):
  File "/cvmfs/software.igwn.org/conda/envs/igwn-py311/bin/pycbc_inspiral", line 214, in <module>
    opt = parser.parse_args()
          ^^^^^^^^^^^^^^^^^^^
  File "/cvmfs/software.igwn.org/conda/envs/igwn-py311-20240206/lib/python3.11/argparse.py", line 1869, in parse_args
    args, argv = self.parse_known_args(args, namespace)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/cvmfs/software.igwn.org/conda/envs/igwn-py311-20240206/lib/python3.11/argparse.py", line 1902, in parse_known_args
    namespace, args = self._parse_known_args(args, namespace)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/cvmfs/software.igwn.org/conda/envs/igwn-py311-20240206/lib/python3.11/argparse.py", line 2114, in _parse_known_args
    start_index = consume_optional(start_index)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/cvmfs/software.igwn.org/conda/envs/igwn-py311-20240206/lib/python3.11/argparse.py", line 2054, in consume_optional
    take_action(action, args, option_string)
  File "/cvmfs/software.igwn.org/conda/envs/igwn-py311-20240206/lib/python3.11/argparse.py", line 1978, in take_action
    action(self, namespace, argument_values, option_string)
  File "/cvmfs/software.igwn.org/conda/envs/igwn-py311-20240206/lib/python3.11/site-packages/pycbc/_version.py", line 63, in __call__
    version_str += lal.git_version.verbose_msg + \
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: can only concatenate str (not "bytes") to str
```
This happens because `subprocess.check_output()` returns a bytestring by default. The same command definitely worked for our recent O4 offline workflows, so this may be a recent change, though I am not sure what exactly changed or when.

Fixing the problem above highlighted another issue. Sometimes the LAL and LALSimulation runtime libraries are named something like `_lal.cpython-39-x86_64-linux-gnu.so` instead of `_lal.so` as the present code assumes, so `--version` fails to report the runtime lib information.

Lastly, I noticed that the CI test that goes through the `--help` options calls each executable twice (probably due to how `$PATH` is set up on the CI VMs). Given the number of executables, this is a significant waste of run time of the tests.

This PR fixes the above problems, adds `pycbc_inspiral --version` as an additional CI test, and does a general cleanup of version-related code.