### PR TITLE
Handling empty table in PyGRB

### DIFF
--- a/bin/pygrb/pycbc_pygrb_page_tables
+++ b/bin/pygrb/pycbc_pygrb_page_tables
@@ -497,10 +497,11 @@ if onsource_file:
         on_trigs_bestnrs = on_trigs['network/reweighted_snr'][...]
 
         # Gather bestNR index
-        bestNR_event = np.argmax(on_trigs_bestnrs)
-        loud_on_bestnr_trigs, loud_on_bestnr = \
-            (on_trigs['network/event_id'][bestNR_event],
-             on_trigs_bestnrs[bestNR_event])
+        if on_trigs_bestnrs.size > 0:
+            bestNR_event = np.argmax(on_trigs_bestnrs)
+            loud_on_bestnr_trigs, loud_on_bestnr = \
+                (on_trigs['network/event_id'][bestNR_event],
+                 on_trigs_bestnrs[bestNR_event])
     # If the loudest event has bestnr = 0, there is no event at all!
     if loud_on_bestnr == 0:
         loud_on_bestnr_trigs = None
@@ -536,9 +537,6 @@ if onsource_file:
             [on_trigs[ifo+'/snr'][ifo_trig_index[ifo]] for ifo in ifos] + \
             [loud_on_bestnr]
         td.append(d)
-    else:
-        td.append(["There are no events"] + [0 for number in range(11)] +
-                  [0 for ifo in ifos] + [0])
 
     # Table header
     th = ['p-value', 'GPS time', 'Rec. m1', 'Rec. m2', 'Rec. Mc',
@@ -546,6 +544,10 @@ if onsource_file:
           'Null SNR'] + [ifo+' SNR' for ifo in ifos] + ['BestNR']
 
     td = list(zip(*td))
+
+    # Handle the case in which there is no data to be placed in the table
+    if not td:
+        td = [[] for i in np.arange(len(th))]
 
     # Write to h5 file
     logging.info("Writing loudest onsource trigger to h5 file.")
@@ -562,7 +564,11 @@ if onsource_file:
     format_strings.extend(['##.##' for ifo in ifos])
     format_strings.extend(['##.##'])
 
-    # Table data
+    # Table data: assemble human readable message when no trigger is recovered
+    if not loud_on_bestnr_trigs:
+        td = [["There are no events"] + ["-" for number in range(11)] +
+              ["-" for ifo in ifos] + ["-"]]
+        td = list(zip(*td))
     td = [np.asarray(d) for d in td]
     html_table = pycbc.results.html_table(td, th,
                                           format_strings=format_strings,
@@ -645,6 +651,10 @@ if found_missed_file is not None:
     logging.info("Writing %d quiet-found injections to h5 and html files.",
                  len(td))
     td = list(zip(*td))
+
+    # Handle the case in which there is no data to be placed in the table
+    if not td:
+        td = [[] for i in np.arange(len(th))]
 
     # Write to h5 file
     with HFile(qf_h5_outfile, 'w') as qf_h5_fp:

--- a/bin/pygrb/pycbc_pygrb_page_tables
+++ b/bin/pygrb/pycbc_pygrb_page_tables
@@ -570,9 +570,8 @@ if onsource_file:
 
     # Table data: assemble human readable message when no trigger is recovered
     if not loud_on_bestnr_trigs:
-        td = [["There are no events"] + ["-" for number in range(11)] +
-              ["-" for ifo in ifos] + ["-"]]
-        td = list(zip(*td))
+        td = [list("-" * len(format_strings))]
+        td[0][0] = "There are no events"
     td = [np.asarray(d) for d in td]
     html_table = pycbc.results.html_table(td, th,
                                           format_strings=format_strings,

--- a/bin/pygrb/pycbc_pygrb_page_tables
+++ b/bin/pygrb/pycbc_pygrb_page_tables
@@ -504,9 +504,8 @@ if onsource_file:
         # Gather bestNR index
         if on_trigs_bestnrs.size > 0:
             bestNR_event = np.argmax(on_trigs_bestnrs)
-            loud_on_bestnr_trigs, loud_on_bestnr = \
-                (on_trigs['network/event_id'][bestNR_event],
-                 on_trigs_bestnrs[bestNR_event])
+            loud_on_bestnr_trigs = on_trigs['network/event_id'][bestNR_event]
+            loud_on_bestnr =  on_trigs_bestnrs[bestNR_event]
     # If the loudest event has bestnr = 0, there is no event at all!
     if loud_on_bestnr == 0:
         loud_on_bestnr_trigs = None

--- a/bin/pygrb/pycbc_pygrb_page_tables
+++ b/bin/pygrb/pycbc_pygrb_page_tables
@@ -430,6 +430,11 @@ if lofft_outfile:
     th.extend([ifo+' time shift (s)' for ifo in ifos])
     th.append('BestNR')
 
+    # When len(offsource_trigs) == 0, the loop above leaves td = [] unchanged
+    # and this case needs to be handled adequately prior to moving on
+    if not td:
+        td = [[] for i in np.arange(len(th))]
+
     # To ensure desired formatting in the h5 file and html table:
     # 1) "transpose" the data preserving its dtype
     td = list(zip(*td))

--- a/bin/pygrb/pycbc_pygrb_page_tables
+++ b/bin/pygrb/pycbc_pygrb_page_tables
@@ -551,7 +551,7 @@ if onsource_file:
 
     # Handle the case in which there is no data to be placed in the table
     if not td:
-        td = [[] for i in np.arange(len(th))]
+        td = [[]] * len(th)
 
     # Write to h5 file
     logging.info("Writing loudest onsource trigger to h5 file.")

--- a/bin/pygrb/pycbc_pygrb_page_tables
+++ b/bin/pygrb/pycbc_pygrb_page_tables
@@ -433,7 +433,7 @@ if lofft_outfile:
     # When len(offsource_trigs) == 0, the loop above leaves td = [] unchanged
     # and this case needs to be handled adequately prior to moving on
     if not td:
-        td = [[] for i in np.arange(len(th))]
+        td = [[]] * len(th)
 
     # To ensure desired formatting in the h5 file and html table:
     # 1) "transpose" the data preserving its dtype
@@ -658,7 +658,7 @@ if found_missed_file is not None:
 
     # Handle the case in which there is no data to be placed in the table
     if not td:
-        td = [[] for i in np.arange(len(th))]
+        td = [[]] * len(th)
 
     # Write to h5 file
     with HFile(qf_h5_outfile, 'w') as qf_h5_fp:


### PR DESCRIPTION
This PR enables the production of tables, within PyGRB, when the table needs to be empty.

## Standard information about the request

This is a: new feature

This change affects: PyGRB

This change changes: result presentation

## Motivation
The current version of `pycbc_pygrb_page_tables` (designed to handle missed/vetoed injections and loudest events) will not work when there is no injection/trigger to be displayed.

## Contents
This PR fixes this issue.  The script no longer assumes there are injections to be displayed; further, it checks whether there is an onsource trigger to be reported: if there is not, the h5 file will be empty, where as the html file will say "There are no events" in the first column and report "-" in the remaining columns, to leave a human readable message.

## Testing performed
The functioning of this can be checked in sections 3.01, 3.03, and 6 of [this](https://ldas-jobs.ligo.caltech.edu/~francesco.pannarale/LVC/pygrb_tutorial/) webpage.

## Additional notes
The code to handle the case in which the offsource yields no triggers is along the lines of the one implemented for the injections, but admittedly it is not tested in this run.

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
