### PR TITLE
pycbc_plot_bank_corner improvements for live

### DIFF
--- a/bin/live/pycbc_live_supervise_collated_trigger_fits
+++ b/bin/live/pycbc_live_supervise_collated_trigger_fits
@@ -270,7 +270,10 @@ def plot_fits(
     ]
     fits_plot_arguments += sv.dict_to_args(plot_fit_options)
 
-    title = "Fit parameters for pycbc-live, triggers from " + day_title_str
+    title = "Fit parameters for pycbc-live, triggers from {}, {}".format(
+        ifo,
+        day_title_str
+    )
     if smoothed == True:
         title += ', smoothed'
     fits_plot_arguments += ['--title', title]

--- a/bin/plotting/pycbc_plot_bank_corner
+++ b/bin/plotting/pycbc_plot_bank_corner
@@ -286,6 +286,7 @@ fig, axis_dict = create_multidim_plot(
     hist_color=hist_color,
     mins=mins,
     maxs=maxs,
+    log_parameters=args.log_parameters,
 )
 
 title_text = f"{os.path.basename(args.bank_file)}"
@@ -322,10 +323,17 @@ for i in range(len(args.parameters)):
             s0.sharex(s1)
 
 for (p1, p2), ax in axis_dict.items():
-    if p1 in args.log_parameters:
-        ax[0].semilogx()
-    if p2 in args.log_parameters:
-        ax[0].semilogy()
+    if p1 == p2:
+        if p1 == args.parameters[-1] and len(args.parameters) == 2:
+            # This will be turned on its side, so set _y_ axis to log
+            ax[0].semilogy()
+        else:
+            ax[0].semilogx()
+    else:
+        if p1 in args.log_parameters:
+            ax[0].semilogx()
+        if p2 in args.log_parameters:
+            ax[0].semilogy()
 
 logging.info("Plot generated")
 fig.set_dpi(args.dpi)

--- a/bin/plotting/pycbc_plot_bank_corner
+++ b/bin/plotting/pycbc_plot_bank_corner
@@ -72,6 +72,12 @@ parser.add_argument("--parameters",
          "property of that parameter will be used. If not "
          "provided, will plot all of the parameters in the "
          "bank.")
+parser.add_argument(
+    '--log-parameters',
+    nargs='+',
+    help="Which parameters are to be plotted on a log scale? "
+         "Must be also given in parameters"
+)
 parser.add_argument('--plot-histogram',
     action='store_true',
     help="Plot 1D histograms of parameters on the "
@@ -103,6 +109,11 @@ parser.add_argument("--color-parameter",
     help="Color scatter points according to the parameter given. "
          "May optionally provide a label in the same way as for "
          "--parameters. Default=No scatter point coloring.")
+parser.add_argument(
+    '--log-colormap',
+    action='store_true',
+    help="Should the colorbar be plotted on a log scale?"
+)
 parser.add_argument('--dpi',
     type=int,
     default=200,
@@ -116,6 +127,13 @@ parser.add_argument('--title',
 
 add_style_opt_to_parser(parser)
 args = parser.parse_args()
+
+for lp in args.log_parameters:
+    if not lp in args.parameters:
+        parser.error(
+            "--log-parameters should be in --parameters. "
+            f"{lp} not in [{', '.join(args.parameters)}]"
+        )
 
 pycbc.init_logging(args.verbose)
 set_style_from_cli(args)
@@ -146,7 +164,7 @@ if args.fits_file is not None:
             param = fits_f[p][:].astype(float)
             # We need to check for the cardinal '-1' value which means
             # that the fit is invalid
-            param[param <= 0] = 0 if 'count' in p and 'log' not in p else np.nan
+            param[param <= 0] = np.nan
             bank[p] = param
 
 logging.info("Got %d templates from the bank", banklen)
@@ -227,12 +245,21 @@ if cpar:
 for p in required_minmax:
     minval = np.nanmin(bank_fa[p][bank_fa[p] != -np.inf])
     maxval = np.nanmax(bank_fa[p][bank_fa[p] != np.inf])
-    valrange = maxval - minval
+    if (p in args.log_parameters) or (p == cpar and args.log_colormap):
+        # Extend the range by 10% in log-space
+        logvalrange = np.log(maxval) - np.log(minval)
+        if p not in mins:
+            mins[p] = np.exp(np.log(minval) - 0.05 * logvalrange)
+        if p not in maxs:
+            maxs[p] = np.exp(np.log(maxval) + 0.05 * logvalrange)
+    else:
+        # Extend the range by 10%
+        valrange = maxval - minval
+        if p not in mins:
+            mins[p] = minval - 0.05 * valrange
+        if p not in maxs:
+            maxs[p] = maxval + 0.05 * valrange
 
-    if p not in mins:
-        mins[p] = minval - 0.05 * valrange
-    if p not in maxs:
-        maxs[p] = maxval + 0.05 * valrange
 
 # Deal with non-coloring case:
 zvals = bank_fa[cpar] if cpar else None
@@ -247,6 +274,7 @@ fig, axis_dict = create_multidim_plot(
     plot_scatter=True,
     plot_contours=False,
     scatter_cmap="viridis",
+    scatter_log_cmap=args.log_colormap,
     marginal_title=False,
     marginal_percentiles=[],
     fill_color='g',
@@ -292,6 +320,12 @@ for i in range(len(args.parameters)):
     if len(sharex_axes) > 1:
         for s0, s1 in zip(sharex_axes[:-1], sharex_axes[1:]):
             s0.sharex(s1)
+
+for (p1, p2), ax in axis_dict.items():
+    if p1 in args.log_parameters:
+        ax[0].semilogx()
+    if p2 in args.log_parameters:
+        ax[0].semilogy()
 
 logging.info("Plot generated")
 fig.set_dpi(args.dpi)

--- a/bin/plotting/pycbc_plot_bank_corner
+++ b/bin/plotting/pycbc_plot_bank_corner
@@ -323,7 +323,7 @@ for i in range(len(args.parameters)):
             s0.sharex(s1)
 
 for (p1, p2), ax in axis_dict.items():
-    if p1 == p2:
+    if p1 == p2 and p1 in args.log_parameters:
         if p1 == args.parameters[-1] and len(args.parameters) == 2:
             # This will be turned on its side, so set _y_ axis to log
             ax[0].semilogy()

--- a/bin/plotting/pycbc_plot_bank_corner
+++ b/bin/plotting/pycbc_plot_bank_corner
@@ -75,6 +75,7 @@ parser.add_argument("--parameters",
 parser.add_argument(
     '--log-parameters',
     nargs='+',
+    default=[],
     help="Which parameters are to be plotted on a log scale? "
          "Must be also given in parameters"
 )

--- a/pycbc/results/scatter_histograms.py
+++ b/pycbc/results/scatter_histograms.py
@@ -631,6 +631,8 @@ def create_multidim_plot(parameters, samples, labels=None,
         The color map to use for the scatter points. Default is 'plasma'.
     scatter_log_cmap : boolean
         Should the scatter point coloring be on a log scale? Default False
+    log_parameters : list or None
+        Which parameters should be plotted on a log scale
     plot_density : {False, bool}
         Plot the density of points as a color map.
     plot_contours : {True, bool}
@@ -654,8 +656,6 @@ def create_multidim_plot(parameters, samples, labels=None,
         Use the given figure instead of creating one.
     axis_dict : dict
         Use the given dictionary of axes instead of creating one.
-    log_parameters : list
-        Which parameters should be plotted on a log scale
 
     Returns
     -------
@@ -668,6 +668,8 @@ def create_multidim_plot(parameters, samples, labels=None,
     """
     if labels is None:
         labels = {p: p for p in parameters}
+    if log_parameters is None:
+        log_parameters = []
     # set up the figure with a grid of axes
     # if only plotting 2 parameters, make the marginal plots smaller
     nparams = len(parameters)

--- a/pycbc/results/scatter_histograms.py
+++ b/pycbc/results/scatter_histograms.py
@@ -337,7 +337,7 @@ def create_marginalized_hist(ax, values, label, percentiles=None,
                              linestyle='-', plot_marginal_lines=True,
                              title=True, expected_value=None,
                              expected_color='red', rotated=False,
-                             plot_min=None, plot_max=None):
+                             plot_min=None, plot_max=None, log_scale=False):
     """Plots a 1D marginalized histogram of the given param from the given
     samples.
 
@@ -380,6 +380,8 @@ def create_marginalized_hist(ax, values, label, percentiles=None,
         creates.
     scalefac : {1., float}
         Factor to scale the default font sizes by. Default is 1 (no scaling).
+    log_scale : boolean
+        Should the histogram bins be logarithmically spaced
     """
     if fillcolor is None:
         htype = 'step'
@@ -389,7 +391,19 @@ def create_marginalized_hist(ax, values, label, percentiles=None,
         orientation = 'horizontal'
     else:
         orientation = 'vertical'
-    ax.hist(values, bins=50, histtype=htype, orientation=orientation,
+    if log_scale:
+        bins = numpy.logspace(
+            numpy.log10(numpy.nanmin(values)),
+            numpy.log10(numpy.nanmax(values)),
+            50
+        )
+    else:
+        bins = numpy.linspace(
+            numpy.nanmin(values),
+            numpy.nanmax(values),
+            50,
+        )
+    ax.hist(values, bins=bins, histtype=htype, orientation=orientation,
             facecolor=fillcolor, edgecolor=color, ls=linestyle, lw=2,
             density=True)
     if percentiles is None:
@@ -545,7 +559,7 @@ def create_multidim_plot(parameters, samples, labels=None,
                          marginal_title=True, marginal_linestyle='-',
                          zvals=None, show_colorbar=True, cbar_label=None,
                          vmin=None, vmax=None, scatter_cmap='plasma',
-                         scatter_log_cmap=False,
+                         scatter_log_cmap=False, log_parameters=None,
                          plot_density=False, plot_contours=True,
                          density_cmap='viridis',
                          contour_color=None, label_contours=True,
@@ -640,6 +654,8 @@ def create_multidim_plot(parameters, samples, labels=None,
         Use the given figure instead of creating one.
     axis_dict : dict
         Use the given dictionary of axes instead of creating one.
+    log_parameters : list
+        Which parameters should be plotted on a log scale
 
     Returns
     -------
@@ -735,6 +751,7 @@ def create_multidim_plot(parameters, samples, labels=None,
             create_marginalized_hist(
                 ax, samples[param], label=labels[param],
                 color=hist_color, fillcolor=fill_color,
+                log_scale=param in log_parameters,
                 plot_marginal_lines=plot_marginal_lines,
                 linestyle=marginal_linestyle, linecolor=line_color,
                 title=marginal_title, expected_value=expected_value,

--- a/pycbc/results/scatter_histograms.py
+++ b/pycbc/results/scatter_histograms.py
@@ -776,7 +776,6 @@ def create_multidim_plot(parameters, samples, labels=None,
             else:
                 cmap_norm = colors.Normalize(vmin=vmin, vmax=vmax)
 
-
             plt = ax.scatter(x=samples[px], y=samples[py], c=zvals, s=5,
                              edgecolors='none', norm=cmap_norm,
                              cmap=scatter_cmap, alpha=alpha, zorder=2)

--- a/pycbc/results/scatter_histograms.py
+++ b/pycbc/results/scatter_histograms.py
@@ -43,7 +43,7 @@ import matplotlib
 if 'matplotlib.backends' not in sys.modules:  # nopep8
     matplotlib.use('agg')
 
-from matplotlib import (offsetbox, pyplot, gridspec)
+from matplotlib import (offsetbox, pyplot, gridspec, colors)
 
 from pycbc.results import str_utils
 from pycbc.io import FieldArray
@@ -545,6 +545,7 @@ def create_multidim_plot(parameters, samples, labels=None,
                          marginal_title=True, marginal_linestyle='-',
                          zvals=None, show_colorbar=True, cbar_label=None,
                          vmin=None, vmax=None, scatter_cmap='plasma',
+                         scatter_log_cmap=False,
                          plot_density=False, plot_contours=True,
                          density_cmap='viridis',
                          contour_color=None, label_contours=True,
@@ -614,6 +615,8 @@ def create_multidim_plot(parameters, samples, labels=None,
         zvals.
     scatter_cmap : {'plasma', string}
         The color map to use for the scatter points. Default is 'plasma'.
+    scatter_log_cmap : boolean
+        Should the scatter point coloring be on a log scale? Default False
     plot_density : {False, bool}
         Plot the density of points as a color map.
     plot_contours : {True, bool}
@@ -749,8 +752,14 @@ def create_multidim_plot(parameters, samples, labels=None,
                 alpha = 0.3
             else:
                 alpha = 1.
+            if scatter_log_cmap:
+                cmap_norm = colors.LogNorm(vmin=vmin, vmax=vmax)
+            else:
+                cmap_norm = colors.Normalize(vmin=vmin, vmax=vmax)
+
+
             plt = ax.scatter(x=samples[px], y=samples[py], c=zvals, s=5,
-                             edgecolors='none', vmin=vmin, vmax=vmax,
+                             edgecolors='none', norm=cmap_norm,
                              cmap=scatter_cmap, alpha=alpha, zorder=2)
 
         if plot_contours or plot_density:


### PR DESCRIPTION
Improvements are needed for the fits plotting.
This allows log ranges to be used for all parameters including the colorbar parameter, and also adds the IFO to the title of the plot when it is called by the live supervisor

## Standard information about the request

This is a new feature
This change affects: plotting from the live search

This change follows style guidelines (See e.g. [PEP8](https://peps.python.org/pep-0008/)), has been proposed using the [contribution guidelines](https://github.com/gwastro/pycbc/blob/master/CONTRIBUTING.md)

## Motivation
Before these changes, we would have to use log(param) in the --parameters argument. This leads to unwieldy labels and non-intuitive axis tick values

## Contents
 - Add two options to pycbc_plot_bank_corner for log parameters and log-colormap
 - check that the log-parameters are sensible
 - Modify the logic for extending the axes so that if it is on a log scale, this will not break things by becomeing a negative value
 - pass the colorbar argument into `create_multidim_plot`, and use manual normalisation objects rather than the default linear norm
 - set semilogy and semilogx on the axis dictionary values when appropriate
 - I've also added the IFO into the plot title when it is called by the supervisor script.

## Testing performed
See https://ldas-jobs.ligo.caltech.edu/~gareth.cabourndavies/testoutput/fit_plots_improvements/L1-FIT_OVER_PARAM-2024_08_07.png for a plot which uses log scale in x axis and linear elsewhere.
https://ldas-jobs.ligo.caltech.edu/~gareth.cabourndavies/testoutput/fit_plots_improvements/L1-FIT_BY_TEMPLATE-2024_08_07.png uses log scale on x and y, and also on the color scale
Other plots in that directory show:
 - where 2 parameters are used, with a histogram (special case where the bottom right histogram plot is rotated 90 degrees)
 - where 3 parameters are used, with a histogram
 - where no log-scaled parameters are used

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
