### PR TITLE
possible f_low bug in decompressed wf

### DIFF
--- a/pycbc/waveform/bank.py
+++ b/pycbc/waveform/bank.py
@@ -782,7 +782,7 @@ class FilterBank(TemplateBank):
                 htilde = self.get_decompressed_waveform(
                     tempout,
                     index,
-                    f_lower=f_low,
+                    f_lower=low_frequency_cutoff,
                     approximant=approximant,
                     df=None
                 )


### PR DESCRIPTION
It looks like the use of `f_low` here is a bug. 

## Standard information about the request

<!--- Some basic info about the change (delete as appropriate) -->
This is a: bug fix, new feature, efficiency update, other (please describe)

This change affects: possibly the offline search if compressed waveforms are used via `generate_with_delta_f_and_max_freq`

This change changes: (possibly) scientific output

This change: has appropriate unit tests ?, follows style guidelines (See e.g. [PEP8](https://peps.python.org/pep-0008/)), has been proposed using the [contribution guidelines](https://github.com/gwastro/pycbc/blob/master/CONTRIBUTING.md)

(nb, I do not know if `generate_with_delta_f_and_max_freq` has a unit test)

This change will: hopefully fix some functionality

## Motivation
Current code looks like it should crash 

## Contents
Replace undefined variable `f_low` with the one specified in the method signature

## Testing performed
None so far

