### PR TITLE
add a distribution to draw sky locations from a HEALPix map

### DIFF
--- a/pycbc/distributions/__init__.py
+++ b/pycbc/distributions/__init__.py
@@ -29,7 +29,7 @@ from pycbc.distributions.angular import UniformAngle, SinAngle, CosAngle, \
 from pycbc.distributions.arbitrary import Arbitrary, FromFile
 from pycbc.distributions.gaussian import Gaussian
 from pycbc.distributions.power_law import UniformPowerLaw, UniformRadius
-from pycbc.distributions.sky_location import UniformSky, FisherSky
+from pycbc.distributions.sky_location import UniformSky, FisherSky, HealpixSky
 from pycbc.distributions.uniform import Uniform
 from pycbc.distributions.uniform_log import UniformLog10
 from pycbc.distributions.spins import IndependentChiPChiEff
@@ -61,7 +61,8 @@ distribs = {
     FixedSamples.name: FixedSamples,
     MchirpfromUniformMass1Mass2.name: MchirpfromUniformMass1Mass2,
     QfromUniformMass1Mass2.name: QfromUniformMass1Mass2,
-    FisherSky.name: FisherSky
+    FisherSky.name: FisherSky,
+    HealpixSky.name: HealpixSky
 }
 
 def read_distributions_from_config(cp, section="prior"):

--- a/pycbc/distributions/sky_location.py
+++ b/pycbc/distributions/sky_location.py
@@ -216,7 +216,7 @@ class HealpixSky:
             alpha_max= 0
             alpha_min = 2*numpy.pi
             
-            rasterized_map = healpix_map.rasterize(scheme = 'NESTED',nside = nside) # marche pas si RING ?
+            rasterized_map = healpix_map.rasterize(scheme = 'NESTED',nside = nside) #marche pas si RING ?
             data = rasterized_map.data
             non_zero_data = data[data != 0]
             renormalization_constant = non_zero_data.sum() 

--- a/pycbc/distributions/sky_location.py
+++ b/pycbc/distributions/sky_location.py
@@ -263,7 +263,7 @@ class HealpixSky:
                 j = sorter[i]
                 pix = rasterized_map.uniq[j]-4*nside*nside
                 delta,alpha =  rasterized_map.pix2ang(
-                    ipix = pix,
+                    pix,
                     lonlat = False
                 )
                 # converts colatitude to latitude

--- a/pycbc/distributions/sky_location.py
+++ b/pycbc/distributions/sky_location.py
@@ -245,14 +245,12 @@ class HealpixSky:
             map_coverage = 0
 
             for i in range(len(data)):
-                # j = numpy.argmax(normalized_data == sort_normalized_data[i])
                 j = sorter[i]
                 pix = rasterized_map.uniq[j] - 4 * nside * nside
                 delta, alpha = rasterized_map.pix2ang(pix, lonlat=False)
                 # converts colatitude to latitude
                 delta = numpy.pi / 2 - delta
 
-                # map_coverage += sort_normalized_data[i]
                 map_coverage += normalized_data[j]
                 delta_max, delta_min = max(delta_max, delta), min(
                     delta_min, delta

--- a/pycbc/distributions/sky_location.py
+++ b/pycbc/distributions/sky_location.py
@@ -180,7 +180,7 @@ class FisherSky:
 
 
 class HealpixSky:
-    """Extract the distribution of a healpix map by using the rejection 
+    """Extract the distribution of a HEALPix map by using the rejection 
     sampling method on the smallest acceptable piece of the celestial sphere.
     Assume the map is not an empty map.
     As in UniformSky and FisherSky, the declination varies from π/2 to -π/2 
@@ -214,7 +214,7 @@ class HealpixSky:
 
             Parameters
             ----------
-            healpix_map : 
+            healpix_map : HealpixMap instance 
             
             nside : int
                 nside of the rasterized map used to determine the boundaries of 
@@ -245,7 +245,7 @@ class HealpixSky:
             alpha_min = 2*numpy.pi
             
             rasterized_map = healpix_map.rasterize(                            # A COMPRENDRE ? marche pas si RING, (code qui ne s'arrete plus) 
-                scheme = 'NESTED',
+                scheme = 'ring',
                 nside = nside
                 )                                                              
             data = rasterized_map.data
@@ -350,7 +350,7 @@ class HealpixSky:
         #gives the points accepted by the rejection sampling method
         def simple_rejection_sampling(healpix_map,size,boundaries):
             """Start from a uniform distribution of points, and accepts those
-            whose values on the healpix_maps are greater than a random value 
+            whose values on the healpix_map are greater than a random value 
             following a uniform law
             
             Parameters

--- a/pycbc/distributions/sky_location.py
+++ b/pycbc/distributions/sky_location.py
@@ -387,7 +387,7 @@ class HealpixSky:
         #sampling method
         theta,phi = numpy.array([]),  numpy.array([])
         while len(theta) < size:
-            THETA,PHI = simple_rejection_sampling(self.heapix_map, #☺pas de maj
+            THETA,PHI = simple_rejection_sampling(self.healpix_map, #☺pas de maj
                                                   size,
                                                   self.boundaries
                                                   )

--- a/pycbc/distributions/sky_location.py
+++ b/pycbc/distributions/sky_location.py
@@ -18,7 +18,10 @@ right ascension and declination.
 """
 
 import logging
-import numpy
+import numpy # changer les np en numpy
+import time #pas besoin enfaite?
+import healpy as hp
+import mhealpy as mhp
 
 from scipy.spatial.transform import Rotation
 
@@ -42,7 +45,7 @@ class UniformSky(angular.UniformSolidAngle):
     _default_azimuthal_angle = 'ra'
 
 
-class FisherSky():
+class FisherSky:
     """A distribution that returns a random angle drawn from an approximate
     `Von_Mises-Fisher distribution`_. Assumes that the Fisher concentration
     parameter is large, so that we can draw the samples from a simple
@@ -175,4 +178,186 @@ class FisherSky():
         return rot_radec
 
 
-__all__ = ['UniformSky', 'FisherSky']
+
+
+class HealpixSky:
+    """description des inputs outputs et de la methode utilisé
+    
+    As in UniformSky,and FisherSky the
+    declination varies from π/2 to -π/2 and the right ascension varies from
+    0 to 2π.
+
+    Parameters
+    ----------
+   healpix_file : file.fits.gz
+   map_covering : percentage of the map covered by the method
+    """
+    name = 'healpix_sky'
+    _params = ['ra', 'dec']
+    
+   
+    
+    
+    
+
+
+
+    def __init__(self, **params):
+        
+        rasterisation_nside = 64 # or 128
+        
+        
+        #give the boundaries of a map m in radian, and following the 
+        #ra-dec convention i-e- theta in [-pi/2, pi/2] phi in [0,2pi]
+        def boundaries(file_name,nside,X): 
+            m = mhp.HealpixMap.read_map(file_name)
+            
+            theta_max,theta_min,phi_max,phi_min = -numpy.pi/2,numpy.pi/2,0,2*numpy.pi
+            
+            rasterize_map = m.rasterize(scheme = 'NESTED',nside = min(nside,m.nside)) #min si jamais nside < m.nside pour eviter pb # scheme pas important ? RING par default
+            data = rasterize_map.data
+            non_zero_data = data[data != 0]
+            A = non_zero_data.sum() # cst de renormalisation
+            
+            normalized_data = data/A
+            sort_normalized_data = - numpy.sort(-non_zero_data/A) # TRI DECROISSANT DE non_zero_data
+            
+            N = len(non_zero_data)
+            S = 0
+            pix, theta, phi = numpy.zeros(N,dtype=int), numpy.zeros(N), numpy.zeros(N)
+            #print(f'{N} pixels non nuls')
+            for i in range(N):
+                j = numpy.argmax(normalized_data == sort_normalized_data[i]) 
+                pix[i] = rasterize_map.uniq[j]-4*nside*nside
+                theta[i],phi[i] =  hp.pix2ang(nside = nside, ipix = pix[i], nest = rasterize_map.is_nested, lonlat = False)
+                theta[i] = numpy.pi/2 - theta[i] # conversion d'angle colatitude -> latitude 
+                
+                S += sort_normalized_data[i]
+                theta_max,theta_min = max(theta_max,theta[i]),min(theta_min,theta[i])
+                phi_max,phi_min = max(phi_max,phi[i]),min(phi_min,phi[i])
+                    
+                if S > X/100 : 
+                    break
+            #ajout de la securité : taille_pix ~ np.pi/4nside-1
+            secu = 2*numpy.pi/(4*nside -1)
+            
+            theta_max = min(theta_max + secu, numpy.pi/2)
+            theta_min = max(theta_min - secu, -numpy.pi/2)
+            phi_max = min(phi_max + secu, 2*numpy.pi)
+            phi_min = max(phi_min - secu, 0)
+     
+            return theta_min,theta_max,phi_min,phi_max
+        #theta_min,theta_max,phi_min,phi_max
+        
+        file_name = params['healpix_file']
+        X = params['map_covering']
+        self.m = mhp.HealpixMap.read_map(file_name)
+        self.boundaries = boundaries(file_name,rasterisation_nside,X) #nside = 64 ou 128 utiliser self.m à la place de file_name ?
+        
+    
+        
+
+    @property
+    def params(self):
+        return self._params
+
+    @classmethod
+    def from_config(cls, cp, section, variable_args):
+        tag = variable_args
+        variable_args = variable_args.split(VARARGS_DELIM)
+        if set(variable_args) != set(cls._params):
+            raise ValueError("Not all parameters used by this distribution "
+                             "included in tag portion of section name")
+        healpix_file = str(cp.get_opt_tag(section, 'healpix_file', tag))
+        map_covering = float(cp.get_opt_tag(section, 'map_covering', tag))
+        
+        return cls(
+            healpix_file=healpix_file,
+            map_covering=map_covering 
+        )
+
+    def rvs(self, size):
+        
+        max_time = 3600 # à suprimer
+        
+        #give arrays of lenght N for delta(declination) and alpha(right ascention) in radians
+        def uniform_distribution_sphere_partial(N,delta_min,delta_max,alpha_min,alpha_max):
+            # angles must be in radians and following the ra-dec convention
+            u = numpy.random.uniform(0, 1, N)
+            v = numpy.random.uniform(0, 1, N)
+            
+            delta = numpy.arcsin( (numpy.sin(delta_max)-numpy.sin(delta_min) ) * u  + numpy.sin(delta_min) )  
+            alpha = (alpha_max - alpha_min) * v + alpha_min
+            
+
+            return alpha, delta  
+        #delta in [-pi/2, pi/2] alpha in [0,2pi]
+        
+        #give the accepted points by the rejection sampling method  (theta,phi)
+        def simple_rejection_sampling(m,N,delta_min,delta_max,alpha_min,alpha_max):                                                  
+
+            data = m.data
+            
+            M = data.max()                                                                      
+            X = numpy.random.uniform(0, M, N)
+
+            alpha,delta = uniform_distribution_sphere_partial(N,delta_min,delta_max,alpha_min,alpha_max)                                
+            theta,phi = numpy.pi/2 -delta,alpha                                           
+           
+            d_data =  numpy.array( m.get_interp_val(theta,phi,lonlat = False) )  # PLUS NECESSAIRE AVEC NOUVELLE VERSION DE MHEALPY
+            
+            dist_theta = theta[ d_data > X ] 
+            dist_phi = phi[ d_data > X ]
+
+            return (dist_theta,dist_phi)
+
+        #does the rejection sampling method multiples times until a limit is reach
+        def sampling_method(m,n,N_max,t_max,delta_min,delta_max,alpha_min,alpha_max):
+            # m = map healpix
+            # n = nombre de points acceptés
+            # N_max = nombre de points total à ne pas depasser , type 100 000 000
+            # t_max = temps max pour faire tourner le programme
+            t_start = time.time()
+
+            theta,  phi = numpy.array([]),  numpy.array([])
+           
+            iteration = int(N_max//n) 
+            for i in range(iteration):
+                
+                if ( time.time() - t_start) > t_max :
+                    print(f'time > time_max = {t_max}')
+                    break
+
+                THETA,PHI = simple_rejection_sampling(m,n,delta_min,delta_max,alpha_min,alpha_max)
+                if len(theta) < n:
+                    theta = numpy.concatenate((theta,THETA), axis = 0) # concatene theta et THETA
+                    phi   = numpy.concatenate((phi, PHI), axis = 0)    # concatene phi et PHI
+                
+                else :
+                    break
+
+            if len(theta) > n:
+                theta = theta[:n]
+                phi = phi[:n]
+            print(i)   
+            return theta,phi
+
+        
+        
+        theta,phi = sampling_method(self.m,size,size*1e9,max_time,self.boundaries) #mettre while pour enlever N_max et t_max
+
+
+        radec = FieldArray(
+            size,
+            dtype=[
+                ('ra', '<f8'),
+                ('dec', '<f8')
+            ]
+        )
+        radec['ra'] = phi
+        radec['dec'] = numpy.pi/2 - theta
+        return radec
+
+
+
+__all__ = ['UniformSky', 'FisherSky', 'HealpixSky']

--- a/pycbc/distributions/sky_location.py
+++ b/pycbc/distributions/sky_location.py
@@ -295,11 +295,11 @@ class HealpixSky:
                              "included in tag portion of section name")
         healpix_file = str(cp.get_opt_tag(section, 'healpix_file', tag))
         coverage = 99.99
-        if cp.has_option(section,'coverage',tag):
+        if cp.has_option_tag(section,'coverage',tag):
             coverage = float(cp.get_opt_tag(section, 'coverage', tag))
         
         rasterisation_nside = 64
-        if cp.has_option(section,'rasterisation_nside',tag):
+        if cp.has_option_tag(section,'rasterisation_nside',tag):
             rasterisation_nside = int(cp.get_opt_tag(section, 'rasterisation_nside', tag))
         return cls(
             healpix_file=healpix_file,

--- a/pycbc/distributions/sky_location.py
+++ b/pycbc/distributions/sky_location.py
@@ -18,8 +18,8 @@ right ascension and declination.
 """
 
 import logging
-import numpy # changer les np en numpy
-import time #pas besoin enfaite?
+import numpy 
+
 
 
 from scipy.spatial.transform import Rotation
@@ -245,7 +245,7 @@ class HealpixSky:
             alpha_max= 0
             alpha_min = 2*numpy.pi
             
-            rasterized_map = healpix_map.rasterize(                            #marche pas si RING 
+            rasterized_map = healpix_map.rasterize(                            #marche pas si RING, (code qui ne s'arrete plus) 
                 scheme = 'NESTED',
                 nside = nside
                 )                                                              
@@ -254,7 +254,7 @@ class HealpixSky:
             renormalization_constant = non_zero_data.sum() 
             
             normalized_data = data/renormalization_constant
-            sort_normalized_data = - numpy.sort(-non_zero_data/renormalization_constant) # TRI DECROISSANT DE non_zero_data
+            sort_normalized_data = - numpy.sort(-non_zero_data/renormalization_constant) # TRI DECROISSANT DE non_zero_data, methode numpy toute faite ?
             
             N = len(non_zero_data)
             map_coverage = 0
@@ -300,7 +300,7 @@ class HealpixSky:
             coverage = 0.9999    
         if coverage > 1 or coverage < 0 : 
             raise ValueError(
-                'Coverage must be between 0 and 1'
+                'Coverage must be between 0 and 1'                             # dire la valeur mise par l'utilisateur ?
                 )
         if 'rasterization_nside' in params:
             rasterization_nside = params['rasterization_nside']
@@ -308,8 +308,8 @@ class HealpixSky:
             rasterization_nside = 64 # or 128
         if bin(rasterization_nside).count('1') != 1 :
             raise ValueError(
-                'Nside must be a power of 2'
-                '(preferably between 16 and 256 for better efficiency)'
+                'Nside must be a power of 2'                                   # dire la valeur mise par l'utilisateur ?  
+                '(preferably between 16 and 256 for better efficiency)'        # laisser ca ?
                 )
         self.healpix_map = mhealpy.HealpixMap.read_map(file_name)
         self.boundaries = boundaries(file_name,rasterization_nside,coverage)   # self.m à la place de file_name ?
@@ -361,7 +361,7 @@ class HealpixSky:
 
             Returns
             -------
-            coordinates of the points,
+            coordinates of the points,                                         # besoin de detailler le return ?
             following the radec convention
 
             """

--- a/pycbc/distributions/sky_location.py
+++ b/pycbc/distributions/sky_location.py
@@ -216,7 +216,7 @@ class HealpixSky:
             alpha_max= 0
             alpha_min = 2*numpy.pi
             
-            rasterized_map = healpix_map.rasterize(scheme = 'RING',nside = nside) # scheme pas important ? RING par default #LE MIN ETAIT SEULEMENT ICI
+            rasterized_map = healpix_map.rasterize(scheme = 'NESTED',nside = nside) # marche pas si RING ?
             data = rasterized_map.data
             non_zero_data = data[data != 0]
             renormalization_constant = non_zero_data.sum() 

--- a/pycbc/distributions/sky_location.py
+++ b/pycbc/distributions/sky_location.py
@@ -18,8 +18,7 @@ right ascension and declination.
 """
 
 import logging
-import numpy 
-
+import numpy
 
 
 from scipy.spatial.transform import Rotation
@@ -38,6 +37,7 @@ class UniformSky(angular.UniformSolidAngle):
     names are "dec" (declination) for the polar angle and "ra" (right
     ascension) for the azimuthal angle, instead of "theta" and "phi".
     """
+
     name = 'uniform_sky'
     _polardistcls = angular.CosAngle
     _default_polar_angle = 'dec'
@@ -78,6 +78,7 @@ class FisherSky:
     angle_unit: str
         Unit for the angle parameters: either "deg" or "rad".
     """
+
     name = 'fisher_sky'
     _params = ['ra', 'dec']
 
@@ -95,7 +96,7 @@ class FisherSky:
             raise ValueError(
                 f'The mean RA must be between 0 and 2π, {mean_ra} rad given'
             )
-        if mean_dec < -numpy.pi/2 or mean_dec > numpy.pi/2:
+        if mean_dec < -numpy.pi / 2 or mean_dec > numpy.pi / 2:
             raise ValueError(
                 'The mean declination must be between '
                 f'-π/2 and π/2, {mean_dec} rad given'
@@ -108,13 +109,13 @@ class FisherSky:
         if sigma > 0.35:
             logger.warning(
                 'Warning: sigma = %s rad is probably too large for the '
-                'Fisher approximation to be valid', sigma
+                'Fisher approximation to be valid',
+                sigma,
             )
         self.rayleigh_scale = 0.66 * sigma
         # Prepare a rotation that puts the North Pole at the mean position
         self.rotation = Rotation.from_euler(
-            'yz',
-            [numpy.pi / 2 - mean_dec, mean_ra]
+            'yz', [numpy.pi / 2 - mean_dec, mean_ra]
         )
 
     @property
@@ -126,8 +127,10 @@ class FisherSky:
         tag = variable_args
         variable_args = variable_args.split(VARARGS_DELIM)
         if set(variable_args) != set(cls._params):
-            raise ValueError("Not all parameters used by this distribution "
-                             "included in tag portion of section name")
+            raise ValueError(
+                "Not all parameters used by this distribution "
+                "included in tag portion of section name"
+            )
         mean_ra = float(cp.get_opt_tag(section, 'mean_ra', tag))
         mean_dec = float(cp.get_opt_tag(section, 'mean_dec', tag))
         sigma = float(cp.get_opt_tag(section, 'sigma', tag))
@@ -136,20 +139,13 @@ class FisherSky:
             mean_ra=mean_ra,
             mean_dec=mean_dec,
             sigma=sigma,
-            angle_unit=angle_unit
+            angle_unit=angle_unit,
         )
 
     def rvs(self, size):
         # Draw samples from a distribution centered on the North pole
-        np_ra = numpy.random.uniform(
-            low=0,
-            high=(2*numpy.pi),
-            size=size
-        )
-        np_dec = numpy.random.rayleigh(
-            scale=self.rayleigh_scale,
-            size=size
-        )
+        np_ra = numpy.random.uniform(low=0, high=(2 * numpy.pi), size=size)
+        np_dec = numpy.random.rayleigh(scale=self.rayleigh_scale, size=size)
 
         # Convert the samples to intermediate cartesian representation
         np_cart = numpy.empty(shape=(size, 3))
@@ -163,13 +159,7 @@ class FisherSky:
         # Convert the samples back to spherical coordinates.
         # Some unpleasant conditional operations are needed
         # to get the correct angle convention.
-        rot_radec = FieldArray(
-            size,
-            dtype=[
-                ('ra', '<f8'),
-                ('dec', '<f8')
-            ]
-        )
+        rot_radec = FieldArray(size, dtype=[('ra', '<f8'), ('dec', '<f8')])
         rot_radec['ra'] = numpy.arctan2(rot_cart[:, 1], rot_cart[:, 0])
         neg_mask = rot_radec['ra'] < 0
         rot_radec['ra'][neg_mask] += 2 * numpy.pi
@@ -177,55 +167,52 @@ class FisherSky:
         return rot_radec
 
 
-
-
 class HealpixSky:
-    """Sample the distribution given by a HEALPix map by using the rejection 
+    """Sample the distribution given by a HEALPix map by using the rejection
     sampling method.
-    To have an acceptable acceptance rate, a rectangle in (alpha,delta) is 
-    first found, that encloses a given ammount of probability (specified by 
-    the coverage parameter). In order to do this the map is rasterized to a
-    resolution specified by rasterization_nside.
-    
-    The declination (delta) varies from π/2 to -π/2 and the right ascension 
+    To have an acceptable acceptance rate, a rectangle in (alpha,delta) is
+    first found, that encloses a given amount of probability (specified by
+    the `coverage` parameter). In order to do this the map is rasterized to a
+    resolution specified by `rasterization_nside`.
+
+    The declination (delta) varies from π/2 to -π/2 and the right ascension
     (alpha) varies from 0 to 2π.
 
     Parameters
     ----------
     healpix_file : str
-        path to a fits file containing probability distribution encoded in a 
-        HEALPix scheme
+        Path to a fits file containing probability distribution encoded in a
+        HEALPix scheme.
     coverage : float
-        fraction of the map covered by the method. Must be between 0 and 1
+        Fraction of the map covered by the method. Must be between 0 and 1.
     rasterization_nside : int
-        nside of the rasterized map used to determine the 
-        boundaries of the input map. Must be a power of 2
+        Nside of the rasterized map used to determine the
+        boundaries of the input map. Must be a power of 2,
+        preferably between 64 and 256.
     """
+
     name = 'healpix_sky'
     _params = ['ra', 'dec']
-    
-    def __init__(self, **params): 
+
+    def __init__(self, **params):
         import mhealpy
-        
-        #give the boundaries of a map m in radian, and following the 
-        #radec convention delta in [-π/2, π/2] alpha in [0,2π]
-        def boundaries(healpix_map,nside,coverage): 
-            """boundaries of the part of the celestial sphere which we are 
-            looking to do the distribution
-            
+
+        def boundaries(healpix_map, nside, coverage):
+            """Boundaries of the part of the celestial sphere which we are
+            looking to do the distribution.
 
             Parameters
             ----------
-            healpix_map : HealpixMap instance 
-            
+            healpix_map : HealpixMap instance
+
             nside : int
-                nside of the rasterized map used to determine the boundaries of 
+                nside of the rasterized map used to determine the boundaries of
                 the input map.
                 must be a power of 2
             coverage : float
                 percentage of the map covered by the method
                 must be betwen 0 and 1
-           
+
             Returns
             -------
             delta_min : float
@@ -238,79 +225,80 @@ class HealpixSky:
                 maximum right ascention of the map in radians.
 
             """
-            
-            nside = min(nside,healpix_map.nside)                               
-            
-            delta_max= -numpy.pi/2
-            delta_min= numpy.pi/2
-            alpha_max= 0
-            alpha_min = 2*numpy.pi
-            #FIXME this only works with 'NESTED', why?
-            rasterized_map = healpix_map.rasterize(                            
-                scheme = 'NESTED',
-                nside = nside
-                )                                                              
+
+            nside = min(nside, healpix_map.nside)
+
+            delta_max = -numpy.pi / 2
+            delta_min = numpy.pi / 2
+            alpha_max = 0
+            alpha_min = 2 * numpy.pi
+            # FIXME this only works with 'NESTED', why?
+            rasterized_map = healpix_map.rasterize(
+                scheme='NESTED', nside=nside
+            )
             data = rasterized_map.data
-            renormalization_constant = data.sum() 
-            
-            normalized_data = data/renormalization_constant
+            renormalization_constant = data.sum()
+
+            normalized_data = data / renormalization_constant
             sorter = numpy.argsort(-normalized_data)
-            
+
             map_coverage = 0
-            
+
             for i in range(len(data)):
-                # j = numpy.argmax(normalized_data == sort_normalized_data[i]) 
+                # j = numpy.argmax(normalized_data == sort_normalized_data[i])
                 j = sorter[i]
-                pix = rasterized_map.uniq[j]-4*nside*nside
-                delta,alpha =  rasterized_map.pix2ang(
-                    pix,
-                    lonlat = False
-                )
+                pix = rasterized_map.uniq[j] - 4 * nside * nside
+                delta, alpha = rasterized_map.pix2ang(pix, lonlat=False)
                 # converts colatitude to latitude
-                delta = numpy.pi/2 - delta 
-                
+                delta = numpy.pi / 2 - delta
+
                 # map_coverage += sort_normalized_data[i]
                 map_coverage += normalized_data[j]
-                delta_max,delta_min = max(delta_max,delta),min(delta_min,delta)
-                alpha_max,alpha_min = max(alpha_max,alpha),min(alpha_min,alpha)
-                    
-                if map_coverage > coverage : 
+                delta_max, delta_min = max(delta_max, delta), min(
+                    delta_min, delta
+                )
+                alpha_max, alpha_min = max(alpha_max, alpha), min(
+                    alpha_min, alpha
+                )
+
+                if map_coverage > coverage:
                     break
-                
-            #A safety margin is added to ensure that the pixels at the edges 
-            #of the distribution are fully accounted for.
-            #width of one pixel : < π/4nside-1
-            
-            margin = 2*numpy.pi/(4*nside -1)
-            
-            delta_max = min(delta_max + margin, numpy.pi/2)
-            delta_min = max(delta_min - margin, -numpy.pi/2)
-            alpha_max = min(alpha_max + margin, 2*numpy.pi)
+
+            # A safety margin is added to ensure that the pixels at the edges
+            # of the distribution are fully accounted for.
+            # width of one pixel : < π/4nside-1
+
+            margin = 2 * numpy.pi / (4 * nside - 1)
+
+            delta_max = min(delta_max + margin, numpy.pi / 2)
+            delta_min = max(delta_min - margin, -numpy.pi / 2)
+            alpha_max = min(alpha_max + margin, 2 * numpy.pi)
             alpha_min = max(alpha_min - margin, 0)
-     
-            return delta_min,delta_max,alpha_min,alpha_max
-       
-        
+
+            return delta_min, delta_max, alpha_min, alpha_max
+
         file_name = params['healpix_file']
-        
+
         coverage = params['coverage']
-      
-        if coverage > 1 or coverage < 0 : 
+
+        if coverage > 1 or coverage < 0:
             raise ValueError(
-                f'Coverage must be between 0 and 1, {coverage} is not correct'                            
-                )
-        
+                f'Coverage must be between 0 and 1, {coverage} is not correct'
+            )
+
         rasterization_nside = params['rasterization_nside']
-     
-        if bin(rasterization_nside).count('1') != 1 :
+
+        if bin(rasterization_nside).count('1') != 1:
             raise ValueError(
-                f'Rasterization_nside must be a power of 2,' 
-                f'{rasterization_nside} is not correct'                                    
-                '(preferably between 16 and 256 for better efficiency)'       
-                )
+                f'Rasterization_nside must be a power of 2,'
+                f'{rasterization_nside} is not correct'
+            )
         self.healpix_map = mhealpy.HealpixMap.read_map(file_name)
-        self.boundaries = boundaries(self.healpix_map,rasterization_nside,coverage)  
-    
+        self.boundaries = boundaries(
+            self.healpix_map, rasterization_nside, coverage
+        )
+        logging.info('HealpixSky boundary is %s', self.boundaries)
+
     @property
     def params(self):
         return self._params
@@ -320,107 +308,97 @@ class HealpixSky:
         tag = variable_args
         variable_args = variable_args.split(VARARGS_DELIM)
         if set(variable_args) != set(cls._params):
-            raise ValueError("Not all parameters used by this distribution "
-                             "included in tag portion of section name")
+            raise ValueError(
+                "Not all parameters used by this distribution "
+                "included in tag portion of section name"
+            )
         healpix_file = str(cp.get_opt_tag(section, 'healpix_file', tag))
         coverage = 0.9999
-        if cp.has_option_tag(section,'coverage',tag):
+        if cp.has_option_tag(section, 'coverage', tag):
             coverage = float(cp.get_opt_tag(section, 'coverage', tag))
-        
+
         rasterization_nside = 64
-        if cp.has_option_tag(section,'rasterization_nside',tag):
-            rasterization_nside = int(cp.get_opt_tag(section, 'rasterization_nside', tag))
+        if cp.has_option_tag(section, 'rasterization_nside', tag):
+            rasterization_nside = int(
+                cp.get_opt_tag(section, 'rasterization_nside', tag)
+            )
         return cls(
             healpix_file=healpix_file,
             coverage=coverage,
-            rasterization_nside=rasterization_nside
+            rasterization_nside=rasterization_nside,
         )
 
     def rvs(self, size):
-        
-        #gives the points accepted by the rejection sampling method
-        def simple_rejection_sampling(healpix_map,size,boundaries):
+        def simple_rejection_sampling(healpix_map, size, boundaries):
             """Start from a uniform distribution of points, and accepts those
-            whose values on the healpix_map are greater than a random value 
-            following a uniform law
-            
-            Parameters
-            ----------
-            healpix_map  : HealpixMap instance                                 
-            size : int
-                number of points tested by the method
-            boundaries : list -> tuple of 4 floats                                                  
-                delta_min,delta_max,alpha_min,alpha_max = boundaries
-                delta is the declination in radians [-pi/2, pi/2]
-                alpha is the right ascention in radians [0,2pi]
+             whose values on the map are greater than a random value
+             following a uniform law
 
-            Returns
-            -------
-           coordinates of the accepted points, 
-           following the mhealpy conventions
+             Parameters
+             ----------
+             healpix_map  : HealpixMap instance
+             size : int
+                 number of points tested by the method
+             boundaries : list -> tuple of 4 floats
+                 delta_min,delta_max,alpha_min,alpha_max = boundaries
+                 delta is the declination in radians [-pi/2, pi/2]
+                 alpha is the right ascention in radians [0,2pi]
 
-            """ 
-            #The angles are in radians and follow the radec convention
-            delta_min,delta_max,alpha_min,alpha_max = boundaries
-            
-            # draw points uniformly distributed inside the region delimited by boundaries
+             Returns
+             -------
+            coordinates of the accepted points,
+            following the mhealpy conventions
+
+            """
+            # The angles are in radians and follow the radec convention
+            delta_min, delta_max, alpha_min, alpha_max = boundaries
+
+            # draw points uniformly distributed inside the region delimited by
+            # boundaries
             u = numpy.random.uniform(0, 1, size)
-            delta = numpy.arcsin( 
-                ( numpy.sin(delta_max) - numpy.sin(delta_min) ) * u  
-                + numpy.sin(delta_min) 
-                )  
+            delta = numpy.arcsin(
+                (numpy.sin(delta_max) - numpy.sin(delta_min)) * u
+                + numpy.sin(delta_min)
+            )
             alpha = numpy.random.uniform(alpha_min, alpha_max, size)
-            #a conversion is required to use get_interp_val                                
-            theta,phi = numpy.pi/2 -delta,alpha
+            # a conversion is required to use get_interp_val
+            theta, phi = numpy.pi / 2 - delta, alpha
 
-            
             data = healpix_map.data
             random_data = numpy.random.uniform(0, data.max(), size)
-            
-        
-            #the latest version of mhealpy is needed to run get_interp_val
-            #get_interp_val might return an astropy object,
-            #hence the need to transform into an array
-            d_data =  numpy.array( healpix_map.get_interp_val(
-                                                            theta,
-                                                            phi,
-                                                            lonlat = False
-                                                            )
-                                    ) 
-            
-            dist_theta = theta[ d_data > random_data ] 
-            dist_phi = phi[ d_data > random_data ]
 
-            return (dist_theta,dist_phi)
-       
-        #Sampling method to generate the desired number of points 
-        theta,phi = numpy.array([]),  numpy.array([])
+            # the version of mhealpy 0.3.4 or later is needed to run
+            # get_interp_val
+            # get_interp_val might return an astropy object depending on the
+            # units of the column of the fits file,
+            # hence the need to transform into an array
+            d_data = numpy.array(
+                healpix_map.get_interp_val(theta, phi, lonlat=False)
+            )
+
+            dist_theta = theta[d_data > random_data]
+            dist_phi = phi[d_data > random_data]
+
+            return (dist_theta, dist_phi)
+
+        # Sampling method to generate the desired number of points
+        theta, phi = numpy.array([]), numpy.array([])
         while len(theta) < size:
-            new_theta,new_phi = simple_rejection_sampling(
-                self.healpix_map,
-                size,
-                self.boundaries
-                )
-            theta = numpy.concatenate((theta,new_theta), axis = 0) 
-            phi   = numpy.concatenate((phi, new_phi), axis = 0)    
+            new_theta, new_phi = simple_rejection_sampling(
+                self.healpix_map, size, self.boundaries
+            )
+            theta = numpy.concatenate((theta, new_theta), axis=0)
+            phi = numpy.concatenate((phi, new_phi), axis=0)
 
         if len(theta) > size:
             theta = theta[:size]
             phi = phi[:size]
-        #end of sampling method
-        
-        #Writing the HDF file and converting back to the radec convention
-        radec = FieldArray(
-            size,
-            dtype=[
-                ('ra', '<f8'),
-                ('dec', '<f8')
-            ]
-        )
-        radec['ra'] = phi
-        radec['dec'] = numpy.pi/2 - theta
-        return radec
 
+        # convert back to the radec convention
+        radec = FieldArray(size, dtype=[('ra', '<f8'), ('dec', '<f8')])
+        radec['ra'] = phi
+        radec['dec'] = numpy.pi / 2 - theta
+        return radec
 
 
 __all__ = ['UniformSky', 'FisherSky', 'HealpixSky']

--- a/pycbc/distributions/sky_location.py
+++ b/pycbc/distributions/sky_location.py
@@ -207,16 +207,15 @@ class HealpixSky:
         
         #give the boundaries of a map m in radian, and following the 
         #radec convention delta in [-π/2, π/2] alpha in [0,2π]
-        def boundaries(healpix_file,nside,coverage): 
+        def boundaries(healpix_map,nside,coverage): 
             """boundaries of the part of the celestial sphere which we are 
             looking to do the distribution
             
 
             Parameters
             ----------
-            healpix_file : str
-                path to a fits file containing probability distribution encoded
-                in a HEALPix scheme
+            healpix_map : 
+            
             nside : int
                 nside of the rasterized map used to determine the boundaries of 
                 the input map.
@@ -237,7 +236,7 @@ class HealpixSky:
                 maximum right ascention of the map in radians.
 
             """
-            healpix_map = mhealpy.HealpixMap.read_map(healpix_file)
+            
             nside = min(nside,healpix_map.nside)                               #min si jamais nside < m.nside pour pas ralentir inutilement
             
             delta_max= -numpy.pi/2
@@ -312,7 +311,7 @@ class HealpixSky:
                 '(preferably between 16 and 256 for better efficiency)'        # laisser ca ?
                 )
         self.healpix_map = mhealpy.HealpixMap.read_map(file_name)
-        self.boundaries = boundaries(file_name,rasterization_nside,coverage)   # self.m à la place de file_name ?
+        self.boundaries = boundaries(self.healpix_map,rasterization_nside,coverage)  
         
     
         

--- a/pycbc/distributions/sky_location.py
+++ b/pycbc/distributions/sky_location.py
@@ -216,7 +216,7 @@ class HealpixSky:
             alpha_max= 0
             alpha_min = 2*numpy.pi
             
-            rasterized_map = healpix_map.rasterize(scheme = 'NESTED',nside = nside) # scheme pas important ? RING par default #LE MIN ETAIT SEULEMENT ICI
+            rasterized_map = healpix_map.rasterize(scheme = 'RING',nside = nside) # scheme pas important ? RING par default #LE MIN ETAIT SEULEMENT ICI
             data = rasterized_map.data
             non_zero_data = data[data != 0]
             renormalization_constant = non_zero_data.sum() 

--- a/pycbc/distributions/sky_location.py
+++ b/pycbc/distributions/sky_location.py
@@ -245,7 +245,7 @@ class HealpixSky:
             alpha_min = 2*numpy.pi
             
             rasterized_map = healpix_map.rasterize(                            # A COMPRENDRE ? marche pas si RING, (code qui ne s'arrete plus) 
-                scheme = 'ring',
+                scheme = 'NESTED',
                 nside = nside
                 )                                                              
             data = rasterized_map.data

--- a/pycbc/distributions/sky_location.py
+++ b/pycbc/distributions/sky_location.py
@@ -194,7 +194,7 @@ class HealpixSky:
     coverage : {float, 0.9999}
         percentage of the map covered by the method
         
-    rasterization_nside : {int, 64}@
+    rasterization_nside : {int, 64}
         nside of the rasterized map used to determine the 
         boundaries of the input map.
     """
@@ -269,7 +269,7 @@ class HealpixSky:
                 'Coverage must be between 0 and 1'
                 )
         if 'rasterization_nside' in params:
-            rasterization_nside = params['rasterisation_nside']
+            rasterization_nside = params['rasterization_nside']
         else :
             rasterization_nside = 64 # or 128
         if bin(rasterization_nside).count('1') != 1 :

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -33,6 +33,7 @@ from pycbc.workflow import WorkflowConfigParser
 EXCLUDE_DIST_NAMES = ["fromfile", "arbitrary",
                       "external", "external_func_fromfile",
                       "fisher_sky",
+                      "healpix_sky",
                       "uniform_solidangle", "uniform_sky",
                       "independent_chip_chieff",
                       "uniform_f0_tau", "fixed_samples"]


### PR DESCRIPTION
Add a class HealpixSky to `pycbc/pycbc/distributions/sky_location.py` that allow one to sample the distribution given by a HEALPix sky map by using the rejection sampling method.

## Standard information about the request

This change follows style guidelines (See e.g. [PEP8](https://peps.python.org/pep-0008/)) and includes running `black` to reformat `sky_location.py`.

This change adds a new feature to the distributions module, mainly for use in PyGRB.

## Motivation

Versions of PyGRB used for past analyses approximated the uncertainty in the GRB sky location with circular patches, or using "IPN boxes". In many cases, the uncertainties actually are not circular at all. This is typically the case for IPN localizations, which can resemble thin rings over large patches of the sky. Nowadays, most GRBs have their sky location uncertainties represented as complete probability densities over the sky, encoded via the HEALPix scheme, and stored in FITS files. This change will allow PyGRB to directly read those FITS files, without making approximations.

## Contents

The class HealpixSky samples the distribution given by a HEALPix map by using the rejection sampling method. 
To have an practical acceptance rate even with precise localizations, a bounding rectangle in (alpha,delta) is first determined as a preprocessing step, which encloses a given amount of probability (specified by the `coverage` parameter). In order to do this in a simple way, the map is temporarily rasterized to a resolution specified by `rasterization_nside`. The choice of this parameter is not very critical, it mainly affects the run time. It is probably possible to modify the algorithm so that this step is not necessary, and the `coverage` and `rasterization_nside` can be dropped. This is something to be looked at in a future pull request. Anyway, the present method seems to work, providing 10000 samples in order of tens of seconds max for most IPN maps.

In order to use this distribution with `pycbc_create_injections`, the corresponding `.ini` file must contain a section that looks like this:
```
[prior-ra+dec]
name = healpix_sky
; Path to the skymap file in FITS format. Can be gzipped (.fits.gz).
healpix_file =  /path/to/skymap.fits
; Must be a power of 2, 128 seems to works best in terms of run time.
; Optional parameter, internal default set to 64.
rasterization_nside =  128
; Must be between 0 and 1, 1 meaning that you consider all the space where the data is non zero.
; Optional parameter, internal default set to 0.9999.
coverage = 0.999
```

## Links to any issues or associated PRs

This addresses #4267.

## Testing performed

Test on the following GRBs are to be done to check accuracy and speed:
```
GRB211124A_IPN_map_hpx.fits.gz
GRB220203A_IPN_map_hpx.fits.gz
GRB220209A_IPN_map_hpx.fits.gz
GRB220211A_IPN_map_hpx.fits.gz
GRB220711C_IPN_map_hpx.fits.gz
GRB220905A_IPN_map_hpx.fits.gz
GRB220927A_IPN_map_hpx.fits.gz
GRB221022C_IPN_map_hpx.fits.gz
GRB221124A_IPN_map_hpx.fits.gz
GRB221226A_IPN_map_hpx.fits.gz
GRB230511D_IPN_map_hpx.fits.gz
GRB230518A_IPN_map_hpx.fits.gz
GRB230625B_IPN_map_hpx.fits.gz
GRB230712A_IPN_map_hpx.fits.gz
GRB230712C_IPN_map_hpx.fits.gz
GRB230715D_IPN_map_hpx.fits.gz
GRB231018A_IPN_map_hpx_moc.fits.gz
GRB231224A_IPN_map_hpx_moc.fits.gz
GRB240119A_IPN_map_hpx_moc.fits.gz
GRB240124B_IPN_map_hpx.fits.gz
GRB240125A_IPN_map_hpx_moc.fits.gz
GRB240125B_IPN_map_hpx_moc.fits.gz
GRB240205A_IPN_map_hpx_moc.fits.gz
GRB240209A_IPN_map_hpx_moc.fits.gz
GRB240410A_IPN_map_hpx.fits.gz
GRB240504A_IPN_map_hpx_moc.fits.gz
GRB240514B_IPN_map_hpx_moc.fits.gz
GRB240529A_IPN_map_hpx_moc.fits.gz
GRB240531A_IPN_map_hpx_moc.fits.gz
GRB240603A_IPN_map_hpx_moc.fits.gz
GRB240607A_IPN_map_hpx_moc.fits.gz
GRB240615A_IPN_map_hpx_moc.fits.gz
GRB240628B_IPN_map_hpx_moc.fits.gz
GRB240715A_IPN_map_hpx_moc.fits.gz
```

## Additional notes

This code requires mhealpy 0.3.4 or later. Previous versions have a bug that prevents a function from working.

- [ ] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
