### PR TITLE
Implement cached memory in eventmgr

### DIFF
--- a/pycbc/events/eventmgr.py
+++ b/pycbc/events/eventmgr.py
@@ -803,7 +803,7 @@ class EventManagerCoherent(EventManagerMultiDetBase):
         self.write_gating_info_to_hdf(f)
         # Output network stuff
         f.prefix = 'network'
-        network_events = self.network_events
+        network_events = self.network_events[:self.network_events_size]
         for col in network_events.dtype.names:
             if col == 'time_index':
                 f['end_time_gc'] = (

--- a/pycbc/events/eventmgr.py
+++ b/pycbc/events/eventmgr.py
@@ -406,7 +406,7 @@ class EventManager(object):
                 refcheck=False
             )
 
-        self.events[self._events_size:new_event_size] = (
+        self._events[self._events_size:new_event_size] = (
             self.template_events[:self.template_event_size]
         )
         self._events_size = new_event_size


### PR DESCRIPTION
This patch continues to work on optimizations on pyGRB (following #5148). This is a bit more invasive than other things. It was noticed in 5148 that resizing output arrays in `eventmgr` was a considerable cost in pyGRB. This can be fixed by implementing cached memory (rather than repeatedly using numpy.append and throwing away arrays when done). In this model we store the array (larger than the triggers stored in it) and the current valid size, and keep track of both together. Only if the number of valid triggers exceeds the size of the array do we resize and then we stick at the new size.

## Standard information about the request

This is a: efficiency update,

This change affects: the offline search, PyGRB

This change changes: output

This change: has appropriate unit tests, follows style guidelines (See e.g. [PEP8](https://peps.python.org/pep-0008/)), has been proposed using the [contribution guidelines](https://github.com/gwastro/pycbc/blob/master/CONTRIBUTING.md)

This change will: [hopefully] be transparent to the user.

## Motivation

To make pyGRB more efficient.

## Contents

We rework memory management in eventmgr for all classes.

## Links to any issues or associated PRs

#5148

## Testing performed

I've run the multi_inspiral example with this (coupled with #5153). Need to see it pass the test suite here next.


- [./ ] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
