### PR TITLE
Fix taper bug in time-domain generator

### DIFF
--- a/pycbc/waveform/generator.py
+++ b/pycbc/waveform/generator.py
@@ -276,15 +276,16 @@ class TDomainCBCGenerator(BaseCBCGenerator):
         """Applies a taper if it is in current params.
         """
         hp, hc = res
-
-        hp_tapered = hp.taper_timeseries(location=self.current_params['taper'], 
-                                         tapermethod=self.current_params.get('taper_method', 'lal'), 
-                                         taper_window=self.current_params.get('taper_window'))
-        hc_tapered = hc.taper_timeseries(location=self.current_params['taper'], 
-                                         tapermethod=self.current_params.get('taper_method', 'lal'), 
-                                         taper_window=self.current_params.get('taper_window'))
+        if 'taper' in self.current_params:
+            location = self.current_params['taper']
+            hp = hp.taper_timeseries(location=location,
+                                     tapermethod=self.current_params.get('taper_method', 'lal'), 
+                                     taper_window=self.current_params.get('taper_window'))
+            hc = hc.taper_timeseries(location=location,
+                                     tapermethod=self.current_params.get('taper_method', 'lal'), 
+                                     taper_window=self.current_params.get('taper_window'))
  
-        return hp_tapered, hc_tapered
+        return hp, hc
 
 
 class TDomainCBCModesGenerator(BaseCBCGenerator):


### PR DESCRIPTION
PR #5191 introduced a bug in which `taper` would be required by the `TDomainCBCGenerator` class. The correct behavior (i.e. only apply tapering if `taper` is in `current_params`; else just return the raw generated waveforms) seems to have been integrated into `TDomainCBCModesGenerator`, but just wasn't carried into the other class. This PR makes the two classes consistent such that `taper` remains an optional argument.

- [ x ] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
