### PR TITLE
Add any provided key to `lal_pars` for waveform generation

### DIFF
--- a/pycbc/waveform/waveform.py
+++ b/pycbc/waveform/waveform.py
@@ -88,8 +88,21 @@ def _check_lal_pars(p):
         The lal type dictionary to pass to the lalsimulation waveform functions.
     """
     lal_pars = lal.CreateDict()
-    #nonGRparams can be straightforwardly added if needed, however they have to
-    # be invoked one by one
+    # try and add all provided items to lal_pars. We try both the provided key
+    # as well as a camel case version
+    for key, value in p.items():
+        if value is None:
+            continue
+        camelcase = "".join([subkey.capitalize() for subkey in key.split("_")])
+        for _key in [key, camelcase]:
+            _func  = getattr(
+                lalsimulation, "SimInspiralWaveformParamsInsert" + _key, None
+            )
+            if _func is not None:
+                _func(lal_pars, value)
+                break
+    # some keys require specific functions to be added to lal_pars. Below we
+    # add these parameters one by one
     if p['phase_order']!=-1:
         lalsimulation.SimInspiralWaveformParamsInsertPNPhaseOrder(lal_pars,int(p['phase_order']))
     if p['amplitude_order']!=-1:
@@ -122,10 +135,6 @@ def _check_lal_pars(p):
         lalsimulation.SimInspiralWaveformParamsInsertdQuadMon2(lal_pars, p['dquad_mon2'])
     if p['numrel_data']:
         lalsimulation.SimInspiralWaveformParamsInsertNumRelData(lal_pars, str(p['numrel_data']))
-    if p['modes_choice']:
-        lalsimulation.SimInspiralWaveformParamsInsertModesChoice(lal_pars, p['modes_choice'])
-    if p['frame_axis']:
-        lalsimulation.SimInspiralWaveformParamsInsertFrameAxis(lal_pars, p['frame_axis'])
     if p['side_bands']:
         lalsimulation.SimInspiralWaveformParamsInsertSideband(lal_pars, p['side_bands'])
     if p['mode_array'] is not None:
@@ -133,6 +142,7 @@ def _check_lal_pars(p):
         for l,m in p['mode_array']:
             lalsimulation.SimInspiralModeArrayActivateMode(ma, l, m)
         lalsimulation.SimInspiralWaveformParamsInsertModeArray(lal_pars, ma)
+
     #TestingGR parameters:
     if p['dchi0'] is not None:
         lalsimulation.SimInspiralWaveformParamsInsertNonGRDChi0(lal_pars,p['dchi0'])

--- a/pycbc/waveform/waveform.py
+++ b/pycbc/waveform/waveform.py
@@ -96,7 +96,7 @@ def _check_lal_pars(p):
         camelcase = "".join([subkey.capitalize() for subkey in key.split("_")])
         for _key in [key, camelcase]:
             _func  = getattr(
-                lalsimulation, "SimInspiralWaveformParamsInsert" + _key, None
+                lalsimulation, f"SimInspiralWaveformParamsInsert{_key}", None
             )
             if _func is not None:
                 _func(lal_pars, value)


### PR DESCRIPTION
The purpose of this PR is to pass additional flags provided to `pycbc`'s waveform generation to the relevant `lalsimulation` functions by adding them to `lal_pars`. The code first checks to see if the provided key can be added, and then it tries a camelcase version. The keys are added via the `lalsimulation.SimInspiralWaveformParamsInsert{key}` function. This code was inspired from `bilby`: https://git.ligo.org/lscsoft/bilby/-/blob/master/bilby/gw/source.py?ref_type=heads#L583-586.

I opted to try both e.g. `modes_choice` and `ModesChoice` as the prior is more convenient to add to configs/HDF. This change is particularly useful for modifying the default behaviour of waveform models (for example turning off multi-banding in `IMRPhenomXPHM`). This change will affect all pipelines that provide additional flags to the waveform generator.

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
