### PR TITLE
Enforce pygrb_efficiency subsections

### DIFF
--- a/bin/pygrb/pycbc_pygrb_efficiency
+++ b/bin/pygrb/pycbc_pygrb_efficiency
@@ -573,7 +573,7 @@ if opts.background_output_file:
     ax.legend()
     ax.grid()
     ax.set_ylim([0, 1])
-    ax.set_xlim(0, 2.*upper_dist - lower_dist)
+    ax.set_xlim(0, 1.3*upper_dist)
     ax.set_ylabel("Fraction of injections found louder than loudest background")
     ax.set_xlabel("Distance (Mpc)")
     plot_title = "Detection efficiency - "+inj_set_name
@@ -655,13 +655,13 @@ if opts.onsource_output_file:
     ax.get_legend().get_frame().set_alpha(0.5)
     ax.grid()
     ax.set_ylim([0, 1])
-    ax.set_xlim(0, 2.*upper_dist - lower_dist)
+    ax.set_xlim(0, 1.3*upper_dist)
     ax.set_ylabel("Fraction of injections found louder than " +
                   "loudest foreground")
     ax.set_xlabel("Distance (Mpc)")
     ax.plot([excl_dist], [0.9], 'gx')
     ax.set_ylim([0, 1])
-    ax.set_xlim(0, 2.*upper_dist - lower_dist)
+    ax.set_xlim(0, 1.3*upper_dist)
     plot_title = "Exclusion distance - "+inj_set_name
     plot_caption = "Injection recovery efficiency using "
     plot_caption += "BestNR as detection statistic.  "

--- a/bin/pygrb/pycbc_pygrb_results_workflow
+++ b/bin/pygrb/pycbc_pygrb_results_workflow
@@ -208,12 +208,10 @@ bank_file = _workflow.resolve_url_to_file(bank_file)
 
 # Sanity check and File instances of the input injection files
 inj_sets = wflow.cp.get_subsections('injections')
-inj_sets.sort()
 eff_secs = wflow.cp.get_subsections('pygrb_efficiency')
-eff_secs.sort()
-if eff_secs != inj_sets:
-    err_msg = "Each [injections] subsection requires a "
-    err_msg += "corresponding [pygrb_efficiency] subsection. "
+if not set(inj_sets).issubset(eff_secs):
+    err_msg = "Each [injections] subsection requires at "
+    err_msg += "least one dedicated [pygrb_efficiency] subsection. "
     err_msg += "[injections] subsections found: %s. "
     err_msg += "[pygrb_efficiency] subsections found: %s. "
     logging.error(err_msg, inj_sets, eff_secs)

--- a/bin/pygrb/pycbc_pygrb_results_workflow
+++ b/bin/pygrb/pycbc_pygrb_results_workflow
@@ -206,8 +206,17 @@ logging.info("Offtrials: %s", [f.storage_path for f in offtrial_files])
 bank_file = os.path.join(start_rundir, args.bank_file)
 bank_file = _workflow.resolve_url_to_file(bank_file)
 
-# File instances of the input injection files
+# Sanity check and File instances of the input injection files
 inj_sets = wflow.cp.get_subsections('injections')
+inj_sets.sort()
+eff_secs = wflow.cp.get_subsections('pygrb_efficiency')
+eff_secs.sort()
+if eff_secs != inj_sets:
+    err_msg = "Each [injections] subsection requires a "
+    err_msg += "corresponding [pygrb_efficiency] subsection. "
+    err_msg += "[injections] subsections found: %s. "
+    err_msg += "[pygrb_efficiency] subsections found: %s. "
+    logging.error(err_msg, inj_sets, eff_secs)
 inj_sets = [i.upper() for i in inj_sets]
 inj_files = labels_in_files_metadata(inj_sets, start_rundir, args.inj_files)
 
@@ -532,6 +541,7 @@ for stat in stats:
         out_dir,
         trig_file=offsource_file,
         inj_file=inj_file,
+        seg_files=seg_files,
         tags=[stat],
     )
     plotting_nodes.append(plot_node)


### PR DESCRIPTION
- Require one `pygrb_efficiency` subsection in the config file for each injection set, i.e. `[injections]` subsection.
- Insert a line that was accidentally removed
- Lower the high end limit of the x axis in `pygrb_efficiency` plots.

## Standard information about the request
This is a: bug fix.  Prior to this fix, `pygrb_efficiency` was using a single value of lower/upper distance values, regardless of the injection set.

This change affects: PyGRB

This change changes: result presentation plotting and scientific output

This change was tested by rerunning the results generation of a GRB analysis [here](https://ldas-jobs.ligo.caltech.edu/~francesco.pannarale/LVC/pygrb_oct2024_1/5._exclusion_distances/).  Note that the [previous version](https://ldas-jobs.ligo.caltech.edu/~francesco.pannarale/LVC/pygrb_sep2024_3/5._exclusion_distances/) of plots in this section was "jagged".

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
