### PR TITLE
Fix issue with string format in reading LVK HDF format injection files

### DIFF
--- a/bin/pycbc_convertinjfiletohdf
+++ b/bin/pycbc_convertinjfiletohdf
@@ -151,7 +151,11 @@ class LVKNewStyleInjectionSet(object):
             elif lvk_name == 't_co_gps_add':
                 continue
             else:
-                data[pycbc_name] = self.inj_file[f'{self.subdir}/{lvk_name}'][:]
+                lvk_file_dset = self.inj_file[f'{self.subdir}/{lvk_name}']
+                if lvk_file_dset.dtype.char in ['U', 'O']:
+                    data[pycbc_name] = lvk_file_dset[:].astype('S')
+                else:
+                    data[pycbc_name] = lvk_file_dset[:]
         return data
 
 


### PR DESCRIPTION
I hate strings in python3 and HDF!

There is an issue when reading LVK HDF format injection files that the approximant field is not the right sort of string, and the code breaks. Based off what we do here:

https://github.com/gwastro/pycbc/blob/master/pycbc/inject/inject.py#L485

I added the same check for the LVK set (except that one seems to be stored in 'O' format, not 'U'). Before the fix output files say:

```
/approximant             Dataset {111616/111616}
    Location:  1:976
    Links:     1
    Storage:   892928 logical bytes, 1785856 allocated bytes, 50.00% utilization
    Type:      variable-length null-terminated UTF-8 string
```

and PyCBC refuses to read them. After this patch they say:

```
/approximant             Dataset {111616/111616}
    Location:  1:976
    Links:     1
    Storage:   1451008 logical bytes, 1451008 allocated bytes, 100.00% utilization
    Type:      13-byte null-padded ASCII string
```

and we are happy! 