### PR TITLE
Adding eccentric chirp mass in conversions.py

### DIFF
--- a/pycbc/conversions.py
+++ b/pycbc/conversions.py
@@ -478,6 +478,47 @@ def mass2_from_tau0_tau3(tau0, tau3, f_lower):
     return mass2_from_mtotal_eta(mtotal, eta)
 
 
+def ecc_mchirp_from_mchirp_ecc(mchirp, ecc):
+    """ The effective eccentric mchirp parameter as defined in
+    the equation 8 in https://arxiv.org/pdf/2107.14736.
+    Eccentricity must be defined at the dominant (2,2) mode GW
+    frequency of 10 Hz.
+    """
+    # Constants from Table 1
+    xi = 0.06110974175360381
+    delta = -0.4193723077257345
+
+    Xi_beta = 0.00801015132110059
+    Delta_beta = -2.14807199936756e-5
+    kappa_beta = 1.12702400406416e-8
+    zeta_beta = -1.9753003183066e-12
+
+    Xi_gamma = 0.024204222771565382
+    Delta_gamma = -6.261945897154536e-6
+    kappa_gamma = 1.1175104924576945e-8
+    zeta_gamma = -3.681726165703978e-12
+
+    # Calculate coefficients (Eq 9)
+    alpha = xi * mchirp + delta
+
+    beta = (Xi_beta * mchirp**2 +
+            Delta_beta * mchirp**4 +
+            kappa_beta * mchirp**6 +
+            zeta_beta * mchirp**8)
+
+    gamma = (Xi_gamma * mchirp**2 +
+             Delta_gamma * mchirp**4 +
+             kappa_gamma * mchirp**6 +
+             zeta_gamma * mchirp**8)
+
+    e2 = ecc**2
+    e4 = e2**2
+    e6 = e4 * e2
+
+    ecc_mchirp = mchirp * (1 + alpha * e2 + beta * e4 + gamma * e6)
+
+    return ecc_mchirp
+
 def lambda_tilde(mass1, mass2, lambda1, lambda2):
     """ The effective lambda parameter
 

--- a/pycbc/conversions.py
+++ b/pycbc/conversions.py
@@ -215,7 +215,7 @@ def mchirp_from_mass1_mass2(mass1, mass2):
     """Returns the chirp mass from mass1 and mass2."""
     return eta_from_mass1_mass2(mass1, mass2)**(3./5) * (mass1 + mass2)
 
-def Emchirp_from_mass1_mass2_eccentricity(mass1, mass2, eccentricity, method='SPA_Phase'):
+def Emchirp_from_mass1_mass2_eccentricity(mass1, mass2, eccentricity, method='spa_phase'):
     """Returns the effective eccentric chirp mass from mass1, mass2 and eccentricity
 
     Parameters
@@ -225,14 +225,14 @@ def Emchirp_from_mass1_mass2_eccentricity(mass1, mass2, eccentricity, method='SP
     mass2 : float or array
         Mass of the secondary object
     eccentricity : float or array
-        Eccentricity of the orbit (For "Fit" method, eccentricity must be defined at 10 Hz.
-        For "SPA_Phase" method, eccentricity can be defined at any frequency, usually the start
+        Eccentricity of the orbit (For "fit" method, eccentricity must be defined at 10 Hz.
+        For "spa_phase" method, eccentricity can be defined at any frequency, usually the start
         frequency of the waveform.)
     method : str, optiona
-        Method to use for the calculation ("SPA_Phase", "Fit").
+        Method to use for the calculation ("spa_phase", "fit").
         See `Emchirp_from_mchirp_eccentricity` for details.
     """
-    allowed_methods = ("SPA_Phase", "Fit")
+    allowed_methods = ("spa_phase", "fit")
     if method not in allowed_methods:
         raise ValueError("method must be one of {}".format(allowed_methods))
     mchirp = mchirp_from_mass1_mass2(mass1, mass2)
@@ -501,7 +501,7 @@ def mass2_from_tau0_tau3(tau0, tau3, f_lower):
     return mass2_from_mtotal_eta(mtotal, eta)
 
 
-def Emchirp_from_mchirp_eccentricity(mchirp, eccentricity, method="SPA_Phase"):
+def Emchirp_from_mchirp_eccentricity(mchirp, eccentricity, method="spa_phase"):
     """Return the effective eccentric chirp mass: Emchirp.
 
     Parameters
@@ -510,10 +510,10 @@ def Emchirp_from_mchirp_eccentricity(mchirp, eccentricity, method="SPA_Phase"):
         Chirp mass of the system
     eccentricity : float or array
         Eccentricity of the system
-    method : {"SPA_Phase", "Fit"},
-         Method to use for calculation (default is "SPA_Phase")
+    method : {"spa_phase", "fit"},
+         Method to use for calculation (default is "spa_phase")
 
-        "SPA_Phase":
+        "spa_phase":
             Effective eccentric mchirp parameter derived from the
             leading term of the stationary phase approximation (SPA)
             of the phase of low eccentric system as defined in Eq. 1.1
@@ -524,13 +524,13 @@ def Emchirp_from_mchirp_eccentricity(mchirp, eccentricity, method="SPA_Phase"):
             the orbit. The SPA phase only contain dominat (2,2) mode
             contribution with no higher eccentric harmonics.
 
-        "Fit":
+        "fit":
             Effective eccentric mchirp parameter derived from fitting to
             time-frequency track. The fitting formula is given in Eq. 8 of
             https://arxiv.org/abs/2107.14736. Eccentricity must be defined
             at the dominant (2,2) mode GW frequency of 10 Hz.
     """
-    allowed_methods = ("SPA_Phase", "Fit")
+    allowed_methods = ("spa_phase", "fit")
 
     if method not in allowed_methods:
         raise ValueError("method must be one of {}".format(allowed_methods))
@@ -539,10 +539,10 @@ def Emchirp_from_mchirp_eccentricity(mchirp, eccentricity, method="SPA_Phase"):
 
     e2 = eccentricity * eccentricity
 
-    if method == "SPA_Phase":
+    if method == "spa_phase":
         Emchirp =  mchirp / (1.0 - 157.0 / 24.0 * e2)**(3.0 / 5.0)
 
-    elif method == "Fit":
+    elif method == "fit":
         # Constants from Table 1 of https://arxiv.org/abs/2107.14736
         xi = 0.06110974175360381
         delta = -0.4193723077257345
@@ -573,7 +573,7 @@ def Emchirp_from_mchirp_eccentricity(mchirp, eccentricity, method="SPA_Phase"):
         Emchirp = mchirp * (1 + e2 * (alpha + e2 * (beta + e2 * gamma)))
     return formatreturn(Emchirp, input_is_array)
 
-def mchirp_from_Emchirp_ecc(Emchirp, eccentricity, method="SPA_Phase"):
+def mchirp_from_Emchirp_ecc(Emchirp, eccentricity, method="spa_phase"):
     """Return the chirp mass from the effective eccentric chirp mass and eccentricity.
 
     Parameters
@@ -582,10 +582,10 @@ def mchirp_from_Emchirp_ecc(Emchirp, eccentricity, method="SPA_Phase"):
         Effective eccentric chirp mass of the system
     eccentricity : float or array
         Eccentricity of the system
-    method : {"SPA_Phase", "Fit"},
-         Method to use for calculation (default is "SPA_Phase")
+    method : {"spa_phase", "fit"},
+         Method to use for calculation (default is "spa_phase")
 
-        "SPA_Phase":
+        "spa_phase":
             Inverse of the effective eccentric mchirp parameter from
             Eq. 1.1 of https://arxiv.org/abs/2108.05861. Eccentricity
             can be defined at any frequency, usually start frequency
@@ -594,13 +594,13 @@ def mchirp_from_Emchirp_ecc(Emchirp, eccentricity, method="SPA_Phase"):
             The SPA phase only contain dominat (2,2) mode contribution with no
             higher eccentric harmonics.
 
-        "Fit":
+        "fit":
             Inverse of the effective eccentric mchirp parameter derived from
             fitting to time-frequency track. The fitting formula is given in
             Eq. 8 of https://arxiv.org/abs/2107.14736. Eccentricity must be
             defined at the dominant (2,2) mode GW frequency of 10 Hz.
     """
-    allowed_methods = ("SPA_Phase", "Fit")
+    allowed_methods = ("spa_phase", "fit")
 
     if method not in allowed_methods:
         raise ValueError("method must be one of {}".format(allowed_methods))
@@ -609,10 +609,10 @@ def mchirp_from_Emchirp_ecc(Emchirp, eccentricity, method="SPA_Phase"):
 
     e2 = eccentricity * eccentricity
 
-    if method == "SPA_Phase":
+    if method == "spa_phase":
         m = Emchirp * ( 1 - 157/24 * e2 )**(3/5)
 
-    elif method == "Fit":
+    elif method == "fit":
         # Constants from Table 1 of https://arxiv.org/abs/2107.14736
         xi = 0.06110974175360381
         delta = -0.4193723077257345
@@ -2088,6 +2088,6 @@ __all__ = ['Emchirp_from_mchirp_ecc', 'mchirp_from_Emchirp_ecc',
            'remnant_mass_from_mass1_mass2_cartesian_spin_eos',
            'lambda1_from_delta_lambda_tilde_lambda_tilde',
            'lambda2_from_delta_lambda_tilde_lambda_tilde',
-           'delta_lambda_tilde', 'hypertriangle', 
+           'delta_lambda_tilde', 'hypertriangle',
            'Emchirp_from_mass1_mass2_eccentricity'
           ]

--- a/pycbc/conversions.py
+++ b/pycbc/conversions.py
@@ -215,6 +215,14 @@ def mchirp_from_mass1_mass2(mass1, mass2):
     """Returns the chirp mass from mass1 and mass2."""
     return eta_from_mass1_mass2(mass1, mass2)**(3./5) * (mass1 + mass2)
 
+def mchirp_eccentric_from_mass1_mass2_eccentricity(mass1, mass2, eccentricity):
+    """Returns the eccentric chirp mass from mass1, mass2 and eccentricity
+
+    The definition is based on Eq. 1.1, Favata et al., Phy. Rev. D, 105, 023003 (2022)
+    """
+    mchirp = mchirp_from_mass1_mass2(mass1, mass2)
+    mchirp_eccentric = mchirp / ( 1 - 157./24 * eccentricity * eccentricity )**(3./5)
+    return mchirp_eccentric
 
 def mass1_from_mtotal_q(mtotal, q):
     """Returns a component mass from the given total mass and mass ratio.

--- a/pycbc/conversions.py
+++ b/pycbc/conversions.py
@@ -133,7 +133,7 @@ def hypertriangle(*params, bounds=(0, 1)):
     ref_shape = numpy.shape(params[0])
     assert numpy.all([numpy.shape(params[i]) == ref_shape for i in range(len(params))]), \
         "All inputs must have the same number of elements"
-    
+
     # map to numpy array
     params, input_is_array = ensurearray(params)
 
@@ -143,7 +143,7 @@ def hypertriangle(*params, bounds=(0, 1)):
 
     # rescale the parameters to the unit hypercube
     scaled_params = (params - bounds[0])/(bounds[1] - bounds[0])
-    
+
     # hypertriangulate
     try:
         K, num_pts = scaled_params.shape
@@ -215,13 +215,28 @@ def mchirp_from_mass1_mass2(mass1, mass2):
     """Returns the chirp mass from mass1 and mass2."""
     return eta_from_mass1_mass2(mass1, mass2)**(3./5) * (mass1 + mass2)
 
-def mchirp_eccentric_from_mass1_mass2_eccentricity(mass1, mass2, eccentricity):
-    """Returns the eccentric chirp mass from mass1, mass2 and eccentricity
+def Emchirp_from_mass1_mass2_eccentricity(mass1, mass2, eccentricity, method='SPA_Phase'):
+    """Returns the effective eccentric chirp mass from mass1, mass2 and eccentricity
 
-    The definition is based on Eq. 1.1, Favata et al., Phy. Rev. D, 105, 023003 (2022)
+    Parameters
+    ----------
+    mass1 : float or array
+        Mass of the primary object
+    mass2 : float or array
+        Mass of the secondary object
+    eccentricity : float or array
+        Eccentricity of the orbit (For "Fit" method, eccentricity must be defined at 10 Hz.
+        For "SPA_Phase" method, eccentricity can be defined at any frequency, usually the start
+        frequency of the waveform.)
+    method : str, optiona
+        Method to use for the calculation ("SPA_Phase", "Fit").
+        See `Emchirp_from_mchirp_eccentricity` for details.
     """
+    allowed_methods = ("SPA_Phase", "Fit")
+    if method not in allowed_methods:
+        raise ValueError("method must be one of {}".format(allowed_methods))
     mchirp = mchirp_from_mass1_mass2(mass1, mass2)
-    mchirp_eccentric = mchirp / ( 1 - 157./24 * eccentricity * eccentricity )**(3./5)
+    mchirp_eccentric = Emchirp_from_mchirp_eccentricity(mchirp, eccentricity, method=method)
     return mchirp_eccentric
 
 def mass1_from_mtotal_q(mtotal, q):
@@ -486,100 +501,161 @@ def mass2_from_tau0_tau3(tau0, tau3, f_lower):
     return mass2_from_mtotal_eta(mtotal, eta)
 
 
-def Emchirp_from_mchirp_ecc(mchirp, ecc):
-    """ The effective eccentric mchirp parameter as defined in
-    the equation 8 in https://arxiv.org/pdf/2107.14736.
-    Eccentricity must be defined at the dominant (2,2) mode GW
-    frequency of 10 Hz.
+def Emchirp_from_mchirp_eccentricity(mchirp, eccentricity, method="SPA_Phase"):
+    """Return the effective eccentric chirp mass: Emchirp.
+
+    Parameters
+    ----------
+    mchirp : float or array
+        Chirp mass of the system
+    eccentricity : float or array
+        Eccentricity of the system
+    method : {"SPA_Phase", "Fit"},
+         Method to use for calculation (default is "SPA_Phase")
+
+        "SPA_Phase":
+            Effective eccentric mchirp parameter derived from the
+            leading term of the stationary phase approximation (SPA)
+            of the phase of low eccentric system as defined in Eq. 1.1
+            of https://arxiv.org/abs/2108.05861. The eccentricity can
+            be defined at any frequency, usually start frequency of the
+            waveform. The eccentriciy is defiend as the time component
+            of eccentricity from the quasi-Keplerian parametrization of
+            the orbit. The SPA phase only contain dominat (2,2) mode
+            contribution with no higher eccentric harmonics.
+
+        "Fit":
+            Effective eccentric mchirp parameter derived from fitting to
+            time-frequency track. The fitting formula is given in Eq. 8 of
+            https://arxiv.org/abs/2107.14736. Eccentricity must be defined
+            at the dominant (2,2) mode GW frequency of 10 Hz.
     """
-    # Constants from Table 1
-    xi = 0.06110974175360381
-    delta = -0.4193723077257345
+    allowed_methods = ("SPA_Phase", "Fit")
 
-    Xi_beta = 0.00801015132110059
-    Delta_beta = -2.14807199936756e-5
-    kappa_beta = 1.12702400406416e-8
-    zeta_beta = -1.9753003183066e-12
+    if method not in allowed_methods:
+        raise ValueError("method must be one of {}".format(allowed_methods))
 
-    Xi_gamma = 0.024204222771565382
-    Delta_gamma = -6.261945897154536e-6
-    kappa_gamma = 1.1175104924576945e-8
-    zeta_gamma = -3.681726165703978e-12
+    mchirp, eccentricity, input_is_array = ensurearray(mchirp, eccentricity)
 
-    # Calculate coefficients (Eq 9)
-    alpha = xi * mchirp + delta
+    e2 = eccentricity * eccentricity
 
-    beta = (Xi_beta * mchirp**2 +
-            Delta_beta * mchirp**4 +
-            kappa_beta * mchirp**6 +
-            zeta_beta * mchirp**8)
+    if method == "SPA_Phase":
+        Emchirp =  mchirp / (1.0 - 157.0 / 24.0 * e2)**(3.0 / 5.0)
 
-    gamma = (Xi_gamma * mchirp**2 +
-             Delta_gamma * mchirp**4 +
-             kappa_gamma * mchirp**6 +
-             zeta_gamma * mchirp**8)
+    elif method == "Fit":
+        # Constants from Table 1 of https://arxiv.org/abs/2107.14736
+        xi = 0.06110974175360381
+        delta = -0.4193723077257345
 
-    e2 = ecc**2
-    e4 = e2**2
-    e6 = e4 * e2
+        Xi_beta = 0.00801015132110059
+        Delta_beta = -2.14807199936756e-5
+        kappa_beta = 1.12702400406416e-8
+        zeta_beta = -1.9753003183066e-12
 
-    Emchirp = mchirp * (1 + alpha * e2 + beta * e4 + gamma * e6)
+        Xi_gamma = 0.024204222771565382
+        Delta_gamma = -6.261945897154536e-6
+        kappa_gamma = 1.1175104924576945e-8
+        zeta_gamma = -3.681726165703978e-12
 
-    return Emchirp
+        mchirp2 = mchirp * mchirp
 
-def mchirp_from_Emchirp_ecc(Emchirp, ecc):
-    """ The inverse of Emchirp_from_mchirp_ecc.
-    Returns the chirp mass given the eccentric chirp mass and eccentricity.
-    The eccentricity must be defined at 10 Hz.
+        # Calculate coefficients (Eq 9)
+        alpha = xi * mchirp + delta
+
+        beta = mchirp2 * ( Xi_beta  +
+                           mchirp2 * ( Delta_beta  +
+                           mchirp2 * ( kappa_beta  +
+                           mchirp2 * zeta_beta )))
+        gamma = mchirp2 * ( Xi_gamma +
+                            mchirp2 * ( Delta_gamma +
+                            mchirp2 * ( kappa_gamma  +
+                            mchirp2 * zeta_gamma )))
+        Emchirp = mchirp * (1 + e2 * (alpha + e2 * (beta + e2 * gamma)))
+    return formatreturn(Emchirp, input_is_array)
+
+def mchirp_from_Emchirp_ecc(Emchirp, eccentricity, method="SPA_Phase"):
+    """Return the chirp mass from the effective eccentric chirp mass and eccentricity.
+
+    Parameters
+    ----------
+    Emchirp : float or array
+        Effective eccentric chirp mass of the system
+    eccentricity : float or array
+        Eccentricity of the system
+    method : {"SPA_Phase", "Fit"},
+         Method to use for calculation (default is "SPA_Phase")
+
+        "SPA_Phase":
+            Inverse of the effective eccentric mchirp parameter from
+            Eq. 1.1 of https://arxiv.org/abs/2108.05861. Eccentricity
+            can be defined at any frequency, usually start frequency
+            of the waveform. The eccentriciy is defiend as the time component
+            of eccentricity from the quasi-Keplerian parametrization of the orbit.
+            The SPA phase only contain dominat (2,2) mode contribution with no
+            higher eccentric harmonics.
+
+        "Fit":
+            Inverse of the effective eccentric mchirp parameter derived from
+            fitting to time-frequency track. The fitting formula is given in
+            Eq. 8 of https://arxiv.org/abs/2107.14736. Eccentricity must be
+            defined at the dominant (2,2) mode GW frequency of 10 Hz.
     """
-    Emchirp, ecc, input_is_array = ensurearray(Emchirp, ecc)
+    allowed_methods = ("SPA_Phase", "Fit")
 
-    # Constants from Table 1 of https://arxiv.org/pdf/2107.14736
-    xi = 0.06110974175360381
-    delta = -0.4193723077257345
-    Xi_beta = 0.00801015132110059
-    Delta_beta = -2.14807199936756e-5
-    kappa_beta = 1.12702400406416e-8
-    zeta_beta = -1.9753003183066e-12
-    Xi_gamma = 0.024204222771565382
-    Delta_gamma = -6.261945897154536e-6
-    kappa_gamma = 1.1175104924576945e-8
-    zeta_gamma = -3.681726165703978e-12
+    if method not in allowed_methods:
+        raise ValueError("method must be one of {}".format(allowed_methods))
 
-    e2 = ecc**2
-    e4 = e2**2
-    e6 = e4 * e2
+    Emchirp, eccentricity, input_is_array = ensurearray(Emchirp, eccentricity)
 
-    # Use Newton's method to solve the equation for mchirp
-    # Initial guess using the quadratic approximation
-    A = xi * e2
-    B = 1 + delta * e2
-    C = -Emchirp
-    m = numpy.where(A > 0, (-B + numpy.sqrt(B**2 - 4*A*C)) / (2*A), Emchirp)
+    e2 = eccentricity * eccentricity
 
-    for _ in range(5):
-        m2 = m**2
-        m3 = m2 * m
-        m4 = m2**2
-        m5 = m4 * m
-        m6 = m3**2
-        m7 = m6 * m
-        m8 = m4**2
+    if method == "SPA_Phase":
+        m = Emchirp * ( 1 - 157/24 * e2 )**(3/5)
 
-        alpha = xi * m + delta
-        beta = Xi_beta * m2 + Delta_beta * m4 + kappa_beta * m6 + zeta_beta * m8
-        gamma = Xi_gamma * m2 + Delta_gamma * m4 + kappa_gamma * m6 + zeta_gamma * m8
+    elif method == "Fit":
+        # Constants from Table 1 of https://arxiv.org/abs/2107.14736
+        xi = 0.06110974175360381
+        delta = -0.4193723077257345
+        Xi_beta = 0.00801015132110059
+        Delta_beta = -2.14807199936756e-5
+        kappa_beta = 1.12702400406416e-8
+        zeta_beta = -1.9753003183066e-12
+        Xi_gamma = 0.024204222771565382
+        Delta_gamma = -6.261945897154536e-6
+        kappa_gamma = 1.1175104924576945e-8
+        zeta_gamma = -3.681726165703978e-12
 
-        f = m * (1 + alpha * e2 + beta * e4 + gamma * e6) - Emchirp
+        # Use Newton's method to solve the equation for mchirp
+        # Initial guess using the quadratic approximation
+        A = xi * e2
+        B = 1 + delta * e2
+        C = - Emchirp
+        m = numpy.where(A > 0, (-B + numpy.sqrt(B**2 - 4*A*C)) / (2*A), Emchirp)
 
-        d_alpha = xi
-        d_beta = 2 * Xi_beta * m + 4 * Delta_beta * m3 + 6 * kappa_beta * m5 + 8 * zeta_beta * m7
-        d_gamma = 2 * Xi_gamma * m + 4 * Delta_gamma * m3 + 6 * kappa_gamma * m5 + 8 * zeta_gamma * m7
-
-        df = (1 + alpha * e2 + beta * e4 + gamma * e6) + m * (d_alpha * e2 + d_beta * e4 + d_gamma * e6)
-        m = m - f / df
+        for _ in range(5):
+            m2 = m * m
+            alpha = xi * m + delta
+            beta = m2 * ( Xi_beta + m2 * ( Delta_beta +
+                                    m2 * ( kappa_beta +
+                                    m2 * zeta_beta )))
+            gamma = m2 * ( Xi_gamma +
+                                m2 * ( Delta_gamma +
+                                m2 * ( kappa_gamma  +
+                                m2 * zeta_gamma )))
+            f = m * (1 + e2 * (alpha + e2 * ( beta + e2 *gamma ))) - Emchirp
+            d_alpha = xi
+            d_beta = m * ( 2 * Xi_beta + m2 * ( 4 * Delta_beta +
+                                                m2 *( 6 * kappa_beta +
+                                                m2 * 8 * zeta_beta )))
+            d_gamma = m * ( 2 * Xi_gamma + m2 * ( 4 * Delta_gamma +
+                                           m2 * ( 6 * kappa_gamma +
+                                           m2 * 8 * zeta_gamma )))
+            df = (1 + e2 * (alpha  + e2 * ( beta + e2 * gamma )) +
+                 m * e2 * (d_alpha + e2 * ( d_beta + e2 * d_gamma )))
+            m = m - f / df
 
     return formatreturn(m, input_is_array)
+
 def lambda_tilde(mass1, mass2, lambda1, lambda2):
     """ The effective lambda parameter
 

--- a/pycbc/conversions.py
+++ b/pycbc/conversions.py
@@ -215,7 +215,8 @@ def mchirp_from_mass1_mass2(mass1, mass2):
     """Returns the chirp mass from mass1 and mass2."""
     return eta_from_mass1_mass2(mass1, mass2)**(3./5) * (mass1 + mass2)
 
-def Emchirp_from_mass1_mass2_eccentricity(mass1, mass2, eccentricity, method='spa_phase'):
+
+def eccmchirp_from_mass1_mass2_eccentricity(mass1, mass2, eccentricity, method='spa_phase'):
     """Returns the effective eccentric chirp mass from mass1, mass2 and eccentricity
 
     Parameters
@@ -230,14 +231,15 @@ def Emchirp_from_mass1_mass2_eccentricity(mass1, mass2, eccentricity, method='sp
         frequency of the waveform.)
     method : str, optiona
         Method to use for the calculation ("spa_phase", "fit").
-        See `Emchirp_from_mchirp_eccentricity` for details.
+        See `eccmchirp_from_mchirp_eccentricity` for details.
     """
     allowed_methods = ("spa_phase", "fit")
     if method not in allowed_methods:
         raise ValueError("method must be one of {}".format(allowed_methods))
     mchirp = mchirp_from_mass1_mass2(mass1, mass2)
-    mchirp_eccentric = Emchirp_from_mchirp_eccentricity(mchirp, eccentricity, method=method)
+    mchirp_eccentric = eccmchirp_from_mchirp_eccentricity(mchirp, eccentricity, method=method)
     return mchirp_eccentric
+
 
 def mass1_from_mtotal_q(mtotal, q):
     """Returns a component mass from the given total mass and mass ratio.
@@ -501,8 +503,8 @@ def mass2_from_tau0_tau3(tau0, tau3, f_lower):
     return mass2_from_mtotal_eta(mtotal, eta)
 
 
-def Emchirp_from_mchirp_eccentricity(mchirp, eccentricity, method="spa_phase"):
-    """Return the effective eccentric chirp mass: Emchirp.
+def eccmchirp_from_mchirp_eccentricity(mchirp, eccentricity, method="spa_phase"):
+    """Return the effective eccentric chirp mass: eccmchirp.
 
     Parameters
     ----------
@@ -573,12 +575,12 @@ def Emchirp_from_mchirp_eccentricity(mchirp, eccentricity, method="spa_phase"):
         Emchirp = mchirp * (1 + e2 * (alpha + e2 * (beta + e2 * gamma)))
     return formatreturn(Emchirp, input_is_array)
 
-def mchirp_from_Emchirp_ecc(Emchirp, eccentricity, method="spa_phase"):
+def mchirp_from_eccmchirp_eccentricity(eccmchirp, eccentricity, method="spa_phase"):
     """Return the chirp mass from the effective eccentric chirp mass and eccentricity.
 
     Parameters
     ----------
-    Emchirp : float or array
+    eccmchirp : float or array
         Effective eccentric chirp mass of the system
     eccentricity : float or array
         Eccentricity of the system
@@ -605,12 +607,12 @@ def mchirp_from_Emchirp_ecc(Emchirp, eccentricity, method="spa_phase"):
     if method not in allowed_methods:
         raise ValueError("method must be one of {}".format(allowed_methods))
 
-    Emchirp, eccentricity, input_is_array = ensurearray(Emchirp, eccentricity)
+    eccmchirp, eccentricity, input_is_array = ensurearray(eccmchirp, eccentricity)
 
     e2 = eccentricity * eccentricity
 
     if method == "spa_phase":
-        m = Emchirp * ( 1 - 157/24 * e2 )**(3/5)
+        m = eccmchirp * ( 1 - 157/24 * e2 )**(3/5)
 
     elif method == "fit":
         # Constants from Table 1 of https://arxiv.org/abs/2107.14736
@@ -629,8 +631,8 @@ def mchirp_from_Emchirp_ecc(Emchirp, eccentricity, method="spa_phase"):
         # Initial guess using the quadratic approximation
         A = xi * e2
         B = 1 + delta * e2
-        C = - Emchirp
-        m = numpy.where(A > 0, (-B + numpy.sqrt(B**2 - 4*A*C)) / (2*A), Emchirp)
+        C = - eccmchirp
+        m = numpy.where(A > 0, (-B + numpy.sqrt(B**2 - 4*A*C)) / (2*A), eccmchirp)
 
         for _ in range(5):
             m2 = m * m
@@ -2047,7 +2049,9 @@ def nltides_gw_phase_diff_isco(f_low, f0, amplitude, n, m1, m2):
     return formatreturn(phi_i - phi_l, input_is_array)
 
 
-__all__ = ['Emchirp_from_mchirp_ecc', 'mchirp_from_Emchirp_ecc',
+__all__ = ['eccmchirp_from_mchirp_eccentricity',
+           'mchirp_from_eccmchirp_eccentricity',
+           'eccmchirp_from_mass1_mass2_eccentricity',
            'dquadmon_from_lambda', 'lambda_tilde',
            'lambda_from_mass_tov_file', 'primary_mass',
            'secondary_mass', 'mtotal_from_mass1_mass2',
@@ -2088,6 +2092,5 @@ __all__ = ['Emchirp_from_mchirp_ecc', 'mchirp_from_Emchirp_ecc',
            'remnant_mass_from_mass1_mass2_cartesian_spin_eos',
            'lambda1_from_delta_lambda_tilde_lambda_tilde',
            'lambda2_from_delta_lambda_tilde_lambda_tilde',
-           'delta_lambda_tilde', 'hypertriangle',
-           'Emchirp_from_mass1_mass2_eccentricity'
+           'delta_lambda_tilde', 'hypertriangle'
           ]

--- a/pycbc/conversions.py
+++ b/pycbc/conversions.py
@@ -2088,5 +2088,6 @@ __all__ = ['Emchirp_from_mchirp_ecc', 'mchirp_from_Emchirp_ecc',
            'remnant_mass_from_mass1_mass2_cartesian_spin_eos',
            'lambda1_from_delta_lambda_tilde_lambda_tilde',
            'lambda2_from_delta_lambda_tilde_lambda_tilde',
-           'delta_lambda_tilde', 'hypertriangle'
+           'delta_lambda_tilde', 'hypertriangle', 
+           'Emchirp_from_mass1_mass2_eccentricity'
           ]


### PR DESCRIPTION
This PR adds functionality to compute the eccentricity-weighted chirp mass/eccentric chirp mass. The implementation introduces a new function in conversions.py.  This papermeter is useful for estimating the noise-trigger rate of eccentric searches performed with TaylorF2Ecc.  The parameter is derived analytically from the leading term of the TaylorF2Ecc phase expression in Eqs. 1.1, 3.3-3.6a of  https://arxiv.org/abs/2108.05861.  The eccentricity is defined as the time component of eccentricity ($e=e_t$) in quasi-Keplerian terms.   

 -  Limitations of the new parameter:   Since the TaylorF2Ecc model is valid in a small eccentricity regime ($e \lesssim 0.2$), this new effective parameter is likewise expected to be valid only within the regime of validity of the  TaylorF2Ecc model.

- [ ] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
 