### PR TITLE
Fars_vs_stat plot in results page

### DIFF
--- a/bin/plotting/pycbc_page_fars_vs_stat
+++ b/bin/plotting/pycbc_page_fars_vs_stat
@@ -55,12 +55,14 @@ ax = fig.add_subplot(111)
 ifar_calc_points = np.linspace(-10, 30, 200)
 
 fitted = []  # List of combos for which a fit is used
-for f in opts.trigger_files:
+for item in opts.trigger_files:
+    sig_key, f = item.split(':', 1)  # Split at the first colon
     logging.info(f"Opening {f}")
     with h5py.File(f, 'r') as exc_zlag_f:
-        logging.info(f"Ifos {exc_zlag_f.attrs['ifos']}")  # eg 'H1 L1'
-        sig_key = exc_zlag_f.attrs['ifos'].replace(' ', '')  # eg 'H1L1'
-        coinc_key = sig_key.replace('1', '')  # eg 'HL'
+        ifos = ' '.join(list(sig_key))  # eg 'H1 L1'
+        logging.info(f"Ifos {ifos}")
+        sig_key = ifos.replace(' ', '')  # eg 'H1L1'
+        coinc_key = ''.join([c for c in sig_key if not c.isdigit()])  # eg 'HL'
         stat_exc = exc_zlag_f['background_exc']['stat'][:]
         dec_fac_exc = exc_zlag_f['background_exc']['decimation_factor'][:]
         bg_time = convert_s_to_y(exc_zlag_f.attrs['background_time_exc'])

--- a/bin/plotting/pycbc_page_fars_vs_stat
+++ b/bin/plotting/pycbc_page_fars_vs_stat
@@ -55,14 +55,12 @@ ax = fig.add_subplot(111)
 ifar_calc_points = np.linspace(-10, 30, 200)
 
 fitted = []  # List of combos for which a fit is used
-for item in opts.trigger_files:
-    sig_key, f = item.split(':', 1)  # Split at the first colon
+for f in opts.trigger_files:
     logging.info(f"Opening {f}")
     with h5py.File(f, 'r') as exc_zlag_f:
-        ifos = ' '.join(list(sig_key))  # eg 'H1 L1'
-        logging.info(f"Ifos {ifos}")
-        sig_key = ifos.replace(' ', '')  # eg 'H1L1'
-        coinc_key = ''.join([c for c in sig_key if not c.isdigit()])  # eg 'HL'
+        logging.info(f"Ifos {exc_zlag_f.attrs['ifos']}")  # eg 'H1 L1'
+        sig_key = exc_zlag_f.attrs['ifos'].replace(' ', '')  # eg 'H1L1'
+        coinc_key = sig_key.replace('1', '')  # eg 'HL'
         stat_exc = exc_zlag_f['background_exc']['stat'][:]
         dec_fac_exc = exc_zlag_f['background_exc']['decimation_factor'][:]
         bg_time = convert_s_to_y(exc_zlag_f.attrs['background_time_exc'])

--- a/bin/plotting/pycbc_page_fars_vs_stat
+++ b/bin/plotting/pycbc_page_fars_vs_stat
@@ -9,10 +9,6 @@ from pycbc import init_logging, add_common_pycbc_options, results
 from pycbc.events import significance
 from pycbc.conversions import sec_to_year as convert_s_to_y
 
-plt.rcParams.update({
-    "text.usetex": True,
-})
-
 parser = argparse.ArgumentParser(usage='pycbc_page_ifar_vs_stat [--options]',
                     description='Plots cumulative IFAR vs stat for'
                           'backgrounds of different event types.')

--- a/bin/workflows/pycbc_make_offline_search_workflow
+++ b/bin/workflows/pycbc_make_offline_search_workflow
@@ -603,10 +603,10 @@ wf.setup_foreground_minifollowups(workflow, combined_bg_file,
                                   'daxes', mfup_dir_bg,
                                   tags=combined_bg_file.tags + ['background'])
 
-#Far_vs_stat for each ifo combination in a single plot
+# Far vs stat for all ifo combinations in a single plot
 farstat = wf.make_farstat_plot(workflow, final_bg_files, rdir['background_triggers'],
-                                      require='summ',
-                                      tags=bg_file.tags + ['closed'])
+                               require='summ',
+                               tags=bg_file.tags + ['closed'])
 
 # Sub-pages for each ifo combination
 snrifar_summ = []

--- a/bin/workflows/pycbc_make_offline_search_workflow
+++ b/bin/workflows/pycbc_make_offline_search_workflow
@@ -603,11 +603,12 @@ wf.setup_foreground_minifollowups(workflow, combined_bg_file,
                                   'daxes', mfup_dir_bg,
                                   tags=combined_bg_file.tags + ['background'])
 
-# Sub-pages for each ifo combination
+#Far_vs_stat for each ifo combination in a single plot
 farstat = wf.make_farstat_plot(workflow, final_bg_files, rdir['background_triggers'],
                                       require='summ',
                                       tags=bg_file.tags + ['closed'])
 
+# Sub-pages for each ifo combination
 snrifar_summ = []
 for key in final_bg_files:
     bg_file = final_bg_files[key]

--- a/bin/workflows/pycbc_make_offline_search_workflow
+++ b/bin/workflows/pycbc_make_offline_search_workflow
@@ -604,6 +604,9 @@ wf.setup_foreground_minifollowups(workflow, combined_bg_file,
                                   tags=combined_bg_file.tags + ['background'])
 
 # Sub-pages for each ifo combination
+farstat = wf.make_farstat_plot(workflow, final_bg_files, rdir['background_triggers'],
+                                      require='summ',
+                                      tags=bg_file.tags + ['closed'])
 
 snrifar_summ = []
 for key in final_bg_files:
@@ -629,7 +632,7 @@ for key in final_bg_files:
                                     tags=bg_file.tags + ['closed_box'])
         closed_page = [(snrifar_cb, ifar_cb)]
     else:
-        closed_page = [(snrifar_cb,)]
+        closed_page = [(snrifar_cb, farstat)]
     if len(ifo_sets) > 1:
         # If there is only one ifo_set, then this table has already been made
         table = wf.make_foreground_table(workflow, bg_file, hdfbank, open_dir,

--- a/examples/search/executables.ini
+++ b/examples/search/executables.ini
@@ -62,6 +62,7 @@ single_template = ${which:pycbc_single_template}
 plot_singles_timefreq = ${which:pycbc_plot_singles_timefreq}
 plot_snrratehist = ${which:pycbc_page_snrratehist}
 plot_waveform = ${which:pycbc_plot_waveform}
+page_farstat = ${which:pycbc_page_fars_vs_stat}
 
 [pegasus_profile]
 condor|request_memory = 1000

--- a/examples/search/plotting.ini
+++ b/examples/search/plotting.ini
@@ -243,10 +243,9 @@ decimation-factor = 100
 open-box=
 
 [page_farstat]
-far-calculation-method = H1:trigger_fit L1:trigger_fit
-limit-ifar = H1:1000 L1:1000
-fit-function = H1:exponential L1:exponential
-fit-threshold = H1:-1.2 L1:0
+far-calculation-method = ${sngls_statmap|far-calculation-method}
+fit-function = ${sngls_statmap|fit-function}
+fit-threshold = ${sngls_statmap|fit-threshold}
 
 [page_vetotable]
 [plot_bank]

--- a/examples/search/plotting.ini
+++ b/examples/search/plotting.ini
@@ -242,6 +242,12 @@ decimation-factor = 100
 [page_ifar-open_box]
 open-box=
 
+[page_farstat]
+far-calculation-method = H1:trigger_fit L1:trigger_fit
+limit-ifar = H1:1000 L1:1000
+fit-function = H1:exponential L1:exponential
+fit-threshold = H1:-1.2 L1:0
+
 [page_vetotable]
 [plot_bank]
 log-x =

--- a/pycbc/workflow/plotting.py
+++ b/pycbc/workflow/plotting.py
@@ -333,6 +333,23 @@ def make_ifar_plot(workflow, trigger_file, out_dir, tags=None,
     workflow += node
     return node.output_files[0]
 
+def make_farstat_plot(workflow, trigger_files, out_dir, tags=None,
+                   hierarchical_level=None, require=None, executable='page_farstat'):
+    """ Creates a node in the workflow for plotting cumulative histogram
+    of IFAR vs stat values.
+    """
+
+    makedir(out_dir)
+    opt = list(trigger_files.values())
+    ifo_combos = ' '.join(sorted(trigger_files.keys(), key=lambda x: (len(x), x)))
+    exe = PlotExecutable(workflow.cp, executable,
+                         out_dir=out_dir, tags=tags)
+    node = exe.create_node()
+    node.add_multiifo_input_list_opt('--trigger-files', opt)
+    node.add_opt('--ifo-combos', ifo_combos)
+    node.new_output_file_opt(workflow.analysis_time, '.png', '--output-file')
+    workflow += node
+    return node.output_files[0]
 
 def make_snrchi_plot(workflow, trig_files, veto_file, veto_name,
                      out_dir, exclude=None, require=None, tags=None):

--- a/pycbc/workflow/plotting.py
+++ b/pycbc/workflow/plotting.py
@@ -343,7 +343,7 @@ def make_farstat_plot(workflow, trigger_files, out_dir, tags=None,
     opt = list(trigger_files.values())
     ifo_combos = ' '.join(sorted(trigger_files.keys(), key=lambda x: (len(x), x)))
 
-    exe = PlotExecutable(workflow.cp, executable,
+    exe = PlotExecutable(workflow.cp, executable, ifos=workflow.ifos,
                          out_dir=out_dir, tags=tags)
     node = exe.create_node()
     node.add_input_list_opt('--trigger-files', opt)

--- a/pycbc/workflow/plotting.py
+++ b/pycbc/workflow/plotting.py
@@ -342,10 +342,11 @@ def make_farstat_plot(workflow, trigger_files, out_dir, tags=None,
     makedir(out_dir)
     opt = list(trigger_files.values())
     ifo_combos = ' '.join(sorted(trigger_files.keys(), key=lambda x: (len(x), x)))
+
     exe = PlotExecutable(workflow.cp, executable,
                          out_dir=out_dir, tags=tags)
     node = exe.create_node()
-    node.add_multiifo_input_list_opt('--trigger-files', opt)
+    node.add_input_list_opt('--trigger-files', opt)
     node.add_opt('--ifo-combos', ifo_combos)
     node.new_output_file_opt(workflow.analysis_time, '.png', '--output-file')
     workflow += node


### PR DESCRIPTION

<!---
This is a brief template for making pull requests for PyCBC.
This is _not_ a proscriptive template - you can use a different style if you want.
Please do think about the questions posed here and whether the details will be useful to include in your PR
Please add sufficient details so that people looking back at the request with no context around the work can understand the changes.
To choose reviewers, please look at the git blame for the code you are changing (if applicable),
or discuss in the #pycbc-code channel of the gwastro slack.
Please add labels as appropriate
-->

<!-- TOP-LEVEL SUMMARY:-->
 Incorporating the output of  `pycbc_page_fars_vs_stat` plot in the pycbc results page. This plot would be visible in the summary page and under the background triggers page.


## Standard information about the request

<!--- Some basic info about the change (delete as appropriate) -->
This is a: new feature which adds an additional plot to the summary page. 

<!--- Some things which help with code management (delete as appropriate) -->
This change: has appropriate unit tests, follows style guidelines (See e.g. [PEP8](https://peps.python.org/pep-0008/)), has been proposed using the [contribution guidelines](https://github.com/gwastro/pycbc/blob/master/CONTRIBUTING.md)

<!--- Notes about the effect of this change -->

## Motivation
The far vs stat plots in the summary pages is crucial to validate the ranking of events during a offline run. 

## Contents
Adds a new job in the `pycbc_make_offline_search_workflow` which is defined in the `workflow/plotting.py`.  Config changes in the mini-search to keep the changes consistent with this PR.

## Links to any issues or associated PRs
The v2.3.10 release PR see ([https://github.com/gwastro/pycbc/pull/5044](https://github.com/gwastro/pycbc/pull/5044)) requires this to be merged first. 

## Testing performed
I've tested the mini-search workflow after updating the configs, and it runs successfully.

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
