### PR TITLE
Standardize logging - many places

### DIFF
--- a/bin/all_sky_search/pycbc_coinc_hdfinjfind
+++ b/bin/all_sky_search/pycbc_coinc_hdfinjfind
@@ -161,8 +161,8 @@ for trigger_file, injection_file in zip(args.trigger_files,
                  % (len(found), len(missed), len(ambiguous)))
 
     if len(ambiguous) > 0:
-        logging.warn('More than one coinc trigger found associated '
-                     'with injection')
+        logging.warning('More than one coinc trigger found associated '
+                        'with injection')
         am = numpy.arange(0, len(inj_time), 1)[left[ambiguous]]
         bm = numpy.arange(0, len(inj_time), 1)[right[ambiguous]]
 

--- a/bin/all_sky_search/pycbc_coinc_statmap
+++ b/bin/all_sky_search/pycbc_coinc_statmap
@@ -202,8 +202,8 @@ else:
 back_locs = all_trigs.timeslide_id != 0
 
 if (back_locs.sum()) == 0:
-    logging.warn("There were no background events, so we could not assign "
-                 "any statistic values")
+    logging.warning("There were no background events, so we could not "
+                    "assign any statistic values")
     sys.exit()
 
 logging.info("Dumping background triggers (inclusive of zerolag)")

--- a/bin/all_sky_search/pycbc_fit_sngls_split_binned
+++ b/bin/all_sky_search/pycbc_fit_sngls_split_binned
@@ -154,7 +154,7 @@ else:
 if args.bin_param == 'template_duration' and params[args.bin_param].min() == 0:
     # Accessing the 0th entry of an empty region reference will return
     # zero due to a quirk of h5py.
-    logging.warn('WARNING: Some templates do not contain triggers')
+    logging.warning('WARNING: Some templates do not contain triggers')
     # Use the lowest nonzero template duration as lower limit for bins
     pbin_lower_lim = params[args.bin_param][params[args.bin_param] > 0].min()
 else:

--- a/bin/bank/pycbc_geom_aligned_2dstack
+++ b/bin/bank/pycbc_geom_aligned_2dstack
@@ -252,7 +252,9 @@ for entry in temp_bank:
         # Double check that no points appear outside what was calculated above
         if len(xis_close):
             if vec3_min > xis_close[:,2].min():
-                logging.warn("WARNING: Numerical placement fails, trying again")
+                logging.warning(
+                    "WARNING: Numerical placement fails, trying again"
+                )
                 temp_idx = xis_close[:,2].argmin()
                 temmpBestMasses = masses_close[temp_idx]
                 temmpBestXis = xis_close[temp_idx]
@@ -269,7 +271,9 @@ for entry in temp_bank:
                     vec3_max = temmpvec3_max
                     vec3_depth = vec3_max - vec3_min
             if vec3_max < xis_close[:,2].max():
-                logging.warn("WARNING: Numerical placement fails, trying again")
+                logging.warniing(
+                    "WARNING: Numerical placement fails, trying again"
+                )
                 temp_idx = xis_close[:,2].argmax()
                 temmpBestMasses = physMasses[temp_idx]
                 temmpBestXis = xis[temp_idx]

--- a/bin/bank/pycbc_geom_aligned_2dstack
+++ b/bin/bank/pycbc_geom_aligned_2dstack
@@ -271,7 +271,7 @@ for entry in temp_bank:
                     vec3_max = temmpvec3_max
                     vec3_depth = vec3_max - vec3_min
             if vec3_max < xis_close[:,2].max():
-                logging.warniing(
+                logging.warning(
                     "WARNING: Numerical placement fails, trying again"
                 )
                 temp_idx = xis_close[:,2].argmax()

--- a/bin/hwinj/pycbc_generate_hwinj
+++ b/bin/hwinj/pycbc_generate_hwinj
@@ -249,7 +249,7 @@ pycbc.init_logging(opts.verbose)
 # check that sample rates are the same
 for ifo in opts.instruments:
     if opts.sample_rate[ifo] != opts.sample_rate[opts.instruments[0]]:
-        logging.warn('Sample rates must be equal for all IFOs.')
+        logging.warning('Sample rates must be equal for all IFOs.')
         sys.exit()
 sample_rate = opts.sample_rate[opts.instruments[0]]
 
@@ -513,8 +513,8 @@ prefix = opts.tag + '_' + str(start_time)
 logging.info('Writing XML file')
 xml_filename = prefix + '.xml.gz'
 if os.path.exists(xml_filename):
-    logging.warn('Filename %s already exists and will not be overwritten',
-                 xml_filename)
+    logging.warning('Filename %s already exists and will not be overwritten',
+                    xml_filename)
     sys.exit()
 else:
     utils.write_filename(outdoc, xml_filename)
@@ -537,8 +537,8 @@ for ifo in opts.instruments:
 
     # check if filename exists
     if os.path.exists(txt_filename):
-        logging.warn('Filename %s already exists and will not be overwritten',
-                     txt_filename)
+        logging.warning('Filename %s already exists and will not be overwritten',
+                        txt_filename)
         sys.exit()
 
     # save waveform as single-column ASCII for awgstream to use

--- a/bin/hwinj/pycbc_generate_hwinj
+++ b/bin/hwinj/pycbc_generate_hwinj
@@ -17,12 +17,16 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 import argparse
+import logging
+import numpy
+import os
+import sys
+
 from ligo.lw import ligolw
 from ligo.lw import lsctables
 from ligo.lw import table
 from ligo.lw import utils
-import logging
-import numpy
+
 import pycbc
 import pycbc.version
 from pycbc import DYN_RANGE_FAC
@@ -39,8 +43,6 @@ from pycbc.types.optparse import MultiDetOptionAppendAction
 from pycbc.types.optparse import convert_to_process_params_dict
 from pycbc.io.ligolw import create_process_table
 from pycbc.waveform import FilterBank, get_td_waveform, td_approximants, taper_timeseries
-import os
-import sys
 
 def _empty_row(obj):
     """Create an empty sim_inspiral or sngl_inspiral row where the columns have
@@ -116,6 +118,7 @@ parser = argparse.ArgumentParser(
                   usage=__name__ + ' [--options]',
                   description="Generates a hardware injection waveform using "
                               "a time-domain waveform.")
+pycbc.add_common_pycbc_options(parser)
 
 # IFO network options
 parser.add_argument('--network-snr', type=float, required=True,
@@ -239,9 +242,9 @@ if not opts.psd_estimation and (opts.frame_files or opts.frame_type
                    "(--frame-files, --frame-type, --frame-cache, "
                    "and --fake-strain).")
 
-# setup log
-logging_level = logging.DEBUG
-logging.basicConfig(format='%(asctime)s : %(message)s', level=logging_level)
+# setup log: default is DEBUG (2)
+log_level = 2 if opts.verbose is None else opts.verbose + 2
+pycbc.init_logging(opts.verbose)
 
 # check that sample rates are the same
 for ifo in opts.instruments:

--- a/bin/hwinj/pycbc_generate_hwinj_from_xml
+++ b/bin/hwinj/pycbc_generate_hwinj_from_xml
@@ -62,7 +62,7 @@ opts = parser.parse_args()
 
 # setup logging - default level is DEBUG (2)
 logging_level = 2 if opts.verbose is None else opts.verbose + 2
-init_logging.(logging_level)
+init_logging(logging_level)
 
 # read in injection LIGOLW XML file
 logging.info('Reading injection file')

--- a/bin/hwinj/pycbc_generate_hwinj_from_xml
+++ b/bin/hwinj/pycbc_generate_hwinj_from_xml
@@ -16,10 +16,14 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
+
 import argparse
 import logging
 import numpy
-import os, sys
+import os
+import sys
+
+from pycbc import add_common_pycbc_options, init_logging
 from pycbc.inject import InjectionSet, legacy_approximant_name
 from pycbc.types import TimeSeries
 from pycbc.waveform import get_td_waveform
@@ -41,6 +45,8 @@ parser = argparse.ArgumentParser(
              from the sim_inspiral row, Y is the GPS start time of the ASCII waveform file, \
              and Z is the duration of the file in seconds.')
 
+add_common_pycbc_options(parser)
+
 # add command line options
 parser.add_argument('--injection-file', type=str, required=True,
              help='Path to the LIGOLW XML file that contains a sim_inspiral table.')
@@ -54,9 +60,9 @@ parser.add_argument('--ifos', nargs='+', default=['H1', 'L1'], required=True,
 # parse command line
 opts = parser.parse_args()
 
-# setup log
-logging_level = logging.DEBUG
-logging.basicConfig(format='%(asctime)s : %(message)s', level=logging_level)
+# setup logging - default level is DEBUG (2)
+logging_level = 2 if opts.verbose is None else opts.verbose + 2
+init_logging.(logging_level)
 
 # read in injection LIGOLW XML file
 logging.info('Reading injection file')

--- a/bin/hwinj/pycbc_generate_hwinj_from_xml
+++ b/bin/hwinj/pycbc_generate_hwinj_from_xml
@@ -99,18 +99,25 @@ for sim in injections.table:
 
         # create a time series of zeroes to inject waveform into
         initial_array = numpy.zeros(num_samples, dtype=h_plus.dtype)
-        output = TimeSeries(initial_array, delta_t=1.0/opts.sample_rate, epoch=start_time, dtype=h_plus.dtype)
+        output = TimeSeries(
+            initial_array,
+            delta_t=1.0/opts.sample_rate,
+            epoch=start_time,
+            dtype=h_plus.dtype)
 
         # inject waveform into time series of zeroes
         logging.info('Injecting %s waveform into timeseries of zeroes', ifo)
         injections.apply(output, ifo, simulation_ids=[sim.simulation_id])
 
         # set output filename
-        txt_filename = opts.tag + str(sim_id) + '_' + str(start_time) + '_' + ifo + '.txt'
+        txt_filename = f'{opts.tag}{sim_id:d}_{start_time:d}_{ifo}.txt'
 
         # check if filename does not exist
         if os.path.exists(txt_filename):
-            logging.warn('Filename %s already exists and will not be overwritten', txt_filename)
+            logging.warning(
+                'Filename %s already exists and will not be overwritten',
+                txt_filename
+            )
             sys.exit()
 
         # save waveform as single column ASCII for awgstream to use

--- a/bin/hwinj/pycbc_insert_frame_hwinj
+++ b/bin/hwinj/pycbc_insert_frame_hwinj
@@ -19,6 +19,8 @@
 import argparse
 import logging
 import numpy
+
+from pycbc import add_common_pycbc_options, init_logging
 from pycbc.frame import write_frame
 from pycbc import strain as _strain
 
@@ -26,6 +28,7 @@ from pycbc import strain as _strain
 parser = argparse.ArgumentParser(usage='pycbc_insert_frame_hwinj [--options]',
                                  description="Inserts a single-column ASCII "
                                              "file into frame data.")
+add_common_pycbc_options(pycbc)
 
 # injection options
 parser.add_argument('--hwinj-file', type=str, required=True,
@@ -54,9 +57,9 @@ _strain.insert_strain_option_group(parser)
 # parse command line
 opts = parser.parse_args()
 
-# setup log
-logging_level = logging.DEBUG
-logging.basicConfig(format='%(asctime)s : %(message)s', level=logging_level)
+# setup log: default is DEBUG (2)
+logging_level = 2 if opts.verbose is None else opts.verbose + 2
+init_logging(logging_level)
 
 # get strain
 strain = _strain.from_cli(opts, precision=opts.precision)

--- a/bin/hwinj/pycbc_insert_frame_hwinj
+++ b/bin/hwinj/pycbc_insert_frame_hwinj
@@ -28,7 +28,7 @@ from pycbc import strain as _strain
 parser = argparse.ArgumentParser(usage='pycbc_insert_frame_hwinj [--options]',
                                  description="Inserts a single-column ASCII "
                                              "file into frame data.")
-add_common_pycbc_options(pycbc)
+add_common_pycbc_options(parser)
 
 # injection options
 parser.add_argument('--hwinj-file', type=str, required=True,

--- a/bin/hwinj/pycbc_plot_hwinj
+++ b/bin/hwinj/pycbc_plot_hwinj
@@ -25,9 +25,12 @@ import matplotlib.pyplot as plt
 import numpy
 import sys
 
+from pycbc import add_common_pycbc_options, init_logging
+
 # command line usage
 parser = argparse.ArgumentParser(usage=__file__ + " [--options]",
                                  description=__doc__)
+add_common_pycbc_options(parser)
 
 # I/O options
 parser.add_argument("--input-file", required=True,
@@ -51,19 +54,11 @@ parser.add_argument("--y-label", default="Counts",
 parser.add_argument("--title", default="",
                     help="Title shown above plot.")
 
-# verbose option
-parser.add_argument("--verbose", action="store_true",
-                    help="Display log messages while executing.")
-
 # parse command line
 opts = parser.parse_args()
 
 # setup log
-if opts.verbose:
-    logging_level = logging.DEBUG
-else:
-    logging_level = logging.WARN
-logging.basicConfig(format="%(asctime)s : %(message)s", level=logging_level)
+init_logging(opts.verbose)
 
 # read data
 logging.info("Reading data")

--- a/bin/inference/pycbc_inference_plot_movie
+++ b/bin/inference/pycbc_inference_plot_movie
@@ -262,7 +262,7 @@ if opts.plot_injection_parameters:
             vals = injections[p]
         except NameError:
             # injection doesn't have this parameter, skip
-            logging.warn("Could not find injection parameter {}".format(p))
+            logging.warning("Could not find injection parameter %s", p)
             continue
         unique_vals = numpy.unique(vals)
         if unique_vals.size != 1:

--- a/bin/inference/pycbc_inference_plot_posterior
+++ b/bin/inference/pycbc_inference_plot_posterior
@@ -226,7 +226,7 @@ if opts.plot_injection_parameters:
             vals = injections[p]
         except (NameError, TypeError, AttributeError):
             # injection doesn't have this parameter, skip
-            logging.warn("Could not find injection parameter {}".format(p))
+            logging.warning("Could not find injection parameter %s", p)
             continue
 
         if opts.pick_injection_by_time:

--- a/bin/live/pycbc_live_combine_single_fits
+++ b/bin/live/pycbc_live_combine_single_fits
@@ -19,12 +19,11 @@ import argparse
 import logging
 import numpy as np
 import h5py
+
 import pycbc
 
-
 parser = argparse.ArgumentParser(description=__doc__)
-parser.add_argument("--verbose", action="store_true",
-                    help="Print extra debugging information", default=False)
+pycbc.add_common_pycbc_options(parser)
 parser.add_argument("--trfits-files", nargs="+", required=True,
                     help="Files containing daily trigger fits")
 parser.add_argument("--conservative-percentile", type=int, default=95,

--- a/bin/live/pycbc_live_plot_combined_single_fits
+++ b/bin/live/pycbc_live_plot_combined_single_fits
@@ -29,8 +29,7 @@ import pycbc
 
 
 parser = argparse.ArgumentParser(description=__doc__)
-parser.add_argument("--verbose", action="store_true",
-                    help="Print extra debugging information", default=False)
+pycbc.add_common_pycbc_options(parser)
 parser.add_argument("--combined-fits-file", required=True,
                     help="File containing information on the combined trigger "
                          "fits.")

--- a/bin/live/pycbc_live_plot_single_trigger_fits
+++ b/bin/live/pycbc_live_plot_single_trigger_fits
@@ -30,8 +30,7 @@ from pycbc.events.trigger_fits import cum_fit as eval_cum_fit
 
 
 parser = argparse.ArgumentParser(description=__doc__)
-parser.add_argument("--verbose", action="store_true",
-                    help="Print extra debugging information", default=False)
+pycbc.add_common_pycbc_options(parser)
 parser.add_argument("--trigger-fits-file", required=True,
                     help="Trigger fits file to plot")
 default_plot_format = "{ifo}-TRIGGER-FITS.png"

--- a/bin/live/pycbc_live_single_trigger_fits
+++ b/bin/live/pycbc_live_single_trigger_fits
@@ -227,7 +227,7 @@ for counter, filename in enumerate(files):
     try:
         h5py.File(f, 'r')
     except IOError:
-        logging.warn('IOError with file ' + f)
+        logging.warning('IOError with file %s', f)
         continue
 
     # Triggers for this file

--- a/bin/live/pycbc_live_single_trigger_fits
+++ b/bin/live/pycbc_live_single_trigger_fits
@@ -22,6 +22,7 @@ import argparse
 import logging
 import numpy as np
 import h5py
+
 import pycbc
 from pycbc.bin_utils import IrregularBins
 from pycbc.events import cuts, trigger_fits as trstats
@@ -60,8 +61,7 @@ def duration_bins_from_cli(args):
 
 
 parser = argparse.ArgumentParser(description=__doc__)
-parser.add_argument("--verbose", action="store_true",
-                    help="Print extra debugging information", default=False)
+pycbc.add_common_pycbc_options(parser)
 parser.add_argument("--ifos", nargs="+", required=True,
                     help="Which ifo are we fitting the triggers for? "
                          "Required")
@@ -128,6 +128,8 @@ cuts.insert_cuts_option_group(parser)
 
 args = parser.parse_args()
 
+pycbc.init_logging(args.verbose)
+
 # Check input options
 
 # Pruning options are mutually required or not needed
@@ -159,8 +161,6 @@ if args.duration_bin_end and \
     parser.error("--duration-bin-end must be greater than "
                  "--duration-bin-start, got "
                  f"{args.duration_bin_end} and {args.duration_bin_start}")
-
-pycbc.init_logging(args.verbose)
 
 duration_bin_edges = duration_bins_from_cli(args)
 logging.info("Duration bin edges: %s", duration_bin_edges)

--- a/bin/minifollowups/pycbc_foreground_minifollowup
+++ b/bin/minifollowups/pycbc_foreground_minifollowup
@@ -24,6 +24,7 @@ import re
 import h5py
 
 import pycbc.workflow as wf
+from pycbc import init_logging, add_common_pycbc_options
 from pycbc.results import layout
 from pycbc.types import MultiDetOptionAction
 from pycbc.events import select_segments_by_definer, coinc
@@ -33,6 +34,7 @@ from pycbc.workflow.core import resolve_url_to_file
 import pycbc.version
 
 parser = argparse.ArgumentParser(description=__doc__[1:])
+add_common_pycbc_options(parser)
 parser.add_argument('--version', action='version', version=pycbc.version.git_verbose_msg)
 parser.add_argument('--bank-file',
                     help="HDF format template bank file")
@@ -66,8 +68,9 @@ wf.add_workflow_command_line_group(parser)
 wf.add_workflow_settings_cli(parser, include_subdax_opts=True)
 args = parser.parse_args()
 
-logging.basicConfig(format='%(asctime)s:%(levelname)s : %(message)s',
-                    level=logging.INFO)
+# Default logging level is info: --verbose adds to this
+log_level = 1 if args.verbose is None else args.verbose + 1
+init_logging(log_level)
 
 workflow = wf.Workflow(args)
 

--- a/bin/minifollowups/pycbc_injection_minifollowup
+++ b/bin/minifollowups/pycbc_injection_minifollowup
@@ -23,6 +23,8 @@ import logging
 import copy
 import numpy
 import h5py
+
+from pycbc import init_logging, add_common_pycbc_options
 import pycbc.workflow as wf
 import pycbc.workflow.minifollowups as mini
 import pycbc.version
@@ -120,6 +122,7 @@ def sort_injections(args, inj_group, missed):
 
 
 parser = argparse.ArgumentParser(description=__doc__)
+add_common_pycbc_options(parser)
 parser.add_argument('--version', action='version', version=pycbc.version.git_verbose_msg)
 parser.add_argument('--bank-file',
                     help="HDF format template bank file")
@@ -158,8 +161,10 @@ wf.add_workflow_command_line_group(parser)
 wf.add_workflow_settings_cli(parser, include_subdax_opts=True)
 args = parser.parse_args()
 
-logging.basicConfig(format='%(asctime)s:%(levelname)s : %(message)s',
-                    level=logging.INFO)
+
+# Default logging level is info: --verbose adds to this
+log_level = 1 if args.verbose is None else args.verbose + 1
+init_logging(log_level)
 
 workflow = wf.Workflow(args)
 

--- a/bin/minifollowups/pycbc_page_coincinfo
+++ b/bin/minifollowups/pycbc_page_coincinfo
@@ -16,17 +16,28 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 """ Make tables describing a foreground event"""
 
-import h5py, argparse, logging, sys
-import matplotlib; matplotlib.use('Agg')
-import numpy, lal, datetime
-import pycbc.version, pycbc.results, pycbc.pnutils
+import h5py
+import argparse
+import logging
+import sys
+import matplotlib
+matplotlib.use('Agg')
+import datetime
+import numpy
+
+import lal
+
+from pycbc import add_common_pycbc_options
+import pycbc.version
+import pycbc.results
+import pycbc.pnutils
 from pycbc.events import ranking
 from pycbc.results import followup
 
 parser = argparse.ArgumentParser()
+add_common_pycbc_options(parser)
 parser.add_argument('--version', action='version',
     version=pycbc.version.git_verbose_msg)
-parser.add_argument('--verbose', action='store_true')
 parser.add_argument('--single-trigger-files', nargs='+',
     help="HDF format single detector trigger files for the full data run")
 parser.add_argument('--bank-file',

--- a/bin/minifollowups/pycbc_page_injinfo
+++ b/bin/minifollowups/pycbc_page_injinfo
@@ -15,14 +15,21 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 """ Make tables describing a missed injection"""
-import h5py, argparse, pycbc.version, pycbc.results, sys
-import numpy, pycbc.pnutils
+import h5py
+import argparse
+import sys
+import numpy
+
+import pycbc.version
+import pycbc.results
+import pycbc.pnutils
+from pycbc import init_logging, add_common_pycbc_options
 from pycbc.detector import Detector
 
 parser = argparse.ArgumentParser()
+add_common_pycbc_options(parser)
 parser.add_argument('--version', action='version',
     version=pycbc.version.git_verbose_msg)
-parser.add_argument('--verbose', action='store_true')
 parser.add_argument('--output-file')
 parser.add_argument('--injection-file', required=True,
     help="The HDF format injection file. Required")
@@ -32,6 +39,8 @@ parser.add_argument('--n-nearest', type=int,
     help="Optional, used in the title")
 
 args = parser.parse_args()
+
+init_logging(args.verbose)
 
 f = h5py.File(args.injection_file, 'r')
 iidx = args.injection_index

--- a/bin/minifollowups/pycbc_page_snglinfo
+++ b/bin/minifollowups/pycbc_page_snglinfo
@@ -37,7 +37,6 @@ parser = argparse.ArgumentParser()
 add_common_pycbc_options(parser)
 parser.add_argument('--version', action='version',
     version=pycbc.version.git_verbose_msg)
-parser.add_argument('--verbose', action='store_true')
 parser.add_argument('--single-trigger-file', required=True,
     help="HDF format single detector trigger files for the full "
          "data run")

--- a/bin/minifollowups/pycbc_page_snglinfo
+++ b/bin/minifollowups/pycbc_page_snglinfo
@@ -16,16 +16,25 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 """ Make tables describing a sngl event"""
-import sys, h5py, matplotlib, numpy, datetime, argparse
+import sys
+import h5py
+import numpy
+import datetime
+import argparse
+import matplotlib
 matplotlib.use('Agg')
+
 import lal
+
 import pycbc.version, pycbc.events, pycbc.results, pycbc.pnutils
 from pycbc.results import followup
 from pycbc.events import stat as pystat
 from pycbc.io import hdf
+from pycbc import init_logging, add_common_pycbc_options
 
 
 parser = argparse.ArgumentParser()
+add_common_pycbc_options(parser)
 parser.add_argument('--version', action='version',
     version=pycbc.version.git_verbose_msg)
 parser.add_argument('--verbose', action='store_true')
@@ -68,7 +77,7 @@ pystat.insert_statistic_option_group(parser,
 
 args = parser.parse_args()
 
-pycbc.init_logging(args.verbose)
+init_logging(args.verbose)
 
 if args.trigger_id is not None:
     # Make a mask which is just the trigger of interest

--- a/bin/minifollowups/pycbc_plot_chigram
+++ b/bin/minifollowups/pycbc_plot_chigram
@@ -1,9 +1,18 @@
 #!/bin/env python
-import h5py, pycbc.types, numpy, argparse, pycbc.results, sys
-import matplotlib; matplotlib.use('Agg')
+import h5py
+import numpy
+import argparse
+import sys
+import matplotlib
+matplotlib.use('Agg')
 import pylab
 
+from pybc import init_logging, add_common_pycbc_options
+import pycbc.types
+import pycbc.results
+
 parser=argparse.ArgumentParser()
+add_common_pycbc_options(parser)
 parser.add_argument('--single-template-file',
                     help="HDF output of pycbc_single_template")
 parser.add_argument('--central-time', type=float,
@@ -15,6 +24,8 @@ parser.add_argument('--window', type=float,
 parser.add_argument('--plot-type', choices=['snr', 'chisq'], default='chisq')
 parser.add_argument('--output-file')
 args = parser.parse_args()
+
+init_logging(args.verbose)
 
 f = h5py.File(args.single_template_file, 'r')
 y = f['chisq_boundaries'][:]

--- a/bin/minifollowups/pycbc_plot_chigram
+++ b/bin/minifollowups/pycbc_plot_chigram
@@ -7,7 +7,7 @@ import matplotlib
 matplotlib.use('Agg')
 import pylab
 
-from pybc import init_logging, add_common_pycbc_options
+from pycbc import init_logging, add_common_pycbc_options
 import pycbc.types
 import pycbc.results
 

--- a/bin/minifollowups/pycbc_plot_trigger_timeseries
+++ b/bin/minifollowups/pycbc_plot_trigger_timeseries
@@ -16,18 +16,26 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 """ Plot the single detector trigger timeseries """
-import argparse, logging, pycbc.version, pycbc.results, sys
+import argparse
+import logging
+import sys
+import h5py
+import matplotlib
+matplotlib.use('Agg')
+import pylab
+import numpy
+
+from pycbc import init_logging, add_common_pycbc_options
+import pycbc.version
+import pycbc.results
 from pycbc.types import MultiDetOptionAction
 from pycbc.events import ranking
 from pycbc.io import HFile, SingleDetTriggers
-import h5py
-import matplotlib; matplotlib.use('Agg'); import pylab
-import numpy
 
 parser = argparse.ArgumentParser()
+add_common_pycbc_options(parser)
 parser.add_argument('--version', action='version',
     version=pycbc.version.git_verbose_msg)
-parser.add_argument('--verbose', action='store_true')
 parser.add_argument('--single-trigger-files', nargs='+',
     action=MultiDetOptionAction, metavar="IFO:FILE",
     help="The HDF format single detector merged trigger files, in "
@@ -48,7 +56,7 @@ parser.add_argument('--output-file')
 parser.add_argument('--log-y-axis', action='store_true')
 
 args = parser.parse_args()
-pycbc.init_logging(args.verbose)
+init_logging(args.verbose)
 
 any_data = False
 

--- a/bin/minifollowups/pycbc_single_template_plot
+++ b/bin/minifollowups/pycbc_single_template_plot
@@ -23,14 +23,14 @@ import numpy
 import matplotlib
 matplotlib.use('Agg')
 import pylab
+
 import pycbc.results
 from pycbc.events import ranking
 
-
 parser = argparse.ArgumentParser(description=__doc__)
+pycbc.add_common_pycbc_options(parser)
 parser.add_argument('--version', action='version',
     version=pycbc.version.git_verbose_msg)
-parser.add_argument('--verbose')
 parser.add_argument('--single-template-file', required=True,
     help="HDF file containing the SNR and CHISQ timeseries. "
          " The output of pycbc_single_template")

--- a/bin/minifollowups/pycbc_sngl_minifollowup
+++ b/bin/minifollowups/pycbc_sngl_minifollowup
@@ -17,10 +17,15 @@
 """
 Followup single-detector triggers which do not contribute to foreground events
 """
-import os, argparse, logging
+import os
+import argparse
+import logging
 import numpy
+
 from ligo.lw import table
 from ligo.lw import utils as ligolw_utils
+
+from pycbc import init_logging, add_common_pycbc_options
 from pycbc.results import layout
 from pycbc.types.optparse import MultiDetOptionAction
 from pycbc.events import select_segments_by_definer
@@ -33,6 +38,7 @@ from pycbc.events import stat, veto, coinc
 from pycbc.io import hdf
 
 parser = argparse.ArgumentParser(description=__doc__[1:])
+add_common_pycbc_options(parser)
 parser.add_argument('--version', action='version', version=pycbc.version.git_verbose_msg)
 parser.add_argument('--bank-file',
                     help="HDF format template bank file")
@@ -90,8 +96,9 @@ stat.insert_statistic_option_group(parser,
     default_ranking_statistic='single_ranking_only')
 args = parser.parse_args()
 
-logging.basicConfig(format='%(asctime)s:%(levelname)s : %(message)s',
-                    level=logging.INFO)
+# Default logging level is info: --verbose adds to this
+log_level = 1 if args.verbose is None else args.verbose + 1
+init_logging(log_level)
 
 workflow = wf.Workflow(args)
 workflow.ifos = [args.instrument]

--- a/bin/minifollowups/pycbc_upload_prep_minifollowup
+++ b/bin/minifollowups/pycbc_upload_prep_minifollowup
@@ -26,6 +26,7 @@ import numpy as np
 
 from ligo import segments
 
+from pycbc import init_logging, add_common_pycbc_options
 import pycbc.workflow as wf
 from pycbc.results import layout
 from pycbc.types import MultiDetOptionAction
@@ -36,9 +37,7 @@ from pycbc.workflow.core import resolve_url_to_file, resolve_td_option
 import pycbc.version
 
 parser = argparse.ArgumentParser(description=__doc__[1:])
-parser.add_argument('--verbose', action='count',
-                    help='Add progressively more verbose output, '
-                         'default=info')
+add_common_pycbc_options(parser)
 parser.add_argument('--version', action='version', version=pycbc.version.git_verbose_msg)
 parser.add_argument('--bank-file',
                     help="HDF format template bank file")
@@ -66,11 +65,9 @@ wf.add_workflow_command_line_group(parser)
 wf.add_workflow_settings_cli(parser, include_subdax_opts=True)
 args = parser.parse_args()
 
-if args.verbose:
-    args.verbose += 1
-else:
-    args.verbose = 1
-pycbc.init_logging(args.verbose)
+# Default logging level is info: --verbose adds to this
+log_level = 1 if args.verbose is None else args.verbose + 1
+init_logging(log_level)
 
 workflow = wf.Workflow(args)
 

--- a/bin/population/pycbc_multiifo_pastro
+++ b/bin/population/pycbc_multiifo_pastro
@@ -249,7 +249,7 @@ if args.diagnostic_plots:
 
 # add in prior event info
 if args.prior_event_info:
-    logging.warn('Adding events from', args.prior_event_info)
+    logging.warning('Adding events from', args.prior_event_info)
     prior_info = np.genfromtxt(args.prior_event_info, names=True)
     allfgbg = np.append(allfgbg, prior_info['ln_bayes_factor'])
 else:  # no prior events!
@@ -291,7 +291,7 @@ cmed, cminus, cplus = fgmc_plots.dist_summary(
 # if VT and error are provided, convert signal PDF to rate PDF
 if args.vt_mean:
     if args.vt_err is None:
-        logging.warn('NB : no VT error provided, will use 0!')
+        logging.warning('NB : no VT error provided, will use 0!')
         args.vt_err = 0.
     logging.info('Rate in units of ' + args.rate_units + ' ...')
     print('Rate without VT uncertainty :')

--- a/bin/population/pycbc_multiifo_pastro
+++ b/bin/population/pycbc_multiifo_pastro
@@ -18,7 +18,7 @@ use('Agg')
 from matplotlib import rcParams
 from matplotlib import pyplot as plt
 
-from pycbc import init_logging
+from pycbc import init_logging, add_common_pycbc_options
 from pycbc.population import fgmc_functions as utils
 from pycbc.population import fgmc_laguerre as fgmcl
 from pycbc.population import fgmc_plots
@@ -34,7 +34,7 @@ rcParams.update({'axes.labelsize': 12,
 
 
 parser = argparse.ArgumentParser()
-parser.add_argument('-V', '--verbose', action='store_true', default=False)
+add_common_pycbc_options(parser)
 parser.add_argument('--diagnostic-plots', action='store_true', default=False,
                     help='Make extra diagnostic scatter plots')
 parser.add_argument('--full-data-files', nargs='+',

--- a/bin/population/pycbc_population_plots
+++ b/bin/population/pycbc_population_plots
@@ -41,7 +41,7 @@ from pycbc.population import rates_functions as rf
 
 # Parse command line
 parser = argparse.ArgumentParser(
-    description="Plot rate prior and posteriors."
+    description=__doc__
 )
 pycbc.add_common_pycbc_options(parser)
 parser.add_argument('--prior-samples', required=True,

--- a/bin/population/pycbc_population_plots
+++ b/bin/population/pycbc_population_plots
@@ -27,19 +27,23 @@ __date__ = "31.10.2017"
 
 import logging
 import argparse
-import pycbc.version
-
-import h5py
-import pylab
-import numpy as np
-import scipy.stats as ss
-from matplotlib import cm
-from pycbc.population import rates_functions as rf
 from numpy import logaddexp, log, newaxis, expm1
+import h5py
+import numpy as np
+from matplotlib import cm
+import pylab
+
+import scipy.stats as ss
+
+import pycbc
+import pycbc.version
+from pycbc.population import rates_functions as rf
 
 # Parse command line
-parser = argparse.ArgumentParser(description=
-                                      "Plot rate prior and posteriors.")
+parser = argparse.ArgumentParser(
+    description="Plot rate prior and posteriors."
+)
+pycbc.add_common_pycbc_options(parser)
 parser.add_argument('--prior-samples', required=True,
                               help="File containing rate prior samples")
 parser.add_argument('--posterior-samples', nargs='+', required=True,
@@ -56,6 +60,8 @@ parser.add_argument('--plot-labels', nargs='+',
               required=True, help="Labels for the population models.")
 
 opts = parser.parse_args()
+pycbc.init_logging(opts.verbose)
+
 assert len(opts.posterior_samples) == len(opts.population_models), \
               "Unequal number of posterior files and population models!"
 

--- a/bin/population/pycbc_population_rates
+++ b/bin/population/pycbc_population_rates
@@ -17,6 +17,8 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 """
+Estimate rates for flat in log and power-law mass distribution.
+
 This script estimates black hole merger rates for astro-physical models:
 1) Uniform in log of the component mass
 2) Power-law distribution of the masses
@@ -32,19 +34,20 @@ __date__ = "31.10.2017"
 
 import logging
 import argparse
-import pycbc.version
-
 import h5py
 import numpy as np
 import scipy.stats as ss
+from numpy import logaddexp, log, newaxis, expm1
+
+import pycbc
 from pycbc.population import scale_injections as si
 from pycbc.population import rates_functions as rf
-from numpy import logaddexp, log, newaxis, expm1
+import pycbc.version
 
 
 # Parse command line
-parser = argparse.ArgumentParser(description="Estimate rates for flat in "
-                                     "log and power-law mass distribution.")
+parser = argparse.ArgumentParser(description=__doc__)
+pycbc.add_common_pycbc_options(parser)
 parser.add_argument('--sim-files', nargs='+', required=True, help="List of "
                         "simulation files to estimate the sensitive volume")
 parser.add_argument('--m_dist', nargs='+', required=True, help="Specify "
@@ -84,6 +87,9 @@ parser.add_argument('--calibration-error', dest='cal_err', type=float,
                                       " errors in measurement of distance.")
 
 opts = parser.parse_args()
+
+pycbc.init_logging(opts.verbose)
+
 path = opts.output_file
 
 assert opts.min_tmplt_mchirp < opts.max_tmplt_mchirp, \

--- a/bin/pycbc_banksim
+++ b/bin/pycbc_banksim
@@ -363,9 +363,9 @@ with ctx:
         if f_lower < options.filter_low_frequency_cutoff:
             # Not entirely clear what to do here?
             if not flow_warned:
-                logging.warn("Template's flower is smaller than "
-                             "--filter-low-frequency-cutoff. Raising flower "
-                             "of template to match.")
+                logging.warning("Template's flower is smaller than "
+                                "--filter-low-frequency-cutoff. Raising "
+                                "flower of template to match.")
                 flow_warned=True
             f_lower = options.filter_low_frequency_cutoff
 

--- a/bin/pycbc_banksim_skymax
+++ b/bin/pycbc_banksim_skymax
@@ -386,9 +386,9 @@ with ctx:
         if f_lower < options.filter_low_frequency_cutoff:
             # Not entirely clear what to do here?
             if not flow_warned:
-                logging.warn("Template's flower is smaller than "
-                             "--filter-low-frequency-cutoff. Raising flower "
-                             "of template to match.")
+                logging.warning("Template's flower is smaller than "
+                                "--filter-low-frequency-cutoff. Raising "
+                                "flower of template to match.")
                 flow_warned=True
             f_lower = options.filter_low_frequency_cutoff
 

--- a/bin/pycbc_fit_sngl_trigs
+++ b/bin/pycbc_fit_sngl_trigs
@@ -216,7 +216,7 @@ for ifo in opt.ifos:
 
     snr = sngls.get_column("snr")
     if not len(snr):
-        logging.warn("no trigs, skipping %s" % ifo)
+        logging.warning("no trigs, skipping %s", ifo)
         continue
     chisq = sngls.get_column("chisq")
     chisq_dof = sngls.get_column("chisq_dof")

--- a/bin/pycbc_make_banksim
+++ b/bin/pycbc_make_banksim
@@ -168,8 +168,10 @@ try:
     accounting_group = confs.get('workflow', 'accounting-group')
 except:
     accounting_group = None
-    logging.warn('Warning: accounting-group not specified, LDG clusters may'
-                 ' reject this workflow!')
+    logging.warning(
+        'Warning: accounting-group not specified, LDG clusters may '
+        'reject this workflow!'
+    )
 
 logging.info("Making workspace directories")
 mkdir('scripts')

--- a/bin/pycbc_make_faithsim
+++ b/bin/pycbc_make_faithsim
@@ -88,8 +88,10 @@ try:
     accounting_group = confs.get('workflow', 'accounting-group')
 except:
     accounting_group = None
-    logging.warn('Warning: accounting-group not specified, LDG clusters may'
-                 ' reject this workflow!')
+    logging.warning(
+        'Warning: accounting-group not specified, LDG clusters may '
+        'reject this workflow!'
+    )
 
 logging.info("Making workspace directories")
 mkdir('scripts')

--- a/bin/pycbc_optimal_snr
+++ b/bin/pycbc_optimal_snr
@@ -326,7 +326,7 @@ if __name__ == '__main__':
 
             iterator = tqdm(iterator, total=len(inj_table))
         except ImportError:
-            logging.warn('cannot import tqdm; not showing progress bar')
+            logging.warning('cannot import tqdm; not showing progress bar')
             pass
 
     for inj in iterator:

--- a/bin/pycbc_process_sngls
+++ b/bin/pycbc_process_sngls
@@ -109,8 +109,11 @@ if args.store_bank_values:
         if n == 'template_hash':
             continue
         if not hasattr(sngls, n):
-            logging.warn("Bank's %s dataset or group is not supported "
-                         "by SingleDetTriggers, ignoring it", n)
+            logging.warning(
+                "Bank's %s dataset or group is not supported "
+                "by SingleDetTriggers, ignoring it",
+                n
+            )
             continue
         # don't repeat things that already came from the trigger file
         # (e.g. template_duration)

--- a/pycbc/__init__.py
+++ b/pycbc/__init__.py
@@ -110,8 +110,8 @@ def init_logging(verbose=False,
             log_level = logging.WARN
         else:
             log_level = logging.DEBUG
-        logging.warn('Got signal %d, setting log level to %d',
-                     signum, log_level)
+        logging.warning('Got signal %d, setting log level to %d',
+                        signum, log_level)
         logger.setLevel(log_level)
 
     signal.signal(signal.SIGUSR1, sig_handler)

--- a/pycbc/catalog/__init__.py
+++ b/pycbc/catalog/__init__.py
@@ -25,8 +25,12 @@
 """ This package provides information about LIGO/Virgo detections of
 compact binary mergers
 """
+import logging
 import numpy
+
 from . import catalog
+
+logger = logging.getLogger('pycbc.catalog')
 
 _aliases = {}
 _aliases['mchirp'] = 'chirp_mass_source'

--- a/pycbc/catalog/catalog.py
+++ b/pycbc/catalog/catalog.py
@@ -25,8 +25,12 @@
 """ This modules contains information about the announced LIGO/Virgo
 compact binary mergers
 """
+import logging
 import json
+
 from pycbc.io import get_file
+
+logger = logging.getLogger('pycbc.catalog.catalog')
 
 # For the time being all quantities are the 1-d median value
 # FIXME with posteriors when available and we can just post-process that

--- a/pycbc/coordinates/base.py
+++ b/pycbc/coordinates/base.py
@@ -27,10 +27,11 @@
 Base coordinate transformations, this module provides transformations between
 cartesian and spherical coordinates.
 """
-import numpy
 import logging
+import numpy
 
 logger = logging.getLogger('pycbc.coordinates.base')
+
 
 def cartesian_to_spherical_rho(x, y, z):
     """ Calculates the magnitude in spherical coordinates from Cartesian

--- a/pycbc/coordinates/base.py
+++ b/pycbc/coordinates/base.py
@@ -28,7 +28,9 @@ Base coordinate transformations, this module provides transformations between
 cartesian and spherical coordinates.
 """
 import numpy
+import logging
 
+logger = logging.getLogger('pycbc.coordinates.base')
 
 def cartesian_to_spherical_rho(x, y, z):
     """ Calculates the magnitude in spherical coordinates from Cartesian

--- a/pycbc/coordinates/space.py
+++ b/pycbc/coordinates/space.py
@@ -29,7 +29,9 @@ is a circular orbit, need to be replaced by a more realistic and general orbit
 model in the near future.
 """
 
+import logging
 import numpy as np
+
 from scipy.spatial.transform import Rotation
 from scipy.optimize import fsolve
 from astropy import units
@@ -39,6 +41,8 @@ from astropy.coordinates import BarycentricMeanEcliptic, PrecessedGeocentric
 from astropy.coordinates import get_body_barycentric
 from astropy.coordinates import SkyCoord
 from astropy.coordinates.builtin_frames import ecliptic_transforms
+
+logger = logging.getLogger('pycbc.coordinates.space')
 
 # This constant makes sure LISA is behind the Earth by 19-23 degrees.
 # Making this a stand-alone constant will also make it callable by

--- a/pycbc/distributions/angular.py
+++ b/pycbc/distributions/angular.py
@@ -15,14 +15,16 @@
 """
 This modules provides classes for evaluating angular distributions.
 """
-
+import logging
 from configparser import Error
 import numpy
+
 from pycbc import VARARGS_DELIM
 from pycbc import boundaries
 from pycbc.distributions import bounded
 from pycbc.distributions import uniform
 
+logger = logging.getLogger('pycbc.distributions.angular')
 
 class UniformAngle(uniform.Uniform):
     """A uniform distribution in which the dependent variable is between

--- a/pycbc/distributions/angular.py
+++ b/pycbc/distributions/angular.py
@@ -26,6 +26,7 @@ from pycbc.distributions import uniform
 
 logger = logging.getLogger('pycbc.distributions.angular')
 
+
 class UniformAngle(uniform.Uniform):
     """A uniform distribution in which the dependent variable is between
     `[0,2pi)`.

--- a/pycbc/distributions/arbitrary.py
+++ b/pycbc/distributions/arbitrary.py
@@ -16,12 +16,15 @@
 This modules provides classes for evaluating arbitrary distributions from
 a file.
 """
-
+import logging
 import h5py
 import numpy
 import scipy.stats
+
 from pycbc.distributions import bounded
 import pycbc.transforms
+
+logger = logging.getLogger('pycbc.distributions.arbitrary')
 
 class Arbitrary(bounded.BoundedDist):
     r"""A distribution constructed from a set of parameter values using a kde.

--- a/pycbc/distributions/bounded.py
+++ b/pycbc/distributions/bounded.py
@@ -15,13 +15,15 @@
 """
 This modules provides classes for evaluating distributions with bounds.
 """
-
+import logging
 import warnings
 from configparser import Error
-
 import numpy
+
 from pycbc import boundaries
 from pycbc import VARARGS_DELIM
+
+logger = logging.getLogger('pycbc.distributions.bounded')
 
 #
 #   Distributions for priors

--- a/pycbc/distributions/constraints.py
+++ b/pycbc/distributions/constraints.py
@@ -15,14 +15,16 @@
 """
 This modules provides classes for evaluating multi-dimensional constraints.
 """
-
+import logging
 import re
 import scipy.spatial
 import numpy
 import h5py
+
 from pycbc import transforms
 from pycbc.io import record
 
+logger = logging.getLogger('pycbc.distributions.constraints')
 
 class Constraint(object):
     """Creates a constraint that evaluates to True if parameters obey

--- a/pycbc/distributions/constraints.py
+++ b/pycbc/distributions/constraints.py
@@ -26,6 +26,7 @@ from pycbc.io import record
 
 logger = logging.getLogger('pycbc.distributions.constraints')
 
+
 class Constraint(object):
     """Creates a constraint that evaluates to True if parameters obey
     the constraint and False if they do not.

--- a/pycbc/distributions/external.py
+++ b/pycbc/distributions/external.py
@@ -16,12 +16,16 @@
 This modules provides classes for evaluating PDF, logPDF, CDF and inverse CDF
 from external arbitrary distributions, and drawing samples from them.
 """
-
+import logging
 import importlib
 import numpy as np
+
 import scipy.integrate as scipy_integrate
 import scipy.interpolate as scipy_interpolate
+
 from pycbc import VARARGS_DELIM
+
+logger = logging.getLogger('pycbc.distributions.external')
 
 
 class External(object):

--- a/pycbc/distributions/fixedsamples.py
+++ b/pycbc/distributions/fixedsamples.py
@@ -19,7 +19,11 @@ set of points
 import logging
 import numpy
 import numpy.random
+
 from pycbc import VARARGS_DELIM
+
+logger = logging.getLogger('pycbc.distributions.fixedsamples')
+
 
 class FixedSamples(object):
     """
@@ -137,7 +141,7 @@ class FixedSamples(object):
             raise ValueError("Fixed sample distrubtion only supports a single"
                              " distribution to sample from.")
 
-        logging.info('Drawing samples for fixed sample distribution:%s', params)
+        logger.info('Drawing samples for fixed sample distribution:%s', params)
         samples = dist[0].rvs(size=int(float(size)))
         samples = {p: samples[p] for p in samples.dtype.names}
 

--- a/pycbc/distributions/gaussian.py
+++ b/pycbc/distributions/gaussian.py
@@ -15,11 +15,14 @@
 """
 This modules provides classes for evaluating Gaussian distributions.
 """
-
+import logging
 import numpy
 from scipy.special import erf, erfinv
 import scipy.stats
+
 from pycbc.distributions import bounded
+
+logger = logging.getLogger('pycbc.distributions.gaussian')
 
 class Gaussian(bounded.BoundedDist):
     r"""A Gaussian distribution on the given parameters; the parameters are

--- a/pycbc/distributions/joint.py
+++ b/pycbc/distributions/joint.py
@@ -16,7 +16,11 @@
 """
 import logging
 import numpy
+
 from pycbc.io.record import FieldArray
+
+logger = logging.getLogger('pycbc.distributions.joint')
+
 
 class JointDistribution(object):
     """
@@ -111,7 +115,7 @@ class JointDistribution(object):
         n_test_samples = kwargs["n_test_samples"] \
                              if "n_test_samples" in kwargs else int(1e6)
         if self._constraints:
-            logging.info("Renormalizing distribution for constraints")
+            logger.info("Renormalizing distribution for constraints")
 
             # draw samples
             samples = {}

--- a/pycbc/distributions/mass.py
+++ b/pycbc/distributions/mass.py
@@ -16,12 +16,16 @@
 """This modules provides classes for evaluating distributions for mchirp and
 q (i.e., mass ratio) from uniform component mass.
 """
-
+import logging
 import numpy
+
 from scipy.interpolate import interp1d
 from scipy.special import hyp2f1
+
 from pycbc.distributions import power_law
 from pycbc.distributions import bounded
+
+logger = logging.getLogger('pycbc.distributions.mass')
 
 
 class MchirpfromUniformMass1Mass2(power_law.UniformPowerLaw):

--- a/pycbc/distributions/power_law.py
+++ b/pycbc/distributions/power_law.py
@@ -16,9 +16,12 @@
 This modules provides classes for evaluating distributions where the
 probability density function is a power law.
 """
-
+import logging
 import numpy
+
 from pycbc.distributions import bounded
+
+logger = logging.getLogger('pycbc.distributions.power_law')
 
 class UniformPowerLaw(bounded.BoundedDist):
     r"""

--- a/pycbc/distributions/qnm.py
+++ b/pycbc/distributions/qnm.py
@@ -13,12 +13,16 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-
+import logging
 import re
 import numpy
+
 import pycbc
 from pycbc import conversions, boundaries
+
 from . import uniform, bounded
+
+logger = logging.getLogger('pycbc.distributions.qnm')
 
 
 class UniformF0Tau(uniform.Uniform):

--- a/pycbc/distributions/sky_location.py
+++ b/pycbc/distributions/sky_location.py
@@ -19,10 +19,14 @@ right ascension and declination.
 
 import logging
 import numpy
+
 from scipy.spatial.transform import Rotation
+
 from pycbc.distributions import angular
 from pycbc import VARARGS_DELIM
 from pycbc.io import FieldArray
+
+logger = logging.getLogger('pycbc.distributions.sky_location')
 
 
 class UniformSky(angular.UniformSolidAngle):
@@ -100,7 +104,7 @@ class FisherSky():
                 '(preferably much smaller)'
             )
         if sigma > 0.35:
-            logging.warning(
+            logger.warning(
                 'Warning: sigma = %s rad is probably too large for the '
                 'Fisher approximation to be valid', sigma
             )

--- a/pycbc/distributions/spins.py
+++ b/pycbc/distributions/spins.py
@@ -15,8 +15,9 @@
 """
 This modules provides spin distributions of CBCs.
 """
-
+import logging
 import numpy
+
 from pycbc import conversions
 from pycbc.distributions.uniform import Uniform
 from pycbc.distributions.angular import UniformAngle
@@ -24,6 +25,9 @@ from pycbc.distributions.power_law import UniformPowerLaw
 from pycbc.distributions.arbitrary import Arbitrary
 from pycbc.distributions.bounded import get_param_bounds_from_config, \
     VARARGS_DELIM, BoundedDist
+
+logger = logging.getLogger('pycbc.distributions.spins')
+
 
 class IndependentChiPChiEff(Arbitrary):
     r"""A distribution such that :math:`\chi_{\mathrm{eff}}` and

--- a/pycbc/distributions/uniform.py
+++ b/pycbc/distributions/uniform.py
@@ -15,9 +15,13 @@
 """
 This modules provides classes for evaluating uniform distributions.
 """
-
+import logging
 import numpy
+
 from pycbc.distributions import bounded
+
+logger = logging.getLogger('pycbc.distributions.uniform')
+
 
 class Uniform(bounded.BoundedDist):
     """

--- a/pycbc/distributions/uniform_log.py
+++ b/pycbc/distributions/uniform_log.py
@@ -15,9 +15,13 @@
 """ This modules provides classes for evaluating distributions whose logarithm
 are uniform.
 """
-
+import logging
 import numpy
+
 from pycbc.distributions import uniform
+
+logger = logging.getLogger('pycbc.distributions.uniform_log')
+
 
 class UniformLog10(uniform.Uniform):
     """ A uniform distribution on the log base 10 of the given parameters.

--- a/pycbc/distributions/utils.py
+++ b/pycbc/distributions/utils.py
@@ -25,11 +25,14 @@
 This module provides functions for drawing samples from a standalone .ini file
 in a Python script, rather than in the command line.
 """
-
+import logging
 import numpy as np
+
 from pycbc.types.config import InterpolatingConfigParser
 from pycbc import transforms
 from pycbc import distributions
+
+logger = logging.getLogger('pycbc.distributions.utils')
 
 
 def prior_from_config(cp, prior_section='prior'):

--- a/pycbc/frame/frame.py
+++ b/pycbc/frame/frame.py
@@ -26,12 +26,15 @@ import math
 import re
 from urllib.parse import urlparse
 import numpy
+
 import lalframe
 import lal
 from gwdatafind import find_urls as find_frame_urls
+
 import pycbc
 from pycbc.types import TimeSeries, zeros
 
+logger = logging.getLogger('pycbc.frame.frame')
 
 # map LAL series types to corresponding functions and Numpy types
 _fr_type_map = {
@@ -198,7 +201,7 @@ def read_frame(location, channels, start_time=None,
 
     cum_cache = locations_to_cache(locations)
     if sieve:
-        logging.info("Using frames that match regexp: %s", sieve)
+        logger.info("Using frames that match regexp: %s", sieve)
         lal.CacheSieve(cum_cache, 0, 0, None, None, sieve)
     if start_time is not None and end_time is not None:
         # Before sieving, check if this is sane. Otherwise it will fail later.
@@ -402,14 +405,14 @@ def query_and_read_frame(frame_type, channels, start_time, end_time,
         from pycbc.frame.gwosc import read_frame_gwosc
         return read_frame_gwosc(channels, start_time, end_time)
 
-    logging.info('Querying datafind server')
+    logger.info('Querying datafind server')
     paths = frame_paths(
         frame_type,
         int(start_time),
         int(numpy.ceil(end_time)),
         site=site
     )
-    logging.info('Found frame file paths: %s', ' '.join(paths))
+    logger.info('Found frame file paths: %s', ' '.join(paths))
     return read_frame(
         paths,
         channels,

--- a/pycbc/frame/gwosc.py
+++ b/pycbc/frame/gwosc.py
@@ -17,11 +17,14 @@
 This modules contains functions for getting data from the Gravitational Wave
 Open Science Center (GWOSC).
 """
+import logging
 import json
 from urllib.request import urlopen
+
 from pycbc.io import get_file
 from pycbc.frame import read_frame
 
+logger = logging.getLogger('pycbc.frame.gwosc')
 
 _GWOSC_URL = "https://www.gwosc.org/archive/links/%s/%s/%s/%s/json/"
 

--- a/pycbc/frame/store.py
+++ b/pycbc/frame/store.py
@@ -16,9 +16,13 @@
 """
 This modules contains functions for reading in data from hdf stores
 """
+import logging
 import h5py
 import numpy
+
 from pycbc.types import TimeSeries
+
+logger = logging.getLogger('pycbc.frame.store')
 
 
 def read_store(fname, channel, start_time, end_time):

--- a/pycbc/inference/io/base_hdf.py
+++ b/pycbc/inference/io/base_hdf.py
@@ -586,7 +586,10 @@ class BaseInferenceFile(h5py.File, metaclass=ABCMeta):
             with h5py.File(injection_file, "r") as fp:
                 super(BaseInferenceFile, self).copy(fp, group)
         except IOError:
-            logging.warn("Could not read %s as an HDF file", injection_file)
+            logging.warning(
+                "Could not read %s as an HDF file",
+                injection_file
+            )
 
     def read_injections(self, group=None):
         """Gets injection parameters.

--- a/pycbc/tmpltbank/coord_utils.py
+++ b/pycbc/tmpltbank/coord_utils.py
@@ -239,7 +239,7 @@ def get_random_mass(numPoints, massRangeParams, eos='2H'):
             warn_msg += "(%s). " %(max_ns_g_mass)
             warn_msg += "The code will proceed using the latter value "
             warn_msg += "as the boundary mass."
-            logger.warn(warn_msg)
+            logger.warning(warn_msg)
             boundary_mass = max_ns_g_mass
 
         # Empty arrays to store points that pass all cuts
@@ -715,7 +715,7 @@ def find_max_and_min_frequencies(name, mass_range_params, freqs):
         warn_msg += "for the metric: %s Hz. " %(freqs.min())
         warn_msg += "Distances for these waveforms will be calculated at "
         warn_msg += "the lowest available metric frequency."
-        logger.warn(warn_msg)
+        logger.warning(warn_msg)
     if upper_f_cutoff > freqs.max():
         warn_msg = "WARNING: "
         warn_msg += "Highest frequency cutoff is %s Hz " %(upper_f_cutoff,)
@@ -723,7 +723,7 @@ def find_max_and_min_frequencies(name, mass_range_params, freqs):
         warn_msg += "for the metric: %s Hz. " %(freqs.max())
         warn_msg += "Distances for these waveforms will be calculated at "
         warn_msg += "the largest available metric frequency."
-        logger.warn(warn_msg)
+        logger.warning(warn_msg)
     return find_closest_calculated_frequencies(cutoffs, freqs)
 
 

--- a/pycbc/tmpltbank/option_utils.py
+++ b/pycbc/tmpltbank/option_utils.py
@@ -928,7 +928,7 @@ class massRangeParameters(object):
             delta_ns_mass or self.default_delta_ns_mass)
         self.use_eos_max_ns_mass = use_eos_max_ns_mass
         if self.remnant_mass_threshold is not None:
-            if self.ns_eos is not '2H':
+            if self.ns_eos != '2H':
                 errMsg = """
                          By setting a value for --remnant-mass-threshold
                          you have asked to filter out EM dim NS-BH templates.

--- a/pycbc/tmpltbank/partitioned_bank.py
+++ b/pycbc/tmpltbank/partitioned_bank.py
@@ -527,7 +527,7 @@ class PartitionedTmpltbank(object):
                 warn_msg += "convention is that mass1 > mass2. Swapping mass1 "
                 warn_msg += "and mass2 and adding point to bank. This message "
                 warn_msg += "will not be repeated."
-                logger.warn(warn_msg)
+                logger.warning(warn_msg)
                 self.spin_warning_given = True
 
         # These that masses obey the restrictions of mass_range_params

--- a/pycbc/workflow/coincidence.py
+++ b/pycbc/workflow/coincidence.py
@@ -29,8 +29,12 @@ https://ldas-jobs.ligo.caltech.edu/~cbc/docs/pycbc/coincidence.html
 
 import os
 import logging
+
 from ligo import segments
+
 from pycbc.workflow.core import FileList, make_analysis_dir, Executable, Node, File
+
+logger = logging.getLogger('pycbc.workflow.coincidence')
 
 class PyCBCBank2HDFExecutable(Executable):
     """Converts xml tmpltbank to hdf format"""
@@ -385,7 +389,7 @@ def convert_bank_to_hdf(workflow, xmlbank, out_dir, tags=None):
     if len(xmlbank) > 1:
         raise ValueError('Can only convert a single template bank')
 
-    logging.info('convert template bank to HDF')
+    logger.info('convert template bank to HDF')
     make_analysis_dir(out_dir)
     bank2hdf_exe = PyCBCBank2HDFExecutable(workflow.cp, 'bank2hdf',
                                             ifos=workflow.ifos,
@@ -400,7 +404,7 @@ def convert_trig_to_hdf(workflow, hdfbank, xml_trigger_files, out_dir, tags=None
     if tags is None:
         tags = []
     #FIXME, make me not needed
-    logging.info('convert single inspiral trigger files to hdf5')
+    logger.info('convert single inspiral trigger files to hdf5')
     make_analysis_dir(out_dir)
 
     trig_files = FileList()
@@ -485,7 +489,7 @@ def setup_interval_coinc_inj(workflow, hdfbank,
     if tags is None:
         tags = []
     make_analysis_dir(out_dir)
-    logging.info('Setting up coincidence for injections')
+    logger.info('Setting up coincidence for injections')
 
     # Wall time knob and memory knob
     factor = int(workflow.cp.get_opt_tags('workflow-coincidence',
@@ -517,7 +521,7 @@ def setup_interval_coinc_inj(workflow, hdfbank,
         bg_files += coinc_node.output_files
         workflow.add_node(coinc_node)
 
-    logging.info('...leaving coincidence for injections')
+    logger.info('...leaving coincidence for injections')
 
     return setup_statmap_inj(workflow, ifiles.keys(), bg_files,
                              background_file, out_dir,
@@ -533,7 +537,7 @@ def setup_interval_coinc(workflow, hdfbank, trig_files, stat_files,
     if tags is None:
         tags = []
     make_analysis_dir(out_dir)
-    logging.info('Setting up coincidence')
+    logger.info('Setting up coincidence')
 
     ifos, _ = trig_files.categorize_by_attr('ifo')
     findcoinc_exe = PyCBCFindCoincExecutable(workflow.cp, 'coinc',
@@ -562,7 +566,7 @@ def setup_interval_coinc(workflow, hdfbank, trig_files, stat_files,
     statmap_files = setup_statmap(workflow, ifos, bg_files,
                                   out_dir, tags=tags)
 
-    logging.info('...leaving coincidence ')
+    logger.info('...leaving coincidence ')
     return statmap_files
 
 
@@ -594,7 +598,7 @@ def setup_sngls(workflow, hdfbank, trig_files, stat_files,
     statmap_files = setup_sngls_statmap(workflow, ifos[0], bg_files,
                                         out_dir, tags=tags)
 
-    logging.info('...leaving coincidence ')
+    logger.info('...leaving coincidence ')
     return statmap_files
 
 
@@ -630,7 +634,7 @@ def setup_sngls_inj(workflow, hdfbank, inj_trig_files,
                                             background_file,
                                             out_dir, tags=tags)
 
-    logging.info('...leaving coincidence ')
+    logger.info('...leaving coincidence ')
     return statmap_files
 
 
@@ -673,7 +677,7 @@ def setup_combine_statmap(workflow, final_bg_file_list, bg_file_list,
     if tags is None:
         tags = []
     make_analysis_dir(out_dir)
-    logging.info('Setting up combine statmap')
+    logger.info('Setting up combine statmap')
 
     cstat_exe_name = os.path.basename(workflow.cp.get("executables",
                                                       "combine_statmap"))
@@ -707,7 +711,7 @@ def setup_exclude_zerolag(workflow, statmap_file, other_statmap_files,
     if tags is None:
         tags = []
     make_analysis_dir(out_dir)
-    logging.info('Setting up exclude zerolag')
+    logger.info('Setting up exclude zerolag')
 
     exc_zerolag_exe = PyCBCExcludeZerolag(workflow.cp, 'exclude_zerolag',
                                           ifos=ifos, tags=tags,
@@ -729,10 +733,10 @@ def rerank_coinc_followup(workflow, statmap_file, bank_file, out_dir,
     make_analysis_dir(out_dir)
 
     if not workflow.cp.has_section("workflow-rerank"):
-        logging.info("No reranking done in this workflow")
+        logger.info("No reranking done in this workflow")
         return statmap_file
     else:
-        logging.info("Setting up reranking of candidates")
+        logger.info("Setting up reranking of candidates")
 
     # Generate reduced data files (maybe this could also be used elsewhere?)
     stores = FileList([])

--- a/pycbc/workflow/configuration.py
+++ b/pycbc/workflow/configuration.py
@@ -38,6 +38,8 @@ from urllib.parse import urlparse
 
 from pycbc.types.config import InterpolatingConfigParser
 
+logger = logging.getLogger('pycbc.workflow.configuration')
+
 # NOTE urllib is weird. For some reason it only allows known schemes and will
 # give *wrong* results, rather then failing, if you use something like gsiftp
 # We can add schemes explicitly, as below, but be careful with this!
@@ -90,7 +92,7 @@ def resolve_url(url, directory=None, permissions=None, copy_to_cwd=True):
         import ciecplib
         # Make the scitokens logger a little quieter
         # (it is called through ciecpclib)
-        logging.getLogger('scitokens').setLevel(logging.root.level + 10)
+        logging.getLogger('scitokens').setLevel(logger.level + 10)
         with ciecplib.Session() as s:
             if u.netloc in ("git.ligo.org", "code.pycbc.phy.syr.edu"):
                 # authenticate with git.ligo.org using callback

--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -61,6 +61,7 @@ from .pegasus_sites import make_catalog
 
 logger = logging.getLogger('pycbc.workflow.core')
 
+
 def make_analysis_dir(path):
     """
     Make the analysis directory path, any parent directories that don't already

--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -500,7 +500,7 @@ class Executable(pegasus_workflow.Executable):
             msg="Cannot find file-retention-level in [workflow] section "
             msg+="of the configuration file. Setting a default value of "
             msg+="retain all files."
-            logger.warn(msg)
+            logger.warning(msg)
             self.retain_files = True
             self.global_retention_threshold = 1
             self.cp.set("workflow", "file-retention-level", "all_files")
@@ -531,7 +531,7 @@ class Executable(pegasus_workflow.Executable):
                     warn_msg += "been set in class {0}. ".format(type(self))
                     warn_msg += "This value should be set explicitly. "
                     warn_msg += "All output from this class will be stored."
-                    logger.warn(warn_msg)
+                    logger.warning(warn_msg)
                     Executable._warned_classes_list.append(type(self).__name__)
             elif self.global_retention_threshold > self.current_retention_level:
                 self.retain_files = False
@@ -554,7 +554,7 @@ class Executable(pegasus_workflow.Executable):
         if tags is None:
             tags = []
         if '' in tags:
-            logger.warn('DO NOT GIVE ME EMPTY TAGS (in %s)', self.name)
+            logger.warning('DO NOT GIVE ME EMPTY TAGS (in %s)', self.name)
             tags.remove('')
         tags = [tag.upper() for tag in tags]
         self.tags = tags
@@ -563,7 +563,7 @@ class Executable(pegasus_workflow.Executable):
             warn_msg = "This job has way too many tags. "
             warn_msg += "Current tags are {}. ".format(' '.join(tags))
             warn_msg += "Current executable {}.".format(self.name)
-            logger.info(warn_msg)
+            logger.warning(warn_msg)
 
         if len(tags) != 0:
             self.tagged_name = "{0}-{1}".format(self.name, '_'.join(tags))
@@ -609,7 +609,7 @@ class Executable(pegasus_workflow.Executable):
             else:
                 warn_string = "warning: config file is missing section "
                 warn_string += "[{0}]".format(sec)
-                logger.warn(warn_string)
+                logger.warning(warn_string)
 
         # get uppermost section
         if self.cp.has_section(f'{self.name}-defaultvalues'):
@@ -1166,7 +1166,7 @@ class File(pegasus_workflow.File):
         if tags is None:
             tags = []
         if '' in tags:
-            logger.warn('DO NOT GIVE EMPTY TAGS (from %s)', exe_name)
+            logger.warning('DO NOT GIVE EMPTY TAGS (from %s)', exe_name)
             tags.remove('')
         self.tags = tags
 
@@ -1846,7 +1846,7 @@ class SegFile(File):
                         # Setting valid segment now is hard!
                         warn_msg = "No information with which to set valid "
                         warn_msg += "segment."
-                        logger.warn(warn_msg)
+                        logger.warning(warn_msg)
                         valid_segment = segments.segment([0,1])
         instnc = cls(ifo_list, description, valid_segment,
                      segment_dict=segmentlistdict, seg_summ_dict=seg_summ_dict,

--- a/pycbc/workflow/datafind.py
+++ b/pycbc/workflow/datafind.py
@@ -832,7 +832,7 @@ def get_missing_segs_from_frame_file_cache(datafindcaches):
             if not cache[0].scheme == 'file':
                 warn_msg = "We have %s entries in the " %(cache[0].scheme,)
                 warn_msg += "cache file. I do not check if these exist."
-                logger.info(warn_msg)
+                logger.warning(warn_msg)
                 continue
             _, currMissingFrames = cache.checkfilesexist(on_missing="warn")
             missingSegs = segments.segmentlist(e.segment \
@@ -1042,7 +1042,7 @@ def log_datafind_command(observatory, frameType, startTime, endTime,
         else:
             errMsg = "Unknown datafind kwarg given: %s. " %(name)
             errMsg+= "This argument is stripped in the logged .sh command."
-            logger.warn(errMsg)
+            logger.warning(errMsg)
 
     fileName = "%s-%s-%d-%d.sh" \
                %(observatory, frameType, startTime, endTime-startTime)

--- a/pycbc/workflow/dq.py
+++ b/pycbc/workflow/dq.py
@@ -25,6 +25,8 @@
 import logging
 from pycbc.workflow.core import (FileList, Executable, Node, make_analysis_dir)
 
+logger = logging.getLogger('pycbc.workflow.dq')
+
 
 class PyCBCBinTemplatesDQExecutable(Executable):
     current_retention_level = Executable.MERGED_TRIGGERS
@@ -61,7 +63,7 @@ def setup_dq_reranking(workflow, insps, bank,
                        analyzable_name,
                        dq_seg_file,
                        output_dir=None, tags=None):
-    logging.info("Setting up dq reranking")
+    logger.info("Setting up dq reranking")
     make_analysis_dir(output_dir)
     output_files = FileList()
     output_labels = []
@@ -135,5 +137,5 @@ def setup_dq_reranking(workflow, insps, bank,
         output_files += bin_triggers_node.output_files
         output_labels += [dq_label]
 
-    logging.info("Finished setting up dq reranking")
+    logger.info("Finished setting up dq reranking")
     return output_files, output_labels

--- a/pycbc/workflow/grb_utils.py
+++ b/pycbc/workflow/grb_utils.py
@@ -30,9 +30,11 @@ http://pycbc.org/pycbc/latest/html/workflow.html
 
 import glob
 import os
+import logging
 import numpy as np
 from scipy.stats import rayleigh
 from gwdatafind.utils import filename_metadata
+
 from pycbc import makedir
 from pycbc.workflow.core import \
     File, FileList, configparser_value_to_file, resolve_url_to_file,\
@@ -40,6 +42,8 @@ from pycbc.workflow.core import \
 from pycbc.workflow.jobsetup import select_generic_executable
 from pycbc.workflow.pegasus_workflow import SubWorkflow
 from pycbc.workflow.plotting import PlotExecutable
+
+logger = logging.getLogger('pycbc.workflow.grb_utils')
 
 
 def _select_grb_pp_class(wflow, curr_exe):

--- a/pycbc/workflow/inference_followups.py
+++ b/pycbc/workflow/inference_followups.py
@@ -16,9 +16,13 @@
 """
 Module that contains functions for setting up the inference workflow.
 """
+import logging
+
 from pycbc.workflow.core import (Executable, makedir)
 from pycbc.workflow.plotting import PlotExecutable
 from pycbc.results import layout
+
+logger = logging.getLogger('pycbc.workflow.inference_followups')
 
 
 def make_inference_plot(workflow, input_file, output_dir,

--- a/pycbc/workflow/injection.py
+++ b/pycbc/workflow/injection.py
@@ -32,10 +32,13 @@ https://ldas-jobs.ligo.caltech.edu/~cbc/docs/pycbc/NOTYETCREATED.html
 import logging
 import os.path
 import configparser as ConfigParser
+
 from pycbc.workflow.core import FileList, make_analysis_dir, Node
 from pycbc.workflow.core import Executable, resolve_url_to_file
 from pycbc.workflow.jobsetup import (LalappsInspinjExecutable,
         PycbcCreateInjectionsExecutable, select_generic_executable)
+
+logger = logging.getLogger('pycbc.workflow.injection')
 
 def veto_injections(workflow, inj_file, veto_file, veto_name, out_dir, tags=None):
     tags = [] if tags is None else tags
@@ -90,7 +93,7 @@ def compute_inj_optimal_snr(workflow, inj_file, precalc_psd_files, out_dir,
                                               'parallelization-factor',
                                               tags))
     except Exception as e:
-        logging.warning(e)
+        logger.warning(e)
         factor = 1
 
     if factor == 1:
@@ -196,7 +199,7 @@ def setup_injection_workflow(workflow, output_dir=None,
     """
     if tags is None:
         tags = []
-    logging.info("Entering injection module.")
+    logger.info("Entering injection module.")
     make_analysis_dir(output_dir)
 
     # Get full analysis segment for output file naming
@@ -254,5 +257,5 @@ def setup_injection_workflow(workflow, output_dir=None,
 
         inj_tags.append(inj_tag)
 
-    logging.info("Leaving injection module.")
+    logger.info("Leaving injection module.")
     return inj_files, inj_tags

--- a/pycbc/workflow/matched_filter.py
+++ b/pycbc/workflow/matched_filter.py
@@ -29,12 +29,17 @@ https://ldas-jobs.ligo.caltech.edu/~cbc/docs/pycbc/NOTYETCREATED.html
 """
 
 
-import os, logging
+import os
+import logging
 from math import radians
+
 from pycbc.workflow.core import FileList, make_analysis_dir
 from pycbc.workflow.jobsetup import (select_matchedfilter_class,
                                      sngl_ifo_job_setup,
                                      multi_ifo_coherent_job_setup)
+
+logger = logging.getLogger('pycbc.workflow.matched_filter')
+
 
 def setup_matchedfltr_workflow(workflow, science_segs, datafind_outs,
                                tmplt_banks, output_dir=None,
@@ -80,7 +85,7 @@ def setup_matchedfltr_workflow(workflow, science_segs, datafind_outs,
     '''
     if tags is None:
         tags = []
-    logging.info("Entering matched-filtering setup module.")
+    logger.info("Entering matched-filtering setup module.")
     make_analysis_dir(output_dir)
     cp = workflow.cp
 
@@ -90,13 +95,13 @@ def setup_matchedfltr_workflow(workflow, science_segs, datafind_outs,
 
     # Could have a number of choices here
     if mfltrMethod == "WORKFLOW_INDEPENDENT_IFOS":
-        logging.info("Adding matched-filter jobs to workflow.")
+        logger.info("Adding matched-filter jobs to workflow.")
         inspiral_outs = setup_matchedfltr_dax_generated(workflow, science_segs,
                                       datafind_outs, tmplt_banks, output_dir,
                                       injection_file=injection_file,
                                       tags=tags)
     elif mfltrMethod == "WORKFLOW_MULTIPLE_IFOS":
-        logging.info("Adding matched-filter jobs to workflow.")
+        logger.info("Adding matched-filter jobs to workflow.")
         inspiral_outs = setup_matchedfltr_dax_generated_multi(workflow,
                                       science_segs, datafind_outs, tmplt_banks,
                                       output_dir, injection_file=injection_file,
@@ -106,7 +111,7 @@ def setup_matchedfltr_workflow(workflow, science_segs, datafind_outs,
         errMsg += "WORKFLOW_INDEPENDENT_IFOS or WORKFLOW_MULTIPLE_IFOS."
         raise ValueError(errMsg)
 
-    logging.info("Leaving matched-filtering setup module.")
+    logger.info("Leaving matched-filtering setup module.")
     return inspiral_outs
 
 def setup_matchedfltr_dax_generated(workflow, science_segs, datafind_outs,
@@ -169,7 +174,7 @@ def setup_matchedfltr_dax_generated(workflow, science_segs, datafind_outs,
     # If we want to use multi-detector matched-filtering or something similar to this
     # it would probably require a new module
     for ifo in ifos:
-        logging.info("Setting up matched-filtering for %s." %(ifo))
+        logger.info("Setting up matched-filtering for %s.", ifo)
         job_instance = exe_class(workflow.cp, 'inspiral', ifo=ifo,
                                                out_dir=output_dir,
                                                injection_file=injection_file,
@@ -234,7 +239,7 @@ def setup_matchedfltr_dax_generated_multi(workflow, science_segs, datafind_outs,
     # List for holding the output
     inspiral_outs = FileList([])
 
-    logging.info("Setting up matched-filtering for %s." %(' '.join(ifos),))
+    logger.info("Setting up matched-filtering for %s.", ' '.join(ifos))
 
     if match_fltr_exe == 'pycbc_multi_inspiral':
         exe_class = select_matchedfilter_class(match_fltr_exe)
@@ -268,8 +273,10 @@ def setup_matchedfltr_dax_generated_multi(workflow, science_segs, datafind_outs,
                                  tags=tags)
         if cp.has_option("workflow", "do-long-slides") and "slide" in tags[-1]:
             slide_num = int(tags[-1].replace("slide", ""))
-            logging.info("Setting up matched-filtering for slide {}"
-                         .format(slide_num))
+            logger.info(
+                "Setting up matched-filtering for slide %d",
+                slide_num
+            )
             slide_shift = int(cp.get("inspiral", "segment-length"))
             time_slide_dict = {ifo: (slide_num + 1) * ix * slide_shift
                                for ix, ifo in enumerate(ifos)}

--- a/pycbc/workflow/minifollowups.py
+++ b/pycbc/workflow/minifollowups.py
@@ -14,8 +14,11 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-import logging, os.path
+import logging
+import os.path
+
 from ligo import segments
+
 from pycbc.events import coinc
 from pycbc.workflow.core import Executable, FileList
 from pycbc.workflow.core import makedir, resolve_url_to_file
@@ -27,6 +30,8 @@ except ImportError:
     # Python 2
     from itertools import izip_longest as zip_longest
 from pycbc.workflow.pegasus_workflow import SubWorkflow
+
+logger = logging.getLogger('pycbc.workflow.minifollowups')
 
 def grouper(iterable, n, fillvalue=None):
     """ Create a list of n length tuples
@@ -71,11 +76,13 @@ def setup_foreground_minifollowups(workflow, coinc_file, single_triggers,
         A list of tuples which specify the displayed file layout for the
         minifollops plots.
     """
-    logging.info('Entering minifollowups module')
+    logger.info('Entering minifollowups module')
 
     if not workflow.cp.has_section('workflow-minifollowups'):
-        logging.info('There is no [workflow-minifollowups] section in configuration file')
-        logging.info('Leaving minifollowups')
+        msg = 'There is no [workflow-minifollowups] section in '
+        msg += 'configuration file'
+        logger.info(msg)
+        logger.info('Leaving minifollowups')
         return
 
     tags = [] if tags is None else tags
@@ -125,7 +132,7 @@ def setup_foreground_minifollowups(workflow, coinc_file, single_triggers,
                                    staging_site=workflow.staging_site,
                                    cache_file=workflow.cache_file)
     job.add_into_workflow(workflow)
-    logging.info('Leaving minifollowups module')
+    logger.info('Leaving minifollowups module')
 
 def setup_single_det_minifollowups(workflow, single_trig_file, tmpltbank_file,
                                    insp_segs, insp_data_name, insp_anal_name,
@@ -163,13 +170,13 @@ def setup_single_det_minifollowups(workflow, single_trig_file, tmpltbank_file,
         A list of tuples which specify the displayed file layout for the
         minifollops plots.
     """
-    logging.info('Entering minifollowups module')
+    logger.info('Entering minifollowups module')
 
     if not workflow.cp.has_section('workflow-sngl_minifollowups'):
         msg = 'There is no [workflow-sngl_minifollowups] section in '
         msg += 'configuration file'
-        logging.info(msg)
-        logging.info('Leaving minifollowups')
+        logger.info(msg)
+        logger.info('Leaving minifollowups')
         return
 
     tags = [] if tags is None else tags
@@ -233,7 +240,7 @@ def setup_single_det_minifollowups(workflow, single_trig_file, tmpltbank_file,
                                    staging_site=workflow.staging_site,
                                    cache_file=workflow.cache_file)
     job.add_into_workflow(workflow)
-    logging.info('Leaving minifollowups module')
+    logger.info('Leaving minifollowups module')
 
 
 def setup_injection_minifollowups(workflow, injection_file, inj_xml_file,
@@ -269,11 +276,13 @@ def setup_injection_minifollowups(workflow, injection_file, inj_xml_file,
         A list of tuples which specify the displayed file layout for the
         minifollops plots.
     """
-    logging.info('Entering injection minifollowups module')
+    logger.info('Entering injection minifollowups module')
 
     if not workflow.cp.has_section('workflow-injection_minifollowups'):
-        logging.info('There is no [workflow-injection_minifollowups] section in configuration file')
-        logging.info('Leaving minifollowups')
+        msg = 'There is no [workflow-injection_minifollowups] section in '
+        msg += 'configuration file'
+        logger.info(msg)
+        logger.info('Leaving minifollowups')
         return
 
     tags = [] if tags is None else tags
@@ -322,7 +331,7 @@ def setup_injection_minifollowups(workflow, injection_file, inj_xml_file,
                                    cache_file=workflow.cache_file)
     job.add_into_workflow(workflow)
 
-    logging.info('Leaving injection minifollowups module')
+    logger.info('Leaving injection minifollowups module')
 
 
 class SingleTemplateExecutable(PlotExecutable):
@@ -1179,11 +1188,13 @@ def setup_upload_prep_minifollowups(workflow, coinc_file, xml_all_file,
         A list of tuples which specify the displayed file layout for the
         minifollowups plots.
     """
-    logging.info('Entering minifollowups module')
+    logger.info('Entering minifollowups module')
 
     if not workflow.cp.has_section('workflow-minifollowups'):
-        logging.info('There is no [workflow-minifollowups] section in configuration file')
-        logging.info('Leaving minifollowups')
+        msg = 'There is no [workflow-minifollowups] section in '
+        msg += 'configuration file'
+        logger.info(msg)
+        logger.info('Leaving minifollowups')
         return
 
     tags = [] if tags is None else tags
@@ -1237,4 +1248,4 @@ def setup_upload_prep_minifollowups(workflow, coinc_file, xml_all_file,
                                    staging_site=workflow.staging_site,
                                    cache_file=workflow.cache_file)
     job.add_into_workflow(workflow)
-    logging.info('Leaving minifollowups module')
+    logger.info('Leaving minifollowups module')

--- a/pycbc/workflow/pegasus_sites.py
+++ b/pycbc/workflow/pegasus_sites.py
@@ -12,16 +12,20 @@ most use cases. You can override individual details here. It should also be
 possible to implement a new site, but not sure how that would work in practice.
 """
 
+import logging
 import os.path
 import tempfile
 import urllib.parse
 from shutil import which
 from urllib.parse import urljoin
 from urllib.request import pathname2url
+
 from Pegasus.api import Directory, FileServer, Site, Operation, Namespace
 from Pegasus.api import Arch, OS, SiteCatalog
 
 from pycbc.version import last_release, version, release  # noqa
+
+logger = logging.getLogger('pycbc.workflow.pegasus_sites')
 
 if release == 'True':
     sing_version = version

--- a/pycbc/workflow/pegasus_workflow.py
+++ b/pycbc/workflow/pegasus_workflow.py
@@ -35,7 +35,10 @@ import warnings
 from packaging import version
 from urllib.request import pathname2url
 from urllib.parse import urljoin, urlsplit
+
 import Pegasus.api as dax
+
+logger = logging.getLogger('pycbc.workflow.pegasus_workflow')
 
 PEGASUS_FILE_DIRECTORY = os.path.join(os.path.dirname(__file__),
                                       'pegasus_files')
@@ -323,7 +326,7 @@ class Workflow(object):
 
         # Get the logger associated with the Pegasus workflow import
         pegasus_logger = logging.getLogger('Pegasus')
-        pegasus_logger.setLevel(logging.root.level + 10)
+        pegasus_logger.setLevel(logger.level + 10)
         self.name = name
         self._rc = dax.ReplicaCatalog()
         self._tc = dax.TransformationCatalog()

--- a/pycbc/workflow/plotting.py
+++ b/pycbc/workflow/plotting.py
@@ -25,9 +25,14 @@
 This module is responsible for setting up plotting jobs.
 https://ldas-jobs.ligo.caltech.edu/~cbc/docs/pycbc/NOTYETCREATED.html
 """
+
+import logging
 from urllib.request import pathname2url
 from urllib.parse import urljoin
+
 from pycbc.workflow.core import File, FileList, makedir, Executable
+
+logger = logging.getLogger('pycbc.workflow.plotting')
 
 
 def excludestr(tags, substr):

--- a/pycbc/workflow/psd.py
+++ b/pycbc/workflow/psd.py
@@ -17,9 +17,15 @@
 """This module is responsible for setting up PSD-related jobs in workflows.
 """
 
+import logging
+
+from ligo.segments import segmentlist
+
 from pycbc.workflow.core import FileList, make_analysis_dir, Executable
 from pycbc.workflow.core import SegFile
-from ligo.segments import segmentlist
+
+logger = logging.getLogger('pycbc.workflow.psd')
+
 
 class CalcPSDExecutable(Executable):
     current_retention_level = Executable.ALL_TRIGGERS

--- a/pycbc/workflow/psdfiles.py
+++ b/pycbc/workflow/psdfiles.py
@@ -31,8 +31,11 @@ workflows.
 
 import logging
 import configparser as ConfigParser
+
 from pycbc.workflow.core import FileList
 from pycbc.workflow.core import make_analysis_dir, resolve_url_to_file
+
+logger = logging.getLogger('pycbc.workflow.psdfiles')
 
 def setup_psd_workflow(workflow, science_segs, datafind_outs,
                              output_dir=None, tags=None):
@@ -62,7 +65,7 @@ def setup_psd_workflow(workflow, science_segs, datafind_outs,
     '''
     if tags is None:
         tags = []
-    logging.info("Entering static psd module.")
+    logger.info("Entering static psd module.")
     make_analysis_dir(output_dir)
     cp = workflow.cp
 
@@ -76,14 +79,14 @@ def setup_psd_workflow(workflow, science_segs, datafind_outs,
         return FileList([])
 
     if psdMethod == "PREGENERATED_FILE":
-        logging.info("Setting psd from pre-generated file(s).")
+        logger.info("Setting psd from pre-generated file(s).")
         psd_files = setup_psd_pregenerated(workflow, tags=tags)
     else:
         errMsg = "PSD method not recognized. Only "
         errMsg += "PREGENERATED_FILE is currently supported."
         raise ValueError(errMsg)
 
-    logging.info("Leaving psd module.")
+    logger.info("Leaving psd module.")
     return psd_files
 
 
@@ -136,7 +139,7 @@ def setup_psd_pregenerated(workflow, tags=None):
             except ConfigParser.Error:
                 # It's unlikely, but not impossible, that only some ifos
                 # will have pregenerated PSDs
-                logging.warn("No psd file specified for IFO %s." % (ifo,))
+                logger.warn("No psd file specified for IFO %s.", ifo)
                 pass
 
     return psd_files

--- a/pycbc/workflow/psdfiles.py
+++ b/pycbc/workflow/psdfiles.py
@@ -139,7 +139,7 @@ def setup_psd_pregenerated(workflow, tags=None):
             except ConfigParser.Error:
                 # It's unlikely, but not impossible, that only some ifos
                 # will have pregenerated PSDs
-                logger.warn("No psd file specified for IFO %s.", ifo)
+                logger.warning("No psd file specified for IFO %s.", ifo)
                 pass
 
     return psd_files

--- a/pycbc/workflow/splittable.py
+++ b/pycbc/workflow/splittable.py
@@ -30,10 +30,13 @@ https://ldas-jobs.ligo.caltech.edu/~cbc/docs/pycbc/NOTYETCREATED.html
 
 import os
 import logging
+
 from pycbc.workflow.core import FileList, make_analysis_dir
 from pycbc.workflow.jobsetup import (PycbcSplitBankExecutable,
         PycbcSplitBankXmlExecutable, PycbcSplitInspinjExecutable,
         PycbcHDFSplitInjExecutable)
+
+logger = logging.getLogger('pycbc.workflow.splittable')
 
 def select_splitfilejob_instance(curr_exe):
     """
@@ -95,7 +98,7 @@ def setup_splittable_workflow(workflow, input_tables, out_dir=None, tags=None):
     '''
     if tags is None:
         tags = []
-    logging.info("Entering split output files module.")
+    logger.info("Entering split output files module.")
     make_analysis_dir(out_dir)
     # Parse for options in .ini file
     splitMethod = workflow.cp.get_opt_tags("workflow-splittable",
@@ -103,7 +106,7 @@ def setup_splittable_workflow(workflow, input_tables, out_dir=None, tags=None):
 
     if splitMethod == "IN_WORKFLOW":
         # Scope here for choosing different options
-        logging.info("Adding split output file jobs to workflow.")
+        logger.info("Adding split output file jobs to workflow.")
         split_table_outs = setup_splittable_dax_generated(workflow,
                 input_tables, out_dir, tags)
     elif splitMethod == "NOOP":
@@ -115,7 +118,7 @@ def setup_splittable_workflow(workflow, input_tables, out_dir=None, tags=None):
         errMsg += "IN_WORKFLOW or NOOP."
         raise ValueError(errMsg)
 
-    logging.info("Leaving split output files module.")
+    logger.info("Leaving split output files module.")
     return split_table_outs
 
 def setup_splittable_dax_generated(workflow, input_tables, out_dir, tags):

--- a/pycbc/workflow/tmpltbank.py
+++ b/pycbc/workflow/tmpltbank.py
@@ -32,10 +32,14 @@ https://ldas-jobs.ligo.caltech.edu/~cbc/docs/pycbc/ahope/template_bank.html
 import os
 import logging
 import configparser as ConfigParser
+
 import pycbc
 from pycbc.workflow.core import FileList
 from pycbc.workflow.core import make_analysis_dir, resolve_url_to_file
 from pycbc.workflow.jobsetup import select_tmpltbank_class, sngl_ifo_job_setup
+
+logger = logging.getLogger('pycbc.workflow.tmpltbank')
+
 
 def setup_tmpltbank_workflow(workflow, science_segs, datafind_outs,
                              output_dir=None, psd_files=None, tags=None,
@@ -69,7 +73,7 @@ def setup_tmpltbank_workflow(workflow, science_segs, datafind_outs,
     '''
     if tags is None:
         tags = []
-    logging.info("Entering template bank generation module.")
+    logger.info("Entering template bank generation module.")
     make_analysis_dir(output_dir)
     cp = workflow.cp
 
@@ -80,21 +84,21 @@ def setup_tmpltbank_workflow(workflow, science_segs, datafind_outs,
     # There can be a large number of different options here, for e.g. to set
     # up fixed bank, or maybe something else
     if tmpltbankMethod == "PREGENERATED_BANK":
-        logging.info("Setting template bank from pre-generated bank(s).")
+        logger.info("Setting template bank from pre-generated bank(s).")
         tmplt_banks = setup_tmpltbank_pregenerated(workflow, tags=tags)
     # Else we assume template banks will be generated in the workflow
     elif tmpltbankMethod == "WORKFLOW_INDEPENDENT_IFOS":
-        logging.info("Adding template bank jobs to workflow.")
+        logger.info("Adding template bank jobs to workflow.")
         tmplt_banks = setup_tmpltbank_dax_generated(workflow, science_segs,
                                          datafind_outs, output_dir, tags=tags,
                                          psd_files=psd_files)
     elif tmpltbankMethod == "WORKFLOW_INDEPENDENT_IFOS_NODATA":
-        logging.info("Adding template bank jobs to workflow.")
+        logger.info("Adding template bank jobs to workflow.")
         tmplt_banks = setup_tmpltbank_without_frames(workflow, output_dir,
                                          tags=tags, independent_ifos=True,
                                          psd_files=psd_files)
     elif tmpltbankMethod == "WORKFLOW_NO_IFO_VARIATION_NODATA":
-        logging.info("Adding template bank jobs to workflow.")
+        logger.info("Adding template bank jobs to workflow.")
         tmplt_banks = setup_tmpltbank_without_frames(workflow, output_dir,
                                          tags=tags, independent_ifos=False,
                                          psd_files=psd_files)
@@ -112,7 +116,7 @@ def setup_tmpltbank_workflow(workflow, science_segs, datafind_outs,
     # the bank in the format as it was inputted.
     tmplt_bank_filename=tmplt_banks[0].name
     ext = tmplt_bank_filename.split('.', 1)[1]
-    logging.info("Input bank is a %s file", ext)
+    logger.info("Input bank is a %s file", ext)
     if return_format is None :
         tmplt_banks_return = tmplt_banks
     elif return_format in ('hdf', 'h5', 'hdf5'):
@@ -125,7 +129,7 @@ def setup_tmpltbank_workflow(workflow, science_segs, datafind_outs,
         else:
             raise NotImplementedError("{0} to {1} conversion is not "
                                       "supported.".format(ext, return_format))
-    logging.info("Leaving template bank generation module.")
+    logger.info("Leaving template bank generation module.")
     return tmplt_banks_return
 
 def setup_tmpltbank_dax_generated(workflow, science_segs, datafind_outs,

--- a/pycbc/workflow/versioning.py
+++ b/pycbc/workflow/versioning.py
@@ -26,8 +26,11 @@ Module to generate/manage the executable used for version information
 in workflows
 """
 import os
+import logging
+
 from pycbc.workflow.core import Executable
 
+logger = logging.getLogger('pycbc.workflow.versioning')
 
 class VersioningExecutable(Executable):
     """

--- a/pycbc/workflow/versioning.py
+++ b/pycbc/workflow/versioning.py
@@ -32,6 +32,7 @@ from pycbc.workflow.core import Executable
 
 logger = logging.getLogger('pycbc.workflow.versioning')
 
+
 class VersioningExecutable(Executable):
     """
     Executable for getting version information


### PR DESCRIPTION
As part of the series of PRs to standardize logging (#4631, #4576), here is the next batch

Here we update:
 - `bin/hwinj`
 - `bin/live`
 - `bin/population`
 - `bin/minifollowup`
 - `pycbc/catalog`
 - `pycbc/coordinates`
 - `pycbc/distributions`
 - `pycbc/frame`
 - `pycbc/workflow`