### PR TITLE
Add lfs resolution to resolve_url gitlab helper

### DIFF
--- a/pycbc/workflow/configuration.py
+++ b/pycbc/workflow/configuration.py
@@ -125,7 +125,7 @@ def resolve_url_http(url, u, filename):
         # URL format. As a different approach, we could rely on the gitlab
         # Python module to (arguably) make this more robust. For now I prefer
         # to avoid adding one more dependency, and stick with ciecplib.
-        url = f'https://git.ligo.org/api/v4/projects/{project}/repository/files/{file_path}/raw?ref={ref}'
+        url = f'https://git.ligo.org/api/v4/projects/{project}/repository/files/{file_path}/raw?ref={ref}&lfs=true'
         # Get the user's Personal Access Token and pass it as a header
         xdg_config_home = (
             os.environ.get('XDG_CONFIG_HOME') or os.path.expanduser('~/.config')


### PR DESCRIPTION
Equivalent of #5135, but I didn't realise this was on master as well, I thought it was only the v23 release branch, this is also needed on v28 release branch

We noticed that files under git-lfs did not work with the reworked resolve_url

Adding `&lfs=true` seems to make the gitlab download helper work for lfs files _as well as_ non-lfs files still working

Tested by using resolve_url to download both lfs and non-lfs files