### PR TITLE
Add multi-gpu support for cupy scheme

### DIFF
--- a/pycbc/scheme.py
+++ b/pycbc/scheme.py
@@ -154,7 +154,7 @@ class CUPYScheme(Scheme):
 
     def __exit__(self, *args):
         super().__exit__(*args)
-        self.cuda.device.__exit__(*args)
+        self.cuda_device.__exit__(*args)
 
 
 class CPUScheme(Scheme):

--- a/pycbc/scheme.py
+++ b/pycbc/scheme.py
@@ -151,6 +151,13 @@ class CUPYScheme(Scheme):
     def __enter__(self):
         super().__enter__()
         self.cuda_device.__enter__()
+        logger.warning(
+            "You are using the CUPY GPU backend for PyCBC. This backend is "
+            "still only a prototype. It may be useful for your application "
+            "but it may fail unexpectedly, run slowly, or not give correct "
+            "output. Please do contribute to the effort to develop this "
+            "further."
+        )
 
     def __exit__(self, *args):
         super().__exit__(*args)

--- a/pycbc/scheme.py
+++ b/pycbc/scheme.py
@@ -31,6 +31,7 @@ import pycbc
 from functools import wraps
 import logging
 from .libutils import get_ctypes_library
+from .pool import use_mpi
 
 logger = logging.getLogger('pycbc.scheme')
 
@@ -117,26 +118,43 @@ class CUDAScheme(Scheme):
 
 
 class CUPYScheme(Scheme):
-    """Scheme for using CUPY"""
+    """Scheme for using CUPY.
+
+    Supports using CUPY with MPI. If MPI is enabled, will use all available
+    devices. The environment variable `CUDA_VISIBLE_DEVICES` can be used to
+    restrict the devices used.
+
+    Parameters
+    ----------
+    device_num : int, optional
+        The device number to use. If not provided, will use the default, 0.
+        Should not be provided when using MPI to parallelize across devices.
+    """
     def __init__(self, device_num=None):
         import cupy # Fail now if cupy is not there.
         import cupy.cuda
+
+        do_mpi, _, rank = use_mpi(require_mpi=False, log=False)
+
+        if device_num is not None and do_mpi:
+            logger.warning("MPI is enabled, but a device number was provided.")
+
+        if device_num is None and do_mpi:
+            # Logical device numbers will always be 0, 1, 2, ... etc. irrespective
+            # of the physical device numbers.
+            device_num = rank % cupy.cuda.runtime.getDeviceCount()
+            logging.debug("MPI enabled, using CUDA device %s", device_num)
+
         self.device_num = device_num
         self.cuda_device = cupy.cuda.Device(self.device_num)
+
     def __enter__(self):
         super().__enter__()
         self.cuda_device.__enter__()
-        logging.warn(
-            "You are using the CUPY GPU backend for PyCBC. This backend is "
-            "still only a prototype. It may be useful for your application "
-            "but it may fail unexpectedly, run slowly, or not give correct "
-            "output. Please do contribute to the effort to develop this "
-            "further."
-        )
 
     def __exit__(self, *args):
         super().__exit__(*args)
-        self.cuda_device.__exit__(*args)
+        self.cuda.device.__exit__(*args)
 
 
 class CPUScheme(Scheme):

--- a/pycbc/scheme.py
+++ b/pycbc/scheme.py
@@ -143,7 +143,7 @@ class CUPYScheme(Scheme):
             # Logical device numbers will always be 0, 1, 2, ... etc. irrespective
             # of the physical device numbers.
             device_num = rank % cupy.cuda.runtime.getDeviceCount()
-            logging.debug("MPI enabled, using CUDA device %s", device_num)
+            logger.debug("MPI enabled, using CUDA device %s", device_num)
 
         self.device_num = device_num
         self.cuda_device = cupy.cuda.Device(self.device_num)


### PR DESCRIPTION
<!---
Please delete these comments when you submit the pull request

Please add a title which is a concise description of what you are doing,
e.g. 'Fix bug with numpy import in pycbc_coinc_findtrigs' or 'add high frequency sky location dependent response for long detectors'
-->

<!---
This is a brief template for making pull requests for PyCBC.
This is _not_ a proscriptive template - you can use a different style if you want.
Please do think about the questions posed here and whether the details will be useful to include in your PR
Please add sufficient details so that people looking back at the request with no context around the work can understand the changes.
To choose reviewers, please look at the git blame for the code you are changing (if applicable),
or discuss in the #pycbc-code channel of the gwastro slack.
Please add labels as appropriate
-->

<!-- TOP-LEVEL SUMMARY: Please provide a brief, one-or-two-sentence description of the PR here
-->

This PR adds support for using multiple GPUs via MPI with the cupy backend. It is a follow-on to https://github.com/gwastro/pycbc/pull/4952

## Standard information about the request

<!--- Some basic info about the change (delete as appropriate) -->
This is a: new feature

<!--- What codes will this affect? (delete as apropriate)
If you do not know which areas will be affected, please ask in the gwastro #pycbc-code slack
-->
This change affects: in theory, any code that uses cupy schemes but, since the cupy scheme is relatively new, I don't believe it is being used it production 

<!--- What code areas will this affect? (delete as apropriate) -->
This change changes: GPU support

<!--- Some things which help with code management (delete as appropriate) -->
This change: 
- does not have unit tests as I don't think we can test multi-GPU support in the CI.
- follows style guidelines (See e.g. [PEP8](https://peps.python.org/pep-0008/))
- has been proposed using the [contribution guidelines](https://github.com/gwastro/pycbc/blob/master/CONTRIBUTING.md)

<!--- Notes about the effect of this change -->
This change will: N/A

## Motivation
<!--- Describe why your changes are being made -->

The current cupy scheme is limited to a single GPU but using multiple GPUs when they are available can further accelerate analyses.

## Contents
<!--- Describe your changes, this doesn't need to be a line-by-line code change discussion,
but rather a general discussion of the methods chosen -->

I've added logic to check if MPI is being used and then set the device number accordingly based on the total number of devices visible to cupy

## Links to any issues or associated PRs
<!--- If this is fixing / working around an already-reported issue, please link to it here -->

Follow on from https://github.com/gwastro/pycbc/pull/4952

## Testing performed
<!--- Describe tests for the code changes, either already performed or to be performed -->

I've tested this for the pre-merger work that was used when testing https://github.com/gwastro/pycbc/pull/4952

## Additional notes
<!--- Anything which does not fit in the above sections -->

In the current version, if the user specifies a device number this takes priority over the MPI-based logic. We could consider swapping this so the value is ignored when using MPI.

I based this implementation on what is described in this blogpost: https://blog.hpc.qmul.ac.uk/strategies-multi-node-gpu/#mpi-process-for-each-gpu-pure-mpi-approach

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
