### PR TITLE
Draft: Start pushing tags to permanently-kept documentation pages

### DIFF
--- a/.github/workflows/basic-tests.yml
+++ b/.github/workflows/basic-tests.yml
@@ -75,3 +75,23 @@ jobs:
         BRANCH: gh-pages
         FOLDER: _gh-pages
         SINGLE_COMMIT: true
+  deploy_documentation_release:
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.ref == 'refs/head/master' && github.event_name == 'release'
+    steps:
+    - name: retrieve built documentation
+      uses: actions/download-artifact@v2
+      with:
+        name: documentation-page
+    - name: debug
+      run: |
+        mkdir _gh-pages
+        mv latest _gh-pages/${GITHUB_REF#refs/tags/}
+    - name: deploying tag ${GITHUB_REF#refs/tags/} to gh-pages
+      uses: JamesIves/github-pages-deploy-action@3.7.1
+      with:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        BRANCH: gh-pages
+        FOLDER: _gh-pages
+        SINGLE_COMMIT: true


### PR DESCRIPTION
Here I am starting to put together an idea on how to provide documentation for every release. I.e. instead of only having https://pycbc.org/pycbc/latest/html/, we would have https://pycbc.org/pycbc/v2.4.X/html/ as well, which points to the documentation at that release

## Standard information about the request
This change affects continuous integration and the documentation

This change has been proposed using the [contribution guidelines](https://github.com/gwastro/pycbc/blob/master/CONTRIBUTING.md)

This change will require a new release to ensure that it is correctly enacted

## Motivation
This is best practice anyway, but there is an issue at #2504

## Contents
 - Add a new job to the CI which is only run when a release is made.
 - This will also add the documentation to a new folder within the gh-pages repo
 - The gh-pages repo should then have the release kept whenever the documentation is built again, and will be pushed for each version

Plan for next steps
 - Get a dropdown of links for each version (plus latest) added to the bottom of the sidebar on the documentation pages
 - Add a link to the latest released version of the documentation to pypi

## Testing performed
I'm not sure how to test this without making a release!

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
