### PR TITLE
Script to create hdf trigger merge files from PyCBC Live output trigger files

### DIFF
--- a/bin/live/pycbc_live_collate_triggers
+++ b/bin/live/pycbc_live_collate_triggers
@@ -1,0 +1,302 @@
+import glob
+import numpy
+import argparse
+import h5py
+import os
+import logging
+import timeit
+from datetime import datetime, timedelta
+
+# Set up the command line argument parser
+parser = argparse.ArgumentParser(description='Find trigger files and combine '
+                                             'them into a single hdf trigger '
+                                             'merge file.')
+
+parser.add_argument('--trigger-file-method', type=str, required=True,
+                    help='The method to use to find the trigger files. '
+                         'Options are: file, dir, start-end-date, '
+                         ' start-num-days, gps-start-end-time.',
+                    choices=['file', 'dir', 'start-end-date',
+                             'start-num-days', 'gps-start-end-time'])
+
+parser.add_argument('--trigger-dir', type=str, required=False,
+                    help='The directory containing all of the PyCBC Live '
+                         'trigger files. The directory must contain sub-'
+                         'directories with naming schemes "YYYY-MM-DD".'
+                         'The trigger files must be of the format: '
+                         '"{ifos}-Live-GPSTIME-INCREMENT.hdf".')
+
+# Take trigger files from file
+parser.add_argument('--list-of-trigger-files', type=str,
+                    help='A file containing all the trigger files you '
+                    ' would like to collate.')
+
+# Take trigger files from start and end date
+parser.add_argument('--start-date', type=str, required=False,
+                    help='The first day of triggers you want to collate.'
+                         'If no end date is given, the start date is the '
+                         'only day.')
+parser.add_argument('--end-date', type=str, required=False,
+                    help='The final day of triggers to collect. If no end '
+                         'is provided then only the start day is used.')
+
+# Take trigger files from start and num days
+parser.add_argument('--num-days', type=int, required=False,
+                    help='The number of days after (and including) the start '
+                    'date to collate triggers from.')
+
+# Take trigger files from gps start and end time
+parser.add_argument('--gps-start-time', type=int, required=False,
+                    help='Start time of the collection of trigger files.')
+parser.add_argument('--gps-end-time', type=int, required=False,
+                    help='End time of the collection of trigger files.')
+
+parser.add_argument('--ifos', type=str, required=True, nargs='+',
+                    help='The detectors to extract triggers for in the '
+                         'trigger files.')
+
+# Option to output list of trigger files
+parser.add_argument('--output-trigger-file-list', type=str,
+                    help='Name of the output file to save the list of trigger files.')
+
+parser.add_argument('--output-dir', type=str, required=True,
+                    help='The directory to write the collated trigger file '
+                         'to. The file will be named with the following '
+                         'format: "{ifos}-Live-STARTGPS-ENDGPS.hdf" unless '
+                         'an output file name is provided.')
+parser.add_argument('--output-file-name', type=str, required=False,
+                    help='The name of the output file to save the collated '
+                         'trigger file to. If not provided, the file will be '
+                         'named with the format: "{ifos}-Live-STARTGPS-ENDGPS.hdf"')
+
+args = parser.parse_args()
+
+logging.basicConfig(level=logging.INFO)
+
+# GRAB THE TRIGGER FILES TO COLLATE
+if args.trigger_file_method == 'file':
+    assert args.list_of_trigger_files, 'Please provide a list of trigger files.'
+    trigger_files = numpy.loadtxt(args.list_of_trigger_files,
+                                  delimiter=',', dtype=str)
+
+if args.trigger_file_method == 'dir':
+    assert args.trigger_dir, 'Please provide a directory containing trigger files.'
+    trigger_files = [
+        l for l in glob.glob(args.trigger_dir + '/*/*-Live-*.hdf', recursive=True)
+    ]
+
+if args.trigger_file_method == 'start-end-date':
+    assert args.start_date, 'Please provide a start date.'
+    assert args.end_date, 'Please provide an end date.'
+    assert args.trigger_dir, 'Please provide a directory containing trigger files.'
+    # Convert dates to datetime to get the days array
+    start_date = datetime.strptime(args.start_date, '%Y-%m-%d').date()
+    end_date = datetime.strptime(args.end_date, '%Y-%m-%d').date()
+
+    # Create the days array
+    days = []
+    delta = timedelta(days=1)
+
+    # Loop through the days and add each date to the list
+    current_date = start_date
+    while current_date <= end_date:
+        days.append(current_date)
+        current_date += delta
+
+    # Convert to strings in a list
+    days = [str(date).replace('-', '_') for date in days]
+    num_days = str(len(days))
+
+    trigger_files = [
+        os.path.join(args.trigger_dir, day, trigger_file)
+        for day in days
+        for trigger_file in os.listdir(os.path.join(args.trigger_dir, day))
+    ]
+
+if args.trigger_file_method == 'start-num-days':
+    assert args.start_date, 'Please provide a start date.'
+    assert args.num_days, 'Please provide a number of days.'
+    assert args.trigger_dir, 'Please provide a directory containing trigger files.'
+    # Convert dates to datetime to get the days array
+    start_date = datetime.strptime(args.start_date, '%Y-%m-%d').date()
+    num_days = timedelta(days=args.num_days - 1)
+    end_date = start_date + num_days
+
+    # Create the days array
+    days = []
+    delta = timedelta(days=1)
+
+    # Loop through the days and add each date to the list
+    current_date = start_date
+    while current_date <= end_date:
+        days.append(current_date)
+        current_date += delta
+
+    # Convert to strings in a list
+    days = [str(date).replace('-', '_') for date in days]
+    num_days = str(len(days))
+
+    trigger_files = [
+        os.path.join(args.trigger_dir, day, trigger_file)
+        for day in days
+        for trigger_file in os.listdir(os.path.join(args.trigger_dir, day))
+    ]
+
+if args.trigger_file_method == 'gps-start-end-time':
+    assert args.gps_start_time, 'Please provide a GPS start time.'
+    assert args.gps_end_time, 'Please provide a GPS end time.'
+    assert args.trigger_dir, 'Please provide a directory containing trigger files.'
+
+    trigger_files = [
+        l for l in glob.glob(args.trigger_dir + '/*/*-Live-*.hdf', recursive=True)
+        if float(l.split('/')[-1][10:27]) > args.gps_start_time and float(l.split('/')[-1][10:27]) < args.gps_end_time
+    ]
+
+start = timeit.default_timer()
+logging.info(f" {len(trigger_files)} files found")
+
+if args.output_trigger_file_list:
+    logging.info(' Writing list of trigger files to: ' + args.output_trigger_file_list)
+    with open(args.output_trigger_file_list, 'w') as f:
+        for item in trigger_files:
+            f.write("%s\n" % item)
+
+# Record start and end gpstime for the output file
+#  This assumes the trigger files are sorted chronologically
+start_gpstime = float(trigger_files[0].split('/')[-1][10:27])
+end_gpstime = float(trigger_files[-1].split('/')[-1][10:27])
+
+###########################
+# COLLATE THE TRIGGER FILES
+###########################
+
+if args.output_file_name:
+    output_file = args.output_dir + args.output_file_name
+else:
+    ifo_string = "".join(args.ifos)
+    print(ifo_string)
+    output_file = args.output_dir + f'{ifo_string}-Live-' + start_gpstime + '-' + end_gpstime + '.hdf'
+
+logging.info(f" Creating a file at: {output_file}")
+with h5py.File(output_file, 'a') as destination:
+    # Create the ifo groups in the trigger file
+    for ifo in args.ifos:
+        if ifo not in destination:
+            destination.create_group(ifo)
+
+    file_count = 0
+    for source_file in trigger_files:
+        file_count += 1
+        trigger_file = os.path.basename(source_file)
+        if not (trigger_file.endswith('.hdf') and trigger_file.startswith('*-Live')):
+            continue
+
+        start_time = float(trigger_file.split('-')[2])
+        duration = float(trigger_file.split('-')[3][:-4])
+        end_time = start_time + duration
+
+        if file_count % 100 == 0:
+            logging.info(f" Files appended: {file_count}/{len(trigger_files)}")
+
+        with h5py.File(source_file, 'r') as source:
+            for ifo in args.ifos:
+                triggers = source[ifo]
+                if ('approximant' not in triggers) or (len(triggers['approximant']) == 0):
+                        continue
+
+                for name, dataset in triggers.items():
+
+                    if name in destination[ifo]:
+                        if triggers[name].shape[0] == 0:
+                            continue
+                        # Append new data to existing dataset in destination
+                        destination[ifo][name].resize((destination[ifo][name].shape[0] + triggers[name].shape[0]), axis=0)
+                        destination[ifo][name][-triggers[name].shape[0]:] = triggers[name]
+                    else:
+                        destination[ifo].create_dataset(name, data=dataset, chunks=True, maxshape=(None,))
+
+                for attr_name, attr_value in source.attrs.items():
+                    destination.attrs[attr_name] = attr_value
+
+                # Create or get the '/search' subgroup within 'H1'/'L1'/'V1'
+                if 'search' not in destination[ifo]:
+                    destination[ifo].create_group('search')
+
+                # Create or append 'start_time' and 'end_time' datasets within the '/search' group
+                if 'start_time' in destination[ifo]['search']:
+                    destination[ifo]['search']['start_time'].resize((destination[ifo]['search']['start_time'].shape[0] + 1), axis=0)
+                    destination[ifo]['search']['start_time'][-1] = start_time
+                else:
+                    destination[ifo]['search'].create_dataset('start_time', chunks=True, data=numpy.array([start_time]), maxshape=(None,))
+
+                if 'end_time' in destination[ifo]['search']:
+                    destination[ifo]['search']['end_time'].resize((destination[ifo]['search']['end_time'].shape[0] + 1), axis=0)
+                    destination[ifo]['search']['end_time'][-1] = end_time
+                else:
+                    destination[ifo]['search'].create_dataset('end_time', chunks=True, data=numpy.array([end_time]), maxshape=(None,))
+
+# Add all the template boundaries
+with h5py.File(output_file, 'a') as output:
+    for ifo in args.ifos:
+        logging.info(f" Adding template boundaries for {ifo}")
+        # Grab the ifo you want
+        triggers = output[ifo]
+        try:
+            template_ids = triggers['template_id'][:]
+        except:
+            logging.info(f"  No triggers for {ifo}, skipping")
+            continue
+
+        # 17.4 seconds to do this
+        tids = numpy.arange(numpy.max(template_ids) + 1, dtype=int)
+
+        sorted_indices = numpy.argsort(template_ids)
+        sorted_template_ids = template_ids[sorted_indices]
+        unique_template_ids, template_id_counts = numpy.unique(sorted_template_ids, return_counts=True)
+        index_boundaries = numpy.cumsum(template_id_counts)
+        template_boundaries = numpy.insert(index_boundaries, 0, 0)[:-1]
+
+        # Re-running purposes, comment out otherwise
+        #del triggers['template_boundaries']
+        triggers['template_boundaries'] = template_boundaries
+
+        # Sort other datasets by template_id so it makes sense:
+        # Datasets with the same length as the number of triggers:
+        #   Approximant, chisq, chisq_dof, coa_phase, end_time, f_lower
+        #   mass_1, mass_2, sg_chisq, sigmasq, snr, spin1z, spin2z,
+        #   template_duration, template_hash, template_id
+        for key in triggers.keys():
+            if len(triggers[key]) == len(template_ids):
+                logging.info(f'  Sorting {key} by template id')
+                sorted_key = triggers[key][:][sorted_indices]
+                triggers[key][:] = sorted_key
+
+
+        # Chisq is saved as reduced chisq for live triggers but offline
+        #  code required original chisq. This converts it back.
+        tmpval = triggers['chisq'][:] * (2 * triggers['chisq_dof'][:] - 2)
+        triggers['chisq'][:] = tmpval
+
+        # Datasets which need region references:
+        region_ref_datasets = ('chisq_dof', 'chisq', 'coa_phase',
+                               'end_time', 'sg_chisq', 'snr',
+                               'template_duration', 'sigmasq')
+        if 'psd_var_val' in triggers.keys():
+            region_ref_datasets += ('psd_var_val',)
+        start_boundaries = template_boundaries
+        end_boundaries = numpy.roll(start_boundaries, -1)
+        end_boundaries[-1] = len(template_ids)
+
+        for dataset in region_ref_datasets:
+            dset = triggers[dataset][:]
+            refs = []
+
+            for i in range(len(template_boundaries)):
+                refs.append(triggers[dataset].regionref[start_boundaries[i]:end_boundaries[i]])
+
+            triggers.create_dataset\
+            (dataset + '_template', data=refs, dtype=h5py.special_dtype(ref=h5py.RegionReference))
+
+end = timeit.default_timer()
+total_time = float(end - start)
+logging.info(f" Time taken: {total_time}")

--- a/bin/live/pycbc_live_collate_triggers
+++ b/bin/live/pycbc_live_collate_triggers
@@ -149,7 +149,7 @@ if args.trigger_file_method == 'gps-start-end-time':
 
     trigger_files = [
         l for l in glob.glob(args.trigger_dir + '/*/*-Live-*.hdf', recursive=True)
-        if float(l.split('/')[-1][10:27]) > args.gps_start_time and float(l.split('/')[-1][10:27]) < args.gps_end_time
+        if float(l.split('/')[-1].split("-")[2]) > args.gps_start_time and float(l.split('/')[-1].split("-")[2]) < args.gps_end_time
     ]
 
 start = timeit.default_timer()
@@ -163,8 +163,8 @@ if args.output_trigger_file_list:
 
 # Record start and end gpstime for the output file
 #  This assumes the trigger files are sorted chronologically
-start_gpstime = float(trigger_files[0].split('/')[-1][10:27])
-end_gpstime = float(trigger_files[-1].split('/')[-1][10:27])
+start_gpstime = float(trigger_files[0].split('/')[-1].split("-")[2])
+end_gpstime = float(trigger_files[0].split('/')[-1].split("-")[2])
 
 ###########################
 # COLLATE THE TRIGGER FILES
@@ -184,11 +184,15 @@ with h5py.File(output_file, 'a') as destination:
         if ifo not in destination:
             destination.create_group(ifo)
 
+    # The user must give the ifos in the same order as the trigger files
+    #  For PyCBC Live it's always H1L1 or H1L1V1?
+    ifo_prefix = "".join(args.ifos)
+
     file_count = 0
     for source_file in trigger_files:
         file_count += 1
         trigger_file = os.path.basename(source_file)
-        if not (trigger_file.endswith('.hdf') and trigger_file.startswith('*-Live')):
+        if not (trigger_file.endswith('.hdf') and trigger_file.startswith(f'{ifo_prefix}-Live')):
             continue
 
         start_time = float(trigger_file.split('-')[2])

--- a/bin/live/pycbc_live_collate_triggers
+++ b/bin/live/pycbc_live_collate_triggers
@@ -17,6 +17,7 @@
 import glob
 import numpy
 import argparse
+import itertools
 import h5py
 import os
 import logging
@@ -92,14 +93,14 @@ if args.trigger_file_method == 'file':
     if not args.list_of_trigger_files:
         parser.error('Please provide a list of trigger files.')
 
-    trigger_files = numpy.loadtxt(args.list_of_trigger_files,
+    initial_trigger_files = numpy.loadtxt(args.list_of_trigger_files,
                                   delimiter=',', dtype=str)
 
 if args.trigger_file_method == 'dir':
     if not args.trigger_dir:
         parser.error('Please provide a directory containing trigger files.')
 
-    trigger_files = [
+    initial_trigger_files = [
         l for l in glob.glob(args.trigger_dir + '/*/*-Live-*.hdf', recursive=True)
     ]
 
@@ -129,7 +130,7 @@ if args.trigger_file_method == 'start-end-date':
     days = [str(date).replace('-', '_') for date in days]
     num_days = str(len(days))
 
-    trigger_files = [
+    initial_trigger_files = [
         os.path.join(args.trigger_dir, day, trigger_file)
         for day in days
         for trigger_file in os.listdir(os.path.join(args.trigger_dir, day))
@@ -162,7 +163,7 @@ if args.trigger_file_method == 'start-num-days':
     days = [str(date).replace('-', '_') for date in days]
     num_days = str(len(days))
 
-    trigger_files = [
+    initial_trigger_files = [
         os.path.join(args.trigger_dir, day, trigger_file)
         for day in days
         for trigger_file in os.listdir(os.path.join(args.trigger_dir, day))
@@ -176,12 +177,24 @@ if args.trigger_file_method == 'gps-start-end-time':
     if not args.trigger_dir:
         parser.error('Please provide a directory containing trigger files.')
 
-    trigger_files = [
+    initial_trigger_files = [
         l for l in glob.glob(args.trigger_dir + '/*/*-Live-*.hdf', recursive=True)
         if float(l.split('/')[-1].split("-")[2]) > args.gps_start_time and float(l.split('/')[-1].split("-")[2]) < args.gps_end_time
     ]
 
-logging.info(f" {len(trigger_files)} files found")
+logging.info(f" {len(initial_trigger_files)} files found")
+
+# Check if all files found are in the correct format and are trigger files
+ifo_permutations = [''.join(p) for p in itertools.permutations(args.ifos)]
+ifo_prefix_set = set(ifo_permutations)
+
+trigger_files = []
+for source_file in initial_trigger_files:
+    trigger_file = os.path.basename(source_file)
+    if any(trigger_file.startswith(prefix + '-Live') for prefix in ifo_prefix_set):
+        trigger_files.append(source_file)
+
+logging.info(f" {len(trigger_files)} confirmed trigger files")
 
 if args.output_trigger_file_list:
     logging.info(' Writing list of trigger files to: ' + args.output_trigger_file_list)
@@ -212,16 +225,10 @@ with h5py.File(output_file, 'a') as destination:
         if ifo not in destination:
             destination.create_group(ifo)
 
-    # The user must give the ifos in the same order as the trigger files
-    #  For PyCBC Live it's always H1L1 or H1L1V1?
-    ifo_prefix = "".join(args.ifos)
-
     file_count = 0
     for source_file in trigger_files:
         file_count += 1
         trigger_file = os.path.basename(source_file)
-        if not (trigger_file.endswith('.hdf') and trigger_file.startswith(f'{ifo_prefix}-Live')):
-            continue
 
         start_time = float(trigger_file.split('-')[2])
         duration = float(trigger_file.split('-')[3][:-4])

--- a/bin/live/pycbc_live_collate_triggers
+++ b/bin/live/pycbc_live_collate_triggers
@@ -174,7 +174,6 @@ if args.output_file_name:
     output_file = args.output_dir + args.output_file_name
 else:
     ifo_string = "".join(args.ifos)
-    print(ifo_string)
     output_file = args.output_dir + f'{ifo_string}-Live-' + start_gpstime + '-' + end_gpstime + '.hdf'
 
 logging.info(f" Creating a file at: {output_file}")

--- a/bin/live/pycbc_live_collate_triggers
+++ b/bin/live/pycbc_live_collate_triggers
@@ -1,17 +1,31 @@
+#!/usr/bin/env python
+
+# Copyright 2024 Arthur Tolley
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+
+"""Find trigger files and combine them into a single hdf trigger merge file."""
+
 import glob
 import numpy
 import argparse
 import h5py
 import os
 import logging
-import timeit
+import pycbc
 from datetime import datetime, timedelta
 
 # Set up the command line argument parser
-parser = argparse.ArgumentParser(description='Find trigger files and combine '
-                                             'them into a single hdf trigger '
-                                             'merge file.')
-
+parser = argparse.ArgumentParser(description=__doc__)
+pycbc.add_common_pycbc_options(parser)
 parser.add_argument('--trigger-file-method', type=str, required=True,
                     help='The method to use to find the trigger files. '
                          'Options are: file, dir, start-end-date, '
@@ -71,24 +85,32 @@ parser.add_argument('--output-file-name', type=str, required=False,
 
 args = parser.parse_args()
 
-logging.basicConfig(level=logging.INFO)
+pycbc.init_logging(args.verbose)
 
 # GRAB THE TRIGGER FILES TO COLLATE
 if args.trigger_file_method == 'file':
-    assert args.list_of_trigger_files, 'Please provide a list of trigger files.'
+    if not args.list_of_trigger_files:
+        parser.error('Please provide a list of trigger files.')
+
     trigger_files = numpy.loadtxt(args.list_of_trigger_files,
                                   delimiter=',', dtype=str)
 
 if args.trigger_file_method == 'dir':
-    assert args.trigger_dir, 'Please provide a directory containing trigger files.'
+    if not args.trigger_dir:
+        parser.error('Please provide a directory containing trigger files.')
+
     trigger_files = [
         l for l in glob.glob(args.trigger_dir + '/*/*-Live-*.hdf', recursive=True)
     ]
 
 if args.trigger_file_method == 'start-end-date':
-    assert args.start_date, 'Please provide a start date.'
-    assert args.end_date, 'Please provide an end date.'
-    assert args.trigger_dir, 'Please provide a directory containing trigger files.'
+    if not args.start_date:
+        parser.error('Please provide a start date.')
+    if not args.end_date:
+        parser.error('Please provide an end date.')
+    if not args.trigger_dir:
+        parser.error('Please provide a directory containing trigger files.')
+
     # Convert dates to datetime to get the days array
     start_date = datetime.strptime(args.start_date, '%Y-%m-%d').date()
     end_date = datetime.strptime(args.end_date, '%Y-%m-%d').date()
@@ -114,9 +136,13 @@ if args.trigger_file_method == 'start-end-date':
     ]
 
 if args.trigger_file_method == 'start-num-days':
-    assert args.start_date, 'Please provide a start date.'
-    assert args.num_days, 'Please provide a number of days.'
-    assert args.trigger_dir, 'Please provide a directory containing trigger files.'
+    if not args.start_date:
+        parser.error('Please provide a start date.')
+    if not args.num_days:
+        parser.error('Please provide a number of days.')
+    if not args.trigger_dir:
+        parser.error('Please provide a directory containing trigger files.')
+
     # Convert dates to datetime to get the days array
     start_date = datetime.strptime(args.start_date, '%Y-%m-%d').date()
     num_days = timedelta(days=args.num_days - 1)
@@ -143,16 +169,18 @@ if args.trigger_file_method == 'start-num-days':
     ]
 
 if args.trigger_file_method == 'gps-start-end-time':
-    assert args.gps_start_time, 'Please provide a GPS start time.'
-    assert args.gps_end_time, 'Please provide a GPS end time.'
-    assert args.trigger_dir, 'Please provide a directory containing trigger files.'
+    if not args.gps_start_time:
+        parser.error('Please provide a GPS start time.')
+    if not args.gps_end_time:
+        parser.error('Please provide a GPS end time.')
+    if not args.trigger_dir:
+        parser.error('Please provide a directory containing trigger files.')
 
     trigger_files = [
         l for l in glob.glob(args.trigger_dir + '/*/*-Live-*.hdf', recursive=True)
         if float(l.split('/')[-1].split("-")[2]) > args.gps_start_time and float(l.split('/')[-1].split("-")[2]) < args.gps_end_time
     ]
 
-start = timeit.default_timer()
 logging.info(f" {len(trigger_files)} files found")
 
 if args.output_trigger_file_list:
@@ -161,11 +189,6 @@ if args.output_trigger_file_list:
         for item in trigger_files:
             f.write("%s\n" % item)
 
-# Record start and end gpstime for the output file
-#  This assumes the trigger files are sorted chronologically
-start_gpstime = float(trigger_files[0].split('/')[-1].split("-")[2])
-end_gpstime = float(trigger_files[0].split('/')[-1].split("-")[2])
-
 ###########################
 # COLLATE THE TRIGGER FILES
 ###########################
@@ -173,6 +196,12 @@ end_gpstime = float(trigger_files[0].split('/')[-1].split("-")[2])
 if args.output_file_name:
     output_file = args.output_dir + args.output_file_name
 else:
+    # Extract the gpstimes for every file and take min/max for start and end
+    trigger_file_times = [float(trigger_file.split('/')[-1].split("-")[2])
+                          for trigger_file in trigger_files]
+    start_gpstime = min(trigger_file_times)
+    end_gpstime = max(trigger_file_times)
+
     ifo_string = "".join(args.ifos)
     output_file = args.output_dir + f'{ifo_string}-Live-' + start_gpstime + '-' + end_gpstime + '.hdf'
 
@@ -250,17 +279,11 @@ with h5py.File(output_file, 'a') as output:
             logging.info(f"  No triggers for {ifo}, skipping")
             continue
 
-        # 17.4 seconds to do this
-        tids = numpy.arange(numpy.max(template_ids) + 1, dtype=int)
-
         sorted_indices = numpy.argsort(template_ids)
         sorted_template_ids = template_ids[sorted_indices]
         unique_template_ids, template_id_counts = numpy.unique(sorted_template_ids, return_counts=True)
         index_boundaries = numpy.cumsum(template_id_counts)
         template_boundaries = numpy.insert(index_boundaries, 0, 0)[:-1]
-
-        # Re-running purposes, comment out otherwise
-        #del triggers['template_boundaries']
         triggers['template_boundaries'] = template_boundaries
 
         # Sort other datasets by template_id so it makes sense:
@@ -276,7 +299,7 @@ with h5py.File(output_file, 'a') as output:
 
 
         # Chisq is saved as reduced chisq for live triggers but offline
-        #  code required original chisq. This converts it back.
+        # code requires original chisq. This converts it back.
         tmpval = triggers['chisq'][:] * (2 * triggers['chisq_dof'][:] - 2)
         triggers['chisq'][:] = tmpval
 
@@ -300,6 +323,4 @@ with h5py.File(output_file, 'a') as output:
             triggers.create_dataset\
             (dataset + '_template', data=refs, dtype=h5py.special_dtype(ref=h5py.RegionReference))
 
-end = timeit.default_timer()
-total_time = float(end - start)
-logging.info(f" Time taken: {total_time}")
+logging.info("Done!")

--- a/bin/live/pycbc_live_collate_triggers
+++ b/bin/live/pycbc_live_collate_triggers
@@ -42,12 +42,6 @@ parser.add_argument(
     help="The list of detectors to include triggers in the merged file"
 )
 
-# Option to output list of trigger files
-parser.add_argument(
-    '--output-trigger-file-list',
-    help='Name of the output file to save the list of trigger files.'
-)
-
 parser.add_argument(
     '--output-file',
     required=True,
@@ -66,15 +60,6 @@ pycbc.init_logging(args.verbose)
 logging.info("Finding trigger files")
 trigger_files = liveio.find_trigger_files_from_cli(args)
 logging.info("%s files found", len(trigger_files))
-
-if args.output_trigger_file_list:
-    logging.info(
-        'Writing list of trigger files to %s ',
-        args.output_trigger_file_list
-    )
-    with open(args.output_trigger_file_list, 'w') as f:
-        for item in trigger_files:
-            f.write("%s\n" % item)
 
 ###########################
 # COLLATE THE TRIGGER FILES
@@ -96,6 +81,10 @@ file_count = 0
 n_triggers = {ifo: 0 for ifo in args.ifos}
 n_triggers_cut = {ifo: 0 for ifo in args.ifos}
 segs = {ifo: segmentlist([]) for ifo in args.ifos}
+
+with h5py.File(args.bank_file,'r') as bank_file:
+    # Count the number of templates
+    n_templates = bank_file['template_hash'].size
 
 with h5py.File(args.output_file, 'w') as destination:
     # Create the ifo groups in the trigger file
@@ -171,7 +160,7 @@ with h5py.File(args.output_file, 'w') as destination:
                             n_triggers_cut[ifo],
                             axis=0
                         )
-                        destination[ifo][name][-keep_idx.size:] = triggers[name]
+                        destination[ifo][name][-keep_idx.size:] = dataset
                     else:
                         destination[ifo].create_dataset(
                             name,
@@ -208,15 +197,10 @@ with h5py.File(args.output_file, 'w') as destination:
                 n_triggers_cut[ifo],
             )
 
-with h5py.File(args.bank_file,'r') as bank_file:
-    # Count the number of templates
-    n_templates = bank_file['template_hash'].size
-
-# Add all the template boundaries
-with h5py.File(args.output_file, 'a') as output:
+    # Add all the template boundaries
     for ifo in args.ifos:
         logging.info("Processing %s", ifo)
-        triggers = output[ifo]
+        triggers = destination[ifo]
         try:
             template_ids = triggers['template_id'][:]
         except KeyError:

--- a/bin/live/pycbc_live_collate_triggers
+++ b/bin/live/pycbc_live_collate_triggers
@@ -103,8 +103,7 @@ with h5py.File(args.output_file, 'w') as destination:
         if ifo not in destination:
             destination.create_group(ifo)
 
-    for source_file in trigger_files:
-        file_count += 1
+    for file_count, source_file in enumerate(trigger_files):
         trigger_file = os.path.basename(source_file)
 
         start_time = float(trigger_file.split('-')[2])
@@ -161,7 +160,7 @@ with h5py.File(args.output_file, 'w') as destination:
                 }
 
                 if ('approximant' not in triggers) or (len(triggers['approximant']) == 0):
-                        continue
+                    continue
 
                 for name, dataset in triggers.items():
                     if name in destination[ifo]:


### PR DESCRIPTION
This script is used to convert a large number of PyCBC Live trigger output files to a hdf trigger merge file.

## Standard information about the request

<!--- Some basic info about the change -->
This is a: new feature

<!--- What codes will this affect?
-->
This change affects: the live search

<!--- What code areas will this affect? -->
This change changes: scientific output

## Motivation
<!--- Describe why your changes are being made -->

Using template fits in the PyCBC Live search (#4527) requires template fits to be made separate to using them. One of the requirements to make these files is a hdf trigger merge. This code produces that trigger merge file.

## Contents
<!--- Describe your changes, this doesn't need to be a line-by-line code change discussion,
but rather a general discussion of the methods chosen -->

The PyCBC Live search outputs a trigger file every stride (8s for Live, 1s for Early Warning) containing any triggers found within the previous stride. This code takes a number of options to be given these trigger files and will then collate them into a single hdf object: from a list of trigger files, from a directory containing subdirectories containing trigger files (typically one subdirectory for each day), from a start and end date, from a start date and a number of days, from a gps start and end time.

The template fit creation code expects the triggers to be in a certain format (the offline trigger file format) and therefore the Live triggers need to be converted to match that format, creating new datasets where needed and ensuring other datasets are correct: for example, PyCBC Live stores chisq as reduced chisq whereas the offline search doesn't, so we convert these PyCBC Live triggers to the offline format.

The triggers are also sorted by template_id and region references are created using the template_id boundaries to allow for rapid access in future codes.

## Links to any issues or associated PRs
<!--- If this is fixing / working around an already-reported issue, please link to it here -->

- Template fits in Live: #4527  

## Testing performed
<!--- Describe tests for the code changes, either already performed or to be performed -->

I have taken 2 days worth of PyCBC Live triggers with H1, L1 & V1 triggers and run the following scripts to test:

From a file containing a list of trigger files:
```
python ../pycbc_live_collate_triggers \
    --trigger-file-method file \
    --list-of-trigger-files test_file_list.txt \
    --ifos H1 L1 V1 \
    --output-trigger-file-list test_file_list_collated.txt \
    --output-dir ./ \
    --output-file-name test_collated_triggers.hdf
```

From a directory containing subdirectories containing trigger files:
```
python ../pycbc_live_collate_triggers \
     --trigger-file-method dir \
     --trigger-dir /home/arthur.tolley/PyCBC_changes/collate_triggers_script/pycbc/bin/live/testing \
     --ifos H1 L1 V1 \
     --output-trigger-file-list test_file_list_collated_dir.txt \
     --output-dir ./ \
     --output-file-name test_collated_triggers_dir.hdf
```

From a start and end date:
```
python ../pycbc_live_collate_triggers \
     --trigger-file-method start-end-date \
     --trigger-dir /home/arthur.tolley/PyCBC_changes/collate_triggers_script/pycbc/bin/live/testing \
     --start-date 2024-04-11 \
     --end-date 2024-04-12 \
     --ifos H1 L1 V1 \
     --output-trigger-file-list test_file_list_collated_start-end.txt \
     --output-dir ./ \
     --output-file-name test_collated_triggers_start-end.hdf
```

From a start date and a number of days:
```
python ../pycbc_live_collate_triggers \
     --trigger-file-method start-num-days \
     --trigger-dir /home/arthur.tolley/PyCBC_changes/collate_triggers_script/pycbc/bin/live/testing \
     --start-date 2024-04-11 \
     --num-days 2 \
     --ifos H1 L1 V1 \
     --output-trigger-file-list test_file_list_collated_start-num.txt \
     --output-dir ./ \
     --output-file-name test_collated_triggers_start-num.hdf
```

From a start and end gps time:
```
python ../pycbc_live_collate_triggers \
     --trigger-file-method gps-start-end-time \
     --trigger-dir /home/arthur.tolley/PyCBC_changes/collate_triggers_script/pycbc/bin/live/testing \
     --gps-start-time 1396828816 \
     --gps-end-time 1396844864 \
     --ifos H1 L1 V1 \
     --output-trigger-file-list test_file_list_collated_gps.txt \
     --output-dir ./ \
     --output-file-name test_collated_triggers_gps.hdf
```

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
