### PR TITLE
Allow units for `--ra` and `--dec`, improve external trigger info table

### DIFF
--- a/bin/pycbc_multi_inspiral
+++ b/bin/pycbc_multi_inspiral
@@ -216,13 +216,13 @@ parser.add_argument(
     "--ra",
     type=angle_as_radians,
     help="Right ascension of a single sky point to search. Use the rad or deg "
-    "prefix to specify units, otherwise radians are assumed."
+    "suffix to specify units, otherwise radians are assumed."
 )
 parser.add_argument(
     "--dec",
     type=angle_as_radians,
     help="Declination of a single sky point to search. Use the rad or deg "
-    "prefix to specify units, otherwise radians are assumed."
+    "suffix to specify units, otherwise radians are assumed."
 )
 parser.add_argument(
     "--sky-grid",

--- a/bin/pycbc_multi_inspiral
+++ b/bin/pycbc_multi_inspiral
@@ -46,7 +46,7 @@ from pycbc import (
 from pycbc.events import ranking, coherent as coh, EventManagerCoherent
 from pycbc.io.hdf import HFile
 from pycbc.filter import MatchedFilterControl
-from pycbc.types import zeros, float32, complex64
+from pycbc.types import zeros, float32, complex64, angle_as_radians
 from pycbc.vetoes import sgchisq
 from pycbc.tmpltbank.sky_grid import SkyGrid
 
@@ -214,11 +214,15 @@ parser.add_argument(
 )
 parser.add_argument(
     "--ra",
-    type=float,
-    help="Right ascension of sky point to search (radians).",
+    type=angle_as_radians,
+    help="Right ascension of a single sky point to search. Use the rad or deg "
+    "prefix to specify units, otherwise radians are assumed."
 )
 parser.add_argument(
-    "--dec", type=float, help="Declination of sky point to search (radians)."
+    "--dec",
+    type=angle_as_radians,
+    help="Declination of a single sky point to search. Use the rad or deg "
+    "prefix to specify units, otherwise radians are assumed."
 )
 parser.add_argument(
     "--sky-grid",

--- a/bin/pygrb/pycbc_pygrb_grb_info_table
+++ b/bin/pygrb/pycbc_pygrb_grb_info_table
@@ -53,15 +53,15 @@ parser.add_argument("--trigger-time", type=int,
 parser.add_argument("--ra", type=angle_as_radians,
                     required=True,
                     help="Right ascension of the GRB. Use the rad or deg "
-                    "prefix to specify units, otherwise radians are assumed.")
+                    "suffix to specify units, otherwise radians are assumed.")
 parser.add_argument("--dec", type=angle_as_radians,
                     required=True,
-                    help="Declination of the GRB. Use the rad or deg prefix "
+                    help="Declination of the GRB. Use the rad or deg suffix "
                     "to specify units, otherwise radians are assumed.")
 parser.add_argument("--sky-error", type=angle_as_radians,
                     default=0,
                     help="Sky-localisation error of the GRB. Use the rad or "
-                    "deg prefix to specify units, otherwise radians are assumed.")
+                    "deg suffix to specify units, otherwise radians are assumed.")
 parser.add_argument("--ifos", action="store", nargs='+',
                     default=None, required=True,
                     help="List containing the active IFOs.")

--- a/bin/pygrb/pycbc_pygrb_grb_info_table
+++ b/bin/pygrb/pycbc_pygrb_grb_info_table
@@ -24,15 +24,17 @@
 import sys
 import argparse
 from datetime import datetime
-import numpy
+import math
 
 import lal
 
 from pycbc import add_common_pycbc_options, init_logging
 import pycbc.version
 import pycbc.results
-from pycbc.detector import Detector
+from pycbc.detector import Detector, ppdets
 from pycbc.results.pygrb_postprocessing_utils import get_antenna_dist_factor
+from pycbc.types import angle_as_radians
+
 
 __author__ = "Francesco Pannarale <francesco.pannarale@ligo.org>"
 __version__ = pycbc.version.git_verbose_msg
@@ -48,15 +50,18 @@ add_common_pycbc_options(parser)
 parser.add_argument("--trigger-time", type=int,
                     required=True,
                     help="GPS time of the GRB.")
-parser.add_argument("--ra", type=float,
+parser.add_argument("--ra", type=angle_as_radians,
                     required=True,
-                    help="Right ascension (radians) of the GRB.")
-parser.add_argument("--dec", type=float,
+                    help="Right ascension of the GRB. Use the rad or deg "
+                    "prefix to specify units, otherwise radians are assumed.")
+parser.add_argument("--dec", type=angle_as_radians,
                     required=True,
-                    help="Declination (radians) of the GRB.")
-parser.add_argument("--sky-error", type=float,
-                    default=0, required=False,
-                    help="Sky-localisation error (radians) of the GRB.")
+                    help="Declination of the GRB. Use the rad or deg prefix "
+                    "to specify units, otherwise radians are assumed.")
+parser.add_argument("--sky-error", type=angle_as_radians,
+                    default=0,
+                    help="Sky-localisation error of the GRB. Use the rad or "
+                    "deg prefix to specify units, otherwise radians are assumed.")
 parser.add_argument("--ifos", action="store", nargs='+',
                     default=None, required=True,
                     help="List containing the active IFOs.")
@@ -74,40 +79,45 @@ data = [[]]
 data[0].append(str(opts.trigger_time))
 headers.append('GPS Time')
 
-utc_time = datetime(*lal.GPSToUTC(opts.trigger_time)[0:6]).strftime("%B %d %Y, %H:%M:%S UTC")
+utc_time = datetime(*lal.GPSToUTC(opts.trigger_time)[0:6]).strftime("%Y-%m-%d %H:%M:%S")
 data[0].append(utc_time)
-headers.append('Coordinated Universal Time')
+headers.append('UTC Time')
 
-data[0].append(str(numpy.rad2deg(opts.ra)))
+data[0].append(f'{math.degrees(opts.ra):.3f}')
 headers.append('R.A. (deg)')
 
-data[0].append(str(numpy.rad2deg(opts.dec)))
+data[0].append(f'{math.degrees(opts.dec):.3f}')
 headers.append('Dec (deg)')
 
-data[0].append(str(opts.sky_error))
-headers.append('Sky Error')
+data[0].append(f'{math.degrees(opts.sky_error):.3f}')
+headers.append('Sky Error (deg)')
 
-data[0].append(''.join(opts.ifos))
+data[0].append(ppdets(opts.ifos, ''))
 headers.append('IFOs')
 
 for ifo in opts.ifos:
     antenna = Detector(ifo)
-    factor = get_antenna_dist_factor(antenna,
-                                     opts.ra,
-                                     opts.dec,
-                                     float(opts.trigger_time))
-    data[0].append('%.3f' % factor)
+    factor = get_antenna_dist_factor(
+        antenna, opts.ra, opts.dec, float(opts.trigger_time)
+    )
+    data[0].append(f'{factor:.3f}')
     headers.append(ifo + ' Antenna Factor')
 
 html = pycbc.results.dq.redirect_javascript + \
         str(pycbc.results.static_table(data, headers))
 
-title = 'GRB Summary Information'
-caption = 'Parameters of the GRB. The reported antenna factors are the '
-caption += 'dist / eff distance  as defined by (4.3) in '
-caption += 'https://arxiv.org/abs/0705.1514.'
+title = 'External Trigger Summary Information'
+caption = (
+    'Parameters of the external trigger. The reported antenna factors are the '
+    'dist / eff distance as defined by Eq (4.3) in '
+    'https://arxiv.org/abs/0705.1514.'
+)
 
-pycbc.results.save_fig_with_metadata(html, opts.output_file, {},
-                        cmd = ' '.join(sys.argv),
-                        title = title,
-                        caption = caption)
+pycbc.results.save_fig_with_metadata(
+    html,
+    opts.output_file,
+    {},
+    cmd=' '.join(sys.argv),
+    title=title,
+    caption=caption
+)

--- a/pycbc/types/optparse.py
+++ b/pycbc/types/optparse.py
@@ -14,12 +14,18 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
 """
 This modules contains extensions for use with argparse
 """
+
 import copy
+import warnings
 import argparse
+import re
+import math
 from collections import defaultdict
+
 
 class DictWithDefaultReturn(defaultdict):
     default_set = False
@@ -531,3 +537,31 @@ def nonnegative_int(s):
     To be used as type in argparse arguments.
     """
     return _nonnegative_type(s, dtype=int)
+
+def angle_as_radians(s):
+    """
+    Interpret argument as a string defining an angle, which will be converted
+    to radians and returned as float. The format can be either "<value><unit>"
+    (e.g. 12deg, 1rad), "<value> <unit>" (e.g. 12 deg, 1 rad) or just
+    "<value>", in which case the unit will be assumed to be radians.
+
+    To be used as type in argparse arguments.
+    """
+    # if `s` converts to a float then there is no unit, so assume radians
+    try:
+        value = float(s)
+        warnings.warn(
+            f'Angle units not specified for {value}, assuming radians'
+        )
+        return value
+    except:
+        pass
+    # looks like we have units, so do some parsing
+    rematch = re.match('([0-9.e+-]+) *(deg|rad)', s)
+    value = float(rematch.group(1))
+    unit = rematch.group(2)
+    if unit == 'deg':
+        return math.radians(value)
+    if unit == 'rad':
+        return value
+    raise argparse.ArgumentTypeError(f'Unknown unit {unit}')


### PR DESCRIPTION
This allows PyGRB users to do `--ra 12deg` or `--ra 2rad`, thus clearing confusion on the units and removing the need to convert from degrees to radians. It also improves the external trigger summary table in a couple ways.

## Standard information about the request

This is a new feature and restyling of result presentation.

This change affects mainly PyGRB.

This is backwards compatible, but it will print a warning if `--ra` and `--dec` are used without units.

## Motivation

While doing some test PyGRB runs, @Thomas-JACQUOT and I ran into some confusion about which angular units we are supposed to use. `pycbc_multi_inspiral`, `pycbc_pygrb_grb_info_table` and the workflow config now consistently take radians as input args. However, results are typically presented in degrees. More importantly, radians are seldom used in the astro community, so the user would have to manually convert degrees to radians as part of setting up PyGRB, which is annoying and risks introducing errors.

The table shown by `pycbc_pygrb_grb_info_table` is also using a non-standard format for the UTC time, and too many digits for the sky location parameters.

## Contents

This introduces the ability to add a `deg` or `rad` prefix to the values passed via `--ra` and `--dec`, thus clearing any confusion on the units. It is still possible to give unit-less values, in which case the code will assume they are radians (consistent with the old behavior) and print a warning.

This change also cleans up the code of `pycbc_pygrb_grb_info_table` and changes its output so that 3 decimal digits are used for the sky location parameters, and the ISO date format is used for the UTC time.

## Links to any issues or associated PRs

N/A

## Testing performed

I manually ran `pycbc_pygrb_grb_info_table` for GRB190427A.

Before:
```
pycbc_pygrb_grb_info_table --trigger-time 1240374873 --ra 280.2194 --dec 40.30997 --sky-error 0.0404485333333 --ifos L1 V1 --output-file L1V1-PYGRB_GRB_INFO_TABLE_GRB190427A-1240372047-5648.html
```
![image](https://github.com/user-attachments/assets/aa4bfb0e-2134-4e8b-acaa-4e2114ef55e5)

After:
```
pycbc_pygrb_grb_info_table --trigger-time 1240374873 --ra 280.2194deg --dec 40.30997deg --sky-error 0.0404485333333deg --ifos L1 V1 --output-file ~/Desktop/L1V1-PYGRB_GRB_INFO_TABLE_GRB190427A-1240372047-5648.html
```
![image](https://github.com/user-attachments/assets/4221ec23-a5d4-4ed6-b1bc-18b86acb3717)

Reference from the old production run:
![image](https://github.com/user-attachments/assets/812a0dc4-ee1b-4356-853e-42775c5f56d1)

## Additional notes

N/A

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
