### PR TITLE
Substituting scatterplots with hexbins where possible

### DIFF
--- a/bin/pygrb/pycbc_pygrb_plot_chisq_veto
+++ b/bin/pygrb/pycbc_pygrb_plot_chisq_veto
@@ -154,9 +154,11 @@ if opts.plot_title is None:
     else:
         opts.plot_title += f" vs {snr_type.capitalize()} SNR"
 if opts.plot_caption is None:
-    opts.plot_caption = ("Blue crosses: background triggers. ")
     if found_missed_file:
-        opts.plot_caption += "Red crosses: injections triggers. "
+        opts.plot_caption = "Blue crosses: background triggers. "\
+            "Red crosses: injections triggers. "
+    else:
+        opts.plot_caption = "Distribution of background triggers. "
     if veto_type == 'network':
         opts.plot_caption += ("Gray shaded region: area cut by the " +
                               "reweighted SNR threshold. " +

--- a/bin/pygrb/pycbc_pygrb_plot_null_stats
+++ b/bin/pygrb/pycbc_pygrb_plot_null_stats
@@ -111,10 +111,11 @@ y_labels = {'null': "Null SNR",
 if opts.plot_title is None:
     opts.plot_title = y_labels[opts.y_variable] + " vs Coherent SNR"
 if opts.plot_caption is None:
-    opts.plot_caption = ("Blue crosses: background triggers.  ")
     if found_missed_file:
-        opts.plot_caption = opts.plot_caption +\
-                            ("Red crosses: injections triggers.  ")
+        opts.plot_caption = "Blue crosses: background triggers.  "\
+            "Red crosses: injections triggers.  "
+    else:
+        opts.plot_caption = "Distribution of background triggers.  "
 
     if opts.y_variable == 'coincident':
         opts.plot_caption += ("Green line: coincident SNR = coherent SNR.")

--- a/bin/pygrb/pycbc_pygrb_plot_snr_timeseries
+++ b/bin/pygrb/pycbc_pygrb_plot_snr_timeseries
@@ -214,10 +214,13 @@ y_label = y_labels[snr_type]
 # Determine title and caption
 if opts.plot_title is None:
     opts.plot_title = y_label + " vs Time"
-if opts.plot_caption is None:
-    opts.plot_caption = ("Blue crosses: background triggers.  ")
-    if inj_file:
-        opts.plot_caption += ("Red crosses: injections triggers.")
+if inj_file:
+    if opts.plot_caption is None:
+        opts.plot_caption = ("Blue crosses: background triggers.  "\
+            "Red crosses: injections triggers.")
+else:
+    if opts.plot_caption is None:
+        opts.plot_caption = ("Distribution of background triggers.")
 
 # Single IFO SNR versus time plots
 if not opts.x_lims:

--- a/bin/pygrb/pycbc_pygrb_plot_snr_timeseries
+++ b/bin/pygrb/pycbc_pygrb_plot_snr_timeseries
@@ -214,12 +214,12 @@ y_label = y_labels[snr_type]
 # Determine title and caption
 if opts.plot_title is None:
     opts.plot_title = y_label + " vs Time"
-if inj_file:
-    if opts.plot_caption is None:
+
+if opts.plot_caption is None:
+    if inj_file:
         opts.plot_caption = ("Blue crosses: background triggers.  "\
             "Red crosses: injections triggers.")
-else:
-    if opts.plot_caption is None:
+    else:
         opts.plot_caption = ("Distribution of background triggers.")
 
 # Single IFO SNR versus time plots

--- a/pycbc/results/pygrb_plotting_utils.py
+++ b/pycbc/results/pygrb_plotting_utils.py
@@ -191,15 +191,48 @@ def pygrb_plotter(trigs, injs, xlabel, ylabel, opts,
                   colors=None, vert_spike=False, cmd=None):
     """Master function to plot PyGRB results"""
     from matplotlib import pyplot as plt
+    import matplotlib
 
     # Set up plot
     fig = plt.figure()
     cax = fig.gca()
+    # Axes: labels and limits
+    cax.set_xlabel(xlabel)
+    cax.set_ylabel(ylabel)
+    if opts.x_lims:
+        x_lims = map(float, opts.x_lims.split(','))
+        cax.set_xlim(x_lims)
+    if opts.y_lims:
+        y_lims = map(float, opts.y_lims.split(','))
+        cax.set_ylim(y_lims)
     # Plot trigger-related and (if present) injection-related quantities
-    cax_plotter = cax.loglog if opts.use_logs else cax.plot
-    cax_plotter(trigs[0], trigs[1], 'bx')
-    if not (injs[0] is None and injs[1] is None):
+    if (injs[0] is None and injs[1] is None) or \
+        (len(injs[0]) == 0 and len(injs[1]) == 0):
+        scales = ['log', 'log'] if opts.use_logs else ['linear', 'linear']
+        ## Necessary trick to avoid artifacts
+        xmin, xmax = cax.get_xlim()
+        if not isinstance(trigs[0], numpy.ndarray):
+            trigs[0] = numpy.array(trigs[0])
+        if not isinstance(trigs[1], numpy.ndarray):
+            trigs[1] = numpy.array(trigs[1])
+        mask = (trigs[0] >= xmin) & (trigs[0] <= xmax)
+        norm = matplotlib.colors.LogNorm()
+        gsize = 300
+        if mask.sum() == 0:
+            ## Necessary to make plot appear even in absence of points
+            norm = matplotlib.colors.LogNorm(vmin=1, vmax=10)
+        elif mask.sum() < 100:
+            gsize = 100  
+        ax = cax.hexbin(trigs[0][mask], trigs[1][mask], gridsize=gsize, xscale=scales[0],
+                        yscale=scales[1], lw=0.04, mincnt=1,
+                        norm=norm, zorder=2)
+        cb = plt.colorbar(ax)
+        cb.set_label('Trigger Density')
+    else:
+        cax_plotter = cax.loglog if opts.use_logs else cax.plot
+        cax_plotter(trigs[0], trigs[1], 'bx')
         cax_plotter(injs[0], injs[1], 'r+')
+        
     cax.grid()
     # Plot contours
     if conts is not None:
@@ -212,15 +245,6 @@ def pygrb_plotter(trigs, injs, xlabel, ylabel, opts,
         polyx = numpy.append(polyx, [max(snr_vals), min(snr_vals)])
         polyy = numpy.append(polyy, [limy, limy])
         cax.fill(polyx, polyy, color='#dddddd')
-    # Axes: labels and limits
-    cax.set_xlabel(xlabel)
-    cax.set_ylabel(ylabel)
-    if opts.x_lims:
-        x_lims = map(float, opts.x_lims.split(','))
-        cax.set_xlim(x_lims)
-    if opts.y_lims:
-        y_lims = map(float, opts.y_lims.split(','))
-        cax.set_ylim(y_lims)
     # Wrap up
     plt.tight_layout()
     save_fig_with_metadata(fig, opts.output_file, cmd=cmd,


### PR DESCRIPTION
In cases where many points are displayed as crosses the plots become crowded. This change those scatter plots into hexbins.

This change affects: PyGRB plotting

This change changes: plotting

Please see [this](https://ldas-jobs.ligo.caltech.edu/~marco.cusinato/LVK/GRB231117A_3/2._signal_consistency/2.01_chi_squared_tests/)