### PR TITLE
Change to frame finding in collated DQ script

### DIFF
--- a/bin/live/pycbc_live_collated_dq_trigger_rates
+++ b/bin/live/pycbc_live_collated_dq_trigger_rates
@@ -20,16 +20,39 @@ for a day of PyCBC Live triggers.
 import logging
 import argparse
 import hashlib
+import os
 
 import numpy as np
 
 import pycbc
 from pycbc.io import HFile
 
-import gwdatafind
-
 from gwpy.timeseries import TimeSeriesDict
 from gwpy.segments import Segment, DataQualityFlag
+
+
+def find_frames(ifo, frame_dir, frame_type, start, end):
+    """
+    Find the frame files for a given time range.
+    """
+    ifo_frame_type = frame_type.format(ifo=ifo)
+    ifo_pattern = f'{ifo[0]}-{ifo_frame_type}_llhoft-'
+    folder_pattern = ifo_pattern + '{supertime}'
+    file_pattern = ifo_pattern + '{time}-1.gwf'
+    path_pattern = os.path.join(
+        frame_dir,
+        ifo_frame_type,
+        folder_pattern,
+        file_pattern,
+    )
+
+    files = []
+    for t in range(int(start), int(end) + 1):
+        supertime = int(t / 10000)
+        files.append(path_pattern.format(supertime=supertime, time=t))
+
+    return files
+
 
 parser = argparse.ArgumentParser(description=__doc__)
 parser.add_argument("--trigger-file", required=True)
@@ -37,11 +60,14 @@ parser.add_argument("--ifo", required=True)
 parser.add_argument("--gps-start-time", required=True, type=int)
 parser.add_argument("--gps-end-time", required=True, type=int)
 parser.add_argument("--template-bin-file", required=True)
-parser.add_argument("--analysis-frame-type", required=True)
+parser.add_argument("--frame-directory", required=True)
+parser.add_argument("--frame-type", required=True)
 parser.add_argument("--analysis-flag-name", required=True)
 parser.add_argument("--dq-channel", required=True)
 parser.add_argument("--dq-ok-channel", required=True)
 parser.add_argument("--dq-thresh", required=True, type=float)
+parser.add_argument("--dq-padding", type=float, default=1.0)
+parser.add_argument("--replay-offset", type=int, default=0)
 parser.add_argument("--output", required=True)
 pycbc.add_common_pycbc_options(parser)
 args = parser.parse_args()
@@ -52,31 +78,44 @@ pycbc.init_logging(args.verbose)
 ar_flag_name = args.analysis_flag_name.format(ifo=args.ifo)
 day_seg = Segment(args.gps_start_time, args.gps_end_time)
 observing_flag = DataQualityFlag.query(ar_flag_name, day_seg)
+
+# shift observing flag to current time
+observing_flag.pad(args.replay_offset, args.replay_offset)
+
 observing_segs = observing_flag.active
 livetime = observing_flag.livetime
 logging.info(f'Found {livetime} seconds of observing time at {args.ifo}.')
 
 # for each segment, check how much time was dq flagged
 flagged_time = 0
-frame_type = args.analysis_frame_type.format(ifo=args.ifo)
 dq_channel = args.dq_channel.format(ifo=args.ifo)
 dq_ok_channel = args.dq_ok_channel.format(ifo=args.ifo)
 for seg in observing_segs:
-    frames = gwdatafind.find_urls(
-        args.ifo[0],
-        frame_type,
+    frames = find_frames(
+        args.ifo,
+        args.frame_directory,
+        args.frame_type,
         seg[0],
         seg[1],
     )
+
     tsdict = TimeSeriesDict.read(
         frames,
         channels=[dq_channel, dq_ok_channel],
         start=seg[0],
         end=seg[1],
     )
+
     dq_ok_flag = (tsdict[dq_ok_channel] == 1).to_dqflag()
     dq_flag = (tsdict[dq_channel] <= args.dq_thresh).to_dqflag()
-    flagged_time += (dq_flag & dq_ok_flag).livetime
+    valid_bad_dq = dq_flag & dq_ok_flag
+
+    # pad flag outwards to match the padding used in the live script
+    valid_bad_dq.protract(args.dq_padding)
+    valid_bad_dq.coalesce()
+
+    flagged_time += (valid_bad_dq & observing_flag).livetime
+
 logging.info(f'Found {flagged_time} seconds of dq flagged time at {args.ifo}.')
 
 bg_livetime = livetime - flagged_time

--- a/bin/live/pycbc_live_collated_dq_trigger_rates
+++ b/bin/live/pycbc_live_collated_dq_trigger_rates
@@ -21,6 +21,7 @@ import logging
 import argparse
 import hashlib
 import os
+import glob
 
 import numpy as np
 
@@ -38,18 +39,18 @@ def find_frames(ifo, frame_dir, frame_type, start, end):
     ifo_frame_type = frame_type.format(ifo=ifo)
     ifo_pattern = f'{ifo[0]}-{ifo_frame_type}_llhoft-'
     folder_pattern = ifo_pattern + '{supertime}'
-    file_pattern = ifo_pattern + '{time}-1.gwf'
     path_pattern = os.path.join(
         frame_dir,
         ifo_frame_type,
         folder_pattern,
-        file_pattern,
     )
 
+    start_round = int(start / 10000)
+    end_round = int(end / 10000)
     files = []
-    for t in range(int(start), int(end) + 1):
-        supertime = int(t / 10000)
-        files.append(path_pattern.format(supertime=supertime, time=t))
+    for t in range(start_round, end_round + 1):
+        framedir = path_pattern.format(supertime=t)
+        files += glob.glob(os.path.join(framedir, '*.gwf'))
 
     return files
 
@@ -80,7 +81,7 @@ day_seg = Segment(args.gps_start_time, args.gps_end_time)
 observing_flag = DataQualityFlag.query(ar_flag_name, day_seg)
 
 # shift observing flag to current time
-observing_flag.pad(args.replay_offset, args.replay_offset)
+observing_flag = observing_flag.pad(args.replay_offset, args.replay_offset)
 
 observing_segs = observing_flag.active
 livetime = observing_flag.livetime
@@ -91,6 +92,8 @@ flagged_time = 0
 dq_channel = args.dq_channel.format(ifo=args.ifo)
 dq_ok_channel = args.dq_ok_channel.format(ifo=args.ifo)
 for seg in observing_segs:
+    print('DEBUG: Segment:', seg)
+    print('DEBUG: Finding frames')
     frames = find_frames(
         args.ifo,
         args.frame_directory,
@@ -99,21 +102,28 @@ for seg in observing_segs:
         seg[1],
     )
 
+    print('DEBUG: Reading frames')
     tsdict = TimeSeriesDict.read(
         frames,
         channels=[dq_channel, dq_ok_channel],
         start=seg[0],
         end=seg[1],
+        pad=0,
     )
 
+    print('DEBUG: Calculating dq and dq_ok flags')
     dq_ok_flag = (tsdict[dq_ok_channel] == 1).to_dqflag()
     dq_flag = (tsdict[dq_channel] <= args.dq_thresh).to_dqflag()
+
+    print('DEBUG: Calculating valid_bad_dq')
     valid_bad_dq = dq_flag & dq_ok_flag
 
     # pad flag outwards to match the padding used in the live script
+    print('DEBUG: Protracting and coalescing')
     valid_bad_dq.protract(args.dq_padding)
     valid_bad_dq.coalesce()
 
+    print('DEBUG: Adding flagged time')
     flagged_time += (valid_bad_dq & observing_flag).livetime
 
 logging.info(f'Found {flagged_time} seconds of dq flagged time at {args.ifo}.')

--- a/bin/live/pycbc_live_collated_dq_trigger_rates
+++ b/bin/live/pycbc_live_collated_dq_trigger_rates
@@ -92,8 +92,6 @@ flagged_time = 0
 dq_channel = args.dq_channel.format(ifo=args.ifo)
 dq_ok_channel = args.dq_ok_channel.format(ifo=args.ifo)
 for seg in observing_segs:
-    print('DEBUG: Segment:', seg)
-    print('DEBUG: Finding frames')
     frames = find_frames(
         args.ifo,
         args.frame_directory,
@@ -102,7 +100,6 @@ for seg in observing_segs:
         seg[1],
     )
 
-    print('DEBUG: Reading frames')
     tsdict = TimeSeriesDict.read(
         frames,
         channels=[dq_channel, dq_ok_channel],
@@ -111,19 +108,15 @@ for seg in observing_segs:
         pad=0,
     )
 
-    print('DEBUG: Calculating dq and dq_ok flags')
     dq_ok_flag = (tsdict[dq_ok_channel] == 1).to_dqflag()
     dq_flag = (tsdict[dq_channel] <= args.dq_thresh).to_dqflag()
 
-    print('DEBUG: Calculating valid_bad_dq')
     valid_bad_dq = dq_flag & dq_ok_flag
 
     # pad flag outwards to match the padding used in the live script
-    print('DEBUG: Protracting and coalescing')
     valid_bad_dq.protract(args.dq_padding)
     valid_bad_dq.coalesce()
 
-    print('DEBUG: Adding flagged time')
     flagged_time += (valid_bad_dq & observing_flag).livetime
 
 logging.info(f'Found {flagged_time} seconds of dq flagged time at {args.ifo}.')

--- a/bin/live/pycbc_live_supervise_collated_trigger_fits
+++ b/bin/live/pycbc_live_supervise_collated_trigger_fits
@@ -495,16 +495,19 @@ def daily_dq_trigger_rates(
     fname_format = daily_dq_controls['daily-dq-format']
     ddtr_out_fname = fname_format.format(date=day_str, ifo=ifo)
 
-    today = get_true_date(day_dt, daily_dq_controls)
+    start_time = get_true_date(day_dt, daily_dq_controls)
 
-    gps_start_time = gpstime.utc_to_gps(today).gpsSeconds
-    gps_end_time = gpstime.utc_to_gps(today + timedelta(days=1)).gpsSeconds
+    gps_start_time = gpstime.utc_to_gps(start_time).gpsSeconds
+    gps_end_time = gpstime.utc_to_gps(start_time + timedelta(days=1)).gpsSeconds
+
+    offset = gpstime.utc_to_gps(day_dt).gpsSeconds - gps_start_time
 
     ddtr_out_full = os.path.join(output_dir, ddtr_out_fname)
     daily_dq_args = ['pycbc_live_collated_dq_trigger_rates']
     daily_dq_args += ['--trigger-file', trigger_merge_file]
     daily_dq_args += ['--output', ddtr_out_full]
     daily_dq_args += ['--ifo', ifo]
+    daily_dq_args += ['--replay-offset', offset]
 
     daily_dq_options['gps-start-time'] = f'{gps_start_time:d}'
     daily_dq_options['gps-end-time'] = f'{gps_end_time:d}'

--- a/bin/live/pycbc_live_supervise_collated_trigger_fits
+++ b/bin/live/pycbc_live_supervise_collated_trigger_fits
@@ -507,10 +507,10 @@ def daily_dq_trigger_rates(
     daily_dq_args += ['--trigger-file', trigger_merge_file]
     daily_dq_args += ['--output', ddtr_out_full]
     daily_dq_args += ['--ifo', ifo]
-    daily_dq_args += ['--replay-offset', offset]
 
     daily_dq_options['gps-start-time'] = f'{gps_start_time:d}'
     daily_dq_options['gps-end-time'] = f'{gps_end_time:d}'
+    daily_dq_options['replay-offset'] = f'{offset:d}'
     daily_dq_args += sv.dict_to_args(daily_dq_options)
 
     sv.run_and_error(daily_dq_args, controls)


### PR DESCRIPTION
Previously, the collated DQ script relied on gwdatafind to find frames for the past day. This was not appropriate for the MDC because gwdatafind would point at frames that did not actually match the MDC frames. This change allows a directory to be specified to read the frames from, intended to be the low-latency frame cache.

## Standard information about the request

This is a: bug fix

This change affects the live search, only when using supervised fitting to produce stat files for the DQ statistic.

This change changes scientific output, but hopefully not by much.

## Motivation
GWdatafind was pointing to frames that did not match the frames actually circulated in the MDC. This lead to a bug because the main PyCBC Live script and the dq fitting script did not agree on whether there were DQ flaged times, because they were getting their data from different sources.

## Contents
Instead of relying on gwdatafind, specify a root directory that frames can be found in and a frame type in the supervised fitting config file. The structure of the frame directory is predictable, allowing the code to find the frames it needs.

## Testing performed
Ran on the MDC analysis machines for days when the previous version of this code had crashed.


- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
