### PR TITLE
qtransform interpolation should be linear to avoid negative values

### DIFF
--- a/pycbc/types/timeseries.py
+++ b/pycbc/types/timeseries.py
@@ -760,10 +760,11 @@ class TimeSeries(Array):
         # Interpolate if requested
         if delta_f or delta_t or logfsteps:
             if return_complex:
-                interp_amp = interp2d(times, freqs, abs(q_plane.T))
-                interp_phase = interp2d(times, freqs, _numpy.angle(q_plane.T))
+                interp_amp = interp2d(freqs, times, abs(q_plane), kx=1, ky=1)
+                interp_phase = interp2d(freqs, times, _numpy.angle(q_plane),
+                                        kx=1, ky=1)
             else:
-                interp = interp2d(times, freqs, q_plane.T)
+                interp = interp2d(freqs, times, q_plane, kx=1, ky=1)
 
         if delta_t:
             times = _numpy.arange(float(self.start_time),
@@ -777,12 +778,12 @@ class TimeSeries(Array):
 
         if delta_f or delta_t or logfsteps:
             if return_complex:
-                q_plane = _numpy.exp(1.0j * interp_phase(times, freqs))
-                q_plane *= interp_amp(times, freqs)
+                q_plane = _numpy.exp(1.0j * interp_phase(freqs, times))
+                q_plane *= interp_amp(freqs, times)
             else:
-                q_plane = interp(times, freqs)
+                q_plane = interp(freqs, times)
 
-        return times, freqs, q_plane.T
+        return times, freqs, q_plane
 
     def notch_fir(self, f1, f2, order, beta=5.0, remove_corrupted=True):
         """ notch filter the time series using an FIR filtered generated from


### PR DESCRIPTION
In a previous update scipy removed interp2d. Per the guide, we moved to rectbivariatespline, however, this meant that the default changed from linear to cubic interpolation. This isn't ideal for qtransform plots due to the fact that it results in negative values. These show up as "snow" when plotting the amplitude in results pages for example. e.g. 
![data](https://github.com/user-attachments/assets/3ffccefe-4e1c-4277-acb0-02da7787c9ff)

This was repoted by @yi-fan-wang and others.
