### PR TITLE
Versioning page in workflows

### DIFF
--- a/bin/workflows/pycbc_make_inference_inj_workflow
+++ b/bin/workflows/pycbc_make_inference_inj_workflow
@@ -30,7 +30,6 @@ from pycbc import __version__
 from pycbc import results
 from pycbc.results import layout
 from pycbc.results import metadata
-from pycbc.results import versioning
 from pycbc.workflow import configuration
 from pycbc.workflow import core
 from pycbc.workflow.jobsetup import (PycbcCreateInjectionsExecutable,

--- a/bin/workflows/pycbc_make_psd_estimation_workflow
+++ b/bin/workflows/pycbc_make_psd_estimation_workflow
@@ -189,6 +189,15 @@ result_plots += [(seg_summ_table,)]
 
 two_column_layout('plots', result_plots)
 
+
+# Create versioning information
+pycbc.workflow.make_versioning_page(
+    workflow,
+    container.cp,
+    rdir['workflow/version'],
+)
+
+
 pycbc.workflow.make_results_web_page(finalize_workflow,
                                      os.path.join(os.getcwd(),
                                      'plots'))

--- a/bin/workflows/pycbc_make_sbank_workflow
+++ b/bin/workflows/pycbc_make_sbank_workflow
@@ -384,4 +384,11 @@ for cycle_idx in range(num_cycles):
     seed_file = h5add_node.output_files[0]
     bins_inp_file = seed_file
 
+# Create versioning information
+wf.make_versioning_page(
+    workflow,
+    workflow.cp,
+    args.output_dir,
+)
+
 workflow.save()

--- a/bin/workflows/pycbc_make_uberbank_workflow
+++ b/bin/workflows/pycbc_make_uberbank_workflow
@@ -282,4 +282,11 @@ dax_job.set_subworkflow_properties(map_file,
 dax_job.add_inputs(*seed_files)
 dax_job.add_into_workflow(workflow)
 
+# Create versioning information
+wf.make_versioning_page(
+    workflow,
+    workflow.cp,
+    args.output_dir,
+)
+
 workflow.save()

--- a/docs/resources/sbank_example1.ini
+++ b/docs/resources/sbank_example1.ini
@@ -60,6 +60,7 @@ v1=
 sbank = ${which:lalapps_cbc_sbank}
 sbank_mchirp_bins = ${which:lalapps_cbc_sbank_hdf5_choose_mchirp_boundaries}
 h5add = ${which:lalapps_cbc_sbank_hdf5_bankcombiner}
+page_versioning = ${which:pycbc_page_versioning}
 
 ; Then options for all executables are added. These are added directly to the
 ; jobs as described here:
@@ -132,3 +133,5 @@ template-weight = equal
 
 [llwadd]
 ; Global llwadd options, if any, go here
+
+[page_versioning]

--- a/docs/resources/sbank_example2.ini
+++ b/docs/resources/sbank_example2.ini
@@ -60,6 +60,7 @@ v1=
 sbank = ${which:lalapps_cbc_sbank}
 sbank_mchirp_bins = ${which:lalapps_cbc_sbank_hdf5_choose_mchirp_boundaries}
 h5add = ${which:lalapps_cbc_sbank_hdf5_bankcombiner}
+page_versioning = ${which:pycbc_page_versioning}
 
 ; Then options for all executables are added. These are added directly to the
 ; jobs as described here:
@@ -204,3 +205,5 @@ template-weight = equal
 
 [llwadd]
 ; Global llwadd options, if any, go here
+
+[page_versioning]

--- a/docs/resources/uberbank_example1.ini
+++ b/docs/resources/uberbank_example1.ini
@@ -96,6 +96,7 @@ sbank_workflow = ${which:pycbc_make_sbank_workflow}
 sbank_mchirp_bins = ${which:lalapps_cbc_sbank_hdf5_choose_mchirp_boundaries}
 h5add = ${which:lalapps_cbc_sbank_hdf5_bankcombiner}
 geom_aligned_bank = ${which:pycbc_geom_aligned_bank}
+page_versioning = ${which:pycbc_page_versioning}
 
 ; Then options for all executables are added. These are added directly to the
 ; jobs as described here:
@@ -338,3 +339,5 @@ match-min = 0.95
 convergence-threshold = 50000
 max-new-templates = 20000000
 match-min = 0.95
+
+[page_versioning]

--- a/examples/faith/pegasus_workflow_conf.ini
+++ b/examples/faith/pegasus_workflow_conf.ini
@@ -120,8 +120,11 @@ parameter-x = inclination
 parameter-y = sigma2
 parameter-z = mchirp
 
+[page_versioning]
+
 [pegasus_profile]
 condor|accounting_group = ligo.dev.o4.cbc.uber.pycbcoffline
 condor|request_disk = 100000
 condor|request_memory = 2048
 pycbc|primary_site = condorpool_symlink
+

--- a/examples/faith/pegasus_workflow_conf.ini
+++ b/examples/faith/pegasus_workflow_conf.ini
@@ -120,11 +120,8 @@ parameter-x = inclination
 parameter-y = sigma2
 parameter-z = mchirp
 
-[page_versioning]
-
 [pegasus_profile]
 condor|accounting_group = ligo.dev.o4.cbc.uber.pycbcoffline
 condor|request_disk = 100000
 condor|request_memory = 2048
 pycbc|primary_site = condorpool_symlink
-

--- a/examples/tmpltbank/bank_workflow_test/test_uberbank.ini
+++ b/examples/tmpltbank/bank_workflow_test/test_uberbank.ini
@@ -99,6 +99,7 @@ sbank_workflow = ${which:pycbc_make_sbank_workflow}
 sbank_mchirp_bins = ${which:sbank_hdf5_choose_mchirp_boundaries}
 h5add = ${which:sbank_hdf5_bankcombiner}
 geom_aligned_bank = ${which:pycbc_geom_aligned_bank}
+page_versioning = ${which:pycbc_page_versioning}
 
 ; Then options for all executables are added. These are added directly to the
 ; jobs as described here:
@@ -256,3 +257,4 @@ match-min = 0.90
 ; BBH parallel and readder jobs, cycles 4 and 5
 match-min = 0.90
 
+[page_versioning]


### PR DESCRIPTION
Add the versioning page to a few workflows whihc did not save the information

## Standard information about the request

This is a fix to add version information

This change affects the bank generation workflows


This change follows style guidelines (See e.g. [PEP8](https://peps.python.org/pep-0008/)), has been proposed using the [contribution guidelines](https://github.com/gwastro/pycbc/blob/master/CONTRIBUTING.md)


## Motivation
Fix #2058

## Contents
Add the make_versioning_page to the psd_estimation, sbank and uberbank workflows


## Testing performed
Will run the appropriate workflows next, just getting this PR in first

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
