### PR TITLE
Adding warning for no injections

### DIFF
--- a/pycbc/inject/inject.py
+++ b/pycbc/inject/inject.py
@@ -568,6 +568,7 @@ class CBCHDFInjectionSet(_HDFInjectionSet):
             # safety buffer
             start_time = inj.tc - 2 * (inj_length + 1)
             if end_time < t0 or start_time > t1:
+                logger.warning("No injections applied.")
                 continue
             signal = self.make_strain_from_inj_object(inj, delta_t,
                      detector_name, f_lower=f_l,

--- a/pycbc/strain/strain.py
+++ b/pycbc/strain/strain.py
@@ -318,8 +318,6 @@ def from_cli(opt, dyn_range_fac=1, precision='single',
                            distance_scale=opt.injection_scale_factor,
                            injection_sample_rate=opt.injection_sample_rate,
                            inj_filter_rejector=inj_filter_rejector)
-    else:
-        logger.warning("No injections applied.")
 
     if opt.sgburst_injection_file:
         logger.info("Applying sine-Gaussian burst injections")

--- a/pycbc/strain/strain.py
+++ b/pycbc/strain/strain.py
@@ -318,6 +318,8 @@ def from_cli(opt, dyn_range_fac=1, precision='single',
                            distance_scale=opt.injection_scale_factor,
                            injection_sample_rate=opt.injection_sample_rate,
                            inj_filter_rejector=inj_filter_rejector)
+    else:
+        logger.warning("No injections applied.")
 
     if opt.sgburst_injection_file:
         logger.info("Applying sine-Gaussian burst injections")


### PR DESCRIPTION
This raises a warning if no injections are applied during an inference job.