### PR TITLE
Make the numpy FFT backend support batching

### DIFF
--- a/pycbc/fft/npfft.py
+++ b/pycbc/fft/npfft.py
@@ -72,6 +72,14 @@ WARN_MSG = ("You are using the class-based PyCBC FFT API, with the numpy "
             "(for e.g. MKL or FFTW)")
 
 
+def _batched_view(vec, nbatch, dist):
+    """View a flat pycbc array as its nbatch transform rows, each `dist`
+    apart. nbatch=1 is just a single row, so this also covers the unbatched
+    case.
+    """
+    return vec.data[:nbatch * dist].reshape(nbatch, dist)
+
+
 class FFT(_BaseFFT):
     """
     Class for performing FFTs via the numpy interface.
@@ -82,7 +90,21 @@ class FFT(_BaseFFT):
         self.prec, self.itype, self.otype = _check_fft_args(invec, outvec)
 
     def execute(self):
-        fft(self.invec, self.outvec, self.prec, self.itype, self.otype)
+        # nbatch independent transforms of length self.size, laid out
+        # contiguously. Previously the whole buffer was handed to numpy.fft
+        # as ONE transform of length nbatch*size whenever nbatch > 1,
+        # silently returning wrong results for every batched caller.
+        if self.invec.ptr == self.outvec.ptr:
+            raise NotImplementedError("numpy backend of pycbc.fft does not "
+                                      "support in-place transforms")
+        inp = _batched_view(self.invec, self.nbatch, self.idist)
+        out = _batched_view(self.outvec, self.nbatch, self.odist)
+        if self.itype == 'complex' and self.otype == 'complex':
+            out[:] = numpy.fft.fft(inp[:, :self.size], axis=-1)
+        elif self.itype == 'real' and self.otype == 'complex':
+            out[:] = numpy.fft.rfft(inp[:, :self.size], axis=-1)
+        else:
+            raise ValueError(_INV_FFT_MSG.format("FFT", self.itype, self.otype))
 
 
 class IFFT(_BaseIFFT):
@@ -95,4 +117,21 @@ class IFFT(_BaseIFFT):
         self.prec, self.itype, self.otype = _check_fft_args(invec, outvec)
 
     def execute(self):
-        ifft(self.invec, self.outvec, self.prec, self.itype, self.otype)
+        # See FFT.execute. The un-normalization below is by self.size, the
+        # length of a single transform, not len(outvec) (which is nbatch
+        # times too large for nbatch > 1).
+        if self.invec.ptr == self.outvec.ptr:
+            raise NotImplementedError("numpy backend of pycbc.fft does not "
+                                      "support in-place transforms")
+        inp = _batched_view(self.invec, self.nbatch, self.idist)
+        out = _batched_view(self.outvec, self.nbatch, self.odist)
+        if self.itype == 'complex' and self.otype == 'complex':
+            out[:, :self.size] = numpy.fft.ifft(inp[:, :self.size], axis=-1)
+        elif self.itype == 'complex' and self.otype == 'real':
+            out[:, :self.size] = numpy.fft.irfft(inp[:, :self.idist],
+                                                 n=self.size, axis=-1)
+        else:
+            raise ValueError(_INV_FFT_MSG.format("IFFT", self.itype, self.otype))
+        # pycbc's class-based IFFT is unnormalized (matching MKL/FFTW), while
+        # numpy.fft.ifft divides by n.
+        out[:, :self.size] *= self.size

--- a/test/fft_base.py
+++ b/test/fft_base.py
@@ -772,3 +772,45 @@ class _BaseTestFFTClass(unittest.TestCase):
             output_args = {"delta_t": self.delta, "epoch": self.epoch}
             _test_raise_excep_ifft(self,inarr,outexp,output_args)
 
+    def test_batched_c2c(self):
+        nbatch, size = 4, 16
+        dt = complex64
+        tol = self.tdict[dt]
+
+        with self.context:
+            set_backend(self.backends)
+            rows = [ar(randn(size) + 1j * randn(size), dtype=dt)
+                    for _ in range(nbatch)]
+
+            # Each row of a batched FFT should match that row's own
+            # unbatched FFT.
+            batch_in = ar(zeros(nbatch * size, dtype=dt))
+            batch_out = ar(zeros(nbatch * size, dtype=dt))
+            for i, row in enumerate(rows):
+                batch_in[i * size:(i + 1) * size] = row
+            pycbc.fft.FFT(batch_in, batch_out, nbatch=nbatch, size=size).execute()
+
+            for i, row in enumerate(rows):
+                row_out = ar(zeros(size, dtype=dt))
+                pycbc.fft.FFT(ar(row), row_out).execute()
+                got = batch_out[i * size:(i + 1) * size]
+                self.assertTrue(
+                    row_out.almost_equal_norm(got, tol=tol),
+                    msg="batched (nbatch={0}) FFT row {1} did not match "
+                        "the same row's unbatched FFT".format(nbatch, i))
+
+            # Same check for IFFT.
+            batch_in2 = ar(zeros(nbatch * size, dtype=dt))
+            batch_out2 = ar(zeros(nbatch * size, dtype=dt))
+            for i, row in enumerate(rows):
+                batch_in2[i * size:(i + 1) * size] = row
+            pycbc.fft.IFFT(batch_in2, batch_out2, nbatch=nbatch, size=size).execute()
+
+            for i, row in enumerate(rows):
+                row_out = ar(zeros(size, dtype=dt))
+                pycbc.fft.IFFT(ar(row), row_out).execute()
+                got = batch_out2[i * size:(i + 1) * size]
+                self.assertTrue(
+                    row_out.almost_equal_norm(got, tol=tol),
+                    msg="batched (nbatch={0}) IFFT row {1} did not match "
+                        "the same row's unbatched IFFT".format(nbatch, i))


### PR DESCRIPTION
npfft's class-based FFT/IFFT accepted nbatch and size, passed them to the base class (which validated them and set self.size/idist/odist), and then ignored them. This fixes that and also adds a test for batched FFTs to make sure at least the basic interface works. 

This is mostly for compatibility. It is not very fast, nor will I really try to optimize it except that it allows a basic version on some platforms. 

It's no so obvious, but the way the FFT tests are set up it should go through each backend. I see it in the output and is consistent with how we did some of the other tests here. 

## Additional notes
Tested as part of #5395 (since it appears that on mac it is not uncommon for the numpy fallback to be hit and then in that case just give wrong answers). 

- [ ] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
