### PR TITLE
Polarization problem with marginalized time model

### DIFF
--- a/pycbc/inference/models/marginalized_gaussian_noise.py
+++ b/pycbc/inference/models/marginalized_gaussian_noise.py
@@ -360,6 +360,11 @@ class MarginalizedTime(DistMarg, BaseGaussianNoise):
                                                                  params['tc'])
             dtc = params['tc'] + dt
 
+            pol_phase = numpy.exp(-2.0j * params['polarization'])
+            f = (fp + 1.0j * fc) * pol_phase
+            fp = f.real
+            fc = f.imag
+            
             cplx_hd = fp * cplx_hpd[det].at_time(dtc,
                                                  interpolate='quadratic')
             cplx_hd += fc * cplx_hcd[det].at_time(dtc,

--- a/pycbc/inference/models/marginalized_gaussian_noise.py
+++ b/pycbc/inference/models/marginalized_gaussian_noise.py
@@ -349,6 +349,10 @@ class MarginalizedTime(DistMarg, BaseGaussianNoise):
 
             if self.precalc_antenna_factors:
                 fp, fc, dt = self.get_precalc_antenna_factors(det)
+                pol_phase = numpy.exp(-2.0j * params['polarization'])
+                f = (fp + 1.0j * fc) * pol_phase
+                fp = f.real
+                fc = f.imag
             else:
                 fp, fc = self.dets[det].antenna_pattern(
                                         params['ra'],
@@ -360,11 +364,6 @@ class MarginalizedTime(DistMarg, BaseGaussianNoise):
                                                                  params['tc'])
             dtc = params['tc'] + dt
 
-            pol_phase = numpy.exp(-2.0j * params['polarization'])
-            f = (fp + 1.0j * fc) * pol_phase
-            fp = f.real
-            fc = f.imag
-            
             cplx_hd = fp * cplx_hpd[det].at_time(dtc,
                                                  interpolate='quadratic')
             cplx_hd += fc * cplx_hcd[det].at_time(dtc,


### PR DESCRIPTION
The marginalized time model currently projects the signal onto the detector with the polarization fixed to zero. This causes issues for parameter estimation when polarization is measurable. This pull request introduces a polarization factor to the projection to address this limitation.