### PR TITLE
Fix subtle bug when using `LIGOTimeGPS` with `TimeSeries.at_time()`

### DIFF
--- a/pycbc/types/timeseries.py
+++ b/pycbc/types/timeseries.py
@@ -243,10 +243,12 @@ class TimeSeries(Array):
 
     def at_time(self, time, nearest_sample=False,
                 interpolate=None, extrapolate=None):
-        """ Return the value at the specified gps time
+        """ Return the value of the TimeSeries at the specified GPS time.
 
         Parameters
         ----------
+        time: scalar or array-like
+            GPS time at which the value is wanted.
         nearest_sample: bool
             Return the sample at the time nearest to the chosen time rather
             than rounded down.
@@ -278,9 +280,9 @@ class TimeSeries(Array):
                 keep_idx = _numpy.where(left & right)[0]
                 vtime = vtime[keep_idx]
             else:
-                raise ValueError("Unsuported extrapolate: %s" % extrapolate)
+                raise ValueError(f"Unsuported extrapolate: {extrapolate}")
 
-        fi = (vtime - float(self.start_time))*self.sample_rate
+        fi = (vtime - float(self.start_time)) * self.sample_rate
         i = _numpy.asarray(_numpy.floor(fi)).astype(int)
         di = fi - i
 
@@ -305,10 +307,9 @@ class TimeSeries(Array):
             ans[keep_idx] = old
             ans = _numpy.array(ans, ndmin=1)
 
-        if _numpy.isscalar(time):
+        if _numpy.ndim(time) == 0:
             return ans[0]
-        else:
-            return ans
+        return ans
 
     at_times = at_time
 

--- a/pycbc/types/timeseries.py
+++ b/pycbc/types/timeseries.py
@@ -243,12 +243,13 @@ class TimeSeries(Array):
 
     def at_time(self, time, nearest_sample=False,
                 interpolate=None, extrapolate=None):
-        """ Return the value of the TimeSeries at the specified GPS time.
+        """Return the value of the TimeSeries at the specified GPS time.
 
         Parameters
         ----------
         time: scalar or array-like
-            GPS time at which the value is wanted.
+            GPS time at which the value is wanted. Note that LIGOTimeGPS
+            objects counts as a scalar.
         nearest_sample: bool
             Return the sample at the time nearest to the chosen time rather
             than rounded down.

--- a/pycbc/types/timeseries.py
+++ b/pycbc/types/timeseries.py
@@ -256,7 +256,7 @@ class TimeSeries(Array):
             Return the interpolated value of the time series. Choices
             are simple linear or quadratic interpolation.
         extrapolate: str or float, None
-            Value to return if time is outsidde the range of the vector or
+            Value to return if time is outside the range of the vector or
             method of extrapolating the value.
         """
         if nearest_sample:
@@ -280,7 +280,7 @@ class TimeSeries(Array):
                 keep_idx = _numpy.where(left & right)[0]
                 vtime = vtime[keep_idx]
             else:
-                raise ValueError(f"Unsuported extrapolate: {extrapolate}")
+                raise ValueError(f"Unsupported extrapolate: {extrapolate}")
 
         fi = (vtime - float(self.start_time)) * self.sample_rate
         i = _numpy.asarray(_numpy.floor(fi)).astype(int)

--- a/pycbc/types/timeseries.py
+++ b/pycbc/types/timeseries.py
@@ -249,7 +249,7 @@ class TimeSeries(Array):
         ----------
         time: scalar or array-like
             GPS time at which the value is wanted. Note that LIGOTimeGPS
-            objects counts as a scalar.
+            objects count as scalar.
         nearest_sample: bool
             Return the sample at the time nearest to the chosen time rather
             than rounded down.

--- a/test/test_timeseries.py
+++ b/test/test_timeseries.py
@@ -49,7 +49,7 @@ elif _scheme == 'cpu':
 
 from numpy import ndarray as CPUArray
 
-class TestTimeSeriesBase(array_base,unittest.TestCase):
+class TestTimeSeriesBase(array_base, unittest.TestCase):
     __test__ = False
     def setUp(self):
         self.scheme = _scheme
@@ -481,10 +481,10 @@ class TestTimeSeriesBase(array_base,unittest.TestCase):
         a = TimeSeries([0, 1, 2, 3, 4, 5, 6, 7], delta_t=1.0)
 
         self.assertAlmostEqual(a.at_time(0.5), 0.0)
-        self.assertAlmostEqual(a.at_time(0.6,  nearest_sample=True), 1.0)
+        self.assertAlmostEqual(a.at_time(0.6, nearest_sample=True), 1.0)
         self.assertAlmostEqual(a.at_time(0.5, interpolate='linear'), 0.5)
-        self.assertAlmostEqual(a.at_time([2.5],
-                               interpolate='quadratic'), 2.5)
+        self.assertAlmostEqual(a.at_time([2.5], interpolate='quadratic'), 2.5)
+        self.assertAlmostEqual(a.at_time(lal.LIGOTimeGPS(2.1)), 2.0)
 
         i = numpy.array([-0.2, 0.5, 1.5, 7.0])
 
@@ -503,6 +503,11 @@ class TestTimeSeriesBase(array_base,unittest.TestCase):
         x = a.at_time(i, extrapolate=0, interpolate='quadratic')
         n = numpy.array([0, 0.0, 1.5, 0.0])
         self.assertAlmostEqual((x-n).sum(), 0)
+
+        # Check that the output corresponds to input being scalar/array.
+        self.assertEqual(numpy.ndim(a.at_time(0.5)), 0)
+        self.assertEqual(numpy.ndim(a.at_time(lal.LIGOTimeGPS(2.1))), 0)
+        self.assertEqual(numpy.ndim(a.at_time(i)), 1)
 
     def test_inject(self):
         a = TimeSeries(numpy.zeros(2**20, dtype=numpy.float32),


### PR DESCRIPTION
#4351 introduced a subtle bug which started affecting the SNR calculation in PyCBC Live's followup-detector code. The issue was never noticed because it triggered no failures in the Live example, and was never cherry-picked into the 2.1 release branch. We only started seeing it recently, when we started running our extensive MDC tests from the master branch. The bug crashes the code that serializes the p_astro results into a JSON string.

## Standard information about the request

This is a bug fix which affects the online search and potentially other things (anything that uses `TimeSeries.at_time()`). This changes the scientific output (which previously could not exist) and should not require anything else.

## Motivation

We recently started testing the master branch on our extensive MDC, and immediately saw this error whenever an event was being uploaded:
```
Traceback (most recent call last):
  File "…/lib/python3.9/threading.py", line 980, in _bootstrap_inner
    self.run()
  File "…/lib/python3.9/threading.py", line 917, in run
    self._target(*self._args, **self._kwargs)
  File "…/bin/pycbc_live", line 481, in upload_in_thread
    gid = event.upload(
  File "…/lib/python3.9/site-packages/pycbc/io/gracedb.py", line 375, in upload
    self.save(fname)
  File "…/lib/python3.9/site-packages/pycbc/io/gracedb.py", line 323, in save
    json.dump(self.astro_probs, multipaf)
  File "…/lib/python3.9/json/__init__.py", line 179, in dump
    for chunk in iterable:
  File "…/lib/python3.9/json/encoder.py", line 431, in _iterencode
    yield from _iterencode_dict(o, _current_indent_level)
  File "…/lib/python3.9/json/encoder.py", line 405, in _iterencode_dict
    yield from chunks
  File "…/lib/python3.9/json/encoder.py", line 438, in _iterencode
    o = _default(o)
  File "…/lib/python3.9/json/encoder.py", line 179, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type ndarray is not JSON serializable
```
I tracked down the problem to PR #4351 and the `TimeSeries.at_time()` function. `pycbc_live` calls that function to get the SNR at the peak of the SNR timeseries. The time is expressed as a LIGOTimeGPS, and `numpy.isscalar()` returns `False` for a LIGOTimeGPS object, so `at_time()` returns a one-element Numpy array even for a single time point. This then causes several quantities downstream to be single-element Numpy arrays instead of Numpy scalars, including p_astro, and at that point the `json` module crashes with the above error.

## Contents

Numpy recommends using `ndim(object) == 0` instead of `isscalar(object)`. This seems to do what we think for LIGOTimeGPS, so I switched to that instead.

I also cleaned up various bits in the same method, but this is unrelated to the bug.

## Links to any issues or associated PRs

#4351.

## Testing performed

I ran the Live example after this fix with the p_astro calculation enabled, and verified that it completes.

We may want to add the p_astro calculation to the example for good, but I will not do so in this PR. There are obviously many possible combinations of PyCBC Live configuration that one could test, and I doubt we can cover more than one or two in the CI. As I argued before, I would rather prefer a deeper offline CI test which can be triggered manually and takes maybe around a day, but tests PyCBC Live in much more detail. So rather than simply adding p_astro to the example, I would rather work on putting that together instead.

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
