### PR TITLE
add multiprocessing to pycbc_brute_bank

### DIFF
--- a/bin/bank/pycbc_brute_bank
+++ b/bin/bank/pycbc_brute_bank
@@ -26,7 +26,6 @@ import argparse
 import pickle
 import numpy.random
 from scipy.stats import gaussian_kde
-import multiprocessing
 
 import pycbc.waveform, pycbc.filter, pycbc.types, pycbc.psd, pycbc.fft, pycbc.conversions
 import pycbc.pool

--- a/bin/bank/pycbc_brute_bank
+++ b/bin/bank/pycbc_brute_bank
@@ -26,6 +26,7 @@ import argparse
 import pickle
 import numpy.random
 from scipy.stats import gaussian_kde
+import multiprocessing
 
 import pycbc.waveform, pycbc.filter, pycbc.types, pycbc.psd, pycbc.fft, pycbc.conversions
 from pycbc import transforms
@@ -75,6 +76,7 @@ parser.add_argument('--tau0-crawl', type=float)
 parser.add_argument('--tau0-start', type=float)
 parser.add_argument('--tau0-end', type=float)
 parser.add_argument('--tau0-cutoff-frequency', type=float, default=15.0)
+parser.add_argument('--num_cores', type=int, default=1, help='number of cores for parallelization.')
 pycbc.psd.insert_psd_option_group(parser)
 args = parser.parse_args()
 
@@ -247,20 +249,52 @@ class TriangleBank(object):
     def check_params(self, gen, params, threshold):
         num_tried = 0
         num_added = 0
-        for i in range(len(tuple(params.values())[0])):
-            num_tried += 1.0
+        total_num = len(tuple(params.values())[0])
 
-            try:
-                hp = gen.generate(**{key:params[key][i] for key in params})
-            except Exception as err:
-                print(err)
-                continue
+        if args.num_cores == 1:
+            for i in range(total_num):
+                num_tried += 1.0
 
-            hp.gen = gen
-            hp.threshold = threshold
-            if hp not in self:
-                num_added += 1
-                self.insert(hp)
+                try:
+                    hp = gen.generate(**{key:params[key][i] for key in params})
+                except Exception as err:
+                    print(err)
+                    continue
+
+                hp.gen = gen
+                hp.threshold = threshold
+                if hp not in self:
+                    num_added += 1
+                    self.insert(hp)
+
+        # use multiprocessing
+        elif args.num_cores > 1:
+            waveform_cache = []
+            with multiprocessing.Pool(args.num_cores) as pool:
+                for return_wf in pool.imap_unordered(
+                    wf_wrapper, 
+                    ({k: params[k][idx] for k in params} for idx in range(total_num))
+                ):
+                    waveform_cache += [return_wf]
+            
+            for i in range(total_num):
+                num_tried += 1
+                hp = waveform_cache[i]
+
+                if isinstance(hp, pycbc.types.FrequencySeries):
+                    hp.gen = gen
+                    hp.threshold = threshold 
+                    if hp not in self:
+                        num_added += 1
+                        self.insert(hp)
+                elif numpy.isnan(hp):
+                    logging.info("Waveform generation failed!")
+                    continue
+                else:
+                    raise ValueError("Waveform generation problem.")
+        
+        else:
+            raise ValueError("Number of cores should be a positive integer.")
 
         return bank, num_added / float(num_tried)
 
@@ -336,6 +370,14 @@ size = int(1.0 / tolerance)
 gen = GenUniformWaveform(args.buffer_length,
     args.sample_rate, args.low_frequency_cutoff)
 bank = TriangleBank()
+
+if args.num_cores > 1:
+    def wf_wrapper(p):
+        try:
+            hp = gen.generate(**p)
+            return hp
+        except Exception:
+            return numpy.nan
 
 if args.input_file:
     f = h5py.File(args.input_file, 'r')

--- a/bin/bank/pycbc_brute_bank
+++ b/bin/bank/pycbc_brute_bank
@@ -253,25 +253,24 @@ class TriangleBank(object):
         total_num = len(tuple(params.values())[0])
         waveform_cache = []
 
-        with multiprocessing.Pool(args.nprocesses) as pool:
-            for return_wf in pool.imap_unordered(
+        pool = pycbc.pool.choose_pool(args.nprocesses)
+        for return_wf in pool.imap_unordered(
                 wf_wrapper, 
                 ({k: params[k][idx] for k in params} for idx in range(total_num))
             ):
-                waveform_cache += [return_wf]
-        
+            waveform_cache += [return_wf]
+        del pool
+
         for hp in waveform_cache:
-            if isinstance(hp, pycbc.types.FrequencySeries):
+            if hp is not None:
                 hp.gen = gen
                 hp.threshold = threshold 
                 if hp not in self:
                     num_added += 1
                     self.insert(hp)
-            elif hp is None:
+            else:
                 logging.info("Waveform generation failed!")
                 continue
-            else:
-                raise ValueError("Waveform generation wrapper problem!")
 
         return bank, num_added / total_num
 

--- a/bin/bank/pycbc_brute_bank
+++ b/bin/bank/pycbc_brute_bank
@@ -76,7 +76,7 @@ parser.add_argument('--tau0-crawl', type=float)
 parser.add_argument('--tau0-start', type=float)
 parser.add_argument('--tau0-end', type=float)
 parser.add_argument('--tau0-cutoff-frequency', type=float, default=15.0)
-parser.add_argument('--num_cores', type=int, default=1, help='number of cores for parallelization.')
+parser.add_argument('--num_cores', type=int, default=1, help='number of cores for waveform generation parallelization.')
 pycbc.psd.insert_psd_option_group(parser)
 args = parser.parse_args()
 

--- a/bin/bank/pycbc_brute_bank
+++ b/bin/bank/pycbc_brute_bank
@@ -29,6 +29,7 @@ from scipy.stats import gaussian_kde
 import multiprocessing
 
 import pycbc.waveform, pycbc.filter, pycbc.types, pycbc.psd, pycbc.fft, pycbc.conversions
+import pycbc.pool
 from pycbc import transforms
 from pycbc.waveform.spa_tmplt import spa_length_in_time
 from pycbc.distributions import read_params_from_config
@@ -76,7 +77,8 @@ parser.add_argument('--tau0-crawl', type=float)
 parser.add_argument('--tau0-start', type=float)
 parser.add_argument('--tau0-end', type=float)
 parser.add_argument('--tau0-cutoff-frequency', type=float, default=15.0)
-parser.add_argument('--num_cores', type=int, default=1, help='number of cores for waveform generation parallelization.')
+parser.add_argument('--nprocesses', type=int, default=1, 
+    help='Number of processes to use for waveform generation parallelization. If not given then only a single core will be used.')
 pycbc.psd.insert_psd_option_group(parser)
 args = parser.parse_args()
 
@@ -247,56 +249,31 @@ class TriangleBank(object):
                 mmax = m
 
     def check_params(self, gen, params, threshold):
-        num_tried = 0
         num_added = 0
         total_num = len(tuple(params.values())[0])
+        waveform_cache = []
 
-        if args.num_cores == 1:
-            for i in range(total_num):
-                num_tried += 1.0
-
-                try:
-                    hp = gen.generate(**{key:params[key][i] for key in params})
-                except Exception as err:
-                    print(err)
-                    continue
-
+        with multiprocessing.Pool(args.nprocesses) as pool:
+            for return_wf in pool.imap_unordered(
+                wf_wrapper, 
+                ({k: params[k][idx] for k in params} for idx in range(total_num))
+            ):
+                waveform_cache += [return_wf]
+        
+        for hp in waveform_cache:
+            if isinstance(hp, pycbc.types.FrequencySeries):
                 hp.gen = gen
-                hp.threshold = threshold
+                hp.threshold = threshold 
                 if hp not in self:
                     num_added += 1
                     self.insert(hp)
+            elif hp is None:
+                logging.info("Waveform generation failed!")
+                continue
+            else:
+                raise ValueError("Waveform generation wrapper problem!")
 
-        # use multiprocessing
-        elif args.num_cores > 1:
-            waveform_cache = []
-            with multiprocessing.Pool(args.num_cores) as pool:
-                for return_wf in pool.imap_unordered(
-                    wf_wrapper, 
-                    ({k: params[k][idx] for k in params} for idx in range(total_num))
-                ):
-                    waveform_cache += [return_wf]
-            
-            for i in range(total_num):
-                num_tried += 1
-                hp = waveform_cache[i]
-
-                if isinstance(hp, pycbc.types.FrequencySeries):
-                    hp.gen = gen
-                    hp.threshold = threshold 
-                    if hp not in self:
-                        num_added += 1
-                        self.insert(hp)
-                elif numpy.isnan(hp):
-                    logging.info("Waveform generation failed!")
-                    continue
-                else:
-                    raise ValueError("Waveform generation problem.")
-        
-        else:
-            raise ValueError("Number of cores should be a positive integer.")
-
-        return bank, num_added / float(num_tried)
+        return bank, num_added / total_num
 
 class GenUniformWaveform(object):
     def __init__(self, buffer_length, sample_rate, f_lower):
@@ -371,13 +348,12 @@ gen = GenUniformWaveform(args.buffer_length,
     args.sample_rate, args.low_frequency_cutoff)
 bank = TriangleBank()
 
-if args.num_cores > 1:
-    def wf_wrapper(p):
-        try:
-            hp = gen.generate(**p)
-            return hp
-        except Exception:
-            return numpy.nan
+def wf_wrapper(p):
+    try:
+        hp = gen.generate(**p)
+        return hp
+    except Exception:
+        return None
 
 if args.input_file:
     f = h5py.File(args.input_file, 'r')

--- a/pycbc/pool.py
+++ b/pycbc/pool.py
@@ -128,6 +128,7 @@ class SinglePool(object):
     # so that the general pool interfaces can use
     # imap irrespective of the pool type. 
     imap = map
+    imap_unordered = map
 
 def use_mpi(require_mpi=False, log=True):
     """ Get whether MPI is enabled and if so the current size and rank


### PR DESCRIPTION
<!---
Please delete these comments when you submit the pull request

Please add a title which is a concise description of what you are doing,
e.g. 'Fix bug with numpy import in pycbc_coinc_findtrigs' or 'add high frequency sky location dependent response for long detectors'
-->

<!---
This is a brief template for making pull requests for PyCBC.
This is _not_ a proscriptive template - you can use a different style if you want.
Please do think about the questions posed here and whether the details will be useful to include in your PR
Please add sufficient details so that people looking back at the request with no context around the work can understand the changes.
To choose reviewers, please look at the git blame for the code you are changing (if applicable),
or discuss in the #pycbc-code channel of the gwastro slack.
Please add labels as appropriate
-->

<!-- TOP-LEVEL SUMMARY: Please provide a brief, one-or-two-sentence description of the PR here
-->

## Standard information about the request

<!--- Some basic info about the change (delete as appropriate) -->
This is a: efficiency update

<!--- What codes will this affect? (delete as apropriate)
If you do not know which areas will be affected, please ask in the gwastro #pycbc-code slack
-->
This change affects: the pycbc_brute_bank

<!--- What code areas will this affect? (delete as apropriate) -->
This change changes: this only add a multiprocessing feature to the existing pycbc_brute_bank and wouldn't change any other exisiting results

<!--- Some things which help with code management (delete as appropriate) -->
This change would simply follow the unit tests designed for pycbc_brute_bank (if there is any)

<!--- Notes about the effect of this change -->
This change will not break current functionality, not require additional dependencies, not require a new release

## Motivation
<!--- Describe why your changes are being made -->

When a waveform generation is slow, the bottleneck for pycbc_brute_bank is the waveform generation speed. So I parallelize the waveform generation. This PR doesn't affect any match computation.

## Contents
<!--- Describe your changes, this doesn't need to be a line-by-line code change discussion,
but rather a general discussion of the methods chosen -->

I added a parallelization for waveform generation in pycbc_brute_bank

## Links to any issues or associated PRs
<!--- If this is fixing / working around an already-reported issue, please link to it here -->

None

## Testing performed
<!--- Describe tests for the code changes, either already performed or to be performed -->

Tested with "--num_cores = 96" and it works fine.

## Additional notes
<!--- Anything which does not fit in the above sections -->

ACKNOWLEGMENT: with significant techinical support from @raffienficiaud

- [x ] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
