### PR TITLE
Brute Bank Input File Error

### DIFF
--- a/bin/bank/pycbc_brute_bank
+++ b/bin/bank/pycbc_brute_bank
@@ -237,6 +237,16 @@ class TriangleBank(object):
                 return False
 
             hc = self[j]
+
+            # Defensive initialization if matches/indices are missing
+            if not hasattr(hc, 'matches'):
+                hc.matches = numpy.empty(len(self))
+                hc.matches[:] = numpy.nan
+
+            if not hasattr(hc, 'indices'):
+                hc.indices = numpy.arange(len(self))
+
+
             m = hp.gen.match(hp, hc)
             matches[j] = m
             mnum += 1


### PR DESCRIPTION

This patch initializes match if it is not defined. When using a seed bank in some instance I received "AttributeError: 'FrequencySeries' object has no attribute 'matches'. Did you mean: 'match'?"