### PR TITLE
Fixes to PyGRB found-missed plot

### DIFF
--- a/bin/pygrb/pycbc_pygrb_plot_injs_results
+++ b/bin/pygrb/pycbc_pygrb_plot_injs_results
@@ -189,7 +189,6 @@ def complete_inj_data(injs, keys, tag, ifos=[]):
 # =============================================================================
 
 # FIXME: not all of these work
-# TODO: effective distance
 admitted_vars = easy_keys + ['mtotal', 'q', 'mchirp',
                              'spin1a', 'spin2a',
                              'incl', 'cos_incl', 'abs_incl', 'cos_abs_incl',
@@ -410,7 +409,7 @@ axis_labels_dict = {'mchirp': "Chirp Mass (solar masses)",
                     'q': "Mass ratio",
                     'distance': "Distance (Mpc)",
                     'eff_site_dist': f"{opts.ifo} effective distance (Mpc)",
-                    'eff_dist': "Inverse sum of effective distances (Mpc)",
+                    'eff_dist': "Inverse sum of inverse effective distances (Mpc)",
                     'end_time': "GPS time (s)",
                     'sky_error': "Rec. sky error (rad)",
                     'coa_phase': "Phase of complex SNR (rad)",
@@ -582,7 +581,7 @@ if plot_title is None:
                   'mtotal': "total mass",
                   'q': "mass ratio",
                   'distance': "distance (Mpc)",
-                  'eff_dist': "inverse sum of effective distances",
+                  'eff_dist': "inverse sum of inverse effective distances",
                   'eff_site_dist': "site specific effective distance",
                   'end_time': "time",
                   'coa_phase': "phase of complex SNR",


### PR DESCRIPTION
Fix a couple issues in PyGRB's found-missed plot code.

## Standard information about the request

This is a bug fix and result visualization improvement.

This change affects PyGRB.

This change changes result presentation / plotting.

## Motivation

PyGRB's found-missed plots have a few issues:
* GPS time axes are incorrectly labeled as "Time since {external trigger time}` where in fact it is just the GPS time.
* The `--colormap` option is ignored and a hardcoded choice is made instead.
* The colorbar for p-values is linear, but p-values between ~0.1 and 1 essentially tell the same story, so most of the colorbar range is useless. A log scale is more appropriate here.
* The choice of plotting order is implemented through significant code duplication.
* The variable choices `longitude` and `latitude` do not work as they have been replaced by `ra` and `dec` in PyGRB.

## Contents

* Fix the GPS time labeling.
* Fix the `longitude` and `latitude` variable choices.
* Do not ignore the `--colormap` option.
* Introduce a `--linear-colormap` option and default to a log colormap.
* Increase the resolution of plots in PNG format and tweak the size of some symbols.
* Add a legend.
* Add/fix units in axis labels.
* Implement support for `eff_dist`, though I implemented the inverse of the sum of the inverses, not literally the inverse of the sum (like the labels say, which I think makes no sense… Happy to discuss this).
* Minor code cleanup and simplification. I removed the site name conversion code, as we can assume H1, L1 etc is clear to every analyst.

## Links to any issues or associated PRs

This addresses some of my own requests in #3660.

## Testing performed

A few comparisons here: https://ldas-jobs.ligo.caltech.edu/~tito.canton/pycbc/test_pr5178/new/.

## Additional notes

None.

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
