### PR TITLE
Detector and geocenter time in PyGRB results production

### DIFF
--- a/bin/pygrb/pycbc_pygrb_minifollowups
+++ b/bin/pygrb/pycbc_pygrb_minifollowups
@@ -194,8 +194,8 @@ seg_files = wf.FileList(
 # proxy for the valid science segments, and ignore vetoed time inside it.
 valid_segs = segmentlist([ppu._read_seg_files(seg_file_abs_paths)['off']])
 
-# As opposed to injections, (loudest) off/on-source events are on data that
-# can be time-slid so the try finds the time shift dataset and succeeds.
+# Determine if we are following up injections or loudest off/on-source triggers.
+# If the time shift dataset exists, then assume we are doing the latter.
 is_injection_followup = True
 try:
     time_shift = fp[ifos[0]+' time shift (s)'][0]

--- a/bin/pygrb/pycbc_pygrb_minifollowups
+++ b/bin/pygrb/pycbc_pygrb_minifollowups
@@ -216,7 +216,7 @@ for num_event in range(num_events):
     # Handle injections
     # They are on unslid data so geocenter time is used
     if is_injection_followup:
-        gps_time = fp['GPS time'][num_event]
+        gps_time = fp['GC GPS time (s)'][num_event]
         gps_time = gps_time.astype(float)
         for snr_type in ['reweighted', 'coherent']:
             files += make_timeseries_plot(workflow, trig_file,

--- a/bin/pygrb/pycbc_pygrb_minifollowups
+++ b/bin/pygrb/pycbc_pygrb_minifollowups
@@ -194,8 +194,8 @@ seg_files = wf.FileList(
 # proxy for the valid science segments, and ignore vetoed time inside it.
 valid_segs = segmentlist([ppu._read_seg_files(seg_file_abs_paths)['off']])
 
-# (Loudest) off/on-source events are on time-slid data so the
-# try will succeed, as it finds the time shift columns.
+# As opposed to injections, (loudest) off/on-source events are on data that
+# can be time-slid so the try finds the time shift dataset and succeeds.
 is_injection_followup = True
 try:
     time_shift = fp[ifos[0]+' time shift (s)'][0]
@@ -207,16 +207,17 @@ except KeyError:
 for num_event in range(num_events):
     files = FileList([])
     logging.info('Processing event: %s', num_event+1)
-    gps_time = fp['GPS time'][num_event]
-    gps_time = gps_time.astype(float)
     tags = args.tags + [str(num_event+1)]
     if wiki_file:
         row = []
         for key in fp.keys():
             row.append(fp[key][num_event])
         add_wiki_row(wiki_file, row)
-    # Handle injections (which are on unslid data)
+    # Handle injections
+    # They are on unslid data so geocenter time is used
     if is_injection_followup:
+        gps_time = fp['GPS time'][num_event]
+        gps_time = gps_time.astype(float)
         for snr_type in ['reweighted', 'coherent']:
             files += make_timeseries_plot(workflow, trig_file,
                                           snr_type, gps_time,
@@ -229,12 +230,12 @@ for num_event in range(num_events):
                                           args.output_dir,
                                           tags=tags,
                                           data_segments=valid_segs)
-    # Handle off/on-source loudest triggers follow-up (which may be on slid
-    # data in the case of the off-source)
+    # Handle off/on-source loudest triggers follow-up
+    # They are data that may be slid so detector time is used
     else:
         for i_ifo, ifo in enumerate(ifos):
-            time_shift = fp[ifo+' time shift (s)'][num_event]
-            ifo_time = gps_time + time_shift
+            ifo_time = fp[ifo+' GPS time (s)'][num_event]
+            ifo_time = ifo_time.astype(float)
             files += make_timeseries_plot(workflow, trig_file,
                                           'single', ifo_time,
                                           args.output_dir, ifo=ifo,

--- a/bin/pygrb/pycbc_pygrb_page_tables
+++ b/bin/pygrb/pycbc_pygrb_page_tables
@@ -438,15 +438,19 @@ if lofft_outfile:
         d.extend([trig_data[ifo+'/snr'][ifo_trig_index[ifo]]
                   for ifo in ifos])
         d.extend([slide_dict[trig_slide_id][ifo] for ifo in ifos])
+        d.extend([trig_data[ifo+'/end_time'][ifo_trig_index[ifo]]
+                  for ifo in ifos])
         d.append(bestnr)
         td.append(d)
 
-    # th: table header [pycbc_pygrb_minifollowups looks for 'Slide Num']
+    # th: table header
+    # Check against pycbc_pygrb_minifollowups prior to changing any of these
     th = ['Trial', 'Slide Num', 'p-value', 'GPS time',
           'Rec. m1', 'Rec. m2', 'Rec. Mc', 'Rec. spin1z', 'Rec. spin2z',
           'Rec. RA', 'Rec. Dec', 'SNR', 'Chi^2', 'Null SNR']
     th.extend([ifo+' SNR' for ifo in ifos])
     th.extend([ifo+' time shift (s)' for ifo in ifos])
+    th.extend([ifo+' GPS time (s)' for ifo in ifos])
     th.append('BestNR')
 
     # When len(offsource_trigs) == 0, the loop above leaves td = [] unchanged
@@ -479,8 +483,9 @@ if lofft_outfile:
     format_strings = ['##.##', '##.##', None, '##.#####',
                       '##.##', '##.##', '##.##', '##.##', '##.##',
                       '##.##', '##.##', '##.##', '##.##', '##.##']
-    format_strings.extend(['##.##' for ifo in ifos])
-    format_strings.extend(['##.##' for ifo in ifos])
+    format_strings.extend(['##.##' for _ in ifos])
+    format_strings.extend(['##.##' for _ in ifos])
+    format_strings.extend(['##.##' for _ in ifos])
     format_strings.extend(['##.##'])
     html_table = pycbc.results.html_table(td, th,
                                           format_strings=format_strings,
@@ -558,13 +563,16 @@ if onsource_file:
              on_trigs['network/my_network_chisq'][trig_index],
              on_trigs['network/null_snr'][trig_index]] + \
             [on_trigs[ifo+'/snr'][ifo_trig_index[ifo]] for ifo in ifos] + \
-            [loud_on_bestnr]
+            [on_trigs[ifo+'/end_time'][ifo_trig_index[ifo]]
+             for ifo in ifos] + [loud_on_bestnr]
         td.append(d)
 
     # Table header
+    # Check against pycbc_pygrb_minifollowups prior to changing any of these
     th = ['p-value', 'GPS time', 'Rec. m1', 'Rec. m2', 'Rec. Mc',
           'Rec. spin1z', 'Rec. spin2z', 'Rec. RA', 'Rec. Dec', 'SNR', 'Chi^2',
-          'Null SNR'] + [ifo+' SNR' for ifo in ifos] + ['BestNR']
+          'Null SNR'] + [ifo+' SNR' for ifo in ifos] + \
+          [ifo+' GPS time (s)' for ifo in ifos] + ['BestNR']
 
     td = list(zip(*td))
 
@@ -584,7 +592,8 @@ if onsource_file:
     # Format of table data
     format_strings = [None, '##.#####', '##.##', '##.##', '##.##', '##.##',
                       '##.##', '##.##', '##.##', '##.##', '##.##', '##.##']
-    format_strings.extend(['##.##' for ifo in ifos])
+    format_strings.extend(['##.##' for _ in ifos])
+    format_strings.extend(['##.##' for _ in ifos])
     format_strings.extend(['##.##'])
 
     # Table data: assemble human readable message when no trigger is recovered
@@ -638,6 +647,9 @@ if found_missed_file is not None:
 
     # Write quiet triggers to file
     sites = [ifo[0] for ifo in ifos]
+    # Table header
+    # Check against pycbc_pygrb_minifollowups prior to changing any of these
+    # Injections are in zero-lag so no timing information at the IFOs is needed
     th = ['Dist'] + ['Eff. Dist. '+site for site in sites] +\
          ['GPS time', 'GPS time - Rec. Time'] +\
          ['Inj. m1', 'Inj. m2', 'Inj. Mc', 'Rec. m1', 'Rec. m2', 'Rec. Mc',
@@ -652,7 +664,7 @@ if found_missed_file is not None:
           'Rec S1z', 'Rec S2z']
     # Format of table data
     format_strings = ['##.##']
-    format_strings.extend(['##.##' for ifo in ifos])
+    format_strings.extend(['##.##' for _ in ifos])
     format_strings.extend(['##.#####', '##.#####',
                            '##.##', '##.##', '##.##',
                            '##.##', '##.##', '##.##',

--- a/bin/pygrb/pycbc_pygrb_page_tables
+++ b/bin/pygrb/pycbc_pygrb_page_tables
@@ -445,7 +445,7 @@ if lofft_outfile:
 
     # th: table header
     # Check against pycbc_pygrb_minifollowups prior to changing any of these
-    th = ['Trial', 'Slide Num', 'p-value', 'GPS time',
+    th = ['Trial', 'Slide Num', 'p-value', 'GC GPS time (s)',
           'Rec. m1', 'Rec. m2', 'Rec. Mc', 'Rec. spin1z', 'Rec. spin2z',
           'Rec. RA', 'Rec. Dec', 'SNR', 'Chi^2', 'Null SNR']
     th.extend([ifo+' SNR' for ifo in ifos])
@@ -480,12 +480,12 @@ if lofft_outfile:
     td = [np.asarray(d) for d in td]
 
     # Format of table data
-    format_strings = ['##.##', '##.##', None, '##.#####',
+    format_strings = ['##.##', '##.##', None, '##.###',
                       '##.##', '##.##', '##.##', '##.##', '##.##',
                       '##.##', '##.##', '##.##', '##.##', '##.##']
     format_strings.extend(['##.##' for _ in ifos])
     format_strings.extend(['##.##' for _ in ifos])
-    format_strings.extend(['##.##' for _ in ifos])
+    format_strings.extend(['##.###' for _ in ifos])
     format_strings.extend(['##.##'])
     html_table = pycbc.results.html_table(td, th,
                                           format_strings=format_strings,
@@ -569,7 +569,7 @@ if onsource_file:
 
     # Table header
     # Check against pycbc_pygrb_minifollowups prior to changing any of these
-    th = ['p-value', 'GPS time', 'Rec. m1', 'Rec. m2', 'Rec. Mc',
+    th = ['p-value', 'GC GPS time (s)', 'Rec. m1', 'Rec. m2', 'Rec. Mc',
           'Rec. spin1z', 'Rec. spin2z', 'Rec. RA', 'Rec. Dec', 'SNR', 'Chi^2',
           'Null SNR'] + [ifo+' SNR' for ifo in ifos] + \
           [ifo+' GPS time (s)' for ifo in ifos] + ['BestNR']
@@ -590,10 +590,10 @@ if onsource_file:
     logging.info("Writing loudest onsource trigger to html file.")
 
     # Format of table data
-    format_strings = [None, '##.#####', '##.##', '##.##', '##.##', '##.##',
+    format_strings = [None, '##.###', '##.##', '##.##', '##.##', '##.##',
                       '##.##', '##.##', '##.##', '##.##', '##.##', '##.##']
     format_strings.extend(['##.##' for _ in ifos])
-    format_strings.extend(['##.##' for _ in ifos])
+    format_strings.extend(['##.###' for _ in ifos])
     format_strings.extend(['##.##'])
 
     # Table data: assemble human readable message when no trigger is recovered
@@ -651,7 +651,7 @@ if found_missed_file is not None:
     # Check against pycbc_pygrb_minifollowups prior to changing any of these
     # Injections are in zero-lag so no timing information at the IFOs is needed
     th = ['Dist'] + ['Eff. Dist. '+site for site in sites] +\
-         ['GPS time', 'GPS time - Rec. Time'] +\
+         ['GC GPS time (s)', 'GPS time - Rec. Time'] +\
          ['Inj. m1', 'Inj. m2', 'Inj. Mc', 'Rec. m1', 'Rec. m2', 'Rec. Mc',
           'Inj. inc', 'Inj. RA', 'Inj. Dec', 'Rec. RA', 'Rec. Dec', 'SNR',
           'Chi^2', 'Null SNR'] +\

--- a/bin/pygrb/pycbc_pygrb_plot_snr_timeseries
+++ b/bin/pygrb/pycbc_pygrb_plot_snr_timeseries
@@ -206,6 +206,10 @@ if inj_file:
 # Generate plots
 logging.info("Plotting...")
 
+# Prepare the horizontal axis label
+x_label = "Geocenter" if 'network' in x_key else opts.ifo
+x_label += f" time since {central_time:.3f} (s)"
+
 # Determine what goes on the vertical axis
 y_labels = {'coherent': "Coherent SNR",
             'single': f"{ifo} SNR",
@@ -226,5 +230,5 @@ if not opts.x_lims:
     opts.x_lims = f"{start},{end}"
 plu.pygrb_plotter([trig_data_time, trig_data_snr],
                   [inj_data_time, inj_data_snr],
-                  f"Time since {central_time:.3f} (s)", y_label,
+                  x_label, y_label,
                   opts, cmd=' '.join(sys.argv))

--- a/bin/pygrb/pycbc_pygrb_plot_snr_timeseries
+++ b/bin/pygrb/pycbc_pygrb_plot_snr_timeseries
@@ -144,12 +144,14 @@ inj_data = ppu.load_data(inj_file, ifos, data_tag='injs',
                          slide_id=0)
 
 # Specify HDF file keys for x quantity (time) and y quantity (SNR)
+x_key = 'network/end_time_gc'
+y_key = 'network/' + opts.y_variable + '_snr'
 if opts.y_variable == 'single':
-    x_key = opts.ifo + '/end_time'
     y_key = opts.ifo + '/snr'
-else:
-    x_key = 'network/end_time_gc'
-    y_key = 'network/' + opts.y_variable + '_snr'
+    # When looking at a single slide in a detector use the time at the detector
+    # Otherwise use the time at the geocenter to look at all slides at once
+    if opts.slide_id != 'all':
+        x_key = opts.ifo + '/end_time'
 
 # Extract needed trigger properties and store them as dictionaries
 # Based on trial_dict: if vetoes were applied, trig_* are the veto survivors


### PR DESCRIPTION
This PR ensures that geocenter time and detector time are correctly tracked and used by PyGRB when producing:
- minifollowups of loudest injections (geocenter time) and triggers (detector time)
- tables of loudest events (detector time is also included)
- SNR timeseries (geocenter time is used when overlaying time slides at a detector, but detector time is used when looking at a single slide).

## Standard information about the request

This is an improvement in results presentation and also a bug fix [the follow up of a loud trigger performed with timeslid data should be performed at the correct time in the slid detector(s)]

This change affects: PyGRB

This change changes: result presentation / plotting

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
