### PR TITLE
Avoid some python-ligo-lw releases in sbank

### DIFF
--- a/.github/workflows/bank-compress-workflow.yml
+++ b/.github/workflows/bank-compress-workflow.yml
@@ -40,7 +40,7 @@ jobs:
         pip install .
     - name: installing sbank
       run: |
-        pip install sbank
+        pip install sbank "python-ligo-lw!=2.2.0,!=2.1.0,!=2.0.0,!=1.8.4"
     - name: generating template bank
       run: bash -e examples/search/bank.sh
     - name: running workflow

--- a/.github/workflows/tmpltbank-workflow.yml
+++ b/.github/workflows/tmpltbank-workflow.yml
@@ -36,7 +36,7 @@ jobs:
         python -m pip install --upgrade pip setuptools
         pip install GitPython # This shouldn't really be needed!
         pip install -r requirements.txt
-        pip install sbank
+        pip install sbank "python-ligo-lw!=2.2.0,!=2.1.0,!=2.0.0,!=1.8.4"
         pip install .
     - name: generating, submitting and running workflow
       env:


### PR DESCRIPTION
As suggested by @raffienficiaud

This should install sbank for the tests avoiding a few problematic releases in python-ligo-lw, which will then allow us to perform a release. We can then remove this when sbank gets rid of the python-ligo-lw dependency

## Standard information about the request

This is a bug workaround
This change changes bank CI tests
This change has been proposed using the [contribution guidelines](https://github.com/gwastro/pycbc/blob/master/CONTRIBUTING.md)


- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
