### PR TITLE
Input file handling in pycbc_pygrb_page_tables

### DIFF
--- a/bin/pygrb/pycbc_pygrb_page_tables
+++ b/bin/pygrb/pycbc_pygrb_page_tables
@@ -256,7 +256,7 @@ else:
     output_files = [lofft_outfile, lofft_h5_outfile]
     if None in output_files:
         parser.error('Please provide both off-source output files ' +
-                     'when using --onsource-file.')
+                     'when using --offsource-file.')
 logging.info("Setting output directory.")
 for output_file in output_files:
     if output_file:

--- a/bin/pygrb/pycbc_pygrb_page_tables
+++ b/bin/pygrb/pycbc_pygrb_page_tables
@@ -234,22 +234,29 @@ qf_h5_outfile = opts.quiet_found_injs_h5_output_file
 
 # Set output files and directories
 output_files = []
-# The user may want to process injections (possibly also against onsource)...
-if found_missed_file is not None:
+
+# Check for correct input
+if [found_missed_file, onsource_file, offsource_file].count(None) != 2:
+    parser.error('Please provide one of --found-missed-file, ' +
+                 '--onsource-file, or --offsource-file.')
+# The user may process injections...
+elif found_missed_file is not None:
     output_files = [qf_outfile, mf_outfile, qf_h5_outfile]
     if None in output_files:
         parser.error('Please provide all 3 injections output files when ' +
                      'using --found-missed-file')
-# ...or just triggers in offsource and onsource
+# ...or triggers in the onsource...
 elif onsource_file is not None:
-    output_files = [lont_outfile, lont_h5_outfile, lofft_outfile,
-                    lofft_h5_outfile]
+    output_files = [lont_outfile, lont_h5_outfile]
     if None in output_files:
         parser.error('Please provide both on-source output files ' +
-                     'and both off-source output files when using ' +
-                     '--onsource-file.')
+                     'when using --onsource-file.')
+# ...or triggers in the offsource (offsource_file is not None)
 else:
-    parser.error('Please provide --found-missed-file and/or --onsource-file.')
+    output_files = [lofft_outfile, lofft_h5_outfile]
+    if None in output_files:
+        parser.error('Please provide both off-source output files ' +
+                     'when using --onsource-file.')
 logging.info("Setting output directory.")
 for output_file in output_files:
     if output_file:


### PR DESCRIPTION
This change clearly separates the usage of injections, onsource, and offsource as input for `pycbc_pygrb_page_tables`.  The user may specify only one of these inputs.  This ensures that these specific onsource and offsource results are kept separate in the workflow and the onsource tables do not end in the closed box as additional files.

## Standard information about the request

This is a: clean up of a post-processing code, but also a bug fix for the pygrb tables because it prevents onsource results from appearing in the closed box.


<!--- What codes will this affect? (delete as apropriate)
This change affects: PyGRB

This change changes: result presentation

## Testing performed
Before the change, the onsource loudest event was in the [closed box](https://ldas-jobs.ligo.caltech.edu/~francesco.pannarale/LVC/pygrb_jun2024_1/4._loudest_offsource_events/) as an additional file.  After the change it is gone from the [closed box section](https://ldas-jobs.ligo.caltech.edu/~francesco.pannarale/LVC/pygrb_aug2024_4/4._loudest_offsource_events/) and correctly pops up in the [onsource](https://ldas-jobs.ligo.caltech.edu/~francesco.pannarale/LVC/pygrb_aug2024_4/6._open_box/).

- [ ] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
