### PR TITLE
Hide redundant offset text in corner plots

### DIFF
--- a/pycbc/results/scatter_histograms.py
+++ b/pycbc/results/scatter_histograms.py
@@ -123,11 +123,13 @@ def create_axes_grid(parameters, labels=None, height_ratios=None,
                     ax.set_xlabel('{}'.format(labels[px]), fontsize=18)
                 else:
                     pyplot.setp(ax.get_xticklabels(), visible=False)
+                    ax.xaxis.offsetText.set_visible(False)
                 # y labels only on left
                 if ncolumn == 0:
                     ax.set_ylabel('{}'.format(labels[py]), fontsize=18)
                 else:
                     pyplot.setp(ax.get_yticklabels(), visible=False)
+                    ax.yaxis.offsetText.set_visible(False)
             else:
                 # make non-used axes invisible
                 ax.axis('off')


### PR DESCRIPTION
<!---
Please delete these comments when you submit the pull request

Please add a title which is a concise description of what you are doing,
e.g. 'Fix bug with numpy import in pycbc_coinc_findtrigs' or 'add high frequency sky location dependent response for long detectors'
-->

<!---
This is a brief template for making pull requests for PyCBC.
This is _not_ a proscriptive template - you can use a different style if you want.
Please do think about the questions posed here and whether the details will be useful to include in your PR
Please add sufficient details so that people looking back at the request with no context around the work can understand the changes.
To choose reviewers, please look at the git blame for the code you are changing (if applicable),
or discuss in the #pycbc-code channel of the gwastro slack.
Please add labels as appropriate
-->

<!-- TOP-LEVEL SUMMARY: Please provide a brief, one-or-two-sentence description of the PR here
-->

## Standard information about the request

<!--- Some basic info about the change (delete as appropriate) -->
This is a: bug fix

<!--- What codes will this affect? (delete as apropriate)
If you do not know which areas will be affected, please ask in the gwastro #pycbc-code slack
-->
This change affects: inference

<!--- What code areas will this affect? (delete as apropriate) -->
This change changes: result presentation / plotting

## Motivation
<!--- Describe why your changes are being made -->
In corner plots, intermediate subplots may still display axis offset text (e.g. 1e-6) even when their tick labels are hidden, which is visually confusing.
Example:
<img width="1625" height="1355" alt="test" src="https://github.com/user-attachments/assets/efcf4463-318a-43e7-b4fd-bb9e95c1cc11" />

## Contents
<!--- Describe your changes, this doesn't need to be a line-by-line code change discussion,
but rather a general discussion of the methods chosen -->
The fix hides `xaxis.offsetText` and `yaxis.offsetText` for all subplots except those on the bottom row and left column.
<img width="1625" height="1355" alt="test_after" src="https://github.com/user-attachments/assets/82fbc5bc-0c48-49b9-9364-503ce9db7354" />

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
