### PR TITLE
don't keep file open within injectionset

### DIFF
--- a/pycbc/inject/inject.py
+++ b/pycbc/inject/inject.py
@@ -348,7 +348,6 @@ class _HDFInjectionSet(metaclass=ABCMeta):
 
     Attributes
     ----------
-    filehandler
     table
     static_args
     extra_args

--- a/pycbc/inject/inject.py
+++ b/pycbc/inject/inject.py
@@ -365,7 +365,6 @@ class _HDFInjectionSet(metaclass=ABCMeta):
         # open the file
         fp = h5py.File(sim_file, 'r')
         group = fp if hdf_group is None else fp[hdf_group]
-        self.filehandler = fp
         # get parameters
         parameters = list(group.keys())
         # get all injection parameter values
@@ -414,6 +413,7 @@ class _HDFInjectionSet(metaclass=ABCMeta):
         self.table = self._tableclass.from_kwargs(**injvals)
         # save the extra arguments
         self.extra_args = kwds
+        fp.close()
 
     @abstractmethod
     def apply(self, strain, detector_name, distance_scale=1,


### PR DESCRIPTION
When working with the InjectionSet class in a notebook it is somewhat annoying that you can't rerun it without running into file handling issues. This occurs because it keeps an open connection to the file. If you want to say rewrite the injection file or have a separate write handle, this can be incompatible. We don't actually use the file handle for anything, so I've removed the property and put in a close at the end of initialization. 