### PR TITLE
Use more f-strings in `pycbc_live`

### DIFF
--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -330,7 +330,7 @@ class LiveEventManager(object):
             * self.bank.sample_rate)
         flen = int(tlen / 2 + 1)
         delta_f = self.bank.sample_rate / float(tlen)
-        cmd = 'timeout {} '.format(args.snr_opt_timeout)
+        cmd = f'timeout {args.snr_opt_timeout} '
         exepath = which('pycbc_optimize_snr')
         cmd += exepath + ' '
 
@@ -342,17 +342,16 @@ class LiveEventManager(object):
         data_fils_str = '--data-files '
         psd_fils_str = '--psd-files '
         for ifo in live_ifos:
-            curr_fname = \
-                fname.replace('.xml.gz',
-                              '_{}_data_overwhitened.hdf'.format(ifo))
+            curr_fname = fname.replace(
+                '.xml.gz', f'_{ifo}_data_overwhitened.hdf'
+            )
             curr_data = self.data_readers[ifo].overwhitened_data(delta_f)
             curr_data.save(curr_fname)
-            data_fils_str += '{}:{} ' .format(ifo, curr_fname)
-            curr_fname = fname.replace('.xml.gz',
-                                       '_{}_psd.hdf'.format(ifo))
+            data_fils_str += f'{ifo}:{curr_fname} '
+            curr_fname = fname.replace('.xml.gz', f'_{ifo}_psd.hdf')
             curr_psd = curr_data.psd
             curr_psd.save(curr_fname)
-            psd_fils_str += '{}:{} ' .format(ifo, curr_fname)
+            psd_fils_str += f'{ifo}:{curr_fname} '
         cmd += data_fils_str
         cmd += psd_fils_str
 
@@ -386,10 +385,10 @@ class LiveEventManager(object):
                                                     'mc_area_args/',
                                                     self.mc_area_args)
 
-        cmd += '--params-file {} '.format(curr_fname)
-        cmd += '--approximant {} '.format(apr)
-        cmd += '--gracedb-server {} '.format(self.gracedb_server)
-        cmd += '--gracedb-search {} '.format(self.gracedb_search)
+        cmd += f'--params-file {curr_fname} '
+        cmd += f'--approximant {apr} '
+        cmd += f'--gracedb-server {self.gracedb_server} '
+        cmd += f'--gracedb-search {self.gracedb_search} '
 
         labels = self.snr_opt_label
         labels += ' '.join(self.gracedb_labels or [])
@@ -408,7 +407,7 @@ class LiveEventManager(object):
             cmd += '--enable-gracedb-upload '
 
         if self.fu_cores:
-            cmd += '--cores {} '.format(self.fu_cores)
+            cmd += f'--cores {self.fu_cores} '
 
         if args.processing_scheme:
             # we will use the cores for multiple workers of the
@@ -420,11 +419,11 @@ class LiveEventManager(object):
             # unlikely to benefit from a processing scheme with more
             # than 1 thread anyway.
             opt_scheme = args.processing_scheme.split(':')[0]
-            cmd += '--processing-scheme {}:1 '.format(opt_scheme)
+            cmd += f'--processing-scheme {opt_scheme}:1 '
 
         # Save the command which would be used:
         snroc_fname = os.path.join(out_dir_path, 'snr_optimize_command.txt')
-        with open(snroc_fname,'w') as snroc_file:
+        with open(snroc_fname, 'w') as snroc_file:
             snroc_file.write(cmd)
 
         return cmd, out_dir_path
@@ -490,10 +489,10 @@ class LiveEventManager(object):
         if optimize_snr_checks:
             logging.info('Optimizing SNR for event above threshold ..')
             self.run_optimize_snr(
-                    cmd,
-                    out_dir_path,
-                    fname.replace('.xml.gz', '_attributes.hdf'),
-                    gid
+                cmd,
+                out_dir_path,
+                fname.replace('.xml.gz', '_attributes.hdf'),
+                gid
             )
 
     def check_coincs(self, ifos, coinc_results, psds):
@@ -572,8 +571,7 @@ class LiveEventManager(object):
         # prevent singles being uploaded as well for coinc events
         self.last_few_coincs_uploaded.append(event.merger_time)
         # Only need to keep a few (10) events
-        self.last_few_coincs_uploaded = \
-            self.last_few_coincs_uploaded[-10:]
+        self.last_few_coincs_uploaded = self.last_few_coincs_uploaded[-10:]
 
         # Save the event
         if not upload_checks:
@@ -773,8 +771,7 @@ class LiveEventManager(object):
 
             for ifo in results:
                 for k in results[ifo]:
-                    f['%s/%s' % (ifo, k)] = \
-                            h5py_unicode_workaround(results[ifo][k])
+                    f[f'{ifo}/{k}'] = h5py_unicode_workaround(results[ifo][k])
 
             for key in raw_results:
                 f[key] = h5py_unicode_workaround(raw_results[key])
@@ -797,12 +794,11 @@ class LiveEventManager(object):
                 gate_dtype = [('center_time', float),
                               ('zero_half_width', float),
                               ('taper_width', float)]
-                f['{}/gates'.format(ifo)] = \
-                        numpy.array(gates[ifo], dtype=gate_dtype)
+                f[f'{ifo}/gates'] = numpy.array(gates[ifo], dtype=gate_dtype)
 
         for ifo in (store_psd or {}):
             if store_psd[ifo] is not None:
-                store_psd[ifo].save(fname, group='%s/psd' % ifo)
+                store_psd[ifo].save(fname, group=f'{ifo}/psd')
 
 
 def check_max_length(args, waveforms):
@@ -1072,9 +1068,14 @@ if not args.enable_gracedb_upload and args.enable_single_detector_upload:
     parser.error('You are not allowed to enable single ifo upload without the '
                  '--enable-gracedb-upload option!')
 
-log_format = '%(asctime)s {} {} %(message)s'.format(platform.node(),
-                                                    mpi.COMM_WORLD.Get_rank())
-pycbc.init_logging(args.verbose, format=log_format)
+# Configure the log messages so that they are prefixed by the timestamp, the
+# hostname of the originating node and the MPI rank of the originating process
+pycbc.init_logging(
+    args.verbose,
+    format='%(asctime)s {} {} %(message)s'.format(
+        platform.node(), mpi.COMM_WORLD.Get_rank()
+    )
+)
 
 ctx = scheme.from_cli(args)
 fft.from_cli(args)
@@ -1084,8 +1085,13 @@ valid_pad = args.analysis_chunk
 total_pad = args.trim_padding * 2 + valid_pad
 lfc = None if args.enable_bank_start_frequency else args.low_frequency_cutoff
 bank = waveform.LiveFilterBank(
-        args.bank_file, args.sample_rate, total_pad, low_frequency_cutoff=lfc,
-        approximant=args.approximant, increment=args.increment)
+    args.bank_file,
+    args.sample_rate,
+    total_pad,
+    low_frequency_cutoff=lfc,
+    approximant=args.approximant,
+    increment=args.increment
+)
 if bank.min_f_lower < args.low_frequency_cutoff:
     parser.error('--low-frequency-cutoff ({} Hz) must not be larger than the '
                  'minimum f_lower across all templates '
@@ -1138,12 +1144,16 @@ with ctx:
         bank.table.sort(order='mchirp')
         waveforms = list(bank[evnt.rank-1::evnt.size-1])
         check_max_length(args, waveforms)
-        mf = LiveBatchMatchedFilter(waveforms, args.snr_threshold,
-                                    args.chisq_bins, sg_chisq,
-                                    snr_abort_threshold=args.snr_abort_threshold,
-                                    newsnr_threshold=args.newsnr_threshold,
-                                    max_triggers_in_batch=args.max_triggers_in_batch,
-                                    maxelements=args.max_batch_size)
+        mf = LiveBatchMatchedFilter(
+            waveforms,
+            args.snr_threshold,
+            args.chisq_bins,
+            sg_chisq,
+            snr_abort_threshold=args.snr_abort_threshold,
+            newsnr_threshold=args.newsnr_threshold,
+            max_triggers_in_batch=args.max_triggers_in_batch,
+            maxelements=args.max_batch_size
+        )
 
     # Synchronize start time if not provided on the command line
     if not args.start_time:
@@ -1188,8 +1198,9 @@ with ctx:
             global my_coinc_id
             my_coinc_id = i
             c = estimators[my_coinc_id]
-            setproctitle('PyCBC Live {} bg estimator'.format(
-                    ppdets(c.ifos, '-')))
+            setproctitle(
+                'PyCBC Live {} bg estimator'.format(ppdets(c.ifos, '-'))
+            )
 
         def estimator_refresh_threads(_):
             c = estimators[my_coinc_id]


### PR DESCRIPTION
Cleanup of `pycbc_live` to use more f-strings and apply some `black`-style formatting. No change in functionality expected.

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
