### PR TITLE
add str() to all tdi

### DIFF
--- a/pycbc/psd/analytical_space.py
+++ b/pycbc/psd/analytical_space.py
@@ -1612,7 +1612,7 @@ def sh_transformed_psd_lisa_tdi_XYZ(length, delta_f, low_freq_cutoff,
         Please see Eq.(7,41-43) in <LISA-LCST-SGS-TN-001> for more details.
     """
     fr = np.linspace(low_freq_cutoff, (length-1)*2*delta_f, length)
-    if tdi in ["1.5", "2.0"]:
+    if str(tdi) in ["1.5", "2.0"]:
         response = averaged_response_lisa_tdi(fr, len_arm, tdi)
     else:
         raise ValueError("The version of TDI, currently only for 1.5 or 2.0.")
@@ -1657,7 +1657,7 @@ def semi_analytical_psd_lisa_confusion_noise(length, delta_f, low_freq_cutoff,
         noise, no instrumental noise.
     """
     fr = np.linspace(low_freq_cutoff, (length-1)*2*delta_f, length)
-    if tdi in ["1.5", "2.0"]:
+    if str(tdi) in ["1.5", "2.0"]:
         response = averaged_response_lisa_tdi(fr, len_arm, tdi)
     else:
         raise ValueError("The version of TDI, currently only for 1.5 or 2.0.")
@@ -1701,7 +1701,7 @@ def analytical_psd_tianqin_confusion_noise(length, delta_f, low_freq_cutoff,
         noise, no instrumental noise.
     """
     fr = np.linspace(low_freq_cutoff, (length-1)*2*delta_f, length)
-    if tdi in ["1.5", "2.0"]:
+    if str(tdi) in ["1.5", "2.0"]:
         response = averaged_response_tianqin_tdi(fr, len_arm, tdi)
     else:
         raise ValueError("The version of TDI, currently only for 1.5 or 2.0.")
@@ -1745,7 +1745,7 @@ def analytical_psd_taiji_confusion_noise(length, delta_f, low_freq_cutoff,
         noise, no instrumental noise.
     """
     fr = np.linspace(low_freq_cutoff, (length-1)*2*delta_f, length)
-    if tdi in ["1.5", "2.0"]:
+    if str(tdi) in ["1.5", "2.0"]:
         response = averaged_response_taiji_tdi(fr, len_arm, tdi)
     else:
         raise ValueError("The version of TDI, currently only for 1.5 or 2.0.")

--- a/test/test_coordinates_space.py
+++ b/test/test_coordinates_space.py
@@ -227,6 +227,7 @@ class TestParams(unittest.TestCase):
             # set parameters
             params = {}
             YRSID_SI = 31558149.763545603
+            params['tdi'] = '1.5'
             params['ref_frame'] = 'SSB'
             params['approximant'] = 'BBHX_PhenomD'
             params['base_approximant'] = 'BBHX_PhenomD'


### PR DESCRIPTION
<!---
Please delete these comments when you submit the pull request

Please add a title which is a concise description of what you are doing,
e.g. 'Fix bug with numpy import in pycbc_coinc_findtrigs' or 'add high frequency sky location dependent response for long detectors'
-->

<!---
This is a brief template for making pull requests for PyCBC.
This is _not_ a proscriptive template - you can use a different style if you want.
Please do think about the questions posed here and whether the details will be useful to include in your PR
Please add sufficient details so that people looking back at the request with no context around the work can understand the changes.
To choose reviewers, please look at the git blame for the code you are changing (if applicable),
or discuss in the #pycbc-code channel of the gwastro slack.
Please add labels as appropriate
-->

<!-- TOP-LEVEL SUMMARY: Please provide a brief, one-or-two-sentence description of the PR here
-->

Force `tdi` to be `str` just like other places in the code. Otherwise, PyCBC Inference will read it as a number. that will cause error.

<!--- Some basic info about the change (delete as appropriate) -->
This is a: bug fix

<!--- What codes will this affect? (delete as apropriate)
If you do not know which areas will be affected, please ask in the gwastro #pycbc-code slack
-->
This change affects: inference

## Motivation
<!--- Describe why your changes are being made -->
Fix issues encountered in PE.

## Contents
<!--- Describe your changes, this doesn't need to be a line-by-line code change discussion,
but rather a general discussion of the methods chosen -->
Adding `strt()` to all `tdi` input.

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
