### PR TITLE
Adding jittering functions for the distance in PyGRB

### DIFF
--- a/pycbc/conversions.py
+++ b/pycbc/conversions.py
@@ -28,6 +28,7 @@ from other parameters. All exposed functions in this module's namespace return
 one parameter given a set of inputs.
 """
 
+import random
 import copy
 import numpy
 import logging
@@ -1806,6 +1807,75 @@ def nltides_gw_phase_diff_isco(f_low, f0, amplitude, n, m1, m2):
 
     return formatreturn(phi_i - phi_l, input_is_array)
 
+def jittering_distance_gaussian(prev_dist, amp_cal_error, phase_cal_error):
+    """ Jitter the distance in order to take in account the
+    calibration errors in phase and amplitude by following a
+    gaussian distribution. Gaussian distribution is not 
+    recommended because it could give you negative distance 
+    as soon as it covers the entire real space. The formula
+    for mu and sigma are obtained in [PUT REF HERE]
+
+
+    Parameters
+    ----------
+    prev_dist : numpy.array
+        distance distribution before the jittering
+    amp_cal_error : float
+        amplitude calibration error (percentage) of the wanted 
+        detector. It will affect the width of the gaussian
+        distribution.
+    phase_cal_error : float
+        phase calibration error (degrees) of the wanted detector. 
+        It will affect the center of the gaussian distribution.
+
+    Returns
+    -------
+    distance : numpy.array
+        distance distribution after the jittering, a gaussian 
+        distribution centerend on the phase calibration error
+        and with a width of the amplitude calibration error.
+
+    """
+    mu = prev_dist * (1 + 0.5 * numpy.deg2rad(phase_cal_error)**2)
+    sigma = (amp_cal_error / 100) * prev_dist
+    
+    return numpy.random.normal(mu, sigma)
+
+def jittering_distance_lognormal(prev_dist, amp_cal_error, phase_cal_error):
+    """ Jitter the distance in order to take in account the
+    calibration errors in phase and amplitude by following a
+    lognormal distribution. The formula for mu and sigma are 
+    obtained in [PUT REF HERE]
+
+    Parameters
+    ----------
+    prev_dist : numpy.array
+        distance distribution before the jittering
+    amp_cal_error : float
+        amplitude calibration error (percentage) of the wanted 
+        detector. It will affect the width of the gaussian
+        distribution.
+    phase_cal_error : float
+        phase calibration error (degrees) of the wanted detector. 
+        It will affect the center of the gaussian distribution.
+
+    Returns
+    -------
+    distance : numpy.array
+        distance distribution after the jittering, a lognormal 
+        distribution centerend on the phase calibration error
+        and with a width of the amplitude calibration error.
+
+    """
+    mu = prev_dist * (1 + 0.5 * numpy.deg2rad(phase_cal_error)**2)
+    sigma = (amp_cal_error / 100) * prev_dist
+    
+    lognorm = []
+
+    for i in range(len(prev_dist)):
+        lognorm.append(numpy.log(random.lognormvariate(mu[i], sigma[i])))
+
+    return lognorm
 
 __all__ = ['dquadmon_from_lambda', 'lambda_tilde',
            'lambda_from_mass_tov_file', 'primary_mass',
@@ -1847,5 +1917,6 @@ __all__ = ['dquadmon_from_lambda', 'lambda_tilde',
            'remnant_mass_from_mass1_mass2_cartesian_spin_eos',
            'lambda1_from_delta_lambda_tilde_lambda_tilde',
            'lambda2_from_delta_lambda_tilde_lambda_tilde',
-           'delta_lambda_tilde'
+           'delta_lambda_tilde', 'jittering_distance_gaussian',
+           'jittering_distance_lognormal'
           ]


### PR DESCRIPTION
This commit aims to add to PyGRB the jittering distance function of [https://github.com/gwastro/pycbc-pylal/blob/master/bin/ligolw_cbc_jitter_skyloc#L187-L202](url)  

From #4591 discussion, I just decided to create only two functions in order to not add a new step in the procedure of computing the calibration errors in the waveform generation.

The formula used in both jittering functions is obtained in [https://orca.cardiff.ac.uk/id/eprint/96479/12/2016williamsonarphd%20DPR.pdf](url).