### PR TITLE
Fix Pegasus selector profile key

### DIFF
--- a/pycbc/workflow/pegasus_workflow.py
+++ b/pycbc/workflow/pegasus_workflow.py
@@ -75,7 +75,7 @@ class ProfileShortcuts(object):
         self.add_profile("dagman", "retry", number)
 
     def set_execution_site(self, site):
-        self.add_profile("selector", "execution_site", site)
+        self.add_profile("selector", "execution.site", site)
 
 
 class Executable(ProfileShortcuts):


### PR DESCRIPTION
Change the selector profile to `execution.site` from `execution_site`.

See: https://pegasus.isi.edu/documentation/reference-guide/configuration.html