### PR TITLE
Resolve warnings of NumPy library

### DIFF
--- a/bin/all_sky_search/pycbc_distribute_background_bins
+++ b/bin/all_sky_search/pycbc_distribute_background_bins
@@ -43,7 +43,7 @@ logging.info('%s coinc triggers' % len(d))
 for name, outname in zip(names, args.output_files):
     # select the coincs from only this bin and save to a single combined file
     locs = locs_dict[name]
-    e = d.select(numpy.in1d(d.template_id, locs))
+    e = d.select(numpy.isin(d.template_id, locs))
     logging.info('%s coincs in mass bin: %s' % (len(e), name))
     e.save(outname)
     f = pycbc.io.HFile(outname)

--- a/bin/pygrb/pycbc_grb_trig_cluster
+++ b/bin/pygrb/pycbc_grb_trig_cluster
@@ -94,7 +94,7 @@ def slice_hdf5(inputfile, outfile, include, verbose=False):
                         h5in.copy(h5in[old.name], h5out, old.name)
                         bar.update()
             for ifo in ifos:
-                idx = numpy.in1d(h5in[ifo]["event_id"][()], ifo_index[ifo])
+                idx = numpy.isin(h5in[ifo]["event_id"][()], ifo_index[ifo])
                 for old in h5in[ifo].values():
                     if isinstance(old, h5py.Dataset):
                         h5out.create_dataset(

--- a/bin/pygrb/pycbc_grb_trig_combiner
+++ b/bin/pygrb/pycbc_grb_trig_combiner
@@ -51,7 +51,7 @@ TQDM_KW = {
 }
 
 
-# -- utilties -----------------------------------
+# -- utilities -----------------------------------
 
 def merge_hdf5_files(inputfiles, outputfile, verbose=False, **compression_kw):
     """Merge several HDF5 files into a single file
@@ -168,7 +168,7 @@ def merge_hdf5_files(inputfiles, outputfile, verbose=False, **compression_kw):
             h5out.create_dataset(dset, data=numpy.concatenate(data),
                                  **compression_kw)
             del data
-        # END OF DATSET LOOP
+        # END OF DATASET LOOP
 
         # Handling event_id datasets seprately
         dset = all_event_id_names[0]
@@ -269,7 +269,7 @@ def bin_events(inputfile, bins, outdir, filetag,
                             h5in.copy(h5in[old.name], h5out, old.name)
                             bar.update()
                 for ifo in ifos:
-                    idx = numpy.in1d(h5in[ifo]["event_id"][()], ifo_index[ifo])
+                    idx = numpy.isin(h5in[ifo]["event_id"][()], ifo_index[ifo])
                     for old in h5in[ifo].values():
                         if isinstance(old, h5py.Dataset):
                             h5out.create_dataset(
@@ -298,7 +298,7 @@ def read_segment_files(segdir):
             with open(os.path.join(segdir, filename), "r") as f:
                 segs[name], = fromsegwizard(f)
         except ValueError as exc:
-            exc.args = ("more than one segment, an error has occured",)
+            exc.args = ("more than one segment, an error has occurred",)
             raise
     return segs
 

--- a/pycbc/events/coinc.py
+++ b/pycbc/events/coinc.py
@@ -143,7 +143,7 @@ def background_bin_from_string(background_bins, data):
                 locs = sub_locs
 
         # make sure we don't reuse anything from an earlier bin
-        locs = numpy.delete(locs, numpy.where(numpy.in1d(locs, used))[0])
+        locs = numpy.delete(locs, numpy.where(numpy.isin(locs, used))[0])
         used = numpy.concatenate([used, locs])
         bins[name] = locs
 

--- a/test/validation_code/old_coinc.py
+++ b/test/validation_code/old_coinc.py
@@ -119,7 +119,7 @@ def background_bin_from_string(background_bins, data):
                 locs = sub_locs
 
         # make sure we don't reuse anything from an earlier bin
-        locs = numpy.delete(locs, numpy.where(numpy.in1d(locs, used))[0])
+        locs = numpy.delete(locs, numpy.where(numpy.isin(locs, used))[0])
         used = numpy.concatenate([used, locs])
         bins[name] = locs
 


### PR DESCRIPTION
# PR Summary

Replaces deprecated `numpy.in1d()` calls with `numpy.isin()` to resolve deprecation warnings while maintaining identical functionality.

## Standard information about the request

This is a: bug fix

This change affects: Any code using numpy array comparisons

This change changes: Internal array comparison implementation

This change: has appropriate unit tests, follows style guidelines (See e.g. [PEP8](https://peps.python.org/pep-0008/)), has been proposed using the [contribution guidelines](https://github.com/gwastro/pycbc/blob/master/CONTRIBUTING.md)

This change will: maintain current functionality while removing deprecation warnings

## Motivation
NumPy has deprecated `in1d()` in favor of `isin()` since version 1.13.0. This change:
- Removes annoying deprecation warnings during runtime
- Future-proofs the code against eventual removal of `in1d()`
- Maintains identical functionality as `isin()` is the direct replacement

## Contents
- Replaced all instances of `np.in1d()` with `np.isin()`
- Verified equivalent behavior through existing test suite

## Links to any issues or associated PRs
Fixes #<issue-number>  <!-- Add issue number if applicable -->

## Testing performed
- Ran full test suite to verify no behavior changes

## Additional notes
- `isin()` has been available since NumPy 1.13.0 (Jan 2017)
- No additional dependencies required
- Backward compatible with all supported NumPy versions

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)