### PR TITLE
Relax pip<22.0 constraint

### DIFF
--- a/.github/workflows/bank-compress-workflow.yml
+++ b/.github/workflows/bank-compress-workflow.yml
@@ -34,7 +34,7 @@ jobs:
     - run: sudo apt-get -o Acquire::Retries=3 install *fftw3* intel-mkl*
     - name: Install pycbc
       run: |
-        python -m pip install --upgrade 'pip<22.0' setuptools
+        python -m pip install --upgrade pip setuptools
         pip install GitPython # This shouldn't really be needed!
         pip install -r requirements.txt
         pip install .

--- a/.github/workflows/inference-workflow.yml
+++ b/.github/workflows/inference-workflow.yml
@@ -29,7 +29,7 @@ jobs:
     - run: sudo apt-get -o Acquire::Retries=3 install *fftw3* intel-mkl*
     - name: Install pycbc
       run: |
-        python -m pip install --upgrade 'pip<22.0' setuptools
+        python -m pip install --upgrade pip setuptools
         pip install GitPython # This shouldn't really be needed!
         pip install -r requirements.txt
         pip install .

--- a/.github/workflows/search-workflow.yml
+++ b/.github/workflows/search-workflow.yml
@@ -34,7 +34,7 @@ jobs:
     - run: sudo apt-get -o Acquire::Retries=3 install *fftw3* intel-mkl*
     - name: Install pycbc
       run: |
-        python -m pip install --upgrade 'pip<22.0' setuptools
+        python -m pip install --upgrade pip setuptools
         pip install GitPython # This shouldn't really be needed!
         pip install -r requirements.txt
         pip install .

--- a/.github/workflows/tmpltbank-workflow.yml
+++ b/.github/workflows/tmpltbank-workflow.yml
@@ -33,7 +33,7 @@ jobs:
     - run: sudo apt-get -o Acquire::Retries=3 install *fftw3* intel-mkl*
     - name: Install pycbc
       run: |
-        python -m pip install --upgrade 'pip<22.0' setuptools
+        python -m pip install --upgrade pip setuptools
         pip install GitPython # This shouldn't really be needed!
         pip install -r requirements.txt
         pip install sbank

--- a/.github/workflows/workflow-tests.yml
+++ b/.github/workflows/workflow-tests.yml
@@ -38,7 +38,7 @@ jobs:
     - run: sudo apt-get -o Acquire::Retries=3 install *fftw3* intel-mkl*
     - name: Install pycbc
       run: |
-        python -m pip install --upgrade 'pip<22.0' setuptools
+        python -m pip install --upgrade pip setuptools
         pip install GitPython # This shouldn't really be needed!
         pip install -r requirements.txt
         pip install .

--- a/docker/etc/docker-install.sh
+++ b/docker/etc/docker-install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -v
 set -e
 cd /scratch
-python3.9 -m pip install --upgrade 'pip<22.0'
+python3.9 -m pip install --upgrade pip
 python3.9 -m pip install -r requirements.txt
 python3.9 -m pip install -r requirements-igwn.txt
 python3.9 -m pip install -r companion.txt

--- a/tools/docker_build_dist.sh
+++ b/tools/docker_build_dist.sh
@@ -59,7 +59,7 @@ if [ "x${PYCBC_CONTAINER}" == "xpycbc_rhel_virtualenv" ]; then
   echo -e "[easy_install]\\nzip_ok = false\\n" > ${VIRTUAL_ENV}/.local/.pydistutils.cfg
 
   echo -e "\\n>> [`date`] Upgrading pip and setuptools"
-  pip install --upgrade 'pip<22.0' setuptools pytest
+  pip install --upgrade pip setuptools pytest
   pip install six packaging appdirs mkl
 
   echo -e "\\n>> [`date`] Installing PyCBC dependencies from requirements.txt"


### PR DESCRIPTION
Years ago we forced pip < 22.0 due to a regression (#3925). We can probably drop this now.

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
