### PR TITLE
Enabling output of dof from autochisq.values()

### DIFF
--- a/bin/pycbc_inspiral
+++ b/bin/pycbc_inspiral
@@ -283,7 +283,7 @@ def template_triggers(t_num):
                                       out_vals['chisq_dof'],
                                       idx+stilde.analyze.start)
 
-        out_vals['cont_chisq'] = \
+        out_vals['cont_chisq'], _ = \
               autochisq.values(snr, idx+stilde.analyze.start, template,
                                stilde.psd, norm, stilde=stilde,
                                low_frequency_cutoff=flow)

--- a/bin/pycbc_multi_inspiral
+++ b/bin/pycbc_multi_inspiral
@@ -153,9 +153,45 @@ parser.add_argument("--chisq-bins", default=0)
 # Commenting out unused options: remove if they remain unused
 # parser.add_argument("--chisq-threshold", type=float, default=0)
 # parser.add_argument("--chisq-delta", type=float, default=0)
-parser.add_argument("--autochi-number-points", type=int, default=0)
-parser.add_argument("--autochi-stride", type=int, default=0)
-parser.add_argument("--autochi-onesided", action='store_true', default=False)
+parser.add_argument("--autochi-number-points", type=int, default=0,
+                    help="The number of points to use, in both directions if"
+                         "doing a two-sided auto-chisq, to calculate the"
+                         "auto-chisq statistic.")
+parser.add_argument("--autochi-stride", type=int, default=0,
+                    help="The gap, in sample points, between the points at"
+                         "which to calculate auto-chisq.")
+parser.add_argument("--autochi-two-phase", action="store_true",
+                    default=False,
+                    help="If given auto-chisq will be calculated by testing "
+                         "against both phases of the SNR time-series. "
+                         "If not given, only the phase matching the trigger "
+                         "will be used.")
+parser.add_argument("--autochi-onesided", action='store',
+                    choices=['left','right'],
+                    help="Decide whether to calculate auto-chisq using"
+                         "points on both sides of the trigger or only on one"
+                         "side. If not given points on both sides will be"
+                         "used. If given, with either 'left' or 'right',"
+                         "only points on that side (right = forward in time,"
+                         "left = back in time) will be used.")
+parser.add_argument("--autochi-reverse-template", action="store_true",
+                    default=False,
+                    help="If given, time-reverse the template before"
+                         "calculating the auto-chisq statistic. This will"
+                         "come at additional computational cost as the SNR"
+                         "time-series will need recomputing for the time-"
+                         "reversed template.")
+parser.add_argument("--autochi-max-valued", action="store_true",
+                    default=False,
+                    help="If given, store only the maximum value of the auto-"
+                         "chisq over all points tested. A disadvantage of this "
+                         "is that the mean value will not be known "
+                         "analytically.")
+parser.add_argument("--autochi-max-valued-dof", action="store", metavar="INT",
+                    type=int,
+                    help="If using --autochi-max-valued this value denotes "
+                         "the pre-calculated mean value that will be stored "
+                         "as the auto-chisq degrees-of-freedom value.")
 parser.add_argument(
     "--downsample-factor",
     type=int,
@@ -474,6 +510,10 @@ with ctx:
         args.autochi_stride,
         args.autochi_number_points,
         onesided=args.autochi_onesided,
+        twophase=args.autochi_two_phase,
+        reverse_template=args.autochi_reverse_template,
+        take_maximum_value=args.autochi_max_valued,
+        maximal_value_dof=args.autochi_max_valued_dof
     )
 
     # Overwhiten all frequency-domain segments by dividing by the PSD estimate

--- a/bin/pycbc_multi_inspiral
+++ b/bin/pycbc_multi_inspiral
@@ -492,7 +492,8 @@ with ctx:
         'chisq_dof': int,
         'bank_chisq': float32,
         'bank_chisq_dof': int,
-        'cont_chisq': float32,
+        'auto_chisq': float32,
+        'auto_chisq_dof': int,
         'slide_id': int,
     }
     ifo_out_vals = {
@@ -503,7 +504,8 @@ with ctx:
         'chisq_dof': None,
         'bank_chisq': None,
         'bank_chisq_dof': None,
-        'cont_chisq': None,
+        'auto_chisq': None,
+        'auto_chisq_dof': int,
         'slide_id': None,
     }
     ifo_names = sorted(ifo_out_vals.keys())
@@ -972,7 +974,10 @@ with ctx:
                                 coinc_idx_det_frame[ifo]
                                 + stilde[ifo].analyze.start,
                             )
-                            ifo_out_vals['cont_chisq'] = autochisq.values(
+                            (
+                                ifo_out_vals['auto_chisq'],
+                                ifo_out_vals['auto_chisq_dof'],
+                            ) = autochisq.values(
                                 snr_dict[ifo] / norm_dict[ifo],
                                 coinc_idx_det_frame[ifo],
                                 template,

--- a/bin/pygrb/pycbc_pygrb_plot_chisq_veto
+++ b/bin/pygrb/pycbc_pygrb_plot_chisq_veto
@@ -91,7 +91,7 @@ def load_data(input_file, ifos, vetoes, opts, injections=False):
         # Tags to find vetoes in HDF files
         veto_tags = {'standard': 'chisq',
                      'bank': 'bank_chisq',
-                     'auto': 'cont_chisq'}
+                     'auto': 'auto_chisq'}
 
         # FIXME: network data contains my_network_chisq
         chisq_key = 'network/my_network_chisq' if injections \

--- a/examples/gw150914/PyCBCInspiral.ipynb
+++ b/examples/gw150914/PyCBCInspiral.ipynb
@@ -593,7 +593,7 @@
     "                                              out_vals['chisq_dof'],\n",
     "                                              idx+stilde.analyze.start)\n",
     "\n",
-    "                out_vals['cont_chisq'] = \\\n",
+    "                out_vals['cont_chisq'], _ = \\\n",
     "                      autochisq.values(snr, idx+stilde.analyze.start, template,\n",
     "                                       stilde.psd, norm, stilde=stilde,\n",
     "                                       low_frequency_cutoff=flow)\n",

--- a/pycbc/events/eventmgr.py
+++ b/pycbc/events/eventmgr.py
@@ -761,7 +761,8 @@ class EventManagerCoherent(EventManagerMultiDetBase):
                 f['chisq'] = ifo_events['chisq']
                 f['bank_chisq'] = ifo_events['bank_chisq']
                 f['bank_chisq_dof'] = ifo_events['bank_chisq_dof']
-                f['cont_chisq'] = ifo_events['cont_chisq']
+                f['auto_chisq'] = ifo_events['auto_chisq']
+                f['auto_chisq_dof'] = ifo_events['auto_chisq_dof']
                 f['end_time'] = ifo_events['time_index'] / \
                         float(self.opt.sample_rate[ifo]) + \
                         self.opt.gps_start_time[ifo]

--- a/pycbc/vetoes/autochisq.py
+++ b/pycbc/vetoes/autochisq.py
@@ -61,9 +61,10 @@ def autochisq_from_precomputed(sn, corr_sn, hautocorr, indices,
 
     Returns
     -------
-    autochisq: [tuple]
-        returns autochisq values and snr corresponding to the instances
-        of time defined by indices
+    dof: int
+        number of degrees of freedom
+    autochisq: Array[float]
+        autochisq values corresponding to the time instances defined by indices
     """
     Nsnr = len(sn)
 
@@ -133,7 +134,7 @@ def autochisq_from_precomputed(sn, corr_sn, hautocorr, indices,
     if twophase:
         dof = dof * 2
 
-    return dof, achisq, indices
+    return dof, achisq
 
 class SingleDetAutoChisq(object):
     """Class that handles precomputation and memory management for efficiently
@@ -276,11 +277,11 @@ class SingleDetAutoChisq(object):
 
             achi_list = np.array([])
             index_list = np.array(indices)
-            dof, achi_list, _ = autochisq_from_precomputed(sn, correlation_snr,
-                               self._autocor, index_list, stride=self.stride,
-                               num_points=self.num_points,
-                               oneside=self.one_sided, twophase=self.two_phase,
-                               maxvalued=self.take_maximum_value)
+            dof, achi_list = autochisq_from_precomputed(sn, correlation_snr,
+                             self._autocor, index_list, stride=self.stride,
+                             num_points=self.num_points,
+                             oneside=self.one_sided, twophase=self.two_phase,
+                             maxvalued=self.take_maximum_value)
             self.dof = dof
             return achi_list, dof
         else:

--- a/pycbc/vetoes/autochisq.py
+++ b/pycbc/vetoes/autochisq.py
@@ -283,6 +283,8 @@ class SingleDetAutoChisq(object):
                                maxvalued=self.take_maximum_value)
             self.dof = dof
             return achi_list, dof
+        else:
+            return None, None
 
 class SingleDetSkyMaxAutoChisq(SingleDetAutoChisq):
     """Stub for precessing auto chisq if anyone ever wants to code it up.

--- a/pycbc/vetoes/autochisq.py
+++ b/pycbc/vetoes/autochisq.py
@@ -223,6 +223,14 @@ class SingleDetAutoChisq(object):
             The lower frequency to consider in matched-filters
         high_frequency_cutoff : float
             The upper frequency to consider in matched-filters
+
+        Returns
+        -------
+        achi_list : TimeSeries of auto veto values - if indices
+        is None then evaluated at all time samples, if not then only at
+        requested sample indices
+
+        dof: int, approx number of statistical degrees of freedom
         """
         if self.do and (len(indices) > 0):
             htilde = make_frequency_series(template)
@@ -274,7 +282,7 @@ class SingleDetAutoChisq(object):
                                oneside=self.one_sided, twophase=self.two_phase,
                                maxvalued=self.take_maximum_value)
             self.dof = dof
-            return achi_list
+            return achi_list, dof
 
 class SingleDetSkyMaxAutoChisq(SingleDetAutoChisq):
     """Stub for precessing auto chisq if anyone ever wants to code it up.

--- a/test/test_autochisq.py
+++ b/test/test_autochisq.py
@@ -112,11 +112,11 @@ class TestAutochisquare(unittest.TestCase):
 
 
         with _context:
-           dof, achisq, indices= \
+           dof, achisq = \
                autochisq_from_precomputed(snr, snr, hacor, indx, stride=3,
                                           num_points=20)
 
-        obt_snr = abs(snr[indices[1]])
+        obt_snr = abs(snr[indx[1]])
         obt_ach = achisq[1]
         self.assertTrue(obt_snr > 10.0 and obt_snr < 12.0)
         self.assertTrue(obt_ach < 3.e-3)
@@ -162,11 +162,11 @@ class TestAutochisquare(unittest.TestCase):
         snr = snr*nrm
 
         with _context:
-           dof, achisq, indices= \
+           dof, achisq = \
                autochisq_from_precomputed(snr, snr, hacor, indx, stride=3,
                                           num_points=20)
 
-        obt_snr = abs(snr[indices[1]])
+        obt_snr = abs(snr[indx[1]])
         obt_ach = achisq[1]
         self.assertTrue(obt_snr > 12.0 and obt_snr < 15.0)
         self.assertTrue(obt_ach > 6.8e3)


### PR DESCRIPTION
Unlike other chi-squared values methods, autochisq.values() computes the number of degrees of freedom but does not return it.  This PR makes the situation even across the values methods of the various chi-squares.

This change affects: PyGRB (autochi-square plots can now be generated) and `pycbc_inspiral` (coincident searches) but the degrees of freedom are dumped to `_` so nothing meaningful is modified.

## Testing performed
A full PyGRB workflow with the generation of autochi-square plots was successfully carried out.

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
