### PR TITLE
V23_RELEASE_BRANCH Implement minimum statistic storage in sngls_findtrigs

### DIFF
--- a/bin/all_sky_search/pycbc_sngls_findtrigs
+++ b/bin/all_sky_search/pycbc_sngls_findtrigs
@@ -43,6 +43,8 @@ parser.add_argument('--cluster-window', type=float,
                     help='Window (seconds) during which to keep the trigger '
                          'with the loudest statistic value. '
                          'Default=do not cluster')
+parser.add_argument("--minimum-stat", type=float,
+                    help="Minimum statistic value to store.")
 parser.add_argument("--output-file",
                     help="File to store the candidate triggers")
 stat.insert_statistic_option_group(parser)
@@ -158,6 +160,12 @@ for tnum in template_ids:
         stat_t = stat_t[cid]
         tids_full = tids_full[cid]
         trigger_times = trigger_times[cid]
+
+    if args.minimum_stat is not None:
+        keep = stat_t >= args.minimum_stat
+        stat_t = stat_t[keep]
+        tids_full = tids_full[keep]
+        trigger_times = trigger_times[keep]
 
     trigger_ids_all += list(tids_full)
     template_ids_all += list(tnum * np.ones_like(tids_full))


### PR DESCRIPTION
sngls_statmap is taking a lot of memory, part of that is the lack of real cuts being applied to sngls_findtrigs

There is no scientific benefit to keeping anything below the stat-threshold being used in pycbc_sngls_statmap, so this way we can cut things out that we won't use later as early as possible

## Standard information about the request

This is an efficiency update
This change affects the offline search
This change changes:  result presentation / plotting, scientific output (a little bit)

This change: follows style guidelines (See e.g. [PEP8](https://peps.python.org/pep-0008/)), has been proposed using the [contribution guidelines](https://github.com/gwastro/pycbc/blob/master/CONTRIBUTING.md)

## Motivation
sngls_statmap has very high memory use - this is mainly due to sngls_findtrigs not getting rid of anything

## Contents
Implement a --minimum-stat threshold cut in sngls-findtrigs

## Links to any issues or associated PRs
https://github.com/gwastro/pycbc/pull/4724

## Testing performed
Code run, statmap generated, and then plotted with pycbc_page_snrifar, I will link to plots once the runs are completed!

## Additional notes
I would prefer decimation of the triggers below this cut, so that the plots in particular can go lower, but I am struggling to implement that. This can go on the v23 release branch as a fix there

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
