### PR TITLE
V23 RELEASE BRANCH: Efficiency savings in pycbc_injection_minifollowup

### DIFF
--- a/bin/minifollowups/pycbc_injection_minifollowup
+++ b/bin/minifollowups/pycbc_injection_minifollowup
@@ -386,18 +386,36 @@ for num_event in range(num_events):
 
     for curr_ifo in args.single_detector_triggers:
         single_fname = args.single_detector_triggers[curr_ifo]
-        hd_sngl = SingleDetTriggers(single_fname, args.bank_file, None, None,
-                                    None, curr_ifo)
-        end_times = hd_sngl.end_time
+        # pre-cut for triggers within the time window of the injection
+        with HFile(single_fname) as trig_file:
+            n_triggers = trig_file[f'{curr_ifo}/end_time'].size
+            idx, _ = trig_file.select(
+                lambda t: abs(t - inj_params['tc']) < args.inj_window,
+                f'{curr_ifo}/end_time',
+                return_indices=True
+            )
+
+        if len(idx) == 0:
+            # No triggers in this window
+            continue
+        lgc_mask = numpy.zeros(n_triggers, dtype=bool)
+        lgc_mask[idx] = True
+
+        hd_sngl = SingleDetTriggers(
+            single_fname,
+            args.bank_file,
+            None,
+            None,
+            None,
+            curr_ifo,
+            premask=lgc_mask
+        )
         # Use SNR here or NewSNR??
         snr = hd_sngl.snr
-        lgc_mask = abs(end_times - inj_params['tc']) < args.inj_window
 
-        if len(snr[lgc_mask]) == 0:
-            continue
-
-        snr_idx = numpy.arange(len(lgc_mask))[lgc_mask][snr[lgc_mask].argmax()]
+        snr_idx = idx[snr.argmax()]
         hd_sngl.mask = [snr_idx]
+
         curr_params = copy.deepcopy(inj_params)
         curr_params['mass1'] = hd_sngl.mass1[0]
         curr_params['mass2'] = hd_sngl.mass2[0]


### PR DESCRIPTION
pycbc_injection_minifollowup has already been fixed on master to cut according to end time and use a premask for SingleDetTriggers, but not on the v23 release branch - this implements those changes here

This isnt such a problem with small(er) injection files, but can be with larger ones, which is why we have only just seen the issue

## Standard information about the request

<!--- Some basic info about the change (delete as appropriate) -->
This is an efficiency update

This change affects the offline search

This change follows style guidelines (See e.g. [PEP8](https://peps.python.org/pep-0008/)), has been proposed using the [contribution guidelines](https://github.com/gwastro/pycbc/blob/master/CONTRIBUTING.md)

## Motivation
See efficiency testing below

## Contents
Use HFile.select() function to efficiently cut down the triggers in the injection minifollowup

## Links to any issues or associated PRs
Kind of the opposite of #4761 !


## Testing performed
Efficiency tested by using `time -v`:
v2.3.7:
```
	Maximum resident set size (kbytes): 2141384
```
current master (v2.4.2):
```
	Maximum resident set size (kbytes): 628760
```
After this change:
```
	Maximum resident set size (kbytes): 619912
```
Note that this used an injection set which wasn't particularly onerous - the savings will be even better for a larger hdf_trigger_merge file

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
