### PR TITLE
Add explicit error message for samplers

### DIFF
--- a/pycbc/inference/sampler/__init__.py
+++ b/pycbc/inference/sampler/__init__.py
@@ -14,7 +14,7 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 """
-This modules provides a list of implemented samplers for parameter estimation.
+This module provides a list of implemented samplers for parameter estimation.
 """
 
 import logging
@@ -87,7 +87,7 @@ def load_from_config(cp, model, **kwargs):
         Config parser to read from.
     model : pycbc.inference.model
         Which model to pass to the sampler.
-    \**kwargs :
+    **kwargs :
         All other keyword arguments are passed directly to the sampler's
         ``from_config`` file.
 
@@ -101,4 +101,9 @@ def load_from_config(cp, model, **kwargs):
         return DummySampler.from_config(cp, model, **kwargs)
 
     name = cp.get('sampler', 'name')
-    return samplers[name].from_config(cp, model, **kwargs)
+    try:
+        return samplers[name].from_config(cp, model, **kwargs)
+    except KeyError:
+        raise ImportError(f"No accessible sampler named {name}. Please check if the name is correct"
+                          f" or the required package for this sampler is installed correctly."
+                          f" Accessible samplers: {list(samplers.keys())}")


### PR DESCRIPTION
This is a minor change for adding a more informative error message to enhance user experience.

People (especially beginners) may not realize the core issue when seeing, for example, this error message:
```
  File "/home/dice/anaconda3/lib/python3.11/site-packages/pycbc/inference/sampler/__init__.py", line 104, in load_from_config
    return samplers[name].from_config(cp, model, **kwargs)
           ~~~~~~~~^^^^^^
KeyError: 'emcee'
```
New error message gives explicit guidance.

- [ x ] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
