### PR TITLE
iDQ workflow code shouldn't look for ifos that aren't there

### DIFF
--- a/pycbc/workflow/dq.py
+++ b/pycbc/workflow/dq.py
@@ -83,7 +83,7 @@ def setup_dq_reranking(workflow, insps, bank,
         dq_types[dql] = workflow.cp.get_opt_tags(
             'workflow-data_quality', 'dq-type', [dql])
 
-    ifos = set(dq_ifos.values())
+    ifos = set(dq_ifos.values()) & set(workflow.ifos)
 
     for ifo in ifos:
         # get the dq label, type, and name for this ifo


### PR DESCRIPTION
The all-sky workflow code is setup so that the `workflow-ifos` section of the config should be the *only* place that decides what ifos are active. If (for example) that section lists h1 and v1, then sections labelled `l1` elsewhere in the config file should be ignored ... They should also not break anything (ie. having `l1` sections should be fine, they just won't be used). This then means that if I want to swap to a L1 V1 analysis I just turn L1 on and remove h1 from `workflow-ifos`.

At the moment the iDQ workflow code breaks this, by searching for section names (and not checking if they are actually being used). The fix is trivial, just do an "AND" operation, with `workflow-ifos` when iDQ figures out which ifos are present. This still allows the functionality that if there is not a "workflow-iDQ-v1" section, we will not try to do V1 iDQ things, even if V1 is active.