### PR TITLE
Update PyPI publish action to latest release

### DIFF
--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -57,6 +57,6 @@ jobs:
         ls -lh dist
     - name: Publish to PyPI
       if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
       with:
         password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
We use the pypa/gh-action-pypi-publish to publish releases on PyPI. We use the master branch of that action, but this has been [discouraged years ago](https://github.com/pypa/gh-action-pypi-publish/tree/release/v1?tab=readme-ov-file#-master-branch-sunset-) (there is a prominent message hidden deep into the GitHub Actions pages, but it is hard to see unless you intentionally peek into those). This updates it to directly use the hash of the latest v1 tag as of today. Using the hash directly is another recommendation I have seen recently in a few places.

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
