### PR TITLE
Avoid Numpy 2.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # requirements for most basic library use
 astropy>=2.0.3,!=4.2.1,!=4.0.5
 Mako>=1.0.1
-scipy>=0.16.0
+scipy>=0.16.0,<1.17.0
 matplotlib>=2.0.0
 numpy>=1.16.0,!=1.19.0,!=2.2.2,<2.4
 pillow

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup_requires = ['numpy>=1.16.0']
 install_requires = setup_requires + [
     'cython>=0.29',
     'numpy>=1.16.0,!=1.19.0,!=2.2.2,<2.4',
-    'scipy>=0.16.0',
+    'scipy>=0.16.0,<1.17.0',
     'astropy>=2.0.3,!=4.2.1,!=4.0.5',
     'matplotlib>=1.5.1',
     'mpld3>=0.3',


### PR DESCRIPTION
Numpy 2.4 is causing CI failures that at the moment are not entirely under our control (see #5250). Temporarily avoid Numpy 2.4.

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
