### PR TITLE
Handling vetoes and timeslides in pygrb mini followups

### DIFF
--- a/bin/pygrb/pycbc_pygrb_minifollowups
+++ b/bin/pygrb/pycbc_pygrb_minifollowups
@@ -56,22 +56,22 @@ def add_wiki_row(outfile, cols):
 
 
 def make_timeseries_plot(workflow, trig_file, snr_type, central_time,
-                         shift_time, out_dir, ifo=None, seg_files=None,
-                         veto_file=None, slide_id=0, tags=None):
+                         out_dir, ifo=None, seg_files=None,
+                         veto_file=None, tags=None):
     """Adds a node for a timeseries of PyGRB results to the workflow"""
 
     tags = [] if tags is None else tags
 
-    # If necessary, overwrite the slide-id configuration option to ensure only
-    # the correct timeslide is used in these follow-up plots
+    # Ensure that zero-lag data is used in these follow-up plots and store
+    # the slide-id option originally provided
     orig_slide_id = None
     if workflow.cp.has_option('pygrb_plot_snr_timeseries','slide-id'):
         orig_slide_id = workflow.cp.get('pygrb_plot_snr_timeseries','slide-id')
-        workflow.cp.add_options_to_section(
-            'pygrb_plot_snr_timeseries',
-            [('slide-id', str(slide_id))],
-            True
-        )
+    workflow.cp.add_options_to_section(
+        'pygrb_plot_snr_timeseries',
+        [('slide-id', '0')],
+        True
+    )
 
     # Initialize job node with its tags
     grb_name = workflow.cp.get('workflow', 'trigger-name')
@@ -97,10 +97,7 @@ def make_timeseries_plot(workflow, trig_file, snr_type, central_time,
     node.add_opt('--y-variable', snr_type)
     if ifo is not None:
         node.add_opt('--ifo', ifo)
-    reset_central_time = shift_time - central_time
-    # Horizontal axis range the = prevents errors with negative times
-    x_lims = str(-5.+reset_central_time)+','+str(reset_central_time+5.)
-    node.add_opt('--x-lims='+x_lims)
+    node.add_opt('--x-lims=-5.,5.')
     # Plot title
     if ifo is not None:
         title_str = f"'{ifo} SNR at {central_time:.3f} (s)'"
@@ -113,13 +110,16 @@ def make_timeseries_plot(workflow, trig_file, snr_type, central_time,
     # Add job node to workflow
     workflow += node
 
-    # Revert back the original slide-id option if necessary
+    # Revert the config parser back to how it was given
     if orig_slide_id:
         workflow.cp.add_options_to_section(
             'pygrb_plot_snr_timeseries',
             [('slide-id', orig_slide_id)],
             True
         )
+    else:
+        workflow.cp.remove_option('pygrb_plot_snr_timeseries','slide-id')
+
 
     return node.output_files
 
@@ -200,9 +200,10 @@ except:
 # Loop over triggers/injections to be followed up
 for num_event in range(num_events):
     files = FileList([])
-    logging.info('Processing event: %s', num_event)
+    logging.info('Processing event: %s', num_event+1)
     gps_time = fp['GPS time'][num_event]
     gps_time = gps_time.astype(float)
+    tags = args.tags + [str(num_event+1)]
     if wiki_file:
         row = []
         for key in fp.keys():
@@ -212,37 +213,30 @@ for num_event in range(num_events):
     if is_injection_followup:
         for snr_type in ['reweighted', 'coherent']:
             files += make_timeseries_plot(workflow, trig_file,
-                                          snr_type, gps_time, gps_time,
+                                          snr_type, gps_time,
                                           args.output_dir, ifo=None,
                                           seg_files=seg_files,
                                           veto_file=veto_file,
-                                          slide_id=0,
-                                          tags=args.tags + [str(num_event)])
+                                          tags=tags)
         for ifo in ifos:
             files += mini.make_qscan_plot(workflow, ifo, gps_time,
                                           args.output_dir,
-                                          tags=args.tags + [str(num_event)])
-    # Handle off/on-source loudest triggers follow-up (which are on slid data)
+                                          tags=tags)
+    # Handle off/on-source loudest triggers follow-up (which may be on slid
+    # data in the case of the off-source)
     else:
-        # If the file has information about slides, this is the follow up of an
-        # offsource event, otherwise it is the loudest onsource event, and
-        # zero-lag data must be used
-        slide_id = 0
-        if 'Slide Num' in fp.keys():
-            slide_id = fp['Slide Num'][num_event]
-        for ifo in ifos:
+        for i_ifo, ifo in enumerate(ifos):
             time_shift = fp[ifo+' time shift (s)'][num_event]
-            ifo_time = gps_time - time_shift
+            ifo_time = gps_time + time_shift
             files += make_timeseries_plot(workflow, trig_file,
-                                          'single', gps_time, ifo_time,
+                                          'single', ifo_time,
                                           args.output_dir, ifo=ifo,
                                           seg_files=seg_files,
                                           veto_file=veto_file,
-                                          slide_id=slide_id,
-                                          tags=args.tags + [str(num_event)])
+                                          tags=tags)
             files += mini.make_qscan_plot(workflow, ifo, ifo_time,
                                           args.output_dir,
-                                          tags=args.tags + [str(num_event)])
+                                          tags=tags)
 
     layouts += list(layout.grouper(files, 2))
 

--- a/bin/pygrb/pycbc_pygrb_minifollowups
+++ b/bin/pygrb/pycbc_pygrb_minifollowups
@@ -102,8 +102,7 @@ def make_timeseries_plot(workflow, trig_file, snr_type, central_time,
     if ifo is not None:
         title_str = f"'{ifo} SNR at {central_time:.3f} (s)'"
     else:
-        title_str = "'%s SNR at %.3f (s)'" % (snr_type.capitalize(),
-                                              central_time)
+        title_str = f"'{snr_type.capitalize()} SNR at {central_time:.3f} (s)'"
     node.add_opt('--trigger-time', central_time)
     node.add_opt('--plot-title', title_str)
 
@@ -193,7 +192,7 @@ is_injection_followup = True
 try:
     time_shift = fp[ifos[0]+' time shift (s)'][0]
     is_injection_followup = False
-except:
+except KeyError:
     pass
 
 # Loop over triggers/injections to be followed up

--- a/bin/pygrb/pycbc_pygrb_minifollowups
+++ b/bin/pygrb/pycbc_pygrb_minifollowups
@@ -120,7 +120,6 @@ def make_timeseries_plot(workflow, trig_file, snr_type, central_time,
     else:
         workflow.cp.remove_option('pygrb_plot_snr_timeseries','slide-id')
 
-
     return node.output_files
 
 

--- a/bin/pygrb/pycbc_pygrb_minifollowups
+++ b/bin/pygrb/pycbc_pygrb_minifollowups
@@ -56,10 +56,22 @@ def add_wiki_row(outfile, cols):
 
 
 def make_timeseries_plot(workflow, trig_file, snr_type, central_time,
-                         shift_time, out_dir, ifo=None, tags=None):
+                         shift_time, out_dir, ifo=None, seg_files=None,
+                         veto_file=None, slide_id=0, tags=None):
     """Adds a node for a timeseries of PyGRB results to the workflow"""
 
     tags = [] if tags is None else tags
+
+    # If necessary, overwrite the slide-id configuration option to ensure only
+    # the correct timeslide is used in these follow-up plots
+    orig_slide_id = None
+    if workflow.cp.has_option('pygrb_plot_snr_timeseries','slide-id'):
+        orig_slide_id = workflow.cp.get('pygrb_plot_snr_timeseries','slide-id')
+        workflow.cp.add_options_to_section(
+            'pygrb_plot_snr_timeseries',
+            [('slide-id', str(slide_id))],
+            True
+        )
 
     # Initialize job node with its tags
     grb_name = workflow.cp.get('workflow', 'trigger-name')
@@ -71,6 +83,14 @@ def make_timeseries_plot(workflow, trig_file, snr_type, central_time,
                           ifos=workflow.ifos, out_dir=out_dir,
                           tags=tags+extra_tags).create_node()
     node.add_input_opt('--trig-file', trig_file)
+    # Include the onsource trial if this is a follow up on the onsource
+    if 'loudest_onsource_event' in tags:
+        node.add_opt('--onsource')
+    # Pass the segments files and veto file
+    if seg_files:
+        node.add_input_list_opt('--seg-files', seg_files)
+    if veto_file:
+        node.add_input_opt('--veto-file', veto_file)
     node.new_output_file_opt(workflow.analysis_time, '.png',
                              '--output-file', tags=extra_tags)
     # Quantity to be displayed on the y-axis of the plot
@@ -93,6 +113,14 @@ def make_timeseries_plot(workflow, trig_file, snr_type, central_time,
     # Add job node to workflow
     workflow += node
 
+    # Revert back the original slide-id option if necessary
+    if orig_slide_id:
+        workflow.cp.add_options_to_section(
+            'pygrb_plot_snr_timeseries',
+            [('slide-id', orig_slide_id)],
+            True
+        )
+
     return node.output_files
 
 
@@ -107,6 +135,11 @@ parser.add_argument('--followups-file',
                     help="HDF file with the triggers/injections to follow up")
 parser.add_argument('--wiki-file',
                     help="Name of file to save wiki-formatted table in")
+parser.add_argument("-a", "--seg-files", nargs="+", action="store",
+                    default=[], help="The location of the buffer, " +
+                    "onsource and offsource txt segment files.")
+parser.add_argument("-V", "--veto-file", action="store",
+                    help="The location of the xml veto file.")
 wf.add_workflow_command_line_group(parser)
 wf.add_workflow_settings_cli(parser, include_subdax_opts=True)
 ppu.pygrb_add_bestnr_cut_opt(parser)
@@ -142,6 +175,19 @@ trig_file = resolve_url_to_file(os.path.abspath(args.trig_file))
 ifos = ppu.extract_ifos(os.path.abspath(args.trig_file))
 num_ifos = len(ifos)
 
+# File instance of the veto file
+veto_file = args.veto_file
+start_rundir = os.getcwd()
+if veto_file:
+    veto_file = os.path.join(start_rundir, args.veto_file)
+    veto_file = wf.resolve_url_to_file(veto_file)
+
+# Convert the segments files to a FileList
+seg_files = wf.FileList([
+    wf.resolve_url_to_file(os.path.join(start_rundir, f))
+    for f in args.seg_files
+])
+
 # (Loudest) off/on-source events are on time-slid data so the
 # try will succeed, as it finds the time shift columns.
 is_injection_followup = True
@@ -150,7 +196,6 @@ try:
     is_injection_followup = False
 except:
     pass
-
 
 # Loop over triggers/injections to be followed up
 for num_event in range(num_events):
@@ -163,27 +208,39 @@ for num_event in range(num_events):
         for key in fp.keys():
             row.append(fp[key][num_event])
         add_wiki_row(wiki_file, row)
+    # Handle injections (which are on unslid data)
+    if is_injection_followup:
+        for snr_type in ['reweighted', 'coherent']:
+            files += make_timeseries_plot(workflow, trig_file,
+                                          snr_type, gps_time, gps_time,
+                                          args.output_dir, ifo=None,
+                                          seg_files=seg_files,
+                                          veto_file=veto_file,
+                                          slide_id=0,
+                                          tags=args.tags + [str(num_event)])
+        for ifo in ifos:
+            files += mini.make_qscan_plot(workflow, ifo, gps_time,
+                                          args.output_dir,
+                                          tags=args.tags + [str(num_event)])
     # Handle off/on-source loudest triggers follow-up (which are on slid data)
-    if not is_injection_followup:
+    else:
+        # If the file has information about slides, this is the follow up of an
+        # offsource event, otherwise it is the loudest onsource event, and
+        # zero-lag data must be used
+        slide_id = 0
+        if 'Slide Num' in fp.keys():
+            slide_id = fp['Slide Num'][num_event]
         for ifo in ifos:
             time_shift = fp[ifo+' time shift (s)'][num_event]
             ifo_time = gps_time - time_shift
             files += make_timeseries_plot(workflow, trig_file,
                                           'single', gps_time, ifo_time,
                                           args.output_dir, ifo=ifo,
+                                          seg_files=seg_files,
+                                          veto_file=veto_file,
+                                          slide_id=slide_id,
                                           tags=args.tags + [str(num_event)])
             files += mini.make_qscan_plot(workflow, ifo, ifo_time,
-                                          args.output_dir,
-                                          tags=args.tags + [str(num_event)])
-    # Handle injections (which are on unslid data)
-    else:
-        for snr_type in ['reweighted', 'coherent']:
-            files += make_timeseries_plot(workflow, trig_file,
-                                          snr_type, gps_time, gps_time,
-                                          args.output_dir, ifo=None,
-                                          tags=args.tags + [str(num_event)])
-        for ifo in ifos:
-            files += mini.make_qscan_plot(workflow, ifo, gps_time,
                                           args.output_dir,
                                           tags=args.tags + [str(num_event)])
 

--- a/bin/pygrb/pycbc_pygrb_page_tables
+++ b/bin/pygrb/pycbc_pygrb_page_tables
@@ -395,7 +395,7 @@ if lofft_outfile:
         d.append(bestnr)
         td.append(d)
 
-    # th: table header
+    # th: table header [pycbc_pygrb_minifollowups looks for 'Slide Num']
     th = ['Trial', 'Slide Num', 'p-value', 'GPS time',
           'Rec. m1', 'Rec. m2', 'Rec. Mc', 'Rec. spin1z', 'Rec. spin2z',
           'Rec. RA', 'Rec. Dec', 'SNR', 'Chi^2', 'Null SNR']

--- a/pycbc/results/pygrb_postprocessing_utils.py
+++ b/pycbc/results/pygrb_postprocessing_utils.py
@@ -23,7 +23,6 @@
 Module to generate PyGRB figures: scatter plots and timeseries.
 """
 
-import os
 import logging
 import argparse
 import copy
@@ -33,6 +32,7 @@ import h5py
 from scipy import stats
 import ligo.segments as segments
 from pycbc.events.coherent import reweightedsnr_cut
+from pycbc.events import veto
 from pycbc import add_common_pycbc_options
 from pycbc.io.hdf import HFile
 
@@ -242,7 +242,7 @@ def _extract_vetoes(veto_file, ifos, offsource):
             vetoes[ifo] = segments.segmentlist([offsource]) - clean_segs[ifo]
         vetoes.coalesce()
         for ifo in ifos:
-            for v in vetoes[ifo]: 
+            for v in vetoes[ifo]:
                 v_span = v[1] - v[0]
                 logging.info("%ds of data vetoed at GPS time %d",
                              v_span, v[0])
@@ -269,7 +269,7 @@ def _slide_vetoes(vetoes, slide_dict_or_list, slide_id, ifos):
 
 
 # =============================================================================
-# Recursive function to reach all datasets in an HDF file handle 
+# Recursive function to reach all datasets in an HDF file handle
 # =============================================================================
 def _dataset_iterator(g, prefix=''):
     """Reach all datasets in an HDF file handle"""
@@ -368,9 +368,6 @@ def load_data(input_file, ifos, rw_snr_threshold=None, data_tag=None,
     return trigs_dict
 
 
-
-
-
 # =============================================================================
 # Detector utils:
 # * Function to calculate the antenna response F+^2 + Fx^2
@@ -466,8 +463,7 @@ def extract_trig_properties(trial_dict, trigs, slide_dict, seg_dict, keys):
 
     # Sort the triggers into each slide
     sorted_trigs = sort_trigs(trial_dict, trigs, slide_dict, seg_dict)
-    n_surviving_trigs = sum([len(sorted_trigs[slide_id])
-                             for slide_id in sorted_trigs.keys()])
+    n_surviving_trigs = sum([len(i) for i in sorted_trigs.values()])
     msg = f"{n_surviving_trigs} triggers found within the trials dictionary "
     msg += "and sorted."
     logging.info(msg)
@@ -490,7 +486,6 @@ def extract_trig_properties(trial_dict, trigs, slide_dict, seg_dict, keys):
     logging.info("Triggers information extracted.")
 
     return found_trigs
-
 
 
 # =============================================================================

--- a/pycbc/results/pygrb_postprocessing_utils.py
+++ b/pycbc/results/pygrb_postprocessing_utils.py
@@ -583,7 +583,7 @@ def load_segment_dict(hdf_file_path):
 # =============================================================================
 def construct_trials(seg_files, seg_dict, ifos, slide_dict, veto_file,
                      hide_onsource=True):
-    """Constructs trials from triggers, timeslides, segments and vetoes"""
+    """Constructs trials from segments, timeslides, and vetoes"""
 
     logging.info("Constructing trials.")
     trial_dict = {}

--- a/pycbc/results/pygrb_postprocessing_utils.py
+++ b/pycbc/results/pygrb_postprocessing_utils.py
@@ -582,7 +582,7 @@ def load_segment_dict(hdf_file_path):
 # Construct the trials from the timeslides, segments, and vetoes
 # =============================================================================
 def construct_trials(seg_files, seg_dict, ifos, slide_dict, veto_file,
-                     show_onsource=False):
+                     hide_onsource=True):
     """Constructs trials from triggers, timeslides, segments and vetoes"""
 
     logging.info("Constructing trials.")
@@ -603,7 +603,7 @@ def construct_trials(seg_files, seg_dict, ifos, slide_dict, veto_file,
 
         # Fill in the buffer segment list if the onsource data must be hidden
         seg_buffer = segments.segmentlist()
-        if show_onsource:
+        if hide_onsource:
             for ifo in ifos:
                 slide_offset = slide_dict[slide_id][ifo]
                 seg_buffer.append(segments.segment(segs['buffer'][0] -


### PR DESCRIPTION
This PR is the third in the series started in PR #4929.

## Standard information about the request (and the following ones that will be linked to this)

This is a: a new feature enabling veto definer file usage in PyGRB.  Utilities and scripts in results production are being  streamlined along the way.

This change affects: PyGRB

This change changes: result presentation / plotting and scientific output.

<!--- Notes about the effect of this change -->
If this change breaks the standard automated test running `--help` for PyGRB plotting scripts, I will add some workarounds to avoid this.  If needed, these will likely be empty functions: the plotting scripts will be progressively renovated in the whole series of PRs.

## Motivation
Now that the workflow generator passes around the veto definer file, the mini followups need to handle it use it.  In checking `pycbc_pygrb_minifollowups` I noticed that it is better to enforce the correct timesmlide is being plotted.

## Contents
- Enable passing veto and segments files to `pycbc_pygrb_minifollowups` and the jobs it prepares.
- Figure out the correct timeslide to be plotted (e.g., zero-lag for the loudest onsource event) and ensure it is the one used in time series plots.
- Somewhat unrelated, but in preparation of other PRs, the utility `construct_trials` was improved and the utility `extract_basic_trig_properties ` was generalized to `extract_trig_properties` in which the user specifies what datasets need to be extracted from the trigger file.

## Testing performed
The totality of the changes that will be broken down in multiple PRs was tested on GRB 170817A data by producing a full results webpage (see [here](https://ldas-jobs.ligo.caltech.edu/~francesco.pannarale/LVC/pygrb_nov2024_1/)).

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)