### PR TITLE
Revert to regular BBHx install for tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ conda_deps =
 
 [bbhx]
 deps =
-    git+https://github.com/titodalcanton/BBHx.git@py39-and-cleanup; sys_platform == 'linux'
+    bbhx; sys_platform == 'linux'
     git+https://github.com/gwastro/BBHX-waveform-model.git; sys_platform == 'linux'
 conda_deps =
     liblapacke


### PR DESCRIPTION
A while ago we started using a fork of BBHx as a workaround for some issues upstream. Let's see if we can drop that now.

## Links to any issues or associated PRs

#4857 

## Testing performed

None, relying on CI.

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
