### PR TITLE
fix normalization of sky and time marginalization to reduce integral …

### DIFF
--- a/pycbc/inference/models/relbin.py
+++ b/pycbc/inference/models/relbin.py
@@ -868,7 +868,9 @@ class RelativeTimeDom(RelativeTime):
             # Note, this includes complex conjugation already
             # as our stored inner products were hp* x data
             htf = (f.real * ip + 1.0j * f.imag * ic)
-            sh = self.sh[ifo].at_time(dts, interpolate='quadratic')
+            sh = self.sh[ifo].at_time(dts, 
+                                      interpolate='quadratic',
+                                      extrapolate=0.0j)
             sh_total += sh * htf
             hh_total += self.hh[ifo] * abs(htf) ** 2.0
 

--- a/pycbc/inference/models/tools.py
+++ b/pycbc/inference/models/tools.py
@@ -364,14 +364,17 @@ class DistMarg():
         starts = []
         ends = []
 
-        tmin = tcmin + dt - snrs[iref].delta_t
-        tmax = tcmax + dt + snrs[iref].delta_t
+        delt = snrs[iref].delta_t
+        tmin = tcmin + dt - delt
+        tmax = tcmax + dt + delt
         if hasattr(self, 'tstart'):
             tmin = self.tstart[iref]
             tmax = self.tend[iref]
 
-        starts.append(max(tmin, snrs[iref].start_time))
-        ends.append(min(tmax, snrs[iref].end_time))
+        # Make sure we draw from times within prior and that have enough
+        # SNR calculated to do later interpolation
+        starts.append(max(tmin, snrs[iref].start_time + delt))
+        ends.append(min(tmax, snrs[iref].end_time - delt * 2))
 
         idels = {}
         for ifo in ifos[1:]:
@@ -498,9 +501,8 @@ class DistMarg():
                 tmin = self.tstart[ifo]
                 tmax = self.tend[ifo]
 
-            start = max(tmin, snrs[ifo].start_time)
-            end = min(tmax, snrs[ifo].end_time)
-
+            start = max(tmin, snr.start_time + snr.delta_t)
+            end = min(tmax, snr.end_time - snr.delta_t * 2)
             snr = snr.time_slice(start, end, mode='nearest')
 
             w = snr.squared_norm().numpy() / 2.0

--- a/pycbc/inference/models/tools.py
+++ b/pycbc/inference/models/tools.py
@@ -409,7 +409,7 @@ class DistMarg():
 
         # Update the current proposed times and the marginalization values
         # assumes uniform prior!
-        logw = - logweight[tci] + numpy.log(1.0 / len(logweight)) 
+        logw = - logweight[tci] + numpy.log(1.0 / len(logweight))
         self.marginalize_vector_params['tc'] = tc
         self.marginalize_vector_params['logw_partial'] = logw
 

--- a/pycbc/inference/models/tools.py
+++ b/pycbc/inference/models/tools.py
@@ -45,10 +45,6 @@ def draw_sample(loglr, size=None):
     cdf = numpy.exp(loglr).cumsum()
     cdf /= cdf[-1]
     xl = numpy.searchsorted(cdf, x)
-    
-    loglr = loglr - logsumexp(loglr)
-    w = numpy.exp(loglr)
-    xl = numpy.random.choice(range(len(loglr)), p=w, size=size)
     return xl
 
 

--- a/pycbc/inference/models/tools.py
+++ b/pycbc/inference/models/tools.py
@@ -287,7 +287,7 @@ class DistMarg():
             choice = slice(None, None)
         else:
             choice = numpy.random.choice(len(logw), size=self.vsamples,
-                                     replace=False)
+                                         replace=False)
 
         for k in self.snr_params:
             self.marginalize_vector_params[k] = self.premarg[k][choice]
@@ -364,7 +364,8 @@ class DistMarg():
         starts = []
         ends = []
 
-        tmin, tmax = tcmin + dt - snrs[iref].delta_t, tcmax + dt + snrs[iref].delta_t
+        tmin = tcmin + dt - snrs[iref].delta_t
+        tmax = tcmax + dt + snrs[iref].delta_t
         if hasattr(self, 'tstart'):
             tmin = self.tstart[iref]
             tmax = self.tend[iref]
@@ -395,7 +396,7 @@ class DistMarg():
                                         mode='nearest')
             logweight += snrv.squared_norm().numpy()
         logweight /= 2.0
-        logweight -= logsumexp(logweight) # Normalize to PDF
+        logweight -= logsumexp(logweight)  # Normalize to PDF
 
         # Draw proportional to the incoherent likelihood
         # Draw first which time sample
@@ -407,7 +408,8 @@ class DistMarg():
         tc = tct + tci * snr.delta_t + float(snr.start_time) - dt
 
         # Update the current proposed times and the marginalization values
-        logw = - logweight[tci] + numpy.log(1.0 / len(logweight)) # assumes uniform prior!
+        # assumes uniform prior!
+        logw = - logweight[tci] + numpy.log(1.0 / len(logweight)) 
         self.marginalize_vector_params['tc'] = tc
         self.marginalize_vector_params['logw_partial'] = logw
 
@@ -462,12 +464,12 @@ class DistMarg():
                 if t not in dmap:
                     dmap[t] = []
                 dmap[t].append(i)
-            
+
             if len(ifos) == 1:
                 dmap[()] = numpy.arange(0, size, 1).astype(int)
 
             # Sky prior by bin
-            bin_prior = {t:len(dmap[t]) / size for t in dmap}          
+            bin_prior = {t: len(dmap[t]) / size for t in dmap}
 
             return dmap, tcmin, tcmax, fp, fc, ra, dec, dtc, bin_prior
 

--- a/pycbc/inference/models/tools.py
+++ b/pycbc/inference/models/tools.py
@@ -45,15 +45,15 @@ def draw_sample(loglr, size=None):
     cdf = numpy.exp(loglr).cumsum()
     cdf /= cdf[-1]
     xl = numpy.searchsorted(cdf, x)
+    
+    loglr = loglr - logsumexp(loglr)
+    w = numpy.exp(loglr)
+    xl = numpy.random.choice(range(len(loglr)), p=w, size=size)
     return xl
 
 
 class DistMarg():
     """Help class to add bookkeeping for likelihood marginalization"""
-
-    marginalize_phase = None
-    distance_marginalization = None
-    distance_interpolator = None
 
     def setup_marginalization(self,
                               variable_params,
@@ -287,7 +287,11 @@ class DistMarg():
 
         # Update the current proposed times and the marginalization values
         logw = self.premarg['logw_partial']
-        choice = numpy.random.randint(0, len(logw), size=self.vsamples)
+        if self.vsamples == len(logw):
+            choice = slice(None, None)
+        else:
+            choice = numpy.random.choice(len(logw), size=self.vsamples,
+                                     replace=False)
 
         for k in self.snr_params:
             self.marginalize_vector_params[k] = self.premarg[k][choice]
@@ -339,7 +343,8 @@ class DistMarg():
         """
         if not hasattr(self, 'tinfo'):
             # determine the rough time offsets for this sky location
-            tcmin, tcmax = self.marginalized_vector_priors['tc'].bounds['tc']
+            tcprior = self.marginalized_vector_priors['tc']
+            tcmin, tcmax = tcprior.bounds['tc']
             tcave = (tcmax + tcmin) / 2.0
             ifos = list(snrs.keys())
             if hasattr(self, 'keep_ifos'):
@@ -363,7 +368,7 @@ class DistMarg():
         starts = []
         ends = []
 
-        tmin, tmax = tcmin - dt, tcmax + dt
+        tmin, tmax = tcmin + dt - snrs[iref].delta_t, tcmax + dt + snrs[iref].delta_t
         if hasattr(self, 'tstart'):
             tmin = self.tstart[iref]
             tmax = self.tend[iref]
@@ -394,6 +399,7 @@ class DistMarg():
                                         mode='nearest')
             logweight += snrv.squared_norm().numpy()
         logweight /= 2.0
+        logweight -= logsumexp(logweight) # Normalize to PDF
 
         # Draw proportional to the incoherent likelihood
         # Draw first which time sample
@@ -405,15 +411,14 @@ class DistMarg():
         tc = tct + tci * snr.delta_t + float(snr.start_time) - dt
 
         # Update the current proposed times and the marginalization values
-        logw = - logweight[tci]
+        logw = - logweight[tci] + numpy.log(1.0 / len(logweight)) # assumes uniform prior!
         self.marginalize_vector_params['tc'] = tc
         self.marginalize_vector_params['logw_partial'] = logw
 
         if self._current_params is not None:
             # Update the importance weights for each vector sample
-            logw = self.marginalize_vector_weights + logw
             self._current_params.update(self.marginalize_vector_params)
-            self.marginalize_vector_weights = logw - logsumexp(logw)
+            self.marginalize_vector_weights += logw
 
         return self.marginalize_vector_params
 
@@ -461,11 +466,14 @@ class DistMarg():
                 if t not in dmap:
                     dmap[t] = []
                 dmap[t].append(i)
-
+            
             if len(ifos) == 1:
                 dmap[()] = numpy.arange(0, size, 1).astype(int)
 
-            return dmap, tcmin, tcmax, fp, fc, ra, dec, dtc
+            # Sky prior by bin
+            bin_prior = {t:len(dmap[t]) / size for t in dmap}          
+
+            return dmap, tcmin, tcmax, fp, fc, ra, dec, dtc, bin_prior
 
         if not hasattr(self, 'tinfo'):
             self.tinfo = {}
@@ -474,7 +482,7 @@ class DistMarg():
             logging.info('pregenerating sky pointings')
             self.tinfo[ikey] = make_init()
 
-        dmap, tcmin, tcmax, fp, fc, ra, dec, dtc = self.tinfo[ikey]
+        dmap, tcmin, tcmax, fp, fc, ra, dec, dtc, bin_prior = self.tinfo[ikey]
 
         vsamples = size if size is not None else self.vsamples
 
@@ -501,16 +509,17 @@ class DistMarg():
             i = draw_sample(w, size=vsamples)
 
             if sref is not None:
-                mcweight -= w[i]
+                mcweight += w[i]
                 delt = float(snr.start_time - sref.start_time)
                 i += round(delt / sref.delta_t)
                 dx.append(iref - i)
             else:
                 sref = snr
                 iref = i
-                mcweight = -w[i]
+                mcweight = w[i]
 
             idx.append(i)
+        mcweight -= logsumexp(mcweight)
 
         # check if delay is in dict, if not, throw out
         ti = []
@@ -522,7 +531,7 @@ class DistMarg():
             if t in dmap:
                 randi = int(rand[i] * (len(dmap[t])))
                 ix.append(dmap[t][randi])
-                wi.append(len(dmap[t]))
+                wi.append(bin_prior[t])
                 ti.append(i)
 
         # If we had really poor efficiency at finding a point, we should
@@ -535,6 +544,7 @@ class DistMarg():
         ix = numpy.resize(numpy.array(ix, dtype=int), vsamples)
         self.sample_idx = ix
         self.precalc_antenna_factors = fp, fc, dtc
+        resize_factor = len(ti) / vsamples
 
         ra = ra[ix]
         dec = dec[ix]
@@ -551,7 +561,10 @@ class DistMarg():
         tc = tct + iref[ti] * snr.delta_t + float(sref.start_time) - dtc[ifos[0]]
 
         # Update the current proposed times and the marginalization values
-        logw_sky = mcweight[ti] + numpy.log(wi)
+        # There's an overall normalization here which may introduce a constant
+        # factor at the moment.
+        logw_sky = -mcweight[ti] + numpy.log(wi) - numpy.log(resize_factor)
+
         self.marginalize_vector_params['tc'] = tc
         self.marginalize_vector_params['ra'] = ra
         self.marginalize_vector_params['dec'] = dec
@@ -559,9 +572,8 @@ class DistMarg():
 
         if self._current_params is not None:
             # Update the importance weights for each vector sample
-            logw = self.marginalize_vector_weights + logw_sky
             self._current_params.update(self.marginalize_vector_params)
-            self.marginalize_vector_weights = logw - logsumexp(logw)
+            self.marginalize_vector_weights += logw_sky
 
         return self.marginalize_vector_params
 


### PR DESCRIPTION
…uncertainty

This reduces the uncertainty in the monte-carlo integral for time / sky marginalization. I was using a normalization that incorrectly introduced a large sample variance when in fact it was not needed. In testing this means that the likelihood (not log likelihood thankfully) std deviation is ~ 5-10% after 1000 samples and improves with root(N) as expected. For many cases, this is sufficient unless the level of accuracy required is very high. 

I've also added some comments for future improvements. The marginalizations implicitly assume a uniform time prior, which should be alleviated in a future pull request. 