### PR TITLE
Final version of pycbc_pygrb_plot_injs_results

### DIFF
--- a/bin/pygrb/pycbc_pygrb_plot_injs_results
+++ b/bin/pygrb/pycbc_pygrb_plot_injs_results
@@ -28,7 +28,7 @@ import matplotlib.pyplot as plt
 import matplotlib
 import numpy as np
 
-import pycbc.pnutils
+import pycbc.conversions
 import pycbc.results
 import pycbc.version
 from pycbc import init_logging
@@ -95,7 +95,7 @@ def complete_mass_data(injs, key, tag):
     if key == 'mtotal':
         data = injs[tag+'/mass1'][:] + injs[tag+'/mass2'][:]
     elif key == 'mchirp':
-        data, _ = pycbc.pnutils.mass1_mass2_to_mchirp_eta(
+        data = conversions.mchirp_from_mass1_mass2(
             injs[tag+'/mass1'],
             injs[tag+'/mass2'])
     else:

--- a/bin/pygrb/pycbc_pygrb_plot_injs_results
+++ b/bin/pygrb/pycbc_pygrb_plot_injs_results
@@ -67,7 +67,7 @@ def complete_incl_data(injs, key, tag):
     # Whether the user requests incl, |incl|, cos(incl), or cos(|incl|)
     # the following information is needed
     # TODO: make sure it is clear that inclination is interpreted as theta_jn
-    local_dict['incl'] = injs[tag+'/thetajn'][:]
+    local_dict['incl'] = injs[tag+'/thetajn']
 
     # Requesting |incl| or cos(|incl|)
     if 'abs_' in key:
@@ -90,16 +90,17 @@ def complete_mass_data(injs, key, tag):
     """Extract data related to mass ratio, chirp mass or total mass from raw
     injection data"""
 
-    data = np.full(len(injs[tag+'/mass1'][:]), None)
+    mass1 = injs[tag+'/mass1']
+    mass2 = injs[tag+'/mass2']
+
+    data = np.full(len(mass1), None)
 
     if key == 'mtotal':
-        data = injs[tag+'/mass1'][:] + injs[tag+'/mass2'][:]
+        data = mass1 + mass2
     elif key == 'mchirp':
-        data = conversions.mchirp_from_mass1_mass2(
-            injs[tag+'/mass1'],
-            injs[tag+'/mass2'])
+        data = conversions.mchirp_from_mass1_mass2(mass1, mass2)
     else:
-        data = injs[tag+'/mass2'][:] / injs[tag+'/mass1'][:]
+        data = mass2 / mass1
         data = np.where(data > 1, 1./data, data)
 
     return data
@@ -109,14 +110,14 @@ def complete_sky_error_data(injs, tag):
     """Extract data related to sky_error from raw injection and trigger data"""
 
     # Missed injections are assigned null values
-    data = np.full(len(injs[tag+'/mass1'][:]), None)
+    data = np.full(len(injs[tag+'/mass1']), None)
     if tag == 'found':
         inj = {}
-        inj['ra'] = injs[tag+'/ra'][:]
-        inj['dec'] = injs[tag+'/dec'][:]
+        inj['ra'] = injs[tag+'/ra']
+        inj['dec'] = injs[tag+'/dec']
         trig = {}
-        trig['ra'] = injs['network/ra'][:]
-        trig['dec'] = injs['network/dec'][:]
+        trig['ra'] = injs['network/ra']
+        trig['dec'] = injs['network/dec']
         data = np.arccos(np.cos(inj['dec'] - trig['dec']) -
                          np.cos(inj['dec']) * np.cos(trig['dec']) *
                          (1 - np.cos(inj['ra'] - trig['ra'])))
@@ -270,7 +271,8 @@ trig_data = ppu.extract_trig_properties(
     keys
 )
 
-background = trig_data['network/reweighted_snr'][:]
+background = list(trig_data['network/reweighted_snr'].values())
+background = np.concatenate(background)
 max_bkgd_reweighted_snr = background.max()
 
 # =======================
@@ -289,7 +291,7 @@ found_inj = complete_inj_data(inj_data, [x_qty, y_qty], 'found', ifos=ifos)
 if opts.newsnr_threshold:
     rw_snr_cut = found_inj['reweighted_snr'] < opts.newsnr_threshold
     for key in [x_qty, y_qty]:
-        missed_inj[key] = np.concatenate((missed_inj[key][:], found_inj[key][rw_snr_cut]))
+        missed_inj[key] = np.concatenate((missed_inj[key], found_inj[key][rw_snr_cut]))
         found_inj[key] = found_inj[key][~rw_snr_cut]
     for ifo in ifos:
         found_inj[ifo+'/end_time'] = found_inj[ifo+'/end_time'][~rw_snr_cut]
@@ -312,7 +314,7 @@ if len(list(found_after_vetoes['reweighted_snr'])) > 0:
     found_after_vetoes_stat = \
         found_inj['reweighted_snr'][found_idx] \
         if 'found_after_vetoes/stat' not in found_after_vetoes.keys() else \
-        found_after_vetoes['found_after_vetoes/stat'][:]
+        found_after_vetoes['found_after_vetoes/stat']
 
     # Separate triggers into:
     # 1) Found louder than background

--- a/bin/pygrb/pycbc_pygrb_plot_injs_results
+++ b/bin/pygrb/pycbc_pygrb_plot_injs_results
@@ -93,8 +93,6 @@ def complete_mass_data(injs, key, tag):
     mass1 = injs[tag+'/mass1']
     mass2 = injs[tag+'/mass2']
 
-    data = np.full(len(mass1), None)
-
     if key == 'mtotal':
         data = mass1 + mass2
     elif key == 'mchirp':

--- a/bin/pygrb/pycbc_pygrb_plot_injs_results
+++ b/bin/pygrb/pycbc_pygrb_plot_injs_results
@@ -146,7 +146,7 @@ def complete_inj_data(injs, keys, tag, ifos=[]):
             if key == 'end_time':
                 data_dict[key] = injs[tag+'/tc']
                 # data_dict[key] -= grb_time
-            elif key in ['mtotal', 'mchirp', 'q']:
+            elif key in ['mchirp', 'mtotal', 'q']:
                 data_dict[key] = complete_mass_data(injs, key, tag)
             elif 'incl' in key:
                 data_dict[key] = complete_incl_data(injs, key, tag)

--- a/bin/pygrb/pycbc_pygrb_plot_injs_results
+++ b/bin/pygrb/pycbc_pygrb_plot_injs_results
@@ -271,7 +271,7 @@ trig_data = ppu.extract_trig_properties(
 )
 
 background = trig_data['network/reweighted_snr'][:]
-max_bkgd_reweighted_snr = max(background)
+max_bkgd_reweighted_snr = background.max()
 
 # =======================
 # Post-process injections

--- a/bin/pygrb/pycbc_pygrb_plot_injs_results
+++ b/bin/pygrb/pycbc_pygrb_plot_injs_results
@@ -22,18 +22,17 @@ Plot found/missed injection properties for the triggered search (PyGRB).
 """
 
 import logging
+import os.path
+import sys
 import matplotlib.pyplot as plt
 import matplotlib
 import numpy as np
-import os.path
-import sys
 
 import pycbc.pnutils
 import pycbc.results
 import pycbc.version
 from pycbc import init_logging
 from pycbc.results import pygrb_postprocessing_utils as ppu
-from pycbc.io.hdf import HFile
 
 plt.switch_backend('Agg')
 matplotlib.rc("image")
@@ -60,7 +59,7 @@ def process_var_strings(qty):
     return qty
 
 
-def load_incl_data(input_file_handle, key, tag):
+def complete_incl_data(injs, key, tag):
     """Extract data related to inclination from raw injection data"""
 
     local_dict = {}
@@ -68,7 +67,7 @@ def load_incl_data(input_file_handle, key, tag):
     # Whether the user requests incl, |incl|, cos(incl), or cos(|incl|)
     # the following information is needed
     # TODO: make sure it is clear that inclination is interpreted as theta_jn
-    local_dict['incl'] = input_file_handle[tag+'/thetajn'][:]
+    local_dict['incl'] = injs[tag+'/thetajn'][:]
 
     # Requesting |incl| or cos(|incl|)
     if 'abs_' in key:
@@ -87,38 +86,37 @@ def load_incl_data(input_file_handle, key, tag):
     return data
 
 
-# Function to extract mass ratio or total mass data from a injection file
-def load_mass_data(input_file_handle, key, tag):
+def complete_mass_data(injs, key, tag):
     """Extract data related to mass ratio, chirp mass or total mass from raw
     injection data"""
 
+    data = np.full(len(injs[tag+'/mass1'][:]), None)
+
     if key == 'mtotal':
-        data = input_file_handle[tag+'/mass1'][:] + \
-               input_file_handle[tag+'/mass2'][:]
+        data = injs[tag+'/mass1'][:] + injs[tag+'/mass2'][:]
     elif key == 'mchirp':
         data, _ = pycbc.pnutils.mass1_mass2_to_mchirp_eta(
-            input_file_handle[tag+'/mass1'][:],
-            input_file_handle[tag+'/mass2'][:])
+            injs[tag+'/mass1'],
+            injs[tag+'/mass2'])
     else:
-        data = input_file_handle[tag+'/mass2'][:] / \
-               input_file_handle[tag+'/mass1'][:]
+        data = injs[tag+'/mass2'][:] / injs[tag+'/mass1'][:]
         data = np.where(data > 1, 1./data, data)
 
     return data
 
 
-def load_sky_error_data(input_file_handle, key, tag):
+def complete_sky_error_data(injs, tag):
     """Extract data related to sky_error from raw injection and trigger data"""
-    if tag == 'missed':
-        # Missed injections are assigned null values
-        data = np.full(len(input_file_handle[tag+'/mass1'][:]), None)
-    else:
+
+    # Missed injections are assigned null values
+    data = np.full(len(injs[tag+'/mass1'][:]), None)
+    if tag == 'found':
         inj = {}
-        inj['ra'] = input_file_handle[tag+'/ra'][:]
-        inj['dec'] = input_file_handle[tag+'/dec'][:]
+        inj['ra'] = injs[tag+'/ra'][:]
+        inj['dec'] = injs[tag+'/dec'][:]
         trig = {}
-        trig['ra'] = input_file_handle['network/ra'][:]
-        trig['dec'] = input_file_handle['network/dec'][:]
+        trig['ra'] = injs['network/ra'][:]
+        trig['dec'] = injs['network/dec'][:]
         data = np.arccos(np.cos(inj['dec'] - trig['dec']) -
                          np.cos(inj['dec']) * np.cos(trig['dec']) *
                          (1 - np.cos(inj['ra'] - trig['ra'])))
@@ -136,8 +134,7 @@ easy_keys = ['distance', 'mass1', 'mass2', 'polarization',
              'dec', 'ra', 'phi_ref']
 
 
-# Function to extract desired data from an injection file
-def load_data(input_file_handle, keys, tag):
+def complete_inj_data(injs, keys, tag, ifos=[]):
     """Create a dictionary containing the data specified by the
     list of keys extracted from an injection file"""
 
@@ -146,23 +143,28 @@ def load_data(input_file_handle, keys, tag):
     for key in keys:
         data_dict[key] = np.array([])
         try:
-            if key in easy_keys:
-                data_dict[key] = f[tag][key][:]
-            elif key == 'end_time':
-                data_dict[key] = f[tag]['tc'][:]
+            if key == 'end_time':
+                data_dict[key] = injs[tag+'/tc']
                 # data_dict[key] -= grb_time
-            elif key in ['q', 'mchirp', 'mtotal']:
-                data_dict[key] = load_mass_data(input_file_handle, key, tag)
+            elif key in ['mtotal', 'mchirp', 'q']:
+                data_dict[key] = complete_mass_data(injs, key, tag)
             elif 'incl' in key:
-                data_dict[key] = load_incl_data(input_file_handle, key, tag)
+                data_dict[key] = complete_incl_data(injs, key, tag)
             elif key == 'sky_error':
-                data_dict[key] = load_sky_error_data(input_file_handle, key,
-                                                     tag)
+                data_dict[key] = complete_sky_error_data(injs, tag)
+            else:
+                data_dict[key] = injs[tag+'/'+key]
         except KeyError:
             # raise NotImplemented(key+' not allowed: returning empty entry')
-            logging.info(key+' not allowed yet')
+            logging.info("%s/%s not allowed yet", tag, key)
 
-    logging.info("{0} {1} injections analysed.".format(len(data_dict[keys[0]]), tag))
+    # Include information needed to apply vetoes and reweighted SNR cut
+    if tag == 'found':
+        for ifo in ifos:
+            data_dict[ifo+'/end_time'] = injs[ifo+'/end_time']
+        data_dict['reweighted_snr'] = injs['network/reweighted_snr']
+
+    logging.info("%d %s injections analysed.", len(data_dict[keys[0]]), tag)
 
     return data_dict
 
@@ -209,7 +211,9 @@ parser.add_argument("--missed-on-top", action='store_true',
                     help="Plot missed injections on top of found ones and "
                          "high FAR on top of low FAR")
 ppu.pygrb_add_bestnr_cut_opt(parser)
+ppu.pygrb_add_slide_opts(parser)
 opts = parser.parse_args()
+ppu.slide_opts_helper(opts)
 
 init_logging(opts.verbose, format="%(asctime)s: %(levelname)s: %(message)s")
 
@@ -224,7 +228,6 @@ if 'eff_site_dist' in [x_qty, y_qty] and opts.ifo is None:
 # Store options used multiple times in local variables
 outfile = opts.output_file
 trig_file = os.path.abspath(opts.trig_file)
-f = HFile(opts.found_missed_file, 'r')
 grb_time = opts.trigger_time
 
 # Set output directory
@@ -233,44 +236,87 @@ outdir = os.path.split(os.path.abspath(outfile))[0]
 if not os.path.isdir(outdir):
     os.makedirs(outdir)
 
-# Extract IFOs and vetoes
-ifos, vetoes = ppu.extract_ifos_and_vetoes(trig_file, opts.veto_files,
-                                           opts.veto_category)
+# Extract IFOs
+ifos = ppu.extract_ifos(trig_file)
 
-# Load triggers. Time-slides not yet available
-logging.info("Loading triggers...")
-trig_data = ppu.load_triggers(trig_file, ifos, vetoes,
-                              rw_snr_threshold=opts.newsnr_threshold)
-max_reweighted_snr = max(trig_data['network/reweighted_snr'][:])
+# Generate time-slides dictionary
+slide_dict = ppu.load_time_slides(trig_file)
+
+# Generate segments dictionary
+segment_dict = ppu.load_segment_dict(trig_file)
+
+# Construct trials removing vetoed times
+trial_dict, total_trials = ppu.construct_trials(
+    opts.seg_files,
+    segment_dict,
+    ifos,
+    slide_dict,
+    opts.veto_file
+)
+
+# Load triggers (apply reweighted SNR cut, not vetoes)
+all_off_trigs = ppu.load_data(trig_file, ifos, data_tag='trigs',
+                              rw_snr_threshold=opts.newsnr_threshold,
+                              slide_id=opts.slide_id)
+
+# Extract needed trigger properties and store them as dictionaries
+# Based on trial_dict: if vetoes were applied, trig_* are the veto survivors
+keys = ['network/reweighted_snr']
+trig_data = ppu.extract_trig_properties(
+    trial_dict,
+    all_off_trigs,
+    slide_dict,
+    segment_dict,
+    keys
+)
+
+background = trig_data['network/reweighted_snr'][:]
+max_bkgd_reweighted_snr = max(background)
 
 # =======================
 # Post-process injections
 # =======================
+# Load injection data without applying the reweighted SNR cut, nor vetoes
+inj_data = ppu.load_data(opts.found_missed_file, ifos, data_tag='injs',
+                         slide_id=0)
 # Extract the necessary data from the missed injections for the plot
-missed_inj = load_data(f, [x_qty, y_qty], 'missed')
+missed_inj = complete_inj_data(inj_data, [x_qty, y_qty], 'missed', ifos=ifos)
 
 # Extract the necessary data from the found injections for the plot
-found_inj = load_data(f, [x_qty, y_qty], 'found')
+found_inj = complete_inj_data(inj_data, [x_qty, y_qty], 'found', ifos=ifos)
 
-# Injections found surviving vetoes
-found_after_vetoes = found_inj if 'found_after_vetoes' not in f.keys() \
-    else f['found_after_vetoes']
-# FIXME: Found but vetoed injections
-# missed_after_vetoes = list(set(found) - set(found_after_vetoes))
-# missed_after_vetoes = np.sort(missed_after_vetoes).astype(int)
-missed_after_vetoes = {x_qty: np.array([]), y_qty: np.array([])}
-# Injections found but not louder than background
-# are populated further down
+# Apply reweighted SNR cut
+if opts.newsnr_threshold:
+    rw_snr_cut = found_inj['reweighted_snr'] < opts.newsnr_threshold
+    for key in [x_qty, y_qty]:
+        missed_inj[key] = np.concatenate((missed_inj[key][:], found_inj[key][rw_snr_cut]))
+        found_inj[key] = found_inj[key][~rw_snr_cut]
+    for ifo in ifos:
+        found_inj[ifo+'/end_time'] = found_inj[ifo+'/end_time'][~rw_snr_cut]
+    msg = f"After applying reweighted SNR cut at {opts.newsnr_threshold}: "
+    msg += f"{len(found_inj[x_qty])} found injections and "
+    msg += f"{len(missed_inj[x_qty])} missed injections"
+    logging.info(msg)
+
+# Split in injections found surviving vetoes and injections found but vetoed
+found_after_vetoes, vetoed, found_idx, _ = ppu.apply_vetoes_to_found_injs(
+    opts.found_missed_file,
+    found_inj,
+    ifos,
+    veto_file=opts.veto_file
+)
 
 # Extract the detection statistic of injections found after vetoes
-if len(list(f['network'].keys())) > 0:
-    found_after_vetoes_stat = f['network/reweighted_snr'][:] \
-        if 'found_after_vetoes' not in f.keys() else \
-        f['found_after_vetoes/stat'][:]
+# Injections found but not louder than background are populated further down
+if len(list(found_after_vetoes['reweighted_snr'])) > 0:
+    found_after_vetoes_stat = \
+        found_inj['reweighted_snr'][found_idx] \
+        if 'found_after_vetoes/stat' not in found_after_vetoes.keys() else \
+        found_after_vetoes['found_after_vetoes/stat'][:]
 
     # Separate triggers into:
     # 1) Found louder than background
-    louder_mask = found_after_vetoes_stat > max_reweighted_snr
+    louder_mask = found_after_vetoes_stat > max_bkgd_reweighted_snr
     found_louder = {}
     for key in found_after_vetoes.keys():
         found_louder[key] = found_after_vetoes[key][louder_mask]
@@ -278,7 +324,7 @@ if len(list(f['network'].keys())) > 0:
 
     # 2) Found quieter than background: injections found (bestnr > 0)
     #    but not louder than background (non-zero FAP)
-    quieter_mask = (found_after_vetoes_stat <= max_reweighted_snr) \
+    quieter_mask = (found_after_vetoes_stat <= max_bkgd_reweighted_snr) \
         & (found_after_vetoes_stat != 0)
     found_quieter = {}
     for key in found_after_vetoes.keys():
@@ -292,6 +338,9 @@ if len(list(f['network'].keys())) > 0:
         else 'found_after_vetoes/ifar_exc'
     found_quieter['ifar'] = f[ifar_string][quieter_mask]
     """
+    found_quieter['fap'] = np.array([sum(background > bestnr) for bestnr in
+                                     found_quieter['reweighted_snr']],
+                                    dtype=float) / len(background)
 
     # 3) Missed due to vetoes
     # TODO: needs function to cherry-pick a subset of inj_data specified by
@@ -299,18 +348,14 @@ if len(list(f['network'].keys())) > 0:
 else:
     found_louder = {x_qty: np.array([]), y_qty: np.array([])}
     found_quieter = {x_qty: np.array([]), y_qty: np.array([])}
-# TMP FIX
-vetoed = missed_after_vetoes
 
 # Statistics: found on top (found-missed)
 # TODO: ifar still missing
-#FM = np.argsort(found_quieter['ifar'])
-logging.info("WARNING: IFAR not implemented yet")
-logging.info("WARNING: Avoiding failure by setting it to -1 and shifting colorbar from [0,1] to [-2,0].")
 if found_quieter[x_qty].size:
-   FM = np.full(found_quieter['reweighted_snr'].shape, -1)
-   # Statistics: missed on top (missed-found)
-   MF = FM[::-1]
+    # Statistics: found on top (found-missed)
+    FM = np.argsort(found_quieter['fap'])
+    # Statistics: missed on top (missed-found)
+    MF = FM[::-1]
 
 # Post-processing of injections ends here
 
@@ -327,9 +372,9 @@ axis_labels_dict = {'mchirp': "Chirp Mass (solar masses)",
                     'mtotal': "Total mass (solar masses)",
                     'q': "Mass ratio",
                     'distance': "Distance (Mpc)",
-                    'eff_site_dist': "%s effective distance (Mpc)" % sitename.get(opts.ifo),
+                    'eff_site_dist': f"{sitename.get(opts.ifo)} effective distance (Mpc)",
                     'eff_dist': "Inverse sum of effective distances (Mpc)",
-                    'end_time': "Time since %s (s)" % grb_time,
+                    'end_time': f"Time since {grb_time} (s)",
                     'sky_error': "Rec. sky error (radians)",
                     'coa_phase': "Phase of complex SNR (radians)",
                     'latitude': "Latitude (degrees)",
@@ -374,32 +419,28 @@ if not opts.missed_on_top:
     if missed_inj[x_qty].size and missed_inj[y_qty].size:
         ax.scatter(missed_inj[x_qty], missed_inj[y_qty],
                    c="black", marker="x", s=10)
-    # FIXME: once vetoed is filled in properly
-    # if vetoed[x_qty].size:
-    if x_qty in vetoed.keys():
+    if vetoed[x_qty].size:
         ax.scatter(vetoed[x_qty], vetoed[y_qty], c="red", marker="x", s=10)
-    if found_quieter[x_qty].size:
-        p = ax.scatter(found_quieter[x_qty][FM], found_quieter[y_qty][FM],
-                       c=found_quieter['reweighted_snr'][FM],
-                       cmap=cmap, vmin=-2, vmax=0, s=40,
-                       edgecolor="w", linewidths=2.0)
-        cb = plt.colorbar(p, label="p-value")
     if found_louder[x_qty].size:
         ax.scatter(found_louder[x_qty], found_louder[y_qty],
                    c=fnd_col, marker="+", s=30)
+    if found_quieter[x_qty].size:
+        p = ax.scatter(found_quieter[x_qty][FM], found_quieter[y_qty][FM],
+                       c=found_quieter['fap'][FM],
+                       cmap=cmap, vmin=0, vmax=1, s=40,
+                       edgecolor="w", linewidths=2.0)
+        cb = plt.colorbar(p, label="p-value")
 elif opts.missed_on_top:
     if found_louder[x_qty].size:
         ax.scatter(found_louder[x_qty], found_louder[y_qty],
                    c=fnd_col, marker="+", s=15)
     if found_quieter[x_qty].size:
         p = ax.scatter(found_quieter[x_qty][MF], found_quieter[y_qty][MF],
-                       c=found_quieter['reweighted_snr'][MF],
-                       cmap=cmap, vmin=-2, vmax=0, s=40,
+                       c=found_quieter['fap'][MF],
+                       cmap=cmap, vmin=0, vmax=1, s=40,
                        edgecolor="w", linewidths=2.0)
         cb = plt.colorbar(p, label="p-value")
-    # FIXME: once vetoed is filled in properly
-    # if vetoed[x_qty].size:
-    if x_qty in vetoed.keys():
+    if vetoed[x_qty].size:
         ax.scatter(vetoed[x_qty], vetoed[y_qty], c="red", marker="x", s=40)
     if missed_inj[x_qty].size and missed_inj[y_qty].size:
         ax.scatter(missed_inj[x_qty], missed_inj[y_qty],
@@ -438,7 +479,7 @@ if "incl" in x_qty or "incl" in y_qty:
         tt = np.asarray([0, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120,
                          130, 140, 150, 180])
         tks = np.cos(np.deg2rad(tt))
-        tk_labs = ['cos(%d deg)' % tk for tk in tt]
+        tk_labs = [f'cos({tk} deg)' for tk in tt]
         # if x_qty == "cos_incl":
         if "cos_" in x_qty:
             plt.xticks(tks, tk_labs, fontsize=10)
@@ -455,14 +496,14 @@ if "incl" in x_qty or "incl" in y_qty:
 # Take care of caption
 plot_caption = opts.plot_caption
 if plot_caption is None:
-    plot_caption = "Black cross indicates no trigger was found "
+    plot_caption = "A black cross indicates no trigger was found "
     plot_caption += "coincident with the injection.\n"
-    plot_caption += "Red cross indicates a trigger was found "
+    plot_caption += "A red cross indicates a trigger was found "
     plot_caption += "coincident with the injection but it was vetoed.\n"
-    plot_caption += "Yellow plus indicates that a trigger was found "
+    plot_caption += "A yellow plus indicates that a trigger was found "
     plot_caption += "coincident with the injection and it was louder "
     plot_caption += "than all events in the offsource.\n"
-    plot_caption += "Coloured circle indicates that a trigger was "
+    plot_caption += "A coloured circle indicates that a trigger was "
     plot_caption += "found coincident with the injection but it was "
     plot_caption += "not louder than all offsource events. The colour "
     plot_caption += "bar gives the p-value of the trigger."


### PR DESCRIPTION
This PR is the eighth in the series started in PR #4929.  Much like PRs #4947, #4950, #4955, and #4958, this PR provides a version of `pycbc_pygrb_plot_injs_results` that uses veto and segments files, as well as the utilities introduced recently to streamline the PyGRB results scripts.

## Standard information about the request (and the following ones that will be linked to this)

This is a: a new feature enabling veto definer file usage in PyGRB.  Utilities and scripts in results production are being  streamlined along the way.

This change affects: PyGRB

This change changes: result presentation / plotting and scientific output.

<!--- Notes about the effect of this change -->
Should this change break the standard automated test running `--help` for PyGRB plotting scripts, I will add some workarounds to avoid this.  If needed, these will likely be empty functions: the plotting scripts will be progressively renovated in the whole series of PRs.

## Motivation
Now that the workflow generator passes the veto definer file to the jobs where needed, its usage in the PyGRB results scripts is possible.

## Testing performed
The totality of the changes that will be broken down in multiple PRs was tested on GRB 170817A data by producing a full results webpage (see [here](https://ldas-jobs.ligo.caltech.edu/~francesco.pannarale/LVC/pygrb_nov2024_1/)).

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)