### PR TITLE
fix a bug to save model current stats for maxL polarization

### DIFF
--- a/pycbc/inference/models/marginalized_gaussian_noise.py
+++ b/pycbc/inference/models/marginalized_gaussian_noise.py
@@ -504,7 +504,7 @@ class MarginalizedPolarization(DistMarg, BaseGaussianNoise):
         # store the maxl polarization
         setattr(self._current_stats,
                 'maxl_polarization',
-                params['polarization'])
+                params['polarization'][idx])
         setattr(self._current_stats, 'maxl_loglr', maxl)
 
         # just store the maxl optimal snrsq


### PR DESCRIPTION
I think an index `idx` is missing to save the polarization that gives the maximum likelihood in the polarization marginalization model