### PR TITLE
Speed up workflow CI test

### DIFF
--- a/.github/workflows/search-workflow.yml
+++ b/.github/workflows/search-workflow.yml
@@ -10,6 +10,8 @@ jobs:
   build:
     runs-on: ubuntu-24.04
     timeout-minutes: 90
+    env:
+      PEGASUS_METRICS='false'
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python

--- a/.github/workflows/search-workflow.yml
+++ b/.github/workflows/search-workflow.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 90
     env:
-      PEGASUS_METRICS='false'
+      PEGASUS_METRICS: 'false'
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python


### PR DESCRIPTION
The test suite is currently failing because the "run small workflow" test is running for more than 90 minutes. After putting pegasus into debug mode (changing this line to "debug" for reference https://github.com/gwastro/pycbc/blob/master/pycbc/workflow/pegasus_files/pegasus-properties.conf#L4) I could see that every job is spending about 3 minutes doing some pegasus metric logging task (even though all jobs complete in seconds other than the inspirals). With many jobs this then doesn't complete.

There is a broader question of whether to disable this across the board (adding the same line into the file linked above would do that), but for now I just make the CI work again,

## Standard information about the request

This is a: Poke to make the CI work

This change affects: Only the speed of the CI

This change changes: CI

This change: has appropriate unit tests, follows style guidelines (See e.g. [PEP8](https://peps.python.org/pep-0008/)), has been proposed using the [contribution guidelines](https://github.com/gwastro/pycbc/blob/master/CONTRIBUTING.md)

This change will: fix current functionality

## Motivation

We need our test suite to run.

## Contents

Add an environment variable to turn off pegasus metric logging.

## Testing performed

Tested in another PR ... Basically if the test suite runs (and the workflow test runs in under an hour), this works.

- [./] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
