### PR TITLE
Bugfix: allow nothing to be given in --labels

### DIFF
--- a/bin/all_sky_search/pycbc_upload_single_event_to_gracedb
+++ b/bin/all_sky_search/pycbc_upload_single_event_to_gracedb
@@ -72,7 +72,7 @@ if args.production_server:
 else:
     gracedb = GraceDb(service_url='https://gracedb-playground.ligo.org/api/')
 
-labels = [l.upper() for l in args.labels]
+labels = [l.upper() for l in args.labels] if args.labels is not None else []
 allowed_labels = gracedb.allowed_labels
 
 if set(labels) - set(allowed_labels):

--- a/bin/all_sky_search/pycbc_upload_single_event_to_gracedb
+++ b/bin/all_sky_search/pycbc_upload_single_event_to_gracedb
@@ -72,7 +72,7 @@ if args.production_server:
 else:
     gracedb = GraceDb(service_url='https://gracedb-playground.ligo.org/api/')
 
-labels = [l.upper() for l in args.labels] if args.labels is not None else []
+labels = [l.upper() for l in (args.labels or [])]
 allowed_labels = gracedb.allowed_labels
 
 if set(labels) - set(allowed_labels):


### PR DESCRIPTION
Uploading an event without supplying `--labels` causes an error.

Though we probably will want labels added, this is still a bug