### PR TITLE
Add a module and class for handling sky grids for `pycbc_multi_inspiral`

### DIFF
--- a/bin/pycbc_multi_inspiral
+++ b/bin/pycbc_multi_inspiral
@@ -79,7 +79,12 @@ def slide_limiter(args):
 time_init = time.time()
 parser = argparse.ArgumentParser(description=__doc__)
 add_common_pycbc_options(parser)
-parser.add_argument("--output", type=str)
+parser.add_argument(
+    "--output",
+    type=str,
+    required=True,
+    help="Path to the output file."
+)
 parser.add_argument(
     "--instruments",
     nargs="+",
@@ -87,10 +92,16 @@ parser.add_argument(
     required=True,
     help="List of instruments to analyze.",
 )
-parser.add_argument("--bank-file", type=str)
+parser.add_argument(
+    "--bank-file",
+    type=str,
+    required=True,
+    help="Path to the template bank file."
+)
 parser.add_argument(
     "--low-frequency-cutoff",
     type=float,
+    required=True,
     help="The low frequency cutoff to use for filtering (Hz).",
 )
 # Add approximant arg
@@ -203,16 +214,16 @@ parser.add_argument(
 parser.add_argument(
     "--ra",
     type=float,
-    help="Right ascension of sky point to search (radians),",
+    help="Right ascension of sky point to search (radians).",
 )
 parser.add_argument(
-    "--dec", type=float, help="Declination of sky point to search (radians),"
+    "--dec", type=float, help="Declination of sky point to search (radians)."
 )
 parser.add_argument(
     "--sky-grid",
     type=str,
-    help="Sky-grid to search, an hdf file containing two datasets: "
-    "ra and dec, both in radians",
+    help="Path to an HDF file containing the sky grid to search over, "
+    "with two datasets, ra and dec, both in radians.",
 )
 parser.add_argument(
     "--coinc-threshold",
@@ -297,8 +308,8 @@ parser.add_argument(
     help="Size of each time slide shift.",
 )
 parser.add_argument(
-        "--do-shortslides",
-        action="store_true"
+    "--do-shortslides",
+    action="store_true"
 )
 # Add options groups
 strain.insert_strain_option_group_multi_ifo(parser)

--- a/bin/pycbc_multi_inspiral
+++ b/bin/pycbc_multi_inspiral
@@ -31,7 +31,6 @@ import argparse
 import numpy as np
 
 from pycbc import (
-    detector,
     fft,
     init_logging,
     inject,
@@ -578,7 +577,9 @@ with ctx:
         logging.info("Template bank size after thinning: %d", n_bank)
 
     logging.info("Calculating antenna pattern functions at every sky position")
-    antenna_pattern = calculate_antenna_patterns(args.instruments, t_gps)
+    antenna_pattern = sky_positions.calculate_antenna_patterns(
+        args.instruments, t_gps
+    )
 
     logging.info("Starting the filtering...")
     # Loop over templates

--- a/bin/pycbc_multi_inspiral
+++ b/bin/pycbc_multi_inspiral
@@ -49,48 +49,8 @@ from pycbc.io.hdf import HFile
 from pycbc.filter import MatchedFilterControl
 from pycbc.types import zeros, float32, complex64
 from pycbc.vetoes import sgchisq
+from pycbc.tmpltbank.sky_grid import SkyGrid
 
-
-def sky_grid_from_cli(parser, args):
-    """Read the sky grid or the single sky position given the CLI arguments."""
-    if args.sky_grid is not None and (
-        args.ra is not None or args.dec is not None
-    ):
-        parser.error(
-            'Please provide either a sky grid via --sky-grid or a '
-            'single sky position via --ra and --dec, not both'
-        )
-    if args.sky_grid is not None:
-        with HFile(args.sky_grid, 'r') as sky_grid_file:
-            ra = sky_grid_file['ra'][:]
-            dec = sky_grid_file['dec'][:]
-    elif args.ra is not None and args.dec is not None:
-        ra = np.array([args.ra])
-        dec = np.array([args.dec])
-    else:
-        parser.error(
-            'Please specify a sky grid via --sky-grid '
-            'or a single position via --ra and --dec'
-        )
-    return np.array([ra, dec])
-
-
-def calculate_antenna_pattern(args, sky_pos_indices):
-    """Calculate the antenna pattern functions for all detectors and sky
-    positions.
-    """
-    antenna_pattern = {}
-    for ifo in args.instruments:
-        curr_det = detector.Detector(ifo)
-        antenna_pattern[ifo] = [None] * len(sky_pos_indices)
-        for index in sky_pos_indices:
-            antenna_pattern[ifo][index] = curr_det.antenna_pattern(
-                sky_positions[0][index],
-                sky_positions[1][index],
-                polarization=0,
-                t_gps=t_gps,
-            )
-    return antenna_pattern
 
 def slide_limiter(args):
     '''
@@ -392,8 +352,7 @@ with ctx:
     nifo = len(args.instruments[:])
     flow = args.low_frequency_cutoff
     t_gps = args.trigger_time
-    sky_positions = sky_grid_from_cli(parser, args)
-    sky_pos_indices = np.arange(sky_positions.shape[1])
+    sky_positions = SkyGrid.from_cli(parser, args)
     # The following for loop is used to check whether
     # the sampling rate, flen and tlen agree for all detectors
     # taking the zeroth detector in the list as a reference.
@@ -448,36 +407,26 @@ with ctx:
     # Given the time delays wrt to IFO 0 in time_slides, create a dictionary
     # for time delay indices evaluated wrt the geocenter, in units of samples,
     # i.e. (time delay from geocenter + time slide)*sampling_rate
-    time_delay_idx_zerolag = {
-        position_index: {
-            ifo: detector.Detector(ifo).time_delay_from_earth_center(
-                sky_positions[0][position_index],
-                sky_positions[1][position_index],
-                t_gps,
-            )
-            for ifo in args.instruments
-        }
-        for position_index in sky_pos_indices
-    }
+    time_delays_zerolag = sky_positions.calculate_time_delays(
+        args.instruments, t_gps
+    )
     time_delay_idx = {
         slide: {
             position_index: {
-                ifo: int(
-                    round(
+                ifo: round(
                         (
-                            time_delay_idx_zerolag[position_index][ifo]
+                            time_delays_zerolag[ifo][position_index]
                             + time_slides[ifo][slide]
                         )
                         * sample_rate
                     )
-                )
                 for ifo in args.instruments
             }
-            for position_index in sky_pos_indices
+            for position_index in range(len(sky_positions))
         }
         for slide in slide_ids
     }
-    del time_delay_idx_zerolag
+    del time_delays_zerolag
 
     logging.info("Setting up MatchedFilterControl at each IFO")
     # Prototype container for the output of MatchedFilterControl and
@@ -629,7 +578,7 @@ with ctx:
         logging.info("Template bank size after thinning: %d", n_bank)
 
     logging.info("Calculating antenna pattern functions at every sky position")
-    antenna_pattern = calculate_antenna_pattern(args, sky_pos_indices)
+    antenna_pattern = calculate_antenna_patterns(args.instruments, t_gps)
 
     logging.info("Starting the filtering...")
     # Loop over templates
@@ -713,11 +662,11 @@ with ctx:
             for slide in range(num_slides):
                 logging.info("Analyzing slide %d/%d", slide, num_slides)
                 # Loop over sky positions
-                for position_index in sky_pos_indices:
+                for position_index in range(len(sky_positions)):
                     logging.info(
                         "Analyzing sky position %d/%d",
                         position_index + 1,
-                        len(sky_pos_indices),
+                        len(sky_positions),
                     )
                     # Adjust the indices of triggers (if there are any)
                     # and store trigger indices list in a dictionary;
@@ -1084,10 +1033,10 @@ with ctx:
                         )
                         network_out_vals['nifo'] = [nifo] * num_events
                         network_out_vals['dec'] = [
-                            sky_positions[1][position_index]
+                            sky_positions.decs[position_index]
                         ] * num_events
                         network_out_vals['ra'] = [
-                            sky_positions[0][position_index]
+                            sky_positions.ras[position_index]
                         ] * num_events
                         network_out_vals['slide_id'] = [slide] * num_events
                         event_mgr.add_template_events_to_network(

--- a/bin/pycbc_multi_inspiral
+++ b/bin/pycbc_multi_inspiral
@@ -417,9 +417,7 @@ with ctx:
     # Given the time delays wrt to IFO 0 in time_slides, create a dictionary
     # for time delay indices evaluated wrt the geocenter, in units of samples,
     # i.e. (time delay from geocenter + time slide)*sampling_rate
-    time_delays_zerolag = sky_positions.calculate_time_delays(
-        args.instruments, t_gps
-    )
+    time_delays_zerolag = sky_positions.calculate_time_delays()
     time_delay_idx = {
         slide: {
             position_index: {
@@ -588,9 +586,7 @@ with ctx:
         logging.info("Template bank size after thinning: %d", n_bank)
 
     logging.info("Calculating antenna pattern functions at every sky position")
-    antenna_pattern = sky_positions.calculate_antenna_patterns(
-        args.instruments, t_gps
-    )
+    antenna_pattern = sky_positions.calculate_antenna_patterns()
 
     logging.info("Starting the filtering...")
     # Loop over templates

--- a/bin/pycbc_multi_inspiral
+++ b/bin/pycbc_multi_inspiral
@@ -414,12 +414,12 @@ with ctx:
         slide: {
             position_index: {
                 ifo: round(
-                        (
-                            time_delays_zerolag[ifo][position_index]
-                            + time_slides[ifo][slide]
-                        )
-                        * sample_rate
+                    (
+                        time_delays_zerolag[ifo][position_index]
+                        + time_slides[ifo][slide]
                     )
+                    * sample_rate
+                )
                 for ifo in args.instruments
             }
             for position_index in range(len(sky_positions))
@@ -647,7 +647,9 @@ with ctx:
                 snr_dict[ifo] = (
                     snr_ts[matched_filter[ifo].segments[s_num].analyze] * norm
                 )
-                assert len(snr_dict[ifo]) > 0, f'SNR time series for {ifo} is empty'
+                assert (
+                    len(snr_dict[ifo]) > 0
+                ), f'SNR time series for {ifo} is empty'
                 norm_dict[ifo] = norm
                 corr_dict[ifo] = corr.copy()
                 idx[ifo] = ind.copy()

--- a/pycbc/tmpltbank/sky_grid.py
+++ b/pycbc/tmpltbank/sky_grid.py
@@ -94,11 +94,11 @@ class SkyGrid:
             result[det_name] = np.empty((len(self), 2))
             for i, (ra, dec) in enumerate(self):
                 result[det_name][i] = det.antenna_pattern(
-                    ra, dec, 0, polarization=0, t_gps=gps_time
+                    ra, dec, 0, t_gps=gps_time
                 )
         return result
 
-    def calculate_time_delays(self, detectors, gps_time):
+    def calculate_time_delays(self, detector_names, gps_time):
         """Calculate the time delays from the Earth center to a list of GW
         detectors at each point in the grid. Return a dict, keyed by detector
         name, whose items are 1-dimensional Numpy arrays containing the time

--- a/pycbc/tmpltbank/sky_grid.py
+++ b/pycbc/tmpltbank/sky_grid.py
@@ -31,26 +31,22 @@ class SkyGrid:
         self.positions = np.vstack([ra, dec]).T
 
     def __len__(self):
-        """Returns the number of points in the sky grid.
-        """
+        """Returns the number of points in the sky grid."""
         return self.positions.shape[0]
 
     def __getitem__(self, index):
-        """Returns the coordinates of a single point in the grid.
-        """
+        """Returns the coordinates of a single point in the grid."""
         return self.positions[index]
 
     @property
     def ras(self):
-        """Returns all right ascensions.
-        """
-        return self.positions[:,0]
+        """Returns all right ascensions."""
+        return self.positions[:, 0]
 
     @property
     def decs(self):
-        """Returns all declinations.
-        """
-        return self.positions[:,1]
+        """Returns all declinations."""
+        return self.positions[:, 1]
 
     @classmethod
     def from_cli(cls, cli_parser, cli_args):
@@ -73,16 +69,14 @@ class SkyGrid:
 
     @classmethod
     def read_from_file(cls, path):
-        """Initialize a sky grid from a given HDF5 file.
-        """
+        """Initialize a sky grid from a given HDF5 file."""
         with h5py.File(path, 'r') as hf:
             ra = hf['ra'][:]
             dec = hf['dec'][:]
         return cls(ra, dec)
 
     def write_to_file(self, path):
-        """Writes a sky grid to an HDF5 file.
-        """
+        """Writes a sky grid to an HDF5 file."""
         with h5py.File(path, 'w') as hf:
             hf['ra'] = self.ras
             hf['dec'] = self.decs

--- a/pycbc/tmpltbank/sky_grid.py
+++ b/pycbc/tmpltbank/sky_grid.py
@@ -1,0 +1,113 @@
+"""Functionality for handling grids of points in the sky for coherent SNR
+calculation via `pycbc_multi_inspiral`. The main operation to be performed on
+these points is calculating the antenna pattern functions and time delays from
+the Earth center for a network of detectors.
+"""
+
+import numpy as np
+import h5py
+
+from pycbc.detector import Detector
+
+
+class SkyGrid:
+    def __init__(self, ra, dec):
+        """Initialize a sky grid from a list of RA/dec coordinates.
+
+        Parameters
+        ----------
+        ra: iterable of floats
+            Right ascensions for each point UNITS AND ANGULAR CONVENTION.
+        dec: iterable of floats
+            Declination for each point UNITS AND ANGULAR CONVENTION.
+        """
+        # Question: should the list of detectors and reference times be part of
+        # the SkyGrid object? Or should they be given each time they are needed,
+        # independently? This decision will affect the `calculate_*()` methods
+        # down below.
+        # We store the points in a 2D array internally, first dimension runs
+        # over the list of points, second dimension is RA/dec.
+        # Question: should we use Astropy sky positions instead?
+        self.positions = np.vstack([ra, dec]).T
+
+    def __len__(self):
+        """Returns the number of points in the sky grid.
+        """
+        return self.positions.shape[0]
+
+    def __getitem__(self, index):
+        """Returns the coordinates of a single point in the grid.
+        """
+        return self.positions[index]
+
+    @property
+    def ras(self):
+        """Returns all right ascensions.
+        """
+        return self.positions[:,0]
+
+    @property
+    def decs(self):
+        """Returns all declinations.
+        """
+        return self.positions[:,1]
+
+    @classmethod
+    def from_cli(cls, cli_parser, cli_args):
+        """Initialize a sky grid from command-line interface, via argparse
+        objects.
+        """
+        if cli_args.sky_grid is not None:
+            if cli_args.ra is not None or cli_args.dec is not None:
+                cli_parser.error('Use --sky-grid or --ra & --dec, not both')
+            return cls.read_from_file(cli_args.sky_grid)
+        if cli_args.ra is not None and cli_args.dec is not None:
+            return cls([cli_args.ra], [cli_args.dec])
+        cli_parser.error('--ra and --dec must be used together')
+
+    @classmethod
+    def read_from_file(cls, path):
+        """Initialize a sky grid from a given HDF5 file.
+        """
+        with h5py.File(path, 'r') as hf:
+            ra = hf['ra'][:]
+            dec = hf['dec'][:]
+        return cls(ra, dec)
+
+    def write_to_file(self, path):
+        """Writes a sky grid to an HDF5 file.
+        """
+        with h5py.File(path, 'w') as hf:
+            hf['ra'] = self.ras
+            hf['dec'] = self.decs
+
+    def calculate_antenna_patterns(self, detector_names, gps_time):
+        """Calculate the antenna pattern functions at each point in the grid
+        for a list of GW detectors.
+        """
+        result = {}
+        for det_name in detector_names:
+            det = Detector(det_name)
+            result[det_name] = np.empty((len(self), 2))
+            for i, (ra, dec) in enumerate(self):
+                result[det_name][i] = det.antenna_pattern(
+                    ra, dec, 0, t_gps=gps_time
+                )
+        return result
+
+    def calculate_time_delays(self, detectors, gps_time):
+        """Calculate the time delays from the Earth center to a list of GW
+        detectors at each point in the grid.
+        """
+        result = {}
+        for det_name in detector_names:
+            det = Detector(det_name)
+            result[det_name] = np.empty(len(self))
+            for i, (ra, dec) in enumerate(self):
+                result[det_name][i] = det.time_delay_from_earth_center(
+                    ra, dec, t_gps=gps_time
+                )
+        return result
+
+
+__all__ = ['SkyGrid']

--- a/pycbc/tmpltbank/sky_grid.py
+++ b/pycbc/tmpltbank/sky_grid.py
@@ -17,9 +17,10 @@ class SkyGrid:
         Parameters
         ----------
         ra: iterable of floats
-            Right ascensions for each point UNITS AND ANGULAR CONVENTION.
+            Right ascensions for each point in radians, in the interval [0,2π).
         dec: iterable of floats
-            Declination for each point UNITS AND ANGULAR CONVENTION.
+            Declination for each point in radians, where π/2 is the North pole,
+            -π/2 is the South pole, and 0 is the celestial equator.
         detectors: iterable of str
             List of detector names associated with the sky grid, typically the
             detectors for which the grid has been placed or is to be placed.
@@ -47,12 +48,13 @@ class SkyGrid:
 
     @property
     def ras(self):
-        """Returns all right ascensions."""
+        """Returns all right ascensions in radians, in the interval [0,2π)."""
         return self.positions[:, 0]
 
     @property
     def decs(self):
-        """Returns all declinations."""
+        """Returns all declinations in radians, where π/2 is the North pole,
+        -π/2 is the South pole, and 0 is the celestial equator."""
         return self.positions[:, 1]
 
     @classmethod

--- a/pycbc/tmpltbank/sky_grid.py
+++ b/pycbc/tmpltbank/sky_grid.py
@@ -11,7 +11,7 @@ from pycbc.detector import Detector
 
 
 class SkyGrid:
-    def __init__(self, ra, dec):
+    def __init__(self, ra, dec, detectors, ref_gps_time):
         """Initialize a sky grid from a list of RA/dec coordinates.
 
         Parameters
@@ -20,15 +20,22 @@ class SkyGrid:
             Right ascensions for each point UNITS AND ANGULAR CONVENTION.
         dec: iterable of floats
             Declination for each point UNITS AND ANGULAR CONVENTION.
+        detectors: iterable of str
+            List of detector names associated with the sky grid, typically the
+            detectors for which the grid has been placed or is to be placed.
+            The detectors will be used when calculating the antenna pattern
+            functions and time delays from Earth center.
+        ref_gps_time: float
+            Reference GPS time associated with the sky grid. This will be used
+            when calculating the antenna pattern functions and time delays from
+            Earth center.
         """
-        # Question: should the list of detectors and reference times be part of
-        # the SkyGrid object? Or should they be given each time they are needed,
-        # independently? This decision will affect the `calculate_*()` methods
-        # down below.
         # We store the points in a 2D array internally, first dimension runs
         # over the list of points, second dimension is RA/dec.
         # Question: should we use Astropy sky positions instead?
         self.positions = np.vstack([ra, dec]).T
+        self.detectors = sorted(detectors)
+        self.ref_gps_time = ref_gps_time
 
     def __len__(self):
         """Returns the number of points in the sky grid."""
@@ -61,6 +68,7 @@ class SkyGrid:
                 )
             return cls.read_from_file(cli_args.sky_grid)
         if cli_args.ra is not None and cli_args.dec is not None:
+            # FIXME where do we get the detectors and ref time from?
             return cls([cli_args.ra], [cli_args.dec])
         cli_parser.error(
             'Please specify a sky grid via --sky-grid or a single sky '
@@ -73,44 +81,48 @@ class SkyGrid:
         with h5py.File(path, 'r') as hf:
             ra = hf['ra'][:]
             dec = hf['dec'][:]
-        return cls(ra, dec)
+            detectors = hf.attrs['detectors']
+            ref_gps_time = hf.attrs['ref_gps_time']
+        return cls(ra, dec, detectors, ref_gps_time)
 
     def write_to_file(self, path):
         """Writes a sky grid to an HDF5 file."""
         with h5py.File(path, 'w') as hf:
             hf['ra'] = self.ras
             hf['dec'] = self.decs
+            hf.attrs['detectors'] = self.detectors
+            hf.attrs['ref_gps_time'] = self.ref_gps_time
 
-    def calculate_antenna_patterns(self, detector_names, gps_time):
+    def calculate_antenna_patterns(self):
         """Calculate the antenna pattern functions at each point in the grid
-        for a list of GW detectors. Return a dict, keyed by detector name,
-        whose items are 2-dimensional Numpy arrays. The first dimension of
-        these arrays runs over the sky grid, and the second dimension runs over
-        the plus and cross polarizations.
+        for the list of GW detectors specified at instantiation. Return a dict,
+        keyed by detector name, whose items are 2-dimensional Numpy arrays.
+        The first dimension of these arrays runs over the sky grid, and the
+        second dimension runs over the plus and cross polarizations.
         """
         result = {}
-        for det_name in detector_names:
+        for det_name in self.detectors:
             det = Detector(det_name)
             result[det_name] = np.empty((len(self), 2))
             for i, (ra, dec) in enumerate(self):
                 result[det_name][i] = det.antenna_pattern(
-                    ra, dec, 0, t_gps=gps_time
+                    ra, dec, 0, t_gps=self.ref_gps_time
                 )
         return result
 
-    def calculate_time_delays(self, detector_names, gps_time):
-        """Calculate the time delays from the Earth center to a list of GW
-        detectors at each point in the grid. Return a dict, keyed by detector
-        name, whose items are 1-dimensional Numpy arrays containing the time
-        delays for each sky point.
+    def calculate_time_delays(self):
+        """Calculate the time delays from the Earth center to each GW detector
+        specified at instantiation, for each point in the grid. Return a dict,
+        keyed by detector name, whose items are 1-dimensional Numpy arrays
+        containing the time delays for each sky point.
         """
         result = {}
-        for det_name in detector_names:
+        for det_name in self.detectors:
             det = Detector(det_name)
             result[det_name] = np.empty(len(self))
             for i, (ra, dec) in enumerate(self):
                 result[det_name][i] = det.time_delay_from_earth_center(
-                    ra, dec, t_gps=gps_time
+                    ra, dec, t_gps=self.ref_gps_time
                 )
         return result
 

--- a/pycbc/tmpltbank/sky_grid.py
+++ b/pycbc/tmpltbank/sky_grid.py
@@ -68,8 +68,12 @@ class SkyGrid:
                 )
             return cls.read_from_file(cli_args.sky_grid)
         if cli_args.ra is not None and cli_args.dec is not None:
-            # FIXME where do we get the detectors and ref time from?
-            return cls([cli_args.ra], [cli_args.dec])
+            return cls(
+                [cli_args.ra],
+                [cli_args.dec],
+                cli_args.instruments,
+                cli_args.trigger_time
+            )
         cli_parser.error(
             'Please specify a sky grid via --sky-grid or a single sky '
             'position via --ra and --dec'


### PR DESCRIPTION
Calculating the coherent network SNR (`pycbc_multi_inspiral`) requires a grid of points in the sky. This adds a module and class to manage such grids in a more centralized way.

## Standard information about the request

This is mostly refactoring existing code into a new module. This change affects PyGRB but does not change any output.

## Motivation

`pycbc_multi_inspiral` is a very long script at this point, and `pycbc_make_sky_grid` might also become very long as we implement various algorithms for placing sky grids available in the literature. Centralizing the management of sky grids, including reading/writing them from/to files, seems beneficial.

## Contents

I added a pycbc.tmpltbank.sky_grid module which currently contains a `SkyGrid` class, with methods to read and write sky grids from HDF5 files, calculate the antenna patterns and time delays over the grid for a network of detectors, and handle CLI arguments related to sky grids.

## Links to any issues or associated PRs

None.

## Testing performed

I wrote a short script to plot the antenna patterns and time delays over a sky grids of random points for various detectors, and visually checked that those made sense:

![image](https://github.com/gwastro/pycbc/assets/11317236/ef845e60-a7bb-4a44-960c-feb836340382)

## Additional notes

None.

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
