### PR TITLE
Improve CUDA initialization and error handling (WSL-specific / platform-specific fix)

### DIFF
--- a/pycbc/__init__.py
+++ b/pycbc/__init__.py
@@ -180,21 +180,20 @@ VARARGS_DELIM = '+'
 
 # Check for optional components of the PyCBC Package
 try:
-    # This is a crude check to make sure that the driver is installed
-    try:
-        loaded_modules = subprocess.Popen(['lsmod'], stdout=subprocess.PIPE).communicate()[0]
-        loaded_modules = loaded_modules.decode()
-        if 'nvidia' not in loaded_modules:
-            raise ImportError("nvidia driver may not be installed correctly")
-    except OSError:
-        pass
-
-    # Check that pycuda is installed and can talk to the driver
     import pycuda.driver as _pycudadrv
-
-    HAVE_CUDA=True
-except ImportError:
-    HAVE_CUDA=False
+    #check how many CUDA device is installed
+        try:
+            _pycudadrv.init()
+            device_count = _pycudadrv.Device.count()
+        except Exception:
+            device_count = 0
+        #Set value to true if there is usable device
+        HAVE_CUDA = (device_count > 0)
+        if HAVE_CUDA and device_count == 0:
+            import warnings
+            warnings.warn("PyCUDA imported but no CUDA device found; disabling CUDA support")
+    except ImportError:
+HAVE_CUDA = False
 
 # Check for MKL capability
 try:


### PR DESCRIPTION
Refactor CUDA device check and remove obsolete driver check.
**Descrption**
On WSL2(Windows Linux Subsystem), PyCBC’s current CUDA detection logic (in `pycbc/__init__.py`) fails because it checks lsmod for an nvidia kernel module. Since on WSL the NVIDIA driver is virtualized (and lsmod may not show “nvidia”), this check often fails, even when PyCUDA is functional, leading to `pycbc.HAVE_CUDA = False` and inability to use `CUDAScheme`.

## Standard information about the request

This is a bug fix to issue #5231 


This change affects: `__init__.py` Line


This change changes: Checking if CUDA is avilable.

<!--- Some things which help with code management (delete as appropriate) -->
This change: has appropriate unit tests, follows style guidelines (See e.g. [PEP8](https://peps.python.org/pep-0008/)), has been proposed using the [contribution guidelines](https://github.com/gwastro/pycbc/blob/master/CONTRIBUTING.md)

<!--- Notes about the effect of this change -->
This change will: break current functionality, require additional dependencies, require a new release, other (please describe)

## Motivation
Bugfix according to a bug encountered when running PyCBC CUDA on WSL.

## Contents
Replace the `lsmod`‑based check with a more robust test that initializes PyCUDA and counts devices.

## Links to any issues or associated PRs
issue #5231 

## Testing performed
Performed on WSL2. Works well.

## Additional notes
None

- [ ] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
