### PR TITLE
Unpin lalsuite version

### DIFF
--- a/.github/workflows/basic-tests.yml
+++ b/.github/workflows/basic-tests.yml
@@ -29,12 +29,17 @@ jobs:
     - name: installing auxiliary data files
       run: |
         GIT_LFS_SKIP_SMUDGE=1 git clone https://git.ligo.org/lscsoft/lalsuite-extra
+        GIT_LFS_SKIP_SMUDGE=1 git clone https://git.ligo.org/waveforms/software/lalsuite-waveform-data
         cd lalsuite-extra
         git lfs pull -I "data/lalsimulation/SEOBNRv2ROM_*.dat"
         git lfs pull -I "data/lalsimulation/*ChirpTime*.dat"
         git lfs pull -I "data/lalsimulation/SEOBNRv4ROM_v2.0.hdf5"
         mv data/lalsimulation/* ../
         cd ../
+        cd lalsuite-waveform-data
+        git lfs pull -I "waveform_data/SEOBNRv4ROM_v3.0.hdf5"
+        mv waveform_data/SEOBNRv4ROM_v3.0.hdf5 ../
+        cd ..
     - name: run pycbc test suite
       run: |
         export LAL_DATA_PATH=$PWD

--- a/.github/workflows/basic-tests.yml
+++ b/.github/workflows/basic-tests.yml
@@ -28,8 +28,8 @@ jobs:
         pip install tox pip setuptools --upgrade
     - name: installing auxiliary data files
       run: |
-        curl --show-error --silent --remote-name https://git.ligo.org/lscsoft/lalsuite-extra/-/raw/master/data/lalsimulation/SEOBNRv4ROM_v2.0.hdf5 > SEOBNRv4ROM_v2.0.hdf5
-        curl --show-error --silent --remote-name  https://git.ligo.org/waveforms/software/lalsuite-waveform-data/-/raw/main/waveform_data/SEOBNRv4ROM_v3.0.hdf5 > SEOBNRv4ROM_v3.0.hdf5
+        curl --show-error --silent --remote-name https://git.ligo.org/lscsoft/lalsuite-extra/-/raw/master/data/lalsimulation/SEOBNRv4ROM_v2.0.hdf5
+        curl --show-error --silent --remote-name  https://git.ligo.org/waveforms/software/lalsuite-waveform-data/-/raw/main/waveform_data/SEOBNRv4ROM_v3.0.hdf5
     - name: run pycbc test suite
       run: |
         export LAL_DATA_PATH=$PWD

--- a/.github/workflows/basic-tests.yml
+++ b/.github/workflows/basic-tests.yml
@@ -29,17 +29,13 @@ jobs:
     - name: installing auxiliary data files
       run: |
         GIT_LFS_SKIP_SMUDGE=1 git clone https://git.ligo.org/lscsoft/lalsuite-extra
-        GIT_LFS_SKIP_SMUDGE=1 git clone https://git.ligo.org/waveforms/software/lalsuite-waveform-data
         cd lalsuite-extra
         git lfs pull -I "data/lalsimulation/SEOBNRv2ROM_*.dat"
         git lfs pull -I "data/lalsimulation/*ChirpTime*.dat"
         git lfs pull -I "data/lalsimulation/SEOBNRv4ROM_v2.0.hdf5"
         mv data/lalsimulation/* ../
         cd ../
-        cd lalsuite-waveform-data
-        git lfs pull -I "waveform_data/SEOBNRv4ROM_v3.0.hdf5"
-        mv waveform_data/SEOBNRv4ROM_v3.0.hdf5 ../
-        cd ..
+        curl https://git.ligo.org/waveforms/software/lalsuite-waveform-data/-/raw/main/waveform_data/SEOBNRv4ROM_v3.0.hdf5 > SEOBNRv4ROM_v3.0.hdf5
     - name: run pycbc test suite
       run: |
         export LAL_DATA_PATH=$PWD

--- a/.github/workflows/basic-tests.yml
+++ b/.github/workflows/basic-tests.yml
@@ -24,18 +24,12 @@ jobs:
     - name: installing system packages
       run: |
         sudo apt-get -o Acquire::Retries=3 update
-        sudo apt-get -o Acquire::Retries=3 install *fftw3* mpi intel-mkl* git-lfs graphviz
+        sudo apt-get -o Acquire::Retries=3 install *fftw3* mpi intel-mkl* graphviz
         pip install tox pip setuptools --upgrade
     - name: installing auxiliary data files
       run: |
-        GIT_LFS_SKIP_SMUDGE=1 git clone https://git.ligo.org/lscsoft/lalsuite-extra
-        cd lalsuite-extra
-        git lfs pull -I "data/lalsimulation/SEOBNRv2ROM_*.dat"
-        git lfs pull -I "data/lalsimulation/*ChirpTime*.dat"
-        git lfs pull -I "data/lalsimulation/SEOBNRv4ROM_v2.0.hdf5"
-        mv data/lalsimulation/* ../
-        cd ../
-        curl https://git.ligo.org/waveforms/software/lalsuite-waveform-data/-/raw/main/waveform_data/SEOBNRv4ROM_v3.0.hdf5 > SEOBNRv4ROM_v3.0.hdf5
+        curl --show-error --silent --remote-name https://git.ligo.org/lscsoft/lalsuite-extra/-/raw/master/data/lalsimulation/SEOBNRv4ROM_v2.0.hdf5 > SEOBNRv4ROM_v2.0.hdf5
+        curl --show-error --silent --remote-name  https://git.ligo.org/waveforms/software/lalsuite-waveform-data/-/raw/main/waveform_data/SEOBNRv4ROM_v3.0.hdf5 > SEOBNRv4ROM_v3.0.hdf5
     - name: run pycbc test suite
       run: |
         export LAL_DATA_PATH=$PWD

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,9 +10,7 @@ jinja2
 mpld3>=0.3
 beautifulsoup4>=4.6.0
 cython
-# lalsuite 7.25 requires a data file which is not public
-#- pinning temporarily until it is
-lalsuite!=7.2,<7.25
+lalsuite!=7.2
 lscsoft-glue>=1.59.3
 igwn-segments
 tqdm


### PR DESCRIPTION
The various data files needed for lalsuite are now available publically again (lalsuite will inform the user of this if the user does not have the files in their path).

Therefore I unpin lalsuite. I've dumped the new SEOBNR file into our existing CVMFS directory so the CI will need no more changes.

To confirm SEOBNRv4_ROM_v3 is identical to SEOBNRv4_ROM_v2 (it just contains a certain bit of metadata that is irrelevant for us).

This would be needed for #5019 (and a lalsuite release that uses igwn-ligolw, if that doesn't already exist).