### PR TITLE
Update GitHub actions to use modern versions

### DIFF
--- a/.github/workflows/basic-tests.yml
+++ b/.github/workflows/basic-tests.yml
@@ -51,7 +51,7 @@ jobs:
         tox -e py-inference
     - name: store documentation page
       if: matrix.test-type == 'docs' && matrix.python-version == '3.12'
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: documentation-page
         path: _gh-pages

--- a/.github/workflows/basic-tests.yml
+++ b/.github/workflows/basic-tests.yml
@@ -61,7 +61,7 @@ jobs:
     if: github.ref == 'refs/heads/master' && github.event_name == 'push'
     steps:
     - name: retrieve built documentation
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v4.1.7
       with:
         name: documentation-page
     - name: debug

--- a/.github/workflows/basic-tests.yml
+++ b/.github/workflows/basic-tests.yml
@@ -16,7 +16,7 @@ jobs:
         python-version: ['3.9', '3.10', '3.11', '3.12']
         test-type: [unittest, search, docs]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:

--- a/.github/workflows/basic-tests.yml
+++ b/.github/workflows/basic-tests.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: installing system packages

--- a/.github/workflows/build_venv.yml
+++ b/.github/workflows/build_venv.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v1
       -
         name: "Set up Python"
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9
       -

--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
-          name: wheel-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.version }}
+          name: wheel-${{ matrix.os }}
           path: ./wheelhouse/*.whl
   deploy_pypi:
     name: Build and publish Python 🐍 distributions 📦 to PyPI
@@ -54,7 +54,8 @@ jobs:
     - name: build pycbc for pypi
       run: |
         python setup.py sdist
-        mv artifact/* dist/
+        ls -lh
+        mv -v wheel-* dist/
     - name: Publish distribution 📦 to PyPI
       if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
       uses: pypa/gh-action-pypi-publish@master

--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -29,8 +29,10 @@ jobs:
           CIBW_BUILD: cp39-* cp310-* cp311-* cp312-*
           CIBW_SKIP: "*musllinux*"
           CIBW_ARCHS_MACOS: x86_64 arm64
-      - uses: actions/upload-artifact@v4
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
         with:
+          name: wheel-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.version }}
           path: ./wheelhouse/*.whl
   deploy_pypi:
     name: Build and publish Python 🐍 distributions 📦 to PyPI
@@ -46,6 +48,8 @@ jobs:
         python-version: '3.10'
     - uses: actions/download-artifact@v4.1.7
       with:
+        pattern: wheel-*
+        merge-multiple: true
         path: ./
     - name: build pycbc for pypi
       run: |

--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -44,7 +44,7 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: '3.10'
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v4.1.7
       with:
         path: ./
     - name: build pycbc for pypi

--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -15,7 +15,7 @@ jobs:
         os: [ubuntu-20.04, macos-12]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - uses: actions/setup-python@v4
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-20.04
     needs: build_wheels
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Set up Python 3.10

--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -54,7 +54,6 @@ jobs:
     - name: Build source distribution
       run: |
         python setup.py sdist
-        ls -lh
         ls -lh dist
     - name: Publish to PyPI
       if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')

--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -29,7 +29,7 @@ jobs:
           CIBW_BUILD: cp39-* cp310-* cp311-* cp312-*
           CIBW_SKIP: "*musllinux*"
           CIBW_ARCHS_MACOS: x86_64 arm64
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           path: ./wheelhouse/*.whl
   deploy_pypi:

--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
       - name: Install cibuildwheel
@@ -43,7 +43,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: Set up Python 3.10
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.10'
     - uses: actions/download-artifact@v4.1.7

--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -35,7 +35,7 @@ jobs:
           name: wheel-${{ matrix.os }}
           path: ./wheelhouse/*.whl
   deploy_pypi:
-    name: Build and publish Python 🐍 distributions 📦 to PyPI
+    name: Package and publish to PyPI
     runs-on: ubuntu-20.04
     needs: build_wheels
     steps:
@@ -50,13 +50,13 @@ jobs:
       with:
         pattern: wheel-*
         merge-multiple: true
-        path: ./
-    - name: build pycbc for pypi
+        path: dist/
+    - name: Build source distribution
       run: |
         python setup.py sdist
         ls -lh
-        mv -v wheel-* dist/
-    - name: Publish distribution 📦 to PyPI
+        ls -lh dist
+    - name: Publish to PyPI
       if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
       uses: pypa/gh-action-pypi-publish@master
       with:

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v1
       -
         name: "Set up Python"
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9
       -

--- a/.github/workflows/inference-workflow.yml
+++ b/.github/workflows/inference-workflow.yml
@@ -48,12 +48,12 @@ jobs:
         find submitdir/work/ -type f -name '*.tar.gz' -delete
     - name: store log files
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: logs
         path: gw_output/submitdir/work
     - name: store result page
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: results
         path: html

--- a/.github/workflows/inference-workflow.yml
+++ b/.github/workflows/inference-workflow.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.10'
     - name: install condor

--- a/.github/workflows/mac-test.yml
+++ b/.github/workflows/mac-test.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - run: |

--- a/.github/workflows/search-workflow.yml
+++ b/.github/workflows/search-workflow.yml
@@ -55,12 +55,12 @@ jobs:
         find submitdir/work/ -type f -name '*.tar.gz' -delete
     - name: store log files
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: logs
         path: output/submitdir/work
     - name: store result page
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: results
         path: html

--- a/.github/workflows/search-workflow.yml
+++ b/.github/workflows/search-workflow.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.10'
     - name: install condor

--- a/.github/workflows/tmpltbank-workflow.yml
+++ b/.github/workflows/tmpltbank-workflow.yml
@@ -51,7 +51,7 @@ jobs:
         find submitdir/work/ -type f -name '*.tar.gz' -delete
     - name: store log files
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: logs
         path: output/submitdir/work

--- a/.github/workflows/tmpltbank-workflow.yml
+++ b/.github/workflows/tmpltbank-workflow.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.10'
     - name: install condor

--- a/.github/workflows/tut-test.yml
+++ b/.github/workflows/tut-test.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: installing packages

--- a/.github/workflows/tut-test.yml
+++ b/.github/workflows/tut-test.yml
@@ -15,7 +15,7 @@ jobs:
         os: [ubuntu-20.04]
         python-version: ['3.10', '3.11', '3.12']
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:

--- a/.github/workflows/workflow-tests.yml
+++ b/.github/workflows/workflow-tests.yml
@@ -50,7 +50,7 @@ jobs:
         find submitdir/work/ -type f -name '*.tar.gz' -delete
     - name: store log files
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: logs-${{matrix.test-type}}
         path: examples/workflow/generic/${{matrix.test-type}}/submitdir/work

--- a/.github/workflows/workflow-tests.yml
+++ b/.github/workflows/workflow-tests.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.10'
     - name: install condor


### PR DESCRIPTION
As stated in #4865, a github workflow tool seems to have a security risk. dependabot doesn't seem capable of rebasing itself, so I open a new PR here with the same change.