### PR TITLE
Fix bug when plotting maximum likelihood point in `create_multidim_plot`

### DIFF
--- a/pycbc/results/scatter_histograms.py
+++ b/pycbc/results/scatter_histograms.py
@@ -679,12 +679,6 @@ def create_multidim_plot(parameters, samples, labels=None,
     else:
         width_ratios = height_ratios = None
 
-    if plot_maxl:
-        # make sure loglikelihood is provide
-        if 'loglikelihood' not in samples.fieldnames:
-            raise ValueError("plot-maxl requires loglikelihood")
-        maxidx = samples['loglikelihood'].argmax()
-
     # only plot scatter if more than one parameter
     plot_scatter = plot_scatter and nparams > 1
 
@@ -703,6 +697,12 @@ def create_multidim_plot(parameters, samples, labels=None,
             zvals = 'gray'
             if plot_contours and contour_color is None:
                 contour_color = 'navy'
+
+    if plot_maxl:
+        # make sure loglikelihood is provide
+        if 'loglikelihood' not in samples.fieldnames:
+            raise ValueError("plot-maxl requires loglikelihood")
+        maxidx = samples['loglikelihood'].argmax()
 
     # create the axis grid
     if fig is None and axis_dict is None:


### PR DESCRIPTION
This is a bugfix to the `create_multidim_plot` function in `scatter_histograms.py`. Specifying `--plot-maxl` does not plot the expected maximum likelihood point when used in conjunction with `--plot-scatter` in multidimensional plots. Currently, `plot-maxl` selects the index of the max likelihood sample before `plot-scatter` sorts the samples by their z argument. When both options are specified, the selected maxL index will generally not correspond to the maxL sample in the newly sorted array.

This PR moves the indexing selection for `plot-maxl` after the samples are sorted by `plot-scatter`. This should have no effect if using either option separately with codes using `create_multidim_plot` (e.g. `pycbc_inference_plot_posterior`), but should now correctly plot the maxL sample if both are specified.