### PR TITLE
Remove SNR triggers not close to injection with injfilterrejector

### DIFF
--- a/bin/pycbc_multi_inspiral
+++ b/bin/pycbc_multi_inspiral
@@ -724,9 +724,6 @@ with ctx:
                 ), f'SNR time series for {ifo} is empty'
                 norm_dict[ifo] = norm
                 corr_dict[ifo] = corr.copy()
-                # change to integer indexes because we will have to do
-                # arithmetic with time_delay_idx, which can be positive
-                # or negative
                 idx[ifo] = ind
                 snr[ifo] = snrv * norm
                 # Initialize the cache for power chi^2

--- a/bin/pycbc_multi_inspiral
+++ b/bin/pycbc_multi_inspiral
@@ -700,6 +700,22 @@ with ctx:
                 ].matched_filter_and_cluster(
                     s_num, template.sigmasq(stilde[ifo].psd), window=0
                 )
+                # change to integer indexes because we will have to do
+                # arithmetic with time_delay_idx, which can be positive
+                # or negative
+                ind = ind.astype(np.int32)
+                if inj_filter_rejector[ifo].enabled:
+                    trig_times = (
+                        (ind + stilde[ifo].cumulative_index) /
+                        snr_ts.sample_rate +
+                        args.gps_start_time[ifo]
+                    )
+                    inj_idxs = inj_filter_rejector[ifo].find_indices_in_injection_intervals(
+                        trig_times
+                    )
+                    ind = ind[inj_idxs]
+                    snrv = snrv[inj_idxs]
+
                 snr_dict[ifo] = (
                     snr_ts[matched_filter[ifo].segments[s_num].analyze] * norm
                 )
@@ -711,7 +727,7 @@ with ctx:
                 # change to integer indexes because we will have to do
                 # arithmetic with time_delay_idx, which can be positive
                 # or negative
-                idx[ifo] = ind.astype(np.int32)
+                idx[ifo] = ind
                 snr[ifo] = snrv * norm
                 # Initialize the cache for power chi^2
                 power_chisq_arrays[ifo] = np.full(

--- a/pycbc/inject/injfilterrejector.py
+++ b/pycbc/inject/injfilterrejector.py
@@ -181,8 +181,7 @@ class InjFilterRejector(object):
         ):
             self.enabled = False
             return
-        else:
-            self.enabled = True
+        self.enabled = True
 
         # Store parameters
         self.chirp_time_window = chirp_time_window

--- a/pycbc/inject/injfilterrejector.py
+++ b/pycbc/inject/injfilterrejector.py
@@ -34,56 +34,67 @@ from pycbc.pnutils import mass1_mass2_to_tau0_tau3
 from pycbc.types import FrequencySeries, zeros
 from pycbc.types import MultiDetOptionAction
 
-_injfilterrejector_group_help = \
-    ("Options that, if injections are present in "
-     "this run, are responsible for performing pre-checks between injections "
-     "in the data being filtered and the current search template to determine "
-     "if the template has any chance of actually detecting the injection. "
-     "The parameters of this test are given by the various options below. "
-     "The --injection-filter-rejector-chirp-time-window and "
-     "--injection-filter-rejector-match-threshold options need to be provided "
-     "if those tests are desired. Other options will take default values "
-     "unless overriden. More details on these options follow.")
-
-_injfilterer_cthresh_help = \
-    ("If this value is not None and an "
-     "injection file is given then we will calculate the difference in "
-     "chirp time (tau_0) between the template and each injection in the "
-     "analysis segment. If the difference is greate than this threshold for "
-     "all injections then filtering is not performed. By default this will "
-     "be None.")
-_injfilterer_mthresh_help = \
-    ("If this value is not None and an "
-     "injection file is provided then we will calculate a 'coarse match' "
-     "between the template and each injection in the analysis segment. If the "
-     "match is less than this threshold for all injections then filtering is "
-     "not performed. Parameters for the 'coarse match' follow. By default "
-     "this value will be None.")
-_injfilterer_deltaf_help = \
-    ("If injections are present and a match threshold is "
-     "provided, this option specifies the frequency spacing that will be used "
-     "for injections, templates and PSD when computing the 'coarse match'. "
-     "Templates will be generated directly with this spacing. The PSD and "
-     "injections will be resampled.")
-_injfilterer_fmax_help = \
-    ("If injections are present and a match threshold is "
-     "provided, this option specifies the maximum frequency that will be used "
-     "for injections, templates and PSD when computing the 'coarse match'. "
-     "Templates will be generated directly with this max frequency. The PSD "
-     "and injections' frequency series will be truncated.")
-_injfilterer_buffer_help = \
-    ("If injections are present and either a match "
-     "threshold or a chirp-time window is given, we will determine if "
-     "injections are 'in' the specified analysis chunk by using the end "
-     "times. If this value is non-zero the analysis chunk is extended on both "
-     "sides by this amount before determining if injections are within the "
-     "given window.")
-_injfilterer_flower_help = \
-    ("If injections are present and either a match "
-     "threshold or a chirp-time window is given, this value is used to set "
-     "the lower frequency for determine chirp times or for calculating "
-     "matches. If this value is None the lower frequency used for the full "
-     "matched-filter is used. Otherwise this value is used.")
+_injfilterrejector_group_help = (
+    "Options that, if injections are present in "
+    "this run, are responsible for performing pre-checks between injections "
+    "in the data being filtered and the current search template to determine "
+    "if the template has any chance of actually detecting the injection. "
+    "The parameters of this test are given by the various options below. "
+    "The --injection-filter-rejector-chirp-time-window and "
+    "--injection-filter-rejector-match-threshold options need to be provided "
+    "if those tests are desired. Other options will take default values "
+    "unless overriden. More details on these options follow."
+)
+_injfilterer_cthresh_help = (
+    "If this value is not None and an "
+    "injection file is given then we will calculate the difference in "
+    "chirp time (tau_0) between the template and each injection in the "
+    "analysis segment. If the difference is greate than this threshold for "
+    "all injections then filtering is not performed. By default this will "
+    "be None."
+)
+_injfilterer_mthresh_help = (
+    "If this value is not None and an "
+    "injection file is provided then we will calculate a 'coarse match' "
+    "between the template and each injection in the analysis segment. If the "
+    "match is less than this threshold for all injections then filtering is "
+    "not performed. Parameters for the 'coarse match' follow. By default "
+    "this value will be None."
+)
+_injfilterer_deltaf_help = (
+    "If injections are present and a match threshold is "
+    "provided, this option specifies the frequency spacing that will be used "
+    "for injections, templates and PSD when computing the 'coarse match'. "
+    "Templates will be generated directly with this spacing. The PSD and "
+    "injections will be resampled."
+)
+_injfilterer_fmax_help = (
+    "If injections are present and a match threshold is "
+    "provided, this option specifies the maximum frequency that will be used "
+    "for injections, templates and PSD when computing the 'coarse match'. "
+    "Templates will be generated directly with this max frequency. The PSD "
+    "and injections' frequency series will be truncated."
+)
+_injfilterer_buffer_help = (
+    "If injections are present and either a match "
+    "threshold or a chirp-time window is given, we will determine if "
+    "injections are 'in' the specified analysis chunk by using the end "
+    "times. If this value is non-zero the analysis chunk is extended on both "
+    "sides by this amount before determining if injections are within the "
+    "given window."
+)
+_injfilterer_flower_help = (
+    "If injections are present and either a match "
+    "threshold or a chirp-time window is given, this value is used to set "
+    "the lower frequency for determine chirp times or for calculating "
+    "matches. If this value is None the lower frequency used for the full "
+    "matched-filter is used. Otherwise this value is used."
+)
+_injfilterer_trwindow_help = (
+    "After computing triggers, reject triggers that are not within this "
+    "window of injection times. This avoids doing expensive chi-squared "
+    "computation on triggers not associated with injections."
+)
 
 
 def insert_injfilterrejector_option_group(parser):
@@ -108,6 +119,9 @@ def insert_injfilterrejector_option_group(parser):
     curr_arg = "--injection-filter-rejector-f-lower"
     injfilterrejector_group.add_argument(curr_arg, type=int, default=None,
                                          help=_injfilterer_flower_help)
+    curr_arg = "--injection-filter-rejector-trigger-window"
+    injfilterrejector_group.add_argument(curr_arg, type=float, default=None,
+                                         help=_injfilterer_trwindow_help)
 
 
 def insert_injfilterrejector_option_group_multi_ifo(parser):
@@ -138,6 +152,10 @@ def insert_injfilterrejector_option_group_multi_ifo(parser):
     injfilterrejector_group.add_argument(
         curr_arg, type=int, default=None, help=_injfilterer_flower_help,
         metavar='IFO:VALUE', action=MultiDetOptionAction, nargs='+')
+    curr_arg = "--injection-filter-rejector-trigger-window"
+    injfilterrejector_group.add_argument(
+        curr_arg, type=float, default=None, help=_injfilterer_trwindow_help,
+        metavar='IFO:VALUE', action=MultiDetOptionAction, nargs='+')
 
 
 class InjFilterRejector(object):
@@ -150,11 +168,17 @@ class InjFilterRejector(object):
 
     def __init__(self, injection_file, chirp_time_window,
                  match_threshold, f_lower, coarsematch_deltaf=1.,
-                 coarsematch_fmax=256, seg_buffer=10):
+                 coarsematch_fmax=256, seg_buffer=10, inj_trigger_window=None):
         """Initialise InjFilterRejector instance."""
         # Determine if InjFilterRejector is to be enabled
-        if injection_file is None or injection_file == 'False' or\
-                (chirp_time_window is None and match_threshold is None):
+        if (
+            injection_file is None or injection_file == 'False' or
+            (
+                chirp_time_window is None and
+                match_threshold is None and
+                inj_trigger_window is None
+            )
+        ):
             self.enabled = False
             return
         else:
@@ -167,6 +191,7 @@ class InjFilterRejector(object):
         self.coarsematch_fmax = coarsematch_fmax
         self.seg_buffer = seg_buffer
         self.f_lower = f_lower
+        self.inj_trigger_window = inj_trigger_window
         assert(self.f_lower is not None)
 
         # Variables for storing arrays (reduced injections, memory
@@ -175,6 +200,8 @@ class InjFilterRejector(object):
         self._short_template_mem = None
         self._short_psd_storage = {}
         self._short_template_id = None
+        self._end_times = None
+        self._injection_intervals = None
 
     @classmethod
     def from_cli(cls, opt):
@@ -186,6 +213,7 @@ class InjFilterRejector(object):
         coarsematch_deltaf = opt.injection_filter_rejector_coarsematch_deltaf
         coarsematch_fmax = opt.injection_filter_rejector_coarsematch_fmax
         seg_buffer = opt.injection_filter_rejector_seg_buffer
+        trig_window = opt.injection_filter_rejector_trigger_window
         if opt.injection_filter_rejector_f_lower is not None:
             f_lower = opt.injection_filter_rejector_f_lower
         else:
@@ -197,7 +225,7 @@ class InjFilterRejector(object):
         return cls(injection_file, chirp_time_window, match_threshold,
                    f_lower, coarsematch_deltaf=coarsematch_deltaf,
                    coarsematch_fmax=coarsematch_fmax,
-                   seg_buffer=seg_buffer)
+                   seg_buffer=seg_buffer, inj_trigger_window=trig_window)
 
     @classmethod
     def from_cli_single_ifo(cls, opt, ifo):
@@ -210,6 +238,7 @@ class InjFilterRejector(object):
             opt.injection_filter_rejector_coarsematch_deltaf[ifo]
         coarsematch_fmax = opt.injection_filter_rejector_coarsematch_fmax[ifo]
         seg_buffer = opt.injection_filter_rejector_seg_buffer[ifo]
+        trig_window = opt.injection_filter_rejector_trigger_window[ifo]
         if opt.injection_filter_rejector_f_lower[ifo] is not None:
             f_lower = opt.injection_filter_rejector_f_lower[ifo]
         else:
@@ -221,7 +250,7 @@ class InjFilterRejector(object):
         return cls(injection_file, chirp_time_window,
                    match_threshold, f_lower,
                    coarsematch_deltaf, coarsematch_fmax,
-                   seg_buffer=seg_buffer)
+                   seg_buffer=seg_buffer, inj_trigger_window=trig_window)
 
     @classmethod
     def from_cli_multi_ifos(cls, opt, ifos):
@@ -230,6 +259,95 @@ class InjFilterRejector(object):
         for ifo in ifos:
             inj_filter_rejectors[ifo] = cls.from_cli_single_ifo(opt, ifo)
         return inj_filter_rejectors
+
+    def get_inj_end_times(self):
+        """Return a list of the injection end times."""
+        if self._end_times is None:
+            self._end_times = []
+            for inj in self.injection_params.table:
+                if isinstance(inj, np.record):
+                    # hdf format file
+                    end_time = inj['tc']
+                else:
+                    # must be an xml file originally
+                    end_time = inj.geocent_end_time + \
+                        1E-9 * inj.geocent_end_time_ns
+                self._end_times.append(end_time)
+            self._end_times = np.array(self._end_times)
+        return self._end_times
+
+    # Written together with Google Gemini
+    def precompute_injection_intervals(self):
+        """
+        Precompute and merges windows around the injections to speed up
+        determining if triggers are in injection times later.
+        """
+        window = self.inj_trigger_window
+        inj_times = self.get_inj_end_times()
+        if inj_times.size == 0:
+            return np.empty((0, 2))
+
+        # Create individual intervals
+        starts = inj_times - window
+        ends = inj_times + window
+        intervals = np.c_[starts, ends]
+
+        # Sort intervals by their start points
+        intervals = intervals[intervals[:, 0].argsort()]
+
+        merged_intervals = []
+        if intervals.shape[0] > 0:
+            current_merged_interval = intervals[0].copy()
+            for i in range(1, intervals.shape[0]):
+                if intervals[i, 0] <= current_merged_interval[1]:  # Overlap
+                    current_merged_interval[1] = max(
+                        current_merged_interval[1],
+                        intervals[i, 1]
+                    )
+                else:
+                    merged_intervals.append(current_merged_interval)
+                    current_merged_interval = intervals[i].copy()
+            merged_intervals.append(current_merged_interval) # Add the last one
+
+        return np.array(merged_intervals)
+
+    # Written together with Google Gemini
+    def find_indices_in_injection_intervals(self, trig_times):
+        """
+        Identify indices within trig_times that corresponds to times within
+        the injection intervals.
+        """
+        if not self.enabled or self.inj_trigger_window is None:
+            return slice(None) # Pythonic way to say "take all triggers"
+
+        if self._injection_intervals is None:
+            self._injection_intervals = self.precompute_injection_intervals()
+
+        merged_intervals = self._injection_intervals
+        if trig_times.size == 0 or merged_intervals.size == 0:
+            return np.array([], dtype=int)
+
+        # Initialize a boolean array to mark matching elements in trig_times
+        # This array will be True at positions where trig_times elements
+        # fall into any interval
+        is_matching = np.zeros(trig_times.shape, dtype=bool)
+
+        # Iterate through each precomputed merged interval
+        for start, end in merged_intervals:
+            # Perform a vectorized comparison for the current interval
+            # This finds all elements in trig_times that are >= start AND <= end
+            curr_interval_matches = (trig_times >= start) & (trig_times <= end)
+
+            # Use bitwise OR assignment to accumulate the matches.
+            # If an element in trig_times matches ANY of the intervals,
+            # its corresponding position in 'is_matching' will become True.
+            is_matching |= curr_interval_matches
+
+        # Get the actual indices where 'is_matching' is True
+        # numpy.where returns a tuple, we need the first element which is the array of indices
+        return is_matching
+
+
 
     def generate_short_inj_from_inj(self, inj_waveform, simulation_id):
         """Generate and a store a truncated representation of inj_waveform."""

--- a/pycbc/inject/injfilterrejector.py
+++ b/pycbc/inject/injfilterrejector.py
@@ -274,8 +274,8 @@ class InjFilterRejector(object):
     # Written together with Google Gemini
     def precompute_injection_intervals(self):
         """
-        Precompute and merges windows around the injections to speed up
-        determining if triggers are in injection times later.
+        Precompute and merge windows around the injections to speed up later
+        determination of whether triggers are within the injection times.
         """
         window = self.inj_trigger_window
         # This function returns sorted injection times

--- a/pycbc/vetoes/chisq.py
+++ b/pycbc/vetoes/chisq.py
@@ -393,7 +393,10 @@ class SingleDetPowerChisq(object):
                 if num_above > 0:
                     chisq_out[above] = _chisq
             else:
-                chisq_out = _chisq
+                if num_above == 0:
+                    chisq_out = numpy.zeros(0, dtype=numpy.float32)
+                else:
+                    chisq_out = _chisq
 
             return chisq_out, numpy.repeat(dof, len(indices))# dof * numpy.ones_like(indices)
         else:

--- a/pycbc/vetoes/chisq.py
+++ b/pycbc/vetoes/chisq.py
@@ -370,6 +370,7 @@ class SingleDetPowerChisq(object):
         """
         if self.do:
             num_above = len(indices)
+            dof = -100
             if self.snr_threshold:
                 above = abs(snrv * snr_norm) > self.snr_threshold
                 num_above = above.sum()
@@ -377,7 +378,6 @@ class SingleDetPowerChisq(object):
                 above_indices = indices[above]
                 above_snrv = snrv[above]
                 chisq_out = numpy.zeros(len(indices), dtype=numpy.float32)
-                dof = -100
             else:
                 above_indices = indices
                 above_snrv = snrv


### PR DESCRIPTION
This PR adds a new option to injfilterrejector such that triggers in the SNR timeseries that are not close to injections are rejected immediately after matchedfiltering and are not sent on the the signal-based vetoes.

This is particularly relevant for pyGRB where the chi-squared can be a dominant cost, and computing this for glitches nowhere near injections in injection runs is unnecessary. For now I only hook this up to multi_inspiral, but it can be easily attached to other inspiral front-ends as needed. Related to #5148 

## Standard information about the request

This is a: new feature, efficiency update, 

This change affects: PyGRB

This change changes: scientific output (although not meaningfully as such triggers would be later removed in post-processing anyway).

This change: follows style guidelines (See e.g. [PEP8](https://peps.python.org/pep-0008/)), has been proposed using the [contribution guidelines](https://github.com/gwastro/pycbc/blob/master/CONTRIBUTING.md)

This change will: not break current functionality, not require additional dependencies, not require a new release

## Motivation

#5148 Lays out the motivation for optimizing pyGRB. This is a part of that.

## Contents

New methods are added to injfilterrejector to do this including command-line options. This is hooked up to multi_inspiral (only) as well.

## Links to any issues or associated PRs

#5148

## Testing performed

I've tested this on the example provided in #5148 (profile will appear there shortly). Other tests welcome (but pyGRB folks need to give me unit tests if they want me to do anything extensive).

- [./] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
