### PR TITLE
Allow mixed precision input for compression

### DIFF
--- a/pycbc/waveform/compress.py
+++ b/pycbc/waveform/compress.py
@@ -254,7 +254,7 @@ def compress_waveform(htilde, sample_points, tolerance, interpolation,
     s2 = filter.sigma(htilde, psd=psd, low_frequency_cutoff=fmin)
 
     if psd is not None:
-        htilde2 = htilde / psd / s2
+        htilde2 = htilde / psd[:len(htilde)] / s2
     else:
         htilde2 = htilde / s2
 

--- a/pycbc/waveform/compress.py
+++ b/pycbc/waveform/compress.py
@@ -254,11 +254,10 @@ def compress_waveform(htilde, sample_points, tolerance, interpolation,
     s2 = filter.sigma(htilde, psd=psd, low_frequency_cutoff=fmin)
 
     if psd is not None:
-        htilde2 = htilde / (psd[:len(htilde)] * s2)
+        htilde2 = htilde / psd / s2
     else:
         htilde2 = htilde / s2
 
-    # Do a first test to see if we are done
     mismatch = 1. - abs(filter.overlap_cplx(hdecomp / s1, htilde2,
                                   low_frequency_cutoff=fmin, normalized=False))
     if mismatch > tolerance:

--- a/pycbc/waveform/compress.py
+++ b/pycbc/waveform/compress.py
@@ -632,10 +632,12 @@ def fd_decompress(amp, phase, sample_frequencies, out=None, df=None,
             delta_f=df)
     else:
         # check for precision compatibility
-        if out.precision == 'double' and precision == 'single':
-            amp = amp.astype(numpy.float64)
-            phase = phase.astype(numpy.float64)
-            sample_frequencies = sample_frequencies.astype(numpy.float64)
+        if out.precision != precision:
+            precision = out.precision
+            rtype = _real_dtypes[precision]
+            amp = amp.astype(rtype)
+            phase = phase.astype(rtype)
+            sample_frequencies = sample_frequencies.astype(rtype)
         df = out.delta_f
         hlen = len(out)
     if f_lower is None:


### PR DESCRIPTION
This is a minor feature change that does type promotion rather than raising an error if mixed precisions are given for the compression code.

The main reason for this to make it easier to use the pycbc_bank_fir code, introduced in #5395 with precalculated compressed waveforms internally. These can be stored at inconsistent resolutions with the internal testing. It's easier to add here rather than add a few places where we do the typo promotion elsewhere. 