### PR TITLE
Update GraceDB test so that it doesn't try to use x509 credentials

### DIFF
--- a/pycbc/io/gracedb.py
+++ b/pycbc/io/gracedb.py
@@ -344,7 +344,8 @@ class CandidateForGraceDB(object):
             logger.info('P_astro file saved as %s', self.pastro_file)
 
     def upload(self, fname, gracedb_server=None, testing=True,
-               extra_strings=None, search='AllSky', labels=None):
+               extra_strings=None, search='AllSky', labels=None,
+               **kwargs):
         """Upload this candidate to GraceDB, and annotate it with a few useful
         plots and comments.
 
@@ -362,6 +363,9 @@ class CandidateForGraceDB(object):
             String going into the "search" field of the GraceDB event.
         labels: list
             Optional list of labels to tag the new event with.
+        kwargs: named keyword arguments
+            Extra keyword arguments to be passed to GraceDB upload function.
+            Can also overwrite reload_certificate and reload_buffer here.
         """
         from matplotlib import pyplot as plt
 
@@ -385,6 +389,8 @@ class CandidateForGraceDB(object):
         if not hasattr(self, 'gracedb'):
             logger.info('Connecting to GraceDB')
             gdbargs = {'reload_certificate': True, 'reload_buffer': 300}
+            if kwargs is not None:
+                gdbargs.update(kwargs)
             if gracedb_server:
                 gdbargs['service_url'] = gracedb_server
             try:

--- a/test/test_io_gracedb.py
+++ b/test/test_io_gracedb.py
@@ -112,7 +112,7 @@ class TestIOGraceDB(unittest.TestCase):
             # The upload will fail, but it should not raise an exception
             # and it should still leave the event file around
             coinc.upload(coinc_file_name, gracedb_server='localhost',
-                         testing=True)
+                         testing=True, force_noauth=True)
         else:
             # no GraceDb module, so just save the coinc file
             coinc.save(coinc_file_name)


### PR DESCRIPTION
This is to get rid of the LIGO x509 deprecation warning in the CI tests.

It looks like the auth fails anyway, so using the `force_noauth` kwarg looks like the right thing to do.

## Standard information about the request

This is a deprecation workaround

This change affects: the CI, I think the code touches the live stuff, but I don't think this will actually affect things

This change follows style guidelines (See e.g. [PEP8](https://peps.python.org/pep-0008/)), has been proposed using the [contribution guidelines](https://github.com/gwastro/pycbc/blob/master/CONTRIBUTING.md)

## Motivation
Silence a deprecation warning

## Contents
Force the gracedb client to have no authorisation check, which avoids the deprecation warning

## Links to any issues or associated PRs
#5179

## Testing performed
`pytest test/test_io_gracedb.py` now only has warnings for `pkg_resources`

As an extra step I hacked the `igwn_auth_utils` code to fail rather than warn (multiple deprecation warnings, pytest filters not working, grumble grumble), and this change makes it pass

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
