### PR TITLE
Add statistic correction option

### DIFF
--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -963,9 +963,9 @@ class ExpFitStatistic(PhaseTDStatistic):
         # This will be used to keep track of the template number being used
         self.curr_tnum = None
 
-        # This applies a constant offset to *all* statistic values. Can be
-        # used to apply weights for difference coincident combinations, or
-        # just to rescale the statistic plot. Default is to not apply this.
+        # Applies a constant offset to all statistic values in a given instance.
+        # This can be used to e.g. change relative rankings between different
+        # event types. Default is zero offset.
         self.stat_correction = float(
             self.kwargs.get("statistic_correction", 0)
         )

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -1770,7 +1770,7 @@ class ExpFitStatistic(PhaseTDStatistic):
         # Combine the signal and noise rates
         loglr = ln_s - ln_noise_rate
 
-        # Apply statistic correction if given
+        # Apply statistic correction
         loglr += self.stat_correction
 
         # From this combined rate, what is the minimum snglstat value

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -1688,7 +1688,7 @@ class ExpFitStatistic(PhaseTDStatistic):
         # Combine the signal and noise rates
         loglr = ln_s - ln_noise_rate
 
-        # Apply statistic correction if given
+        # Apply statistic correction
         loglr += self.stat_correction
 
         # cut off underflowing and very small values

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -1600,7 +1600,7 @@ class ExpFitStatistic(PhaseTDStatistic):
         # Combine the signal and noise rates
         loglr = ln_s - ln_noise_rate
 
-        # Apply statistic correction if given
+        # Apply statistic correction
         loglr += self.stat_correction
 
         # cut off underflowing and very small values

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -972,7 +972,7 @@ class ExpFitStatistic(PhaseTDStatistic):
 
         # Go through the keywords and add class information as needed:
         if self.kwargs["sensitive_volume"]:
-            # Add network sensitivity beckmark
+            # Add network sensitivity benchmark
             self.single_dtype.append(("benchmark_logvol", numpy.float32))
             # benchmark_logvol is a benchmark sensitivity array
             # over template id

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -963,6 +963,13 @@ class ExpFitStatistic(PhaseTDStatistic):
         # This will be used to keep track of the template number being used
         self.curr_tnum = None
 
+        # This applies a constant offset to *all* statistic values. Can be
+        # used to apply weights for difference coincident combinations, or
+        # just to rescale the statistic plot. Default is to not apply this.
+        self.stat_correction = float(
+            self.kwargs.get("statistic_correction", 0)
+        )
+
         # Go through the keywords and add class information as needed:
         if self.kwargs["sensitive_volume"]:
             # Add network sensitivity beckmark
@@ -1593,6 +1600,9 @@ class ExpFitStatistic(PhaseTDStatistic):
         # Combine the signal and noise rates
         loglr = ln_s - ln_noise_rate
 
+        # Apply statistic correction if given
+        loglr += self.stat_correction
+
         # cut off underflowing and very small values
         loglr[loglr < self.min_stat] = self.min_stat
         return loglr
@@ -1678,6 +1688,9 @@ class ExpFitStatistic(PhaseTDStatistic):
         # Combine the signal and noise rates
         loglr = ln_s - ln_noise_rate
 
+        # Apply statistic correction if given
+        loglr += self.stat_correction
+
         # cut off underflowing and very small values
         loglr[loglr < self.min_stat] = self.min_stat
 
@@ -1756,6 +1769,9 @@ class ExpFitStatistic(PhaseTDStatistic):
 
         # Combine the signal and noise rates
         loglr = ln_s - ln_noise_rate
+
+        # Apply statistic correction if given
+        loglr += self.stat_correction
 
         # From this combined rate, what is the minimum snglstat value
         # in the pivot IFO needed to reach the threshold?


### PR DESCRIPTION
This patch adds a `statistic_correction` "statistic keyword" in `stat.py`. This option will add a constant factor to *all* returned statistic values.

The immediate problem this patch sets out to fix is this plot (from https://inspirehep.net/literature/2053424)

![image](https://github.com/user-attachments/assets/d00fa027-a03a-4681-9ab4-7e37fb60ab1b)

This shows the desired behaviour using the state of the art statistic as of a few years ago. In particular HL doubles lie above other things.

When adding the new KDE term we see this relative behaviour change and H/L singles lie above the doubles line, causing singles to be weighted *more* than HL doubles when combining. Using this option we can downrank singles relative to doubles (and add appropriate factors when considering 3-ifo behaviour).

However, the patch is broader than that, it could be used (for e.g.) to try to make `0` correspond to a 50/50 chance of being real ... Or any other thing you could dream up where we just want to scale the statistic.

I've tested that this produces the desired effect.