### PR TITLE
make sure FD white_noise has the same length as asd

### DIFF
--- a/pycbc/noise/reproduceable.py
+++ b/pycbc/noise/reproduceable.py
@@ -171,7 +171,9 @@ def colored_noise(psd, start_time, end_time,
                          end_time + filter_duration,
                          seed=seed,
                          sample_rate=sample_rate)
+    # make sure FD white_noise has the same length as asd
     white_noise = white_noise.to_frequencyseries()
+    white_noise.resize(len(asd))
     # Here we color. Do not want to duplicate memory here though so use '*='
     white_noise *= asd*scale
     del asd


### PR DESCRIPTION
<!---
Please delete these comments when you submit the pull request

Please add a title which is a concise description of what you are doing,
e.g. 'Fix bug with numpy import in pycbc_coinc_findtrigs' or 'add high frequency sky location dependent response for long detectors'
-->

<!---
This is a brief template for making pull requests for PyCBC.
This is _not_ a proscriptive template - you can use a different style if you want.
Please do think about the questions posed here and whether the details will be useful to include in your PR
Please add sufficient details so that people looking back at the request with no context around the work can understand the changes.
To choose reviewers, please look at the git blame for the code you are changing (if applicable),
or discuss in the #pycbc-code channel of the gwastro slack.
Please add labels as appropriate
-->

<!-- TOP-LEVEL SUMMARY: Please provide a brief, one-or-two-sentence description of the PR here
-->

## Standard information about the request

<!--- Some basic info about the change (delete as appropriate) -->
This is a: bug fix

<!--- What codes will this affect? (delete as apropriate)
If you do not know which areas will be affected, please ask in the gwastro #pycbc-code slack
-->
This change affects: noise generation, inference

<!--- Notes about the effect of this change -->
This change will: avoid noise generation bug in some conor LISA PE examples

## Motivation
<!--- Describe why your changes are being made -->
I encountered the `len not match` issue in some LISA tests, not all of them:
```
2024-09-12T22:22:28.777+00:00 INFO : Making colored noise
2024-09-12T22:22:30.494+00:00 INFO : len(psd): 2211906
2024-09-12T22:22:30.649+00:00 INFO : len(asd): 2211906
2024-09-12T22:22:31.943+00:00 INFO : int(wn_dur * sample_rate) // 2 + 1: 2211906
2024-09-12T22:22:31.944+00:00 INFO : len(white_noise): 2211907
```

## Contents
<!--- Describe your changes, this doesn't need to be a line-by-line code change discussion,
but rather a general discussion of the methods chosen -->
Force resize the FD white_noise.

## Links to any issues or associated PRs
<!--- If this is fixing / working around an already-reported issue, please link to it here -->

## Testing performed
<!--- Describe tests for the code changes, either already performed or to be performed -->

## Additional notes
<!--- Anything which does not fit in the above sections -->

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
