### PR TITLE
Fix problem on pycbc live due to numpy 2 

### DIFF
--- a/examples/live/check_results.py
+++ b/examples/live/check_results.py
@@ -11,7 +11,7 @@ from pycbc.io.ligolw import LIGOLWContentHandler
 from ligo.lw.utils import load_filename as load_xml_doc
 from ligo.lw import lsctables
 from pycbc import conversions as conv
-import LigoLWEventSource
+from ligo.skymap.io import LigoLWEventSource
 
 def close(a, b, c):
     return abs(a - b) <= c

--- a/examples/live/check_results.py
+++ b/examples/live/check_results.py
@@ -11,7 +11,7 @@ from pycbc.io.ligolw import LIGOLWContentHandler
 from ligo.lw.utils import load_filename as load_xml_doc
 from ligo.lw import lsctables
 from pycbc import conversions as conv
-
+import LigoLWEventSource
 
 def close(a, b, c):
     return abs(a - b) <= c

--- a/pycbc/io/gracedb.py
+++ b/pycbc/io/gracedb.py
@@ -222,7 +222,10 @@ class CandidateForGraceDB(object):
             fseries = lal.CreateREAL8FrequencySeries(
                 "psd", psd.epoch, kwargs['low_frequency_cutoff'], psd.delta_f,
                 lal.StrainUnit**2 / lal.HertzUnit, len(psd) - kmin)
-            fseries.data.data = psd.numpy()[kmin:].astype(numpy.float64) / pycbc.DYN_RANGE_FAC ** 2.0
+            fseries.data.data = (
+                psd.numpy()[kmin:].astype(numpy.float64)
+                / pycbc.DYN_RANGE_FAC ** 2.0
+            )
             psds_lal[ifo] = fseries
         make_psd_xmldoc(psds_lal, outdoc)
 

--- a/pycbc/io/gracedb.py
+++ b/pycbc/io/gracedb.py
@@ -222,7 +222,7 @@ class CandidateForGraceDB(object):
             fseries = lal.CreateREAL8FrequencySeries(
                 "psd", psd.epoch, kwargs['low_frequency_cutoff'], psd.delta_f,
                 lal.StrainUnit**2 / lal.HertzUnit, len(psd) - kmin)
-            fseries.data.data = psd.numpy()[kmin:] / pycbc.DYN_RANGE_FAC ** 2.0
+            fseries.data.data = psd.numpy()[kmin:].astype(numpy.float64) / pycbc.DYN_RANGE_FAC ** 2.0
             psds_lal[ifo] = fseries
         make_psd_xmldoc(psds_lal, outdoc)
 


### PR DESCRIPTION
This fixes #4912.

I explictly convert the PSD to double precision before the division, as soon numpy 2.x is not doing it automatically anymore. 

I also add another check of the XML files to make sure that the PSDs in there are valid.
