### PR TITLE
Allow PhenomXPHM options in laldict for v23 release branch

### DIFF
--- a/.github/workflows/basic-tests.yml
+++ b/.github/workflows/basic-tests.yml
@@ -28,7 +28,7 @@ jobs:
         pip install "tox<4.0.0" pip setuptools --upgrade
     - name: installing auxiliary data files
       run: |
-        GIT_LFS_SKIP_SMUDGE=1 git clone https://git.ligo.org/lscsoft/lalsuite-extra
+        GIT_CLONE_PROTECTION_ACTIVE=false GIT_LFS_SKIP_SMUDGE=1 git clone https://git.ligo.org/lscsoft/lalsuite-extra
         cd lalsuite-extra
         git lfs pull -I "data/lalsimulation/SEOBNRv2ROM_*.dat"
         git lfs pull -I "data/lalsimulation/*ChirpTime*.dat"

--- a/pycbc/waveform/parameters.py
+++ b/pycbc/waveform/parameters.py
@@ -545,6 +545,18 @@ dbeta2 = Parameter("dbeta2",
 dbeta3 = Parameter("dbeta3",
                 dtype=float, default=0., label=r"$d\beta_3$",
                 description="Intermediate testingGR parameter.")
+
+## Specific waveform parameters
+
+dchi0 = Parameter("ThresholdMband",
+                dtype=float, default=None, label="ThresholdMband",
+                description="PhenomXHM Multibanding")
+
+dchi0 = Parameter("PrecThresholdMband",
+                dtype=float, default=None, label="PrecThresholdMband",
+                description="PhenomXPHM Multibanding")
+
+
 #
 # =============================================================================
 #

--- a/pycbc/waveform/parameters.py
+++ b/pycbc/waveform/parameters.py
@@ -548,11 +548,11 @@ dbeta3 = Parameter("dbeta3",
 
 ## Specific waveform parameters
 
-dchi0 = Parameter("ThresholdMband",
+threshmband = Parameter("ThresholdMband",
                 dtype=float, default=None, label="ThresholdMband",
                 description="PhenomXHM Multibanding")
 
-dchi0 = Parameter("PrecThresholdMband",
+precthreshmband = Parameter("PrecThresholdMband",
                 dtype=float, default=None, label="PrecThresholdMband",
                 description="PhenomXPHM Multibanding")
 
@@ -587,7 +587,7 @@ extrinsic_params = orientation_params + location_params
 testingGR_params = ParameterList\
     ([dchi0, dchi1, dchi2, dchi3, dchi4, dchi5, dchi5l, dchi6, dchi6l,
       dchi7, dalpha1, dalpha2, dalpha3, dalpha4, dalpha5,
-      dbeta1, dbeta2, dbeta3])
+      dbeta1, dbeta2, dbeta3, precthreshmband, threshmband])
 
 # intrinsic parameters of a CBC waveform. Some of these are not recognized
 # by every waveform model

--- a/pycbc/waveform/waveform.py
+++ b/pycbc/waveform/waveform.py
@@ -170,6 +170,16 @@ def _check_lal_pars(p):
         lalsimulation.SimInspiralWaveformParamsInsertNonGRDBeta2(lal_pars,p['dbeta2'])
     if p['dbeta3'] is not None:
         lalsimulation.SimInspiralWaveformParamsInsertNonGRDBeta3(lal_pars,p['dbeta3'])
+    if p['PrecThresholdMband'] is not None:
+        lalsimulation.SimInspiralWaveformParamsInsertPhenomXPHMThresholdMband(
+            lal_pars,
+            p['PrecThresholdMband'],
+        )
+    if p['ThresholdMband'] is not None:
+        lalsimulation.SimInspiralWaveformParamsInsertPhenomXHMThresholdMband(
+            lal_pars,
+            p['ThresholdMband'],
+        )
     return lal_pars
 
 def _lalsim_td_waveform(**p):

--- a/tools/install_travis.sh
+++ b/tools/install_travis.sh
@@ -28,7 +28,7 @@ chmod +x $p
 
 # LAL extra data files
 # FIXME, should be a way to make reduced package (with subset of data files)
-GIT_LFS_SKIP_SMUDGE=1 git clone https://git.ligo.org/lscsoft/lalsuite-extra
+GIT_CLONE_PROTECTION_ACTIVE=false GIT_LFS_SKIP_SMUDGE=1 git clone https://git.ligo.org/lscsoft/lalsuite-extra
 cd lalsuite-extra
 git lfs pull -I "data/lalsimulation/SEOBNRv2ROM_*.dat"
 git lfs pull -I "data/lalsimulation/*ChirpTime*.dat"


### PR DESCRIPTION
There are some important options for generating XPHM, which we need to support in the v23 release branch. There is a related PR (#4728), which tries to deal with the more general case, though there are concerns about lalsimulation's naming and how to predict that.

For now, I hardcode the necessary values, and leave a more general discussion for the main branch. 

For the wider audience: BE CAREFUL WITH PHENOMXPHM! There is a rare failure mode where it will produce `inf`s (or other garbage) for long waveforms. This appears to be a bug with the multi-banding, which is on by default.

I have tested this on one of these failure modes via a HDF input file, with the new option (avoiding multi-banding) I get sane output, without I get infs.