### PR TITLE
always save the latest lognl in the demargin hdf

### DIFF
--- a/bin/inference/pycbc_inference_model_stats
+++ b/bin/inference/pycbc_inference_model_stats
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/work/shichao.wu/anaconda3/envs/bbhx_env/bin/python3.9
 
 # Copyright (C) 2020 Collin Capano
 #
@@ -17,8 +17,9 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 """Recalculates log likelihood and prior for points in a given inference or
-posterior file and writes them to a new file. Also records auxillary model
-stats that may have been ignored by the sampler.
+posterior file and writes them to a new file, overwrites all lognl in the
+samples group attrs. Also records auxillary model stats that may have been
+ignored by the sampler.
 """
 
 import os
@@ -92,20 +93,33 @@ model = models.read_from_config(cp)
 # from the variable parameter space
 model.sampling_transforms = None
 
-# create function for calling the model to get the stats
+# create function for calling the model to get the stats, lognl, and rec
 def callmodel(arg):
     iteration, paramvals = arg
     # calculate the logposterior to get all stats populated
     model.update(**{p: paramvals[p] for p in model.variable_params})
     _ = model.logposterior
     stats = model.get_current_stats()
+    if hasattr(model, 'submodels'):
+        lognls = {}
+        lognls['lognl'] = 0
+        for lbl, submodel in model.submodels.items():
+            submodel_lognl = 0
+            for det in submodel.detectors:
+                lognls['{}__{}_lognl'.format(lbl, det)] =\
+                    submodel.det_lognl(det)
+                submodel_lognl += submodel.det_lognl(det)
+            lognls['{}__lognl'.format(lbl)] = submodel_lognl
+            lognls['lognl'] += submodel_lognl
+    else:
+        lognls = {det: model.det_lognl(det) for det in model.detectors}
 
     rec = {}
     if opts.reconstruct_parameters:
         model.update(**{p: paramvals[p] for p in model.variable_params})
         # Ensure unique random seed for each reconstruction
         rec = model.reconstruct(seed=iteration)
-    return stats, rec
+    return stats, lognls, rec
 
 # these help for parallelization for MPI
 models._global_instance = callmodel
@@ -132,18 +146,29 @@ logging.info("Calculating stats")
 data = list(tqdm.tqdm(pool.imap(model_call, enumerate(samples)),
             total=len(samples)))
 stats = [x[0] for x in data]
-rec = [x[1] for x in data]
+lognls = [x[1] for x in data][0]
+rec = [x[2] for x in data]
 
 # write to the output file
 logging.info("Copying input to output")
 shutil.copy(opts.input_file, opts.output_file)
 
-logging.info("Writing stats to output")
+logging.info("Writing stats, lognls, and rec to output")
 out = loadfile(opts.output_file, 'a')
 idx = range(len(stats))
 for pi, p in enumerate(model.default_stats):
     vals = numpy.array([stats[ii][pi] for ii in idx]).reshape(shape)
     out.write_data(p, vals, path=fp.samples_group, append=False)
+
+# overwrite all lognl in the samples attrs, there is a precision issue
+# in lognl calculation, during reconstruct process, model will get slightly
+# different lognl and loglr values (so loglikelihood). This becomes a problem
+# when loglr is very small compared to lognl, which numerical precision is
+# domainted by lognl. If still use the original lognl before the reconstruct
+# process, pycbc_inference_plot_posterior will get wrong loglr/snr for plotting
+for key in out['samples'].attrs:
+    if key in lognls:
+        out['samples'].attrs[key] = lognls[key]
 
 if opts.reconstruct_parameters:
     logging.info("Writing reconstructed parameters")

--- a/bin/inference/pycbc_inference_model_stats
+++ b/bin/inference/pycbc_inference_model_stats
@@ -1,4 +1,4 @@
-#! /user/bin/env python
+#!/user/bin/env python
 
 # Copyright (C) 2020 Collin Capano
 #

--- a/bin/inference/pycbc_inference_model_stats
+++ b/bin/inference/pycbc_inference_model_stats
@@ -1,4 +1,4 @@
-#!/work/shichao.wu/anaconda3/envs/bbhx_env/bin/python3.9
+#! /user/bin/env python
 
 # Copyright (C) 2020 Collin Capano
 #

--- a/bin/inference/pycbc_inference_model_stats
+++ b/bin/inference/pycbc_inference_model_stats
@@ -1,4 +1,4 @@
-#!/user/bin/env python
+#!/usr/bin/env python
 
 # Copyright (C) 2020 Collin Capano
 #


### PR DESCRIPTION
<!---
Please delete these comments when you submit the pull request

Please add a title which is a concise description of what you are doing,
e.g. 'Fix bug with numpy import in pycbc_coinc_findtrigs' or 'add high frequency sky location dependent response for long detectors'
-->

<!---
This is a brief template for making pull requests for PyCBC.
This is _not_ a proscriptive template - you can use a different style if you want.
Please do think about the questions posed here and whether the details will be useful to include in your PR
Please add sufficient details so that people looking back at the request with no context around the work can understand the changes.
To choose reviewers, please look at the git blame for the code you are changing (if applicable),
or discuss in the #pycbc-code channel of the gwastro slack.
Please add labels as appropriate
-->

<!-- TOP-LEVEL SUMMARY: Please provide a brief, one-or-two-sentence description of the PR here
-->

## Standard information about the request

<!--- Some basic info about the change (delete as appropriate) -->
This is a: bug fix,

<!--- What codes will this affect? (delete as apropriate)
If you do not know which areas will be affected, please ask in the gwastro #pycbc-code slack
-->
This change affects: inference

<!--- What code areas will this affect? (delete as apropriate) -->
This change changes: result presentation / plotting, scientific output

<!--- Notes about the effect of this change -->
This change will: nothing

## Motivation
<!--- Describe why your changes are being made -->
There is a precision issue in lognl calculation, during reconstruct process, model will get slightly different lognl and loglr values (so loglikelihood). This becomes a problem when loglr is very small compared to lognl, which numerical precision is domainted by lognl. If still use the original lognl before the reconstruct process, `pycbc_inference_plot_posterior` will get wrong loglr/snr for plotting.

## Contents
<!--- Describe your changes, this doesn't need to be a line-by-line code change discussion,
but rather a general discussion of the methods chosen -->
Save the latest `lognl` into the demargin hdf file.

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)