### PR TITLE
editing get_available_detectors() to avoid repetition

### DIFF
--- a/pycbc/detector.py
+++ b/pycbc/detector.py
@@ -56,8 +56,6 @@ def gmst_accurate(gps_time):
 def get_available_detectors():
     """ List the available detectors """
     dets = list(_ground_detectors.keys())
-    for pfx, name in get_available_lal_detectors():
-        dets += [pfx]
     return dets
 
 def get_available_lal_detectors():


### PR DESCRIPTION
## Standard information about the request

This is a: bug fix

This change affects the function: `pycbc.detector.get_available_detectors()`

This change changes: output of the above function

This change will likely not affect any other functions

## Motivation
The output of `get_available_detectors()` was a list of LAL detectors repeated twice in addition to the detectors added by the user. This was happening because of the addition of LAL detectors once in lines 193-207 as follows in `pycbc/detector.py` file
```
# prepopulate using detectors hardcoded into lalsuite
for pref, name in get_available_lal_detectors():
    lalsim = pycbc.libutils.import_optional('lalsimulation')
    lal_det = lalsim.DetectorPrefixToLALDetector(pref).frDetector
    add_detector_on_earth(pref,
                          lal_det.vertexLongitudeRadians,
                          lal_det.vertexLatitudeRadians,
                          height=lal_det.vertexElevation,
                          xangle=lal_det.xArmAzimuthRadians,
                          yangle=lal_det.yArmAzimuthRadians,
                          xlength=lal_det.xArmMidpoint * 2,
                          ylength=lal_det.yArmMidpoint * 2,
                          xaltitude=lal_det.xArmAltitudeRadians,
                          yaltitude=lal_det.yArmAltitudeRadians,
                          )
```
and once more inside the `get_available_detectors()` function. Hence the lines inside the `get_available_detectors()` function have been removed.

## Testing performed
Basic test using a simple python script shows that the change is working.

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
