### PR TITLE
Add checksums to hdf5 datasets datasets

### DIFF
--- a/pycbc/io/hdf.py
+++ b/pycbc/io/hdf.py
@@ -39,30 +39,30 @@ class HGroup(h5py.Group):
         if track_order is None:
             track_order = h5py.h5.get_config().track_order
 
-        # FIXME: use the h5py file locker? with h5py.phil:
-        name, lcpl = self._e(name, lcpl=True)
-        gcpl = HGroup._gcpl_crt_order if track_order else None
-        gid = h5py.h5g.create(self.id, name, lcpl=lcpl, gcpl=gcpl)
-        return HGroup(gid)
-
-
-    def __setitem__(self, name, obj):
-        """
-        Wrapper around h5py's __setitem__ so that checksums are used
-        """
-        if type(obj) not in [h5py.HLObject, h5py.SoftLink, h5py.ExternalLink, np.dtype]:
+        with h5py._objects.phil:
             name, lcpl = self._e(name, lcpl=True)
-            print(f"Setting {name} while using fletcher32")
-            ds = self.create_dataset(None, data=obj, fletcher32=True)
-            h5py.h5o.link(ds.id, self.id, name, lcpl=lcpl)
-        else:
-            h5py.File.__setitem__(self, name, obj)
+            gcpl = HGroup._gcpl_crt_order if track_order else None
+            gid = h5py.h5g.create(self.id, name, lcpl=lcpl, gcpl=gcpl)
+            return HGroup(gid)
+
+    def create_dataset(self, name, shape=None, dtype=None, data=None, **kwds):
+        """
+        Wrapper around h5py's create_dataset so that checksums are used
+        """
+        kwds['fletcher32'] = True
+        return h5py.Group.create_dataset(
+            self,
+            name,
+            shape=shape,
+            dtype=dtype,
+            data=data,
+            **kwds
+        )
 
 
 class HFile(HGroup, h5py.File):
     """ Low level extensions to the capabilities of reading an hdf5 File
     """
-
     def select(self, fcn, *args, chunksize=10**6, derived=None, group='',
                return_data=True, premask=None):
         """ Return arrays from an hdf5 file that satisfy the given function

--- a/pycbc/io/hdf.py
+++ b/pycbc/io/hdf.py
@@ -49,7 +49,8 @@ class HGroup(h5py.Group):
         """
         Wrapper around h5py's create_dataset so that checksums are used
         """
-        kwds['fletcher32'] = True
+        if hasattr(data, 'dtype') and not data.dtype == object:
+            kwds['fletcher32'] = True
         return h5py.Group.create_dataset(
             self,
             name,


### PR DESCRIPTION
Add fletcher32 checksums by default to hdf5 datasets

## Standard information about the request

This is a new feature
This change affects everywhere that hdf5 file objects are used
This change follows style guidelines (See e.g. [PEP8](https://peps.python.org/pep-0008/)), has been proposed using the [contribution guidelines](https://github.com/gwastro/pycbc/blob/master/CONTRIBUTING.md)

## Motivation
This will check whether data has been corrupted in any way during 

## Implementation
Add a wrapper around the h5py Group object which does two things:
 - Reimplements the `create_group` function so that it points to this wrapper
 - adds the fletcher32 keyword to the `create_dataset` method
Add an inheritence to this wrapper to the HFile class, so that these are used in the file generally

## Links to any issues or associated PRs
#1525 - (I was sorting issues in order, oldest first)

## Testing performed
Run fit_sngls_over_multiparam - which uses both direct assignment on the file as well as `create_group()` and assignment to that, and check that the files are identical at the output.
 - File hashes did not match (as expected)
 - all attributes and datasets were identical (as expected)
 - Running `h5ls -rv` on the output we see that all datasets have the line `Filter-0:  fletcher32-3  {}`

Same test on `pycbc_add_statmap`, same result

## Additional notes
Some note about the implementation:
 - I don't really like how much of the `create_group` method's code is copied from the h5py source code, but couldn't see a nicer implementation.
 - the fact that h5py.File just inherits from h5py.Group made this much easier!

I can add compression to the `create_dataset` wrapper if wanted, and then we can replace the stuff in `pycbc_coinc_statmap`, though I'm not sure of the I/O penalty for that

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
