### PR TITLE
Update example config files to use the page_versioning script

### DIFF
--- a/examples/workflow/inference/gw150914_gw170814-dynesty/workflow_config.ini
+++ b/examples/workflow/inference/gw150914_gw170814-dynesty/workflow_config.ini
@@ -98,6 +98,7 @@ create_fits_file = ${which:pycbc_inference_create_fits}
 plot_skymap = ${which:pycbc_inference_plot_skymap}
 plot_spectrum = ${which:pycbc_plot_psd_file}
 results_page = ${which:pycbc_make_html_page}
+page_versioning = ${which:pycbc_page_versioning}
 ; diagnostic plots: at the moment, there are none for Dynesty
 
 [pegasus_profile]


### PR DESCRIPTION
Example configs for inference were out-of-date and did not include the `pycbc_page_versioning` script in executables

## Standard information about the request

This is a documentation fix

This change affects inference documentation

This change follows style guidelines (See e.g. [PEP8](https://peps.python.org/pep-0008/)), has been proposed using the [contribution guidelines](https://github.com/gwastro/pycbc/blob/master/CONTRIBUTING.md)


## Motivation
Documentation was out of date

## Contents
Updating executables section of config(s) to include the script

## Links to any issues or associated PRs
#4431

## Testing performed
None - though I thought this oversight should have been caught by the CI tests?


- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
