### PR TITLE
Fix combined plots xlim bug

### DIFF
--- a/bin/live/pycbc_live_plot_combined_single_significance_fits
+++ b/bin/live/pycbc_live_plot_combined_single_significance_fits
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 
-# Copyright 2020 Gareth S. Davies
+# Copyright 2020 Gareth S. Cabourn Davies
 #
 # This program is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License as published by the
@@ -105,8 +105,10 @@ max_end = max([separate_ends[ifo].max() for ifo in ifos])
 
 xtix = []
 xtix_labels = []
+# start ticks at the midnight before the first datapoint
 t = min_start
-while t < max_end:
+# Last tick will be the midnight after the last datapoint
+while t < max_end + 86400:
     # Strip off the time information, ticks are at midnight
     time_dt = gpstime.gps_to_utc(t).date()
     xtix_labels.append(time_dt.strftime("%Y-%m-%d"))
@@ -114,6 +116,7 @@ while t < max_end:
     t += 86400
 
 logging.info("Plotting fits information")
+
 for ifo in ifos:
     logging.info(ifo)
 
@@ -192,8 +195,11 @@ for ifo in ifos:
     for ax in [ax_count, ax_alpha]:
         ax.set_xticks(xtix)
         ax.set_xticklabels(xtix_labels, rotation=90)
-        # Add 1/4 day padding either side
-        ax.set_xlim(xtix[0] - 21600, xtix[-1] + 21600)
+        # Add 1/4 day padding either side of the lines
+        ax.set_xlim(
+            min(separate_starts[ifo]) - 21600,
+            max(separate_starts[ifo]) + 21600
+        )
         ax.grid(zorder=-30)
 
     fig_count.tight_layout()


### PR DESCRIPTION
The `pycbc_live_plot_combined_significance_fits` code had a bug where it would sometimes cut off the final datapoint, this fixes the bug

## Standard information about the request

This is a: bug fix
This change affects: the live search
This changes: plotting

This change: follows style guidelines (See e.g. [PEP8](https://peps.python.org/pep-0008/)), has been proposed using the [contribution guidelines](https://github.com/gwastro/pycbc/blob/master/CONTRIBUTING.md)


## Motivation
The combined significance fits plots did not always show the latest datapoint, we wanted to fix this. This basically comes from the fact that the start / end points of the fits files are not exactly on a date boundary.

## Contents
We use the datapoints themselves to decide the xlim, rather than the ticks which can move compared to the datapoints

By adding some padding to the end of the loop used to generate the list of ticks, we do not miss that tick either

## Links to any issues or associated PRs
None

## Testing performed
Plot remade [here](https://ldas-jobs.ligo.caltech.edu/~gareth.cabourndavies/testoutput/various_tests/plot_combined_xlim/L1-2024_04_02-2024_04_21-TRIGGER_FITS_COMBINED-counts_new), showing the correct behaviour, as opposed to [the previous behaviour](https://ldas-jobs.ligo.caltech.edu/~gareth.cabourndavies/testoutput/various_tests/plot_combined_xlim/L1-2024_04_02-2024_04_21-TRIGGER_FITS_COMBINED-counts_test.png)


- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
