### PR TITLE
Insist on a label that the code of conduct must have been agreed to

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,6 +15,9 @@ or discuss in the #pycbc-code channel of the gwastro slack.
 Please add labels as appropriate
 -->
 
+<!--- The author of this pull request must confirm that they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
+by applying the label `code of conduct agreed` to the PR -->
+
 <!-- TOP-LEVEL SUMMARY: Please provide a brief, one-or-two-sentence description of the PR here
 -->
 
@@ -52,5 +55,3 @@ but rather a general discussion of the methods chosen -->
 
 ## Additional notes
 <!--- Anything which does not fit in the above sections -->
-
-- [ ] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)

--- a/.github/workflows/block_merge.yml
+++ b/.github/workflows/block_merge.yml
@@ -1,9 +1,7 @@
 name: Custom PR failures
 
 on:
-  pull_request:
-    branches:
-      - master
+  pull_request
 
 jobs:
   fail-for-code-of-conduct-not-agreed:

--- a/.github/workflows/block_merge.yml
+++ b/.github/workflows/block_merge.yml
@@ -1,0 +1,17 @@
+name: Custom PR failures
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  fail-for-code-of-conduct-not-agreed:
+    if: contains(github.event.pull_request.labels.*.name, 'code of conduct agreed')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if code of conduct has not been agreed
+        run: |
+          echo "The Code of Conduct has not been agreed to, please read it "
+          echo "and apply the code of conduct agreed label and rerun the CI."
+          exit 1

--- a/.github/workflows/block_merge.yml
+++ b/.github/workflows/block_merge.yml
@@ -1,11 +1,11 @@
-name: Custom PR failures
+name: "Custom PR failures"
 
 on:
   pull_request
 
 jobs:
   fail-for-code-of-conduct-not-agreed:
-    if: contains(github.event.pull_request.labels.*.name, 'code of conduct agreed')
+    if: "!contains(github.event.pull_request.labels.*.name, 'code of conduct agreed')"
     runs-on: ubuntu-latest
     steps:
       - name: Fail if code of conduct has not been agreed


### PR DESCRIPTION
At the moment, we have a tick box, which can easily be ignored/deleted.

I think we should ask people something active to agree to act according to the code of conduct, and the best way to enforce that is to have a label which must be applied.

## Standard information about the request
This change has been proposed using the [contribution guidelines](https://github.com/gwastro/pycbc/blob/master/CONTRIBUTING.md)

## Motivation
An active requirement is better than a tick box which may be ignored

## Contents
Add a GitHub action to check the PR and see that the label has been applied


## Testing performed
I will _not_ apply the labels to this PR to begin with, and hopefully the CI will then fail. Applying the label and restarting should then work

Note - ⬇️⬇️ this bit ⬇️⬇️ of the template is being removed after this PR

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
