### PR TITLE
Fixed rounding bug in pycbc_dtphase

### DIFF
--- a/bin/all_sky_search/pycbc_dtphase
+++ b/bin/all_sky_search/pycbc_dtphase
@@ -187,9 +187,9 @@ for ifo0 in args.ifos:
             dt = (data[ifo0]['t'] - data[ifo1]['t'])
             dp = (data[ifo0]['p'] - data[ifo1]['p']) % (2. * np.pi)
             sr = (data[ifo1]['s'] / data[ifo0]['s'])
-            dtbin = (dt / twidth).astype(int)
-            dpbin = (dp / pwidth).astype(int)
-            srbin = (sr / swidth).astype(int)
+            dtbin = np.rint(dt / twidth).astype(int)
+            dpbin = np.rint(dp / pwidth).astype(int)
+            srbin = np.rint(sr / swidth).astype(int)
 
             # We'll only store a limited range of ratios
             if keep is None:

--- a/pycbc/events/eventmgr_cython.pyx
+++ b/pycbc/events/eventmgr_cython.pyx
@@ -2,7 +2,7 @@ import numpy as np
 cimport numpy as cnp
 import cython
 from cython import wraparound, boundscheck, cdivision
-from libc.math cimport M_PI, sqrt
+from libc.math cimport M_PI, sqrt, rint
 from libc.math cimport round as cround
 
 
@@ -75,9 +75,9 @@ def logsignalrateinternals_computepsignalbins(
         sdif[idx] = (s[ridx] * sense * sqrt(sigref[ridx])) / (sref[ridx] * senseref * sqrt(sig[ridx]))
 
     for idx in range(length):
-        tbin[idx] = <int>(tdif[idx] / twidth)
-        pbin[idx] = <int>(pdif[idx] / pwidth)
-        sbin[idx] = <int>(sdif[idx] / swidth)
+        tbin[idx] = <int>rint(tdif[idx] / twidth)
+        pbin[idx] = <int>rint(pdif[idx] / pwidth)
+        sbin[idx] = <int>rint(sdif[idx] / swidth)
 
 
 @boundscheck(False)

--- a/test/validation_code/old_stat.py
+++ b/test/validation_code/old_stat.py
@@ -543,9 +543,9 @@ class PhaseTDStatistic(QuadratureSumStatistic):
                 sdif = s / sref * sense / senseref * sigref / sig
 
                 # Put into bins
-                tbin = (tdif / self.twidth).astype(int)
-                pbin = (pdif / self.pwidth).astype(int)
-                sbin = (sdif / self.swidth).astype(int)
+                tbin = numpy.rint(tdif / self.twidth).astype(int)
+                pbin = numpy.rint(pdif / self.pwidth).astype(int)
+                sbin = numpy.rint(sdif / self.swidth).astype(int)
                 binned += [tbin, pbin, sbin]
 
             # Convert binned to same dtype as stored in hist


### PR DESCRIPTION


<!-- TOP-LEVEL SUMMARY: Please provide a brief, one-or-two-sentence description of the PR here
-->

When binning samples into integer bins, the current code truncates the samples rather than consistently rounding. This results in the 0 bin having approximately twice as many samples as the others. This fix will round the samples to the nearest integer instead.

<!--- Some basic info about the change (delete as appropriate) -->

This is a bug fix regarding how samples are rounded.

<!--- What codes will this affect? (delete as apropriate)

This change affects: the offline search, the live search and anywhere else which uses the PTA histograms.

<!--- What code areas will this affect? (delete as apropriate) -->
This change changes:  scientific output

<!--- Some things which help with code management (delete as appropriate) -->
This change:  follows style guidelines (See e.g. [PEP8](https://peps.python.org/pep-0008/)), has been proposed using the [contribution guidelines](https://github.com/gwastro/pycbc/blob/master/CONTRIBUTING.md)

<!--- Notes about the effect of this change -->
This change will: it should not affect anything other than slightly changing the weights of different bins in the PTA histograms.

## Motivation
<!--- Describe why your changes are being made -->

The current version, truncates samples resulting in all samples between -1 and 1 being sorted into the zero bin. This causes an over-density in this bin compared to others.

## Contents
<!--- Describe your changes, this doesn't need to be a line-by-line code change discussion,
but rather a general discussion of the methods chosen -->

Rather than truncating the samples, this simply rounds the samples to the nearest integer.

## Links to any issues or associated PRs
<!--- If this is fixing / working around an already-reported issue, please link to it here -->

## Testing performed
<!--- Describe tests for the code changes, either already performed or to be performed -->

I have recreated the histogram files with this change and it works the same just without this over density at 0.

## Additional notes
<!--- Anything which does not fit in the above sections -->

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
