### PR TITLE
Fix floating-point truncation in Gaussian noise grid lengths

### DIFF
--- a/pycbc/noise/gaussian.py
+++ b/pycbc/noise/gaussian.py
@@ -27,16 +27,17 @@
 noise spectrum.
 """
 
-from pycbc import libutils
-from pycbc.types import TimeSeries, zeros
-from pycbc.types import complex_same_precision_as, FrequencySeries
 import lal
 import numpy.random
 
-lalsimulation = libutils.import_optional('lalsimulation')
+from pycbc import libutils
+from pycbc.types import FrequencySeries, TimeSeries, complex_same_precision_as, zeros
+
+lalsimulation = libutils.import_optional("lalsimulation")
+
 
 def frequency_noise_from_psd(psd, seed=None):
-    """ Create noise with a given psd.
+    """Create noise with a given psd.
 
     Return noise coloured with the given psd. The returned noise
     FrequencySeries has the same length and frequency step as the given psd.
@@ -61,7 +62,7 @@ def frequency_noise_from_psd(psd, seed=None):
     sigma = sigma.numpy()
     dtype = complex_same_precision_as(psd)
 
-    not_zero = (sigma != 0)
+    not_zero = sigma != 0
 
     sigma_red = sigma[not_zero]
     noise_re = numpy.random.normal(0, sigma_red)
@@ -71,12 +72,11 @@ def frequency_noise_from_psd(psd, seed=None):
     noise = numpy.zeros(len(sigma), dtype=dtype)
     noise[not_zero] = noise_red
 
-    return FrequencySeries(noise,
-                           delta_f=psd.delta_f,
-                           dtype=dtype)
+    return FrequencySeries(noise, delta_f=psd.delta_f, dtype=dtype)
+
 
 def noise_from_psd(length, delta_t, psd, seed=None):
-    """ Create noise with a given psd.
+    """Create noise with a given psd.
 
     Return noise with a given psd. Note that if unique noise is desired
     a unique seed should be provided.
@@ -105,33 +105,38 @@ def noise_from_psd(length, delta_t, psd, seed=None):
     randomness = lal.gsl_rng("ranlux", seed)
 
     N = round(1.0 / delta_t / psd.delta_f)
-    n = N//2+1
-    stride = N//2
+    n = N // 2 + 1
+    stride = N // 2
 
     if n > len(psd):
         raise ValueError("PSD not compatible with requested delta_t")
 
     psd = (psd[0:n]).lal()
-    psd.data.data[n-1] = 0
+    psd.data.data[n - 1] = 0
     psd.data.data[0] = 0
 
     segment = TimeSeries(zeros(N), delta_t=delta_t).lal()
     length_generated = 0
 
     lalsimulation.SimNoise(segment, 0, psd, randomness)
-    while (length_generated < length):
+    while length_generated < length:
         if (length_generated + stride) < length:
-            noise_ts.data[length_generated:length_generated+stride] = segment.data.data[0:stride]
+            noise_ts.data[length_generated : length_generated + stride] = (
+                segment.data.data[0:stride]
+            )
         else:
-            noise_ts.data[length_generated:length] = segment.data.data[0:length-length_generated]
+            noise_ts.data[length_generated:length] = segment.data.data[
+                0 : length - length_generated
+            ]
 
         length_generated += stride
         lalsimulation.SimNoise(segment, stride, psd, randomness)
 
     return noise_ts
 
+
 def noise_from_string(psd_name, length, delta_t, seed=None, low_frequency_cutoff=10.0):
-    """ Create noise from an analytic PSD
+    """Create noise from an analytic PSD
 
     Return noise from the chosen PSD. Note that if unique noise is desired
     a unique seed should be provided.
@@ -159,6 +164,6 @@ def noise_from_string(psd_name, length, delta_t, seed=None, low_frequency_cutoff
 
     # We just need enough resolution to resolve lines
     delta_f = 1.0 / 8
-    flen = round(.5 / delta_t / delta_f) + 1
+    flen = round(0.5 / delta_t / delta_f) + 1
     psd = pycbc.psd.from_string(psd_name, flen, delta_f, low_frequency_cutoff)
     return noise_from_psd(int(length), delta_t, psd, seed=seed)

--- a/pycbc/noise/gaussian.py
+++ b/pycbc/noise/gaussian.py
@@ -104,7 +104,7 @@ def noise_from_psd(length, delta_t, psd, seed=None):
 
     randomness = lal.gsl_rng("ranlux", seed)
 
-    N = int (1.0 / delta_t / psd.delta_f)
+    N = round(1.0 / delta_t / psd.delta_f)
     n = N//2+1
     stride = N//2
 
@@ -159,6 +159,6 @@ def noise_from_string(psd_name, length, delta_t, seed=None, low_frequency_cutoff
 
     # We just need enough resolution to resolve lines
     delta_f = 1.0 / 8
-    flen = int(.5 / delta_t / delta_f) + 1
+    flen = round(.5 / delta_t / delta_f) + 1
     psd = pycbc.psd.from_string(psd_name, flen, delta_f, low_frequency_cutoff)
     return noise_from_psd(int(length), delta_t, psd, seed=seed)

--- a/test/test_noise.py
+++ b/test/test_noise.py
@@ -25,11 +25,16 @@
 These are the unittests for noise generation
 """
 import unittest
+
+import numpy
 import pycbc.psd
 from utils import simple_exit
+from pycbc.noise.gaussian import noise_from_psd as gaussian_noise_from_psd
+from pycbc.noise.gaussian import noise_from_string as gaussian_noise_from_string
 from pycbc.noise.reproduceable import noise_from_string
 from pycbc.fft.fftw import set_measure_level
 from pycbc.noise.reproduceable import normal
+from pycbc.types import FrequencySeries
 set_measure_level(0)
 
 class TestNoise(unittest.TestCase):
@@ -65,8 +70,37 @@ class TestNoise(unittest.TestCase):
         ts2 = normal(25, 35, sample_rate=16384, seed=87693)
         self.assertEqual(ts1.time_slice(25, 30), ts2.time_slice(25, 30))
 
+
+class TestGaussianNoise(unittest.TestCase):
+    def test_noise_from_psd_rounding(self):
+        length = 186
+        delta_t = 1.0 / 4096
+        delta_f = 1.0 / (length * delta_t)
+        psd = FrequencySeries(
+            numpy.ones(length // 2 + 1),
+            delta_f=delta_f,
+        )
+
+        noise = gaussian_noise_from_psd(length, delta_t, psd, seed=1234)
+
+        self.assertEqual(len(noise), length)
+
+    def test_noise_from_string_rounding(self):
+        length = 186
+        delta_t = 4.0 / 93
+
+        noise = gaussian_noise_from_string(
+            'aLIGOZeroDetHighPower',
+            length,
+            delta_t,
+            seed=1234,
+        )
+
+        self.assertEqual(len(noise), length)
+
 suite = unittest.TestSuite()
 suite.addTest(unittest.TestLoader().loadTestsFromTestCase(TestNoise))
+suite.addTest(unittest.TestLoader().loadTestsFromTestCase(TestGaussianNoise))
 
 if __name__ == '__main__':
     results = unittest.TextTestRunner(verbosity=2).run(suite)


### PR DESCRIPTION
## Summary

Use nearest-integer rounding when deriving time-domain segment and
frequency-series lengths from `delta_t` and `delta_f` in
`pycbc.noise.gaussian`.

This prevents floating-point values that are slightly below an integer from
being truncated by one sample and subsequently rejected by
`lalsimulation.SimNoise`.

Fixes #4864.

## Standard information about the request

This is a: bug fix

This change affects: Gaussian noise generation

This change: has appropriate unit tests, follows style guidelines, has been
proposed using the contribution guidelines

This change: may require a new release.

## Motivation

`noise_from_psd` currently reconstructs its internal segment length using:

```python
N = int(1.0 / delta_t / psd.delta_f)
```

For a mathematically consistent even-length grid, floating-point roundoff can
produce:

```text
expected N = 186
raw N      = 185.999999999999971578
int(N)     = 185
round(N)   = 186
```

The truncated length is inconsistent with the PSD frequency spacing, causing:

```text
XLAL Error - XLALSimNoise (LALSimNoise.c:162): Invalid argument
RuntimeError: Invalid argument
```

The same issue can affect the derived `flen` calculation in
`noise_from_string`.

## Changes

- Use `round` when deriving `N` in `noise_from_psd`.
- Use `round` when deriving `flen` in `noise_from_string`.
- Keep `int(length)` unchanged because `length` is an API argument rather than
  a grid size reconstructed from floating-point values.
- Add even-length regression tests for both code paths.

The regression cases intentionally use an even internal length so this fix is
independent of the separate discussion about odd-length FFT behavior.

LALSuite's `XLALSimNoise` already validates the equivalent grid relationship
using nearest-integer rounding.

## Testing performed

The new regression cases fail on the current implementation with
`RuntimeError: Invalid argument` and pass after the change, returning the
requested 186 samples.

```text
python -m pytest test/test_noise.py -q
.....                                                                    [100%]
5 passed
```

- [x] The author of this pull request confirms they will adhere to the
  [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md).
