### PR TITLE
Add orbit-provider protocol and constellation-frame machinery

### DIFF
--- a/pycbc/coordinates/__init__.py
+++ b/pycbc/coordinates/__init__.py
@@ -18,9 +18,11 @@ more advanced transformations between ground-based detectors and space-borne
 detectors.
 """
 
+# ruff: noqa: F403, F405 -- deliberate `import *` re-export, see __all__
+
 from pycbc.coordinates.base import *
 from pycbc.coordinates.space import *
-
+from pycbc.coordinates.space_orbit import *
 
 __all__ = ['cartesian_to_spherical_rho', 'cartesian_to_spherical_azimuthal',
            'cartesian_to_spherical_polar', 'cartesian_to_spherical',
@@ -34,4 +36,6 @@ __all__ = ['cartesian_to_spherical_rho', 'cartesian_to_spherical_azimuthal',
            'lisa_position_ssb', 'earth_position_ssb',
            't_geo_from_ssb', 't_ssb_from_t_geo', 'ssb_to_geo', 'geo_to_ssb',
            'lisa_to_geo', 'geo_to_lisa',
+           'constellation_frame',
+           't_detector_from_ssb', 't_ssb_from_t_detector',
            ]

--- a/pycbc/coordinates/space.py
+++ b/pycbc/coordinates/space.py
@@ -49,6 +49,12 @@ logger = logging.getLogger('pycbc.coordinates.space')
 # the waveform plugin and PE config file. In the unit of 's'.
 TIME_OFFSET_20_DEGREES = 7365189.431698299
 
+# Earth's mean orbital angular frequency, 2*pi / sidereal year (365.256363
+# days). Note this is the sidereal year, not astropy's `units.yr`, which is
+# the Julian year (365.25 days) and would shift the constellation phase by
+# ~1e-4 rad over a year.
+EARTH_ORBIT_ANGULAR_FREQUENCY = 1.99098659277e-7  # [rad/s]
+
 # "rotation_matrix_ssb_to_lisa" and "lisa_position_ssb" should be
 # more general for other detectors in the near future.
 
@@ -105,7 +111,7 @@ def lisa_position_ssb(t_lisa, t0=TIME_OFFSET_20_DEGREES):
         The angular displacement of LISA in the SSB frame.
         In the unit of 'radian'.
     """
-    OMEGA_0 = 1.99098659277e-7
+    OMEGA_0 = EARTH_ORBIT_ANGULAR_FREQUENCY
     R_ORBIT = au.value
     alpha = np.mod(OMEGA_0 * (t_lisa + t0), 2*np.pi)
     p = np.array([[R_ORBIT * np.cos(alpha)],
@@ -942,6 +948,7 @@ def geo_to_lisa(t_geo, longitude_geo, latitude_geo, polarization_geo,
 
 
 __all__ = ['TIME_OFFSET_20_DEGREES',
+           'EARTH_ORBIT_ANGULAR_FREQUENCY',
            'localization_to_propagation_vector',
            'propagation_vector_to_localization', 'polarization_newframe',
            't_lisa_from_ssb', 't_ssb_from_t_lisa',

--- a/pycbc/coordinates/space.py
+++ b/pycbc/coordinates/space.py
@@ -50,9 +50,12 @@ logger = logging.getLogger('pycbc.coordinates.space')
 TIME_OFFSET_20_DEGREES = 7365189.431698299
 
 # Earth's mean orbital angular frequency, 2*pi / sidereal year (365.256363
-# days). Note this is the sidereal year, not astropy's `units.yr`, which is
-# the Julian year (365.25 days) and would shift the constellation phase by
-# ~1e-4 rad over a year.
+# days), matching lisaconstants.ASTRONOMICAL_YEAR. The guiding centre is
+# propagated in a frame pinned to the J2000 equinox, which does not precess,
+# so the period relative to the fixed stars is the right one: the tropical
+# year would only apply if the frame precessed with the equinox, and
+# astropy's units.yr is the Julian year, a defined time unit rather than an
+# orbital period.
 EARTH_ORBIT_ANGULAR_FREQUENCY = 1.99098659277e-7  # [rad/s]
 
 # "rotation_matrix_ssb_to_lisa" and "lisa_position_ssb" should be

--- a/pycbc/coordinates/space_orbit.py
+++ b/pycbc/coordinates/space_orbit.py
@@ -31,9 +31,6 @@ and return shape as `lisaorbits.Orbits` (https://pypi.org/project/lisaorbits)
 can be used as an orbit provider here, including a real `lisaorbits.Orbits`
 instance passed in directly -- this module does not import or depend on
 `lisaorbits` itself.
-
-This module does not change or replace anything in `pycbc.coordinates.space`;
-it is purely additive.
 """
 import numpy as np
 from astropy.constants import c as SPEED_OF_LIGHT
@@ -91,7 +88,7 @@ def constellation_frame(t, orbit, sc=(1, 2, 3)):
     normal = normal / np.linalg.norm(normal, axis=-1, keepdims=True)
 
     x_raw = r1 - centroid
-    # remove any out-of-plane component so the x-axis is exactly in-plane
+    # project out any out-of-plane component
     x_axis = x_raw - np.sum(x_raw * normal, axis=-1, keepdims=True) * normal
     x_axis = x_axis / np.linalg.norm(x_axis, axis=-1, keepdims=True)
 
@@ -105,9 +102,9 @@ def constellation_frame(t, orbit, sc=(1, 2, 3)):
     # The constellation geometry alone only pins the frame down to a
     # rotation about its own normal and the sign of the in-plane axes; fix
     # that by matching rotation_matrix_ssb_to_lisa's convention (a 180
-    # degree rotation about the normal). Pure axis-labeling, no physics
-    # effect -- verified to reproduce rotation_matrix_ssb_to_lisa exactly
-    # in the circular-orbit limit, see test_coordinates_space_orbit.py.
+    # degree rotation about the normal). Axis labelling only, no physics
+    # effect; the circular-orbit limit is checked against
+    # rotation_matrix_ssb_to_lisa in test_coordinates_space_orbit.py.
     axis_convention = np.diag([-1.0, -1.0, 1.0])
     rotation = rotation @ axis_convention
 

--- a/pycbc/coordinates/space_orbit.py
+++ b/pycbc/coordinates/space_orbit.py
@@ -1,0 +1,214 @@
+# Copyright (C) 2026  Shichao Wu, Alex Nitz
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+#
+# =============================================================================
+#
+#                                   Preamble
+#
+# =============================================================================
+#
+"""
+This module generalizes the constellation-frame machinery in
+`pycbc.coordinates.space` (which assumes a fixed, analytic, circular LISA
+orbit) to work with an arbitrary triangular constellation orbit, analytic or
+numerical, for any mission (LISA, Taiji, TianQin, ...).
+
+Any object exposing `compute_position(t, sc)` with the same call signature
+and return shape as `lisaorbits.Orbits` (https://pypi.org/project/lisaorbits)
+can be used as an orbit provider here, including a real `lisaorbits.Orbits`
+instance passed in directly -- this module does not import or depend on
+`lisaorbits` itself.
+
+This module does not change or replace anything in `pycbc.coordinates.space`;
+it is purely additive.
+"""
+import numpy as np
+from astropy.constants import c as SPEED_OF_LIGHT
+from scipy.optimize import fsolve
+
+logger = __import__('logging').getLogger(__name__)
+
+
+def constellation_frame(t, orbit, sc=(1, 2, 3)):
+    """Compute the instantaneous constellation centroid and the rotation
+    matrix from the SSB frame to a frame comoving with the constellation,
+    directly from the spacecraft positions supplied by `orbit`.
+
+    Generalizes `rotation_matrix_ssb_to_lisa`/`lisa_position_ssb` in
+    `pycbc.coordinates.space` (fixed circular LISA orbit) to any
+    3-spacecraft triangular constellation given analytic or numerical
+    positions -- e.g. LISA, Taiji, or TianQin.
+
+    For each time sample, the instantaneous frame is built from the three
+    spacecraft positions as:
+
+    * the centroid of the three spacecraft;
+    * the plane normal (right-handed with respect to spacecraft ordering
+      1 -> 2 -> 3), taken as the z-axis;
+    * the projection onto that plane of the direction from the centroid to
+      spacecraft 1, taken as the x-axis;
+    * completing a right-handed orthonormal triad for the y-axis.
+
+    Parameters
+    ----------
+    t : (N,) array-like
+        SSB time(s) [s] at which to evaluate the frame.
+    orbit : OrbitProvider
+        Any object exposing `compute_position(t, sc)` with the calling
+        convention of `lisaorbits.Orbits` (e.g. a `lisaorbits.Orbits`
+        instance, or a `NumericOrbits` instance).
+    sc : (3,) array-like, optional
+        1-indexed spacecraft labels identifying the 3 constellation
+        vertices, in the order used to define the plane normal and the
+        reference (x-axis) spacecraft. Default (1, 2, 3).
+
+    Returns
+    -------
+    centroid : (N, 3) ndarray
+        Constellation centroid position in the SSB frame [m].
+    rotation : (N, 3, 3) ndarray
+        Rotation matrix from the SSB frame to the constellation frame at
+        each time sample, such that ``v_constellation = rotation @ v_ssb``.
+    """
+    t = np.atleast_1d(np.asarray(t, dtype=float))
+    pos = orbit.compute_position(t, sc)  # (N, 3, 3)
+    r1, r2, r3 = pos[:, 0], pos[:, 1], pos[:, 2]
+
+    centroid = (r1 + r2 + r3) / 3.0
+
+    normal = np.cross(r2 - r1, r3 - r1)
+    normal = normal / np.linalg.norm(normal, axis=-1, keepdims=True)
+
+    x_raw = r1 - centroid
+    # remove any out-of-plane component so the x-axis is exactly in-plane
+    x_axis = x_raw - np.sum(x_raw * normal, axis=-1, keepdims=True) * normal
+    x_axis = x_axis / np.linalg.norm(x_axis, axis=-1, keepdims=True)
+
+    y_axis = np.cross(normal, x_axis)
+
+    # rows are the new (constellation-frame) basis vectors, expressed in the
+    # SSB basis, so that `rotation @ v_ssb` gives the components of `v_ssb`
+    # in the constellation frame.
+    rotation = np.stack([x_axis, y_axis, normal], axis=1)  # (N, 3, 3)
+
+    # The constellation geometry alone only pins the frame down to a
+    # rotation about its own normal and the sign of the in-plane axes; fix
+    # that by matching rotation_matrix_ssb_to_lisa's convention (a 180
+    # degree rotation about the normal). Pure axis-labeling, no physics
+    # effect -- verified to reproduce rotation_matrix_ssb_to_lisa exactly
+    # in the circular-orbit limit, see test_coordinates_space_orbit.py.
+    axis_convention = np.diag([-1.0, -1.0, 1.0])
+    rotation = rotation @ axis_convention
+
+    return centroid, rotation
+
+
+def _solve_frame_arrival_time(t_known, k_ssb, position_fn, forward):
+    """Shared `fsolve` pattern behind `t_lisa_from_ssb`/`t_ssb_from_t_lisa`,
+    `t_geo_from_ssb`/`t_ssb_from_t_geo` (in `pycbc.coordinates.space`), and
+    `t_detector_from_ssb`/`t_ssb_from_t_detector` below: solve
+    `t - t_other - dot(k, position(t)) / c = 0` for whichever side is
+    unknown, given a light-travel-time relationship between the SSB origin
+    and a moving frame's origin.
+
+    Parameters
+    ----------
+    t_known : float
+        The time at the known side of the relationship [s].
+    k_ssb : array-like
+        The unit propagation vector of the GW signal in the SSB frame.
+    position_fn : callable
+        `position_fn(t)` returns the moving frame's origin position [m] in
+        the SSB frame at SSB time `t`.
+    forward : bool
+        True solves for the frame's own time given `t_known = t_ssb` (the
+        frame's position depends on the unknown itself, so `position_fn`
+        is re-evaluated inside the root-solve). False solves for `t_ssb`
+        given `t_known` = the frame's own time (the frame's position is
+        evaluated once, at the known time, since it doesn't depend on the
+        unknown `t_ssb`).
+
+    Returns
+    -------
+    float
+        The time at the unknown side of the relationship [s].
+    """
+    k_ssb = np.ravel(np.asarray(k_ssb, dtype=float))
+    if forward:
+        def equation(t):
+            p = np.ravel(np.asarray(position_fn(t[0]), dtype=float))
+            return t[0] - t_known - np.dot(k_ssb, p) / SPEED_OF_LIGHT.value
+    else:
+        p = np.ravel(np.asarray(position_fn(t_known), dtype=float))
+
+        def equation(t):
+            return t_known - t[0] - np.dot(k_ssb, p) / SPEED_OF_LIGHT.value
+    return fsolve(equation, t_known)[0]
+
+
+def t_detector_from_ssb(t_ssb, k_ssb, orbit, sc=(1, 2, 3)):
+    """Compute the time at which a GW signal arrives at the constellation
+    centroid, given the time and propagation direction in the SSB frame.
+
+    This generalizes `pycbc.coordinates.space.t_lisa_from_ssb` to accept an
+    arbitrary orbit provider instead of the fixed circular LISA orbit. The
+    constellation is moving, so the arrival time is found by solving the
+    implicit light-travel-time equation self-consistently, exactly as in the
+    original function.
+
+    Parameters
+    ----------
+    t_ssb : float
+        The time at which the GW signal arrives at the origin of the SSB
+        frame [s].
+    k_ssb : (3,) array-like
+        The unit propagation vector of the GW signal in the SSB frame.
+    orbit : OrbitProvider
+        Any object exposing `compute_position(t, sc)`, see
+        `constellation_frame`.
+    sc : (3,) array-like, optional
+        1-indexed spacecraft labels defining the constellation. Default
+        (1, 2, 3).
+
+    Returns
+    -------
+    float
+        The time at which the GW signal arrives at the constellation
+        centroid [s].
+    """
+    def position_fn(t):
+        return constellation_frame([t], orbit, sc=sc)[0][0]
+    return _solve_frame_arrival_time(t_ssb, k_ssb, position_fn, forward=True)
+
+
+def t_ssb_from_t_detector(t_detector, k_ssb, orbit, sc=(1, 2, 3)):
+    """Compute the time at which a GW signal arrives at the origin of the
+    SSB frame, given the arrival time at the constellation centroid and the
+    propagation direction in the SSB frame.
+
+    Inverse of `t_detector_from_ssb`; see that function for parameter and
+    return conventions.
+    """
+    def position_fn(t):
+        return constellation_frame([t], orbit, sc=sc)[0][0]
+    return _solve_frame_arrival_time(
+        t_detector, k_ssb, position_fn, forward=False)
+
+__all__ = [
+    'constellation_frame',
+    't_detector_from_ssb',
+    't_ssb_from_t_detector',
+]

--- a/pycbc/coordinates/space_orbit.py
+++ b/pycbc/coordinates/space_orbit.py
@@ -48,12 +48,10 @@ def constellation_frame(t, orbit, sc=(1, 2, 3)):
     directly from the spacecraft positions supplied by `orbit`.
 
     Generalizes `rotation_matrix_ssb_to_lisa`/`lisa_position_ssb` in
-    `pycbc.coordinates.space` (fixed circular LISA orbit) to any
-    3-spacecraft triangular constellation given analytic or numerical
-    positions -- e.g. LISA, Taiji, or TianQin.
+    `pycbc.coordinates.space`, which assume a fixed circular LISA orbit, to
+    any 3-spacecraft triangular constellation.
 
-    For each time sample, the instantaneous frame is built from the three
-    spacecraft positions as:
+    The frame is built at each time sample from the three positions as:
 
     * the centroid of the three spacecraft;
     * the plane normal (right-handed with respect to spacecraft ordering
@@ -117,12 +115,9 @@ def constellation_frame(t, orbit, sc=(1, 2, 3)):
 
 
 def _solve_frame_arrival_time(t_known, k_ssb, position_fn, forward):
-    """Shared `fsolve` pattern behind `t_lisa_from_ssb`/`t_ssb_from_t_lisa`,
-    `t_geo_from_ssb`/`t_ssb_from_t_geo` (in `pycbc.coordinates.space`), and
-    `t_detector_from_ssb`/`t_ssb_from_t_detector` below: solve
-    `t - t_other - dot(k, position(t)) / c = 0` for whichever side is
-    unknown, given a light-travel-time relationship between the SSB origin
-    and a moving frame's origin.
+    """Solve `t - t_other - dot(k, position(t)) / c = 0` for whichever side
+    is unknown, i.e. the light-travel-time relationship between the SSB
+    origin and a moving frame's origin.
 
     Parameters
     ----------
@@ -134,12 +129,10 @@ def _solve_frame_arrival_time(t_known, k_ssb, position_fn, forward):
         `position_fn(t)` returns the moving frame's origin position [m] in
         the SSB frame at SSB time `t`.
     forward : bool
-        True solves for the frame's own time given `t_known = t_ssb` (the
-        frame's position depends on the unknown itself, so `position_fn`
-        is re-evaluated inside the root-solve). False solves for `t_ssb`
-        given `t_known` = the frame's own time (the frame's position is
-        evaluated once, at the known time, since it doesn't depend on the
-        unknown `t_ssb`).
+        True solves for the frame's own time given `t_known = t_ssb`; the
+        frame position then depends on the unknown, so `position_fn` is
+        re-evaluated inside the root solve. False solves for `t_ssb`, where
+        the frame position is known up front and evaluated once.
 
     Returns
     -------
@@ -163,17 +156,14 @@ def t_detector_from_ssb(t_ssb, k_ssb, orbit, sc=(1, 2, 3)):
     """Compute the time at which a GW signal arrives at the constellation
     centroid, given the time and propagation direction in the SSB frame.
 
-    This generalizes `pycbc.coordinates.space.t_lisa_from_ssb` to accept an
-    arbitrary orbit provider instead of the fixed circular LISA orbit. The
-    constellation is moving, so the arrival time is found by solving the
-    implicit light-travel-time equation self-consistently, exactly as in the
-    original function.
+    Generalizes `pycbc.coordinates.space.t_lisa_from_ssb` to any orbit
+    provider. The constellation moves, so the arrival time solves the
+    implicit light-travel-time equation, as in the original.
 
     Parameters
     ----------
     t_ssb : float
-        The time at which the GW signal arrives at the origin of the SSB
-        frame [s].
+        Arrival time at the SSB frame origin [s].
     k_ssb : (3,) array-like
         The unit propagation vector of the GW signal in the SSB frame.
     orbit : OrbitProvider
@@ -186,8 +176,7 @@ def t_detector_from_ssb(t_ssb, k_ssb, orbit, sc=(1, 2, 3)):
     Returns
     -------
     float
-        The time at which the GW signal arrives at the constellation
-        centroid [s].
+        Arrival time at the constellation centroid [s].
     """
     def position_fn(t):
         return constellation_frame([t], orbit, sc=sc)[0][0]

--- a/test/test_coordinates_space_orbit.py
+++ b/test/test_coordinates_space_orbit.py
@@ -19,9 +19,9 @@ Regression tests for `pycbc.coordinates.space_orbit`.
 Fed the circular LISA orbit that `pycbc.coordinates.space` assumes, the
 generic orbit-provider machinery must reproduce those hard-coded functions.
 The reference orbit is the LISA Data Challenge manual's "Equal arm analytic
-orbit" (LISA-LCST-SGS-MAN-001, Sec. 8.1.1, Eq. 48-52), written out below
-rather than imported from `lisaorbits`, so these tests have no optional
-dependency and are not comparing the code against itself.
+orbit" (LISA-LCST-SGS-MAN-001, Sec. 8.1.1, Eq. 48-52), written out below so
+these tests have no optional dependency and do not check the code against
+itself.
 """
 import numpy
 import unittest
@@ -35,10 +35,8 @@ from utils import simple_exit
 seed = 8202
 numpy.random.seed(seed)
 
-# Reference constants for the LDC "Equal arm analytic orbit" (LISA flavor).
-# The orbit *formula* below is deliberately re-derived rather than imported,
-# so these tests compare two independent implementations; the physical
-# constants it is evaluated with are shared, not re-typed.
+# Constants for the LDC "Equal arm analytic orbit" (LISA flavour). The
+# formula below is re-derived; the physical constants it uses are shared.
 OMEGA_0 = space.EARTH_ORBIT_ANGULAR_FREQUENCY
 ARMLENGTH = 2.5e9  # matches pycbc.detector.space._space_detectors['LISA']
 SEMI_MAJOR_AXIS = au.value
@@ -49,8 +47,7 @@ T0 = space.TIME_OFFSET_20_DEGREES
 def _random_sky_position(with_polarization=False):
     """Shared random (lam, beta[, pol]) sky position/polarization, drawn
     fresh each call from this module's seeded RNG. Used throughout this
-    file instead of hard-coded literals, so a passing test isn't
-    accidentally relying on some property of that one specific value.
+    file, so a passing test isn't relying on one specific value.
     """
     lam = numpy.random.uniform(0.0, 2 * numpy.pi)
     beta = numpy.random.uniform(-numpy.pi / 2, numpy.pi / 2)
@@ -200,8 +197,8 @@ class TestConstellationFrame(unittest.TestCase):
     def test_trails_real_earth_by_documented_lag(self):
         """The guiding center must trail the real Earth (not a zero-phase
         circular proxy) by the 19-23 degree range documented for
-        `TIME_OFFSET_20_DEGREES`, at any time -- not just near the
-        particular epoch that constant happens to have been tuned at.
+        `TIME_OFFSET_20_DEGREES`, at any time, not only near the epoch
+        that constant was tuned at.
         """
         centroid, _ = space_orbit.constellation_frame(self.times, self.orbit)
         for i, t in enumerate(self.times):

--- a/test/test_coordinates_space_orbit.py
+++ b/test/test_coordinates_space_orbit.py
@@ -40,10 +40,10 @@ seed = 8202
 numpy.random.seed(seed)
 
 # Reference constants for the LDC "Equal arm analytic orbit" (LISA flavor).
-# Deliberately re-derived here rather than imported from `space_orbit`, so
-# these tests compare two independent implementations rather than comparing
-# the code to itself.
-OMEGA_0 = 1.99098659277e-7  # 2*pi / sidereal year [rad/s]
+# The orbit *formula* below is deliberately re-derived rather than imported,
+# so these tests compare two independent implementations; the physical
+# constants it is evaluated with are shared, not re-typed.
+OMEGA_0 = space.EARTH_ORBIT_ANGULAR_FREQUENCY
 ARMLENGTH = 2.5e9  # matches pycbc.detector.space._space_detectors['LISA']
 SEMI_MAJOR_AXIS = au.value
 ECCENTRICITY = ARMLENGTH / (2 * SEMI_MAJOR_AXIS * numpy.sqrt(3))
@@ -64,27 +64,29 @@ def _random_sky_position(with_polarization=False):
     return lam, beta
 
 
-class _LisaGuidingCenterFixture:
-    """Mixin providing `_phase(t)` for the LISA fixture's guiding-center
-    convention (`OMEGA_0 * (t + T0)`) -- mirrors the shape of
-    `space_orbit._LisaGuidingCenter`, but independently written (not
-    imported from production), so a bug in the production formula
-    wouldn't be invisible here. Combine with
-    `_EqualArmConstellationFixture`.
+class AnalyticEqualArmOrbit:
+    """Reference implementation of the LDC manual's "Equal arm analytic
+    orbit" (LISA-LCST-SGS-MAN-001, Sec. 8.1.1, Eq. 48-52; Rubbo, Cornish &
+    Poujade 2004, Phys. Rev. D 69, 082003), LISA flavour.
+
+    Written out here rather than imported from `pycbc`, so these tests
+    check `space_orbit.constellation_frame` and the arrival-time functions
+    against an independent implementation of the orbit they are supposed to
+    reproduce, instead of against the code under test.
+
+    Parameters
+    ----------
+    eccentricity : float, optional
+        Constellation eccentricity. Default `ECCENTRICITY`, from LISA's own
+        arm length.
     """
+    def __init__(self, eccentricity=None):
+        self.eccentricity = (
+            ECCENTRICITY if eccentricity is None else eccentricity)
+
     def _phase(self, t):
         return OMEGA_0 * (t + T0)
 
-
-class _EqualArmConstellationFixture:
-    """Mixin implementing `compute_position` for the LDC manual's 'Equal
-    arm analytic orbit' (LISA-LCST-SGS-MAN-001, Sec. 8.1.1, Eq. 48-52) --
-    mirrors `space_orbit._EqualArmConstellation`, independently written.
-    Shared by `AnalyticEqualArmOrbit`/`AnalyticTaijiOrbit` below (same
-    functional form, per Rubbo, Cornish & Poujade 2004, Phys. Rev. D 69,
-    082003); the concrete class's own `__init__` must set
-    `self.eccentricity`.
-    """
     def compute_position(self, t, sc=(1, 2, 3)):
         t = numpy.atleast_1d(numpy.asarray(t, dtype=float))
         sc = numpy.atleast_1d(sc)
@@ -105,26 +107,6 @@ class _EqualArmConstellationFixture:
         return out
 
 
-class AnalyticEqualArmOrbit(_LisaGuidingCenterFixture,
-                             _EqualArmConstellationFixture):
-    """Reference implementation of the LDC manual's 'Equal arm analytic
-    orbit', LISA flavor. Used only to validate `space_orbit.
-    constellation_frame` and related functions against the existing
-    analytic functions in `pycbc.coordinates.space`, which assume this
-    same orbit but only track the (eccentricity-independent) guiding
-    center.
-
-    Parameters
-    ----------
-    eccentricity : float, optional
-        Constellation eccentricity. Default `ECCENTRICITY` (LISA's own
-        arm length).
-    """
-    def __init__(self, eccentricity=None):
-        self.eccentricity = (
-            ECCENTRICITY if eccentricity is None else eccentricity)
-
-
 def _arm_lengths(orbit, t):
     pos = orbit.compute_position(t)
     r1, r2, r3 = pos[:, 0], pos[:, 1], pos[:, 2]
@@ -134,6 +116,17 @@ def _arm_lengths(orbit, t):
 
 
 class TestConstellationFrame(unittest.TestCase):
+    """`constellation_frame` and the arrival-time functions, driven by an
+    independent implementation of the same analytic LISA orbit that
+    `pycbc.coordinates.space` hard-codes.
+
+    The first four tests pin the generalised machinery against the existing
+    `lisa_position_ssb`, `rotation_matrix_ssb_to_lisa`, `t_lisa_from_ssb`
+    and `t_ssb_from_t_lisa`, i.e. they show it reduces to the current
+    behaviour in the circular-orbit case. The rest are self-contained
+    property checks (design arm length, orthonormality, round trip, and the
+    documented Earth-trailing angle) that need no external reference.
+    """
     def setUp(self):
         self.orbit = AnalyticEqualArmOrbit()
         self.precision = 1e-6  # relative to ~1 AU length scale / O(1) rotation
@@ -194,29 +187,6 @@ class TestConstellationFrame(unittest.TestCase):
                 msg=f't_ssb_from_t_detector does not match '
                     f't_ssb_from_t_lisa at t_lisa={t_lisa}')
 
-
-class TestLisaOrbit(unittest.TestCase):
-    """Standalone sanity checks for the LISA fixture, mirroring
-    `TestTaijiOrbit`/`TestTianQinOrbit` below. `TestConstellationFrame`
-    above already gives LISA a stronger check (byte-level agreement with
-    the pre-existing hardcoded `pycbc.coordinates.space` formulas), but
-    that is a different kind of test; these are the same direct,
-    self-contained checks the other two missions get, for consistency.
-
-    Unlike Taiji's fixture (whose 20 degree lead is a bare angular offset
-    added directly to its own phase, checked against an equally-invented
-    zero-phase circular proxy for the Earth), this fixture's `T0` is a time
-    shift, not an angle, and it does not correspond to a clean angle offset
-    from an arbitrary zero-phase circular reference -- comparing against
-    one gives a constant but physically meaningless ~84 degrees. Comparing
-    instead against the real Earth position (`space.earth_position_ssb`,
-    real ephemeris) does give the intended ~20 degree lag, matching the
-    documented 19-23 degree range for `TIME_OFFSET_20_DEGREES`.
-    """
-    def setUp(self):
-        self.orbit = AnalyticEqualArmOrbit()
-        self.times = numpy.random.uniform(0.0, 3.15e7, size=50)
-
     def test_arm_length_matches_design_value(self):
         for d in _arm_lengths(self.orbit, self.times):
             self.assertLess(
@@ -264,7 +234,6 @@ class TestLisaOrbit(unittest.TestCase):
 suite = unittest.TestSuite()
 suite.addTest(unittest.TestLoader().loadTestsFromTestCase(
     TestConstellationFrame))
-suite.addTest(unittest.TestLoader().loadTestsFromTestCase(TestLisaOrbit))
 
 if __name__ == '__main__':
     results = unittest.TextTestRunner(verbosity=2).run(suite)

--- a/test/test_coordinates_space_orbit.py
+++ b/test/test_coordinates_space_orbit.py
@@ -1,0 +1,271 @@
+# Copyright (C) 2026  Shichao Wu, Alex Nitz
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+"""
+Regression tests for `pycbc.coordinates.space_orbit`.
+
+The core claim being tested is backward compatibility: the generic,
+orbit-provider-based machinery in `space_orbit` must reproduce the existing,
+hard-coded circular-orbit LISA functions in `pycbc.coordinates.space` exactly
+(to floating point precision) when fed the same analytic circular orbit that
+those functions assume. The reference orbit used here is the "Equal arm
+analytic orbit" defined in the LISA Data Challenge manual
+(LISA-LCST-SGS-MAN-001, Sec. 8.1.1, Eq. 48-52); this is the same closed-form
+per-spacecraft trajectory implemented by `lisaorbits.EqualArmlengthOrbits`,
+reimplemented here directly (not imported from `lisaorbits`) so this test has
+no optional dependency.
+"""
+import numpy
+import unittest
+from astropy.constants import au
+
+from pycbc.coordinates import space
+from pycbc.coordinates import space_orbit
+from utils import simple_exit
+
+
+seed = 8202
+numpy.random.seed(seed)
+
+# Reference constants for the LDC "Equal arm analytic orbit" (LISA flavor).
+# Deliberately re-derived here rather than imported from `space_orbit`, so
+# these tests compare two independent implementations rather than comparing
+# the code to itself.
+OMEGA_0 = 1.99098659277e-7  # 2*pi / sidereal year [rad/s]
+ARMLENGTH = 2.5e9  # matches pycbc.detector.space._space_detectors['LISA']
+SEMI_MAJOR_AXIS = au.value
+ECCENTRICITY = ARMLENGTH / (2 * SEMI_MAJOR_AXIS * numpy.sqrt(3))
+T0 = space.TIME_OFFSET_20_DEGREES
+
+
+def _random_sky_position(with_polarization=False):
+    """Shared random (lam, beta[, pol]) sky position/polarization, drawn
+    fresh each call from this module's seeded RNG. Used throughout this
+    file instead of hard-coded literals, so a passing test isn't
+    accidentally relying on some property of that one specific value.
+    """
+    lam = numpy.random.uniform(0.0, 2 * numpy.pi)
+    beta = numpy.random.uniform(-numpy.pi / 2, numpy.pi / 2)
+    if with_polarization:
+        pol = numpy.random.uniform(0.0, 2 * numpy.pi)
+        return lam, beta, pol
+    return lam, beta
+
+
+class _LisaGuidingCenterFixture:
+    """Mixin providing `_phase(t)` for the LISA fixture's guiding-center
+    convention (`OMEGA_0 * (t + T0)`) -- mirrors the shape of
+    `space_orbit._LisaGuidingCenter`, but independently written (not
+    imported from production), so a bug in the production formula
+    wouldn't be invisible here. Combine with
+    `_EqualArmConstellationFixture`.
+    """
+    def _phase(self, t):
+        return OMEGA_0 * (t + T0)
+
+
+class _EqualArmConstellationFixture:
+    """Mixin implementing `compute_position` for the LDC manual's 'Equal
+    arm analytic orbit' (LISA-LCST-SGS-MAN-001, Sec. 8.1.1, Eq. 48-52) --
+    mirrors `space_orbit._EqualArmConstellation`, independently written.
+    Shared by `AnalyticEqualArmOrbit`/`AnalyticTaijiOrbit` below (same
+    functional form, per Rubbo, Cornish & Poujade 2004, Phys. Rev. D 69,
+    082003); the concrete class's own `__init__` must set
+    `self.eccentricity`.
+    """
+    def compute_position(self, t, sc=(1, 2, 3)):
+        t = numpy.atleast_1d(numpy.asarray(t, dtype=float))
+        sc = numpy.atleast_1d(sc)
+        alpha = self._phase(t)
+        out = numpy.empty((len(t), len(sc), 3))
+        for k, n in enumerate(sc):
+            beta_n = (n - 1) * 2 * numpy.pi / 3.0
+            out[:, k, 0] = SEMI_MAJOR_AXIS * numpy.cos(alpha) \
+                + SEMI_MAJOR_AXIS * self.eccentricity * (
+                    numpy.sin(alpha) * numpy.cos(alpha) * numpy.sin(beta_n)
+                    - (1 + numpy.sin(alpha) ** 2) * numpy.cos(beta_n))
+            out[:, k, 1] = SEMI_MAJOR_AXIS * numpy.sin(alpha) \
+                + SEMI_MAJOR_AXIS * self.eccentricity * (
+                    numpy.sin(alpha) * numpy.cos(alpha) * numpy.cos(beta_n)
+                    - (1 + numpy.cos(alpha) ** 2) * numpy.sin(beta_n))
+            out[:, k, 2] = -numpy.sqrt(3) * SEMI_MAJOR_AXIS \
+                * self.eccentricity * numpy.cos(alpha - beta_n)
+        return out
+
+
+class AnalyticEqualArmOrbit(_LisaGuidingCenterFixture,
+                             _EqualArmConstellationFixture):
+    """Reference implementation of the LDC manual's 'Equal arm analytic
+    orbit', LISA flavor. Used only to validate `space_orbit.
+    constellation_frame` and related functions against the existing
+    analytic functions in `pycbc.coordinates.space`, which assume this
+    same orbit but only track the (eccentricity-independent) guiding
+    center.
+
+    Parameters
+    ----------
+    eccentricity : float, optional
+        Constellation eccentricity. Default `ECCENTRICITY` (LISA's own
+        arm length).
+    """
+    def __init__(self, eccentricity=None):
+        self.eccentricity = (
+            ECCENTRICITY if eccentricity is None else eccentricity)
+
+
+def _arm_lengths(orbit, t):
+    pos = orbit.compute_position(t)
+    r1, r2, r3 = pos[:, 0], pos[:, 1], pos[:, 2]
+    return (numpy.linalg.norm(r1 - r2, axis=-1),
+            numpy.linalg.norm(r2 - r3, axis=-1),
+            numpy.linalg.norm(r1 - r3, axis=-1))
+
+
+class TestConstellationFrame(unittest.TestCase):
+    def setUp(self):
+        self.orbit = AnalyticEqualArmOrbit()
+        self.precision = 1e-6  # relative to ~1 AU length scale / O(1) rotation
+        self.times = numpy.random.uniform(0.0, 3.15e7, size=50)
+
+    def test_centroid_matches_lisa_position_ssb(self):
+        """The constellation centroid derived from the 3 spacecraft
+        positions must match the existing (eccentricity-independent)
+        guiding-center formula `lisa_position_ssb`, since the average of the
+        Equal Arm orbit's eccentricity terms over the 3 spacecraft is
+        exactly zero at every order.
+        """
+        centroid, _ = space_orbit.constellation_frame(self.times, self.orbit)
+        expected = numpy.array([
+            space.lisa_position_ssb(t, T0)[0].flatten().astype(float)
+            for t in self.times
+        ])
+        maxdiff = numpy.max(numpy.abs(centroid - expected))
+        self.assertLess(maxdiff, self.precision * SEMI_MAJOR_AXIS,
+                        f'constellation centroid does not match '
+                        f'lisa_position_ssb; max abs diff {maxdiff}')
+
+    def test_rotation_matches_rotation_matrix_ssb_to_lisa(self):
+        """The rotation matrix derived from the 3 spacecraft positions must
+        match the existing analytic `rotation_matrix_ssb_to_lisa`.
+        """
+        _, rotation = space_orbit.constellation_frame(self.times, self.orbit)
+        for i, t in enumerate(self.times):
+            alpha = OMEGA_0 * (t + T0)
+            expected = space.rotation_matrix_ssb_to_lisa(alpha)
+            maxdiff = numpy.max(numpy.abs(rotation[i] - expected))
+            self.assertLess(maxdiff, self.precision,
+                            f'rotation matrix at t={t} does not match '
+                            f'rotation_matrix_ssb_to_lisa; max abs diff '
+                            f'{maxdiff}')
+
+    def test_t_detector_from_ssb_matches_t_lisa_from_ssb(self):
+        lam, beta = _random_sky_position()
+        k_ssb = space.localization_to_propagation_vector(
+            lam, beta, use_astropy=False).flatten()
+        for t_ssb in self.times[:10]:
+            expected = space.t_lisa_from_ssb(t_ssb, lam, beta, T0)
+            derived = space_orbit.t_detector_from_ssb(
+                t_ssb, k_ssb, self.orbit)
+            self.assertLess(abs(derived - expected), 1e-10,
+                msg=f't_detector_from_ssb does not match t_lisa_from_ssb '
+                    f'at t_ssb={t_ssb}')
+
+    def test_t_ssb_from_t_detector_matches_t_ssb_from_t_lisa(self):
+        lam, beta = _random_sky_position()
+        k_ssb = space.localization_to_propagation_vector(
+            lam, beta, use_astropy=False).flatten()
+        for t_lisa in self.times[:10]:
+            expected = space.t_ssb_from_t_lisa(t_lisa, lam, beta, T0)
+            derived = space_orbit.t_ssb_from_t_detector(
+                t_lisa, k_ssb, self.orbit)
+            self.assertLess(abs(derived - expected), 1e-10,
+                msg=f't_ssb_from_t_detector does not match '
+                    f't_ssb_from_t_lisa at t_lisa={t_lisa}')
+
+
+class TestLisaOrbit(unittest.TestCase):
+    """Standalone sanity checks for the LISA fixture, mirroring
+    `TestTaijiOrbit`/`TestTianQinOrbit` below. `TestConstellationFrame`
+    above already gives LISA a stronger check (byte-level agreement with
+    the pre-existing hardcoded `pycbc.coordinates.space` formulas), but
+    that is a different kind of test; these are the same direct,
+    self-contained checks the other two missions get, for consistency.
+
+    Unlike Taiji's fixture (whose 20 degree lead is a bare angular offset
+    added directly to its own phase, checked against an equally-invented
+    zero-phase circular proxy for the Earth), this fixture's `T0` is a time
+    shift, not an angle, and it does not correspond to a clean angle offset
+    from an arbitrary zero-phase circular reference -- comparing against
+    one gives a constant but physically meaningless ~84 degrees. Comparing
+    instead against the real Earth position (`space.earth_position_ssb`,
+    real ephemeris) does give the intended ~20 degree lag, matching the
+    documented 19-23 degree range for `TIME_OFFSET_20_DEGREES`.
+    """
+    def setUp(self):
+        self.orbit = AnalyticEqualArmOrbit()
+        self.times = numpy.random.uniform(0.0, 3.15e7, size=50)
+
+    def test_arm_length_matches_design_value(self):
+        for d in _arm_lengths(self.orbit, self.times):
+            self.assertLess(
+                numpy.max(numpy.abs(d - ARMLENGTH)), 1.0,
+                'LISA arm length deviates from the 2.5e6 km design value '
+                'by more than 1 m')
+
+    def test_trails_real_earth_by_documented_lag(self):
+        """The guiding center must trail the real Earth (not a zero-phase
+        circular proxy) by the 19-23 degree range documented for
+        `TIME_OFFSET_20_DEGREES`, at any time -- not just near the
+        particular epoch that constant happens to have been tuned at.
+        """
+        centroid, _ = space_orbit.constellation_frame(self.times, self.orbit)
+        for i, t in enumerate(self.times):
+            earth_pos = space.earth_position_ssb(t)[0].flatten().astype(
+                float)
+            cos_angle = numpy.dot(centroid[i], earth_pos) / (
+                numpy.linalg.norm(centroid[i]) * numpy.linalg.norm(
+                    earth_pos))
+            angle_deg = numpy.rad2deg(numpy.arccos(
+                numpy.clip(cos_angle, -1, 1)))
+            self.assertTrue(
+                17.0 < angle_deg < 24.0,
+                f'LISA-to-real-Earth angle {angle_deg} deg at t={t} is '
+                f'outside the documented ~19-23 degree range')
+
+    def test_rotation_orthonormal(self):
+        _, rotation = space_orbit.constellation_frame(self.times, self.orbit)
+        for r in rotation:
+            self.assertLess(
+                numpy.max(numpy.abs(r @ r.T - numpy.eye(3))), 1e-8)
+
+    def test_round_trip_time_delay(self):
+        lam, beta = _random_sky_position()
+        k_ssb = space.localization_to_propagation_vector(
+            lam, beta, use_astropy=False).flatten()
+        for t_ssb in self.times[:10]:
+            t_det = space_orbit.t_detector_from_ssb(t_ssb, k_ssb, self.orbit)
+            t_ssb_roundtrip = space_orbit.t_ssb_from_t_detector(
+                t_det, k_ssb, self.orbit)
+            self.assertLess(abs(t_ssb_roundtrip - t_ssb), 1e-10)
+
+
+suite = unittest.TestSuite()
+suite.addTest(unittest.TestLoader().loadTestsFromTestCase(
+    TestConstellationFrame))
+suite.addTest(unittest.TestLoader().loadTestsFromTestCase(TestLisaOrbit))
+
+if __name__ == '__main__':
+    results = unittest.TextTestRunner(verbosity=2).run(suite)
+    simple_exit(results)

--- a/test/test_coordinates_space_orbit.py
+++ b/test/test_coordinates_space_orbit.py
@@ -16,16 +16,12 @@
 """
 Regression tests for `pycbc.coordinates.space_orbit`.
 
-The core claim being tested is backward compatibility: the generic,
-orbit-provider-based machinery in `space_orbit` must reproduce the existing,
-hard-coded circular-orbit LISA functions in `pycbc.coordinates.space` exactly
-(to floating point precision) when fed the same analytic circular orbit that
-those functions assume. The reference orbit used here is the "Equal arm
-analytic orbit" defined in the LISA Data Challenge manual
-(LISA-LCST-SGS-MAN-001, Sec. 8.1.1, Eq. 48-52); this is the same closed-form
-per-spacecraft trajectory implemented by `lisaorbits.EqualArmlengthOrbits`,
-reimplemented here directly (not imported from `lisaorbits`) so this test has
-no optional dependency.
+Fed the circular LISA orbit that `pycbc.coordinates.space` assumes, the
+generic orbit-provider machinery must reproduce those hard-coded functions.
+The reference orbit is the LISA Data Challenge manual's "Equal arm analytic
+orbit" (LISA-LCST-SGS-MAN-001, Sec. 8.1.1, Eq. 48-52), written out below
+rather than imported from `lisaorbits`, so these tests have no optional
+dependency and are not comparing the code against itself.
 """
 import numpy
 import unittest
@@ -65,14 +61,9 @@ def _random_sky_position(with_polarization=False):
 
 
 class AnalyticEqualArmOrbit:
-    """Reference implementation of the LDC manual's "Equal arm analytic
-    orbit" (LISA-LCST-SGS-MAN-001, Sec. 8.1.1, Eq. 48-52; Rubbo, Cornish &
-    Poujade 2004, Phys. Rev. D 69, 082003), LISA flavour.
-
-    Written out here rather than imported from `pycbc`, so these tests
-    check `space_orbit.constellation_frame` and the arrival-time functions
-    against an independent implementation of the orbit they are supposed to
-    reproduce, instead of against the code under test.
+    """The LDC manual's "Equal arm analytic orbit" (LISA-LCST-SGS-MAN-001,
+    Sec. 8.1.1, Eq. 48-52; Rubbo, Cornish & Poujade 2004, Phys. Rev. D 69,
+    082003), LISA flavour, written out independently of `pycbc`.
 
     Parameters
     ----------
@@ -116,16 +107,11 @@ def _arm_lengths(orbit, t):
 
 
 class TestConstellationFrame(unittest.TestCase):
-    """`constellation_frame` and the arrival-time functions, driven by an
-    independent implementation of the same analytic LISA orbit that
-    `pycbc.coordinates.space` hard-codes.
-
-    The first four tests pin the generalised machinery against the existing
+    """Some tests here pin the new machinery against the existing
     `lisa_position_ssb`, `rotation_matrix_ssb_to_lisa`, `t_lisa_from_ssb`
-    and `t_ssb_from_t_lisa`, i.e. they show it reduces to the current
-    behaviour in the circular-orbit case. The rest are self-contained
-    property checks (design arm length, orthonormality, round trip, and the
-    documented Earth-trailing angle) that need no external reference.
+    and `t_ssb_from_t_lisa`, showing it reduces to current behaviour for a
+    circular orbit. The rest are self-contained property checks (arm
+    length, orthonormality, round trip, Earth-trailing angle).
     """
     def setUp(self):
         self.orbit = AnalyticEqualArmOrbit()
@@ -162,6 +148,23 @@ class TestConstellationFrame(unittest.TestCase):
                             f'rotation matrix at t={t} does not match '
                             f'rotation_matrix_ssb_to_lisa; max abs diff '
                             f'{maxdiff}')
+
+    def test_reference_arrival_time_functions_round_trip(self):
+        """The two tests below pin the new functions against
+        `t_lisa_from_ssb`/`t_ssb_from_t_lisa`, so that pair has to be
+        self-consistent for the comparison to mean anything. On master it
+        has no round-trip test of its own -- only the indirect one through
+        `test_round_robin` in test_coordinates_space.py, which goes through
+        the four-parameter transforms -- so check it directly here first.
+        """
+        lam, beta = _random_sky_position()
+        for t_ssb in self.times[:10]:
+            t_lisa = space.t_lisa_from_ssb(t_ssb, lam, beta, T0)
+            recovered = space.t_ssb_from_t_lisa(t_lisa, lam, beta, T0)
+            self.assertLess(
+                abs(recovered - t_ssb), 1e-10,
+                f't_lisa_from_ssb/t_ssb_from_t_lisa do not round trip at '
+                f't_ssb={t_ssb}')
 
     def test_t_detector_from_ssb_matches_t_lisa_from_ssb(self):
         lam, beta = _random_sky_position()


### PR DESCRIPTION
<!---
Please delete these comments when you submit the pull request

Please add a title which is a concise description of what you are doing,
e.g. 'Fix bug with numpy import in pycbc_coinc_findtrigs' or 'add high frequency sky location dependent response for long detectors'
-->

<!---
This is a brief template for making pull requests for PyCBC.
This is _not_ a proscriptive template - you can use a different style if you want.
Please do think about the questions posed here and whether the details will be useful to include in your PR
Please add sufficient details so that people looking back at the request with no context around the work can understand the changes.
To choose reviewers, please look at the git blame for the code you are changing (if applicable),
or discuss in the #pycbc-code channel of the gwastro slack.
Please add labels as appropriate
-->

<!-- TOP-LEVEL SUMMARY: Please provide a brief, one-or-two-sentence description of the PR here
-->

## Standard information about the request

<!--- Some basic info about the change (delete as appropriate) -->
This is a: new feature

<!--- What codes will this affect? (delete as apropriate)
If you do not know which areas will be affected, please ask in the gwastro #pycbc-code slack
-->
This change affects: inference, LISA-related code

<!--- What code areas will this affect? (delete as apropriate) -->
This change changes: documentation, result presentation / plotting, scientific output

<!--- Some things which help with code management (delete as appropriate) -->
This change: has appropriate unit tests, follows style guidelines (See e.g. [PEP8](https://peps.python.org/pep-0008/)), has been proposed using the [contribution guidelines](https://github.com/gwastro/pycbc/blob/master/CONTRIBUTING.md)

## Motivation
<!--- Describe why your changes are being made -->
The "constellation-frame" mechanism in `pycbc.coordinates.space` (originally hard-coded for LISA's circular orbits) has been generalized to support arbitrary triangular constellation orbits for any mission.

## Contents
<!--- Describe your changes, this doesn't need to be a line-by-line code change discussion,
but rather a general discussion of the methods chosen -->

A new module, `pycbc/coordinates/space_orbit.py`, has been introduced. It includes `constellation_frame` (constructed directly from the positions of three spacecraft, providing the centroid and the rotation matrix from the Solar System Barycenter (SSB) frame to the constellation frame) as well as `t_detector_from_ssb` and `t_ssb_from_t_detector` (handling time-of-arrival conversions at the constellation centroid), all sharing a common `fsolve` helper function. Orbit providers need only implement a `compute_position(t, sc)` method matching the signature and return shape of `lisaorbits.Orbits`, allowing actual `lisaorbits` instances to be passed directly; the module itself neither imports nor depends on `lisaorbits`.

## Links to any issues or associated PRs
<!--- If this is fixing / working around an already-reported issue, please link to it here -->
This PR generalizes PR https://github.com/gwastro/pycbc/pull/4289

## Testing performed
<!--- Describe tests for the code changes, either already performed or to be performed -->
Existing content in `pycbc.coordinates.space` remains unchanged; this update is purely additive. The new mechanism was validated by comparing its output against the existing `lisa_position_ssb`, `rotation_matrix_ssb_to_lisa`, `t_lisa_from_ssb`, and `t_ssb_from_t_lisa` functions. The orbital data used for testing were derived independently based on the LDC manual rather than generated by the code under test, thereby confirming that the generalized implementation successfully reproduces the original LISA-specific behavior for circular orbits.

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
