### PR TITLE
Add support for explicit mode-by-mode waveform generators

### DIFF
--- a/pycbc/waveform/generator.py
+++ b/pycbc/waveform/generator.py
@@ -1414,6 +1414,9 @@ def get_td_generator(approximant, modes=False):
         if modes:
             return TDomainCBCModesGenerator
         return TDomainCBCGenerator
+    
+    if approximant in waveform_modes._mode_waveform_td:
+        return TDomainCBCModesGenerator
 
     if approximant in ringdown.ringdown_td_approximants:
         if approximant in ['TdQNMfromFinalMassSpin', 'TdModesfromFinalMassSpin']:
@@ -1432,6 +1435,9 @@ def get_fd_generator(approximant, modes=False):
         if modes:
             return FDomainCBCModesGenerator
         return FDomainCBCGenerator
+    
+    if approximant in waveform_modes._mode_waveform_fd:
+        return FDomainCBCModesGenerator
 
     if approximant in ringdown.ringdown_fd_approximants:
         if approximant == ['FdQNMfromFinalMassSpin', 'FdModesfromFinalMassSpin']:

--- a/pycbc/waveform/generator.py
+++ b/pycbc/waveform/generator.py
@@ -344,7 +344,13 @@ class FDomainMassSpinRingdownGenerator(BaseGenerator):
 
     """
     def __init__(self, variable_args=(), **frozen_params):
-        super(FDomainMassSpinRingdownGenerator, self).__init__(ringdown.get_fd_from_final_mass_spin,
+        if frozen_params['approximant'] == 'FdQNMfromFinalMassSpin':
+            approximant = ringdown.get_fd_from_final_mass_spin
+        elif frozen_params['approximant'] == 'FdModesfromFinalMassSpin':
+            approximant = ringdown.get_fd_modes_from_final_mass_spin
+        else:
+            raise ValueError(f"Invalid approximant name: {frozen_params['approximant']}")
+        super(FDomainMassSpinRingdownGenerator, self).__init__(approximant,
             variable_args=variable_args, **frozen_params)
 
 
@@ -372,7 +378,13 @@ class FDomainFreqTauRingdownGenerator(BaseGenerator):
 
     """
     def __init__(self, variable_args=(), **frozen_params):
-        super(FDomainFreqTauRingdownGenerator, self).__init__(ringdown.get_fd_from_freqtau,
+        if frozen_params['approximant'] == 'FdQNMfromFreqTau':
+            approximant = ringdown.get_fd_from_freqtau
+        elif frozen_params['approximant'] == 'FdModesfromFreqTau':
+            approximant = ringdown.get_fd_modes_from_freqtau
+        else:
+            raise ValueError(f"Invalid approximant name: {frozen_params['approximant']}")
+        super(FDomainFreqTauRingdownGenerator, self).__init__(approximant,
             variable_args=variable_args, **frozen_params)
 
 
@@ -400,7 +412,13 @@ class TDomainMassSpinRingdownGenerator(BaseGenerator):
 
     """
     def __init__(self, variable_args=(), **frozen_params):
-        super(TDomainMassSpinRingdownGenerator, self).__init__(ringdown.get_td_from_final_mass_spin,
+        if frozen_params['approximant'] == 'TdQNMfromFinalMassSpin':
+            approximant = ringdown.get_td_from_final_mass_spin
+        elif frozen_params['approximant'] == 'TdModesfromFinalMassSpin':
+            approximant = ringdown.get_td_modes_from_final_mass_spin
+        else:
+            raise ValueError(f"Invalid approximant name: {frozen_params['approximant']}")
+        super(TDomainMassSpinRingdownGenerator, self).__init__(approximant,
             variable_args=variable_args, **frozen_params)
 
 
@@ -428,7 +446,13 @@ class TDomainFreqTauRingdownGenerator(BaseGenerator):
 
     """
     def __init__(self, variable_args=(), **frozen_params):
-        super(TDomainFreqTauRingdownGenerator, self).__init__(ringdown.get_td_from_freqtau,
+        if frozen_params['approximant'] == 'TdQNMfromFreqTau':
+            approximant = ringdown.get_td_from_freqtau
+        elif frozen_params['approximant'] == 'TdModesfromFreqTau':
+            approximant = ringdown.get_td_modes_from_freqtau
+        else:
+            raise ValueError(f"Invalid approximant name: {frozen_params['approximant']}")
+        super(TDomainFreqTauRingdownGenerator, self).__init__(approximant,
             variable_args=variable_args, **frozen_params)
 
 
@@ -1392,7 +1416,7 @@ def get_td_generator(approximant, modes=False):
         return TDomainCBCGenerator
 
     if approximant in ringdown.ringdown_td_approximants:
-        if approximant == 'TdQNMfromFinalMassSpin':
+        if approximant in ['TdQNMfromFinalMassSpin', 'TdModesfromFinalMassSpin']:
             return TDomainMassSpinRingdownGenerator
         return TDomainFreqTauRingdownGenerator
 
@@ -1410,7 +1434,7 @@ def get_fd_generator(approximant, modes=False):
         return FDomainCBCGenerator
 
     if approximant in ringdown.ringdown_fd_approximants:
-        if approximant == 'FdQNMfromFinalMassSpin':
+        if approximant == ['FdQNMfromFinalMassSpin', 'FdModesfromFinalMassSpin']:
             return FDomainMassSpinRingdownGenerator
         return FDomainFreqTauRingdownGenerator
 

--- a/pycbc/waveform/plugin.py
+++ b/pycbc/waveform/plugin.py
@@ -3,7 +3,7 @@
 
 
 def add_custom_waveform(approximant, function, domain,
-                        sequence=False, has_det_response=False,
+                        sequence=False, has_det_response=False, modes=False,
                         force=False,):
     """ Make custom waveform available to pycbc
 
@@ -24,6 +24,7 @@ def add_custom_waveform(approximant, function, domain,
     from pycbc.waveform.waveform import (cpu_fd, cpu_td, fd_sequence,
                                          fd_det, fd_det_sequence,
                                          td_fd_waveform_transform)
+    from pycbc.waveform.waveform_modes import _mode_waveform_td
 
     used = RuntimeError("Can't load plugin waveform {}, the name is"
                         " already in use.".format(approximant))
@@ -31,8 +32,11 @@ def add_custom_waveform(approximant, function, domain,
     if domain == 'time':
         if not force and (approximant in cpu_td):
             raise used
-        cpu_td[approximant] = function
-        td_fd_waveform_transform(approximant)
+        if modes:
+            _mode_waveform_td[approximant] = function
+        else:
+            cpu_td[approximant] = function
+            td_fd_waveform_transform(approximant)
     elif domain == 'frequency':
         if sequence:
             if not has_det_response:
@@ -120,8 +124,13 @@ def retrieve_waveform_plugins():
                             sequence=True, has_det_response=True)
 
     # Check for td waveforms
-    for plugin in entry_points(group='pycbc.waveform.td'):
-        add_custom_waveform(plugin.name, plugin.load(), 'time')
+    for plugin in pkg_resources.iter_entry_points('pycbc.waveform.td'):
+        add_custom_waveform(plugin.name, plugin.resolve(), 'time')
+
+    # Check for td modal waveforms
+    for plugin in pkg_resources.iter_entry_points('pycbc.waveform.td_modes'):
+        add_custom_waveform(plugin.name, plugin.resolve(), 'time',
+                            modes=True)
 
     # Check for waveform length estimates
     for plugin in entry_points(group='pycbc.waveform.length'):

--- a/pycbc/waveform/plugin.py
+++ b/pycbc/waveform/plugin.py
@@ -124,12 +124,12 @@ def retrieve_waveform_plugins():
                             sequence=True, has_det_response=True)
 
     # Check for td waveforms
-    for plugin in pkg_resources.iter_entry_points('pycbc.waveform.td'):
-        add_custom_waveform(plugin.name, plugin.resolve(), 'time')
+    for plugin in entry_points(group='pycbc.waveform.td'):
+        add_custom_waveform(plugin.name, plugin.load(), 'time')
 
     # Check for td modal waveforms
-    for plugin in pkg_resources.iter_entry_points('pycbc.waveform.td_modes'):
-        add_custom_waveform(plugin.name, plugin.resolve(), 'time',
+    for plugin in entry_points(group='pycbc.waveform.td_modes'):
+        add_custom_waveform(plugin.name, plugin.load(), 'time',
                             modes=True)
 
     # Check for waveform length estimates

--- a/pycbc/waveform/ringdown.py
+++ b/pycbc/waveform/ringdown.py
@@ -1312,13 +1312,13 @@ def get_fd_modes_from_freqtau(template=None, **kwargs):
 # Approximant names ###########################################################
 ringdown_fd_approximants = {
     'FdQNMfromFinalMassSpin': get_fd_from_final_mass_spin,
-    'FdQNMModesfromFinalMassSpin': get_fd_modes_from_final_mass_spin,
+    'FdModesfromFinalMassSpin': get_fd_modes_from_final_mass_spin,
     'FdQNMfromFreqTau': get_fd_from_freqtau,
-    'FdQNMModesfromFreqTau': get_fd_modes_from_freqtau}
+    'FdModesfromFreqTau': get_fd_modes_from_freqtau}
 
 
 ringdown_td_approximants = {
     'TdQNMfromFinalMassSpin': get_td_from_final_mass_spin,
-    'TdQNMModesfromFinalMassSpin': get_td_modes_from_final_mass_spin,
+    'TdModesfromFinalMassSpin': get_td_modes_from_final_mass_spin,
     'TdQNMfromFreqTau': get_td_from_freqtau,
-    'TdQNMModesfromFreqTau': get_td_modes_from_freqtau}
+    'TdModesfromFreqTau': get_td_modes_from_freqtau}

--- a/pycbc/waveform/ringdown.py
+++ b/pycbc/waveform/ringdown.py
@@ -706,7 +706,8 @@ def fd_damped_sinusoid(f_0, tau, amp, phi, freqs, t_0=0.,
 #### Base multi-mode for all approximants
 ######################################################
 
-def multimode_base(input_params, domain, freq_tau_approximant=False):
+def multimode_base(input_params, domain, freq_tau_approximant=False,
+                   sum_modes=True):
     """Return a superposition of damped sinusoids in either time or frequency
     domains with parameters set by input_params.
 
@@ -725,6 +726,9 @@ def multimode_base(input_params, domain, freq_tau_approximant=False):
         Choose the waveform approximant to use. Either based on
         mass/spin (set to False, default), or on frequencies/damping times
         of the modes (set to True).
+    sum_modes : {True, bool}, optional
+        Specify whether to return the individual damped sinusoids. If False,
+        return the individual modes. If True (default), return the sum.
 
     Returns
     -------
@@ -771,16 +775,34 @@ def multimode_base(input_params, domain, freq_tau_approximant=False):
                 taus[mode] += input_params['delta_tau{}'.format(mode)]*tau
     # setup the output
     if domain == 'td':
-        outplus, outcross = td_output_vector(freqs, taus,
+        if sum_modes:
+            outplus, outcross = td_output_vector(freqs, taus,
+                                input_params['taper'], input_params['delta_t'],
+                                input_params['t_final'])
+            sample_times = outplus.sample_times.numpy()
+        else:
+            out = {}
+            modes = list(freqs.keys())
+            for mode in modes:
+                out[mode] = list(td_output_vector(freqs, taus,
                             input_params['taper'], input_params['delta_t'],
-                            input_params['t_final'])
-        sample_times = outplus.sample_times.numpy()
+                            input_params['t_final']))
+            sample_times = out[modes[0]][0].sample_times.numpy()
     elif domain == 'fd':
         kmin = int(input_params['f_lower'] / input_params['delta_f'])
-        outplus, outcross = fd_output_vector(freqs, taus,
+        if sum_modes:
+            outplus, outcross = fd_output_vector(freqs, taus,
+                                input_params['delta_f'],
+                                input_params['f_final'])
+            sample_freqs = outplus.sample_frequencies.numpy()[kmin:]
+        else:
+            out = {}
+            modes = list(freqs.keys())
+            for mode in modes:
+                out[mode] = list(fd_output_vector(freqs, taus,
                             input_params['delta_f'],
-                            input_params['f_final'])
-        sample_freqs = outplus.sample_frequencies.numpy()[kmin:]
+                            input_params['f_final']))
+            sample_freqs = out[modes[0]][0].sample_frequencies.numpy()[kmin:]
     else:
         raise ValueError('unrecognised domain argument {}; '
                          'must be either fd or td'.format(domain))
@@ -798,8 +820,12 @@ def multimode_base(input_params, domain, freq_tau_approximant=False):
                 dphi=dphis[lmn], dbeta=dbetas[lmn],
                 harmonics=harmonics, final_spin=final_spin,
                 pol=pols[lmn], polnm=polnms[lmn])
-            outplus += hplus
-            outcross += hcross
+            if sum_modes:
+                outplus += hplus
+                outcross += hcross
+            else:
+                out[lmn][0] += norm * hplus
+                out[lmn][1] += norm * hcross
         elif domain == 'fd':
             hplus, hcross = fd_damped_sinusoid(
                 freqs[lmn], taus[lmn], amps[lmn], phis[lmn], sample_freqs,
@@ -808,9 +834,16 @@ def multimode_base(input_params, domain, freq_tau_approximant=False):
                 azimuthal=input_params['azimuthal'],
                 harmonics=harmonics, final_spin=final_spin,
                 pol=pols[lmn], polnm=polnms[lmn])
-            outplus[kmin:] += hplus
-            outcross[kmin:] += hcross
-    return norm * outplus, norm * outcross
+            if sum_modes:
+                outplus[kmin:] += hplus
+                outcross[kmin:] += hcross
+            else:
+                out[lmn][0][kmin:] += norm * hplus
+                out[lmn][1][kmin:] += norm * hcross
+    if sum_modes:
+        return norm * outplus, norm * outcross
+    else:
+        return out
 
 
 ######################################################
@@ -928,6 +961,18 @@ def get_td_from_final_mass_spin(template=None, **kwargs):
     input_params = props(template, mass_spin_required_args, td_args, **kwargs)
     return multimode_base(input_params, domain='td')
 
+def get_td_modes_from_final_mass_spin(template=None, **kwargs):
+    """Return time domain ringdown modes for all modes specified.
+    See get_td_from_final_mass_spin for full list of kwargs.
+
+    Returns
+    -------
+    out : dict
+        The plus and cross polarization of each ringdown mode keyed by lmn
+    """
+    input_params = props(template, mass_spin_required_args, td_args, **kwargs)
+    return multimode_base(input_params, domain='td', sum_modes=False)
+
 def get_fd_from_final_mass_spin(template=None, **kwargs):
     """Return frequency domain ringdown with all the modes specified.
 
@@ -1022,6 +1067,18 @@ def get_fd_from_final_mass_spin(template=None, **kwargs):
     """
     input_params = props(template, mass_spin_required_args, fd_args, **kwargs)
     return multimode_base(input_params, domain='fd')
+
+def get_fd_modes_from_final_mass_spin(template=None, **kwargs):
+    """Return frequency domain ringdown modes for all modes specified.
+    See get_fd_from_final_mass_spin for full list of kwargs.
+
+    Returns
+    -------
+    out : dict
+        The plus and cross polarization of each ringdown mode keyed by lmn
+    """
+    input_params = props(template, mass_spin_required_args, fd_args, **kwargs)
+    return multimode_base(input_params, domain='fd', sum_modes=False)
 
 def get_td_from_freqtau(template=None, **kwargs):
     """Return time domain ringdown with all the modes specified.
@@ -1126,6 +1183,19 @@ def get_td_from_freqtau(template=None, **kwargs):
     input_params = props(template, freqtau_required_args, td_args, **kwargs)
     return multimode_base(input_params, domain='td', freq_tau_approximant=True)
 
+def get_td_modes_from_freqtau(template=None, **kwargs):
+    """Return time domain ringdown modes for all modes specified.
+    See get_td_from_freqtau for full list of kwargs.
+
+    Returns
+    -------
+    out : dict
+        The plus and cross polarization of each ringdown mode keyed by lmn
+    """
+    input_params = props(template, freqtau_required_args, td_args, **kwargs)
+    return multimode_base(input_params, domain='td', freq_tau_approximant=True,
+                          sum_modes=False)
+
 def get_fd_from_freqtau(template=None, **kwargs):
     """Return frequency domain ringdown with all the modes specified.
 
@@ -1226,12 +1296,29 @@ def get_fd_from_freqtau(template=None, **kwargs):
     input_params = props(template, freqtau_required_args, fd_args, **kwargs)
     return multimode_base(input_params, domain='fd', freq_tau_approximant=True)
 
+def get_fd_modes_from_freqtau(template=None, **kwargs):
+    """Return frequency domain ringdown modes for all modes specified.
+    See get_fd_from_freqtau for full list of kwargs.
+
+    Returns
+    -------
+    out : dict
+        The plus and cross polarization of each ringdown mode keyed by lmn
+    """
+    input_params = props(template, freqtau_required_args, fd_args, **kwargs)
+    return multimode_base(input_params, domain='fd', freq_tau_approximant=True,
+                          sum_modes=False)
+
 # Approximant names ###########################################################
 ringdown_fd_approximants = {
     'FdQNMfromFinalMassSpin': get_fd_from_final_mass_spin,
-    'FdQNMfromFreqTau': get_fd_from_freqtau}
+    'FdQNMModesfromFinalMassSpin': get_fd_modes_from_final_mass_spin,
+    'FdQNMfromFreqTau': get_fd_from_freqtau,
+    'FdQNMModesfromFreqTau': get_fd_modes_from_freqtau}
 
 
 ringdown_td_approximants = {
     'TdQNMfromFinalMassSpin': get_td_from_final_mass_spin,
-    'TdQNMfromFreqTau': get_td_from_freqtau}
+    'TdQNMModesfromFinalMassSpin': get_td_modes_from_final_mass_spin,
+    'TdQNMfromFreqTau': get_td_from_freqtau,
+    'TdQNMModesfromFreqTau': get_td_modes_from_freqtau}

--- a/pycbc/waveform/waveform_modes.py
+++ b/pycbc/waveform/waveform_modes.py
@@ -371,9 +371,6 @@ _mode_waveform_td = {'EOBNRv2': get_lalsimulation_modes,
                      'TaylorT2': get_lalsimulation_modes,
                      'TaylorT3': get_lalsimulation_modes,
                      'TaylorT4': get_lalsimulation_modes,
-                     'TdModesfromFinalMassSpin':
-                         ringdown.get_td_modes_from_final_mass_spin,
-                     'TdModesfromFreqTau': ringdown.get_td_modes_from_freqtau,
                      }
 _mode_waveform_fd = {'IMRPhenomXHM': get_imrphenomxh_modes,
                      'FdModesfromFinalMassSpin':

--- a/pycbc/waveform/waveform_modes.py
+++ b/pycbc/waveform/waveform_modes.py
@@ -23,7 +23,6 @@ from pycbc import libutils, pnutils
 from pycbc.types import (TimeSeries, FrequencySeries)
 from pycbc.constants import MSUN_SI, PC_SI
 from .waveform import (props, _check_lal_pars, check_args)
-from pycbc.waveform import ringdown
 from . import parameters
 
 lalsimulation = libutils.import_optional('lalsimulation')

--- a/pycbc/waveform/waveform_modes.py
+++ b/pycbc/waveform/waveform_modes.py
@@ -373,9 +373,6 @@ _mode_waveform_td = {'EOBNRv2': get_lalsimulation_modes,
                      'TaylorT4': get_lalsimulation_modes,
                      }
 _mode_waveform_fd = {'IMRPhenomXHM': get_imrphenomxh_modes,
-                     'FdModesfromFinalMassSpin':
-                         ringdown.get_fd_modes_from_final_mass_spin,
-                     'FdModesfromFreqTau': ringdown.get_fd_modes_from_freqtau,
                      }
 # 'IMRPhenomXPHM':get_imrphenomhm_modes needs to be implemented
 # LAL function do not split strain mode by mode

--- a/pycbc/waveform/waveform_modes.py
+++ b/pycbc/waveform/waveform_modes.py
@@ -23,6 +23,7 @@ from pycbc import libutils, pnutils
 from pycbc.types import (TimeSeries, FrequencySeries)
 from pycbc.constants import MSUN_SI, PC_SI
 from .waveform import (props, _check_lal_pars, check_args)
+from pycbc.waveform import ringdown
 from . import parameters
 
 lalsimulation = libutils.import_optional('lalsimulation')
@@ -370,8 +371,14 @@ _mode_waveform_td = {'EOBNRv2': get_lalsimulation_modes,
                      'TaylorT2': get_lalsimulation_modes,
                      'TaylorT3': get_lalsimulation_modes,
                      'TaylorT4': get_lalsimulation_modes,
+                     'TdModesfromFinalMassSpin':
+                         ringdown.get_td_modes_from_final_mass_spin,
+                     'TdModesfromFreqTau': ringdown.get_td_modes_from_freqtau,
                      }
 _mode_waveform_fd = {'IMRPhenomXHM': get_imrphenomxh_modes,
+                     'FdModesfromFinalMassSpin':
+                         ringdown.get_fd_modes_from_final_mass_spin,
+                     'FdModesfromFreqTau': ringdown.get_fd_modes_from_freqtau,
                      }
 # 'IMRPhenomXPHM':get_imrphenomhm_modes needs to be implemented
 # LAL function do not split strain mode by mode


### PR DESCRIPTION
This PR adds generators for generating the ringdown models mode-by-mode, as well as allowing for multimodal waveform plugins that explicitly calculate individual modes to be generated in the same way. 

Earlier iterations of PR #5229 attempted to calculate likelihoods by generating templates as individual modes (e.g. QNM approximants). The current iteration of that PR no longer requires these changes; however, I've kept them here in case they end up being useful in the future. 

- [ x ] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)