### PR TITLE
Fix the corrupted 1-D tophat smoothing in pycbc_fit_sngls_over_multiparam

### DIFF
--- a/bin/all_sky_search/pycbc_fit_sngls_over_multiparam
+++ b/bin/all_sky_search/pycbc_fit_sngls_over_multiparam
@@ -419,7 +419,10 @@ if len(parvals) == 1 and args.smoothing_method == 'smooth_tophat':
     logging.info("Using efficient 1D tophat smoothing")
     sort = parvals[0].argsort()
     parvals_0 = parvals[0][sort]
-
+    ntotal = ntotal[sort]
+    nabove = nabove[sort]
+    invalphan = invalphan[sort]
+    
     # For each template, find the range of nearby templates which fall within
     # the chosen window.
     left = numpy.searchsorted(parvals_0, parvals[0] - args.smoothing_width[0])


### PR DESCRIPTION
I think the current 1-d tophat smoothing is corrupted since lines 126-128 were removed in [here](https://github.com/gwastro/pycbc/pull/3946/changes#diff-a6579abae29408a0887f9992b3a57fe5e13695c77df1c8e609892519c513f78bL126). The smoothing parameter is sorted but the cumulative sum of `nabove`, `ntotal`, and `invalphan` are not sorted. The reviewers can double-check this.

I made an explicit example to verify my guess. First, generate an example bank with 5 templates with mchirp = `3,1,4,2,5`, and its fitting parameter file with nabove = `30,10,40,20,50`, and its alpha (the exponent of the fitted rate) = `3,1,4,2,5`. Let's say we want to smooth over mchirp with smoothing length = `1.5`. 

For the first template mchirp = 3, that means we average over any chirp mass between `[1.5, 4.5]`, that includes the templates with mchirp = 2 and 3 and 4. (However, due to yet another bug where the cumulative sum is implemented as `cumsum[right] - cumsum[left]`, such that in this example mchirp =2 is not considered. I believe the correct index should be `left-1` not `left`, but I'll leave this point for a future PR to make an easier case demonstration for this PR). 

So I expect the smoothed `nabove` should be `(30+40)/2=35`, the smoothed `alpha` should be `1/ [( 1/3 * 30 + 1/4*40) / (30 + 40)] = 3.5`. However this is not what I see using the current master branch's code to run the following example. This PR added back what was deleted in line 126-128 in [link](https://github.com/gwastro/pycbc/pull/3946/changes#diff-a6579abae29408a0887f9992b3a57fe5e13695c77df1c8e609892519c513f78bL126) to add back sorted nabove, ntotal and invalphan, then the results are as expected. 

I also reverted to this commit: baa082340fc02308cf6c5e8f7123dd7d068bbba4, one commit before removing the sorted nabove/ntotal/invalphan. I notice that the results are consistent with this PR. 

Can the reviewer double check if this makes sense or do I misunderstand anything?

The demonstration example is made as follows:

  - Create a bank file and a fitting file:
```
import numpy as np
import h5py

bank_file = 'test_bank.hdf'
with h5py.File(bank_file, 'w') as f:
    mchirp = np.array([3, 1, 4, 2, 5])
    mass = mchirp / (2.0 ** (1/5))
    f.create_dataset('mass1', data=mass)
    f.create_dataset('mass2', data=mass)
    f.create_dataset('spin1z', data=np.zeros(5))
    f.create_dataset('spin2z', data=np.zeros(5))
    f.create_dataset('mchirp', data=mchirp)

fit_file = 'test_fit.hdf'
with h5py.File(fit_file, 'w') as f:
    f.create_dataset('template_id', data=np.arange(5))
    f.create_dataset('count_above_thresh', data=np.array([30, 10, 40, 20, 50]))
    f.create_dataset('count_in_template', data=np.array([100, 100, 100, 100, 100]))
    f.create_dataset('fit_coeff', data=np.array([3,1,4,2,5]))
    f.attrs['ifo'] = 'H1'
    f.attrs['stat_threshold'] = 5.0
    f.attrs['analysis_time'] = 1.0

print(f"Generated {bank_file} and {fit_file}")
```

 - Then smooth the fitting file:
```
pycbc_fit_sngls_over_multiparam \
    --template-fit-file test_fit.hdf \
    --bank-file test_bank.hdf \
    --output test_smoothed.hdf \
    --fit-param mchirp \
    --log-param false \
    --smoothing-width 1.5 \
    --smoothing-method smooth_tophat \
    --verbose
```

With this PR, the resulting `count_above_thresh` is `35, 20, 45, 25, 50`, without this PR it's `30, 10, 35, 25, 50`.
With this PR, `fit_coeff` is `3.5, 2, 4.5, 2.5, 5`, without this PR it's `3,1,3.5, 2.5, 5`


## Standard information about the request

<!--- Some basic info about the change (delete as appropriate) -->
This is a bug fix.

<!--- What codes will this affect? (delete as apropriate)
If you do not know which areas will be affected, please ask in the gwastro #pycbc-code slack
-->
This change affects the offline search using 1-D tophat smoothing for fitted noise rate

<!--- What code areas will this affect? (delete as apropriate) -->
This change changes scientific output

<!--- Some things which help with code management (delete as appropriate) -->
This change follows style guidelines (See e.g. [PEP8](https://peps.python.org/pep-0008/)), has been proposed using the [contribution guidelines](https://github.com/gwastro/pycbc/blob/master/CONTRIBUTING.md). I hope I can add a unittest in the future when I have time.

<!--- Notes about the effect of this change -->
I think v2.3.X release also needs this change.

## Motivation
<!--- Describe why your changes are being made -->

## Contents
<!--- Describe your changes, this doesn't need to be a line-by-line code change discussion,
but rather a general discussion of the methods chosen -->

## Links to any issues or associated PRs
<!--- If this is fixing / working around an already-reported issue, please link to it here -->

## Testing performed
<!--- Describe tests for the code changes, either already performed or to be performed -->

## Additional notes
<!--- Anything which does not fit in the above sections -->

- [ ] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
