### PR TITLE
Reweighted SNR cut enabled in PyGRB post-processing

### DIFF
--- a/bin/pygrb/pycbc_make_offline_grb_workflow
+++ b/bin/pygrb/pycbc_make_offline_grb_workflow
@@ -298,7 +298,7 @@ if wflow.cp.has_section("workflow-injections"):
     # Generate injection files
     if IPN:
         # TODO: we used to pass this file to setup_injection_workflow as
-        # exttrig_file = sim_pts_file to then use it in lalapps_insping.
+        # exttrig_file = sim_pts_file to then use it in lalapps_inspinj.
         # The code below picks it up but does not pass it: get
         # setup_injection_workflow or pycbc_create_injections handle it
         # directly via configparser_value_to_file

--- a/bin/pygrb/pycbc_pygrb_efficiency
+++ b/bin/pygrb/pycbc_pygrb_efficiency
@@ -31,8 +31,8 @@ import numpy as np
 import scipy
 from scipy import stats
 import pycbc.version
-from pycbc.detector import Detector
 from pycbc import init_logging
+from pycbc.detector import Detector
 from pycbc.results import save_fig_with_metadata
 from pycbc.results import pygrb_postprocessing_utils as ppu
 from pycbc.conversions import mchirp_from_mass1_mass2
@@ -169,10 +169,12 @@ if not os.path.isdir(outdir):
 ifos, vetoes = ppu.extract_ifos_and_vetoes(trig_file, opts.veto_files,
                                            opts.veto_category)
 
-# Load triggers, time-slides, and segment dictionary
+# Load triggers (apply reweighted SNR cut), time-slides, and segment dictionary
 logging.info("Loading triggers.")
-trigs = ppu.load_triggers(trig_file, vetoes)
-logging.info("%d triggers loaded.", trigs['network/event_id'].len())
+trigs = ppu.load_triggers(trig_file, ifos, vetoes,
+                          rw_snr_threshold=opts.newsnr_threshold)
+logging.info("%d offsource triggers surviving reweighted SNR cut.",
+    len(trigs['network/event_id']))
 logging.info("Loading timeslides.")
 slide_dict = ppu.load_time_slides(trig_file)
 logging.info("Loading segments.")
@@ -243,9 +245,10 @@ with h5py.File(opts.bank_file, 'r') as bank_file:
 # =======================
 if onsource_file:
 
-    # Get trigs
-    on_trigs = ppu.load_triggers(onsource_file, vetoes)
-    logging.info("%d onsource triggers loaded.", on_trigs['network/event_id'].len())
+    logging.info("Processing onsource.")
+    # Get onsouce_triggers (apply reweighted SNR cut)
+    on_trigs = ppu.load_triggers(onsource_file, ifos, vetoes,
+                                 rw_snr_threshold=opts.newsnr_threshold)
 
     # Calculate chirp mass values
     on_mchirp = template_mchirps[on_trigs['network/template_id']]
@@ -295,9 +298,11 @@ if do_injections:
 
     sites = [ifo[0] for ifo in ifos]
 
-    # Triggers and injections recovered in some form: discard ones at vetoed times
-    # This injs object contains the information about found/missed injections AND triggers
-    injs = ppu.load_triggers(found_missed_file, vetoes)
+    # injs contains the information about found/missed injections AND triggers
+    # Triggers and injections are discared if at vetoed times and/or below
+    # Reweighted SNR thrshold
+    injs = ppu.load_triggers(found_missed_file, ifos, vetoes,
+                             rw_snr_threshold=opts.newsnr_threshold)
 
     logging.info("Missed/found injections/triggers loaded.")
 
@@ -363,7 +368,6 @@ if do_injections:
     logging.info("%d found injections analysed.", len(injs['found/tc']))
 
     # Process missed injections (injs['missed'])
-
     logging.info("%d missed injections analysed.", len(injs['missed/tc']))
 
     # Create new set of injections for efficiency calculations
@@ -596,9 +600,12 @@ if do_injections:
             excl_dist = d + (e - (percentile / 100.)) * (d - d_low) /\
                     (e_low - e)
         else:
+            # Warn the user if the exclusion distance cannot be established,
+            # but let the workflow continue: the user will see the plot(s) and
+            # repeat with more injections
             excl_dist = 0
-            err_msg = "Efficiency below %d%% in first bin!" % (percentile)
-            logging.error(err_msg)
+            msg = "Efficiency below %d%% in first bin!" % (percentile)
+            logging.warning(msg)
         # TODO: include percentile, excl_dist on output pages
 
     # Plot efficiency using loudest foreground

--- a/bin/pygrb/pycbc_pygrb_efficiency
+++ b/bin/pygrb/pycbc_pygrb_efficiency
@@ -117,7 +117,7 @@ parser.add_argument("-C", "--cluster-window", action="store", type=float,
 parser.add_argument("--bank-file", action="store", type=str,
                     help="Location of the full template bank used.")
 ppu.pygrb_add_injmc_opts(parser)
-ppu.pygrb_add_bestnr_opts(parser)
+ppu.pygrb_add_bestnr_cut_opt(parser)
 opts = parser.parse_args()
 
 init_logging(opts.verbose, format="%(asctime)s: %(levelname)s: %(message)s")
@@ -128,17 +128,12 @@ bank_file = h5py.File(opts.bank_file, 'r')
 # Check options
 do_injections = opts.found_missed_file is not None
 
-if not opts.newsnr_threshold:
-    opts.newsnr_threshold = opts.snr_threshold
-
 # Store options used multiple times in local variables
 outdir = os.path.split(os.path.abspath(opts.background_output_file))[0]
 trig_file = opts.trig_file
 onsource_file = opts.onsource_file
 found_missed_file = opts.found_missed_file
 inj_set_name = opts.injection_set_name
-chisq_index = opts.chisq_index
-chisq_nhigh = opts.chisq_nhigh
 wf_err = opts.waveform_error
 cal_errs = {}
 cal_errs['G1'] = opts.g1_cal_error
@@ -152,12 +147,8 @@ cal_dc_errs['H1'] = opts.h1_dc_cal_error
 cal_dc_errs['K1'] = opts.k1_dc_cal_error
 cal_dc_errs['L1'] = opts.l1_dc_cal_error
 cal_dc_errs['V1'] = opts.v1_dc_cal_error
-snr_thresh = opts.snr_threshold
-sngl_snr_thresh = opts.sngl_snr_threshold
+# pycbc_multi_inspiral already applies sngl, coinc and null SNR cuts
 new_snr_thresh = opts.newsnr_threshold
-null_grad_thresh = opts.null_grad_thresh
-null_grad_val = opts.null_grad_val
-null_thresh = list(map(float, opts.null_snr_threshold.split(',')))
 upper_dist = opts.upper_inj_dist
 lower_dist = opts.lower_inj_dist
 num_bins = opts.num_bins
@@ -264,7 +255,7 @@ if onsource_file:
 
     # Retrieve BestNRs and record loudest trig by BestNR.
     # Get indices of loudest triggers and pick the loudest.
-    if on_trigs:
+    if on_trigs and on_trigs['network/reweighted_snr'].size > 0:
         loud_on_bestnr_idx = np.argmax(on_trigs['network/reweighted_snr'])
         loud_on_bestnr = np.max(on_trigs['network/reweighted_snr'])
 

--- a/bin/pygrb/pycbc_pygrb_minifollowups
+++ b/bin/pygrb/pycbc_pygrb_minifollowups
@@ -17,7 +17,7 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 """
-Temporary script to produce qscans of loudest triggers/missed injections
+Set up qscans and SNR timeseries plots of loudest triggers/missed injections
 """
 
 # =============================================================================
@@ -27,22 +27,21 @@ import os
 import argparse
 import logging
 import h5py
-import numpy as np
 from pycbc import init_logging
 import pycbc.workflow as wf
-from pycbc.workflow.core import resolve_url_to_file
+from pycbc.workflow.core import FileList, resolve_url_to_file
 import pycbc.workflow.minifollowups as mini
 import pycbc.version
 import pycbc.events
+import pycbc.results.pygrb_postprocessing_utils as ppu
 from pycbc.results import layout
-from pycbc.results.pygrb_postprocessing_utils import extract_ifos
 from pycbc.workflow.plotting import PlotExecutable
 from pycbc.workflow.grb_utils import build_veto_filelist, build_segment_filelist
 
 __author__ = "Francesco Pannarale <francesco.pannarale@ligo.org>"
 __version__ = pycbc.version.git_verbose_msg
 __date__ = pycbc.version.date
-__program__ = "pycbc_pygrb_minifollowupss"
+__program__ = "pycbc_pygrb_minifollowups"
 
 
 # =============================================================================
@@ -112,13 +111,14 @@ def make_timeseries_plot(workflow, trig_file, snr_type, central_time,
 # Main script starts here
 # =============================================================================
 parser = argparse.ArgumentParser(description=__doc__[1:])
-parser.add_argument('--version', action='version', version=pycbc.version.git_verbose_msg)
+parser.add_argument('--version', action='version',
+                    version=pycbc.version.git_verbose_msg)
 parser.add_argument("-v", "--verbose", default=False, action="store_true",
                     help="Verbose output")
 parser.add_argument('--trig-file',
-                    help="xml file containing the triggers found by PyGRB")
+                    help="HDF file with the triggers found by PyGRB")
 parser.add_argument('--followups-file',
-                    help="HDF format file containing trigger/injections to follow up")
+                    help="HDF file with the triggers/injections to follow up")
 parser.add_argument('--wiki-file',
                     help="Name of file to save wiki-formatted table in")
 parser.add_argument('--veto-files', nargs='+', action="store",
@@ -129,6 +129,7 @@ parser.add_argument("-a", "--seg-files", nargs="+", action="store",
                     "onsource and offsource segment files.")
 wf.add_workflow_command_line_group(parser)
 wf.add_workflow_settings_cli(parser, include_subdax_opts=True)
+ppu.pygrb_add_bestnr_cut_opt(parser)
 args = parser.parse_args()
 
 init_logging(args.verbose, format="%(asctime)s: %(levelname)s: %(message)s")
@@ -156,7 +157,7 @@ num_events = min(num_events, len(fp['BestNR'][:]))
 
 # Determine ifos used in the analysis
 trig_file = resolve_url_to_file(os.path.abspath(args.trig_file))
-ifos = extract_ifos(os.path.abspath(args.trig_file))
+ifos = ppu.extract_ifos(os.path.abspath(args.trig_file))
 num_ifos = len(ifos)
 
 # (Loudest) off/on-source events are on time-slid data so the
@@ -171,7 +172,7 @@ except:
 
 # Loop over triggers/injections to be followed up
 for num_event in range(num_events):
-    files = wf.FileList([])
+    files = FileList([])
     logging.info('Processing event: %s', num_event)
     gps_time = fp['GPS time'][num_event]
     gps_time = gps_time.astype(float)
@@ -180,7 +181,7 @@ for num_event in range(num_events):
         for key in fp.keys():
             row.append(fp[key][num_event])
         add_wiki_row(wiki_file, row)
-    # Handle off/on-source (loudest) triggers follow-up (which are on slid data)
+    # Handle off/on-source loudest triggers follow-up (which are on slid data)
     if not is_injection_followup:
         for ifo in ifos:
             time_shift = fp[ifo+' time shift (s)'][num_event]

--- a/bin/pygrb/pycbc_pygrb_page_tables
+++ b/bin/pygrb/pycbc_pygrb_page_tables
@@ -130,8 +130,8 @@ def load_missed_found_injections(hdf_file, ifos, snr_threshold, bank_file,
     # parameters. This is used to marginalize over calibration errors.
     # also save the snr per ifo
     for ifo in ifos:
-        if np.all(inj_data['network/event_id'][...] == 
-                      inj_data['%s/event_id' % ifo][...]):
+        if np.all(inj_data['network/event_id'][...] ==
+                  inj_data['%s/event_id' % ifo][...]):
             found_data['sigmasq_%s' % ifo] = inj_data['%s/sigmasq' % ifo][...]
             found_data['snr_%s' % ifo] = inj_data['%s/snr' % ifo][...]
         else:
@@ -295,7 +295,7 @@ logging.info("Loading triggers.")
 trig_data = ppu.load_triggers(offsource_file, ifos, None,
                               rw_snr_threshold=opts.newsnr_threshold)
 logging.info("%d offsource triggers surviving reweighted SNR cut.",
-    len(trig_data['network/event_id']))
+             len(trig_data['network/event_id']))
 logging.info("Loading timeslides.")
 slide_dict = ppu.load_time_slides(offsource_file)
 logging.info("Loading segments.")
@@ -409,7 +409,8 @@ if lofft_outfile:
              trig_data['network/coherent_snr'][trig_index],
              trig_data['network/my_network_chisq'][trig_index],
              trig_data['network/null_snr'][trig_index]]
-        d.extend([trig_data['%s/snr' % ifo][ifo_trig_index[ifo]] for ifo in ifos])
+        d.extend([trig_data['%s/snr' % ifo][ifo_trig_index[ifo]]
+                  for ifo in ifos])
         d.extend([slide_dict[trig_slide_id][ifo] for ifo in ifos])
         d.append(bestnr)
         td.append(d)

--- a/bin/pygrb/pycbc_pygrb_page_tables
+++ b/bin/pygrb/pycbc_pygrb_page_tables
@@ -193,10 +193,6 @@ parser.add_argument("--onsource-file", action="store",
 parser.add_argument("--found-missed-file", action="store",
                     help="HDF format file with injections to output " +
                     "details about.")
-parser.add_argument("--newsnr-threshold", action="store", type=float,
-                    default=0., help="NewSNR threshold to " +
-                    "dicriminate events with SNR < threshold." +
-                    "Default 0: all the events are considered.")
 parser.add_argument("--num-loudest-off-trigs", action="store",
                     type=int, default=30, help="Number of loudest " +
                     "offsouce triggers to output details about.")
@@ -225,6 +221,7 @@ parser.add_argument("-C", "--cluster-window", action="store", type=float,
                     default=0.1, help="The cluster window used " +
                     "to cluster triggers in time.")
 ppu.pygrb_add_injmc_opts(parser)
+ppu.pygrb_add_bestnr_cut_opt(parser)
 opts = parser.parse_args()
 
 init_logging(opts.verbose, format="%(asctime)s: %(levelname)s: %(message)s")
@@ -295,7 +292,10 @@ ifos, vetoes = ppu.extract_ifos_and_vetoes(offsource_file, opts.veto_files,
 
 # Load triggers, time-slides, and segment dictionary
 logging.info("Loading triggers.")
-trig_data = ppu.load_triggers(offsource_file, None)
+trig_data = ppu.load_triggers(offsource_file, ifos, None,
+                              rw_snr_threshold=opts.newsnr_threshold)
+logging.info("%d offsource triggers surviving reweighted SNR cut.",
+    len(trig_data['network/event_id']))
 logging.info("Loading timeslides.")
 slide_dict = ppu.load_time_slides(offsource_file)
 logging.info("Loading segments.")
@@ -479,15 +479,13 @@ if lofft_outfile:
 if onsource_file:
 
     # Get trigs
-    on_trigs = ppu.load_triggers(onsource_file, None)
-    logging.info("%d onsource triggers loaded.",
-                 len(on_trigs['network/event_id']))
+    on_trigs = ppu.load_triggers(onsource_file, ifos, None,
+                                 rw_snr_threshold=opts.newsnr_threshold)
 
     # Record loudest trig by BestNR
     loud_on_bestnr = 0
     if on_trigs:
-        on_trigs_bestnrs = reweightedsnr_cut(
-            on_trigs['network/reweighted_snr'][...], opts.newsnr_threshold)
+        on_trigs_bestnrs = on_trigs['network/reweighted_snr'][...]
 
         # Gather bestNR index
         bestNR_event = np.argmax(on_trigs_bestnrs)
@@ -576,8 +574,6 @@ if onsource_file:
     pycbc.results.save_fig_with_metadata(str(html_table), lont_outfile,
                                          **kwds)
 
-    # Close the onsource file
-    on_trigs.close()
 else:
     tot_off_snr = np.array([])
     for slide_id in slide_dict:
@@ -846,7 +842,5 @@ if found_missed_file is not None:
 
 # Close the bank file
 bank_data.close()
-# Close the trig file
-trig_data.close()
 
 # Post-processing of injections ends here

--- a/bin/pygrb/pycbc_pygrb_plot_chisq_veto
+++ b/bin/pygrb/pycbc_pygrb_plot_chisq_veto
@@ -49,8 +49,8 @@ __program__ = "pycbc_pygrb_plot_chisq_veto"
 # =============================================================================
 # Functions
 # =============================================================================
-# Functions to load trigger data
-def load_data(input_file, vetoes, opts, injections=False):
+# Function to load trigger data: includes applying cut in reweighted SNR
+def load_data(input_file, ifos, vetoes, opts, injections=False):
     """Load data from a trigger/injection file"""
     
     snr_type = opts.snr_type
@@ -66,21 +66,22 @@ def load_data(input_file, vetoes, opts, injections=False):
         if injections:
             logging.info("Loading injections...")
             # This will eventually become load_injections
-            trigs_or_injs = ppu.load_triggers(input_file, vetoes)
+            trigs_or_injs = \
+                ppu.load_triggers(input_file, ifos, vetoes,
+                                  rw_snr_threshold=opts.newsnr_threshold)
         else:
             logging.info("Loading triggers...")
-            trigs_or_injs = ppu.load_triggers(input_file, vetoes)
+            trigs_or_injs = \
+                ppu.load_triggers(input_file, ifos, vetoes,
+                                  rw_snr_threshold=opts.newsnr_threshold)
         
-        num_trigs_or_injs = len(trigs_or_injs['network/end_time_gc'][:])
+        # Count surviving points
+        num_trigs_or_injs = len(trigs_or_injs['network/reweighted_snr'])
         
         if snr_type in ['coherent', 'null', 'reweighted']:
             data[snr_type] = trigs_or_injs['network/%s_snr' % snr_type][:]
         elif snr_type == 'single':
-            key = opts.ifo + '/snr_' + opts.ifo.lower()
-            # TODO: Undoes current L710 in EventManagerCoherent.write_to_hdf
-            # and is ugly hardcoded!
-            if opts.ifo.lower() != 'h1':
-                key = key[:-1]
+            key = opts.ifo + '/snr'
             data[snr_type] = trigs_or_injs[key][:]
 
         # Calculate coincident SNR
@@ -167,8 +168,7 @@ def contour_colors(opts, new_snrs=None):
     # and keep track of where it is
     if new_snrs is None:
         new_snrs = [5.5, 6, 6.5, 7, 8, 9, 10, 11]
-    new_snr_thresh = opts.newsnr_threshold
-    colors = ["k-" if snr == new_snr_thresh else
+    colors = ["k-" if snr == opts.newsnr_threshold else
               "y-" if snr == int(snr) else
               "y--" for snr in new_snrs]
 
@@ -190,11 +190,12 @@ parser.add_argument("-z", "--zoom-in", default=False, action="store_true",
 parser.add_argument("-y", "--y-variable", required=True,
                     choices=['standard', 'bank', 'auto'],
                     help="Quantity to plot on the vertical axis.")
-# TODO: get 'single' to work
 parser.add_argument("--snr-type", default='coherent',
                     choices=['coherent', 'coincident', 'null', 'reweighted',
                     'single'], help="SNR value to plot on x-axis. Can be " +
                     "coherent, coincident, null, reweighted, or single IFO SNR")
+ppu.pygrb_add_bestnr_cut_opt(parser)
+ppu.pygrb_add_single_snr_cut_opt(parser)
 ppu.pygrb_add_bestnr_opts(parser)
 opts = parser.parse_args()
 
@@ -258,10 +259,10 @@ if ifo and ifo not in ifos:
     raise RuntimeError(err_msg)
 
 # Extract trigger data
-trig_data = load_data(trig_file, vetoes, opts)
+trig_data = load_data(trig_file, ifos, vetoes, opts)
 
 # Extract (or initialize) injection data
-inj_data = load_data(found_missed_file, vetoes, opts, injections=True)
+inj_data = load_data(found_missed_file, ifos, vetoes, opts, injections=True)
 
 # Sanity checks
 if trig_data[snr_type] is None and inj_data[snr_type] is None:

--- a/bin/pygrb/pycbc_pygrb_plot_coh_ifosnr
+++ b/bin/pygrb/pycbc_pygrb_plot_coh_ifosnr
@@ -35,8 +35,8 @@ import numpy
 import scipy
 import h5py
 import pycbc.version
-from pycbc.detector import Detector
 from pycbc import init_logging
+from pycbc.detector import Detector
 from pycbc.results import save_fig_with_metadata
 from pycbc.results import pygrb_postprocessing_utils as ppu
 from pycbc.results import pygrb_plotting_utils as plu
@@ -54,7 +54,7 @@ __program__ = "pycbc_pygrb_plot_coh_ifosnr"
 # Functions
 # =============================================================================
 # Function to load trigger data
-def load_data(input_file, vetoes, ifos, opts, injections=False):
+def load_data(input_file, ifos, vetoes, opts, injections=False):
     """Load data from a trigger/injection file"""
 
     # Initialize the dictionary
@@ -70,29 +70,32 @@ def load_data(input_file, vetoes, ifos, opts, injections=False):
         if injections:
             logging.info("Loading injections...")
             # TODO: This will eventually become load_injections
-            trigs = ppu.load_triggers(input_file, vetoes)
+            trigs = ppu.load_triggers(input_file, ifos, vetoes,
+                                      rw_snr_threshold=opts.newsnr_threshold)
         else:
             logging.info("Loading triggers...")
-            trigs = ppu.load_triggers(input_file, vetoes)
-
-        num_trigs = len(trigs['network/end_time_gc'][:])
+            trigs = ppu.load_triggers(input_file, ifos, vetoes,
+                                      rw_snr_threshold=opts.newsnr_threshold)
 
         # Load SNR data
-        data['coherent'] = trigs['network/coherent_snr'][:]
+        data['coherent'] = trigs['network/coherent_snr']
 
         # Get single ifo SNR data
+        ifo_trig_index = {}
         for ifo in ifos:
-            att = ifo.lower()
-            # TODO: do we want pycbc_grb_inj_finder or other executables upstream to handle this?
-            data['single'][ifo] = trigs['%s/snr' % ifo][:]
+            sorted_ifo_ids = [numpy.where(trigs['%s/event_id' % ifo] == idx)[0]
+                              for idx in trigs['network/event_id']]
+            sorted_ifo_ids = numpy.array(sorted_ifo_ids).flatten()
+            ifo_trig_index[ifo] = sorted_ifo_ids
+            data['single'][ifo] = trigs['%s/snr' % ifo][:][sorted_ifo_ids]
 
         # Get sigma for each ifo
+        sigma = {}
         for ifo in ifos:
-            sigma = dict((ifo, list(
-                trigs['%s/sigmasq' % ifo])) for ifo in ifos)
+            sigma[ifo] = trigs['%s/sigmasq' % ifo][:][ifo_trig_index[ifo]]
 
         # Create array for sigma_tot
-        sigma_tot = numpy.zeros(num_trigs)
+        sigma_tot = numpy.zeros(len(data['coherent']))
 
         # Get parameters necessary for antenna responses
         ra = trigs['network/ra'][:]
@@ -105,7 +108,6 @@ def load_data(input_file, vetoes, ifos, opts, injections=False):
             ifo_f_resp = \
                 ppu.get_antenna_responses(antenna, ra,
                                           dec, time)
-
             # Get the average for f_resp_mean and calculate sigma_tot
             data['f_resp_mean'][ifo] = ifo_f_resp.mean()
             sigma_tot += (sigma[ifo] * ifo_f_resp)
@@ -123,7 +125,7 @@ def load_data(input_file, vetoes, ifos, opts, injections=False):
                     data['sigma_max'] = 0
                     data['sigma_min'] = 0
 
-        logging.info("%d triggers found.", num_trigs)
+        logging.info("%d triggers found.", len(data['coherent']))
 
     return data
 
@@ -157,6 +159,7 @@ parser.add_argument("--found-missed-file",
                     help="The hdf injection results file", required=False)
 parser.add_argument("-z", "--zoom-in", default=False, action="store_true",
                     help="Output file a zoomed in version of the plot.")
+ppu.pygrb_add_bestnr_cut_opt(parser)
 opts = parser.parse_args()
 
 init_logging(opts.verbose, format="%(asctime)s: %(levelname)s: %(message)s")
@@ -198,10 +201,10 @@ ifos, vetoes = ppu.extract_ifos_and_vetoes(trig_file, opts.veto_files,
                                            opts.veto_category)
 
 # Extract trigger data
-trig_data = load_data(trig_file, vetoes, ifos, opts)
+trig_data = load_data(trig_file, ifos, vetoes, opts)
 
 # Extract (or initialize) injection data
-inj_data = load_data(found_file, vetoes, ifos, opts, injections=True)
+inj_data = load_data(found_file, ifos, vetoes, opts, injections=True)
 
 # Generate plots
 logging.info("Plotting...")

--- a/bin/pygrb/pycbc_pygrb_plot_injs_results
+++ b/bin/pygrb/pycbc_pygrb_plot_injs_results
@@ -21,11 +21,17 @@
 Plot found/missed injection properties for the triggered search (PyGRB).
 """
 
-import h5py, logging, os.path, argparse, sys
-import numpy as np
+import h5py
+import logging
 import matplotlib.pyplot as plt
 import matplotlib
-import pycbc.pnutils, pycbc.results, pycbc.version
+import numpy as np
+import os.path
+import sys
+
+import pycbc.pnutils
+import pycbc.results
+import pycbc.version
 from pycbc import init_logging
 from pycbc.results import pygrb_postprocessing_utils as ppu
 
@@ -66,7 +72,8 @@ def load_incl_data(input_file_handle, key, tag):
 
     # Requesting |incl| or cos(|incl|)
     if 'abs_' in key:
-        local_dict['abs_incl'] = 0.5*np.pi - abs(local_dict['incl'] - 0.5*np.pi)
+        local_dict['abs_incl'] = 0.5*np.pi - \
+            abs(local_dict['incl'] - 0.5*np.pi)
 
     # Requesting cos(incl) or cos(|incl|): take cosine
     if 'cos_' in key:
@@ -93,7 +100,7 @@ def load_mass_data(input_file_handle, key, tag):
             input_file_handle[tag+'/mass1'][:],
             input_file_handle[tag+'/mass2'][:])
     else:
-        data = input_file_handle[tag+'/mass2'][:]/\
+        data = input_file_handle[tag+'/mass2'][:] / \
                input_file_handle[tag+'/mass1'][:]
         data = np.where(data > 1, 1./data, data)
 
@@ -119,7 +126,7 @@ def load_sky_error_data(input_file_handle, key, tag):
     return data
 
 
-# These are keys in the found-missed-file under 'found' and 'missed' 
+# These are keys in the found-missed-file under 'found' and 'missed'
 # TODO: also in the found-missed injs file is 'inclination'
 easy_keys = ['distance', 'mass1', 'mass2', 'polarization',
              'spin1_a', 'spin1x', 'spin1y', 'spin1z',
@@ -127,6 +134,8 @@ easy_keys = ['distance', 'mass1', 'mass2', 'polarization',
              'spin1_azimuthal', 'spin1_polar',
              'spin2_azimuthal', 'spin2_polar',
              'dec', 'ra', 'phi_ref']
+
+
 # Function to extract desired data from an injection file
 def load_data(input_file_handle, keys, tag):
     """Create a dictionary containing the data specified by the
@@ -141,32 +150,21 @@ def load_data(input_file_handle, keys, tag):
                 data_dict[key] = f[tag][key][:]
             elif key == 'end_time':
                 data_dict[key] = f[tag]['tc'][:]
-                #data_dict[key] -= grb_time
+                # data_dict[key] -= grb_time
             elif key in ['q', 'mchirp', 'mtotal']:
                 data_dict[key] = load_mass_data(input_file_handle, key, tag)
             elif 'incl' in key:
                 data_dict[key] = load_incl_data(input_file_handle, key, tag)
             elif key == 'sky_error':
                 data_dict[key] = load_sky_error_data(input_file_handle, key,
-                                                 tag)
+                                                     tag)
         except KeyError:
-            #raise NotImplemented(key+' not allowed: returning empty entry')
+            # raise NotImplemented(key+' not allowed: returning empty entry')
             logging.info(key+' not allowed yet')
 
     logging.info("{0} {1} injections analysed.".format(len(data_dict[keys[0]]), tag))
 
     return data_dict
-
-
-def load_trig_data(input_file, vetoes):
-    """Load data from a trigger file"""
-
-    logging.info("Loading triggers...")
-    trigs = ppu.load_triggers(input_file, vetoes)
-
-    return trigs
-
-
 
 
 # =============================================================================
@@ -177,9 +175,9 @@ parser = ppu.pygrb_initialize_plot_parser(description=__doc__,
 parser.add_argument("--found-missed-file",
                     help="The hdf injection results file", required=True)
 parser.add_argument("--trig-file",
-                    help="The hdf offsource trigger file", required=True)            
+                    help="The hdf offsource trigger file", required=True)
 parser.add_argument("--trigger-time",
-                    help="The GPS time of the external trigger", required=True)            
+                    help="The GPS time of the external trigger", required=True)
 # FIXME: not all of these work
 # TODO: effective distance
 admitted_vars = easy_keys + ['mtotal', 'q', 'mchirp',
@@ -202,8 +200,8 @@ parser.add_argument("-y", "--y-variable", default=None, required=True,
                     "(Underscores may be omitted in specifying this option).")
 parser.add_argument("--y-log", action="store_true",
                     help="Use log vertical axis")
-parser.add_argument("--colormap",default='cividis_r',
-                   help="Type of colormap to be used for the plots.")
+parser.add_argument("--colormap", default='cividis_r',
+                    help="Type of colormap to be used for the plots.")
 parser.add_argument("--far-type", choices=('inclusive', 'exclusive'),
                     default='inclusive',
                     help="Type of far to plot for the color. Choices are "
@@ -211,6 +209,7 @@ parser.add_argument("--far-type", choices=('inclusive', 'exclusive'),
 parser.add_argument("--missed-on-top", action='store_true',
                     help="Plot missed injections on top of found ones and "
                          "high FAR on top of low FAR")
+ppu.pygrb_add_bestnr_cut_opt(parser)
 opts = parser.parse_args()
 
 init_logging(opts.verbose, format="%(asctime)s: %(levelname)s: %(message)s")
@@ -240,7 +239,9 @@ ifos, vetoes = ppu.extract_ifos_and_vetoes(trig_file, opts.veto_files,
                                            opts.veto_category)
 
 # Load triggers. Time-slides not yet available
-trig_data = load_trig_data(trig_file, vetoes)
+logging.info("Loading triggers...")
+trig_data = ppu.load_triggers(trig_file, ifos, vetoes,
+                              rw_snr_threshold=opts.newsnr_threshold)
 max_reweighted_snr = max(trig_data['network/reweighted_snr'][:])
 
 # =======================
@@ -253,17 +254,20 @@ missed_inj = load_data(f, [x_qty, y_qty], 'missed')
 found_inj = load_data(f, [x_qty, y_qty], 'found')
 
 # Injections found surviving vetoes
-found_after_vetoes = found_inj if 'found_after_vetoes' not in f.keys() else f['found_after_vetoes']
+found_after_vetoes = found_inj if 'found_after_vetoes' not in f.keys() \
+    else f['found_after_vetoes']
 # FIXME: Found but vetoed injections
-#missed_after_vetoes = list(set(found) - set(found_after_vetoes))
-#missed_after_vetoes = np.sort(missed_after_vetoes).astype(int)
+# missed_after_vetoes = list(set(found) - set(found_after_vetoes))
+# missed_after_vetoes = np.sort(missed_after_vetoes).astype(int)
 missed_after_vetoes = {x_qty: np.array([]), y_qty: np.array([])}
 # Injections found but not louder than background
 # are populated further down
 
 # Extract the detection statistic of injections found after vetoes
 if len(list(f['network'].keys())) > 0:
-    found_after_vetoes_stat = f['network/reweighted_snr'][:] if 'found_after_vetoes' not in f.keys() else f['found_after_vetoes/stat'][:]
+    found_after_vetoes_stat = f['network/reweighted_snr'][:] \
+        if 'found_after_vetoes' not in f.keys() else \
+        f['found_after_vetoes/stat'][:]
 
     # Separate triggers into:
     # 1) Found louder than background
@@ -272,15 +276,16 @@ if len(list(f['network'].keys())) > 0:
     for key in found_after_vetoes.keys():
         found_louder[key] = found_after_vetoes[key][louder_mask]
     found_louder['reweighted_snr'] = found_after_vetoes_stat[louder_mask]
-    
+
     # 2) Found quieter than background: injections found (bestnr > 0)
     #    but not louder than background (non-zero FAP)
-    quieter_mask = (found_after_vetoes_stat <= max_reweighted_snr) & (found_after_vetoes_stat != 0)
+    quieter_mask = (found_after_vetoes_stat <= max_reweighted_snr) \
+        & (found_after_vetoes_stat != 0)
     found_quieter = {}
     for key in found_after_vetoes.keys():
         found_quieter[key] = found_after_vetoes[key][quieter_mask]
     found_quieter['reweighted_snr'] = found_after_vetoes_stat[quieter_mask]
-    
+
     # TODO: ifar still missing
     """
     # Extract inclusive/exclusive IFAR for injections found quieter than background
@@ -315,8 +320,8 @@ if found_quieter[x_qty].size:
 # ==========
 
 # Info for site-specific plots
-sitename = {'G1':'GEO', 'H1':'Hanford', 'L1':'Livingston', 'V1':'Virgo',
-            'K1':'KAGRA', 'A1': 'India Aundha'}
+sitename = {'G1': 'GEO', 'H1': 'Hanford', 'L1': 'Livingston', 'V1': 'Virgo',
+            'K1': 'KAGRA', 'A1': 'India Aundha'}
 
 # Take care of axes labels
 axis_labels_dict = {'mchirp': "Chirp Mass (solar masses)",
@@ -361,16 +366,17 @@ ax.set_ylabel(y_label)
 # Define p-value colour
 cmap = plt.get_cmap('cividis_r')
 # Set color for out-of-range values
-#cmap.set_over('g')
+# cmap.set_over('g')
 
 # Define the 'found' injection colour
 fnd_col = cmap(0)
 fnd_col = np.array([fnd_col])
 if not opts.missed_on_top:
     if missed_inj[x_qty].size and missed_inj[y_qty].size:
-        ax.scatter(missed_inj[x_qty], missed_inj[y_qty], c="black", marker="x", s=10)
-    #FIXME: once vetoed is filled in properly
-    #if vetoed[x_qty].size:
+        ax.scatter(missed_inj[x_qty], missed_inj[y_qty],
+                   c="black", marker="x", s=10)
+    # FIXME: once vetoed is filled in properly
+    # if vetoed[x_qty].size:
     if x_qty in vetoed.keys():
         ax.scatter(vetoed[x_qty], vetoed[y_qty], c="red", marker="x", s=10)
     if found_quieter[x_qty].size:
@@ -380,22 +386,25 @@ if not opts.missed_on_top:
                        edgecolor="w", linewidths=2.0)
         cb = plt.colorbar(p, label="p-value")
     if found_louder[x_qty].size:
-        ax.scatter(found_louder[x_qty], found_louder[y_qty], c=fnd_col, marker="+", s=30)
+        ax.scatter(found_louder[x_qty], found_louder[y_qty],
+                   c=fnd_col, marker="+", s=30)
 elif opts.missed_on_top:
     if found_louder[x_qty].size:
-        ax.scatter(found_louder[x_qty], found_louder[y_qty], c=fnd_col, marker="+", s=15)
+        ax.scatter(found_louder[x_qty], found_louder[y_qty],
+                   c=fnd_col, marker="+", s=15)
     if found_quieter[x_qty].size:
         p = ax.scatter(found_quieter[x_qty][MF], found_quieter[y_qty][MF],
                        c=found_quieter['reweighted_snr'][MF],
                        cmap=cmap, vmin=-2, vmax=0, s=40,
                        edgecolor="w", linewidths=2.0)
         cb = plt.colorbar(p, label="p-value")
-    #FIXME: once vetoed is filled in properly
-    #if vetoed[x_qty].size:
+    # FIXME: once vetoed is filled in properly
+    # if vetoed[x_qty].size:
     if x_qty in vetoed.keys():
         ax.scatter(vetoed[x_qty], vetoed[y_qty], c="red", marker="x", s=40)
     if missed_inj[x_qty].size and missed_inj[y_qty].size:
-        ax.scatter(missed_inj[x_qty], missed_inj[y_qty], c="black", marker="x", s=40)
+        ax.scatter(missed_inj[x_qty], missed_inj[y_qty],
+                   c="black", marker="x", s=40)
 ax.grid()
 
 # Handle axis limits when plotting spins
@@ -411,7 +420,8 @@ if "spin" in y_qty and missed_inj['spin2_a'].size:
 # Handle axis limits when plotting inclination
 if "incl" in x_qty or "incl" in y_qty:
     max_inc = np.pi
-    #max_inc = max(np.concatenate((g_found[qty], g_ifar[qty], g_missed2[qty], missed_inj[qty])))
+    # max_inc = max(np.concatenate((g_found[qty], g_ifar[qty], \
+    #                               g_missed2[qty], missed_inj[qty])))
     max_inc_deg = np.rad2deg(max_inc)
     max_inc_deg = np.ceil(max_inc_deg/10.0)*10
     max_inc = np.deg2rad(max_inc_deg)
@@ -423,24 +433,25 @@ if "incl" in x_qty or "incl" in y_qty:
         ax.set_ylim(0, max_inc_deg)
     elif y_qty == "abs_incl":
         ax.set_ylim(0, max_inc_deg*0.5)
-    #if "cos_incl" in [x_qty, y_qty]:
+    # if "cos_incl" in [x_qty, y_qty]:
     if "cos_" in [x_qty, y_qty]:
-        #tt = np.arange(0, max_inc_deg + 10, 10)
-        tt = np.asarray([0, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 180])
+        # tt = np.arange(0, max_inc_deg + 10, 10)
+        tt = np.asarray([0, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120,
+                         130, 140, 150, 180])
         tks = np.cos(np.deg2rad(tt))
         tk_labs = ['cos(%d deg)' % tk for tk in tt]
-        #if x_qty == "cos_incl":
+        # if x_qty == "cos_incl":
         if "cos_" in x_qty:
             plt.xticks(tks, tk_labs, fontsize=10)
             fig.autofmt_xdate()
             ax.set_xlim(np.cos(max_inc), 1)
-            #ax.set_xlim(-1, 1)
-        #if y_qty == "cos_incl":
+            # ax.set_xlim(-1, 1)
+        # if y_qty == "cos_incl":
         if "cos_" in y_qty:
             plt.yticks(tks, tk_labs, fontsize=10)
             fig.autofmt_xdate()
             ax.set_ylim(np.cos(max_inc), 1)
-            #ax.set_ylim(-1, 1)
+            # ax.set_ylim(-1, 1)
 
 # Take care of caption
 plot_caption = opts.plot_caption
@@ -491,7 +502,7 @@ if plot_title is None:
     else:
         plot_title = "Injection recovery with respect to "
         plot_title += title_dict[x_qty]
-        plot_title += " and "+ title_dict[y_qty]
+        plot_title += " and " + title_dict[y_qty]
 
 # Wrap up
 plt.tight_layout()

--- a/bin/pygrb/pycbc_pygrb_plot_null_stats
+++ b/bin/pygrb/pycbc_pygrb_plot_null_stats
@@ -48,7 +48,7 @@ __program__ = "pycbc_pygrb_plot_null_stats"
 # Functions
 # =============================================================================
 # Function to load trigger data
-def load_data(input_file, vetoes, opts, injections=False):
+def load_data(input_file, ifos, vetoes, opts, injections=False):
     """Load data from a trigger/injection file"""
 
     null_stat_type = opts.y_variable
@@ -62,28 +62,30 @@ def load_data(input_file, vetoes, opts, injections=False):
         if injections:
             logging.info("Loading injections...")
             # This will eventually become ppu.load_injections()
-            trigs_or_injs = ppu.load_triggers(input_file, vetoes)
+            trigs_or_injs = \
+                ppu.load_triggers(input_file, ifos, vetoes,
+                                  rw_snr_threshold=opts.newsnr_threshold)
         else:
             logging.info("Loading triggers...")
-            trigs_or_injs = ppu.load_triggers(input_file, vetoes)
-            
-        num_trigs_or_injs = len(trigs_or_injs['network/end_time_gc'][:])
+            trigs_or_injs = \
+                ppu.load_triggers(input_file, ifos, vetoes,
+                                  rw_snr_threshold=opts.newsnr_threshold)
 
         # Coherent SNR is always used
-        data['coherent'] = trigs_or_injs['network/coherent_snr'][:]
+        data['coherent'] = trigs_or_injs['network/coherent_snr']
 
+        # The other SNR may vary
         if null_stat_type == 'null':
-            data[null_stat_type] = trigs_or_injs['network/%s_snr' % null_stat_type][:]
+            data[null_stat_type] = \
+                trigs_or_injs['network/%s_snr' % null_stat_type][:]
         elif null_stat_type == 'single':
-            key = opts.ifo + '/snr_' + opts.ifo.lower()
-            # TODO: Undoes current L710 in EventManagerCoherent.write_to_hdf
-            # and is ugly hardcoded!
-            if opts.ifo.lower() != 'h1':
-                key = key[:-1]
+            key = opts.ifo + '/snr'
             data[null_stat_type] = trigs_or_injs[key][:]
         elif null_stat_type == 'coincident':
             data[null_stat_type] = ppu.get_coinc_snr(trigs_or_injs)
 
+        # Count surviving points
+        num_trigs_or_injs = len(trigs_or_injs['network/reweighted_snr'])
         if injections:
             logging.info("%d injections found.", num_trigs_or_injs)
         else:
@@ -140,7 +142,7 @@ parser.add_argument("-z", "--zoom-in", default=False, action="store_true",
 parser.add_argument("-y", "--y-variable", default=None,
                     choices=['coincident', 'null'], #TODO: overwhitened?
                     help="Quantity to plot on the vertical axis.")
-ppu.pygrb_add_bestnr_opts(parser)
+ppu.pygrb_add_null_snr_opts(parser)
 ppu.pygrb_add_bestnr_cut_opt(parser)
 opts = parser.parse_args()
 
@@ -181,14 +183,14 @@ if not os.path.isdir(outdir):
     os.makedirs(outdir)
 
 # Extract IFOs and vetoes
-_, vetoes = ppu.extract_ifos_and_vetoes(trig_file, opts.veto_files,
+ifos, vetoes = ppu.extract_ifos_and_vetoes(trig_file, opts.veto_files,
                                         opts.veto_category)
 
 # Extract trigger data
-trig_data = load_data(trig_file, vetoes, opts)
+trig_data = load_data(trig_file, ifos, vetoes, opts)
 
 # Extract (or initialize) injection data
-inj_data = load_data(found_missed_file, vetoes, opts, injections=True)
+inj_data = load_data(found_missed_file, ifos, vetoes, opts, injections=True)
 
 # Generate plots
 logging.info("Plotting...")

--- a/bin/pygrb/pycbc_pygrb_plot_null_stats
+++ b/bin/pygrb/pycbc_pygrb_plot_null_stats
@@ -141,6 +141,7 @@ parser.add_argument("-y", "--y-variable", default=None,
                     choices=['coincident', 'null'], #TODO: overwhitened?
                     help="Quantity to plot on the vertical axis.")
 ppu.pygrb_add_bestnr_opts(parser)
+ppu.pygrb_add_bestnr_cut_opt(parser)
 opts = parser.parse_args()
 
 init_logging(opts.verbose, format="%(asctime)s: %(levelname)s: %(message)s")

--- a/bin/pygrb/pycbc_pygrb_plot_skygrid
+++ b/bin/pygrb/pycbc_pygrb_plot_skygrid
@@ -46,12 +46,12 @@ __program__ = "pycbc_pygrb_plot_skygrid"
 # Functions
 # =============================================================================
 # Load trigger data
-def load_data(input_file, vetoes, injections=False):
+def load_data(input_file, ifos, vetoes, injections=False):
     """Load data from a trigger/injection file"""
     
     logging.info("Loading triggers...")
     
-    trigs = ppu.load_triggers(input_file, vetoes)
+    trigs = ppu.load_triggers(input_file, ifos, vetoes)
         
     return trigs
 
@@ -85,7 +85,7 @@ ifos, vetoes = ppu.extract_ifos_and_vetoes(trig_file, opts.veto_files,
                                            opts.veto_category)
 
 # Load trigger data
-trig_data = load_data(trig_file, vetoes)
+trig_data = load_data(trig_file, ifos, vetoes)
 
 #
 # Generate sky grid plot

--- a/bin/pygrb/pycbc_pygrb_plot_snr_timeseries
+++ b/bin/pygrb/pycbc_pygrb_plot_snr_timeseries
@@ -28,7 +28,6 @@ import sys
 import os
 import logging
 import numpy
-import h5py
 import matplotlib.pyplot as plt
 from matplotlib import rc
 import pycbc.version
@@ -50,19 +49,24 @@ __program__ = "pycbc_pygrb_plot_snr_timeseries"
 # Functions
 # =============================================================================
 # Load trigger data
-def load_data(input_file, vetoes, injections=False):
+def load_data(input_file, ifos, vetoes, rw_snr_threshold=None,
+              injections=False):
     """Load data from a trigger/injection file"""
-    
+
     trigs_or_injs = None
     if input_file:
         if injections:
             logging.info("Loading injections...")
             # This will eventually become load_injections
-            trigs_or_injs = ppu.load_triggers(input_file, vetoes)
+            trigs_or_injs = \
+                ppu.load_triggers(input_file, ifos, vetoes,
+                                  rw_snr_threshold=rw_snr_threshold)
         else:
             logging.info("Loading triggers...")
-            trigs_or_injs = ppu.load_triggers(input_file, vetoes)
-        
+            trigs_or_injs = \
+                ppu.load_triggers(input_file, ifos, vetoes,
+                                  rw_snr_threshold=rw_snr_threshold)
+
     return trigs_or_injs
 
 
@@ -81,27 +85,11 @@ def get_start_end_times(data_time, central_time):
 
 # Reset times so that t=0 is corresponds to the given trigger time
 def reset_times(data_time, trig_time):
-    """Reset times in data so that t=0 corresponds to the trigger time provided"""
+    """Reset times so that t=0 corresponds to the trigger time provided"""
 
-    #data.time = [t-trig_time for t in data.time]
     data_time = [t-trig_time for t in data_time]
 
     return data_time
-
-# Apply reweighted SNR cut: when plotting reweighted SNR, keep all points to
-# show the impact of the cut, otherwise remove points with reweighted SNR
-# below threshold
-def prune_data(rw_snr, time_in, snr_in, opts, snr_type):
-    """Prune data from points with reweighted SNR below threshold"""
-
-    rw_snr = reweightedsnr_cut(rw_snr, opts.newsnr_threshold)
-    if snr_type == 'reweighted':
-        return time_in, rw_snr
-    mask = rw_snr == 0
-    time_out = numpy.ma.masked_array(time_in, mask=mask)
-    snr_out = numpy.ma.masked_array(snr_in, mask=mask)
-
-    return time_out, snr_out
 
 
 # =============================================================================
@@ -126,7 +114,8 @@ init_logging(opts.verbose, format="%(asctime)s: %(levelname)s: %(message)s")
 
 # Check options
 trig_file = os.path.abspath(opts.trig_file)
-inj_file = os.path.abspath(opts.found_missed_file) if opts.found_missed_file else None
+inj_file = \
+    os.path.abspath(opts.found_missed_file) if opts.found_missed_file else None
 snr_type = opts.y_variable
 ifo = opts.ifo
 if snr_type == 'single' and ifo is None:
@@ -142,13 +131,27 @@ if not os.path.isdir(outdir):
 
 # Extract IFOs and vetoes
 ifos, vetoes = ppu.extract_ifos_and_vetoes(trig_file, opts.veto_files,
-                                        opts.veto_category)
+                                           opts.veto_category)
 
-# Load trigger data
-trig_data = load_data(trig_file, vetoes)
-
-# Load (or initialize) injection data
-inj_data = load_data(inj_file, vetoes, injections=True)
+# Load trigger and injections data: when plotting reweighted SNR, keep all
+# points to show the impact of the cut, otherwise remove points with
+# reweighted SNR below threshold
+if snr_type == 'reweighted':
+    trig_data = load_data(trig_file, ifos, vetoes)
+    trig_data['network/reweighted_snr'] = \
+        reweightedsnr_cut(trig_data['network/reweighted_snr'],
+                          opts.newsnr_threshold)
+    inj_data = load_data(inj_file, ifos, vetoes, injections=True)
+    if inj_data is not None:
+        inj_data['network/reweighted_snr'] = \
+            reweightedsnr_cut(inj_data['network/reweighted_snr'],
+                              opts.newsnr_threshold)
+else:
+    trig_data = load_data(trig_file, ifos, vetoes,
+                          rw_snr_threshold=opts.newsnr_threshold)
+    inj_data = load_data(inj_file, ifos, vetoes,
+                         rw_snr_threshold=opts.newsnr_threshold,
+                         injections=True)
 
 # Specify HDF file keys for x quantity (time) and y quantity (SNR)
 if snr_type == 'single':
@@ -176,15 +179,6 @@ start, end = get_start_end_times(trig_data_time, central_time)
 trig_data_time = reset_times(trig_data_time, central_time)
 if inj_file:
     inj_data_time = reset_times(inj_data_time, central_time)
-
-# Obtain rewighted SNRs and apply reweighted SNR cut
-trig_rw_snr = trig_data['network/reweighted_snr'][:]
-inj_rw_snr = inj_data['network/reweighted_snr'][:] if inj_file else None
-trig_data_time, trig_data_snr = \
-    prune_data(trig_rw_snr, trig_data_time, trig_data_snr, opts, snr_type)
-if inj_file:
-    inj_data_time, inj_data_snr = \
-        prune_data(inj_rw_snr, inj_data_time, inj_data_snr, opts, snr_type)
 
 # Generate plots
 logging.info("Plotting...")

--- a/bin/pygrb/pycbc_pygrb_plot_snr_timeseries
+++ b/bin/pygrb/pycbc_pygrb_plot_snr_timeseries
@@ -33,6 +33,7 @@ import matplotlib.pyplot as plt
 from matplotlib import rc
 import pycbc.version
 from pycbc import init_logging
+from pycbc.events.coherent import reweightedsnr_cut
 from pycbc.results import pygrb_postprocessing_utils as ppu
 from pycbc.results import pygrb_plotting_utils as plu
 
@@ -87,6 +88,21 @@ def reset_times(data_time, trig_time):
 
     return data_time
 
+# Apply reweighted SNR cut: when plotting reweighted SNR, keep all points to
+# show the impact of the cut, otherwise remove points with reweighted SNR
+# below threshold
+def prune_data(rw_snr, time_in, snr_in, opts, snr_type):
+    """Prune data from points with reweighted SNR below threshold"""
+
+    rw_snr = reweightedsnr_cut(rw_snr, opts.newsnr_threshold)
+    if snr_type == 'reweighted':
+        return time_in, rw_snr
+    mask = rw_snr == 0
+    time_out = numpy.ma.masked_array(time_in, mask=mask)
+    snr_out = numpy.ma.masked_array(snr_in, mask=mask)
+
+    return time_out, snr_out
+
 
 # =============================================================================
 # Main script starts here
@@ -103,7 +119,7 @@ parser.add_argument("--trigger-time", type=float, default=0,
 parser.add_argument("-y", "--y-variable", default=None,
                     choices=['coherent', 'single', 'reweighted', 'null'],
                     help="Quantity to plot on the vertical axis.")
-ppu.pygrb_add_bestnr_opts(parser)
+ppu.pygrb_add_bestnr_cut_opt(parser)
 opts = parser.parse_args()
 
 init_logging(opts.verbose, format="%(asctime)s: %(levelname)s: %(message)s")
@@ -160,6 +176,15 @@ start, end = get_start_end_times(trig_data_time, central_time)
 trig_data_time = reset_times(trig_data_time, central_time)
 if inj_file:
     inj_data_time = reset_times(inj_data_time, central_time)
+
+# Obtain rewighted SNRs and apply reweighted SNR cut
+trig_rw_snr = trig_data['network/reweighted_snr'][:]
+inj_rw_snr = inj_data['network/reweighted_snr'][:] if inj_file else None
+trig_data_time, trig_data_snr = \
+    prune_data(trig_rw_snr, trig_data_time, trig_data_snr, opts, snr_type)
+if inj_file:
+    inj_data_time, inj_data_snr = \
+        prune_data(inj_rw_snr, inj_data_time, inj_data_snr, opts, snr_type)
 
 # Generate plots
 logging.info("Plotting...")

--- a/bin/pygrb/pycbc_pygrb_plot_stats_distribution
+++ b/bin/pygrb/pycbc_pygrb_plot_stats_distribution
@@ -54,6 +54,7 @@ parser.add_argument("-F", "--trig-file", action="store", required=True,
 parser.add_argument("-x", "--x-variable", required=True,
                     choices=["bestnr", "snr", "snruncut"],
                     help="Quantity to plot on the horizontal axis.")
+ppu.pygrb_add_bestnr_cut_opt(parser)
 opts = parser.parse_args()
 
 init_logging(opts.verbose, format="%(asctime)s: %(levelname)s: %(message)s")
@@ -74,8 +75,9 @@ ifos, vetoes = ppu.extract_ifos_and_vetoes(trig_file, opts.veto_files,
 
 # Load triggers, time-slides, and segment dictionary
 logging.info("Loading triggers.")
-trigs = ppu.load_triggers(trig_file, vetoes)
-logging.info("%d triggers loaded.", trigs['network/event_id'].len())
+trigs = ppu.load_triggers(trig_file, ifos, vetoes,
+                          rw_snr_threshold=opts.newsnr_threshold)
+logging.info("%d triggers loaded.", len(trigs['network/event_id']))
 logging.info("Loading timeslides.")
 slide_dict = ppu.load_time_slides(trig_file)
 logging.info("Loading segments.")

--- a/pycbc/results/pygrb_postprocessing_utils.py
+++ b/pycbc/results/pygrb_postprocessing_utils.py
@@ -152,13 +152,22 @@ def pygrb_add_bestnr_opts(parser):
                         "increase above the threshold")
 
 
+def pygrb_add_bestnr_cut_opt(parser):
+    """Add to the parser object an argument to place a threshold on BestNR."""
+    if parser is None:
+        parser = argparse.ArgumentParser()
+    parser.add_argument("--newsnr-threshold", type=float, metavar='THRESHOLD',
+                        default=6.0,
+                        help="Cut triggers with NewSNR less than THRESHOLD")
+
+
 # =============================================================================
 # Wrapper to read segments files
 # =============================================================================
 def _read_seg_files(seg_files):
     """Read segments txt files"""
 
-    if len(seg_files) != 3:
+    if len(seg_files) != 3 or seg_files is None:
         err_msg = "The location of three segment files is necessary."
         err_msg += "[bufferSeg.txt, offSourceSeg.txt, onSourceSeg.txt]"
         raise RuntimeError(err_msg)

--- a/pycbc/results/pygrb_postprocessing_utils.py
+++ b/pycbc/results/pygrb_postprocessing_utils.py
@@ -126,8 +126,7 @@ def pygrb_add_injmc_opts(parser):
 
 
 def pygrb_add_bestnr_opts(parser):
-    """Add to the parser object the arguments used for BestNR calculation,
-    null SNR, single SNR cut and null SNR cut."""
+    """Add to the parser object the arguments used for BestNR calculation"""
     if parser is None:
         parser = argparse.ArgumentParser()
     parser.add_argument("-Q", "--chisq-index", action="store", type=float,
@@ -136,10 +135,11 @@ def pygrb_add_bestnr_opts(parser):
     parser.add_argument("-N", "--chisq-nhigh", action="store", type=float,
                         default=2.0, help="chisq_nhigh for newSNR " +
                         "calculation (default: 2")
-    parser.add_argument("-B", "--sngl-snr-threshold", action="store",
-                        type=float, default=4.0, help="Single detector SNR " +
-                        "threshold, the two most sensitive detectors " +
-                        "should have SNR above this.")
+
+
+def pygrb_add_null_snr_opts(parser):
+    """Add to the parser object the arguments used for null SNR calculation
+    and null SNR cut."""
     parser.add_argument("-A", "--null-snr-threshold", action="store",
                         default="3.5,5.25",
                         help="Comma separated lower,higher null SNR " +
@@ -150,6 +150,15 @@ def pygrb_add_bestnr_opts(parser):
     parser.add_argument("-D", "--null-grad-val", action="store", type=float,
                         default=0.2, help="Rate the null SNR cut will " +
                         "increase above the threshold")
+
+
+def pygrb_add_single_snr_cut_opt(parser):
+    """Add to the parser object an argument to place a threshold on single
+    detector SNR."""
+    parser.add_argument("-B", "--sngl-snr-threshold", action="store",
+                        type=float, default=4.0, help="Single detector SNR " +
+                        "threshold, the two most sensitive detectors " +
+                        "should have SNR above this.")
 
 
 def pygrb_add_bestnr_cut_opt(parser):

--- a/pycbc/results/pygrb_postprocessing_utils.py
+++ b/pycbc/results/pygrb_postprocessing_utils.py
@@ -398,7 +398,8 @@ def load_triggers(input_file, ifos, vetoes, rw_snr_threshold=None):
             elif path[:2] in ifos:
                 ifo = path[:2]
                 if ifo_ids_above_thresh_locations[ifo].size != 0:
-                    trigs_dict[path] = dset[:][ifo_ids_above_thresh_locations[ifo]]
+                    trigs_dict[path] = \
+                        dset[:][ifo_ids_above_thresh_locations[ifo]]
                 else:
                     trigs_dict[path] = numpy.array([])
             # The dataset is relative to the network: cut it before copying


### PR DESCRIPTION
## Standard information about the request

This is a new feature in the PyGRB post-processing which enables and applies the cut in reweighted SNR, something that `pycbc_multi_inspiral` does not apply, preserving all reweighted SNR information until the end of the filtering stage.

This change affects: PyGRB, post-processing only.

This change changes: result presentation / plotting, scientific output

## Motivation
The option to cut in reweighted SNR existed but was never used.

## Contents
* General options to define null SNR, reweighted SNR, and SNR cuts are placed in separate "add_to_parser" methods.
* Codes using those options call the specific "add_to_parser" methods they need.
* The cut in reweighted SNR was implemented.  HDF input is parsed and the reweighted SNR is used to determine what information to keep.  This does not assume that network and IFO datasets are ordered identically, so it looks through the `event_id` datasets of the IFO groups to perform the cut correctly.
* All scripts needed to perform the cut do so now, and have undergone some minor cleanup.

## Testing performed
This change was tested by producing [this results webpage](https://ldas-jobs.ligo.caltech.edu/~francesco.pannarale/LVC/pygrb_may2024_test5/)

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
