### PR TITLE
PyCBC Live: check state vector before trying to read h(t)

### DIFF
--- a/pycbc/frame/frame.py
+++ b/pycbc/frame/frame.py
@@ -589,8 +589,8 @@ class DataBuffer(object):
             return TimeSeries(data.data.data, delta_t=data.deltaT,
                               epoch=self.read_pos,
                               dtype=dtype)
-        except Exception:
-            raise RuntimeError('Cannot read {0} frame data'.format(self.channel_name))
+        except:
+            raise RuntimeError(f'Cannot read {self.channel_name} frame data')
 
     def null_advance(self, blocksize):
         """Advance and insert zeros
@@ -826,19 +826,22 @@ class StatusBuffer(DataBuffer):
         return idx
 
     def advance(self, blocksize):
-        """ Add blocksize seconds more to the buffer, push blocksize seconds
-        from the beginning.
+        """Read `blocksize` seconds of new status data, append it to the end of
+        the internal status buffer, and drop `blocksize` seconds from the
+        beginning of the buffer. Check if the newly added status data indicates
+        usable or unusable strain data.
 
         Parameters
         ----------
         blocksize: int
-            The number of seconds to attempt to read from the channel
+            The number of seconds to attempt to read from the channel.
 
         Returns
         -------
         status: boolean
-            Returns True if all of the status information if valid,
-            False if any is not.
+            Returns True if all of the status information if valid, False if
+            any is not, None if there was a problem reading the status
+            information.
         """
         try:
             if self.increment_update_cache:
@@ -847,7 +850,8 @@ class StatusBuffer(DataBuffer):
             return self.check_valid(ts)
         except RuntimeError:
             self.null_advance(blocksize)
-            return False
+            return None
+
 
 class iDQBuffer(object):
 

--- a/pycbc/strain/strain.py
+++ b/pycbc/strain/strain.py
@@ -1930,13 +1930,17 @@ class StrainBuffer(pycbc.frame.DataBuffer):
         start = len(self.raw_buffer) - csize * self.factor
         strain = self.raw_buffer[start:]
 
-        strain =  pycbc.filter.highpass_fir(strain, self.highpass_frequency,
-                                       self.highpass_samples,
-                                       beta=self.beta)
+        strain =  pycbc.filter.highpass_fir(
+            strain,
+            self.highpass_frequency,
+            self.highpass_samples,
+            beta=self.beta
+        )
         strain = (strain * self.dyn_range_fac).astype(numpy.float32)
 
-        strain = pycbc.filter.resample_to_delta_t(strain,
-                                           1.0/self.sample_rate, method='ldas')
+        strain = pycbc.filter.resample_to_delta_t(
+            strain, 1.0 / self.sample_rate, method='ldas'
+        )
 
         # remove corruption at beginning
         strain = strain[self.corruption:]
@@ -1945,7 +1949,8 @@ class StrainBuffer(pycbc.frame.DataBuffer):
         if self.taper_immediate_strain:
             logger.info("Tapering start of %s strain block", self.detector)
             strain = gate_data(
-                    strain, [(strain.start_time, 0., self.autogating_taper)])
+                strain, [(strain.start_time, 0., self.autogating_taper)]
+            )
             self.taper_immediate_strain = False
 
         # Stitch into continuous stream
@@ -1956,20 +1961,28 @@ class StrainBuffer(pycbc.frame.DataBuffer):
         # apply gating if needed
         if self.autogating_threshold is not None:
             autogating_duration_length = self.autogating_duration * self.sample_rate
-            autogating_start_sample = int(len(self.strain) - autogating_duration_length)
+            autogating_start_sample = int(
+                len(self.strain) - autogating_duration_length
+            )
             glitch_times = detect_loud_glitches(
-                    self.strain[autogating_start_sample:-self.corruption],
-                    psd_duration=self.autogating_psd_segment_length, psd_stride=self.autogating_psd_stride,
-                    threshold=self.autogating_threshold,
-                    cluster_window=self.autogating_cluster,
-                    low_freq_cutoff=self.highpass_frequency,
-                    corrupt_time=self.autogating_pad)
+                self.strain[autogating_start_sample:-self.corruption],
+                psd_duration=self.autogating_psd_segment_length,
+                psd_stride=self.autogating_psd_stride,
+                threshold=self.autogating_threshold,
+                cluster_window=self.autogating_cluster,
+                low_freq_cutoff=self.highpass_frequency,
+                corrupt_time=self.autogating_pad
+            )
             if len(glitch_times) > 0:
-                logger.info('Autogating %s at %s', self.detector,
-                            ', '.join(['%.3f' % gt for gt in glitch_times]))
-                self.gate_params = \
-                        [(gt, self.autogating_width, self.autogating_taper)
-                         for gt in glitch_times]
+                logger.info(
+                    'Autogating %s at %s',
+                    self.detector,
+                    ', '.join(['%.3f' % gt for gt in glitch_times])
+                )
+                self.gate_params = [
+                    (gt, self.autogating_width, self.autogating_taper)
+                    for gt in glitch_times
+                ]
                 self.strain = gate_data(self.strain, self.gate_params)
 
         if self.psd is None and self.wait_duration <=0:
@@ -1985,13 +1998,13 @@ class StrainBuffer(pycbc.frame.DataBuffer):
         state_channel = analyze_flags = None
         if args.state_channel and ifo in args.state_channel \
                 and args.analyze_flags and ifo in args.analyze_flags:
-            state_channel = ':'.join([ifo, args.state_channel[ifo]])
+            state_channel = f'{ifo}:{args.state_channel[ifo]}'
             analyze_flags = args.analyze_flags[ifo].split(',')
 
         dq_channel = dq_flags = None
         if args.data_quality_channel and ifo in args.data_quality_channel \
                 and args.data_quality_flags and ifo in args.data_quality_flags:
-            dq_channel = ':'.join([ifo, args.data_quality_channel[ifo]])
+            dq_channel = f'{ifo}:{args.data_quality_channel[ifo]}'
             dq_flags = args.data_quality_flags[ifo].split(',')
 
         idq_channel = None


### PR DESCRIPTION
Draft.

This is an attempt to improve PyCBC Live's behavior in the presence of occasional quirks with frame files. It addresses #4800.

## Standard information about the request

This is an improvement on existing behavior which could arguably be considered a bugfix. In normal observing conditions, this should bring no functional change.

This change affects the live search.

This change changes the low-latency frame file reading algorithm.

This change leads to a minor API breakage in the `pycbc.frame` module by occasionally changing the return value of a method.

## Motivation

Before this change, the StrainBuffer class tries to read the strain channel first, and then it reads the state vector to check if the data is actually analyzable. We recently became aware that the strain channel may be entirely missing from the frame files when a detector is not in observing mode. With the existing code, this causes a repeated failure in reading h(t), which the code interprets as the frame files being absent, causing it to wait for the expiration of the frame file timeout. This behavior is not the most desirable: the strain channel is *never* going to appear, so the end effect is that the latency of the search in the other detectors is increased for no useful purpose.

## Contents

The correct fix would be to catch the reading errors in a way that distinguishes between the frame files being absent, and the channel being absent. I am *not* doing this here for now, but I might include it at the end.

Instead, I am changing the order of the operations so that StrainBuffer reads the state vector first. Only if the state vector indicates usable data, then StrainBuffer proceeds to read h(t) as well. I think this is the most logical behavior, and it should effectively address the issue, assuming that the strain channel is only absent when the detector is not observing. If that assumption is violated (which would indicate a problem on the data generation side, upstream of PyCBC Live) then the code would still reach the frame file timeout, which is not ideal. As indicated above, I might address this too in a second step, or maybe in a followup PR.

## Links to any issues or associated PRs

This addresses issue #4800.

## Testing performed

Not tested yet, just a draft.

## Additional notes

None.

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
