### PR TITLE
Tables and minifollowups in PyGRB

### DIFF
--- a/bin/pygrb/pycbc_pygrb_pp_workflow
+++ b/bin/pygrb/pycbc_pygrb_pp_workflow
@@ -415,13 +415,29 @@ for inj_set in inj_sets:
                 # take [0]
                 files.append(output_files[0])
     # Generate quiet-found and missed-found html tables
-    # TODO:  pass loudest-onsource-trigger/loudest-offsource-triggers
-    # arguments if inj_set=None
-    inj_layout = list(layout.grouper(files, 2))
+    html_node, [mf_table, qf_table, qf_h5] = \
+        _workflow.make_pygrb_injs_tables(wflow, out_dir, bank_file,
+                                         offsource_file, seg_files,
+                                         inj_file=inj_file,
+                                         tags=inj_file.tags)
+    html_nodes.append(html_node)
+
+    inj_layout = list(layout.grouper(files, 2)) + [(mf_table,), (qf_table,)]
     layout.two_column_layout(out_dir, inj_layout)
 
-    # TODO: Follow up of loudest N quiet-found injections:
-
+    # Follow up of loudest N quiet/missed-found injections:
+    # qf_h5 includes quiet and missed found injections
+    out_dir = rdir['injections/'+inj_set+'loudest_quiet_found_followups']
+    if not wflow.cp.has_section('workflow-minifollowups'):
+        msg = 'No [workflow-minifollowups] section found in '
+        msg += 'configuration file'
+        logging.info(msg)
+    else:
+        logging.info('Entering minifollowups module for injections')
+        _workflow.setup_pygrb_minifollowups(
+            wflow, qf_h5, offsource_file, 'daxes', out_dir,
+            tags=inj_file.tags+['loudest_quiet_found_injs'])
+        logging.info('Leaving minifollowups')
 
 #
 # FAP distributions
@@ -441,7 +457,27 @@ for stat in stats:
     # pycbc_pygrb_plot_stats_distribution produces only one plot: take [0]
     files.append(output_file[0])
 
-# TODO: Include minifollow-ups materiale
+# Generate loudest off-source triggers table
+html_node, [lofft_table, lofft_h5] = \
+     _workflow.make_pygrb_injs_tables(wflow, out_dir, bank_file,
+                                      offsource_file, seg_files)
+html_nodes.append(html_node)
+
+lofft_layout = list(layout.grouper(files, 2)) + [(lofft_table,)]
+layout.two_column_layout(out_dir, lofft_layout)
+
+# Follow up N loudest offsource triggers (parent-child)
+out_dir = rdir['loudest_offsource_events/followups']
+if not wflow.cp.has_section('workflow-minifollowups'):
+    msg = 'No [workflow-minifollowups] section found in '
+    msg += 'configuration file'
+    logging.info(msg)
+else:
+    logging.info('Entering minifollowups module for offsource')
+    _workflow.setup_pygrb_minifollowups(wflow, lofft_h5, offsource_file,
+                                        'daxes', out_dir,
+                                        tags=['loudest_offsource_events'])
+    logging.info('Leaving minifollowups')
 
 
 #
@@ -477,12 +513,6 @@ for i, offtrial in enumerate(offtrials):
         files.extend(output_files)
     eff_layout = list(layout.grouper(files, 2))
     layout.two_column_layout(out_dir, eff_layout, offtrial)
-
-# TODO: add onsource calculation by using the true onsource file
-
-#
-# Trigger Followups (TODO)
-#
 
 # Make room for throughput histograms (TODO)
 base = rdir['workflow/throughput']
@@ -535,7 +565,43 @@ _workflow.make_results_web_page(
 out_dir = rdir['open_box']
 _workflow.makedir(out_dir)
 os.chmod(out_dir, 0o0700)
-# TODO: follow up loudest offsource trigger
+
+# Generate loudest on-source trigger table
+_workflow.makedir(out_dir)
+html_node, [lont_table, lont_h5] = \
+     _workflow.make_pygrb_injs_tables(wflow, out_dir, bank_file,
+                                      offsource_file, seg_files,
+                                      on_file=onsource_file)
+html_nodes.append(html_node)
+
+# Reweighted and coherent SNR timseries for the full data stretch
+timeseries_plots = _workflow.FileList([])
+for snr_type in ['reweighted', 'coherent']:
+    plot_node, output_files = \
+        _workflow.make_pygrb_plot(wflow,
+                                  'pygrb_plot_snr_timeseries',
+                                  out_dir,
+                                  trig_file=all_times_file,
+                                  tags=[snr_type, 'alltimes'])
+    plotting_nodes.append(plot_node)
+    timeseries_plots.extend(output_files)
+openbox_layout = [(lont_table,)] + list(layout.grouper(timeseries_plots, 2))
+layout.two_column_layout(out_dir, openbox_layout)
+
+
+# Loudest on-source trigger follow up
+out_dir = rdir['open_box/loudest_event_followup']
+if not wflow.cp.has_section('workflow-minifollowups'):
+    msg = 'No [workflow-minifollowups] section found in '
+    msg += 'configuration file'
+    logging.info(msg)
+else:
+    logging.info("Entering minifollowups module for loudest onsource")
+    _workflow.setup_pygrb_minifollowups(wflow, lont_h5, onsource_file,
+                                        'daxes', out_dir,
+                                        tags=['loudest_onsource_event'])
+    logging.info("Leaving onsource minifollowups")
+
 
 # Close the log and flush to the html file
 logging.shutdown()

--- a/bin/pygrb/pycbc_pygrb_pp_workflow
+++ b/bin/pygrb/pycbc_pygrb_pp_workflow
@@ -574,7 +574,7 @@ html_node, [lont_table, lont_h5] = \
                                       on_file=onsource_file)
 html_nodes.append(html_node)
 
-# Reweighted and coherent SNR timseries for the full data stretch
+# Reweighted and coherent SNR timeseries for the full data stretch
 timeseries_plots = _workflow.FileList([])
 for snr_type in ['reweighted', 'coherent']:
     plot_node, output_files = \


### PR DESCRIPTION
This PR is the 4th PR in a series opened by https://github.com/gwastro/pycbc/pull/4891.

It allows PyGRB results webpages to display tables for
1. "quiet-found" and "missed-found" injections
2. the loudest off-source triggers
3. and the loudest on-source trigger.

It allows sets up and runs sub-workflows for the "minifollowups" of
1. the N loudest "quiet-found" injections
2. the M loudest off-source triggers
3. and the loudest on-source trigger.
Results of the minifollowups are gathered and displayed in the results webpage.

Finally, the PR also enables producing and displaying the reweighted and coherent SNR timeseries for the whole data set, onsource included, in the open box.

## Standard information about the request

This is an additional feature for the webpage produced by a PyGRB analysis

This change affects PyGRB.

This change changes: result presentation / plotting of scientific output.

This brings master closer to producing a full results webpage as in [this example](https://ldas-jobs.ligo.caltech.edu/~francesco.pannarale/LVC/pygrb_sep2024_3/).

## Contents
For all three categories the code structure is similar:
- the table to be displayed is generated for, e.g., the loudest offsource triggers, alongside an hdf5 file with the same information
- this file is then used to set up the minifollowups, just like the all-sky search does.
The production of the "all times" time series is fairly simple, and mimics similar code in the rest of the script.

## Testing performed
As for the previous three PRs in this series that change `pycbc_pygrb_pp_workflow`, the complete set of changes will produce the end result linked above, but this single PR will enable only part of it and does not have stand alone.

## Additional notes
As a reminder, the plan is to run `black` at the very end of this set of PRs.

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
