### PR TITLE
Various improvements to minifollowup tables

### DIFF
--- a/bin/minifollowups/pycbc_page_coincinfo
+++ b/bin/minifollowups/pycbc_page_coincinfo
@@ -77,6 +77,13 @@ pystat.insert_statistic_option_group(parser,
 args = parser.parse_args()
 pycbc.init_logging(args.verbose)
 
+if args.ranking_statistic not in ['quadsum', 'single_ranking_only']:
+    logging.warning(
+        "For the coincident info table, we only use single ranking, not %s, "
+        "this option will be ignored",
+        args.ranking_statistic
+    )
+
 # Get the nth loudest trigger from the output of pycbc_coinc_statmap
 f = HFile(args.statmap_file, 'r')
 d = f[args.statmap_file_subspace_name]
@@ -191,12 +198,6 @@ for ifo in files.keys():
     headers.append("UTC&nbsp;End&nbsp;Time")
     headers.append("GPS&nbsp;End&nbsp;time")
 
-    # SNR and phase (not showing any single-det stat here)
-    data[-1].append('%5.2f' % d['snr'][i])
-    data[-1].append('%5.2f' % d['coa_phase'][i])
-    #data[-1].append('%5.2f' % ranking.newsnr(d['snr'][i], rchisq))
-    headers.append("&rho;")
-    headers.append("Phase")
     #headers.append("Stat")
     # Determine statistic naming
     if args.sngl_ranking == "newsnr":
@@ -210,20 +211,16 @@ for ifo in files.keys():
     else:
         sngl_stat_name = args.sngl_ranking
 
-    if args.ranking_statistic in ["quadsum", "single_ranking_only"]:
-        stat_name = sngl_stat_name
-        stat_name_long = sngl_stat_name
-    else:
-        # Name would be too long - just call it ranking statistic
-        stat_name = 'Ranking Statistic'
-        stat_name_long = ' with '.join(
-            [args.ranking_statistic, args.sngl_ranking]
-        )
-    sds = rank_method.single(trig_dict)
-    stat = rank_method.rank_stat_single((ifo, sds))
-    headers.append(stat_name)
+    stat = rank_method.get_sngl_ranking(trig_dict)
+    headers.append(sngl_stat_name)
     data[-1].append('%5.2f' % stat[0])
 
+    # SNR and phase (not showing any single-det stat here)
+    data[-1].append('%5.2f' % d['snr'][i])
+    data[-1].append('%5.2f' % d['coa_phase'][i])
+    #data[-1].append('%5.2f' % ranking.newsnr(d['snr'][i], rchisq))
+    headers.append("&rho;")
+    headers.append("Phase")
     # Signal-glitch discrimators
     data[-1].append('%5.2f' % rchisq)
     data[-1].append('%i' % d['chisq_dof'][i])

--- a/bin/minifollowups/pycbc_page_coincinfo
+++ b/bin/minifollowups/pycbc_page_coincinfo
@@ -190,9 +190,6 @@ for ifo in files.keys():
     if args.include_summary_page_link:
         data[-1].append(pycbc.results.dq.get_summary_page_link(ifo, utc))
         headers.append("Detector&nbsp;status")
-    else:
-        data[-1].append(ifo)
-        headers.append("Ifo")
 
     # End times
     data[-1].append(str(datetime.datetime(*utc)))

--- a/bin/minifollowups/pycbc_page_coincinfo
+++ b/bin/minifollowups/pycbc_page_coincinfo
@@ -30,7 +30,7 @@ from pycbc import add_common_pycbc_options
 import pycbc.results
 import pycbc.pnutils
 from pycbc.io.hdf import HFile
-from pycbc.events import ranking
+from pycbc.events import ranking, stat as pystat
 from pycbc.results import followup
 
 parser = argparse.ArgumentParser()
@@ -69,7 +69,10 @@ parser.add_argument('--include-summary-page-link', action='store_true',
 parser.add_argument('--include-gracedb-link', action='store_true',
     help="If given, will provide a link to search GraceDB for events "
          "within a 3s window around the coincidence time.")
-
+parser.add_argument('--max-columns', type=int,
+    help="Maximum number of columns allowed in the table (not including detector names)")
+pystat.insert_statistic_option_group(parser,
+    default_ranking_statistic='single_ranking_only')
 
 args = parser.parse_args()
 pycbc.init_logging(args.verbose)
@@ -146,6 +149,9 @@ statmapfile = d
 # table. Each entry in data corresponds to each row in the final table and
 # should be a list of values. So data is will be a list of lists.
 data = []
+row_labels = list(files.keys())
+rank_method = pystat.get_statistic_from_opts(args, list(files.keys()))
+
 for ifo in files.keys():
 
     # ignore ifo if coinc didn't participate (only for multi-ifo workflow)
@@ -161,7 +167,12 @@ for ifo in files.keys():
 
     time = d['end_time'][i]
     utc = lal.GPSToUTC(int(time))[0:6]
-
+    trig_dict = {
+        k: numpy.array([d[k][i]])
+        for k in d.keys()
+        if not k.endswith('_template')
+        and k not in ['gating', 'search', 'template_boundaries']
+    }
     # Headers will store the headers that will appear in the table.
     headers = []
     data.append([])
@@ -187,6 +198,31 @@ for ifo in files.keys():
     headers.append("&rho;")
     headers.append("Phase")
     #headers.append("Stat")
+    # Determine statistic naming
+    if args.sngl_ranking == "newsnr":
+        sngl_stat_name = "Reweighted SNR"
+    elif args.sngl_ranking == "newsnr_sgveto":
+        sngl_stat_name = "Reweighted SNR (+sgveto)"
+    elif args.sngl_ranking == "newsnr_sgveto_psdvar":
+        sngl_stat_name = "Reweighted SNR (+sgveto+psdvar)"
+    elif args.sngl_ranking == "snr":
+        sngl_stat_name = "SNR"
+    else:
+        sngl_stat_name = args.sngl_ranking
+
+    if args.ranking_statistic in ["quadsum", "single_ranking_only"]:
+        stat_name = sngl_stat_name
+        stat_name_long = sngl_stat_name
+    else:
+        # Name would be too long - just call it ranking statistic
+        stat_name = 'Ranking Statistic'
+        stat_name_long = ' with '.join(
+            [args.ranking_statistic, args.sngl_ranking]
+        )
+    sds = rank_method.single(trig_dict)
+    stat = rank_method.rank_stat_single((ifo, sds))
+    headers.append(stat_name)
+    data[-1].append('%5.2f' % stat[0])
 
     # Signal-glitch discrimators
     data[-1].append('%5.2f' % rchisq)
@@ -218,7 +254,12 @@ for ifo in files.keys():
     headers.append("s<sub>2z</sub>")
     headers.append("Duration")
 
-html += str(pycbc.results.static_table(data, headers))
+html += str(pycbc.results.static_table(
+    data,
+    headers,
+    columns_max=args.max_columns,
+    row_labels=row_labels
+))
 ###############################################################################
 
 pycbc.results.save_fig_with_metadata(html, args.output_file, {},

--- a/bin/minifollowups/pycbc_page_coincinfo
+++ b/bin/minifollowups/pycbc_page_coincinfo
@@ -83,6 +83,7 @@ if args.ranking_statistic not in ['quadsum', 'single_ranking_only']:
         "this option will be ignored",
         args.ranking_statistic
     )
+    args.ranking_statistic = 'quadsum'
 
 # Get the nth loudest trigger from the output of pycbc_coinc_statmap
 f = HFile(args.statmap_file, 'r')

--- a/bin/minifollowups/pycbc_page_coincinfo
+++ b/bin/minifollowups/pycbc_page_coincinfo
@@ -157,7 +157,7 @@ statmapfile = d
 # table. Each entry in data corresponds to each row in the final table and
 # should be a list of values. So data is will be a list of lists.
 data = []
-row_labels = list(files.keys())
+row_labels = []
 rank_method = pystat.get_statistic_from_opts(args, list(files.keys()))
 
 for ifo in files.keys():
@@ -166,6 +166,7 @@ for ifo in files.keys():
     if (statmapfile['%s/time' % ifo][n] == -1.0):
         continue
 
+    row_labels.append(ifo)
     d = files[ifo]
     i = idx[ifo]
     tid = d['template_id'][i]

--- a/bin/minifollowups/pycbc_page_coincinfo
+++ b/bin/minifollowups/pycbc_page_coincinfo
@@ -219,7 +219,6 @@ for ifo in files.keys():
     # SNR and phase (not showing any single-det stat here)
     data[-1].append('%5.2f' % d['snr'][i])
     data[-1].append('%5.2f' % d['coa_phase'][i])
-    #data[-1].append('%5.2f' % ranking.newsnr(d['snr'][i], rchisq))
     headers.append("&rho;")
     headers.append("Phase")
     # Signal-glitch discrimators

--- a/bin/minifollowups/pycbc_page_injinfo
+++ b/bin/minifollowups/pycbc_page_injinfo
@@ -35,6 +35,8 @@ parser.add_argument('--injection-index', type=int, required=True,
     help="The index of the injection to print out. Required")
 parser.add_argument('--n-nearest', type=int,
     help="Optional, used in the title")
+parser.add_argument('--max-columns', type=int,
+    help="Optional, maximum number of columns used for the table")
 
 args = parser.parse_args()
 
@@ -127,7 +129,7 @@ for p in params:
     headers += [labels[p]]
 
 table = numpy.array([data], dtype=str)
-html = str(pycbc.results.static_table(table, headers))
+html = str(pycbc.results.static_table(table, headers, columns_max=args.max_columns))
 
 tag = ''
 if args.n_nearest is not None:

--- a/bin/minifollowups/pycbc_page_injinfo
+++ b/bin/minifollowups/pycbc_page_injinfo
@@ -20,6 +20,7 @@ import sys
 import numpy
 
 import pycbc.results
+from pycbc import conversions as conv
 import pycbc.pnutils
 from pycbc import init_logging, add_common_pycbc_options
 from pycbc.detector import Detector
@@ -65,13 +66,24 @@ labels = {
     'spin1z': 's<sub>1z</sub>',
     'spin2x': 's<sub>2x</sub>',
     'spin2y': 's<sub>2y</sub>',
-    'spin2z': 's<sub>2z</sub>'
+    'spin2z': 's<sub>2z</sub>',
+    'chieff': '&chi;<sub>eff</sub>',
+    'chip': '&chi;<sub>p</sub>',
 }
 
 params += ['tc']
 
 m1, m2 = f['injections']['mass1'][iidx], f['injections']['mass2'][iidx]
-mchirp, eta = pycbc.pnutils.mass1_mass2_to_mchirp_eta(m1, m2)
+s1x, s2x = f['injections']['spin1x'][iidx], f['injections']['spin2x'][iidx]
+s1y, s2y = f['injections']['spin1y'][iidx], f['injections']['spin2y'][iidx]
+s1z, s2z = f['injections']['spin1z'][iidx], f['injections']['spin2z'][iidx]
+
+derived = {}
+derived['mchirp'], derived['eta'] = \
+    pycbc.pnutils.mass1_mass2_to_mchirp_eta(m1, m2)
+derived['mtotal'] = conv.mtotal_from_mass1_mass2(m1, m2)
+derived['chieff'] = conv.chi_eff(m1, m2, s1z, s2z)
+derived['chip'] = conv.chi_p(m1, m2, s1x, s1y, s2x, s2y)
 
 if 'optimal_snr' in ' '.join(list(f['injections'].keys())):
     ifolist = f.attrs['ifos'].split(' ')
@@ -82,32 +94,30 @@ else:
     eff_dist = {}
     for ifo in ['H1', 'L1', 'V1']:
         eff_dist[ifo] = Detector(ifo).effective_distance(
-                             f['injections/distance'][iidx],
-                             f['injections/ra'][iidx],
-                             f['injections/dec'][iidx],
-                             f['injections/polarization'][iidx],
-                             f['injections/tc'][iidx],
-                             f['injections/inclination'][iidx])
-
+            f['injections/distance'][iidx],
+            f['injections/ra'][iidx],
+            f['injections/dec'][iidx],
+            f['injections/polarization'][iidx],
+            f['injections/tc'][iidx],
+            f['injections/inclination'][iidx]
+        )
     params += ['dec_chirp_dist', 'eff_dist_h', 'eff_dist_l', 'eff_dist_v']
     dec_dist = max(eff_dist['H1'], eff_dist['L1'])
     dec_chirp_dist = pycbc.pnutils.chirp_distance(dec_dist, mchirp)
 
 params += ['mass1', 'mass2', 'mchirp', 'eta', 'ra', 'dec',
             'inclination', 'spin1x', 'spin1y', 'spin1z', 'spin2x', 'spin2y',
-            'spin2z']
+            'spin2z', 'chieff', 'chip']
 
 for p in params:
 
     if p in f['injections']:
         data += ["%.2f" % f['injections'][p][iidx]]
+    elif p in derived.keys():
+        data += [f'{derived[p]:.2f}']
     elif 'eff_dist' in p:
         ifo = '%s1' % p.split('_')[-1]
         data += ["%.2f" % eff_dist[ifo.upper()]]
-    elif p == 'mchirp':
-        data += ["%.2f" % mchirp]
-    elif p == 'eta':
-        data += ["%.2f" % eta]
     elif p == 'dec_chirp_dist':
         data += ["%.2f" % dec_chirp_dist]
     else:

--- a/bin/minifollowups/pycbc_page_snglinfo
+++ b/bin/minifollowups/pycbc_page_snglinfo
@@ -68,6 +68,8 @@ parser.add_argument('--include-gracedb-link', action='store_true',
 parser.add_argument('--significance-file',
     help="If given, will search for this trigger's id in the file to see if "
          "stat and p_astro values exists for this trigger.")
+parser.add_argument('--max-columns', type=int,
+    help="Optional. Set a maximum number of columns to be used in the output table")
 pystat.insert_statistic_option_group(parser,
     default_ranking_statistic='single_ranking_only')
 
@@ -117,7 +119,7 @@ if args.n_loudest is not None:
     sngl_file.apply_mask(l[0])
 
 # make a table for the single detector information ############################
-time = sngl_file.end_time
+time = sngl_file.end_time[0]
 utc = lal.GPSToUTC(int(time))[0:6]
 
 # Headers here will contain the list of headers that will appear in the
@@ -128,6 +130,8 @@ headers = []
 # that corresponding to the selected trigger. So this will be a list of a
 # single list that will hold the values to go into the table.
 data = [[]]
+
+row_labels = [args.instrument]
 
 # DQ summary link
 if args.include_summary_page_link:
@@ -141,11 +145,10 @@ headers.append("UTC")
 headers.append("End&nbsp;time")
 
 # SNR and statistic
-data[0].append('%5.2f' % sngl_file.snr)
-data[0].append('%5.2f' % sngl_file.get_column('coa_phase'))
-data[0].append('%5.2f' % stat)
 headers.append("&rho;")
+data[0].append('%5.2f' % sngl_file.snr[0])
 headers.append("Phase")
+data[0].append('%5.2f' % sngl_file.get_column('coa_phase')[0])
 # Determine statistic naming
 if args.sngl_ranking == "newsnr":
     sngl_stat_name = "Reweighted SNR"
@@ -169,30 +172,31 @@ else:
     )
 
 headers.append(stat_name)
+data[0].append('%5.2f' % stat[0])
 
 # Signal-glitch discrimators
-data[0].append('%5.2f' % sngl_file.rchisq)
-data[0].append('%i' % sngl_file.get_column('chisq_dof'))
+data[0].append('%5.2f' % sngl_file.rchisq[0])
+data[0].append('%i' % sngl_file.get_column('chisq_dof')[0])
 headers.append("&chi;<sup>2</sup><sub>r</sub>")
 headers.append("&chi;<sup>2</sup>&nbsp;bins")
 try:
-    data[0].append('%5.2f' % sngl_file.sgchisq)
+    data[0].append('%5.2f' % sngl_file.sgchisq[0])
     headers.append("sg&chi;<sup>2</sup>")
 except:
     pass
 try:
-    data[0].append('%5.2f' % sngl_file.psd_var_val)
+    data[0].append('%5.2f' % sngl_file.psd_var_val[0])
     headers.append("PSD var")
 except:
     pass
 
 # Template parameters
-data[0].append('%5.2f' % sngl_file.mass1)
-data[0].append('%5.2f' % sngl_file.mass2)
-data[0].append('%5.2f' % sngl_file.mchirp)
-data[0].append('%5.2f' % sngl_file.spin1z)
-data[0].append('%5.2f' % sngl_file.spin2z)
-data[0].append('%5.2f' % sngl_file.template_duration)
+data[0].append('%5.2f' % sngl_file.mass1[0])
+data[0].append('%5.2f' % sngl_file.mass2[0])
+data[0].append('%5.2f' % sngl_file.mchirp[0])
+data[0].append('%5.2f' % sngl_file.spin1z[0])
+data[0].append('%5.2f' % sngl_file.spin2z[0])
+data[0].append('%5.2f' % sngl_file.template_duration[0])
 headers.append("m<sub>1</sub>")
 headers.append("m<sub>2</sub>")
 headers.append("M<sub>c</sub>")
@@ -221,7 +225,7 @@ if args.include_gracedb_link:
     data[0].append(gdb_search_link)
 
 html = pycbc.results.dq.redirect_javascript + \
-        str(pycbc.results.static_table(data, headers))
+        str(pycbc.results.static_table(data, headers, row_labels=row_labels, columns_max=args.max_columns))
 ###############################################################################
 
 # Set up default titles and the captions for the file

--- a/examples/search/plotting.ini
+++ b/examples/search/plotting.ini
@@ -61,6 +61,8 @@ window = 0.1
 [html_snippet]
 
 [page_coincinfo]
+sngl-ranking = newsnr_sgveto_psdvar
+
 [page_coincinfo-background]
 statmap-file-subspace-name=background_exc
 

--- a/pycbc/results/dq.py
+++ b/pycbc/results/dq.py
@@ -23,12 +23,16 @@ search_form_string="""<form name="%s_alog_search" id="%s_alog_search" method="po
 </form>"""
 
 data_h1_string = """<a href=https://ldas-jobs.ligo-wa.caltech.edu/~detchar/summary/day/%s>
-Summary</a>&nbsp;<a onclick="redirect('h1_alog_search',
+Summary</a>
+&nbsp;
+<a onclick="redirect('h1_alog_search',
 'https://alog.ligo-wa.caltech.edu/aLOG/includes/search.php?adminType=search');
 return true;">aLOG</a>"""
 
 data_l1_string="""<a href=https://ldas-jobs.ligo-la.caltech.edu/~detchar/summary/day/%s>
-Summary</a>&nbsp;<a onclick="redirect('l1_alog_search',
+Summary</a>
+&nbsp;
+<a onclick="redirect('l1_alog_search',
 'https://alog.ligo-la.caltech.edu/aLOG/includes/search.php?adminType=search');
 return true;">aLOG</a>"""
 

--- a/pycbc/results/dq.py
+++ b/pycbc/results/dq.py
@@ -22,14 +22,16 @@ search_form_string="""<form name="%s_alog_search" id="%s_alog_search" method="po
 <input type="hidden" name="srcDateTo" id="srcDateTo" value="%s" size="20"/>
 </form>"""
 
-data_h1_string = """<a href=https://ldas-jobs.ligo-wa.caltech.edu/~detchar/summary/day/%s>
+data_h1_string = """
+<a href=https://ldas-jobs.ligo-wa.caltech.edu/~detchar/summary/day/%s>
 Summary</a>
 &nbsp;
 <a onclick="redirect('h1_alog_search',
 'https://alog.ligo-wa.caltech.edu/aLOG/includes/search.php?adminType=search');
 return true;">aLOG</a>"""
 
-data_l1_string="""<a href=https://ldas-jobs.ligo-la.caltech.edu/~detchar/summary/day/%s>
+data_l1_string="""
+<a href=https://ldas-jobs.ligo-la.caltech.edu/~detchar/summary/day/%s>
 Summary</a>
 &nbsp;
 <a onclick="redirect('l1_alog_search',

--- a/pycbc/results/dq.py
+++ b/pycbc/results/dq.py
@@ -22,21 +22,13 @@ search_form_string="""<form name="%s_alog_search" id="%s_alog_search" method="po
 <input type="hidden" name="srcDateTo" id="srcDateTo" value="%s" size="20"/>
 </form>"""
 
-data_h1_string = """H1
-&nbsp;
-<a href=https://ldas-jobs.ligo-wa.caltech.edu/~detchar/summary/day/%s>
-Summary</a>
-&nbsp;
-<a onclick="redirect('h1_alog_search',
+data_h1_string = """<a href=https://ldas-jobs.ligo-wa.caltech.edu/~detchar/summary/day/%s>
+Summary</a>&nbsp;<a onclick="redirect('h1_alog_search',
 'https://alog.ligo-wa.caltech.edu/aLOG/includes/search.php?adminType=search');
 return true;">aLOG</a>"""
 
-data_l1_string="""L1
-&nbsp;
-<a href=https://ldas-jobs.ligo-la.caltech.edu/~detchar/summary/day/%s>
-Summary</a>
-&nbsp;
-<a onclick="redirect('l1_alog_search',
+data_l1_string="""<a href=https://ldas-jobs.ligo-la.caltech.edu/~detchar/summary/day/%s>
+Summary</a>&nbsp;<a onclick="redirect('l1_alog_search',
 'https://alog.ligo-la.caltech.edu/aLOG/includes/search.php?adminType=search');
 return true;">aLOG</a>"""
 

--- a/pycbc/results/static/css/pycbc/orange.css
+++ b/pycbc/results/static/css/pycbc/orange.css
@@ -92,3 +92,17 @@ font-size:16px;
 a {
     color:#000000;
 }
+
+table {
+    display: block;
+    overflow-x: auto;
+    white-space: nowrap;
+}
+
+td {
+    text-align: center;
+}
+
+th {
+    text-align: center;
+}

--- a/pycbc/results/table_utils.py
+++ b/pycbc/results/table_utils.py
@@ -161,11 +161,15 @@ def static_table(data, titles=None, columns_max=None, row_labels=None):
     """
     data = copy.deepcopy(data)
     titles = copy.deepcopy(titles)
+    row_labels = copy.deepcopy(row_labels)
     drows, dcols = numpy.array(data).shape
     if titles is not None and not len(titles) == dcols:
-            raise RuntimeError("titles and data lengths do not match")
+        raise ValueError("titles and data lengths do not match")
+
     if row_labels is not None and not len(row_labels) == drows:
-        raise RuntimeError("row labels must be the same number of rows supplied to data")
+        raise ValueError(
+            "row_labels must be the same number of rows supplied to data"
+        )
 
     if columns_max is not None:
         n_rows = int(numpy.ceil(len(data[0]) / columns_max))

--- a/pycbc/results/table_utils.py
+++ b/pycbc/results/table_utils.py
@@ -150,6 +150,9 @@ def static_table(data, titles=None, columns_max=None, row_labels=None):
         Vector str of titles, must be the same length as data
     columns_max : integer or None
         If given, will restrict the number of columns in the table
+    row_labels : list of strings
+        Optional list of row labels to be given as the first cell in
+        each data row. Does not count towards columns_max
 
     Returns
     -------

--- a/pycbc/results/table_utils.py
+++ b/pycbc/results/table_utils.py
@@ -23,7 +23,10 @@
 #
 """ This module provides functions to generate sortable html tables
 """
-import mako.template, uuid
+import mako.template
+import uuid
+import copy
+import numpy
 
 google_table_template = mako.template.Template("""
     <script type='text/javascript' src='https://www.google.com/jsapi'></script>
@@ -103,42 +106,82 @@ def html_table(columns, names, page_size=None, format_strings=None):
 
 static_table_template = mako.template.Template("""
     <table class="table">
-        % if titles is not None:
-            <tr>
-            % for i in range(len(titles)):
-                <th>
-                    ${titles[i]}
-                </th>
-            % endfor
-            </tr>
-        % endif
+        % for row in range(n_rows):
+            % if titles is not None:
+                <tr>
+                % if row_labels is not None:
+                    <td>
+                    </td>
+                % endif
+                % for i in range(n_columns):
+                    <th>
+                        ${titles[row * n_columns + i]}
+                    </th>
+                % endfor
+                </tr>
+            % endif
 
-        % for i in range(len(data)):
-            <tr>
-            % for j in range(len(data[i])):
-                <td>
-                    ${data[i][j]}
-                </td>
+            % for i in range(len(data)):
+                <tr>
+                % if row_labels is not None:
+                    <td>
+                        ${row_labels[i]}
+                    </td>
+                % endif
+                % for j in range(n_columns):
+                    <td>
+                        ${data[i][row * n_columns + j]}
+                    </td>
+                % endfor
+                </tr>
             % endfor
-            </tr>
         % endfor
     </table>
 """)
 
-def static_table(data, titles=None):
-    """ Return an html tableo of this data
+def static_table(data, titles=None, columns_max=None, row_labels=None):
+    """ Return an html table of this data
 
     Parameters
     ----------
-    data : two-dimensional numpy string array
+    data : two-dimensional string array
         Array containing the cell values
     titles : numpy array
-        Vector str of titles
+        Vector str of titles, must be the same length as data
+    columns_max : integer or None
+        If given, will restrict the number of columns in the table
 
     Returns
     -------
     html_table : str
         A string containing the html table.
     """
-    return static_table_template.render(data=data, titles=titles)
+    data = copy.deepcopy(data)
+    titles = copy.deepcopy(titles)
+    drows, dcols = numpy.array(data).shape
+    if titles is not None and not len(titles) == dcols:
+            raise RuntimeError("titles and data lengths do not match")
+    if row_labels is not None and not len(row_labels) == drows:
+        raise RuntimeError("row labels must be the same number of rows supplied to data")
+
+    if columns_max is not None:
+        n_rows = int(numpy.ceil(len(data[0]) / columns_max))
+        n_columns = min(columns_max, len(data[0]))
+        if len(data[0]) < n_rows * n_columns:
+            # Pad the data and titles with empty strings
+            n_missing = int(n_rows * n_columns - len(data[0]))
+            data = numpy.hstack((data, numpy.zeros((len(data), n_missing), dtype='U1')))
+            if titles is not None:
+                titles += [' '] * n_missing
+    else:
+        n_rows = 1
+        n_columns = len(data[0])
+
+    return static_table_template.render(
+        data=data,
+        titles=titles,
+        n_columns=n_columns,
+        n_rows=n_rows,
+        row_labels=row_labels,
+    )
 


### PR DESCRIPTION
Added a few features to the minifollowup (coincinfo, snglinfo, injinfo) tables:
 - Added chi_eff and chi_p to injinfo
 - Allowing the user to specify a maximum number of columns in the table (as these are starting to get long!), and therefore adding row names
 - Using proper sngl_ranking in the pycbc_page_coincinfo table
 - Silencing some warnings in snglinfo regarding using single-entry arrays instead of floats

## Standard information about the request

This is an enhancement to an existing feature

This change affects the offline search minifollowups.
Some of the functionality is used in inference, but the use-cases there are unaffected

This change changes result presentation

This change follows style guidelines (See e.g. [PEP8](https://peps.python.org/pep-0008/)), has been proposed using the [contribution guidelines](https://github.com/gwastro/pycbc/blob/master/CONTRIBUTING.md)


## Motivation
This is mainly to make things easier when looking at result tables

## Contents
 - Add new entries to the injinfo table 
 - Alter the table template and how it is called so that we can limit the number of columns
 - Add row labels (and remove these from the DQ summary link)

## Links to any issues or associated PRs
#4837 

## Testing performed
Running the codes with appropriate arguments

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
