### PR TITLE
Fix inverted nbatch/size check in FFT._check_fwd_args

### DIFF
--- a/pycbc/fft/core.py
+++ b/pycbc/fft/core.py
@@ -98,7 +98,7 @@ def _check_fwd_args(invec, itype, outvec, otype, nbatch, size):
     olen = len(outvec)
     if nbatch < 1:
         raise ValueError("nbatch must be >= 1")
-    if (nbatch > 1) and size is not None:
+    if (nbatch > 1) and size is None:
         raise ValueError("When nbatch > 1, size cannot be 'None'")
     if size is None:
         size = ilen


### PR DESCRIPTION
The forward-FFT argument check rejected the only valid way to request a batched transform (nbatch > 1 with an explicit size) while silently accepting the invalid nbatch > 1, size=None case. _check_inv_args already had the correct condition; batched forward FFTs via the class-based API just hadn't been exercised elsewhere in the codebase until now.

<!---
Please delete these comments when you submit the pull request

Please add a title which is a concise description of what you are doing,
e.g. 'Fix bug with numpy import in pycbc_coinc_findtrigs' or 'add high frequency sky location dependent response for long detectors'
-->

<!---
This is a brief template for making pull requests for PyCBC.
This is _not_ a proscriptive template - you can use a different style if you want.
Please do think about the questions posed here and whether the details will be useful to include in your PR
Please add sufficient details so that people looking back at the request with no context around the work can understand the changes.
To choose reviewers, please look at the git blame for the code you are changing (if applicable),
or discuss in the #pycbc-code channel of the gwastro slack.
Please add labels as appropriate
-->

<!-- TOP-LEVEL SUMMARY: Please provide a brief, one-or-two-sentence description of the PR here
-->

## Standard information about the request

<!--- Some basic info about the change (delete as appropriate) -->
This is a bug fix. 

<!--- What codes will this affect? (delete as apropriate)
If you do not know which areas will be affected, please ask in the gwastro #pycbc-code slack
-->
This change affects nothing as we didn't use this option in any codes. 

<!--- Some things which help with code management (delete as appropriate) -->
This change: has appropriate unit tests, follows style guidelines (See e.g. [PEP8](https://peps.python.org/pep-0008/)), has been proposed using the [contribution guidelines](https://github.com/gwastro/pycbc/blob/master/CONTRIBUTING.md)

<!--- Notes about the effect of this change -->
This change will: break current functionality, require additional dependencies, require a new release, other (please describe)

## Motivation
<!--- Describe why your changes are being made -->

## Contents
<!--- Describe your changes, this doesn't need to be a line-by-line code change discussion,
but rather a general discussion of the methods chosen -->

## Links to any issues or associated PRs
<!--- If this is fixing / working around an already-reported issue, please link to it here -->

## Testing performed
I've tested this in a downstream PR #5395. 


## Additional notes
This is required for #5395 

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
