### PR TITLE
Update how live fitting deals with invalid values

### DIFF
--- a/bin/live/pycbc_live_combine_single_fits
+++ b/bin/live/pycbc_live_combine_single_fits
@@ -161,9 +161,8 @@ for ifo in args.ifos:
     fout_ifo['separate_fits/start_time'] = trigger_file_starts[ad_order]
     fout_ifo['separate_fits/end_time'] = trigger_file_ends[ad_order]
 
-    for counter, a_c_u_l in enumerate(zip(alphas_bin[ifo],
-                                          counts_bin[ifo], bu, bl)):
-        a, c, u, l = a_c_u_l
+    for counter, (a, c) in enumerate(zip(alphas_bin[ifo],
+                                         counts_bin[ifo])):
         # Sort alpha and counts by date
         a = np.array(a)[ad_order]
         c = np.array(c)[ad_order]

--- a/bin/live/pycbc_live_combine_single_fits
+++ b/bin/live/pycbc_live_combine_single_fits
@@ -154,7 +154,8 @@ for ifo in args.ifos:
     logging.info(ifo)
     fout_ifo = fout.create_group(ifo)
     l_times = np.array(live_times[ifo])
-    fout_ifo.attrs['live_time'] = l_times.sum()
+    total_time = l_times.sum()
+    fout_ifo.attrs['live_time'] = total_time
 
     fout_ifo['separate_fits/live_times'] = l_times[ad_order]
     fout_ifo['separate_fits/start_time'] = trigger_file_starts[ad_order]
@@ -166,16 +167,20 @@ for ifo in args.ifos:
         # Sort alpha and counts by date
         a = np.array(a)[ad_order]
         c = np.array(c)[ad_order]
-        invalphan = c / a
-        mean_alpha = c.mean() / invalphan.mean()
-        cons_alpha = np.percentile(a, 100 - args.conservative_percentile)
+
+        # ignore anything with the 'invalid' salient values
+        valid = c > 0
+
+        invalphan = c[valid] / a[valid]
+        mean_alpha = c[valid].mean() / invalphan.mean()
+        cons_alpha = np.percentile(a[valid], 100 - args.conservative_percentile)
         cons_alphas_out[ifo][counter] = cons_alpha
         alphas_out[ifo][counter] = mean_alpha
         # To get the count values, we need to convert to rates and back again
-        r = c / l_times[ad_order]
+        r = c [valid]/ l_times[ad_order][valid]
         cons_rate = np.percentile(r, args.conservative_percentile)
-        cons_counts_out[ifo][counter] = cons_rate * l_times[ad_order].sum()
-        counts_out[ifo][counter] = np.mean(r) * l_times[ad_order].sum()
+        cons_counts_out[ifo][counter] = cons_rate * total_time
+        counts_out[ifo][counter] = np.mean(r) * total_time
 
         fout_ifo[f'separate_fits/bin_{counter:d}/fit_coeff'] = a
         fout_ifo[f'separate_fits/bin_{counter:d}/counts'] = c

--- a/bin/live/pycbc_live_combine_single_fits
+++ b/bin/live/pycbc_live_combine_single_fits
@@ -170,19 +170,27 @@ for ifo in args.ifos:
         # ignore anything with the 'invalid' salient values
         valid = c > 0
 
+        fout_ifo[f'separate_fits/bin_{counter:d}/fit_coeff'] = a
+        fout_ifo[f'separate_fits/bin_{counter:d}/counts'] = c
+
+        if not any(valid):
+            cons_alphas_out[ifo][counter] = np.nan
+            alphas_out[ifo][counter] = np.nan
+            cons_counts_out[ifo][counter] = np.nan
+            counts_out[ifo][counter] = np.nan
+            continue
+
         invalphan = c[valid] / a[valid]
         mean_alpha = c[valid].mean() / invalphan.mean()
         cons_alpha = np.percentile(a[valid], 100 - args.conservative_percentile)
         cons_alphas_out[ifo][counter] = cons_alpha
         alphas_out[ifo][counter] = mean_alpha
+
         # To get the count values, we need to convert to rates and back again
-        r = c [valid]/ l_times[ad_order][valid]
+        r = c[valid]/ l_times[ad_order][valid]
         cons_rate = np.percentile(r, args.conservative_percentile)
         cons_counts_out[ifo][counter] = cons_rate * total_time
         counts_out[ifo][counter] = np.mean(r) * total_time
-
-        fout_ifo[f'separate_fits/bin_{counter:d}/fit_coeff'] = a
-        fout_ifo[f'separate_fits/bin_{counter:d}/counts'] = c
 
     # Output the mean average values
     fout_ifo['mean/fit_coeff'] = alphas_out[ifo]
@@ -192,17 +200,18 @@ for ifo in args.ifos:
     fout_ifo['conservative/fit_coeff'] = cons_alphas_out[ifo]
     fout_ifo['conservative/counts'] = cons_counts_out[ifo]
 
-    # Take some averages for plotting and summary values
-    overall_invalphan = counts_out[ifo] / alphas_out[ifo]
-    overall_meanalpha = counts_out[ifo].mean() / overall_invalphan.mean()
-
     # For the fixed version, we just set this to 1
     fout_ifo['fixed/counts'] = [1] * len(counts_out[ifo])
     fout_ifo['fixed/fit_coeff'] = [0] * len(alphas_out[ifo])
 
+    # Take some averages for plotting and summary values
+    overall_invalphan = counts_out[ifo] / alphas_out[ifo]
+    overall_meanalpha = np.nanmean(counts_out[ifo]) \
+        / np.nanmean(overall_invalphan)
+
     # Add some useful info to the output file
     fout_ifo.attrs['mean_alpha'] = overall_meanalpha
-    fout_ifo.attrs['total_counts'] = counts_out[ifo].sum()
+    fout_ifo.attrs['total_counts'] = np.nansum(counts_out[ifo])
 
 fout.close()
 

--- a/bin/live/pycbc_live_plot_combined_single_fits
+++ b/bin/live/pycbc_live_plot_combined_single_fits
@@ -140,7 +140,8 @@ for ifo in ifos:
             continue
 
         l_times = separate_times[ifo]
-        rate = counts / l_times
+        with np.errstate(divide='ignore'):
+            rate = counts / l_times
 
         ma = mean_alpha[ifo][i]
         ca = cons_alpha[ifo][i]
@@ -151,7 +152,7 @@ for ifo in ifos:
         bin_colour = plt.get_cmap(args.colormap)(bin_prop)
         bin_label = f"duration {bl:.2f}-{bu:.2f}"
         alpha_lines += ax_alpha.plot(separate_starts[ifo], alphas, c=bin_colour,
-                                     label=bin_label)
+                                     label=bin_label, marker='x')
         alpha_lines.append(ax_alpha.axhline(ma,
                                             label="total fit = %.2f" % ma,
                                             c=bin_colour, linestyle='--',))
@@ -161,14 +162,21 @@ for ifo in ifos:
                                             label=alpha_lab))
 
         count_lines += ax_count.plot(separate_starts[ifo], rate, c=bin_colour,
-                                     label=bin_label)
+                                     label=bin_label, marker='x')
+
+        if mr < 1e-3:
+            mlab = f"mean = {mr:.3e}"
+            clab = f"{conservative_percentile:d}th %ile = {cr:.2e}"
+        else:
+            mlab = f"mean = {mr:.3f}"
+            clab = f"{conservative_percentile:d}th %ile = {cr:.3f}"
+
         count_lines.append(ax_count.axhline(mr,
                                             c=bin_colour, linestyle='--',
-                                            label=f"mean = {mr:.3f}"))
-        count_lab = f"{conservative_percentile:d}th %ile = {cr:.3f}"
+                                            label=mlab))
         count_lines.append(ax_count.axhline(cr,
                                             c=bin_colour, linestyle=':',
-                                            label=count_lab))
+                                            label=clab))
 
     alpha_labels = [l.get_label() for l in alpha_lines]
     ax_alpha.legend(alpha_lines, alpha_labels, loc='lower center',

--- a/bin/live/pycbc_live_plot_combined_single_fits
+++ b/bin/live/pycbc_live_plot_combined_single_fits
@@ -168,7 +168,7 @@ for ifo in ifos:
 
         if mr < 1e-3:
             mlab = f"mean = {mr:.3e}"
-            clab = f"{conservative_percentile:d}th %ile = {cr:.2e}"
+            clab = f"{conservative_percentile:d}th %ile = {cr:.3e}"
         else:
             mlab = f"mean = {mr:.3f}"
             clab = f"{conservative_percentile:d}th %ile = {cr:.3f}"

--- a/bin/live/pycbc_live_plot_combined_single_fits
+++ b/bin/live/pycbc_live_plot_combined_single_fits
@@ -152,7 +152,8 @@ for ifo in ifos:
         bin_colour = plt.get_cmap(args.colormap)(bin_prop)
         bin_label = f"duration {bl:.2f}-{bu:.2f}"
         alpha_lines += ax_alpha.plot(separate_starts[ifo], alphas, c=bin_colour,
-                                     label=bin_label, marker='x')
+                                     label=bin_label, marker='.',
+                                     markersize=10)
         alpha_lines.append(ax_alpha.axhline(ma,
                                             label="total fit = %.2f" % ma,
                                             c=bin_colour, linestyle='--',))
@@ -162,7 +163,8 @@ for ifo in ifos:
                                             label=alpha_lab))
 
         count_lines += ax_count.plot(separate_starts[ifo], rate, c=bin_colour,
-                                     label=bin_label, marker='x')
+                                     label=bin_label, marker='.',
+                                     markersize=10)
 
         if mr < 1e-3:
             mlab = f"mean = {mr:.3e}"

--- a/pycbc/events/single.py
+++ b/pycbc/events/single.py
@@ -225,8 +225,17 @@ class LiveSingle(object):
 
         rate = rates[dur_bin]
         coeff = coeffs[dur_bin]
+        if np.isnan(coeff) or np.isnan(rate):
+            logger.warning(
+                "Single trigger fits are not valid - singles "
+                "cannot be assessed for this detector at this time."
+            )
+            return None
+
         rate_louder = rate * fits.cum_fit('exponential', [sngl_ranking],
                                           coeff, thresh)[0]
+
         # apply a trials factor of the number of duration bins
         rate_louder *= len(rates)
+
         return conv.sec_to_year(1. / rate_louder)


### PR DESCRIPTION
We noticed some plotting issues with when there are zero-live-time days for singles fit plots.

This PR:
 - removes invalid values from the `mean` count and fit coefficient calculation inputs, so that the count does not become infinite. This would effect results where we use the `mean` value - at the moment we use `conservative` so it doesn't matter
 - adds markers to the plot, so that we can see information where there is a day on its own
 - Allows the labels to be in scientific format below 1e-3, so that we don't simply state zero for the mean and conservative values of these

The cumulative effect of these can be seen in the before / after comparison below:

Before:

![image](https://github.com/gwastro/pycbc/assets/44500294/fc02fec2-7341-4871-a9ee-e9661a6be0b4)

After:

![image](https://github.com/gwastro/pycbc/assets/44500294/f4446459-fcd6-452e-b7dc-ef15f39cf8e9)
