### PR TITLE
Improve Executable constructor doc

### DIFF
--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -137,7 +137,7 @@ class Executable(pegasus_workflow.Executable):
             If True, Pegasus simply uses the name of the (executable) script
             to label the Executable instance, otherwise it also includes tags
             in the labeling and, e.g., performance information is recorded
-            individually by jov rather than being grouped together on the
+            individually by job rather than being grouped together on the
             basis of the script name.
         set_submit_subdir: boolean [default True]
             Place condor files associated with this executable under a

--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -121,10 +121,8 @@ class Executable(pegasus_workflow.Executable):
         -----------
         cp : ConfigParser object
             The ConfigParser object holding the workflow configuration settings
-        exec_name : string
+        name : string
             Executable name
-        universe : string, optional
-            Condor universe to run the job in
         ifos : string or list, optional
             The ifo(s) that the Job is valid for. If the job is
             independently valid for multiple ifos it can be provided as a list.
@@ -135,6 +133,11 @@ class Executable(pegasus_workflow.Executable):
             The folder to store output files of this job.
         tags : list of strings
             A list of strings that is used to identify this job.
+        reuse_executable: boolean [default True]
+            Set pegasus_name to name (rather than tagged_name)?
+        set_submit_subdir: boolean [default True]
+            Set up the sub-directory to use in the submit directory?
+            Regulates pegasus --> relative.submit.dir
         """
         if isinstance(ifos, str):
             self.ifo_list = [ifos]

--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -134,10 +134,15 @@ class Executable(pegasus_workflow.Executable):
         tags : list of strings
             A list of strings that is used to identify this job.
         reuse_executable: boolean [default True]
-            Set pegasus_name to name (rather than tagged_name)?
+            If True, Pegasus simply uses the name of the (executable) script
+            to label the Executable instance, otherwise it also includes tags
+            in the labeling and, e.g., performance information is recorded
+            individually by jov rather than being grouped together on the
+            basis of the script name.
         set_submit_subdir: boolean [default True]
-            Set up the sub-directory to use in the submit directory?
-            Regulates pegasus --> relative.submit.dir
+            Place condor files associated with this executable under a
+            sub-directory (named according to the executable name) in the
+            submitdir.
         """
         if isinstance(ifos, str):
             self.ifo_list = [ifos]


### PR DESCRIPTION
The `Executable` constructor documentation is a bit out of date and this PR is intended to fix it.

This is simply a documentation change.

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
