### PR TITLE
Make coinc_statmap work in the case that no foreground is present

### DIFF
--- a/bin/all_sky_search/pycbc_coinc_statmap
+++ b/bin/all_sky_search/pycbc_coinc_statmap
@@ -291,9 +291,9 @@ if fore_locs.sum() > 0:
     f['foreground/ifar_exc'] = conv.sec_to_year(ifar_exc)
     f['foreground/fap_exc'] = fap_exc
 else:
-    f['foreground/ifar'] = numpy.array([])
+    f['foreground/ifar'] = ifar = numpy.array([])
     f['foreground/fap'] = numpy.array([])
-    f['foreground/ifar_exc'] = numpy.array([])
+    f['foreground/ifar_exc'] = ifar_exc = numpy.array([])
     f['foreground/fap_exc'] = numpy.array([])
 
 if 'name' in all_trigs.attrs:
@@ -330,6 +330,10 @@ else :
 # Step 2 : Loop until we don't have to hierarchically remove anymore. This
 #          will happen when ifar_foreground has no elements greater than
 #          the background time.
+
+# This is a workaround for the case that we have no foreground, so that the
+# while loop comparison doesnt fail straight away
+ifar_foreground = numpy.append(ifar_foreground, 0)
 
 while numpy.any(ifar_foreground >= background_time):
     # If the user wants to stop doing hierarchical removals after a set


### PR DESCRIPTION
Prasia found a bug in pycbc_coinc_statmap if no foreground events have been found,
this fixes that

## Standard information about the request

This is a: bug fix
This change affects: the offline search
This change changes: nothing
This change: has been proposed using the [contribution guidelines](https://github.com/gwastro/pycbc/blob/master/CONTRIBUTING.md)


## Motivation
Fix bug for a legitimate use-case in the offline search

## Contents

A variable was being used later in the code which was only set in the case that there was some foreground

This sets the variable and ensures that it is usable later

## Links to any issues or associated PRs
https://github.com/gwastro/pycbc/issues/4907

## Testing performed
To be tested with downstream codes

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
