### PR TITLE
add ability to cache detector response to marginalize time model and us…

### DIFF
--- a/examples/inference/margtime/margtime.ini
+++ b/examples/inference/margtime/margtime.ini
@@ -3,6 +3,9 @@
 name = marginalized_time
 low-frequency-cutoff = 30.0
 
+# This is the sample rate used for the model and marginalization
+sample_rate = 2048
+
 marginalize_vector_params = tc, ra, dec, polarization
 marginalize_vector_samples = 500
 

--- a/examples/inference/margtime/margtime.ini
+++ b/examples/inference/margtime/margtime.ini
@@ -4,10 +4,10 @@ name = marginalized_time
 low-frequency-cutoff = 30.0
 
 # This is the sample rate used for the model and marginalization
-sample_rate = 2048
+sample_rate = 4096
 
 marginalize_vector_params = tc, ra, dec, polarization
-marginalize_vector_samples = 500
+marginalize_vector_samples = 2000
 
 ; You shouldn't use phase marginalization if the approximant has
 ; higher-order modes

--- a/examples/inference/margtime/run.sh
+++ b/examples/inference/margtime/run.sh
@@ -1,6 +1,6 @@
 OMP_NUM_THREADS=1 pycbc_inference \
 --config-file `dirname "$0"`/margtime.ini \
---nprocesses 2 \
+--nprocesses 1 \
 --processing-scheme mkl \
 --output-file marg_150914.hdf \
 --seed 0 \
@@ -23,4 +23,5 @@ pycbc_inference_plot_posterior \
  "primary_mass(mass1, mass2) / (1 + redshift(distance)):srcmass1" \
  "secondary_mass(mass1, mass2) / (1 + redshift(distance)):srcmass2" \
  ra dec tc inclination coa_phase polarization distance \
+--vmin 23.2 \
 --z-arg snr

--- a/pycbc/inference/models/marginalized_gaussian_noise.py
+++ b/pycbc/inference/models/marginalized_gaussian_noise.py
@@ -242,13 +242,15 @@ class MarginalizedTime(DistMarg, BaseGaussianNoise):
                     gates=self.gates, **kwargs['static_params'])
 
         self.dets = {}
-        
+
         if sample_rate is not None:
-            logging.info("Using %s sample rate for marginalization", sample_rate)
+            logging.info("Using %s sample rate for marginalization",
+                         sample_rate)
             for det in self._whitened_data:
-                tlen = int(round(float(sample_rate) * self.whitened_data[det].duration))
+                tlen = int(round(float(sample_rate) *
+                           self.whitened_data[det].duration))
                 flen = tlen // 2 + 1
-                self._whitened_data[det].resize(flen)    
+                self._whitened_data[det].resize(flen)
 
     def _nowaveform_loglr(self):
         """Convenience function to set loglr values if no waveform generated.
@@ -334,7 +336,7 @@ class MarginalizedTime(DistMarg, BaseGaussianNoise):
         for det in wfs:
             if det not in self.dets:
                 self.dets[det] = Detector(det)
-                
+
             if self.precalc_antenna_factors:
                 fp, fc, dt = self.get_precalc_antenna_factors(det)
             else:
@@ -347,7 +349,7 @@ class MarginalizedTime(DistMarg, BaseGaussianNoise):
                                                                  params['dec'],
                                                                  params['tc'])
             dtc = params['tc'] + dt
-            
+
             cplx_hd = fp * cplx_hpd[det].at_time(dtc,
                                                  interpolate='quadratic')
             cplx_hd += fc * cplx_hcd[det].at_time(dtc,


### PR DESCRIPTION
This implements two features into the marginalized time model. 

1) it can now take a 'sample_rate' argument. If given, a different sample rate can be used for the marginalization than the intrinsic one of the data. Note it really should be higher than the data sample rate to make sense.

2) The detector response factors are now retrieved from the precalculated ones which improves the marginalization speed by ~ 50 %. 
