### PR TITLE
Ensure that the PyGRB offsource segmentlist contains ints

### DIFF
--- a/pycbc/workflow/segment.py
+++ b/pycbc/workflow/segment.py
@@ -198,6 +198,8 @@ def get_triggered_coherent_segment(workflow, sciencesegs):
                 offsrc = seg
     else:
         offsrc = offsrclist[0]
+    # Force int boundaries in case we get floats as input,
+    # which can create problems downstream
     offsrc = segments.segment(int(offsrc[0]), int(offsrc[1]))
 
     if abs(offsrc) < minduration + 2 * padding:

--- a/pycbc/workflow/segment.py
+++ b/pycbc/workflow/segment.py
@@ -248,6 +248,8 @@ def get_triggered_coherent_segment(workflow, sciencesegs):
         offsrc &= segments.segment(offsrc[0],
                                    offsrc[0] + maxduration + 2 * padding)
 
+    offsrc = segments.segment(int(offsrc[0]), int(offsrc[1]))
+
     # Trimming off-source
     excess = (abs(offsrc) - 2 * padding) % quanta
     if excess != 0:
@@ -261,6 +263,7 @@ def get_triggered_coherent_segment(workflow, sciencesegs):
             elif offset > 0:
                 offsrc &= segments.segment(offsrc[0],
                                            offsrc[1] - excess)
+            offsrc = segments.segment(int(offsrc[0]), int(offsrc[1]))
             assert abs(offsrc) % quanta == 2 * padding
         else:
             logger.info("This will make OFF-SOURCE symmetrical about trigger "

--- a/pycbc/workflow/segment.py
+++ b/pycbc/workflow/segment.py
@@ -198,6 +198,7 @@ def get_triggered_coherent_segment(workflow, sciencesegs):
                 offsrc = seg
     else:
         offsrc = offsrclist[0]
+    offsrc = segments.segment(int(offsrc[0]), int(offsrc[1]))
 
     if abs(offsrc) < minduration + 2 * padding:
         fail = segments.segment([triggertime - minduration / 2. - padding,
@@ -218,7 +219,6 @@ def get_triggered_coherent_segment(workflow, sciencesegs):
 
     logger.info("%ds of padding applied at beginning and end of segment.",
                 padding)
-
 
     # Construct on-source
     onstart = triggertime - onbefore
@@ -248,8 +248,6 @@ def get_triggered_coherent_segment(workflow, sciencesegs):
         offsrc &= segments.segment(offsrc[0],
                                    offsrc[0] + maxduration + 2 * padding)
 
-    offsrc = segments.segment(int(offsrc[0]), int(offsrc[1]))
-
     # Trimming off-source
     excess = (abs(offsrc) - 2 * padding) % quanta
     if excess != 0:
@@ -263,7 +261,6 @@ def get_triggered_coherent_segment(workflow, sciencesegs):
             elif offset > 0:
                 offsrc &= segments.segment(offsrc[0],
                                            offsrc[1] - excess)
-            offsrc = segments.segment(int(offsrc[0]), int(offsrc[1]))
             assert abs(offsrc) % quanta == 2 * padding
         else:
             logger.info("This will make OFF-SOURCE symmetrical about trigger "


### PR DESCRIPTION
This PR fixes an error encountered when generating PyGRB workflows with an offsource that is not symmetric around the trigger time.

## Standard information about the request

<!--- Some basic info about the change (delete as appropriate) -->
This is a: bug fix.

<!--- What codes will this affect? (delete as apropriate)
If you do not know which areas will be affected, please ask in the gwastro #pycbc-code slack
-->
This change affects: PyGRB

<!--- What code areas will this affect? (delete as apropriate) -->
This change changes: it fixes a workflow generator error.

## Motivation
<!--- Describe why your changes are being made -->

The error encountered is
```
2025-04-16T09:13:54.792-07:00 INFO : Leaving matched-filtering setup module.
Traceback (most recent call last):
  File "/cvmfs/software.igwn.org/pycbc/x86_64_rhel_8/virtualenv/pycbc-v2.8.2/bin/pycbc_make_offline_grb_workflow", line 474, in <module>
    _workflow.setup_pygrb_pp_workflow(wflow, pp_dir, seg_dir,
  File "/cvmfs/software.igwn.org/pycbc/x86_64_rhel_8/virtualenv/pycbc-v2.8.2/lib/python3.9/site-packages/pycbc/workflow/grb_utils.py", line 352, in setup_pygrb_pp_workflow
    node, out_file = job_instance.create_node(trig_file, pp_dir)
  File "/cvmfs/software.igwn.org/pycbc/x86_64_rhel_8/virtualenv/pycbc-v2.8.2/lib/python3.9/site-packages/pycbc/workflow/grb_utils.py", line 436, in create_node
    ifotag, filetag, segment = filename_metadata(in_file.name)
  File "/cvmfs/software.igwn.org/pycbc/x86_64_rhel_8/virtualenv/pycbc-v2.8.2/lib/python3.9/site-packages/gwdatafind/utils.py", line 159, in filename_metadata
    start = int(start)
ValueError: invalid literal for int() with base 10: '1378035096.0'
```

This number with the `.0` comes from the filename metadata and is established when maximising the coincident time.  So far, all tests had happened without needing to layout the offsource asymmetrically around the trigger time, hence this is uncovered only now.

The PyCBC end of the code has not changed in years, nevertheless something going from the determination of the offsource start and end times to the call to `gwdatafind/utils.py` must have changed.  The solution is to ensure that these times are ints, regardless of how the offsource window is shaped.

## Contents
<!--- Describe your changes, this doesn't need to be a line-by-line code change discussion,
but rather a general discussion of the methods chosen -->
There is a single change that resolves the error: the first time the offsource segment is defined, its start and end times are explicitly converted to ints.  All operations with this segment that may follow involve segments with extremes that are ints, so the int type will be preserved.

## Testing performed
The problematic workflow is now generated successfully.

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
