### PR TITLE
Rounding error of template lengths in pycbc_live

### DIFF
--- a/pycbc/waveform/bank.py
+++ b/pycbc/waveform/bank.py
@@ -630,6 +630,7 @@ class LiveFilterBank(TemplateBank):
             delta_f = self.freq_resolution_for_template(index)
 
         flen = round(self.sample_rate / (2 * delta_f) + 1)
+        assert flen & 1, f'flen should be odd, but got {flen}'
 
         if f_end is None or f_end >= (flen * delta_f):
             f_end = (flen - 1) * delta_f


### PR DESCRIPTION
<!-- TOP-LEVEL SUMMARY: Please provide a brief, one-or-two-sentence description of the PR here
-->

Rounding error for long templates in the [LiveFilterBank object](https://github.com/gwastro/pycbc/blob/ca10cb45464cd9934c4a6c5fe27b1d73acc26e28/pycbc/waveform/bank.py#L520) may cause the template length to be **even** and off by one.  

## Standard information about the request

<!--- Some basic info about the change (delete as appropriate) -->
This is a: bug fix

<!--- What codes will this affect? (delete as apropriate)
If you do not know which areas will be affected, please ask in the gwastro #pycbc-code slack
-->
This change affects: the live search

<!--- Some things which help with code management (delete as appropriate) -->
This change: has appropriate unit tests, follows style guidelines (See e.g. [PEP8](https://peps.python.org/pep-0008/)), has been proposed using the [contribution guidelines](https://github.com/gwastro/pycbc/blob/master/CONTRIBUTING.md)

<!--- Notes about the effect of this change -->
This change: may require a new release.

## Motivation

Templates in the LiveFilterBank as computed [here](https://github.com/gwastro/pycbc/blob/ca10cb45464cd9934c4a6c5fe27b1d73acc26e28/pycbc/waveform/bank.py#L632) should not have an even number of samples`flen`. 

However, in some cases the `int` floors the `flen` to an even number. An example I encountered while running pycbc_live using a single template (the exact parameters are not important here):

```
>>> int(2048/0.00134408602150537645/2 + 1)
761856
```

where the sample_rate = 2048, and the `delta_f` computed internally is `0.00134408602150537645`. 

The even number of samples (off exactly by one sample) causes length mismatch error while matched filtering. 

## Contents
Trivial change of `int` --> `round`

## Testing performed
The fix is trivial and does not break `pycbc_live`.

- [ ] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
