### PR TITLE
Improve pycbc_page_coincinfor

### DIFF
--- a/bin/minifollowups/pycbc_page_coincinfo
+++ b/bin/minifollowups/pycbc_page_coincinfo
@@ -162,7 +162,7 @@ for ifo in files.keys():
     mchirp = (pycbc.pnutils.mass1_mass2_to_mchirp_eta(bank['mass1'][tid],
                                                       bank['mass2'][tid]))[0]
 
-    time = d['end_time'][:][i]
+    time = d['end_time'][i]
     utc = lal.GPSToUTC(int(time))[0:6]
 
     # Headers will store the headers that will appear in the table.


### PR DESCRIPTION
`pycbc_page_coincinfo` is quite memory inefficient because of a typo. Easy to fix. This is a part of merging #4724 onto the main branch (and the easiest part).

## Standard information about the request

This is a: efficiency update

This change affects: the offline search plotting

This change changes: result presentation / plotting

This change: has appropriate unit tests, follows style guidelines (See e.g. [PEP8](https://peps.python.org/pep-0008/)), has been proposed using the [contribution guidelines](https://github.com/gwastro/pycbc/blob/master/CONTRIBUTING.md)

This change will: break nothing

## Motivation

See #4724

## Contents

Self evident

## Testing performed

Is tested. 


- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
