### PR TITLE
add in altitude support and simplify adding detector function

### DIFF
--- a/pycbc/detector.py
+++ b/pycbc/detector.py
@@ -122,7 +122,7 @@ def add_detector_on_earth(name, longitude, latitude,
     resps = []
     vecs = []
     for angle, azi in [(yangle, yaltitude), (xangle, xaltitude)]:
-        rm0 = rotation_matrix(angle * units.rad , 'z')
+        rm0 = rotation_matrix(angle * units.rad, 'z')
         rmN = rotation_matrix(-azi *  units.rad, 'y')
         rm = rm2 @ rm1 @ rm0 @ rmN
         # apply rotation
@@ -191,11 +191,12 @@ def load_detector_config(config_files):
                              " {} are required".format(arg_names))
         method(det.upper(), *args, **kwds)
 
+
 # prepopulate using detectors hardcoded into lalsuite
 for pref, name in get_available_lal_detectors():
     lalsim = pycbc.libutils.import_optional('lalsimulation')
     lal_det = lalsim.DetectorPrefixToLALDetector(pref).frDetector
-    add_detector_on_earth(pref, 
+    add_detector_on_earth(pref,
                           lal_det.vertexLongitudeRadians,
                           lal_det.vertexLatitudeRadians,
                           height=lal_det.vertexElevation,

--- a/test/test_detector.py
+++ b/test/test_detector.py
@@ -54,6 +54,24 @@ class TestDetector(unittest.TestCase):
                 t2 = d1.light_travel_time_to_detector(d2)
                 self.assertAlmostEqual(t1, t2, 7)
 
+    def test_custom_detector(self):
+        det.add_detector_on_earth("TEST", 1.3, 0.5, yangle=0, xaltitude=0.01)
+        d = det.Detector("TEST")
+
+        # Check that we can call the new detector response
+        fp, fc = d.antenna_pattern(1.5, 1.0, 0, 1000000000)
+
+        # Check it interacts with existing detectors
+        d2 = det.Detector("H1")
+        t1 = d2.light_travel_time_to_detector(d)
+
+    def test_response_matrix(self):
+        import lal
+        for ifo in ['H1', 'L1', 'V1', 'K1', 'I1']:
+            ref_resp = lal.cached_detector_by_prefix[ifo].response
+            resp = det.Detector(ifo).response
+            self.assertAlmostEqual((ref_resp - resp).max(), 0, places=6)
+
     def test_antenna_pattern(self):
         vals = list(zip(self.ra, self.dec, self.pol, self.time))
         for ifo in self.d:


### PR DESCRIPTION
* Adds in the ability to set the altitude angles for custom detectors
* Simplify detector class, use lal only for its detector location information rather than the response value itself. This makes it easier to provide consistent metadata between custom and lal-builtin detectors
* Simplify the add detector on the earth function (use matrix multiplication operator, make the rotations clearer / more obvious / start rotations from simpler form of the basic arm response)

Todo
* update unittest to include both  use of custom detector and crosscheck response matrix calculation against builtin lal value