### PR TITLE
disable git lfs post-clone hook checks for lalsuite-extra

### DIFF
--- a/.github/workflows/basic-tests.yml
+++ b/.github/workflows/basic-tests.yml
@@ -28,7 +28,7 @@ jobs:
         pip install "tox<4.0.0" pip setuptools --upgrade
     - name: installing auxiliary data files
       run: |
-        GIT_LFS_SKIP_SMUDGE=1 git clone https://git.ligo.org/lscsoft/lalsuite-extra
+        GIT_CLONE_PROTECTION_ACTIVE=false GIT_LFS_SKIP_SMUDGE=1 git clone https://git.ligo.org/lscsoft/lalsuite-extra
         cd lalsuite-extra
         git lfs pull -I "data/lalsimulation/SEOBNRv2ROM_*.dat"
         git lfs pull -I "data/lalsimulation/*ChirpTime*.dat"

--- a/tools/install_travis.sh
+++ b/tools/install_travis.sh
@@ -28,7 +28,7 @@ chmod +x $p
 
 # LAL extra data files
 # FIXME, should be a way to make reduced package (with subset of data files)
-GIT_LFS_SKIP_SMUDGE=1 git clone https://git.ligo.org/lscsoft/lalsuite-extra
+GIT_CLONE_PROTECTION_ACTIVE=false GIT_LFS_SKIP_SMUDGE=1 git clone https://git.ligo.org/lscsoft/lalsuite-extra
 cd lalsuite-extra
 git lfs pull -I "data/lalsimulation/SEOBNRv2ROM_*.dat"
 git lfs pull -I "data/lalsimulation/*ChirpTime*.dat"


### PR DESCRIPTION
git has introduced a post-hook ban for security, but it seems to break git-lfs

This is the workaround until that is fixed

## Standard information about the request

This is a fudge
This change affect continuous integration

## Contents
Fix as suggested by the failure message

## Links to any issues or associated PRs
https://github.com/git-lfs/git-lfs/issues/5749

## Testing performed
Testing is through the CI

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
