### PR TITLE
Fix numpy include path

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -72,10 +72,9 @@ def find_files(dirname, relpath=None):
 
 class cbuild_ext(_build_ext):
     def run(self):
-        import pkg_resources
-
         # At this point we can be sure pip has already installed numpy
-        numpy_incl = pkg_resources.resource_filename('numpy', 'core/include')
+        import numpy
+        numpy_incl = numpy.get_include()
 
         for ext in self.extensions:
             if (hasattr(ext, 'include_dirs') and


### PR DESCRIPTION
This PR patches `setup.py` to dynamically discover the NumPy include path, rather than hardcoding.

Fixes #4698.

## Standard information about the request

<!--- Some basic info about the change (delete as appropriate) -->
This is a: bug fix
<!--- What codes will this affect? (delete as apropriate)
If you do not know which areas will be affected, please ask in the gwastro #pycbc-code slack
-->
This change affects: everything

<!--- What code areas will this affect? (delete as apropriate) -->
This change changes: the build

<!--- Some things which help with code management (delete as appropriate) -->
This change: has appropriate unit tests, follows style guidelines (See e.g. [PEP8](https://peps.python.org/pep-0008/)), has been proposed using the [contribution guidelines](https://github.com/gwastro/pycbc/blob/master/CONTRIBUTING.md)

<!--- Notes about the effect of this change -->
This change will: require a new release

## Motivation
<!--- Describe why your changes are being made -->

The current build is broken when using numpy 2.0.0 release candidates.

## Contents
<!--- Describe your changes, this doesn't need to be a line-by-line code change discussion,
but rather a general discussion of the methods chosen -->

Patch `setup.py` to use `numpy.get_include()`.

## Links to any issues or associated PRs
<!--- If this is fixing / working around an already-reported issue, please link to it here -->
Fixes #4698 

## Testing performed
<!--- Describe tests for the code changes, either already performed or to be performed -->
Local testing

## Additional notes
<!--- Anything which does not fit in the above sections -->

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
