### PR TITLE
PyGRB: handling the 2 IFO case with the coherent search methods

### DIFF
--- a/bin/pycbc_multi_inspiral
+++ b/bin/pycbc_multi_inspiral
@@ -793,10 +793,10 @@ with ctx:
                         coinc_triggers = {}
                         logging.debug("No coincident triggers were found")
                     # If there are triggers above coinc threshold and more
-                    # than 2 IFOs, then calculate the coherent statistics for
+                    # than 1 IFO, then calculate the coherent statistics for
                     # them and apply the cut on coherent SNR (with threshold
                     # equal to the coinc SNR one)
-                    if len(coinc_idx) != 0 and nifo > 2:
+                    if len(coinc_idx) != 0 and nifo > 1:
                         logging.debug("Calculating their coherent statistics")
                         # Plus and cross antenna pattern dictionaries
                         fp = {
@@ -971,7 +971,7 @@ with ctx:
                             chisq, chisq_dof, coherent_ifo_trigs
                         )
                         # Calculate chisq reweighted SNR
-                        if nifo > 2:
+                        if nifo > 1:
                             reweighted_snr = ranking.newsnr(
                                 rho_coh,
                                 network_chisq_dict,
@@ -986,13 +986,6 @@ with ctx:
                                 null_min=args.null_min,
                                 null_grad=args.null_grad,
                                 null_step=args.null_step,
-                            )
-                        elif nifo == 2:
-                            reweighted_snr = ranking.newsnr(
-                                rho_coinc,
-                                network_chisq_dict,
-                                q=args.chisq_index,
-                                n=args.chisq_nhigh,
                             )
                         else:
                             rho_sngl = abs(
@@ -1054,11 +1047,9 @@ with ctx:
                                 ifo_names,
                                 [ifo_out_vals[n] for n in ifo_names],
                             )
-                        if nifo > 2:
+                        if nifo > 1:
                             network_out_vals['coherent_snr'] = rho_coh
                             network_out_vals['null_snr'] = null
-                        elif nifo == 2:
-                            network_out_vals['coherent_snr'] = rho_coinc
                         else:
                             network_out_vals['coherent_snr'] = abs(
                                 snr_dict[args.instruments[0]][


### PR DESCRIPTION
`pycbc_multi_inspiral` treats the case with 2 interferometers as a coincident search, rather than a coherent search.  With the assumption of a left/right circularly polarised signal, this should not be the case.  See https://inspirehep.net/literature/1323266, Section V A.

## Standard information about the request
<!--- Some basic info about the change (delete as appropriate) -->
This is a: new feature.

<!--- What codes will this affect? (delete as apropriate)
This change affects: PyGRB

<!--- What code areas will this affect? (delete as apropriate) -->
This change changes: scientific output

<!--- Some things which help with code management (delete as appropriate) -->
This change is supported by the CI tests in PyCBC.

## Contents
Anywhere `pycbc_multi_inspiral` separated the 1 IFO, the 2 IFO and more than 2 IFO cases, I simply reduced the branches to 1 IFO vs more than 1 IFO.

## Testing performed
Tests with full runs are in progress.

## Additional notes
<!--- Anything which does not fit in the above sections -->

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
