### PR TITLE
Hfile pycbc version information check

### DIFF
--- a/bin/all_sky_search/pycbc_add_statmap
+++ b/bin/all_sky_search/pycbc_add_statmap
@@ -3,10 +3,11 @@
 with more than one ifo combination available. Cluster to keep foreground
 coincs with the highest stat value.
 """
-import h5py, numpy as np, argparse, logging, pycbc, pycbc.events, pycbc.io
+import numpy as np, argparse, logging, pycbc, pycbc.events, pycbc.io
 import pycbc.version
 import pycbc.conversions as conv
 from pycbc.events import coinc, significance
+from pycbc.io import HFile
 from ligo import segments
 import sys, copy
 
@@ -91,9 +92,9 @@ else :
 
 pycbc.init_logging(args.verbose)
 
-files = [h5py.File(n, 'r') for n in args.statmap_files]
+files = [HFile(n, 'r') for n in args.statmap_files]
 
-f = h5py.File(args.output_file, "w")
+f = HFile(args.output_file, "w")
 
 # Work out the combinations of detectors used by each input file
 all_ifo_combos = []
@@ -308,7 +309,7 @@ if injection_style:
     # if background files are provided, this is being used for injections
     # use provided background files to calculate the FARs
     for bg_fname in args.background_files:
-        bg_f = h5py.File(bg_fname, 'r')
+        bg_f = HFile(bg_fname, 'r')
         ifo_combo_key = bg_f.attrs['ifos'].replace(' ','')
         _, far[ifo_combo_key] = significance.get_far(
                 bg_f['background/stat'][:],

--- a/pycbc/io/hdf.py
+++ b/pycbc/io/hdf.py
@@ -42,7 +42,7 @@ class HFile(h5py.File):
             # Check the pycbc version in the file matches the current one
             if 'pycbc_version' in self.attrs:
                 if not self.attrs['pycbc_version'] == pycbc_version:
-                    logging.warning(
+                    logging.info(
                         "PyCBC version of the file (%s) does not match the "
                         "one currently being used (%s). Results may not be "
                         "as expected.",

--- a/pycbc/io/hdf.py
+++ b/pycbc/io/hdf.py
@@ -31,12 +31,12 @@ class HFile(h5py.File):
     """ Low level extensions to the capabilities of reading an hdf5 File
     """
     def __init__(
-            self,
-            filename,
-            permission='r',
-            check_pycbc_version=True,
-            **kwargs
-        ):
+        self,
+        filename,
+        permission='r',
+        check_pycbc_version=True,
+        **kwargs
+    ):
         h5py.File.__init__(self, filename, permission, **kwargs)
         if permission in ['r','r+', 'a'] and check_pycbc_version:
             # Check the pycbc version in the file matches the current one
@@ -54,17 +54,16 @@ class HFile(h5py.File):
                 original_version = self.attrs['pycbc_version'] \
                     if 'pycbc_version' in self.attrs else 'None'
                 if original_version != 'None' and not \
-                    original_version == pycbc_version:
-                        # Read/write on the file - update the pycbc version,
-                        # but warn
-                        logging.warning(
-                            "File opened with read and write permissions, "
-                            "updating pycbc_version from %s to %s.",
-                            original_version,
-                            pycbc_version
-                        )
+                        original_version == pycbc_version:
+                    # Read/write on the file - update the pycbc version,
+                    # but warn
+                    logging.warning(
+                        "File opened with read and write permissions, "
+                        "updating pycbc_version from %s to %s.",
+                        original_version,
+                        pycbc_version
+                    )
             self.attrs['pycbc_version'] = pycbc_version
-
 
     def select(self, fcn, *args, chunksize=10**6, derived=None, group='',
                return_data=True, premask=None):


### PR DESCRIPTION
Add a `pycbc_version` attribute when opening a HFile to write, and check that it exists/matches when opening for reading.

## Standard information about the request

This is a new feature
This change (can) affect all codes which use h5py input/output, if wanted
This changes warnings seen when running the code, no scientific content or results plotting will be affected

This change follows style guidelines (See e.g. [PEP8](https://peps.python.org/pep-0008/)), has been proposed using the [contribution guidelines](https://github.com/gwastro/pycbc/blob/master/CONTRIBUTING.md)

I can add unit tests if desired

This change will warn when different versions of PyCBC are being used

## Motivation
When the code changes, there are (sometimes unwitting) differences in how the files from the code are output/input. This just adds a warning to the user to be wary of that.

## Contents
When a HFile object is opened, the file read/write permission will be used to determine whether or not to check / update the `pycbc_version` attribute.

 - If this version does not match the one being used, a warning is shown.
 - If using append permission, the version is changed, and a warning is shown


## Testing performed
Tested each case (same / different versions, and unversioned files), and the correct warnings are given each time. 
Tested that the permissions are carried through to the underlying h5py.File, and appropriate errors are raised.


- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
