### PR TITLE
fix cdfinv of external text file distribution when multiple are  used in a joint distribution

### DIFF
--- a/pycbc/distributions/external.py
+++ b/pycbc/distributions/external.py
@@ -119,7 +119,7 @@ class External(object):
 
 
 class DistributionFunctionFromFile(External):
-    """Evaluating PDF, logPDF, CDF and inverse CDF from the external
+    r"""Evaluating PDF, logPDF, CDF and inverse CDF from the external
         density function.
 
     To add to an inference configuration file:

--- a/pycbc/distributions/external.py
+++ b/pycbc/distributions/external.py
@@ -160,8 +160,6 @@ class DistributionFunctionFromFile(External):
                  column_index=None, **kwargs):
         super().__init__(cdfinv=self._cdfinv, logpdf=self._logpdf)
         self.params = params
-        print("from file", params)
-        print(self.params)
         self.data = np.loadtxt(fname=file_path, unpack=True, comments='#')
         self.column_index = int(column_index)
         self.epsabs = kwargs.get('epsabs', 1.49e-05)
@@ -171,9 +169,10 @@ class DistributionFunctionFromFile(External):
         if not file_path:
             raise ValueError("Must provide the path to density function file.")
 
-    def _pdf(self, x, **kwargs):
+    def _pdf(self, **kwargs):
         """Calculate and interpolate the PDF by using the given density
         function, then return the corresponding value at the given x."""
+        x = kwargs[self.params[0]])
         if self.interp['pdf'] == callable:
             func_unnorm = scipy_interpolate.interp1d(
                 self.data[0], self.data[self.column_index])
@@ -186,13 +185,14 @@ class DistributionFunctionFromFile(External):
         pdf_val = np.float64(self.interp['pdf'](x))
         return pdf_val
 
-    def _logpdf(self, x, **kwargs):
+    def _logpdf(self, **kwargs):
         """Calculate the logPDF by calling `pdf` function."""
         return np.log(self._pdf(x, **kwargs))
 
-    def _cdf(self, x, **kwargs):
+    def _cdf(self, **kwargs):
         """Calculate and interpolate the CDF, then return the corresponding
         value at the given x."""
+        x = kwargs[self.params[0]])
         if self.interp['cdf'] == callable:
             cdf_list = []
             for x_val in self.x_list:
@@ -208,6 +208,7 @@ class DistributionFunctionFromFile(External):
     def _cdfinv(self, **kwargs):
         """Calculate and interpolate the inverse CDF, then return the
         corresponding parameter value at the given CDF value."""
+        xval = kwargs[self.params[0]])
         if self.interp['cdfinv'] == callable:
             cdf_list = []
             for x_value in self.x_list:
@@ -215,7 +216,7 @@ class DistributionFunctionFromFile(External):
             self.interp['cdfinv'] = \
                 scipy_interpolate.interp1d(cdf_list, self.x_list)
         cdfinv_val = {self.params[0]: np.float64(
-            self.interp['cdfinv'](kwargs[self.params[0]]))}
+            self.interp['cdfinv'](xval)}
         return cdfinv_val
 
     @classmethod

--- a/pycbc/distributions/external.py
+++ b/pycbc/distributions/external.py
@@ -119,11 +119,9 @@ class External(object):
 
 
 class DistributionFunctionFromFile(External):
-    r"""Evaluating PDF, logPDF, CDF and inverse CDF from the external
+    """Evaluating PDF, logPDF, CDF and inverse CDF from the external
         density function.
 
-    Instances of this class can be called like a distribution in the .ini file.
-    
     To add to an inference configuration file:
 
     .. code-block:: ini
@@ -137,10 +135,10 @@ class DistributionFunctionFromFile(External):
     ----------
     params : list
         list of parameter names
-   file_path: str
-        The path of the external density function's .txt file. 
-   column_index: int
-        The column index of the density distribution. By default, the first column
+    file_path: str
+        The path of the external density function's .txt file.
+    column_index: int
+        The column index of the density distribution. By default, the first
         should be the values of a certain parameter, such as "mass", other
         columns should be the corresponding density values (as a function of
         that parameter). If you add the name of the parameter in the first
@@ -227,7 +225,7 @@ class DistributionFunctionFromFile(External):
         file_path = cp.get_opt_tag(section, 'file_path', tag)
         column_index = cp.get_opt_tag(section, 'column_index', tag)
         return cls(params=params, file_path=file_path,
-                                  column_index=column_index)
+                   column_index=column_index)
 
 
 __all__ = ['External', 'DistributionFunctionFromFile']


### PR DESCRIPTION
@WuShichao There is a bug in the external from fun distribution in how it retrieves the parameter name. 

At the same time, the config file format was overly complicated. I've simplified this. so that one can do 

[prior-final_mass]
name = external_func_fromfile
file_path = spin.txt
column_index = 1

The change is backwards compatible. 

@WuShichao Can you please verify and review? Also add it to your todo list to put in a unittest for this class. 