### PR TITLE
Allowing config-files when setting up pycbc_create_injections injection job

### DIFF
--- a/bin/workflows/pycbc_make_inference_inj_workflow
+++ b/bin/workflows/pycbc_make_inference_inj_workflow
@@ -256,7 +256,7 @@ for num_inj in range(n_injections):
             sub_workflow.cp, "create_injections", ifos=sub_workflow.ifos,
             out_dir=injection_file_dir)
         node, injection_file = create_injections_exe.create_node(
-            config_file, seed=seed, tags=opts.tags+[event])
+            [config_file], seed=seed, tags=opts.tags+[event])
         node.add_opt("--ninjections", 1)
         sub_workflow += node
         seed = seed + 1

--- a/pycbc/workflow/injection.py
+++ b/pycbc/workflow/injection.py
@@ -225,17 +225,17 @@ def setup_injection_workflow(workflow, output_dir=None,
                           out_dir=output_dir, ifos='HL',
                           tags=curr_tags)
             if exe is PycbcCreateInjectionsExecutable:
+                if workflow.cp.has_option('workflow-injections',
+                                          section+'-config-file'):
+                    logger.error('Please use '+section+'-config-files '
+                                 'instead of '+section+'-config-file '
+                                 'in [workflow-injections]')
                 config_urls = workflow.cp.get('workflow-injections',
-                                              section+'-config-file') if \
-                    workflow.cp.has_option('workflow-injections',
-                                           section+'-config-file') else \
-                    workflow.cp.get('workflow-injections',
-                                    section+'-config-files')
+                                              section+'-config-files')
                 config_urls = config_urls.split(',')
                 config_files = FileList([resolve_url_to_file(cf.strip())
                                          for cf in config_urls])
-                node, inj_file = inj_job.create_node()
-                node.add_input_list_opt('--config-files', config_files)
+                node, inj_file = inj_job.create_node(config_files)
             else:
                 node = inj_job.create_node(full_segment)
             if injection_method == "AT_RUNTIME":

--- a/pycbc/workflow/injection.py
+++ b/pycbc/workflow/injection.py
@@ -225,11 +225,6 @@ def setup_injection_workflow(workflow, output_dir=None,
                           out_dir=output_dir, ifos='HL',
                           tags=curr_tags)
             if exe is PycbcCreateInjectionsExecutable:
-                if workflow.cp.has_option('workflow-injections',
-                                          section+'-config-file'):
-                    logger.error('Please use '+section+'-config-files '
-                                 'instead of '+section+'-config-file '
-                                 'in [workflow-injections]')
                 config_urls = workflow.cp.get('workflow-injections',
                                               section+'-config-files')
                 config_urls = config_urls.split(',')

--- a/pycbc/workflow/injection.py
+++ b/pycbc/workflow/injection.py
@@ -225,10 +225,17 @@ def setup_injection_workflow(workflow, output_dir=None,
                           out_dir=output_dir, ifos='HL',
                           tags=curr_tags)
             if exe is PycbcCreateInjectionsExecutable:
-                config_url = workflow.cp.get('workflow-injections',
-                                             section+'-config-file')
-                config_file = resolve_url_to_file(config_url)
-                node, inj_file = inj_job.create_node(config_file)
+                config_urls = workflow.cp.get('workflow-injections',
+                                              section+'-config-file') if \
+                    workflow.cp.has_option('workflow-injections',
+                                           section+'-config-file') else \
+                    workflow.cp.get('workflow-injections',
+                                    section+'-config-files')
+                config_urls = config_urls.split(',')
+                config_files = FileList([resolve_url_to_file(cf.strip())
+                                         for cf in config_urls])
+                node, inj_file = inj_job.create_node()
+                node.add_input_list_opt('--config-files', config_files)
             else:
                 node = inj_job.create_node(full_segment)
             if injection_method == "AT_RUNTIME":

--- a/pycbc/workflow/jobsetup.py
+++ b/pycbc/workflow/jobsetup.py
@@ -1080,14 +1080,14 @@ class PycbcCreateInjectionsExecutable(Executable):
     current_retention_level = Executable.ALL_TRIGGERS
     extension = '.hdf'
 
-    def create_node(self, config_file=None, seed=None, tags=None):
+    def create_node(self, config_files=None, seed=None, tags=None):
         """ Set up a CondorDagmanNode class to run ``pycbc_create_injections``.
 
         Parameters
         ----------
-        config_file : pycbc.workflow.core.File
-            A ``pycbc.workflow.core.File`` for inference configuration file
-            to be used with ``--config-files`` option.
+        config_files : pycbc.workflow.core.FileList
+            A ``pycbc.workflow.core.FileList`` for injection configuration
+            files to be used with ``--config-files`` option.
         seed : int
             Seed to use for generating injections.
         tags : list
@@ -1109,8 +1109,8 @@ class PycbcCreateInjectionsExecutable(Executable):
 
         # make node for running executable
         node = Node(self)
-        if config_file is not None:
-            node.add_input_opt("--config-files", config_file)
+        if config_files is not None:
+            node.add_input_list_opt("--config-files", config_files)
         if seed:
             node.add_opt("--seed", seed)
         injection_file = node.new_output_file_opt(analysis_time,


### PR DESCRIPTION
## Standard information about the request

The problem: `pycbc_create_injections` takes the `--config-files` option, but `setup_injection_workflow` assumes a single configuration file is passed to `pycbc_create_injections` jobs with the `config-file=...` option.  This is a general limitation (and, specifically, PyGRB would gladly avoid this).

This PR allows `setup_injection_workflow` to also accept and handle multiple files under `config-files`.

The motivation to modify `setup_injection_workflow` is to not break the existing behaviour and syntax, but to expand it (i.e., users can rely on `config-file=...` and `config-files=...` passing one or multiple files).  The cleaner solution would be to modify the `PycbcCreateInjectionsExecutable` class so that `def create_node(self, config_file=None, ...)` works as `def create_node(self, config_files=None, ...)`, i.e., the keyword argument matches the `pycbc_create_injections` option `--config-files`.  However, this would break things for anyone using `config-file=...` in setting up their workflows.

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
