### PR TITLE
Silence  matplotlib font-manager noise on import

### DIFF
--- a/pycbc/__init__.py
+++ b/pycbc/__init__.py
@@ -106,7 +106,11 @@ def add_common_pycbc_options(parser):
 # PyCBC is run verbosely. init_logging holds them one step behind the level
 # it sets for everything else. Only the one whose noise has actually been
 # measured is listed; others can be added as they are found.
-NOISY_LOGGERS = ["matplotlib.font_manager"]
+NOISY_LOGGERS = [
+    "matplotlib.font_manager",
+    "scitokens",
+    "Pegasus"
+]
 
 
 def init_logging(verbose=False, default_level=0, to_file=None,

--- a/pycbc/__init__.py
+++ b/pycbc/__init__.py
@@ -102,8 +102,16 @@ def add_common_pycbc_options(parser):
     )
 
 
+# Loggers from other packages that talk far more than they are worth when
+# PyCBC is run verbosely. init_logging holds them one step behind the level
+# it sets for everything else. Only the one whose noise has actually been
+# measured is listed; others can be added as they are found.
+NOISY_LOGGERS = ["matplotlib.font_manager"]
+
+
 def init_logging(verbose=False, default_level=0, to_file=None,
-                 format='%(asctime)s %(levelname)s : %(message)s'):
+                 format='%(asctime)s %(levelname)s : %(message)s',
+                 reduce_log_level=NOISY_LOGGERS):
     """Common utility for setting up logging in PyCBC.
 
     Installs a signal handler such that verbosity can be activated at
@@ -124,6 +132,10 @@ def init_logging(verbose=False, default_level=0, to_file=None,
         overwritten if it already exists.
     format : str, optional
         The format to use for logging messages.
+    reduce_log_level : list of str, optional
+        Loggers to keep one step less verbose than everything else, so that
+        their output does not bury PyCBC's own. Asking for more verbosity
+        still reaches them.
     """
     def sig_handler(signum, frame):
         logger = logging.getLogger()
@@ -149,6 +161,13 @@ def init_logging(verbose=False, default_level=0, to_file=None,
     verbose_int = default_level if verbose is None \
         else int(verbose) + default_level
     logger.setLevel(logging.WARNING - verbose_int * 10)  # Initial setting
+
+    # These talk far more than they are worth: font_manager alone emits tens
+    # of thousands of DEBUG records per figure. Held one step behind the
+    # root rather than pinned, so a high enough verbosity still shows them.
+    for name in reduce_log_level:
+        logging.getLogger(name).setLevel(logger.level + 10)
+
     if to_file is not None:
         handler = logging.FileHandler(to_file, mode='w')
     else:

--- a/pycbc/workflow/configuration.py
+++ b/pycbc/workflow/configuration.py
@@ -135,11 +135,6 @@ def resolve_url_http(url, u, filename):
                 'PRIVATE-TOKEN': pat_fh.read().decode('ascii').strip()
             }
 
-    # Make the scitokens logger a little quieter
-    # (it is called through ciecpclib)
-    curr_level = logging.getLogger().level
-    logging.getLogger('scitokens').setLevel(curr_level + 10)
-
     with ciecplib.Session() as s:
         r = s.get(url, allow_redirects=True, headers=headers)
         r.raise_for_status()

--- a/pycbc/workflow/pegasus_workflow.py
+++ b/pycbc/workflow/pegasus_workflow.py
@@ -346,14 +346,6 @@ class Workflow(object):
     """
     def __init__(self, name='my_workflow', directory=None, cache_file=None,
                  dax_file_name=None):
-        # Pegasus logging is fairly verbose, quieten it down a bit
-        # This sets the logger to one level less verbose than the root
-        # (pycbc) logger
-
-        curr_level = logging.getLogger().level
-        # Get the logger associated with the Pegasus workflow import
-        pegasus_logger = logging.getLogger('Pegasus')
-        pegasus_logger.setLevel(curr_level + 10)
         self.name = name
         self._rc = dax.ReplicaCatalog()
         self._tc = dax.TransformationCatalog()


### PR DESCRIPTION
LAL enables SWIG stdout/stderr redirection under IPython/Jupyter, which carries a performance penalty and prints a "Wswiglal-redir-stdio" warning. Disable it on import via LAL's own swig_redirect_standard_output_error(False); set PYCBC_LAL_SWIG_REDIRECT_STDIO to keep LAL's native behaviour.

Also raise the matplotlib.font_manager logger to WARNING so its flood of DEBUG "findfont: ..." records (tens of thousands per figure) no longer swamps the output of pycbc tools run with --verbose.