### PR TITLE
Function to setup pygrb_grb_info_table jobs

### DIFF
--- a/bin/pygrb/pycbc_pygrb_pp_workflow
+++ b/bin/pygrb/pycbc_pygrb_pp_workflow
@@ -144,7 +144,7 @@ files = _workflow.FileList([])
 #
 # Create information table about the GRB trigger and plot the search grid
 #
-info_table_node, grb_info_table = _workflow.make_info_table(wflow, out_dir)
+info_table_node, grb_info_table = _workflow.make_info_table(wflow, 'pygrb_grb_info_table', out_dir)
 html_nodes.append(info_table_node)
 files.append(grb_info_table)
 #

--- a/pycbc/workflow/grb_utils.py
+++ b/pycbc/workflow/grb_utils.py
@@ -539,8 +539,6 @@ def make_pygrb_plot(workflow, exec_name, out_dir,
         node.add_opt('--y-variable', tags[0])
     # Quantity to be displayed on the x-axis of the plot
     elif exec_name == 'pygrb_plot_stats_distribution':
-        seg_filelist = FileList([resolve_url_to_file(sf) for sf in seg_files])
-        node.add_input_list_opt('--seg-files', seg_filelist)
         node.add_opt('--x-variable', tags[0])
     elif exec_name == 'pygrb_plot_injs_results':
         # Variables to plot on x and y axes

--- a/pycbc/workflow/grb_utils.py
+++ b/pycbc/workflow/grb_utils.py
@@ -539,6 +539,8 @@ def make_pygrb_plot(workflow, exec_name, out_dir,
         node.add_opt('--y-variable', tags[0])
     # Quantity to be displayed on the x-axis of the plot
     elif exec_name == 'pygrb_plot_stats_distribution':
+        seg_filelist = FileList([resolve_url_to_file(sf) for sf in seg_files])
+        node.add_input_list_opt('--seg-files', seg_filelist)
         node.add_opt('--x-variable', tags[0])
     elif exec_name == 'pygrb_plot_injs_results':
         # Variables to plot on x and y axes
@@ -560,30 +562,36 @@ def make_pygrb_plot(workflow, exec_name, out_dir,
     return node, node.output_files
 
 
-def make_info_table(workflow, out_dir, tags=None):
-    """Setup a job to create an html snippet with the GRB trigger information.
+def make_info_table(workflow, exec_name, out_dir, in_files=None, tags=None):
+    """
+    Setup a job to create an html snippet with the GRB trigger information
+    or exlusion distances information.
     """
 
+    # Organize tags
     tags = [] if tags is None else tags
-
-    # Executable
-    exec_name = 'pygrb_grb_info_table'
+    grb_name = workflow.cp.get('workflow', 'trigger-name')
+    extra_tags = ['GRB'+grb_name]
 
     # Initialize job node
-    grb_name = workflow.cp.get('workflow', 'trigger-name')
-    extra_tags = ['GRB'+grb_name, 'INFO_TABLE']
     node = PlotExecutable(workflow.cp, exec_name,
                           ifos=workflow.ifos, out_dir=out_dir,
                           tags=tags+extra_tags).create_node()
 
     # Options
-    node.add_opt('--trigger-time', workflow.cp.get('workflow', 'trigger-time'))
-    node.add_opt('--ra', workflow.cp.get('workflow', 'ra'))
-    node.add_opt('--dec', workflow.cp.get('workflow', 'dec'))
-    node.add_opt('--sky-error', workflow.cp.get('workflow', 'sky-error'))
-    node.add_opt('--ifos', ' '.join(workflow.ifos))
+    if exec_name=='pygrb_grb_info_table':
+        node.add_opt('--trigger-time', workflow.cp.get('workflow', 'trigger-time'))
+        node.add_opt('--ra', workflow.cp.get('workflow', 'ra'))
+        node.add_opt('--dec', workflow.cp.get('workflow', 'dec'))
+        node.add_opt('--sky-error', workflow.cp.get('workflow', 'sky-error'))
+        node.add_opt('--ifos', ' '.join(workflow.ifos))
+    elif exec_name=='pygrb_exclusion_dist_table':
+        node.add_input_opt('--input-files', in_files)
+
+    # Output
     node.new_output_file_opt(workflow.analysis_time, '.html',
                              '--output-file', tags=extra_tags)
+
     # Add job node to workflow
     workflow += node
 

--- a/pycbc/workflow/grb_utils.py
+++ b/pycbc/workflow/grb_utils.py
@@ -560,7 +560,8 @@ def make_pygrb_plot(workflow, exec_name, out_dir,
     return node, node.output_files
 
 
-def make_info_table(workflow, exec_name, out_dir, in_files=None, tags=None):
+def make_pygrb_info_table(workflow, exec_name, out_dir, in_files=None,
+                          tags=None):
     """
     Setup a job to create an html snippet with the GRB trigger information
     or exlusion distances information.
@@ -578,11 +579,6 @@ def make_info_table(workflow, exec_name, out_dir, in_files=None, tags=None):
 
     # Options
     if exec_name == 'pygrb_grb_info_table':
-        node.add_opt('--trigger-time',
-                     workflow.cp.get('workflow', 'trigger-time'))
-        node.add_opt('--ra', workflow.cp.get('workflow', 'ra'))
-        node.add_opt('--dec', workflow.cp.get('workflow', 'dec'))
-        node.add_opt('--sky-error', workflow.cp.get('workflow', 'sky-error'))
         node.add_opt('--ifos', ' '.join(workflow.ifos))
     elif exec_name == 'pygrb_exclusion_dist_table':
         node.add_input_opt('--input-files', in_files)

--- a/pycbc/workflow/grb_utils.py
+++ b/pycbc/workflow/grb_utils.py
@@ -579,13 +579,14 @@ def make_info_table(workflow, exec_name, out_dir, in_files=None, tags=None):
                           tags=tags+extra_tags).create_node()
 
     # Options
-    if exec_name=='pygrb_grb_info_table':
-        node.add_opt('--trigger-time', workflow.cp.get('workflow', 'trigger-time'))
+    if exec_name == 'pygrb_grb_info_table':
+        node.add_opt('--trigger-time',
+                     workflow.cp.get('workflow', 'trigger-time'))
         node.add_opt('--ra', workflow.cp.get('workflow', 'ra'))
         node.add_opt('--dec', workflow.cp.get('workflow', 'dec'))
         node.add_opt('--sky-error', workflow.cp.get('workflow', 'sky-error'))
         node.add_opt('--ifos', ' '.join(workflow.ifos))
-    elif exec_name=='pygrb_exclusion_dist_table':
+    elif exec_name == 'pygrb_exclusion_dist_table':
         node.add_input_opt('--input-files', in_files)
 
     # Output


### PR DESCRIPTION
## Standard information about the request
This PR expands the scope of `make_info_table` so it can add jobs to the workflow for `pygrb_exclusion_dist_table` as well as `pygrb_grb_info_table`.

<!--- Some basic info about the change (delete as appropriate) -->
This is a: a new feature for PyGRB workflow generation.

<!--- What codes will this affect? (delete as apropriate)
This change affects: PyGRB

<!--- What code areas will this affect? (delete as apropriate) -->
This change allows to expand presentation of scientific output in PyGRB webpages

## Links to any issues or associated PRs
This change is the 3rd PR of a series started with https://github.com/gwastro/pycbc/pull/4872.

## Testing performed
As for the previous two PRs an example of a complete webpage is [here](https://ldas-jobs.ligo.caltech.edu/~francesco.pannarale/LVC/pygrb_aug2024_4/), but the full webpage will be reproducible only once all workflow changes are on master.

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
