### PR TITLE
Add mechanism for re-loading the statistic files in live

### DIFF
--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -1048,6 +1048,8 @@ parser.add_argument('--psd-variation', action='store_true',
                          "values for each single detector triggers found by "
                          "the search. Required when using a single detector "
                          "ranking statistic that includes psd variation.")
+parser.add_argument("--statistic-refresh-rate", type=float,
+                    help="How often to refresh the statistic object")
 
 scheme.insert_processing_option_group(parser)
 LiveSingle.insert_args(parser)
@@ -1166,6 +1168,8 @@ with ctx:
     if analyze_singles and evnt.rank == 0:
         sngl_estimator = {ifo: LiveSingle.from_cli(args, ifo)
                           for ifo in evnt.trigg_ifos}
+        for estim in sngl_estimator.values():
+            estim.start_refresh_thread()
 
     # Create double coincident background estimator
     # for every pair of triggering interferometers
@@ -1186,6 +1190,10 @@ with ctx:
             setproctitle('PyCBC Live {} bg estimator'.format(
                     ppdets(c.ifos, '-')))
 
+        def estimator_refresh_threads(_):
+            c = estimators[my_coinc_id]
+            c.start_refresh_thread()
+
         def get_coinc(results):
             c = estimators[my_coinc_id]
             r = c.add_singles(results)
@@ -1200,6 +1208,7 @@ with ctx:
 
         coinc_pool = BroadcastPool(len(estimators))
         coinc_pool.allmap(set_coinc_id, range(len(estimators)))
+        coinc_pool.broadcast(estimator_refresh_threads, None)
 
     logging.info('Starting')
 
@@ -1428,3 +1437,5 @@ if evnt.rank == 1:
 
 if args.enable_profiling is not None and evnt.rank == args.enable_profiling:
     pr.dump_stats(f'profiling_rank_{evnt.rank:03d}')
+
+logging.info("Exiting as the end time has been reached")

--- a/pycbc/events/coinc.py
+++ b/pycbc/events/coinc.py
@@ -1433,7 +1433,7 @@ class LiveCoincTimeslideBackgroundEstimator(object):
                 with self.stat_calculator_lock:
                     self.stat_calculator.check_update_files()
             # Sleep one second for safety
-            time.sleep(1)
+            timemod.sleep(1)
             # Now include the time it took the check / update the statistic
             since_stat_refresh = \
                 (dt.now() - self.time_stat_refreshed).total_seconds()
@@ -1445,6 +1445,7 @@ class LiveCoincTimeslideBackgroundEstimator(object):
             timemod.sleep(
                 self.statistic_refresh_rate - since_stat_refresh + 1
             )
+
 
 __all__ = [
     "background_bin_from_string",

--- a/pycbc/events/coinc.py
+++ b/pycbc/events/coinc.py
@@ -25,9 +25,18 @@
 coincident triggers.
 """
 
-import numpy, logging, pycbc.pnutils, copy
+import numpy
+import logging
+import copy
+from datetime import datetime as dt
+import time as timemod
+import threading
+
+import pycbc.pnutils
 from pycbc.detector import Detector, ppdets
 from pycbc import conversions as conv
+
+from . import stat as pycbcstat
 from .eventmgr_cython import coincbuffer_expireelements
 from .eventmgr_cython import coincbuffer_numgreater
 from .eventmgr_cython import timecoincidence_constructidxs
@@ -829,6 +838,7 @@ class LiveCoincTimeslideBackgroundEstimator(object):
                  ifar_limit=100,
                  timeslide_interval=.035,
                  coinc_window_pad=.002,
+                 statistic_refresh_rate=None,
                  return_background=False,
                  **kwargs):
         """
@@ -856,6 +866,9 @@ class LiveCoincTimeslideBackgroundEstimator(object):
         coinc_window_pad: float
             Amount of time allowed to form a coincidence in addition to the
             time of flight in seconds.
+        statistic_refresh_rate: float
+            How regularly to run the update_files method on the statistic
+            class (in seconds), default not do do this
         return_background: boolean
             If true, background triggers will also be included in the file
             output.
@@ -863,17 +876,20 @@ class LiveCoincTimeslideBackgroundEstimator(object):
             Additional options for the statistic to use. See stat.py
             for more details on statistic options.
         """
-        from . import stat
         self.num_templates = num_templates
         self.analysis_block = analysis_block
 
-        stat_class = stat.get_statistic(background_statistic)
+        stat_class = pycbcstat.get_statistic(background_statistic)
         self.stat_calculator = stat_class(
             sngl_ranking,
             stat_files,
             ifos=ifos,
             **kwargs
         )
+
+        self.time_stat_refreshed = dt.now()
+        self.stat_calculator_lock = threading.Lock()
+        self.statistic_refresh_rate = statistic_refresh_rate
 
         self.timeslide_interval = timeslide_interval
         self.return_background = return_background
@@ -955,7 +971,6 @@ class LiveCoincTimeslideBackgroundEstimator(object):
 
     @classmethod
     def from_cli(cls, args, num_templates, analysis_chunk, ifos):
-        from . import stat
 
         # Allow None inputs
         stat_files = args.statistic_files or []
@@ -964,7 +979,7 @@ class LiveCoincTimeslideBackgroundEstimator(object):
         # flatten the list of lists of filenames to a single list (may be empty)
         stat_files = sum(stat_files, [])
 
-        kwargs = stat.parse_statistic_keywords_opt(stat_keywords)
+        kwargs = pycbcstat.parse_statistic_keywords_opt(stat_keywords)
 
         return cls(num_templates, analysis_chunk,
                    args.ranking_statistic,
@@ -975,13 +990,13 @@ class LiveCoincTimeslideBackgroundEstimator(object):
                    timeslide_interval=args.timeslide_interval,
                    ifos=ifos,
                    coinc_window_pad=args.coinc_window_pad,
+                   statistic_refresh_rate=args.statistic_refresh_rate,
                    **kwargs)
 
     @staticmethod
     def insert_args(parser):
-        from . import stat
 
-        stat.insert_statistic_option_group(parser)
+        pycbcstat.insert_statistic_option_group(parser)
 
         group = parser.add_argument_group('Coincident Background Estimation')
         group.add_argument('--store-background', action='store_true',
@@ -1374,11 +1389,12 @@ class LiveCoincTimeslideBackgroundEstimator(object):
         valid_ifos = [k for k in results.keys() if results[k] and k in self.ifos]
         if len(valid_ifos) == 0: return {}
 
-        # Add single triggers to the internal buffer
-        self._add_singles_to_buffer(results, ifos=valid_ifos)
+        with self.stat_calculator_lock:
+            # Add single triggers to the internal buffer
+            self._add_singles_to_buffer(results, ifos=valid_ifos)
 
-        # Calculate zerolag and background coincidences
-        _, coinc_results = self._find_coincs(results, valid_ifos=valid_ifos)
+            # Calculate zerolag and background coincidences
+            _, coinc_results = self._find_coincs(results, valid_ifos=valid_ifos)
 
         # record if a coinc is possible in this chunk
         if len(valid_ifos) == 2:
@@ -1386,6 +1402,49 @@ class LiveCoincTimeslideBackgroundEstimator(object):
 
         return coinc_results
 
+    def start_refresh_thread(self):
+        """
+        Start a thread managing whether the stat_calculator will be updated
+        """
+        thread = threading.Thread(
+            target=self.refresh_statistic,
+            daemon=True
+        )
+        logger.info(
+            "Starting %s statistic refresh thread",
+            ''.join(self.ifos),
+        )
+        thread.start()
+
+    def refresh_statistic(self):
+        """
+        Function to refresh the stat_calculator at regular intervals
+        """
+        while True:
+            # How long since the statistic was last updated?
+            since_stat_refresh = \
+                (dt.now() - self.time_stat_refreshed).total_seconds()
+            if since_stat_refresh > self.statistic_refresh_rate:
+                self.time_stat_refreshed = dt.now()
+                logger.info(
+                    "Checking %s statistic for updated files",
+                    ''.join(self.ifos),
+                )
+                with self.stat_calculator_lock:
+                    self.stat_calculator.check_update_files()
+            # Sleep one second for safety
+            time.sleep(1)
+            # Now include the time it took the check / update the statistic
+            since_stat_refresh = \
+                (dt.now() - self.time_stat_refreshed).total_seconds()
+            logger.debug(
+                "%s statistic: Waiting %.3fs for next refresh",
+                ''.join(self.ifos),
+                self.statistic_refresh_rate - since_stat_refresh,
+            )
+            timemod.sleep(
+                self.statistic_refresh_rate - since_stat_refresh + 1
+            )
 
 __all__ = [
     "background_bin_from_string",

--- a/pycbc/events/single.py
+++ b/pycbc/events/single.py
@@ -3,6 +3,9 @@
 import logging
 import copy
 import h5py
+import threading
+from datetime import datetime as dt
+import time
 import numpy as np
 
 from pycbc.events import trigger_fits as fits, stat
@@ -25,12 +28,57 @@ class LiveSingle(object):
                  statistic=None,
                  sngl_ranking=None,
                  stat_files=None,
+                 statistic_refresh_rate=None,
                  **kwargs):
+        """
+        Parameters
+        ----------
+        ifo: str
+            Name of the ifo that is being analyzed
+        newsnr_threshold: float
+            Minimum value for the reweighted SNR of the event under
+            consideration. Which reweighted SNR is defined by sngl_ranking
+        reduced_chisq_threshold: float
+            Maximum value for the reduced chisquared of the event under
+            consideration
+        duration_threshold: float
+            Minimum value for the duration of the template which found the
+            event under consideration
+        fit_file: str or path
+            (optional) the file containing information about the
+            single-detector event significance distribution fits
+        sngl_ifar_est_dist: str
+            Which trigger distribution to use when calculating IFAR of
+            single-detector events
+        fixed_ifar: float
+            (optional) give a fixed IFAR value to any event which passes the
+            threshold criteria
+        statistic: str
+            The name of the statistic to rank events.
+        sngl_ranking: str
+            The single detector ranking to use with the background statistic
+        stat_files: list of strs
+            List of filenames that contain information used to construct
+            various coincident statistics.
+        maximum_ifar: float
+            The largest inverse false alarm rate in years that we would like to
+            calculate.
+        statistic_refresh_rate: float
+            How regularly to run the update_files method on the statistic
+            class (in seconds), default not do do this
+        kwargs: dict
+            Additional options for the statistic to use. See stat.py
+            for more details on statistic options.
+        """
         self.ifo = ifo
         self.fit_file = fit_file
         self.sngl_ifar_est_dist = sngl_ifar_est_dist
         self.fixed_ifar = fixed_ifar
         self.maximum_ifar = maximum_ifar
+
+        self.time_stat_refreshed = dt.now()
+        self.stat_calculator_lock = threading.Lock()
+        self.statistic_refresh_rate = statistic_refresh_rate
 
         stat_class = stat.get_statistic(statistic)
         self.stat_calculator = stat_class(
@@ -188,6 +236,7 @@ class LiveSingle(object):
            statistic=args.ranking_statistic,
            sngl_ranking=args.sngl_ranking,
            stat_files=stat_files,
+           statistic_refresh_rate=args.statistic_refresh_rate,
            **kwargs
            )
 
@@ -227,7 +276,9 @@ class LiveSingle(object):
         trigsc['chisq_dof'] = (cut_trigs['chisq_dof'] + 2) / 2
 
         # Calculate the ranking reweighted SNR for cutting
-        single_rank = self.stat_calculator.get_sngl_ranking(trigsc)
+        with self.stat_calculator_lock:
+            single_rank = self.stat_calculator.get_sngl_ranking(trigsc)
+
         sngl_idx = single_rank > self.thresholds['ranking']
         if not np.any(sngl_idx):
             return None
@@ -236,8 +287,9 @@ class LiveSingle(object):
                         for k in trigs}
 
         # Calculate the ranking statistic
-        sngl_stat = self.stat_calculator.single(cutall_trigs)
-        rank = self.stat_calculator.rank_stat_single((self.ifo, sngl_stat))
+        with self.stat_calculator_lock:
+            sngl_stat = self.stat_calculator.single(cutall_trigs)
+            rank = self.stat_calculator.rank_stat_single((self.ifo, sngl_stat))
 
         # 'cluster' by taking the maximal statistic value over the trigger set
         i = rank.argmax()
@@ -303,3 +355,44 @@ class LiveSingle(object):
         rate_louder *= len(rates)
 
         return min(conv.sec_to_year(1. / rate_louder), self.maximum_ifar)
+
+    def start_refresh_thread(self):
+        """
+        Start a thread managing whether the stat_calculator will be updated
+        """
+        thread = threading.Thread(
+            target=self.refresh_statistic,
+            daemon=True
+        )
+        logger.info("Starting %s statistic refresh thread", self.ifo)
+        thread.start()
+
+    def refresh_statistic(self):
+        """
+        Function to refresh the stat_calculator at regular intervals
+        """
+        while True:
+            # How long since the statistic was last updated?
+            since_stat_refresh = \
+                (dt.now() - self.time_stat_refreshed).total_seconds()
+            if since_stat_refresh > self.statistic_refresh_rate:
+                self.time_stat_refreshed = dt.now()
+                logger.info(
+                    "Checking %s statistic for updated files",
+                    self.ifo,
+                )
+                with self.stat_calculator_lock:
+                    self.stat_calculator.check_update_files()
+            # Sleep one second for safety
+            time.sleep(1)
+            # Now use the time it took the check / update the statistic
+            since_stat_refresh = \
+                (dt.now() - self.time_stat_refreshed).total_seconds()
+            logger.debug(
+                "%s statistic: Waiting %.3fs for next refresh",
+                self.ifo,
+                self.statistic_refresh_rate - since_stat_refresh
+            )
+            time.sleep(
+                self.statistic_refresh_rate - since_stat_refresh
+            )

--- a/pycbc/events/single.py
+++ b/pycbc/events/single.py
@@ -2,7 +2,6 @@
 """
 import logging
 import copy
-import h5py
 import threading
 from datetime import datetime as dt
 import time
@@ -11,6 +10,7 @@ import numpy as np
 from pycbc.events import trigger_fits as fits, stat
 from pycbc.types import MultiDetOptionAction
 from pycbc import conversions as conv
+from pycbc.io.hdf import HFile
 from pycbc import bin_utils
 
 logger = logging.getLogger('pycbc.events.single')
@@ -317,7 +317,7 @@ class LiveSingle(object):
             return self.fixed_ifar[self.ifo]
 
         try:
-            with h5py.File(self.fit_file, 'r') as fit_file:
+            with HFile(self.fit_file, 'r') as fit_file:
                 bin_edges = fit_file['bins_edges'][:]
                 live_time = fit_file[self.ifo].attrs['live_time']
                 thresh = fit_file.attrs['fit_threshold']

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -26,10 +26,10 @@ This module contains functions for calculating coincident ranking statistic
 values.
 """
 import logging
-import numpy
-import h5py
 from hashlib import sha1
 from datetime import datetime as dt
+import numpy
+import h5py
 
 from . import ranking
 from . import coinc_rate
@@ -37,6 +37,7 @@ from .eventmgr_cython import logsignalrateinternals_computepsignalbins
 from .eventmgr_cython import logsignalrateinternals_compute2detrate
 
 logger = logging.getLogger('pycbc.events.stat')
+
 
 class Stat(object):
     """Base class which should be extended to provide a coincident statistic"""
@@ -123,6 +124,7 @@ class Stat(object):
                 )
             else:
                 del changed_file_hashes[stat]
+                continue
         else:
             logger.debug(
                 "No %s statistic files have changed",
@@ -460,7 +462,7 @@ class PhaseTDStatistic(QuadratureSumStatistic):
 
         if selected is None and len(ifos) > 1:
             raise RuntimeError("Couldn't figure out which stat file to use")
-        elif len(ifos) == 1:
+        if len(ifos) == 1:
             # We dont need the histogram file, but we are trying to get one
             # just skip it in this case
             return
@@ -599,6 +601,8 @@ class PhaseTDStatistic(QuadratureSumStatistic):
             # This is a PhaseTDStatistic file which needs updating
             self.get_hist()
             return True
+        return False
+
 
     def logsignalrate(self, stats, shift, to_shift):
         """
@@ -936,6 +940,7 @@ class ExpFitStatistic(QuadratureSumStatistic):
                 key
             )
             return True
+        return False
 
     def get_ref_vals(self, ifo):
         """
@@ -1455,6 +1460,7 @@ class ExpFitBgRateStatistic(ExpFitStatistic):
             ifo = key[:2]
             self.reassign_rate(ifo)
             return True
+        return False
 
     def rank_stat_coinc(self, s, slide, step, to_shift,
                         **kwargs): # pylint:disable=unused-argument
@@ -1612,6 +1618,7 @@ class ExpFitFgBgNormStatistic(PhaseTDStatistic,
             self.assign_median_sigma(ifo)
             self.assign_benchmark_logvol()
             return True
+        return False
 
     def lognoiserate(self, trigs, alphabelow=6):
         """
@@ -2142,6 +2149,7 @@ class ExpFitFgBgKDEStatistic(ExpFitFgBgNormStatistic):
             kde_style = key.split('-')[0]
             self.assign_kdes(kde_style)
             return True
+        return False
 
     def kde_ratio(self):
         """
@@ -2368,6 +2376,7 @@ class DQExpFitFgBgNormStatistic(ExpFitFgBgNormStatistic):
             self.assign_template_bins(key)
             self.setup_segments(key)
             return True
+        return False
 
     def find_dq_noise_rate(self, trigs, dq_state):
         """Get dq values for a specific ifo and dq states"""

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -122,14 +122,13 @@ class Stat(object):
                     ''.join(self.ifos),
                     stat,
                 )
-            else:
-                del changed_file_hashes[stat]
-                continue
         else:
             logger.debug(
                 "No %s statistic files have changed",
                 ''.join(self.ifos)
             )
+            return []
+
         return list(changed_file_hashes.keys())
 
     def check_update_files(self):
@@ -602,7 +601,6 @@ class PhaseTDStatistic(QuadratureSumStatistic):
             self.get_hist()
             return True
         return False
-
 
     def logsignalrate(self, stats, shift, to_shift):
         """

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -122,12 +122,15 @@ class Stat(object):
                     ''.join(self.ifos),
                     stat,
                 )
-        else:
+            else:
+                # Remove the dataset from the dictionary of hashes
+                del changed_file_hashes[stat]
+
+        if changed_file_hashes == {}:
             logger.debug(
                 "No %s statistic files have changed",
                 ''.join(self.ifos)
             )
-            return []
 
         return list(changed_file_hashes.keys())
 

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -28,13 +28,15 @@ values.
 import logging
 import numpy
 import h5py
+from hashlib import sha1
+from datetime import datetime as dt
+
 from . import ranking
 from . import coinc_rate
 from .eventmgr_cython import logsignalrateinternals_computepsignalbins
 from .eventmgr_cython import logsignalrateinternals_compute2detrate
 
 logger = logging.getLogger('pycbc.events.stat')
-
 
 class Stat(object):
     """Base class which should be extended to provide a coincident statistic"""
@@ -68,6 +70,9 @@ class Stat(object):
                                    " %s. Can't provide more than one!" % stat)
             logger.info("Found file %s for stat %s", filename, stat)
             self.files[stat] = filename
+        # Keep track of when stat files hashes so it can be
+        # reloaded if it has changed
+        self.file_hashes = self.get_file_hashes()
 
         # Provide the dtype of the single detector method's output
         # This is used by background estimation codes that need to maintain
@@ -84,6 +89,64 @@ class Stat(object):
         for key, value in kwargs.items():
             if key.startswith('sngl_ranking_'):
                 self.sngl_ranking_kwargs[key[13:]] = value
+
+    def get_file_hashes(self):
+        """
+        Get sha1 hashes for all the files
+        """
+        logger.debug(
+            "Getting file hashes"
+        )
+        start = dt.now()
+        file_hashes = {}
+        for stat, filename in self.files.items():
+            with open(filename, 'rb') as file_binary:
+                file_hashes[stat] = sha1(file_binary.read()).hexdigest()
+        logger.debug(
+            "Got file hashes for %d files, took %.3es",
+            len(self.files),
+            (dt.now() - start).total_seconds()
+        )
+        return file_hashes
+
+    def files_changed(self):
+        """
+        Compare hashes of files now with the ones we have cached
+        """
+        changed_file_hashes = self.get_file_hashes()
+        for stat, old_hash in self.file_hashes.items():
+            if changed_file_hashes[stat] != old_hash:
+                logger.info(
+                    "%s statistic file %s has changed",
+                    ''.join(self.ifos),
+                    stat,
+                )
+            else:
+                del changed_file_hashes[stat]
+        else:
+            logger.debug(
+                "No %s statistic files have changed",
+                ''.join(self.ifos)
+            )
+        return list(changed_file_hashes.keys())
+
+    def check_update_files(self):
+        """
+        Check whether files associated with the statistic need updated,
+        then do so for each file which needs changing
+        """
+        files_changed = self.files_changed()
+        for file_key in files_changed:
+            self.update_file(file_key)
+        self.file_hashes = self.get_file_hashes()
+
+    def update_file(self, key):
+        """
+        Update file used in this statistic referenced by key.
+        """
+        err_msg = "This function is a stub that should be overridden by the "
+        err_msg += "sub-classes. You shouldn't be seeing this error!"
+        raise NotImplementedError(err_msg)
 
     def get_sngl_ranking(self, trigs):
         """
@@ -351,6 +414,13 @@ class PhaseTDStatistic(QuadratureSumStatistic):
 
         if pregenerate_hist and not len(ifos) == 1:
             self.get_hist()
+        elif len(ifos) == 1:
+            # remove all phasetd files from self.files and self.file_hashes,
+            # as they are not needed
+            for k in list(self.files.keys()):
+                if 'phasetd_newsnr' in k:
+                    del self.files[k]
+                    del self.file_hashes[k]
 
     def get_hist(self, ifos=None):
         """
@@ -380,8 +450,20 @@ class PhaseTDStatistic(QuadratureSumStatistic):
                 selected = name
                 break
 
+        # If there are other phasetd_newsnr files, they aren't needed.
+        # So tidy them out of the self.files dictionary
+        rejected = [key for key in self.files.keys()
+                    if 'phasetd_newsnr' in key and not key == selected]
+        for k in rejected:
+            del self.files[k]
+            del self.file_hashes[k]
+
         if selected is None and len(ifos) > 1:
             raise RuntimeError("Couldn't figure out which stat file to use")
+        elif len(ifos) == 1:
+            # We dont need the histogram file, but we are trying to get one
+            # just skip it in this case
+            return
 
         logger.info("Using signal histogram %s for ifos %s", selected, ifos)
         weights = {}
@@ -494,6 +576,29 @@ class PhaseTDStatistic(QuadratureSumStatistic):
             self.relsense[ifo] = sense
 
         self.has_hist = True
+
+    def update_file(self, key):
+        """
+        Update file used in this statistic.
+        If others are used (i.e. this statistic is inherited), they will
+        need updated separately
+        """
+        if 'phasetd_newsnr' in key and not len(self.ifos) == 1:
+            if ''.join(sorted(self.ifos)) not in key:
+                logger.debug(
+                    "%s file is not used for %s statistic",
+                    key,
+                    ''.join(self.ifos)
+                )
+                return False
+            logger.info(
+                "Updating %s statistic %s file",
+                ''.join(self.ifos),
+                key
+            )
+            # This is a PhaseTDStatistic file which needs updating
+            self.get_hist()
+            return True
 
     def logsignalrate(self, stats, shift, to_shift):
         """
@@ -711,7 +816,9 @@ class PhaseTDStatistic(QuadratureSumStatistic):
         if not self.has_hist:
             self.get_hist()
 
-        fixed_statsq = sum([b['snglstat'] ** 2 for a, b in sngls_list])
+        fixed_statsq = sum(
+            [b['snglstat'] ** 2 for a, b in sngls_list if a != limifo]
+        )
         s1 = thresh ** 2. - fixed_statsq
         # Assume best case scenario and use maximum signal rate
         s1 -= 2. * self.hist_max
@@ -752,9 +859,11 @@ class ExpFitStatistic(QuadratureSumStatistic):
         parsed_attrs = [f.split('-') for f in self.files.keys()]
         self.bg_ifos = [at[0] for at in parsed_attrs if
                        (len(at) == 2 and at[1] == 'fit_coeffs')]
+
         if not len(self.bg_ifos):
             raise RuntimeError("None of the statistic files has the required "
                                "attribute called {ifo}-fit_coeffs !")
+
         self.fits_by_tid = {}
         self.alphamax = {}
         for i in self.bg_ifos:
@@ -808,6 +917,25 @@ class ExpFitStatistic(QuadratureSumStatistic):
         coeff_file.close()
 
         return fits_by_tid_dict
+
+    def update_file(self, key):
+        """
+        Update file used in this statistic.
+        If others are used (i.e. this statistic is inherited), they will
+        need updated separately
+        """
+        if key.endswith('-fit_coeffs'):
+            # This is a ExpFitStatistic file which needs updating
+            # Which ifo is it?
+            ifo = key[:2]
+            self.fits_by_tid[ifo] = self.assign_fits(ifo)
+            self.get_ref_vals(ifo)
+            logger.info(
+                "Updating %s statistic %s file",
+                ''.join(self.ifos),
+                key
+            )
+            return True
 
     def get_ref_vals(self, ifo):
         """
@@ -1151,6 +1279,18 @@ class PhaseTDExpFitStatistic(PhaseTDStatistic, ExpFitCombinedSNR):
         PhaseTDStatistic.__init__(self, sngl_ranking, files=files,
                                   ifos=ifos, **kwargs)
 
+    def update_file(self, key):
+        """
+        Update file used in this statistic.
+        If others are used (i.e. this statistic is inherited), they will
+        need updated separately
+        """
+        # Here we inherit the PhaseTD and ExpFit file checks,
+        # nothing else needs doing
+        uf_exp_fit = ExpFitCombinedSNR.update_file(self, key)
+        uf_phasetd = PhaseTDStatistic.update_file(self, key)
+        return uf_exp_fit or uf_phasetd
+
     def single(self, trigs):
         """
         Calculate the necessary single detector information
@@ -1299,6 +1439,23 @@ class ExpFitBgRateStatistic(ExpFitStatistic):
             self.fits_by_tid[ifo]['fit_by_rate_above_thresh'] /= analysis_time
             self.fits_by_tid[ifo]['fit_by_rate_in_template'] /= analysis_time
 
+    def update_file(self, key):
+        """
+        Update file used in this statistic.
+        If others are used (i.e. this statistic is inherited), they will
+        need updated separately
+        """
+        # Check if the file to update is an ExpFit file
+        uf_expfit = ExpFitStatistic.update_file(self, key)
+        # If this has been updated we must do the reassign_rate step here
+        # on top of the file update from earlier
+        if uf_expfit:
+            # This is a fit coeff file which needs updating
+            # Which ifo is it?
+            ifo = key[:2]
+            self.reassign_rate(ifo)
+            return True
+
     def rank_stat_coinc(self, s, slide, step, to_shift,
                         **kwargs): # pylint:disable=unused-argument
         """
@@ -1399,12 +1556,9 @@ class ExpFitFgBgNormStatistic(PhaseTDStatistic,
         for ifo in self.bg_ifos:
             self.assign_median_sigma(ifo)
 
-        ref_ifos = reference_ifos.split(',')
-
-        # benchmark_logvol is a benchmark sensitivity array over template id
-        hl_net_med_sigma = numpy.amin([self.fits_by_tid[ifo]['median_sigma']
-                                       for ifo in ref_ifos], axis=0)
-        self.benchmark_logvol = 3. * numpy.log(hl_net_med_sigma)
+        self.ref_ifos = reference_ifos.split(',')
+        self.benchmark_logvol = None
+        self.assign_benchmark_logvol()
         self.single_increasing = False
         # Initialize variable to hold event template id(s)
         self.curr_tnum = None
@@ -1424,6 +1578,40 @@ class ExpFitFgBgNormStatistic(PhaseTDStatistic,
             tid_sort = numpy.argsort(template_id)
             self.fits_by_tid[ifo]['median_sigma'] = \
                 coeff_file['median_sigma'][:][tid_sort]
+
+    def assign_benchmark_logvol(self):
+        """
+        Assign the benchmark log-volume used by the statistic.
+        This is the sensitive log-volume of each template in the
+        network of reference IFOs
+        """
+        # benchmark_logvol is a benchmark sensitivity array over template id
+        bench_net_med_sigma = numpy.amin(
+            [self.fits_by_tid[ifo]['median_sigma'] for ifo in self.ref_ifos],
+            axis=0,
+        )
+        self.benchmark_logvol = 3. * numpy.log(bench_net_med_sigma)
+
+    def update_file(self, key):
+        """
+        Update file used in this statistic.
+        If others are used (i.e. this statistic is inherited), they will
+        need updated separately
+        """
+        # Here we inherit the PhaseTD file checks
+        uf_phasetd = PhaseTDStatistic.update_file(self, key)
+        uf_exp_fit = ExpFitBgRateStatistic.update_file(self, key)
+        if uf_phasetd:
+            # The key to update refers to a PhaseTDStatistic file
+            return True
+        if uf_exp_fit:
+            # The key to update refers to a ExpFitBgRateStatistic file
+            # In this case we must reload some statistic information
+            # Which ifo is it?
+            ifo = key[:2]
+            self.assign_median_sigma(ifo)
+            self.assign_benchmark_logvol()
+            return True
 
     def lognoiserate(self, trigs, alphabelow=6):
         """
@@ -1555,7 +1743,6 @@ class ExpFitFgBgNormStatistic(PhaseTDStatistic,
             ln_noise_rate = coinc_rate.combination_noise_lograte(
                                     sngl_rates, kwargs['time_addition'],
                                     kwargs['dets'])
-                                    
             # Extent of time-difference space occupied
             noise_twindow = coinc_rate.multiifo_noise_coincident_area(
                                 self.hist_ifos, kwargs['time_addition'],
@@ -1934,6 +2121,28 @@ class ExpFitFgBgKDEStatistic(ExpFitFgBgNormStatistic):
         with h5py.File(self.files[kname + '-kde_file'], 'r') as kde_file:
             self.kde_by_tid[kname + '_kdevals'] = kde_file['data_kde'][:]
 
+    def update_file(self, key):
+        """
+        Update file used in this statistic.
+        If others are used (i.e. this statistic is inherited), they will
+        need updated separately
+        """
+        # Inherit from ExpFitFgBgNormStatistic
+        uf_expfit = ExpFitFgBgNormStatistic.update_file(self, key)
+        if uf_expfit:
+            # The key to update refers to a ExpFitFgBgNormStatistic file
+            return True
+        # Is the key a KDE statistic file that we update here?
+        if key.endswith('kde_file'):
+            logger.info(
+                "Updating %s statistic %s file",
+                ''.join(self.ifos),
+                key
+            )
+            kde_style = key.split('-')[0]
+            self.assign_kdes(kde_style)
+            return True
+
     def kde_ratio(self):
         """
         Calculate the weighting factor according to the ratio of the
@@ -2137,6 +2346,29 @@ class DQExpFitFgBgNormStatistic(ExpFitFgBgNormStatistic):
 
         return dq_state_segs_dict
 
+    def update_file(self, key):
+        """
+        Update file used in this statistic.
+        If others are used (i.e. this statistic is inherited), they will
+        need updated separately
+        """
+        # Inherit from ExpFitFgBgNormStatistic
+        uf_expfit = ExpFitFgBgNormStatistic.update_file(self, key)
+        if uf_expfit:
+            # We have updated a ExpFitFgBgNormStatistic file already
+            return True
+        # We also need to check if the DQ files have updated
+        if key.endswith('dq_stat_info'):
+            logger.info(
+                "Updating %s statistic %s file",
+                ''.join(self.ifos),
+                key
+            )
+            self.assign_dq_rates(key)
+            self.assign_template_bins(key)
+            self.setup_segments(key)
+            return True
+
     def find_dq_noise_rate(self, trigs, dq_state):
         """Get dq values for a specific ifo and dq states"""
 
@@ -2196,7 +2428,6 @@ class DQExpFitFgBgNormStatistic(ExpFitFgBgNormStatistic):
         """
 
         # make sure every trig has a dq state
-
         try:
             ifo = trigs.ifo
         except AttributeError:
@@ -2244,6 +2475,17 @@ class DQExpFitFgBgKDEStatistic(DQExpFitFgBgNormStatistic):
         self.kde_by_tid = {}
         for kname in self.kde_names:
             ExpFitFgBgKDEStatistic.assign_kdes(self, kname)
+
+    def update_file(self, key):
+        """
+        Update file used in this statistic.
+        If others are used (i.e. this statistic is inherited), they will
+        need updated separately
+        """
+        # Inherit from DQExpFitFgBgNormStatistic and ExpFitFgBgKDEStatistic
+        uf_dq = DQExpFitFgBgNormStatistic.update_file(self, key)
+        uf_kde = ExpFitFgBgKDEStatistic.update_file(self, key)
+        return uf_dq or uf_kde
 
     def kde_ratio(self):
         """

--- a/test/test_live_coinc_compare.py
+++ b/test/test_live_coinc_compare.py
@@ -76,7 +76,8 @@ class TestPyCBCLiveCoinc(unittest.TestCase):
             timeslide_interval=0.1,
             background_ifar_limit=100,
             store_background=True,
-            coinc_window_pad=0.002
+            coinc_window_pad=0.002,
+            statistic_refresh_rate=None,
         )
 
         # number of templates in the bank


### PR DESCRIPTION
Statistic files will be changed by a supervisor script in live for future uses. This PR adds the ability to check the sha1 hashes of the file and compare it to a stored copy so that if the file has changed, it can be reloaded.

In this usage, the file in the command line arguments would be overwritten (or a symlink which is updated), and then the statistic would refresh at an appropriate rate.

## Standard information about the request

This is a new feature
This change affects the live search; Offline code is touched but not affected
This change changes scientific output

This change follows style guidelines (See e.g. [PEP8](https://peps.python.org/pep-0008/)), has been proposed using the [contribution guidelines](https://github.com/gwastro/pycbc/blob/master/CONTRIBUTING.md)

## Motivation
We want to be able to use a proper ranking statistic in Live, but do not want to have to use static files, or restart the search regularly in order to update them. This change means that the ranking statistic files can be reloaded

## Contents
 - Add functions to check the hashes of all files associated with the statistic object
 - Add threads for each statistic object which will monitor if the files have changed. These sleep until the next refresh time
 - Add functions to each statistic which detects whether the files needed by that statistic have been updated, and runs the appropriate function needed to reload the information from that file.

## Links to any issues or associated PRs
Link to draft PR: https://github.com/GarethCabournDavies/pycbc/pull/5/files
#4689, #4527, #4813

Note that this will significantly clash with #4608 

## Testing performed
 - Started pycbc live - printed some values from the fits files.
 - Updated fits files, checked that the values are updated after this, and that the updated files were logged

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
