### PR TITLE
fix typo that caused variable not to be initialized

### DIFF
--- a/pycbc/inference/models/tools.py
+++ b/pycbc/inference/models/tools.py
@@ -120,7 +120,7 @@ class DistMarg():
         self.reconstruct_phase = False
         self.reconstruct_distance = False
         self.reconstruct_vector = False
-        self.precalc_antennna_factors = False
+        self.precalc_antenna_factors = False
 
         # Handle any requested parameter vector / brute force marginalizations
         self.marginalize_vector_params = {}


### PR DESCRIPTION
In the distribution marginalization class, there is a variable with a spelling error that causes it to not be initialized. Most of the time this is not a problem, but I've found some corner cases where this might actually result in an error. There are some functions which check if this variable is set, and hence if isn't initialized it will fail. 