### PR TITLE
add zero-noise PE example for LISA

### DIFF
--- a/examples/inference/lisa_smbhb_inj/lisa_smbhb_relbin.ini
+++ b/examples/inference/lisa_smbhb_inj/lisa_smbhb_relbin.ini
@@ -52,8 +52,7 @@ tc =
 
 [static_params]
 ; Change it to "ref_frame = SSB", if you use SSB frame in injection file.
-; ref_frame = LISA
-ref_frame = SSB
+ref_frame = LISA
 approximant = BBHX_PhenomD
 ; You can use "1.5" or "2.0" for TDI.
 ; Please use the same TDI version for PSD and injection file.

--- a/examples/inference/lisa_smbhb_inj/lisa_smbhb_relbin.ini
+++ b/examples/inference/lisa_smbhb_inj/lisa_smbhb_relbin.ini
@@ -5,6 +5,10 @@ analysis-start-time = -4800021
 analysis-end-time = 26735979
 pad-data = 0
 sample-rate = 0.2
+channel-name = LISA_A:LISA_A LISA_E:LISA_E LISA_T:LISA_T
+injection-file = injection_smbhb.hdf
+
+; with noise simulation
 fake-strain = LISA_A:analytical_psd_lisa_tdi_AE LISA_E:analytical_psd_lisa_tdi_AE LISA_T:analytical_psd_lisa_tdi_T
 ; fake-strain-extra-args = LISA_A:len_arm:2.5e9 LISA_A:acc_noise_level:2.4e-15 LISA_A:oms_noise_level:7.9e-12 LISA_A:tdi:1.5 LISA_E:len_arm:2.5e9 LISA_E:acc_noise_level:2.4e-15 LISA_E:oms_noise_level:7.9e-12 LISA_E:tdi:1.5 LISA_T:len_arm:2.5e9 LISA_T:acc_noise_level:2.4e-15 LISA_T:oms_noise_level:7.9e-12 LISA_T:tdi:1.5
 fake-strain-extra-args = len_arm:2.5e9 acc_noise_level:2.4e-15 oms_noise_level:7.9e-12 tdi:1.5
@@ -19,8 +23,16 @@ psd-segment-length = 267840
 psd-segment-stride = 133920
 psd-start-time = -4800021
 psd-end-time = 26735979
-channel-name = LISA_A:LISA_A LISA_E:LISA_E LISA_T:LISA_T
-injection-file = injection_smbhb.hdf
+
+; ; zero noise simulation, but still use PSD in likelihood
+; ; when using zero noise, please comment out above "with noise simulation" block and uncomment out this block
+; fake-strain = zeroNoise
+; fake-strain-flow = 0.0001
+; fake-strain-sample-rate = 0.2
+; fake-strain-filter-duration = 31536000
+; psd-model = LISA_A:analytical_psd_lisa_tdi_AE LISA_E:analytical_psd_lisa_tdi_AE LISA_T:analytical_psd_lisa_tdi_T
+; ; psd-extra-args = LISA_A:len_arm:2.5e9 LISA_A:acc_noise_level:2.4e-15 LISA_A:oms_noise_level:7.9e-12 LISA_A:tdi:1.5 LISA_E:len_arm:2.5e9 LISA_E:acc_noise_level:2.4e-15 LISA_E:oms_noise_level:7.9e-12 LISA_E:tdi:1.5 LISA_T:len_arm:2.5e9 LISA_T:acc_noise_level:2.4e-15 LISA_T:oms_noise_level:7.9e-12 LISA_T:tdi:1.5
+; psd-extra-args = len_arm:2.5e9 acc_noise_level:2.4e-15 oms_noise_level:7.9e-12 tdi:1.5
 
 [model]
 name = relative
@@ -40,7 +52,8 @@ tc =
 
 [static_params]
 ; Change it to "ref_frame = SSB", if you use SSB frame in injection file.
-ref_frame = LISA
+; ref_frame = LISA
+ref_frame = SSB
 approximant = BBHX_PhenomD
 ; You can use "1.5" or "2.0" for TDI.
 ; Please use the same TDI version for PSD and injection file.


### PR DESCRIPTION
<!---
Please delete these comments when you submit the pull request

Please add a title which is a concise description of what you are doing,
e.g. 'Fix bug with numpy import in pycbc_coinc_findtrigs' or 'add high frequency sky location dependent response for long detectors'
-->

<!---
This is a brief template for making pull requests for PyCBC.
This is _not_ a proscriptive template - you can use a different style if you want.
Please do think about the questions posed here and whether the details will be useful to include in your PR
Please add sufficient details so that people looking back at the request with no context around the work can understand the changes.
To choose reviewers, please look at the git blame for the code you are changing (if applicable),
or discuss in the #pycbc-code channel of the gwastro slack.
Please add labels as appropriate
-->

<!-- TOP-LEVEL SUMMARY: Please provide a brief, one-or-two-sentence description of the PR here
-->

## Standard information about the request

<!--- Some basic info about the change (delete as appropriate) -->
This is a: doc update

<!--- What codes will this affect? (delete as apropriate)
If you do not know which areas will be affected, please ask in the gwastro #pycbc-code slack
-->
This change affects: inference, doc

<!--- What code areas will this affect? (delete as apropriate) -->
This change changes: documentation

## Motivation
<!--- Describe why your changes are being made -->
In the current PyCBC Doc, it seems there are no `zeroNoise` examples for PE. Also, someone asked how to perform LISA PE with zero noise injection while still passing extra arguments to PSD functions in the likelihood calculation.

## Contents
<!--- Describe your changes, this doesn't need to be a line-by-line code change discussion,
but rather a general discussion of the methods chosen -->
Add code to show how to use `psd-extra-args` with `psd-model`, when `fake-strain = zeroNoise`.

## Testing performed
<!--- Describe tests for the code changes, either already performed or to be performed -->
`zero noise`
![lisa_smbhb_mass_tc](https://github.com/user-attachments/assets/ae33e501-647e-4378-8ac9-361af80fdcf9)
`noise`
![lisa_smbhb_mass_tc_noise](https://github.com/user-attachments/assets/6f5d2744-775f-4929-af76-8fb20c444469)

## Additional notes
<!--- Anything which does not fit in the above sections -->

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
