### PR TITLE
Fix a small error in the construction of the circular sky grid

### DIFF
--- a/bin/pycbc_make_sky_grid
+++ b/bin/pycbc_make_sky_grid
@@ -8,7 +8,7 @@ gravitational wave triggers and calculate the coherent SNRs and related
 statistics. 
 
 The grid is constructed following the method described in Section V of
-https://arxiv.org/abs/1410.6042.
+Williamson et al 2014, https://arxiv.org/abs/1410.6042.
 
 Please refer to help(pycbc.types.angle_as_radians) for the recommended
 configuration file syntax for angle arguments.
@@ -84,24 +84,31 @@ def make_multi_det_grid(args):
     ]
     angular_spacing = min(ang_spacings)
 
-    sky_points = np.zeros((1, 2))
-
-    number_of_rings = int(args.sky_error / angular_spacing)
+    # The first point is always exactly at the North pole
+    sky_points = [
+        [0, np.pi / 2]
+    ]
 
     # Generate the sky grid centered at the North pole
-    for i in range(number_of_rings + 1):
-        if i == 0:
-            sky_points[0][0] = 0
-            sky_points[0][1] = np.pi / 2
-        else:
-            number_of_points = int(2 * np.pi * i)
-            for j in range(number_of_points):
-                sky_points = np.row_stack(
-                    (
-                        sky_points,
-                        np.array([j / i, np.pi / 2 - i * angular_spacing]),
-                    )
-                )
+    number_of_rings = int(args.sky_error / angular_spacing)
+    for i in range(1, number_of_rings + 1):
+        # Note: Williamson et al 2014 states that the number of points in the
+        # i-th ring is 2πi / x, with x the angular spacing. This is not correct.
+        # In the approximation where the error radius is tiny (i.e. the initial
+        # grid stays close to the North pole) the correct number is 2πi.
+        # However, here we implement the general case, correct over the whole
+        # extent of the polar angle, for which the number is instead
+        # 2π cos(π/2 - ix) / x.
+        polar_angle = np.pi / 2 - i * angular_spacing
+        number_of_points = round(
+            2 * np.pi * np.cos(polar_angle) / angular_spacing
+        )
+        sky_points += [
+            [2 * np.pi * j / number_of_points, polar_angle]
+            for j in range(number_of_points)
+        ]
+
+    sky_points = np.array(sky_points)
 
     # Convert spherical coordinates to cartesian coordinates
     cart = spher_to_cart(sky_points)


### PR DESCRIPTION
**Note: this PR targets the 2.8 release branch.**

Fix a small bug in the placement of the circular sky grid used by PyGRB 2.8.

## Standard information about the request

This is a bug fix.

This change affects PyGRB 2.8.

This change changes scientific output.

## Motivation

Answering some review questions for PyGRB 2.8 reminded me that the circular grid implemented in `pycbc_make_sky_grid` has a couple minor issues:
1. It leaves a "seam" at the end of each ring due to incorrect rounding.
2. In calculating the number of points per ring, it assumes that the error radius is small. This approximation is mostly ok considering the typical uncertainties of Fermi/GBM localizations, but the exact calculation is not much more complicated, so the approximation is pointless.

## Contents

I reimplemented the loop that places the rings using the correct calculation, and I added comment to explain why the calculation differs from what stated in Williamson et al 2014.

## Links to any issues or associated PRs

N/A

## Testing performed

I built a few different sky grids with the old and new code and plotted them together:

<img width="960" height="720" alt="image" src="https://github.com/user-attachments/assets/8b04b207-f62e-469f-8c3b-d2ee5d4156e5" />

<img width="960" height="720" alt="image" src="https://github.com/user-attachments/assets/d187cf0c-f185-44f6-8ebf-f3a7692c3bc5" />

<img width="960" height="720" alt="image" src="https://github.com/user-attachments/assets/fd51a41c-9820-4f66-b624-a88cb36fb1ee" />

<img width="960" height="720" alt="image" src="https://github.com/user-attachments/assets/e7d116a7-52eb-4b55-9e5f-1bb9a154490f" />

## Additional notes
<!--- Anything which does not fit in the above sections -->

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
