### PR TITLE
force all double internal precision for higher order waveform decompression

### DIFF
--- a/pycbc/waveform/decompress_cpu_ccode.cpp
+++ b/pycbc/waveform/decompress_cpu_ccode.cpp
@@ -39,26 +39,26 @@
 template <class T, class T_COMPLEX>
 static inline void _decomp_ccode_segment(
     T_COMPLEX* h_seg,
-    T f1, T f2, T a1, T a2, T p1, T p2,
-    T df, int64_t k, const int64_t kmax,
+    double f1, double f2, double a1, double a2, double p1, double p2,
+    double df, int64_t k, const int64_t kmax,
     const int update_interval)
 {
     T* outptr = (T*) h_seg;
-    T inv_sdf = 1.0 / (f2 - f1);
-    T m_amp = (a2 - a1) * inv_sdf;
-    T b_amp = a1 - m_amp * f1;
-    T m_phi = (p2 - p1) * inv_sdf;
-    T b_phi = p1 - m_phi * f1;
+    double inv_sdf = 1.0 / (f2 - f1);
+    double m_amp = (a2 - a1) * inv_sdf;
+    double b_amp = a1 - m_amp * f1;
+    double m_phi = (p2 - p1) * inv_sdf;
+    double b_phi = p1 - m_phi * f1;
 
-    T h_re, h_im, g_re, g_im, dphi_re, dphi_im;
-    T incrh_re, incrh_im, incrg_re, incrg_im, f;
+    double h_re, h_im, g_re, g_im, dphi_re, dphi_im;
+    double incrh_re, incrh_im, incrg_re, incrg_im, f;
     int64_t findex = k;
     int64_t k_sub_max;
 
     while (findex < kmax) {
         f = findex * df;
-        T interp_amp = m_amp * f + b_amp;
-        T interp_phi = m_phi * f + b_phi;
+        double interp_amp = m_amp * f + b_amp;
+        double interp_phi = m_phi * f + b_phi;
         dphi_re = cos(m_phi * df);
         dphi_im = sin(m_phi * df);
         h_re = interp_amp * cos(interp_phi);
@@ -66,8 +66,8 @@ static inline void _decomp_ccode_segment(
         g_re = m_amp * df * cos(interp_phi);
         g_im = m_amp * df * sin(interp_phi);
 
-        *outptr = h_re;
-        *(outptr + 1) = h_im;
+        *outptr = (T)h_re;
+        *(outptr + 1) = (T)h_im;
         outptr += 2;
         findex++;
 
@@ -84,8 +84,8 @@ static inline void _decomp_ccode_segment(
             g_re = incrg_re;
             g_im = incrg_im;
 
-            *outptr = h_re;
-            *(outptr + 1) = h_im;
+            *outptr = (T)h_re;
+            *(outptr + 1) = (T)h_im;
             outptr += 2;
             findex++;
         }
@@ -103,34 +103,34 @@ static inline void _decomp_ccode_segment(
 template <class T, class T_COMPLEX>
 static inline void _decomp_qcode_segment(
     T_COMPLEX* h_seg,
-    T f0, T f1, T f2, T a0, T a1, T a2, T p0, T p1, T p2,
-    T df, int64_t k_start, const int64_t kmax, // Renamed k to k_start
+    double f0, double f1, double f2, double a0, double a1, double a2, double p0, double p1, double p2,
+    double df, int64_t k_start, const int64_t kmax, // Renamed k to k_start
     const int update_interval)
 {
-    T f;
-    T h2 = df * df;
+    double f;
+    double h2 = df * df;
 
     // Denominators for Lagrange basis (constant for segment)
-    T denom0 = (f0 - f1) * (f0 - f2);
-    T denom1 = (f1 - f0) * (f1 - f2);
-    T denom2 = (f2 - f0) * (f2 - f1);
+    double denom0 = (f0 - f1) * (f0 - f2);
+    double denom1 = (f1 - f0) * (f1 - f2);
+    double denom2 = (f2 - f0) * (f2 - f1);
 
     // --- Get power-basis coefficients: c2*f^2 + c1*f + c0 ---
-    T c_a2 = a0/denom0 + a1/denom1 + a2/denom2;
-    T c_p2 = p0/denom0 + p1/denom1 + p2/denom2;
-    T c_a1 = -a0*(f1+f2)/denom0 - a1*(f0+f2)/denom1 - a2*(f0+f1)/denom2;
-    T c_p1 = -p0*(f1+f2)/denom0 - p1*(f0+f2)/denom1 - p2*(f0+f1)/denom2;
-    T c_a0 = a0*f1*f2/denom0 + a1*f0*f2/denom1 + a2*f0*f1/denom2;
-    T c_p0 = p0*f1*f2/denom0 + p1*f0*f2/denom1 + p2*f0*f1/denom2;
+    double c_a2 = a0/denom0 + a1/denom1 + a2/denom2;
+    double c_p2 = p0/denom0 + p1/denom1 + p2/denom2;
+    double c_a1 = -a0*(f1+f2)/denom0 - a1*(f0+f2)/denom1 - a2*(f0+f1)/denom2;
+    double c_p1 = -p0*(f1+f2)/denom0 - p1*(f0+f2)/denom1 - p2*(f0+f1)/denom2;
+    double c_a0 = a0*f1*f2/denom0 + a1*f0*f2/denom1 + a2*f0*f1/denom2;
+    double c_p0 = p0*f1*f2/denom0 + p1*f0*f2/denom1 + p2*f0*f1/denom2;
 
     // --- Finite difference constants (constant for segment) ---
-    T d2_a_const = 2 * c_a2 * h2;
-    T d2_p_const = 2 * c_p2 * h2;
-    T_COMPLEX d2_phase_const = std::polar((T)1.0, d2_p_const);
+    double d2_a_const = 2 * c_a2 * h2;
+    double d2_p_const = 2 * c_p2 * h2;
+    std::complex<double> d2_phase_const = std::polar(1.0, d2_p_const);
 
     // Stepper variables
-    T a, p, d1_a, d1_p;
-    T_COMPLEX phase, d_phase;
+    double a, p, d1_a, d1_p;
+    std::complex<double> phase, d_phase;
     int64_t k_sub_max;
     int64_t k = k_start; // k is now the local loop variable
 
@@ -144,12 +144,12 @@ static inline void _decomp_qcode_segment(
         p = c_p2*f*f + c_p1*f + c_p0;
         d1_a = c_a2*(2*f*df + h2) + c_a1*df;
         d1_p = c_p2*(2*f*df + h2) + c_p1*df;
-        phase = std::polar((T)1.0, p);
-        d_phase = std::polar((T)1.0, d1_p);
+        phase = std::polar(1.0, p);
+        d_phase = std::polar(1.0, d1_p);
 
         // --- Fast Inner Loop ---
         for (; k < k_sub_max; k++) {
-            h_seg[k - k_start] = a * phase; // Corrected indexing
+            h_seg[k - k_start] = (T_COMPLEX)(a * phase); // Corrected indexing and cast
             phase = phase * d_phase;
             d_phase = d_phase * d2_phase_const;
             a = a + d1_a;
@@ -169,40 +169,42 @@ static inline void _decomp_qcode_segment(
 template <class T, class T_COMPLEX>
 static inline void _decomp_tcode_segment(
     T_COMPLEX* h_seg,
-    T f0, T f1, T f2, T f3, T a0, T a1, T a2, T a3, T p0, T p1, T p2, T p3,
-    T df, int64_t k_start, const int64_t kmax, // Renamed k to k_start
+    double f0, double f1, double f2, double f3, 
+    double a0, double a1, double a2, double a3, 
+    double p0, double p1, double p2, double p3,
+    double df, int64_t k_start, const int64_t kmax, // Renamed k to k_start
     const int update_interval)
 {
-    T f;
-    T h2 = df * df;
-    T h3 = h2 * df;
+    double f;
+    double h2 = df * df;
+    double h3 = h2 * df;
 
     // --- Denominators for Lagrange basis (constant for segment) ---
-    T denom0 = (f0-f1)*(f0-f2)*(f0-f3);
-    T denom1 = (f1-f0)*(f1-f2)*(f1-f3);
-    T denom2 = (f2-f0)*(f2-f1)*(f2-f3);
-    T denom3 = (f3-f0)*(f3-f1)*(f3-f2);
+    double denom0 = (f0-f1)*(f0-f2)*(f0-f3);
+    double denom1 = (f1-f0)*(f1-f2)*(f1-f3);
+    double denom2 = (f2-f0)*(f2-f1)*(f2-f3);
+    double denom3 = (f3-f0)*(f3-f1)*(f3-f2);
 
     // --- Get power-basis coefficients: c3*f^3 + c2*f^2 + c1*f + c0 ---
     // --- Amplitude ---
-    T c_a3 = a0/denom0 + a1/denom1 + a2/denom2 + a3/denom3;
-    T c_a2 = -a0*(f1+f2+f3)/denom0 - a1*(f0+f2+f3)/denom1 - a2*(f0+f1+f3)/denom2 - a3*(f0+f1+f2)/denom3;
-    T c_a1 = a0*(f1*f2 + f1*f3 + f2*f3)/denom0 + a1*(f0*f2 + f0*f3 + f2*f3)/denom1 + a2*(f0*f1 + f0*f3 + f1*f3)/denom2 + a3*(f0*f1 + f0*f2 + f1*f2)/denom3;
-    T c_a0 = -a0*(f1*f2*f3)/denom0 - a1*(f0*f2*f3)/denom1 - a2*(f0*f1*f3)/denom2 - a3*(f0*f1*f2)/denom3;
+    double c_a3 = a0/denom0 + a1/denom1 + a2/denom2 + a3/denom3;
+    double c_a2 = -a0*(f1+f2+f3)/denom0 - a1*(f0+f2+f3)/denom1 - a2*(f0+f1+f3)/denom2 - a3*(f0+f1+f2)/denom3;
+    double c_a1 = a0*(f1*f2 + f1*f3 + f2*f3)/denom0 + a1*(f0*f2 + f0*f3 + f2*f3)/denom1 + a2*(f0*f1 + f0*f3 + f1*f3)/denom2 + a3*(f0*f1 + f0*f2 + f1*f2)/denom3;
+    double c_a0 = -a0*(f1*f2*f3)/denom0 - a1*(f0*f2*f3)/denom1 - a2*(f0*f1*f3)/denom2 - a3*(f0*f1*f2)/denom3;
     // --- Phase ---
-    T c_p3 = p0/denom0 + p1/denom1 + p2/denom2 + p3/denom3;
-    T c_p2 = -p0*(f1+f2+f3)/denom0 - p1*(f0+f2+f3)/denom1 - p2*(f0+f1+f3)/denom2 - p3*(f0+f1+f2)/denom3;
-    T c_p1 = p0*(f1*f2 + f1*f3 + f2*f3)/denom0 + p1*(f0*f2 + f0*f3 + f2*f3)/denom1 + p2*(f0*f1 + f0*f3 + f1*f3)/denom2 + p3*(f0*f1 + f0*f2 + f1*f2)/denom3;
-    T c_p0 = -p0*(f1*f2*f3)/denom0 - p1*(f0*f2*f3)/denom1 - p2*(f0*f1*f3)/denom2 - p3*(f0*f1*f2)/denom3;
+    double c_p3 = p0/denom0 + p1/denom1 + p2/denom2 + p3/denom3;
+    double c_p2 = -p0*(f1+f2+f3)/denom0 - p1*(f0+f2+f3)/denom1 - p2*(f0+f1+f3)/denom2 - p3*(f0+f1+f2)/denom3;
+    double c_p1 = p0*(f1*f2 + f1*f3 + f2*f3)/denom0 + p1*(f0*f2 + f0*f3 + f2*f3)/denom1 + p2*(f0*f1 + f0*f3 + f1*f3)/denom2 + p3*(f0*f1 + f0*f2 + f1*f2)/denom3;
+    double c_p0 = -p0*(f1*f2*f3)/denom0 - p1*(f0*f2*f3)/denom1 - p2*(f0*f1*f3)/denom2 - p3*(f0*f1*f2)/denom3;
 
     // --- Finite difference constants (constant for segment) ---
-    T d3_a_const = 6 * c_a3 * h3;
-    T d3_p_const = 6 * c_p3 * h3;
-    T_COMPLEX d3_phase_const = std::polar((T)1.0, d3_p_const);
+    double d3_a_const = 6 * c_a3 * h3;
+    double d3_p_const = 6 * c_p3 * h3;
+    std::complex<double> d3_phase_const = std::polar(1.0, d3_p_const);
 
     // Stepper variables
-    T a, p, d1_a, d1_p, d2_a, d2_p;
-    T_COMPLEX phase, d1_phase, d2_phase;
+    double a, p, d1_a, d1_p, d2_a, d2_p;
+    std::complex<double> phase, d1_phase, d2_phase;
     int64_t k_sub_max;
     int64_t k = k_start; // k is now the local loop variable
 
@@ -225,13 +227,13 @@ static inline void _decomp_tcode_segment(
         d2_p = c_p3*(6*f*h2 + 6*h3) + c_p2*(2*h2);
 
         // Complex phase steppers
-        phase = std::polar((T)1.0, p);
-        d1_phase = std::polar((T)1.0, d1_p);
-        d2_phase = std::polar((T)1.0, d2_p);
+        phase = std::polar(1.0, p);
+        d1_phase = std::polar(1.0, d1_p);
+        d2_phase = std::polar(1.0, d2_p);
 
         // --- Fast Inner Loop ---
         for (; k < k_sub_max; k++) {
-            h_seg[k - k_start] = a * phase; // Corrected indexing
+            h_seg[k - k_start] = (T_COMPLEX)(a * phase); // Corrected indexing and cast
 
             // Step phase forward
             phase = phase * d1_phase;
@@ -257,46 +259,46 @@ static inline void _decomp_tcode_segment(
 template <class T, class T_COMPLEX>
 static inline void _decomp_Qcode_segment(
     T_COMPLEX* h_seg,
-    T f0, T f1, T f2, T f3, T f4, // 5 freqs
-    T a0, T a1, T a2, T a3, T a4, // 5 amps
-    T p0, T p1, T p2, T p3, T p4, // 5 phases
-    T df, int64_t k_start, const int64_t kmax,
+    double f0, double f1, double f2, double f3, double f4, // 5 freqs
+    double a0, double a1, double a2, double a3, double a4, // 5 amps
+    double p0, double p1, double p2, double p3, double p4, // 5 phases
+    double df, int64_t k_start, const int64_t kmax,
     const int update_interval)
 {
-    T f;
-    T h2 = df * df;
-    T h3 = h2 * df;
-    T h4 = h3 * df;
+    double f;
+    double h2 = df * df;
+    double h3 = h2 * df;
+    double h4 = h3 * df;
 
     // --- Denominators for Lagrange basis (constant for segment) ---
-    T denom0 = (f0-f1)*(f0-f2)*(f0-f3)*(f0-f4);
-    T denom1 = (f1-f0)*(f1-f2)*(f1-f3)*(f1-f4);
-    T denom2 = (f2-f0)*(f2-f1)*(f2-f3)*(f2-f4);
-    T denom3 = (f3-f0)*(f3-f1)*(f3-f2)*(f3-f4);
-    T denom4 = (f4-f0)*(f4-f1)*(f4-f2)*(f4-f3);
+    double denom0 = (f0-f1)*(f0-f2)*(f0-f3)*(f0-f4);
+    double denom1 = (f1-f0)*(f1-f2)*(f1-f3)*(f1-f4);
+    double denom2 = (f2-f0)*(f2-f1)*(f2-f3)*(f2-f4);
+    double denom3 = (f3-f0)*(f3-f1)*(f3-f2)*(f3-f4);
+    double denom4 = (f4-f0)*(f4-f1)*(f4-f2)*(f4-f3);
 
     // --- Get power-basis coefficients: c4*f^4 + c3*f^3 + c2*f^2 + c1*f + c0 ---
     // --- Amplitude ---
-    T c_a4 = a0/denom0 + a1/denom1 + a2/denom2 + a3/denom3 + a4/denom4;
-    T c_a3 = -a0*(f1+f2+f3+f4)/denom0 - a1*(f0+f2+f3+f4)/denom1 - a2*(f0+f1+f3+f4)/denom2 - a3*(f0+f1+f2+f4)/denom3 - a4*(f0+f1+f2+f3)/denom4;
-    T c_a2 = a0*(f1*f2+f1*f3+f1*f4+f2*f3+f2*f4+f3*f4)/denom0 + a1*(f0*f2+f0*f3+f0*f4+f2*f3+f2*f4+f3*f4)/denom1 + a2*(f0*f1+f0*f3+f0*f4+f1*f3+f1*f4+f3*f4)/denom2 + a3*(f0*f1+f0*f2+f0*f4+f1*f2+f1*f4+f2*f4)/denom3 + a4*(f0*f1+f0*f2+f0*f3+f1*f2+f1*f3+f2*f3)/denom4;
-    T c_a1 = -a0*(f1*f2*f3+f1*f2*f4+f1*f3*f4+f2*f3*f4)/denom0 - a1*(f0*f2*f3+f0*f2*f4+f0*f3*f4+f2*f3*f4)/denom1 - a2*(f0*f1*f3+f0*f1*f4+f0*f3*f4+f1*f3*f4)/denom2 - a3*(f0*f1*f2+f0*f1*f4+f0*f2*f4+f1*f2*f4)/denom3 - a4*(f0*f1*f2+f0*f1*f3+f0*f2*f3+f1*f2*f3)/denom4;
-    T c_a0 = a0*(f1*f2*f3*f4)/denom0 + a1*(f0*f2*f3*f4)/denom1 + a2*(f0*f1*f3*f4)/denom2 + a3*(f0*f1*f2*f4)/denom3 + a4*(f0*f1*f2*f3)/denom4;
+    double c_a4 = a0/denom0 + a1/denom1 + a2/denom2 + a3/denom3 + a4/denom4;
+    double c_a3 = -a0*(f1+f2+f3+f4)/denom0 - a1*(f0+f2+f3+f4)/denom1 - a2*(f0+f1+f3+f4)/denom2 - a3*(f0+f1+f2+f4)/denom3 - a4*(f0+f1+f2+f3)/denom4;
+    double c_a2 = a0*(f1*f2+f1*f3+f1*f4+f2*f3+f2*f4+f3*f4)/denom0 + a1*(f0*f2+f0*f3+f0*f4+f2*f3+f2*f4+f3*f4)/denom1 + a2*(f0*f1+f0*f3+f0*f4+f1*f3+f1*f4+f3*f4)/denom2 + a3*(f0*f1+f0*f2+f0*f4+f1*f2+f1*f4+f2*f4)/denom3 + a4*(f0*f1+f0*f2+f0*f3+f1*f2+f1*f3+f2*f3)/denom4;
+    double c_a1 = -a0*(f1*f2*f3+f1*f2*f4+f1*f3*f4+f2*f3*f4)/denom0 - a1*(f0*f2*f3+f0*f2*f4+f0*f3*f4+f2*f3*f4)/denom1 - a2*(f0*f1*f3+f0*f1*f4+f0*f3*f4+f1*f3*f4)/denom2 - a3*(f0*f1*f2+f0*f1*f4+f0*f2*f4+f1*f2*f4)/denom3 - a4*(f0*f1*f2+f0*f1*f3+f0*f2*f3+f1*f2*f3)/denom4;
+    double c_a0 = a0*(f1*f2*f3*f4)/denom0 + a1*(f0*f2*f3*f4)/denom1 + a2*(f0*f1*f3*f4)/denom2 + a3*(f0*f1*f2*f4)/denom3 + a4*(f0*f1*f2*f3)/denom4;
     // --- Phase ---
-    T c_p4 = p0/denom0 + p1/denom1 + p2/denom2 + p3/denom3 + p4/denom4;
-    T c_p3 = -p0*(f1+f2+f3+f4)/denom0 - p1*(f0+f2+f3+f4)/denom1 - p2*(f0+f1+f3+f4)/denom2 - p3*(f0+f1+f2+f4)/denom3 - p4*(f0+f1+f2+f3)/denom4;
-    T c_p2 = p0*(f1*f2+f1*f3+f1*f4+f2*f3+f2*f4+f3*f4)/denom0 + p1*(f0*f2+f0*f3+f0*f4+f2*f3+f2*f4+f3*f4)/denom1 + p2*(f0*f1+f0*f3+f0*f4+f1*f3+f1*f4+f3*f4)/denom2 + p3*(f0*f1+f0*f2+f0*f4+f1*f2+f1*f4+f2*f4)/denom3 + p4*(f0*f1+f0*f2+f0*f3+f1*f2+f1*f3+f2*f3)/denom4;
-    T c_p1 = -p0*(f1*f2*f3+f1*f2*f4+f1*f3*f4+f2*f3*f4)/denom0 - p1*(f0*f2*f3+f0*f2*f4+f0*f3*f4+f2*f3*f4)/denom1 - p2*(f0*f1*f3+f0*f1*f4+f0*f3*f4+f1*f3*f4)/denom2 - p3*(f0*f1*f2+f0*f1*f4+f0*f2*f4+f1*f2*f4)/denom3 - p4*(f0*f1*f2+f0*f1*f3+f0*f2*f3+f1*f2*f3)/denom4;
-    T c_p0 = p0*(f1*f2*f3*f4)/denom0 + p1*(f0*f2*f3*f4)/denom1 + p2*(f0*f1*f3*f4)/denom2 + p3*(f0*f1*f2*f4)/denom3 + p4*(f0*f1*f2*f3)/denom4;
+    double c_p4 = p0/denom0 + p1/denom1 + p2/denom2 + p3/denom3 + p4/denom4;
+    double c_p3 = -p0*(f1+f2+f3+f4)/denom0 - p1*(f0+f2+f3+f4)/denom1 - p2*(f0+f1+f3+f4)/denom2 - p3*(f0+f1+f2+f4)/denom3 - p4*(f0+f1+f2+f3)/denom4;
+    double c_p2 = p0*(f1*f2+f1*f3+f1*f4+f2*f3+f2*f4+f3*f4)/denom0 + p1*(f0*f2+f0*f3+f0*f4+f2*f3+f2*f4+f3*f4)/denom1 + p2*(f0*f1+f0*f3+f0*f4+f1*f3+f1*f4+f3*f4)/denom2 + p3*(f0*f1+f0*f2+f0*f4+f1*f2+f1*f4+f2*f4)/denom3 + p4*(f0*f1+f0*f2+f0*f3+f1*f2+f1*f3+f2*f3)/denom4;
+    double c_p1 = -p0*(f1*f2*f3+f1*f2*f4+f1*f3*f4+f2*f3*f4)/denom0 - p1*(f0*f2*f3+f0*f2*f4+f0*f3*f4+f2*f3*f4)/denom1 - p2*(f0*f1*f3+f0*f1*f4+f0*f3*f4+f1*f3*f4)/denom2 - p3*(f0*f1*f2+f0*f1*f4+f0*f2*f4+f1*f2*f4)/denom3 - p4*(f0*f1*f2+f0*f1*f3+f0*f2*f3+f1*f2*f3)/denom4;
+    double c_p0 = p0*(f1*f2*f3*f4)/denom0 + p1*(f0*f2*f3*f4)/denom1 + p2*(f0*f1*f3*f4)/denom2 + p3*(f0*f1*f2*f4)/denom3 + p4*(f0*f1*f2*f3)/denom4;
 
     // --- Finite difference constants (constant for segment) ---
-    T d4_a_const = 24 * c_a4 * h4;
-    T d4_p_const = 24 * c_p4 * h4;
-    T_COMPLEX d4_phase_const = std::polar((T)1.0, d4_p_const);
+    double d4_a_const = 24 * c_a4 * h4;
+    double d4_p_const = 24 * c_p4 * h4;
+    std::complex<double> d4_phase_const = std::polar(1.0, d4_p_const);
 
     // Stepper variables
-    T a, p, d1_a, d1_p, d2_a, d2_p, d3_a, d3_p;
-    T_COMPLEX phase, d1_phase, d2_phase, d3_phase;
+    double a, p, d1_a, d1_p, d2_a, d2_p, d3_a, d3_p;
+    std::complex<double> phase, d1_phase, d2_phase, d3_phase;
     int64_t k_sub_max;
     int64_t k = k_start; // k is now the local loop variable
 
@@ -323,14 +325,14 @@ static inline void _decomp_Qcode_segment(
         d3_p = c_p4*(24*f*h3 + 36*h4) + c_p3*(6*h3);
 
         // Complex phase steppers
-        phase = std::polar((T)1.0, p);
-        d1_phase = std::polar((T)1.0, d1_p);
-        d2_phase = std::polar((T)1.0, d2_p);
-        d3_phase = std::polar((T)1.0, d3_p);
+        phase = std::polar(1.0, p);
+        d1_phase = std::polar(1.0, d1_p);
+        d2_phase = std::polar(1.0, d2_p);
+        d3_phase = std::polar(1.0, d3_p);
 
         // --- Fast Inner Loop ---
         for (; k < k_sub_max; k++) {
-            h_seg[k - k_start] = a * phase; // Corrected indexing
+            h_seg[k - k_start] = (T_COMPLEX)(a * phase); // Corrected indexing and cast
 
             // Step phase forward
             phase = phase * d1_phase;
@@ -358,7 +360,7 @@ template <class T, class T_COMPLEX>
 static inline void _decomp_main_loop(
     int degree, // The degree of interpolation to aim for
     T_COMPLEX * h,
-    T delta_f,
+    double delta_f, // Force double here
     const int64_t hlen,
     const int64_t start_index,
     T * sample_frequencies,
@@ -370,7 +372,8 @@ static inline void _decomp_main_loop(
     int64_t k, kmax;
     int64_t last_findex = start_index;
     const int update_interval = 128;
-    T f0, f1, f2, f3, f4, a0, a1, a2, a3, a4, p0, p1, p2, p3, p4;
+    // Use double for all local scalar logic
+    double f0, f1, f2, f3, f4, a0, a1, a2, a3, a4, p0, p1, p2, p3, p4;
 
     // Determine the maximum possible degree based on number of points
     int max_possible_degree;
@@ -388,13 +391,13 @@ static inline void _decomp_main_loop(
     memset(h, 0, sizeof(T_COMPLEX)*start_index);
 
     for (int64_t i = imin; i < sflen-1; i++) {
-        // Get segment boundaries (always needed)
-        f1 = sample_frequencies[i];
-        f2 = sample_frequencies[i+1];
-        a1 = amp[i];
-        a2 = amp[i+1];
-        p1 = phase[i];
-        p2 = phase[i+1];
+        // Get segment boundaries (always needed) - cast to double
+        f1 = (double)sample_frequencies[i];
+        f2 = (double)sample_frequencies[i+1];
+        a1 = (double)amp[i];
+        a2 = (double)amp[i+1];
+        p1 = (double)phase[i];
+        p2 = (double)phase[i+1];
 
         // Calculate start and end indices for this segment
         if (i == imin) {
@@ -424,6 +427,7 @@ static inline void _decomp_main_loop(
         if (current_degree > 2 && i >= sflen - 2) current_degree = 2;
 
         // --- Call the correct helper based on current_degree ---
+        // Note: Helpers now accept explicit doubles for scalars
         switch (current_degree) {
             case 1:
                 _decomp_ccode_segment<T, T_COMPLEX>(
@@ -432,18 +436,18 @@ static inline void _decomp_main_loop(
                 break;
 
             case 2:
-                f0 = sample_frequencies[i-1];
-                a0 = amp[i-1]; p0 = phase[i-1];
+                f0 = (double)sample_frequencies[i-1];
+                a0 = (double)amp[i-1]; p0 = (double)phase[i-1];
                 _decomp_qcode_segment<T, T_COMPLEX>(
                     &h[k], f0, f1, f2, a0, a1, a2, p0, p1, p2,
                     delta_f, k, kmax, update_interval);
                 break;
 
             case 3:
-                f0 = sample_frequencies[i-1];
-                f3 = sample_frequencies[i+2];
-                a0 = amp[i-1]; a3 = amp[i+2];
-                p0 = phase[i-1]; p3 = phase[i+2];
+                f0 = (double)sample_frequencies[i-1];
+                f3 = (double)sample_frequencies[i+2];
+                a0 = (double)amp[i-1]; a3 = (double)amp[i+2];
+                p0 = (double)phase[i-1]; p3 = (double)phase[i+2];
                 _decomp_tcode_segment<T, T_COMPLEX>(
                     &h[k], f0, f1, f2, f3, a0, a1, a2, a3, p0, p1, p2, p3,
                     delta_f, k, kmax, update_interval);
@@ -451,11 +455,11 @@ static inline void _decomp_main_loop(
             
             case 4:
             default: // Catches degree >= 4
-                f0 = sample_frequencies[i-1];
-                f3 = sample_frequencies[i+2];
-                f4 = sample_frequencies[i+3];
-                a0 = amp[i-1]; a3 = amp[i+2]; a4 = amp[i+3];
-                p0 = phase[i-1]; p3 = phase[i+2]; p4 = phase[i+3];
+                f0 = (double)sample_frequencies[i-1];
+                f3 = (double)sample_frequencies[i+2];
+                f4 = (double)sample_frequencies[i+3];
+                a0 = (double)amp[i-1]; a3 = (double)amp[i+2]; a4 = (double)amp[i+3];
+                p0 = (double)phase[i-1]; p3 = (double)phase[i+2]; p4 = (double)phase[i+3];
                 _decomp_Qcode_segment<T, T_COMPLEX>(
                     &h[k], f0, f1, f2, f3, f4, a0, a1, a2, a3, a4, p0, p1, p2, p3, p4,
                     delta_f, k, kmax, update_interval);
@@ -482,7 +486,8 @@ static inline void _decomp_main_loop(
 void _decomp_ccode_double(std::complex<double> * h, double delta_f, const int64_t hlen, const int64_t start_index, double * sample_frequencies, double * amp, double * phase, const int64_t sflen, const int64_t imin) {
     _decomp_main_loop<double, std::complex<double> >(1, h, delta_f, hlen, start_index, sample_frequencies, amp, phase, sflen, imin);
 }
-void _decomp_ccode_float(std::complex<float> * h, float delta_f, const int64_t hlen, const int64_t start_index, float * sample_frequencies, float * amp, float * phase, const int64_t sflen, const int64_t imin) {
+// Updated delta_f to double
+void _decomp_ccode_float(std::complex<float> * h, double delta_f, const int64_t hlen, const int64_t start_index, float * sample_frequencies, float * amp, float * phase, const int64_t sflen, const int64_t imin) {
     _decomp_main_loop<float, std::complex<float> >(1, h, delta_f, hlen, start_index, sample_frequencies, amp, phase, sflen, imin);
 }
 
@@ -490,7 +495,8 @@ void _decomp_ccode_float(std::complex<float> * h, float delta_f, const int64_t h
 void _decomp_qcode_double(std::complex<double> * h, double delta_f, const int64_t hlen, const int64_t start_index, double * sample_frequencies, double * amp, double * phase, const int64_t sflen, const int64_t imin) {
     _decomp_main_loop<double, std::complex<double> >(2, h, delta_f, hlen, start_index, sample_frequencies, amp, phase, sflen, imin);
 }
-void _decomp_qcode_float(std::complex<float> * h, float delta_f, const int64_t hlen, const int64_t start_index, float * sample_frequencies, float * amp, float * phase, const int64_t sflen, const int64_t imin) {
+// Updated delta_f to double
+void _decomp_qcode_float(std::complex<float> * h, double delta_f, const int64_t hlen, const int64_t start_index, float * sample_frequencies, float * amp, float * phase, const int64_t sflen, const int64_t imin) {
     _decomp_main_loop<float, std::complex<float> >(2, h, delta_f, hlen, start_index, sample_frequencies, amp, phase, sflen, imin);
 }
 
@@ -498,7 +504,8 @@ void _decomp_qcode_float(std::complex<float> * h, float delta_f, const int64_t h
 void _decomp_tcode_double(std::complex<double> * h, double delta_f, const int64_t hlen, const int64_t start_index, double * sample_frequencies, double * amp, double * phase, const int64_t sflen, const int64_t imin) {
     _decomp_main_loop<double, std::complex<double> >(3, h, delta_f, hlen, start_index, sample_frequencies, amp, phase, sflen, imin);
 }
-void _decomp_tcode_float(std::complex<float> * h, float delta_f, const int64_t hlen, const int64_t start_index, float * sample_frequencies, float * amp, float * phase, const int64_t sflen, const int64_t imin) {
+// Updated delta_f to double
+void _decomp_tcode_float(std::complex<float> * h, double delta_f, const int64_t hlen, const int64_t start_index, float * sample_frequencies, float * amp, float * phase, const int64_t sflen, const int64_t imin) {
     _decomp_main_loop<float, std::complex<float> >(3, h, delta_f, hlen, start_index, sample_frequencies, amp, phase, sflen, imin);
 }
 
@@ -506,6 +513,7 @@ void _decomp_tcode_float(std::complex<float> * h, float delta_f, const int64_t h
 void _decomp_Qcode_double(std::complex<double> * h, double delta_f, const int64_t hlen, const int64_t start_index, double * sample_frequencies, double * amp, double * phase, const int64_t sflen, const int64_t imin) {
     _decomp_main_loop<double, std::complex<double> >(4, h, delta_f, hlen, start_index, sample_frequencies, amp, phase, sflen, imin);
 }
-void _decomp_Qcode_float(std::complex<float> * h, float delta_f, const int64_t hlen, const int64_t start_index, float * sample_frequencies, float * amp, float * phase, const int64_t sflen, const int64_t imin) {
+// Updated delta_f to double
+void _decomp_Qcode_float(std::complex<float> * h, double delta_f, const int64_t hlen, const int64_t start_index, float * sample_frequencies, float * amp, float * phase, const int64_t sflen, const int64_t imin) {
     _decomp_main_loop<float, std::complex<float> >(4, h, delta_f, hlen, start_index, sample_frequencies, amp, phase, sflen, imin);
 }


### PR DESCRIPTION
Use double precision for (expecially) the higher order interpolation, even if the input / output is single precision. This ensures consistent accuracy. We are seeing for the higher order interpolation that the waveform can run into numerical issues with the phase calculation. It's still a largely memory bound calculation, so this doesn't seem to impact performance much and avoids the headache. 

No issues seen with the existing linear order. 