### PR TITLE
Fix PyGRB clustering

### DIFF
--- a/pycbc/events/eventmgr.py
+++ b/pycbc/events/eventmgr.py
@@ -755,13 +755,17 @@ class EventManagerCoherent(EventManagerMultiDetBase):
         tvec = net_event_dict[:net_event_size][tcolumn][slide_indices]
         if not window_size == 0:
             # cluster events over the window
+
+            # findchirp_cluster_over_window requires the input to be time
+            # sorted.
             time_sorting = tvec.argsort()
             cvec = cvec[time_sorting]
             tvec = tvec[time_sorting]
 
             indices = findchirp_cluster_over_window(tvec, cvec, window_size)
-            # if a slide_indices = 0
             indices = time_sorting[indices]
+
+            # if a slide_indices = 0
             if any(~slide_indices):
                 indices = numpy.concatenate((
                         numpy.flatnonzero(~slide_indices),

--- a/pycbc/events/eventmgr.py
+++ b/pycbc/events/eventmgr.py
@@ -755,8 +755,13 @@ class EventManagerCoherent(EventManagerMultiDetBase):
         tvec = net_event_dict[:net_event_size][tcolumn][slide_indices]
         if not window_size == 0:
             # cluster events over the window
+            time_sorting = tvec.argsort()
+            cvec = cvec[time_sorting]
+            tvec = tvec[time_sorting]
+
             indices = findchirp_cluster_over_window(tvec, cvec, window_size)
             # if a slide_indices = 0
+            indices = time_sorting[indices]
             if any(~slide_indices):
                 indices = numpy.concatenate((
                         numpy.flatnonzero(~slide_indices),


### PR DESCRIPTION
Fix the PyGRB clustering issue reported in #5194

## Standard information about the request

This is a: bug fix and efficiency update

This change affects: PyGRB

This change changes: scientific output

This change: Has been tested against the 8-unit, 12 hour PyGRB set of tests that Tito proposed.

## Motivation

As discussed in #5194, there appears to be an issue in PyGRB's clustering when using multiple sky points. This has 2 issues:

* There is a chance that if a timeseries contains 2 prominent peaks one of them may be erroneously clustered away. The chance of this happening is reasonably low, but not negligible.
* Numerous triggers that should be clustered away are not, causing file sizes to bloat, and causing efficiency concerns (both in `pycbc_multi_inspiral` itself and downstream). An example of this is that in Tito's PyGRB test suite, test 1 (large sky grid, loud injection) outputs 1273680 triggers. This job is analysing 5000s of data with a cluster window of 0.1s. An *upper limit* of 50000 triggers is set by that. Enabling the new option to only keep triggers around 2s of an injection *increases* this to over 2 million triggers (theoretically it's basically impossible to get this many). With this fix (see also #5153) we output 17089 triggers.

## Contents

The issue is that the input timeseries must be sorted. If you don't do that, it doesn't work, so we add a sort.

## Links to any issues or associated PRs

Related to #5153. Fixes #5194

## Testing performed

I've run Tito's test suite. We now get:

RUN1: 17089
RUN2: 4538
RUN3: 44
RUN4: 11917
RUN5: 789
RUN6: 9806
RUN7: 9425

triggers respectively (run 8 ran into cluster maintenance: pcdev2 was restarted, so rerunning that now).

I've put the run times and profiles here:

https://ldas-jobs.ligo.caltech.edu/~ian.harry/tmp_tito/pygrb_profile/pcdev2_fixedcluster_ifron/

I belive this represents a significant improvement w.r.t. the latest numbers in #5148 (not I've also included #5153 here). In particular `finalize_template_events` is no longer a bottleneck anyway because the number of template events is massively reduced in those runs.

I had noted that `findchirp_cluster` is a "quick but not perfect" algorithm in #5153. Some of the conclusions I drew there were incorrect as I hadn't realised that it was being used incorrectly, but you can compare the output numbers here with those quoted in #5153 and see that theres around a 20% increase. This is understood. I did try implementing a "better" clustering algorithm, but if you see the profiles here:

https://ldas-jobs.ligo.caltech.edu/~ian.harry/tmp_tito/pygrb_profile/pcdev2_newcluster_ifron/

we see that the clustering itself becomes a bottleneck. So I think this is the best solution.

- [ :-)] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
