### PR TITLE
Bugfix and Improve cache parsing on newer CPUs

### DIFF
--- a/pycbc/libutils.py
+++ b/pycbc/libutils.py
@@ -256,6 +256,22 @@ def get_lscpu_caches():
         check=True
     )
 
+    l1d_cline_size = subprocess.run(
+        ["cat", "/sys/devices/system/cpu/cpu0/cache/index0/coherency_line_size"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=True
+    ).stdout
+
+    l2_cline_size = subprocess.run(
+        ["cat", "/sys/devices/system/cpu/cpu0/cache/index2/coherency_line_size"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=True
+    ).stdout
+
     l3_cline_size = subprocess.run(
         ["cat", "/sys/devices/system/cpu/cpu0/cache/index3/coherency_line_size"],
         stdout=subprocess.PIPE,
@@ -263,6 +279,8 @@ def get_lscpu_caches():
         text=True,
         check=True
     ).stdout
+
+
     #print(l3_cline_size)
     cache_dict = {}
     
@@ -290,6 +308,8 @@ def get_lscpu_caches():
             caches_dict_bytes.update({key : val})
 
     gcaches_dict = convert_to_getconf_conven(caches_dict_bytes)
+    gcaches_dict.update({"LEVEL1_DCACHE_LINESIZE" : int(l1d_cline_size)})
+    gcaches_dict.update({"LEVEL2_CACHE_LINESIZE" : int(l2_cline_size)})
     gcaches_dict.update({"LEVEL3_CACHE_LINESIZE" : int(l3_cline_size)})
 
     return gcaches_dict

--- a/pycbc/opt.py
+++ b/pycbc/opt.py
@@ -98,12 +98,11 @@ else:
         LEVEL1_DCACHE_ASSOC = getval('LEVEL1_DCACHE_ASSOC')
         LEVEL2_CACHE_ASSOC = getval('LEVEL2_CACHE_ASSOC')
         LEVEL3_CACHE_ASSOC = getval('LEVEL3_CACHE_ASSOC')
-    
-        # Use getconf for cache line sizes
-        # lscpu also returns this, todo for later
-        LEVEL2_CACHE_LINESIZE = getconf('LEVEL2_CACHE_LINESIZE')
-        # See darwin line above
-        LEVEL1_DCACHE_LINESIZE = getconf('LEVEL1_DCACHE_LINESIZE')
+
+        # Can use getconf for cache line sizes
+        # but it fails to fetch it for L3
+        LEVEL1_DCACHE_LINESIZE = getval('LEVEL1_DCACHE_LINESIZE')
+        LEVEL2_CACHE_LINESIZE = getval('LEVEL2_CACHE_LINESIZE')
         LEVEL3_CACHE_LINESIZE = getval('LEVEL3_CACHE_LINESIZE')
     else:
         # Get cache linesize from sysctl


### PR DESCRIPTION
# Summary

On newer CPUs (e.g. Intel 258v), the linux `getconf` function in glibc has issues fetching the correct cache configuration.
It returns incorrect cache sizes for all caches, and returns nothing for cache associations. 

This PR changes the way cache configuration is read in by pycbc. 

# Details
The incorrect cache reporting by `getconf` led `pycbc` to throw the following error:

> File ~/soft/anaconda/envs/gw/lib/python3.11/site-packages/pycbc/__init__.py:201
>     199 # Check for MKL capability
>     200 try:
> --> [201](https://file+.vscode-resource.vscode-cdn.net/home/vaishakprasad/Projects/ligo/s230814ah/NR/~/soft/anaconda/envs/gw/lib/python3.11/site-packages/pycbc/__init__.py:201)     import pycbc.fft.mkl
>     202     HAVE_MKL=True
>     203 except (ImportError, OSError):
> 
> File ~/soft/anaconda/envs/gw/lib/python3.11/site-packages/pycbc/fft/__init__.py:17
>       1 # Copyright (C) 2012  Josh Willis, Andrew Miller
>       2 #
>       3 # This program is free software; you can redistribute it and/or modify it
>    (...)     14 # with this program; if not, write to the Free Software Foundation, Inc.,
>      15 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
> ---> [17](https://file+.vscode-resource.vscode-cdn.net/home/vaishakprasad/Projects/ligo/s230814ah/NR/~/soft/anaconda/envs/gw/lib/python3.11/site-packages/pycbc/fft/__init__.py:17) from .parser_support import insert_fft_option_group, verify_fft_options, from_cli
>      18 from .func_api import fft, ifft
>      19 from .class_api import FFT, IFFT
> 
> File ~/soft/anaconda/envs/gw/lib/python3.11/site-packages/pycbc/fft/parser_support.py:29
>       1 # Copyright (C) 2012  Josh Willis, Andrew Miller
>       2 #
>       3 # This program is free software; you can redistribute it and/or modify it
>    (...)     22 # =============================================================================
>      23 #
>      24 """
>      25 This package provides a front-end to various fast Fourier transform
>      26 implementations within PyCBC.
>      27 """
> ---> [29](https://file+.vscode-resource.vscode-cdn.net/home/vaishakprasad/Projects/ligo/s230814ah/NR/~/soft/anaconda/envs/gw/lib/python3.11/site-packages/pycbc/fft/parser_support.py:29) from .backend_support import get_backend_modules, get_backend_names
>      30 from .backend_support import set_backend, get_backend
>      32 # Next we add all of the machinery to set backends and their options
>      33 # from the command line.
> 
> File ~/soft/anaconda/envs/gw/lib/python3.11/site-packages/pycbc/fft/backend_support.py:77
>      75 for scheme_name in ["cpu", "mkl", "cuda", "cupy"]:
>      76     try:
> ---> [77](https://file+.vscode-resource.vscode-cdn.net/home/vaishakprasad/Projects/ligo/s230814ah/NR/~/soft/anaconda/envs/gw/lib/python3.11/site-packages/pycbc/fft/backend_support.py:77)         mod = __import__('pycbc.fft.backend_' + scheme_name, fromlist = ['_alist', '_adict'])
>      78         _alist = getattr(mod, "_alist")
>      79         _adict = getattr(mod, "_adict")
> 
> File ~/soft/anaconda/envs/gw/lib/python3.11/site-packages/pycbc/fft/backend_cpu.py:18
>       1 #  Copyright (C) 2014 Josh Willis
>       2 #
>       3 #  This program is free software; you can redistribute it and/or modify
>    (...)     15 #  Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
>      16 #  MA  02111-1307  USA
> ---> [18](https://file+.vscode-resource.vscode-cdn.net/home/vaishakprasad/Projects/ligo/s230814ah/NR/~/soft/anaconda/envs/gw/lib/python3.11/site-packages/pycbc/fft/backend_cpu.py:18) from .core import _list_available
>      20 _backend_dict = {'fftw' : 'fftw',
>      21                  'mkl' : 'mkl',
>      22                  'numpy' : 'npfft'}
>      23 _backend_list = ['mkl', 'fftw', 'numpy']
> 
> File ~/soft/anaconda/envs/gw/lib/python3.11/site-packages/pycbc/fft/core.py:28
>       1 # Copyright (C) 2012  Josh Willis, Andrew Miller
>       2 #
>       3 # This program is free software; you can redistribute it and/or modify it
>    (...)     22 # =============================================================================
>      23 #
>      24 """
>      25 This package provides a front-end to various fast Fourier transform
>      26 implementations within PyCBC.
>      27 """
> ---> [28](https://file+.vscode-resource.vscode-cdn.net/home/vaishakprasad/Projects/ligo/s230814ah/NR/~/soft/anaconda/envs/gw/lib/python3.11/site-packages/pycbc/fft/core.py:28) from pycbc.types import Array as _Array
>      29 from pycbc.types import TimeSeries as _TimeSeries
>      30 from pycbc.types import FrequencySeries as _FrequencySeries
> 
> File ~/soft/anaconda/envs/gw/lib/python3.11/site-packages/pycbc/types/__init__.py:[1](https://file+.vscode-resource.vscode-cdn.net/home/vaishakprasad/Projects/ligo/s230814ah/NR/~/soft/anaconda/envs/gw/lib/python3.11/site-packages/pycbc/types/__init__.py:1)
> ----> 1 from .array import *
>       2 from .timeseries import *
>       3 from .frequencyseries import *
> 
> File ~/soft/anaconda/envs/gw/lib/python3.11/site-packages/pycbc/types/array.py:43
>      41 import pycbc.scheme as _scheme
>      42 from pycbc.scheme import schemed, cpuonly
> ---> [43](https://file+.vscode-resource.vscode-cdn.net/home/vaishakprasad/Projects/ligo/s230814ah/NR/~/soft/anaconda/envs/gw/lib/python3.11/site-packages/pycbc/types/array.py:43) from pycbc.opt import LimitedSizeDict
>      45 #! FIXME: the uint32 datatype has not been fully tested,
>      46 # we should restrict any functions that do not allow an
>      47 # array of uint32 integers
>      48 _ALLOWED_DTYPES = [_numpy.float32, _numpy.float64, _numpy.complex64,
>      49                    _numpy.complex128, _numpy.uint32, _numpy.int32, int]
> 
> File ~/soft/anaconda/envs/gw/lib/python3.11/site-packages/pycbc/opt.py:60
>      58 LEVEL2_CACHE_ASSOC = getconf('LEVEL2_CACHE_ASSOC')
>      59 LEVEL2_CACHE_LINESIZE = getconf('LEVEL2_CACHE_LINESIZE')
> ---> [60](https://file+.vscode-resource.vscode-cdn.net/home/vaishakprasad/Projects/ligo/s230814ah/NR/~/soft/anaconda/envs/gw/lib/python3.11/site-packages/pycbc/opt.py:60) LEVEL3_CACHE_SIZE = getconf('LEVEL3_CACHE_SIZE')
>      61 LEVEL3_CACHE_ASSOC = getconf('LEVEL3_CACHE_ASSOC')
>      62 LEVEL3_CACHE_LINESIZE = getconf('LEVEL3_CACHE_LINESIZE')
> 
> File ~/soft/anaconda/envs/gw/lib/python3.11/site-packages/pycbc/opt.py:48, in getconf(confvar)
>      47 def getconf(confvar):
> ---> [48](https://file+.vscode-resource.vscode-cdn.net/home/vaishakprasad/Projects/ligo/s230814ah/NR/~/soft/anaconda/envs/gw/lib/python3.11/site-packages/pycbc/opt.py:48)     return int(subprocess.check_output(['getconf', confvar]))
> 
> ValueError: invalid literal for int() with base 10: b'undefined\n'


`lscpu` provided by (`util-linux`) gives accurate information about the caches. It is also included in MacOS. 

This PR changes the way cache configuration is read in by pycbc. 

## Previous plan:
1. If MacOS or Win, try to read L2 size from env. If not available ignore.
2. If linux, check and use getconf.

## New plan:
1. If OS==win, only read L2 size from env variable.
1. If OS==linux, use lscpu for cache config (size + assoc)
1. If OS==darwin, read L2 linesize from sysctl. Ignore others.

 ## Bugfixes
 1. Read correct cache config for newer linux machines
 
 ## Improvements
 1. Mac can now read in L2 linesize 