### PR TITLE
Fix issue of using bank or files via osdf

### DIFF
--- a/pycbc/workflow/configuration.py
+++ b/pycbc/workflow/configuration.py
@@ -159,9 +159,10 @@ def resolve_url(
         # OSDF will require a scitoken to be present and stashcp to be
         # available. Thanks Dunky for the code here!
         cmd = [
-            which("stashcp") or "stashcp",
-            u.path,
-            filename,
+            which("pelican") or "pelican", 
+            "object get", 
+            u.scheme + "://" + u.path, 
+            filename
         ]
 
         try:


### PR DESCRIPTION

stashcp doesn't work now while using files over osdf. pelican is needed to access files from osdf. 

## Standard information about the request

This is a: bug fix

This change affects: the offline search, inference, PyGRB workflows involving osdf files

<!--- What code areas will this affect?  -->
This change changes: access over osdf files.


<!--- Notes about the effect of this change -->
This change will require pelican (https://docs.pelicanplatform.org/install). It also needs a release to run offline workflow.

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
