### PR TITLE
Use base64 encoding for array data in LIGOLW files

### DIFF
--- a/pycbc/io/ligolw.py
+++ b/pycbc/io/ligolw.py
@@ -274,7 +274,9 @@ def _build_series(series, dim_names, comment, delta_name, delta_unit):
             numpy.arange(len(series.data.data)) * delta,
             series.data.data
         ))
-    a = ligolw.Array.build(series.name, data, dim_names=dim_names)
+    a = ligolw.Array.build(
+        series.name, data, dim_names=dim_names, encoding='base64'
+    )
     a.Unit = str(series.sampleUnits)
     dim0 = a.getElementsByTagName(ligolw.Dim.tagName)[0]
     dim0.Unit = delta_unit

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,7 +36,7 @@ urllib3
 markupsafe <= 2.0.1
 
 # Requirements for LIGO Light-Weight XML format access needed by some workflows
-igwn-ligolw
+igwn-ligolw>=2.1.0
 
 # Needed for Parameter Estimation Tasks
 emcee==2.2.1

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ install_requires = setup_requires + [
     'setuptools',
     'gwdatafind',
     'pegasus-wms.api >= 5.1.1',
-    'igwn-ligolw',
+    'igwn-ligolw >= 2.1.0',
     'igwn-segments',
     'lalsuite!=7.2',
     'lscsoft-glue>=1.59.3',


### PR DESCRIPTION
Use the new base64 encoding for array data in LIGOLW XML files.

## Standard information about the request

This is an efficiency update.

This change affects anything that generates LIGOLW XML files with array data, which should only be the offline search and the live search when used for LVK analyses.

This change changes the file format of certain data products.

This change will tighten some dependency requirements.

## Motivation

So far, search candidates in LIGOLW XML format have carried binary SNR and PSD data encoded as tables of ASCII numbers. This implies some unnecessary rounding and it is relatively slow, even affecting the alert latency to some extent. igwn-ligolw has recently enabled storing exact binary array data as base64-encoded ASCII. I propose we switch to this new encoding before the next observing run.

There is an argument for sticking with the old encoding: it allows humans to rapidly inspect the SNR/PSD data with a simple text editor. However, although I definitely used this a few times in the past, I am willing to trade it for the advantages of the base64 encoding. Decoding the base64 stream "by hand" should not be too difficult anyway, if really necessary.

## Contents

This simply passes a kwarg to request the base64 encoding, and updates the dependency requirements to make sure the right version of igwn-ligolw is installed.

## Links to any issues or associated PRs

Closes #5268.

## Testing performed

The Live example (part of CI) tests this, because it runs BAYESTAR on the resulting candidates, and it does a loose check on the estimated PSDs. I also spot-checked a couple of the candidates with a text editor to verify that the new encoding is used.

More extensive tests will be done when validating the search code for the next observing run.

## Additional notes

N/A

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
