### PR TITLE
Use time-domain waveforms for bank generation

### DIFF
--- a/bin/bank/pycbc_brute_bank
+++ b/bin/bank/pycbc_brute_bank
@@ -53,6 +53,8 @@ parser.add_argument('--approximant',  required=False,
 parser.add_argument('--minimal-match', default=0.97, type=float)
 parser.add_argument('--buffer-length', default=2, type=float,
     help='size of waveform buffer in seconds')
+parser.add_argument('--use-td-waveform', action='store_true',
+    help='Generate waveform in the time domain (default is frequency domain).')
 parser.add_argument('--full-resolution-buffer-length', default=None, type=float,
     help='Size of the waveform buffer in seconds for generating time-domain signals at full resolution before conversion to the frequency domain.')
 parser.add_argument('--max-signal-length', type= float,
@@ -363,17 +365,25 @@ class GenUniformWaveform(object):
         if hasattr(kwds['approximant'], 'decode'):
             kwds['approximant'] = kwds['approximant'].decode()
 
+        if args.full_resolution_buffer_length is not None: 
+            buff_len =  args.full_resolution_buffer_length
+        else:
+            buff_len = 1.0 / self.delta_f
+
         if kwds['approximant'] in pycbc.waveform.fd_approximants():
-            if args.full_resolution_buffer_length is not None:
-                # Generate the frequency-domain waveform at full frequency resolution
-                high_hp, high_hc = pycbc.waveform.get_fd_waveform(delta_f=1 / args.full_resolution_buffer_length,
+
+            # Optionally generate time-domain waveform
+            if args.use_td_waveform:
+                hp, hc = pycbc.waveform.get_td_waveform(delta_t=1.0 / args.sample_rate,
                                                     **kwds)
-                # Decimate the generated signal to a reduced frequency resolution
-                hp = decimate_frequency_domain(high_hp, 1 / args.buffer_length)
-                hc = decimate_frequency_domain(high_hc, 1 / args.buffer_length)
+
+                hp = hp.to_frequencyseries(delta_f = 1.0 / buff_len)
+                hc = hc.to_frequencyseries(delta_f = 1.0 / buff_len)
+   
             else:
-                hp, hc = pycbc.waveform.get_fd_waveform(delta_f=self.delta_f,
+                hp, hc = pycbc.waveform.get_fd_waveform(delta_f = 1.0 / buff_len,
                                                     **kwds)
+      
             if  args.use_cross:
                 hp = hc
 
@@ -386,6 +396,10 @@ class GenUniformWaveform(object):
                         pycbc.types.zeros(self.flen, dtype=numpy.complex64),
                         delta_f=self.delta_f, delta_t=dt,
                         **kwds)
+
+        if args.full_resolution_buffer_length is not None:
+            # Decimate the generated signal to a reduced frequency resolution
+            hp = decimate_frequency_domain(hp, 1 / args.buffer_length)
 
         hp.resize(self.flen)
         hp = hp.astype(numpy.complex64)


### PR DESCRIPTION
<!---
Please delete these comments when you submit the pull request

Please add a title which is a concise description of what you are doing,
e.g. 'Fix bug with numpy import in pycbc_coinc_findtrigs' or 'add high frequency sky location dependent response for long detectors'
-->

<!---
This is a brief template for making pull requests for PyCBC.
This is _not_ a proscriptive template - you can use a different style if you want.
Please do think about the questions posed here and whether the details will be useful to include in your PR
Please add sufficient details so that people looking back at the request with no context around the work can understand the changes.
To choose reviewers, please look at the git blame for the code you are changing (if applicable),
or discuss in the #pycbc-code channel of the gwastro slack.
Please add labels as appropriate
-->

<!-- TOP-LEVEL SUMMARY: Please provide a brief, one-or-two-sentence description of the PR here
-->

## A support for generating template banks using time-domain waveforms

This feature extends pycbc_brute_bank to allow users to generate template banks using time-domain (TD) waveform models. 

This change affects: the offline search 

This change changes: documentation, scientific output

## Motivation

The main motivation for this feature is that several waveform families either lack faster frequency-domain implementations or are substantially more accurate when evaluated in the time domain. Because the pycbc_brute_bank code computes matches in the frequency domain, TD waveforms must be converted before overlaps can be calculated. Using TD waveforms requires an additional step where the generated time-series waveform is converted to the frequency domain using the get_fd_waveform_from_td function in waveform.py, before the match calculation is done. This step conversion step introduces additional computational cost, and in some cases (eg. SEOBNRv5HM) may dominate the overall runtime of the bank generation process.  

This PR implements the TD-to-FD conversion internally using a straightforward FFT-based calculation. 


- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
