### PR TITLE
Fix arguments in generate_with_delta_f_and_max_freq

### DIFF
--- a/pycbc/waveform/bank.py
+++ b/pycbc/waveform/bank.py
@@ -732,7 +732,18 @@ class FilterBank(TemplateBank):
     def generate_with_delta_f_and_max_freq(self, t_num, max_freq, delta_f,
                                            low_frequency_cutoff=None,
                                            cached_mem=None):
-        """Generate the template with index t_num using custom length."""
+        """Generate the template with index t_num using custom length.
+
+        Parameters
+        ---------
+        t_num (int): The index of the template to generate.
+        max_freq (float): The maximum frequency of the generated waveform.
+        delta_f (float): The frequency resolution (frequency bin size).
+        low_frequency_cutoff (float, optional): The starting frequency. Defaults to None,
+            which uses the default for the approximant.
+        cached_mem (numpy.ndarray, optional): A pre-allocated array for storing the waveform.
+            If None, a new array is created. Defaults to None.
+        """
         approximant = self.approximant(t_num)
         # Don't want to use INTERP waveforms in here
         if approximant.endswith('_INTERP'):
@@ -750,8 +761,8 @@ class FilterBank(TemplateBank):
         if (self.has_compressed_waveforms and self.enable_compressed_waveforms):
             try:
                 htilde = self.get_decompressed_waveform(
-                    tempout,
-                    index,
+                    cached_mem,
+                    t_num,
                     f_lower=low_frequency_cutoff,
                     approximant=approximant,
                     df=None


### PR DESCRIPTION
## Standard information about the request

<!--- Some basic info about the change (delete as appropriate) -->
This is a: bug fix

This change affects: the offline search

This change changes: scientific output if compressed waveforms are generated with a given delta_f and maximum frequency.

This change: has appropriate unit tests, follows style guidelines (See e.g. [PEP8](https://peps.python.org/pep-0008/)), has been proposed using the [contribution guidelines](https://github.com/gwastro/pycbc/blob/master/CONTRIBUTING.md)

This change may require a new release. However, searches using the v_23 branch might not be impacted as the waveforms might be generated via the `_getitem__` instead, which does have the correct arguments. 

## Contents

Undefined inputs are being used in generating decompressed waveform with delta_f and maximum frequency. This PR corrects the input arguments passed to the `generate_with_delta_f_and_max_freq` function.

## Testing performed
No testing has yet been performed. 

- Rahul Dhurkunde The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
