### PR TITLE
Make `pycbc_pygrb_grb_info_table` more flexible 

### DIFF
--- a/bin/pygrb/pycbc_pygrb_grb_info_table
+++ b/bin/pygrb/pycbc_pygrb_grb_info_table
@@ -35,6 +35,7 @@ import lal
 from pycbc import add_common_pycbc_options, init_logging
 import pycbc.version
 import pycbc.results
+import pycbc.distributions
 from pycbc.detector import Detector, ppdets
 from pycbc.results.pygrb_postprocessing_utils import get_antenna_dist_factor
 from pycbc.types import angle_as_radians
@@ -54,12 +55,13 @@ add_common_pycbc_options(parser)
 parser.add_argument("--trigger-time", type=int,
                     required=True,
                     help="GPS time of the GRB.")
+parser.add_argument("--input-distribution", type=str,
+                    help="Input Distribution of the GRB. Use distribution "
+                    "functions in pycbc.distributions.sky_location code.")
 parser.add_argument("--ra", type=angle_as_radians,
-                    required=True,
                     help="Right ascension of the GRB. Use the rad or deg "
                     "suffix to specify units, otherwise radians are assumed.")
 parser.add_argument("--dec", type=angle_as_radians,
-                    required=True,
                     help="Declination of the GRB. Use the rad or deg suffix "
                     "to specify units, otherwise radians are assumed.")
 parser.add_argument("--sky-error", type=angle_as_radians,
@@ -88,14 +90,23 @@ utc_time = datetime(*lal.GPSToUTC(opts.trigger_time)[0:6]).strftime("%Y-%m-%d %H
 data[0].append(utc_time)
 headers.append('UTC Time')
 
-data[0].append(f'{math.degrees(opts.ra):.3f}')
-headers.append('R.A. (deg)')
+if opts.input_dist != None:
+    input_dist = eval('pycbc.distributions.' + opts.input_dist)
+    data[0].append(f'{math.degrees(input_dist.get_max_prob_point()[0]):.3f}')
+    headers.append('R.A. (deg)')
 
-data[0].append(f'{math.degrees(opts.dec):.3f}')
-headers.append('Dec (deg)')
+    data[0].append(f'{math.degrees(input_dist.get_max_prob_point()[1]):.3f}')
+    headers.append('Dec (deg)')
 
-data[0].append(f'{math.degrees(opts.sky_error):.3f}')
-headers.append('Sky Error (deg)')
+else:
+    data[0].append(f'{math.degrees(opts.ra):.3f}')
+    headers.append('R.A. (deg)')
+
+    data[0].append(f'{math.degrees(opts.dec):.3f}')
+    headers.append('Dec (deg)')
+
+    data[0].append(f'{math.degrees(opts.sky_error):.3f}')
+    headers.append('Sky Error (deg)')
 
 data[0].append(ppdets(opts.ifos, ''))
 headers.append('IFOs')


### PR DESCRIPTION
Adding a new argument to `pycbc_pygrb_grb_info_table` to make it work with #5085.

## Standard information about the request.

This is a new implementation to make `pycbc_pygrb_grb_info_table`  work with #5085.

This change affects PyGRB workflows.

This change changes plotting grb information.

## Motivation
PyGRB workflow will not be able to work if this change is not merged, `pycbc_pygrb_grb_info_table` only takes as input ra dec and sky-error, where with #5085 you can generate a sky grid without giving ra dec and sky error but only giving an input distribution. We need to add an argument that takes input distribution in account. 

## Contents
Only few Ifs statements and a new argument input_dist.

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
