### PR TITLE
Cleanup stuff that handles the Docker image and CVMFS release

### DIFF
--- a/.github/workflows/build_venv.yml
+++ b/.github/workflows/build_venv.yml
@@ -13,11 +13,6 @@ jobs:
       -
         uses: actions/checkout@v1
       -
-        name: "Set up Python"
-        uses: actions/setup-python@v5
-        with:
-          python-version: 3.9
-      -
         env:
           OSG_ACCESS: "${{secrets.OSG_ACCESS}}"
         name: "Preparing ssh stuff"
@@ -29,4 +24,3 @@ jobs:
           DOCKER_SECURE_ENV_VARS: true
         name: "Creating the virtual environment"
         run: "bash -e tools/docker_build_and_test.sh"
-

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -13,11 +13,6 @@ jobs:
       -
         uses: actions/checkout@v1
       -
-        name: "Set up Python"
-        uses: actions/setup-python@v5
-        with:
-          python-version: 3.9
-      -
         name: "Preparing a host container"
         run: "docker build -t pycbc-docker-tmp ."
       -
@@ -35,4 +30,3 @@ jobs:
           DOCKER_USERNAME: "${{secrets.DOCKERHUB_USERNAME}}"
         name: "Pushing docker image"
         run: "bash -e docker/etc/push_image.sh"
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,6 @@ ADD docker/etc/cvmfs/config-osg.opensciencegrid.org.conf /etc/cvmfs/config-osg.o
 RUN <<EOF
 dnf -y install https://ecsft.cern.ch/dist/cvmfs/cvmfs-release/cvmfs-release-latest.noarch.rpm
 dnf -y install cvmfs cvmfs-config-default
-dnf clean all
 dnf makecache
 dnf -y groupinstall "Development Tools" "Scientific Support"
 rpm -e --nodeps git perl-Git
@@ -44,7 +43,6 @@ EOF
 
 # set up environment
 RUN <<EOF
-cd /
 mkdir -p /cvmfs/config-osg.opensciencegrid.org /cvmfs/software.igwn.org /cvmfs/gwosc.osgstorage.org
 echo "config-osg.opensciencegrid.org /cvmfs/config-osg.opensciencegrid.org cvmfs ro,noauto 0 0" >> /etc/fstab
 echo "software.igwn.org /cvmfs/software.igwn.org cvmfs ro,noauto 0 0" >> /etc/fstab
@@ -71,8 +69,8 @@ dnf -y install \
     openmpi-devel
 python3.9 -m pip install schwimmbad
 MPICC=/lib64/openmpi/bin/mpicc CFLAGS='-I /usr/include/openmpi-x86_64/ -L /usr/lib64/openmpi/lib/ -lmpi' python3.9 -m pip install --no-cache-dir mpi4py
+echo "/usr/lib64/openmpi/lib/" > /etc/ld.so.conf.d/openmpi.conf
 EOF
-RUN echo "/usr/lib64/openmpi/lib/" > /etc/ld.so.conf.d/openmpi.conf
 
 # Now update all of our library installations
 RUN rm -f /etc/ld.so.cache && /sbin/ldconfig

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,22 +7,71 @@ ADD docker/etc/cvmfs/60-osg.conf /etc/cvmfs/60-osg.conf
 ADD docker/etc/cvmfs/config-osg.opensciencegrid.org.conf /etc/cvmfs/config-osg.opensciencegrid.org.conf
 
 # Set up extra repositories
-RUN dnf -y install https://ecsft.cern.ch/dist/cvmfs/cvmfs-release/cvmfs-release-latest.noarch.rpm && dnf -y install cvmfs cvmfs-config-default && dnf clean all && dnf makecache && \
-    dnf -y groupinstall "Development Tools" \
-                        "Scientific Support" && \
-    rpm -e --nodeps git perl-Git && dnf -y install @python39 rsync zlib-devel libpng-devel libjpeg-devel sqlite-devel openssl-devel fftw-libs-single fftw-devel fftw fftw-libs-long fftw-libs fftw-libs-double gsl gsl-devel hdf5 hdf5-devel python39-devel swig which osg-ca-certs && python3.9 -m pip install --upgrade pip setuptools wheel cython && python3.9 -m pip install mkl ipython jupyter jupyterhub jupyterlab lalsuite && \
-    dnf -y install https://repo.opensciencegrid.org/osg/3.5/el8/testing/x86_64/osg-wn-client-3.5-5.osg35.el8.noarch.rpm && dnf clean all
+RUN <<EOF
+dnf -y install https://ecsft.cern.ch/dist/cvmfs/cvmfs-release/cvmfs-release-latest.noarch.rpm
+dnf -y install cvmfs cvmfs-config-default
+dnf clean all
+dnf makecache
+dnf -y groupinstall "Development Tools" "Scientific Support"
+rpm -e --nodeps git perl-Git
+dnf -y install \
+    @python39 \
+    fftw \
+    fftw-devel \
+    fftw-libs \
+    fftw-libs-double \
+    fftw-libs-long \
+    fftw-libs-single \
+    gsl \
+    gsl-devel \
+    hdf5 \
+    hdf5-devel \
+    libjpeg-devel \
+    libpng-devel \
+    openssl-devel \
+    osg-ca-certs \
+    python39-devel \
+    rsync \
+    sqlite-devel \
+    swig \
+    which \
+    zlib-devel
+python3.9 -m pip install --upgrade pip setuptools wheel cython
+python3.9 -m pip install mkl ipython jupyter jupyterhub jupyterlab lalsuite
+dnf -y install https://repo.opensciencegrid.org/osg/3.5/el8/testing/x86_64/osg-wn-client-3.5-5.osg35.el8.noarch.rpm
+dnf clean all
+EOF
 
 # set up environment
-RUN cd / && \
-    mkdir -p /cvmfs/config-osg.opensciencegrid.org /cvmfs/software.igwn.org /cvmfs/gwosc.osgstorage.org && echo "config-osg.opensciencegrid.org /cvmfs/config-osg.opensciencegrid.org cvmfs ro,noauto 0 0" >> /etc/fstab && echo "software.igwn.org /cvmfs/software.igwn.org cvmfs ro,noauto 0 0" >> /etc/fstab && echo "gwosc.osgstorage.org /cvmfs/gwosc.osgstorage.org cvmfs ro,noauto 0 0" >> /etc/fstab && mkdir -p /oasis /scratch /projects /usr/lib64/slurm /var/run/munge && \
-    groupadd -g 1000 pycbc && useradd -u 1000 -g 1000 -d /opt/pycbc -k /etc/skel -m -s /bin/bash pycbc
+RUN <<EOF
+cd /
+mkdir -p /cvmfs/config-osg.opensciencegrid.org /cvmfs/software.igwn.org /cvmfs/gwosc.osgstorage.org
+echo "config-osg.opensciencegrid.org /cvmfs/config-osg.opensciencegrid.org cvmfs ro,noauto 0 0" >> /etc/fstab
+echo "software.igwn.org /cvmfs/software.igwn.org cvmfs ro,noauto 0 0" >> /etc/fstab
+echo "gwosc.osgstorage.org /cvmfs/gwosc.osgstorage.org cvmfs ro,noauto 0 0" >> /etc/fstab
+mkdir -p /oasis /scratch /projects /usr/lib64/slurm /var/run/munge
+groupadd -g 1000 pycbc
+useradd -u 1000 -g 1000 -d /opt/pycbc -k /etc/skel -m -s /bin/bash pycbc
+EOF
 
-# Install MPI software needed for pycbc_inference
-# at the end.
-RUN dnf -y install libibverbs libibverbs-devel libibmad libibmad-devel libibumad libibumad-devel librdmacm librdmacm-devel libmlx5 libmlx4 openmpi openmpi-devel && \
-    python3.9 -m pip install schwimmbad && \
-    MPICC=/lib64/openmpi/bin/mpicc CFLAGS='-I /usr/include/openmpi-x86_64/ -L /usr/lib64/openmpi/lib/ -lmpi' python3.9 -m pip install --no-cache-dir mpi4py
+# Install MPI software needed for pycbc_inference at the end.
+RUN <<EOF
+dnf -y install \
+    libibmad \
+    libibmad-devel \
+    libibumad \
+    libibumad-devel \
+    libibverbs \
+    libibverbs-devel \
+    libmlx4 \
+    libmlx5 \
+    librdmacm \
+    librdmacm-devel \
+    openmpi \
+    openmpi-devel
+python3.9 -m pip install schwimmbad
+MPICC=/lib64/openmpi/bin/mpicc CFLAGS='-I /usr/include/openmpi-x86_64/ -L /usr/lib64/openmpi/lib/ -lmpi' python3.9 -m pip install --no-cache-dir mpi4py
+EOF
 RUN echo "/usr/lib64/openmpi/lib/" > /etc/ld.so.conf.d/openmpi.conf
 
 # Now update all of our library installations
@@ -41,7 +90,7 @@ ENV LAL_DATA_PATH "/cvmfs/software.igwn.org/pycbc/lalsuite-extra/current/share/l
 
 # When the container is started with
 #   docker run -it pycbc/pycbc-el8:latest
-# the default is to start a loging shell as the pycbc user.
+# the default is to start a login shell as the pycbc user.
 # This can be overridden to log in as root with
 #   docker run -it pycbc/pycbc-el8:latest /bin/bash -l
 CMD ["/bin/su", "-l", "pycbc"]

--- a/docker/etc/docker-install.sh
+++ b/docker/etc/docker-install.sh
@@ -1,5 +1,8 @@
 #!/bin/bash -v
+
 set -e
+
+# Install PyCBC
 cd /scratch
 python3.9 -m pip install --upgrade 'pip<22.0'
 python3.9 -m pip install -r requirements.txt
@@ -7,15 +10,28 @@ python3.9 -m pip install -r requirements-igwn.txt
 python3.9 -m pip install -r companion.txt
 python3.9 -m pip install .
 cd /
+
+# Copy PyCBC source repository into the image
 mkdir -p /opt/pycbc/src
 cp -a /scratch /opt/pycbc/src/pycbc
+
+# Copy the lalsuite extra data into the image
 chmod a+rw /dev/fuse
 mount /cvmfs/config-osg.opensciencegrid.org
 mount /cvmfs/software.igwn.org
 mkdir -p /opt/pycbc/pycbc-software/share/lal-data
-rsync --exclude='SEOBNRv1ROM*' --exclude='SEOBNRv2ROM_DS_HI_v1.0.hdf5' --exclude='NRSur4d2s_FDROM.hdf5' -ravz /cvmfs/software.igwn.org/pycbc/lalsuite-extra/current/share/lalsimulation/ /opt/pycbc/pycbc-software/share/lal-data/
+rsync \
+	--exclude='SEOBNRv1ROM*' \
+	--exclude='SEOBNRv2ROM_DS_HI_v1.0.hdf5' \
+	--exclude='NRSur4d2s_FDROM.hdf5' \
+	-ravz \
+	/cvmfs/software.igwn.org/pycbc/lalsuite-extra/current/share/lalsimulation/ \
+	/opt/pycbc/pycbc-software/share/lal-data/
 umount /cvmfs/config-osg.opensciencegrid.org
 umount /cvmfs/software.igwn.org
+
+# Set ownership and permissions correctly
 chown -R 1000:1000 /opt/pycbc/src /opt/pycbc/pycbc-software
 chmod -R u=rwX,g=rX,o=rX /opt/pycbc
+
 exit 0

--- a/docker/etc/push_image.sh
+++ b/docker/etc/push_image.sh
@@ -1,15 +1,14 @@
 SOURCE_TAG=`git show-ref | grep ${GITHUB_SHA} | grep -E -o "refs/tags.{0,100}" | cut -c11-`
 MASTER_HASH=`git rev-parse origin/master`
-if [ "x${SOURCE_TAG}"  == "x" ] ; then
-    if [ "x${MASTER_HASH}"  == "x${GITHUB_SHA}" ] ; then
-        echo "$DOCKER_PASSWORD" | docker login --username "$DOCKER_USERNAME" --password-stdin
-        docker tag ${DOCKER_IMG} ${DOCKER_IMG}:latest || exit 1 ;
-        docker push ${DOCKER_IMG}:latest || exit 1 ;
-    else
+
+if [ "x${SOURCE_TAG}" == "x" ] ; then
+    if [ "x${MASTER_HASH}" != "x${GITHUB_SHA}" ] ; then
         echo "Not on master or a tag, so not pushing the docker image."
+        exit
     fi
-else
-    echo "$DOCKER_PASSWORD" | docker login --username "$DOCKER_USERNAME" --password-stdin
-    docker tag ${DOCKER_IMG} ${DOCKER_IMG}:${SOURCE_TAG} || exit 1 ;
-    docker push ${DOCKER_IMG}:${SOURCE_TAG} || exit 1 ;
-fi ;
+    SOURCE_TAG=latest
+fi
+
+docker login --username "$DOCKER_USERNAME" --password "$DOCKER_PASSWORD"
+docker tag ${DOCKER_IMG} ${DOCKER_IMG}:${SOURCE_TAG} || exit 1 ;
+docker push ${DOCKER_IMG}:${SOURCE_TAG} || exit 1 ;

--- a/tools/docker_build_prepssh.sh
+++ b/tools/docker_build_prepssh.sh
@@ -1,6 +1,5 @@
 mkdir -p ~/.ssh
-touch ~/.ssh/id_rsa ~/.ssh/ldg_user ~/.ssh/ldg_token
-chmod 600 ~/.ssh/id_rsa ~/.ssh/ldg_user ~/.ssh/ldg_token
+touch ~/.ssh/ldg_user ~/.ssh/ldg_token
 echo "${OSG_ACCESS}" > ~/.ssh/id_rsa
 echo -e "Host sugwg-test1.phy.syr.edu\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config ;
 echo -e "Host sugwg-condor.phy.syr.edu\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config ;


### PR DESCRIPTION
While working on #5089, I found the Docker and CVMFS stuff a bit hard to follow and redundant, so here I try to clean in up a bit.

## Standard information about the request

This is mostly a cleanup of the Docker image and publication on CVMFS with no expected functional changes.

## Motivation

Mainly to simplify the upcoming PR that will upgrade the Python version shipped in the Docker image and in the CVMFS virtualenvs.

## Contents

First, I noticed that the CI jobs that build the Docker image and the CVMFS venv currently run the "setup Python" block. This does not seem necessary though, since everything in both jobs happens inside containers anyway. So I removed the "setup Python" stuff.

Second, I cleaned up the Dockerfile, mostly to break down long chains of commands into separate lines, to make further changes easier to review.

Third, I removed a couple of things in the Dockerfile that I *think* had no effect. Hopefully this can be reviewed carefully by others though.

Lastly, I reformatted a couple shell scripts  associated with Docker and CVMFS to make them easier to read and edit.

Again, I tried hard not to change the functionality. I think there are further things to improve, for example we should probably clear the dnf and pip caches after making the Docker image, to reduce the size. But I prefer to propose those in a followup PR, which should be easier to review after this one.

## Links to any issues or associated PRs

N/A

## Testing performed

None, relying on the CI.

## Additional notes

N/A

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
