### PR TITLE
`multi_inspiral`: avoid repeated power chi^2 calculations in the critical loop

### DIFF
--- a/bin/pycbc_multi_inspiral
+++ b/bin/pycbc_multi_inspiral
@@ -990,15 +990,15 @@ with ctx:
                             # Figure out which new indices we need to calculate
                             # the chi^2 for
                             needed_idx = coinc_idx_det_frame[ifo]
-                            available_idx = np.flatnonzero(np.logical_not(np.isnan(power_chisq_arrays[ifo])))
-                            new_needed_idx = np.setdiff1d(needed_idx, available_idx)
-                            del available_idx
-                            logging.info(
-                                'Calculating power chi^2 for %s at %d new points of %d needed',
-                                ifo,
-                                len(new_needed_idx),
-                                len(needed_idx)
+                            available_idx = np.flatnonzero(
+                                np.logical_not(
+                                    np.isnan(power_chisq_arrays[ifo])
+                                )
                             )
+                            new_needed_idx = np.setdiff1d(
+                                needed_idx, available_idx
+                            )
+                            del available_idx
                             if len(new_needed_idx) > 0:
                                 new_chisq, new_chisq_dof = power_chisq.values(
                                     corr_dict[ifo],

--- a/bin/pycbc_multi_inspiral
+++ b/bin/pycbc_multi_inspiral
@@ -990,14 +990,11 @@ with ctx:
                             # Figure out which new indices we need to calculate
                             # the chi^2 for
                             needed_idx = coinc_idx_det_frame[ifo]
-                            unavailable_idx = np.flatnonzero(
-                                np.isnan(power_chisq_arrays[ifo])
+                            unavailable_mask = np.isnan(
+                                power_chisq_arrays[ifo][needed_idx]
                             )
-                            new_needed_idx = np.intersect1d(
-                                needed_idx, unavailable_idx
-                            )
-                            del unavailable_idx
-                            if new_needed_idx.size:
+                            if unavailable_mask.any():
+                                new_needed_idx = needed_idx[unavailable_mask]
                                 new_chisq, new_chisq_dof = power_chisq.values(
                                     corr_dict[ifo],
                                     snr_dict[ifo][new_needed_idx] / norm_dict[ifo],
@@ -1008,10 +1005,10 @@ with ctx:
                                 )
                                 power_chisq_arrays[ifo][new_needed_idx] = new_chisq
                                 power_chisq_dof_arrays[ifo][new_needed_idx] = new_chisq_dof
-                                del new_chisq, new_chisq_dof
+                                del new_chisq, new_chisq_dof, new_needed_idx
                             chisq[ifo] = power_chisq_arrays[ifo][needed_idx]
                             chisq_dof[ifo] = power_chisq_dof_arrays[ifo][needed_idx]
-                            del needed_idx, new_needed_idx
+                            del needed_idx, unavailable_mask
                         # Calculate network chisq value
                         network_chisq_dict = coh.network_chisq(
                             chisq, chisq_dof, coherent_ifo_trigs

--- a/bin/pycbc_multi_inspiral
+++ b/bin/pycbc_multi_inspiral
@@ -990,16 +990,14 @@ with ctx:
                             # Figure out which new indices we need to calculate
                             # the chi^2 for
                             needed_idx = coinc_idx_det_frame[ifo]
-                            available_idx = np.flatnonzero(
-                                np.logical_not(
-                                    np.isnan(power_chisq_arrays[ifo])
-                                )
+                            unavailable_idx = np.flatnonzero(
+                                np.isnan(power_chisq_arrays[ifo])
                             )
-                            new_needed_idx = np.setdiff1d(
-                                needed_idx, available_idx
+                            new_needed_idx = np.intersect1d(
+                                needed_idx, unavailable_idx
                             )
-                            del available_idx
-                            if len(new_needed_idx) > 0:
+                            del unavailable_idx
+                            if new_needed_idx.size:
                                 new_chisq, new_chisq_dof = power_chisq.values(
                                     corr_dict[ifo],
                                     snr_dict[ifo][new_needed_idx] / norm_dict[ifo],

--- a/bin/pycbc_multi_inspiral
+++ b/bin/pycbc_multi_inspiral
@@ -684,6 +684,10 @@ with ctx:
             idx = dict.fromkeys(args.instruments)
             # - The list of normalized SNR values at the trigger locations
             snr = dict.fromkeys(args.instruments)
+            # - Power chi^2 and corresponding DoF for each time sample.
+            #   Typically only a tiny fraction will be populated.
+            all_power_chisq = dict.fromkeys(args.instruments)
+            all_power_chisq_dof = dict.fromkeys(args.instruments)
             for ifo in args.instruments:
                 logging.debug(
                     "Filtering template %d/%d, ifo %s", t_num + 1, n_bank, ifo
@@ -709,6 +713,22 @@ with ctx:
                 # or negative
                 idx[ifo] = ind.astype(np.int32)
                 snr[ifo] = snrv * norm
+                logging.debug(
+                    'Calculating power chi^2 for %s on %d points',
+                    ifo,
+                    len(idx[ifo])
+                )
+                all_power_chisq[ifo] = np.zeros(len(snr_dict[ifo]), dtype=np.float32) + np.nan
+                all_power_chisq_dof[ifo] = np.zeros(len(snr_dict[ifo]), dtype=np.int32)
+                all_power_chisq[ifo][idx[ifo]], all_power_chisq_dof[ifo][idx[ifo]] = power_chisq.values(
+                    corr,
+                    snr_dict[ifo][idx[ifo]] / norm,
+                    norm,
+                    stilde[ifo].psd,
+                    idx[ifo] + stilde[ifo].analyze.start,
+                    template,
+                )
+                del snr_ts, norm, corr, ind, snrv
 
             # Move onto next segment if there are no triggers.
             n_trigs = [len(snr[ifo]) for ifo in args.instruments]
@@ -969,24 +989,22 @@ with ctx:
                             ifo: snr_dict[ifo][coinc_idx_det_frame[ifo]]
                             for ifo in args.instruments
                         }
-                        # Calculate the powerchi2 values of remaining triggers
-                        # (this uses the SNR timeseries before the time delay,
-                        # so we undo it; the same holds for normalisation)
-                        chisq = {}
-                        chisq_dof = {}
+                        # Pick up the precalculated power-chi2 values for the
+                        # remaining triggers
+                        power_chisq = {}
+                        power_chisq_dof = {}
                         for ifo in args.instruments:
-                            chisq[ifo], chisq_dof[ifo] = power_chisq.values(
-                                corr_dict[ifo],
-                                coherent_ifo_trigs[ifo] / norm_dict[ifo],
-                                norm_dict[ifo],
-                                stilde[ifo].psd,
+                            power_chisq[ifo] = all_power_chisq[ifo][
                                 coinc_idx_det_frame[ifo]
-                                + stilde[ifo].analyze.start,
-                                template,
-                            )
+                            ]
+                            assert (power_chisq[ifo] > 0).all()
+                            power_chisq_dof[ifo] = all_power_chisq_dof[ifo][
+                                coinc_idx_det_frame[ifo]
+                            ]
+                            assert (power_chisq_dof[ifo] > 0).all()
                         # Calculate network chisq value
                         network_chisq_dict = coh.network_chisq(
-                            chisq, chisq_dof, coherent_ifo_trigs
+                            power_chisq, power_chisq_dof, coherent_ifo_trigs
                         )
                         # Calculate chisq reweighted SNR
                         if nifo > 1:
@@ -1047,8 +1065,8 @@ with ctx:
                                 stilde=stilde[ifo],
                                 low_frequency_cutoff=flow,
                             )
-                            ifo_out_vals['chisq'] = chisq[ifo]
-                            ifo_out_vals['chisq_dof'] = chisq_dof[ifo]
+                            ifo_out_vals['chisq'] = power_chisq[ifo]
+                            ifo_out_vals['chisq_dof'] = power_chisq_dof[ifo]
                             ifo_out_vals['time_index'] = (
                                 coinc_idx_det_frame[ifo]
                                 + stilde[ifo].cumulative_index

--- a/bin/pycbc_multi_inspiral
+++ b/bin/pycbc_multi_inspiral
@@ -686,8 +686,8 @@ with ctx:
             snr = dict.fromkeys(args.instruments)
             # - Power chi^2 and corresponding DoF for each time sample.
             #   Typically only a tiny fraction will be populated.
-            all_power_chisq = dict.fromkeys(args.instruments)
-            all_power_chisq_dof = dict.fromkeys(args.instruments)
+            power_chisq_arrays = dict.fromkeys(args.instruments)
+            power_chisq_dof_arrays = dict.fromkeys(args.instruments)
             for ifo in args.instruments:
                 logging.debug(
                     "Filtering template %d/%d, ifo %s", t_num + 1, n_bank, ifo
@@ -718,9 +718,13 @@ with ctx:
                     ifo,
                     len(idx[ifo])
                 )
-                all_power_chisq[ifo] = np.zeros(len(snr_dict[ifo]), dtype=np.float32) + np.nan
-                all_power_chisq_dof[ifo] = np.zeros(len(snr_dict[ifo]), dtype=np.int32)
-                all_power_chisq[ifo][idx[ifo]], all_power_chisq_dof[ifo][idx[ifo]] = power_chisq.values(
+                power_chisq_arrays[ifo] = np.full(
+                    len(snr_dict[ifo]), np.nan, dtype=np.float32
+                )
+                power_chisq_dof_arrays[ifo] = np.zeros(
+                    len(snr_dict[ifo]), dtype=np.int32
+                )
+                power_chisq_arrays[ifo][idx[ifo]], power_chisq_dof_arrays[ifo][idx[ifo]] = power_chisq.values(
                     corr,
                     snr_dict[ifo][idx[ifo]] / norm,
                     norm,
@@ -991,18 +995,23 @@ with ctx:
                         }
                         # Pick up the precalculated power-chi2 values for the
                         # remaining triggers
-                        power_chisq = {}
-                        power_chisq_dof = {}
-                        for ifo in args.instruments:
-                            power_chisq[ifo] = all_power_chisq[ifo][
+                        power_chisq_values = {
+                            ifo: power_chisq_arrays[ifo][
                                 coinc_idx_det_frame[ifo]
                             ]
-                            power_chisq_dof[ifo] = all_power_chisq_dof[ifo][
+                            for ifo in args.instruments
+                        }
+                        power_chisq_dof_values = {
+                            ifo: power_chisq_dof_arrays[ifo][
                                 coinc_idx_det_frame[ifo]
                             ]
+                            for ifo in args.instruments
+                        }
                         # Calculate network chisq value
                         network_chisq_dict = coh.network_chisq(
-                            power_chisq, power_chisq_dof, coherent_ifo_trigs
+                            power_chisq_values,
+                            power_chisq_dof_values,
+                            coherent_ifo_trigs
                         )
                         # Calculate chisq reweighted SNR
                         if nifo > 1:
@@ -1063,8 +1072,8 @@ with ctx:
                                 stilde=stilde[ifo],
                                 low_frequency_cutoff=flow,
                             )
-                            ifo_out_vals['chisq'] = power_chisq[ifo]
-                            ifo_out_vals['chisq_dof'] = power_chisq_dof[ifo]
+                            ifo_out_vals['chisq'] = power_chisq_values[ifo]
+                            ifo_out_vals['chisq_dof'] = power_chisq_dof_values[ifo]
                             ifo_out_vals['time_index'] = (
                                 coinc_idx_det_frame[ifo]
                                 + stilde[ifo].cumulative_index

--- a/bin/pycbc_multi_inspiral
+++ b/bin/pycbc_multi_inspiral
@@ -684,7 +684,7 @@ with ctx:
             idx = dict.fromkeys(args.instruments)
             # - The list of normalized SNR values at the trigger locations
             snr = dict.fromkeys(args.instruments)
-            # - Power chi^2 and corresponding DoF for each time sample.
+            # - Cache for power chi^2 and corresponding DoF for each time sample.
             #   Typically only a tiny fraction will be populated.
             power_chisq_arrays = dict.fromkeys(args.instruments)
             power_chisq_dof_arrays = dict.fromkeys(args.instruments)
@@ -713,22 +713,12 @@ with ctx:
                 # or negative
                 idx[ifo] = ind.astype(np.int32)
                 snr[ifo] = snrv * norm
-                logging.debug(
-                    'Calculating power chi^2 for %s on %d points', ifo, len(ind)
-                )
+                # Initialize the cache for power chi^2
                 power_chisq_arrays[ifo] = np.full(
                     len(snr_dict[ifo]), np.nan, dtype=np.float32
                 )
                 power_chisq_dof_arrays[ifo] = np.zeros(
                     len(snr_dict[ifo]), dtype=np.int32
-                )
-                power_chisq_arrays[ifo][ind], power_chisq_dof_arrays[ifo][ind] = power_chisq.values(
-                    corr,
-                    snr_dict[ifo][ind] / norm,
-                    norm,
-                    stilde[ifo].psd,
-                    ind + stilde[ifo].analyze.start,
-                    template,
                 )
                 del snr_ts, norm, corr, ind, snrv
 
@@ -991,20 +981,36 @@ with ctx:
                             ifo: snr_dict[ifo][coinc_idx_det_frame[ifo]]
                             for ifo in args.instruments
                         }
-                        # Pick up the precalculated power-chi2 values for the
-                        # remaining triggers
-                        power_chisq_values = {
-                            ifo: power_chisq_arrays[ifo][
-                                coinc_idx_det_frame[ifo]
-                            ]
-                            for ifo in args.instruments
-                        }
-                        power_chisq_dof_values = {
-                            ifo: power_chisq_dof_arrays[ifo][
-                                coinc_idx_det_frame[ifo]
-                            ]
-                            for ifo in args.instruments
-                        }
+                        # Calculate the powerchi2 values of remaining triggers
+                        # (this uses the SNR timeseries before the time delay,
+                        # so we undo it; the same holds for normalisation)
+                        chisq = {}
+                        chisq_dof = {}
+                        for ifo in args.instruments:
+                            # Figure out which new indices we need to calculate
+                            # the chi^2 for
+                            needed_idx = coinc_idx_det_frame[ifo]
+                            available_idx = np.flatnonzero(np.logical_not(np.isnan(power_chisq_arrays[ifo])))
+                            new_needed_idx = np.setdiff1d(needed_idx, available_idx)
+                            logging.info(
+                                'Calculating power chi^2 for %s at %d new points of %d needed',
+                                ifo,
+                                sum(new_needed_idx),
+                                sum(needed_idx)
+                            )
+                            new_chisq, new_chisq_dof = power_chisq.values(
+                                corr_dict[ifo],
+                                coherent_ifo_trigs[ifo] / norm_dict[ifo],
+                                norm_dict[ifo],
+                                stilde[ifo].psd,
+                                new_needed_idx + stilde[ifo].analyze.start,
+                                template,
+                            )
+                            power_chisq_arrays[ifo][new_needed_idx] = new_chisq
+                            power_chisq_dof_arrays[ifo][new_needed_idx] = new_chisq_dof
+                            chisq[ifo] = power_chisq_arrays[ifo][needed_idx]
+                            chisq_dof[ifo] = power_chisq_dof_arrays[ifo][needed_idx]
+                            del needed_idx, available_idx, new_needed_idx
                         # Calculate network chisq value
                         network_chisq_dict = coh.network_chisq(
                             power_chisq_values,

--- a/bin/pycbc_multi_inspiral
+++ b/bin/pycbc_multi_inspiral
@@ -997,11 +997,9 @@ with ctx:
                             power_chisq[ifo] = all_power_chisq[ifo][
                                 coinc_idx_det_frame[ifo]
                             ]
-                            assert (power_chisq[ifo] > 0).all()
                             power_chisq_dof[ifo] = all_power_chisq_dof[ifo][
                                 coinc_idx_det_frame[ifo]
                             ]
-                            assert (power_chisq_dof[ifo] > 0).all()
                         # Calculate network chisq value
                         network_chisq_dict = coh.network_chisq(
                             power_chisq, power_chisq_dof, coherent_ifo_trigs

--- a/bin/pycbc_multi_inspiral
+++ b/bin/pycbc_multi_inspiral
@@ -992,30 +992,31 @@ with ctx:
                             needed_idx = coinc_idx_det_frame[ifo]
                             available_idx = np.flatnonzero(np.logical_not(np.isnan(power_chisq_arrays[ifo])))
                             new_needed_idx = np.setdiff1d(needed_idx, available_idx)
+                            del available_idx
                             logging.info(
                                 'Calculating power chi^2 for %s at %d new points of %d needed',
                                 ifo,
-                                sum(new_needed_idx),
-                                sum(needed_idx)
+                                len(new_needed_idx),
+                                len(needed_idx)
                             )
-                            new_chisq, new_chisq_dof = power_chisq.values(
-                                corr_dict[ifo],
-                                coherent_ifo_trigs[ifo] / norm_dict[ifo],
-                                norm_dict[ifo],
-                                stilde[ifo].psd,
-                                new_needed_idx + stilde[ifo].analyze.start,
-                                template,
-                            )
-                            power_chisq_arrays[ifo][new_needed_idx] = new_chisq
-                            power_chisq_dof_arrays[ifo][new_needed_idx] = new_chisq_dof
+                            if len(new_needed_idx) > 0:
+                                new_chisq, new_chisq_dof = power_chisq.values(
+                                    corr_dict[ifo],
+                                    snr_dict[ifo][new_needed_idx] / norm_dict[ifo],
+                                    norm_dict[ifo],
+                                    stilde[ifo].psd,
+                                    new_needed_idx + stilde[ifo].analyze.start,
+                                    template,
+                                )
+                                power_chisq_arrays[ifo][new_needed_idx] = new_chisq
+                                power_chisq_dof_arrays[ifo][new_needed_idx] = new_chisq_dof
+                                del new_chisq, new_chisq_dof
                             chisq[ifo] = power_chisq_arrays[ifo][needed_idx]
                             chisq_dof[ifo] = power_chisq_dof_arrays[ifo][needed_idx]
-                            del needed_idx, available_idx, new_needed_idx
+                            del needed_idx, new_needed_idx
                         # Calculate network chisq value
                         network_chisq_dict = coh.network_chisq(
-                            power_chisq_values,
-                            power_chisq_dof_values,
-                            coherent_ifo_trigs
+                            chisq, chisq_dof, coherent_ifo_trigs
                         )
                         # Calculate chisq reweighted SNR
                         if nifo > 1:
@@ -1076,8 +1077,8 @@ with ctx:
                                 stilde=stilde[ifo],
                                 low_frequency_cutoff=flow,
                             )
-                            ifo_out_vals['chisq'] = power_chisq_values[ifo]
-                            ifo_out_vals['chisq_dof'] = power_chisq_dof_values[ifo]
+                            ifo_out_vals['chisq'] = chisq[ifo]
+                            ifo_out_vals['chisq_dof'] = chisq_dof[ifo]
                             ifo_out_vals['time_index'] = (
                                 coinc_idx_det_frame[ifo]
                                 + stilde[ifo].cumulative_index

--- a/bin/pycbc_multi_inspiral
+++ b/bin/pycbc_multi_inspiral
@@ -714,9 +714,7 @@ with ctx:
                 idx[ifo] = ind.astype(np.int32)
                 snr[ifo] = snrv * norm
                 logging.debug(
-                    'Calculating power chi^2 for %s on %d points',
-                    ifo,
-                    len(idx[ifo])
+                    'Calculating power chi^2 for %s on %d points', ifo, len(ind)
                 )
                 power_chisq_arrays[ifo] = np.full(
                     len(snr_dict[ifo]), np.nan, dtype=np.float32
@@ -724,12 +722,12 @@ with ctx:
                 power_chisq_dof_arrays[ifo] = np.zeros(
                     len(snr_dict[ifo]), dtype=np.int32
                 )
-                power_chisq_arrays[ifo][idx[ifo]], power_chisq_dof_arrays[ifo][idx[ifo]] = power_chisq.values(
+                power_chisq_arrays[ifo][ind], power_chisq_dof_arrays[ifo][ind] = power_chisq.values(
                     corr,
-                    snr_dict[ifo][idx[ifo]] / norm,
+                    snr_dict[ifo][ind] / norm,
                     norm,
                     stilde[ifo].psd,
-                    idx[ifo] + stilde[ifo].analyze.start,
+                    ind + stilde[ifo].analyze.start,
                     template,
                 )
                 del snr_ts, norm, corr, ind, snrv


### PR DESCRIPTION
In the presence of loud injections (and perhaps glitches) and with large sky grids, `multi_inspiral` spends most of its time doing chi^2 calculations. This reduces that.

## Standard information about the request

This is an efficiency update.

This change affects PyGRB.

## Motivation

This addresses the first thing I described in #5148, namely the fact that some `multi_inspiral` jobs can take many hours just doing repeated power chi^2 calculations in the critical loop over time slides and sky points. As the calculation is a single-detector operation, it does not depend on time slide or sky position, so its result be cached for reuse in the following iterations.

## Contents

I introduce a cache for the power chi^2 values and DoF. Every time a new chi^2 calculation is required, I check which time samples had their chi^2 calculated before, and I only call the chi^2 code for the new samples.

This change, together with #5157, brings the wall clock time from 35 hours to 8 for the test job I have been profiling in #5148.

@spxiwh noted that the point chi^2 code is not necessarily the most efficient when there are many points to calculate; in fact, coh_PTF_inspiral used to do the old FFT-based calculation. Still, I already know that this PR leads to a huge speedup in the limiting cases, so I propose we postpone further optimizations to later PRs.

## Links to any issues or associated PRs

#5148 

## Testing performed

### Checking that I have not messed up the calculation

I noticed that power chi^2 values tend to be non-deterministic even across runs of the same code done a few minutes apart, so checking that the results do not change is a bit challenging. This non-determinism comes in large part from the PSD estimate itself not being deterministic (which also means the trigger list itself is not stable). I got around this by dumping PSD estimates to files once, and then loading them with `--psd-file` instead of redoing the PSD estimation each time. This at least gets the trigger list to be identical across runs.

Using this "fixed" PSDs, I then did several runs of the GW170817 `multi_inspiral` example with and without this PR, with detectors set to H, HL and HLV. With the HLV network I also tested a case with 20 sky grid points as opposed to 1. I found differences in chi^2 values for about 1% of the triggers, with the maximum abs difference being slightly over 0.001, and the median being of order 0.0001. I attribute those differences to the residual non-determinism in chi^2 calculation.

I also compared the triggers of a few jobs taken from actual workflows, although I did not fix the PSDs for these. For the cases where the number of triggers is unchanged, I found that the chi^2 values have differences of up to ~8, but the values are in the thousands or tens of thousands, so this looks again just random rounding variations, unrelated to this PR.

### Evaluating the speedup

To test the speedup in realistic cases, I took a few representative jobs from a couple recent PyGRB workflows, covering cases with and without injections, loud and quiet injections, big sky grids and single-point grids. I compared the wall-clock run times using the 2.8.3 release venv, with times using a venv with this PR. The new venv matches the 2.8.3 release venv as closely as possible, in particular it has identical versions of Python, Numpy, Scipy, LALSuite. For those with LVK access, the raw results are here:

https://ldas-jobs.ligo.caltech.edu/~tito.canton/pycbc/pygrb2/multi_inspiral_test_cases/

This is a summary of the wall clock run times as reported by `pycbc_multi_inspiral` itself at the end (the user times as measured by `/usr/bin/time` give similar speedup factors, or even larger):

Test case number | Test case description | WCT on pcdev5 with 2.8.3 | WCT on pcdev5 with PR #5158 | WCT speedup on pcdev5
-- | -- | -- | -- | --
1 | HL, big sky grid, injections, long job | 130432 | 26320 | 4.96
2 | HL, big sky grid, no injections, average duration | 16198 | 11554 | 1.40
3 | HL, big sky grid, injections, short job | 1515 | 1200 | 1.26
4 | HL, single sky point, injections, long job | 2032 | 2001 | 1.02
5 | HL, single sky point, injections, short job | 411 | 402 | 1.02
6 | Like 4 but with H only | 973 | 977 | 1.00
7 | HL, big-ish sky grid, injections, long job | 151736 | 19172 | 7.91

As expected, this PR (combined with #5157) leads to a speedup of several factors when there are many triggers from matched filtering and many sky grid points. The speedup is tens of percent for "average" jobs. For the fastest jobs, where initialization is a large fraction of the total time and/or there is a single sky point, there is basically no change.

## Additional notes

N/A

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
