### PR TITLE
Add option to inpaint with explicit matrix inversion and multiplication

### DIFF
--- a/pycbc/inference/models/gated_gaussian_noise.py
+++ b/pycbc/inference/models/gated_gaussian_noise.py
@@ -323,7 +323,6 @@ class BaseGatedGaussian(BaseGaussianNoise):
         and cache to memory.
         """
         cache_matrices = {}
-        print('inverting matrices for the first time')
         # get gate length and invpsd
         for det in self._invpsds:
             lindex, rindex = self.gate_indices(det)
@@ -333,7 +332,6 @@ class BaseGatedGaussian(BaseGaussianNoise):
             cache_matrices[det] = invmat
         # cache results
         self._cov_matrices[rindex-lindex] = cache_matrices
-        print(rindex-lindex)
         return invmat
 
     @abstractmethod
@@ -1180,8 +1178,6 @@ class GatedGaussianMargPhase(BaseGatedGaussian):
             recalibration=self.recalibration,
             generator_class=generator.FDomainDetFrameTwoPhaseGenerator,
             **self.static_params)
-        print(kwargs)
-        print(self.paint_method)
 
     def get_waveforms(self):
         r"""Generate the waveforms.

--- a/pycbc/inference/models/gated_gaussian_noise.py
+++ b/pycbc/inference/models/gated_gaussian_noise.py
@@ -322,16 +322,19 @@ class BaseGatedGaussian(BaseGaussianNoise):
         """Get the uninverted covariance matrix for the model's inverse PSDs
         and cache to memory.
         """
-        cache_matrices = {}
         # get gate length and invpsd
         for det in self._invpsds:
             lindex, rindex = self.gate_indices(det)
             invpsd = self._invpsds[det]
             # invert
             invmat = invert_covariance(invpsd, lindex, rindex)
-            cache_matrices[det] = invmat
-        # cache results
-        self._cov_matrices[rindex-lindex] = cache_matrices
+            # cache results
+            try:
+                # time window dict already exists; fill in entry
+                self._cov_matrices[int(rindex-lindex)][det] = invmat
+            except:
+                # time window dict does not exist; populate w/ new dict
+                self._cov_matrices[int(rindex-lindex)] = {det: invmat}
         return invmat
 
     @abstractmethod
@@ -399,7 +402,7 @@ class BaseGatedGaussian(BaseGaussianNoise):
                 if self.paint_method == 'matmul':
                     try:
                         lidx, ridx = self.gate_indices(det)
-                        invmat = self._cov_matrices[ridx-lidx][det]
+                        invmat = self._cov_matrices[int(ridx-lidx)][det]
                     except KeyError:
                         invmat = self.invert_covariance(det)
                 else:
@@ -594,7 +597,7 @@ class BaseGatedGaussian(BaseGaussianNoise):
             if self.paint_method == 'matmul':
                 try:
                     lidx, ridx = self.gate_indices(det)
-                    invmat = self._cov_matrices[ridx-lidx][det]
+                    invmat = self._cov_matrices[int(ridx-lidx)][det]
                 except KeyError:
                     invmat = self.invert_covariance(det)
             else:
@@ -770,7 +773,7 @@ class GatedGaussianNoise(BaseGatedGaussian):
             if self.paint_method == 'matmul':
                 try:
                     lidx, ridx = self.gate_indices(det)
-                    invmat = self._cov_matrices[ridx-lidx][det]
+                    invmat = self._cov_matrices[int(ridx-lidx)][det]
                 except KeyError:
                     invmat = self.invert_covariance(det)
             else:
@@ -859,7 +862,7 @@ class GatedGaussianNoise(BaseGatedGaussian):
             if self.paint_method == 'matmul':
                 try:
                     lidx, ridx = self.gate_indices(det)
-                    invmat = self._cov_matrices[ridx-lidx][det]
+                    invmat = self._cov_matrices[int(ridx-lidx)][det]
                 except KeyError:
                     invmat = self.invert_covariance(det)
             else:
@@ -942,7 +945,7 @@ class GatedGaussianMargPol(BaseGatedGaussian):
                 if self.paint_method == 'matmul':
                     try:
                         lidx, ridx = self.gate_indices(det)
-                        invmat = self._cov_matrices[ridx-lidx][det]
+                        invmat = self._cov_matrices[int(ridx-lidx)][det]
                     except KeyError:
                         invmat = self.invert_covariance(det)
                 else:
@@ -1219,7 +1222,7 @@ class GatedGaussianMargPhase(BaseGatedGaussian):
             if self.paint_method == 'matmul':
                 try:
                     lidx, ridx = self.gate_indices(det)
-                    invmat = self._cov_matrices[ridx-lidx][det]
+                    invmat = self._cov_matrices[int(ridx-lidx)][det]
                 except KeyError:
                     invmat = self.invert_covariance(det)
             else:

--- a/pycbc/inference/models/gated_gaussian_noise.py
+++ b/pycbc/inference/models/gated_gaussian_noise.py
@@ -323,19 +323,17 @@ class BaseGatedGaussian(BaseGaussianNoise):
         and cache to memory.
         """
         # get gate length and invpsd
-        for det in self._invpsds:
-            lindex, rindex = self.gate_indices(det)
-            invpsd = self._invpsds[det]
-            # invert
-            invmat = invert_covariance(invpsd, lindex, rindex)
-            print('from scratch: ', numpy.shape(invmat), rindex, lindex, det)
-            # cache results
-            try:
-                # time window dict already exists; fill in entry
-                self._cov_matrices[int(rindex-lindex)][det] = invmat
-            except:
-                # time window dict does not exist; populate w/ new dict
-                self._cov_matrices[int(rindex-lindex)] = {det: invmat}
+        lindex, rindex = self.gate_indices(det)
+        invpsd = self._invpsds[det]
+        # invert
+        invmat = invert_covariance(invpsd, lindex, rindex)
+        # cache results
+        try:
+            # time window dict already exists; fill in entry
+            self._cov_matrices[int(rindex-lindex)][det] = invmat
+        except:
+            # time window dict does not exist; populate w/ new dict
+            self._cov_matrices[int(rindex-lindex)] = {det: invmat}
         return invmat
 
     @abstractmethod
@@ -404,7 +402,6 @@ class BaseGatedGaussian(BaseGaussianNoise):
                     try:
                         lidx, ridx = self.gate_indices(det)
                         invmat = self._cov_matrices[int(ridx-lidx)][det]
-                        print('from cache: ', invmat.shape, ridx, lidx, det)
                     except KeyError:
                         invmat = self.invert_covariance(det)
                 else:

--- a/pycbc/inference/models/gated_gaussian_noise.py
+++ b/pycbc/inference/models/gated_gaussian_noise.py
@@ -65,11 +65,7 @@ class BaseGatedGaussian(BaseGaussianNoise):
                                                       False))
         self._cond = {}
         # cache inpainting options
-        if 'paint_method' not in kwargs:
-            self.paint_method = 'toeplitz'
-        else:
-            ### FIXME: does this happen automatically?
-            self.paint_method = kwargs['paint_method']
+        self.paint_method = kwargs.get('paint-method', 'toeplitz')
         self._cov_matrices = {}
         # cache samples and linear regression for determinant extrapolation
         self._cov_samples = {}
@@ -319,21 +315,30 @@ class BaseGatedGaussian(BaseGaussianNoise):
         return data
 
     def invert_covariance(self, det):
-        """Get the uninverted covariance matrix for the model's inverse PSDs
-        and cache to memory.
+        """Get the uninverted covariance matrix for the model's inverse PSDs.
+        Once the inverse matrix is calculated for a given gate time in this
+        detector, store to cache; future calls of this function will pull from
+        that cache instead.
         """
-        # get gate length and invpsd
+        # don't bother with covariance matrix if we're using toeplitz solver
+        if self.paint_method == 'toeplitz':
+            return None
+        # check if there are cache results for this gate length
         lindex, rindex = self.gate_indices(det)
-        invpsd = self._invpsds[det]
-        # invert
-        invmat = invert_covariance(invpsd, lindex, rindex)
-        # cache results
         try:
-            # time window dict already exists; fill in entry
-            self._cov_matrices[int(rindex-lindex)][det] = invmat
-        except:
-            # time window dict does not exist; populate w/ new dict
-            self._cov_matrices[int(rindex-lindex)] = {det: invmat}
+            cov_matrices = self._cov_matrices[int(rindex-lindex)]
+        except KeyError:
+            cov_matrices = {}
+        # check if this det has a precalculated matrix for this gate length
+        try:
+            invmat = cov_matrices[det]
+        except KeyError:
+            invpsd = self._invpsds[det]
+            # construct and invert covariance matrix
+            invmat = invert_covariance(invpsd, lindex, rindex)
+            cov_matrices[det] = invmat
+            # cache results
+            self._cov_matrices[int(rindex-lindex)] = cov_matrices
         return invmat
 
     @abstractmethod
@@ -398,14 +403,7 @@ class BaseGatedGaussian(BaseGaussianNoise):
             except KeyError:
                 # doesn't exist yet, or the gate times changed
                 cache.clear()
-                if self.paint_method == 'matmul':
-                    try:
-                        lidx, ridx = self.gate_indices(det)
-                        invmat = self._cov_matrices[int(ridx-lidx)][det]
-                    except KeyError:
-                        invmat = self.invert_covariance(det)
-                else:
-                    invmat = None
+                invmat = self.invert_covariance(det)
                 d = d.gate(gatestartdelay + dgatedelay/2,
                            window=dgatedelay/2, copy=True,
                            invpsd=invpsd, method='paint',
@@ -593,14 +591,7 @@ class BaseGatedGaussian(BaseGaussianNoise):
             slc = slice(self._kmin[det], self._kmax[det])
             # gate the data
             data = self.td_data[det]
-            if self.paint_method == 'matmul':
-                try:
-                    lidx, ridx = self.gate_indices(det)
-                    invmat = self._cov_matrices[int(ridx-lidx)][det]
-                except KeyError:
-                    invmat = self.invert_covariance(det)
-            else:
-                invmat = None
+            invmat = self.invert_covariance(det)
             gated_dt = data.gate(gatestartdelay + dgatedelay/2,
                                  window=dgatedelay/2, copy=True,
                                  invpsd=invpsd, method='paint',
@@ -769,14 +760,7 @@ class GatedGaussianNoise(BaseGatedGaussian):
             ht = h.to_timeseries()
             res = data - ht
             rtilde = res.to_frequencyseries()
-            if self.paint_method == 'matmul':
-                try:
-                    lidx, ridx = self.gate_indices(det)
-                    invmat = self._cov_matrices[int(ridx-lidx)][det]
-                except KeyError:
-                    invmat = self.invert_covariance(det)
-            else:
-                invmat = None
+            invmat = self.invert_covariance(det)
             gated_res = res.gate(gatestartdelay + dgatedelay/2,
                                  window=dgatedelay/2, copy=True,
                                  invpsd=invpsd, method='paint',
@@ -858,14 +842,7 @@ class GatedGaussianNoise(BaseGatedGaussian):
             invpsd = self._invpsds[det]
             gate_times = self.get_gate_times()
             gatestartdelay, dgatedelay = gate_times[det]
-            if self.paint_method == 'matmul':
-                try:
-                    lidx, ridx = self.gate_indices(det)
-                    invmat = self._cov_matrices[int(ridx-lidx)][det]
-                except KeyError:
-                    invmat = self.invert_covariance(det)
-            else:
-                invmat = None
+            invmat = self.invert_covariance(det)
             ht = ht.gate(gatestartdelay + dgatedelay/2,
                          window=dgatedelay/2, copy=False,
                          invpsd=invpsd, method='paint',
@@ -941,14 +918,7 @@ class GatedGaussianMargPol(BaseGatedGaussian):
             pols = []
             for h in wfs[det]:
                 ht = h.to_timeseries()
-                if self.paint_method == 'matmul':
-                    try:
-                        lidx, ridx = self.gate_indices(det)
-                        invmat = self._cov_matrices[int(ridx-lidx)][det]
-                    except KeyError:
-                        invmat = self.invert_covariance(det)
-                else:
-                    invmat = None
+                invmat = self.invert_covariance(det)
                 ht = ht.gate(gatestartdelay + dgatedelay/2,
                              window=dgatedelay/2, copy=False,
                              invpsd=invpsd, method='paint',
@@ -1218,14 +1188,7 @@ class GatedGaussianMargPhase(BaseGatedGaussian):
             invpsd = self._invpsds[det]
             gate_times = self.get_gate_times()
             gatestartdelay, dgatedelay = gate_times[det]
-            if self.paint_method == 'matmul':
-                try:
-                    lidx, ridx = self.gate_indices(det)
-                    invmat = self._cov_matrices[int(ridx-lidx)][det]
-                except KeyError:
-                    invmat = self.invert_covariance(det)
-            else:
-                invmat = None
+            invmat = self.invert_covariance(det)
             hct = hct.gate(gatestartdelay + dgatedelay/2,
                            window=dgatedelay/2, copy=False,
                            invpsd=invpsd, method='paint',

--- a/pycbc/inference/models/gated_gaussian_noise.py
+++ b/pycbc/inference/models/gated_gaussian_noise.py
@@ -32,6 +32,7 @@ from pycbc import types
 from pycbc.waveform.utils import time_from_frequencyseries
 from pycbc.waveform import generator
 from pycbc.filter import highpass
+from pycbc.strain.gate import invert_covariance
 from .gaussian_noise import (BaseGaussianNoise, create_waveform_generator,
                              catch_waveform_error)
 from .base_data import BaseDataModel
@@ -60,9 +61,16 @@ class BaseGatedGaussian(BaseGaussianNoise):
         self._gatetimes = {}
         self._det_lognls = {}
         # cache condition number calculations
-        self.check_condition_number = bool(kwargs.get('check-condition-number', 
+        self.check_condition_number = bool(kwargs.get('check-condition-number',
                                                       False))
         self._cond = {}
+        # cache inpainting options
+        if 'paint_method' not in kwargs:
+            self.paint_method = 'toeplitz'
+        else:
+            ### FIXME: does this happen automatically?
+            self.paint_method = kwargs['paint_method']
+        self._cov_matrices = {}
         # cache samples and linear regression for determinant extrapolation
         self._cov_samples = {}
         self._cov_regressions = {}
@@ -310,6 +318,24 @@ class BaseGatedGaussian(BaseGaussianNoise):
                     raise ValueError("whiten must be either 0, 1, or 2")
         return data
 
+    def invert_covariance(self, det):
+        """Get the uninverted covariance matrix for the model's inverse PSDs
+        and cache to memory.
+        """
+        cache_matrices = {}
+        print('inverting matrices for the first time')
+        # get gate length and invpsd
+        for det in self._invpsds:
+            lindex, rindex = self.gate_indices(det)
+            invpsd = self._invpsds[det]
+            # invert
+            invmat = invert_covariance(invpsd, lindex, rindex)
+            cache_matrices[det] = invmat
+        # cache results
+        self._cov_matrices[rindex-lindex] = cache_matrices
+        print(rindex-lindex)
+        return invmat
+
     @abstractmethod
     def get_waveforms(self):
         """The waveforms generated using the current parameters.
@@ -372,9 +398,19 @@ class BaseGatedGaussian(BaseGaussianNoise):
             except KeyError:
                 # doesn't exist yet, or the gate times changed
                 cache.clear()
+                if self.paint_method == 'matmul':
+                    try:
+                        lidx, ridx = self.gate_indices(det)
+                        invmat = self._cov_matrices[ridx-lidx][det]
+                    except KeyError:
+                        invmat = self.invert_covariance(det)
+                else:
+                    invmat = None
                 d = d.gate(gatestartdelay + dgatedelay/2,
                            window=dgatedelay/2, copy=True,
-                           invpsd=invpsd, method='paint')
+                           invpsd=invpsd, method='paint',
+                           paint_method=self.paint_method,
+                           paint_invmat=invmat)
                 dtilde = d.to_frequencyseries()
                 # save for next time
                 cache[gatestartdelay, dgatedelay] = dtilde
@@ -389,7 +425,7 @@ class BaseGatedGaussian(BaseGaussianNoise):
         parameters; see ``get_gate_times_hmeco`` for details. Otherwise, the
         gate times will just be retrieved from the ``t_gate_start`` and
         ``t_gate_end`` parameters.
-        
+
         If the user flagged ``check_condition_number``, also checks if
         inpainting with the calculated gate times will be numerically
         stable. See ``self.condition_number()`` for more info.
@@ -496,12 +532,12 @@ class BaseGatedGaussian(BaseGaussianNoise):
             gatestartdelay = min(gatestartdelay, params['t_gate_start'])
             gatetimes[det] = (gatestartdelay, dgate)
         return gatetimes
-    
+
     def condition_number(self, det, lindex, rindex):
         """Calculate the condition number associated with the inverse
         covariance matrix used to gate and inpaint. Throws a warning if the
         condition number is greater than 1e16.
-        
+
         Parameters
         ----------
         det : str
@@ -557,9 +593,19 @@ class BaseGatedGaussian(BaseGaussianNoise):
             slc = slice(self._kmin[det], self._kmax[det])
             # gate the data
             data = self.td_data[det]
+            if self.paint_method == 'matmul':
+                try:
+                    lidx, ridx = self.gate_indices(det)
+                    invmat = self._cov_matrices[ridx-lidx][det]
+                except KeyError:
+                    invmat = self.invert_covariance(det)
+            else:
+                invmat = None
             gated_dt = data.gate(gatestartdelay + dgatedelay/2,
                                  window=dgatedelay/2, copy=True,
-                                 invpsd=invpsd, method='paint')
+                                 invpsd=invpsd, method='paint',
+                                 paint_method=self.paint_method,
+                                 paint_invmat=invmat)
             # convert to the frequency series
             gated_d = gated_dt.to_frequencyseries()
             # overwhiten
@@ -723,9 +769,19 @@ class GatedGaussianNoise(BaseGatedGaussian):
             ht = h.to_timeseries()
             res = data - ht
             rtilde = res.to_frequencyseries()
+            if self.paint_method == 'matmul':
+                try:
+                    lidx, ridx = self.gate_indices(det)
+                    invmat = self._cov_matrices[ridx-lidx][det]
+                except KeyError:
+                    invmat = self.invert_covariance(det)
+            else:
+                invmat = None
             gated_res = res.gate(gatestartdelay + dgatedelay/2,
                                  window=dgatedelay/2, copy=True,
-                                 invpsd=invpsd, method='paint')
+                                 invpsd=invpsd, method='paint',
+                                 paint_method=self.paint_method,
+                                 paint_invmat=invmat)
             gated_rtilde = gated_res.to_frequencyseries()
             # overwhiten
             gated_rtilde *= invpsd
@@ -802,9 +858,19 @@ class GatedGaussianNoise(BaseGatedGaussian):
             invpsd = self._invpsds[det]
             gate_times = self.get_gate_times()
             gatestartdelay, dgatedelay = gate_times[det]
+            if self.paint_method == 'matmul':
+                try:
+                    lidx, ridx = self.gate_indices(det)
+                    invmat = self._cov_matrices[ridx-lidx][det]
+                except KeyError:
+                    invmat = self.invert_covariance(det)
+            else:
+                invmat = None
             ht = ht.gate(gatestartdelay + dgatedelay/2,
-                            window=dgatedelay/2, copy=False,
-                            invpsd=invpsd, method='paint')
+                         window=dgatedelay/2, copy=False,
+                         invpsd=invpsd, method='paint',
+                         paint_method=self.paint_method,
+                         paint_invmat=invmat)
             h = ht.to_frequencyseries()
             out[det] = h
         return out
@@ -875,9 +941,19 @@ class GatedGaussianMargPol(BaseGatedGaussian):
             pols = []
             for h in wfs[det]:
                 ht = h.to_timeseries()
+                if self.paint_method == 'matmul':
+                    try:
+                        lidx, ridx = self.gate_indices(det)
+                        invmat = self._cov_matrices[ridx-lidx][det]
+                    except KeyError:
+                        invmat = self.invert_covariance(det)
+                else:
+                    invmat = None
                 ht = ht.gate(gatestartdelay + dgatedelay/2,
-                            window=dgatedelay/2, copy=False,
-                            invpsd=invpsd, method='paint')
+                             window=dgatedelay/2, copy=False,
+                             invpsd=invpsd, method='paint',
+                             paint_method=self.paint_method,
+                             paint_invmat=invmat)
                 h = ht.to_frequencyseries()
                 pols.append(h)
             out[det] = tuple(pols)
@@ -1104,6 +1180,8 @@ class GatedGaussianMargPhase(BaseGatedGaussian):
             recalibration=self.recalibration,
             generator_class=generator.FDomainDetFrameTwoPhaseGenerator,
             **self.static_params)
+        print(kwargs)
+        print(self.paint_method)
 
     def get_waveforms(self):
         r"""Generate the waveforms.
@@ -1142,12 +1220,24 @@ class GatedGaussianMargPhase(BaseGatedGaussian):
             invpsd = self._invpsds[det]
             gate_times = self.get_gate_times()
             gatestartdelay, dgatedelay = gate_times[det]
+            if self.paint_method == 'matmul':
+                try:
+                    lidx, ridx = self.gate_indices(det)
+                    invmat = self._cov_matrices[ridx-lidx][det]
+                except KeyError:
+                    invmat = self.invert_covariance(det)
+            else:
+                invmat = None
             hct = hct.gate(gatestartdelay + dgatedelay/2,
                            window=dgatedelay/2, copy=False,
-                           invpsd=invpsd, method='paint')
+                           invpsd=invpsd, method='paint',
+                           paint_method=self.paint_method,
+                           paint_invmat=invmat)
             hst = hst.gate(gatestartdelay + dgatedelay/2,
                            window=dgatedelay/2, copy=False,
-                           invpsd=invpsd, method='paint')
+                           invpsd=invpsd, method='paint',
+                           paint_method=self.paint_method,
+                           paint_invmat=invmat)
             hc = hct.to_frequencyseries()
             hs = hst.to_frequencyseries()
             out[det] = (hc, hs)

--- a/pycbc/inference/models/gated_gaussian_noise.py
+++ b/pycbc/inference/models/gated_gaussian_noise.py
@@ -328,6 +328,7 @@ class BaseGatedGaussian(BaseGaussianNoise):
             invpsd = self._invpsds[det]
             # invert
             invmat = invert_covariance(invpsd, lindex, rindex)
+            print(numpy.shape(invmat), rindex, lindex, det)
             # cache results
             try:
                 # time window dict already exists; fill in entry

--- a/pycbc/inference/models/gated_gaussian_noise.py
+++ b/pycbc/inference/models/gated_gaussian_noise.py
@@ -328,7 +328,7 @@ class BaseGatedGaussian(BaseGaussianNoise):
             invpsd = self._invpsds[det]
             # invert
             invmat = invert_covariance(invpsd, lindex, rindex)
-            print(numpy.shape(invmat), rindex, lindex, det)
+            print('from scratch: ', numpy.shape(invmat), rindex, lindex, det)
             # cache results
             try:
                 # time window dict already exists; fill in entry
@@ -404,6 +404,7 @@ class BaseGatedGaussian(BaseGaussianNoise):
                     try:
                         lidx, ridx = self.gate_indices(det)
                         invmat = self._cov_matrices[int(ridx-lidx)][det]
+                        print('from cache: ', invmat.shape, ridx, lidx, det)
                     except KeyError:
                         invmat = self.invert_covariance(det)
                 else:

--- a/pycbc/inference/models/gated_gaussian_noise.py
+++ b/pycbc/inference/models/gated_gaussian_noise.py
@@ -65,7 +65,10 @@ class BaseGatedGaussian(BaseGaussianNoise):
                                                       False))
         self._cond = {}
         # cache inpainting options
-        self.paint_method = kwargs.get('paint-method', 'toeplitz')
+        paint_method = kwargs.get('paint_method')
+        if paint_method is None:
+            paint_method = kwargs.get('paint-method', 'toeplitz')
+        self.paint_method = paint_method
         self._cov_matrices = {}
         # cache samples and linear regression for determinant extrapolation
         self._cov_samples = {}
@@ -132,6 +135,9 @@ class BaseGatedGaussian(BaseGaussianNoise):
         self._invpsds.clear()
         self._invasds.clear()
         self._gated_data.clear()
+        self._cov_matrices.clear()
+        self._cov_samples.clear()
+        self._cov_regressions.clear()
         # store the psds
         for det, d in self._data.items():
             if psds is None:

--- a/pycbc/strain/gate.py
+++ b/pycbc/strain/gate.py
@@ -142,7 +142,7 @@ def add_gate_option_group(parser):
 
 
 def gate_and_paint(data, lindex, rindex, invpsd, copy=True):
-    """Gates and in-paints data.
+    """Gates and in-paints data using a Toeplitz solver.
 
     Parameters
     ----------
@@ -176,5 +176,66 @@ def gate_and_paint(data, lindex, rindex, invpsd, copy=True):
     # remove the projection into the null space
     proj = linalg.solve_toeplitz(tdfilter[:(rindex - lindex)],
                                  owhgated_data[lindex:rindex])
+    data[lindex:rindex] -= proj
+    return data
+
+def invert_covariance(invpsd, lindex, rindex):
+    """Calculate the uninverted covariance matrix.
+    Parameters
+    ----------
+    invpsd : FrequencySeries
+        The inverse of the PSD.
+    lindex : int
+        The start index of the gate.
+    rindex : int
+        The end index of the gate.
+
+    Returns
+    -------
+    array :
+        The uninverted covariance matrix associated with the inverse PSD in the
+        time window [lindex, rindex].
+    """
+    tdfilter = invpsd.astype('complex').to_timeseries() * invpsd.delta_t
+    mat = linalg.toeplitz(tdfilter[:(rindex-lindex)])
+    invmat = linalg.inv(mat)
+    return invmat
+
+def gate_and_paint_matmul(data, lindex, rindex, invpsd, invmat=None, copy=True):
+    """Gates and in-paints data using explicit matrix multiplication.
+
+    Parameters
+    ----------
+    data : TimeSeries
+        The data to gate.
+    lindex : int
+        The start index of the gate.
+    rindex : int
+        The end index of the gate.
+    invpsd : FrequencySeries
+        The inverse of the PSD.
+    invmat : array, optional
+        The uninverted covariance matrix. If None, calculate on function call.
+    copy : bool, optional
+        Copy the data before applying the gate. Otherwise, the gate will
+        be applied in-place. Default is True.
+    
+    Returns
+    -------
+    TimeSeries :
+        The gated and in-painted time series.
+    """
+    if copy:
+        data = data.copy()
+    data[lindex:rindex] = 0
+    # get the over-whitened gated data
+    owhgated_data = (data.to_frequencyseries() * invpsd).to_timeseries()
+
+    # invert the matrix if not provided
+    if invmat is None:
+        invmat = invert_covariance(invpsd, lindex, rindex)
+
+    # remove the projection into the null space
+    proj = invmat @ owhgated_data[lindex:rindex]
     data[lindex:rindex] -= proj
     return data

--- a/pycbc/types/timeseries.py
+++ b/pycbc/types/timeseries.py
@@ -673,7 +673,8 @@ class TimeSeries(Array):
         return lindex, rindex
 
     def gate(self, time, window=0.25, method='taper', copy=True,
-             taper_width=0.25, invpsd=None):
+             taper_width=0.25, invpsd=None, paint_method='toeplitz',
+             paint_invmat=None):
         """ Gate out portion of time series
 
         Parameters
@@ -693,6 +694,14 @@ class TimeSeries(Array):
         invpsd: pycbc.types.FrequencySeries
             The inverse PSD to use for painting method. If not given,
             a PSD is generated using default settings.
+        paint_method: str
+            Which method to use for inpainting the gated region if
+            method='paint'. If 'toeplitz', use a Toeplitz solver. If 'matmul',
+            use explicit matrix inversion and multiplication.
+        paint_invmat: array
+            The uninverted covariance matrix to use to calculate inpainting if
+            paint_method='matmul'. If None (default), calculate from given
+            invpsd.
 
         Returns
         -------
@@ -706,7 +715,8 @@ class TimeSeries(Array):
         elif method == 'paint':
             # Uses the hole-filling method of
             # https://arxiv.org/pdf/1908.05644.pdf
-            from pycbc.strain.gate import gate_and_paint
+            from pycbc.strain.gate import (gate_and_paint, 
+                                           gate_and_paint_matmul)
             from pycbc.waveform.utils import apply_fd_time_shift
             if invpsd is None:
                 # These are some bare minimum settings, normally you
@@ -716,14 +726,27 @@ class TimeSeries(Array):
             rindex_time = float(self.start_time + rindex * self.delta_t)
             offset = rindex_time - (time + window)
             if offset == 0:
-                return gate_and_paint(data, lindex, rindex, invpsd, copy=False)
+                print(paint_method)
+                if paint_method == 'toeplitz':
+                    return gate_and_paint(data, lindex, rindex, invpsd, copy=False)
+                elif paint_method == 'matmul':
+                    return gate_and_paint_matmul(data, lindex, rindex, invpsd,
+                                                 invmat=paint_invmat, copy=False)
+                else:
+                    raise ValueError(f'Unrecognized paint_method input {paint_method}')
             else:
                 # time shift such that gate end time lands on a specific data sample
                 fdata = data.to_frequencyseries()
                 fdata = apply_fd_time_shift(fdata, offset + fdata.epoch, copy=False)
                 # gate and paint in time domain
                 data = fdata.to_timeseries()
-                data = gate_and_paint(data, lindex, rindex, invpsd, copy=False)
+                if paint_method == 'toeplitz':
+                    data = gate_and_paint(data, lindex, rindex, invpsd, copy=False)
+                elif paint_method == 'matmul':
+                    data = gate_and_paint_matmul(data, lindex, rindex, invpsd,
+                                                 invmat=paint_invmat, copy=False)
+                else:
+                    raise ValueError(f'Unrecognized paint_method input {paint_method}')
                 # shift back to the original time
                 fdata = data.to_frequencyseries()
                 fdata = apply_fd_time_shift(fdata, -offset + fdata.epoch, copy=False)

--- a/pycbc/types/timeseries.py
+++ b/pycbc/types/timeseries.py
@@ -705,7 +705,7 @@ class TimeSeries(Array):
 
         Returns
         -------
-        data: pycbc.types.TimeSeris
+        data: pycbc.types.TimeSeries
             Gated time series
         """
         data = self.copy() if copy else self
@@ -726,7 +726,6 @@ class TimeSeries(Array):
             rindex_time = float(self.start_time + rindex * self.delta_t)
             offset = rindex_time - (time + window)
             if offset == 0:
-                print(paint_method)
                 if paint_method == 'toeplitz':
                     return gate_and_paint(data, lindex, rindex, invpsd, copy=False)
                 elif paint_method == 'matmul':


### PR DESCRIPTION
This PR adds the option to explicitly invert the inverse covariance matrix when gating and inpainting in place of the Toeplitz solver.

## Standard information about the request

This is a new feature that affects the gating code. Default behavior should be preserved; activating the option should give the exact same results as the default (albeit with improved performance).

## Motivation
The dominant cost in gated model likelihood calculations is the Toeplitz solver, which is complexity O(n^2) (n being the sample length of the gate). We found that solving the inpainting equation by explicitly multiplying by the uninverted covariance matrix is at least an order of magnitude faster than an equivalent Toeplitz solver call. So, provided we evaluate the inverse and cache to memory, this method should significantly speed up PE with the gated models.

## Contents
Two new functions are added to `pycbc.strain.gate` to allow for inversion of the inverse covariance matrix and inpainting using matrix multiplication. In the gated models (via `BaseGatedGaussian`), a model option `paint_method` is added. The default `toeplitz` uses the Toeplitz solver as we currently do. Specifying `matmul` calls the inversion function, inpaints using matrix multiplication when gating the data, and caches the result for each detector at the current gate length to memory. Subsequent calls with the same gate length instead call the matrices from memory for inpainting.

- [ x ] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
