### PR TITLE
Docker: set default Python version early, use it more; purge pip cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ dnf -y install \
     swig \
     which \
     zlib-devel
-RUN alternatives --set python /usr/bin/python3.9
+alternatives --set python /usr/bin/python3.9
 python -m pip install --upgrade pip setuptools wheel cython
 python -m pip install mkl ipython jupyter jupyterhub jupyterlab lalsuite
 dnf -y install https://repo.opensciencegrid.org/osg/3.5/el8/testing/x86_64/osg-wn-client-3.5-5.osg35.el8.noarch.rpm

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,10 +35,10 @@ dnf -y install \
     swig \
     which \
     zlib-devel
-python3.9 -m pip install --upgrade pip setuptools wheel cython
-python3.9 -m pip install mkl ipython jupyter jupyterhub jupyterlab lalsuite
+RUN alternatives --set python /usr/bin/python3.9
+python -m pip install --upgrade pip setuptools wheel cython
+python -m pip install mkl ipython jupyter jupyterhub jupyterlab lalsuite
 dnf -y install https://repo.opensciencegrid.org/osg/3.5/el8/testing/x86_64/osg-wn-client-3.5-5.osg35.el8.noarch.rpm
-dnf clean all
 EOF
 
 # set up environment
@@ -67,16 +67,13 @@ dnf -y install \
     librdmacm-devel \
     openmpi \
     openmpi-devel
-python3.9 -m pip install schwimmbad
-MPICC=/lib64/openmpi/bin/mpicc CFLAGS='-I /usr/include/openmpi-x86_64/ -L /usr/lib64/openmpi/lib/ -lmpi' python3.9 -m pip install --no-cache-dir mpi4py
+python -m pip install schwimmbad
+MPICC=/lib64/openmpi/bin/mpicc CFLAGS='-I /usr/include/openmpi-x86_64/ -L /usr/lib64/openmpi/lib/ -lmpi' python -m pip install --no-cache-dir mpi4py
 echo "/usr/lib64/openmpi/lib/" > /etc/ld.so.conf.d/openmpi.conf
 EOF
 
 # Now update all of our library installations
 RUN rm -f /etc/ld.so.cache && /sbin/ldconfig
-
-# Make python be what we want
-RUN alternatives --set python /usr/bin/python3.9
 
 # Explicitly set the path so that it is not inherited from build the environment
 ENV PATH "/usr/local/bin:/usr/bin:/bin:/lib64/openmpi/bin/bin"

--- a/docker/etc/docker-install.sh
+++ b/docker/etc/docker-install.sh
@@ -4,11 +4,11 @@ set -e
 
 # Install PyCBC
 cd /scratch
-python3.9 -m pip install --upgrade pip
-python3.9 -m pip install -r requirements.txt
-python3.9 -m pip install -r requirements-igwn.txt
-python3.9 -m pip install -r companion.txt
-python3.9 -m pip install .
+python -m pip install --upgrade pip
+python -m pip install -r requirements.txt
+python -m pip install -r requirements-igwn.txt
+python -m pip install -r companion.txt
+python -m pip install .
 cd /
 
 # Copy PyCBC source repository into the image
@@ -33,5 +33,9 @@ umount /cvmfs/software.igwn.org
 # Set ownership and permissions correctly
 chown -R 1000:1000 /opt/pycbc/src /opt/pycbc/pycbc-software
 chmod -R u=rwX,g=rX,o=rX /opt/pycbc
+
+# Cleanup any leftover stuff cached by dnf and pip
+dnf clean all
+python -m pip cache purge
 
 exit 0


### PR DESCRIPTION
Followup of #5091 and prelude to (a simpler version of) #5089.

In a bunch of places we are explicitly calling `python3.9` which complicates upgrading the version. This sets the system-wide Python version to `python3.9` right after installing it, so it is safe to just call `python` afterwards.

I also noticed that the Docker image contained about 800 Mb of pip cache, so this clears the cache at the end of the installs.

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
