### PR TITLE
Adding --fake-strain-from-file and channel names/frame types for O4 data

### DIFF
--- a/bin/pycbc_make_skymap
+++ b/bin/pycbc_make_skymap
@@ -58,7 +58,7 @@ def default_frame_type(time, ifo):
         if ifo == 'V1':
             return 'HoftOnline'
         elif ifo in ['H1', 'L1']:
-            return ifo + '_HOFT_C00'
+            return ifo + '_HOFT_C00_AR'
     raise ValueError('Detector {} not supported at time {}'.format(ifo, time))
 
 def default_channel_name(time, ifo):
@@ -85,7 +85,7 @@ def default_channel_name(time, ifo):
         if ifo == 'V1':
             return ifo + ':Hrec_hoft_16384Hz'
         elif ifo in ['H1', 'L1']:
-            return ifo + ':GDS-CALIB_STRAIN_CLEAN'
+            return ifo + ':GDS-CALIB_STRAIN_CLEAN_AR'
     raise ValueError('Detector {} not supported at time {}'.format(ifo, time))
 
 def main(trig_time, mass1, mass2, spin1z, spin2z, f_low, f_upper, sample_rate,
@@ -169,8 +169,6 @@ def main(trig_time, mass1, mass2, spin1z, spin2z, f_low, f_upper, sample_rate,
     st_psd_paths = {}
     st_out_paths = {}
     for ifo in ifos:
-        if ifo not in frame_types:
-            frame_types[ifo] = default_frame_type(mean_trig_time, ifo)
         if ifo not in channel_names:
             if (fake_strain[ifo] is not None or fake_strain_from_file[ifo] is not None):
                 channel_names[ifo] = ifo + ':FAKE_DATA'
@@ -238,7 +236,7 @@ def main(trig_time, mass1, mass2, spin1z, spin2z, f_low, f_upper, sample_rate,
                 command.append("--fake-strain-seed")
                 command.append(str(fake_strain_seed[ifo]))
         elif fake_strain_from_file[ifo] is not None:
-            # use fake strain for this ifo
+            # use fake strain for this ifo with ASDs given from files
             command.append("--fake-strain-from-file")
             command.append(fake_strain_from_file[ifo])
             if fake_strain_seed[ifo] is not None:

--- a/bin/pycbc_make_skymap
+++ b/bin/pycbc_make_skymap
@@ -47,12 +47,18 @@ def default_frame_type(time, ifo):
             return 'V1O2Repro2A'
         elif ifo in ['H1', 'L1']:
             return ifo + '_CLEANED_HOFT_C02'
-    elif time >= 1235433618:
+    elif time >= 1235433618 and time < 1368975618:
         # O3
         if ifo == 'V1':
             return 'V1Online'
         elif ifo in ['H1', 'L1']:
             return ifo + '_HOFT_CLEAN_SUB60HZ_C01'
+    elif time >= 1368975618:
+        # O4
+        if ifo == 'V1':
+            return 'HoftOnline'
+        elif ifo in ['H1', 'L1']:
+            return ifo + '_HOFT_C00'
     raise ValueError('Detector {} not supported at time {}'.format(ifo, time))
 
 def default_channel_name(time, ifo):
@@ -68,12 +74,18 @@ def default_channel_name(time, ifo):
             return ifo + ':Hrec_hoft_V1O2Repro2A_16384Hz'
         elif ifo in ['H1', 'L1']:
             return ifo + ':DCH-CLEAN_STRAIN_C02'
-    elif time >= 1235433618:
+    elif time >= 1235433618 and time < 1368975618:
         # O3
         if ifo == 'V1':
             return ifo + ':Hrec_hoft_16384Hz'
         elif ifo in ['H1', 'L1']:
             return ifo + ':DCS-CALIB_STRAIN_CLEAN_SUB60HZ_C01'
+    elif time > 1368975618:
+        # O4
+        if ifo == 'V1':
+            return ifo + ':Hrec_hoft_16384Hz'
+        elif ifo in ['H1', 'L1']:
+            return ifo + ':GDS-CALIB_STRAIN_CLEAN'
     raise ValueError('Detector {} not supported at time {}'.format(ifo, time))
 
 def main(trig_time, mass1, mass2, spin1z, spin2z, f_low, f_upper, sample_rate,
@@ -83,7 +95,7 @@ def main(trig_time, mass1, mass2, spin1z, spin2z, f_low, f_upper, sample_rate,
          segment_source=None, segment_server=None,
          gracedb_server=None, test_event=True,
          custom_frame_files=None, approximant=None, detector_state=None,
-         veto_definer=None, injection_file=None, fake_strain=None,
+         veto_definer=None, injection_file=None, fake_strain=None, fake_strain_from_file=None,
          fake_strain_seed=None, rescale_loglikelihood=None):
 
     if not test_event and not gracedb_server:
@@ -157,8 +169,10 @@ def main(trig_time, mass1, mass2, spin1z, spin2z, f_low, f_upper, sample_rate,
     st_psd_paths = {}
     st_out_paths = {}
     for ifo in ifos:
+        if ifo not in frame_types:
+            frame_types[ifo] = default_frame_type(mean_trig_time, ifo)
         if ifo not in channel_names:
-            if fake_strain[ifo] is not None:
+            if (fake_strain[ifo] is not None or fake_strain_from_file[ifo] is not None):
                 channel_names[ifo] = ifo + ':FAKE_DATA'
             else:
                 channel_names[ifo] = default_channel_name(mean_trig_time, ifo)
@@ -220,6 +234,13 @@ def main(trig_time, mass1, mass2, spin1z, spin2z, f_low, f_upper, sample_rate,
             # use fake strain for this ifo
             command.append("--fake-strain")
             command.append(fake_strain[ifo])
+            if fake_strain_seed[ifo] is not None:
+                command.append("--fake-strain-seed")
+                command.append(str(fake_strain_seed[ifo]))
+        elif fake_strain_from_file[ifo] is not None:
+            # use fake strain for this ifo
+            command.append("--fake-strain-from-file")
+            command.append(fake_strain_from_file[ifo])
             if fake_strain_seed[ifo] is not None:
                 command.append("--fake-strain-seed")
                 command.append(str(fake_strain_seed[ifo]))
@@ -556,6 +577,9 @@ if __name__ == '__main__':
     parser.add_argument('--fake-strain', type=str, 
                         action=MultiDetOptionAction, metavar="IFO:FAKE_STRAIN",
                         help="The set of fake-strains for each detector")
+    parser.add_argument('--fake-strain-from-file', type=str, 
+                        action=MultiDetOptionAction, metavar="IFO:FAKE_STRAIN_FROM_FILE",
+                        help="The set of fake-strains for each detector from files")
     parser.add_argument('--fake-strain-seed', type=int,
                         action=MultiDetOptionAction, metavar="IFO:FAKE_STRAIN_SEED",
                         help="The set of fake-strains-seeds for each detector")
@@ -582,5 +606,5 @@ if __name__ == '__main__':
          approximant=opt.approximant, detector_state=opt.detector_state,
          segment_source=opt.segment_source, segment_server=opt.segment_server,
          veto_definer=opt.veto_definer, injection_file=opt.injection_file, 
-         fake_strain=opt.fake_strain, fake_strain_seed=opt.fake_strain_seed,
+         fake_strain=opt.fake_strain, fake_strain_from_file=opt.fake_strain_from_file, fake_strain_seed=opt.fake_strain_seed,
          rescale_loglikelihood=opt.rescale_loglikelihood)


### PR DESCRIPTION
Current version of pycbc_make_skymap doesn't support usage of O4 strain. Generation of fake strain is also only available through `--fake-strain` using simulated ASDs stored within PyCBC and not external/custom ASD. 

## Standard information about the request
- This change enables usage of local ASD files as input for fake strain generation
- This change allows reading O4 strain at CIT if one wants to generate injections on real-time data

## Motivation
I wanted to use `pycbc_make_skymap` to investigate impact of transient noise on GW sky localisation during O4b for Virgo, but this required the proposed changes to be made.

## Contents
- Argument `--fake-strain-from-file` to compute fake strain based on custom ASD file as input, which is already available in `pycbc_single_template`
- Input file for ASD should be a two column file, line per line: FREQUENCY ASD_VALUE. Example in [DCC](https://dcc.ligo.org/LIGO-T2400104)
- Added strain channel names and frame types for H1/L1/V1 during O4, according to definitions [here](https://wiki.ligo.org/LSC/JRPComm/ObsRun4).
- GPStime start of O4a set to 1368975618, but we can also include ER15 times if needed

## Testing performed
Code tested both for usage of O4 strain and `--fake-strain-from-file` argument.

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
