### PR TITLE
Making the check on sigma for FisherSky class more relax (allowing 0 value)

### DIFF
--- a/pycbc/distributions/sky_location.py
+++ b/pycbc/distributions/sky_location.py
@@ -98,7 +98,7 @@ class FisherSky:
                 'The mean declination must be between '
                 f'-π/2 and π/2, {mean_dec} rad given'
             )
-        if sigma <= 0 or sigma > 2 * numpy.pi:
+        if sigma < 0 or sigma > 2 * numpy.pi:
             raise ValueError(
                 'Sigma must be positive and smaller than 2π '
                 '(preferably much smaller)'

--- a/pycbc/distributions/sky_location.py
+++ b/pycbc/distributions/sky_location.py
@@ -100,7 +100,7 @@ class FisherSky:
             )
         if sigma < 0 or sigma > 2 * numpy.pi:
             raise ValueError(
-                'Sigma must be positive and smaller than 2π '
+                'Sigma must be non-negative and smaller than 2π '
                 '(preferably much smaller)'
             )
         if sigma > 0.35:


### PR DESCRIPTION
This PR is allowing 0 values for `sigma` in the `FisherSky` class. The `FisherSky` class follows a `numpy.random.rayleigh` distribution which allows 0 values for `sigma` (see this [comment](https://git.ligo.org/ligo-cbc/pycbc-config/-/merge_requests/414#note_1228331))

## Standard information about the request

This change affects: PyGRB 

<!--- Notes about the effect of this change -->
This change will: allow to use `FisherSky` distribution for GRBs that has a `sky_error` equals to 0.
## Motivation
I want to do this PR in order to use PyGRB with GRBs that has a `sky_error` equals to 0 and uses `FisherSky` class as a prior for the right ascension and the declination.

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
