### PR TITLE
PyGRB single IFO case fixes

### DIFF
--- a/bin/pycbc_multi_inspiral
+++ b/bin/pycbc_multi_inspiral
@@ -757,9 +757,9 @@ with ctx:
                         % len(snr_dict[ifo])
                         for ifo in args.instruments
                     }
-                    # Calculate the coincident and coherent SNR.
-                    # First check there is enough data to compute the SNRs.
-                    if len(coinc_idx) != 0 and nifo > 1:
+                    # Calculate the coincident SNR, regardless of how many IFOs
+                    # are available, only if there are triggers so far.
+                    if len(coinc_idx) != 0:
                         # Find coinc SNR at trigger times and apply coinc SNR
                         # threshold (which depopulates coinc_idx accordingly)
                         (
@@ -781,14 +781,6 @@ with ctx:
                                 "With max coincident SNR = %.2f",
                                 max(rho_coinc),
                             )
-                    # If there is only one IFO, just take its triggers
-                    # and their SNRs
-                    elif len(coinc_idx) != 0 and nifo == 1:
-                        coinc_triggers = {
-                            args.instruments[0]: snr_dict[args.instruments[0]][
-                                coinc_idx_det_frame[args.instruments[0]]
-                            ]
-                        }
                     else:
                         coinc_triggers = {}
                         logging.debug("No coincident triggers were found")

--- a/bin/pycbc_multi_inspiral
+++ b/bin/pycbc_multi_inspiral
@@ -758,10 +758,11 @@ with ctx:
                         for ifo in args.instruments
                     }
                     # Calculate the quadrature sum of individual detector SNRs,
-                    # regardless of how many IFOs are available.  This is
-                    # referred to as coincident SNR in the code, and it
-                    # accounts for a coherent SNR component and an incoherent
-                    # one. The calculation is performed only if triggers were
+                    # regardless of how many IFOs are available.
+                    # This accounts for a coherent SNR component and an
+                    # incoherent one.  It is referred to as coincident SNR
+                    # throughout the code, even in the single IFO case.
+                    # The calculation is performed only if triggers were
                     # gathered so far.
                     if len(coinc_idx) != 0:
                         # Find coinc SNR at trigger times and apply coinc SNR

--- a/bin/pycbc_multi_inspiral
+++ b/bin/pycbc_multi_inspiral
@@ -757,8 +757,12 @@ with ctx:
                         % len(snr_dict[ifo])
                         for ifo in args.instruments
                     }
-                    # Calculate the coincident SNR, regardless of how many IFOs
-                    # are available, only if there are triggers so far.
+                    # Calculate the quadrature sum of individual detector SNRs,
+                    # regardless of how many IFOs are available.  This is
+                    # referred to as coincident SNR in the code, and it
+                    # accounts for a coherent SNR component and an incoherent
+                    # one. The calculation is performed only if triggers were
+                    # gathered so far.
                     if len(coinc_idx) != 0:
                         # Find coinc SNR at trigger times and apply coinc SNR
                         # threshold (which depopulates coinc_idx accordingly)

--- a/bin/pygrb/pycbc_grb_trig_combiner
+++ b/bin/pygrb/pycbc_grb_trig_combiner
@@ -137,7 +137,7 @@ def merge_hdf5_files(inputfiles, outputfile, verbose=False, **compression_kw):
     all_event_id_names = sngl_event_id_names + network_event_id_names
 
     # handle search datasets as a special case
-    # (they will the same in all files)
+    # (they will be the same in all files)
     search_datasets = set(filter(lambda x: "/search/" in x, dataset_names))
     gating_datasets = set(filter(lambda x: "/gating/" in x, dataset_names))
     once_only_datasets = search_datasets.union(gating_datasets)

--- a/pycbc/pnutils.py
+++ b/pycbc/pnutils.py
@@ -1025,6 +1025,8 @@ def jframe_to_l0frame(mass1, mass2, f_ref, phiref=0., thetajn=0., phijl=0.,
         binary (in solar masses)
     f_ref : float
         The reference frequency.
+    phiref : float
+        The reference phase.
     thetajn : float
         Angle between the line of sight and the total angular momentume J.
     phijl : float

--- a/pycbc/results/pygrb_postprocessing_utils.py
+++ b/pycbc/results/pygrb_postprocessing_utils.py
@@ -345,7 +345,7 @@ def load_data(input_file, ifos, rw_snr_threshold=None, data_tag=None,
             # The dataset contains search information or missed injections
             # information, not properties of triggers or found injections:
             # just copy it
-            if 'search' in path or 'missed' in path:
+            if 'search' in path or 'missed' in path or 'gating' in path:
                 trigs_dict[path] = dset[:]
             # The dataset is trig/inj info at an IFO:
             # cut with the correct index


### PR DESCRIPTION
- This PR fixes a bug in the PyGRB post-processing: when auto-gating occurs, the `gating` entry of results files should not be treated as a numpy array pertaining to the triggers found.  This was never encountered before because auto-gating was never triggered in the tests we ran so far.
- This PR also makes sure that the coincident SNR cut is applied in the single IFO case applies, in line with what happens when 2 or more IFOs are available for the analysis.  This keeps the amount of data under control, and is the strategy adopted previously with PyGRB+coh_PTF.
- Finally, this PR fixes two comments: one for syntax and one missing an input parameter description.

This change affects: PyGRB

This change changes: scientific output

## Testing
With the first of these changes, I was able to produce plots that would otherwise through an error when trying to use index triggers on, e.g., `L1/gating/` in the results files.

The output files of inspiral jobs of a single IFO run are seen to be reduced by a factor 10 in size with the cut on coincident SNR (which is effectively a second cut on single IFO SNR) in place.

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
