### PR TITLE
Fix epoch in cached fft

### DIFF
--- a/pycbc/strain/strain.py
+++ b/pycbc/strain/strain.py
@@ -1383,7 +1383,10 @@ def execute_cached_fft(invec_data, normalize_by_rate=True, ifft=False,
             outvec._data *= invec._delta_t
     if copy_output:
         outvec = outvec.copy()
-    outvec._epoch = invec_data._epoch
+    try:
+        outvec._epoch = invec_data._epoch
+    except AttributeError:
+        pass
     return outvec
 
 

--- a/pycbc/strain/strain.py
+++ b/pycbc/strain/strain.py
@@ -1383,6 +1383,7 @@ def execute_cached_fft(invec_data, normalize_by_rate=True, ifft=False,
             outvec._data *= invec._delta_t
     if copy_output:
         outvec = outvec.copy()
+    outvec._epoch = invec_data._epoch
     return outvec
 
 

--- a/test/test_strain.py
+++ b/test/test_strain.py
@@ -1,0 +1,65 @@
+"""
+These unit tests are for the pycbc.strain.strain module
+"""
+import numpy
+from pycbc.types import TimeSeries
+from pycbc.strain.strain import (
+    execute_cached_fft,
+    execute_cached_ifft,
+)
+import unittest
+
+from utils import simple_exit
+
+
+class TestStrain(unittest.TestCase):
+
+    def setUp(self):
+
+        self.rng = numpy.random.default_rng()
+        self.td_data = TimeSeries(
+            self.rng.normal(size=100), delta_t=0.2, epoch=1123456789.6,
+        )
+        self.fd_data = self.td_data.to_frequencyseries()
+        # Tolerance for float64
+        self.tol = 1e-14
+        # Higher tolerance for elementwise comparison
+        self.elem_tol = 1e-13
+
+    def test_cached_fft(self):
+        fd_data = execute_cached_fft(
+            self.td_data,
+            uid=87651,
+            copy_output=True,
+        )
+        self.assertTrue(
+            fd_data.almost_equal_norm(
+                self.fd_data, tol=self.tol, dtol=self.tol
+            )
+        )
+        self.assertTrue(
+            fd_data.almost_equal_elem(self.fd_data, tol=self.elem_tol)
+        )
+
+    def test_cached_ifft(self):
+        td_data = execute_cached_ifft(
+            self.fd_data,
+            uid=87652,
+            copy_output=True,
+        )
+        self.assertTrue(
+            td_data.almost_equal_norm(
+                self.td_data, tol=self.tol, dtol=self.tol
+            )
+        )
+        self.assertTrue(
+            td_data.almost_equal_elem(self.td_data, tol=self.elem_tol)
+        )
+
+
+suite = unittest.TestSuite()
+suite.addTest(unittest.TestLoader().loadTestsFromTestCase(TestStrain))
+
+if __name__ == '__main__':
+    results = unittest.TextTestRunner(verbosity=2).run(suite)
+    simple_exit(results)

--- a/test/test_strain.py
+++ b/test/test_strain.py
@@ -23,8 +23,6 @@ class TestStrain(unittest.TestCase):
         self.fd_data = self.td_data.to_frequencyseries()
         # Tolerance for float64
         self.tol = 1e-14
-        # Higher tolerance for elementwise comparison
-        self.elem_tol = 1e-13
 
     def test_cached_fft(self):
         fd_data = execute_cached_fft(
@@ -37,9 +35,6 @@ class TestStrain(unittest.TestCase):
                 self.fd_data, tol=self.tol, dtol=self.tol
             )
         )
-        self.assertTrue(
-            fd_data.almost_equal_elem(self.fd_data, tol=self.elem_tol)
-        )
 
     def test_cached_ifft(self):
         td_data = execute_cached_ifft(
@@ -51,9 +46,6 @@ class TestStrain(unittest.TestCase):
             td_data.almost_equal_norm(
                 self.td_data, tol=self.tol, dtol=self.tol
             )
-        )
-        self.assertTrue(
-            td_data.almost_equal_elem(self.td_data, tol=self.elem_tol)
         )
 
 


### PR DESCRIPTION
<!---
Please delete these comments when you submit the pull request

Please add a title which is a concise description of what you are doing,
e.g. 'Fix bug with numpy import in pycbc_coinc_findtrigs' or 'add high frequency sky location dependent response for long detectors'
-->

<!---
This is a brief template for making pull requests for PyCBC.
This is _not_ a proscriptive template - you can use a different style if you want.
Please do think about the questions posed here and whether the details will be useful to include in your PR
Please add sufficient details so that people looking back at the request with no context around the work can understand the changes.
To choose reviewers, please look at the git blame for the code you are changing (if applicable),
or discuss in the #pycbc-code channel of the gwastro slack.
Please add labels as appropriate
-->

<!-- TOP-LEVEL SUMMARY: Please provide a brief, one-or-two-sentence description of the PR here
-->

Update `pycbc.strain.strain.execute_cached_fft` so that the epoch of the output frequency/time series is set to match that of the input rather than being zero.

## Standard information about the request

<!--- Some basic info about the change (delete as appropriate) -->
This is a: bug fix

<!--- What codes will this affect? (delete as apropriate)
If you do not know which areas will be affected, please ask in the gwastro #pycbc-code slack
-->
This change affects any code that makes use of `execute_cached_fft` or functions/classes that call it. This includes `pycbc.filter` and `pycbc.psd` given this, it could impact a large part of the codebase.

<!--- What code areas will this affect? (delete as apropriate) -->
This change changes: scientific output

<!--- Some things which help with code management (delete as appropriate) -->
This change: has appropriate unit tests, follows style guidelines (See e.g. [PEP8](https://peps.python.org/pep-0008/)), has been proposed using the [contribution guidelines](https://github.com/gwastro/pycbc/blob/master/CONTRIBUTING.md)

<!--- Notes about the effect of this change -->
This change will: fix an existing bug

## Motivation
<!--- Describe why your changes are being made -->

This fixes a bug in `pycbc.strain.strain.execute_cached_fft`

## Contents
<!--- Describe your changes, this doesn't need to be a line-by-line code change discussion,
but rather a general discussion of the methods chosen -->

* Specify the `_epoch` attribute of the output frequency/time series based on the input
* Add a basic unit test for `execute_cached_fft` and `execute_cached_ifft`

## Links to any issues or associated PRs
<!--- If this is fixing / working around an already-reported issue, please link to it here -->

N/A

## Testing performed
<!--- Describe tests for the code changes, either already performed or to be performed -->

Added unit tests to test the changes

## Additional notes
<!--- Anything which does not fit in the above sections -->

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)

## Minimal example

```python
import pycbc
import pycbc.strain
ts = pycbc.types.TimeSeries([1, 2, 3], delta_t=0.2, epoch=1e9)
fs = pycbc.strain.strain.execute_cached_fft(ts)
print(ts._epoch, fs._epoch)
```
which prints:
```
1000000000 0
```
