### PR TITLE
Avoid nan values in network volume term

### DIFF
--- a/.github/workflows/basic-tests.yml
+++ b/.github/workflows/basic-tests.yml
@@ -24,17 +24,12 @@ jobs:
     - name: installing system packages
       run: |
         sudo apt-get -o Acquire::Retries=3 update
-        sudo apt-get -o Acquire::Retries=3 install *fftw3* mpi intel-mkl* git-lfs graphviz
-        pip install "tox<4.0.0" pip setuptools --upgrade
+        sudo apt-get -o Acquire::Retries=3 install *fftw3* mpi intel-mkl* graphviz
+        pip install tox pip setuptools --upgrade
     - name: installing auxiliary data files
       run: |
-        GIT_LFS_SKIP_SMUDGE=1 git clone https://git.ligo.org/lscsoft/lalsuite-extra
-        cd lalsuite-extra
-        git lfs pull -I "data/lalsimulation/SEOBNRv2ROM_*.dat"
-        git lfs pull -I "data/lalsimulation/*ChirpTime*.dat"
-        git lfs pull -I "data/lalsimulation/SEOBNRv4ROM_v2.0.hdf5"
-        mv data/lalsimulation/* ../
-        cd ../
+        curl --show-error --silent --remote-name https://git.ligo.org/lscsoft/lalsuite-extra/-/raw/master/data/lalsimulation/SEOBNRv4ROM_v2.0.hdf5
+        curl --show-error --silent --remote-name  https://git.ligo.org/waveforms/software/lalsuite-waveform-data/-/raw/main/waveform_data/SEOBNRv4ROM_v3.0.hdf5
     - name: run pycbc test suite
       run: |
         export LAL_DATA_PATH=$PWD

--- a/bin/plotting/pycbc_plot_singles_vs_params
+++ b/bin/plotting/pycbc_plot_singles_vs_params
@@ -30,7 +30,7 @@ from matplotlib.colors import LogNorm
 from matplotlib.ticker import LogLocator
 import h5py
 import sys
-from packaging.Version import Version
+from packaging.version import Version
 
 import pycbc
 import pycbc.pnutils

--- a/bin/plotting/pycbc_plot_singles_vs_params
+++ b/bin/plotting/pycbc_plot_singles_vs_params
@@ -30,6 +30,7 @@ from matplotlib.colors import LogNorm
 from matplotlib.ticker import LogLocator
 import h5py
 import sys
+from packaging.Version import Version
 
 import pycbc
 import pycbc.pnutils
@@ -148,7 +149,7 @@ hexbin_style = {
 
 # In earlier versions mpl will try to take the max over bins with 0 triggers
 # and fail, unless we tell it to leave these blank by setting mincnt
-if matplotlib.__version__ < '3.8.1':
+if Version(matplotlib.__version__) < Version('3.8.1'):
     hexbin_style['mincnt'] = 0
 
 if opts.log_x:

--- a/bin/pycbc_multi_inspiral
+++ b/bin/pycbc_multi_inspiral
@@ -660,7 +660,10 @@ with ctx:
                 ), f'SNR time series for {ifo} is empty'
                 norm_dict[ifo] = norm
                 corr_dict[ifo] = corr.copy()
-                idx[ifo] = ind.copy()
+                # change to integer indexes because we will have to do
+                # arithmetic with time_delay_idx, which can be positive 
+                # or negative
+                idx[ifo] = ind.astype(np.int32)
                 snr[ifo] = snrv * norm
 
             # Move onto next segment if there are no triggers.
@@ -691,8 +694,8 @@ with ctx:
                                 idx[ifo]
                                 > time_delay_idx[slide][position_index][ifo],
                                 idx[ifo]
-                                - time_delay_idx[slide][position_index][ifo]
-                                < len(snr_dict[ifo]),
+                                < time_delay_idx[slide][position_index][ifo]
+                                + len(snr_dict[ifo]),
                             )
                         ]
                         for ifo in args.instruments

--- a/bin/pygrb/pycbc_make_offline_grb_workflow
+++ b/bin/pygrb/pycbc_make_offline_grb_workflow
@@ -236,10 +236,39 @@ if wflow.cp.has_option("workflow-condition_strain", "do-gating"):
         datafind_files.append(gated_cache)
 
 datafind_veto_files.extend(datafind_files)
-ifo_list = sorted(sciSegs.keys())
-ifo = ifo_list[0]
-ifos = ''.join(ifo_list)
-wflow.ifos = ifos
+
+# Retrieve vetoes
+veto_file = None
+if wflow.cp.has_option("workflow-segments", "segments-vetoes"):
+    veto_file = _workflow.get_segments_file(wflow,
+                                            'vetoes', 
+                                            'segments-vetoes',
+                                            seg_dir,
+                                            tags=['veto'])
+    datafind_veto_files.append(veto_file)
+# Check that the onsource is free from vetoes
+for ifo in ifos:
+    avail_segs = select_segments_by_definer(veto_file.storage_path, ifo=ifo)
+    avail_segs.coalesce()
+    # In case no relevant vetoes are available, avail_segs becomes an empty list
+    if len(avail_segs) > 0:
+        vetoed_segs = offSrc[ifo] - avail_segs
+        if onSrc[ifo].intersects(vetoed_segs):
+            intersection = onSrc[ifo] & vetoed_segs
+            logging.error(
+                "The onsource %s contains the time %s that is vetoed in %s.",
+                onSrc[ifo][0][:],
+                intersection,
+                ifo
+            )
+            sys.exit()
+
+# Generate sky grid if needed
+skygrid_file = None
+if wflow.cp.has_option("workflow", "sky-error"):
+    logging.info("Generating sky-grid file.")
+    skygrid_file = _workflow.make_skygrid_node(wflow, df_dir, tags=['SEARCH'])
+    datafind_veto_files.extend(skygrid_file)
 
 # Config file consistency check for IPN GRBs
 if wflow.cp.has_option("workflow-inspiral", "ipn-search-points") \

--- a/pycbc/events/significance.py
+++ b/pycbc/events/significance.py
@@ -197,7 +197,7 @@ def get_n_louder(back_stat, fore_stat, dec_facs,
             "Removing %d NaN background statistic values",
             np.count_nonzero(nanmask),
         )
-    bstat = copy.deepcopy(back_stat)
+    back_stat = copy.deepcopy(back_stat)
     back_stat[nanmask] = -np.inf
 
     return _significance_meth_dict[method](

--- a/pycbc/events/significance.py
+++ b/pycbc/events/significance.py
@@ -194,8 +194,8 @@ def get_n_louder(back_stat, fore_stat, dec_facs,
     nanmask = np.isnan(back_stat)
     if any(nanmask):
         logging.warning(
-            "Removing %d NaN background statistic values",
-            np.count_nonzero(nanmask),
+            "Setting %d NaN background statistic values to -inf",
+            nanmask.sum(),
         )
         back_stat = copy.deepcopy(back_stat)
         back_stat[nanmask] = -np.inf

--- a/pycbc/events/significance.py
+++ b/pycbc/events/significance.py
@@ -197,8 +197,8 @@ def get_n_louder(back_stat, fore_stat, dec_facs,
             "Removing %d NaN background statistic values",
             np.count_nonzero(nanmask),
         )
-    back_stat = copy.deepcopy(back_stat)
-    back_stat[nanmask] = -np.inf
+        back_stat = copy.deepcopy(back_stat)
+        back_stat[nanmask] = -np.inf
 
     return _significance_meth_dict[method](
         back_stat,

--- a/pycbc/events/significance.py
+++ b/pycbc/events/significance.py
@@ -187,6 +187,14 @@ def get_n_louder(back_stat, fore_stat, dec_facs,
     Wrapper to find the correct n_louder calculation method using standard
     inputs
     """
+    # This nan to inf conversion is a safety shield; there shouldn't be any
+    # nan statistic values, but if there are, they should be considered as
+    # quiet as possible. nans are considered greater than any floats in an
+    # argsort
+    nanmask = np.isnan(back_stat)
+    bstat = copy.deepcopy(back_stat)
+    back_stat[nanmask] = -np.inf
+
     return _significance_meth_dict[method](
         back_stat,
         fore_stat,

--- a/pycbc/events/significance.py
+++ b/pycbc/events/significance.py
@@ -192,16 +192,16 @@ def get_n_louder(back_stat, fore_stat, dec_facs,
     # quiet as possible. nans are considered greater than any floats in an
     # argsort
     nanmask = np.isnan(back_stat)
+
     if any(nanmask):
         logging.warning(
             "Setting %d NaN background statistic values to -inf",
             nanmask.sum(),
         )
-        back_stat = copy.deepcopy(back_stat)
-        back_stat[nanmask] = -np.inf
+    back_stat_nonan = np.where(nanmask, -np.inf, back_stat)
 
     return _significance_meth_dict[method](
-        back_stat,
+        back_stat_nonan,
         fore_stat,
         dec_facs,
         **kwargs)

--- a/pycbc/events/significance.py
+++ b/pycbc/events/significance.py
@@ -192,6 +192,11 @@ def get_n_louder(back_stat, fore_stat, dec_facs,
     # quiet as possible. nans are considered greater than any floats in an
     # argsort
     nanmask = np.isnan(back_stat)
+    if any(nanmask):
+        logging.warning(
+            "Removing %d NaN background statistic values",
+            np.count_nonzero(nanmask),
+        )
     bstat = copy.deepcopy(back_stat)
     back_stat[nanmask] = -np.inf
 

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -1717,7 +1717,9 @@ class ExpFitFgBgNormStatistic(PhaseTDStatistic,
         sngls = single_info[1]
         ln_noise_rate = sngls['snglstat']
         ln_noise_rate -= self.benchmark_lograte
-        if not numpy.isnan(sngls['benchmark_logvol']):
+        # Benchmark log volume will be the same for all triggers, so if
+        # any are nan, they are all nan
+        if not any(numpy.isnan(sngls['benchmark_logvol'])):
             network_sigmasq = sngls['sigmasq']
             network_logvol = 1.5 * numpy.log(network_sigmasq)
             benchmark_logvol = sngls['benchmark_logvol']
@@ -1779,7 +1781,9 @@ class ExpFitFgBgNormStatistic(PhaseTDStatistic,
         # benchmark_logvol for a given template is not ifo-dependent, so
         # choose the first ifo for convenience
         benchmark_logvol = s[0][1]['benchmark_logvol']
-        if not numpy.isnan(benchmark_logvol):
+        # Benchmark log volume will be the same for all triggers, so if
+        # any are nan, they are all nan
+        if not any(numpy.isnan(benchmark_logvol)):
             # Network sensitivity for a given coinc type is approximately
             # determined by the least sensitive ifo
             network_sigmasq = numpy.amin(

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -1598,7 +1598,7 @@ class ExpFitFgBgNormStatistic(PhaseTDStatistic,
         network of reference IFOs
         """
         # benchmark_logvol is a benchmark sensitivity array over template id
-        bench_net_med_sigma = numpy.amin(
+        bench_net_med_sigma = numpy.nanmin(
             [self.fits_by_tid[ifo]['median_sigma'] for ifo in self.ref_ifos],
             axis=0,
         )
@@ -1715,13 +1715,16 @@ class ExpFitFgBgNormStatistic(PhaseTDStatistic,
             The array of single detector statistics
         """
         sngls = single_info[1]
-
         ln_noise_rate = sngls['snglstat']
         ln_noise_rate -= self.benchmark_lograte
-        network_sigmasq = sngls['sigmasq']
-        network_logvol = 1.5 * numpy.log(network_sigmasq)
-        benchmark_logvol = sngls['benchmark_logvol']
-        network_logvol -= benchmark_logvol
+        if not np.isnan(sngls['benchmark_logvol']):
+            # Only include this term if the benchmark log volume is defined
+            # This should always be the case in the offline search, but may
+            # not be in the live search.
+            network_sigmasq = sngls['sigmasq']
+            network_logvol = 1.5 * numpy.log(network_sigmasq)
+            benchmark_logvol = sngls['benchmark_logvol']
+            network_logvol -= benchmark_logvol
         ln_s = -4 * numpy.log(sngls['snr'] / self.ref_snr)
         loglr = network_logvol - ln_noise_rate + ln_s
         # cut off underflowing and very small values

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -1723,7 +1723,7 @@ class ExpFitFgBgNormStatistic(PhaseTDStatistic,
             benchmark_logvol = sngls['benchmark_logvol']
             network_logvol -= benchmark_logvol
         else:
-            # If the benchmark rate is nan, we don't want to propogate
+            # If the benchmark rate is nan, we don't want to propagate
             # the nan through to the statistic. Assume that the
             # sigma of this event is equal to what we would use as a
             # benchmark. This can happen in Live if there are not enough

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -1718,14 +1718,16 @@ class ExpFitFgBgNormStatistic(PhaseTDStatistic,
         ln_noise_rate = sngls['snglstat']
         ln_noise_rate -= self.benchmark_lograte
         if not np.isnan(sngls['benchmark_logvol']):
-            # Only include this term if the benchmark log volume is defined
-            # This should always be the case in the offline search, but may
-            # not be in the live search.
             network_sigmasq = sngls['sigmasq']
             network_logvol = 1.5 * numpy.log(network_sigmasq)
             benchmark_logvol = sngls['benchmark_logvol']
             network_logvol -= benchmark_logvol
         else:
+            # If the benchmark rate is nan, we don't want to propogate
+            # the nan through to the statistic. Assume that the
+            # sigma of this event is equal to what we would use as a
+            # benchmark. This can happen in Live if there are not enough
+            # triggers in the background fit files
             network_logvol = 0
         ln_s = -4 * numpy.log(sngls['snr'] / self.ref_snr)
         loglr = network_logvol - ln_noise_rate + ln_s
@@ -1778,17 +1780,20 @@ class ExpFitFgBgNormStatistic(PhaseTDStatistic,
         # choose the first ifo for convenience
         benchmark_logvol = s[0][1]['benchmark_logvol']
         if not np.isnan(benchmark_logvol):
-            # Only include this term if the benchmark log volume is defined
-            # This should always be the case in the offline search, but may
-            # not be in the live search.
             # Network sensitivity for a given coinc type is approximately
             # determined by the least sensitive ifo
             network_sigmasq = numpy.amin(
                 [sngl[1]['sigmasq'] for sngl in s],
                 axis=0
             )
-            network_logvol = 1.5 * numpy.log(network_sigmasq) - benchmark_logvol
+            network_logvol = 1.5 * numpy.log(network_sigmasq)
+            network_logvol -= benchmark_logvol
         else:
+            # If the benchmark rate is nan, we don't want to propogate
+            # the nan through to the statistic. Assume that the
+            # sigma of this event is equal to what we would use as a
+            # benchmark. This can happen in Live if there are not enough
+            # triggers in the background fit files
             network_logvol = 0
 
         # Use prior histogram to get Bayes factor for signal vs noise

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -1717,7 +1717,7 @@ class ExpFitFgBgNormStatistic(PhaseTDStatistic,
         sngls = single_info[1]
         ln_noise_rate = sngls['snglstat']
         ln_noise_rate -= self.benchmark_lograte
-        if not np.isnan(sngls['benchmark_logvol']):
+        if not numpy.isnan(sngls['benchmark_logvol']):
             network_sigmasq = sngls['sigmasq']
             network_logvol = 1.5 * numpy.log(network_sigmasq)
             benchmark_logvol = sngls['benchmark_logvol']
@@ -1779,7 +1779,7 @@ class ExpFitFgBgNormStatistic(PhaseTDStatistic,
         # benchmark_logvol for a given template is not ifo-dependent, so
         # choose the first ifo for convenience
         benchmark_logvol = s[0][1]['benchmark_logvol']
-        if not np.isnan(benchmark_logvol):
+        if not numpy.isnan(benchmark_logvol):
             # Network sensitivity for a given coinc type is approximately
             # determined by the least sensitive ifo
             network_sigmasq = numpy.amin(

--- a/pycbc/waveform/decompress_cpu.py
+++ b/pycbc/waveform/decompress_cpu.py
@@ -33,10 +33,9 @@ def inline_linear_interp(amp, phase, sample_frequencies, output,
 
     rprec = real_same_precision_as(output)
     cprec = complex_same_precision_as(output)
-    sample_frequencies = numpy.array(sample_frequencies, copy=False,
-                                     dtype=rprec)
-    amp = numpy.array(amp, copy=False, dtype=rprec)
-    phase = numpy.array(phase, copy=False, dtype=rprec)
+    sample_frequencies = numpy.asarray(sample_frequencies, dtype=rprec)
+    amp = numpy.asarray(amp, dtype=rprec)
+    phase = numpy.asarray(phase, dtype=rprec)
     sflen = len(sample_frequencies)
     h = numpy.array(output.data, copy=False, dtype=cprec)
     hlen = len(output)

--- a/pycbc/workflow/jobsetup.py
+++ b/pycbc/workflow/jobsetup.py
@@ -685,8 +685,8 @@ class PyCBCMultiInspiralExecutable(Executable):
 
         # If doing single IFO search, make sure slides are disabled
         if len(self.ifo_list) < 2 and \
-                (node.get_opt('--do-short-slides') is not None or \
-                 node.get_opt('--short-slide-offset') is not None):
+                (self.get_opt('--do-short-slides') is not None or \
+                 self.get_opt('--short-slide-offset') is not None):
             raise ValueError("Cannot run with time slides in a single IFO "
                              "configuration! Please edit your configuration "
                              "file accordingly.")

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,7 +40,7 @@ emcee==2.2.1
 dynesty
 
 # For building documentation
-Sphinx>=4.2.0
+Sphinx>=4.2.0,!=8.2.0
 sphinx-carousel
 sphinx-rtd-theme>=1.0.0
 sphinxcontrib-programoutput>=0.11

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,22 @@ deps =
     :preinstall: -rrequirements.txt
     -rcompanion.txt
     mkl;'arm' not in platform_machine
+conda_deps =
+    c-compiler
+    cxx-compiler
+    gsl
+    mysqlclient
+    ; these packages don't install cleanly with pip, conda has patches
+    python-ligo-lw
+    blas=*=openblas
+
+[bbhx]
+deps =
+    git+https://github.com/titodalcanton/BBHx.git@py39-and-cleanup; sys_platform == 'linux'
+    git+https://github.com/gwastro/BBHX-waveform-model.git; sys_platform == 'linux'
+conda_deps =
+    liblapacke
+    openblas
 
 [testenv]
 allowlist_externals = bash

--- a/tox.ini
+++ b/tox.ini
@@ -37,6 +37,7 @@ conda_deps=
     ; mac: clangxx_osx-64
     gsl
     lapack==3.6.1
+    blas=*=openblas
 conda_channels=conda-forge
 setenv =
     ; Tell the linker to look for shared libs inside the temporary Conda env.


### PR DESCRIPTION
When testing live with the new ranking statistic, we were getting a lot of weird FARs - this is due to getting stat values which were nan, and these were considered louder than everything else in the count_n_louder.

## Standard information about the request

This is a bug fix
This change affects the live search, and touches code of the offline search, but shouldn't affect anything
This change changes scientific output
This change follows style guidelines (See e.g. [PEP8](https://peps.python.org/pep-0008/)), has been proposed using the [contribution guidelines](https://github.com/gwastro/pycbc/blob/master/CONTRIBUTING.md)


## Contents
We combat this problem in three ways, which should prevent it occurring as much as possible:
1. If median sigma from fits files for any benchmark-network detector is NaN, then we ignore it. As a result, e.g. NaNs in L1 should not affect H1 singles, which was the case before. Hopefully this will cut most cases, as it goes from being an "or" to an "and" for H1 and L1 
2. If the benchmark is NaN - i.e. both detectors have NaNs in the fits files - then we do not apply the log sensitivity term.
3. As a final fail-safe, in the significance calculation, move any background with statistic NaN to have statistic of `-np.inf`. This shouldn't happen due to the protections above

Downsides of this approach:
 - If there is a much-less-sensitive detector which has NaN values, then the down-ranking from this factor will not be as it applied
 - If there is a foreground event which has statistic NaN, then it would be ranked higher than all background, I don't think this should be possible given the protections 1 and 2 in place, but this is a concern about protection 3

## Links to any issues or associated PRs
#5050 

## Testing performed
None yet

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
