### PR TITLE
Improve the compressed waveform code

### DIFF
--- a/bin/pycbc_compress_bank
+++ b/bin/pycbc_compress_bank
@@ -23,14 +23,13 @@ hdf file."""
 import argparse
 import numpy
 import logging
-import time
 import multiprocessing
 
 import pycbc
-from pycbc import psd
+import pycbc.psd
 from pycbc.waveform import compress
 from pycbc import waveform
-from pycbc.types import FrequencySeries, real_same_precision_as
+from pycbc.types import real_same_precision_as
 
 # --- WORKER FUNCTION ---
 def _worker(ii):
@@ -153,6 +152,10 @@ if __name__ == "__main__":
 
     pycbc.init_logging(args.verbose)
 
+    # Verify if the input options for calculating the psd are correct, if
+    # a PSD is to be used while calculating the overlaps in compress.py . If
+    # using a PSD is not desired, this check would prevent raising an error
+    # asking for PSD options.
     if args.psd_model or args.psd_file or args.asd_file:
         pycbc.psd.verify_psd_options(args, parser)
 
@@ -170,6 +173,8 @@ if __name__ == "__main__":
     dtype = numpy.complex128
 
     logging.info("loading bank")
+    # we'll do everything in double precision; if single is desired, we'll
+    # cast to single when saving the waveforms
     bank_obj = waveform.FilterBank(args.bank_file, N//2+1, df_val, dtype,
                                    low_frequency_cutoff=args.low_frequency_cutoff,
                                    approximant=args.approximant,

--- a/bin/pycbc_compress_bank
+++ b/bin/pycbc_compress_bank
@@ -14,6 +14,7 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
 __description__ = \
 """"Loads a bank of waveforms and compresses them using the specified
 compression algorithm. The resulting compressed waveforms are saved to an
@@ -23,6 +24,7 @@ import argparse
 import numpy
 import logging
 import time
+import multiprocessing
 
 import pycbc
 from pycbc import psd
@@ -30,193 +32,194 @@ from pycbc.waveform import compress
 from pycbc import waveform
 from pycbc.types import FrequencySeries, real_same_precision_as
 
-parser = argparse.ArgumentParser(description=__description__)
-pycbc.add_common_pycbc_options(parser)
-parser.add_argument("--bank-file", type=str, required=True,
-                    help="Bank hdf file to load.")
-parser.add_argument("--output", type=str, required=True,
-                    help="The hdf file to save the templates and "
-                    "compressed waveforms to.")
-parser.add_argument("--low-frequency-cutoff", type=float, default=None,
-                    help="The low frequency cutoff to use for generating "
-                    "the waveforms (Hz). If this is not provided, the code "
-                    "will look for a low frequency cutoff corressponding "
-                    "to each template stored in the bank. If a "
-                    "--low-frequency-cutoff is provided and the bank stores "
-                    "a low frequency cutoff for each template as well, the "
-                    "former is used to generate the waveforms.")
-# add approximant arg
-pycbc.waveform.bank.add_approximant_arg(parser)
-parser.add_argument("--sample-rate", type=int, required=True,
-                    help="Half this value sets the maximum frequency of "
-                    "the compressed waveforms. Must be a power of 2.")
-parser.add_argument("--segment-length", type=int, required=True,
-                    help="The segment length to use for generating the "
-                    "templates for compression, and for calculating "
-                    "overlap for tolerance. Must be a power of 2, "
-                    "and at least twice as long as the longest template "
-                    "in the bank.")
-parser.add_argument("--tmplt-index", nargs=2, type=int, default=None,
-                    help="Only generate compressed waveforms for the given "
-                    "indices in the bank file. Must provide both a start "
-                    "and a stop index. Default is to compress all of the "
-                    "templates in the bank file.")
-parser.add_argument("--compression-algorithm", type=str, required=True,
-                    choices=list(compress.compression_algorithms.keys()) + ['bounds'],
-                    help="The compression algorithm to use for selecting "
-                    "frequency points.")
-parser.add_argument("--t-pad", type=float, default=0.001,
-                    help="The minimum duration used for t(f) in seconds. "
-                    "The inverse of this gives the maximum frequency "
-                    "step that will be used in the compressed waveforms. "
-                    "Default is 0.001.")
-parser.add_argument("--tolerance", type=float, default=0.001,
-                    help="The maximum mismatch to allow between the "
-                    "interpolated waveform must and the full waveform. "
-                    "Points will be added to the compressed waveform "
-                    "until its interpolation has a mismatch <= this value. "
-                    "Default is 0.001.")
-parser.add_argument("--interpolation", type=str, default="inline_linear",
-                    help="The interpolation to use for decompressing the "
-                    "waveforms for checking tolerance. Options are "
-                    "'inline_linear', or any interpolation recognized by "
-                    "scipy's interp1d kind argument. Default is inline_linear.")
-parser.add_argument("--precision", type=str, choices=["double", "single"],
-                    default="single",
-                    help="What precision to generate and store the "
-                    "waveforms with; default is double.")
-parser.add_argument("--force", action="store_true", default=False,
-                    help="Overwrite the given hdf file if it exists. "
-                    "Otherwise, an error is raised.")
-parser.add_argument("--scale", type=float, default=1,
-                    help="Scale factor to apply to the courseness of the initial "
-                         "compression points. >1 means a courser set of initial "
-                         "points. The algorithm will still add points to meet"
-                         "the tolerance goals.")
-parser.add_argument(
-    "--do-not-compress",
-    nargs="+",
-    help="If given, will not compress waveforms using "
-         "the given approximant. Recommended 'SPAtmplt TaylorF2'."
-)
-
-# Insert the PSD options
-pycbc.psd.insert_psd_option_group(parser, include_data_options=False)
-
-args = parser.parse_args()
-
-pycbc.init_logging(args.verbose)
-
-# Verify if the input options for calculating the psd are correct, if
-# a PSD is to be used while calculating the overlaps in compress.py . If
-# using a PSD is not desired, this check would prevent raising an error
-# asking for PSD options.
-if args.psd_model or args.psd_file or args.asd_file :
-    pycbc.psd.verify_psd_options(args, parser)
-
-if args.sample_rate % 2 != 0:
-    raise ValueError("sample rate must be a power of 2")
-if args.segment_length % 2 != 0:
-    raise ValueError("segment length must be a power of 2")
-
-if args.do_not_compress is None:
-    args.do_not_compress = []
-
-df = 1./args.segment_length
-fmax = args.sample_rate/2.
-N = args.sample_rate * args.segment_length
-
-# load the bank
-logging.info("loading bank")
-# we'll do everything in double precision; if single is desired, we'll
-# cast to single when saving the waveforms
-dtype = numpy.complex128
-
-bank = waveform.FilterBank(args.bank_file, N//2+1, df, dtype,
-                           low_frequency_cutoff=args.low_frequency_cutoff,
-                           approximant=args.approximant,
-                           enable_compressed_waveforms=False)
-templates = bank.table
-if args.tmplt_index is not None:
-    imin, imax = args.tmplt_index
-    templates = templates[imin:imax]
-    bank.table = templates
-
-# generate output file
-logging.info("writing template info to output")
-output = bank.write_to_hdf(args.output, force=args.force,
-                           write_compressed_waveforms=False)
-
-output.create_group("compressed_waveforms")
-
-# get the psd
-logging.info("getting psd")
-psd = pycbc.psd.from_cli(args, length=N//2+1, delta_f=df,
-                         low_frequency_cutoff=templates.f_lower.min(),
-                         dyn_range_factor=pycbc.DYN_RANGE_FAC,
-                         precision='double')
-
-# get the compressed sample points for each template
-logging.info("getting compressed amplitude and phase")
-
-# scratch space
-decomp_scratch = FrequencySeries(numpy.zeros(N, dtype=dtype), delta_f=df)
-
-for ii in range(templates.size):
-    tmplt = bank.table[ii]
-    if tmplt['approximant'] in args.do_not_compress:
-        continue
-    # generate the waveform
-    t1 = time.time()
-    htilde = bank[ii]
-    htime = time.time() - t1
-    logging.info("... %.2f ms to generate normally", htime * 1000)
-    fmin=tmplt.f_lower
+# --- WORKER FUNCTION ---
+def _worker(ii):
+    """Worker function to generate and compress a single template."""
+    tmplt = bank_table[ii]
+    if tmplt['approximant'] in do_not_compress:
+        return None
+    
+    # Generate the waveform
+    htilde = bank_obj[ii]
+    fmin = tmplt.f_lower
     template_duration = htilde.chirp_length
     
     if template_duration is None:
-        template_duration = args.segment_length // 2
-        logging.info("Warning: was not able to determine template duration, setting half segment length")
+        template_duration = seg_len // 2
+        logging.info("Warning: was not able to determine template duration, "
+                     "setting half segment length for template %s", tmplt.template_hash)
     
-    output['template_duration'][ii] = template_duration
-    # check that the segment length is at least twice the template duration
-    if args.segment_length < 2*template_duration:
-        raise ValueError("segment length is < twice the duration "
-                         "({}) of template {}".format(template_duration,
-                         tmplt.template_hash))
-    kmin = int(numpy.ceil(fmin / df))
+    kmin = int(numpy.ceil(fmin / df_val))
     htilde[:kmin] = 0 # This ensures proper phase unwrapping
     if numpy.abs(htilde[kmin]) == 0:
-        raise ValueError("""The amplitude of the waveform at the
-                         low_frequency_cutoff is zero. A non-zero value
-                         is required.""")
+        raise ValueError("The amplitude of the waveform at the "
+                         "low_frequency_cutoff is zero. A non-zero value "
+                         "is required.")
                          
     kmax = numpy.nonzero(abs(htilde))[0][-1]
     
-    # get the compressed sample points
-    if args.compression_algorithm == 'mchirp':
+    # Get the compressed sample points
+    if alg == 'mchirp':
         sample_points = compress.mchirp_compression(tmplt.mass1, tmplt.mass2,
-            fmin, kmax*df, min_seglen=args.t_pad, df_multiple=df,
-            scale=args.scale).astype(
-            real_same_precision_as(htilde))
-    elif args.compression_algorithm == 'spa':
-        sample_points = compress.spa_compression(htilde, fmin, kmax*df,
-            min_seglen=args.t_pad,
-            scale=args.scale).astype(real_same_precision_as(htilde))
-    elif args.compression_algorithm == 'bounds':
-        sample_points = numpy.array([fmin, kmax*df])
+            fmin, kmax*df_val, min_seglen=t_pad, df_multiple=df_val,
+            scale=scale_val).astype(real_same_precision_as(htilde))
+    elif alg == 'spa':
+        sample_points = compress.spa_compression(htilde, fmin, kmax*df_val,
+            min_seglen=t_pad, scale=scale_val).astype(real_same_precision_as(htilde))
+    elif alg == 'bounds':
+        sample_points = numpy.array([fmin, kmax*df_val])
     else:
-        raise ValueError("unrecognized compression algorithm %s" %(
-            args.compression_algorithm))
+        raise ValueError("unrecognized compression algorithm %s" % alg)
 
-    # compress
+    # Compress
     hcompressed = compress.compress_waveform(
-        htilde, sample_points, args.tolerance, args.interpolation,
-        'double', decomp_scratch=decomp_scratch, psd=psd)
+        htilde, sample_points, tol, interp,
+        'double', decomp_scratch=None, psd=psd_obj)
 
-    # save results
-    hcompressed.write_to_hdf(output, tmplt.template_hash,
-                             precision=args.precision)
+    return ii, tmplt.template_hash, hcompressed, template_duration
 
-logging.info("finished")
-bank.filehandler.close()
+# --- MAIN EXECUTION ---
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__description__)
+    pycbc.add_common_pycbc_options(parser)
+    parser.add_argument("--bank-file", type=str, required=True,
+                        help="Bank hdf file to load.")
+    parser.add_argument("--output", type=str, required=True,
+                        help="The hdf file to save the templates and "
+                        "compressed waveforms to.")
+    parser.add_argument("--low-frequency-cutoff", type=float, default=None,
+                        help="The low frequency cutoff to use for generating "
+                        "the waveforms (Hz). If this is not provided, the code "
+                        "will look for a low frequency cutoff corressponding "
+                        "to each template stored in the bank. If a "
+                        "--low-frequency-cutoff is provided and the bank stores "
+                        "a low frequency cutoff for each template as well, the "
+                        "former is used to generate the waveforms.")
+    pycbc.waveform.bank.add_approximant_arg(parser)
+    parser.add_argument("--sample-rate", type=int, required=True,
+                        help="Half this value sets the maximum frequency of "
+                        "the compressed waveforms. Must be a power of 2.")
+    parser.add_argument("--segment-length", type=int, required=True,
+                        help="The segment length to use for generating the "
+                        "templates for compression, and for calculating "
+                        "overlap for tolerance. Must be a power of 2, "
+                        "and at least twice as long as the longest template "
+                        "in the bank.")
+    parser.add_argument("--tmplt-index", nargs=2, type=int, default=None,
+                        help="Only generate compressed waveforms for the given "
+                        "indices in the bank file. Must provide both a start "
+                        "and a stop index. Default is to compress all of the "
+                        "templates in the bank file.")
+    parser.add_argument("--compression-algorithm", type=str, required=True,
+                        choices=list(compress.compression_algorithms.keys()) + ['bounds'],
+                        help="The compression algorithm to use for selecting "
+                        "frequency points.")
+    parser.add_argument("--nprocesses", type=int, default=1,
+                        help="Number of parallel processes to use.")
+    parser.add_argument("--t-pad", type=float, default=0.001,
+                        help="The minimum duration used for t(f) in seconds. "
+                        "The inverse of this gives the maximum frequency "
+                        "step that will be used in the compressed waveforms. "
+                        "Default is 0.001.")
+    parser.add_argument("--tolerance", type=float, default=0.001,
+                        help="The maximum mismatch to allow between the "
+                        "interpolated waveform must and the full waveform. "
+                        "Points will be added to the compressed waveform "
+                        "until its interpolation has a mismatch <= this value. "
+                        "Default is 0.001.")
+    parser.add_argument("--interpolation", type=str, default="inline_linear",
+                        help="The interpolation to use for decompressing the "
+                        "waveforms for checking tolerance. Options are "
+                        "'inline_linear', or any interpolation recognized by "
+                        "scipy's interp1d kind argument. Default is inline_linear.")
+    parser.add_argument("--precision", type=str, choices=["double", "single"],
+                        default="single",
+                        help="What precision to generate and store the "
+                        "waveforms with; default is double.")
+    parser.add_argument("--force", action="store_true", default=False,
+                        help="Overwrite the given hdf file if it exists. "
+                        "Otherwise, an error is raised.")
+    parser.add_argument("--scale", type=float, default=1,
+                        help="Scale factor to apply to the courseness of the initial "
+                             "compression points. >1 means a courser set of initial "
+                             "points. The algorithm will still add points to meet"
+                             "the tolerance goals.")
+    parser.add_argument("--do-not-compress", nargs="+",
+                        help="If given, will not compress waveforms using "
+                             "the given approximant. Recommended 'SPAtmplt TaylorF2'.")
+
+    pycbc.psd.insert_psd_option_group(parser, include_data_options=False)
+    args = parser.parse_args()
+
+    pycbc.init_logging(args.verbose)
+
+    if args.psd_model or args.psd_file or args.asd_file:
+        pycbc.psd.verify_psd_options(args, parser)
+
+    if args.sample_rate % 2 != 0:
+        raise ValueError("sample rate must be a power of 2")
+    if args.segment_length % 2 != 0:
+        raise ValueError("segment length must be a power of 2")
+
+    if args.do_not_compress is None:
+        args.do_not_compress = []
+
+    df_val = 1./args.segment_length
+    fmax = args.sample_rate/2.
+    N = args.sample_rate * args.segment_length
+    dtype = numpy.complex128
+
+    logging.info("loading bank")
+    bank_obj = waveform.FilterBank(args.bank_file, N//2+1, df_val, dtype,
+                                   low_frequency_cutoff=args.low_frequency_cutoff,
+                                   approximant=args.approximant,
+                                   enable_compressed_waveforms=False)
+    
+    if args.tmplt_index is not None:
+        imin, imax = args.tmplt_index
+        bank_obj.table = bank_obj.table[imin:imax]
+
+    # Map shared globals for workers
+    bank_table = bank_obj.table
+    do_not_compress = args.do_not_compress
+    seg_len = args.segment_length
+    tol = args.tolerance
+    interp = args.interpolation
+    alg = args.compression_algorithm
+    t_pad = args.t_pad
+    scale_val = args.scale
+    
+    logging.info("getting psd")
+    psd_obj = pycbc.psd.from_cli(args, length=N//2+1, delta_f=df_val,
+                                 low_frequency_cutoff=bank_table.f_lower.min(),
+                                 dyn_range_factor=pycbc.DYN_RANGE_FAC,
+                                 precision='double')
+
+    logging.info("writing template info to output")
+    output = bank_obj.write_to_hdf(args.output, force=args.force,
+                                   write_compressed_waveforms=False)
+    output.create_group("compressed_waveforms")
+
+    logging.info("Starting compression with %d processes", args.nprocesses)
+    
+    pool = multiprocessing.Pool(processes=args.nprocesses)
+    results = pool.imap_unordered(_worker, range(bank_table.size))
+
+    for result in results:
+        if result is None:
+            continue
+        idx, tmplt_hash, hcompressed, duration = result
+        
+        # Verify segment length against duration one last time in main thread
+        if args.segment_length < 2*duration:
+            raise ValueError("segment length is < twice the duration "
+                             "({}) of template {}".format(duration, tmplt_hash))
+                             
+        output['template_duration'][idx] = duration
+        hcompressed.write_to_hdf(output, tmplt_hash, precision=args.precision)
+        logging.info("Saved compressed template %s", tmplt_hash)
+
+    pool.close()
+    pool.join()
+    output.close()
+    logging.info("finished")

--- a/bin/pycbc_compress_bank
+++ b/bin/pycbc_compress_bank
@@ -62,7 +62,7 @@ parser.add_argument("--tmplt-index", nargs=2, type=int, default=None,
                     "and a stop index. Default is to compress all of the "
                     "templates in the bank file.")
 parser.add_argument("--compression-algorithm", type=str, required=True,
-                    choices=compress.compression_algorithms.keys(),
+                    choices=list(compress.compression_algorithms.keys()) + ['bounds'],
                     help="The compression algorithm to use for selecting "
                     "frequency points.")
 parser.add_argument("--t-pad", type=float, default=0.001,
@@ -173,6 +173,11 @@ for ii in range(templates.size):
     logging.info("... %.2f ms to generate normally", htime * 1000)
     fmin=tmplt.f_lower
     template_duration = htilde.chirp_length
+    
+    if template_duration is None:
+        template_duration = args.segment_length // 2
+        logging.info("Warning: was not able to determine template duration, setting half segment length")
+    
     output['template_duration'][ii] = template_duration
     # check that the segment length is at least twice the template duration
     if args.segment_length < 2*template_duration:
@@ -180,12 +185,14 @@ for ii in range(templates.size):
                          "({}) of template {}".format(template_duration,
                          tmplt.template_hash))
     kmin = int(numpy.ceil(fmin / df))
+    htilde[:kmin] = 0 # This ensures proper phase unwrapping
     if numpy.abs(htilde[kmin]) == 0:
         raise ValueError("""The amplitude of the waveform at the
                          low_frequency_cutoff is zero. A non-zero value
                          is required.""")
+                         
     kmax = numpy.nonzero(abs(htilde))[0][-1]
-
+    
     # get the compressed sample points
     if args.compression_algorithm == 'mchirp':
         sample_points = compress.mchirp_compression(tmplt.mass1, tmplt.mass2,
@@ -196,6 +203,8 @@ for ii in range(templates.size):
         sample_points = compress.spa_compression(htilde, fmin, kmax*df,
             min_seglen=args.t_pad,
             scale=args.scale).astype(real_same_precision_as(htilde))
+    elif args.compression_algorithm == 'bounds':
+        sample_points = numpy.array([fmin, kmax*df])
     else:
         raise ValueError("unrecognized compression algorithm %s" %(
             args.compression_algorithm))

--- a/pycbc/waveform/compress.py
+++ b/pycbc/waveform/compress.py
@@ -233,10 +233,9 @@ def compress_waveform(htilde, sample_points, tolerance, interpolation,
     """
     fmin = sample_points.min()
     df = htilde.delta_f
-    
-    # Original truncation restored per your requirement
+
     sample_index = (sample_points / df).astype(int)
-    
+
     amp = utils.amplitude_from_frequencyseries(htilde)
     phase = utils.phase_from_frequencyseries(htilde)
 
@@ -254,19 +253,28 @@ def compress_waveform(htilde, sample_points, tolerance, interpolation,
     kmax = min(len(htilde), len(hdecomp))
     htilde = htilde[:kmax]
     hdecomp = hdecomp[:kmax]
-    
+
+    s1 = filter.sigma(hdecomp, psd=psd, low_frequency_cutoff=fmin)    
     s2 = filter.sigma(htilde, psd=psd, low_frequency_cutoff=fmin)
     if psd is not None:
         htilde2 = htilde / (psd * s2)
     else:
         htilde2 = htilde / s2
-    
-    s1 = filter.sigma(hdecomp, psd=psd, low_frequency_cutoff=fmin)
+
+    # Do a first test to see if we are done
     mismatch = 1. - abs(filter.overlap_cplx(hdecomp / s1, htilde2,
-                                  low_frequency_cutoff=fmin, normalized=False))
-    
+                                  low_frequency_cutoff=fmin, normalized=False))  
     if mismatch > tolerance:
+        # Calculate the overlap erros within each frequency bins.
+        # We use this to determine where to add more interpolation points
         vecdiffs = vecdiff(htilde, hdecomp, sample_points, psd=psd)
+
+
+    # We will find where in the frequency series the interpolated waveform
+    # has the smallest overlap with the full waveform, 
+    # We try to add a new interpolation point in every frequency bin
+    # that fails this check. Continue untill the overall reconstruction 
+    # waveform meets our mismatch target with the origianl waveform
 
     added_points = []
     iteration_count = 0
@@ -285,6 +293,8 @@ def compress_waveform(htilde, sample_points, tolerance, interpolation,
             selected_segments = bad_segments[:max_batch_size]
         else:
             # Scalpel phase
+            # If we don't have that many bad segments, but still haven't
+            # converged, add at least a small number to see if that helps
             num_to_add = min(20, len(vecdiffs))
             selected_segments = vecdiffs.argsort()[::-1][:num_to_add]
         
@@ -293,7 +303,6 @@ def compress_waveform(htilde, sample_points, tolerance, interpolation,
         for minpt in selected_segments:
             # Calculate midpoint using indices to avoid float drift issues
             add_freq = (sample_points[minpt] + sample_points[minpt+1]) / 2.0
-            # Restoration of original truncation logic for midpoint placement
             addidx = int(add_freq / df) 
             
             if addidx not in sample_index and addidx not in new_addidxs:
@@ -344,8 +353,9 @@ def compress_waveform(htilde, sample_points, tolerance, interpolation,
             mismatch = 1. - abs(filter.overlap_cplx(hdecomp / s1, htilde2,
                                             low_frequency_cutoff=fmin,
                                             normalized=False))
-            
-        if mismatch > tolerance:
+        else mismatch > tolerance:
+            # Calculate the overlap erros within each frequency bins.
+            # We use this to determine where to add more interpolation points
             vecdiffs = vecdiff(htilde, hdecomp, sample_points, psd=psd)
             
         added_points.extend(new_addidxs)

--- a/pycbc/waveform/compress.py
+++ b/pycbc/waveform/compress.py
@@ -351,7 +351,7 @@ def compress_waveform(htilde, sample_points, tolerance, interpolation,
         added_points.extend(new_addidxs)
         
         # --- 6. Iteration Logging ---
-        logging.info(
+        logging.debug(
             "Iter %i: mismatch %.6f, added %i points (total %i), iter time %.2f ms",
             iteration_count, mismatch, len(new_addidxs), len(sample_points),
             (time.time() - iteration_start_time) * 1000

--- a/pycbc/waveform/compress.py
+++ b/pycbc/waveform/compress.py
@@ -231,9 +231,13 @@ def compress_waveform(htilde, sample_points, tolerance, interpolation,
     CompressedWaveform
         The compressed waveform data; see `CompressedWaveform` for details.
     """
+  
     fmin = sample_points.min()
     df = htilde.delta_f
+    
+    # Original truncation restored per request
     sample_index = (sample_points / df).astype(int)
+    
     amp = utils.amplitude_from_frequencyseries(htilde)
     phase = utils.phase_from_frequencyseries(htilde)
 
@@ -249,9 +253,11 @@ def compress_waveform(htilde, sample_points, tolerance, interpolation,
                             out=decomp_scratch, df=outdf, f_lower=fmin,
                             interpolation=interpolation)
     htime = time.time() - t1
+    
     kmax = min(len(htilde), len(hdecomp))
     htilde = htilde[:kmax]
     hdecomp = hdecomp[:kmax]
+    
     s1 = filter.sigma(hdecomp, psd=psd, low_frequency_cutoff=fmin)    
     s2 = filter.sigma(htilde, psd=psd, low_frequency_cutoff=fmin)
     
@@ -262,75 +268,104 @@ def compress_waveform(htilde, sample_points, tolerance, interpolation,
     
     mismatch = 1. - abs(filter.overlap_cplx(hdecomp / s1, htilde2,
                                   low_frequency_cutoff=fmin, normalized=False))
+    
     if mismatch > tolerance:
-        # we'll need the difference in the waveforms as a function of frequency
         vecdiffs = vecdiff(htilde, hdecomp, sample_points, psd=psd)
 
-    # We will find where in the frequency series the interpolated waveform
-    # has the smallest overlap with the full waveform, add a sample point
-    # there, and re-interpolate. We repeat this until the overall mismatch
-    # is > than the desired tolerance
     added_points = []
+    iteration_count = 0
+    # Safety cap to prevent Runge's phenomenon from massive single-pass injections
+    max_batch_size = 100 
+    
     while mismatch > tolerance:
-        minpt = vecdiffs.argmax()
-        # add a point at the frequency halfway between minpt and minpt+1
-        add_freq = sample_points[[minpt, minpt+1]].mean()
-        addidx = int(round(add_freq/df))
-        # ensure that only new points are added
-        if addidx in sample_index:
+        iteration_start_time = time.time()
+        iteration_count += 1
+        
+        # --- 1. Absolute Heuristic Selection ---
+        # Find all segments whose local error exceeds the global budget
+        bad_segments = numpy.where(vecdiffs > tolerance)[0]
+        
+        if len(bad_segments) > 0:
+            # Sledgehammer Phase: Take all failing segments (up to safety cap)
+            # Sort by error magnitude so we prioritize the worst violators
+            bad_segments = bad_segments[numpy.argsort(vecdiffs[bad_segments])[::-1]]
+            selected_segments = bad_segments[:max_batch_size]
+        else:
+            # Scalpel Phase: No single segment violates tolerance, but the sum does.
+            # Pick the top 5 worst remaining segments to push the sum down.
+            selected_segments = vecdiffs.argsort()[::-1][:5]
+        
+        # --- 2. Propose new points ---
+        new_addidxs = []
+        for minpt in selected_segments:
+            add_freq = sample_points[[minpt, minpt+1]].mean()
+            addidx = int(add_freq / df) 
+            if addidx not in sample_index and addidx not in new_addidxs:
+                new_addidxs.append(addidx)
+                
+        # Fallback: Collision handling
+        if not new_addidxs:
             diffidx = vecdiffs.argsort()
             addpt = -1
-            while addidx in sample_index:
-                addpt -= 1
+            while True:
                 try:
                     minpt = diffidx[addpt]
                 except IndexError:
                     raise ValueError("unable to compress to desired tolerance")
+                
                 add_freq = sample_points[[minpt, minpt+1]].mean()
-                addidx = int(round(add_freq/df))
-        new_index = numpy.zeros(sample_index.size+1, dtype=int)
-        new_index[:minpt+1] = sample_index[:minpt+1]
-        new_index[minpt+1] = addidx
-        new_index[minpt+2:] = sample_index[minpt+1:]
+                addidx = int(add_freq / df)
+                if addidx not in sample_index:
+                    new_addidxs.append(addidx)
+                    break
+                addpt -= 1
+
+        # --- 3. Update sample points ---
+        new_index = numpy.concatenate((sample_index, new_addidxs))
+        new_index.sort()
         sample_index = new_index
-        sample_points = (sample_index * df).astype(
-            real_same_precision_as(htilde))
+        sample_points = (sample_index * df).astype(real_same_precision_as(htilde))
             
-        # get the new compressed points
         comp_amp = amp.take(sample_index)
         comp_phase = phase.take(sample_index)
-        # update the vecdiffs and mismatch
         
+        # --- 4. Decompress ---
         t1 = time.time()
         hdecomp = fd_decompress(comp_amp, comp_phase, sample_points,
                                 out=decomp_scratch, df=outdf,
                                 f_lower=fmin, interpolation=interpolation)
-        
+        # htime records only the single final pass timing at loop exit
         htime = time.time() - t1
         hdecomp = hdecomp[:kmax]
-        new_vecdiffs = numpy.zeros(vecdiffs.size+1)
-        new_vecdiffs[:minpt] = vecdiffs[:minpt]
-        new_vecdiffs[minpt+2:] = vecdiffs[minpt+1:]
-        new_vecdiffs[minpt:minpt+2] = vecdiff(htilde, hdecomp,
-                                              sample_points[minpt:minpt+2],
-                                              psd=psd)
-        vecdiffs = new_vecdiffs
   
+        # --- 5. Re-evaluate global mismatch ---
         mismatch = 1. - abs(filter.overlap_cplx(hdecomp / s2, htilde2,
                                             low_frequency_cutoff=fmin,
-                                            normalized=False,
-                                           ))
-
+                                            normalized=False))
+        
         if mismatch <= tolerance:
             s1 = filter.sigma(hdecomp, psd=psd, low_frequency_cutoff=fmin)
             mismatch = 1. - abs(filter.overlap_cplx(hdecomp / s1, htilde2,
                                             low_frequency_cutoff=fmin,
-                                            normalized=False,
-                                           ))
-        added_points.append(addidx)
+                                            normalized=False))
+            
+        # --- 6. Rebuild vecdiffs ---
+        if mismatch > tolerance:
+            vecdiffs = vecdiff(htilde, hdecomp, sample_points, psd=psd)
+            
+        added_points.extend(new_addidxs)
+        
+        # --- 7. Iteration Logging ---
+        iter_time = time.time() - iteration_start_time
+        logging.debug(
+            "Iter %i: mismatch %.6f, added %i points (total %i), iter time %.2f ms",
+            iteration_count, mismatch, len(new_addidxs), len(sample_points),
+            iter_time * 1000
+        )
+
     compression_factor = len(htilde) / len(sample_points)
     logging.info(
-        "mismatch: %f, N points: %i (%i added), compression:%.3e, time %.2f ms",
+        "mismatch: %f, N points: %i (%i added), compression:%.3e, final decomp time %.2f ms",
         mismatch,
         len(comp_amp),
         len(added_points),
@@ -343,7 +378,6 @@ def compress_waveform(htilde, sample_points, tolerance, interpolation,
                               tolerance=tolerance, mismatch=mismatch,
                               precision=precision,
                               compression_factor=compression_factor)
-
 _precision_map = {
     'float32': 'single',
     'float64': 'double',

--- a/pycbc/waveform/compress.py
+++ b/pycbc/waveform/compress.py
@@ -165,14 +165,10 @@ compression_algorithms = {
         }
 
 def _vecdiff(htilde, hinterp, fmin, fmax, psd=None):
-    return abs(filter.overlap_cplx(htilde, htilde,
+    return 1 - abs(filter.overlap_cplx(htilde, hinterp,
                           low_frequency_cutoff=fmin,
                           high_frequency_cutoff=fmax,
-                          normalized=False, psd=psd)
-               - filter.overlap_cplx(htilde, hinterp,
-                          low_frequency_cutoff=fmin,
-                          high_frequency_cutoff=fmax,
-                          normalized=False, psd=psd))
+                          psd=psd))
 
 def vecdiff(htilde, hinterp, sample_points, psd=None):
     """Computes a statistic indicating between which sample points a waveform
@@ -254,10 +250,11 @@ def compress_waveform(htilde, sample_points, tolerance, interpolation,
     htilde = htilde[:kmax]
     hdecomp = hdecomp[:kmax]
 
-    s1 = filter.sigma(hdecomp, psd=psd, low_frequency_cutoff=fmin)    
+    s1 = filter.sigma(hdecomp, psd=psd, low_frequency_cutoff=fmin)
     s2 = filter.sigma(htilde, psd=psd, low_frequency_cutoff=fmin)
+
     if psd is not None:
-        htilde2 = htilde / (psd * s2)
+        htilde2 = htilde / (psd[:len(htilde)] * s2)
     else:
         htilde2 = htilde / s2
 
@@ -275,63 +272,39 @@ def compress_waveform(htilde, sample_points, tolerance, interpolation,
     # We try to add a new interpolation point in every frequency bin
     # that fails this check. Continue untill the overall reconstruction 
     # waveform meets our mismatch target with the origianl waveform
-
     added_points = []
     iteration_count = 0
-    max_batch_size = 100 
-    
+    max_batch_size = 100
+
     while mismatch > tolerance:
         iteration_start_time = time.time()
         iteration_count += 1
         
-        # --- 1. Absolute Heuristic Selection ---
-        bad_segments = numpy.where(vecdiffs > tolerance)[0]
+        # Pick the worst bins
+        num_bad = (vecdiffs > tolerance).sum()
+        vsort = vecdiffs.argsort()[::-1]
         
-        if len(bad_segments) > 0:
-            # Sledgehammer phase
-            bad_segments = bad_segments[numpy.argsort(vecdiffs[bad_segments])[::-1]]
-            selected_segments = bad_segments[:max_batch_size]
-        else:
-            # Scalpel phase
-            # If we don't have that many bad segments, but still haven't
-            # converged, add at least a small number to see if that helps
-            num_to_add = min(20, len(vecdiffs))
-            selected_segments = vecdiffs.argsort()[::-1][:num_to_add]
-        
+        # This add fraction of the bad segments, up to a maximum 
+        # If there are no bad segments, we still try to add the first single
+        # one (can be large numerical error in the veddiff calculation, so
+        # rounding cause all to be below the tolerance yet thte full fails).
+        num_select = min(max_batch_size, (num_bad // 4 + 1))
+        selected_segments = vsort[:num_select]
+
         # --- 2. Propose new points ---
         new_addidxs = []
         for minpt in selected_segments:
             # Calculate midpoint using indices to avoid float drift issues
             add_freq = (sample_points[minpt] + sample_points[minpt+1]) / 2.0
-            addidx = int(add_freq / df) 
-            
+            addidx = int(add_freq / df)     
             if addidx not in sample_index and addidx not in new_addidxs:
                 new_addidxs.append(addidx)
-                
-        # Fallback for collisions
-        if not new_addidxs:
-            diffidx = vecdiffs.argsort()
-            addpt = -1
-            while True:
-                try:
-                    minpt = diffidx[addpt]
-                    add_freq = (sample_points[minpt] + sample_points[minpt+1]) / 2.0
-                    addidx = int(add_freq / df)
-                    if addidx not in sample_index:
-                        new_addidxs.append(addidx)
-                        break
-                    if (addidx + 1) not in sample_index:
-                        new_addidxs.append(addidx + 1)
-                        break
-                except IndexError:
-                    raise ValueError("unable to compress to desired tolerance")
-                addpt -= 1
 
         # --- 3. Update and Sort ---
         sample_index = numpy.unique(numpy.concatenate((sample_index, new_addidxs)))
         sample_index.sort()
+        sample_index = sample_index.astype(int)
         sample_points = (sample_index * df).astype(real_same_precision_as(htilde))
-            
         comp_amp = amp.take(sample_index)
         comp_phase = phase.take(sample_index)
         
@@ -340,16 +313,20 @@ def compress_waveform(htilde, sample_points, tolerance, interpolation,
         hdecomp = fd_decompress(comp_amp, comp_phase, sample_points,
                                 out=decomp_scratch, df=outdf,
                                 f_lower=fmin, interpolation=interpolation)
-        htime = time.time() - t1 # Record only this pass
-        hdecomp = hdecomp[:kmax]
-  
+        htime = time.time() - t1
+
+        s1 = filter.sigma(hdecomp, psd=psd, low_frequency_cutoff=fmin)
+
         # --- 5. Re-evaluate global mismatch ---
-        mismatch = 1. - abs(filter.overlap_cplx(hdecomp / s2, htilde2,
+        mismatch = 1. - abs(filter.overlap_cplx(hdecomp / s1, htilde2,
                                             low_frequency_cutoff=fmin,
                                             normalized=False))
-        
+
+        o = filter.overlap_cplx(hdecomp / s1, htilde2,
+                                low_frequency_cutoff=fmin,
+                                normalized=False)
+
         if mismatch <= tolerance:
-            s1 = filter.sigma(hdecomp, psd=psd, low_frequency_cutoff=fmin)
             mismatch = 1. - abs(filter.overlap_cplx(hdecomp / s1, htilde2,
                                             low_frequency_cutoff=fmin,
                                             normalized=False))
@@ -357,9 +334,9 @@ def compress_waveform(htilde, sample_points, tolerance, interpolation,
             # Calculate the overlap errors within each frequency bins.
             # We use this to determine where to add more interpolation points
             vecdiffs = vecdiff(htilde, hdecomp, sample_points, psd=psd)
-            
+
         added_points.extend(new_addidxs)
-        
+
         # --- 6. Iteration Logging ---
         logging.debug(
             "Iter %i: mismatch %.6f, added %i points (total %i), iter time %.2f ms",

--- a/pycbc/waveform/compress.py
+++ b/pycbc/waveform/compress.py
@@ -949,4 +949,5 @@ class CompressedWaveform(object):
             tolerance=fp_group.attrs['tolerance'],
             mismatch=fp_group.attrs['mismatch'],
             precision=fp_group.attrs['precision'],
+            compression_factor=fp_group.attrs['compression_factor'],
             load_to_memory=load_to_memory)

--- a/pycbc/waveform/compress.py
+++ b/pycbc/waveform/compress.py
@@ -231,7 +231,6 @@ def compress_waveform(htilde, sample_points, tolerance, interpolation,
     CompressedWaveform
         The compressed waveform data; see `CompressedWaveform` for details.
     """
-  
     fmin = sample_points.min()
     df = htilde.delta_f
     

--- a/pycbc/waveform/compress.py
+++ b/pycbc/waveform/compress.py
@@ -272,6 +272,7 @@ def compress_waveform(htilde, sample_points, tolerance, interpolation,
     # is > than the desired tolerance
     added_points = []
     while mismatch > tolerance:
+        print(mismatch, len(sample_points))
         minpt = vecdiffs.argmax()
         # add a point at the frequency halfway between minpt and minpt+1
         add_freq = sample_points[[minpt, minpt+1]].mean()
@@ -305,6 +306,7 @@ def compress_waveform(htilde, sample_points, tolerance, interpolation,
         hdecomp = fd_decompress(comp_amp, comp_phase, sample_points,
                                 out=decomp_scratch, df=outdf,
                                 f_lower=fmin, interpolation=interpolation)
+        
         htime = time.time() - t1
         hdecomp = hdecomp[:kmax]
         new_vecdiffs = numpy.zeros(vecdiffs.size+1)
@@ -319,6 +321,20 @@ def compress_waveform(htilde, sample_points, tolerance, interpolation,
                                             low_frequency_cutoff=fmin,
                                             normalized=False,
                                            ))
+
+        from matplotlib import pyplot as plt
+        if len(sample_points) % 1000 == 0:
+            #htilde.real().plot(alpha=0.5, label='target')
+            #hdecomp.real().plot(alpha=0.5, label='reconstructed match=%s' % (1-mismatch))
+            phase.plot(label='target')
+            phase2 = utils.phase_from_frequencyseries(hdecomp)
+            phase2.plot(label='reconstructed')
+            
+            plt.xscale('log')
+            plt.xlim(30, 1024)
+            plt.legend()
+            plt.show()
+
         
         if mismatch <= tolerance:
             s1 = filter.sigma(hdecomp, psd=psd, low_frequency_cutoff=fmin)

--- a/pycbc/waveform/compress.py
+++ b/pycbc/waveform/compress.py
@@ -272,7 +272,6 @@ def compress_waveform(htilde, sample_points, tolerance, interpolation,
     # is > than the desired tolerance
     added_points = []
     while mismatch > tolerance:
-        print(mismatch, len(sample_points))
         minpt = vecdiffs.argmax()
         # add a point at the frequency halfway between minpt and minpt+1
         add_freq = sample_points[[minpt, minpt+1]].mean()
@@ -322,20 +321,6 @@ def compress_waveform(htilde, sample_points, tolerance, interpolation,
                                             normalized=False,
                                            ))
 
-        from matplotlib import pyplot as plt
-        if len(sample_points) % 1000 == 0:
-            #htilde.real().plot(alpha=0.5, label='target')
-            #hdecomp.real().plot(alpha=0.5, label='reconstructed match=%s' % (1-mismatch))
-            phase.plot(label='target')
-            phase2 = utils.phase_from_frequencyseries(hdecomp)
-            phase2.plot(label='reconstructed')
-            
-            plt.xscale('log')
-            plt.xlim(30, 1024)
-            plt.legend()
-            plt.show()
-
-        
         if mismatch <= tolerance:
             s1 = filter.sigma(hdecomp, psd=psd, low_frequency_cutoff=fmin)
             mismatch = 1. - abs(filter.overlap_cplx(hdecomp / s1, htilde2,

--- a/pycbc/waveform/compress.py
+++ b/pycbc/waveform/compress.py
@@ -265,7 +265,7 @@ def compress_waveform(htilde, sample_points, tolerance, interpolation,
     mismatch = 1. - abs(filter.overlap_cplx(hdecomp / s1, htilde2,
                                   low_frequency_cutoff=fmin, normalized=False))  
     if mismatch > tolerance:
-        # Calculate the overlap erros within each frequency bins.
+        # Calculate the overlap errors within each frequency bins.
         # We use this to determine where to add more interpolation points
         vecdiffs = vecdiff(htilde, hdecomp, sample_points, psd=psd)
 
@@ -353,8 +353,8 @@ def compress_waveform(htilde, sample_points, tolerance, interpolation,
             mismatch = 1. - abs(filter.overlap_cplx(hdecomp / s1, htilde2,
                                             low_frequency_cutoff=fmin,
                                             normalized=False))
-        else mismatch > tolerance:
-            # Calculate the overlap erros within each frequency bins.
+        else:
+            # Calculate the overlap errors within each frequency bins.
             # We use this to determine where to add more interpolation points
             vecdiffs = vecdiff(htilde, hdecomp, sample_points, psd=psd)
             

--- a/pycbc/waveform/compress.py
+++ b/pycbc/waveform/compress.py
@@ -234,7 +234,7 @@ def compress_waveform(htilde, sample_points, tolerance, interpolation,
     fmin = sample_points.min()
     df = htilde.delta_f
     
-    # Original truncation restored per request
+    # Original truncation restored per your requirement
     sample_index = (sample_points / df).astype(int)
     
     amp = utils.amplitude_from_frequencyseries(htilde)
@@ -242,29 +242,26 @@ def compress_waveform(htilde, sample_points, tolerance, interpolation,
 
     comp_amp = amp.take(sample_index)
     comp_phase = phase.take(sample_index)
-    if decomp_scratch is None:
-        outdf = df
-    else:
-        outdf = None
+    outdf = df if decomp_scratch is None else None
     
     t1 = time.time()
     hdecomp = fd_decompress(comp_amp, comp_phase, sample_points,
                             out=decomp_scratch, df=outdf, f_lower=fmin,
                             interpolation=interpolation)
+    # This will be overwritten in the loop to store the final pass time
     htime = time.time() - t1
     
     kmax = min(len(htilde), len(hdecomp))
     htilde = htilde[:kmax]
     hdecomp = hdecomp[:kmax]
     
-    s1 = filter.sigma(hdecomp, psd=psd, low_frequency_cutoff=fmin)    
     s2 = filter.sigma(htilde, psd=psd, low_frequency_cutoff=fmin)
-    
     if psd is not None:
-        htilde2 = htilde / psd / s2
+        htilde2 = htilde / (psd * s2)
     else:
         htilde2 = htilde / s2
     
+    s1 = filter.sigma(hdecomp, psd=psd, low_frequency_cutoff=fmin)
     mismatch = 1. - abs(filter.overlap_cplx(hdecomp / s1, htilde2,
                                   low_frequency_cutoff=fmin, normalized=False))
     
@@ -273,7 +270,6 @@ def compress_waveform(htilde, sample_points, tolerance, interpolation,
 
     added_points = []
     iteration_count = 0
-    # Safety cap to prevent Runge's phenomenon from massive single-pass injections
     max_batch_size = 100 
     
     while mismatch > tolerance:
@@ -281,48 +277,50 @@ def compress_waveform(htilde, sample_points, tolerance, interpolation,
         iteration_count += 1
         
         # --- 1. Absolute Heuristic Selection ---
-        # Find all segments whose local error exceeds the global budget
         bad_segments = numpy.where(vecdiffs > tolerance)[0]
         
         if len(bad_segments) > 0:
-            # Sledgehammer Phase: Take all failing segments (up to safety cap)
-            # Sort by error magnitude so we prioritize the worst violators
+            # Sledgehammer phase
             bad_segments = bad_segments[numpy.argsort(vecdiffs[bad_segments])[::-1]]
             selected_segments = bad_segments[:max_batch_size]
         else:
-            # Scalpel Phase: No single segment violates tolerance, but the sum does.
-            # Pick the top 5 worst remaining segments to push the sum down.
-            selected_segments = vecdiffs.argsort()[::-1][:5]
+            # Scalpel phase
+            num_to_add = min(20, len(vecdiffs))
+            selected_segments = vecdiffs.argsort()[::-1][:num_to_add]
         
         # --- 2. Propose new points ---
         new_addidxs = []
         for minpt in selected_segments:
-            add_freq = sample_points[[minpt, minpt+1]].mean()
+            # Calculate midpoint using indices to avoid float drift issues
+            add_freq = (sample_points[minpt] + sample_points[minpt+1]) / 2.0
+            # Restoration of original truncation logic for midpoint placement
             addidx = int(add_freq / df) 
+            
             if addidx not in sample_index and addidx not in new_addidxs:
                 new_addidxs.append(addidx)
                 
-        # Fallback: Collision handling
+        # Fallback for collisions
         if not new_addidxs:
             diffidx = vecdiffs.argsort()
             addpt = -1
             while True:
                 try:
                     minpt = diffidx[addpt]
+                    add_freq = (sample_points[minpt] + sample_points[minpt+1]) / 2.0
+                    addidx = int(add_freq / df)
+                    if addidx not in sample_index:
+                        new_addidxs.append(addidx)
+                        break
+                    if (addidx + 1) not in sample_index:
+                        new_addidxs.append(addidx + 1)
+                        break
                 except IndexError:
                     raise ValueError("unable to compress to desired tolerance")
-                
-                add_freq = sample_points[[minpt, minpt+1]].mean()
-                addidx = int(add_freq / df)
-                if addidx not in sample_index:
-                    new_addidxs.append(addidx)
-                    break
                 addpt -= 1
 
-        # --- 3. Update sample points ---
-        new_index = numpy.concatenate((sample_index, new_addidxs))
-        new_index.sort()
-        sample_index = new_index
+        # --- 3. Update and Sort ---
+        sample_index = numpy.unique(numpy.concatenate((sample_index, new_addidxs)))
+        sample_index.sort()
         sample_points = (sample_index * df).astype(real_same_precision_as(htilde))
             
         comp_amp = amp.take(sample_index)
@@ -333,8 +331,7 @@ def compress_waveform(htilde, sample_points, tolerance, interpolation,
         hdecomp = fd_decompress(comp_amp, comp_phase, sample_points,
                                 out=decomp_scratch, df=outdf,
                                 f_lower=fmin, interpolation=interpolation)
-        # htime records only the single final pass timing at loop exit
-        htime = time.time() - t1
+        htime = time.time() - t1 # Record only this pass
         hdecomp = hdecomp[:kmax]
   
         # --- 5. Re-evaluate global mismatch ---
@@ -348,28 +345,24 @@ def compress_waveform(htilde, sample_points, tolerance, interpolation,
                                             low_frequency_cutoff=fmin,
                                             normalized=False))
             
-        # --- 6. Rebuild vecdiffs ---
         if mismatch > tolerance:
             vecdiffs = vecdiff(htilde, hdecomp, sample_points, psd=psd)
             
         added_points.extend(new_addidxs)
         
-        # --- 7. Iteration Logging ---
-        iter_time = time.time() - iteration_start_time
-        logging.debug(
+        # --- 6. Iteration Logging ---
+        logging.info(
             "Iter %i: mismatch %.6f, added %i points (total %i), iter time %.2f ms",
             iteration_count, mismatch, len(new_addidxs), len(sample_points),
-            iter_time * 1000
+            (time.time() - iteration_start_time) * 1000
         )
 
-    compression_factor = len(htilde) / len(sample_points)
+    # Cast compression_factor to float to avoid HDF5 TypeErrors
+    compression_factor = float(len(htilde)) / float(len(sample_points))
+    
     logging.info(
         "mismatch: %f, N points: %i (%i added), compression:%.3e, final decomp time %.2f ms",
-        mismatch,
-        len(comp_amp),
-        len(added_points),
-        compression_factor,
-        htime * 1000,
+        mismatch, len(comp_amp), len(added_points), compression_factor, htime * 1000,
     )
 
     return CompressedWaveform(sample_points, comp_amp, comp_phase,

--- a/pycbc/waveform/compress.py
+++ b/pycbc/waveform/compress.py
@@ -254,7 +254,12 @@ def compress_waveform(htilde, sample_points, tolerance, interpolation,
     hdecomp = hdecomp[:kmax]
     s1 = filter.sigma(hdecomp, psd=psd, low_frequency_cutoff=fmin)    
     s2 = filter.sigma(htilde, psd=psd, low_frequency_cutoff=fmin)
-    htilde2 = htilde / psd / s2
+    
+    if psd is not None:
+        htilde2 = htilde / psd / s2
+    else:
+        htilde2 = htilde / s2
+    
     mismatch = 1. - abs(filter.overlap_cplx(hdecomp / s1, htilde2,
                                   low_frequency_cutoff=fmin, normalized=False))
     if mismatch > tolerance:

--- a/pycbc/waveform/decompress_cpu_ccode.cpp
+++ b/pycbc/waveform/decompress_cpu_ccode.cpp
@@ -172,30 +172,36 @@ static inline void _decomp_tcode_segment(
     double f0, double f1, double f2, double f3, 
     double a0, double a1, double a2, double a3, 
     double p0, double p1, double p2, double p3,
-    double df, int64_t k_start, const int64_t kmax, // Renamed k to k_start
+    double df, int64_t k_start, const int64_t kmax,
     const int update_interval)
 {
-    double f;
+    double f, x;
     double h2 = df * df;
     double h3 = h2 * df;
 
-    // --- Denominators for Lagrange basis (constant for segment) ---
-    double denom0 = (f0-f1)*(f0-f2)*(f0-f3);
-    double denom1 = (f1-f0)*(f1-f2)*(f1-f3);
-    double denom2 = (f2-f0)*(f2-f1)*(f2-f3);
-    double denom3 = (f3-f0)*(f3-f1)*(f3-f2);
+    // --- ORIGIN SHIFT ---
+    double x0 = 0.0;
+    double x1 = f1 - f0;
+    double x2 = f2 - f0;
+    double x3 = f3 - f0;
 
-    // --- Get power-basis coefficients: c3*f^3 + c2*f^2 + c1*f + c0 ---
+    // --- Denominators for Lagrange basis ---
+    double denom0 = (x0-x1)*(x0-x2)*(x0-x3);
+    double denom1 = (x1-x0)*(x1-x2)*(x1-x3);
+    double denom2 = (x2-x0)*(x2-x1)*(x2-x3);
+    double denom3 = (x3-x0)*(x3-x1)*(x3-x2);
+
+    // --- Get shifted power-basis coefficients ---
     // --- Amplitude ---
     double c_a3 = a0/denom0 + a1/denom1 + a2/denom2 + a3/denom3;
-    double c_a2 = -a0*(f1+f2+f3)/denom0 - a1*(f0+f2+f3)/denom1 - a2*(f0+f1+f3)/denom2 - a3*(f0+f1+f2)/denom3;
-    double c_a1 = a0*(f1*f2 + f1*f3 + f2*f3)/denom0 + a1*(f0*f2 + f0*f3 + f2*f3)/denom1 + a2*(f0*f1 + f0*f3 + f1*f3)/denom2 + a3*(f0*f1 + f0*f2 + f1*f2)/denom3;
-    double c_a0 = -a0*(f1*f2*f3)/denom0 - a1*(f0*f2*f3)/denom1 - a2*(f0*f1*f3)/denom2 - a3*(f0*f1*f2)/denom3;
+    double c_a2 = -a0*(x1+x2+x3)/denom0 - a1*(x0+x2+x3)/denom1 - a2*(x0+x1+x3)/denom2 - a3*(x0+x1+x2)/denom3;
+    double c_a1 = a0*(x1*x2 + x1*x3 + x2*x3)/denom0 + a1*(x0*x2 + x0*x3 + x2*x3)/denom1 + a2*(x0*x1 + x0*x3 + x1*x3)/denom2 + a3*(x0*x1 + x0*x2 + x1*x2)/denom3;
+    double c_a0 = -a0*(x1*x2*x3)/denom0 - a1*(x0*x2*x3)/denom1 - a2*(x0*x1*x3)/denom2 - a3*(x0*x1*x2)/denom3;
     // --- Phase ---
     double c_p3 = p0/denom0 + p1/denom1 + p2/denom2 + p3/denom3;
-    double c_p2 = -p0*(f1+f2+f3)/denom0 - p1*(f0+f2+f3)/denom1 - p2*(f0+f1+f3)/denom2 - p3*(f0+f1+f2)/denom3;
-    double c_p1 = p0*(f1*f2 + f1*f3 + f2*f3)/denom0 + p1*(f0*f2 + f0*f3 + f2*f3)/denom1 + p2*(f0*f1 + f0*f3 + f1*f3)/denom2 + p3*(f0*f1 + f0*f2 + f1*f2)/denom3;
-    double c_p0 = -p0*(f1*f2*f3)/denom0 - p1*(f0*f2*f3)/denom1 - p2*(f0*f1*f3)/denom2 - p3*(f0*f1*f2)/denom3;
+    double c_p2 = -p0*(x1+x2+x3)/denom0 - p1*(x0+x2+x3)/denom1 - p2*(x0+x1+x3)/denom2 - p3*(x0+x1+x2)/denom3;
+    double c_p1 = p0*(x1*x2 + x1*x3 + x2*x3)/denom0 + p1*(x0*x2 + x0*x3 + x2*x3)/denom1 + p2*(x0*x1 + x0*x3 + x1*x3)/denom2 + p3*(x0*x1 + x0*x2 + x1*x2)/denom3;
+    double c_p0 = -p0*(x1*x2*x3)/denom0 - p1*(x0*x2*x3)/denom1 - p2*(x0*x1*x3)/denom2 - p3*(x0*x1*x2)/denom3;
 
     // --- Finite difference constants (constant for segment) ---
     double d3_a_const = 6 * c_a3 * h3;
@@ -206,48 +212,45 @@ static inline void _decomp_tcode_segment(
     double a, p, d1_a, d1_p, d2_a, d2_p;
     std::complex<double> phase, d1_phase, d2_phase;
     int64_t k_sub_max;
-    int64_t k = k_start; // k is now the local loop variable
+    int64_t k = k_start; 
 
     for (; k < kmax; ) {
-        // --- Re-calculate steppers to correct FP error ---
         f = k * df;
+        x = f - f0; // --- EVALUATE RELATIVE TO ORIGIN ---
         k_sub_max = k + update_interval;
         if (k_sub_max > kmax) k_sub_max = kmax;
 
         // Initial values for this sub-block
-        a = c_a3*f*f*f + c_a2*f*f + c_a1*f + c_a0;
-        p = c_p3*f*f*f + c_p2*f*f + c_p1*f + c_p0;
+        a = c_a3*x*x*x + c_a2*x*x + c_a1*x + c_a0;
+        p = c_p3*x*x*x + c_p2*x*x + c_p1*x + c_p0;
 
-        // First differences at f (Delta_f)
-        d1_a = c_a3*(3*f*f*df + 3*f*h2 + h3) + c_a2*(2*f*df + h2) + c_a1*df;
-        d1_p = c_p3*(3*f*f*df + 3*f*h2 + h3) + c_p2*(2*f*df + h2) + c_p1*df;
+        // First differences at x (Delta_x)
+        d1_a = c_a3*(3*x*x*df + 3*x*h2 + h3) + c_a2*(2*x*df + h2) + c_a1*df;
+        d1_p = c_p3*(3*x*x*df + 3*x*h2 + h3) + c_p2*(2*x*df + h2) + c_p1*df;
 
-        // Second differences at f (Delta^2_f)
-        d2_a = c_a3*(6*f*h2 + 6*h3) + c_a2*(2*h2);
-        d2_p = c_p3*(6*f*h2 + 6*h3) + c_p2*(2*h2);
+        // Second differences at x (Delta^2_x)
+        d2_a = c_a3*(6*x*h2 + 6*h3) + c_a2*(2*h2);
+        d2_p = c_p3*(6*x*h2 + 6*h3) + c_p2*(2*h2);
 
         // Complex phase steppers
         phase = std::polar(1.0, p);
         d1_phase = std::polar(1.0, d1_p);
         d2_phase = std::polar(1.0, d2_p);
 
-        // --- Fast Inner Loop ---
+        // --- Fast Inner Loop (Remains Identical) ---
         for (; k < k_sub_max; k++) {
-            h_seg[k - k_start] = (T_COMPLEX)(a * phase); // Corrected indexing and cast
+            h_seg[k - k_start] = (T_COMPLEX)(a * phase); 
 
-            // Step phase forward
             phase = phase * d1_phase;
             d1_phase = d1_phase * d2_phase;
             d2_phase = d2_phase * d3_phase_const;
 
-            // Step amplitude forward
             a = a + d1_a;
             d1_a = d1_a + d2_a;
             d2_a = d2_a + d3_a_const;
         }
     }
 }
-
 
 /* =====================================================================
  *
@@ -265,31 +268,39 @@ static inline void _decomp_Qcode_segment(
     double df, int64_t k_start, const int64_t kmax,
     const int update_interval)
 {
-    double f;
+    double f, x;
     double h2 = df * df;
     double h3 = h2 * df;
     double h4 = h3 * df;
 
-    // --- Denominators for Lagrange basis (constant for segment) ---
-    double denom0 = (f0-f1)*(f0-f2)*(f0-f3)*(f0-f4);
-    double denom1 = (f1-f0)*(f1-f2)*(f1-f3)*(f1-f4);
-    double denom2 = (f2-f0)*(f2-f1)*(f2-f3)*(f2-f4);
-    double denom3 = (f3-f0)*(f3-f1)*(f3-f2)*(f3-f4);
-    double denom4 = (f4-f0)*(f4-f1)*(f4-f2)*(f4-f3);
+    // --- ORIGIN SHIFT ---
+    double x0 = 0.0; // f0 - f0
+    double x1 = f1 - f0;
+    double x2 = f2 - f0;
+    double x3 = f3 - f0;
+    double x4 = f4 - f0;
 
-    // --- Get power-basis coefficients: c4*f^4 + c3*f^3 + c2*f^2 + c1*f + c0 ---
+    // --- Denominators for Lagrange basis ---
+    // (x_i - x_j) is mathematically identical to (f_i - f_j)
+    double denom0 = (x0-x1)*(x0-x2)*(x0-x3)*(x0-x4);
+    double denom1 = (x1-x0)*(x1-x2)*(x1-x3)*(x1-x4);
+    double denom2 = (x2-x0)*(x2-x1)*(x2-x3)*(x2-x4);
+    double denom3 = (x3-x0)*(x3-x1)*(x3-x2)*(x3-x4);
+    double denom4 = (x4-x0)*(x4-x1)*(x4-x2)*(x4-x3);
+
+    // --- Get shifted power-basis coefficients ---
     // --- Amplitude ---
     double c_a4 = a0/denom0 + a1/denom1 + a2/denom2 + a3/denom3 + a4/denom4;
-    double c_a3 = -a0*(f1+f2+f3+f4)/denom0 - a1*(f0+f2+f3+f4)/denom1 - a2*(f0+f1+f3+f4)/denom2 - a3*(f0+f1+f2+f4)/denom3 - a4*(f0+f1+f2+f3)/denom4;
-    double c_a2 = a0*(f1*f2+f1*f3+f1*f4+f2*f3+f2*f4+f3*f4)/denom0 + a1*(f0*f2+f0*f3+f0*f4+f2*f3+f2*f4+f3*f4)/denom1 + a2*(f0*f1+f0*f3+f0*f4+f1*f3+f1*f4+f3*f4)/denom2 + a3*(f0*f1+f0*f2+f0*f4+f1*f2+f1*f4+f2*f4)/denom3 + a4*(f0*f1+f0*f2+f0*f3+f1*f2+f1*f3+f2*f3)/denom4;
-    double c_a1 = -a0*(f1*f2*f3+f1*f2*f4+f1*f3*f4+f2*f3*f4)/denom0 - a1*(f0*f2*f3+f0*f2*f4+f0*f3*f4+f2*f3*f4)/denom1 - a2*(f0*f1*f3+f0*f1*f4+f0*f3*f4+f1*f3*f4)/denom2 - a3*(f0*f1*f2+f0*f1*f4+f0*f2*f4+f1*f2*f4)/denom3 - a4*(f0*f1*f2+f0*f1*f3+f0*f2*f3+f1*f2*f3)/denom4;
-    double c_a0 = a0*(f1*f2*f3*f4)/denom0 + a1*(f0*f2*f3*f4)/denom1 + a2*(f0*f1*f3*f4)/denom2 + a3*(f0*f1*f2*f4)/denom3 + a4*(f0*f1*f2*f3)/denom4;
+    double c_a3 = -a0*(x1+x2+x3+x4)/denom0 - a1*(x0+x2+x3+x4)/denom1 - a2*(x0+x1+x3+x4)/denom2 - a3*(x0+x1+x2+x4)/denom3 - a4*(x0+x1+x2+x3)/denom4;
+    double c_a2 = a0*(x1*x2+x1*x3+x1*x4+x2*x3+x2*x4+x3*x4)/denom0 + a1*(x0*x2+x0*x3+x0*x4+x2*x3+x2*x4+x3*x4)/denom1 + a2*(x0*x1+x0*x3+x0*x4+x1*x3+x1*x4+x3*x4)/denom2 + a3*(x0*x1+x0*x2+x0*x4+x1*x2+x1*x4+x2*x4)/denom3 + a4*(x0*x1+x0*x2+x0*x3+x1*x2+x1*x3+x2*x3)/denom4;
+    double c_a1 = -a0*(x1*x2*x3+x1*x2*x4+x1*x3*x4+x2*x3*x4)/denom0 - a1*(x0*x2*x3+x0*x2*x4+x0*x3*x4+x2*x3*x4)/denom1 - a2*(x0*x1*x3+x0*x1*x4+x0*x3*x4+x1*x3*x4)/denom2 - a3*(x0*x1*x2+x0*x1*x4+x0*x2*x4+x1*x2*x4)/denom3 - a4*(x0*x1*x2+x0*x1*x3+x0*x2*x3+x1*x2*x3)/denom4;
+    double c_a0 = a0*(x1*x2*x3*x4)/denom0 + a1*(x0*x2*x3*x4)/denom1 + a2*(x0*x1*x3*x4)/denom2 + a3*(x0*x1*x2*x4)/denom3 + a4*(x0*x1*x2*x3)/denom4;
     // --- Phase ---
     double c_p4 = p0/denom0 + p1/denom1 + p2/denom2 + p3/denom3 + p4/denom4;
-    double c_p3 = -p0*(f1+f2+f3+f4)/denom0 - p1*(f0+f2+f3+f4)/denom1 - p2*(f0+f1+f3+f4)/denom2 - p3*(f0+f1+f2+f4)/denom3 - p4*(f0+f1+f2+f3)/denom4;
-    double c_p2 = p0*(f1*f2+f1*f3+f1*f4+f2*f3+f2*f4+f3*f4)/denom0 + p1*(f0*f2+f0*f3+f0*f4+f2*f3+f2*f4+f3*f4)/denom1 + p2*(f0*f1+f0*f3+f0*f4+f1*f3+f1*f4+f3*f4)/denom2 + p3*(f0*f1+f0*f2+f0*f4+f1*f2+f1*f4+f2*f4)/denom3 + p4*(f0*f1+f0*f2+f0*f3+f1*f2+f1*f3+f2*f3)/denom4;
-    double c_p1 = -p0*(f1*f2*f3+f1*f2*f4+f1*f3*f4+f2*f3*f4)/denom0 - p1*(f0*f2*f3+f0*f2*f4+f0*f3*f4+f2*f3*f4)/denom1 - p2*(f0*f1*f3+f0*f1*f4+f0*f3*f4+f1*f3*f4)/denom2 - p3*(f0*f1*f2+f0*f1*f4+f0*f2*f4+f1*f2*f4)/denom3 - p4*(f0*f1*f2+f0*f1*f3+f0*f2*f3+f1*f2*f3)/denom4;
-    double c_p0 = p0*(f1*f2*f3*f4)/denom0 + p1*(f0*f2*f3*f4)/denom1 + p2*(f0*f1*f3*f4)/denom2 + p3*(f0*f1*f2*f4)/denom3 + p4*(f0*f1*f2*f3)/denom4;
+    double c_p3 = -p0*(x1+x2+x3+x4)/denom0 - p1*(x0+x2+x3+x4)/denom1 - p2*(x0+x1+x3+x4)/denom2 - p3*(x0+x1+x2+x4)/denom3 - p4*(x0+x1+x2+x3)/denom4;
+    double c_p2 = p0*(x1*x2+x1*x3+x1*x4+x2*x3+x2*x4+x3*x4)/denom0 + p1*(x0*x2+x0*x3+x0*x4+x2*x3+x2*x4+x3*x4)/denom1 + p2*(x0*x1+x0*x3+x0*x4+x1*x3+x1*x4+x3*x4)/denom2 + p3*(x0*x1+x0*x2+x0*x4+x1*x2+x1*x4+x2*x4)/denom3 + p4*(x0*x1+x0*x2+x0*x3+x1*x2+x1*x3+x2*x3)/denom4;
+    double c_p1 = -p0*(x1*x2*x3+x1*x2*x4+x1*x3*x4+x2*x3*x4)/denom0 - p1*(x0*x2*x3+x0*x2*x4+x0*x3*x4+x2*x3*x4)/denom1 - p2*(x0*x1*x3+x0*x1*x4+x0*x3*x4+x1*x3*x4)/denom2 - p3*(x0*x1*x2+x0*x1*x4+x0*x2*x4+x1*x2*x4)/denom3 - p4*(x0*x1*x2+x0*x1*x3+x0*x2*x3+x1*x2*x3)/denom4;
+    double c_p0 = p0*(x1*x2*x3*x4)/denom0 + p1*(x0*x2*x3*x4)/denom1 + p2*(x0*x1*x3*x4)/denom2 + p3*(x0*x1*x2*x4)/denom3 + p4*(x0*x1*x2*x3)/denom4;
 
     // --- Finite difference constants (constant for segment) ---
     double d4_a_const = 24 * c_a4 * h4;
@@ -300,29 +311,30 @@ static inline void _decomp_Qcode_segment(
     double a, p, d1_a, d1_p, d2_a, d2_p, d3_a, d3_p;
     std::complex<double> phase, d1_phase, d2_phase, d3_phase;
     int64_t k_sub_max;
-    int64_t k = k_start; // k is now the local loop variable
+    int64_t k = k_start; 
 
     for (; k < kmax; ) {
-        // --- Re-calculate steppers to correct FP error ---
         f = k * df;
+        x = f - f0; // --- EVALUATE RELATIVE TO ORIGIN ---
+        
         k_sub_max = k + update_interval;
         if (k_sub_max > kmax) k_sub_max = kmax;
 
-        // Initial values for this sub-block
-        a = c_a4*f*f*f*f + c_a3*f*f*f + c_a2*f*f + c_a1*f + c_a0;
-        p = c_p4*f*f*f*f + c_p3*f*f*f + c_p2*f*f + c_p1*f + c_p0;
+        // Initial values for this sub-block using x
+        a = c_a4*x*x*x*x + c_a3*x*x*x + c_a2*x*x + c_a1*x + c_a0;
+        p = c_p4*x*x*x*x + c_p3*x*x*x + c_p2*x*x + c_p1*x + c_p0;
 
-        // First differences at f (Delta_f)
-        d1_a = c_a4*(4*f*f*f*df + 6*f*f*h2 + 4*f*h3 + h4) + c_a3*(3*f*f*df + 3*f*h2 + h3) + c_a2*(2*f*df + h2) + c_a1*df;
-        d1_p = c_p4*(4*f*f*f*df + 6*f*f*h2 + 4*f*h3 + h4) + c_p3*(3*f*f*df + 3*f*h2 + h3) + c_p2*(2*f*df + h2) + c_p1*df;
+        // First differences at x (Delta_x)
+        d1_a = c_a4*(4*x*x*x*df + 6*x*x*h2 + 4*x*h3 + h4) + c_a3*(3*x*x*df + 3*x*h2 + h3) + c_a2*(2*x*df + h2) + c_a1*df;
+        d1_p = c_p4*(4*x*x*x*df + 6*x*x*h2 + 4*x*h3 + h4) + c_p3*(3*x*x*df + 3*x*h2 + h3) + c_p2*(2*x*df + h2) + c_p1*df;
 
-        // Second differences at f (Delta^2_f)
-        d2_a = c_a4*(12*f*f*h2 + 24*f*h3 + 14*h4) + c_a3*(6*f*h2 + 6*h3) + c_a2*(2*h2);
-        d2_p = c_p4*(12*f*f*h2 + 24*f*h3 + 14*h4) + c_p3*(6*f*h2 + 6*h3) + c_p2*(2*h2);
+        // Second differences at x (Delta^2_x)
+        d2_a = c_a4*(12*x*x*h2 + 24*x*h3 + 14*h4) + c_a3*(6*x*h2 + 6*h3) + c_a2*(2*h2);
+        d2_p = c_p4*(12*x*x*h2 + 24*x*h3 + 14*h4) + c_p3*(6*x*h2 + 6*h3) + c_p2*(2*h2);
         
-        // Third differences at f (Delta^3_f)
-        d3_a = c_a4*(24*f*h3 + 36*h4) + c_a3*(6*h3);
-        d3_p = c_p4*(24*f*h3 + 36*h4) + c_p3*(6*h3);
+        // Third differences at x (Delta^3_x)
+        d3_a = c_a4*(24*x*h3 + 36*h4) + c_a3*(6*h3);
+        d3_p = c_p4*(24*x*h3 + 36*h4) + c_p3*(6*h3);
 
         // Complex phase steppers
         phase = std::polar(1.0, p);
@@ -330,17 +342,15 @@ static inline void _decomp_Qcode_segment(
         d2_phase = std::polar(1.0, d2_p);
         d3_phase = std::polar(1.0, d3_p);
 
-        // --- Fast Inner Loop ---
+        // --- Fast Inner Loop (Remains Identical) ---
         for (; k < k_sub_max; k++) {
-            h_seg[k - k_start] = (T_COMPLEX)(a * phase); // Corrected indexing and cast
+            h_seg[k - k_start] = (T_COMPLEX)(a * phase); 
 
-            // Step phase forward
             phase = phase * d1_phase;
             d1_phase = d1_phase * d2_phase;
             d2_phase = d2_phase * d3_phase;
             d3_phase = d3_phase * d4_phase_const;
 
-            // Step amplitude forward
             a = a + d1_a;
             d1_a = d1_a + d2_a;
             d2_a = d2_a + d3_a;
@@ -348,7 +358,6 @@ static inline void _decomp_Qcode_segment(
         }
     }
 }
-
 
 /* =====================================================================
  *

--- a/pycbc/waveform/decompress_cpu_ccode.cpp
+++ b/pycbc/waveform/decompress_cpu_ccode.cpp
@@ -79,7 +79,6 @@ static inline void _decomp_ccode_segment(
         k_sub_max = findex + update_interval;
         if (k_sub_max > kmax) k_sub_max = kmax;
 
-        // --- Fast Inner Loop (Remains Identical) ---
         while (findex < k_sub_max) {
             incrh_re = h_re * dphi_re - h_im * dphi_im;
             incrh_im = h_re * dphi_im + h_im * dphi_re;

--- a/pycbc/waveform/decompress_cpu_ccode.cpp
+++ b/pycbc/waveform/decompress_cpu_ccode.cpp
@@ -45,20 +45,25 @@ static inline void _decomp_ccode_segment(
 {
     T* outptr = (T*) h_seg;
     double inv_sdf = 1.0 / (f2 - f1);
+    
+    // Slopes
     double m_amp = (a2 - a1) * inv_sdf;
-    double b_amp = a1 - m_amp * f1;
     double m_phi = (p2 - p1) * inv_sdf;
-    double b_phi = p1 - m_phi * f1;
+    // Intercepts (b_amp, b_phi) are implicitly a1 and p1 when shifted!
 
     double h_re, h_im, g_re, g_im, dphi_re, dphi_im;
-    double incrh_re, incrh_im, incrg_re, incrg_im, f;
+    double incrh_re, incrh_im, incrg_re, incrg_im, f, x;
     int64_t findex = k;
     int64_t k_sub_max;
 
     while (findex < kmax) {
         f = findex * df;
-        double interp_amp = m_amp * f + b_amp;
-        double interp_phi = m_phi * f + b_phi;
+        x = f - f1; // --- ORIGIN SHIFT ---
+        
+        // Evaluate relative to the start of the segment
+        double interp_amp = m_amp * x + a1;
+        double interp_phi = m_phi * x + p1;
+        
         dphi_re = cos(m_phi * df);
         dphi_im = sin(m_phi * df);
         h_re = interp_amp * cos(interp_phi);
@@ -74,6 +79,7 @@ static inline void _decomp_ccode_segment(
         k_sub_max = findex + update_interval;
         if (k_sub_max > kmax) k_sub_max = kmax;
 
+        // --- Fast Inner Loop (Remains Identical) ---
         while (findex < k_sub_max) {
             incrh_re = h_re * dphi_re - h_im * dphi_im;
             incrh_im = h_re * dphi_im + h_im * dphi_re;
@@ -92,7 +98,6 @@ static inline void _decomp_ccode_segment(
     }
 }
 
-
 /* =====================================================================
  *
  * FAST QUADRATIC INTERPOLATION (HELPER)
@@ -104,24 +109,29 @@ template <class T, class T_COMPLEX>
 static inline void _decomp_qcode_segment(
     T_COMPLEX* h_seg,
     double f0, double f1, double f2, double a0, double a1, double a2, double p0, double p1, double p2,
-    double df, int64_t k_start, const int64_t kmax, // Renamed k to k_start
+    double df, int64_t k_start, const int64_t kmax,
     const int update_interval)
 {
-    double f;
+    double f, x;
     double h2 = df * df;
 
-    // Denominators for Lagrange basis (constant for segment)
-    double denom0 = (f0 - f1) * (f0 - f2);
-    double denom1 = (f1 - f0) * (f1 - f2);
-    double denom2 = (f2 - f0) * (f2 - f1);
+    // --- ORIGIN SHIFT ---
+    double x0 = 0.0;
+    double x1 = f1 - f0;
+    double x2 = f2 - f0;
 
-    // --- Get power-basis coefficients: c2*f^2 + c1*f + c0 ---
+    // --- Denominators for Lagrange basis ---
+    double denom0 = (x0 - x1) * (x0 - x2);
+    double denom1 = (x1 - x0) * (x1 - x2);
+    double denom2 = (x2 - x0) * (x2 - x1);
+
+    // --- Get shifted power-basis coefficients: c2*x^2 + c1*x + c0 ---
     double c_a2 = a0/denom0 + a1/denom1 + a2/denom2;
     double c_p2 = p0/denom0 + p1/denom1 + p2/denom2;
-    double c_a1 = -a0*(f1+f2)/denom0 - a1*(f0+f2)/denom1 - a2*(f0+f1)/denom2;
-    double c_p1 = -p0*(f1+f2)/denom0 - p1*(f0+f2)/denom1 - p2*(f0+f1)/denom2;
-    double c_a0 = a0*f1*f2/denom0 + a1*f0*f2/denom1 + a2*f0*f1/denom2;
-    double c_p0 = p0*f1*f2/denom0 + p1*f0*f2/denom1 + p2*f0*f1/denom2;
+    double c_a1 = -a0*(x1+x2)/denom0 - a1*(x0+x2)/denom1 - a2*(x0+x1)/denom2;
+    double c_p1 = -p0*(x1+x2)/denom0 - p1*(x0+x2)/denom1 - p2*(x0+x1)/denom2;
+    double c_a0 = a0*x1*x2/denom0 + a1*x0*x2/denom1 + a2*x0*x1/denom2;
+    double c_p0 = p0*x1*x2/denom0 + p1*x0*x2/denom1 + p2*x0*x1/denom2;
 
     // --- Finite difference constants (constant for segment) ---
     double d2_a_const = 2 * c_a2 * h2;
@@ -132,32 +142,38 @@ static inline void _decomp_qcode_segment(
     double a, p, d1_a, d1_p;
     std::complex<double> phase, d_phase;
     int64_t k_sub_max;
-    int64_t k = k_start; // k is now the local loop variable
+    int64_t k = k_start; 
 
     for (; k < kmax; ) {
-        // --- Re-calculate steppers to correct FP error ---
         f = k * df;
+        x = f - f0; // --- EVALUATE RELATIVE TO ORIGIN ---
+        
         k_sub_max = k + update_interval;
         if (k_sub_max > kmax) k_sub_max = kmax;
 
-        a = c_a2*f*f + c_a1*f + c_a0;
-        p = c_p2*f*f + c_p1*f + c_p0;
-        d1_a = c_a2*(2*f*df + h2) + c_a1*df;
-        d1_p = c_p2*(2*f*df + h2) + c_p1*df;
+        // Initial values for this sub-block using x
+        a = c_a2*x*x + c_a1*x + c_a0;
+        p = c_p2*x*x + c_p1*x + c_p0;
+        
+        // First differences at x (Delta_x)
+        d1_a = c_a2*(2*x*df + h2) + c_a1*df;
+        d1_p = c_p2*(2*x*df + h2) + c_p1*df;
+        
         phase = std::polar(1.0, p);
         d_phase = std::polar(1.0, d1_p);
 
-        // --- Fast Inner Loop ---
+        // --- Fast Inner Loop (Remains Identical) ---
         for (; k < k_sub_max; k++) {
-            h_seg[k - k_start] = (T_COMPLEX)(a * phase); // Corrected indexing and cast
+            h_seg[k - k_start] = (T_COMPLEX)(a * phase); 
+            
             phase = phase * d_phase;
             d_phase = d_phase * d2_phase_const;
+            
             a = a + d1_a;
             d1_a = d1_a + d2_a_const;
         }
     }
 }
-
 
 /* =====================================================================
  *
@@ -426,10 +442,10 @@ static inline void _decomp_main_loop(
         // Start with the highest requested degree
         int current_degree = degree; 
 
-        // Degrade based on start position
-        if (i == imin) current_degree = 1; // First segment must be linear
-        else if (i == imin + 1 && current_degree > 2) current_degree = 2;
-        else if (i == imin + 2 && current_degree > 3) current_degree = 3;
+        // Degrade based on absolute array boundaries, NOT the f_lower index (imin).
+        // Because all higher-order stencils look back exactly one index (i-1), 
+        // only absolute index 0 lacks the leftward memory to run them.
+        if (i == 0) current_degree = 1; 
 
         // Degrade based on end position (Quartic needs i+3, Cubic needs i+2)
         if (current_degree > 3 && i >= sflen - 3) current_degree = 3;

--- a/pycbc/waveform/decompress_cpu_ccode.cpp
+++ b/pycbc/waveform/decompress_cpu_ccode.cpp
@@ -161,7 +161,7 @@ static inline void _decomp_qcode_segment(
         phase = std::polar(1.0, p);
         d_phase = std::polar(1.0, d1_p);
 
-        // --- Fast Inner Loop (Remains Identical) ---
+        // --- Fast Inner Loop  ---
         for (; k < k_sub_max; k++) {
             h_seg[k - k_start] = (T_COMPLEX)(a * phase); 
             
@@ -252,7 +252,7 @@ static inline void _decomp_tcode_segment(
         d1_phase = std::polar(1.0, d1_p);
         d2_phase = std::polar(1.0, d2_p);
 
-        // --- Fast Inner Loop (Remains Identical) ---
+        // --- Fast Inner Loop ---
         for (; k < k_sub_max; k++) {
             h_seg[k - k_start] = (T_COMPLEX)(a * phase); 
 
@@ -357,7 +357,7 @@ static inline void _decomp_Qcode_segment(
         d2_phase = std::polar(1.0, d2_p);
         d3_phase = std::polar(1.0, d3_p);
 
-        // --- Fast Inner Loop (Remains Identical) ---
+        // --- Fast Inner Loop  ---
         for (; k < k_sub_max; k++) {
             h_seg[k - k_start] = (T_COMPLEX)(a * phase); 
 


### PR DESCRIPTION
<!---
Please delete these comments when you submit the pull request

Please add a title which is a concise description of what you are doing,
e.g. 'Fix bug with numpy import in pycbc_coinc_findtrigs' or 'add high frequency sky location dependent response for long detectors'
-->

<!---
This is a brief template for making pull requests for PyCBC.
This is _not_ a proscriptive template - you can use a different style if you want.
Please do think about the questions posed here and whether the details will be useful to include in your PR
Please add sufficient details so that people looking back at the request with no context around the work can understand the changes.
To choose reviewers, please look at the git blame for the code you are changing (if applicable),
or discuss in the #pycbc-code channel of the gwastro slack.
Please add labels as appropriate
-->

<!-- TOP-LEVEL SUMMARY: Please provide a brief, one-or-two-sentence description of the PR here
-->

## Standard information about the request

<!--- Some basic info about the change (delete as appropriate) -->
This is a feature update and bugfix. 

<!--- What codes will this affect? (delete as apropriate)
If you do not know which areas will be affected, please ask in the gwastro #pycbc-code slack
-->
This change affects searches that use waveform compression or the decompression methods in pycbc.

## Motivation

This PR makes several improvements to the waveform compression algorithm.

1) The pycbc_compress bank script is made to run in parallel with a new -nprocesses option to enable use of multiple cores

2) The heuristic for identifying points to add to the interpolation grid is rewritten. It now places multiple points at once rather than one-by-one. It adds a point wherever the subregion overlap does not meet the global target. This increases the converge rate significantly and avoids some edge cases that place points where they are less helpful. 

3) This improves the numerical stability of the finite differencing when the freuency is large. Essentially we work in terms of the offset which reduces the numerical range of some of the calculation. This is most important for the higher order interpolations, but affects all of them. 


## Links to any issues or associated PRs
<!--- If this is fixing / working around an already-reported issue, please link to it here -->

## Testing performed
<!--- Describe tests for the code changes, either already performed or to be performed -->
Verified that sample search produces the same results and hand run inspiral job.
Verified that the in-built tests of the reconstructed waveform converge. 

## Additional notes
<!--- Anything which does not fit in the above sections -->

- [ ] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
