### PR TITLE
Fix OpenMP threshold code on Intel Macs

### DIFF
--- a/pycbc/events/simd_threshold_ccode.cpp
+++ b/pycbc/events/simd_threshold_ccode.cpp
@@ -92,11 +92,14 @@ void _parallel_threshold(int64_t N, std::complex<float> * __restrict arr,
 
             #pragma omp ordered
             {
-                t+=c;
+                t += c;
+                memmove(
+                    outl + t - c, outl + start, sizeof(unsigned int)*c
+                );
+                memmove(
+                    outv + t - c, outv + start, sizeof(std::complex<float>)*c
+                );
             }
-            memmove(outl+t-c, outl+start, sizeof(unsigned int)*c);
-            memmove(outv+t-c, outv+start, sizeof(std::complex<float>)*c);
-
         }
 
         count[0] = t;

--- a/test/test_threshold.py
+++ b/test/test_threshold.py
@@ -14,47 +14,41 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-#
-# =============================================================================
-#
-#                                   Preamble
-#
-# =============================================================================
-#
 """
-These are the unittests for the pycbc.waveform module
+Unit tests for PyCBC's thresholding code.
 """
+
 import unittest
 import numpy
-from pycbc.types import *
-from pycbc.scheme import *
-from pycbc.events import *
+from pycbc.types import Array, complex64
+from pycbc.events import threshold
 from utils import parse_args_all_schemes, simple_exit
 
 _scheme, _context = parse_args_all_schemes("Threshold")
 
-from pycbc.events.threshold_cpu import threshold_numpy
-trusted_threshold = threshold_numpy
+from pycbc.events.threshold_cpu import threshold_numpy as trusted_threshold
+
 
 class TestThreshold(unittest.TestCase):
-    def setUp(self,*args):
+    def setUp(self, *args):
         self.context = _context
         self.scheme = _scheme
         r = numpy.random.uniform(low=-1, high=1.0, size=2**20)
         i = numpy.random.uniform(low=-1, high=1.0, size=2**20)
-        v = r + i*1.0j
+        v = r + i * 1.0j
         self.series = Array(v, dtype=complex64)
         self.threshold = 1.3
         self.locs, self.vals = trusted_threshold(self.series, self.threshold)
-        self.tolerance = 1e-6
-        print(len(self.locs), len(self.vals))
+        print(f'Reference: {len(self.locs)} locs, {len(self.vals)} vals')
 
     def test_threshold(self):
         with self.context:
             locs, vals = threshold(self.series, self.threshold)
+            print(f'Test: {len(locs)} locs, {len(vals)} vals')
             self.assertTrue((locs == self.locs).all())
             self.assertTrue((vals == self.vals).all())
-            print(len(locs), len(vals))
+
+
 suite = unittest.TestSuite()
 suite.addTest(unittest.TestLoader().loadTestsFromTestCase(TestThreshold))
 


### PR DESCRIPTION
Fix incorrect results from the OpenMP threshold code on Intel Macs. Fixes #4828.

## Standard information about the request

This is a bug fix which should not change any result (apart from fixing the buggy situations).

## Motivation

See the explanation in #4828 for details, but the essence is that the thresholding code was broken on Intel Macs when using OpenMP.

## Contents

The problematic code is moved inside an ordered OpenMP directive.

I also did some cleanup of `test_threshold.py`.

## Links to any issues or associated PRs

#4828

## Testing performed

Testing done on an Intel Mac using the `test_threshold.py` unit test.

## Additional notes

N/A

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
