### PR TITLE
fix duplicate logging

### DIFF
--- a/pycbc/__init__.py
+++ b/pycbc/__init__.py
@@ -141,6 +141,11 @@ def init_logging(verbose=False, default_level=0, to_file=None,
     # See https://docs.python.org/3/library/logging.html#levels
     # for log level definitions
     logger = logging.getLogger()
+
+    # This resets duplicate loggers in preference of ours.
+    # Otherwise, you may see duplicate messages
+    logger.handlers.clear()
+
     verbose_int = default_level if verbose is None \
         else int(verbose) + default_level
     logger.setLevel(logging.WARNING - verbose_int * 10)  # Initial setting


### PR DESCRIPTION
If a package is important which starts doing logging in the import itself, this will setup a logger which conflicts with the pycbc one set up with pycbc.init_logging. What will usually happen is that all logging messages from that point forward will be duplicated. This is pretty annoying. This fix, simply clears out the loggers at the point when init_logging is first called so that going forward everything goes through that. 