### PR TITLE
Changes run_dir in pycbc_make_offline_grb_workflow to allow proper output-dir config

### DIFF
--- a/bin/pygrb/pycbc_make_offline_grb_workflow
+++ b/bin/pygrb/pycbc_make_offline_grb_workflow
@@ -54,10 +54,11 @@ logging.info("Generating %s workflow" % workflow_name)
 
 # Setup run directory
 triggername = str(wflow.cp.get("workflow", "trigger-name"))
-logging.info("Workflow will be generated in %s" % args.output_dir)
-if not os.path.exists(args.output_dir):
-    os.makedirs(args.output_dir)
-os.chdir(args.output_dir)
+output_dir = os.path.abspath(args.output_dir)
+logging.info("Workflow will be generated in %s", output_dir)
+if not os.path.exists(output_dir):
+    os.makedirs(output_dir)
+os.chdir(output_dir)
 
 # SEGMENTS
 triggertime = int(wflow.cp.get("workflow", "trigger-time"))
@@ -345,7 +346,7 @@ if wflow.cp.has_section("workflow-injections"):
                               "injections-method")
     if inj_method == "IN_WORKFLOW" and \
             wflow.cp.has_option("workflow-injections", "tc-prior-at-runtime"):
-        tc_path = os.path.join(args.output_dir, "tc_prior.ini")
+        tc_path = os.path.join(output_dir, "tc_prior.ini")
         _workflow.generate_tc_prior(wflow, tc_path, bufferSeg)
 
     # Generate injection files


### PR DESCRIPTION
<!---
Please delete these comments when you submit the pull request

Please add a title which is a concise description of what you are doing,
e.g. 'Fix bug with numpy import in pycbc_coinc_findtrigs' or 'add high frequency sky location dependent response for long detectors'
-->

<!---
This is a brief template for making pull requests for PyCBC.
This is _not_ a proscriptive template - you can use a different style if you want.
Please do think about the questions posed here and whether the details will be useful to include in your PR
Please add sufficient details so that people looking back at the request with no context around the work can understand the changes.
To choose reviewers, please look at the git blame for the code you are changing (if applicable),
or discuss in the #pycbc-code channel of the gwastro slack.
Please add labels as appropriate
-->

<!-- TOP-LEVEL SUMMARY: Please provide a brief, one-or-two-sentence description of the PR here
-->

## Standard information about the request

<!--- Some basic info about the change (delete as appropriate) -->
This is a bug fix for gitlab issue described here: https://git.ligo.org/pycbc/pygrb-offline-analysis/-/issues/48 wherein the method through which pycbc_make_offline_grb_workflow wrote the output directory was hard coded to be just the GRB##### tag. It will now (hopefully) be whatever is entered as the output-dir config. 

<!--- What codes will this affect? (delete as apropriate)
If you do not know which areas will be affected, please ask in the gwastro #pycbc-code slack
-->
This change affects: PyGRB

<!--- What code areas will this affect? (delete as apropriate) -->
This change changes: directory location for PyGRB run

<!--- Notes about the effect of this change -->
This change should not break current functionality

## Motivation
<!--- Describe why your changes are being made -->
The PyGRB search attempted to use an --output ${GRB} argument that caused issues. The name of the output directory never changed. Hopefully this solves that. 

## Links to any issues or associated PRs
<!--- If this is fixing / working around an already-reported issue, please link to it here -->
https://git.ligo.org/pycbc/pygrb-offline-analysis/-/issues/48


- [ ] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
