### PR TITLE
logw

### DIFF
--- a/pycbc/inference/models/tools.py
+++ b/pycbc/inference/models/tools.py
@@ -545,6 +545,7 @@ class DistMarg():
         # If we had really poor efficiency at finding a point, we should
         # give up and just use the original random draws
         if len(ix) < 0.05 * vsamples:
+            self.marginalize_vector_params['logw_partial'] = numpy.zeros(vsamples)
             return
 
         # fill back to fixed size with repeat samples


### PR DESCRIPTION
In cases where marginalization is not efficient, demarginalization may raise the following error:

```2025-03-26T10:53:43.208-04:00 INFO : Writing reconstructed parameters
Traceback (most recent call last):
  File "/home/aakyuz/miniconda3/envs/workflow_python/bin/pycbc_inference_model_stats", line 150, in <module>
    vals = numpy.array([r[p] for r in rec]).reshape(shape)
                       ^^^^^^^^^^^^^^^^^^^
  File "/home/aakyuz/miniconda3/envs/workflow_python/bin/pycbc_inference_model_stats", line 150, in <listcomp>
    vals = numpy.array([r[p] for r in rec]).reshape(shape)
                        ~^^^
KeyError: 'logw_partial'
```

This PR resolves the error by assigning zero values to logw_partial when demarginalization returns early without assigning any values due to inefficiency.

