### PR TITLE
Matmul inpainting unittest

### DIFF
--- a/test/test_infmodel.py
+++ b/test/test_infmodel.py
@@ -169,27 +169,29 @@ class TestModels(unittest.TestCase):
         self.assertAlmostEqual(self.a2, model.loglr, delta=0.04)
     
     def test_gated_gaussian_psd_opts(self):
-        model_toeplitz = models.GatedGaussianNoise(
+        assert True
+        if False:
+            model_toeplitz = models.GatedGaussianNoise(
                                  self.variable3, copy.deepcopy(self.data),
                                  low_frequency_cutoff=self.flow,
                                  psds=self.psds,
                                  static_params=self.static3,
                                  prior=self.prior3,)
-        model_matmul = models.GatedGaussianNoise(
+            model_matmul = models.GatedGaussianNoise(
                                  self.variable3, copy.deepcopy(self.data),
                                  low_frequency_cutoff=self.flow,
                                  psds=self.psds,
                                  static_params=self.static3,
                                  prior=self.prior3, paint_method='matmul',)
-        model_toeplitz.update(**self.q1)
-        model_matmul.update(**self.q1)
-        # check likelihoods match calculated
-        self.assertAlmostEqual(self.a3, model_toeplitz.loglr, delta=0.01)
-        self.assertAlmostEqual(self.a3, model_matmul.loglr, delta=0.01)
-        # check paint method is being set correctly
-        self.assertEqual('toeplitz', model_toeplitz.paint_method)
-        self.assertEqual('matmul', model_matmul.paint_method)
-
+            model_toeplitz.update(**self.q1)
+            model_matmul.update(**self.q1)
+            # check likelihoods match calculated
+            self.assertAlmostEqual(self.a3, model_toeplitz.loglr, delta=0.01)
+            self.assertAlmostEqual(self.a3, model_matmul.loglr, delta=0.01)
+            # check paint method is being set correctly
+            self.assertEqual('toeplitz', model_toeplitz.paint_method)
+            self.assertEqual('matmul', model_matmul.paint_method)
+        
     def test_brute_pol_phase_marg(self):
         # Uses the old polarization syntax untill we decide to remove it.
         # Untill then, this also tests that that interface stays working.

--- a/test/test_infmodel.py
+++ b/test/test_infmodel.py
@@ -24,11 +24,6 @@
 """
 These are the unittests for pycbc.inference.models
 """
-import os
-os.environ["OMP_NUM_THREADS"] = '1'
-os.environ["OPENBLAS_NUM_THREADS"] = '1'
-os.environ["MKL_NUM_THREADS"] = '1'
-os.environ["JULIA_NUM_THREADS"] = '1'
 
 import unittest
 import copy

--- a/test/test_infmodel.py
+++ b/test/test_infmodel.py
@@ -24,6 +24,10 @@
 """
 These are the unittests for pycbc.inference.models
 """
+import os
+os.environ["OMP_NUM_THREADS"] = '1'
+os.environ["OPENBLAS_NUM_THREADS"] = '1'
+
 import unittest
 import copy
 from utils import simple_exit
@@ -100,7 +104,7 @@ class TestModels(unittest.TestCase):
         cls.variable2 = cls.variable + ['polarization']
         cls.prior2 = JointDistribution(cls.variable2, inclination_prior,
                                        distance_prior, pol)
-        
+
         # set up for gated model tests
         cls.static3 = cls.static.copy()
         cls.static3['t_gate_start'] = cls.static3['tc']
@@ -117,7 +121,7 @@ class TestModels(unittest.TestCase):
         # answer taken from brute marginize pol + phase
         cls.a2 = 542.581
         cls.pol_samples = 200
-        
+
         # answer with gate applied, no normalization
         cls.a3 = -1245.8677296410897
 
@@ -167,31 +171,29 @@ class TestModels(unittest.TestCase):
                         )
         model.update(**self.q1)
         self.assertAlmostEqual(self.a2, model.loglr, delta=0.04)
-    
+
     def test_gated_gaussian_psd_opts(self):
+        model_toeplitz = models.GatedGaussianNoise(
+                                 self.variable3, copy.deepcopy(self.data),
+                                 low_frequency_cutoff=self.flow,
+                                 psds=self.psds,
+                                 static_params=self.static3,
+                                 prior=self.prior3,)
         model_matmul = models.GatedGaussianNoise(
                                  self.variable3, copy.deepcopy(self.data),
                                  low_frequency_cutoff=self.flow,
                                  psds=self.psds,
                                  static_params=self.static3,
                                  prior=self.prior3, paint_method='matmul',)
+        model_toeplitz.update(**self.q1)
         model_matmul.update(**self.q1)
         # check likelihoods match calculated
-        
+        self.assertAlmostEqual(self.a3, model_toeplitz.loglr, delta=0.01)
         self.assertAlmostEqual(self.a3, model_matmul.loglr, delta=0.01)
         # check paint method is being set correctly
+        self.assertEqual('toeplitz', model_toeplitz.paint_method)
         self.assertEqual('matmul', model_matmul.paint_method)
-        if False:
-            model_toeplitz = models.GatedGaussianNoise(
-                                 self.variable3, copy.deepcopy(self.data),
-                                 low_frequency_cutoff=self.flow,
-                                 psds=self.psds,
-                                 static_params=self.static3,
-                                 prior=self.prior3,)
-            model_toeplitz.update(**self.q1)
-            self.assertAlmostEqual(self.a3, model_toeplitz.loglr, delta=0.01)
-            self.assertEqual('toeplitz', model_toeplitz.paint_method)
-        
+
     def test_brute_pol_phase_marg(self):
         # Uses the old polarization syntax untill we decide to remove it.
         # Untill then, this also tests that that interface stays working.
@@ -493,7 +495,6 @@ class TestMarginalizedPolModels(unittest.TestCase):
         # now test
         polsamples = margpol_model.pol
         self._test_models(margpol_model, orig_model, polsamples)
-
 
 suite = unittest.TestSuite()
 suite.addTest(unittest.TestLoader().loadTestsFromTestCase(TestModels))

--- a/test/test_infmodel.py
+++ b/test/test_infmodel.py
@@ -170,19 +170,19 @@ class TestModels(unittest.TestCase):
     
     def test_gated_gaussian_psd_opts(self):
         assert True
-        if False:
-            model_toeplitz = models.GatedGaussianNoise(
+        model_toeplitz = models.GatedGaussianNoise(
                                  self.variable3, copy.deepcopy(self.data),
                                  low_frequency_cutoff=self.flow,
                                  psds=self.psds,
                                  static_params=self.static3,
                                  prior=self.prior3,)
-            model_matmul = models.GatedGaussianNoise(
+        model_matmul = models.GatedGaussianNoise(
                                  self.variable3, copy.deepcopy(self.data),
                                  low_frequency_cutoff=self.flow,
                                  psds=self.psds,
                                  static_params=self.static3,
                                  prior=self.prior3, paint_method='matmul',)
+        if False:
             model_toeplitz.update(**self.q1)
             model_matmul.update(**self.q1)
             # check likelihoods match calculated

--- a/test/test_infmodel.py
+++ b/test/test_infmodel.py
@@ -110,7 +110,7 @@ class TestModels(unittest.TestCase):
         # set up for gated model tests
         cls.static3 = cls.static.copy()
         cls.static3['t_gate_start'] = cls.static3['tc']
-        cls.static3['t_gate_end'] = cls.static3['tc'] + 0.2
+        cls.static3['t_gate_end'] = cls.static3['tc'] + 0.05
         cls.variable3 = cls.variable
         cls.prior3 = JointDistribution(cls.variable3, inclination_prior,
                                        distance_prior)
@@ -125,7 +125,7 @@ class TestModels(unittest.TestCase):
         cls.pol_samples = 200
 
         # answer with gate applied, no normalization
-        cls.a3 = -1245.8677296410897
+        cls.a3 = -1246.1948739646468
 
     def test_base_phase_marg(self):
         model = models.MarginalizedPhaseGaussianNoise(

--- a/test/test_infmodel.py
+++ b/test/test_infmodel.py
@@ -27,6 +27,8 @@ These are the unittests for pycbc.inference.models
 import os
 os.environ["OMP_NUM_THREADS"] = '1'
 os.environ["OPENBLAS_NUM_THREADS"] = '1'
+os.environ["MKL_NUM_THREADS"] = '1'
+os.environ["JULIA_NUM_THREADS"] = '1'
 
 import unittest
 import copy

--- a/test/test_infmodel.py
+++ b/test/test_infmodel.py
@@ -100,6 +100,14 @@ class TestModels(unittest.TestCase):
         cls.variable2 = cls.variable + ['polarization']
         cls.prior2 = JointDistribution(cls.variable2, inclination_prior,
                                        distance_prior, pol)
+        
+        # set up for gated model tests
+        cls.static3 = cls.static.copy()
+        cls.static3['t_gate_start'] = cls.static3['tc']
+        cls.static3['t_gate_end'] = cls.static3['tc'] + 0.2
+        cls.variable3 = cls.variable
+        cls.prior3 = JointDistribution(cls.variable3, inclination_prior,
+                                       distance_prior)
 
         ###### Expected answers
         # Answer taken from marginalized gaussian model
@@ -109,6 +117,9 @@ class TestModels(unittest.TestCase):
         # answer taken from brute marginize pol + phase
         cls.a2 = 542.581
         cls.pol_samples = 200
+        
+        # answer with gate applied, no normalization
+        cls.a3 = -1245.8677296410897
 
     def test_base_phase_marg(self):
         model = models.MarginalizedPhaseGaussianNoise(
@@ -156,6 +167,28 @@ class TestModels(unittest.TestCase):
                         )
         model.update(**self.q1)
         self.assertAlmostEqual(self.a2, model.loglr, delta=0.04)
+    
+    def test_gated_gaussian_psd_opts(self):
+        model_toeplitz = models.GatedGaussianNoise(
+                                 self.variable3, copy.deepcopy(self.data),
+                                 low_frequency_cutoff=self.flow,
+                                 psds=self.psds,
+                                 static_params=self.static3,
+                                 prior=self.prior3,)
+        model_matmul = models.GatedGaussianNoise(
+                                 self.variable3, copy.deepcopy(self.data),
+                                 low_frequency_cutoff=self.flow,
+                                 psds=self.psds,
+                                 static_params=self.static3,
+                                 prior=self.prior3, paint_method='matmul',)
+        model_toeplitz.update(**self.q1)
+        model_matmul.update(**self.q1)
+        # check likelihoods match calculated
+        self.assertAlmostEqual(self.a3, model_toeplitz.loglr, delta=0.01)
+        self.assertAlmostEqual(self.a3, model_matmul.loglr, delta=0.01)
+        # check paint method is being set correctly
+        self.assertEqual('toeplitz', model_toeplitz.paint_method)
+        self.assertEqual('matmul', model_matmul.paint_method)
 
     def test_brute_pol_phase_marg(self):
         # Uses the old polarization syntax untill we decide to remove it.

--- a/test/test_infmodel.py
+++ b/test/test_infmodel.py
@@ -169,27 +169,28 @@ class TestModels(unittest.TestCase):
         self.assertAlmostEqual(self.a2, model.loglr, delta=0.04)
     
     def test_gated_gaussian_psd_opts(self):
-        model_toeplitz = models.GatedGaussianNoise(
-                                 self.variable3, copy.deepcopy(self.data),
-                                 low_frequency_cutoff=self.flow,
-                                 psds=self.psds,
-                                 static_params=self.static3,
-                                 prior=self.prior3,)
         model_matmul = models.GatedGaussianNoise(
                                  self.variable3, copy.deepcopy(self.data),
                                  low_frequency_cutoff=self.flow,
                                  psds=self.psds,
                                  static_params=self.static3,
                                  prior=self.prior3, paint_method='matmul',)
-        model_toeplitz.update(**self.q1)
         model_matmul.update(**self.q1)
         # check likelihoods match calculated
-        self.assertAlmostEqual(self.a3, model_toeplitz.loglr, delta=0.01)
+        
         self.assertAlmostEqual(self.a3, model_matmul.loglr, delta=0.01)
         # check paint method is being set correctly
-        self.assertEqual('toeplitz', model_toeplitz.paint_method)
+        self.assertEqual('matmul', model_matmul.paint_method)
         if False:
-            self.assertEqual('matmul', model_matmul.paint_method)
+            model_toeplitz = models.GatedGaussianNoise(
+                                 self.variable3, copy.deepcopy(self.data),
+                                 low_frequency_cutoff=self.flow,
+                                 psds=self.psds,
+                                 static_params=self.static3,
+                                 prior=self.prior3,)
+            model_toeplitz.update(**self.q1)
+            self.assertAlmostEqual(self.a3, model_toeplitz.loglr, delta=0.01)
+            self.assertEqual('toeplitz', model_toeplitz.paint_method)
         
     def test_brute_pol_phase_marg(self):
         # Uses the old polarization syntax untill we decide to remove it.

--- a/test/test_infmodel.py
+++ b/test/test_infmodel.py
@@ -182,9 +182,9 @@ class TestModels(unittest.TestCase):
                                  psds=self.psds,
                                  static_params=self.static3,
                                  prior=self.prior3, paint_method='matmul',)
+        model_toeplitz.update(**self.q1)
+        model_matmul.update(**self.q1)
         if False:
-            model_toeplitz.update(**self.q1)
-            model_matmul.update(**self.q1)
             # check likelihoods match calculated
             self.assertAlmostEqual(self.a3, model_toeplitz.loglr, delta=0.01)
             self.assertAlmostEqual(self.a3, model_matmul.loglr, delta=0.01)

--- a/test/test_infmodel.py
+++ b/test/test_infmodel.py
@@ -184,12 +184,12 @@ class TestModels(unittest.TestCase):
                                  prior=self.prior3, paint_method='matmul',)
         model_toeplitz.update(**self.q1)
         model_matmul.update(**self.q1)
+        # check likelihoods match calculated
+        self.assertAlmostEqual(self.a3, model_toeplitz.loglr, delta=0.01)
+        # check paint method is being set correctly
+        self.assertEqual('toeplitz', model_toeplitz.paint_method)
         if False:
-            # check likelihoods match calculated
-            self.assertAlmostEqual(self.a3, model_toeplitz.loglr, delta=0.01)
             self.assertAlmostEqual(self.a3, model_matmul.loglr, delta=0.01)
-            # check paint method is being set correctly
-            self.assertEqual('toeplitz', model_toeplitz.paint_method)
             self.assertEqual('matmul', model_matmul.paint_method)
         
     def test_brute_pol_phase_marg(self):

--- a/test/test_infmodel.py
+++ b/test/test_infmodel.py
@@ -169,7 +169,6 @@ class TestModels(unittest.TestCase):
         self.assertAlmostEqual(self.a2, model.loglr, delta=0.04)
     
     def test_gated_gaussian_psd_opts(self):
-        assert True
         model_toeplitz = models.GatedGaussianNoise(
                                  self.variable3, copy.deepcopy(self.data),
                                  low_frequency_cutoff=self.flow,
@@ -186,10 +185,10 @@ class TestModels(unittest.TestCase):
         model_matmul.update(**self.q1)
         # check likelihoods match calculated
         self.assertAlmostEqual(self.a3, model_toeplitz.loglr, delta=0.01)
+        self.assertAlmostEqual(self.a3, model_matmul.loglr, delta=0.01)
         # check paint method is being set correctly
         self.assertEqual('toeplitz', model_toeplitz.paint_method)
         if False:
-            self.assertAlmostEqual(self.a3, model_matmul.loglr, delta=0.01)
             self.assertEqual('matmul', model_matmul.paint_method)
         
     def test_brute_pol_phase_marg(self):


### PR DESCRIPTION
A unittest for PR #5300 was initially written up to compare the matrix multiplication gating and in-painting method with the regular Toeplitz solver. However, this unittest would hang up and time out the Github Action. In the interest of getting the matrix multiplication functionality to master, this branch separates out the unittest so we can separately figure out how to run this.

- [ x ] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
