### PR TITLE
allow staging executable output

### DIFF
--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -180,6 +180,11 @@ class Executable(pegasus_workflow.Executable):
 
         self.update_current_retention_level(self.current_retention_level)
 
+        self.stage_out = None
+        if cp.has_option_tags('pegasus_profile-%s' % name, 'pycbc|stage-out', tags):
+            self.stage_out = cp.get_opt_tags('pegasus_profile-%s' % name, 
+                                             'pycbc|stage-out', tags)
+
         # Should I reuse this executable?
         if reuse_executable:
             self.pegasus_name = self.name
@@ -1002,7 +1007,8 @@ class Node(pegasus_workflow.Node):
         fil = File(self.executable.ifo_list, self.executable.name,
                    valid_seg, extension=extension, store_file=store_file,
                    directory=self.executable.out_dir, tags=all_tags,
-                   use_tmp_subdirs=use_tmp_subdirs)
+                   use_tmp_subdirs=use_tmp_subdirs,
+                   stage_out=self.executable.stage_out)
         self.add_output_opt(option_name, fil)
         return fil
 
@@ -1062,7 +1068,8 @@ class Node(pegasus_workflow.Node):
             curr_file = File(ifo, self.executable.name, analysis_time,
                              extension=extension, store_file=store_file,
                              directory=self.executable.out_dir, tags=all_tags,
-                             use_tmp_subdirs=use_tmp_subdirs)
+                             use_tmp_subdirs=use_tmp_subdirs,
+                             stage_out=self.executable.stage_out)
             output_files.append(curr_file)
         self.add_multiifo_output_list_opt(opt, output_files)
 
@@ -1113,7 +1120,7 @@ class File(pegasus_workflow.File):
     '''
     def __init__(self, ifos, exe_name, segs, file_url=None,
                  extension=None, directory=None, tags=None,
-                 store_file=True, use_tmp_subdirs=False):
+                 store_file=True, use_tmp_subdirs=False, stage_out=None):
         """
         Create a File instance
 
@@ -1152,6 +1159,8 @@ class File(pegasus_workflow.File):
             This is a list of descriptors describing what this file is. For
             e.g. this might be ["BNSINJECTIONS" ,"LOWMASS","CAT_2_VETO"].
             These are used in file naming.
+        stage_out: str
+            Path to stage output file to if stored, otherwise assumed local.
         """
         self.metadata = {}
 
@@ -1211,11 +1220,17 @@ class File(pegasus_workflow.File):
 
             filename = self._filename(self.ifo_string, self.tagged_description,
                                       extension, self.segment_list.extent())
-            path = os.path.join(directory, filename)
-            if not os.path.isabs(path):
-                path = os.path.join(os.getcwd(), path)
-            file_url = urllib.parse.urlunparse(['file', 'localhost', path,
-                                                None, None, None])
+            
+            if stage_out:
+                if not stage_out.endswith('/'):
+                    stage_out += '/'
+                file_url = urllib.parse.urljoin(stage_out, filename)
+            else:
+                path = os.path.join(directory, filename)
+                if not os.path.isabs(path):
+                    path = os.path.join(os.getcwd(), path)
+                file_url = urllib.parse.urlunparse(['file', 'localhost', path,
+                                                    None, None, None])
 
         if use_tmp_subdirs and len(self.segment_list):
             pegasus_lfn = str(int(self.segment_list.extent()[0]))[:-4]
@@ -1225,7 +1240,10 @@ class File(pegasus_workflow.File):
         super(File, self).__init__(pegasus_lfn)
 
         if store_file:
-            self.storage_path = urllib.parse.urlsplit(file_url).path
+            if stage_out:
+                self.storage_path = file_url
+            else:
+                self.storage_path = urllib.parse.urlsplit(file_url).path
         else:
             self.storage_path = None
 

--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -1224,7 +1224,7 @@ class File(pegasus_workflow.File):
             if stage_out:
                 if not stage_out.endswith('/'):
                     stage_out += '/'
-                file_url = urllib.parse.urljoin(stage_out, filename)
+                file_url = stage_out + filename
             else:
                 path = os.path.join(directory, filename)
                 if not os.path.isabs(path):


### PR DESCRIPTION
This add a new option you can set in the pegasus profile for a job type that tells it to stage its output to some other location rather than to the standard local file layout. Note this just affects the final storage location, not scratch or working space. 

Example config

[pegasus_profile-inspiral]
pycbc|stage-out = scp://gravity-dev2/home/ahnitz/transfer_test

This is useful if you have a remote archival result location and locally storage on a cluster limited.