### PR TITLE
Fix broken segment handling code in PyGRB

### DIFF
--- a/bin/pygrb/pycbc_make_offline_grb_workflow
+++ b/bin/pygrb/pycbc_make_offline_grb_workflow
@@ -121,10 +121,10 @@ elif len(sciSegs.keys()) < 2 and not single_ifo:
     msg += "configuration file."
     logging.error(msg)
     sys.exit()
-else:
-    onSrc, offSrc, bufferSeg = _workflow.generate_triggered_segment(wflow,
-                                                                    seg_dir,
-                                                                    sciSegs)
+
+onSrc, offSrc, bufferSeg = _workflow.generate_triggered_segment(
+    wflow, seg_dir, sciSegs
+)
 
 sciSegs = segmentlistdict(sciSegs)
 if onSrc is None:

--- a/bin/pygrb/pycbc_make_offline_grb_workflow
+++ b/bin/pygrb/pycbc_make_offline_grb_workflow
@@ -129,9 +129,11 @@ else:
 sciSegs = segmentlistdict(sciSegs)
 if onSrc is None:
     logging.info("Making segment plot and exiting.")
+    # `make_grb_segments_plot()` wants a single segment for fail_criterion.
+    fail_criterion = offSrc[wflow.ifos[0]][0]
     make_grb_segments_plot(
         wflow, sciSegs, triggertime, triggername,
-        seg_dir, fail_criterion=offSrc)
+        seg_dir, fail_criterion=fail_criterion)
     sys.exit()
 
 plot_met = make_grb_segments_plot(

--- a/bin/pygrb/pycbc_make_offline_grb_workflow
+++ b/bin/pygrb/pycbc_make_offline_grb_workflow
@@ -128,10 +128,10 @@ else:
 
 sciSegs = segmentlistdict(sciSegs)
 if onSrc is None:
+    logging.info("Making segment plot and exiting.")
     make_grb_segments_plot(
         wflow, sciSegs, triggertime, triggername,
         seg_dir, fail_criterion=offSrc)
-    logging.info("Making segment plot and exiting.")
     sys.exit()
 
 plot_met = make_grb_segments_plot(

--- a/pycbc/workflow/segment.py
+++ b/pycbc/workflow/segment.py
@@ -163,7 +163,7 @@ def get_triggered_coherent_segment(workflow, sciencesegs):
     --------
     onsource : igwn_segments.segmentlistdict or None
         A dictionary containing the on source segments for network IFOs,
-        or None if no segments are available for the onsource.
+        or None if no segments are available that meet the requirements.
 
     offsource : igwn_segments.segmentlistdict
         A dictionary containing the off source segments for network IFOs

--- a/pycbc/workflow/segment.py
+++ b/pycbc/workflow/segment.py
@@ -319,7 +319,7 @@ def generate_triggered_segment(workflow, out_dir, sciencesegs):
     min_seg = segments.segment(triggertime - onbefore - minbefore - padding,
                                triggertime + onafter + minafter + padding)
     scisegs = segments.segmentlistdict({ifo: sciencesegs[ifo]
-            for ifo in sciencesegs.keys() if min_seg in sciencesegs[ifo]
+            for ifo in sciencesegs if min_seg in sciencesegs[ifo]
             and abs(sciencesegs[ifo]) >= minduration})
     # Find highest number of IFOs that give an acceptable coherent segment
     num_ifos = len(scisegs)
@@ -337,30 +337,26 @@ def generate_triggered_segment(workflow, out_dir, sciencesegs):
                     workflow, segs)
 
         # Which combination gives the longest coherent segment?
-        valid_combs = [iifos for iifos in onsource.keys()
+        valid_combs = [iifos for iifos in onsource
                        if onsource[iifos] is not None]
 
         if len(valid_combs) == 0:
             # If none, offsource dict will contain segments showing criteria
             # that have not been met, for use in plotting
-            if len(offsource.keys()) > 1:
-                seg_lens = {ifos: abs(next(offsource[ifos].values())[0])
-                            for ifos in offsource.keys()}
-                best_comb = max(seg_lens.iterkeys(),
-                                key=(lambda key: seg_lens[key]))
-            else:
-                best_comb = tuple(offsource.keys())[0]
+            seg_lens = {
+                ifos: abs(next(iter(offsource[ifos].values()))[0])
+                for ifos in offsource
+            }
+            best_comb = max(seg_lens, key=seg_lens.get)
             logger.info("No combination of %d IFOs with suitable science "
                         "segment.", num_ifos)
         else:
             # Identify best analysis segment
-            if len(valid_combs) > 1:
-                seg_lens = {ifos: abs(next(offsource[ifos].values())[0])
-                            for ifos in valid_combs}
-                best_comb = max(seg_lens.iterkeys(),
-                                key=(lambda key: seg_lens[key]))
-            else:
-                best_comb = valid_combs[0]
+            seg_lens = {
+                ifos: abs(next(iter(offsource[ifos].values()))[0])
+                for ifos in valid_combs
+            }
+            best_comb = max(seg_lens, key=seg_lens.get)
             logger.info("Calculated science segments.")
 
             offsourceSegfile = os.path.join(out_dir, "offSourceSeg.txt")

--- a/pycbc/workflow/segment.py
+++ b/pycbc/workflow/segment.py
@@ -392,6 +392,11 @@ def generate_triggered_segment(workflow, out_dir, sciencesegs):
     try:
         return None, offsource[best_comb], None
     except UnboundLocalError:
+        # Catches the case where the while loop above is never taken.
+        min_seg = segments.segmentlistdict({
+            ifo: segments.segmentlist([min_seg])
+            for ifo in sciencesegs
+        })
         return None, min_seg, None
 
 def get_flag_segments_file(workflow, name, option_name, out_dir, tags=None):

--- a/pycbc/workflow/segment.py
+++ b/pycbc/workflow/segment.py
@@ -161,8 +161,9 @@ def get_triggered_coherent_segment(workflow, sciencesegs):
 
     Returns
     --------
-    onsource : igwn_segments.segmentlistdict
-        A dictionary containing the on source segments for network IFOs
+    onsource : igwn_segments.segmentlistdict or None
+        A dictionary containing the on source segments for network IFOs,
+        or None if no segments are available for the onsource.
 
     offsource : igwn_segments.segmentlistdict
         A dictionary containing the off source segments for network IFOs
@@ -207,7 +208,10 @@ def get_triggered_coherent_segment(workflow, sciencesegs):
                                  triggertime + minduration / 2. + padding])
         logger.warning("Available network segment shorter than minimum "
                        "allowed duration.")
-        return None, fail
+        offsource = segments.segmentlistdict()
+        for iifo in sciencesegs:
+            offsource[iifo] = segments.segmentlist([fail])
+        return None, offsource
 
     # Will segment duration be the maximum desired length or not?
     if abs(offsrc) >= maxduration + 2 * padding:
@@ -239,7 +243,7 @@ def get_triggered_coherent_segment(workflow, sciencesegs):
                                     0.5 * maxduration))
 
     # Construct off-source
-    if (idealsegment in offsrc):
+    if idealsegment in offsrc:
         offsrc = idealsegment
 
     elif idealsegment[1] not in offsrc:
@@ -281,9 +285,7 @@ def get_triggered_coherent_segment(workflow, sciencesegs):
     # Put segments into segmentlistdicts
     onsource = segments.segmentlistdict()
     offsource = segments.segmentlistdict()
-    ifos = ''
     for iifo in sciencesegs.keys():
-        ifos += str(iifo)
         onsource[iifo] = onsrc
         offsource[iifo] = offsrc
 
@@ -333,7 +335,7 @@ def generate_triggered_segment(workflow, out_dir, sciencesegs):
             logger.info("Calculating optimal segment for %s.", ifos)
             segs = segments.segmentlistdict({ifo: scisegs[ifo]
                                              for ifo in ifo_combo})
-            onsource[ifos], offsource[ifos] = get_triggered_coherent_segment(\
+            onsource[ifos], offsource[ifos] = get_triggered_coherent_segment(
                     workflow, segs)
 
         # Which combination gives the longest coherent segment?
@@ -357,7 +359,10 @@ def generate_triggered_segment(workflow, out_dir, sciencesegs):
                 for ifos in valid_combs
             }
             best_comb = max(seg_lens, key=seg_lens.get)
-            logger.info("Calculated science segments.")
+            logger.info(
+                "Calculated science segments, best combination is %s",
+                best_comb
+            )
 
             offsourceSegfile = os.path.join(out_dir, "offSourceSeg.txt")
             segmentsUtils.tosegwizard(open(offsourceSegfile, "w"),
@@ -372,7 +377,7 @@ def generate_triggered_segment(workflow, out_dir, sciencesegs):
             bufferright = int(cp.get('workflow-exttrig_segments',
                                      'num-buffer-after'))
             onlen = onbefore + onafter
-            bufferSegment = segments.segment(\
+            bufferSegment = segments.segment(
                     triggertime - onbefore - bufferleft * onlen,
                     triggertime + onafter + bufferright * onlen)
             bufferSegfile = os.path.join(out_dir, "bufferSeg.txt")


### PR DESCRIPTION
It looks like #2717 left some of the segment-handling code broken in the transition from Python 2 to 3. We are finally hitting that problem now:
```
Traceback (most recent call last):
  File "[…]/bin/pycbc_make_offline_grb_workflow", line 125, in <module>
    onSrc, offSrc, bufferSeg = _workflow.generate_triggered_segment(wflow,
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "[…]/lib/python3.12/site-packages/pycbc/workflow/segment.py", line 361, in generate_triggered_segment
    seg_lens = {ifos: abs(next(offsource[ifos].values())[0])
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: 'dict_values' object is not an iterator
```
This should fix it. I also noticed that some of the surrounding "if" statements were not apparently necessary, so I took the chance to simplify the code - please double check this.

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
