### PR TITLE
Add waveform error handling to Relbin (and other models)

### DIFF
--- a/pycbc/inference/models/gaussian_noise.py
+++ b/pycbc/inference/models/gaussian_noise.py
@@ -1242,8 +1242,8 @@ def catch_waveform_error(method):
     happens when the wrapped method is executed:
 
       * A `NoWaveformError` is raised.
-      * A `FailedWaveformError` is raised and the model has an
-        `ignore_failed_waveforms` attribute that is set to True.
+      * A `RuntimeError` or `FailedWaveformError` is raised and the model has
+        an `ignore_failed_waveforms` attribute that is set to True.
 
     This requires the model to have a `_nowaveform_return` method.
     """
@@ -1255,7 +1255,7 @@ def catch_waveform_error(method):
             retval = method(self, *args, **kwargs)
         except NoWaveformError:
             retval = self._nowaveform_return()
-        except FailedWaveformError as e:
+        except (RuntimeError, FailedWaveformError) as e:
             try:
                 ignore_failed = self.ignore_failed_waveforms
             except AttributeError:

--- a/pycbc/inference/models/relbin.py
+++ b/pycbc/inference/models/relbin.py
@@ -37,6 +37,7 @@ from pycbc.detector import Detector
 from pycbc.types import Array, TimeSeries
 
 from .gaussian_noise import (BaseGaussianNoise, catch_waveform_error)
+from pycbc.waveform import FailedWaveformError
 from .relbin_cpu import (likelihood_parts, likelihood_parts_v,
                          likelihood_parts_multi, likelihood_parts_multi_v,
                          likelihood_parts_det, likelihood_parts_det_multi,
@@ -605,13 +606,15 @@ class Relative(DistMarg, BaseGaussianNoise):
         return results
 
     def _nowaveform_handler(self):
-        """Sets loglr values if no waveform generated.
+        """Returns -inf for loglr if no waveform generated.
+
+        If `return_sh_hh` is set to True, a FailedWaveformError will be raised.
         """
         if self.return_sh_hh:
-            results = (-numpy.inf, -numpy.inf)
-        else:
-            results = -numpy.inf
-        return results
+            raise FailedWaveformError("Waveform failed to generate and "
+                                      "return_sh_hh set to True! I don't know "
+                                      "what to return in this case.")
+        return -numpy.inf
 
     def write_metadata(self, fp, group=None):
         """Adds writing the fiducial parameters and epsilon to file's attrs.

--- a/test/test_infmodel.py
+++ b/test/test_infmodel.py
@@ -27,13 +27,16 @@ These are the unittests for pycbc.inference.models
 import unittest
 import copy
 from utils import simple_exit
+import numpy
 from pycbc.catalog import Merger
-from pycbc.psd import interpolate, inverse_spectrum_truncation
+from pycbc.psd import interpolate, inverse_spectrum_truncation, aLIGOZeroDetHighPower
+from pycbc.noise import noise_from_psd
 from pycbc.frame import read_frame
 from pycbc.filter import highpass, resample_to_delta_t
 from astropy.utils.data import download_file
 from pycbc.inference import models
 from pycbc.distributions import Uniform, JointDistribution, SinAngle, UniformAngle
+from pycbc.waveform.waveform import FailedWaveformError
 
 class TestModels(unittest.TestCase):
 
@@ -166,8 +169,174 @@ class TestModels(unittest.TestCase):
         model.update(**self.q1)
         self.assertAlmostEqual(self.a2, model.loglr, delta=0.002)
 
+
+class TestWaveformErrors(unittest.TestCase):
+    """Tests that models handle no waveform errors correctly."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.psds = {}
+        cls.data = {}
+        # static params for the test
+        cls.static = {
+            'f_final_func': 'SchwarzISCO',
+            'approximant':"TaylorF2",
+            'polarization': 0,
+            'ra': 3.44615914,
+            'dec': -0.40808407,
+            'tc':  1187008882.42840,
+            'distance': 42.,
+            'inclination': 2.5
+            }
+        cls.variable = ['mass1', 'mass2', 'f_lower']
+        ifos = ['H1', 'L1', 'V1']
+        # generate the reference psd
+        flow = 20
+        seglen = 256
+        delta_f = 1./seglen
+        sample_rate = 4096
+        delta_t = 1./sample_rate
+        flen = int(sample_rate * seglen / 2) + 1
+        psd = aLIGOZeroDetHighPower(flen, delta_f, flow)
+        seed = 1000
+        cls.flow = {'H1': flow, 'L1': flow, 'V1': flow}
+        # generate the noise
+        for ifo in ifos:
+            print("Generating {} noise".format(ifo))
+
+            tsamples = int(seglen * sample_rate)
+            ts = noise_from_psd(tsamples, delta_t, psd, seed=seed)
+            ts._epoch = cls.static['tc'] - seglen/2
+            seed += 1027
+            cls.data[ifo] = ts
+            cls.psds[ifo] = psd
+        # setup priors
+        inclination_prior = SinAngle(inclination=None)
+        distance_prior = Uniform(distance=(10, 100))
+        tc_prior = Uniform(tc=(m.time-0.1, m.time+0.1))
+        pol = UniformAngle(polarization=None)
+        cls.prior = JointDistribution(cls.variable, inclination_prior,
+                                       distance_prior)
+
+        # set up for marginalized polarization tests
+        cls.static2 = cls.static.copy()
+        cls.static2.pop('polarization')
+        cls.variable2 = cls.variable + ['polarization']
+        cls.prior2 = JointDistribution(cls.variable2, inclination_prior,
+                                       distance_prior, pol)
+        # set up gated parameters
+        staticgate = cls.static.copy()
+        staticgate['t_gate_start'] = static['tc'] - 1.
+        staticgate['t_gate_end'] = static['tc']
+        self.staticgate = staticgate
+        # margpol
+        staticgate2 = cls.static2.copy()
+        staticgate2['t_gate_start'] = static2['tc'] - 1.
+        staticgate2['t_gate_end'] = static2['tc']
+        self.staticgate2 = staticgate2
+        # the parameters to test:
+        # these parameters should pass
+        cls.pass_params = {'mass1': 1.4, 'mass2': 1.4, 'f_lower': flow}
+        # these parameters should trigger a NoWaveformError
+        cls.nowf_params = {'mass1': 1.4, 'mass2': 1.4, 'f_lower': 4000.}
+        # these parameters should cause a FailedWaveformError
+        cls.fail_params = {'mass1': -1.4, 'mass2': 1.4, 'f_lower': flow}
+
+    def _run_tests(self, model):
+        # first check that the model works
+        model.update(**self.pass_params)
+        self.assertTrue(numpy.isfinite(model.loglr))
+        # now check that a no waveform error is caught correctly
+        model.update(**self.nowf_params)
+        self.assertEqual(model.loglr == -numpy.inf)
+        # now check that a failed waveform is caught correctly
+        model.update(**self.fail_params)
+        self.assertEqual(model.loglr == -numpy.inf)
+        # now check that an error is raised if ignore_failed_waveforms is False
+        model.ignore_failed_waveforms = False
+        model.update(**self.fail_params)
+        model.assertRaises((FailedWaveformError, RuntimeError), model.loglr)
+
+    def test_base_phase_marg(self):
+        model = models.MarginalizedPhaseGaussianNoise(
+                                self.variable, copy.deepcopy(self.data),
+                                low_frequency_cutoff=self.flow,
+                                psds=self.psds,
+                                static_params=self.static,
+                                prior=self.prior,
+                                ignore_failed_waveforms=True)
+        self._run_tests(model)
+
+    def test_relative_phase_marg(self):
+        model = models.Relative(self.variable, copy.deepcopy(self.data),
+                                 low_frequency_cutoff=self.flow,
+                                 psds = self.psds,
+                                 static_params = self.static,
+                                 prior = self.prior,
+                                 fiducial_params = {'mass1':1.3756},
+                                 epsilon = .1,
+                                )
+        self._run_tests(model)
+
+    def test_single_phase_marg(self):
+        model = models.SingleTemplate(
+                        self.variable, copy.deepcopy(self.data),
+                        low_frequency_cutoff=self.flow,
+                        psds = self.psds,
+                        static_params = self.static,
+                        prior = self.prior,
+                        )
+        self._run_tests(model)
+
+    def test_single_pol_phase_marg(self):
+        model = models.SingleTemplate(
+                        self.variable2, copy.deepcopy(self.data),
+                        low_frequency_cutoff=self.flow,
+                        psds = self.psds,
+                        static_params = self.static2,
+                        prior = self.prior2,
+                        marginalize_vector_samples = 1000,
+                        marginalize_vector_params = 'polarization',
+                        )
+        self._run_tests(model)
+
+    def test_brute_pol_phase_marg(self):
+        # Uses the old polarization syntax untill we decide to remove it.
+        # Untill then, this also tests that that interface stays working.
+        model = models.BruteParallelGaussianMarginalize(
+                        self.variable, data=copy.deepcopy(self.data),
+                        low_frequency_cutoff=self.flow,
+                        psds = self.psds,
+                        static_params = self.static2,
+                        prior = self.prior,
+                        marginalize_phase=400,
+                        cores=1,
+                        base_model='marginalized_polarization',
+                        )
+        self._run_tests(model)
+
+    def test_gated_gaussian_noise(self):
+        model = models.GatedGaussianNoise(
+            self.variable, data=copy.deepcopy(self.data),
+            low_frequency_cutoff=self.flow,
+            psds=self.psds,
+            static_params=self.staticgate,
+            prior=self.prior)
+        self._run_tests(model)
+
+    def test_gated_gaussian_margpol(self):
+        model = models.GatedGaussianNoise(
+            self.variable, data=copy.deepcopy(self.data),
+            low_frequency_cutoff=self.flow,
+            psds=self.psds,
+            static_params=self.staticgate2,
+            prior=self.prior)
+        self._run_tests(model)
+
+
 suite = unittest.TestSuite()
 suite.addTest(unittest.TestLoader().loadTestsFromTestCase(TestModels))
+suite.addTest(unittest.TestLoader().loadTestsFromTestCase(TestWaveformErrors))
 
 if __name__ == '__main__':
     from astropy.utils import iers


### PR DESCRIPTION
The `Relative` model (and models that inherit from it) do not catch failed waveform errors like the GaussianNoise models do. This adds that functionality to those models.

To avoid repeating code, and to standardize catching these errors, I created a decorator `catch_waveform_error` that can be added to any method that will call a waveform generator. The decorator will catch any `NoWaveformError`, `FailedWaveformError`, and `RuntimeError`. It will then call the class's `_nowaveform_handler` method (for the latter two errors this will only happen if the class's `ignore_failed_waveforms` attribute is set to True). In order for this to work, I had to rename some of the class's `_nowaveform_loglr` and `_nowaveform_logl` to `_nowaveform_handler`.

All models that previously caught these errors have been updated to use the decorator, along with the new addition to the Relative model. I added unit tests to test that the models appropriately catch each error.

One slight issue: in order to catch waveform errors in the Relative model, I also had to catch RuntimeErrors. This is being done at the level of the loglr function. This does mean that if a RuntimeError is raised elsewhere in the loglr function (not by the waverform generator), then the `_nowaveform_handler` will be triggered. I figured this would be ok since it's usually the waveform generator that raise RuntimeErrors.