### PR TITLE
Typo fix: precessing -> processing

### DIFF
--- a/pycbc/scheme.py
+++ b/pycbc/scheme.py
@@ -262,7 +262,7 @@ def insert_processing_option_group(parser):
                       default=0, type=int)
 
 def from_cli(opt):
-    """Parses the command line options and returns a precessing scheme.
+    """Parses the command line options and returns a processing scheme.
 
     Parameters
     ----------


### PR DESCRIPTION
Fixing a (Freudian?) typo I caught.  It's processing scheme rather than precessing scheme.

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
