### PR TITLE
fix a bug in the mutli loglikelihood method of the gated gaussian noise class

### DIFF
--- a/pycbc/inference/models/gated_gaussian_noise.py
+++ b/pycbc/inference/models/gated_gaussian_noise.py
@@ -694,8 +694,8 @@ class GatedGaussianNoise(BaseGatedGaussian):
         for det in self.data:
             # get max waveform length
             mlen = max([len(x[det]) for x in wfs])
-            [x[det].copy().resize(mlen) for x in wfs]
-            combine[det] = sum([x[det] for x in wfs])
+            wfs_resize = [x[det].copy().resize(mlen) for x in wfs]
+            combine[det] = sum([x[det] for x in wfs_resize])
 
         self._current_wfs = combine
         return self._loglikelihood()


### PR DESCRIPTION
This PR fixes a one-line bug in the `multi_loglikelihood` method of `GatedGaussianNoise` class. I think this is critical as otherwise two waveforms with different lengths can't be summed in the next line. 

In particular, this PR wouldn't affect the previous ringdown black hole spectroscopy runs, as ringdown analysis only uses `hierarchical` model, not `multi_signal`. 

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
