### PR TITLE
Add NumericOrbits spline interpolator and pycbc HDF5 orbit format

### DIFF
--- a/pycbc/coordinates/__init__.py
+++ b/pycbc/coordinates/__init__.py
@@ -18,9 +18,11 @@ more advanced transformations between ground-based detectors and space-borne
 detectors.
 """
 
+# ruff: noqa: F403, F405 -- deliberate `import *` re-export, see __all__
+
 from pycbc.coordinates.base import *
 from pycbc.coordinates.space import *
-
+from pycbc.coordinates.space_orbit import *
 
 __all__ = ['cartesian_to_spherical_rho', 'cartesian_to_spherical_azimuthal',
            'cartesian_to_spherical_polar', 'cartesian_to_spherical',
@@ -34,4 +36,5 @@ __all__ = ['cartesian_to_spherical_rho', 'cartesian_to_spherical_azimuthal',
            'lisa_position_ssb', 'earth_position_ssb',
            't_geo_from_ssb', 't_ssb_from_t_geo', 'ssb_to_geo', 'geo_to_ssb',
            'lisa_to_geo', 'geo_to_lisa',
+           'NumericOrbits',
            ]

--- a/pycbc/coordinates/space_orbit.py
+++ b/pycbc/coordinates/space_orbit.py
@@ -1,0 +1,256 @@
+# Copyright (C) 2026  Shichao Wu, Alex Nitz
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+#
+# =============================================================================
+#
+#                                   Preamble
+#
+# =============================================================================
+#
+"""
+This module generalizes the constellation-frame machinery in
+`pycbc.coordinates.space` (which assumes a fixed, analytic, circular LISA
+orbit) to work with an arbitrary triangular constellation orbit, analytic or
+numerical, for any mission (LISA, Taiji, TianQin, ...).
+
+Any object exposing `compute_position(t, sc)` with the same call signature
+and return shape as `lisaorbits.Orbits` (https://pypi.org/project/lisaorbits)
+can be used as an orbit provider, including a real `lisaorbits.Orbits`
+instance passed in directly -- this module does not import or depend on
+`lisaorbits` itself. Users who do not have `lisaorbits` installed can instead
+use `NumericOrbits` below, which reads the same (times, positions[,
+velocities]) input as `lisaorbits.InterpolatedOrbits` and interpolates using
+only `scipy`.
+
+`compute_velocity(t, sc)` and `compute_acceleration(t, sc)` (same calling
+convention, [m/s] and [m/s^2]) are analytic derivatives of the interpolating
+spline, exactly mirroring `lisaorbits.InterpolatedOrbits`.
+
+This module does not change or replace anything in `pycbc.coordinates.space`;
+it is purely additive.
+"""
+import h5py
+import numpy as np
+from scipy.interpolate import make_interp_spline
+
+logger = __import__('logging').getLogger(__name__)
+
+
+class NumericOrbits:
+    """Interpolate a numerical constellation orbit given as arrays of
+    spacecraft position (and, optionally, velocity) samples in the SSB frame.
+
+    Mirrors the input contract of `lisaorbits.InterpolatedOrbits`, using
+    only `scipy` for the spline interpolation, so it works as a drop-in
+    `OrbitProvider` without requiring `lisaorbits` to be installed.
+
+    Parameters
+    ----------
+    t_interp : (N,) array-like
+        Interpolating SSB times [s] (must be strictly increasing).
+    positions : (N, M, 3) array-like
+        Spacecraft positions in the SSB frame [m]: N time samples, M
+        spacecraft (any number, not just 3 -- see `num_sc` below), 3
+        Cartesian (x, y, z) coordinates each.
+    velocities : (N, M, 3) array-like or None, optional
+        Spacecraft velocities in the SSB frame [m/s], same shape as
+        `positions`. If None (the default), velocities are computed as the
+        analytic derivative of the position spline.
+    interp_order : int, optional
+        Spline interpolation order. Default 5 (quintic), matching the
+        default used by `lisaorbits.InterpolatedOrbits`.
+    """
+
+    def __init__(self, t_interp, positions, velocities=None, interp_order=5):
+        self.t_interp = np.asarray(t_interp, dtype=float)
+        self.positions = np.asarray(positions, dtype=float)
+
+        if self.t_interp.ndim != 1:
+            raise ValueError(
+                f't_interp must be 1-dimensional, got shape '
+                f'{self.t_interp.shape}')
+        if self.positions.ndim != 3 or self.positions.shape[2] != 3:
+            raise ValueError(
+                'positions must have shape (N, M, 3), got shape '
+                f'{self.positions.shape}')
+        if self.positions.shape[0] != self.t_interp.shape[0]:
+            raise ValueError(
+                'positions and t_interp must agree along the time axis: '
+                f'got {self.positions.shape[0]} and {self.t_interp.shape[0]}')
+
+        self.num_sc = self.positions.shape[1]
+        self.interp_order = int(interp_order)
+        if self.interp_order < 3:
+            raise ValueError(
+                f'interp_order must be at least 3, got {interp_order}')
+
+        def interpolate(y):
+            # One vector-valued spline over all (spacecraft, xyz) columns
+            # flattened together, not num_sc*3 separate scalar splines:
+            # scipy shares the basis-function computation across columns
+            # in a single BSpline call, ~5-8x faster with identical results.
+            return make_interp_spline(
+                self.t_interp, y.reshape(len(self.t_interp), -1),
+                k=self.interp_order)
+
+        self._pos_spline = interpolate(self.positions)
+
+        if velocities is not None:
+            velocities = np.asarray(velocities, dtype=float)
+            if velocities.shape != self.positions.shape:
+                raise ValueError(
+                    'velocities must have the same shape as positions: '
+                    f'got {velocities.shape} and {self.positions.shape}')
+            self._vel_spline = interpolate(velocities)
+        else:
+            self._vel_spline = self._pos_spline.derivative()
+        # Kept only so `to_file` can round-trip whether velocities were
+        # explicitly supplied (written out) or derived (omitted, so a
+        # reloaded instance re-derives them the same way this one did).
+        self.velocities = velocities
+
+        # Acceleration is always the derivative of the velocity spline
+        # (provided or derived), matching lisaorbits.InterpolatedOrbits.
+        self._acc_spline = self._vel_spline.derivative()
+    def _sc_indices(self, sc):
+        """Map 1-indexed spacecraft labels (matching the `lisaorbits`
+        convention) to 0-indexed array positions. `sc=None` selects all
+        spacecraft.
+        """
+        if sc is None:
+            return np.arange(self.num_sc)
+        sc = np.atleast_1d(np.asarray(sc))
+        if np.any(sc < 1) or np.any(sc > self.num_sc):
+            raise ValueError(
+                f'spacecraft labels must be in [1, {self.num_sc}], got {sc}')
+        return sc - 1
+    def _evaluate(self, spline, t, sc):
+        t = np.atleast_1d(np.asarray(t, dtype=float))
+        idx = self._sc_indices(sc)
+        values = spline(t).reshape(len(t), self.num_sc, 3)
+        return values[:, idx, :]
+    def compute_position(self, t, sc=None):
+        """Spacecraft position(s) at time(s) `t`.
+
+        Parameters
+        ----------
+        t : (N,) array-like
+            SSB time [s].
+        sc : (M,) array-like or None, optional
+            1-indexed spacecraft label(s). Default all spacecraft.
+
+        Returns
+        -------
+        (N, M, 3) ndarray
+            Spacecraft position(s) in the SSB frame [m].
+        """
+        return self._evaluate(self._pos_spline, t, sc)
+    def compute_velocity(self, t, sc=None):
+        """Spacecraft velocity/ies at time(s) `t`. Same conventions as
+        `compute_position`.
+
+        Returns
+        -------
+        (N, M, 3) ndarray
+            Spacecraft velocity/ies in the SSB frame [m/s].
+        """
+        return self._evaluate(self._vel_spline, t, sc)
+    def compute_acceleration(self, t, sc=None):
+        """Spacecraft acceleration(s) at time(s) `t`, as the analytic
+        derivative of `compute_velocity`'s spline. Same conventions as
+        `compute_position`.
+
+        Returns
+        -------
+        (N, M, 3) ndarray
+            Spacecraft acceleration(s) in the SSB frame [m/s^2].
+        """
+        return self._evaluate(self._acc_spline, t, sc)
+    @classmethod
+    def from_file(cls, path, group=None, interp_order=5):
+        """Load a numerical constellation orbit from an HDF5 file.
+
+        The file (or the given group within it) must contain datasets `t`
+        (shape (N,), SSB time [s]) and `positions` (shape (N, M, 3), SSB-
+        frame spacecraft positions [m]). An optional `velocities` dataset
+        (same shape as `positions`) is used if present; otherwise
+        velocities are the analytic derivative of the position spline, as
+        in `__init__`. This is the file format LISA, Taiji, or TianQin (or
+        a numerically-propagated orbit for any of them) can be supplied
+        in, e.g. from a PE config's `orbit-file` option (see
+        `pycbc.transforms`).
+
+        Parameters
+        ----------
+        path : str
+            Path to the HDF5 orbit file.
+        group : str, optional
+            Name of an HDF5 group within the file to read the datasets
+            from. Default None (read from the file's root).
+        interp_order : int, optional
+            See `__init__`. Default 5.
+
+        Returns
+        -------
+        NumericOrbits
+            A `NumericOrbits` instance built from the file's contents.
+        """
+        with h5py.File(path, 'r') as f:
+            node = f[group] if group is not None else f
+            t_interp = node['t'][:]
+            positions = node['positions'][:]
+            velocities = node['velocities'][:] \
+                if 'velocities' in node else None
+        return cls(t_interp, positions, velocities=velocities,
+                   interp_order=interp_order)
+    def to_file(self, path, group=None, mode='w'):
+        """Write this orbit to an HDF5 file in the format read by
+        `from_file`, e.g. for use with a PE config's `orbit-file` option
+        (see `pycbc.transforms`).
+
+        Writes datasets `t` (SSB time [s]) and `positions` (SSB-frame
+        spacecraft positions [m]). If this instance was constructed with
+        explicit `velocities`, those are written too; otherwise the
+        `velocities` dataset is omitted, so a round trip through
+        `from_file` re-derives velocities from the position spline exactly
+        as this instance does, rather than through an extra layer of
+        spline interpolation of re-sampled velocities. Acceleration is
+        never stored -- as in `__init__`, it's always the analytic
+        derivative of the velocity spline.
+
+        Parameters
+        ----------
+        path : str
+            Path to the HDF5 orbit file to write.
+        group : str, optional
+            Name of an HDF5 group within the file to write the datasets
+            to. Default None (write to the file's root).
+        mode : str, optional
+            `h5py.File` mode. Default 'w' (create the file, truncating any
+            existing file at `path`); use 'a' to add a group to an
+            existing file.
+        """
+        with h5py.File(path, mode) as f:
+            node = f.create_group(group) if group is not None else f
+            node['t'] = self.t_interp
+            node['positions'] = self.positions
+            if self.velocities is not None:
+                node['velocities'] = self.velocities
+
+
+__all__ = [
+    'NumericOrbits',
+]

--- a/pycbc/coordinates/space_orbit.py
+++ b/pycbc/coordinates/space_orbit.py
@@ -37,10 +37,7 @@ only `scipy`.
 
 `compute_velocity(t, sc)` and `compute_acceleration(t, sc)` (same calling
 convention, [m/s] and [m/s^2]) are analytic derivatives of the interpolating
-spline, exactly mirroring `lisaorbits.InterpolatedOrbits`.
-
-This module does not change or replace anything in `pycbc.coordinates.space`;
-it is purely additive.
+spline, mirroring `lisaorbits.InterpolatedOrbits`.
 """
 import h5py
 import numpy as np
@@ -232,9 +229,8 @@ class NumericOrbits:
         spacecraft positions [m]). If this instance was constructed with
         explicit `velocities`, those are written too; otherwise the
         `velocities` dataset is omitted, so a round trip through
-        `from_file` re-derives velocities from the position spline exactly
-        as this instance does, rather than through an extra layer of
-        spline interpolation of re-sampled velocities. Acceleration is
+        `from_file` re-derives velocities from the position spline the
+        same way this instance does.
         never stored -- as in `__init__`, it's always the analytic
         derivative of the velocity spline.
 

--- a/pycbc/coordinates/space_orbit.py
+++ b/pycbc/coordinates/space_orbit.py
@@ -125,6 +125,7 @@ class NumericOrbits:
         # Acceleration is always the derivative of the velocity spline
         # (provided or derived), matching lisaorbits.InterpolatedOrbits.
         self._acc_spline = self._vel_spline.derivative()
+
     def _sc_indices(self, sc):
         """Map 1-indexed spacecraft labels (matching the `lisaorbits`
         convention) to 0-indexed array positions. `sc=None` selects all
@@ -137,11 +138,13 @@ class NumericOrbits:
             raise ValueError(
                 f'spacecraft labels must be in [1, {self.num_sc}], got {sc}')
         return sc - 1
+
     def _evaluate(self, spline, t, sc):
         t = np.atleast_1d(np.asarray(t, dtype=float))
         idx = self._sc_indices(sc)
         values = spline(t).reshape(len(t), self.num_sc, 3)
         return values[:, idx, :]
+
     def compute_position(self, t, sc=None):
         """Spacecraft position(s) at time(s) `t`.
 
@@ -158,6 +161,7 @@ class NumericOrbits:
             Spacecraft position(s) in the SSB frame [m].
         """
         return self._evaluate(self._pos_spline, t, sc)
+
     def compute_velocity(self, t, sc=None):
         """Spacecraft velocity/ies at time(s) `t`. Same conventions as
         `compute_position`.
@@ -168,6 +172,7 @@ class NumericOrbits:
             Spacecraft velocity/ies in the SSB frame [m/s].
         """
         return self._evaluate(self._vel_spline, t, sc)
+
     def compute_acceleration(self, t, sc=None):
         """Spacecraft acceleration(s) at time(s) `t`, as the analytic
         derivative of `compute_velocity`'s spline. Same conventions as
@@ -179,6 +184,7 @@ class NumericOrbits:
             Spacecraft acceleration(s) in the SSB frame [m/s^2].
         """
         return self._evaluate(self._acc_spline, t, sc)
+
     @classmethod
     def from_file(cls, path, group=None, interp_order=5):
         """Load a numerical constellation orbit from an HDF5 file.
@@ -216,6 +222,7 @@ class NumericOrbits:
                 if 'velocities' in node else None
         return cls(t_interp, positions, velocities=velocities,
                    interp_order=interp_order)
+
     def to_file(self, path, group=None, mode='w'):
         """Write this orbit to an HDF5 file in the format read by
         `from_file`, e.g. for use with a PE config's `orbit-file` option

--- a/test/test_coordinates_space_orbit.py
+++ b/test/test_coordinates_space_orbit.py
@@ -21,8 +21,7 @@ spacecraft positions, optionally velocities) with a scipy B-spline, and
 reads/writes pycbc's own HDF5 orbit format. The reference orbit used here is
 the "Equal arm analytic orbit" of the LISA Data Challenge manual
 (LISA-LCST-SGS-MAN-001, Sec. 8.1.1, Eq. 48-52), reimplemented directly in
-this file rather than imported, so these tests compare two independent
-implementations rather than comparing the code to itself.
+this file, so these tests compare two independent implementations.
 """
 import os
 import tempfile
@@ -182,7 +181,7 @@ class TestNumericOrbitsFileIO(unittest.TestCase):
         """With no explicit velocities at construction, the `velocities`
         dataset must be omitted (not written as zeros or anything else), so
         a reloaded instance re-derives velocities from the position spline
-        exactly as the original did.
+        the same way the original did.
         """
         orbit = space_orbit.NumericOrbits(
             self.t_grid, self.exact_orbit.compute_position(self.t_grid))

--- a/test/test_coordinates_space_orbit.py
+++ b/test/test_coordinates_space_orbit.py
@@ -1,0 +1,251 @@
+# Copyright (C) 2026  Shichao Wu, Alex Nitz
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+"""
+Regression tests for `pycbc.coordinates.space_orbit.NumericOrbits`.
+
+`NumericOrbits` interpolates a tabulated constellation orbit (times and
+spacecraft positions, optionally velocities) with a scipy B-spline, and
+reads/writes pycbc's own HDF5 orbit format. The reference orbit used here is
+the "Equal arm analytic orbit" of the LISA Data Challenge manual
+(LISA-LCST-SGS-MAN-001, Sec. 8.1.1, Eq. 48-52), reimplemented directly in
+this file rather than imported, so these tests compare two independent
+implementations rather than comparing the code to itself.
+"""
+import os
+import tempfile
+import h5py
+import numpy
+import unittest
+from astropy.constants import au
+
+from pycbc.coordinates import space
+from pycbc.coordinates import space_orbit
+from utils import simple_exit
+
+
+seed = 8202
+numpy.random.seed(seed)
+
+OMEGA_0 = 1.99098659277e-7  # 2*pi / sidereal year [rad/s]
+ARMLENGTH = 2.5e9  # matches pycbc.detector.space._space_detectors['LISA']
+SEMI_MAJOR_AXIS = au.value
+ECCENTRICITY = ARMLENGTH / (2 * SEMI_MAJOR_AXIS * numpy.sqrt(3))
+T0 = space.TIME_OFFSET_20_DEGREES
+
+
+class _LisaGuidingCenterFixture:
+    """Mixin providing `_phase(t)` for the LISA fixture's guiding-center
+    convention (`OMEGA_0 * (t + T0)`) -- mirrors the shape of
+    `space_orbit._LisaGuidingCenter`, but independently written (not
+    imported from production), so a bug in the production formula
+    wouldn't be invisible here. Combine with
+    `_EqualArmConstellationFixture`.
+    """
+    def _phase(self, t):
+        return OMEGA_0 * (t + T0)
+
+
+class _EqualArmConstellationFixture:
+    """Mixin implementing `compute_position` for the LDC manual's 'Equal
+    arm analytic orbit' (LISA-LCST-SGS-MAN-001, Sec. 8.1.1, Eq. 48-52) --
+    mirrors `space_orbit._EqualArmConstellation`, independently written.
+    Shared by `AnalyticEqualArmOrbit`/`AnalyticTaijiOrbit` below (same
+    functional form, per Rubbo, Cornish & Poujade 2004, Phys. Rev. D 69,
+    082003); the concrete class's own `__init__` must set
+    `self.eccentricity`.
+    """
+    def compute_position(self, t, sc=(1, 2, 3)):
+        t = numpy.atleast_1d(numpy.asarray(t, dtype=float))
+        sc = numpy.atleast_1d(sc)
+        alpha = self._phase(t)
+        out = numpy.empty((len(t), len(sc), 3))
+        for k, n in enumerate(sc):
+            beta_n = (n - 1) * 2 * numpy.pi / 3.0
+            out[:, k, 0] = SEMI_MAJOR_AXIS * numpy.cos(alpha) \
+                + SEMI_MAJOR_AXIS * self.eccentricity * (
+                    numpy.sin(alpha) * numpy.cos(alpha) * numpy.sin(beta_n)
+                    - (1 + numpy.sin(alpha) ** 2) * numpy.cos(beta_n))
+            out[:, k, 1] = SEMI_MAJOR_AXIS * numpy.sin(alpha) \
+                + SEMI_MAJOR_AXIS * self.eccentricity * (
+                    numpy.sin(alpha) * numpy.cos(alpha) * numpy.cos(beta_n)
+                    - (1 + numpy.cos(alpha) ** 2) * numpy.sin(beta_n))
+            out[:, k, 2] = -numpy.sqrt(3) * SEMI_MAJOR_AXIS \
+                * self.eccentricity * numpy.cos(alpha - beta_n)
+        return out
+
+
+class AnalyticEqualArmOrbit(_LisaGuidingCenterFixture,
+                             _EqualArmConstellationFixture):
+    """Reference implementation of the LDC manual's 'Equal arm analytic
+    orbit', LISA flavor. Used only to validate `space_orbit.
+    constellation_frame` and related functions against the existing
+    analytic functions in `pycbc.coordinates.space`, which assume this
+    same orbit but only track the (eccentricity-independent) guiding
+    center.
+
+    Parameters
+    ----------
+    eccentricity : float, optional
+        Constellation eccentricity. Default `ECCENTRICITY` (LISA's own
+        arm length).
+    """
+    def __init__(self, eccentricity=None):
+        self.eccentricity = (
+            ECCENTRICITY if eccentricity is None else eccentricity)
+
+
+class TestNumericOrbits(unittest.TestCase):
+    def setUp(self):
+        self.orbit = AnalyticEqualArmOrbit()
+        # coarse grid, similar density to a typical lisaorbits orbit file
+        self.t_grid = numpy.linspace(0.0, 3.15e7, 400)
+        self.positions = self.orbit.compute_position(self.t_grid)
+        self.numeric = space_orbit.NumericOrbits(self.t_grid, self.positions)
+        self.t_query = numpy.random.uniform(1e5, 3.1e7, size=20)
+
+    def test_position_interpolation_accuracy(self):
+        """Interpolated positions must reproduce the analytic orbit to a
+        small fraction of the ~1 AU length scale, at off-grid query times.
+        """
+        interpolated = self.numeric.compute_position(self.t_query)
+        exact = self.orbit.compute_position(self.t_query)
+        maxdiff = numpy.max(numpy.abs(interpolated - exact))
+        self.assertLess(maxdiff, 1e-6 * SEMI_MAJOR_AXIS,
+                        f'NumericOrbits position interpolation error too '
+                        f'large: {maxdiff} m')
+
+    def test_rejects_mismatched_shapes(self):
+        with self.assertRaises(ValueError):
+            space_orbit.NumericOrbits(self.t_grid, self.positions[:-1])
+        with self.assertRaises(ValueError):
+            space_orbit.NumericOrbits(
+                self.t_grid, self.positions,
+                velocities=self.positions[:, :, :2])
+
+    def test_velocity_is_the_derivative_of_the_position_spline(self):
+        """With no velocities supplied, `compute_velocity` is the analytic
+        derivative of the position spline; it must agree with a central
+        finite difference of `compute_position` on the same instance.
+        """
+        dt = 1.0
+        fd = (self.numeric.compute_position(self.t_query + dt)
+              - self.numeric.compute_position(self.t_query - dt)) / (2 * dt)
+        analytic = self.numeric.compute_velocity(self.t_query)
+        self.assertLess(numpy.max(numpy.abs(analytic - fd)), 1e-3)
+
+    def test_acceleration_is_the_second_derivative(self):
+        """`compute_acceleration` is the second analytic derivative of the
+        same spline, and must agree with a central finite difference of
+        `compute_velocity`.
+        """
+        dt = 1.0
+        fd = (self.numeric.compute_velocity(self.t_query + dt)
+              - self.numeric.compute_velocity(self.t_query - dt)) / (2 * dt)
+        analytic = self.numeric.compute_acceleration(self.t_query)
+        self.assertLess(numpy.max(numpy.abs(analytic - fd)), 1e-6)
+
+    def test_explicit_velocities_are_used_verbatim(self):
+        """When velocities are supplied they must be interpolated in their
+        own right, not re-derived from the positions.
+        """
+        marker = numpy.full_like(self.positions, 1234.5)
+        numeric = space_orbit.NumericOrbits(
+            self.t_grid, self.positions, velocities=marker)
+        got = numeric.compute_velocity(self.t_query)
+        self.assertLess(numpy.max(numpy.abs(got - 1234.5)), 1e-6)
+
+
+class TestNumericOrbitsFileIO(unittest.TestCase):
+    """`to_file`, paired with `from_file`, is what lets an orbit built in
+    memory be saved once and then referenced by a PE config's `orbit-file`
+    option.
+    """
+    def setUp(self):
+        self.exact_orbit = AnalyticEqualArmOrbit()
+        self.t_grid = numpy.arange(0.0, 3.15e7, 86400.0)
+        self.tmpdir = tempfile.mkdtemp()
+
+    def test_to_file_round_trip_without_velocities(self):
+        """With no explicit velocities at construction, the `velocities`
+        dataset must be omitted (not written as zeros or anything else), so
+        a reloaded instance re-derives velocities from the position spline
+        exactly as the original did.
+        """
+        orbit = space_orbit.NumericOrbits(
+            self.t_grid, self.exact_orbit.compute_position(self.t_grid))
+        path = os.path.join(self.tmpdir, 'roundtrip_no_vel.hdf5')
+        orbit.to_file(path)
+
+        with h5py.File(path, 'r') as f:
+            self.assertIn('t', f)
+            self.assertIn('positions', f)
+            self.assertNotIn('velocities', f)
+
+        reloaded = space_orbit.NumericOrbits.from_file(path)
+        query_t = numpy.linspace(self.t_grid[5], self.t_grid[-5], 30)
+        self.assertLess(numpy.max(numpy.abs(
+            reloaded.compute_position(query_t)
+            - orbit.compute_position(query_t))), 1e-6)
+        self.assertLess(numpy.max(numpy.abs(
+            reloaded.compute_velocity(query_t)
+            - orbit.compute_velocity(query_t))), 1e-6)
+        self.assertLess(numpy.max(numpy.abs(
+            reloaded.compute_acceleration(query_t)
+            - orbit.compute_acceleration(query_t))), 1e-6)
+
+    def test_to_file_round_trip_with_explicit_velocities(self):
+        positions = self.exact_orbit.compute_position(self.t_grid)
+        dt = 1.0
+        velocities = (self.exact_orbit.compute_position(self.t_grid + dt)
+                      - self.exact_orbit.compute_position(self.t_grid - dt)
+                      ) / (2 * dt)
+        orbit = space_orbit.NumericOrbits(
+            self.t_grid, positions, velocities=velocities)
+        path = os.path.join(self.tmpdir, 'roundtrip_with_vel.hdf5')
+        orbit.to_file(path)
+
+        with h5py.File(path, 'r') as f:
+            self.assertIn('velocities', f)
+
+        reloaded = space_orbit.NumericOrbits.from_file(path)
+        query_t = numpy.linspace(self.t_grid[5], self.t_grid[-5], 30)
+        self.assertLess(numpy.max(numpy.abs(
+            reloaded.compute_velocity(query_t)
+            - orbit.compute_velocity(query_t))), 1e-6)
+
+    def test_to_file_group_option_round_trip(self):
+        orbit = space_orbit.NumericOrbits(
+            self.t_grid, self.exact_orbit.compute_position(self.t_grid))
+        path = os.path.join(self.tmpdir, 'grouped.hdf5')
+        orbit.to_file(path, group='lisa')
+        orbit.to_file(path, group='taiji', mode='a')
+
+        for group in ('lisa', 'taiji'):
+            reloaded = space_orbit.NumericOrbits.from_file(path, group=group)
+            query_t = numpy.linspace(self.t_grid[5], self.t_grid[-5], 30)
+            self.assertLess(numpy.max(numpy.abs(
+                reloaded.compute_position(query_t)
+                - orbit.compute_position(query_t))), 1e-6)
+
+
+suite = unittest.TestSuite()
+suite.addTest(unittest.TestLoader().loadTestsFromTestCase(TestNumericOrbits))
+suite.addTest(unittest.TestLoader().loadTestsFromTestCase(
+    TestNumericOrbitsFileIO))
+
+if __name__ == '__main__':
+    results = unittest.TextTestRunner(verbosity=2).run(suite)
+    simple_exit(results)


### PR DESCRIPTION
<!---
Please delete these comments when you submit the pull request

Please add a title which is a concise description of what you are doing,
e.g. 'Fix bug with numpy import in pycbc_coinc_findtrigs' or 'add high frequency sky location dependent response for long detectors'
-->

<!---
This is a brief template for making pull requests for PyCBC.
This is _not_ a proscriptive template - you can use a different style if you want.
Please do think about the questions posed here and whether the details will be useful to include in your PR
Please add sufficient details so that people looking back at the request with no context around the work can understand the changes.
To choose reviewers, please look at the git blame for the code you are changing (if applicable),
or discuss in the #pycbc-code channel of the gwastro slack.
Please add labels as appropriate
-->

<!-- TOP-LEVEL SUMMARY: Please provide a brief, one-or-two-sentence description of the PR here
-->

## Standard information about the request

<!--- Some basic info about the change (delete as appropriate) -->
This is a: new feature

<!--- What codes will this affect? (delete as apropriate)
If you do not know which areas will be affected, please ask in the gwastro #pycbc-code slack
-->
This change affects: inference, LISA-related code

<!--- What code areas will this affect? (delete as apropriate) -->
This change changes: documentation, result presentation / plotting, scientific output

<!--- Some things which help with code management (delete as appropriate) -->
This change: has appropriate unit tests, follows style guidelines (See e.g. [PEP8](https://peps.python.org/pep-0008/)), has been proposed using the [contribution guidelines](https://github.com/gwastro/pycbc/blob/master/CONTRIBUTING.md)

## Motivation
<!--- Describe why your changes are being made -->
Adding support for numerical orbits.

## Contents
<!--- Describe your changes, this doesn't need to be a line-by-line code change discussion,
but rather a general discussion of the methods chosen -->
The `NumericOrbits` class has been added. This class accepts constellation orbit data provided as a list (containing time, spacecraft positions, and optional velocity information) and performs interpolation using `scipy` B-splines; the `compute_position`, `compute_velocity`, and `compute_acceleration` methods it provides are consistent with `lisaorbits.Orbits` in terms of calling syntax and the shape of returned data. If velocity data is not explicitly provided, velocity and acceleration are calculated as analytical derivatives of the spline (matching the mechanism of `lisaorbits.InterpolatedOrbits`); if velocity data is provided, the velocity itself is interpolated. This implementation uses a single vector-valued spline to handle all data columns (spacecraft and x/y/z coordinates) simultaneously; compared to constructing separate splines for each column, this approach offers significantly faster construction and computation speeds while yielding identical results.

## Links to any issues or associated PRs
<!--- If this is fixing / working around an already-reported issue, please link to it here -->
Follows PR https://github.com/gwastro/pycbc/pull/5421

## Testing performed
<!--- Describe tests for the code changes, either already performed or to be performed -->
There have been no changes to the contents of `pycbc.coordinates.space`; this is purely an addition of new functionality. The reference orbits used for testing were constructed based on an independent re-implementation of the "equal-arm analytic orbits" described in the LDC manual, rather than being derived from the code under test.

## Additional notes
<!--- Anything which does not fit in the above sections -->

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
