### PR TITLE
Allow pycbc_fit_sngls_over_multiparam to take in multiple files

### DIFF
--- a/bin/all_sky_search/pycbc_fit_sngls_over_multiparam
+++ b/bin/all_sky_search/pycbc_fit_sngls_over_multiparam
@@ -292,7 +292,7 @@ for filename in args.template_fit_file:
                     logging.warning(
                         "Fit files correspond to different IFOs: %s and %s, "
                         "only %s is being used for output file attributes",
-                        attr_dict[k], fits.attrs[k]
+                        attr_dict[k], fits.attrs[k], attr_dict[k],
                     )
                 continue
             elif not attr_dict[k] == fits.attrs[k]:

--- a/bin/all_sky_search/pycbc_fit_sngls_over_multiparam
+++ b/bin/all_sky_search/pycbc_fit_sngls_over_multiparam
@@ -265,8 +265,7 @@ for filename in args.template_fit_file:
         for k in fits.attrs.keys():
             if k == 'analysis_time':
                 # For this, we want the mean, not check that it is identical
-                analysis_time += fits.attrs['analysis_time'] \
-                    if 'analysis_time' in fits.attrs else 0
+                analysis_time += fits.attrs['analysis_time']
                 continue
             if k not in attr_dict:
                 # This is the first time this attribute

--- a/bin/all_sky_search/pycbc_fit_sngls_over_multiparam
+++ b/bin/all_sky_search/pycbc_fit_sngls_over_multiparam
@@ -253,10 +253,6 @@ init_logging(args.verbose)
 analysis_time = 0
 attr_dict = {}
 
-# This will be used to check the fit files have the same number of templates
-# (therefore probably using the same bank)
-num_templates = None
-
 # These end up as n_files * n_templates arrays
 tid = numpy.array([], dtype=int)
 nabove = numpy.array([], dtype=int)
@@ -265,10 +261,14 @@ alpha = numpy.array([], dtype=float)
 median_sigma = numpy.array([], dtype=float)
 
 logging.info("Loading input template fits")
+
+# This will be used to check the fit files have the same number of templates
+# (therefore probably using the same bank)
+num_templates = None
+
 for filename in args.template_fit_file:
     with h5py.File(filename, 'r') as fits:
         if num_templates is None:
-            # First file; store number of templates
             num_templates = fits['template_id'].size
         elif not num_templates == fits['template_id'].size:
             raise RuntimeError(
@@ -285,7 +285,15 @@ for filename in args.template_fit_file:
                 # It's the first time we encounter this attribute
                 attr_dict[k] = fits.attrs[k]
             elif k == 'ifo':
-                # We don't mind if this attribute is different
+                # We don't mind if this attribute is different, however the
+                # output attributes will only correspond to the first file's
+                # IFO. Warn if different IFOs are being used.
+                if not attr_dict[k] == fits.attrs[k]:
+                    logging.warning(
+                        "Fit files correspond to different IFOs: %s and %s, "
+                        "only %s is being used for output file attributes",
+                        attr_dict[k], fits.attrs[k]
+                    )
                 continue
             elif not attr_dict[k] == fits.attrs[k]:
                 # Check that the files are consistent with one another

--- a/bin/all_sky_search/pycbc_fit_sngls_over_multiparam
+++ b/bin/all_sky_search/pycbc_fit_sngls_over_multiparam
@@ -245,13 +245,29 @@ assert len(args.log_param) == len(args.fit_param) == len(args.smoothing_width)
 
 init_logging(args.verbose)
 
-fits = h5py.File(args.template_fit_file, 'r')
+with h5py.File(args.template_fit_file, 'r') as fits:
+    # get attributes from the template-level fit
+    ifo = fits.attrs['ifo']
+    stat_threshold = fits.attrs['stat_threshold']
+    analysis_time = fits.attrs['analysis_time'] if 'analysis_time' in fits.attrs else None
 
-# get the ifo from the template-level fit
-ifo = fits.attrs['ifo']
+    # get template id and template parameter values
+    tid = fits['template_id'][:]
+    nabove = fits['count_above_thresh'][:]
+    ntotal = fits['count_in_template'][:]
+    alpha = fits['fit_coeff'][:]
+    try:
+        median_sigma = fits['median_sigma'][:]
+    except KeyError:
+        logging.info('Median_sigma dataset not present in input file')
+        median_sigma = None
 
-# get template id and template parameter values
-tid = fits['template_id'][:]
+    if args.output_fits_by_template:
+        fbtdict = {}
+        for k in ['count_above_thresh', 'fit_coeff', 'count_in_template']:
+            fbtdict[k] = fits[k][:]
+
+
 
 logging.info('Calculating template parameter values')
 bank = h5py.File(args.bank_file, 'r')
@@ -273,11 +289,9 @@ for param, slog in zip(args.fit_param, args.log_param):
     else:
         raise ValueError("invalid log param argument, use 'true', or 'false'")
 
-nabove = fits['count_above_thresh'][:]
-ntotal = fits['count_in_template'][:]
 # For an exponential fit 1/alpha is linear in the trigger statistic values
 # so calculating weighted sums or averages of 1/alpha is appropriate
-invalpha = 1. / fits['fit_coeff'][:]
+invalpha = 1. / alpha
 invalphan = invalpha * nabove
 
 nabove_smoothed = []
@@ -377,10 +391,8 @@ outfile['template_id'] = tid
 outfile['count_above_thresh'] = nabove_smoothed
 outfile['fit_coeff'] = alpha_smoothed
 outfile['count_in_template'] = ntotal_smoothed
-try:
-    outfile['median_sigma'] = fits['median_sigma'][:]
-except KeyError:
-    logging.info('Median_sigma dataset not present in input file')
+if median_sigma is not None:
+    outfile['median_sigma'] = median_sigma
 
 for param, vals, slog in zip(args.fit_param, parvals, args.log_param):
     if slog in ['false', 'False', 'FALSE']:
@@ -391,13 +403,13 @@ for param, vals, slog in zip(args.fit_param, parvals, args.log_param):
 if args.output_fits_by_template:
     outfile.create_group('fit_by_template')
     for k in ['count_above_thresh', 'fit_coeff', 'count_in_template']:
-        outfile['fit_by_template'][k] = fits[k][:]
+        outfile['fit_by_template'][k] = fbtdict[k]
 
 # Add metadata, some is inherited from template level fit
 outfile.attrs['ifo'] = ifo
-outfile.attrs['stat_threshold'] = fits.attrs['stat_threshold']
-if 'analysis_time' in fits.attrs:
-    outfile.attrs['analysis_time'] = fits.attrs['analysis_time']
+outfile.attrs['stat_threshold'] = stat_threshold
+if analysis_time is not None:
+    outfile.attrs['analysis_time'] = analysis_time
 
 # Add a magic file attribute so that coinc_findtrigs can parse it
 outfile.attrs['stat'] = ifo + '-fit_coeffs'

--- a/bin/all_sky_search/pycbc_fit_sngls_over_multiparam
+++ b/bin/all_sky_search/pycbc_fit_sngls_over_multiparam
@@ -177,8 +177,10 @@ parser = argparse.ArgumentParser(usage="",
 pycbc.add_common_pycbc_options(parser)
 parser.add_argument("--version", action=pycbc.version.Version)
 parser.add_argument("--template-fit-file", required=True, nargs='+',
-                    help="hdf5 file containing fit coefficients for each"
-                         " individual template. Required")
+                    help="hdf5 file(s) containing fit coefficients for each "
+                         "individual template. Can smooth over multiple "
+                         "files provided they correspond to the same bank "
+                         "and fitting settings. Required")
 parser.add_argument("--bank-file", required=True,
                     help="hdf file containing template parameters. Required")
 parser.add_argument("--output", required=True,
@@ -262,7 +264,9 @@ for filename in args.template_fit_file:
         # get attributes from the template-level fit
         for k in fits.attrs.keys():
             if k == 'analysis_time':
-                # We handle this differently
+                # For this, we want the mean, not check that it is identical
+                analysis_time += fits.attrs['analysis_time'] \
+                    if 'analysis_time' in fits.attrs else 0
                 continue
             if k not in attr_dict:
                 # This is the first time this attribute
@@ -274,8 +278,6 @@ for filename in args.template_fit_file:
                 err_msg += f"has attribute {k} of {fits.attrs[k]}, whereas "
                 err_msg += f"previous files have value {attr_dict[k]}"
                 raise RuntimeError(err_msg)
-
-        analysis_time += fits.attrs['analysis_time'] if 'analysis_time' in fits.attrs else 0
 
         # get template id and template parameter values
         tid = numpy.concatenate((tid, fits['template_id'][:]))
@@ -293,11 +295,12 @@ for filename in args.template_fit_file:
 invalpha = 1. / alpha
 invalphan = invalpha * nabove
 
+# convert the sum above into a mean
 analysis_time /= len(args.template_fit_file)
 
 # If we are using multiple files, we should 'smooth' within each template
 # before smoothing over templates going forward. As the templates will
-# all be have identical template_ids and have the same number of values,
+# all have identical template_ids and have the same number of values,
 # we can take the mean of means and it will still be correct
 if len(args.template_fit_file) > 1:
     logging.info("Averaging within the same template for multiple files")

--- a/bin/all_sky_search/pycbc_fit_sngls_over_multiparam
+++ b/bin/all_sky_search/pycbc_fit_sngls_over_multiparam
@@ -253,6 +253,11 @@ init_logging(args.verbose)
 analysis_time = 0
 attr_dict = {}
 
+# This will be used to check the fit files have the same number of templates
+# (therefore probably using the same bank)
+num_templates = None
+
+# These end up as n_files * n_templates arrays
 tid = numpy.array([], dtype=int)
 nabove = numpy.array([], dtype=int)
 ntotal = numpy.array([], dtype=int)
@@ -262,6 +267,14 @@ median_sigma = numpy.array([], dtype=float)
 logging.info("Loading input template fits")
 for filename in args.template_fit_file:
     with h5py.File(filename, 'r') as fits:
+        if num_templates is None:
+            # First file; store number of templates
+            num_templates = fits['template_id'].size
+        elif not num_templates == fits['template_id'].size:
+            raise RuntimeError(
+                "Input fit files correspond to different banks. "
+                "This situation is not yet supported."
+            )
         # get attributes from the template-level fit
         for k in fits.attrs.keys():
             if k == 'analysis_time':
@@ -271,6 +284,9 @@ for filename in args.template_fit_file:
             if k not in attr_dict:
                 # It's the first time we encounter this attribute
                 attr_dict[k] = fits.attrs[k]
+            elif k == 'ifo':
+                # We don't mind if this attribute is different
+                continue
             elif not attr_dict[k] == fits.attrs[k]:
                 # Check that the files are consistent with one another
                 err_msg = f"Input files are not consistent, file {filename} "
@@ -297,11 +313,12 @@ invalphan = invalpha * nabove
 # convert the sum above into a mean
 analysis_time /= len(args.template_fit_file)
 
-# If we are using multiple files, we should average within each template
-# before smoothing over templates going forward. As the templates will
-# all have identical template_ids and have the same number of values,
-# we can take the mean of means and it will still be correct
 if len(args.template_fit_file) > 1:
+    # From the n_templates * n_files arrays, average within each template.
+    # To do this, we average the n_files occurrences which have the same tid
+
+    # The linearity of the average means that we can do this in two steps
+    # without biasing the final result.
     logging.info("Averaging within the same template for multiple files")
     tid_unique = numpy.unique(tid)
 

--- a/bin/all_sky_search/pycbc_fit_sngls_over_multiparam
+++ b/bin/all_sky_search/pycbc_fit_sngls_over_multiparam
@@ -264,12 +264,11 @@ for filename in args.template_fit_file:
         # get attributes from the template-level fit
         for k in fits.attrs.keys():
             if k == 'analysis_time':
-                # For this, we want the mean, not check that it is identical
+                # For this attribute only, we want the mean
                 analysis_time += fits.attrs['analysis_time']
                 continue
             if k not in attr_dict:
-                # This is the first time this attribute
-                # has been encountered
+                # It's the first time we encounter this attribute
                 attr_dict[k] = fits.attrs[k]
             elif not attr_dict[k] == fits.attrs[k]:
                 # Check that the files are consistent with one another
@@ -297,7 +296,7 @@ invalphan = invalpha * nabove
 # convert the sum above into a mean
 analysis_time /= len(args.template_fit_file)
 
-# If we are using multiple files, we should 'smooth' within each template
+# If we are using multiple files, we should average within each template
 # before smoothing over templates going forward. As the templates will
 # all have identical template_ids and have the same number of values,
 # we can take the mean of means and it will still be correct
@@ -326,9 +325,9 @@ if len(args.template_fit_file) > 1:
     median_sigma = (mssum[right] - mssum[left]) / num
 
 if args.output_fits_by_template:
-    # Save fit_by_template values for saving later
-    # Note that these will be the values averaged over the same template in
-    # different files in the case that we have two or more input files
+    # Store fit_by_template values for output file
+    # For more than one input fit file, these values are averaged over the same
+    # template in different files
     fbt_dict = {
         'count_above_thresh': nabove,
         'count_in_template': ntotal,

--- a/bin/all_sky_search/pycbc_fit_sngls_over_multiparam
+++ b/bin/all_sky_search/pycbc_fit_sngls_over_multiparam
@@ -88,6 +88,7 @@ def smooth_tophat(nabove, invalphan, ntotal, dists):
                             idx_within_area)
 
 
+# This is the default number of triggers required for n_closest smoothing
 _default_total_trigs = 500
 
 
@@ -240,10 +241,10 @@ for inputstr in smooth_kwargs:
         key, value = inputstr.split(':')
         kwarg_dict[key] = value
     except ValueError:
-            err_txt = "--smoothing-keywords must take input in the " \
-                      "form KWARG1:VALUE1 KWARG2:VALUE2 KWARG3:VALUE3 ... " \
-                      "Received {}".format(' '.join(args.smoothing_keywords))
-            raise ValueError(err_txt)
+        err_txt = "--smoothing-keywords must take input in the " \
+                  "form KWARG1:VALUE1 KWARG2:VALUE2 KWARG3:VALUE3 ... " \
+                  "Received {}".format(' '.join(args.smoothing_keywords))
+        raise ValueError(err_txt)
 
 assert len(args.log_param) == len(args.fit_param) == len(args.smoothing_width)
 

--- a/bin/all_sky_search/pycbc_fit_sngls_over_multiparam
+++ b/bin/all_sky_search/pycbc_fit_sngls_over_multiparam
@@ -262,10 +262,9 @@ median_sigma = numpy.array([], dtype=float)
 
 logging.info("Loading input template fits")
 
-# This will be used to check the fit files have the same number of templates
-# (therefore probably using the same bank)
+# Check on fit files having the same number of templates, as expected if
+# they use the same bank
 num_templates = None
-
 for filename in args.template_fit_file:
     with h5py.File(filename, 'r') as fits:
         if num_templates is None:

--- a/bin/all_sky_search/pycbc_fit_sngls_over_multiparam
+++ b/bin/all_sky_search/pycbc_fit_sngls_over_multiparam
@@ -88,7 +88,11 @@ def smooth_tophat(nabove, invalphan, ntotal, dists):
                             idx_within_area)
 
 
-def smooth_n_closest(nabove, invalphan, ntotal, dists, total_trigs=500):
+_default_total_trigs = 500
+
+
+def smooth_n_closest(nabove, invalphan, ntotal, dists,
+                     total_trigs=_default_total_trigs):
     """
     Smooth templates according to the closest N templates
     No weighting is applied
@@ -97,13 +101,11 @@ def smooth_n_closest(nabove, invalphan, ntotal, dists, total_trigs=500):
     templates_required = 0
     n_triggers = 0
     # Count number of templates required to gather total_trigs templates,
-    # start at closest
-    # total_trigs, if supplied on command line will be a str so convert to int
-    while n_triggers < int(total_trigs):
-        n_triggers += nabove[dist_sort[n_triggers]]
-        templates_required += 1
-    logging.debug("%d templates required to obtain %d triggers",
-                  templates_required, n_triggers)
+    # starting at closest
+    ntcs = nabove[dist_sort].cumsum()
+    templates_required = numpy.searchsorted(ntcs, total_trigs) + 1
+    logging.debug("%d template(s) required to obtain %d(>%d) triggers",
+                  templates_required, ntcs[templates_required - 1], total_trigs)
     idx_to_smooth = dist_sort[:templates_required]
     return smooth_templates(nabove, invalphan, ntotal, idx_to_smooth)
 
@@ -254,6 +256,7 @@ ntotal = numpy.array([], dtype=int)
 alpha = numpy.array([], dtype=float)
 median_sigma = numpy.array([], dtype=float)
 
+logging.info("Loading input template fits")
 for filename in args.template_fit_file:
     with h5py.File(filename, 'r') as fits:
         # get attributes from the template-level fit
@@ -284,7 +287,6 @@ for filename in args.template_fit_file:
         except KeyError:
             logging.info('Median_sigma dataset not present in input file')
             median_sigma = None
-
 
 # For an exponential fit 1/alpha is linear in the trigger statistic values
 # so calculating weighted sums or averages of 1/alpha is appropriate
@@ -337,6 +339,16 @@ if args.output_fits_by_template:
         alpha = nabove / invalphan
     alpha[nabove == 0] = -100
     fbt_dict['fit_coeff'] = alpha
+
+n_required = _default_total_trigs if 'total_trigs' not in kwarg_dict \
+    else kwarg_dict['total_trigs']
+if args.smoothing_method == 'n_closest' and n_required > nabove.sum():
+    logging.warning(
+        "There are %.2f triggers above threshold, not enough to give a "
+        "total of %d for smoothing",
+        nabove.sum(),
+        n_required
+    )
 
 logging.info('Calculating template parameter values')
 bank = h5py.File(args.bank_file, 'r')

--- a/bin/all_sky_search/pycbc_fit_sngls_over_multiparam
+++ b/bin/all_sky_search/pycbc_fit_sngls_over_multiparam
@@ -174,7 +174,7 @@ parser = argparse.ArgumentParser(usage="",
 
 pycbc.add_common_pycbc_options(parser)
 parser.add_argument("--version", action=pycbc.version.Version)
-parser.add_argument("--template-fit-file", required=True,
+parser.add_argument("--template-fit-file", required=True, nargs='+',
                     help="hdf5 file containing fit coefficients for each"
                          " individual template. Required")
 parser.add_argument("--bank-file", required=True,
@@ -245,29 +245,98 @@ assert len(args.log_param) == len(args.fit_param) == len(args.smoothing_width)
 
 init_logging(args.verbose)
 
-with h5py.File(args.template_fit_file, 'r') as fits:
-    # get attributes from the template-level fit
-    ifo = fits.attrs['ifo']
-    stat_threshold = fits.attrs['stat_threshold']
-    analysis_time = fits.attrs['analysis_time'] if 'analysis_time' in fits.attrs else None
+analysis_time = 0
+attr_dict = {}
 
-    # get template id and template parameter values
-    tid = fits['template_id'][:]
-    nabove = fits['count_above_thresh'][:]
-    ntotal = fits['count_in_template'][:]
-    alpha = fits['fit_coeff'][:]
-    try:
-        median_sigma = fits['median_sigma'][:]
-    except KeyError:
-        logging.info('Median_sigma dataset not present in input file')
-        median_sigma = None
+tid = numpy.array([], dtype=int)
+nabove = numpy.array([], dtype=int)
+ntotal = numpy.array([], dtype=int)
+alpha = numpy.array([], dtype=float)
+median_sigma = numpy.array([], dtype=float)
 
-    if args.output_fits_by_template:
-        fbtdict = {}
-        for k in ['count_above_thresh', 'fit_coeff', 'count_in_template']:
-            fbtdict[k] = fits[k][:]
+for filename in args.template_fit_file:
+    with h5py.File(filename, 'r') as fits:
+        # get attributes from the template-level fit
+        for k in fits.attrs.keys():
+            if k == 'analysis_time':
+                # We handle this differently
+                continue
+            if k not in attr_dict:
+                # This is the first time this attribute
+                # has been encountered
+                attr_dict[k] = fits.attrs[k]
+            elif not attr_dict[k] == fits.attrs[k]:
+                # Check that the files are consistent with one another
+                err_msg = f"Input files are not consistent, file {filename} "
+                err_msg += f"has attribute {k} of {fits.attrs[k]}, whereas "
+                err_msg += f"previous files have value {attr_dict[k]}"
+                raise RuntimeError(err_msg)
+
+        analysis_time += fits.attrs['analysis_time'] if 'analysis_time' in fits.attrs else 0
+
+        # get template id and template parameter values
+        tid = numpy.concatenate((tid, fits['template_id'][:]))
+        nabove = numpy.concatenate((nabove, fits['count_above_thresh'][:]))
+        ntotal = numpy.concatenate((ntotal, fits['count_in_template'][:]))
+        alpha = numpy.concatenate((alpha, fits['fit_coeff'][:]))
+        try:
+            median_sigma = numpy.concatenate((median_sigma, fits['median_sigma'][:]))
+        except KeyError:
+            logging.info('Median_sigma dataset not present in input file')
+            median_sigma = None
 
 
+# For an exponential fit 1/alpha is linear in the trigger statistic values
+# so calculating weighted sums or averages of 1/alpha is appropriate
+invalpha = 1. / alpha
+invalphan = invalpha * nabove
+
+analysis_time /= len(args.template_fit_file)
+
+# If we are using multiple files, we should 'smooth' within each template
+# before smoothing over templates going forward. As the templates will
+# all be have identical template_ids and have the same number of values,
+# we can take the mean of means and it will still be correct
+if len(args.template_fit_file) > 1:
+    logging.info("Averaging within the same template for multiple files")
+    tid_unique = numpy.unique(tid)
+
+    # sort into template_id order
+    tidsort = tid.argsort()
+
+    # For each unique template id, find the range of identical template ids
+    left = numpy.searchsorted(tid[tidsort], tid_unique, side='left')
+    right = numpy.searchsorted(tid[tidsort], tid_unique, side='right') - 1
+
+    # Precompute the sums so we can quickly look up differences
+    nasum = nabove[tidsort].cumsum()
+    invsum = invalphan[tidsort].cumsum()
+    ntsum = ntotal[tidsort].cumsum()
+    mssum = median_sigma[tidsort].cumsum()
+    num = right - left
+
+    tid = tid_unique
+    nabove = (nasum[right] - nasum[left]) / num
+    invalphan = (invsum[right] - invsum[left]) / num
+    ntotal = (ntsum[right] - ntsum[left]) / num
+    median_sigma = (mssum[right] - mssum[left]) / num
+
+if args.output_fits_by_template:
+    # Save fit_by_template values for saving later
+    # Note that these will be the values averaged over the same template in
+    # different files in the case that we have two or more input files
+    fbt_dict = {
+        'count_above_thresh': nabove,
+        'count_in_template': ntotal,
+    }
+    with numpy.errstate(invalid='ignore'):
+        # If n_above is zero, then we'll get an 'invalid' warning as we
+        # are dividing zero by zero. This is normal, and we'll deal with
+        # those properly just below, so ignore this so people don't see
+        # a warning and panic
+        alpha = nabove / invalphan
+    alpha[nabove == 0] = -100
+    fbt_dict['fit_coeff'] = alpha
 
 logging.info('Calculating template parameter values')
 bank = h5py.File(args.bank_file, 'r')
@@ -288,11 +357,6 @@ for param, slog in zip(args.fit_param, args.log_param):
         parnames.append(f"log({param})")
     else:
         raise ValueError("invalid log param argument, use 'true', or 'false'")
-
-# For an exponential fit 1/alpha is linear in the trigger statistic values
-# so calculating weighted sums or averages of 1/alpha is appropriate
-invalpha = 1. / alpha
-invalphan = invalpha * nabove
 
 nabove_smoothed = []
 alpha_smoothed = []
@@ -347,9 +411,6 @@ elif numpy.isfinite(_smooth_cut[args.smoothing_method]):
     logging.info("Cutting between %d and %d templates for each smoothing",
                  n_removed.min(), n_removed.max())
     # Sort the values to be smoothed by parameter value
-    nabove = nabove[par_sort]
-    invalphan = invalphan[par_sort]
-    ntotal = ntotal[par_sort]
     logging.info("Smoothing ...")
     slices = [slice(l,r) for l, r in zip(lefts, rights)]
     for i in rang:
@@ -357,9 +418,9 @@ elif numpy.isfinite(_smooth_cut[args.smoothing_method]):
         slc = slices[i]
         d = dist(i, slc, parvals, args.smoothing_width)
 
-        smoothed_tuple = smooth(nabove[slc],
-                                invalphan[slc],
-                                ntotal[slc],
+        smoothed_tuple = smooth(nabove[par_sort][slc],
+                                invalphan[par_sort][slc],
+                                ntotal[par_sort][slc],
                                 d,
                                 args.smoothing_method,
                                 **kwarg_dict)
@@ -401,16 +462,16 @@ for param, vals, slog in zip(args.fit_param, parvals, args.log_param):
         outfile[param] = numpy.exp(vals)
 
 if args.output_fits_by_template:
-    outfile.create_group('fit_by_template')
-    for k in ['count_above_thresh', 'fit_coeff', 'count_in_template']:
-        outfile['fit_by_template'][k] = fbtdict[k]
+    fbt_group = outfile.create_group('fit_by_template')
+    for k, v in fbt_dict.items():
+        fbt_group[k] = v
 
 # Add metadata, some is inherited from template level fit
-outfile.attrs['ifo'] = ifo
-outfile.attrs['stat_threshold'] = stat_threshold
-if analysis_time is not None:
+for k, v in attr_dict.items():
+    outfile.attrs[k] = v
+if not analysis_time == 0:
     outfile.attrs['analysis_time'] = analysis_time
 
 # Add a magic file attribute so that coinc_findtrigs can parse it
-outfile.attrs['stat'] = ifo + '-fit_coeffs'
+outfile.attrs['stat'] = attr_dict['ifo'] + '-fit_coeffs'
 logging.info('Done!')


### PR DESCRIPTION
Update `pycbc_fit_sngls_over_multiparam` to take in multiple --template-fit-file inputs

#### Why?
This will be useful for e.g. if we generate `pycbc_fit_sngls_by_template` for part of the data, e.g. a day, and then want to smooth over many days at once, we could do this in a rolling window in the live search

#### How?
 - Firstly, read in the files and concatenate datasets together: `template_id`, median_sigma`, `count_above_thresh`, `count_in_template` and `fit_coeff`.
 - While doing this, check that all the attributes which should match (`ifo`, `sngl_stat`, `fit_threshold`), do. Otherwise, RuntimeError
 - For each of `nabove`, `ntotal` and `invalphan`, smooth identical template_ids over files before doing the smoothing over parameters as before. This works as these datasets are linearly added for smoothing.

#### Nuances
 - Here we take a mean of `median_sigma` over different files. `median_sigma` is meant to be a representative value for each template in that IFO, and taking the median previously removes any outliers. So taking the mean after this should be safe
 - The `fit_by_template` output group now contains the `fit_by_template` values' mean average over files - like with `median_sigma`, this group is later used to find particularly noisy, isolated templates, so this should be okay

#### Testing
I have run the new code with one input file against the old code, and tested the output files against one another. This was done for all different smoothing methods [see note on n_closest below]. Every dataset and (shared) attribute was compared between new/old outputs and are all identical in this case.

The files differ by more than just numerical noise in a couple of minor ways:
 - The attributes in the output file now include the `sngl_stat` and `fit_function` from the `fit_by_template` attributes
 - The `fit_by_template/count_above_thresh` and `fit_by_template/count_in_template` datasets change from int64 to float64 when more than one file is given, to allow for the smoothing over files to give a non-integer count values.

For taking in multiple files, I have tested providing the same file two / three times, these should result in exactly the same output, e.g. mean(0,1,2,3) = mean(0,1,2,3,0,1,2,3)

In these tests, all new/old datasets are the same to within a `numpy.isclose`; more stringent comparison shows that all new/old datasets are identical except there is variation in the `median_sigma` dataset. `median_sigma` values change by up to 9e-10 (values are in the thousands, and we take a log of this in the statistic so I don't think this matters too much).

#### Efficiency
The smoothing over files uses the similar methodology to the efficient 1d tophat smoothing, so this step takes less than a second for a full O4 offline bank

#### Other notes
 - I think this change means we could parallelise `pycbc_fit_sngls_by_template` in the offline search to work over different parts of the bank, but haven't thought too much about how to implement that or whether it would even be useful
 - I have additionally fixed a bug in selecting templates for the `n_closest` smoothing method. I did this for both the 'master' copy of the code, and the new version. The results after this fix were the same as for other smoothing methods.