### PR TITLE
Cherry-pick Mac OS fix onto v2.7 branch

### DIFF
--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-12]
+        os: [ubuntu-20.04, macos-14]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/mac-test.yml
+++ b/.github/workflows/mac-test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        os: [macos-12]
+        os: [macos-latest]
         python-version: ['3.10', '3.11', '3.12']
     steps:
     - uses: actions/checkout@v1

--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,7 @@ def get_version_info():
         vinfo = _version_helper.generate_git_version_info()
     except:
         vinfo = vdummy()
-        vinfo.version = '2.7.1'
+        vinfo.version = '2.7.2'
         vinfo.release = 'True'
 
     version_script = f"""# coding: utf-8


### PR DESCRIPTION
This cherry picks https://github.com/gwastro/pycbc/commit/f1606419b64d53bb12ab45c9bbef6f3611dbdfe8 onto the v2.7 release branch so that Mac OS wheels build