### PR TITLE
Fix tox build failures by adding pip to conda_deps

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,7 @@ deps =
     -rcompanion.txt
     mkl;'arm' not in platform_machine
 conda_deps =
+    pip
     c-compiler
     cxx-compiler
     gsl


### PR DESCRIPTION
Fix CI build failures for Python 3.12+ by explicitly adding pip to the tox-conda environment dependencies.

## Standard information about the request

<!--- Some basic info about the change (delete as appropriate) -->
This is a: bug fix

<!--- What code areas will this affect? (delete as apropriate) -->
This change changes: CI tests

## Motivation
CI tests were failing due to missing `pip` module, example [here](https://github.com/gwastro/pycbc/actions/runs/26525353674/job/78127398431#step:8:30).

We are only seeing this now because python environments created using `tox-conda` no longer bundle `pip` by default, causing the installation to fail on Python versions >= 3.12. 


## Contents
Added pip to the conda dependencies in the tox.ini. 

## Testing performed
The search CI test passes successfully: [LINK](https://github.com/rahuldhurkunde/pycbc/actions/runs/26697312855/job/78683919208)

### Additional comment

`tox-conda` is an unmaintained plugin and is always downgraded to an older `3.x` version. For long-term fix, we may need an alternative: switching to `tox-mamba` could be an option.

- [ ] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
