### PR TITLE
Fix the way FFT tests are skipped

### DIFF
--- a/test/test_fft_mkl_threaded.py
+++ b/test/test_fft_mkl_threaded.py
@@ -22,50 +22,50 @@
 # =============================================================================
 #
 """
-These are the unit-tests for the pycbc.fft subpackage, testing only unthreaded
-backends for the various schemes.
+These are the unit tests for the pycbc.fft subpackage, testing the threaded MKL
+backend only.
 """
 import platform
 import unittest
 
 import pycbc.fft
 from pycbc.scheme import CPUScheme
-from sys import exit as _exit
 from utils import parse_args_cpu_only, simple_exit
 from fft_base import _BaseTestFFTClass
 
+
 parse_args_cpu_only("MKL threaded backend")
 
-# See if we can get set the FFTW backend to 'openmp'; if not, say so and exit.
+# See if MKL is available; if not, say so and exit.
+
 if 'arm64' in platform.machine():
-    print("MKL not supported on arm64, skipping")
-    pass
-elif not 'mkl' in pycbc.fft.get_backend_names():
-    print("MKL does not seem to be available; why isn't it installed?")
-    _exit(0)
-else:
-    # Now set the number of threads to something nontrivial
+    raise unittest.SkipTest("MKL not supported on arm64, skipping")
+if not 'mkl' in pycbc.fft.get_backend_names():
+    raise unittest.SkipTest(
+        "MKL does not seem to be available; why isn't it installed?"
+    )
 
-    # Most of the work is now done in fft_base.
+# Now set the number of threads to something nontrivial
 
-    FFTTestClasses = []
-    for num_threads in [2,4,6,8]:
-        kdict = {'backends' : ['mkl'],
-                 'scheme' : 'cpu',
-                 'context' : CPUScheme(num_threads=num_threads)}
-        klass = type('FFTW_OpenMP_test',
-                     (_BaseTestFFTClass,),kdict)
-        klass.__test__ = True
-        FFTTestClasses.append(klass)
+# Most of the work is now done in fft_base.
 
+FFTTestClasses = []
+for num_threads in [2,4,6,8]:
+    kdict = {'backends' : ['mkl'],
+             'scheme' : 'cpu',
+             'context' : CPUScheme(num_threads=num_threads)}
+    klass = type('FFTW_OpenMP_test',
+                 (_BaseTestFFTClass,),kdict)
+    klass.__test__ = True
+    FFTTestClasses.append(klass)
 
-    # Finally, we create suites and run them
+# Finally, we create suites and run them
 
-    if __name__ == '__main__':
+if __name__ == '__main__':
 
-        suite = unittest.TestSuite()
-        for klass in FFTTestClasses:
-            suite.addTest(unittest.TestLoader().loadTestsFromTestCase(klass))
+    suite = unittest.TestSuite()
+    for klass in FFTTestClasses:
+        suite.addTest(unittest.TestLoader().loadTestsFromTestCase(klass))
 
-        results = unittest.TextTestRunner(verbosity=2).run(suite)
-        simple_exit(results)
+    results = unittest.TextTestRunner(verbosity=2).run(suite)
+    simple_exit(results)

--- a/test/test_fftw_pthreads.py
+++ b/test/test_fftw_pthreads.py
@@ -22,31 +22,35 @@
 # =============================================================================
 #
 """
-These are the unit-tests for the pycbc.fft.fftw subpackage, testing only the pthreads
-threading backend.
+These are the unit-tests for the pycbc.fft.fftw subpackage, testing only the
+pthreads threading backend.
 """
 
 import pycbc.fft
 from pycbc.scheme import CPUScheme
 import unittest
-from sys import exit as _exit
 from utils import parse_args_cpu_only, simple_exit
 from fft_base import _BaseTestFFTClass
 
+
 parse_args_cpu_only("FFTW pthreads backend")
 
-# See if we can get set the FFTW backend to 'pthreads'; if not, say so and exit.
+# See if we can set the FFTW backend to 'pthreads'; if not, say so and exit.
 
-if 'fftw' in pycbc.fft.get_backend_names():
-    import pycbc.fft.fftw
-    try:
-        pycbc.fft.fftw.set_threads_backend('pthreads')
-    except:
-        print("Unable to import pthreads threads backend to FFTW; skipping pthreads thread tests")
-        _exit(0)
-else:
-    print("FFTW does not seem to be an available CPU backend; skipping pthreads thread tests")
-    _exit(0)
+if 'fftw' not in pycbc.fft.get_backend_names():
+    raise unittest.SkipTest(
+        "FFTW does not seem to be an available CPU backend; "
+        "skipping pthreads thread tests"
+    )
+
+import pycbc.fft.fftw
+try:
+    pycbc.fft.fftw.set_threads_backend('pthreads')
+except:
+    raise unittest.SkipTest(
+        "Unable to import pthreads threads backend to FFTW; "
+        "skipping pthreads thread tests"
+    )
 
 # Most of the work is now done in fft_base.
 


### PR DESCRIPTION
A couple unit tests are skipped by simply exiting, which is not the right way. Fixing.

## Standard information about the request

This is a bug fix in the unit tests.

This change affects the FFT unit tests.

## Motivation

If I use `pytest` on a working copy of the repository, and I do not have MKL installed, the `test_fft_mkl_threaded` test crashes the entire test suite. The reason is that `test_fft_mkl_threaded` detects that MKL is missing and tries to just exit the script early; pytest does not seem to like this and treats it as an error (not an error in the code being tested, but an error in the test itself).

A better way is to raise a `unittest.SkipTest` exception instead, in which case pytest will skip the test silently and carry on with the others. If you run the specific test manually, however, you will see the exception, so you will still know why the test is being skipped.

## Contents

Raise `unittest.SkipTest` exception instead of exiting. Also cleaning up the code a bit and updating comments and docstrings.

## Links to any issues or associated PRs

None.

## Testing performed

Tried running the tests locally via `pytest` and manually.

## Additional notes

None.

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
