### PR TITLE
Avoid unnecessary SNR (re)normalization in `multi_inspiral`

### DIFF
--- a/bin/pycbc_multi_inspiral
+++ b/bin/pycbc_multi_inspiral
@@ -1030,8 +1030,8 @@ with ctx:
                                 template,
                                 stilde[ifo].psd,
                                 stilde[ifo],
-                                coherent_ifo_trigs[ifo] / norm_dict[ifo],
-                                norm_dict[ifo],
+                                coherent_ifo_trigs[ifo],
+                                1,  # coherent_ifo_trigs already normalized
                                 coinc_idx_det_frame[ifo]
                                 + stilde[ifo].analyze.start,
                             )
@@ -1039,11 +1039,11 @@ with ctx:
                                 ifo_out_vals['auto_chisq'],
                                 ifo_out_vals['auto_chisq_dof'],
                             ) = autochisq.values(
-                                snr_dict[ifo] / norm_dict[ifo],
+                                snr_dict[ifo],
                                 coinc_idx_det_frame[ifo],
                                 template,
                                 stilde[ifo].psd,
-                                norm_dict[ifo],
+                                1,  # snr_dict already normalized
                                 stilde=stilde[ifo],
                                 low_frequency_cutoff=flow,
                             )

--- a/bin/pycbc_multi_inspiral
+++ b/bin/pycbc_multi_inspiral
@@ -977,8 +977,8 @@ with ctx:
                         for ifo in args.instruments:
                             chisq[ifo], chisq_dof[ifo] = power_chisq.values(
                                 corr_dict[ifo],
-                                coherent_ifo_trigs[ifo] / norm_dict[ifo],
-                                norm_dict[ifo],
+                                coherent_ifo_trigs[ifo],
+                                1,  # coherent_ifo_trigs already normalized
                                 stilde[ifo].psd,
                                 coinc_idx_det_frame[ifo]
                                 + stilde[ifo].analyze.start,

--- a/bin/pycbc_multi_inspiral
+++ b/bin/pycbc_multi_inspiral
@@ -977,8 +977,8 @@ with ctx:
                         for ifo in args.instruments:
                             chisq[ifo], chisq_dof[ifo] = power_chisq.values(
                                 corr_dict[ifo],
-                                coherent_ifo_trigs[ifo],
-                                1,  # coherent_ifo_trigs already normalized
+                                coherent_ifo_trigs[ifo] / norm_dict[ifo],
+                                norm_dict[ifo],
                                 stilde[ifo].psd,
                                 coinc_idx_det_frame[ifo]
                                 + stilde[ifo].analyze.start,

--- a/bin/pycbc_multi_inspiral
+++ b/bin/pycbc_multi_inspiral
@@ -562,7 +562,7 @@ with ctx:
         'bank_chisq': None,
         'bank_chisq_dof': None,
         'auto_chisq': None,
-        'auto_chisq_dof': int,
+        'auto_chisq_dof': None,
         'slide_id': None,
     }
     ifo_names = sorted(ifo_out_vals.keys())


### PR DESCRIPTION
`pycbc_multi_inspiral` is unnecessarily un-normalizing the SNRs in preparation for the chi^2 calculations.

## Standard information about the request

This is an efficiency update.

This change affects PyGRB.

This change should not affect any result, just code speed.

## Motivation

In #5148, @spxiwh realized that `pycbc_multi_inspiral` is spending a relatively large amount of time doing array divisions. Indeed, in the inner loop over sky points, the SNRs are un-normalized before being passed to the chi^2 calculations, *even when those calculations are disabled*. This is not a huge problem compared to other inefficiencies, but of the various optimizations discussed in #5148, this is the most straightforward one by far.

## Contents

On a close inspection of the chi^2 codes, I realized that the corresponding `value()` methods have really no reason to take the un-normalized SNRs and the normalization factor separately, since all they do is to simply multiply them. So here I just pass the normalized SNRs and a dummy normalization of 1.

I also took the opportunity to fix a likely typo in the initialization of `ifo_out_vals` which has been on my radar for a while.

## Links to any issues or associated PRs

#5148

## Testing performed

None yet.

## Additional notes

Out of curiosity, I had a fresh peek at how `pycbc_inspiral` calls the chi^2 calculations. It seems to me that, if one were to enable all three types of chi^2, `pycbc_inspiral` would be normalizing the same SNRs three times. Perhaps it would be more efficient to refactor the code such that the normalization is done once, before calling the chi^2 codes, and have the chi^2 codes simply take normalized SNRs.

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
