### PR TITLE
Fix IndexError in PyCBC Live's followup code

### DIFF
--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -804,13 +804,13 @@ class LiveEventManager(object):
                 store_psd[ifo].save(fname, group='%s/psd' % ifo)
 
 
-def check_max_length(waveforms):
+def check_max_length(args, waveforms):
     """Check that the `--max-length` option is sufficient to accomodate the
     longest template in the bank and the PSD estimation options.
     """
     lengths = numpy.array([1.0 / wf.delta_f for wf in waveforms])
     psd_len = args.psd_segment_length * (args.psd_samples // 2 + 1)
-    max_length = max(lengths.max() + args.pvalue_lookback, psd_len)
+    max_length = max(lengths.max() + args.pvalue_lookback_time, psd_len)
     if max_length > args.max_length:
         raise ValueError(
             '--max-length is too short for this template bank. '
@@ -1133,7 +1133,7 @@ with ctx:
     if evnt.rank > 0:
         bank.table.sort(order='mchirp')
         waveforms = list(bank[evnt.rank-1::evnt.size-1])
-        check_max_length(waveforms)
+        check_max_length(args, waveforms)
         mf = LiveBatchMatchedFilter(waveforms, args.snr_threshold,
                                     args.chisq_bins, sg_chisq,
                                     snr_abort_threshold=args.snr_abort_threshold,

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -104,6 +104,7 @@ class LiveEventManager(object):
         self.padata = livepau.PAstroData(args.p_astro_spec, args.bank_file)
         self.use_date_prefix = args.day_hour_output_prefix
         self.ifar_upload_threshold = args.ifar_upload_threshold
+        self.pvalue_lookback_time = args.pvalue_lookback_time
         self.pvalue_livetime = args.pvalue_combination_livetime
         self.gracedb_server = args.gracedb_server
         self.gracedb_search = args.gracedb_search
@@ -221,7 +222,8 @@ class LiveEventManager(object):
                 self.data_readers[ifo],
                 self.bank,
                 template_id,
-                coinc_times
+                coinc_times,
+                lookback=self.pvalue_lookback_time
             )
             if pvalue_info is None:
                 continue
@@ -802,6 +804,20 @@ class LiveEventManager(object):
                 store_psd[ifo].save(fname, group='%s/psd' % ifo)
 
 
+def check_max_length(waveforms):
+    """Check that the `--max-length` option is sufficient to accomodate the
+    longest template in the bank and the PSD estimation options.
+    """
+    lengths = numpy.array([1.0 / wf.delta_f for wf in waveforms])
+    psd_len = args.psd_segment_length * (args.psd_samples // 2 + 1)
+    max_length = max(lengths.max() + args.pvalue_lookback, psd_len)
+    if max_length > args.max_length:
+        raise ValueError(
+            '--max-length is too short for this template bank. '
+            f'Use at least {max_length}.'
+        )
+
+
 parser = argparse.ArgumentParser(description=__doc__)
 pycbc.waveform.bank.add_approximant_arg(parser)
 parser.add_argument('--verbose', action='store_true')
@@ -962,6 +978,10 @@ parser.add_argument('--enable-background-estimation', default=False, action='sto
 parser.add_argument('--ifar-double-followup-threshold', type=float, required=True,
                     help='Inverse-FAR threshold to followup double coincs with'
                          'additional detectors')
+parser.add_argument('--pvalue-lookback-time', type=float, default=150,
+                    metavar='SECONDS',
+                    help='Lookback time for the calculation of the p-value in '
+                         'followup detectors.')
 parser.add_argument('--pvalue-combination-livetime', type=float, required=True,
                     help="Livetime used for p-value combination with followup "
                          "detectors, in years")
@@ -1110,13 +1130,10 @@ with ctx:
         print(e)
         exit()
 
-    maxlen = args.psd_segment_length * (args.psd_samples // 2 + 1)
     if evnt.rank > 0:
         bank.table.sort(order='mchirp')
         waveforms = list(bank[evnt.rank-1::evnt.size-1])
-        lengths = numpy.array([1.0 / wf.delta_f for wf in waveforms])
-        psd_len = args.psd_segment_length * (args.psd_samples // 2 + 1)
-        maxlen = max(lengths.max(), psd_len)
+        check_max_length(waveforms)
         mf = LiveBatchMatchedFilter(waveforms, args.snr_threshold,
                                     args.chisq_bins, sg_chisq,
                                     snr_abort_threshold=args.snr_abort_threshold,
@@ -1138,11 +1155,8 @@ with ctx:
     # Initialize the data readers for all detectors. For rank 0, we need data
     # from all detectors, including the localization-only ones. For higher
     # ranks, we only need the detectors that can generate candidates.
-    if args.max_length is not None:
-        maxlen = args.max_length
-    maxlen = int(maxlen)
     data_reader = {
-        ifo: StrainBuffer.from_cli(ifo, args, maxlen)
+        ifo: StrainBuffer.from_cli(ifo, args, args.max_length)
         for ifo in (evnt.ifos if evnt.rank == 0 else evnt.trigg_ifos)
     }
     evnt.data_readers = data_reader

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -1156,7 +1156,7 @@ with ctx:
     # from all detectors, including the localization-only ones. For higher
     # ranks, we only need the detectors that can generate candidates.
     data_reader = {
-        ifo: StrainBuffer.from_cli(ifo, args, args.max_length)
+        ifo: StrainBuffer.from_cli(ifo, args)
         for ifo in (evnt.ifos if evnt.rank == 0 else evnt.trigg_ifos)
     }
     evnt.data_readers = data_reader

--- a/examples/live/run.sh
+++ b/examples/live/run.sh
@@ -131,7 +131,7 @@ python -m mpi4py `which pycbc_live` \
 --sample-rate 2048 \
 --enable-bank-start-frequency \
 --low-frequency-cutoff ${f_min} \
---max-length 256 \
+--max-length 512 \
 --approximant "SPAtmplt:mtotal<4" "SEOBNRv4_ROM:else" \
 --chisq-bins "0.72*get_freq('fSEOBNRv4Peak',params.mass1,params.mass2,params.spin1z,params.spin2z)**0.7" \
 --snr-abort-threshold 500 \

--- a/pycbc/filter/matchedfilter.py
+++ b/pycbc/filter/matchedfilter.py
@@ -1896,7 +1896,9 @@ def followup_event_significance(ifo, data_reader, bank,
             return None
 
     # Calculate SNR time series for this duration
-    htilde = bank.get_template(template_id, td_samples=buffer_samples)
+    htilde = bank.get_template(
+        template_id, bank.sample_rate / float(buffer_samples)
+    )
     stilde = data_reader.overwhitened_data(htilde.delta_f)
 
     sigma2 = htilde.sigmasq(stilde.psd)

--- a/pycbc/filter/matchedfilter.py
+++ b/pycbc/filter/matchedfilter.py
@@ -1807,6 +1807,17 @@ def followup_event_significance(ifo, data_reader, bank,
     for details. A portion of the SNR time series around the on-source window
     is also returned for use in BAYESTAR.
 
+    If the calculation cannot be carried out, for example because `ifo` is
+    not in observing mode at the requested time, then None is returned.
+    Otherwise, the dict contains the following keys. `snr_series` is a
+    TimeSeries object with the SNR time series for BAYESTAR. `peak_time` is the
+    time of maximum SNR in the on-source window. `pvalue` is the p-value for
+    the maximum on-source SNR compared to the off-source realizations.
+    `pvalue_saturated` is a bool indicating whether the p-value is limited by
+    the number of off-source realizations, i.e. whether the maximum on-source
+    SNR is larger than all the off-source ones. `sigma2` is the SNR
+    normalization (squared) for the given template and detector.
+
     Parameters
     ----------
     ifo: str
@@ -1835,19 +1846,8 @@ def followup_event_significance(ifo, data_reader, bank,
     Returns
     -------
     followup_info: dict or None
-        If the calculation cannot be carried out, for example because `ifo` is
-        not in observing mode at the requested time, then None is returned.
-        Otherwise, the dict contains the following keys:
-        * `snr_series`: TimeSeries object containing the SNR time series for
-          BAYESTAR.
-        * `peak_time`: time of maximum SNR in the on-source window.
-        * `pvalue`: p-value for the maximum on-source SNR compared to the
-          off-source realizations.
-        * `pvalue_saturated`: bool indicating whether the p-value is limited by
-          the number of off-source realizations, i.e. whether the maximum
-          on-source SNR is larger than all the off-source ones.
-        * `sigma2`: SNR normalization factor (squared) for the given template
-          and detector.
+        Results of the followup calculation (see above) or None if `ifo` did
+        not have usable data.
     """
     from pycbc.waveform import get_waveform_filter_length_in_time
     tmplt = bank.table[template_id]

--- a/pycbc/filter/matchedfilter.py
+++ b/pycbc/filter/matchedfilter.py
@@ -1819,14 +1819,16 @@ def followup_event_significance(ifo, data_reader, bank,
         Index of the template in the bank.
     coinc_times: dict
         Dictionary keyed by detector names reporting the coalescence times of
-        a candidate measured at the different detectors.
+        a candidate measured at the different detectors. Used to define the
+        on-source window of the candidate in `ifo`.
     coinc_threshold: float
         Nominal statistical uncertainty in `coinc_times`; expands the
         on-source window by twice the given amount.
     lookback: float
         Nominal amount of time to use for the calculation of the onsource and
         offsource SNR time series. The actual time may be reduced depending on
-        the duration of the template and the strain buffer in the data reader.
+        the duration of the template and the strain buffer in the data reader
+        (if so, a warning is logged).
     duration: float
         Duration of the SNR time series to be reported to BAYESTAR.
 
@@ -1839,7 +1841,7 @@ def followup_event_significance(ifo, data_reader, bank,
         * `snr_series`: TimeSeries object containing the SNR time series for
           BAYESTAR.
         * `peak_time`: time of maximum SNR in the on-source window.
-        `pvalue`: p-value for the maximum on-source SNR compared to the
+        * `pvalue`: p-value for the maximum on-source SNR compared to the
           off-source realizations.
         * `pvalue_saturated`: bool indicating whether the p-value is limited by
           the number of off-source realizations, i.e. whether the maximum

--- a/pycbc/filter/matchedfilter.py
+++ b/pycbc/filter/matchedfilter.py
@@ -1804,7 +1804,48 @@ def followup_event_significance(ifo, data_reader, bank,
     to determine if the SNR in the first detector has a significant peak
     in the on-source window. The significance is given in terms of a
     p-value. See Dal Canton et al. 2021 (https://arxiv.org/abs/2008.07494)
-    for details.
+    for details. A portion of the SNR time series around the on-source window
+    is also returned for use in BAYESTAR.
+
+    Parameters
+    ----------
+    ifo: str
+        Which detector is being used for the calculation.
+    data_reader: StrainBuffer
+        StrainBuffer object providing the data for the given detector.
+    bank: LiveFilterBank
+        Template bank object providing the template related quantities.
+    template_id: int
+        Index of the template in the bank.
+    coinc_times: dict
+        Dictionary keyed by detector names reporting the coalescence times of
+        a candidate measured at the different detectors.
+    coinc_threshold: float
+        Nominal statistical uncertainty in `coinc_times`; expands the
+        on-source window by twice the given amount.
+    lookback: float
+        Nominal amount of time to use for the calculation of the onsource and
+        offsource SNR time series. The actual time may be reduced depending on
+        the duration of the template and the strain buffer in the data reader.
+    duration: float
+        Duration of the SNR time series to be reported to BAYESTAR.
+
+    Returns
+    -------
+    followup_info: dict or None
+        If the calculation cannot be carried out, for example because `ifo` is
+        not in observing mode at the requested time, then None is returned.
+        Otherwise, the dict contains the following keys:
+        * `snr_series`: TimeSeries object containing the SNR time series for
+          BAYESTAR.
+        * `peak_time`: time of maximum SNR in the on-source window.
+        `pvalue`: p-value for the maximum on-source SNR compared to the
+          off-source realizations.
+        * `pvalue_saturated`: bool indicating whether the p-value is limited by
+          the number of off-source realizations, i.e. whether the maximum
+          on-source SNR is larger than all the off-source ones.
+        * `sigma2`: SNR normalization factor (squared) for the given template
+          and detector.
     """
     from pycbc.waveform import get_waveform_filter_length_in_time
     tmplt = bank.table[template_id]

--- a/pycbc/filter/matchedfilter.py
+++ b/pycbc/filter/matchedfilter.py
@@ -1947,7 +1947,7 @@ def followup_event_significance(ifo, data_reader, bank,
 
     # Calculate SNR time series for the entire lookback duration
     htilde = bank.get_template(
-        template_id, bank.sample_rate / float(buffer_samples)
+        template_id, delta_f=bank.sample_rate / float(buffer_samples)
     )
     stilde = data_reader.overwhitened_data(htilde.delta_f)
 

--- a/pycbc/strain/strain.py
+++ b/pycbc/strain/strain.py
@@ -1420,8 +1420,8 @@ STRAINBUFFER_UNIQUE_ID_3 = 665849947
 
 class StrainBuffer(pycbc.frame.DataBuffer):
     def __init__(self, frame_src, channel_name, start_time,
-                 max_buffer=512,
-                 sample_rate=4096,
+                 max_buffer,
+                 sample_rate,
                  low_frequency_cutoff=20,
                  highpass_frequency=15.0,
                  highpass_reduction=200.0,
@@ -1462,9 +1462,9 @@ class StrainBuffer(pycbc.frame.DataBuffer):
             Name of the channel to read from the frame files
         start_time:
             Time to start reading from.
-        max_buffer: {int, 512}, Optional
-            Length of the buffer in seconds
-        sample_rate: {int, 2048}, Optional
+        max_buffer: int
+            Length of the strain buffer in seconds.
+        sample_rate: int, Optional
             Rate in Hz to sample the data.
         low_frequency_cutoff: {float, 20}, Optional
             The low frequency cutoff to use for inverse spectrum truncation
@@ -1536,7 +1536,7 @@ class StrainBuffer(pycbc.frame.DataBuffer):
             filesystem.
         """
         super(StrainBuffer, self).__init__(frame_src, channel_name, start_time,
-                                           max_buffer=32,
+                                           max_buffer=max_buffer,
                                            force_update_cache=force_update_cache,
                                            increment_update_cache=increment_update_cache)
 
@@ -1988,7 +1988,7 @@ class StrainBuffer(pycbc.frame.DataBuffer):
         strain_channel = ':'.join([ifo, args.channel_name[ifo]])
 
         return cls(frame_src, strain_channel,
-                   args.start_time, max_buffer=maxlen * 2,
+                   args.start_time, max_buffer=maxlen,
                    state_channel=state_channel,
                    data_quality_channel=dq_channel,
                    idq_channel=idq_channel,

--- a/pycbc/strain/strain.py
+++ b/pycbc/strain/strain.py
@@ -1952,7 +1952,7 @@ class StrainBuffer(pycbc.frame.DataBuffer):
         return self.wait_duration <= 0
 
     @classmethod
-    def from_cli(cls, ifo, args, maxlen):
+    def from_cli(cls, ifo, args):
         """Initialize a StrainBuffer object (data reader) for a particular
         detector.
         """
@@ -1987,34 +1987,38 @@ class StrainBuffer(pycbc.frame.DataBuffer):
             frame_src = [args.frame_src[ifo]]
         strain_channel = ':'.join([ifo, args.channel_name[ifo]])
 
-        return cls(frame_src, strain_channel,
-                   args.start_time, max_buffer=maxlen,
-                   state_channel=state_channel,
-                   data_quality_channel=dq_channel,
-                   idq_channel=idq_channel,
-                   idq_state_channel=idq_state_channel,
-                   idq_threshold=args.idq_threshold,
-                   sample_rate=args.sample_rate,
-                   low_frequency_cutoff=args.low_frequency_cutoff,
-                   highpass_frequency=args.highpass_frequency,
-                   highpass_reduction=args.highpass_reduction,
-                   highpass_bandwidth=args.highpass_bandwidth,
-                   psd_samples=args.psd_samples,
-                   trim_padding=args.trim_padding,
-                   psd_segment_length=args.psd_segment_length,
-                   psd_inverse_length=args.psd_inverse_length,
-                   autogating_threshold=args.autogating_threshold,
-                   autogating_cluster=args.autogating_cluster,
-                   autogating_pad=args.autogating_pad,
-                   autogating_width=args.autogating_width,
-                   autogating_taper=args.autogating_taper,
-                   autogating_duration=args.autogating_duration,
-                   autogating_psd_segment_length=args.autogating_psd_segment_length,
-                   autogating_psd_stride=args.autogating_psd_stride,
-                   psd_abort_difference=args.psd_abort_difference,
-                   psd_recalculate_difference=args.psd_recalculate_difference,
-                   force_update_cache=args.force_update_cache,
-                   increment_update_cache=args.increment_update_cache[ifo],
-                   analyze_flags=analyze_flags,
-                   data_quality_flags=dq_flags,
-                   dq_padding=args.data_quality_padding)
+        return cls(
+            frame_src,
+            strain_channel,
+            args.start_time,
+            max_buffer=args.max_length,
+            state_channel=state_channel,
+            data_quality_channel=dq_channel,
+            idq_channel=idq_channel,
+            idq_state_channel=idq_state_channel,
+            idq_threshold=args.idq_threshold,
+            sample_rate=args.sample_rate,
+            low_frequency_cutoff=args.low_frequency_cutoff,
+            highpass_frequency=args.highpass_frequency,
+            highpass_reduction=args.highpass_reduction,
+            highpass_bandwidth=args.highpass_bandwidth,
+            psd_samples=args.psd_samples,
+            trim_padding=args.trim_padding,
+            psd_segment_length=args.psd_segment_length,
+            psd_inverse_length=args.psd_inverse_length,
+            autogating_threshold=args.autogating_threshold,
+            autogating_cluster=args.autogating_cluster,
+            autogating_pad=args.autogating_pad,
+            autogating_width=args.autogating_width,
+            autogating_taper=args.autogating_taper,
+            autogating_duration=args.autogating_duration,
+            autogating_psd_segment_length=args.autogating_psd_segment_length,
+            autogating_psd_stride=args.autogating_psd_stride,
+            psd_abort_difference=args.psd_abort_difference,
+            psd_recalculate_difference=args.psd_recalculate_difference,
+            force_update_cache=args.force_update_cache,
+            increment_update_cache=args.increment_update_cache[ifo],
+            analyze_flags=analyze_flags,
+            data_quality_flags=dq_flags,
+            dq_padding=args.data_quality_padding
+        )


### PR DESCRIPTION
This should fix at least some of the issues identified in #4643, at least avoiding a crash when similar problems occur.

Specifically, this does the following:
* Add a `--pvalue-lookback-time` CLI option that controls how much time we need to do the followup p-value and SNR time series calculation. The option defaults to 150 s, so no change in CLI is needed here and no functional change is expected.
* Redesign the logic around the `--max-length` CLI option, which was previously confusing and I think unnecessary. Now the length passed to `StrainBuffer` is *exactly* what given via `--max-length` (not twice that, or something calculated via other means). There is also a check to make sure the value is sensible when `pycbc_live` is starting (this addresses one of my early comments in #4643). This **may** require a CLI change, we should recheck what the right value is given the banks in use and the lookback time.
* Changes `followup_event_significance()` to require the correct amount of data and not count the template durations twice. Also, explicitly check that the required data is going to be available, and print warnings or errors if that is not the case (but do not crash).
* Docstring improvement and code cleanup, though I tried hard to resist the urge in the interest of a short diff.

Note that this breaks the API by changing the args of `StrainBuffer.from_cli()` and `LiveFilterBank.get_template()`, but nothing else in the code apart from `pycbc_live` appears to use those.