### PR TITLE
specify an older branch of BBHx in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,7 @@ deps =
     {[base]deps}
     pytest
     ; Needed for `BBHx` package to work with PyCBC
-    git+https://github.com/mikekatz04/BBHx.git@01c54a5; sys_platform == 'linux'
+    git+https://github.com/mikekatz04/BBHx.git@4fff509; sys_platform == 'linux'
     git+https://github.com/gwastro/BBHX-waveform-model.git; sys_platform == 'linux'
 conda_deps=
     mysqlclient
@@ -66,7 +66,7 @@ commands = bash tools/pycbc_test_suite.sh
 deps =
     {[base]deps}
     ; Needed for `BBHx` package to work with PyCBC
-    git+https://github.com/mikekatz04/BBHx.git@01c54a5; sys_platform == 'linux'
+    git+https://github.com/mikekatz04/BBHx.git@4fff509; sys_platform == 'linux'
     git+https://github.com/gwastro/BBHX-waveform-model.git; sys_platform == 'linux'
 conda_deps=
     mysqlclient

--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,7 @@ deps =
     {[base]deps}
     pytest
     ; Needed for `BBHx` package to work with PyCBC
-    git+https://github.com/mikekatz04/BBHx.git; sys_platform == 'linux'
+    git+https://github.com/mikekatz04/BBHx.git@01c54a5; sys_platform == 'linux'
     git+https://github.com/gwastro/BBHX-waveform-model.git; sys_platform == 'linux'
 conda_deps=
     mysqlclient
@@ -66,7 +66,7 @@ commands = bash tools/pycbc_test_suite.sh
 deps =
     {[base]deps}
     ; Needed for `BBHx` package to work with PyCBC
-    git+https://github.com/mikekatz04/BBHx.git; sys_platform == 'linux'
+    git+https://github.com/mikekatz04/BBHx.git@01c54a5; sys_platform == 'linux'
     git+https://github.com/gwastro/BBHX-waveform-model.git; sys_platform == 'linux'
 conda_deps=
     mysqlclient


### PR DESCRIPTION
@ahnitz This PR specified a branch 2 weeks ago for BBHx. 
**Note:
`BBHx` updates its Python requirement to be >=3.12 due to some updates in Michael Katz's other LISA packages, but PyCBC's CI tests are for older versions of Python.**