### PR TITLE
Improve conservative percentile calculation in live combining single significance fits

### DIFF
--- a/bin/live/pycbc_live_combine_single_significance_fits
+++ b/bin/live/pycbc_live_combine_single_significance_fits
@@ -201,8 +201,8 @@ for ifo in args.ifos:
             invalphan,
             args.conservative_percentile
         )
-        cons_alpha = cons_count / cons_invalphan
-        cons_alphas_out[ifo][counter] = cons_alpha
+        # Conservative alpha estimate using percentile rather than mean
+        cons_alphas_out[ifo][counter] = cons_count / cons_invalphan 
         alphas_out[ifo][counter] = mean_alpha
 
         # To get the count values, we need to convert to rates and back again


### PR DESCRIPTION
We realised that in some cases, the simple percentile of fit coefficient can be less conservative than the maximum likelihood method - particularly for separated fits with a large fit coefficient and a small number of triggers.

This is as the maximum likelihood calculation takes number of triggers into account, but the percentile does not, leading to low-trigger-count fits taking up much more importance than they should.

I have updated the calculation of the conservative fit coefficient to use a calculation more similar to the maximum likelihood method.

The standard calculation is `mean(counts) / mean(counts / alpha)`

I have updated the 'conservative' fit to use `percentile(counts, 100 - p) / percentile(counts / alpha, p)`

Using `100 - p` for the numerator, but `p` for the denominator means a smaller fit coefficient, but I'm not sure if this skews the calculation too much.

As a result, I have included an alternative versiion using `p` for both as "ALT" in the results folder linked below (In fact, I _think_ I prefer this).

## Possible alternative methods
- since numpy v2, the percentile function allows for weights. Weighting by number of triggers, we become conservative again and are able to simply use the old calculation. This also allows the weighting to be a command line option if wanted.
- Include the errors from the fit coefficient calculation in the separated fit files, then combine the fits using `alpha + sigma_alpha` and `count + sqrt(count)` to give the conservative fit. This would remove the option of conservative percentile in the interface

See plots in https://ldas-jobs.ligo.caltech.edu/~gareth.cabourndavies/pycbclive/various_tests/single_significance_fits_weighted_percentile/

## Standard information about the request

This is a new feature
This change affects the live search
This change changes, scientific output
This change follows style guidelines (See e.g. [PEP8](https://peps.python.org/pep-0008/)), has been proposed using the [contribution guidelines](https://github.com/gwastro/pycbc/blob/master/CONTRIBUTING.md)

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
