### PR TITLE
Add support for inessai sampler

### DIFF
--- a/companion.txt
+++ b/companion.txt
@@ -17,7 +17,7 @@ https://github.com/willvousden/ptemcee/archive/master.tar.gz
 # Force the cpu-only version of PyTorch
 --extra-index-url https://download.pytorch.org/whl/cpu
 torch
-nessai>=0.11.0
+nessai>=0.12.0
 snowline
 
 # useful to look at PyCBC Live with htop

--- a/examples/inference/samplers/inessai_stub.ini
+++ b/examples/inference/samplers/inessai_stub.ini
@@ -1,0 +1,4 @@
+[sampler]
+name = inessai
+nlive = 200
+min_samples = 100

--- a/examples/inference/samplers/run.sh
+++ b/examples/inference/samplers/run.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-for f in cpnest_stub.ini emcee_stub.ini emcee_pt_stub.ini dynesty_stub.ini ultranest_stub.ini epsie_stub.ini nessai_stub.ini snowline_stub.ini; do
+for f in cpnest_stub.ini emcee_stub.ini emcee_pt_stub.ini dynesty_stub.ini ultranest_stub.ini epsie_stub.ini nessai_stub.ini inessai_stub.ini snowline_stub.ini; do
         echo $f
 	pycbc_inference \
         --config-files `dirname $0`/simp.ini `dirname $0`/$f \
@@ -17,6 +17,7 @@ ultranest_stub.ini.hdf:ultranest \
 epsie_stub.ini.hdf:espie \
 cpnest_stub.ini.hdf:cpnest \
 nessai_stub.ini.hdf:nessai \
+inessai_stub.ini.hdf:inessai \
 snowline_stub.ini.hdf:snowline \
 --output-file sample.png \
 --plot-contours \

--- a/pycbc/inference/sampler/__init__.py
+++ b/pycbc/inference/sampler/__init__.py
@@ -69,8 +69,9 @@ except ImportError:
     pass
 
 try:
-    from .nessai import NessaiSampler
+    from .nessai import INessaiSampler, NessaiSampler
     samplers[NessaiSampler.name] = NessaiSampler
+    samplers[INessaiSampler.name] = INessaiSampler
 except ImportError:
     pass
 

--- a/pycbc/inference/sampler/nessai.py
+++ b/pycbc/inference/sampler/nessai.py
@@ -109,7 +109,7 @@ class NessaiSampler(BaseSampler):
         if output is None:
             output = os.path.join(
                 os.path.dirname(os.path.abspath(self.checkpoint_file)),
-                "outdir_nessai",
+                f"outdir_{self.name}",
             )
 
         if kwargs is not None:
@@ -381,7 +381,6 @@ class NessaiModel(nessai.model.Model):
         # As of nessai v0.12.0, this method is not required to use the
         # importance nested sampler
         raise NotImplementedError
-    
 
 
 class INessaiSampler(NessaiSampler):

--- a/pycbc/inference/sampler/nessai.py
+++ b/pycbc/inference/sampler/nessai.py
@@ -23,10 +23,15 @@ from ...pool import choose_pool
 
 
 class NessaiSampler(BaseSampler):
-    """Class to construct a FlowSampler from the nessai package."""
+    """Class to construct a FlowSampler from the nessai package.
+    
+    Supports both the standard and importance nested sampler version of nessai.
+    Defaults to the standard version.
+    """
 
     name = "nessai"
     _io = NessaiFile
+    _importance_nested_sampler = False
 
     def __init__(
         self,
@@ -69,25 +74,29 @@ class NessaiSampler(BaseSampler):
     @property
     def samples(self):
         """The raw nested samples including the corresponding weights"""
-        if self._sampler.ns.nested_samples:
-            ns = numpy.array(self._sampler.ns.nested_samples)
-            samples = nessai.livepoint.live_points_to_dict(
-                ns,
-                self.model.sampling_params,
-            )
-            samples["logwt"] = self._sampler.ns.state.log_posterior_weights
-            samples["loglikelihood"] = ns["logL"]
-            samples["logprior"] = ns["logP"]
-            samples["it"] = ns["it"]
-        else:
-            samples = {}
+        # When using the importance nested sampler, use all samples rather
+        # than the nested samples.
+        try:
+            raw_samples = numpy.array(self._sampler.ns.samples)
+        except AttributeError:
+            raw_samples = numpy.array(self._sampler.ns.nested_samples)
+        if not len(raw_samples):
+            return {}
+        samples = nessai.livepoint.live_points_to_dict(
+            raw_samples,
+            self.model.sampling_params,
+        )
+        samples["logwt"] = self._sampler.ns.state.log_posterior_weights
+        samples["loglikelihood"] = raw_samples["logL"]
+        samples["logprior"] = raw_samples["logP"]
+        samples["it"] = raw_samples["it"]
         return samples
 
     def run(self, **kwargs):
         """Run the sampler"""
         default_kwds, default_run_kwds = self.get_default_kwds(
             importance_nested_sampler=self.extra_kwds.get(
-                "importance_nested_sampler", False
+                "importance_nested_sampler", self._importance_nested_sampler
             )
         )
 
@@ -163,13 +172,7 @@ class NessaiSampler(BaseSampler):
                 "importance_nested_sampler",
             )
         else:
-            importance_nested_sampler = False
-
-        # Requires additional development work, see the model class below
-        if importance_nested_sampler is True:
-            raise NotImplementedError(
-                "Importance nested sampler is not currently supported"
-            )
+            importance_nested_sampler = cls._importance_nested_sampler
 
         default_kwds, default_run_kwds = cls.get_default_kwds(
             importance_nested_sampler
@@ -188,7 +191,9 @@ class NessaiSampler(BaseSampler):
             default_kwds.pop(kwd, None)
             default_run_kwds.pop(kwd, None)
 
-        kwds = {}
+        kwds = {
+            "importance_nested_sampler": importance_nested_sampler,
+        }
         run_kwds = {}
 
         # ast.literal_eval is used here since specifying a dictionary with all
@@ -365,11 +370,21 @@ class NessaiModel(nessai.model.Model):
 
     def from_unit_hypercube(self, x):
         """Map from the unit-hypercube to the prior."""
-        # Needs to be implemented for importance nested sampler
-        # This method is already available in pycbc but the inverse is not
-        raise NotImplementedError
+        x_out = x.copy()
+        inv = self.model.prior_distribution.cdfinv(**{n: x[n] for n in self.names})
+        for name in self.names:
+            x_out[name] = inv[name]
+        return x_out
 
     def to_unit_hypercube(self, x):
         """Map to the unit-hypercube to the prior."""
-        # Needs to be implemented for importance nested sampler
+        # As of nessai v0.12.0, this method is not required to use the
+        # importance nested sampler
         raise NotImplementedError
+    
+
+
+class INessaiSampler(NessaiSampler):
+    """Wrapper for nessai that defaults to the importance nested sampler"""
+    name = "inessai"
+    _importance_nested_sampler = True


### PR DESCRIPTION
<!---
Please delete these comments when you submit the pull request

Please add a title which is a concise description of what you are doing,
e.g. 'Fix bug with numpy import in pycbc_coinc_findtrigs' or 'add high frequency sky location dependent response for long detectors'
-->

<!---
This is a brief template for making pull requests for PyCBC.
This is _not_ a proscriptive template - you can use a different style if you want.
Please do think about the questions posed here and whether the details will be useful to include in your PR
Please add sufficient details so that people looking back at the request with no context around the work can understand the changes.
To choose reviewers, please look at the git blame for the code you are changing (if applicable),
or discuss in the #pycbc-code channel of the gwastro slack.
Please add labels as appropriate
-->

<!-- TOP-LEVEL SUMMARY: Please provide a brief, one-or-two-sentence description of the PR here
-->

## Standard information about the request

<!--- Some basic info about the change (delete as appropriate) -->
This is a: bug fix, new feature, efficiency update, other (please describe)

<!--- What codes will this affect? (delete as apropriate)
If you do not know which areas will be affected, please ask in the gwastro #pycbc-code slack
-->
This change affects: inference

<!--- What code areas will this affect? (delete as apropriate) -->
This change changes: the `nessai` sampler to support the importance nested sampler version

<!--- Some things which help with code management (delete as appropriate) -->
This change: is tested via an example, follows style guidelines (See e.g. [PEP8](https://peps.python.org/pep-0008/)), has been proposed using the [contribution guidelines](https://github.com/gwastro/pycbc/blob/master/CONTRIBUTING.md)

<!--- Notes about the effect of this change -->
This change will: does not break any existing code

## Motivation
<!--- Describe why your changes are being made -->

With the release of nessai 0.12.0, a method for mapping from the prior to the unit hypercube is no longer required for the importance nested sampler (ins). This means we can support the ins (inessai) with a few minor changes to the existing implementation.

## Contents
<!--- Describe your changes, this doesn't need to be a line-by-line code change discussion,
but rather a general discussion of the methods chosen -->

Updates to the existing class so that it supports the `importance_nested_sampler` option. This is `False` by default.

I also added a second class `INessaiSampler` that has this default switch to `True` and has the name set to `inessai`.

This means there are two ways of calling the importance nested sampler.


## Testing performed
<!--- Describe tests for the code changes, either already performed or to be performed -->

Run the example included in `examples/inference/samplers/`

## Additional notes
<!--- Anything which does not fit in the above sections -->

**To-do**

- [ ] Test checkpoint after this change, since it reworks the `samples` property.
- [ ] Test on BBH

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
