### PR TITLE
Ensure pygrb webpage is generated after all results files are produced

### DIFF
--- a/bin/pygrb/pycbc_pygrb_results_workflow
+++ b/bin/pygrb/pycbc_pygrb_results_workflow
@@ -735,16 +735,6 @@ _workflow.makedir(rdir['workflow/input_map'])
 _workflow.makedir(rdir['workflow/output_map'])
 _workflow.makedir(rdir['workflow/planning'])
 
-logging.info(
-    "Path for make_results_web_page: %s", os.path.join(os.getcwd(), rdir.base)
-)
-_workflow.make_results_web_page(
-    wflow,
-    os.path.join(os.getcwd(), rdir.base),
-    template='red',
-    explicit_dependencies=plotting_nodes + html_nodes,
-)
-
 # Protect the open box results folder
 out_dir = rdir['open_box']
 _workflow.makedir(out_dir)
@@ -831,6 +821,17 @@ for inj_set in inj_sets:
     html_nodes.append(excl_dist_table_node)
     eff_layout += [(eff_plot, excl_dist_table[0])]
 layout.two_column_layout(out_dir, eff_layout)
+
+# Job to gather all html material in the webpage
+logging.info(
+    "Path for make_results_web_page: %s", os.path.join(os.getcwd(), rdir.base)
+)
+_workflow.make_results_web_page(
+    wflow,
+    os.path.join(os.getcwd(), rdir.base),
+    template='red',
+    explicit_dependencies=plotting_nodes + html_nodes,
+)
 
 # Close the log and flush to the html file
 logging.shutdown()


### PR DESCRIPTION
PyGRB webpages often had gaps that could be fixed by running the `pycbc_make_html_page` job by hand, after a full workflow was completed.  This was a sign of incorrect dependencies in the workflow (i.e., `pycbc_make_html_page` was being called too early).

To fix this, this PR simply moves the call to `make_results_web_page` further down in the `pycbc_pygrb_results_workflow` workflow generator, so that the job dependencies are correct: **all** nodes that will give jobs that produce plots, tables, etc. are now in the collection of dependencies passed to `make_results_web_page`, so `pycbc_make_html_page` runs after those jobs.

This is a: bug fix.

This change affects: PyGRB

I produced [this](https://ldas-jobs.ligo.caltech.edu/~francesco.pannarale/LVC/pygrb_tutorial/) results webpage from a short workflow with no need to "sync" it by hand after the workflow had finished running.

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
