### PR TITLE
Use π phase shift to allow swap test for more modes

### DIFF
--- a/test/lalsim.py
+++ b/test/lalsim.py
@@ -324,10 +324,20 @@ class TestLALSimulation(unittest.TestCase):
         #"""
 
         hp, hc = get_waveform(self.p)
-        hpswap, hcswap = get_waveform(self.p, mass1=self.p.mass2, mass2=self.p.mass1,
-                spin1x=self.p.spin2x, spin1y=self.p.spin2y, spin1z=self.p.spin2z,
-                spin2x=self.p.spin1x, spin2y=self.p.spin1y, spin2z=self.p.spin1z,
-                lambda1=self.p.lambda2, lambda2=self.p.lambda1)
+        hpswap, hcswap = get_waveform(
+            self.p,
+            mass1=self.p.mass2,
+            mass2=self.p.mass1,
+            spin1x=self.p.spin2x,
+            spin1y=self.p.spin2y,
+            spin1z=self.p.spin2z,
+            spin2x=self.p.spin1x,
+            spin2y=self.p.spin1y,
+            spin2z=self.p.spin1z,
+            lambda1=self.p.lambda2,
+            lambda2=self.p.lambda1,
+            coa_phase=self.p.coa_phase + lal.PI
+        )
         op = overlap(hp, hpswap)
         self.assertAlmostEqual(1, op, places=7)
         oc = overlap(hc, hcswap)


### PR DESCRIPTION
I'm not sure on whether this is actually tested for higher-order modes, but the sanity checks of `test/lalsim.py` should use this π phase shift in order to work for anything except 2,±2

## Standard information about the request

This change affects the test suite

This change, follows style guidelines (See e.g. [PEP8](https://peps.python.org/pep-0008/)), has been proposed using the [contribution guidelines](https://github.com/gwastro/pycbc/blob/master/CONTRIBUTING.md)


## Motivation
#2126 

## Contents
Add a phase shift for the component swap test

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
