### PR TITLE
Sort all quantities consistently in grb_inj_finder

### DIFF
--- a/bin/pygrb/pycbc_grb_inj_finder
+++ b/bin/pygrb/pycbc_grb_inj_finder
@@ -268,9 +268,9 @@ with tqdm.tqdm(args.inj_files, desc="Finding injections",
         # read triggers
         triggers = read_hdf5_triggers(trigfiles)
         time = triggers['network/end_time_gc']
-        snr = triggers['network/'+args.rank_column]
-        event_id = triggers['network/event_id']
         time_sorting = time.argsort()
+        snr = triggers['network/'+args.rank_column][time_sorting]
+        event_id = triggers['network/event_id'][time_sorting]
 
         # determine found or missed
         _left = numpy.searchsorted(


### PR DESCRIPTION
## Standard information about the request

This is a: bug fix.

This change affects: PyGRB.

This change changes: result presentation / plotting, scientific output.

## Motivation
The PyGRB workflows were showing inconsistent injection results in the output pages:
1. Network power chi-squares looked erratic
![H1L1-PYGRB_PLOT_CHISQ_VETO_NETWORK_NSBH_GRB170728A-1185258293-5648](https://github.com/gwastro/pycbc/assets/11437405/83886459-24ff-4fc3-a790-072bb520d5c0)

2. Differences between injection and recovery times were scattered all over the analysis time (for both injection sets used; the axes are in seconds)
![dt](https://github.com/gwastro/pycbc/assets/11437405/956203eb-ace3-4ea0-84ad-89651fa9f3cb)

3. Recovered chirp mass values were incompatible with the injected values.

[Here](https://ldas-jobs.ligo.caltech.edu/~francesco.pannarale/LVC/GRB170728A_may2024_test2/) is a webpage with these, but I will not keep it much longer at this point.

## Contents
`pycbc_grb_inj_finder` was sorting timing information, extracting indices with `argsort` based on such sorted array and using them on other two arrays that had not been sorted the same way.  These contain the SNR (coherent, reweghited, ..., it is a user choice) and the event_ids.  This meant that the incorrect event_id was associated to each found injection, causing the issues in plots and tables outlined above.  The fix is to simply sort the SNR and event_id arrays as the timing one, prior to using the argsorted indices on them.

## Testing performed
Here is a plot of the same chi square after the fix.
![H1L1-PYGRB_PLOT_CHISQ_VETO_NETWORK_NSBH_GRB170728A-1185258293-5648-1](https://github.com/gwastro/pycbc/assets/11437405/043fb35a-ef16-4c21-8047-5449b007bbf4)

It is taken from the [regenerated version of the webpage](https://ldas-jobs.ligo.caltech.edu/~francesco.pannarale/LVC/GRB170728A_may2024_test2_rerank/) for the example linked above.

Finally, a plot of the time differences (injected - recovered) for the two injection sets in this specific run.
![dt-1](https://github.com/gwastro/pycbc/assets/11437405/093f98b5-947d-41cc-9b99-94d68ed9c332)

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
