### PR TITLE
Fixing pygrb coincidences

### DIFF
--- a/bin/pycbc_multi_inspiral
+++ b/bin/pycbc_multi_inspiral
@@ -638,7 +638,7 @@ with ctx:
     # Loop over templates
     for t_num, template in enumerate(bank):
         # Loop over segments
-        for s_num in range(len(segments[args.instruments[0]]))
+        for s_num in range(len(segments[args.instruments[0]])):
             stilde = {ifo: segments[ifo][s_num] for ifo in args.instruments}
             # Checks the 'inj_filter_rejector' options to determine whether
             # to filter this template/segment if injections are present

--- a/bin/pycbc_multi_inspiral
+++ b/bin/pycbc_multi_inspiral
@@ -638,7 +638,7 @@ with ctx:
     # Loop over templates
     for t_num, template in enumerate(bank):
         # Loop over segments
-        for s_num, segment_ifo0 in enumerate(segments[args.instruments[0]]):
+        for s_num in range(len(segments[args.instruments[0]]))
             stilde = {ifo: segments[ifo][s_num] for ifo in args.instruments}
             # Checks the 'inj_filter_rejector' options to determine whether
             # to filter this template/segment if injections are present

--- a/bin/pycbc_multi_inspiral
+++ b/bin/pycbc_multi_inspiral
@@ -638,7 +638,7 @@ with ctx:
     # Loop over templates
     for t_num, template in enumerate(bank):
         # Loop over segments
-        for s_num, stilde in enumerate(segments[args.instruments[0]]):
+        for s_num, segment_ifo0 in enumerate(segments[args.instruments[0]]):
             stilde = {ifo: segments[ifo][s_num] for ifo in args.instruments}
             # Checks the 'inj_filter_rejector' options to determine whether
             # to filter this template/segment if injections are present
@@ -694,6 +694,8 @@ with ctx:
             #   Typically only a tiny fraction will be populated.
             power_chisq_arrays = dict.fromkeys(args.instruments)
             power_chisq_dof_arrays = dict.fromkeys(args.instruments)
+            # For convenience also store the lengths of the snr_dict values
+            wraparound_dict = dict.fromkeys(args.instruments)
             for ifo in args.instruments:
                 logging.debug(
                     "Filtering template %d/%d, ifo %s", t_num + 1, n_bank, ifo
@@ -725,8 +727,9 @@ with ctx:
                 snr_dict[ifo] = (
                     snr_ts[matched_filter[ifo].segments[s_num].analyze] * norm
                 )
+                wraparound_dict[ifo] = len(snr_dict[ifo])
                 assert (
-                    len(snr_dict[ifo]) > 0
+                    wraparound_dict[ifo] > 0
                 ), f'SNR time series for {ifo} is empty'
                 norm_dict[ifo] = norm
                 corr_dict[ifo] = corr.copy()
@@ -734,10 +737,10 @@ with ctx:
                 snr[ifo] = snrv * norm
                 # Initialize the cache for power chi^2
                 power_chisq_arrays[ifo] = np.full(
-                    len(snr_dict[ifo]), np.nan, dtype=np.float32
+                    wraparound_dict[ifo], np.nan, dtype=np.float32
                 )
                 power_chisq_dof_arrays[ifo] = np.zeros(
-                    len(snr_dict[ifo]), dtype=np.int32
+                    wraparound_dict[ifo], dtype=np.int32
                 )
                 del snr_ts, norm, corr, ind, snrv
 
@@ -756,22 +759,37 @@ with ctx:
                         position_index + 1,
                         len(sky_positions),
                     )
-                    # Adjust the indices of triggers (if there are any)
-                    # and store trigger indices list in a dictionary;
-                    # when there are no triggers, the dictionary is empty.
-                    # Indices are kept only if they do not get time shifted
-                    # out of the time we are looking at, i.e., require
+                    # Adjust the indices of triggers (if there are any) and
+                    # store trigger indices list in a dictionary; when there
+                    # are no triggers, the dictionary is empty. Indices are
+                    # kept only if they remain within the time being processed
+                    # after they time delay correction from detector to
+                    # geocenter due to sky location is applied, i.e., require
+                    # them to be between 0 and len(snr_dict[ifo]).
                     # idx[ifo] - time_delay_idx[slide][position_index][ifo]
+<<<<<<< HEAD
                     # (which applies the necessary time shift by operating on
                     # indices) to be between 0 and len(snr_dict[ifo]).
+=======
+                    # operates on indices to apply a time shift from detctor
+                    # to geocenter. The trimming here is carried out on the
+                    # zerolag indices, i.e., setting slide to 0, to ensure that
+                    # the starting indices are legitimate. Later, when looking
+                    # for coincidences, one must wrap around the timeslid
+                    # idx[ifo] - time_delay_idx[slide][position_index][ifo].
+>>>>>>> 6dfc2bf11 (Check bounds on zerolag indices; then slide, wraparound, and search for coincidences)
                     idx_dict = {
                         ifo: idx[ifo][
                             np.logical_and(
                                 idx[ifo]
+<<<<<<< HEAD
                                 > time_delay_idx[slide][position_index][ifo],
+=======
+                                > time_delay_idx[0][position_index][ifo],
+>>>>>>> 6dfc2bf11 (Check bounds on zerolag indices; then slide, wraparound, and search for coincidences)
                                 idx[ifo]
-                                < time_delay_idx[slide][position_index][ifo]
-                                + len(snr_dict[ifo]),
+                                < time_delay_idx[0][position_index][ifo]
+                                + wraparound_dict[ifo],
                             )
                         ]
                         for ifo in args.instruments
@@ -782,27 +800,30 @@ with ctx:
                     # and applies the single IFO SNR cut asking for triggers to
                     # have SNR >= args.sngl_snr_threshold in at least
                     # args.nifo_sngl_snr_threshold IFOs; recall that idx_dict
-                    # tracks (at the geocent) triggers above threshold in
+                    # tracks (at the detectors) triggers above threshold in
                     # individual detectors. If only one IFO is available, then
                     # the method returns trigger indices for that IFO. Given
                     # that we are looping over timeslides and sky positions,
                     # the appropriate dictionary of time delays wrt the
-                    # geocenter must be passed to operate at the geocenter.
+                    # geocenter must be passed to operate at the geocenter,
+                    # as well as the dictionary to enable the wrap around at
+                    # each detecotor prior to searching for coincidences.
                     coinc_idx = coh.get_coinc_indexes(
                         idx_dict, time_delay_idx[slide][position_index],
-                        args.nifo_sngl_snr_threshold
+                        args.nifo_sngl_snr_threshold, wraparound_dict
                     )
                     logging.debug(
                         "Found %d coincident triggers", len(coinc_idx)
                     )
-                    # Time delay is applied to indices at the geocenter to have
-                    # them at the IFOs (hence the + which undoes the delay).
+                    # Time delay is applied to (coincident) indices at the
+                    # geocenter to have them at the IFOs (hence the + which
+                    # undoes the delay). The wrap around is performed.
                     coinc_idx_det_frame = {
                         ifo: (
                             coinc_idx
                             + time_delay_idx[slide][position_index][ifo]
                         )
-                        % len(snr_dict[ifo])
+                        % wraparound_dict[ifo]
                         for ifo in args.instruments
                     }
                     # Calculate the quadrature sum of individual detector SNRs,
@@ -985,17 +1006,18 @@ with ctx:
                         # Updated coinc_idx_det_frame to account for the
                         # effect of the cuts applied so far (operate on the
                         # time related indices with a +time_delay_idx to
-                        # transform geocenter time to IFO time).
+                        # transform geocenter time to IFO time). The wrap
+                        # around is performed.
                         coinc_idx_det_frame = {
                             ifo: (
                                 coinc_idx
                                 + time_delay_idx[slide][position_index][ifo]
                             )
-                            % len(snr_dict[ifo])
+                            % wraparound_dict[ifo]
                             for ifo in args.instruments
                         }
                         # Build dictionary with per-IFO complex SNR time series
-                        # of the most recent set of triggers
+                        # of the most recent set of triggers.
                         coherent_ifo_trigs = {
                             ifo: snr_dict[ifo][coinc_idx_det_frame[ifo]]
                             for ifo in args.instruments
@@ -1076,6 +1098,7 @@ with ctx:
                                 stilde[ifo],
                                 coherent_ifo_trigs[ifo],
                                 1,  # coherent_ifo_trigs already normalized
+                                # FIXME: why not stilde[ifo].cumulative_index?
                                 coinc_idx_det_frame[ifo]
                                 + stilde[ifo].analyze.start,
                             )
@@ -1084,6 +1107,7 @@ with ctx:
                                 ifo_out_vals['auto_chisq_dof'],
                             ) = autochisq.values(
                                 snr_dict[ifo],
+                                # FIXME: why no + stilde[ifo]...?
                                 coinc_idx_det_frame[ifo],
                                 template,
                                 stilde[ifo].psd,
@@ -1122,8 +1146,11 @@ with ctx:
                         network_out_vals['my_network_chisq'] = np.real(
                             network_chisq_dict
                         )
+                        # coinc_idx has the geocenter indices of triggers.
+                        # The wrap around happened in get_coinc_indices.
                         network_out_vals['time_index'] = (
-                            coinc_idx + stilde[ifo].cumulative_index
+                            coinc_idx
+                            + stilde[args.instruments[0]].cumulative_index
                         )
                         network_out_vals['nifo'] = [nifo] * num_events
                         network_out_vals['dec'] = [

--- a/bin/pycbc_multi_inspiral
+++ b/bin/pycbc_multi_inspiral
@@ -767,26 +767,17 @@ with ctx:
                     # geocenter due to sky location is applied, i.e., require
                     # them to be between 0 and len(snr_dict[ifo]).
                     # idx[ifo] - time_delay_idx[slide][position_index][ifo]
-<<<<<<< HEAD
-                    # (which applies the necessary time shift by operating on
-                    # indices) to be between 0 and len(snr_dict[ifo]).
-=======
                     # operates on indices to apply a time shift from detctor
                     # to geocenter. The trimming here is carried out on the
                     # zerolag indices, i.e., setting slide to 0, to ensure that
                     # the starting indices are legitimate. Later, when looking
                     # for coincidences, one must wrap around the timeslid
                     # idx[ifo] - time_delay_idx[slide][position_index][ifo].
->>>>>>> 6dfc2bf11 (Check bounds on zerolag indices; then slide, wraparound, and search for coincidences)
                     idx_dict = {
                         ifo: idx[ifo][
                             np.logical_and(
                                 idx[ifo]
-<<<<<<< HEAD
-                                > time_delay_idx[slide][position_index][ifo],
-=======
                                 > time_delay_idx[0][position_index][ifo],
->>>>>>> 6dfc2bf11 (Check bounds on zerolag indices; then slide, wraparound, and search for coincidences)
                                 idx[ifo]
                                 < time_delay_idx[0][position_index][ifo]
                                 + wraparound_dict[ifo],

--- a/bin/pycbc_multi_inspiral
+++ b/bin/pycbc_multi_inspiral
@@ -763,7 +763,7 @@ with ctx:
                     # store trigger indices list in a dictionary; when there
                     # are no triggers, the dictionary is empty. Indices are
                     # kept only if they remain within the time being processed
-                    # after they time delay correction from detector to
+                    # after the time delay correction from detector to
                     # geocenter due to sky location is applied, i.e., require
                     # them to be between 0 and len(snr_dict[ifo]).
                     # idx[ifo] - time_delay_idx[slide][position_index][ifo]

--- a/bin/pycbc_multi_inspiral
+++ b/bin/pycbc_multi_inspiral
@@ -765,13 +765,14 @@ with ctx:
                     # kept only if they remain within the time being processed
                     # after the time delay correction from detector to
                     # geocenter due to sky location is applied, i.e., require
-                    # them to be between 0 and len(snr_dict[ifo]).
+                    # them to be between 0 and len(snr_dict[ifo]). In general
                     # idx[ifo] - time_delay_idx[slide][position_index][ifo]
                     # operates on indices to apply a time shift from detctor
-                    # to geocenter. The trimming here is carried out on the
-                    # zerolag indices, i.e., setting slide to 0, to ensure that
-                    # the starting indices are legitimate. Later, when looking
-                    # for coincidences, one must wrap around the timeslid
+                    # to geocenter at a given timeslide. The trimming carried
+                    # out here to ensure that the starting indices are
+                    # legitimate is on the zerolag indices, i.e., the keyword
+                    # slide is set to 0. Later, when looking for coincidences,
+                    # one must wrap around the appropriate timeslid
                     # idx[ifo] - time_delay_idx[slide][position_index][ifo].
                     idx_dict = {
                         ifo: idx[ifo][

--- a/bin/pycbc_multi_inspiral
+++ b/bin/pycbc_multi_inspiral
@@ -798,7 +798,7 @@ with ctx:
                     # the appropriate dictionary of time delays wrt the
                     # geocenter must be passed to operate at the geocenter,
                     # as well as the dictionary to enable the wrap around at
-                    # each detecotor prior to searching for coincidences.
+                    # each detector prior to searching for coincidences.
                     coinc_idx = coh.get_coinc_indexes(
                         idx_dict, time_delay_idx[slide][position_index],
                         args.nifo_sngl_snr_threshold, wraparound_dict

--- a/bin/pycbc_multi_inspiral
+++ b/bin/pycbc_multi_inspiral
@@ -1089,7 +1089,6 @@ with ctx:
                                 stilde[ifo],
                                 coherent_ifo_trigs[ifo],
                                 1,  # coherent_ifo_trigs already normalized
-                                # FIXME: why not stilde[ifo].cumulative_index?
                                 coinc_idx_det_frame[ifo]
                                 + stilde[ifo].analyze.start,
                             )
@@ -1098,7 +1097,6 @@ with ctx:
                                 ifo_out_vals['auto_chisq_dof'],
                             ) = autochisq.values(
                                 snr_dict[ifo],
-                                # FIXME: why no + stilde[ifo]...?
                                 coinc_idx_det_frame[ifo],
                                 template,
                                 stilde[ifo].psd,

--- a/pycbc/events/coherent.py
+++ b/pycbc/events/coherent.py
@@ -32,7 +32,7 @@ from .eventmgr_cython import get_coinc_indexes_cython_twodet_twocoinc
 logger = logging.getLogger('pycbc.events.coherent')
 
 
-def get_coinc_indexes(idx_dict, time_delay_idx, min_nifos):
+def get_coinc_indexes(idx_dict, time_delay_idx, min_nifos, wraparound_dict):
     """Return the indexes corresponding to coincident triggers. If only one
     detector is available in the network, the list of its unique indexes is
     simply returned.
@@ -48,6 +48,8 @@ def get_coinc_indexes(idx_dict, time_delay_idx, min_nifos):
     min_nifos: int
         The minimum number of detectors needed to be above threshold
         for a coincidence to be produced
+    wraparound_dict: dict
+        The length at which indices (at the detector) must be wrapped around
 
     Returns
     -------
@@ -71,6 +73,8 @@ def get_coinc_indexes(idx_dict, time_delay_idx, min_nifos):
             idxarr2,
             time_delay_idx[ifos[0]],
             time_delay_idx[ifos[1]],
+            wraparound_dict[ifos[0]],
+            wraparound_dict[ifos[1]],
             outarr
         )
         return outarr[:num_idxs]
@@ -78,11 +82,15 @@ def get_coinc_indexes(idx_dict, time_delay_idx, min_nifos):
     for ifo in idx_dict.keys():
         # Create list of indexes above single detector threshold, in geocent
         # time (-time_delay_idx[ifo] applies the time delay for the specific
-        # detector). This can be searched later for triggers appearing in
-        # multiple detectors.
+        # detector). The periodic boundary condition of time slides is
+        # enforced by wrapping around the index list of each detector. This
+        # collective list will later be searched for repeating index values as
+        # these represent triggers appearing in multiple detectors.
+        # SHOULD IT BE idx_dict[ifo] % wraparound_dict[ifo] THEN ENFORCING
+        # 0 <= WRAPPED INDEX - time_delay_idx[ifo] < wraparound_dict[ifo]?
         if len(idx_dict[ifo]) != 0:
             coinc_list = np.hstack(
-                [coinc_list, idx_dict[ifo] - time_delay_idx[ifo]]
+                [coinc_list, (idx_dict[ifo] - time_delay_idx[ifo]) % wraparound_dict[ifo]]
             )
     # Search through coinc_idx for repeated indexes. These must have been loud
     # in at least min_nifos detectors if the analysis uses more than 1

--- a/pycbc/events/coherent.py
+++ b/pycbc/events/coherent.py
@@ -86,8 +86,6 @@ def get_coinc_indexes(idx_dict, time_delay_idx, min_nifos, wraparound_dict):
         # enforced by wrapping around the index list of each detector. This
         # collective list will later be searched for repeating index values as
         # these represent triggers appearing in multiple detectors.
-        # SHOULD IT BE idx_dict[ifo] % wraparound_dict[ifo] THEN ENFORCING
-        # 0 <= WRAPPED INDEX - time_delay_idx[ifo] < wraparound_dict[ifo]?
         if len(idx_dict[ifo]) != 0:
             coinc_list = np.hstack(
                 [coinc_list, (idx_dict[ifo] - time_delay_idx[ifo]) % wraparound_dict[ifo]]

--- a/pycbc/events/eventmgr_cython.pyx
+++ b/pycbc/events/eventmgr_cython.pyx
@@ -314,7 +314,7 @@ ctypedef fused numeric_type:
 
 @boundscheck(False)
 @wraparound(False)
-@cdivision(True)
+@cdivision(False) # Needed to emulate Python behaviour of % operator
 def get_coinc_indexes_cython_twodet_twocoinc(
     numeric_type [::1] idxarr1,
     numeric_type [::1] idxarr2,
@@ -332,17 +332,15 @@ def get_coinc_indexes_cython_twodet_twocoinc(
     cdef numeric_type cpos1
     cdef numeric_type cpos2
 
-    while arr1pos < arr1_size and arr2pos < arr2_size:
+    while arr1pos < arr1_size:
         cpos1 = (idxarr1[arr1pos] - offset1) % wraparound1
-        cpos2 = (idxarr2[arr2pos] - offset2) % wraparound2
-        if cpos1 == cpos2:
-            outputs[outpos] = cpos1
-            outpos += 1
-            arr1pos += 1
+        while arr2pos < arr2_size:
+            cpos2 = (idxarr2[arr2pos] - offset2) % wraparound2
+            if cpos1 == cpos2:
+                outputs[outpos] = cpos1
+                outpos += 1
             arr2pos += 1
-        elif cpos1 < cpos2:
-            arr1pos += 1
-        else:
-            arr2pos += 1
+        arr2pos = 0
+        arr1pos += 1
     return outpos
 

--- a/pycbc/events/eventmgr_cython.pyx
+++ b/pycbc/events/eventmgr_cython.pyx
@@ -320,6 +320,8 @@ def get_coinc_indexes_cython_twodet_twocoinc(
     numeric_type [::1] idxarr2,
     numeric_type offset1,
     numeric_type offset2,
+    numeric_type wraparound1,
+    numeric_type wraparound2,
     numeric_type [::1] outputs
 ):
     cdef Py_ssize_t arr1pos = 0
@@ -331,8 +333,8 @@ def get_coinc_indexes_cython_twodet_twocoinc(
     cdef numeric_type cpos2
 
     while arr1pos < arr1_size and arr2pos < arr2_size:
-        cpos1 = idxarr1[arr1pos] - offset1
-        cpos2 = idxarr2[arr2pos] - offset2
+        cpos1 = (idxarr1[arr1pos] - offset1) % wraparound1
+        cpos2 = (idxarr2[arr2pos] - offset2) % wraparound2
         if cpos1 == cpos2:
             outputs[outpos] = cpos1
             outpos += 1

--- a/pycbc/events/eventmgr_cython.pyx
+++ b/pycbc/events/eventmgr_cython.pyx
@@ -314,7 +314,7 @@ ctypedef fused numeric_type:
 
 @boundscheck(False)
 @wraparound(False)
-@cdivision(False) # Needed to emulate Python behaviour of % operator
+@cdivision(False) # Ensure the behaviour of the Python % operator is emulated
 def get_coinc_indexes_cython_twodet_twocoinc(
     numeric_type [::1] idxarr1,
     numeric_type [::1] idxarr2,


### PR DESCRIPTION
Fix incomplete and buggy handling of slides in looking for coincidence within PyGRB.

## Standard information about the request

This is a: bug fix.

This change affects: the PyGRB background.

This change changes: scientific output

## Motivation
It was noticed that the PyGRB timeslides contain fewer and fewer triggers as the sliding progresses.  When plotted as a function of time, the triggers in the slides were showing gaps that widened with sliding.  Here is a plot of trigger times and slide IDs.

[time_index_vs_slide_id_skygrid.pdf](https://github.com/user-attachments/files/28021403/time_index_vs_slide_id_skygrid.pdf)

## Contents
This needs a fix on two levels as far as I can tell.

1. `pycbc_multi_inspiral` has the `time_delay_idx` dictionary to store the indexing "corrections" needed at a given slide, sky position and detector to convert indices from geocenter to detector or vice versa.  `pycbc_multi_inspiral` checks that the indices, after correction, are in a meaningful range.  However, this is designed thinking of detector-geocenter zerolag delay, while `time_delay_idx` is also going to shift things according to the slide.  Effectively, this does the correct trimming for the first IFO (typically H1), but as the others are timeslid it drops triggers.  The first part of the fix is to perform this check  on `slide=0` (zerolag) so that only index+skyposition combinations that do not suit our purposes are thrown away.

2. At this point the indices may be slid AND wrapped around so that `get_coinc_indices` can convert them to geocenter and look for repeated indices.  In the current implementation we are looking for repeated indices without a wraparound, so coincidences are lost.  The second part of the fix carries out the wrap around in a consistent way.  This is done also in the cythonized function for the 2 IFO case.

In summary, the current implementation throws away too many triggers prior when searching for coincidences and then loses coincidences by not wrapping around time slides.  After the fix, there are no more gaps in a plot like the one shown above; further a couple additional slide IDs can be populated, whereas they were effectively empty prior to the fix.

## Testing performed
Other than the diagnostic plot above being resolved, the p-value distribution of the background in a number of test boxes has smaller uncertainties, indicating that the background is now populated more fully.

## Additional notes
<!--- Anything which does not fit in the above sections -->

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
