### PR TITLE
Dont use pylab, use pyplot directly

### DIFF
--- a/bin/bank/pycbc_bank_verification
+++ b/bin/bank/pycbc_bank_verification
@@ -27,7 +27,7 @@ import logging
 import numpy
 import matplotlib
 matplotlib.use('Agg')
-import pylab
+from matplotlib import pyplot as plt
 
 from igwn_ligolw import lsctables, utils as ligolw_utils
 
@@ -277,10 +277,10 @@ points_fittingfactor = numpy.array(points_fittingfactor)
 logging.info("Distances calculated.")
 
 if opts.histogram_output_file:
-    pylab.hist(points_fittingfactor, 100)
-    pylab.xlabel("Fitting factor")
-    pylab.ylabel("# of signals")
-    pylab.savefig(opts.histogram_output_file)
+    plt.hist(points_fittingfactor, 100)
+    plt.xlabel("Fitting factor")
+    plt.ylabel("# of signals")
+    plt.savefig(opts.histogram_output_file)
 
 if opts.print_distances:
     print()

--- a/bin/inference/pycbc_validate_test_posterior
+++ b/bin/inference/pycbc_validate_test_posterior
@@ -7,7 +7,7 @@ import numpy
 import argparse
 from matplotlib import use
 use('Agg')
-import pylab
+from matplotlib import pyplot as plt
 
 from scipy.stats import ks_2samp
 
@@ -52,7 +52,7 @@ for dist in prior.distributions:
     ref = ref[(bound.min < ref[param]) & (ref[param] < bound.max)]
 
 nparam = len(model.variable_params)
-fig, axs = pylab.subplots(1, nparam, figsize=[6*nparam, 4], dpi=100)
+fig, axs = plt.subplots(1, nparam, figsize=[6*nparam, 4], dpi=100)
 
 result = d1.read_samples(model.variable_params)
 failed = False
@@ -62,16 +62,16 @@ for param, ax in zip(model.variable_params, axs):
     kv, pvalue = ks_2samp(ref[param], rpart)
     print("{}, p-value={:.3f}".format(param, pvalue))
 
-    pylab.sca(ax)
-    pylab.hist(ref[param], density=True, bins=30, label='reference')
-    pylab.hist(result[param], density=True, bins=30, alpha=0.5, label='sampler')
-    pylab.title('KS p-value = {:.4f}'.format(pvalue))
-    pylab.xlabel(param)
-    pylab.legend()
+    plt.sca(ax)
+    plt.hist(ref[param], density=True, bins=30, label='reference')
+    plt.hist(result[param], density=True, bins=30, alpha=0.5, label='sampler')
+    plt.title('KS p-value = {:.4f}'.format(pvalue))
+    plt.xlabel(param)
+    plt.legend()
     ax.get_yaxis().set_visible(False)
 
     if pvalue < args.p_value_threshold:
         failed = True
 
-pylab.savefig(args.output_file)
+plt.savefig(args.output_file)
 sys.exit(failed)

--- a/bin/minifollowups/pycbc_plot_chigram
+++ b/bin/minifollowups/pycbc_plot_chigram
@@ -4,7 +4,7 @@ import argparse
 import sys
 import matplotlib
 matplotlib.use('Agg')
-import pylab
+from matplotlib import pyplot as plt
 
 from pycbc import init_logging, add_common_pycbc_options
 import pycbc.types
@@ -29,8 +29,8 @@ init_logging(args.verbose)
 
 f = HFile(args.single_template_file, 'r')
 y = f['chisq_boundaries'][:]
-fig = pylab.figure()
-ax = pylab.gca()
+fig = plt.figure()
+ax = plt.gca()
 
 snr = pycbc.types.load_timeseries(args.single_template_file, group='snr')
 chisq = pycbc.types.load_timeseries(args.single_template_file, group='chisq')
@@ -54,16 +54,16 @@ for i in range(len(f['chisq_bins'].keys())):
     l = y[i:i+2]
     ax.pcolorfast(x, numpy.array([i, i+1]), ts.reshape(1, len(ts)))
 
-pylab.ylabel('Frequency (Hz)')
+plt.ylabel('Frequency (Hz)')
 
 xlabel = 'Time (s)'
 if args.central_time:
     xlabel += ' - %.2f' % args.central_time
     if args.window:
-        pylab.xlim(xmin=-args.window, xmax=args.window)
+        plt.xlim(xmin=-args.window, xmax=args.window)
 
-pylab.xlabel(xlabel)
-c = pylab.colorbar(ax.get_children()[2], ax=ax)
+plt.xlabel(xlabel)
+c = plt.colorbar(ax.get_children()[2], ax=ax)
 
 if args.plot_type == 'chisq':
     c.set_label("$\\rho_l^2 - \\rho^2/p$")

--- a/bin/minifollowups/pycbc_plot_trigger_timeseries
+++ b/bin/minifollowups/pycbc_plot_trigger_timeseries
@@ -21,7 +21,7 @@ import logging
 import sys
 import matplotlib
 matplotlib.use('Agg')
-import pylab
+from matplotlib import pyplot as plt
 import numpy
 
 from pycbc import init_logging, add_common_pycbc_options
@@ -56,7 +56,7 @@ init_logging(args.verbose)
 
 any_data = False
 
-fig = pylab.figure()
+fig = plt.figure()
 
 min_rank = numpy.inf
 for ifo in args.single_trigger_files.keys():
@@ -77,7 +77,7 @@ for ifo in args.single_trigger_files.keys():
     if not len(idx):
         # No triggers in this window, add to the legend and continue
         # Make sure it isnt on the plot
-        pylab.scatter(-2 * args.window, 0,
+        plt.scatter(-2 * args.window, 0,
                       color=pycbc.results.ifo_color(ifo),
                       marker='x',
                       label=ifo)
@@ -95,7 +95,7 @@ for ifo in args.single_trigger_files.keys():
     logging.info("Getting %s", args.plot_type)
     rank = ranking.get_sngls_ranking_from_trigs(trigs, args.plot_type)
 
-    pylab.scatter(trigs['end_time'] - t, rank,
+    plt.scatter(trigs['end_time'] - t, rank,
                   color=pycbc.results.ifo_color(ifo), marker='x',
                   label=ifo)
 
@@ -111,21 +111,21 @@ for ifo in args.single_trigger_files.keys():
             continue
         special_red_idx = numpy.where(idx == special_idx)[0]
 
-        pylab.scatter(trigs.trigs_f[f'{ifo}/end_time'][special_idx] - t,
+        plt.scatter(trigs.trigs_f[f'{ifo}/end_time'][special_idx] - t,
                       rank[special_red_idx], marker='*', s=50, color='yellow')
 
 if args.log_y_axis and any_data:
-    pylab.yscale('log')
+    plt.yscale('log')
 
 if not numpy.isinf(min_rank):
-    pylab.ylim(ymin=min_rank)
+    plt.ylim(ymin=min_rank)
 
-pylab.xlabel('time (s)')
-pylab.ylabel(args.plot_type)
+plt.xlabel('time (s)')
+plt.ylabel(args.plot_type)
 
-pylab.xlim(xmin=-args.window, xmax=args.window)
-pylab.legend()
-pylab.grid()
+plt.xlim(xmin=-args.window, xmax=args.window)
+plt.legend()
+plt.grid()
 
 logging.info("Saving figure")
 pycbc.results.save_fig_with_metadata(fig, args.output_file,

--- a/bin/minifollowups/pycbc_single_template_plot
+++ b/bin/minifollowups/pycbc_single_template_plot
@@ -21,7 +21,7 @@ import sys
 import numpy
 import matplotlib
 matplotlib.use('Agg')
-import pylab
+from matplotlib import pyplot as plt
 
 import pycbc.results
 from pycbc.events import ranking
@@ -55,8 +55,8 @@ try:
     delta_t = f['snr'].attrs['delta_t']
     start_time = f['snr'].attrs['start_time']
 except:
-    pylab.text(0.5, 0.5, 'no triggers found')
-    pylab.savefig(args.output_file)
+    plt.text(0.5, 0.5, 'no triggers found')
+    plt.savefig(args.output_file)
     sys.exit()
 
 if args.event_time is not None:
@@ -82,7 +82,7 @@ chisq = f['chisq'][left:right][:]
 rang = (numpy.arange(0, len(snr), 1) - (center - left)) * delta_t
 newsnr = ranking.newsnr(snr, chisq)
 
-fig, ax1 = pylab.subplots()
+fig, ax1 = plt.subplots()
 ax1.plot(rang, snr, color='blue', label='SNR')
 ax1.plot(rang, newsnr, color='purple', label='NewSNR')
 ax1.set_ylabel('SNR')

--- a/bin/plotting/pycbc_faithsim_plots
+++ b/bin/plotting/pycbc_faithsim_plots
@@ -10,7 +10,7 @@ import matplotlib
 matplotlib.use("Agg")
 import matplotlib.cm
 from matplotlib.ticker import MultipleLocator
-import pylab
+from matplotlib import pyplot as plt
 import numpy as np
 
 from pycbc import init_logging, add_common_pycbc_options
@@ -53,8 +53,8 @@ def basic_scatter(
     if vmax is not None:
         vmax = float(vmax)
 
-    fig = pylab.figure(num=None)
-    pylab.scatter(
+    fig = plt.figure(num=None)
+    plt.scatter(
         xval,
         yval,
         c=cval,
@@ -67,7 +67,7 @@ def basic_scatter(
     )
 
     if len(neg_idx) > 0:
-        pylab.scatter(
+        plt.scatter(
             xval[neg_idx],
             yval[neg_idx],
             c="red",
@@ -77,11 +77,11 @@ def basic_scatter(
         matplotlib.pyplot.legend()
 
     if cval is not None:
-        bar = pylab.colorbar()
+        bar = plt.colorbar()
         bar.set_label(cname)
 
-    pylab.xlabel(xname)
-    pylab.ylabel(yname)
+    plt.xlabel(xname)
+    plt.ylabel(yname)
 
     if xmin is None:
         xmin = min(xval)
@@ -93,8 +93,8 @@ def basic_scatter(
     else:
         ymin = float(ymin)
 
-    pylab.xlim(xmin, max(xval))
-    pylab.ylim(ymin, max(yval))
+    plt.xlim(xmin, max(xval))
+    plt.ylim(ymin, max(yval))
 
     ax = fig.gca()
     if majorL:
@@ -106,10 +106,10 @@ def basic_scatter(
         ax.xaxis.set_minor_locator(MultipleLocator(minorL))
         ax.yaxis.set_minor_locator(MultipleLocator(minorL))
 
-    pylab.grid()
-    pylab.title(title)
+    plt.grid()
+    plt.title(title)
 
-    pylab.savefig(out_name, dpi=500)
+    plt.savefig(out_name, dpi=500)
 
 
 parser = argparse.ArgumentParser(description=__doc__)

--- a/bin/plotting/pycbc_ifar_catalog
+++ b/bin/plotting/pycbc_ifar_catalog
@@ -20,7 +20,7 @@ import numpy
 import sys
 import logging
 import matplotlib as mpl; mpl.use('Agg')
-import pylab
+from matplotlib import pyplot as plt
 
 from scipy.stats import norm, poisson
 
@@ -70,8 +70,8 @@ opts = parser.parse_args()
 init_logging(opts.verbose)
 
 if opts.use_tex:
-    pylab.rc('text', usetex=True)
-    pylab.rc('font', **{'family': 'serif', 'serif': ['Computer Modern']})
+    plt.rc('text', usetex=True)
+    plt.rc('font', **{'family': 'serif', 'serif': ['Computer Modern']})
 
 trigf = [HFile(f, 'r') for f in opts.trigger_files]
 
@@ -95,7 +95,7 @@ if h_inc_back_num is None:
 
 if h_inc_back_num > h_iterations:
     # Produce a null plot saying no hierarchical removals can be plotted
-    fig = pylab.figure()
+    fig = plt.figure()
     ax = fig.add_subplot(111)
 
     ax.set_xlim(0, 1)
@@ -161,10 +161,10 @@ for f in trigf:
 expected_cumnum = conversions.sec_to_year(fg_time) / expected_ifar
 
 # make figure
-fig = pylab.figure(1)
+fig = plt.figure(1)
 
 # plot the expected background
-pylab.loglog(expected_ifar, expected_cumnum, linestyle='--', linewidth=1,
+plt.loglog(expected_ifar, expected_cumnum, linestyle='--', linewidth=1,
              color='black', label='Expected Background')
 
 # plot the counting error
@@ -204,17 +204,17 @@ for sigma in [1, 2, 3, 4]:
         upper[sigma].append(nup + 1.5)
 
 plotifar = expected_ifar[::-1]
-pylab.fill_between(plotifar, lower[4], lower[3], facecolor='k', alpha=0.15,
+plt.fill_between(plotifar, lower[4], lower[3], facecolor='k', alpha=0.15,
                    label=r'$<4\sigma$')
-pylab.fill_between(plotifar, lower[3], lower[2], facecolor='k', alpha=0.3,
+plt.fill_between(plotifar, lower[3], lower[2], facecolor='k', alpha=0.3,
                    label=r'$<3\sigma$')
-pylab.fill_between(plotifar, lower[2], lower[1], facecolor='k', alpha=0.45,
+plt.fill_between(plotifar, lower[2], lower[1], facecolor='k', alpha=0.45,
                    label=r'$<2\sigma$')
-pylab.fill_between(plotifar, lower[1], upper[1], facecolor='k', alpha=0.6,
+plt.fill_between(plotifar, lower[1], upper[1], facecolor='k', alpha=0.6,
                    label=r'$<1\sigma$')
-pylab.fill_between(plotifar, upper[1], upper[2], facecolor='k', alpha=0.45)
-pylab.fill_between(plotifar, upper[2], upper[3], facecolor='k', alpha=0.3)
-pylab.fill_between(plotifar, upper[3], upper[4], facecolor='k', alpha=0.15)
+plt.fill_between(plotifar, upper[1], upper[2], facecolor='k', alpha=0.45)
+plt.fill_between(plotifar, upper[2], upper[3], facecolor='k', alpha=0.3)
+plt.fill_between(plotifar, upper[3], upper[4], facecolor='k', alpha=0.15)
 
 # plot the foreground triggers
 if opts.open_box:
@@ -223,32 +223,32 @@ if opts.open_box:
         fore_ifar[over_trunc] = numpy.ones(over_trunc.sum()) * \
                                                         opts.truncate_threshold
         for i in fore_cumnum[over_trunc]:
-            pylab.arrow(opts.truncate_threshold, i, opts.truncate_threshold, 0,
+            plt.arrow(opts.truncate_threshold, i, opts.truncate_threshold, 0,
                         head_width=0.1 * i, head_length=0.4 * \
                         opts.truncate_threshold, ec='b', fc='b')
-    pylab.loglog(fore_ifar, fore_cumnum, linestyle='None', color='blue',
+    plt.loglog(fore_ifar, fore_cumnum, linestyle='None', color='blue',
                  marker='^', ms=6, label='Foreground')
     max_ifar = max(fore_ifar)
 
     if h_inc_back_num > 0:
         max_ifar = max(max_ifar, max(h_rm_ifar))
-        pylab.loglog(h_rm_ifar, h_rm_cumnum, linestyle='None', color='#b66dff',
+        plt.loglog(h_rm_ifar, h_rm_cumnum, linestyle='None', color='#b66dff',
                      marker='v', label='Hierarchically Removed Foreground')
 
 # format plot
 if opts.open_box:
     # scale the plot around the foreground
-    pylab.ylim(0.7, 0.05 * len(fore_cumnum))
-    pylab.xlim(30 * min(fore_ifar), 3 * max_ifar)
+    plt.ylim(0.7, 0.05 * len(fore_cumnum))
+    plt.xlim(30 * min(fore_ifar), 3 * max_ifar)
 else:
-    pylab.ylim(0.7, max(expected_cumnum))
-pylab.grid()
-pylab.legend(loc='upper right', fontsize=13)
-pylab.ylabel('Cumulative Number', size='large')
+    plt.ylim(0.7, max(expected_cumnum))
+plt.grid()
+plt.legend(loc='upper right', fontsize=13)
+plt.ylabel('Cumulative Number', size='large')
 ifar_label = 'Inverse False Alarm Rate (yr)'
 if opts.use_exclusive_ifar:
     ifar_label = 'Exclusive ' + ifar_label
-pylab.xlabel(ifar_label, size='large')
+plt.xlabel(ifar_label, size='large')
 
 # save
 caption = 'This is a cumulative histogram of triggers. The blue triangles ' \

--- a/bin/plotting/pycbc_page_banktriggerrate
+++ b/bin/plotting/pycbc_page_banktriggerrate
@@ -3,7 +3,8 @@
 """
 import matplotlib
 matplotlib.use('Agg')
-import numpy, argparse, pylab, pycbc.pnutils
+from matplotlib import pyplot as plt
+import numpy, argparse, pycbc.pnutils
 from pycbc.io.hdf import HFile
 
 from pycbc import init_logging, add_common_pycbc_options
@@ -56,15 +57,15 @@ for trig_filename in args.trigger_files:
 chisq = numpy.concatenate(chisqs) / (float(args.chisq_bins) * 2 - 2)
 snr = numpy.concatenate(snrs)
 
-pylab.figure()
-pylab.scatter(snr[0:1000000], chisq[0:1000000])
-pylab.xlim(6, 8)
-pylab.ylim(.8, 3)
-pylab.savefig('snrchi.png')
+plt.figure()
+plt.scatter(snr[0:1000000], chisq[0:1000000])
+plt.xlim(6, 8)
+plt.ylim(.8, 3)
+plt.savefig('snrchi.png')
    
-pylab.figure() 
-pylab.scatter(et, m1+m2, c=template_num, s=template_num/template_num.max()*50)
-pylab.ylabel('Total Mass')
-pylab.xlabel('Eta')
-pylab.colorbar()
-pylab.savefig(args.output_file)
+plt.figure() 
+plt.scatter(et, m1+m2, c=template_num, s=template_num/template_num.max()*50)
+plt.ylabel('Total Mass')
+plt.xlabel('Eta')
+plt.colorbar()
+plt.savefig(args.output_file)

--- a/bin/plotting/pycbc_page_coinc_snrchi
+++ b/bin/plotting/pycbc_page_coinc_snrchi
@@ -4,7 +4,8 @@ import sys
 import numpy, argparse, matplotlib
 from matplotlib import colors
 matplotlib.use('Agg')
-import pylab, pycbc.results
+from matplotlib import pyplot as plt
+import pycbc.results
 from pycbc.io import (
     get_chisq_from_file_choice, chisq_choices, SingleDetTriggers, HFile
 )
@@ -79,8 +80,8 @@ bkg_chisq = bkg_chisq[bkg_tid_idx_inverse]
 bkg_pos = bkg_chisq > 0
 bkg_snr = bkg_snr[bkg_pos]
 bkg_chisq = bkg_chisq[bkg_pos]
-fig = pylab.figure()
-pylab.scatter(bkg_snr, bkg_chisq, marker='o', color='black',
+fig = plt.figure()
+plt.scatter(bkg_snr, bkg_chisq, marker='o', color='black',
               linewidth=0, s=4, label='Background', alpha=0.6,
               zorder=args.background_front)
 
@@ -152,7 +153,7 @@ inj_pos = inj_chisq > 0
 if len(coloring[args.colorbar_choice][0]) == 0:
     coloring[args.colorbar_choice] = (None, None, None)
 else:  # Only plot positive chisq
-    pylab.scatter(inj_snr[inj_pos], inj_chisq[inj_pos],
+    plt.scatter(inj_snr[inj_pos], inj_chisq[inj_pos],
                   c=coloring[args.colorbar_choice][0][inj_pos],
                   norm=coloring[args.colorbar_choice][2], s=20,
                   marker='^', linewidth=0, label="Injections",
@@ -170,34 +171,34 @@ except ValueError:
 if args.newsnr_contours:
     for cval in args.newsnr_contours:
         snrv = snr_from_chisq(r, cval)
-        pylab.plot(snrv, r, '--', color='grey', linewidth=1)
+        plt.plot(snrv, r, '--', color='grey', linewidth=1)
 
-ax = pylab.gca()
+ax = plt.gca()
 ax.set_xscale('log')
 ax.set_yscale('log')
 
 try:
-    cb = pylab.colorbar()
+    cb = plt.colorbar()
     cb.set_label(coloring[args.colorbar_choice][1], size='large')
 except (TypeError, ZeroDivisionError):
     # Catch case of no injection triggers
     if len(inj_chisq):
         raise
 
-pylab.title('%s Coincident Triggers' % ifo, size='large')
-pylab.xlabel('SNR', size='large')
-pylab.ylabel('Reduced $\chi^2$', size='large')
+plt.title('%s Coincident Triggers' % ifo, size='large')
+plt.xlabel('SNR', size='large')
+plt.ylabel('Reduced $\chi^2$', size='large')
 try:
-    pylab.xlim(min(inj_snr.min(), bkg_snr.min()) * 0.99,
+    plt.xlim(min(inj_snr.min(), bkg_snr.min()) * 0.99,
                max(inj_snr.max(), bkg_snr.max()) * 1.4)
-    pylab.ylim(min(bkg_chisq.min(), inj_chisq[inj_pos].min()) * 0.7,
+    plt.ylim(min(bkg_chisq.min(), inj_chisq[inj_pos].min()) * 0.7,
                max(bkg_chisq.max(), inj_chisq.max()) * 1.4)
 except ValueError:
     # Raised if no injection triggers
     pass
-pylab.legend(loc='lower right', prop={'size': 10})
-pylab.grid(which='major', ls='solid', alpha=0.7, linewidth=.5)
-pylab.grid(which='minor', ls='solid', alpha=0.7, linewidth=.1)
+plt.legend(loc='lower right', prop={'size': 10})
+plt.grid(which='major', ls='solid', alpha=0.7, linewidth=.5)
+plt.grid(which='minor', ls='solid', alpha=0.7, linewidth=.1)
 
 title = '%s %s chisq vs SNR. %s background with injections %s' \
         % (ifo.upper(), args.chisq_choice, ''.join(ifos).upper(),

--- a/bin/plotting/pycbc_page_ifar
+++ b/bin/plotting/pycbc_page_ifar
@@ -19,9 +19,9 @@ import argparse
 import numpy
 import sys
 import copy
-import pylab
 import matplotlib as mpl
 mpl.use('Agg')
+from matplotlib import pyplot as plt
 
 from pycbc import init_logging, add_common_pycbc_options
 import pycbc.results
@@ -107,7 +107,7 @@ if h_inc_back_num is None:
 if h_inc_back_num > h_iterations:
     # Produce a null plot saying no hierarchical removals can be plotted
     import sys
-    fig = pylab.figure()
+    fig = plt.figure()
     ax = fig.add_subplot(111)
 
     ax.set_xlim(0, 1)
@@ -189,7 +189,7 @@ else :
         back_ifar = fp['background/ifar'][:]
 
 # make figure
-fig = pylab.figure(1)
+fig = plt.figure(1)
 
 # get a unique list of timeslide_ids and loop over them
 interval = fp.attrs['timeslide_interval']
@@ -249,9 +249,9 @@ for tsid in tsids:
 
     # plot the time slide triggers
     if len(ts_ifar) > 1:
-        pylab.loglog(ts_ifar, ts_cumnum, color='gray', alpha=0.4)
+        plt.loglog(ts_ifar, ts_cumnum, color='gray', alpha=0.4)
     elif len(ts_ifar) == 1:
-        pylab.plot(ts_ifar, ts_cumnum, color='gray', marker='.', alpha=0.4)
+        plt.plot(ts_ifar, ts_cumnum, color='gray', marker='.', alpha=0.4)
     else:
         empty_slide_count += 1
 
@@ -259,51 +259,51 @@ allbkg_ifars = numpy.array(allbkg_ifars)
 allbkg_ifars = allbkg_ifars * (fp.attrs['foreground_time'] / allbkg_dur )
 allbkg_ifars.sort()
 allbkg_cumnum = numpy.arange(len(allbkg_ifars), 0, -1)
-pylab.loglog(allbkg_ifars, allbkg_cumnum, color='green', linewidth=1.5,
+plt.loglog(allbkg_ifars, allbkg_cumnum, color='green', linewidth=1.5,
              label="All decimated background")
 
 # plot the expected background
-pylab.loglog(expected_ifar, expected_cumnum, linestyle='--', linewidth=2,
+plt.loglog(expected_ifar, expected_cumnum, linestyle='--', linewidth=2,
              color='black', label='Expected Background')
 
 # plot the counting error
 error_plus = expected_cumnum + numpy.sqrt(expected_cumnum)
 error_minus = expected_cumnum - numpy.sqrt(expected_cumnum)
 error_minus = numpy.where(error_minus<=0, 1e-5, error_minus)
-pylab.fill_between(expected_ifar, error_minus, error_plus, facecolor='y',
+plt.fill_between(expected_ifar, error_minus, error_plus, facecolor='y',
                    alpha=0.4, label='$N^{1/2}$ Errors')
 
 # plot the counting error
 error_plus = expected_cumnum + 2 * numpy.sqrt(expected_cumnum)
 error_minus = expected_cumnum - 2*numpy.sqrt(expected_cumnum)
 error_minus = numpy.where(error_minus<=0, 1e-5, error_minus)
-pylab.fill_between(expected_ifar, error_minus, error_plus, facecolor='y',
+plt.fill_between(expected_ifar, error_minus, error_plus, facecolor='y',
                    alpha=0.2, label='$2N^{1/2}$ Errors')
 
 # plot the foreground triggers
 if opts.open_box:
-    pylab.loglog(fore_ifar, fore_cumnum, linestyle='None', color='blue',
+    plt.loglog(fore_ifar, fore_cumnum, linestyle='None', color='blue',
                  marker='^', label='Foreground')
 
     if h_inc_back_num > 0:
-        pylab.loglog(h_rm_ifar, h_rm_cumnum, linestyle='None', color='#b66dff',
+        plt.loglog(h_rm_ifar, h_rm_cumnum, linestyle='None', color='#b66dff',
                      marker='v', label='Hierarchically Removed Foreground')
 
 # format plot
 if opts.open_box and len(fore_cumnum) > 100:
     # If we have > 100 foreground triggers, scale the plot around the
     # foreground
-    pylab.ylim(0.8, 1.1 * len(fore_cumnum))
-    pylab.xlim(0.9 * min(fore_ifar))
+    plt.ylim(0.8, 1.1 * len(fore_cumnum))
+    plt.xlim(0.9 * min(fore_ifar))
 elif len(allbkg_cumnum) > 0:
     # If we have < 100 foreground triggers (or this is closed box), scale the
     # plot around the cumulative background (the green line).
-    pylab.ylim(0.8, 1.1 * len(allbkg_cumnum))
-    pylab.xlim(0.9 * min(allbkg_ifars))
-pylab.grid()
-pylab.legend(loc='upper right', fontsize=9)
-pylab.ylabel('Cumulative Number')
-pylab.xlabel('Inverse False Alarm Rate (yr)')
+    plt.ylim(0.8, 1.1 * len(allbkg_cumnum))
+    plt.xlim(0.9 * min(allbkg_ifars))
+plt.grid()
+plt.legend(loc='upper right', fontsize=9)
+plt.ylabel('Cumulative Number')
+plt.xlabel('Inverse False Alarm Rate (yr)')
 
 # save
 caption = 'This is a cumulative histogram of triggers. The blue triangles ' \

--- a/bin/plotting/pycbc_page_segments
+++ b/bin/plotting/pycbc_page_segments
@@ -5,8 +5,8 @@ import argparse
 from itertools import cycle
 import matplotlib
 matplotlib.use('Agg')
+from matplotlib import pyplot as plt
 import numpy
-import pylab
 import mpld3
 import mpld3.plugins
 from matplotlib.patches import Rectangle
@@ -57,7 +57,7 @@ def plot_segs(start, end, color=None, y=0, h=1):
         color = next(plot_segs.colors)
 
     for s, e in zip(start, end):
-        ax = pylab.gca()
+        ax = plt.gca()
         patch = Rectangle((s, y), (e-s), h, facecolor=color)
         ax.add_patch(patch)
         patches.append(patch)
@@ -87,7 +87,7 @@ css = """
 """
 
 mpld3.plugins.DEFAULT_PLUGINS = []
-fig = pylab.figure(figsize=[10, 5])
+fig = plt.figure(figsize=[10, 5])
 ax = fig.gca()
 
 names = []

--- a/bin/plotting/pycbc_page_segplot
+++ b/bin/plotting/pycbc_page_segplot
@@ -19,7 +19,7 @@
 import argparse
 import matplotlib; matplotlib.use('Agg')
 import matplotlib.pyplot as plt
-import numpy, pylab, pycbc.events, mpld3, mpld3.plugins
+import numpy, pycbc.events, mpld3, mpld3.plugins
 import sys
 from itertools import cycle
 
@@ -187,9 +187,9 @@ interactive_legend = mpld3.plugins.InteractiveLegendPlugin(line_collections,
 mpld3.plugins.connect(fig, interactive_legend)
 
 # format the plot
-pylab.ylim(0, len(ifos) * (h + 0.2))
-pylab.xlim(smin, smax)
-pylab.xlabel('GPS Time (s)')
+plt.ylim(0, len(ifos) * (h + 0.2))
+plt.xlim(smin, smax)
+plt.xlabel('GPS Time (s)')
 
 # add whitespace for the legend
 fig.subplots_adjust(left=0.0, right=0.6, top=0.9, bottom=0.1)

--- a/bin/plotting/pycbc_page_sensitivity
+++ b/bin/plotting/pycbc_page_sensitivity
@@ -7,8 +7,7 @@ import logging
 import matplotlib
 import sys
 matplotlib.use('Agg')
-from matplotlib.pyplot import cm
-import pylab
+from matplotlib import pyplot as plt
 
 import pycbc.pnutils
 import pycbc.results
@@ -230,7 +229,7 @@ if args.hdf_out:
     plotdict['xvals'] = x_values
 
 # Switches for plotting inclusive/exclusive significance
-color = iter(cm.rainbow(numpy.linspace(0, 1, len(args.bins)-1)))
+color = iter(plt.cm.rainbow(numpy.linspace(0, 1, len(args.bins)-1)))
 if not args.exclusive_sig:
     fvalues = [found['sig'], found['sig_exc']]
     do_labels = [True, False]
@@ -240,7 +239,7 @@ else:
     do_labels = [True]
     alphas = [.6]
 
-fig = pylab.figure()
+fig = plt.figure()
 # Cycle over parameter bins plotting each in turn
 for j in range(len(args.bins)-1):
     c = next(color)
@@ -328,14 +327,14 @@ for j in range(len(args.bins)-1):
             reach, ehigh, elow = vols, vol_errors, vol_errors
         elif args.dist_type == 'vt':
             ylabel = "Volume $\\times$ Time (yr Mpc$^3$)"
-            pylab.ticklabel_format(style='sci', axis='y', scilimits=(0,0))
+            plt.ticklabel_format(style='sci', axis='y', scilimits=(0,0))
 
             reach, ehigh, elow = vols * t, vol_errors * t, vol_errors * t
 
         label = labels[args.bin_type] % (left, right) if do_label else None
-        pylab.plot(x_values, reach, label=label, c=c)
-        pylab.plot(x_values, reach, alpha=alpha, c='black')
-        pylab.fill_between(x_values, reach - elow, reach + ehigh,
+        plt.plot(x_values, reach, label=label, c=c)
+        plt.plot(x_values, reach, alpha=alpha, c='black')
+        plt.fill_between(x_values, reach - elow, reach + ehigh,
                            facecolor=c, edgecolor=c, alpha=alpha)
         if label and args.hdf_out:
             plotdict['data/%s' % label] = reach
@@ -347,7 +346,7 @@ if args.hdf_out:
     for key in plotdict.keys():
         outfile.create_dataset(key, data=plotdict[key])
 
-ax = pylab.gca()
+ax = plt.gca()
 
 if args.log_dist:
     ax.set_yscale('log')
@@ -359,15 +358,15 @@ if args.sig_type == 'fap':
     ax.invert_xaxis()
 
 if args.min_dist is not None:
-    pylab.ylim(ymin=args.min_dist)
+    plt.ylim(ymin=args.min_dist)
 if args.max_dist is not None:
-    pylab.ylim(ymax=args.max_dist)
+    plt.ylim(ymax=args.max_dist)
 
-pylab.ylabel(ylabel)
-pylab.xlabel(xlabel)
+plt.ylabel(ylabel)
+plt.xlabel(xlabel)
 
-pylab.grid()
-pylab.legend(loc='lower left')
+plt.grid()
+plt.legend(loc='lower left')
 
 pycbc.results.save_fig_with_metadata(fig, args.output_file,
      title="Sensitive %s vs %s: binned by %s using %s method"

--- a/bin/plotting/pycbc_page_snrchi
+++ b/bin/plotting/pycbc_page_snrchi
@@ -5,7 +5,7 @@ import argparse
 import matplotlib
 import sys
 matplotlib.use('Agg')
-import pylab
+from matplotlib import pyplot as plt
 
 import pycbc.results
 from pycbc.io import (
@@ -91,14 +91,14 @@ def snr_from_chisq(chisq, newsnr, q=6.):
     snr[ind] = float(newsnr) / ( 0.5 * (1. + chisq[ind] ** (q/2.)) ) ** (-1./q)
     return snr
 
-fig = pylab.figure(1)
+fig = plt.figure(1)
 
 r = numpy.logspace(numpy.log(chisq.min()), numpy.log(chisq.max()), 300)
 
 for i, cval in enumerate(args.newsnr_contours):
     logging.info("Plotting newsnr %s contour", cval)
     snrv = snr_from_chisq(r, cval)
-    pylab.plot(snrv, r, color='black', lw=0.5)
+    plt.plot(snrv, r, color='black', lw=0.5)
     if i == 0:
         label = "$\\hat{\\rho} = %s$" % cval
     else:
@@ -107,22 +107,22 @@ for i, cval in enumerate(args.newsnr_contours):
         label_pos_idx = numpy.where(snrv > snr.max() * 0.8)[0][0]
     except IndexError:
         label_pos_idx = 0
-    pylab.text(snrv[label_pos_idx], r[label_pos_idx], label, fontsize=6,
+    plt.text(snrv[label_pos_idx], r[label_pos_idx], label, fontsize=6,
                horizontalalignment='center', verticalalignment='center',
                bbox=dict(facecolor='white', lw=0, pad=0, alpha=0.9))
 
-pylab.hexbin(snr, chisq, gridsize=300, xscale='log', yscale='log', lw=0.04,
+plt.hexbin(snr, chisq, gridsize=300, xscale='log', yscale='log', lw=0.04,
              mincnt=1, norm=matplotlib.colors.LogNorm())
 
-ax = pylab.gca()
-pylab.grid()   
+ax = plt.gca()
+plt.grid()   
 ax.set_xscale('log')
-cb = pylab.colorbar() 
-pylab.xlim(snr.min(), snr.max() * 1.1)
-pylab.ylim(chisq.min(), chisq.max() * 1.1)
+cb = plt.colorbar() 
+plt.xlim(snr.min(), snr.max() * 1.1)
+plt.ylim(chisq.min(), chisq.max() * 1.1)
 cb.set_label('Trigger Density')
-pylab.xlabel('Signal-to-Noise Ratio')
-pylab.ylabel('Reduced $\\chi^2$')
+plt.xlabel('Signal-to-Noise Ratio')
+plt.ylabel('Reduced $\\chi^2$')
 pycbc.results.save_fig_with_metadata(fig, args.output_file, 
      title="%s :SNR vs Reduced %s &chi;<sup>2</sup>" % (ifo, args.chisq_choice),
      caption="Distribution of SNR and %s &chi;&sup2; for single detector triggers: "

--- a/bin/plotting/pycbc_page_snrifar
+++ b/bin/plotting/pycbc_page_snrifar
@@ -6,7 +6,7 @@
 import argparse, numpy, logging, sys
 import matplotlib
 matplotlib.use('Agg')
-import pylab
+from matplotlib import pyplot as plt
 
 from scipy.special import erfc, erfinv
 from pycbc.io.hdf import HFile
@@ -101,7 +101,7 @@ if h_inc_back_num is None:
 if h_inc_back_num > h_iterations:
     # Produce a null plot saying no hierarchical removals can be plotted
     import sys
-    fig = pylab.figure()
+    fig = plt.figure()
     ax = fig.add_subplot(111)
 
     ax.set_xlim(0, 1)
@@ -236,12 +236,12 @@ else:
         plot_xmax = max(cstat_back.max(), cstat_fore.max())
     plot_xmax += (plot_xmax - plot_xmin)/10.
 
-fig = pylab.figure(1)
+fig = plt.figure(1)
 back_marker = 'x'
-pylab.scatter(cstat_back_exc, far_back_exc, color='gray', marker=back_marker, s=10, label='Closed Box Background')
+plt.scatter(cstat_back_exc, far_back_exc, color='gray', marker=back_marker, s=10, label='Closed Box Background')
 
 if not args.closed_box:
-    pylab.scatter(cstat_back, far_back, color='black', marker=back_marker, s=10,
+    plt.scatter(cstat_back, far_back, color='black', marker=back_marker, s=10,
         label='Open Box Background')
 
     if cstat_fore is not None and len(cstat_fore):
@@ -263,12 +263,12 @@ if not args.closed_box:
                 cstat_fore = numpy.delete(cstat_fore, rm_idx)
                 cstat_rate = numpy.delete(cstat_rate, rm_idx)
 
-            pylab.scatter(cstat_fore_h_rm, cstat_rate_h_rm, s=60, color='#b66dff',
+            plt.scatter(cstat_fore_h_rm, cstat_rate_h_rm, s=60, color='#b66dff',
                           marker=args.fg_marker_h_rm,
                           label='Hierarchically Removed Foreground', zorder=100,
                           linewidth=0.5, edgecolors='white')
 
-        pylab.scatter(cstat_fore, cstat_rate, s=60, color='#ff6600',
+        plt.scatter(cstat_fore, cstat_rate, s=60, color='#ff6600',
                       marker=args.fg_marker, label='Foreground', zorder=100,
                       linewidth=0.5, edgecolors='white')
 
@@ -280,11 +280,11 @@ if not args.closed_box:
                 arr_start = cstat_rate[ii]
                 # make the arrow length 1/15 the height of the plot
                 arr_end = arr_start * (plot_ymin / plot_ymax) ** (1./15)
-                pylab.plot([r, r], [arr_start, arr_end], lw=2, color='black',
+                plt.plot([r, r], [arr_start, arr_end], lw=2, color='black',
                            zorder=99)
-                pylab.plot([r, r], [arr_start, arr_end], lw=2.6, color='white',
+                plt.plot([r, r], [arr_start, arr_end], lw=2.6, color='white',
                            zorder=97)
-                pylab.scatter([r], [arr_end], marker='v', c='black',
+                plt.scatter([r], [arr_end], marker='v', c='black',
                               edgecolors='white', lw=0.5, s=40, zorder=98) 
 
             if h_inc_back_num > 0:
@@ -296,56 +296,56 @@ if not args.closed_box:
                         continue
                     # make the arrow length 1/15 the height of the plot
                     arr_end = arr_start * (plot_ymin / plot_ymax) ** (1./15)
-                    pylab.plot([r, r], [arr_start, arr_end], lw=2,
+                    plt.plot([r, r], [arr_start, arr_end], lw=2,
                               color='black', zorder=99)
-                    pylab.plot([r, r], [arr_start, arr_end], lw=2.6,
+                    plt.plot([r, r], [arr_start, arr_end], lw=2.6,
                               color='white', zorder=97)
-                    pylab.scatter([r], [arr_end], marker='v', c='black',
+                    plt.scatter([r], [arr_end], marker='v', c='black',
                                  edgecolors='white', lw=0.5, s=40, zorder=98)
 
 if not args.cumulative:
     # add second y-axis for probabilities, sigmas
     sigmas = numpy.arange(6)+1
-    ax1 = pylab.gca()
+    ax1 = plt.gca()
     if hasattr(ax1, 'set_facecolor'):
         ax1.set_facecolor('none')
     else:
         ax1.set_axis_bgcolor('none')
     ax2 = ax1.twinx()
     ax1.set_zorder(ax2.get_zorder()+1) # put axis1 on top
-    pylab.sca(ax2)
+    plt.sca(ax2)
     # where to stick the sigma lables; we'll put them 1/25th from the
     # right axis
     anntx = plot_xmax - (plot_xmax - plot_xmin)/25.
     sigps = p_from_sigma(sigmas)
     for ii,p in enumerate(sigps[:-1]):
         nextp = sigps[ii+1]
-        pylab.axhspan(far_from_p(nextp, foreground_livetime, far_back.max()),
+        plt.axhspan(far_from_p(nextp, foreground_livetime, far_back.max()),
                       far_from_p(p, foreground_livetime, far_back.max()),
                       linewidth=0,
-                      color=pylab.cm.Blues(float(sigmas[ii+1]) / sigmas.size),
+                      color=plt.cm.Blues(float(sigmas[ii+1]) / sigmas.size),
                       alpha=0.3, zorder=-1) 
             # add sigma label
-        pylab.annotate('%1.0f$\sigma$' % sigmas[ii],
+        plt.annotate('%1.0f$\sigma$' % sigmas[ii],
                        (anntx, far_from_p(p, foreground_livetime,
                        far_back.max())), zorder=100)
         ax2.plot([],[])
-    pylab.sca(ax1)
+    plt.sca(ax1)
 
-pylab.xlabel(r'Ranking Statistic')
-pylab.yscale('log')
-pylab.ylim(plot_ymin, plot_ymax * 10.0)
-pylab.xlim(plot_xmin, plot_xmax)
-pylab.legend(loc="upper right", fontsize=9)
-pylab.grid()
+plt.xlabel(r'Ranking Statistic')
+plt.yscale('log')
+plt.ylim(plot_ymin, plot_ymax * 10.0)
+plt.xlim(plot_xmin, plot_xmax)
+plt.legend(loc="upper right", fontsize=9)
+plt.grid()
     
 if args.cumulative:
-    pylab.ylabel('Cumulative Rate (yr$^{-1}$)')   
+    plt.ylabel('Cumulative Rate (yr$^{-1}$)')   
 else:
     if args.trials_factor == 1:
-        pylab.ylabel('False Alarm Rate (yr$^{-1}$)')
+        plt.ylabel('False Alarm Rate (yr$^{-1}$)')
     elif args.trials_factor >= 1:
-        pylab.ylabel('Combined False Alarm Rate (yr$^{-1}$)')
+        plt.ylabel('Combined False Alarm Rate (yr$^{-1}$)')
     ax2.set_ylabel('p-value')
     ax2.set_yscale('log')
     ymin, ymax = ax1.get_ylim()
@@ -367,11 +367,11 @@ else:
     pticks = numpy.arange(tick_min, tick_max+1)
     # Convert back to FAR
     fticks = far_from_p(10**pticks, foreground_livetime, far_back.max())
-    ax2.yaxis.set_major_locator(pylab.NullLocator())
+    ax2.yaxis.set_major_locator(plt.NullLocator())
     ax2.set_yticks(fticks)
     # Set the labels
     ax2.set_yticklabels(['$10^{%i}$' %(val) for val in pticks.astype(int)])
-pylab.tight_layout()
+plt.tight_layout()
 figure_title = "%s: " % f.attrs['ifos'] if 'ifos' in f.attrs else ""
 figure_title += "%s bin, Cumulative Rate vs Rank" % f.attrs['name'] if 'name' in f.attrs else "FAR vs Rank"
 

--- a/bin/plotting/pycbc_page_snrratehist
+++ b/bin/plotting/pycbc_page_snrratehist
@@ -9,7 +9,7 @@ import logging
 import sys
 import matplotlib
 matplotlib.use('Agg')
-import pylab
+from matplotlib import pyplot as plt
 
 from scipy.special import erf, erfinv
 from pycbc.io.hdf import HFile
@@ -68,7 +68,7 @@ if h_inc_back_num is None:
 if h_inc_back_num > h_iterations:
     # Produce a null plot saying no hierarchical removals can be plotted
     import sys
-    fig = pylab.figure()
+    fig = plt.figure()
     ax = fig.add_subplot(111)
 
     ax.set_xlim(0, 1)
@@ -121,7 +121,7 @@ dec_exc, bstat_exc = dec_exc[s], bstat_exc[s]
 
 logging.info('Found %s background (exclusive zerolag) triggers' % len(bstat_exc))
 
-fig = pylab.figure()
+fig = plt.figure()
 
 if fstat is not None:
     minimum = min(fstat.min(), bstat.min())
@@ -139,7 +139,7 @@ bins = numpy.arange(minimum, maximum + bin_size, bin_size)
 
 # plot background minus foreground
 exc_binweights = dec_exc / conv.sec_to_year(f.attrs['background_time_exc'])
-exc_binvals = pylab.hist(bstat_exc, bins=bins, histtype='step',
+exc_binvals = plt.hist(bstat_exc, bins=bins, histtype='step',
                          linewidth=2,
                          color='grey', log=True,
                          label= 'Background Uncorrelated with Foreground',
@@ -152,7 +152,7 @@ if not args.closed_box:
     bg_key = 'background_time' if h_inc_back_num == 0 \
         else 'background_time_h%s' % h_inc_back_num
     binweights = dec / conv.sec_to_year(f.attrs[bg_key])
-    pylab.hist(
+    plt.hist(
         bstat,
         bins=bins,
         histtype='step',
@@ -197,7 +197,7 @@ if fstat is not None and not args.closed_box:
             count_h_rm = (right_h_rm - left_h_rm) / \
                          conv.sec_to_year(f.attrs['foreground_time_h%s' % h_inc_back_num])
 
-        pylab.errorbar(bins[:-1] + bin_size / 2, count_h_rm,
+        plt.errorbar(bins[:-1] + bin_size / 2, count_h_rm,
                        xerr=bin_size/2,
                        label='Hierarchically Removed Foreground', mec='none',
                        fmt='s', ms=1, capthick=0, elinewidth=4,
@@ -206,19 +206,19 @@ if fstat is not None and not args.closed_box:
     left = numpy.searchsorted(fstat, le)
     right = numpy.searchsorted(fstat, re)
     count = (right - left) / conv.sec_to_year(f.attrs['foreground_time'])
-    pylab.errorbar(bins[:-1] + bin_size / 2, count, xerr=bin_size/2,
+    plt.errorbar(bins[:-1] + bin_size / 2, count, xerr=bin_size/2,
                    label='Foreground', mec='none', fmt='o', ms=1, capthick=0,
                    elinewidth=4,  color='#ff6600')
 
-pylab.xlabel('Ranking statistic (bin size = %.2f)' % bin_size)
-pylab.ylabel('Trigger Rate (yr$^{-1})$')
+plt.xlabel('Ranking statistic (bin size = %.2f)' % bin_size)
+plt.ylabel('Trigger Rate (yr$^{-1})$')
 if args.x_min is not None:
-    pylab.xlim(xmin=args.x_min)
+    plt.xlim(xmin=args.x_min)
 else:
-    pylab.xlim(xmin=numpy.floor(histpeak))
-pylab.ylim(ymin=0.5 / conv.sec_to_year(f.attrs['background_time_exc']))
-pylab.grid()
-leg = pylab.legend(fontsize=9)
+    plt.xlim(xmin=numpy.floor(histpeak))
+plt.ylim(ymin=0.5 / conv.sec_to_year(f.attrs['background_time_exc']))
+plt.grid()
+leg = plt.legend(fontsize=9)
 
 end = sigma_from_p(fap.min() * args.trials_factor)
 
@@ -240,22 +240,22 @@ if not args.closed_box:
         if x1 == x2:
             continue
 
-        ymin, ymax = pylab.gca().get_ylim()
+        ymin, ymax = plt.gca().get_ylim()
         try:
             x = [bstat[::-1][x1], bstat[::-1][x2]]
         except IndexError:
             break
-        pylab.fill_between(x, ymin, ymax, zorder=-1,
-                           color=pylab.cm.Blues(next_sig / 8.0))
+        plt.fill_between(x, ymin, ymax, zorder=-1,
+                           color=plt.cm.Blues(next_sig / 8.0))
 
         if next_sig == end:
             next_sig = '%.1f' % next_sig
 
-        pylab.text(bstat[::-1][x2] - .1, ymax, r"$%s \sigma$" % next_sig,
+        plt.text(bstat[::-1][x2] - .1, ymax, r"$%s \sigma$" % next_sig,
                    fontsize=10, horizontalalignment='center',
                    verticalalignment='bottom')
 
-ax1 =  pylab.gca()
+ax1 =  plt.gca()
 ax2 = ax1.twinx()
 
 if h_inc_back_num == 0:

--- a/bin/plotting/pycbc_plot_background_coincs
+++ b/bin/plotting/pycbc_plot_background_coincs
@@ -4,9 +4,9 @@
 import argparse
 import matplotlib
 matplotlib.use('Agg')
+from matplotlib import pyplot as plt
 from matplotlib.colors import LogNorm
 from matplotlib.ticker import LogLocator
-import pylab
 from pycbc.io.hdf import HFile
 
 from pycbc import add_common_pycbc_options, init_logging
@@ -50,7 +50,7 @@ if args.min_z is not None:
 if args.max_z is not None:
     hexbin_style['vmax'] = args.max_z
 
-fig = pylab.figure()
+fig = plt.figure()
 ax = fig.gca()
 if args.z_var == 'density':
     hb = ax.hexbin(x, y, norm=LogNorm(), vmin=1, **hexbin_style)

--- a/bin/plotting/pycbc_plot_bank_bins
+++ b/bin/plotting/pycbc_plot_bank_bins
@@ -7,7 +7,7 @@ import h5py
 import numpy
 import matplotlib
 matplotlib.use('Agg')
-import pylab
+from matplotlib import pyplot as plt
 import inspect
 from itertools import cycle
 
@@ -119,22 +119,22 @@ x_var_name = getattr(bank, args.x_var + '_param').__doc__
 y_var = getattr(bank, args.y_var + '_param')()
 y_var_name = getattr(bank, args.y_var + '_param').__doc__
 
-fig = pylab.figure()
-pylab.grid()
+fig = plt.figure()
+plt.grid()
 for name in locs_dict:
     locs = locs_dict[name]
-    pylab.scatter(x_var[locs], y_var[locs], label=name, edgecolor='none', s=1,
+    plt.scatter(x_var[locs], y_var[locs], label=name, edgecolor='none', s=1,
                   c=next(color))
 
-pylab.legend(loc='upper left', markerscale=5)
-pylab.xlabel(x_var_name)
-pylab.ylabel(y_var_name)
-pylab.xlim(x_var.min(), x_var.max())
-pylab.ylim(y_var.min(), y_var.max())
+plt.legend(loc='upper left', markerscale=5)
+plt.xlabel(x_var_name)
+plt.ylabel(y_var_name)
+plt.xlim(x_var.min(), x_var.max())
+plt.ylim(y_var.min(), y_var.max())
 if args.log_x:
-    pylab.xscale('log')
+    plt.xscale('log')
 if args.log_y:
-    pylab.yscale('log')
+    plt.yscale('log')
 
 title = "Template Bank and Bins Used to Compute Background"
 caption = """This plot shows the template bank in the {x_var}-{y_var} plane.

--- a/bin/plotting/pycbc_plot_gating
+++ b/bin/plotting/pycbc_plot_gating
@@ -7,7 +7,7 @@ import logging
 import numpy as np
 import matplotlib
 matplotlib.use('agg')
-import pylab as pl
+from matplotlib import pyplot as plt
 from matplotlib.patches import Rectangle
 import mpld3
 import mpld3.plugins
@@ -48,7 +48,7 @@ for fn in args.input_file:
         have_gates = have_gates or (len(gate_data[key]) > 0)
 
 mpld3.plugins.DEFAULT_PLUGINS = []
-fig = pl.figure(figsize=(10, 5))
+fig = plt.figure(figsize=(10, 5))
 ax = fig.gca()
 ax.set_yticks([])
 

--- a/bin/plotting/pycbc_plot_psd_file
+++ b/bin/plotting/pycbc_plot_psd_file
@@ -5,7 +5,7 @@ import matplotlib
 matplotlib.use('Agg')
 import numpy
 import argparse
-import pylab
+from matplotlib import pyplot as plt
 import sys
 
 import pycbc
@@ -50,7 +50,7 @@ pycbc.init_logging(args.verbose)
 # set the matplotlib style
 pycbc.results.set_style_from_cli(args)
 
-fig = pylab.figure(0)
+fig = plt.figure(0)
 ax = fig.gca()
 ax.grid(which='both', ls='solid', alpha=0.2, lw=0.3)
 ax.set_ylabel('Amplitude Spectral Density (Strain / $\\sqrt{\\rm Hz}$)')

--- a/bin/plotting/pycbc_plot_psd_timefreq
+++ b/bin/plotting/pycbc_plot_psd_timefreq
@@ -27,7 +27,7 @@ import numpy
 import sys
 import matplotlib
 matplotlib.use('agg')
-import pylab
+from matplotlib import pyplot as plt
 from matplotlib.colors import LogNorm
 from pycbc.io.hdf import HFile
 
@@ -54,7 +54,7 @@ parser.add_argument('--reduction-method', choices=['min','max','mean','median'],
 opts = parser.parse_args()
 pycbc.init_logging(opts.verbose)
 
-fig=pylab.figure()
+fig=plt.figure()
 ax=fig.gca()
 
 logging.info('Reading %s', opts.psd_file)
@@ -132,7 +132,7 @@ ax.set_xticklabels( ticklabels )
 ax.set_xlabel('Days since GPS %d' % start.min(), fontsize=18 )
 ax.set_ylabel('Frequency (Hz)', fontsize=18 )
 fig.set_size_inches(18.5, 10.5)
-pylab.tight_layout()
+plt.tight_layout()
 
 title = ('Evolution of the noise spectral density over time in %s' % ifo)
 caption = ('Variation of the amplitude spectral density over time. The original'

--- a/bin/plotting/pycbc_plot_range
+++ b/bin/plotting/pycbc_plot_range
@@ -6,7 +6,7 @@ matplotlib.use('Agg');
 import logging
 import numpy
 import argparse
-import pylab
+from matplotlib import pyplot as plt
 import sys
 
 import pycbc.results
@@ -34,10 +34,10 @@ pycbc.init_logging(args.verbose)
 
 canonical_snr = 8.0
 
-fig = pylab.figure(0)
-pylab.xlabel('Time (s)')
-pylab.ylabel('Inspiral Range (Mpc)')
-pylab.grid()
+fig = plt.figure(0)
+plt.xlabel('Time (s)')
+plt.ylabel('Inspiral Range (Mpc)')
+plt.grid()
 
 for psd_file in args.psd_files:
     f = HFile(psd_file, 'r')
@@ -76,11 +76,11 @@ for psd_file in args.psd_files:
         else:
             label = str(ifo)
         wf_key = (m1, m2, apx)
-        pylab.errorbar((start+end)/2, ranges[wf_key], xerr=(end-start)/2,
+        plt.errorbar((start+end)/2, ranges[wf_key], xerr=(end-start)/2,
                        ecolor=pycbc.results.ifo_color(ifo), label=label,
                        fmt='none')
 
-pylab.legend(loc="best", fontsize='small')
+plt.legend(loc="best", fontsize='small')
 
 if len(args.approximant) == 1:
     fig.suptitle('$%sM_{\odot}-%sM_{\odot}$ %s' % (m1, m2, apx))

--- a/bin/plotting/pycbc_plot_singles_timefreq
+++ b/bin/plotting/pycbc_plot_singles_timefreq
@@ -27,7 +27,7 @@ import argparse
 import numpy as np
 import matplotlib
 matplotlib.use('agg')
-import pylab as pl
+from matplotlib import pyplot as plt
 import matplotlib.mlab as mlab
 from matplotlib.colors import LogNorm
 from matplotlib.ticker import LogLocator
@@ -77,7 +77,7 @@ if opts.center_time is None:
 else:
     center_time = opts.center_time
 
-fig = pl.figure(figsize=(11,5.5))
+fig = plt.figure(figsize=(11,5.5))
 fig.subplots_adjust(left=0.06, right=0.95, bottom=0.09, top=0.95)
 ax = fig.gca()
 

--- a/bin/plotting/pycbc_plot_singles_vs_params
+++ b/bin/plotting/pycbc_plot_singles_vs_params
@@ -25,7 +25,7 @@ import argparse
 import numpy as np
 import matplotlib
 matplotlib.use('agg')
-import pylab as pl
+from matplotlib import pyplot as plt
 from matplotlib.colors import LogNorm
 from matplotlib.ticker import LogLocator
 import sys
@@ -127,9 +127,9 @@ fig_caption = f"This plot shows the {opts.z_var} of single detector " + \
 
 if not any(mask):
     # All triggers removed - make a blank plot which says so:
-    fig = pl.figure()
+    fig = plt.figure()
     ax = fig.gca()
-    pl.text(0.5, 0.5, 'no triggers in the range')
+    plt.text(0.5, 0.5, 'no triggers in the range')
 
     pycbc.results.save_fig_with_metadata(
         fig,
@@ -160,7 +160,7 @@ maxz = opts.max_z
 hexbin_style['norm'] = LogNorm(vmin=minz, vmax=maxz)
 
 logging.info('Plotting')
-fig = pl.figure()
+fig = plt.figure()
 ax = fig.gca()
 
 if opts.z_var == 'density':

--- a/bin/plotting/pycbc_plot_throughput
+++ b/bin/plotting/pycbc_plot_throughput
@@ -3,7 +3,7 @@
 import argparse
 import matplotlib
 matplotlib.use('Agg')
-import pylab as pl
+from matplotlib import pyplot as plt
 
 from scipy.stats import hmean
 
@@ -23,7 +23,7 @@ args = parser.parse_args()
 
 pycbc.init_logging(args.verbose)
 
-fig, (ax1, ax2, ax3) = pl.subplots(3,1,figsize=(10,10))
+fig, (ax1, ax2, ax3) = plt.subplots(3,1,figsize=(10,10))
 
 for pa in args.input_file:
     f = HFile(pa, 'r')

--- a/bin/population/pycbc_population_plots
+++ b/bin/population/pycbc_population_plots
@@ -29,7 +29,7 @@ import argparse
 from numpy import logaddexp, log, newaxis, expm1
 import numpy as np
 from matplotlib import cm
-import pylab
+from matplotlib import pyplot as plt
 
 import scipy.stats as ss
 
@@ -80,7 +80,7 @@ with HFile(opts.rate_file, 'w') as out:
 
 # Make prior/posterior plot -- estimate p_astro
 p_astro = []
-pylab.figure()
+plt.figure()
 color=iter(cm.rainbow(np.linspace(0, 1, len(opts.population_models))))
 mods = zip(opts.posterior_samples, opts.population_models, opts.plot_labels)
 
@@ -96,9 +96,9 @@ for fpost, model, lbl in mods:
 
     log_R = np.log(Rfpr)
     xs = np.linspace(min(log_R), max(log_R), 200)
-    pylab.plot(np.exp(xs), ss.skewnorm.pdf(xs, prior_alpha, prior_mu,
+    plt.plot(np.exp(xs), ss.skewnorm.pdf(xs, prior_alpha, prior_mu,
             prior_sigma), '--', label=lbl + ' Prior', color=c)
-    pylab.plot(np.exp(xs), ss.skewnorm.pdf(xs, post_alpha, post_m,
+    plt.plot(np.exp(xs), ss.skewnorm.pdf(xs, post_alpha, post_m,
                post_sigma), label=lbl + ' Posterior', color=c)
 
     Lfpo, Lbpo = fpo[model + '/Lf'][:], fpo[model + '/Lb'][:]
@@ -113,21 +113,21 @@ for fpost, model, lbl in mods:
     fpo.close()
 f.close()
 
-pylab.xscale('log')
-pylab.xlabel(r'$R$ ($\mathrm{Gpc}^{-3} \, \mathrm{yr}^{-1}$)')
-pylab.ylabel(r'$RP(R)$')
-pylab.legend(loc='best')
-pylab.savefig(opts.rates_figure)
+plt.xscale('log')
+plt.xlabel(r'$R$ ($\mathrm{Gpc}^{-3} \, \mathrm{yr}^{-1}$)')
+plt.ylabel(r'$RP(R)$')
+plt.legend(loc='best')
+plt.savefig(opts.rates_figure)
 
-pylab.figure()
+plt.figure()
 color=iter(cm.rainbow(np.linspace(0, 1, len(opts.population_models))))
 for pas, lbl in zip(p_astro, opts.plot_labels):
     c = next(color)
-    pylab.plot(log_fg_ratios, 1 - pas, '.', label = lbl, color = c)
+    plt.plot(log_fg_ratios, 1 - pas, '.', label = lbl, color = c)
 
-pylab.xlabel(r'$\log p(x\mid f)/p(x\mid b)$')
-pylab.ylabel(r'$1-p_\mathrm{astro}$')
-pylab.legend(loc='best')
-pylab.yscale('log')
-pylab.savefig(opts.pastro_figure)
+plt.xlabel(r'$\log p(x\mid f)/p(x\mid b)$')
+plt.ylabel(r'$1-p_\mathrm{astro}$')
+plt.legend(loc='best')
+plt.yscale('log')
+plt.savefig(opts.pastro_figure)
 print(p_astro)

--- a/bin/pycbc_make_banksim
+++ b/bin/pycbc_make_banksim
@@ -457,10 +457,9 @@ f = open("scripts/pycbc_banksim_plots", "w")
 f.write("""#!/usr/bin/env python
 import matplotlib
 matplotlib.use('agg')
-from matplotlib import pyplot
+from matplotlib import pyplot as plt
 from pycbc import pnutils
 import numpy
-import pylab
 
 goldenratio = 2 / (1 + 5**.5)
 #matplotlib.rcParams.update({
@@ -516,40 +515,40 @@ s1m = (ispin1x**2+ispin1y**2+ispin1z**2)**0.5
 s2m = (ispin2x**2+ispin2y**2+ispin2z**2)**0.5
 
 def mhist(c1, name, cum=False, normed=True, log=False, bins=100, xl="", yl=""):
-    pylab.figure()
-    pylab.xlabel(xl)
-    pylab.ylabel(yl)
+    plt.figure()
+    plt.xlabel(xl)
+    plt.ylabel(yl)
     if log:
-        pylab.yscale('log')
-    pylab.hist(c1, bins=bins, density=normed, histtype='step', cumulative=cum)
-    pylab.savefig(name)
+        plt.yscale('log')
+    plt.hist(c1, bins=bins, density=normed, histtype='step', cumulative=cum)
+    plt.savefig(name)
 
 def mplot(c1, c2, c, name, xl="", yl="", vmin=None, vmax=None):
-    pylab.figure()
-    pylab.axes((0.15, 0.15, 0.8, 0.8))
-    pylab.scatter(c1, c2, c=c, linewidth=0, s=1, vmin=vmin, vmax=vmax)
-    pylab.colorbar()
-    pylab.xlim(min(c1), max(c1))
-    pylab.ylim(min(c2), max(c2))
-    pylab.xlabel(xl)
-    pylab.ylabel(yl)
-    pylab.savefig(name)
+    plt.figure()
+    plt.axes((0.15, 0.15, 0.8, 0.8))
+    plt.scatter(c1, c2, c=c, linewidth=0, s=1, vmin=vmin, vmax=vmax)
+    plt.colorbar()
+    plt.xlim(min(c1), max(c1))
+    plt.ylim(min(c2), max(c2))
+    plt.xlabel(xl)
+    plt.ylabel(yl)
+    plt.savefig(name)
 
 mhist(imchirp-tmchirp, "plots/hist-mchirp-diff.png")
 mhist((imchirp-tmchirp)/imchirp, "plots/hist-mchirp-reldiff.png")
 mhist(match, "plots/hist-match.png")
 mhist(match, "plots/hist-match-cum.png", cum=1, log=True, bins=10000, xl = "Match", yl="Fraction of injections < Match")
 
-pylab.figure(102)
-pylab.ylabel('Fraction of Injections')
-pylab.xlabel('Fitting factor')
-pylab.yscale('log')
-pylab.xlim(0.95, 1.0)
-pylab.ylim(1e-4, 1)
-hBins = pylab.arange(0.,1.,0.0005,dtype=float)
-n, bins,patches=pylab.hist(match,cumulative=1,bins=hBins,density=True)
-pylab.grid()
-pylab.savefig("plots/cum_hist.png")
+plt.figure(102)
+plt.ylabel('Fraction of Injections')
+plt.xlabel('Fitting factor')
+plt.yscale('log')
+plt.xlim(0.95, 1.0)
+plt.ylim(1e-4, 1)
+hBins = numpy.arange(0.,1.,0.0005,dtype=float)
+n, bins,patches=plt.hist(match,cumulative=1,bins=hBins,density=True)
+plt.grid()
+plt.savefig("plots/cum_hist.png")
 
 mplot(imass1, imass2, match, "plots/m1-m2-match.png")
 mplot(tmass1, tmass2, match, "plots/tm1-tm2-match.png")

--- a/bin/pycbc_make_faithsim
+++ b/bin/pycbc_make_faithsim
@@ -216,7 +216,7 @@ f.write("""#!/usr/bin/env python
 import matplotlib
 matplotlib.use('Agg')
 import matplotlib.cm
-import pylab
+from matplotlib import pyplot as plt
 import numpy as np
 from matplotlib.ticker import MultipleLocator
 import glob
@@ -236,14 +236,14 @@ def basic_scatter(out_name, xname, yname, title, xval, yval,
                   ymin=None, majorL=None, minorL=None):
     cmap = matplotlib.cm.jet
     cmap.set_under(color='gray')
-    fig = pylab.figure(num=None, figsize=(10, 5))
-    pylab.scatter(xval, yval, c=cval, linewidths=0, s=3, vmin=vmin, vmax=vmax, cmap=cmap, alpha=0.7)
+    fig = plt.figure(num=None, figsize=(10, 5))
+    plt.scatter(xval, yval, c=cval, linewidths=0, s=3, vmin=vmin, vmax=vmax, cmap=cmap, alpha=0.7)
     if cval is not None:
-        bar = pylab.colorbar()
+        bar = plt.colorbar()
         bar.set_label(cname)
         
-    pylab.xlabel(xname)
-    pylab.ylabel(yname)
+    plt.xlabel(xname)
+    plt.ylabel(yname)
     
     if xmin is None:
         xmin = min(xval)
@@ -251,8 +251,8 @@ def basic_scatter(out_name, xname, yname, title, xval, yval,
     if ymin is None:
         ymin = min(yval)
         
-    pylab.xlim(xmin, max(xval))
-    pylab.ylim(ymin, max(yval))
+    plt.xlim(xmin, max(xval))
+    plt.ylim(ymin, max(yval))
     
     ax = fig.gca()
     if majorL:
@@ -265,10 +265,10 @@ def basic_scatter(out_name, xname, yname, title, xval, yval,
     
     fol = 'plots/' 
     
-    pylab.grid()
-    pylab.title(title)
-    pylab.savefig(fol + 'THUMB-' + out_name, dpi=50)
-    pylab.savefig(fol + out_name, dpi=500)
+    plt.grid()
+    plt.title(title)
+    plt.savefig(fol + 'THUMB-' + out_name, dpi=50)
+    plt.savefig(fol + out_name, dpi=500)
 
 fils = glob.glob("result*.dat")
 for fil in fils:

--- a/pycbc/io/gracedb.py
+++ b/pycbc/io/gracedb.py
@@ -363,7 +363,7 @@ class CandidateForGraceDB(object):
         labels: list
             Optional list of labels to tag the new event with.
         """
-        import pylab as pl
+        from matplotlib import pyplot as plt
 
         if fname.endswith('.xml.gz'):
             self.basename = fname.replace('.xml.gz', '')
@@ -523,12 +523,12 @@ class CandidateForGraceDB(object):
                          if v != 0.0}
             labels, sizes = zip(*prob_plot.items())
             colors = [source_color(label) for label in labels]
-            fig, ax = pl.subplots()
+            fig, ax = plt.subplots()
             ax.pie(sizes, labels=labels, colors=colors, autopct='%1.1f%%',
                    textprops={'fontsize': 15})
             ax.axis('equal')
             fig.savefig(self.prob_plotf)
-            pl.close()
+            plt.close()
             if gid is not None:
                 try:
                     self.gracedb.write_log(

--- a/pycbc/results/followup.py
+++ b/pycbc/results/followup.py
@@ -33,7 +33,8 @@ import numpy, matplotlib
 import sys
 if 'matplotlib.backends' not in sys.modules:
     matplotlib.use('agg')
-import pylab, mpld3, mpld3.plugins
+    from matplotlib import pyplot as plt
+import mpld3, mpld3.plugins
 from igwn_segments import segment
 from pycbc.io.hdf import HFile
 
@@ -81,7 +82,7 @@ def columns_from_file_list(file_list, columns, ifo, start, end):
 ifo_color = {'H1': 'blue', 'L1':'red', 'V1':'green'}
 
 def coinc_timeseries_plot(coinc_file, start, end):
-    fig = pylab.figure()
+    fig = plt.figure()
     f = HFile(coinc_file, 'r')
 
     stat1 = f['foreground/stat1']
@@ -91,34 +92,34 @@ def coinc_timeseries_plot(coinc_file, start, end):
     ifo1 = f.attrs['detector_1']
     ifo2 = f.attrs['detector_2']
 
-    pylab.scatter(time1, stat1, label=ifo1, color=ifo_color[ifo1])
-    pylab.scatter(time2, stat2, label=ifo2, color=ifo_color[ifo2])
+    plt.scatter(time1, stat1, label=ifo1, color=ifo_color[ifo1])
+    plt.scatter(time2, stat2, label=ifo2, color=ifo_color[ifo2])
 
     fmt = '.12g'
     mpld3.plugins.connect(fig, mpld3.plugins.MousePosition(fmt=fmt))
-    pylab.legend()
-    pylab.xlabel('Time (s)')
-    pylab.ylabel('NewSNR')
-    pylab.grid()
+    plt.legend()
+    plt.xlabel('Time (s)')
+    plt.ylabel('NewSNR')
+    plt.grid()
     return mpld3.fig_to_html(fig)
 
 def trigger_timeseries_plot(file_list, ifos, start, end):
 
-    fig = pylab.figure()
+    fig = plt.figure()
     for ifo in ifos:
         trigs = columns_from_file_list(file_list,
                                        ['snr', 'end_time'],
                                        ifo, start, end)
         print(trigs)
-        pylab.scatter(trigs['end_time'], trigs['snr'], label=ifo,
+        plt.scatter(trigs['end_time'], trigs['snr'], label=ifo,
                       color=ifo_color[ifo])
 
         fmt = '.12g'
         mpld3.plugins.connect(fig, mpld3.plugins.MousePosition(fmt=fmt))
-    pylab.legend()
-    pylab.xlabel('Time (s)')
-    pylab.ylabel('SNR')
-    pylab.grid()
+    plt.legend()
+    plt.xlabel('Time (s)')
+    plt.ylabel('SNR')
+    plt.grid()
     return mpld3.fig_to_html(fig)
 
 def times_to_urls(times, window, tag):

--- a/pycbc/results/plot.py
+++ b/pycbc/results/plot.py
@@ -3,10 +3,10 @@
 
 def hist_overflow(val, val_max, **kwds):
     """ Make a histogram with an overflow bar above val_max """
-    import pylab
+    from matplotlib import pyplot as plt
 
     overflow = len(val[val>=val_max])
-    pylab.hist(val[val<val_max], **kwds)
+    plt.hist(val[val<val_max], **kwds)
 
     if 'color' in kwds:
         color = kwds['color']
@@ -14,8 +14,8 @@ def hist_overflow(val, val_max, **kwds):
         color = None
 
     if overflow > 0:
-        rect = pylab.bar(val_max+0.05, overflow, .5, color=color)[0]
-        pylab.text(rect.get_x(),
+        rect = plt.bar(val_max+0.05, overflow, .5, color=color)[0]
+        plt.text(rect.get_x(),
                    1.10*rect.get_height(), '%s+' % val_max)
 
 

--- a/pycbc/results/snr.py
+++ b/pycbc/results/snr.py
@@ -26,7 +26,7 @@
 """
 Module to generate SNR figures
 """
-import pylab as pl
+from matplotlib import pyplot as plt
 from pycbc.results import ifo_color
 
 
@@ -52,22 +52,22 @@ def generate_snr_plot(snrdict, output_filename, triggers, ref_time):
     -------
         None
     """
-    pl.figure()
+    plt.figure()
     ref_time = int(ref_time)
     for ifo in sorted(snrdict):
         curr_snrs = snrdict[ifo]
 
-        pl.plot(curr_snrs.sample_times - ref_time, abs(curr_snrs),
-                c=ifo_color(ifo), label=ifo)
+        plt.plot(curr_snrs.sample_times - ref_time, abs(curr_snrs),
+                 c=ifo_color(ifo), label=ifo)
         if ifo in triggers:
-            pl.plot(triggers[ifo][0] - ref_time,
-                    triggers[ifo][1], marker='x', c=ifo_color(ifo))
+            plt.plot(triggers[ifo][0] - ref_time,
+                     triggers[ifo][1], marker='x', c=ifo_color(ifo))
 
-    pl.legend()
-    pl.xlabel(f'GPS time from {ref_time:d} (s)')
-    pl.ylabel('SNR')
-    pl.savefig(output_filename)
-    pl.close()
+    plt.legend()
+    plt.xlabel(f'GPS time from {ref_time:d} (s)')
+    plt.ylabel('SNR')
+    plt.savefig(output_filename)
+    plt.close()
 
 
 __all__ = ["generate_snr_plot"]

--- a/test/lalsim.py
+++ b/test/lalsim.py
@@ -84,7 +84,7 @@ print("Running {0} unit tests for {1}:".format('CPU', "Lalsimulation Waveforms")
 import matplotlib
 if not opt.show_plots:
     matplotlib.use('Agg')
-import pylab
+from matplotlib import pyplot as plt
 
 def get_waveform(p, **kwds):
     """ Given the input parameters get me the waveform, whether it is TD or
@@ -129,52 +129,52 @@ class TestLALSimulation(unittest.TestCase):
         else:
             sample_attr = 'sample_frequencies'
 
-        f = pylab.figure()
-        pylab.axes([.1, .2, 0.8, 0.70])
+        f = plt.figure()
+        plt.axes([.1, .2, 0.8, 0.70])
         hp_ref, hc_ref = get_waveform(self.p, coa_phase=0)
-        pylab.plot(getattr(hp_ref, sample_attr), hp_ref.real(), label="phiref")
+        plt.plot(getattr(hp_ref, sample_attr), hp_ref.real(), label="phiref")
 
         hp, hc = get_waveform(self.p, coa_phase=lal.PI/4)
         m, i = match(hp_ref, hp)
         self.assertAlmostEqual(1, m, places=2)
         o = overlap(hp_ref, hp)
-        pylab.plot(getattr(hp, sample_attr), hp.real(), label="$phiref \pi/4$")
+        plt.plot(getattr(hp, sample_attr), hp.real(), label="$phiref \pi/4$")
 
         hp, hc = get_waveform(self.p, coa_phase=lal.PI/2)
         m, i = match(hp_ref, hp)
         o = overlap(hp_ref, hp)
         self.assertAlmostEqual(1, m, places=7)
         self.assertAlmostEqual(-1, o, places=7)
-        pylab.plot(getattr(hp, sample_attr), hp.real(), label="$phiref \pi/2$")
+        plt.plot(getattr(hp, sample_attr), hp.real(), label="$phiref \pi/2$")
 
         hp, hc = get_waveform(self.p, coa_phase=lal.PI)
         m, i = match(hp_ref, hp)
         o = overlap(hp_ref, hp)
         self.assertAlmostEqual(1, m, places=7)
         self.assertAlmostEqual(1, o, places=7)
-        pylab.plot(getattr(hp, sample_attr), hp.real(), label="$phiref \pi$")
+        plt.plot(getattr(hp, sample_attr), hp.real(), label="$phiref \pi$")
 
-        pylab.xlim(min(getattr(hp, sample_attr)), max(getattr(hp, sample_attr)))
-        pylab.title("Vary %s oribital phiref, h+" % self.p.approximant)
+        plt.xlim(min(getattr(hp, sample_attr)), max(getattr(hp, sample_attr)))
+        plt.title("Vary %s oribital phiref, h+" % self.p.approximant)
 
         if self.p.approximant in td_approximants():
-            pylab.xlabel("Time to coalescence (s)")
+            plt.xlabel("Time to coalescence (s)")
         else:
-            pylab.xlabel("GW Frequency (Hz)")
+            plt.xlabel("GW Frequency (Hz)")
 
-        pylab.ylabel("GW Strain (real part)")
-        pylab.legend(loc="upper left")
+        plt.ylabel("GW Strain (real part)")
+        plt.legend(loc="upper left")
 
         info = self.version_txt
-        pylab.figtext(0.05, 0.05, info)
+        plt.figtext(0.05, 0.05, info)
 
         if self.save_plots:
             pname = self.plot_dir + "/%s-vary-phase.png" % self.p.approximant
-            pylab.savefig(pname)
+            plt.savefig(pname)
         if self.show_plots:
-            pylab.show()
+            plt.show()
         else:
-            pylab.close(f)
+            plt.close(f)
 
 
     def test_distance_scaling(self):
@@ -189,37 +189,37 @@ class TestLALSimulation(unittest.TestCase):
         hpf, hcf = get_waveform(self.p, distance=distance*fac*fac)
         hpn, hcn = get_waveform(self.p, distance=distance/fac)
 
-        f = pylab.figure()
-        pylab.axes([.1, .2, 0.8, 0.70])
+        f = plt.figure()
+        plt.axes([.1, .2, 0.8, 0.70])
         htilde = make_frequency_series(hpc)
-        pylab.loglog(htilde.sample_frequencies, abs(htilde), label="D")
+        plt.loglog(htilde.sample_frequencies, abs(htilde), label="D")
 
         htilde = make_frequency_series(hpm)
-        pylab.loglog(htilde.sample_frequencies, abs(htilde), label="D * %s" %fac)
+        plt.loglog(htilde.sample_frequencies, abs(htilde), label="D * %s" %fac)
 
         htilde = make_frequency_series(hpf)
-        pylab.loglog(htilde.sample_frequencies, abs(htilde), label="D * %s" %(fac*fac))
+        plt.loglog(htilde.sample_frequencies, abs(htilde), label="D * %s" %(fac*fac))
 
         htilde = make_frequency_series(hpn)
-        pylab.loglog(htilde.sample_frequencies, abs(htilde), label="D / %s" %fac)
+        plt.loglog(htilde.sample_frequencies, abs(htilde), label="D / %s" %fac)
 
-        pylab.title("Vary %s distance, $\\tilde{h}$+" % self.p.approximant)
-        pylab.xlabel("GW Frequency (Hz)")
-        pylab.ylabel("GW Strain")
-        pylab.legend()
-        pylab.xlim(xmin=self.p.f_lower)
+        plt.title("Vary %s distance, $\\tilde{h}$+" % self.p.approximant)
+        plt.xlabel("GW Frequency (Hz)")
+        plt.ylabel("GW Strain")
+        plt.legend()
+        plt.xlim(xmin=self.p.f_lower)
 
         info = self.version_txt
-        pylab.figtext(0.05, .05, info)
+        plt.figtext(0.05, .05, info)
 
         if self.save_plots:
             pname = self.plot_dir + "/%s-distance-scaling.png" % self.p.approximant
-            pylab.savefig(pname)
+            plt.savefig(pname)
 
         if self.show_plots:
-            pylab.show()
+            plt.show()
         else:
-            pylab.close(f)
+            plt.close(f)
 
         self.assertTrue(hpc.almost_equal_elem(hpm * fac, tolerance, relative=True))
         self.assertTrue(hpc.almost_equal_elem(hpf * fac * fac, tolerance, relative=True))
@@ -296,24 +296,24 @@ class TestLALSimulation(unittest.TestCase):
             s = sigma(hp, low_frequency_cutoff=self.p.f_lower)
             sigmas.append(s)
 
-        f = pylab.figure()
-        pylab.axes([.1, .2, 0.8, 0.70])
-        pylab.plot(incs, sigmas)
-        pylab.title("Vary %s inclination, $\\tilde{h}$+" % self.p.approximant)
-        pylab.xlabel("Inclination (radians)")
-        pylab.ylabel("sigma (flat PSD)")
+        f = plt.figure()
+        plt.axes([.1, .2, 0.8, 0.70])
+        plt.plot(incs, sigmas)
+        plt.title("Vary %s inclination, $\\tilde{h}$+" % self.p.approximant)
+        plt.xlabel("Inclination (radians)")
+        plt.ylabel("sigma (flat PSD)")
 
         info = self.version_txt
-        pylab.figtext(0.05, 0.05, info)
+        plt.figtext(0.05, 0.05, info)
 
         if self.save_plots:
             pname = self.plot_dir + "/%s-vary-inclination.png" % self.p.approximant
-            pylab.savefig(pname)
+            plt.savefig(pname)
 
         if self.show_plots:
-            pylab.show()
+            plt.show()
         else:
-            pylab.close(f)
+            plt.close(f)
 
         self.assertAlmostEqual(sigmas[-1], sigmas[0], places=7)
         self.assertAlmostEqual(max(sigmas), sigmas[0], places=7)
@@ -349,26 +349,26 @@ class TestLALSimulation(unittest.TestCase):
         hpTS=TimeSeries(hpdec, delta_t=self.p.delta_t*2.,epoch=hp.start_time)
         hcTS=TimeSeries(hcdec, delta_t=self.p.delta_t*2.,epoch=hc.start_time)
 
-        f = pylab.figure()
-        pylab.plot(hp.sample_times, hp.data,label="rate %s Hz" %"{:.0f}".format(1./self.p.delta_t))
-        pylab.plot(hp2dec.sample_times, hp2dec.data, label="rate %s Hz" %"{:.0f}".format(1./(self.p.delta_t*2.)))
+        f = plt.figure()
+        plt.plot(hp.sample_times, hp.data,label="rate %s Hz" %"{:.0f}".format(1./self.p.delta_t))
+        plt.plot(hp2dec.sample_times, hp2dec.data, label="rate %s Hz" %"{:.0f}".format(1./(self.p.delta_t*2.)))
 
-        pylab.title("Halving %s rate, $\\tilde{h}$+" % self.p.approximant)
-        pylab.xlabel("time (sec)")
-        pylab.ylabel("amplitude")
-        pylab.legend()
+        plt.title("Halving %s rate, $\\tilde{h}$+" % self.p.approximant)
+        plt.xlabel("time (sec)")
+        plt.ylabel("amplitude")
+        plt.legend()
 
         info = self.version_txt
-        pylab.figtext(0.05, 0.05, info)
+        plt.figtext(0.05, 0.05, info)
 
         if self.save_plots:
             pname = self.plot_dir + "/%s-vary-rate.png" % self.p.approximant
-            pylab.savefig(pname)
+            plt.savefig(pname)
 
         if self.show_plots:
-            pylab.show()
+            plt.show()
         else:
-            pylab.close(f)
+            plt.close(f)
 
         op=overlap(hpTS,hp2dec)
         self.assertAlmostEqual(1., op, places=2)


### PR DESCRIPTION
I had some import issues which I thought were caused by using pylab rather than pyplot directly. Turns out they aren't, but this should mean that we aren't using this when it is deprecated


## Standard information about the request

This is a deprecation fix
This change touches all areas of the codebase, but should have no effect

This change follows style guidelines (See e.g. [PEP8](https://peps.python.org/pep-0008/)), has been proposed using the [contribution guidelines](https://github.com/gwastro/pycbc/blob/master/CONTRIBUTING.md)


## Motivation
From [matplotlib documentation](https://matplotlib.org/3.1.1/tutorials/introductory/usage.html#matplotlib-pyplot-and-pylab-how-are-they-related)
```pylab is a convenience module that bulk imports [matplotlib.pyplot](https://matplotlib.org/3.1.1/api/_as_gen/matplotlib.pyplot.html#module-matplotlib.pyplot) (for plotting) and [numpy](https://docs.scipy.org/doc/numpy/reference/index.html#module-numpy) (for mathematics and working with arrays) in a single namespace. pylab is deprecated and its use is strongly discouraged because of namespace pollution. Use pyplot instead.```

## Contents
mainly a find-and-replace style change for pylon - one bit required actual thought about whether pylab was wrapping numpy or pyplot


- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
