### PR TITLE
Use pycbc conversions as single source of truth for converting seconds and years

### DIFF
--- a/bin/all_sky_search/pycbc_sngls_statmap
+++ b/bin/all_sky_search/pycbc_sngls_statmap
@@ -271,7 +271,7 @@ else :
 #          above the set threshold, or a set maximum.
 
 # Convert threshold into seconds
-hier_ifar_thresh_s = args.hierarchical_removal_ifar_threshold \
+hier_ifar_thresh_s = args.hierarchical_removal_ifar_threshold /  \
     conv.sec_to_year(1)
 
 while numpy.any(ifar_louder > hier_ifar_thresh_s):

--- a/bin/all_sky_search/pycbc_sngls_statmap
+++ b/bin/all_sky_search/pycbc_sngls_statmap
@@ -6,7 +6,7 @@ with producing the combined foreground and background triggers.
 """
 
 import argparse, h5py, itertools
-import lal, logging, numpy, copy
+import logging, numpy, copy
 from pycbc.events import veto, coinc
 from pycbc.events import triggers, trigger_fits as trstats
 from pycbc.events import significance
@@ -271,7 +271,8 @@ else :
 #          above the set threshold, or a set maximum.
 
 # Convert threshold into seconds
-hier_ifar_thresh_s = args.hierarchical_removal_ifar_threshold * lal.YRJUL_SI
+hier_ifar_thresh_s = args.hierarchical_removal_ifar_threshold \
+    conv.sec_to_year(1)
 
 while numpy.any(ifar_louder > hier_ifar_thresh_s):
     # If the user wants to stop doing hierarchical removals after a set

--- a/bin/plotting/pycbc_page_ifar
+++ b/bin/plotting/pycbc_page_ifar
@@ -19,13 +19,13 @@ import argparse
 import h5py
 import numpy
 import sys
-import lal
 import matplotlib as mpl; mpl.use('Agg')
 import pylab
 import pycbc.results
 import pycbc.version
 import copy
 from pycbc.events import veto
+from pycbc import conversions as conv
 from ligo import segments
 
 def calculate_time_slide_duration(pifo_segments, fifo_segments, offset=0):
@@ -151,7 +151,7 @@ if opts.open_box:
 
 # get expected foreground IFAR values and cumulative number for each IFAR value
 expected_ifar = numpy.logspace(-8, 2, num=100, endpoint=True, base=10.0)
-expected_cumnum = fp.attrs['foreground_time'] / expected_ifar / lal.YRJUL_SI 
+expected_cumnum = conv.sec_to_year(fp.attrs['foreground_time'] / expected_ifar)
 
 # get background timeslide IDs and IFAR values
 

--- a/bin/plotting/pycbc_page_sensitivity
+++ b/bin/plotting/pycbc_page_sensitivity
@@ -6,7 +6,7 @@ matplotlib.use('Agg')
 from matplotlib.pyplot import cm
 import pylab, pycbc.pnutils, pycbc.results, pycbc, pycbc.version
 from pycbc import sensitivity
-from lal import YRJUL_SI as lal_YRJUL_SI
+from pycbc import conversions as conv
 
 parser = argparse.ArgumentParser(description=__doc__)
 parser.add_argument('--version', action='version', version=pycbc.version.git_verbose_msg)
@@ -185,7 +185,7 @@ for fi in args.injection_file:
 
         # Time in years
         if args.dist_type == 'vt':
-            t += f.attrs['foreground_time_exc'] / lal_YRJUL_SI
+            t += conv.sec_to_year(f.attrs['foreground_time_exc'])
 
 # Parameter bin legend labels
 labels = {

--- a/bin/plotting/pycbc_page_snrifar
+++ b/bin/plotting/pycbc_page_snrifar
@@ -3,10 +3,11 @@
     ranking statistic, or make statistical significance vs ranking statistic
     cumulative histograms. 
 """
-import argparse, h5py, numpy, logging, sys, lal
+import argparse, h5py, numpy, logging, sys
 import matplotlib
 matplotlib.use('Agg')
 import pylab, pycbc.results, pycbc.version
+from pycbc import conversions as conv
 from scipy.special import erfc, erfinv
 
 def sigma_from_p(p):
@@ -126,13 +127,13 @@ if h_inc_back_num > h_iterations:
 
 args.cumulative = not args.not_cumulative
 
-foreground_livetime = f.attrs['foreground_time'] / lal.YRJUL_SI
+foreground_livetime = conv.sec_to_year(f.attrs['foreground_time'])
 try:
     
     if args.cumulative:
         cstat_fore = f['foreground/stat'][:]
         cstat_fore.sort()
-        cstat_rate = numpy.arange(len(cstat_fore), 0, -1) / f.attrs['foreground_time'] * lal.YRJUL_SI
+        cstat_rate = numpy.arange(len(cstat_fore), 0, -1) / foreground_livetime
         fap_end = f['foreground/fap'][:].min() * args.trials_factor
     else:
         cstat_fore = f['foreground/stat'][:]

--- a/bin/plotting/pycbc_page_snrratehist
+++ b/bin/plotting/pycbc_page_snrratehist
@@ -145,31 +145,19 @@ histpeak = bins[exc_binvals[0].argmax()]
 
 # plot full background
 if not args.closed_box:
-    if h_inc_back_num == 0:
-        binweights = dec / conv.sec_to_year(f.attrs['background_time'])
-        pylab.hist(
-            bstat,
-            bins=bins,
-            histtype='step',
-            linewidth=2,
-            color='black',
-            log=True,
-            label='Full Background',
-            weights=binweights
-        )
-    else :
-        bg_time_sec = f.attrs['background_time_h%s' % h_inc_back_num]
-        binweights = dec / conv.sec_to_year(bg_time_sec)
-        pylab.hist(
-            bstat,
-            bins=bins,
-            histtype='step',
-            linewidth=2,
-            color='black',
-            log=True,
-            label='Full Background',
-            weights=binweights
-        )
+    bg_key = 'background_time' if h_inc_back_num == 0 \
+        else 'background_time_h%s' % h_inc_back_num
+    binweights = dec / conv.sec_to_year(f.attrs[bg_key])
+    pylab.hist(
+        bstat,
+        bins=bins,
+        histtype='step',
+        linewidth=2,
+        color='black',
+        log=True,
+        label='Full Background',
+        weights=binweights
+    )
 
 if fstat is not None and not args.closed_box:
     le, re = bins[:-1], bins[1:]

--- a/bin/plotting/pycbc_page_snrratehist
+++ b/bin/plotting/pycbc_page_snrratehist
@@ -3,10 +3,11 @@
     Also has the ability to plot inclusive backgrounds from different stages
     of hierarchical removal.
 """
-import argparse, h5py, numpy, logging, sys, lal
+import argparse, h5py, numpy, logging, sys
 import matplotlib
 matplotlib.use('Agg')
 import pylab, pycbc.results, pycbc.version
+from pycbc import conversions as conv
 from scipy.special import erf, erfinv
 
 def sigma_from_p(p):
@@ -98,11 +99,11 @@ else:
 
 if h_inc_back_num == 0:
     bstat = f['background/stat'][:]
-    fap = 1 - numpy.exp(- f.attrs['foreground_time'] / f['background/ifar'][:] / lal.YRJUL_SI)
+    fap = 1 - numpy.exp(- conv.sec_to_year(f.attrs['foreground_time']) / f['background/ifar'][:])
     dec = f['background/decimation_factor'][:]
 else :
     bstat = f['background_h%s/stat' % h_inc_back_num][:]
-    fap = 1 - numpy.exp(- f.attrs['foreground_time_h%s' % h_inc_back_num] / f['background_h%s/ifar' % h_inc_back_num][:] / lal.YRJUL_SI)
+    fap = 1 - numpy.exp(- conv.sec_to_year(f.attrs['foreground_time_h%s' % h_inc_back_num]) / f['background_h%s/ifar' % h_inc_back_num][:])
     dec = f['background_h%s/decimation_factor' % h_inc_back_num][:]
 
 s = bstat.argsort()
@@ -133,7 +134,7 @@ bin_size = args.bin_size if args.bin_size else (maximum - minimum) / 100.
 bins = numpy.arange(minimum, maximum + bin_size, bin_size)
 
 # plot background minus foreground
-exc_binweights = dec_exc / f.attrs['background_time_exc'] * lal.YRJUL_SI
+exc_binweights = dec_exc / conv.sec_to_year(f.attrs['background_time_exc'])
 exc_binvals = pylab.hist(bstat_exc, bins=bins, histtype='step',
                          linewidth=2,
                          color='grey', log=True,
@@ -145,17 +146,27 @@ histpeak = bins[exc_binvals[0].argmax()]
 # plot full background
 if not args.closed_box:
     if h_inc_back_num == 0:
-        pylab.hist(bstat, bins=bins, histtype='step',
-                   linewidth=2,
-                   color='black', log=True,
-                   label='Full Background',
-                   weights=dec / f.attrs['background_time'] * lal.YRJUL_SI)
+        pylab.hist(
+            bstat,
+            bins=bins,
+            histtype='step',
+            linewidth=2,
+            color='black',
+            log=True,
+            label='Full Background',
+            weights=dec / conv.sec_to_year(f.attrs['background_time'])
+        )
     else :
-        pylab.hist(bstat, bins=bins, histtype='step',
-                   linewidth=2,
-                   color='black', log=True,
-                   label='Full Background',
-                   weights=dec / f.attrs['background_time_h%s' % h_inc_back_num] * lal.YRJUL_SI)
+        pylab.hist(
+            bstat,
+            bins=bins,
+            histtype='step',
+            linewidth=2,
+            color='black',
+            log=True,
+            label='Full Background',
+            weights=dec / conv.sec_to_year(f.attrs['background_time_h%s' % h_inc_back_num])
+        )
 
 if fstat is not None and not args.closed_box:
     le, re = bins[:-1], bins[1:]
@@ -184,13 +195,12 @@ if fstat is not None and not args.closed_box:
         # before h-removal.
         if h_inc_back_num == 0:
             count_h_rm = (right_h_rm - left_h_rm) / \
-                         f.attrs['foreground_time'] * lal.YRJUL_SI
+                         conv.sec_to_year(f.attrs['foreground_time'])
 
         # Or use the foreground time after h-removal
         else:
             count_h_rm = (right_h_rm - left_h_rm) / \
-                         f.attrs['foreground_time_h%s' % h_inc_back_num] * \
-                         lal.YRJUL_SI
+                         conv.sec_to_year(f.attrs['foreground_time_h%s' % h_inc_back_num])
 
         pylab.errorbar(bins[:-1] + bin_size / 2, count_h_rm,
                        xerr=bin_size/2,
@@ -200,7 +210,7 @@ if fstat is not None and not args.closed_box:
 
     left = numpy.searchsorted(fstat, le)
     right = numpy.searchsorted(fstat, re)
-    count = (right - left) / f.attrs['foreground_time'] * lal.YRJUL_SI
+    count = (right - left) / conv.sec_to_year(f.attrs['foreground_time'])
     pylab.errorbar(bins[:-1] + bin_size / 2, count, xerr=bin_size/2,
                    label='Foreground', mec='none', fmt='o', ms=1, capthick=0,
                    elinewidth=4,  color='#ff6600')
@@ -211,7 +221,7 @@ if args.x_min is not None:
     pylab.xlim(xmin=args.x_min)
 else:
     pylab.xlim(xmin=numpy.floor(histpeak))
-pylab.ylim(ymin=0.5 / f.attrs['background_time_exc'] * lal.YRJUL_SI)
+pylab.ylim(ymin=0.5 / conv.sec_to_year(f.attrs['background_time_exc']))
 pylab.grid()
 leg = pylab.legend(fontsize=9)
 
@@ -254,9 +264,9 @@ ax1 =  pylab.gca()
 ax2 = ax1.twinx()
 
 if h_inc_back_num == 0:
-    fac = f.attrs['foreground_time'] / lal.YRJUL_SI
+    fac = conv.sec_to_year(f.attrs['foreground_time'])
 else :
-    fac = f.attrs['foreground_time_h%s' % h_inc_back_num] / lal.YRJUL_SI
+    fac = conv.sec_to_year(f.attrs['foreground_time_h%s' % h_inc_back_num])
 
 ymin = ax1.get_ylim()[0] * fac
 ymax =  ax1.get_ylim()[1] * fac

--- a/bin/plotting/pycbc_page_snrratehist
+++ b/bin/plotting/pycbc_page_snrratehist
@@ -146,6 +146,7 @@ histpeak = bins[exc_binvals[0].argmax()]
 # plot full background
 if not args.closed_box:
     if h_inc_back_num == 0:
+        binweights = dec / conv.sec_to_year(f.attrs['background_time'])
         pylab.hist(
             bstat,
             bins=bins,
@@ -154,9 +155,11 @@ if not args.closed_box:
             color='black',
             log=True,
             label='Full Background',
-            weights=dec / conv.sec_to_year(f.attrs['background_time'])
+            weights=binweights
         )
     else :
+        bg_time_sec = f.attrs['background_time_h%s' % h_inc_back_num]
+        binweights = dec / conv.sec_to_year(bg_time_sec)
         pylab.hist(
             bstat,
             bins=bins,
@@ -165,7 +168,7 @@ if not args.closed_box:
             color='black',
             log=True,
             label='Full Background',
-            weights=dec / conv.sec_to_year(f.attrs['background_time_h%s' % h_inc_back_num])
+            weights=binweights
         )
 
 if fstat is not None and not args.closed_box:

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -44,6 +44,7 @@ from pycbc.filter import resample
 from pycbc.psd import estimate
 from pycbc.psd import variation
 from pycbc.live import snr_optimizer
+from pycbc import conversions as conv
 
 # Use cached class-based FFTs in the resample and estimate module
 resample.USE_CACHING_FOR_LFILTER = True
@@ -1194,7 +1195,7 @@ with ctx:
 
         def output_background(_):
             estim = estimators[my_coinc_id]
-            bg_time = estim.background_time / lal.YRJUL_SI
+            bg_time = conv.sec_to_year(estim.background_time)
             return estim.ifos, estim.coincs.data, bg_time
 
         coinc_pool = BroadcastPool(len(estimators))

--- a/bin/pycbc_upload_xml_to_gracedb
+++ b/bin/pycbc_upload_xml_to_gracedb
@@ -41,6 +41,7 @@ from pycbc.io.ligolw import LIGOLWContentHandler
 from pycbc.psd import interpolate
 from pycbc.types import FrequencySeries
 from pycbc.results import generate_asd_plot
+from pycbc import conversions as conv
 
 
 def check_gracedb_for_event(gdb_handle, query, far):
@@ -49,7 +50,7 @@ def check_gracedb_for_event(gdb_handle, query, far):
     which matches the FAR given
     """
     gdb_events_match_query = list(gdb_handle.events(query=query))
-    ifar = 1. / lal.YRJUL_SI / far
+    ifar = conv.sec_to_year(1. / far)
     for gdb_event in gdb_events_match_query:
         # Test each gracedb event to see if the FAR matches this event
         if np.abs(gdb_event['far'] - far) < 1e-16:
@@ -158,7 +159,7 @@ for event in coinc_table:
             coinc_inspiral_table_curr.append(coinc_insp)
 
     if args.min_ifar is not None and \
-            coinc_inspiral_table_curr[0].combined_far > 1./args.min_ifar/lal.YRJUL_SI:
+            coinc_inspiral_table_curr[0].combined_far > conv.sec_to_year(1. / args.min_ifar):
         continue
 
     time = coinc_inspiral_table_curr[0].end_time

--- a/bin/pycbc_upload_xml_to_gracedb
+++ b/bin/pycbc_upload_xml_to_gracedb
@@ -159,7 +159,7 @@ for event in coinc_table:
             coinc_inspiral_table_curr.append(coinc_insp)
 
     if args.min_ifar is not None and \
-            coinc_inspiral_table_curr[0].combined_far > conv.sec_to_year(1. / args.min_ifar):
+            conv.sec_to_year(1. / coinc_inspiral_table_curr[0].combined_far) < args.min_ifar:  # event IFAR is smaller than the minimum
         continue
 
     time = coinc_inspiral_table_curr[0].end_time

--- a/pycbc/events/coinc.py
+++ b/pycbc/events/coinc.py
@@ -25,7 +25,7 @@
 coincident triggers.
 """
 
-import numpy, logging, pycbc.pnutils, pycbc.conversions, copy, lal
+import numpy, logging, pycbc.pnutils, pycbc.conversions, copy
 from pycbc.detector import Detector, ppdets
 from pycbc.conversions import mchirp_from_mass1_mass2
 from .eventmgr_cython import coincbuffer_expireelements
@@ -878,7 +878,7 @@ class LiveCoincTimeslideBackgroundEstimator(object):
         if len(self.ifos) != 2:
             raise ValueError("Only a two ifo analysis is supported at this time")
 
-        self.lookback_time = (ifar_limit * lal.YRJUL_SI * timeslide_interval) ** 0.5
+        self.lookback_time = (ifar_limit / conv.sec_to_year(1.) * timeslide_interval) ** 0.5
         self.buffer_size = int(numpy.ceil(self.lookback_time / analysis_block))
 
         self.dets = {ifo: Detector(ifo) for ifo in ifos}
@@ -1034,7 +1034,7 @@ class LiveCoincTimeslideBackgroundEstimator(object):
             in which case `ifar` is to be considered an upper limit.
         """
         n = self.coincs.num_greater(coinc_stat)
-        ifar = self.background_time / lal.YRJUL_SI / (n + 1)
+        ifar = conv.sec_to_year(self.background_time) / (n + 1)
         return ifar, n == 0
 
     def set_singles_buffer(self, results):

--- a/pycbc/events/coinc.py
+++ b/pycbc/events/coinc.py
@@ -25,9 +25,9 @@
 coincident triggers.
 """
 
-import numpy, logging, pycbc.pnutils, pycbc.conversions, copy
+import numpy, logging, pycbc.pnutils, copy
 from pycbc.detector import Detector, ppdets
-from pycbc.conversions import mchirp_from_mass1_mass2
+from pycbc import conversions as conv
 from .eventmgr_cython import coincbuffer_expireelements
 from .eventmgr_cython import coincbuffer_numgreater
 from .eventmgr_cython import timecoincidence_constructidxs
@@ -91,14 +91,19 @@ def background_bin_from_string(background_bins, data):
                 vals = pycbc.pnutils.mass1_mass2_to_mchirp_eta(
                                                    data['mass1'], data['mass2'])[0]
             elif bin_type == 'ratio':
-                vals = pycbc.conversions.q_from_mass1_mass2(
-                                                   data['mass1'], data['mass2'])
+                vals = conv.q_from_mass1_mass2(data['mass1'], data['mass2'])
             elif bin_type == 'eta':
                 vals = pycbc.pnutils.mass1_mass2_to_mchirp_eta(
-                                                   data['mass1'], data['mass2'])[1]
+                    data['mass1'],
+                    data['mass2']
+                )[1]
             elif bin_type == 'chi_eff':
-                vals = pycbc.conversions.chi_eff(data['mass1'], data['mass2'],
-                                                 data['spin1z'], data['spin2z'])
+                vals = conv.chi_eff(
+                    data['mass1'],
+                    data['mass2'],
+                    data['spin1z'],
+                    data['spin2z']
+                )
             elif bin_type.endswith('Peak'):
                 vals = pycbc.pnutils.get_freq(
                     'f' + bin_type,
@@ -1175,7 +1180,7 @@ class LiveCoincTimeslideBackgroundEstimator(object):
             # Find newly added triggers in fixed_ifo
             trigs = results[fixed_ifo]
             # Calculate mchirp as a vectorized operation
-            mchirps = mchirp_from_mass1_mass2(
+            mchirps = conv.mchirp_from_mass1_mass2(
                 trigs['mass1'], trigs['mass2']
             )
             # Loop over them one trigger at a time

--- a/pycbc/events/significance.py
+++ b/pycbc/events/significance.py
@@ -28,9 +28,9 @@ read in the associated options to do so.
 """
 import logging
 import copy
-import lal
 import numpy as np
 from pycbc.events import trigger_fits as trstats
+from pycbc import conversions as conv
 
 logger = logging.getLogger('pycbc.events.significance')
 

--- a/pycbc/events/significance.py
+++ b/pycbc/events/significance.py
@@ -367,7 +367,7 @@ def ifar_opt_to_far_limit(ifar_str):
     """
     ifar_float = positive_float(ifar_str)
 
-    far_hz = 0. if (ifar_float == 0.) else 1. / (lal.YRJUL_SI * ifar_float)
+    far_hz = 0. if (ifar_float == 0.) else conv.sec_to_year(1. / ifar_float)
 
     return far_hz
 

--- a/pycbc/io/hdf.py
+++ b/pycbc/io/hdf.py
@@ -10,7 +10,7 @@ import pickle
 
 from itertools import chain
 from io import BytesIO
-from lal import LIGOTimeGPS, YRJUL_SI
+from lal import LIGOTimeGPS
 
 from ligo.lw import ligolw
 from ligo.lw import lsctables
@@ -1228,7 +1228,7 @@ class ForegroundTriggers(object):
             coinc_inspiral_row.combined_far = 1./coinc_event_vals['ifar'][idx]
             # Transform to Hz
             coinc_inspiral_row.combined_far = \
-                                    coinc_inspiral_row.combined_far / YRJUL_SI
+                conversions.sec_to_year(coinc_inspiral_row.combined_far)
             coinc_event_row.likelihood = coinc_event_vals['stat'][idx]
             coinc_inspiral_row.minimum_duration = 0.
             coinc_event_table.append(coinc_event_row)

--- a/pycbc/population/live_pastro.py
+++ b/pycbc/population/live_pastro.py
@@ -1,10 +1,11 @@
 import logging
 import h5py
 import numpy
-from lal import YRJUL_SI as lal_s_per_yr
 from pycbc.tmpltbank import bank_conversions as bankconv
 from pycbc.events import triggers
 from . import fgmc_functions as fgmcfun
+
+_s_per_yr = 1. / conv.sec_to_year(1.)
 
 
 def check_template_param_bin_data(spec_json):
@@ -177,7 +178,7 @@ def template_param_bin_pa(padata, trdata, horizons):
         expfac = padata.spec['bg_fac']
 
     # FAR is in Hz, therefore convert to rate per year (per SNR)
-    dnoise = noise_density_from_far(trdata['far'], expfac) * lal_s_per_yr
+    dnoise = noise_density_from_far(trdata['far'], expfac) * _s_per_yr
     logging.debug('FAR %.3g, noise density per yr per SNR %.3g',
                   trdata['far'], dnoise)
     # Scale by fraction of templates in bin
@@ -231,7 +232,7 @@ def template_param_bin_types_pa(padata, trdata, horizons):
     tr_ifos = trdata['triggered']
 
     # FAR is in Hz, therefore convert to rate per year (per SNR)
-    dnoise = noise_density_from_far(trdata['far'], expfac) * lal_s_per_yr
+    dnoise = noise_density_from_far(trdata['far'], expfac) * _s_per_yr
     logging.debug('FAR %.3g, noise density per yr per SNR %.3g',
                   trdata['far'], dnoise)
     # Scale by fraction of templates in bin

--- a/pycbc/population/live_pastro.py
+++ b/pycbc/population/live_pastro.py
@@ -1,6 +1,7 @@
 import logging
 import h5py
 import numpy
+from pycbc import conversions as conv
 from pycbc.tmpltbank import bank_conversions as bankconv
 from pycbc.events import triggers
 from . import fgmc_functions as fgmcfun

--- a/test/test_significance_module.py
+++ b/test/test_significance_module.py
@@ -4,10 +4,10 @@ import unittest
 import argparse
 import itertools
 import copy
-import lal
 import numpy as np
 from utils import simple_exit
 from pycbc.events import significance
+from pycbc import conversions as conv
 
 def parse_args(args):
     # Helper function to convert a list of flags/options into
@@ -122,7 +122,7 @@ test_dict['H1L1']['fit_threshold'] = 6
 test_dict['H1']['fit_threshold'] = 5.5
 test_dict['L1']['fit_threshold'] = 5
 test_dict['H1L1']['far_limit'] = 0
-test_dict['H1']['far_limit'] = 1. / lal.YRJUL_SI
+test_dict['H1']['far_limit'] = conv.sec_to_year(1.)
 test_dict['L1']['far_limit'] = 0
 
 calc_methods = ['H1L1:trigger_fit', 'H1:trigger_fit', 'L1:trigger_fit']


### PR DESCRIPTION
Use the pycbc conversions sec_to_year function throughout so that there is a single source of truth for the conversion of seconds and years, and we dont call into lal for YRJUL_SI so much

## Motivation
Solve #2885

## Contents
Whenever the previous constant was being used, use the conversion function instead

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
