### PR TITLE
Add log counts option to live combined significance plot

### DIFF
--- a/bin/live/pycbc_live_plot_combined_single_significance_fits
+++ b/bin/live/pycbc_live_plot_combined_single_significance_fits
@@ -49,6 +49,11 @@ parser.add_argument("--colormap", default="rainbow_r", choices=plt.colormaps(),
 parser.add_argument("--log-colormap", action='store_true',
                     help="Use log spacing for choosing colormap values "
                          "based on duration bins.")
+parser.add_argument(
+    '--log-counts',
+    action='store_true',
+    help="Plot the trigger rate above threshold on a log scale."
+)
 args = parser.parse_args()
 
 if '{ifo}' not in args.output_plot_name_format or \
@@ -188,6 +193,8 @@ for ifo in ifos:
     ax_alpha.set_ylabel('Fit coefficient')
 
     count_labels = [l.get_label() for l in count_lines]
+    if args.log_counts:
+        ax_count.semilogy()
     ax_count.legend(count_lines, count_labels, loc='lower center',
                     ncol=5, bbox_to_anchor=(0.5, 1.01))
     ax_count.set_ylabel('Rate of triggers above fit threshold [s$^{-1}$]')

--- a/bin/live/pycbc_live_plot_combined_single_significance_fits
+++ b/bin/live/pycbc_live_plot_combined_single_significance_fits
@@ -169,6 +169,10 @@ for ifo in ifos:
                                             c=bin_colour, linestyle=':',
                                             label=alpha_lab))
 
+        # Invalid counts
+        inv_counts = rate <= 0
+        rate[inv_counts] = None
+
         count_lines += ax_count.plot(separate_starts[ifo], rate, c=bin_colour,
                                      label=bin_label, marker='.',
                                      markersize=10)


### PR DESCRIPTION
Add a log-counts option to the pycbc live significance fits plotting.
Plots [with](https://ldas-jobs.ligo.caltech.edu/~gareth.cabourndavies/testoutput/various_tests/live_plot_combined_ylog/H1-TRIGGER-FITS-counts_NEW.png) and [without](https://ldas-jobs.ligo.caltech.edu/~gareth.cabourndavies/testoutput/various_tests/live_plot_combined_ylog/H1-TRIGGER-FITS-counts_OLD.png) the flag

## Standard information about the request

This is a new feature
This change affects the live search
This change changes result presentation / plotting

This change follows style guidelines (See e.g. [PEP8](https://peps.python.org/pep-0008/)), has been proposed using the [contribution guidelines](https://github.com/gwastro/pycbc/blob/master/CONTRIBUTING.md)

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
