### PR TITLE
TEMP: Add temporary PyPMC git repo dependency

### DIFF
--- a/companion.txt
+++ b/companion.txt
@@ -18,8 +18,8 @@ https://github.com/willvousden/ptemcee/archive/master.tar.gz
 --extra-index-url https://download.pytorch.org/whl/cpu
 torch
 nessai>=0.11.0
-# TEMPORARY - REMOVE THIS ONCE PYPMC HAS A RELEASE
-git+https://github.com/pypmc/pypmc
+# TEMPORARY - REMOVE THIS ONCE PYPMC HAS A RELEASE v1.2.6
+git+https://github.com/pypmc/pypmc@dc5ff5f
 snowline
 
 # useful to look at PyCBC Live with htop


### PR DESCRIPTION
TEMPORARY: add pypmc install from git repo to override snowline install.

This is until pypmc make a release, and should get CI tests to pass

## Standard information about the request

This is a temporary workaround, and should be remove as soon as possible
This change affects continuous integration

This change follows style guidelines (See e.g. [PEP8](https://peps.python.org/pep-0008/)), has been proposed using the [contribution guidelines](https://github.com/gwastro/pycbc/blob/master/CONTRIBUTING.md)

This change updates dependencies, but will want reverting ASAP

## Motivation
Get CI to run

## Contents
Install pypmc from the git repo, this is until the deprecated pkg_resources is removed in a release

## Links to any issues or associated PRs
https://github.com/pypmc/pypmc/issues/118

## Testing performed
This will be done by the CI

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
