### PR TITLE
Using geocenter time in PyGRB timeseries plots of all timeslides

### DIFF
--- a/bin/pygrb/pycbc_pygrb_minifollowups
+++ b/bin/pygrb/pycbc_pygrb_minifollowups
@@ -77,7 +77,7 @@ def make_timeseries_plot(workflow, trig_file, snr_type, central_time,
             exec_name,
             'slide-id',
             snr_type)
-        mod_tag = exec_name+'-'+snr_type
+        mod_tag = exec_name + '-' + snr_type
     workflow.cp.add_options_to_section(
         mod_tag,
         [('slide-id', '0')],

--- a/bin/pygrb/pycbc_pygrb_minifollowups
+++ b/bin/pygrb/pycbc_pygrb_minifollowups
@@ -62,16 +62,26 @@ def make_timeseries_plot(workflow, trig_file, snr_type, central_time,
 
     tags = [] if tags is None else tags
 
+    exec_name = 'pygrb_plot_snr_timeseries'
+
     # Ensure that zero-lag data is used in these follow-up plots and store
-    # the slide-id option originally provided
+    # the slide-id option originally provided.  This may be passed by the user
+    # as part of the [pygrb_plot_snr_timeseries] section or in one of its
+    # subsections: this is tracked to then be restored appropriately.
     orig_slide_id = None
-    if workflow.cp.has_option('pygrb_plot_snr_timeseries', 'slide-id'):
-        orig_slide_id = workflow.cp.get('pygrb_plot_snr_timeseries',
-                                        'slide-id')
+    mod_tag = exec_name
+    if workflow.cp.has_option(exec_name, 'slide-id'):
+        orig_slide_id = workflow.cp.get(exec_name, 'slide-id')
+    elif workflow.cp.has_option_tag(exec_name, 'slide-id', snr_type):
+        orig_slide_id = workflow.cp.get_opt_tag(
+            exec_name,
+            'slide-id',
+            snr_type)
+        mod_tag = exec_name+'-'+snr_type
     workflow.cp.add_options_to_section(
-        'pygrb_plot_snr_timeseries',
+        mod_tag,
         [('slide-id', '0')],
-        True
+        overwrite_options=True
     )
 
     # Initialize job node with its tags
@@ -80,7 +90,7 @@ def make_timeseries_plot(workflow, trig_file, snr_type, central_time,
     extra_tags += [snr_type]
     if ifo is not None:
         extra_tags += [ifo]
-    node = PlotExecutable(workflow.cp, 'pygrb_plot_snr_timeseries',
+    node = PlotExecutable(workflow.cp, exec_name,
                           ifos=workflow.ifos, out_dir=out_dir,
                           tags=tags+extra_tags).create_node()
     node.add_input_opt('--trig-file', trig_file)
@@ -113,12 +123,12 @@ def make_timeseries_plot(workflow, trig_file, snr_type, central_time,
     # Revert the config parser back to how it was given
     if orig_slide_id:
         workflow.cp.add_options_to_section(
-            'pygrb_plot_snr_timeseries',
+            mod_tag,
             [('slide-id', orig_slide_id)],
-            True
+            overwrite_options=True
         )
     else:
-        workflow.cp.remove_option('pygrb_plot_snr_timeseries', 'slide-id')
+        workflow.cp.remove_option(mod_tag, 'slide-id')
 
     return node.output_files
 
@@ -194,7 +204,8 @@ seg_files = wf.FileList(
 # proxy for the valid science segments, and ignore vetoed time inside it.
 valid_segs = segmentlist([ppu._read_seg_files(seg_file_abs_paths)['off']])
 
-# Determine if we are following up injections or loudest off/on-source triggers.
+# Determine whether injections or loudest off/on-source triggers are
+# being followed up.
 # If the time shift dataset exists, then assume we are doing the latter.
 is_injection_followup = True
 try:

--- a/bin/pygrb/pycbc_pygrb_plot_snr_timeseries
+++ b/bin/pygrb/pycbc_pygrb_plot_snr_timeseries
@@ -144,14 +144,18 @@ inj_data = ppu.load_data(inj_file, ifos, data_tag='injs',
                          slide_id=0)
 
 # Specify HDF file keys for x quantity (time) and y quantity (SNR)
+# and start preparing the horizontal axis label
 x_key = 'network/end_time_gc'
+x_label = "Geocenter"
 y_key = 'network/' + opts.y_variable + '_snr'
 if opts.y_variable == 'single':
     y_key = opts.ifo + '/snr'
-    # When looking at a single slide in a detector use the time at the detector
-    # Otherwise use the time at the geocenter to look at all slides at once
-    if opts.slide_id != 'all':
+    # When plotting all slides (in which case opts.slide_id stores None), use
+    # the geocenter time. Otherwise, a single slide is being considered (and
+    # opts.slide_id stores an integer) and the detector time is used.
+    if opts.slide_id != None:
         x_key = opts.ifo + '/end_time'
+        x_label = opts.ifo
 
 # Extract needed trigger properties and store them as dictionaries
 # Based on trial_dict: if vetoes were applied, trig_* are the veto survivors
@@ -206,8 +210,7 @@ if inj_file:
 # Generate plots
 logging.info("Plotting...")
 
-# Prepare the horizontal axis label
-x_label = "Geocenter" if 'network' in x_key else opts.ifo
+# Complete the horizontal axis label
 x_label += f" time since {central_time:.3f} (s)"
 
 # Determine what goes on the vertical axis

--- a/bin/pygrb/pycbc_pygrb_plot_snr_timeseries
+++ b/bin/pygrb/pycbc_pygrb_plot_snr_timeseries
@@ -99,9 +99,13 @@ inj_file = \
     os.path.abspath(opts.found_missed_file) if opts.found_missed_file else None
 snr_type = opts.y_variable
 ifo = opts.ifo
-if snr_type == 'single' and ifo is None:
-    err_msg = "Please specify an interferometer for a single IFO plot"
-    parser.error(err_msg)
+if snr_type == 'single':
+    if ifo is None:
+        err_msg = "Please specify an interferometer for a single IFO plot"
+        parser.error(err_msg)
+    if opts.slide_id !=0:
+        err_msg = "The single IFO SNR plot is possible only for slide-id=0."
+        parser.error(err_msg)
 
 logging.info("Imported and ready to go.")
 
@@ -147,15 +151,13 @@ inj_data = ppu.load_data(inj_file, ifos, data_tag='injs',
 # and start preparing the horizontal axis label
 x_key = 'network/end_time_gc'
 x_label = "Geocenter"
-y_key = 'network/' + opts.y_variable + '_snr'
-if opts.y_variable == 'single':
+y_key = 'network/' + snr_type + '_snr'
+if snr_type == 'single':
+    # When plotting single IFO SNR, a single timeslide (slide-id=0) can be used
+    # and the horizontal axis shows detector time.
+    x_key = opts.ifo + '/end_time'
+    x_label = opts.ifo
     y_key = opts.ifo + '/snr'
-    # When plotting all slides (in which case opts.slide_id stores None), use
-    # the geocenter time. Otherwise, a single slide is being considered (and
-    # opts.slide_id stores an integer) and the detector time is used.
-    if opts.slide_id != None:
-        x_key = opts.ifo + '/end_time'
-        x_label = opts.ifo
 
 # Extract needed trigger properties and store them as dictionaries
 # Based on trial_dict: if vetoes were applied, trig_* are the veto survivors

--- a/bin/pygrb/pycbc_pygrb_plot_snr_timeseries
+++ b/bin/pygrb/pycbc_pygrb_plot_snr_timeseries
@@ -153,7 +153,7 @@ x_key = 'network/end_time_gc'
 x_label = "Geocenter"
 y_key = 'network/' + snr_type + '_snr'
 if snr_type == 'single':
-    # When plotting single IFO SNR, a single timeslide (slide-id=0) can be used
+    # When plotting single IFO SNR, a single timeslide (slide-id=0) must be used
     # and the horizontal axis shows detector time.
     x_key = opts.ifo + '/end_time'
     x_label = opts.ifo

--- a/bin/pygrb/pycbc_pygrb_plot_snr_timeseries
+++ b/bin/pygrb/pycbc_pygrb_plot_snr_timeseries
@@ -103,7 +103,7 @@ if snr_type == 'single':
     if ifo is None:
         err_msg = "Please specify an interferometer for a single IFO plot"
         parser.error(err_msg)
-    if opts.slide_id !=0:
+    if opts.slide_id != 0:
         err_msg = "The single IFO SNR plot is possible only for slide-id=0."
         parser.error(err_msg)
 


### PR DESCRIPTION
The PyGRB executable that plots SNR timeseries currently allows to overlay slides or to plot specific timeslides.  When slides are overlayed, it uses the geocenter time on the horizontal axis, regardless of whether single IFO, reweighted, coherent, or null SNR is being shown on the vertical axis.  For single IFO SNR timeseries plots with all slides, this implies that:

1. the onsource of a closed box is not correctly omitted for slid detector data, because geocenter start and end times are used to identify the onsource window and this is not slid;
2. the horizontal axis values are mixing different meanings for different slides.

Further
3. the executable the sets up minifollowup jobs assumes that the user sticks to the same `slide-id` option choice, regardless of the SNR timeseries plot; this causes the workflow generation to fail whenever the user diversifies the choices on the basis of the specific SNR timeseries to plot.

This PR addresses the first two issues according to the following rationale: the search uses single IFO SNR timeseries as a zero-lag "input" to assemble other kinds of SNRs considered at the geocenter and their background (using timeslides).  Therefore with this PR
1. the user can only produce zero-lag (`slide-id=0`) single SNR timeseries plots;
2. single IFO SNR timeseries plots use the detector time on the horizontal axis, whereas reweighted/coherent/null SNR timeseries plots use geocenter time; the onsource + buffer window used to hide the onsource in the closed box is order of magnitudes larger than the millisecond variations between geocenter time and (unslid) detector time;

Finally:
3. the assumption in the minifollowups executable is dropped and they workflow now successfully generates, also when different `slide-id` options are indicated for different SNR timeseries cases.

<!--- Some basic info about the change (delete as appropriate) -->
This is a: bug fix (item 3), improvement in results display (items 1 and 2)

<!--- What codes will this affect? (delete as apropriate)
If you do not know which areas will be affected, please ask in the gwastro #pycbc-code slack
-->
This change affects: PyGRB

<!--- What code areas will this affect? (delete as apropriate) -->
This change changes: result plotting

## Testing performed
<!--- Describe tests for the code changes, either already performed or to be performed -->
Here is a plot of all time slides for a specific GRB at L1 with the current code
<img width="640" height="480" alt="H1L1-PYGRB_PLOT_SNR_TIMESERIES_SINGLE_GRB1_L1_v287" src="https://github.com/user-attachments/assets/d86abd4c-0c71-4c42-825a-c5a6afddb003" />

Here is how it looks with these code changes: note the reduction in data points because only zero-lag is allowed to be shown for single IFO SNR timeseries

<img width="640" height="480" alt="H1L1-PYGRB_PLOT_SNR_TIMESERIES_SINGLE_GRB1_L1-1369545660-5648" src="https://github.com/user-attachments/assets/a91d6b45-3865-460c-ad22-0634c032cac5" />


Further, I successfully ran the post-processing of this GRB with the following setups:
```
[pygrb_plot_snr_timeseries]
verbose =
newsnr-threshold = 6.

; Subsection order determines the menu order on the results webpage
[pygrb_plot_snr_timeseries-reweighted]
slide-id = all

[pygrb_plot_snr_timeseries-coherent]
slide-id = all

[pygrb_plot_snr_timeseries-single]
slide-id = 0

[pygrb_plot_snr_timeseries-null]
slide-id = all
```

and

```
[pygrb_plot_snr_timeseries]
verbose =
newsnr-threshold = 6.
slide-id = 0

; Subsection order determines the menu order on the results webpage
[pygrb_plot_snr_timeseries-reweighted]

[pygrb_plot_snr_timeseries-coherent]

[pygrb_plot_snr_timeseries-single]

[pygrb_plot_snr_timeseries-null]
```

In both cases, as desired by design, the minifollowup plots of SNR timeseries focus on zero-lag data only.

## Additional notes
Should we want to enable plotting `slide-id!=0` for single IFO SNR, extra work will be necessary to appropriately move around the onsource+buffer hiding window.

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
