### PR TITLE
verbose option has been removed in pegasus status

### DIFF
--- a/pycbc/workflow/pegasus_workflow.py
+++ b/pycbc/workflow/pegasus_workflow.py
@@ -728,7 +728,7 @@ class Workflow(object):
 
         # Set up convenience scripts
         with open('status', 'w') as fp:
-            fp.write('pegasus-status --verbose ')
+            fp.write('pegasus-status ')
             fp.write('--long {}/work $@'.format(submitdir))
 
         with open('debug', 'w') as fp:


### PR DESCRIPTION
Pegasus has remove the "--verbose" flag as an option to pegasus-status in the latest releases. We need to update our 'status' shell script to work with this. 