### PR TITLE
BUGFIX in timeseries.time_slice rounding

### DIFF
--- a/pycbc/types/timeseries.py
+++ b/pycbc/types/timeseries.py
@@ -188,10 +188,10 @@ class TimeSeries(Array):
         start_idx = float(start - self.start_time) * self.sample_rate
         end_idx = float(end - self.start_time) * self.sample_rate
 
-        if _numpy.isclose(start_idx, round(start_idx)):
+        if _numpy.isclose(start_idx, round(start_idx), rtol=0, atol=1E-3):
             start_idx = round(start_idx)
 
-        if _numpy.isclose(end_idx, round(end_idx)):
+        if _numpy.isclose(end_idx, round(end_idx), rtol=0, atol=1E-3):
             end_idx = round(end_idx)
 
         if mode == 'floor':


### PR DESCRIPTION
We've been following up some failures [in LVK readiness replay tests] where PyCBC has been producing outputs that Bayestar cannot ingest. This comes from the `pycbc_optimize_snr` code and is because SNR timeseries being output are not centered around the trigger times. Seems to happen mostly for followup ifos, where the SNR is small.

We tracked this down to a BUG in timeseries.time_slice. Specifically we do:
```
_numpy.isclose(start_idx, round(start_idx))
```
to check if the start_idx being computed is close enough to the number above (ie. start_idx = 56.9999). In that case, we don't want to round down, and instead just assume that 56.9999 is 57. *HOWEVER* if the idxes are large enough, this can give some strange output. For example:
```
>>> numpy.isclose(42998.58, 42999)
True
```
The optimize code runs something like this, then slices the timeseries, and does the same thing again. However after slicing the idxes are smaller, so doing:
```
>>> numpy.isclose(198.58, 199)
False
```
gives inconsistent output. For idxs larger than 1 million this will *always* round up, e.g. start_idx = 1000000.0001 rounds to 1000001.

The logic by which this code chooses to round up should be based on the value of `start_idx % 1`, not on some relative error. 

To fix this I propose setting `rtol` to 0 and using `atol`. The default value of `1E-8` seems too small to me, but not sure what the "right" value is. I went with 1E-3, so XX.999 and above is rounded to 1, below is not.
