### PR TITLE
shared / local should all accept file paths

### DIFF
--- a/pycbc/workflow/datafind.py
+++ b/pycbc/workflow/datafind.py
@@ -767,7 +767,8 @@ def convert_cachelist_to_filelist(datafindcache_list):
                 # Be careful here! If all your frames files are on site
                 # = local and you try to run on OSG, it will likely
                 # overwhelm the condor file transfer process!
-                currFile.add_pfn(frame.url, site='local')
+                for site in ['local', 'condorpool_shared']:
+                    currFile.add_pfn(frame.url, site=site)
             else:
                 # Frame is at some unknown URL. Pegasus will decide how to deal
                 # with this, but will likely transfer to local site first, and


### PR DESCRIPTION
This change affects how file:// paths (in particular for frame files) in a cache are handled when using (and only when) the condorpool_shared site. I think in this case, file:// should just as equally be treated as being valid for direct access on the condorpool_shared site as they are on the local. This makes it a bit simpler to directly have jobs point to the frame files or other local objects. The issue is that when using a datafind lcf frame cache file, there is no implicit site (e.g. unlike pegasus cache files). 