### PR TITLE
Deprecation fixes

### DIFF
--- a/pycbc/coordinates/space.py
+++ b/pycbc/coordinates/space.py
@@ -179,7 +179,7 @@ def propagation_vector_to_localization(k, use_astropy=True, frame=None):
             latitude = frame.dec.rad
     else:
         # latitude already within [-pi/2, pi/2]
-        latitude = np.float64(np.arcsin(-k[2]))
+        latitude = np.float64(np.arcsin(-k[2])[0])
         longitude = np.float64(np.arctan2(-k[1]/np.cos(latitude),
                                -k[0]/np.cos(latitude)))
         # longitude should within [0, 2*pi)

--- a/pycbc/coordinates/space.py
+++ b/pycbc/coordinates/space.py
@@ -179,9 +179,9 @@ def propagation_vector_to_localization(k, use_astropy=True, frame=None):
             latitude = frame.dec.rad
     else:
         # latitude already within [-pi/2, pi/2]
-        latitude = np.float64(np.arcsin(-k[2])[0])
-        longitude = np.float64(np.arctan2(-k[1]/np.cos(latitude),
-                               -k[0]/np.cos(latitude)))
+        latitude = np.float64(np.arcsin(-k[2,0]))
+        longitude = np.float64(np.arctan2(-k[1,0]/np.cos(latitude),
+                               -k[0,0]/np.cos(latitude)))
         # longitude should within [0, 2*pi)
         longitude = np.mod(longitude, 2*np.pi)
 

--- a/pycbc/cosmology.py
+++ b/pycbc/cosmology.py
@@ -34,8 +34,7 @@ import numpy
 from scipy import interpolate
 import astropy.cosmology
 from astropy import units
-from astropy.cosmology.core import CosmologyError
-from astropy.cosmology import parameters
+from astropy.cosmology import CosmologyError, parameters
 import pycbc.conversions
 
 logger = logging.getLogger('pycbc.cosmology')

--- a/pycbc/events/coinc.py
+++ b/pycbc/events/coinc.py
@@ -1325,7 +1325,7 @@ class LiveCoincTimeslideBackgroundEstimator(object):
         if num_zerolag > 0:
             idx = cidx[zerolag_idx][0]
             zerolag_cstat = cstat[cidx][zerolag_idx]
-            ifar, ifar_sat = self.ifar(zerolag_cstat)
+            ifar, ifar_sat = self.ifar(zerolag_cstat[0])
             zerolag_results = {
                 'foreground/ifar': ifar,
                 'foreground/ifar_saturated': ifar_sat,

--- a/pycbc/inference/models/relbin.py
+++ b/pycbc/inference/models/relbin.py
@@ -223,7 +223,7 @@ class Relative(DistMarg, BaseGaussianNoise):
         for ifo in data:
             # store data and frequencies
             d0 = self.data[ifo]
-            self.f[ifo] = numpy.array(d0.sample_frequencies)
+            self.f[ifo] = numpy.asarray(d0.sample_frequencies)
             self.df[ifo] = d0.delta_f
             self.end_time[ifo] = float(d0.end_time)
 

--- a/pycbc/inference/models/relbin.py
+++ b/pycbc/inference/models/relbin.py
@@ -223,7 +223,7 @@ class Relative(DistMarg, BaseGaussianNoise):
         for ifo in data:
             # store data and frequencies
             d0 = self.data[ifo]
-            self.f[ifo] = numpy.asarray(d0.sample_frequencies)
+            self.f[ifo] = d0.sample_frequencies.numpy()
             self.df[ifo] = d0.delta_f
             self.end_time[ifo] = float(d0.end_time)
 

--- a/pycbc/io/ligolw.py
+++ b/pycbc/io/ligolw.py
@@ -264,13 +264,13 @@ def _build_series(series, dim_names, comment, delta_name, delta_unit):
     elem.appendChild(ligolw.Param.from_pyvalue('f0', series.f0, unit='s^-1'))
     delta = getattr(series, delta_name)
     if numpy.iscomplexobj(series.data.data):
-        data = numpy.row_stack((
+        data = numpy.vstack((
             numpy.arange(len(series.data.data)) * delta,
             series.data.data.real,
             series.data.data.imag
         ))
     else:
-        data = numpy.row_stack((
+        data = numpy.vstack((
             numpy.arange(len(series.data.data)) * delta,
             series.data.data
         ))

--- a/pycbc/waveform/waveform.py
+++ b/pycbc/waveform/waveform.py
@@ -369,7 +369,7 @@ def get_obj_attrs(obj):
     """
     pr = {}
     if obj is not None:
-        if isinstance(obj, numpy.rec.recarray):
+        if isinstance(obj, numpy.record):
             for name in obj.dtype.names:
                 pr[name] = getattr(obj, name)
         elif hasattr(obj, '__dict__') and obj.__dict__:

--- a/pycbc/waveform/waveform.py
+++ b/pycbc/waveform/waveform.py
@@ -369,7 +369,7 @@ def get_obj_attrs(obj):
     """
     pr = {}
     if obj is not None:
-        if isinstance(obj, numpy.core.records.record):
+        if isinstance(obj, numpy.rec.recarray):
             for name in obj.dtype.names:
                 pr[name] = getattr(obj, name)
         elif hasattr(obj, '__dict__') and obj.__dict__:


### PR DESCRIPTION
This fixes a few of the deprecation warnings in #5179

## Standard information about the request

This is a: deprecation fix
This change affects: the offline search, the live search, inference, PyGRB
This change changes: documentation, result presentation / plotting, scientific output
This change follows style guidelines (See e.g. [PEP8](https://peps.python.org/pep-0008/)), has been proposed using the [contribution guidelines](https://github.com/gwastro/pycbc/blob/master/CONTRIBUTING.md)

## Motivation
Things are deprecated; if we don't remove them now, they will be failures

## Contents
Generally, this is just going through the suggested fixes for the deprecations.

I'm not sure on one or two places:
- in `pycbc/coordinates/space.py`, could this ever actually be an array, is it only a single-value array in the tests? This is also a warning in `pycbc/events/coinc.py`, which I need to check

## Links to any issues or associated PRs
#5179 

## Testing performed
`tox-e py-unittest` runs with fewer deprecation warnings

## Additional notes

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
