### PR TITLE
fix a memory leakage bug in pycbc_brute_bank

### DIFF
--- a/bin/bank/pycbc_brute_bank
+++ b/bin/bank/pycbc_brute_bank
@@ -259,6 +259,7 @@ class TriangleBank(object):
                 ({k: params[k][idx] for k in params} for idx in range(total_num))
             ):
             waveform_cache += [return_wf]
+        pool.close_pool()
         del pool
 
         for hp in waveform_cache:

--- a/pycbc/pool.py
+++ b/pycbc/pool.py
@@ -91,7 +91,7 @@ class BroadcastPool(multiprocessing.pool.Pool):
         return results
 
     def map(self, func, items, chunksize=None):
-        """ Catch keyboard interupts to allow the pool to exit cleanly.
+        """ Catch keyboard interrupts to allow the pool to exit cleanly.
 
         Parameters
         ----------

--- a/pycbc/pool.py
+++ b/pycbc/pool.py
@@ -91,7 +91,7 @@ class BroadcastPool(multiprocessing.pool.Pool):
         return results
 
     def map(self, func, items, chunksize=None):
-        """ Catch keyboard interuppts to allow the pool to exit cleanly.
+        """ Catch keyboard interupts to allow the pool to exit cleanly.
 
         Parameters
         ----------
@@ -113,6 +113,13 @@ class BroadcastPool(multiprocessing.pool.Pool):
                 self.join()
                 raise KeyboardInterrupt
 
+    def close_pool(self):
+        """ Close the pool and remove the reference
+        """
+        self.close()
+        self.join()
+        atexit.unregister(_shutdown_pool)
+
 def _dummy_broadcast(self, f, args):
     self.map(f, [args] * self.size)
 
@@ -129,6 +136,11 @@ class SinglePool(object):
     # imap irrespective of the pool type. 
     imap = map
     imap_unordered = map
+
+    def close_pool(self):
+        ''' Dummy function to be consistent with BroadcastPool
+        '''
+        pass
 
 def use_mpi(require_mpi=False, log=True):
     """ Get whether MPI is enabled and if so the current size and rank


### PR DESCRIPTION
https://github.com/gwastro/pycbc/pull/4803 has a memory leakage bug because, as far as I understand, `atexit` makes a reference to the multiprocessing pool so it doesn't completely terminate after each call. This PR add a method to close the pool and remove the reference. I did a test with what failed before, the memory leakage doesn't occur again.