### PR TITLE
3 docstrings related to pycbc.types.angle_as_radians

### DIFF
--- a/bin/pycbc_make_sky_grid
+++ b/bin/pycbc_make_sky_grid
@@ -9,6 +9,9 @@ statistics.
 
 The grid is constructed following the method described in Section V of
 https://arxiv.org/abs/1410.6042.
+
+Please refer to help(pycbc.types.angle_as_radians) for the recommended
+configuration file syntax for angle arguments.
 """
 
 import numpy as np

--- a/bin/pygrb/pycbc_pygrb_grb_info_table
+++ b/bin/pygrb/pycbc_pygrb_grb_info_table
@@ -16,7 +16,11 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-"""Create GRB info table."""
+"""Create GRB info table.
+
+Please refer to help(pycbc.types.angle_as_radians) for the recommended
+configuration file syntax for angle arguments.
+"""
 
 # =============================================================================
 # Preamble

--- a/pycbc/types/optparse.py
+++ b/pycbc/types/optparse.py
@@ -545,10 +545,11 @@ def angle_as_radians(s):
     (e.g. 12deg, 1rad), "<value> <unit>" (e.g. 12 deg, 1 rad) or just
     "<value>", in which case the unit will be assumed to be radians.
 
-    When writing angles in configuration files, the format "<value> <unit>"
-    prevents errors with negative values when Pegasus generates the .sh
-    file for executables that rely on this function and require angles
-    in their command line.
+    When writing angles in configuration files as options to be passed to
+    executables that rely on this function and require angles in their command
+    line, the format "<value> <unit>", with the quotation marks included,
+    prevents errors with negative values due to how Pegasus renders options in
+    .sh files.
 
     To be used as type in argparse arguments.
     """

--- a/pycbc/types/optparse.py
+++ b/pycbc/types/optparse.py
@@ -545,11 +545,14 @@ def angle_as_radians(s):
     (e.g. 12deg, 1rad), "<value> <unit>" (e.g. 12 deg, 1 rad) or just
     "<value>", in which case the unit will be assumed to be radians.
 
-    When writing angles in configuration files as options to be passed to
-    executables that rely on this function and require angles in their command
-    line, the format "<value> <unit>", with the quotation marks included,
-    prevents errors with negative values due to how Pegasus renders options in
-    .sh files.
+    Note that the format "<value><unit>", with a negative value and no space,
+    is not parsed correctly by argparse; for more information, see
+    https://stackoverflow.com/questions/16174992/cant-get-argparse-to-read-quoted-string-with-dashes-in-it
+
+    Note: when writing angles in workflow configuration files as options to be
+    passed to executables that rely on this function and require angles in their
+    command line, the format "<value> <unit>", with the quotation marks
+    included, is required due to how Pegasus renders options in .sh files.
 
     To be used as type in argparse arguments.
     """

--- a/pycbc/types/optparse.py
+++ b/pycbc/types/optparse.py
@@ -545,6 +545,11 @@ def angle_as_radians(s):
     (e.g. 12deg, 1rad), "<value> <unit>" (e.g. 12 deg, 1 rad) or just
     "<value>", in which case the unit will be assumed to be radians.
 
+    When writing angles in configuration files, the format "<value> <unit>"
+    prevents errors with negative values when Pegasus generates the .sh
+    file for executables that rely on this function and require angles
+    in their command line.
+
     To be used as type in argparse arguments.
     """
     # if `s` converts to a float then there is no unit, so assume radians


### PR DESCRIPTION
This PR simply expands the docstrings of pycbc.types.angle_as_radians, pycbc_pygrb_grb_info_table, and pycbc_make_sky_grid.

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
