### PR TITLE
FIX: bank should return failure code if sent a term signal

### DIFF
--- a/bin/bank/pycbc_brute_bank
+++ b/bin/bank/pycbc_brute_bank
@@ -356,7 +356,7 @@ def handle_exit_signal(signum, frame):
     logging.warning(f"Signal {signum} received. Triggering emergency save...")
     save_bank()
     # Force exit so the script doesn't try to resume the loops
-    os._exit(0)
+    os._exit(1)
 
 def save_bank(): # Use a local name
     logging.info("Saving current bank to %s", args.output_file)


### PR DESCRIPTION
I added previous the ability for the bank to dump its in progress results when sent a termination signal, however, a  term signal can be sent for a number of reason, including by condor. The output is not exactly a checkpoint file and our workflow certainly can't handle it like that. In that case, we really should be using a failure-mode exit code in these cases, otherwise, condor can think the job in fact completed, when in reality it was sent a termination signal (say by out of memory killer) and in fact did not finish. 
