### PR TITLE
Update pegasus_workflow.py

### DIFF
--- a/pycbc/workflow/pegasus_workflow.py
+++ b/pycbc/workflow/pegasus_workflow.py
@@ -800,9 +800,13 @@ class SubWorkflow(dax.SubWorkflow):
         # change the attribute here.
         # WORSE, we only want to set this if the pegasus *planner* is version
         # 5.0.4 or larger
-        sproc_out = subprocess.check_output(['pegasus-version']).strip()
-        sproc_out = sproc_out.decode()
-        if version.parse(sproc_out) >= version.parse('5.0.4'):
+        try:
+            sproc_out = subprocess.check_output(['pegasus-version']).strip()
+            sproc_out = sproc_out.decode()
+            if version.parse(sproc_out) >= version.parse('5.0.4'):
+                output_map_file.for_planning=True
+        except:
+            print("Could not execute pegasus-version, assuming >= 5.0.4")
             output_map_file.for_planning=True
         self.add_inputs(output_map_file)
 

--- a/pycbc/workflow/pegasus_workflow.py
+++ b/pycbc/workflow/pegasus_workflow.py
@@ -806,7 +806,7 @@ class SubWorkflow(dax.SubWorkflow):
             if version.parse(sproc_out) >= version.parse('5.0.4'):
                 output_map_file.for_planning=True
         except:
-            print("Could not execute pegasus-version, assuming >= 5.0.4")
+            logging.warning("Could not execute pegasus-version, assuming >= 5.0.4")
             output_map_file.for_planning=True
         self.add_inputs(output_map_file)
 


### PR DESCRIPTION
# Bugfix in pegasus_workflow.py


This fix implements a workaround for cases where PyCBC and/or PyGRB workflows have a subworkflow structure that forbid the 
`pegasus-version` command from being successfully executed on working nodes. 

<!--- Some basic info about the change (delete as appropriate) -->
This is a: bug fix.

<!--- What codes will this affect? (delete as apropriate)
PyCBC allsky and PyGRB workflows.
-->
This change affects: the offline search, PyGRB.
