### PR TITLE
Add Effective precession spin chi_p to pycbc_pygrb_plot_injs_results

### DIFF
--- a/bin/pygrb/pycbc_pygrb_plot_injs_results
+++ b/bin/pygrb/pycbc_pygrb_plot_injs_results
@@ -540,11 +540,10 @@ if "spin" in y_qty and missed_inj['spin2_a'].size:
                                          found_inj[y_qty].max())) / 10])
 
 # Handle axis limits when plotting chi_p
-if "chi_p" in x_qty or "chi_p" in y_qty:
-    if x_qty == 'chi_p':
-        ax.set_xlim(0, 1)
-    if y_qty == 'chi_p':
-        ax.set_ylim(0, 1)
+if x_qty == 'chi_p':
+    ax.set_xlim(0, 1)
+if y_qty == 'chi_p':
+    ax.set_ylim(0, 1)
         
 # Handle axis limits when plotting inclination
 if "incl" in x_qty or "incl" in y_qty:


### PR DESCRIPTION
Added the Effective precession spin chi_p to the variables available in pycbc_pygrb_plot_injs_results

## Standard information about the request

<!--- Some basic info about the change (delete as appropriate) -->
This is a: new feature

<!--- What codes will this affect? (delete as apropriate)
If you do not know which areas will be affected, please ask in the gwastro #pycbc-code slack
-->
This change affects: PyGRB

<!--- What code areas will this affect? (delete as apropriate) -->
This change changes: result plotting

<!--- Some things which help with code management (delete as appropriate) -->
This change: has appropriate unit tests, follows style guidelines (See e.g. [PEP8](https://peps.python.org/pep-0008/)), has been proposed using the [contribution guidelines](https://github.com/gwastro/pycbc/blob/master/CONTRIBUTING.md)

## Contents
<!--- Describe your changes, this doesn't need to be a line-by-line code change discussion,
but rather a general discussion of the methods chosen -->
Defined new function `complete_spin_data`, 
added the `elif` for chi_p in `complete_inj_data`, 
added 'chip' and 'chi_p' to `admitted_vars` and chi_p axes label in `axis_labels_dict`, 
added how to handle axis limits when plotting chi_p

## Testing performed
<!--- Describe tests for the code changes, either already performed or to be performed -->
The code was tested locally experimenting the functionality of the options --x-variable chi_p, --x-variable chip, —y-variable chi_p, —y-variable chip

## Additional notes
<!--- Anything which does not fit in the above sections -->
Work done in collaboration with @chiaramasia01, @elisabigongiari, under the supervision of @bpatricelli

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
