### PR TITLE
CI: single source of truth

### DIFF
--- a/.github/actions/defaults/action.yml
+++ b/.github/actions/defaults/action.yml
@@ -1,0 +1,21 @@
+name: Defaults
+description: "Composite action that exposes default values for workflows (e.g., python_version)."
+
+inputs:
+  python-version:
+    description: "Default Python version to use in workflows"
+    required: false
+    default: '3.11'
+
+runs:
+  using: composite
+  steps:
+    - id: set
+      run: |
+        echo "python_version=${{ inputs.python-version }}" >> $GITHUB_OUTPUT
+      shell: bash
+
+outputs:
+  python_version:
+    description: "Python version string"
+    value: ${{ steps.set.outputs.python_version }}

--- a/.github/actions/install-htcondor-pegasus/action.yml
+++ b/.github/actions/install-htcondor-pegasus/action.yml
@@ -1,0 +1,24 @@
+name: Install HTCondor and Pegasus
+description: "Composite action to install HTCondor and Pegasus on Ubuntu runners."
+runs:
+  using: "composite"
+  steps:
+    - name: Install HTCondor
+      shell: bash
+      run: |
+        wget -qO - https://research.cs.wisc.edu/htcondor/ubuntu/HTCondor-Release.gpg.key | sudo apt-key add -
+        echo "deb http://research.cs.wisc.edu/htcondor/ubuntu/8.9/focal focal contrib" | sudo tee -a /etc/apt/sources.list
+        echo "deb-src http://research.cs.wisc.edu/htcondor/ubuntu/8.9/focal focal contrib" | sudo tee -a /etc/apt/sources.list
+        sudo apt-get -o Acquire::Retries=3 update
+        sudo apt-get -o Acquire::Retries=3 install -y minihtcondor
+        # systemd may not be available in all runners, ignore failures when enabling
+        sudo systemctl start condor || true
+        sudo systemctl enable condor || true
+
+    - name: Install Pegasus
+      shell: bash
+      run: |
+        wget -qO - https://download.pegasus.isi.edu/pegasus/gpg.txt | sudo apt-key add -
+        echo "deb https://download.pegasus.isi.edu/pegasus/ubuntu noble main" | sudo tee -a /etc/apt/sources.list
+        sudo apt-get -o Acquire::Retries=3 update
+        sudo apt-get -o Acquire::Retries=3 install -y pegasus=5.1.1-1+ubuntu24

--- a/.github/actions/install-system-deps/action.yml
+++ b/.github/actions/install-system-deps/action.yml
@@ -1,0 +1,16 @@
+name: Install system packages
+description: "Composite action to install common system packages (fftw3, intel-mkl, mpi, graphviz) on Ubuntu runners."
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Update apt
+      shell: bash
+      run: |
+        sudo apt-get -o Acquire::Retries=3 update
+
+    - name: Install system packages
+      shell: bash
+      run: |
+        set -euxo pipefail
+        sudo apt-get -o Acquire::Retries=3 install -y *fftw3* intel-mkl* mpi graphviz

--- a/.github/actions/populate-caches/action.yml
+++ b/.github/actions/populate-caches/action.yml
@@ -1,0 +1,79 @@
+name: Populate caches (LAL aux + example GW data)
+description: "Composite action that restores LAL auxiliary data and example GW data caches and downloads missing files."
+
+runs:
+  using: "composite"
+  steps:
+    - name: Restore LAL auxiliary data cache
+      id: restore-lal-aux
+      uses: actions/cache@v4
+      with:
+        key: lal-aux-data
+        path: $HOME/lal_aux_data
+
+    - name: Download LAL auxiliary data files on miss
+      if: ${{ steps.restore-lal-aux.outputs.cache-hit != 'true' }}
+      run: |
+        mkdir -p $HOME/lal_aux_data
+        pushd $HOME/lal_aux_data
+        curl --show-error --silent --fail --retry 3 --retry-delay 5 --retry-connrefused \
+          --remote-name https://zenodo.org/records/14999310/files/SEOBNRv4ROM_v2.0.hdf5 \
+          --remote-name https://zenodo.org/records/14999310/files/SEOBNRv4ROM_v3.0.hdf5
+        popd
+
+    - name: Restore example GW data cache
+      name: Populate caches (LAL aux + example GW data)
+      description: "Composite action that restores LAL auxiliary data and example GW data caches and downloads missing files."
+
+      runs:
+        using: "composite"
+        steps:
+          - name: Restore LAL auxiliary data cache
+            id: restore-lal-aux
+            uses: actions/cache@v4
+            with:
+              key: lal-aux-data
+              path: $HOME/lal_aux_data
+
+          - name: Download LAL auxiliary data files on miss
+            if: ${{ steps.restore-lal-aux.outputs.cache-hit != 'true' }}
+            run: |
+              mkdir -p $HOME/lal_aux_data
+              pushd $HOME/lal_aux_data
+              curl --show-error --silent --fail --retry 3 --retry-delay 5 --retry-connrefused \
+                --remote-name https://zenodo.org/records/14999310/files/SEOBNRv4ROM_v2.0.hdf5 \
+                --remote-name https://zenodo.org/records/14999310/files/SEOBNRv4ROM_v3.0.hdf5
+              popd
+
+          - name: Restore example GW data cache
+            id: restore-example-gw
+            uses: actions/cache@v4
+            with:
+              key: example-gw-data
+              path: |
+                docs/_include/*_TDI_v2.gwf
+                docs/_include/*_GWOSC_4KHZ_R1-1126257415-4096.gwf
+                docs/_include/*_LOSC_CLN_4_V1-1187007040-2048.gwf
+                examples/inference/lisa_smbhb_ldc/*_psd.txt
+                examples/inference/lisa_smbhb_ldc/*_TDI_v2.gwf
+                examples/inference/lisa_smbhb_ldc/MBHB_params_v2_LISA_frame.pkl
+                examples/inference/margtime/*.gwf
+                examples/inference/multisignal/*.gwf
+                examples/inference/relative/*.gwf
+                examples/inference/relmarg/*.gwf
+                examples/inference/single/*.gwf
+                examples/search/*.gwf
+
+          - name: Set path outputs for cached data
+            id: set_paths
+            run: |
+              echo "lal_data_path=$HOME/lal_aux_data" >> $GITHUB_OUTPUT
+              echo "example_gw_cache_key=example-gw-data" >> $GITHUB_OUTPUT
+
+      outputs:
+        lal_data_path:
+          description: "Path where LAL auxiliary data is stored on the runner"
+          value: ${{ steps.set_paths.outputs.lal_data_path }}
+        example_gw_cache_key:
+          description: "Cache key used for example GW data"
+          value: ${{ steps.set_paths.outputs.example_gw_cache_key }}

--- a/.github/actions/populate-caches/action.yml
+++ b/.github/actions/populate-caches/action.yml
@@ -21,8 +21,7 @@ runs:
           --remote-name https://zenodo.org/records/14999310/files/SEOBNRv4ROM_v3.0.hdf5
         popd
 
-    - name: Restore example GW data cache
-      name: Populate caches (LAL aux + example GW data)
+    - name: Populate caches (LAL aux + example GW data)
       description: "Composite action that restores LAL auxiliary data and example GW data caches and downloads missing files."
 
       runs:
@@ -45,30 +44,30 @@ runs:
                 --remote-name https://zenodo.org/records/14999310/files/SEOBNRv4ROM_v3.0.hdf5
               popd
 
-          - name: Restore example GW data cache
-            id: restore-example-gw
-            uses: actions/cache@v4
-            with:
-              key: example-gw-data
-              path: |
-                docs/_include/*_TDI_v2.gwf
-                docs/_include/*_GWOSC_4KHZ_R1-1126257415-4096.gwf
-                docs/_include/*_LOSC_CLN_4_V1-1187007040-2048.gwf
-                examples/inference/lisa_smbhb_ldc/*_psd.txt
-                examples/inference/lisa_smbhb_ldc/*_TDI_v2.gwf
-                examples/inference/lisa_smbhb_ldc/MBHB_params_v2_LISA_frame.pkl
-                examples/inference/margtime/*.gwf
-                examples/inference/multisignal/*.gwf
-                examples/inference/relative/*.gwf
-                examples/inference/relmarg/*.gwf
-                examples/inference/single/*.gwf
-                examples/search/*.gwf
+    - name: Restore example GW data cache
+      id: restore-example-gw
+      uses: actions/cache@v4
+      with:
+        key: example-gw-data
+        path: |
+          docs/_include/*_TDI_v2.gwf
+          docs/_include/*_GWOSC_4KHZ_R1-1126257415-4096.gwf
+          docs/_include/*_LOSC_CLN_4_V1-1187007040-2048.gwf
+          examples/inference/lisa_smbhb_ldc/*_psd.txt
+          examples/inference/lisa_smbhb_ldc/*_TDI_v2.gwf
+          examples/inference/lisa_smbhb_ldc/MBHB_params_v2_LISA_frame.pkl
+          examples/inference/margtime/*.gwf
+          examples/inference/multisignal/*.gwf
+          examples/inference/relative/*.gwf
+          examples/inference/relmarg/*.gwf
+          examples/inference/single/*.gwf
+          examples/search/*.gwf
 
-          - name: Set path outputs for cached data
-            id: set_paths
-            run: |
-              echo "lal_data_path=$HOME/lal_aux_data" >> $GITHUB_OUTPUT
-              echo "example_gw_cache_key=example-gw-data" >> $GITHUB_OUTPUT
+    - name: Set path outputs for cached data
+      id: set_paths
+      run: |
+        echo "lal_data_path=$HOME/lal_aux_data" >> $GITHUB_OUTPUT
+        echo "example_gw_cache_key=example-gw-data" >> $GITHUB_OUTPUT
 
       outputs:
         lal_data_path:

--- a/.github/workflows/bank-compress-workflow.yml
+++ b/.github/workflows/bank-compress-workflow.yml
@@ -12,26 +12,17 @@ jobs:
     timeout-minutes: 90
     steps:
     - uses: actions/checkout@v5
+    - name: Load defaults
+      id: defaults
+      uses: ./.github/actions/defaults
     - name: Set up Python
       uses: actions/setup-python@v6
       with:
-        python-version: '3.11'
-    - name: install condor
-      run: |
-        wget -qO - https://research.cs.wisc.edu/htcondor/ubuntu/HTCondor-Release.gpg.key | sudo apt-key add -
-        echo "deb http://research.cs.wisc.edu/htcondor/ubuntu/8.9/focal focal contrib" | sudo tee -a /etc/apt/sources.list
-        echo "deb-src http://research.cs.wisc.edu/htcondor/ubuntu/8.9/focal focal contrib" | sudo tee -a /etc/apt/sources.list
-        sudo apt-get -o Acquire::Retries=3 update
-        sudo apt-get -o Acquire::Retries=3 install minihtcondor
-        sudo systemctl start condor
-        sudo systemctl enable condor
-    - name: install pegasus
-      run: |
-        wget -qO - https://download.pegasus.isi.edu/pegasus/gpg.txt | sudo apt-key add -
-        echo "deb https://download.pegasus.isi.edu/pegasus/ubuntu noble main" | sudo tee -a /etc/apt/sources.list
-        sudo apt-get -o Acquire::Retries=3 update
-        sudo apt-get -o Acquire::Retries=3 install pegasus=5.1.1-1+ubuntu24
-    - run: sudo apt-get -o Acquire::Retries=3 install *fftw3* intel-mkl*
+        python-version: ${{ steps.defaults.outputs.python_version }}
+    - name: Install condor & pegasus
+      uses: ./.github/actions/install-htcondor-pegasus
+    - name: Install system dependencies
+      uses: ./.github/actions/install-system-deps
     - name: Install pycbc
       run: |
         python -m pip install --upgrade pip setuptools

--- a/.github/workflows/basic-tests.yml
+++ b/.github/workflows/basic-tests.yml
@@ -13,7 +13,7 @@ jobs:
       max-parallel: 60
       matrix:
         os: [ubuntu-24.04]
-        python-version: ['3.11', '3.12', '3.13']
+        python_version: ['3.11', '3.12', '3.13']
         test-type: [unittest, search, docs]
     steps:
     - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
@@ -23,64 +23,33 @@ jobs:
       with:
         pixi-version: latest
 
+    - name: Populate caches (LAL aux + example GW data)
+      id: populate
+      uses: ./.github/actions/populate-caches
+
+    - name: Expose LAL_DATA_PATH to subsequent steps
+      run: echo "LAL_DATA_PATH=${{ steps.populate.outputs.lal_data_path }}" >> $GITHUB_ENV
+
     - name: Inject Python Version
       run: |
-        pixi add python="${{ matrix.python-version }}.*"
-
-    - name: Cache LAL auxiliary data files
-      id: cache-lal-aux-data
-      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
-      with:
-        key: lal-aux-data
-        path: ~/lal_aux_data
-
-    - if: ${{ steps.cache-lal-aux-data.outputs.cache-hit != 'true' }}
-      name: Download LAL auxiliary data files
-      run: |
-        mkdir ~/lal_aux_data
-        pushd ~/lal_aux_data
-        curl --show-error --silent \
-          --remote-name https://zenodo.org/records/14999310/files/SEOBNRv4ROM_v2.0.hdf5 \
-          --remote-name https://zenodo.org/records/14999310/files/SEOBNRv4ROM_v3.0.hdf5
-        popd
-
-    - name: Cache example GW data
-      id: cache-example-gw-data
-      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
-      with:
-        key: example-gw-data
-        path: |
-          docs/_include/*_TDI_v2.gwf
-          docs/_include/*_GWOSC_4KHZ_R1-1126257415-4096.gwf
-          docs/_include/*_LOSC_CLN_4_V1-1187007040-2048.gwf
-          examples/inference/lisa_smbhb_ldc/*_psd.txt
-          examples/inference/lisa_smbhb_ldc/*_TDI_v2.gwf
-          examples/inference/lisa_smbhb_ldc/MBHB_params_v2_LISA_frame.pkl
-          examples/inference/margtime/*.gwf
-          examples/inference/multisignal/*.gwf
-          examples/inference/relative/*.gwf
-          examples/inference/relmarg/*.gwf
-          examples/inference/single/*.gwf
+        pixi add python="${{ matrix.python_version }}.*"
 
     - name: run pycbc test suite
       run: |
-        export LAL_DATA_PATH=$HOME/lal_aux_data
         pixi run -e ${{matrix.test-type}} test-${{matrix.test-type}}
 
     - name: check help messages work
       if: matrix.test-type == 'unittest'
       run: |
-        export LAL_DATA_PATH=$HOME/lal_aux_data
         pixi run -e help test-help
 
     - name: run inference tests
       if: matrix.test-type == 'search'
       run: |
-        export LAL_DATA_PATH=$HOME/lal_aux_data
         pixi run -e inference test-inference
 
     - name: store documentation page
-      if: matrix.test-type == 'docs' && matrix.python-version == '3.12'
+      if: matrix.test-type == 'docs' && matrix.python_version == '3.12'
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: documentation-page

--- a/.github/workflows/check_code.yml
+++ b/.github/workflows/check_code.yml
@@ -6,10 +6,13 @@ jobs:
         steps:
             - name: Check out repository
               uses: actions/checkout@v5
+            - name: Load defaults
+              id: defaults
+              uses: ./.github/actions/defaults
             - name: Set up Python
               uses: actions/setup-python@v6
               with:
-                  python-version: 3.11
+                  python-version: ${{ steps.defaults.outputs.python_version }}
             - name: Install flake8
               run: pip install flake8
             - name: Checking executables for unused imports

--- a/.github/workflows/inference-workflow.yml
+++ b/.github/workflows/inference-workflow.yml
@@ -7,26 +7,17 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v5
+    - name: Load defaults
+      id: defaults
+      uses: ./.github/actions/defaults
     - name: Set up Python
       uses: actions/setup-python@v6
       with:
-        python-version: '3.11'
-    - name: install condor
-      run: |
-        wget -qO - https://research.cs.wisc.edu/htcondor/ubuntu/HTCondor-Release.gpg.key | sudo apt-key add -
-        echo "deb http://research.cs.wisc.edu/htcondor/ubuntu/8.9/focal focal contrib" | sudo tee -a /etc/apt/sources.list
-        echo "deb-src http://research.cs.wisc.edu/htcondor/ubuntu/8.9/focal focal contrib" | sudo tee -a /etc/apt/sources.list
-        sudo apt-get -o Acquire::Retries=3 update
-        sudo apt-get -o Acquire::Retries=3 install minihtcondor
-        sudo systemctl start condor
-        sudo systemctl enable condor
-    - name: install pegasus
-      run: |
-        wget -qO - https://download.pegasus.isi.edu/pegasus/gpg.txt | sudo apt-key add -
-        echo "deb https://download.pegasus.isi.edu/pegasus/ubuntu noble main" | sudo tee -a /etc/apt/sources.list
-        sudo apt-get -o Acquire::Retries=3 update
-        sudo apt-get -o Acquire::Retries=3 install pegasus=5.1.1-1+ubuntu24
-    - run: sudo apt-get -o Acquire::Retries=3 install *fftw3* intel-mkl*
+        python-version: ${{ steps.defaults.outputs.python_version }}
+    - name: install condor and pegasus
+      uses: ./.github/actions/install-htcondor-pegasus
+    - name: install system dependecies
+      uses: ./.github/actions/install-system-deps
     - name: Install pycbc
       run: |
         python -m pip install --upgrade pip setuptools

--- a/.github/workflows/mac-test.yml
+++ b/.github/workflows/mac-test.yml
@@ -13,7 +13,7 @@ jobs:
       max-parallel: 4
       matrix:
         os: [macos-latest]
-        python-version:
+        python_version:
           - '3.11'
           - '3.12'
           - '3.13'
@@ -28,7 +28,7 @@ jobs:
 
     - name: Inject Python Version
       run: |
-        pixi add python="${{ matrix.python-version }}.*"
+        pixi add python="${{ matrix.python_version }}.*"
 
     - name: Run basic pycbc test suite
       run: |

--- a/.github/workflows/search-workflow.yml
+++ b/.github/workflows/search-workflow.yml
@@ -14,26 +14,17 @@ jobs:
       PEGASUS_METRICS: 'false'
     steps:
     - uses: actions/checkout@v5
+    - name: Load defaults
+      id: defaults
+      uses: ./.github/actions/defaults
     - name: Set up Python
       uses: actions/setup-python@v6
       with:
-        python-version: '3.11'
-    - name: install condor
-      run: |
-        wget -qO - https://research.cs.wisc.edu/htcondor/ubuntu/HTCondor-Release.gpg.key | sudo apt-key add -
-        echo "deb http://research.cs.wisc.edu/htcondor/ubuntu/8.9/focal focal contrib" | sudo tee -a /etc/apt/sources.list
-        echo "deb-src http://research.cs.wisc.edu/htcondor/ubuntu/8.9/focal focal contrib" | sudo tee -a /etc/apt/sources.list
-        sudo apt-get -o Acquire::Retries=3 update
-        sudo apt-get -o Acquire::Retries=3 install minihtcondor
-        sudo systemctl start condor
-        sudo systemctl enable condor
-    - name: install pegasus
-      run: |
-        wget -qO - https://download.pegasus.isi.edu/pegasus/gpg.txt | sudo apt-key add -
-        echo "deb https://download.pegasus.isi.edu/pegasus/ubuntu noble main" | sudo tee -a /etc/apt/sources.list
-        sudo apt-get -o Acquire::Retries=3 update
-        sudo apt-get -o Acquire::Retries=3 install pegasus=5.1.1-1+ubuntu24
-    - run: sudo apt-get -o Acquire::Retries=3 install *fftw3* intel-mkl*
+        python-version: ${{ steps.defaults.outputs.python_version }}
+    - name: Install condor & pegasus
+      uses: ./.github/actions/install-htcondor-pegasus
+    - name: installing system packages
+      uses: .github/actions/install-system-deps
     - name: Install pycbc
       run: |
         python -m pip install --upgrade pip setuptools

--- a/.github/workflows/tmpltbank-workflow.yml
+++ b/.github/workflows/tmpltbank-workflow.yml
@@ -11,26 +11,17 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v5
+    - name: Load defaults
+      id: defaults
+      uses: ./.github/actions/defaults
     - name: Set up Python
       uses: actions/setup-python@v6
       with:
-        python-version: '3.11'
-    - name: install condor
-      run: |
-        wget -qO - https://research.cs.wisc.edu/htcondor/ubuntu/HTCondor-Release.gpg.key | sudo apt-key add -
-        echo "deb http://research.cs.wisc.edu/htcondor/ubuntu/8.9/focal focal contrib" | sudo tee -a /etc/apt/sources.list
-        echo "deb-src http://research.cs.wisc.edu/htcondor/ubuntu/8.9/focal focal contrib" | sudo tee -a /etc/apt/sources.list
-        sudo apt-get -o Acquire::Retries=3 update
-        sudo apt-get -o Acquire::Retries=3 install minihtcondor
-        sudo systemctl start condor
-        sudo systemctl enable condor
-    - name: install pegasus
-      run: |
-        wget -qO - https://download.pegasus.isi.edu/pegasus/gpg.txt | sudo apt-key add -
-        echo "deb https://download.pegasus.isi.edu/pegasus/ubuntu noble main" | sudo tee -a /etc/apt/sources.list
-        sudo apt-get -o Acquire::Retries=3 update
-        sudo apt-get -o Acquire::Retries=3 install pegasus=5.1.1-1+ubuntu24
-    - run: sudo apt-get -o Acquire::Retries=3 install *fftw3* intel-mkl*
+        python-version: ${{ steps.defaults.outputs.python_version }}
+    - name: Install condor & pegasus
+      uses: ./.github/actions/install-htcondor-pegasus
+    - name: Install system dependencies
+      uses: ./.github/actions/install-system-deps
     - name: Install pycbc
       run: |
         python -m pip install --upgrade pip setuptools

--- a/.github/workflows/tut-test.yml
+++ b/.github/workflows/tut-test.yml
@@ -13,17 +13,18 @@ jobs:
       max-parallel: 60
       matrix:
         os: [ubuntu-24.04]
-        python-version: ['3.11', '3.12', '3.13']
+        python_version: ['3.11', '3.12', '3.13']
     steps:
     - uses: actions/checkout@v5
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Set up Python ${{ matrix.python_version }}
       uses: actions/setup-python@v6
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: ${{ matrix.python_version }}
+
+    - name: Install system dependencies
+      uses: ./.github/actions/install-system-deps
     - name: installing packages
       run: |
-        sudo apt-get -o Acquire::Retries=3 update
-        sudo apt-get -o Acquire::Retries=3 install *fftw3* mpi intel-mkl*
         pip install tox pip setuptools notebook --upgrade
         pip install .
     - name: retrieving pycbc tutorials

--- a/.github/workflows/workflow-tests.yml
+++ b/.github/workflows/workflow-tests.yml
@@ -16,26 +16,17 @@ jobs:
         test-type: [simple_subworkflow_data, multilevel_subworkflow_data]
     steps:
     - uses: actions/checkout@v5
+    - name: Load defaults
+      id: defaults
+      uses: ./.github/actions/defaults
     - name: Set up Python
       uses: actions/setup-python@v6
       with:
-        python-version: '3.11'
-    - name: install condor
-      run: |
-        wget -qO - https://research.cs.wisc.edu/htcondor/ubuntu/HTCondor-Release.gpg.key | sudo apt-key add -
-        echo "deb http://research.cs.wisc.edu/htcondor/ubuntu/8.9/focal focal contrib" | sudo tee -a /etc/apt/sources.list
-        echo "deb-src http://research.cs.wisc.edu/htcondor/ubuntu/8.9/focal focal contrib" | sudo tee -a /etc/apt/sources.list
-        sudo apt-get -o Acquire::Retries=3 update
-        sudo apt-get -o Acquire::Retries=3 install minihtcondor
-        sudo systemctl start condor
-        sudo systemctl enable condor
-    - name: install pegasus
-      run: |
-        wget -qO - https://download.pegasus.isi.edu/pegasus/gpg.txt | sudo apt-key add -
-        echo "deb https://download.pegasus.isi.edu/pegasus/ubuntu noble main" | sudo tee -a /etc/apt/sources.list
-        sudo apt-get -o Acquire::Retries=3 update
-        sudo apt-get -o Acquire::Retries=3 install pegasus=5.1.1-1+ubuntu24
-    - run: sudo apt-get -o Acquire::Retries=3 install *fftw3* intel-mkl*
+        python-version: ${{ steps.defaults.outputs.python_version }}
+    - name: Install condor & pegasus
+      uses: ./.github/actions/install-htcondor-pegasus
+    - name: Install system dependencies
+      uses: ./.github/actions/install-system-deps
     - name: Install pycbc
       run: |
         python -m pip install --upgrade pip setuptools

--- a/examples/search/get.sh
+++ b/examples/search/get.sh
@@ -3,13 +3,35 @@ set -e
 
 # Not downloading frames from dcc.ligo.org to avoid failures.
 # DCC often is not responsive to queries from within the GitHub CI.
-# The commented commands below are how to get the frame files from DCC if you
+# The URL below is the location of the frame files from DCC if you
 # wanted to verify they are the same.
+# https://dcc.ligo.org/public/0146/P1700341/001/
 
-#wget -nv https://dcc.ligo.org/public/0146/P1700341/001/H-H1_LOSC_CLN_4_V1-1186740069-3584.gwf
-#wget -nv https://dcc.ligo.org/public/0146/P1700341/001/L-L1_LOSC_CLN_4_V1-1186740069-3584.gwf
-#wget -nv https://dcc.ligo.org/public/0146/P1700341/001/V-V1_LOSC_CLN_4_V1-1186739813-4096.gwf
 
-wget -nv https://media.githubusercontent.com/media/gwastro/pycbc_data/master/H-H1_LOSC_CLN_4_V1-1186740069-3584.gwf
-wget -nv https://media.githubusercontent.com/media/gwastro/pycbc_data/master/L-L1_LOSC_CLN_4_V1-1186740069-3584.gwf
-wget -nv https://media.githubusercontent.com/media/gwastro/pycbc_data/master/V-V1_LOSC_CLN_4_V1-1186739813-4096.gwf
+# List of frame files used by the example
+FILES=(
+	"H-H1_LOSC_CLN_4_V1-1186740069-3584.gwf"
+	"L-L1_LOSC_CLN_4_V1-1186740069-3584.gwf"
+	"V-V1_LOSC_CLN_4_V1-1186739813-4096.gwf"
+)
+
+for f in "${FILES[@]}"; do
+	# If file is already in current working directory, skip
+	if [ -f "./$f" ]; then
+		echo "Found $f in working directory; skipping download."
+		continue
+	fi
+
+	# If file is present in examples/search (i.e. the cache), then copy it
+	if [ -f "examples/search/$f" ]; then
+		echo "Found $f in examples/search (cache); copying."
+		cp "examples/search/$f" ./
+		continue
+	fi
+
+	# Otherwise, download from the DCC
+	echo "Downloading $f from github user content..."
+	wget -nv "https://media.githubusercontent.com/media/gwastro/pycbc_data/master/$f"
+	# Copy into the cache folder
+	cp $f examples/search/
+done


### PR DESCRIPTION
This is an attempt to have single sources of truth defined for the CI workflows. As a few of the workflows use the same information, it would be good to reuse it without the repetition across files.

## Standard information about the request

This change follows style guidelines (See e.g. [PEP8](https://peps.python.org/pep-0008/)), has been proposed using the [contribution guidelines](https://github.com/gwastro/pycbc/blob/master/CONTRIBUTING.md)

## Motivation
Single source of truth

## Contents
Add a new GitHub actions, to be called by the workflows. This defines a single source of truth which is then inherited by the other workflows

## Testing performed
this seems to work in the act tests performed, but these have not been extensive


- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
