### PR TITLE
Make the generation of the skygrid in `pycbc_make_offline_grb_workflow` more flexible

### DIFF
--- a/bin/pygrb/pycbc_make_offline_grb_workflow
+++ b/bin/pygrb/pycbc_make_offline_grb_workflow
@@ -274,7 +274,7 @@ for ifo in ifos:
 
 # Generate sky grid if needed
 skygrid_file = None
-if wflow.cp.has_option("workflow", "sky-error"):
+if wflow.cp.has_option("workflow", "sky-error") or wflow.cp.has_option("workflow", "input-dist"):
     logging.info("Generating sky-grid file.")
     skygrid_file = _workflow.make_skygrid_node(wflow, df_dir, tags=['SEARCH'])
     input_files.extend(skygrid_file)


### PR DESCRIPTION
Adding input-dist variable in check of the workflow section for the generation of the sky grid
## Standard information about the request

<!--- Some basic info about the change (delete as appropriate) -->
This is a new feature

This change affects PyGRB

This change changes PyGRB's workflow generation

## Motivation
In order to use the new implementation of the skygrid generator (#5085) we need to make this check of the workflow section more flexible with a new check with the variable `input-dist`.

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
