### PR TITLE
Fix a bug with pycbc_fit_sngls_over_multiparam 

### DIFF
--- a/bin/all_sky_search/pycbc_fit_sngls_over_multiparam
+++ b/bin/all_sky_search/pycbc_fit_sngls_over_multiparam
@@ -241,6 +241,8 @@ kwarg_dict = {}
 for inputstr in smooth_kwargs:
     try:
         key, value = inputstr.split(':')
+        if key == 'total_trigs':
+            value = int(value)
         kwarg_dict[key] = value
     except ValueError:
         err_txt = "--smoothing-keywords must take input in the " \


### PR DESCRIPTION
<!---
Please delete these comments when you submit the pull request

Please add a title which is a concise description of what you are doing,
e.g. 'Fix bug with numpy import in pycbc_coinc_findtrigs' or 'add high frequency sky location dependent response for long detectors'
-->

<!---
This is a brief template for making pull requests for PyCBC.
This is _not_ a proscriptive template - you can use a different style if you want.
Please do think about the questions posed here and whether the details will be useful to include in your PR
Please add sufficient details so that people looking back at the request with no context around the work can understand the changes.
To choose reviewers, please look at the git blame for the code you are changing (if applicable),
or discuss in the #pycbc-code channel of the gwastro slack.
Please add labels as appropriate
-->

<!-- TOP-LEVEL SUMMARY: Please provide a brief, one-or-two-sentence description of the PR here
-->

## Standard information about the request

<!--- Some basic info about the change (delete as appropriate) -->
This is a: bug fix

<!--- What codes will this affect? (delete as apropriate)
If you do not know which areas will be affected, please ask in the gwastro #pycbc-code slack
-->
This change affects: the offline search

<!--- What code areas will this affect? (delete as apropriate) -->
This change changes offline and online search

<!--- Some things which help with code management (delete as appropriate) -->
This change  follows style guidelines (See e.g. [PEP8](https://peps.python.org/pep-0008/)), has been proposed using the [contribution guidelines](https://github.com/gwastro/pycbc/blob/master/CONTRIBUTING.md)

<!--- Notes about the effect of this change -->
This change will not change any existing results

## Motivation
<!--- Describe why your changes are being made -->

There is a bug in the original code (see 'contents' in the next section) that `kwargs_dict['total_trigs']` is a string because it's read from command line arguments. It needs to be converted to `int` when comparing to `nabove.sum()`, otherwise I see the following breaks:

```
python ./my-pycbc_fit_sngls_over_multiparam --verbose --fit-param template_duration chi_eff eta --f-lower 30 --log-param True False False \
--smoothing-width 0.3 0.2 0.08 \
--output-fits-by-template --approximant TaylorF2 \
--template-fit-file full_data/H1-FIT_BY_TEMPLATE_FULL_DATA-1418483127-1393287.hdf \
--bank-file bank/H1L1V1-BANK2HDF-1418483127-1393287.hdf \
--output test-H1-FIT_OVER_PARAM_FULL_DATA-1418483127-1393287.hdf --smoothing-keywords total_trigs:500 --smoothing-method 'n_closest'
```

```
Traceback (most recent call last):
  File "*****************./pycbc_fit_sngls_over_multiparam", line 379, in <module>
    if args.smoothing_method == 'n_closest' and n_required > nabove.sum():
TypeError: '<' not supported between instances of 'numpy.ndarray' and 'str'
```

## Contents
<!--- Describe your changes, this doesn't need to be a line-by-line code change discussion,
but rather a general discussion of the methods chosen -->

The original code: kwarg_dict['total_trigs'] is a string
```
n_required = _default_total_trigs if 'total_trigs' not in kwarg_dict \
    else kwarg_dict['total_trigs']
if args.smoothing_method == 'n_closest' and n_required > nabove.sum():
    logging.warning(
        "There are %.2f triggers above threshold, not enough to give a "
        "total of %d for smoothing",
        nabove.sum(),
        n_required
    )
```

I added an explicit conversion if 'total_trigs' is read from command line arguments. It's a two-line change.

## Links to any issues or associated PRs
<!--- If this is fixing / working around an already-reported issue, please link to it here -->

## Testing performed
<!--- Describe tests for the code changes, either already performed or to be performed -->

With this PR, it fixed the above type error.

## Additional notes
<!--- Anything which does not fit in the above sections -->

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
