### PR TITLE
Minor bugfixes in the `banksim` workflow's postprocessing 

### DIFF
--- a/bin/pycbc_make_banksim
+++ b/bin/pycbc_make_banksim
@@ -511,7 +511,7 @@ def mhist(c1, name, cum=False, normed=True, log=False, bins=100, xl="", yl=""):
     pylab.ylabel(yl)
     if log:
         pylab.yscale('log')
-    pylab.hist(c1, bins=bins, normed=normed, histtype='step', cumulative=cum)
+    pylab.hist(c1, bins=bins, density=normed, histtype='step', cumulative=cum)
     pylab.savefig(name)
 
 def mplot(c1, c2, c, name, xl="", yl="", vmin=None, vmax=None):
@@ -537,7 +537,7 @@ pylab.yscale('log')
 pylab.xlim(0.95, 1.0)
 pylab.ylim(1e-4, 1)
 hBins = pylab.arange(0.,1.,0.0005,dtype=float)
-n, bins,patches=pylab.hist(match,cumulative=1,bins=hBins,normed=True)
+n, bins,patches=pylab.hist(match,cumulative=1,bins=hBins,density=True)
 pylab.grid()
 pylab.savefig("plots/cum_hist.png")
     

--- a/bin/pycbc_make_banksim
+++ b/bin/pycbc_make_banksim
@@ -318,14 +318,14 @@ f = open("results.dat", "w")
 for row in res: 
     outstr = ""
     if row['bank'] not in btables:
-        indoc = utils.load_filename(row['bank'], False,
+        indoc = utils.load_filename(eval(row['bank']).decode('utf-8'), False,
                                     contenthandler=LIGOLWContentHandler)
-        btables[row['bank']] = table.get_table(indoc, "sngl_inspiral") 
+        btables[row['bank']] = table.Table.get_table(indoc, "sngl_inspiral")
 
     if row['sim'] not in itables:
-        indoc = utils.load_filename(row['sim'], False,
+        indoc = utils.load_filename(eval(row['sim']).decode('utf-8'), False,
                                     contenthandler=LIGOLWContentHandler)
-        itables[row['sim']] = table.get_table(indoc, "sim_inspiral") 
+        itables[row['sim']] = table.Table.get_table(indoc, "sim_inspiral")
     
     bt = btables[row['bank']][row['bank_i']]     
     it = itables[row['sim']][row['sim_i']]


### PR DESCRIPTION
A few minor bugfixes that are required in the `banksim` workflow's postprocessing scripts to ensure compatibility with latest versions of `ligo`, `matplotlib` and `python`.


## Standard information about the request

<!--- Some basic info about the change (delete as appropriate) -->
This is a: bug fix

<!--- What codes will this affect? (delete as apropriate)
If you do not know which areas will be affected, please ask in the gwastro #pycbc-code slack
-->
This change affects: the banksim workflow

<!--- What code areas will this affect? (delete as apropriate) -->
This change changes: result presentation / plotting

<!--- Notes about the effect of this change -->
This change will: re-enable current functionality

## Motivation
To ensure compatibility of banksim postprocessing with updated Python 3.9+ and matplotlib 3+.

## Contents

 - handle the encoding of bank file names, as they are being written as UTF8.
 - call the `get_table` method inside of `ligo.lw.Table`
 - update argument for call to create histogram with `matplotlib.pyplot.hist`

## Links to any issues or associated PRs
Fixes #4700


- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
