### PR TITLE
Allow td-> fd automatic conversion more often, if taper settings are chosen

### DIFF
--- a/pycbc/types/timeseries.py
+++ b/pycbc/types/timeseries.py
@@ -19,18 +19,14 @@ Provides a class representing a time series.
 """
 import os as _os
 import h5py
-
-import numpy as _numpy
-from scipy.io.wavfile import write as write_wav
-
 from pycbc.types.array import Array, _convert, complex_same_precision_as, zeros
-from pycbc.types.utils import determine_epoch
 from pycbc.types.array import _nocomplex
 from pycbc.types.frequencyseries import FrequencySeries
 from pycbc.types import float32, float64
-from pycbc.libutils import import_optional
+import lal as _lal
+import numpy as _numpy
+from scipy.io.wavfile import write as write_wav
 
-_lal = import_optional('lal')
 
 class TimeSeries(Array):
     """Models a time series consisting of uniformly sampled scalar values.
@@ -50,7 +46,7 @@ class TimeSeries(Array):
     """
 
     def __init__(self, initial_array, delta_t=None,
-                 epoch="", dtype=None, copy=True):
+                 epoch=None, dtype=None, copy=True):
         if len(initial_array) < 1:
             raise ValueError('initial_array must contain at least one sample.')
         if delta_t is None:
@@ -61,10 +57,23 @@ class TimeSeries(Array):
         if not delta_t > 0:
             raise ValueError('delta_t must be a positive number')
 
-        self._epoch = determine_epoch(epoch, initial_array)
-
+        # Get epoch from initial_array if epoch not given (or is None)
+        # If initialy array has no epoch, set epoch to 0.
+        # If epoch is provided, use that.
+        if not isinstance(epoch, _lal.LIGOTimeGPS):
+            if epoch is None:
+                if isinstance(initial_array, TimeSeries):
+                    epoch = initial_array._epoch
+                else:
+                    epoch = _lal.LIGOTimeGPS(0)
+            elif epoch is not None:
+                try:
+                    epoch = _lal.LIGOTimeGPS(epoch)
+                except:
+                    raise TypeError('epoch must be either None or a lal.LIGOTimeGPS')
         Array.__init__(self, initial_array, dtype=dtype, copy=copy)
         self._delta_t = delta_t
+        self._epoch = epoch
 
     def to_astropy(self, name='pycbc'):
         """ Return an astropy.timeseries.TimeSeries instance
@@ -82,8 +91,6 @@ class TimeSeries(Array):
 
     def epoch_close(self, other):
         """ Check if the epoch is close enough to allow operations """
-        if self._epoch is None or other._epoch is None:
-            return False
         dt = abs(float(self.start_time - other.start_time))
         return dt <= 1e-7
 
@@ -118,8 +125,8 @@ class TimeSeries(Array):
                     self.start_time, other.start_time))
 
     def _getslice(self, index):
-        # Set the new epoch - index.start or self._epoch may be None
-        if index.start is None or self._epoch is None:
+        # Set the new epoch---note that index.start may also be None
+        if index.start is None:
             new_epoch = self._epoch
         else:
             if index.start < 0:
@@ -208,7 +215,7 @@ class TimeSeries(Array):
 
     @property
     def start_time(self):
-        """Return time series start time.
+        """Return time series start time as a LIGOTimeGPS.
         """
         return self._epoch
 
@@ -216,14 +223,14 @@ class TimeSeries(Array):
     def start_time(self, time):
         """ Set the start time
         """
-        self._epoch = float64(time)
+        self._epoch = _lal.LIGOTimeGPS(time)
 
     def get_end_time(self):
-        """Return time series end time.
+        """Return time series end time as a LIGOTimeGPS.
         """
         return self._epoch + self.get_duration()
     end_time = property(get_end_time,
-                        doc="Time series end time.")
+                        doc="Time series end time as a LIGOTimeGPS.")
 
     def get_sample_times(self):
         """Return an Array containing the sample times.
@@ -476,7 +483,7 @@ class TimeSeries(Array):
             LAL time series object containing the same data as self.
             The actual type depends on the sample's dtype.  If the epoch of
             self is 'None', the epoch of the returned LAL object will be
-            LIGOTimeGPS(0,0);
+            LIGOTimeGPS(0,0); otherwise, the same as that of self.
 
         Raises
         ------
@@ -484,7 +491,7 @@ class TimeSeries(Array):
             If time series is stored in GPU memory.
         """
         lal_data = None
-        ep = _lal.LIGOTimeGPS(self._epoch)
+        ep = self._epoch
 
         if self._data.dtype == _numpy.float32:
             lal_data = _lal.CreateREAL4TimeSeries("",ep,0,self.delta_t,_lal.SecondUnit,len(self))
@@ -584,6 +591,12 @@ class TimeSeries(Array):
             PyCBC time series.
         """
         import lalsimulation as sim
+        
+        if hasattr(location, 'decode'):
+            location = location.decode()
+            
+        if hasattr(tapermethod, 'decode'):
+            tapermethod = tapermethod.decode()
 
         taper_map = {
             'TAPER_NONE'    : None,
@@ -599,7 +612,7 @@ class TimeSeries(Array):
             _numpy.dtype(float64): sim.SimInspiralREAL8WaveTaper}
 
         tsdata = self
-
+        
         if location is None:
             raise ValueError("Must specify a tapering method (function was called"
                             "with location=None)")

--- a/pycbc/types/timeseries.py
+++ b/pycbc/types/timeseries.py
@@ -19,14 +19,18 @@ Provides a class representing a time series.
 """
 import os as _os
 import h5py
-from pycbc.types.array import Array, _convert, complex_same_precision_as, zeros
-from pycbc.types.array import _nocomplex
-from pycbc.types.frequencyseries import FrequencySeries
-from pycbc.types import float32, float64
-import lal as _lal
+
 import numpy as _numpy
 from scipy.io.wavfile import write as write_wav
 
+from pycbc.types.array import Array, _convert, complex_same_precision_as, zeros
+from pycbc.types.utils import determine_epoch
+from pycbc.types.array import _nocomplex
+from pycbc.types.frequencyseries import FrequencySeries
+from pycbc.types import float32, float64
+from pycbc.libutils import import_optional
+
+_lal = import_optional('lal')
 
 class TimeSeries(Array):
     """Models a time series consisting of uniformly sampled scalar values.
@@ -46,7 +50,7 @@ class TimeSeries(Array):
     """
 
     def __init__(self, initial_array, delta_t=None,
-                 epoch=None, dtype=None, copy=True):
+                 epoch="", dtype=None, copy=True):
         if len(initial_array) < 1:
             raise ValueError('initial_array must contain at least one sample.')
         if delta_t is None:
@@ -57,20 +61,7 @@ class TimeSeries(Array):
         if not delta_t > 0:
             raise ValueError('delta_t must be a positive number')
 
-        # Get epoch from initial_array if epoch not given (or is None)
-        # If initialy array has no epoch, set epoch to 0.
-        # If epoch is provided, use that.
-        if not isinstance(epoch, _lal.LIGOTimeGPS):
-            if epoch is None:
-                if isinstance(initial_array, TimeSeries):
-                    epoch = initial_array._epoch
-                else:
-                    epoch = _lal.LIGOTimeGPS(0)
-            elif epoch is not None:
-                try:
-                    epoch = _lal.LIGOTimeGPS(epoch)
-                except:
-                    raise TypeError('epoch must be either None or a lal.LIGOTimeGPS')
+        self._epoch = determine_epoch(epoch, initial_array)
         Array.__init__(self, initial_array, dtype=dtype, copy=copy)
         self._delta_t = delta_t
         self._epoch = epoch
@@ -91,6 +82,8 @@ class TimeSeries(Array):
 
     def epoch_close(self, other):
         """ Check if the epoch is close enough to allow operations """
+        if self._epoch is None or other._epoch is None:
+                    return False
         dt = abs(float(self.start_time - other.start_time))
         return dt <= 1e-7
 
@@ -125,8 +118,8 @@ class TimeSeries(Array):
                     self.start_time, other.start_time))
 
     def _getslice(self, index):
-        # Set the new epoch---note that index.start may also be None
-        if index.start is None:
+        # Set the new epoch - index.start or self._epoch may be None
+        if index.start is None or self._epoch is None:
             new_epoch = self._epoch
         else:
             if index.start < 0:
@@ -209,7 +202,7 @@ class TimeSeries(Array):
 
     @property
     def delta_f(self):
-        """Return the delta_f this ts would have in the frequency domain
+        """Return time series start time.
         """
         return 1.0 / self.duration
 
@@ -223,14 +216,14 @@ class TimeSeries(Array):
     def start_time(self, time):
         """ Set the start time
         """
-        self._epoch = _lal.LIGOTimeGPS(time)
+        self._epoch = float64(time)
 
     def get_end_time(self):
-        """Return time series end time as a LIGOTimeGPS.
+        """Return time series end time.
         """
         return self._epoch + self.get_duration()
     end_time = property(get_end_time,
-                        doc="Time series end time as a LIGOTimeGPS.")
+                        doc="Time series end time.")
 
     def get_sample_times(self):
         """Return an Array containing the sample times.
@@ -491,7 +484,7 @@ class TimeSeries(Array):
             If time series is stored in GPU memory.
         """
         lal_data = None
-        ep = self._epoch
+        ep = _lal.LIGOTimeGPS(self._epoch)
 
         if self._data.dtype == _numpy.float32:
             lal_data = _lal.CreateREAL4TimeSeries("",ep,0,self.delta_t,_lal.SecondUnit,len(self))

--- a/pycbc/types/timeseries.py
+++ b/pycbc/types/timeseries.py
@@ -64,7 +64,6 @@ class TimeSeries(Array):
         self._epoch = determine_epoch(epoch, initial_array)
         Array.__init__(self, initial_array, dtype=dtype, copy=copy)
         self._delta_t = delta_t
-        self._epoch = epoch
 
     def to_astropy(self, name='pycbc'):
         """ Return an astropy.timeseries.TimeSeries instance
@@ -83,7 +82,7 @@ class TimeSeries(Array):
     def epoch_close(self, other):
         """ Check if the epoch is close enough to allow operations """
         if self._epoch is None or other._epoch is None:
-                    return False
+            return False
         dt = abs(float(self.start_time - other.start_time))
         return dt <= 1e-7
 
@@ -202,13 +201,13 @@ class TimeSeries(Array):
 
     @property
     def delta_f(self):
-        """Return time series start time.
+        """Return the delta_f this ts would have in the frequency domain
         """
         return 1.0 / self.duration
 
     @property
     def start_time(self):
-        """Return time series start time as a LIGOTimeGPS.
+        """Return time series start time.
         """
         return self._epoch
 
@@ -476,7 +475,7 @@ class TimeSeries(Array):
             LAL time series object containing the same data as self.
             The actual type depends on the sample's dtype.  If the epoch of
             self is 'None', the epoch of the returned LAL object will be
-            LIGOTimeGPS(0,0); otherwise, the same as that of self.
+            the same as that of self.
 
         Raises
         ------
@@ -605,7 +604,7 @@ class TimeSeries(Array):
             _numpy.dtype(float64): sim.SimInspiralREAL8WaveTaper}
 
         tsdata = self
-        
+
         if location is None:
             raise ValueError("Must specify a tapering method (function was called"
                             "with location=None)")

--- a/pycbc/waveform/plugin.py
+++ b/pycbc/waveform/plugin.py
@@ -22,7 +22,8 @@ def add_custom_waveform(approximant, function, domain,
         Check if waveform generator has built-in detector response.
     """
     from pycbc.waveform.waveform import (cpu_fd, cpu_td, fd_sequence,
-                                         fd_det, fd_det_sequence)
+                                         fd_det, fd_det_sequence, 
+                                         td_fd_waveform_transform)
 
     used = RuntimeError("Can't load plugin waveform {}, the name is"
                         " already in use.".format(approximant))
@@ -31,6 +32,7 @@ def add_custom_waveform(approximant, function, domain,
         if not force and (approximant in cpu_td):
             raise used
         cpu_td[approximant] = function
+        td_fd_waveform_transform(approximant)
     elif domain == 'frequency':
         if sequence:
             if not has_det_response:

--- a/pycbc/waveform/plugin.py
+++ b/pycbc/waveform/plugin.py
@@ -22,7 +22,7 @@ def add_custom_waveform(approximant, function, domain,
         Check if waveform generator has built-in detector response.
     """
     from pycbc.waveform.waveform import (cpu_fd, cpu_td, fd_sequence,
-                                         fd_det, fd_det_sequence, 
+                                         fd_det, fd_det_sequence,
                                          td_fd_waveform_transform)
 
     used = RuntimeError("Can't load plugin waveform {}, the name is"

--- a/pycbc/waveform/waveform.py
+++ b/pycbc/waveform/waveform.py
@@ -719,8 +719,12 @@ def get_fd_waveform_from_td(**params):
         hp = wfutils.td_taper(hp, hp.start_time, hp.start_time + window)
         hc = wfutils.td_taper(hc, hc.start_time, hc.start_time + window)
     else:
-        hp = hp.taper_timeseries(location=params['taper'], tapermethod=params['taper_method'], taper_window=params['taper_window'])
-        hc = hc.taper_timeseries(location=params['taper'], tapermethod=params['taper_method'], taper_window=params['taper_window'])
+        hp = hp.taper_timeseries(location=params['taper'],
+                                 tapermethod=params['taper_method'],
+                                 taper_window=params['taper_window'])
+        hc = hc.taper_timeseries(location=params['taper'],
+                                 tapermethod=params['taper_method'],
+                                 taper_window=params['taper_window'])
 
     # avoid wraparound
     hp = hp.to_frequencyseries().cyclic_time_shift(hp.start_time)

--- a/pycbc/waveform/waveform.py
+++ b/pycbc/waveform/waveform.py
@@ -685,8 +685,8 @@ def get_fd_waveform_from_td(**params):
             full_duration = get_waveform_filter_length_in_time(**nparams)
             nparams['f_lower'] -= 1
 
-    if 'f_fref' not in nparams:
-        nparams['f_ref'] = params['f_lower']
+    if 'f_ref' not in nparams and 'f_lower' in nparams:
+        nparams['f_ref'] = nparams['f_lower']
 
     # We'll try to do the right thing and figure out what the frequency
     # end is. Otherwise, we'll just assume 2048 Hz.

--- a/pycbc/waveform/waveform.py
+++ b/pycbc/waveform/waveform.py
@@ -714,7 +714,7 @@ def get_fd_waveform_from_td(**params):
 
     if not 'taper_method' in params:
         # apply the tapering, we will use a safety factor here to allow for
-        # somewhat innacurate duration difference estimation.
+        # somewhat inaccurate duration difference estimation.
         window = (full_duration - duration) * 0.8
         hp = wfutils.td_taper(hp, hp.start_time, hp.start_time + window)
         hc = wfutils.td_taper(hc, hc.start_time, hc.start_time + window)

--- a/pycbc/waveform/waveform.py
+++ b/pycbc/waveform/waveform.py
@@ -27,7 +27,7 @@ waveforms.
 """
 
 import os
-import lal, numpy, copy
+import lal, numpy
 from pycbc.types import TimeSeries, FrequencySeries, zeros, Array
 from pycbc.types import real_same_precision_as, complex_same_precision_as
 import pycbc.scheme as _scheme

--- a/pycbc/waveform/waveform.py
+++ b/pycbc/waveform/waveform.py
@@ -674,14 +674,16 @@ def get_fd_waveform_from_td(**params):
     hc: pycbc.types.FrequencySeries
         Cross polarization time series
     """
-
-    # determine the duration to use
-    full_duration = duration = get_waveform_filter_length_in_time(**params)
     nparams = params.copy()
+    if not 'taper_method' in params:
+        # determine the duration to use for an automatic tapering choice.
+        # If taper method specified, assume they have set f_lower as they
+        # want exactly.
+        full_duration = duration = get_waveform_filter_length_in_time(**params)
 
-    while full_duration < duration * 1.5:
-        full_duration = get_waveform_filter_length_in_time(**nparams)
-        nparams['f_lower'] -= 1
+        while full_duration < duration * 1.5:
+            full_duration = get_waveform_filter_length_in_time(**nparams)
+            nparams['f_lower'] -= 1
 
     if 'f_fref' not in nparams:
         nparams['f_ref'] = params['f_lower']
@@ -710,11 +712,15 @@ def get_fd_waveform_from_td(**params):
     hp.resize(tsamples)
     hc.resize(tsamples)
 
-    # apply the tapering, we will use a safety factor here to allow for
-    # somewhat innacurate duration difference estimation.
-    window = (full_duration - duration) * 0.8
-    hp = wfutils.td_taper(hp, hp.start_time, hp.start_time + window)
-    hc = wfutils.td_taper(hc, hc.start_time, hc.start_time + window)
+    if not 'taper_method' in params:
+        # apply the tapering, we will use a safety factor here to allow for
+        # somewhat innacurate duration difference estimation.
+        window = (full_duration - duration) * 0.8
+        hp = wfutils.td_taper(hp, hp.start_time, hp.start_time + window)
+        hc = wfutils.td_taper(hc, hc.start_time, hc.start_time + window)
+    else:
+        hp = hp.taper_timeseries(location=params['taper'], tapermethod=params['taper_method'], taper_window=params['taper_window'])
+        hc = hc.taper_timeseries(location=params['taper'], tapermethod=params['taper_method'], taper_window=params['taper_window'])
 
     # avoid wraparound
     hp = hp.to_frequencyseries().cyclic_time_shift(hp.start_time)
@@ -1158,7 +1164,7 @@ def td_fd_waveform_transform(approximant):
         # We can make a fd version of td approximants
         cpu_fd[approximant] = get_fd_waveform_from_td
 
-    if approximant in fd_apx:
+    if approximant in fd_apx and (approximant in _filter_time_lengths):
         # We can do interpolation for waveforms that have a time length
         apx_int = approximant + '_INTERP'
         cpu_fd[apx_int] = get_interpolated_fd_waveform
@@ -1169,9 +1175,8 @@ def td_fd_waveform_transform(approximant):
         # (ex. IMRPhenomXX)
         cpu_td[approximant] = get_td_waveform_from_fd
 
-for apx in copy.copy(_filter_time_lengths):
+for apx in list(_filter_time_lengths.keys()) + list(cpu_fd.keys()):
     td_fd_waveform_transform(apx)
-
 
 td_wav = _scheme.ChooseBySchemeDict()
 fd_wav = _scheme.ChooseBySchemeDict()


### PR DESCRIPTION
<!---
Please delete these comments when you submit the pull request

Please add a title which is a concise description of what you are doing,
e.g. 'Fix bug with numpy import in pycbc_coinc_findtrigs' or 'add high frequency sky location dependent response for long detectors'
-->

<!---
This is a brief template for making pull requests for PyCBC.
This is _not_ a proscriptive template - you can use a different style if you want.
Please do think about the questions posed here and whether the details will be useful to include in your PR
Please add sufficient details so that people looking back at the request with no context around the work can understand the changes.
To choose reviewers, please look at the git blame for the code you are changing (if applicable),
or discuss in the #pycbc-code channel of the gwastro slack.
Please add labels as appropriate
-->

<!-- TOP-LEVEL SUMMARY: Please provide a brief, one-or-two-sentence description of the PR here
-->

## Standard information about the request

<!--- Some basic info about the change (delete as appropriate) -->
This is a new feature

<!--- What codes will this affect? (delete as apropriate)
This is largely backwards compatible, but enables more td-> fd conversions when possible.

<!--- What code areas will this affect? (delete as apropriate) -->
Available waveforms through get_fd_waveform

<!--- Some things which help with code management (delete as appropriate) -->
This change: has appropriate unit tests, follows style guidelines (See e.g. [PEP8](https://peps.python.org/pep-0008/)), has been proposed using the [contribution guidelines](https://github.com/gwastro/pycbc/blob/master/CONTRIBUTING.md)

## Motivation

This allow additional waveforms to work through the get_fd_waveform interface that are auto-converted from td waveforms. This makes additional approximants functional for codes that expect or require this interface.

## Contents

Currently, td-> fd conversion only occurs under certain conditions, e.g. a valid length estimator. However, this enables td-> fd conversion to work where this is not available and the user manually sets the tapering options. 

If you explicilty set the 'taper method' option it will apply the taper as directed and proceed with the conversion. Otherwise, it will use the existing logic which requires the existence of a length estimator to determine the tapering settings. 

## Links to any issues or associated PRs
<!--- If this is fixing / working around an already-reported issue, please link to it here -->

## Testing performed
<!--- Describe tests for the code changes, either already performed or to be performed -->

## Additional notes
<!--- Anything which does not fit in the above sections -->

- [X] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
