### PR TITLE
Bugfix to `plot_posterior` when plotting extracted posterior files

### DIFF
--- a/bin/inference/pycbc_inference_plot_posterior
+++ b/bin/inference/pycbc_inference_plot_posterior
@@ -48,7 +48,7 @@ from pycbc.results.scatter_histograms import create_multidim_plot
 use('agg')
 
 # add options to command line
-parser = io.ResultsArgumentParser(defaultparams='all')
+parser = io.ResultsArgumentParser(defaultparams='samples')
 pycbc.add_common_pycbc_options(parser)
 # program-specific
 parser.add_argument("--output-file", type=str, required=True,


### PR DESCRIPTION
This PR fixes a bug when running `pycbc_inference_plot_posterior` with an extracted posterior file and wildcard parameters. 

## Standard information about the request

This is a bug fix. This change affects posterior plotting via `plot_posterior`. This change changes the behavior of `plot_posterior` when using a wildcard parameter argument to call only the parameters present in the file.

## Motivation
Currently, if using a wildcard (i.e. `--parameters '*'`), this script calls the `variable_params` section of the file, which assumes that the parameters to be plotted are the same as the parameters that were sampled over during PE. However, if the user provides a posterior extracted using `pycbc_inference_extract_samples`, the parameters stored in the file are not guaranteed to be the same as the `variable_params` (e.g., a waveform transform may have been applied during extraction). Thus, the script will attempt to call parameter names that may not be in the posterior and throw an error. Ideally, the wildcard should call all the parameters present in the file regardless of what was sampled over during PE.

## Contents
This PR changes the behavior of `plot_posterior` (via the `ResultsArgumentParser` call) to plot all parameters in the file rather than the `variable_params` section when using the `'*'` wildcard. All other functionality remains unchanged; i.e. if the user specifies all of the parameters manually, this PR has no effect.

## Additional notes
This largely produces the same expected functionality of the wildcard parameter. There is one additional side effect: if the posterior contains likelihood parameters (e.g. `loglikelihood`, `logwt`), those will be plotted as their own scatter plots. Ideally, these wouldn't be plotted, but they have no effect on the plotting otherwise. Additional changes can be made to this PR to exclude these parameters if that is the optimal behavior.

- [ x ] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
