### PR TITLE
Fix PyGRB postprocessing to cover the case in which 0 found injections survive vetoes

### DIFF
--- a/bin/pygrb/pycbc_pygrb_efficiency
+++ b/bin/pygrb/pycbc_pygrb_efficiency
@@ -564,6 +564,12 @@ if len(found_after_vetoes['network/template_id']):
 # ==========
 logging.info("Plotting.")
 
+# Calculate distances (as means) for the horizontal axis, only if there are
+# found injections
+if len(found_after_vetoes['network/template_id']):
+    dist_plot_vals = [np.asarray(dist_bin).mean()
+                      for dist_bin in dist_bins]
+
 # Plot efficiency using loudest background
 if opts.background_output_file:
     fig = plt.figure()
@@ -571,10 +577,6 @@ if opts.background_output_file:
 
     # Without found injections, do not determine these quantities to plot
     if len(found_after_vetoes['network/template_id']):
-        # Calculate distances (horizontal axis) as means
-        dist_plot_vals = [np.asarray(dist_bin).mean()
-                          for dist_bin in dist_bins]
-
         # Calculate error bars for efficiency/distance plots and datafiles
         # using max BestNR of background
         yerr_low_mc, yerr_high_mc, fraction_mc = efficiency_with_errs(

--- a/bin/pygrb/pycbc_pygrb_plot_injs_results
+++ b/bin/pygrb/pycbc_pygrb_plot_injs_results
@@ -474,12 +474,16 @@ ax.grid()
 # Handle axis limits when plotting spins
 if "spin" in x_qty and missed_inj['spin1_a'].size:
     max_missed_inj = missed_inj['spin1_a'].max()
-    ax.set_xlim([0, np.ceil(10 * max(max_missed_inj,
-                                     found_inj[x_qty].max())) / 10])
+    ax.set_xlim([0, np.ceil(10 * max_missed_inj) / 10])
+    if found_inj[x_qty].size:
+        ax.set_xlim([0, np.ceil(10 * max(max_missed_inj,
+                                         found_inj[x_qty].max())) / 10])
 if "spin" in y_qty and missed_inj['spin2_a'].size:
     max_missed_inj = missed_inj['spin2_a'].max()
-    ax.set_ylim([0, np.ceil(10 * max(max_missed_inj,
-                                     found_inj[y_qty].max())) / 10])
+    ax.set_ylim([0, np.ceil(10 * max_missed_inj) / 10])
+    if found_inj[y_qty].size:
+        ax.set_ylim([0, np.ceil(10 * max(max_missed_inj,
+                                         found_inj[y_qty].max())) / 10])
 
 # Handle axis limits when plotting inclination
 if "incl" in x_qty or "incl" in y_qty:

--- a/pycbc/results/pygrb_postprocessing_utils.py
+++ b/pycbc/results/pygrb_postprocessing_utils.py
@@ -401,9 +401,12 @@ def apply_vetoes_to_found_injs(found_missed_file, found_injs, ifos,
     keep_keys = keys if keys else found_injs.keys()
 
     if not found_missed_file or ifos[0]+'/end_time' not in found_injs.keys():
+        t_id_key = 'network/template_id'
+        if t_id_key not in keep_keys:
+            keep_keys = list(keep_keys+[t_id_key])
         empty_dict = dict.fromkeys(keep_keys, numpy.array([]))
-        empty_dict['network/template_id'] = \
-            empty_dict['network/template_id'].astype(dtype=numpy.int64)
+        empty_dict[t_id_key] = \
+            empty_dict[t_id_key].astype(dtype=numpy.int64)
         return (empty_dict, empty_dict, None, None)
 
     found_idx = numpy.arange(len(found_injs[ifos[0]+'/end_time'][:]))


### PR DESCRIPTION
## Motivation
<!--- Describe why your changes are being made -->
@sebastiangomezlopez uncovered an issue with some of the PyGRB post-processing jobs that is caused by not adequately handling runs where no found injections remain after applying vetoes and cuts.

For example
```
        -----Task #1 - pygrb_plot_injs_results_ID30 - ID0000048 - Kickstart stderr------

         2025-04-04T09:31:38.138-07:00: INFO: Setting output directory.
2025-04-04T09:31:38.141-07:00: INFO: Loading timeslides.
2025-04-04T09:31:38.145-07:00: INFO: Loading segments.
2025-04-04T09:31:38.147-07:00: INFO: Constructing trials.
2025-04-04T09:31:38.164-07:00: INFO: 904 trials generated.
2025-04-04T09:31:38.172-07:00: INFO: 50407 triggers loaded.
2025-04-04T09:31:38.183-07:00: INFO: 24 triggers surviving reweighted SNR cut at 6.0.
2025-04-04T09:31:38.262-07:00: INFO: 24 triggers found within the trials dictionary and sorted.
2025-04-04T09:31:38.263-07:00: INFO: Triggers information extracted.
2025-04-04T09:31:38.267-07:00: INFO: Background bestNR calculated.
2025-04-04T09:31:38.269-07:00: INFO: 5 injections loaded.
2025-04-04T09:31:38.270-07:00: INFO: 5 injections surviving reweighted SNR cut at None.
2025-04-04T09:31:38.301-07:00: INFO: 0 missed injections analysed.
2025-04-04T09:31:38.301-07:00: INFO: 5 found injections analysed.
2025-04-04T09:31:38.301-07:00: INFO: After applying reweighted SNR cut at 6.0: 0 found injections and 5 missed injections
2025-04-04T09:31:38.301-07:00: INFO: Applying data vetoes to found injections...
2025-04-04T09:31:38.305-07:00: INFO: 0 injections vetoed.
2025-04-04T09:31:38.305-07:00: INFO: 0 injections surviving vetoes.
Traceback (most recent call last):
  File "/home/sebastian.gomezlopez/.conda/envs/pygrb_312/bin/pycbc_pygrb_plot_injs_results", line 478, in <module>
    found_inj[x_qty].max())) / 10])
    ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/sebastian.gomezlopez/.conda/envs/pygrb_312/lib/python3.12/site-packages/numpy/core/_methods.py", line 41, in _amax
    return umr_maximum(a, axis, None, out, keepdims, initial, where)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: zero-size array to reduction operation maximum which has no identity
```
and 
```
        2025-04-03T08:09:36.332-07:00: INFO: Imported and ready to go.
        2025-04-03T08:09:36.333-07:00: INFO: Loading timeslides.
        2025-04-03T08:09:36.334-07:00: INFO: Loading segments.
        2025-04-03T08:09:36.336-07:00: INFO: Constructing trials.
        2025-04-03T08:09:36.346-07:00: INFO: 904 trials generated.
        2025-04-03T08:09:36.349-07:00: INFO: Loading triggers.
        2025-04-03T08:09:36.415-07:00: INFO: 24 triggers found within the trials dictionary and sorted.
        2025-04-03T08:09:36.416-07:00: INFO: Triggers information extracted.
        Traceback (most recent call last):
          File "/cvmfs/software.igwn.org/pycbc/x86_64_rhel_8/virtualenv/pycbc-v2.8.1/bin/pycbc_pygrb_plot_snr_timeseries", line 165, in <module>
            found_after_vetoes, *_ = ppu.apply_vetoes_to_found_injs(
          File "/cvmfs/software.igwn.org/pycbc/x86_64_rhel_8/virtualenv/pycbc-v2.8.1/lib/python3.9/site-packages/pycbc/results/pygrb_postprocessing_utils.py", line 406, in apply_vetoes_to_found_injs
            empty_dict['network/template_id'].astype(dtype=numpy.int64)                                                             KeyError: 'network/template_id'
```

This PR fixes this bug.  It may be a corner case, but nevertheless the code must be able to handle it.

## Standard information about the request

<!--- Some basic info about the change (delete as appropriate) -->
This is a: bug fix

<!--- What codes will this affect? (delete as apropriate)
If you do not know which areas will be affected, please ask in the gwastro #pycbc-code slack
-->
This change affects:PyGRB

<!--- Notes about the effect of this change -->
This change will: require a new PyGRB release, i.e., `v2.8.2`.

## Contents
`pycbc_pygrb_plot_injs_results`, `pycbc_pygrb_efficiency` and the function `apply_vetoes_to_found_injs` no longer assume that there are found injections to be handled/shown.

## Testing performed
@sebastiangomezlopez reran the whole post-processing portion of his test to completion without any further issues, after these changes were implemented.

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
