### PR TITLE
Revert change to default beta ladder in PTEmcee Sampler

### DIFF
--- a/pycbc/inference/sampler/ptemcee.py
+++ b/pycbc/inference/sampler/ptemcee.py
@@ -30,8 +30,7 @@ from .base import (BaseSampler, setup_output)
 from .base_mcmc import (BaseMCMC, EnsembleSupport, raw_samples_to_dict,
                         get_optional_arg_from_config)
 from .base_multitemper import (read_betas_from_hdf,
-                               ensemble_compute_acf, ensemble_compute_acl,
-                               default_beta_ladder)
+                               ensemble_compute_acf, ensemble_compute_acl)
 from ..burn_in import EnsembleMultiTemperedMCMCBurnInTests
 from pycbc.inference.io import PTEmceeFile
 from .. import models
@@ -108,7 +107,7 @@ class PTEmceeSampler(EnsembleSupport, BaseMCMC, BaseSampler):
         must be specified.
     Tmax : float, optional
         Specify the maximum temperature to use. This may be used with
-        ``ntemps``; see :py:func:`default_beta_ladder` for details. Either
+        ``ntemps``; see :py:func:`ptemcee.make_ladder` for details. Either
         this, ``ntemps``, or ``betas`` must be specified.
     betas : list of float, optional
         Specify the betas to use. Must be provided if ``ntemps`` and ``Tmax``
@@ -152,7 +151,7 @@ class PTEmceeSampler(EnsembleSupport, BaseMCMC, BaseSampler):
         if ntemps is None and Tmax is None and betas is None:
             raise ValueError("must provide either ntemps/Tmax or betas")
         if betas is None:
-            betas = default_beta_ladder(ndim, ntemps=ntemps, Tmax=Tmax)
+            betas = ptemcee.make_ladder(ndim, ntemps=ntemps, Tmax=Tmax)
         # construct the keyword arguments to pass; if a kwarg is None, we
         # won't pass it, resulting in ptemcee's defaults being used
         kwargs = {}


### PR DESCRIPTION
At the end of PR #5388 I changed our wrapper of the PTEmcee sampler to use an internal function for constructing an initial temperature ladder rather than the `make_ladder` that's in ptemcee. This was because the tutorial tests were failing, claiming that there was no `make_ladder` function in ptemcee. There is a `make_ladder` function in ptemcee; It turns out the real issue with the tutorials test was that they were installing the wrong version of ptemcee. Unfortunately, automerge merged #5388 even though the tutorial tests were failing, so to undo I have to create a new PR.

This patch reverts that change and goes back to using ptemcee's `make_ladder` function. It also serves to double check that the tutorial tests are now passing.