### PR TITLE
fix a bug that trigger id array would be float type when empty

### DIFF
--- a/bin/all_sky_search/pycbc_sngls_findtrigs
+++ b/bin/all_sky_search/pycbc_sngls_findtrigs
@@ -197,7 +197,7 @@ for i, tnum in enumerate(template_ids):
 dec_facs = np.ones_like(template_ids_all)
 stat_all = np.array(stat_all)
 template_ids_all = np.array(template_ids_all, dtype=int)
-trigger_ids_all = np.array(trigger_ids_all)
+trigger_ids_all = np.array(trigger_ids_all, dtype=int)
 trigger_times_all = np.array(trigger_times_all)
 
 logging.info("%d events", dec_facs.size)


### PR DESCRIPTION
This is a one-line fix to enforce the type of template id to be int.

## Standard information about the request

<!--- Some basic info about the change (delete as appropriate) -->
This is a bug fix

<!--- What codes will this affect? (delete as apropriate)
If you do not know which areas will be affected, please ask in the gwastro #pycbc-code slack
-->
This change affects the type of the template_id array, which is used by the offline search.

<!--- What code areas will this affect? (delete as apropriate) -->
This change changes offline search

<!--- Some things which help with code management (delete as appropriate) -->
This change follows style guidelines (See e.g. [PEP8](https://peps.python.org/pep-0008/)), has been proposed using the [contribution guidelines](https://github.com/gwastro/pycbc/blob/master/CONTRIBUTING.md)

<!--- Notes about the effect of this change -->
This change has been introduced to v2.3.X in https://github.com/gwastro/pycbc/commit/a50f50f1a526d9344a62fd0671e95903e523f305. This PR is the same change for the master branch.

This PR is a minimized version of https://github.com/gwastro/pycbc/pull/5317, in there I introduced more codes to examine the types of variables in statmap files, which may or may not be necessary and hence not merged and under discussion.

## Motivation
<!--- Describe why your changes are being made -->

## Contents
<!--- Describe your changes, this doesn't need to be a line-by-line code change discussion,
but rather a general discussion of the methods chosen -->

## Links to any issues or associated PRs
<!--- If this is fixing / working around an already-reported issue, please link to it here -->

## Testing performed
<!--- Describe tests for the code changes, either already performed or to be performed -->

## Additional notes
<!--- Anything which does not fit in the above sections -->

- [ ] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
