### PR TITLE
Fix nansum check in pygrb_efficiency

### DIFF
--- a/bin/pygrb/pycbc_pygrb_efficiency
+++ b/bin/pygrb/pycbc_pygrb_efficiency
@@ -624,10 +624,10 @@ ax.plot(dist_plot_vals, (fraction_no_mc), 'g-',
 ax.errorbar(dist_plot_vals, (fraction_no_mc),
             yerr=[yerr_low_no_mc, yerr_high_no_mc], c='green')
 marg_eff = fraction_mc
-if not np.nansum(marg_eff) > 0:
+if np.nansum(marg_eff) > 0:
     ax.plot(dist_plot_vals, marg_eff, 'r-', label='Marginalised')
     ax.errorbar(dist_plot_vals, marg_eff, yerr=[yerr_low, yerr_high], c='red')
-if not np.nansum(red_efficiency) > 0:
+if np.nansum(red_efficiency) > 0:
     ax.plot(dist_plot_vals, red_efficiency, 'm-',
             label='Inc. counting errors')
 ax.set_ylim([0, 1])


### PR DESCRIPTION
Fix bug introduce in PR #4812.

The previous PR for `pygrb_efficiency` soften a check by using `nansum(...)`.  However, in 2 out of 3 places `not nansum(...)` was used.

## Standard information about the request

This is a: bug fix.

This change affects: PyGRB

This change changes: plotting and scientific output (exclusion distances)

This change was tested in https://ldas-jobs.ligo.caltech.edu/~francesco.pannarale/LVC/pygrb_sep2024_2/5._exclusion_distances.

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
