### PR TITLE
Fix logic for determining frame type in `pycbc_make_skymap`

### DIFF
--- a/bin/pycbc_make_skymap
+++ b/bin/pycbc_make_skymap
@@ -106,14 +106,6 @@ def main(trig_time, mass1, mass2, spin1z, spin2z, f_low, f_upper, sample_rate,
         frame_types = {}
     if channel_names is None:
         channel_names = {}
-    for ifo in ifos:
-        if ifo not in frame_types:
-            frame_types[ifo] = default_frame_type(mean_trig_time, ifo)
-        if ifo not in channel_names:
-            if fake_strain[ifo] is not None:
-                channel_names[ifo] = ifo + ':FAKE_DATA'
-            else:
-                channel_names[ifo] = default_channel_name(mean_trig_time, ifo)
 
     # resulting files will be tagged with this string
     file_name_tag = '{:.0f}'.format(mean_trig_time)
@@ -165,6 +157,12 @@ def main(trig_time, mass1, mass2, spin1z, spin2z, f_low, f_upper, sample_rate,
     st_psd_paths = {}
     st_out_paths = {}
     for ifo in ifos:
+        if ifo not in channel_names:
+            if fake_strain[ifo] is not None:
+                channel_names[ifo] = ifo + ':FAKE_DATA'
+            else:
+                channel_names[ifo] = default_channel_name(mean_trig_time, ifo)
+
         # compose the command line for the single-template process
         st_psd_paths[ifo] = os.path.join(
                 tmpdir, 'PSD_{}_{}.txt'.format(file_name_tag, ifo))
@@ -227,6 +225,8 @@ def main(trig_time, mass1, mass2, spin1z, spin2z, f_low, f_upper, sample_rate,
                 command.append(str(fake_strain_seed[ifo]))
         elif custom_frame_files is None or ifo not in custom_frame_files:
             # use default guesses for this ifo
+            if ifo not in frame_types:
+                frame_types[ifo] = default_frame_type(mean_trig_time, ifo)
             command.append("--frame-type")
             command.append(frame_types[ifo])
         else:


### PR DESCRIPTION
Fixes a crash in `pycbc_make_skymap` triggered by using simulated strain and a detector that is not H1, L1 or V1.

## Standard information about the request

This is a bug fix which affects only `pycbc_make_skymap`.

## Motivation

A student reported that adding KAGRA to our example produces this error:
```
Traceback (most recent call last):
  File "/home/tito/virtualenvs/pycbc/bin/pycbc_make_skymap", line 574, in <module>
    main(opt.trig_time, opt.mass1, opt.mass2,
  File "/home/tito/virtualenvs/pycbc/bin/pycbc_make_skymap", line 111, in main
    frame_types[ifo] = default_frame_type(mean_trig_time, ifo)
  File "/home/tito/virtualenvs/pycbc/bin/pycbc_make_skymap", line 56, in default_frame_type
    raise ValueError('Detector {} not supported at time {}'.format(ifo, time))
ValueError: Detector K1 not supported at time 1272790260.0
```

## Contents

The logic that determines the frame type to pass to `pycbc_single_template` was wrong in a trivial way. It was trying to guess the frame type based on the detector and trigger time even when the fake strain is being used, i.e. when no guessing is necessary. I reworked the logic to only guess the frame type when necessary.

## Links to any issues or associated PRs

N/A

## Testing performed

I ran the example before and after the fix, first with the default HLV network and then by adding KAGRA as well. Here are the results, just for fun:

![image](https://github.com/user-attachments/assets/d0061ce5-83e0-443d-889c-12fa5a3f3a00)

![image](https://github.com/user-attachments/assets/b6dab5e1-cdfb-4b7f-a11a-0e22e33f23cd)

## Additional notes

Hopefully we will see KAGRA at 80 Mpc soon 🤞

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
