### PR TITLE
Try dropping amqplib requirement

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,17 +2,12 @@ FROM igwn/base:el8
 
 ADD docker/etc/profile.d/pycbc.sh /etc/profile.d/pycbc.sh
 ADD docker/etc/profile.d/pycbc.csh /etc/profile.d/pycbc.csh
-ADD docker/etc/cvmfs/default.local /etc/cvmfs/default.local
-ADD docker/etc/cvmfs/60-osg.conf /etc/cvmfs/60-osg.conf
-ADD docker/etc/cvmfs/config-osg.opensciencegrid.org.conf /etc/cvmfs/config-osg.opensciencegrid.org.conf
 
 # We are going to use pip as root a lot; tell it not to complain
 ENV PIP_ROOT_USER_ACTION=ignore
 
 # Set up extra repositories
 RUN <<EOF
-dnf -y install https://cvmrepo.s3.cern.ch/cvmrepo/yum/cvmfs-release-latest.noarch.rpm
-dnf -y install cvmfs cvmfs-config-default
 dnf makecache
 dnf -y groupinstall "Development Tools" "Scientific Support"
 rpm -e --nodeps git perl-Git
@@ -41,43 +36,16 @@ dnf -y install \
     zlib-devel
 alternatives --set python /usr/bin/python3.11
 python -m pip install --upgrade pip setuptools wheel cython
-python -m pip install mkl ipython jupyter jupyterhub jupyterlab lalsuite
-dnf -y install https://repo.opensciencegrid.org/osg/3.5/el8/testing/x86_64/osg-wn-client-3.5-5.osg35.el8.noarch.rpm
+python -m pip install mkl lalsuite
 dnf clean all
 python -m pip cache purge
 EOF
 
 # set up environment
 RUN <<EOF
-mkdir -p /cvmfs/config-osg.opensciencegrid.org /cvmfs/software.igwn.org /cvmfs/gwosc.osgstorage.org
-echo "config-osg.opensciencegrid.org /cvmfs/config-osg.opensciencegrid.org cvmfs ro,noauto 0 0" >> /etc/fstab
-echo "software.igwn.org /cvmfs/software.igwn.org cvmfs ro,noauto 0 0" >> /etc/fstab
-echo "gwosc.osgstorage.org /cvmfs/gwosc.osgstorage.org cvmfs ro,noauto 0 0" >> /etc/fstab
 mkdir -p /oasis /scratch /projects /usr/lib64/slurm /var/run/munge
 groupadd -g 1000 pycbc
 useradd -u 1000 -g 1000 -d /opt/pycbc -k /etc/skel -m -s /bin/bash pycbc
-EOF
-
-# Install MPI software needed for pycbc_inference at the end.
-RUN <<EOF
-dnf -y install \
-    libibmad \
-    libibmad-devel \
-    libibumad \
-    libibumad-devel \
-    libibverbs \
-    libibverbs-devel \
-    libmlx4 \
-    libmlx5 \
-    librdmacm \
-    librdmacm-devel \
-    openmpi \
-    openmpi-devel
-python -m pip install schwimmbad
-MPICC=/lib64/openmpi/bin/mpicc CFLAGS='-I /usr/include/openmpi-x86_64/ -L /usr/lib64/openmpi/lib/ -lmpi' python -m pip install --no-cache-dir mpi4py
-echo "/usr/lib64/openmpi/lib/" > /etc/ld.so.conf.d/openmpi.conf
-dnf clean all
-python -m pip cache purge
 EOF
 
 # Now update all of our library installations
@@ -85,11 +53,6 @@ RUN rm -f /etc/ld.so.cache && /sbin/ldconfig
 
 # Explicitly set the path so that it is not inherited from build the environment
 ENV PATH="/usr/local/bin:/usr/bin:/bin:/lib64/openmpi/bin/bin"
-
-# Set the default LAL_DATA_PATH to point at CVMFS first, then the container.
-# Users wanting it to point elsewhere should start docker using:
-#   docker <cmd> -e LAL_DATA_PATH="/my/new/path"
-ENV LAL_DATA_PATH="/cvmfs/software.igwn.org/pycbc/lalsuite-extra/current/share/lalsimulation:/opt/pycbc/pycbc-software/share/lal-data"
 
 # When the container is started with
 #   docker run -it pycbc/pycbc-el8:latest

--- a/docker/etc/docker-install.sh
+++ b/docker/etc/docker-install.sh
@@ -2,10 +2,17 @@
 
 set -e
 
+echo //// DEBUG ///////////////////////////////////////
+python -c "import sys; print(sys.executable); import traceback; import importlib; print('stdlib OK')"
+echo //////////////////////////////////////////////////
+
 # Install PyCBC
 cd /scratch
 python -m pip install --upgrade pip
 python -m pip install -r requirements.txt
+echo //// DEBUG ///////////////////////////////////////
+python -c "import sys; print(sys.executable); import traceback; import importlib; print('stdlib OK')"
+echo //////////////////////////////////////////////////
 python -m pip install -r requirements-igwn.txt
 python -m pip install -r companion.txt
 python -m pip install .

--- a/docker/etc/docker-install.sh
+++ b/docker/etc/docker-install.sh
@@ -8,13 +8,13 @@ echo //////////////////////////////////////////////////
 
 # Install PyCBC
 cd /scratch
-python -m pip install --upgrade pip
-python -m pip install -r requirements.txt
+python -m pip install --verbose --upgrade pip
+python -m pip install --verbose -r requirements.txt
 echo //// DEBUG ///////////////////////////////////////
 python -c "import sys; print(sys.executable); print(sys.path); import traceback; import importlib; print('stdlib OK')"
 echo //////////////////////////////////////////////////
 export PYTHONVERBOSE=true
-python -m pip install -r requirements-igwn.txt
+python -m pip install --verbose -r requirements-igwn.txt
 python -m pip install -r companion.txt
 python -m pip install .
 cd /

--- a/docker/etc/docker-install.sh
+++ b/docker/etc/docker-install.sh
@@ -3,7 +3,7 @@
 set -e
 
 echo //// DEBUG ///////////////////////////////////////
-python -c "import sys; print(sys.executable); import traceback; import importlib; print('stdlib OK')"
+python -c "import sys; print(sys.executable); print(sys.path); import traceback; import importlib; print('stdlib OK')"
 echo //////////////////////////////////////////////////
 
 # Install PyCBC
@@ -11,8 +11,9 @@ cd /scratch
 python -m pip install --upgrade pip
 python -m pip install -r requirements.txt
 echo //// DEBUG ///////////////////////////////////////
-python -c "import sys; print(sys.executable); import traceback; import importlib; print('stdlib OK')"
+python -c "import sys; print(sys.executable); print(sys.path); import traceback; import importlib; print('stdlib OK')"
 echo //////////////////////////////////////////////////
+export PYTHONVERBOSE=true
 python -m pip install -r requirements-igwn.txt
 python -m pip install -r companion.txt
 python -m pip install .

--- a/requirements-igwn.txt
+++ b/requirements-igwn.txt
@@ -2,5 +2,4 @@
 ligo-proxy-utils
 ciecplib[kerberos] >= 0.7.0
 dqsegdb2 >= 1.1.4
-amqplib
 htchirp >= 2.0


### PR DESCRIPTION
The Docker build CI job is failing with this message:
```
Collecting amqplib (from -r requirements-igwn.txt (line 5))
  Downloading amqplib-1.0.2.tgz (58 kB)
  Installing build dependencies: started
  Installing build dependencies: finished with status 'error'
  error: subprocess-exited-with-error

  × installing build dependencies for amqplib did not run successfully.
  │ exit code: 1
  ╰─> [10 lines of output]
      Error processing line 1 of /usr/local/lib/python3.11/site-packages/sphinxcontrib_jsmath-1.0.1-py3.7-nspkg.pth:

      Error in sitecustomize; set PYTHONVERBOSE for traceback:
      ModuleNotFoundError: No module named 'traceback'
      Traceback (most recent call last):
        File "/usr/local/lib/python3.11/site-packages/pip/__pip-runner__.py", line 29, in <module>
          import runpy  # noqa: E402
          ^^^^^^^^^^^^
        File "<frozen runpy>", line 14, in <module>
      ModuleNotFoundError: No module named 'importlib'
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
ERROR: Failed to build 'amqplib' when installing build dependencies for amqplib
```
I see amqplib is apparently only needed for Pegasus to report telemetry data back to the developers. Also, amqplib's last release on PyPI was 15 years ago. So here I try to drop that requirement.

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
