### PR TITLE
Fix bug in `pycbc_optimal_snr`

### DIFF
--- a/bin/pycbc_optimal_snr
+++ b/bin/pycbc_optimal_snr
@@ -175,7 +175,7 @@ if __name__ == '__main__':
 
     if opts.ifos is not None:
         detectors = opts.ifos
-        if opts.snr_columns is not None:
+        if opts.snr_columns:
             parser.error("Can't use both --ifos and --snr-columns !")
         opts.snr_columns = {i: 'optimal_snr_' + i for i in opts.ifos}
     else:


### PR DESCRIPTION
Fixes a long-standing bug in `pycbc_optimal_snr`'s option parsing logic.

## Standard information about the request

This is a bug fix.

This change affects the offline search, PyGRB.

## Motivation

#5362 highlighted a bug in the way `pycbc_optimal_snr` validates its CLI arguments. It turns out that `args.snr_columns` can never be None, as it is a DictWithDefaultReturn instance even when `--snr-columns` is not given. The bug only happens when using the `--ifos` option, which apparently never happened before #5362!

## Contents

Switch from using `if args.snr_columns is not None` to just `if args.snr_columns`.

## Links to any issues or associated PRs

Followup of #5362.

## Testing performed

I wrote a short Python script to remind myself how MultiDetOptionAction works. Relying on the CI for the actual tests.

## Additional notes

None (😎)

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
