### PR TITLE
psd read changes

### DIFF
--- a/pycbc/psd/read.py
+++ b/pycbc/psd/read.py
@@ -55,7 +55,7 @@ def from_numpy_arrays(freq_data, noise_data, length, delta_f, low_freq_cutoff):
     flow = kmin * delta_f
 
     data_start = (0 if freq_data[0]==low_freq_cutoff else numpy.searchsorted(freq_data, flow) - 1)
-
+    data_start = max(0, data_start)
     # If the cutoff is exactly in the file, start there
     if freq_data[data_start+1] == low_freq_cutoff:
         data_start += 1


### PR DESCRIPTION
This is a reopened version of an accidentally closed pull request.

I am working with the strain sensitivity curves for Cosmic Explorer, which are available [here](https://dcc.cosmicexplorer.org/CE-T2000017/public). When I read the data files using the pycbc.psd.read.from_txt function with df=0.1, low_freq_cutoff=5.1, and length=4000, I observed that the resulting curves appear flat, as shown in the attached plot.

After examining the issue, I found that this issue does not occur with different values for low_freq_cutoff. The problem arises due to floating point arithmetic. Specifically, the value of low_freq_cutoff is 5.1 and delta_f is 0.1, so kmin should ideally be 51. However, in Python, the calculation 5.1 / 0.1 yields 50.99999999999999, and since the code uses the int function, kmin is set to 50. This causes flow to be 5 and data_start to be -1 because the first value of freq_data is slightly above 50 for Cosmic Explorer.

I would suggest that you resolve this issue by replacing the int function with the round function in the relevant part of the code. This change will ensure that kmin is correctly calculated as 51 when low_freq_cutoff is 5.1 and delta_f is 0.1.

![338024600-a06b661d-47a0-4e24-b20a-86838f20dc78](https://github.com/user-attachments/assets/78a432d1-29aa-4492-a21c-576ddc7fbd6d)