### PR TITLE
Fixing overlaping sections bug

### DIFF
--- a/pycbc/types/config.py
+++ b/pycbc/types/config.py
@@ -230,7 +230,8 @@ class InterpolatingConfigParser(DeepCopyableConfigParser):
         """
         Read a .ini file and return it as a ConfigParser class.
         This function does none of the parsing/combining of sections. It simply
-        reads the file and returns it unedited
+        reads the file, checks if there are overlaping options
+        and returns it unedited
 
         Stub awaiting more functionality - see configparser_test.py
 
@@ -245,6 +246,26 @@ class InterpolatingConfigParser(DeepCopyableConfigParser):
             The ConfigParser class containing the read in .ini file
         """
         # Read the file
+
+        options_seen = {}
+
+        for filename in fpath:
+            parser = ConfigParser.ConfigParser()
+            parser.read(filename)
+
+            for section in parser.sections():
+                if section not in options_seen:
+                    options_seen[section] = set()
+
+                section_options = parser.options(section)
+
+                option_intersection = options_seen[section].intersection(section_options)
+
+                if option_intersection:
+                    raise ValueError(f"Duplicate option(s) {', '.join(option_intersection)} found in section '{section}' in file '{filename}'")
+
+                options_seen[section].update(section_options)
+
         self.read(fpath)
 
     def get_subsections(self, section_name):

--- a/pycbc/types/config.py
+++ b/pycbc/types/config.py
@@ -101,8 +101,6 @@ class InterpolatingConfigParser(DeepCopyableConfigParser):
 
         super().__init__()
 
-        self.read_ini_file(configFiles)
-
         # Enable case sensitive options
         self.optionxform = str
 
@@ -118,6 +116,8 @@ class InterpolatingConfigParser(DeepCopyableConfigParser):
             if '%' not in value and '$' not in value
         }
         self.read_dict({'environment': env_vals})
+
+        self.read_ini_file(configFiles)
 
         # Split sections like [inspiral&tmplt] into [inspiral] and [tmplt]
         self.split_multi_sections()
@@ -254,17 +254,20 @@ class InterpolatingConfigParser(DeepCopyableConfigParser):
             parser.read(filename)
 
             for section in parser.sections():
-                if section not in options_seen:
-                    options_seen[section] = set()
+                if section == "environment":
+                    continue
+                else:
+                    if section not in options_seen:
+                        options_seen[section] = set()
 
-                section_options = parser.options(section)
+                    section_options = parser.options(section)
 
-                option_intersection = options_seen[section].intersection(section_options)
+                    option_intersection = options_seen[section].intersection(section_options)
 
-                if option_intersection:
-                    raise ValueError(f"Duplicate option(s) {', '.join(option_intersection)} found in section '{section}' in file '{filename}'")
+                    if option_intersection:
+                        raise ValueError(f"Duplicate option(s) {', '.join(option_intersection)} found in section '{section}' in file '{filename}'")
 
-                options_seen[section].update(section_options)
+                    options_seen[section].update(section_options)
 
         self.read(fpath)
 

--- a/pycbc/types/config.py
+++ b/pycbc/types/config.py
@@ -101,8 +101,6 @@ class InterpolatingConfigParser(DeepCopyableConfigParser):
 
         super().__init__()
 
-        self.read_ini_file(configFiles)
-
         # Enable case sensitive options
         self.optionxform = str
 
@@ -118,6 +116,8 @@ class InterpolatingConfigParser(DeepCopyableConfigParser):
             if '%' not in value and '$' not in value
         }
         self.read_dict({'environment': env_vals})
+
+        self.read_ini_file(configFiles)
 
         # Split sections like [inspiral&tmplt] into [inspiral] and [tmplt]
         self.split_multi_sections()
@@ -250,17 +250,16 @@ class InterpolatingConfigParser(DeepCopyableConfigParser):
         options_seen = {}
 
         for filename in fpath:
-            parser = ConfigParser.ConfigParser()
-            parser.read(filename)
+            self.read(filename)
 
-            for section in parser.sections():
+            for section in self.sections():
                 if section == "environment":
                     continue
                 else:
                     if section not in options_seen:
                         options_seen[section] = set()
 
-                    section_options = parser.options(section)
+                    section_options = self.options(section)
 
                     option_intersection = options_seen[section].intersection(section_options)
 
@@ -269,7 +268,6 @@ class InterpolatingConfigParser(DeepCopyableConfigParser):
 
                     options_seen[section].update(section_options)
 
-        self.read(fpath)
 
     def get_subsections(self, section_name):
         """Return a list of subsections for the given section name"""

--- a/pycbc/types/config.py
+++ b/pycbc/types/config.py
@@ -101,6 +101,8 @@ class InterpolatingConfigParser(DeepCopyableConfigParser):
 
         super().__init__()
 
+        self.read_ini_file(configFiles)
+
         # Enable case sensitive options
         self.optionxform = str
 
@@ -116,8 +118,6 @@ class InterpolatingConfigParser(DeepCopyableConfigParser):
             if '%' not in value and '$' not in value
         }
         self.read_dict({'environment': env_vals})
-
-        self.read_ini_file(configFiles)
 
         # Split sections like [inspiral&tmplt] into [inspiral] and [tmplt]
         self.split_multi_sections()

--- a/pycbc/types/config.py
+++ b/pycbc/types/config.py
@@ -250,24 +250,24 @@ class InterpolatingConfigParser(DeepCopyableConfigParser):
         options_seen = {}
 
         for filename in fpath:
-            self.read(filename)
+            parser = ConfigParser.ConfigParser()
+            parser.optionxform=str
+            parser.read(filename)
 
-            for section in self.sections():
-                if section == "environment":
-                    continue
-                else:
-                    if section not in options_seen:
-                        options_seen[section] = set()
+            for section in parser.sections():
+                if section not in options_seen:
+                    options_seen[section] = set()
 
-                    section_options = self.options(section)
+                section_options = parser.options(section)
 
-                    option_intersection = options_seen[section].intersection(section_options)
+                option_intersection = options_seen[section].intersection(section_options)
 
-                    if option_intersection:
-                        raise ValueError(f"Duplicate option(s) {', '.join(option_intersection)} found in section '{section}' in file '{filename}'")
+                if option_intersection:
+                    raise ValueError(f"Duplicate option(s) {', '.join(option_intersection)} found in section '{section}' in file '{filename}'")
 
-                    options_seen[section].update(section_options)
+                options_seen[section].update(section_options)
 
+        self.read(fpath)
 
     def get_subsections(self, section_name):
         """Return a list of subsections for the given section name"""


### PR DESCRIPTION
This PR adds a check for repeated options in configuration files used for inference jobs. Previously, if an option was repeated across multiple configuration files, the latest instance would overwrite earlier ones without raising an error. Now, the code detects repeated options and raises an error.