### PR TITLE
Address ci deprecations

### DIFF
--- a/.github/workflows/bank-compress-workflow.yml
+++ b/.github/workflows/bank-compress-workflow.yml
@@ -8,7 +8,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 90
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/basic-tests.yml
+++ b/.github/workflows/basic-tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       max-parallel: 60
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-24.04]
         python-version: ['3.9', '3.10', '3.11', '3.12']
         test-type: [unittest, search, docs]
     steps:

--- a/.github/workflows/build_venv.yml
+++ b/.github/workflows/build_venv.yml
@@ -8,7 +8,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       -
         uses: actions/checkout@v1

--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-14]
+        os: [ubuntu-24.04, macos-14]
 
     steps:
       - uses: actions/checkout@v4
@@ -36,7 +36,7 @@ jobs:
           path: ./wheelhouse/*.whl
   deploy_pypi:
     name: Package and publish to PyPI
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs: build_wheels
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -20,7 +20,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.11'
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel
       - name: Build wheels
@@ -42,10 +42,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
-    - name: Set up Python 3.10
+    - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
+        python-version: '3.11'
     - uses: actions/download-artifact@v4.1.7
       with:
         pattern: wheel-*

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -8,7 +8,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       -
         uses: actions/checkout@v1

--- a/.github/workflows/inference-workflow.yml
+++ b/.github/workflows/inference-workflow.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python

--- a/.github/workflows/search-workflow.yml
+++ b/.github/workflows/search-workflow.yml
@@ -8,7 +8,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 90
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/tmpltbank-workflow.yml
+++ b/.github/workflows/tmpltbank-workflow.yml
@@ -8,7 +8,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python

--- a/.github/workflows/tut-test.yml
+++ b/.github/workflows/tut-test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       max-parallel: 60
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-24.04]
         python-version: ['3.10', '3.11', '3.12']
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/workflow-tests.yml
+++ b/.github/workflows/workflow-tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       max-parallel: 60
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-24.04]
         test-type: [simple_subworkflow_data, multilevel_subworkflow_data]
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
I noticed a couple recent deprecations related to our CI tests. This should address them.

One is the version of Ubuntu: https://github.com/actions/runner-images/issues/11101.

The other one is the Python version used to build the distribution workflow.

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
