### PR TITLE
Add a feature to fit noise trigger rates with respect to eccentricity

### DIFF
--- a/bin/all_sky_search/pycbc_fit_sngls_binned
+++ b/bin/all_sky_search/pycbc_fit_sngls_binned
@@ -184,21 +184,20 @@ for veto_file, veto_segment_name in zip(args.veto_file, args.veto_segment_name):
 
 ### Functions for doing the pruning (removal of trigs at loudest times)
 
-def get_pars(args, tag, m1, m2, s1z, s2z):
+def get_pars(args, tag, bank, tid):
     # here used for both pruning and binning params
     paramarg = getattr(args, tag+'_param')
     try:
         # will fail if m1 is a float rather than a sequence
-        logging.info('Getting %s values for %i triggers' % (paramarg, len(m1)))
+        logging.info('Getting %s values for %i triggers' % (paramarg, len(bank['mass1'])))
     except:
         pass
-    return triggers.get_param(paramarg, args, m1, m2, s1z, s2z)
+    return triggers.get_param(paramarg, args, bank, tid)
 
 if args.prune_param:
     logging.info('Getting min and max param values')
-    prpars = get_pars(args, 'prune',
-                      templatef['mass1'][:], templatef['mass2'][:],
-                      templatef['spin1z'][:], templatef['spin2z'][:])
+    templateid = np.arange(len(templatef['template_hash'][:]))
+    prpars = get_pars(args, 'prune', templatef, templateid)
     minprpar = min(prpars)
     maxprpar = max(prpars)
     del prpars
@@ -232,8 +231,7 @@ if args.prune_param:
         lstat = statpruneall[loudest]
         ltid = tidpruneall[loudest]
         ltime = timepruneall[loudest]
-        m1, m2, s1z, s2z = triggers.get_mass_spin(templatef, ltid)
-        lbin = trstats.which_bin(get_pars(args, 'prune', m1, m2, s1z, s2z),
+        lbin = trstats.which_bin(get_pars(args, 'prune', templatef, ltid),
                                  minprpar, maxprpar,
                                  args.prune_bins, log=args.log_prune_param)
         # is the bin where the loudest trigger lives full already?
@@ -275,8 +273,7 @@ if args.prune_param:
 if trig_dur:
     binpars = tdur + args.min_duration
 else:
-    m1, m2, s1z, s2z = triggers.get_mass_spin(templatef, tid)
-    binpars = get_pars(args, 'bin', m1, m2, s1z, s2z)
+    binpars = get_pars(args, 'bin', templatef, tid)
 logging.info("Parameter range of triggers: %f - %f" %
                                                   (min(binpars), max(binpars)))
 

--- a/bin/all_sky_search/pycbc_fit_sngls_binned
+++ b/bin/all_sky_search/pycbc_fit_sngls_binned
@@ -188,7 +188,7 @@ def get_pars(args, tag, bank, tid):
     # here used for both pruning and binning params
     paramarg = getattr(args, tag+'_param')
     try:
-        # will fail if m1 is a float rather than a sequence
+        # will fail if mass1 is not in the bank
         logging.info('Getting %s values for %i triggers' % (paramarg, len(bank['mass1'])))
     except:
         pass
@@ -196,7 +196,7 @@ def get_pars(args, tag, bank, tid):
 
 if args.prune_param:
     logging.info('Getting min and max param values')
-    templateid = np.arange(len(templatef['template_hash'][:]))
+    templateid = np.arange(len(templatef['mass1'])) # get the full range
     prpars = get_pars(args, 'prune', templatef, templateid)
     minprpar = min(prpars)
     maxprpar = max(prpars)

--- a/bin/all_sky_search/pycbc_fit_sngls_by_template
+++ b/bin/all_sky_search/pycbc_fit_sngls_by_template
@@ -261,7 +261,7 @@ total_time = abs(all_segments)
 # do pruning (removal of trigs at N loudest times defined over param bins)
 if args.prune_param:
     logging.info('Getting min and max param values')
-    templateid = np.arange(len(templatef['template_hash'][:]))
+    templateid = np.arange(len(templatef['mass1'])) # get the full range
     pars = triggers.get_param(args.prune_param, args, templatef, templateid)
     minpar = min(pars)
     maxpar = max(pars)

--- a/bin/all_sky_search/pycbc_fit_sngls_by_template
+++ b/bin/all_sky_search/pycbc_fit_sngls_by_template
@@ -261,9 +261,8 @@ total_time = abs(all_segments)
 # do pruning (removal of trigs at N loudest times defined over param bins)
 if args.prune_param:
     logging.info('Getting min and max param values')
-    pars = triggers.get_param(args.prune_param, args,
-                     templatef['mass1'][:], templatef['mass2'][:],
-                     templatef['spin1z'][:], templatef['spin2z'][:])
+    templateid = np.arange(len(templatef['template_hash'][:]))
+    pars = triggers.get_param(args.prune_param, args, templatef, templateid)
     minpar = min(pars)
     maxpar = max(pars)
     del pars
@@ -297,9 +296,8 @@ if args.prune_param:
         lstat = statpruneall[loudest]
         ltid = tidpruneall[loudest]
         ltime = timepruneall[loudest]
-        m1, m2, s1z, s2z = triggers.get_mass_spin(templatef, ltid)
         lbin = trstats.which_bin(triggers.get_param(args.prune_param, args,
-                                                    m1, m2, s1z, s2z),
+                                                    templatef, ltid),
                                  minpar, maxpar, args.prune_bins,
                                                       log=args.log_prune_param)
         # is the bin where the loudest trigger lives full already?

--- a/bin/all_sky_search/pycbc_fit_sngls_over_multiparam
+++ b/bin/all_sky_search/pycbc_fit_sngls_over_multiparam
@@ -386,13 +386,12 @@ if args.smoothing_method == 'n_closest' and n_required > nabove.sum():
 
 logging.info('Calculating template parameter values')
 bank = HFile(args.bank_file, 'r')
-m1, m2, s1z, s2z = triggers.get_mass_spin(bank, tid)
 
 parvals = []
 parnames = []
 
 for param, slog in zip(args.fit_param, args.log_param):
-    data = triggers.get_param(param, args, m1, m2, s1z, s2z)
+    data = triggers.get_param(param, args, bank, tid)
     if slog in ['false', 'False', 'FALSE']:
         logging.info('Using param: %s', param)
         parvals.append(data)

--- a/bin/all_sky_search/pycbc_fit_sngls_over_multiparam
+++ b/bin/all_sky_search/pycbc_fit_sngls_over_multiparam
@@ -193,6 +193,7 @@ parser.add_argument("--fit-param", nargs='+',
                     help="Parameter(s) over which to regress the background "
                          "fit coefficients. Required. Either read from "
                          "template fit file or choose from mchirp, mtotal, "
+                         "q, eccentricity, "
                          "chi_eff, eta, tau_0, tau_3, template_duration, "
                          "a frequency cutoff in pnutils or a frequency function"
                          "in LALSimulation. To regress the background over "
@@ -499,9 +500,14 @@ else:
             **kwarg_dict
         )
 
-if not isinstance(nabove_smoothed, numpy.ndarray):
-    nabove_smoothed = numpy.array(nabove_smoothed)
-assert all(nabove_smoothed > 0), "Some nabove_smoothed values are not above zero"
+non_positive_mask = smoothed_vals[:, 0] <= 0
+if numpy.any(non_positive_mask):
+    n_bad = numpy.sum(non_positive_mask)
+    raise ValueError(
+        f"{n_bad} template(s) have zero triggers above threshold. "
+        "This will cause problems for the fit coefficient values, and is likely "
+        "due to too small smoothing width or too large fitting threshold. "
+    )
 logging.info("Writing output")
 outfile = HFile(args.output, 'w')
 outfile['template_id'] = tid

--- a/bin/all_sky_search/pycbc_fit_sngls_over_multiparam
+++ b/bin/all_sky_search/pycbc_fit_sngls_over_multiparam
@@ -499,6 +499,9 @@ else:
             **kwarg_dict
         )
 
+if not isinstance(nabove_smoothed, numpy.ndarray):
+    nabove_smoothed = numpy.array(nabove_smoothed)
+assert all(nabove_smoothed > 0), "Some nabove_smoothed values are not above zero"
 logging.info("Writing output")
 outfile = HFile(args.output, 'w')
 outfile['template_id'] = tid

--- a/bin/all_sky_search/pycbc_fit_sngls_over_multiparam
+++ b/bin/all_sky_search/pycbc_fit_sngls_over_multiparam
@@ -193,6 +193,7 @@ parser.add_argument("--fit-param", nargs='+',
                     help="Parameter(s) over which to regress the background "
                          "fit coefficients. Required. Either read from "
                          "template fit file or choose from mchirp, mtotal, "
+                         "q, eccentricity, "
                          "chi_eff, eta, tau_0, tau_3, template_duration, "
                          "a frequency cutoff in pnutils or a frequency function"
                          "in LALSimulation. To regress the background over "
@@ -501,9 +502,14 @@ else:
             **kwarg_dict
         )
 
-if not isinstance(nabove_smoothed, numpy.ndarray):
-    nabove_smoothed = numpy.array(nabove_smoothed)
-assert all(nabove_smoothed > 0), "Some nabove_smoothed values are not above zero"
+non_positive_mask = smoothed_vals[:, 0] <= 0
+if numpy.any(non_positive_mask):
+    n_bad = numpy.sum(non_positive_mask)
+    raise ValueError(
+        f"{n_bad} template(s) have zero triggers above threshold. "
+        "This will cause problems for the fit coefficient values, and is likely "
+        "due to too small smoothing width or too large fitting threshold. "
+    )
 logging.info("Writing output")
 outfile = HFile(args.output, 'w')
 outfile['template_id'] = tid

--- a/bin/all_sky_search/pycbc_fit_sngls_over_multiparam
+++ b/bin/all_sky_search/pycbc_fit_sngls_over_multiparam
@@ -388,13 +388,12 @@ if args.smoothing_method == 'n_closest' and n_required > nabove.sum():
 
 logging.info('Calculating template parameter values')
 bank = HFile(args.bank_file, 'r')
-m1, m2, s1z, s2z = triggers.get_mass_spin(bank, tid)
 
 parvals = []
 parnames = []
 
 for param, slog in zip(args.fit_param, args.log_param):
-    data = triggers.get_param(param, args, m1, m2, s1z, s2z)
+    data = triggers.get_param(param, args, bank, tid)
     if slog in ['false', 'False', 'FALSE']:
         logging.info('Using param: %s', param)
         parvals.append(data)

--- a/bin/all_sky_search/pycbc_fit_sngls_over_multiparam
+++ b/bin/all_sky_search/pycbc_fit_sngls_over_multiparam
@@ -501,6 +501,9 @@ else:
             **kwarg_dict
         )
 
+if not isinstance(nabove_smoothed, numpy.ndarray):
+    nabove_smoothed = numpy.array(nabove_smoothed)
+assert all(nabove_smoothed > 0), "Some nabove_smoothed values are not above zero"
 logging.info("Writing output")
 outfile = HFile(args.output, 'w')
 outfile['template_id'] = tid

--- a/pycbc/events/triggers.py
+++ b/pycbc/events/triggers.py
@@ -130,8 +130,12 @@ def get_param(par, args, bank, tid):
         parvals = m1 + m2
     elif par == 'eta':
         parvals = conversions.eta_from_mass1_mass2(m1, m2)
+    elif par == 'q':
+        parvals = conversions.q_from_mass1_mass2(m1, m2)
     elif par in ['chi_eff', 'effective_spin']:
         parvals = conversions.chi_eff(m1, m2, s1z, s2z)
+    elif par == 'eccentricity':
+        parvals = bank['eccentricity'][:][tid]
     elif par == 'template_duration':
         if 'template_duration' in bank:
             parvals = bank['template_duration'][:][tid]

--- a/pycbc/events/triggers.py
+++ b/pycbc/events/triggers.py
@@ -104,7 +104,7 @@ def get_mass_spin(bank, tid):
     return m1, m2, s1z, s2z
 
 
-def get_param(par, args, m1, m2, s1z, s2z):
+def get_param(par, args, bank, tid):
     """
     Helper function
 
@@ -114,14 +114,16 @@ def get_param(par, args, m1, m2, s1z, s2z):
         Name of parameter to calculate
     args : Namespace object returned from ArgumentParser instance
         Calling code command line options, used for f_lower value
-    m1 : float or array of floats
-        First binary component mass (etc.)
+    bank:
+
+    tid: 
 
     Returns
     -------
     parvals : float or array of floats
         Calculated parameter values
     """
+    m1, m2, s1z, s2z = get_mass_spin(bank, tid)
     if par == 'mchirp':
         parvals = conversions.mchirp_from_mass1_mass2(m1, m2)
     elif par == 'mtotal':
@@ -131,10 +133,12 @@ def get_param(par, args, m1, m2, s1z, s2z):
     elif par in ['chi_eff', 'effective_spin']:
         parvals = conversions.chi_eff(m1, m2, s1z, s2z)
     elif par == 'template_duration':
+        if 'template_duration' in bank:
+            parvals = bank['template_duration'][:][tid]
         # default to SEOBNRv4 duration function
-        if not hasattr(args, 'approximant') or args.approximant is None:
+        elif not hasattr(args, 'approximant') or args.approximant is None:
             args.approximant = "SEOBNRv4"
-        parvals = pnutils.get_imr_duration(m1, m2, s1z, s2z, args.f_lower,
+            parvals = pnutils.get_imr_duration(m1, m2, s1z, s2z, args.f_lower,
                                            args.approximant)
         if args.min_duration:
             parvals += args.min_duration

--- a/pycbc/events/triggers.py
+++ b/pycbc/events/triggers.py
@@ -106,7 +106,8 @@ def get_mass_spin(bank, tid):
 
 def get_param(par, args, bank, tid):
     """
-    Helper function
+    Helper function to extract parameters from bank and calculate
+    derived parameters
 
     Parameters
     ----------
@@ -114,9 +115,10 @@ def get_param(par, args, bank, tid):
         Name of parameter to calculate
     args : Namespace object returned from ArgumentParser instance
         Calling code command line options, used for f_lower value
-    bank:
-
-    tid: 
+    bank : h5py File object
+        Bank parameter file
+    tid : integer or array of int
+        Indices of the entries to be returned
 
     Returns
     -------
@@ -137,12 +139,10 @@ def get_param(par, args, bank, tid):
     elif par == 'eccentricity':
         parvals = bank['eccentricity'][:][tid]
     elif par == 'template_duration':
-        if 'template_duration' in bank:
-            parvals = bank['template_duration'][:][tid]
         # default to SEOBNRv4 duration function
-        elif not hasattr(args, 'approximant') or args.approximant is None:
+        if not hasattr(args, 'approximant') or args.approximant is None:
             args.approximant = "SEOBNRv4"
-            parvals = pnutils.get_imr_duration(m1, m2, s1z, s2z, args.f_lower,
+        parvals = pnutils.get_imr_duration(m1, m2, s1z, s2z, args.f_lower,
                                            args.approximant)
         if args.min_duration:
             parvals += args.min_duration


### PR DESCRIPTION
This PR was used in the work https://arxiv.org/abs/2508.05018 for a search with eccentricity. I added a feature to fit the noise trigger rate as a function of eccentricity and smooth over it. Mass ratio `q` is also added.

## Standard information about the request

<!--- Some basic info about the change (delete as appropriate) -->
This is a new feature

<!--- What codes will this affect? (delete as apropriate)
If you do not know which areas will be affected, please ask in the gwastro #pycbc-code slack
-->
This change doesn't affect previous results.

<!--- What code areas will this affect? (delete as apropriate) -->
This change changes scientific output

<!--- Some things which help with code management (delete as appropriate) -->
This change follows style guidelines (See e.g. [PEP8](https://peps.python.org/pep-0008/)), has been proposed using the [contribution guidelines](https://github.com/gwastro/pycbc/blob/master/CONTRIBUTING.md). But it doesn't have unittest yet.

<!--- Notes about the effect of this change -->
This change will not break any current functionality, it should have backwards compatibility to any previous noise trigger rate fit and smoothing in offline search. 

## Motivation
<!--- Describe why your changes are being made -->
Add this for an offline search including eccentricity

## Contents
<!--- Describe your changes, this doesn't need to be a line-by-line code change discussion,
but rather a general discussion of the methods chosen -->
It changes pycbc/events/triggers.py and three other pycbc_fit_* related commands in bin, see code diff for more details.

## Links to any issues or associated PRs
<!--- If this is fixing / working around an already-reported issue, please link to it here -->

## Testing performed
<!--- Describe tests for the code changes, either already performed or to be performed -->
I don't have any explicit tests at the moment but try to add some unittests in the future. I can point to the [configuration file](https://github.com/gwastro/O3-eccentricBBH-search/blob/master/config/analysis.ini#L175) of my work https://arxiv.org/abs/2508.05018, where we use this PR and thus it's some tests

## Additional notes
<!--- Anything which does not fit in the above sections -->

- [ ] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
