### PR TITLE
PyGRB: minor fixes to workflow generator 

### DIFF
--- a/bin/pygrb/pycbc_make_offline_grb_workflow
+++ b/bin/pygrb/pycbc_make_offline_grb_workflow
@@ -252,6 +252,7 @@ if wflow.cp.has_option("workflow-segments", "segments-vetoes"):
 for ifo in ifos:
     avail_segs = select_segments_by_definer(veto_file.storage_path, ifo=ifo)
     avail_segs.coalesce()
+    # In case no relevant vetoes are available, avail_segs becomes an empty list
     if len(avail_segs) > 0:
         vetoed_segs = offSrc[ifo] - avail_segs
         if onSrc[ifo].intersects(vetoed_segs):
@@ -263,13 +264,6 @@ for ifo in ifos:
                 ifo
             )
             sys.exit()
-    else:
-        vetoed_segs = offSrc[ifo]
-        logging.info(
-                  "%s has no vetoed segments in the onsource timewindow %s.",
-                  ifo,
-                  onSrc[ifo][0][:]
-                  )
 
 # Generate sky grid if needed
 skygrid_file = None

--- a/bin/pygrb/pycbc_make_offline_grb_workflow
+++ b/bin/pygrb/pycbc_make_offline_grb_workflow
@@ -252,16 +252,24 @@ if wflow.cp.has_option("workflow-segments", "segments-vetoes"):
 for ifo in ifos:
     avail_segs = select_segments_by_definer(veto_file.storage_path, ifo=ifo)
     avail_segs.coalesce()
-    vetoed_segs = offSrc[ifo] - avail_segs
-    if onSrc[ifo].intersects(vetoed_segs):
-        intersection = onSrc[ifo] & vetoed_segs
-        logging.error(
-            "The onsource %s contains the time %s that is vetoed in %s.",
-            onSrc[ifo][0][:],
-            intersection,
-            ifo
-        )
-        sys.exit()
+    if len(avail_segs) > 0:
+        vetoed_segs = offSrc[ifo] - avail_segs
+        if onSrc[ifo].intersects(vetoed_segs):
+            intersection = onSrc[ifo] & vetoed_segs
+            logging.error(
+                "The onsource %s contains the time %s that is vetoed in %s.",
+                onSrc[ifo][0][:],
+                intersection,
+                ifo
+            )
+            sys.exit()
+    else:
+        vetoed_segs = offSrc[ifo]
+        logging.info(
+                  "%s has no vetoed segments in the onsource timewindow %s.",
+                  ifo,
+                  onSrc[ifo][0][:]
+                  )
 
 # Generate sky grid if needed
 skygrid_file = None

--- a/pycbc/workflow/jobsetup.py
+++ b/pycbc/workflow/jobsetup.py
@@ -687,8 +687,8 @@ class PyCBCMultiInspiralExecutable(Executable):
 
         # If doing single IFO search, make sure slides are disabled
         if len(self.ifo_list) < 2 and \
-                (node.get_opt('--do-short-slides') is not None or \
-                 node.get_opt('--short-slide-offset') is not None):
+                (self.get_opt('--do-short-slides') is not None or \
+                 self.get_opt('--short-slide-offset') is not None):
             raise ValueError("Cannot run with time slides in a single IFO "
                              "configuration! Please edit your configuration "
                              "file accordingly.")


### PR DESCRIPTION
## Standard information about the request

<!--- Some basic info about the change (delete as appropriate) -->
This is a: bug fix.

<!--- What codes will this affect? (delete as apropriate)
If you do not know which areas will be affected, please ask in the gwastro #pycbc-code slack
-->
This change affects: PyGRB

<!--- What code areas will this affect? (delete as apropriate) -->
This change changes: PyGRB workflow generation.

## Motivation
<!--- Describe why your changes are being made -->

This PR contains 2 separate bugfixes uncovered while testing the code on single detector GRB runs using O4a data.

## Contents

1. In the context of handling Veto definer files, `pycbc_make_offline_grb_workflow` checks for veto segments present in the onsource timewindow, i.e. around the GRB trigger, and throws an error if that's the case to avoid submitting jobs and  end up wasting CPU hours.

Currently lines [252-264](https://github.com/gwastro/pycbc/blob/a83736d49ffdf21b4fe3c6630e1067ff207981d6/bin/pygrb/pycbc_make_offline_grb_workflow#L252) lack an if statement to avoid operating with an empty list, when `avail_segs` has no elements. 

2. Single detector runs were not tested in the past. However by recently doing so, we uncovered a minor bug in `pycbc/workflow/jobsetup.py`. Specifically lines [690&691](https://github.com/gwastro/pycbc/blob/a83736d49ffdf21b4fe3c6630e1067ff207981d6/pycbc/workflow/jobsetup.py#L690) were mistakenly using the method `get_opts` from the wrong object.


