### PR TITLE
PyGRB: mark minifollowup subworkflows as parents of results_page jobs

### DIFF
--- a/bin/pygrb/pycbc_make_offline_grb_workflow
+++ b/bin/pygrb/pycbc_make_offline_grb_workflow
@@ -134,15 +134,15 @@ if onSrc is None:
         seg_dir, fail_criterion=offSrc)
     logging.info("Making segment plot and exiting.")
     sys.exit()
-else:
-    plot_met = make_grb_segments_plot(
-        wflow, sciSegs, triggertime, triggername, seg_dir,
-        coherent_seg=offSrc[tuple(offSrc.keys())[0]][0])
-    segs_plot = _workflow.File(plot_met[0], plot_met[1], plot_met[2],
-                               file_url=plot_met[3])
-    segs_plot.add_pfn(segs_plot.cache_entry.path, site="local")
-    sciSegs = offSrc
-    all_files.append(segs_plot)
+
+plot_met = make_grb_segments_plot(
+    wflow, sciSegs, triggertime, triggername, seg_dir,
+    coherent_seg=offSrc[tuple(offSrc.keys())[0]][0])
+segs_plot = _workflow.File(plot_met[0], plot_met[1], plot_met[2],
+                           file_url=plot_met[3])
+segs_plot.add_pfn(segs_plot.cache_entry.path, site="local")
+sciSegs = offSrc
+all_files.append(segs_plot)
 
 if len(sciSegs) == 1:
     logging.info("Generating a single IFO search.")

--- a/bin/pygrb/pycbc_make_offline_grb_workflow
+++ b/bin/pygrb/pycbc_make_offline_grb_workflow
@@ -49,7 +49,6 @@ init_logging(args.verbose, default_level=1)
 wflow = _workflow.Workflow(args, workflow_name)
 all_files = _workflow.FileList([])
 tags = []
-init_dir = os.getcwd()
 
 logging.info("Generating %s workflow" % workflow_name)
 
@@ -110,12 +109,12 @@ else:
 # Do checks for no/single IFO case
 single_ifo = wflow.cp.has_option("workflow", "allow-single-ifo-search")
 if len(sciSegs.keys()) == 0:
-    plot_met = make_grb_segments_plot(wflow, segmentlistdict(), triggertime,
+    make_grb_segments_plot(wflow, segmentlistdict(), triggertime,
                                       triggername, seg_dir)
     logging.error("No science segments available.")
     sys.exit()
 elif len(sciSegs.keys()) < 2 and not single_ifo:
-    plot_met = make_grb_segments_plot(wflow, segmentlistdict(sciSegs),
+    make_grb_segments_plot(wflow, segmentlistdict(sciSegs),
                                       triggertime, triggername, seg_dir)
     msg = "Science segments exist only for %s. " % tuple(sciSegs.keys())[0]
     msg += "If you wish to enable single IFO running add the option "
@@ -130,7 +129,7 @@ else:
 
 sciSegs = segmentlistdict(sciSegs)
 if onSrc is None:
-    plot_met = make_grb_segments_plot(
+    make_grb_segments_plot(
         wflow, sciSegs, triggertime, triggername,
         seg_dir, fail_criterion=offSrc)
     logging.info("Making segment plot and exiting.")
@@ -176,8 +175,6 @@ elif wflow.cp.has_option("inspiral", "analyse-segment-end"):
 else:
     wflow.analysis_time = segment(int(sciSegs[ifo][0][0]) + deadtime + padding,
                                   int(sciSegs[ifo][0][1]) - deadtime - padding)
-
-ext_file = None
 
 # DATAFIND
 df_dir = os.path.join(curr_dir, "datafind")

--- a/bin/pygrb/pycbc_pygrb_results_workflow
+++ b/bin/pygrb/pycbc_pygrb_results_workflow
@@ -232,6 +232,7 @@ wflow.ifos = ifos
 
 plotting_nodes = []
 html_nodes = []
+mfu_nodes = []
 
 # Convert the segments files to a FileList
 seg_files = _workflow.build_segment_filelist(args.segment_dir)
@@ -531,7 +532,7 @@ for inj_set in inj_sets:
         logging.info(msg)
     else:
         logging.info('Entering minifollowups module for injections')
-        _workflow.setup_pygrb_minifollowups(
+        mfu_node = _workflow.setup_pygrb_minifollowups(
             wflow,
             qf_h5,
             offsource_file,
@@ -541,6 +542,7 @@ for inj_set in inj_sets:
             veto_file=veto_file,
             tags=inj_file.tags + ['loudest_quiet_found_injs'],
         )
+        mfu_nodes.append(mfu_node)
         logging.info('Leaving minifollowups')
 
 #
@@ -584,7 +586,7 @@ if not wflow.cp.has_section('workflow-minifollowups'):
     logging.info(msg)
 else:
     logging.info('Entering minifollowups module for offsource')
-    _workflow.setup_pygrb_minifollowups(
+    mfu_node = _workflow.setup_pygrb_minifollowups(
         wflow,
         lofft_h5,
         offsource_file,
@@ -594,6 +596,7 @@ else:
         veto_file=veto_file,
         tags=['loudest_offsource_events'],
     )
+    mfu_nodes.append(mfu_node)
     logging.info('Leaving minifollowups')
 
 
@@ -764,7 +767,6 @@ for snr_type in ['reweighted', 'coherent']:
 openbox_layout = [(lont_table,)] + list(layout.grouper(timeseries_plots, 2))
 layout.two_column_layout(out_dir, openbox_layout)
 
-
 # Loudest on-source trigger follow up
 out_dir = rdir['open_box/loudest_event_followup']
 if not wflow.cp.has_section('workflow-minifollowups'):
@@ -773,7 +775,7 @@ if not wflow.cp.has_section('workflow-minifollowups'):
     logging.info(msg)
 else:
     logging.info("Entering minifollowups module for loudest onsource")
-    _workflow.setup_pygrb_minifollowups(
+    mfu_node = _workflow.setup_pygrb_minifollowups(
         wflow,
         lont_h5,
         onsource_file,
@@ -783,6 +785,7 @@ else:
         veto_file=veto_file,
         tags=['loudest_onsource_event'],
     )
+    mfu_nodes.append(mfu_node)
     logging.info("Leaving onsource minifollowups")
 
 # Exclusion distances and efficiency plots based on the on-source
@@ -830,7 +833,7 @@ _workflow.make_results_web_page(
     wflow,
     os.path.join(os.getcwd(), rdir.base),
     template='red',
-    explicit_dependencies=plotting_nodes + html_nodes,
+    explicit_dependencies=plotting_nodes + html_nodes + mfu_nodes,
 )
 
 # Close the log and flush to the html file

--- a/pycbc/workflow/grb_utils.py
+++ b/pycbc/workflow/grb_utils.py
@@ -757,6 +757,8 @@ def setup_pygrb_minifollowups(workflow, followups_file, trigger_file,
     job.add_into_workflow(workflow)
     logging.info('Leaving minifollowups module')
 
+    return job
+
 
 def setup_pygrb_results_workflow(workflow, res_dir, trig_files,
                                  inj_files, bank_file, seg_dir,

--- a/pycbc/workflow/pegasus_workflow.py
+++ b/pycbc/workflow/pegasus_workflow.py
@@ -440,6 +440,26 @@ class Workflow(object):
         self._adag.add_dependency(parent_workflow._as_job,
                                   children=[child_workflow._as_job])
 
+
+    def add_node_or_subworkflow_dependency(self, parent, child):
+        """Add a dependency between nodes and subworkflows, seamlessly handling
+        both types of parents and children.
+
+        Parameters
+        ----------
+        parent : Node or Workflow instance
+        child : Node or Workflow instance
+        """
+        def convert(thing):
+            if hasattr(thing, '_dax_node'):
+                return thing._dax_node
+            elif hasattr(thing, '_as_job'):
+                return thing._as_job
+            raise TypeError('neither _dax_node nor _as_job present, help!')
+
+        self._adag.add_dependency(convert(parent), children=[convert(child)])
+
+
     def add_transformation(self, tranformation):
         """ Add a transformation to this workflow
 

--- a/pycbc/workflow/plotting.py
+++ b/pycbc/workflow/plotting.py
@@ -472,7 +472,7 @@ def make_results_web_page(workflow, results_dir, template='orange',
     workflow += node
     if explicit_dependencies is not None:
         for dep in explicit_dependencies:
-            workflow.add_node_or_subworkflow_dependency(dep, node)
+            workflow.add_explicit_dependancy(dep, node)
 
 
 def make_single_hist(workflow, trig_file, veto_file, veto_name,

--- a/pycbc/workflow/plotting.py
+++ b/pycbc/workflow/plotting.py
@@ -472,7 +472,7 @@ def make_results_web_page(workflow, results_dir, template='orange',
     workflow += node
     if explicit_dependencies is not None:
         for dep in explicit_dependencies:
-            workflow.add_explicit_dependancy(dep, node)
+            workflow.add_node_or_subworkflow_dependency(dep, node)
 
 
 def make_single_hist(workflow, trig_file, veto_file, veto_name,


### PR DESCRIPTION
PyGRB workflows often produce results webpages that are missing the minifollowup plots. This should hopefully fix that.

## Standard information about the request

This is a bug fix.

This change affects PyGRB.

This change changes result presentation / plotting.

This change will require a new release.

## Motivation

Results webpages from recent PyGRB workflows have empty minifollowup sections. So far we have handled this manually by rerunning the results_page job, but this is obviously undesirable.

Inspecting one of the DAX file reveals that the results_page job has no explicit dependency on any of the minifollowup jobs, so it should not be a surprise that whether the minifollowups content shows up is just a matter of chance.

## Contents

I made the `SubWorkflow` instances that are responsible for the minifollowups be explicit parents of the results_page job, as is already done for other plots. To do this in a clean way, I adapted a bit the APIs of the pycbc.workflow module.

Although unrelated to this problem, I also dropped a few unused variables from the PyGRB workflow generator.

## Links to any issues or associated PRs

N/A

## Testing performed

I manually reran the `pycbc_pygrb_results_workflow` job from a recent workflow that was missing the minifollowup content, and then compared the original DAX with the new DAX. You can see the missing dependencies appear. I assume this will fix the problem, though that is yet to be verified, and I am running a full workflow to that end (testing other recent PRs as well).

## Additional notes

N/A

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
