### PR TITLE
Typo in live significance fits supervision script

### DIFF
--- a/bin/live/pycbc_live_supervise_single_significance_fits
+++ b/bin/live/pycbc_live_supervise_single_significance_fits
@@ -143,7 +143,7 @@ def run_and_error(command_arguments):
 control_options = [
     "check-daily-output",
     "combined-days",
-    "mail-volunteers-file"
+    "mail-volunteers-file",
     "output-directory",
     "output-id-str",
     "public-dir",


### PR DESCRIPTION
Typo in the supervision script

## Standard information about the request
This is a bug fix

This change affects the live search

This change follows style guidelines (See e.g. [PEP8](https://peps.python.org/pep-0008/)), has been proposed using the [contribution guidelines](https://github.com/gwastro/pycbc/blob/master/CONTRIBUTING.md)


## Testing performed
None

## Additional notes


- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
