### PR TITLE
Security: Missing input validation in `read_store` function

### DIFF
--- a/pycbc/frame/store.py
+++ b/pycbc/frame/store.py
@@ -71,5 +71,13 @@ def read_store(fname, channel, start_time, end_time):
 
     start = int((start_time - stime) * sample_rate)
     end = int((end_time - stime) * sample_rate)
+
+    if start < 0:
+        raise ValueError("Start index is out of bounds")
+    if end > len(data):
+        raise ValueError("End index is out of bounds")
+    if start >= end:
+        raise ValueError("Start index must be less than end index")
+
     return TimeSeries(data[start:end], delta_t=1.0/sample_rate,
                       epoch=start_time)


### PR DESCRIPTION
## Summary

Security: Missing input validation in `read_store` function

## Problem

**Severity**: `Low` | **File**: `pycbc/frame/store.py:L56`

The `read_store` function in `pycbc/frame/store.py` reads from an file using `HFile` but does not validate that `start_time` and `end_time consistent with the file's actual data ranges before performing array slicing. While there are some checks, the function could be more robust against malformed inputs.

## Solution

Add explicit bounds checking for `start_time` and `end_time` parameters, and validate that the computed `start` and `end` indices are within array bounds before slicing.

## Changes

- `pycbc/frame/store.py` (modified)