### PR TITLE
Temporary hack in order to build PyPMC from source

### DIFF
--- a/docker/etc/docker-install.sh
+++ b/docker/etc/docker-install.sh
@@ -3,7 +3,7 @@
 set -e
 
 # FIXME Temporary hack in order to build PyPMC from source.
-# Remove this, and the `scl enable gcc-toolset-14` wrappers further below,
+# Remove this, and the `scl enable gcc-toolset-12` wrappers further below,
 # once PyPMC 1.2.6 is released.
 dnf -y install gcc-toolset-12
 

--- a/tools/docker_build_dist.sh
+++ b/tools/docker_build_dist.sh
@@ -47,7 +47,7 @@ if [ "x${PYCBC_CONTAINER}" == "xpycbc_rhel_virtualenv" ]; then
   yum -y install hdf5-static libxml2-static zlib-static libstdc++-static cfitsio-static glibc-static swig fftw-static gsl-static gsl gsl-devel --skip-broken
 
   # FIXME Temporary hack in order to build PyPMC from source.
-  # Remove this, and the `scl enable gcc-toolset-14` wrappers further below,
+  # Remove this, and the `scl enable gcc-toolset-12` wrappers further below,
   # once PyPMC 1.2.6 is released.
   dnf -y install gcc-toolset-12
 


### PR DESCRIPTION
This is a continuation of #5292 that will hopefully fix the CI failures for the Docker build and LVK env build.

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
