### PR TITLE
Revert temporary dependence on PyPMC fork

### DIFF
--- a/companion.txt
+++ b/companion.txt
@@ -22,10 +22,6 @@ https://github.com/willvousden/ptemcee/archive/master.tar.gz
 --extra-index-url https://download.pytorch.org/whl/cpu
 torch
 nessai>=0.11.0
-
-# Needed to make sure numpy2 build works, remove when PR merged
-# https://github.com/pypmc/pypmc/pull/105/files
-git+https://github.com/ahnitz/pypmc@n2
 snowline
 
 # useful to look at PyCBC Live with htop


### PR DESCRIPTION
This reverts a temporary measure added in #4863 due to CI tests failing because of PyPMC. With #4863 we started depending on a custom branch of PyPMC to work around an error, and I think the underlying issue has now been addressed in PyPMC.

Fixes #4861.

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
