### PR TITLE
Fix usage of release flag in Pegasus sites code

### DIFF
--- a/pycbc/workflow/pegasus_sites.py
+++ b/pycbc/workflow/pegasus_sites.py
@@ -25,9 +25,10 @@ from Pegasus.api import Arch, OS, SiteCatalog
 
 from pycbc.version import last_release, version, release  # noqa
 
+
 logger = logging.getLogger('pycbc.workflow.pegasus_sites')
 
-if release == 'True':
+if release:
     sing_version = version
 else:
     sing_version = last_release


### PR DESCRIPTION
In #5033 I converted the release flag from a string (either `'True'` or `'False'`) to an actual bool. However, I forgot to update a place that actually uses the release flag to figure out the path to the Singularity/Apptainer image. This fixes it.

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
