### PR TITLE
Reorganize FAR/stat plots on summary page

### DIFF
--- a/bin/workflows/pycbc_make_offline_search_workflow
+++ b/bin/workflows/pycbc_make_offline_search_workflow
@@ -582,11 +582,6 @@ symlink_result(table, 'open_box_result/significance')
 main_page = [(ifar_ob,), (table, )]
 layout.two_column_layout(rdir['open_box_result'], main_page)
 
-#detailed_page = [(snrifar, ratehist), (snrifar_ifar, ifar_ob), (table,)]
-#layout.two_column_layout(rdir['open_box_result/significance'], detailed_page)
-
-closed_page = [(bank_plot,)]
-layout.two_column_layout(rdir['background_triggers'], closed_page)
 
 # run minifollowups on the output of the loudest events
 mfup_dir_fg = rdir['open_box_result/loudest_events_followup']
@@ -608,8 +603,13 @@ farstat = wf.make_farstat_plot(workflow, final_bg_files, rdir['background_trigge
                                require='summ',
                                tags=bg_file.tags + ['closed'])
 
+closed_page = [(bank_plot, farstat)]
+layout.two_column_layout(rdir['background_triggers'], closed_page)
+
+# Add farstat plot to summary page
+snrifar_summ = [(farstat,)]
+
 # Sub-pages for each ifo combination
-snrifar_summ = []
 for key in final_bg_files:
     bg_file = final_bg_files[key]
     open_dir = rdir['open_box_result/{}_candidates'.format(key)]
@@ -633,7 +633,7 @@ for key in final_bg_files:
                                     tags=bg_file.tags + ['closed_box'])
         closed_page = [(snrifar_cb, ifar_cb)]
     else:
-        closed_page = [(snrifar_cb, farstat)]
+        closed_page = [(snrifar_cb,)]
     if len(ifo_sets) > 1:
         # If there is only one ifo_set, then this table has already been made
         table = wf.make_foreground_table(workflow, bg_file, hdfbank, open_dir,
@@ -643,7 +643,6 @@ for key in final_bg_files:
     detailed_page = [(snrifar, ratehist), (snrifar_ifar, ifar_ob), (table,)]
     layout.two_column_layout(open_dir, detailed_page)
 
-    snrifar_summ += closed_page
     layout.two_column_layout(closed_dir, closed_page)
 
 #################### Plotting of data quality results #########################


### PR DESCRIPTION
This patch makes a few tweaks to the result pages.

* The summary page has become a bit overrun with statistic plots. With the new plot added by Tom, I think it makes sense to move the FAR vs Rank and Cumulative number vs IFAR plots to the relevant subsections. Now *only* the new plot is shown to summarize the behaviour of the statistic.
* The above point also fixes the issue that the new plot was duplicated num-ifo times on the summary page.
* The new plot was not displaying correctly in section 5 (because it was being linked to the wrong subsection). This is fixed here and it should now appear in the top of section 5.