### PR TITLE
Precision issue in pycbc_plot_singles_timefreq

### DIFF
--- a/bin/plotting/pycbc_plot_singles_timefreq
+++ b/bin/plotting/pycbc_plot_singles_timefreq
@@ -102,8 +102,10 @@ trig_f = HFile(opts.trig_file, 'r')
 trigs = trig_f[opts.detector]
 
 def rough_filter(snr, chisq, chisq_dof, end_time, tmp_id, tmp_dur):
-    return np.logical_and(end_time > opts.gps_start_time,
-                          end_time < opts.gps_end_time + tmp_dur)
+    return np.logical_and(
+        end_time > opts.gps_start_time,
+        end_time < opts.gps_end_time + tmp_dur.astype('float64')
+    )
 
 indices, data_tuple = trig_f.select(
     rough_filter,


### PR DESCRIPTION
Fix a precision issue causing `pycbc_plot_singles_timefreq` to not correctly identify triggers in the time window.

## Standard information about the request

This is a: bug fix

This change affects: the offline search (plotting)

This change changes: result plotting,

This change: has appropriate unit tests, follows style guidelines (See e.g. [PEP8](https://peps.python.org/pep-0008/)), has been proposed using the [contribution guidelines](https://github.com/gwastro/pycbc/blob/master/CONTRIBUTING.md)

## Motivation

We've seen cases where the inspiral trace plotted on `pycbc_plot_singles_timefreq` doesn't look correct (ie. it's not showing the trigger it should, often showing something seconds away from the peak). This fixes that.

## Contents

The issue was in the logic block `end_time < opts.gps_end_time + tmp_dur`. `tmp_dur` is the numpy array on the right hand side, and the addition is evaluated first, so ` opts.gps_end_time + tmp_dur` is the operation in question. As `tmp_dur` is float32, the addition is done at float32, even though GPS times require more precision than float32 can handle. This means we see things like: `1238724747+ 3.0900245 = 1238724700.0`. Doing this calculation at float64 is more than enough for this operation.


## Testing performed

I verified for a bad example that the trace is now in the right place, and compared to *not* using tmp_dur in this calculation at all (getting expected number of triggers in these cases).

- [./] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
