### PR TITLE
More robust pygrb_page_tables

### DIFF
--- a/bin/pygrb/pycbc_pygrb_page_tables
+++ b/bin/pygrb/pycbc_pygrb_page_tables
@@ -494,7 +494,7 @@ if onsource_file:
     # Get trigs
     on_trigs = ppu.load_data(onsource_file, ifos, data_tag=None,
                              rw_snr_threshold=opts.newsnr_threshold,
-                             slide_id='all')
+                             slide_id=0)
 
     # Record loudest trig by BestNR
     loud_on_bestnr = 0

--- a/pycbc/results/pygrb_postprocessing_utils.py
+++ b/pycbc/results/pygrb_postprocessing_utils.py
@@ -344,9 +344,10 @@ def load_data(input_file, ifos, rw_snr_threshold=None, data_tag=None,
     trigs_dict = {}
     with HFile(input_file, "r") as trigs:
         for (path, dset) in _dataset_iterator(trigs):
-            # The dataset contains search information, not trig/inj properties:
+            # The dataset contains search information or missed injections
+            # information, not properties of triggers or found injections:
             # just copy it
-            if 'search' in path:
+            if 'search' in path or 'missed' in path:
                 trigs_dict[path] = dset[:]
             # The dataset is trig/inj info at an IFO: cut with the correct index
             elif path[:2] in ifos:

--- a/pycbc/results/pygrb_postprocessing_utils.py
+++ b/pycbc/results/pygrb_postprocessing_utils.py
@@ -344,11 +344,11 @@ def load_data(input_file, ifos, rw_snr_threshold=None, data_tag=None,
     trigs_dict = {}
     with HFile(input_file, "r") as trigs:
         for (path, dset) in _dataset_iterator(trigs):
-            # The dataset contains information other than trig/inj properties:
+            # The dataset contains search information, not trig/inj properties:
             # just copy it
-            if len(dset) != num_orig_pts:
+            if 'search' in path:
                 trigs_dict[path] = dset[:]
-            # The dataset is relative to an IFO: cut with the correct index
+            # The dataset is trig/inj info at an IFO: cut with the correct index
             elif path[:2] in ifos:
                 ifo = path[:2]
                 if ifo_ids_above_thresh_locations[ifo].size != 0:
@@ -356,7 +356,7 @@ def load_data(input_file, ifos, rw_snr_threshold=None, data_tag=None,
                         dset[:][ifo_ids_above_thresh_locations[ifo]]
                 else:
                     trigs_dict[path] = numpy.array([])
-            # The dataset is relative to the network: cut it before copying
+            # The dataset trig/inj network info: cut it before copying
             else:
                 trigs_dict[path] = dset[above_thresh]
 

--- a/pycbc/results/pygrb_postprocessing_utils.py
+++ b/pycbc/results/pygrb_postprocessing_utils.py
@@ -356,7 +356,7 @@ def load_data(input_file, ifos, rw_snr_threshold=None, data_tag=None,
                         dset[:][ifo_ids_above_thresh_locations[ifo]]
                 else:
                     trigs_dict[path] = numpy.array([])
-            # The dataset trig/inj network info: cut it before copying
+            # The dataset is trig/inj network info: cut it before copying
             else:
                 trigs_dict[path] = dset[above_thresh]
 


### PR DESCRIPTION
## Motivation
When recently running a light PyGRB workflow, the results webpage was not displaying the loudest onsource trigger information even though the workflow had found one.  Additionally, the follow up of the trigger did not happen.

## Contents
There are 2 changes in the PR.
1. The call to load the onsource data in page_tables was asking for all timeslides (`slide_id="all"`), but the onsource is in zero-lag data so it now uses `slide_id=0`.  This fixes the issue reported in the motivation.
2. Digging through the code for the source of the issue, I spotted an `if/elif` structure that was heavily relying on lengths of arrays.  I changed it in order to make it more robust.  I should note that now this relies on the words "search" and "missed" possibily being in the hdf5 keys: if the keys structure were to change, the first if condition could become always false.  However, this new structure is clear of surviving because of corner cases in array lengths.

## Standard information about the request
This is a: bug fix

This change affects: PyGRB

This change changes: result presentation, scientific output

## Testing performed
The run that raised the issue is available [here](https://ldas-jobs.ligo.caltech.edu/~francesco.pannarale/LVC/pygrb_tutorial/).
The new webpage, with the fixes, is instead [here](https://ldas-jobs.ligo.caltech.edu/~francesco.pannarale/LVC/pygrb_tutorial_3/).

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
