### PR TITLE
Choice of clustering in pycbc_add_statmap

### DIFF
--- a/bin/all_sky_search/pycbc_add_statmap
+++ b/bin/all_sky_search/pycbc_add_statmap
@@ -37,6 +37,8 @@ parser.add_argument('--veto-window', type=float, default=0.1,
     help="Time around each zerolag trigger to window out [default=.1s]")
 parser.add_argument('--cluster-window', type=float,
     help="Time interval to cluster coincident events over")
+parser.add_argument('--cluster-stat', default='stat',
+    help="What ranking to use when clustering zerolag [default='stat']")
 parser.add_argument('--output-coinc-types', action='store_true',
     help="Create additional foreground dataset recording coinc type for each"
          " event. Mainly for debugging")
@@ -247,7 +249,7 @@ fg_times = (f['foreground/%s/time' % ifo][:] for ifo in all_ifos)
 
 # Cluster by statistic value. Currently only clustering zerolag,
 # i.e. foreground, so set all timeslide_ids to zero
-cidx = pycbc.events.cluster_coincs_multiifo(f['foreground/stat'][:],
+cidx = pycbc.events.cluster_coincs_multiifo(f[f'foreground/{args.cluster_stat}'][:],
                                             fg_times,
                                             np.zeros(n_triggers), 0,
                                             args.cluster_window)

--- a/bin/all_sky_search/pycbc_add_statmap
+++ b/bin/all_sky_search/pycbc_add_statmap
@@ -247,7 +247,7 @@ for ifo in all_ifos:
 # fg_times is a tuple of trigger time arrays
 fg_times = (f['foreground/%s/time' % ifo][:] for ifo in all_ifos)
 
-# Cluster by statistic value. Currently only clustering zerolag,
+# Cluster using the chosen method. Currently only clustering zerolag,
 # i.e. foreground, so set all timeslide_ids to zero
 cidx = pycbc.events.cluster_coincs_multiifo(f[f'foreground/{args.cluster_stat}'][:],
                                             fg_times,

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,7 +40,7 @@ emcee==2.2.1
 dynesty
 
 # For building documentation
-Sphinx>=4.2.0
+Sphinx>=4.2.0,!=8.2.0
 sphinx-carousel
 sphinx-rtd-theme>=1.0.0
 sphinxcontrib-programoutput>=0.11

--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,7 @@ conda_deps =
     mysqlclient
     ; these packages don't install cleanly with pip, conda has patches
     python-ligo-lw
+    blas=*=openblas
 
 [bbhx]
 deps =


### PR DESCRIPTION
Don't hard-code 'stat' as the zerolag (foreground) clustering quantity for add statmap.  Useful to investigate other choices eg ifar / ifar_exc 

## Standard information about the request

<!--- Some basic info about the change (delete as appropriate) -->
This is a: feature enhancement

<!--- What codes will this affect? (delete as appropriate)
This change affects: the offline search (but only if a non-default option is chosen)

<!--- What code areas will this affect? (delete as appropriate) -->
This change changes: scientific output (with a non-default option)

<!--- Some things which help with code management (delete as appropriate) -->
This change: has appropriate unit tests, follows style guidelines (See e.g. [PEP8](https://peps.python.org/pep-0008/)), has been proposed using the [contribution guidelines](https://github.com/gwastro/pycbc/blob/master/CONTRIBUTING.md)

<!--- Notes about the effect of this change -->
This change will: not break anything hopefully

## Motivation
<!--- Describe why your changes are being made -->
In a recent tuning investigation I wanted to compare the effect of clustering with ifar vs 'stat'

## Contents
One extra option

## Testing performed
Works when run by hand on some exclude_zerolag files
