### PR TITLE
PyCBC Live: fix errors from stat refresh code when not being used

### DIFF
--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -1049,7 +1049,8 @@ parser.add_argument('--psd-variation', action='store_true',
                          "the search. Required when using a single detector "
                          "ranking statistic that includes psd variation.")
 parser.add_argument("--statistic-refresh-rate", type=float,
-                    help="How often to refresh the statistic object")
+                    help="How often to refresh the statistic object, "
+                         "in seconds. If omitted, no refreshing is done.")
 
 scheme.insert_processing_option_group(parser)
 LiveSingle.insert_args(parser)

--- a/pycbc/events/coinc.py
+++ b/pycbc/events/coinc.py
@@ -1406,14 +1406,17 @@ class LiveCoincTimeslideBackgroundEstimator(object):
         Start a thread managing whether the stat_calculator will be updated
         """
         if self.statistic_refresh_rate is None:
+            logger.info(
+                "Statistic refresh disabled for %s", ppdets(self.ifos, "-")
+            )
             return
         thread = threading.Thread(
             target=self.refresh_statistic,
-            daemon=True
+            daemon=True,
+            name="Stat refresh " + ppdets(self.ifos, "-")
         )
         logger.info(
-            "Starting %s statistic refresh thread",
-            ''.join(self.ifos),
+            "Starting %s statistic refresh thread", ppdets(self.ifos, "-")
         )
         thread.start()
 

--- a/pycbc/events/coinc.py
+++ b/pycbc/events/coinc.py
@@ -1431,7 +1431,7 @@ class LiveCoincTimeslideBackgroundEstimator(object):
                 self.time_stat_refreshed = timemod.time()
                 logger.info(
                     "Checking %s statistic for updated files",
-                    ''.join(self.ifos),
+                    ppdets(self.ifos, "-"),
                 )
                 with self.stat_calculator_lock:
                     self.stat_calculator.check_update_files()
@@ -1441,12 +1441,10 @@ class LiveCoincTimeslideBackgroundEstimator(object):
             since_stat_refresh = timemod.time() - self.time_stat_refreshed
             logger.debug(
                 "%s statistic: Waiting %.3fs for next refresh",
-                ''.join(self.ifos),
+                ppdets(self.ifos, "-"),
                 self.statistic_refresh_rate - since_stat_refresh,
             )
-            timemod.sleep(
-                self.statistic_refresh_rate - since_stat_refresh + 1
-            )
+            timemod.sleep(self.statistic_refresh_rate - since_stat_refresh + 1)
 
 
 __all__ = [

--- a/pycbc/events/coinc.py
+++ b/pycbc/events/coinc.py
@@ -28,7 +28,6 @@ coincident triggers.
 import numpy
 import logging
 import copy
-from datetime import datetime as dt
 import time as timemod
 import threading
 
@@ -317,7 +316,7 @@ def time_multi_coincidence(times, slide_step=0, slop=.003,
         #  tested against fixed and pivot are now present for testing with new
         #  dependent ifos
         for ifo2 in ids:
-            logger.info('added ifo %s, testing against %s' % (ifo1, ifo2))
+            logger.info('added ifo %s, testing against %s', ifo1, ifo2)
             w = win(ifo1, ifo2)
             left = time1.searchsorted(ctimes[ifo2] - w)
             right = time1.searchsorted(ctimes[ifo2] + w)
@@ -887,7 +886,7 @@ class LiveCoincTimeslideBackgroundEstimator(object):
             **kwargs
         )
 
-        self.time_stat_refreshed = dt.now()
+        self.time_stat_refreshed = timemod.time()
         self.stat_calculator_lock = threading.Lock()
         self.statistic_refresh_rate = statistic_refresh_rate
 
@@ -1406,6 +1405,8 @@ class LiveCoincTimeslideBackgroundEstimator(object):
         """
         Start a thread managing whether the stat_calculator will be updated
         """
+        if self.statistic_refresh_rate is None:
+            return
         thread = threading.Thread(
             target=self.refresh_statistic,
             daemon=True
@@ -1422,10 +1423,9 @@ class LiveCoincTimeslideBackgroundEstimator(object):
         """
         while True:
             # How long since the statistic was last updated?
-            since_stat_refresh = \
-                (dt.now() - self.time_stat_refreshed).total_seconds()
+            since_stat_refresh = timemod.time() - self.time_stat_refreshed
             if since_stat_refresh > self.statistic_refresh_rate:
-                self.time_stat_refreshed = dt.now()
+                self.time_stat_refreshed = timemod.time()
                 logger.info(
                     "Checking %s statistic for updated files",
                     ''.join(self.ifos),
@@ -1435,8 +1435,7 @@ class LiveCoincTimeslideBackgroundEstimator(object):
             # Sleep one second for safety
             timemod.sleep(1)
             # Now include the time it took the check / update the statistic
-            since_stat_refresh = \
-                (dt.now() - self.time_stat_refreshed).total_seconds()
+            since_stat_refresh = timemod.time() - self.time_stat_refreshed
             logger.debug(
                 "%s statistic: Waiting %.3fs for next refresh",
                 ''.join(self.ifos),


### PR DESCRIPTION
#4816 leads to an error if `--statistic-refresh-rate` is not used. The error causes the refresh threads to crash, but this is not detected in the CI tests, which only check the final results.

## Standard information about the request

This is mostly a bug fix but includes a few minor improvements and simplifications.

This change affects the live search.

## Motivation

The core of the error is this message (possibly mangled due to multithreading, sorry):
```
  File "…/lib/python3.9/site-packages/pycbc/events/coinc.py", line 1427, in refresh_statistic
    if since_stat_refresh > self.statistic_refresh_rate:
TypeError: '>' not supported between instances of 'float' and 'NoneType'
```

## Contents

Adds a check for None, cleans up a few logging messages, improves an argparse help string, uses simpler timing functions.

## Links to any issues or associated PRs

Improves #4816.

## Testing performed

Error discovered by staring at the Live example while it runs. Testing performed in the same way.

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
