### PR TITLE
Use a (reduced) hash for checking if files are the same in resolve_url

### DIFF
--- a/bin/minifollowups/pycbc_upload_prep_minifollowup
+++ b/bin/minifollowups/pycbc_upload_prep_minifollowup
@@ -95,13 +95,19 @@ insp_data_seglists = {}
 insp_analysed_seglists = {}
 for ifo in args.single_detector_triggers:
     strig_fname = args.single_detector_triggers[ifo]
-    strig_file = resolve_url_to_file(os.path.abspath(strig_fname),
-                                     attrs={'ifos': ifo})
+    strig_file = resolve_url_to_file(
+        os.path.abspath(strig_fname),
+        attrs={'ifos': ifo},
+        hash_bytes=int(1e6)
+    )
     single_triggers.append(strig_file)
 
     psd_fname = args.psd_files[ifo]
-    psd_file = resolve_url_to_file(os.path.abspath(psd_fname),
-                                     attrs={'ifos': ifo})
+    psd_file = resolve_url_to_file(
+        os.path.abspath(psd_fname),
+        attrs={'ifos': ifo},
+        hash_bytes=int(1e6)
+    )
     psd_files.append(psd_file)
 
     fsdt[ifo] = h5py.File(args.single_detector_triggers[ifo], 'r')

--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -2080,7 +2080,7 @@ class CalledProcessErrorMod(Exception):
         return msg
 
 
-def resolve_url_to_file(curr_pfn, attrs=None):
+def resolve_url_to_file(curr_pfn, attrs=None, hash_bytes=None):
     """
     Resolves a PFN into a workflow.File object.
 
@@ -2122,7 +2122,7 @@ def resolve_url_to_file(curr_pfn, attrs=None):
         curr_file = file_input_from_config_dict[curr_lfn][1]
     else:
         # Use resolve_url to download file/symlink as appropriate
-        local_file_path = resolve_url(curr_pfn)
+        local_file_path = resolve_url(curr_pfn, hash_bytes=hash_bytes)
         # Create File object with default local path
         curr_file = File.from_path(local_file_path, attrs=attrs)
 


### PR DESCRIPTION
Currently the resolve_url function uses os.stat to check whether files are already in the resolved location or not.

However the check uses os.stat, which does not work for copies of files, as the CAM times will be different

This uses a hash of the files instead, cut down to the first 1e7 bytes by default, to compare the files instead. This means we are more able to meet the conditions required to invoke the no-op.

The cut to use the first 1e7 bytes is because that seems to be safe rather than loading entire files of e.g. HDF_TRIGGER_MERGE files.

## Standard information about the request

This is a bug fix to an efficiency saving
This change affects all code areas which use workflow generation

This change follows style guidelines (See e.g. [PEP8](https://peps.python.org/pep-0008/)), has been proposed using the [contribution guidelines](https://github.com/gwastro/pycbc/blob/master/CONTRIBUTING.md)

## Motivation
The no-op shortcut which had been intended when the local file already exists in the `resolve_url` function was not being used, this allows it to be implemented.

## Contents
Change the os.stat() call to check if files are the same to use a reduced hash of the files

## Testing performed
minifollowup creation script run when file has already been copied to the cwd - this did not attempt to copy the file

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
