### PR TITLE
Fixing codeclimate failures (hopefully)

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -44,7 +44,6 @@ plugins:
       - XXX
   pylint:
     enabled: true
-    channel: "beta"
     checks:
       import-error:
         enabled: false


### PR DESCRIPTION
We previously used the beta channel of pylint, before it was fully supported in codeclimate. No reason to do this now, and the beta channel seems to fail. This PR will still report codeclimate failures, but digging deeper seems to suggest that this is working. A PR rebased to this after this is merged will be the real test.

@ahnitz can you merge this.