### PR TITLE
Run `pip list` after building LVK venv

### DIFF
--- a/tools/docker_build_dist.sh
+++ b/tools/docker_build_dist.sh
@@ -77,6 +77,9 @@ if [ "x${PYCBC_CONTAINER}" == "xpycbc_rhel_virtualenv" ]; then
   echo -e "\\n>> [`date`] Running basic tests"
   pytest
 
+  echo -e "\\n>> [`date`] Running pip list"
+  pip list
+
   cat << EOF >> $VIRTUAL_ENV/bin/activate
 
 


### PR DESCRIPTION
Show the output of `pip list` when building the LVK virtualenv. This is useful to see how the dependencies are getting upgraded with respect to the previous release.

## Standard information about the request

This change affects the LVK virtualenv.

This change affects logging output only.

## Motivation

When making a new minor release for a production LVK release branch, it can be useful to check if any of the dependencies will be upgraded with respect to the previous release. For example, we want to be sure that Numpy will not have a major version upgrade as a result of a minor fix on the PyCBC side.

## Contents

Simply run `pip list` together with the unit tests of the LVK virtualenv being created. This can then be copy-pasted and diff'ed against a `pip list` ran from the current virtualenv.

## Links to any issues or associated PRs

None.

## Testing performed

Not needed.

## Additional notes

None.

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
