### PR TITLE
Options and cuts in pycbc_multi_inspiral

### DIFF
--- a/bin/pycbc_multi_inspiral
+++ b/bin/pycbc_multi_inspiral
@@ -433,8 +433,7 @@ with ctx:
     # Directly use existing SingleDetPowerChisq, SingleDetBankVeto, and
     # SingleDetAutoChisq to calculate single detector chi-squares for
     # multiple IFOs
-    power_chisq = vetoes.SingleDetPowerChisq(args.chisq_bins,
-                                             args.chisq_snr_threshold)
+    power_chisq = vetoes.SingleDetPowerChisq(args.chisq_bins)
     bank_chisq = vetoes.SingleDetBankVeto(
         args.bank_veto_bank_file,
         flen,

--- a/bin/pycbc_multi_inspiral
+++ b/bin/pycbc_multi_inspiral
@@ -48,6 +48,7 @@ from pycbc import (
 )
 from pycbc.events import ranking, coherent as coh, EventManagerCoherent
 from pycbc.filter import MatchedFilterControl
+from pycbc.results import pygrb_postprocessing_utils as ppu
 from pycbc.types import zeros, float32, complex64
 from pycbc.vetoes import sgchisq
 
@@ -102,6 +103,7 @@ time_init = time.time()
 parser = argparse.ArgumentParser(description=__doc__)
 parser.add_argument('--version', action=pycbc.version.Version)
 add_common_pycbc_options(parser)
+ppu.pygrb_add_bestnr_opts(parser)
 parser.add_argument("--output", type=str)
 parser.add_argument(
     "--instruments",
@@ -111,12 +113,6 @@ parser.add_argument(
     help="List of instruments to analyze.",
 )
 parser.add_argument("--bank-file", type=str)
-parser.add_argument(
-    "--sngl-snr-threshold",
-    type=float,
-    metavar='THRESHOLD',
-    help="Single IFO SNR threshold for trigger generation."
-)
 parser.add_argument(
     "--low-frequency-cutoff",
     type=float,
@@ -274,11 +270,8 @@ inject.insert_injfilterrejector_option_group_multi_ifo(parser)
 sgchisq.SingleDetSGChisq.insert_option_group(parser)
 args = parser.parse_args()
 init_logging(args.verbose)
-# Set GRB time variable for convenience
-t_gps = args.trigger_time
 # Arrange detectors alphabetically so they are always called in the same order
 args.instruments.sort()
-nifo = len(args.instruments[:])
 # Use class verification methods to check whether input CLI options provided
 # by parser to pycbc.strain, pycbc.strain.StrainSegments, pycbc.psd,
 # pycbc.scheme, and pycbc.fft modules are sane.
@@ -310,8 +303,13 @@ strain_segments_dict = strain.StrainSegments.from_cli_multi_ifos(
 ctx = scheme.from_cli(args)
 with ctx:
     fft.from_cli(args)
-    # Set some often used variables for easy access
+    # Set some convenience variables: number of IFOs, lower frequency,
+    # GRB time, sky positions to search (either a grid or single sky point)
+    nifo = len(args.instruments[:])
     flow = args.low_frequency_cutoff
+    t_gps = args.trigger_time
+    sky_positions = sky_grid_from_cli(parser, args)
+    sky_pos_indices = np.arange(sky_positions.shape[1])
     # The following for loop is used to check whether
     # the sampling rate, flen and tlen agree for all detectors
     # taking the zeroth detector in the list as a reference.
@@ -354,15 +352,12 @@ with ctx:
         precision='single',
     )
 
-    sky_positions = sky_grid_from_cli(parser, args)
-    sky_pos_indices = np.arange(sky_positions.shape[1])
-
     logging.info("Determining time slide shifts and time delays")
     # Create a dictionary of time slide shifts; IFO 0 is unshifted
     slide_ids = np.arange(1 + args.num_slides)
     time_slides = {
-        ifo: args.slide_shift * slide_ids * n_ifo
-        for n_ifo, ifo in enumerate(args.instruments)
+        ifo: args.slide_shift * slide_ids * ifo_idx
+        for ifo_idx, ifo in enumerate(args.instruments)
     }
     # Given the time delays wrt to IFO 0 in time_slides, create a dictionary
     # for time delay indices evaluated wrt the geocenter, in units of samples,
@@ -427,7 +422,6 @@ with ctx:
             downsample_factor=args.downsample_factor,
             upsample_threshold=args.upsample_threshold,
             upsample_method=args.upsample_method,
-            cluster_function='symmetric',
         )
         for ifo in args.instruments
     }
@@ -437,7 +431,7 @@ with ctx:
     # Directly use existing SingleDetPowerChisq, SingleDetBankVeto, and
     # SingleDetAutoChisq to calculate single detector chi-squares for
     # multiple IFOs
-    power_chisq = vetoes.SingleDetPowerChisq(args.chisq_bins)
+    power_chisq = vetoes.SingleDetPowerChisq(args.chisq_bins, opt.chisq_snr_threshold)
     bank_chisq = vetoes.SingleDetBankVeto(
         args.bank_veto_bank_file,
         flen,
@@ -615,6 +609,12 @@ with ctx:
                 snr_dict[ifo] = (
                     snr_ts[matched_filter[ifo].segments[s_num].analyze] * norm
                 )
+                # Raise error if this segment has no data
+                if len(snr_dict[ifo]) == 0:
+                    raise RuntimeError(
+                        'The SNR triggers dictionary is empty. This '
+                        'should not be possible.'
+                    )
                 norm_dict[ifo] = norm
                 corr_dict[ifo] = corr.copy()
                 idx[ifo] = ind.copy()
@@ -672,14 +672,6 @@ with ctx:
                     logging.info(
                         "Found %d coincident triggers", len(coinc_idx)
                     )
-                    for ifo in args.instruments:
-                        # Raise errror if this segment has no data
-                        # FIXME: raise this sooner?
-                        if len(snr_dict[ifo]) == 0:
-                            raise RuntimeError(
-                                'The SNR triggers dictionary is empty. This '
-                                'should not be possible.'
-                            )
                     # Time delay is applied to indices to have them at the IFOs
                     coinc_idx_det_frame = {
                         ifo: (

--- a/bin/pycbc_multi_inspiral
+++ b/bin/pycbc_multi_inspiral
@@ -433,7 +433,8 @@ with ctx:
     # Directly use existing SingleDetPowerChisq, SingleDetBankVeto, and
     # SingleDetAutoChisq to calculate single detector chi-squares for
     # multiple IFOs
-    power_chisq = vetoes.SingleDetPowerChisq(args.chisq_bins, opt.chisq_snr_threshold)
+    power_chisq = vetoes.SingleDetPowerChisq(args.chisq_bins,
+                                             args.chisq_snr_threshold)
     bank_chisq = vetoes.SingleDetBankVeto(
         args.bank_veto_bank_file,
         flen,

--- a/bin/pycbc_multi_inspiral
+++ b/bin/pycbc_multi_inspiral
@@ -48,7 +48,6 @@ from pycbc import (
 )
 from pycbc.events import ranking, coherent as coh, EventManagerCoherent
 from pycbc.filter import MatchedFilterControl
-from pycbc.results import pygrb_postprocessing_utils as ppu
 from pycbc.types import zeros, float32, complex64
 from pycbc.vetoes import sgchisq
 

--- a/bin/pycbc_multi_inspiral
+++ b/bin/pycbc_multi_inspiral
@@ -213,29 +213,35 @@ parser.add_argument(
     "value will be discarded.",
 )
 parser.add_argument(
-    "--do-null-cut", action='store_true', help="Apply a cut based on null SNR."
+    "--do-null-cut", action='store_true', help="Apply a cut based on null "
+    "SNR: retained triggers have null SNR smaller than null-min and "
+    "coherent SNR smaller than null-step, or null SNR smaller than "
+    "(null-grad * coherent SNR + null_min) and coherent SNR greater than "
+    "null-step."
 )
 parser.add_argument(
     "--null-min",
     type=float,
     default=5.25,
-    help="Triggers with null_snr above this value will be discarded "
-    "(default: 5.25)."
+    help="In addition to its usage with the flag --do-null-cut, null-min is "
+    "used in SNR reweighting: reweighting happens for triggers with null SNR "
+    "greater than (null-min - 1) and coherent SNR smaller than null-step, or "
+    "null SNR greater than (null-grad * coherent SNR + null_min - 1) and "
+    "coherent SNR greater than null-step (default: 5.25)."
 )
 parser.add_argument(
     "--null-grad",
     type=float,
     default=0.2,
-    help="The gradient of the line defining the null cut "
-    "after the null step (default: 0.2)."
+    help="The gradient of the null SNR cut and/or of the SNR reweighting "
+    "theshold when coherent SNR > null_step (default: 0.2)."
 )
 parser.add_argument(
     "--null-step",
     type=float,
     default=20.0,
-    help="Triggers with coherent snr above null_step will "
-    "be cut according to the null_grad and null_min "
-    "(default: 20)."
+    help="The threshold for a second condition set to cut in null SNR "
+    "and/or reweight SNR (default: 20)."
 )
 parser.add_argument(
     "--trigger-time",
@@ -905,6 +911,9 @@ with ctx:
                             # Calculate null reweighted SNR
                             reweighted_snr = coh.reweight_snr_by_null(
                                 reweighted_snr, null, rho_coh
+                                null_min=args.null_min,
+                                null_grad=args.null_grad,
+                                null_step=args.null_step,
                             )
                         elif nifo == 2:
                             reweighted_snr = ranking.newsnr(

--- a/bin/pycbc_multi_inspiral
+++ b/bin/pycbc_multi_inspiral
@@ -215,8 +215,8 @@ parser.add_argument(
     action="store",
     type=float,
     default=4.0,
-    help="Single detector SNR threshold: the two most sensitive detectors "
-    "must have SNR above this (default: 3)."
+    metavar='THRESHOLD',
+    help="Single IFO SNR threshold for trigger generation (default: 4)."
 )
 parser.add_argument(
     "--chisq-index",

--- a/bin/pycbc_multi_inspiral
+++ b/bin/pycbc_multi_inspiral
@@ -933,7 +933,7 @@ with ctx:
                             )
                             # Calculate null reweighted SNR
                             reweighted_snr = coh.reweight_snr_by_null(
-                                reweighted_snr, null, rho_coh
+                                reweighted_snr, null, rho_coh,
                                 null_min=args.null_min,
                                 null_grad=args.null_grad,
                                 null_step=args.null_step,

--- a/bin/pycbc_multi_inspiral
+++ b/bin/pycbc_multi_inspiral
@@ -640,12 +640,7 @@ with ctx:
                 snr_dict[ifo] = (
                     snr_ts[matched_filter[ifo].segments[s_num].analyze] * norm
                 )
-                # Raise error if this segment has no data
-                if len(snr_dict[ifo]) == 0:
-                    raise RuntimeError(
-                        'The SNR triggers dictionary is empty. This '
-                        'should not be possible.'
-                    )
+                assert len(snr_dict[ifo]) > 0, f'SNR time series for {ifo} is empty'
                 norm_dict[ifo] = norm
                 corr_dict[ifo] = corr.copy()
                 idx[ifo] = ind.copy()

--- a/bin/pycbc_multi_inspiral
+++ b/bin/pycbc_multi_inspiral
@@ -219,21 +219,23 @@ parser.add_argument(
     "--null-min",
     type=float,
     default=5.25,
-    help="Triggers with null_snr above this value will be discarded.",
+    help="Triggers with null_snr above this value will be discarded "
+    "(default: 5.25)."
 )
 parser.add_argument(
     "--null-grad",
     type=float,
     default=0.2,
     help="The gradient of the line defining the null cut "
-    "after the null step.",
+    "after the null step (default: 0.2)."
 )
 parser.add_argument(
     "--null-step",
     type=float,
     default=20.0,
     help="Triggers with coherent snr above null_step will "
-    "be cut according to the null_grad and null_min.",
+    "be cut according to the null_grad and null_min "
+    "(default: 20)."
 )
 parser.add_argument(
     "--trigger-time",
@@ -839,6 +841,10 @@ with ctx:
                             ) = coh.null_snr(
                                 rho_coh,
                                 rho_coinc,
+                                apply_cut=args.do_null_cut,
+                                null_min=args.null_min,
+                                null_grad=args.null_grad,
+                                null_step=args.null_step,
                                 snrv=coinc_triggers,
                                 index=coinc_idx,
                             )
@@ -893,7 +899,8 @@ with ctx:
                         # Calculate chisq reweighted SNR
                         if nifo > 2:
                             reweighted_snr = ranking.newsnr(
-                                rho_coh, network_chisq_dict
+                                rho_coh, network_chisq_dict,
+                                q=args.chisq_index, n=args.chisq-nhigh
                             )
                             # Calculate null reweighted SNR
                             reweighted_snr = coh.reweight_snr_by_null(
@@ -901,7 +908,8 @@ with ctx:
                             )
                         elif nifo == 2:
                             reweighted_snr = ranking.newsnr(
-                                rho_coinc, network_chisq_dict
+                                rho_coinc, network_chisq_dict,
+                                q=args.chisq_index, n=args.chisq-nhigh
                             )
                         else:
                             rho_sngl = abs(
@@ -910,7 +918,8 @@ with ctx:
                                 ]
                             )
                             reweighted_snr = ranking.newsnr(
-                                rho_sngl, network_chisq_dict
+                                rho_sngl, network_chisq_dict,
+                                q=args.chisq_index, n=args.chisq-nhigh
                             )
                         # All out vals must be the same length, so single
                         # value entries are repeated once per event

--- a/bin/pycbc_multi_inspiral
+++ b/bin/pycbc_multi_inspiral
@@ -223,7 +223,7 @@ parser.add_argument(
     action="store",
     type=float,
     default=6.0,
-    help="chisq_index for the reweighting of coherent SNR by chi-square "
+    help="chisq-index (q) for the reweighting of coherent SNR by chi-square "
     "(default: 6)."
 )
 parser.add_argument(
@@ -231,7 +231,8 @@ parser.add_argument(
     action="store",
     type=float,
     default=2.0,
-    help="chisq_nhigh for newSNR calculation (default: 2)."
+    help="chisq-nhigh (n) for the reweighting of coherent SNR by chi-square "
+    "(default: 2)."
 )
 parser.add_argument(
     "--do-null-cut",

--- a/bin/pycbc_multi_inspiral
+++ b/bin/pycbc_multi_inspiral
@@ -103,7 +103,6 @@ time_init = time.time()
 parser = argparse.ArgumentParser(description=__doc__)
 parser.add_argument('--version', action=pycbc.version.Version)
 add_common_pycbc_options(parser)
-ppu.pygrb_add_bestnr_opts(parser)
 parser.add_argument("--output", type=str)
 parser.add_argument(
     "--instruments",
@@ -213,11 +212,35 @@ parser.add_argument(
     "value will be discarded.",
 )
 parser.add_argument(
-    "--do-null-cut", action='store_true', help="Apply a cut based on null "
-    "SNR: retained triggers have null SNR smaller than null-min and "
-    "coherent SNR smaller than null-step, or null SNR smaller than "
-    "(null-grad * coherent SNR + null_min) and coherent SNR greater than "
-    "null-step."
+    "--sngl-snr-threshold",
+    action="store",
+    type=float,
+    default=4.0,
+    help="Single detector SNR threshold: the two most sensitive detectors "
+    "must have SNR above this (default: 3)."
+)
+parser.add_argument(
+    "--chisq-index",
+    action="store",
+    type=float,
+    default=6.0,
+    help="chisq_index for the reweighting of coherent SNR by chi-square "
+    "(default: 6)."
+)
+parser.add_argument(
+    "--chisq-nhigh",
+    action="store",
+    type=float,
+    default=2.0,
+    help="chisq_nhigh for newSNR calculation (default: 2)."
+)
+parser.add_argument(
+    "--do-null-cut",
+    action='store_true',
+    help="Apply a cut based on null SNR: retained triggers have null SNR "
+    "smaller than null-min and coherent SNR smaller than null-step, or null "
+    "SNR smaller than (null-grad * coherent SNR + null_min) and coherent SNR "
+    "greater than null-step."
 )
 parser.add_argument(
     "--null-min",

--- a/bin/pycbc_multi_inspiral
+++ b/bin/pycbc_multi_inspiral
@@ -900,7 +900,7 @@ with ctx:
                         if nifo > 2:
                             reweighted_snr = ranking.newsnr(
                                 rho_coh, network_chisq_dict,
-                                q=args.chisq_index, n=args.chisq-nhigh
+                                q=args.chisq_index, n=args.chisq_nhigh
                             )
                             # Calculate null reweighted SNR
                             reweighted_snr = coh.reweight_snr_by_null(
@@ -909,7 +909,7 @@ with ctx:
                         elif nifo == 2:
                             reweighted_snr = ranking.newsnr(
                                 rho_coinc, network_chisq_dict,
-                                q=args.chisq_index, n=args.chisq-nhigh
+                                q=args.chisq_index, n=args.chisq_nhigh
                             )
                         else:
                             rho_sngl = abs(
@@ -919,7 +919,7 @@ with ctx:
                             )
                             reweighted_snr = ranking.newsnr(
                                 rho_sngl, network_chisq_dict,
-                                q=args.chisq_index, n=args.chisq-nhigh
+                                q=args.chisq_index, n=args.chisq_nhigh
                             )
                         # All out vals must be the same length, so single
                         # value entries are repeated once per event

--- a/bin/pycbc_multi_inspiral
+++ b/bin/pycbc_multi_inspiral
@@ -53,11 +53,9 @@ from pycbc.vetoes import sgchisq
 
 
 def sky_grid_from_cli(parser, args):
-    """Read the sky grid or the single sky position given the CLI arguments.
-    """
-    if (
-        args.sky_grid is not None
-        and (args.ra is not None or args.dec is not None)
+    """Read the sky grid or the single sky position given the CLI arguments."""
+    if args.sky_grid is not None and (
+        args.ra is not None or args.dec is not None
     ):
         parser.error(
             'Please provide either a sky grid via --sky-grid or a '
@@ -190,12 +188,10 @@ parser.add_argument(
 parser.add_argument(
     "--ra",
     type=float,
-    help="Right ascension of sky point to search (radians),"
+    help="Right ascension of sky point to search (radians),",
 )
 parser.add_argument(
-    "--dec",
-    type=float,
-    help="Declination of sky point to search (radians),"
+    "--dec", type=float, help="Declination of sky point to search (radians),"
 )
 parser.add_argument(
     "--sky-grid",
@@ -216,7 +212,7 @@ parser.add_argument(
     type=float,
     default=4.0,
     metavar='THRESHOLD',
-    help="Single IFO SNR threshold for trigger generation (default: 4)."
+    help="Single IFO SNR threshold for trigger generation (default: 4).",
 )
 parser.add_argument(
     "--chisq-index",
@@ -224,7 +220,7 @@ parser.add_argument(
     type=float,
     default=6.0,
     help="chisq-index (q) for the reweighting of coherent SNR by chi-square "
-    "(default: 6)."
+    "(default: 6).",
 )
 parser.add_argument(
     "--chisq-nhigh",
@@ -232,7 +228,7 @@ parser.add_argument(
     type=float,
     default=2.0,
     help="chisq-nhigh (n) for the reweighting of coherent SNR by chi-square "
-    "(default: 2)."
+    "(default: 2).",
 )
 parser.add_argument(
     "--do-null-cut",
@@ -240,7 +236,7 @@ parser.add_argument(
     help="Apply a cut based on null SNR: retained triggers have null SNR "
     "smaller than null-min and coherent SNR smaller than null-step, or null "
     "SNR smaller than (null-grad * coherent SNR + null_min) and coherent SNR "
-    "greater than null-step."
+    "greater than null-step.",
 )
 parser.add_argument(
     "--null-min",
@@ -250,21 +246,21 @@ parser.add_argument(
     "used in SNR reweighting: reweighting happens for triggers with null SNR "
     "greater than (null-min - 1) and coherent SNR smaller than null-step, or "
     "null SNR greater than (null-grad * coherent SNR + null_min - 1) and "
-    "coherent SNR greater than null-step (default: 5.25)."
+    "coherent SNR greater than null-step (default: 5.25).",
 )
 parser.add_argument(
     "--null-grad",
     type=float,
     default=0.2,
     help="The gradient of the null SNR cut and/or of the SNR reweighting "
-    "theshold when coherent SNR > null_step (default: 0.2)."
+    "theshold when coherent SNR > null_step (default: 0.2).",
 )
 parser.add_argument(
     "--null-step",
     type=float,
     default=20.0,
     help="The threshold for a second condition set to cut in null SNR "
-    "and/or reweight SNR (default: 20)."
+    "and/or reweight SNR (default: 20).",
 )
 parser.add_argument(
     "--trigger-time",
@@ -353,13 +349,15 @@ with ctx:
         else:
             vname = "Sample rate"
             err_msg = " must be consistent across all ifos."
-            assert sample_rate == strain_dict[ifo].sample_rate, vname+err_msg
+            assert sample_rate == strain_dict[ifo].sample_rate, vname + err_msg
             vname = "Frequency length"
-            assert flen == strain_segments_dict[ifo].freq_len, vname+err_msg
+            assert flen == strain_segments_dict[ifo].freq_len, vname + err_msg
             vname = "Time length"
-            assert tlen == strain_segments_dict[ifo].time_len, vname+err_msg
+            assert tlen == strain_segments_dict[ifo].time_len, vname + err_msg
             vname = "delta_f (=segment length inverse)"
-            assert delta_f == strain_segments_dict[ifo].delta_f, vname+err_msg
+            assert delta_f == strain_segments_dict[ifo].delta_f, (
+                vname + err_msg
+            )
     # segments is a dictionary of frequency domain objects, each one of which
     # is the Fourier transform of the segments in strain_segments_dict
     logging.info("Making frequency-domain data segments")
@@ -729,7 +727,7 @@ with ctx:
                         if len(coinc_idx) != 0:
                             logging.info(
                                 "With max coincident SNR = %.2f",
-                                max(rho_coinc)
+                                max(rho_coinc),
                             )
                     # If there is only one IFO, just take its triggers
                     # and their SNRs
@@ -741,9 +739,7 @@ with ctx:
                         }
                     else:
                         coinc_triggers = {}
-                        logging.info(
-                            "No coincident triggers were found"
-                        )
+                        logging.info("No coincident triggers were found")
                     # If there are triggers above coinc threshold and more
                     # than 2 IFOs, then calculate the coherent statistics for
                     # them and apply the cut on coherent SNR (with threshold
@@ -774,7 +770,7 @@ with ctx:
                             ) = coh.coherent_snr(
                                 coinc_triggers,
                                 coinc_idx,
-                                0.,
+                                0.0,
                                 project_l,
                                 rho_coinc,
                             )
@@ -790,7 +786,7 @@ with ctx:
                             ) = coh.coherent_snr(
                                 coinc_triggers,
                                 coinc_idx,
-                                0.,
+                                0.0,
                                 project_r,
                                 rho_coinc,
                             )
@@ -804,11 +800,13 @@ with ctx:
                             coinc_idx_l = coinc_idx_l[lr_above]
                             coinc_idx_r = coinc_idx_r[lr_above]
                             for ifo in coinc_triggers_l.keys():
-                                coinc_triggers_l[ifo] = \
-                                    coinc_triggers_l[ifo][lr_above]
+                                coinc_triggers_l[ifo] = coinc_triggers_l[ifo][
+                                    lr_above
+                                ]
                             for ifo in coinc_triggers_r.keys():
-                                coinc_triggers_r[ifo] = \
-                                    coinc_triggers_r[ifo][lr_above]
+                                coinc_triggers_r[ifo] = coinc_triggers_r[ifo][
+                                    lr_above
+                                ]
                             rho_coinc_l = rho_coinc_l[lr_above]
                             rho_coinc_r = rho_coinc_r[lr_above]
                             # Point by point, track the larger of the two
@@ -923,20 +921,26 @@ with ctx:
                         # Calculate chisq reweighted SNR
                         if nifo > 2:
                             reweighted_snr = ranking.newsnr(
-                                rho_coh, network_chisq_dict,
-                                q=args.chisq_index, n=args.chisq_nhigh
+                                rho_coh,
+                                network_chisq_dict,
+                                q=args.chisq_index,
+                                n=args.chisq_nhigh,
                             )
                             # Calculate null reweighted SNR
                             reweighted_snr = coh.reweight_snr_by_null(
-                                reweighted_snr, null, rho_coh,
+                                reweighted_snr,
+                                null,
+                                rho_coh,
                                 null_min=args.null_min,
                                 null_grad=args.null_grad,
                                 null_step=args.null_step,
                             )
                         elif nifo == 2:
                             reweighted_snr = ranking.newsnr(
-                                rho_coinc, network_chisq_dict,
-                                q=args.chisq_index, n=args.chisq_nhigh
+                                rho_coinc,
+                                network_chisq_dict,
+                                q=args.chisq_index,
+                                n=args.chisq_nhigh,
                             )
                         else:
                             rho_sngl = abs(
@@ -945,8 +949,10 @@ with ctx:
                                 ]
                             )
                             reweighted_snr = ranking.newsnr(
-                                rho_sngl, network_chisq_dict,
-                                q=args.chisq_index, n=args.chisq_nhigh
+                                rho_sngl,
+                                network_chisq_dict,
+                                q=args.chisq_index,
+                                n=args.chisq_nhigh,
                             )
                         # All out vals must be the same length, so single
                         # value entries are repeated once per event

--- a/pycbc/results/pygrb_postprocessing_utils.py
+++ b/pycbc/results/pygrb_postprocessing_utils.py
@@ -126,25 +126,20 @@ def pygrb_add_injmc_opts(parser):
 
 
 def pygrb_add_bestnr_opts(parser):
-    """Add to the parser object the arguments used for BestNR calculation."""
+    """Add to the parser object the arguments used for BestNR calculation,
+    null SNR, single SNR cut and null SNR cut."""
     if parser is None:
         parser = argparse.ArgumentParser()
     parser.add_argument("-Q", "--chisq-index", action="store", type=float,
-                        default=6.0, help="chisq_index for newSNR calculation")
+                        default=6.0, help="chisq_index for newSNR " +
+                        "calculation (default: 6)")
     parser.add_argument("-N", "--chisq-nhigh", action="store", type=float,
-                        default=2.0, help="nhigh for newSNR calculation")
+                        default=2.0, help="chisq_nhigh for newSNR " +
+                        "calculation (default: 2")
     parser.add_argument("-B", "--sngl-snr-threshold", action="store",
                         type=float, default=4.0, help="Single detector SNR " +
                         "threshold, the two most sensitive detectors " +
                         "should have SNR above this.")
-    parser.add_argument("-d", "--snr-threshold", action="store", type=float,
-                        default=6.0, help="SNR threshold for recording " +
-                        "triggers.")
-    parser.add_argument("-c", "--newsnr-threshold", action="store", type=float,
-                        default=6.0, help="NewSNR threshold for " +
-                        "calculating the chisq of triggers (based on value " +
-                        "of auto and bank chisq  values. By default will " +
-                        "take the same value as snr-threshold.")
     parser.add_argument("-A", "--null-snr-threshold", action="store",
                         default="3.5,5.25",
                         help="Comma separated lower,higher null SNR " +


### PR DESCRIPTION
- Passing options from `pycbc_multi_inspiral` command line to the methods that calculate null SNR, cut in null SNR, and calculate reweighted SNR.
- Renaming `n_ifo` as `ifo_idx` to avoid confusion with the already existing `nifo`.
- Grouping together the definitions of auxiliary variables.

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
