### PR TITLE
Update to pegasus 5.0.8

### DIFF
--- a/.github/workflows/inference-workflow.yml
+++ b/.github/workflows/inference-workflow.yml
@@ -25,7 +25,7 @@ jobs:
         wget -qO - https://download.pegasus.isi.edu/pegasus/gpg.txt | sudo apt-key add -
         echo "deb https://download.pegasus.isi.edu/pegasus/ubuntu bionic main" | sudo tee -a /etc/apt/sources.list
         sudo apt-get -o Acquire::Retries=3 update
-        sudo apt-get -o Acquire::Retries=3 install pegasus=5.0.6-1+ubuntu18
+        sudo apt-get -o Acquire::Retries=3 install pegasus=5.0.8-1+ubuntu18
     - run: sudo apt-get -o Acquire::Retries=3 install *fftw3* intel-mkl*
     - name: Install pycbc
       run: |

--- a/.github/workflows/search-workflow.yml
+++ b/.github/workflows/search-workflow.yml
@@ -30,7 +30,7 @@ jobs:
         wget -qO - https://download.pegasus.isi.edu/pegasus/gpg.txt | sudo apt-key add -
         echo "deb https://download.pegasus.isi.edu/pegasus/ubuntu bionic main" | sudo tee -a /etc/apt/sources.list
         sudo apt-get -o Acquire::Retries=3 update
-        sudo apt-get -o Acquire::Retries=3 install pegasus=5.0.6-1+ubuntu18
+        sudo apt-get -o Acquire::Retries=3 install pegasus=5.0.8-1+ubuntu18
     - run: sudo apt-get -o Acquire::Retries=3 install *fftw3* intel-mkl*
     - name: Install pycbc
       run: |

--- a/.github/workflows/tmpltbank-workflow.yml
+++ b/.github/workflows/tmpltbank-workflow.yml
@@ -29,7 +29,7 @@ jobs:
         wget -qO - https://download.pegasus.isi.edu/pegasus/gpg.txt | sudo apt-key add -
         echo "deb https://download.pegasus.isi.edu/pegasus/ubuntu bionic main" | sudo tee -a /etc/apt/sources.list
         sudo apt-get -o Acquire::Retries=3 update
-        sudo apt-get -o Acquire::Retries=3 install pegasus=5.0.6-1+ubuntu18
+        sudo apt-get -o Acquire::Retries=3 install pegasus=5.0.8-1+ubuntu18
     - run: sudo apt-get -o Acquire::Retries=3 install *fftw3* intel-mkl*
     - name: Install pycbc
       run: |

--- a/.github/workflows/workflow-tests.yml
+++ b/.github/workflows/workflow-tests.yml
@@ -34,7 +34,7 @@ jobs:
         wget -qO - https://download.pegasus.isi.edu/pegasus/gpg.txt | sudo apt-key add -
         echo "deb https://download.pegasus.isi.edu/pegasus/ubuntu bionic main" | sudo tee -a /etc/apt/sources.list
         sudo apt-get -o Acquire::Retries=3 update
-        sudo apt-get -o Acquire::Retries=3 install pegasus=5.0.6-1+ubuntu18
+        sudo apt-get -o Acquire::Retries=3 install pegasus=5.0.8-1+ubuntu18
     - run: sudo apt-get -o Acquire::Retries=3 install *fftw3* intel-mkl*
     - name: Install pycbc
       run: |

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,9 +17,17 @@ tqdm
 gwdatafind>=1.1.3
 
 # Requirements for full pegasus env
-pegasus-wms.api >= 5.0.6
-# Need GitPython: See discussion in https://github.com/gwastro/pycbc/pull/4454
+# https://pegasus.isi.edu/documentation/user-guide/installation.html#mixing-environments-system-venv-conda
+# six is listed, but is now not needed.
+pegasus-wms.api >= 5.0.8
+boto3
+certifi
 GitPython
+pyjwt
+pyyaml
+s3transfer
+urllib3
+
 # need to pin until pegasus for further upstream
 # addresses incompatibility between old flask/jinja2 and latest markupsafe
 markupsafe <= 2.0.1

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ install_requires = setup_requires + [
     'tqdm',
     'setuptools',
     'gwdatafind',
-    'pegasus-wms.api >= 5.0.6',
+    'pegasus-wms.api >= 5.0.8',
     'python-ligo-lw >= 1.7.0',
     'ligo-segments',
     'lalsuite!=7.2',


### PR DESCRIPTION
Update PyCBC to require pegasus 5.0.8

## Standard information about the request

This is a: dependency update

This change affects: all workflows

This change will: I don't *think* this will break any functionality based on quite a bit of testing on LVK machines. I wouldn't want to update a workflow mid-run, but even that *might* work.

## Motivation

This pegasus release contains a number of bug fixes and feature additions requested by us. It will make it much easier to run workflows in modern python environments.

## Contents

Update pegasus dependencies to 5.0.8. This is mostly changes in the executables, the API package does not have much that is different.

## Testing performed

I've run workflows on LDG machines and on OSG with this. Discussed extensively with Karan+Mats+Stuart.

- [✔️  ] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
