### PR TITLE
Resolve_url for the cache file

### DIFF
--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -694,7 +694,7 @@ class Workflow(pegasus_workflow.Workflow):
         super(Workflow, self).__init__(
             name=name if name is not None else args.workflow_name,
             directory=output_dir,
-            cache_file=args.cache_file,
+            cache_file=resolve_url(args.cache_file),
             dax_file_name=dax_file,
         )
 

--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -691,10 +691,16 @@ class Workflow(pegasus_workflow.Workflow):
         else:
             output_dir = args.output_dir or None
 
+        if args.cache_file is not None:
+            # Resolve any cache files locations
+            cache_file = resolve_url(args.cache_file)
+        else:
+            cache_file = None
+
         super(Workflow, self).__init__(
             name=name if name is not None else args.workflow_name,
             directory=output_dir,
-            cache_file=resolve_url(args.cache_file),
+            cache_file=cache_file,
             dax_file_name=dax_file,
         )
 


### PR DESCRIPTION
cache files in the workflow generators were not being got from repos in the same way that we could before. This fixes that

## Standard information about the request

This is a bug fix / new implementation of an old feature
This change affects: the offline search, inference, PyGRB
This change: follows style guidelines (See e.g. [PEP8](https://peps.python.org/pep-0008/)), has been proposed using the [contribution guidelines](https://github.com/gwastro/pycbc/blob/master/CONTRIBUTING.md)


## Testing performed
Workflow generates when using a file on gitlab

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
