### PR TITLE
PyGRB reweighted SNR cut bug

### DIFF
--- a/bin/pygrb/pycbc_pygrb_plot_injs_results
+++ b/bin/pygrb/pycbc_pygrb_plot_injs_results
@@ -309,6 +309,7 @@ if opts.newsnr_threshold:
         found_inj[key] = found_inj[key][~rw_snr_cut]
     for ifo in ifos:
         found_inj[ifo+'/end_time'] = found_inj[ifo+'/end_time'][~rw_snr_cut]
+    found_inj['reweighted_snr'] = found_inj['reweighted_snr'][~rw_snr_cut]
     msg = f"After applying reweighted SNR cut at {opts.newsnr_threshold}: "
     msg += f"{len(found_inj[x_qty])} found injections and "
     msg += f"{len(missed_inj[x_qty])} missed injections"


### PR DESCRIPTION
@Thomas-JACQUOT uncovered a bug when running PyGRB without vetoes.  

One of the plotting scripts was not applying the reweighted SNR cut to the reweighted SNR values of found injections.  This would then lead to indexing errors such as
```
IndexError: boolean index did not match indexed array along dimension 0; dimension is 6080 but corresponding boolean dimension is 5827
```

This PR only affects PyGRB and fixes this problem.

I encourage @Thomas-JACQUOT to use this branch to ensure that his run goes to completion.

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
