### PR TITLE
Update offline source probability for change to mchirp area

### DIFF
--- a/bin/pycbc_source_probability_offline
+++ b/bin/pycbc_source_probability_offline
@@ -27,8 +27,6 @@ parser.add_argument('--search-tag', required=True,
 parser.add_argument('--ifar-threshold', type=float, default=None,
                     help='Select only candidate events with IFAR '
                          'above threshold.')
-parser.add_argument('--include-mass-gap', action='store_true',
-                    help='Option to include the Mass Gap region.')
 mchirp_area.insert_args(parser)
 args = parser.parse_args()
 
@@ -87,7 +85,8 @@ for event in tqdm.trange(len(ifar)):
                        / sngl_snr[ifo][0][event] for ifo in ifos_event])
     probs = mchirp_area.calc_probabilities(mchirp[event], coinc_snr,
                                            min_eff_dist, mc_area_args)
-    if not args.include_mass_gap and "Mass Gap" in probs:
+    # We do not expect a mass gap entry, but just in case
+    if "Mass Gap" in probs:
         probs.pop("Mass Gap")
     ifo_names = ''.join(sorted(ifos_event))
     out_name = dir_path + '%s-%s-%i-1.json' % (ifo_names, args.search_tag,

--- a/bin/pycbc_source_probability_offline
+++ b/bin/pycbc_source_probability_offline
@@ -32,7 +32,7 @@ parser.add_argument('--include-mass-gap', action='store_true',
 mchirp_area.insert_args(parser)
 args = parser.parse_args()
 
-mc_area_args = mchirp_area.from_cli(args)
+mc_area_args = mchirp_area.from_cli(args, parser)
 
 if not args.include_mass_gap:
     mass_bdary = mc_area_args['mass_bdary']

--- a/bin/pycbc_source_probability_offline
+++ b/bin/pycbc_source_probability_offline
@@ -32,11 +32,6 @@ args = parser.parse_args()
 
 mc_area_args = mchirp_area.from_cli(args, parser)
 
-if not args.include_mass_gap:
-    mass_bdary = mc_area_args['mass_bdary']
-    assert mass_bdary['ns_max'] == mass_bdary['gap_max'], \
-           'NS/Mass Gap boundaries should be the same.'
-
 pycbc.init_logging(args.verbose)
 
 TRIGGER_FILE = args.trigger_file.split('/')[-1]

--- a/bin/pycbc_source_probability_offline
+++ b/bin/pycbc_source_probability_offline
@@ -87,7 +87,7 @@ for event in tqdm.trange(len(ifar)):
                        / sngl_snr[ifo][0][event] for ifo in ifos_event])
     probs = mchirp_area.calc_probabilities(mchirp[event], coinc_snr,
                                            min_eff_dist, mc_area_args)
-    if not args.include_mass_gap:
+    if not args.include_mass_gap and "Mass Gap" in probs:
         probs.pop("Mass Gap")
     ifo_names = ''.join(sorted(ifos_event))
     out_name = dir_path + '%s-%s-%i-1.json' % (ifo_names, args.search_tag,


### PR DESCRIPTION
Fix a from_cli bug and remove mass gap related options and code, as mass gap classification does not need to be supported for offline calculation

## Standard information about the request

<!--- Some basic info about the change (delete as appropriate) -->
This is a: bug fix

<!--- What codes will this affect? (delete as apropriate)
If you do not know which areas will be affected, please ask in the gwastro #pycbc-code slack
-->
This change affects: the offline search

<!--- What code areas will this affect? (delete as appropriate) -->
This change changes: ability to produce a scientific result vs no result

<!--- Some things which help with code management (delete as appropriate) -->
This change: follows style guidelines (See e.g. [PEP8](https://peps.python.org/pep-0008/))

<!--- Notes about the effect of this change -->
Bug fix

## Motivation
Offline source probability code fails to run as it was not updated for a module change

## Contents
Try to make it run

## Testing performed
To be tested by local install and attempting to run offline source probability

The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
