### PR TITLE
Fixing null cut in pycbc_multi_inspiral

### DIFF
--- a/bin/pygrb/pycbc_pygrb_plot_null_stats
+++ b/bin/pygrb/pycbc_pygrb_plot_null_stats
@@ -111,10 +111,7 @@ def calculate_contours(opts, new_snrs=None):
 
     # Determine contour
     null_cont = []
-    null_thresh = []
-    for val in map(float, opts.null_snr_threshold.split(',')):
-        null_thresh.append(val)
-    null_thresh = null_thresh[-1]
+    null_thresh = opts.null_snr_threshold
     null_grad_snr = opts.null_grad_thresh
     null_grad_val = opts.null_grad_val
     for snr in snr_vals:
@@ -170,10 +167,8 @@ if opts.plot_caption is None:
     else:
         opts.plot_caption = opts.plot_caption +\
                              "Black line: veto line.  " +\
-                             "Green line: above this triggers have reduced " +\
-                             "detection statistic.  " +\
-                             "Magenta line: in this line the statistic is " +\
-                             "reduced by a factor of two."
+                             "Magenta line: above this triggers have reduced " +\
+                             "detection statistic."
 
 logging.info("Imported and ready to go.")
 
@@ -208,15 +203,12 @@ if null_stat_type == 'coincident':
     null_stat_conts = [[4, x_max]]
 # Overwhitened null stat (null SNR) and null stat  cases: newSNR contours
 else:
-    cont_colors = ['k-', 'g-', 'm-']
+    cont_colors = ['k-', 'm-']
     null_cont, snr_vals = calculate_contours(opts, new_snrs=None)
     null_stat_conts = [null_cont]
     if zoom_in:
-        null_thresh = list(map(float, opts.null_snr_threshold.split(',')))
-        null_thresh_width = null_thresh[1] - null_thresh[0]
-        null_stat_conts.append(numpy.asarray(null_cont) - null_thresh_width)
-        if null_thresh_width > 1:
-            null_stat_conts.append(numpy.asarray(null_cont) - null_thresh_width + 1)
+        null_thresh = opts.null_snr_threshold
+        null_stat_conts.append(numpy.asarray(null_cont) - 1)
     shade_cont_value = 0
 
 # Overwhitened null stat (null SNR), null stat or coincident SNR vs

--- a/bin/pygrb/pycbc_pygrb_plot_null_stats
+++ b/bin/pygrb/pycbc_pygrb_plot_null_stats
@@ -28,7 +28,6 @@ import sys
 import os
 import logging
 import numpy
-import h5py
 from matplotlib import rc
 import matplotlib.pyplot as plt
 import pycbc.version
@@ -93,6 +92,7 @@ def load_data(input_file, ifos, vetoes, opts, injections=False):
 
     return data
 
+
 # Function that produces the contrours to be plotted
 def calculate_contours(opts, new_snrs=None):
     """Generate the contours to plot"""
@@ -109,7 +109,7 @@ def calculate_contours(opts, new_snrs=None):
     snr_high_vals = numpy.arange(30, 500, 1)
     snr_vals = numpy.asarray(list(snr_low_vals) + list(snr_high_vals))
 
-    # Determine contour
+    # Determine contour consistenly with null_snr in coherent.py
     null_cont = []
     null_thresh = opts.null_snr_threshold
     null_grad_snr = opts.null_grad_thresh
@@ -137,7 +137,7 @@ parser.add_argument("--found-missed-file",
 parser.add_argument("-z", "--zoom-in", default=False, action="store_true",
                     help="Output file a zoomed in version of the plot.")
 parser.add_argument("-y", "--y-variable", default=None,
-                    choices=['coincident', 'null'], #TODO: overwhitened?
+                    choices=['coincident', 'null'],  # TODO: overwhitened?
                     help="Quantity to plot on the vertical axis.")
 ppu.pygrb_add_null_snr_opts(parser)
 ppu.pygrb_add_bestnr_cut_opt(parser)
@@ -147,13 +147,14 @@ init_logging(opts.verbose, format="%(asctime)s: %(levelname)s: %(message)s")
 
 # Check options
 trig_file = os.path.abspath(opts.trig_file)
-found_missed_file = os.path.abspath(opts.found_missed_file) if opts.found_missed_file else None
+found_missed_file = os.path.abspath(opts.found_missed_file)\
+    if opts.found_missed_file else None
 zoom_in = opts.zoom_in
 null_stat_type = opts.y_variable
 
 # Prepare plot title and caption
 y_labels = {'null': "Null SNR",
-            'coincident': "Coincident SNR"} #TODO: overwhitened
+            'coincident': "Coincident SNR"}  # TODO: overwhitened
 if opts.plot_title is None:
     opts.plot_title = y_labels[null_stat_type] + " vs Coherent SNR"
 if opts.plot_caption is None:
@@ -167,8 +168,8 @@ if opts.plot_caption is None:
     else:
         opts.plot_caption = opts.plot_caption +\
                              "Black line: veto line.  " +\
-                             "Magenta line: above this triggers have reduced " +\
-                             "detection statistic."
+                             "Magenta line: above this triggers have " +\
+                             "reduced detection statistic."
 
 logging.info("Imported and ready to go.")
 
@@ -179,7 +180,7 @@ if not os.path.isdir(outdir):
 
 # Extract IFOs and vetoes
 ifos, vetoes = ppu.extract_ifos_and_vetoes(trig_file, opts.veto_files,
-                                        opts.veto_category)
+                                           opts.veto_category)
 
 # Extract trigger data
 trig_data = load_data(trig_file, ifos, vetoes, opts)
@@ -198,7 +199,8 @@ x_max = None
 # Coincident SNR plot case: we want a coinc=coh diagonal line on the plot
 if null_stat_type == 'coincident':
     cont_colors = ['g-']
-    x_max = plu.axis_max_value(trig_data['coherent'], inj_data['coherent'], found_missed_file)
+    x_max = plu.axis_max_value(trig_data['coherent'], inj_data['coherent'],
+                               found_missed_file)
     snr_vals = [4, x_max]
     null_stat_conts = [[4, x_max]]
 # Overwhitened null stat (null SNR) and null stat  cases: newSNR contours

--- a/pycbc/events/coherent.py
+++ b/pycbc/events/coherent.py
@@ -341,7 +341,7 @@ def null_snr(
         keep = (
             ((null < null_min) & (rho_coh <= null_step))
             | (
-                (null < (rho_coh * null_grad + null_min))
+                (null < ((rho_coh - null_step) * null_grad + null_min))
                 & (rho_coh > null_step)
                 )
             )

--- a/pycbc/results/pygrb_postprocessing_utils.py
+++ b/pycbc/results/pygrb_postprocessing_utils.py
@@ -141,9 +141,10 @@ def pygrb_add_null_snr_opts(parser):
     """Add to the parser object the arguments used for null SNR calculation
     and null SNR cut."""
     parser.add_argument("-A", "--null-snr-threshold", action="store",
-                        default="3.5,5.25",
-                        help="Comma separated lower,higher null SNR " +
-                        "threshold for null SNR cut")
+                        default=5.25,
+                        type=float,
+                        help="Null SNR threshold for null SNR cut "
+                        "(default: 5.25)")
     parser.add_argument("-T", "--null-grad-thresh", action="store", type=float,
                         default=20., help="Threshold above which to " +
                         "increase the values of the null SNR cut")


### PR DESCRIPTION
## Standard information about the request

This is a: bug fix with some minor cleanup in style.

This change affects: the PyGRB search

This change corrects scientific output

This change was tested by running a full PyGRB workflow.

## Motivation
The null SNR cut used by `pycbc_multi_inspiral` implemented a discontinuous threshold reported in Eq, (12) [here](https://arxiv.org/pdf/1410.6042).  The correct formula for a continuous threshold is reported in Eq. (4.73) of [this](https://orca.cardiff.ac.uk/id/eprint/128124/) PhD thesis.

## Contents
While correcting the code to reflect the correct null SNR cut, I also cleaned up `pycbc_pygrb_plot_null_stats` for line length, indentation, etc.

## Testing performed
A full PyGRB workflow (in its current form) was run.  I am attaching a plot before the fix and one after the fix.  Injections are no longer ending in the vetoed region.  The green line in the plot was removed and the plot caption reflects this.

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)

![H1L1V1-PYGRB_PLOT_NULL_STATS_NULL_ZOOMIN_NSBH_GRB170817A-1187006058-5648](https://github.com/gwastro/pycbc/assets/11437405/3cefccfd-c689-4d06-9f49-349c13d62498)
![H1L1V1-PYGRB_PLOT_NULL_STATS_NULL_ZOOMIN_NSBH_GRB170817A-1187006058-5648-1](https://github.com/gwastro/pycbc/assets/11437405/238bc9d4-48ad-485c-88f2-d19ddd45471e)


