### PR TITLE
don't forget to actually deploy the documentation

### DIFF
--- a/.github/workflows/basic-tests.yml
+++ b/.github/workflows/basic-tests.yml
@@ -50,7 +50,7 @@ jobs:
         export LAL_DATA_PATH=$PWD
         tox -e py-inference
     - name: store documentation page
-      if: matrix.test-type == 'docs' && matrix.python-version == '3.8'
+      if: matrix.test-type == 'docs' && matrix.python-version == '3.12'
       uses: actions/upload-artifact@v2
       with:
         name: documentation-page


### PR DESCRIPTION
In #4716 python 3.8 was dropped, but I forgot to update the check on which python version actually servers to deploy the documentation. This changes it to use the latest (python3.12) documentation build instead.