### PR TITLE
Revert Git lfs clone protection workaround

### DIFF
--- a/.github/workflows/basic-tests.yml
+++ b/.github/workflows/basic-tests.yml
@@ -28,7 +28,7 @@ jobs:
         pip install "tox<4.0.0" pip setuptools --upgrade
     - name: installing auxiliary data files
       run: |
-        GIT_CLONE_PROTECTION_ACTIVE=false GIT_LFS_SKIP_SMUDGE=1 git clone https://git.ligo.org/lscsoft/lalsuite-extra
+        GIT_LFS_SKIP_SMUDGE=1 git clone https://git.ligo.org/lscsoft/lalsuite-extra
         cd lalsuite-extra
         git lfs pull -I "data/lalsimulation/SEOBNRv2ROM_*.dat"
         git lfs pull -I "data/lalsimulation/*ChirpTime*.dat"

--- a/tools/install_travis.sh
+++ b/tools/install_travis.sh
@@ -28,7 +28,7 @@ chmod +x $p
 
 # LAL extra data files
 # FIXME, should be a way to make reduced package (with subset of data files)
-GIT_CLONE_PROTECTION_ACTIVE=false GIT_LFS_SKIP_SMUDGE=1 git clone https://git.ligo.org/lscsoft/lalsuite-extra
+GIT_LFS_SKIP_SMUDGE=1 git clone https://git.ligo.org/lscsoft/lalsuite-extra
 cd lalsuite-extra
 git lfs pull -I "data/lalsimulation/SEOBNRv2ROM_*.dat"
 git lfs pull -I "data/lalsimulation/*ChirpTime*.dat"


### PR DESCRIPTION
## Standard information about the request
This change affects continuous integration
This change has been proposed using the [contribution guidelines](https://github.com/gwastro/pycbc/blob/master/CONTRIBUTING.md)

## Contents
Revert the changes in #4755 

## Links to any issues or associated PRs
https://github.com/gwastro/pycbc/pull/4755
https://github.com/git-lfs/git-lfs/issues/5749

## Testing performed
Tests are in the CI

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
