### PR TITLE
Fix a couple of output/upload value issues in pycbc live

### DIFF
--- a/pycbc/events/single.py
+++ b/pycbc/events/single.py
@@ -303,7 +303,8 @@ class LiveSingle(object):
 
         # fill in a new candidate event
         candidate = {
-            f'foreground/{self.ifo}/{k}': cutall_trigs[k][i] for k in trigs
+            f'foreground/{self.ifo}/{k}': cut_trigs[k][sngl_idx][i]
+            for k in trigs
         }
         candidate['foreground/stat'] = rank[i]
         candidate['foreground/ifar'] = ifar

--- a/pycbc/io/gracedb.py
+++ b/pycbc/io/gracedb.py
@@ -136,7 +136,7 @@ class CandidateForGraceDB(object):
         coinc_event_row.time_slide_id = lsctables.TimeSlideID(0)
         coinc_event_row.process_id = proc_id
         coinc_event_row.coinc_event_id = coinc_id
-        coinc_event_row.likelihood = 0.
+        coinc_event_row.likelihood = coinc_results['foreground/stat']
         coinc_event_table.append(coinc_event_row)
         outdoc.childNodes[0].appendChild(coinc_event_table)
 

--- a/pycbc/io/gracedb.py
+++ b/pycbc/io/gracedb.py
@@ -136,7 +136,10 @@ class CandidateForGraceDB(object):
         coinc_event_row.time_slide_id = lsctables.TimeSlideID(0)
         coinc_event_row.process_id = proc_id
         coinc_event_row.coinc_event_id = coinc_id
-        coinc_event_row.likelihood = coinc_results['foreground/stat']
+        if 'foreground/stat' in coinc_results:
+            coinc_event_row.likelihood = coinc_results['foreground/stat']
+        else:
+            coinc_event_row.likelihood = 0.
         coinc_event_table.append(coinc_event_row)
         outdoc.childNodes[0].appendChild(coinc_event_table)
 


### PR DESCRIPTION
Update the chisquared uploaded to gracedb to be reduced, and save the ranking statistic value

## Standard information about the request

This is a bug fix
This change affects the live search
This change changes scientific output
This change: follows style guidelines (See e.g. [PEP8](https://peps.python.org/pep-0008/)), has been proposed using the [contribution guidelines](https://github.com/gwastro/pycbc/blob/master/CONTRIBUTING.md)

## Motivation / contents

We noticed that the chisquared for singles was not the reduced chisquared - I tracked it down to where I'd missed that I was using the same trigger set for statistic calculation as I was for the upload, which is not what is done for coincs, this is now set back to the un-modified set of triggers.

We also realised that the ranking statistic isnt being saved - I have added this to the gracedb upload/xml by utilising the "likelihood" value in the coinc row of the table.


## Testing performed
Need to test this, but thought it best to get the PR in first


- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
