### PR TITLE
Fixing bug in input files check

### DIFF
--- a/bin/pygrb/pycbc_pygrb_page_tables
+++ b/bin/pygrb/pycbc_pygrb_page_tables
@@ -236,9 +236,10 @@ qf_h5_outfile = opts.quiet_found_injs_h5_output_file
 output_files = []
 
 # Check for correct input
-if [found_missed_file, onsource_file, offsource_file].count(None) != 2:
-    parser.error('Please provide one of --found-missed-file, ' +
-                 '--onsource-file, or --offsource-file.')
+if [found_missed_file, onsource_file].count(None) == 0:
+    parser.error('Please provide --found-missed-file to process injections, ' +
+                 '--onsource-file to process the on-source, or neither of ' +
+                 'them to process the off-source triggers.')
 # The user may process injections...
 elif found_missed_file is not None:
     output_files = [qf_outfile, mf_outfile, qf_h5_outfile]
@@ -251,7 +252,8 @@ elif onsource_file is not None:
     if None in output_files:
         parser.error('Please provide both on-source output files ' +
                      'when using --onsource-file.')
-# ...or triggers in the offsource (offsource_file is not None)
+# ...or triggers in the offsource
+# (both onsource_file and found_missed_file are None)
 else:
     output_files = [lofft_outfile, lofft_h5_outfile]
     if None in output_files:


### PR DESCRIPTION
Fix bug when checking user choices for input files.

## Standard information about the request

This is a: bug fix

This change affects: PyGRB

This change changes: result presentation

## Motivation
The `--offsource-file` option was set to `required=True` (as it should be), but then only one out of `--offsource-file`, `--onsource-file` and `--found-missed-file` was allowed to be passed, so the user could not process the onsource or the found/missed injections.

## Contents
The test is now ensuring that `--onsource-file` and `--found-missed-file` are not simultaneously given by the user.

## Testing performed
The change was tried in a full (re)post-post processing of [this box](https://ldas-jobs.ligo.caltech.edu/~francesco.pannarale/LVC/pygrb_aug2024_4/) giving [this new webpage](https://ldas-jobs.ligo.caltech.edu/~francesco.pannarale/LVC/pygrb_sep2024_1/).

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
