### PR TITLE
Allow geocentric as target frame in `det_tc`

### DIFF
--- a/pycbc/conversions.py
+++ b/pycbc/conversions.py
@@ -1237,7 +1237,7 @@ def det_tc(detector_name, ra, dec, tc, ref_frame='geocentric', relative=False):
     Parameters
     ----------
     detector_name : string
-        The name of the detector, e.g., 'H1'.
+        The name of the detector, e.g., 'H1', or 'geocentric'.
     ra : float
         The right ascension of the signal, in radians.
     dec : float
@@ -1259,6 +1259,9 @@ def det_tc(detector_name, ra, dec, tc, ref_frame='geocentric', relative=False):
 
     if ref_frame == detector_name:
         return tc
+    if detector_name == 'geocentric':
+        refdet = Detector(ref_frame)
+        return tc - refdet.time_delay_from_earth_center(ra, dec, ref_time)
     if detector_name not in _detector_cache:
         _detector_cache[detector_name] = Detector(detector_name)
     detector = _detector_cache[detector_name]

--- a/test/test_conversions.py
+++ b/test/test_conversions.py
@@ -82,6 +82,11 @@ class TestParams(unittest.TestCase):
                                     self.spin1y, self.spin2y)
         self.secondary_spinz = conversions.secondary_spin(self.m1, self.m2,
                                     self.spin1z, self.spin2z)
+        
+        # set up some sky locations and times
+        self.ra = numpy.random.uniform(0, 2*numpy.pi, size=self.numtests)
+        self.dec = numpy.random.uniform(-numpy.pi/2, numpy.pi/2, size=self.numtests)
+        self.tc = numpy.random.uniform(1e9, 2e9, size=self.numtests)
 
 
     def test_physical_consistency(self):
@@ -181,6 +186,24 @@ class TestParams(unittest.TestCase):
             self.spin2x[maxidx],self.spin2y[maxidx]
             )
         self.assertTrue(passed, msg.format("conversions.chi_p", "chi_p", maxdiff, failinputs))
+        
+    def test_det_tc(self):
+        """Check that times remain unchanged when converting from one frame to
+        another and back."""
+        vals = list(zip(self.ra, self.dec, self.tc))
+        ref_frames = ['geocentric', 'H1', 'L1', 'V1']
+        target_frames = ['geocentric', 'H1', 'L1', 'V1']
+        for ra1, dec1, time1 in vals:
+            for ref in ref_frames:
+                for target in target_frames:
+                    # convert from ref to target
+                    conv = conversions.det_tc(target, ra1, dec1, time1,
+                                              ref_frame=ref)
+                    # convert back
+                    back = conversions.det_tc(ref, ra1, dec1, conv,
+                                              ref_frame=target)
+                    # check that this equals the original time
+                    self.assertAlmostEqual(back, time1, places=6)
 
 suite = unittest.TestSuite()
 suite.addTest(unittest.TestLoader().loadTestsFromTestCase(TestParams))


### PR DESCRIPTION
This PR adds functionality to convert times in a detector frame back to geocentric using `det_tc`. Times can already be converted from geocenter to a detector by default, and this functionality is unchanged. This patch allows for the inverse logic if the user specifies `geocentric` in the first argument. Similar functionality is available in the `Detector` class; this patch allows for the same functionality as a waveform transform (e.g. to be used in `plot_posterior`).

I've also added a unittest to `test_conversions.py` to make sure that the same time is recovered when converting to a different frame and back for an array of times, sky locations, and across the LIGO/Virgo detectors + geocenter.

- [ x ] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)