### PR TITLE
Handle RA and dec in radians in pygrb

### DIFF
--- a/bin/pygrb/pycbc_pygrb_grb_info_table
+++ b/bin/pygrb/pycbc_pygrb_grb_info_table
@@ -47,10 +47,10 @@ parser.add_argument("--trigger-time", action="store",
                     help="GPS time of the GRB.")
 parser.add_argument("--ra", action="store",
                     default=None, required=True,
-                    help="Right ascention (degrees) of the GRB.")
+                    help="Right ascention (radians) of the GRB.")
 parser.add_argument("--dec", action="store",
                     default=None, required=True,
-                    help="Declination (degrees) of the GRB.")
+                    help="Declination (radians) of the GRB.")
 parser.add_argument("--sky-error", action="store",
                     default=0, required=False,
                     help="Sky-localisation error (degrees) of the GRB.")
@@ -73,10 +73,10 @@ utc_time = datetime(*lal.GPSToUTC(int(opts.trigger_time))[0:6]).strftime("%B %d 
 data[0].append(utc_time)
 headers.append('Coordinated Universal Time')
 
-data[0].append(str(opts.ra))
+data[0].append(str(numpy.rad2deg(float(opts.ra))))
 headers.append('R.A. (deg)')
 
-data[0].append(str(opts.dec))
+data[0].append(str(numpy.rad2deg(float(opts.dec))))
 headers.append('Dec (deg)')
 
 data[0].append(str(opts.sky_error))
@@ -88,8 +88,8 @@ headers.append('IFOs')
 for ifo in opts.ifos:
     antenna = Detector(ifo)
     factor = get_antenna_dist_factor(antenna,
-                                     numpy.deg2rad(float(opts.ra)),
-                                     numpy.deg2rad(float(opts.dec)),
+                                     float(opts.ra),
+                                     float(opts.dec),
                                      float(opts.trigger_time))
     data[0].append('%.3f' % factor)
     headers.append(ifo + ' Antenna Factor')

--- a/bin/pygrb/pycbc_pygrb_grb_info_table
+++ b/bin/pygrb/pycbc_pygrb_grb_info_table
@@ -42,18 +42,18 @@ __program__ = "pycbc_pygrb_grb_info_table"
 parser = argparse.ArgumentParser(description=__doc__, formatter_class=
                                  argparse.ArgumentDefaultsHelpFormatter)
 parser.add_argument("--version", action="version", version=__version__)
-parser.add_argument("--trigger-time", action="store",
-                    default=None, required=True,
+parser.add_argument("--trigger-time", type=int,
+                    required=True,
                     help="GPS time of the GRB.")
-parser.add_argument("--ra", action="store",
-                    default=None, required=True,
-                    help="Right ascention (radians) of the GRB.")
-parser.add_argument("--dec", action="store",
-                    default=None, required=True,
+parser.add_argument("--ra", type=float,
+                    required=True,
+                    help="Right ascension (radians) of the GRB.")
+parser.add_argument("--dec", type=float,
+                    required=True,
                     help="Declination (radians) of the GRB.")
-parser.add_argument("--sky-error", action="store",
+parser.add_argument("--sky-error", type=float,
                     default=0, required=False,
-                    help="Sky-localisation error (degrees) of the GRB.")
+                    help="Sky-localisation error (radians) of the GRB.")
 parser.add_argument("--ifos", action="store", nargs='+',
                     default=None, required=True,
                     help="List containing the active IFOs.")
@@ -69,14 +69,14 @@ data = [[]]
 data[0].append(str(opts.trigger_time))
 headers.append('GPS Time')
 
-utc_time = datetime(*lal.GPSToUTC(int(opts.trigger_time))[0:6]).strftime("%B %d %Y, %H:%M:%S UTC")
+utc_time = datetime(*lal.GPSToUTC(opts.trigger_time)[0:6]).strftime("%B %d %Y, %H:%M:%S UTC")
 data[0].append(utc_time)
 headers.append('Coordinated Universal Time')
 
-data[0].append(str(numpy.rad2deg(float(opts.ra))))
+data[0].append(str(numpy.rad2deg(opts.ra)))
 headers.append('R.A. (deg)')
 
-data[0].append(str(numpy.rad2deg(float(opts.dec))))
+data[0].append(str(numpy.rad2deg(opts.dec)))
 headers.append('Dec (deg)')
 
 data[0].append(str(opts.sky_error))
@@ -88,8 +88,8 @@ headers.append('IFOs')
 for ifo in opts.ifos:
     antenna = Detector(ifo)
     factor = get_antenna_dist_factor(antenna,
-                                     float(opts.ra),
-                                     float(opts.dec),
+                                     opts.ra,
+                                     opts.dec,
                                      float(opts.trigger_time))
     data[0].append('%.3f' % factor)
     headers.append(ifo + ' Antenna Factor')

--- a/bin/pygrb/pycbc_pygrb_page_tables
+++ b/bin/pygrb/pycbc_pygrb_page_tables
@@ -117,8 +117,8 @@ def load_missed_found_injections(hdf_file, ifos, snr_threshold, bank_file,
         found_data['rec_mass1'],
         found_data['rec_mass2'])
     # Recovered RA and Dec
-    found_data['rec_ra'] = np.degrees(inj_data['network/ra'][...])
-    found_data['rec_dec'] = np.degrees(inj_data['network/dec'][...])
+    found_data['rec_ra'] = inj_data['network/ra'][...]
+    found_data['rec_dec'] = inj_data['network/dec'][...]
     # Statistics values
     for param in ['coherent_snr', 'reweighted_snr', 'null_snr']:
         found_data[param] = inj_data['network/%s' % param][...]
@@ -375,8 +375,8 @@ if lofft_outfile:
              mchirps[trig_index],
              bank_data['spin1z'][trig_data['network/template_id'][trig_index]],
              bank_data['spin2z'][trig_data['network/template_id'][trig_index]],
-             np.degrees(trig_data['network/ra'][trig_index]),
-             np.degrees(trig_data['network/dec'][trig_index]),
+             trig_data['network/ra'][trig_index],
+             trig_data['network/dec'][trig_index],
              trig_data['network/coherent_snr'][trig_index],
              trig_data['network/my_network_chisq'][trig_index],
              trig_data['network/null_snr'][trig_index]]
@@ -500,8 +500,8 @@ if onsource_file:
              mchirps[on_trigs['network/template_id'][trig_index]],
              bank_data['spin1z'][on_trigs['network/template_id'][trig_index]],
              bank_data['spin2z'][on_trigs['network/template_id'][trig_index]],
-             np.degrees(on_trigs['network/ra'][trig_index]),
-             np.degrees(on_trigs['network/dec'][trig_index]),
+             on_trigs['network/ra'][trig_index],
+             on_trigs['network/dec'][trig_index],
              on_trigs['network/coherent_snr'][trig_index],
              on_trigs['network/my_network_chisq'][trig_index],
              on_trigs['network/null_snr'][trig_index]] + \

--- a/pycbc/workflow/matched_filter.py
+++ b/pycbc/workflow/matched_filter.py
@@ -31,7 +31,6 @@ https://ldas-jobs.ligo.caltech.edu/~cbc/docs/pycbc/NOTYETCREATED.html
 
 import os
 import logging
-from math import radians
 
 from pycbc.workflow.core import FileList, make_analysis_dir
 from pycbc.workflow.jobsetup import (select_matchedfilter_class,
@@ -243,12 +242,11 @@ def setup_matchedfltr_dax_generated_multi(workflow, science_segs, datafind_outs,
 
     if match_fltr_exe == 'pycbc_multi_inspiral':
         exe_class = select_matchedfilter_class(match_fltr_exe)
-        # Right ascension + declination provided in degrees,
-        # so convert to radians
+        # Right ascension + declination must be provided in radians
         cp.set('inspiral', 'ra',
-               str(radians(float(cp.get('workflow', 'ra')))))
+               cp.get('workflow', 'ra'))
         cp.set('inspiral', 'dec',
-               str(radians(float(cp.get('workflow', 'dec')))))
+               cp.get('workflow', 'dec'))
         # At the moment we aren't using sky grids, but when we do this code
         # might be used then. 
         # from pycbc.workflow.grb_utils import get_sky_grid_scale


### PR DESCRIPTION
This PR simply uses radians for right ascension and declination throughout PyGRB.  Displaying them in degrees in the summary table on the results webpage is preserved.  This cleanup fixes the single IFO vs coherent IFO diagnostic plots.

## Standard information about the request

This is a: bug fix

This change affects: PyGRB

This change changes: result presentation / plotting

## Motivation
<!--- Describe why your changes are being made -->
The injections in plots such as
 
![H1L1-PYGRB_PLOT_COH_IFOSNR_NSBH_GRB170728A_H1-1185258293-5648](https://github.com/gwastro/pycbc/assets/11437405/6b84bac8-0cea-4788-a02f-e97436a4c448)

with 2 IFOs or

![H1L1V1-PYGRB_PLOT_COH_IFOSNR_ZOOMIN_NSBH_GRB170817A_H1-1187006058-5648](https://github.com/gwastro/pycbc/assets/11437405/2e59a5e7-2530-4012-b3cf-03b2f7bf65f6)

with 3 IFOs look wrong, but otherwise the behaviour of injections looks good.  The PR ensures that R.A. and declination are handled consistently throughout the workflow, so that the resulting plots are now correspondingly

![H1L1-PYGRB_PLOT_COH_IFOSNR_NSBH_GRB170728A_H1-1185258293-5648](https://github.com/gwastro/pycbc/assets/11437405/cceb3b55-4260-4b4f-b336-2f3cf7d340fb)

and

![H1L1V1-PYGRB_PLOT_COH_IFOSNR_ZOOMIN_NSBH_GRB170817A_H1-1187006058-5648-1](https://github.com/gwastro/pycbc/assets/11437405/d161f6ef-5d1e-4217-a46e-90f695e0ec13)

## Testing performed
The updated plots were produced rerunning the entire workflow from injection production onwards (injection filtering, post-processing).

- [ ] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
