### PR TITLE
Pick cherries for v2.8.1

### DIFF
--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -57,6 +57,6 @@ jobs:
         ls -lh dist
     - name: Publish to PyPI
       if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
       with:
         password: ${{ secrets.pypi_password }}

--- a/pycbc/workflow/pegasus_sites.py
+++ b/pycbc/workflow/pegasus_sites.py
@@ -25,9 +25,10 @@ from Pegasus.api import Arch, OS, SiteCatalog
 
 from pycbc.version import last_release, version, release  # noqa
 
+
 logger = logging.getLogger('pycbc.workflow.pegasus_sites')
 
-if release == 'True':
+if release:
     sing_version = version
 else:
     sing_version = last_release

--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,7 @@ def get_version_info():
         vinfo = _version_helper.generate_git_version_info()
     except:
         vinfo = vdummy()
-        vinfo.version = '2.8.0'
+        vinfo.version = '2.8.1'
         vinfo.release = True
 
     version_script = f"""# coding: utf-8


### PR DESCRIPTION
This cherry-picks #5097 (minor update of distribution tools) and #5098 (important bugfix) into the PyGRB release branch, and prepares for 2.8.1.

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
