### PR TITLE
Allow relbin's fiducial parameters to not be floats

### DIFF
--- a/pycbc/inference/models/relbin.py
+++ b/pycbc/inference/models/relbin.py
@@ -655,11 +655,23 @@ class Relative(DistMarg, BaseGaussianNoise):
         )
 
         # get fiducial params from config
-        fid_params = {
-            p.replace("_ref", ""): float(cp.get("model", p))
-            for p in cp.options("model")
-            if p.endswith("_ref")
-        }
+        fid_params = {}
+        for p in cp.options("model"):
+            if p.endswith("_ref"):
+                val = cp.get("model", p)
+                if val == '':
+                    # means had "param =", indicating a boolean that should be
+                    # True
+                    val = True
+                else:
+                    # try casting to float
+                    try:
+                        val = float(val)
+                    # will get a value error if val is a string; just keep
+                    # as a string in that case
+                    except ValueError:
+                        pass
+                fid_params[p.replace("_ref", "")] = val
 
         # add optional params with default values if not specified
         opt_params = {


### PR DESCRIPTION
Currently the Relative model tries to cast all of the reference parameters specified in the model section to floats. This is a problem if you want to pass in, say, a string (like a different approximant name than what's in the static params) or another parameter type to be  passed to the waveform generartor. This patch fixes the issue by first checking if it's a boolean parameter, then catching any attempt to cast to float that fails.