### PR TITLE
Pygrb segplot bug

### DIFF
--- a/pycbc/results/pygrb_plotting_utils.py
+++ b/pycbc/results/pygrb_plotting_utils.py
@@ -71,7 +71,7 @@ def make_grb_segments_plot(wkflow, science_segs, trigger_time, trigger_name,
     from pycbc.results.color import ifo_color
 
     ifos = wkflow.ifos
-    if len(science_segs.keys()) == 0:
+    if len(sum(science_segs.values(), [])) == 0:
         extent = segments.segment(int(wkflow.cp.get("workflow", "start-time")),
                                   int(wkflow.cp.get("workflow", "end-time")))
     else:


### PR DESCRIPTION
## Standard information about the request

This is a: bug fix.

This change affects: PyGRB

This change changes: result plotting whenever no data is available, allowing the workflow generator to end gracefully.

## Motivation
When trying to generate a PyGRB workflow at a time when no data of any detector is available in the offsource and the onsource, the desired behaviour is for the workflow generation script to generate an empty plot, warn the user there is no data and exit.  However, this was not the case.

## Contents
Tracing back the error, all that needs to be done is to check whether a specific dictionary contains any meaningful information (i.e., segments) or not, rather than checking if it has keys.  If each key has empty lists, there are no segments, and the empty plot has to be produced.

## Links to any issues or associated PRs
[<!--- If this is fixing / working around an already-reported issue, please link to it here -->](https://github.com/gwastro/pycbc/issues/5131)

## Testing performed
Running this branch on data-empty times, the correct behaviour is seen.

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
