### PR TITLE
Fix issue preventing extract samples from combining files

### DIFF
--- a/bin/inference/pycbc_inference_extract_samples
+++ b/bin/inference/pycbc_inference_extract_samples
@@ -137,7 +137,8 @@ for fp in fps:
 # resume points (may not be the same across multiple files)
 # effective nsamples (that can just be obtained from the samples size)
 skip_attrs = ['filetype', 'thin_start', 'thin_interval', 'thin_end',
-              'thinned_by', 'cmd', 'resume_points', 'effective_nsamples']
+              'thinned_by', 'cmd', 'resume_points', 'effective_nsamples',
+              'run_start_time', 'run_end_time']
 # also skip evidence if multiple files are being combined, since that will
 # not be the same
 if len(opts.input_file) > 1:


### PR DESCRIPTION
`pycbc_inference_extract_samples` is supposed to be able to combine files. However, this functionality is currently broken because it tries to enforce that the `run_start_time` and `run_end_time` that is stored in the input files be the same. This patch fixes that by adding `run_start_time` and `run_end_time` to the list of file attrs that are ignored when combining files.