### PR TITLE
Error in demarginalization 

### DIFF
--- a/pycbc/inference/models/tools.py
+++ b/pycbc/inference/models/tools.py
@@ -442,8 +442,11 @@ class DistMarg():
             ifos = self.keep_ifos
         ikey = ''.join(ifos)
 
+        vsamples = size if size is not None else self.vsamples
+
         # No good SNR peaks, go with prior draw
         if len(ifos) == 0:
+            self.marginalize_vector_params['logw_partial'] = numpy.zeros(vsamples)
             return
 
         def make_init():
@@ -492,8 +495,6 @@ class DistMarg():
             self.tinfo[ikey] = make_init()
 
         dmap, tcmin, tcmax, fp, fc, ra, dec, dtc, bin_prior = self.tinfo[ikey]
-
-        vsamples = size if size is not None else self.vsamples
 
         # draw times from each snr time series
         # Is it worth doing this if some detector has low SNR?


### PR DESCRIPTION
The error described in the PR https://github.com/gwastro/pycbc/pull/5106 was persistent since the function has another return. This PR is assigning zero values to logw_partial when demarginalization returns early without assigning any values due to lack of snr peaks.