### PR TITLE
Updating pegasus_sites configuration

### DIFF
--- a/pycbc/workflow/pegasus_sites.py
+++ b/pycbc/workflow/pegasus_sites.py
@@ -233,6 +233,9 @@ def add_osg_site(sitecat, cp):
                       value="False")
     site.add_profiles(Namespace.CONDOR, key="My.SingularityCleanEnv",
                       value="True")
+    # These numbers below correspond to the codes in table B.2 here:
+    # https://htcondor.readthedocs.io/en/24.0/codes-other-values/job-event-log-codes.html
+    # Values recommended by a condor expert
     site.add_profiles(Namespace.CONDOR, key="My.DAGManNodesMask",
                       value=r"\"0,1,2,4,5,7,8,9,10,11,12,13,16,17,24,27,35,36,40\"")
     site.add_profiles(Namespace.CONDOR, key="Requirements",

--- a/pycbc/workflow/pegasus_sites.py
+++ b/pycbc/workflow/pegasus_sites.py
@@ -97,18 +97,18 @@ def add_condorpool_symlink_site(sitecat, cp):
                       value="true")
     site.add_profiles(Namespace.PEGASUS, key='auxillary.local',
                       value="true")
-    site.add_profiles(Namespace.CONDOR, key="+OpenScienceGrid",
+    site.add_profiles(Namespace.CONDOR, key="My.OpenScienceGrid",
                       value="False")
     site.add_profiles(Namespace.CONDOR, key="should_transfer_files",
                       value="Yes")
     site.add_profiles(Namespace.CONDOR, key="when_to_transfer_output",
                       value="ON_EXIT_OR_EVICT")
     site.add_profiles(Namespace.CONDOR, key="getenv", value="True")
-    site.add_profiles(Namespace.CONDOR, key="+DESIRED_Sites",
+    site.add_profiles(Namespace.CONDOR, key="My.DESIRED_Sites",
                       value='"nogrid"')
-    site.add_profiles(Namespace.CONDOR, key="+IS_GLIDEIN",
+    site.add_profiles(Namespace.CONDOR, key="My.IS_GLIDEIN",
                       value='"False"')
-    site.add_profiles(Namespace.CONDOR, key="+flock_local",
+    site.add_profiles(Namespace.CONDOR, key="My.flock_local",
                       value="True")
     site.add_profiles(Namespace.DAGMAN, key="retry", value="2")
     sitecat.add_sites(site)
@@ -129,18 +129,18 @@ def add_condorpool_copy_site(sitecat, cp):
                       value=True)
     site.add_profiles(Namespace.PEGASUS, key='auxillary.local',
                       value="true")
-    site.add_profiles(Namespace.CONDOR, key="+OpenScienceGrid",
+    site.add_profiles(Namespace.CONDOR, key="My.OpenScienceGrid",
                       value="False")
     site.add_profiles(Namespace.CONDOR, key="should_transfer_files",
                       value="Yes")
     site.add_profiles(Namespace.CONDOR, key="when_to_transfer_output",
                       value="ON_EXIT_OR_EVICT")
     site.add_profiles(Namespace.CONDOR, key="getenv", value="True")
-    site.add_profiles(Namespace.CONDOR, key="+DESIRED_Sites",
+    site.add_profiles(Namespace.CONDOR, key="My.DESIRED_Sites",
                       value='"nogrid"')
-    site.add_profiles(Namespace.CONDOR, key="+IS_GLIDEIN",
+    site.add_profiles(Namespace.CONDOR, key="My.IS_GLIDEIN",
                       value='"False"')
-    site.add_profiles(Namespace.CONDOR, key="+flock_local",
+    site.add_profiles(Namespace.CONDOR, key="My.flock_local",
                       value="True")
     site.add_profiles(Namespace.DAGMAN, key="retry", value="2")
     sitecat.add_sites(site)
@@ -170,18 +170,18 @@ def add_condorpool_shared_site(sitecat, cp, local_path, local_url):
                       value="true")
     site.add_profiles(Namespace.PEGASUS, key='auxillary.local',
                       value="true")
-    site.add_profiles(Namespace.CONDOR, key="+OpenScienceGrid",
+    site.add_profiles(Namespace.CONDOR, key="My.OpenScienceGrid",
                       value="False")
     site.add_profiles(Namespace.CONDOR, key="should_transfer_files",
                       value="Yes")
     site.add_profiles(Namespace.CONDOR, key="when_to_transfer_output",
                       value="ON_EXIT_OR_EVICT")
     site.add_profiles(Namespace.CONDOR, key="getenv", value="True")
-    site.add_profiles(Namespace.CONDOR, key="+DESIRED_Sites",
+    site.add_profiles(Namespace.CONDOR, key="My.DESIRED_Sites",
                       value='"nogrid"')
-    site.add_profiles(Namespace.CONDOR, key="+IS_GLIDEIN",
+    site.add_profiles(Namespace.CONDOR, key="My.IS_GLIDEIN",
                       value='"False"')
-    site.add_profiles(Namespace.CONDOR, key="+flock_local",
+    site.add_profiles(Namespace.CONDOR, key="My.flock_local",
                       value="True")
     site.add_profiles(Namespace.DAGMAN, key="retry", value="2")
     # Need to set PEGASUS_HOME
@@ -223,21 +223,24 @@ def add_osg_site(sitecat, cp):
                       value="ON_SUCCESS")
     site.add_profiles(Namespace.CONDOR, key="success_exit_code",
                       value="0")
-    site.add_profiles(Namespace.CONDOR, key="+OpenScienceGrid",
+    site.add_profiles(Namespace.CONDOR, key="My.OpenScienceGrid",
                       value="True")
     site.add_profiles(Namespace.CONDOR, key="getenv",
                       value="False")
-    site.add_profiles(Namespace.CONDOR, key="+InitializeModulesEnv",
+    site.add_profiles(Namespace.CONDOR, key="ulog_execute_attrs",
+                      value="GLIDEIN_Site")
+    site.add_profiles(Namespace.CONDOR, key="My.InitializeModulesEnv",
                       value="False")
-    site.add_profiles(Namespace.CONDOR, key="+SingularityCleanEnv",
+    site.add_profiles(Namespace.CONDOR, key="My.SingularityCleanEnv",
                       value="True")
+    site.add_profiles(Namespace.CONDOR, key="My.DAGManNodesMask",
+                      value=r"\"0,1,2,4,5,7,8,9,10,11,12,13,16,17,24,27,35,36,40\"")
     site.add_profiles(Namespace.CONDOR, key="Requirements",
                       value="(HAS_SINGULARITY =?= TRUE) && "
-                            "(HAS_LIGO_FRAMES =?= True) && "
                             "(IS_GLIDEIN =?= True)")
     cvmfs_loc = '"/cvmfs/singularity.opensciencegrid.org/pycbc/pycbc-el8:v'
     cvmfs_loc += sing_version + '"'
-    site.add_profiles(Namespace.CONDOR, key="+SingularityImage",
+    site.add_profiles(Namespace.CONDOR, key="My.SingularityImage",
                       value=cvmfs_loc)
     # On OSG failure rate is high
     site.add_profiles(Namespace.DAGMAN, key="retry", value="4")


### PR DESCRIPTION
We have recently conducted an exercise where we examined in detail an OSG PyCBC workflow, and identified all of the failure modes, highlighting some fail modes, including a few on our end. The discussion is here https://git.ligo.org/computing/helpdesk/-/issues/7042  It's probably behind the LVK paywall, but I don't there's anything confidential here so could probably share as needed.

There's some reasonably minor changes coming out of this for production workflows, but largely this adds in extra debugging in the log files to make debugging OSG workflows easier in the future. In particular:

* We remove `HAS_LIGO_FRAMES`. It's not set in many places, and we don't need it. Having this present will *massively* reduce the potential to run on OSG.
* Changing all `+ValueForCondor` settings to `My.ValueForCondor` as current recommendation (the `+` syntax is deprecated).
* Adding two new settings on OSG to log more clearly what site the job is running on, and when input/output file transfer begins/ends (input file transfer is a clear issue in some cases, and would like this to be logged). (see git.ligo.org link for more detail on this, but largely it turns on logging of when transfers start/stop and writes the site name into the executing log message so we know more easily where stuff is running ... We may still tweak this a little bit).

The test suite will not do much useful here, but this has been tested on an example workflow on LDG.