### PR TITLE
updated for depcreated fillcolor value

### DIFF
--- a/pycbc/results/scatter_histograms.py
+++ b/pycbc/results/scatter_histograms.py
@@ -385,6 +385,7 @@ def create_marginalized_hist(ax, values, label, percentiles=None,
     """
     if fillcolor is None:
         htype = 'step'
+        fillcolor = 'none'
     else:
         htype = 'stepfilled'
     if rotated:


### PR DESCRIPTION
<!---
Please delete these comments when you submit the pull request

Please add a title which is a concise description of what you are doing,
e.g. 'Fix bug with numpy import in pycbc_coinc_findtrigs' or 'add high frequency sky location dependent response for long detectors'
-->

<!---
This is a brief template for making pull requests for PyCBC.
This is _not_ a proscriptive template - you can use a different style if you want.
Please do think about the questions posed here and whether the details will be useful to include in your PR
Please add sufficient details so that people looking back at the request with no context around the work can understand the changes.
To choose reviewers, please look at the git blame for the code you are changing (if applicable),
or discuss in the #pycbc-code channel of the gwastro slack.
Please add labels as appropriate
-->

<!-- TOP-LEVEL SUMMARY: Please provide a brief, one-or-two-sentence description of the PR here
-->

## Standard information about the request

<!--- Some basic info about the change (delete as appropriate) -->
This is a: bug fix

<!--- What codes will this affect? (delete as apropriate)
Anything that uses scatter_histograms function to make corner plots.


<!--- Notes about the effect of this change -->
This change will: break current functionality, require additional dependencies, require a new release, other (please describe)

## Motivation
The most recent matplotlib release May 8th, dropped the ability to pass None as a facecolor to indicated that it should not be visible. Instead it requires passing the literal string 'none'. 


## Additional notes
<!--- Anything which does not fit in the above sections -->

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
