### PR TITLE
Support for pegasus v5.1.1

### DIFF
--- a/.github/workflows/bank-compress-workflow.yml
+++ b/.github/workflows/bank-compress-workflow.yml
@@ -28,9 +28,9 @@ jobs:
     - name: install pegasus
       run: |
         wget -qO - https://download.pegasus.isi.edu/pegasus/gpg.txt | sudo apt-key add -
-        echo "deb https://download.pegasus.isi.edu/pegasus/ubuntu bionic main" | sudo tee -a /etc/apt/sources.list
+        echo "deb https://download.pegasus.isi.edu/pegasus/ubuntu noble main" | sudo tee -a /etc/apt/sources.list
         sudo apt-get -o Acquire::Retries=3 update
-        sudo apt-get -o Acquire::Retries=3 install pegasus=5.1.1-1+ubuntu18
+        sudo apt-get -o Acquire::Retries=3 install pegasus=5.1.1-1+ubuntu24
     - run: sudo apt-get -o Acquire::Retries=3 install *fftw3* intel-mkl*
     - name: Install pycbc
       run: |

--- a/.github/workflows/bank-compress-workflow.yml
+++ b/.github/workflows/bank-compress-workflow.yml
@@ -30,7 +30,7 @@ jobs:
         wget -qO - https://download.pegasus.isi.edu/pegasus/gpg.txt | sudo apt-key add -
         echo "deb https://download.pegasus.isi.edu/pegasus/ubuntu bionic main" | sudo tee -a /etc/apt/sources.list
         sudo apt-get -o Acquire::Retries=3 update
-        sudo apt-get -o Acquire::Retries=3 install pegasus=5.0.8-1+ubuntu18
+        sudo apt-get -o Acquire::Retries=3 install pegasus=5.1.1-1+ubuntu18
     - run: sudo apt-get -o Acquire::Retries=3 install *fftw3* intel-mkl*
     - name: Install pycbc
       run: |

--- a/.github/workflows/inference-workflow.yml
+++ b/.github/workflows/inference-workflow.yml
@@ -23,9 +23,9 @@ jobs:
     - name: install pegasus
       run: |
         wget -qO - https://download.pegasus.isi.edu/pegasus/gpg.txt | sudo apt-key add -
-        echo "deb https://download.pegasus.isi.edu/pegasus/ubuntu bionic main" | sudo tee -a /etc/apt/sources.list
+        echo "deb https://download.pegasus.isi.edu/pegasus/ubuntu noble main" | sudo tee -a /etc/apt/sources.list
         sudo apt-get -o Acquire::Retries=3 update
-        sudo apt-get -o Acquire::Retries=3 install pegasus=5.1.1-1+ubuntu18
+        sudo apt-get -o Acquire::Retries=3 install pegasus=5.1.1-1+ubuntu24
     - run: sudo apt-get -o Acquire::Retries=3 install *fftw3* intel-mkl*
     - name: Install pycbc
       run: |

--- a/.github/workflows/inference-workflow.yml
+++ b/.github/workflows/inference-workflow.yml
@@ -25,7 +25,7 @@ jobs:
         wget -qO - https://download.pegasus.isi.edu/pegasus/gpg.txt | sudo apt-key add -
         echo "deb https://download.pegasus.isi.edu/pegasus/ubuntu bionic main" | sudo tee -a /etc/apt/sources.list
         sudo apt-get -o Acquire::Retries=3 update
-        sudo apt-get -o Acquire::Retries=3 install pegasus=5.0.8-1+ubuntu18
+        sudo apt-get -o Acquire::Retries=3 install pegasus=5.1.1-1+ubuntu18
     - run: sudo apt-get -o Acquire::Retries=3 install *fftw3* intel-mkl*
     - name: Install pycbc
       run: |

--- a/.github/workflows/search-workflow.yml
+++ b/.github/workflows/search-workflow.yml
@@ -28,9 +28,9 @@ jobs:
     - name: install pegasus
       run: |
         wget -qO - https://download.pegasus.isi.edu/pegasus/gpg.txt | sudo apt-key add -
-        echo "deb https://download.pegasus.isi.edu/pegasus/ubuntu bionic main" | sudo tee -a /etc/apt/sources.list
+        echo "deb https://download.pegasus.isi.edu/pegasus/ubuntu noble main" | sudo tee -a /etc/apt/sources.list
         sudo apt-get -o Acquire::Retries=3 update
-        sudo apt-get -o Acquire::Retries=3 install pegasus=5.1.1-1+ubuntu18
+        sudo apt-get -o Acquire::Retries=3 install pegasus=5.1.1-1+ubuntu24
     - run: sudo apt-get -o Acquire::Retries=3 install *fftw3* intel-mkl*
     - name: Install pycbc
       run: |

--- a/.github/workflows/search-workflow.yml
+++ b/.github/workflows/search-workflow.yml
@@ -30,7 +30,7 @@ jobs:
         wget -qO - https://download.pegasus.isi.edu/pegasus/gpg.txt | sudo apt-key add -
         echo "deb https://download.pegasus.isi.edu/pegasus/ubuntu bionic main" | sudo tee -a /etc/apt/sources.list
         sudo apt-get -o Acquire::Retries=3 update
-        sudo apt-get -o Acquire::Retries=3 install pegasus=5.0.8-1+ubuntu18
+        sudo apt-get -o Acquire::Retries=3 install pegasus=5.1.1-1+ubuntu18
     - run: sudo apt-get -o Acquire::Retries=3 install *fftw3* intel-mkl*
     - name: Install pycbc
       run: |

--- a/.github/workflows/tmpltbank-workflow.yml
+++ b/.github/workflows/tmpltbank-workflow.yml
@@ -29,7 +29,7 @@ jobs:
         wget -qO - https://download.pegasus.isi.edu/pegasus/gpg.txt | sudo apt-key add -
         echo "deb https://download.pegasus.isi.edu/pegasus/ubuntu bionic main" | sudo tee -a /etc/apt/sources.list
         sudo apt-get -o Acquire::Retries=3 update
-        sudo apt-get -o Acquire::Retries=3 install pegasus=5.0.8-1+ubuntu18
+        sudo apt-get -o Acquire::Retries=3 install pegasus=5.1.1-1+ubuntu18
     - run: sudo apt-get -o Acquire::Retries=3 install *fftw3* intel-mkl*
     - name: Install pycbc
       run: |

--- a/.github/workflows/tmpltbank-workflow.yml
+++ b/.github/workflows/tmpltbank-workflow.yml
@@ -27,9 +27,9 @@ jobs:
     - name: install pegasus
       run: |
         wget -qO - https://download.pegasus.isi.edu/pegasus/gpg.txt | sudo apt-key add -
-        echo "deb https://download.pegasus.isi.edu/pegasus/ubuntu bionic main" | sudo tee -a /etc/apt/sources.list
+        echo "deb https://download.pegasus.isi.edu/pegasus/ubuntu noble main" | sudo tee -a /etc/apt/sources.list
         sudo apt-get -o Acquire::Retries=3 update
-        sudo apt-get -o Acquire::Retries=3 install pegasus=5.1.1-1+ubuntu18
+        sudo apt-get -o Acquire::Retries=3 install pegasus=5.1.1-1+ubuntu24
     - run: sudo apt-get -o Acquire::Retries=3 install *fftw3* intel-mkl*
     - name: Install pycbc
       run: |

--- a/.github/workflows/workflow-tests.yml
+++ b/.github/workflows/workflow-tests.yml
@@ -32,9 +32,9 @@ jobs:
     - name: install pegasus
       run: |
         wget -qO - https://download.pegasus.isi.edu/pegasus/gpg.txt | sudo apt-key add -
-        echo "deb https://download.pegasus.isi.edu/pegasus/ubuntu bionic main" | sudo tee -a /etc/apt/sources.list
+        echo "deb https://download.pegasus.isi.edu/pegasus/ubuntu noble main" | sudo tee -a /etc/apt/sources.list
         sudo apt-get -o Acquire::Retries=3 update
-        sudo apt-get -o Acquire::Retries=3 install pegasus=5.1.1-1+ubuntu18
+        sudo apt-get -o Acquire::Retries=3 install pegasus=5.1.1-1+ubuntu24
     - run: sudo apt-get -o Acquire::Retries=3 install *fftw3* intel-mkl*
     - name: Install pycbc
       run: |

--- a/.github/workflows/workflow-tests.yml
+++ b/.github/workflows/workflow-tests.yml
@@ -34,7 +34,7 @@ jobs:
         wget -qO - https://download.pegasus.isi.edu/pegasus/gpg.txt | sudo apt-key add -
         echo "deb https://download.pegasus.isi.edu/pegasus/ubuntu bionic main" | sudo tee -a /etc/apt/sources.list
         sudo apt-get -o Acquire::Retries=3 update
-        sudo apt-get -o Acquire::Retries=3 install pegasus=5.0.8-1+ubuntu18
+        sudo apt-get -o Acquire::Retries=3 install pegasus=5.1.1-1+ubuntu18
     - run: sudo apt-get -o Acquire::Retries=3 install *fftw3* intel-mkl*
     - name: Install pycbc
       run: |

--- a/bin/pycbc_submit_dax
+++ b/bin/pycbc_submit_dax
@@ -126,7 +126,7 @@ echo
 rm -f submitdir
 ln -sf $SUBMIT_DIR submitdir
 
-echo "pegasus-status --verbose --long $SUBMIT_DIR/work \$@" > status
+echo "pegasus-status --long $SUBMIT_DIR/work \$@" > status
 chmod 755 status
 
 echo "pegasus-analyzer -r -v $SUBMIT_DIR/work \$@" > debug

--- a/pycbc/workflow/pegasus_workflow.py
+++ b/pycbc/workflow/pegasus_workflow.py
@@ -737,7 +737,7 @@ class Workflow(object):
 
         with open('debug', 'w') as fp:
             fp.write('export PEGASUS_UPDATE_PYTHONPATH=0; pegasus-analyzer -r ')
-            fp.write(f'-v {submitdir}/work $@'))
+            fp.write(f'-v {submitdir}/work $@')
 
         with open('stop', 'w') as fp:
             fp.write('export PEGASUS_UPDATE_PYTHONPATH=0; pegasus-remove ')

--- a/pycbc/workflow/pegasus_workflow.py
+++ b/pycbc/workflow/pegasus_workflow.py
@@ -724,22 +724,28 @@ class Workflow(object):
         #        file. This is overridden for subworkflows, but is not for
         #        main workflows with submit_dax. If we ever remove submit_dax
         #        we should include the location explicitly here.
+
+        # Need to set this to avoid pegasus pulling in other environment
+        os.environ['PEGASUS_UPDATE_PYTHONPATH'] = '0'
+
         self._adag.plan(**planner_args)
 
         # Set up convenience scripts
         with open('status', 'w') as fp:
-            fp.write('pegasus-status --verbose ')
-            fp.write('--long {}/work $@'.format(submitdir))
+            fp.write('export PEGASUS_UPDATE_PYTHONPATH=0; pegasus-status ')
+            fp.write(f'--long {submitdir}/work $@')
 
         with open('debug', 'w') as fp:
-            fp.write('pegasus-analyzer -r ')
-            fp.write('-v {}/work $@'.format(submitdir))
+            fp.write('export PEGASUS_UPDATE_PYTHONPATH=0; pegasus-analyzer -r ')
+            fp.write(f'-v {submitdir}/work $@'))
 
         with open('stop', 'w') as fp:
-            fp.write('pegasus-remove {}/work $@'.format(submitdir))
+            fp.write('export PEGASUS_UPDATE_PYTHONPATH=0; pegasus-remove ')
+            fp.write(f'{submitdir}/work $@')
 
         with open('start', 'w') as fp:
-            fp.write('pegasus-run {}/work $@'.format(submitdir))
+            fp.write('export PEGASUS_UPDATE_PYTHONPATH=0; pegasus-run ')
+            fp.write(f'{submitdir}/work $@')
 
         os.chmod('status', 0o755)
         os.chmod('debug', 0o755)

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,10 @@ gwdatafind>=1.1.3
 # Requirements for full pegasus env
 # https://pegasus.isi.edu/documentation/user-guide/installation.html#mixing-environments-system-venv-conda
 # six is listed, but is now not needed.
-pegasus-wms.api >= 5.0.8
+pegasus-wms >= 5.1.1
+pegasus-wms.api >= 5.1.1
+pegasus-wms.common >= 5.1.1
+pegasus-wms.worker >= 5.1.1
 boto3
 certifi
 GitPython

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ install_requires = setup_requires + [
     'tqdm',
     'setuptools',
     'gwdatafind',
-    'pegasus-wms.api >= 5.0.8',
+    'pegasus-wms.api >= 5.1.1',
     # FIXME igwn-ligolw 2.1.0 + lalsuite 7.25.1 produce errors arising from the
     # old python-ligo-lw module. Remove pin when we have moved to a lalsuite
     # that no longer depends on python-ligo-lw.


### PR DESCRIPTION
Move PyCBC to the pegasus v5.1.X series, implementing what was discussed here https://github.com/gwastro/pycbc/issues/5116.

## Standard information about the request

This is a: dependency update

This change affects: all workflows

This change changes: workflows

This change: has appropriate unit tests, follows style guidelines (See e.g. [PEP8](https://peps.python.org/pep-0008/)), has been proposed using the [contribution guidelines](https://github.com/gwastro/pycbc/blob/master/CONTRIBUTING.md)

This change will: there's some minor incompatibility between pegasus 5.0.X and 5.1.X, so this will not work if using 5.0.X

## Motivation

We want to move to pegasus v5.1.X series. This fixes https://github.com/gwastro/pycbc/issues/5020 and marks a new minor version release for pegasus.

## Contents

* Remove the `--verbose`  option from `./status`
* Enforce all workflows use `PEGASUS_UPDATE_PYTHONPATH=0` to avoid python version mismatches, which were happening with pegasus 5.0.X ... We've been moving to fix this throughout the 5.0.X series, and 5.0.8 included a lot of this. However, there's been enough issues with trying to use stuff installed systemwide, that I want to enforce this now (for e.g. pegasus-plan may not run unless you do this, depending on python versions at the system level and in your environment). This will require us installed *all* the pegasus packages, so requirements are updated.

## Links to any issues or associated PRs

https://github.com/gwastro/pycbc/issues/5116

## Testing performed

I've ran a full workflow on pegasus 5.1.X using this.

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
