### PR TITLE
Converting indexes of triggers into np.int32 because of numpy 2.x

### DIFF
--- a/bin/pycbc_multi_inspiral
+++ b/bin/pycbc_multi_inspiral
@@ -661,10 +661,10 @@ with ctx:
                 ), f'SNR time series for {ifo} is empty'
                 norm_dict[ifo] = norm
                 corr_dict[ifo] = corr.copy()
-                idx[ifo] = ind.astype(np.int32)
                 # change to integer indexes because we will have to do
                 # arithmetic with time_delay_idx, which can be positive 
-                #or negative
+                # or negative
+                idx[ifo] = ind.astype(np.int32)
                 snr[ifo] = snrv * norm
 
             # Move onto next segment if there are no triggers.

--- a/bin/pycbc_multi_inspiral
+++ b/bin/pycbc_multi_inspiral
@@ -661,7 +661,10 @@ with ctx:
                 ), f'SNR time series for {ifo} is empty'
                 norm_dict[ifo] = norm
                 corr_dict[ifo] = corr.copy()
-                idx[ifo] = ind.copy()
+                idx[ifo] = ind.astype(np.int32)
+                # change to integer indexes because we will have to do
+                # arithmetic with time_delay_idx, which can be positive 
+                #or negative
                 snr[ifo] = snrv * norm
 
             # Move onto next segment if there are no triggers.
@@ -692,8 +695,8 @@ with ctx:
                                 idx[ifo]
                                 > time_delay_idx[slide][position_index][ifo],
                                 idx[ifo]
-                                - time_delay_idx[slide][position_index][ifo]
-                                < len(snr_dict[ifo]),
+                                < time_delay_idx[slide][position_index][ifo]
+                                + len(snr_dict[ifo]),
                             )
                         ]
                         for ifo in args.instruments


### PR DESCRIPTION

This PR is refering to #4956 and is converting indexes of triggers of the `pycbc_multi_inspiral` script from `np.uint32` to `np.int32`.

### Context

I was trying to run some workflows with `PyGRB` with numpy 2.x and it gave me an `Overflow Error`. Apparently it's because of numpy version, they have change the promotion rules with python scalars (explained [here](https://numpy.org/neps/nep-0050-scalar-promotion.html#nep50)). WIth @titodalcanton, we decided to convert manually the indexes of triggers into `np.int32` to avoid this `Overflow Error`.  

It will make every script that use the `pycbc_multi_inspiral` script works if you are working with numpy 2.x. 

## Motivation
I change this line of the code in order to maintain the code working correctly with further version of numpy. 
I've also put the `time_delay_idx` variable on the other side of the inequality in order to have this variable in the same side in every inequalities (it's completely equivalent) 

- [] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
