### PR TITLE
Generalize time-domain waveform modes generation via lalsim

### DIFF
--- a/pycbc/waveform/waveform_modes.py
+++ b/pycbc/waveform/waveform_modes.py
@@ -232,6 +232,89 @@ def get_nrhybsur_modes(**params):
 get_nrsur_modes.__doc__ = _formatdocstr(get_nrsur_modes.__doc__)
 get_nrhybsur_modes.__doc__ = _formatdocstr(get_nrhybsur_modes.__doc__)
 
+def get_lalsimulation_approximant(approximant):
+    import lalsimulation as ls
+    return {
+        'EOBNRv2': ls.EOBNRv2,
+        'EOBNRv2HM': ls.EOBNRv2HM,
+        'IMRPhenomTPHM': ls.IMRPhenomTPHM,
+        'NRSur7dq2': ls.NRSur7dq2,
+        'NRSur7dq4': ls.NRSur7dq4,
+        'NRHybSur3dq8': ls.NRHybSur3dq8,
+        'pSEOBNRv4HM_PA': ls.pSEOBNRv4HM_PA,
+        'SEOBNRv4HM_PA': ls.SEOBNRv4HM_PA,
+        'SEOBNRv4P': ls.SEOBNRv4P,
+        'SEOBNRv4PHM': ls.SEOBNRv4PHM,
+        'SpinTaylorT1': ls.SpinTaylorT1,
+        'SpinTaylorT4': ls.SpinTaylorT4,
+        'SpinTaylorT5': ls.SpinTaylorT5,
+        'TaylorT1': ls.TaylorT1,
+        'TaylorT2': ls.TaylorT2,
+        'TaylorT3': ls.TaylorT3,
+        'TaylorT4': ls.TaylorT4,
+        }[approximant]
+
+def get_lalsimulation_modes(**params):
+    """Generates approximant waveform mode-by-mode.
+
+    All waveform parameters should be provided as keyword arguments.
+    Recognized parameters are listed below. Unrecognized arguments are ignored.
+
+    Parameters
+    ----------
+    template: object
+        An object that has attached properties. This can be used to substitute
+        for keyword arguments. A common example would be a row in an xml table.
+    approximant : str
+        The approximant to generate. Must be available in ``lalsimulation``.
+    {delta_t}
+    {mass1}
+    {mass2}
+    {spin1x}
+    {spin1y}
+    {spin1z}
+    {spin2x}
+    {spin2y}
+    {spin2z}
+    {f_lower}
+    {f_ref}
+    {distance}
+    {mode_array}
+    {ell_max}
+    {approximant}
+
+    Returns
+    -------
+    dict :
+        Dictionary of ``(l, m)`` -> ``(h_+, -h_x)`` ``TimeSeries``.
+    """
+    ell_max = 5
+    if 'ell_max' in params:
+        ell_max = params['ell_max']
+    laldict = _check_lal_pars(params)
+    ret = lalsimulation.SimInspiralChooseTDModes(
+        params['coa_phase'],
+        params['delta_t'],
+        params['mass1']*lal.MSUN_SI,
+        params['mass2']*lal.MSUN_SI,
+        params['spin1x'],
+        params['spin1y'],
+        params['spin1z'],
+        params['spin2x'],
+        params['spin2y'],
+        params['spin2z'],
+        params['f_lower'], params['f_ref'],
+        params['distance']*1e6*lal.PC_SI, laldict,
+        ell_max,
+        get_lalsimulation_approximant(params['approximant'])
+    )
+    hlms = {}
+    while ret:
+        hlm = TimeSeries(ret.mode.data.data, delta_t=ret.mode.deltaT,
+                         epoch=ret.mode.epoch)
+        hlms[(ret.l, ret.m)] = (hlm.real(), hlm.imag())
+        ret = ret.next
+    return hlms
 
 def get_imrphenomxh_modes(**params):
     """Generates ``IMRPhenomXHM`` waveforms mode-by-mode. """
@@ -269,8 +352,23 @@ def get_imrphenomxh_modes(**params):
     return hlms
 
 
-_mode_waveform_td = {'NRSur7dq4': get_nrsur_modes,
+_mode_waveform_td = {'EOBNRv2': get_lalsimulation_modes,
+                     'EOBNRv2HM': get_lalsimulation_modes,
+                     'IMRPhenomTPHM': get_lalsimulation_modes,
+                     'NRSur7dq2': get_lalsimulation_modes,
+                     'NRSur7dq4': get_nrsur_modes,
                      'NRHybSur3dq8': get_nrhybsur_modes,
+                     'pSEOBNRv4HM_PA': get_lalsimulation_modes,
+                     'SEOBNRv4HM_PA': get_lalsimulation_modes,
+                     'SEOBNRv4P': get_lalsimulation_modes,
+                     'SEOBNRv4PHM': get_lalsimulation_modes,
+                     'SpinTaylorT1': get_lalsimulation_modes,
+                     'SpinTaylorT4': get_lalsimulation_modes,
+                     'SpinTaylorT5': get_lalsimulation_modes,
+                     'TaylorT1': get_lalsimulation_modes,
+                     'TaylorT2': get_lalsimulation_modes,
+                     'TaylorT3': get_lalsimulation_modes,
+                     'TaylorT4': get_lalsimulation_modes,
                      }
 _mode_waveform_fd = {'IMRPhenomXHM': get_imrphenomxh_modes,
                      }


### PR DESCRIPTION
<!---
This is a brief template for making pull requests for PyCBC.
This is _not_ a proscriptive template - you can use a different style if you want.
Please do think about the questions posed here and whether the details will be useful to include in your PR
Please add sufficient details so that people looking back at the request with no context around the work can understand the changes.
To choose reviewers, please look at the git blame for the code you are changing (if applicable),
or discuss in the #pycbc-code channel of the gwastro slack.
Please add labels as appropriate
-->

<!-- TOP-LEVEL SUMMARY: Please provide a brief, one-or-two-sentence description of the PR here
-->
Generalize time-domain waveform modes generation via `lalsimulation``

## Standard information about the request

<!--- Some basic info about the change (delete as appropriate) -->
This is a: new feature

<!--- What codes will this affect? (delete as appropriate)
If you do not know which areas will be affected, please ask in the gwastro #pycbc-code slack
-->
This change affects: No existing code, this is a new feature

<!--- What code areas will this affect? (delete as apropriate) -->
This change changes: CBC waveform modes generation

<!--- Some things which help with code management (delete as appropriate) -->
This change: has appropriate unit tests, follows style guidelines (See e.g. [PEP8](https://peps.python.org/pep-0008/)), has been proposed using the [contribution guidelines](https://github.com/gwastro/pycbc/blob/master/CONTRIBUTING.md)


## Motivation
<!--- Describe why your changes are being made -->
There are many approximants implemented in `lalsimulation` that allow for generation of individual spherical harmonic modes of gravitational radiation. We want to interface them through the `waveform.get_td_waveform_modes` interface, which currently works for a small number of approximants.

## Contents
<!--- Describe your changes, this doesn't need to be a line-by-line code change discussion,
but rather a general discussion of the methods chosen -->

* Added a function to generate waveform modes for many time-domain approximants available via lalsimulation.

* Added a function to generate lalsimulation approximant object from model name string.

## Links to any issues or associated PRs
<!--- If this is fixing / working around an already-reported issue, please link to it here -->

## Testing performed
<!--- Describe tests for the code changes, either already performed or to be performed -->

## Additional notes
<!--- Anything which does not fit in the above sections -->

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
