### PR TITLE
Fix bug in left-right SNR comparison in pycbc_multi_inspiral

### DIFF
--- a/bin/pycbc_multi_inspiral
+++ b/bin/pycbc_multi_inspiral
@@ -768,7 +768,6 @@ with ctx:
                             )
                             # Apply cut to remove points with left or right
                             # polarized coherent SNR below threshold
-                            #if len(coinc_snr) != 0:
                             l_above = rho_coh_l > args.coinc_threshold
                             r_above = rho_coh_r > args.coinc_threshold
                             lr_above = l_above & r_above

--- a/bin/pycbc_multi_inspiral
+++ b/bin/pycbc_multi_inspiral
@@ -31,6 +31,7 @@ import argparse
 import numpy as np
 import h5py
 
+import pycbc.version
 from pycbc import (
     detector,
     fft,
@@ -55,6 +56,7 @@ from pycbc.vetoes import sgchisq
 # pycbc_multi_inspiral executable.
 time_init = time.time()
 parser = argparse.ArgumentParser(description=__doc__)
+parser.add_argument('--version', action=pycbc.version.Version)
 add_common_pycbc_options(parser)
 parser.add_argument("--output", type=str)
 parser.add_argument(
@@ -66,18 +68,11 @@ parser.add_argument(
 )
 parser.add_argument("--bank-file", type=str)
 parser.add_argument(
-    "--snr-threshold",
+    "--sngl-snr-threshold",
     type=float,
     metavar='THRESHOLD',
     help="Single IFO SNR threshold for trigger generation."
 )
-# Commenting out unused options: remove if they remain unused
-# parser.add_argument(
-#     "--newsnr-threshold",
-#     type=float,
-#     metavar='THRESHOLD',
-#     help="Cut triggers with NewSNR less than THRESHOLD",
-# )
 parser.add_argument(
     "--low-frequency-cutoff",
     type=float,
@@ -395,7 +390,7 @@ with ctx:
         ifo: MatchedFilterControl(
             args.low_frequency_cutoff,
             None,
-            args.snr_threshold,
+            args.sngl_snr_threshold,
             tlen,
             delta_f,
             complex64,
@@ -736,6 +731,8 @@ with ctx:
                             ifo: ap[ifo][position_index][1]
                             for ifo in args.instruments
                         }
+                        # The cut is applied after the left vs right
+                        # comparison to ensure the arrays have equal lengths
                         if args.projection == 'left+right':
                             # Left polarized coherent SNR
                             project_l = coh.get_projection_matrix(
@@ -749,7 +746,7 @@ with ctx:
                             ) = coh.coherent_snr(
                                 coinc_triggers,
                                 coinc_idx,
-                                args.coinc_threshold,
+                                0.,
                                 project_l,
                                 rho_coinc,
                             )
@@ -765,10 +762,28 @@ with ctx:
                             ) = coh.coherent_snr(
                                 coinc_triggers,
                                 coinc_idx,
-                                args.coinc_threshold,
+                                0.,
                                 project_r,
                                 rho_coinc,
                             )
+                            # Apply cut to remove points with left or right
+                            # polarized coherent SNR below threshold
+                            #if len(coinc_snr) != 0:
+                            l_above = rho_coh_l > args.coinc_threshold
+                            r_above = rho_coh_r > args.coinc_threshold
+                            lr_above = l_above & r_above
+                            rho_coh_l = rho_coh_l[lr_above]
+                            rho_coh_r = rho_coh_r[lr_above]
+                            coinc_idx_l = coinc_idx_l[lr_above]
+                            coinc_idx_r = coinc_idx_r[lr_above]
+                            for ifo in coinc_triggers_l.keys():
+                                coinc_triggers_l[ifo] = \
+                                    coinc_triggers_l[ifo][lr_above]
+                            for ifo in coinc_triggers_r.keys():
+                                coinc_triggers_r[ifo] = \
+                                    coinc_triggers_r[ifo][lr_above]
+                            rho_coinc_l = rho_coinc_l[lr_above]
+                            rho_coinc_r = rho_coinc_r[lr_above]
                             # Point by point, track the larger of the two
                             # and store its information
                             max_idx = np.argmax([rho_coh_l, rho_coh_r], axis=0)

--- a/examples/multi_inspiral/faceon_faceaway.sh
+++ b/examples/multi_inspiral/faceon_faceaway.sh
@@ -65,7 +65,7 @@ for POL in 'standard' 'left' 'right' 'left+right'; do
             H1:H1-${CHANNEL}-${GPS_START}-${DUR}.gwf \
             L1:L1-${CHANNEL}-${GPS_START}-${DUR}.gwf \
             V1:V1-${CHANNEL}-${GPS_START}-${DUR}.gwf \
-        --snr-threshold 4.0 \
+        --sngl-snr-threshold 4.0 \
         --chisq-bins "0.9*get_freq('fSEOBNRv4Peak',params.mass1,params.mass2,params.spin1z,params.spin2z)**(2./3.)" \
         --bank-veto-bank-file ${BANK_VETO_FILE} \
         --cluster-method window \

--- a/examples/multi_inspiral/run.sh
+++ b/examples/multi_inspiral/run.sh
@@ -46,7 +46,7 @@ pycbc_multi_inspiral \
     --approximant IMRPhenomD \
     --order -1 \
     --low-frequency-cutoff 30 \
-    --snr-threshold 3.0 \
+    --sngl-snr-threshold 3.0 \
     --chisq-bins "0.9*get_freq('fSEOBNRv4Peak',params.mass1,params.mass2,params.spin1z,params.spin2z)**(2./3.)" \
     --pad-data 8 \
     --strain-high-pass 25 \


### PR DESCRIPTION
## Standard information about the request

This is a: bug fix and adds a minor new feature

It only affects `pycbc_multi_inspiral`

## Contents
This change fixes a bug in the comparison procedure between left and right projected coherent SNRs.  The cut on coherent SNR must be applied **after** the point-by-point comparisons of left/right SNRs and not prior to it to the two SNRs individually.  This ensures that arrays of equal lengths are compared.

This PR also renames an option and adds `--version`.

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
