### PR TITLE
Report the effective sample size of the vector marginalization

### DIFF
--- a/pycbc/inference/models/tools.py
+++ b/pycbc/inference/models/tools.py
@@ -63,6 +63,7 @@ class DistMarg():
                               marginalize_vector_params=None,
                               marginalize_vector_samples=1e3,
                               marginalize_sky_initial_samples=1e6,
+                              monitor_vector_ess=False,
                               **kwargs):
         """ Setup the model for use with distance marginalization
 
@@ -145,6 +146,8 @@ class DistMarg():
             kwargs.pop('polarization_samples')
 
         self.reset_vector_params()
+
+        self.monitor_vector_ess = str_to_bool(monitor_vector_ess)
 
         self.marginalize_phase = str_to_bool(marginalize_phase)
 
@@ -288,7 +291,8 @@ class DistMarg():
                                       distance=distance,
                                       skip_vector=skip_vector,
                                       return_complex=return_complex,
-                                      return_peak=return_peak)
+                                      return_peak=return_peak,
+                                      monitor_ess=self.monitor_vector_ess)
 
     def premarg_draw(self):
         """ Choose random samples from prechosen set"""
@@ -890,6 +894,7 @@ def marginalize_likelihood(sh, hh,
                            interpolator=None,
                            return_peak=False,
                            return_complex=False,
+                           monitor_ess=False,
                            ):
     """ Return the marginalized likelihood.
 
@@ -981,6 +986,13 @@ def marginalize_likelihood(sh, hh,
     if isinstance(vloglr, float):
         vloglr = float(vloglr)
     elif not skip_vector:
+        if monitor_ess:
+            # how many of the drawn points carry the answer: low against
+            # the number drawn means it rests on a handful of them
+            lw = vloglr + logw
+            w = numpy.exp(lw - lw.max())
+            logging.info("vector marginalization: %.0f effective of %d",
+                         w.sum() ** 2.0 / numpy.vdot(w, w), len(w))
         vloglr = float(logsumexp(vloglr, b=numpy.exp(logw)))
 
     if return_peak:


### PR DESCRIPTION
This adds an (optional) monitor of the vector marginalizations that reports the effective sample size. Note that this is only due to the vector part of the marginalization alone, so doesn't account for any other systematics. It must be set on in the config file so by default this is not run, but it should be useful for debugging the marginalization code / options. 

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
