### PR TITLE
Fix the docker build

### DIFF
--- a/docker/etc/docker-install.sh
+++ b/docker/etc/docker-install.sh
@@ -3,12 +3,23 @@
 set -e
 
 # Install PyCBC
+#
+# --use-feature venv-isolation is required here: pip's default ("virtual")
+# build isolation isolates sdist builds by replaying site.py's .pth
+# processing in a subprocess via a generated sitecustomize.py. Old-style
+# namespace-package .pth shims (e.g. the one shipped by sphinxcontrib-jsmath,
+# pulled in via Sphinx in requirements.txt) crash that replay with spurious
+# "ModuleNotFoundError: No module named 'traceback'/'importlib'" errors,
+# which then breaks the build of any sdist-only dependency later in the
+# install (amqplib being the one that happens to trip over it first).
+# Using pip's real venv-based isolation avoids replaying the outer
+# environment's .pth files at all.
 cd /scratch
 python -m pip install --upgrade pip
-python -m pip install -r requirements.txt
-python -m pip install -r requirements-igwn.txt
-python -m pip install -r companion.txt
-python -m pip install .
+python -m pip install --use-feature venv-isolation -r requirements.txt
+python -m pip install --use-feature venv-isolation -r requirements-igwn.txt
+python -m pip install --use-feature venv-isolation -r companion.txt
+python -m pip install --use-feature venv-isolation .
 cd /
 
 # Copy PyCBC source repository into the image

--- a/docker/etc/docker-install.sh
+++ b/docker/etc/docker-install.sh
@@ -4,22 +4,13 @@ set -e
 
 # Install PyCBC
 #
-# --use-feature venv-isolation is required here: pip's default ("virtual")
-# build isolation isolates sdist builds by replaying site.py's .pth
-# processing in a subprocess via a generated sitecustomize.py. Old-style
-# namespace-package .pth shims (e.g. the one shipped by sphinxcontrib-jsmath,
-# pulled in via Sphinx in requirements.txt) crash that replay with spurious
-# "ModuleNotFoundError: No module named 'traceback'/'importlib'" errors,
-# which then breaks the build of any sdist-only dependency later in the
-# install (amqplib being the one that happens to trip over it first).
-# Using pip's real venv-based isolation avoids replaying the outer
-# environment's .pth files at all.
+# pip 26.2 excluded, see https://github.com/gwastro/pycbc/pull/5391
 cd /scratch
-python -m pip install --upgrade pip
-python -m pip install --use-feature venv-isolation -r requirements.txt
-python -m pip install --use-feature venv-isolation -r requirements-igwn.txt
-python -m pip install --use-feature venv-isolation -r companion.txt
-python -m pip install --use-feature venv-isolation .
+python -m pip install --upgrade 'pip!=26.2'
+python -m pip install -r requirements.txt
+python -m pip install -r requirements-igwn.txt
+python -m pip install -r companion.txt
+python -m pip install .
 cd /
 
 # Copy PyCBC source repository into the image


### PR DESCRIPTION
The dockerbuild is currently broken. It looks to be related to an issue in pip 26.2 (explained in more detail below). There's two potential fixes for this, either building pip in a slightly different way, or by hoping that pip will fix this in the future and skipping pip 26.2. 

This PR skips pip 26.2 (although the different pip build is in a commit below) and we can revisit if this doesn't get fixed upstream.

## Standard information about the request

This is a: bug fix

This change affects: the docker build

This change changes: docker build

This change: has appropriate unit tests, follows style guidelines (See e.g. [PEP8](https://peps.python.org/pep-0008/)), has been proposed using the [contribution guidelines](https://github.com/gwastro/pycbc/blob/master/CONTRIBUTING.md)

## Motivation

The docker build currently fails. The reason is:

"""
What's actually happening: the very latest pip (26.2) defaults to a "virtual" build-isolation mode that, when it needs to build any sdist-only package (no wheel), spawns a subprocess that force-replays all of site.py's .pth-file processing via a generated sitecustomize.py. That replay does sys.path = [] and only re-adds site-packages directories — it never re-adds the standard library path. If any .pth file executed during that window needs to import something, it can't find the stdlib.

Sphinx's dependency sphinxcontrib-jsmath (pulled in by requirements.txt for doc builds) still ships an ancient PEP-420-incompatible namespace-package .pth shim that does exactly that. So the first time pip needs to build any sdist-only package after Sphinx is installed, that shim's .pth code crashes trying to import importlib.util, which cascades into pip's own bootstrap failing on import runpy — giving the "ModuleNotFoundError: No module named 'traceback'/'importlib'" you saw. amqplib is just the first sdist-only package pip happens to hit in the requirements list — I confirmed awkde (from companion.txt, installed via git) would hit the identical crash later. Removing amqplib would only defer the failure.
"""

So it's a new feature in pip, which seems to cause a regression in older pythons. Either we fix this by working around this, or we hope it just gets resolved anyway in pip (or at least we wait to see if the next pip has this problem and then address this then if needed). I'll leave both patches in the history of this PR so we can see options if needed later.

## Contents

Add `--use-feature venv-isolation` to pip builds in the Docker build step.

## Links to any issues or associated PRs

#5389 (which this would supplant)

## Testing performed

The Docker image builds on my laptop, let's hope it does here as well!

## Additional notes

Thanks Claude!

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
