### PR TITLE
Avoid nan values in network volume term - MASTER VERSION

### DIFF
--- a/pycbc/events/significance.py
+++ b/pycbc/events/significance.py
@@ -207,11 +207,10 @@ def get_n_louder(back_stat, fore_stat, dec_facs,
             "Setting %d NaN background statistic values to inf",
             nanmask.sum(),
         )
-        back_stat = copy.deepcopy(back_stat)
-        back_stat[nanmask] = -np.inf
+    back_stat_nonan = np.where(nanmask, -np.inf, back_stat
 
     return _significance_meth_dict[method](
-        back_stat,
+        back_stat_nonan,
         fore_stat,
         dec_facs,
         **kwargs)

--- a/pycbc/events/significance.py
+++ b/pycbc/events/significance.py
@@ -197,18 +197,16 @@ def get_n_louder(back_stat, fore_stat, dec_facs,
     Wrapper to find the correct n_louder calculation method using standard
     inputs
     """
-    # This nan to inf conversion is a safety shield; there shouldn't be any
-    # nan statistic values, but if there are, they should be considered as
-    # quiet as possible. nans are considered greater than any floats in an
-    # argsort
+    # Deal with edge case: we don't expect nan statistic values but if they
+    # exist they will ruin the n_louder count, as they are considered larger
+    # than floats in an argsort.
     nanmask = np.isnan(back_stat)
     if any(nanmask):
         logging.warning(
             "Setting %d NaN background statistic values to inf",
             nanmask.sum(),
         )
-    back_stat_nonan = np.where(nanmask, -np.inf, back_stat
-
+    back_stat_nonan = np.where(nanmask, -np.inf, back_stat)
     return _significance_meth_dict[method](
         back_stat_nonan,
         fore_stat,

--- a/pycbc/events/significance.py
+++ b/pycbc/events/significance.py
@@ -197,6 +197,14 @@ def get_n_louder(back_stat, fore_stat, dec_facs,
     Wrapper to find the correct n_louder calculation method using standard
     inputs
     """
+    # This nan to inf conversion is a safety shield; there shouldn't be any
+    # nan statistic values, but if there are, they should be considered as
+    # quiet as possible. nans are considered greater than any floats in an
+    # argsort
+    nanmask = np.isnan(back_stat)
+    bstat = copy.deepcopy(back_stat)
+    back_stat[nanmask] = -np.inf
+
     return _significance_meth_dict[method](
         back_stat,
         fore_stat,

--- a/pycbc/events/significance.py
+++ b/pycbc/events/significance.py
@@ -202,8 +202,13 @@ def get_n_louder(back_stat, fore_stat, dec_facs,
     # quiet as possible. nans are considered greater than any floats in an
     # argsort
     nanmask = np.isnan(back_stat)
-    bstat = copy.deepcopy(back_stat)
-    back_stat[nanmask] = -np.inf
+    if any(nanmask):
+        logging.warning(
+            "Removing %d NaN background statistic values",
+            np.count_nonzero(nanmask),
+        )
+        back_stat = copy.deepcopy(back_stat)
+        back_stat[nanmask] = -np.inf
 
     return _significance_meth_dict[method](
         back_stat,

--- a/pycbc/events/significance.py
+++ b/pycbc/events/significance.py
@@ -204,8 +204,8 @@ def get_n_louder(back_stat, fore_stat, dec_facs,
     nanmask = np.isnan(back_stat)
     if any(nanmask):
         logging.warning(
-            "Removing %d NaN background statistic values",
-            np.count_nonzero(nanmask),
+            "Setting %d NaN background statistic values to inf",
+            nanmask.sum(),
         )
         back_stat = copy.deepcopy(back_stat)
         back_stat[nanmask] = -np.inf

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -1506,7 +1506,9 @@ class ExpFitStatistic(PhaseTDStatistic):
         # choose the first ifo for convenience
         benchmark_logvol = sngls[0][1]["benchmark_logvol"]
 
-        if numpy.isnan(benchmark_logvol):
+        # Benchmark log volume will be the same for all triggers, so if
+        # any are nan, they are all nan
+        if any(numpy.isnan(benchmark_logvol)):
             # This can be the case in pycbc live if there are no triggers
             # from this template in the trigger fits file. If so, assume 
             # that sigma for the triggers being ranked is

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -1510,7 +1510,7 @@ class ExpFitStatistic(PhaseTDStatistic):
             # This can be the case in pycbc live if there are no triggers
             # from this template in the trigger fits file. In this case we
             # just assume that the sigma of the trigger of interest is
-            # representative of the network.
+            # representative of the benchmark network.
             return 0
 
         # Network sensitivity for a given coinc type is approximately

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -1506,7 +1506,7 @@ class ExpFitStatistic(PhaseTDStatistic):
         # choose the first ifo for convenience
         benchmark_logvol = sngls[0][1]["benchmark_logvol"]
 
-        if np.isnan(benchmark_logvol):
+        if numpy.isnan(benchmark_logvol):
             # This can be the case in pycbc live if there are no triggers
             # from this template in the trigger fits file. If so, assume 
             # that sigma for the triggers being ranked is

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -1501,9 +1501,6 @@ class ExpFitStatistic(PhaseTDStatistic):
             log of the cube of the sensitive distance (sigma), divided by
             a benchmark volume.
         """
-        # Network sensitivity for a given coinc type is approximately
-        # determined by the least sensitive ifo
-
         # Get benchmark log volume as single-ifo information :
         # benchmark_logvol for a given template is not ifo-dependent, so
         # choose the first ifo for convenience
@@ -1516,6 +1513,8 @@ class ExpFitStatistic(PhaseTDStatistic):
             # representative of the network.
             return 0
 
+        # Network sensitivity for a given coinc type is approximately
+        # determined by the least sensitive ifo
         network_sigmasq = numpy.amin(
             [sngl[1]["sigmasq"] for sngl in sngls], axis=0
         )

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -1508,8 +1508,8 @@ class ExpFitStatistic(PhaseTDStatistic):
 
         if np.isnan(benchmark_logvol):
             # This can be the case in pycbc live if there are no triggers
-            # from this template in the trigger fits file. In this case we
-            # just assume that the sigma of the trigger of interest is
+            # from this template in the trigger fits file. If so, assume 
+            # that sigma for the triggers being ranked is
             # representative of the benchmark network.
             return 0
 

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -1503,16 +1503,24 @@ class ExpFitStatistic(PhaseTDStatistic):
         """
         # Network sensitivity for a given coinc type is approximately
         # determined by the least sensitive ifo
-        network_sigmasq = numpy.amin(
-            [sngl[1]["sigmasq"] for sngl in sngls], axis=0
-        )
-        # Volume \propto sigma^3 or sigmasq^1.5
-        network_logvol = 1.5 * numpy.log(network_sigmasq)
+
         # Get benchmark log volume as single-ifo information :
         # benchmark_logvol for a given template is not ifo-dependent, so
         # choose the first ifo for convenience
         benchmark_logvol = sngls[0][1]["benchmark_logvol"]
-        network_logvol -= benchmark_logvol
+
+        if np.isnan(benchmark_logvol):
+            # This can be the case in pycbc live if there are no triggers
+            # from this template in the trigger fits file. In this case we
+            # just assume that the sigma of the trigger of interest is
+            # representative of the network.
+            return 0
+
+        network_sigmasq = numpy.amin(
+            [sngl[1]["sigmasq"] for sngl in sngls], axis=0
+        )
+        # Volume \propto sigma^3 or sigmasq^1.5
+        network_logvol = 1.5 * numpy.log(network_sigmasq) - benchmark_logvol
 
         return network_logvol
 

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -970,7 +970,7 @@ class ExpFitStatistic(PhaseTDStatistic):
             # benchmark_logvol is a benchmark sensitivity array
             # over template id
             ref_ifos = self.kwargs.get("reference_ifos", "H1,L1").split(",")
-            hl_net_med_sigma = numpy.amin(
+            hl_net_med_sigma = numpy.nanmin(
                 [self.fits_by_tid[ifo]["median_sigma"] for ifo in ref_ifos],
                 axis=0,
             )


### PR DESCRIPTION
When testing live with the new ranking statistic, we were getting a lot of weird FARs - this is due to getting stat values which were nan, and these were considered louder than everything else in the count_n_louder.

## Standard information about the request

This is a bug fix
This change affects the live search, and touches code of the offline search, but shouldn't affect anything
This change changes scientific output
This change follows style guidelines (See e.g. [PEP8](https://peps.python.org/pep-0008/)), has been proposed using the [contribution guidelines](https://github.com/gwastro/pycbc/blob/master/CONTRIBUTING.md)


## Contents
We combat this problem in three ways, which should prevent it occurring as much as possible:
1. If median sigma from fits files for any benchmark-network detector is NaN, then we ignore it. As a result, e.g. NaNs in L1 should not affect H1 singles, which was the case before. Hopefully this will cut most cases, as it goes from being an "or" to an "and" for H1 and L1 
2. If the benchmark is NaN - i.e. both detectors have NaNs in the fits files - then we do not apply the log sensitivity term.
3. As a final fail-safe, in the significance calculation, move any background with statistic NaN to have statistic of `-np.inf`. This shouldn't happen due to the protections above

Downsides of this approach:
 - If there is a much-less-sensitive detector which has NaN values, then the down-ranking from this factor will not be as it applied
 - If there is a foreground event which has statistic NaN, then it would be ranked higher than all background, I don't think this should be possible given the protections 1 and 2 in place, but this is a concern about protection 3

## Links to any issues or associated PRs
#5049 

## Testing performed
None yet

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
