### PR TITLE
Add agnostic constellation orbit I/O and analytic orbit classes

### DIFF
--- a/pycbc/coordinates/__init__.py
+++ b/pycbc/coordinates/__init__.py
@@ -17,10 +17,11 @@ This modules provides functions for base coordinate transformations, and
 more advanced transformations between ground-based detectors and space-borne
 detectors.
 """
+# ruff: noqa: F403, F405 -- deliberate `import *` re-export, see __all__
 
 from pycbc.coordinates.base import *
 from pycbc.coordinates.space import *
-
+from pycbc.coordinates.space_orbit import *
 
 __all__ = ['cartesian_to_spherical_rho', 'cartesian_to_spherical_azimuthal',
            'cartesian_to_spherical_polar', 'cartesian_to_spherical',
@@ -34,4 +35,9 @@ __all__ = ['cartesian_to_spherical_rho', 'cartesian_to_spherical_azimuthal',
            'lisa_position_ssb', 'earth_position_ssb',
            't_geo_from_ssb', 't_ssb_from_t_geo', 'ssb_to_geo', 'geo_to_ssb',
            'lisa_to_geo', 'geo_to_lisa',
+           'NumericOrbits', 'LisaEqualArmOrbit', 'LisaKeplerianOrbit',
+           'TaijiEqualArmOrbit', 'TaijiKeplerianOrbit',
+           'TianQinAnalyticOrbit',
+           'constellation_frame',
+           't_detector_from_ssb', 't_ssb_from_t_detector',
            ]

--- a/pycbc/coordinates/space_orbit.py
+++ b/pycbc/coordinates/space_orbit.py
@@ -1,0 +1,1509 @@
+# Copyright (C) 2026  Shichao Wu, Alex Nitz
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+#
+# =============================================================================
+#
+#                                   Preamble
+#
+# =============================================================================
+#
+"""
+This module generalizes the constellation-frame machinery in
+`pycbc.coordinates.space` (which assumes a fixed, analytic, circular LISA
+orbit) to work with an arbitrary triangular constellation orbit, analytic or
+numerical, for any mission (LISA, Taiji, TianQin, ...).
+
+Any object exposing `compute_position(t, sc)` with the same call signature
+and return shape as `lisaorbits.Orbits` (https://pypi.org/project/lisaorbits)
+can be used as an orbit provider here, including a real `lisaorbits.Orbits`
+instance (`EqualArmlengthOrbits`, `KeplerianOrbits`, `InterpolatedOrbits`,
+`OEMOrbits`) passed in directly -- this module does not import or depend on
+`lisaorbits` itself. Users who do not have `lisaorbits` installed can instead
+use `NumericOrbits` below, which reads the same (times, positions[,
+velocities]) input as `lisaorbits.InterpolatedOrbits` and interpolates using
+only `scipy`.
+
+`compute_velocity(t, sc)` and `compute_acceleration(t, sc)` (same calling
+convention, [m/s] and [m/s^2] respectively) are also provided everywhere in
+this module -- `NumericOrbits` and the analytic mission classes below --
+needed by single-link response models that depend on spacecraft velocity
+(e.g. the sinc-type finite-armlength/light-travel-time correction) or
+acceleration. For the analytic classes these are exact closed-form
+derivatives of `compute_position` (the same formula
+`lisaorbits.EqualArmlengthOrbits` differentiates, verified to agree with it
+at essentially machine precision in the test suite), not finite-difference
+approximations; for `NumericOrbits` they are analytic derivatives of the
+interpolating spline, exactly mirroring `lisaorbits.InterpolatedOrbits`.
+
+This module does not change or replace anything in `pycbc.coordinates.space`;
+it is purely additive.
+"""
+import h5py
+import numpy as np
+from astropy import units
+from astropy.constants import au as ASTRONOMICAL_UNIT
+from astropy.constants import c as SPEED_OF_LIGHT
+from astropy.coordinates import (
+    ICRS,
+    BarycentricMeanEcliptic,
+    get_body_barycentric_posvel,
+)
+from astropy.time import Time, TimeDelta
+from scipy.interpolate import make_interp_spline
+from scipy.optimize import fsolve
+
+logger = __import__('logging').getLogger(__name__)
+
+
+def _parse_oem_file(path):
+    """Minimal, dependency-free parser for a CCSDS OEM (Orbit Ephemeris
+    Message) v2.0 file, e.g. as published in
+    https://github.com/esa/lisa-orbit-files and read by
+    `lisaorbits.OEMOrbits` (via the external `oem` package). Only the
+    first ephemeris segment is distinguished; a file with more than one
+    `META_START`/`META_STOP` block would have its data rows silently
+    concatenated (not a concern for the single-segment files tested
+    against here).
+
+    Parameters
+    ----------
+    path : str
+        Path to the OEM file.
+
+    Returns
+    -------
+    meta : dict
+        Metadata key/value pairs (e.g. `REF_FRAME`, `CENTER_NAME`,
+        `TIME_SYSTEM`), collected from both the file header and the
+        META_START/META_STOP block.
+    epochs_iso : list of str
+        ISO 8601 timestamp string for each data row.
+    rows : (N, 6) or (N, 9) ndarray
+        Position [km], velocity [km/s], and (if present) acceleration
+        [km/s^2] for each data row, in that column order.
+    """
+    meta = {}
+    epochs_iso = []
+    values = []
+    with open(path, 'r') as f:
+        for line in f:
+            line = line.strip()
+            if not line or line in ('META_START', 'META_STOP'):
+                continue
+            if line[0].isdigit():
+                fields = line.split()
+                epochs_iso.append(fields[0])
+                values.append([float(x) for x in fields[1:]])
+            elif '=' in line:
+                key, _, value = line.partition('=')
+                meta[key.strip()] = value.strip()
+    if not epochs_iso:
+        raise ValueError(f'{path}: no data rows found')
+    version = meta.get('CCSDS_OEM_VERS')
+    if version is not None and version != '2.0':
+        raise ValueError(
+            f'{path}: unsupported CCSDS_OEM_VERS {version!r} (expected '
+            "'2.0')")
+    return meta, epochs_iso, np.array(values)
+
+
+class NumericOrbits:
+    """Interpolate a numerical constellation orbit given as arrays of
+    spacecraft position (and, optionally, velocity) samples in the SSB frame.
+
+    Mirrors the input contract of `lisaorbits.InterpolatedOrbits`, using
+    only `scipy` for the spline interpolation, so it works as a drop-in
+    `OrbitProvider` without requiring `lisaorbits` to be installed.
+
+    Parameters
+    ----------
+    t_interp : (N,) array-like
+        Interpolating SSB times [s] (must be strictly increasing).
+    positions : (N, M, 3) array-like
+        Spacecraft positions in the SSB frame [m]: N time samples, M
+        spacecraft (any number, not just 3 -- see `num_sc` below), 3
+        Cartesian (x, y, z) coordinates each.
+    velocities : (N, M, 3) array-like or None, optional
+        Spacecraft velocities in the SSB frame [m/s], same shape as
+        `positions`. If None (the default), velocities are computed as the
+        analytic derivative of the position spline.
+    interp_order : int, optional
+        Spline interpolation order. Default 5 (quintic), matching the
+        default used by `lisaorbits.InterpolatedOrbits`.
+    """
+
+    def __init__(self, t_interp, positions, velocities=None, interp_order=5):
+        self.t_interp = np.asarray(t_interp, dtype=float)
+        self.positions = np.asarray(positions, dtype=float)
+
+        if self.t_interp.ndim != 1:
+            raise ValueError(
+                f't_interp must be 1-dimensional, got shape '
+                f'{self.t_interp.shape}')
+        if self.positions.ndim != 3 or self.positions.shape[2] != 3:
+            raise ValueError(
+                'positions must have shape (N, M, 3), got shape '
+                f'{self.positions.shape}')
+        if self.positions.shape[0] != self.t_interp.shape[0]:
+            raise ValueError(
+                'positions and t_interp must agree along the time axis: '
+                f'got {self.positions.shape[0]} and {self.t_interp.shape[0]}')
+
+        self.num_sc = self.positions.shape[1]
+        self.interp_order = int(interp_order)
+        if self.interp_order < 3:
+            raise ValueError(
+                f'interp_order must be at least 3, got {interp_order}')
+
+        def interpolate(y):
+            # One vector-valued spline over all (spacecraft, xyz) columns
+            # flattened together, not num_sc*3 separate scalar splines:
+            # scipy shares the basis-function computation across columns
+            # in a single BSpline call, ~5-8x faster with identical results.
+            return make_interp_spline(
+                self.t_interp, y.reshape(len(self.t_interp), -1),
+                k=self.interp_order)
+
+        self._pos_spline = interpolate(self.positions)
+
+        if velocities is not None:
+            velocities = np.asarray(velocities, dtype=float)
+            if velocities.shape != self.positions.shape:
+                raise ValueError(
+                    'velocities must have the same shape as positions: '
+                    f'got {velocities.shape} and {self.positions.shape}')
+            self._vel_spline = interpolate(velocities)
+        else:
+            self._vel_spline = self._pos_spline.derivative()
+        # Kept only so `to_file` can round-trip whether velocities were
+        # explicitly supplied (written out) or derived (omitted, so a
+        # reloaded instance re-derives them the same way this one did).
+        self.velocities = velocities
+
+        # Acceleration is always the derivative of the velocity spline
+        # (provided or derived), matching lisaorbits.InterpolatedOrbits.
+        self._acc_spline = self._vel_spline.derivative()
+
+    def _sc_indices(self, sc):
+        """Map 1-indexed spacecraft labels (matching the `lisaorbits`
+        convention) to 0-indexed array positions. `sc=None` selects all
+        spacecraft.
+        """
+        if sc is None:
+            return np.arange(self.num_sc)
+        sc = np.atleast_1d(np.asarray(sc))
+        if np.any(sc < 1) or np.any(sc > self.num_sc):
+            raise ValueError(
+                f'spacecraft labels must be in [1, {self.num_sc}], got {sc}')
+        return sc - 1
+
+    def _evaluate(self, spline, t, sc):
+        t = np.atleast_1d(np.asarray(t, dtype=float))
+        idx = self._sc_indices(sc)
+        values = spline(t).reshape(len(t), self.num_sc, 3)
+        return values[:, idx, :]
+
+    def compute_position(self, t, sc=None):
+        """Spacecraft position(s) at time(s) `t`.
+
+        Parameters
+        ----------
+        t : (N,) array-like
+            SSB time [s].
+        sc : (M,) array-like or None, optional
+            1-indexed spacecraft label(s). Default all spacecraft.
+
+        Returns
+        -------
+        (N, M, 3) ndarray
+            Spacecraft position(s) in the SSB frame [m].
+        """
+        return self._evaluate(self._pos_spline, t, sc)
+
+    def compute_velocity(self, t, sc=None):
+        """Spacecraft velocity/ies at time(s) `t`. Same conventions as
+        `compute_position`.
+
+        Returns
+        -------
+        (N, M, 3) ndarray
+            Spacecraft velocity/ies in the SSB frame [m/s].
+        """
+        return self._evaluate(self._vel_spline, t, sc)
+
+    def compute_acceleration(self, t, sc=None):
+        """Spacecraft acceleration(s) at time(s) `t`, as the analytic
+        derivative of `compute_velocity`'s spline. Same conventions as
+        `compute_position`.
+
+        Returns
+        -------
+        (N, M, 3) ndarray
+            Spacecraft acceleration(s) in the SSB frame [m/s^2].
+        """
+        return self._evaluate(self._acc_spline, t, sc)
+
+    @classmethod
+    def from_file(cls, path, group=None, interp_order=5):
+        """Load a numerical constellation orbit from an HDF5 file.
+
+        The file (or the given group within it) must contain datasets `t`
+        (shape (N,), SSB time [s]) and `positions` (shape (N, M, 3), SSB-
+        frame spacecraft positions [m]). An optional `velocities` dataset
+        (same shape as `positions`) is used if present; otherwise
+        velocities are the analytic derivative of the position spline, as
+        in `__init__`. This is the file format LISA, Taiji, or TianQin (or
+        a numerically-propagated orbit for any of them) can be supplied
+        in, e.g. from a PE config's `orbit-file` option (see
+        `pycbc.transforms`).
+
+        Parameters
+        ----------
+        path : str
+            Path to the HDF5 orbit file.
+        group : str, optional
+            Name of an HDF5 group within the file to read the datasets
+            from. Default None (read from the file's root).
+        interp_order : int, optional
+            See `__init__`. Default 5.
+
+        Returns
+        -------
+        NumericOrbits
+            A `NumericOrbits` instance built from the file's contents.
+        """
+        with h5py.File(path, 'r') as f:
+            node = f[group] if group is not None else f
+            t_interp = node['t'][:]
+            positions = node['positions'][:]
+            velocities = node['velocities'][:] \
+                if 'velocities' in node else None
+        return cls(t_interp, positions, velocities=velocities,
+                   interp_order=interp_order)
+
+    def to_file(self, path, group=None, mode='w'):
+        """Write this orbit to an HDF5 file in the format read by
+        `from_file`, e.g. for use with a PE config's `orbit-file` option
+        (see `pycbc.transforms`).
+
+        Writes datasets `t` (SSB time [s]) and `positions` (SSB-frame
+        spacecraft positions [m]). If this instance was constructed with
+        explicit `velocities`, those are written too; otherwise the
+        `velocities` dataset is omitted, so a round trip through
+        `from_file` re-derives velocities from the position spline exactly
+        as this instance does, rather than through an extra layer of
+        spline interpolation of re-sampled velocities. Acceleration is
+        never stored -- as in `__init__`, it's always the analytic
+        derivative of the velocity spline.
+
+        Parameters
+        ----------
+        path : str
+            Path to the HDF5 orbit file to write.
+        group : str, optional
+            Name of an HDF5 group within the file to write the datasets
+            to. Default None (write to the file's root).
+        mode : str, optional
+            `h5py.File` mode. Default 'w' (create the file, truncating any
+            existing file at `path`); use 'a' to add a group to an
+            existing file.
+        """
+        with h5py.File(path, mode) as f:
+            node = f.create_group(group) if group is not None else f
+            node['t'] = self.t_interp
+            node['positions'] = self.positions
+            if self.velocities is not None:
+                node['velocities'] = self.velocities
+
+    @classmethod
+    def from_oem_files(cls, oem_1, oem_2, oem_3, interp_order=5):
+        """Load a numerical constellation orbit from three CCSDS OEM
+        (Orbit Ephemeris Message) files, one per spacecraft -- the format
+        used by ESA's official LISA orbit files
+        (https://github.com/esa/lisa-orbit-files), readable by
+        `lisaorbits.OEMOrbits`, parsed here with a small self-contained
+        parser (no dependency on `lisaorbits` or its `oem` package).
+
+        OEM files give position/velocity in the ICRS/EME2000 (equatorial)
+        frame, km and km/s, ISO 8601 timestamps in TCB or TDB; this
+        converts to pycbc's convention (SSB BarycentricMeanEcliptic,
+        meters, GPS seconds) via `_icrs_to_ecliptic_rotation_matrix`. Any
+        acceleration triplet in the file is ignored -- acceleration is
+        always derived from the velocity spline, as in `__init__`.
+
+        Only the first ephemeris segment of each file is read (matching
+        `lisaorbits.OEMOrbits`); raises `ValueError` if `REF_FRAME` isn't
+        `EME2000`, or if the three files don't share identical epochs.
+
+        Parameters
+        ----------
+        oem_1, oem_2, oem_3 : str
+            Paths to the OEM files for spacecraft 1, 2, and 3.
+        interp_order : int, optional
+            See `__init__`. Default 5.
+
+        Returns
+        -------
+        NumericOrbits
+            A `NumericOrbits` instance, in pycbc's SSB-ecliptic convention,
+            built from the three files' contents.
+        """
+        t_gps = None
+        positions_icrs_km = []
+        for path in (oem_1, oem_2, oem_3):
+            meta, epochs_iso, rows = _parse_oem_file(path)
+            if meta.get('REF_FRAME') != 'EME2000':
+                raise ValueError(
+                    f"{path}: expected REF_FRAME = EME2000, got "
+                    f"{meta.get('REF_FRAME')!r}")
+            scale = 'tdb' if meta.get('TIME_SYSTEM') == 'TDB' else 'tcb'
+            this_t_gps = Time(
+                epochs_iso, format='isot', scale=scale).gps
+            if t_gps is None:
+                t_gps = this_t_gps
+            elif not np.array_equal(t_gps, this_t_gps):
+                raise ValueError(
+                    'input OEM files do not share identical epochs')
+            positions_icrs_km.append(rows[:, 0:3])
+
+        positions_icrs_m = np.stack(positions_icrs_km, axis=1) * 1e3  # (N,3,3)
+        rotation = _icrs_to_ecliptic_rotation_matrix()
+        positions_ecliptic_m = (
+            positions_icrs_m.reshape(-1, 3) @ rotation.T
+        ).reshape(positions_icrs_m.shape)
+        return cls(t_gps, positions_ecliptic_m, interp_order=interp_order)
+
+    @classmethod
+    def from_lisaorbits_file(cls, path, interp_order=5):
+        """Load a numerical constellation orbit from an orbit file
+        generated by `lisaorbits.Orbits.write` (the format used by the
+        wider LISA community's simulation tools, e.g. LISA Instrument),
+        without requiring `lisaorbits` itself to be installed.
+
+        Positions come from the `tcb/x` dataset, ICRS frame, sampled
+        uniformly in TCB time as `t0 + arange(size)*dt` (from the file's
+        `t0`/`dt`/`size` attrs, TCB seconds since
+        `lisaconstants.LISA_EPOCH_TCB` = 2035-01-01T00:00:00 TCB);
+        converted to pycbc's convention the same way as `from_oem_files`.
+        As there, `tcb/v`/`tcb/a` are ignored -- velocity/acceleration
+        come from the position spline instead.
+
+        Parameters
+        ----------
+        path : str
+            Path to a `lisaorbits`-format orbit HDF5 file.
+        interp_order : int, optional
+            See `__init__`. Default 5.
+
+        Returns
+        -------
+        NumericOrbits
+            A `NumericOrbits` instance, in pycbc's SSB-ecliptic convention,
+            built from the file's contents.
+        """
+        with h5py.File(path, 'r') as f:
+            t0 = float(f.attrs['t0'])
+            dt = float(f.attrs['dt'])
+            size = int(f.attrs['size'])
+            positions_icrs_m = f['tcb/x'][:]
+
+        t_tcb = t0 + np.arange(size) * dt
+        epoch = Time('2035-01-01T00:00:00.000', format='isot', scale='tcb')
+        t_gps = (epoch + TimeDelta(t_tcb, format='sec')).gps
+
+        rotation = _icrs_to_ecliptic_rotation_matrix()
+        positions_ecliptic_m = (
+            positions_icrs_m.reshape(-1, 3) @ rotation.T
+        ).reshape(positions_icrs_m.shape)
+        return cls(t_gps, positions_ecliptic_m, interp_order=interp_order)
+
+    @classmethod
+    def from_triangle_dat_files(cls, orbit_dir, sc_labels=('1', '2', '3'),
+                                t0=0.0, dt=86400.0, max_rows=None,
+                                interp_order=5):
+        """Load a numerical constellation orbit from Taiji Data Challenge
+        (TDC) Triangle-Simulator-format orbit files: a directory
+        containing `SCP{label}.dat`/`SCV{label}.dat` per spacecraft
+        (position/velocity, one row per sample, ASCII, AU / AU-per-day,
+        ecliptic SSB frame -- Triangle-Simulator's own `Orbit` class
+        format, shipped with its `OrbitData/` datasets).
+
+        Unlike OEM, these files carry no absolute timestamps, just a row
+        index -- the caller supplies the SSB time of the first row
+        (`t0`) and the row spacing (`dt`, default 1 day, matching every
+        `OrbitData/` dataset Triangle-Simulator ships).
+
+        Parameters
+        ----------
+        orbit_dir : str
+            Directory containing `SCP{label}.dat`/`SCV{label}.dat` files.
+        sc_labels : sequence of str, optional
+            Spacecraft file-name labels, in the order they should be
+            assigned to 1-indexed spacecraft. Default `('1', '2', '3')`,
+            matching Triangle-Simulator's own convention.
+        t0 : float, optional
+            SSB time [s] (pycbc convention: GPS seconds) of the first row.
+            Default 0.0 -- the caller is responsible for supplying the
+            correct absolute epoch if one is needed; these files carry no
+            timestamp of their own.
+        dt : float, optional
+            Time spacing between rows [s]. Default 86400.0 (1 day),
+            matching every dataset shipped with Triangle-Simulator.
+        max_rows : int or None, optional
+            Passed to `numpy.loadtxt` to read only the first `max_rows`
+            samples (for quick tests on large files). Default None (read
+            all rows).
+        interp_order : int, optional
+            See `__init__`. Default 5.
+
+        Returns
+        -------
+        NumericOrbits
+            A `NumericOrbits` instance built from the three files' contents.
+        """
+        positions = []
+        velocities = []
+        n_rows = None
+        for label in sc_labels:
+            pos = np.loadtxt(
+                f'{orbit_dir}/SCP{label}.dat',
+                max_rows=max_rows) * ASTRONOMICAL_UNIT.value
+            vel = np.loadtxt(
+                f'{orbit_dir}/SCV{label}.dat',
+                max_rows=max_rows) * ASTRONOMICAL_UNIT.value / 86400.0
+            if n_rows is None:
+                n_rows = pos.shape[0]
+            elif pos.shape[0] != n_rows or vel.shape[0] != n_rows:
+                raise ValueError(
+                    f'{orbit_dir}: SCP/SCV*.dat files have mismatched '
+                    'row counts across spacecraft')
+            positions.append(pos)
+            velocities.append(vel)
+
+        t_interp = t0 + np.arange(n_rows) * dt
+        positions = np.stack(positions, axis=1)  # (N, M, 3)
+        velocities = np.stack(velocities, axis=1)
+        return cls(t_interp, positions, velocities=velocities,
+                   interp_order=interp_order)
+
+
+_ICRS_TO_ECLIPTIC_ROTATION = None
+
+
+def _icrs_to_ecliptic_rotation_matrix():
+    """The fixed 3x3 rotation matrix from ICRS (equatorial, e.g. EME2000)
+    to the BarycentricMeanEcliptic(equinox='J2000') convention this module
+    and `pycbc.coordinates.space` use. Both frames are barycentric (no
+    origin shift), and the equinox is pinned to a fixed epoch, so this is a
+    pure, time-independent axis rotation; it is computed once (by rotating
+    the ICRS unit basis vectors) and cached, rather than invoking the full
+    astropy frame-transform machinery on every call.
+    """
+    global _ICRS_TO_ECLIPTIC_ROTATION
+    if _ICRS_TO_ECLIPTIC_ROTATION is None:
+        basis = np.eye(3)
+        icrs = ICRS(x=basis[0] * units.m, y=basis[1] * units.m,
+                    z=basis[2] * units.m, representation_type='cartesian')
+        ecl = icrs.transform_to(
+            BarycentricMeanEcliptic(equinox='J2000')).cartesian
+        # transform(e_k) gives the k-th column of the ICRS->ecliptic
+        # rotation matrix directly (no transpose): stacking ecl.x/y/z as
+        # rows already places ecl.{x,y,z}[k] (the i-th ecliptic coordinate
+        # of ICRS basis vector e_k) at matrix position [i, k].
+        _ICRS_TO_ECLIPTIC_ROTATION = np.array([
+            ecl.x.to(units.m).value,
+            ecl.y.to(units.m).value,
+            ecl.z.to(units.m).value,
+        ])
+    return _ICRS_TO_ECLIPTIC_ROTATION
+
+
+def _real_earth_ecliptic_longitude(t=0.0):
+    """Real Earth's ecliptic longitude at SSB time `t` [s], from
+    `pycbc.coordinates.space.earth_position_ssb` (astropy-based real
+    ephemeris). Imported lazily (not at module level) to avoid a circular
+    import: `pycbc.coordinates.space` imports from this module.
+    """
+    from pycbc.coordinates.space import earth_position_ssb
+    return earth_position_ssb(t)[1]
+
+
+def _real_body_position_velocity(t, body='earth'):
+    """Real position and velocity of any astropy-recognized solar-system
+    body (e.g. 'earth', 'moon') in the SSB ecliptic frame, at SSB time(s)
+    `t` [s] (GPS seconds), from astropy's JPL-based ephemeris (includes
+    real perturbations, unlike any closed-form orbit approximation). Uses
+    the cached `_icrs_to_ecliptic_rotation_matrix` rather than
+    `pycbc.coordinates.space.earth_position_ssb`'s own per-call astropy
+    frame transform, so repeated queries stay fast. Imported lazily to
+    avoid a circular import.
+
+    Parameters
+    ----------
+    t : array-like
+        SSB time(s) [s] (GPS seconds).
+    body : str, optional
+        Name of the body, as recognized by
+        `astropy.coordinates.get_body_barycentric_posvel`. Default
+        `'earth'`.
+
+    Returns
+    -------
+    position : (N, 3) ndarray
+        The body's position in the SSB ecliptic frame [m].
+    velocity : (N, 3) ndarray
+        The body's velocity in the SSB ecliptic frame [m/s].
+    """
+    time = Time(np.atleast_1d(t), format='gps')
+    pos, vel = get_body_barycentric_posvel(body, time)
+    rotation = _icrs_to_ecliptic_rotation_matrix()
+    pos_icrs = np.stack([pos.x.to(units.m).value,
+                        pos.y.to(units.m).value,
+                        pos.z.to(units.m).value], axis=-1)
+    vel_icrs = np.stack([vel.x.to(units.m / units.s).value,
+                        vel.y.to(units.m / units.s).value,
+                        vel.z.to(units.m / units.s).value], axis=-1)
+    return pos_icrs @ rotation.T, vel_icrs @ rotation.T
+
+
+def _real_earth_position_velocity(t):
+    """Real Earth position/velocity in the SSB ecliptic frame. See
+    `_real_body_position_velocity` (this is a thin wrapper for `'earth'`,
+    kept for the existing call sites in this module).
+    """
+    return _real_body_position_velocity(t, 'earth')
+
+
+EARTH_ORBIT_ANGULAR_FREQUENCY = 1.99098659277e-7  # [rad/s]
+# = 2*pi / (sidereal year in seconds, 31558149.7635456); pinned as a
+# literal (not derived via `import lal`) per project convention of
+# avoiding a lal dependency in new code.
+
+# Named constants instead of np.deg2rad() calls directly in the default
+# constructor arguments below, to avoid a ruff B008 warning.
+_TAIJI_LEAD_ANGLE = np.deg2rad(20.0)
+_TIANQIN_LAMBDA_S = np.deg2rad(120.5)
+_TIANQIN_BETA_S = np.deg2rad(-4.7)
+# The theoretical value (not the 1.7e5 km engineering rounding also seen in
+# the literature), for consistency with pycbc.psd.analytical_space's own
+# TianQin PSD functions, which all default to this same value.
+_TIANQIN_ARMLENGTH = np.sqrt(3) * 1e8
+
+
+def _equal_arm_orbit_position(alpha, armlength, sc):
+    """Shared first-order-in-eccentricity Keplerian expansion (Rubbo,
+    Cornish & Poujade 2004, Phys. Rev. D 69, 082003) underlying
+    `LisaEqualArmOrbit` and `TaijiEqualArmOrbit`: a rigid, circular
+    triangular constellation at guiding-center phase `alpha` [rad], with
+    the given `armlength` [m].
+
+    `sin(alpha)`/`cos(alpha)` (the only per-element transcendental calls
+    needed -- everything else reduces to `beta_n`-dependent scalars via
+    the angle-subtraction identity for `cos(alpha - beta_n)`) are
+    evaluated once and reused across spacecraft, not recomputed inside the
+    loop: for large `alpha` arrays this is the dominant cost, so this
+    matters for performance parity with `lisaorbits`, not just style.
+    """
+    a = ASTRONOMICAL_UNIT.value
+    e = armlength / (2 * a * np.sqrt(3))
+    sin_a, cos_a = np.sin(alpha), np.cos(alpha)
+    sin_a_cos_a = sin_a * cos_a
+    sin_a2, cos_a2 = sin_a ** 2, cos_a ** 2
+    out = np.empty((len(alpha), len(sc), 3))
+    for k, n in enumerate(sc):
+        beta_n = (n - 1) * 2 * np.pi / 3.0
+        sin_b, cos_b = np.sin(beta_n), np.cos(beta_n)
+        out[:, k, 0] = a * cos_a + a * e * (
+            sin_a_cos_a * sin_b - (1 + sin_a2) * cos_b)
+        out[:, k, 1] = a * sin_a + a * e * (
+            sin_a_cos_a * cos_b - (1 + cos_a2) * sin_b)
+        out[:, k, 2] = -np.sqrt(3) * a * e * (
+            cos_a * cos_b + sin_a * sin_b)  # cos(alpha - beta_n)
+    return out
+
+
+def _equal_arm_orbit_velocity(alpha, omega, armlength, sc):
+    """d/dt of `_equal_arm_orbit_position`, given the (constant) guiding-
+    center angular frequency `omega` = d(alpha)/dt [rad/s]. Exact analytic
+    derivative of the same closed-form position expansion (chain rule
+    through `alpha(t)`), not a finite-difference approximation -- the same
+    precision-in-principle as `lisaorbits.EqualArmlengthOrbits.
+    compute_velocity`, which differentiates the identical formula. See
+    `_equal_arm_orbit_position` for the per-spacecraft caching rationale.
+    """
+    a = ASTRONOMICAL_UNIT.value
+    e = armlength / (2 * a * np.sqrt(3))
+    sin_a, cos_a = np.sin(alpha), np.cos(alpha)
+    sin_a_cos_a = sin_a * cos_a
+    cos2_minus_sin2 = cos_a ** 2 - sin_a ** 2
+    out = np.empty((len(alpha), len(sc), 3))
+    for k, n in enumerate(sc):
+        beta_n = (n - 1) * 2 * np.pi / 3.0
+        sin_b, cos_b = np.sin(beta_n), np.cos(beta_n)
+        out[:, k, 0] = omega * (
+            -a * sin_a + a * e * (
+                cos2_minus_sin2 * sin_b - 2 * sin_a_cos_a * cos_b))
+        out[:, k, 1] = omega * (
+            a * cos_a + a * e * (
+                cos2_minus_sin2 * cos_b + 2 * sin_a_cos_a * sin_b))
+        out[:, k, 2] = omega * (
+            np.sqrt(3) * a * e * (
+                sin_a * cos_b - cos_a * sin_b))  # sin(alpha - beta_n)
+    return out
+
+
+def _equal_arm_orbit_acceleration(alpha, omega, armlength, sc):
+    """d^2/dt^2 of `_equal_arm_orbit_position`, i.e. d/dt of
+    `_equal_arm_orbit_velocity`. See `_equal_arm_orbit_position` for the
+    precision/performance rationale.
+    """
+    a = ASTRONOMICAL_UNIT.value
+    e = armlength / (2 * a * np.sqrt(3))
+    sin_a, cos_a = np.sin(alpha), np.cos(alpha)
+    sin_a_cos_a = sin_a * cos_a
+    sin_a2, cos_a2 = sin_a ** 2, cos_a ** 2
+    omega2 = omega ** 2
+    out = np.empty((len(alpha), len(sc), 3))
+    for k, n in enumerate(sc):
+        beta_n = (n - 1) * 2 * np.pi / 3.0
+        sin_b, cos_b = np.sin(beta_n), np.cos(beta_n)
+        out[:, k, 0] = omega2 * (
+            -a * cos_a - 4 * a * e * (
+                sin_a_cos_a * sin_b + (0.5 - sin_a2) * cos_b))
+        out[:, k, 1] = omega2 * (
+            -a * sin_a - 4 * a * e * (
+                sin_a_cos_a * cos_b + (0.5 - cos_a2) * sin_b))
+        out[:, k, 2] = omega2 * (
+            np.sqrt(3) * a * e * (
+                cos_a * cos_b + sin_a * sin_b))  # cos(alpha - beta_n)
+    return out
+
+
+def _kepler_orbit_elements(armlength, semi_major_axis):
+    """Eccentricity and inclination for the second-order-in-eccentricity
+    equal-arm Kepler constellation: three spacecraft on independent
+    two-body Kepler ellipses (same semi-major axis and eccentricity,
+    tilted out of the ecliptic by a common inclination, each rotated 120
+    degrees in mean anomaly and ascending node from the others), chosen
+    so mutual distances stay close to `armlength` to second order in
+    eccentricity -- one order better than `_equal_arm_orbit_position`'s
+    flat construction.
+
+    Standard "tilted formation" result (same construction as
+    `lisaorbits.KeplerianOrbits`); implemented here independently and
+    validated against its output to near machine precision.
+    """
+    alpha = armlength / (2.0 * semi_major_axis)
+    delta = 5.0 / 8.0
+    nu = np.pi / 3.0 + delta * alpha
+    e = np.sqrt(
+        1 + 4 * alpha * np.cos(nu) / np.sqrt(3) + 4 * alpha ** 2 / 3) - 1
+    tan_i = (alpha * np.sin(nu)
+             / (np.sqrt(3) / 2.0 + alpha * np.cos(nu)))
+    cos_i = 1.0 / np.sqrt(1 + tan_i ** 2)
+    sin_i = tan_i * cos_i
+    return e, cos_i, sin_i
+
+
+def _kepler_eccentric_anomaly(mean_anomaly, e, kepler_order=2):
+    """Solve Kepler's equation `psi - e*sin(psi) = mean_anomaly` for the
+    eccentric anomaly `psi`: start from the low-eccentricity "equation
+    of the center" series (accurate to O(e^4)) and refine with
+    `kepler_order` Newton-Raphson iterations. For LISA/Taiji's small
+    eccentricities (~1e-2), one iteration already reaches machine
+    precision.
+    """
+    m = mean_anomaly
+    psi = (m + (e - e ** 3 / 8.0) * np.sin(m)
+           + 0.5 * e ** 2 * np.sin(2 * m)
+           + 3.0 / 8.0 * e ** 3 * np.sin(3 * m))
+    for _ in range(kepler_order):
+        error = psi - e * np.sin(psi) - m
+        psi = psi - error / (1 - e * np.cos(psi))
+    return psi
+
+
+def _kepler_orbit_position(alpha, armlength, semi_major_axis, sc,
+                           kepler_order=2):
+    """Spacecraft position(s) for the second-order-in-eccentricity
+    tilted-Kepler-ellipse equal-arm constellation (see
+    `_kepler_orbit_elements`), at guiding-center phase `alpha` [rad].
+    """
+    e, cos_i, sin_i = _kepler_orbit_elements(armlength, semi_major_axis)
+    a = semi_major_axis
+    out = np.empty((len(alpha), len(sc), 3))
+    for k, n in enumerate(sc):
+        theta_n = (n - 1) * 2 * np.pi / 3.0
+        psi = _kepler_eccentric_anomaly(
+            alpha - theta_n, e, kepler_order=kepler_order)
+        cos_psi, sin_psi = np.cos(psi), np.sin(psi)
+        ref_x = a * cos_i * (cos_psi - e)
+        ref_y = a * np.sqrt(1 - e ** 2) * sin_psi
+        ref_z = -a * sin_i * (cos_psi - e)
+        cos_lam, sin_lam = np.cos(theta_n), np.sin(theta_n)
+        out[:, k, 0] = cos_lam * ref_x - sin_lam * ref_y
+        out[:, k, 1] = sin_lam * ref_x + cos_lam * ref_y
+        out[:, k, 2] = ref_z
+    return out
+
+
+def _kepler_orbit_velocity(alpha, omega, armlength, semi_major_axis, sc,
+                           kepler_order=2):
+    """d/dt of `_kepler_orbit_position`, given the (constant) guiding-
+    center angular frequency `omega` = d(alpha)/dt [rad/s].
+    """
+    e, cos_i, sin_i = _kepler_orbit_elements(armlength, semi_major_axis)
+    a = semi_major_axis
+    out = np.empty((len(alpha), len(sc), 3))
+    for k, n in enumerate(sc):
+        theta_n = (n - 1) * 2 * np.pi / 3.0
+        psi = _kepler_eccentric_anomaly(
+            alpha - theta_n, e, kepler_order=kepler_order)
+        cos_psi, sin_psi = np.cos(psi), np.sin(psi)
+        dpsi_dt = omega / (1 - e * cos_psi)
+        ref_vx = -a * dpsi_dt * cos_i * sin_psi
+        ref_vy = a * dpsi_dt * np.sqrt(1 - e ** 2) * cos_psi
+        ref_vz = a * dpsi_dt * sin_i * sin_psi
+        cos_lam, sin_lam = np.cos(theta_n), np.sin(theta_n)
+        out[:, k, 0] = cos_lam * ref_vx - sin_lam * ref_vy
+        out[:, k, 1] = sin_lam * ref_vx + cos_lam * ref_vy
+        out[:, k, 2] = ref_vz
+    return out
+
+
+def _kepler_orbit_acceleration(alpha, omega, armlength, semi_major_axis,
+                               sc, kepler_order=2):
+    """d^2/dt^2 of `_kepler_orbit_position`. For an unperturbed two-body
+    Kepler ellipse, the acceleration is simply the Newtonian gravitational
+    acceleration towards the central body, `-n^2 a^3 r / |r|^3` (using
+    `n = omega`, `a = semi_major_axis`, matching the standard
+    :math:`\\ddot r = -GM r/|r|^3` with `GM = n^2 a^3` for this orbit's own
+    period) -- this holds regardless of eccentricity or orbit orientation,
+    so it is evaluated directly from the position, not by an independent
+    per-component derivative.
+    """
+    pos = _kepler_orbit_position(
+        alpha, armlength, semi_major_axis, sc, kepler_order=kepler_order)
+    r = np.linalg.norm(pos, axis=-1)
+    factor = -(omega ** 2) * (semi_major_axis ** 3) / r ** 3
+    return pos * factor[:, :, np.newaxis]
+
+
+class _LisaGuidingCenter:
+    """Mixin providing `_phase(t)` for LISA's guiding-center convention:
+    `t0` is added to *time* (`omega*(t+t0)`), a legacy convention kept for
+    BBHx compatibility. Combine with `_EqualArmConstellation`/
+    `_KeplerConstellation`; the concrete class's own `__init__` must set
+    `self.t0`.
+    """
+
+    def _phase(self, t):
+        return EARTH_ORBIT_ANGULAR_FREQUENCY * (t + self.t0)
+
+
+class _TaijiGuidingCenter:
+    """Mixin providing `_phase(t)` for Taiji's guiding-center convention:
+    `lead_angle` is added directly to *phase* (`omega*t + kappa0 +
+    lead_angle`) -- unlike LISA's time-offset convention above, the two
+    are not directly comparable term-for-term. Combine with
+    `_EqualArmConstellation`/`_KeplerConstellation`; the concrete class's
+    own `__init__` must set `self.kappa0`/`self.lead_angle`.
+    """
+
+    def _phase(self, t):
+        return EARTH_ORBIT_ANGULAR_FREQUENCY * t + self.kappa0 \
+            + self.lead_angle
+
+
+class _EqualArmConstellation:
+    """Mixin implementing `compute_position`/`compute_velocity`/
+    `compute_acceleration` for the rigid, circular, first-order-in-
+    eccentricity equal-arm constellation (Rubbo, Cornish & Poujade 2004,
+    Phys. Rev. D 69, 082003) -- shared by `LisaEqualArmOrbit` and
+    `TaijiEqualArmOrbit`, which differ only in their guiding-center phase
+    convention (see `_LisaGuidingCenter`/`_TaijiGuidingCenter`, combined
+    in via multiple inheritance) and their `armlength` default. The
+    concrete class's own `__init__` must set `self.armlength`.
+    """
+
+    def compute_position(self, t, sc=(1, 2, 3)):
+        """Spacecraft position(s) at time(s) `t`. See
+        `NumericOrbits.compute_position` for the calling convention.
+
+        Returns
+        -------
+        (N, M, 3) ndarray
+            Spacecraft position(s) in the SSB frame [m].
+        """
+        t = np.atleast_1d(np.asarray(t, dtype=float))
+        sc = np.atleast_1d(sc)
+        alpha = self._phase(t)
+        return _equal_arm_orbit_position(alpha, self.armlength, sc)
+
+    def compute_velocity(self, t, sc=(1, 2, 3)):
+        """Spacecraft velocity/ies at time(s) `t`, as the exact analytic
+        derivative of `compute_position` (not a finite-difference
+        approximation). See `NumericOrbits.compute_position` for the
+        calling convention.
+
+        Returns
+        -------
+        (N, M, 3) ndarray
+            Spacecraft velocity/ies in the SSB frame [m/s].
+        """
+        t = np.atleast_1d(np.asarray(t, dtype=float))
+        sc = np.atleast_1d(sc)
+        alpha = self._phase(t)
+        return _equal_arm_orbit_velocity(
+            alpha, EARTH_ORBIT_ANGULAR_FREQUENCY, self.armlength, sc)
+
+    def compute_acceleration(self, t, sc=(1, 2, 3)):
+        """Spacecraft acceleration(s) at time(s) `t`, as the exact
+        analytic second derivative of `compute_position`. See
+        `NumericOrbits.compute_position` for the calling convention.
+
+        Returns
+        -------
+        (N, M, 3) ndarray
+            Spacecraft acceleration(s) in the SSB frame [m/s^2].
+        """
+        t = np.atleast_1d(np.asarray(t, dtype=float))
+        sc = np.atleast_1d(sc)
+        alpha = self._phase(t)
+        return _equal_arm_orbit_acceleration(
+            alpha, EARTH_ORBIT_ANGULAR_FREQUENCY, self.armlength, sc)
+
+
+class _KeplerConstellation:
+    """Mixin implementing `compute_position`/`compute_velocity`/
+    `compute_acceleration` for the second-order-in-eccentricity tilted-
+    Kepler-ellipse equal-arm constellation (see `_kepler_orbit_elements`)
+    -- shared by `LisaKeplerianOrbit` and `TaijiKeplerianOrbit`, same
+    combination pattern as `_EqualArmConstellation`. The concrete class's
+    own `__init__` must set `self.armlength`/`self.semi_major_axis`/
+    `self.kepler_order`.
+    """
+
+    def compute_position(self, t, sc=(1, 2, 3)):
+        """Spacecraft position(s) at time(s) `t`. See
+        `NumericOrbits.compute_position` for the calling convention.
+
+        Returns
+        -------
+        (N, M, 3) ndarray
+            Spacecraft position(s) in the SSB frame [m].
+        """
+        t = np.atleast_1d(np.asarray(t, dtype=float))
+        sc = np.atleast_1d(sc)
+        alpha = self._phase(t)
+        return _kepler_orbit_position(
+            alpha, self.armlength, self.semi_major_axis, sc,
+            kepler_order=self.kepler_order)
+
+    def compute_velocity(self, t, sc=(1, 2, 3)):
+        """Spacecraft velocity/ies at time(s) `t`. See
+        `NumericOrbits.compute_position` for the calling convention.
+
+        Returns
+        -------
+        (N, M, 3) ndarray
+            Spacecraft velocity/ies in the SSB frame [m/s].
+        """
+        t = np.atleast_1d(np.asarray(t, dtype=float))
+        sc = np.atleast_1d(sc)
+        alpha = self._phase(t)
+        return _kepler_orbit_velocity(
+            alpha, EARTH_ORBIT_ANGULAR_FREQUENCY, self.armlength,
+            self.semi_major_axis, sc, kepler_order=self.kepler_order)
+
+    def compute_acceleration(self, t, sc=(1, 2, 3)):
+        """Spacecraft acceleration(s) at time(s) `t`. See
+        `NumericOrbits.compute_position` for the calling convention.
+
+        Returns
+        -------
+        (N, M, 3) ndarray
+            Spacecraft acceleration(s) in the SSB frame [m/s^2].
+        """
+        t = np.atleast_1d(np.asarray(t, dtype=float))
+        sc = np.atleast_1d(sc)
+        alpha = self._phase(t)
+        return _kepler_orbit_acceleration(
+            alpha, EARTH_ORBIT_ANGULAR_FREQUENCY, self.armlength,
+            self.semi_major_axis, sc, kepler_order=self.kepler_order)
+
+
+class LisaEqualArmOrbit(_LisaGuidingCenter, _EqualArmConstellation):
+    """Idealized LISA heliocentric orbit: the same rigid, circular
+    (first-order-in-eccentricity) equal-arm triangle already used by
+    `pycbc.coordinates.space.lisa_position_ssb`/
+    `rotation_matrix_ssb_to_lisa` (the `orbit=None` default of
+    `ssb_to_lisa`/`lisa_to_ssb`/etc.), exposed as an explicit
+    `OrbitProvider` -- e.g. to pass to `constellation_frame`, or as a
+    baseline against a numeric or other-mission orbit.
+    `LisaEqualArmOrbit()` with no arguments reproduces the
+    existing `orbit=None` behavior exactly.
+
+    Unlike `TaijiEqualArmOrbit`/`TianQinAnalyticOrbit`, `t0` does *not*
+    default to a real-Earth-anchored epoch -- it's the pre-existing
+    constant tuned for BBHx compatibility, and changing that default
+    here would silently disagree with `pycbc.coordinates.space`'s own
+    default. Pass a different `t0` for a different reference epoch.
+
+    Parameters
+    ----------
+    armlength : float, optional
+        Constellation arm length [m]. Default 2.5e9 (design value).
+    t0 : float or None, optional
+        Reference time offset [s], with the same meaning as in
+        `pycbc.coordinates.space.lisa_position_ssb`. Default None, which
+        uses `pycbc.coordinates.space.TIME_OFFSET_20_DEGREES`.
+    """
+
+    def __init__(self, armlength=2.5e9, t0=None):
+        self.armlength = float(armlength)
+        if t0 is None:
+            from pycbc.coordinates.space import TIME_OFFSET_20_DEGREES
+            t0 = TIME_OFFSET_20_DEGREES
+        self.t0 = float(t0)
+
+
+class LisaKeplerianOrbit(_LisaGuidingCenter, _KeplerConstellation):
+    """LISA heliocentric orbit built from a genuine two-body Kepler
+    ellipse per spacecraft, rather than `LisaEqualArmOrbit`'s flat,
+    first-order-in-eccentricity expansion: three spacecraft on
+    independent, common-inclination, common-eccentricity ellipses, each
+    rotated 120 degrees from the others in mean anomaly and ascending
+    node, with eccentricity/inclination from a standard "tilted
+    formation" equal-arm construction (see `_kepler_orbit_elements`),
+    accurate to second order in eccentricity. Independently implemented
+    and validated to near machine precision against
+    `lisaorbits.KeplerianOrbits`, not ported from it.
+
+    Not strictly "more accurate" than `LisaEqualArmOrbit`: that first-
+    order construction happens to keep LISA's arm length essentially
+    exactly constant over a year, while this true-Kepler construction has
+    a real ~0.2% arm-length variation (an inherent property of the
+    construction, not a numerical error). Use this to match reference
+    data built with a true-Kepler-ellipse convention (e.g. some LDC/TDC
+    products); use `LisaEqualArmOrbit` otherwise (it's also this
+    module's pre-existing default).
+
+    Parameters
+    ----------
+    armlength : float, optional
+        Constellation arm length [m]. Default 2.5e9 (design value).
+    semi_major_axis : float, optional
+        Guiding-center semi-major axis [m]. Default 1 AU.
+    t0 : float or None, optional
+        Reference time offset [s], with the same meaning as in
+        `LisaEqualArmOrbit`. Default None, which uses
+        `pycbc.coordinates.space.TIME_OFFSET_20_DEGREES`.
+    kepler_order : int, optional
+        Number of Newton-Raphson iterations used to solve Kepler's
+        equation for the eccentric anomaly. Default 2 (converges to
+        machine precision for LISA's eccentricity well within this).
+    """
+
+    def __init__(self, armlength=2.5e9, semi_major_axis=None, t0=None,
+                kepler_order=2):
+        self.armlength = float(armlength)
+        self.semi_major_axis = (
+            ASTRONOMICAL_UNIT.value if semi_major_axis is None
+            else float(semi_major_axis))
+        if t0 is None:
+            from pycbc.coordinates.space import TIME_OFFSET_20_DEGREES
+            t0 = TIME_OFFSET_20_DEGREES
+        self.t0 = float(t0)
+        self.kepler_order = int(kepler_order)
+
+
+class TaijiEqualArmOrbit(_TaijiGuidingCenter, _EqualArmConstellation):
+    """Idealized Taiji heliocentric orbit: a rigid, circular (first-order-
+    in-eccentricity) equal-arm triangle, per Rubbo, Cornish & Poujade
+    2004 (Phys. Rev. D 69, 082003) -- the same functional form as the
+    LISA orbit in `pycbc.coordinates.space.lisa_position_ssb`/
+    `rotation_matrix_ssb_to_lisa`, but leading the Earth-like guiding
+    center by `lead_angle` (design value 20 degrees) instead of trailing
+    it, with Taiji's own arm length.
+
+    For prototyping (e.g. single-link response and TDI work) ahead of an
+    official numerical orbit product -- not a substitute for real
+    mission ephemeris; use `NumericOrbits.from_file` once one exists.
+
+    Parameters
+    ----------
+    armlength : float, optional
+        Constellation arm length [m]. Default 3.0e9 (design value).
+    lead_angle : float, optional
+        Angle by which the constellation leads the Earth-like guiding
+        center [rad] -- added directly to orbital phase, so positive means
+        ahead of the guiding center (unlike LISA's `t0`, which is added to
+        *time* to produce a trailing offset; the two are not directly
+        comparable term-for-term). Default ``deg2rad(20)`` (design value).
+    kappa0 : float or None, optional
+        Reference ecliptic longitude of the Earth-like guiding center at
+        `t=0` [rad], before `lead_angle` is added. Default None, which
+        anchors it to the real Earth's ecliptic longitude at SSB time 0
+        (via `pycbc.coordinates.space.earth_position_ssb`), so that
+        `TaijiEqualArmOrbit()` with no arguments is roughly realistic
+        "today". Pass an explicit value for an arbitrary or
+        scenario-specific reference epoch instead.
+    """
+
+    def __init__(self, armlength=3.0e9, lead_angle=_TAIJI_LEAD_ANGLE,
+                kappa0=None):
+        self.armlength = float(armlength)
+        self.lead_angle = float(lead_angle)
+        if kappa0 is None:
+            kappa0 = _real_earth_ecliptic_longitude(0.0)
+        self.kappa0 = float(kappa0)
+
+
+class TaijiKeplerianOrbit(_TaijiGuidingCenter, _KeplerConstellation):
+    """Taiji heliocentric orbit, accurate to second order in eccentricity
+    (rather than `TaijiEqualArmOrbit`'s first order) -- see
+    `LisaKeplerianOrbit` for the underlying construction. Leads the
+    Earth-like guiding center by `lead_angle` (design value 20 degrees),
+    with Taiji's own arm length.
+
+    Parameters
+    ----------
+    armlength : float, optional
+        Constellation arm length [m]. Default 3.0e9 (design value).
+    semi_major_axis : float, optional
+        Guiding-center semi-major axis [m]. Default 1 AU.
+    lead_angle : float, optional
+        Angle by which the constellation leads the Earth-like guiding
+        center [rad] -- added directly to orbital phase, so positive means
+        ahead of the guiding center (unlike LISA's `t0`, which is added to
+        *time* to produce a trailing offset; the two are not directly
+        comparable term-for-term). Default ``deg2rad(20)`` (design value).
+    kappa0 : float or None, optional
+        Reference ecliptic longitude of the Earth-like guiding center at
+        `t=0` [rad], before `lead_angle` is added. Default None, which
+        anchors it to the real Earth's ecliptic longitude at SSB time 0,
+        as in `TaijiEqualArmOrbit`.
+    kepler_order : int, optional
+        See `LisaKeplerianOrbit`. Default 2.
+    """
+
+    def __init__(self, armlength=3.0e9, semi_major_axis=None,
+                lead_angle=_TAIJI_LEAD_ANGLE, kappa0=None, kepler_order=2):
+        self.armlength = float(armlength)
+        self.semi_major_axis = (
+            ASTRONOMICAL_UNIT.value if semi_major_axis is None
+            else float(semi_major_axis))
+        self.lead_angle = float(lead_angle)
+        if kappa0 is None:
+            kappa0 = _real_earth_ecliptic_longitude(0.0)
+        self.kappa0 = float(kappa0)
+        self.kepler_order = int(kepler_order)
+
+
+class TianQinAnalyticOrbit:
+    """Idealized analytic TianQin geocentric orbit: a fast, rigidly-
+    rotating triangular constellation whose plane is fixed in inertial
+    space (pointing towards the calibration source RX J0806.3+1527),
+    around a guiding center coincident with the Earth, per Hu et al 2018
+    (Class. Quantum Grav. 35, 095008). Unlike LISA/Taiji, the triangle's
+    shape and orientation are held fixed rather than letting each
+    spacecraft flex on its own ellipse.
+
+    `guiding_center` picks how the Earth-like guiding center moves:
+    `'circular'` (default) is a pure circular heliocentric orbit,
+    neglecting Earth's ~1.7% eccentricity; `'real_earth'` uses astropy's
+    JPL ephemeris instead, more accurate but needing a lookup (and, for
+    acceleration, a finite difference, since astropy has no direct
+    acceleration) per call rather than a closed form.
+
+    Not a substitute for real mission ephemeris, same caveat as
+    `TaijiEqualArmOrbit`.
+
+    Parameters
+    ----------
+    armlength : float, optional
+        Constellation arm length [m]. Default `sqrt(3) * 1e8` (the
+        theoretical design value; matches `pycbc.psd.analytical_space`'s
+        TianQin PSD functions).
+    lambda_s, beta_s : float, optional
+        Ecliptic longitude/latitude of the calibration source RX
+        J0806.3+1527 [rad], which fixes the constellation plane's
+        orientation. Defaults are the design values (120.5 deg, -4.7 deg).
+    rotation_period : float, optional
+        Constellation self-rotation period [s]. Default 3.65 days (design
+        value).
+    initial_orbit_phase : float, optional
+        Initial fast-rotation phase of the first spacecraft [rad].
+        Default 0 -- unlike `kappa0` below, there is no "real" reference
+        for this (it is an arbitrary, mission-dependent choice).
+    kappa0 : float or None, optional
+        Reference ecliptic longitude of the Earth-like guiding center at
+        `t=0` [rad], used only when `guiding_center='circular'`. Default
+        None, which anchors it to the real Earth's ecliptic longitude at
+        SSB time 0 (via `pycbc.coordinates.space.earth_position_ssb`), so
+        that `TianQinAnalyticOrbit()` with no arguments is roughly
+        realistic "today". Pass an explicit value for an arbitrary or
+        scenario-specific reference epoch instead.
+    guiding_center : {'circular', 'real_earth'}, optional
+        See above. Default `'circular'` (unchanged default behavior).
+    """
+
+    def __init__(self, armlength=_TIANQIN_ARMLENGTH, lambda_s=_TIANQIN_LAMBDA_S,
+                beta_s=_TIANQIN_BETA_S, rotation_period=3.65 * 86400.0,
+                initial_orbit_phase=0.0, kappa0=None,
+                guiding_center='circular'):
+        self.armlength = float(armlength)
+        self.lambda_s = float(lambda_s)
+        self.beta_s = float(beta_s)
+        self.rotation_period = float(rotation_period)
+        self.initial_orbit_phase = float(initial_orbit_phase)
+        if guiding_center not in ('circular', 'real_earth'):
+            raise ValueError(
+                "guiding_center must be 'circular' or 'real_earth', got "
+                f"{guiding_center!r}")
+        self.guiding_center = guiding_center
+        if kappa0 is None:
+            kappa0 = _real_earth_ecliptic_longitude(0.0)
+        self.kappa0 = float(kappa0)
+
+    def _guiding_center_position(self, t):
+        if self.guiding_center == 'real_earth':
+            pos, _ = _real_earth_position_velocity(t)
+            return pos
+        a = ASTRONOMICAL_UNIT.value
+        alpha_earth = EARTH_ORBIT_ANGULAR_FREQUENCY * t + self.kappa0
+        return a * np.stack([
+            np.cos(alpha_earth), np.sin(alpha_earth),
+            np.zeros_like(t)], axis=-1)
+
+    def _guiding_center_position_velocity(self, t):
+        if self.guiding_center == 'real_earth':
+            return _real_earth_position_velocity(t)
+        a = ASTRONOMICAL_UNIT.value
+        omega_e = EARTH_ORBIT_ANGULAR_FREQUENCY
+        alpha_earth = omega_e * t + self.kappa0
+        pos = a * np.stack([
+            np.cos(alpha_earth), np.sin(alpha_earth),
+            np.zeros_like(t)], axis=-1)
+        vel = a * omega_e * np.stack([
+            -np.sin(alpha_earth), np.cos(alpha_earth),
+            np.zeros_like(t)], axis=-1)
+        return pos, vel
+
+    def _guiding_center_acceleration(self, t):
+        if self.guiding_center == 'real_earth':
+            # astropy does not expose Earth's acceleration directly;
+            # a small central finite difference of its (real, ephemeris-
+            # based) velocity is far more accurate here than falling back
+            # to an idealized two-body -GM_sun*r/|r|^3 approximation,
+            # which would reintroduce the very approximation this mode
+            # exists to avoid.
+            dt = 1.0
+            _, vel_plus = _real_earth_position_velocity(t + dt)
+            _, vel_minus = _real_earth_position_velocity(t - dt)
+            return (vel_plus - vel_minus) / (2 * dt)
+        a = ASTRONOMICAL_UNIT.value
+        omega_e = EARTH_ORBIT_ANGULAR_FREQUENCY
+        alpha_earth = omega_e * t + self.kappa0
+        return -a * omega_e ** 2 * np.stack([
+            np.cos(alpha_earth), np.sin(alpha_earth),
+            np.zeros_like(t)], axis=-1)
+
+    def compute_position(self, t, sc=(1, 2, 3)):
+        """Spacecraft position(s) at time(s) `t`. See
+        `NumericOrbits.compute_position` for the calling convention.
+
+        Returns
+        -------
+        (N, M, 3) ndarray
+            Spacecraft position(s) in the SSB frame [m].
+        """
+        t = np.atleast_1d(np.asarray(t, dtype=float))
+        sc = np.atleast_1d(sc)
+        earth = self._guiding_center_position(t)
+        f_sc = 1.0 / self.rotation_period
+        out = np.empty((len(t), len(sc), 3))
+        for k, n in enumerate(sc):
+            kappa_n = 2 * np.pi / 3.0 * (n - 1) + self.initial_orbit_phase
+            phase = 2 * np.pi * f_sc * t + kappa_n
+            xn = (self.armlength / np.sqrt(3)) * (
+                np.sin(self.beta_s) * np.cos(self.lambda_s)
+                * np.sin(phase)
+                + np.sin(self.lambda_s) * np.cos(phase))
+            yn = (self.armlength / np.sqrt(3)) * (
+                np.sin(self.beta_s) * np.sin(self.lambda_s)
+                * np.sin(phase)
+                - np.cos(self.lambda_s) * np.cos(phase))
+            zn = -(self.armlength / np.sqrt(3)) \
+                * np.cos(self.beta_s) * np.sin(phase)
+            out[:, k, 0] = earth[:, 0] + xn
+            out[:, k, 1] = earth[:, 1] + yn
+            out[:, k, 2] = earth[:, 2] + zn
+        return out
+
+    def compute_velocity(self, t, sc=(1, 2, 3)):
+        """Spacecraft velocity/ies at time(s) `t`, exact (not a finite-
+        difference approximation): with `guiding_center='circular'`, both
+        the guiding center and the fast-rotation term have constant
+        angular frequency, so each is a simple chain-rule derivative of
+        `compute_position`; with `'real_earth'`, the guiding-center
+        velocity comes directly from the ephemeris instead. See
+        `NumericOrbits.compute_position` for the calling convention.
+
+        Returns
+        -------
+        (N, M, 3) ndarray
+            Spacecraft velocity/ies in the SSB frame [m/s].
+        """
+        t = np.atleast_1d(np.asarray(t, dtype=float))
+        sc = np.atleast_1d(sc)
+        _, earth_vel = self._guiding_center_position_velocity(t)
+        omega_sc = 2 * np.pi / self.rotation_period
+        out = np.empty((len(t), len(sc), 3))
+        for k, n in enumerate(sc):
+            kappa_n = 2 * np.pi / 3.0 * (n - 1) + self.initial_orbit_phase
+            phase = omega_sc * t + kappa_n
+            vxn = omega_sc * (self.armlength / np.sqrt(3)) * (
+                np.sin(self.beta_s) * np.cos(self.lambda_s)
+                * np.cos(phase)
+                - np.sin(self.lambda_s) * np.sin(phase))
+            vyn = omega_sc * (self.armlength / np.sqrt(3)) * (
+                np.sin(self.beta_s) * np.sin(self.lambda_s)
+                * np.cos(phase)
+                + np.cos(self.lambda_s) * np.sin(phase))
+            vzn = -omega_sc * (self.armlength / np.sqrt(3)) \
+                * np.cos(self.beta_s) * np.cos(phase)
+            out[:, k, 0] = earth_vel[:, 0] + vxn
+            out[:, k, 1] = earth_vel[:, 1] + vyn
+            out[:, k, 2] = earth_vel[:, 2] + vzn
+        return out
+
+    def compute_acceleration(self, t, sc=(1, 2, 3)):
+        """Spacecraft acceleration(s) at time(s) `t`, exact: with
+        `guiding_center='circular'`, both terms are uniform circular
+        motion, so each term's acceleration is -omega^2 times that
+        term's position; with `'real_earth'`, the guiding-center
+        contribution is a finite difference of the real ephemeris
+        velocity instead (see `_guiding_center_acceleration`). See
+        `NumericOrbits.compute_position` for the calling convention.
+
+        Returns
+        -------
+        (N, M, 3) ndarray
+            Spacecraft acceleration(s) in the SSB frame [m/s^2].
+        """
+        t = np.atleast_1d(np.asarray(t, dtype=float))
+        sc = np.atleast_1d(sc)
+        earth_acc = self._guiding_center_acceleration(t)
+        omega_sc = 2 * np.pi / self.rotation_period
+        out = np.empty((len(t), len(sc), 3))
+        for k, n in enumerate(sc):
+            kappa_n = 2 * np.pi / 3.0 * (n - 1) + self.initial_orbit_phase
+            phase = omega_sc * t + kappa_n
+            xn = (self.armlength / np.sqrt(3)) * (
+                np.sin(self.beta_s) * np.cos(self.lambda_s)
+                * np.sin(phase)
+                + np.sin(self.lambda_s) * np.cos(phase))
+            yn = (self.armlength / np.sqrt(3)) * (
+                np.sin(self.beta_s) * np.sin(self.lambda_s)
+                * np.sin(phase)
+                - np.cos(self.lambda_s) * np.cos(phase))
+            zn = -(self.armlength / np.sqrt(3)) \
+                * np.cos(self.beta_s) * np.sin(phase)
+            out[:, k, 0] = earth_acc[:, 0] - omega_sc ** 2 * xn
+            out[:, k, 1] = earth_acc[:, 1] - omega_sc ** 2 * yn
+            out[:, k, 2] = earth_acc[:, 2] - omega_sc ** 2 * zn
+        return out
+
+
+def constellation_frame(t, orbit, sc=(1, 2, 3)):
+    """Compute the instantaneous constellation centroid and the rotation
+    matrix from the SSB frame to a frame comoving with the constellation,
+    directly from the spacecraft positions supplied by `orbit`.
+
+    Generalizes `rotation_matrix_ssb_to_lisa`/`lisa_position_ssb` in
+    `pycbc.coordinates.space` (fixed circular LISA orbit) to any
+    3-spacecraft triangular constellation given analytic or numerical
+    positions -- e.g. LISA, Taiji, or TianQin.
+
+    For each time sample, the instantaneous frame is built from the three
+    spacecraft positions as:
+
+    * the centroid of the three spacecraft;
+    * the plane normal (right-handed with respect to spacecraft ordering
+      1 -> 2 -> 3), taken as the z-axis;
+    * the projection onto that plane of the direction from the centroid to
+      spacecraft 1, taken as the x-axis;
+    * completing a right-handed orthonormal triad for the y-axis.
+
+    Parameters
+    ----------
+    t : (N,) array-like
+        SSB time(s) [s] at which to evaluate the frame.
+    orbit : OrbitProvider
+        Any object exposing `compute_position(t, sc)` with the calling
+        convention of `lisaorbits.Orbits` (e.g. a `lisaorbits.Orbits`
+        instance, or a `NumericOrbits` instance).
+    sc : (3,) array-like, optional
+        1-indexed spacecraft labels identifying the 3 constellation
+        vertices, in the order used to define the plane normal and the
+        reference (x-axis) spacecraft. Default (1, 2, 3).
+
+    Returns
+    -------
+    centroid : (N, 3) ndarray
+        Constellation centroid position in the SSB frame [m].
+    rotation : (N, 3, 3) ndarray
+        Rotation matrix from the SSB frame to the constellation frame at
+        each time sample, such that ``v_constellation = rotation @ v_ssb``.
+    """
+    t = np.atleast_1d(np.asarray(t, dtype=float))
+    pos = orbit.compute_position(t, sc)  # (N, 3, 3)
+    r1, r2, r3 = pos[:, 0], pos[:, 1], pos[:, 2]
+
+    centroid = (r1 + r2 + r3) / 3.0
+
+    normal = np.cross(r2 - r1, r3 - r1)
+    normal = normal / np.linalg.norm(normal, axis=-1, keepdims=True)
+
+    x_raw = r1 - centroid
+    # remove any out-of-plane component so the x-axis is exactly in-plane
+    x_axis = x_raw - np.sum(x_raw * normal, axis=-1, keepdims=True) * normal
+    x_axis = x_axis / np.linalg.norm(x_axis, axis=-1, keepdims=True)
+
+    y_axis = np.cross(normal, x_axis)
+
+    # rows are the new (constellation-frame) basis vectors, expressed in the
+    # SSB basis, so that `rotation @ v_ssb` gives the components of `v_ssb`
+    # in the constellation frame.
+    rotation = np.stack([x_axis, y_axis, normal], axis=1)  # (N, 3, 3)
+
+    # The constellation geometry alone only pins the frame down to a
+    # rotation about its own normal and the sign of the in-plane axes; fix
+    # that by matching rotation_matrix_ssb_to_lisa's convention (a 180
+    # degree rotation about the normal). Pure axis-labeling, no physics
+    # effect -- verified to reproduce rotation_matrix_ssb_to_lisa exactly
+    # in the circular-orbit limit, see test_coordinates_space_orbit.py.
+    axis_convention = np.diag([-1.0, -1.0, 1.0])
+    rotation = rotation @ axis_convention
+
+    return centroid, rotation
+
+
+def _solve_frame_arrival_time(t_known, k_ssb, position_fn, forward):
+    """Shared `fsolve` pattern behind `t_lisa_from_ssb`/`t_ssb_from_t_lisa`,
+    `t_geo_from_ssb`/`t_ssb_from_t_geo` (in `pycbc.coordinates.space`), and
+    `t_detector_from_ssb`/`t_ssb_from_t_detector` below: solve
+    `t - t_other - dot(k, position(t)) / c = 0` for whichever side is
+    unknown, given a light-travel-time relationship between the SSB origin
+    and a moving frame's origin.
+
+    Parameters
+    ----------
+    t_known : float
+        The time at the known side of the relationship [s].
+    k_ssb : array-like
+        The unit propagation vector of the GW signal in the SSB frame.
+    position_fn : callable
+        `position_fn(t)` returns the moving frame's origin position [m] in
+        the SSB frame at SSB time `t`.
+    forward : bool
+        True solves for the frame's own time given `t_known = t_ssb` (the
+        frame's position depends on the unknown itself, so `position_fn`
+        is re-evaluated inside the root-solve). False solves for `t_ssb`
+        given `t_known` = the frame's own time (the frame's position is
+        evaluated once, at the known time, since it doesn't depend on the
+        unknown `t_ssb`).
+
+    Returns
+    -------
+    float
+        The time at the unknown side of the relationship [s].
+    """
+    k_ssb = np.ravel(np.asarray(k_ssb, dtype=float))
+    if forward:
+        def equation(t):
+            p = np.ravel(np.asarray(position_fn(t[0]), dtype=float))
+            return t[0] - t_known - np.dot(k_ssb, p) / SPEED_OF_LIGHT.value
+    else:
+        p = np.ravel(np.asarray(position_fn(t_known), dtype=float))
+
+        def equation(t):
+            return t_known - t[0] - np.dot(k_ssb, p) / SPEED_OF_LIGHT.value
+    return fsolve(equation, t_known)[0]
+
+
+def t_detector_from_ssb(t_ssb, k_ssb, orbit, sc=(1, 2, 3)):
+    """Compute the time at which a GW signal arrives at the constellation
+    centroid, given the time and propagation direction in the SSB frame.
+
+    This generalizes `pycbc.coordinates.space.t_lisa_from_ssb` to accept an
+    arbitrary orbit provider instead of the fixed circular LISA orbit. The
+    constellation is moving, so the arrival time is found by solving the
+    implicit light-travel-time equation self-consistently, exactly as in the
+    original function.
+
+    Parameters
+    ----------
+    t_ssb : float
+        The time at which the GW signal arrives at the origin of the SSB
+        frame [s].
+    k_ssb : (3,) array-like
+        The unit propagation vector of the GW signal in the SSB frame.
+    orbit : OrbitProvider
+        Any object exposing `compute_position(t, sc)`, see
+        `constellation_frame`.
+    sc : (3,) array-like, optional
+        1-indexed spacecraft labels defining the constellation. Default
+        (1, 2, 3).
+
+    Returns
+    -------
+    float
+        The time at which the GW signal arrives at the constellation
+        centroid [s].
+    """
+    def position_fn(t):
+        return constellation_frame([t], orbit, sc=sc)[0][0]
+    return _solve_frame_arrival_time(t_ssb, k_ssb, position_fn, forward=True)
+
+
+def t_ssb_from_t_detector(t_detector, k_ssb, orbit, sc=(1, 2, 3)):
+    """Compute the time at which a GW signal arrives at the origin of the
+    SSB frame, given the arrival time at the constellation centroid and the
+    propagation direction in the SSB frame.
+
+    Inverse of `t_detector_from_ssb`; see that function for parameter and
+    return conventions.
+    """
+    def position_fn(t):
+        return constellation_frame([t], orbit, sc=sc)[0][0]
+    return _solve_frame_arrival_time(
+        t_detector, k_ssb, position_fn, forward=False)
+
+
+__all__ = [
+    'NumericOrbits',
+    'LisaEqualArmOrbit',
+    'LisaKeplerianOrbit',
+    'TaijiEqualArmOrbit',
+    'TaijiKeplerianOrbit',
+    'TianQinAnalyticOrbit',
+    'constellation_frame',
+    't_detector_from_ssb',
+    't_ssb_from_t_detector',
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ pycbc = { path = ".", editable = true, extras = ["test"] }
 
 [tool.pixi.environments]
 default = { features = ["bbhx"], solve-group = "default" }
-unittest = { features = ["bbhx"], solve-group = "default" }
+unittest = { features = ["bbhx", "lisaorbits"], solve-group = "default" }
 help = { features = ["help", "bbhx"], solve-group = "default" }
 search = { features = ["search", "bbhx"], solve-group = "default" }
 inference = { features = ["inference", "bbhx"], solve-group = "default" }
@@ -45,6 +45,15 @@ openblas = "*"
 [tool.pixi.feature.bbhx.target.linux-64.pypi-dependencies]
 BBHx = { git = "https://github.com/titodalcanton/BBHx.git", rev = "py39-and-cleanup" }
 pycbc-bbhx-plugin = { git = "https://github.com/gwastro/BBHX-waveform-model.git" }
+
+[tool.pixi.feature.lisaorbits.pypi-dependencies]
+# No version pin: lisaorbits >= 3.0 requires Python >= 3.12, so on the
+# Python 3.11 leg pixi resolves this down to the latest 3.8-compatible
+# release (2.4.2) instead of failing to solve the environment at all.
+# test_coordinates_space_orbit.py's lisaorbits>=3.0-gated checks handle
+# that themselves (skip with a clear reason on Python < 3.12, since no
+# lisaorbits release there satisfies both constraints).
+lisaorbits = "*"
 
 [tool.pixi.feature.help.dependencies]
 mpi4py = "*"

--- a/test/test_coordinates_space_orbit.py
+++ b/test/test_coordinates_space_orbit.py
@@ -1,0 +1,1693 @@
+# Copyright (C) 2026  Shichao Wu, Alex Nitz
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+"""
+Regression tests for `pycbc.coordinates.space_orbit`.
+
+The core claim being tested is backward compatibility: the generic,
+orbit-provider-based machinery in `space_orbit` must reproduce the existing,
+hard-coded circular-orbit LISA functions in `pycbc.coordinates.space` exactly
+(to floating point precision) when fed the same analytic circular orbit that
+those functions assume. The reference orbit used here is the "Equal arm
+analytic orbit" defined in the LISA Data Challenge manual
+(LISA-LCST-SGS-MAN-001, Sec. 8.1.1, Eq. 48-52); this is the same closed-form
+per-spacecraft trajectory implemented by `lisaorbits.EqualArmlengthOrbits`,
+reimplemented here directly (not imported from `lisaorbits`) so this test has
+no optional dependency.
+
+Beyond the LISA special case, this file also checks that `constellation_frame`
+generalizes correctly to constellations with genuinely different geometry:
+Taiji (heliocentric, like LISA but leading the Earth by 20 degrees instead of
+trailing it, with a different arm length/eccentricity) and TianQin (a fast,
+rigidly-rotating triangle around a geocentric guiding center, in a plane
+fixed in inertial space rather than precessing over a year). The Taiji
+fixture uses the same first-order-in-eccentricity Keplerian expansion as the
+LDC manual's Eq. 48-52 above (Rubbo, Cornish & Poujade 2004, Phys. Rev. D 69,
+082003), just with Taiji's own arm length/eccentricity and a +20 degree lead
+angle instead of LISA's trailing offset. The TianQin fixture follows Hu et al
+2018 (Class. Quantum Grav. 35, 095008), simplified to a pure circular
+heliocentric guiding center coincident with the Earth (consistent with how
+the LISA/Taiji guiding center above is also treated as the zero-eccentricity
+limit of the same family of orbits).
+"""
+import os
+import sys
+import tempfile
+import h5py
+import numpy
+import unittest
+from astropy.constants import au
+
+from pycbc.coordinates import space
+from pycbc.coordinates import space_orbit
+from utils import simple_exit
+
+
+seed = 8202
+numpy.random.seed(seed)
+
+OMEGA_0 = space_orbit.EARTH_ORBIT_ANGULAR_FREQUENCY  # LISA/Taiji-like [rad/s]
+ARMLENGTH = 2.5e9  # matches pycbc.detector.space._space_detectors['LISA']
+SEMI_MAJOR_AXIS = au.value
+ECCENTRICITY = ARMLENGTH / (2 * SEMI_MAJOR_AXIS * numpy.sqrt(3))
+T0 = space.TIME_OFFSET_20_DEGREES
+
+
+def _random_sky_position(with_polarization=False):
+    """Shared random (lam, beta[, pol]) sky position/polarization, drawn
+    fresh each call from this module's seeded RNG. Used throughout this
+    file instead of hard-coded literals, so a passing test isn't
+    accidentally relying on some property of that one specific value.
+    """
+    lam = numpy.random.uniform(0.0, 2 * numpy.pi)
+    beta = numpy.random.uniform(-numpy.pi / 2, numpy.pi / 2)
+    if with_polarization:
+        pol = numpy.random.uniform(0.0, 2 * numpy.pi)
+        return lam, beta, pol
+    return lam, beta
+
+# Official ESA lisa-orbit-files v2.0 ('esa-trailing'), fetched by fixed URL
+# + SHA256 instead of through `OEMOrbits.from_included` (its `version=`
+# kwarg and default dataset aren't consistent across lisaorbits releases).
+# Pinning guarantees every run checks the same real orbit data. Shared by
+# TestNumericOrbitsFileReaders and TestOptionalESAOemOrbitFiles below.
+_ESA_V2_TRAILING_OEM_URLS_AND_HASHES = [
+    ('https://github.com/esa/lisa-orbit-files/raw/v2.0/crema_2p0/'
+     'tcb_time_scale/mida-20deg/trajectory_out_mida-20deg_cw_sg-2nmss_'
+     'may_launch_lisa1.oem',
+     'sha256:59a662a2a57fffdac10f339417b3d437d1f1c46a2af7cab75dffd699'
+     'a28096cb'),
+    ('https://github.com/esa/lisa-orbit-files/raw/v2.0/crema_2p0/'
+     'tcb_time_scale/mida-20deg/trajectory_out_mida-20deg_cw_sg-2nmss_'
+     'may_launch_lisa2.oem',
+     'sha256:3e3ddabe5b27e233095136846bd50ea9fcd5939855dc52ad6464654f'
+     'a5bb21f0'),
+    ('https://github.com/esa/lisa-orbit-files/raw/v2.0/crema_2p0/'
+     'tcb_time_scale/mida-20deg/trajectory_out_mida-20deg_cw_sg-2nmss_'
+     'may_launch_lisa3.oem',
+     'sha256:4be88fdd1ae5c00b22d1955a03a8b126ccb94979884a0c2bd09f72c0'
+     '0dbb4633'),
+]
+
+
+def _require_lisaorbits():
+    """Import and return `lisaorbits`, for the tests below that need a
+    real install of it.
+
+    Raises `unittest.SkipTest` -- not caught by a caller's own
+    `except ImportError`, so `try: lisaorbits = _require_lisaorbits() ...
+    except ImportError:` blocks keep working unchanged -- in the LVK
+    reference virtualenv (`build_venv.yml`/`docker_build_dist.sh`), which
+    deliberately never installs `lisaorbits`: that environment exists to
+    stay representative of a real LVK production install, where an
+    ESA/LISA-specific package like this has no reason to be present.
+    Everywhere else, behaves like a plain `import lisaorbits`: raises
+    `ImportError` if it's genuinely missing, so a broken dev/CI
+    environment still shows up as a real failure, not a silent skip.
+    """
+    if os.environ.get('PYCBC_LVK_REFERENCE_ENV'):
+        raise unittest.SkipTest(
+            'lisaorbits is deliberately not installed in the LVK '
+            'reference virtualenv (build_venv.yml), to keep it '
+            'representative of a real LVK production install')
+    import lisaorbits
+    return lisaorbits
+
+
+# Several tests below cross-check space_orbit's formulas against real
+# `lisaorbits` output, and all need lisaorbits >= 3.0: earlier releases
+# have a bug in their ICRS->ecliptic conversion (call astropy's
+# heliocentricmeanecliptic without `obstime`, so it silently defaults to
+# J2000.0 instead of the orbit's actual epoch), confirmed to disagree
+# with pycbc's own formulas by ~1e9-6e10 m depending on the test.
+# lisaorbits >= 3.0 itself requires Python >= 3.12, so an older Python
+# has no release that's both correct and installable -- skipped there,
+# not failed, since it's a version floor these tests can't clear. The
+# one exception is test_from_oem_files_matches_lisaorbits_on_real_esa_data,
+# which fails outright instead of skipping on any lisaorbits problem
+# (missing, too old, or a fetch failure), since there's no reference to
+# compare against if it's computed with the same bug -- it was exactly
+# this kind of failure quietly becoming a skip that let the bug go
+# unnoticed for a while.
+
+
+# Real Earth's ecliptic longitude at GPS t=0, taken directly from pycbc's own
+# (astropy-based) `earth_position_ssb` -- used below as the phase-zero
+# reference for the Taiji/TianQin fixtures' guiding center, so that "leads/
+# coincides with the Earth" checks can be made against the real Earth
+# (`earth_position_ssb` itself) rather than an arbitrarily-phased toy
+# circular reference. No external ephemeris/orbital-element constants are
+# used here; this is the one already-existing real-ephemeris function in
+# pycbc.coordinates.space, evaluated once.
+PHI0_REAL = space.earth_position_ssb(0.0)[1]
+
+
+TAIJI_ARMLENGTH = 3.0e9  # matches pycbc.detector.space._space_detectors
+TAIJI_ECCENTRICITY = TAIJI_ARMLENGTH / (2 * SEMI_MAJOR_AXIS * numpy.sqrt(3))
+TAIJI_LEAD_ANGLE = numpy.deg2rad(20.0)
+
+
+class _LisaGuidingCenterFixture:
+    """Mixin providing `_phase(t)` for the LISA fixture's guiding-center
+    convention (`OMEGA_0 * (t + T0)`) -- mirrors the shape of
+    `space_orbit._LisaGuidingCenter`, but independently written (not
+    imported from production), so a bug in the production formula
+    wouldn't be invisible here. Combine with
+    `_EqualArmConstellationFixture`.
+    """
+    def _phase(self, t):
+        return OMEGA_0 * (t + T0)
+
+
+class _TaijiGuidingCenterFixture:
+    """Mixin providing `_phase(t)` for the Taiji fixture's guiding-center
+    convention (`OMEGA_0 * t + PHI0_REAL + TAIJI_LEAD_ANGLE`, anchored to
+    real Earth's longitude at t=0 so "leads the Earth by 20 degrees" can
+    be checked against the real Earth position, not an arbitrarily-phased
+    circular proxy) -- mirrors `space_orbit._TaijiGuidingCenter`,
+    independently written. Combine with `_EqualArmConstellationFixture`.
+    """
+    def _phase(self, t):
+        return OMEGA_0 * t + PHI0_REAL + TAIJI_LEAD_ANGLE
+
+
+class _EqualArmConstellationFixture:
+    """Mixin implementing `compute_position` for the LDC manual's 'Equal
+    arm analytic orbit' (LISA-LCST-SGS-MAN-001, Sec. 8.1.1, Eq. 48-52) --
+    mirrors `space_orbit._EqualArmConstellation`, independently written.
+    Shared by `AnalyticEqualArmOrbit`/`AnalyticTaijiOrbit` below (same
+    functional form, per Rubbo, Cornish & Poujade 2004, Phys. Rev. D 69,
+    082003); the concrete class's own `__init__` must set
+    `self.eccentricity`.
+    """
+    def compute_position(self, t, sc=(1, 2, 3)):
+        t = numpy.atleast_1d(numpy.asarray(t, dtype=float))
+        sc = numpy.atleast_1d(sc)
+        alpha = self._phase(t)
+        out = numpy.empty((len(t), len(sc), 3))
+        for k, n in enumerate(sc):
+            beta_n = (n - 1) * 2 * numpy.pi / 3.0
+            out[:, k, 0] = SEMI_MAJOR_AXIS * numpy.cos(alpha) \
+                + SEMI_MAJOR_AXIS * self.eccentricity * (
+                    numpy.sin(alpha) * numpy.cos(alpha) * numpy.sin(beta_n)
+                    - (1 + numpy.sin(alpha) ** 2) * numpy.cos(beta_n))
+            out[:, k, 1] = SEMI_MAJOR_AXIS * numpy.sin(alpha) \
+                + SEMI_MAJOR_AXIS * self.eccentricity * (
+                    numpy.sin(alpha) * numpy.cos(alpha) * numpy.cos(beta_n)
+                    - (1 + numpy.cos(alpha) ** 2) * numpy.sin(beta_n))
+            out[:, k, 2] = -numpy.sqrt(3) * SEMI_MAJOR_AXIS \
+                * self.eccentricity * numpy.cos(alpha - beta_n)
+        return out
+
+
+class AnalyticEqualArmOrbit(_LisaGuidingCenterFixture,
+                             _EqualArmConstellationFixture):
+    """Reference implementation of the LDC manual's 'Equal arm analytic
+    orbit', LISA flavor. Used only to validate `space_orbit.
+    constellation_frame` and related functions against the existing
+    analytic functions in `pycbc.coordinates.space`, which assume this
+    same orbit but only track the (eccentricity-independent) guiding
+    center.
+
+    Parameters
+    ----------
+    eccentricity : float, optional
+        Constellation eccentricity. Default `ECCENTRICITY` (LISA's own
+        arm length).
+    """
+    def __init__(self, eccentricity=None):
+        self.eccentricity = (
+            ECCENTRICITY if eccentricity is None else eccentricity)
+
+
+class AnalyticTaijiOrbit(_TaijiGuidingCenterFixture,
+                          _EqualArmConstellationFixture):
+    """Reference implementation of the Taiji heliocentric orbit --
+    `AnalyticEqualArmOrbit`'s formula with Taiji's own guiding-center
+    convention and eccentricity. Used only to check that
+    `constellation_frame`/`NumericOrbits` handle a constellation genuinely
+    different from the LISA fixture above (different arm length,
+    eccentricity, and heliocentric lead angle).
+    """
+    def __init__(self):
+        self.eccentricity = TAIJI_ECCENTRICITY
+
+
+# TianQin: a fast-rotating rigid triangle (per Hu et al 2018, Class.
+# Quantum Grav. 35, 095008) whose plane is fixed in inertial space (pointing
+# towards the calibration source RX J0806.3+1527), around a guiding center
+# that coincides with the Earth. The guiding center itself is simplified to
+# a pure circular heliocentric orbit (Earth's real orbital eccentricity is
+# irrelevant to what most tests below check), but its phase is anchored to
+# PHI0_REAL (real Earth's longitude at t=0) so that "coincides with the
+# Earth" can also be checked against the real Earth position, not just an
+# arbitrarily-phased circular proxy.
+TIANQIN_ARMLENGTH = numpy.sqrt(3) * 1e8  # matches
+# pycbc.detector.space._space_detectors and space_orbit.TianQinAnalyticOrbit
+TIANQIN_LAMBDA_S = numpy.deg2rad(120.5)  # direction to RX J0806.3+1527
+TIANQIN_BETA_S = numpy.deg2rad(-4.7)
+TIANQIN_F_SC = 1.0 / (3.65 * 86400.0)  # ~3.65 day rotation period
+
+
+class AnalyticTianQinOrbit:
+    """Reference implementation of the TianQin geocentric orbit (per Hu et
+    al 2018, Class. Quantum Grav. 35, 095008). Used to check that
+    `constellation_frame` correctly derives a *non-precessing* constellation
+    plane, in contrast to LISA/Taiji above.
+    """
+    def compute_position(self, t, sc=(1, 2, 3), initial_orbit_phase=0.0):
+        t = numpy.atleast_1d(numpy.asarray(t, dtype=float))
+        sc = numpy.atleast_1d(sc)
+        alpha_earth = OMEGA_0 * t + PHI0_REAL
+        earth = SEMI_MAJOR_AXIS * numpy.stack([
+            numpy.cos(alpha_earth), numpy.sin(alpha_earth),
+            numpy.zeros_like(t)], axis=-1)
+        out = numpy.empty((len(t), len(sc), 3))
+        for k, n in enumerate(sc):
+            kappa_n = 2 * numpy.pi / 3.0 * (n - 1) + initial_orbit_phase
+            phase = 2 * numpy.pi * TIANQIN_F_SC * t + kappa_n
+            xn = (TIANQIN_ARMLENGTH / numpy.sqrt(3)) * (
+                numpy.sin(TIANQIN_BETA_S) * numpy.cos(TIANQIN_LAMBDA_S)
+                * numpy.sin(phase)
+                + numpy.sin(TIANQIN_LAMBDA_S) * numpy.cos(phase))
+            yn = (TIANQIN_ARMLENGTH / numpy.sqrt(3)) * (
+                numpy.sin(TIANQIN_BETA_S) * numpy.sin(TIANQIN_LAMBDA_S)
+                * numpy.sin(phase)
+                - numpy.cos(TIANQIN_LAMBDA_S) * numpy.cos(phase))
+            zn = -(TIANQIN_ARMLENGTH / numpy.sqrt(3)) \
+                * numpy.cos(TIANQIN_BETA_S) * numpy.sin(phase)
+            out[:, k, 0] = earth[:, 0] + xn
+            out[:, k, 1] = earth[:, 1] + yn
+            out[:, k, 2] = earth[:, 2] + zn
+        return out
+
+
+def _arm_lengths(orbit, t):
+    pos = orbit.compute_position(t)
+    r1, r2, r3 = pos[:, 0], pos[:, 1], pos[:, 2]
+    return (numpy.linalg.norm(r1 - r2, axis=-1),
+            numpy.linalg.norm(r2 - r3, axis=-1),
+            numpy.linalg.norm(r1 - r3, axis=-1))
+
+
+class TestConstellationFrame(unittest.TestCase):
+    def setUp(self):
+        self.orbit = AnalyticEqualArmOrbit()
+        self.precision = 1e-6  # relative to ~1 AU length scale / O(1) rotation
+        self.times = numpy.random.uniform(0.0, 3.15e7, size=50)
+
+    def test_centroid_matches_lisa_position_ssb(self):
+        """The constellation centroid derived from the 3 spacecraft
+        positions must match the existing (eccentricity-independent)
+        guiding-center formula `lisa_position_ssb`, since the average of the
+        Equal Arm orbit's eccentricity terms over the 3 spacecraft is
+        exactly zero at every order.
+        """
+        centroid, _ = space_orbit.constellation_frame(self.times, self.orbit)
+        expected = numpy.array([
+            space.lisa_position_ssb(t, T0)[0].flatten().astype(float)
+            for t in self.times
+        ])
+        maxdiff = numpy.max(numpy.abs(centroid - expected))
+        self.assertLess(maxdiff, self.precision * SEMI_MAJOR_AXIS,
+                        f'constellation centroid does not match '
+                        f'lisa_position_ssb; max abs diff {maxdiff}')
+
+    def test_rotation_matches_rotation_matrix_ssb_to_lisa(self):
+        """The rotation matrix derived from the 3 spacecraft positions must
+        match the existing analytic `rotation_matrix_ssb_to_lisa`.
+        """
+        _, rotation = space_orbit.constellation_frame(self.times, self.orbit)
+        for i, t in enumerate(self.times):
+            alpha = OMEGA_0 * (t + T0)
+            expected = space.rotation_matrix_ssb_to_lisa(alpha)
+            maxdiff = numpy.max(numpy.abs(rotation[i] - expected))
+            self.assertLess(maxdiff, self.precision,
+                            f'rotation matrix at t={t} does not match '
+                            f'rotation_matrix_ssb_to_lisa; max abs diff '
+                            f'{maxdiff}')
+
+    def test_t_detector_from_ssb_matches_t_lisa_from_ssb(self):
+        lam, beta = _random_sky_position()
+        k_ssb = space.localization_to_propagation_vector(
+            lam, beta, use_astropy=False).flatten()
+        for t_ssb in self.times[:10]:
+            expected = space.t_lisa_from_ssb(t_ssb, lam, beta, T0)
+            derived = space_orbit.t_detector_from_ssb(
+                t_ssb, k_ssb, self.orbit)
+            self.assertLess(abs(derived - expected), 1e-10,
+                msg=f't_detector_from_ssb does not match t_lisa_from_ssb '
+                    f'at t_ssb={t_ssb}')
+
+    def test_t_ssb_from_t_detector_matches_t_ssb_from_t_lisa(self):
+        lam, beta = _random_sky_position()
+        k_ssb = space.localization_to_propagation_vector(
+            lam, beta, use_astropy=False).flatten()
+        for t_lisa in self.times[:10]:
+            expected = space.t_ssb_from_t_lisa(t_lisa, lam, beta, T0)
+            derived = space_orbit.t_ssb_from_t_detector(
+                t_lisa, k_ssb, self.orbit)
+            self.assertLess(abs(derived - expected), 1e-10,
+                msg=f't_ssb_from_t_detector does not match '
+                    f't_ssb_from_t_lisa at t_lisa={t_lisa}')
+
+
+class TestNumericOrbits(unittest.TestCase):
+    def setUp(self):
+        self.orbit = AnalyticEqualArmOrbit()
+        # coarse grid, similar density to a typical lisaorbits orbit file
+        self.t_grid = numpy.linspace(0.0, 3.15e7, 400)
+        self.positions = self.orbit.compute_position(self.t_grid)
+        self.numeric = space_orbit.NumericOrbits(self.t_grid, self.positions)
+        self.t_query = numpy.random.uniform(1e5, 3.1e7, size=20)
+
+    def test_position_interpolation_accuracy(self):
+        """Interpolated positions must reproduce the analytic orbit to a
+        small fraction of the ~1 AU length scale, at off-grid query times.
+        """
+        interpolated = self.numeric.compute_position(self.t_query)
+        exact = self.orbit.compute_position(self.t_query)
+        maxdiff = numpy.max(numpy.abs(interpolated - exact))
+        self.assertLess(maxdiff, 1e-6 * SEMI_MAJOR_AXIS,
+                        f'NumericOrbits position interpolation error too '
+                        f'large: {maxdiff} m')
+
+    def test_constellation_frame_consistent_with_numeric_orbits(self):
+        """Feeding `constellation_frame` a `NumericOrbits` instance built
+        from a dense sampling of the analytic orbit must reproduce the
+        result of feeding it the analytic orbit provider directly.
+        """
+        centroid_num, rotation_num = space_orbit.constellation_frame(
+            self.t_query, self.numeric)
+        centroid_ana, rotation_ana = space_orbit.constellation_frame(
+            self.t_query, self.orbit)
+        self.assertLess(
+            numpy.max(numpy.abs(centroid_num - centroid_ana)),
+            1e-6 * SEMI_MAJOR_AXIS)
+        self.assertLess(
+            numpy.max(numpy.abs(rotation_num - rotation_ana)), 1e-6)
+
+    def test_rejects_mismatched_shapes(self):
+        with self.assertRaises(ValueError):
+            space_orbit.NumericOrbits(self.t_grid, self.positions[:-1])
+        with self.assertRaises(ValueError):
+            space_orbit.NumericOrbits(
+                self.t_grid, self.positions,
+                velocities=self.positions[:, :, :2])
+
+    def test_velocity_interpolation_accuracy(self):
+        """`compute_velocity`, auto-derived from the position spline (no
+        velocities given), must reproduce the analytic orbit's own exact
+        velocity at off-grid query times.
+        """
+        exact_orbit = space_orbit.LisaEqualArmOrbit()
+        positions = exact_orbit.compute_position(self.t_grid)
+        numeric = space_orbit.NumericOrbits(self.t_grid, positions)
+        interpolated = numeric.compute_velocity(self.t_query)
+        exact = exact_orbit.compute_velocity(self.t_query)
+        maxdiff = numpy.max(numpy.abs(interpolated - exact))
+        self.assertLess(maxdiff, 1e-3,
+                        f'NumericOrbits velocity interpolation error too '
+                        f'large: {maxdiff} m/s')
+
+    def test_acceleration_interpolation_accuracy(self):
+        """`compute_acceleration`, derived as the second analytic
+        derivative of the position spline (no velocities or accelerations
+        given), must reproduce the analytic orbit's own exact acceleration
+        at off-grid query times.
+        """
+        exact_orbit = space_orbit.LisaEqualArmOrbit()
+        positions = exact_orbit.compute_position(self.t_grid)
+        numeric = space_orbit.NumericOrbits(self.t_grid, positions)
+        interpolated = numeric.compute_acceleration(self.t_query)
+        exact = exact_orbit.compute_acceleration(self.t_query)
+        maxdiff = numpy.max(numpy.abs(interpolated - exact))
+        self.assertLess(maxdiff, 1e-6,
+                        f'NumericOrbits acceleration interpolation error '
+                        f'too large: {maxdiff} m/s^2')
+
+
+class TestLisaOrbit(unittest.TestCase):
+    """Standalone sanity checks for the LISA fixture, mirroring
+    `TestTaijiOrbit`/`TestTianQinOrbit` below. `TestConstellationFrame`
+    above already gives LISA a stronger check (byte-level agreement with
+    the pre-existing hardcoded `pycbc.coordinates.space` formulas), but
+    that is a different kind of test; these are the same direct,
+    self-contained checks the other two missions get, for consistency.
+
+    Unlike Taiji's fixture (whose 20 degree lead is a bare angular offset
+    added directly to its own phase, checked against an equally-invented
+    zero-phase circular proxy for the Earth), this fixture's `T0` is a time
+    shift, not an angle, and it does not correspond to a clean angle offset
+    from an arbitrary zero-phase circular reference -- comparing against
+    one gives a constant but physically meaningless ~84 degrees. Comparing
+    instead against the real Earth position (`space.earth_position_ssb`,
+    real ephemeris) does give the intended ~20 degree lag, matching the
+    documented 19-23 degree range for `TIME_OFFSET_20_DEGREES`.
+    """
+    def setUp(self):
+        self.orbit = AnalyticEqualArmOrbit()
+        self.times = numpy.random.uniform(0.0, 3.15e7, size=50)
+
+    def test_arm_length_matches_design_value(self):
+        for d in _arm_lengths(self.orbit, self.times):
+            self.assertLess(
+                numpy.max(numpy.abs(d - ARMLENGTH)), 1.0,
+                'LISA arm length deviates from the 2.5e6 km design value '
+                'by more than 1 m')
+
+    def test_trails_real_earth_by_documented_lag(self):
+        """The guiding center must trail the real Earth (not a zero-phase
+        circular proxy) by the 19-23 degree range documented for
+        `TIME_OFFSET_20_DEGREES`, at any time -- not just near the
+        particular epoch that constant happens to have been tuned at.
+        """
+        centroid, _ = space_orbit.constellation_frame(self.times, self.orbit)
+        for i, t in enumerate(self.times):
+            earth_pos = space.earth_position_ssb(t)[0].flatten().astype(
+                float)
+            cos_angle = numpy.dot(centroid[i], earth_pos) / (
+                numpy.linalg.norm(centroid[i]) * numpy.linalg.norm(
+                    earth_pos))
+            angle_deg = numpy.rad2deg(numpy.arccos(
+                numpy.clip(cos_angle, -1, 1)))
+            self.assertTrue(
+                17.0 < angle_deg < 24.0,
+                f'LISA-to-real-Earth angle {angle_deg} deg at t={t} is '
+                f'outside the documented ~19-23 degree range')
+
+    def test_rotation_orthonormal(self):
+        _, rotation = space_orbit.constellation_frame(self.times, self.orbit)
+        for r in rotation:
+            self.assertLess(
+                numpy.max(numpy.abs(r @ r.T - numpy.eye(3))), 1e-8)
+
+    def test_round_trip_time_delay(self):
+        lam, beta = _random_sky_position()
+        k_ssb = space.localization_to_propagation_vector(
+            lam, beta, use_astropy=False).flatten()
+        for t_ssb in self.times[:10]:
+            t_det = space_orbit.t_detector_from_ssb(t_ssb, k_ssb, self.orbit)
+            t_ssb_roundtrip = space_orbit.t_ssb_from_t_detector(
+                t_det, k_ssb, self.orbit)
+            self.assertLess(abs(t_ssb_roundtrip - t_ssb), 1e-10)
+
+
+class TestTaijiOrbit(unittest.TestCase):
+    def setUp(self):
+        self.orbit = AnalyticTaijiOrbit()
+        self.times = numpy.random.uniform(0.0, 3.15e7, size=50)
+
+    def test_arm_length_matches_design_value(self):
+        for d in _arm_lengths(self.orbit, self.times):
+            self.assertLess(
+                numpy.max(numpy.abs(d - TAIJI_ARMLENGTH)), 1.0,
+                'Taiji arm length deviates from the 3e6 km design value '
+                'by more than 1 m')
+
+    def test_leads_earth_like_guiding_center_by_20_degrees(self):
+        """Taiji's guiding center must lead a coincident, zero-eccentricity
+        circular orbit anchored to the same real-Earth phase reference
+        (PHI0_REAL) as the Taiji fixture's own zeroth-order term, by exactly
+        20 degrees, at every time (alpha'' = alpha - beta + 20 deg).
+        """
+        centroid, _ = space_orbit.constellation_frame(self.times, self.orbit)
+        alpha_earth = OMEGA_0 * self.times + PHI0_REAL
+        earth_like = SEMI_MAJOR_AXIS * numpy.stack([
+            numpy.cos(alpha_earth), numpy.sin(alpha_earth),
+            numpy.zeros_like(self.times)], axis=-1)
+        cos_angle = numpy.sum(centroid * earth_like, axis=-1) / (
+            numpy.linalg.norm(centroid, axis=-1)
+            * numpy.linalg.norm(earth_like, axis=-1))
+        angle_deg = numpy.rad2deg(numpy.arccos(numpy.clip(cos_angle, -1, 1)))
+        maxdiff = numpy.max(numpy.abs(angle_deg - 20.0))
+        self.assertLess(maxdiff, 1e-6,
+                        f'Taiji-to-idealized-guiding-center angle is off '
+                        f'by {maxdiff} deg from the expected 20 deg lead')
+
+    def test_leads_real_earth_by_approximately_20_degrees(self):
+        """Because the guiding center's phase is anchored to real Earth's
+        longitude at t=0 (PHI0_REAL), Taiji must also lead the *real* Earth
+        position (`space.earth_position_ssb`, real ephemeris, not the
+        idealized circular proxy above) by approximately 20 degrees -- not
+        exactly, since this fixture's guiding center is still an idealized
+        circle while the real Earth's orbit is eccentric, but within a few
+        degrees, and stably so over time (checked here over one year;
+        verified separately to hold over multiple decades).
+        """
+        centroid, _ = space_orbit.constellation_frame(self.times, self.orbit)
+        for i, t in enumerate(self.times):
+            earth_pos = space.earth_position_ssb(t)[0].flatten().astype(
+                float)
+            cos_angle = numpy.dot(centroid[i], earth_pos) / (
+                numpy.linalg.norm(centroid[i]) * numpy.linalg.norm(
+                    earth_pos))
+            angle_deg = numpy.rad2deg(numpy.arccos(
+                numpy.clip(cos_angle, -1, 1)))
+            self.assertTrue(
+                15.0 < angle_deg < 25.0,
+                f'Taiji-to-real-Earth angle {angle_deg} deg at t={t} is '
+                f'outside the expected ~20 +/- 5 degree range')
+
+    def test_rotation_orthonormal(self):
+        _, rotation = space_orbit.constellation_frame(self.times, self.orbit)
+        for r in rotation:
+            self.assertLess(
+                numpy.max(numpy.abs(r @ r.T - numpy.eye(3))), 1e-8)
+
+    def test_round_trip_time_delay(self):
+        lam, beta = _random_sky_position()
+        k_ssb = space.localization_to_propagation_vector(
+            lam, beta, use_astropy=False).flatten()
+        for t_ssb in self.times[:10]:
+            t_det = space_orbit.t_detector_from_ssb(t_ssb, k_ssb, self.orbit)
+            t_ssb_roundtrip = space_orbit.t_ssb_from_t_detector(
+                t_det, k_ssb, self.orbit)
+            self.assertLess(abs(t_ssb_roundtrip - t_ssb), 1e-10)
+
+
+class TestTianQinOrbit(unittest.TestCase):
+    def setUp(self):
+        self.orbit = AnalyticTianQinOrbit()
+        self.times = numpy.random.uniform(0.0, 3.15e7, size=50)
+
+    def test_arm_length_matches_design_value(self):
+        for d in _arm_lengths(self.orbit, self.times):
+            self.assertLess(
+                numpy.max(numpy.abs(d - TIANQIN_ARMLENGTH)), 1.0,
+                'TianQin arm length deviates from the 1.7e5 km design '
+                'value by more than 1 m')
+
+    def test_centroid_matches_earthlike_guiding_center(self):
+        """TianQin's 3 spacecraft are equally spaced in phase around their
+        guiding center, so their average must cancel the fast-rotation term
+        exactly, leaving just the (here, circular, real-Earth-phase-anchored
+        via PHI0_REAL) Earth-like guiding center.
+        """
+        centroid, _ = space_orbit.constellation_frame(self.times, self.orbit)
+        alpha_earth = OMEGA_0 * self.times + PHI0_REAL
+        earth_like = SEMI_MAJOR_AXIS * numpy.stack([
+            numpy.cos(alpha_earth), numpy.sin(alpha_earth),
+            numpy.zeros_like(self.times)], axis=-1)
+        self.assertLess(numpy.max(numpy.abs(centroid - earth_like)), 1e-3)
+
+    def test_centroid_close_to_real_earth_position(self):
+        """Because the guiding center's phase is anchored to real Earth's
+        longitude at t=0 (PHI0_REAL), TianQin's centroid must also stay
+        close to the *real* Earth position (`space.earth_position_ssb`),
+        not just the idealized circular proxy above -- within a few percent
+        of 1 AU, the expected residual from treating the guiding center as
+        a perfect circle instead of Earth's real, slightly eccentric orbit.
+        """
+        centroid, _ = space_orbit.constellation_frame(self.times, self.orbit)
+        for i, t in enumerate(self.times):
+            earth_pos = space.earth_position_ssb(t)[0].flatten().astype(
+                float)
+            diff = numpy.linalg.norm(centroid[i] - earth_pos)
+            self.assertLess(
+                diff, 0.06 * SEMI_MAJOR_AXIS,
+                f'TianQin centroid at t={t} is more than 6% of 1 AU away '
+                f'from the real Earth position (diff={diff:.3e} m)')
+
+    def test_constellation_plane_normal_is_time_independent(self):
+        """Unlike LISA/Taiji (whose constellation plane precesses over a
+        year), TianQin's plane is fixed in inertial space (pointing towards
+        RX J0806.3+1527): the normal derived by `constellation_frame` must
+        be the same at every sampled time, even though the in-plane axes
+        rotate rapidly (~3.65 day period).
+        """
+        year_times = numpy.linspace(0.0, 3.15e7, 50)
+        _, rotation = space_orbit.constellation_frame(year_times, self.orbit)
+        normal = rotation[:, 2, :]
+        x_axis = rotation[:, 0, :]
+        self.assertLess(
+            numpy.max(numpy.abs(normal - normal[0])), 1e-6,
+            'TianQin constellation plane normal is not time-independent')
+        # the in-plane axis, in contrast, must rotate substantially over a
+        # year (~100 fast rotations), i.e. this is not a degenerate check
+        self.assertGreater(numpy.max(numpy.abs(x_axis - x_axis[0])), 0.5)
+
+    def test_rotation_orthonormal(self):
+        _, rotation = space_orbit.constellation_frame(self.times, self.orbit)
+        for r in rotation:
+            self.assertLess(
+                numpy.max(numpy.abs(r @ r.T - numpy.eye(3))), 1e-8)
+
+    def test_round_trip_time_delay(self):
+        lam, beta = _random_sky_position()
+        k_ssb = space.localization_to_propagation_vector(
+            lam, beta, use_astropy=False).flatten()
+        for t_ssb in self.times[:10]:
+            t_det = space_orbit.t_detector_from_ssb(t_ssb, k_ssb, self.orbit)
+            t_ssb_roundtrip = space_orbit.t_ssb_from_t_detector(
+                t_det, k_ssb, self.orbit)
+            self.assertLess(abs(t_ssb_roundtrip - t_ssb), 1e-10)
+
+
+class TestProductionAnalyticOrbits(unittest.TestCase):
+    """`space_orbit.LisaEqualArmOrbit`/`TaijiEqualArmOrbit`/
+    `TianQinAnalyticOrbit` are the production (not test-only) analytic
+    reference orbits: unlike the hand-written `AnalyticEqualArmOrbit`/
+    `AnalyticTaijiOrbit`/`AnalyticTianQinOrbit` fixtures above (used purely
+    to give `constellation_frame` etc. an independent implementation to
+    check against), these are importable, user-facing classes intended
+    for prototyping single-link response/TDI work before an official
+    numeric orbit product exists.
+
+    The key check here is that each *separately implemented* production
+    class agrees with the hand-written test fixture bit for bit when given
+    the same reference phase -- i.e. that promoting the fixtures' math to
+    a real, documented, parameterized class did not introduce any
+    transcription error. `LisaEqualArmOrbit` additionally must reproduce
+    `pycbc.coordinates.space`'s pre-existing hardcoded functions exactly
+    with its default (no-argument) `t0`, since that default is meant to be
+    a drop-in stand-in for the existing `orbit=None` code path -- unlike
+    Taiji/TianQin, it does not default to a real-Earth-anchored epoch.
+    """
+    def test_lisa_matches_hardcoded_space_functions(self):
+        orbit = space_orbit.LisaEqualArmOrbit()
+        times = numpy.random.uniform(0.0, 3.15e7, size=20)
+        centroid, rotation = space_orbit.constellation_frame(times, orbit)
+        expected_centroid = numpy.array([
+            space.lisa_position_ssb(t, orbit.t0)[0].flatten().astype(float)
+            for t in times
+        ])
+        self.assertLess(
+            numpy.max(numpy.abs(centroid - expected_centroid)),
+            1e-6 * SEMI_MAJOR_AXIS)
+        for i, t in enumerate(times):
+            alpha = OMEGA_0 * (t + orbit.t0)
+            expected_rotation = space.rotation_matrix_ssb_to_lisa(alpha)
+            self.assertLess(
+                numpy.max(numpy.abs(rotation[i] - expected_rotation)), 1e-6)
+
+    def test_lisa_matches_independent_fixture_implementation(self):
+        production = space_orbit.LisaEqualArmOrbit()
+        fixture = AnalyticEqualArmOrbit()
+        times = numpy.random.uniform(0.0, 3.15e7, size=20)
+        pos_production = production.compute_position(times)
+        pos_fixture = fixture.compute_position(times)
+        self.assertLess(
+            numpy.max(numpy.abs(pos_production - pos_fixture)), 1e-3,
+            'LisaEqualArmOrbit does not match the independent '
+            'AnalyticEqualArmOrbit test fixture')
+
+    def test_lisa_default_t0_matches_time_offset_20_degrees(self):
+        orbit = space_orbit.LisaEqualArmOrbit()
+        self.assertEqual(orbit.t0, space.TIME_OFFSET_20_DEGREES)
+
+    def test_lisa_custom_t0_overrides_default(self):
+        orbit = space_orbit.LisaEqualArmOrbit(t0=0.0)
+        self.assertEqual(orbit.t0, 0.0)
+        default_orbit = space_orbit.LisaEqualArmOrbit()
+        self.assertGreater(
+            numpy.max(numpy.abs(
+                orbit.compute_position([1e7])
+                - default_orbit.compute_position([1e7]))),
+            1e6)
+
+    def test_taiji_matches_independent_fixture_implementation(self):
+        production = space_orbit.TaijiEqualArmOrbit(kappa0=PHI0_REAL)
+        fixture = AnalyticTaijiOrbit()
+        times = numpy.random.uniform(0.0, 3.15e7, size=20)
+        pos_production = production.compute_position(times)
+        pos_fixture = fixture.compute_position(times)
+        self.assertLess(
+            numpy.max(numpy.abs(pos_production - pos_fixture)), 1e-3,
+            'TaijiEqualArmOrbit does not match the independent '
+            'AnalyticTaijiOrbit test fixture')
+
+    def test_tianqin_matches_independent_fixture_implementation(self):
+        production = space_orbit.TianQinAnalyticOrbit(kappa0=PHI0_REAL)
+        fixture = AnalyticTianQinOrbit()
+        times = numpy.random.uniform(0.0, 3.15e7, size=20)
+        pos_production = production.compute_position(times)
+        pos_fixture = fixture.compute_position(times)
+        self.assertLess(
+            numpy.max(numpy.abs(pos_production - pos_fixture)), 1e-3,
+            'TianQinAnalyticOrbit does not match the independent '
+            'AnalyticTianQinOrbit test fixture')
+
+    def test_tianqin_default_guiding_center_is_circular(self):
+        orbit = space_orbit.TianQinAnalyticOrbit()
+        self.assertEqual(orbit.guiding_center, 'circular')
+
+    def test_tianqin_rejects_invalid_guiding_center(self):
+        with self.assertRaises(ValueError):
+            space_orbit.TianQinAnalyticOrbit(guiding_center='bogus')
+
+    def test_tianqin_real_earth_guiding_center_matches_earth_position_ssb(
+            self):
+        """With `guiding_center='real_earth'`, the constellation centroid
+        must match `pycbc.coordinates.space.earth_position_ssb`'s real,
+        astropy/JPL-ephemeris-based Earth position directly (not just a
+        circular approximation of it).
+        """
+        orbit = space_orbit.TianQinAnalyticOrbit(guiding_center='real_earth')
+        times = numpy.random.uniform(0.0, 3.15e7, size=10)
+        centroid, _ = space_orbit.constellation_frame(times, orbit)
+        expected = numpy.array([
+            space.earth_position_ssb(t)[0].flatten().astype(float)
+            for t in times
+        ])
+        self.assertLess(
+            numpy.max(numpy.abs(centroid - expected)), 1.0,
+            'real_earth guiding center does not match earth_position_ssb')
+
+    def test_tianqin_real_earth_deviates_from_circular_by_eccentricity_scale(
+            self):
+        """The whole point of `guiding_center='real_earth'` is to capture
+        Earth's real ~1.7% orbital eccentricity (and other real
+        perturbations) that the circular approximation neglects; with a
+        matching reference epoch (kappa0=None on both, i.e. both anchored
+        to the real Earth's actual longitude at t=0), the two should
+        differ by something on the order of that eccentricity times 1 AU,
+        not be identical (bug: real_earth silently falling back to
+        circular) or absurdly different (bug: mismatched time/frame
+        convention).
+        """
+        circular = space_orbit.TianQinAnalyticOrbit()
+        real = space_orbit.TianQinAnalyticOrbit(guiding_center='real_earth')
+        times = numpy.linspace(0.0, 3.15e7, 50)
+        centroid_c, _ = space_orbit.constellation_frame(times, circular)
+        centroid_r, _ = space_orbit.constellation_frame(times, real)
+        diff = numpy.linalg.norm(centroid_c - centroid_r, axis=-1)
+        self.assertGreater(diff.min(), 0.005 * SEMI_MAJOR_AXIS)
+        self.assertLess(diff.max(), 0.05 * SEMI_MAJOR_AXIS)
+
+    def test_tianqin_real_earth_velocity_matches_finite_difference(self):
+        dt = 1.0
+        orbit = space_orbit.TianQinAnalyticOrbit(guiding_center='real_earth')
+        t = numpy.random.uniform(1e6, 3.1e7, size=5)
+        pos_plus = orbit.compute_position(t + dt)
+        pos_minus = orbit.compute_position(t - dt)
+        finite_diff_vel = (pos_plus - pos_minus) / (2 * dt)
+        analytic_vel = orbit.compute_velocity(t)
+        self.assertLess(
+            numpy.max(numpy.abs(analytic_vel - finite_diff_vel)), 1e-2)
+
+    def test_tianqin_real_earth_acceleration_matches_finite_difference(self):
+        dt = 1.0
+        orbit = space_orbit.TianQinAnalyticOrbit(guiding_center='real_earth')
+        t = numpy.random.uniform(1e6, 3.1e7, size=5)
+        vel_plus = orbit.compute_velocity(t + dt)
+        vel_minus = orbit.compute_velocity(t - dt)
+        finite_diff_acc = (vel_plus - vel_minus) / (2 * dt)
+        analytic_acc = orbit.compute_acceleration(t)
+        self.assertLess(
+            numpy.max(numpy.abs(analytic_acc - finite_diff_acc)), 1e-6)
+
+    def test_default_kappa0_anchors_to_real_earth(self):
+        for cls in (space_orbit.TaijiEqualArmOrbit,
+                    space_orbit.TianQinAnalyticOrbit):
+            orbit = cls()
+            self.assertAlmostEqual(orbit.kappa0, PHI0_REAL, places=9)
+
+    def test_custom_kappa0_overrides_default(self):
+        for cls in (space_orbit.TaijiEqualArmOrbit,
+                    space_orbit.TianQinAnalyticOrbit):
+            orbit = cls(kappa0=0.0)
+            self.assertEqual(orbit.kappa0, 0.0)
+            default_orbit = cls()
+            # different kappa0 must give a different position at a fixed
+            # time (sanity check that the parameter actually does
+            # something, not a silently-ignored constructor argument)
+            self.assertGreater(
+                numpy.max(numpy.abs(
+                    orbit.compute_position([1e7])
+                    - default_orbit.compute_position([1e7]))),
+                1e6)
+
+    def test_arm_lengths_match_design_values(self):
+        cases = [
+            (space_orbit.LisaEqualArmOrbit(), ARMLENGTH),
+            (space_orbit.TaijiEqualArmOrbit(), TAIJI_ARMLENGTH),
+            (space_orbit.TianQinAnalyticOrbit(), TIANQIN_ARMLENGTH),
+        ]
+        times = numpy.random.uniform(0.0, 3.15e7, size=20)
+        for orbit, expected_armlength in cases:
+            for d in _arm_lengths(orbit, times):
+                self.assertLess(
+                    numpy.max(numpy.abs(d - expected_armlength)), 1.0)
+
+    def test_velocity_matches_finite_difference_of_position(self):
+        """`compute_velocity` is an exact analytic derivative, not a
+        finite-difference approximation -- but a central finite difference
+        of `compute_position`, at a small enough step, must still agree
+        with it to high precision. This is independent of `lisaorbits`.
+        """
+        dt = 1.0  # s
+        for orbit in (space_orbit.LisaEqualArmOrbit(),
+                      space_orbit.TaijiEqualArmOrbit(),
+                      space_orbit.TianQinAnalyticOrbit()):
+            t = numpy.random.uniform(1e5, 3.1e7, size=10)
+            pos_plus = orbit.compute_position(t + dt)
+            pos_minus = orbit.compute_position(t - dt)
+            finite_diff_vel = (pos_plus - pos_minus) / (2 * dt)
+            analytic_vel = orbit.compute_velocity(t)
+            self.assertLess(
+                numpy.max(numpy.abs(analytic_vel - finite_diff_vel)), 1e-3)
+
+    def test_acceleration_matches_finite_difference_of_velocity(self):
+        """Same rationale as `test_velocity_matches_finite_difference_of_
+        position`, one derivative order up.
+        """
+        dt = 1.0  # s
+        for orbit in (space_orbit.LisaEqualArmOrbit(),
+                      space_orbit.TaijiEqualArmOrbit(),
+                      space_orbit.TianQinAnalyticOrbit()):
+            t = numpy.random.uniform(1e5, 3.1e7, size=10)
+            vel_plus = orbit.compute_velocity(t + dt)
+            vel_minus = orbit.compute_velocity(t - dt)
+            finite_diff_acc = (vel_plus - vel_minus) / (2 * dt)
+            analytic_acc = orbit.compute_acceleration(t)
+            self.assertLess(
+                numpy.max(numpy.abs(analytic_acc - finite_diff_acc)), 1e-6)
+
+
+class TestKeplerianOrbits(unittest.TestCase):
+    """`LisaKeplerianOrbit`/`TaijiKeplerianOrbit` implement the second-
+    order-in-eccentricity tilted-Kepler-ellipse equal-arm constellation
+    (three spacecraft on independent, common-inclination, common-
+    eccentricity Kepler ellipses, 120 degrees apart in both mean anomaly
+    and ascending node) -- a standard "tilted formation" construction
+    (the same physics `lisaorbits.KeplerianOrbits` implements),
+    independently implemented here (own code, not ported from any other
+    implementation) and validated against it.
+    """
+    def test_velocity_matches_finite_difference_of_position(self):
+        dt = 1.0  # s
+        for orbit in (space_orbit.LisaKeplerianOrbit(),
+                      space_orbit.TaijiKeplerianOrbit()):
+            t = numpy.random.uniform(1e5, 3.1e7, size=10)
+            pos_plus = orbit.compute_position(t + dt)
+            pos_minus = orbit.compute_position(t - dt)
+            finite_diff_vel = (pos_plus - pos_minus) / (2 * dt)
+            analytic_vel = orbit.compute_velocity(t)
+            self.assertLess(
+                numpy.max(numpy.abs(analytic_vel - finite_diff_vel)), 1e-3)
+
+    def test_acceleration_matches_finite_difference_of_velocity(self):
+        dt = 1.0  # s
+        for orbit in (space_orbit.LisaKeplerianOrbit(),
+                      space_orbit.TaijiKeplerianOrbit()):
+            t = numpy.random.uniform(1e5, 3.1e7, size=10)
+            vel_plus = orbit.compute_velocity(t + dt)
+            vel_minus = orbit.compute_velocity(t - dt)
+            finite_diff_acc = (vel_plus - vel_minus) / (2 * dt)
+            analytic_acc = orbit.compute_acceleration(t)
+            self.assertLess(
+                numpy.max(numpy.abs(analytic_acc - finite_diff_acc)), 1e-6)
+
+    def test_mean_arm_length_close_to_design_value(self):
+        """Unlike `LisaEqualArmOrbit` (whose specific choice of orbital
+        phases happens to keep the arm length essentially exactly
+        constant at the design value for LISA's small eccentricity --
+        confirmed here against real lisaorbits.EqualArmlengthOrbits data,
+        spread ~1e-5 m), the true-Kepler-ellipse construction here trades
+        that near-perfect constancy for matching a real Keplerian orbit's
+        physics: real lisaorbits.KeplerianOrbits itself has a ~0.2%
+        arm-length variation over a year for LISA's parameters, and a mean
+        arm length that undershoots the nominal design value by a similar
+        amount (confirmed against real lisaorbits.KeplerianOrbits data).
+        This just checks the mean stays within that same, expected,
+        percent-level range of the design value -- not that this
+        construction is "more accurate" in an absolute sense, which it is
+        not for this quantity.
+        """
+        t = numpy.linspace(0.0, 3.15e7, 200)
+        orbit = space_orbit.LisaKeplerianOrbit(t0=0.0)
+        pos = orbit.compute_position(t, (1, 2))
+        length = numpy.linalg.norm(pos[:, 0] - pos[:, 1], axis=-1)
+        self.assertLess(abs(length.mean() - ARMLENGTH), 0.01 * ARMLENGTH)
+
+    def test_matches_lisaorbits_keplerian_orbits_exactly(self):
+        """Direct, machine-precision cross-check of position/velocity/
+        acceleration against a real `lisaorbits.KeplerianOrbits` instance,
+        using its own angular frequency (as in the analogous first-order
+        test) to isolate the comparison from the unrelated
+        EARTH_ORBIT_ANGULAR_FREQUENCY-vs-sqrt(GM_SUN/a**3) difference.
+
+        Requires lisaorbits >= 3.0, Python >= 3.12 -- see the module-level
+        note above `_require_lisaorbits` for why.
+        """
+        if sys.version_info < (3, 12):
+            self.skipTest(
+                'lisaorbits >= 3.0 (required, see docstring) needs Python '
+                f'>= 3.12; this environment is on Python '
+                f'{sys.version_info.major}.{sys.version_info.minor}')
+        try:
+            lisaorbits = _require_lisaorbits()
+        except ImportError as exc:
+            self.fail(f'lisaorbits is not installed: {exc!r}')
+        version = tuple(int(p) for p in lisaorbits.__version__.split('.')[:2])
+        if version < (3, 0):
+            self.fail(f'lisaorbits {lisaorbits.__version__} is too old '
+                      '(see this test\'s docstring); upgrade to >= 3.0')
+        ref = lisaorbits.KeplerianOrbits(L=ARMLENGTH)
+        ref_ecliptic = ICRSOrbitAdapter(ref)
+
+        t = numpy.random.uniform(1e5, 3.1e7, size=20)
+        sc = (1, 2, 3)
+        alpha = ref.n * t
+
+        self.assertAlmostEqual(
+            space_orbit._kepler_orbit_elements(ARMLENGTH, ref.a)[0], ref.e,
+            places=12)
+
+        pos_mine = space_orbit._kepler_orbit_position(
+            alpha, ARMLENGTH, ref.a, sc)
+        vel_mine = space_orbit._kepler_orbit_velocity(
+            alpha, ref.n, ARMLENGTH, ref.a, sc)
+        acc_mine = space_orbit._kepler_orbit_acceleration(
+            alpha, ref.n, ARMLENGTH, ref.a, sc)
+
+        pos_ref = ref_ecliptic.compute_position(t, sc)
+        vel_ref = ref_ecliptic.compute_velocity(t, sc)
+        acc_ref = ref_ecliptic.compute_acceleration(t, sc)
+
+        self.assertLess(numpy.max(numpy.abs(pos_mine - pos_ref)), 1e-2)
+        self.assertLess(numpy.max(numpy.abs(vel_mine - vel_ref)), 1e-8)
+        self.assertLess(numpy.max(numpy.abs(acc_mine - acc_ref)), 1e-14)
+
+
+class TestNumericOrbitsGeneralizesBeyondLisa(unittest.TestCase):
+    """`NumericOrbits` must interpolate Taiji- and TianQin-shaped orbits
+    accurately too, not just the LISA special case in `TestNumericOrbits`
+    above. TianQin's much shorter (~3.65 day) rotation period requires a
+    denser sampling grid than LISA/Taiji's yearly one to interpolate well.
+    """
+    def test_taiji_interpolation_accuracy(self):
+        orbit = AnalyticTaijiOrbit()
+        t_grid = numpy.linspace(0.0, 3.15e7, 400)
+        numeric = space_orbit.NumericOrbits(
+            t_grid, orbit.compute_position(t_grid))
+        t_query = numpy.random.uniform(1e5, 3.1e7, size=20)
+        interpolated = numeric.compute_position(t_query)
+        exact = orbit.compute_position(t_query)
+        self.assertLess(numpy.max(numpy.abs(interpolated - exact)),
+                        1e-6 * SEMI_MAJOR_AXIS)
+
+    def test_tianqin_interpolation_accuracy(self):
+        orbit = AnalyticTianQinOrbit()
+        # dense enough to resolve the ~3.65 day rotation period
+        t_grid = numpy.linspace(0.0, 3.15e7, 20000)
+        numeric = space_orbit.NumericOrbits(
+            t_grid, orbit.compute_position(t_grid))
+        t_query = numpy.random.uniform(1e5, 3.1e7, size=20)
+        interpolated = numeric.compute_position(t_query)
+        exact = orbit.compute_position(t_query)
+        self.assertLess(numpy.max(numpy.abs(interpolated - exact)),
+                        1e-6 * TIANQIN_ARMLENGTH)
+
+
+class TestOptionalLisaorbitsDuckTyping(unittest.TestCase):
+    """Verify that a real `lisaorbits.Orbits` instance works directly with
+    `constellation_frame` (duck typing, no adapter code) and matches
+    pycbc's own formulas. Requires `lisaorbits` to be installed -- it's an
+    optional dependency (`space_orbit` itself never imports it), but these
+    tests fail rather than skip if it's missing, so a broken/absent
+    install shows up as red CI, not a silently-skipped check.
+    """
+    def test_lisaorbits_instance_accepted_directly(self):
+        try:
+            lisaorbits = _require_lisaorbits()
+        except ImportError as exc:
+            self.fail(f'lisaorbits is not installed: {exc!r}')
+        orbit = lisaorbits.EqualArmlengthOrbits()
+        times = numpy.array([1e6, 1e7])
+        centroid, rotation = space_orbit.constellation_frame(times, orbit)
+        self.assertEqual(centroid.shape, (2, 3))
+        self.assertEqual(rotation.shape, (2, 3, 3))
+        self.assertTrue(numpy.all(numpy.isfinite(centroid)))
+        self.assertTrue(numpy.all(numpy.isfinite(rotation)))
+        # rotation matrices must be orthogonal
+        for r in rotation:
+            self.assertLess(
+                numpy.max(numpy.abs(r @ r.T - numpy.eye(3))), 1e-8)
+
+    def test_position_velocity_acceleration_match_lisaorbits_exactly(self):
+        """`space_orbit`'s analytic position/velocity/acceleration formulas
+        (`_equal_arm_orbit_position/_velocity/_acceleration`, underlying
+        `LisaEqualArmOrbit`/`TaijiEqualArmOrbit`) are, by construction, the
+        exact same closed-form Keplerian expansion (Rubbo, Cornish &
+        Poujade 2004) that `lisaorbits.EqualArmlengthOrbits` implements --
+        this checks that claim directly, at essentially machine precision,
+        rather than merely "close".
+
+        `EqualArmlengthOrbits()`'s defaults give a guiding-center phase
+        `mbar(t) = n * t` (`t_init`, `m_init1`, `lambda1` all 0), where `n`
+        is its own physically-derived angular frequency
+        (`sqrt(GM_SUN/a**3)`) -- not `space_orbit`'s own
+        `EARTH_ORBIT_ANGULAR_FREQUENCY` constant (tuned to Earth's actual
+        sidereal year, which differs slightly from a bare two-body Kepler
+        frequency at 1 AU). Since `_equal_arm_orbit_velocity`/
+        `_acceleration` take the angular frequency as an explicit
+        parameter (not hardcoded), using `EqualArmlengthOrbits`'s own `n`
+        directly here isolates a pure formula-for-formula comparison from
+        that unrelated frequency-convention difference.
+
+        Requires lisaorbits >= 3.0, Python >= 3.12 -- see the module-level
+        note above `_require_lisaorbits` for why.
+        """
+        if sys.version_info < (3, 12):
+            self.skipTest(
+                'lisaorbits >= 3.0 (required, see docstring) needs Python '
+                f'>= 3.12; this environment is on Python '
+                f'{sys.version_info.major}.{sys.version_info.minor}')
+        try:
+            lisaorbits = _require_lisaorbits()
+        except ImportError as exc:
+            self.fail(f'lisaorbits is not installed: {exc!r}')
+        version = tuple(int(p) for p in lisaorbits.__version__.split('.')[:2])
+        if version < (3, 0):
+            self.fail(f'lisaorbits {lisaorbits.__version__} is too old '
+                      '(see this test\'s docstring); upgrade to >= 3.0')
+        ref = lisaorbits.EqualArmlengthOrbits(L=ARMLENGTH)
+        ref_ecliptic = ICRSOrbitAdapter(ref)
+
+        t = numpy.random.uniform(1e5, 3.1e7, size=20)
+        sc = (1, 2, 3)
+        alpha = ref.n * t  # matches ref's own mbar(t) for these defaults
+
+        pos_mine = space_orbit._equal_arm_orbit_position(alpha, ARMLENGTH, sc)
+        vel_mine = space_orbit._equal_arm_orbit_velocity(
+            alpha, ref.n, ARMLENGTH, sc)
+        acc_mine = space_orbit._equal_arm_orbit_acceleration(
+            alpha, ref.n, ARMLENGTH, sc)
+
+        pos_ref = ref_ecliptic.compute_position(t, sc)
+        vel_ref = ref_ecliptic.compute_velocity(t, sc)
+        acc_ref = ref_ecliptic.compute_acceleration(t, sc)
+
+        self.assertLess(numpy.max(numpy.abs(pos_mine - pos_ref)), 1e-3)
+        self.assertLess(numpy.max(numpy.abs(vel_mine - vel_ref)), 1e-6)
+        self.assertLess(numpy.max(numpy.abs(acc_mine - acc_ref)), 1e-9)
+
+    def test_numeric_orbits_matches_interpolated_orbits_on_identical_data(self):
+        """`NumericOrbits` and `lisaorbits.InterpolatedOrbits` both build a
+        quintic spline (`scipy.interpolate.make_interp_spline`, `k=5` by
+        default in both) over the same kind of (times, positions[,
+        velocities]) input. This checks that, fed *exactly* the same
+        sampled data, the two produce matching position/velocity/
+        acceleration at off-grid query times -- the numeric-orbit
+        counterpart of `test_position_velocity_acceleration_match_
+        lisaorbits_exactly` above (which only covered the analytic-orbit
+        path).
+        """
+        try:
+            lisaorbits = _require_lisaorbits()
+        except ImportError as exc:
+            self.fail(f'lisaorbits is not installed: {exc!r}')
+        exact_orbit = space_orbit.LisaEqualArmOrbit()
+        t_grid = numpy.linspace(0.0, 3.15e7, 400)
+        positions = exact_orbit.compute_position(t_grid)
+
+        pycbc_numeric = space_orbit.NumericOrbits(t_grid, positions)
+        ref_numeric = lisaorbits.InterpolatedOrbits(
+            t_grid, positions, t_init=t_grid[10])
+
+        query_t = numpy.random.uniform(t_grid[20], t_grid[-20], size=30)
+        sc = (1, 2, 3)
+        for method, tol in [('compute_position', 1e-3),
+                             ('compute_velocity', 1e-6),
+                             ('compute_acceleration', 1e-6)]:
+            mine = getattr(pycbc_numeric, method)(query_t, sc)
+            ref = getattr(ref_numeric, method)(query_t, sc)
+            self.assertLess(
+                numpy.max(numpy.abs(mine - ref)), tol,
+                f'{method} disagrees with lisaorbits.InterpolatedOrbits '
+                f'by more than {tol}')
+
+
+class TestNumericOrbitsFileReaders(unittest.TestCase):
+    """`NumericOrbits.from_oem_files`/`from_triangle_dat_files` read two
+    real-world numeric orbit formats natively (no `lisaorbits`/`oem`
+    dependency). These tests write small, synthetic fixture files (a
+    known analytic orbit, re-encoded in each format) so they never depend
+    on a local, machine-specific data checkout, and check the round trip
+    recovers the original orbit.
+    """
+    def setUp(self):
+        self.exact_orbit = space_orbit.LisaEqualArmOrbit()
+        self.t_grid = numpy.arange(0.0, 3.15e7, 86400.0)
+        self.tmpdir = tempfile.mkdtemp()
+
+    def test_from_triangle_dat_files_round_trip(self):
+        positions = self.exact_orbit.compute_position(self.t_grid)
+        velocities = self.exact_orbit.compute_velocity(self.t_grid)
+        for k, label in enumerate(('1', '2', '3')):
+            numpy.savetxt(
+                os.path.join(self.tmpdir, f'SCP{label}.dat'),
+                positions[:, k, :] / au.value)
+            numpy.savetxt(
+                os.path.join(self.tmpdir, f'SCV{label}.dat'),
+                velocities[:, k, :] / au.value * 86400.0)
+
+        orbit = space_orbit.NumericOrbits.from_triangle_dat_files(
+            self.tmpdir, t0=self.t_grid[0], dt=86400.0)
+        query_t = numpy.linspace(
+            self.t_grid[5], self.t_grid[-5], 30)
+        recovered = orbit.compute_position(query_t)
+        exact = self.exact_orbit.compute_position(query_t)
+        self.assertLess(numpy.max(numpy.abs(recovered - exact)), 1.0)
+
+    def test_from_triangle_dat_files_rejects_mismatched_row_counts(self):
+        positions = self.exact_orbit.compute_position(self.t_grid)
+        for k, label in enumerate(('1', '2', '3')):
+            n_rows = len(self.t_grid) - (1 if label == '3' else 0)
+            numpy.savetxt(
+                os.path.join(self.tmpdir, f'SCP{label}.dat'),
+                positions[:n_rows, k, :] / au.value)
+            numpy.savetxt(
+                os.path.join(self.tmpdir, f'SCV{label}.dat'),
+                positions[:n_rows, k, :] / au.value)
+        with self.assertRaises(ValueError):
+            space_orbit.NumericOrbits.from_triangle_dat_files(self.tmpdir)
+
+    def _write_oem_file(self, path, positions_icrs_km, velocities_icrs_km_s,
+                        epochs_iso, ref_frame='EME2000',
+                        time_system='TCB'):
+        with open(path, 'w') as f:
+            f.write('CCSDS_OEM_VERS = 2.0\n')
+            f.write('CREATION_DATE  = 2024-01-01T00:00:00\n')
+            f.write('ORIGINATOR     = pycbc-test\n\n')
+            f.write('META_START\n')
+            f.write('OBJECT_NAME          = TEST\n')
+            f.write('OBJECT_ID            = -1\n')
+            f.write('CENTER_NAME          = SUN\n')
+            f.write(f'REF_FRAME            = {ref_frame}\n')
+            f.write(f'TIME_SYSTEM          = {time_system}\n')
+            f.write(f'START_TIME           = {epochs_iso[0]}\n')
+            f.write(f'STOP_TIME            = {epochs_iso[-1]}\n')
+            f.write('INTERPOLATION        = HERMITE\n')
+            f.write('INTERPOLATION_DEGREE = 7\n')
+            f.write('META_STOP\n\n')
+            for epoch, pos, vel in zip(
+                    epochs_iso, positions_icrs_km, velocities_icrs_km_s):
+                f.write(
+                    f'{epoch} {pos[0]:.6f} {pos[1]:.6f} {pos[2]:.6f} '
+                    f'{vel[0]:.9f} {vel[1]:.9f} {vel[2]:.9f}\n')
+
+    def test_from_oem_files_round_trip(self):
+        from astropy.time import Time
+
+        positions_ecl = self.exact_orbit.compute_position(self.t_grid)
+        velocities_ecl = self.exact_orbit.compute_velocity(self.t_grid)
+        rotation = space_orbit._icrs_to_ecliptic_rotation_matrix()
+        # ecliptic -> ICRS is the inverse (transpose) of the cached
+        # ICRS -> ecliptic rotation used throughout this module.
+        positions_icrs = (
+            positions_ecl.reshape(-1, 3) @ rotation
+        ).reshape(positions_ecl.shape) / 1e3  # m -> km
+        velocities_icrs = (
+            velocities_ecl.reshape(-1, 3) @ rotation
+        ).reshape(velocities_ecl.shape) / 1e3  # m/s -> km/s
+
+        epochs_iso = Time(self.t_grid, format='gps').tcb.isot
+        oem_paths = []
+        for k, label in enumerate(('1', '2', '3')):
+            path = os.path.join(self.tmpdir, f'test_sc{label}.oem')
+            self._write_oem_file(
+                path, positions_icrs[:, k, :], velocities_icrs[:, k, :],
+                epochs_iso)
+            oem_paths.append(path)
+
+        orbit = space_orbit.NumericOrbits.from_oem_files(*oem_paths)
+        query_t = numpy.linspace(self.t_grid[5], self.t_grid[-5], 30)
+        recovered = orbit.compute_position(query_t)
+        exact = self.exact_orbit.compute_position(query_t)
+        # Dominated by ordinary quintic-spline interpolation error at
+        # 1-day cadence (consistent with the ~20 m level already measured
+        # elsewhere in this test suite for similarly-sampled data), not by
+        # the ISO8601/km-precision text round trip, which is far smaller.
+        self.assertLess(numpy.max(numpy.abs(recovered - exact)), 20.0)
+
+    def test_from_oem_files_rejects_non_eme2000_frame(self):
+        from astropy.time import Time
+        positions_ecl = self.exact_orbit.compute_position(self.t_grid)
+        epochs_iso = Time(self.t_grid, format='gps').tcb.isot
+        oem_paths = []
+        for k, label in enumerate(('1', '2', '3')):
+            path = os.path.join(self.tmpdir, f'test_sc{label}.oem')
+            self._write_oem_file(
+                path, positions_ecl[:, k, :] / 1e3,
+                positions_ecl[:, k, :] / 1e3, epochs_iso,
+                ref_frame='ICRF')
+            oem_paths.append(path)
+        with self.assertRaises(ValueError):
+            space_orbit.NumericOrbits.from_oem_files(*oem_paths)
+
+    def test_from_oem_files_rejects_mismatched_epochs(self):
+        from astropy.time import Time
+        positions_ecl = self.exact_orbit.compute_position(self.t_grid)
+        epochs_iso = Time(self.t_grid, format='gps').tcb.isot
+        epochs_iso_shifted = Time(
+            self.t_grid + 1.0, format='gps').tcb.isot
+        oem_paths = []
+        for k, label in enumerate(('1', '2', '3')):
+            path = os.path.join(self.tmpdir, f'test_sc{label}.oem')
+            these_epochs = epochs_iso_shifted if label == '3' else epochs_iso
+            self._write_oem_file(
+                path, positions_ecl[:, k, :] / 1e3,
+                positions_ecl[:, k, :] / 1e3, these_epochs)
+            oem_paths.append(path)
+        with self.assertRaises(ValueError):
+            space_orbit.NumericOrbits.from_oem_files(*oem_paths)
+
+    def test_from_oem_files_matches_lisaorbits_on_real_esa_data(self):
+        """Fetch the official ESA lisa-orbit-files v2.0 trio and check
+        that pycbc's own from_oem_files parser agrees with a real
+        lisaorbits.OEMOrbits reading the same files.
+
+        Requires lisaorbits >= 3.0, Python >= 3.12 -- see the module-level
+        note above `_require_lisaorbits` for why. This is the test that
+        note's "fails outright, not skip" exception refers to: any
+        lisaorbits problem here fails the test rather than skipping it,
+        since there's no reference value to compare against once
+        lisaorbits itself is computing wrong.
+        """
+        if sys.version_info < (3, 12):
+            self.skipTest(
+                'lisaorbits >= 3.0 (required, see docstring) needs Python '
+                f'>= 3.12; this environment is on Python '
+                f'{sys.version_info.major}.{sys.version_info.minor}')
+        try:
+            lisaorbits = _require_lisaorbits()
+            from lisaorbits import OEMOrbits
+            import lisaconstants
+            import pooch
+            from astropy.time import Time
+        except ImportError as exc:
+            self.fail(f'lisaorbits (or a dependency) is not installed: '
+                      f'{exc!r}')
+
+        version = tuple(int(p) for p in lisaorbits.__version__.split('.')[:2])
+        if version < (3, 0):
+            self.fail(
+                f'lisaorbits {lisaorbits.__version__} is too old (see this '
+                'test\'s docstring); upgrade to >= 3.0 to run this check')
+
+        try:
+            oem_paths = [
+                pooch.retrieve(url, known_hash=known_hash, progressbar=False)
+                for url, known_hash
+                in _ESA_V2_TRAILING_OEM_URLS_AND_HASHES]
+        except Exception as exc:  # pylint: disable=broad-except
+            self.fail('could not fetch official ESA lisa-orbit-files: '
+                      f'{exc!r}')
+
+        native = space_orbit.NumericOrbits.from_oem_files(*oem_paths)
+        ref_ecliptic = ICRSOrbitAdapter(OEMOrbits(*oem_paths))
+
+        query_gps = numpy.linspace(
+            native.t_interp[10], native.t_interp[-10], 30)
+        epoch = Time(lisaconstants.LISA_EPOCH_TCB, format='isot',
+                    scale='tcb')
+        query_tcb_sec = (Time(query_gps, format='gps').tcb - epoch).sec
+
+        pos_native = native.compute_position(query_gps)
+        pos_ref = ref_ecliptic.compute_position(query_tcb_sec)
+        self.assertLess(numpy.max(numpy.abs(pos_native - pos_ref)), 1.0)
+
+    def test_to_file_round_trip_without_velocities(self):
+        """`to_file` (paired with `from_file`) is the missing link that
+        lets any orbit built via `from_oem_files`/`from_triangle_dat_files`/
+        `from_lisaorbits_file` (none of which write pycbc's own HDF5
+        schema) be saved once and then referenced by a real PE config's
+        `orbit-file` option. With no explicit velocities at construction,
+        the `velocities` dataset must be omitted (not written as zeros or
+        anything else), so a reloaded instance re-derives velocities from
+        the position spline exactly as the original did.
+        """
+        orbit = space_orbit.NumericOrbits(
+            self.t_grid, self.exact_orbit.compute_position(self.t_grid))
+        path = os.path.join(self.tmpdir, 'roundtrip_no_vel.hdf5')
+        orbit.to_file(path)
+
+        with h5py.File(path, 'r') as f:
+            self.assertIn('t', f)
+            self.assertIn('positions', f)
+            self.assertNotIn('velocities', f)
+
+        reloaded = space_orbit.NumericOrbits.from_file(path)
+        query_t = numpy.linspace(self.t_grid[5], self.t_grid[-5], 30)
+        self.assertLess(numpy.max(numpy.abs(
+            reloaded.compute_position(query_t)
+            - orbit.compute_position(query_t))), 1e-6)
+        self.assertLess(numpy.max(numpy.abs(
+            reloaded.compute_velocity(query_t)
+            - orbit.compute_velocity(query_t))), 1e-6)
+        self.assertLess(numpy.max(numpy.abs(
+            reloaded.compute_acceleration(query_t)
+            - orbit.compute_acceleration(query_t))), 1e-6)
+
+    def test_to_file_round_trip_with_explicit_velocities(self):
+        positions = self.exact_orbit.compute_position(self.t_grid)
+        velocities = self.exact_orbit.compute_velocity(self.t_grid)
+        orbit = space_orbit.NumericOrbits(
+            self.t_grid, positions, velocities=velocities)
+        path = os.path.join(self.tmpdir, 'roundtrip_with_vel.hdf5')
+        orbit.to_file(path)
+
+        with h5py.File(path, 'r') as f:
+            self.assertIn('velocities', f)
+
+        reloaded = space_orbit.NumericOrbits.from_file(path)
+        query_t = numpy.linspace(self.t_grid[5], self.t_grid[-5], 30)
+        self.assertLess(numpy.max(numpy.abs(
+            reloaded.compute_velocity(query_t)
+            - orbit.compute_velocity(query_t))), 1e-6)
+
+    def test_to_file_group_option_round_trip(self):
+        orbit = space_orbit.NumericOrbits(
+            self.t_grid, self.exact_orbit.compute_position(self.t_grid))
+        path = os.path.join(self.tmpdir, 'grouped.hdf5')
+        orbit.to_file(path, group='lisa')
+        orbit.to_file(path, group='taiji', mode='a')
+
+        for group in ('lisa', 'taiji'):
+            reloaded = space_orbit.NumericOrbits.from_file(path, group=group)
+            query_t = numpy.linspace(self.t_grid[5], self.t_grid[-5], 30)
+            self.assertLess(numpy.max(numpy.abs(
+                reloaded.compute_position(query_t)
+                - orbit.compute_position(query_t))), 1e-6)
+
+    def test_from_lisaorbits_file_matches_native_data(self):
+        """`from_lisaorbits_file` reads the file format produced by
+        `lisaorbits.Orbits.write` (positions under `tcb/x`, ICRS frame,
+        uniform TCB sampling from `t0`/`dt`/`size` attributes) without
+        requiring `lisaorbits` to parse it back. `.write` dumps the orbit's
+        raw ICRS positions directly, not through the buggy obstime-less
+        ecliptic conversion other lisaorbits-gated tests here need to
+        guard against (see `TestOptionalLisaorbitsDuckTyping`'s docstring),
+        and the reference values here are computed independently with
+        pycbc's own rotation matrix, so no lisaorbits version requirement
+        applies -- only needs `lisaorbits` to be installed, to build the
+        fixture file.
+        """
+        try:
+            lisaorbits = _require_lisaorbits()
+        except ImportError as exc:
+            self.fail(f'lisaorbits is not installed: {exc!r}')
+
+        native_orbit = lisaorbits.EqualArmlengthOrbits()
+        path = os.path.join(self.tmpdir, 'lisaorbits_native.h5')
+        native_orbit.write(path, dt=3600.0, size=200)
+
+        loaded = space_orbit.NumericOrbits.from_lisaorbits_file(path)
+
+        with h5py.File(path, 'r') as f:
+            t0, dt, size = (
+                float(f.attrs['t0']), float(f.attrs['dt']),
+                int(f.attrs['size']))
+            positions_icrs = f['tcb/x'][:]
+        t_tcb = t0 + numpy.arange(size) * dt
+        rotation = space_orbit._icrs_to_ecliptic_rotation_matrix()
+        positions_ecliptic = (
+            positions_icrs.reshape(-1, 3) @ rotation.T
+        ).reshape(positions_icrs.shape)
+
+        from astropy.time import Time, TimeDelta
+        epoch = Time('2035-01-01T00:00:00.000', format='isot', scale='tcb')
+        t_gps = (epoch + TimeDelta(t_tcb, format='sec')).gps
+
+        query_idx = numpy.array([20, 100, 180])
+        recovered = loaded.compute_position(t_gps[query_idx])
+        self.assertLess(numpy.max(numpy.abs(
+            recovered - positions_ecliptic[query_idx])), 1e-3)
+
+        # Design arm length sanity check (LISA: 2.5e6 km).
+        arm_12 = numpy.linalg.norm(
+            recovered[:, 0] - recovered[:, 1], axis=-1)
+        self.assertLess(numpy.max(numpy.abs(arm_12 - 2.5e9)), 1.0)
+
+
+class ICRSOrbitAdapter:
+    """Wrap an `OrbitProvider` given in the ICRS (equatorial) frame so it
+    can be used as a drop-in `OrbitProvider` in pycbc's own
+    BarycentricMeanEcliptic convention.
+
+    Test-only helper: it has no caller in `pycbc` itself, only here, where
+    it lets these tests compare pycbc's own orbit math directly against a
+    real, independently-generated `lisaorbits` object (analytic or
+    real-ESA-file-backed) without a round trip through a file just to pick
+    up the frame conversion -- see `TestICRSOrbitAdapter`,
+    `TestKeplerianOrbits.test_matches_lisaorbits_keplerian_orbits_exactly`,
+    and `TestOptionalESAOemOrbitFiles` below.
+
+    Real spacecraft ephemerides are most often published in an equatorial
+    frame (e.g. CCSDS OEM files use EME2000, which `lisaorbits.OEMOrbits`
+    reads without further rotation, so any `lisaorbits.Orbits` instance
+    built from such files reports positions in ICRS). `space_orbit` and
+    `pycbc.coordinates.space` assume the SSB ecliptic frame throughout, so
+    such an orbit cannot be passed to `constellation_frame` etc. directly
+    without producing silently-wrong frame-dependent
+    quantities (e.g. `constellation_frame`'s rotation matrix and centroid
+    components) -- even though frame-independent quantities like arm
+    length happen to come out correct either way.
+
+    This class wraps `compute_position`/`compute_velocity`/
+    `compute_acceleration`; all three are rotated with the same fixed
+    matrix, since the ICRS -> ecliptic transform (fixed equinox, no origin
+    shift) commutes with time differentiation.
+
+    Parameters
+    ----------
+    orbit : OrbitProvider
+        Any object exposing `compute_position(t, sc)` (and, optionally,
+        `compute_velocity(t, sc)`) with positions/velocities in the ICRS
+        frame -- for example a real `lisaorbits.OEMOrbits` instance built
+        from official ESA lisa-orbit-files data.
+    """
+    def __init__(self, orbit):
+        self._orbit = orbit
+        self._rotation_T = space_orbit._icrs_to_ecliptic_rotation_matrix().T
+
+    def _rotate(self, arr):
+        """Apply the fixed ICRS -> ecliptic rotation to an (N, M, 3)
+        array. Reshaping to (N*M, 3) first and rotating with a single 2D
+        matmul is dramatically faster than broadcasting the 3x3 rotation
+        directly over the leading (N, M) axes of the 3D array (measured
+        ~35x at N*M ~ 3e5): numpy/BLAS vectorizes one large 2D matmul far
+        better than many small batched ones.
+        """
+        shape = arr.shape
+        return (arr.reshape(-1, 3) @ self._rotation_T).reshape(shape)
+
+    def compute_position(self, t, sc=(1, 2, 3)):
+        return self._rotate(self._orbit.compute_position(t, sc))
+
+    def compute_velocity(self, t, sc=(1, 2, 3)):
+        return self._rotate(self._orbit.compute_velocity(t, sc))
+
+    def compute_acceleration(self, t, sc=(1, 2, 3)):
+        return self._rotate(self._orbit.compute_acceleration(t, sc))
+
+
+class TestICRSOrbitAdapter(unittest.TestCase):
+    """`ICRSOrbitAdapter` wraps an ICRS-frame orbit provider (as produced by
+    real spacecraft ephemerides, e.g. CCSDS OEM files) so it can be used as
+    a drop-in `OrbitProvider` in pycbc's own SSB-ecliptic convention. These
+    tests build a synthetic "ICRS-frame" fixture by rotating one of this
+    module's own ecliptic-frame analytic orbits with the *inverse* of the
+    adapter's own rotation matrix, then check the adapter recovers the
+    original ecliptic-frame values -- a self-contained round trip that
+    does not depend on `lisaorbits` or any external orbit file.
+    """
+    def setUp(self):
+        self.ecliptic_orbit = space_orbit.LisaEqualArmOrbit()
+        self.rotation = space_orbit._icrs_to_ecliptic_rotation_matrix()
+        self.times = numpy.linspace(1e6, 3.15e7, 50)
+
+    def _fake_icrs_orbit(self):
+        ecliptic_orbit = self.ecliptic_orbit
+        rotation = self.rotation
+
+        class _FakeICRSOrbit:
+            def compute_position(self, t, sc=(1, 2, 3)):
+                pos_ecliptic = ecliptic_orbit.compute_position(t, sc)
+                return pos_ecliptic @ rotation  # ecliptic -> ICRS
+
+        return _FakeICRSOrbit()
+
+    def test_round_trip_recovers_ecliptic_positions(self):
+        adapter = ICRSOrbitAdapter(self._fake_icrs_orbit())
+        recovered = adapter.compute_position(self.times, (1, 2, 3))
+        expected = self.ecliptic_orbit.compute_position(self.times, (1, 2, 3))
+        self.assertLess(numpy.max(numpy.abs(recovered - expected)), 1e-3)
+
+    def test_rotation_is_orthogonal(self):
+        r = self.rotation
+        self.assertLess(numpy.max(numpy.abs(r @ r.T - numpy.eye(3))), 1e-10)
+
+    def test_rotation_matches_independent_astropy_transform(self):
+        """A round trip through the adapter alone cannot catch a sign or
+        transpose error in the cached rotation matrix (composing a matrix
+        with its own transpose is the identity regardless of whether the
+        matrix itself is correct). This test instead compares the cached
+        matrix's action on an arbitrary, non-basis vector against a fresh,
+        independent call to astropy's ICRS -> BarycentricMeanEcliptic
+        transform, so a transpose/sign bug in the matrix construction
+        cannot hide behind a self-consistent-but-wrong round trip.
+        """
+        from astropy import units as apy_units
+        from astropy.coordinates import ICRS, BarycentricMeanEcliptic
+
+        v_icrs = numpy.array([1.3, -0.7, 2.1])
+        icrs = ICRS(x=v_icrs[0] * apy_units.m, y=v_icrs[1] * apy_units.m,
+                    z=v_icrs[2] * apy_units.m, representation_type='cartesian')
+        ecl = icrs.transform_to(
+            BarycentricMeanEcliptic(equinox='J2000')).cartesian
+        expected = numpy.array([ecl.x.to(apy_units.m).value,
+                                 ecl.y.to(apy_units.m).value,
+                                 ecl.z.to(apy_units.m).value])
+
+        result = self.rotation @ v_icrs
+        self.assertLess(numpy.max(numpy.abs(result - expected)), 1e-8)
+
+    def test_compute_velocity_rotates_consistently(self):
+        t_grid = numpy.linspace(0.0, 3.15e7, 400)
+        pos_ecliptic = self.ecliptic_orbit.compute_position(t_grid)
+        numeric_ecliptic = space_orbit.NumericOrbits(t_grid, pos_ecliptic)
+
+        rotation = self.rotation
+
+        class _FakeICRSOrbit:
+            def compute_position(self, t, sc=(1, 2, 3)):
+                return numeric_ecliptic.compute_position(t, sc) @ rotation
+
+            def compute_velocity(self, t, sc=(1, 2, 3)):
+                return numeric_ecliptic.compute_velocity(t, sc) @ rotation
+
+        adapter = ICRSOrbitAdapter(_FakeICRSOrbit())
+        query_t = numpy.linspace(1e6, 3.1e7, 50)
+        recovered_vel = adapter.compute_velocity(query_t, (1, 2, 3))
+        expected_vel = numeric_ecliptic.compute_velocity(query_t, (1, 2, 3))
+        self.assertLess(
+            numpy.max(numpy.abs(recovered_vel - expected_vel)), 1e-3)
+
+    def test_compute_acceleration_rotates_consistently(self):
+        t_grid = numpy.linspace(0.0, 3.15e7, 400)
+        pos_ecliptic = self.ecliptic_orbit.compute_position(t_grid)
+        numeric_ecliptic = space_orbit.NumericOrbits(t_grid, pos_ecliptic)
+
+        rotation = self.rotation
+
+        class _FakeICRSOrbit:
+            def compute_position(self, t, sc=(1, 2, 3)):
+                return numeric_ecliptic.compute_position(t, sc) @ rotation
+
+            def compute_velocity(self, t, sc=(1, 2, 3)):
+                return numeric_ecliptic.compute_velocity(t, sc) @ rotation
+
+            def compute_acceleration(self, t, sc=(1, 2, 3)):
+                return numeric_ecliptic.compute_acceleration(t, sc) @ rotation
+
+        adapter = ICRSOrbitAdapter(_FakeICRSOrbit())
+        query_t = numpy.linspace(1e6, 3.1e7, 50)
+        recovered_acc = adapter.compute_acceleration(query_t, (1, 2, 3))
+        expected_acc = numeric_ecliptic.compute_acceleration(query_t, (1, 2, 3))
+        self.assertLess(
+            numpy.max(numpy.abs(recovered_acc - expected_acc)), 1e-6)
+
+    def test_usable_directly_with_constellation_frame(self):
+        adapter = ICRSOrbitAdapter(self._fake_icrs_orbit())
+        centroid, rotation = space_orbit.constellation_frame(
+            self.times, adapter)
+        expected_centroid, expected_rotation = space_orbit.constellation_frame(
+            self.times, self.ecliptic_orbit)
+        self.assertLess(
+            numpy.max(numpy.abs(centroid - expected_centroid)), 1e-3)
+        self.assertLess(
+            numpy.max(numpy.abs(rotation - expected_rotation)), 1e-8)
+
+
+class TestOptionalESAOemOrbitFiles(unittest.TestCase):
+    """Verify that `space_orbit` correctly consumes real ESA LISA orbit
+    files (CCSDS OEM format, `_ESA_V2_TRAILING_OEM_URLS_AND_HASHES` above).
+
+    Unlike `lisaorbits`' own analytic orbits (e.g. `EqualArmlengthOrbits`,
+    used in `TestOptionalLisaorbitsDuckTyping` above), OEM files are given in
+    the EME2000 (~ICRS) equatorial frame, not the SSB ecliptic frame that
+    `space_orbit`/`space` assume. This test therefore also exercises
+    `ICRSOrbitAdapter`, which any caller must use (or replicate) before
+    treating OEM-derived positions as a `space_orbit` `OrbitProvider`.
+
+    Requires `lisaorbits` and network access to fetch the (~600 kB total)
+    orbit files; fails rather than skips if either isn't available, so a
+    broken environment shows up as red CI, not a silently-skipped check.
+    """
+    def test_esa_oem_orbit_matches_design_arm_length(self):
+        try:
+            _require_lisaorbits()
+            from lisaorbits import OEMOrbits
+            import pooch
+        except ImportError as exc:
+            self.fail(f'lisaorbits is not installed: {exc!r}')
+        try:
+            oem_paths = [
+                pooch.retrieve(url, known_hash=known_hash, progressbar=False)
+                for url, known_hash
+                in _ESA_V2_TRAILING_OEM_URLS_AND_HASHES]
+        except Exception as exc:  # pylint: disable=broad-except
+            self.fail('could not fetch official ESA lisa-orbit-files: '
+                      f'{exc!r}')
+        oem_orbit = OEMOrbits(*oem_paths)
+
+        t_grid = numpy.linspace(
+            oem_orbit.t_start + 5 * 86400.0,
+            oem_orbit.t_end - 5 * 86400.0, 100)
+        esa_orbit = ICRSOrbitAdapter(oem_orbit)
+        pos = esa_orbit.compute_position(t_grid, (1, 2))
+        length = numpy.linalg.norm(pos[:, 0] - pos[:, 1], axis=-1)
+        self.assertTrue(numpy.all(numpy.isfinite(length)))
+        # LISA's design arm length is 2.5 million km; real orbit files
+        # deviate from this by up to a few percent due to orbital dynamics.
+        self.assertTrue(numpy.all(numpy.abs(length / 1e3 - 2.5e6) < 1e5))
+
+        centroid, rotation = space_orbit.constellation_frame(t_grid, esa_orbit)
+        for r in rotation:
+            self.assertLess(
+                numpy.max(numpy.abs(r @ r.T - numpy.eye(3))), 1e-8)
+        centroid_au = numpy.linalg.norm(centroid, axis=-1) / SEMI_MAJOR_AXIS
+        self.assertTrue(numpy.all(numpy.abs(centroid_au - 1.0) < 0.05))
+
+
+suite = unittest.TestSuite()
+suite.addTest(unittest.TestLoader().loadTestsFromTestCase(
+    TestConstellationFrame))
+suite.addTest(unittest.TestLoader().loadTestsFromTestCase(TestNumericOrbits))
+suite.addTest(unittest.TestLoader().loadTestsFromTestCase(TestLisaOrbit))
+suite.addTest(unittest.TestLoader().loadTestsFromTestCase(TestTaijiOrbit))
+suite.addTest(unittest.TestLoader().loadTestsFromTestCase(TestTianQinOrbit))
+suite.addTest(unittest.TestLoader().loadTestsFromTestCase(
+    TestProductionAnalyticOrbits))
+suite.addTest(unittest.TestLoader().loadTestsFromTestCase(
+    TestKeplerianOrbits))
+suite.addTest(unittest.TestLoader().loadTestsFromTestCase(
+    TestNumericOrbitsGeneralizesBeyondLisa))
+suite.addTest(unittest.TestLoader().loadTestsFromTestCase(
+    TestNumericOrbitsFileReaders))
+suite.addTest(unittest.TestLoader().loadTestsFromTestCase(
+    TestICRSOrbitAdapter))
+suite.addTest(unittest.TestLoader().loadTestsFromTestCase(
+    TestOptionalLisaorbitsDuckTyping))
+suite.addTest(unittest.TestLoader().loadTestsFromTestCase(
+    TestOptionalESAOemOrbitFiles))
+
+if __name__ == '__main__':
+    results = unittest.TextTestRunner(verbosity=2).run(suite)
+    simple_exit(results)

--- a/tools/docker_build_and_test.sh
+++ b/tools/docker_build_and_test.sh
@@ -10,7 +10,7 @@ fi
 
 SOURCE_TAG=`git show-ref | grep ${GITHUB_SHA} | grep -E -o "refs/tags.{0,100}" | cut -c11-`
 
-sudo docker run --name buildvm -v `pwd`:/pycbc:rw -e GITHUB_ACTIONS="${GITHUB_ACTIONS}" ${DOCKER_IMG} /bin/bash -c "bash /pycbc/tools/docker_build_dist.sh --pycbc-container=${PYCBC_CONTAINER} --pycbc-code=${GITHUB_REF} --secure=${DOCKER_SECURE_ENV_VARS} --tag=${SOURCE_TAG}"
+sudo docker run --name buildvm -v `pwd`:/pycbc:rw -e GITHUB_ACTIONS="${GITHUB_ACTIONS}" -e PYCBC_LVK_REFERENCE_ENV=1 ${DOCKER_IMG} /bin/bash -c "bash /pycbc/tools/docker_build_dist.sh --pycbc-container=${PYCBC_CONTAINER} --pycbc-code=${GITHUB_REF} --secure=${DOCKER_SECURE_ENV_VARS} --tag=${SOURCE_TAG}"
 
 echo -e "\\n>> [`date`] Docker exited"
 


### PR DESCRIPTION
This PR carries only the generalized, orbit-provider-based infrastructure in `pycbc.coordinates.space_orbit` -- NumericOrbits (loading numeric orbits from pycbc's own HDF5 format, ESA CCSDS OEM files, lisaorbits-format files, and Taiji Data Challenge Triangle-Simulator files), the LisaEqualArmOrbit/LisaKeplerianOrbit/TaijiEqualArmOrbit/ TaijiKeplerianOrbit/TianQinAnalyticOrbit analytic orbit-provider classes, and constellation_frame/t_detector_from_ssb/ t_ssb_from_t_detector, which generalize `pycbc.coordinates.space`'s existing hard-coded circular-LISA-orbit functions to any constellation via this new orbit-provider protocol.

`pycbc.coordinates.space` itself is untouched here; every test in this PR validates the new orbit machinery only against space.py functions that already exist on master (no orbit= support needed), confirming the generalized machinery reproduces the existing LISA-only behavior exactly in the circular-orbit special case. The follow-up PR that teaches `space.py/pycbc.transforms` to actually accept an orbit provider builds on top of this one.

<!---
Please delete these comments when you submit the pull request

Please add a title which is a concise description of what you are doing,
e.g. 'Fix bug with numpy import in pycbc_coinc_findtrigs' or 'add high frequency sky location dependent response for long detectors'
-->

<!---
This is a brief template for making pull requests for PyCBC.
This is _not_ a proscriptive template - you can use a different style if you want.
Please do think about the questions posed here and whether the details will be useful to include in your PR
Please add sufficient details so that people looking back at the request with no context around the work can understand the changes.
To choose reviewers, please look at the git blame for the code you are changing (if applicable),
or discuss in the #pycbc-code channel of the gwastro slack.
Please add labels as appropriate
-->

<!-- TOP-LEVEL SUMMARY: Please provide a brief, one-or-two-sentence description of the PR here
-->

## Standard information about the request

<!--- Some basic info about the change (delete as appropriate) -->
This is a: new feature

<!--- What codes will this affect? (delete as apropriate)
If you do not know which areas will be affected, please ask in the gwastro #pycbc-code slack
-->
This change affects: inference, LISA-related code

<!--- What code areas will this affect? (delete as apropriate) -->
This change changes: documentation

<!--- Some things which help with code management (delete as appropriate) -->
This change: has appropriate unit tests, follows style guidelines (See e.g. [PEP8](https://peps.python.org/pep-0008/)), has been proposed using the [contribution guidelines](https://github.com/gwastro/pycbc/blob/master/CONTRIBUTING.md)


## Motivation
<!--- Describe why your changes are being made -->
This PR generalizes my previous PR https://github.com/gwastro/pycbc/pull/4289 to numerical LISA/Taiji/TianQin orbits.

## Links to any issues or associated PRs
<!--- If this is fixing / working around an already-reported issue, please link to it here -->
This PR simplifies and splits the prototype PR https://github.com/gwastro/pycbc/pull/5394

## Testing performed
<!--- Describe tests for the code changes, either already performed or to be performed -->
See test scripts in this PR.


- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
