### PR TITLE
Allowing the FisherSky class to have angle unit suffix rad deg

### DIFF
--- a/pycbc/distributions/sky_location.py
+++ b/pycbc/distributions/sky_location.py
@@ -68,16 +68,18 @@ class FisherSky:
 
     Parameters
     ----------
-    mean_ra: float
-        RA of the center of the distribution.  Use the rad or deg suffix to
+    mean_ra: float or str
+        RA of the center of the distribution. Use the rad or deg suffix to
         specify units, otherwise radians are assumed.
-    mean_dec: float
+    mean_dec: float or str
         Declination of the center of the distribution. Use the rad or deg 
         suffix to specify units, otherwise radians are assumed.
-    sigma: float
+    sigma: float or str
         Spread of the distribution. For the precise interpretation, see Eq 8
         of `Briggs et al 1999 ApJS 122 503`_. This should be smaller than
-        about 20 deg for the approximation to be valid.
+        about 20 deg for the approximation to be valid. Use the rad or deg 
+        suffix to specify units, otherwise radians are assumed.
+
     """
 
     name = 'fisher_sky'

--- a/pycbc/distributions/sky_location.py
+++ b/pycbc/distributions/sky_location.py
@@ -69,9 +69,11 @@ class FisherSky:
     Parameters
     ----------
     mean_ra: float
-        RA of the center of the distribution.
+        RA of the center of the distribution.  Use the rad or deg suffix to
+        specify units, otherwise radians are assumed.
     mean_dec: float
-        Declination of the center of the distribution.
+        Declination of the center of the distribution. Use the rad or deg 
+        suffix to specify units, otherwise radians are assumed.
     sigma: float
         Spread of the distribution. For the precise interpretation, see Eq 8
         of `Briggs et al 1999 ApJS 122 503`_. This should be smaller than
@@ -124,9 +126,9 @@ class FisherSky:
                 "Not all parameters used by this distribution "
                 "included in tag portion of section name"
             )
-        mean_ra = float(cp.get_opt_tag(section, 'mean_ra', tag))
-        mean_dec = float(cp.get_opt_tag(section, 'mean_dec', tag))
-        sigma = float(cp.get_opt_tag(section, 'sigma', tag))
+        mean_ra = cp.get_opt_tag(section, 'mean_ra', tag)
+        mean_dec = cp.get_opt_tag(section, 'mean_dec', tag)
+        sigma = cp.get_opt_tag(section, 'sigma', tag)
         return cls(
             mean_ra=mean_ra,
             mean_dec=mean_dec,

--- a/pycbc/distributions/sky_location.py
+++ b/pycbc/distributions/sky_location.py
@@ -85,9 +85,25 @@ class FisherSky:
     def __init__(self, **params):
         if params['angle_unit'] not in ['deg', 'rad']:
             raise ValueError("Only deg or rad is allowed as angle unit")
-        mean_ra = params['mean_ra']
-        mean_dec = params['mean_dec']
-        sigma = params['sigma']
+        try:
+            rematch_ra = re.match('([0-9.e+-]+) *(deg|rad)', params['mean_ra'])
+            rematch_dec = re.match('([0-9.e+-]+) *(deg|rad)', params['mean_dec'])
+            rematch_sigma = re.match('([0-9.e+-]+) *(deg|rad)', params['sigma'])
+            if params['angle_unit'] != rematch_ra.group(2) \
+                or params['angle_unit'] != rematch_dec.group(2) \
+                or params['angle_unit'] != rematch_sigma.group(2):
+                raise ValueError(
+                    f"Angle_unit ({params['angle_unit']}) and ra 
+                    ({rematch_ra.group(2)}) dec ({rematch_dec.group(2)}) units 
+                    must be the same"
+                )
+            mean_ra = float(rematch_ra.group(1))
+            mean_dec = float(rematch_dec.group(1))
+            sigma = float(rematch_sigma.group(1))
+        except:
+            mean_ra = params['mean_ra']
+            mean_dec = params['mean_dec']
+            sigma = params['sigma']
         if params['angle_unit'] == 'deg':
             mean_ra = numpy.deg2rad(mean_ra)
             mean_dec = numpy.deg2rad(mean_dec)


### PR DESCRIPTION
This PR aims to allow `FisherSky` class to have angle unit suffix rad deg

## Standard information about the request

This is a new feature, which make the  `FisherSky` class able to deal with angle unit suffixes

<!--- Notes about the effect of this change -->
This change will: change nothing in other parts of the code, it adds only a new feature for the `FisherSky` class.
## Motivation
<!--- Describe why your changes are being made -->
@titodalcanton, @pannarale and I wanted to change the `[prior-ra+dec]` section of `GRBXXXX.ini` files in order to be more clear (see discussion [here](https://git.ligo.org/ligo-cbc/pycbc-config/-/merge_requests/414#note_1224603)). To do so, it needs to change the `FisherSky` class to make it able to deal with angle unit suffixes (just as @titodalcanton did [here](https://github.com/gwastro/pycbc/pull/4965))
## Contents
<!--- Describe your changes, this doesn't need to be a line-by-line code change discussion,
but rather a general discussion of the methods chosen -->

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
