### PR TITLE
Pass kwargs to pool constructor in `choose_pool`

### DIFF
--- a/pycbc/pool.py
+++ b/pycbc/pool.py
@@ -131,6 +131,10 @@ def _dummy_broadcast(self, f, args):
     self.map(f, [args] * self.size)
 
 class SinglePool(object):
+
+    def __init__(self, **_):
+        pass
+
     def broadcast(self, fcn, args):
         return self.map(fcn, [args])
 
@@ -174,15 +178,18 @@ def use_mpi(require_mpi=False, log=True):
     return use_mpi, size, rank
 
 
-def choose_pool(processes, mpi=False):
-    """ Get processing pool
+def choose_pool(processes, mpi=False, **kwargs):
+    """ Get processing pool.
+
+    Keyword arguments are pass to the pool constructor.
     """
     do_mpi, size, rank = use_mpi(require_mpi=mpi)
     if do_mpi:
         try:
             import schwimmbad
             pool = schwimmbad.choose_pool(mpi=do_mpi,
-                                          processes=(size - 1))
+                                          processes=(size - 1),
+                                          **kwargs)
             pool.broadcast = types.MethodType(_dummy_broadcast, pool)
             atexit.register(pool.close)
 
@@ -197,11 +204,11 @@ def choose_pool(processes, mpi=False):
             raise ValueError("Failed to start up an MPI pool, "
                              "install mpi4py / schwimmbad")
     elif processes == 1:
-        pool = SinglePool()
+        pool = SinglePool(**kwargs)
     else:
         if processes == -1:
             processes = cpu_count()
-        pool = BroadcastPool(processes)
+        pool = BroadcastPool(processes, **kwargs)
 
     pool.size = processes
     if size:

--- a/pycbc/pool.py
+++ b/pycbc/pool.py
@@ -181,7 +181,7 @@ def use_mpi(require_mpi=False, log=True):
 def choose_pool(processes, mpi=False, **kwargs):
     """ Get processing pool.
 
-    Keyword arguments are pass to the pool constructor.
+    Keyword arguments are passed to the pool constructor.
     """
     do_mpi, size, rank = use_mpi(require_mpi=mpi)
     if do_mpi:


### PR DESCRIPTION
<!---
Please delete these comments when you submit the pull request

Please add a title which is a concise description of what you are doing,
e.g. 'Fix bug with numpy import in pycbc_coinc_findtrigs' or 'add high frequency sky location dependent response for long detectors'
-->

<!---
This is a brief template for making pull requests for PyCBC.
This is _not_ a proscriptive template - you can use a different style if you want.
Please do think about the questions posed here and whether the details will be useful to include in your PR
Please add sufficient details so that people looking back at the request with no context around the work can understand the changes.
To choose reviewers, please look at the git blame for the code you are changing (if applicable),
or discuss in the #pycbc-code channel of the gwastro slack.
Please add labels as appropriate
-->

<!-- TOP-LEVEL SUMMARY: Please provide a brief, one-or-two-sentence description of the PR here
-->

Pass keyword arguments passed to `choose_pool` to the pool constructor. This enables additional configuration of the pool.

## Standard information about the request

<!--- Some basic info about the change (delete as appropriate) -->
This is a: bug fix

<!--- What codes will this affect? (delete as apropriate)
If you do not know which areas will be affected, please ask in the gwastro #pycbc-code slack
-->
This change affects:  `pycbc_bruke_bank`, inference. However, since `choose_pool` is never called with any keyword arguments, things are functionally the same.

<!--- What code areas will this affect? (delete as apropriate) -->
This change changes: configuration

<!--- Some things which help with code management (delete as appropriate) -->
This change: has appropriate unit tests, follows style guidelines (See e.g. [PEP8](https://peps.python.org/pep-0008/))

<!--- Notes about the effect of this change -->
This change is backwards compatible

## Motivation

This enables specifying e.g. `initalizer` and `initargs` when creating a pool. Both the default [`multiprocessing` library](https://docs.python.org/3/library/multiprocessing.html#module-multiprocessing.pool) and [`schwimmbad`](https://schwimmbad.readthedocs.io/en/latest/api.html#schwimmbad.MultiPool) support these arguments.

This will allow me to improve how the multiprocessing pool is configured for `nessai`, which will be a subsequent PR.

## Contents

I've added `kwargs` to `choose_pool`. I've also updated `SinglePool` to allow arbitrary keyword arguments, this is consistent with [`SerialPool`](https://github.com/adrn/schwimmbad/blob/main/src/schwimmbad/serial.py#L16) from `schwimmbad`.

## Links to any issues or associated PRs
N/A

## Testing performed

The changes are covered by existing tests.

## Additional notes
<!--- Anything which does not fit in the above sections -->

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
