### PR TITLE
Removing old line preventing PyGRB workflows from starting

### DIFF
--- a/pycbc/workflow/grb_utils.py
+++ b/pycbc/workflow/grb_utils.py
@@ -372,7 +372,6 @@ class PycbcGrbTrigCombinerExecutable(Executable):
         node.add_opt("--segment-dir", seg_dir)
         node.add_input_list_opt("--input-files", insp_files)
         node.add_opt("--user-tag", "PYGRB")
-        node.add_opt("--num-trials", self.num_trials)
         node.add_input_opt("--bank-file", bank_file)
         # Prepare output file tag
         user_tag = f"PYGRB_GRB{self.trigger_name}"


### PR DESCRIPTION
We do not need this line of code anymore since `--num-trials` is now passed via config files

## Standard information about the request

<!--- Some basic info about the change (delete as appropriate) -->
This is a: bug fix

<!--- What codes will this affect? (delete as apropriate)
-->
This change affects: PyGRB

<!--- Some things which help with code management (delete as appropriate) -->
This change: has appropriate unit tests, follows style guidelines (See e.g. [PEP8](https://peps.python.org/pep-0008/)), has been proposed using the [contribution guidelines](https://github.com/gwastro/pycbc/blob/master/CONTRIBUTING.md)

<!--- Notes about the effect of this change -->
This change will: fix `pycbc_make_offline_grb_workflow` which is presently showing the following error:

```
Traceback (most recent call last):
  File "/home/sebastian.gomezlopez/.conda/envs/pygrb_prod/bin/pycbc_make_offline_grb_workflow", line 442, in <module>
    _workflow.setup_pygrb_pp_workflow(wflow, pp_dir, seg_dir,
  File "/home/sebastian.gomezlopez/.conda/envs/pygrb_prod/lib/python3.9/site-packages/pycbc/workflow/grb_utils.py", line 317, in setup_pygrb_pp_workflow
    node, trig_files = job_instance.create_node(wf.ifos, seg_dir, segment,
  File "/home/sebastian.gomezlopez/.conda/envs/pygrb_prod/lib/python3.9/site-packages/pycbc/workflow/grb_utils.py", line 375, in create_node
    node.add_opt("--num-trials", self.num_trials)
  File "/home/sebastian.gomezlopez/.conda/envs/pygrb_prod/lib/python3.9/site-packages/pycbc/workflow/pegasus_workflow.py", line 220, in add_opt
    raise ValueError(err_msg)
ValueError: Trying to set option --num-trials with value 6, but it has already been provided by the configuration file. Usually this should not be given in the config file, but contact developers to check
```