### PR TITLE
Remove empty workflow pages

### DIFF
--- a/bin/workflows/pycbc_make_bank_compression_workflow
+++ b/bin/workflows/pycbc_make_bank_compression_workflow
@@ -30,12 +30,6 @@ def finalize(container, workflow, finalize_workflow):
             'cmd': "PYCBC_SUBMIT_DAX_ARGV", }
     save_fig_with_metadata(dashboard_str, dashboard_file.storage_path, **kwds)
 
-    # Create pages for the submission script to write data
-    wf.makedir(rdir['workflow/dax'])
-    wf.makedir(rdir['workflow/input_map'])
-    wf.makedir(rdir['workflow/output_map'])
-    wf.makedir(rdir['workflow/planning'])
-
     wf.make_results_web_page(
         finalize_workflow,
         os.path.join(os.getcwd(), rdir.base)

--- a/bin/workflows/pycbc_make_offline_search_workflow
+++ b/bin/workflows/pycbc_make_offline_search_workflow
@@ -76,13 +76,6 @@ def finalize(container, workflow, finalize_workflow):
             'cmd': "PYCBC_SUBMIT_DAX_ARGV", }
     save_fig_with_metadata(dashboard_str, dashboard_file.storage_path, **kwds)
 
-    # Create pages for the submission script to write data
-    # FIXME: add this
-    # wf.makedir(rdir['workflow/dax'])
-    # wf.makedir(rdir['workflow/input_map'])
-    # wf.makedir(rdir['workflow/output_map'])
-    # wf.makedir(rdir['workflow/planning'])
-
     wf.make_results_web_page(finalize_workflow, os.path.join(os.getcwd(),
                                                              rdir.base))
 


### PR DESCRIPTION
Some years ago some workflow files were linked from the result web pages. This hasn't worked for some time, and is commented out in the all-sky workflow.

Given that the `.dax` file might be almost 1GB large in some cases that we have, I don't think I want to have these available from the web directory in any case. So I just remove the lines that create directories where these used to live.

In practice this just removes some webpages that are currently empty.

## Standard information about the request

This is a: removal of an old, not working, feature.

This change affects: a couple of web pages

This change changes: result presentation / plotting

This change: has appropriate unit tests, follows style guidelines (See e.g. [PEP8](https://peps.python.org/pep-0008/)), has been proposed using the [contribution guidelines](https://github.com/gwastro/pycbc/blob/master/CONTRIBUTING.md)

## Motivation

It's hot here, so I'm looking at some old issues. This will fix #5065.

## Contents

Removes a bunch of lines responsible for creating the empty directories

## Links to any issues or associated PRs

#5065 


- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
