### PR TITLE
Go back to getting awkde from the original developer

### DIFF
--- a/companion.txt
+++ b/companion.txt
@@ -27,6 +27,5 @@ setproctitle
 sympy>=1.9
 
 # Needed for KDE trigger statistics
-# FIXME Tito's fork to fix an awkde build error on Python 3.11
-git+https://github.com/titodalcanton/awkde.git@py311_fix
+git+https://github.com/mennthor/awkde.git@master
 scikit-learn


### PR DESCRIPTION
With #4243, we had to fork awkde to fix a bug preventing its usage on Python 3.11. The fix has now been merged in awkde's master branch, so we can now drop my fork.

## Standard information about the request

This is a minor simplification of PyCBC's dependencies, with no functional changes.

## Motivation

I prefer to avoid PyCBC depending on my forks of other people's repositories.

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
