### PR TITLE
add trigger cuts in trigger fit

### DIFF
--- a/bin/all_sky_search/pycbc_fit_sngls_by_template
+++ b/bin/all_sky_search/pycbc_fit_sngls_by_template
@@ -21,12 +21,13 @@ import pycbc
 from pycbc import events, init_logging
 from pycbc.events import triggers, trigger_fits as trstats
 from pycbc.events import stat as statsmod
+from pycbc.events import cuts
 from pycbc.types.optparse import MultiDetOptionAction
 from pycbc.io import HFile
 
 #### DEFINITIONS AND FUNCTIONS ####
 
-def get_stat(statname, trigs, threshold):
+def get_stat(args, trigs, threshold):
     # For now this is using the single detector ranking. If we want, this
     # could use the Stat classes in stat.py using similar code as in hdf/io.py
     # This requires additional options, so only change this if it's useful!
@@ -35,6 +36,7 @@ def get_stat(statname, trigs, threshold):
     select = []
     size = len(trigs['end_time'])
     s = 0
+    trigger_cut_dict, _ = cuts.ingest_cuts_option_group(args)
     while s < size:
         e = s + chunk_size if (s + chunk_size) <= size else size
 
@@ -42,12 +44,15 @@ def get_stat(statname, trigs, threshold):
         # as the stat classes expect.
         chunk = {k: trigs[k][s:e] for k in trigs if len(trigs[k]) == size}
         
+        trigger_keep_ids = cuts.apply_trigger_cuts(chunk, trigger_cut_dict)
+        chunk = {k: chunk[k][trigger_keep_ids] for k in chunk}
+
         rank_method = statsmod.get_statistic_from_opts(args, [args.ifo])
         chunk_stat = rank_method.get_sngl_ranking(chunk)
 
         above = chunk_stat >= threshold
         stat.append(chunk_stat[above])
-        select.append(above)
+        select.append(trigger_keep_ids[above])
         s += chunk_size
 
     # Return boolean area that selects the triggers above threshold
@@ -119,6 +124,7 @@ parser.add_argument("--approximant", default="SEOBNRv4",
 
 statsmod.insert_statistic_option_group(parser,
     default_ranking_statistic='single_ranking_only')
+cuts.insert_cuts_option_group(parser)
 args = parser.parse_args()
 
 init_logging(args.verbose)

--- a/bin/all_sky_search/pycbc_fit_sngls_by_template
+++ b/bin/all_sky_search/pycbc_fit_sngls_by_template
@@ -52,7 +52,10 @@ def get_stat(args, trigs, threshold):
 
         above = chunk_stat >= threshold
         stat.append(chunk_stat[above])
-        select.append(trigger_keep_ids[above])
+
+        trigger_keep_bool = np.zeros(e-s, dtype=bool)
+        trigger_keep_bool[trigger_keep_ids][above] = True
+        select.append(trigger_keep_bool)
         s += chunk_size
 
     # Return boolean area that selects the triggers above threshold

--- a/bin/all_sky_search/pycbc_fit_sngls_by_template
+++ b/bin/all_sky_search/pycbc_fit_sngls_by_template
@@ -54,7 +54,7 @@ def get_stat(args, trigs, threshold):
         stat.append(chunk_stat[above])
 
         trigger_keep_bool = np.zeros(e-s, dtype=bool)
-        trigger_keep_bool[trigger_keep_ids][above] = True
+        trigger_keep_bool[trigger_keep_ids[above]] = True
         select.append(trigger_keep_bool)
         s += chunk_size
 

--- a/bin/all_sky_search/pycbc_fit_sngls_by_template
+++ b/bin/all_sky_search/pycbc_fit_sngls_by_template
@@ -43,9 +43,11 @@ def get_stat(args, trigs, threshold):
         # read and format chunk of data so it can be read by key
         # as the stat classes expect.
         chunk = {k: trigs[k][s:e] for k in trigs if len(trigs[k]) == size}
-        
-        trigger_keep_ids = cuts.apply_trigger_cuts(chunk, trigger_cut_dict)
-        chunk = {k: chunk[k][trigger_keep_ids] for k in chunk}
+
+        if len(trigger_cut_dict) > 0:
+            # Apply trigger cuts        
+            trigger_keep_ids = cuts.apply_trigger_cuts(chunk, trigger_cut_dict)
+            chunk = {k: arr[trigger_keep_ids] for k, arr in chunk.items()}
 
         rank_method = statsmod.get_statistic_from_opts(args, [args.ifo])
         chunk_stat = rank_method.get_sngl_ranking(chunk)

--- a/bin/all_sky_search/pycbc_fit_sngls_by_template
+++ b/bin/all_sky_search/pycbc_fit_sngls_by_template
@@ -43,9 +43,10 @@ def get_stat(args, trigs, threshold):
         # read and format chunk of data so it can be read by key
         # as the stat classes expect.
         chunk = {k: trigs[k][s:e] for k in trigs if len(trigs[k]) == size}
+        trigger_keep_bool = np.zeros(e-s, dtype=bool)
 
         if len(trigger_cut_dict) > 0:
-            # Apply trigger cuts        
+            # Apply trigger cuts
             trigger_keep_ids = cuts.apply_trigger_cuts(chunk, trigger_cut_dict)
             chunk = {k: arr[trigger_keep_ids] for k, arr in chunk.items()}
 
@@ -55,8 +56,11 @@ def get_stat(args, trigs, threshold):
         above = chunk_stat >= threshold
         stat.append(chunk_stat[above])
 
-        trigger_keep_bool = np.zeros(e-s, dtype=bool)
-        trigger_keep_bool[trigger_keep_ids[above]] = True
+        if len(trigger_cut_dict) > 0:
+            trigger_keep_bool[trigger_keep_ids[above]] = True
+        else:
+            trigger_keep_bool[above] = True
+
         select.append(trigger_keep_bool)
         s += chunk_size
 

--- a/bin/all_sky_search/pycbc_fit_sngls_by_template
+++ b/bin/all_sky_search/pycbc_fit_sngls_by_template
@@ -28,6 +28,25 @@ from pycbc.io import HFile
 #### DEFINITIONS AND FUNCTIONS ####
 
 def get_stat(args, trigs, threshold):
+    """
+    Select the triggers and calculate the single detector statistic.
+
+    Parameters
+    ----------
+    args: argparse.Namespace
+        The argparse object containing options and parameters.
+    trigs: dict
+        The dictionary of single detector trigger data.
+    threshold: float
+        The statistic threshold value for selecting triggers.
+
+    Returns
+    -------
+    np.concatenate(select): np.ndarray
+        A boolean array that selects the triggers.
+    np.concatenate(stat): np.ndarray
+        The statistic values of the selected triggers.
+    """
     # For now this is using the single detector ranking. If we want, this
     # could use the Stat classes in stat.py using similar code as in hdf/io.py
     # This requires additional options, so only change this if it's useful!


### PR DESCRIPTION
<!---
Please delete these comments when you submit the pull request

Please add a title which is a concise description of what you are doing,
e.g. 'Fix bug with numpy import in pycbc_coinc_findtrigs' or 'add high frequency sky location dependent response for long detectors'
-->

<!---
This is a brief template for making pull requests for PyCBC.
This is _not_ a proscriptive template - you can use a different style if you want.
Please do think about the questions posed here and whether the details will be useful to include in your PR
Please add sufficient details so that people looking back at the request with no context around the work can understand the changes.
To choose reviewers, please look at the git blame for the code you are changing (if applicable),
or discuss in the #pycbc-code channel of the gwastro slack.
Please add labels as appropriate
-->

<!-- TOP-LEVEL SUMMARY: Please provide a brief, one-or-two-sentence description of the PR here
-->

## Add trigger cuts in the single detector trigger fitting codes

<!--- Some basic info about the change (delete as appropriate) -->
This is a new feature

<!--- What codes will this affect? (delete as apropriate)
If you do not know which areas will be affected, please ask in the gwastro #pycbc-code slack
-->
This change wouldn't affect anything if you don't use trigger cuts in the trigger fitting, .i.e., it's backward compatible. But offline search, live search, PyGRB, and any other pipeline that depends on trigger fitting could use this new feature.

<!--- What code areas will this affect? (delete as apropriate) -->
This change changes scientific output

<!--- Some things which help with code management (delete as appropriate) -->
This change follows style guidelines (See e.g. [PEP8](https://peps.python.org/pep-0008/)), has been proposed using the [contribution guidelines](https://github.com/gwastro/pycbc/blob/master/CONTRIBUTING.md). I'll try to add some unittests, but they don't exist at the moment

<!--- Notes about the effect of this change -->
This change won't change any current pipelines, as it has backward compatibility.

## Motivation
<!--- Describe why your changes are being made -->
We made some trigger cutting in the single trigger fitting and the coincidence job in 3-OGC and 4-OGC with an argument called "statistic-keywords", for example see [here](https://github.com/gwastro/4-ogc/blob/master/search/bank/bank_bbh.ini#L36). However I think it's never merged into the main branch. At the same time, there is a nice module in PyCBC to cut triggers using the codes in `events/cuts.py`. So I introduce these cuts into the trigger fitting codes. The coincidence codes already have it.

## Contents
<!--- Describe your changes, this doesn't need to be a line-by-line code change discussion,
but rather a general discussion of the methods chosen -->
Adding trigger cuts in [bin/all_sky_search/pycbc_fit_sngls_by_template](https://github.com/gwastro/pycbc/compare/master...yi-fan-wang:pycbc:triggerfitcut?expand=1#diff-3e27918d238d5d855742e1f2d3f6a875b61f2abc45a1ff1426067900c1fb5b66)

## Links to any issues or associated PRs
<!--- If this is fixing / working around an already-reported issue, please link to it here -->

## Testing performed
<!--- Describe tests for the code changes, either already performed or to be performed -->
To be performed

## Additional notes
<!--- Anything which does not fit in the above sections -->

- [ ] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
