### PR TITLE
Add support for numpy2

### DIFF
--- a/pycbc/events/threshold_cpu.py
+++ b/pycbc/events/threshold_cpu.py
@@ -46,7 +46,7 @@ outl = None
 outv = None
 count = None
 def threshold_inline(series, value):
-    arr = numpy.array(series.data, dtype=numpy.complex64)
+    arr = numpy.asarray(series.data, dtype=numpy.complex64)
     global outl, outv, count
     if outl is None or len(outl) < len(series):
         outl = numpy.zeros(len(series), dtype=numpy.uint32)
@@ -70,7 +70,7 @@ threshold_only = threshold_inline
 
 class CPUThresholdCluster(_BaseThresholdCluster):
     def __init__(self, series):
-        self.series = numpy.array(series.data,
+        self.series = numpy.asarray(series.data,
                                   dtype=numpy.complex64)
         self.slen = numpy.uint32(len(series))
         self.outv = numpy.zeros(self.slen, numpy.complex64)


### PR DESCRIPTION
Remove usage of `copy=False` for NumPy >= 2.0 compatibility

NumPy 2.0 disallows `copy=False`, raising a ValueError instead of silently copying as in NumPy 1.x. This commit replaces `numpy.array(..., copy=False)` with `numpy.asarray(...)` to ensure the code works under both NumPy 1.x and 2.x.