### PR TITLE
Correct call to extract_basic_trig_properties in pycbc_pygrb_efficiency

### DIFF
--- a/bin/pygrb/pycbc_pygrb_efficiency
+++ b/bin/pygrb/pycbc_pygrb_efficiency
@@ -196,7 +196,8 @@ logging.info("%d trials generated.", total_trials)
 
 # Extract basic trigger properties and store as dictionaries
 trig_time, trig_snr, trig_bestnr = \
-    ppu.extract_basic_trig_properties(trial_dict, trigs, slide_dict, segment_dict)
+    ppu.extract_basic_trig_properties(trial_dict, trigs, slide_dict,
+                                      segment_dict, opts)
 
 # Calculate BestNR values and maximum
 time_veto_max_bestnr = {}


### PR DESCRIPTION
`extract_basic_trig_properties` wants 5 arguments but it only had 4 in `pycbc_pygrb_efficiency`.

- [ ] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
