### PR TITLE
Standardize logging: bin, bin/bank and pycbc/tmpltbank

### DIFF
--- a/bin/bank/pycbc_aligned_bank_cat
+++ b/bin/bank/pycbc_aligned_bank_cat
@@ -48,9 +48,8 @@ __program__ = "pycbc_aligned_bank_cat"
 parser = argparse.ArgumentParser(description=__doc__,
            formatter_class=tmpltbank.IndentedHelpFormatterWithNL)
 
+pycbc.add_common_pycbc_options(parser)
 parser.add_argument("--version", action="version", version=__version__)
-parser.add_argument("--verbose", action="store_true", default=False,
-                    help="verbose output")
 parser.add_argument("-i", "--input-glob",
                     help="file glob the list of paramters")
 parser.add_argument("-I", "--input-files", nargs='+',
@@ -76,11 +75,7 @@ tmpltbank.insert_base_bank_options(parser, match_req=False)
 
 options = parser.parse_args()
 
-if options.verbose:
-    log_level = logging.DEBUG
-else:
-    log_level = logging.WARN
-logging.basicConfig(format='%(asctime)s %(message)s', level=log_level)
+pycbc.init_logging(options.verbose)
 
 # Sanity check options
 if not options.output_file:

--- a/bin/bank/pycbc_aligned_stoch_bank
+++ b/bin/bank/pycbc_aligned_stoch_bank
@@ -23,6 +23,7 @@ Stochastic aligned spin bank generator.
 import argparse
 import numpy
 import logging
+
 import pycbc
 import pycbc.version
 from pycbc import tmpltbank
@@ -45,8 +46,7 @@ parser = argparse.ArgumentParser(description=_desc,
 
 # Begin with code specific options
 parser.add_argument("--version", action="version", version=__version__)
-parser.add_argument("--verbose", action="store_true", default=False,
-                    help="verbose output")
+pycbc.add_common_pycbc_options(parser)
 parser.add_argument("-V", "--vary-fupper", action="store_true", default=False,
                     help="Use a variable upper frequency cutoff in laying "
                     "out the bank.  OPTIONAL.")
@@ -96,12 +96,7 @@ tmpltbank.insert_ethinca_metric_options(parser)
 
 opts = parser.parse_args()
 
-if opts.verbose:
-    log_level = logging.DEBUG
-else:
-    log_level = logging.WARN
-log_format='%(asctime)s %(message)s'
-logging.basicConfig(format=log_format, level=log_level)
+pycbc.init_logging(opts.verbose)
 
 # delete defaults for redundant options if not varying fupper
 if not opts.vary_fupper:

--- a/bin/bank/pycbc_bank_verification
+++ b/bin/bank/pycbc_bank_verification
@@ -26,14 +26,16 @@ import argparse
 import logging
 import numpy
 import h5py
+import matplotlib
+matplotlib.use('Agg')
+import pylab
+
 from ligo.lw import lsctables, utils as ligolw_utils
+
 import pycbc
 import pycbc.version
 from pycbc import tmpltbank, psd, strain
 from pycbc.io.ligolw import LIGOLWContentHandler
-import matplotlib
-matplotlib.use('Agg')
-import pylab
 
 
 __author__  = "Ian Harry <ian.harry@astro.cf.ac.uk>"
@@ -48,8 +50,7 @@ parser = argparse.ArgumentParser(description=__doc__,
 
 # Begin with code specific options
 parser.add_argument("--version", action="version", version=__version__)
-parser.add_argument("--verbose", action="store_true", default=False,
-                    help="verbose output")
+pycbc.add_common_pycbc_options(parser)
 parser.add_argument("--histogram-output-file", action="store", default=None,
                     help="Output a histogram of fitting factors to the "
                     "supplied file. If not given no histogram is produced.")
@@ -111,11 +112,7 @@ pycbc.strain.insert_strain_option_group(parser)
 
 opts = parser.parse_args()
 
-if opts.verbose:
-    log_level = logging.DEBUG
-else:
-    log_level = logging.WARN
-logging.basicConfig(format='%(asctime)s %(message)s', level=log_level)
+pycbc.init_logging(opts.verbose)
 
 # Sanity check options
 tmpltbank.verify_metric_calculation_options(opts, parser)

--- a/bin/bank/pycbc_brute_bank
+++ b/bin/bank/pycbc_brute_bank
@@ -19,16 +19,21 @@
 
 """Generate a bank of templates using a brute force stochastic method.
 """
-import numpy, h5py, logging, argparse, numpy.random
+import numpy
+import h5py
+import logging
+import argparse
+import numpy.random
+from scipy.stats import gaussian_kde
+
 import pycbc.waveform, pycbc.filter, pycbc.types, pycbc.psd, pycbc.fft, pycbc.conversions
 from pycbc import transforms
 from pycbc.waveform.spa_tmplt import spa_length_in_time
 from pycbc.distributions import read_params_from_config
 from pycbc.distributions.utils import draw_samples_from_config, prior_from_config
-from scipy.stats import gaussian_kde
 
 parser = argparse.ArgumentParser(description=__doc__)
-parser.add_argument('--verbose', action='store_true')
+pycbc.add_common_pycbc_options(parser)
 parser.add_argument('--output-file', required=True,
     help='Output file name for template bank.')
 parser.add_argument('--input-file',
@@ -71,9 +76,9 @@ parser.add_argument('--tau0-end', type=float)
 parser.add_argument('--tau0-cutoff-frequency', type=float, default=15.0)
 pycbc.psd.insert_psd_option_group(parser)
 args = parser.parse_args()
+
 pycbc.init_logging(args.verbose)
 numpy.random.seed(args.seed)
-
 
 # Read the .ini file if it's in the input.
 if args.input_config is not None:

--- a/bin/bank/pycbc_coinc_bank2hdf
+++ b/bin/bank/pycbc_coinc_bank2hdf
@@ -23,6 +23,7 @@ with their template.
 import argparse
 import logging
 import numpy
+
 import pycbc
 from pycbc.waveform import bank
 
@@ -56,6 +57,7 @@ def parse_parameters(parameters):
 parser = argparse.ArgumentParser()
 parser.add_argument('--version', action='version',
                     version=pycbc.version.git_verbose_msg)
+pycbc.add_common_pycbc_options(parser)
 parser.add_argument('--bank-file', required=True,
                     help="The bank file to load. Must end in '.xml[.gz]' "
                          "and must contain a SnglInspiral table or must end "
@@ -82,8 +84,6 @@ bank.add_approximant_arg(parser,
 parser.add_argument("--force", action="store_true", default=False,
                     help="Overwrite the given hdf file if it exists. "
                          "Otherwise, an error is raised.")
-parser.add_argument("--verbose", action="store_true", default=False,
-                    help="Be verbose.")
 args = parser.parse_args()
 
 pycbc.init_logging(args.verbose)

--- a/bin/bank/pycbc_geom_aligned_2dstack
+++ b/bin/bank/pycbc_geom_aligned_2dstack
@@ -31,6 +31,7 @@ import copy
 import numpy
 import logging
 import h5py
+
 import pycbc.tmpltbank
 import pycbc.version
 from pycbc import pnutils
@@ -47,10 +48,9 @@ usage = """usage: %prog [options]"""
 _desc = __doc__[1:]
 parser = argparse.ArgumentParser(usage, description=_desc,
            formatter_class=pycbc.tmpltbank.IndentedHelpFormatterWithNL)
+pycbc.add_common_pycbc_options(parser)
 # Code specific options
 parser.add_argument('--version', action='version', version=__version__)
-parser.add_argument("--verbose", action="store_true", default=False,\
-                    help="verbose output")
 parser.add_argument("--pn-order", action="store", type=str,\
                   default=None,\
                   help="Determines the PN order to use. Note that if you "+\
@@ -106,11 +106,7 @@ opts = parser.parse_args()
 opts.eval_vec4_depth = not opts.skip_vec4_depth
 opts.eval_vec5_depth = not opts.skip_vec5_depth
 
-if opts.verbose:
-    log_level = logging.DEBUG
-else:
-    log_level = logging.WARN
-logging.basicConfig(format='%(asctime)s %(message)s', level=log_level)
+pycbc.init_logging(opts.verbose)
 
 # Sanity check options
 if not opts.pn_order:

--- a/bin/bank/pycbc_geom_aligned_bank
+++ b/bin/bank/pycbc_geom_aligned_bank
@@ -31,8 +31,10 @@ import logging
 import h5py
 import configparser
 from scipy import spatial
+
 from ligo.lw import ligolw
 from ligo.lw import utils as ligolw_utils
+
 import pycbc
 import pycbc.psd
 import pycbc.strain
@@ -175,9 +177,8 @@ parser = argparse.ArgumentParser(description=_desc,
            formatter_class=pycbc.tmpltbank.IndentedHelpFormatterWithNL)
 
 # Begin with code specific options
+pycbc.add_common_pycbc_options(parser)
 parser.add_argument('--version', action='version', version=__version__)
-parser.add_argument("-V", "--verbose", action="store_true", default=False,
-                    help="verbose output")
 parser.add_argument("-s", "--stack-distance", action="store", type=float,\
                   default=0.2, help="Minimum metric spacing before we "+\
                                "stack.")
@@ -249,12 +250,7 @@ outdoc.appendChild(ligolw.LIGO_LW())
 create_process_table(outdoc, __program__, options=vars(opts))
 ligolw_utils.write_filename(outdoc, opts.metadata_file)
 
-if opts.verbose:
-    log_level = logging.DEBUG
-else:
-    log_level = logging.WARN
-log_format='%(asctime)s %(message)s'
-logging.basicConfig(format=log_format, level=log_level)
+pycbc.init_logging(opts.verbose)
 
 opts.max_mismatch = 1 - opts.min_match
 

--- a/bin/bank/pycbc_geom_nonspinbank
+++ b/bin/bank/pycbc_geom_nonspinbank
@@ -25,6 +25,7 @@ import math
 import copy
 import numpy
 import logging
+
 import pycbc
 import pycbc.version
 import pycbc.psd
@@ -48,8 +49,7 @@ parser = argparse.ArgumentParser(
 
 # Begin with code specific options
 parser.add_argument('--version', action='version', version=__version__)
-parser.add_argument("-V", "--verbose", action="store_true", default=False,
-                    help="verbose output")
+pycbc.add_common_pycbc_options(parser)
 parser.add_argument("--random-seed", action="store", type=int,
                     default=None,
                     help="""Random seed to use when calling numpy.random
@@ -78,11 +78,7 @@ tmpltbank.insert_ethinca_metric_options(parser)
 
 opts = parser.parse_args()
 
-if opts.verbose:
-    log_level = logging.DEBUG
-else:
-    log_level = logging.WARN
-logging.basicConfig(format='%(asctime)s %(message)s', level=log_level)
+pycbc.init_logging(opts.verbose)
 
 opts.max_mismatch = 1 - opts.min_match
 tmpltbank.verify_metric_calculation_options(opts, parser)

--- a/bin/bank/pycbc_tmpltbank_to_chi_params
+++ b/bin/bank/pycbc_tmpltbank_to_chi_params
@@ -33,7 +33,9 @@ import argparse
 import logging
 import numpy
 import h5py
+
 from ligo.lw import lsctables, utils as ligolw_utils
+
 from pycbc import tmpltbank, psd, strain
 from pycbc.io.ligolw import LIGOLWContentHandler
 
@@ -44,8 +46,7 @@ parser = argparse.ArgumentParser(description=__doc__,
 
 # Begin with code specific options
 parser.add_argument("--version", action="version", version=__version__)
-parser.add_argument("--verbose", action="store_true", default=False,
-                    help="verbose output")
+pycbc.add_common_pycbc_options(parser)
 parser.add_argument("--input-bank", action="store", required=True,
                     help="The template bank to use an input.")
 parser.add_argument("--output-file", action="store", required=True,
@@ -88,11 +89,7 @@ pycbc.strain.insert_strain_option_group(parser)
 
 opts = parser.parse_args()
 
-if opts.verbose:
-    log_level = logging.DEBUG
-else:
-    log_level = logging.WARN
-logging.basicConfig(format='%(asctime)s %(message)s', level=log_level)
+pycbc.init_logging(opts.verbose)
 
 # Sanity check options
 tmpltbank.verify_metric_calculation_options(opts, parser)

--- a/bin/pycbc_banksim
+++ b/bin/pycbc_banksim
@@ -21,8 +21,11 @@ import logging
 from tqdm import tqdm
 from numpy import complex64, array
 from argparse import ArgumentParser
+from math import ceil, log
+
 from ligo.lw import utils as ligolw_utils
 from ligo.lw import lsctables
+
 from pycbc.pnutils import mass1_mass2_to_mchirp_eta
 from pycbc.pnutils import mass1_mass2_to_tau0_tau3
 from pycbc.pnutils import nearest_larger_binary_number
@@ -32,7 +35,6 @@ from pycbc import DYN_RANGE_FAC
 from pycbc.types import FrequencySeries, TimeSeries, zeros, complex_same_precision_as
 from pycbc.filter import match, sigmasq
 from pycbc.io.ligolw import LIGOLWContentHandler
-from math import ceil, log
 import pycbc.psd, pycbc.scheme, pycbc.fft, pycbc.strain, pycbc.version
 from pycbc.detector import overhead_antenna_pattern as generate_fplus_fcross
 from pycbc.waveform import TemplateBank
@@ -144,8 +146,7 @@ aprs = sorted(list(set(td_approximants() + fd_approximants())))
 parser = ArgumentParser(description=__doc__)
 parser.add_argument("--match-file", dest="out_file", metavar="FILE",
                     required=True, help="File to output match results")
-parser.add_argument("--verbose", action='store_true', default=False,
-                    help="Print verbose statements")
+pycbc.add_common_pycbc_options(parser)
 parser.add_argument("--version", action="version",
                     version=pycbc.version.git_verbose_msg)
 

--- a/bin/pycbc_banksim_combine_banks
+++ b/bin/pycbc_banksim_combine_banks
@@ -26,6 +26,7 @@ from os.path import isfile
 import argparse
 import logging
 from numpy import *
+
 import pycbc
 import pycbc.version
 
@@ -37,14 +38,15 @@ _desc = __doc__[1:]
 parser = argparse.ArgumentParser(description=_desc)
 
 parser.add_argument('--version', action=pycbc.version.Version)
-parser.add_argument("--verbose", action="store_true", default=False,
-                    help="verbose output")
+pycbc.add_common_pycbc_options(parser)
 parser.add_argument("-I", "--input-files", nargs='+',
                     help="Explicit list of input files.")
 parser.add_argument("-o", "--output-file", required=True,
                     help="Output file name")
 
 options = parser.parse_args()
+
+pycbc.init_logging(options.verbose)
 
 dtypef = dtype([('match', float64), ('bank', unicode_, 256),
                 ('bank_i', int32), ('sim', unicode_, 256),

--- a/bin/pycbc_banksim_match_combine
+++ b/bin/pycbc_banksim_match_combine
@@ -26,7 +26,9 @@ import imp
 import argparse
 import numpy as np
 import h5py
+
 from ligo.lw import utils, table
+
 import pycbc
 from pycbc import pnutils
 from pycbc.waveform import TemplateBank
@@ -43,8 +45,7 @@ __program__ = "pycbc_banksim_match_combine"
 parser = argparse.ArgumentParser(description=__doc__)
 
 parser.add_argument("--version", action="version", version=__version__)
-parser.add_argument("--verbose", action="store_true", default=False,
-                    help="verbose output")
+pycbc.add_common_pycbc_options(parser)
 parser.add_argument("--match-files", nargs='+',
                     help="Explicit list of match files.")
 #parser.add_argument("--inj-files", nargs='+',
@@ -61,6 +62,8 @@ parser.add_argument("--filter-func-file", default=None,
                          "take as call profile, mass1, mass2, spin1z, spin2z, "
                          "as numpy arrays.")
 options = parser.parse_args()
+
+pycbc.init_logging(options.verbose)
 
 dtypem = np.dtype([('match', np.float64), ('bank', np.unicode_, 256),
                       ('bank_i', np.int32), ('sim', np.unicode_, 256),

--- a/bin/pycbc_banksim_skymax
+++ b/bin/pycbc_banksim_skymax
@@ -21,8 +21,12 @@ import sys
 import logging
 from numpy import complex64, float32, sqrt, argmax, real, array
 from argparse import ArgumentParser
+from math import ceil, log
+from tqdm import tqdm
+
 from ligo.lw import utils as ligolw_utils
 from ligo.lw import lsctables
+
 from pycbc.pnutils import mass1_mass2_to_mchirp_eta, f_SchwarzISCO
 from pycbc.pnutils import nearest_larger_binary_number
 from pycbc.pnutils import mass1_mass2_to_tau0_tau3
@@ -35,11 +39,9 @@ from pycbc.filter import overlap_cplx, matched_filter
 from pycbc.filter import compute_max_snr_over_sky_loc_stat
 from pycbc.filter import compute_max_snr_over_sky_loc_stat_no_phase
 from pycbc.io.ligolw import LIGOLWContentHandler
-from math import ceil, log
 import pycbc.psd, pycbc.scheme, pycbc.fft, pycbc.strain, pycbc.version
 from pycbc.detector import overhead_antenna_pattern as generate_fplus_fcross
 from pycbc.waveform import TemplateBank
-from tqdm import tqdm
 
 ## Remove the need for these functions ########################################
     
@@ -150,8 +152,7 @@ aprs = sorted(list(set(td_approximants() + fd_approximants())))
 parser = ArgumentParser(description=__doc__)
 parser.add_argument("--match-file", dest="out_file", metavar="FILE",
                     required=True, help="File to output match results")
-parser.add_argument("--verbose", action='store_true', default=False,
-                    help="Print verbose statements")
+pycbc.add_common_pycbc_options(parser)
 parser.add_argument("--version", action="version",
                     version=pycbc.version.git_verbose_msg)
 

--- a/bin/pycbc_coinc_time
+++ b/bin/pycbc_coinc_time
@@ -1,7 +1,13 @@
 #!/bin/env python
-import argparse, logging, pycbc.version, ligo.segments, numpy
+import argparse
+import logging
+import numpy
 from dqsegdb.apicalls import dqsegdbQueryTimes as query
+
+import ligo.segments
+
 #from pycbc.workflow.segment import cat_to_veto_def_cat as convert_cat
+import pycbc.version
 
 def sane(seg_list):
     """ Convert list of len two lists containing strs to segment list """
@@ -85,7 +91,7 @@ def get_vetoes(veto_def, ifo, server, veto_name, start_default, end_default):
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--version', action='version', version=pycbc.version.git_verbose_msg)
-parser.add_argument('--verbose', action='store_true')
+pycbc.add_common_pycbc_options(parser)
 
 parser.add_argument('--gps-start-time', type=int, required=True,
                     help="integer gps start time")

--- a/bin/pycbc_compress_bank
+++ b/bin/pycbc_compress_bank
@@ -30,6 +30,7 @@ import argparse
 import numpy
 import h5py
 import logging
+
 import pycbc
 from pycbc import psd, DYN_RANGE_FAC
 from pycbc.waveform import compress
@@ -40,6 +41,7 @@ from pycbc import filter
 
 
 parser = argparse.ArgumentParser(description=__description__)
+pycbc.add_common_pycbc_options(parser)
 parser.add_argument("--bank-file", type=str, required=True,
                     help="Bank hdf file to load.")
 parser.add_argument("--output", type=str, required=True,
@@ -96,7 +98,6 @@ parser.add_argument("--precision", type=str, choices=["double", "single"],
 parser.add_argument("--force", action="store_true", default=False,
                     help="Overwrite the given hdf file if it exists. "
                     "Otherwise, an error is raised.")
-parser.add_argument("--verbose", action="store_true", default=False)
 
 # Insert the PSD options
 pycbc.psd.insert_psd_option_group(parser, include_data_options=False)

--- a/bin/pycbc_convertinjfiletohdf
+++ b/bin/pycbc_convertinjfiletohdf
@@ -160,6 +160,7 @@ class LVKNewStyleInjectionSet(object):
 
 
 parser = argparse.ArgumentParser()
+pycbc.add_common_pycbc_options(parser)
 parser.add_argument('--version', action='version',
                     version=pycbc.version.git_verbose_msg)
 parser.add_argument('--injection-file', required=True,
@@ -167,8 +168,6 @@ parser.add_argument('--injection-file', required=True,
                          "and must contain a SimInspiral table")
 parser.add_argument('--output-file', required=True,
                     help="The ouput file name. Must end in '.hdf'.")
-parser.add_argument("--verbose", action="store_true", default=False,
-                    help="Be verbose.")
 args = parser.parse_args()
 
 pycbc.init_logging(args.verbose)

--- a/bin/pycbc_create_injections
+++ b/bin/pycbc_create_injections
@@ -108,10 +108,14 @@ along with any numpy ufunc. So, in the above example, mass ratio (q) is
 constrained to be <= 4 by using a function from the conversions module.
 """
 
-import os, sys
+import os
+import sys
 import argparse
 import logging
 import numpy
+import h5py
+from numpy.random import uniform
+
 import pycbc
 import pycbc.version
 from pycbc.inject import InjectionSet
@@ -122,12 +126,11 @@ from pycbc.io import record
 from pycbc.waveform import parameters
 from pycbc.workflow import configuration
 from pycbc.workflow import WorkflowConfigParser
-from numpy.random import uniform
-import h5py
 
 parser = argparse.ArgumentParser(description=__doc__,
             formatter_class=argparse.RawDescriptionHelpFormatter)
 configuration.add_workflow_command_line_group(parser)
+pycbc.add_common_pycbc_options(parser)
 parser.add_argument('--version', action='version',
                     version=pycbc.version.git_verbose_msg,
                     help='Prints version information.')
@@ -163,8 +166,6 @@ parser.add_argument('--static-params-section', default="static_params",
 parser.add_argument("--force", action="store_true", default=False,
                     help="If the output-file already exists, overwrite it. "
                          "Otherwise, an OSError is raised.")
-parser.add_argument("--verbose", action="store_true", default=False,
-                    help="Print logging messages.")
 opts = parser.parse_args()
 
 pycbc.init_logging(opts.verbose)

--- a/bin/pycbc_data_store
+++ b/bin/pycbc_data_store
@@ -1,16 +1,23 @@
 #!/usr/bin/env python
 """ Create HDF strain cache file
 """
-import logging, argparse, numpy, h5py
-import pycbc, pycbc.strain, pycbc.dq
+import logging
+import argparse
+import numpy
+import h5py
+
+import pycbc
+import pycbc.strain
+import pycbc.dq
 from pycbc.version import git_verbose_msg as version
 from pycbc.fft.fftw import set_measure_level
 from pycbc.events.veto import segments_to_start_end
+
 set_measure_level(0)
 
 parser = argparse.ArgumentParser(description=__doc__)
+pycbc.add_common_pycbc_options(parser)
 parser.add_argument('--version', action='version', version=version)
-parser.add_argument('--verbose', action="store_true")
 parser.add_argument("--science-name", help="Science flag definition")
 parser.add_argument("--segment-server")
 parser.add_argument("--veto-definer-file")

--- a/bin/pycbc_faithsim
+++ b/bin/pycbc_faithsim
@@ -27,6 +27,7 @@ import logging
 from numpy import complex64
 import argparse
 import sys
+
 from ligo.lw import utils as ligolw_utils
 from ligo.lw import lsctables
 
@@ -84,8 +85,7 @@ parser = argparse.ArgumentParser(usage='',
     description="Calculate faithfulness for a set of waveforms.")
 parser.add_argument('--version', action='version',
                     version=pycbc.version.git_verbose_msg)
-parser.add_argument("-V", "--verbose", action="store_true",
-                    help="print extra debugging information", default=False)
+pycbc.add_common_pycbc_options(parser)
 parser.add_argument("--param-file", dest="bank_file", metavar="FILE",
                     help="Sngl or Sim Inspiral Table containing waveform "
                          "parameters.")

--- a/bin/pycbc_faithsim_collect_results
+++ b/bin/pycbc_faithsim_collect_results
@@ -5,12 +5,16 @@ Program for collecting the results of pycbc_faithsim comparing two approximants
 computing the match between them and creating a .dat file with the results. 
 """
 
-import numpy as np
-from ligo.lw import utils, table, lsctables
-from pycbc.io.ligolw import LIGOLWContentHandler
 import argparse
+import numpy as np
+
+from ligo.lw import utils, table, lsctables
+
+from pycbc import add_common_pycbc_options, init_logging
+from pycbc.io.ligolw import LIGOLWContentHandler
 
 parser = argparse.ArgumentParser(description=__doc__)
+add_common_pycbc_options(parser)
 parser.add_argument(
     "--match-inputs",
     action="append",
@@ -25,6 +29,8 @@ parser.add_argument(
 )
 parser.add_argument("--output", required=True, help="name of the output .dat file")
 args = parser.parse_args()
+
+init_logging(options.verbose)
 
 mfields = ("match", "overlap", "time_offset", "sigma1", "sigma2")
 bfields = (

--- a/bin/pycbc_fit_sngl_trigs
+++ b/bin/pycbc_fit_sngl_trigs
@@ -55,10 +55,8 @@ def get_bins(opt, pmin, pmax):
 parser = argparse.ArgumentParser(usage="",
     description="Perform maximum-likelihood fits of single inspiral trigger"
                 "distributions to various functions")
-
+pycbc.add_common_pycbc_options(parser)
 parser.add_argument("--version", action=pycbc.version.Version)
-parser.add_argument("-V", "--verbose", action="store_true",
-                    help="Print extra debugging information", default=False)
 parser.add_argument("--inputs", nargs="+",
                     help="Input file or space-separated list of input files "
                     "containing single triggers.  Currently .xml(.gz) "
@@ -134,11 +132,7 @@ binopt.add_argument("--irregular-bins",
 
 opt = parser.parse_args()
 
-if opt.verbose:
-    log_level = logging.DEBUG
-else:
-    log_level = logging.WARN
-logging.basicConfig(format='%(asctime)s : %(message)s', level=log_level)
+pycbc.init_logging(opt.verbose)
 
 statname = opt.sngl_stat.replace("_", " ")
 paramname = opt.fit_param.replace("_", " ")

--- a/bin/pycbc_gwosc_segment_query
+++ b/bin/pycbc_gwosc_segment_query
@@ -6,14 +6,10 @@ import json
 import argparse
 import shutil
 from urllib.request import urlopen
+
 import ligo.segments
+
 from pycbc.workflow import SegFile
-
-
-# Logging formatting from pycbc optimal snr
-log_fmt = '%(asctime)s %(message)s'
-log_date_fmt = '%Y-%m-%d %H:%M:%S'
-logging.basicConfig(level=logging.INFO, format=log_fmt, datefmt=log_date_fmt)
 
 
 # Function to query json segment data from GWOSC
@@ -64,12 +60,15 @@ def write_xml_file(ifo, summary_segment, segments, filename):
 
 
 parser = argparse.ArgumentParser()
+pycbc.add_common_pycbc_options(parser)
 parser.add_argument('--gps-start-time', type=int, required=True)
 parser.add_argument('--gps-end-time', type=int, required=True)
 parser.add_argument('--include-segments', type=str, required=True)
 parser.add_argument('--output-file', type=str, required=True)
 parser.add_argument('--protract-hw-inj', type=int, default=0)
 args = parser.parse_args()
+
+pycbc.init_logging(args.verbose)
 
 gps_start_time = args.gps_start_time
 gps_end_time = args.gps_end_time

--- a/bin/pycbc_gwosc_segment_query
+++ b/bin/pycbc_gwosc_segment_query
@@ -9,6 +9,7 @@ from urllib.request import urlopen
 
 import ligo.segments
 
+import pycbc
 from pycbc.workflow import SegFile
 
 

--- a/bin/pycbc_hdf5_splitbank
+++ b/bin/pycbc_hdf5_splitbank
@@ -25,13 +25,15 @@ import argparse
 import numpy
 import h5py
 import logging
+from numpy import random
+
 import pycbc, pycbc.version
 from pycbc.waveform import bank
-from numpy import random
 
 __author__  = "Soumi De <soumi.de@ligo.org>"
 
 parser = argparse.ArgumentParser(description=__doc__[1:])
+pycbc.add_common_pycbc_options(parser)
 parser.add_argument("--version", action="version",
                   version=pycbc.version.git_verbose_msg)
 parser.add_argument("--bank-file", type=str,
@@ -61,10 +63,10 @@ parser.add_argument("--random-seed", type=int,
 parser.add_argument("--force", action="store_true", default=False,
                     help="Overwrite the given hdf file if it exists. "
                          "Otherwise, an error is raised.")
-parser.add_argument("--verbose", action="store_true", default=False)
-
 
 args = parser.parse_args()
+
+pycbc.init_logging(args.verbose)
 
 # input checks
 if args.mchirp_sort and (args.random_seed is not None):

--- a/bin/pycbc_hdf_splitinj
+++ b/bin/pycbc_hdf_splitinj
@@ -6,14 +6,16 @@ Split sets are organized to maximize time between injections.
 """
 
 import argparse
-from pycbc.inject import InjectionSet
 import h5py
 import numpy as np
+
+from pycbc.inject import InjectionSet
 import pycbc.version
 
 
 # Parse command line
 parser = argparse.ArgumentParser(description=__doc__)
+pycbc.add_common_pycbc_options(parser)
 parser.add_argument("--version", action="version",
                     version=pycbc.version.git_verbose_msg)
 parser.add_argument("-f", "--output-files", nargs='*', required=True,
@@ -22,6 +24,8 @@ parser.add_argument("-i", "--input-file", required=True,
                     help="Injection file to be split")
 
 args = parser.parse_args()
+
+pycbc.init_logging(args.verbose)
 
 # Read in input file as both an hdf file and an InjectionSet object
 inj_file = h5py.File(args.input_file, 'r')

--- a/bin/pycbc_inj_cut
+++ b/bin/pycbc_inj_cut
@@ -29,14 +29,17 @@ __email__ = "stephen.fairhurst@ligo.org"
 import argparse
 import logging
 import numpy
+
+from ligo.lw import utils as ligolw_utils
+from ligo.lw import lsctables
+
 import pycbc
 import pycbc.inject
-from ligo.lw import utils as ligolw_utils
 from pycbc.types import MultiDetOptionAction
-from ligo.lw import lsctables
 import pycbc.version
 
 parser = argparse.ArgumentParser(description=__doc__)
+pycbc.add_common_pycbc_options(parser)
 parser.add_argument('--version', action=pycbc.version.Version)
 parser.add_argument('--input', dest='inj_xml', required=True, help='Input LIGOLW injections file.')
 parser.add_argument('--output-missed', dest='output_missed', required=False,
@@ -53,19 +56,12 @@ parser.add_argument('--snr-columns', nargs='+', action=MultiDetOptionAction,
                         ' no useful data in it, good candidates are usually' \
                         ' alpha1, alpha2 etc.')
 parser.add_argument("-z", "--write-compress", action="store_true", help="Write compressed xml.gz files.")
-parser.add_argument("-v", "--verbose", action="store_true", default=False,
-                    help="Extended standard output.")
 
 opts = parser.parse_args()
 
-log_fmt = '%(asctime)s %(message)s'
-log_date_fmt = '%Y-%m-%d %H:%M:%S'
-logging.basicConfig(level=logging.INFO, format=log_fmt, datefmt=log_date_fmt)
+pycbc.init_logging(opts.verbose)
 
-if opts.verbose:
-    logging.info("Loading injections")
 injections = pycbc.inject.InjectionSet(opts.inj_xml)
-
 
 # injections that we should do: table and name of the file that will store it
 output_inject = opts.output_inject
@@ -89,11 +85,20 @@ for i, inj in enumerate(injections.table):
     else:
         out_sim_inspiral_inject.append(inj)
             
-logging.info('Found %d/%d (potentially) found injections.  Storing them to %s.', len(out_sim_inspiral_inject), len(injections.table), output_inject)
-logging.info('Found %d/%d missed injections.', len(out_sim_inspiral_missed), len(injections.table))
+logging.info(
+    'Found %d/%d (potentially) found injections. Storing them to %s.',
+    len(out_sim_inspiral_inject),
+    len(injections.table),
+    output_inject
+)
 
-if opts.verbose:
-    logging.info('Writing output')
+logging.info(
+    'Found %d/%d missed injections.',
+    len(out_sim_inspiral_missed),
+    len(injections.table)
+)
+
+logging.info('Writing output')
 llw_doc = injections.indoc
 llw_root = llw_doc.childNodes[0]
 llw_root.removeChild(injections.table)

--- a/bin/pycbc_inspiral
+++ b/bin/pycbc_inspiral
@@ -16,19 +16,24 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-import sys, os, copy
-import logging, argparse, numpy, itertools
+import sys
+import os
+import copy
+import logging
+import argparse
+import numpy
+import itertools
+import time
+from multiprocessing import Pool
+
 import pycbc
 import pycbc.version
 from pycbc import vetoes, psd, waveform, strain, scheme, fft, DYN_RANGE_FAC, events
 from pycbc.vetoes.sgchisq import SingleDetSGChisq
 from pycbc.filter import MatchedFilterControl, make_frequency_series, qtransform
 from pycbc.types import TimeSeries, FrequencySeries, zeros, float32, complex64
-from multiprocessing import Pool
-import pycbc.version
 import pycbc.opt
 import pycbc.inject
-import time
 
 last_progress_update = -1.0
 
@@ -48,9 +53,8 @@ tstart = time.time()
 parser = argparse.ArgumentParser(usage='',
     description="Find single detector gravitational-wave triggers.")
 
+pycbc.add_common_pycbc_options(parser)
 parser.add_argument('--version', action=pycbc.version.Version)
-parser.add_argument("-V", "--verbose", action="store_true",
-                  help="print extra debugging information", default=False )
 parser.add_argument("--update-progress",
                   help="updates a file 'progress.txt' with a value 0 .. 1.0 when this amount of (filtering) progress was made",
                   type=float, default=0)

--- a/bin/pycbc_inspiral_skymax
+++ b/bin/pycbc_inspiral_skymax
@@ -16,7 +16,11 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-import logging, argparse, sys, numpy
+import logging
+import argparse
+import sys
+import numpy
+
 from pycbc import vetoes, psd, waveform, events, strain, scheme, fft
 from pycbc.vetoes.sgchisq import SingleDetSGChisq
 from pycbc import DYN_RANGE_FAC
@@ -28,8 +32,7 @@ import pycbc.opt
 parser = argparse.ArgumentParser(usage='',
     description="Find single detector precessing gravitational-wave triggers.")
 
-parser.add_argument("-V", "--verbose", action="store_true",
-                  help="print extra debugging information", default=False )
+pycbc.add_common_pycbc_options(parser)
 parser.add_argument("--output", type=str, help="FIXME: ADD")
 parser.add_argument("--bank-file", type=str, help="FIXME: ADD")
 parser.add_argument("--snr-threshold",

--- a/bin/pycbc_make_banksim
+++ b/bin/pycbc_make_banksim
@@ -9,6 +9,7 @@ import tempfile
 from optparse import OptionParser
 from glue.pipeline import CondorDAGJob, CondorDAGNode, CondorDAG, CondorJob
 
+from pycbc import init_logging
 
 class BaseJob(CondorDAGJob, CondorJob):
     def __init__(self, log_dir, executable, cp, section, gpu=False,
@@ -131,7 +132,8 @@ parser.add_option('--config', type=str)
 if options.config is None:
     raise ValueError("Config file is required")  
 
-logging.basicConfig(format='%(asctime)s %(message)s', level=logging.INFO)
+# logging INFO
+init_logging(1)
 
 confs = ConfigParser.ConfigParser()
 confs.read(options.config)

--- a/bin/pycbc_make_faithsim
+++ b/bin/pycbc_make_faithsim
@@ -9,6 +9,7 @@ import tempfile
 from optparse import OptionParser
 from glue.pipeline import CondorDAGJob, CondorDAGNode, CondorDAG, CondorJob
 
+from pycbc import init_logging
 
 class BaseJob(CondorDAGJob, CondorJob):
     def __init__(self, log_dir, executable, cp, section, accounting_group=None):
@@ -65,7 +66,8 @@ parser.add_option('--config', type=str)
 if options.config is None:
     raise ValueError("Config file is required")
 
-logging.basicConfig(format='%(asctime)s %(message)s', level=logging.INFO)
+# logging INFO
+init_logging(1)
 
 confs = ConfigParser.ConfigParser()
 confs.read(options.config)

--- a/bin/pycbc_make_html_page
+++ b/bin/pycbc_make_html_page
@@ -17,14 +17,17 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 import argparse
-import os, stat
-import pycbc.results
+import os
+import stat
 import random
 import shutil
 import zipfile
 import codecs
-from ligo import segments
 from jinja2 import Environment, FileSystemLoader
+
+from ligo import segments
+
+import pycbc.results
 from pycbc.results.render import get_embedded_config, render_workflow_html_template, setup_template_render
 from pycbc.workflow import segment
 import pycbc.version
@@ -166,6 +169,7 @@ parser = argparse.ArgumentParser(usage='pycbc_make_html_page \
                   description="Create static html pages of a filesystem's content.")
 parser.add_argument("--version", action="version",
                   version=pycbc.version.git_verbose_msg)
+pycbc.add_common_pycbc_options(parser)
 parser.add_argument('-f', '--template-file', type=str,
                   help='Template file to use for skeleton html page.')
 parser.add_argument('-b', '--output-path', type=str,
@@ -181,11 +185,11 @@ parser.add_argument('-s', '--analysis-subtitle', type=str,
 parser.add_argument('-l', '--logo', type=str,
                   default=default_logo_location,
                   help='File location of logo to include at top of page')
-parser.add_argument('-v', '--verbose', action='store_true',
-                  help='Print extra debugging information.', default=False)
 parser.add_argument('-P', '--protect-results', action='store_true',
                   help='Make the output web pages read only.', default=False)
 opts = parser.parse_args()
+
+pycbc.init_logging(opts.verbose)
 
 # edit command line options
 analysis_title = opts.analysis_title.strip('"').rstrip('"')

--- a/bin/pycbc_make_sky_grid
+++ b/bin/pycbc_make_sky_grid
@@ -13,6 +13,7 @@ import argparse
 import itertools
 from scipy.spatial.transform import Rotation as R
 
+import pycbc
 from pycbc.detector import Detector
 
 

--- a/bin/pycbc_make_sky_grid
+++ b/bin/pycbc_make_sky_grid
@@ -10,9 +10,11 @@ The grid is constructed following the method described in Section V of https://a
 import numpy as np
 import h5py
 import argparse
-from pycbc.detector import Detector
 import itertools
 from scipy.spatial.transform import Rotation as R
+
+from pycbc.detector import Detector
+
 
 def spher_to_cart(sky_points):
     """Convert spherical coordinates to cartesian coordinates.
@@ -32,15 +34,28 @@ def cart_to_spher(sky_points):
     return spher
 
 parser = argparse.ArgumentParser(description=__doc__)
-parser.add_argument('--ra', type=float, help="Right ascension (in rad) of the center of the external trigger error box")
-parser.add_argument('--dec', type=float, help="Declination (in rad) of the center of the external trigger error box")
-parser.add_argument('--instruments', nargs="+", type=str, required=True, help="List of instruments to analyze.")
-parser.add_argument('--sky-error', type=float, required=True, help="3-sigma confidence radius (in rad) of the external trigger error box")
-parser.add_argument('--trigger-time', type=int, required=True, help="Time (in s) of the external trigger")
-parser.add_argument('--timing-uncertainty', type=float, default=0.0001, help="Timing uncertainty (in s) we are willing to accept")
-parser.add_argument('--output', type=str, required=True, help="Name of the sky grid")
+pycbc.add_common_pycbc_options(parser)
+parser.add_argument('--ra', type=float,
+    help="Right ascension (in rad) of the center of the external trigger "
+         "error box")
+parser.add_argument('--dec', type=float,
+    help="Declination (in rad) of the center of the external trigger "
+         "error box")
+parser.add_argument('--instruments', nargs="+", type=str, required=True,
+    help="List of instruments to analyze.")
+parser.add_argument('--sky-error', type=float, required=True,
+    help="3-sigma confidence radius (in rad) of the external trigger error "
+         "box")
+parser.add_argument('--trigger-time', type=int, required=True,
+    help="Time (in s) of the external trigger")
+parser.add_argument('--timing-uncertainty', type=float, default=0.0001,
+    help="Timing uncertainty (in s) we are willing to accept")
+parser.add_argument('--output', type=str, required=True,
+        help="Name of the sky grid")
 
 args = parser.parse_args()
+
+pycbc.init_logging(args.verbose)
 
 if len(args.instruments) == 1:
     parser.error('Can not make a sky grid for only one detector.')

--- a/bin/pycbc_make_skymap
+++ b/bin/pycbc_make_skymap
@@ -19,6 +19,9 @@ mpl_use_backend('agg')
 
 import numpy as np
 import h5py
+
+from ligo.gracedb.rest import GraceDb
+
 import pycbc
 from pycbc.filter import sigmasq
 from pycbc.io import live, WaveformArray
@@ -29,7 +32,6 @@ from pycbc.pnutils import nearest_larger_binary_number
 from pycbc.waveform.spa_tmplt import spa_length_in_time
 from pycbc import frame, waveform, dq
 from pycbc.psd import interpolate
-from ligo.gracedb.rest import GraceDb
 
 
 def default_frame_type(time, ifo):
@@ -476,9 +478,9 @@ def main(trig_time, mass1, mass2, spin1z, spin2z, f_low, f_upper, sample_rate,
     shutil.rmtree(tmpdir)
 
 if __name__ == '__main__':
-    pycbc.init_logging(True)
 
     parser = argparse.ArgumentParser(description=__doc__)
+    pycbc.add_common_pycbc_options(parser)
     parser.add_argument('--version', action=pycbc.version.Version)
     # note that I am not using a MultiDetOptionAction for --trig-time as I
     # explicitly want to handle cases like `--trig-time 1234` and
@@ -562,6 +564,8 @@ if __name__ == '__main__':
                         help="SNR rescaling factor used in BAYESTAR")
 
     opt = parser.parse_args()
+
+    pycbc.init_logging(opt.verbose)
 
     frame_type_dict = {f.split(':')[0]: f.split(':')[1] for f in opt.frame_type} \
             if opt.frame_type is not None else None

--- a/bin/pycbc_merge_inj_hdf
+++ b/bin/pycbc_merge_inj_hdf
@@ -24,6 +24,7 @@ import logging
 import argparse
 import numpy as np
 import h5py
+
 import pycbc
 import pycbc.inject
 import pycbc.version
@@ -43,20 +44,16 @@ def get_gc_end_time(injection):
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description=__doc__)
+    pycbc.add_common_pycbc_options(parser)
     parser.add_argument("--version", action=pycbc.version.Version)
     parser.add_argument('--injection-files', '-i', dest='injection_file',
                         required=True, nargs='+',
                         help='Input HDF5 files defining injections')
     parser.add_argument('--output-file', '-o', dest='out_file', required=True,
                         help='Output HDF5 file')
-    parser.add_argument("--verbose", action="store_true", default=False,
-                        help="Print logging messages")
     opts = parser.parse_args()
 
-    log_level = logging.INFO if opts.verbose else logging.WARN
-    logging.basicConfig(level=log_level,
-                        format='%(asctime)s %(message)s',
-                        datefmt='%Y-%m-%d %H:%M:%S')
+    pycbc.init_logging(opts.verbose)
 
     logging.info("Loading injections")
 

--- a/bin/pycbc_multi_inspiral
+++ b/bin/pycbc_multi_inspiral
@@ -31,6 +31,7 @@ from collections import defaultdict
 import argparse
 import numpy as np
 import h5py
+
 from pycbc import (
     detector, fft, init_logging, inject, opt, psd, scheme, strain, vetoes,
     waveform, DYN_RANGE_FAC
@@ -46,9 +47,7 @@ from pycbc.vetoes import sgchisq
 # pycbc_multi_inspiral executable.
 time_init = time.time()
 parser = argparse.ArgumentParser(description=__doc__)
-parser.add_argument("-V", "--verbose", action="store_true",
-                    help="prints extra debugging information during runtime",
-                    default=False)
+pycbc.add_common_pycbc_options(parser)
 parser.add_argument("--output", type=str)
 parser.add_argument("--instruments", nargs="+", type=str, required=True,
                     help="List of instruments to analyze.")

--- a/bin/pycbc_multi_inspiral
+++ b/bin/pycbc_multi_inspiral
@@ -34,7 +34,7 @@ import h5py
 
 from pycbc import (
     detector, fft, init_logging, inject, opt, psd, scheme, strain, vetoes,
-    waveform, DYN_RANGE_FAC
+    waveform, DYN_RANGE_FAC, add_common_pycbc_options
 )
 from pycbc.events import ranking, coherent as coh, EventManagerCoherent
 from pycbc.filter import MatchedFilterControl
@@ -47,7 +47,7 @@ from pycbc.vetoes import sgchisq
 # pycbc_multi_inspiral executable.
 time_init = time.time()
 parser = argparse.ArgumentParser(description=__doc__)
-pycbc.add_common_pycbc_options(parser)
+add_common_pycbc_options(parser)
 parser.add_argument("--output", type=str)
 parser.add_argument("--instruments", nargs="+", type=str, required=True,
                     help="List of instruments to analyze.")

--- a/bin/pycbc_optimal_snr
+++ b/bin/pycbc_optimal_snr
@@ -185,7 +185,7 @@ if __name__ == '__main__':
     if not opts.time_varying_psds:
         pycbc.psd.verify_psd_options_multi_ifo(opts, parser, detectors)
 
-    pycbc.init_logging(args.verbose)
+    pycbc.init_logging(opts.verbose)
 
     seg_len = opts.seg_length
     sample_rate = opts.sample_rate

--- a/bin/pycbc_optimal_snr
+++ b/bin/pycbc_optimal_snr
@@ -27,12 +27,14 @@ import argparse
 import multiprocessing
 import numpy as np
 import h5py
+
+from ligo.lw import utils as ligolw_utils
+from ligo.lw import lsctables
+
 import pycbc
 import pycbc.inject
 import pycbc.psd
 import pycbc.version
-from ligo.lw import utils as ligolw_utils
-from ligo.lw import lsctables
 from pycbc.filter import sigma, make_frequency_series
 from pycbc.types import TimeSeries, FrequencySeries, zeros, float32, \
                         MultiDetOptionAction, load_frequencyseries
@@ -117,6 +119,7 @@ def get_gc_end_time(injection):
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description=__doc__)
+    pycbc.add_common_pycbc_options(parser)
     parser.add_argument("--version", action=pycbc.version.Version)
     parser.add_argument('--input-file', '-i', dest='injection_file',
                         required=True,
@@ -159,11 +162,6 @@ if __name__ == '__main__':
     parser.add_argument('--ignore-waveform-errors', action='store_true',
                         help='Ignore errors in waveform generation and keep '
                              'the corresponding column unchanged')
-    parser.add_argument('--verbose', action='store_true',
-                        help='Print which injection is going to be attempted '
-                             'next and when it completes. Use this to debug '
-                             'misbehaving approximants which crash or quit '
-                             'the Python interpreter')
     parser.add_argument('--progress', action='store_true',
                         help='Show a progress bar (requires tqdm)')
     psd_group = pycbc.psd.insert_psd_option_group_multi_ifo(parser)
@@ -187,10 +185,7 @@ if __name__ == '__main__':
     if not opts.time_varying_psds:
         pycbc.psd.verify_psd_options_multi_ifo(opts, parser, detectors)
 
-    log_level = logging.INFO if opts.verbose else logging.WARN
-    logging.basicConfig(level=log_level,
-                        format='%(asctime)s %(message)s',
-                        datefmt='%Y-%m-%d %H:%M:%S')
+    pycbc.init_logging(args.verbose)
 
     seg_len = opts.seg_length
     sample_rate = opts.sample_rate
@@ -240,20 +235,27 @@ if __name__ == '__main__':
             psd = psds[det](injection_time)
             if psd is None:
                 continue
-            logging.info('Trying injection %s at %s', inj.simulation_id, det)
+            logging.debug('Trying injection %s at %s', inj.simulation_id, det)
             try:
                 wave = get_injection(injections, det, injection_time,
                                      simulation_id=inj.simulation_id)
             except Exception as e:
                 if opts.ignore_waveform_errors:
-                    logging.warn('%s: waveform generation failed, skipping (%s)',
-                                 inj.simulation_id, e)
+                    logging.debug(
+                        '%s: waveform generation failed, skipping (%s)',
+                        inj.simulation_id,
+                        e
+                    )
                     continue
                 else:
                     logging.error('%s: waveform generation failed with the '
                                   'following exception', inj.simulation_id)
                     raise
-            logging.info('Injection %s at %s completed', inj.simulation_id, det)
+            logging.debug(
+                'Injection %s at %s completed',
+                inj.simulation_id,
+                det
+            )
             sval = sigma(wave, psd=psd, low_frequency_cutoff=f_low)
             if ligolw:
                 setattr(inj, column, sval)

--- a/bin/pycbc_optimize_snr
+++ b/bin/pycbc_optimize_snr
@@ -5,14 +5,14 @@
 import os
 import argparse
 import logging
+import numpy
+import h5py
 
 # we will make plots on a likely headless machine, so make sure matplotlib's
 # backend is set appropriately
 from matplotlib import use as mpl_use_backend
 mpl_use_backend('agg')
 
-import numpy
-import h5py
 import pycbc
 from pycbc import (
     fft, scheme, version
@@ -27,9 +27,9 @@ from pycbc.live import snr_optimizer
 
 
 parser = argparse.ArgumentParser(description=__doc__)
+pycbc.add_common_pycbc_options(parser)
 parser.add_argument('--version', action='version',
                     version=version.git_verbose_msg)
-parser.add_argument('--verbose', action='store_true')
 parser.add_argument('--params-file', required=True,
                     help='Location of the attributes file created by PyCBC '
                          'Live')

--- a/bin/pycbc_process_sngls
+++ b/bin/pycbc_process_sngls
@@ -6,12 +6,13 @@ import argparse
 import logging
 import numpy
 import h5py
+
 from pycbc.io import SingleDetTriggers
 from pycbc.events import stat, coinc, veto
 
 
 parser = argparse.ArgumentParser(description=__doc__)
-
+pycbc.add_common_pycbc_options(parser)
 parser.add_argument('--single-trig-file', required=True,
                     help='Path to file containing single-detector triggers in '
                          'HDF5 format. Required')
@@ -41,7 +42,7 @@ stat.insert_statistic_option_group(parser)
 
 args = parser.parse_args()
 
-logging.basicConfig(format='%(asctime)s %(message)s', level=logging.INFO)
+pycbc.init_logging(args.verbose)
 
 # Munge together SNR cut and any other filter specified
 snr_filter = 'self.snr>%f' % (args.min_snr) if args.min_snr > 0. else None 

--- a/bin/pycbc_process_sngls
+++ b/bin/pycbc_process_sngls
@@ -7,6 +7,7 @@ import logging
 import numpy
 import h5py
 
+import pycbc
 from pycbc.io import SingleDetTriggers
 from pycbc.events import stat, coinc, veto
 

--- a/bin/pycbc_randomize_inj_dist_by_optsnr
+++ b/bin/pycbc_randomize_inj_dist_by_optsnr
@@ -14,6 +14,8 @@ from argparse import ArgumentParser
 from ligo.lw import lsctables
 from ligo.lw import utils as ligolw_utils
 from ligo.lw import table
+
+import pycbc
 from pycbc.io.ligolw import LIGOLWContentHandler
 
 
@@ -50,6 +52,7 @@ def get_weights(distribution, r, r1, r2):
     return min_vol, weight
 
 parser = ArgumentParser(description = __doc__)
+pycbc.add_common_pycbc_options(parser)
 parser.add_argument('--xml-file', required = True, 
                     help = 'Input LIGOLW file defining injections.')
 parser.add_argument('--output-file', required=True, 
@@ -90,9 +93,10 @@ parser.add_argument('--scale-by-chirp-dist', action='store_true',
 parser.add_argument('--seed', type = int, default = int((time.time()*100)% 1e6), 
                     help = 'Set the seed to use for the random number generator. ' \
                     'If none specified, will use the current time.')
-parser.add_argument('--verbose', action = 'store_true', help = 'Be verbose.')
 
 opts = parser.parse_args()
+
+pycbc.init_logging(opts.verbose)
 
 # parse the distributions
 # beta is the only special one

--- a/bin/pycbc_single_template
+++ b/bin/pycbc_single_template
@@ -17,7 +17,13 @@
 """ Calculate the SNR and CHISQ timeseries for either a chosen template, or
 a specific Nth loudest coincident event.
 """
-import sys, logging, argparse, numpy, pycbc, h5py
+import sys
+import logging
+import argparse
+import numpy
+import h5py
+
+import pycbc
 from pycbc import vetoes, psd, waveform, strain, scheme, fft, filter
 from pycbc.io import WaveformArray
 from pycbc import events
@@ -86,11 +92,10 @@ def select_segments(fname, anal_name, data_name, ifo, time, pad_data):
 
 parser = argparse.ArgumentParser(usage='',
     description="Single template gravitational-wave followup")
+pycbc.add_common_pycbc_options(parser)
 parser.add_argument('--version', action=pycbc.version.Version)
 parser.add_argument('--output-file', required=True)
 parser.add_argument('--subtract-template', action='store_true')
-parser.add_argument("-V", "--verbose", action="store_true",
-                  help="print extra debugging information", default=False )
 parser.add_argument("--low-frequency-cutoff", type=float,
                   help="The low frequency cutoff to use for filtering (Hz)")
 parser.add_argument("--high-frequency-cutoff", type=float,
@@ -182,6 +187,8 @@ scheme.insert_processing_option_group(parser)
 fft.insert_fft_option_group(parser)
 opt = parser.parse_args()
 
+pycbc.init_logging(opt.verbose)
+
 # Exclude invalid options
 if opt.window and opt.trigger_time is None:
     raise RuntimeError("Can't use --window option without a valid trigger time!")
@@ -210,7 +217,6 @@ strain.verify_strain_options(opt, parser)
 strain.StrainSegments.verify_segment_options(opt, parser)
 scheme.verify_processing_options(opt, parser)
 fft.verify_fft_options(opt,parser)
-pycbc.init_logging(opt.verbose)
 
 ctx = scheme.from_cli(opt)
 gwstrain = strain.from_cli(opt, pycbc.DYN_RANGE_FAC)

--- a/bin/pycbc_source_probability_offline
+++ b/bin/pycbc_source_probability_offline
@@ -9,12 +9,14 @@ import tqdm
 import argparse
 import logging
 import numpy as np
+
 import pycbc
 from pycbc.io import hdf
 from pycbc.pnutils import mass1_mass2_to_mchirp_eta
 from pycbc import mchirp_area
 
 parser = argparse.ArgumentParser(description=__doc__)
+pycbc.add_common_pycbc_options(parser)
 parser.add_argument('--trigger-file', required=True)
 parser.add_argument('--bank-file', required=True)
 parser.add_argument('--single-detector-triggers', nargs='+', required=True)
@@ -27,7 +29,6 @@ parser.add_argument('--ifar-threshold', type=float, default=None,
                          'above threshold.')
 parser.add_argument('--include-mass-gap', action='store_true',
                     help='Option to include the Mass Gap region.')
-parser.add_argument('--verbose', action='count')
 parser.add_argument("--version", action="version",
                     version=pycbc.version.git_verbose_msg)
 mchirp_area.insert_args(parser)

--- a/bin/pycbc_split_inspinj
+++ b/bin/pycbc_split_inspinj
@@ -5,12 +5,14 @@ import argparse
 from ligo.lw import utils as ligolw_utils
 from ligo.lw import lsctables
 from itertools import cycle
+
 import pycbc.version
 from pycbc.io.ligolw import LIGOLWContentHandler, get_table_columns
 
 
 # Parse command line
 parser = argparse.ArgumentParser()
+pycbc.add_common_pycbc_options(parser)
 parser.add_argument("--version", action="version",
                     version=pycbc.version.git_verbose_msg)
 group = parser.add_mutually_exclusive_group(required=True)
@@ -30,7 +32,10 @@ if args.output_files and args.output_dir:
 
 # Read in input file
 xmldoc = ligolw_utils.load_filename(
-        args.input_file, verbose=True, contenthandler=LIGOLWContentHandler)
+    args.input_file,
+    verbose=args.verbose,
+    contenthandler=LIGOLWContentHandler
+)
 tabletype = lsctables.SimInspiralTable
 allinjs = tabletype.get_table(xmldoc)
 

--- a/bin/pycbc_splitbank
+++ b/bin/pycbc_splitbank
@@ -29,10 +29,12 @@
 
 import argparse
 from numpy import random, ceil
+
 from ligo.lw import ligolw
 from ligo.lw import lsctables
 from ligo.lw import utils as ligolw_utils
 
+import pycbc
 from pycbc import version
 from pycbc.io.ligolw import LIGOLWContentHandler, create_process_table
 from pycbc.conversions import mchirp_from_mass1_mass2

--- a/bin/pycbc_splitbank
+++ b/bin/pycbc_splitbank
@@ -32,6 +32,7 @@ from numpy import random, ceil
 from ligo.lw import ligolw
 from ligo.lw import lsctables
 from ligo.lw import utils as ligolw_utils
+
 from pycbc import version
 from pycbc.io.ligolw import LIGOLWContentHandler, create_process_table
 from pycbc.conversions import mchirp_from_mass1_mass2
@@ -46,6 +47,7 @@ __program__ = "pycbc_splitbank"
 parser = argparse.ArgumentParser(description=__doc__)
 parser.add_argument('--version', action='version', version=version.git_verbose_msg)
 
+pycbc.add_common_pycbc_options(parser)
 group = parser.add_mutually_exclusive_group(required=True)
 group.add_argument('--templates-per-bank', metavar='SAMPLES',
                     help='number of templates in the output banks', type=int)
@@ -61,8 +63,6 @@ group.add_argument("-O", "--output-filenames", nargs='*', default=None,
 parser.add_argument("-o", "--output-prefix", default=None,
                     help="Prefix to add to the template bank name (name becomes output#.xml[.gz])" )
 
-parser.add_argument("-V", "--verbose", action="store_true",
-                    help="Print extra debugging information", default=False )
 parser.add_argument("-t", "--bank-file", metavar='INPUT_FILE',
                     help='Template bank to split', required=True)
 parser.add_argument("--sort-frequency-cutoff",

--- a/bin/pycbc_upload_xml_to_gracedb
+++ b/bin/pycbc_upload_xml_to_gracedb
@@ -23,23 +23,25 @@ Take a coinc xml file containing multiple events and upload to gracedb.
 import os
 import argparse
 import logging
-from ligo.gracedb.rest import GraceDb
 import numpy as np
 import h5py
 import matplotlib
 matplotlib.use('agg')
 
-import pycbc
+from ligo.gracedb.rest import GraceDb
 import lal
 import lal.series
 from ligo.lw import lsctables
 from ligo.lw import utils as ligolw_utils
 from ligo.segments import segment, segmentlist
+
+import pycbc
 from pycbc.io.live import gracedb_tag_with_version
 from pycbc.io.ligolw import LIGOLWContentHandler
 from pycbc.psd import interpolate
 from pycbc.types import FrequencySeries
 from pycbc.results import generate_asd_plot
+
 
 def check_gracedb_for_event(gdb_handle, query, far):
     """
@@ -68,6 +70,7 @@ logging.basicConfig(format='%(asctime)s:%(levelname)s : %(message)s',
                     level=logging.INFO)
 
 parser = argparse.ArgumentParser(description=__doc__)
+pycbc.add_common_pycbc_options(parser)
 parser.add_argument("--psd-files", nargs='+', required=True,
                     help='HDF file(s) containing the PSDs to upload')
 parser.add_argument('--input-file', required=True, type=str,
@@ -108,6 +111,8 @@ parser.add_argument('--generate-plots', action='store_true',
                          "not given.")
 
 args = parser.parse_args()
+
+pycbc.init_logging(args.verbose)
 
 if args.production_server:
     gracedb = GraceDb()

--- a/pycbc/__init__.py
+++ b/pycbc/__init__.py
@@ -79,11 +79,11 @@ def add_common_pycbc_options(parser):
         title="PyCBC common options",
         description="Common options for PyCBC executables.",
     )
-    group.add_argument('-V', '--verbose', action='count', default=0,
+    group.add_argument('-v', '--verbose', action='count', default=0,
                        help='Add verbosity to logging. Adding the option '
                             'multiple times makes logging progressively '
-                            'more verbose, e.g. --verbose or -V provides '
-                            'logging at the info level, but -VV or '
+                            'more verbose, e.g. --verbose or -v provides '
+                            'logging at the info level, but -vv or '
                             '--verbose --verbose provides debug logging.')
 
 def init_logging(verbose=False,

--- a/pycbc/tmpltbank/bank_conversions.py
+++ b/pycbc/tmpltbank/bank_conversions.py
@@ -27,8 +27,12 @@ specific values from PyCBC template banks.
 """
 
 import numpy as np
+import logging
+
 from pycbc import conversions as conv
 from pycbc import pnutils
+
+logger = logging.getLogger('pycbc.tmpltbank.bank_conversions')
 
 # Convert from parameter name to helper function
 # some multiple names are used for the same function

--- a/pycbc/tmpltbank/bank_conversions.py
+++ b/pycbc/tmpltbank/bank_conversions.py
@@ -26,8 +26,8 @@ This module is supplied to make a convenience function for converting into
 specific values from PyCBC template banks.
 """
 
-import numpy as np
 import logging
+import numpy as np
 
 from pycbc import conversions as conv
 from pycbc import pnutils

--- a/pycbc/tmpltbank/bank_output_utils.py
+++ b/pycbc/tmpltbank/bank_output_utils.py
@@ -1,7 +1,10 @@
 import numpy
 import h5py
+import logging
+
 from lal import PI, MTSUN_SI, TWOPI, GAMMA
 from ligo.lw import ligolw, lsctables, utils as ligolw_utils
+
 from pycbc import pnutils
 from pycbc.tmpltbank.lambda_mapping import ethinca_order_from_string
 from pycbc.io.ligolw import (
@@ -9,6 +12,8 @@ from pycbc.io.ligolw import (
 )
 
 from pycbc.waveform import get_waveform_filter_length_in_time as gwflit
+
+logger = logging.getLogger('pycbc.tmpltbank.bank_output_utils')
 
 def convert_to_sngl_inspiral_table(params, proc_id):
     '''

--- a/pycbc/tmpltbank/bank_output_utils.py
+++ b/pycbc/tmpltbank/bank_output_utils.py
@@ -1,6 +1,6 @@
+import logging
 import numpy
 import h5py
-import logging
 
 from lal import PI, MTSUN_SI, TWOPI, GAMMA
 from ligo.lw import ligolw, lsctables, utils as ligolw_utils

--- a/pycbc/tmpltbank/brute_force_methods.py
+++ b/pycbc/tmpltbank/brute_force_methods.py
@@ -1,5 +1,9 @@
 import numpy
+import logging
+
 from pycbc.tmpltbank.coord_utils import get_cov_params
+
+logger = logging.getLogger('pycbc.tmpltbank.brute_force_methods')
 
 
 def get_physical_covaried_masses(xis, bestMasses, bestXis, req_match,

--- a/pycbc/tmpltbank/brute_force_methods.py
+++ b/pycbc/tmpltbank/brute_force_methods.py
@@ -1,5 +1,5 @@
-import numpy
 import logging
+import numpy
 
 from pycbc.tmpltbank.coord_utils import get_cov_params
 

--- a/pycbc/tmpltbank/calc_moments.py
+++ b/pycbc/tmpltbank/calc_moments.py
@@ -14,8 +14,8 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-import numpy
 import logging
+import numpy
 
 from pycbc.tmpltbank.lambda_mapping import generate_mapping
 

--- a/pycbc/tmpltbank/calc_moments.py
+++ b/pycbc/tmpltbank/calc_moments.py
@@ -15,7 +15,11 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 import numpy
+import logging
+
 from pycbc.tmpltbank.lambda_mapping import generate_mapping
+
+logger = logging.getLogger('pycbc.tmpltbank.calc_moments')
 
 
 def determine_eigen_directions(metricParams, preserveMoments=False,

--- a/pycbc/tmpltbank/coord_utils.py
+++ b/pycbc/tmpltbank/coord_utils.py
@@ -16,10 +16,14 @@
 
 import logging
 import numpy
+
 from pycbc.tmpltbank.lambda_mapping import get_chirp_params
 from pycbc import conversions
 from pycbc import pnutils
 from pycbc.neutron_stars import load_ns_sequence
+
+logger = logging.getLogger('pycbc.tmpltbank.coord_utils')
+
 
 def estimate_mass_range(numPoints, massRangeParams, metricParams, fUpper,\
                         covary=True):
@@ -235,7 +239,7 @@ def get_random_mass(numPoints, massRangeParams, eos='2H'):
             warn_msg += "(%s). " %(max_ns_g_mass)
             warn_msg += "The code will proceed using the latter value "
             warn_msg += "as the boundary mass."
-            logging.warn(warn_msg)
+            logger.warn(warn_msg)
             boundary_mass = max_ns_g_mass
 
         # Empty arrays to store points that pass all cuts
@@ -711,7 +715,7 @@ def find_max_and_min_frequencies(name, mass_range_params, freqs):
         warn_msg += "for the metric: %s Hz. " %(freqs.min())
         warn_msg += "Distances for these waveforms will be calculated at "
         warn_msg += "the lowest available metric frequency."
-        logging.warn(warn_msg)
+        logger.warn(warn_msg)
     if upper_f_cutoff > freqs.max():
         warn_msg = "WARNING: "
         warn_msg += "Highest frequency cutoff is %s Hz " %(upper_f_cutoff,)
@@ -719,7 +723,7 @@ def find_max_and_min_frequencies(name, mass_range_params, freqs):
         warn_msg += "for the metric: %s Hz. " %(freqs.max())
         warn_msg += "Distances for these waveforms will be calculated at "
         warn_msg += "the largest available metric frequency."
-        logging.warn(warn_msg)
+        logger.warn(warn_msg)
     return find_closest_calculated_frequencies(cutoffs, freqs)
 
 

--- a/pycbc/tmpltbank/lambda_mapping.py
+++ b/pycbc/tmpltbank/lambda_mapping.py
@@ -18,9 +18,10 @@ import logging
 import numpy
 
 from lal import MTSUN_SI, PI, CreateREAL8Vector
-lalsimulation = pycbc.libutils.import_optional('lalsimulation')
 
 import pycbc.libutils
+
+lalsimulation = pycbc.libutils.import_optional('lalsimulation')
 
 logger = logging.getLogger('pycbc.tmpltbank.lambda_mapping')
 

--- a/pycbc/tmpltbank/lambda_mapping.py
+++ b/pycbc/tmpltbank/lambda_mapping.py
@@ -14,11 +14,15 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 import re
+import logging
 import numpy
-import pycbc.libutils
-from lal import MTSUN_SI, PI, CreateREAL8Vector
 
+from lal import MTSUN_SI, PI, CreateREAL8Vector
 lalsimulation = pycbc.libutils.import_optional('lalsimulation')
+
+import pycbc.libutils
+
+logger = logging.getLogger('pycbc.tmpltbank.lambda_mapping')
 
 # PLEASE ENSURE THESE ARE KEPT UP TO DATE WITH THE REST OF THIS FILE
 pycbcValidTmpltbankOrders = ['zeroPN','onePN','onePointFivePN','twoPN',\

--- a/pycbc/tmpltbank/lattice_utils.py
+++ b/pycbc/tmpltbank/lattice_utils.py
@@ -14,10 +14,11 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
+import logging
 import copy
 import numpy
+
 import lal
-import logging
 
 logger = logging.getLogger('pycbc.tmpltbank.lattice_utils')
 

--- a/pycbc/tmpltbank/lattice_utils.py
+++ b/pycbc/tmpltbank/lattice_utils.py
@@ -17,6 +17,9 @@
 import copy
 import numpy
 import lal
+import logging
+
+logger = logging.getLogger('pycbc.tmpltbank.lattice_utils')
 
 def generate_hexagonal_lattice(maxv1, minv1, maxv2, minv2, mindist):
     """

--- a/pycbc/tmpltbank/option_utils.py
+++ b/pycbc/tmpltbank/option_utils.py
@@ -594,8 +594,8 @@ def verify_mass_range_options(opts, parser, nonSpin=False):
     if hasattr(opts, 'remnant_mass_threshold') \
             and opts.remnant_mass_threshold is not None:
         logger.info("""You have asked to exclude EM dim NS-BH systems from the
-                       target parameter space. The script will assume that m1 is
-                       the BH and m2 is the NS: make sure that your settings
+                       target parameter space. The script will assume that m1
+                       is the BH and m2 is the NS: make sure that your settings
                        respect this convention. The script will also treat the
                        NS as non-spinning: use NS spins in the template bank
                        at your own risk!""")

--- a/pycbc/tmpltbank/option_utils.py
+++ b/pycbc/tmpltbank/option_utils.py
@@ -19,10 +19,14 @@ import logging
 import textwrap
 import numpy
 import os
+
 from pycbc.tmpltbank.lambda_mapping import get_ethinca_orders, pycbcValidOrdersHelpDescriptions
 from pycbc import pnutils
 from pycbc.neutron_stars import load_ns_sequence
 from pycbc.types import positive_float, nonnegative_float
+
+logger = logging.getLogger('pycbc.tmpltbank.option_utils')
+
 
 class IndentedHelpFormatterWithNL(argparse.ArgumentDefaultsHelpFormatter):
     """
@@ -589,21 +593,21 @@ def verify_mass_range_options(opts, parser, nonSpin=False):
     # inform him/her about the caveats involved in this.
     if hasattr(opts, 'remnant_mass_threshold') \
             and opts.remnant_mass_threshold is not None:
-        logging.info("""You have asked to exclude EM dim NS-BH systems from the
-                        target parameter space. The script will assume that m1 is
-                        the BH and m2 is the NS: make sure that your settings
-                        respect this convention. The script will also treat the
-                        NS as non-spinning: use NS spins in the template bank
-                        at your own risk!""")
+        logger.info("""You have asked to exclude EM dim NS-BH systems from the
+                       target parameter space. The script will assume that m1 is
+                       the BH and m2 is the NS: make sure that your settings
+                       respect this convention. The script will also treat the
+                       NS as non-spinning: use NS spins in the template bank
+                       at your own risk!""")
         if opts.use_eos_max_ns_mass:
-            logging.info("""You have asked to take into account the maximum NS
+            logger.info("""You have asked to take into account the maximum NS
                         mass value for the EOS in use.""")
         # Find out if the EM constraint surface data already exists or not
         # and inform user whether this will be read from file or generated.
         # This is the minumum eta as a function of BH spin and NS mass
         # required to produce an EM counterpart
         if os.path.isfile('constraint_em_bright.npz'):
-            logging.info("""The constraint surface for EM bright binaries
+            logger.info("""The constraint surface for EM bright binaries
                         will be read in from constraint_em_bright.npz.""")
 
     # Assign min/max total mass from mass1, mass2 if not specified

--- a/pycbc/tmpltbank/partitioned_bank.py
+++ b/pycbc/tmpltbank/partitioned_bank.py
@@ -17,7 +17,10 @@
 import copy
 import numpy
 import logging
+
 from pycbc.tmpltbank import coord_utils
+
+logger = logging.getLogger('pycbc.tmpltbank.partitioned_bank')
 
 class PartitionedTmpltbank(object):
     """
@@ -524,7 +527,7 @@ class PartitionedTmpltbank(object):
                 warn_msg += "convention is that mass1 > mass2. Swapping mass1 "
                 warn_msg += "and mass2 and adding point to bank. This message "
                 warn_msg += "will not be repeated."
-                logging.warn(warn_msg)
+                logger.warn(warn_msg)
                 self.spin_warning_given = True
 
         # These that masses obey the restrictions of mass_range_params


### PR DESCRIPTION
Following on from #4576

This is the executables directly in `bin`, and in `bin/bank`. We specifically ignore:
 - `pycbc_live` - so that the logging monitors don't break
 - `pycbc_get_ffinal` - this uses optparse rather than argparse, and seems complicated using a mix of config files and CLI, so I'm skipping it for now.
 - `pycbc_live_nagios_monitor` - this doesn't really want to be verbose anyway, as it just monitors the logging output of `pycbc_live`
 - `pycbc_make_banksim` and `pycbc_make_faithsim` don't have verbose options; logging is set to INFO by default. Though the logging is standardized by this change

Also adding in the modules in `pycbc/tmpltbank`