### PR TITLE
Minor fixes to Dockerfile, pin awkde hash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,9 @@ ADD docker/etc/cvmfs/default.local /etc/cvmfs/default.local
 ADD docker/etc/cvmfs/60-osg.conf /etc/cvmfs/60-osg.conf
 ADD docker/etc/cvmfs/config-osg.opensciencegrid.org.conf /etc/cvmfs/config-osg.opensciencegrid.org.conf
 
+# We are going to use pip as root a lot; tell it not to complain
+ENV PIP_ROOT_USER_ACTION=ignore
+
 # Set up extra repositories
 RUN <<EOF
 dnf -y install https://cvmrepo.s3.cern.ch/cvmrepo/yum/cvmfs-release-latest.noarch.rpm
@@ -40,6 +43,8 @@ alternatives --set python /usr/bin/python3.11
 python -m pip install --upgrade pip setuptools wheel cython
 python -m pip install mkl ipython jupyter jupyterhub jupyterlab lalsuite
 dnf -y install https://repo.opensciencegrid.org/osg/3.5/el8/testing/x86_64/osg-wn-client-3.5-5.osg35.el8.noarch.rpm
+dnf clean all
+python -m pip cache purge
 EOF
 
 # set up environment
@@ -71,18 +76,20 @@ dnf -y install \
 python -m pip install schwimmbad
 MPICC=/lib64/openmpi/bin/mpicc CFLAGS='-I /usr/include/openmpi-x86_64/ -L /usr/lib64/openmpi/lib/ -lmpi' python -m pip install --no-cache-dir mpi4py
 echo "/usr/lib64/openmpi/lib/" > /etc/ld.so.conf.d/openmpi.conf
+dnf clean all
+python -m pip cache purge
 EOF
 
 # Now update all of our library installations
 RUN rm -f /etc/ld.so.cache && /sbin/ldconfig
 
 # Explicitly set the path so that it is not inherited from build the environment
-ENV PATH "/usr/local/bin:/usr/bin:/bin:/lib64/openmpi/bin/bin"
+ENV PATH="/usr/local/bin:/usr/bin:/bin:/lib64/openmpi/bin/bin"
 
 # Set the default LAL_DATA_PATH to point at CVMFS first, then the container.
 # Users wanting it to point elsewhere should start docker using:
 #   docker <cmd> -e LAL_DATA_PATH="/my/new/path"
-ENV LAL_DATA_PATH "/cvmfs/software.igwn.org/pycbc/lalsuite-extra/current/share/lalsimulation:/opt/pycbc/pycbc-software/share/lal-data"
+ENV LAL_DATA_PATH="/cvmfs/software.igwn.org/pycbc/lalsuite-extra/current/share/lalsimulation:/opt/pycbc/pycbc-software/share/lal-data"
 
 # When the container is started with
 #   docker run -it pycbc/pycbc-el8:latest

--- a/companion.txt
+++ b/companion.txt
@@ -29,5 +29,5 @@ setproctitle
 sympy>=1.9
 
 # Needed for KDE trigger statistics
-git+https://github.com/mennthor/awkde.git@master
+git+https://github.com/mennthor/awkde.git@5b601fe4d92229d5deb8737fd121dce193bac552
 scikit-learn


### PR DESCRIPTION
A few minor tweaks:
* Clean the dnf and pip caches after each use to prevent the Docker image from growing unnecessarily (I think @spxiwh had this concern a while ago).
* Silence an unnecessary warning from pip
* Update deprecated syntax for env variables in the Dockerfile
* Pin the github URL for awkde to a specific commit instead of the master branch (this was suggested by Copilot in another PR). I use the latest commit on master, which is 2 years old. Perhaps we should consider incorporating the functionality into PyCBC at this point?

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
