### PR TITLE
Apply labels and close stale issues and PRs

### DIFF
--- a/.github/workflows/stale_issues_prs.yml
+++ b/.github/workflows/stale_issues_prs.yml
@@ -1,0 +1,20 @@
+name: 'Close stale issues and PR'
+on:
+  schedule:
+    - cron: '0 */6 * * *'
+      
+permissions:
+    issues:write
+    pull-requests:write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          stale-issue-message: 'This issue is stale because it has been open 60 days with no activity. Remove stale label or comment or this will be closed in 7 days.'
+          stale-pr-message: 'This PR is stale because it has been open 60 days with no activity. Remove stale label or comment or this will be closed in 7 days.'
+          close-issue-message: 'This issue was closed because it has been labelled as stale for 7 days with no activity.'
+          close-pr-message: 'This PR was closed because it has been labelled as stale for 7 days with no activity.'
+          exempt-issue-labels: 'long term','bug'

--- a/.github/workflows/stale_issues_prs.yml
+++ b/.github/workflows/stale_issues_prs.yml
@@ -2,7 +2,7 @@ name: 'Close stale issues and PR'
 on:
   schedule:
     - cron: '0 */6 * * *'
-      
+
 permissions:
     issues:write
     pull-requests:write


### PR DESCRIPTION
This implements a new GitHub action to apply labels warning that a PR or issue is stale, and closes it automatically if nothing happens for a week after it has been labelled stale

I _think_ I've set it so that we can apply `bug` or `long term` labels so that this won't happen.

## Standard information about the request

This is a new feature for GitHub management
This change has been proposed using the [contribution guidelines](https://github.com/gwastro/pycbc/blob/master/CONTRIBUTING.md)

## Motivation
I want to reduce the number of issues, and this is the easiest way to do that, rather than commenting on each one asking for an update.

## Contents
Add a GitHub workflow which uses the [Close Stale Issues](https://github.com/marketplace/actions/close-stale-issues) action to mark and close issues/PRs

## Links to any issues or associated PRs
I _could_ link all the issues and PRs older than a couple of months, but lets not do that for now.

## Testing performed
None

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
