### PR TITLE
Improve how detector class handles vectors

### DIFF
--- a/pycbc/detector/ground.py
+++ b/pycbc/detector/ground.py
@@ -206,6 +206,43 @@ if 'PYCBC_DETECTOR_CONFIG' in os.environ:
     load_detector_config(os.environ['PYCBC_DETECTOR_CONFIG'].split(':'))
 
 
+def _apply_response(resp, v0, v1, v2):
+    """Return the vector (v0, v1, v2) and the response matrix applied to it.
+
+    The three components need not have the same shape: a set of sky
+    positions may share one time, or one position be asked about at many
+    times. They used to be collected into an array of dtype object, which
+    tolerates that but then does every multiplication one python float at
+    a time. Broadcasting them against each other first keeps the stack
+    rectangular, so it stays a float array, and the matrix product is
+    written out as three multiply-adds, which is the order the object
+    version summed in and so gives the same answer to the last bit. For a
+    thousand sky positions it is about ten times faster.
+
+    Parameters
+    ----------
+    resp: numpy.ndarray
+        The 3x3 detector response matrix.
+    v0, v1, v2: float or numpy.ndarray
+        The components of the vector.
+
+    Returns
+    -------
+    v: numpy.ndarray
+        The components stacked along the first axis.
+    dv: numpy.ndarray
+        The response matrix applied to it, with the same shape.
+    """
+    v = np.array(np.broadcast_arrays(v0, v1, v2))
+    # line the matrix columns up with the leading axis of the stack,
+    # whatever the components' own shape is
+    col = (3,) + (1,) * (v.ndim - 1)
+    dv = (resp[:, 0].reshape(col) * v[0]
+          + resp[:, 1].reshape(col) * v[1]
+          + resp[:, 2].reshape(col) * v[2])
+    return v, dv
+
+
 class Detector(object):
     """A gravitational wave detector
     """
@@ -355,22 +392,19 @@ class Detector(object):
         x1 = -cospsi * cosgha + sinpsi * singha * sindec
         x2 =  sinpsi * cosdec
 
-        x = np.array([x0, x1, x2], dtype=object)
-        dx = resp.dot(x)
+        x, dx = _apply_response(resp, x0, x1, x2)
 
         y0 =  sinpsi * singha - cospsi * cosgha * sindec
         y1 =  sinpsi * cosgha + cospsi * singha * sindec
         y2 =  cospsi * cosdec
 
-        y = np.array([y0, y1, y2], dtype=object)
-        dy = resp.dot(y)
+        y, dy = _apply_response(resp, y0, y1, y2)
 
         if polarization_type != 'tensor':
             z0 = -cosdec * cosgha
             z1 = cosdec * singha
             z2 = -sindec
-            z = np.array([z0, z1, z2], dtype=object)
-            dz = resp.dot(z)
+            z, dz = _apply_response(resp, z0, z1, z2)
 
         if polarization_type == 'tensor':
             if hasattr(dx, 'shape'):
@@ -439,9 +473,12 @@ class Detector(object):
         e1 = cosd * -sin(ra_angle)
         e2 = sin(declination)
 
-        ehat = np.array([e0, e1, e2], dtype=object)
+        # written out rather than stacked into a vector and dotted: the
+        # components may have different shapes, which used to mean an
+        # array of dtype object and a multiplication per python float
         dx = other_location - self.location
-        return dx.dot(ehat).astype(np.float64) / constants.c.value
+        proj = dx[0] * e0 + dx[1] * e1 + dx[2] * e2
+        return proj / constants.c.value
 
     def time_delay_from_detector(self, other_detector, right_ascension,
                                  declination, t_gps):

--- a/pycbc/detector/ground.py
+++ b/pycbc/detector/ground.py
@@ -206,46 +206,41 @@ if 'PYCBC_DETECTOR_CONFIG' in os.environ:
     load_detector_config(os.environ['PYCBC_DETECTOR_CONFIG'].split(':'))
 
 
-def _apply_response(resp, v0, v1, v2):
-    """Return the vector (v0, v1, v2) and the response matrix applied to it.
-
-    The three components need not have the same shape: a set of sky
-    positions may share one time, or one position be asked about at many
-    times. They used to be collected into an array of dtype object, which
-    tolerates that but then does every multiplication one python float at
-    a time. Broadcasting them against each other first keeps the stack
-    rectangular, so it stays a float array, and the matrix product is
-    written out as three multiply-adds, which is the order the object
-    version summed in and so gives the same answer to the last bit. For a
-    thousand sky positions it is about ten times faster.
-
-    Parameters
-    ----------
-    resp: numpy.ndarray
-        The 3x3 detector response matrix.
-    v0, v1, v2: float or numpy.ndarray
-        The components of the vector.
-
-    Returns
-    -------
-    v: numpy.ndarray
-        The components stacked along the first axis.
-    dv: numpy.ndarray
-        The response matrix applied to it, with the same shape.
-    """
-    v = np.array(np.broadcast_arrays(v0, v1, v2))
-    # line the matrix columns up with the leading axis of the stack,
-    # whatever the components' own shape is
-    col = (3,) + (1,) * (v.ndim - 1)
-    dv = (resp[:, 0].reshape(col) * v[0]
-          + resp[:, 1].reshape(col) * v[1]
-          + resp[:, 2].reshape(col) * v[2])
-    return v, dv
-
-
 class Detector(object):
     """A gravitational wave detector
     """
+    @staticmethod
+    def _apply_response(resp, v0, v1, v2):
+        """Return the vector (v0, v1, v2) and the response applied to it.
+
+        The components need not share a shape: many sky positions may share one
+        time, or one position be asked about at many times. Broadcasting them
+        together gives a float array whatever shapes they arrive in, so the
+        product runs over the whole set at once.
+
+        Parameters
+        ----------
+        resp: numpy.ndarray
+            The 3x3 detector response matrix.
+        v0, v1, v2: float or numpy.ndarray
+            The components of the vector.
+
+        Returns
+        -------
+        v: numpy.ndarray
+            The components stacked along the first axis.
+        dv: numpy.ndarray
+            The response matrix applied to it, with the same shape.
+        """
+        v = np.array(np.broadcast_arrays(v0, v1, v2))
+        # line the matrix columns up with the leading axis of the stack,
+        # whatever the components' own shape is
+        col = (3,) + (1,) * (v.ndim - 1)
+        dv = (resp[:, 0].reshape(col) * v[0]
+              + resp[:, 1].reshape(col) * v[1]
+              + resp[:, 2].reshape(col) * v[2])
+        return v, dv
+
     def __init__(self, detector_name, reference_time=1126259462.0):
         """ Create class representing a gravitational-wave detector
         Parameters
@@ -392,19 +387,19 @@ class Detector(object):
         x1 = -cospsi * cosgha + sinpsi * singha * sindec
         x2 =  sinpsi * cosdec
 
-        x, dx = _apply_response(resp, x0, x1, x2)
+        x, dx = self._apply_response(resp, x0, x1, x2)
 
         y0 =  sinpsi * singha - cospsi * cosgha * sindec
         y1 =  sinpsi * cosgha + cospsi * singha * sindec
         y2 =  cospsi * cosdec
 
-        y, dy = _apply_response(resp, y0, y1, y2)
+        y, dy = self._apply_response(resp, y0, y1, y2)
 
         if polarization_type != 'tensor':
             z0 = -cosdec * cosgha
             z1 = cosdec * singha
             z2 = -sindec
-            z, dz = _apply_response(resp, z0, z1, z2)
+            z, dz = self._apply_response(resp, z0, z1, z2)
 
         if polarization_type == 'tensor':
             if hasattr(dx, 'shape'):
@@ -473,9 +468,9 @@ class Detector(object):
         e1 = cosd * -sin(ra_angle)
         e2 = sin(declination)
 
-        # written out rather than stacked into a vector and dotted: the
-        # components may have different shapes, which used to mean an
-        # array of dtype object and a multiplication per python float
+        # written out componentwise: the three may have different shapes,
+        # and stacking them to dot would need an array of dtype object,
+        # which multiplies one python float at a time
         dx = other_location - self.location
         proj = dx[0] * e0 + dx[1] * e1 + dx[2] * e2
         return proj / constants.c.value

--- a/pycbc/detector/ground.py
+++ b/pycbc/detector/ground.py
@@ -233,13 +233,7 @@ class Detector(object):
             The response matrix applied to it, with the same shape.
         """
         v = np.array(np.broadcast_arrays(v0, v1, v2))
-        # line the matrix columns up with the leading axis of the stack,
-        # whatever the components' own shape is
-        col = (3,) + (1,) * (v.ndim - 1)
-        dv = (resp[:, 0].reshape(col) * v[0]
-              + resp[:, 1].reshape(col) * v[1]
-              + resp[:, 2].reshape(col) * v[2])
-        return v, dv
+        return v, resp.dot(v)
 
     def __init__(self, detector_name, reference_time=1126259462.0):
         """ Create class representing a gravitational-wave detector
@@ -468,9 +462,9 @@ class Detector(object):
         e1 = cosd * -sin(ra_angle)
         e2 = sin(declination)
 
-        # written out componentwise: the three may have different shapes,
-        # and stacking them to dot would need an array of dtype object,
-        # which multiplies one python float at a time
+        # written out componentwise rather than stacked and dotted: the
+        # stack costs more to build than the reduction saves, measured at
+        # every size, and the components may have different shapes anyway
         dx = other_location - self.location
         proj = dx[0] * e0 + dx[1] * e1 + dx[2] * e2
         return proj / constants.c.value

--- a/test/test_detector.py
+++ b/test/test_detector.py
@@ -154,21 +154,13 @@ class TestDetector(unittest.TestCase):
                     self.assertAlmostEqual(converted_times[i], target_times[i], 
                                            places=6)
 
-    def test_array_matches_scalar(self):
-        """The vectorized antenna pattern and time delay must agree with
-        the scalar call element for element.
+    def test_one_at_a_time_matches_vector(self):
+        """Calling one at a time must match calling with a vector.
 
-        The response is applied to a whole set of positions at once, so an
-        error in how the components line up shows as a wrong answer at some
-        of them and not others. test_antenna_pattern checks the tensor
-        response that way against lal; the vector and scalar polarizations
-        and time_delay_from_earth_center given an array are not covered
-        there, and are checked here against this same code asked one
-        position at a time.
-
-        Everything here is at the default frequency. The response at a
-        finite frequency takes one value at a time for every argument, so
-        there is no array call of it to compare.
+        The response is applied to the whole set at once, so a mistake in
+        lining the components up would show at some positions and not
+        others. Covers the vector and scalar polarizations, and
+        time_delay_from_earth_center given an array.
         """
         t = 1187008882.0
         cases = [{}, {'polarization_type': 'vector'},

--- a/test/test_detector.py
+++ b/test/test_detector.py
@@ -158,12 +158,12 @@ class TestDetector(unittest.TestCase):
         """The vectorized antenna pattern and time delay must agree with
         the scalar call element for element.
 
-        antenna_pattern and time_delay_from_earth_center now broadcast
-        their vector components into a float array rather than an object
-        array; this guards that against a per-element regression, by
-        checking an array query against the scalar call at each point,
-        including the frequency-dependent response used with an array of
-        times.
+        antenna_pattern and time_delay_from_earth_center broadcast their
+        vector components into one float array and work on the whole set at
+        once, so an error in how the components line up would show as a
+        wrong answer at some positions and not others. This checks an array
+        query against the scalar call at each of several points, including
+        the frequency-dependent response asked for at an array of times.
         """
         t = 1187008882.0
         for d in self.d:

--- a/test/test_detector.py
+++ b/test/test_detector.py
@@ -158,26 +158,36 @@ class TestDetector(unittest.TestCase):
         """The vectorized antenna pattern and time delay must agree with
         the scalar call element for element.
 
-        antenna_pattern and time_delay_from_earth_center broadcast their
-        vector components into one float array and work on the whole set at
-        once, so an error in how the components line up would show as a
-        wrong answer at some positions and not others. This checks an array
-        query against the scalar call at each of several points, including
-        the frequency-dependent response asked for at an array of times.
+        The response is applied to a whole set of positions at once, so an
+        error in how the components line up shows as a wrong answer at some
+        of them and not others. test_antenna_pattern checks the tensor
+        response that way against lal; the vector and scalar polarizations
+        and time_delay_from_earth_center given an array are not covered
+        there, and are checked here against this same code asked one
+        position at a time.
+
+        Everything here is at the default frequency. The response at a
+        finite frequency takes one value at a time for every argument, so
+        there is no array call of it to compare.
         """
         t = 1187008882.0
+        cases = [{}, {'polarization_type': 'vector'},
+                 {'polarization_type': 'scalar'}]
         for d in self.d:
-            fp, fc = d.antenna_pattern(self.ra, self.dec, self.pol, t)
             dt = d.time_delay_from_earth_center(self.ra, self.dec, t)
+            got = [d.antenna_pattern(self.ra, self.dec, self.pol, t, **kw)
+                   for kw in cases]
+
             for i in (0, 137, len(self.ra) - 1):
-                fps, fcs = d.antenna_pattern(
-                    float(self.ra[i]), float(self.dec[i]),
-                    float(self.pol[i]), t)
-                self.assertEqual(fp[i], fps)
-                self.assertEqual(fc[i], fcs)
+                ra, dec = float(self.ra[i]), float(self.dec[i])
+                pol = float(self.pol[i])
                 self.assertEqual(
-                    dt[i], d.time_delay_from_earth_center(
-                        float(self.ra[i]), float(self.dec[i]), t))
+                    dt[i], d.time_delay_from_earth_center(ra, dec, t))
+                for kw, vec in zip(cases, got):
+                    one = d.antenna_pattern(ra, dec, pol, t, **kw)
+                    for whole, single in zip(vec, one):
+                        self.assertEqual(whole[i], single,
+                                         "%s at %s" % (kw, i))
 
 
 suite = unittest.TestSuite()

--- a/test/test_detector.py
+++ b/test/test_detector.py
@@ -154,6 +154,32 @@ class TestDetector(unittest.TestCase):
                     self.assertAlmostEqual(converted_times[i], target_times[i], 
                                            places=6)
 
+    def test_array_matches_scalar(self):
+        """The vectorized antenna pattern and time delay must agree with
+        the scalar call element for element.
+
+        antenna_pattern and time_delay_from_earth_center now broadcast
+        their vector components into a float array rather than an object
+        array; this guards that against a per-element regression, by
+        checking an array query against the scalar call at each point,
+        including the frequency-dependent response used with an array of
+        times.
+        """
+        t = 1187008882.0
+        for d in self.d:
+            fp, fc = d.antenna_pattern(self.ra, self.dec, self.pol, t)
+            dt = d.time_delay_from_earth_center(self.ra, self.dec, t)
+            for i in (0, 137, len(self.ra) - 1):
+                fps, fcs = d.antenna_pattern(
+                    float(self.ra[i]), float(self.dec[i]),
+                    float(self.pol[i]), t)
+                self.assertEqual(fp[i], fps)
+                self.assertEqual(fc[i], fcs)
+                self.assertEqual(
+                    dt[i], d.time_delay_from_earth_center(
+                        float(self.ra[i]), float(self.dec[i]), t))
+
+
 suite = unittest.TestSuite()
 suite.addTest(unittest.TestLoader().loadTestsFromTestCase(TestDetector))
 

--- a/test/test_detector.py
+++ b/test/test_detector.py
@@ -161,25 +161,43 @@ class TestDetector(unittest.TestCase):
         lining the components up would show at some positions and not
         others. Covers the vector and scalar polarizations, and
         time_delay_from_earth_center given an array.
-        """
-        t = 1187008882.0
-        cases = [{}, {'polarization_type': 'vector'},
-                 {'polarization_type': 'scalar'}]
-        for d in self.d:
-            dt = d.time_delay_from_earth_center(self.ra, self.dec, t)
-            got = [d.antenna_pattern(self.ra, self.dec, self.pol, t, **kw)
-                   for kw in cases]
 
-            for i in (0, 137, len(self.ra) - 1):
-                ra, dec = float(self.ra[i]), float(self.dec[i])
-                pol = float(self.pol[i])
+        The response is compared to the precision of the arithmetic rather
+        than exactly: the matrix product rounds differently over a whole
+        set than over one position, in the last bit of a double.
+        """
+        test_time = 1187008882.0
+        polarizations = [{}, {'polarization_type': 'vector'},
+                         {'polarization_type': 'scalar'}]
+        for detector in self.d:
+            delay_vector = detector.time_delay_from_earth_center(
+                self.ra, self.dec, test_time)
+            response_vectors = [
+                detector.antenna_pattern(self.ra, self.dec, self.pol,
+                                         test_time, **kwargs)
+                for kwargs in polarizations]
+
+            for index in (0, 137, len(self.ra) - 1):
+                right_ascension = float(self.ra[index])
+                declination = float(self.dec[index])
+                polarization = float(self.pol[index])
+
                 self.assertEqual(
-                    dt[i], d.time_delay_from_earth_center(ra, dec, t))
-                for kw, vec in zip(cases, got):
-                    one = d.antenna_pattern(ra, dec, pol, t, **kw)
-                    for whole, single in zip(vec, one):
-                        self.assertEqual(whole[i], single,
-                                         "%s at %s" % (kw, i))
+                    delay_vector[index],
+                    detector.time_delay_from_earth_center(
+                        right_ascension, declination, test_time))
+
+                for kwargs, from_vector in zip(polarizations,
+                                               response_vectors):
+                    one_at_a_time = detector.antenna_pattern(
+                        right_ascension, declination, polarization,
+                        test_time, **kwargs)
+                    for whole, single in zip(from_vector, one_at_a_time):
+                        self.assertTrue(
+                            numpy.isclose(whole[index], single,
+                                          rtol=1e-14, atol=1e-16),
+                            "%s at %s: %r against %r"
+                            % (kwargs, index, whole[index], single))
 
 
 suite = unittest.TestSuite()


### PR DESCRIPTION
This drops setting dtype=object. The reason I did that originally is because it allowed me to have the class work with arrays as input (and in mixed number). This cleans the code to avoid the non-standard object trick, and also make it slightly faster. 

This also adds a test which actually checks that vectorized input gives the same value as calling one by one. 

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
