### PR TITLE
Adding Newtonian chirp time and  time-frequency track for for TaylorF2Ecc 

### DIFF
--- a/pycbc/conversions.py
+++ b/pycbc/conversions.py
@@ -215,7 +215,7 @@ def mchirp_from_mass1_mass2(mass1, mass2):
     """Returns the chirp mass from mass1 and mass2."""
     return eta_from_mass1_mass2(mass1, mass2)**(3./5) * (mass1 + mass2)
 
-def Emchirp_from_mass1_mass2_eccentricity(mass1, mass2, eccentricity, method='SPA_Phase'):
+def Emchirp_from_mass1_mass2_eccentricity(mass1, mass2, eccentricity, method='spa_phase'):
     """Returns the effective eccentric chirp mass from mass1, mass2 and eccentricity
 
     Parameters
@@ -225,14 +225,14 @@ def Emchirp_from_mass1_mass2_eccentricity(mass1, mass2, eccentricity, method='SP
     mass2 : float or array
         Mass of the secondary object
     eccentricity : float or array
-        Eccentricity of the orbit (For "Fit" method, eccentricity must be defined at 10 Hz.
-        For "SPA_Phase" method, eccentricity can be defined at any frequency, usually the start
+        Eccentricity of the orbit (For "fit" method, eccentricity must be defined at 10 Hz.
+        For "spa_phase" method, eccentricity can be defined at any frequency, usually the start
         frequency of the waveform.)
     method : str, optiona
-        Method to use for the calculation ("SPA_Phase", "Fit").
+        Method to use for the calculation ("spa_phase", "fit").
         See `Emchirp_from_mchirp_eccentricity` for details.
     """
-    allowed_methods = ("SPA_Phase", "Fit")
+    allowed_methods = ("spa_phase", "fit")
     if method not in allowed_methods:
         raise ValueError("method must be one of {}".format(allowed_methods))
     mchirp = mchirp_from_mass1_mass2(mass1, mass2)
@@ -704,10 +704,10 @@ def mchirp_from_Emchirp_ecc(Emchirp, eccentricity, method="SPA_Phase"):
         Effective eccentric chirp mass of the system
     eccentricity : float or array
         Eccentricity of the system
-    method : {"SPA_Phase", "Fit"},
-         Method to use for calculation (default is "SPA_Phase")
+    method : {"spa_phase", "fit"},
+         Method to use for calculation (default is "spa_phase")
 
-        "SPA_Phase":
+        "spa_phase":
             Inverse of the effective eccentric mchirp parameter from
             Eq. 1.1 of https://arxiv.org/abs/2108.05861. Eccentricity
             can be defined at any frequency, usually start frequency
@@ -716,13 +716,13 @@ def mchirp_from_Emchirp_ecc(Emchirp, eccentricity, method="SPA_Phase"):
             The SPA phase only contain dominat (2,2) mode contribution with no
             higher eccentric harmonics.
 
-        "Fit":
+        "fit":
             Inverse of the effective eccentric mchirp parameter derived from
             fitting to time-frequency track. The fitting formula is given in
             Eq. 8 of https://arxiv.org/abs/2107.14736. Eccentricity must be
             defined at the dominant (2,2) mode GW frequency of 10 Hz.
     """
-    allowed_methods = ("SPA_Phase", "Fit")
+    allowed_methods = ("spa_phase", "fit")
 
     if method not in allowed_methods:
         raise ValueError("method must be one of {}".format(allowed_methods))
@@ -731,10 +731,10 @@ def mchirp_from_Emchirp_ecc(Emchirp, eccentricity, method="SPA_Phase"):
 
     e2 = eccentricity * eccentricity
 
-    if method == "SPA_Phase":
+    if method == "spa_phase":
         m = Emchirp * ( 1 - 157/24 * e2 )**(3/5)
 
-    elif method == "Fit":
+    elif method == "fit":
         # Constants from Table 1 of https://arxiv.org/abs/2107.14736
         xi = 0.06110974175360381
         delta = -0.4193723077257345
@@ -2212,6 +2212,6 @@ __all__ = ['eccmchirp_from_mchirp_eccentricity',
            'remnant_mass_from_mass1_mass2_cartesian_spin_eos',
            'lambda1_from_delta_lambda_tilde_lambda_tilde',
            'lambda2_from_delta_lambda_tilde_lambda_tilde',
-           'delta_lambda_tilde', 'hypertriangle', 
+           'delta_lambda_tilde', 'hypertriangle',
            'Emchirp_from_mass1_mass2_eccentricity'
           ]

--- a/pycbc/conversions.py
+++ b/pycbc/conversions.py
@@ -215,6 +215,14 @@ def mchirp_from_mass1_mass2(mass1, mass2):
     """Returns the chirp mass from mass1 and mass2."""
     return eta_from_mass1_mass2(mass1, mass2)**(3./5) * (mass1 + mass2)
 
+def mchirp_eccentric_from_mass1_mass2_eccentricity(mass1, mass2, eccentricity):
+    """Returns the eccentric chirp mass from mass1, mass2 and eccentricity
+
+    The definition is based on Eq. 1.1, Favata et al., Phy. Rev. D, 105, 023003 (2022)
+    """
+    mchirp = mchirp_from_mass1_mass2(mass1, mass2)
+    mchirp_eccentric = mchirp / ( 1 - 157./24 * eccentricity * eccentricity )**(3./5)
+    return mchirp_eccentric
 
 def eccmchirp_from_mass1_mass2_eccentricity(mass1, mass2, eccentricity, method='spa_phase'):
     """Returns the effective eccentric chirp mass from mass1, mass2 and eccentricity

--- a/pycbc/conversions.py
+++ b/pycbc/conversions.py
@@ -162,34 +162,6 @@ def hypertriangle(*params, bounds=(0, 1)):
         out_params = [out_params[i][0] for i in range(K)]
     return out_params
 
-def solve_root(f, a, b, tol=1e-6, max_iter=100):
-    """Simple bisection root solver."""
-    fa = f(a)
-    fb = f(b)
-
-    if fa * fb > 0:
-        raise ValueError(f"Root not bracketed: f({a})={fa}, f({b})={fb}")
-
-    if abs(fa) < tol: return a
-    if abs(fb) < tol: return b
-
-    for _ in range(max_iter):
-        c = (a + b) / 2
-        fc = f(c)
-
-        if abs(fc) < tol or (b - a) / 2 < tol:
-            return c
-
-        if fa * fc < 0:
-            b = c
-            fb = fc
-        else:
-            a = c
-            fa = fc
-
-    return (a + b) / 2
-
-
 #
 # =============================================================================
 #
@@ -686,66 +658,59 @@ def mchirp_from_eccmchirp_eccentricity(eccmchirp, eccentricity, method="spa_phas
 
     return formatreturn(m, input_is_array)
 
-def _mchirp_from_ecc_mchirp_ecc(ecc_mchirp, ecc):
+def mchirp_from_Emchirp_ecc(Emchirp, ecc):
+    """ The inverse of Emchirp_from_mchirp_ecc.
+    Returns the chirp mass given the eccentric chirp mass and eccentricity.
+    The eccentricity must be defined at 10 Hz.
     """
-    Inverse function to get mchirp from ecc_mchirp and ecc.
-    Solves ecc_mchirp_from_mchirp_ecc(mchirp, ecc) - ecc_mchirp = 0
-    """
-    def target(mchirp):
-        return ecc_mchirp_from_mchirp_ecc(mchirp, ecc) - ecc_mchirp
+    Emchirp, ecc, input_is_array = ensurearray(Emchirp, ecc)
 
-    # Search strategy:
-    # We know mchirp ~ ecc_mchirp.
-    # We try to bracket the root starting from this guess.
+    # Constants from Table 1 of https://arxiv.org/pdf/2107.14736
+    xi = 0.06110974175360381
+    delta = -0.4193723077257345
+    Xi_beta = 0.00801015132110059
+    Delta_beta = -2.14807199936756e-5
+    kappa_beta = 1.12702400406416e-8
+    zeta_beta = -1.9753003183066e-12
+    Xi_gamma = 0.024204222771565382
+    Delta_gamma = -6.261945897154536e-6
+    kappa_gamma = 1.1175104924576945e-8
+    zeta_gamma = -3.681726165703978e-12
 
-    guess = ecc_mchirp
-    # Initial bracket width factor
-    factor = 0.2
+    e2 = ecc**2
+    e4 = e2**2
+    e6 = e4 * e2
 
-    # Try finding a bracket
-    lower = guess * (1 - factor)
-    upper = guess * (1 + factor)
+    # Use Newton's method to solve the equation for mchirp
+    # Initial guess using the quadratic approximation
+    A = xi * e2
+    B = 1 + delta * e2
+    C = -Emchirp
+    m = numpy.where(A > 0, (-B + numpy.sqrt(B**2 - 4*A*C)) / (2*A), Emchirp)
 
-    # Limit max iterations for bracket expansion
-    max_iter = 10
+    for _ in range(5):
+        m2 = m**2
+        m3 = m2 * m
+        m4 = m2**2
+        m5 = m4 * m
+        m6 = m3**2
+        m7 = m6 * m
+        m8 = m4**2
 
-    try:
-        f_lower = target(lower)
-        f_upper = target(upper)
+        alpha = xi * m + delta
+        beta = Xi_beta * m2 + Delta_beta * m4 + kappa_beta * m6 + zeta_beta * m8
+        gamma = Xi_gamma * m2 + Delta_gamma * m4 + kappa_gamma * m6 + zeta_gamma * m8
 
-        # Expand if signs are the same
-        for _ in range(max_iter):
-            if f_lower * f_upper < 0:
-                break
+        f = m * (1 + alpha * e2 + beta * e4 + gamma * e6) - Emchirp
 
-            if abs(f_lower) < abs(f_upper):
-                # Root is likely lower
-                lower /= 1.5
-                f_lower = target(lower)
-            else:
-                # Root is likely higher
-                upper *= 1.5
-                f_upper = target(upper)
+        d_alpha = xi
+        d_beta = 2 * Xi_beta * m + 4 * Delta_beta * m3 + 6 * kappa_beta * m5 + 8 * zeta_beta * m7
+        d_gamma = 2 * Xi_gamma * m + 4 * Delta_gamma * m3 + 6 * kappa_gamma * m5 + 8 * zeta_gamma * m7
 
-            # Safety checks for physical range (roughly 0 to 100 for this approx)
-            if upper > 100:
-                upper = 100
-                f_upper = target(upper)
-                if f_lower * f_upper > 0:
-                     # If still same sign at 100, we might be out of validity range
-                     # or function turns over.
-                     break
+        df = (1 + alpha * e2 + beta * e4 + gamma * e6) + m * (d_alpha * e2 + d_beta * e4 + d_gamma * e6)
+        m = m - f / df
 
-            if lower < 0.1:
-                lower = 0.1
-                f_lower = target(lower)
-
-        return solve_root(target, lower, upper)
-    except Exception:
-        return numpy.nan
-
-mchirp_from_ecc_mchirp_ecc = numpy.vectorize(_mchirp_from_ecc_mchirp_ecc)
-
+    return formatreturn(m, input_is_array)
 def lambda_tilde(mass1, mass2, lambda1, lambda2):
     """ The effective lambda parameter
 

--- a/pycbc/conversions.py
+++ b/pycbc/conversions.py
@@ -215,7 +215,8 @@ def mchirp_from_mass1_mass2(mass1, mass2):
     """Returns the chirp mass from mass1 and mass2."""
     return eta_from_mass1_mass2(mass1, mass2)**(3./5) * (mass1 + mass2)
 
-def Emchirp_from_mass1_mass2_eccentricity(mass1, mass2, eccentricity, method='spa_phase'):
+
+def eccmchirp_from_mass1_mass2_eccentricity(mass1, mass2, eccentricity, method='spa_phase'):
     """Returns the effective eccentric chirp mass from mass1, mass2 and eccentricity
 
     Parameters
@@ -230,13 +231,13 @@ def Emchirp_from_mass1_mass2_eccentricity(mass1, mass2, eccentricity, method='sp
         frequency of the waveform.)
     method : str, optiona
         Method to use for the calculation ("spa_phase", "fit").
-        See `Emchirp_from_mchirp_eccentricity` for details.
+        See `eccmchirp_from_mchirp_eccentricity` for details.
     """
     allowed_methods = ("spa_phase", "fit")
     if method not in allowed_methods:
         raise ValueError("method must be one of {}".format(allowed_methods))
     mchirp = mchirp_from_mass1_mass2(mass1, mass2)
-    mchirp_eccentric = Emchirp_from_mchirp_eccentricity(mchirp, eccentricity, method=method)
+    mchirp_eccentric = eccmchirp_from_mchirp_eccentricity(mchirp, eccentricity, method=method)
     return mchirp_eccentric
 
 def eccmchirp_from_mass1_mass2_eccentricity(mass1, mass2, eccentricity, method='spa_phase'):
@@ -700,7 +701,7 @@ def mchirp_from_Emchirp_ecc(Emchirp, eccentricity, method="SPA_Phase"):
 
     Parameters
     ----------
-    Emchirp : float or array
+    eccmchirp : float or array
         Effective eccentric chirp mass of the system
     eccentricity : float or array
         Eccentricity of the system
@@ -727,12 +728,12 @@ def mchirp_from_Emchirp_ecc(Emchirp, eccentricity, method="SPA_Phase"):
     if method not in allowed_methods:
         raise ValueError("method must be one of {}".format(allowed_methods))
 
-    Emchirp, eccentricity, input_is_array = ensurearray(Emchirp, eccentricity)
+    eccmchirp, eccentricity, input_is_array = ensurearray(eccmchirp, eccentricity)
 
     e2 = eccentricity * eccentricity
 
     if method == "spa_phase":
-        m = Emchirp * ( 1 - 157/24 * e2 )**(3/5)
+        m = eccmchirp * ( 1 - 157/24 * e2 )**(3/5)
 
     elif method == "fit":
         # Constants from Table 1 of https://arxiv.org/abs/2107.14736
@@ -751,8 +752,8 @@ def mchirp_from_Emchirp_ecc(Emchirp, eccentricity, method="SPA_Phase"):
         # Initial guess using the quadratic approximation
         A = xi * e2
         B = 1 + delta * e2
-        C = - Emchirp
-        m = numpy.where(A > 0, (-B + numpy.sqrt(B**2 - 4*A*C)) / (2*A), Emchirp)
+        C = - eccmchirp
+        m = numpy.where(A > 0, (-B + numpy.sqrt(B**2 - 4*A*C)) / (2*A), eccmchirp)
 
         for _ in range(5):
             m2 = m * m
@@ -2212,6 +2213,5 @@ __all__ = ['eccmchirp_from_mchirp_eccentricity',
            'remnant_mass_from_mass1_mass2_cartesian_spin_eos',
            'lambda1_from_delta_lambda_tilde_lambda_tilde',
            'lambda2_from_delta_lambda_tilde_lambda_tilde',
-           'delta_lambda_tilde', 'hypertriangle',
-           'Emchirp_from_mass1_mass2_eccentricity'
+           'delta_lambda_tilde', 'hypertriangle'
           ]

--- a/pycbc/conversions.py
+++ b/pycbc/conversions.py
@@ -162,6 +162,34 @@ def hypertriangle(*params, bounds=(0, 1)):
         out_params = [out_params[i][0] for i in range(K)]
     return out_params
 
+def solve_root(f, a, b, tol=1e-6, max_iter=100):
+    """Simple bisection root solver."""
+    fa = f(a)
+    fb = f(b)
+
+    if fa * fb > 0:
+        raise ValueError(f"Root not bracketed: f({a})={fa}, f({b})={fb}")
+
+    if abs(fa) < tol: return a
+    if abs(fb) < tol: return b
+
+    for _ in range(max_iter):
+        c = (a + b) / 2
+        fc = f(c)
+
+        if abs(fc) < tol or (b - a) / 2 < tol:
+            return c
+
+        if fa * fc < 0:
+            b = c
+            fb = fc
+        else:
+            a = c
+            fa = fc
+
+    return (a + b) / 2
+
+
 #
 # =============================================================================
 #
@@ -657,6 +685,66 @@ def mchirp_from_eccmchirp_eccentricity(eccmchirp, eccentricity, method="spa_phas
             m = m - f / df
 
     return formatreturn(m, input_is_array)
+
+def _mchirp_from_ecc_mchirp_ecc(ecc_mchirp, ecc):
+    """
+    Inverse function to get mchirp from ecc_mchirp and ecc.
+    Solves ecc_mchirp_from_mchirp_ecc(mchirp, ecc) - ecc_mchirp = 0
+    """
+    def target(mchirp):
+        return ecc_mchirp_from_mchirp_ecc(mchirp, ecc) - ecc_mchirp
+
+    # Search strategy:
+    # We know mchirp ~ ecc_mchirp.
+    # We try to bracket the root starting from this guess.
+
+    guess = ecc_mchirp
+    # Initial bracket width factor
+    factor = 0.2
+
+    # Try finding a bracket
+    lower = guess * (1 - factor)
+    upper = guess * (1 + factor)
+
+    # Limit max iterations for bracket expansion
+    max_iter = 10
+
+    try:
+        f_lower = target(lower)
+        f_upper = target(upper)
+
+        # Expand if signs are the same
+        for _ in range(max_iter):
+            if f_lower * f_upper < 0:
+                break
+
+            if abs(f_lower) < abs(f_upper):
+                # Root is likely lower
+                lower /= 1.5
+                f_lower = target(lower)
+            else:
+                # Root is likely higher
+                upper *= 1.5
+                f_upper = target(upper)
+
+            # Safety checks for physical range (roughly 0 to 100 for this approx)
+            if upper > 100:
+                upper = 100
+                f_upper = target(upper)
+                if f_lower * f_upper > 0:
+                     # If still same sign at 100, we might be out of validity range
+                     # or function turns over.
+                     break
+
+            if lower < 0.1:
+                lower = 0.1
+                f_lower = target(lower)
+
+        return solve_root(target, lower, upper)
+    except Exception:
+        return numpy.nan
+
+mchirp_from_ecc_mchirp_ecc = numpy.vectorize(_mchirp_from_ecc_mchirp_ecc)
 
 def lambda_tilde(mass1, mass2, lambda1, lambda2):
     """ The effective lambda parameter

--- a/pycbc/conversions.py
+++ b/pycbc/conversions.py
@@ -215,13 +215,28 @@ def mchirp_from_mass1_mass2(mass1, mass2):
     """Returns the chirp mass from mass1 and mass2."""
     return eta_from_mass1_mass2(mass1, mass2)**(3./5) * (mass1 + mass2)
 
-def mchirp_eccentric_from_mass1_mass2_eccentricity(mass1, mass2, eccentricity):
-    """Returns the eccentric chirp mass from mass1, mass2 and eccentricity
+def Emchirp_from_mass1_mass2_eccentricity(mass1, mass2, eccentricity, method='SPA_Phase'):
+    """Returns the effective eccentric chirp mass from mass1, mass2 and eccentricity
 
-    The definition is based on Eq. 1.1, Favata et al., Phy. Rev. D, 105, 023003 (2022)
+    Parameters
+    ----------
+    mass1 : float or array
+        Mass of the primary object
+    mass2 : float or array
+        Mass of the secondary object
+    eccentricity : float or array
+        Eccentricity of the orbit (For "Fit" method, eccentricity must be defined at 10 Hz.
+        For "SPA_Phase" method, eccentricity can be defined at any frequency, usually the start
+        frequency of the waveform.)
+    method : str, optiona
+        Method to use for the calculation ("SPA_Phase", "Fit").
+        See `Emchirp_from_mchirp_eccentricity` for details.
     """
+    allowed_methods = ("SPA_Phase", "Fit")
+    if method not in allowed_methods:
+        raise ValueError("method must be one of {}".format(allowed_methods))
     mchirp = mchirp_from_mass1_mass2(mass1, mass2)
-    mchirp_eccentric = mchirp / ( 1 - 157./24 * eccentricity * eccentricity )**(3./5)
+    mchirp_eccentric = Emchirp_from_mchirp_eccentricity(mchirp, eccentricity, method=method)
     return mchirp_eccentric
 
 def eccmchirp_from_mass1_mass2_eccentricity(mass1, mass2, eccentricity, method='spa_phase'):
@@ -666,59 +681,103 @@ def mchirp_from_eccmchirp_eccentricity(eccmchirp, eccentricity, method="spa_phas
 
     return formatreturn(m, input_is_array)
 
-def mchirp_from_Emchirp_ecc(Emchirp, ecc):
-    """ The inverse of Emchirp_from_mchirp_ecc.
-    Returns the chirp mass given the eccentric chirp mass and eccentricity.
-    The eccentricity must be defined at 10 Hz.
+        # Calculate coefficients (Eq 9)
+        alpha = xi * mchirp + delta
+
+        beta = mchirp2 * ( Xi_beta  +
+                           mchirp2 * ( Delta_beta  +
+                           mchirp2 * ( kappa_beta  +
+                           mchirp2 * zeta_beta )))
+        gamma = mchirp2 * ( Xi_gamma +
+                            mchirp2 * ( Delta_gamma +
+                            mchirp2 * ( kappa_gamma  +
+                            mchirp2 * zeta_gamma )))
+        Emchirp = mchirp * (1 + e2 * (alpha + e2 * (beta + e2 * gamma)))
+    return formatreturn(Emchirp, input_is_array)
+
+def mchirp_from_Emchirp_ecc(Emchirp, eccentricity, method="SPA_Phase"):
+    """Return the chirp mass from the effective eccentric chirp mass and eccentricity.
+
+    Parameters
+    ----------
+    Emchirp : float or array
+        Effective eccentric chirp mass of the system
+    eccentricity : float or array
+        Eccentricity of the system
+    method : {"SPA_Phase", "Fit"},
+         Method to use for calculation (default is "SPA_Phase")
+
+        "SPA_Phase":
+            Inverse of the effective eccentric mchirp parameter from
+            Eq. 1.1 of https://arxiv.org/abs/2108.05861. Eccentricity
+            can be defined at any frequency, usually start frequency
+            of the waveform. The eccentriciy is defiend as the time component
+            of eccentricity from the quasi-Keplerian parametrization of the orbit.
+            The SPA phase only contain dominat (2,2) mode contribution with no
+            higher eccentric harmonics.
+
+        "Fit":
+            Inverse of the effective eccentric mchirp parameter derived from
+            fitting to time-frequency track. The fitting formula is given in
+            Eq. 8 of https://arxiv.org/abs/2107.14736. Eccentricity must be
+            defined at the dominant (2,2) mode GW frequency of 10 Hz.
     """
-    Emchirp, ecc, input_is_array = ensurearray(Emchirp, ecc)
+    allowed_methods = ("SPA_Phase", "Fit")
 
-    # Constants from Table 1 of https://arxiv.org/pdf/2107.14736
-    xi = 0.06110974175360381
-    delta = -0.4193723077257345
-    Xi_beta = 0.00801015132110059
-    Delta_beta = -2.14807199936756e-5
-    kappa_beta = 1.12702400406416e-8
-    zeta_beta = -1.9753003183066e-12
-    Xi_gamma = 0.024204222771565382
-    Delta_gamma = -6.261945897154536e-6
-    kappa_gamma = 1.1175104924576945e-8
-    zeta_gamma = -3.681726165703978e-12
+    if method not in allowed_methods:
+        raise ValueError("method must be one of {}".format(allowed_methods))
 
-    e2 = ecc**2
-    e4 = e2**2
-    e6 = e4 * e2
+    Emchirp, eccentricity, input_is_array = ensurearray(Emchirp, eccentricity)
 
-    # Use Newton's method to solve the equation for mchirp
-    # Initial guess using the quadratic approximation
-    A = xi * e2
-    B = 1 + delta * e2
-    C = -Emchirp
-    m = numpy.where(A > 0, (-B + numpy.sqrt(B**2 - 4*A*C)) / (2*A), Emchirp)
+    e2 = eccentricity * eccentricity
 
-    for _ in range(5):
-        m2 = m**2
-        m3 = m2 * m
-        m4 = m2**2
-        m5 = m4 * m
-        m6 = m3**2
-        m7 = m6 * m
-        m8 = m4**2
+    if method == "SPA_Phase":
+        m = Emchirp * ( 1 - 157/24 * e2 )**(3/5)
 
-        alpha = xi * m + delta
-        beta = Xi_beta * m2 + Delta_beta * m4 + kappa_beta * m6 + zeta_beta * m8
-        gamma = Xi_gamma * m2 + Delta_gamma * m4 + kappa_gamma * m6 + zeta_gamma * m8
+    elif method == "Fit":
+        # Constants from Table 1 of https://arxiv.org/abs/2107.14736
+        xi = 0.06110974175360381
+        delta = -0.4193723077257345
+        Xi_beta = 0.00801015132110059
+        Delta_beta = -2.14807199936756e-5
+        kappa_beta = 1.12702400406416e-8
+        zeta_beta = -1.9753003183066e-12
+        Xi_gamma = 0.024204222771565382
+        Delta_gamma = -6.261945897154536e-6
+        kappa_gamma = 1.1175104924576945e-8
+        zeta_gamma = -3.681726165703978e-12
 
-        f = m * (1 + alpha * e2 + beta * e4 + gamma * e6) - Emchirp
+        # Use Newton's method to solve the equation for mchirp
+        # Initial guess using the quadratic approximation
+        A = xi * e2
+        B = 1 + delta * e2
+        C = - Emchirp
+        m = numpy.where(A > 0, (-B + numpy.sqrt(B**2 - 4*A*C)) / (2*A), Emchirp)
 
-        d_alpha = xi
-        d_beta = 2 * Xi_beta * m + 4 * Delta_beta * m3 + 6 * kappa_beta * m5 + 8 * zeta_beta * m7
-        d_gamma = 2 * Xi_gamma * m + 4 * Delta_gamma * m3 + 6 * kappa_gamma * m5 + 8 * zeta_gamma * m7
-
-        df = (1 + alpha * e2 + beta * e4 + gamma * e6) + m * (d_alpha * e2 + d_beta * e4 + d_gamma * e6)
-        m = m - f / df
+        for _ in range(5):
+            m2 = m * m
+            alpha = xi * m + delta
+            beta = m2 * ( Xi_beta + m2 * ( Delta_beta +
+                                    m2 * ( kappa_beta +
+                                    m2 * zeta_beta )))
+            gamma = m2 * ( Xi_gamma +
+                                m2 * ( Delta_gamma +
+                                m2 * ( kappa_gamma  +
+                                m2 * zeta_gamma )))
+            f = m * (1 + e2 * (alpha + e2 * ( beta + e2 *gamma ))) - Emchirp
+            d_alpha = xi
+            d_beta = m * ( 2 * Xi_beta + m2 * ( 4 * Delta_beta +
+                                                m2 *( 6 * kappa_beta +
+                                                m2 * 8 * zeta_beta )))
+            d_gamma = m * ( 2 * Xi_gamma + m2 * ( 4 * Delta_gamma +
+                                           m2 * ( 6 * kappa_gamma +
+                                           m2 * 8 * zeta_gamma )))
+            df = (1 + e2 * (alpha  + e2 * ( beta + e2 * gamma )) +
+                 m * e2 * (d_alpha + e2 * ( d_beta + e2 * d_gamma )))
+            m = m - f / df
 
     return formatreturn(m, input_is_array)
+
 def lambda_tilde(mass1, mass2, lambda1, lambda2):
     """ The effective lambda parameter
 

--- a/pycbc/conversions.py
+++ b/pycbc/conversions.py
@@ -2212,5 +2212,6 @@ __all__ = ['eccmchirp_from_mchirp_eccentricity',
            'remnant_mass_from_mass1_mass2_cartesian_spin_eos',
            'lambda1_from_delta_lambda_tilde_lambda_tilde',
            'lambda2_from_delta_lambda_tilde_lambda_tilde',
-           'delta_lambda_tilde', 'hypertriangle'
+           'delta_lambda_tilde', 'hypertriangle', 
+           'Emchirp_from_mass1_mass2_eccentricity'
           ]

--- a/pycbc/conversions.py
+++ b/pycbc/conversions.py
@@ -240,30 +240,6 @@ def eccmchirp_from_mass1_mass2_eccentricity(mass1, mass2, eccentricity, method='
     mchirp_eccentric = eccmchirp_from_mchirp_eccentricity(mchirp, eccentricity, method=method)
     return mchirp_eccentric
 
-def eccmchirp_from_mass1_mass2_eccentricity(mass1, mass2, eccentricity, method='spa_phase'):
-    """Returns the effective eccentric chirp mass from mass1, mass2 and eccentricity
-
-    Parameters
-    ----------
-    mass1 : float or array
-        Mass of the primary object
-    mass2 : float or array
-        Mass of the secondary object
-    eccentricity : float or array
-        Eccentricity of the orbit (For "fit" method, eccentricity must be defined at 10 Hz.
-        For "spa_phase" method, eccentricity can be defined at any frequency, usually the start
-        frequency of the waveform.)
-    method : str, optiona
-        Method to use for the calculation ("spa_phase", "fit").
-        See `eccmchirp_from_mchirp_eccentricity` for details.
-    """
-    allowed_methods = ("spa_phase", "fit")
-    if method not in allowed_methods:
-        raise ValueError("method must be one of {}".format(allowed_methods))
-    mchirp = mchirp_from_mass1_mass2(mass1, mass2)
-    mchirp_eccentric = eccmchirp_from_mchirp_eccentricity(mchirp, eccentricity, method=method)
-    return mchirp_eccentric
-
 
 def mass1_from_mtotal_q(mtotal, q):
     """Returns a component mass from the given total mass and mass ratio.
@@ -600,103 +576,6 @@ def eccmchirp_from_mchirp_eccentricity(mchirp, eccentricity, method="spa_phase")
     return formatreturn(Emchirp, input_is_array)
 
 def mchirp_from_eccmchirp_eccentricity(eccmchirp, eccentricity, method="spa_phase"):
-    """Return the chirp mass from the effective eccentric chirp mass and eccentricity.
-
-    Parameters
-    ----------
-    eccmchirp : float or array
-        Effective eccentric chirp mass of the system
-    eccentricity : float or array
-        Eccentricity of the system
-    method : {"spa_phase", "fit"},
-         Method to use for calculation (default is "spa_phase")
-
-        "spa_phase":
-            Inverse of the effective eccentric mchirp parameter from
-            Eq. 1.1 of https://arxiv.org/abs/2108.05861. Eccentricity
-            can be defined at any frequency, usually start frequency
-            of the waveform. The eccentriciy is defiend as the time component
-            of eccentricity from the quasi-Keplerian parametrization of the orbit.
-            The SPA phase only contain dominat (2,2) mode contribution with no
-            higher eccentric harmonics.
-
-        "fit":
-            Inverse of the effective eccentric mchirp parameter derived from
-            fitting to time-frequency track. The fitting formula is given in
-            Eq. 8 of https://arxiv.org/abs/2107.14736. Eccentricity must be
-            defined at the dominant (2,2) mode GW frequency of 10 Hz.
-    """
-    allowed_methods = ("spa_phase", "fit")
-
-    if method not in allowed_methods:
-        raise ValueError("method must be one of {}".format(allowed_methods))
-
-    eccmchirp, eccentricity, input_is_array = ensurearray(eccmchirp, eccentricity)
-
-    e2 = eccentricity * eccentricity
-
-    if method == "spa_phase":
-        m = eccmchirp * ( 1 - 157/24 * e2 )**(3/5)
-
-    elif method == "fit":
-        # Constants from Table 1 of https://arxiv.org/abs/2107.14736
-        xi = 0.06110974175360381
-        delta = -0.4193723077257345
-        Xi_beta = 0.00801015132110059
-        Delta_beta = -2.14807199936756e-5
-        kappa_beta = 1.12702400406416e-8
-        zeta_beta = -1.9753003183066e-12
-        Xi_gamma = 0.024204222771565382
-        Delta_gamma = -6.261945897154536e-6
-        kappa_gamma = 1.1175104924576945e-8
-        zeta_gamma = -3.681726165703978e-12
-
-        # Use Newton's method to solve the equation for mchirp
-        # Initial guess using the quadratic approximation
-        A = xi * e2
-        B = 1 + delta * e2
-        C = - eccmchirp
-        m = numpy.where(A > 0, (-B + numpy.sqrt(B**2 - 4*A*C)) / (2*A), eccmchirp)
-
-        for _ in range(5):
-            m2 = m * m
-            alpha = xi * m + delta
-            beta = m2 * ( Xi_beta + m2 * ( Delta_beta +
-                                    m2 * ( kappa_beta +
-                                    m2 * zeta_beta )))
-            gamma = m2 * ( Xi_gamma +
-                                m2 * ( Delta_gamma +
-                                m2 * ( kappa_gamma  +
-                                m2 * zeta_gamma )))
-            f = m * (1 + e2 * (alpha + e2 * ( beta + e2 *gamma ))) - Emchirp
-            d_alpha = xi
-            d_beta = m * ( 2 * Xi_beta + m2 * ( 4 * Delta_beta +
-                                                m2 *( 6 * kappa_beta +
-                                                m2 * 8 * zeta_beta )))
-            d_gamma = m * ( 2 * Xi_gamma + m2 * ( 4 * Delta_gamma +
-                                           m2 * ( 6 * kappa_gamma +
-                                           m2 * 8 * zeta_gamma )))
-            df = (1 + e2 * (alpha  + e2 * ( beta + e2 * gamma )) +
-                 m * e2 * (d_alpha + e2 * ( d_beta + e2 * d_gamma )))
-            m = m - f / df
-
-    return formatreturn(m, input_is_array)
-
-        # Calculate coefficients (Eq 9)
-        alpha = xi * mchirp + delta
-
-        beta = mchirp2 * ( Xi_beta  +
-                           mchirp2 * ( Delta_beta  +
-                           mchirp2 * ( kappa_beta  +
-                           mchirp2 * zeta_beta )))
-        gamma = mchirp2 * ( Xi_gamma +
-                            mchirp2 * ( Delta_gamma +
-                            mchirp2 * ( kappa_gamma  +
-                            mchirp2 * zeta_gamma )))
-        Emchirp = mchirp * (1 + e2 * (alpha + e2 * (beta + e2 * gamma)))
-    return formatreturn(Emchirp, input_is_array)
-
-def mchirp_from_Emchirp_ecc(Emchirp, eccentricity, method="SPA_Phase"):
     """Return the chirp mass from the effective eccentric chirp mass and eccentricity.
 
     Parameters

--- a/pycbc/pnutils.py
+++ b/pycbc/pnutils.py
@@ -29,10 +29,10 @@ between quantities.
 import logging
 import numpy
 
+import lal
 from scipy.optimize import bisect, brentq, minimize
 
 from pycbc import conversions, libutils
-from pycbc.constants import MSUN_SI, PI, MTSUN_SI, PC_SI
 
 logger = logging.getLogger('pycbc.pnutils')
 
@@ -190,10 +190,10 @@ def get_beta_sigma_from_aligned_spins(eta, spin1z, spin2z):
     return beta, sigma, gamma
 
 def solar_mass_to_kg(solar_masses):
-    return solar_masses * MSUN_SI
+    return solar_masses * lal.MSUN_SI
 
 def parsecs_to_meters(distance):
-    return distance * PC_SI
+    return distance * lal.PC_SI
 
 def megaparsecs_to_meters(distance):
     return parsecs_to_meters(distance) * 1e6
@@ -258,7 +258,7 @@ def f_LightRing(M):
     f : float or numpy.array
         Frequency in Hz
     """
-    return 1.0 / (3.0**(1.5) * PI * M * MTSUN_SI)
+    return 1.0 / (3.0**(1.5) * lal.PI * M * lal.MTSUN_SI)
 
 def f_ERD(M):
     """
@@ -277,7 +277,7 @@ def f_ERD(M):
     f : float or numpy.array
         Frequency in Hz
     """
-    return 1.07 * 0.5326 / (2*PI * 0.955 * M * MTSUN_SI)
+    return 1.07 * 0.5326 / (2*lal.PI * 0.955 * M * lal.MTSUN_SI)
 
 def f_FRD(m1, m2):
     """
@@ -301,7 +301,7 @@ def f_FRD(m1, m2):
     m_total, eta = mass1_mass2_to_mtotal_eta(m1, m2)
     tmp = ( (1. - 0.63*(1. - 3.4641016*eta + 2.9*eta**2)**(0.3)) /
     (1. - 0.057191*eta - 0.498*eta**2) )
-    return tmp / (2.*PI * m_total*MTSUN_SI)
+    return tmp / (2.*lal.PI * m_total*lal.MTSUN_SI)
 
 def f_LRD(m1, m2):
     """
@@ -536,26 +536,26 @@ def _get_imr_duration(m1, m2, s1z, s2z, f_low, approximant="SEOBNRv4"):
     if approximant == "SEOBNRv2":
         chi = lalsim.SimIMRPhenomBComputeChi(m1, m2, s1z, s2z)
         time_length = lalsim.SimIMRSEOBNRv2ChirpTimeSingleSpin(
-                                m1 * MSUN_SI, m2 * MSUN_SI, chi, f_low)
+                                m1 * lal.MSUN_SI, m2 * lal.MSUN_SI, chi, f_low)
     elif approximant == "IMRPhenomXAS":
         time_length = lalsim.SimIMRPhenomXASDuration(
-                           m1 * MSUN_SI, m2 * MSUN_SI, s1z, s2z, f_low)
+                           m1 * lal.MSUN_SI, m2 * lal.MSUN_SI, s1z, s2z, f_low)
     elif approximant == "IMRPhenomD":
         time_length = lalsim.SimIMRPhenomDChirpTime(
-                           m1 * MSUN_SI, m2 * MSUN_SI, s1z, s2z, f_low)
+                           m1 * lal.MSUN_SI, m2 * lal.MSUN_SI, s1z, s2z, f_low)
     elif approximant in ["SEOBNRv4", "SEOBNRv4_ROM"]:
         # NB the LALSim function has f_low as first argument
         time_length = lalsim.SimIMRSEOBNRv4ROMTimeOfFrequency(
-                           f_low, m1 * MSUN_SI, m2 * MSUN_SI, s1z, s2z)
+                           f_low, m1 * lal.MSUN_SI, m2 * lal.MSUN_SI, s1z, s2z)
     elif approximant in ["SEOBNRv5", "SEOBNRv5_ROM"]:
         time_length = lalsim.SimIMRSEOBNRv5ROMTimeOfFrequency(
-                           f_low, m1 * MSUN_SI, m2 * MSUN_SI, s1z, s2z)
+                           f_low, m1 * lal.MSUN_SI, m2 * lal.MSUN_SI, s1z, s2z)
     elif approximant in ["SPAtmplt", "TaylorF2"]:
         chi = lalsim.SimInspiralTaylorF2ReducedSpinComputeChi(
             m1, m2, s1z, s2z
         )
         time_length = lalsim.SimInspiralTaylorF2ReducedSpinChirpTime(
-            f_low, m1 * MSUN_SI, m2 * MSUN_SI, chi, -1
+            f_low, m1 * lal.MSUN_SI, m2 * lal.MSUN_SI, chi, -1
         )
     else:
         raise RuntimeError("I can't calculate a duration for %s" % approximant)
@@ -566,7 +566,7 @@ def _get_imr_duration(m1, m2, s1z, s2z, f_low, approximant="SEOBNRv4"):
 get_imr_duration = numpy.vectorize(_get_imr_duration)
 
 def get_inspiral_tf(tc, mass1, mass2, spin1, spin2, f_low, n_points=100,
-        pn_2order=7, approximant='TaylorF2'):
+        pn_2order=7, eccentricity=None, approximant='TaylorF2'):
     """Compute the time-frequency evolution of an inspiral signal.
 
     Return a tuple of time and frequency vectors tracking the evolution of an
@@ -580,6 +580,8 @@ def get_inspiral_tf(tc, mass1, mass2, spin1, spin2, f_low, n_points=100,
     params.mass2 = mass2
     params.spin1z = spin1
     params.spin2z = spin2
+    if eccentricity is not None:
+        params.eccentricity = eccentricity
     try:
         approximant = eval(approximant, {'__builtins__': None},
                            dict(params=params))
@@ -630,6 +632,15 @@ def get_inspiral_tf(tc, mass1, mass2, spin1, spin2, f_low, n_points=100,
                 float(spin2),
                 f
             )
+    elif approximant=='TaylorF2Ecc':
+        f_high = f_SchwarzISCO(mass1 + mass2)
+        from pycbc.waveform.spa_tmplt import eccentric_chirp_time
+        def tof_func(f):
+            return eccentric_chirp_time(
+                    float(mass1),
+                    float(mass2),
+                    float(eccentricity),
+                    f)
     else:
         raise ValueError(f'Approximant {approximant} not supported')
     track_f = numpy.logspace(numpy.log10(f_low), numpy.log10(f_high), n_points)
@@ -637,6 +648,132 @@ def get_inspiral_tf(tc, mass1, mass2, spin1, spin2, f_low, n_points=100,
     track_t = tc - tof_func_vec(track_f)
     return (track_t, track_f)
 
+# Functions adapted from https://github.com/gmorras/pyEFPE/blob/main/pyEFPE/waveform/functions.py
+#      Original function --->  Functions here
+#      tLO_func          --->  eccentric_newtonian_time
+#      F_tLO_series      --->  _eccentric_enhancement_function
+#      F_tLO_series_at_0 --->  _enhancement_function_low
+#      F_tLO_series_at_1 --->  _enhancement_function_high
+
+def eccentric_newtonian_time(m1, m2, eccentricity, f_low):
+    """Returns the Newtonian eccentric-binary time to coalescence.
+
+    This computes the leading-order inspiral time for an eccentric compact
+    binary using Eq. (119) of Morras et al., arXiv:2502.03929. The
+    eccentricity correction is evaluated with
+    :func:`_eccentric_enhancement_function`.
+
+    Parameters
+    ----------
+    m1, m2 : float or array_like
+        Component masses in solar masses. Inputs must be broadcastable to a
+        common shape.
+    eccentricity : float or array_like
+        Orbital eccentricity defined at ``f_low``.
+    f_low : float or array_like
+        Starting gravitational-wave frequency in Hz.
+
+    Returns
+    -------
+    float or numpy.ndarray
+        Newtonian time to coalescence in seconds. Scalar inputs return a
+        scalar; array-like inputs return a NumPy array.
+    """
+    m1, m2, eccentricity, f_low = numpy.broadcast_arrays(
+        numpy.asarray(m1, dtype=float),
+        numpy.asarray(m2, dtype=float),
+        numpy.asarray(eccentricity, dtype=float),
+        numpy.asarray(f_low, dtype=float),
+    )
+
+    M = m1 + m2
+    ecc_sq = eccentricity * eccentricity
+    one_minus_ecc_sq = 1 - ecc_sq
+    one_minus_ecc_sq_sqrt = numpy.sqrt(one_minus_ecc_sq)
+    velocity = frequency_to_velocity(f_low, M)
+    # weighted_velocity is the `y` variable in Morras et al., arXiv:2502.03929
+    weighted_velocity = velocity / one_minus_ecc_sq_sqrt
+    eta = conversions.eta_from_mass1_mass2(m1, m2)
+    M_sec = M * lal.MTSUN_SI
+    t_N = (5 / (256 * one_minus_ecc_sq_sqrt * eta) * M_sec *
+            (weighted_velocity**-8) * _eccentric_enhancement_function(ecc_sq))
+    return t_N.item() if t_N.ndim == 0 else t_N
+
+
+def _eccentric_enhancement_function(eccentricity_sq):
+
+    eccentricity_sq_arr = numpy.asarray(eccentricity_sq, dtype=float)
+
+    # Value of eccentricity^2 to decide which enhancement function to be used,
+    # based on Morras et al., arXiv:2502.03929
+    eccentricity_sq_switch = 0.4
+
+    #if eccentricity^2 <= 0.4  use series expansion from `_enhancement_function_low`,
+    #                otherwise use series expansion from `_enhancement_function_high`
+
+    if eccentricity_sq_arr.ndim == 0:
+        eccentricity_sq_scalar = float(eccentricity_sq_arr)
+        if eccentricity_sq_scalar <= eccentricity_sq_switch:
+            return _enhancement_function_low(eccentricity_sq_scalar)
+        else:
+            return _enhancement_function_high(eccentricity_sq_scalar)
+
+    else:
+        F = numpy.empty_like(eccentricity_sq_arr, dtype=float)
+        low_ecc_index = eccentricity_sq_arr <= eccentricity_sq_switch
+        high_ecc_index = numpy.logical_not(low_ecc_index)
+        if numpy.any(low_ecc_index):
+            F[low_ecc_index] = _enhancement_function_low(eccentricity_sq_arr[low_ecc_index])
+        if numpy.any(high_ecc_index):
+            F[high_ecc_index] = _enhancement_function_high(eccentricity_sq_arr[high_ecc_index])
+        return F
+
+#coefficeints of polynomials for `_enhancement_function_low`
+_LOW_ECC_COEFFS = numpy.array([
+    1.000000000000000, -0.1511627906976744, 0.2656836084021005, 0.007463780007501875,
+    0.08800790590714085, 0.03153077124184580, 0.04185392210761341, 0.02761371124737777,
+    0.02642686119635599, 0.02145414169943131, 0.01926563742403364, 0.01677217450181226,
+    0.01503898450331388, 0.01347003088516929, 0.01220348405026613, 0.01110346195121149,
+    0.01016749330223870, 0.009352447459389354, 0.008642114232972108, 0.008016709107501086,
+    0.007463457161231162, 0.006970902964332086, 0.006530253812462707, 0.006134111124121483,
+    0.005776451398258840, 0.005452229768143720, 0.005157232928828976, 0.004887901117379935,
+    0.004641215172072290, 0.004414596725230578, 0.004205833180162198, 0.004013015784562471,
+    0.003834490347048246, 0.003668816871424952, 0.003514736646109113, 0.003371145103099870,
+    0.003237069368178693, 0.003111649567641214, 0.002994123194217794, 0.002883811964918853,
+    0.002780110725151045, 0.002682478039498533, 0.002590428180410570, 0.002503524280447905,
+    0.002421372457429333, 0.002343616756405161, 0.002269934780185545, 0.002200033902499887,
+    0.002133647975961232, 0.002070534461714599, 0.002010471919657125,
+])
+
+#coefficeints of polynomials for `_enhancement_function_high`
+_HIGH_ECC_COEFFS = numpy.array([
+    0.40941176470588236, 0.02286320645905421, 0.008142925951557094, 0.004155878512401501,
+    0.0024847568765827364, 0.001633290511588348, 0.0011455395465032605, 0.000842577094447224,
+    0.0006427195446513564, 0.0005045715814217113, 0.00040544477831148924, 0.0003321116545345162,
+    0.0002764636962467965, 0.00023331895675436905, 0.0001992473575067662, 0.00017190919726595898,
+    0.00014966654751355843, 0.000131346469484909, 0.00011609207361015848, 0.00010326617525262309,
+    9.238740896587563e-05, 8.308691874613337e-05, 7.50784086790562e-05, 6.813705814151314e-05,
+    6.20844345948999e-05, 5.677753690123865e-05, 5.210072977646673e-05, 4.7959732146031274e-05,
+    4.427708468062032e-05, 4.0988696117937945e-05, 3.80411855904995e-05, 3.538981870077757e-05,
+    3.2996890965966614e-05, 3.083045152872919e-05, 2.886328796018351e-05, 2.707211306399751e-05,
+    2.543690918050699e-05, 2.3940396192787112e-05, 2.256759736012561e-05, 2.1305483020854193e-05,
+    2.014267666038337e-05, 1.906921121897629e-05, 1.8076326095558655e-05, 1.7156297290322297e-05,
+    1.6302294667351972e-05, 1.550826151746742e-05, 1.4768812541410176e-05, 1.407914711455732e-05,
+])
+
+def _enhancement_function_low(eccentricity_sq):
+    # Maclaurin seies of Eq. D6. Morras et al., arXiv:2502.03929
+    return numpy.polyval(numpy.flip(_LOW_ECC_COEFFS), eccentricity_sq)
+
+def _enhancement_function_high(eccentricity_sq):
+    # Series expansion of Eq. D7, Morras et al., arXiv:2502.03929
+    # around sqrt(1 - eccentricity^2) = 0
+    cns = _HIGH_ECC_COEFFS
+    pre_factor = (48/19)*((425/304)**(1181/2299))
+    u = 1 - eccentricity_sq
+    eccentric_factor = eccentricity_sq**(-24 / 19) * (1 + (121 / 304) * eccentricity_sq)**(-3480 / 2299)
+    eccentric_factor *= 1 - 1.4555165803216864*numpy.sqrt(u) + u*numpy.polyval(numpy.flip(cns),u)
+    return pre_factor * eccentric_factor
 
 ##############################This code was taken from Andy ###########
 
@@ -659,7 +796,7 @@ def _energy_coeffs(m1, m2, chi1, chi2):
     energy4 = -3.375 + (19*eta)/8. - pow(eta,2)/24.
     energy5 = 0.
     energy6 = -10.546875 - (155*pow(eta,2))/96. - (35*pow(eta,3))/5184. \
-                + eta*(59.80034722222222 - (205*pow(PI,2))/96.)
+                + eta*(59.80034722222222 - (205*pow(lal.PI,2))/96.)
 
     energy3 += (32*beta)/113. + (52*chisym*eta)/113.
 
@@ -718,12 +855,12 @@ def _dtdv_coeffs(m1, m2, chi1, chi2):
 
     dtdv0 = 1. # FIXME: Wrong but doesn't matter for now.
     dtdv2 = (1./336.) * (743. + 924.*eta)
-    dtdv3 = -4. * PI + beta
+    dtdv3 = -4. * lal.PI + beta
     dtdv4 = (3058673. + 5472432.*eta + 4353552.*eta*eta)/1016064. - sigma12 - sigmaqm
-    dtdv5 = (1./672.) * PI * (-7729. + 1092.*eta) + (146597.*beta/18984. + 42.*beta*eta/113. - 417307.*chisym*eta/18984. - 1389.*chisym*eta*eta/226.)
+    dtdv5 = (1./672.) * lal.PI * (-7729. + 1092.*eta) + (146597.*beta/18984. + 42.*beta*eta/113. - 417307.*chisym*eta/18984. - 1389.*chisym*eta*eta/226.)
     dtdv6 = 22.065 + 165.416*eta - 2.20067*eta*eta + 4.93152*eta*eta*eta
     dtdv6log = 1712./315.
-    dtdv7 = (PI/1016064.) * (-15419335. - 12718104.*eta + 4975824.*eta*eta)
+    dtdv7 = (lal.PI/1016064.) * (-15419335. - 12718104.*eta + 4975824.*eta*eta)
 
     return (dtdv0, dtdv2, dtdv3, dtdv4, dtdv5, dtdv6, dtdv6log, dtdv7)
 
@@ -788,7 +925,7 @@ def energy_coefficients(m1, m2, s1z=0, s2z=0, phase_order=-1, spin_order=-1):
         ecof[5] = 0
     if phase_order >= 6:
         ecof[6] = - 675.0/64.0 + ( 34445.0/576.0    \
-              - 205.0/96.0 * PI * PI ) * eta  \
+              - 205.0/96.0 * lal.PI * lal.PI ) * eta  \
               - (155.0/96.0) *eta * eta - 35.0/5184.0 * eta * eta
     # Spin terms
 
@@ -1074,7 +1211,7 @@ def jframe_to_l0frame(mass1, mass2, f_ref, phiref=0., thetajn=0., phijl=0.,
     inclination, spin1x, spin1y, spin1z, spin2x, spin2y, spin2z = \
         lalsim.SimInspiralTransformPrecessingNewInitialConditions(
             thetajn, phijl, spin1_polar, spin2_polar, spin12_deltaphi,
-            spin1_a, spin2_a, mass1*MSUN_SI, mass2*MSUN_SI, f_ref,
+            spin1_a, spin2_a, mass1*lal.MSUN_SI, mass2*lal.MSUN_SI, f_ref,
             phiref)
     out = {'inclination': inclination,
            'spin1x': spin1x,

--- a/pycbc/pnutils.py
+++ b/pycbc/pnutils.py
@@ -29,10 +29,10 @@ between quantities.
 import logging
 import numpy
 
-import lal
 from scipy.optimize import bisect, brentq, minimize
 
 from pycbc import conversions, libutils
+from pycbc.constants import MSUN_SI, PI, MTSUN_SI, PC_SI
 
 logger = logging.getLogger('pycbc.pnutils')
 
@@ -190,10 +190,10 @@ def get_beta_sigma_from_aligned_spins(eta, spin1z, spin2z):
     return beta, sigma, gamma
 
 def solar_mass_to_kg(solar_masses):
-    return solar_masses * lal.MSUN_SI
+    return solar_masses * MSUN_SI
 
 def parsecs_to_meters(distance):
-    return distance * lal.PC_SI
+    return distance * PC_SI
 
 def megaparsecs_to_meters(distance):
     return parsecs_to_meters(distance) * 1e6
@@ -258,7 +258,7 @@ def f_LightRing(M):
     f : float or numpy.array
         Frequency in Hz
     """
-    return 1.0 / (3.0**(1.5) * lal.PI * M * lal.MTSUN_SI)
+    return 1.0 / (3.0**(1.5) * PI * M * MTSUN_SI)
 
 def f_ERD(M):
     """
@@ -277,7 +277,7 @@ def f_ERD(M):
     f : float or numpy.array
         Frequency in Hz
     """
-    return 1.07 * 0.5326 / (2*lal.PI * 0.955 * M * lal.MTSUN_SI)
+    return 1.07 * 0.5326 / (2*PI * 0.955 * M * MTSUN_SI)
 
 def f_FRD(m1, m2):
     """
@@ -301,7 +301,7 @@ def f_FRD(m1, m2):
     m_total, eta = mass1_mass2_to_mtotal_eta(m1, m2)
     tmp = ( (1. - 0.63*(1. - 3.4641016*eta + 2.9*eta**2)**(0.3)) /
     (1. - 0.057191*eta - 0.498*eta**2) )
-    return tmp / (2.*lal.PI * m_total*lal.MTSUN_SI)
+    return tmp / (2.*PI * m_total*MTSUN_SI)
 
 def f_LRD(m1, m2):
     """
@@ -536,26 +536,26 @@ def _get_imr_duration(m1, m2, s1z, s2z, f_low, approximant="SEOBNRv4"):
     if approximant == "SEOBNRv2":
         chi = lalsim.SimIMRPhenomBComputeChi(m1, m2, s1z, s2z)
         time_length = lalsim.SimIMRSEOBNRv2ChirpTimeSingleSpin(
-                                m1 * lal.MSUN_SI, m2 * lal.MSUN_SI, chi, f_low)
+                                m1 * MSUN_SI, m2 * MSUN_SI, chi, f_low)
     elif approximant == "IMRPhenomXAS":
         time_length = lalsim.SimIMRPhenomXASDuration(
-                           m1 * lal.MSUN_SI, m2 * lal.MSUN_SI, s1z, s2z, f_low)
+                           m1 * MSUN_SI, m2 * MSUN_SI, s1z, s2z, f_low)
     elif approximant == "IMRPhenomD":
         time_length = lalsim.SimIMRPhenomDChirpTime(
-                           m1 * lal.MSUN_SI, m2 * lal.MSUN_SI, s1z, s2z, f_low)
+                           m1 * MSUN_SI, m2 * MSUN_SI, s1z, s2z, f_low)
     elif approximant in ["SEOBNRv4", "SEOBNRv4_ROM"]:
         # NB the LALSim function has f_low as first argument
         time_length = lalsim.SimIMRSEOBNRv4ROMTimeOfFrequency(
-                           f_low, m1 * lal.MSUN_SI, m2 * lal.MSUN_SI, s1z, s2z)
+                           f_low, m1 * MSUN_SI, m2 * MSUN_SI, s1z, s2z)
     elif approximant in ["SEOBNRv5", "SEOBNRv5_ROM"]:
         time_length = lalsim.SimIMRSEOBNRv5ROMTimeOfFrequency(
-                           f_low, m1 * lal.MSUN_SI, m2 * lal.MSUN_SI, s1z, s2z)
+                           f_low, m1 * MSUN_SI, m2 * MSUN_SI, s1z, s2z)
     elif approximant in ["SPAtmplt", "TaylorF2"]:
         chi = lalsim.SimInspiralTaylorF2ReducedSpinComputeChi(
             m1, m2, s1z, s2z
         )
         time_length = lalsim.SimInspiralTaylorF2ReducedSpinChirpTime(
-            f_low, m1 * lal.MSUN_SI, m2 * lal.MSUN_SI, chi, -1
+            f_low, m1 * MSUN_SI, m2 * MSUN_SI, chi, -1
         )
     else:
         raise RuntimeError("I can't calculate a duration for %s" % approximant)
@@ -694,7 +694,7 @@ def eccentric_newtonian_time(m1, m2, eccentricity, f_low):
     # weighted_velocity is the `y` variable in Morras et al., arXiv:2502.03929
     weighted_velocity = velocity / one_minus_ecc_sq_sqrt
     eta = conversions.eta_from_mass1_mass2(m1, m2)
-    M_sec = M * lal.MTSUN_SI
+    M_sec = M * MTSUN_SI
     t_N = (5 / (256 * one_minus_ecc_sq_sqrt * eta) * M_sec *
             (weighted_velocity**-8) * _eccentric_enhancement_function(ecc_sq))
     return t_N.item() if t_N.ndim == 0 else t_N
@@ -796,7 +796,7 @@ def _energy_coeffs(m1, m2, chi1, chi2):
     energy4 = -3.375 + (19*eta)/8. - pow(eta,2)/24.
     energy5 = 0.
     energy6 = -10.546875 - (155*pow(eta,2))/96. - (35*pow(eta,3))/5184. \
-                + eta*(59.80034722222222 - (205*pow(lal.PI,2))/96.)
+                + eta*(59.80034722222222 - (205*pow(PI,2))/96.)
 
     energy3 += (32*beta)/113. + (52*chisym*eta)/113.
 
@@ -855,12 +855,12 @@ def _dtdv_coeffs(m1, m2, chi1, chi2):
 
     dtdv0 = 1. # FIXME: Wrong but doesn't matter for now.
     dtdv2 = (1./336.) * (743. + 924.*eta)
-    dtdv3 = -4. * lal.PI + beta
+    dtdv3 = -4. * PI + beta
     dtdv4 = (3058673. + 5472432.*eta + 4353552.*eta*eta)/1016064. - sigma12 - sigmaqm
-    dtdv5 = (1./672.) * lal.PI * (-7729. + 1092.*eta) + (146597.*beta/18984. + 42.*beta*eta/113. - 417307.*chisym*eta/18984. - 1389.*chisym*eta*eta/226.)
+    dtdv5 = (1./672.) * PI * (-7729. + 1092.*eta) + (146597.*beta/18984. + 42.*beta*eta/113. - 417307.*chisym*eta/18984. - 1389.*chisym*eta*eta/226.)
     dtdv6 = 22.065 + 165.416*eta - 2.20067*eta*eta + 4.93152*eta*eta*eta
     dtdv6log = 1712./315.
-    dtdv7 = (lal.PI/1016064.) * (-15419335. - 12718104.*eta + 4975824.*eta*eta)
+    dtdv7 = (PI/1016064.) * (-15419335. - 12718104.*eta + 4975824.*eta*eta)
 
     return (dtdv0, dtdv2, dtdv3, dtdv4, dtdv5, dtdv6, dtdv6log, dtdv7)
 
@@ -925,7 +925,7 @@ def energy_coefficients(m1, m2, s1z=0, s2z=0, phase_order=-1, spin_order=-1):
         ecof[5] = 0
     if phase_order >= 6:
         ecof[6] = - 675.0/64.0 + ( 34445.0/576.0    \
-              - 205.0/96.0 * lal.PI * lal.PI ) * eta  \
+              - 205.0/96.0 * PI * PI ) * eta  \
               - (155.0/96.0) *eta * eta - 35.0/5184.0 * eta * eta
     # Spin terms
 
@@ -1211,7 +1211,7 @@ def jframe_to_l0frame(mass1, mass2, f_ref, phiref=0., thetajn=0., phijl=0.,
     inclination, spin1x, spin1y, spin1z, spin2x, spin2y, spin2z = \
         lalsim.SimInspiralTransformPrecessingNewInitialConditions(
             thetajn, phijl, spin1_polar, spin2_polar, spin12_deltaphi,
-            spin1_a, spin2_a, mass1*lal.MSUN_SI, mass2*lal.MSUN_SI, f_ref,
+            spin1_a, spin2_a, mass1*MSUN_SI, mass2*MSUN_SI, f_ref,
             phiref)
     out = {'inclination': inclination,
            'spin1x': spin1x,

--- a/pycbc/waveform/spa_tmplt.py
+++ b/pycbc/waveform/spa_tmplt.py
@@ -23,17 +23,12 @@
 """
 from math import sqrt, log
 import warnings
-import numpy
-
-import pycbc.pnutils
+import numpy, lal, pycbc.pnutils
 from pycbc.scheme import schemed
 from pycbc.types import FrequencySeries, Array, complex64, float32, zeros
 from pycbc.waveform.utils import ceilpow2
-from pycbc.constants import PI, GAMMA, MTSUN_SI, PC_SI, MRSUN_SI
-from pycbc.libutils import import_optional
 
-lal = import_optional('lal')
-lalsimulation = import_optional('lalsimulation')
+lalsimulation = pycbc.libutils.import_optional('lalsimulation')
 
 def findchirp_chirptime(m1, m2, fLower, porder):
     # variables used to compute chirp time
@@ -48,27 +43,27 @@ def findchirp_chirptime(m1, m2, fLower, porder):
         porder = 7
 
     if porder >= 7:
-        c7T = PI * (14809.0 * eta * eta / 378.0 - 75703.0 * eta / 756.0 - 15419335.0 / 127008.0)
+        c7T = lal.PI * (14809.0 * eta * eta / 378.0 - 75703.0 * eta / 756.0 - 15419335.0 / 127008.0)
 
     if porder >= 6:
-        c6T = GAMMA * 6848.0 / 105.0 - 10052469856691.0 / 23471078400.0 +\
-            PI * PI * 128.0 / 3.0 + \
-            eta * (3147553127.0 / 3048192.0 - PI * PI * 451.0 / 12.0) -\
+        c6T = lal.GAMMA * 6848.0 / 105.0 - 10052469856691.0 / 23471078400.0 +\
+            lal.PI * lal.PI * 128.0 / 3.0 + \
+            eta * (3147553127.0 / 3048192.0 - lal.PI * lal.PI * 451.0 / 12.0) -\
             eta * eta * 15211.0 / 1728.0 + eta * eta * eta * 25565.0 / 1296.0 +\
             eta * eta * eta * 25565.0 / 1296.0 + numpy.log(4.0) * 6848.0 / 105.0
         c6LogT = 6848.0 / 105.0
 
     if porder >= 5:
-        c5T = 13.0 * PI * eta / 3.0 - 7729.0 * PI / 252.0
+        c5T = 13.0 * lal.PI * eta / 3.0 - 7729.0 * lal.PI / 252.0
 
     if porder >= 4:
         c4T = 3058673.0 / 508032.0 + eta * (5429.0 / 504.0 + eta * 617.0 / 72.0)
-        c3T = -32.0 * PI / 5.0
+        c3T = -32.0 * lal.PI / 5.0
         c2T = 743.0 / 252.0 + eta * 11.0 / 3.0
-        c0T = 5.0 * m * MTSUN_SI / (256.0 * eta)
+        c0T = 5.0 * m * lal.MTSUN_SI / (256.0 * eta)
 
     # This is the PN parameter v evaluated at the lower freq. cutoff
-    xT = pow (PI * m * MTSUN_SI * fLower, 1.0 / 3.0)
+    xT = pow (lal.PI * m * lal.MTSUN_SI * fLower, 1.0 / 3.0)
     x2T = xT * xT
     x3T = xT * x2T
     x4T = x2T * x2T
@@ -104,6 +99,23 @@ def spa_length_in_time(**kwds):
     return findchirp_chirptime(m1, m2, flow, porder)
 
 
+def eccentric_chirp_time(m1, m2, e0, fLower):
+    return pycbc.pnutils.eccentric_newtonian_time(m1, m2, e0, fLower)
+
+
+def eccentric_spa_length_in_time(**kwds):
+    """
+    Returns the length in time of the template,
+    based on masses, eccentricity and low-frequency
+    cut-off (eccentricity is defined at the low-frequency
+    cut-off).
+    """
+    m1 = kwds['mass1']
+    m2 = kwds['mass2']
+    e0 = kwds['eccentricity']
+    f_low = kwds['f_lower']
+    return eccentric_chirp_time(m1, m2, e0, f_low)
+
 def spa_amplitude_factor(**kwds):
     m1 = kwds['mass1']
     m2 = kwds['mass2']
@@ -115,10 +127,10 @@ def spa_amplitude_factor(**kwds):
 
     M = m1 + m2
 
-    m_sec = M * MTSUN_SI
-    piM = PI * m_sec
+    m_sec = M * lal.MTSUN_SI
+    piM = lal.PI * m_sec
 
-    amp0 = 4. * m1 * m2 / (1e6 * PC_SI) * MRSUN_SI * MTSUN_SI * sqrt(PI / 12.)
+    amp0 = 4. * m1 * m2 / (1e6 * lal.PC_SI) * lal.MRSUN_SI * lal.MTSUN_SI * sqrt(lal.PI / 12.)
 
     fac = numpy.sqrt(-dETaN / FTaN) * amp0 * (piM ** (-7./6.))
     return -fac
@@ -219,7 +231,7 @@ def spa_tmplt(**kwds):
     pfl5 = phasing.vlogv[5] / pfaN
     pfl6 = phasing.vlogv[6] / pfaN
 
-    piM = PI * (mass1 + mass2) * MTSUN_SI
+    piM = lal.PI * (mass1 + mass2) * lal.MTSUN_SI
 
     if 'sample_points' not in kwds:
         f_lower = kwds['f_lower']

--- a/pycbc/waveform/spa_tmplt.py
+++ b/pycbc/waveform/spa_tmplt.py
@@ -210,7 +210,7 @@ def spa_tmplt(**kwds):
 
     amp_factor = spa_amplitude_factor(mass1=mass1, mass2=mass2) / distance
 
-    lal_pars = CreateDict()
+    lal_pars = lal.CreateDict()
     if phase_order != -1:
         lalsimulation.SimInspiralWaveformParamsInsertPNPhaseOrder(
             lal_pars, phase_order)

--- a/pycbc/waveform/spa_tmplt.py
+++ b/pycbc/waveform/spa_tmplt.py
@@ -23,12 +23,17 @@
 """
 from math import sqrt, log
 import warnings
-import numpy, lal, pycbc.pnutils
+import numpy
+
+import pycbc.pnutils
 from pycbc.scheme import schemed
 from pycbc.types import FrequencySeries, Array, complex64, float32, zeros
 from pycbc.waveform.utils import ceilpow2
+from pycbc.constants import PI, GAMMA, MTSUN_SI, PC_SI, MRSUN_SI
+from pycbc.libutils import import_optional
 
-lalsimulation = pycbc.libutils.import_optional('lalsimulation')
+lal = import_optional('lal')
+lalsimulation = import_optional('lalsimulation')
 
 def findchirp_chirptime(m1, m2, fLower, porder):
     # variables used to compute chirp time
@@ -43,27 +48,27 @@ def findchirp_chirptime(m1, m2, fLower, porder):
         porder = 7
 
     if porder >= 7:
-        c7T = lal.PI * (14809.0 * eta * eta / 378.0 - 75703.0 * eta / 756.0 - 15419335.0 / 127008.0)
+        c7T = PI * (14809.0 * eta * eta / 378.0 - 75703.0 * eta / 756.0 - 15419335.0 / 127008.0)
 
     if porder >= 6:
-        c6T = lal.GAMMA * 6848.0 / 105.0 - 10052469856691.0 / 23471078400.0 +\
-            lal.PI * lal.PI * 128.0 / 3.0 + \
-            eta * (3147553127.0 / 3048192.0 - lal.PI * lal.PI * 451.0 / 12.0) -\
+        c6T = GAMMA * 6848.0 / 105.0 - 10052469856691.0 / 23471078400.0 +\
+            PI * PI * 128.0 / 3.0 + \
+            eta * (3147553127.0 / 3048192.0 - PI * PI * 451.0 / 12.0) -\
             eta * eta * 15211.0 / 1728.0 + eta * eta * eta * 25565.0 / 1296.0 +\
             eta * eta * eta * 25565.0 / 1296.0 + numpy.log(4.0) * 6848.0 / 105.0
         c6LogT = 6848.0 / 105.0
 
     if porder >= 5:
-        c5T = 13.0 * lal.PI * eta / 3.0 - 7729.0 * lal.PI / 252.0
+        c5T = 13.0 * PI * eta / 3.0 - 7729.0 * PI / 252.0
 
     if porder >= 4:
         c4T = 3058673.0 / 508032.0 + eta * (5429.0 / 504.0 + eta * 617.0 / 72.0)
-        c3T = -32.0 * lal.PI / 5.0
+        c3T = -32.0 * PI / 5.0
         c2T = 743.0 / 252.0 + eta * 11.0 / 3.0
-        c0T = 5.0 * m * lal.MTSUN_SI / (256.0 * eta)
+        c0T = 5.0 * m * MTSUN_SI / (256.0 * eta)
 
     # This is the PN parameter v evaluated at the lower freq. cutoff
-    xT = pow (lal.PI * m * lal.MTSUN_SI * fLower, 1.0 / 3.0)
+    xT = pow (PI * m * MTSUN_SI * fLower, 1.0 / 3.0)
     x2T = xT * xT
     x3T = xT * x2T
     x4T = x2T * x2T
@@ -127,10 +132,10 @@ def spa_amplitude_factor(**kwds):
 
     M = m1 + m2
 
-    m_sec = M * lal.MTSUN_SI
-    piM = lal.PI * m_sec
+    m_sec = M * MTSUN_SI
+    piM = PI * m_sec
 
-    amp0 = 4. * m1 * m2 / (1e6 * lal.PC_SI) * lal.MRSUN_SI * lal.MTSUN_SI * sqrt(lal.PI / 12.)
+    amp0 = 4. * m1 * m2 / (1e6 * PC_SI) * MRSUN_SI * MTSUN_SI * sqrt(PI / 12.)
 
     fac = numpy.sqrt(-dETaN / FTaN) * amp0 * (piM ** (-7./6.))
     return -fac
@@ -205,7 +210,7 @@ def spa_tmplt(**kwds):
 
     amp_factor = spa_amplitude_factor(mass1=mass1, mass2=mass2) / distance
 
-    lal_pars = lal.CreateDict()
+    lal_pars = CreateDict()
     if phase_order != -1:
         lalsimulation.SimInspiralWaveformParamsInsertPNPhaseOrder(
             lal_pars, phase_order)
@@ -231,7 +236,7 @@ def spa_tmplt(**kwds):
     pfl5 = phasing.vlogv[5] / pfaN
     pfl6 = phasing.vlogv[6] / pfaN
 
-    piM = lal.PI * (mass1 + mass2) * lal.MTSUN_SI
+    piM = PI * (mass1 + mass2) * MTSUN_SI
 
     if 'sample_points' not in kwds:
         f_lower = kwds['f_lower']

--- a/pycbc/waveform/waveform.py
+++ b/pycbc/waveform/waveform.py
@@ -511,6 +511,7 @@ def get_fd_waveform_sequence(template=None, **kwds):
     template: object
         An object that has attached properties. This can be used to substitute
         for keyword arguments. A common example would be a row in an xml table.
+
     {params}
 
     Returns
@@ -547,6 +548,7 @@ def get_fd_det_waveform_sequence(template=None, **kwds):
     template: object
         An object that has attached properties. This can be used to substitute
         for keyword arguments. A common example would be a row in an xml table.
+
     {params}
 
     Returns
@@ -583,6 +585,7 @@ def get_td_waveform(template=None, **kwargs):
     template: object
         An object that has attached properties. This can be used to subsitute
         for keyword arguments. A common example would be a row in an xml table.
+
     {params}
 
     Returns
@@ -617,6 +620,7 @@ def get_fd_waveform(template=None, **kwargs):
     template: object
         An object that has attached properties. This can be used to substitute
         for keyword arguments. A common example would be a row in an xml table.
+
     {params}
 
     Returns
@@ -688,7 +692,7 @@ def get_fd_waveform_from_td(**params):
             full_duration = get_waveform_filter_length_in_time(**nparams)
             nparams['f_lower'] -= 1
 
-    if 'f_fref' not in nparams and 'f_lower' in nparams:
+    if 'f_ref' not in nparams and 'f_lower' in nparams:
         nparams['f_ref'] = nparams['f_lower']
 
     # We'll try to do the right thing and figure out what the frequency
@@ -717,7 +721,7 @@ def get_fd_waveform_from_td(**params):
 
     if not 'taper_method' in params:
         # apply the tapering, we will use a safety factor here to allow for
-        # somewhat innacurate duration difference estimation.
+        # somewhat inaccurate duration difference estimation.
         window = (full_duration - duration) * 0.8
         hp = wfutils.td_taper(hp, hp.start_time, hp.start_time + window)
         hc = wfutils.td_taper(hc, hc.start_time, hc.start_time + window)
@@ -743,6 +747,7 @@ def get_fd_det_waveform(template=None, **kwargs):
     template: object
         An object that has attached properties. This can be used to substitute
         for keyword arguments. An example would be a row in an xml table.
+
     {params}
 
     Returns

--- a/pycbc/waveform/waveform.py
+++ b/pycbc/waveform/waveform.py
@@ -27,7 +27,7 @@ waveforms.
 """
 
 import os
-import lal, numpy, copy
+import lal, numpy
 from pycbc.types import TimeSeries, FrequencySeries, zeros, Array
 from pycbc.types import real_same_precision_as, complex_same_precision_as
 import pycbc.scheme as _scheme
@@ -369,7 +369,7 @@ def get_obj_attrs(obj):
     """
     pr = {}
     if obj is not None:
-        if isinstance(obj, numpy.core.records.record):
+        if isinstance(obj, numpy.record):
             for name in obj.dtype.names:
                 pr[name] = getattr(obj, name)
         elif hasattr(obj, '__dict__') and obj.__dict__:
@@ -414,7 +414,14 @@ def parse_mode_array(input_params):
                 ma = str(int(ma))
             # if ma is a str convert to (int, int) (e.g., '22' -> (2, 2))
             if isinstance(ma, str):
-                l, m = ma
+                if len(ma) == 2: # format is "22", presumed m is positive
+                    l, m = ma
+                elif len(ma) == 3: # format is "2+2", "2-2", signed m
+                    l = ma[0]
+                    m = ma[1:]
+                else:
+                    raise ValueError(f"Unknown lm mode string format: {ma}")
+
                 ma = (int(l), int(m))
             mode_array[ii] = ma
         input_params['mode_array'] = mode_array
@@ -563,10 +570,10 @@ def get_fd_det_waveform_sequence(template=None, **kwds):
 
 get_fd_waveform_sequence.__doc__ = get_fd_waveform_sequence.__doc__.format(
     params=parameters.fd_waveform_sequence_params.docstr(prefix="    ",
-           include_label=False).lstrip(' '))
+           include_label=False))
 get_fd_det_waveform_sequence.__doc__ = get_fd_det_waveform_sequence.__doc__.format(
     params=parameters.fd_waveform_sequence_params.docstr(prefix="    ",
-           include_label=False).lstrip(' '))
+           include_label=False))
 
 def get_td_waveform(template=None, **kwargs):
     """Return the plus and cross polarizations of a time domain waveform.
@@ -600,7 +607,7 @@ def get_td_waveform(template=None, **kwargs):
 
 get_td_waveform.__doc__ = get_td_waveform.__doc__.format(
     params=parameters.td_waveform_params.docstr(prefix="    ",
-           include_label=False).lstrip(' '))
+           include_label=False))
 
 def get_fd_waveform(template=None, **kwargs):
     """Return a frequency domain gravitational waveform.
@@ -649,7 +656,7 @@ def get_fd_waveform(template=None, **kwargs):
 
 get_fd_waveform.__doc__ = get_fd_waveform.__doc__.format(
     params=parameters.fd_waveform_params.docstr(prefix="    ",
-           include_label=False).lstrip(' '))
+           include_label=False))
 
 def get_fd_waveform_from_td(**params):
     """ Return time domain version of fourier domain approximant.
@@ -670,17 +677,19 @@ def get_fd_waveform_from_td(**params):
     hc: pycbc.types.FrequencySeries
         Cross polarization time series
     """
-
-    # determine the duration to use
-    full_duration = duration = get_waveform_filter_length_in_time(**params)
     nparams = params.copy()
+    if not 'taper_method' in params:
+        # determine the duration to use for an automatic tapering choice.
+        # If taper method specified, assume they have set f_lower as they
+        # want exactly.
+        full_duration = duration = get_waveform_filter_length_in_time(**params)
 
-    while full_duration < duration * 1.5:
-        full_duration = get_waveform_filter_length_in_time(**nparams)
-        nparams['f_lower'] -= 1
+        while full_duration < duration * 1.5:
+            full_duration = get_waveform_filter_length_in_time(**nparams)
+            nparams['f_lower'] -= 1
 
-    if 'f_fref' not in nparams:
-        nparams['f_ref'] = params['f_lower']
+    if 'f_fref' not in nparams and 'f_lower' in nparams:
+        nparams['f_ref'] = nparams['f_lower']
 
     # We'll try to do the right thing and figure out what the frequency
     # end is. Otherwise, we'll just assume 2048 Hz.
@@ -706,11 +715,19 @@ def get_fd_waveform_from_td(**params):
     hp.resize(tsamples)
     hc.resize(tsamples)
 
-    # apply the tapering, we will use a safety factor here to allow for
-    # somewhat innacurate duration difference estimation.
-    window = (full_duration - duration) * 0.8
-    hp = wfutils.td_taper(hp, hp.start_time, hp.start_time + window)
-    hc = wfutils.td_taper(hc, hc.start_time, hc.start_time + window)
+    if not 'taper_method' in params:
+        # apply the tapering, we will use a safety factor here to allow for
+        # somewhat innacurate duration difference estimation.
+        window = (full_duration - duration) * 0.8
+        hp = wfutils.td_taper(hp, hp.start_time, hp.start_time + window)
+        hc = wfutils.td_taper(hc, hc.start_time, hc.start_time + window)
+    else:
+        hp = hp.taper_timeseries(location=params['taper'],
+                                 tapermethod=params['taper_method'],
+                                 taper_window=params['taper_window'])
+        hc = hc.taper_timeseries(location=params['taper'],
+                                 tapermethod=params['taper_method'],
+                                 taper_window=params['taper_window'])
 
     # avoid wraparound
     hp = hp.to_frequencyseries().cyclic_time_shift(hp.start_time)
@@ -748,7 +765,7 @@ def get_fd_det_waveform(template=None, **kwargs):
 
 get_fd_det_waveform.__doc__ = get_fd_det_waveform.__doc__.format(
     params=parameters.fd_waveform_params.docstr(prefix="    ",
-           include_label=False).lstrip(' '))
+           include_label=False))
 
 def _base_get_td_waveform_from_fd(template=None, rwrap=None, **params):
     """ The base function to calculate time domain version of fourier
@@ -881,7 +898,7 @@ def get_td_det_waveform_from_fd_det(template=None, rwrap=None, **params):
 get_td_det_waveform_from_fd_det.__doc__ = \
     get_td_det_waveform_from_fd_det.__doc__.format(
         params=parameters.td_waveform_params.docstr(prefix="    ",
-            include_label=False).lstrip(' '))
+            include_label=False))
 
 def get_interpolated_fd_waveform(dtype=numpy.complex64, return_hc=True,
                                  **params):
@@ -1155,7 +1172,7 @@ def td_fd_waveform_transform(approximant):
         # We can make a fd version of td approximants
         cpu_fd[approximant] = get_fd_waveform_from_td
 
-    if approximant in fd_apx:
+    if approximant in fd_apx and (approximant in _filter_time_lengths):
         # We can do interpolation for waveforms that have a time length
         apx_int = approximant + '_INTERP'
         cpu_fd[apx_int] = get_interpolated_fd_waveform
@@ -1166,7 +1183,7 @@ def td_fd_waveform_transform(approximant):
         # (ex. IMRPhenomXX)
         cpu_td[approximant] = get_td_waveform_from_fd
 
-for apx in copy.copy(_filter_time_lengths):
+for apx in list(_filter_time_lengths.keys()) + list(cpu_fd.keys()):
     td_fd_waveform_transform(apx)
 
 
@@ -1314,10 +1331,13 @@ def get_two_pol_waveform_filter(outplus, outcross, template, **kwargs):
         # taper the time series hp if required
         if 'taper' in input_params.keys() and \
                 input_params['taper'] is not None:
-            hp = wfutils.taper_timeseries(hp, input_params['taper'],
-                                          return_lal=False)
-            hc = wfutils.taper_timeseries(hc, input_params['taper'],
-                                          return_lal=False)
+            hp = hp.taper_timeseries(location=input_params['taper'],
+            tapermethod=input_params.get('taper_method', 'lal'),
+            taper_window=input_params.get('taper_window'), return_lal=False)
+            hc = hc.taper_timeseries(location=input_params['taper'],
+            tapermethod=input_params.get('taper_method', 'lal'),
+            taper_window=input_params.get('taper_window'), return_lal=False)
+
         # total duration of the waveform
         tmplt_length = len(hp) * hp.delta_t
         # for IMR templates the zero of time is at max amplitude (merger)

--- a/pycbc/waveform/waveform.py
+++ b/pycbc/waveform/waveform.py
@@ -27,7 +27,7 @@ waveforms.
 """
 
 import os
-import lal, numpy
+import lal, numpy, copy
 from pycbc.types import TimeSeries, FrequencySeries, zeros, Array
 from pycbc.types import real_same_precision_as, complex_same_precision_as
 import pycbc.scheme as _scheme
@@ -41,7 +41,7 @@ from pycbc.filter import interpolate_complex_frequency, resample_to_delta_t
 import pycbc
 from .spa_tmplt import spa_tmplt, spa_tmplt_norm, spa_tmplt_end, \
                       spa_tmplt_precondition, spa_amplitude_factor, \
-                      spa_length_in_time
+                      spa_length_in_time, eccentric_spa_length_in_time
 
 class NoWaveformError(Exception):
     """This should be raised if generating a waveform would just result in all
@@ -369,7 +369,7 @@ def get_obj_attrs(obj):
     """
     pr = {}
     if obj is not None:
-        if isinstance(obj, numpy.record):
+        if isinstance(obj, numpy.core.records.record):
             for name in obj.dtype.names:
                 pr[name] = getattr(obj, name)
         elif hasattr(obj, '__dict__') and obj.__dict__:
@@ -414,14 +414,7 @@ def parse_mode_array(input_params):
                 ma = str(int(ma))
             # if ma is a str convert to (int, int) (e.g., '22' -> (2, 2))
             if isinstance(ma, str):
-                if len(ma) == 2: # format is "22", presumed m is positive
-                    l, m = ma
-                elif len(ma) == 3: # format is "2+2", "2-2", signed m
-                    l = ma[0]
-                    m = ma[1:]
-                else:
-                    raise ValueError(f"Unknown lm mode string format: {ma}")
-
+                l, m = ma
                 ma = (int(l), int(m))
             mode_array[ii] = ma
         input_params['mode_array'] = mode_array
@@ -511,7 +504,6 @@ def get_fd_waveform_sequence(template=None, **kwds):
     template: object
         An object that has attached properties. This can be used to substitute
         for keyword arguments. A common example would be a row in an xml table.
-
     {params}
 
     Returns
@@ -548,7 +540,6 @@ def get_fd_det_waveform_sequence(template=None, **kwds):
     template: object
         An object that has attached properties. This can be used to substitute
         for keyword arguments. A common example would be a row in an xml table.
-
     {params}
 
     Returns
@@ -572,10 +563,10 @@ def get_fd_det_waveform_sequence(template=None, **kwds):
 
 get_fd_waveform_sequence.__doc__ = get_fd_waveform_sequence.__doc__.format(
     params=parameters.fd_waveform_sequence_params.docstr(prefix="    ",
-           include_label=False))
+           include_label=False).lstrip(' '))
 get_fd_det_waveform_sequence.__doc__ = get_fd_det_waveform_sequence.__doc__.format(
     params=parameters.fd_waveform_sequence_params.docstr(prefix="    ",
-           include_label=False))
+           include_label=False).lstrip(' '))
 
 def get_td_waveform(template=None, **kwargs):
     """Return the plus and cross polarizations of a time domain waveform.
@@ -585,7 +576,6 @@ def get_td_waveform(template=None, **kwargs):
     template: object
         An object that has attached properties. This can be used to subsitute
         for keyword arguments. A common example would be a row in an xml table.
-
     {params}
 
     Returns
@@ -610,7 +600,7 @@ def get_td_waveform(template=None, **kwargs):
 
 get_td_waveform.__doc__ = get_td_waveform.__doc__.format(
     params=parameters.td_waveform_params.docstr(prefix="    ",
-           include_label=False))
+           include_label=False).lstrip(' '))
 
 def get_fd_waveform(template=None, **kwargs):
     """Return a frequency domain gravitational waveform.
@@ -620,7 +610,6 @@ def get_fd_waveform(template=None, **kwargs):
     template: object
         An object that has attached properties. This can be used to substitute
         for keyword arguments. A common example would be a row in an xml table.
-
     {params}
 
     Returns
@@ -660,7 +649,7 @@ def get_fd_waveform(template=None, **kwargs):
 
 get_fd_waveform.__doc__ = get_fd_waveform.__doc__.format(
     params=parameters.fd_waveform_params.docstr(prefix="    ",
-           include_label=False))
+           include_label=False).lstrip(' '))
 
 def get_fd_waveform_from_td(**params):
     """ Return time domain version of fourier domain approximant.
@@ -681,19 +670,17 @@ def get_fd_waveform_from_td(**params):
     hc: pycbc.types.FrequencySeries
         Cross polarization time series
     """
+
+    # determine the duration to use
+    full_duration = duration = get_waveform_filter_length_in_time(**params)
     nparams = params.copy()
-    if not 'taper_method' in params:
-        # determine the duration to use for an automatic tapering choice.
-        # If taper method specified, assume they have set f_lower as they
-        # want exactly.
-        full_duration = duration = get_waveform_filter_length_in_time(**params)
 
-        while full_duration < duration * 1.5:
-            full_duration = get_waveform_filter_length_in_time(**nparams)
-            nparams['f_lower'] -= 1
+    while full_duration < duration * 1.5:
+        full_duration = get_waveform_filter_length_in_time(**nparams)
+        nparams['f_lower'] -= 1
 
-    if 'f_ref' not in nparams and 'f_lower' in nparams:
-        nparams['f_ref'] = nparams['f_lower']
+    if 'f_fref' not in nparams:
+        nparams['f_ref'] = params['f_lower']
 
     # We'll try to do the right thing and figure out what the frequency
     # end is. Otherwise, we'll just assume 2048 Hz.
@@ -719,19 +706,11 @@ def get_fd_waveform_from_td(**params):
     hp.resize(tsamples)
     hc.resize(tsamples)
 
-    if not 'taper_method' in params:
-        # apply the tapering, we will use a safety factor here to allow for
-        # somewhat inaccurate duration difference estimation.
-        window = (full_duration - duration) * 0.8
-        hp = wfutils.td_taper(hp, hp.start_time, hp.start_time + window)
-        hc = wfutils.td_taper(hc, hc.start_time, hc.start_time + window)
-    else:
-        hp = hp.taper_timeseries(location=params['taper'],
-                                 tapermethod=params['taper_method'],
-                                 taper_window=params['taper_window'])
-        hc = hc.taper_timeseries(location=params['taper'],
-                                 tapermethod=params['taper_method'],
-                                 taper_window=params['taper_window'])
+    # apply the tapering, we will use a safety factor here to allow for
+    # somewhat innacurate duration difference estimation.
+    window = (full_duration - duration) * 0.8
+    hp = wfutils.td_taper(hp, hp.start_time, hp.start_time + window)
+    hc = wfutils.td_taper(hc, hc.start_time, hc.start_time + window)
 
     # avoid wraparound
     hp = hp.to_frequencyseries().cyclic_time_shift(hp.start_time)
@@ -747,7 +726,6 @@ def get_fd_det_waveform(template=None, **kwargs):
     template: object
         An object that has attached properties. This can be used to substitute
         for keyword arguments. An example would be a row in an xml table.
-
     {params}
 
     Returns
@@ -770,7 +748,7 @@ def get_fd_det_waveform(template=None, **kwargs):
 
 get_fd_det_waveform.__doc__ = get_fd_det_waveform.__doc__.format(
     params=parameters.fd_waveform_params.docstr(prefix="    ",
-           include_label=False))
+           include_label=False).lstrip(' '))
 
 def _base_get_td_waveform_from_fd(template=None, rwrap=None, **params):
     """ The base function to calculate time domain version of fourier
@@ -824,7 +802,7 @@ def _base_get_td_waveform_from_fd(template=None, rwrap=None, **params):
     tsize = int(1.0 / nparams['delta_t'] /  nparams['delta_f'])
     fsize = tsize // 2 + 1
 
-    if nparams['approximant'] not in fd_det:
+    if nparams['approximant'] not in fd_det or nparams['approximant'] !='TaylorF2Ecc':
         hp, hc = get_fd_waveform(**nparams)
         # Resize to the right sample rate
         hp.resize(fsize)
@@ -903,7 +881,7 @@ def get_td_det_waveform_from_fd_det(template=None, rwrap=None, **params):
 get_td_det_waveform_from_fd_det.__doc__ = \
     get_td_det_waveform_from_fd_det.__doc__.format(
         params=parameters.td_waveform_params.docstr(prefix="    ",
-            include_label=False))
+            include_label=False).lstrip(' '))
 
 def get_interpolated_fd_waveform(dtype=numpy.complex64, return_hc=True,
                                  **params):
@@ -1096,6 +1074,7 @@ _filter_preconditions["SPAtmplt"] = spa_tmplt_precondition
 
 _filter_ends["SPAtmplt"] = spa_tmplt_end
 _filter_ends["TaylorF2"] = spa_tmplt_end
+_filter_ends["TaylorF2Ecc"] = spa_tmplt_end
 #_filter_ends["SEOBNRv1_ROM_EffectiveSpin"] = seobnrv2_final_frequency
 #_filter_ends["SEOBNRv1_ROM_DoubleSpin"] =  seobnrv2_final_frequency
 #_filter_ends["SEOBNRv2_ROM_EffectiveSpin"] = seobnrv2_final_frequency
@@ -1108,6 +1087,7 @@ _filter_ends["TaylorF2"] = spa_tmplt_end
 _template_amplitude_norms["SPAtmplt"] = spa_amplitude_factor
 _filter_time_lengths["SPAtmplt"] = spa_length_in_time
 _filter_time_lengths["TaylorF2"] = spa_length_in_time
+_filter_time_lengths["TaylorF2Ecc"] = eccentric_spa_length_in_time
 _filter_time_lengths["SpinTaylorT5"] = spa_length_in_time
 _filter_time_lengths["SEOBNRv1_ROM_EffectiveSpin"] = seobnrv2_length_in_time
 _filter_time_lengths["SEOBNRv1_ROM_DoubleSpin"] = seobnrv2_length_in_time
@@ -1175,7 +1155,7 @@ def td_fd_waveform_transform(approximant):
         # We can make a fd version of td approximants
         cpu_fd[approximant] = get_fd_waveform_from_td
 
-    if approximant in fd_apx and (approximant in _filter_time_lengths):
+    if approximant in fd_apx:
         # We can do interpolation for waveforms that have a time length
         apx_int = approximant + '_INTERP'
         cpu_fd[apx_int] = get_interpolated_fd_waveform
@@ -1186,8 +1166,9 @@ def td_fd_waveform_transform(approximant):
         # (ex. IMRPhenomXX)
         cpu_td[approximant] = get_td_waveform_from_fd
 
-for apx in list(_filter_time_lengths.keys()) + list(cpu_fd.keys()):
+for apx in copy.copy(_filter_time_lengths):
     td_fd_waveform_transform(apx)
+
 
 td_wav = _scheme.ChooseBySchemeDict()
 fd_wav = _scheme.ChooseBySchemeDict()
@@ -1333,12 +1314,10 @@ def get_two_pol_waveform_filter(outplus, outcross, template, **kwargs):
         # taper the time series hp if required
         if 'taper' in input_params.keys() and \
                 input_params['taper'] is not None:
-            hp = hp.taper_timeseries(location=input_params['taper'], 
-            tapermethod=input_params.get('taper_method', 'lal'), 
-            taper_window=input_params.get('taper_window'), return_lal=False)
-            hc = hc.taper_timeseries(location=input_params['taper'], 
-            tapermethod=input_params.get('taper_method', 'lal'), 
-            taper_window=input_params.get('taper_window'), return_lal=False)
+            hp = wfutils.taper_timeseries(hp, input_params['taper'],
+                                          return_lal=False)
+            hc = wfutils.taper_timeseries(hc, input_params['taper'],
+                                          return_lal=False)
         # total duration of the waveform
         tmplt_length = len(hp) * hp.delta_t
         # for IMR templates the zero of time is at max amplitude (merger)


### PR DESCRIPTION
## Summary

This PR adds leading-order eccentric chirp-time support for `TaylorF2Ecc` and feature to compute time-frequency track for TaylorF2Ecc.

The main changes are:
 - Adds `eccentric_newtonian_time` in `pycbc.pnutils`, based on Eq. (119) of Morras et al. arXiv:2502.03929.
 - Adds `eccentric_chirp_time` and `eccentric_spa_length_in_time` in `spa_tmplt.py`.
 - Adds `TaylorF2Ecc` in `waveform.py` for waveform duration/filter length handling.
 - Extends `get_inspiral_tf` to accept an `eccentricity` argument and support `TaylorF2Ecc`.


These functionalities are added for searches with `TaylorF2Ecc`. This changes will not affect existing  offline search,  live search, inference and PyGRB.

