### PR TITLE
update setuptools build minimum

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools",
+requires = ["setuptools>=70.0.0",
             "wheel",
             "cython>=0.29.21",
             "numpy>=2.0.0",


### PR DESCRIPTION
PyPI will begin enforcing PEP 625 which requires that source package names use lower case letters. Ensuring these requirements was implemented in setuptools but in a new enough version that not all our environments seem to have it by default. I've updated our pyproject.toml to ensure we have a recent enough version. 

This may need to be cherry picked into any branches that are making future releases also. 