### PR TITLE
Tidy up of unused imports

### DIFF
--- a/.github/workflows/check_code.yml
+++ b/.github/workflows/check_code.yml
@@ -1,0 +1,15 @@
+name: Flake8 check
+on: [pull_request]
+jobs:
+    flake8 unused imports:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Install flake8
+              run: pip install flake8
+            - name: Checking executables for unused imports
+              run: flake8 --select=F401 `find bin -type f`
+            - name: Checking modules for unused imports
+              run: flake8 --select=F401 `find pycbc | grep '\.py$' | grep -v -e __init__ -e "version.py"`
+            - name: Checking tests for unused imports
+              run: flake8 --select=F401 `find test | grep '\.py$' | grep -v test_schemes`
+

--- a/.github/workflows/check_code.yml
+++ b/.github/workflows/check_code.yml
@@ -7,7 +7,7 @@ jobs:
             - name: Install flake8
               run: pip install flake8
             - name: Checking executables for unused imports
-              run: flake8 --select=F401 `find bin -type f`
+              run: flake8 --select=F401 `find bin -type f -name pycbc_*`
             - name: Checking modules for unused imports
               run: flake8 --select=F401 `find pycbc | grep '\.py$' | grep -v -e __init__ -e "version.py"`
             - name: Checking tests for unused imports

--- a/.github/workflows/check_code.yml
+++ b/.github/workflows/check_code.yml
@@ -1,15 +1,23 @@
 name: Flake8 check
 on: [pull_request]
 jobs:
-    flake8 unused imports:
+    flake8_unused_imports:
         runs-on: ubuntu-latest
         steps:
+            - name: Check out repository
+              uses: actions/checkout@v3
+            - name: Set up Python
+              uses: actions/setup-python@v4
+              with:
+                  python-version: 3.11
             - name: Install flake8
               run: pip install flake8
             - name: Checking executables for unused imports
-              run: flake8 --select=F401 `find bin -type f -name pycbc_*`
+              run: flake8 --select=F401 $(find bin -type f -name pycbc_*)
             - name: Checking modules for unused imports
-              run: flake8 --select=F401 `find pycbc | grep '\.py$' | grep -v -e __init__ -e "version.py"`
+              run: |
+                flake8 --select=F401 $(find pycbc | grep '\.py$' | grep -v -e __init__ -e 'version.py')
             - name: Checking tests for unused imports
-              run: flake8 --select=F401 `find test | grep '\.py$' | grep -v test_schemes`
+              run: |
+                flake8 --select=F401 $(find test | grep '\.py$' | grep -v test_schemes)
 

--- a/bin/all_sky_search/pycbc_add_statmap
+++ b/bin/all_sky_search/pycbc_add_statmap
@@ -3,12 +3,11 @@
 with more than one ifo combination available. Cluster to keep foreground
 coincs with the highest stat value.
 """
-import igwn_segments as segments
 import numpy as np, argparse, logging, pycbc, pycbc.events, pycbc.io
+import igwn_segments as segments
 import pycbc.version
 import pycbc.conversions as conv
-from pycbc.events import coinc, significance
-import sys, copy
+from pycbc.events import significance
 
 def get_ifo_string(fi):
     # Returns a string of a space-separated list of ifos from input file.

--- a/bin/all_sky_search/pycbc_apply_rerank
+++ b/bin/all_sky_search/pycbc_apply_rerank
@@ -2,7 +2,7 @@
 """Rewrite statmap file and rerank candidates using the statistic values
 generated from the followup of candidates.
 """
-import numpy, argparse, logging, pycbc
+import numpy, argparse, pycbc
 from pycbc.io import HFile
 from pycbc.conversions import sec_to_year
 from pycbc.events import significance

--- a/bin/all_sky_search/pycbc_coinc_findtrigs
+++ b/bin/all_sky_search/pycbc_coinc_findtrigs
@@ -3,7 +3,7 @@ import copy, argparse, logging, numpy, numpy.random
 import shutil, uuid, os.path, atexit
 from igwn_segments import infinity
 import pycbc
-from pycbc.events import veto, coinc, stat, ranking, cuts
+from pycbc.events import veto, coinc, stat, cuts
 from pycbc.io import HFile
 from pycbc import pool, init_logging
 from numpy.random import seed, shuffle

--- a/bin/all_sky_search/pycbc_coinc_statmap
+++ b/bin/all_sky_search/pycbc_coinc_statmap
@@ -7,8 +7,8 @@ the capability of doing hierarchical removal of foreground triggers that are
 louder than all of the background triggers. We use this to properly assess
 the FANs of any other gravitational waves in the dataset.
 """
-import argparse, itertools
-import lal, logging, numpy
+import argparse
+import logging, numpy
 from pycbc.events import veto, coinc, significance
 import pycbc.pnutils, pycbc.io
 import sys

--- a/bin/all_sky_search/pycbc_coinc_statmap_inj
+++ b/bin/all_sky_search/pycbc_coinc_statmap_inj
@@ -4,7 +4,7 @@ The program combines coincident output files generated
 by pycbc_coinc_findtrigs to generated a mapping between SNR and FAP, along
 with producing the combined foreground and background triggers
 """
-import argparse, logging, copy, pycbc.io, numpy
+import argparse, logging, pycbc.io, numpy
 from pycbc.events import significance
 import pycbc.conversions as conv
 from pycbc import init_logging

--- a/bin/all_sky_search/pycbc_coinc_statmap_inj
+++ b/bin/all_sky_search/pycbc_coinc_statmap_inj
@@ -4,8 +4,8 @@ The program combines coincident output files generated
 by pycbc_coinc_findtrigs to generated a mapping between SNR and FAP, along
 with producing the combined foreground and background triggers
 """
-import argparse, logging, itertools, copy, pycbc.io, numpy, lal
-from pycbc.events import veto, coinc, significance
+import argparse, logging, copy, pycbc.io, numpy
+from pycbc.events import significance
 import pycbc.conversions as conv
 from pycbc import init_logging
 

--- a/bin/all_sky_search/pycbc_combine_coincident_events
+++ b/bin/all_sky_search/pycbc_combine_coincident_events
@@ -5,7 +5,6 @@ The resulting file would contain triggers from the full set of input files
 """
 import numpy
 import argparse
-import logging
 
 import pycbc
 from pycbc.io import HFile

--- a/bin/all_sky_search/pycbc_combine_statmap
+++ b/bin/all_sky_search/pycbc_combine_statmap
@@ -4,7 +4,7 @@ combinations at the time of coincidence. This clusters to find the most
 significant foreground, but leaves the background triggers alone.
 """
 
-import numpy, argparse, logging, pycbc, pycbc.events, pycbc.io, lal
+import numpy, argparse, logging, pycbc, pycbc.events, pycbc.io
 import igwn_segments as segments
 
 parser = argparse.ArgumentParser()

--- a/bin/all_sky_search/pycbc_exclude_zerolag
+++ b/bin/all_sky_search/pycbc_exclude_zerolag
@@ -5,7 +5,7 @@ coincidences from *any* coincidence type with ifar above a certain threshold
 """
 
 import numpy as np, argparse, logging, pycbc, pycbc.io
-from pycbc.events import veto, coinc, significance
+from pycbc.events import veto, significance
 import pycbc.conversions as conv
 
 parser = argparse.ArgumentParser()

--- a/bin/all_sky_search/pycbc_fit_sngls_by_template
+++ b/bin/all_sky_search/pycbc_fit_sngls_by_template
@@ -13,7 +13,6 @@
 # Public License for more details.
 
 
-import sys, h5py
 import argparse, logging
 
 import copy, numpy as np

--- a/bin/all_sky_search/pycbc_fit_sngls_over_multiparam
+++ b/bin/all_sky_search/pycbc_fit_sngls_over_multiparam
@@ -13,7 +13,7 @@
 # Public License for more details.
 
 
-import sys, argparse, logging, numpy
+import argparse, logging, numpy
 from scipy.stats import norm
 
 import pycbc

--- a/bin/all_sky_search/pycbc_fit_sngls_over_param
+++ b/bin/all_sky_search/pycbc_fit_sngls_over_param
@@ -13,7 +13,6 @@
 # Public License for more details.
 
 
-import sys
 import argparse, logging
 
 import numpy as np

--- a/bin/all_sky_search/pycbc_get_loudest_params
+++ b/bin/all_sky_search/pycbc_get_loudest_params
@@ -4,7 +4,6 @@ Finds the loudest snr or newsnr event within a given time window, parses the
 parameters of the template, and writes them to an hdf and/or stdout.
 """
 
-import lal
 import numpy as np
 import argparse
 import logging

--- a/bin/all_sky_search/pycbc_make_bayestar_skymap
+++ b/bin/all_sky_search/pycbc_make_bayestar_skymap
@@ -20,14 +20,11 @@ import shutil
 import logging
 import os
 import glob
-import sys
-import random
 import tempfile
 
 from ligo.lw import lsctables, utils as ligolw_utils
 
 import pycbc
-from pycbc import init_logging
 from pycbc.waveform import bank as wavebank
 from pycbc.io import WaveformArray
 from pycbc.io.ligolw import LIGOLWContentHandler

--- a/bin/all_sky_search/pycbc_plot_kde_vals
+++ b/bin/all_sky_search/pycbc_plot_kde_vals
@@ -5,7 +5,6 @@ import matplotlib.pyplot as plt
 from matplotlib.colors import LogNorm
 from pycbc import init_logging, add_common_pycbc_options
 from pycbc.io import HFile
-import logging
 
 parser = argparse.ArgumentParser(description=__doc__)
 add_common_pycbc_options(parser)

--- a/bin/all_sky_search/pycbc_prepare_xml_for_gracedb
+++ b/bin/all_sky_search/pycbc_prepare_xml_for_gracedb
@@ -40,7 +40,7 @@ from pycbc.io.ligolw import (
     snr_series_to_xml,
 )
 from pycbc.psd import interpolate
-from pycbc.types import FrequencySeries, TimeSeries, load_timeseries
+from pycbc.types import FrequencySeries, load_timeseries
 from pycbc.types import MultiDetOptionAction
 from pycbc.results import generate_asd_plot, generate_snr_plot
 

--- a/bin/all_sky_search/pycbc_reduce_template_bank
+++ b/bin/all_sky_search/pycbc_reduce_template_bank
@@ -21,7 +21,6 @@ Reduce a template bank using some input parameter cuts
 """
 
 
-import numpy
 import logging
 import argparse
 import pycbc

--- a/bin/all_sky_search/pycbc_rerank_passthrough
+++ b/bin/all_sky_search/pycbc_rerank_passthrough
@@ -1,6 +1,6 @@
 #!/bin/env python
 """Dummy script to pass through stat files and test reranking"""
-import numpy, argparse, logging, pycbc
+import argparse, logging, pycbc
 from pycbc.io import HFile
 
 parser = argparse.ArgumentParser()

--- a/bin/all_sky_search/pycbc_sngls_findtrigs
+++ b/bin/all_sky_search/pycbc_sngls_findtrigs
@@ -1,14 +1,11 @@
 #!/usr/bin/env python
-import argparse, logging, h5py, numpy as np
-from igwn_segments import infinity
+import argparse, logging, numpy as np
 from numpy.random import seed, shuffle
 
 import pycbc
 from pycbc.events import veto, coinc, stat
-import pycbc.conversions as conv
 from pycbc import io
-from pycbc.events import cuts, trigger_fits as trfits
-from pycbc.events.veto import indices_outside_times
+from pycbc.events import cuts
 from pycbc.types.optparse import MultiDetOptionAction
 from pycbc import init_logging
 

--- a/bin/all_sky_search/pycbc_sngls_pastro
+++ b/bin/all_sky_search/pycbc_sngls_pastro
@@ -14,7 +14,7 @@ import pycbc, pycbc.io, copy
 import argparse, logging, numpy as np
 from ligo.lw import lsctables, utils as ligolw_utils
 from pycbc import conversions as conv
-from pycbc.events import veto, stat, ranking, coinc, single as sngl
+from pycbc.events import veto
 from pycbc.io.ligolw import LIGOLWContentHandler
 from igwn_segments import segment, segmentlist
 import matplotlib

--- a/bin/all_sky_search/pycbc_sngls_statmap
+++ b/bin/all_sky_search/pycbc_sngls_statmap
@@ -5,13 +5,11 @@ by pycbc_sngls_findtrigs to generate a mapping between SNR and FAP/FAR, along
 with producing the combined foreground and background triggers.
 """
 
-import argparse, itertools
+import argparse
 import logging, numpy, copy
-from pycbc.events import veto, coinc
-from pycbc.events import triggers, trigger_fits as trstats
+from pycbc.events import veto
 from pycbc.events import significance
 import pycbc.pnutils, pycbc.io
-import sys
 import pycbc.conversions as conv
 
 class fw(object):

--- a/bin/all_sky_search/pycbc_sngls_statmap_inj
+++ b/bin/all_sky_search/pycbc_sngls_statmap_inj
@@ -5,13 +5,10 @@ by pycbc_sngls_findtrigs to generate a mapping between SNR and FAP/FAR, along
 with producing the combined foreground and background triggers.
 """
 
-import argparse, itertools
-import lal, logging, numpy
-from pycbc.events import veto, coinc
-from pycbc.events import triggers, trigger_fits as trstats
+import argparse
+import logging, numpy
 from pycbc.events import significance
 import pycbc.pnutils, pycbc.io
-import sys
 import pycbc.conversions as conv
 
 class fw(object):

--- a/bin/all_sky_search/pycbc_template_kde_calc
+++ b/bin/all_sky_search/pycbc_template_kde_calc
@@ -14,7 +14,6 @@
 
 import numpy, operator, argparse, logging
 from pycbc import init_logging, add_common_pycbc_options
-import pycbc.conversions as convert
 from pycbc import libutils
 from pycbc.events import triggers
 from pycbc.io import HFile

--- a/bin/all_sky_search/pycbc_upload_single_event_to_gracedb
+++ b/bin/all_sky_search/pycbc_upload_single_event_to_gracedb
@@ -25,10 +25,8 @@ import sys
 import argparse
 import logging
 from ligo.gracedb.rest import GraceDb
-import numpy as np
 
 import pycbc
-import lal
 from pycbc.io.gracedb import gracedb_tag_with_version
 
 parser = argparse.ArgumentParser(description=__doc__)

--- a/bin/bank/pycbc_aligned_bank_cat
+++ b/bin/bank/pycbc_aligned_bank_cat
@@ -33,7 +33,6 @@ import pycbc
 import pycbc.psd
 import pycbc.strain
 import pycbc.version
-from pycbc.waveform import get_waveform_filter_length_in_time
 from pycbc.io.ligolw import LIGOLWContentHandler
 from pycbc.io.hdf import HFile
 

--- a/bin/bank/pycbc_brute_bank
+++ b/bin/bank/pycbc_brute_bank
@@ -22,7 +22,6 @@
 import numpy
 import logging
 import argparse
-import pickle
 import numpy.random
 from scipy.stats import gaussian_kde
 

--- a/bin/bank/pycbc_coinc_bank2hdf
+++ b/bin/bank/pycbc_coinc_bank2hdf
@@ -22,7 +22,6 @@ with their template.
 """
 import argparse
 import logging
-import numpy
 
 import pycbc
 from pycbc.waveform import bank

--- a/bin/bank/pycbc_geom_aligned_bank
+++ b/bin/bank/pycbc_geom_aligned_bank
@@ -40,7 +40,6 @@ import pycbc.strain
 import pycbc.version
 import pycbc.tmpltbank
 import pycbc.workflow as wf
-import pycbc.workflow.pegasus_workflow as pwf
 from pycbc.workflow import WorkflowConfigParser
 from pycbc.workflow.core import resolve_url_to_file
 from pycbc.io.ligolw import create_process_table

--- a/bin/hwinj/pycbc_generate_hwinj
+++ b/bin/hwinj/pycbc_generate_hwinj
@@ -38,11 +38,10 @@ from pycbc.detector import Detector
 from pycbc.inject import InjectionSet, legacy_approximant_name
 from pycbc.filter import make_frequency_series
 from pycbc.filter import sigmasq
-from pycbc.types import Array, FrequencySeries, TimeSeries, zeros
-from pycbc.types.optparse import MultiDetOptionAppendAction
+from pycbc.types import TimeSeries
 from pycbc.types.optparse import convert_to_process_params_dict
 from pycbc.io.ligolw import create_process_table
-from pycbc.waveform import FilterBank, get_td_waveform, td_approximants, taper_timeseries
+from pycbc.waveform import get_td_waveform, td_approximants, taper_timeseries
 
 def _empty_row(obj):
     """Create an empty sim_inspiral or sngl_inspiral row where the columns have

--- a/bin/hwinj/pycbc_plot_hwinj
+++ b/bin/hwinj/pycbc_plot_hwinj
@@ -23,7 +23,6 @@ import logging
 import matplotlib as mpl; mpl.use("Agg")
 import matplotlib.pyplot as plt
 import numpy
-import sys
 
 from pycbc import add_common_pycbc_options, init_logging
 

--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -22,17 +22,14 @@ import os
 import sys
 import argparse
 import logging
-import shutil
 
 import numpy
 
 import pycbc
-from pycbc import (distributions, transforms, fft,
-                   opt, scheme, pool)
-from pycbc.waveform import generator
+from pycbc import fft, opt, scheme, pool
 
 from pycbc import inference
-from pycbc.inference import (models, burn_in, option_utils)
+from pycbc.inference import models
 from pycbc.inference.io import loadfile
 from pycbc.workflow import configuration
 

--- a/bin/inference/pycbc_inference_extract_samples
+++ b/bin/inference/pycbc_inference_extract_samples
@@ -38,8 +38,6 @@ across combined files.
 """
 
 import os
-import argparse
-import logging
 import numpy
 import pycbc
 from pycbc.inference.io import (ResultsArgumentParser, results_from_cli,

--- a/bin/inference/pycbc_inference_model_stats
+++ b/bin/inference/pycbc_inference_model_stats
@@ -25,7 +25,6 @@ import os
 import argparse
 import shutil
 import logging
-import time
 import numpy
 import tqdm
 

--- a/bin/inference/pycbc_inference_plot_acceptance_rate
+++ b/bin/inference/pycbc_inference_plot_acceptance_rate
@@ -21,7 +21,6 @@ import logging
 from matplotlib import use
 use('agg')
 import matplotlib.pyplot as plt
-import numpy
 import pycbc
 from pycbc import results
 from pycbc.inference import io

--- a/bin/inference/pycbc_inference_plot_acf
+++ b/bin/inference/pycbc_inference_plot_acf
@@ -16,7 +16,6 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-import argparse
 import logging
 import sys
 
@@ -29,7 +28,6 @@ import pycbc
 from pycbc import results
 from pycbc.inference import io
 
-from pycbc.inference import option_utils
 from pycbc.inference.sampler import samplers
 
 # command line usage

--- a/bin/inference/pycbc_inference_plot_acl
+++ b/bin/inference/pycbc_inference_plot_acl
@@ -16,7 +16,6 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-import argparse
 import logging
 import sys
 

--- a/bin/inference/pycbc_inference_plot_gelman_rubin
+++ b/bin/inference/pycbc_inference_plot_gelman_rubin
@@ -17,7 +17,6 @@
 """ Plots the Gelman-Rubin convergence diagnositic statistic.
 """
 
-import argparse
 import logging
 import matplotlib
 matplotlib.use("Agg")
@@ -27,7 +26,7 @@ import sys
 from pycbc import (
     results, init_logging, add_common_pycbc_options
 )
-from pycbc.inference import (gelman_rubin, io, option_utils)
+from pycbc.inference import (gelman_rubin, io)
 
 # add options to command line
 parser = io.ResultsArgumentParser(skip_args=['walkers'])

--- a/bin/inference/pycbc_inference_plot_geweke
+++ b/bin/inference/pycbc_inference_plot_geweke
@@ -18,7 +18,6 @@
 """ Plots the Geweke convergence diagnositic statistic.
 """
 
-import argparse
 import logging
 import matplotlib as mpl; mpl.use("Agg")
 import matplotlib.pyplot as plt
@@ -26,7 +25,7 @@ import pycbc
 from pycbc import results
 import sys
 
-from pycbc.inference import (io, geweke, option_utils)
+from pycbc.inference import (io, geweke)
 
 # add options to command line
 parser = io.ResultsArgumentParser(skip_args=['walkers'])

--- a/bin/inference/pycbc_inference_plot_inj_recovery
+++ b/bin/inference/pycbc_inference_plot_inj_recovery
@@ -4,7 +4,6 @@ of injections.
 """
 
 import sys
-import argparse
 import logging
 import matplotlib as mpl; mpl.use("Agg")
 import matplotlib.colorbar as cbar
@@ -12,7 +11,6 @@ import matplotlib.pyplot as plt
 import numpy
 import pycbc
 from matplotlib import cm
-from pycbc import inject
 from pycbc.inference import (option_utils, io)
 from pycbc.results import save_fig_with_metadata
 

--- a/bin/inference/pycbc_inference_plot_movie
+++ b/bin/inference/pycbc_inference_plot_movie
@@ -38,7 +38,6 @@ the movie.
 # =============================================================================
 #
 
-import argparse
 import logging
 import subprocess
 import os

--- a/bin/inference/pycbc_inference_plot_posterior
+++ b/bin/inference/pycbc_inference_plot_posterior
@@ -25,7 +25,6 @@
 # =============================================================================
 #
 
-import argparse
 import itertools
 import logging
 import sys

--- a/bin/inference/pycbc_inference_plot_pp
+++ b/bin/inference/pycbc_inference_plot_pp
@@ -20,7 +20,6 @@ within a credible interval versus credible interval.
 """
 
 import sys
-import argparse
 import logging
 import itertools
 
@@ -31,7 +30,6 @@ from scipy import stats
 import matplotlib
 matplotlib.use('agg')
 from matplotlib import pyplot as plt
-import matplotlib.style as style
 
 import pycbc
 import pycbc.results.plot

--- a/bin/inference/pycbc_inference_plot_prior
+++ b/bin/inference/pycbc_inference_plot_prior
@@ -28,7 +28,7 @@ use('agg')
 from matplotlib import pyplot as plt
 
 import pycbc
-from pycbc import (distributions, results, waveform)
+from pycbc import (results, waveform)
 from pycbc.inference.option_utils import ParseParametersArg
 from pycbc.distributions.utils import prior_from_config
 from pycbc.workflow import WorkflowConfigParser

--- a/bin/inference/pycbc_inference_plot_samples
+++ b/bin/inference/pycbc_inference_plot_samples
@@ -23,11 +23,10 @@ import logging
 from matplotlib import use
 use('agg')
 from matplotlib import pyplot as plt
-from matplotlib import rc
 import numpy
 import pycbc
 from pycbc import results
-from pycbc.inference import (option_utils, io)
+from pycbc.inference import io
 import sys
 
 # command line usage

--- a/bin/inference/pycbc_inference_plot_thermodynamic_integrand
+++ b/bin/inference/pycbc_inference_plot_thermodynamic_integrand
@@ -28,13 +28,11 @@
 import argparse
 import matplotlib
 matplotlib.use("agg")
-from matplotlib import rc
 import matplotlib.pyplot as plt
 import numpy
 
 from pycbc import add_common_pycbc_options, init_logging
 from pycbc.inference import io
-import pycbc.version
 
 parser = argparse.ArgumentParser()
 add_common_pycbc_options(parser)

--- a/bin/inference/pycbc_inference_pp_table_summary
+++ b/bin/inference/pycbc_inference_pp_table_summary
@@ -19,7 +19,6 @@
 an html table.
 """
 
-import argparse
 import logging
 import numpy
 import sys

--- a/bin/inference/pycbc_inference_start_from_samples
+++ b/bin/inference/pycbc_inference_start_from_samples
@@ -3,8 +3,6 @@
 """
 
 import argparse
-import numpy
-import h5py
 from numpy.random import choice
 
 from pycbc import add_common_pycbc_options, init_logging

--- a/bin/inference/pycbc_inference_table_summary
+++ b/bin/inference/pycbc_inference_table_summary
@@ -17,9 +17,6 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 import os
-import argparse
-import h5py
-import logging
 import numpy
 import sys
 import pycbc

--- a/bin/inference/pycbc_validate_test_posterior
+++ b/bin/inference/pycbc_validate_test_posterior
@@ -9,7 +9,7 @@ from matplotlib import use
 use('Agg')
 import pylab
 
-from scipy.stats import gaussian_kde, ks_2samp
+from scipy.stats import ks_2samp
 
 from pycbc.distributions.utils import prior_from_config
 from pycbc.inference import models, io

--- a/bin/live/pycbc_live_collate_triggers
+++ b/bin/live/pycbc_live_collate_triggers
@@ -14,14 +14,11 @@
 
 """Find trigger files and combine them into a single hdf trigger merge file."""
 
-import glob
 import numpy
 import argparse
-import itertools
 import h5py
 import os
 import logging
-from datetime import datetime, timedelta
 
 from igwn_segments import segmentlist, segment
 

--- a/bin/live/pycbc_live_single_significance_fits
+++ b/bin/live/pycbc_live_single_significance_fits
@@ -16,7 +16,6 @@
 
 See https://arxiv.org/abs/2008.07494 for a description of the method."""
 
-import os
 import sys
 import argparse
 import logging
@@ -28,7 +27,6 @@ from pycbc.events import cuts, trigger_fits as trstats, stat
 from pycbc.io import DictArray, HFile
 from pycbc.io import live as liveio
 from pycbc.live import significance_fits as sngls_io
-from pycbc.events import ranking
 from pycbc.events.coinc import cluster_over_time
 from pycbc.types import MultiDetOptionAction
 

--- a/bin/minifollowups/pycbc_foreground_minifollowup
+++ b/bin/minifollowups/pycbc_foreground_minifollowup
@@ -17,7 +17,6 @@
 """ Followup foreground events
 """
 import os
-import sys
 import argparse
 import logging
 import re

--- a/bin/minifollowups/pycbc_page_coincinfo
+++ b/bin/minifollowups/pycbc_page_coincinfo
@@ -30,7 +30,7 @@ from pycbc import add_common_pycbc_options
 import pycbc.results
 import pycbc.pnutils
 from pycbc.io.hdf import HFile
-from pycbc.events import ranking, stat as pystat
+from pycbc.events import stat as pystat
 from pycbc.results import followup
 
 parser = argparse.ArgumentParser()

--- a/bin/minifollowups/pycbc_page_snglinfo
+++ b/bin/minifollowups/pycbc_page_snglinfo
@@ -17,7 +17,6 @@
 
 """ Make tables describing a sngl event"""
 import sys
-import h5py
 import numpy
 import datetime
 import argparse

--- a/bin/minifollowups/pycbc_plot_trigger_timeseries
+++ b/bin/minifollowups/pycbc_plot_trigger_timeseries
@@ -19,7 +19,6 @@
 import argparse
 import logging
 import sys
-import h5py
 import matplotlib
 matplotlib.use('Agg')
 import pylab

--- a/bin/minifollowups/pycbc_upload_prep_minifollowup
+++ b/bin/minifollowups/pycbc_upload_prep_minifollowup
@@ -17,20 +17,17 @@
 """ Prepare files for upload to GraceDB for foreground events
 """
 import os
-import sys
 import argparse
 import logging
-import re
 import numpy as np
 
 import igwn_segments as segments
 
 from pycbc import init_logging, add_common_pycbc_options
 import pycbc.workflow as wf
-from pycbc.results import layout
 from pycbc.types import MultiDetOptionAction
-from pycbc.events import select_segments_by_definer, coinc
-from pycbc.io import get_all_subkeys, HFile
+from pycbc.events import select_segments_by_definer
+from pycbc.io import HFile
 import pycbc.workflow.minifollowups as mini
 from pycbc.workflow.core import resolve_url_to_file, resolve_td_option
 

--- a/bin/plotting/pycbc_banksim_plot_eff_fitting_factor
+++ b/bin/plotting/pycbc_banksim_plot_eff_fitting_factor
@@ -22,7 +22,6 @@ point-source files.
 import sys
 import numpy
 import argparse
-import logging
 import matplotlib
 matplotlib.use('Agg')
 import matplotlib.pyplot as plt

--- a/bin/plotting/pycbc_banksim_plot_fitting_factors
+++ b/bin/plotting/pycbc_banksim_plot_fitting_factors
@@ -20,7 +20,6 @@
 import sys
 import argparse
 import numpy
-import logging
 import matplotlib
 matplotlib.use('Agg')
 import matplotlib.pyplot as plt

--- a/bin/plotting/pycbc_banksim_table_point_injs
+++ b/bin/plotting/pycbc_banksim_table_point_injs
@@ -20,7 +20,6 @@
 import sys
 import argparse
 import numpy
-import logging
 
 import pycbc.version
 from pycbc import results

--- a/bin/plotting/pycbc_faithsim_plots
+++ b/bin/plotting/pycbc_faithsim_plots
@@ -9,13 +9,11 @@ import argparse
 import matplotlib
 matplotlib.use("Agg")
 import matplotlib.cm
-from matplotlib.ticker import MultipleLocator, FormatStrFormatter
+from matplotlib.ticker import MultipleLocator
 import pylab
 import numpy as np
 
-from ligo.lw import utils, table, lsctables
-
-from pycbc import pnutils, init_logging, add_common_pycbc_options
+from pycbc import init_logging, add_common_pycbc_options
 from pycbc.conversions import (
     mtotal_from_mass1_mass2,
     q_from_mass1_mass2,

--- a/bin/plotting/pycbc_page_banktriggerrate
+++ b/bin/plotting/pycbc_page_banktriggerrate
@@ -3,7 +3,7 @@
 """
 import matplotlib
 matplotlib.use('Agg')
-import numpy, argparse, os, pylab, pycbc.pnutils
+import numpy, argparse, pylab, pycbc.pnutils
 from pycbc.io.hdf import HFile
 
 from pycbc import init_logging, add_common_pycbc_options

--- a/bin/plotting/pycbc_page_foundmissed
+++ b/bin/plotting/pycbc_page_foundmissed
@@ -3,7 +3,6 @@
 """
 import numpy
 import logging
-import os.path
 import argparse
 import sys
 import matplotlib
@@ -12,7 +11,6 @@ import matplotlib.pyplot as plot
 
 import pycbc.results.followup, pycbc.pnutils, pycbc.results
 import pycbc.pnutils
-from pycbc import init_logging, add_common_pycbc_options
 from pycbc.detector import Detector
 from pycbc.io.hdf import HFile
 
@@ -66,7 +64,7 @@ parser.add_argument('--missed-on-top', action='store_true',
                          "high FAR on top of low FAR")
 args = parser.parse_args()
 
-init_logging(args.verbose)
+pycbc.init_logging(args.verbose)
 
 logging.info('Read in the data')
 f = HFile(args.injection_file, 'r')

--- a/bin/plotting/pycbc_page_ifar
+++ b/bin/plotting/pycbc_page_ifar
@@ -23,8 +23,6 @@ import pylab
 import matplotlib as mpl
 mpl.use('Agg')
 
-import igwn_segments as segments
-
 from pycbc import init_logging, add_common_pycbc_options
 import pycbc.results
 from pycbc.events import veto

--- a/bin/plotting/pycbc_page_recovery
+++ b/bin/plotting/pycbc_page_recovery
@@ -6,7 +6,7 @@ matplotlib.use("Agg")
 import matplotlib.pyplot as plot
 
 import pycbc.detector
-from pycbc import pnutils, results
+from pycbc import results
 from pycbc.events import triggers
 from pycbc.io.hdf import HFile
 

--- a/bin/plotting/pycbc_page_segplot
+++ b/bin/plotting/pycbc_page_segplot
@@ -20,15 +20,12 @@ import argparse
 import matplotlib; matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 import numpy, pylab, pycbc.events, mpld3, mpld3.plugins
-import itertools, datetime, time
 import sys
 from itertools import cycle
-from matplotlib.patches import Rectangle
 
 from pycbc import add_common_pycbc_options, init_logging
 from pycbc.events.veto import get_segment_definer_comments
-from pycbc.results.color import ifo_color
-from pycbc.results.mpld3_utils import MPLSlide, LineTooltip
+from pycbc.results.mpld3_utils import LineTooltip
 from pycbc.workflow import SegFile
 
 # parse command line

--- a/bin/plotting/pycbc_page_segtable
+++ b/bin/plotting/pycbc_page_segtable
@@ -17,7 +17,6 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 import argparse
-import logging
 import numpy
 import pycbc.results
 import sys

--- a/bin/plotting/pycbc_page_snrchi
+++ b/bin/plotting/pycbc_page_snrchi
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 import logging
 import numpy
-import h5py
 import argparse
 import matplotlib
 import sys
@@ -9,7 +8,6 @@ matplotlib.use('Agg')
 import pylab
 
 import pycbc.results
-from pycbc.events import veto
 from pycbc.io import (
     get_chisq_from_file_choice, chisq_choices, SingleDetTriggers, HFile
 )

--- a/bin/plotting/pycbc_page_snrifar
+++ b/bin/plotting/pycbc_page_snrifar
@@ -3,7 +3,7 @@
     ranking statistic, or make statistical significance vs ranking statistic
     cumulative histograms. 
 """
-import argparse, h5py, numpy, logging, sys
+import argparse, numpy, logging, sys
 import matplotlib
 matplotlib.use('Agg')
 import pylab

--- a/bin/plotting/pycbc_page_versioning
+++ b/bin/plotting/pycbc_page_versioning
@@ -10,7 +10,6 @@ import argparse
 import logging
 
 import pycbc
-from pycbc import init_logging, add_common_pycbc_options
 from pycbc.results import (save_fig_with_metadata, html_escape,
     get_library_version_info, get_code_version_numbers)
 
@@ -26,7 +25,7 @@ parser.add_argument("--output-file", required=True,
                     help="The directory for output html snippets")
 args = parser.parse_args()
 
-init_logging(args.verbose)
+pycbc.init_logging(args.verbose)
 
 if not len(args.executables) == len(args.executables_names):
     raise parser.error("--executables-files and executables-names must be "

--- a/bin/plotting/pycbc_plot_background_coincs
+++ b/bin/plotting/pycbc_plot_background_coincs
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 """ Plot PyCBC's background coinc triggers
 """
-import numpy
 import argparse
 import matplotlib
 matplotlib.use('Agg')

--- a/bin/plotting/pycbc_plot_bank_corner
+++ b/bin/plotting/pycbc_plot_bank_corner
@@ -33,7 +33,6 @@ from pycbc.results.plot import (add_style_opt_to_parser, set_style_from_cli)
 from pycbc.io import FieldArray, HFile
 from pycbc.inference import option_utils
 from pycbc.tmpltbank import bank_conversions as bconv
-from pycbc.pnutils import get_imr_duration
 from pycbc.results.scatter_histograms import create_multidim_plot
 from pycbc.results import metadata
 

--- a/bin/plotting/pycbc_plot_dq_likelihood_vs_time
+++ b/bin/plotting/pycbc_plot_dq_likelihood_vs_time
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 """Plot the DQ log likelihood versus time for a specific background bin
 """
-import logging
 import sys
 import argparse
 import numpy

--- a/bin/plotting/pycbc_plot_dq_percentiles
+++ b/bin/plotting/pycbc_plot_dq_percentiles
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 """ Plot the log likelihood percentiles for a DQ bin
 """
-import logging
 import sys
 import argparse
 import numpy

--- a/bin/plotting/pycbc_plot_gating
+++ b/bin/plotting/pycbc_plot_gating
@@ -14,7 +14,6 @@ import mpld3.plugins
 
 import pycbc
 from pycbc.results.color import ifo_color
-from pycbc.results.mpld3_utils import MPLSlide
 from pycbc.io.hdf import HFile
 
 

--- a/bin/plotting/pycbc_plot_hist
+++ b/bin/plotting/pycbc_plot_hist
@@ -4,7 +4,6 @@
 
 import numpy
 import argparse
-import logging
 import sys
 from itertools import cycle
 from matplotlib import use
@@ -14,7 +13,7 @@ from matplotlib import pyplot
 import pycbc
 import pycbc.results
 import pycbc.io
-from pycbc.events import background_bin_from_string, veto, ranking
+from pycbc.events import background_bin_from_string, ranking
 
 parser = argparse.ArgumentParser(description=__doc__)
 pycbc.add_common_pycbc_options(parser)

--- a/bin/plotting/pycbc_plot_qscan
+++ b/bin/plotting/pycbc_plot_qscan
@@ -25,8 +25,6 @@ information on the Q-transform and its parameters.
 
 import sys
 import argparse
-import logging
-import numpy
 
 import matplotlib
 matplotlib.use('Agg')

--- a/bin/plotting/pycbc_plot_singles_vs_params
+++ b/bin/plotting/pycbc_plot_singles_vs_params
@@ -28,7 +28,6 @@ matplotlib.use('agg')
 import pylab as pl
 from matplotlib.colors import LogNorm
 from matplotlib.ticker import LogLocator
-import h5py
 import sys
 from packaging.version import Version
 

--- a/bin/plotting/pycbc_plot_throughput
+++ b/bin/plotting/pycbc_plot_throughput
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 import argparse
-import logging
-import numpy as np
 import matplotlib
 matplotlib.use('Agg')
 import pylab as pl

--- a/bin/plotting/pycbc_plot_trigrate
+++ b/bin/plotting/pycbc_plot_trigrate
@@ -19,7 +19,6 @@ import logging
 from matplotlib import use
 use('Agg')
 from matplotlib import pyplot as plt
-import copy
 import numpy as np
 from scipy import stats as scistats
 

--- a/bin/plotting/pycbc_plot_waveform
+++ b/bin/plotting/pycbc_plot_waveform
@@ -18,18 +18,15 @@
 """
 
 # imports
-import sys, argparse, matplotlib, numpy, math
+import sys, argparse, matplotlib, numpy
 matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 from mpl_toolkits.axes_grid1.inset_locator import zoomed_inset_axes
-from mpl_toolkits.axes_grid1.inset_locator import mark_inset
 
 from pycbc import waveform, io
 from pycbc import results
 from pycbc import init_logging, add_common_pycbc_options
-from pycbc.fft import ifft
-from pycbc.types import complex_same_precision_as
-from pycbc.types import TimeSeries, zeros, complex64
+from pycbc.types import zeros, complex64
 
 parser = argparse.ArgumentParser(usage='', description=__doc__)
 add_common_pycbc_options(parser)
@@ -157,8 +154,6 @@ if tmplt_length > 1.:
                     x_zoom_fac*template_td.sample_times.max()])
     axins.get_xaxis().set_ticks([])
     axins.get_yaxis().set_ticks([])
-    # Can't get this to work for what I'm doing :-(
-    #mark_inset(ax, axins, loc1=1, loc2=3, fc="none", ec="0.5")
 
 plt.subplot(2,1,2)
 plt.plot(template.sample_frequencies, abs(template))

--- a/bin/population/pycbc_population_plots
+++ b/bin/population/pycbc_population_plots
@@ -25,7 +25,6 @@ __email__ = "vaibhav.tiwari@ligo.org"
 __version__ = "0.0"
 __date__ = "31.10.2017"
 
-import logging
 import argparse
 from numpy import logaddexp, log, newaxis, expm1
 import numpy as np

--- a/bin/population/pycbc_population_rates
+++ b/bin/population/pycbc_population_rates
@@ -32,11 +32,8 @@ __email__ = "vaibhav.tiwari@ligo.org"
 __version__ = "0.0"
 __date__ = "31.10.2017"
 
-import logging
 import argparse
 import numpy as np
-import scipy.stats as ss
-from numpy import logaddexp, log, newaxis, expm1
 
 import pycbc
 from pycbc.population import scale_injections as si
@@ -149,7 +146,7 @@ alpha, mu, sigma = rf.fit(R)
 
 #Estimate rates
 rate_samples = {}
-log_R = log(R)
+log_R = np.log(R)
 mu_log_vt = np.log(vol_time/1e9)
 sigma_log_vt = sigma_w_cal_uncrt
 Rf_samp = rf.skew_lognormal_samples(alpha, mu, sigma, min(log_R), max(log_R))

--- a/bin/pycbc_banksim_combine_banks
+++ b/bin/pycbc_banksim_combine_banks
@@ -22,10 +22,8 @@ files. It is assumed that input files have analysed the same set of injections.
 Concatenation of injections is done separately.
 """
 
-from os.path import isfile
 import argparse
-import logging
-from numpy import *
+from numpy import dtype, array
 
 import pycbc
 

--- a/bin/pycbc_banksim_skymax
+++ b/bin/pycbc_banksim_skymax
@@ -17,9 +17,8 @@
 """Calculate the fitting factors of simulated signals with a template bank."""
 
 
-import sys
 import logging
-from numpy import complex64, float32, sqrt, argmax, real, array
+from numpy import complex64, sqrt, argmax, real, array
 from argparse import ArgumentParser
 from math import ceil, log
 from tqdm import tqdm
@@ -27,14 +26,14 @@ from tqdm import tqdm
 from ligo.lw import utils as ligolw_utils
 from ligo.lw import lsctables
 
-from pycbc.pnutils import mass1_mass2_to_mchirp_eta, f_SchwarzISCO
+from pycbc.pnutils import mass1_mass2_to_mchirp_eta
 from pycbc.pnutils import nearest_larger_binary_number
 from pycbc.pnutils import mass1_mass2_to_tau0_tau3
 from pycbc.waveform import get_td_waveform, get_fd_waveform, td_approximants, fd_approximants
 from pycbc.waveform.utils import taper_timeseries
 from pycbc import DYN_RANGE_FAC
-from pycbc.types import FrequencySeries, TimeSeries, zeros, real_same_precision_as, complex_same_precision_as
-from pycbc.filter import match, sigmasq, resample_to_delta_t
+from pycbc.types import FrequencySeries, TimeSeries, zeros, complex_same_precision_as
+from pycbc.filter import sigmasq
 from pycbc.filter import overlap_cplx, matched_filter
 from pycbc.filter import compute_max_snr_over_sky_loc_stat
 from pycbc.filter import compute_max_snr_over_sky_loc_stat_no_phase

--- a/bin/pycbc_compress_bank
+++ b/bin/pycbc_compress_bank
@@ -31,6 +31,7 @@ import numpy
 import logging
 
 import pycbc
+import pycbc.psd
 from pycbc.waveform import compress
 from pycbc import waveform
 from pycbc.types import FrequencySeries, real_same_precision_as

--- a/bin/pycbc_compress_bank
+++ b/bin/pycbc_compress_bank
@@ -31,7 +31,7 @@ import numpy
 import logging
 
 import pycbc
-import pycbc.psd
+from pycbc import psd
 from pycbc.waveform import compress
 from pycbc import waveform
 from pycbc.types import FrequencySeries, real_same_precision_as
@@ -107,7 +107,7 @@ pycbc.init_logging(args.verbose)
 # using a PSD is not desired, this check would prevent raising an error
 # asking for PSD options.
 if args.psd_model or args.psd_file or args.asd_file :
-    psd.verify_psd_options(args, parser)
+    pycbc.psd.verify_psd_options(args, parser)
 
 if args.sample_rate % 2 != 0:
     raise ValueError("sample rate must be a power of 2")

--- a/bin/pycbc_compress_bank
+++ b/bin/pycbc_compress_bank
@@ -28,17 +28,12 @@ hdf file."""
 
 import argparse
 import numpy
-import h5py
 import logging
 
 import pycbc
-from pycbc import psd, DYN_RANGE_FAC
 from pycbc.waveform import compress
 from pycbc import waveform
 from pycbc.types import FrequencySeries, real_same_precision_as
-from pycbc import pnutils
-from pycbc import filter
-
 
 parser = argparse.ArgumentParser(description=__description__)
 pycbc.add_common_pycbc_options(parser)

--- a/bin/pycbc_convertinjfiletohdf
+++ b/bin/pycbc_convertinjfiletohdf
@@ -25,8 +25,7 @@ import numpy
 import shutil
 
 import pycbc
-from pycbc.inject import InjectionSet, CBCHDFInjectionSet
-from pycbc.types import float64, float32
+from pycbc.inject import CBCHDFInjectionSet
 from pycbc.io.record import FieldArray
 from pycbc.io.hdf import HFile
 

--- a/bin/pycbc_create_injections
+++ b/bin/pycbc_create_injections
@@ -113,7 +113,6 @@ import sys
 import argparse
 import logging
 import numpy
-import h5py
 from numpy.random import uniform
 
 import pycbc
@@ -121,8 +120,6 @@ from pycbc.inject import InjectionSet
 from pycbc import distributions
 from pycbc import transforms
 from pycbc.distributions import JointDistribution
-from pycbc.io import record
-from pycbc.waveform import parameters
 from pycbc.workflow import configuration
 from pycbc.workflow import WorkflowConfigParser
 

--- a/bin/pycbc_data_store
+++ b/bin/pycbc_data_store
@@ -3,7 +3,6 @@
 """
 import logging
 import argparse
-import numpy
 
 import pycbc
 import pycbc.strain

--- a/bin/pycbc_faithsim_collect_results
+++ b/bin/pycbc_faithsim_collect_results
@@ -8,7 +8,7 @@ computing the match between them and creating a .dat file with the results.
 import argparse
 import numpy as np
 
-from ligo.lw import utils, table, lsctables
+from ligo.lw import utils, lsctables
 
 from pycbc import add_common_pycbc_options, init_logging
 from pycbc.io.ligolw import LIGOLWContentHandler

--- a/bin/pycbc_get_ffinal
+++ b/bin/pycbc_get_ffinal
@@ -7,14 +7,13 @@ the duration of time domain waveforms.
 __prog__ = 'pycbc_get_ffinal'
 __author__ = 'Collin Capano <collin.capano@ligo.org>'
 
-import os, sys
+import sys
 import numpy
 import argparse
 
 import pycbc
 from pycbc import waveform
 
-from ligo.lw import lsctables
 from ligo.lw import utils as ligolw_utils
 from ligo.lw import table
 from ligo.lw.utils import process

--- a/bin/pycbc_hdf5_splitbank
+++ b/bin/pycbc_hdf5_splitbank
@@ -23,7 +23,6 @@ smaller banks where the number of smaller banks is a user input
 
 import argparse
 import numpy
-import h5py
 import logging
 from numpy import random
 
@@ -92,7 +91,6 @@ if args.random_sort:
     tmplt_bank.table = templates
 
 if args.mchirp_sort:
-    from pycbc import pnutils
     mcsort = numpy.argsort(templates.mchirp)
     templates = templates[mcsort]
     tmplt_bank.table = templates

--- a/bin/pycbc_inspiral
+++ b/bin/pycbc_inspiral
@@ -22,15 +22,14 @@ import copy
 import logging
 import argparse
 import numpy
-import itertools
 import time
 from pycbc.pool import BroadcastPool as Pool
 
 import pycbc
 from pycbc import vetoes, psd, waveform, strain, scheme, fft, DYN_RANGE_FAC, events
 from pycbc.vetoes.sgchisq import SingleDetSGChisq
-from pycbc.filter import MatchedFilterControl, make_frequency_series, qtransform
-from pycbc.types import TimeSeries, FrequencySeries, zeros, float32, complex64
+from pycbc.filter import MatchedFilterControl, qtransform
+from pycbc.types import zeros, float32, complex64
 import pycbc.opt
 import pycbc.inject
 

--- a/bin/pycbc_inspiral_skymax
+++ b/bin/pycbc_inspiral_skymax
@@ -24,8 +24,8 @@ import numpy
 from pycbc import vetoes, psd, waveform, events, strain, scheme, fft
 from pycbc.vetoes.sgchisq import SingleDetSGChisq
 from pycbc import DYN_RANGE_FAC
-from pycbc.filter import MatchedFilterSkyMaxControl, make_frequency_series, MatchedFilterSkyMaxControlNoPhase
-from pycbc.types import TimeSeries, FrequencySeries, zeros, float32, complex64
+from pycbc.filter import MatchedFilterSkyMaxControl, MatchedFilterSkyMaxControlNoPhase
+from pycbc.types import zeros, float32, complex64
 import pycbc.fft.fftw
 import pycbc.opt
 

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -10,12 +10,11 @@ launched with mpirun.
 See https://arxiv.org/abs/1805.11174 for an overview."""
 
 import sys
-import argparse, numpy, pycbc, logging, cProfile, h5py, lal, json
+import argparse, numpy, pycbc, logging, cProfile, h5py, json
 import os.path
 import itertools
 import platform
 import subprocess
-import multiprocessing
 from multiprocessing.dummy import threading
 from matplotlib import use
 use('agg')
@@ -43,7 +42,6 @@ from pycbc.detector import ppdets
 from pycbc.filter import resample
 from pycbc.psd import estimate
 from pycbc.psd import variation
-from pycbc.live import snr_optimizer
 from pycbc import conversions as conv
 
 # Use cached class-based FFTs in the resample and estimate module

--- a/bin/pycbc_make_faithsim
+++ b/bin/pycbc_make_faithsim
@@ -52,7 +52,6 @@ def mkdir(dir_name):
         pass
 
 def matches_in_list(slist, match):
-    import re
     matches = []
     for st in slist:
         if st.startswith(match):

--- a/bin/pycbc_make_html_page
+++ b/bin/pycbc_make_html_page
@@ -19,17 +19,13 @@
 import argparse
 import os
 import stat
-import random
 import shutil
 import zipfile
 import codecs
 from jinja2 import Environment, FileSystemLoader
 
-import igwn_segments as segments
-
 import pycbc.results
 from pycbc.results.render import get_embedded_config, render_workflow_html_template, setup_template_render
-from pycbc.workflow import segment
 
 def examine_dir(cwd):
     """

--- a/bin/pycbc_make_skymap
+++ b/bin/pycbc_make_skymap
@@ -18,14 +18,13 @@ from matplotlib import use as mpl_use_backend
 mpl_use_backend('agg')
 
 import numpy as np
-import h5py
 
 from ligo.gracedb.rest import GraceDb
 
 import pycbc
 from pycbc.filter import sigmasq
 from pycbc.io import gracedb as pycbc_gracedb, WaveformArray
-from pycbc.types import (TimeSeries, FrequencySeries, load_timeseries,
+from pycbc.types import (load_timeseries,
                          load_frequencyseries, MultiDetMultiColonOptionAction,
                          MultiDetOptionAction, MultiDetOptionAppendAction)
 from pycbc.pnutils import nearest_larger_binary_number

--- a/bin/pycbc_merge_inj_hdf
+++ b/bin/pycbc_merge_inj_hdf
@@ -23,7 +23,6 @@ Merge hdf injection files
 import logging
 import argparse
 import numpy as np
-import h5py
 
 import pycbc
 import pycbc.inject

--- a/bin/pycbc_multi_inspiral
+++ b/bin/pycbc_multi_inspiral
@@ -44,7 +44,6 @@ from pycbc import (
     add_common_pycbc_options,
 )
 from pycbc.events import ranking, coherent as coh, EventManagerCoherent
-from pycbc.io.hdf import HFile
 from pycbc.filter import MatchedFilterControl
 from pycbc.types import zeros, float32, complex64, angle_as_radians
 from pycbc.vetoes import sgchisq

--- a/bin/pycbc_randomize_inj_dist_by_optsnr
+++ b/bin/pycbc_randomize_inj_dist_by_optsnr
@@ -13,7 +13,6 @@ from argparse import ArgumentParser
 
 from ligo.lw import lsctables
 from ligo.lw import utils as ligolw_utils
-from ligo.lw import table
 
 import pycbc
 from pycbc.io.ligolw import LIGOLWContentHandler

--- a/bin/pycbc_source_probability_offline
+++ b/bin/pycbc_source_probability_offline
@@ -3,7 +3,6 @@
 Compute source probabilities using mchirp estimation method for all events
 in a chunk with an IFAR above certain threshold.
 """
-import h5py
 import json
 import tqdm
 import argparse

--- a/bin/pygrb/pycbc_grb_inj_finder
+++ b/bin/pygrb/pycbc_grb_inj_finder
@@ -25,7 +25,6 @@ import operator
 import os
 import re
 from collections import defaultdict
-from itertools import compress
 from functools import reduce
 
 import tqdm

--- a/bin/pygrb/pycbc_pygrb_minifollowups
+++ b/bin/pygrb/pycbc_pygrb_minifollowups
@@ -27,7 +27,6 @@ import os
 import argparse
 import logging
 
-from pycbc import init_logging
 import pycbc.workflow as wf
 from pycbc.workflow.core import FileList, resolve_url_to_file
 import pycbc.workflow.minifollowups as mini

--- a/bin/pygrb/pycbc_pygrb_plot_skygrid
+++ b/bin/pygrb/pycbc_pygrb_plot_skygrid
@@ -26,7 +26,6 @@ import sys
 import os
 import logging
 import numpy
-import h5py
 from matplotlib import pyplot as plt
 from matplotlib import rc
 import pycbc.version

--- a/bin/workflow_comparisons/offline_search/pycbc_combine_injection_comparisons
+++ b/bin/workflow_comparisons/offline_search/pycbc_combine_injection_comparisons
@@ -15,9 +15,6 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-import logging
-from glob import glob
-from os import path
 import argparse
 import numpy as np
 from h5py import File

--- a/bin/workflows/pycbc_make_bank_verifier_workflow
+++ b/bin/workflows/pycbc_make_bank_verifier_workflow
@@ -32,7 +32,7 @@ import igwn_segments as segments
 from pycbc import add_common_pycbc_options, init_logging
 import pycbc.version
 import pycbc.workflow as wf
-from pycbc.results import (static_table, layout)
+from pycbc.results import layout
 from pycbc.workflow.jobsetup import (select_generic_executable,
                                      int_gps_time_to_str,
                                      PycbcCreateInjectionsExecutable,

--- a/bin/workflows/pycbc_make_faithsim_workflow
+++ b/bin/workflows/pycbc_make_faithsim_workflow
@@ -6,7 +6,6 @@ and generate files containing the match between them and plots.
 """
 
 import pycbc.workflow as wf
-import logging
 import argparse
 
 from pycbc import add_common_pycbc_options, init_logging

--- a/bin/workflows/pycbc_make_faithsim_workflow
+++ b/bin/workflows/pycbc_make_faithsim_workflow
@@ -5,18 +5,12 @@ Program for running a faithfulness comparisons workflow analysis between two app
 and generate files containing the match between them and plots.
 """
 
-import os
-import pycbc
 import pycbc.workflow as wf
-import logging
-import configparser as ConfigParser
-import numpy as np
 import logging
 import argparse
 
 from pycbc import add_common_pycbc_options, init_logging
 from pycbc.workflow.plotting import PlotExecutable
-from pycbc.workflow import setup_splittable_dax_generated
 
 def make_faithsim_plot(workflow, analysis_time, input_file, out_dir, tags=None):
     tags = [] if tags is None else tags

--- a/bin/workflows/pycbc_make_inference_inj_workflow
+++ b/bin/workflows/pycbc_make_inference_inj_workflow
@@ -28,7 +28,6 @@ import sys
 
 from pycbc import results, init_logging, add_common_pycbc_options
 from pycbc.results import layout
-from pycbc.results import metadata
 from pycbc.workflow import configuration
 from pycbc.workflow import core
 from pycbc.workflow.jobsetup import (PycbcCreateInjectionsExecutable,

--- a/bin/workflows/pycbc_make_inference_plots_workflow
+++ b/bin/workflows/pycbc_make_inference_plots_workflow
@@ -20,25 +20,17 @@ inference samples files.
 """
 
 import argparse
-import h5py
 import logging
 import os
-import pycbc
-import pycbc.workflow.minifollowups as mini
 import socket
 import sys
 import shlex
 import numpy
 
-import igwn_segments as segments
-
 from pycbc import results, init_logging, add_common_pycbc_options
 from pycbc.results import layout
-from pycbc.types import MultiDetOptionAction
-from pycbc.types import MultiDetOptionAppendAction
 from pycbc.workflow import configuration
 from pycbc.workflow import core
-from pycbc.workflow import datafind
 from pycbc.workflow import plotting
 from pycbc.workflow import versioning
 import pycbc.workflow.inference_followups as inffu

--- a/bin/workflows/pycbc_make_inference_workflow
+++ b/bin/workflows/pycbc_make_inference_workflow
@@ -19,7 +19,6 @@
 """
 
 import argparse
-import h5py
 import logging
 import os
 import shlex
@@ -27,17 +26,11 @@ import socket
 import sys
 import numpy
 
-import igwn_segments as segments
-
 import pycbc
-import pycbc.workflow.minifollowups as mini
 from pycbc import results
 from pycbc.results import layout
-from pycbc.types import MultiDetOptionAction
-from pycbc.types import MultiDetOptionAppendAction
 from pycbc.workflow import configuration
 from pycbc.workflow import core
-from pycbc.workflow import datafind
 from pycbc.workflow import plotting
 from pycbc.workflow import versioning
 import pycbc.workflow.inference_followups as inffu

--- a/bin/workflows/pycbc_make_offline_search_workflow
+++ b/bin/workflows/pycbc_make_offline_search_workflow
@@ -28,8 +28,6 @@ import socket
 import os
 import argparse
 import logging
-import configparser as ConfigParser
-import numpy
 import datetime
 import itertools
 
@@ -38,8 +36,7 @@ import lal
 
 import pycbc.events
 import pycbc.workflow as wf
-from pycbc.results import static_table, layout, save_fig_with_metadata
-from pycbc.results.metadata import html_escape
+from pycbc.results import layout, save_fig_with_metadata
 
 
 def symlink_path(f, path):

--- a/bin/workflows/pycbc_make_sbank_workflow
+++ b/bin/workflows/pycbc_make_sbank_workflow
@@ -29,7 +29,6 @@ import argparse
 
 import pycbc
 import pycbc.workflow as wf
-import pycbc.workflow.pegasus_workflow as pwf
 
 # We define classes for all executables used in the workflow
 

--- a/docs/remove_non_standard_imports.py
+++ b/docs/remove_non_standard_imports.py
@@ -24,7 +24,6 @@ requested in sphinx, remove this code and use it if it gets added.
 We may need to write a patch for Sphinx to add this functionality.
 """
 
-import os,sys
 import glob
 
 

--- a/examples/cal/foton_filter_esd_saturation/pycbc_foton_filter
+++ b/examples/cal/foton_filter_esd_saturation/pycbc_foton_filter
@@ -18,15 +18,10 @@
 import argparse
 import logging
 import numpy
-import sys
-from foton import FilterFile, Filter
+from foton import FilterFile
 
-from pycbc import init_logging, add_common_pycbc_options
 from pycbc.filter.fotonfilter import filter_data, get_swstat_bits, read_gain_from_frames
 from pycbc.frame import frame_paths
-from pycbc.inject import InjectionSet, legacy_approximant_name
-from pycbc.types import TimeSeries
-from pycbc.waveform import get_td_waveform
 
 # list of IFOs
 ifo_list = ['H1', 'L1']
@@ -35,7 +30,7 @@ ifo_list = ['H1', 'L1']
 parser = argparse.ArgumentParser(usage='pycbc_foton_filter [--options]',
              description='Filter a single-column ASCII time series.')
 
-add_common_pycbc_options(parser)
+pycbc.add_common_pycbc_options(parser)
 
 # injection options
 parser.add_argument("--data-file", type=str, required=True,

--- a/examples/detector/custom.py
+++ b/examples/detector/custom.py
@@ -1,6 +1,5 @@
 import matplotlib.pyplot as plt
 from pycbc.detector import add_detector_on_earth, Detector
-import pycbc.psd
 import numpy as np
 
 # Set up potential Cosmic Explorer detector locations

--- a/examples/multi_inspiral/check_gw170817_trigs.py
+++ b/examples/multi_inspiral/check_gw170817_trigs.py
@@ -6,7 +6,6 @@
 import sys
 import logging
 import h5py
-import numpy as np
 from pycbc import init_logging
 
 init_logging(True)

--- a/pycbc/cosmology.py
+++ b/pycbc/cosmology.py
@@ -31,7 +31,7 @@ Any other distance measure is explicitly named; e.g., ``comoving_distance``.
 
 import logging
 import numpy
-from scipy import interpolate, integrate
+from scipy import interpolate
 import astropy.cosmology
 from astropy import units
 from astropy.cosmology.core import CosmologyError

--- a/pycbc/detector/ground.py
+++ b/pycbc/detector/ground.py
@@ -31,7 +31,7 @@ between ground-based observatories.
 import os
 import logging
 import numpy as np
-from numpy import cos, sin, pi
+from numpy import cos, sin
 
 import lal
 from astropy.time import Time

--- a/pycbc/events/threshold_cupy.py
+++ b/pycbc/events/threshold_cupy.py
@@ -26,7 +26,6 @@ import cupy as cp
 import functools
 import mako.template
 from .eventmgr import _BaseThresholdCluster
-import pycbc.scheme
 
 val = None
 loc = None

--- a/pycbc/fft/cupyfft.py
+++ b/pycbc/fft/cupyfft.py
@@ -26,7 +26,6 @@ This module provides the cupy backend of the fast Fourier transform
 for the PyCBC package.
 """
 
-import logging
 import cupy.fft
 from .core import _check_fft_args
 from .core import _BaseFFT, _BaseIFFT

--- a/pycbc/inference/sampler/dynesty.py
+++ b/pycbc/inference/sampler/dynesty.py
@@ -31,13 +31,11 @@ import time
 import numpy
 import dynesty, dynesty.dynesty, dynesty.nestedsamplers
 from pycbc.pool import choose_pool
-from dynesty import utils as dyfunc
 from pycbc.inference.io import (DynestyFile, validate_checkpoint_files,
                                 loadfile)
 from .base import (BaseSampler, setup_output)
 from .base_mcmc import get_optional_arg_from_config
 from .base_cube import setup_calls
-from .. import models
 
 
 #

--- a/pycbc/types/array_cupy.py
+++ b/pycbc/types/array_cupy.py
@@ -25,8 +25,6 @@
 """
 import cupy as cp
 from pycbc.types.array import common_kind, complex128, float64
-from scipy.linalg import blas
-from pycbc.types import real_same_precision_as
 
 def zeros(length, dtype=cp.float64):
     return cp.zeros(length, dtype=dtype)

--- a/pycbc/waveform/generator.py
+++ b/pycbc/waveform/generator.py
@@ -34,7 +34,6 @@ from .waveform import (FailedWaveformError)
 from . import ringdown
 from . import supernovae
 from . import waveform_modes
-from pycbc import transforms
 from pycbc.types import TimeSeries
 from pycbc.waveform import parameters
 from pycbc.waveform.utils import apply_fseries_time_shift, taper_timeseries, \

--- a/pycbc/workflow/grb_utils.py
+++ b/pycbc/workflow/grb_utils.py
@@ -28,7 +28,6 @@ generation of pygrb workflows. For details about pycbc.workflow see here:
 http://pycbc.org/pycbc/latest/html/workflow.html
 """
 
-import glob
 import os
 import logging
 import numpy as np

--- a/pycbc/workflow/injection.py
+++ b/pycbc/workflow/injection.py
@@ -31,11 +31,10 @@ https://ldas-jobs.ligo.caltech.edu/~cbc/docs/pycbc/NOTYETCREATED.html
 
 import logging
 import os.path
-import configparser as ConfigParser
 
 from pycbc.workflow.core import FileList, make_analysis_dir, Node
 from pycbc.workflow.core import Executable, resolve_url_to_file
-from pycbc.workflow.jobsetup import (LalappsInspinjExecutable,
+from pycbc.workflow.jobsetup import (
         PycbcCreateInjectionsExecutable, select_generic_executable)
 
 logger = logging.getLogger('pycbc.workflow.injection')

--- a/pycbc/workflow/jobsetup.py
+++ b/pycbc/workflow/jobsetup.py
@@ -30,7 +30,6 @@ https://ldas-jobs.ligo.caltech.edu/~cbc/docs/pycbc/ahope.html
 
 import math, os
 import igwn_segments as segments
-import lal
 from pycbc.workflow.core import Executable, File, FileList, Node
 
 def int_gps_time_to_str(t):

--- a/test/fft_base.py
+++ b/test/fft_base.py
@@ -69,10 +69,7 @@ from numpy.random import randn
 import pycbc.fft
 from pycbc.fft.backend_support import set_backend
 import unittest
-import sys
-from utils import parse_args_all_schemes, simple_exit
 from lal import LIGOTimeGPS as LTG
-import lal as _lal
 
 # Because we run many similar tests where we only vary dtypes, precisions,
 # or Array/TimeSeries/FrequencySeries, it is helpful to define the following

--- a/test/test_array.py
+++ b/test/test_array.py
@@ -26,14 +26,11 @@ These are the unittests for the pycbc array type
 '''
 
 
-import pycbc
 import unittest
-import itertools
 from pycbc.types import *
 from pycbc.scheme import *
 import numpy
 from utils import array_base, parse_args_all_schemes, simple_exit
-import sys
 import os
 import tempfile
 

--- a/test/test_autochisq.py
+++ b/test/test_autochisq.py
@@ -8,7 +8,6 @@ import numpy as np
 from math import cos, sin, pi, exp
 import unittest
 from utils import parse_args_all_schemes, simple_exit
-import time
 
 _scheme, _context = parse_args_all_schemes("Auto Chi-squared Veto")
 

--- a/test/test_coordinates_space.py
+++ b/test/test_coordinates_space.py
@@ -153,7 +153,7 @@ class TestParams(unittest.TestCase):
         """
         from pycbc.waveform import get_fd_det_waveform
 
-        from pycbc.detector import Detector, add_detector_on_earth,
+        from pycbc.detector import Detector, add_detector_on_earth
         from pycbc.waveform import get_td_waveform
         import importlib
 

--- a/test/test_coordinates_space.py
+++ b/test/test_coordinates_space.py
@@ -152,14 +152,9 @@ class TestParams(unittest.TestCase):
         used in the calculation.
         """
         from pycbc.waveform import get_fd_det_waveform
-        from pycbc.coordinates.space import (ssb_to_lisa, lisa_to_ssb,
-                                             ssb_to_geo, lisa_to_geo)
 
-        from pycbc.types.frequencyseries import FrequencySeries
-        from pycbc.detector import (Detector, load_detector_config,
-                                    add_detector_on_earth,
-                                    _ground_detectors)
-        from pycbc.waveform import get_td_waveform, get_fd_waveform
+        from pycbc.detector import Detector, add_detector_on_earth,
+        from pycbc.waveform import get_td_waveform
         import importlib
 
         def is_module_installed(module_name):
@@ -260,7 +255,7 @@ class TestParams(unittest.TestCase):
                     0, 2*numpy.pi, endpoint=False, num=nx):
                 params['tc'], params['eclipticlongitude'], \
                 params['eclipticlatitude'], params['polarization'] = \
-                    lisa_to_ssb(t_lisa, 0, numpy.pi/4,
+                    space.lisa_to_ssb(t_lisa, 0, numpy.pi/4,
                                 polarization_lisa, params['t_offset'])
 
                 nparams = {'mass1':params['mass1'], 'mass2':params['mass2'],
@@ -283,9 +278,12 @@ class TestParams(unittest.TestCase):
                                 'LISA_Z':lisa_Z_fd}
 
                 t_geo, ra, dec, polarization_geo = \
-                    ssb_to_geo(params['tc'], params['eclipticlongitude'], 
-                            params['eclipticlatitude'],
-                            params['polarization'])
+                    space.ssb_to_geo(
+                        params['tc'],
+                        params['eclipticlongitude'], 
+                        params['eclipticlatitude'],
+                        params['polarization']
+                    )
 
                 params_3g = params.copy()
                 params_3g['tc'] = t_geo

--- a/test/test_frequencyseries.py
+++ b/test/test_frequencyseries.py
@@ -25,13 +25,11 @@
 These are the unittests for the pycbc frequencyseries type
 '''
 
-import pycbc
 import unittest
 from pycbc.types import *
 from pycbc.scheme import *
 import numpy
 import lal
-import sys
 import os
 import tempfile
 from utils import array_base, parse_args_all_schemes, simple_exit

--- a/test/test_live_coinc_compare.py
+++ b/test/test_live_coinc_compare.py
@@ -3,13 +3,10 @@
 import unittest
 from types import SimpleNamespace
 import numpy as np
-# Some duplicate imports, but I want to copy code without changing it!
-import numpy, logging, pycbc.pnutils, pycbc.conversions, copy, lal
-import cProfile
+import logging
 from astropy.utils.data import download_file
 from pycbc import gps_now
 from pycbc.events.coinc import LiveCoincTimeslideBackgroundEstimator as Coincer
-import pycbc.events.coinc
 from utils import simple_exit
 import validation_code.old_coinc as old_coinc
 
@@ -145,7 +142,7 @@ class TestPyCBCLiveCoinc(unittest.TestCase):
                     if type(newout[key]) is np.ndarray:
                         self.assertTrue(len(newout[key]) == len(oldout[key]))
                         self.assertTrue(
-                            numpy.isclose(newout[key], oldout[key]).all()
+                            np.isclose(newout[key], oldout[key]).all()
                         )
                     else:
                         self.assertTrue(newout[key] == oldout[key])
@@ -161,7 +158,7 @@ class TestPyCBCLiveCoinc(unittest.TestCase):
         new_coincer = self.new_coincer
         old_coincer = self.old_coincer
         self.assertTrue(len(new_coincer.coincs.data) == len(old_coincer.coincs.data))
-        self.assertTrue(numpy.isclose(new_coincer.coincs.data, old_coincer.coincs.data, rtol=1e-06).all())
+        self.assertTrue(np.isclose(new_coincer.coincs.data, old_coincer.coincs.data, rtol=1e-06).all())
 
         for ifo in new_coincer.singles:
             lgc = True

--- a/test/test_schemes.py
+++ b/test/test_schemes.py
@@ -30,13 +30,10 @@ arithemtic operation, and one that should *not* move its data (regardless of sch
 We do not specifically test that the lalwrapped functions raise exceptions from the
 GPU, because that test is done in the test_lalwrap unit tests.
 '''
-import pycbc
 import unittest
 from pycbc.types import *
 from pycbc.scheme import *
-import numpy
-from numpy import dtype, float32, float64, complex64, complex128
-import lal
+from numpy import float32, float64, complex64, complex128
 from utils import parse_args_all_schemes, simple_exit
 
 _scheme, _context = parse_args_all_schemes("Scheme")

--- a/test/test_timeseries.py
+++ b/test/test_timeseries.py
@@ -25,14 +25,12 @@
 These are the unittests for the pycbc timeseries type
 '''
 
-import pycbc
 import unittest
 from pycbc.types import *
 from pycbc.scheme import *
 import numpy
 import lal
 from utils import array_base, parse_args_all_schemes, simple_exit
-import sys
 import os
 import tempfile
 


### PR DESCRIPTION
Remove unused imports from codes throughout the repository
This should save time during the running of the codes, as well as helping move towards a code-checked-before-merging model.

## Standard information about the request

This change _should_ have absolutely no effect, but changes are in every part of the code base

This change: follows style guidelines (See e.g. [PEP8](https://peps.python.org/pep-0008/)), has been proposed using the [contribution guidelines](https://github.com/gwastro/pycbc/blob/master/CONTRIBUTING.md)

## Motivation
Want to start improving quality and checking whether submitted code meets quality requirements

## Contents
Used flake8 to find unused imports, if there were any, then get rid of them
The files chosen were:
- anything under `bin` which started with `pycbc_`
- anything under `pycbc` which ends `.py`, but ignore any `__init__.py` or the special `version.py`
- anything under `test` which ends `.py` - ignore the scheme testing as that uses try/except-wrapped imports, which fail flake8

## Links to any issues or associated PRs
Issue raised in #4999 


- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
