### PR TITLE
Fix bug in fetching injection group param

### DIFF
--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-12]
+        os: [ubuntu-20.04, macos-14]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/mac-test.yml
+++ b/.github/workflows/mac-test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        os: [macos-12]
+        os: [macos-latest]
         python-version: ['3.10', '3.11', '3.12']
     steps:
     - uses: actions/checkout@v1

--- a/pycbc/events/triggers.py
+++ b/pycbc/events/triggers.py
@@ -227,7 +227,7 @@ def get_inj_param(injfile, param, ifo, args=None):
 
     inj = injfile["injections"]
     if param in inj.keys():
-        return inj["injections/"+param]
+        return inj[param][:]
 
     if param == "end_time_"+ifo[0].lower():
         return inj['end_time'][:] + det.time_delay_from_earth_center(


### PR DESCRIPTION
The injection param fetching has an obvious bug in a branch which I am guessing has never been used .. see the change

This is a: bug fix

This change affects: plotting utility code currently not used in offline search

This change changes: result presentation / plotting

This change: follows style guidelines (See e.g. [PEP8](https://peps.python.org/pep-0008/)), has been proposed using the [contribution guidelines](https://github.com/gwastro/pycbc/blob/master/CONTRIBUTING.md)

This change will: not have any effect other than improving ability to retrieve injection params

## Testing performed
Works to retrieve the `injections/tc` dataset.
