### PR TITLE
Do not force pygrb_efficiency to produce all output: let the user decide

### DIFF
--- a/bin/pygrb/pycbc_pygrb_efficiency
+++ b/bin/pygrb/pycbc_pygrb_efficiency
@@ -98,11 +98,11 @@ parser.add_argument("-F", "--trig-file", action="store", required=True,
 parser.add_argument("--onsource-file", action="store",
                     help="Location of on-source trigger file (or a " +
                     "background trigger file to be treated as such).")
-parser.add_argument("--background-output-file", required=True,
+parser.add_argument("--background-output-file",
                     help="Detection efficiency output file.")
-parser.add_argument("--onsource-output-file", required=True,
+parser.add_argument("--onsource-output-file",
                     help="Exclusion distance output file.")
-parser.add_argument("--exclusion-dist-output-file", required=True,
+parser.add_argument("--exclusion-dist-output-file",
                     help="JSON file containing exclusion distances.")
 parser.add_argument("-g", "--glitch-check-factor", action="store",
                     type=float, default=1.0, help="When deciding " +
@@ -132,8 +132,15 @@ init_logging(opts.verbose, format="%(asctime)s: %(levelname)s: %(message)s")
 # Load bank file
 bank_file = HFile(opts.bank_file, 'r')
 
+# Check options
+if opts.exclusion_dist_output_file is not None or \
+    opts.onsource_output_file is not None:
+    if opts.onsource_file is None:
+        logging.error("Requesting the --exclusion-dist-output-file or the " +
+                      "--onsource-output-file requires the --onsource-file " +
+                      "as nput.")
+
 # Store options used multiple times in local variables
-outdir = os.path.split(os.path.abspath(opts.background_output_file))[0]
 trig_file = opts.trig_file
 onsource_file = opts.onsource_file
 found_missed_file = opts.found_missed_file
@@ -164,10 +171,15 @@ num_mc_injs = opts.num_mc_injections
 np.random.seed(opts.seed)
 logging.info("Setting random seed to %d.", opts.seed)
 
-# Set output directory
-logging.info("Setting output directory.")
-if not os.path.isdir(outdir):
-    os.makedirs(outdir)
+# Set output directories
+outdir = None
+for output_file in [opts.exclusion_dist_output_file,
+    opts.background_output_file, opts.onsource_output_file]:
+    if output_file is not None:
+        logging.info("Setting output directory.")
+        outdir = os.path.split(os.path.abspath(output_file))[0]
+        if not os.path.isdir(outdir):
+            os.makedirs(outdir)
 
 # Extract IFOs and vetoes
 ifos, vetoes = ppu.extract_ifos_and_vetoes(trig_file, opts.veto_files,
@@ -544,31 +556,32 @@ else:
     sens_dist = d + (e - 0.5) * (d - d_low) / (e_low - e)
 
 # Plot efficiency using loudest background
-fig = plt.figure()
-ax = fig.gca()
-ax.plot(dist_plot_vals, (fraction_no_mc), 'g-',
-        label='No marginalisation')
-ax.errorbar(dist_plot_vals, (fraction_no_mc),
-            yerr=[yerr_low_no_mc, yerr_high_no_mc], c='green')
-marg_eff = fraction_mc
-if np.nansum(marg_eff) > 0:
-    ax.plot(dist_plot_vals, marg_eff, 'r-', label='Marginalised')
-    ax.errorbar(dist_plot_vals, marg_eff, yerr=[yerr_low_mc, yerr_high_mc],
-                c='red')
-ax.legend()
-ax.grid()
-ax.set_ylim([0, 1])
-ax.set_xlim(0, 2.*upper_dist - lower_dist)
-ax.set_ylabel("Fraction of injections found louder than loudest background")
-ax.set_xlabel("Distance (Mpc)")
-plot_title = "Detection efficiency - "+inj_set_name
-plot_caption = "Injection recovery efficiency using "
-plot_caption += "BestNR as detection statistic.  "
-plot_caption += "Injections louder than loudest background trigger."
-fig_path = opts.background_output_file
-save_fig_with_metadata(fig, fig_path, cmd=' '.join(sys.argv),
-                       title=plot_title, caption=plot_caption)
-plt.close()
+if opts.background_output_file:
+    fig = plt.figure()
+    ax = fig.gca()
+    ax.plot(dist_plot_vals, (fraction_no_mc), 'g-',
+            label='No marginalisation')
+    ax.errorbar(dist_plot_vals, (fraction_no_mc),
+                yerr=[yerr_low_no_mc, yerr_high_no_mc], c='green')
+    marg_eff = fraction_mc
+    if np.nansum(marg_eff) > 0:
+        ax.plot(dist_plot_vals, marg_eff, 'r-', label='Marginalised')
+        ax.errorbar(dist_plot_vals, marg_eff, yerr=[yerr_low_mc, yerr_high_mc],
+                    c='red')
+    ax.legend()
+    ax.grid()
+    ax.set_ylim([0, 1])
+    ax.set_xlim(0, 2.*upper_dist - lower_dist)
+    ax.set_ylabel("Fraction of injections found louder than loudest background")
+    ax.set_xlabel("Distance (Mpc)")
+    plot_title = "Detection efficiency - "+inj_set_name
+    plot_caption = "Injection recovery efficiency using "
+    plot_caption += "BestNR as detection statistic.  "
+    plot_caption += "Injections louder than loudest background trigger."
+    fig_path = opts.background_output_file
+    save_fig_with_metadata(fig, fig_path, cmd=' '.join(sys.argv),
+                           title=plot_title, caption=plot_caption)
+    plt.close()
 
 # Calculate error bars for efficiency/distance plots and datafiles
 # using max BestNR of foreground
@@ -607,51 +620,53 @@ for percentile in [50, 90]:
 
 # Write 50% and 90% exclusion distances to JSON file
 # Also include injection set name and trial name
-excl_dist_dict = {}
-excl_dist_dict['inj_set'] = inj_set_name
-excl_dist_dict['trial_name'] = opts.trial_name
-excl_dist_dict['50%'] = sens_dist
-excl_dist_dict['90%'] = excl_dist
-with open(opts.exclusion_dist_output_file, 'w') as excl_dist_file:
-    json.dump(excl_dist_dict, excl_dist_file)
+if opts.exclusion_dist_output_file:
+    excl_dist_dict = {}
+    excl_dist_dict['inj_set'] = inj_set_name
+    excl_dist_dict['trial_name'] = opts.trial_name
+    excl_dist_dict['50%'] = sens_dist
+    excl_dist_dict['90%'] = excl_dist
+    with open(opts.exclusion_dist_output_file, 'w') as excl_dist_file:
+        json.dump(excl_dist_dict, excl_dist_file)
 
 # Plot efficiency using loudest foreground
-fig = plt.figure()
-ax = fig.gca()
-ax.grid()
-ax.plot(dist_plot_vals, (fraction_no_mc), 'g-',
-        label='No marginalisation')
-ax.errorbar(dist_plot_vals, (fraction_no_mc),
-            yerr=[yerr_low_no_mc, yerr_high_no_mc], c='green')
-marg_eff = fraction_mc
-if np.nansum(marg_eff) > 0:
-    ax.plot(dist_plot_vals, marg_eff, 'r-', label='Marginalised')
-    ax.errorbar(dist_plot_vals, marg_eff, yerr=[yerr_low, yerr_high], c='red')
-if np.nansum(red_efficiency) > 0:
-    ax.plot(dist_plot_vals, red_efficiency, 'm-',
-            label='Inc. counting errors')
-ax.set_ylim([0, 1])
-ax.grid()
-ax.legend()
-ax.get_legend().get_frame().set_alpha(0.5)
-ax.grid()
-ax.set_ylim([0, 1])
-ax.set_xlim(0, 2.*upper_dist - lower_dist)
-ax.set_ylabel("Fraction of injections found louder than "+\
-              "loudest foreground")
-ax.set_xlabel("Distance (Mpc)")
-ax.plot([excl_dist], [0.9], 'gx')
-ax.set_ylim([0, 1])
-ax.set_xlim(0, 2.*upper_dist - lower_dist)
-plot_title = "Exclusion distance - "+inj_set_name
-plot_caption = "Injection recovery efficiency using "
-plot_caption += "BestNR as detection statistic.  "
-plot_caption += "Injections louder than loudest foreground trigger.\n"
-plot_caption += f" 90%% exclusion distance: {excl_dist} Mpc\n"
-plot_caption += f" 50%% sensitive distance: {sens_dist} Mpc"
-fig_path = opts.onsource_output_file
-save_fig_with_metadata(fig, fig_path, cmd=' '.join(sys.argv),
-                       title=plot_title, caption=plot_caption)
-plt.close()
+if opts.onsource_output_file:
+    fig = plt.figure()
+    ax = fig.gca()
+    ax.grid()
+    ax.plot(dist_plot_vals, (fraction_no_mc), 'g-',
+            label='No marginalisation')
+    ax.errorbar(dist_plot_vals, (fraction_no_mc),
+                yerr=[yerr_low_no_mc, yerr_high_no_mc], c='green')
+    marg_eff = fraction_mc
+    if np.nansum(marg_eff) > 0:
+        ax.plot(dist_plot_vals, marg_eff, 'r-', label='Marginalised')
+        ax.errorbar(dist_plot_vals, marg_eff, yerr=[yerr_low, yerr_high], c='red')
+    if np.nansum(red_efficiency) > 0:
+        ax.plot(dist_plot_vals, red_efficiency, 'm-',
+                label='Inc. counting errors')
+    ax.set_ylim([0, 1])
+    ax.grid()
+    ax.legend()
+    ax.get_legend().get_frame().set_alpha(0.5)
+    ax.grid()
+    ax.set_ylim([0, 1])
+    ax.set_xlim(0, 2.*upper_dist - lower_dist)
+    ax.set_ylabel("Fraction of injections found louder than "+\
+                  "loudest foreground")
+    ax.set_xlabel("Distance (Mpc)")
+    ax.plot([excl_dist], [0.9], 'gx')
+    ax.set_ylim([0, 1])
+    ax.set_xlim(0, 2.*upper_dist - lower_dist)
+    plot_title = "Exclusion distance - "+inj_set_name
+    plot_caption = "Injection recovery efficiency using "
+    plot_caption += "BestNR as detection statistic.  "
+    plot_caption += "Injections louder than loudest foreground trigger.\n"
+    plot_caption += f" 90%% exclusion distance: {excl_dist} Mpc\n"
+    plot_caption += f" 50%% sensitive distance: {sens_dist} Mpc"
+    fig_path = opts.onsource_output_file
+    save_fig_with_metadata(fig, fig_path, cmd=' '.join(sys.argv),
+                           title=plot_title, caption=plot_caption)
+    plt.close()
 
-logging.info("Plots complete.")
+logging.info("Done.")

--- a/bin/pygrb/pycbc_pygrb_efficiency
+++ b/bin/pygrb/pycbc_pygrb_efficiency
@@ -69,7 +69,7 @@ def efficiency_with_errs(found_bestnr, num_injections, num_mc_injs=0):
     err_common = all_injs * (2 * only_found_injs + 1)
     err_denom = 2 * all_injs * (all_injs + 1)
     err_vary = 4 * all_injs * only_found_injs * (all_injs - only_found_injs) \
-                + all_injs**2
+        + all_injs**2
     err_vary = err_vary**0.5
     err_low = (err_common - err_vary)/err_denom
     err_low_mc = fraction - err_low
@@ -174,11 +174,11 @@ logging.info("Setting random seed to %d.", opts.seed)
 # Set output directories
 outdir = None
 for output_file in [opts.exclusion_dist_output_file,
-    opts.background_output_file, opts.onsource_output_file]:
+                    opts.background_output_file, opts.onsource_output_file]:
     if output_file is not None:
-        logging.info("Setting output directory.")
         outdir = os.path.split(os.path.abspath(output_file))[0]
         if not os.path.isdir(outdir):
+            logging.info("Creating the output directoryi %s.", outdir)
             os.makedirs(outdir)
 
 # Extract IFOs and vetoes
@@ -190,7 +190,7 @@ logging.info("Loading triggers.")
 trigs = ppu.load_triggers(trig_file, ifos, vetoes,
                           rw_snr_threshold=opts.newsnr_threshold)
 logging.info("%d offsource triggers surviving reweighted SNR cut.",
-    len(trigs['network/event_id']))
+             len(trigs['network/event_id']))
 logging.info("Loading timeslides.")
 slide_dict = ppu.load_time_slides(trig_file)
 logging.info("Loading segments.")
@@ -223,7 +223,7 @@ for slide_id in slide_dict:
             continue
         # Max BestNR
         time_veto_max_bestnr[slide_id][j] = \
-                        max(trig_bestnr[slide_id][trial_cut])
+            max(trig_bestnr[slide_id][trial_cut])
 
 logging.info("SNR and bestNR maxima calculated.")
 
@@ -242,7 +242,8 @@ offsource_trigs.reverse()
 # and loudest SNR, so could just add this to the above's caption.
 # ==========================
 max_bestnr, _, full_time_veto_max_bestnr =\
-    ppu.max_median_stat(slide_dict, time_veto_max_bestnr, trig_bestnr, total_trials)
+    ppu.max_median_stat(slide_dict, time_veto_max_bestnr, trig_bestnr,
+                        total_trials)
 
 # ==========================
 # Calculate template chirp masses from bank
@@ -364,7 +365,8 @@ f_resp = {}
 for ifo in ifos:
     antenna = Detector(ifo)
     f_resp[ifo] = ppu.get_antenna_responses(antenna,
-                                            injs['found/ra'][:], injs['found/dec'][:],
+                                            injs['found/ra'][:],
+                                            injs['found/dec'][:],
                                             injs['found/tc'][:])
 
 inj_sigma_mult = (np.asarray(list(inj_sigma.values())) *
@@ -386,16 +388,16 @@ logging.info("%d missed injections analysed.", len(injs['missed/tc']))
 # Create new set of injections for efficiency calculations
 total_injs = len(injs['found/distance']) + len(injs['missed/distance'])
 long_inj = {}
-long_inj['dist'] = stats.uniform.rvs(size=total_injs) * (upper_dist-lower_dist) +\
-                   upper_dist
+long_inj['dist'] = stats.uniform.rvs(size=total_injs) * \
+    (upper_dist-lower_dist) + upper_dist
 
 logging.info("%d long distance injections created.", total_injs)
 
 # Set distance bins and data arrays
 dist_bins = zip(np.arange(lower_dist, upper_dist + (upper_dist-lower_dist),
-                         (upper_dist-lower_dist)/num_bins),
+                          (upper_dist-lower_dist)/num_bins),
                 np.arange(lower_dist, upper_dist + (upper_dist-lower_dist),
-                         (upper_dist-lower_dist)/num_bins) +
+                          (upper_dist-lower_dist)/num_bins) +
                          (upper_dist-lower_dist)/num_bins)
 dist_bins = list(dist_bins)
 
@@ -433,9 +435,9 @@ logging.info("Calibration amplitude uncertainty calculated.")
 # same time, so filling them up sequentially will vary the numbers a little
 # (this is an MC, order of operations matters!)
 found_inj_dist_mc = ppu.mc_cal_wf_errs(num_mc_injs, injs['found/distance'],
-                                          cal_error, wav_err, max_dc_cal_error)
+                                       cal_error, wav_err, max_dc_cal_error)
 missed_inj_dist_mc = ppu.mc_cal_wf_errs(num_mc_injs, injs['missed/distance'],
-                                           cal_error, wav_err, max_dc_cal_error)
+                                        cal_error, wav_err, max_dc_cal_error)
 long_inj['dist_mc'] = ppu.mc_cal_wf_errs(num_mc_injs, long_inj['dist'],
                                          cal_error, wav_err, max_dc_cal_error)
 
@@ -472,10 +474,10 @@ found_excl = on_bestnr_cut & (more_sig_than_onsource) & \
 # If not missed, double check bestnr against nearby triggers
 near_test = np.zeros((found_excl).sum()).astype(bool)
 for j, (t, bestnr) in enumerate(zip(injs['found/tc'][found_excl],
-                                    injs['network/reweighted_snr'][found_excl])):
+                                injs['network/reweighted_snr'][found_excl])):
     # 0 is the zero-lag timeslide
-    near_bestnr = trig_bestnr[0]\
-                  [np.abs(trig_time[0]-t) < cluster_window]
+    near_bestnr = \
+        trig_bestnr[0][np.abs(trig_time[0]-t) < cluster_window]
     near_test[j] = ~((near_bestnr * glitch_check_fac > bestnr).any())
 # Apply the local test
 c = 0
@@ -533,7 +535,7 @@ dist_plot_vals = [np.asarray(dist_bin).mean() for dist_bin in dist_bins]
 # using max BestNR of background
 yerr_low_mc, yerr_high_mc, fraction_mc = efficiency_with_errs(
      found_max_bestnr['mc'], num_injections['mc'], num_mc_injs=num_mc_injs)
-yerr_low_no_mc, yerr_high_no_mc, fraction_no_mc = efficiency_with_errs(\
+yerr_low_no_mc, yerr_high_no_mc, fraction_no_mc = efficiency_with_errs(
                            found_max_bestnr['no_mc'], num_injections['no_mc'])
 
 # Calculate and save to disk the 50% sensitive distance
@@ -585,10 +587,11 @@ if opts.background_output_file:
 
 # Calculate error bars for efficiency/distance plots and datafiles
 # using max BestNR of foreground
-yerr_low_no_mc, yerr_high_no_mc, fraction_no_mc = efficiency_with_errs(\
+yerr_low_no_mc, yerr_high_no_mc, fraction_no_mc = efficiency_with_errs(
                             found_on_bestnr['no_mc'], num_injections['no_mc'])
-yerr_low, yerr_high, fraction_mc = efficiency_with_errs(found_on_bestnr['mc'],\
-                                 num_injections['mc'], num_mc_injs=num_mc_injs)
+yerr_low, yerr_high, fraction_mc = \
+    efficiency_with_errs(found_on_bestnr['mc'], num_injections['mc'],
+                         num_mc_injs=num_mc_injs)
 
 # Marginalized efficiency (isf = inverse survival function)
 red_efficiency = (fraction_mc) - (yerr_low) * scipy.stats.norm.isf(0.1)
@@ -609,7 +612,7 @@ for percentile in [50, 90]:
         e = excl_efficiency[i]
         e_low = excl_efficiency[i-1]
         excl_dist = d + (e - (percentile / 100.)) * (d - d_low) /\
-                (e_low - e)
+            (e_low - e)
     else:
         # Warn the user if the exclusion distance cannot be established,
         # but let the workflow continue: the user will see the plot(s) and
@@ -641,7 +644,8 @@ if opts.onsource_output_file:
     marg_eff = fraction_mc
     if np.nansum(marg_eff) > 0:
         ax.plot(dist_plot_vals, marg_eff, 'r-', label='Marginalised')
-        ax.errorbar(dist_plot_vals, marg_eff, yerr=[yerr_low, yerr_high], c='red')
+        ax.errorbar(dist_plot_vals, marg_eff, yerr=[yerr_low, yerr_high],
+                    c='red')
     if np.nansum(red_efficiency) > 0:
         ax.plot(dist_plot_vals, red_efficiency, 'm-',
                 label='Inc. counting errors')
@@ -652,7 +656,7 @@ if opts.onsource_output_file:
     ax.grid()
     ax.set_ylim([0, 1])
     ax.set_xlim(0, 2.*upper_dist - lower_dist)
-    ax.set_ylabel("Fraction of injections found louder than "+\
+    ax.set_ylabel("Fraction of injections found louder than " +
                   "loudest foreground")
     ax.set_xlabel("Distance (Mpc)")
     ax.plot([excl_dist], [0.9], 'gx')


### PR DESCRIPTION
This PR allows the user to choose which output files (if any) `pygrb_efficiency` must produce.

## Standard information about the request
This is adds flexibility to an existing post-processing script.

This change affects: PyGRB

This change changes: the ability to specifiy what plots and tables `pygrb_efficiency` must create.

## Motivation
There is no need for post-processing scripts to produce all the output they can possibly produce.  The user may or may not need all outputs when calling a script.

## Contents
`pygrb_efficiency` can produce three outputs so the lines to produce them are now encapsulated in three `if`s.

Additionally, the code makes sure that all input files necessary to produce the requested output files are passed.

## Testing performed
All plots in sections 5 and 6.02 of [this webpage](https://ldas-jobs.ligo.caltech.edu/~francesco.pannarale/LVC/pygrb_sep2024_2/) were made with this updated version of `pygrb_efficiency`.

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
