### PR TITLE
Fix template_id accidentally being float type when no trigger is found in pycbc_sngls_findtrigs

### DIFF
--- a/bin/all_sky_search/pycbc_sngls_findtrigs
+++ b/bin/all_sky_search/pycbc_sngls_findtrigs
@@ -177,7 +177,7 @@ data = {"stat": stat_all,
         "timeslide_id": np.zeros_like(stat_all),
         "template_id": template_ids_all,
         "%s/time" % ifo : trigger_times_all,
-        "%s/trigger_id" % ifo: trigger_ids_all}
+        "%s/trigger_id" % ifo: np.array(trigger_ids_all, dtype=int)}
 
 logging.info("saving triggers")
 f = io.HFile(args.output_file, 'w')


### PR DESCRIPTION
This PR is a concise version of https://github.com/gwastro/pycbc/pull/5317 and also for v2.3.X branch and release.

Current issue:
There is a bug in `pycbc_sngls_findtrigs` where the `template_id` in an output trigger file can become a float type when no trigger is found. This would cause the entire search trigger file to have a float type `template_id` when one of the sub-runs has this zero-trigger problem. This would eventually break, for example, `pycbc_page_coincinfo` when generating a table using a template_id to retrieve a trigger. The command would fail as a float is used as an index.

Solution:
Force an int type for `template_id` in `pycbc_sngls_findtrigs`


<!---
Please delete these comments when you submit the pull request

Please add a title which is a concise description of what you are doing,
e.g. 'Fix bug with numpy import in pycbc_coinc_findtrigs' or 'add high frequency sky location dependent response for long detectors'
-->

<!---
This is a brief template for making pull requests for PyCBC.
This is _not_ a proscriptive template - you can use a different style if you want.
Please do think about the questions posed here and whether the details will be useful to include in your PR
Please add sufficient details so that people looking back at the request with no context around the work can understand the changes.
To choose reviewers, please look at the git blame for the code you are changing (if applicable),
or discuss in the #pycbc-code channel of the gwastro slack.
Please add labels as appropriate
-->

<!-- TOP-LEVEL SUMMARY: Please provide a brief, one-or-two-sentence description of the PR here
-->

## Standard information about the request

<!--- Some basic info about the change (delete as appropriate) -->
This is a: bug fix

<!--- What codes will this affect? (delete as apropriate)
If you do not know which areas will be affected, please ask in the gwastro #pycbc-code slack
-->
This change wouldn't change any previous results, it has backwards compatibility

<!--- What code areas will this affect? (delete as apropriate) -->

<!--- Some things which help with code management (delete as appropriate) -->
This change follows style guidelines (See e.g. [PEP8](https://peps.python.org/pep-0008/)), has been proposed using the [contribution guidelines](https://github.com/gwastro/pycbc/blob/master/CONTRIBUTING.md)

<!--- Notes about the effect of this change -->


## Motivation
<!--- Describe why your changes are being made -->

## Contents
<!--- Describe your changes, this doesn't need to be a line-by-line code change discussion,
but rather a general discussion of the methods chosen -->

## Links to any issues or associated PRs
<!--- If this is fixing / working around an already-reported issue, please link to it here -->
This PR is a concise and more easily reviewable version of https://github.com/gwastro/pycbc/pull/5317

## Testing performed
<!--- Describe tests for the code changes, either already performed or to be performed -->
I have tested this PR in this script: https://ldas-jobs.ligo.caltech.edu/~yifan.wang/ssm-o4b-study/debug-sumit-run/patch-fix-dtype/single-run/ (LIGO account needed to access it). It works as expected. The result file has zero trigger with a correct int type of template_id

## Additional notes
<!--- Anything which does not fit in the above sections -->

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
