### PR TITLE
Downsample waveform in gated gaussian model

### DIFF
--- a/pycbc/inference/models/gated_gaussian_noise.py
+++ b/pycbc/inference/models/gated_gaussian_noise.py
@@ -29,7 +29,7 @@ from pycbc.detector import Detector
 from pycbc.pnutils import hybrid_meco_frequency
 from pycbc.waveform.utils import time_from_frequencyseries
 from pycbc.waveform import generator
-from pycbc.filter import highpass
+from pycbc.filter import highpass, resample_to_delta_t
 from .gaussian_noise import (BaseGaussianNoise, create_waveform_generator)
 from .base_data import BaseDataModel
 from .data_utils import fd_data_from_strain_dict
@@ -207,6 +207,12 @@ class BaseGatedGaussian(BaseGaussianNoise):
                     h = highpass(
                         h.to_timeseries(),
                         frequency=self.highpass_waveforms).to_frequencyseries()
+                if 'waveform_srate' in self.static_params:
+                    logging.warning("Resampling waveform from %f to %f Hz",
+                                    self.static_params['waveform_srate'], self.data[det].sample_rate)
+                    h = resample_to_delta_t(h.to_timeseries(),
+                                     1. / self.data[det].sample_rate,
+                                     method='ldas').to_frequencyseries()
                 wfs[det] = h
             self._current_wfs = wfs
         return self._current_wfs

--- a/pycbc/inference/models/gaussian_noise.py
+++ b/pycbc/inference/models/gaussian_noise.py
@@ -1215,6 +1215,9 @@ def create_waveform_generator(
                         d.start_time == start_time]):
                 raise ValueError("data must all have the same delta_t, "
                                  "delta_f, and start_time")
+    if 'waveform_srate' in static_params:
+        delta_t = 1. / static_params['waveform_srate']
+        logging.warning("Overriding delta_t to match waveform_srate")
     waveform_generator = generator_class(
         generator_function, epoch=start_time,
         variable_args=variable_params, detectors=list(data.keys()),


### PR DESCRIPTION
<!---
Please delete these comments when you submit the pull request

Please add a title which is a concise description of what you are doing,
e.g. 'Fix bug with numpy import in pycbc_coinc_findtrigs' or 'add high frequency sky location dependent response for long detectors'
-->

<!---
This is a brief template for making pull requests for PyCBC.
This is _not_ a proscriptive template - you can use a different style if you want.
Please do think about the questions posed here and whether the details will be useful to include in your PR
Please add sufficient details so that people looking back at the request with no context around the work can understand the changes.
To choose reviewers, please look at the git blame for the code you are changing (if applicable),
or discuss in the #pycbc-code channel of the gwastro slack.
Please add labels as appropriate
-->

<!-- TOP-LEVEL SUMMARY: Please provide a brief, one-or-two-sentence description of the PR here
-->

## Standard information about the request

<!--- Some basic info about the change (delete as appropriate) -->
This is a: new feature

<!--- What codes will this affect? (delete as apropriate)
If you do not know which areas will be affected, please ask in the gwastro #pycbc-code slack
-->
This change affects: inference

<!--- What code areas will this affect? (delete as apropriate) -->
This change changes: scientific output

<!--- Some things which help with code management (delete as appropriate) -->
This change: follows style guidelines (See e.g. [PEP8](https://peps.python.org/pep-0008/)), has been proposed using the [contribution guidelines](https://github.com/gwastro/pycbc/blob/master/CONTRIBUTING.md)

<!--- Notes about the effect of this change -->
This change will: only affect the "gated_gaussian_noise" model in the inference.

## Motivation
<!--- Describe why your changes are being made -->

Siegel el at. showed in their [recent paper](https://arxiv.org/abs/2410.02704) the waveform should also be downsampled. So I add this feature for some tests. For nwo it's in gated gaussian model.
 
## Contents
<!--- Describe your changes, this doesn't need to be a line-by-line code change discussion,
but rather a general discussion of the methods chosen -->

Add a new attribute `waveform_srate` in the `static_params`. The waveform would be generated in this sample rate and down sampled to the data's sample rate.

An example of the configuration file:

> [data]
> sample-rate = 1024
> 
> [static_params]
> waveform_srate = 2048

With this configuration, the waveform would be generated with sampling rate 2048 Hz first and downsampled to 1024 Hz.

## Links to any issues or associated PRs
<!--- If this is fixing / working around an already-reported issue, please link to it here -->

## Testing performed
<!--- Describe tests for the code changes, either already performed or to be performed -->

## Additional notes
<!--- Anything which does not fit in the above sections -->

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
