### PR TITLE
Fix CI failures

### DIFF
--- a/docs/_include/inference_example_lisa_smbhb_inj.sh
+++ b/docs/_include/inference_example_lisa_smbhb_inj.sh
@@ -1,3 +1,6 @@
 set -e
 export OMP_NUM_THREADS=1
-echo "Done"
+cp ../../examples/inference/lisa_smbhb_inj/injection_smbhb.ini injection_smbhb.ini
+sh ../../examples/inference/lisa_smbhb_inj/injection_smbhb.sh
+sh ../../examples/inference/lisa_smbhb_inj/run.sh
+sh ../../examples/inference/lisa_smbhb_inj/plot.sh

--- a/docs/_include/inference_example_lisa_smbhb_inj.sh
+++ b/docs/_include/inference_example_lisa_smbhb_inj.sh
@@ -1,6 +1,3 @@
 set -e
 export OMP_NUM_THREADS=1
-cp ../../examples/inference/lisa_smbhb_inj/injection_smbhb.ini injection_smbhb.ini
-sh ../../examples/inference/lisa_smbhb_inj/injection_smbhb.sh
-sh ../../examples/inference/lisa_smbhb_inj/run.sh
-sh ../../examples/inference/lisa_smbhb_inj/plot.sh
+echo "Done"

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,7 +40,7 @@ emcee==2.2.1
 dynesty
 
 # For building documentation
-Sphinx>=4.2.0
+Sphinx>=4.2.0,!=8.2.0
 sphinx-carousel
 sphinx-rtd-theme>=1.0.0
 sphinxcontrib-programoutput>=0.11

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ jinja2
 mpld3>=0.3
 beautifulsoup4>=4.6.0
 cython
-lalsuite!=7.2
+lalsuite!=7.2,<7.25
 lscsoft-glue>=1.59.3
 igwn-segments
 tqdm

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ jinja2
 mpld3>=0.3
 beautifulsoup4>=4.6.0
 cython
-lalsuite!=7.2,<7.25
+lalsuite!=7.2
 lscsoft-glue>=1.59.3
 igwn-segments
 tqdm

--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,7 @@ conda_deps =
     mysqlclient
     ; these packages don't install cleanly with pip, conda has patches
     python-ligo-lw
+    blas=*=openblas
 
 [bbhx]
 deps =


### PR DESCRIPTION
The CI is currently failing. I see two separate issues causing failures:

* lalsuite's FFT functions are segfaulting (@duncanmmacleod for info, as it really shouldn't do that). It seems that the issue is mixing MKL-compiled lower-level binaries. In particular the main difference between a functional run, and a failing CI run is:
```
< libblas                   3.9.0           28_h59b9bed_openblas    conda-forge
< libcblas                  3.9.0           28_he106b2a_openblas    conda-forge
---
> libblas                   3.9.0            16_linux64_mkl    conda-forge
> libcblas                  3.9.0            16_linux64_mkl    conda-forge
99,100c99,100
< liblapack                 3.9.0           28_h7ac8fdf_openblas    conda-forge
< liblapacke                3.9.0           28_he2f377e_openblas    conda-forge
---
> liblapack                 3.9.0            16_linux64_mkl    conda-forge
> liblapacke                3.9.0            16_linux64_mkl    conda-forge
```
This patch forces a openblas installation of these libraries (though I don't understand conda well, and I've probably done it wrong) and fixes this problem.
* The new release of sphinx breaks the documentation. The error is not helpful. I've avoided the latest (v8.2.0) release of sphinx here, but will look deeper if this recurs in the next sphinx release.