### PR TITLE
Set random seeds for fake noise in make_skymap example

### DIFF
--- a/examples/make_skymap/simulated_data.sh
+++ b/examples/make_skymap/simulated_data.sh
@@ -9,6 +9,10 @@ pycbc_make_skymap \
         H1:aLIGOMidLowSensitivityP1200087 \
         L1:aLIGOMidLowSensitivityP1200087 \
         V1:AdVEarlyHighSensitivityP1200087 \
+    --fake-strain-seed \
+        H1:1234 \
+        L1:2345 \
+        V1:3456 \
     --injection-file injections.hdf \
     --thresh-SNR 5.5 \
     --f-low 20 \


### PR DESCRIPTION
This modifies one of the examples of `pycbc_make_skymap` to make it clear that random seeds for fake noise must be set explicitly.

## Standard information about the request

This is a documentation enhancement.

This change affects one of the examples of `pycbc_make_skymap`.

## Motivation

When simulating noise on multiple detectors via `--fake-strain`, it is important to set different random seeds in different detectors, otherwise you will get the same noise realization in all detectors, which is usually *not* how you want to simulate noise!

The example of `pycbc_make_skymap` that uses simulated noise was not setting the seed explicitly, therefore implicitly using the same seed for all detectors. The resulting skymap *looks* correct visually, but this can lead to weird results when doing large simulations and checking the results statistically.

## Contents

In light of the issue described above, this PR adds explicit seeds to the example.

## Links to any issues or associated PRs

N/A

## Testing performed

Ran the example before and after this change and plotted the resulting SNR timeseries. Before, I get this:

![image](https://github.com/user-attachments/assets/76638baa-d62c-4db3-a12c-7ee504bad9b6)

After, I get this:

![image](https://github.com/user-attachments/assets/e8e66420-b9e6-4303-bdab-52d9853ed7b2)

Note the pattern of the noise fluctuations away from the central SNR peaks.

## Additional notes

Thanks to Nicolas and Clara for noticing this.

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
