### PR TITLE
Use pregenerated injection frame file to perform pregenerated injections (resurrected)

### DIFF
--- a/pycbc/inject/inject.py
+++ b/pycbc/inject/inject.py
@@ -161,10 +161,17 @@ class _XMLInjectionSet(object):
         self.table = lsctables.SimInspiralTable.get_table(self.indoc)
         self.extra_args = kwds
 
-    def apply(self, strain, detector_name, f_lower=None, distance_scale=1,
-              simulation_ids=None,
-              inj_filter_rejector=None,
-              injection_sample_rate=None,):
+    def apply(
+        self,
+        strain,
+        detector_name,
+        f_lower=None,
+        distance_scale=1,
+        simulation_ids=None,
+        inj_filter_rejector=None,
+        injection_sample_rate=None,
+        generate_injections=True,
+    ):
         """Add injections (as seen by a particular detector) to a time series.
 
         Parameters
@@ -187,6 +194,13 @@ class _XMLInjectionSet(object):
             injection if necessary.
         injection_sample_rate: float, optional
             The sample rate to generate the signal before injection
+        generate_injections: boolean, optional (default=True)
+            If this is False, injections will not be added to the data. This
+            can be used if your data already contains injections, or if you
+            are separately providing injection strain to add to the data, and
+            you still want to know injection times to make use of injection
+            optimizations (mostly through the InjFilterRejector).
+            Not implemented for XML injections.
 
         Returns
         -------
@@ -197,6 +211,12 @@ class _XMLInjectionSet(object):
         TypeError
             For invalid types of `strain`.
         """
+        if not generate_injections:
+            raise NotImplementedError(
+                "XML injections do not support the generate_injections "
+                "key-word argument."
+            )
+
         if strain.dtype not in (float32, float64):
             raise TypeError("Strain dtype must be float32 or float64, not " \
                     + str(strain.dtype))
@@ -497,10 +517,17 @@ class CBCHDFInjectionSet(_HDFInjectionSet):
     injtype = 'cbc'
     required_params = ('tc',)
 
-    def apply(self, strain, detector_name, f_lower=None, distance_scale=1,
-              simulation_ids=None,
-              inj_filter_rejector=None,
-              injection_sample_rate=None,):
+    def apply(
+        self,
+        strain,
+        detector_name,
+        f_lower=None,
+        distance_scale=1,
+        simulation_ids=None,
+        inj_filter_rejector=None,
+        injection_sample_rate=None,
+        generate_injections=True,
+    ):
         """Add injections (as seen by a particular detector) to a time series.
 
         Parameters
@@ -523,6 +550,12 @@ class CBCHDFInjectionSet(_HDFInjectionSet):
             injection if necessary.
         injection_sample_rate: float, optional
             The sample rate to generate the signal before injection
+        generate_injections: boolean, optional (default=True)
+            If this is False, injections will not be added to the data. This
+            can be used if your data already contains injections, or if you
+            are separately providing injection strain to add to the data, and
+            you still want to know injection times to make use of injection
+            optimizations (mostly through the InjFilterRejector).
 
         Returns
         -------
@@ -533,11 +566,24 @@ class CBCHDFInjectionSet(_HDFInjectionSet):
         TypeError
             For invalid types of `strain`.
         """
+        # There is a case where injections are not added to the data, but
+        # still need to be generated for the match threshold option in the
+        # InjFilterRejector. User needs to be careful with this though!
+        if inj_filter_rejector.match_threshold and not generate_injections:
+            warn_msg = "You have asked to use the match threshold option in "
+                       "InjFilterRejector, but injections are not being "
+                       "directly added from the supplied injection file. "
+                       "Be very sure that the injection file exactly matches "
+                       "how the injections were pregenerated!"
+            logging.warn(warn_msg)
+        must_make_injections = (
+            generate_injections or inj_filter_rejector.match_threshold
+        )
+
         if strain.dtype not in (float32, float64):
             raise TypeError("Strain dtype must be float32 or float64, not " \
                     + str(strain.dtype))
 
-        lalstrain = strain.lal()
         if self.table[0]['approximant'] in fd_det:
             t0 = float(strain.start_time)
             t1 = float(strain.end_time)
@@ -546,8 +592,12 @@ class CBCHDFInjectionSet(_HDFInjectionSet):
             t0 = float(strain.start_time) - earth_travel_time
             t1 = float(strain.end_time) + earth_travel_time
 
-        # pick lalsimulation injection function
-        add_injection = injection_func_map[strain.dtype]
+
+        if generate_injections:
+            lalstrain = strain.lal()
+
+            # pick lalsimulation injection function
+            add_injection = injection_func_map[strain.dtype]
 
         delta_t = strain.delta_t
         if injection_sample_rate is not None:
@@ -569,21 +619,33 @@ class CBCHDFInjectionSet(_HDFInjectionSet):
             start_time = inj.tc - 2 * (inj_length + 1)
             if end_time < t0 or start_time > t1:
                 continue
-            signal = self.make_strain_from_inj_object(inj, delta_t,
-                     detector_name, f_lower=f_l,
-                     distance_scale=distance_scale)
-            signal = resample_to_delta_t(signal, strain.delta_t, method='ldas')
-            if float(signal.start_time) > t1:
-                continue
+            if must_make_injections:
+                signal = self.make_strain_from_inj_object(
+                    inj,
+                    delta_t,
+                    detector_name,
+                    f_lower=f_l,
+                    distance_scale=distance_scale,
+                )
+                signal = resample_to_delta_t(
+                    signal,
+                    strain.delta_t,
+                    method='ldas'
+                )
+                if float(signal.start_time) > t1:
+                    continue
+                signal = signal.astype(strain.dtype)
+                injected_ids.append(ii)
+                if inj_filter_rejector is not None:
+                   inj_filter_rejector.generate_short_inj_from_inj(signal, ii)
 
-            signal = signal.astype(strain.dtype)
-            signal_lal = signal.lal()
-            add_injection(lalstrain, signal_lal, None)
-            injected_ids.append(ii)
-            if inj_filter_rejector is not None:
-                inj_filter_rejector.generate_short_inj_from_inj(signal, ii)
 
-        strain.data[:] = lalstrain.data.data[:]
+            if generate_injections:
+                signal_lal = signal.lal()
+                add_injection(lalstrain, signal_lal, None)
+
+        if generate_injections:
+            strain.data[:] = lalstrain.data.data[:]
 
         injected = copy.copy(self)
         injected.table = injections[np.array(injected_ids).astype(int)]
@@ -663,9 +725,16 @@ class RingdownHDFInjectionSet(_HDFInjectionSet):
     injtype = 'ringdown'
     required_params = ('tc',)
 
-    def apply(self, strain, detector_name, distance_scale=1,
-              simulation_ids=None, inj_filter_rejector=None,
-              injection_sample_rate=None):
+    def apply(
+        self,
+        strain,
+        detector_name,
+        distance_scale=1,
+        simulation_ids=None,
+        inj_filter_rejector=None,
+        injection_sample_rate=None,
+        generate_injections=True,
+    ):
         """Add injection (as seen by a particular detector) to a time series.
 
         Parameters
@@ -684,6 +753,13 @@ class RingdownHDFInjectionSet(_HDFInjectionSet):
             be raised.
         injection_sample_rate: float, optional
             The sample rate to generate the signal before injection
+        generate_injections: boolean, optional (default=True)
+            If this is False, injections will not be added to the data. This
+            can be used if your data already contains injections, or if you
+            are separately providing injection strain to add to the data, and
+            you still want to know injection times to make use of injection
+            optimizations (mostly through the InjFilterRejector).
+            Not yet implemented for Ringdown Injection Files.
 
         Returns
         -------
@@ -693,12 +769,20 @@ class RingdownHDFInjectionSet(_HDFInjectionSet):
         ------
         NotImplementedError
             If an ``inj_filter_rejector`` is provided.
+            Or if generate_injections is not True.
         TypeError
             For invalid types of `strain`.
         """
         if inj_filter_rejector is not None:
             raise NotImplementedError("Ringdown injections do not support "
                                       "inj_filter_rejector")
+
+        if not generate_injections:
+            raise NotImplementedError(
+                "The generate_injections flag is not implemented for Ringdown "
+                "injections."
+            )
+
         if strain.dtype not in (float32, float64):
             raise TypeError("Strain dtype must be float32 or float64, not " \
                     + str(strain.dtype))
@@ -937,11 +1021,25 @@ class IncoherentFromFileHDFInjectionSet(_HDFInjectionSet):
                                   side='right')
         return ts
 
-    def apply(self, strain, detector_name, distance_scale=1,
-              injection_sample_rate=None, inj_filter_rejector=None):
+    def apply(
+        self,
+        strain,
+        detector_name,
+        distance_scale=1,
+        injection_sample_rate=None,
+        inj_filter_rejector=None,
+        generate_injections=True
+    ):
         if inj_filter_rejector is not None:
             raise NotImplementedError("IncoherentFromFile injections do not "
                                       "support inj_filter_rejector")
+
+        if not generate_injections:
+            raise NotImplementedError(
+                "IncoherentFromFile injections do not support the "
+                "generate_injections key-word argument."
+            )
+
         if injection_sample_rate is not None:
             delta_t = 1./injection_sample_rate
         else:

--- a/pycbc/inject/inject.py
+++ b/pycbc/inject/inject.py
@@ -570,11 +570,13 @@ class CBCHDFInjectionSet(_HDFInjectionSet):
         # still need to be generated for the match threshold option in the
         # InjFilterRejector. User needs to be careful with this though!
         if inj_filter_rejector.match_threshold and not generate_injections:
-            warn_msg = "You have asked to use the match threshold option in "
-                       "InjFilterRejector, but injections are not being "
-                       "directly added from the supplied injection file. "
-                       "Be very sure that the injection file exactly matches "
-                       "how the injections were pregenerated!"
+            warn_msg = (
+                "You have asked to use the match threshold option in "
+                "InjFilterRejector, but injections are not being "
+                "directly added from the supplied injection file. "
+                "Be very sure that the injection file exactly matches "
+                "how the injections were pregenerated!"
+            )
             logging.warn(warn_msg)
         must_make_injections = (
             generate_injections or inj_filter_rejector.match_threshold

--- a/pycbc/inject/inject.py
+++ b/pycbc/inject/inject.py
@@ -569,17 +569,20 @@ class CBCHDFInjectionSet(_HDFInjectionSet):
         # There is a case where injections are not added to the data, but
         # still need to be generated for the match threshold option in the
         # InjFilterRejector. User needs to be careful with this though!
-        if inj_filter_rejector.match_threshold and not generate_injections:
-            warn_msg = (
-                "You have asked to use the match threshold option in "
-                "InjFilterRejector, but injections are not being "
-                "directly added from the supplied injection file. "
-                "Be very sure that the injection file exactly matches "
-                "how the injections were pregenerated!"
-            )
-            logging.warn(warn_msg)
+        if inj_filter_rejector is not None:
+            if inj_filter_rejector.match_threshold and not generate_injections:
+                warn_msg = (
+                    "You have asked to use the match threshold option in "
+                    "InjFilterRejector, but injections are not being "
+                    "directly added from the supplied injection file. "
+                    "Be very sure that the injection file exactly matches "
+                    "how the injections were pregenerated!"
+                )
+                logging.warn(warn_msg)
         must_make_injections = (
-            generate_injections or inj_filter_rejector.match_threshold
+            generate_injections or (
+               inj_filter_rejector and inj_filter_rejector.match_threshold
+            )
         )
 
         if strain.dtype not in (float32, float64):

--- a/pycbc/strain/strain.py
+++ b/pycbc/strain/strain.py
@@ -817,12 +817,12 @@ def insert_strain_option_group_multi_ifo(parser, gps_times=True):
                     default=True, action="store_false",
                     dest="generate_injections",
                     help="If this options are given, the injections in "
-                           "injection-file or sgburst-injection-file are not "
-                           "added into the data. This can be used for "
-                           "debugging (ie. in minifollowups), or if using "
-                           "injections from frame files where you need to "
-                           "know injection parameters to allow the "
-                           "injection optimization settings.")
+                          "injection-file or sgburst-injection-file are not "
+                          "added into the data. This can be used for "
+                          "debugging (ie. in minifollowups), or if using "
+                          "injections from frame files where you need to "
+                          "know injection parameters to allow the "
+                          "injection optimization settings.")
 
     data_reading_group_multi.add_argument("--sgburst-injection-file", type=str,
                     nargs="+", action=MultiDetOptionAction,

--- a/pycbc/strain/strain.py
+++ b/pycbc/strain/strain.py
@@ -282,8 +282,10 @@ def from_cli(opt, dyn_range_fac=1, precision='single',
 
     if opt.injection_frame_files or opt.injection_frame_type:
         if opt.injection_frame_files and opt.injection_frame_type:
-            err_msg = "You cannot supply both injection-frame-files and "
-                      "injection-frame-type"
+            err_msg = (
+                "You cannot supply both injection-frame-files and "
+                "injection-frame-type"
+            )
             raise ValueError(err_msg)
 
         logging.info("Reading Frames containing injections")

--- a/pycbc/strain/strain.py
+++ b/pycbc/strain/strain.py
@@ -580,7 +580,7 @@ def insert_strain_option_group(parser, gps_times=True):
     data_reading_group.add_argument("--sgburst-injection-file", type=str,
                       help="(optional) Injection file containing parameters"
                       "of sine-Gaussian burst signals to add to the strain")
-    data_reading_group.add_argument("--do-not-inject-from-file", type=bool,
+    data_reading_group.add_argument("--do-not-inject-from-file",
                       action="store_false", dest="generate_injections",
                       default=True,
                       help="If this options are given, the injections in "

--- a/pycbc/strain/strain.py
+++ b/pycbc/strain/strain.py
@@ -814,7 +814,7 @@ def insert_strain_option_group_multi_ifo(parser, gps_times=True):
                     help="(optional) Injection file containing parameters"
                          "of CBC signals to be added to the strain")
     data_reading_group_multi.add_argument("--do-not-inject-from-file",
-                    type=bool, action="store_false",
+                    default=True, action="store_false",
                     dest="generate_injections",
                     help="If this options are given, the injections in "
                            "injection-file or sgburst-injection-file are not "

--- a/pycbc/strain/strain.py
+++ b/pycbc/strain/strain.py
@@ -813,6 +813,17 @@ def insert_strain_option_group_multi_ifo(parser, gps_times=True):
                     metavar='IFO:FILE',
                     help="(optional) Injection file containing parameters"
                          "of CBC signals to be added to the strain")
+    data_reading_group_multi.add_argument("--do-not-inject-from-file",
+                    type=bool, action="store_false",
+                    dest="generate_injections",
+                    help="If this options are given, the injections in "
+                           "injection-file or sgburst-injection-file are not "
+                           "added into the data. This can be used for "
+                           "debugging (ie. in minifollowups), or if using "
+                           "injections from frame files where you need to "
+                           "know injection parameters to allow the "
+                           "injection optimization settings.")
+
     data_reading_group_multi.add_argument("--sgburst-injection-file", type=str,
                     nargs="+", action=MultiDetOptionAction,
                     metavar='IFO:FILE',
@@ -839,6 +850,21 @@ def insert_strain_option_group_multi_ifo(parser, gps_times=True):
                     action=MultiDetOptionAction, metavar='IFO:VALUE',
                     help="Override the f_final field of a CBC XML "
                          "injection file (frequency in Hz)")
+    # Options for getting injection from frame files
+    data_reading_group_multi.add_argument("--injection-channel-name", type=str,
+                      action=MultiDetOptionAction, metavar='IFO:VALUE',
+                      help="The channel containing the injection strain data")
+    data_reading_group_multi.add_argument("--injection-frame-type", type=str,
+                      action=MultiDetOptionAction, metavar='IFO:VALUE',
+                      help="We are going to add injections from frame files. "
+                           "This will use datafind to get the needed frame "
+                           "files of this type.")
+    data_reading_group_multi.add_argument("--injection-frame-files",
+                      type=str, nargs="+", metavar='IFO:FRAME_FILES',
+                      action=MultiDetOptionAppendAction, 
+                      help="We are going to add injections from frame files. "
+                           "This provides the list of frame files containing "
+                           "injection strain.")
 
     # Gating options
     data_reading_group_multi.add_argument("--gating-file", nargs="+",

--- a/pycbc/strain/strain.py
+++ b/pycbc/strain/strain.py
@@ -343,13 +343,15 @@ def from_cli(opt, dyn_range_fac=1, precision='single',
             injector.apply(strain, opt.channel_name.split(':')[0],
                            distance_scale=opt.injection_scale_factor,
                            injection_sample_rate=opt.injection_sample_rate,
-                           inj_filter_rejector=inj_filter_rejector)
+                           inj_filter_rejector=inj_filter_rejector,
+                           generate_injections=opt.generate_injections)
 
     if opt.sgburst_injection_file:
         logger.info("Applying sine-Gaussian burst injections")
         injector = SGBurstInjectionSet(opt.sgburst_injection_file)
         injector.apply(strain, opt.channel_name.split(':')[0],
-                         distance_scale=opt.injection_scale_factor)
+                       distance_scale=opt.injection_scale_factor,
+                       generate_injections=opt.generate_injections)
 
     if precision == 'single':
         logger.info("Converting to float32")
@@ -576,6 +578,16 @@ def insert_strain_option_group(parser, gps_times=True):
     data_reading_group.add_argument("--sgburst-injection-file", type=str,
                       help="(optional) Injection file containing parameters"
                       "of sine-Gaussian burst signals to add to the strain")
+    data_reading_group.add_argument("--do-not-inject-from-file", type=bool,
+                      action="store_false", dest="generate_injections",
+                      default=True,
+                      help="If this options are given, the injections in "
+                           "injection-file or sgburst-injection-file are not "
+                           "added into the data. This can be used for "
+                           "debugging (ie. in minifollowups), or if using "
+                           "injections from frame files where you need to "
+                           "know injection parameters to allow the "
+                           "injection optimization settings.")
     data_reading_group.add_argument("--injection-scale-factor", type=float,
                       default=1,
                       help="Divide injections by this factor "


### PR DESCRIPTION
## Standard information about the request

This is a: new feature

This change affects: the offline search, inference, PyGRB

This change changes: scientific output

This change: has appropriate unit tests, follows style guidelines (See e.g. [PEP8](https://peps.python.org/pep-0008/)), has been proposed using the [contribution guidelines](https://github.com/gwastro/pycbc/blob/master/CONTRIBUTING.md)

This change will: add new functionality, but not break anything

## Motivation

This is an attempt to resurrect #4477. In the past it has been difficult to guarantee that different search codes are making identical injections, and therefore comparisons can be hard. In addition some newer injection waveforms can require *huge* amounts of RAM, making it difficult to set requirements for jobs running on OSG. Using pregenerated injection frame files fixes this and such files can be easily distributed over OSG

## Contents

We add the ability to add injections from frame files containing pregenerated injections (... I note that one could put *anything* in these files, so if you wanted to inject cosmic string blip direct collapse non-GR mergers this would be the easiest way to do that).

## Links to any issues or associated PRs

This is taken from #4477 I've resurrected the code and reworked a few things.

## Testing performed

I will need to test this on pregenerated injection frames. The CI will test it in "normal" settings.

## Additional notes

@ahnitz Had some comments on the original PR. Some responses here:

* Regarding the `generate_injections` option in InjectionSet.apply(). I think it is *not* the right approach to not call InjectionSet.apply() if not generating injections, but still wanting to filter them. All our injection optimization (when not to analyse segments, times, templates etc. is based on information that comes from here when we read the injection files. Actually making the injections is one line (which we bypass if this is set), but all the rest is still needed. We're basically already doing this in the minifollowups where we use the hack of setting `injection_scale_factor` to 0 to acheive exactly the same thing. That can now be done "properly" ... reminding that we do want to *not* generate injections when using these frames because of high memory usage of some injection models.
* Duplication in `strain.py`'s `from_cli` module. There is similarly between injection_frame reading and normal frame reading. I avoided further duplication by adding the two together immediately after reading the injection frames. I'm okay with this duplication ... The `from_cli` function could do with a cleanup and consideration of structure (might be nice to be flexible about the *order* in which things are done), but that feels out of scope of this.

I think other issues are addressed.

- [./ ] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
