### PR TITLE
Add functionality to sample coalescence time in detector frame

### DIFF
--- a/pycbc/detector/ground.py
+++ b/pycbc/detector/ground.py
@@ -475,8 +475,8 @@ class Detector(object):
                                              declination,
                                              t_gps)
     
-    def convert_tc(self, ref_tc, ra, dec, ref_frame='geocentric'):
-        """Convert tc from reference frame to another detector.
+    def arrival_time(self, ref_tc, ra, dec, ref_frame='geocentric'):
+        """Compute the arrival time in this detector.
         
         Parameters
         ----------
@@ -487,14 +487,13 @@ class Detector(object):
         dec : float
             Declination.
         ref_frame : str (optional)
-            The detector to convert from, in which tc is sampled. Default
+            The detector to convert from, in which ref_tc is sampled. Default
             'geocentric'.
             
         Returns
         -------
         float : 
-            The coalescence time converted to the detector specified by
-            current_frame.
+            The coalescence time converted to the current detector frame.
         """
         if ref_frame == 'geocentric':
             # from geocenter

--- a/pycbc/detector/ground.py
+++ b/pycbc/detector/ground.py
@@ -474,6 +474,45 @@ class Detector(object):
                                              right_ascension,
                                              declination,
                                              t_gps)
+    
+    def convert_tc(self, ref_tc, ra, dec, ref_frame='geocentric'):
+        """Convert tc from reference frame to another detector.
+        
+        Parameters
+        ----------
+        ref_tc : {float, lal.LIGOTimeGPS}
+            The coalescence time to convert, defined in ref_frame
+        ra : float
+            Right ascension.
+        dec : float
+            Declination.
+        ref_frame : str (optional)
+            The detector to convert from, in which tc is sampled. Default
+            'geocentric'.
+            
+        Returns
+        -------
+        float : 
+            The coalescence time converted to the detector specified by
+            current_frame.
+        """
+        if ref_frame == 'geocentric':
+            # from geocenter
+            tc = ref_tc + \
+                self.time_delay_from_earth_center(ra, dec, ref_tc)
+        elif ref_frame == self.name:
+            # no time shift; sampling in current det
+            tc = ref_tc
+        elif ref_frame in get_available_detectors():
+            # from sampling det
+            refdet = Detector(ref_frame)
+            tc = ref_tc + \
+                self.time_delay_from_detector(refdet, ra, dec, ref_tc)
+        else:
+            raise ValueError(f'Unrecognized ref_frame argument {ref_frame}. '
+                             'Accepted arguments are: "geocentric", '
+                             f'{get_available_detectors()}')
+        return tc
 
     def project_wave(self, hp, hc, ra, dec, polarization,
                      method='lal',

--- a/pycbc/inference/models/gated_gaussian_noise.py
+++ b/pycbc/inference/models/gated_gaussian_noise.py
@@ -875,15 +875,15 @@ class GatedGaussianMargPol(BaseGatedGaussian):
         # cycle over
         loglr = 0.
         lognl = 0.
+        refframe = self.current_params.get('tc_ref_frame', 'geocentric')
+        ref_tc = self.current_params['tc']
+        ra = self.current_params['ra']
+        dec = self.current_params['dec']
         for det, (hp, hc) in wfs.items():
             # get the antenna patterns
             if det not in self.dets:
                 self.dets[det] = Detector(det)
             # calculate tc in frame
-            refframe = self.current_params.get('tc_ref_frame', 'geocentric')
-            ref_tc = self.current_params['tc']
-            ra = self.current_params['ra']
-            dec = self.current_params['dec']
             tc = self.dets[det].convert_tc(ref_tc, ra, dec, refframe)
             # evaluate antenna pattern
             fp, fc = self.dets[det].antenna_pattern(ra, dec, self.pol, tc)

--- a/pycbc/inference/models/gated_gaussian_noise.py
+++ b/pycbc/inference/models/gated_gaussian_noise.py
@@ -884,8 +884,8 @@ class GatedGaussianMargPol(BaseGatedGaussian):
             ref_tc = self.current_params['tc']
             ra = self.current_params['ra']
             dec = self.current_params['dec']
-            tc = self.waveform_generator.convert_tc(ref_tc, ra, dec, det,
-                                                    refframe)
+            tc = self.dets[det].convert_tc(ref_tc, ra, dec, refframe)
+            # evaluate antenna pattern
             fp, fc = self.dets[det].antenna_pattern(ra, dec, self.pol, tc)
             start_index, end_index = self.gate_indices(det)
             norm = self.det_lognorm(det, start_index, end_index)

--- a/pycbc/inference/models/gated_gaussian_noise.py
+++ b/pycbc/inference/models/gated_gaussian_noise.py
@@ -884,7 +884,7 @@ class GatedGaussianMargPol(BaseGatedGaussian):
             if det not in self.dets:
                 self.dets[det] = Detector(det)
             # calculate tc in frame
-            tc = self.dets[det].convert_tc(ref_tc, ra, dec, refframe)
+            tc = self.dets[det].arrival_time(ref_tc, ra, dec, refframe)
             # evaluate antenna pattern
             fp, fc = self.dets[det].antenna_pattern(ra, dec, self.pol, tc)
             start_index, end_index = self.gate_indices(det)

--- a/pycbc/inference/models/gated_gaussian_noise.py
+++ b/pycbc/inference/models/gated_gaussian_noise.py
@@ -884,21 +884,8 @@ class GatedGaussianMargPol(BaseGatedGaussian):
             ref_tc = self.current_params['tc']
             ra = self.current_params['ra']
             dec = self.current_params['dec']
-            if refframe == 'geocentric':
-                # from geocenter
-                tc = ref_tc + \
-                    self.dets[det].time_delay_from_earth_center(ra, dec, ref_tc)
-            elif refframe == det:
-                # no time shift; sampling in current det
-                tc = ref_tc
-            elif refframe in self.dets.keys():
-                # from sampling det
-                refdet = self.dets[refframe]
-                tc = ref_tc + \
-                    self.dets[det].time_delay_from_detector(refdet, ra, dec, ref_tc)
-            else:
-                raise ValueError('tc_ref_frame param must be a detector name ',
-                                 'or "geocentric"')
+            tc = self.waveform_generator.convert_tc(ref_tc, ra, dec, det,
+                                                    refframe)
             fp, fc = self.dets[det].antenna_pattern(ra, dec, self.pol, tc)
             start_index, end_index = self.gate_indices(det)
             norm = self.det_lognorm(det, start_index, end_index)

--- a/pycbc/inference/models/marginalized_gaussian_noise.py
+++ b/pycbc/inference/models/marginalized_gaussian_noise.py
@@ -336,7 +336,7 @@ class MarginalizedTime(DistMarg, BaseGaussianNoise):
         for det in wfs:
             if det not in self.dets:
                 self.dets[det] = Detector(det)
-            tc = self.dets[det].convert_tc(ref_tc, ra, dec, refframe)
+            tc = self.dets[det].arrival_time(ref_tc, ra, dec, refframe)
             if self.precalc_antenna_factors:
                 fp, fc, dt = self.get_precalc_antenna_factors(det)
                 pol_phase = numpy.exp(-2.0j * params['polarization'])
@@ -347,14 +347,10 @@ class MarginalizedTime(DistMarg, BaseGaussianNoise):
                 fp, fc = self.dets[det].antenna_pattern(
                                         ra, dec,
                                         params['polarization'], tc)
-                dt = self.dets[det].time_delay_from_earth_center(params['ra'],
-                                                                 params['dec'],
-                                                                 tc)
-            dtc = tc + dt
 
-            cplx_hd = fp * cplx_hpd[det].at_time(dtc,
+            cplx_hd = fp * cplx_hpd[det].at_time(tc,
                                                  interpolate='quadratic')
-            cplx_hd += fc * cplx_hcd[det].at_time(dtc,
+            cplx_hd += fc * cplx_hcd[det].at_time(tc,
                                                   interpolate='quadratic')
             hh = (fp * fp * hphp[det] +
                   fc * fc * hchc[det] +
@@ -472,7 +468,7 @@ class MarginalizedPolarization(DistMarg, BaseGaussianNoise):
         for det, (hp, hc) in wfs.items():
             if det not in self.dets:
                 self.dets[det] = Detector(det)
-            tc = self.dets[det].convert_tc(ref_tc, ra, dec, refframe)
+            tc = self.dets[det].arrival_time(ref_tc, ra, dec, refframe)
             fp, fc = self.dets[det].antenna_pattern(ra, dec,
                                     params['polarization'], tc)
 
@@ -674,7 +670,7 @@ class MarginalizedHMPolPhase(BaseGaussianNoise):
         for det, modes in wfs.items():
             if det not in self.dets:
                 self.dets[det] = Detector(det)
-            tc = self.dets[det].convert_tc(ref_tc, ra, dec, refframe)
+            tc = self.dets[det].arrival_time(ref_tc, ra, dec, refframe)
             fp, fc = self.dets[det].antenna_pattern(ra, dec, self.pol, tc)
 
             # loop over modes and prepare the waveform modes

--- a/pycbc/inference/models/marginalized_gaussian_noise.py
+++ b/pycbc/inference/models/marginalized_gaussian_noise.py
@@ -328,14 +328,14 @@ class MarginalizedTime(DistMarg, BaseGaussianNoise):
 
         self.draw_ifos(snr_estimate, log=False, **self.kwargs)
         self.snr_draw(snrs=snr_estimate)
-
+        
+        refframe = params.get('tc_ref_frame', 'geocentric')
+        ra = params['ra']
+        dec = params['dec']
+        ref_tc = params['tc']
         for det in wfs:
             if det not in self.dets:
                 self.dets[det] = Detector(det)
-            refframe = params.get('tc_ref_frame', 'geocentric')
-            ra = params['ra']
-            dec = params['dec']
-            ref_tc = params['tc']
             tc = self.dets[det].convert_tc(ref_tc, ra, dec, refframe)
             if self.precalc_antenna_factors:
                 fp, fc, dt = self.get_precalc_antenna_factors(det)
@@ -465,13 +465,13 @@ class MarginalizedPolarization(DistMarg, BaseGaussianNoise):
                 wfs.update(self.waveform_generator[det].generate(**params))
 
         lr = sh_total = hh_total = 0.
+        refframe = params.get('tc_ref_frame', 'geocentric')
+        ra = params['ra']
+        dec = params['dec']
+        ref_tc = params['tc']
         for det, (hp, hc) in wfs.items():
             if det not in self.dets:
                 self.dets[det] = Detector(det)
-            refframe = params.get('tc_ref_frame', 'geocentric')
-            ra = params['ra']
-            dec = params['dec']
-            ref_tc = params['tc']
             tc = self.dets[det].convert_tc(ref_tc, ra, dec, refframe)
             fp, fc = self.dets[det].antenna_pattern(ra, dec,
                                     params['polarization'], tc)
@@ -667,13 +667,13 @@ class MarginalizedHMPolPhase(BaseGaussianNoise):
         lr = 0.
         hds = {}
         hhs = {}
+        refframe = params.get('tc_ref_frame', 'geocentric')
+        ra = params['ra']
+        dec = params['dec']
+        ref_tc = params['tc']
         for det, modes in wfs.items():
             if det not in self.dets:
                 self.dets[det] = Detector(det)
-            refframe = params.get('tc_ref_frame', 'geocentric')
-            ra = params['ra']
-            dec = params['dec']
-            ref_tc = params['tc']
             tc = self.dets[det].convert_tc(ref_tc, ra, dec, refframe)
             fp, fc = self.dets[det].antenna_pattern(ra, dec, self.pol, tc)
 

--- a/pycbc/inference/models/marginalized_gaussian_noise.py
+++ b/pycbc/inference/models/marginalized_gaussian_noise.py
@@ -336,7 +336,7 @@ class MarginalizedTime(DistMarg, BaseGaussianNoise):
             ra = params['ra']
             dec = params['dec']
             ref_tc = params['tc']
-            tc = self.waveform_generator.convert_tc(ref_tc, ra, dec, 
+            tc = self.dets[det].convert_tc(ref_tc, ra, dec, 
                                                     det, refframe)
             if self.precalc_antenna_factors:
                 fp, fc, dt = self.get_precalc_antenna_factors(det)
@@ -473,7 +473,7 @@ class MarginalizedPolarization(DistMarg, BaseGaussianNoise):
             ra = params['ra']
             dec = params['dec']
             ref_tc = params['tc']
-            tc = self.waveform_generator.convert_tc(ref_tc, ra, dec, 
+            tc = self.dets[det].convert_tc(ref_tc, ra, dec, 
                                                     det, refframe)
             fp, fc = self.dets[det].antenna_pattern(ra, dec,
                                     params['polarization'], tc)
@@ -676,7 +676,7 @@ class MarginalizedHMPolPhase(BaseGaussianNoise):
             ra = params['ra']
             dec = params['dec']
             ref_tc = params['tc']
-            tc = self.waveform_generator.convert_tc(ref_tc, ra, dec, 
+            tc = self.dets[det].convert_tc(ref_tc, ra, dec, 
                                                     det, refframe)
             fp, fc = self.dets[det].antenna_pattern(ra, dec, self.pol, tc)
 

--- a/pycbc/inference/models/marginalized_gaussian_noise.py
+++ b/pycbc/inference/models/marginalized_gaussian_noise.py
@@ -336,8 +336,7 @@ class MarginalizedTime(DistMarg, BaseGaussianNoise):
             ra = params['ra']
             dec = params['dec']
             ref_tc = params['tc']
-            tc = self.dets[det].convert_tc(ref_tc, ra, dec, 
-                                                    det, refframe)
+            tc = self.dets[det].convert_tc(ref_tc, ra, dec, refframe)
             if self.precalc_antenna_factors:
                 fp, fc, dt = self.get_precalc_antenna_factors(det)
                 pol_phase = numpy.exp(-2.0j * params['polarization'])
@@ -473,8 +472,7 @@ class MarginalizedPolarization(DistMarg, BaseGaussianNoise):
             ra = params['ra']
             dec = params['dec']
             ref_tc = params['tc']
-            tc = self.dets[det].convert_tc(ref_tc, ra, dec, 
-                                                    det, refframe)
+            tc = self.dets[det].convert_tc(ref_tc, ra, dec, refframe)
             fp, fc = self.dets[det].antenna_pattern(ra, dec,
                                     params['polarization'], tc)
 
@@ -676,8 +674,7 @@ class MarginalizedHMPolPhase(BaseGaussianNoise):
             ra = params['ra']
             dec = params['dec']
             ref_tc = params['tc']
-            tc = self.dets[det].convert_tc(ref_tc, ra, dec, 
-                                                    det, refframe)
+            tc = self.dets[det].convert_tc(ref_tc, ra, dec, refframe)
             fp, fc = self.dets[det].antenna_pattern(ra, dec, self.pol, tc)
 
             # loop over modes and prepare the waveform modes

--- a/pycbc/inference/models/marginalized_gaussian_noise.py
+++ b/pycbc/inference/models/marginalized_gaussian_noise.py
@@ -340,15 +340,19 @@ class MarginalizedTime(DistMarg, BaseGaussianNoise):
                 fp = f.real
                 fc = f.imag
             else:
+                refframe = params.get('tc_ref_frame', 'geocentric')
+                ra = params['ra']
+                dec = params['dec']
+                ref_tc = params['tc']
+                tc = self.waveform_generator.convert_tc(ref_tc, ra, dec, 
+                                                        det, refframe)
                 fp, fc = self.dets[det].antenna_pattern(
-                                        params['ra'],
-                                        params['dec'],
-                                        params['polarization'],
-                                        params['tc'])
+                                        ra, dec,
+                                        params['polarization'], tc)
                 dt = self.dets[det].time_delay_from_earth_center(params['ra'],
                                                                  params['dec'],
-                                                                 params['tc'])
-            dtc = params['tc'] + dt
+                                                                 tc)
+            dtc = tc + dt
 
             cplx_hd = fp * cplx_hpd[det].at_time(dtc,
                                                  interpolate='quadratic')
@@ -466,11 +470,14 @@ class MarginalizedPolarization(DistMarg, BaseGaussianNoise):
         for det, (hp, hc) in wfs.items():
             if det not in self.dets:
                 self.dets[det] = Detector(det)
-            fp, fc = self.dets[det].antenna_pattern(
-                                    params['ra'],
-                                    params['dec'],
-                                    params['polarization'],
-                                    params['tc'])
+            refframe = params.get('tc_ref_frame', 'geocentric')
+            ra = params['ra']
+            dec = params['dec']
+            ref_tc = params['tc']
+            tc = self.waveform_generator.convert_tc(ref_tc, ra, dec, 
+                                                    det, refframe)
+            fp, fc = self.dets[det].antenna_pattern(ra, dec,
+                                    params['polarization'], tc)
 
             # the kmax of the waveforms may be different than internal kmax
             kmax = min(max(len(hp), len(hc)), self._kmax[det])
@@ -666,11 +673,13 @@ class MarginalizedHMPolPhase(BaseGaussianNoise):
         for det, modes in wfs.items():
             if det not in self.dets:
                 self.dets[det] = Detector(det)
-
-            fp, fc = self.dets[det].antenna_pattern(params['ra'],
-                                                    params['dec'],
-                                                    self.pol,
-                                                    params['tc'])
+            refframe = params.get('tc_ref_frame', 'geocentric')
+            ra = params['ra']
+            dec = params['dec']
+            ref_tc = params['tc']
+            tc = self.waveform_generator.convert_tc(ref_tc, ra, dec, 
+                                                    det, refframe)
+            fp, fc = self.dets[det].antenna_pattern(ra, dec, self.pol, tc)
 
             # loop over modes and prepare the waveform modes
             # we will sum up zetalm = glm <ulm, d> + i glm <vlm, d>

--- a/pycbc/inference/models/marginalized_gaussian_noise.py
+++ b/pycbc/inference/models/marginalized_gaussian_noise.py
@@ -332,7 +332,12 @@ class MarginalizedTime(DistMarg, BaseGaussianNoise):
         for det in wfs:
             if det not in self.dets:
                 self.dets[det] = Detector(det)
-
+            refframe = params.get('tc_ref_frame', 'geocentric')
+            ra = params['ra']
+            dec = params['dec']
+            ref_tc = params['tc']
+            tc = self.waveform_generator.convert_tc(ref_tc, ra, dec, 
+                                                    det, refframe)
             if self.precalc_antenna_factors:
                 fp, fc, dt = self.get_precalc_antenna_factors(det)
                 pol_phase = numpy.exp(-2.0j * params['polarization'])
@@ -340,12 +345,6 @@ class MarginalizedTime(DistMarg, BaseGaussianNoise):
                 fp = f.real
                 fc = f.imag
             else:
-                refframe = params.get('tc_ref_frame', 'geocentric')
-                ra = params['ra']
-                dec = params['dec']
-                ref_tc = params['tc']
-                tc = self.waveform_generator.convert_tc(ref_tc, ra, dec, 
-                                                        det, refframe)
                 fp, fc = self.dets[det].antenna_pattern(
                                         ra, dec,
                                         params['polarization'], tc)

--- a/pycbc/waveform/generator.py
+++ b/pycbc/waveform/generator.py
@@ -676,18 +676,19 @@ class FDomainDetFrameGenerator(BaseFDomainDetFrameGenerator):
                 dec = self.current_params['dec']
                 ref_tc = self.current_params['tc']
                 pol = self.current_params['polarization']
+                # apply response function
+                fp, fc = det.antenna_pattern(ra, dec, pol, ref_tc)
+                thish = fp*hp + fc*hc
+                # time shift
                 if refframe == 'geocentric':
-                    # apply detector response function
-                    fp, fc = det.antenna_pattern(ra, dec, pol, ref_tc)
-                    thish = fp*hp + fc*hc
-                    # apply the time shift from geocenter
+                    # from geocenter
                     tc = ref_tc + \
                         det.time_delay_from_earth_center(ra, dec, ref_tc)
                 elif refframe == detname:
-                    # do not apply a time shift; tc is being sampled in this det
+                    # no time shift; sampling in current det
                     tc = ref_tc
                 elif refframe in self.detectors.keys():
-                    # apply time shift from sampling det to current det
+                    # from sampling det
                     refdet = self.detectors[refframe]
                     tc = ref_tc + \
                         det.time_delay_from_detector(refdet, ra, dec, ref_tc)

--- a/pycbc/waveform/generator.py
+++ b/pycbc/waveform/generator.py
@@ -676,10 +676,7 @@ class FDomainDetFrameGenerator(BaseFDomainDetFrameGenerator):
                 dec = self.current_params['dec']
                 ref_tc = self.current_params['tc']
                 pol = self.current_params['polarization']
-                # apply response function
-                fp, fc = det.antenna_pattern(ra, dec, pol, ref_tc)
-                thish = fp*hp + fc*hc
-                # time shift
+                # convert tc to detector frame
                 if refframe == 'geocentric':
                     # from geocenter
                     tc = ref_tc + \
@@ -695,6 +692,10 @@ class FDomainDetFrameGenerator(BaseFDomainDetFrameGenerator):
                 else:
                     raise ValueError('tc_ref_frame param must be a detector name',
                                      'or "geocentric"')
+                # apply response function
+                fp, fc = det.antenna_pattern(ra, dec, pol, tc)
+                thish = fp*hp + fc*hc
+                # apply time shift
                 h[detname] = apply_fd_time_shift(thish, tc+tshift, copy=False)
                 if self.recalib:
                     # recalibrate with given calibration model

--- a/pycbc/waveform/generator.py
+++ b/pycbc/waveform/generator.py
@@ -561,45 +561,6 @@ class BaseFDomainDetFrameGenerator(metaclass=ABCMeta):
     def select_rframe_generator(self, approximant):
         """Method to select waveform generator based on an approximant."""
         pass
-    
-    def convert_tc(self, ref_tc, ra, dec, current_frame,
-                   ref_frame='geocentric'):
-        """Convert tc from reference frame to another detector.
-        
-        Parameters
-        ----------
-        ref_tc : {float, lal.LIGOTimeGPS}
-            The coalescence time to convert, defined in ref_frame
-        ra : float
-            Right ascension.
-        dec : float
-            Declination.
-        current_frame : str
-            The detector to convert to.
-        ref_frame : str (optional)
-            The detector to convert from, in which tc is sampled. Default
-            'geocentric'.
-            
-        Returns
-        -------
-        float : 
-            The coalescence time converted to the detector specified by
-            current_frame.
-        """
-        cdet = Detector(current_frame)
-        if ref_frame == 'geocentric':
-            # from geocenter
-            tc = ref_tc + \
-                cdet.time_delay_from_earth_center(ra, dec, ref_tc)
-        elif ref_frame == current_frame:
-            # no time shift; sampling in current det
-            tc = ref_tc
-        else:
-            # from sampling det
-            refdet = Detector(ref_frame)
-            tc = ref_tc + \
-                cdet.time_delay_from_detector(refdet, ra, dec, ref_tc)
-        return tc
 
 
 class FDomainDetFrameGenerator(BaseFDomainDetFrameGenerator):

--- a/pycbc/waveform/generator.py
+++ b/pycbc/waveform/generator.py
@@ -678,7 +678,7 @@ class FDomainDetFrameGenerator(BaseFDomainDetFrameGenerator):
                 dec = self.current_params['dec']
                 ref_tc = self.current_params['tc']
                 pol = self.current_params['polarization']
-                tc = self.det.convert_tc(ref_tc, ra, dec, refframe)
+                tc = det.convert_tc(ref_tc, ra, dec, refframe)
                 # apply response function
                 fp, fc = det.antenna_pattern(ra, dec, pol, tc)
                 thish = fp*hp + fc*hc
@@ -815,7 +815,7 @@ class FDomainDetFrameTwoPolGenerator(BaseFDomainDetFrameGenerator):
                 ra = self.current_params['ra']
                 dec = self.current_params['dec']
                 ref_tc = self.current_params['tc']
-                tc = self.convert_tc(ref_tc, ra, dec, detname, refframe)
+                tc = det.convert_tc(ref_tc, ra, dec, refframe)
                 # apply time shift
                 dethp = apply_fd_time_shift(hp, tc+tshift, copy=True)
                 dethc = apply_fd_time_shift(hc, tc+tshift, copy=True)
@@ -1068,7 +1068,7 @@ class FDomainDetFrameModesGenerator(BaseFDomainDetFrameGenerator):
                     ra = self.current_params['ra']
                     dec = self.current_params['dec']
                     ref_tc = self.current_params['tc']
-                    tc = self.convert_tc(ref_tc, ra, dec, detname, refframe)
+                    tc = det.convert_tc(ref_tc, ra, dec, refframe)
                     # apply time shift
                     detulm = apply_fd_time_shift(ulm, tc+tshift, copy=True)
                     detvlm = apply_fd_time_shift(vlm, tc+tshift, copy=True)

--- a/pycbc/waveform/generator.py
+++ b/pycbc/waveform/generator.py
@@ -690,7 +690,7 @@ class FDomainDetFrameGenerator(BaseFDomainDetFrameGenerator):
                     tc = ref_tc + \
                         det.time_delay_from_detector(refdet, ra, dec, ref_tc)
                 else:
-                    raise ValueError('tc_ref_frame param must be a detector name',
+                    raise ValueError('tc_ref_frame param must be a detector name ',
                                      'or "geocentric"')
                 # apply response function
                 fp, fc = det.antenna_pattern(ra, dec, pol, tc)
@@ -821,10 +821,27 @@ class FDomainDetFrameTwoPolGenerator(BaseFDomainDetFrameGenerator):
         h = {}
         if self.detector_names != ['RF']:
             for detname, det in self.detectors.items():
-                # apply the time shift
-                tc = self.current_params['tc'] + \
-                    det.time_delay_from_earth_center(self.current_params['ra'],
-                         self.current_params['dec'], self.current_params['tc'])
+                refframe = self.current_params.get('tc_ref_frame', 'geocentric')
+                ra = self.current_params['ra']
+                dec = self.current_params['dec']
+                ref_tc = self.current_params['tc']
+                # convert tc to detector frame
+                if refframe == 'geocentric':
+                    # from geocenter
+                    tc = ref_tc + \
+                        det.time_delay_from_earth_center(ra, dec, ref_tc)
+                elif refframe == detname:
+                    # no time shift; sampling in current det
+                    tc = ref_tc
+                elif refframe in self.detectors.keys():
+                    # from sampling det
+                    refdet = self.detectors[refframe]
+                    tc = ref_tc + \
+                        det.time_delay_from_detector(refdet, ra, dec, ref_tc)
+                else:
+                    raise ValueError('tc_ref_frame param must be a detector name ',
+                                     'or "geocentric"')
+                # apply time shift
                 dethp = apply_fd_time_shift(hp, tc+tshift, copy=True)
                 dethc = apply_fd_time_shift(hc, tc+tshift, copy=True)
                 if self.recalib:
@@ -1069,12 +1086,27 @@ class FDomainDetFrameModesGenerator(BaseFDomainDetFrameGenerator):
             ulm._epoch = vlm._epoch = self._epoch
             if self.detector_names != ['RF']:
                 for detname, det in self.detectors.items():
-                    # apply the time shift
-                    tc = self.current_params['tc'] + \
-                        det.time_delay_from_earth_center(
-                            self.current_params['ra'],
-                            self.current_params['dec'],
-                            self.current_params['tc'])
+                    refframe = self.current_params.get('tc_ref_frame', 'geocentric')
+                    ra = self.current_params['ra']
+                    dec = self.current_params['dec']
+                    ref_tc = self.current_params['tc']
+                    # convert tc to detector frame
+                    if refframe == 'geocentric':
+                        # from geocenter
+                        tc = ref_tc + \
+                            det.time_delay_from_earth_center(ra, dec, ref_tc)
+                    elif refframe == detname:
+                        # no time shift; sampling in current det
+                        tc = ref_tc
+                    elif refframe in self.detectors.keys():
+                        # from sampling det
+                        refdet = self.detectors[refframe]
+                        tc = ref_tc + \
+                            det.time_delay_from_detector(refdet, ra, dec, ref_tc)
+                    else:
+                        raise ValueError('tc_ref_frame param must be a detector name ',
+                                         'or "geocentric"')
+                    # apply time shift
                     detulm = apply_fd_time_shift(ulm, tc+tshift, copy=True)
                     detvlm = apply_fd_time_shift(vlm, tc+tshift, copy=True)
                     if self.recalib:

--- a/pycbc/waveform/generator.py
+++ b/pycbc/waveform/generator.py
@@ -671,7 +671,7 @@ class FDomainDetFrameGenerator(BaseFDomainDetFrameGenerator):
         h = {}
         if self.detector_names != ['RF']:
             for detname, det in self.detectors.items():
-                refframe = self.current_params.get('tc_ref_frame')
+                refframe = self.current_params.get('tc_ref_frame', 'geocentric')
                 ra = self.current_params['ra']
                 dec = self.current_params['dec']
                 ref_tc = self.current_params['tc']

--- a/pycbc/waveform/generator.py
+++ b/pycbc/waveform/generator.py
@@ -686,7 +686,7 @@ class FDomainDetFrameGenerator(BaseFDomainDetFrameGenerator):
                 elif refframe == detname:
                     # do not apply a time shift; tc is being sampled in this det
                     tc = ref_tc
-                elif refframe in self.detectors.items():
+                elif refframe in self.detectors.keys():
                     # apply time shift from sampling det to current det
                     refdet = self.detectors[refframe]
                     tc = ref_tc + \

--- a/pycbc/waveform/generator.py
+++ b/pycbc/waveform/generator.py
@@ -678,7 +678,7 @@ class FDomainDetFrameGenerator(BaseFDomainDetFrameGenerator):
                 dec = self.current_params['dec']
                 ref_tc = self.current_params['tc']
                 pol = self.current_params['polarization']
-                tc = self.convert_tc(ref_tc, ra, dec, detname, refframe)
+                tc = self.det.convert_tc(ref_tc, ra, dec, refframe)
                 # apply response function
                 fp, fc = det.antenna_pattern(ra, dec, pol, tc)
                 thish = fp*hp + fc*hc

--- a/pycbc/waveform/generator.py
+++ b/pycbc/waveform/generator.py
@@ -639,10 +639,13 @@ class FDomainDetFrameGenerator(BaseFDomainDetFrameGenerator):
         generator class; instead, they are used to apply the detector response
         function and/or shift the waveform in time. The parameters are:
 
-          * tc: The GPS time of coalescence (should be geocentric time).
+          * tc: The GPS time of coalescence.
           * ra: Right ascension.
           * dec: declination
           * polarization: polarization.
+          * tc_ref_frame (optional): reference frame in which tc is defined.
+            Must be one of: 'geocentric', for geocentric time, or one of the
+            detector names. Default 'geocentric.'
 
         All of these must be provided in either the variable args or the
         frozen params if detectors is not None. If detectors
@@ -785,9 +788,12 @@ class FDomainDetFrameTwoPolGenerator(BaseFDomainDetFrameGenerator):
         generator class; instead, they are used to apply the detector response
         function and/or shift the waveform in time. The parameters are:
 
-          * tc: The GPS time of coalescence (should be geocentric time).
+          * tc: The GPS time of coalescence.
           * ra: Right ascension.
           * dec: declination
+          * tc_ref_frame (optional): reference frame in which tc is defined.
+            Must be one of: 'geocentric', for geocentric time, or one of the
+            detector names. Default 'geocentric.'
 
         All of these must be provided in either the variable args or the
         frozen params if detectors is not None. If detectors
@@ -1048,6 +1054,9 @@ class FDomainDetFrameModesGenerator(BaseFDomainDetFrameGenerator):
           * tc: The GPS time of coalescence (should be geocentric time).
           * ra: Right ascension.
           * dec: declination
+          * tc_ref_frame (optional): reference frame in which tc is defined.
+            Must be one of: 'geocentric', for geocentric time, or one of the
+            detector names. Default 'geocentric.'
 
         All of these must be provided in either the variable args or the
         frozen params if detectors is not None. If detectors

--- a/pycbc/waveform/generator.py
+++ b/pycbc/waveform/generator.py
@@ -672,13 +672,13 @@ class FDomainDetFrameGenerator(BaseFDomainDetFrameGenerator):
         hp._epoch = hc._epoch = self._epoch
         h = {}
         if self.detector_names != ['RF']:
+            ra = self.current_params['ra']
+            dec = self.current_params['dec']
+            ref_tc = self.current_params['tc']
+            pol = self.current_params['polarization']
+            refframe = self.current_params.get('tc_ref_frame', 'geocentric')
             for detname, det in self.detectors.items():
-                refframe = self.current_params.get('tc_ref_frame', 'geocentric')
-                ra = self.current_params['ra']
-                dec = self.current_params['dec']
-                ref_tc = self.current_params['tc']
-                pol = self.current_params['polarization']
-                tc = det.convert_tc(ref_tc, ra, dec, refframe)
+                tc = det.arrival_time(ref_tc, ra, dec, refframe)
                 # apply response function
                 fp, fc = det.antenna_pattern(ra, dec, pol, tc)
                 thish = fp*hp + fc*hc
@@ -815,7 +815,7 @@ class FDomainDetFrameTwoPolGenerator(BaseFDomainDetFrameGenerator):
                 ra = self.current_params['ra']
                 dec = self.current_params['dec']
                 ref_tc = self.current_params['tc']
-                tc = det.convert_tc(ref_tc, ra, dec, refframe)
+                tc = det.arrival_time(ref_tc, ra, dec, refframe)
                 # apply time shift
                 dethp = apply_fd_time_shift(hp, tc+tshift, copy=True)
                 dethc = apply_fd_time_shift(hc, tc+tshift, copy=True)
@@ -1068,7 +1068,7 @@ class FDomainDetFrameModesGenerator(BaseFDomainDetFrameGenerator):
                     ra = self.current_params['ra']
                     dec = self.current_params['dec']
                     ref_tc = self.current_params['tc']
-                    tc = det.convert_tc(ref_tc, ra, dec, refframe)
+                    tc = det.arrival_time(ref_tc, ra, dec, refframe)
                     # apply time shift
                     detulm = apply_fd_time_shift(ulm, tc+tshift, copy=True)
                     detvlm = apply_fd_time_shift(vlm, tc+tshift, copy=True)

--- a/test/test_detector.py
+++ b/test/test_detector.py
@@ -117,7 +117,42 @@ class TestDetector(unittest.TestCase):
 
             self.assertAlmostEqual(ra, ra1, 3)
             self.assertAlmostEqual(dec, dec1, 7)
-
+            
+    def test_det_tc_conversion(self):
+        """Test that the convert_tc method functions properly. The same times
+        should be returned in all frames regardless of the reference.
+        """
+        vals = list(zip(self.ra, self.dec, self.time))
+        ref_frames = ['geocentric', 'H1', 'L1', 'V1']
+        target_frames = ['H1', 'L1', 'V1']
+        # convert the times from geocentric using time_delay_from_earth_center
+        test_times = {'geocentric': self.time}
+        for ifo in target_frames:
+            d = det.Detector(ifo)
+            det_times = []
+            for ra1, dec1, time1 in vals:
+                tc = time1 + d.time_delay_from_earth_center(ra1, dec1, time1)
+                det_times.append(tc)
+            test_times[ifo] = det_times
+        # convert the nominal times to each of the other detectors
+        for target_ifo in target_frames:
+            # set up the target detector
+            d = det.Detector(target_ifo)
+            target_times = test_times[target_ifo]
+            for ref_ifo in ref_frames:
+                ref_times = test_times[ref_ifo]
+                converted_times = []
+                for i in range(len(vals)):
+                    ra1, dec1, _ = vals[i]
+                    ref_tc = ref_times[i]
+                    # convert the reference time to the target detector
+                    tc = d.convert_tc(ref_tc, ra1, dec1, ref_frame = ref_ifo)
+                    converted_times.append(tc)
+                # check that the times converted to target match nominal
+                print(f"Testing conversion from {ref_ifo} to {target_ifo}")
+                for i in range(len(converted_times)):
+                    self.assertAlmostEqual(converted_times[i], target_times[i], 
+                                           places=6)
 
 suite = unittest.TestSuite()
 suite.addTest(unittest.TestLoader().loadTestsFromTestCase(TestDetector))

--- a/test/test_detector.py
+++ b/test/test_detector.py
@@ -146,7 +146,7 @@ class TestDetector(unittest.TestCase):
                     ra1, dec1, _ = vals[i]
                     ref_tc = ref_times[i]
                     # convert the reference time to the target detector
-                    tc = d.convert_tc(ref_tc, ra1, dec1, ref_frame = ref_ifo)
+                    tc = d.arrival_time(ref_tc, ra1, dec1, ref_frame = ref_ifo)
                     converted_times.append(tc)
                 # check that the times converted to target match nominal
                 print(f"Testing conversion from {ref_ifo} to {target_ifo}")


### PR DESCRIPTION
This PR adds the ability to sample the coalescence time parameter `tc` in the detector frame. Currently, `tc` is sampled in the geocentric frame and converted to detector frames to calculate likelihoods. The changes here preserve this behavior by default, but add the ability to sample in one of the detectors specified in the inference configuration.

## Standard information about the request

This is a new feature. This change mainly affects inference when using `FDomainDetFrameGenerator`. Any code that uses the `generate` method to generate waveforms in the detector frame can also make use of this. Current functionality (generating using `tc` in geocentric frame) is preserved by default.

## Motivation
This change is being made as a potential improvement to convergence when conducting PE, especially when implementing sky location and time marginalization in PE (see PR #5117). Sampling over the full sky can result in a ~30 ms variation in arrival time. If we additionally sample over `tc` directly, this can lead to a large posterior range. Additionally, there is a degeneracy between shifting sky location and `tc` that can lead to complicated posterior distributions, which can lead to convergence issues in the results. Sampling in one of the detector frames should alleviate convergence issues by removing the degeneracy between `tc` and sky location and reducing the sampling uncertainty in at least one of the detectors.

## Contents
All changes are made to the `generate` method of `FDomainDetFrameGenerator`. This functionality can be activated by adding an option `tc_ref_frame` to the configuration, e.g.:
```
[static-params]
tc_ref_frame = L1
```
During waveform generation in PE, time shifts will be applied in each detector relative to the specified frame. If `tc_ref_frame = geocentric` is specified (or if the option is omitted from the config), the same `time_delay_from_earth_center` delay is applied to all detectors, mimicking current behavior. If the specified frame matches one of the detectors specified in the `[data]` section, no time shift will be applied in that detector, and `time_delay_from_detector` is used instead to compute the time shift from the sampling detector to all other detectors.

- [ x ] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
