### PR TITLE
Add decimation to sngls_findtrigs

### DIFF
--- a/bin/all_sky_search/pycbc_sngls_findtrigs
+++ b/bin/all_sky_search/pycbc_sngls_findtrigs
@@ -205,7 +205,6 @@ for i, tnum in enumerate(template_ids):
     stat_all += list(stat_t)
 
 # Perform decimation
-
 dec_facs = np.ones_like(template_ids_all)
 stat_all = np.array(stat_all)
 template_ids_all = np.array(template_ids_all)
@@ -216,16 +215,13 @@ logging.info("%d events", dec_facs.size)
 for t, f in zip(threshes, factors):
     # Find the events with statistic above the threshold - these will be kept:
     abovethresh = stat_all >= t
-    # Any events below threshold, multiply total decimation factor by the
-    # current factor
+    # Any events below threshold, change decimation factor to the current one
     belowthresh = np.logical_not(abovethresh)
     dec_facs[belowthresh] = f
 
     # Also keep events with trigger id as an integer multiple of the factor
     # Work out which events would be kept whatever happens
     factor_idx = trigger_ids_all % f == 0
-    # Find the events which are below this threshold
-    kept_decimated = np.logical_and(factor_idx, belowthresh)
     # Keep events which are above threshold or a trigger_id multiple of
     # the factor
     keep = np.logical_or(abovethresh, factor_idx)

--- a/bin/all_sky_search/pycbc_sngls_findtrigs
+++ b/bin/all_sky_search/pycbc_sngls_findtrigs
@@ -214,18 +214,21 @@ trigger_times_all = np.array(trigger_times_all)
 
 logging.info("%d events", dec_facs.size)
 for t, f in zip(threshes, factors):
-    # Keep events with trigger id as a multiple of the factor
+    # Find the events with statistic above the threshold - these will be kept:
+    abovethresh = stat_all >= t
+    # Any events below threshold, multiply total decimation factor by the
+    # current factor
+    belowthresh = np.logical_not(abovethresh)
+    dec_facs[belowthresh] = f
+
+    # Also keep events with trigger id as an integer multiple of the factor
     # Work out which events would be kept whatever happens
     factor_idx = trigger_ids_all % f == 0
-    # If the events are below the threshold, but being kept, multiply the
-    # decimation factor
     # Find the events which are below this threshold
-    belowthresh_idx = stat_all < t
-    kept_decimated = np.logical_and(factor_idx, belowthresh_idx)
-    dec_facs[kept_decimated] *= int(f)
+    kept_decimated = np.logical_and(factor_idx, belowthresh)
     # Keep events which are above threshold or a trigger_id multiple of
     # the factor
-    keep = np.logical_or(stat_all >= t, factor_idx)
+    keep = np.logical_or(abovethresh, factor_idx)
     # Do the cuts:
     dec_facs = dec_facs[keep]
     stat_all = stat_all[keep]

--- a/bin/all_sky_search/pycbc_sngls_findtrigs
+++ b/bin/all_sky_search/pycbc_sngls_findtrigs
@@ -45,6 +45,16 @@ parser.add_argument('--cluster-window', type=float,
                          'Default=do not cluster')
 parser.add_argument("--output-file",
                     help="File to store the candidate triggers")
+parser.add_argument("--loudest-keep-values",
+                    default='[6:1]',
+                    help="Apply successive multiplicative levels of"
+                         " decimation to coincs with stat value below the"
+                         " given thresholds. Supply as a comma-separated list"
+                         " of threshold:decimation value pairs surrounded by"
+                         " square brackets (no spaces!). Decimation values must"
+                         " be positive integers."
+                         " Ex. [15:5,10:30,5:30,0:30]."
+                         " Default: no decimation")
 stat.insert_statistic_option_group(parser)
 cuts.insert_cuts_option_group(parser)
 args = parser.parse_args()
@@ -118,8 +128,9 @@ template_ids = cuts.apply_template_cuts(
 logging.info("%d out of %d templates kept after applying template cuts",
              len(template_ids), original_bank_len)
 
-logging.info('Clustering events over %s s window within each template',
-             args.cluster_window)
+if args.cluster_window is not None:
+  logging.info('Clustering events over %s s window within each template',
+               args.cluster_window)
 
 extra_kwargs = {}
 for inputstr in args.statistic_keywords:
@@ -132,8 +143,36 @@ for inputstr in args.statistic_keywords:
                   "Received {}".format(args.statistic_keywords)
         raise ValueError(err_txt)
 
+loudest_keep_vals = args.loudest_keep_values.strip('[]').split(',')
 
-for tnum in template_ids:
+threshes = []
+factors = []
+tot_fac = 1
+for decstr in loudest_keep_vals:
+    thresh, factor = decstr.split(':')
+    if float(factor) % 1:
+        raise RuntimeError("Non-integer decimation is not supported")
+    if int(factor) < 1:
+        raise RuntimeError("Negative or zero decimation does not make sense")
+    if int(factor) == 1:
+        continue
+    tot_fac *= float(factor)
+    threshes.append(float(thresh))
+    factors.append(tot_fac)
+
+# Sort the threshes into descending order
+# - allows decimation factors to be given in any order
+threshorder = np.argsort(threshes)[::-1]
+threshes = np.array(threshes)[threshorder]
+factors = np.array(factors)[threshorder]
+
+
+for i, tnum in enumerate(template_ids):
+    if i % 1000 == 0:
+        logging.info(
+            "Calculating statistic in template %d out of %d",
+            i, len(template_ids),
+        )
     tids_uncut = trigs.set_template(tnum)
 
     trigger_keep_ids = cuts.apply_trigger_cuts(trigs, trigger_cut_dict,
@@ -145,14 +184,15 @@ for tnum in template_ids:
                       len(tids_uncut) - len(tids_full))
 
     n_tot_trigs = tids_full.size
-    if not n_tot_trigs: continue
+    if n_tot_trigs == 0:
+        continue
 
     # Stat class instance to calculate the ranking statistic
     sds = rank_method.single(trigs)[trigger_keep_ids]
     stat_t = rank_method.rank_stat_single((ifo, sds),
                                           **extra_kwargs)
     trigger_times = sds['end_time']
-    if args.cluster_window:
+    if args.cluster_window is not None:
         cid = coinc.cluster_over_time(stat_t, trigger_times,
                                       args.cluster_window)
         stat_t = stat_t[cid]
@@ -164,8 +204,44 @@ for tnum in template_ids:
     trigger_times_all += list(trigger_times)
     stat_all += list(stat_t)
 
+# Perform decimation
+
+dec_facs = np.ones_like(template_ids_all)
+stat_all = np.array(stat_all)
+template_ids_all = np.array(template_ids_all)
+trigger_ids_all = np.array(trigger_ids_all)
+trigger_times_all = np.array(trigger_times_all)
+
+logging.info("%d events", dec_facs.size)
+for t, f in zip(threshes, factors):
+    # Keep events with trigger id as a multiple of the factor
+    # Work out which events would be kept whatever happens
+    factor_idx = trigger_ids_all % f == 0
+    # If the events are below the threshold, but being kept, multiply the
+    # decimation factor
+    # Find the events which are below this threshold
+    belowthresh_idx = stat_all < t
+    kept_decimated = np.logical_and(factor_idx, belowthresh_idx)
+    dec_facs[kept_decimated] *= int(f)
+    # Keep events which are above threshold or a trigger_id multiple of
+    # the factor
+    keep = np.logical_or(stat_all >= t, factor_idx)
+    # Do the cuts:
+    dec_facs = dec_facs[keep]
+    stat_all = stat_all[keep]
+    template_ids_all = template_ids_all[keep]
+    trigger_ids_all = trigger_ids_all[keep]
+    trigger_times_all = trigger_times_all[keep]
+
+    logging.info(
+        "%d events after decimation at statistic %.3f with factor %d",
+        dec_facs.size,
+        t,
+        f
+    )
+
 data = {"stat": stat_all,
-        "decimation_factor": np.ones_like(stat_all),
+        "decimation_factor": dec_facs,
         "timeslide_id": np.zeros_like(stat_all),
         "template_id": template_ids_all,
         "%s/time" % ifo : trigger_times_all,

--- a/bin/all_sky_search/pycbc_sngls_statmap
+++ b/bin/all_sky_search/pycbc_sngls_statmap
@@ -341,11 +341,12 @@ while numpy.any(ifar_louder > hier_ifar_thresh_s):
 
     logging.info("Calculating FAN from background statistic values")
     back_stat = fore_stat = all_trigs.stat
+    bkg_dec_facs = all_trigs.decimation_factor
 
     bg_far, fg_far = significance.get_far(
         back_stat,
         fore_stat,
-        numpy.ones_like(back_stat),
+        bkg_dec_facs,
         fg_time,
         **significance_dict[ifo])
 
@@ -375,7 +376,7 @@ while numpy.any(ifar_louder > hier_ifar_thresh_s):
         _, fg_far_exc = significance.get_far(
             back_stat_exc,
             fore_stat,
-            numpy.ones_like(back_stat_exc),
+            bkg_exc_dec_facs,
             fg_time_exc,
             **significance_dict[ifo])
 

--- a/pycbc/events/significance.py
+++ b/pycbc/events/significance.py
@@ -153,8 +153,11 @@ def n_louder_from_fit(back_stat, fore_stat, dec_facs,
 
     # Count the number of below-threshold background events louder than the
     # bg and foreground
-    bg_n_louder[bg_below], fg_n_louder[fg_below] = \
-        count_n_louder(back_stat[bg_below], fore_stat[fg_below], dec_facs[bg_below])
+    bg_n_louder[bg_below], fg_n_louder[fg_below] = count_n_louder(
+        back_stat[bg_below],
+        fore_stat[fg_below],
+        dec_facs[bg_below]
+    )
 
     # As we have only counted the louder below-threshold events, need to
     # add the above threshold events, which by definition are louder than

--- a/pycbc/events/significance.py
+++ b/pycbc/events/significance.py
@@ -57,8 +57,8 @@ def count_n_louder(bstat, fstat, dec,
         The number of background triggers above each foreground trigger
     """
     sort = bstat.argsort()
-    bstat = bstat[sort]
-    dec = dec[sort]
+    bstat = copy.deepcopy(bstat)[sort]
+    dec = copy.deepcopy(dec)[sort]
 
     # calculate cumulative number of triggers louder than the trigger in
     # a given index. We need to subtract the decimation factor, as the cumsum
@@ -154,7 +154,7 @@ def n_louder_from_fit(back_stat, fore_stat, dec_facs,
     # Count the number of below-threshold background events louder than the
     # bg and foreground
     bg_n_louder[bg_below], fg_n_louder[fg_below] = \
-        count_n_louder(back_stat[bg_below], fore_stat[fg_below], dec_facs)
+        count_n_louder(back_stat[bg_below], fore_stat[fg_below], dec_facs[bg_below])
 
     # As we have only counted the louder below-threshold events, need to
     # add the above threshold events, which by definition are louder than


### PR DESCRIPTION
This change adds decimation into the `pycbc_sngls_findtrigs` code

## Standard information about the request

This is a new feature/efficiency change
This change affects the offline search
This changes result presentation / plotting, and has slight effects on scientific output (these should be negligible)
This change follows style guidelines and has been proposed using the contribution guidelines

## Motivation
We saw that the sngls_statmap job was using a lot of memory - part of this was as the sngls_findtrigs jobs were saving _everything_, even when the events had no chance of being real, or included in the significance fitting.

## Contents
Events are decimated below certain thresholds in the sngls_findtrigs code. This is done by using successive factors and statistic thresholds, and only keeping events with statistic below the threshold if the `trigger_id` is an integer multiple of the factor (multiplied by any previous factors).

This is the same as is done in the coinc jobs except that it is the `trigger_id` which is used to decide on decimation rather than the `timeslide_id`. I don't think this will add any bias.

## Links to any issues or associated PRs
A hotfix was applied to the v23 release branch in https://github.com/gwastro/pycbc/pull/4732

This solution is a bit nicer than the one in #4732 - basically this allows us to still see the diustribution to lower statistic values when plotting, which enables us to tweak the significance fit threshold

## Testing performed
The sngls_findtrigs from an O4 chunk were calculated, and then the statmap job was run, the pycbc_page_snrifar for these is here (LVK paywall):
[decimated](https://ldas-jobs.ligo.caltech.edu/~gareth.cabourndavies/testoutput/sngls_statmap_efficiency/testing/output/H1-SNGLS_STATMAP_decimated.png) vs [original](https://ldas-jobs.ligo.caltech.edu/~gareth.cabourndavies/testoutput/sngls_statmap_efficiency/testing/output/H1-SNGLS_STATMAP.png)

Decimation levels for this test are `[0:10,-2.5:10,-5:10,-10:10,-20:999999]`

We see that the behaviour above stat around -2.5 is the same, but we get extra (once we account for decimation) events below this.

I think the 'extra' events are due to not being clustered away post-decimation, which means that we actually see the distribution to lower statistic values!

We also used a fit threshold of -1.2 in the statmap code, so we see that the significance fitting works even when the fit threshold is below the decimation thresholds

## Additional notes
We also fix a bug in the significance module:
 - things below the threshold were not using the correct decimation for the count_n_louder switch - this has been fixed
 - This was not seen before as in all use-cases, the decimation was the same (1) for every event, so grabbing the wrong decimation value had no effect

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
