### PR TITLE
Live singles fits plot names

### DIFF
--- a/bin/live/pycbc_live_supervise_collated_trigger_fits
+++ b/bin/live/pycbc_live_supervise_collated_trigger_fits
@@ -226,6 +226,11 @@ def fit_over_multiparam(
         "specified parameters",
         len(daily_files)
     )
+    logging.info(
+        "Smoothing fits using fit_over_multiparam with %d files and "
+        "specified parameters",
+        len(daily_files)
+    )
     file_id_str = f'{first_date}-{end_date}'
     out_fname = fit_over_controls['fit-over-format'].format(
         dates=file_id_str,
@@ -293,7 +298,6 @@ def single_significance_fits(
         day_str,
         day_dt,
         controls,
-        test_options,
         stat_files=None,
     ):
     """
@@ -466,7 +470,6 @@ def supervise_collation_fits_dq(args, day_dt, day_str):
     combined_control_options = config_opts['significance_combined_fits_control']
     combined_plot_options = config_opts['plot_significance_combined']
     combined_plot_control_options = config_opts['plot_significance_combined_control']
-    test_options = config_opts['test']
 
     # The main output directory will have a date subdirectory which we
     # put the output into
@@ -541,7 +544,6 @@ def supervise_collation_fits_dq(args, day_dt, day_str):
             day_str,
             day_dt,
             controls,
-            test_options,
             stat_files=stat_files,
         )
         plot_single_significance_fits(

--- a/bin/live/pycbc_live_supervise_collated_trigger_fits
+++ b/bin/live/pycbc_live_supervise_collated_trigger_fits
@@ -306,7 +306,10 @@ def single_significance_fits(
     """
     daily_options['output'] = os.path.join(
         output_dir,
-        daily_controls['sig-daily-format'].format(date=day_str),
+        daily_controls['sig-daily-format'].format(
+            ifos=''.join(controls['ifos'].split()),
+            date=day_str
+        ),
     )
     daily_args = ['pycbc_live_single_significance_fits']
 
@@ -326,7 +329,10 @@ def plot_single_significance_fits(daily_output, daily_plot_options, controls):
     """
     Plotting daily significance fits, and link to public directory if wanted
     """
-    daily_plot_output = f'{daily_output[:-4]}_{{ifo}}.png'
+    daily_plot_output = daily_output[:-4].replace(
+        ''.join(controls['ifos'].split()),
+        '{ifo}'
+    ) + '.png'
     logging.info(
         "Plotting daily significance fits from %s to %s",
         daily_output,
@@ -369,9 +375,14 @@ def combine_significance_fits(
     Supervise the smoothing of live trigger significance fits using
     pycbc_live_combine_single_significance_fits
     """
+    # This has a trick to do partial formatting, get the IFOs into the
+    # string, but not the date
     daily_files, first_date, end_date = find_daily_fit_files(
         combined_controls,
-        combined_controls['daily-format'],
+        combined_controls['daily-format'].format(
+            ifos=''.join(controls['ifos'].split()),
+            date='{date}'
+        ),
         controls['output-directory'],
     )
     logging.info(


### PR DESCRIPTION
Fix an annoyance in the naming of single significance plots for each IFO.

Also remove unused options

## Standard information about the request

This is a minor fix
This change affects the live search
This change changes naming of live automatically produced plots

This change follows style guidelines (See e.g. [PEP8](https://peps.python.org/pep-0008/)), has been proposed using the [contribution guidelines](https://github.com/gwastro/pycbc/blob/master/CONTRIBUTING.md)



## Contents
Change to use a daily singles fit filename format which uses IFOs, and then replaces that string for the single-ifo plots

## Testing performed
Supervisor script still runs and makes plots with the appropriate name (once the config is updated as appropriate)


- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
