### PR TITLE
Add a colour map for consistent coincidence colors

### DIFF
--- a/pycbc/results/color.py
+++ b/pycbc/results/color.py
@@ -21,84 +21,85 @@ _source_color_map = {
 }
 
 _coinc_color_map = {
-    'H1L1': '#caff00',
-    'H1V1': '#088e49',
-    'L1V1': '#00ffe3',
-    'H1L1V1': '#ca9210',
-    'H1K1': '#0cd75d',
-    'K1L1': '#df9aff',
-    'H1K1L1': '#ff866d',
-    'K1V1': '#6d61ff',
-    'H1K1V1': '#b65910',
-    'K1L1V1': '#00c2ce',
-    'H1K1L1V1': '#82a200',
-    'H1I1': '#20869e',
-    'I1L1': '#b2baff',
-    'H1I1L1': '#4db68e',
-    'I1V1': '#8a7520',
-    'H1I1V1': '#92e7ff',
-    'I1L1V1': '#928ad2',
-    'H1I1L1V1': '#ffe77d',
-    'I1K1': '#c2c600',
-    'H1I1K1': '#10ff00',
-    'I1K1L1': '#087ddb',
-    'H1I1K1L1': '#5dffa6',
-    'I1K1V1': '#f36100',
-    'H1I1K1V1': '#ce5dff',
-    'I1K1L1V1': '#00927d',
-    'H1I1K1L1V1': '#00ae31',
-    'G1H1': '#0000aa',
-    'G1L1': '#650400',
-    'G1H1L1': '#550075',
-    'G1V1': '#004500',
-    'G1H1V1': '#615d61',
-    'G1L1V1': '#a69a96',
-    'G1H1L1V1': '#ebe3eb',
-    'G1K1': '#593d00',
-    'G1H1K1': '#00495d',
-    'G1K1L1': '#4d498e',
-    'G1H1K1L1': '#28614d',
-    'G1K1V1': '#1035ff',
-    'G1H1K1V1': '#efbe9e',
-    'G1K1L1V1': '#824539',
-    'G1H1K1L1V1': '#a61400',
-    'G1I1': '#201c49',
-    'G1H1I1': '#aac6be',
-    'G1I1L1': '#8200e7',
-    'G1H1I1L1': '#496900',
-    'G1I1V1': '#718269',
-    'G1H1I1V1': '#86a2b6',
-    'G1I1L1V1': '#493951',
-    'G1H1I1L1V1': '#a2aa6d',
-    'G1I1K1': '#391804',
-    'G1H1I1K1': '#aa7165',
-    'G1I1K1L1': '#657196',
-    'G1H1I1K1L1': '#00392d',
-    'G1I1K1V1': '#c6b2ce',
-    'G1H1I1K1V1': '#c2f7db',
-    'G1I1K1L1V1': '#414535',
-    'G1H1I1K1L1V1': '#242800',
+    'H1L1': '#caff00',  # lime green
+    'H1V1': '#088e49',  # dark green
+    'L1V1': '#00ffe3',  # cyan
+    'H1L1V1': '#ca9210',  # brown
+    'H1K1': '#0cd75d',  # bright green
+    'K1L1': '#df9aff',  # light purple
+    'H1K1L1': '#ff866d',  # coral
+    'K1V1': '#6d61ff',  # blue violet
+    'H1K1V1': '#b65910',  # sienna
+    'K1L1V1': '#00c2ce',  # turquoise
+    'H1K1L1V1': '#82a200',  # olive
+    'H1I1': '#20869e',  # teal
+    'I1L1': '#b2baff',  # light blue
+    'H1I1L1': '#4db68e',  # sea green
+    'I1V1': '#8a7520',  # olive drab
+    'H1I1V1': '#92e7ff',  # sky blue
+    'I1L1V1': '#928ad2',  # medium purple
+    'H1I1L1V1': '#ffe77d',  # light yellow
+    'I1K1': '#c2c600',  # chartreuse
+    'H1I1K1': '#10ff00',  # neon green
+    'I1K1L1': '#087ddb',  # dodger blue
+    'H1I1K1L1': '#5dffa6',  # aquamarine
+    'I1K1V1': '#f36100',  # orange red
+    'H1I1K1V1': '#ce5dff',  # medium orchid
+    'I1K1L1V1': '#00927d',  # dark cyan
+    'H1I1K1L1V1': '#00ae31',  # forest green
+    'G1H1': '#0000aa',  # blue
+    'G1L1': '#650400',  # dark red
+    'G1H1L1': '#550075',  # indigo
+    'G1V1': '#004500',  # dark green
+    'G1H1V1': '#615d61',  # gray
+    'G1L1V1': '#a69a96',  # light gray
+    'G1H1L1V1': '#ebe3eb',  # very light gray
+    'G1K1': '#593d00',  # dark brown
+    'G1H1K1': '#00495d',  # dark cyan
+    'G1K1L1': '#4d498e',  # dark slate blue
+    'G1H1K1L1': '#28614d',  # dark green
+    'G1K1V1': '#1035ff',  # blue
+    'G1H1K1V1': '#efbe9e',  # light brown
+    'G1K1L1V1': '#824539',  # brown
+    'G1H1K1L1V1': '#a61400',  # red
+    'G1I1': '#201c49',  # dark slate blue
+    'G1H1I1': '#aac6be',  # light cyan
+    'G1I1L1': '#8200e7',  # purple
+    'G1H1I1L1': '#496900',  # olive drab
+    'G1I1V1': '#718269',  # dark olive green
+    'G1H1I1V1': '#86a2b6',  # light steel blue
+    'G1I1L1V1': '#493951',  # dark slate gray
+    'G1H1I1L1V1': '#a2aa6d',  # dark khaki
+    'G1I1K1': '#391804',  # dark brown
+    'G1H1I1K1': '#aa7165',  # rosy brown
+    'G1I1K1L1': '#657196',  # slate gray
+    'G1H1I1K1L1': '#00392d',  # dark green
+    'G1I1K1V1': '#c6b2ce',  # thistle
+    'G1H1I1K1V1': '#c2f7db',  # light green
+    'G1I1K1L1V1': '#414535',  # dark olive green
+    'G1H1I1K1L1V1': '#242800',  # olive
 }
 
 def ifo_color(ifo):
-    """ Return a color defining the IFO of interest
+    """ Return a color for the IFO
     """
     return _ifo_color_map[ifo]
 
 
 def source_color(source):
-    """ Return a standard color to indicate the source type """
+    """ Return a color to indicate the source type """
     return _source_color_map[source]
 
 def coinc_color(coinc):
     """ Return a color for the coincidence type 
+
     Parameters:
-    coinc: tuple
-        A tuple of strings for the IFOs in the coincidence.
+    coinc: string
+        A strings for the IFOs in the coincidence.
         
     Returns:
     string
-        The color from the corresponding color map
+        The RGB color for the corresponding coinc
     """
     if len(coinc) == 1 and coinc in _ifo_color_map:
         return _ifo_color_map[coinc]

--- a/pycbc/results/color.py
+++ b/pycbc/results/color.py
@@ -20,10 +20,87 @@ _source_color_map = {
     'BHG': '#C6C29E'    # dark khaki
 }
 
+_coinc_color_map = {
+    'H1L1': '#caff00',
+    'H1V1': '#088e49',
+    'L1V1': '#00ffe3',
+    'H1L1V1': '#ca9210',
+    'H1K1': '#0cd75d',
+    'K1L1': '#df9aff',
+    'H1K1L1': '#ff866d',
+    'K1V1': '#6d61ff',
+    'H1K1V1': '#b65910',
+    'K1L1V1': '#00c2ce',
+    'H1K1L1V1': '#82a200',
+    'H1I1': '#20869e',
+    'I1L1': '#b2baff',
+    'H1I1L1': '#4db68e',
+    'I1V1': '#8a7520',
+    'H1I1V1': '#92e7ff',
+    'I1L1V1': '#928ad2',
+    'H1I1L1V1': '#ffe77d',
+    'I1K1': '#c2c600',
+    'H1I1K1': '#10ff00',
+    'I1K1L1': '#087ddb',
+    'H1I1K1L1': '#5dffa6',
+    'I1K1V1': '#f36100',
+    'H1I1K1V1': '#ce5dff',
+    'I1K1L1V1': '#00927d',
+    'H1I1K1L1V1': '#00ae31',
+    'G1H1': '#0000aa',
+    'G1L1': '#650400',
+    'G1H1L1': '#550075',
+    'G1V1': '#004500',
+    'G1H1V1': '#615d61',
+    'G1L1V1': '#a69a96',
+    'G1H1L1V1': '#ebe3eb',
+    'G1K1': '#593d00',
+    'G1H1K1': '#00495d',
+    'G1K1L1': '#4d498e',
+    'G1H1K1L1': '#28614d',
+    'G1K1V1': '#1035ff',
+    'G1H1K1V1': '#efbe9e',
+    'G1K1L1V1': '#824539',
+    'G1H1K1L1V1': '#a61400',
+    'G1I1': '#201c49',
+    'G1H1I1': '#aac6be',
+    'G1I1L1': '#8200e7',
+    'G1H1I1L1': '#496900',
+    'G1I1V1': '#718269',
+    'G1H1I1V1': '#86a2b6',
+    'G1I1L1V1': '#493951',
+    'G1H1I1L1V1': '#a2aa6d',
+    'G1I1K1': '#391804',
+    'G1H1I1K1': '#aa7165',
+    'G1I1K1L1': '#657196',
+    'G1H1I1K1L1': '#00392d',
+    'G1I1K1V1': '#c6b2ce',
+    'G1H1I1K1V1': '#c2f7db',
+    'G1I1K1L1V1': '#414535',
+    'G1H1I1K1L1V1': '#242800',
+}
 
 def ifo_color(ifo):
+    """ Return a color defining the IFO of interest
+    """
     return _ifo_color_map[ifo]
 
 
 def source_color(source):
+    """ Return a standard color to indicate the source type """
     return _source_color_map[source]
+
+def coinc_color(coinc):
+    """ Return a color for the coincidence type 
+    Parameters:
+    coinc: tuple
+        A tuple of strings for the IFOs in the coincidence.
+        
+    Returns:
+    string
+        The color from the corresponding color map
+    """
+    if len(coinc) == 1 and coinc in _ifo_color_map:
+        return _ifo_color_map[coinc]
+    else:
+        return _coinc_color_map[coinc]


### PR DESCRIPTION
As we are now making plots with difference coincidences on one chart, I thought we should make a consistent chart to refer to each detector combination.

## Standard information about the request

This is a new feature

This change changes result presentation / plotting

This change follows style guidelines (See e.g. [PEP8](https://peps.python.org/pep-0008/)), has been proposed using the [contribution guidelines](https://github.com/gwastro/pycbc/blob/master/CONTRIBUTING.md)

## Contents
Add a dictionary of colour choices and a function to wrap it.

How this is made is probably the more interesting thing:

This was made from combining the `_ifo_color_map` colors and generating a maximally-distinct colour based on a few things.
I set this up by starting with an IFO-precedence list: H1 L1 V1 K1 I1 G1
I then created coincidences containing the most-preferred IFOs and extended the color palette using [glasbey](https://glasbey.readthedocs.io/en/latest/) to maximise the distinctness of the new color(s).

In words:
 - From H (red) and L (blue) colors, I got the maximally distinct color (lime green) for HL
 - I then added in V, and got the maximally-distinct set of colors which would extend H, L, V and HL's already-defined colorset, and used it to get the HV, LV and HLV colours
 - This is repeated in turn for K, I and then G
 - I then asked github copilot to name all the colors (though I don't really know what 'olive drab' and 'rosy brown' are)

The code I ran is here:
```
def generate_precedence_color_map(n_ifos=None):
    # Create a color map which adds in the coincidences containing ifos in the order of ifo_precedence
    # This means that the coincs containing the most preferred IFOs will be colored first, and the less preferred IFOs will be colored last
    # As a result the most-used combinations will be maximally distinguishable
    if n_ifos == 1:
        # Single-IFO "coincs" just use the color of the ifo from the original _ifo_color_map
        return {ifo_precedence[0]: _ifo_color_map[ifo_precedence[0]]}
    
    n_ifos = n_ifos if n_ifos is not None else len(ifo_precedence)
    # Generate the color map for the IFOs up to the IFO before this one
    color_map = generate_precedence_color_map(n_ifos=n_ifos-1)
    # Now we add the coincidences formed with the 
    new_coincs = []
    for k in list(color_map.keys()) + ['']:
        # Add the new IFO into the key in alphabetical order
        # split the string into each IFO, these will be 2 characters long
        ifos = [k[i:i+2] for i in range(0, len(k), 2)]
        # Add the new IFO into the list, put it into alpabetical order, and rejoin the string
        new_coinc = ''.join(sorted(ifos + [ifo_precedence[n_ifos-1]]))
        if new_coinc in _ifo_color_map:
            color_map[new_coinc] = _ifo_color_map[new_coinc]
        else:
            new_coincs.append(new_coinc)

    new_palette = glasbey.extend_palette(list(color_map.values()), palette_size=len(new_coincs) + len(color_map))
    color_map.update({s: new_palette[i + len(color_map)] for i, s in enumerate(new_coincs)})=
    return color_map

precedence_cmap = generate_precedence_color_map()
# Remove the single-ifo combinations
precedence_cmap = {k: v for k, v in precedence_cmap.items() if k not in _ifo_color_map}
```

I didn't want to add the code directly because
1. It can take a while to run the same thing every time
2. I didn't want to add a new dependency

Right now, nothing links to this function/dictionary, so I expect all tests to pass, but we can use this for different coincs on the same plot

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
