### PR TITLE
Cleanup sky stuff in multi_inspiral

### DIFF
--- a/bin/pycbc_multi_inspiral
+++ b/bin/pycbc_multi_inspiral
@@ -80,7 +80,7 @@ def calculate_antenna_pattern(args, sky_pos_indices):
     """
     antenna_pattern = {}
     for ifo in args.instruments:
-        curr_det = Detector(ifo)
+        curr_det = detector.Detector(ifo)
         antenna_pattern[ifo] = [None] * len(sky_pos_indices)
         for index in sky_pos_indices:
             antenna_pattern[ifo][index] = curr_det.antenna_pattern(

--- a/bin/pycbc_multi_inspiral
+++ b/bin/pycbc_multi_inspiral
@@ -58,7 +58,10 @@ def sky_grid_from_cli(parser, args):
         args.sky_grid is not None
         and (args.ra is not None or args.dec is not None)
     ):
-        parser.error('Give either a sky grid or a sky position, not both')
+        parser.error(
+            'Please provide either a sky grid via --sky-grid or a '
+            'single sky position via --ra and --dec, not both'
+        )
     if args.sky_grid is not None:
         with h5py.File(args.sky_grid, 'r') as sky_grid_file:
             ra = sky_grid_file['ra'][:]

--- a/bin/pycbc_multi_inspiral
+++ b/bin/pycbc_multi_inspiral
@@ -51,6 +51,47 @@ from pycbc.types import zeros, float32, complex64
 from pycbc.vetoes import sgchisq
 
 
+def sky_grid_from_cli(parser, args):
+    """Read the sky grid or the single sky position given the CLI arguments.
+    """
+    if (
+        args.sky_grid is not None
+        and (args.ra is not None or args.dec is not None)
+    ):
+        parser.error('Give either a sky grid or a sky position, not both')
+    if args.sky_grid is not None:
+        with h5py.File(args.sky_grid, 'r') as sky_grid_file:
+            ra = sky_grid_file['ra'][:]
+            dec = sky_grid_file['dec'][:]
+    elif args.ra is not None and args.dec is not None:
+        ra = np.array([args.ra])
+        dec = np.array([args.dec])
+    else:
+        parser.error(
+            'Please specify a sky grid via --sky-grid '
+            'or a single position via --ra and --dec'
+        )
+    return np.array([ra, dec])
+
+
+def calculate_antenna_pattern(args, sky_pos_indices):
+    """Precalculate the antenna pattern functions for all detectors and sky
+    positions.
+    """
+    antenna_pattern = {}
+    for ifo in args.instruments:
+        curr_det = Detector(ifo)
+        antenna_pattern[ifo] = [None] * len(sky_pos_indices)
+        for index in sky_pos_indices:
+            antenna_pattern[ifo][index] = curr_det.antenna_pattern(
+                sky_positions[0][index],
+                sky_positions[1][index],
+                polarization=0,
+                t_gps=t_gps,
+            )
+    return antenna_pattern
+
+
 # The following block of lines sets up the command-line interface (CLI) for the
 # pycbc_multi_inspiral executable.
 time_init = time.time()
@@ -315,25 +356,8 @@ with ctx:
         precision='single',
     )
 
-    # Read the sky grid or the single sky position
-    if (
-        args.sky_grid is not None
-        and args.ra is not None
-        and args.dec is not None
-    ):
-        parser.error('Give either a sky grid or a sky position, not both')
-
-    if args.sky_grid is not None:
-        sky_grid = h5py.File(args.sky_grid, 'r')
-        ra = np.array(sky_grid['ra'])
-        dec = np.array(sky_grid['dec'])
-    if args.ra is not None and args.dec is not None:
-        ra = np.array([args.ra])
-        dec = np.array([args.dec])
-
-    sky_positions = np.array([ra, dec])
-    num_sky_positions = sky_positions.shape[1]
-    positions_array = np.arange(num_sky_positions)
+    sky_positions = sky_grid_from_cli(parser, args)
+    sky_pos_indices = np.arange(sky_positions.shape[1])
 
     logging.info("Determining time slide shifts and time delays")
     # Create a dictionary of time slide shifts; IFO 0 is unshifted
@@ -354,7 +378,7 @@ with ctx:
             )
             for ifo in args.instruments
         }
-        for position_index in positions_array
+        for position_index in sky_pos_indices
     }
     time_delay_idx = {
         slide: {
@@ -370,7 +394,7 @@ with ctx:
                 )
                 for ifo in args.instruments
             }
-            for position_index in positions_array
+            for position_index in sky_pos_indices
         }
         for slide in slide_ids
     }
@@ -521,25 +545,8 @@ with ctx:
         n_bank = len(bank)
         logging.info("Template bank size after thinning: %d", n_bank)
 
-    # Antenna patterns
-    antenna_patterns = [
-        [[0 for i in range(2)] for position_index in positions_array]
-        for i in range(len(args.instruments))
-    ]
-    for i, ifo in enumerate(args.instruments):
-        for position_index in positions_array:
-            antenna_patterns[i][position_index] = detector.Detector(
-                ifo
-            ).antenna_pattern(
-                sky_positions[0][position_index],
-                sky_positions[1][position_index],
-                polarization=0,
-                t_gps=t_gps,
-            )
-
-    ap = {}
-    for i, ifo in enumerate(args.instruments):
-        ap[ifo] = antenna_patterns[i]
+    logging.info("Calculating antenna pattern functions at every sky position")
+    antenna_pattern = calculate_antenna_pattern(args, sky_pos_indices)
 
     logging.info("Starting the filtering...")
     # Loop over templates
@@ -625,11 +632,11 @@ with ctx:
             for slide in range(args.num_slides + 1):
                 logging.info("Analyzing slide %d/%d", slide, args.num_slides)
                 # Loop over sky positions
-                for position_index in positions_array:
+                for position_index in sky_pos_indices:
                     logging.info(
                         "Analyzing sky position %d/%d",
                         position_index + 1,
-                        len(positions_array),
+                        len(sky_pos_indices),
                     )
                     # Adjust the indices of triggers (if there are any)
                     # and store trigger indices list in a dictionary;
@@ -729,11 +736,11 @@ with ctx:
                         logging.info("Calculating their coherent statistics")
                         # Plus and cross antenna pattern dictionaries
                         fp = {
-                            ifo: ap[ifo][position_index][0]
+                            ifo: antenna_pattern[ifo][position_index][0]
                             for ifo in args.instruments
                         }
                         fc = {
-                            ifo: ap[ifo][position_index][1]
+                            ifo: antenna_pattern[ifo][position_index][1]
                             for ifo in args.instruments
                         }
                         if args.projection == 'left+right':

--- a/bin/pycbc_multi_inspiral
+++ b/bin/pycbc_multi_inspiral
@@ -75,7 +75,7 @@ def sky_grid_from_cli(parser, args):
 
 
 def calculate_antenna_pattern(args, sky_pos_indices):
-    """Precalculate the antenna pattern functions for all detectors and sky
+    """Calculate the antenna pattern functions for all detectors and sky
     positions.
     """
     antenna_pattern = {}


### PR DESCRIPTION
Cleanup of the sky grid and antenna pattern calculations in `pycbc_multi_inspiral`.

## Standard information about the request

This is a code cleanup and minor bugfix.

This change affects PyGRB.

No changes to results or scientific output are expected.

No functionality or API should be broken by this.

## Motivation

`pycbc_multi_inspiral` implements a very long algorithm right now, including many branches and multiple long loops. Looking through it, I noticed that the code handling the sky grid CLI and calculating the antenna pattern is more complicated than necessary, uses more variables than needed, and pollutes the namespace with several temporary variables. There is also a check for simultaneous usage of `--sky-grid`, `--ra` and `--dec` which is not entirely correct, for example it will miss the cases where `--sky-grid` and `--ra` are both given, or none are given at all.

## Contents

I created two small helper functions that handle the CLI arguments related to the sky grid (including a proper check of them) and the precalculation of the antenna pattern functions.

## Links to any issues or associated PRs

None.

## Testing performed

None, apart from the automatic CI tests.

## Additional notes

I think the present calculation/handling of the antenna pattern and time delays is not particularly efficient, as it uses dicts and lists, and is repeated identically by every `pycbc_multi_inspiral` job. I wonder how much total time this entails in a PyGRB workflow with a large sky grid. It may be useful to evaluate this, and switch to precalculating the antenna pattern and time delays just once, maybe in `pycbc_make_skygrid`, and using multidimensional Numpy arrays for carrying around the precalculated values.

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
