### PR TITLE
Fix bug in GatedGaussian and add MargPol unit tests

### DIFF
--- a/pycbc/inference/models/gated_gaussian_noise.py
+++ b/pycbc/inference/models/gated_gaussian_noise.py
@@ -646,10 +646,7 @@ class GatedGaussianNoise(BaseGatedGaussian):
             The value of the log likelihood.
         """
         # generate the template waveform
-        # We'll gate them here, but not in-paint. We'll do the in-painting
-        # once, on the residual. We'll gate the waveforms here so that
-        # zero before/after gate can be applied to them.
-        wfs = self.get_gated_waveforms()
+        wfs = self.get_waveforms()
         # get the times of the gates
         gate_times = self.get_gate_times()
         logl = 0.


### PR DESCRIPTION
PR #5117 introduced a bug into the `GatedGaussianNoise` model. When the waveforms are generated in the `GatedGaussianNoise.loglikelihood` function `get_waveforms` should be called, but that was accidentally changed to `get_gated_waveforms`. The unit tests introduced in that PR didn't catch this as they only tested the `GatedGaussianMargPol` and `Hierarchical` models.

This patch fixes the bug by reverting the the line back to `get_waveforms`. It also introduces unit tests that should prevent this in the future. The new unit tests manually call the unmarginalized model's loglikelihoods over the same polarization samples the marg pol model uses, integrates it, and checks that that yields the same result as the marginalized model. The test is applied to both the gated models and the ungated models. For the ungated models, a similar test can be added in the future for the other marginalizations.

In writing the unit test I noticed that neither the `GatedGaussianMargPol` nor the `MarginalizedPolarization` models are dividing the likelihood by 2pi (i.e., the norm of the prior over polarization). I think this is also a bug, or at least an inconsistency. The analytic marginalized phase models include the 1/2pi in the loglikelihood by construction; it's in the definition of the modified Bessel function. I think that's the right thing to do since the marginalization should include the prior. I decided not to change that in this PR, however, because I wasn't sure what the other marginalizations are doing. This should be addressed in another PR.

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
