### PR TITLE
add new requirements to have singularity for OSG site

### DIFF
--- a/pycbc/workflow/pegasus_sites.py
+++ b/pycbc/workflow/pegasus_sites.py
@@ -225,7 +225,8 @@ def add_osg_site(sitecat, cp):
                       value=r"\"0,1,2,4,5,7,8,9,10,11,12,13,16,17,24,27,35,36,40\"")
     site.add_profiles(Namespace.CONDOR, key="Requirements",
                       value="(HAS_SINGULARITY =?= TRUE) && "
-                            "(IS_GLIDEIN =?= True)")
+                            "(IS_GLIDEIN =?= True) && "
+                            "(HAS_CVMFS_singularity_opensciencegrid_org =?= True)")
     cvmfs_loc = '"/cvmfs/singularity.opensciencegrid.org/pycbc/pycbc-el8:v'
     cvmfs_loc += sing_version + '"'
     site.add_profiles(Namespace.CONDOR, key="My.SingularityImage",


### PR DESCRIPTION
## Standard information about the request

This is a fix to add a new condor requirement `HAS_CVMFS_singularity_opensciencegrid_org=True` in the Pegasus workflow when using OSG sites. This is caused by a upstream OSG configuration change shown [here](https://github.com/opensciencegrid/osg-flock/commit/914b2cc5874ac377a3c6f160c5b247e6cb6aa706).  Hence the attribute `HAS_SINGULARITY=True` no longer implies `HAS_CVMFS_singularity_opensciencegrid_org=True`.  So the old requirements don't actually require the CVMFS singularity image repository and one can land places where there's a CVMFS problem.



This solution is given by James Clark in this [LVK computing issue](https://git.ligo.org/computing/helpdesk/-/issues/8359#note_1664585)(LVK account required to check the page)





- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
