### PR TITLE
Fix interpolation of config files in pycbc_brute_bank

### DIFF
--- a/bin/bank/pycbc_brute_bank
+++ b/bin/bank/pycbc_brute_bank
@@ -86,11 +86,7 @@ args = parser.parse_args()
 pycbc.init_logging(args.verbose)
 numpy.random.seed(args.seed)
 
-config_parser = pycbc.types.config.InterpolatingConfigParser()
-file = open(args.input_config, 'r')
-config_parser.read_file(file)
-file.close()
-
+config_parser = pycbc.types.config.InterpolatingConfigParser([args.input_config])
 variable_args, static_args = read_params_from_config(
     config_parser, prior_section='prior',
     vargs_section='variable_params',


### PR DESCRIPTION
Refactor config parser initialization to read directly from input config. Currently the interpolation is actually bypassed because it is invoking a parent class method which does not invoke the interpolation. The fix is to use the expected constructor.


- [ ] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
