### PR TITLE
Fix the workflow option to plan now but submit later

### DIFF
--- a/.github/workflows/search-splitable-workflow.yml
+++ b/.github/workflows/search-splitable-workflow.yml
@@ -53,6 +53,7 @@ jobs:
         bash -e examples/search/gen.sh
         cp *.gwf output/
         cd output
+        ./start
         python ../examples/search/check_job.py
         find submitdir/work/ -type f -name '*.tar.gz' -delete
     - name: store log files

--- a/.github/workflows/search-workflow.yml
+++ b/.github/workflows/search-workflow.yml
@@ -52,6 +52,7 @@ jobs:
         bash -e examples/search/gen.sh
         cp *.gwf output/
         cd output
+        ./start
         python ../examples/search/check_job.py
         find submitdir/work/ -type f -name '*.tar.gz' -delete
     - name: store log files

--- a/examples/search/gen.sh
+++ b/examples/search/gen.sh
@@ -6,7 +6,3 @@ pycbc_make_offline_search_workflow \
 --output-dir output \
 --config-files analysis.ini plotting.ini executables.ini injections_minimal.ini \
 --config-overrides results_page:output-path:$(pwd)/html
-
-cd output
-./start
-cd ..

--- a/examples/search/gen.sh
+++ b/examples/search/gen.sh
@@ -5,5 +5,8 @@ pycbc_make_offline_search_workflow \
 --workflow-name gw \
 --output-dir output \
 --config-files analysis.ini plotting.ini executables.ini injections_minimal.ini \
---config-overrides results_page:output-path:$(pwd)/html \
---submit-now
+--config-overrides results_page:output-path:$(pwd)/html
+
+cd output
+./start
+cd ..

--- a/examples/search/gen.sh
+++ b/examples/search/gen.sh
@@ -5,4 +5,5 @@ pycbc_make_offline_search_workflow \
 --workflow-name gw \
 --output-dir output \
 --config-files analysis.ini plotting.ini executables.ini injections_minimal.ini \
---config-overrides results_page:output-path:$(pwd)/html
+--config-overrides results_page:output-path:$(pwd)/html \
+--plan-now

--- a/examples/search/master.sh
+++ b/examples/search/master.sh
@@ -8,4 +8,5 @@ bash -e gen.sh
 
 cp *.gwf output
 cd output
+./start
 python ../check_job.py

--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -873,6 +873,7 @@ class Workflow(pegasus_workflow.Workflow):
         super(Workflow, self).save(filename=filename,
                                    output_map_path=output_map_path,
                                    submit_now=self.args.submit_now,
+                                   plan_now=self.args.plan_now,
                                    root=root)
 
     def save_config(self, fname, output_dir, cp=None):
@@ -2331,6 +2332,11 @@ def add_workflow_settings_cli(parser, include_subdax_opts=False):
     wfgrp.add_argument("--cache-file", default=None,
                        help="Path to input file containing list of files to "
                             "be reused (the 'input_map' file)")
+    wfgrp.add_argument("--plan-now", default=False, action='store_true',
+                       help="If given, workflow will immediately be planned "
+                            "on completion of workflow generation but not "
+                            "submitted to the condor pool. A start script "
+                            "will be created to submit to condor.")
     wfgrp.add_argument("--submit-now", default=False, action='store_true',
                        help="If given, workflow will immediately be submitted "
                             "on completion of workflow generation")

--- a/pycbc/workflow/pegasus_workflow.py
+++ b/pycbc/workflow/pegasus_workflow.py
@@ -594,9 +594,9 @@ class Workflow(object):
         for wf in self.sub_workflows:
             wf.traverse_workflow_io()
 
-    def save(self, filename=None, submit_now=False,
+    def save(self, filename=None, submit_now=False, plan_now=False,
              output_map_path=None, root=True):
-        """ Write this workflow to DAX file
+        """ Write this workflow to DAX file and plan/submit it if necessary
         """
         if filename is None:
             filename = self.filename
@@ -641,7 +641,8 @@ class Workflow(object):
         os.chdir(self.out_dir)
         self._adag.write(filename)
         if not self.in_workflow:
-            self.plan_and_submit(submit_now=submit_now)
+            if submit_now or plan_now:
+                self.plan_and_submit(submit_now=submit_now)
         os.chdir(olddir)
 
     def plan_and_submit(self, submit_now=True):

--- a/pycbc/workflow/pegasus_workflow.py
+++ b/pycbc/workflow/pegasus_workflow.py
@@ -594,7 +594,7 @@ class Workflow(object):
         for wf in self.sub_workflows:
             wf.traverse_workflow_io()
 
-    def save(self, filename=None, submit_now=False, plan_now=False,
+    def save(self, filename=None, submit_now=False,
              output_map_path=None, root=True):
         """ Write this workflow to DAX file
         """
@@ -641,30 +641,7 @@ class Workflow(object):
         os.chdir(self.out_dir)
         self._adag.write(filename)
         if not self.in_workflow:
-            if submit_now or plan_now:
-                self.plan_and_submit(submit_now=submit_now)
-            else:
-                with open('additional_planner_args.dat', 'w') as f:
-                    stage_site_str = self.staging_site_str
-                    exec_sites = self.exec_sites_str
-                    # We should add an option to add additional
-                    # pegasus properties (through the config files?) here.
-                    prop_file = os.path.join(PEGASUS_FILE_DIRECTORY,
-                                            'pegasus-properties.conf')
-                    f.write('--conf {} '.format(prop_file))
-                    if self.cache_file is not None:
-                        f.write('--cache {} '.format(self.cache_file))
-
-                    f.write('--output-sites local ')
-                    f.write('--sites {} '.format(exec_sites))
-                    f.write('--staging-site {} '.format(stage_site_str))
-                    f.write('--cluster label,horizontal ')
-                    f.write('--cleanup inplace ')
-                    f.write('--relative-dir work ')
-                    # --dir is not being set here because it might be easier to
-                    # set this in submit_dax still?
-                    f.write('-q ')
-                    f.write('--dax {}'.format(filename))
+            self.plan_and_submit(submit_now=submit_now)
         os.chdir(olddir)
 
     def plan_and_submit(self, submit_now=True):


### PR DESCRIPTION
#5294 describes a bug where we cannot plan, but not submit, workflows following a recent cleanup. I think this is what is needed to fix it.

I edited one of the test workflows (run in the CI) to use this option.

## Standard information about the request

This is a: bug fix,

This change affects: the workflow module (but only to fix a broken path not currently in use)

This change changes: hopefully nothing

This change: has appropriate unit tests, follows style guidelines (See e.g. [PEP8](https://peps.python.org/pep-0008/)), has been proposed using the [contribution guidelines](https://github.com/gwastro/pycbc/blob/master/CONTRIBUTING.md)

## Motivation

#5294 needs fixing.

## Contents

We change the logic a bit in pegasus_workflow to remove the old block that `pycbc_submit_dax` used and ensure that the workflow is always planned if it is not a subworkflow.

## Links to any issues or associated PRs

Fixes #5294 

## Testing performed

The CI will test this

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
