### PR TITLE
Move to igwn-ligolw

### DIFF
--- a/bin/all_sky_search/pycbc_coinc_hdfinjfind
+++ b/bin/all_sky_search/pycbc_coinc_hdfinjfind
@@ -4,7 +4,7 @@ files.
 """
 
 import argparse, logging, types, numpy, os.path
-from ligo.lw import lsctables, utils as ligolw_utils
+from igwn_ligolw import lsctables, utils as ligolw_utils
 import igwn_segments as segments
 import pycbc
 from pycbc import events, init_logging

--- a/bin/all_sky_search/pycbc_make_bayestar_skymap
+++ b/bin/all_sky_search/pycbc_make_bayestar_skymap
@@ -22,7 +22,7 @@ import os
 import glob
 import tempfile
 
-from ligo.lw import lsctables, utils as ligolw_utils
+from igwn_ligolw import lsctables, utils as ligolw_utils
 
 import pycbc
 from pycbc.waveform import bank as wavebank

--- a/bin/all_sky_search/pycbc_prepare_xml_for_gracedb
+++ b/bin/all_sky_search/pycbc_prepare_xml_for_gracedb
@@ -29,8 +29,8 @@ matplotlib.use('agg')
 
 import lal
 import lal.series
-from ligo.lw import lsctables
-from ligo.lw import utils as ligolw_utils
+from igwn_ligolw import lsctables
+from igwn_ligolw import utils as ligolw_utils
 from igwn_segments import segment, segmentlist
 
 import pycbc

--- a/bin/all_sky_search/pycbc_prepare_xml_for_gracedb
+++ b/bin/all_sky_search/pycbc_prepare_xml_for_gracedb
@@ -131,11 +131,11 @@ for event in coinc_table:
 else:
     raise ValueError(f"event {args.event_id} not found in coinc table")
 
-coinc_event_table_curr = lsctables.New(lsctables.CoincTable)
+coinc_event_table_curr = lsctables.CoincTable.new()
 coinc_event_table_curr.append(event)
-coinc_inspiral_table_curr = lsctables.New(lsctables.CoincInspiralTable)
-coinc_event_map_table_curr = lsctables.New(lsctables.CoincMapTable)
-sngl_inspiral_table_curr = lsctables.New(lsctables.SnglInspiralTable)
+coinc_inspiral_table_curr = lsctables.CoincInspiralTable.new()
+coinc_event_map_table_curr = lsctables.CoincMapTable.new()
+sngl_inspiral_table_curr = lsctables.SnglInspiralTable.new()
 
 for coinc_insp in coinc_inspiral_table:
     if coinc_insp.coinc_event_id == event.coinc_event_id:

--- a/bin/all_sky_search/pycbc_sngls_pastro
+++ b/bin/all_sky_search/pycbc_sngls_pastro
@@ -12,7 +12,7 @@ coincidences.
 
 import pycbc, pycbc.io, copy
 import argparse, logging, numpy as np
-from ligo.lw import lsctables, utils as ligolw_utils
+from igwn_ligolw import lsctables, utils as ligolw_utils
 from pycbc import conversions as conv
 from pycbc.events import veto
 from pycbc.io.ligolw import LIGOLWContentHandler

--- a/bin/all_sky_search/pycbc_strip_injections
+++ b/bin/all_sky_search/pycbc_strip_injections
@@ -2,7 +2,7 @@
 import numpy, argparse, pycbc.pnutils, logging
 from pycbc.events import veto
 from pycbc.io.ligolw import LIGOLWContentHandler
-from ligo.lw import ligolw, table, utils as ligolw_utils
+from igwn_ligolw import ligolw, table, utils as ligolw_utils
 
 
 effd = {"H1":"eff_dist_h", "L1":"eff_dist_l", "V1":"eff_dist_v"}

--- a/bin/all_sky_search/pycbc_strip_injections
+++ b/bin/all_sky_search/pycbc_strip_injections
@@ -2,7 +2,7 @@
 import numpy, argparse, pycbc.pnutils, logging
 from pycbc.events import veto
 from pycbc.io.ligolw import LIGOLWContentHandler
-from igwn_ligolw import ligolw, table, utils as ligolw_utils
+from igwn_ligolw import ligolw, utils as ligolw_utils
 
 
 effd = {"H1":"eff_dist_h", "L1":"eff_dist_l", "V1":"eff_dist_v"}
@@ -26,7 +26,7 @@ pycbc.init_logging(args.verbose)
 
 logging.info('File: %s' % args.injection_file)
 indoc = ligolw_utils.load_filename(args.injection_file, False, contenthandler=LIGOLWContentHandler)
-sim_table = table.Table.get_table(indoc, 'sim_inspiral')
+sim_table = ligolw.Table.get_table(indoc, 'sim_inspiral')
 
 logging.info('%s Injections in file' % len(sim_table))
 

--- a/bin/bank/pycbc_aligned_bank_cat
+++ b/bin/bank/pycbc_aligned_bank_cat
@@ -25,7 +25,7 @@ import logging
 import glob
 import argparse
 import numpy
-from ligo.lw import utils
+from igwn_ligolw import utils
 from pycbc import tmpltbank
 # Old ligolw output functions no longer imported at package level
 import pycbc.tmpltbank.bank_output_utils as bank_output

--- a/bin/bank/pycbc_bank_verification
+++ b/bin/bank/pycbc_bank_verification
@@ -29,7 +29,7 @@ import matplotlib
 matplotlib.use('Agg')
 import pylab
 
-from ligo.lw import lsctables, utils as ligolw_utils
+from igwn_ligolw import lsctables, utils as ligolw_utils
 
 import pycbc
 import pycbc.version

--- a/bin/bank/pycbc_geom_aligned_bank
+++ b/bin/bank/pycbc_geom_aligned_bank
@@ -31,8 +31,8 @@ import logging
 import configparser
 from scipy import spatial
 
-from ligo.lw import ligolw
-from ligo.lw import utils as ligolw_utils
+from igwn_ligolw import ligolw
+from igwn_ligolw import utils as ligolw_utils
 
 import pycbc
 import pycbc.psd

--- a/bin/bank/pycbc_tmpltbank_to_chi_params
+++ b/bin/bank/pycbc_tmpltbank_to_chi_params
@@ -33,7 +33,7 @@ import argparse
 import logging
 import numpy
 
-from ligo.lw import lsctables, utils as ligolw_utils
+from igwn_ligolw import lsctables, utils as ligolw_utils
 
 from pycbc import tmpltbank, psd, strain
 from pycbc.io.ligolw import LIGOLWContentHandler

--- a/bin/hwinj/pycbc_generate_hwinj
+++ b/bin/hwinj/pycbc_generate_hwinj
@@ -22,10 +22,10 @@ import numpy
 import os
 import sys
 
-from ligo.lw import ligolw
-from ligo.lw import lsctables
-from ligo.lw import table
-from ligo.lw import utils
+from igwn_ligolw import ligolw
+from igwn_ligolw import lsctables
+from igwn_ligolw import table
+from igwn_ligolw import utils
 
 import pycbc
 import pycbc.version

--- a/bin/hwinj/pycbc_generate_hwinj
+++ b/bin/hwinj/pycbc_generate_hwinj
@@ -24,7 +24,6 @@ import sys
 
 from igwn_ligolw import ligolw
 from igwn_ligolw import lsctables
-from igwn_ligolw import table
 from igwn_ligolw import utils
 
 import pycbc
@@ -296,7 +295,7 @@ if opts.dquad_mon2 is not None:
 # You'd think that would it to redefine the table columns, but wait, it gets
 # worse!
 class SimInspiralNew(lsctables.SimInspiral):
-    __slots__ = tuple(map(table.Column.ColumnName,
+    __slots__ = tuple(map(ligolw.Column.ColumnName,
                           lsctables.SimInspiralTable.validcolumns))
 lsctables.SimInspiral = SimInspiralNew
 lsctables.SimInspiralTable.RowType = SimInspiralNew

--- a/bin/hwinj/pycbc_generate_hwinj
+++ b/bin/hwinj/pycbc_generate_hwinj
@@ -301,8 +301,9 @@ lsctables.SimInspiral = SimInspiralNew
 lsctables.SimInspiralTable.RowType = SimInspiralNew
 
 # create sim_inspiral table
-sim_table = lsctables.New(lsctables.SimInspiralTable,
-                          columns=lsctables.SimInspiralTable.validcolumns)
+sim_table = lsctables.SimInspiralTable.new(
+    columns=lsctables.SimInspiralTable.validcolumns
+)
 outdoc.childNodes[0].appendChild(sim_table)
 
 sim = _empty_row(lsctables.SimInspiral)
@@ -343,8 +344,9 @@ sim.waveform = waveform_string
 name, phase_order = legacy_approximant_name(sim.waveform)
 
 # create sngl_inspiral table
-sngl_table = lsctables.New(lsctables.SnglInspiralTable,
-                           columns=lsctables.SnglInspiralTable.validcolumns)
+sngl_table = lsctables.SnglInspiralTable.new(
+    columns=lsctables.SnglInspiralTable.validcolumns
+)
 outdoc.childNodes[0].appendChild(sngl_table)
 
 # create sngl_inspiral row for injection

--- a/bin/minifollowups/pycbc_sngl_minifollowup
+++ b/bin/minifollowups/pycbc_sngl_minifollowup
@@ -22,8 +22,8 @@ import argparse
 import logging
 import numpy
 
-from ligo.lw import table
-from ligo.lw import utils as ligolw_utils
+from igwn_ligolw import table
+from igwn_ligolw import utils as ligolw_utils
 
 from pycbc import init_logging, add_common_pycbc_options
 from pycbc.results import layout

--- a/bin/minifollowups/pycbc_sngl_minifollowup
+++ b/bin/minifollowups/pycbc_sngl_minifollowup
@@ -22,7 +22,7 @@ import argparse
 import logging
 import numpy
 
-from igwn_ligolw import table
+from igwn_ligolw import ligolw
 from igwn_ligolw import utils as ligolw_utils
 
 from pycbc import init_logging, add_common_pycbc_options
@@ -209,7 +209,7 @@ if args.non_coinc_time_only:
 
     segs_doc = ligolw_utils.load_filename(args.inspiral_segments,
                                           contenthandler=h)
-    seg_def_table = table.Table.get_table(segs_doc, 'segment_definer')
+    seg_def_table = ligolw.Table.get_table(segs_doc, 'segment_definer')
     def_ifos = seg_def_table.getColumnByName('ifos')
     def_ifos = [str(ifo) for ifo in def_ifos]
     ifo_list = list(set(def_ifos))

--- a/bin/plotting/pycbc_page_segments
+++ b/bin/plotting/pycbc_page_segments
@@ -40,7 +40,7 @@ def timestr(s):
     return t
 
 def get_name(segment_file):
-    from ligo.lw import table, utils as ligolw_utils
+    from igwn_ligolw import table, utils as ligolw_utils
     from pycbc.io.ligolw import LIGOLWContentHandler
 
     indoc = ligolw_utils.load_filename(

--- a/bin/plotting/pycbc_page_segments
+++ b/bin/plotting/pycbc_page_segments
@@ -40,12 +40,12 @@ def timestr(s):
     return t
 
 def get_name(segment_file):
-    from igwn_ligolw import table, utils as ligolw_utils
+    from igwn_ligolw import ligolw, utils as ligolw_utils
     from pycbc.io.ligolw import LIGOLWContentHandler
 
     indoc = ligolw_utils.load_filename(
             segment_file, False, contenthandler=LIGOLWContentHandler)
-    n = table.Table.get_table(indoc, 'segment_definer')[0]
+    n = ligolw.Table.get_table(indoc, 'segment_definer')[0]
     return "%s:%s:%s" % (n.ifos, n.name, n.version)
 
 def plot_segs(start, end, color=None, y=0, h=1):

--- a/bin/plotting/pycbc_page_vetotable
+++ b/bin/plotting/pycbc_page_vetotable
@@ -23,8 +23,8 @@ import logging
 import numpy
 import sys
 
-from ligo.lw import lsctables
-from ligo.lw import utils
+from igwn_ligolw import lsctables
+from igwn_ligolw import utils
 
 import pycbc.results
 from pycbc.results import save_fig_with_metadata

--- a/bin/plotting/pycbc_plot_Nth_loudest_coinc_omicron.py
+++ b/bin/plotting/pycbc_plot_Nth_loudest_coinc_omicron.py
@@ -12,7 +12,7 @@ import matplotlib
 matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 
-from ligo.lw import lsctables, utils
+from igwn_ligolw import lsctables, utils
 
 import pycbc.events
 from pycbc.waveform import (

--- a/bin/pycbc_banksim
+++ b/bin/pycbc_banksim
@@ -23,8 +23,8 @@ from numpy import complex64, array
 from argparse import ArgumentParser
 from math import ceil, log
 
-from ligo.lw import utils as ligolw_utils
-from ligo.lw import lsctables
+from igwn_ligolw import utils as ligolw_utils
+from igwn_ligolw import lsctables
 
 from pycbc.pnutils import mass1_mass2_to_mchirp_eta
 from pycbc.pnutils import mass1_mass2_to_tau0_tau3

--- a/bin/pycbc_banksim_match_combine
+++ b/bin/pycbc_banksim_match_combine
@@ -25,7 +25,7 @@ bank files, and the number of injections in each must correspond one-to-one.
 import argparse
 import numpy as np
 
-from ligo.lw import utils, table
+from igwn_ligolw import utils, table
 
 import pycbc
 from pycbc import pnutils

--- a/bin/pycbc_banksim_match_combine
+++ b/bin/pycbc_banksim_match_combine
@@ -25,7 +25,7 @@ bank files, and the number of injections in each must correspond one-to-one.
 import argparse
 import numpy as np
 
-from igwn_ligolw import utils, table
+from igwn_ligolw import utils, ligolw
 
 import pycbc
 from pycbc import pnutils
@@ -111,7 +111,7 @@ for idx, row in enumerate(res):
     if row['sim'] not in itables:
         indoc = utils.load_filename(row['sim'], False,
                                     contenthandler=LIGOLWContentHandler)
-        itables[row['sim']] = table.Table.get_table(indoc, "sim_inspiral") 
+        itables[row['sim']] = ligolw.Table.get_table(indoc, "sim_inspiral") 
     
     bt = btables[row['bank']][row['bank_i']]     
     it = itables[row['sim']][row['sim_i']]

--- a/bin/pycbc_banksim_skymax
+++ b/bin/pycbc_banksim_skymax
@@ -23,8 +23,8 @@ from argparse import ArgumentParser
 from math import ceil, log
 from tqdm import tqdm
 
-from ligo.lw import utils as ligolw_utils
-from ligo.lw import lsctables
+from igwn_ligolw import utils as ligolw_utils
+from igwn_ligolw import lsctables
 
 from pycbc.pnutils import mass1_mass2_to_mchirp_eta
 from pycbc.pnutils import nearest_larger_binary_number

--- a/bin/pycbc_convertinjfiletohdf
+++ b/bin/pycbc_convertinjfiletohdf
@@ -30,7 +30,7 @@ from pycbc.io.record import FieldArray
 from pycbc.io.hdf import HFile
 
 from pycbc.io.ligolw import LIGOLWContentHandler
-from ligo.lw import utils as ligolw_utils, lsctables
+from igwn_ligolw import utils as ligolw_utils, lsctables
 
 
 # Handlers for alternative injection formats

--- a/bin/pycbc_faithsim
+++ b/bin/pycbc_faithsim
@@ -28,8 +28,8 @@ from numpy import complex64
 import argparse
 import sys
 
-from ligo.lw import utils as ligolw_utils
-from ligo.lw import lsctables
+from igwn_ligolw import utils as ligolw_utils
+from igwn_ligolw import lsctables
 
 import pycbc.strain
 import pycbc.psd

--- a/bin/pycbc_faithsim_collect_results
+++ b/bin/pycbc_faithsim_collect_results
@@ -8,7 +8,7 @@ computing the match between them and creating a .dat file with the results.
 import argparse
 import numpy as np
 
-from ligo.lw import utils, lsctables
+from igwn_ligolw import utils, lsctables
 
 from pycbc import add_common_pycbc_options, init_logging
 from pycbc.io.ligolw import LIGOLWContentHandler

--- a/bin/pycbc_get_ffinal
+++ b/bin/pycbc_get_ffinal
@@ -14,9 +14,9 @@ import argparse
 import pycbc
 from pycbc import waveform
 
-from ligo.lw import utils as ligolw_utils
-from ligo.lw import table
-from ligo.lw.utils import process
+from igwn_ligolw import utils as ligolw_utils
+from igwn_ligolw import table
+from igwn_ligolw.utils import process
 
 appx_options = waveform.td_approximants() + waveform.fd_approximants()
 

--- a/bin/pycbc_get_ffinal
+++ b/bin/pycbc_get_ffinal
@@ -16,7 +16,7 @@ from pycbc import waveform
 
 from igwn_ligolw import utils as ligolw_utils
 from igwn_ligolw import ligolw
-from igwn_ligolw.utils import process
+
 
 appx_options = waveform.td_approximants() + waveform.fd_approximants()
 
@@ -127,7 +127,7 @@ if infile is not None:
         compress='auto',
         verbose=opts.verbose
     )
-    this_process = process.register_to_xmldoc(xmldoc, __prog__, opts.__dict__)
+    this_process = xmldoc.register_process(__prog__, opts.__dict__)
     sngl_insp_table = ligolw.Table.get_table(xmldoc, 'sngl_inspiral')
 else:
     # FIXME: try to get this from the waveform_opts group

--- a/bin/pycbc_get_ffinal
+++ b/bin/pycbc_get_ffinal
@@ -15,7 +15,7 @@ import pycbc
 from pycbc import waveform
 
 from igwn_ligolw import utils as ligolw_utils
-from igwn_ligolw import table
+from igwn_ligolw import ligolw
 from igwn_ligolw.utils import process
 
 appx_options = waveform.td_approximants() + waveform.fd_approximants()
@@ -128,7 +128,7 @@ if infile is not None:
         verbose=opts.verbose
     )
     this_process = process.register_to_xmldoc(xmldoc, __prog__, opts.__dict__)
-    sngl_insp_table = table.Table.get_table(xmldoc, 'sngl_inspiral')
+    sngl_insp_table = ligolw.Table.get_table(xmldoc, 'sngl_inspiral')
 else:
     # FIXME: try to get this from the waveform_opts group
     tmplt_args = ['mass1', 'mass2', 'spin1x', 'spin1y', 'spin1z', 'spin2x',

--- a/bin/pycbc_inj_cut
+++ b/bin/pycbc_inj_cut
@@ -30,8 +30,8 @@ import argparse
 import logging
 import numpy
 
-from ligo.lw import utils as ligolw_utils
-from ligo.lw import lsctables
+from igwn_ligolw import utils as ligolw_utils
+from igwn_ligolw import lsctables
 
 import pycbc
 import pycbc.inject

--- a/bin/pycbc_inj_cut
+++ b/bin/pycbc_inj_cut
@@ -66,12 +66,14 @@ output_inject = opts.output_inject
 if opts.write_compress:
     if not output_inject.endswith('gz'):
         output_inject = output_inject+'.gz'
-out_sim_inspiral_inject = lsctables.New(lsctables.SimInspiralTable,
-                                 columns=injections.table.columnnames)
+out_sim_inspiral_inject = lsctables.SimInspiralTable.new(
+    columns=injections.table.columnnames
+)
 
 # missed injections table 
-out_sim_inspiral_missed = lsctables.New(lsctables.SimInspiralTable,
-                                 columns=injections.table.columnnames)
+out_sim_inspiral_missed = lsctables.SimInspiralTable.new(
+    columns=injections.table.columnnames
+)
 if opts.write_compress:
     if not output_missed.endswith('gz'):
         output_missed = output_missed+'.gz'

--- a/bin/pycbc_make_banksim
+++ b/bin/pycbc_make_banksim
@@ -95,7 +95,7 @@ def mkdir(dir_name):
 
 def mc_min_max_from_sorted_file(fname):
     from igwn_ligolw.utils import load_filename
-    from igwn_ligolw.table import Table
+    from igwn_ligolw.ligolw import Table
     from pycbc.pnutils import mass1_mass2_to_mchirp_eta
     from pycbc.io.ligolw import LIGOLWContentHandler
 
@@ -303,7 +303,8 @@ f = open("scripts/pycbc_banksim_collect_results", "w")
 f.write("""#!/usr/bin/env python
 from os.path import isfile
 import numpy as np
-from igwn_ligolw import utils, table
+from igwn_ligolw import utils
+from igwn_ligolw.ligolw import Table
 import glob
 
 from pycbc.io.ligolw import LIGOLWContentHandler
@@ -329,12 +330,12 @@ for row in res:
     if row['bank'] not in btables:
         indoc = utils.load_filename(eval(row['bank']).decode('utf-8'), False,
                                     contenthandler=LIGOLWContentHandler)
-        btables[row['bank']] = table.Table.get_table(indoc, "sngl_inspiral")
+        btables[row['bank']] = Table.get_table(indoc, "sngl_inspiral")
 
     if row['sim'] not in itables:
         indoc = utils.load_filename(eval(row['sim']).decode('utf-8'), False,
                                     contenthandler=LIGOLWContentHandler)
-        itables[row['sim']] = table.Table.get_table(indoc, "sim_inspiral")
+        itables[row['sim']] = Table.get_table(indoc, "sim_inspiral")
     
     bt = btables[row['bank']][row['bank_i']]     
     it = itables[row['sim']][row['sim_i']]

--- a/bin/pycbc_make_banksim
+++ b/bin/pycbc_make_banksim
@@ -94,8 +94,8 @@ def mkdir(dir_name):
         pass
 
 def mc_min_max_from_sorted_file(fname):
-    from ligo.lw.utils import load_filename
-    from ligo.lw.table import Table
+    from igwn_ligolw.utils import load_filename
+    from igwn_ligolw.table import Table
     from pycbc.pnutils import mass1_mass2_to_mchirp_eta
     from pycbc.io.ligolw import LIGOLWContentHandler
 
@@ -303,7 +303,7 @@ f = open("scripts/pycbc_banksim_collect_results", "w")
 f.write("""#!/usr/bin/env python
 from os.path import isfile
 import numpy as np
-from ligo.lw import utils, table
+from igwn_ligolw import utils, table
 import glob
 
 from pycbc.io.ligolw import LIGOLWContentHandler

--- a/bin/pycbc_make_faithsim
+++ b/bin/pycbc_make_faithsim
@@ -147,7 +147,7 @@ dag.add_node(pnode)
 f = open("scripts/pycbc_faithsim_collect_results", "w")
 f.write("""#!/usr/bin/env python
 import numpy as np
-from igwn_ligolw import utils, table, lsctables
+from igwn_ligolw import utils, lsctables
 import glob
 from pycbc.io.ligolw import LIGOLWContentHandler
 
@@ -218,8 +218,7 @@ matplotlib.use('Agg')
 import matplotlib.cm
 import pylab
 import numpy as np
-from igwn_ligolw import utils, table, lsctables
-from matplotlib.ticker import MultipleLocator, FormatStrFormatter
+from matplotlib.ticker import MultipleLocator
 import glob
 
 from pycbc import pnutils

--- a/bin/pycbc_make_faithsim
+++ b/bin/pycbc_make_faithsim
@@ -147,7 +147,7 @@ dag.add_node(pnode)
 f = open("scripts/pycbc_faithsim_collect_results", "w")
 f.write("""#!/usr/bin/env python
 import numpy as np
-from ligo.lw import utils, table, lsctables
+from igwn_ligolw import utils, table, lsctables
 import glob
 from pycbc.io.ligolw import LIGOLWContentHandler
 
@@ -218,7 +218,7 @@ matplotlib.use('Agg')
 import matplotlib.cm
 import pylab
 import numpy as np
-from ligo.lw import utils, table, lsctables
+from igwn_ligolw import utils, table, lsctables
 from matplotlib.ticker import MultipleLocator, FormatStrFormatter
 import glob
 

--- a/bin/pycbc_optimal_snr
+++ b/bin/pycbc_optimal_snr
@@ -27,8 +27,8 @@ import argparse
 import multiprocessing
 import numpy as np
 
-from ligo.lw import utils as ligolw_utils
-from ligo.lw import lsctables
+from igwn_ligolw import utils as ligolw_utils
+from igwn_ligolw import lsctables
 
 import pycbc
 import pycbc.inject

--- a/bin/pycbc_optimal_snr
+++ b/bin/pycbc_optimal_snr
@@ -298,8 +298,7 @@ if __name__ == '__main__':
     inj_table = sorted(inj_table, key=sort_func)
 
     if ligolw:
-        new_inj_table = lsctables.New(
-            lsctables.SimInspiralTable,
+        new_inj_table = lsctables.SimInspiralTable.new(
             columns=get_table_columns(injections.table)
         )
     else:

--- a/bin/pycbc_randomize_inj_dist_by_optsnr
+++ b/bin/pycbc_randomize_inj_dist_by_optsnr
@@ -11,8 +11,8 @@ import time
 from scipy import stats, special
 from argparse import ArgumentParser
 
-from ligo.lw import lsctables
-from ligo.lw import utils as ligolw_utils
+from igwn_ligolw import lsctables
+from igwn_ligolw import utils as ligolw_utils
 
 import pycbc
 from pycbc.io.ligolw import LIGOLWContentHandler

--- a/bin/pycbc_split_inspinj
+++ b/bin/pycbc_split_inspinj
@@ -2,8 +2,8 @@
 
 # Copyright (C) 2014 Andrew Lundgren
 import argparse
-from ligo.lw import utils as ligolw_utils
-from ligo.lw import lsctables
+from igwn_ligolw import utils as ligolw_utils
+from igwn_ligolw import lsctables
 from itertools import cycle
 
 import pycbc

--- a/bin/pycbc_split_inspinj
+++ b/bin/pycbc_split_inspinj
@@ -44,7 +44,7 @@ xmlroot.removeChild(allinjs)
 num_splits = args.num_splits or len(args.output_files)
 
 new_inj_tables = [
-    lsctables.New(tabletype, columns=get_table_columns(allinjs))
+    tabletype.new(columns=get_table_columns(allinjs))
     for _ in range(num_splits)
 ]
 

--- a/bin/pycbc_splitbank
+++ b/bin/pycbc_splitbank
@@ -30,9 +30,9 @@
 import argparse
 from numpy import random, ceil
 
-from ligo.lw import ligolw
-from ligo.lw import lsctables
-from ligo.lw import utils as ligolw_utils
+from igwn_ligolw import ligolw
+from igwn_ligolw import lsctables
+from igwn_ligolw import utils as ligolw_utils
 
 import pycbc
 from pycbc.io.ligolw import LIGOLWContentHandler, create_process_table

--- a/bin/pycbc_splitbank
+++ b/bin/pycbc_splitbank
@@ -35,7 +35,9 @@ from igwn_ligolw import lsctables
 from igwn_ligolw import utils as ligolw_utils
 
 import pycbc
-from pycbc.io.ligolw import LIGOLWContentHandler, create_process_table
+from pycbc.io.ligolw import (
+    LIGOLWContentHandler, create_process_table, get_table_columns
+)
 from pycbc.conversions import mchirp_from_mass1_mass2
 from pycbc.pnutils import frequency_cutoff_from_name
 
@@ -96,15 +98,7 @@ except:
     template_bank_table = lsctables.SimInspiralTable.get_table(indoc)
     tabletype = lsctables.SimInspiralTable
 
-# make a list of columns that are present in the input table.
-# The : split is needed for columns like `process:process_id`,
-# which must be listed as `process:process_id` in `lsctables.New()`,
-# but are listed as just `process_id` in the `columnnames` attribute
-used_columns = []
-for col in template_bank_table.validcolumns:
-    att = col.split(':')[-1]
-    if att in template_bank_table.columnnames:
-        used_columns.append(col)
+used_columns = get_table_columns(template_bank_table)
 
 length = len(template_bank_table)
 
@@ -151,7 +145,7 @@ for num, (idx1, idx2) in enumerate(zip(index_list[:-1], index_list[1:])):
         options=args.__dict__
     )
 
-    sngl_inspiral_table = lsctables.New(tabletype, columns=used_columns)
+    sngl_inspiral_table = tabletype.new(columns=used_columns)
     outdoc.childNodes[0].appendChild(sngl_inspiral_table)
 
     for i in range(idx2-idx1):

--- a/bin/pycbc_upload_xml_to_gracedb
+++ b/bin/pycbc_upload_xml_to_gracedb
@@ -30,8 +30,8 @@ matplotlib.use('agg')
 from ligo.gracedb.rest import GraceDb
 import lal
 import lal.series
-from ligo.lw import lsctables
-from ligo.lw import utils as ligolw_utils
+from igwn_ligolw import lsctables
+from igwn_ligolw import utils as ligolw_utils
 from igwn_segments import segment, segmentlist
 
 import pycbc

--- a/bin/pycbc_upload_xml_to_gracedb
+++ b/bin/pycbc_upload_xml_to_gracedb
@@ -144,11 +144,11 @@ xmldoc.childNodes[-1].removeChild(coinc_inspiral_table)
 xmldoc.childNodes[-1].removeChild(coinc_table)
 
 for event in coinc_table:
-    coinc_event_table_curr = lsctables.New(lsctables.CoincTable)
+    coinc_event_table_curr = lsctables.CoincTable.new()
     coinc_event_table_curr.append(event)
-    coinc_inspiral_table_curr = lsctables.New(lsctables.CoincInspiralTable)
-    coinc_event_map_table_curr = lsctables.New(lsctables.CoincMapTable)
-    sngl_inspiral_table_curr = lsctables.New(lsctables.SnglInspiralTable)
+    coinc_inspiral_table_curr = lsctables.CoincInspiralTable.new()
+    coinc_event_map_table_curr = lsctables.CoincMapTable.new()
+    sngl_inspiral_table_curr = lsctables.SnglInspiralTable.new()
 
     coinc_event_id = event.coinc_event_id
     for coinc_insp in coinc_inspiral_table:

--- a/examples/live/check_results.py
+++ b/examples/live/check_results.py
@@ -8,8 +8,8 @@ import numpy as np
 import pycbc
 from pycbc.io import FieldArray, HFile
 from pycbc.io.ligolw import LIGOLWContentHandler
-from ligo.lw.utils import load_filename as load_xml_doc
-from ligo.lw import lsctables
+from igwn_ligolw.utils import load_filename as load_xml_doc
+from igwn_ligolw import lsctables
 from pycbc import conversions as conv
 from ligo.skymap.io import LigoLWEventSource
 

--- a/examples/workflow/dayhopecheck/dayhopecheck.py
+++ b/examples/workflow/dayhopecheck/dayhopecheck.py
@@ -49,9 +49,9 @@ import argparse
 import igwn_segments as segments
 import pycbc.workflow as _workflow
 
-from ligo.lw import ligolw
-from ligo.lw import utils as ligolw_utils
-from ligo.lw.utils import process as ligolw_process
+from igwn_ligolw import ligolw
+from igwn_ligolw import utils as ligolw_utils
+from igwn_ligolw.utils import process as ligolw_process
 
 from glue.segmentdb import segmentdb_utils
 

--- a/examples/workflow/dayhopecheck/dayhopecheck.py
+++ b/examples/workflow/dayhopecheck/dayhopecheck.py
@@ -51,7 +51,6 @@ import pycbc.workflow as _workflow
 
 from igwn_ligolw import ligolw
 from igwn_ligolw import utils as ligolw_utils
-from igwn_ligolw.utils import process as ligolw_process
 
 from glue.segmentdb import segmentdb_utils
 
@@ -118,8 +117,7 @@ insps = _workflow.setup_matchedfltr_workflow(workflow, scienceSegs, datafinds,
 outdoc = ligolw.Document()
 outdoc.appendChild(ligolw.LIGO_LW())
 # FIXME: PROGRAM NAME and dictionary of opts should be variables defined up above
-proc_id = ligolw_process.register_to_xmldoc(outdoc, 'dayhopetest',
-                                            vars(args) ).process_id
+proc_id = outdoc.register_process('dayhopetest', vars(args)).process_id
 for ifo in workflow.ifos:
     # Lets get the segment lists we need
     segIfoFiles = segsList.find_output_with_ifo(ifo)

--- a/pycbc/dq.py
+++ b/pycbc/dq.py
@@ -52,7 +52,7 @@ def parse_veto_definer(veto_def_filename, ifos):
         Returns a dictionary first indexed by ifo, then category level, and
         finally a list of veto definitions.
     """
-    from ligo.lw import table, utils as ligolw_utils
+    from igwn_ligolw import table, utils as ligolw_utils
     from pycbc.io.ligolw import LIGOLWContentHandler as h
 
     data = {}

--- a/pycbc/dq.py
+++ b/pycbc/dq.py
@@ -52,7 +52,7 @@ def parse_veto_definer(veto_def_filename, ifos):
         Returns a dictionary first indexed by ifo, then category level, and
         finally a list of veto definitions.
     """
-    from igwn_ligolw import table, utils as ligolw_utils
+    from igwn_ligolw import ligolw, utils as ligolw_utils
     from pycbc.io.ligolw import LIGOLWContentHandler as h
 
     data = {}
@@ -64,7 +64,7 @@ def parse_veto_definer(veto_def_filename, ifos):
 
     indoc = ligolw_utils.load_filename(veto_def_filename, False,
                                        contenthandler=h)
-    veto_table = table.Table.get_table(indoc, 'veto_definer')
+    veto_table = ligolw.Table.get_table(indoc, 'veto_definer')
 
     ifo = veto_table.getColumnByName('ifo')
     name = veto_table.getColumnByName('name')

--- a/pycbc/events/veto.py
+++ b/pycbc/events/veto.py
@@ -4,7 +4,7 @@ segment.
 import logging
 import numpy
 from igwn_segments import segment, segmentlist
-from ligo.lw import table, lsctables, utils as ligolw_utils
+from igwn_ligolw import table, lsctables, utils as ligolw_utils
 
 logger = logging.getLogger('pycbc.events.veto')
 

--- a/pycbc/events/veto.py
+++ b/pycbc/events/veto.py
@@ -4,7 +4,7 @@ segment.
 import logging
 import numpy
 from igwn_segments import segment, segmentlist
-from igwn_ligolw import table, lsctables, utils as ligolw_utils
+from igwn_ligolw import ligolw, lsctables, utils as ligolw_utils
 
 logger = logging.getLogger('pycbc.events.veto')
 
@@ -112,9 +112,9 @@ def select_segments_by_definer(segment_file, segment_name=None, ifo=None):
     from pycbc.io.ligolw import LIGOLWContentHandler as h
 
     indoc = ligolw_utils.load_filename(segment_file, False, contenthandler=h)
-    segment_table  = table.Table.get_table(indoc, 'segment')
+    segment_table  = ligolw.Table.get_table(indoc, 'segment')
 
-    seg_def_table = table.Table.get_table(indoc, 'segment_definer')
+    seg_def_table = ligolw.Table.get_table(indoc, 'segment_definer')
     def_ifos = seg_def_table.getColumnByName('ifos')
     def_names = seg_def_table.getColumnByName('name')
     def_ids = seg_def_table.getColumnByName('segment_def_id')

--- a/pycbc/inject/inject.py
+++ b/pycbc/inject/inject.py
@@ -32,7 +32,7 @@ import logging
 from abc import ABCMeta, abstractmethod
 
 import lal
-from ligo.lw import utils as ligolw_utils, ligolw, lsctables
+from igwn_ligolw import utils as ligolw_utils, ligolw, lsctables
 
 from pycbc import waveform, frame, libutils
 from pycbc.opt import LimitedSizeDict

--- a/pycbc/inject/inject.py
+++ b/pycbc/inject/inject.py
@@ -313,7 +313,7 @@ class _XMLInjectionSet(object):
         """
         xmldoc = ligolw.Document()
         xmldoc.appendChild(ligolw.LIGO_LW())
-        simtable = lsctables.New(lsctables.SimInspiralTable)
+        simtable = lsctables.SimInspiralTable.new()
         xmldoc.childNodes[0].appendChild(simtable)
         if static_args is None:
             static_args = {}

--- a/pycbc/io/gracedb.py
+++ b/pycbc/io/gracedb.py
@@ -10,9 +10,9 @@ import copy
 from multiprocessing.dummy import threading
 
 import lal
-from ligo.lw import ligolw
-from ligo.lw import lsctables
-from ligo.lw import utils as ligolw_utils
+from igwn_ligolw import ligolw
+from igwn_ligolw import lsctables
+from igwn_ligolw import utils as ligolw_utils
 
 import pycbc
 from pycbc import version as pycbc_version

--- a/pycbc/io/gracedb.py
+++ b/pycbc/io/gracedb.py
@@ -116,7 +116,7 @@ class CandidateForGraceDB(object):
                                        detectors=snr_ifos).process_id
 
         # Set up coinc_definer table
-        coinc_def_table = lsctables.New(lsctables.CoincDefTable)
+        coinc_def_table = lsctables.CoincDefTable.new()
         coinc_def_id = lsctables.CoincDefID(0)
         coinc_def_row = lsctables.CoincDef()
         coinc_def_row.search = "inspiral"
@@ -128,7 +128,7 @@ class CandidateForGraceDB(object):
 
         # Set up coinc inspiral and coinc event tables
         coinc_id = lsctables.CoincID(0)
-        coinc_event_table = lsctables.New(lsctables.CoincTable)
+        coinc_event_table = lsctables.CoincTable.new()
         coinc_event_row = lsctables.Coinc()
         coinc_event_row.coinc_def_id = coinc_def_id
         coinc_event_row.nevents = len(snr_ifos)
@@ -144,8 +144,8 @@ class CandidateForGraceDB(object):
         outdoc.childNodes[0].appendChild(coinc_event_table)
 
         # Set up sngls
-        sngl_inspiral_table = lsctables.New(lsctables.SnglInspiralTable)
-        coinc_event_map_table = lsctables.New(lsctables.CoincMapTable)
+        sngl_inspiral_table = lsctables.SnglInspiralTable.new()
+        coinc_event_map_table = lsctables.CoincMapTable.new()
 
         # Marker variable recording template info from a valid sngl trigger
         sngl_populated = None
@@ -201,7 +201,7 @@ class CandidateForGraceDB(object):
         outdoc.childNodes[0].appendChild(sngl_inspiral_table)
 
         # Set up the coinc inspiral table
-        coinc_inspiral_table = lsctables.New(lsctables.CoincInspiralTable)
+        coinc_inspiral_table = lsctables.CoincInspiralTable.new()
         coinc_inspiral_row = lsctables.CoincInspiral()
         # This seems to be used as FAP, which should not be in gracedb
         coinc_inspiral_row.false_alarm_rate = 0.

--- a/pycbc/io/hdf.py
+++ b/pycbc/io/hdf.py
@@ -12,9 +12,9 @@ from itertools import chain
 from io import BytesIO
 from lal import LIGOTimeGPS
 
-from ligo.lw import ligolw
-from ligo.lw import lsctables
-from ligo.lw import utils as ligolw_utils
+from igwn_ligolw import ligolw
+from igwn_ligolw import lsctables
+from igwn_ligolw import utils as ligolw_utils
 
 from pycbc.io.ligolw import (
     return_search_summary,

--- a/pycbc/io/hdf.py
+++ b/pycbc/io/hdf.py
@@ -1119,7 +1119,7 @@ class ForegroundTriggers(object):
         )
         proc_id = proc_table.process_id
 
-        search_summ_table = lsctables.New(lsctables.SearchSummaryTable)
+        search_summ_table = lsctables.SearchSummaryTable.new()
         coinc_h5file = self.coinc_file.h5file
         try:
             start_time = coinc_h5file['segments']['coinc']['start'][:].min()
@@ -1141,12 +1141,12 @@ class ForegroundTriggers(object):
         search_summ_table.append(search_summary)
         outdoc.childNodes[0].appendChild(search_summ_table)
 
-        sngl_inspiral_table = lsctables.New(lsctables.SnglInspiralTable)
-        coinc_def_table = lsctables.New(lsctables.CoincDefTable)
-        coinc_event_table = lsctables.New(lsctables.CoincTable)
-        coinc_inspiral_table = lsctables.New(lsctables.CoincInspiralTable)
-        coinc_event_map_table = lsctables.New(lsctables.CoincMapTable)
-        time_slide_table = lsctables.New(lsctables.TimeSlideTable)
+        sngl_inspiral_table = lsctables.SnglInspiralTable.new()
+        coinc_def_table = lsctables.CoincDefTable.new()
+        coinc_event_table = lsctables.CoincTable.new()
+        coinc_inspiral_table = lsctables.CoincInspiralTable.new()
+        coinc_event_map_table = lsctables.CoincMapTable.new()
+        time_slide_table = lsctables.TimeSlideTable.new()
 
         # Set up time_slide table
         time_slide_id = lsctables.TimeSlideID(0)

--- a/pycbc/io/ligolw.py
+++ b/pycbc/io/ligolw.py
@@ -18,16 +18,16 @@
 import os
 import sys
 import numpy
-from ligo.lw import lsctables
-from ligo.lw import ligolw
-from ligo.lw.ligolw import Param, LIGOLWContentHandler \
+from igwn_ligolw import lsctables
+from igwn_ligolw import ligolw
+from igwn_ligolw.ligolw import Param, LIGOLWContentHandler \
     as OrigLIGOLWContentHandler
-from ligo.lw.lsctables import TableByName
-from ligo.lw.table import Column, TableStream
-from ligo.lw.types import FormatFunc, FromPyType, ToPyType
-from ligo.lw.utils import process as ligolw_process
-from ligo.lw.param import Param as LIGOLWParam
-from ligo.lw.array import Array as LIGOLWArray
+from igwn_ligolw.lsctables import TableByName
+from igwn_ligolw.table import Column, TableStream
+from igwn_ligolw.types import FormatFunc, FromPyType, ToPyType
+from igwn_ligolw.utils import process as ligolw_process
+from igwn_ligolw.param import Param as LIGOLWParam
+from igwn_ligolw.array import Array as LIGOLWArray
 import pycbc.version as pycbc_version
 
 

--- a/pycbc/io/ligolw.py
+++ b/pycbc/io/ligolw.py
@@ -20,13 +20,12 @@ import sys
 import numpy
 from igwn_ligolw import lsctables
 from igwn_ligolw import ligolw
-from igwn_ligolw.ligolw import Param, LIGOLWContentHandler \
+from igwn_ligolw.ligolw import LIGOLWContentHandler \
     as OrigLIGOLWContentHandler
 from igwn_ligolw.lsctables import TableByName
 from igwn_ligolw.table import Column, TableStream
 from igwn_ligolw.types import FormatFunc, FromPyType, ToPyType
 from igwn_ligolw.utils import process as ligolw_process
-from igwn_ligolw.param import Param as LIGOLWParam
 from igwn_ligolw.array import Array as LIGOLWArray
 import pycbc.version as pycbc_version
 
@@ -183,7 +182,7 @@ def legacy_row_id_converter(ContentHandler):
     def endElementNS(self, uri_localname, qname,
                      __orig_endElementNS=ContentHandler.endElementNS):
         """Convert values of <Param> elements from ilwdchar to int."""
-        if isinstance(self.current, Param) and self.current.Type in IDTypes:
+        if isinstance(self.current, ligolw.Param) and self.current.Type in IDTypes:
             old_type = ToPyType[self.current.Type]
             old_val = str(old_type(self.current.pcdata))
             new_value = ROWID_PYTYPE(old_val.split(":")[-1])
@@ -265,7 +264,7 @@ def _build_series(series, dim_names, comment, delta_name, delta_unit):
     if comment is not None:
         elem.appendChild(ligolw.Comment()).pcdata = comment
     elem.appendChild(ligolw.Time.from_gps(series.epoch, 'epoch'))
-    elem.appendChild(LIGOLWParam.from_pyvalue('f0', series.f0, unit='s^-1'))
+    elem.appendChild(ligolw.Param.from_pyvalue('f0', series.f0, unit='s^-1'))
     delta = getattr(series, delta_name)
     if numpy.iscomplexobj(series.data.data):
         data = numpy.row_stack((
@@ -308,7 +307,7 @@ def make_psd_xmldoc(psddict, xmldoc=None):
             's^-1'
         )
         fs = lw.appendChild(xmlseries)
-        fs.appendChild(LIGOLWParam.from_pyvalue('instrument', instrument))
+        fs.appendChild(ligolw.Param.from_pyvalue('instrument', instrument))
     return xmldoc
 
 def snr_series_to_xml(snr_series, document, sngl_inspiral_id):
@@ -326,7 +325,7 @@ def snr_series_to_xml(snr_series, document, sngl_inspiral_id):
         's'
     )
     snr_node = document.childNodes[-1].appendChild(snr_xml)
-    eid_param = LIGOLWParam.from_pyvalue('event_id', sngl_inspiral_id)
+    eid_param = ligolw.Param.from_pyvalue('event_id', sngl_inspiral_id)
     snr_node.appendChild(eid_param)
 
 def get_table_columns(table):

--- a/pycbc/io/ligolw.py
+++ b/pycbc/io/ligolw.py
@@ -144,7 +144,7 @@ def create_process_table(document, program_name=None, detectors=None,
     if options is None:
         options = {}
 
-    # ligo.lw does not like `cvs_entry_time` being an empty string
+    # igwn_ligolw does not like `cvs_entry_time` being an empty string
     cvs_entry_time = pycbc_version.date or None
 
     opts = options.copy()

--- a/pycbc/io/ligolw.py
+++ b/pycbc/io/ligolw.py
@@ -20,13 +20,10 @@ import sys
 import numpy
 from igwn_ligolw import lsctables
 from igwn_ligolw import ligolw
-from igwn_ligolw.ligolw import LIGOLWContentHandler \
-    as OrigLIGOLWContentHandler
+from igwn_ligolw.ligolw import LIGOLWContentHandler as OrigLIGOLWContentHandler
 from igwn_ligolw.lsctables import TableByName
-from igwn_ligolw.table import Column, TableStream
 from igwn_ligolw.types import FormatFunc, FromPyType, ToPyType
 from igwn_ligolw.utils import process as ligolw_process
-from igwn_ligolw.array import Array as LIGOLWArray
 import pycbc.version as pycbc_version
 
 
@@ -83,7 +80,7 @@ def return_empty_sngl(nones=False):
     sngl = lsctables.SnglInspiral()
     cols = lsctables.SnglInspiralTable.validcolumns
     for entry in cols:
-        col_name = Column.ColumnName(entry)
+        col_name = ligolw.Column.ColumnName(entry)
         value = None if nones else default_null_value(col_name, cols[entry])
         setattr(sngl, col_name, value)
     return sngl
@@ -111,7 +108,7 @@ def return_search_summary(start_time=0, end_time=0, nevents=0, ifos=None):
     search_summary = lsctables.SearchSummary()
     cols = lsctables.SearchSummaryTable.validcolumns
     for entry in cols:
-        col_name = Column.ColumnName(entry)
+        col_name = ligolw.Column.ColumnName(entry)
         value = default_null_value(col_name, cols[entry])
         setattr(search_summary, col_name, value)
 
@@ -220,7 +217,9 @@ def legacy_row_id_converter(ContentHandler):
             validcolumns = TableByName[parent.Name].validcolumns
             if result.Name not in validcolumns:
                 stripped_column_to_valid_column = {
-                    Column.ColumnName(name): name for name in validcolumns}
+                    ligolw.Column.ColumnName(name): name
+                    for name in validcolumns
+                }
                 if result.Name in stripped_column_to_valid_column:
                     result.setAttribute(
                         'Name', stripped_column_to_valid_column[result.Name])
@@ -238,7 +237,7 @@ def legacy_row_id_converter(ContentHandler):
 
         """
         result = __orig_startStream(self, parent, attrs)
-        if isinstance(result, TableStream):
+        if isinstance(result, ligolw.Table.Stream):
             loadcolumns = set(parent.columnnames)
             if parent.loadcolumns is not None:
                 # FIXME:  convert loadcolumns attributes to sets to
@@ -277,7 +276,7 @@ def _build_series(series, dim_names, comment, delta_name, delta_unit):
             numpy.arange(len(series.data.data)) * delta,
             series.data.data
         ))
-    a = LIGOLWArray.build(series.name, data, dim_names=dim_names)
+    a = ligolw.Array.build(series.name, data, dim_names=dim_names)
     a.Unit = str(series.sampleUnits)
     dim0 = a.getElementsByTagName(ligolw.Dim.tagName)[0]
     dim0.Unit = delta_unit

--- a/pycbc/io/ligolw.py
+++ b/pycbc/io/ligolw.py
@@ -345,6 +345,5 @@ def get_table_columns(table):
 
 
 @legacy_row_id_converter
-@lsctables.use_in
 class LIGOLWContentHandler(OrigLIGOLWContentHandler):
     "Dummy class needed for loading LIGOLW files"

--- a/pycbc/io/ligolw.py
+++ b/pycbc/io/ligolw.py
@@ -23,7 +23,6 @@ from igwn_ligolw import ligolw
 from igwn_ligolw.ligolw import LIGOLWContentHandler as OrigLIGOLWContentHandler
 from igwn_ligolw.lsctables import TableByName
 from igwn_ligolw.types import FormatFunc, FromPyType, ToPyType
-from igwn_ligolw.utils import process as ligolw_process
 import pycbc.version as pycbc_version
 
 
@@ -152,8 +151,7 @@ def create_process_table(document, program_name=None, detectors=None,
         for key in key_del:
             opts.pop(key)
 
-    process = ligolw_process.register_to_xmldoc(
-        document,
+    process = document.register_process(
         program_name,
         opts,
         version=pycbc_version.version,

--- a/pycbc/io/ligolw.py
+++ b/pycbc/io/ligolw.py
@@ -327,10 +327,10 @@ def snr_series_to_xml(snr_series, document, sngl_inspiral_id):
 
 def get_table_columns(table):
     """Return a list of columns that are present in the given table, in a
-    format that can be passed to `lsctables.New()`.
+    format that can be passed to `igwn_ligolw.Table.new()`.
 
     The split on ":" is needed for columns like `process:process_id`, which
-    must be listed as `process:process_id` in `lsctables.New()`, but are
+    must be listed as `process:process_id` in `igwn_ligolw.Table.new()`, but are
     listed as just `process_id` in the `columnnames` attribute of the given
     table.
     """

--- a/pycbc/io/record.py
+++ b/pycbc/io/record.py
@@ -708,7 +708,7 @@ class FieldArray(numpy.recarray):
     Convert a LIGOLW xml table:
 
     >>> type(sim_table)
-        ligo.lw.lsctables.SimInspiralTable
+        igwn_ligolw.lsctables.SimInspiralTable
     >>> sim_array = FieldArray.from_ligolw_table(sim_table)
     >>> sim_array.mass1
     array([ 2.27440691,  1.85058105,  1.61507106, ...,  2.0504961 ,

--- a/pycbc/io/record.py
+++ b/pycbc/io/record.py
@@ -29,7 +29,7 @@ waves.
 """
 
 import types, re, copy, numpy, inspect
-from ligo.lw import types as ligolw_types
+from igwn_ligolw import types as ligolw_types
 from pycbc import coordinates, conversions, cosmology
 from pycbc.population import population_models
 from pycbc.waveform import parameters

--- a/pycbc/psd/read.py
+++ b/pycbc/psd/read.py
@@ -161,7 +161,7 @@ def from_xml(filename, length, delta_f, low_freq_cutoff, ifo_string=None,
         The generated frequency series.
     """
     import lal.series
-    from ligo.lw import utils as ligolw_utils
+    from igwn_ligolw import utils as ligolw_utils
 
     with open(filename, 'rb') as fp:
         ct_handler = lal.series.PSDContentHandler

--- a/pycbc/tmpltbank/bank_output_utils.py
+++ b/pycbc/tmpltbank/bank_output_utils.py
@@ -2,7 +2,7 @@ import logging
 import numpy
 
 from lal import PI, MTSUN_SI, TWOPI, GAMMA
-from ligo.lw import ligolw, lsctables, utils as ligolw_utils
+from igwn_ligolw import ligolw, lsctables, utils as ligolw_utils
 
 from pycbc import pnutils
 from pycbc.tmpltbank.lambda_mapping import ethinca_order_from_string

--- a/pycbc/tmpltbank/bank_output_utils.py
+++ b/pycbc/tmpltbank/bank_output_utils.py
@@ -33,7 +33,7 @@ def convert_to_sngl_inspiral_table(params, proc_id):
     SnglInspiralTable
         Bank of templates in SnglInspiralTable format
     '''
-    sngl_inspiral_table = lsctables.New(lsctables.SnglInspiralTable)
+    sngl_inspiral_table = lsctables.SnglInspiralTable.new()
     col_names = ['mass1','mass2','spin1z','spin2z']
 
     for values in params:
@@ -267,7 +267,7 @@ def output_sngl_inspiral_table(outputFile, tempBank, programName="",
         end_time = optDict['gps_end_time']
 
     # make search summary table
-    search_summary_table = lsctables.New(lsctables.SearchSummaryTable)
+    search_summary_table = lsctables.SearchSummaryTable.new()
     search_summary = return_search_summary(
         start_time, end_time, len(sngl_inspiral_table), ifos
     )

--- a/pycbc/types/frequencyseries.py
+++ b/pycbc/types/frequencyseries.py
@@ -400,7 +400,7 @@ class FrequencySeries(Array):
             _numpy.savetxt(path, output)
         elif ext == '.xml' or path.endswith('.xml.gz'):
             from pycbc.io.ligolw import make_psd_xmldoc
-            from ligo.lw import utils
+            from igwn_ligolw import utils
 
             if self.kind != 'real':
                 raise ValueError('XML only supports real frequency series')

--- a/pycbc/waveform/bank.py
+++ b/pycbc/waveform/bank.py
@@ -31,7 +31,7 @@ import os.path
 import h5py
 from copy import copy
 import numpy as np
-from ligo.lw import lsctables, utils as ligolw_utils
+from igwn_ligolw import lsctables, utils as ligolw_utils
 import pycbc.waveform
 import pycbc.pnutils
 import pycbc.waveform.compress

--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -47,9 +47,9 @@ import igwn_segments as segments
 import lal
 import lal.utils
 import Pegasus.api  # Try and move this into pegasus_workflow
-from ligo.lw import lsctables, ligolw
-from ligo.lw import utils as ligolw_utils
-from ligo.lw.utils import segments as ligolw_segments
+from igwn_ligolw import lsctables, ligolw
+from igwn_ligolw import utils as ligolw_utils
+from igwn_ligolw.utils import segments as ligolw_segments
 
 from pycbc import makedir
 from pycbc.io.ligolw import LIGOLWContentHandler, create_process_table

--- a/pycbc/workflow/datafind.py
+++ b/pycbc/workflow/datafind.py
@@ -34,7 +34,7 @@ import logging
 import urllib.parse
 
 import igwn_segments as segments
-from ligo.lw import utils, table
+from igwn_ligolw import utils, table
 from gwdatafind import find_urls as find_frame_urls
 
 from pycbc.workflow.core import SegFile, File, FileList, make_analysis_dir

--- a/pycbc/workflow/datafind.py
+++ b/pycbc/workflow/datafind.py
@@ -34,7 +34,7 @@ import logging
 import urllib.parse
 
 import igwn_segments as segments
-from igwn_ligolw import utils, table
+from igwn_ligolw import utils, ligolw
 from gwdatafind import find_urls as find_frame_urls
 
 from pycbc.workflow.core import SegFile, File, FileList, make_analysis_dir
@@ -888,7 +888,7 @@ def get_segment_summary_times(scienceFile, segmentName):
     )
 
     # Get the segment_def_id for the segmentName
-    segmentDefTable = table.Table.get_table(xmldoc, "segment_definer")
+    segmentDefTable = ligolw.Table.get_table(xmldoc, "segment_definer")
     for entry in segmentDefTable:
         if (entry.ifos == ifo) and (entry.name == channel):
             if len(segmentName) == 2 or (entry.version==version):
@@ -899,7 +899,7 @@ def get_segment_summary_times(scienceFile, segmentName):
                          %(segmentName))
 
     # Get the segmentlist corresponding to this segmentName in segment_summary
-    segmentSummTable = table.Table.get_table(xmldoc, "segment_summary")
+    segmentSummTable = ligolw.Table.get_table(xmldoc, "segment_summary")
     summSegList = segments.segmentlist([])
     for entry in segmentSummTable:
         if entry.segment_def_id == segDefID:

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,8 +32,8 @@ urllib3
 # addresses incompatibility between old flask/jinja2 and latest markupsafe
 markupsafe <= 2.0.1
 
-# Requirements for ligoxml access needed by some workflows
-python-ligo-lw >= 1.8.1
+# Requirements for LIGO Light-Weight XML format access needed by some workflows
+igwn-ligolw
 
 # Needed for Parameter Estimation Tasks
 emcee==2.2.1

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ install_requires = setup_requires + [
     'setuptools',
     'gwdatafind',
     'pegasus-wms.api >= 5.0.8',
-    'python-ligo-lw >= 1.7.0',
+    'igwn-ligolw',
     'igwn-segments',
     'lalsuite!=7.2',
     'lscsoft-glue>=1.59.3',

--- a/test/test_injection.py
+++ b/test/test_injection.py
@@ -26,9 +26,9 @@ from pycbc.inject import InjectionSet
 import unittest
 import numpy
 import itertools
-from ligo.lw import ligolw
-from ligo.lw import lsctables
-from ligo.lw import utils as ligolw_utils
+from igwn_ligolw import ligolw
+from igwn_ligolw import lsctables
+from igwn_ligolw import utils as ligolw_utils
 from utils import parse_args_cpu_only, simple_exit
 
 # Injection tests only need to happen on the CPU

--- a/test/test_injection.py
+++ b/test/test_injection.py
@@ -116,7 +116,7 @@ class TestInjection(unittest.TestCase):
         xmldoc.appendChild(ligolw.LIGO_LW())
 
         # create sim inspiral table, link it to document and fill it
-        sim_table = lsctables.New(lsctables.SimInspiralTable)
+        sim_table = lsctables.SimInspiralTable.new()
         xmldoc.childNodes[-1].appendChild(sim_table)
         for i in range(len(self.injections)):
             row = sim_table.RowType()

--- a/test/test_io_live.py
+++ b/test/test_io_live.py
@@ -25,8 +25,8 @@ from utils import parse_args_cpu_only, simple_exit
 from pycbc.types import TimeSeries, FrequencySeries
 from pycbc.io.gracedb import CandidateForGraceDB
 from pycbc.io.ligolw import LIGOLWContentHandler
-from ligo.lw import lsctables
-from ligo.lw import utils as ligolw_utils
+from igwn_ligolw import lsctables
+from igwn_ligolw import utils as ligolw_utils
 from lal import series as lalseries
 
 # if we have the GraceDb module then we can do deeper tests,

--- a/tools/pycbc_test_suite.sh
+++ b/tools/pycbc_test_suite.sh
@@ -82,14 +82,10 @@ if [ "$PYCBC_TEST_TYPE" = "search" ] || [ -z ${PYCBC_TEST_TYPE+x} ]; then
     popd
 
     # run PyCBC Live test
-    if ((${PYTHON_MINOR_VERSION} > 7)); then
-      # ligo.skymap is only supporting python3.8+, and older releases are
-      # broken by a new release of python-ligo-lw
-      pushd examples/live
-      bash -e run.sh
-      test_result
-      popd
-    fi
+    pushd examples/live
+    bash -e run.sh
+    test_result
+    popd
 
     # run pycbc_multi_inspiral (PyGRB) test
     pushd examples/multi_inspiral
@@ -149,14 +145,10 @@ if [ "$PYCBC_TEST_TYPE" = "inference" ] || [ -z ${PYCBC_TEST_TYPE+x} ]; then
     popd
 
     ## Run pycbc_make_skymap example
-    if ((${PYTHON_MINOR_VERSION} > 7)); then
-      # ligo.skymap is only supporting python3.8+, and older releases are
-      # broken by a new release of python-ligo-lw
-      pushd examples/make_skymap
-      bash -e simulated_data.sh
-      test_result
-      popd
-    fi
+    pushd examples/make_skymap
+    bash -e simulated_data.sh
+    test_result
+    popd
 fi
 
 if [ "$PYCBC_TEST_TYPE" = "docs" ] || [ -z ${PYCBC_TEST_TYPE+x} ]; then

--- a/tools/timing/banksim/banksim.py
+++ b/tools/timing/banksim/banksim.py
@@ -26,8 +26,8 @@
 import sys
 from numpy import complex64,float32
 from optparse import OptionParser
-from ligo.lw import utils as ligolw_utils
-from ligo.lw import table, lsctables
+from igwn_ligolw import utils as ligolw_utils
+from igwn_ligolw import table, lsctables
 
 from pycbc.utils import mass1_mass2_to_mchirp_eta
 from pycbc.waveform import get_td_waveform, get_fd_waveform, td_approximants, fd_approximants

--- a/tools/timing/banksim/banksim.py
+++ b/tools/timing/banksim/banksim.py
@@ -27,7 +27,7 @@ import sys
 from numpy import complex64,float32
 from optparse import OptionParser
 from igwn_ligolw import utils as ligolw_utils
-from igwn_ligolw import table, lsctables
+from igwn_ligolw import lsctables
 
 from pycbc.utils import mass1_mass2_to_mchirp_eta
 from pycbc.waveform import get_td_waveform, get_fd_waveform, td_approximants, fd_approximants

--- a/tox.ini
+++ b/tox.ini
@@ -16,9 +16,11 @@ conda_deps =
     cxx-compiler
     gsl
     mysqlclient
-    ; these packages don't install cleanly with pip, conda has patches
-    ligo-segments # FIXME needed for mac tests to pass, remove when lalsuite drops this dependency
     blas=*=openblas
+    ; FIXME these two are needed for now to let Mac tests pass.
+    ; Remove when lalsuite stops depending on them.
+    ligo-segments
+    python-ligo-lw
 
 [bbhx]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -16,8 +16,6 @@ conda_deps =
     cxx-compiler
     gsl
     mysqlclient
-    ; these packages don't install cleanly with pip, conda has patches
-    python-ligo-lw
     blas=*=openblas
 
 [bbhx]

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,8 @@ conda_deps =
     cxx-compiler
     gsl
     mysqlclient
+    ; these packages don't install cleanly with pip, conda has patches
+    ligo-segments # FIXME needed for mac tests to pass, remove when lalsuite drops this dependency
     blas=*=openblas
 
 [bbhx]

--- a/tox.ini
+++ b/tox.ini
@@ -17,8 +17,11 @@ conda_deps =
     gsl
     mysqlclient
     blas=*=openblas
-    ; FIXME these two are needed for now to let Mac tests pass.
-    ; Remove when lalsuite stops depending on them.
+    ; FIXME ligo-segments and python-ligo-lw are currently pulled in by
+    ; lalsuite, but fail to build with pip on Mac. Their releases on conda-forge
+    ; have patches that allow them to be installed, so we pre-install those
+    ; here. Remove this when lalsuite has fully transitioned to igwn-segments
+    ; and igwn-ligolw.
     ligo-segments
     python-ligo-lw
 


### PR DESCRIPTION
Move from python-ligo-lw to the recently released and more modern igwn-ligolw.

## Standard information about the request

This is a depencency change.
This change should have no impact on any functionality or result.
This change will drop the dependency on python-ligo-lw and introduce a depencency on igwn-ligolw.

## Motivation

igwn-ligolw is more actively maintained and supports modern Python versions and more architectures than python-ligo-lw.

## Contents

Mainly replacing imports, but the transition from python-ligo-lw 1.8.3 to igwn-ligolw 2.0.0 has the side effect of introducing a few breaking changes which never made it to a python-ligo-lw release yet, as well as a couple deprecation warnings, so those are handled as well. We can also further simplify `tox.ini`, consistently with #4857.

## Links to any issues or associated PRs

This is essentially a counterpart to #4999. Improves #4857.

## Testing performed

Ran `tox` and a few of the tests manually on a local machine, but I am relying on the CI for now.

## Additional notes

I am not sure I want to push this to production codes yet, at least not before more significant testing is done with workflows and GraceDB interactions. In particular, I think we should create a release branch for PyGRB's O4a analysis before merging this (@pannarale). So I am applying a "on hold" label.

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
