### PR TITLE
Warn when the distance interpolator range is exceeded

### DIFF
--- a/pycbc/inference/models/tools.py
+++ b/pycbc/inference/models/tools.py
@@ -845,15 +845,31 @@ def setup_distance_marg_interpolant(dist_marg,
                                                  phase=phase)
     interp = RectBivariateSpline(shr, hhr, lvals)
 
+    # said once, the first time it happens
+    warned = [False]
+
+    def warn_out_of_range():
+        warned[0] = True
+        logging.warning(
+            "A likelihood evaluation asked for a signal to noise ratio "
+            "outside marginalize_distance_snr_range %s; beyond it the "
+            "distance marginalized likelihood is set to zero, which biases "
+            "the result. Widen the range.", snr_range)
+
     def interp_wrapper(x, y, bounds_check=True):
         k = None
         if bounds_check:
             if isinstance(x, float):
                 if x > shr_max or x < shr_min or y > hhr_max or y < hhr_min:
+                    if not warned[0]:
+                        warn_out_of_range()
                     return -numpy.inf
             else:
                 k = (x > shr_max) | (x < shr_min)
                 k = k | (y > hhr_max) | (y < hhr_min)
+                # short circuits, so this costs nothing once said
+                if not warned[0] and k.any():
+                    warn_out_of_range()
 
         v = interp(x, y, grid=False)
         if k is not None:


### PR DESCRIPTION
The distance-marginalized likelihood is interpolated over a fixed range of signal to noise ratio set by marginalize_distance_snr_range, default (1, 50). Outside it the value was dropped to zero and returned with no sign that anything had gone wrong, which biases a run whose sampler reaches a louder or quieter point than the range allows and gives the user nothing to notice it by.



- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
