### PR TITLE
New column in PyGRB injections tables

### DIFF
--- a/bin/pygrb/pycbc_pygrb_page_tables
+++ b/bin/pygrb/pycbc_pygrb_page_tables
@@ -702,8 +702,16 @@ if found_missed_file is not None:
             cut_injs[key] = np.full(len(cut_injs['mass1']), -1)
         if key not in missed_injs:
             missed_injs[key] = np.full(len(missed_injs['mass1']), -1)
+    # Update the data to include a label stating whether the injection was
+    # vetoed, found and then removed due to the reweighted SNR cut, or missed
+    vetoed['category'] = np.full(len(vetoed['mass1']), 'Vetoed')
+    cut_injs['category'] = np.full(len(cut_injs['mass1']), 'Cut')
+    missed_injs['category'] = np.full(len(missed_injs['mass1']), 'Missed')
+    # Update the header and table formatter
+    th += ['Category']
+    format_strings.extend(['##'])
     t_missed = [np.concatenate((missed_injs[key], vetoed[key], cut_injs[key]))
-                for key in keys]
+                for key in keys+['category']]
     t_missed = list(zip(*t_missed))
     t_missed.sort(key=lambda elem: elem[0])
     logging.info("Writing %d missed, vetoed, and cut injections to html file.",


### PR DESCRIPTION
This PR adds a column to the PyGRB injections tables so that the user can directly read whether a specific injection was missed, cut (reweighted SNR too low), or vetoed (data quality).

## Standard information about the request

<!--- Some basic info about the change (delete as appropriate) -->
This is a: new feature

This change affects: PyGRB

This change changes: result presentation

## Motivation
The request for this addition was made by the review team.

## Testing performed
I regenerated an existing injections table.  I can share the link to inspect the outcome.  In the meantime, I am attaching a screenshot.

<img width="1096" height="260" alt="image" src="https://github.com/user-attachments/assets/61152deb-88f6-408e-8025-b749afdc145b" />

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
