### PR TITLE
np.unicode_ deprecated

### DIFF
--- a/bin/pycbc_banksim_combine_banks
+++ b/bin/pycbc_banksim_combine_banks
@@ -44,9 +44,9 @@ options = parser.parse_args()
 
 pycbc.init_logging(options.verbose)
 
-dtypef = np.dtype([('match', np.float64), ('bank', np.unicode_, 256),
-                ('bank_i', np.int32), ('sim', np.unicode_, 256),
-                ('sim_i', np.int32), ('sigmasq', np.float64)])
+dtypef = np.dtype([('match', np.float64), ('bank', np.str_, 256),
+                   ('bank_i', np.int32), ('sim', np.str_, 256),
+                   ('sim_i', np.int32), ('sigmasq', np.float64)])
 
 matches=[]
 maxmatch = []

--- a/bin/pycbc_banksim_match_combine
+++ b/bin/pycbc_banksim_match_combine
@@ -63,9 +63,9 @@ options = parser.parse_args()
 
 pycbc.init_logging(options.verbose)
 
-dtypem = np.dtype([('match', np.float64), ('bank', np.unicode_, 256),
-                      ('bank_i', np.int32), ('sim', np.unicode_, 256),
-                      ('sim_i', np.int32), ('sigmasq', np.float64)])
+dtypem = np.dtype([('match', np.float64), ('bank', np.str_, 256),
+                   ('bank_i', np.int32), ('sim', np.str_, 256),
+                   ('sim_i', np.int32), ('sigmasq', np.float64)])
 
 # Collect the results
 res = None


### PR DESCRIPTION
The banks codes didn't work because of this, its a pretty simple fix

## Standard information about the request

This is a bug fix
This change affects banks
This change has been proposed using the [contribution guidelines](https://github.com/gwastro/pycbc/blob/master/CONTRIBUTING.md)


## Contents
Replace numpy unicode_ with numpy str_


## Testing performed
My banksim runs worked after this


- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
