### PR TITLE
Check if sample_points is a pycbc Array and convert if not

### DIFF
--- a/pycbc/waveform/waveform.py
+++ b/pycbc/waveform/waveform.py
@@ -526,6 +526,8 @@ def get_fd_waveform_sequence(template=None, **kwds):
         required = wav_gen.required
     else:
         required = parameters.fd_required
+    if not isinstance(input_params['sample_points'], Array):
+        input_params['sample_points'] = Array(input_params['sample_points'])
     check_args(input_params, required)
     return wav_gen(**input_params)
 

--- a/test/test_waveform.py
+++ b/test/test_waveform.py
@@ -56,7 +56,7 @@ class TestWaveform(unittest.TestCase):
                 self.assertTrue(len(htilde)> 0)
 
     def test_frequency_sequence(self):
-        sample_points = np.geomspace(10, 400, 50)
+        sample_points = numpy.geomspace(10, 400, 50)
         hp, hc = get_fd_waveform_sequence(approximant="IMRPhenomXAS", mass1=20, mass2=20, sample_points=sample_points)
         hp_ref, hc_ref = get_fd_waveform_sequence(approximant="IMRPhenomXAS", mass1=20, mass2=20, sample_points=Array(sample_points))
         self.assertEqual(hp, hp_ref)

--- a/test/test_waveform.py
+++ b/test/test_waveform.py
@@ -30,6 +30,7 @@ from numpy import sqrt, cos, sin
 from pycbc.scheme import CPUScheme
 from pycbc.waveform import get_td_waveform, get_fd_waveform
 from utils import parse_args_all_schemes, simple_exit
+from pycbc.types import Array
 
 _scheme, _context = parse_args_all_schemes("Waveform")
 
@@ -54,6 +55,12 @@ class TestWaveform(unittest.TestCase):
                 htilde, g = get_fd_waveform(approximant=waveform,mass1=20,mass2=20,delta_f=1.0/256,f_lower=40)
                 self.assertTrue(len(htilde)> 0)
 
+    def test_frequency_sequence(self):
+        sample_points = np.geomspace(10, 400, 50)
+        hp, hc = get_fd_waveform_sequence(approximant="IMRPhenomXAS", mass1=20, mass2=20, sample_points=sample_points)
+        hp_ref, hc_ref = get_fd_waveform_sequence(approximant="IMRPhenomXAS", mass1=20, mass2=20, sample_points=Array(sample_points))
+        self.assertEqual(hp, hp_ref)
+        self.assertEqual(hc, hc_ref)
 
     def test_spintaylorf2GPU(self):
 

--- a/test/test_waveform.py
+++ b/test/test_waveform.py
@@ -28,7 +28,7 @@ import unittest
 import numpy
 from numpy import sqrt, cos, sin
 from pycbc.scheme import CPUScheme
-from pycbc.waveform import get_td_waveform, get_fd_waveform
+from pycbc.waveform import get_td_waveform, get_fd_waveform, get_fd_waveform_sequence
 from utils import parse_args_all_schemes, simple_exit
 from pycbc.types import Array
 


### PR DESCRIPTION
`pycbc.waveform.get_fd_waveform_sequence` requires `sample_points` to be a pycbc `Array`  instead of a numpy array. Since `get_fd_waveform` and `get_td_waveform` do not demand any inputs to be pycbc custom types (probably because most/all inputs are floats), it makes sense to add a check for `sample_points` being a numpy array and converting to an `Array` if that is the case. This PR does exactly that.