### PR TITLE
Make sure BBHx knows how to link locally-installed LAPACK

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -39,7 +39,6 @@ conda_deps=
     lapack==3.6.1
 conda_channels=conda-forge
 setenv =
-    PYCBC_TEST_TYPE=docs
     ; Needed to build BBHx's wheel that links to LAPACK in the Conda env
     LIBRARY_PATH={env:CONDA_PREFIX:}/lib:{env:LIBRARY_PATH:}
 commands = pytest

--- a/tox.ini
+++ b/tox.ini
@@ -39,8 +39,9 @@ conda_deps=
     lapack==3.6.1
 conda_channels=conda-forge
 setenv =
-    ; Needed to build BBHx's wheel that links to LAPACK in the Conda env
-    LIBRARY_PATH={env:CONDA_PREFIX:}/lib:{env:LIBRARY_PATH:}
+    ; Tell the linker to look for shared libs inside the temporary Conda env.
+    ; Needed to build BBHx's wheel, whick links to LAPACK.
+    LIBRARY_PATH={envdir}/lib:{env:LIBRARY_PATH:}
 commands = pytest
 
 # The following are long running or may require
@@ -86,6 +87,7 @@ conda_deps=
 conda_channels=conda-forge
 setenv =
     PYCBC_TEST_TYPE=docs
-    ; Needed to build BBHx's wheel that links to LAPACK in the Conda env
-    LIBRARY_PATH={env:CONDA_PREFIX:}/lib:{env:LIBRARY_PATH:}
+    ; Tell the linker to look for shared libs inside the temporary Conda env.
+    ; Needed to build BBHx's wheel, whick links to LAPACK.
+    LIBRARY_PATH={envdir}/lib:{env:LIBRARY_PATH:}
 commands = bash tools/pycbc_test_suite.sh

--- a/tox.ini
+++ b/tox.ini
@@ -38,6 +38,10 @@ conda_deps=
     gsl
     lapack==3.6.1
 conda_channels=conda-forge
+setenv =
+    PYCBC_TEST_TYPE=docs
+    ; Needed to build BBHx's wheel that links to LAPACK in the Conda env
+    LIBRARY_PATH={env:CONDA_PREFIX:}/lib:{env:LIBRARY_PATH:}
 commands = pytest
 
 # The following are long running or may require
@@ -81,5 +85,8 @@ conda_deps=
     lapack==3.6.1
     openmpi
 conda_channels=conda-forge
-setenv = PYCBC_TEST_TYPE=docs
+setenv =
+    PYCBC_TEST_TYPE=docs
+    ; Needed to build BBHx's wheel that links to LAPACK in the Conda env
+    LIBRARY_PATH={env:CONDA_PREFIX:}/lib:{env:LIBRARY_PATH:}
 commands = bash tools/pycbc_test_suite.sh


### PR DESCRIPTION
Fixes a recent CI failure noted by @maxtrevor in #4850.

## Standard information about the request

This is (kind of) a bug fix. This change affects mostly the Tox tests.

## Motivation

Running `pytest` under Tox requires to install BBHx, which needs to link against LAPACK when building its wheel. LAPACK is typically installed via Conda (specified in `tox.ini`) and its shared libraries end up in the temporary Conda env created by Tox.

For some reason which I have not figured out, this used to work fine until a few days ago, when the linker started not being able to find `liblapacke` anymore. As far as I can see, nothing is explicitly telling the linker where to look for the LAPACK shared libraries, so I am not sure how it could work before 🤷.

So this PR explicitly tells the linker to look for shared libraries inside the Conda env, by setting `LIBRARY_PATH`. I do not particularly like this solution, so better ideas are welcome.

## Contents

Adds a few bits to `tox.ini` in order to explicitly set the env var `LIBRARY_PATH` to the `lib` subdirectory of the Conda env prefix. I think assuming `liblapack*` will be there is safe.

## Links to any issues or associated PRs

Fixes a CI failure in #4850.

## Testing performed

Ran Tox locally before opening the PR.

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
