### PR TITLE
Cythonize get_coinc_indices

### DIFF
--- a/pycbc/events/coherent.py
+++ b/pycbc/events/coherent.py
@@ -70,6 +70,11 @@ def get_coinc_indexes(idx_dict, time_delay_idx, min_nifos):
         # Could cache an output array if needed
         idxarr1 = idx_dict[ifos[0]]
         idxarr2 = idx_dict[ifos[1]]
+        # If either detector has no above-threshold triggers, there can be
+        # no coincidences. Handle this explicitly to avoid passing a
+        # zero-length output array into the Cython helper.
+        if len(idxarr1) == 0 or len(idxarr2) == 0:
+            return np.array([], dtype=idxarr1.dtype)
         outarr = np.zeros(max(len(idxarr1), len(idxarr2)), dtype=idxarr1.dtype)
         num_idxs = get_coinc_indexes_twodet_twocoinc(
             idxarr1,

--- a/pycbc/events/coherent.py
+++ b/pycbc/events/coherent.py
@@ -31,16 +31,6 @@ from .eventmgr_cython import get_coinc_indexes_cython_twodet_twocoinc
 
 logger = logging.getLogger('pycbc.events.coherent')
 
-def get_coinc_indexes_twodet_twocoinc(idxarr1, idxarr2, offset1, offset2, output):
-    num_idxs = get_coinc_indexes_cython_twodet_twocoinc(
-        idxarr1,
-        idxarr2,
-        offset1,
-        offset2,
-        output
-    )
-    return num_idxs
-
 
 def get_coinc_indexes(idx_dict, time_delay_idx, min_nifos):
     """Return the indexes corresponding to coincident triggers. If only one
@@ -76,7 +66,7 @@ def get_coinc_indexes(idx_dict, time_delay_idx, min_nifos):
         if len(idxarr1) == 0 or len(idxarr2) == 0:
             return np.array([], dtype=idxarr1.dtype)
         outarr = np.zeros(max(len(idxarr1), len(idxarr2)), dtype=idxarr1.dtype)
-        num_idxs = get_coinc_indexes_twodet_twocoinc(
+        num_idxs = get_coinc_indexes_cython_twodet_twocoinc(
             idxarr1,
             idxarr2,
             time_delay_idx[ifos[0]],

--- a/pycbc/events/eventmgr_cython.pyx
+++ b/pycbc/events/eventmgr_cython.pyx
@@ -322,13 +322,13 @@ def get_coinc_indexes_cython_twodet_twocoinc(
     numeric_type offset2,
     numeric_type [::1] outputs
 ):
-    cdef int arr1pos = 0
-    cdef int arr2pos = 0
-    cdef int outpos = 0
-    cdef int arr1_size = idxarr1.size
-    cdef int arr2_size = idxarr2.size
-    cdef int cpos1
-    cdef int cpos2
+    cdef Py_ssize_t arr1pos = 0
+    cdef Py_ssize_t arr2pos = 0
+    cdef Py_ssize_t outpos = 0
+    cdef Py_ssize_t arr1_size = idxarr1.size
+    cdef Py_ssize_t arr2_size = idxarr2.size
+    cdef numeric_type cpos1
+    cdef numeric_type cpos2
 
     while arr1pos < arr1_size and arr2pos < arr2_size:
         cpos1 = idxarr1[arr1pos] - offset1

--- a/pycbc/events/eventmgr_cython.pyx
+++ b/pycbc/events/eventmgr_cython.pyx
@@ -331,8 +331,8 @@ def get_coinc_indexes_cython_twodet_twocoinc(
 
     while arr1pos < arr1_size and arr2pos < arr2_size:
         cpos1 = idxarr1[arr1pos] - offset1
-        cpos2 = idxarr2[arr2pos]-offset2
-        if (cpos1) == (cpos2):
+        cpos2 = idxarr2[arr2pos] - offset2
+        if cpos1 == cpos2:
             outputs[outpos] = cpos1
             outpos += 1
             arr1pos += 1

--- a/pycbc/events/eventmgr_cython.pyx
+++ b/pycbc/events/eventmgr_cython.pyx
@@ -312,8 +312,9 @@ ctypedef fused numeric_type:
     cython.int
     cython.long
 
-@cython.boundscheck(False)
-@cython.wraparound(False)
+@boundscheck(False)
+@wraparound(False)
+@cdivision(True)
 def get_coinc_indexes_cython_twodet_twocoinc(
     numeric_type [::1] idxarr1,
     numeric_type [::1] idxarr2,

--- a/pycbc/events/eventmgr_cython.pyx
+++ b/pycbc/events/eventmgr_cython.pyx
@@ -1,5 +1,6 @@
 import numpy as np
 cimport numpy as cnp
+import cython
 from cython import wraparound, boundscheck, cdivision
 from libc.math cimport M_PI, sqrt
 from libc.math cimport round as cround
@@ -306,3 +307,39 @@ def timecluster_cython(
         elif max_loc < i:
             i += 1
     return j
+
+ctypedef fused numeric_type:
+    cython.int
+    cython.long
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+def get_coinc_indexes_cython_twodet_twocoinc(
+    numeric_type [::1] idxarr1,
+    numeric_type [::1] idxarr2,
+    numeric_type offset1,
+    numeric_type offset2,
+    numeric_type [::1] outputs
+):
+    cdef int arr1pos = 0
+    cdef int arr2pos = 0
+    cdef int outpos = 0
+    cdef int arr1_size = idxarr1.size
+    cdef int arr2_size = idxarr2.size
+    cdef int cpos1
+    cdef int cpos2
+
+    while arr1pos < arr1_size and arr2pos < arr2_size:
+        cpos1 = idxarr1[arr1pos] - offset1
+        cpos2 = idxarr2[arr2pos]-offset2
+        if (cpos1) == (cpos2):
+            outputs[outpos] = cpos1
+            outpos += 1
+            arr1pos += 1
+            arr2pos += 1
+        elif cpos1 < cpos2:
+            arr1pos += 1
+        else:
+            arr2pos += 1
+    return outpos
+


### PR DESCRIPTION
This continues work in #5148 by Cythonizing the get_coinc_indices function. For now this is still draft, and I put it here to demonstrate how this might work (especially if anyone in the GRB team is interested in learning some Cython, it would be great to have more people with that knowledge).

Particular things that need doing

- [ ] Writing Cython functions for other common use cases
- [ ] Making the one-detector case a no-op if (as I think) it should be
- [ ] Creating a new .pyx file for GRB Cython functions and moving the new functions there (expecting this will not be the only time we Cythonize bits).
- [ ] Testing (I ran Tito's test case 2 and obtained the same number of triggers (within 1)), I've also ran the code on the same test case generating indices with both the old and new methods and set to raise an error if they differ ... It did not fail (after I fixed the bugs that test uncovered).

## Standard information about the request

This is a: efficiency update

This change affects: PyGRB

This change changes: Core scientific code, but only optimization.

This change: has appropriate unit tests, follows style guidelines (See e.g. [PEP8](https://peps.python.org/pep-0008/)), has been proposed using the [contribution guidelines](https://github.com/gwastro/pycbc/blob/master/CONTRIBUTING.md)


## Motivation

#5148 has all the motivation. PyGRB can be slow in some cases. This function was written in "nice" python, but not "fast" python.

## Contents

For the 2-detector case this is just finding duplicated values in 2 sorted arrays. There's a well known algorithm for that problem, and I implement it here.


## Additional notes

<img width="3285" height="1520" alt="image" src="https://github.com/user-attachments/assets/5a5a398c-f545-48b2-82d6-83036dcf51c9" />

Profile (for test case 2) with this PR. It's not as great as I would like, but the dominant cost of get_coinc_indexes remains *outside* of the Cython function (even though it's doing very little!)

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
