### PR TITLE
Calibration configuration Bug Fix

### DIFF
--- a/bin/inference/pycbc_inference_create_calibration_config
+++ b/bin/inference/pycbc_inference_create_calibration_config
@@ -24,18 +24,13 @@ import os, argparse
 import pycbc
 import numpy
 import matplotlib.pyplot as plt
+import logging
 
 from pycbc.types import MultiDetOptionAction
 from pycbc.strain.recalibrate import get_calibration_files_O1_O2_O3, read_calibration_envelop_file
 
 
 parser = argparse.ArgumentParser()
-
-# command line usage
-#parser = argparse.ArgumentParser(
-#            usage="pycbc_inference_create_calibration_config [--options]",
-#            description="Generate the calibration configuration files "
-#                        "to be used woth pycbc_inference.")
 
 pycbc.add_common_pycbc_options(parser)
 
@@ -119,7 +114,7 @@ else:
     tag = opts.tag
 
 for ifo in opts.ifos:
-  logging.info("Minimum %s frequency: %.3f", ifs, min_freq_list[ifo])
+  logging.info("Minimum %s frequency: %.3f", ifo, min_freq_list[ifo])
 
 # Read calibration files
 if opts.calibration_files:


### PR DESCRIPTION

## Standard information about the request

<!--- Some basic info about the change (delete as appropriate) -->
This is a: bug fix. There was a typo and missing import in `pycbc_inference_create_calibration_config`. 

<!--- What codes will this affect? (delete as apropriate)
If you do not know which areas will be affected, please ask in the gwastro #pycbc-code slack
-->
This change affects:  inference.

<!--- What code areas will this affect? (delete as apropriate) -->
This change changes: binary script to generate calibration config file.

<!--- Some things which help with code management (delete as appropriate) -->
This change: has appropriate unit tests, follows style guidelines (See e.g. [PEP8](https://peps.python.org/pep-0008/)), has been proposed using the [contribution guidelines](https://github.com/gwastro/pycbc/blob/master/CONTRIBUTING.md)

<!--- Notes about the effect of this change -->
This change will: not break any existing functionality.

## Motivation
<!--- Describe why your changes are being made -->

## Contents
<!--- Describe your changes, this doesn't need to be a line-by-line code change discussion,
but rather a general discussion of the methods chosen -->

## Links to any issues or associated PRs
<!--- If this is fixing / working around an already-reported issue, please link to it here -->
It is a bug fixed of previous implementation of #4537
## Testing performed
<!--- Describe tests for the code changes, either already performed or to be performed -->

## Additional notes
<!--- Anything which does not fit in the above sections -->

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
