### PR TITLE
Fix incorrect OSDF URL resolution

### DIFF
--- a/pycbc/workflow/configuration.py
+++ b/pycbc/workflow/configuration.py
@@ -205,9 +205,10 @@ def resolve_url(
         # OSDF will require a scitoken to be present and stashcp to be
         # available. Thanks Dunky for the code here!
         cmd = [
-            which("pelican") or "pelican", 
-            "object get", 
-            u.scheme + "://" + u.path, 
+            which("pelican") or "pelican",
+            "object",
+            "get",
+            u.scheme + "://" + u.path,
             filename
         ]
 
@@ -215,12 +216,12 @@ def resolve_url(
             subprocess.run(cmd, check=True, capture_output=True)
         except subprocess.CalledProcessError as err:
             # Print information about the failure
-            print(err.cmd, "failed with")
-            print(err.stderr.decode())
-            print(err.stdout.decode())
+            logging.error(
+                'Command %s failed with the following output:', err.cmd
+            )
+            logging.error(err.stderr.decode())
+            logging.error(err.stdout.decode())
             raise
-
-        return filename
 
     else:
         # TODO: We could support other schemes as needed


### PR DESCRIPTION
`resolve_url()` does not seem to work for OSDF URLs. This should fix it.

## Standard information about the request

This is a bug fix.

This change affects offline workflows.

## Motivation

#5001 changed the way we resolve `osdf://` URLs to use `pelican object get <source> <destination>`. However, the code there actually calls `pelican object\ get <source> <destination>`, i.e. "object get" is given as a single argument made of two words separated by a space, which `pelican` does not like:
```
Error: unknown command "object get" for "pelican"
Run 'pelican --help' for usage.
```

## Contents

This replaces the "object get" arg with two args "object" and "get". I also noticed that the OSDF branch of the code returned immediately after calling `pelican`, which is not what the other branches do, so I removed the return as well.

## Links to any issues or associated PRs

#5001

## Testing performed

None so far, be back shortly.

## Additional notes

This would be needed on the 2.3 and 2.8 release branches if we want to get files from the OSDF.

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
