### PR TITLE
Fix bug in reading single detector event fit_threshold

### DIFF
--- a/pycbc/events/single.py
+++ b/pycbc/events/single.py
@@ -320,7 +320,7 @@ class LiveSingle(object):
             with HFile(self.fit_file, 'r') as fit_file:
                 bin_edges = fit_file['bins_edges'][:]
                 live_time = fit_file[self.ifo].attrs['live_time']
-                thresh = fit_file.attrs['fit_threshold']
+                thresh = fit_file[self.ifo].attrs['fit_threshold']
                 dist_grp = fit_file[self.ifo][self.sngl_ifar_est_dist]
                 rates = dist_grp['counts'][:] / live_time
                 coeffs = dist_grp['fit_coeff'][:]


### PR DESCRIPTION
The `fit_threshold` was being read from the wrong location in an hdf file when computing the significance of single detector events in PyCBC Live.

The location it was reading from used to be correct, but was not updated to reflect changes made to pycbc_live_combine_single_significance_fits executable in https://github.com/gwastro/pycbc/commit/d486ec29d4c52963a3cbff691ce361200475eed9