### PR TITLE
Add option to make sure pycbc_brute_bank keeps all templates if given an input file

### DIFF
--- a/bin/bank/pycbc_brute_bank
+++ b/bin/bank/pycbc_brute_bank
@@ -39,7 +39,7 @@ parser.add_argument('--output-file', required=True,
     help='Output file name for template bank.')
 parser.add_argument('--input-file',
     help='Bank to use as an initial set of starting samples.')
-parser.add_argumetn('--keep-entire-input-file', help="All of the templates in the input file will be kept in the output file, even if they do not pass normal mismatch criteria.", action='store_true')
+parser.add_argument('--keep-entire-input-file', help="All of the templates in the input file will be kept in the output file, even if they do not pass normal mismatch criteria.", action='store_true')
 parser.add_argument('--input-config',
     help='Draw parameters from the given configure file.')
 parser.add_argument('--params',


### PR DESCRIPTION
pycbc_brute_bank currently has an "input-file" option. It uses any points in the input file as the initial set of proposals for the bank it generates. However, this means that some points may get rejected. It can be useful to avoid any rejections at this stage and force all of the initial points to be kept through to the final bank. This add an options which enables that behavior. 

The use case would be to allow using the input-file more generically as a starting bank which is only filled in further, before you'd have to be careful of the order of operations to make sure that nothing would be removed by a later stages mismatch checks. This also enables cases where you change options like the flow, approximant, etc in the later additive stages. 