### PR TITLE
Offline results page tidyup

### DIFF
--- a/bin/workflows/pycbc_make_offline_search_workflow
+++ b/bin/workflows/pycbc_make_offline_search_workflow
@@ -76,10 +76,11 @@ def finalize(container, workflow, finalize_workflow):
     save_fig_with_metadata(dashboard_str, dashboard_file.storage_path, **kwds)
 
     # Create pages for the submission script to write data
-    #wf.makedir(rdir['workflow/dax'])
-    #wf.makedir(rdir['workflow/input_map'])
-    #wf.makedir(rdir['workflow/output_map'])
-    #wf.makedir(rdir['workflow/planning'])
+    # FIXME: add this
+    # wf.makedir(rdir['workflow/dax'])
+    # wf.makedir(rdir['workflow/input_map'])
+    # wf.makedir(rdir['workflow/output_map'])
+    # wf.makedir(rdir['workflow/planning'])
 
     wf.make_results_web_page(finalize_workflow, os.path.join(os.getcwd(),
                                                              rdir.base))
@@ -901,7 +902,7 @@ for inj_file, tag in zip(inj_files, inj_tags):
 if len(files_for_combined_injfind) > 0:
     sen_all = wf.make_sensitivity_plot(workflow, found_inj_comb,
                                        rdir['search_sensitivity'],
-                                       require='all'
+                                       require='all',
                                        exclude="summ")
     inj_all = wf.make_foundmissed_plot(workflow, found_inj_comb,
                                        rdir['injections'],

--- a/bin/workflows/pycbc_make_offline_search_workflow
+++ b/bin/workflows/pycbc_make_offline_search_workflow
@@ -538,7 +538,7 @@ if workflow.cp.has_option_tags('workflow-matchedfilter',
         rdir['workflow/throughput'],
         tags=['full_data']
     )
-   layout.group_layout(throughput_plots)
+   layout.group_layout(rdir['workflow/throughput'], throughput_plots)
 
 # Run minifollowups on loudest sngl detector events
 excl_subsecs = set([])

--- a/bin/workflows/pycbc_make_offline_search_workflow
+++ b/bin/workflows/pycbc_make_offline_search_workflow
@@ -648,25 +648,41 @@ for key in final_bg_files:
 #################### Plotting of data quality results #########################
 
 # DQ log likelihood plots
+dq_summ_dir = rdir[f'data_quality']
+dq_summ = []
 for dqf, dql in zip(dqfiles, dqfile_labels):
     ifo = dqf.ifo
-    outdir = rdir[f'data_quality/{dqf.ifo}_DQ_results']
+    dq_dir = rdir[f'data_quality/{dqf.ifo}_DQ_results']
 
     # plot rates when flag was on
-    wf.make_dq_flag_trigger_rate_plot(workflow, dqf, dql, outdir, tags=[dql])
+    trig_rate_plot = wf.make_dq_flag_trigger_rate_plot(
+        workflow,
+        dqf,
+        dql,
+        dq_dir,
+        tags=[dql]
+    )
+    dq_summ.append(trig_rate_plot)
 
     # make table of dq segment info
-    wf.make_dq_segment_table(workflow, dqf, outdir, tags=[dql])
+    seg_table = wf.make_dq_segment_table(workflow, dqf, dq_dir, tags=[dql])
 
     # plot background bins
     background_bins = workflow.cp.get_opt_tags(
         'bin_templates', 'background-bins', tags=[ifo])
-    wf.make_template_plot(workflow, hdfbank, outdir,
-                          bins=background_bins,
-                          tags=[ifo, 'dq_bins'] + bank_tags)
+    bbin_plot = wf.make_template_plot(
+        workflow,
+        hdfbank,
+        dq_dir,
+        bins=background_bins,
+        tags=[ifo, 'dq_bins'] + bank_tags
+    )
 
     # make table of template bin info
-    wf.make_template_bin_table(workflow, dqf, outdir, tags=[ifo])
+    bininfo = wf.make_template_bin_table(workflow, dqf, dq_dir, tags=[ifo])
+    dq_page = [(trig_rate_plot,), (seg_table, bbin_plot) (bininfo,)]
+    layout.two_column_layout(dq_dir, dq_page)
+layout.single_layout(dq_summ_dir, dq_summ)
 
 ############################## Setup the injection runs #######################
 

--- a/bin/workflows/pycbc_make_offline_search_workflow
+++ b/bin/workflows/pycbc_make_offline_search_workflow
@@ -76,10 +76,10 @@ def finalize(container, workflow, finalize_workflow):
     save_fig_with_metadata(dashboard_str, dashboard_file.storage_path, **kwds)
 
     # Create pages for the submission script to write data
-    wf.makedir(rdir['workflow/dax'])
-    wf.makedir(rdir['workflow/input_map'])
-    wf.makedir(rdir['workflow/output_map'])
-    wf.makedir(rdir['workflow/planning'])
+    #wf.makedir(rdir['workflow/dax'])
+    #wf.makedir(rdir['workflow/input_map'])
+    #wf.makedir(rdir['workflow/output_map'])
+    #wf.makedir(rdir['workflow/planning'])
 
     wf.make_results_web_page(finalize_workflow, os.path.join(os.getcwd(),
                                                              rdir.base))
@@ -494,32 +494,50 @@ layout.group_layout(rdir['single_triggers'], snrchi)
 hist_summ = []
 for insp in full_insps:
     outdir = rdir['single_triggers/%s_binned_triggers' % insp.ifo]
-    wf.make_singles_plot(workflow, [insp], hdfbank, censored_veto,
-                         'closed_box', outdir, tags=['full_data'])
+    singles_plots = wf.make_singles_plot(
+        workflow,
+        [insp],
+        hdfbank,
+        censored_veto,
+        'closed_box',
+        outdir,
+        tags=['full_data']
+    )
+    layout.group_layout(outdir, singles_plots)
     # make non-summary hists using the bank file
     # currently, none of these are made
     outdir = rdir['single_triggers/%s_trigger_histograms' % insp.ifo]
     wf.make_single_hist(workflow, insp, censored_veto, 'closed_box', outdir,
                         bank_file=hdfbank, exclude='summ',
                         tags=['full_data'])
+
+
     # make summary hists for all templates together
     # currently, 2 per ifo: snr and newsnr
     outdir = rdir['single_triggers/%s_trigger_histograms' % insp.ifo]
     allhists = wf.make_single_hist(workflow, insp, censored_veto, 'closed_box',
                                    outdir, require='summ', tags=['full_data'])
+    layout.group_layout(outdir, allhists)
+
     # make hists of newsnr split up by parameter
     # currently, 1 per ifo split by template duration
     outdir = rdir['single_triggers/%s_binned_histograms' % insp.ifo]
     binhists = wf.make_binned_hist(workflow, insp, censored_veto,
                                    'closed_box', outdir, hdfbank,
                                    tags=['full_data'])
+    layout.group_layout(outdir, binhists)
     # put raw SNR and binned newsnr hist in summary
     hist_summ += list(layout.grouper([allhists[0], binhists[0]], 2))
 
 if workflow.cp.has_option_tags('workflow-matchedfilter',
                                'plot-throughput', tags=['full_data']):
-    wf.make_throughput_plot(workflow, full_insps, rdir['workflow/throughput'],
-                            tags=['full_data'])
+   throughput_plots = wf.make_throughput_plot(
+        workflow,
+        full_insps,
+        rdir['workflow/throughput'],
+        tags=['full_data']
+    )
+   layout.group_layout(throughput_plots)
 
 # Run minifollowups on loudest sngl detector events
 excl_subsecs = set([])
@@ -883,12 +901,12 @@ for inj_file, tag in zip(inj_files, inj_tags):
 if len(files_for_combined_injfind) > 0:
     sen_all = wf.make_sensitivity_plot(workflow, found_inj_comb,
                                        rdir['search_sensitivity'],
-                                       require='all')
-    layout.group_layout(rdir['search_sensitivity'], sen_all)
+                                       require='all'
+                                       exclude="summ")
     inj_all = wf.make_foundmissed_plot(workflow, found_inj_comb,
                                        rdir['injections'],
-                                       require='all')
-    layout.group_layout(rdir['injections'], inj_all)
+                                       require='all',
+                                       exclude="summ")
 
     # Make summary page foundmissed and sensitivity plot
     sen_s = wf.make_sensitivity_plot(workflow, found_inj_comb,
@@ -898,6 +916,8 @@ if len(files_for_combined_injfind) > 0:
                                      rdir['injections'],
                                      require='summ')
     inj_summ = list(layout.grouper(inj_s + sen_s, 2))
+    layout.group_layout(rdir['injections'], inj_s + inj_all)
+    layout.group_layout(rdir['search_sensitivity'], sen_s, sen_all)
 
 # Make analysis time summary
 analysis_time_summ = [time_file, seg_summ_plot]
@@ -933,11 +953,12 @@ ini_file = wf.FileList([wf.File(workflow.ifos, '', workflow.analysis_time,
 layout.single_layout(base, ini_file)
 
 # Create versioning information
-wf.make_versioning_page(
+_, version_page = wf.make_versioning_page(
     workflow,
     container.cp,
     rdir['workflow/version'],
 )
+layout.single_layout(rdir['workflow/version'], version_page)
 
 ############################ Finalization ####################################
 finalize(container, workflow, finalize_workflow)

--- a/bin/workflows/pycbc_make_offline_search_workflow
+++ b/bin/workflows/pycbc_make_offline_search_workflow
@@ -47,6 +47,7 @@ def symlink_path(f, path):
     except OSError:
         pass
 
+
 def symlink_result(f, rdir_path):
     symlink_path(f, rdir[rdir_path])
 
@@ -57,6 +58,7 @@ def ifo_combos(ifos):
         combinations = itertools.combinations(ifos, i)
         for ifocomb in combinations:
             yield ifocomb
+
 
 def finalize(container, workflow, finalize_workflow):
     # Create the final log file
@@ -133,6 +135,7 @@ def finalize(container, workflow, finalize_workflow):
     layout.single_layout(rdir['workflow'], ([dashboard_file, gen_file_html, log_file_html]))
     sys.exit(0)
 
+
 def check_stop(job_name, container, workflow, finalize_workflow):
     #This function will finalize the workflow and stop it at the job specified.
     #Under [workflow] supply the option stop-after = and the job name you want the workflow to stop at. Current options are [inspiral, hdf_trigger_merge, statmap]
@@ -143,7 +146,6 @@ def check_stop(job_name, container, workflow, finalize_workflow):
             finalize(container, workflow, finalize_workflow)
         else: 
             pass
-
 
 parser = argparse.ArgumentParser(description=__doc__[1:])
 pycbc.add_common_pycbc_options(parser)
@@ -249,6 +251,7 @@ splitbank_files_fd = wf.setup_splittable_workflow(workflow, [hdfbank],
 bank_tags = []
 if 'mass1_mass2' in workflow.cp.get_subsections('plot_bank'):
     bank_tags=['mass1_mass2']
+
 bank_plot = wf.make_template_plot(workflow, hdfbank,
                                   rdir['background_triggers'],
                                   tags=bank_tags)
@@ -328,7 +331,6 @@ for ifocomb in ifo_combos(ifo_ids.keys()):
                    workflow, bg_file, hdfbank, output_dir,
                    tags=ctagcomb)
 
-
 # Are we analysing single-detector candidates?
 analyze_singles = workflow.cp.has_section('workflow-singles') \
         and workflow.cp.has_option_tags('workflow-singles',
@@ -382,6 +384,14 @@ for ifocomb in ifo_sets:
             output_dir, ordered_ifo_list,
             tags=ctagcomb
         )
+
+# Sort the IFO combinations: longest (most detectors) first, then alphabetical
+final_bg_files = {
+    k: v for k, v in sorted(
+        final_bg_files.items(),
+        key=(lambda kv: (-len(kv[0]), kv[0]))
+    )
+}
 
 if len(ifo_sets) == 1:
     combined_bg_file = no_fg_exc_files[ordered_ifo_list]
@@ -512,7 +522,6 @@ for insp in full_insps:
                         bank_file=hdfbank, exclude='summ',
                         tags=['full_data'])
 
-
     # make summary hists for all templates together
     # currently, 2 per ifo: snr and newsnr
     outdir = rdir['single_triggers/%s_trigger_histograms' % insp.ifo]
@@ -532,13 +541,13 @@ for insp in full_insps:
 
 if workflow.cp.has_option_tags('workflow-matchedfilter',
                                'plot-throughput', tags=['full_data']):
-   throughput_plots = wf.make_throughput_plot(
+    throughput_plot = wf.make_throughput_plot(
         workflow,
         full_insps,
         rdir['workflow/throughput'],
         tags=['full_data']
     )
-   layout.group_layout(rdir['workflow/throughput'], throughput_plots)
+    layout.single_layout(rdir['workflow/throughput'], [throughput_plot])
 
 # Run minifollowups on loudest sngl detector events
 excl_subsecs = set([])
@@ -600,7 +609,6 @@ symlink_result(table, 'open_box_result/significance')
 # Set html pages
 main_page = [(ifar_ob,), (table, )]
 layout.two_column_layout(rdir['open_box_result'], main_page)
-
 
 # run minifollowups on the output of the loudest events
 mfup_dir_fg = rdir['open_box_result/loudest_events_followup']
@@ -667,9 +675,11 @@ for key in final_bg_files:
 #################### Plotting of data quality results #########################
 
 # DQ log likelihood plots
-dq_summ_dir = rdir[f'data_quality']
-dq_summ = []
-for dqf, dql in zip(dqfiles, dqfile_labels):
+
+for dqf, dql in sorted(
+    zip(dqfiles, dqfile_labels),
+    key=lambda dqfl: dqfl[0].ifo
+):
     ifo = dqf.ifo
     dq_dir = rdir[f'data_quality/{dqf.ifo}_DQ_results']
 
@@ -681,7 +691,6 @@ for dqf, dql in zip(dqfiles, dqfile_labels):
         dq_dir,
         tags=[dql]
     )
-    dq_summ.append(trig_rate_plot)
 
     # make table of dq segment info
     seg_table = wf.make_dq_segment_table(workflow, dqf, dq_dir, tags=[dql])
@@ -699,9 +708,8 @@ for dqf, dql in zip(dqfiles, dqfile_labels):
 
     # make table of template bin info
     bininfo = wf.make_template_bin_table(workflow, dqf, dq_dir, tags=[ifo])
-    dq_page = [(trig_rate_plot,), (seg_table, bbin_plot) (bininfo,)]
+    dq_page = [(trig_rate_plot,), (seg_table, bbin_plot), (bininfo,)]
     layout.two_column_layout(dq_dir, dq_page)
-layout.single_layout(dq_summ_dir, dq_summ)
 
 ############################## Setup the injection runs #######################
 
@@ -895,8 +903,13 @@ for inj_file, tag in zip(inj_files, inj_tags):
     # If option given, make throughput plots
     if workflow.cp.has_option_tags('workflow-matchedfilter',
                                    'plot-throughput', tags=[tag]):
-        wf.make_throughput_plot(workflow, insps, rdir['workflow/throughput'],
-                                tags=[tag])
+        # These will show up under the "expand all" button of the page
+        wf.make_throughput_plot(
+            workflow,
+            insps,
+            rdir['workflow/throughput'],
+            tags=[tag]
+        )
 
 ######################## Make combined injection plots ##########################
 if len(files_for_combined_injfind) > 0:
@@ -918,7 +931,7 @@ if len(files_for_combined_injfind) > 0:
                                      require='summ')
     inj_summ = list(layout.grouper(inj_s + sen_s, 2))
     layout.group_layout(rdir['injections'], inj_s + inj_all)
-    layout.group_layout(rdir['search_sensitivity'], sen_s, sen_all)
+    layout.group_layout(rdir['search_sensitivity'], sen_s + sen_all)
 
 # Make analysis time summary
 analysis_time_summ = [time_file, seg_summ_plot]
@@ -941,7 +954,6 @@ for row in summ:
     for f in row:
         symlink_path(f, rdir.base)
 layout.two_column_layout(rdir.base, summ)
-
 
 # Save global config file to results directory
 base = rdir['workflow/configuration']

--- a/pycbc/workflow/plotting.py
+++ b/pycbc/workflow/plotting.py
@@ -146,7 +146,7 @@ def make_throughput_plot(workflow, insp_files, out_dir, tags=None):
     node.add_input_list_opt('--input-file', insp_files)
     node.new_output_file_opt(workflow.analysis_time, '.png', '--output-file')
     workflow += node
-    return node.output_files
+    return node.output_files[0]
 
 
 def make_foreground_table(workflow, trig_file, bank_file, out_dir,

--- a/pycbc/workflow/plotting.py
+++ b/pycbc/workflow/plotting.py
@@ -146,6 +146,7 @@ def make_throughput_plot(workflow, insp_files, out_dir, tags=None):
     node.add_input_list_opt('--input-file', insp_files)
     node.new_output_file_opt(workflow.analysis_time, '.png', '--output-file')
     workflow += node
+    return node.output_files
 
 
 def make_foreground_table(workflow, trig_file, bank_file, out_dir,

--- a/pycbc/workflow/versioning.py
+++ b/pycbc/workflow/versioning.py
@@ -71,4 +71,4 @@ def make_versioning_page(workflow, config_parser, out_dir, tags=None):
     node.new_output_file_opt(workflow.analysis_time, '.html', '--output-file')
     workflow.add_node(node)
 
-    return node
+    return node, node.output_files


### PR DESCRIPTION
I was doing the work from #5062 separately to Ian, and thought I'd apply the same logic/fixes to different parts of the results pages:
 - the DQ, most of the singles and the workflow/(version and throughput) pages were all in "expand all", So I have fixed this by adding the command to make wells
 - Added some things to the DQ summary page
 - In the workflow section, dax, input_map, output_map and planning are all empty. I'm not sure how to add these, so am commenting out for now, but adding a FIXME (I will add an issue as well)
 - I have tried to consolidate the injection and sensitivity pages, which were making the same plots multiple times.

## Standard information about the request

This is a mix of bug fixes and new features
This change affects the offline search
This change changes result presentation / plotting
This change follows style guidelines (See e.g. [PEP8](https://peps.python.org/pep-0008/)), has been proposed using the [contribution guidelines](https://github.com/gwastro/pycbc/blob/master/CONTRIBUTING.md)

## Links to any issues or associated PRs
<!--- If this is fixing / working around an already-reported issue, please link to it here -->

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
