### PR TITLE
Change recursion parameter in resample

### DIFF
--- a/pycbc/filter/resample.py
+++ b/pycbc/filter/resample.py
@@ -128,7 +128,7 @@ def lfilter(coefficients, timeseries):
     else:
         # recursively perform which saves a bit on memory usage
         # but must keep within recursion limit
-        chunksize = max(fillen * 5, len(timeseries) // 128)
+        chunksize = max(fillen * 5, len(timeseries) // 2)
         part1 = lfilter(coefficients, timeseries[0:chunksize])
         part2 = lfilter(coefficients, timeseries[chunksize - fillen:])
         out = timeseries.copy()


### PR DESCRIPTION
Make resampling more efficient by changing the recursion settings.

## Standard information about the request

This is a: efficiency update

This change affects: the offline search, the live search, inference, PyGRB

This change changes: code used for scientific output (but doesn't change output)

## Motivation

We've seen some issues with the recursive resampling used in the `lfilter` function. While there are some optimizations that could be done to the code as it was written, I'm not understanding the logic behind what it does.

In particular, why does it split the code into two uneven (1:127) pieces. Because it does this recursively it means that the sizes in play are wildly varying and the code is called *a lot*. Current data lengths require two levels of recursion, so in general we run on blocks around a few thousand seconds in length. While the number of operations favours lots of short(ish) calls, there is enough function overhead that means that this doesn't hold in practice.

* Memory transfer operations happen every time the function is called, so does not favour lots of calls
* As `lfilter` uses multithreading, there is a *big* hit on setup with short arrays. If one does not set OMP_NUM_THREADS on large-core nodes, this causes a problem (mostly happening with debugging).

A simpler resolution here is to recurse by splitting the data into two equal length pieces. For example standard search data lengths this results in much fewer calls to the function, and a factor of 2 speed up. This also seems a more logical recursion to me.

I note that the function could be significantly sped up if necessary by ensuring that when `lfilter` actually runs, it always runs the same length FFTs, and then use the class-based cached stuff that's already in place for this function for PyCBC Live and is enabled by a boolean flag (flag doesn't help if the FFTs are always slightly different sizes) ... Binary-sized FFTs would also likely help.

## Contents

Change recursion split parameter from 128 to 2.

## Testing performed

I've tested speed with/without this. I'm trusting the CI to properly validate this.

- [ ] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
