### PR TITLE
Enable handling of all pycbc_pygrb_efficiency in workflow

### DIFF
--- a/pycbc/workflow/grb_utils.py
+++ b/pycbc/workflow/grb_utils.py
@@ -526,7 +526,11 @@ def make_pygrb_plot(workflow, exec_name, out_dir,
         node.new_output_file_opt(workflow.analysis_time, '.png',
                                  '--onsource-output-file',
                                  tags=extra_tags+['onsource'])
+        node.new_output_file_opt(workflow.analysis_time, '.json',
+                                 '--exclusion-dist-output-file',
+                                 tags=extra_tags)
         node.add_opt('--injection-set-name', tags[1])
+        node.add_opt('--trial-name', tags[0])
     else:
         node.new_output_file_opt(workflow.analysis_time, '.png',
                                  '--output-file', tags=extra_tags)
@@ -539,6 +543,8 @@ def make_pygrb_plot(workflow, exec_name, out_dir,
         node.add_opt('--y-variable', tags[0])
     # Quantity to be displayed on the x-axis of the plot
     elif exec_name == 'pygrb_plot_stats_distribution':
+        seg_filelist = FileList([resolve_url_to_file(sf) for sf in seg_files])
+        node.add_input_list_opt('--seg-files', seg_filelist)
         node.add_opt('--x-variable', tags[0])
     elif exec_name == 'pygrb_plot_injs_results':
         # Variables to plot on x and y axes

--- a/pycbc/workflow/grb_utils.py
+++ b/pycbc/workflow/grb_utils.py
@@ -543,8 +543,7 @@ def make_pygrb_plot(workflow, exec_name, out_dir,
         node.add_opt('--y-variable', tags[0])
     # Quantity to be displayed on the x-axis of the plot
     elif exec_name == 'pygrb_plot_stats_distribution':
-        seg_filelist = FileList([resolve_url_to_file(sf) for sf in seg_files])
-        node.add_input_list_opt('--seg-files', seg_filelist)
+        node.add_input_list_opt('--seg-files', seg_files)
         node.add_opt('--x-variable', tags[0])
     elif exec_name == 'pygrb_plot_injs_results':
         # Variables to plot on x and y axes


### PR DESCRIPTION
## Standard information about the request

<!--- Some basic info about the change (delete as appropriate) -->
This is the second of the PRs promised in https://github.com/gwastro/pycbc/pull/4872.

It brings the PyGRB workflow utilities up to date with the output produced `pycbc_pygrb_efficiency`.  Specifically, this script now generates a json file with exclusion distances, which the (post processing) workflow generator needs to catch and handle appropriately.  The json file is intended to be used by the executable introduce in https://github.com/gwastro/pycbc/pull/4756 to display exclusion distances in a table.

This change affects: PyGRB

This change changes: presentation of scientific output

This change will come to full circle with another PR to invoke and display the generation of the exclusion distances table.

## Links to any issues or associated PRs
This is the 2nd PR of a series opened by https://github.com/gwastro/pycbc/pull/4872 but it does not depend on it.

## Testing performed
A full results webpage is [available](https://ldas-jobs.ligo.caltech.edu/~francesco.pannarale/LVC/pygrb_aug2024_4/) but it requires more changes than this one to produce.

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
