### PR TITLE
Rename I1 to A1 everywhere

### DIFF
--- a/bin/plotting/pycbc_page_segplot
+++ b/bin/plotting/pycbc_page_segplot
@@ -26,6 +26,7 @@ from itertools import cycle
 from pycbc import add_common_pycbc_options, init_logging
 from pycbc.events.veto import get_segment_definer_comments
 from pycbc.results.mpld3_utils import LineTooltip
+from pycbc.results.color import ifo_color
 from pycbc.workflow import SegFile
 
 # parse command line
@@ -64,12 +65,12 @@ def timestr(s):
 
 # FIXME set colors
 color_cycle = {}
-color_cycle['H1'] = cycle(['#ee0000', '#8c000f', '#840000', '#653700'])
-color_cycle['L1'] = cycle(['#4ba6ff', '#d0fefe', '#0165fc', '#001146'])
-color_cycle['V1'] = cycle(['#9b59b6', '#c20078', '#9a0eea', '#7e1e9c'])
-color_cycle['K1'] = cycle(['#ffb200', '#fdde6c', '#fdb915', '#d8863b'])
-color_cycle['I1'] = cycle(['#b0dd8b', 'ForestGreen', 'DarkGreen', 'DarkOliveGreen'])
-color_cycle['G1'] = cycle(['#222222', '#d8dcd6', '#363737', '#000000'])
+color_cycle['H1'] = cycle([ifo_color('H1'), '#8c000f', '#840000', '#653700'])
+color_cycle['L1'] = cycle([ifo_color('L1'), '#d0fefe', '#0165fc', '#001146'])
+color_cycle['V1'] = cycle([ifo_color('V1'), '#c20078', '#9a0eea', '#7e1e9c'])
+color_cycle['K1'] = cycle([ifo_color('K1'), '#fdde6c', '#fdb915', '#d8863b'])
+color_cycle['A1'] = cycle([ifo_color('A1'), 'ForestGreen', 'DarkGreen', 'DarkOliveGreen'])
+color_cycle['G1'] = cycle([ifo_color('G1'), '#d8dcd6', '#363737', '#000000'])
 
 # set default plugins
 mpld3.plugins.DEFAULT_PLUGINS = []

--- a/examples/search/analysis.ini
+++ b/examples/search/analysis.ini
@@ -56,7 +56,7 @@ plot-throughput =
 do-trigger-fitting =
 
 [workflow-coincidence-full_data]
-timeslide-precedence = H1, L1, V1, K1, I1
+timeslide-precedence = H1, L1, V1, K1, A1
 parallelization-factor = 1
 
 [workflow-coincidence-injections]

--- a/pycbc/detector/ground.py
+++ b/pycbc/detector/ground.py
@@ -219,7 +219,7 @@ class Detector(object):
         Parameters
         ----------
         detector_name: str
-            The two-character detector string, i.e. H1, L1, V1, K1, I1
+            The two-character detector string, i.e. H1, L1, V1, K1, A1
         reference_time: float
             Default is time of GW150914. In this case, the earth's rotation
         will be estimated from a reference time. If 'None', we will

--- a/pycbc/results/color.py
+++ b/pycbc/results/color.py
@@ -5,7 +5,7 @@ _ifo_color_map = {
     'G1': '#222222',  # dark gray
     'K1': '#ffb200',  # yellow/orange
     'H1': '#ee0000',  # red
-    'I1': '#b0dd8b',  # light green
+    'A1': '#b0dd8b',  # light green
     'L1': '#4ba6ff',  # blue
     'V1': '#9b59b6',  # magenta/purple
 }

--- a/test/test_detector.py
+++ b/test/test_detector.py
@@ -67,7 +67,7 @@ class TestDetector(unittest.TestCase):
 
     def test_response_matrix(self):
         import lal
-        for ifo in ['H1', 'L1', 'V1', 'K1', 'I1']:
+        for ifo in ['H1', 'L1', 'V1', 'K1', 'A1']:
             ref_resp = lal.cached_detector_by_prefix[ifo].response
             resp = det.Detector(ifo).response
             self.assertAlmostEqual((ref_resp - resp).max(), 0, places=6)

--- a/test/test_detector.py
+++ b/test/test_detector.py
@@ -68,7 +68,12 @@ class TestDetector(unittest.TestCase):
     def test_response_matrix(self):
         import lal
         for ifo in ['H1', 'L1', 'V1', 'K1', 'A1']:
-            ref_resp = lal.cached_detector_by_prefix[ifo].response
+            if ifo == 'A1':
+                # FIXME: patch until the I1-A1 rename is fixed in lalsuite
+                ref_resp = lal.cached_detector_by_prefix["I1"].response
+            else:
+                ref_resp = lal.cached_detector_by_prefix[ifo].response
+
             resp = det.Detector(ifo).response
             self.assertAlmostEqual((ref_resp - resp).max(), 0, places=6)
 

--- a/test/test_io_gracedb.py
+++ b/test/test_io_gracedb.py
@@ -52,7 +52,7 @@ class TestIOGraceDB(unittest.TestCase):
                          'spin2y': 0,
                          'spin2z': 0}
 
-        self.possible_ifos = 'H1 L1 V1 K1 I1'.split()
+        self.possible_ifos = 'H1 L1 V1 K1 A1'.split()
 
     def do_test(self, n_ifos, n_ifos_extra):
         # choose a random selection of interferometers


### PR DESCRIPTION
LIGO India's short code is now changed to A1, so we change I1 to A1 wherever it is in the codebase.

It looks like I1 still works as legacy, but A1 will be better going forward.

While editing this, I listened to the '90s boyband A1 [their best song](https://www.youtube.com/watch?v=zPKvxYrgBV4)

## Testing performed
Manually ran the tests which I expect to change from this, they all pass

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
