### PR TITLE
Pin dynesty to. <3.0 until the API interface can be updated

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -43,7 +43,7 @@ igwn-ligolw<2.1.0
 
 # Needed for Parameter Estimation Tasks
 emcee==2.2.1
-dynesty
+dynesty<3.0
 
 # For building documentation
 # FIXME Unpin this!


### PR DESCRIPTION
CI jobs are failing as dynesty 3.0 has had some major changes to the API, breaking our interface with it

## Standard information about the request

This is a: bug fix, new feature, efficiency update, other (please describe)
This change affects: inference
This change changes: documentation
This change: has appropriate unit tests, follows style guidelines (See e.g. [PEP8](https://peps.python.org/pep-0008/)), has been proposed using the [contribution guidelines](https://github.com/gwastro/pycbc/blob/master/CONTRIBUTING.md)
This change will: restore current functionality


## Contents
pin dynesty to <3.0

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
