### PR TITLE
CI Fix: separating docs dependencies from requirements.txt

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ pytest = "*"
 graphviz = "*"
 
 [tool.pixi.pypi-dependencies]
-pycbc = { path = ".", editable = true, extras = ["test"] }
+pycbc = { path = ".", editable = true, extras = ["test", "docs"] }
 
 [tool.pixi.environments]
 default = { features = ["bbhx"], solve-group = "default" }

--- a/requirements-igwn.txt
+++ b/requirements-igwn.txt
@@ -2,5 +2,5 @@
 ligo-proxy-utils
 ciecplib[kerberos] >= 0.7.0
 dqsegdb2 >= 1.1.4
-amqplib
+amqp>=5.0.0
 htchirp >= 2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,11 +42,5 @@ igwn-ligolw>=2.1.0
 emcee>=3.0.0
 dynesty<3.0
 
-# For building documentation
-Sphinx>=4.2.0
-sphinx-rtd-theme>=1.0.0
-sphinxcontrib-programoutput>=0.11
-sphinx_design
-
 # Needed for ringdown and time-domain injection (fix wrap-around issue for SMBHB)
 pykerr

--- a/setup.py
+++ b/setup.py
@@ -180,6 +180,12 @@ extras_require = {
     'igwn': [
         'ciecplib>=0.7.0',
     ],
+    'docs': [
+        'Sphinx>=4.2.0',
+        'sphinx-rtd-theme>=1.0.0',
+        'sphinxcontrib-programoutput>=0.11',
+        'sphinx_design',
+    ],
 }
 
 def get_reqs_from_file(filename):


### PR DESCRIPTION
Recent CI jobs have been failing the docker build because it looks like the docs dependencies are clashing with the prerequisites needed by the docker build.

Instead of manually uninstalling them, which does work, I've had a look at separating the docs dependencies so that they aren't used when building the docker image.

We can run `pip install ".[docs]"` - same way as we do with `[test]` or `[igwn]`, and get the docs stuff in.

## Standard information about the request

This is a: bug fix / prerequisites separation
This change fixes: the CI, and docker build

This change: has appropriate unit tests, follows style guidelines (See e.g. [PEP8](https://peps.python.org/pep-0008/)), has been proposed using the [contribution guidelines](https://github.com/gwastro/pycbc/blob/master/CONTRIBUTING.md)

## Motivation
Fix the CI, make things a bit more robust

## Contents
 - Move the requirements for the docs into setup.py as an extra_requires for [docs]
 - Make it so that pixi actually loads that

## Testing performed
If the CI passes for this PR, then we are good. It has passed on my fork, so should pass here as well


- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
