### PR TITLE
Make pycbc_multi_inspiral way less verbose

### DIFF
--- a/bin/pycbc_multi_inspiral
+++ b/bin/pycbc_multi_inspiral
@@ -624,7 +624,7 @@ with ctx:
                 if not inj_filter_rejector[ifo].template_segment_checker(
                     bank, t_num, stilde[ifo]
                 ):
-                    logging.info(
+                    logging.debug(
                         "Skipping segment %d/%d with template %d/%d as no "
                         "detectable injection is present",
                         s_num + 1,
@@ -648,7 +648,11 @@ with ctx:
             if not analyse_segment:
                 continue
             logging.info(
-                "Analyzing segment %d/%d", s_num + 1, len(segments[ifo])
+                "Analyzing template %d/%d, segment %d/%d",
+                t_num + 1,
+                n_bank,
+                s_num + 1,
+                len(segments[ifo])
             )
             # The following dicts with IFOs as keys are created to store
             # copies of the matched filtering results computed below.
@@ -664,7 +668,7 @@ with ctx:
             # - The list of normalized SNR values at the trigger locations
             snr = dict.fromkeys(args.instruments)
             for ifo in args.instruments:
-                logging.info(
+                logging.debug(
                     "Filtering template %d/%d, ifo %s", t_num + 1, n_bank, ifo
                 )
                 # The following lines unpack and store copies of the matched
@@ -696,10 +700,10 @@ with ctx:
 
             # Loop over (short) time-slides, starting with the zero-lag
             for slide in range(num_slides):
-                logging.info("Analyzing slide %d/%d", slide, num_slides)
+                logging.debug("Analyzing slide %d/%d", slide, num_slides)
                 # Loop over sky positions
                 for position_index in range(len(sky_positions)):
-                    logging.info(
+                    logging.debug(
                         "Analyzing sky position %d/%d",
                         position_index + 1,
                         len(sky_positions),
@@ -741,7 +745,7 @@ with ctx:
                                 args.instruments[0]
                             ]
                         )
-                    logging.info(
+                    logging.debug(
                         "Found %d coincident triggers", len(coinc_idx)
                     )
                     # Time delay is applied to indices to have them at the IFOs
@@ -768,12 +772,12 @@ with ctx:
                             args.coinc_threshold,
                             time_delay_idx[slide][position_index],
                         )
-                        logging.info(
+                        logging.debug(
                             "%d triggers above coincident SNR threshold",
                             len(coinc_idx),
                         )
                         if len(coinc_idx) != 0:
-                            logging.info(
+                            logging.debug(
                                 "With max coincident SNR = %.2f",
                                 max(rho_coinc),
                             )
@@ -787,13 +791,13 @@ with ctx:
                         }
                     else:
                         coinc_triggers = {}
-                        logging.info("No coincident triggers were found")
+                        logging.debug("No coincident triggers were found")
                     # If there are triggers above coinc threshold and more
                     # than 2 IFOs, then calculate the coherent statistics for
                     # them and apply the cut on coherent SNR (with threshold
                     # equal to the coinc SNR one)
                     if len(coinc_idx) != 0 and nifo > 2:
-                        logging.info("Calculating their coherent statistics")
+                        logging.debug("Calculating their coherent statistics")
                         # Plus and cross antenna pattern dictionaries
                         fp = {
                             ifo: antenna_pattern[ifo][position_index][0]
@@ -893,12 +897,12 @@ with ctx:
                                 project,
                                 rho_coinc,
                             )
-                        logging.info(
+                        logging.debug(
                             "%d triggers above coherent SNR threshold",
                             len(rho_coh),
                         )
                         if len(coinc_idx) != 0:
-                            logging.info(
+                            logging.debug(
                                 "With max coherent SNR = %.2f", max(rho_coh)
                             )
                             # Calculate the null SNR and apply the null SNR cut
@@ -918,11 +922,11 @@ with ctx:
                                 snrv=coinc_triggers,
                                 index=coinc_idx,
                             )
-                            logging.info(
+                            logging.debug(
                                 "%d triggers above null threshold", len(null)
                             )
                             if len(coinc_idx) != 0:
-                                logging.info(
+                                logging.debug(
                                     "With max null SNR = %.2f", max(null)
                                 )
                     # Now calculate the individual detector chi2 values
@@ -1089,7 +1093,7 @@ with ctx:
                 cluster_window = int(template.chirp_length * sample_rate)
             # Cluster template events by slide
             for slide in range(num_slides):
-                logging.info("Clustering slide %d", slide)
+                logging.debug("Clustering slide %d", slide)
                 event_mgr.cluster_template_network_events(
                     'time_index', 'reweighted_snr', cluster_window, slide=slide
                 )

--- a/pycbc/vetoes/bank_chisq.py
+++ b/pycbc/vetoes/bank_chisq.py
@@ -221,16 +221,15 @@ class SingleDetBankVeto(object):
 
         bank_chisq_dof: int, approx number of statistical degrees of freedom
         """
-        if self.do:
-            logging.info("...Doing bank veto")
-            overlaps = self.cache_overlaps(template, psd)
-            bank_veto_snrs, bank_veto_norms = self.cache_segment_snrs(stilde, psd)
-            chisq = bank_chisq_from_filters(snrv, norm, bank_veto_snrs,
-                                            bank_veto_norms, overlaps, indices)
-            dof = numpy.repeat(self.dof, len(chisq))
-            return chisq, dof
-        else:
+        if not self.do:
             return None, None
+        logging.debug("...Doing bank veto")
+        overlaps = self.cache_overlaps(template, psd)
+        bank_veto_snrs, bank_veto_norms = self.cache_segment_snrs(stilde, psd)
+        chisq = bank_chisq_from_filters(snrv, norm, bank_veto_snrs,
+                                        bank_veto_norms, overlaps, indices)
+        dof = numpy.repeat(self.dof, len(chisq))
+        return chisq, dof
 
 class SingleDetSkyMaxBankVeto(SingleDetBankVeto):
     """Stub for precessing bank veto if anyone ever wants to code it up.

--- a/pycbc/vetoes/bank_chisq.py
+++ b/pycbc/vetoes/bank_chisq.py
@@ -198,7 +198,7 @@ class SingleDetBankVeto(object):
     def cache_segment_snrs(self, stilde, psd):
         key = (id(stilde), id(psd))
         if key not in self._segment_snrs_cache:
-            logging.info("Precalculate the bank veto template snrs")
+            logging.debug("Precalculate the bank veto template snrs")
             data = segment_snrs(self.filters, stilde, psd, self.f_low)
             self._segment_snrs_cache[key] = data
         return self._segment_snrs_cache[key]
@@ -206,7 +206,7 @@ class SingleDetBankVeto(object):
     def cache_overlaps(self, template, psd):
         key = (id(template.params), id(psd))
         if key not in self._overlaps_cache:
-            logging.info("...Calculate bank veto overlaps")
+            logging.debug("...Calculate bank veto overlaps")
             o = template_overlaps(self.filters, template, psd, self.f_low)
             self._overlaps_cache[key] = o
         return self._overlaps_cache[key]


### PR DESCRIPTION
`pycbc_multi_inspiral` is way too verbose when running with realistic production settings. This converts many `logging.info()` calls to `logging.debug()`, so that `--verbose` only shows a single message per (template, segment) combination, which I think is good enough to get a sense of the progress. The current verbosity can be restored with `--verbose 2` when actually testing things.

I also inverted the logic in the auto chi^2 and bank chi^2 codes to return early when there is nothing to do, removing one indentation level.

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
