### PR TITLE
Use approximant parsing argument for make_bayestar

### DIFF
--- a/bin/all_sky_search/pycbc_make_bayestar_skymap
+++ b/bin/all_sky_search/pycbc_make_bayestar_skymap
@@ -23,8 +23,14 @@ import glob
 import sys
 import random
 import tempfile
+
+from ligo.lw import lsctables, utils as ligolw_utils
+
 import pycbc.version
 from pycbc import init_logging
+from pycbc.waveform import bank as wavebank
+from pycbc.io import WaveformArray
+from pycbc.io.ligolw import LIGOLWContentHandler
 
 parser = argparse.ArgumentParser(description=__doc__)
 parser.add_argument('--version', action="version",
@@ -38,14 +44,12 @@ parser.add_argument('--bayestar-executable',
 parser.add_argument('--event-xml', required=True,
                     help="XML file containing event information, SNR "
                          "timeseries and PSD to pass to bayestar")
-parser.add_argument('--waveform', default='TaylorF2',
-                    help="Waveform used in the matched-filtering "
-                         "to generate the SNR timeseries.")
 parser.add_argument('--low-frequency-cutoff', type=float, default=20,
                     help="Low-frequency cutoff used in the matched-filtering "
                          "to generate the SNR timeseries")
 parser.add_argument('--output-file', required=True,
                     help="Filename to output the fits file to.")
+wavebank.add_approximant_arg(parser)
 args, unknown = parser.parse_known_args()
 
 # Default logging is set higher than normal for this job
@@ -57,12 +61,32 @@ bayestar_exe = args.bayestar_executable or 'bayestar-localize-coincs'
 
 tmpdir = tempfile.mkdtemp()
 
+# Work out which approximant is being used
+# Load the file
+xmldoc = ligolw_utils.load_filename(
+    args.event_xml,
+    contenthandler=LIGOLWContentHandler
+)
+
+# Grab the single inspiral table(s) which contain the template information
+sngl_inspiral_table = lsctables.SnglInspiralTable.get_table(xmldoc)
+
+# turn this into a waveform array
+row = WaveformArray.from_ligolw_table(
+    sngl_inspiral_table,
+)
+
+# Work out which waveform is used based on the template information
+# Note that as there are multiple single inspiral tables (one per ifo)
+# with the same information, we use [0] here
+waveform = wavebank.parse_approximant_arg(args.approximant, row)[0]
+
 # Set up the command to pass to bayestar.
 # The XML file path being passed twice is a legacy requirement, not a mistake.
 cmd = [bayestar_exe,
        args.event_xml,
        args.event_xml,
-       '--waveform', args.waveform,
+       '--waveform', waveform,
        '--f-low', str(args.low_frequency_cutoff),
        '-o', tmpdir]
 

--- a/bin/all_sky_search/pycbc_make_bayestar_skymap
+++ b/bin/all_sky_search/pycbc_make_bayestar_skymap
@@ -81,6 +81,10 @@ row = WaveformArray.from_ligolw_table(
 # with the same information, we use [0] here
 waveform = wavebank.parse_approximant_arg(args.approximant, row)[0]
 
+# BAYESTAR uses TaylorF2 instead of SPAtmplt
+if waveform == 'SPAtmplt':
+    waveform = 'TaylorF2'
+
 # Set up the command to pass to bayestar.
 # The XML file path being passed twice is a legacy requirement, not a mistake.
 cmd = [bayestar_exe,

--- a/pycbc/workflow/minifollowups.py
+++ b/pycbc/workflow/minifollowups.py
@@ -1113,11 +1113,12 @@ def make_upload_files(workflow, psd_files, snr_timeseries, xml_all,
         '--output-file',
     )
 
+    # This will be called if the approximant is within the bank
     if approximant == b'SPAtmplt':
         # Bayestar doesn't use the SPAtmplt approximant
         approximant = b'TaylorF2'
     if approximant is not None:
-        bayestar_node.add_opt('--waveform', approximant.decode())
+        bayestar_node.add_opt('--approximant', approximant.decode())
 
     workflow += bayestar_node
 


### PR DESCRIPTION
When generating bayestar skymaps in the upload prep minifollowup, the approximant used was not the same as in the rest of the workflow, this caused issues.

Here we use the standard approximant interface used by other codes in order to work out the appropriate waveform.

## Standard information about the request

This is a: bug fix
This change affects: the offline search
This change changes: result presentation / plotting, scientific output

This change: follows style guidelines (See e.g. [PEP8](https://peps.python.org/pep-0008/)), has been proposed using the [contribution guidelines](https://github.com/gwastro/pycbc/blob/master/CONTRIBUTING.md)
This change will: require a new release on the v23 release branch so that it can be used for o4 LVK results

## Motivation
The correct approximant was not being used for the bayestar subprocess, this means the skymaps would be wrong

## Contents
I have used standard library code for obtaining the approximant from the command line interface given conditions, rather than only allowing one  input.

## Links to any issues or associated PRs
None

## Testing performed
Previously failing event now runs, with the right approximant. Boundary also moved to ensure that the SPAtmplt --> TaylorF2 check was implemented

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
