### PR TITLE
Set maximum document parsing size for yaml docs to 2047 MB for Pegasus

### DIFF
--- a/pycbc/workflow/pegasus_files/pegasus-properties.conf
+++ b/pycbc/workflow/pegasus_files/pegasus-properties.conf
@@ -58,5 +58,5 @@ pegasus.transfer.bypass.input.staging = true
 # This is needed for symlinking, it does nothing in the pegasus_sites.py
 pegasus.transfer.links = true
 
-# Set maximum document parsing size for yaml docs to 2047 MB, the default is 500 MB
+# Increase maximum document parsing size for yaml docs (e.g., *.dax) to 2047 MB; default is 500 MB
 pegasus.parser.document.size=2047


### PR DESCRIPTION
Currently, the maximum allowed size for `*.dax` files passed to `pegasus-plan` is 500 MB, which is the default value by Pegasus. 

We've already seen dax files in an offline search larger than that, hence pegasus-plan failed to run. 

This PR sets a global value for the maximum allowed size to be 2047MB. Note that this is the hardcoded maximum allowed value within Pegasus (https://github.com/pegasus-isi/pegasus/issues/2152). I think any value larger than this would be treated as 2047MB, but I won't bother that now, until we have a *.dax file larger than 2047MB in the future.

This PR is guided by Karan, and suggested by Ian.