### PR TITLE
Prep for v2.3.11 after I messed up v2.3.10

### DIFF
--- a/pycbc/workflow/pegasus_sites.py
+++ b/pycbc/workflow/pegasus_sites.py
@@ -27,7 +27,6 @@ if release == 'True':
     sing_version = version
 else:
     sing_version = last_release
-sing_version = '2.3.9'
 
 # NOTE urllib is weird. For some reason it only allows known schemes and will
 # give *wrong* results, rather then failing, if you use something like gsiftp

--- a/setup.py
+++ b/setup.py
@@ -119,7 +119,7 @@ def get_version_info():
         vinfo = _version_helper.generate_git_version_info()
     except:
         vinfo = vdummy()
-        vinfo.version = '2.3.10'
+        vinfo.version = '2.3.11'
         vinfo.release = 'True'
 
     version_script = f"""# coding: utf-8


### PR DESCRIPTION
I messed up the v2.3.10 release. Need a minor fix, and bump version number, before we can release v2.3.11 to fix it.