### PR TITLE
np.fromstring deprecated in favour of np.frombuffer for bytes

### DIFF
--- a/pycbc/waveform/bank.py
+++ b/pycbc/waveform/bank.py
@@ -204,7 +204,7 @@ def tuple_to_hash(tuple_to_be_hashed):
     """
     h = hashlib.blake2b(np.array(tuple_to_be_hashed).tobytes('C'),
                         digest_size=8)
-    return np.fromstring(h.digest(), dtype=int)[0]
+    return np.frombuffer(h.digest(), dtype=int)[0]
 
 
 class TemplateBank(object):


### PR DESCRIPTION
Getting failures in PRs and I think its caused by this


## Standard information about the request

This is a bug fix
This change touches all areas, but hopefully affects nothing

This change: follows style guidelines (See e.g. [PEP8](https://peps.python.org/pep-0008/)), has been proposed using the [contribution guidelines](https://github.com/gwastro/pycbc/blob/master/CONTRIBUTING.md)

## Motivation
Fixes failure in test suite

## Contents
fromstring is no longer used for bytes strings, this should use frombuffer instead

## Testing performed
I couldn't reproduce the error locally, so this should test it


- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
