### PR TITLE
Add functionality to combine posteriors via evidence sampling in `extract_samples`

### DIFF
--- a/bin/inference/pycbc_inference_extract_samples
+++ b/bin/inference/pycbc_inference_extract_samples
@@ -228,19 +228,17 @@ for fp in fps:
                 current_val = format_attr(out.attrs[key])
             if not isthesame(current_val, val):
                 if key == 'remapped_params':
-                    # ...unless it's remapped_params; just combine unique items
-                    # brute-force if they don't match exactly
-                    cat_params = True
-                    val = numpy.concatenate((val, current_val))
-                    val_set = set(tuple(entry) for entry in val)
-                    val = [list(entry) for entry in val_set]
-                    out.attrs[key] = val
+                    # ...unless it's remapped_params; just save first file's
+                    # entries if they don't match between files
+                    warnings.warn("WARNING: remapped_params metadata does not "
+                                 "match between files; saving metadata from "
+                                 "first file")
                 else:
                     raise ValueError("cannot combine all files; file attr {} is "
                                      "not the same across all files ({} vs {})"
                                      .format(key, current_val, val))
 
-# store what parameters were renamed (if not already concatenated above)
+# store what parameters were renamed (if not already saved above)
 if not cat_params:
     out.attrs['remapped_params'] = list(labels.items())
 


### PR DESCRIPTION
This PR adds functionality to combine posteriors by sampling according to their evidence values when running `pycbc_inference_extract_samples` with multiple input files.

## Standard information about the request

This is a new feature. Current functionality is preserved by default; a new command line argument activates the new functionality. This change affects posterior extraction from raw inference outputs.

## Motivation
Currently, running `pycbc_inference_extract_samples` with multiple input files will combine all posterior samples into one output file, discarding any metadata related to evidence. If, for example, one wishes to split one of the priors across multiple inference jobs (to improve convergence, parallelize the process, etc.), the ideal way to combine posteriors would be to sample points from each run according to their individual evidence values rather than saving all points in one file. A sub-posterior with an evidence value twice as high as another should have twice as many points in the full posterior.

## Contents
A new command-line input, `--combine-via-sampling`, has been added to `pycbc_inference_extract_samples` to allow for posterior file combination where samples are selected according to each file's log evidence values. Each input posterior's samples are assigned a common weight based on that posterior's log evidence value. Points are then sampled for the full posterior by drawing points randomly based on these weights. The resulting posterior will contain as many points as the smallest input posterior, and will contain logZ and dlogZ values in the metadata computed from the `logsumexp` of each logZ and the quadrature sum of each dlogZ, respectively. The original functionality is preserved simply by not specifying `combine-via-sampling` when running `extract_samples`.

- [ x ] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
