### PR TITLE
improve consistency of example / defaults for variable_params

### DIFF
--- a/examples/distributions/example.ini
+++ b/examples/distributions/example.ini
@@ -1,8 +1,8 @@
-[static_args]
+[static_params]
 s0 = 1.0
 s1 = Hello World
 
-[variable_args]
+[variable_params]
 v0 =
 v1 =
 v2 =

--- a/examples/workflow/inference/ringdown_inference.ini
+++ b/examples/workflow/inference/ringdown_inference.ini
@@ -13,7 +13,7 @@ checkpoint-interval = 1000
 [sampler-burn_in]
 burn-in-test = nacl & max_posterior
 
-[variable_args]
+[variable_params]
 ; waveform parameters that will vary in MCMC
 final_mass =
 final_spin =
@@ -21,7 +21,7 @@ amp220 =
 phi220 =
 inclination =
 
-[static_args]
+[static_params]
 ; waveform parameters that will not change in MCMC
 approximant = TdQNMfromFinalMassSpin
 lmns = ['221']

--- a/pycbc/distributions/__init__.py
+++ b/pycbc/distributions/__init__.py
@@ -110,8 +110,8 @@ def _convert_liststring_to_list(lstring):
 
 
 def read_params_from_config(cp, prior_section='prior',
-                            vargs_section='variable_args',
-                            sargs_section='static_args'):
+                            vargs_section='variable_params',
+                            sargs_section='static_params'):
     """Loads static and variable parameters from a configuration file.
 
     Parameters
@@ -122,7 +122,7 @@ def read_params_from_config(cp, prior_section='prior',
         Check that priors exist in the given section. Default is 'prior.'
     vargs_section : str, optional
         The section to get the parameters that will be varied/need priors
-        defined for them. Default is 'variable_args'.
+        defined for them. Default is 'variable_params'.
     sargs_section : str, optional
         The section to get the parameters that will remain fixed. Default is
         'static_args'.
@@ -134,7 +134,7 @@ def read_params_from_config(cp, prior_section='prior',
     static_args : dict
         Dictionary of names -> values giving the parameters to keep fixed.
     """
-    # sanity check that each parameter in [variable_args] has a priors section
+    # sanity check that each parameter in [variable_params] has a priors section
     variable_args = cp.options(vargs_section)
     subsections = cp.get_subsections(prior_section)
     tags = set([p for tag in subsections for p in tag.split('+')])


### PR DESCRIPTION
@cdcapano This is just a small change to switch some of the examples to default to the more common convention now of static_params / variable_params. Also the default in one function that wasn't changed over is now done.