### PR TITLE
Efficient imports

### DIFF
--- a/bin/pycbc_make_banksim
+++ b/bin/pycbc_make_banksim
@@ -273,7 +273,7 @@ f = open("scripts/pycbc_banksim_match_combine", "w")
 f.write("""#!/usr/bin/env python
 from os.path import isfile
 from optparse import OptionParser
-from numpy import *
+from numpy import array
 import glob
 parser = OptionParser()
 
@@ -302,7 +302,7 @@ os.chmod('scripts/pycbc_banksim_match_combine', 0o0777)
 f = open("scripts/pycbc_banksim_collect_results", "w")
 f.write("""#!/usr/bin/env python
 from os.path import isfile
-from numpy import *
+import numpy as np
 from ligo.lw import utils, table
 import glob
 
@@ -316,9 +316,9 @@ dtypem={'names': ('match', 'bank', 'bank_i', 'sim', 'sim_i', 'sigmasq'), 'format
 res = None
 for fil in fils:
     if res is not None:
-        res = append(res, loadtxt(fil, dtype=dtypem))
+        res = np.append(res, loadtxt(fil, dtype=dtypem))
     else:
-        res = loadtxt(fil, dtype=dtypem)
+        res = np.loadtxt(fil, dtype=dtypem)
 
 btables = {}
 itables = {}

--- a/bin/pycbc_make_faithsim
+++ b/bin/pycbc_make_faithsim
@@ -146,7 +146,7 @@ dag.add_node(pnode)
 
 f = open("scripts/pycbc_faithsim_collect_results", "w")
 f.write("""#!/usr/bin/env python
-from numpy import *
+import numpy as np
 from ligo.lw import utils, table, lsctables
 import glob
 from pycbc.io.ligolw import LIGOLWContentHandler
@@ -172,7 +172,7 @@ if __name__ == "__main__":
     btables = {}
     for tag in tags:
         parts = glob.glob("match/match-" + tag + "-*.dat")
-        data = zeros(0, dtype=dtypeo)   
+        data = np.zeros(0, dtype=dtypeo)
         for part in parts:
             btag = part.split('-')[2].split('.')[0]
             bname = "bank/bank" + btag + ".xml.gz"
@@ -181,12 +181,12 @@ if __name__ == "__main__":
                 btables[bname] = lsctables.SimInspiralTable.get_table(indoc)
             bt = btables[bname]
             try:      
-                md = loadtxt(part, dtype=dtypem)
+                md = np.loadtxt(part, dtype=dtypem)
                 if md.size == 0:
                     continue  
             except IOError:
                 continue
-            pdata = zeros(len(bt), dtype=dtypeo)
+            pdata = np.zeros(len(bt), dtype=dtypeo)
             
             for field in mfields: 
                 pdata[field] = md[field]
@@ -195,7 +195,7 @@ if __name__ == "__main__":
                 if field not in mfields:
                     pdata[field] = bt.get_column(field)
             
-            data = append(data, pdata)
+            data = np.append(data, pdata)
         savetxt('result-' + tag + '.dat', data)
 """)
 os.chmod('scripts/pycbc_faithsim_collect_results', 0o0777)
@@ -217,7 +217,7 @@ import matplotlib
 matplotlib.use('Agg')
 import matplotlib.cm
 import pylab
-from numpy import *
+import numpy as np
 from ligo.lw import utils, table, lsctables
 from matplotlib.ticker import MultipleLocator, FormatStrFormatter
 import glob
@@ -274,14 +274,14 @@ def basic_scatter(out_name, xname, yname, title, xval, yval,
 fils = glob.glob("result*.dat")
 for fil in fils:
     tag = fil.split('-')[1].split('.')[0]
-    data = loadtxt(fil, dtype=dtypeo)
+    data = np.loadtxt(fil, dtype=dtypeo)
 
-    mmass1 = maximum(data['mass1'], data['mass2'])
-    mmass2 = minimum(data['mass1'], data['mass2'])
+    mmass1 = np.maximum(data['mass1'], data['mass2'])
+    mmass2 = np.minimum(data['mass1'], data['mass2'])
     mchirp, eta = pnutils.mass1_mass2_to_mchirp_eta(mmass1, mmass2)
 
     M = data['mass1'] + data['mass2']    
-    q = maximum(data['mass1'] / data['mass2'], data['mass2'] / data['mass1'])
+    q = np.maximum(data['mass1'] / data['mass2'], data['mass2'] / data['mass1'])
     s1 = (data['spin1x']**2 + data['spin1y']**2 + data['spin1z']**2)**0.5
     s2 = (data['spin2x']**2 + data['spin2y']**2 + data['spin2z']**2)**0.5
     

--- a/test/bankvetotest.py
+++ b/test/bankvetotest.py
@@ -1,8 +1,7 @@
-from pycbc.types import *
-from pycbc.noise.gaussian import *
-from pycbc.filter import *
-from pycbc.waveform import *
-from pycbc.vetoes import *
+from pycbc.noise.gaussian import noise_from_psd
+from pycbc.filter import matched_filter_core, sigmasq, overlap_cplx
+from pycbc.waveform import get_fd_waveform
+from pycbc.vetoes import bank_chisq_from_filters
 import pycbc.psd
 
 sr = 4096.0

--- a/test/test_array.py
+++ b/test/test_array.py
@@ -28,6 +28,7 @@ These are the unittests for the pycbc array type
 
 import unittest
 from pycbc.types import float32, complex64, float64, complex128, Array, zeros
+from pycbc.scheme import CPUScheme
 import numpy
 from utils import array_base, parse_args_all_schemes, simple_exit
 import os

--- a/test/test_array.py
+++ b/test/test_array.py
@@ -27,8 +27,7 @@ These are the unittests for the pycbc array type
 
 
 import unittest
-from pycbc.types import *
-from pycbc.scheme import *
+from pycbc.types import float32, complex64, float64, complex128, Array, zeros
 import numpy
 from utils import array_base, parse_args_all_schemes, simple_exit
 import os

--- a/test/test_array_lal.py
+++ b/test/test_array_lal.py
@@ -25,8 +25,10 @@
 These are the unittests for the pycbc.filter.matchedfilter module
 """
 import unittest
-from pycbc.types import *
-from pycbc.scheme import *
+from pycbc.types import (
+    Array, TimeSeries, FrequencySeries,
+    float32, float64, complex64, complex128
+)
 from lal import LIGOTimeGPS as LTG
 from utils import parse_args_all_schemes, simple_exit
 

--- a/test/test_autochisq.py
+++ b/test/test_autochisq.py
@@ -2,8 +2,8 @@ from pycbc.fft.fftw import set_measure_level
 set_measure_level(0)
 from pycbc.filter import  matched_filter_core
 from pycbc.types import Array, TimeSeries, FrequencySeries
-from pycbc.waveform import *
-from pycbc.vetoes import *
+from pycbc.waveform import get_td_waveform
+from pycbc.vetoes import make_frequency_series, autochisq_from_precomputed
 import numpy as np
 from math import cos, sin, pi, exp
 import unittest

--- a/test/test_chisq.py
+++ b/test/test_chisq.py
@@ -26,8 +26,7 @@ These are the unittests for the pycbc.waveform module
 """
 import unittest
 import numpy
-from pycbc.types import *
-from pycbc.scheme import *
+from pycbc.types import Array, float32, complex64, zeros
 from utils import parse_args_all_schemes, simple_exit
 
 _scheme, _context = parse_args_all_schemes("correlate")

--- a/test/test_correlate.py
+++ b/test/test_correlate.py
@@ -26,9 +26,8 @@ These are the unittests for the correlate functions in pycbc.filter.matchedfilte
 """
 import unittest
 import numpy
-from pycbc.types import *
-from pycbc.scheme import *
-from pycbc.filter import *
+from pycbc.types import Array, zeros, complex64
+from pycbc.filter import correlate
 from utils import parse_args_all_schemes, simple_exit
 from pycbc.filter.matchedfilter import BatchCorrelator, Correlator
 

--- a/test/test_frequencyseries.py
+++ b/test/test_frequencyseries.py
@@ -26,8 +26,9 @@ These are the unittests for the pycbc frequencyseries type
 '''
 
 import unittest
-from pycbc.types import *
-from pycbc.scheme import *
+from pycbc.types import (
+    Array, FrequencySeries, float32, complex64, float64, complex128,
+)
 import numpy
 import lal
 import os

--- a/test/test_frequencyseries.py
+++ b/test/test_frequencyseries.py
@@ -29,6 +29,7 @@ import unittest
 from pycbc.types import (
     Array, FrequencySeries, float32, complex64, float64, complex128,
 )
+from pycbc.scheme import DefaultScheme
 import numpy
 import lal
 import os
@@ -317,7 +318,7 @@ class TestFrequencySeriesBase(array_base,unittest.TestCase):
         if self.scheme != 'cpu':
             self.assertRaises(TypeError, FrequencySeries, out4, 0.1, copy=False)
             out6 = FrequencySeries(out4, 0.1, dtype=self.dtype, epoch=self.epoch)
-            self.assertTrue(type(out6._scheme) == CPUScheme)
+            self.assertTrue(type(out6._scheme) == DefaultScheme)
             self.assertTrue(type(out6._data) is CPUArray)
             self.assertEqual(out6[0],1)
             self.assertEqual(out6[1],2)

--- a/test/test_matchedfilter.py
+++ b/test/test_matchedfilter.py
@@ -25,9 +25,12 @@
 These are the unittests for the pycbc.filter.matchedfilter module
 """
 import unittest
-from pycbc.types import *
-#from pycbc.scheme import *
-from pycbc.filter import *
+from pycbc.types import (
+    Array, TimeSeries, FrequencySeries, zeros, float32, float64, complex64
+)
+from pycbc.filter import (
+    make_frequency_series, optimized_match, match, matched_filter
+)
 from math import sqrt
 import numpy
 from utils import parse_args_all_schemes, simple_exit

--- a/test/test_matchedfilter.py
+++ b/test/test_matchedfilter.py
@@ -26,7 +26,7 @@ These are the unittests for the pycbc.filter.matchedfilter module
 """
 import unittest
 from pycbc.types import *
-from pycbc.scheme import *
+#from pycbc.scheme import *
 from pycbc.filter import *
 from math import sqrt
 import numpy

--- a/test/test_pnutils.py
+++ b/test/test_pnutils.py
@@ -26,8 +26,14 @@ These are the unittests for the pycbc.filter.matchedfilter module
 """
 import unittest
 import numpy
-from pycbc.pnutils import *
-from pycbc.scheme import *
+from pycbc.pnutils import (
+    mass1_mass2_spin1z_spin2z_to_beta_sigma_gamma,
+    mass1_mass2_to_mchirp_eta,
+    mass1_mass2_to_mtotal_eta,
+    mass1_mass2_to_tau0_tau3,
+    tau0_tau3_to_mass1_mass2,
+    tau0_tau3_to_mtotal_eta,
+)
 from utils import parse_args_cpu_only, simple_exit
 
 # We only need CPU tests

--- a/test/test_resample.py
+++ b/test/test_resample.py
@@ -25,9 +25,8 @@
 These are the unittests for the pycbc.filter.matchedfilter module
 """
 import unittest
-from pycbc.types import *
-from pycbc.filter import *
-from pycbc.scheme import *
+from pycbc.types import Array, TimeSeries, float32, float64, complex64
+from pycbc.filter import resample_to_delta_t
 from utils import parse_args_all_schemes, simple_exit
 from numpy.random import uniform
 import scipy.signal

--- a/test/test_schemes.py
+++ b/test/test_schemes.py
@@ -31,8 +31,8 @@ We do not specifically test that the lalwrapped functions raise exceptions from 
 GPU, because that test is done in the test_lalwrap unit tests.
 '''
 import unittest
-from pycbc.types import *
-from pycbc.scheme import *
+from pycbc.types import Array
+from pycbc.scheme import CUDAScheme, CPUScheme, DefaultScheme
 from numpy import float32, float64, complex64, complex128
 from utils import parse_args_all_schemes, simple_exit
 
@@ -48,7 +48,6 @@ elif isinstance(_context,CPUScheme):
     from numpy import ndarray as SchemeArray
 
 from numpy import ndarray as CPUArray
-
 
 class SchemeTestBase(unittest.TestCase):
     __test__ = False

--- a/test/test_timeseries.py
+++ b/test/test_timeseries.py
@@ -26,8 +26,9 @@ These are the unittests for the pycbc timeseries type
 '''
 
 import unittest
-from pycbc.types import *
-from pycbc.scheme import *
+from pycbc.types import float32, float64, complex64, complex128
+from pycbc.types import Array, TimeSeries
+from pycbc.scheme import DefaultScheme
 import numpy
 import lal
 from utils import array_base, parse_args_all_schemes, simple_exit
@@ -319,7 +320,7 @@ class TestTimeSeriesBase(array_base, unittest.TestCase):
         if self.scheme != 'cpu':
             self.assertRaises(TypeError, TimeSeries, out4, 0.1, copy=False, epoch=self.epoch)
             out6 = TimeSeries(out4, 0.1, dtype=self.dtype)
-            self.assertTrue(type(out6._scheme) == CPUScheme)
+            self.assertTrue(type(out6._scheme) == DefaultScheme)
             self.assertTrue(type(out6._data) is CPUArray)
             self.assertEqual(out6[0],1)
             self.assertEqual(out6[1],2)

--- a/tools/timing/arr_perf.py
+++ b/tools/timing/arr_perf.py
@@ -1,28 +1,30 @@
 #!/usr/bin/python
-from pycbc.scheme import *
-from pycbc.types import *
-from pycbc.fft import *
-from pycbc.events import *
+from pycbc.types import zeros, complex64
+from pycbc.scheme import CPUScheme, CUDAScheme
 import pycbc
-from optparse import OptionParser
+from argparse import ArgumentParser
 from math import sin, log
 import gc
-parser = OptionParser()
+parser = ArgumentParser()
 
-parser.add_option('--scheme','-s',  type = 'choice',
-                    choices = ('cpu','cuda','opencl'),
-                    default = 'cpu', dest = 'scheme',
-                    help = 'specifies processing scheme, can be cpu [default], cuda, or opencl')
+parser.add_argument(
+    '--scheme',
+    '-s',
+    choices = ('cpu','cuda','opencl'),
+    default = 'cpu',
+    dest = 'scheme',
+    help = 'specifies processing scheme, can be cpu [default], cuda, or opencl'
+)
 
-parser.add_option('--device-num','-d', action='store', type = 'int',
+parser.add_argument('--device-num','-d', action='store', type = int,
                     dest = 'devicenum', default=0,
                     help = 'specifies a GPU device to use for CUDA or OpenCL, 0 by default')
 
 
-parser.add_option('--size',type=float, help='FFT size')
-parser.add_option('--iterations', type=int, help='Number of iterations to perform')
+parser.add_argument('--size',type=float, help='FFT size', required=True)
+parser.add_argument('--iterations', type=int, help='Number of iterations to perform', required=True)
 
-(options, args) = parser.parse_args()
+options = parser.parse_args()
 
 #Changing the optvalues to a dict makes them easier to read
 _options = vars(options)
@@ -61,21 +63,21 @@ def addc():
 
 def add():
     with ctx:
-	for i in range(0, niter):
-	    v+v
-	v[0]
+        for i in range(0, niter):
+            v+v
+        v[0]
 
 def mul():
     with ctx:
-	for i in range(0, niter):
-	    v*v
-	v[0]
+        for i in range(0, niter):
+            v*v
+        v[0]
 
 def sqnm():
     with ctx:
-	for i in range(0, niter):
-	    v.squared_norm()
-	v[0]
+        for i in range(0, niter):
+            v.squared_norm()
+        v[0]
 
 import timeit
 

--- a/tools/timing/fft_perf.py
+++ b/tools/timing/fft_perf.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
-from pycbc.scheme import *
-from pycbc.types import *
-from pycbc.fft import *
+from pycbc.scheme import CPUScheme, CUDAScheme
+from pycbc.types import zeros, complex64, check_aligned
+from pycbc.fft import ifft
 import pycbc
 from optparse import OptionParser
 import gc
@@ -39,8 +39,6 @@ if _options['scheme'] == 'cpu':
             set_measure_level(options.measure_level)
             if options.num_threads != 1:
                 set_threads_backend('openmp')
-
-
 if _options['scheme'] == 'cuda':
     ctx = CUDAScheme(device_num=_options['devicenum'])
 if _options['scheme'] == 'opencl':
@@ -66,7 +64,7 @@ if options.import_float_wisdom:
 
 print("Making the plan")
 with ctx:
-    ifft(vecin, vecout, backend=options.backend)
+    ifft(vecin, vecout)
 print("Planning done")
 
 if options.export_float_wisdom:
@@ -75,9 +73,9 @@ if options.export_float_wisdom:
 
 def tifft():
     with ctx:
-	    for i in range(0, niter):
-	        ifft(vecin, vecout, backend=options.backend)
-	    sync = vecout[0]
+        for i in range(0, niter):
+            ifft(vecin, vecout)
+        sync = vecout[0]
 
 import timeit
 gt = timeit.Timer(tifft)

--- a/tools/timing/match_perf.py
+++ b/tools/timing/match_perf.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python
-from pycbc.scheme import *
-from pycbc.types import *
-from pycbc.filter import *
-from pycbc.psd import *
+from pycbc.scheme import CPUScheme, CUDAScheme
+from pycbc.types import TimeSeries, zeros, float32, complex64
+from pycbc.filter import make_frequency_series, match, matched_filter_core, overlap_cplx
 import pycbc
 from math import log
 import numpy

--- a/tools/timing/wav_perf.py
+++ b/tools/timing/wav_perf.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
-from pycbc.scheme import *
-from pycbc.types import *
-from pycbc.waveform import *
+from pycbc.scheme import CPUScheme, CUDAScheme
+from pycbc.types import zeros, complex64
+from pycbc.waveform import get_fd_waveform
 import pycbc
 from optparse import OptionParser
 import gc


### PR DESCRIPTION
In an attempt to remove "from xxx import *"-style imports from more places, I've used `git grep import | grep "*" | grep -v css| grep -v __init__` to find any places where this is used.

I then commented out the import, ran the tests to find what needs importing and getting that explicitly (not the most sophisticated, but seems to have worked).

After this change there is now 1 place which uses "from xxx import *", which is the versioning module, and I think that is valid.

The changes are mainly in the test suite - I've tried as much as possible to get tests to now pass, using cpu and cuda schemes, as these were what was catered for before!

I'd like to have other schemes / backends working, and some cuda tests fail, but that is for another PR

## Standard information about the request

This is a code quality change
This change affects: the offline search, the live search, inference, PyGRB

This change: has appropriate unit tests, follows style guidelines (See e.g. [PEP8](https://peps.python.org/pep-0008/)), has been proposed using the [contribution guidelines](https://github.com/gwastro/pycbc/blob/master/CONTRIBUTING.md)

## Motivation
#4783

## Testing performed
Ran tests manually - they worked. The CI will also check this

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
