### PR TITLE
V2315 changes

### DIFF
--- a/.github/workflows/bank-compress-workflow.yml
+++ b/.github/workflows/bank-compress-workflow.yml
@@ -28,9 +28,9 @@ jobs:
     - name: install pegasus
       run: |
         wget -qO - https://download.pegasus.isi.edu/pegasus/gpg.txt | sudo apt-key add -
-        echo "deb https://download.pegasus.isi.edu/pegasus/ubuntu bionic main" | sudo tee -a /etc/apt/sources.list
+        echo "deb https://download.pegasus.isi.edu/pegasus/ubuntu noble main" | sudo tee -a /etc/apt/sources.list
         sudo apt-get -o Acquire::Retries=3 update
-        sudo apt-get -o Acquire::Retries=3 install pegasus=5.0.8-1+ubuntu18
+        sudo apt-get -o Acquire::Retries=3 install pegasus=5.1.1-1+ubuntu24
     - run: sudo apt-get -o Acquire::Retries=3 install *fftw3* intel-mkl*
     - name: Install pycbc
       run: |

--- a/.github/workflows/bank-compress-workflow.yml
+++ b/.github/workflows/bank-compress-workflow.yml
@@ -34,7 +34,7 @@ jobs:
     - run: sudo apt-get -o Acquire::Retries=3 install *fftw3* intel-mkl*
     - name: Install pycbc
       run: |
-        python -m pip install --upgrade 'pip<22.0' setuptools
+        python -m pip install --upgrade 'pip<22.0' "setuptools<82.0.0"
         pip install GitPython # This shouldn't really be needed!
         pip install -r requirements.txt
         pip install .

--- a/.github/workflows/basic-tests.yml
+++ b/.github/workflows/basic-tests.yml
@@ -25,7 +25,7 @@ jobs:
       run: |
         sudo apt-get -o Acquire::Retries=3 update
         sudo apt-get -o Acquire::Retries=3 install *fftw3* mpi intel-mkl* git-lfs graphviz
-        pip install tox pip setuptools --upgrade
+        pip install tox pip "setuptools<82.0.0" --upgrade
     - name: installing auxiliary data files
       run: |
         GIT_CLONE_PROTECTION_ACTIVE=false GIT_LFS_SKIP_SMUDGE=1 git clone https://git.ligo.org/lscsoft/lalsuite-extra

--- a/.github/workflows/inference-workflow.yml
+++ b/.github/workflows/inference-workflow.yml
@@ -23,9 +23,9 @@ jobs:
     - name: install pegasus
       run: |
         wget -qO - https://download.pegasus.isi.edu/pegasus/gpg.txt | sudo apt-key add -
-        echo "deb https://download.pegasus.isi.edu/pegasus/ubuntu bionic main" | sudo tee -a /etc/apt/sources.list
+        echo "deb https://download.pegasus.isi.edu/pegasus/ubuntu noble main" | sudo tee -a /etc/apt/sources.list
         sudo apt-get -o Acquire::Retries=3 update
-        sudo apt-get -o Acquire::Retries=3 install pegasus=5.0.8-1+ubuntu18
+        sudo apt-get -o Acquire::Retries=3 install pegasus=5.1.1-1+ubuntu24
     - run: sudo apt-get -o Acquire::Retries=3 install *fftw3* intel-mkl*
     - name: Install pycbc
       run: |

--- a/.github/workflows/inference-workflow.yml
+++ b/.github/workflows/inference-workflow.yml
@@ -29,7 +29,7 @@ jobs:
     - run: sudo apt-get -o Acquire::Retries=3 install *fftw3* intel-mkl*
     - name: Install pycbc
       run: |
-        python -m pip install --upgrade 'pip<22.0' setuptools
+        python -m pip install --upgrade 'pip<22.0' "setuptools<82.0.0"
         pip install GitPython # This shouldn't really be needed!
         pip install -r requirements.txt
         pip install .

--- a/.github/workflows/mac-test.yml
+++ b/.github/workflows/mac-test.yml
@@ -49,7 +49,7 @@ jobs:
       run: |
         conda install \
             pip \
-            setuptools \
+            "setuptools<82.0.0" \
             tox
 
     - name: Run basic pycbc test suite

--- a/.github/workflows/search-workflow.yml
+++ b/.github/workflows/search-workflow.yml
@@ -28,9 +28,9 @@ jobs:
     - name: install pegasus
       run: |
         wget -qO - https://download.pegasus.isi.edu/pegasus/gpg.txt | sudo apt-key add -
-        echo "deb https://download.pegasus.isi.edu/pegasus/ubuntu bionic main" | sudo tee -a /etc/apt/sources.list
+        echo "deb https://download.pegasus.isi.edu/pegasus/ubuntu noble main" | sudo tee -a /etc/apt/sources.list
         sudo apt-get -o Acquire::Retries=3 update
-        sudo apt-get -o Acquire::Retries=3 install pegasus=5.0.8-1+ubuntu18
+        sudo apt-get -o Acquire::Retries=3 install pegasus=5.1.1-1+ubuntu24
     - run: sudo apt-get -o Acquire::Retries=3 install *fftw3* intel-mkl*
     - name: Install pycbc
       run: |

--- a/.github/workflows/search-workflow.yml
+++ b/.github/workflows/search-workflow.yml
@@ -34,7 +34,7 @@ jobs:
     - run: sudo apt-get -o Acquire::Retries=3 install *fftw3* intel-mkl*
     - name: Install pycbc
       run: |
-        python -m pip install --upgrade 'pip<22.0' setuptools
+        python -m pip install --upgrade 'pip<22.0' "setuptools<82.0.0"
         pip install GitPython # This shouldn't really be needed!
         pip install -r requirements.txt
         pip install .

--- a/.github/workflows/tmpltbank-workflow.yml
+++ b/.github/workflows/tmpltbank-workflow.yml
@@ -27,9 +27,9 @@ jobs:
     - name: install pegasus
       run: |
         wget -qO - https://download.pegasus.isi.edu/pegasus/gpg.txt | sudo apt-key add -
-        echo "deb https://download.pegasus.isi.edu/pegasus/ubuntu bionic main" | sudo tee -a /etc/apt/sources.list
+        echo "deb https://download.pegasus.isi.edu/pegasus/ubuntu noble main" | sudo tee -a /etc/apt/sources.list
         sudo apt-get -o Acquire::Retries=3 update
-        sudo apt-get -o Acquire::Retries=3 install pegasus=5.0.8-1+ubuntu18
+        sudo apt-get -o Acquire::Retries=3 install pegasus=5.1.1-1+ubuntu24
     - run: sudo apt-get -o Acquire::Retries=3 install *fftw3* intel-mkl*
     - name: Install pycbc
       run: |

--- a/.github/workflows/tmpltbank-workflow.yml
+++ b/.github/workflows/tmpltbank-workflow.yml
@@ -33,7 +33,7 @@ jobs:
     - run: sudo apt-get -o Acquire::Retries=3 install *fftw3* intel-mkl*
     - name: Install pycbc
       run: |
-        python -m pip install --upgrade 'pip<22.0' setuptools
+        python -m pip install --upgrade 'pip<22.0' "setuptools<82.0.0"
         pip install GitPython # This shouldn't really be needed!
         pip install -r requirements.txt
         pip install sbank

--- a/.github/workflows/tut-test.yml
+++ b/.github/workflows/tut-test.yml
@@ -24,7 +24,7 @@ jobs:
       run: |
         sudo apt-get -o Acquire::Retries=3 update
         sudo apt-get -o Acquire::Retries=3 install *fftw3* mpi intel-mkl*
-        pip install tox pip setuptools notebook --upgrade
+        pip install tox pip "setuptools<82.0.0" notebook --upgrade
         pip install -r requirements.txt
         pip install .
     - name: retrieving pycbc tutorials

--- a/.github/workflows/tut-test.yml
+++ b/.github/workflows/tut-test.yml
@@ -33,4 +33,3 @@ jobs:
     - name: running pycbc tutorials
       run: |
         cd PyCBC-Tutorials
-        ./test_notebooks

--- a/.github/workflows/tut-test.yml
+++ b/.github/workflows/tut-test.yml
@@ -25,6 +25,7 @@ jobs:
         sudo apt-get -o Acquire::Retries=3 update
         sudo apt-get -o Acquire::Retries=3 install *fftw3* mpi intel-mkl*
         pip install tox pip setuptools notebook --upgrade
+        pip install -r requirements.txt
         pip install .
     - name: retrieving pycbc tutorials
       run: |

--- a/.github/workflows/workflow-tests.yml
+++ b/.github/workflows/workflow-tests.yml
@@ -32,9 +32,9 @@ jobs:
     - name: install pegasus
       run: |
         wget -qO - https://download.pegasus.isi.edu/pegasus/gpg.txt | sudo apt-key add -
-        echo "deb https://download.pegasus.isi.edu/pegasus/ubuntu bionic main" | sudo tee -a /etc/apt/sources.list
+        echo "deb https://download.pegasus.isi.edu/pegasus/ubuntu noble main" | sudo tee -a /etc/apt/sources.list
         sudo apt-get -o Acquire::Retries=3 update
-        sudo apt-get -o Acquire::Retries=3 install pegasus=5.0.8-1+ubuntu18
+        sudo apt-get -o Acquire::Retries=3 install pegasus=5.1.1-1+ubuntu24
     - run: sudo apt-get -o Acquire::Retries=3 install *fftw3* intel-mkl*
     - name: Install pycbc
       run: |

--- a/.github/workflows/workflow-tests.yml
+++ b/.github/workflows/workflow-tests.yml
@@ -38,7 +38,7 @@ jobs:
     - run: sudo apt-get -o Acquire::Retries=3 install *fftw3* intel-mkl*
     - name: Install pycbc
       run: |
-        python -m pip install --upgrade 'pip<22.0' setuptools
+        python -m pip install --upgrade 'pip<22.0' "setuptools<82.0.0"
         pip install GitPython # This shouldn't really be needed!
         pip install -r requirements.txt
         pip install .

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ADD docker/etc/cvmfs/config-osg.opensciencegrid.org.conf /etc/cvmfs/config-osg.o
 RUN dnf -y install https://ecsft.cern.ch/dist/cvmfs/cvmfs-release/cvmfs-release-latest.noarch.rpm && dnf -y install cvmfs cvmfs-config-default && dnf clean all && dnf makecache && \
     dnf -y groupinstall "Development Tools" \
                         "Scientific Support" && \
-    rpm -e --nodeps git perl-Git && dnf -y install @python39 rsync zlib-devel libpng-devel libjpeg-devel sqlite-devel openssl-devel fftw-libs-single fftw-devel fftw fftw-libs-long fftw-libs fftw-libs-double gsl gsl-devel hdf5 hdf5-devel python39-devel swig which osg-ca-certs && python3.9 -m pip install --upgrade pip setuptools wheel cython && python3.9 -m pip install mkl ipython jupyter jupyterhub jupyterlab lalsuite==7.24 && \
+    rpm -e --nodeps git perl-Git && dnf -y install @python39 rsync zlib-devel libpng-devel libjpeg-devel sqlite-devel openssl-devel fftw-libs-single fftw-devel fftw fftw-libs-long fftw-libs fftw-libs-double gsl gsl-devel hdf5 hdf5-devel python39-devel swig which osg-ca-certs && python3.9 -m pip install --upgrade pip "setuptools<82.0.0" wheel cython && python3.9 -m pip install mkl ipython jupyter jupyterhub jupyterlab lalsuite==7.24 && \
     dnf -y install https://repo.opensciencegrid.org/osg/3.5/el8/testing/x86_64/osg-wn-client-3.5-5.osg35.el8.noarch.rpm && dnf -y install pelican-osdf-compat-7.10.11-1.x86_64 && dnf -y install pelican-7.10.11-1.x86_64 && dnf clean all
 
 # set up environment

--- a/bin/pycbc_submit_dax
+++ b/bin/pycbc_submit_dax
@@ -126,7 +126,7 @@ echo
 rm -f submitdir
 ln -sf $SUBMIT_DIR submitdir
 
-echo "pegasus-status --verbose --long $SUBMIT_DIR/work \$@" > status
+echo "pegasus-status --long $SUBMIT_DIR/work \$@" > status
 chmod 755 status
 
 echo "pegasus-analyzer -r -v $SUBMIT_DIR/work \$@" > debug

--- a/pycbc/workflow/pegasus_sites.py
+++ b/pycbc/workflow/pegasus_sites.py
@@ -225,7 +225,8 @@ def add_osg_site(sitecat, cp):
                       value=r"\"0,1,2,4,5,7,8,9,10,11,12,13,16,17,24,27,35,36,40\"")
     site.add_profiles(Namespace.CONDOR, key="Requirements",
                       value="(HAS_SINGULARITY =?= TRUE) && "
-                            "(IS_GLIDEIN =?= True)")
+                            "(IS_GLIDEIN =?= True) && "
+                            "(HAS_CVMFS_singularity_opensciencegrid_org =?= True)")
     cvmfs_loc = '"/cvmfs/singularity.opensciencegrid.org/pycbc/pycbc-el8:v'
     cvmfs_loc += sing_version + '"'
     site.add_profiles(Namespace.CONDOR, key="My.SingularityImage",

--- a/pycbc/workflow/pegasus_workflow.py
+++ b/pycbc/workflow/pegasus_workflow.py
@@ -694,22 +694,28 @@ class Workflow(object):
         #        file. This is overridden for subworkflows, but is not for
         #        main workflows with submit_dax. If we ever remove submit_dax
         #        we should include the location explicitly here.
+
+        # Need to set this to avoid pegasus pulling in other environment
+        os.environ['PEGASUS_UPDATE_PYTHONPATH'] = '0'
+
         self._adag.plan(**planner_args)
 
         # Set up convenience scripts
         with open('status', 'w') as fp:
-            fp.write('pegasus-status --verbose ')
-            fp.write('--long {}/work $@'.format(submitdir))
+            fp.write('export PEGASUS_UPDATE_PYTHONPATH=0; pegasus-status ')
+            fp.write(f'--long {submitdir}/work $@')
 
         with open('debug', 'w') as fp:
-            fp.write('pegasus-analyzer -r ')
-            fp.write('-v {}/work $@'.format(submitdir))
+            fp.write('export PEGASUS_UPDATE_PYTHONPATH=0; pegasus-analyzer -r ')
+            fp.write(f'-v {submitdir}/work $@')
 
         with open('stop', 'w') as fp:
-            fp.write('pegasus-remove {}/work $@'.format(submitdir))
+            fp.write('export PEGASUS_UPDATE_PYTHONPATH=0; pegasus-remove ')
+            fp.write(f'{submitdir}/work $@')
 
         with open('start', 'w') as fp:
-            fp.write('pegasus-run {}/work $@'.format(submitdir))
+            fp.write('export PEGASUS_UPDATE_PYTHONPATH=0; pegasus-run ')
+            fp.write(f'{submitdir}/work $@')
 
         os.chmod('status', 0o755)
         os.chmod('debug', 0o755)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools",
+requires = ["setuptools<82.0.0",
             "wheel",
             "cython>=3.0.0,<3.1.0",
             "numpy==1.16.0; python_version <= '3.7'",

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,12 +19,12 @@ tqdm
 gwdatafind>=1.1.3
 
 # Requirements for full pegasus env
-pegasus-wms.api == 5.1.2
+pegasus-wms == 5.1.2
 # https://pegasus.isi.edu/documentation/user-guide/installation.html#mixing-environments-system-venv-conda
 # six is listed, but is now not needed.
-pegasus-wms.api >= 5.1.1
-pegasus-wms.common >= 5.1.1
-pegasus-wms.worker >= 5.1.1
+pegasus-wms.api == 5.1.2
+pegasus-wms.common == 5.1.2
+pegasus-wms.worker == 5.1.2
 boto3
 certifi
 GitPython

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,13 +3,13 @@ astropy>=2.0.3,!=4.2.1,!=4.0.5
 Mako>=1.0.1
 # WORKAROUND FRO V23_RELEASE_BRANCH - LIMIT SCIPY VERSION
 scipy>=0.16.0,<1.14.0
-matplotlib==3.9.4
+matplotlib<=3.9.4
 # Remove the upper bound ASAP, this is a temporary fix!!!!!!
 numpy>=1.16.0,!=1.19.0,<1.24.0
 pillow
 h5py>=3.0.0,!=3.7.0
 jinja2
-mpld3>=0.3
+mpld3>=0.3,<0.5.11
 beautifulsoup4>=4.6.0
 cython<3.1.0
 lalsuite!=7.2,<7.25

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,7 +37,7 @@ python-ligo-lw >= 1.8.1
 
 # Needed for Parameter Estimation Tasks
 emcee==2.2.1
-dynesty
+dynesty==2.1.5
 
 # For building documentation
 Sphinx>=4.2.0,<8.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ astropy>=2.0.3,!=4.2.1,!=4.0.5
 Mako>=1.0.1
 # WORKAROUND FRO V23_RELEASE_BRANCH - LIMIT SCIPY VERSION
 scipy>=0.16.0,<1.14.0
-matplotlib>=2.0.0
+matplotlib<3.6
 # Remove the upper bound ASAP, this is a temporary fix!!!!!!
 numpy>=1.16.0,!=1.19.0,<1.24.0
 pillow

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ tqdm
 gwdatafind>=1.1.3
 
 # Requirements for full pegasus env
-pegasus-wms.api >= 5.0.6
+pegasus-wms.api == 5.1.2
 # Need GitPython: See discussion in https://github.com/gwastro/pycbc/pull/4454
 GitPython
 # need to pin until pegasus for further upstream

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,13 @@ gwdatafind>=1.1.3
 
 # Requirements for full pegasus env
 pegasus-wms.api == 5.1.2
-# Need GitPython: See discussion in https://github.com/gwastro/pycbc/pull/4454
+# https://pegasus.isi.edu/documentation/user-guide/installation.html#mixing-environments-system-venv-conda
+# six is listed, but is now not needed.
+pegasus-wms.api >= 5.1.1
+pegasus-wms.common >= 5.1.1
+pegasus-wms.worker >= 5.1.1
+boto3
+certifi
 GitPython
 # need to pin until pegasus for further upstream
 # addresses incompatibility between old flask/jinja2 and latest markupsafe

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ astropy>=2.0.3,!=4.2.1,!=4.0.5
 Mako>=1.0.1
 # WORKAROUND FRO V23_RELEASE_BRANCH - LIMIT SCIPY VERSION
 scipy>=0.16.0,<1.14.0
-matplotlib<3.6
+matplotlib==3.9.4
 # Remove the upper bound ASAP, this is a temporary fix!!!!!!
 numpy>=1.16.0,!=1.19.0,<1.24.0
 pillow

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,8 @@ install_requires = setup_requires + [
     'pegasus-wms.api == 5.1.2',
     'python-ligo-lw >= 1.7.0',
     'ligo-segments',
+    'lalsuite!=7.2,<7.25',
+    'lscsoft-glue>=1.59.3',
     'pykerr',
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -50,8 +50,6 @@ install_requires = setup_requires + [
     'pegasus-wms.api == 5.1.2',
     'python-ligo-lw >= 1.7.0',
     'ligo-segments',
-    'lalsuite!=7.2,<7.25',
-    'lscsoft-glue>=1.59.3',
     'pykerr',
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ install_requires = setup_requires + [
     'Mako>=1.0.1',
     'beautifulsoup4>=4.6.0',
     'tqdm',
-    'setuptools',
+    'setuptools<82.0.0',
     'gwdatafind',
     'pegasus-wms.api == 5.1.2',
     'python-ligo-lw >= 1.7.0',

--- a/setup.py
+++ b/setup.py
@@ -119,7 +119,7 @@ def get_version_info():
         vinfo = _version_helper.generate_git_version_info()
     except:
         vinfo = vdummy()
-        vinfo.version = '2.3.14'
+        vinfo.version = '2.3.15'
         vinfo.release = True
 
     version_script = f"""# coding: utf-8

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ install_requires = setup_requires + [
     'tqdm',
     'setuptools',
     'gwdatafind',
-    'pegasus-wms.api >= 5.0.6',
+    'pegasus-wms.api == 5.1.2',
     'python-ligo-lw >= 1.7.0',
     'ligo-segments',
     'lalsuite!=7.2,<7.25',


### PR DESCRIPTION
Need to make what is hopefully one final release on the v23 release branch to include the new pegasus 5.1.2 release.

I think this should now be ready to merge. It basically contains:

* Some changes to the various github tests to make them work
  * The test workflows now run with 5.1.X (matching the main branch, which actually still runs with 5.1.1)
  * The tutorial tests are disabled ... The tutorials require main PyCBC and shouldn't be tested on release branches like this one
* Merging the "support for pegasus 5.1.X" patch #5142 ... No further changes are needed for 5.1.1
* Force pegasus 5.1.2 dependencies
* Restrict a bunch of other dependencies to "less than whatever it was at the end of 2024"
* Added a SINGULARITY requirement for OSG as recommended by James