### PR TITLE
Add a standard --version option to common pycbc options

### DIFF
--- a/bin/all_sky_search/pycbc_add_statmap
+++ b/bin/all_sky_search/pycbc_add_statmap
@@ -26,8 +26,6 @@ def get_ifo_string(fi):
 
 parser = argparse.ArgumentParser()
 pycbc.add_common_pycbc_options(parser)
-parser.add_argument('--version', action="version",
-                    version=pycbc.version.git_verbose_msg)
 parser.add_argument('--statmap-files', nargs='+',
     help="List of coinc files to be combined")
 parser.add_argument('--background-files', nargs='+', default=None,

--- a/bin/all_sky_search/pycbc_apply_rerank
+++ b/bin/all_sky_search/pycbc_apply_rerank
@@ -10,8 +10,6 @@ from shutil import copyfile
 
 parser = argparse.ArgumentParser()
 pycbc.add_common_pycbc_options(parser)
-parser.add_argument('--version', action='version',
-    version=pycbc.version.git_verbose_msg)
 parser.add_argument('--stat-files', nargs='+',
     help="Statistic files produced by candidate followup codes")
 parser.add_argument('--followup-file',

--- a/bin/all_sky_search/pycbc_average_psd
+++ b/bin/all_sky_search/pycbc_average_psd
@@ -26,13 +26,11 @@ import argparse
 import numpy as np
 import pycbc
 from pycbc.io import HFile
-from pycbc.version import git_verbose_msg as version
 from pycbc.types import MultiDetOptionAction, FrequencySeries
 
 
 parser = argparse.ArgumentParser(description=__doc__)
 pycbc.add_common_pycbc_options(parser)
-parser.add_argument('--version', action='version', version=version)
 parser.add_argument('--input-files', nargs='+', required=True, metavar='PATH',
                     help='HDF5 files from pycbc_calculate_psd (one per '
                          'detector) containing the input PSDs to average.')

--- a/bin/all_sky_search/pycbc_bin_templates
+++ b/bin/all_sky_search/pycbc_bin_templates
@@ -8,12 +8,10 @@ import numpy as np
 
 import pycbc
 import pycbc.pnutils
-from pycbc.version import git_verbose_msg as version
 from pycbc.events import background_bin_from_string
 
 parser = argparse.ArgumentParser(description=__doc__)
 pycbc.add_common_pycbc_options(parser)
-parser.add_argument('--version', action='version', version=version)
 parser.add_argument("--ifo", type=str, required=True)
 parser.add_argument("--f-lower", type=float, default=15.,
                     help='Enforce a uniform low frequency cutoff to '

--- a/bin/all_sky_search/pycbc_bin_trigger_rates_dq
+++ b/bin/all_sky_search/pycbc_bin_trigger_rates_dq
@@ -16,11 +16,9 @@ from pycbc.events.veto import (select_segments_by_definer,
                                segments_to_start_end)
 from pycbc.types.optparse import MultiDetOptionAction
 from pycbc.io.hdf import SingleDetTriggers
-from pycbc.version import git_verbose_msg as version
 
 parser = argparse.ArgumentParser(description=__doc__)
 pycbc.add_common_pycbc_options(parser)
-parser.add_argument('--version', action='version', version=version)
 parser.add_argument("--template-bins-file", required=True)
 parser.add_argument("--trig-file", required=True)
 parser.add_argument("--flag-file", required=True)

--- a/bin/all_sky_search/pycbc_calculate_psd
+++ b/bin/all_sky_search/pycbc_calculate_psd
@@ -5,7 +5,6 @@ import logging, argparse, numpy, multiprocessing, time, copy
 from six.moves import zip_longest
 import pycbc, pycbc.psd, pycbc.strain, pycbc.events
 from pycbc.io import HFile
-from pycbc.version import git_verbose_msg as version
 from pycbc.fft.fftw import set_measure_level
 from pycbc.workflow import resolve_td_option
 from ligo.segments import segmentlist, segment
@@ -13,7 +12,6 @@ set_measure_level(0)
 
 parser = argparse.ArgumentParser(description=__doc__)
 pycbc.add_common_pycbc_options(parser)
-parser.add_argument('--version', action='version', version=version)
 parser.add_argument("--low-frequency-cutoff", type=float, required=True,
                     help="The low frequency cutoff to use for filtering (Hz)")
 parser.add_argument("--analysis-segment-file",  required=True,

--- a/bin/all_sky_search/pycbc_coinc_findtrigs
+++ b/bin/all_sky_search/pycbc_coinc_findtrigs
@@ -3,7 +3,6 @@ import copy, argparse, logging, numpy, numpy.random
 import shutil, uuid, os.path, atexit
 from ligo.segments import infinity
 from pycbc.events import veto, coinc, stat, ranking, cuts
-import pycbc.version
 from pycbc.io import HFile
 from pycbc import pool, init_logging
 from numpy.random import seed, shuffle
@@ -12,7 +11,6 @@ from pycbc.types.optparse import MultiDetOptionAction
 
 parser = argparse.ArgumentParser()
 pycbc.add_common_pycbc_options(parser)
-parser.add_argument("--version", action="version", version=pycbc.version.git_verbose_msg)
 parser.add_argument("--veto-files", nargs='*', action='append', default=[],
                     help="Optional veto file. Triggers within veto segments "
                          "contained in the file are ignored")

--- a/bin/all_sky_search/pycbc_coinc_findtrigs
+++ b/bin/all_sky_search/pycbc_coinc_findtrigs
@@ -2,6 +2,7 @@
 import copy, argparse, logging, numpy, numpy.random
 import shutil, uuid, os.path, atexit
 from ligo.segments import infinity
+import pycbc
 from pycbc.events import veto, coinc, stat, ranking, cuts
 from pycbc.io import HFile
 from pycbc import pool, init_logging

--- a/bin/all_sky_search/pycbc_coinc_hdfinjfind
+++ b/bin/all_sky_search/pycbc_coinc_hdfinjfind
@@ -11,7 +11,6 @@ from pycbc.events import indices_within_segments
 from pycbc.types import MultiDetOptionAction
 from pycbc.inject import CBCHDFInjectionSet
 from pycbc.io import HFile
-import pycbc.version
 from pycbc.io.ligolw import LIGOLWContentHandler
 
 
@@ -57,8 +56,6 @@ def xml_to_hdf(table, hdf_file, hdf_key, columns):
 
 parser = argparse.ArgumentParser(description=__doc__)
 pycbc.add_common_pycbc_options(parser)
-parser.add_argument('--version', action='version',
-                    version=pycbc.version.git_verbose_msg)
 parser.add_argument('--trigger-files', nargs='+', required=True)
 parser.add_argument('--injection-files', nargs='+', required=True)
 parser.add_argument('--veto-file')

--- a/bin/all_sky_search/pycbc_coinc_hdfinjfind
+++ b/bin/all_sky_search/pycbc_coinc_hdfinjfind
@@ -6,6 +6,7 @@ files.
 import argparse, logging, types, numpy, os.path
 from ligo.lw import lsctables, utils as ligolw_utils
 from ligo import segments
+import pycbc
 from pycbc import events, init_logging
 from pycbc.events import indices_within_segments
 from pycbc.types import MultiDetOptionAction

--- a/bin/all_sky_search/pycbc_coinc_mergetrigs
+++ b/bin/all_sky_search/pycbc_coinc_mergetrigs
@@ -4,7 +4,6 @@
 """
 
 import numpy, argparse, h5py, logging
-import pycbc.version
 from pycbc.io import HFile
 from pycbc import init_logging
 
@@ -32,8 +31,6 @@ def region(f, key, boundaries, ids):
 
 parser = argparse.ArgumentParser()
 pycbc.add_common_pycbc_options(parser)
-parser.add_argument('--version', action='version',
-                    version=pycbc.version.git_verbose_msg)
 parser.add_argument('--trigger-files', nargs='+')
 parser.add_argument('--output-file', required=True)
 parser.add_argument('--bank-file', required=True)

--- a/bin/all_sky_search/pycbc_coinc_mergetrigs
+++ b/bin/all_sky_search/pycbc_coinc_mergetrigs
@@ -5,7 +5,7 @@
 
 import numpy, argparse, h5py, logging
 from pycbc.io import HFile
-from pycbc import init_logging
+from pycbc import add_common_pycbc_options, init_logging
 
 def changes(arr):
     l = numpy.where(arr[:-1] != arr[1:])[0]
@@ -30,7 +30,7 @@ def region(f, key, boundaries, ids):
                      dtype=h5py.special_dtype(ref=h5py.RegionReference))
 
 parser = argparse.ArgumentParser()
-pycbc.add_common_pycbc_options(parser)
+add_common_pycbc_options(parser)
 parser.add_argument('--trigger-files', nargs='+')
 parser.add_argument('--output-file', required=True)
 parser.add_argument('--bank-file', required=True)

--- a/bin/all_sky_search/pycbc_coinc_statmap
+++ b/bin/all_sky_search/pycbc_coinc_statmap
@@ -10,7 +10,7 @@ the FANs of any other gravitational waves in the dataset.
 import argparse, itertools
 import lal, logging, numpy
 from pycbc.events import veto, coinc, significance
-import pycbc.version, pycbc.pnutils, pycbc.io
+import pycbc.pnutils, pycbc.io
 import sys
 import pycbc.conversions as conv
 
@@ -35,8 +35,6 @@ class fw(object):
 parser = argparse.ArgumentParser()
 # General required options
 pycbc.add_common_pycbc_options(parser)
-parser.add_argument('--version', action='version',
-                    version=pycbc.version.git_verbose_msg)
 parser.add_argument('--coinc-files', nargs='+',
                     help='List of coincidence files used to calculate the '
                          'FAP, FAR, etc.')

--- a/bin/all_sky_search/pycbc_coinc_statmap_inj
+++ b/bin/all_sky_search/pycbc_coinc_statmap_inj
@@ -6,15 +6,12 @@ with producing the combined foreground and background triggers
 """
 import argparse, logging, itertools, copy, pycbc.io, numpy, lal
 from pycbc.events import veto, coinc, significance
-import pycbc.version
 import pycbc.conversions as conv
 from pycbc import init_logging
 
 parser = argparse.ArgumentParser()
 # General required options
 pycbc.add_common_pycbc_options(parser)
-parser.add_argument('--version', action='version',
-                    version=pycbc.version.git_verbose_msg)
 parser.add_argument('--cluster-window', type=float, default=10,
                     help='Length of time window in seconds to cluster coinc '
                          'events [default=10s]')

--- a/bin/all_sky_search/pycbc_combine_coincident_events
+++ b/bin/all_sky_search/pycbc_combine_coincident_events
@@ -9,7 +9,6 @@ import logging
 
 import pycbc
 from pycbc.io import HFile
-import pycbc.version
 
 def com(f, files, group):
     """ Combine the same column from multiple files into another file f"""
@@ -56,7 +55,6 @@ def com_with_detector_key(f, files, group):
 
 parser = argparse.ArgumentParser()
 pycbc.add_common_pycbc_options(parser)
-parser.add_argument("--version", action="version", version=pycbc.version.git_verbose_msg)
 parser.add_argument('--statmap-files', nargs='+',
                     help="List of coinc files to be redistributed")
 parser.add_argument('--output-file', help="name of output file")

--- a/bin/all_sky_search/pycbc_combine_statmap
+++ b/bin/all_sky_search/pycbc_combine_statmap
@@ -5,12 +5,10 @@ significant foreground, but leaves the background triggers alone.
 """
 
 import numpy, argparse, logging, pycbc, pycbc.events, pycbc.io, lal
-import pycbc.version
 from ligo import segments
 
 parser = argparse.ArgumentParser()
 pycbc.add_common_pycbc_options(parser)
-parser.add_argument("--version", action="version", version=pycbc.version.git_verbose_msg)
 parser.add_argument('--statmap-files', nargs='+',
                     help="List of coinc files to be redistributed")
 parser.add_argument('--cluster-window', type=float)

--- a/bin/all_sky_search/pycbc_cut_merge_triggers_to_tmpltbank
+++ b/bin/all_sky_search/pycbc_cut_merge_triggers_to_tmpltbank
@@ -26,13 +26,10 @@ import argparse
 import numpy
 import h5py
 import pycbc
-import pycbc.version
 from pycbc.io import HFile
 
 parser = argparse.ArgumentParser(description=__doc__)
 pycbc.add_common_pycbc_options(parser)
-parser.add_argument("--version", action="version",
-                    version=pycbc.version.git_verbose_msg)
 parser.add_argument("--input-file", required=True,
                     help="Input merge triggers HDF file.")
 parser.add_argument("--output-file", required=True,

--- a/bin/all_sky_search/pycbc_distribute_background_bins
+++ b/bin/all_sky_search/pycbc_distribute_background_bins
@@ -1,9 +1,7 @@
 #!/bin/env python
 import argparse, numpy, pycbc.events, logging, pycbc.events, pycbc.io
-import pycbc.version
 
 parser = argparse.ArgumentParser()
-parser.add_argument("--version", action=pycbc.version.Version)
 pycbc.add_common_pycbc_options(parser)
 parser.add_argument('--coinc-files', nargs='+',
                     help="List of coinc files to be redistributed")

--- a/bin/all_sky_search/pycbc_exclude_zerolag
+++ b/bin/all_sky_search/pycbc_exclude_zerolag
@@ -5,14 +5,11 @@ coincidences from *any* coincidence type with ifar above a certain threshold
 """
 
 import numpy as np, argparse, logging, pycbc, pycbc.io
-import pycbc.version
 from pycbc.events import veto, coinc, significance
 import pycbc.conversions as conv
 
 parser = argparse.ArgumentParser()
 pycbc.add_common_pycbc_options(parser)
-parser.add_argument("--version", action="version",
-                    version=pycbc.version.git_verbose_msg)
 parser.add_argument('--statmap-file', type=str,
     help="Coinc statmap file to be recalculated based on foreground removal")
 parser.add_argument('--other-statmap-files', nargs='+',

--- a/bin/all_sky_search/pycbc_fit_sngls_binned
+++ b/bin/all_sky_search/pycbc_fit_sngls_binned
@@ -22,6 +22,7 @@ from matplotlib import pyplot as plt
 
 import copy, numpy as np
 
+import pycbc
 from pycbc import events, bin_utils, results
 from pycbc.events import triggers
 from pycbc.events import trigger_fits as trstats

--- a/bin/all_sky_search/pycbc_fit_sngls_binned
+++ b/bin/all_sky_search/pycbc_fit_sngls_binned
@@ -27,7 +27,6 @@ from pycbc.events import triggers
 from pycbc.events import trigger_fits as trstats
 from pycbc.events import stat as pystat
 from pycbc.io import HFile
-import pycbc.version
 
 #### MAIN ####
 
@@ -35,7 +34,6 @@ parser = argparse.ArgumentParser(usage="",
     description="Perform maximum-likelihood fits of single inspiral trigger"
                 " distributions to various functions")
 pycbc.add_common_pycbc_options(parser)
-parser.add_argument("--version", action=pycbc.version.Version)
 parser.add_argument("--trigger-file",
                     help="Input hdf5 file containing single triggers. "
                     "Required")

--- a/bin/all_sky_search/pycbc_fit_sngls_by_template
+++ b/bin/all_sky_search/pycbc_fit_sngls_by_template
@@ -18,6 +18,7 @@ import argparse, logging
 
 import copy, numpy as np
 
+import pycbc
 from pycbc import events, init_logging
 from pycbc.events import triggers, trigger_fits as trstats
 from pycbc.events import stat as statsmod

--- a/bin/all_sky_search/pycbc_fit_sngls_by_template
+++ b/bin/all_sky_search/pycbc_fit_sngls_by_template
@@ -22,7 +22,6 @@ from pycbc import events, init_logging
 from pycbc.events import triggers, trigger_fits as trstats
 from pycbc.events import stat as statsmod
 from pycbc.types.optparse import MultiDetOptionAction
-import pycbc.version
 from pycbc.io import HFile
 
 #### DEFINITIONS AND FUNCTIONS ####
@@ -61,7 +60,6 @@ parser = argparse.ArgumentParser(usage="",
     description="Perform maximum-likelihood fits of single inspiral trigger"
                 " distributions to various functions")
 pycbc.add_common_pycbc_options(parser)
-parser.add_argument("--version", action=pycbc.version.Version)
 parser.add_argument("--trigger-file",
                     help="Input hdf5 file containing single triggers. "
                     "Required")

--- a/bin/all_sky_search/pycbc_fit_sngls_over_multiparam
+++ b/bin/all_sky_search/pycbc_fit_sngls_over_multiparam
@@ -15,6 +15,8 @@
 
 import sys, argparse, logging, numpy
 from scipy.stats import norm
+
+import pycbc
 from pycbc.events import triggers
 from pycbc.io import HFile
 from pycbc import init_logging

--- a/bin/all_sky_search/pycbc_fit_sngls_over_multiparam
+++ b/bin/all_sky_search/pycbc_fit_sngls_over_multiparam
@@ -13,7 +13,7 @@
 # Public License for more details.
 
 
-import sys, argparse, logging, pycbc.version, numpy
+import sys, argparse, logging, numpy
 from scipy.stats import norm
 from pycbc.events import triggers
 from pycbc.io import HFile
@@ -177,7 +177,6 @@ parser = argparse.ArgumentParser(usage="",
                 "background model.")
 
 pycbc.add_common_pycbc_options(parser)
-parser.add_argument("--version", action=pycbc.version.Version)
 parser.add_argument("--template-fit-file", required=True, nargs='+',
                     help="hdf5 file(s) containing fit coefficients for each "
                          "individual template. Can smooth over multiple "

--- a/bin/all_sky_search/pycbc_fit_sngls_over_param
+++ b/bin/all_sky_search/pycbc_fit_sngls_over_param
@@ -18,6 +18,7 @@ import argparse, logging
 
 import numpy as np
 
+import pycbc
 from pycbc import init_logging
 from pycbc.io import HFile
 from pycbc.events import triggers

--- a/bin/all_sky_search/pycbc_fit_sngls_over_param
+++ b/bin/all_sky_search/pycbc_fit_sngls_over_param
@@ -21,7 +21,6 @@ import numpy as np
 from pycbc import init_logging
 from pycbc.io import HFile
 from pycbc.events import triggers
-import pycbc.version
 
 parser = argparse.ArgumentParser(usage="",
     description="Smooth (regress) the dependence of coefficients describing "
@@ -30,7 +29,6 @@ parser = argparse.ArgumentParser(usage="",
                 "background model.")
 
 pycbc.add_common_pycbc_options(parser)
-parser.add_argument("--version", action=pycbc.version.Version)
 parser.add_argument("--template-fit-file",
                     help="Input hdf5 file containing fit coefficients for each"
                          " individual template. Required")

--- a/bin/all_sky_search/pycbc_followup_file
+++ b/bin/all_sky_search/pycbc_followup_file
@@ -7,8 +7,6 @@ from pycbc.io import HFile
 
 parser = argparse.ArgumentParser()
 pycbc.add_common_pycbc_options(parser)
-parser.add_argument('--version', action='version',
-    version=pycbc.version.git_verbose_msg)
 parser.add_argument('--statmap-file',
     help="Statmap file containing the candidates/background to follow up")
 parser.add_argument('--bank-file',

--- a/bin/all_sky_search/pycbc_foreground_censor
+++ b/bin/all_sky_search/pycbc_foreground_censor
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 """Make segment file to blind the results from foreground related triggers """
 
-import os, argparse, logging, pycbc.version
+import os, argparse, logging
 from urllib.parse import urlunparse
 import pycbc.events
 from pycbc.workflow import SegFile
@@ -9,7 +9,6 @@ from pycbc.io import HFile
 
 parser = argparse.ArgumentParser(description=__doc__)
 pycbc.add_common_pycbc_options(parser)
-parser.add_argument('--version', action='version', version=pycbc.version.git_verbose_msg)
 parser.add_argument('--foreground-triggers',
                     help="HDF file containing the zerolag foreground triggers "
                          "from the analysis")

--- a/bin/all_sky_search/pycbc_make_bayestar_skymap
+++ b/bin/all_sky_search/pycbc_make_bayestar_skymap
@@ -26,6 +26,7 @@ import tempfile
 
 from ligo.lw import lsctables, utils as ligolw_utils
 
+import pycbc
 from pycbc import init_logging
 from pycbc.waveform import bank as wavebank
 from pycbc.io import WaveformArray

--- a/bin/all_sky_search/pycbc_make_bayestar_skymap
+++ b/bin/all_sky_search/pycbc_make_bayestar_skymap
@@ -26,7 +26,6 @@ import tempfile
 
 from ligo.lw import lsctables, utils as ligolw_utils
 
-import pycbc.version
 from pycbc import init_logging
 from pycbc.waveform import bank as wavebank
 from pycbc.io import WaveformArray
@@ -34,8 +33,6 @@ from pycbc.io.ligolw import LIGOLWContentHandler
 
 parser = argparse.ArgumentParser(description=__doc__)
 pycbc.add_common_pycbc_options(parser)
-parser.add_argument('--version', action="version",
-                    version=pycbc.version.git_verbose_msg)
 parser.add_argument('--bayestar-executable',
                     help="The bayestar-localize-coinc executable to be run. "
                          "If not given, will use whatever is available in "

--- a/bin/all_sky_search/pycbc_merge_psds
+++ b/bin/all_sky_search/pycbc_merge_psds
@@ -18,12 +18,10 @@
 """ Merge hdf psd files
 """
 import logging, argparse, numpy, pycbc.types
-from pycbc.version import git_verbose_msg as version
 from pycbc.io import HFile
 
 parser = argparse.ArgumentParser(description=__doc__)
 pycbc.add_common_pycbc_options(parser)
-parser.add_argument('--version', action='version', version=version)
 parser.add_argument('--psd-files', nargs='+')
 parser.add_argument("--output-file", required=True)
 

--- a/bin/all_sky_search/pycbc_reduce_template_bank
+++ b/bin/all_sky_search/pycbc_reduce_template_bank
@@ -26,13 +26,10 @@ import logging
 import imp
 import argparse
 import pycbc
-import pycbc.version
 from pycbc.io import HFile
 
 parser = argparse.ArgumentParser(description=__doc__)
 pycbc.add_common_pycbc_options(parser)
-parser.add_argument("--version", action="version",
-                    version=pycbc.version.git_verbose_msg)
 parser.add_argument("--input-bank", required=True,
                     help="Input template bank HDF file.")
 parser.add_argument("--output-bank", required=True,

--- a/bin/all_sky_search/pycbc_rerank_passthrough
+++ b/bin/all_sky_search/pycbc_rerank_passthrough
@@ -5,8 +5,6 @@ from pycbc.io import HFile
 
 parser = argparse.ArgumentParser()
 pycbc.add_common_pycbc_options(parser)
-parser.add_argument('--version', action='version',
-    version=pycbc.version.git_verbose_msg)
 parser.add_argument('--output-file',
     help="File containing the newly assigned statistic values")
 

--- a/bin/all_sky_search/pycbc_sngls_findtrigs
+++ b/bin/all_sky_search/pycbc_sngls_findtrigs
@@ -4,7 +4,6 @@ from ligo.segments import infinity
 from numpy.random import seed, shuffle
 from pycbc.events import veto, coinc, stat
 import pycbc.conversions as conv
-import pycbc.version
 from pycbc import io
 from pycbc.events import cuts, trigger_fits as trfits
 from pycbc.events.veto import indices_outside_times
@@ -13,8 +12,6 @@ from pycbc import init_logging
 
 parser = argparse.ArgumentParser()
 pycbc.add_common_pycbc_options(parser)
-parser.add_argument("--version", action='version',
-                    version=pycbc.version.git_verbose_msg)
 # Basic file input options
 parser.add_argument("--trigger-files", type=str, nargs=1,
                     help="File containing single-detector triggers")

--- a/bin/all_sky_search/pycbc_sngls_findtrigs
+++ b/bin/all_sky_search/pycbc_sngls_findtrigs
@@ -2,6 +2,8 @@
 import argparse, logging, h5py, numpy as np
 from ligo.segments import infinity
 from numpy.random import seed, shuffle
+
+import pycbc
 from pycbc.events import veto, coinc, stat
 import pycbc.conversions as conv
 from pycbc import io

--- a/bin/all_sky_search/pycbc_sngls_pastro
+++ b/bin/all_sky_search/pycbc_sngls_pastro
@@ -17,7 +17,6 @@ from pycbc import conversions as conv
 from pycbc.events import veto, stat, ranking, coinc, single as sngl
 from pycbc.io.ligolw import LIGOLWContentHandler
 from ligo.segments import segment, segmentlist
-import pycbc.version
 import matplotlib
 matplotlib.use('agg')
 from matplotlib import pyplot as plt
@@ -40,8 +39,6 @@ mchirp_power = {
 
 parser = argparse.ArgumentParser()
 pycbc.add_common_pycbc_options(parser)
-parser.add_argument("--version", action='version',
-                    version=pycbc.version.git_verbose_msg)
 parser.add_argument("--single-statmap-files", nargs='+', required=True,
                     help="Single statmap files for which p_astro is "
                          "calculated.")

--- a/bin/all_sky_search/pycbc_sngls_statmap
+++ b/bin/all_sky_search/pycbc_sngls_statmap
@@ -10,7 +10,7 @@ import logging, numpy, copy
 from pycbc.events import veto, coinc
 from pycbc.events import triggers, trigger_fits as trstats
 from pycbc.events import significance
-import pycbc.version, pycbc.pnutils, pycbc.io
+import pycbc.pnutils, pycbc.io
 import sys
 import pycbc.conversions as conv
 
@@ -35,8 +35,6 @@ class fw(object):
 parser = argparse.ArgumentParser()
 # General required options
 pycbc.add_common_pycbc_options(parser)
-parser.add_argument('--version', action='version',
-                    version=pycbc.version.git_verbose_msg)
 parser.add_argument('--sngls-files', nargs='+',
                     help='List of files containing trigger and statistic '
                          'information.')

--- a/bin/all_sky_search/pycbc_sngls_statmap_inj
+++ b/bin/all_sky_search/pycbc_sngls_statmap_inj
@@ -10,7 +10,7 @@ import lal, logging, numpy
 from pycbc.events import veto, coinc
 from pycbc.events import triggers, trigger_fits as trstats
 from pycbc.events import significance
-import pycbc.version, pycbc.pnutils, pycbc.io
+import pycbc.pnutils, pycbc.io
 import sys
 import pycbc.conversions as conv
 
@@ -35,8 +35,6 @@ class fw(object):
 parser = argparse.ArgumentParser()
 # General required options
 pycbc.add_common_pycbc_options(parser)
-parser.add_argument('--version', action='version',
-                    version=pycbc.version.git_verbose_msg)
 parser.add_argument('--sngls-files', nargs='+',
                     help='List of files containign trigger and statistic '
                          'information.')

--- a/bin/all_sky_search/pycbc_strip_injections
+++ b/bin/all_sky_search/pycbc_strip_injections
@@ -1,5 +1,5 @@
 #!/bin/env python
-import numpy, argparse, pycbc.version, pycbc.pnutils, logging
+import numpy, argparse, pycbc.pnutils, logging
 from pycbc.events import veto
 from pycbc.io.ligolw import LIGOLWContentHandler
 from ligo.lw import ligolw, table, utils as ligolw_utils
@@ -13,7 +13,6 @@ def remove(l, i):
 
 parser = argparse.ArgumentParser()
 pycbc.add_common_pycbc_options(parser)
-parser.add_argument('--version', action='version', version=pycbc.version.git_verbose_msg)
 parser.add_argument('--injection-file')
 parser.add_argument('--veto-file', 
                       help="File containing segments used to veto injections")

--- a/bin/bank/pycbc_aligned_bank_cat
+++ b/bin/bank/pycbc_aligned_bank_cat
@@ -25,7 +25,6 @@ import logging
 import glob
 import argparse
 import numpy
-import pycbc.version
 from ligo.lw import utils
 from pycbc import tmpltbank
 # Old ligolw output functions no longer imported at package level
@@ -49,7 +48,6 @@ parser = argparse.ArgumentParser(description=__doc__,
            formatter_class=tmpltbank.IndentedHelpFormatterWithNL)
 
 pycbc.add_common_pycbc_options(parser)
-parser.add_argument("--version", action="version", version=__version__)
 parser.add_argument("-i", "--input-glob",
                     help="file glob the list of paramters")
 parser.add_argument("-I", "--input-files", nargs='+',

--- a/bin/bank/pycbc_aligned_stoch_bank
+++ b/bin/bank/pycbc_aligned_stoch_bank
@@ -25,7 +25,6 @@ import numpy
 import logging
 
 import pycbc
-import pycbc.version
 from pycbc import tmpltbank
 # Old ligolw output functions no longer imported at package level
 import pycbc.tmpltbank.bank_output_utils as bank_output
@@ -34,10 +33,6 @@ import pycbc.psd
 import pycbc.strain
 from pycbc.pnutils import named_frequency_cutoffs
 
-
-__author__  = "Ian Harry <ian.harry@astro.cf.ac.uk>"
-__version__ = pycbc.version.git_verbose_msg
-__program__ = "pycbc_aligned_stoch_bank"
 
 # Read command line option
 _desc = __doc__[1:]

--- a/bin/bank/pycbc_aligned_stoch_bank
+++ b/bin/bank/pycbc_aligned_stoch_bank
@@ -45,7 +45,6 @@ parser = argparse.ArgumentParser(description=_desc,
            formatter_class=tmpltbank.IndentedHelpFormatterWithNL)
 
 # Begin with code specific options
-parser.add_argument("--version", action="version", version=__version__)
 pycbc.add_common_pycbc_options(parser)
 parser.add_argument("-V", "--vary-fupper", action="store_true", default=False,
                     help="Use a variable upper frequency cutoff in laying "

--- a/bin/bank/pycbc_bank_verification
+++ b/bin/bank/pycbc_bank_verification
@@ -49,7 +49,6 @@ parser = argparse.ArgumentParser(description=__doc__,
            formatter_class=tmpltbank.IndentedHelpFormatterWithNL)
 
 # Begin with code specific options
-parser.add_argument("--version", action="version", version=__version__)
 pycbc.add_common_pycbc_options(parser)
 parser.add_argument("--histogram-output-file", action="store", default=None,
                     help="Output a histogram of fitting factors to the "

--- a/bin/bank/pycbc_coinc_bank2hdf
+++ b/bin/bank/pycbc_coinc_bank2hdf
@@ -55,8 +55,6 @@ def parse_parameters(parameters):
     return outnames, columns
 
 parser = argparse.ArgumentParser()
-parser.add_argument('--version', action='version',
-                    version=pycbc.version.git_verbose_msg)
 pycbc.add_common_pycbc_options(parser)
 parser.add_argument('--bank-file', required=True,
                     help="The bank file to load. Must end in '.xml[.gz]' "

--- a/bin/bank/pycbc_geom_aligned_2dstack
+++ b/bin/bank/pycbc_geom_aligned_2dstack
@@ -50,7 +50,6 @@ parser = argparse.ArgumentParser(usage, description=_desc,
            formatter_class=pycbc.tmpltbank.IndentedHelpFormatterWithNL)
 pycbc.add_common_pycbc_options(parser)
 # Code specific options
-parser.add_argument('--version', action='version', version=__version__)
 parser.add_argument("--pn-order", action="store", type=str,\
                   default=None,\
                   help="Determines the PN order to use. Note that if you "+\

--- a/bin/bank/pycbc_geom_aligned_bank
+++ b/bin/bank/pycbc_geom_aligned_bank
@@ -178,7 +178,6 @@ parser = argparse.ArgumentParser(description=_desc,
 
 # Begin with code specific options
 pycbc.add_common_pycbc_options(parser)
-parser.add_argument('--version', action='version', version=__version__)
 parser.add_argument("-s", "--stack-distance", action="store", type=float,\
                   default=0.2, help="Minimum metric spacing before we "+\
                                "stack.")

--- a/bin/bank/pycbc_geom_nonspinbank
+++ b/bin/bank/pycbc_geom_nonspinbank
@@ -48,7 +48,6 @@ parser = argparse.ArgumentParser(
     formatter_class=tmpltbank.IndentedHelpFormatterWithNL)
 
 # Begin with code specific options
-parser.add_argument('--version', action='version', version=__version__)
 pycbc.add_common_pycbc_options(parser)
 parser.add_argument("--random-seed", action="store", type=int,
                     default=None,

--- a/bin/bank/pycbc_tmpltbank_to_chi_params
+++ b/bin/bank/pycbc_tmpltbank_to_chi_params
@@ -45,7 +45,6 @@ parser = argparse.ArgumentParser(description=__doc__,
            formatter_class=tmpltbank.IndentedHelpFormatterWithNL)
 
 # Begin with code specific options
-parser.add_argument("--version", action="version", version=__version__)
 pycbc.add_common_pycbc_options(parser)
 parser.add_argument("--input-bank", action="store", required=True,
                     help="The template bank to use an input.")

--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -31,7 +31,6 @@ from pycbc import (distributions, transforms, fft,
                    opt, scheme, pool)
 from pycbc.waveform import generator
 
-from pycbc import __version__
 from pycbc import inference
 from pycbc.inference import (models, burn_in, option_utils)
 from pycbc.inference.io import loadfile
@@ -41,8 +40,6 @@ from pycbc.workflow import configuration
 parser = argparse.ArgumentParser(usage=__file__ + " [--options]",
                                  description=__doc__)
 pycbc.add_common_pycbc_options(parser)
-parser.add_argument("--version", action="version", version=__version__,
-                    help="Prints version information.")
 # output options
 parser.add_argument("--output-file", type=str, required=True,
                     help="Output file path.")

--- a/bin/inference/pycbc_inference_plot_acceptance_rate
+++ b/bin/inference/pycbc_inference_plot_acceptance_rate
@@ -23,9 +23,7 @@ use('agg')
 import matplotlib.pyplot as plt
 import numpy
 import pycbc
-import pycbc.version
 from pycbc import results
-from pycbc import __version__
 from pycbc.inference import io
 import sys
 
@@ -37,8 +35,6 @@ parser = argparse.ArgumentParser(
 pycbc.add_common_pycbc_options(parser)
 parser.add_argument("--input-file", type=str, required=True,
                     help="Path to input HDF file.")
-parser.add_argument('--version', action='version', version=__version__,
-                    help='show version number and exit')
 # output plot options
 parser.add_argument("--output-file", type=str, required=True,
                     help="Path to output plot.")

--- a/bin/inference/pycbc_inference_plot_acf
+++ b/bin/inference/pycbc_inference_plot_acf
@@ -29,7 +29,6 @@ import pycbc
 from pycbc import results
 from pycbc.inference import io
 
-from pycbc import __version__
 from pycbc.inference import option_utils
 from pycbc.inference.sampler import samplers
 
@@ -39,8 +38,6 @@ parser = io.ResultsArgumentParser(skip_args='thin-interval',
                                   description="Plots autocorrelation function "
                                               "from inference samples.")
 pycbc.add_common_pycbc_options(parser)
-parser.add_argument('--version', action='version', version=__version__,
-                    help='show version number and exit')
 # output plot options
 parser.add_argument("--output-file", type=str, required=True,
                     help="Path to output plot.")

--- a/bin/inference/pycbc_inference_plot_acl
+++ b/bin/inference/pycbc_inference_plot_acl
@@ -30,7 +30,6 @@ import pycbc
 from pycbc import results
 from pycbc.filter import autocorrelation
 
-from pycbc import __version__
 from pycbc.inference import io
 
 # command line usage
@@ -40,8 +39,6 @@ parser = io.ResultsArgumentParser(skip_args=['thin-interval', 'temps'],
                                               "length per walker from an MCMC "
                                               "sampler.")
 pycbc.add_common_pycbc_options(parser)
-parser.add_argument('--version', action='version', version=__version__,
-                    help='show version number and exit')
 # output plot options
 parser.add_argument("--output-file", type=str, required=True,
     help="Path to output plot.")

--- a/bin/inference/pycbc_inference_plot_dynesty_run
+++ b/bin/inference/pycbc_inference_plot_dynesty_run
@@ -26,7 +26,6 @@ from dynesty import plotting as dyplot
 
 from pycbc.inference import io
 import pycbc
-from pycbc import __version__
 from pycbc import results
 import sys
 
@@ -37,8 +36,6 @@ parser = argparse.ArgumentParser(
 pycbc.add_common_pycbc_options(parser)
 parser.add_argument("--input-file", type=str, required=True,
                     help="Path to input HDF file.")
-parser.add_argument('--version', action='version', version=__version__,
-                    help='show version number and exit')
 # output plot options
 parser.add_argument("--output-file", type=str, required=True,
                     help="Path to output plot.")

--- a/bin/inference/pycbc_inference_plot_dynesty_traceplot
+++ b/bin/inference/pycbc_inference_plot_dynesty_traceplot
@@ -26,7 +26,6 @@ from dynesty import plotting as dyplot
 
 from pycbc.inference import io
 import pycbc
-from pycbc import __version__
 from pycbc import results
 import sys
 
@@ -39,8 +38,6 @@ parser = argparse.ArgumentParser(
 pycbc.add_common_pycbc_options(parser)
 parser.add_argument("--input-file", type=str, required=True,
                     help="Path to input HDF file.")
-parser.add_argument('--version', action='version', version=__version__,
-                    help='show version number and exit')
 # output plot options
 parser.add_argument("--output-file", type=str, required=True,
                     help="Path to output plot.")

--- a/bin/inference/pycbc_inference_plot_gelman_rubin
+++ b/bin/inference/pycbc_inference_plot_gelman_rubin
@@ -25,7 +25,7 @@ import matplotlib.pyplot as plt
 import sys
 
 from pycbc import (
-    __version__, results, init_logging, add_common_pycbc_options
+    results, init_logging, add_common_pycbc_options
 )
 from pycbc.inference import (gelman_rubin, io, option_utils)
 
@@ -33,8 +33,6 @@ from pycbc.inference import (gelman_rubin, io, option_utils)
 parser = io.ResultsArgumentParser(skip_args=['walkers'])
 
 add_common_pycbc_options(parser)
-parser.add_argument('--version', action='version', version=__version__,
-                    help='show version number and exit')
 
 # output options
 parser.add_argument("--output-file", type=str, required=True,

--- a/bin/inference/pycbc_inference_plot_geweke
+++ b/bin/inference/pycbc_inference_plot_geweke
@@ -26,7 +26,6 @@ import pycbc
 from pycbc import results
 import sys
 
-from pycbc import __version__
 from pycbc.inference import (io, geweke, option_utils)
 
 # add options to command line
@@ -35,9 +34,6 @@ parser = io.ResultsArgumentParser(skip_args=['walkers'])
 pycbc.add_common_pycbc_options(parser)
 
 # program-specific
-
-parser.add_argument('--version', action='version', version=__version__,
-                    help='show version number and exit')
 
 # output options
 parser.add_argument("--output-file", type=str, required=True,

--- a/bin/inference/pycbc_inference_plot_inj_recovery
+++ b/bin/inference/pycbc_inference_plot_inj_recovery
@@ -11,10 +11,8 @@ import matplotlib.colorbar as cbar
 import matplotlib.pyplot as plt
 import numpy
 import pycbc
-import pycbc.version
 from matplotlib import cm
 from pycbc import inject
-from pycbc import __version__
 from pycbc.inference import (option_utils, io)
 from pycbc.results import save_fig_with_metadata
 
@@ -22,8 +20,6 @@ from pycbc.results import save_fig_with_metadata
 parser = io.ResultsArgumentParser(description=__doc__)
 
 pycbc.add_common_pycbc_options(parser)
-parser.add_argument("--version", action="version", version=__version__,
-                    help="Prints version information.")
 parser.add_argument("--output-file", required=True, type=str,
                     help="Path to save output plot.")
 parser.add_argument("--percentiles", nargs=2, type=float, default=[5, 95],

--- a/bin/inference/pycbc_inference_plot_movie
+++ b/bin/inference/pycbc_inference_plot_movie
@@ -53,7 +53,6 @@ from matplotlib import pyplot
 
 import pycbc.results
 from pycbc import conversions
-from pycbc import __version__
 from pycbc.inference import (option_utils, io)
 
 from pycbc.results.scatter_histograms import (create_multidim_plot,
@@ -111,8 +110,6 @@ def integer_logspace(start, end, num):
 skip_args = ['thin-start', 'thin-interval', 'thin-end', 'iteration']
 parser = io.ResultsArgumentParser(description=__doc__, skip_args=skip_args)
 pycbc.add_common_pycbc_options(parser)
-parser.add_argument("--version", action="version", version=__version__,
-                    help="show version number and exit")
 # make frame number and frame step mutually exclusive
 group = parser.add_mutually_exclusive_group(required=True)
 group.add_argument("--frame-number", type=int,

--- a/bin/inference/pycbc_inference_plot_posterior
+++ b/bin/inference/pycbc_inference_plot_posterior
@@ -36,11 +36,9 @@ import matplotlib
 from matplotlib import (patches, use)
 
 import pycbc
-import pycbc.version
 from pycbc.results.plot import (add_style_opt_to_parser, set_style_from_cli)
 from pycbc.results import metadata
 from pycbc.io import FieldArray
-from pycbc import __version__
 from pycbc import conversions
 from pycbc.workflow import WorkflowConfigParser
 from pycbc.inference import (option_utils, io)
@@ -54,8 +52,6 @@ use('agg')
 parser = io.ResultsArgumentParser()
 pycbc.add_common_pycbc_options(parser)
 # program-specific
-parser.add_argument("--version", action="version", version=__version__,
-                    help="Prints version information.")
 parser.add_argument("--output-file", type=str, required=True,
                     help="Output plot path.")
 parser.add_argument("--plot-prior", nargs="+", type=str,

--- a/bin/inference/pycbc_inference_plot_pp
+++ b/bin/inference/pycbc_inference_plot_pp
@@ -38,13 +38,9 @@ import pycbc.results.plot
 from pycbc.results import save_fig_with_metadata
 from pycbc.inference import (option_utils, io)
 
-from pycbc import __version__
-
 # parse command line
 parser = io.ResultsArgumentParser(description=__doc__)
 pycbc.add_common_pycbc_options(parser)
-parser.add_argument('--version', action='version', version=__version__,
-                    help='show version number and exit')
 parser.add_argument("--output-file", required=True, type=str,
                     help="Path to save output plot.")
 parser.add_argument("--injection-hdf-group", default="injections",

--- a/bin/inference/pycbc_inference_plot_prior
+++ b/bin/inference/pycbc_inference_plot_prior
@@ -28,7 +28,6 @@ use('agg')
 from matplotlib import pyplot as plt
 
 import pycbc
-from pycbc import __version__
 from pycbc import (distributions, results, waveform)
 from pycbc.inference.option_utils import ParseParametersArg
 from pycbc.distributions.utils import prior_from_config
@@ -76,8 +75,6 @@ parser.add_argument("--nsamples", type=int, default=10000,
                          "plotting. Default is 10000.")
 parser.add_argument("--output-file", type=str, required=True,
                     help="Path to output plot.")
-parser.add_argument("--version", action="version", version=__version__,
-                    help="show version number and exit")
 
 # parse the command line
 opts = parser.parse_args()

--- a/bin/inference/pycbc_inference_plot_samples
+++ b/bin/inference/pycbc_inference_plot_samples
@@ -27,7 +27,6 @@ from matplotlib import rc
 import numpy
 import pycbc
 from pycbc import results
-from pycbc import __version__
 from pycbc.inference import (option_utils, io)
 import sys
 
@@ -35,8 +34,6 @@ import sys
 parser = argparse.parser = io.ResultsArgumentParser(
     skip_args=['chains', 'iteration'])
 pycbc.add_common_pycbc_options(parser)
-parser.add_argument("--version", action="version", version=__version__,
-                    help="show version number and exit")
 parser.add_argument("--chains", nargs='+', default=None,
                     help="Chain/walker indices to plot. Options are 'all' or "
                          "one or more chain indices. Default is to plot the "

--- a/bin/live/pycbc_live_supervise_single_significance_fits
+++ b/bin/live/pycbc_live_supervise_single_significance_fits
@@ -465,7 +465,11 @@ def wait_for_utc_time(target_str):
 
 
 parser = argparse.ArgumentParser(description=__doc__)
-parser.add_argument('--config-file', required=True)
+pycbc.add_common_pycbc_options(parser)
+parser.add_argument(
+    '--config-file',
+    required=True
+)
 parser.add_argument(
     '--date',
     help='Date to analyse, if not given, will analyse yesterday (UTC). '
@@ -488,7 +492,7 @@ parser.add_argument(
 )
 args = parser.parse_args()
 
-pycbc.init_logging(True)
+pycbc.init_logging(args.verbose, default_level=1)
 
 if args.run_daily_at is not None and args.date is not None:
     parser.error('Cannot take --run-daily-at and --date at the same time')

--- a/bin/minifollowups/pycbc_foreground_minifollowup
+++ b/bin/minifollowups/pycbc_foreground_minifollowup
@@ -30,11 +30,9 @@ from pycbc.events import select_segments_by_definer, coinc
 from pycbc.io import get_all_subkeys, HFile
 import pycbc.workflow.minifollowups as mini
 from pycbc.workflow.core import resolve_url_to_file
-import pycbc.version
 
 parser = argparse.ArgumentParser(description=__doc__[1:])
 add_common_pycbc_options(parser)
-parser.add_argument('--version', action='version', version=pycbc.version.git_verbose_msg)
 parser.add_argument('--bank-file',
                     help="HDF format template bank file")
 parser.add_argument('--statmap-file',

--- a/bin/minifollowups/pycbc_injection_minifollowup
+++ b/bin/minifollowups/pycbc_injection_minifollowup
@@ -26,7 +26,6 @@ import numpy
 from pycbc import init_logging, add_common_pycbc_options
 import pycbc.workflow as wf
 import pycbc.workflow.minifollowups as mini
-import pycbc.version
 from pycbc.types import MultiDetOptionAction
 from pycbc.events import select_segments_by_definer, coinc
 from pycbc.results import layout
@@ -122,7 +121,6 @@ def sort_injections(args, inj_group, missed):
 
 parser = argparse.ArgumentParser(description=__doc__)
 add_common_pycbc_options(parser)
-parser.add_argument('--version', action='version', version=pycbc.version.git_verbose_msg)
 parser.add_argument('--bank-file',
                     help="HDF format template bank file")
 parser.add_argument('--injection-file',

--- a/bin/minifollowups/pycbc_page_coincinfo
+++ b/bin/minifollowups/pycbc_page_coincinfo
@@ -27,7 +27,6 @@ import numpy
 import lal
 
 from pycbc import add_common_pycbc_options
-import pycbc.version
 import pycbc.results
 import pycbc.pnutils
 from pycbc.io.hdf import HFile
@@ -36,8 +35,6 @@ from pycbc.results import followup
 
 parser = argparse.ArgumentParser()
 add_common_pycbc_options(parser)
-parser.add_argument('--version', action='version',
-    version=pycbc.version.git_verbose_msg)
 parser.add_argument('--single-trigger-files', nargs='+',
     help="HDF format single detector trigger files for the full data run")
 parser.add_argument('--bank-file',

--- a/bin/minifollowups/pycbc_page_injinfo
+++ b/bin/minifollowups/pycbc_page_injinfo
@@ -19,7 +19,6 @@ import argparse
 import sys
 import numpy
 
-import pycbc.version
 import pycbc.results
 import pycbc.pnutils
 from pycbc import init_logging, add_common_pycbc_options
@@ -28,8 +27,6 @@ from pycbc.io.hdf import HFile
 
 parser = argparse.ArgumentParser()
 add_common_pycbc_options(parser)
-parser.add_argument('--version', action='version',
-    version=pycbc.version.git_verbose_msg)
 parser.add_argument('--output-file')
 parser.add_argument('--injection-file', required=True,
     help="The HDF format injection file. Required")

--- a/bin/minifollowups/pycbc_page_snglinfo
+++ b/bin/minifollowups/pycbc_page_snglinfo
@@ -26,7 +26,7 @@ matplotlib.use('Agg')
 
 import lal
 
-import pycbc.version, pycbc.events, pycbc.results, pycbc.pnutils
+import pycbc.events, pycbc.results, pycbc.pnutils
 from pycbc.results import followup
 from pycbc.events import stat as pystat
 from pycbc.io import hdf
@@ -35,8 +35,6 @@ from pycbc import init_logging, add_common_pycbc_options
 
 parser = argparse.ArgumentParser()
 add_common_pycbc_options(parser)
-parser.add_argument('--version', action='version',
-    version=pycbc.version.git_verbose_msg)
 parser.add_argument('--single-trigger-file', required=True,
     help="HDF format single detector trigger files for the full "
          "data run")

--- a/bin/minifollowups/pycbc_plot_trigger_timeseries
+++ b/bin/minifollowups/pycbc_plot_trigger_timeseries
@@ -26,7 +26,6 @@ import pylab
 import numpy
 
 from pycbc import init_logging, add_common_pycbc_options
-import pycbc.version
 import pycbc.results
 from pycbc.types import MultiDetOptionAction
 from pycbc.events import ranking
@@ -34,8 +33,6 @@ from pycbc.io import HFile, SingleDetTriggers
 
 parser = argparse.ArgumentParser()
 add_common_pycbc_options(parser)
-parser.add_argument('--version', action='version',
-    version=pycbc.version.git_verbose_msg)
 parser.add_argument('--single-trigger-files', nargs='+',
     action=MultiDetOptionAction, metavar="IFO:FILE",
     help="The HDF format single detector merged trigger files, in "

--- a/bin/minifollowups/pycbc_single_template_plot
+++ b/bin/minifollowups/pycbc_single_template_plot
@@ -29,8 +29,6 @@ from pycbc.io.hdf import HFile
 
 parser = argparse.ArgumentParser(description=__doc__)
 pycbc.add_common_pycbc_options(parser)
-parser.add_argument('--version', action='version',
-    version=pycbc.version.git_verbose_msg)
 parser.add_argument('--single-template-file', required=True,
     help="HDF file containing the SNR and CHISQ timeseries. "
          " The output of pycbc_single_template")

--- a/bin/minifollowups/pycbc_sngl_minifollowup
+++ b/bin/minifollowups/pycbc_sngl_minifollowup
@@ -30,7 +30,6 @@ from pycbc.results import layout
 from pycbc.types.optparse import MultiDetOptionAction
 from pycbc.events import select_segments_by_definer
 import pycbc.workflow.minifollowups as mini
-import pycbc.version
 import pycbc.workflow as wf
 import pycbc.events
 from pycbc.workflow.core import resolve_url_to_file
@@ -39,7 +38,6 @@ from pycbc.io import hdf
 
 parser = argparse.ArgumentParser(description=__doc__[1:])
 add_common_pycbc_options(parser)
-parser.add_argument('--version', action='version', version=pycbc.version.git_verbose_msg)
 parser.add_argument('--bank-file',
                     help="HDF format template bank file")
 parser.add_argument('--single-detector-file',

--- a/bin/minifollowups/pycbc_upload_prep_minifollowup
+++ b/bin/minifollowups/pycbc_upload_prep_minifollowup
@@ -33,11 +33,9 @@ from pycbc.events import select_segments_by_definer, coinc
 from pycbc.io import get_all_subkeys, HFile
 import pycbc.workflow.minifollowups as mini
 from pycbc.workflow.core import resolve_url_to_file, resolve_td_option
-import pycbc.version
 
 parser = argparse.ArgumentParser(description=__doc__[1:])
 add_common_pycbc_options(parser)
-parser.add_argument('--version', action='version', version=pycbc.version.git_verbose_msg)
 parser.add_argument('--bank-file',
                     help="HDF format template bank file")
 parser.add_argument('--statmap-file',

--- a/bin/plotting/pycbc_banksim_plot_eff_fitting_factor
+++ b/bin/plotting/pycbc_banksim_plot_eff_fitting_factor
@@ -40,7 +40,6 @@ __program__ = "pycbc_banksim_plot_eff_fitting_factor"
 parser = argparse.ArgumentParser(usage='',
     description=__doc__)
 add_common_pycbc_options(parser)
-parser.add_argument("--version", action="version", version=__version__)
 parser.add_argument('--input-files', nargs='+', default=None, required=True,
                     help="List of input files.")
 parser.add_argument('--output-file', default=None, required=True,

--- a/bin/plotting/pycbc_banksim_plot_fitting_factors
+++ b/bin/plotting/pycbc_banksim_plot_fitting_factors
@@ -38,7 +38,6 @@ __program__ = "pycbc_banksim_plot_fitting_factors"
 parser = argparse.ArgumentParser(usage='',
     description="Plot fitting factor distribution.")
 pycbc.add_common_pycbc_options(parser)
-parser.add_argument("--version", action="version", version=__version__)
 parser.add_argument('--input-file', default=None, required=True,
                     help="List of input files.")
 parser.add_argument('--output-file', default=None, required=True,

--- a/bin/plotting/pycbc_banksim_table_point_injs
+++ b/bin/plotting/pycbc_banksim_table_point_injs
@@ -34,7 +34,6 @@ __program__ = "pycbc_banksim_table_point_injs"
 parser = argparse.ArgumentParser(usage='',
     description="Plot effective fitting factor vs mass1 and mass2.")
 pycbc.add_common_pycbc_options(parser)
-parser.add_argument("--version", action="version", version=__version__)
 parser.add_argument('--input-files', nargs='+', default=None, required=True,
                     help="List of input files.")
 parser.add_argument('--directory-links', nargs='+', default=None,

--- a/bin/plotting/pycbc_create_html_snippet
+++ b/bin/plotting/pycbc_create_html_snippet
@@ -26,7 +26,6 @@ import pycbc.results
 # parse command line
 parser = argparse.ArgumentParser()
 add_common_pycbc_options(parser)
-parser.add_argument("--version", action="version", version=pycbc.version.git_verbose_msg)
 parser.add_argument('--output-file', type=str,
                         help='Path of the output HTML file.')
 parser.add_argument('--html-text', type=str,

--- a/bin/plotting/pycbc_ifar_catalog
+++ b/bin/plotting/pycbc_ifar_catalog
@@ -25,7 +25,6 @@ import pylab
 from scipy.stats import norm, poisson
 
 import pycbc.results
-import pycbc.version
 from pycbc import conversions
 from pycbc import init_logging, add_common_pycbc_options
 from pycbc.io.hdf import HFile
@@ -34,8 +33,6 @@ parser = argparse.ArgumentParser(usage='pycbc_ifar_catalog [--options]',
                     description='Plots cumulative IFAR vs count for'
                           ' foreground triggers')
 add_common_pycbc_options(parser)
-parser.add_argument('--version', action='version',
-                    version=pycbc.version.git_verbose_msg)
 parser.add_argument('--trigger-files', nargs='+',
                     help='Path to coincident trigger HDF file(s)')
 parser.add_argument('--output-file', required=True,

--- a/bin/plotting/pycbc_page_coinc_snrchi
+++ b/bin/plotting/pycbc_page_coinc_snrchi
@@ -10,7 +10,6 @@ from pycbc.io import (
 )
 from pycbc import conversions, init_logging, add_common_pycbc_options
 from pycbc.detector import Detector
-import pycbc.version
 
 def snr_from_chisq(chisq, newsnr, q=6.):
     snr = numpy.zeros(len(chisq)) + float(newsnr)
@@ -20,8 +19,6 @@ def snr_from_chisq(chisq, newsnr, q=6.):
 
 parser = argparse.ArgumentParser()
 add_common_pycbc_options(parser)
-parser.add_argument("--version", action="version",
-                    version=pycbc.version.git_verbose_msg)
 parser.add_argument('--found-injection-file', required=True,
                     help='HDF format found injection file. Required')
 parser.add_argument('--single-injection-file', required=True,

--- a/bin/plotting/pycbc_page_dq_table
+++ b/bin/plotting/pycbc_page_dq_table
@@ -8,11 +8,9 @@ import numpy as np
 
 import pycbc
 import pycbc.results
-from pycbc.version import git_verbose_msg as version
 
 parser = argparse.ArgumentParser(description=__doc__)
 pycbc.add_common_pycbc_options(parser)
-parser.add_argument("--version", action="version", version=version)
 parser.add_argument('--ifo', required=True)
 parser.add_argument('--dq-file', required=True)
 parser.add_argument('--output-file')

--- a/bin/plotting/pycbc_page_foreground
+++ b/bin/plotting/pycbc_page_foreground
@@ -11,15 +11,12 @@ import numpy
 
 import pycbc
 import pycbc.results
-import pycbc.version
 from pycbc.io import hdf
 from pycbc.pnutils import mass1_mass2_to_mchirp_eta
 
 
 parser = argparse.ArgumentParser(description=__doc__)
 pycbc.add_common_pycbc_options(parser)
-parser.add_argument("--version", action="version",
-                    version=pycbc.version.git_verbose_msg)
 parser.add_argument('--trigger-file', required=True)
 parser.add_argument('--bank-file', required=True)
 parser.add_argument('--single-detector-triggers', nargs='+')

--- a/bin/plotting/pycbc_page_foundmissed
+++ b/bin/plotting/pycbc_page_foundmissed
@@ -10,7 +10,7 @@ import matplotlib
 matplotlib.use('Agg')
 import matplotlib.pyplot as plot
 
-import pycbc.results.followup, pycbc.pnutils, pycbc.results, pycbc.version
+import pycbc.results.followup, pycbc.pnutils, pycbc.results
 import pycbc.pnutils
 from pycbc import init_logging, add_common_pycbc_options
 from pycbc.detector import Detector
@@ -64,8 +64,6 @@ parser.add_argument('--far-type', choices=('inclusive', 'exclusive'),
 parser.add_argument('--missed-on-top', action='store_true',
                     help="Plot missed injections on top of found ones and "
                          "high FAR on top of low FAR")
-parser.add_argument('--version', action='version',
-                    version=pycbc.version.git_verbose_msg)
 args = parser.parse_args()
 
 init_logging(args.verbose)

--- a/bin/plotting/pycbc_page_ifar
+++ b/bin/plotting/pycbc_page_ifar
@@ -27,7 +27,6 @@ from ligo import segments
 
 from pycbc import init_logging, add_common_pycbc_options
 import pycbc.results
-import pycbc.version
 from pycbc.events import veto
 from pycbc import conversions as conv
 from pycbc.io import HFile
@@ -52,8 +51,6 @@ parser = argparse.ArgumentParser(usage='pycbc_page_ifar [--options]',
                           'coincident foreground triggers and a subset of' 
                           'the coincident time slide triggers.')
 add_common_pycbc_options(parser)
-parser.add_argument('--version', action='version',
-                    version=pycbc.version.git_verbose_msg)
 parser.add_argument('--trigger-file', type=str, required=True,
                     help='Path to coincident trigger HDF file.')
 parser.add_argument('--output-file', type=str, required=True,

--- a/bin/plotting/pycbc_page_injtable
+++ b/bin/plotting/pycbc_page_injtable
@@ -10,7 +10,6 @@ import pycbc.results
 import pycbc.detector
 import pycbc.pnutils
 import pycbc.events
-import pycbc.version
 from pycbc.io.hdf import HFile
 from pycbc import add_common_pycbc_options, init_logging
 from pycbc.types import MultiDetOptionAction
@@ -18,8 +17,6 @@ from pycbc.types import MultiDetOptionAction
 
 parser = argparse.ArgumentParser(description=__doc__)
 add_common_pycbc_options(parser)
-parser.add_argument("--version", action="version",
-                    version=pycbc.version.git_verbose_msg)
 parser.add_argument('--injection-file',
                     help='HDF File containing the matched injections')
 parser.add_argument('--single-trigger-files', nargs='*',

--- a/bin/plotting/pycbc_page_recovery
+++ b/bin/plotting/pycbc_page_recovery
@@ -5,15 +5,13 @@ import numpy, logging, argparse, sys, matplotlib
 matplotlib.use("Agg")
 import matplotlib.pyplot as plot
 
-import pycbc.version, pycbc.detector
+import pycbc.detector
 from pycbc import pnutils, results
 from pycbc.events import triggers
 from pycbc.io.hdf import HFile
 
 parser = argparse.ArgumentParser()
 pycbc.add_common_pycbc_options(parser)
-parser.add_argument("--version", action="version",
-                    version=pycbc.version.git_verbose_msg)
 parser.add_argument("--injection-file", required=True,
                     help="hdf injection file containing found injections. "
                          "Required")

--- a/bin/plotting/pycbc_page_segments
+++ b/bin/plotting/pycbc_page_segments
@@ -11,15 +11,12 @@ import mpld3
 import mpld3.plugins
 from matplotlib.patches import Rectangle
 
-import pycbc.version
 import pycbc.events
 from pycbc.results.mpld3_utils import MPLSlide, Tooltip
 
 
 parser = argparse.ArgumentParser()
 pycbc.add_common_pycbc_options(parser)
-parser.add_argument('--version', action='version',
-                    version=pycbc.version.git_verbose_msg)
 parser.add_argument('--segment-files', nargs='+',
                     help="List of segment files to plot")
 parser.add_argument('--output-file', help="output html file")

--- a/bin/plotting/pycbc_page_segplot
+++ b/bin/plotting/pycbc_page_segplot
@@ -16,7 +16,7 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-import argparse, pycbc.version
+import argparse
 import matplotlib; matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 import numpy, pylab, pycbc.events, mpld3, mpld3.plugins
@@ -30,12 +30,10 @@ from pycbc.events.veto import get_segment_definer_comments
 from pycbc.results.color import ifo_color
 from pycbc.results.mpld3_utils import MPLSlide, LineTooltip
 from pycbc.workflow import SegFile
-import pycbc.version
 
 # parse command line
 parser = argparse.ArgumentParser()
 add_common_pycbc_options(parser)
-parser.add_argument("--version", action="version", version=pycbc.version.git_verbose_msg)
 parser.add_argument('--segment-files', type=str, nargs="+",
                         help='XML files with a segment definer table to read.')
 parser.add_argument('--segment-names', type=str, nargs="+", required=False,

--- a/bin/plotting/pycbc_page_segtable
+++ b/bin/plotting/pycbc_page_segtable
@@ -28,7 +28,6 @@ from ligo import segments
 from pycbc.events.veto import get_segment_definer_comments
 from pycbc.results import save_fig_with_metadata
 from pycbc.workflow import SegFile
-import pycbc.version
 
 def powerset_ifos(ifo_set):
     combo_set = []
@@ -39,8 +38,6 @@ def powerset_ifos(ifo_set):
 # parse command line
 parser = argparse.ArgumentParser()
 pycbc.add_common_pycbc_options(parser)
-parser.add_argument("--version", action="version",
-                        version=pycbc.version.git_verbose_msg)
 parser.add_argument('--segment-files', type=str, nargs="+",
                         help='XML files with a segment definer table to read.')
 parser.add_argument('--segment-names', type=str, nargs="+", required=False, default="",

--- a/bin/plotting/pycbc_page_sensitivity
+++ b/bin/plotting/pycbc_page_sensitivity
@@ -13,15 +13,12 @@ import pylab
 import pycbc.pnutils
 import pycbc.results
 import pycbc
-import pycbc.version
 from pycbc import sensitivity
 from pycbc import conversions as conv
 from pycbc.io.hdf import HFile
 
 parser = argparse.ArgumentParser(description=__doc__)
 pycbc.add_common_pycbc_options(parser)
-parser.add_argument('--version', action='version',
-                    version=pycbc.version.git_verbose_msg)
 parser.add_argument('--injection-file', nargs='+',
                     help="Required. HDF format injection result file or space "
                     "separated list of files")

--- a/bin/plotting/pycbc_page_snrchi
+++ b/bin/plotting/pycbc_page_snrchi
@@ -9,7 +9,6 @@ matplotlib.use('Agg')
 import pylab
 
 import pycbc.results
-import pycbc.version
 from pycbc.events import veto
 from pycbc.io import (
     get_chisq_from_file_choice, chisq_choices, SingleDetTriggers, HFile
@@ -18,8 +17,6 @@ from pycbc.io import (
 parser = argparse.ArgumentParser()
 pycbc.add_common_pycbc_options(parser)
 parser.add_argument('--trigger-file', help='Single ifo trigger file')
-parser.add_argument('--version', action='version',
-                    version=pycbc.version.git_verbose_msg)
 parser.add_argument('--veto-file',
                     help='Optional, file of veto segments to remove triggers')
 parser.add_argument('--segment-name', default=None, type=str,

--- a/bin/plotting/pycbc_page_snrifar
+++ b/bin/plotting/pycbc_page_snrifar
@@ -12,7 +12,6 @@ from scipy.special import erfc, erfinv
 from pycbc.io.hdf import HFile
 
 import pycbc.results
-import pycbc.version
 from pycbc import conversions as conv
 
 def sigma_from_p(p):
@@ -41,8 +40,6 @@ far_from_p = numpy.vectorize(_far_from_p)
 parser = argparse.ArgumentParser()
 # General required options
 pycbc.add_common_pycbc_options(parser)
-parser.add_argument('--version', action='version',
-                    version=pycbc.version.git_verbose_msg)
 parser.add_argument('--trigger-file')
 parser.add_argument('--output-file')
 parser.add_argument('--not-cumulative', action='store_true')

--- a/bin/plotting/pycbc_page_snrratehist
+++ b/bin/plotting/pycbc_page_snrratehist
@@ -15,7 +15,6 @@ from scipy.special import erf, erfinv
 from pycbc.io.hdf import HFile
 
 import pycbc.results
-import pycbc.version
 from pycbc import conversions as conv
 
 def sigma_from_p(p):
@@ -28,8 +27,6 @@ def p_from_sigma(sig):
 parser = argparse.ArgumentParser()
 # General required options
 pycbc.add_common_pycbc_options(parser)
-parser.add_argument('--version', action='version',
-                    version=pycbc.version.git_verbose_msg)
 parser.add_argument('--trigger-file')
 parser.add_argument('--output-file')
 parser.add_argument('--bin-size', type=float)

--- a/bin/plotting/pycbc_page_template_bin_table
+++ b/bin/plotting/pycbc_page_template_bin_table
@@ -8,11 +8,9 @@ import numpy as np
 
 import pycbc
 import pycbc.results
-from pycbc.version import git_verbose_msg as version
 
 parser = argparse.ArgumentParser()
 pycbc.add_common_pycbc_options(parser)
-parser.add_argument("--version", action="version", version=version)
 parser.add_argument('--ifo', required=True)
 parser.add_argument('--dq-file', required=True)
 parser.add_argument('--output-file')

--- a/bin/plotting/pycbc_page_versioning
+++ b/bin/plotting/pycbc_page_versioning
@@ -9,15 +9,12 @@ pycbc results pages
 import argparse
 import logging
 
-import pycbc.version
 from pycbc import init_logging, add_common_pycbc_options
 from pycbc.results import (save_fig_with_metadata, html_escape,
     get_library_version_info, get_code_version_numbers)
 
 parser = argparse.ArgumentParser()
 pycbc.add_common_pycbc_options(parser)
-parser.add_argument('--version', action="version",
-                    version=pycbc.version.git_verbose_msg)
 parser.add_argument('--executables', nargs='+', required=True,
                     help="List of executables to provide version "
                          "information for")

--- a/bin/plotting/pycbc_page_versioning
+++ b/bin/plotting/pycbc_page_versioning
@@ -9,6 +9,7 @@ pycbc results pages
 import argparse
 import logging
 
+import pycbc
 from pycbc import init_logging, add_common_pycbc_options
 from pycbc.results import (save_fig_with_metadata, html_escape,
     get_library_version_info, get_code_version_numbers)

--- a/bin/plotting/pycbc_page_vetotable
+++ b/bin/plotting/pycbc_page_vetotable
@@ -28,7 +28,6 @@ from ligo.lw import utils
 
 import pycbc.results
 from pycbc.results import save_fig_with_metadata
-import pycbc.version
 from pycbc.io.ligolw import LIGOLWContentHandler
 
 
@@ -36,7 +35,6 @@ parser = argparse.ArgumentParser(description=__doc__)
 
 # add command line options
 pycbc.add_common_pycbc_options(parser)
-parser.add_argument("--version", action="version", version=pycbc.version.git_verbose_msg)
 parser.add_argument('--veto-definer-file', type=str,
                         help='XML files with a veto_definer table to read.')
 parser.add_argument('--output-file', type=str,

--- a/bin/plotting/pycbc_plot_bank_bins
+++ b/bin/plotting/pycbc_plot_bank_bins
@@ -12,7 +12,6 @@ import inspect
 from itertools import cycle
 
 import pycbc.events, pycbc.pnutils, pycbc.conversions, pycbc.results
-import pycbc.version
 
 
 class H5BankFile(h5py.File):
@@ -79,8 +78,6 @@ class H5BankFile(h5py.File):
 
 parser = argparse.ArgumentParser()
 pycbc.add_common_pycbc_options(parser)
-parser.add_argument('--version', action='version',
-                    version=pycbc.version.git_verbose_msg)
 parser.add_argument('--bank-file', help='hdf format template bank file',
                     required=True)
 parser.add_argument('--background-bins', nargs='+',

--- a/bin/plotting/pycbc_plot_bank_corner
+++ b/bin/plotting/pycbc_plot_bank_corner
@@ -29,8 +29,6 @@ import logging
 from textwrap import wrap
 
 import pycbc
-import pycbc.version
-from pycbc import __version__
 from pycbc.results.plot import (add_style_opt_to_parser, set_style_from_cli)
 from pycbc.io import FieldArray, HFile
 from pycbc.inference import option_utils
@@ -52,10 +50,6 @@ parameter_options = conversion_options + _fit_parameters
 parser = argparse.ArgumentParser(usage='pycbc_plot_bank_corner [--options]',
                     description=__doc__)
 pycbc.add_common_pycbc_options(parser)
-parser.add_argument("--version",
-    action="version",
-    version=__version__,
-    help="Prints version information.")
 parser.add_argument("--bank-file",
     required=True,
     help="The bank file to read in and plot")

--- a/bin/plotting/pycbc_plot_dq_flag_likelihood
+++ b/bin/plotting/pycbc_plot_dq_flag_likelihood
@@ -9,13 +9,11 @@ from matplotlib import use as matplotlib_use
 from matplotlib import pyplot
 matplotlib_use('Agg')
 
-from pycbc.version import git_verbose_msg as version
 import pycbc.results
 from pycbc.io.hdf import HFile
 
 parser = argparse.ArgumentParser(description=__doc__)
 pycbc.add_common_pycbc_options(parser)
-parser.add_argument('--version', action='version', version=version)
 parser.add_argument("--dq-file", required=True)
 parser.add_argument("--dq-label", required=True)
 parser.add_argument("--ifo", type=str, required=True)

--- a/bin/plotting/pycbc_plot_dq_likelihood_vs_time
+++ b/bin/plotting/pycbc_plot_dq_likelihood_vs_time
@@ -10,13 +10,11 @@ from matplotlib import use
 use('Agg')
 from matplotlib import pyplot
 
-from pycbc.version import git_verbose_msg as version
 import pycbc.results
 from pycbc.io.hdf import HFile
 
 parser = argparse.ArgumentParser(description=__doc__)
 pycbc.add_common_pycbc_options(parser)
-parser.add_argument('--version', action='version', version=version)
 parser.add_argument("--ifo", type=str, required=True)
 parser.add_argument("--dq-file", required=True)
 parser.add_argument('--background-bin', default='all_bin')

--- a/bin/plotting/pycbc_plot_dq_percentiles
+++ b/bin/plotting/pycbc_plot_dq_percentiles
@@ -10,13 +10,11 @@ from matplotlib import use
 use('Agg')
 from matplotlib import pyplot
 
-from pycbc.version import git_verbose_msg as version
 import pycbc.results
 from pycbc.io.hdf import HFile
 
 parser = argparse.ArgumentParser(description=__doc__)
 pycbc.add_common_pycbc_options(parser)
-parser.add_argument('--version', action='version', version=version)
 parser.add_argument("--ifo", type=str,required=True)
 parser.add_argument("--dq-file", required=True)
 parser.add_argument('--background-bin', default='all_bin')

--- a/bin/plotting/pycbc_plot_gating
+++ b/bin/plotting/pycbc_plot_gating
@@ -12,6 +12,7 @@ from matplotlib.patches import Rectangle
 import mpld3
 import mpld3.plugins
 
+import pycbc
 from pycbc.results.color import ifo_color
 from pycbc.results.mpld3_utils import MPLSlide
 from pycbc.io.hdf import HFile

--- a/bin/plotting/pycbc_plot_gating
+++ b/bin/plotting/pycbc_plot_gating
@@ -14,14 +14,11 @@ import mpld3.plugins
 
 from pycbc.results.color import ifo_color
 from pycbc.results.mpld3_utils import MPLSlide
-import pycbc.version
 from pycbc.io.hdf import HFile
 
 
 parser = argparse.ArgumentParser(description=__doc__)
 pycbc.add_common_pycbc_options(parser)
-parser.add_argument("--version", action="version",
-                    version=pycbc.version.git_verbose_msg)
 parser.add_argument('--input-file', nargs='+', required=True,
                     help='Single-detector inspiral HDF5 files to take gating '
                          'data from.')

--- a/bin/plotting/pycbc_plot_hist
+++ b/bin/plotting/pycbc_plot_hist
@@ -12,14 +12,12 @@ use('Agg')
 from matplotlib import pyplot
 
 import pycbc
-import pycbc.version
 import pycbc.results
 import pycbc.io
 from pycbc.events import background_bin_from_string, veto, ranking
 
 parser = argparse.ArgumentParser(description=__doc__)
 pycbc.add_common_pycbc_options(parser)
-parser.add_argument('--version', action='version', version=pycbc.version.git_verbose_msg)
 parser.add_argument('--trigger-file', required=True,
                     help="Combined single detector hdf trigger file")
 parser.add_argument('--veto-file',

--- a/bin/plotting/pycbc_plot_multiifo_dtphase
+++ b/bin/plotting/pycbc_plot_multiifo_dtphase
@@ -26,7 +26,7 @@ matplotlib.use('agg')
 from matplotlib import pyplot as plt
 
 from pycbc.events import coinc_rate
-from pycbc import init_logging, version, add_common_pycbc_options
+from pycbc import init_logging, add_common_pycbc_options
 from pycbc.results import save_fig_with_metadata
 from pycbc.io.hdf import HFile
 
@@ -43,8 +43,6 @@ def marginalise_pdf(pdf, dimensions_to_keep):
 
 parser = argparse.ArgumentParser()
 add_common_pycbc_options(parser)
-parser.add_argument('--version', action="version",
-                    version=version.git_verbose_msg)
 parser.add_argument('--input-file', required=True,
                     help="Input phasetd histogram file, made using "
                          "pycbc_multiifo_dtphase")

--- a/bin/plotting/pycbc_plot_psd_file
+++ b/bin/plotting/pycbc_plot_psd_file
@@ -11,14 +11,11 @@ import sys
 import pycbc
 import pycbc.results
 import pycbc.psd
-import pycbc.version
 from pycbc.io.hdf import HFile
 
 
 parser = argparse.ArgumentParser(description=__doc__)
 pycbc.add_common_pycbc_options(parser)
-parser.add_argument("--version", action="version",
-                    version=pycbc.version.git_verbose_msg)
 parser.add_argument("--psd-files", nargs='+', required=True,
                     help='HDF file(s) containing the PSDs to plot')
 parser.add_argument('--hdf-group', default=None,

--- a/bin/plotting/pycbc_plot_qscan
+++ b/bin/plotting/pycbc_plot_qscan
@@ -34,7 +34,6 @@ from matplotlib import pyplot as plt
 from matplotlib.colors import LogNorm
 
 import pycbc.strain
-import pycbc.version
 import pycbc.results
 
 # https://stackoverflow.com/questions/9978880/python-argument-parser-list-of-list-or-tuple-of-tuples
@@ -47,8 +46,6 @@ def t_window(s):
 
 parser = argparse.ArgumentParser(description=__doc__)
 pycbc.add_common_pycbc_options(parser)
-parser.add_argument("--version", action="version",
-                    version=pycbc.version.git_verbose_msg)
 parser.add_argument('--output-file', required=True, help='Output plot')
 parser.add_argument('--center-time', type=float,
                     help='Center plot on the given GPS time. If omitted, use '

--- a/bin/plotting/pycbc_plot_range
+++ b/bin/plotting/pycbc_plot_range
@@ -11,7 +11,6 @@ import sys
 
 import pycbc.results
 import pycbc.types
-import pycbc.version
 import pycbc.waveform
 import pycbc.filter
 from pycbc.io.hdf import HFile
@@ -21,8 +20,6 @@ set_measure_level(0)
 
 parser = argparse.ArgumentParser(description=__doc__)
 pycbc.add_common_pycbc_options(parser)
-parser.add_argument("--version", action='version',
-                    version=pycbc.version.git_verbose_msg)
 parser.add_argument("--psd-files", nargs='+', help='HDF file of psds')
 parser.add_argument("--output-file", help='output file name')
 parser.add_argument("--mass1", nargs="+", type=float,

--- a/bin/plotting/pycbc_plot_range_vs_mtot
+++ b/bin/plotting/pycbc_plot_range_vs_mtot
@@ -11,7 +11,6 @@ import math
 
 import pycbc.results
 import pycbc.types
-import pycbc.version
 import pycbc.waveform
 import pycbc.filter
 from pycbc.io.hdf import HFile
@@ -21,8 +20,6 @@ set_measure_level(0)
 
 parser = argparse.ArgumentParser(description=__doc__)
 pycbc.add_common_pycbc_options(parser)
-parser.add_argument("--version", action='version',
-                    version=pycbc.version.git_verbose_msg)
 parser.add_argument("--psd-files", nargs='+',
                     help='HDF file of psds')
 parser.add_argument("--output-file", help='output file name')

--- a/bin/plotting/pycbc_plot_singles_timefreq
+++ b/bin/plotting/pycbc_plot_singles_timefreq
@@ -38,14 +38,11 @@ import pycbc.events
 import pycbc.pnutils
 import pycbc.strain
 import pycbc.results
-import pycbc.version
 import pycbc.waveform
 
 
 parser = argparse.ArgumentParser(description=__doc__)
 pycbc.add_common_pycbc_options(parser)
-parser.add_argument("--version", action="version",
-                    version=pycbc.version.git_verbose_msg)
 parser.add_argument('--trig-file', required=True,
                     help='HDF5 file containing single triggers')
 parser.add_argument('--output-file', required=True, help='Output plot')

--- a/bin/plotting/pycbc_plot_singles_vs_params
+++ b/bin/plotting/pycbc_plot_singles_vs_params
@@ -36,13 +36,10 @@ import pycbc.pnutils
 import pycbc.events
 import pycbc.results
 import pycbc.io
-import pycbc.version
 from pycbc.events import ranking
 
 parser = argparse.ArgumentParser(description=__doc__)
 pycbc.add_common_pycbc_options(parser)
-parser.add_argument("--version", action="version",
-                    version=pycbc.version.git_verbose_msg)
 parser.add_argument('--single-trig-file', required=True,
                     help='Path to file containing single-detector triggers in '
                          'HDF5 format. Required')

--- a/bin/plotting/pycbc_plot_throughput
+++ b/bin/plotting/pycbc_plot_throughput
@@ -11,13 +11,10 @@ from scipy.stats import hmean
 
 import pycbc
 from pycbc.results.color import ifo_color
-import pycbc.version
 from pycbc.io.hdf import HFile
 
 parser = argparse.ArgumentParser(description=__doc__)
 pycbc.add_common_pycbc_options(parser)
-parser.add_argument("--version", action="version",
-                    version=pycbc.version.git_verbose_msg)
 parser.add_argument('--input-file', nargs='+', required=True,
                     help='Single-detector inspiral HDF5 files to get '
                     'templates per core.')

--- a/bin/plotting/pycbc_plot_trigrate
+++ b/bin/plotting/pycbc_plot_trigrate
@@ -27,7 +27,6 @@ import pycbc
 from pycbc import io, events, bin_utils, results
 from pycbc.events import triggers
 from pycbc.events import ranking
-import pycbc.version
 
 #### DEFINITIONS AND FUNCTIONS ####
 
@@ -41,7 +40,6 @@ def get_stat(statchoice, trigs):
 
 parser = argparse.ArgumentParser(usage="", description="Plot trigger rates")
 pycbc.add_common_pycbc_options(parser)
-parser.add_argument("--version", action=pycbc.version.Version)
 parser.add_argument("--trigger-file",
                     help="Input hdf5 file containing single triggers. "
                     "Required")

--- a/bin/plotting/pycbc_plot_waveform
+++ b/bin/plotting/pycbc_plot_waveform
@@ -25,7 +25,6 @@ from mpl_toolkits.axes_grid1.inset_locator import zoomed_inset_axes
 from mpl_toolkits.axes_grid1.inset_locator import mark_inset
 
 from pycbc import waveform, io
-from pycbc import version
 from pycbc import results
 from pycbc import init_logging, add_common_pycbc_options
 from pycbc.fft import ifft
@@ -34,8 +33,6 @@ from pycbc.types import TimeSeries, zeros, complex64
 
 parser = argparse.ArgumentParser(usage='', description=__doc__)
 add_common_pycbc_options(parser)
-parser.add_argument('--version', action='version',
-                    version=version.git_verbose_msg)
 parser.add_argument('--output-file', required=True)
 parser.add_argument("--low-frequency-cutoff", type=float,
                   help="The low frequency cutoff to use for generation.")

--- a/bin/pycbc_banksim
+++ b/bin/pycbc_banksim
@@ -35,7 +35,7 @@ from pycbc import DYN_RANGE_FAC
 from pycbc.types import FrequencySeries, TimeSeries, zeros, complex_same_precision_as
 from pycbc.filter import match, sigmasq
 from pycbc.io.ligolw import LIGOLWContentHandler
-import pycbc.psd, pycbc.scheme, pycbc.fft, pycbc.strain, pycbc.version
+import pycbc.psd, pycbc.scheme, pycbc.fft, pycbc.strain
 from pycbc.detector import overhead_antenna_pattern as generate_fplus_fcross
 from pycbc.waveform import TemplateBank
 
@@ -147,8 +147,6 @@ parser = ArgumentParser(description=__doc__)
 parser.add_argument("--match-file", dest="out_file", metavar="FILE",
                     required=True, help="File to output match results")
 pycbc.add_common_pycbc_options(parser)
-parser.add_argument("--version", action="version",
-                    version=pycbc.version.git_verbose_msg)
 
 #Template Settings
 parser.add_argument("--template-file", dest="bank_file", metavar="FILE",

--- a/bin/pycbc_banksim_combine_banks
+++ b/bin/pycbc_banksim_combine_banks
@@ -28,7 +28,6 @@ import logging
 from numpy import *
 
 import pycbc
-import pycbc.version
 
 __author__  = "Ian Harry <ian.harry@astro.cf.ac.uk>"
 __program__ = "pycbc_banksim_combine_banks"
@@ -37,7 +36,6 @@ __program__ = "pycbc_banksim_combine_banks"
 _desc = __doc__[1:]
 parser = argparse.ArgumentParser(description=_desc)
 
-parser.add_argument('--version', action=pycbc.version.Version)
 pycbc.add_common_pycbc_options(parser)
 parser.add_argument("-I", "--input-files", nargs='+',
                     help="Explicit list of input files.")

--- a/bin/pycbc_banksim_match_combine
+++ b/bin/pycbc_banksim_match_combine
@@ -44,7 +44,6 @@ __program__ = "pycbc_banksim_match_combine"
 # Read command line options
 parser = argparse.ArgumentParser(description=__doc__)
 
-parser.add_argument("--version", action="version", version=__version__)
 pycbc.add_common_pycbc_options(parser)
 parser.add_argument("--match-files", nargs='+',
                     help="Explicit list of match files.")

--- a/bin/pycbc_banksim_skymax
+++ b/bin/pycbc_banksim_skymax
@@ -39,7 +39,7 @@ from pycbc.filter import overlap_cplx, matched_filter
 from pycbc.filter import compute_max_snr_over_sky_loc_stat
 from pycbc.filter import compute_max_snr_over_sky_loc_stat_no_phase
 from pycbc.io.ligolw import LIGOLWContentHandler
-import pycbc.psd, pycbc.scheme, pycbc.fft, pycbc.strain, pycbc.version
+import pycbc.psd, pycbc.scheme, pycbc.fft, pycbc.strain
 from pycbc.detector import overhead_antenna_pattern as generate_fplus_fcross
 from pycbc.waveform import TemplateBank
 
@@ -153,8 +153,6 @@ parser = ArgumentParser(description=__doc__)
 parser.add_argument("--match-file", dest="out_file", metavar="FILE",
                     required=True, help="File to output match results")
 pycbc.add_common_pycbc_options(parser)
-parser.add_argument("--version", action="version",
-                    version=pycbc.version.git_verbose_msg)
 
 #Template Settings
 parser.add_argument("--template-file", dest="bank_file", metavar="FILE",

--- a/bin/pycbc_coinc_time
+++ b/bin/pycbc_coinc_time
@@ -6,6 +6,8 @@ from dqsegdb.apicalls import dqsegdbQueryTimes as query
 
 import ligo.segments
 
+import pycbc
+
 def sane(seg_list):
     """ Convert list of len two lists containing strs to segment list """
     segs = ligo.segments.segmentlist([])

--- a/bin/pycbc_coinc_time
+++ b/bin/pycbc_coinc_time
@@ -6,9 +6,6 @@ from dqsegdb.apicalls import dqsegdbQueryTimes as query
 
 import ligo.segments
 
-#from pycbc.workflow.segment import cat_to_veto_def_cat as convert_cat
-import pycbc.version
-
 def sane(seg_list):
     """ Convert list of len two lists containing strs to segment list """
     segs = ligo.segments.segmentlist([])
@@ -90,7 +87,6 @@ def get_vetoes(veto_def, ifo, server, veto_name, start_default, end_default):
     
 
 parser = argparse.ArgumentParser()
-parser.add_argument('--version', action='version', version=pycbc.version.git_verbose_msg)
 pycbc.add_common_pycbc_options(parser)
 
 parser.add_argument('--gps-start-time', type=int, required=True,

--- a/bin/pycbc_condition_strain
+++ b/bin/pycbc_condition_strain
@@ -28,7 +28,6 @@ import logging
 import argparse
 
 import pycbc.strain
-import pycbc.version
 import pycbc.frame
 import pycbc.fft
 from pycbc.types import float32, float64
@@ -47,8 +46,6 @@ def write_strain(file_name, channel, data):
 
 parser = argparse.ArgumentParser(description=__doc__)
 pycbc.add_common_pycbc_options(parser)
-parser.add_argument("--version", action="version",
-                    version=pycbc.version.git_verbose_msg)
 parser.add_argument('--output-strain-file', required=True,
                     help='Name of output frame file. The file format is '
                          'selected based on the extension (.gwf, .npy, .hdf '

--- a/bin/pycbc_convertinjfiletohdf
+++ b/bin/pycbc_convertinjfiletohdf
@@ -161,8 +161,6 @@ class LVKNewStyleInjectionSet(object):
 
 parser = argparse.ArgumentParser()
 pycbc.add_common_pycbc_options(parser)
-parser.add_argument('--version', action='version',
-                    version=pycbc.version.git_verbose_msg)
 parser.add_argument('--injection-file', required=True,
                     help="The injection file to load. Must end in '.xml[.gz]' "
                          "and must contain a SimInspiral table")

--- a/bin/pycbc_create_injections
+++ b/bin/pycbc_create_injections
@@ -117,7 +117,6 @@ import h5py
 from numpy.random import uniform
 
 import pycbc
-import pycbc.version
 from pycbc.inject import InjectionSet
 from pycbc import distributions
 from pycbc import transforms
@@ -131,9 +130,6 @@ parser = argparse.ArgumentParser(description=__doc__,
             formatter_class=argparse.RawDescriptionHelpFormatter)
 configuration.add_workflow_command_line_group(parser)
 pycbc.add_common_pycbc_options(parser)
-parser.add_argument('--version', action='version',
-                    version=pycbc.version.git_verbose_msg,
-                    help='Prints version information.')
 parser.add_argument('--ninjections', type=int,
                     help='Number of injections to create.')
 parser.add_argument('--gps-start-time', type=int, help="Alternative to "

--- a/bin/pycbc_data_store
+++ b/bin/pycbc_data_store
@@ -8,7 +8,6 @@ import numpy
 import pycbc
 import pycbc.strain
 import pycbc.dq
-from pycbc.version import git_verbose_msg as version
 from pycbc.fft.fftw import set_measure_level
 from pycbc.events.veto import segments_to_start_end
 from pycbc.io.hdf import HFile
@@ -17,7 +16,6 @@ set_measure_level(0)
 
 parser = argparse.ArgumentParser(description=__doc__)
 pycbc.add_common_pycbc_options(parser)
-parser.add_argument('--version', action='version', version=version)
 parser.add_argument("--science-name", help="Science flag definition")
 parser.add_argument("--segment-server")
 parser.add_argument("--veto-definer-file")

--- a/bin/pycbc_faithsim
+++ b/bin/pycbc_faithsim
@@ -31,7 +31,6 @@ import sys
 from ligo.lw import utils as ligolw_utils
 from ligo.lw import lsctables
 
-import pycbc.version
 import pycbc.strain
 import pycbc.psd
 from pycbc.waveform import td_approximants, fd_approximants
@@ -83,8 +82,6 @@ psd_names = pycbc.psd.get_lalsim_psd_list()
 taper_choices = ["start","end","startend"]
 parser = argparse.ArgumentParser(usage='',
     description="Calculate faithfulness for a set of waveforms.")
-parser.add_argument('--version', action='version',
-                    version=pycbc.version.git_verbose_msg)
 pycbc.add_common_pycbc_options(parser)
 parser.add_argument("--param-file", dest="bank_file", metavar="FILE",
                     help="Sngl or Sim Inspiral Table containing waveform "

--- a/bin/pycbc_fit_sngl_trigs
+++ b/bin/pycbc_fit_sngl_trigs
@@ -23,7 +23,6 @@ import numpy as np
 from pycbc import io, events, bin_utils
 from pycbc.events import ranking
 from pycbc.events import trigger_fits as trstats
-import pycbc.version
 
 #### DEFINITIONS AND FUNCTIONS ####
 
@@ -56,7 +55,6 @@ parser = argparse.ArgumentParser(usage="",
     description="Perform maximum-likelihood fits of single inspiral trigger"
                 "distributions to various functions")
 pycbc.add_common_pycbc_options(parser)
-parser.add_argument("--version", action=pycbc.version.Version)
 parser.add_argument("--inputs", nargs="+",
                     help="Input file or space-separated list of input files "
                     "containing single triggers.  Currently .xml(.gz) "

--- a/bin/pycbc_fit_sngl_trigs
+++ b/bin/pycbc_fit_sngl_trigs
@@ -20,6 +20,7 @@ use('Agg')
 from matplotlib import pyplot as plt
 import numpy as np
 
+import pycbc
 from pycbc import io, events, bin_utils
 from pycbc.events import ranking
 from pycbc.events import trigger_fits as trstats

--- a/bin/pycbc_hdf5_splitbank
+++ b/bin/pycbc_hdf5_splitbank
@@ -27,15 +27,13 @@ import h5py
 import logging
 from numpy import random
 
-import pycbc, pycbc.version
+import pycbc
 from pycbc.waveform import bank
 
 __author__  = "Soumi De <soumi.de@ligo.org>"
 
 parser = argparse.ArgumentParser(description=__doc__[1:])
 pycbc.add_common_pycbc_options(parser)
-parser.add_argument("--version", action="version",
-                  version=pycbc.version.git_verbose_msg)
 parser.add_argument("--bank-file", type=str,
                     help="Bank hdf file to load.")
 outbanks = parser.add_mutually_exclusive_group(required=True)

--- a/bin/pycbc_hdf_splitinj
+++ b/bin/pycbc_hdf_splitinj
@@ -9,15 +9,12 @@ import argparse
 import numpy as np
 
 from pycbc.inject import InjectionSet
-import pycbc.version
 from pycbc.io.hdf import HFile
 
 
 # Parse command line
 parser = argparse.ArgumentParser(description=__doc__)
 pycbc.add_common_pycbc_options(parser)
-parser.add_argument("--version", action="version",
-                    version=pycbc.version.git_verbose_msg)
 parser.add_argument("-f", "--output-files", nargs='*', required=True,
                     help="Names of output files")
 parser.add_argument("-i", "--input-file", required=True,

--- a/bin/pycbc_hdf_splitinj
+++ b/bin/pycbc_hdf_splitinj
@@ -8,6 +8,7 @@ Split sets are organized to maximize time between injections.
 import argparse
 import numpy as np
 
+import pycbc
 from pycbc.inject import InjectionSet
 from pycbc.io.hdf import HFile
 

--- a/bin/pycbc_inj_cut
+++ b/bin/pycbc_inj_cut
@@ -36,11 +36,9 @@ from ligo.lw import lsctables
 import pycbc
 import pycbc.inject
 from pycbc.types import MultiDetOptionAction
-import pycbc.version
 
 parser = argparse.ArgumentParser(description=__doc__)
 pycbc.add_common_pycbc_options(parser)
-parser.add_argument('--version', action=pycbc.version.Version)
 parser.add_argument('--input', dest='inj_xml', required=True, help='Input LIGOLW injections file.')
 parser.add_argument('--output-missed', dest='output_missed', required=False,
                   help="Output LIGOLW file containing injections we expect to miss.")

--- a/bin/pycbc_inspiral
+++ b/bin/pycbc_inspiral
@@ -27,7 +27,6 @@ import time
 from multiprocessing import Pool
 
 import pycbc
-import pycbc.version
 from pycbc import vetoes, psd, waveform, strain, scheme, fft, DYN_RANGE_FAC, events
 from pycbc.vetoes.sgchisq import SingleDetSGChisq
 from pycbc.filter import MatchedFilterControl, make_frequency_series, qtransform
@@ -54,7 +53,6 @@ parser = argparse.ArgumentParser(usage='',
     description="Find single detector gravitational-wave triggers.")
 
 pycbc.add_common_pycbc_options(parser)
-parser.add_argument('--version', action=pycbc.version.Version)
 parser.add_argument("--update-progress",
                   help="updates a file 'progress.txt' with a value 0 .. 1.0 when this amount of (filtering) progress was made",
                   type=float, default=0)

--- a/bin/pycbc_make_html_page
+++ b/bin/pycbc_make_html_page
@@ -30,7 +30,6 @@ from ligo import segments
 import pycbc.results
 from pycbc.results.render import get_embedded_config, render_workflow_html_template, setup_template_render
 from pycbc.workflow import segment
-import pycbc.version
 
 def examine_dir(cwd):
     """
@@ -167,8 +166,6 @@ default_logo_location = "https://raw.githubusercontent.com/gwastro/" + \
 parser = argparse.ArgumentParser(usage='pycbc_make_html_page \
 [--options]',
                   description="Create static html pages of a filesystem's content.")
-parser.add_argument("--version", action="version",
-                  version=pycbc.version.git_verbose_msg)
 pycbc.add_common_pycbc_options(parser)
 parser.add_argument('-f', '--template-file', type=str,
                   help='Template file to use for skeleton html page.')

--- a/bin/pycbc_make_skymap
+++ b/bin/pycbc_make_skymap
@@ -481,7 +481,6 @@ if __name__ == '__main__':
 
     parser = argparse.ArgumentParser(description=__doc__)
     pycbc.add_common_pycbc_options(parser)
-    parser.add_argument('--version', action=pycbc.version.Version)
     # note that I am not using a MultiDetOptionAction for --trig-time as I
     # explicitly want to handle cases like `--trig-time 1234` and
     # `--trig-time H1:1234 L1:1234` in different ways

--- a/bin/pycbc_merge_inj_hdf
+++ b/bin/pycbc_merge_inj_hdf
@@ -27,7 +27,6 @@ import h5py
 
 import pycbc
 import pycbc.inject
-import pycbc.version
 
 
 def get_gc_end_time(injection):
@@ -45,7 +44,6 @@ def get_gc_end_time(injection):
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description=__doc__)
     pycbc.add_common_pycbc_options(parser)
-    parser.add_argument("--version", action=pycbc.version.Version)
     parser.add_argument('--injection-files', '-i', dest='injection_file',
                         required=True, nargs='+',
                         help='Input HDF5 files defining injections')

--- a/bin/pycbc_multi_inspiral
+++ b/bin/pycbc_multi_inspiral
@@ -30,7 +30,6 @@ import time
 import argparse
 import numpy as np
 
-import pycbc.version
 from pycbc import (
     detector,
     fft,
@@ -120,7 +119,6 @@ def slide_limiter(args):
 # pycbc_multi_inspiral executable.
 time_init = time.time()
 parser = argparse.ArgumentParser(description=__doc__)
-parser.add_argument('--version', action=pycbc.version.Version)
 add_common_pycbc_options(parser)
 parser.add_argument("--output", type=str)
 parser.add_argument(

--- a/bin/pycbc_optimal_snr
+++ b/bin/pycbc_optimal_snr
@@ -33,7 +33,6 @@ from ligo.lw import lsctables
 import pycbc
 import pycbc.inject
 import pycbc.psd
-import pycbc.version
 from pycbc.filter import sigma, make_frequency_series
 from pycbc.types import TimeSeries, FrequencySeries, zeros, float32, \
                         MultiDetOptionAction, load_frequencyseries
@@ -120,7 +119,6 @@ def get_gc_end_time(injection):
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description=__doc__)
     pycbc.add_common_pycbc_options(parser)
-    parser.add_argument("--version", action=pycbc.version.Version)
     parser.add_argument('--input-file', '-i', dest='injection_file',
                         required=True,
                         help='Input LIGOLW file defining injections')

--- a/bin/pycbc_optimize_snr
+++ b/bin/pycbc_optimize_snr
@@ -14,7 +14,7 @@ mpl_use_backend('agg')
 
 import pycbc
 from pycbc import (
-    fft, scheme, version
+    fft, scheme
 )
 from pycbc.types import MultiDetOptionAction, load_frequencyseries
 import pycbc.conversions as cv
@@ -27,8 +27,6 @@ from pycbc.live import snr_optimizer
 
 parser = argparse.ArgumentParser(description=__doc__)
 pycbc.add_common_pycbc_options(parser)
-parser.add_argument('--version', action='version',
-                    version=version.git_verbose_msg)
 parser.add_argument('--params-file', required=True,
                     help='Location of the attributes file created by PyCBC '
                          'Live')

--- a/bin/pycbc_single_template
+++ b/bin/pycbc_single_template
@@ -31,7 +31,6 @@ from pycbc.types import zeros, complex64
 from pycbc.types import complex_same_precision_as
 from pycbc.detector import Detector
 import pycbc.waveform.utils
-import pycbc.version
 
 def subtract_template(stilde, template, snr, trigger_time, flow):
     idx = int((trigger_time - snr.start_time) / snr.delta_t)
@@ -92,7 +91,6 @@ def select_segments(fname, anal_name, data_name, ifo, time, pad_data):
 parser = argparse.ArgumentParser(usage='',
     description="Single template gravitational-wave followup")
 pycbc.add_common_pycbc_options(parser)
-parser.add_argument('--version', action=pycbc.version.Version)
 parser.add_argument('--output-file', required=True)
 parser.add_argument('--subtract-template', action='store_true')
 parser.add_argument("--low-frequency-cutoff", type=float,

--- a/bin/pycbc_source_probability_offline
+++ b/bin/pycbc_source_probability_offline
@@ -29,8 +29,6 @@ parser.add_argument('--ifar-threshold', type=float, default=None,
                          'above threshold.')
 parser.add_argument('--include-mass-gap', action='store_true',
                     help='Option to include the Mass Gap region.')
-parser.add_argument("--version", action="version",
-                    version=pycbc.version.git_verbose_msg)
 mchirp_area.insert_args(parser)
 args = parser.parse_args()
 

--- a/bin/pycbc_split_inspinj
+++ b/bin/pycbc_split_inspinj
@@ -6,15 +6,11 @@ from ligo.lw import utils as ligolw_utils
 from ligo.lw import lsctables
 from itertools import cycle
 
-import pycbc.version
 from pycbc.io.ligolw import LIGOLWContentHandler, get_table_columns
-
 
 # Parse command line
 parser = argparse.ArgumentParser()
 pycbc.add_common_pycbc_options(parser)
-parser.add_argument("--version", action="version",
-                    version=pycbc.version.git_verbose_msg)
 group = parser.add_mutually_exclusive_group(required=True)
 group.add_argument("-n", "--num-splits", type=int,
                    help="Number of files to be generated")

--- a/bin/pycbc_split_inspinj
+++ b/bin/pycbc_split_inspinj
@@ -6,6 +6,7 @@ from ligo.lw import utils as ligolw_utils
 from ligo.lw import lsctables
 from itertools import cycle
 
+import pycbc
 from pycbc.io.ligolw import LIGOLWContentHandler, get_table_columns
 
 # Parse command line

--- a/bin/pycbc_splitbank
+++ b/bin/pycbc_splitbank
@@ -35,7 +35,6 @@ from ligo.lw import lsctables
 from ligo.lw import utils as ligolw_utils
 
 import pycbc
-from pycbc import version
 from pycbc.io.ligolw import LIGOLWContentHandler, create_process_table
 from pycbc.conversions import mchirp_from_mass1_mass2
 from pycbc.pnutils import frequency_cutoff_from_name
@@ -47,8 +46,6 @@ __program__ = "pycbc_splitbank"
 
 # Command line parsing
 parser = argparse.ArgumentParser(description=__doc__)
-parser.add_argument('--version', action='version', version=version.git_verbose_msg)
-
 pycbc.add_common_pycbc_options(parser)
 group = parser.add_mutually_exclusive_group(required=True)
 group.add_argument('--templates-per-bank', metavar='SAMPLES',

--- a/bin/pygrb/pycbc_grb_inj_finder
+++ b/bin/pygrb/pycbc_grb_inj_finder
@@ -39,7 +39,7 @@ from gwdatafind.utils import filename_metadata
 from ligo.segments import segmentlist
 from ligo.segments.utils import fromsegwizard
 
-from pycbc import __version__, add_common_pycbc_options, init_logging
+from pycbc import add_common_pycbc_options, init_logging
 from pycbc.inject import InjectionSet
 from pycbc.io.hdf import HFile
 from pycbc.results.pygrb_postprocessing_utils import template_hash_to_id
@@ -154,14 +154,6 @@ parser = argparse.ArgumentParser(
 )
 
 add_common_pycbc_options(parser)
-
-parser.add_argument(
-    "-V",
-    "--version",
-    action="version",
-    version=__version__,
-    help="show version number and exit",
-)
 
 # input/output
 parser.add_argument(

--- a/bin/pygrb/pycbc_grb_trig_cluster
+++ b/bin/pygrb/pycbc_grb_trig_cluster
@@ -34,7 +34,6 @@ import h5py
 
 from gwdatafind.utils import filename_metadata
 
-from pycbc import __version__
 from pycbc import init_logging, add_common_pycbc_options
 from pycbc.io.hdf import HFile
 
@@ -121,13 +120,6 @@ parser = argparse.ArgumentParser(
 )
 
 add_common_pycbc_options(parser)
-parser.add_argument(
-    "-V",
-    "--version",
-    action="version",
-    version=__version__,
-    help="show version number and exit",
-)
 
 # clustering
 parser.add_argument(

--- a/bin/pygrb/pycbc_grb_trig_combiner
+++ b/bin/pygrb/pycbc_grb_trig_combiner
@@ -35,7 +35,7 @@ from gwdatafind.utils import (file_segment, filename_metadata)
 from ligo import segments
 from ligo.segments.utils import fromsegwizard
 
-from pycbc import __version__, add_common_pycbc_options, init_logging
+from pycbc import add_common_pycbc_options, init_logging
 from pycbc.results.pygrb_postprocessing_utils import template_hash_to_id
 from pycbc.io.hdf import HFile
 
@@ -342,13 +342,6 @@ parser = argparse.ArgumentParser(
 )
 
 add_common_pycbc_options(parser)
-parser.add_argument(
-    "-V",
-    "--version",
-    action="version",
-    version=__version__,
-    help="show version number and exit",
-)
 
 # tags
 parser.add_argument(

--- a/bin/pygrb/pycbc_make_offline_grb_workflow
+++ b/bin/pygrb/pycbc_make_offline_grb_workflow
@@ -20,13 +20,6 @@
 Make workflow for the archival, targeted, coherent inspiral pipeline.
 """
 
-import pycbc.version
-
-__author__ = "Andrew Williamson <andrew.williamson@ligo.org>"
-__version__ = pycbc.version.git_verbose_msg
-__date__ = pycbc.version.date
-__program__ = "pycbc_make_offline_grb_workflow"
-
 import sys
 import os
 import argparse

--- a/bin/pygrb/pycbc_make_offline_grb_workflow
+++ b/bin/pygrb/pycbc_make_offline_grb_workflow
@@ -46,7 +46,6 @@ workflow_name = "pygrb_offline"
 # Parse command line options and instantiate pycbc workflow object
 parser = argparse.ArgumentParser()
 add_common_pycbc_options(parser)
-parser.add_argument("--version", action="version", version=__version__)
 _workflow.add_workflow_command_line_group(parser)
 _workflow.add_workflow_settings_cli(parser)
 args = parser.parse_args()

--- a/bin/pygrb/pycbc_pygrb_efficiency
+++ b/bin/pygrb/pycbc_pygrb_efficiency
@@ -92,8 +92,7 @@ def efficiency_with_errs(found_bestnr, num_injections, num_mc_injs=0):
 # =============================================================================
 # Main script starts here
 # =============================================================================
-parser = ppu.pygrb_initialize_plot_parser(description=__doc__,
-                                          version=__version__)
+parser = ppu.pygrb_initialize_plot_parser(description=__doc__)
 parser.add_argument("-F", "--trig-file", action="store", required=True,
                     help="Location of off-source trigger file.")
 parser.add_argument("--onsource-file", action="store",

--- a/bin/pygrb/pycbc_pygrb_exclusion_dist_table
+++ b/bin/pygrb/pycbc_pygrb_exclusion_dist_table
@@ -32,7 +32,6 @@ __program__ = "pycbc_pygrb_exclusion_dist_table"
 
 parser = argparse.ArgumentParser(description=__doc__, formatter_class=
                                  argparse.ArgumentDefaultsHelpFormatter)
-parser.add_argument("--version", action="version", version=__version__)
 parser.add_argument("--input-files", nargs="+", required=True,
                     help="List of JSON input files" +
                     " output by pycbc_pygrb_efficiency" +

--- a/bin/pygrb/pycbc_pygrb_exclusion_dist_table
+++ b/bin/pygrb/pycbc_pygrb_exclusion_dist_table
@@ -32,6 +32,7 @@ __program__ = "pycbc_pygrb_exclusion_dist_table"
 
 parser = argparse.ArgumentParser(description=__doc__, formatter_class=
                                  argparse.ArgumentDefaultsHelpFormatter)
+pycbc.add_common_pycbc_options(parser)
 parser.add_argument("--input-files", nargs="+", required=True,
                     help="List of JSON input files" +
                     " output by pycbc_pygrb_efficiency" +
@@ -40,6 +41,8 @@ parser.add_argument("--output-file", required=True,
                     help="HTML output file containing table" +
                     " of exclusion distances.")
 opts = parser.parse_args()
+
+pycbc.init_logging(opts.verbose)
 
 # Load JSON files as a list of dictionaries
 file_contents = []

--- a/bin/pygrb/pycbc_pygrb_grb_info_table
+++ b/bin/pygrb/pycbc_pygrb_grb_info_table
@@ -45,7 +45,6 @@ __program__ = "pycbc_pygrb_grb_info_table"
 parser = argparse.ArgumentParser(description=__doc__, formatter_class=
                                  argparse.ArgumentDefaultsHelpFormatter)
 add_common_pycbc_options(parser)
-parser.add_argument("--version", action="version", version=__version__)
 parser.add_argument("--trigger-time", type=int,
                     required=True,
                     help="GPS time of the GRB.")

--- a/bin/pygrb/pycbc_pygrb_minifollowups
+++ b/bin/pygrb/pycbc_pygrb_minifollowups
@@ -105,8 +105,6 @@ def make_timeseries_plot(workflow, trig_file, snr_type, central_time,
 # Main script starts here
 # =============================================================================
 parser = argparse.ArgumentParser(description=__doc__[1:])
-parser.add_argument('--version', action='version',
-                    version=pycbc.version.git_verbose_msg)
 pycbc.add_common_pycbc_options(parser)
 parser.add_argument('--trig-file',
                     help="HDF file with the triggers found by PyGRB")

--- a/bin/pygrb/pycbc_pygrb_page_tables
+++ b/bin/pygrb/pycbc_pygrb_page_tables
@@ -180,8 +180,7 @@ def load_missed_found_injections(hdf_file, ifos, snr_threshold, bank_file,
 # =============================================================================
 # Main script starts here
 # =============================================================================
-parser = ppu.pygrb_initialize_plot_parser(description=__doc__,
-                                          version=__version__)
+parser = ppu.pygrb_initialize_plot_parser(description=__doc__)
 parser.add_argument("-F", "--offsource-file", action="store", required=True,
                     help="Location of off-source trigger file")
 parser.add_argument("--onsource-file", action="store",

--- a/bin/pygrb/pycbc_pygrb_plot_chisq_veto
+++ b/bin/pygrb/pycbc_pygrb_plot_chisq_veto
@@ -171,8 +171,7 @@ def calculate_contours(trig_data, opts, new_snrs=None):
 # =============================================================================
 # Main script starts here
 # =============================================================================
-parser = ppu.pygrb_initialize_plot_parser(description=__doc__,
-                                          version=__version__)
+parser = ppu.pygrb_initialize_plot_parser(description=__doc__)
 parser.add_argument("-t", "--trig-file", action="store",
                     default=None, required=True,
                     help="The location of the trigger file")

--- a/bin/pygrb/pycbc_pygrb_plot_coh_ifosnr
+++ b/bin/pygrb/pycbc_pygrb_plot_coh_ifosnr
@@ -164,9 +164,7 @@ def plot_deviation(percentile, snr_grid, y, ax, style):
 # =============================================================================
 # Main script starts here
 # =============================================================================
-parser = ppu.pygrb_initialize_plot_parser(
-    description=__doc__, version=__version__
-)
+parser = ppu.pygrb_initialize_plot_parser(description=__doc__)
 parser.add_argument(
     "-t",
     "--trig-file",

--- a/bin/pygrb/pycbc_pygrb_plot_injs_results
+++ b/bin/pygrb/pycbc_pygrb_plot_injs_results
@@ -170,8 +170,7 @@ def load_data(input_file_handle, keys, tag):
 # =============================================================================
 # Main script starts here
 # =============================================================================
-parser = ppu.pygrb_initialize_plot_parser(description=__doc__,
-                                          version=__version__)
+parser = ppu.pygrb_initialize_plot_parser(description=__doc__)
 parser.add_argument("--found-missed-file",
                     help="The hdf injection results file", required=True)
 parser.add_argument("--trig-file",

--- a/bin/pygrb/pycbc_pygrb_plot_null_stats
+++ b/bin/pygrb/pycbc_pygrb_plot_null_stats
@@ -127,8 +127,7 @@ def calculate_contours(opts, new_snrs=None):
 # =============================================================================
 # Main script starts here
 # =============================================================================
-parser = ppu.pygrb_initialize_plot_parser(description=__doc__,
-                                          version=__version__)
+parser = ppu.pygrb_initialize_plot_parser(description=__doc__)
 parser.add_argument("-t", "--trig-file", action="store",
                     default=None, required=True,
                     help="The location of the trigger file")

--- a/bin/pygrb/pycbc_pygrb_plot_skygrid
+++ b/bin/pygrb/pycbc_pygrb_plot_skygrid
@@ -58,8 +58,7 @@ def load_data(input_file, ifos, vetoes, injections=False):
 # =============================================================================
 # Main script starts here
 # =============================================================================
-parser = ppu.pygrb_initialize_plot_parser(description=__doc__,
-                                          version=__version__)
+parser = ppu.pygrb_initialize_plot_parser(description=__doc__)
 parser.add_argument("-t", "--trig-file", action="store",
                     default=None, required=True,
                     help="The location of the trigger file")

--- a/bin/pygrb/pycbc_pygrb_plot_snr_timeseries
+++ b/bin/pygrb/pycbc_pygrb_plot_snr_timeseries
@@ -95,8 +95,7 @@ def reset_times(data_time, trig_time):
 # =============================================================================
 # Main script starts here
 # =============================================================================
-parser = ppu.pygrb_initialize_plot_parser(description=__doc__,
-                                          version=__version__)
+parser = ppu.pygrb_initialize_plot_parser(description=__doc__)
 parser.add_argument("-t", "--trig-file", action="store",
                     default=None, required=True,
                     help="The location of the trigger file")

--- a/bin/pygrb/pycbc_pygrb_plot_stats_distribution
+++ b/bin/pygrb/pycbc_pygrb_plot_stats_distribution
@@ -47,8 +47,7 @@ __program__ = "pycbc_pygrb_plot_stats_distribution"
 # =============================================================================
 # Main script starts here
 # =============================================================================
-parser = ppu.pygrb_initialize_plot_parser(description=__doc__,
-                                          version=__version__)
+parser = ppu.pygrb_initialize_plot_parser(description=__doc__)
 parser.add_argument("-F", "--trig-file", action="store", required=True,
                     help="Location of off-source trigger file")
 parser.add_argument("-x", "--x-variable", required=True,

--- a/bin/pygrb/pycbc_pygrb_pp_workflow
+++ b/bin/pygrb/pycbc_pygrb_pp_workflow
@@ -49,7 +49,6 @@ __program__ = "pycbc_pygrb_pp_workflow"
 # Use the standard workflow command-line parsing routines.
 parser = argparse.ArgumentParser(description=__doc__[1:])
 pycbc.add_common_pycbc_options(parser)
-parser.add_argument("--version", action="version", version=__version__)
 parser.add_argument("-t", "--trig-files", action="store",
                     required=True, nargs="+",
                     help="The locations of the trigger files "

--- a/bin/workflows/pycbc_make_bank_verifier_workflow
+++ b/bin/workflows/pycbc_make_bank_verifier_workflow
@@ -156,7 +156,6 @@ class BanksimTablePointInjsExecutable(wf.Executable):
 _desc = __doc__[1:]
 parser = argparse.ArgumentParser(description=_desc)
 add_common_pycbc_options(parser)
-parser.add_argument('--version', action='version', version=__version__)
 wf.add_workflow_command_line_group(parser)
 wf.add_workflow_settings_cli(parser)
 args = parser.parse_args()

--- a/bin/workflows/pycbc_make_faithsim_workflow
+++ b/bin/workflows/pycbc_make_faithsim_workflow
@@ -18,9 +18,6 @@ from pycbc import add_common_pycbc_options, init_logging
 from pycbc.workflow.plotting import PlotExecutable
 from pycbc.workflow import setup_splittable_dax_generated
 
-__version__ = pycbc.version.git_verbose_msg
-
-
 def make_faithsim_plot(workflow, analysis_time, input_file, out_dir, tags=None):
     tags = [] if tags is None else tags
     secs = workflow.cp.get_subsections("pycbc_faithsim_plots")
@@ -100,7 +97,6 @@ class CollectResultsExecutable(wf.Executable):
 
 parser = argparse.ArgumentParser(description=__doc__)
 add_common_pycbc_options(parser)
-parser.add_argument("--version", action="version", version=__version__)
 wf.add_workflow_command_line_group(parser)
 wf.add_workflow_settings_cli(parser)
 args = parser.parse_args()

--- a/bin/workflows/pycbc_make_inference_inj_workflow
+++ b/bin/workflows/pycbc_make_inference_inj_workflow
@@ -23,11 +23,9 @@ import logging
 import os
 import shlex
 import numpy
-import pycbc.version
 import socket
 import sys
 
-from pycbc import __version__
 from pycbc import results, init_logging, add_common_pycbc_options
 from pycbc.results import layout
 from pycbc.results import metadata
@@ -91,9 +89,6 @@ core.add_workflow_settings_cli(parser, include_subdax_opts=True)
 parser.add_argument("--seed", type=int, default=0,
                     help="Starting to seed to use. This will be incremented "
                          "one for each injection analyzed. Default is 0.")
-# version option
-parser.add_argument("--version", action="version", version=__version__,
-                    help="Prints version information.")
 
 # parser command line
 opts = parser.parse_args()

--- a/bin/workflows/pycbc_make_inference_plots_workflow
+++ b/bin/workflows/pycbc_make_inference_plots_workflow
@@ -41,7 +41,6 @@ from pycbc.workflow import core
 from pycbc.workflow import datafind
 from pycbc.workflow import plotting
 from pycbc.workflow import versioning
-from pycbc import __version__
 import pycbc.workflow.inference_followups as inffu
 
 
@@ -134,8 +133,6 @@ add_common_pycbc_options(parser)
 configuration.add_workflow_command_line_group(parser)
 # workflow options
 core.add_workflow_settings_cli(parser, include_subdax_opts=True)
-parser.add_argument("--version", action="version", version=__version__,
-                    help="Prints version information.")
 opts = parser.parse_args()
 
 posterior_file_dir = 'posterior_files'

--- a/bin/workflows/pycbc_make_inference_workflow
+++ b/bin/workflows/pycbc_make_inference_workflow
@@ -40,7 +40,6 @@ from pycbc.workflow import core
 from pycbc.workflow import datafind
 from pycbc.workflow import plotting
 from pycbc.workflow import versioning
-from pycbc import __version__
 import pycbc.workflow.inference_followups as inffu
 from pycbc.workflow.jobsetup import PycbcInferenceExecutable
 
@@ -162,9 +161,6 @@ parser.add_argument("--seed", type=int, default=0,
                     help="Seed to use for inference job(s). If multiple "
                          "events are analyzed, the seed will be incremented "
                          "by one for each event.")
-# version option
-parser.add_argument("--version", action="version", version=__version__,
-                    help="Prints version information.")
 
 
 # parser command line

--- a/bin/workflows/pycbc_make_offline_search_workflow
+++ b/bin/workflows/pycbc_make_offline_search_workflow
@@ -153,7 +153,6 @@ def check_stop(job_name, container, workflow, finalize_workflow):
 
 parser = argparse.ArgumentParser(description=__doc__[1:])
 pycbc.add_common_pycbc_options(parser)
-parser.add_argument('--version', action='version', version=__version__)
 wf.add_workflow_command_line_group(parser)
 wf.add_workflow_settings_cli(parser)
 args = parser.parse_args()

--- a/bin/workflows/pycbc_make_offline_search_workflow
+++ b/bin/workflows/pycbc_make_offline_search_workflow
@@ -22,10 +22,6 @@ finding and ranking then generate post-processing
 and plots.
 """
 import pycbc
-import pycbc.version
-__version__ = pycbc.version.git_verbose_msg
-__date__    = pycbc.version.date
-__program__ = "pycbc_offline"
 
 import sys
 import socket

--- a/bin/workflows/pycbc_make_psd_estimation_workflow
+++ b/bin/workflows/pycbc_make_psd_estimation_workflow
@@ -29,15 +29,12 @@ from ligo import segments as _segments
 import lal
 
 import pycbc
-import pycbc.version
 import pycbc.workflow
 from pycbc.results import save_fig_with_metadata, two_column_layout
 import pycbc.workflow
 
 parser = argparse.ArgumentParser(description=__doc__)
 pycbc.add_common_pycbc_options(parser)
-parser.add_argument('--version', action='version',
-                    version=pycbc.version.git_verbose_msg)
 pycbc.workflow.add_workflow_command_line_group(parser)
 pycbc.workflow.add_workflow_settings_cli(parser)
 args = parser.parse_args()

--- a/bin/workflows/pycbc_make_sbank_workflow
+++ b/bin/workflows/pycbc_make_sbank_workflow
@@ -171,7 +171,6 @@ class CombineHDFBanksExecutable(wf.Executable):
 _desc = __doc__[1:]
 parser = argparse.ArgumentParser(description=_desc)
 pycbc.add_common_pycbc_options(parser)
-parser.add_argument('--version', action='version', version=__version__)
 parser.add_argument("--output-file", type=str, default=None,
                     help="Specify the output file name. Either a name can be "
                          "provided or a full path to file. Is this is not "

--- a/bin/workflows/pycbc_make_sbank_workflow
+++ b/bin/workflows/pycbc_make_sbank_workflow
@@ -28,15 +28,8 @@ import os
 import argparse
 
 import pycbc
-import pycbc.version
 import pycbc.workflow as wf
 import pycbc.workflow.pegasus_workflow as pwf
-
-# Boiler-plate stuff
-__author__  = "Ian Harry <ian.harry@ligo.org>"
-__version__ = pycbc.version.git_verbose_msg
-__date__    = pycbc.version.date
-__program__ = "pycbc_make_sbank_workflow"
 
 # We define classes for all executables used in the workflow
 

--- a/bin/workflows/pycbc_make_uberbank_workflow
+++ b/bin/workflows/pycbc_make_uberbank_workflow
@@ -142,7 +142,6 @@ class SbankDaxGenerator(wf.Executable):
 _desc = __doc__[1:]
 parser = argparse.ArgumentParser(description=_desc)
 pycbc.add_common_pycbc_options(parser)
-parser.add_argument('--version', action='version', version=__version__)
 wf.add_workflow_command_line_group(parser)
 wf.add_workflow_settings_cli(parser)
 args = parser.parse_args()

--- a/pycbc/__init__.py
+++ b/pycbc/__init__.py
@@ -39,9 +39,11 @@ try:
     # before version.py has been generated.
     from .version import git_hash
     from .version import version as pycbc_version
+    from .version import git_verbose_msg
 except:
     git_hash = 'none'
     pycbc_version = 'none'
+    git_verbose_msg = 'none'
 
 __version__ = pycbc_version
 
@@ -79,16 +81,26 @@ def add_common_pycbc_options(parser):
         title="PyCBC common options",
         description="Common options for PyCBC executables.",
     )
-    group.add_argument('-v', '--verbose', action='count', default=0,
-                       help='Add verbosity to logging. Adding the option '
-                            'multiple times makes logging progressively '
-                            'more verbose, e.g. --verbose or -v provides '
-                            'logging at the info level, but -vv or '
-                            '--verbose --verbose provides debug logging.')
+    group.add_argument(
+        '-v',
+        '--verbose',
+        action='count',
+        default=0,
+        help=(
+            'Add verbosity to logging. Adding the option '
+            'multiple times makes logging progressively '
+            'more verbose, e.g. --verbose or -v provides '
+            'logging at the info level, but -vv or '
+            '--verbose --verbose provides debug logging.'
+        )
+    )
     group.add_argument(
         '--version',
         action="version",
-        version=pycbc_version.git_verbose_msg
+        version=git_verbose_msg,
+        help=(
+            'Display version information and exit.'
+        )
     )
 
 

--- a/pycbc/__init__.py
+++ b/pycbc/__init__.py
@@ -39,11 +39,11 @@ try:
     # before version.py has been generated.
     from .version import git_hash
     from .version import version as pycbc_version
-    from .version import Version
+    from .version import PyCBCVersionAction
 except:
     git_hash = 'none'
     pycbc_version = 'none'
-    Version = None
+    PyCBCVersionAction = None
 
 __version__ = pycbc_version
 
@@ -96,9 +96,14 @@ def add_common_pycbc_options(parser):
     )
     group.add_argument(
         '--version',
-        action=Version,
+        action=PyCBCVersionAction,
         help=(
-            'Display version information and exit.'
+            'Display PyCBC version information and exit. '
+            'Can be supplied a modifier integer to control the '
+            'verbosity of the version information. 0 and 1 are the '
+            'same as --version; 2 provides more detailed PyCBC library '
+            'information; 3 provides information about PyCBC, '
+            'LAL and LALSimulation packages (if installed)'
         )
     )
 

--- a/pycbc/__init__.py
+++ b/pycbc/__init__.py
@@ -39,11 +39,11 @@ try:
     # before version.py has been generated.
     from .version import git_hash
     from .version import version as pycbc_version
-    from .version import git_verbose_msg
+    from .version import Version
 except:
     git_hash = 'none'
     pycbc_version = 'none'
-    git_verbose_msg = 'none'
+    Version = None
 
 __version__ = pycbc_version
 
@@ -96,8 +96,7 @@ def add_common_pycbc_options(parser):
     )
     group.add_argument(
         '--version',
-        action="version",
-        version=git_verbose_msg,
+        action=Version,
         help=(
             'Display version information and exit.'
         )

--- a/pycbc/__init__.py
+++ b/pycbc/__init__.py
@@ -97,14 +97,6 @@ def add_common_pycbc_options(parser):
     group.add_argument(
         '--version',
         action=PyCBCVersionAction,
-        help=(
-            'Display PyCBC version information and exit. '
-            'Can be supplied a modifier integer to control the '
-            'verbosity of the version information. 0 and 1 are the '
-            'same as --version; 2 provides more detailed PyCBC library '
-            'information; 3 provides information about PyCBC, '
-            'LAL and LALSimulation packages (if installed)'
-        )
     )
 
 

--- a/pycbc/__init__.py
+++ b/pycbc/__init__.py
@@ -85,6 +85,11 @@ def add_common_pycbc_options(parser):
                             'more verbose, e.g. --verbose or -v provides '
                             'logging at the info level, but -vv or '
                             '--verbose --verbose provides debug logging.')
+    group.add_argument(
+        '--version',
+        action="version",
+        version=pycbc_version.git_verbose_msg
+    )
 
 
 def init_logging(verbose=False, default_level=0, to_file=None,

--- a/pycbc/_version.py
+++ b/pycbc/_version.py
@@ -83,7 +83,7 @@ class PyCBCVersionAction(argparse._StoreAction):
     """
     default_help = (
         'Display PyCBC version information and exit. '
-        'Can be supplied a modifier integer to control the '
+        'Can optionally supply a modifier integer to control the '
         'verbosity of the version information. 0 and 1 are the '
         'same as --version; 2 provides more detailed PyCBC library '
         'information; 3 provides information about PyCBC, '

--- a/pycbc/_version.py
+++ b/pycbc/_version.py
@@ -89,6 +89,7 @@ class PyCBCVersionAction(argparse._StoreAction):
         'information; 3 provides information about PyCBC, '
         'LAL and LALSimulation packages (if installed)'
     )
+
     def __init__(self,
                  option_strings,
                  dest,
@@ -115,7 +116,7 @@ class PyCBCVersionAction(argparse._StoreAction):
         if version_no > 1:
             # --version with flag above 1 - return the verbose version string
             version_str = (
-                "--- PyCBC Version --------------------------\n" + 
+                "--- PyCBC Version --------------------------\n" +
                 pycbc.version.git_verbose_msg
             )
         if version_no > 2:
@@ -133,7 +134,10 @@ class PyCBCVersionAction(argparse._StoreAction):
             except ImportError:
                 version_str += "\nLAL not installed in environment\n"
             else:
-                version_str += get_lal_info(lal, '_lal*.so')
+                version_str += get_lal_info(
+                    lal,
+                    '_lal*.so'
+                )
 
             version_str += "\n\n--- LALSimulation Version-------------------\n"
             try:
@@ -141,7 +145,10 @@ class PyCBCVersionAction(argparse._StoreAction):
             except ImportError:
                 version_str += "\nLALSimulation not installed in environment\n"
             else:
-                version_str += get_lal_info(lalsimulation, '_lalsimulation*.so')
+                version_str += get_lal_info(
+                    lalsimulation,
+                    '_lalsimulation*.so'
+                )
 
         print(version_str)
         sys.exit(0)

--- a/pycbc/_version.py
+++ b/pycbc/_version.py
@@ -81,15 +81,25 @@ class PyCBCVersionAction(argparse._StoreAction):
     PyCBC, and for LAL and LALSimulation depending on an integer variable.
     Can be supplied without the option
     """
+    default_help = (
+        'Display PyCBC version information and exit. '
+        'Can be supplied a modifier integer to control the '
+        'verbosity of the version information. 0 and 1 are the '
+        'same as --version; 2 provides more detailed PyCBC library '
+        'information; 3 provides information about PyCBC, '
+        'LAL and LALSimulation packages (if installed)'
+    )
     def __init__(self,
                  option_strings,
                  dest,
+                 help=default_help,
                  **kw):
         argparse._StoreAction.__init__(
             self,
             option_strings,
             dest=dest,
             nargs='?',
+            help=help,
             type=int,
             **kw,
         )
@@ -98,7 +108,6 @@ class PyCBCVersionAction(argparse._StoreAction):
         version_no = 0 if values is None else values
         import pycbc
         setattr(namespace, self.dest, version_no)
-        print(namespace)
         if version_no <= 1:
             # --version called with zero or default - return the
             # simple version string

--- a/pycbc/_version.py
+++ b/pycbc/_version.py
@@ -28,6 +28,7 @@ import subprocess
 import logging
 
 logger = logging.getLogger('pycbc._version')
+SUPPRESS = "==SUPPRESS=="
 
 
 def print_link(library):
@@ -75,40 +76,66 @@ def get_lal_info(module, lib_glob):
     return version_str
 
 
-class Version(argparse.Action):
-    """Subclass of argparse.Action that prints version information for PyCBC,
-    LAL and LALSimulation.
+class PyCBCVersionAction(argparse._StoreAction):
+    """Subclass of argparse._StoreAction that prints version information for
+    PyCBC, and for LAL and LALSimulation depending on an integer variable.
+    Can be supplied without the option
     """
-    def __init__(self, nargs=0, **kw):
-        super(Version, self).__init__(nargs=nargs, **kw)
-
-    def __call__(self, parser, namespace, values, option_string=None):
-        import pycbc
-
-        version_str = (
-            "--- PyCBC Version --------------------------\n" +
-            pycbc.version.git_verbose_msg +
-            "\n\nImported from: " + inspect.getfile(pycbc)
+    def __init__(self,
+                 option_strings,
+                 dest,
+                 **kw):
+        argparse._StoreAction.__init__(
+            self,
+            option_strings,
+            dest=dest,
+            nargs='?',
+            type=int,
+            **kw,
         )
 
-        version_str += "\n\n--- LAL Version ----------------------------\n"
-        try:
-            import lal.git_version
-        except ImportError:
-            version_str += "\nLAL not installed in environment\n"
-        else:
-            version_str += get_lal_info(lal, '_lal*.so')
+    def __call__(self, parser, namespace, values, option_string=None):
+        version_no = 0 if values is None else values
+        import pycbc
+        setattr(namespace, self.dest, version_no)
+        print(namespace)
+        if version_no <= 1:
+            # --version called with zero or default - return the
+            # simple version string
+            version_str = "PyCBC version: " + pycbc.version.version
+        if version_no > 1:
+            # --version with flag above 1 - return the verbose version string
+            version_str = (
+                "--- PyCBC Version --------------------------\n" + 
+                pycbc.version.git_verbose_msg
+            )
+        if version_no > 2:
+            # --version called more than twice - print all version information
+            # possible
+            import __main__
+            version_str += (
+                "\n\nCurrent Executable: " + __main__.__file__ +
+                "\nImported from: " + inspect.getfile(pycbc) +
+                "\n\n--- LAL Version ----------------------------\n"
+            )
 
-        version_str += "\n\n--- LALSimulation Version-------------------\n"
-        try:
-            import lalsimulation.git_version
-        except ImportError:
-            version_str += "\nLALSimulation not installed in environment\n"
-        else:
-            version_str += get_lal_info(lalsimulation, '_lalsimulation*.so')
+            try:
+                import lal.git_version
+            except ImportError:
+                version_str += "\nLAL not installed in environment\n"
+            else:
+                version_str += get_lal_info(lal, '_lal*.so')
+
+            version_str += "\n\n--- LALSimulation Version-------------------\n"
+            try:
+                import lalsimulation.git_version
+            except ImportError:
+                version_str += "\nLALSimulation not installed in environment\n"
+            else:
+                version_str += get_lal_info(lalsimulation, '_lalsimulation*.so')
 
         print(version_str)
         sys.exit(0)
 
 
-__all__ = ['Version']
+__all__ = ['PyCBCVersionAction']

--- a/pycbc/_version.py
+++ b/pycbc/_version.py
@@ -28,7 +28,6 @@ import subprocess
 import logging
 
 logger = logging.getLogger('pycbc._version')
-SUPPRESS = "==SUPPRESS=="
 
 
 def print_link(library):

--- a/pycbc/results/pygrb_postprocessing_utils.py
+++ b/pycbc/results/pygrb_postprocessing_utils.py
@@ -56,14 +56,13 @@ except ImportError:
 # * Add to the parser object the arguments used for BestNR calculation
 # * Add to the parser object the arguments for found/missed injection files
 # =============================================================================
-def pygrb_initialize_plot_parser(description=None, version=None):
+def pygrb_initialize_plot_parser(description=None):
     """Sets up a basic argument parser object for PyGRB plotting scripts"""
 
     formatter_class = argparse.ArgumentDefaultsHelpFormatter
     parser = argparse.ArgumentParser(description=description,
                                      formatter_class=formatter_class)
     add_common_pycbc_options(parser)
-    parser.add_argument("--version", action="version", version=version)
     parser.add_argument("-o", "--output-file", default=None,
                         help="Output file.")
     parser.add_argument("--x-lims", action="store", default=None,

--- a/tools/pycbc_test_suite.sh
+++ b/tools/pycbc_test_suite.sh
@@ -31,7 +31,7 @@ fi
 if [ "$PYCBC_TEST_TYPE" = "help" ] || [ -z ${PYCBC_TEST_TYPE+x} ]; then
     # check that all executables that do not require
     # special environments can return a help message
-    for prog in `find ${PATH//:/ } -maxdepth 1 -name 'pycbc*' -print 2>/dev/null | egrep -v '(pycbc_live_nagios_monitor|pycbc_make_offline_grb_workflow|pycbc_mvsc_get_features|pycbc_upload_xml_to_gracedb|pycbc_coinc_time)' | sort | uniq`
+    for prog in `find ${PATH//:/ } -maxdepth 1 -name 'pycbc*' -print 2>/dev/null | egrep -v '(pycbc_mvsc_get_features)' | sort | uniq`
     do
         echo -e ">> [`date`] running $prog --help"
         $prog --help &> $LOG_FILE
@@ -44,10 +44,28 @@ if [ "$PYCBC_TEST_TYPE" = "help" ] || [ -z ${PYCBC_TEST_TYPE+x} ]; then
         else
             echo -e "    Pass."
         fi
+	if [[ $prog =~ "pycbc_copy_output_map|pycbc_submit_dax|pycbc_stageout_failed_workflow|pycbc_live_nagios_monitor" ]] ; then
+	    continue
+	fi
+	echo -e ">> [`date`] running $prog --version"
+	$prog --version &> $LOG_FILE
+	if test $? -ne 0 ; then
+            RESULT=1
+            echo -e "    FAILED!"
+            echo -e "---------------------------------------------------------"
+            cat $LOG_FILE
+            echo -e "---------------------------------------------------------"
+        else
+            echo -e "    Pass."
+        fi
     done
-    # also check that --version works for one executable
-    echo -e ">> [`date`] running pycbc_inspiral --version"
+    # also check that --version with increased modifiers works for one executable
+    echo -e ">> [`date`] running pycbc_inspiral --version with modifiers"
     pycbc_inspiral --version &> $LOG_FILE
+    pycbc_inspiral --version 0 &> $LOG_FILE
+    pycbc_inspiral --version 1 &> $LOG_FILE
+    pycbc_inspiral --version 2 &> $LOG_FILE
+    pycbc_inspiral --version 3 &> $LOG_FILE
     if test $? -ne 0 ; then
         RESULT=1
         echo -e "    FAILED!"

--- a/tools/pycbc_test_suite.sh
+++ b/tools/pycbc_test_suite.sh
@@ -44,7 +44,7 @@ if [ "$PYCBC_TEST_TYPE" = "help" ] || [ -z ${PYCBC_TEST_TYPE+x} ]; then
         else
             echo -e "    Pass."
         fi
-	if [[ $prog =~ "pycbc_copy_output_map|pycbc_submit_dax|pycbc_stageout_failed_workflow|pycbc_live_nagios_monitor" ]] ; then
+	if [[ `echo $prog | egrep '(pycbc_copy_output_map|pycbc_submit_dax|pycbc_stageout_failed_workflow)'` ]] ; then
 	    continue
 	fi
 	echo -e ">> [`date`] running $prog --version"

--- a/tools/pycbc_test_suite.sh
+++ b/tools/pycbc_test_suite.sh
@@ -31,7 +31,7 @@ fi
 if [ "$PYCBC_TEST_TYPE" = "help" ] || [ -z ${PYCBC_TEST_TYPE+x} ]; then
     # check that all executables that do not require
     # special environments can return a help message
-    for prog in `find ${PATH//:/ } -maxdepth 1 -name 'pycbc*' -print 2>/dev/null | egrep -v '(pycbc_mvsc_get_features)' | sort | uniq`
+    for prog in `find ${PATH//:/ } -maxdepth 1 -name 'pycbc*' -print 2>/dev/null | egrep -v '(pycbc_live_nagios_monitor|pycbc_mvsc_get_features|pycbc_coinc_time)' | sort | uniq`
     do
         echo -e ">> [`date`] running $prog --help"
         $prog --help &> $LOG_FILE


### PR DESCRIPTION
Add an option to give --version information, allowing the user to specify how verbose the information is

## Standard information about the request

This is a code management improvement
This change touches all areas of the codebase
This change affects no output except the versioning page on reults pages

This change follows style guidelines (See e.g. [PEP8](https://peps.python.org/pep-0008/)), has been proposed using the [contribution guidelines](https://github.com/gwastro/pycbc/blob/master/CONTRIBUTING.md)

## Motivation
This, along with the logging standardization changes previously made, should make it easier to contribute to PyCBC, particularly if making a new executable

## Contents
Removed all cases of '--version' arguments being added to a parser when `add_common_pycbc_options` is used

Modify (and rename) the pycbc.version.Version class to be able to take in a modifier defining how verbose the library version information is.

## Testing performed
Various executables run with `--help` and `--version`, `--version 0`, `--version 1`, `--version 2`, `--version 3` as appropriate

The CI will confirm if I have removed an `import pycbc.version` when it is needed for an implicit pycbc import - which I probably have

Next steps for testing are to run the `pycbc_page_versioning` script with every executable as input, and modify it to have some of the more verbose version information at the top (probably the first executable will be given the modifier)

## Additional notes
I have avoided pycbc_live, for a similar reason to why I have not touched it in the logging changes ; I do not want to damage any of the codes which work on the output of that

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
