### PR TITLE
Adding TaylorF2Ecc

### DIFF
--- a/pycbc/waveform/waveform.py
+++ b/pycbc/waveform/waveform.py
@@ -1108,6 +1108,7 @@ _filter_ends["TaylorF2"] = spa_tmplt_end
 _template_amplitude_norms["SPAtmplt"] = spa_amplitude_factor
 _filter_time_lengths["SPAtmplt"] = spa_length_in_time
 _filter_time_lengths["TaylorF2"] = spa_length_in_time
+_filter_time_lengths["TaylorF2Ecc"] = spa_length_in_time
 _filter_time_lengths["SpinTaylorT5"] = spa_length_in_time
 _filter_time_lengths["SEOBNRv1_ROM_EffectiveSpin"] = seobnrv2_length_in_time
 _filter_time_lengths["SEOBNRv1_ROM_DoubleSpin"] = seobnrv2_length_in_time


### PR DESCRIPTION
This PR solves the error

 
```
Traceback (most recent call last):
          File "/home/aakyuz/miniconda3/envs/inj_test/bin/pycbc_inspiral", line 235, in <module>
            gwstrain = strain.from_cli(opt, dyn_range_fac=DYN_RANGE_FAC,
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
          File "/home/aakyuz/miniconda3/envs/inj_test/lib/python3.12/site-packages/pycbc/strain/strain.py", line 345, in from_cli
            injector.apply(strain, opt.channel_name.split(':')[0],
          File "/home/aakyuz/miniconda3/envs/inj_test/lib/python3.12/site-packages/pycbc/inject/inject.py", line 632, in apply
            signal = self.make_strain_from_inj_object(
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
          File "/home/aakyuz/miniconda3/envs/inj_test/lib/python3.12/site-packages/pycbc/inject/inject.py", line 710, in make_strain_from_inj_object
            hp, hc = get_td_waveform(inj, delta_t=delta_t, f_lower=f_l,
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
          File "/home/aakyuz/miniconda3/envs/inj_test/lib/python3.12/site-packages/pycbc/waveform/waveform.py", line 601, in get_td_waveform
            raise ValueError("Approximant %s not available" %
        ValueError: Approximant TaylorF2Ecc not available

```