### PR TITLE
file handler no longer exists, so will fail if closed

### DIFF
--- a/pycbc/inference/io/base_hdf.py
+++ b/pycbc/inference/io/base_hdf.py
@@ -613,8 +613,6 @@ class BaseInferenceFile(h5py.File, metaclass=ABCMeta):
             group = '/'.join([group, self.injections_group])
         injset = InjectionSet(self.filename, hdf_group=group)
         injections = injset.table.view(FieldArray)
-        # close the new open filehandler to self
-        injset._injhandler.filehandler.close()
         return injections
 
     def write_command_line(self):


### PR DESCRIPTION
This fixes a bug introduced in previous PR of mine. I missed that the file handler was being closed in a place. It no longer exists, so we need to take this line out. 