### PR TITLE
Upgrade Docker image and CVMFS virtualenv to newer Python

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,6 @@ dnf makecache
 dnf -y groupinstall "Development Tools" "Scientific Support"
 rpm -e --nodeps git perl-Git
 dnf -y install \
-    @python39 \
     fftw \
     fftw-devel \
     fftw-libs \
@@ -29,13 +28,15 @@ dnf -y install \
     libpng-devel \
     openssl-devel \
     osg-ca-certs \
-    python39-devel \
+    python3.11 \
+    python3.11-devel \
+    python3.11-pip \
     rsync \
     sqlite-devel \
     swig \
     which \
     zlib-devel
-alternatives --set python /usr/bin/python3.9
+alternatives --set python /usr/bin/python3.11
 python -m pip install --upgrade pip setuptools wheel cython
 python -m pip install mkl ipython jupyter jupyterhub jupyterlab lalsuite
 dnf -y install https://repo.opensciencegrid.org/osg/3.5/el8/testing/x86_64/osg-wn-client-3.5-5.osg35.el8.noarch.rpm

--- a/tools/docker_build_dist.sh
+++ b/tools/docker_build_dist.sh
@@ -37,20 +37,20 @@ fi
 if [ "x${PYCBC_CONTAINER}" == "xpycbc_rhel_virtualenv" ]; then
 
   ENV_OS="x86_64_rhel_8"
-  yum -y install python39 python39-devel
+  yum -y install python3.11 python3.11-devel
+  alternatives --set python /usr/bin/python3.11
   yum -y groupinstall "Development Tools"
   yum -y install which rsync
   yum clean all
   yum makecache
   yum -y install openssl-devel
-  yum -y install python3-virtualenv
   yum -y install hdf5-static libxml2-static zlib-static libstdc++-static cfitsio-static glibc-static swig fftw-static gsl-static gsl gsl-devel --skip-broken
 
   CVMFS_PATH=/cvmfs/software.igwn.org/pycbc/${ENV_OS}/virtualenv
   mkdir -p ${CVMFS_PATH}
 
   VENV_PATH=${CVMFS_PATH}/pycbc-${SOURCE_TAG}
-  virtualenv -p python3.9 ${VENV_PATH}
+  python -m venv ${VENV_PATH}
   echo 'export PYTHONUSERBASE=${VIRTUAL_ENV}/.local' >> ${VENV_PATH}/bin/activate
   echo "export XDG_CACHE_HOME=\${HOME}/cvmfs-pycbc-${SOURCE_TAG}/.cache" >> ${VENV_PATH}/bin/activate
   source ${VENV_PATH}/bin/activate


### PR DESCRIPTION
Security support for Python 3.9 is ending later this year. I would like to move the CVMFS virtualenvs and Docker images to a more recent and supported Python version.

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
