### PR TITLE
Workaround for git.ligo.org authentication change

### DIFF
--- a/pycbc/workflow/configuration.py
+++ b/pycbc/workflow/configuration.py
@@ -105,10 +105,7 @@ def resolve_url_http(url, u, filename):
         re_match = re.match(
             'https://git.ligo.org/([^ ]+)/-/raw/([^ /]+)/(.+)', url
         )
-        assert (
-            re_match,
-            f'Failed to parse URL {url} for git.ligo.org special case'
-        )
+        assert re_match, f'Failed to parse URL {url} for git.ligo.org special case'
         project = re_match.group(1)
         ref = re_match.group(2)
         file_path = re_match.group(3)

--- a/pycbc/workflow/configuration.py
+++ b/pycbc/workflow/configuration.py
@@ -103,7 +103,7 @@ def resolve_url_http(url, u, filename):
         # Token via the headers. Second, we need to translate the raw-download
         # URL scheme to a different scheme that uses GitLab's REST API.
         re_match = re.match(
-            'https://git.ligo.org/([^ ]+)/(?:-/)?raw/([^ /]+)/(.+)', url
+            'https://git.ligo.org/([^ ]+(?<!/-))/(?:-/)?raw/([^ /]+)/(.+)', url
         )
         assert re_match, f'Failed to parse URL {url} for git.ligo.org special case'
         project = re_match.group(1)
@@ -118,6 +118,8 @@ def resolve_url_http(url, u, filename):
         )
         project = urllib.parse.quote(project, safe='')
         ref = urllib.parse.quote(ref, safe='')
+        # GitLab's REST API does not seem to like double slashes
+        file_path = os.path.normpath(file_path)
         file_path = urllib.parse.quote(file_path, safe='')
         # FIXME This code will break once GitLab changes their mind about the
         # URL format. As a different approach, we could rely on the gitlab

--- a/pycbc/workflow/configuration.py
+++ b/pycbc/workflow/configuration.py
@@ -103,7 +103,7 @@ def resolve_url_http(url, u, filename):
         # Token via the headers. Second, we need to translate the raw-download
         # URL scheme to a different scheme that uses GitLab's REST API.
         re_match = re.match(
-            'https://git.ligo.org/([^ ]+)/-/raw/([^ /]+)/(.+)', url
+            'https://git.ligo.org/([^ ]+)/(?:-/)?raw/([^ /]+)/(.+)', url
         )
         assert re_match, f'Failed to parse URL {url} for git.ligo.org special case'
         project = re_match.group(1)

--- a/pycbc/workflow/configuration.py
+++ b/pycbc/workflow/configuration.py
@@ -86,7 +86,7 @@ def hash_compare(filename_1, filename_2, chunk_size=None, max_chunks=None):
     return True
 
 
-def resolve_url_http():
+def resolve_url_http(url, u, filename):
     """Helper function used by `resolve_url()` to handle HTTP and HTTPS URLs.
     """
 


### PR DESCRIPTION
The authentication method used by git.ligo.org changed recently. This breaks downloading files from repositories on git.ligo.org via `pycbc.workflow.resolve_url()`. Here is one way to fix it.

## Standard information about the request

This is a new feature required by an LVK infrastructure change.

This change affects all workflows that use `resolve_url()`, in particular the offline all-sky and PyGRB searches.

This change changes basic workflow infrastructure.

## Motivation

We have historically relied on `ciecplib` to download files from repositoried hosted on git.ligo.org via Shibboleth authentication. Due to changes recently made to git.ligo.org, and outside our control, this does not work anymore. The recommended approach now is to use a GitLab Personal Access Token which each user has to get, store somewhere, and give to each HTTP request for authorization. The URL scheme to download a given file has also changed; the previous scheme, which you still get when you click the "download" button on the web interface, does not work anymore.

## Contents

I refactored part of `resolve_url()`, keeping the functionality as similar as possible, and added a special case for URLs that point to git.ligo.org. That special case assumes the presence of a file at `$XDG_CONFIG_HOME/pycbc/git-ligo-org.pat` with GitLab's PAT in it, reads it, and passes its content as a header to the `ciecplib` call.

Note that the previous code already had git.ligo.org and code.pycbc.phy.syr.edu as special cases to invoke the Shibboleth authentication, though it was much simpler before. code.pycbc.phy.syr.edu does not resolve anymore, so I dropped it.

## Links to any issues or associated PRs

None.

## Testing performed

I tried running the new `resolve_url()` (after setting up my PAT file) and it downloads the file correctly.

## Additional notes

Everyone using a PyCBC workflow that downloads files from a git.ligo.org repository will now have to set up a GitLab PAT via the web interface and store it on the cluster they want to use at `$XDG_CONFIG_HOME/pycbc/git-ligo-org.pat`.

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
