### PR TITLE
Efficiency savings for pycbc_page_coinc_snrchi, and ForegroundTriggers get_snglfile_array_dict

### DIFF
--- a/bin/plotting/pycbc_page_coinc_snrchi
+++ b/bin/plotting/pycbc_page_coinc_snrchi
@@ -5,7 +5,9 @@ import numpy, h5py, argparse, matplotlib
 from matplotlib import colors
 matplotlib.use('Agg')
 import pylab, pycbc.results
-from pycbc.io import get_chisq_from_file_choice, chisq_choices
+from pycbc.io import (
+    get_chisq_from_file_choice, chisq_choices, SingleDetTriggers
+)
 from pycbc import conversions
 from pycbc.detector import Detector
 import pycbc.version
@@ -45,20 +47,34 @@ parser.add_argument('--chisq-choice', choices=chisq_choices,
 parser.add_argument('--output-file', required=True)
 args = parser.parse_args()
 
+# First - check the IFO being used
+with h5py.File(args.single_trigger_file, 'r') as stf:
+    ifo = tuple(stf.keys())[0]
+
 # Add the background triggers
-f = h5py.File(args.coinc_statistic_file, 'r')
-b_tids = {}
-ifos = f.attrs['ifos'].split(' ')
-for tmpifo in ifos:
-    b_tids[tmpifo] = f['background_exc/{}/trigger_id'.format(tmpifo)]
+with h5py.File(args.coinc_statistic_file, 'r') as csf:
+    b_tids = csf['background_exc'][ifo]['trigger_id'][:]
+    # Remove trigger ids == -1, as this indicates that it was found in
+    # other detector(s)
+    b_tids = b_tids[b_tids >= 0]
+    ifos = csf.attrs['ifos'].split(' ')
 
-f = h5py.File(args.single_trigger_file, 'r')
-ifo = tuple(f.keys())[0]
-f = f[ifo]
-tid = b_tids[ifo][:]
-bkg_snr = f['snr'][:][tid]
+trigs = SingleDetTriggers(
+    args.single_trigger_file,
+    ifo,
+    premask=b_tids
+)
 
-bkg_chisq = get_chisq_from_file_choice(f, args.chisq_choice)[tid]
+bkg_snr = trigs.snr
+bkg_chisq = get_chisq_from_file_choice(trigs, args.chisq_choice)
+
+# SingleDetTriggers will have discarded the ordering of the tids, and any
+# duplicates, so we need to do a bit of index juggling to get this back.
+# Numpy's unique() function also removes ordering and duplicates, and
+# the return_inverse gives us the array to convert it back!:
+_, bkg_tid_idx_inverse = numpy.unique(b_tids, return_inverse=True)
+bkg_snr = bkg_snr[bkg_tid_idx_inverse]
+bkg_chisq = bkg_chisq[bkg_tid_idx_inverse]
 
 # don't plot if chisq is not calculated
 bkg_pos = bkg_chisq > 0
@@ -71,9 +87,11 @@ pylab.scatter(bkg_snr, bkg_chisq, marker='o', color='black',
 
 # Add the found injection points
 f = h5py.File(args.found_injection_file, 'r')
-inj_tids = {}
-for tmpifo in ifos:
-    inj_tids[tmpifo] = f['found_after_vetoes/{}/trigger_id'.format(tmpifo)]
+inj_tid = f['found_after_vetoes'][ifo]['trigger_id'][:]
+# Remove trigger ids == -1, as this indicates that it was found in
+# other detector(s)
+valid_inj = inj_tid >= 0
+inj_tid = inj_tid[valid_inj]
 
 eff_dists = Detector(ifo).effective_distance(f['injections/distance'][:],
                                              f['injections/ra'][:],
@@ -82,7 +100,7 @@ eff_dists = Detector(ifo).effective_distance(f['injections/distance'][:],
                                              f['injections/tc'][:],
                                              f['injections/inclination'][:])
 
-inj_idx = f['found_after_vetoes/injection_index'][:]
+inj_idx = f['found_after_vetoes/injection_index'][valid_inj]
 eff_dist = eff_dists[inj_idx]
 m1, m2 = f['injections/mass1'][:][inj_idx], f['injections/mass2'][:][inj_idx]
 s1, s2 = f['injections/spin1z'][:][inj_idx], f['injections/spin2z'][:][inj_idx]
@@ -108,10 +126,24 @@ if 'optimal_snr_{}'.format(ifo) in f['injections']:
     coloring['optimal_snr'] = (opt_snr, 'Optimal SNR', colors.LogNorm())
 
 f = h5py.File(args.single_injection_file, 'r')[ifo]
-tid = inj_tids[ifo][:]
-if len(tid):
-    inj_snr = f['snr'][:][tid]
-    inj_chisq = get_chisq_from_file_choice(f, args.chisq_choice)[tid]
+if len(inj_tid):
+    inj_trigs = SingleDetTriggers(
+        args.single_injection_file,
+        ifo,
+        premask=inj_tid,
+    )
+    inj_snr = inj_trigs.snr
+    inj_chisq = get_chisq_from_file_choice(inj_trigs, args.chisq_choice)
+
+    # Again, the SingleDetTriggers will have discarded order etc. of tids,
+    # so we need to do index juggling
+    _, inj_tid_idx_inverse = numpy.unique(
+        inj_tid,
+        return_inverse=True
+    )
+    inj_snr = inj_snr[inj_tid_idx_inverse]
+    inj_chisq = inj_chisq[inj_tid_idx_inverse]
+
 else:
     inj_snr = numpy.array([])
     inj_chisq = numpy.array([])


### PR DESCRIPTION
The `pycbc_page_coinc_snrchi` code was using a lot of memory - this fixes that
This also fixes the memory usage of `get_snglfile_array_dict` in `ForegroundTriggers`

## Standard information about the request

This is an efficiency update, with a minor bugfix involved as well
This change affects the offline search
This change could change result presentation / plotting, but it doesn't outwith the bugfix

This change, follows style guidelines (See e.g. [PEP8](https://peps.python.org/pep-0008/)), has been proposed using the [contribution guidelines](https://github.com/gwastro/pycbc/blob/master/CONTRIBUTING.md)


## Motivation
The `pycbc_page_coinc_snrchi` code was using a lot of memory
This also fixes the memory usage of `get_snglfile_array_dict` in `ForegroundTriggers`, as used by `pycbc_page_foreground`
There was a minor bug in `pycbc_page_coinc_snrchi` not taking the -1 trigger ids into account properly - this has been fixed

## Contents
Both these cases use the general idea of using boolean arrays to pre-cut the single-detector trigger files when reading. The `pycbc_page_coinc_snrchi` does this through the SingleDetTriggers interface.

They both have additional complication that the boolean mask method loses order / duplicate index information. This is solved using the numpy `unique()` function's `return_inverse` keyword / output, which provides this information.

I looked up whether there are faster / better implementations than the numpy unique function given that we don't use the sorted array, I found [this implementation](https://stackoverflow.com/questions/60174421/faster-return-inverse-in-np-unique) but it looks to be memory intensive, which is the problem we are solving here! It seems to be quick enough anyway

## Links to any issues or associated PRs
https://github.com/gwastro/pycbc/issues/4761
https://github.com/gwastro/pycbc/pull/4724

## Testing performed
Within the codes, I kept the original (as at version 2.3.6) implementations, and then did elementwise comparison of the outputs: `bkg_snr`, `bkg_chisq`, `inj_snr` and `inj_chisq` in the `pycbc_page_coinc_snrchi` code, and `curr` (and `lgc` to be safe) in `get_snglfile_array_dict`. These were all identical.

I compared the output files with diff, and the page_foreground outputs differed by metadata.
The `pycbc_page_coinc_snrchi` output plots differed, but this is due to the bugfix described above.


- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
