### PR TITLE
psd/read.py: now reads the f0 offset when reading PSD from XML

### DIFF
--- a/pycbc/psd/read.py
+++ b/pycbc/psd/read.py
@@ -180,7 +180,13 @@ def from_xml(filename, length, delta_f, low_freq_cutoff, ifo_string=None,
         )
 
     noise_data = psd_freq_series.data.data[:]
-    freq_data = numpy.arange(len(noise_data)) * psd_freq_series.deltaF
+    f0 = psd_freq_series.f0
+    if f0 != 0.0:
+        logger.warning(
+            "XML PSD has non-zero start frequency f0=%.4f Hz; "
+            "applying offset to frequency axis.", f0
+        )
+    freq_data = f0 + numpy.arange(len(noise_data)) * psd_freq_series.deltaF
 
     return from_numpy_arrays(freq_data, noise_data, length, delta_f,
                              low_freq_cutoff)


### PR DESCRIPTION
This fix resolves the issue where reading PSD from a LIGOLW XML file ignores the frequency offset, leading to an incorrect PSD interpretation.

## Standard information about the request

This is a: bug fix

This change affects: reading PSD from an LIGOLW XML file

This change changes: PSD reading

This change: follows style guidelines (See e.g. [PEP8](https://peps.python.org/pep-0008/)), has been proposed using the [contribution guidelines](https://github.com/gwastro/pycbc/blob/master/CONTRIBUTING.md)

This change will: not have any negative effects.

## Motivation

The `pycbc.psd.read.from_xml` code does not read the frequency offset (`f0`) from the LIGOLW XML file. The XML file has the value in the line (part of the "psd" LIGO_LW table) 
`<Dim Name="Frequency" Unit="s^-1" Start="20" Scale="0.25">1969</Dim>` (for an example), particularly `Start="20"`.

## Contents

The new code just uses the `f0` value that LAL has already parsed and applies the shift to the frequency array.

## Links to any issues or associated PRs

I am currently not aware of any related issues.

## Testing performed

It solves the problem. Have not performed any unit tests. Some automated checks are still failing, as they did before.

## Additional notes



- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
