### PR TITLE
HEALPix probabilities not summing up to 1: float64 cast in map pixels sum

### DIFF
--- a/pycbc/distributions/sky_location.py
+++ b/pycbc/distributions/sky_location.py
@@ -321,10 +321,10 @@ class HealpixSky:
         # Sanity-check the probabilities, and ensure they are normalized
         # correctly (sum to one).
         assert type(self.pix_probs) == numpy.ndarray
-        sum_pix_probs = sum(self.pix_probs)
+        sum_pix_probs = self.pix_probs.sum(dtype=numpy.float64)
         if not numpy.isclose(sum_pix_probs, 1):
             warnings.warn(
-                f'Sum of probs in HEALPix map is {sum(self.pix_probs)}, '
+                f'Sum of probs in HEALPix map is {self.pix_probs.sum(dtype=numpy.float64)}, '
                 'far from 1. Something might be wrong with that map'
             )
         self.pix_probs /= sum_pix_probs


### PR DESCRIPTION
Bug fix: in some cases the probabilities in the healpix skymap were not summing to a value close enough to 1. The problem was found by @Thomas-JACQUOT and it was solved by casting the pixel values to a float64 type during their sum
