### PR TITLE
V23 BRANCH: Optimize plotting job memory usage

### DIFF
--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-latest]
+        os: [ubuntu-20.04, macos-12]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/inference-workflow.yml
+++ b/.github/workflows/inference-workflow.yml
@@ -25,7 +25,7 @@ jobs:
         wget -qO - https://download.pegasus.isi.edu/pegasus/gpg.txt | sudo apt-key add -
         echo "deb https://download.pegasus.isi.edu/pegasus/ubuntu bionic main" | sudo tee -a /etc/apt/sources.list
         sudo apt-get -o Acquire::Retries=3 update
-        sudo apt-get -o Acquire::Retries=3 install pegasus
+        sudo apt-get -o Acquire::Retries=3 install pegasus=5.0.6-1+ubuntu18
     - run: sudo apt-get -o Acquire::Retries=3 install *fftw3* intel-mkl*
     - name: Install pycbc
       run: |

--- a/.github/workflows/mac-test.yml
+++ b/.github/workflows/mac-test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        os: [macos-latest]
+        os: [macos-12]
         python-version: [3.8, 3.9, '3.10', '3.11']
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/search-workflow.yml
+++ b/.github/workflows/search-workflow.yml
@@ -30,7 +30,7 @@ jobs:
         wget -qO - https://download.pegasus.isi.edu/pegasus/gpg.txt | sudo apt-key add -
         echo "deb https://download.pegasus.isi.edu/pegasus/ubuntu bionic main" | sudo tee -a /etc/apt/sources.list
         sudo apt-get -o Acquire::Retries=3 update
-        sudo apt-get -o Acquire::Retries=3 install pegasus
+        sudo apt-get -o Acquire::Retries=3 install pegasus=5.0.6-1+ubuntu18
     - run: sudo apt-get -o Acquire::Retries=3 install *fftw3* intel-mkl*
     - name: Install pycbc
       run: |

--- a/.github/workflows/tmpltbank-workflow.yml
+++ b/.github/workflows/tmpltbank-workflow.yml
@@ -29,7 +29,7 @@ jobs:
         wget -qO - https://download.pegasus.isi.edu/pegasus/gpg.txt | sudo apt-key add -
         echo "deb https://download.pegasus.isi.edu/pegasus/ubuntu bionic main" | sudo tee -a /etc/apt/sources.list
         sudo apt-get -o Acquire::Retries=3 update
-        sudo apt-get -o Acquire::Retries=3 install pegasus
+        sudo apt-get -o Acquire::Retries=3 install pegasus=5.0.6-1+ubuntu18
     - run: sudo apt-get -o Acquire::Retries=3 install *fftw3* intel-mkl*
     - name: Install pycbc
       run: |

--- a/.github/workflows/workflow-tests.yml
+++ b/.github/workflows/workflow-tests.yml
@@ -34,7 +34,7 @@ jobs:
         wget -qO - https://download.pegasus.isi.edu/pegasus/gpg.txt | sudo apt-key add -
         echo "deb https://download.pegasus.isi.edu/pegasus/ubuntu bionic main" | sudo tee -a /etc/apt/sources.list
         sudo apt-get -o Acquire::Retries=3 update
-        sudo apt-get -o Acquire::Retries=3 install pegasus
+        sudo apt-get -o Acquire::Retries=3 install pegasus=5.0.6-1+ubuntu18
     - run: sudo apt-get -o Acquire::Retries=3 install *fftw3* intel-mkl*
     - name: Install pycbc
       run: |

--- a/bin/minifollowups/pycbc_page_coincinfo
+++ b/bin/minifollowups/pycbc_page_coincinfo
@@ -151,7 +151,7 @@ for ifo in files.keys():
     mchirp = (pycbc.pnutils.mass1_mass2_to_mchirp_eta(bank['mass1'][tid],
                                                       bank['mass2'][tid]))[0]
 
-    time = d['end_time'][:][i]
+    time = d['end_time'][i]
     utc = lal.GPSToUTC(int(time))[0:6]
 
     # Headers will store the headers that will appear in the table.

--- a/bin/plotting/pycbc_page_coinc_snrchi
+++ b/bin/plotting/pycbc_page_coinc_snrchi
@@ -6,6 +6,7 @@ from matplotlib import colors
 matplotlib.use('Agg')
 import pylab, pycbc.results
 from pycbc.io import get_chisq_from_file_choice, chisq_choices
+from pycbc.io import SingleDetTriggers
 from pycbc import conversions
 from pycbc.detector import Detector
 import pycbc.version
@@ -54,11 +55,22 @@ for tmpifo in ifos:
 
 f = h5py.File(args.single_trigger_file, 'r')
 ifo = tuple(f.keys())[0]
-f = f[ifo]
 tid = b_tids[ifo][:]
-bkg_snr = f['snr'][:][tid]
+mask = numpy.zeros(len(f[f'{ifo}/snr']), dtype=bool)
+f.close()
+mask[tid] = True
+trigs = SingleDetTriggers(
+    args.single_trigger_file,
+    None,
+    None,
+    None,
+    None,
+    ifo,
+    premask=mask
+)
+bkg_snr = trigs['snr']
 
-bkg_chisq = get_chisq_from_file_choice(f, args.chisq_choice)[tid]
+bkg_chisq = get_chisq_from_file_choice(trigs, args.chisq_choice)
 
 # don't plot if chisq is not calculated
 bkg_pos = bkg_chisq > 0
@@ -107,11 +119,32 @@ if 'optimal_snr_{}'.format(ifo) in f['injections']:
     opt_snr = f[opt_snr_str][:][inj_idx]
     coloring['optimal_snr'] = (opt_snr, 'Optimal SNR', colors.LogNorm())
 
-f = h5py.File(args.single_injection_file, 'r')[ifo]
 tid = inj_tids[ifo][:]
 if len(tid):
-    inj_snr = f['snr'][:][tid]
-    inj_chisq = get_chisq_from_file_choice(f, args.chisq_choice)[tid]
+    f = h5py.File(args.single_injection_file, 'r')
+    mask = numpy.zeros(len(f[f'{ifo}/snr']), dtype=bool)
+    f.close()
+    mask[tid] = True
+    inj_trigs = SingleDetTriggers(
+        args.single_injection_file,
+        None,
+        None,
+        None,
+        None,
+        ifo,
+        premask=mask
+    )
+    inj_snr_data = inj_trigs['snr']
+    inj_chisq_data = get_chisq_from_file_choice(inj_trigs, args.chisq_choice)
+    # But the stuff above would have removed ordering and duplicates now
+    # need something of the right length!
+    tid_locations = numpy.where(mask)[0]
+    new_tid_locations = numpy.searchsorted(
+        tid_locations,
+        tid
+    )
+    inj_snr = inj_snr_data[new_tid_locations]
+    inj_chisq = inj_chisq_data[new_tid_locations]
 else:
     inj_snr = numpy.array([])
     inj_chisq = numpy.array([])

--- a/bin/plotting/pycbc_page_snrchi
+++ b/bin/plotting/pycbc_page_snrchi
@@ -3,7 +3,8 @@ import numpy, h5py, argparse, matplotlib, sys
 matplotlib.use('Agg')
 import pylab, pycbc.results, pycbc.version
 from pycbc.events import veto
-from pycbc.io import get_chisq_from_file_choice, chisq_choices
+from pycbc.io import get_chisq_from_file_choice, chisq_choices, HFile
+from pycbc.io import SingleDetTriggers
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--trigger-file', help='Single ifo trigger file')
@@ -21,27 +22,38 @@ args = parser.parse_args()
 
 f = h5py.File(args.trigger_file, 'r')
 ifo = tuple(f.keys())[0]
-f = f[ifo]
-snr = f['snr'][:]
-chisq = get_chisq_from_file_choice(f, args.chisq_choice)
+f.close()
+if args.min_snr:
+    with HFile(args.trigger_file, 'r') as trig_file:
+        n_triggers_orig = trig_file[f'{ifo}/snr'].size
+        idx, _ = trig_file.select(
+            lambda snr: snr >= args.min_snr,
+            f'{ifo}/snr',
+            return_indices=True
+        )
+        data_mask = numpy.zeros(n_triggers_orig, dtype=bool)
+        data_mask[idx] = True
+else:
+    data_mask = None
+
+trigs = SingleDetTriggers(
+    args.trigger_file,
+    None,
+    args.veto_file,
+    args.segment_name,
+    None,
+    ifo,
+    premask=data_mask
+)
+
+snr = trigs['snr']
+chisq = get_chisq_from_file_choice(trigs, args.chisq_choice)
 
 def snr_from_chisq(chisq, newsnr, q=6.):
     snr = numpy.zeros(len(chisq)) + float(newsnr)
     ind = numpy.where(chisq > 1.)[0]
     snr[ind] = float(newsnr) / ( 0.5 * (1. + chisq[ind] ** (q/2.)) ) ** (-1./q)
     return snr
-
-if args.veto_file:
-    time = f['end_time'][:]
-    locs, segs = veto.indices_outside_segments(time, [args.veto_file], 
-                                       segment_name=args.segment_name, ifo=ifo)
-    snr = snr[locs]
-    chisq = chisq[locs]
-
-if args.min_snr is not None:
-    locs = snr > args.min_snr
-    snr = snr[locs]
-    chisq = chisq[locs]
 
 fig = pylab.figure(1)
 

--- a/bin/plotting/pycbc_plot_hist
+++ b/bin/plotting/pycbc_plot_hist
@@ -46,10 +46,31 @@ pycbc.init_logging(args.verbose)
 f = h5py.File(args.trigger_file, 'r')
 ifo = tuple(f.keys())[0]
 
+# This is fixed better on master, but should work here
+if args.x_var == 'snr' or args.x_var == 'newsnr_sgveto':
+    with pycbc.io.HFile(args.trigger_file, 'r') as trig_file:
+        n_triggers_orig = trig_file[f'{ifo}/snr'].size
+        logging.info("Trigger file has %d triggers", n_triggers_orig)
+        logging.info('Generating trigger mask')
+        # psd_var_val may not have been calculated
+        idx, _ = trig_file.select(
+            lambda snr: snr >= args.x_min,
+            f'{ifo}/snr',
+            return_indices=True
+        )
+        data_mask = numpy.zeros(n_triggers_orig, dtype=bool)
+        data_mask[idx] = True
+else:
+    logging.warn(
+        'With %s as --x-var, this is going to be very memory intensive!',
+        args.x_var
+    )
+    data_mask = None
+
 # read single-detector triggers
 trigs = pycbc.io.SingleDetTriggers(args.trigger_file, args.bank_file,
                                    args.veto_file, args.segment_name,
-                                   None, ifo)
+                                   None, ifo, premask=data_mask)
 
 # get x values and find the maximum x value
 val = getattr(trigs, args.x_var)

--- a/pycbc/io/hdf.py
+++ b/pycbc/io/hdf.py
@@ -810,7 +810,21 @@ class ForegroundTriggers(object):
                         curr.append(hdf_dataset[idx])
                     curr = np.array(curr)
                 else:
-                    curr = self.sngl_files[ifo].get_column(variable)[tid]
+                    # Taking code from FileData's get_column
+                    # This needs to be done more cleanly for master!
+                    group = self.sngl_files[ifo].group
+                    if not len(group.keys()):
+                        return np.array([])
+                    dataset = group[variable]
+                    mask = np.zeros(len(dataset), dtype=bool)
+                    mask[tid] = True
+                    needed_data = dataset[mask]
+                    tid_locations = np.where(mask)[0]
+                    new_tid_locations = np.searchsorted(
+                        tid_locations,
+                        tid
+                    )
+                    curr = needed_data[new_tid_locations]
             except IndexError:
                 if len(self.trig_id[ifo]) == 0:
                     curr = np.array([])

--- a/pycbc/results/versioning.py
+++ b/pycbc/results/versioning.py
@@ -21,7 +21,7 @@ import subprocess
 import urllib.parse
 
 import lal, lalframe
-import pycbc.version, glue.git_version
+import pycbc.version
 
 def get_library_version_info():
     """This will return a list of dictionaries containing versioning
@@ -87,19 +87,6 @@ def get_library_version_info():
     except ImportError:
         pass
     library_list.append(lalsimulationinfo)
-
-    glueinfo = {}
-    glueinfo['Name'] = 'LSCSoft-Glue'
-    glueinfo['ID'] = glue.git_version.id
-    glueinfo['Status'] = glue.git_version.status
-    glueinfo['Version'] = glue.git_version.version
-    glueinfo['Tag'] = glue.git_version.tag
-    glueinfo['Author'] = glue.git_version.author
-    glueinfo['Builder'] = glue.git_version.builder
-    glueinfo['Branch'] = glue.git_version.branch
-    glueinfo['Committer'] = glue.git_version.committer
-    glueinfo['Date'] = glue.git_version.date
-    library_list.append(glueinfo)
 
     pycbcinfo = {}
     pycbcinfo['Name'] = 'PyCBC'


### PR DESCRIPTION
THIS WILL BE MERGED ONTO THE v23 RELEASE BRANCH. A SEPARATE PR WILL BE SETUP FOR MERGING THIS
ONTO THE MAIN BRANCH.

We have noticed that many plotting jobs are using a lot of memory. As LDG clusters are now enforcing memory usage more closely, we are having issues getting jobs finished. 6 jobs in particular were identified as offenders:

plot_hist
plot_coinc_snrchi
plot_snrchi
page_foreground
sngls_statmap
merge_page_coincinfo

This patch addresses 5 of them (not sngls_statmap, which is not plotting in any case). 4 of these will also be an issue on the main branch (plot_hist should already be less memory intensive there). Of these 4, 1 is a trivial patch to move across, but others will need reworking to match up with Gareth's changes in #4545. The change to hdf.py also needs Alex to look over it, before merging to the main branch.

Here is performance information before/after this patch for example use cases (page_foreground has a few pathways, so we run 3 examples). The memory usage here is quite low compared to some other examples!

plot_hist:

OLD 	Maximum resident set size (kbytes): 41487604
	User time (seconds): 555.81
NEW 	Maximum resident set size (kbytes): 3135144
	User time (seconds): 115.96
	
plot_coinc_snrchi

OLD	User time (seconds): 173.63
	Maximum resident set size (kbytes): 58355540
NEW	User time (seconds): 181.64
	Maximum resident set size (kbytes): 2447828

plot_snrchi

OLD 	User time (seconds): 989.99
	Maximum resident set size (kbytes): 52556940
NEW	User time (seconds): 227.52
	Maximum resident set size (kbytes): 4724860

page_foreground

OLD1 	User time (seconds): 843.69
	Maximum resident set size (kbytes): 23738796
OLD2	User time (seconds): 168.07
	Maximum resident set size (kbytes): 23715096
OLD3	User time (seconds): 239.99
	Maximum resident set size (kbytes): 23749764

NEW1	User time (seconds): 186.66
	Maximum resident set size (kbytes): 3176904
NEW2	User time (seconds): 44.05
	Maximum resident set size (kbytes): 313200
NEW3	User time (seconds): 124.98
	Maximum resident set size (kbytes): 420688

page_coincinfo

OLD	User time (seconds): 144.31
	Maximum resident set size (kbytes): 23775536
NEW	User time (seconds): 4.79
	Maximum resident set size (kbytes): 207764
	
The outputs of these jobs can be viewed here (apologies, behind an LVK web server, because I had O4 data to hand when doing this ... basically the plots are all identical and XML/HTML lists are identical up to some ordering and rounding).

https://ldas-jobs.ligo.caltech.edu/~ian.harry/pull_requests/plotting_memory_opt/
