### PR TITLE
Support detector frame waveforms for inference

### DIFF
--- a/pycbc/inference/models/gaussian_noise.py
+++ b/pycbc/inference/models/gaussian_noise.py
@@ -707,6 +707,15 @@ class GaussianNoise(BaseGaussianNoise):
         log likelihood. Default is to not include it.
     static_params : dict, optional
         A dictionary of parameter names -> values to keep fixed.
+    det_frame_waveform : bool
+        If True, the waveform will be generated directly in the detector frame
+        using the
+        :py:class:`~pycbc.waveform.generator.FDomainDirectDetFrameGenerator`.
+        This requires the approximant be implemented in
+        :py:func:`~pycbc.waveform.get_fd_det_waveform`.
+        If False, the
+        :py:class:`~pycbc.waveform.generator.FDomainDetFrameGenerator` will be
+        used instead. Defaults to :code:`False`.
     \**kwargs :
         All other keyword arguments are passed to ``BaseDataModel``.
 

--- a/pycbc/inference/models/gaussian_noise.py
+++ b/pycbc/inference/models/gaussian_noise.py
@@ -552,11 +552,18 @@ class BaseGaussianNoise(BaseDataModel, metaclass=ABCMeta):
             args['normalize'] = True
         if cp.has_option('model', 'ignore-failed-waveforms'):
             args['ignore_failed_waveforms'] = True
+        if cp.has_option('model', 'det-frame-waveform'):
+            args['det_frame_waveform'] = True
         if cp.has_option('model', 'no-save-data'):
             args['no_save_data'] = True
         # get any other keyword arguments provided in the model section
-        ignore_args = ['name', 'normalize',
-                       'ignore-failed-waveforms', 'no-save-data']
+        ignore_args = [
+            'name',
+            'normalize',
+            'ignore-failed-waveforms',
+            'no-save-data',
+            'det-frame-waveform'
+        ]
         for option in cp.options("model"):
             if option in ("low-frequency-cutoff", "high-frequency-cutoff"):
                 ignore_args.append(option)
@@ -818,17 +825,22 @@ class GaussianNoise(BaseGaussianNoise):
 
     def __init__(self, variable_params, data, low_frequency_cutoff, psds=None,
                  high_frequency_cutoff=None, normalize=False,
-                 static_params=None, **kwargs):
+                 static_params=None, det_frame_waveform=False, **kwargs):
         # set up the boiler-plate attributes
         super(GaussianNoise, self).__init__(
             variable_params, data, low_frequency_cutoff, psds=psds,
             high_frequency_cutoff=high_frequency_cutoff, normalize=normalize,
             static_params=static_params, **kwargs)
         # Determine if all data have the same sampling rate and segment length
+        if det_frame_waveform:
+            generator_class = generator.FDomainDirectDetFrameGenerator
+        else:
+            generator_class = generator.FDomainDetFrameGenerator
         if self.all_ifodata_same_rate_length:
             # create a waveform generator for all ifos
             self.waveform_generator = create_waveform_generator(
                 self.variable_params, self.data,
+                generator_class=generator_class,
                 waveform_transforms=self.waveform_transforms,
                 recalibration=self.recalibration,
                 gates=self.gates, **self.static_params)
@@ -838,6 +850,7 @@ class GaussianNoise(BaseGaussianNoise):
             for det in self.data:
                 self.waveform_generator[det] = create_waveform_generator(
                     self.variable_params, {det: self.data[det]},
+                    generator_class=generator_class,
                     waveform_transforms=self.waveform_transforms,
                     recalibration=self.recalibration,
                     gates=self.gates, **self.static_params)


### PR DESCRIPTION
This PR adds support for using detector-frame waveforms (e.g. those produced by `get_fd_det_waveform`) in the inference module.

**Summary of changes**

- Add a new generator class, `FDomainDirectDetFrameGenerator` 
- Add the `det_frame_waveform` option to the `GaussianNoise` class to which enables the use of the new generator.

I considered automatically determining if a waveform is implemented in the detector frame or not, but I wasn't sure if a waveform could support both, so opted for a boolean instead. I can change this if it is preferred. I'm happy to rename the class/variables.

**Example**

My use-case for this is for performing inference in LISA with BBHx, so I've tested this with a modified version of the existing SMBH injection example. Here's the result:

![image](https://github.com/gwastro/pycbc/assets/25609742/1cbce8ef-79fd-4b67-bb86-beb89398d0b2)


I can also add this version to the directory if desired. I will note though that this is quite slow; running with nessai and 8 process, it takes around 10 minutes.

**Other thoughts**

I have not tested how this interacts with any other likelihoods, I know it won't be valid for some of them.