### PR TITLE
BUG: Condor job checking bug

### DIFF
--- a/examples/search/check_job.py
+++ b/examples/search/check_job.py
@@ -48,11 +48,4 @@ while 1:
         subprocess.run(["bash", "./stop"])
         # Need to wait here to make sure it fully exits before uploading logs!
         time.sleep(30)
-<<<<<<< HEAD
-
-    for linei in lines:
-        if linei.startswith('Summary') and '(Failure' in linei:
-            print('Job submission has failed')
-            exit(1)
-=======
->>>>>>> 9f25aa328 (move failed workflow test)
+        exit(1)


### PR DESCRIPTION
I found a bug in the `check_jobs.py` script which means that we are passing pass on a failed workflow.

I have added two checks to try to prevent that:
 1. check that the %DONE number should be equal to 100% before considering a job 'passed'
 2. search for the `Summary` line, and if it has the string `Failure`, then the job is considered failed

This was in the logs of an inference workflow runs that I was running for #5262 that was considered passed. I only saw it as it errored on trying to upload the results page:

```
-- Schedd: runnervmkj6or.cuahjxprzsyevh2onn3h2zuybf.phxx.internal.cloudapp.net : <127.0.0.1:9618?...

(No matching jobs found in Condor Q)

UNREADY  READY   PRE   QUEUED   POST   SUCCESS  FAILURE  %DONE  
   0       0      0      0       0        0        0      0.0   
Summary: 1 DAG total (Failure:1)
workflow has completed successfully
```

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
