### PR TITLE
Fix numpy scalar edge case bug

### DIFF
--- a/pycbc/io/hdf.py
+++ b/pycbc/io/hdf.py
@@ -49,7 +49,7 @@ class HGroup(h5py.Group):
         """
         Wrapper around h5py's create_dataset so that checksums are used
         """
-        if hasattr(data, 'dtype') and not data.dtype == object:
+        if isinstance(data, np.ndarray) and not data.dtype == object:
             kwds['fletcher32'] = True
         return h5py.Group.create_dataset(
             self,


### PR DESCRIPTION
Creating a dataset in HFile using a numpy scalar would pass this check as it has a dtype attribute, which isn't what we need here

## Standard information about the request

This is a bug fix
This change affects: the offline search, the live search, inference, PyGRB
This change changes nothing
This change has been proposed using the [contribution guidelines](https://github.com/gwastro/pycbc/blob/master/CONTRIBUTING.md)


## Motivation
Bug fix

## Links to any issues or associated PRs
This was causing problems in #4866

## Testing performed
None

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
