### PR TITLE
Fix check for `pegasus-plan`

### DIFF
--- a/pycbc/workflow/pegasus_sites.py
+++ b/pycbc/workflow/pegasus_sites.py
@@ -186,7 +186,16 @@ def add_condorpool_shared_site(sitecat, cp, local_path, local_url):
     site.add_profiles(Namespace.DAGMAN, key="retry", value="2")
     # Need to set PEGASUS_HOME
     peg_home = which('pegasus-plan')
-    assert peg_home.endswith('bin/pegasus-plan')
+    if peg_home is None:
+        raise RuntimeError(
+            'pegasus-plan command not found. '
+            'Make sure Pegasus is correctly installed.'
+        )
+    if not peg_home.endswith('bin/pegasus-plan'):
+        raise RuntimeError(
+            f'path to pegasus-plan is weird: {peg_home}. '
+            'Make sure Pegasus is correctly installed.'
+        )
     peg_home = peg_home.replace('bin/pegasus-plan', '')
     site.add_profiles(Namespace.ENV, key="PEGASUS_HOME", value=peg_home)
     sitecat.add_sites(site)


### PR DESCRIPTION
When Pegasus is not installed, planning a workflow will give you a weird error. This makes it give a better error.

## Standard information about the request

This is a bug fix.

This change affects anything based on Pegasus workflows.

## Motivation

The old code would give you this error:
```
AttributeError: 'NoneType' object has no attribute 'endswith'
```
and then postdocs and students would ask me what is happening, and I would have to investigate and find out that the cause was a trivial mistake on my end.

With this PR I can skip the "investigate" part.

## Contents

Catch the case when `pegasus-plan` is not available and print out an explicit message.

## Links to any issues or associated PRs

N/A

## Testing performed

None.

## Additional notes

:unicorn_face:

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
