### PR TITLE
Remove tox-conda from workflow CI

### DIFF
--- a/.github/workflows/basic-tests.yml
+++ b/.github/workflows/basic-tests.yml
@@ -29,8 +29,8 @@ jobs:
           mpi \
           intel-mkl* \
           graphviz \
-          libgsl \
-          liblapacke
+          libgsl-dev \
+          liblapacke-dev
         pip install tox pip setuptools --upgrade
     - name: Cache LAL auxiliary data files
       id: cache-lal-aux-data

--- a/.github/workflows/basic-tests.yml
+++ b/.github/workflows/basic-tests.yml
@@ -24,7 +24,13 @@ jobs:
     - name: installing system packages
       run: |
         sudo apt-get -o Acquire::Retries=3 update
-        sudo apt-get -o Acquire::Retries=3 install *fftw3* mpi intel-mkl* graphviz
+        sudo apt-get -o Acquire::Retries=3 install \
+          *fftw3* \
+          mpi \
+          intel-mkl* \
+          graphviz \
+          libgsl \
+          liblapacke
         pip install tox pip setuptools --upgrade
     - name: Cache LAL auxiliary data files
       id: cache-lal-aux-data

--- a/.github/workflows/mac-test.yml
+++ b/.github/workflows/mac-test.yml
@@ -25,6 +25,10 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
+    - name: Install libraries with Homebrew
+      run: |
+        brew install fftw gsl lapack
+
     - name: Install tox
       run: |
         python -m pip install --upgrade pip setuptools tox

--- a/.github/workflows/mac-test.yml
+++ b/.github/workflows/mac-test.yml
@@ -18,40 +18,16 @@ jobs:
           - '3.12'
           - '3.13'
 
-    # this is needed for conda environments to activate automatically
-    defaults:
-      run:
-        shell: bash -el {0}
-
     steps:
     - uses: actions/checkout@v1
-
-    - name: Cache conda packages
-      uses: actions/cache@v4
-      env:
-        # increment to reset cache
-        CACHE_NUMBER: 0
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
       with:
-        path: ~/conda_pkgs_dir
-        key: ${{ runner.os }}-conda-${{ matrix.python-version}}-${{ env.CACHE_NUMBER }}
-
-    - name: Configure conda
-      uses: conda-incubator/setup-miniconda@v3
-      with:
-        activate-environment: test
-        channels: conda-forge
-        miniforge-version: latest
         python-version: ${{ matrix.python-version }}
-
-    - name: Conda info
-      run: conda info --all
 
     - name: Install tox
       run: |
-        conda install \
-            pip \
-            setuptools \
-            tox
+        python -m pip install --upgrade pip setuptools tox
 
     - name: Run basic pycbc test suite
       run: |

--- a/tox.ini
+++ b/tox.ini
@@ -3,40 +3,25 @@ recreate = true
 envlist = py-unittest
 indexserver =
     preinstall = https://pypi.python.org/simple
-requires=tox-conda 
-         setuptools
+requires = setuptools
 
 [base]
 deps =
     :preinstall: -rrequirements.txt
     -rcompanion.txt
     mkl;'arm' not in platform_machine
-conda_deps =
-    c-compiler
-    cxx-compiler
-    gsl
-    mysqlclient
-    blas=*=openblas
-    fftw
+
 
 [bbhx]
 deps =
     git+https://github.com/titodalcanton/BBHx.git@py39-and-cleanup; sys_platform == 'linux'
     git+https://github.com/gwastro/BBHX-waveform-model.git; sys_platform == 'linux'
-conda_deps =
-    liblapacke
-    openblas
+
 
 [testenv]
 allowlist_externals =
     bash
-    conda
-conda_channels=conda-forge
-conda_deps =
-    {[base]conda_deps}
-    {[bbhx]conda_deps}
 commands_pre =
-    conda list
 commands = pytest
 deps =
     {[base]deps}

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,6 @@
 [tox]
 recreate = true
 envlist = py-unittest
-indexserver =
-    preinstall = https://pypi.python.org/simple
 requires = setuptools
 
 [base]
@@ -14,7 +12,7 @@ deps =
 
 [bbhx]
 deps =
-    git+https://github.com/titodalcanton/BBHx.git@py39-and-cleanup; sys_platform == 'linux'
+    bbhx;git+https://github.com/titodalcanton/BBHx.git@py39-and-cleanup; sys_platform == 'linux'
     git+https://github.com/gwastro/BBHX-waveform-model.git; sys_platform == 'linux'
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ requires = setuptools
 
 [base]
 deps =
-    :preinstall: -rrequirements.txt
+    -rrequirements.txt
     -rcompanion.txt
     mkl;'arm' not in platform_machine
 

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ deps =
 
 [bbhx]
 deps =
-    bbhx;git+https://github.com/titodalcanton/BBHx.git@py39-and-cleanup; sys_platform == 'linux'
+    git+https://github.com/titodalcanton/BBHx.git@py39-and-cleanup; sys_platform == 'linux'
     git+https://github.com/gwastro/BBHX-waveform-model.git; sys_platform == 'linux'
 
 


### PR DESCRIPTION
tox-conda is abandonware (no development in 3 years) and it looks like its non-updating was the root of some of the recent failures

I have simply torn out tox-conda and am using virtual environments in the way that tox supports natively.

I would like the CI to use conda to created / cached / used for tox tests, but I dont see a straightforward way to set it up