### PR TITLE
Psd fix

### DIFF
--- a/pycbc/conversions.py
+++ b/pycbc/conversions.py
@@ -451,9 +451,10 @@ def delta_lambda_tilde(mass1, mass2, lambda1, lambda2):
         1 - (13272 / 1319) * eta +
         (8944 / 1319) * eta ** 2
     ) * lsum
-    p2 = (1 - (15910 / 1319) * eta +
-         (32850 / 1319) * eta ** 2 +
-         (3380 / 1319) * eta ** 3
+    p2 = (
+        1 - (15910 / 1319) * eta +
+        (32850 / 1319) * eta ** 2 +
+        (3380 / 1319) * eta ** 3
     ) * ldiff
     return formatreturn(1 / 2 * (p1 + p2), input_is_array)
 

--- a/pycbc/conversions.py
+++ b/pycbc/conversions.py
@@ -452,14 +452,14 @@ def delta_lambda_tilde(mass1, mass2, lambda1, lambda2):
         (8944 / 1319) * eta ** 2
     ) * lsum
     p2 = (1 - (15910 / 1319) * eta +
-        (32850 / 1319) * eta ** 2 +
-        (3380 / 1319) * eta ** 3) * ldiff
+         (32850 / 1319) * eta ** 2 +
+         (3380 / 1319) * eta ** 3) * ldiff
     return formatreturn(1 / 2 * (p1 + p2), input_is_array)
 
 def lambda1_from_delta_lambda_tilde_lambda_tilde(delta_lambda_tilde,
-                                                lambda_tilde,
-                                                mass1,
-                                                mass2):
+                                                 lambda_tilde,
+                                                 mass1,
+                                                 mass2):
     """ Returns lambda1 parameter by using delta lambda tilde,
     lambda tilde, mass1 and mass2.
     """

--- a/pycbc/conversions.py
+++ b/pycbc/conversions.py
@@ -463,7 +463,7 @@ def lambda1_from_delta_lambda_tilde_lambda_tilde(delta_lambda_tilde,
                                                  mass1,
                                                  mass2):
     """ Returns lambda1 parameter by using delta lambda tilde,
-    lambda tilde, mass1 and mass2.
+    lambda tilde, mass1, and mass2.
     """
     m1, m2, delta_lambda_tilde, lambda_tilde, input_is_array = ensurearray(
         mass1, mass2, delta_lambda_tilde, lambda_tilde)
@@ -487,7 +487,7 @@ def lambda2_from_delta_lambda_tilde_lambda_tilde(
         mass1,
         mass2):
     """ Returns lambda2 parameter by using delta lambda tilde,
-    lambda tilde, mass1 and mass2.
+    lambda tilde, mass1, and mass2.
     """
     m1, m2, delta_lambda_tilde, lambda_tilde, input_is_array = ensurearray(
         mass1, mass2, delta_lambda_tilde, lambda_tilde)

--- a/pycbc/conversions.py
+++ b/pycbc/conversions.py
@@ -453,7 +453,8 @@ def delta_lambda_tilde(mass1, mass2, lambda1, lambda2):
     ) * lsum
     p2 = (1 - (15910 / 1319) * eta +
          (32850 / 1319) * eta ** 2 +
-         (3380 / 1319) * eta ** 3) * ldiff
+         (3380 / 1319) * eta ** 3
+    ) * ldiff
     return formatreturn(1 / 2 * (p1 + p2), input_is_array)
 
 def lambda1_from_delta_lambda_tilde_lambda_tilde(delta_lambda_tilde,

--- a/pycbc/conversions.py
+++ b/pycbc/conversions.py
@@ -436,6 +436,10 @@ def lambda_tilde(mass1, mass2, lambda1, lambda2):
     return formatreturn(8.0 / 13.0 * (p1 + p2), input_is_array)
 
 def delta_lambda_tilde(mass1, mass2, lambda1, lambda2):
+    """ Delta lambda tilde parameter defined as
+    equation 15 in 
+    https://journals.aps.org/prd/pdf/10.1103/PhysRevD.91.043002
+    """
     m1, m2, lambda1, lambda2, input_is_array = ensurearray(
         mass1, mass2, lambda1, lambda2)
     lsum = lambda1 + lambda2
@@ -455,11 +459,13 @@ def delta_lambda_tilde(mass1, mass2, lambda1, lambda2):
          )
     return formatreturn(1 / 2 * (p1 + p2), input_is_array)
 
-def lambda1_from_delta_lambda_tilde_lambda_tilde(
-        delta_lambda_tilde, 
-        lambda_tilde, 
-        mass1, 
-        mass2):
+def lambda1_from_delta_lambda_tilde_lambda_tilde(delta_lambda_tilde, 
+                                                lambda_tilde, 
+                                                mass1, 
+                                                mass2):
+    """ Returns lambda1 parameter by using delta lambda tilde,
+    lambda tilde, mass1 and mass2.
+    """
     m1, m2, delta_lambda_tilde, lambda_tilde, input_is_array = ensurearray(
         mass1, mass2, delta_lambda_tilde, lambda_tilde)
     eta = eta_from_mass1_mass2(m1, m2)
@@ -478,6 +484,9 @@ def lambda2_from_delta_lambda_tilde_lambda_tilde(
         lambda_tilde, 
         mass1, 
         mass2):
+    """ Returns lambda2 parameter by using delta lambda tilde,
+    lambda tilde, mass1 and mass2.
+    """
     m1, m2, delta_lambda_tilde, lambda_tilde, input_is_array = ensurearray(
         mass1, mass2, delta_lambda_tilde, lambda_tilde)
     eta = eta_from_mass1_mass2(m1, m2)   
@@ -1835,5 +1844,6 @@ __all__ = ['dquadmon_from_lambda', 'lambda_tilde',
            'remnant_mass_from_mass1_mass2_spherical_spin_eos',
            'remnant_mass_from_mass1_mass2_cartesian_spin_eos',
            'lambda1_from_delta_lambda_tilde_lambda_tilde',
-           'lambda2_from_delta_lambda_tilde_lambda_tilde'
+           'lambda2_from_delta_lambda_tilde_lambda_tilde',
+           'delta_lambda_tilde'
           ]

--- a/pycbc/conversions.py
+++ b/pycbc/conversions.py
@@ -435,6 +435,55 @@ def lambda_tilde(mass1, mass2, lambda1, lambda2):
     p2 = (1 - 4 * eta)**0.5 * (1 + 9 * eta - 11 * eta ** 2.0) * (ldiff)
     return formatreturn(8.0 / 13.0 * (p1 + p2), input_is_array)
 
+def delta_lambda_tilde(mass1, mass2, lambda1, lambda2):
+    m1, m2, lambda1, lambda2, input_is_array = ensurearray(
+        mass1, mass2, lambda1, lambda2)
+    lsum = lambda1 + lambda2
+    ldiff, _ = ensurearray(lambda1 - lambda2)
+    mask = m1 < m2
+    ldiff[mask] = -ldiff[mask]
+    eta = eta_from_mass1_mass2(m1, m2)
+    p1 = numpy.sqrt(1 - 4*eta) * (1 - (13272/1319)*eta + (8944/1319)*eta**2) * lsum
+    p2 = (1 - (15910/1319)*eta + (32850/1319)*eta**2 + (3380/1319)*eta**3) * ldiff
+    return formatreturn(1 / 2 * (p1 + p2), input_is_array)
+
+def lambda1_from_delta_lambda_tilde_lambda_tilde(delta_lambda_tilde, lambda_tilde, mass1, mass2):
+    m1, m2, delta_lambda_tilde, lambda_tilde, input_is_array = ensurearray(
+        mass1, mass2, delta_lambda_tilde, lambda_tilde)
+    
+    eta = eta_from_mass1_mass2(m1, m2)
+    
+    p1 = 1 + 7.0*eta - 31*eta**2.0
+    p2 = (1 - 4*eta)**0.5 * (1 + 9*eta - 11*eta**2.0)
+    p3 = (1 - 4*eta)**0.5 * (1 - 13272/1319*eta + 8944/1319*eta**2)
+    p4 = 1 - (15910/1319)*eta + (32850/1319)*eta**2 + (3380/1319)*eta**3
+    
+    amp = 1/((p1*p4)-(p2*p3))
+    
+    l_tilde_lambda1 = 13/16 * (p3-p4) * lambda_tilde
+    l_delta_tilde_lambda1 = (p1-p2) * delta_lambda_tilde
+    
+    lambda1 = formatreturn(amp * (l_delta_tilde_lambda1 - l_tilde_lambda1), input_is_array)
+    return lambda1
+
+def lambda2_from_delta_lambda_tilde_lambda_tilde(delta_lambda_tilde, lambda_tilde, mass1, mass2):
+    m1, m2, delta_lambda_tilde, lambda_tilde, input_is_array = ensurearray(
+        mass1, mass2, delta_lambda_tilde, lambda_tilde)
+    
+    eta = eta_from_mass1_mass2(m1, m2)
+    
+    p1 = 1 + 7.0*eta - 31*eta**2.0
+    p2 = (1 - 4*eta)**0.5 * (1 + 9*eta - 11*eta**2.0)
+    p3 = (1 - 4*eta)**0.5 * (1 - 13272/1319*eta + 8944/1319*eta**2)
+    p4 = 1 - (15910/1319)*eta + (32850/1319)*eta**2 + (3380/1319)*eta**3
+    
+    amp = 1/((p1*p4)-(p2*p3))
+    
+    l_tilde_lambda2 = 13/16 * (p3+p4) * lambda_tilde
+    l_delta_tilde_lambda2 = (p1+p2) * delta_lambda_tilde
+    
+    lambda2 = formatreturn(amp * (l_tilde_lambda2 - l_delta_tilde_lambda2), input_is_array)
+    return lambda2
 
 def lambda_from_mass_tov_file(mass, tov_file, distance=0.):
     """Return the lambda parameter(s) corresponding to the input mass(es)
@@ -1774,5 +1823,7 @@ __all__ = ['dquadmon_from_lambda', 'lambda_tilde',
            'nltides_gw_phase_diff_isco', 'spin_from_pulsar_freq',
            'freqlmn_from_other_lmn', 'taulmn_from_other_lmn',
            'remnant_mass_from_mass1_mass2_spherical_spin_eos',
-           'remnant_mass_from_mass1_mass2_cartesian_spin_eos'
+           'remnant_mass_from_mass1_mass2_cartesian_spin_eos',
+           'lambda1_from_delta_lambda_tilde_lambda_tilde',
+           'lambda2_from_delta_lambda_tilde_lambda_tilde'
           ]

--- a/pycbc/conversions.py
+++ b/pycbc/conversions.py
@@ -443,46 +443,56 @@ def delta_lambda_tilde(mass1, mass2, lambda1, lambda2):
     mask = m1 < m2
     ldiff[mask] = -ldiff[mask]
     eta = eta_from_mass1_mass2(m1, m2)
-    p1 = numpy.sqrt(1 - 4*eta) * (1 - (13272/1319)*eta + (8944/1319)*eta**2) * lsum
-    p2 = (1 - (15910/1319)*eta + (32850/1319)*eta**2 + (3380/1319)*eta**3) * ldiff
+    p1 = (
+          numpy.sqrt(1 - 4*eta) * 
+          (1 - (13272/1319)*eta + 
+          (8944/1319)*eta**2) * lsum
+          )
+    p2 = (
+         (1 - (15910/1319)*eta + 
+         (32850/1319)*eta**2 + 
+         (3380/1319)*eta**3) * ldiff
+         )
     return formatreturn(1 / 2 * (p1 + p2), input_is_array)
 
-def lambda1_from_delta_lambda_tilde_lambda_tilde(delta_lambda_tilde, lambda_tilde, mass1, mass2):
+def lambda1_from_delta_lambda_tilde_lambda_tilde(
+        delta_lambda_tilde, 
+        lambda_tilde, 
+        mass1, 
+        mass2):
     m1, m2, delta_lambda_tilde, lambda_tilde, input_is_array = ensurearray(
         mass1, mass2, delta_lambda_tilde, lambda_tilde)
-    
     eta = eta_from_mass1_mass2(m1, m2)
-    
     p1 = 1 + 7.0*eta - 31*eta**2.0
     p2 = (1 - 4*eta)**0.5 * (1 + 9*eta - 11*eta**2.0)
     p3 = (1 - 4*eta)**0.5 * (1 - 13272/1319*eta + 8944/1319*eta**2)
     p4 = 1 - (15910/1319)*eta + (32850/1319)*eta**2 + (3380/1319)*eta**3
-    
     amp = 1/((p1*p4)-(p2*p3))
-    
     l_tilde_lambda1 = 13/16 * (p3-p4) * lambda_tilde
     l_delta_tilde_lambda1 = (p1-p2) * delta_lambda_tilde
-    
     lambda1 = formatreturn(amp * (l_delta_tilde_lambda1 - l_tilde_lambda1), input_is_array)
     return lambda1
 
-def lambda2_from_delta_lambda_tilde_lambda_tilde(delta_lambda_tilde, lambda_tilde, mass1, mass2):
+def lambda2_from_delta_lambda_tilde_lambda_tilde(
+        delta_lambda_tilde, 
+        lambda_tilde, 
+        mass1, 
+        mass2):
     m1, m2, delta_lambda_tilde, lambda_tilde, input_is_array = ensurearray(
         mass1, mass2, delta_lambda_tilde, lambda_tilde)
-    
-    eta = eta_from_mass1_mass2(m1, m2)
-    
+    eta = eta_from_mass1_mass2(m1, m2)   
     p1 = 1 + 7.0*eta - 31*eta**2.0
     p2 = (1 - 4*eta)**0.5 * (1 + 9*eta - 11*eta**2.0)
     p3 = (1 - 4*eta)**0.5 * (1 - 13272/1319*eta + 8944/1319*eta**2)
     p4 = 1 - (15910/1319)*eta + (32850/1319)*eta**2 + (3380/1319)*eta**3
-    
     amp = 1/((p1*p4)-(p2*p3))
-    
     l_tilde_lambda2 = 13/16 * (p3+p4) * lambda_tilde
     l_delta_tilde_lambda2 = (p1+p2) * delta_lambda_tilde
-    
-    lambda2 = formatreturn(amp * (l_tilde_lambda2 - l_delta_tilde_lambda2), input_is_array)
+    lambda2 = (
+               formatreturn(amp * 
+               (l_tilde_lambda2 - l_delta_tilde_lambda2), 
+               input_is_array)
+               )
     return lambda2
 
 def lambda_from_mass_tov_file(mass, tov_file, distance=0.):

--- a/pycbc/conversions.py
+++ b/pycbc/conversions.py
@@ -431,13 +431,13 @@ def lambda_tilde(mass1, mass2, lambda1, lambda2):
     mask = m1 < m2
     ldiff[mask] = -ldiff[mask]
     eta = eta_from_mass1_mass2(m1, m2)
-    p1 = (lsum) * (1 + 7. * eta - 31 * eta ** 2.0)
-    p2 = (1 - 4 * eta)**0.5 * (1 + 9 * eta - 11 * eta ** 2.0) * (ldiff)
+    p1 = lsum * (1 + 7. * eta - 31 * eta ** 2.0)
+    p2 = (1 - 4 * eta)**0.5 * (1 + 9 * eta - 11 * eta ** 2.0) * ldiff
     return formatreturn(8.0 / 13.0 * (p1 + p2), input_is_array)
 
 def delta_lambda_tilde(mass1, mass2, lambda1, lambda2):
     """ Delta lambda tilde parameter defined as
-    equation 15 in 
+    equation 15 in
     https://journals.aps.org/prd/pdf/10.1103/PhysRevD.91.043002
     """
     m1, m2, lambda1, lambda2, input_is_array = ensurearray(
@@ -447,21 +447,18 @@ def delta_lambda_tilde(mass1, mass2, lambda1, lambda2):
     mask = m1 < m2
     ldiff[mask] = -ldiff[mask]
     eta = eta_from_mass1_mass2(m1, m2)
-    p1 = (
-          numpy.sqrt(1 - 4*eta) * 
-          (1 - (13272/1319)*eta + 
-          (8944/1319)*eta**2) * lsum
-          )
-    p2 = (
-         (1 - (15910/1319)*eta + 
-         (32850/1319)*eta**2 + 
-         (3380/1319)*eta**3) * ldiff
-         )
+    p1 = numpy.sqrt(1 - 4 * eta) * (
+        1 - (13272 / 1319) * eta +
+        (8944 / 1319) * eta ** 2
+    ) * lsum
+    p2 = (1 - (15910 / 1319) * eta +
+        (32850 / 1319) * eta ** 2 +
+        (3380 / 1319) * eta ** 3) * ldiff
     return formatreturn(1 / 2 * (p1 + p2), input_is_array)
 
-def lambda1_from_delta_lambda_tilde_lambda_tilde(delta_lambda_tilde, 
-                                                lambda_tilde, 
-                                                mass1, 
+def lambda1_from_delta_lambda_tilde_lambda_tilde(delta_lambda_tilde,
+                                                lambda_tilde,
+                                                mass1,
                                                 mass2):
     """ Returns lambda1 parameter by using delta lambda tilde,
     lambda tilde, mass1 and mass2.
@@ -476,20 +473,23 @@ def lambda1_from_delta_lambda_tilde_lambda_tilde(delta_lambda_tilde,
     amp = 1/((p1*p4)-(p2*p3))
     l_tilde_lambda1 = 13/16 * (p3-p4) * lambda_tilde
     l_delta_tilde_lambda1 = (p1-p2) * delta_lambda_tilde
-    lambda1 = formatreturn(amp * (l_delta_tilde_lambda1 - l_tilde_lambda1), input_is_array)
+    lambda1 = formatreturn(
+        amp * (l_delta_tilde_lambda1 - l_tilde_lambda1),
+        input_is_array
+    )
     return lambda1
 
 def lambda2_from_delta_lambda_tilde_lambda_tilde(
-        delta_lambda_tilde, 
-        lambda_tilde, 
-        mass1, 
+        delta_lambda_tilde,
+        lambda_tilde,
+        mass1,
         mass2):
     """ Returns lambda2 parameter by using delta lambda tilde,
     lambda tilde, mass1 and mass2.
     """
     m1, m2, delta_lambda_tilde, lambda_tilde, input_is_array = ensurearray(
         mass1, mass2, delta_lambda_tilde, lambda_tilde)
-    eta = eta_from_mass1_mass2(m1, m2)   
+    eta = eta_from_mass1_mass2(m1, m2)
     p1 = 1 + 7.0*eta - 31*eta**2.0
     p2 = (1 - 4*eta)**0.5 * (1 + 9*eta - 11*eta**2.0)
     p3 = (1 - 4*eta)**0.5 * (1 - 13272/1319*eta + 8944/1319*eta**2)
@@ -497,11 +497,10 @@ def lambda2_from_delta_lambda_tilde_lambda_tilde(
     amp = 1/((p1*p4)-(p2*p3))
     l_tilde_lambda2 = 13/16 * (p3+p4) * lambda_tilde
     l_delta_tilde_lambda2 = (p1+p2) * delta_lambda_tilde
-    lambda2 = (
-               formatreturn(amp * 
-               (l_tilde_lambda2 - l_delta_tilde_lambda2), 
-               input_is_array)
-               )
+    lambda2 = formatreturn(
+        amp * (l_tilde_lambda2 - l_delta_tilde_lambda2),
+        input_is_array
+    )
     return lambda2
 
 def lambda_from_mass_tov_file(mass, tov_file, distance=0.):

--- a/pycbc/psd/read.py
+++ b/pycbc/psd/read.py
@@ -55,6 +55,7 @@ def from_numpy_arrays(freq_data, noise_data, length, delta_f, low_freq_cutoff):
     flow = kmin * delta_f
 
     data_start = (0 if freq_data[0]==low_freq_cutoff else numpy.searchsorted(freq_data, flow) - 1)
+    data_start = max(0, data_start)
 
     # If the cutoff is exactly in the file, start there
     if freq_data[data_start+1] == low_freq_cutoff:


### PR DESCRIPTION
This is a reopened version of an accidentally closed pull request. 

I am working with the strain sensitivity curves for Cosmic Explorer, which are available [here](https://dcc.cosmicexplorer.org/CE-T2000017/public). When I read the data files using the pycbc.psd.read.from_txt function with df=0.1, low_freq_cutoff=5.1, and length=4000, I observed that the resulting curves appear flat, as shown in the attached plot.

After examining the issue, I found that this issue does not occur with different values for low_freq_cutoff. The problem arises due to floating point arithmetic. Specifically, the value of low_freq_cutoff is 5.1 and delta_f is 0.1, so kmin should ideally be 51. However, in Python, the calculation 5.1 / 0.1 yields 50.99999999999999, and since the code uses the int function, kmin is set to 50. This causes flow to be 5 and data_start to be -1 because the first value of freq_data is slightly above 50 for Cosmic Explorer.

I would suggest that you resolve this issue by replacing the int function with the round function in the relevant part of the code. This change will ensure that kmin is correctly calculated as 51 when low_freq_cutoff is 5.1 and delta_f is 0.1.

![338024600-a06b661d-47a0-4e24-b20a-86838f20dc78](https://github.com/user-attachments/assets/2ff40df6-77fc-44aa-aef9-685e67b08ee0)