### PR TITLE
PyGRB: fixing the no found injections case.

### DIFF
--- a/bin/pygrb/pycbc_pygrb_efficiency
+++ b/bin/pygrb/pycbc_pygrb_efficiency
@@ -329,7 +329,7 @@ found_after_vetoes, vetoed, *_ = ppu.apply_vetoes_to_found_injs(
 # ===================================================================
 # Post-process injections: skip this if there are no found injections
 # ===================================================================
-if 'network/template_id' in found_after_vetoes.keys():
+if len(found_after_vetoes['network/template_id']):
     # Calculate quantities not included in trigger files, such as chirp mass
     found_trig_mchirp = \
         template_mchirps[found_after_vetoes['network/template_id']]
@@ -570,7 +570,7 @@ if opts.background_output_file:
     ax = fig.gca()
 
     # Without found injections, do not determine these quantities to plot
-    if 'network/template_id' in found_after_vetoes.keys():
+    if len(found_after_vetoes['network/template_id']):
         # Calculate distances (horizontal axis) as means
         dist_plot_vals = [np.asarray(dist_bin).mean()
                           for dist_bin in dist_bins]
@@ -616,7 +616,7 @@ if opts.background_output_file:
 # excl_dist dictionary contains 50% and 90% exclusion distances
 # It contains NaNs unless there are found injections
 excl_dist = {f"{percentile}%": 'NaN' for percentile in [50, 90]}
-if 'network/template_id' in found_after_vetoes.keys():
+if len(found_after_vetoes['network/template_id']):
     # Calculate error bars for efficiency/distance plots and datafiles
     # using max BestNR of foreground
     yerr_low_no_mc, yerr_high_no_mc, fraction_no_mc = efficiency_with_errs(
@@ -666,7 +666,7 @@ if opts.onsource_output_file:
     fig = plt.figure()
     ax = fig.gca()
     ax.grid()
-    if 'network/template_id' in found_after_vetoes.keys():
+    if len(found_after_vetoes['network/template_id']):
         ax.plot(dist_plot_vals, (fraction_no_mc), 'g-',
                 label='No marginalisation')
         ax.errorbar(dist_plot_vals, (fraction_no_mc),

--- a/bin/pygrb/pycbc_pygrb_efficiency
+++ b/bin/pygrb/pycbc_pygrb_efficiency
@@ -326,233 +326,236 @@ found_after_vetoes, vetoed, *_ = ppu.apply_vetoes_to_found_injs(
     veto_file=veto_file
 )
 
-# Calculate quantities not included in trigger files, such as chirp mass
-found_trig_mchirp = template_mchirps[found_after_vetoes['network/template_id']]
+# Calculate quantities not included in trigger files, such as chirp mass, if
+# there are found triggers
+if 'network/template_id' in found_after_vetoes.keys():
+    found_trig_mchirp = template_mchirps[found_after_vetoes['network/template_id']]
 
-# Construct conditions for injection:
-# 1) found (surviving vetoes) louder than background,
-zero_fap = np.zeros(len(found_after_vetoes['network/end_time_gc'])).astype(bool)
-zero_fap_cut = found_after_vetoes['network/reweighted_snr'] > max_bestnr
-zero_fap = zero_fap | (zero_fap_cut)
+    # Construct conditions for injection:
+    # 1) found (surviving vetoes) louder than background,
+    zero_fap = np.zeros(len(found_after_vetoes['network/end_time_gc'])).astype(bool)
+    zero_fap_cut = found_after_vetoes['network/reweighted_snr'] > max_bestnr
+    zero_fap = zero_fap | (zero_fap_cut)
 
-# 2) found (bestnr > 0, and surviving vetoes) but not louder than background
-nonzero_fap = ~zero_fap & (found_after_vetoes['network/reweighted_snr'] != 0)
+    # 2) found (bestnr > 0, and surviving vetoes) but not louder than background
+    nonzero_fap = ~zero_fap & (found_after_vetoes['network/reweighted_snr'] != 0)
 
-# 3) missed after being recovered (i.e., vetoed) are in vetoed
+    # 3) missed after being recovered (i.e., vetoed) are in vetoed
 
-# Non-zero FAP triggers (g_ifar)
-g_ifar = {}
-g_ifar['bestnr'] = found_after_vetoes['network/reweighted_snr'][nonzero_fap]
-g_ifar['stat'] = np.zeros([len(g_ifar['bestnr'])])
-for ix, (mc, bestnr) in \
-            enumerate(zip(found_trig_mchirp[nonzero_fap], g_ifar['bestnr'])):
-    g_ifar['stat'][ix] = (sorted_bkgd > bestnr).sum()
-g_ifar['stat'] = g_ifar['stat'] / total_trials
+    # Non-zero FAP triggers (g_ifar)
+    g_ifar = {}
+    g_ifar['bestnr'] = found_after_vetoes['network/reweighted_snr'][nonzero_fap]
+    g_ifar['stat'] = np.zeros([len(g_ifar['bestnr'])])
+    for ix, (mc, bestnr) in \
+                enumerate(zip(found_trig_mchirp[nonzero_fap], g_ifar['bestnr'])):
+        g_ifar['stat'][ix] = (sorted_bkgd > bestnr).sum()
+    g_ifar['stat'] = g_ifar['stat'] / total_trials
 
-# Set the sigma values
-inj_sigma = {ifo: found_after_vetoes[f'{ifo}/sigmasq'][:] for ifo in ifos}
-# If the sigmasqs are not populated, we can still do calibration errors,
-# but only in the 1-detector case
-for ifo in ifos:
-    if sum(inj_sigma[ifo] == 0):
-        logging.info("%s: sigmasq not set for at least one trigger.", ifo)
-    if sum(inj_sigma[ifo] != 0) == 0:
-        logging.info("%s: sigmasq not set for any trigger.", ifo)
-        if len(ifos) == 1:
-            msg = "Since this is a single ifo analysis, sigmasq will be "
-            msg += "set to unity for all triggers in order to build the "
-            msg += "calibration errors."
-            logging.info(msg)
-            inj_sigma[ifo][:] = 1.
+    # Set the sigma values
+    inj_sigma = {ifo: found_after_vetoes[f'{ifo}/sigmasq'][:] for ifo in ifos}
+    # If the sigmasqs are not populated, we can still do calibration errors,
+    # but only in the 1-detector case
+    for ifo in ifos:
+        if sum(inj_sigma[ifo] == 0):
+            logging.info("%s: sigmasq not set for at least one trigger.", ifo)
+        if sum(inj_sigma[ifo] != 0) == 0:
+            logging.info("%s: sigmasq not set for any trigger.", ifo)
+            if len(ifos) == 1:
+                msg = "Since this is a single ifo analysis, sigmasq will be "
+                msg += "set to unity for all triggers in order to build the "
+                msg += "calibration errors."
+                logging.info(msg)
+                inj_sigma[ifo][:] = 1.
 
-f_resp = {}
-for ifo in ifos:
-    antenna = Detector(ifo)
-    f_resp[ifo] = ppu.get_antenna_responses(antenna,
-                                            found_after_vetoes['found/ra'][:],
-                                            found_after_vetoes['found/dec'][:],
-                                            found_after_vetoes['found/tc'][:])
+    f_resp = {}
+    for ifo in ifos:
+        antenna = Detector(ifo)
+        f_resp[ifo] = ppu.get_antenna_responses(antenna,
+                                                found_after_vetoes['found/ra'][:],
+                                                found_after_vetoes['found/dec'][:],
+                                                found_after_vetoes['found/tc'][:])
 
-inj_sigma_mult = (np.asarray(list(inj_sigma.values())) *
-                  np.asarray(list(f_resp.values())))
+    inj_sigma_mult = (np.asarray(list(inj_sigma.values())) *
+                      np.asarray(list(f_resp.values())))
 
-inj_sigma_tot = inj_sigma_mult[0, :]
-for i in range(1, len(ifos)):
-    inj_sigma_tot += inj_sigma_mult[i, :]
+    inj_sigma_tot = inj_sigma_mult[0, :]
+    for i in range(1, len(ifos)):
+        inj_sigma_tot += inj_sigma_mult[i, :]
 
-inj_sigma_mean = {}
-for ifo in ifos:
-    inj_sigma_mean[ifo] = ((inj_sigma[ifo]*f_resp[ifo])/inj_sigma_tot).mean()
+    inj_sigma_mean = {}
+    for ifo in ifos:
+        inj_sigma_mean[ifo] = ((inj_sigma[ifo]*f_resp[ifo])/inj_sigma_tot).mean()
 
-msg = f"{len(found_after_vetoes['found/tc'])} injections found and surviving "
-msg += f"vetoes and {len(injs['missed/tc'])} missed injections analysed."
-logging.info(msg)
+    msg = f"{len(found_after_vetoes['found/tc'])} injections found and surviving "
+    msg += f"vetoes and {len(injs['missed/tc'])} missed injections analysed."
+    logging.info(msg)
 
-# Create new set of injections for efficiency calculations:
-# these are as many as the original injections
-total_injs = len(injs['found/distance']) + len(injs['missed/distance'])
-long_inj = {}
-long_inj['dist'] = stats.uniform.rvs(size=total_injs) * \
-    (upper_dist-lower_dist) + upper_dist
+    # Create new set of injections for efficiency calculations:
+    # these are as many as the original injections
+    total_injs = len(injs['found/distance']) + len(injs['missed/distance'])
+    long_inj = {}
+    long_inj['dist'] = stats.uniform.rvs(size=total_injs) * \
+        (upper_dist-lower_dist) + upper_dist
 
-logging.info("%d long distance injections created.", total_injs)
+    logging.info("%d long distance injections created.", total_injs)
 
-# Set distance bins and data arrays
-dist_bins = zip(np.arange(lower_dist, upper_dist + (upper_dist-lower_dist),
-                          (upper_dist-lower_dist)/num_bins),
-                np.arange(lower_dist, upper_dist + (upper_dist-lower_dist),
-                          (upper_dist-lower_dist)/num_bins) +
-                         (upper_dist-lower_dist)/num_bins)
-dist_bins = list(dist_bins)
+    # Set distance bins and data arrays
+    dist_bins = zip(np.arange(lower_dist, upper_dist + (upper_dist-lower_dist),
+                              (upper_dist-lower_dist)/num_bins),
+                    np.arange(lower_dist, upper_dist + (upper_dist-lower_dist),
+                              (upper_dist-lower_dist)/num_bins) +
+                             (upper_dist-lower_dist)/num_bins)
+    dist_bins = list(dist_bins)
 
-num_dist_bins_plus_one = len(dist_bins) + 1
-num_injections = {}
-found_max_bestnr = {}
-found_on_bestnr = {}
-for key in ['mc', 'no_mc']:
-    num_injections[key] = np.zeros(num_dist_bins_plus_one)
-    found_max_bestnr[key] = np.zeros(num_dist_bins_plus_one)
-    found_on_bestnr[key] = np.zeros(num_dist_bins_plus_one)
+    num_dist_bins_plus_one = len(dist_bins) + 1
+    num_injections = {}
+    found_max_bestnr = {}
+    found_on_bestnr = {}
+    for key in ['mc', 'no_mc']:
+        num_injections[key] = np.zeros(num_dist_bins_plus_one)
+        found_max_bestnr[key] = np.zeros(num_dist_bins_plus_one)
+        found_on_bestnr[key] = np.zeros(num_dist_bins_plus_one)
 
-# Construct FAP list for all found injections
-inj_fap = np.zeros(len(found_after_vetoes['found/distance']))
-inj_fap[nonzero_fap] = g_ifar['stat']
+    # Construct FAP list for all found injections
+    inj_fap = np.zeros(len(found_after_vetoes['found/distance']))
+    inj_fap[nonzero_fap] = g_ifar['stat']
 
-# Calculate the amplitude error
-# Begin by calculating the components from each detector
-cal_error = 0
-for ifo in ifos:
-    cal_error += cal_errs[ifo]**2 * inj_sigma_mean[ifo]**2
-cal_error = cal_error**0.5
+    # Calculate the amplitude error
+    # Begin by calculating the components from each detector
+    cal_error = 0
+    for ifo in ifos:
+        cal_error += cal_errs[ifo]**2 * inj_sigma_mean[ifo]**2
+    cal_error = cal_error**0.5
 
-max_dc_cal_error = max(cal_dc_errs.values())
+    max_dc_cal_error = max(cal_dc_errs.values())
 
-# Calibration phase uncertainties are neglected
-logging.info("Calibration amplitude uncertainty calculated.")
+    # Calibration phase uncertainties are neglected
+    logging.info("Calibration amplitude uncertainty calculated.")
 
-# Now create the numbers for the efficiency plots; these include calibration
-# and waveform errors. These are incorporated by running over each injection
-# num_mc_injs times, where each time we draw a random value of distance
+    # Now create the numbers for the efficiency plots; these include calibration
+    # and waveform errors. These are incorporated by running over each injection
+    # num_mc_injs times, where each time we draw a random value of distance
 
-# Distribute injections
-# NOTE: the loop on num_mc_injs would fill up the *_inj['dist_mc']'s at the
-# same time, so filling them up sequentially will vary the numbers a little
-# (this is an MC, order of operations matters!)
-found_inj_dist_mc = ppu.mc_cal_wf_errs(
-    num_mc_injs,
-    found_after_vetoes['found/distance'],
-    cal_error,
-    wav_err,
-    max_dc_cal_error
-)
-missed_inj_dist_mc = ppu.mc_cal_wf_errs(
-    num_mc_injs,
-    np.concatenate((vetoed['found/distance'],injs['missed/distance'])),
-    cal_error,
-    wav_err,
-    max_dc_cal_error
-)
-long_inj['dist_mc'] = ppu.mc_cal_wf_errs(num_mc_injs, long_inj['dist'],
-                                         cal_error, wav_err, max_dc_cal_error)
+    # Distribute injections
+    # NOTE: the loop on num_mc_injs would fill up the *_inj['dist_mc']'s at the
+    # same time, so filling them up sequentially will vary the numbers a little
+    # (this is an MC, order of operations matters!)
+    found_inj_dist_mc = ppu.mc_cal_wf_errs(
+        num_mc_injs,
+        found_after_vetoes['found/distance'],
+        cal_error,
+        wav_err,
+        max_dc_cal_error
+    )
+    missed_inj_dist_mc = ppu.mc_cal_wf_errs(
+        num_mc_injs,
+        np.concatenate((vetoed['found/distance'],injs['missed/distance'])),
+        cal_error,
+        wav_err,
+        max_dc_cal_error
+    )
+    long_inj['dist_mc'] = ppu.mc_cal_wf_errs(num_mc_injs, long_inj['dist'],
+                                             cal_error, wav_err, max_dc_cal_error)
 
-logging.info("MC injection set distributed with %d iterations.",
-             num_mc_injs)
+    logging.info("MC injection set distributed with %d iterations.",
+                 num_mc_injs)
 
-# Check injections against on source
-if onsource_file:
-    more_sig_than_onsource = (inj_fap <= loud_on_fap)
-else:
-    more_sig_than_onsource = (inj_fap <= 0.5)
+    # Check injections against on source
+    if onsource_file:
+        more_sig_than_onsource = (inj_fap <= loud_on_fap)
+    else:
+        more_sig_than_onsource = (inj_fap <= 0.5)
 
-distance_count = np.zeros(len(dist_bins))
+    distance_count = np.zeros(len(dist_bins))
 
-found_trig_max_bestnr = np.empty(len(found_after_vetoes['network/event_id']))
-found_trig_max_bestnr.fill(max_bestnr)
+    found_trig_max_bestnr = np.empty(len(found_after_vetoes['network/event_id']))
+    found_trig_max_bestnr.fill(max_bestnr)
 
-max_bestnr_cut = (found_after_vetoes['network/reweighted_snr'] > found_trig_max_bestnr)
+    max_bestnr_cut = (found_after_vetoes['network/reweighted_snr'] > found_trig_max_bestnr)
 
-# Check louder than on source
-found_trig_loud_on_bestnr = np.empty(len(found_after_vetoes['network/event_id']))
-if onsource_file:
-    found_trig_loud_on_bestnr.fill(loud_on_bestnr)
-else:
-    found_trig_loud_on_bestnr.fill(median_bestnr)
-on_bestnr_cut = found_after_vetoes['network/reweighted_snr'] > found_trig_loud_on_bestnr
+    # Check louder than on source
+    found_trig_loud_on_bestnr = np.empty(len(found_after_vetoes['network/event_id']))
+    if onsource_file:
+        found_trig_loud_on_bestnr.fill(loud_on_bestnr)
+    else:
+        found_trig_loud_on_bestnr.fill(median_bestnr)
+    on_bestnr_cut = found_after_vetoes['network/reweighted_snr'] > found_trig_loud_on_bestnr
 
-# Check whether injection is found for the purposes of exclusion
-# distance calculation.
-# Found: if louder than all on source
-# Missed: if not louder than loudest on source
-found_excl = on_bestnr_cut & (more_sig_than_onsource) & \
-            (found_after_vetoes['network/reweighted_snr'] != 0)
-# If not missed, double check bestnr against nearby triggers
-near_test = np.zeros((found_excl).sum()).astype(bool)
-for j, (t, bestnr) in enumerate(zip(found_after_vetoes['found/tc'][found_excl],
-                                found_after_vetoes['network/reweighted_snr'][found_excl])):
-    # 0 is the zero-lag timeslide
-    near_bestnr = \
-        trig_data[keys[1]][0][np.abs(trig_data[keys[0]][0]-t) < cluster_window]
-    near_test[j] = ~((near_bestnr * glitch_check_fac > bestnr).any())
-# Apply the local test
-c = 0
-for z, b in enumerate(found_excl):
-    if found_excl[z]:
-        found_excl[z] = near_test[c]
-        c += 1
+    # Check whether injection is found for the purposes of exclusion
+    # distance calculation.
+    # Found: if louder than all on source
+    # Missed: if not louder than loudest on source
+    found_excl = on_bestnr_cut & (more_sig_than_onsource) & \
+                (found_after_vetoes['network/reweighted_snr'] != 0)
+    # If not missed, double check bestnr against nearby triggers
+    near_test = np.zeros((found_excl).sum()).astype(bool)
+    for j, (t, bestnr) in enumerate(zip(found_after_vetoes['found/tc'][found_excl],
+                                    found_after_vetoes['network/reweighted_snr'][found_excl])):
+        # 0 is the zero-lag timeslide
+        near_bestnr = \
+            trig_data[keys[1]][0][np.abs(trig_data[keys[0]][0]-t) < cluster_window]
+        near_test[j] = ~((near_bestnr * glitch_check_fac > bestnr).any())
+    # Apply the local test
+    c = 0
+    for z, b in enumerate(found_excl):
+        if found_excl[z]:
+            found_excl[z] = near_test[c]
+            c += 1
 
-# Loop over each random instance of the injection set
-for k in range(num_mc_injs+1):
-    # Loop over the distance bins
-    for j, dist_bin in enumerate(dist_bins):
-        # Construct distance cut
-        found_dist_cut = (dist_bin[0] <= found_inj_dist_mc[k, :]) &\
-                         (found_inj_dist_mc[k, :] < dist_bin[1])
-        missed_dist_cut = (dist_bin[0] <= missed_inj_dist_mc[k, :]) &\
-                          (missed_inj_dist_mc[k, :] < dist_bin[1])
-        long_dist_cut = (dist_bin[0] <= long_inj['dist_mc'][k, :]) &\
-                        (long_inj['dist_mc'][k, :] < dist_bin[1])
+    # Loop over each random instance of the injection set
+    for k in range(num_mc_injs+1):
+        # Loop over the distance bins
+        for j, dist_bin in enumerate(dist_bins):
+            # Construct distance cut
+            found_dist_cut = (dist_bin[0] <= found_inj_dist_mc[k, :]) &\
+                             (found_inj_dist_mc[k, :] < dist_bin[1])
+            missed_dist_cut = (dist_bin[0] <= missed_inj_dist_mc[k, :]) &\
+                              (missed_inj_dist_mc[k, :] < dist_bin[1])
+            long_dist_cut = (dist_bin[0] <= long_inj['dist_mc'][k, :]) &\
+                            (long_inj['dist_mc'][k, :] < dist_bin[1])
 
-        # Count all injections in this distance bin
-        num_found_pass = (found_dist_cut).sum()
-        num_missed_pass = (missed_dist_cut).sum()
-        num_long_pass = long_dist_cut.sum() or 0
-        # Count only zero FAR injections
-        num_zero_far = (found_dist_cut & max_bestnr_cut).sum()
-        # Count number found for exclusion
-        num_excl = (found_dist_cut & (found_excl)).sum()
+            # Count all injections in this distance bin
+            num_found_pass = (found_dist_cut).sum()
+            num_missed_pass = (missed_dist_cut).sum()
+            num_long_pass = long_dist_cut.sum() or 0
+            # Count only zero FAR injections
+            num_zero_far = (found_dist_cut & max_bestnr_cut).sum()
+            # Count number found for exclusion
+            num_excl = (found_dist_cut & (found_excl)).sum()
 
-        # Record number of injections, number found for exclusion
-        # and number of zero FAR
-        if k == 0:
-            key = 'no_mc'
-        else:
-            key = 'mc'
-        num_pass = num_found_pass + num_missed_pass + num_long_pass
-        num_injections[key][j] += num_pass
-        num_injections[key][-1] += num_pass
-        found_max_bestnr[key][j] += num_zero_far
-        found_max_bestnr[key][-1] += num_zero_far
-        found_on_bestnr[key][j] += num_excl
-        found_on_bestnr[key][-1] += num_excl
+            # Record number of injections, number found for exclusion
+            # and number of zero FAR
+            if k == 0:
+                key = 'no_mc'
+            else:
+                key = 'mc'
+            num_pass = num_found_pass + num_missed_pass + num_long_pass
+            num_injections[key][j] += num_pass
+            num_injections[key][-1] += num_pass
+            found_max_bestnr[key][j] += num_zero_far
+            found_max_bestnr[key][-1] += num_zero_far
+            found_on_bestnr[key][j] += num_excl
+            found_on_bestnr[key][-1] += num_excl
 
-logging.info("Found/missed injection efficiency calculations completed.")
+    logging.info("Found/missed injection efficiency calculations completed.")
 
-# Post-processing of injections ends here
+    # Post-processing of injections ends here
 
-# ==========
-# Make plots
-# ==========
-logging.info("Plotting.")
-# Calculate distances (horizontal axis) as means
-dist_plot_vals = [np.asarray(dist_bin).mean() for dist_bin in dist_bins]
+    # ==========
+    # Make plots
+    # ==========
+    logging.info("Plotting.")
+    # Calculate distances (horizontal axis) as means
+    dist_plot_vals = [np.asarray(dist_bin).mean() for dist_bin in dist_bins]
 
-# Calculate error bars for efficiency/distance plots and datafiles
-# using max BestNR of background
-yerr_low_mc, yerr_high_mc, fraction_mc = efficiency_with_errs(
-     found_max_bestnr['mc'], num_injections['mc'], num_mc_injs=num_mc_injs)
-yerr_low_no_mc, yerr_high_no_mc, fraction_no_mc = efficiency_with_errs(
-                           found_max_bestnr['no_mc'], num_injections['no_mc'])
+    # Calculate error bars for efficiency/distance plots and datafiles
+    # using max BestNR of background
+    yerr_low_mc, yerr_high_mc, fraction_mc = efficiency_with_errs(
+         found_max_bestnr['mc'], num_injections['mc'], num_mc_injs=num_mc_injs)
+    yerr_low_no_mc, yerr_high_no_mc, fraction_no_mc = efficiency_with_errs(
+                               found_max_bestnr['no_mc'], num_injections['no_mc'])
 
+<<<<<<< HEAD
 # Plot efficiency using loudest background
 if opts.background_output_file:
     fig = plt.figure()
@@ -581,44 +584,74 @@ if opts.background_output_file:
     save_fig_with_metadata(fig, fig_path, cmd=' '.join(sys.argv),
                            title=plot_title, caption=plot_caption)
     plt.close()
+=======
+    # Plot efficiency using loudest background
+    if opts.background_output_file:
+        fig = plt.figure()
+        ax = fig.gca()
+        ax.plot(dist_plot_vals, (fraction_no_mc), 'g-',
+                label='No marginalisation')
+        ax.errorbar(dist_plot_vals, (fraction_no_mc),
+                    yerr=[yerr_low_no_mc, yerr_high_no_mc], c='green')
+        marg_eff = fraction_mc
+        if np.nansum(marg_eff) > 0:
+            ax.plot(dist_plot_vals, marg_eff, 'r-', label='Marginalised')
+            ax.errorbar(dist_plot_vals, marg_eff, yerr=[yerr_low_mc, yerr_high_mc],
+                        c='red')
+        ax.legend()
+        ax.grid()
+        ax.set_ylim([0, 1])
+        ax.set_xlim(0, 1.3*upper_dist)
+        ax.set_ylabel("Fraction of injections found louder than loudest background")
+        ax.set_xlabel("Distance (Mpc)")
+        plot_title = "Detection efficiency - "+inj_set_name
+        plot_caption = "Injection recovery efficiency using "
+        plot_caption += "BestNR as detection statistic.  "
+        plot_caption += "Injections louder than loudest background trigger."
+        fig_path = opts.background_output_file
+        save_fig_with_metadata(fig, fig_path, cmd=' '.join(sys.argv),
+                               title=plot_title, caption=plot_caption)
+        plt.close()
+>>>>>>> 8134c2fb (Update pycbc_pygrb_efficiency)
 
-# Calculate error bars for efficiency/distance plots and datafiles
-# using max BestNR of foreground
-yerr_low_no_mc, yerr_high_no_mc, fraction_no_mc = efficiency_with_errs(
-                            found_on_bestnr['no_mc'], num_injections['no_mc'])
-yerr_low, yerr_high, fraction_mc = \
-    efficiency_with_errs(found_on_bestnr['mc'], num_injections['mc'],
-                         num_mc_injs=num_mc_injs)
+    # Calculate error bars for efficiency/distance plots and datafiles
+    # using max BestNR of foreground
+    yerr_low_no_mc, yerr_high_no_mc, fraction_no_mc = efficiency_with_errs(
+                                found_on_bestnr['no_mc'], num_injections['no_mc'])
+    yerr_low, yerr_high, fraction_mc = \
+        efficiency_with_errs(found_on_bestnr['mc'], num_injections['mc'],
+                             num_mc_injs=num_mc_injs)
 
-# Marginalized efficiency (isf = inverse survival function)
-red_efficiency = (fraction_mc) - (yerr_low) * scipy.stats.norm.isf(0.1)
+    # Marginalized efficiency (isf = inverse survival function)
+    red_efficiency = (fraction_mc) - (yerr_low) * scipy.stats.norm.isf(0.1)
 
 # Calculate and save to disk 50% and 90% exclusion distances
 # excl_dist dictionary contains 50% and 90% exclusion distances
-excl_dist = {}
-for percentile in [50, 90]:
-    eff_idx = np.where(red_efficiency < (percentile / 100.))[0]
-    if eff_idx.size == 0:
-        green_efficiency = (fraction_no_mc)
-        excl_efficiency = green_efficiency
-        eff_idx = np.where(green_efficiency < (percentile / 100.))[0]
-    else:
-        excl_efficiency = red_efficiency
-    if eff_idx.size and eff_idx[0] != 0:
-        i = eff_idx[0]
-        d = dist_plot_vals[i]
-        d_low = dist_plot_vals[i-1]
-        e = excl_efficiency[i]
-        e_low = excl_efficiency[i-1]
-        excl_dist[f"{percentile}%"] = d + (e - (percentile / 100.)) * (d - d_low) /\
-            (e_low - e)
-    else:
-        # Warn the user if the exclusion distance cannot be established,
-        # but let the workflow continue: the user will see the plot(s) and
-        # repeat with more injections
-        excl_dist[f"{percentile}%"] = 0
-        msg = "Efficiency below %d%% in first bin!" % (percentile)
-        logging.warning(msg)
+excl_dist = {f"{percentile}%": 'NaN' for percentile in [50, 90]}
+if 'network/template_id' in found_after_vetoes.keys():
+    for percentile in [50, 90]:
+        eff_idx = np.where(red_efficiency < (percentile / 100.))[0]
+        if eff_idx.size == 0:
+            green_efficiency = (fraction_no_mc)
+            excl_efficiency = green_efficiency
+            eff_idx = np.where(green_efficiency < (percentile / 100.))[0]
+        else:
+            excl_efficiency = red_efficiency
+        if eff_idx.size and eff_idx[0] != 0:
+            i = eff_idx[0]
+            d = dist_plot_vals[i]
+            d_low = dist_plot_vals[i-1]
+            e = excl_efficiency[i]
+            e_low = excl_efficiency[i-1]
+            excl_dist[f"{percentile}%"] = d + (e - (percentile / 100.)) * (d - d_low) /\
+                (e_low - e)
+        else:
+            # Warn the user if the exclusion distance cannot be established,
+            # but let the workflow continue: the user will see the plot(s) and
+            # repeat with more injections
+            excl_dist[f"{percentile}%"] = 0
+            msg = "Efficiency below %d%% in first bin!" % (percentile)
+            logging.warning(msg)
 
 # Write 50% and 90% exclusion distances to JSON file
 # Also include injection set name and trial name
@@ -628,34 +661,36 @@ if opts.exclusion_dist_output_file:
     with open(opts.exclusion_dist_output_file, 'w') as excl_dist_file:
         json.dump(excl_dist, excl_dist_file)
 
+
 # Plot efficiency using loudest foreground
 if opts.onsource_output_file:
     fig = plt.figure()
     ax = fig.gca()
     ax.grid()
-    ax.plot(dist_plot_vals, (fraction_no_mc), 'g-',
-            label='No marginalisation')
-    ax.errorbar(dist_plot_vals, (fraction_no_mc),
-                yerr=[yerr_low_no_mc, yerr_high_no_mc], c='green')
-    marg_eff = fraction_mc
-    if np.nansum(marg_eff) > 0:
-        ax.plot(dist_plot_vals, marg_eff, 'r-', label='Marginalised')
-        ax.errorbar(dist_plot_vals, marg_eff, yerr=[yerr_low, yerr_high],
-                    c='red')
-    if np.nansum(red_efficiency) > 0:
-        ax.plot(dist_plot_vals, red_efficiency, 'm-',
-                label='Inc. counting errors')
-    ax.set_ylim([0, 1])
-    ax.grid()
-    ax.legend()
-    ax.get_legend().get_frame().set_alpha(0.5)
-    ax.grid()
-    ax.set_ylim([0, 1])
-    ax.set_xlim(0, 1.3*upper_dist)
+    if 'network/template_id' in found_after_vetoes.keys():
+        ax.plot(dist_plot_vals, (fraction_no_mc), 'g-',
+                label='No marginalisation')
+        ax.errorbar(dist_plot_vals, (fraction_no_mc),
+                    yerr=[yerr_low_no_mc, yerr_high_no_mc], c='green')
+        marg_eff = fraction_mc
+        if np.nansum(marg_eff) > 0:
+            ax.plot(dist_plot_vals, marg_eff, 'r-', label='Marginalised')
+            ax.errorbar(dist_plot_vals, marg_eff, yerr=[yerr_low, yerr_high],
+                        c='red')
+        if np.nansum(red_efficiency) > 0:
+            ax.plot(dist_plot_vals, red_efficiency, 'm-',
+                    label='Inc. counting errors')
+        ax.set_ylim([0, 1])
+        ax.grid()
+        ax.legend()
+        ax.get_legend().get_frame().set_alpha(0.5)
+        ax.grid()
+        ax.set_ylim([0, 1])
+        ax.set_xlim(0, 1.3*upper_dist)
+        ax.plot([excl_dist["90%"]], [0.9], 'gx')
     ax.set_ylabel("Fraction of injections found louder than " +
                   "loudest foreground")
     ax.set_xlabel("Distance (Mpc)")
-    ax.plot([excl_dist["90%"]], [0.9], 'gx')
     ax.set_ylim([0, 1])
     ax.set_xlim(0, 1.3*upper_dist)
     plot_title = "Exclusion distance - "+inj_set_name
@@ -670,3 +705,4 @@ if opts.onsource_output_file:
     plt.close()
 
 logging.info("Done.")
+                 

--- a/bin/pygrb/pycbc_pygrb_efficiency
+++ b/bin/pygrb/pycbc_pygrb_efficiency
@@ -326,28 +326,34 @@ found_after_vetoes, vetoed, *_ = ppu.apply_vetoes_to_found_injs(
     veto_file=veto_file
 )
 
-# Calculate quantities not included in trigger files, such as chirp mass, if
-# there are found triggers
+# ===================================================================
+# Post-process injections: skip this if there are no found injections
+# ===================================================================
 if 'network/template_id' in found_after_vetoes.keys():
-    found_trig_mchirp = template_mchirps[found_after_vetoes['network/template_id']]
+    # Calculate quantities not included in trigger files, such as chirp mass
+    found_trig_mchirp = \
+        template_mchirps[found_after_vetoes['network/template_id']]
 
     # Construct conditions for injection:
     # 1) found (surviving vetoes) louder than background,
-    zero_fap = np.zeros(len(found_after_vetoes['network/end_time_gc'])).astype(bool)
+    zero_fap = \
+        np.zeros(len(found_after_vetoes['network/end_time_gc'])).astype(bool)
     zero_fap_cut = found_after_vetoes['network/reweighted_snr'] > max_bestnr
     zero_fap = zero_fap | (zero_fap_cut)
 
-    # 2) found (bestnr > 0, and surviving vetoes) but not louder than background
-    nonzero_fap = ~zero_fap & (found_after_vetoes['network/reweighted_snr'] != 0)
+    # 2) found (bestnr>0, and surviving vetoes) but not louder than background
+    nonzero_fap = ~zero_fap & (found_after_vetoes['network/reweighted_snr']
+                               != 0)
 
     # 3) missed after being recovered (i.e., vetoed) are in vetoed
 
     # Non-zero FAP triggers (g_ifar)
     g_ifar = {}
-    g_ifar['bestnr'] = found_after_vetoes['network/reweighted_snr'][nonzero_fap]
+    g_ifar['bestnr'] = \
+        found_after_vetoes['network/reweighted_snr'][nonzero_fap]
     g_ifar['stat'] = np.zeros([len(g_ifar['bestnr'])])
     for ix, (mc, bestnr) in \
-                enumerate(zip(found_trig_mchirp[nonzero_fap], g_ifar['bestnr'])):
+            enumerate(zip(found_trig_mchirp[nonzero_fap], g_ifar['bestnr'])):
         g_ifar['stat'][ix] = (sorted_bkgd > bestnr).sum()
     g_ifar['stat'] = g_ifar['stat'] / total_trials
 
@@ -370,10 +376,11 @@ if 'network/template_id' in found_after_vetoes.keys():
     f_resp = {}
     for ifo in ifos:
         antenna = Detector(ifo)
-        f_resp[ifo] = ppu.get_antenna_responses(antenna,
-                                                found_after_vetoes['found/ra'][:],
-                                                found_after_vetoes['found/dec'][:],
-                                                found_after_vetoes['found/tc'][:])
+        f_resp[ifo] = ppu.get_antenna_responses(
+            antenna,
+            found_after_vetoes['found/ra'][:],
+            found_after_vetoes['found/dec'][:],
+            found_after_vetoes['found/tc'][:])
 
     inj_sigma_mult = (np.asarray(list(inj_sigma.values())) *
                       np.asarray(list(f_resp.values())))
@@ -384,10 +391,12 @@ if 'network/template_id' in found_after_vetoes.keys():
 
     inj_sigma_mean = {}
     for ifo in ifos:
-        inj_sigma_mean[ifo] = ((inj_sigma[ifo]*f_resp[ifo])/inj_sigma_tot).mean()
+        inj_sigma_mean[ifo] = \
+            ((inj_sigma[ifo]*f_resp[ifo])/inj_sigma_tot).mean()
 
-    msg = f"{len(found_after_vetoes['found/tc'])} injections found and surviving "
-    msg += f"vetoes and {len(injs['missed/tc'])} missed injections analysed."
+    msg = f"{len(found_after_vetoes['found/tc'])} injections found and "
+    msg += f"surviving vetoes and {len(injs['missed/tc'])} missed injections "
+    msg += "analysed."
     logging.info(msg)
 
     # Create new set of injections for efficiency calculations:
@@ -432,9 +441,10 @@ if 'network/template_id' in found_after_vetoes.keys():
     # Calibration phase uncertainties are neglected
     logging.info("Calibration amplitude uncertainty calculated.")
 
-    # Now create the numbers for the efficiency plots; these include calibration
-    # and waveform errors. These are incorporated by running over each injection
-    # num_mc_injs times, where each time we draw a random value of distance
+    # Now create the numbers for the efficiency plots; these include
+    # calibration and waveform errors. These are incorporated by running over
+    # each injection num_mc_injs times, where each time we draw a random value
+    # of distance
 
     # Distribute injections
     # NOTE: the loop on num_mc_injs would fill up the *_inj['dist_mc']'s at the
@@ -449,13 +459,16 @@ if 'network/template_id' in found_after_vetoes.keys():
     )
     missed_inj_dist_mc = ppu.mc_cal_wf_errs(
         num_mc_injs,
-        np.concatenate((vetoed['found/distance'],injs['missed/distance'])),
+        np.concatenate((vetoed['found/distance'], injs['missed/distance'])),
         cal_error,
         wav_err,
         max_dc_cal_error
     )
-    long_inj['dist_mc'] = ppu.mc_cal_wf_errs(num_mc_injs, long_inj['dist'],
-                                             cal_error, wav_err, max_dc_cal_error)
+    long_inj['dist_mc'] = ppu.mc_cal_wf_errs(num_mc_injs,
+                                             long_inj['dist'],
+                                             cal_error,
+                                             wav_err,
+                                             max_dc_cal_error)
 
     logging.info("MC injection set distributed with %d iterations.",
                  num_mc_injs)
@@ -468,32 +481,37 @@ if 'network/template_id' in found_after_vetoes.keys():
 
     distance_count = np.zeros(len(dist_bins))
 
-    found_trig_max_bestnr = np.empty(len(found_after_vetoes['network/event_id']))
+    found_trig_max_bestnr = \
+        np.empty(len(found_after_vetoes['network/event_id']))
     found_trig_max_bestnr.fill(max_bestnr)
 
-    max_bestnr_cut = (found_after_vetoes['network/reweighted_snr'] > found_trig_max_bestnr)
+    max_bestnr_cut = \
+        (found_after_vetoes['network/reweighted_snr'] > found_trig_max_bestnr)
 
     # Check louder than on source
-    found_trig_loud_on_bestnr = np.empty(len(found_after_vetoes['network/event_id']))
+    found_trig_loud_on_bestnr = \
+        np.empty(len(found_after_vetoes['network/event_id']))
     if onsource_file:
         found_trig_loud_on_bestnr.fill(loud_on_bestnr)
     else:
         found_trig_loud_on_bestnr.fill(median_bestnr)
-    on_bestnr_cut = found_after_vetoes['network/reweighted_snr'] > found_trig_loud_on_bestnr
+    on_bestnr_cut = found_after_vetoes['network/reweighted_snr'] > \
+        found_trig_loud_on_bestnr
 
     # Check whether injection is found for the purposes of exclusion
     # distance calculation.
     # Found: if louder than all on source
     # Missed: if not louder than loudest on source
     found_excl = on_bestnr_cut & (more_sig_than_onsource) & \
-                (found_after_vetoes['network/reweighted_snr'] != 0)
+        (found_after_vetoes['network/reweighted_snr'] != 0)
     # If not missed, double check bestnr against nearby triggers
     near_test = np.zeros((found_excl).sum()).astype(bool)
-    for j, (t, bestnr) in enumerate(zip(found_after_vetoes['found/tc'][found_excl],
-                                    found_after_vetoes['network/reweighted_snr'][found_excl])):
+    for j, (t, bestnr) in enumerate(zip(
+            found_after_vetoes['found/tc'][found_excl],
+            found_after_vetoes['network/reweighted_snr'][found_excl])):
         # 0 is the zero-lag timeslide
-        near_bestnr = \
-            trig_data[keys[1]][0][np.abs(trig_data[keys[0]][0]-t) < cluster_window]
+        near_bestnr = trig_data[keys[1]][0][np.abs(trig_data[keys[0]][0]-t) <
+                                            cluster_window]
         near_test[j] = ~((near_bestnr * glitch_check_fac > bestnr).any())
     # Apply the local test
     c = 0
@@ -541,20 +559,33 @@ if 'network/template_id' in found_after_vetoes.keys():
 
     # Post-processing of injections ends here
 
-    # ==========
-    # Make plots
-    # ==========
-    logging.info("Plotting.")
-    # Calculate distances (horizontal axis) as means
-    dist_plot_vals = [np.asarray(dist_bin).mean() for dist_bin in dist_bins]
+# ==========
+# Make plots
+# ==========
+logging.info("Plotting.")
 
-    # Calculate error bars for efficiency/distance plots and datafiles
-    # using max BestNR of background
-    yerr_low_mc, yerr_high_mc, fraction_mc = efficiency_with_errs(
-         found_max_bestnr['mc'], num_injections['mc'], num_mc_injs=num_mc_injs)
-    yerr_low_no_mc, yerr_high_no_mc, fraction_no_mc = efficiency_with_errs(
-                               found_max_bestnr['no_mc'], num_injections['no_mc'])
+# Plot efficiency using loudest background
+if opts.background_output_file:
+    fig = plt.figure()
+    ax = fig.gca()
 
+    # Without found injections, do not determine these quantities to plot
+    if 'network/template_id' in found_after_vetoes.keys():
+        # Calculate distances (horizontal axis) as means
+        dist_plot_vals = [np.asarray(dist_bin).mean()
+                          for dist_bin in dist_bins]
+
+        # Calculate error bars for efficiency/distance plots and datafiles
+        # using max BestNR of background
+        yerr_low_mc, yerr_high_mc, fraction_mc = efficiency_with_errs(
+             found_max_bestnr['mc'],
+             num_injections['mc'],
+             num_mc_injs=num_mc_injs)
+        yerr_low_no_mc, yerr_high_no_mc, fraction_no_mc = efficiency_with_errs(
+             found_max_bestnr['no_mc'],
+             num_injections['no_mc'])
+
+<<<<<<< HEAD
 <<<<<<< HEAD
 # Plot efficiency using loudest background
 if opts.background_output_file:
@@ -589,6 +620,8 @@ if opts.background_output_file:
     if opts.background_output_file:
         fig = plt.figure()
         ax = fig.gca()
+=======
+>>>>>>> 25413c0e (final modifications to pycbc_pygrb_efficiency)
         ax.plot(dist_plot_vals, (fraction_no_mc), 'g-',
                 label='No marginalisation')
         ax.errorbar(dist_plot_vals, (fraction_no_mc),
@@ -596,9 +629,12 @@ if opts.background_output_file:
         marg_eff = fraction_mc
         if np.nansum(marg_eff) > 0:
             ax.plot(dist_plot_vals, marg_eff, 'r-', label='Marginalised')
-            ax.errorbar(dist_plot_vals, marg_eff, yerr=[yerr_low_mc, yerr_high_mc],
+            ax.errorbar(dist_plot_vals,
+                        marg_eff,
+                        yerr=[yerr_low_mc, yerr_high_mc],
                         c='red')
         ax.legend()
+<<<<<<< HEAD
         ax.grid()
         ax.set_ylim([0, 1])
         ax.set_xlim(0, 1.3*upper_dist)
@@ -613,11 +649,33 @@ if opts.background_output_file:
                                title=plot_title, caption=plot_caption)
         plt.close()
 >>>>>>> 8134c2fb (Update pycbc_pygrb_efficiency)
+=======
+    ax.grid()
+    ax.set_ylim([0, 1])
+    ax.set_xlim(0, 1.3*upper_dist)
+    ax.set_ylabel("Fraction of injections found louder than " +
+                  "loudest background")
+    ax.set_xlabel("Distance (Mpc)")
+    plot_title = "Detection efficiency - "+inj_set_name
+    plot_caption = "Injection recovery efficiency using "
+    plot_caption += "BestNR as detection statistic.  "
+    plot_caption += "Injections louder than loudest background trigger."
+    fig_path = opts.background_output_file
+    save_fig_with_metadata(fig, fig_path, cmd=' '.join(sys.argv),
+                           title=plot_title, caption=plot_caption)
+    plt.close()
+>>>>>>> 25413c0e (final modifications to pycbc_pygrb_efficiency)
 
+# Calculate and save to disk 50% and 90% exclusion distances
+# excl_dist dictionary contains 50% and 90% exclusion distances
+# It contains NaNs unless there are found injections
+excl_dist = {f"{percentile}%": 'NaN' for percentile in [50, 90]}
+if 'network/template_id' in found_after_vetoes.keys():
     # Calculate error bars for efficiency/distance plots and datafiles
     # using max BestNR of foreground
     yerr_low_no_mc, yerr_high_no_mc, fraction_no_mc = efficiency_with_errs(
-                                found_on_bestnr['no_mc'], num_injections['no_mc'])
+                                found_on_bestnr['no_mc'],
+                                num_injections['no_mc'])
     yerr_low, yerr_high, fraction_mc = \
         efficiency_with_errs(found_on_bestnr['mc'], num_injections['mc'],
                              num_mc_injs=num_mc_injs)
@@ -625,10 +683,6 @@ if opts.background_output_file:
     # Marginalized efficiency (isf = inverse survival function)
     red_efficiency = (fraction_mc) - (yerr_low) * scipy.stats.norm.isf(0.1)
 
-# Calculate and save to disk 50% and 90% exclusion distances
-# excl_dist dictionary contains 50% and 90% exclusion distances
-excl_dist = {f"{percentile}%": 'NaN' for percentile in [50, 90]}
-if 'network/template_id' in found_after_vetoes.keys():
     for percentile in [50, 90]:
         eff_idx = np.where(red_efficiency < (percentile / 100.))[0]
         if eff_idx.size == 0:
@@ -643,8 +697,8 @@ if 'network/template_id' in found_after_vetoes.keys():
             d_low = dist_plot_vals[i-1]
             e = excl_efficiency[i]
             e_low = excl_efficiency[i-1]
-            excl_dist[f"{percentile}%"] = d + (e - (percentile / 100.)) * (d - d_low) /\
-                (e_low - e)
+            excl_dist[f"{percentile}%"] = \
+                d + (e - (percentile / 100.)) * (d - d_low) / (e_low - e)
         else:
             # Warn the user if the exclusion distance cannot be established,
             # but let the workflow continue: the user will see the plot(s) and
@@ -660,7 +714,6 @@ if opts.exclusion_dist_output_file:
     excl_dist['trial_name'] = opts.trial_name
     with open(opts.exclusion_dist_output_file, 'w') as excl_dist_file:
         json.dump(excl_dist, excl_dist_file)
-
 
 # Plot efficiency using loudest foreground
 if opts.onsource_output_file:
@@ -705,4 +758,3 @@ if opts.onsource_output_file:
     plt.close()
 
 logging.info("Done.")
-                 

--- a/bin/pygrb/pycbc_pygrb_efficiency
+++ b/bin/pygrb/pycbc_pygrb_efficiency
@@ -585,43 +585,6 @@ if opts.background_output_file:
              found_max_bestnr['no_mc'],
              num_injections['no_mc'])
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-# Plot efficiency using loudest background
-if opts.background_output_file:
-    fig = plt.figure()
-    ax = fig.gca()
-    ax.plot(dist_plot_vals, (fraction_no_mc), 'g-',
-            label='No marginalisation')
-    ax.errorbar(dist_plot_vals, (fraction_no_mc),
-                yerr=[yerr_low_no_mc, yerr_high_no_mc], c='green')
-    marg_eff = fraction_mc
-    if np.nansum(marg_eff) > 0:
-        ax.plot(dist_plot_vals, marg_eff, 'r-', label='Marginalised')
-        ax.errorbar(dist_plot_vals, marg_eff, yerr=[yerr_low_mc, yerr_high_mc],
-                    c='red')
-    ax.legend()
-    ax.grid()
-    ax.set_ylim([0, 1])
-    ax.set_xlim(0, 1.3*upper_dist)
-    ax.set_ylabel("Fraction of injections found louder than "
-                  "loudest background")
-    ax.set_xlabel("Distance (Mpc)")
-    plot_title = "Detection efficiency - "+inj_set_name
-    plot_caption = "Injection recovery efficiency using "
-    plot_caption += "BestNR as detection statistic.  "
-    plot_caption += "Injections louder than loudest background trigger."
-    fig_path = opts.background_output_file
-    save_fig_with_metadata(fig, fig_path, cmd=' '.join(sys.argv),
-                           title=plot_title, caption=plot_caption)
-    plt.close()
-=======
-    # Plot efficiency using loudest background
-    if opts.background_output_file:
-        fig = plt.figure()
-        ax = fig.gca()
-=======
->>>>>>> 25413c0e (final modifications to pycbc_pygrb_efficiency)
         ax.plot(dist_plot_vals, (fraction_no_mc), 'g-',
                 label='No marginalisation')
         ax.errorbar(dist_plot_vals, (fraction_no_mc),
@@ -634,22 +597,6 @@ if opts.background_output_file:
                         yerr=[yerr_low_mc, yerr_high_mc],
                         c='red')
         ax.legend()
-<<<<<<< HEAD
-        ax.grid()
-        ax.set_ylim([0, 1])
-        ax.set_xlim(0, 1.3*upper_dist)
-        ax.set_ylabel("Fraction of injections found louder than loudest background")
-        ax.set_xlabel("Distance (Mpc)")
-        plot_title = "Detection efficiency - "+inj_set_name
-        plot_caption = "Injection recovery efficiency using "
-        plot_caption += "BestNR as detection statistic.  "
-        plot_caption += "Injections louder than loudest background trigger."
-        fig_path = opts.background_output_file
-        save_fig_with_metadata(fig, fig_path, cmd=' '.join(sys.argv),
-                               title=plot_title, caption=plot_caption)
-        plt.close()
->>>>>>> 8134c2fb (Update pycbc_pygrb_efficiency)
-=======
     ax.grid()
     ax.set_ylim([0, 1])
     ax.set_xlim(0, 1.3*upper_dist)
@@ -664,7 +611,6 @@ if opts.background_output_file:
     save_fig_with_metadata(fig, fig_path, cmd=' '.join(sys.argv),
                            title=plot_title, caption=plot_caption)
     plt.close()
->>>>>>> 25413c0e (final modifications to pycbc_pygrb_efficiency)
 
 # Calculate and save to disk 50% and 90% exclusion distances
 # excl_dist dictionary contains 50% and 90% exclusion distances

--- a/bin/pygrb/pycbc_pygrb_page_tables
+++ b/bin/pygrb/pycbc_pygrb_page_tables
@@ -658,11 +658,11 @@ if found_missed_file is not None:
              'rec_mass2', 'rec_mchirp', 'inclination', 'ra', 'dec', 'rec_ra',
              'rec_dec', 'coherent_snr', 'chisq', 'null_snr']
     keys += sngl_snr_keys
+    keys += ['bestnr', 'spin1x', 'spin1y', 'spin1z', 'spin2x', 'spin2y',
+             'spin2z', 'rec_spin1z', 'rec_spin2z']
     for key in keys:
         if key not in found_after_vetoes.keys():
             found_after_vetoes[key] = np.array([])
-    keys += ['bestnr', 'spin1x', 'spin1y', 'spin1z', 'spin2x', 'spin2y',
-             'spin2z', 'rec_spin1z', 'rec_spin2z']
     td = [found_after_vetoes[key][nonzero_fap] for key in keys]
     td = list(zip(*td))
     td.sort(key=lambda elem: elem[0])

--- a/bin/pygrb/pycbc_pygrb_page_tables
+++ b/bin/pygrb/pycbc_pygrb_page_tables
@@ -128,37 +128,25 @@ def load_missed_found_injections(hdf_file, ifos, bank_file, snr_threshold=None,
     found_data['rec_ra'] = inj_data['network/ra'][...]
     found_data['rec_dec'] = inj_data['network/dec'][...]
     # Statistics values
-    if 'network/my_network_chisq' and 'network/nifo'in inj_data:
-        for param in ['coherent_snr', 'reweighted_snr', 'null_snr']:
-            found_data[param] = inj_data['network/'+param][...]
-        found_data['chisq'] = inj_data['network/my_network_chisq'][...]
-        found_data['nifos'] = inj_data['network/nifo'][...].astype(int)
-    else:
-        for param in ['coherent_snr', 'reweighted_snr', 'null_snr']:
-            found_data[param] = np.array([])
-        found_data['chisq'] = np.array([])
-        found_data['nifos'] = np.array([])
-    if 'network/event_id' in inj_data:
-        for ifo in ifos:
-            if np.all(inj_data['network/event_id'][...] ==
-                      inj_data[ifo+'/event_id'][...]):
-                found_data['sigmasq_'+ifo] = inj_data[ifo+'/sigmasq'][...]
-                found_data['snr_'+ifo] = inj_data[ifo+'/snr'][...]
-                found_data[ifo+'/end_time'] = inj_data[ifo+'/end_time'][...]
-            else:
-                # Sort the ifo event_id with respect to the network event_id
-                ifo_sorted_indices = np.argsort(inj_data['network/event_id'][...][
-                    np.argsort(inj_data['network/event_id'])].searchsorted(
-                        inj_data[ifo+'/event_id'][...]))
-                found_data['sigmasq_'+ifo] = \
-                    inj_data[ifo+'/sigmasq'][...][ifo_sorted_indices]
-                found_data['snr_'+ifo] = \
-                    inj_data[ifo+'/snr'][...][ifo_sorted_indices]
-    else:
-        for ifo in ifos:
-            found_data['sigmasq_'+ifo] = np.array([])
-            found_data['snr_'+ifo] = np.array([])
-            found_data[ifo+'/end_time'] = np.array([])
+    for param in ['coherent_snr', 'reweighted_snr', 'null_snr']:
+        found_data[param] = inj_data['network/'+param][...]
+    found_data['chisq'] = inj_data['network/my_network_chisq'][...]
+    found_data['nifos'] = inj_data['network/nifo'][...].astype(int)
+    for ifo in ifos:
+        if np.all(inj_data['network/event_id'][...] ==
+                  inj_data[ifo+'/event_id'][...]):
+            found_data['sigmasq_'+ifo] = inj_data[ifo+'/sigmasq'][...]
+            found_data['snr_'+ifo] = inj_data[ifo+'/snr'][...]
+            found_data[ifo+'/end_time'] = inj_data[ifo+'/end_time'][...]
+        else:
+            # Sort the ifo event_id with respect to the network event_id
+            ifo_sorted_indices = np.argsort(inj_data['network/event_id'][...][
+                np.argsort(inj_data['network/event_id'])].searchsorted(
+                    inj_data[ifo+'/event_id'][...]))
+            found_data['sigmasq_'+ifo] = \
+                inj_data[ifo+'/sigmasq'][...][ifo_sorted_indices]
+            found_data['snr_'+ifo] = \
+                inj_data[ifo+'/snr'][...][ifo_sorted_indices]
     # BestNRs
     found_data['bestnr'] = reweightedsnr_cut(found_data['reweighted_snr'][...],
                                              snr_threshold)

--- a/bin/pygrb/pycbc_pygrb_page_tables
+++ b/bin/pygrb/pycbc_pygrb_page_tables
@@ -113,34 +113,53 @@ def load_missed_found_injections(hdf_file, ifos, bank_file, snr_threshold=None,
     for param in ['mass1', 'mass2', 'spin1z', 'spin2z']:
         found_data['rec_'+param] = \
             np.array(bank_file[param])[inj_data['network/template_id']]
-    found_data['time_diff'] = \
-        found_data['tc'] - inj_data['network/end_time_gc'][...]
+    if 'network/end_time_gc' in inj_data:
+        found_data['time_diff'] = \
+                found_data['tc'] - inj_data['network/end_time_gc'][...]
+    else:
+        found_data['time_diff'] = np.array([])
     found_data['rec_mchirp'] = mchirp_from_mass1_mass2(
         found_data['rec_mass1'],
         found_data['rec_mass2'])
     # Recovered RA and Dec
-    found_data['rec_ra'] = inj_data['network/ra'][...]
-    found_data['rec_dec'] = inj_data['network/dec'][...]
+    if 'network/ra' and 'network/dec' in inj_data:
+        found_data['rec_ra'] = inj_data['network/ra'][...]
+        found_data['rec_dec'] = inj_data['network/dec'][...]
+    else:
+        found_data['rec_ra'] = np.array([])
+        found_data['rec_dec'] = np.array([])
     # Statistics values
-    for param in ['coherent_snr', 'reweighted_snr', 'null_snr']:
-        found_data[param] = inj_data['network/'+param][...]
-    found_data['chisq'] = inj_data['network/my_network_chisq'][...]
-    found_data['nifos'] = inj_data['network/nifo'][...].astype(int)
-    for ifo in ifos:
-        if np.all(inj_data['network/event_id'][...] ==
-                  inj_data[ifo+'/event_id'][...]):
-            found_data['sigmasq_'+ifo] = inj_data[ifo+'/sigmasq'][...]
-            found_data['snr_'+ifo] = inj_data[ifo+'/snr'][...]
-            found_data[ifo+'/end_time'] = inj_data[ifo+'/end_time'][...]
-        else:
-            # Sort the ifo event_id with respect to the network event_id
-            ifo_sorted_indices = np.argsort(inj_data['network/event_id'][...][
-                np.argsort(inj_data['network/event_id'])].searchsorted(
-                    inj_data[ifo+'/event_id'][...]))
-            found_data['sigmasq_'+ifo] = \
-                inj_data[ifo+'/sigmasq'][...][ifo_sorted_indices]
-            found_data['snr_'+ifo] = \
-                inj_data[ifo+'/snr'][...][ifo_sorted_indices]
+    if 'network/my_network_chisq' and 'network/nifo'in inj_data:
+        for param in ['coherent_snr', 'reweighted_snr', 'null_snr']:
+            found_data[param] = inj_data['network/'+param][...]
+        found_data['chisq'] = inj_data['network/my_network_chisq'][...]
+        found_data['nifos'] = inj_data['network/nifo'][...].astype(int)
+    else:
+        for param in ['coherent_snr', 'reweighted_snr', 'null_snr']:
+            found_data[param] = np.array([])
+        found_data['chisq'] = np.array([])
+        found_data['nifos'] = np.array([])
+    if 'network/event_id' in inj_data:
+        for ifo in ifos:
+            if np.all(inj_data['network/event_id'][...] ==
+                      inj_data[ifo+'/event_id'][...]):
+                found_data['sigmasq_'+ifo] = inj_data[ifo+'/sigmasq'][...]
+                found_data['snr_'+ifo] = inj_data[ifo+'/snr'][...]
+                found_data[ifo+'/end_time'] = inj_data[ifo+'/end_time'][...]
+            else:
+                # Sort the ifo event_id with respect to the network event_id
+                ifo_sorted_indices = np.argsort(inj_data['network/event_id'][...][
+                    np.argsort(inj_data['network/event_id'])].searchsorted(
+                        inj_data[ifo+'/event_id'][...]))
+                found_data['sigmasq_'+ifo] = \
+                    inj_data[ifo+'/sigmasq'][...][ifo_sorted_indices]
+                found_data['snr_'+ifo] = \
+                    inj_data[ifo+'/snr'][...][ifo_sorted_indices]
+    else:
+        for ifo in ifos:
+            found_data['sigmasq_'+ifo] = np.array([])
+            found_data['snr_'+ifo] = np.array([])
+            found_data[ifo+'/end_time'] = np.array([])
     # BestNRs
     found_data['bestnr'] = reweightedsnr_cut(found_data['reweighted_snr'][...],
                                              snr_threshold)

--- a/bin/pygrb/pycbc_pygrb_page_tables
+++ b/bin/pygrb/pycbc_pygrb_page_tables
@@ -125,12 +125,8 @@ def load_missed_found_injections(hdf_file, ifos, bank_file, snr_threshold=None,
         found_data['rec_mass1'],
         found_data['rec_mass2'])
     # Recovered RA and Dec
-    if 'network/ra' and 'network/dec' in inj_data:
-        found_data['rec_ra'] = inj_data['network/ra'][...]
-        found_data['rec_dec'] = inj_data['network/dec'][...]
-    else:
-        found_data['rec_ra'] = np.array([])
-        found_data['rec_dec'] = np.array([])
+    found_data['rec_ra'] = inj_data['network/ra'][...]
+    found_data['rec_dec'] = inj_data['network/dec'][...]
     # Statistics values
     if 'network/my_network_chisq' and 'network/nifo'in inj_data:
         for param in ['coherent_snr', 'reweighted_snr', 'null_snr']:

--- a/bin/pygrb/pycbc_pygrb_page_tables
+++ b/bin/pygrb/pycbc_pygrb_page_tables
@@ -150,7 +150,7 @@ def load_missed_found_injections(hdf_file, ifos, bank_file, snr_threshold=None,
     # BestNRs
     found_data['bestnr'] = reweightedsnr_cut(found_data['reweighted_snr'][...],
                                              snr_threshold)
-    # Apply reweighted SNR cut
+    # Apply reweighted SNR cut to the found injections
     cut_data = {}
     if snr_threshold:
         logging.info("%d found injections loaded.",
@@ -611,6 +611,9 @@ if found_missed_file is not None:
         veto_file=opts.veto_file
     )
 
+    if 'bestnr' not in found_after_vetoes.keys():
+        found_after_vetoes['bestnr'] = np.array([])
+
     # Construct conditions for injection:
     # 1) found louder than background,
     zero_fap = found_after_vetoes['bestnr'] > max_bestnr
@@ -655,6 +658,9 @@ if found_missed_file is not None:
              'rec_mass2', 'rec_mchirp', 'inclination', 'ra', 'dec', 'rec_ra',
              'rec_dec', 'coherent_snr', 'chisq', 'null_snr']
     keys += sngl_snr_keys
+    for key in keys:
+        if key not in found_after_vetoes.keys():
+            found_after_vetoes[key] = np.array([])
     keys += ['bestnr', 'spin1x', 'spin1y', 'spin1z', 'spin2x', 'spin2y',
              'spin2z', 'rec_spin1z', 'rec_spin2z']
     td = [found_after_vetoes[key][nonzero_fap] for key in keys]
@@ -686,6 +692,11 @@ if found_missed_file is not None:
                                          **kwds)
 
     # Write quiet triggers to html file
+    if len(cut_injs) == 0:
+        cut_injs = dict.fromkeys(keys, np.array([]))
+    for key in keys:
+        if key not in vetoed:
+            vetoed[key] = np.array([])
     t_missed = [np.concatenate((vetoed[key], cut_injs[key])) for key in keys]
     t_missed = list(zip(*t_missed))
     t_missed.sort(key=lambda elem: elem[0])

--- a/bin/pygrb/pycbc_pygrb_page_tables
+++ b/bin/pygrb/pycbc_pygrb_page_tables
@@ -113,11 +113,14 @@ def load_missed_found_injections(hdf_file, ifos, bank_file, snr_threshold=None,
     for param in ['mass1', 'mass2', 'spin1z', 'spin2z']:
         found_data['rec_'+param] = \
             np.array(bank_file[param])[inj_data['network/template_id']]
-    if 'network/end_time_gc' in inj_data:
-        found_data['time_diff'] = \
-                found_data['tc'] - inj_data['network/end_time_gc'][...]
-    else:
-        found_data['time_diff'] = np.array([])
+    # If there are no found injections, simply move on
+    # (there are no injections missed after the cut to return)
+    if 'network/end_time_gc' not in inj_data.keys():
+        return found_data, missed_data, {}
+    # Otherwise carry on getting the recovered parameters and statistic values
+    # of the found injections
+    found_data['time_diff'] = \
+        found_data['tc'] - inj_data['network/end_time_gc'][...]
     found_data['rec_mchirp'] = mchirp_from_mass1_mass2(
         found_data['rec_mass1'],
         found_data['rec_mass2'])

--- a/bin/pygrb/pycbc_pygrb_plot_injs_results
+++ b/bin/pygrb/pycbc_pygrb_plot_injs_results
@@ -163,7 +163,7 @@ def complete_inj_data(injs, keys, tag, ifos=[]):
             key = ifo+'/end_time'
             data_dict[key] = injs[key] if key in injs else np.array([])
         key = 'network/reweighted_snr'
-        data_dict['reweighted_snr'] = \ 
+        data_dict['reweighted_snr'] = \
             injs[key] if key in injs else np.array([])
 
     logging.info("%d %s injections analysed.", len(data_dict[keys[0]]), tag)

--- a/bin/pygrb/pycbc_pygrb_plot_injs_results
+++ b/bin/pygrb/pycbc_pygrb_plot_injs_results
@@ -159,14 +159,12 @@ def complete_inj_data(injs, keys, tag, ifos=[]):
 
     # Include information needed to apply vetoes and reweighted SNR cut
     if tag == 'found':
-        if 'network/reweighted_snr' in injs:
-            for ifo in ifos:
-                data_dict[ifo+'/end_time'] = injs[ifo+'/end_time']
-            data_dict['reweighted_snr'] = injs['network/reweighted_snr']
-        else:
-            for ifo in ifos:
-                data_dict[ifo+'/end_time'] = np.array([])
-            data_dict['reweighted_snr'] = np.array([])
+        for ifo in ifos:
+            key = ifo+'/end_time'
+            data_dict[key] = injs[key] if key in injs else np.array([])
+        key = 'network/reweighted_snr'
+        data_dict['reweighted_snr'] = \ 
+            injs[key] if key in injs else np.array([])
 
     logging.info("%d %s injections analysed.", len(data_dict[keys[0]]), tag)
 

--- a/bin/pygrb/pycbc_pygrb_plot_injs_results
+++ b/bin/pygrb/pycbc_pygrb_plot_injs_results
@@ -298,6 +298,7 @@ logging.info("Background bestNR calculated.")
 # Load injection data without applying the reweighted SNR cut, nor vetoes
 inj_data = ppu.load_data(opts.found_missed_file, ifos, data_tag='injs',
                          slide_id=0)
+
 # Extract the necessary data from the missed injections for the plot
 missed_inj = complete_inj_data(inj_data, [x_qty, y_qty], 'missed', ifos=ifos)
 

--- a/bin/pygrb/pycbc_pygrb_plot_injs_results
+++ b/bin/pygrb/pycbc_pygrb_plot_injs_results
@@ -159,9 +159,14 @@ def complete_inj_data(injs, keys, tag, ifos=[]):
 
     # Include information needed to apply vetoes and reweighted SNR cut
     if tag == 'found':
-        for ifo in ifos:
-            data_dict[ifo+'/end_time'] = injs[ifo+'/end_time']
-        data_dict['reweighted_snr'] = injs['network/reweighted_snr']
+        if 'network/reweighted_snr' in injs:
+            for ifo in ifos:
+                data_dict[ifo+'/end_time'] = injs[ifo+'/end_time']
+            data_dict['reweighted_snr'] = injs['network/reweighted_snr']
+        else:
+            for ifo in ifos:
+                data_dict[ifo+'/end_time'] = np.array([])
+            data_dict['reweighted_snr'] = np.array([])
 
     logging.info("%d %s injections analysed.", len(data_dict[keys[0]]), tag)
 

--- a/pycbc/results/pygrb_postprocessing_utils.py
+++ b/pycbc/results/pygrb_postprocessing_utils.py
@@ -357,9 +357,10 @@ def load_data(input_file, ifos, rw_snr_threshold=None, data_tag=None,
             else:
                 trigs_dict[path] = dset[above_thresh]
 
-            if trigs_dict[path].size == trigs['network/slide_id'][:].size:
-                trigs_dict[path] = _slide_filter(trigs, trigs_dict[path],
-                                                 slide_id=slide_id)
+            if 'network/slide_id' in trigs.keys():
+                if trigs_dict[path].size == trigs['network/slide_id'][:].size:
+                    trigs_dict[path] = _slide_filter(trigs, trigs_dict[path],
+                                                     slide_id=slide_id)
     return trigs_dict
 
 

--- a/pycbc/results/pygrb_postprocessing_utils.py
+++ b/pycbc/results/pygrb_postprocessing_utils.py
@@ -794,13 +794,13 @@ def template_hash_to_id(trigger_file, bank_path):
     trigger_file: HFile object for trigger file
     bank_file: filepath for template bank
     """
-    if 'ifos[0]}/template_hash' not in trigger_file.keys():
-        return numpy.array([], dtype=int)
+    ifos = [k for k in trigger_file.keys() if k != 'network']
+    if ifos[0]'/template_hash' not in trigger_file.keys():
+        return numpy.array([], dtype=numpy.int64)
     with HFile(bank_path, "r") as bank:
         hashes = bank['template_hash'][:]
-    ifos = [k for k in trigger_file.keys() if k != 'network']
     trig_hashes = trigger_file[f'{ifos[0]}/template_hash'][:]
-    trig_ids = numpy.zeros(trig_hashes.shape[0], dtype=int)
+    trig_ids = numpy.zeros(trig_hashes.shape[0], dtype=numpy.int64)
     for idx, t_hash in enumerate(hashes):
         matches = numpy.where(trig_hashes == t_hash)
         trig_ids[matches] = idx

--- a/pycbc/results/pygrb_postprocessing_utils.py
+++ b/pycbc/results/pygrb_postprocessing_utils.py
@@ -312,24 +312,11 @@ def load_data(input_file, ifos, rw_snr_threshold=None, data_tag=None,
             if ifo+'/event_id' in trigs.keys() \
             else numpy.array([], dtype=numpy.int64)
     trigs.close()
-    # Output the number of items loaded only upon a request by the user who is
-    # expected not to set data_tag to 'trigs'or 'injs' when processing the
-    # onsource
-    if data_tag == 'trigs':
-        logging.info("%d triggers loaded.", len(rw_snr))
-    elif data_tag == 'injs':
-        logging.info("%d injections loaded.", len(rw_snr))
-    else:
-        logging.info("Loading triggers.")
-    ifo_ids = {}
-    for ifo in ifos:
-        ifo_ids[ifo] = trigs[ifo+'/event_id'][:]
-    trigs.close()
 
     # Apply the reweighted SNR cut on the reweighted SNR
     if rw_snr_threshold is not None:
         rw_snr = reweightedsnr_cut(rw_snr, rw_snr_threshold)
-    
+
     # Establish the indices of data not surviving the cut
     above_thresh = rw_snr > 0
 
@@ -412,7 +399,7 @@ def apply_vetoes_to_found_injs(found_missed_file, found_injs, ifos,
     """
 
     keep_keys = keys if keys else found_injs.keys()
-    
+
     if not found_missed_file or ifos[0]+'/end_time' not in found_injs.keys():
         return (dict.fromkeys(keep_keys, numpy.array([])),
                 dict.fromkeys(keep_keys, numpy.array([])),

--- a/pycbc/results/pygrb_postprocessing_utils.py
+++ b/pycbc/results/pygrb_postprocessing_utils.py
@@ -401,9 +401,10 @@ def apply_vetoes_to_found_injs(found_missed_file, found_injs, ifos,
     keep_keys = keys if keys else found_injs.keys()
 
     if not found_missed_file or ifos[0]+'/end_time' not in found_injs.keys():
-        return (dict.fromkeys(keep_keys, numpy.array([])),
-                dict.fromkeys(keep_keys, numpy.array([])),
-                None, None)
+        empty_dict = dict.fromkeys(keep_keys, numpy.array([]))
+        empty_dict['network/template_id'] = \
+            empty_dict['network/template_id'].astype(dtype=numpy.int64)
+        return (empty_dict, empty_dict, None, None)
 
     found_idx = numpy.arange(len(found_injs[ifos[0]+'/end_time'][:]))
     veto_idx = numpy.array([], dtype=numpy.int64)

--- a/pycbc/results/pygrb_postprocessing_utils.py
+++ b/pycbc/results/pygrb_postprocessing_utils.py
@@ -795,7 +795,7 @@ def template_hash_to_id(trigger_file, bank_path):
     bank_file: filepath for template bank
     """
     ifos = [k for k in trigger_file.keys() if k != 'network']
-    if ifos[0]'/template_hash' not in trigger_file.keys():
+    if ifos[0]+'/template_hash' not in trigger_file.keys():
         return numpy.array([], dtype=numpy.int64)
     with HFile(bank_path, "r") as bank:
         hashes = bank['template_hash'][:]

--- a/pycbc/results/pygrb_postprocessing_utils.py
+++ b/pycbc/results/pygrb_postprocessing_utils.py
@@ -796,11 +796,11 @@ def template_hash_to_id(trigger_file, bank_path):
     """
     ifos = [k for k in trigger_file.keys() if k != 'network']
     if ifos[0]+'/template_hash' not in trigger_file.keys():
-        return numpy.array([], dtype=numpy.int64)
+        return numpy.array([], dtype=int)
     with HFile(bank_path, "r") as bank:
         hashes = bank['template_hash'][:]
     trig_hashes = trigger_file[f'{ifos[0]}/template_hash'][:]
-    trig_ids = numpy.zeros(trig_hashes.shape[0], dtype=numpy.int64)
+    trig_ids = numpy.zeros(trig_hashes.shape[0], dtype=int)
     for idx, t_hash in enumerate(hashes):
         matches = numpy.where(trig_hashes == t_hash)
         trig_ids[matches] = idx

--- a/pycbc/results/pygrb_postprocessing_utils.py
+++ b/pycbc/results/pygrb_postprocessing_utils.py
@@ -307,6 +307,21 @@ def load_data(input_file, ifos, rw_snr_threshold=None, data_tag=None,
         logging.info("Loading triggers.")
     ifo_ids = {}
     for ifo in ifos:
+        ifo_ids[ifo] = trigs[ifo+'/event_id'][:] \
+            if ifo+'/event_id' in trigs.keys() \
+            else numpy.array([], dtype=numpy.int64)
+    trigs.close()
+    # Output the number of items loaded only upon a request by the user who is
+    # expected not to set data_tag to 'trigs'or 'injs' when processing the
+    # onsource
+    if data_tag == 'trigs':
+        logging.info("%d triggers loaded.", len(rw_snr))
+    elif data_tag == 'injs':
+        logging.info("%d injections loaded.", len(rw_snr))
+    else:
+        logging.info("Loading triggers.")
+    ifo_ids = {}
+    for ifo in ifos:
         ifo_ids[ifo] = trigs[ifo+'/event_id'][:]
     trigs.close()
 

--- a/pycbc/results/pygrb_postprocessing_utils.py
+++ b/pycbc/results/pygrb_postprocessing_utils.py
@@ -291,10 +291,11 @@ def load_data(input_file, ifos, rw_snr_threshold=None, data_tag=None,
         return None
 
     trigs = HFile(input_file, 'r')
-    if 'network/reweighted_snr' not in trigs.keys():
-        return {}
-    rw_snr = trigs['network/reweighted_snr'][:]
-    net_ids = trigs['network/event_id'][:]
+    rw_snr = trigs['network/reweighted_snr'][:] \
+        if 'network/reweighted_snr' in trigs.keys() else numpy.array([])
+    net_ids = trigs['network/event_id'][:] \
+        if 'network/event_id' in trigs.keys() \
+        else numpy.array([], dtype=numpy.int64)
 
     # Output the number of items loaded only upon a request by the user who is
     # expected not to set data_tag to 'trigs'or 'injs' when processing the

--- a/pycbc/results/pygrb_postprocessing_utils.py
+++ b/pycbc/results/pygrb_postprocessing_utils.py
@@ -291,6 +291,8 @@ def load_data(input_file, ifos, rw_snr_threshold=None, data_tag=None,
         return None
 
     trigs = HFile(input_file, 'r')
+    if 'network/reweighted_snr' not in trigs.keys():
+        return {}
     rw_snr = trigs['network/reweighted_snr'][:]
     net_ids = trigs['network/event_id'][:]
 
@@ -310,8 +312,7 @@ def load_data(input_file, ifos, rw_snr_threshold=None, data_tag=None,
 
     # Apply the reweighted SNR cut on the reweighted SNR
     if rw_snr_threshold is not None:
-        rw_snr = reweightedsnr_cut(rw_snr, rw_snr_threshold)
-
+        rw_snr = reweightedsnr_cut(rw_snr.copy(), rw_snr_threshold)
     # Establish the indices of data not surviving the cut
     above_thresh = rw_snr > 0
 
@@ -332,7 +333,6 @@ def load_data(input_file, ifos, rw_snr_threshold=None, data_tag=None,
         ifo_ids_above_thresh_locations[ifo] = \
             numpy.array([numpy.where(ifo_ids[ifo] == net_id)[0][0]
                          for net_id in net_ids[above_thresh]])
-
     # Apply the cut on all the data by removing points with reweighted SNR = 0
     trigs_dict = {}
     with HFile(input_file, "r") as trigs:
@@ -358,9 +358,7 @@ def load_data(input_file, ifos, rw_snr_threshold=None, data_tag=None,
             if trigs_dict[path].size == trigs['network/slide_id'][:].size:
                 trigs_dict[path] = _slide_filter(trigs, trigs_dict[path],
                                                  slide_id=slide_id)
-
     return trigs_dict
-
 
 # =============================================================================
 # Function to apply vetoes to found injections
@@ -393,8 +391,12 @@ def apply_vetoes_to_found_injs(found_missed_file, found_injs, ifos,
     """
 
     keep_keys = keys if keys else found_injs.keys()
-
     if not found_missed_file:
+        return (dict.fromkeys(keep_keys, numpy.array([])),
+                dict.fromkeys(keep_keys, numpy.array([])),
+                None, None)
+
+    if not found_missed_file or ifos[0]+'/end_time' not in found_injs.keys():
         return (dict.fromkeys(keep_keys, numpy.array([])),
                 dict.fromkeys(keep_keys, numpy.array([])),
                 None, None)

--- a/pycbc/results/pygrb_postprocessing_utils.py
+++ b/pycbc/results/pygrb_postprocessing_utils.py
@@ -788,6 +788,8 @@ def template_hash_to_id(trigger_file, bank_path):
     trigger_file: HFile object for trigger file
     bank_file: filepath for template bank
     """
+    if 'ifos[0]}/template_hash' not in trigger_file.keys():
+        return numpy.array([], dtype=int)
     with HFile(bank_path, "r") as bank:
         hashes = bank['template_hash'][:]
     ifos = [k for k in trigger_file.keys() if k != 'network']

--- a/pycbc/results/pygrb_postprocessing_utils.py
+++ b/pycbc/results/pygrb_postprocessing_utils.py
@@ -377,6 +377,7 @@ def load_data(input_file, ifos, rw_snr_threshold=None, data_tag=None,
                 if trigs_dict[path].size == trigs['network/slide_id'][:].size:
                     trigs_dict[path] = _slide_filter(trigs, trigs_dict[path],
                                                      slide_id=slide_id)
+
     return trigs_dict
 
 
@@ -411,6 +412,7 @@ def apply_vetoes_to_found_injs(found_missed_file, found_injs, ifos,
     """
 
     keep_keys = keys if keys else found_injs.keys()
+    
     if not found_missed_file or ifos[0]+'/end_time' not in found_injs.keys():
         return (dict.fromkeys(keep_keys, numpy.array([])),
                 dict.fromkeys(keep_keys, numpy.array([])),

--- a/pycbc/results/pygrb_postprocessing_utils.py
+++ b/pycbc/results/pygrb_postprocessing_utils.py
@@ -312,7 +312,8 @@ def load_data(input_file, ifos, rw_snr_threshold=None, data_tag=None,
 
     # Apply the reweighted SNR cut on the reweighted SNR
     if rw_snr_threshold is not None:
-        rw_snr = reweightedsnr_cut(rw_snr.copy(), rw_snr_threshold)
+        rw_snr = reweightedsnr_cut(rw_snr, rw_snr_threshold)
+    
     # Establish the indices of data not surviving the cut
     above_thresh = rw_snr > 0
 
@@ -333,6 +334,7 @@ def load_data(input_file, ifos, rw_snr_threshold=None, data_tag=None,
         ifo_ids_above_thresh_locations[ifo] = \
             numpy.array([numpy.where(ifo_ids[ifo] == net_id)[0][0]
                          for net_id in net_ids[above_thresh]])
+
     # Apply the cut on all the data by removing points with reweighted SNR = 0
     trigs_dict = {}
     with HFile(input_file, "r") as trigs:
@@ -359,6 +361,7 @@ def load_data(input_file, ifos, rw_snr_threshold=None, data_tag=None,
                 trigs_dict[path] = _slide_filter(trigs, trigs_dict[path],
                                                  slide_id=slide_id)
     return trigs_dict
+
 
 # =============================================================================
 # Function to apply vetoes to found injections
@@ -391,11 +394,6 @@ def apply_vetoes_to_found_injs(found_missed_file, found_injs, ifos,
     """
 
     keep_keys = keys if keys else found_injs.keys()
-    if not found_missed_file:
-        return (dict.fromkeys(keep_keys, numpy.array([])),
-                dict.fromkeys(keep_keys, numpy.array([])),
-                None, None)
-
     if not found_missed_file or ifos[0]+'/end_time' not in found_injs.keys():
         return (dict.fromkeys(keep_keys, numpy.array([])),
                 dict.fromkeys(keep_keys, numpy.array([])),


### PR DESCRIPTION
## Standard information about the request

<!--- Some basic info about the change (delete as appropriate) -->
This is a: bug fix.

<!--- What codes will this affect? (delete as apropriate)
If you do not know which areas will be affected, please ask in the gwastro #pycbc-code slack
-->
This change affects: PyGRB

<!--- What code areas will this affect? (delete as apropriate) -->
This change changes: plotting.

<!--- Notes about the effect of this change -->
This change will: address several problems with `pygrb_postprocessing_utils`  that propagate to several pygrb plotting scripts, and additional changes to make `pycbc_pygrb_efficiency` and 'pycbc_pygrb_page_tables', `pycbc_pygrb_plot_injs_results`  for the no found injections case.

## Motivation
<!--- Describe why your changes are being made -->

This changes were at first done in stages and stacked together to make a test workflow finish.

- First changes to `pygrb_postprocessing_utils` were addressed to fix problems in `pycbc_pygrb_inj_finder`

```
        Finding injections: |          | 0/1 files (  0%) [00:00 | ETA ?], excluded=0, found=0, missed=0
        Finding injections: |          | 0/1 files (  0%) [00:05 | ETA ?], excluded=0, found=0, missed=5
        Finding injections: |##########| 1/1 files (100%) [00:05 | ETA 00:00], excluded=0, found=0, missed=5
        Finding injections: |##########| 1/1 files (100%) [00:05 | ETA 00:00], excluded=0, found=0, missed=5
        Traceback (most recent call last):
          File "/home/sebastian.gomezlopez/.conda/envs/pygrb_312/bin/pycbc_grb_inj_finder", line 346, in <module>
            ids = template_hash_to_id(h5out, args.bank_file)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
          File "/home/sebastian.gomezlopez/.conda/envs/pygrb_312/lib/python3.12/site-packages/pycbc/results/pygrb_postprocessing_utils.py", line 786, in template_hash_to_id
            trig_hashes = trigger_file[f'{ifos[0]}/template_hash'][:]
                          ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^
          File "h5py/_objects.pyx", line 54, in h5py._objects.with_phil.wrapper
          File "h5py/_objects.pyx", line 55, in h5py._objects.with_phil.wrapper
          File "/home/sebastian.gomezlopez/.conda/envs/pygrb_312/lib/python3.12/site-packages/h5py/_hl/group.py", line 357, in __getitem__                  oid = h5o.open(self.id, self._e(name), lapl=self._lapl)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
          File "h5py/_objects.pyx", line 54, in h5py._objects.with_phil.wrapper
          File "h5py/_objects.pyx", line 55, in h5py._objects.with_phil.wrapper
          File "h5py/h5o.pyx", line 257, in h5py.h5o.open
        KeyError: "Unable to synchronously open object (object 'template_hash' doesn't exist)"
```

- Additionally, several changes were added to [load_data](https://github.com/sebastiangomezlopez/pycbc/blob/25413c0e4426580704480b0fedec58197138f33c/pycbc/results/pygrb_postprocessing_utils.py#L283) to avoid errors propagating to plotting scripts such as, 
```
        2025-03-24T03:18:22.919-07:00: INFO: Imported and ready to go.
        2025-03-24T03:18:22.921-07:00: INFO: Loading timeslides.
        2025-03-24T03:18:22.926-07:00: INFO: Loading segments.
        2025-03-24T03:18:22.930-07:00: INFO: Constructing trials.
        2025-03-24T03:18:22.968-07:00: INFO: 121s of data vetoed at GPS time 1187006058
        2025-03-24T03:18:22.968-07:00: INFO: 2s of data vetoed at GPS time 1187009326
        2025-03-24T03:18:22.968-07:00: INFO: 2s of data vetoed at GPS time 1187010566
        2025-03-24T03:18:22.968-07:00: INFO: 25s of data vetoed at GPS time 1187011681
        2025-03-24T03:18:22.968-07:00: INFO: 121s of data vetoed at GPS time 1187006058
        2025-03-24T03:18:22.968-07:00: INFO: 25s of data vetoed at GPS time 1187011681
        2025-03-24T03:18:22.968-07:00: INFO: 121s of data vetoed at GPS time 1187006058
        2025-03-24T03:18:22.969-07:00: INFO: 25s of data vetoed at GPS time 1187011681
        2025-03-24T03:18:23.021-07:00: INFO: 1738 trials generated.
        2025-03-24T03:18:23.025-07:00: INFO: Loading triggers.
        Traceback (most recent call last):
          File "/home/sebastian.gomezlopez/.conda/envs/pygrb_312/bin/pycbc_pygrb_plot_snr_timeseries", line 142, in <module>
            inj_data = ppu.load_data(inj_file, ifos, data_tag='injs',
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
          File "/home/sebastian.gomezlopez/.conda/envs/pygrb_312/lib/python3.12/site-packages/pycbc/results/pygrb_postprocessing_utils.py", line 294, in load_data
            rw_snr = trigs['network/reweighted_snr'][:]
                     ~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^
          File "h5py/_objects.pyx", line 54, in h5py._objects.with_phil.wrapper
          File "h5py/_objects.pyx", line 55, in h5py._objects.with_phil.wrapper
          File "/home/sebastian.gomezlopez/.conda/envs/pygrb_312/lib/python3.12/site-packages/h5py/_hl/group.py", line 357, in __getitem__
            oid = h5o.open(self.id, self._e(name), lapl=self._lapl)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
          File "h5py/_objects.pyx", line 54, in h5py._objects.with_phil.wrapper
          File "h5py/_objects.pyx", line 55, in h5py._objects.with_phil.wrapper
          File "h5py/h5o.pyx", line 257, in h5py.h5o.open
        KeyError: "Unable to synchronously open object (object 'reweighted_snr' doesn't exist)"
```

- And Finally, `pycbc_pygrb_efficiency`,  'pycbc_pygrb_page_tables' and `pycbc_pygrb_plot_injs_results` were modified to avoid the following types of errors:
```
        2025-03-24T10:32:59.437-07:00: INFO: Setting output directory.
        2025-03-24T10:32:59.439-07:00: INFO: Loading timeslides.
        2025-03-24T10:32:59.443-07:00: INFO: Loading segments.
        2025-03-24T10:32:59.445-07:00: INFO: Constructing trials.
        2025-03-24T10:32:59.460-07:00: INFO: 121s of data vetoed at GPS time 1187006058
        2025-03-24T10:32:59.461-07:00: INFO: 2s of data vetoed at GPS time 1187009326
        2025-03-24T10:32:59.461-07:00: INFO: 2s of data vetoed at GPS time 1187010566
        2025-03-24T10:32:59.461-07:00: INFO: 25s of data vetoed at GPS time 1187011681
        2025-03-24T10:32:59.461-07:00: INFO: 121s of data vetoed at GPS time 1187006058
        2025-03-24T10:32:59.461-07:00: INFO: 25s of data vetoed at GPS time 1187011681
        2025-03-24T10:32:59.461-07:00: INFO: 121s of data vetoed at GPS time 1187006058
        2025-03-24T10:32:59.461-07:00: INFO: 25s of data vetoed at GPS time 1187011681
        2025-03-24T10:32:59.475-07:00: INFO: 1738 trials generated.
        2025-03-24T10:32:59.477-07:00: INFO: 130 triggers loaded.
        2025-03-24T10:32:59.478-07:00: INFO: 96 triggers surviving reweighted SNR cut at 6.0.
        2025-03-24T10:32:59.501-07:00: INFO: 93 triggers found within the trials dictionary and sorted.
        2025-03-24T10:32:59.502-07:00: INFO: Triggers information extracted.
        2025-03-24T10:32:59.510-07:00: INFO: Background bestNR calculated.
        2025-03-24T10:32:59.512-07:00: INFO: missed/mchirp not allowed yet
        2025-03-24T10:32:59.512-07:00: INFO: missed/sky_error not allowed yet
        2025-03-24T10:32:59.512-07:00: INFO: 0 missed injections analysed.
        2025-03-24T10:32:59.512-07:00: INFO: found/mchirp not allowed yet
        2025-03-24T10:32:59.512-07:00: INFO: found/sky_error not allowed yet
        Traceback (most recent call last):
          File "/home/sebastian.gomezlopez/.conda/envs/pygrb_312/bin/pycbc_pygrb_plot_injs_results", line 302, in <module>
            found_inj = complete_inj_data(inj_data, [x_qty, y_qty], 'found', ifos=ifos)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
          File "/home/sebastian.gomezlopez/.conda/envs/pygrb_312/bin/pycbc_pygrb_plot_injs_results", line 163, in complete_inj_data
            data_dict[ifo+'/end_time'] = injs[ifo+'/end_time']
                                         ~~~~^^^^^^^^^^^^^^^^^
        KeyError: 'H1/end_time'
```
## Contents
<!--- Describe your changes, this doesn't need to be a line-by-line code change discussion,
but rather a general discussion of the methods chosen -->

## Links to any issues or associated PRs
<!--- If this is fixing / working around an already-reported issue, please link to it here -->

## Testing performed
<!--- Describe tests for the code changes, either already performed or to be performed -->

## Additional notes
<!--- Anything which does not fit in the above sections -->

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
