### PR TITLE
Add an estimator for end frequency of the any custom waveform model  

### DIFF
--- a/pycbc/waveform/plugin.py
+++ b/pycbc/waveform/plugin.py
@@ -74,6 +74,22 @@ def add_length_estimator(approximant, function):
     from pycbc.waveform.waveform import td_fd_waveform_transform
     td_fd_waveform_transform(approximant)
 
+def add_end_frequency_estimator(approximant, function):
+    """ Add end frequency estimator for an approximant
+
+    Parameters
+    ----------
+    approximant : str
+        Name of approximant
+    function : function
+        A function which takes kwargs and returns the end frequency of the waveform
+    """
+    from pycbc.waveform.waveform import _filter_ends
+    if approximant in _filter_ends:
+        raise RuntimeError("Can't load freqeuncy estimator {}, the name is"
+                           " already in use.".format(approximant))
+
+    _filter_ends[approximant] = function
 
 def retrieve_waveform_plugins():
     """ Process external waveform plugins
@@ -106,3 +122,7 @@ def retrieve_waveform_plugins():
     # Check for waveform length estimates
     for plugin in pkg_resources.iter_entry_points('pycbc.waveform.length'):
         add_length_estimator(plugin.name, plugin.resolve())
+
+    # Check for waveform end frequency estimates
+    for plugin in pkg_resources.iter_entry_points('pycbc.waveform.end_frequency'):
+        add_end_frequency_estimator(plugin.name, plugin.resolve())

--- a/pycbc/waveform/plugin.py
+++ b/pycbc/waveform/plugin.py
@@ -74,6 +74,7 @@ def add_length_estimator(approximant, function):
     from pycbc.waveform.waveform import td_fd_waveform_transform
     td_fd_waveform_transform(approximant)
 
+
 def add_end_frequency_estimator(approximant, function):
     """ Add end frequency estimator for an approximant
 
@@ -82,7 +83,7 @@ def add_end_frequency_estimator(approximant, function):
     approximant : str
         Name of approximant
     function : function
-        A function which takes kwargs and returns the end frequency of the waveform
+        A function which takes kwargs and returns the waveform end frequency
     """
     from pycbc.waveform.waveform import _filter_ends
     if approximant in _filter_ends:
@@ -90,6 +91,7 @@ def add_end_frequency_estimator(approximant, function):
                            " already in use.".format(approximant))
 
     _filter_ends[approximant] = function
+
 
 def retrieve_waveform_plugins():
     """ Process external waveform plugins
@@ -124,5 +126,5 @@ def retrieve_waveform_plugins():
         add_length_estimator(plugin.name, plugin.resolve())
 
     # Check for waveform end frequency estimates
-    for plugin in pkg_resources.iter_entry_points('pycbc.waveform.end_frequency'):
+    for plugin in pkg_resources.iter_entry_points('pycbc.waveform.end_freq'):
         add_end_frequency_estimator(plugin.name, plugin.resolve())


### PR DESCRIPTION
 

## Standard information about the request

<!--- Some basic info about the change (delete as appropriate) -->
This is a new feature added for estimating the end frequency of any custom waveform model

This feature will affect plugin.py for waveform 

This change affects: the offline search, the live search, inference, PyGRB

<!--- What code areas will this affect? (delete as apropriate) -->
This change changes: documentation, scientific output

<!--- Some things which help with code management (delete as appropriate) -->
This change: has appropriate unit tests, follows style guidelines (See e.g. [PEP8](https://peps.python.org/pep-0008/)), has been proposed using the [contribution guidelines](https://github.com/gwastro/pycbc/blob/master/CONTRIBUTING.md)

<!--- Notes about the effect of this change -->
This change will: break current functionality, require a new release

## Motivation
Custom waveform approximants may or may not have a frequency-domain version. To make any time-domain waveform useful for searches or parameter estimation, get_fd_waveform_from_td is used. For an accurate time-to-frequency domain transformation, the sampling rate must be appropriately adjusted. This adjustment depends on both the duration of the signal in the time domain and the end frequency of the waveform. The signal duration and end frequency can vary depending on the source parameters and waveform approximants.

While PyCBC already includes a function to estimate the signal duration, it does not yet have a way to estimate the end frequency. That is why adding an end frequency estimator is important. 

## Contents
<!--- Describe your changes, this doesn't need to be a line-by-line code change discussion,
but rather a general discussion of the methods chosen -->

## Links to any issues or associated PRs
<!--- If this is fixing / working around an already-reported issue, please link to it here -->

## Testing performed
<!--- Describe tests for the code changes, either already performed or to be performed -->

## Additional notes
<!--- Anything which does not fit in the above sections -->

- [ ✔] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
