### PR TITLE
Get LAL aux data from Zenodo and cache it

### DIFF
--- a/.github/workflows/basic-tests.yml
+++ b/.github/workflows/basic-tests.yml
@@ -26,23 +26,34 @@ jobs:
         sudo apt-get -o Acquire::Retries=3 update
         sudo apt-get -o Acquire::Retries=3 install *fftw3* mpi intel-mkl* graphviz
         pip install tox pip setuptools --upgrade
-    - name: installing auxiliary data files
+    - name: Cache LAL auxiliary data files
+      id: cache-lal-aux-data
+      uses: actions/cache@v4
+      with:
+        key: lal-aux-data
+        path: ~/lal_aux_data
+    - if: ${{ steps.cache-lal-aux-data.outputs.cache-hit != 'true' }}
+      name: Download LAL auxiliary data files
       run: |
-        curl --show-error --silent --remote-name https://git.ligo.org/lscsoft/lalsuite-extra/-/raw/master/data/lalsimulation/SEOBNRv4ROM_v2.0.hdf5
-        curl --show-error --silent --remote-name  https://git.ligo.org/waveforms/software/lalsuite-waveform-data/-/raw/main/waveform_data/SEOBNRv4ROM_v3.0.hdf5
+        mkdir ~/lal_aux_data
+        pushd ~/lal_aux_data
+        curl --show-error --silent \
+          --remote-name https://zenodo.org/records/14999310/files/SEOBNRv4ROM_v2.0.hdf5 \
+          --remote-name https://zenodo.org/records/14999310/files/SEOBNRv4ROM_v3.0.hdf5
+        popd
     - name: run pycbc test suite
       run: |
-        export LAL_DATA_PATH=$PWD
+        export LAL_DATA_PATH=$HOME/lal_aux_data
         tox -e py-${{matrix.test-type}}
     - name: check help messages work
       if: matrix.test-type == 'unittest'
       run: |
-        export LAL_DATA_PATH=$PWD
+        export LAL_DATA_PATH=$HOME/lal_aux_data
         tox -e py-help
     - name: run inference tests
       if: matrix.test-type == 'search'
       run: |
-        export LAL_DATA_PATH=$PWD
+        export LAL_DATA_PATH=$HOME/lal_aux_data
         tox -e py-inference
     - name: store documentation page
       if: matrix.test-type == 'docs' && matrix.python-version == '3.12'


### PR DESCRIPTION
Edit the basic CI tests to download the LAL auxiliary data (currently only the files for SEOBNRv4_ROM) from Zenodo rather than git.ligo.org, and use a GitHub cache for it. While the speed gain is negligible, hopefully this reduces the load on git.ligo.org and helps make the CI tests more robust against web site outages.

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
