### PR TITLE
Expand PyGRB tables 

### DIFF
--- a/bin/pygrb/pycbc_pygrb_page_tables
+++ b/bin/pygrb/pycbc_pygrb_page_tables
@@ -648,7 +648,7 @@ if found_missed_file is not None:
                            '##.##', '##.##', '##.##',
                            '##.##', '##.##'])
     format_strings.extend(['##.##' for ifo in ifos])
-    format_strings.extend(['##.##', '##.######',
+    format_strings.extend(['##.##', '#.######',
                            '##.##', '##.##', '##.##',
                            '##.##', '##.##', '##.##',
                            '##.##', '##.##'])
@@ -706,18 +706,18 @@ if found_missed_file is not None:
                 for key in keys]
     t_missed = list(zip(*t_missed))
     t_missed.sort(key=lambda elem: elem[0])
-    logging.info("Writing %d missed and missed-found injections to html file.",
+    logging.info("Writing %d missed, vetoed, and cut injections to html file.",
                  len(t_missed))
     t_missed = zip(*t_missed)
     t_missed = [np.asarray(d) for d in t_missed]
     html_table = pycbc.results.html_table(t_missed, th,
                                           format_strings=format_strings,
                                           page_size=20)
-    kwds = {'title': "Missed and found but missed injections",
+    kwds = {'title': "Missed, vetoed, and cut injections",
             'caption': "Parameters of missed injections and \
             recovered parameters and statistic values of \
-            injections that are recovered but then missed because \
-            their reweighted SNR is below threshold or they are vetoed.",
+            injections that are recovered but then vetoed or cut because \
+            their reweighted SNR is below threshold.",
             'cmd': ' '.join(sys.argv), }
     pycbc.results.save_fig_with_metadata(str(html_table), mf_outfile,
                                          **kwds)


### PR DESCRIPTION
## Standard information about the request

<!--- Some basic info about the change (delete as appropriate) -->
This is a: new feature in PyGRB tables.
- A column for p-values is added in injections tables (both "quiet found" and "missed found")
- The table that used to only display "missed-found" injections now also covers missed injections

<!--- What codes will this affect? (delete as apropriate)
If you do not know which areas will be affected, please ask in the gwastro #pycbc-code slack
-->
This change affects: PyGRB

<!--- What code areas will this affect? (delete as apropriate) -->
This change changes: result presentation

## Contents
- I tracked the p-value so that it is shown in the output tables (perhaps useful for "quiet" found injections).
- Given the frequent request to be able to easily read the injection parameters of missed injections, I extended the purpose of the "missed-found" table: it now also reports missed injections.
- Small dictionary improvements
- Fields missing when grouping injections together (e.g., a missed injection does not have a recovered chirp mass) are filled with `-1`s so that the formatting of the table is preserved (which is not the case using `None`, or strings such as `'-'`).

## Testing performed
I shared expanded tables with the PyGRB developers.

## Additional notes
<!--- Anything which does not fit in the above sections -->

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
