### PR TITLE
Remove PyGRB injection set name check

### DIFF
--- a/bin/pygrb/pycbc_grb_inj_combiner
+++ b/bin/pygrb/pycbc_grb_inj_combiner
@@ -258,7 +258,7 @@ usefiles = filter(
     args.input_files,
 )
 
-if not usefiles:
+if not list(usefiles):
     raise ValueError("No files used in inj combiner!\n"
                      "Check injection set name and inclination.\n"
                      "It should have the following form:\n"

--- a/bin/pygrb/pycbc_grb_inj_combiner
+++ b/bin/pygrb/pycbc_grb_inj_combiner
@@ -22,7 +22,6 @@
 
 import argparse
 import os
-import re
 from collections import defaultdict
 from math import (pi as PI, radians)
 
@@ -49,20 +48,7 @@ TQDM_KW = {
     "smoothing": 0.05,
 }
 
-INJSTRING_REGEX = re.compile(r"_[A-Z]*(\d+)(INJ)_(FOUND|MISSED)")
-
 # -- utilties -----------------------------------
-
-
-def use_file(filename, inclination):
-    """Returns `True` if this file can be used to analysis the given inclination
-    """
-    match = INJSTRING_REGEX.search(filename)
-    if match and float(match.groups()[0]) >= inclination:
-        return True
-    return False
-
-
 def theta(h5injgroup):
     """Calculate the theta angle column for an injection group
     """
@@ -252,21 +238,9 @@ parser.add_argument(
 
 args = parser.parse_args()
 
-# determine which files to keep
-usefiles = filter(
-    lambda x: use_file(x, args.max_inclination),
-    args.input_files,
-)
-
-if not list(usefiles):
-    raise ValueError("No files used in inj combiner!\n"
-                     "Check injection set name and inclination.\n"
-                     "It should have the following form:\n"
-                     "{ANY TEXT}{maximum inclination value}INJ.{extension}")
-
 # merge injection files, filtering on-the-fly by inclination
 merge_injection_files(
-    list(usefiles),
+    args.input_files,
     args.output_file,
     inclination=args.max_inclination,
     verbose=args.verbose,

--- a/bin/pygrb/pycbc_make_offline_grb_workflow
+++ b/bin/pygrb/pycbc_make_offline_grb_workflow
@@ -317,16 +317,6 @@ if wflow.cp.has_section("workflow-injections"):
     all_files.extend(inj_files)
     injs = inj_files
 
-    # Check injection set name is correct form
-    inj_regex = re.compile(r"[A-Z]*(\d+)(INJ)")
-    inj_name_check = [inj_regex.match(inj_tag) for inj_tag in inj_tags]
-    if not all(inj_name_check):
-        msg = "Injection set name must have the form {ANY TEXT}{maximum "
-        msg += "inclination value}INJ. You have provided the following "
-        msg += "injection set names: %s." % inj_tags
-        logging.error(msg)
-        sys.exit()
-
     # Either split template bank for injections jobs or use same split banks
     # as for standard matched filter jobs
     if wflow.cp.has_section("workflow-splittable-injections"):

--- a/bin/pygrb/pycbc_make_offline_grb_workflow
+++ b/bin/pygrb/pycbc_make_offline_grb_workflow
@@ -27,11 +27,11 @@ __version__ = pycbc.version.git_verbose_msg
 __date__ = pycbc.version.date
 __program__ = "pycbc_make_offline_grb_workflow"
 
-import shutil
 import sys
 import os
 import argparse
 import logging
+import re
 import pycbc.workflow as _workflow
 from pycbc.workflow.core import configparser_value_to_file
 from ligo.segments import segment, segmentlist, segmentlistdict
@@ -316,6 +316,16 @@ if wflow.cp.has_section("workflow-injections"):
     inj_files, inj_tags = _workflow.setup_injection_workflow(wflow, inj_dir)
     all_files.extend(inj_files)
     injs = inj_files
+
+    # Check injection set name is correct form
+    inj_regex = re.compile(r"_[A-Z]*(\d+)(INJ)")
+    inj_name_check = [inj_regex.match(inj_tag) for inj_tag in inj_tags]
+    if not all(inj_name_check):
+        msg = "Injection set name must have the form {ANY TEXT}{maximum "
+        msg += "inclination value}INJ. You have provided the following "
+        msg += "injection set names: %s." % inj_tags
+        logging.error(msg)
+        sys.exit()
 
     # Either split template bank for injections jobs or use same split banks
     # as for standard matched filter jobs

--- a/bin/pygrb/pycbc_make_offline_grb_workflow
+++ b/bin/pygrb/pycbc_make_offline_grb_workflow
@@ -27,11 +27,11 @@ __version__ = pycbc.version.git_verbose_msg
 __date__ = pycbc.version.date
 __program__ = "pycbc_make_offline_grb_workflow"
 
+import shutil
 import sys
 import os
 import argparse
 import logging
-import re
 import pycbc.workflow as _workflow
 from pycbc.workflow.core import configparser_value_to_file
 from ligo.segments import segment, segmentlist, segmentlistdict

--- a/bin/pygrb/pycbc_make_offline_grb_workflow
+++ b/bin/pygrb/pycbc_make_offline_grb_workflow
@@ -318,7 +318,7 @@ if wflow.cp.has_section("workflow-injections"):
     injs = inj_files
 
     # Check injection set name is correct form
-    inj_regex = re.compile(r"_[A-Z]*(\d+)(INJ)")
+    inj_regex = re.compile(r"[A-Z]*(\d+)(INJ)")
     inj_name_check = [inj_regex.match(inj_tag) for inj_tag in inj_tags]
     if not all(inj_name_check):
         msg = "Injection set name must have the form {ANY TEXT}{maximum "


### PR DESCRIPTION
These changes affect PyGRB.

This PR removes a check on the injection set name that can cause empty results from `pycbc_grb_inj_combiner`. It is up to the user to provide valid inputs to the executable, and placing a filename constraint is unnecessary.

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
