### PR TITLE
Implementation of building a Sky Grid with respect to a given covered probability criterion 

### DIFF
--- a/pycbc/distributions/__init__.py
+++ b/pycbc/distributions/__init__.py
@@ -29,7 +29,7 @@ from pycbc.distributions.angular import UniformAngle, SinAngle, CosAngle, \
 from pycbc.distributions.arbitrary import Arbitrary, FromFile
 from pycbc.distributions.gaussian import Gaussian
 from pycbc.distributions.power_law import UniformPowerLaw, UniformRadius
-from pycbc.distributions.sky_location import UniformSky, FisherSky, HealpixSky
+from pycbc.distributions.sky_location import UniformSky, UniformCircleSky, FisherSky, HealpixSky
 from pycbc.distributions.uniform import Uniform
 from pycbc.distributions.uniform_log import UniformLog10
 from pycbc.distributions.spins import IndependentChiPChiEff
@@ -54,6 +54,7 @@ distribs = {
     SinAngle.name : SinAngle,
     UniformSolidAngle.name : UniformSolidAngle,
     UniformSky.name : UniformSky,
+    UniformCircleSky.name : UniformCircleSky,
     UniformLog10.name : UniformLog10,
     UniformF0Tau.name : UniformF0Tau,
     External.name: External,


### PR DESCRIPTION
## Standard information about the request
This PR is a DRAFT.

This is a new feature for  `pycbc_make_sky_grid` script. 

This change affects PyGRB and may affect All-sky searches in the future when I will implement this technique to UniformSky class (still draft PR).

This change changes how the sky grid is generated and sky location classes. 

This change will have appropriate unit tests.

This change will enhance the sky grid generation by generating a sky grid with respect to the coverage that the user want.

## Motivation

This PR is motivated by having a flexible generation of sky grids in general, depending on how much probability you want to cover. Also, thanks to this PR, we can generate a sky grid with FITS map (in order to solve this issue : #4995)

## Contents
I have implemented a new function to the FisherSky and HealpixSky classes called `to_uniform_patch` that convert these distributions to a uniform patch, depending on the coverage that the user has to specify. This is what would be used to generate the sky grid.

## Links to any issues or associated PRs
#4955 

## Testing performed
Still on going...


- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
