### PR TITLE
Move condorpool_copy to condorIO

### DIFF
--- a/pycbc/workflow/pegasus_sites.py
+++ b/pycbc/workflow/pegasus_sites.py
@@ -120,7 +120,7 @@ def add_condorpool_copy_site(sitecat, cp):
 
     site.add_profiles(Namespace.PEGASUS, key="style", value="condor")
     site.add_profiles(Namespace.PEGASUS, key="data.configuration",
-                      value="nonsharedfs")
+                      value="condorio")
     site.add_profiles(Namespace.PEGASUS, key='transfer.bypass.input.staging',
                       value="true")
     # This explicitly disables symlinking


### PR DESCRIPTION
The LDG clusters are moving away from having shared NFS home directories and instead are relying on transferring files from/to compute nodes. The `condorpool_copy` site, using an environment available in CVMFS, should have been able to work in this mode, but it was actually running `cp` commands (which won't work) rather than using condorIO.

Because condorIO is recommended anyway (as it's easier for admins to monitor) I move the condorpool_copy site to using condorIO for file transfer. Note that we made the same change for OSG some time back.

There is a question around what to do if you need to ship the code environment to the cluster node (and might not have a singularity image), which may need a later patch, but I want to put this one-liner in now.

## Standard information about the request

This is a: Configuration change to the condorpool_copy site

This change affects: pycbc.workflow

This change changes: Only changes how files are transferred when using this site

This change: has appropriate unit tests, follows style guidelines (See e.g. [PEP8](https://peps.python.org/pep-0008/)), has been proposed using the [contribution guidelines](https://github.com/gwastro/pycbc/blob/master/CONTRIBUTING.md)

## Motivation

condorpool_copy should probably be using condorIO anyway, and this will let this site work in the case that there is not a shared filesystem available.

## Contents

One liner to change `data.configuration` to `condorIO`. 

## Testing performed

I've tested in the example workflow that this does what we expect.

- [X] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
