### PR TITLE
Add equal-arm analytic constellation orbits for LISA and Taiji

### DIFF
--- a/pycbc/coordinates/__init__.py
+++ b/pycbc/coordinates/__init__.py
@@ -18,9 +18,11 @@ more advanced transformations between ground-based detectors and space-borne
 detectors.
 """
 
+# ruff: noqa: F403, F405 -- deliberate `import *` re-export, see __all__
+
 from pycbc.coordinates.base import *
 from pycbc.coordinates.space import *
-
+from pycbc.coordinates.space_orbit import *
 
 __all__ = ['cartesian_to_spherical_rho', 'cartesian_to_spherical_azimuthal',
            'cartesian_to_spherical_polar', 'cartesian_to_spherical',
@@ -34,4 +36,5 @@ __all__ = ['cartesian_to_spherical_rho', 'cartesian_to_spherical_azimuthal',
            'lisa_position_ssb', 'earth_position_ssb',
            't_geo_from_ssb', 't_ssb_from_t_geo', 'ssb_to_geo', 'geo_to_ssb',
            'lisa_to_geo', 'geo_to_lisa',
+           'LisaEqualArmOrbit', 'TaijiEqualArmOrbit',
            ]

--- a/pycbc/coordinates/space_orbit.py
+++ b/pycbc/coordinates/space_orbit.py
@@ -1,0 +1,326 @@
+# Copyright (C) 2026  Shichao Wu, Alex Nitz
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+#
+# =============================================================================
+#
+#                                   Preamble
+#
+# =============================================================================
+#
+"""
+Analytic, closed-form constellation orbits for space-borne detectors.
+
+`LisaEqualArmOrbit` and `TaijiEqualArmOrbit` are rigid, circular (first
+order in eccentricity) equal-arm triangular constellations following the
+expansion of Rubbo, Cornish & Poujade 2004 (Phys. Rev. D 69, 082003) -- the
+same functional form as the LISA orbit hard-coded in
+`pycbc.coordinates.space.lisa_position_ssb`/`rotation_matrix_ssb_to_lisa`,
+here exposed as explicit, parameterised orbit providers.
+
+Each class implements `compute_position(t, sc)`, `compute_velocity(t, sc)`
+and `compute_acceleration(t, sc)` with the same calling convention and
+return shapes as `lisaorbits.Orbits`, so they can be passed anywhere an
+orbit provider is expected. Velocity and acceleration are exact analytic
+derivatives of `compute_position`, not finite differences.
+
+These are idealised reference orbits for prototyping ahead of an official
+numeric orbit product; they are not a substitute for real mission
+ephemerides.
+
+This module does not change or replace anything in `pycbc.coordinates.space`;
+it is purely additive.
+"""
+import numpy as np
+from astropy.constants import au as ASTRONOMICAL_UNIT
+
+logger = __import__('logging').getLogger(__name__)
+
+
+EARTH_ORBIT_ANGULAR_FREQUENCY = 1.99098659277e-7  # [rad/s]
+# = 2*pi / (sidereal year in seconds, 31558149.7635456); pinned as a
+# literal (not derived via `import lal`) per project convention of
+# avoiding a lal dependency in new code.
+
+# Named constant instead of an np.deg2rad() call directly in the default
+# constructor argument below, to avoid a ruff B008 warning.
+_TAIJI_LEAD_ANGLE = np.deg2rad(20.0)
+
+
+def _real_earth_ecliptic_longitude(t=0.0):
+    """Real Earth's ecliptic longitude at SSB time `t` [s], from
+    `pycbc.coordinates.space.earth_position_ssb` (astropy-based real
+    ephemeris). Imported lazily (not at module level) to avoid a circular
+    import: `pycbc.coordinates.space` imports from this module.
+    """
+    from pycbc.coordinates.space import earth_position_ssb
+    return earth_position_ssb(t)[1]
+
+
+def _equal_arm_orbit_position(alpha, armlength, sc):
+    """Shared first-order-in-eccentricity Keplerian expansion (Rubbo,
+    Cornish & Poujade 2004, Phys. Rev. D 69, 082003) underlying
+    `LisaEqualArmOrbit` and `TaijiEqualArmOrbit`: a rigid, circular
+    triangular constellation at guiding-center phase `alpha` [rad], with
+    the given `armlength` [m].
+
+    `sin(alpha)`/`cos(alpha)` (the only per-element transcendental calls
+    needed -- everything else reduces to `beta_n`-dependent scalars via
+    the angle-subtraction identity for `cos(alpha - beta_n)`) are
+    evaluated once and reused across spacecraft, not recomputed inside the
+    loop: for large `alpha` arrays this is the dominant cost, so this
+    matters for performance parity with `lisaorbits`, not just style.
+    """
+    a = ASTRONOMICAL_UNIT.value
+    e = armlength / (2 * a * np.sqrt(3))
+    sin_a, cos_a = np.sin(alpha), np.cos(alpha)
+    sin_a_cos_a = sin_a * cos_a
+    sin_a2, cos_a2 = sin_a ** 2, cos_a ** 2
+    out = np.empty((len(alpha), len(sc), 3))
+    for k, n in enumerate(sc):
+        beta_n = (n - 1) * 2 * np.pi / 3.0
+        sin_b, cos_b = np.sin(beta_n), np.cos(beta_n)
+        out[:, k, 0] = a * cos_a + a * e * (
+            sin_a_cos_a * sin_b - (1 + sin_a2) * cos_b)
+        out[:, k, 1] = a * sin_a + a * e * (
+            sin_a_cos_a * cos_b - (1 + cos_a2) * sin_b)
+        out[:, k, 2] = -np.sqrt(3) * a * e * (
+            cos_a * cos_b + sin_a * sin_b)  # cos(alpha - beta_n)
+    return out
+
+
+def _equal_arm_orbit_velocity(alpha, omega, armlength, sc):
+    """d/dt of `_equal_arm_orbit_position`, given the (constant) guiding-
+    center angular frequency `omega` = d(alpha)/dt [rad/s]. Exact analytic
+    derivative of the same closed-form position expansion (chain rule
+    through `alpha(t)`), not a finite-difference approximation -- the same
+    precision-in-principle as `lisaorbits.EqualArmlengthOrbits.
+    compute_velocity`, which differentiates the identical formula. See
+    `_equal_arm_orbit_position` for the per-spacecraft caching rationale.
+    """
+    a = ASTRONOMICAL_UNIT.value
+    e = armlength / (2 * a * np.sqrt(3))
+    sin_a, cos_a = np.sin(alpha), np.cos(alpha)
+    sin_a_cos_a = sin_a * cos_a
+    cos2_minus_sin2 = cos_a ** 2 - sin_a ** 2
+    out = np.empty((len(alpha), len(sc), 3))
+    for k, n in enumerate(sc):
+        beta_n = (n - 1) * 2 * np.pi / 3.0
+        sin_b, cos_b = np.sin(beta_n), np.cos(beta_n)
+        out[:, k, 0] = omega * (
+            -a * sin_a + a * e * (
+                cos2_minus_sin2 * sin_b - 2 * sin_a_cos_a * cos_b))
+        out[:, k, 1] = omega * (
+            a * cos_a + a * e * (
+                cos2_minus_sin2 * cos_b + 2 * sin_a_cos_a * sin_b))
+        out[:, k, 2] = omega * (
+            np.sqrt(3) * a * e * (
+                sin_a * cos_b - cos_a * sin_b))  # sin(alpha - beta_n)
+    return out
+
+
+def _equal_arm_orbit_acceleration(alpha, omega, armlength, sc):
+    """d^2/dt^2 of `_equal_arm_orbit_position`, i.e. d/dt of
+    `_equal_arm_orbit_velocity`. See `_equal_arm_orbit_position` for the
+    precision/performance rationale.
+    """
+    a = ASTRONOMICAL_UNIT.value
+    e = armlength / (2 * a * np.sqrt(3))
+    sin_a, cos_a = np.sin(alpha), np.cos(alpha)
+    sin_a_cos_a = sin_a * cos_a
+    sin_a2, cos_a2 = sin_a ** 2, cos_a ** 2
+    omega2 = omega ** 2
+    out = np.empty((len(alpha), len(sc), 3))
+    for k, n in enumerate(sc):
+        beta_n = (n - 1) * 2 * np.pi / 3.0
+        sin_b, cos_b = np.sin(beta_n), np.cos(beta_n)
+        out[:, k, 0] = omega2 * (
+            -a * cos_a - 4 * a * e * (
+                sin_a_cos_a * sin_b + (0.5 - sin_a2) * cos_b))
+        out[:, k, 1] = omega2 * (
+            -a * sin_a - 4 * a * e * (
+                sin_a_cos_a * cos_b + (0.5 - cos_a2) * sin_b))
+        out[:, k, 2] = omega2 * (
+            np.sqrt(3) * a * e * (
+                cos_a * cos_b + sin_a * sin_b))  # cos(alpha - beta_n)
+    return out
+
+
+class _LisaGuidingCenter:
+    """Mixin providing `_phase(t)` for LISA's guiding-center convention:
+    `t0` is added to *time* (`omega*(t+t0)`), a legacy convention kept for
+    BBHx compatibility. Combine with `_EqualArmConstellation`/
+    `_KeplerConstellation`; the concrete class's own `__init__` must set
+    `self.t0`.
+    """
+
+    def _phase(self, t):
+        return EARTH_ORBIT_ANGULAR_FREQUENCY * (t + self.t0)
+
+
+class _TaijiGuidingCenter:
+    """Mixin providing `_phase(t)` for Taiji's guiding-center convention:
+    `lead_angle` is added directly to *phase* (`omega*t + kappa0 +
+    lead_angle`) -- unlike LISA's time-offset convention above, the two
+    are not directly comparable term-for-term. Combine with
+    `_EqualArmConstellation`/`_KeplerConstellation`; the concrete class's
+    own `__init__` must set `self.kappa0`/`self.lead_angle`.
+    """
+
+    def _phase(self, t):
+        return EARTH_ORBIT_ANGULAR_FREQUENCY * t + self.kappa0 \
+            + self.lead_angle
+
+
+class _EqualArmConstellation:
+    """Mixin implementing `compute_position`/`compute_velocity`/
+    `compute_acceleration` for the rigid, circular, first-order-in-
+    eccentricity equal-arm constellation (Rubbo, Cornish & Poujade 2004,
+    Phys. Rev. D 69, 082003) -- shared by `LisaEqualArmOrbit` and
+    `TaijiEqualArmOrbit`, which differ only in their guiding-center phase
+    convention (see `_LisaGuidingCenter`/`_TaijiGuidingCenter`, combined
+    in via multiple inheritance) and their `armlength` default. The
+    concrete class's own `__init__` must set `self.armlength`.
+    """
+
+    def compute_position(self, t, sc=(1, 2, 3)):
+        """Spacecraft position(s) at time(s) `t`. See
+        `NumericOrbits.compute_position` for the calling convention.
+
+        Returns
+        -------
+        (N, M, 3) ndarray
+            Spacecraft position(s) in the SSB frame [m].
+        """
+        t = np.atleast_1d(np.asarray(t, dtype=float))
+        sc = np.atleast_1d(sc)
+        alpha = self._phase(t)
+        return _equal_arm_orbit_position(alpha, self.armlength, sc)
+
+    def compute_velocity(self, t, sc=(1, 2, 3)):
+        """Spacecraft velocity/ies at time(s) `t`, as the exact analytic
+        derivative of `compute_position` (not a finite-difference
+        approximation). See `NumericOrbits.compute_position` for the
+        calling convention.
+
+        Returns
+        -------
+        (N, M, 3) ndarray
+            Spacecraft velocity/ies in the SSB frame [m/s].
+        """
+        t = np.atleast_1d(np.asarray(t, dtype=float))
+        sc = np.atleast_1d(sc)
+        alpha = self._phase(t)
+        return _equal_arm_orbit_velocity(
+            alpha, EARTH_ORBIT_ANGULAR_FREQUENCY, self.armlength, sc)
+
+    def compute_acceleration(self, t, sc=(1, 2, 3)):
+        """Spacecraft acceleration(s) at time(s) `t`, as the exact
+        analytic second derivative of `compute_position`. See
+        `NumericOrbits.compute_position` for the calling convention.
+
+        Returns
+        -------
+        (N, M, 3) ndarray
+            Spacecraft acceleration(s) in the SSB frame [m/s^2].
+        """
+        t = np.atleast_1d(np.asarray(t, dtype=float))
+        sc = np.atleast_1d(sc)
+        alpha = self._phase(t)
+        return _equal_arm_orbit_acceleration(
+            alpha, EARTH_ORBIT_ANGULAR_FREQUENCY, self.armlength, sc)
+
+
+class LisaEqualArmOrbit(_LisaGuidingCenter, _EqualArmConstellation):
+    """Idealized LISA heliocentric orbit: the same rigid, circular
+    (first-order-in-eccentricity) equal-arm triangle already used by
+    `pycbc.coordinates.space.lisa_position_ssb`/
+    `rotation_matrix_ssb_to_lisa` (the `orbit=None` default of
+    `ssb_to_lisa`/`lisa_to_ssb`/etc.), exposed as an explicit
+    `OrbitProvider` -- e.g. to pass to `constellation_frame`, or as a
+    baseline against a numeric or other-mission orbit.
+    `LisaEqualArmOrbit()` with no arguments reproduces the
+    existing `orbit=None` behavior exactly.
+
+    Unlike `TaijiEqualArmOrbit`/`TianQinAnalyticOrbit`, `t0` does *not*
+    default to a real-Earth-anchored epoch -- it's the pre-existing
+    constant tuned for BBHx compatibility, and changing that default
+    here would silently disagree with `pycbc.coordinates.space`'s own
+    default. Pass a different `t0` for a different reference epoch.
+
+    Parameters
+    ----------
+    armlength : float, optional
+        Constellation arm length [m]. Default 2.5e9 (design value).
+    t0 : float or None, optional
+        Reference time offset [s], with the same meaning as in
+        `pycbc.coordinates.space.lisa_position_ssb`. Default None, which
+        uses `pycbc.coordinates.space.TIME_OFFSET_20_DEGREES`.
+    """
+
+    def __init__(self, armlength=2.5e9, t0=None):
+        self.armlength = float(armlength)
+        if t0 is None:
+            from pycbc.coordinates.space import TIME_OFFSET_20_DEGREES
+            t0 = TIME_OFFSET_20_DEGREES
+        self.t0 = float(t0)
+
+
+class TaijiEqualArmOrbit(_TaijiGuidingCenter, _EqualArmConstellation):
+    """Idealized Taiji heliocentric orbit: a rigid, circular (first-order-
+    in-eccentricity) equal-arm triangle, per Rubbo, Cornish & Poujade
+    2004 (Phys. Rev. D 69, 082003) -- the same functional form as the
+    LISA orbit in `pycbc.coordinates.space.lisa_position_ssb`/
+    `rotation_matrix_ssb_to_lisa`, but leading the Earth-like guiding
+    center by `lead_angle` (design value 20 degrees) instead of trailing
+    it, with Taiji's own arm length.
+
+    For prototyping (e.g. single-link response and TDI work) ahead of an
+    official numerical orbit product -- not a substitute for real
+    mission ephemeris; use `NumericOrbits.from_file` once one exists.
+
+    Parameters
+    ----------
+    armlength : float, optional
+        Constellation arm length [m]. Default 3.0e9 (design value).
+    lead_angle : float, optional
+        Angle by which the constellation leads the Earth-like guiding
+        center [rad] -- added directly to orbital phase, so positive means
+        ahead of the guiding center (unlike LISA's `t0`, which is added to
+        *time* to produce a trailing offset; the two are not directly
+        comparable term-for-term). Default ``deg2rad(20)`` (design value).
+    kappa0 : float or None, optional
+        Reference ecliptic longitude of the Earth-like guiding center at
+        `t=0` [rad], before `lead_angle` is added. Default None, which
+        anchors it to the real Earth's ecliptic longitude at SSB time 0
+        (via `pycbc.coordinates.space.earth_position_ssb`), so that
+        `TaijiEqualArmOrbit()` with no arguments is roughly realistic
+        "today". Pass an explicit value for an arbitrary or
+        scenario-specific reference epoch instead.
+    """
+
+    def __init__(self, armlength=3.0e9, lead_angle=_TAIJI_LEAD_ANGLE,
+                kappa0=None):
+        self.armlength = float(armlength)
+        self.lead_angle = float(lead_angle)
+        if kappa0 is None:
+            kappa0 = _real_earth_ecliptic_longitude(0.0)
+        self.kappa0 = float(kappa0)
+
+
+__all__ = [
+    'LisaEqualArmOrbit',
+    'TaijiEqualArmOrbit',
+]

--- a/pycbc/coordinates/space_orbit.py
+++ b/pycbc/coordinates/space_orbit.py
@@ -37,11 +37,7 @@ orbit provider is expected. Velocity and acceleration are exact analytic
 derivatives of `compute_position`, not finite differences.
 
 These are idealised reference orbits for prototyping ahead of an official
-numeric orbit product; they are not a substitute for real mission
-ephemerides.
-
-This module does not change or replace anything in `pycbc.coordinates.space`;
-it is purely additive.
+numeric orbit product.
 """
 import numpy as np
 from astropy.constants import au as ASTRONOMICAL_UNIT
@@ -54,8 +50,8 @@ EARTH_ORBIT_ANGULAR_FREQUENCY = 1.99098659277e-7  # [rad/s]
 # literal (not derived via `import lal`) per project convention of
 # avoiding a lal dependency in new code.
 
-# Named constant instead of an np.deg2rad() call directly in the default
-# constructor argument below, to avoid a ruff B008 warning.
+# Named constant: ruff B008 disallows the np.deg2rad() call in the default
+# argument below.
 _TAIJI_LEAD_ANGLE = np.deg2rad(20.0)
 
 
@@ -80,8 +76,7 @@ def _equal_arm_orbit_position(alpha, armlength, sc):
     needed -- everything else reduces to `beta_n`-dependent scalars via
     the angle-subtraction identity for `cos(alpha - beta_n)`) are
     evaluated once and reused across spacecraft, not recomputed inside the
-    loop: for large `alpha` arrays this is the dominant cost, so this
-    matters for performance parity with `lisaorbits`, not just style.
+    loop, which for large `alpha` arrays is the dominant cost.
     """
     a = ASTRONOMICAL_UNIT.value
     e = armlength / (2 * a * np.sqrt(3))
@@ -251,8 +246,8 @@ class LisaEqualArmOrbit(_LisaGuidingCenter, _EqualArmConstellation):
     `ssb_to_lisa`/`lisa_to_ssb`/etc.), exposed as an explicit
     `OrbitProvider` -- e.g. to pass to `constellation_frame`, or as a
     baseline against a numeric or other-mission orbit.
-    `LisaEqualArmOrbit()` with no arguments reproduces the
-    existing `orbit=None` behavior exactly.
+    `LisaEqualArmOrbit()` with no arguments reproduces the existing
+    `orbit=None` behaviour.
 
     Unlike `TaijiEqualArmOrbit`/`TianQinAnalyticOrbit`, `t0` does *not*
     default to a real-Earth-anchored epoch -- it's the pre-existing
@@ -287,9 +282,8 @@ class TaijiEqualArmOrbit(_TaijiGuidingCenter, _EqualArmConstellation):
     center by `lead_angle` (design value 20 degrees) instead of trailing
     it, with Taiji's own arm length.
 
-    For prototyping (e.g. single-link response and TDI work) ahead of an
-    official numerical orbit product -- not a substitute for real
-    mission ephemeris; use `NumericOrbits.from_file` once one exists.
+    For prototyping ahead of an official numerical orbit product; use
+    `NumericOrbits.from_file` once one exists.
 
     Parameters
     ----------

--- a/test/test_coordinates_space_orbit.py
+++ b/test/test_coordinates_space_orbit.py
@@ -1,0 +1,272 @@
+# Copyright (C) 2026  Shichao Wu, Alex Nitz
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+"""
+Regression tests for the analytic equal-arm constellation orbits in
+`pycbc.coordinates.space_orbit`.
+
+`LisaEqualArmOrbit` and `TaijiEqualArmOrbit` are checked against a
+hand-written reimplementation of the same closed-form orbit (the LISA Data
+Challenge manual's "Equal arm analytic orbit", LISA-LCST-SGS-MAN-001 Sec.
+8.1.1 Eq. 48-52; Rubbo, Cornish & Poujade 2004, Phys. Rev. D 69, 082003),
+written independently in this file so the tests compare two implementations
+rather than comparing the code to itself. `LisaEqualArmOrbit` is
+additionally required to reproduce `pycbc.coordinates.space`'s pre-existing
+hard-coded LISA orbit with its default `t0`, since that default is meant to
+stand in for the existing code path exactly.
+"""
+import numpy
+import unittest
+from astropy.constants import au
+
+from pycbc.coordinates import space
+from pycbc.coordinates import space_orbit
+from utils import simple_exit
+
+
+seed = 8202
+numpy.random.seed(seed)
+
+OMEGA_0 = 1.99098659277e-7  # 2*pi / sidereal year [rad/s]
+ARMLENGTH = 2.5e9  # matches pycbc.detector.space._space_detectors['LISA']
+SEMI_MAJOR_AXIS = au.value
+ECCENTRICITY = ARMLENGTH / (2 * SEMI_MAJOR_AXIS * numpy.sqrt(3))
+T0 = space.TIME_OFFSET_20_DEGREES
+
+# Real Earth ecliptic longitude at t=0, the epoch Taiji's guiding centre is
+# anchored to by default.
+PHI0_REAL = space.earth_position_ssb(0.0)[1]
+
+TAIJI_ARMLENGTH = 3.0e9  # matches pycbc.detector.space._space_detectors
+TAIJI_ECCENTRICITY = TAIJI_ARMLENGTH / (2 * SEMI_MAJOR_AXIS * numpy.sqrt(3))
+TAIJI_LEAD_ANGLE = numpy.deg2rad(20.0)
+
+
+class _LisaGuidingCenterFixture:
+    """Mixin providing `_phase(t)` for the LISA fixture's guiding-center
+    convention (`OMEGA_0 * (t + T0)`) -- mirrors the shape of
+    `space_orbit._LisaGuidingCenter`, but independently written (not
+    imported from production), so a bug in the production formula
+    wouldn't be invisible here. Combine with
+    `_EqualArmConstellationFixture`.
+    """
+    def _phase(self, t):
+        return OMEGA_0 * (t + T0)
+
+
+class _TaijiGuidingCenterFixture:
+    """Mixin providing `_phase(t)` for the Taiji fixture's guiding-center
+    convention (`OMEGA_0 * t + PHI0_REAL + TAIJI_LEAD_ANGLE`, anchored to
+    real Earth's longitude at t=0 so "leads the Earth by 20 degrees" can
+    be checked against the real Earth position, not an arbitrarily-phased
+    circular proxy) -- mirrors `space_orbit._TaijiGuidingCenter`,
+    independently written. Combine with `_EqualArmConstellationFixture`.
+    """
+    def _phase(self, t):
+        return OMEGA_0 * t + PHI0_REAL + TAIJI_LEAD_ANGLE
+
+
+class _EqualArmConstellationFixture:
+    """Mixin implementing `compute_position` for the LDC manual's 'Equal
+    arm analytic orbit' (LISA-LCST-SGS-MAN-001, Sec. 8.1.1, Eq. 48-52) --
+    mirrors `space_orbit._EqualArmConstellation`, independently written.
+    Shared by `AnalyticEqualArmOrbit`/`AnalyticTaijiOrbit` below (same
+    functional form, per Rubbo, Cornish & Poujade 2004, Phys. Rev. D 69,
+    082003); the concrete class's own `__init__` must set
+    `self.eccentricity`.
+    """
+    def compute_position(self, t, sc=(1, 2, 3)):
+        t = numpy.atleast_1d(numpy.asarray(t, dtype=float))
+        sc = numpy.atleast_1d(sc)
+        alpha = self._phase(t)
+        out = numpy.empty((len(t), len(sc), 3))
+        for k, n in enumerate(sc):
+            beta_n = (n - 1) * 2 * numpy.pi / 3.0
+            out[:, k, 0] = SEMI_MAJOR_AXIS * numpy.cos(alpha) \
+                + SEMI_MAJOR_AXIS * self.eccentricity * (
+                    numpy.sin(alpha) * numpy.cos(alpha) * numpy.sin(beta_n)
+                    - (1 + numpy.sin(alpha) ** 2) * numpy.cos(beta_n))
+            out[:, k, 1] = SEMI_MAJOR_AXIS * numpy.sin(alpha) \
+                + SEMI_MAJOR_AXIS * self.eccentricity * (
+                    numpy.sin(alpha) * numpy.cos(alpha) * numpy.cos(beta_n)
+                    - (1 + numpy.cos(alpha) ** 2) * numpy.sin(beta_n))
+            out[:, k, 2] = -numpy.sqrt(3) * SEMI_MAJOR_AXIS \
+                * self.eccentricity * numpy.cos(alpha - beta_n)
+        return out
+
+
+class AnalyticEqualArmOrbit(_LisaGuidingCenterFixture,
+                             _EqualArmConstellationFixture):
+    """Reference implementation of the LDC manual's 'Equal arm analytic
+    orbit', LISA flavor. Used only to validate `space_orbit.
+    constellation_frame` and related functions against the existing
+    analytic functions in `pycbc.coordinates.space`, which assume this
+    same orbit but only track the (eccentricity-independent) guiding
+    center.
+
+    Parameters
+    ----------
+    eccentricity : float, optional
+        Constellation eccentricity. Default `ECCENTRICITY` (LISA's own
+        arm length).
+    """
+    def __init__(self, eccentricity=None):
+        self.eccentricity = (
+            ECCENTRICITY if eccentricity is None else eccentricity)
+
+
+class AnalyticTaijiOrbit(_TaijiGuidingCenterFixture,
+                          _EqualArmConstellationFixture):
+    """Reference implementation of the Taiji heliocentric orbit --
+    `AnalyticEqualArmOrbit`'s formula with Taiji's own guiding-center
+    convention and eccentricity. Used only to check that
+    `constellation_frame`/`NumericOrbits` handle a constellation genuinely
+    different from the LISA fixture above (different arm length,
+    eccentricity, and heliocentric lead angle).
+    """
+    def __init__(self):
+        self.eccentricity = TAIJI_ECCENTRICITY
+
+
+def _arm_lengths(orbit, t):
+    pos = orbit.compute_position(t)
+    r1, r2, r3 = pos[:, 0], pos[:, 1], pos[:, 2]
+    return (numpy.linalg.norm(r1 - r2, axis=-1),
+            numpy.linalg.norm(r2 - r3, axis=-1),
+            numpy.linalg.norm(r1 - r3, axis=-1))
+
+
+class TestEqualArmAnalyticOrbits(unittest.TestCase):
+    """`LisaEqualArmOrbit`/`TaijiEqualArmOrbit` are the production (not
+    test-only) analytic reference orbits, intended for prototyping ahead of
+    an official numeric orbit product. The key check is that each
+    separately implemented production class agrees with the hand-written
+    fixture above when given the same reference phase, i.e. that promoting
+    the fixtures' math to a real, documented, parameterised class did not
+    introduce a transcription error.
+    """
+    def test_lisa_matches_hardcoded_space_functions(self):
+        """With its default `t0`, `LisaEqualArmOrbit` must reproduce the
+        constellation centroid of `pycbc.coordinates.space`'s pre-existing
+        hard-coded LISA orbit, since that default is meant to be a drop-in
+        stand-in for the existing `orbit=None` code path.
+        """
+        orbit = space_orbit.LisaEqualArmOrbit()
+        times = numpy.random.uniform(0.0, 3.15e7, size=20)
+        centroid = orbit.compute_position(times).mean(axis=1)
+        expected = numpy.array([
+            space.lisa_position_ssb(t, orbit.t0)[0].flatten().astype(float)
+            for t in times
+        ])
+        self.assertLess(numpy.max(numpy.abs(centroid - expected)),
+                        1e-6 * SEMI_MAJOR_AXIS)
+
+    def test_lisa_matches_independent_fixture_implementation(self):
+        production = space_orbit.LisaEqualArmOrbit()
+        fixture = AnalyticEqualArmOrbit()
+        times = numpy.random.uniform(0.0, 3.15e7, size=20)
+        self.assertLess(
+            numpy.max(numpy.abs(production.compute_position(times)
+                                - fixture.compute_position(times))), 1e-3,
+            'LisaEqualArmOrbit does not match the independent '
+            'AnalyticEqualArmOrbit test fixture')
+
+    def test_lisa_default_t0_matches_time_offset_20_degrees(self):
+        orbit = space_orbit.LisaEqualArmOrbit()
+        self.assertEqual(orbit.t0, space.TIME_OFFSET_20_DEGREES)
+
+    def test_lisa_custom_t0_overrides_default(self):
+        orbit = space_orbit.LisaEqualArmOrbit(t0=0.0)
+        self.assertEqual(orbit.t0, 0.0)
+        default_orbit = space_orbit.LisaEqualArmOrbit()
+        self.assertGreater(
+            numpy.max(numpy.abs(
+                orbit.compute_position([1e7])
+                - default_orbit.compute_position([1e7]))),
+            1e6)
+
+    def test_taiji_matches_independent_fixture_implementation(self):
+        production = space_orbit.TaijiEqualArmOrbit(kappa0=PHI0_REAL)
+        fixture = AnalyticTaijiOrbit()
+        times = numpy.random.uniform(0.0, 3.15e7, size=20)
+        self.assertLess(
+            numpy.max(numpy.abs(production.compute_position(times)
+                                - fixture.compute_position(times))), 1e-3,
+            'TaijiEqualArmOrbit does not match the independent '
+            'AnalyticTaijiOrbit test fixture')
+
+    def test_taiji_default_kappa0_anchors_to_real_earth(self):
+        self.assertAlmostEqual(
+            space_orbit.TaijiEqualArmOrbit().kappa0, PHI0_REAL, places=9)
+
+    def test_taiji_custom_kappa0_overrides_default(self):
+        orbit = space_orbit.TaijiEqualArmOrbit(kappa0=0.0)
+        self.assertEqual(orbit.kappa0, 0.0)
+        default_orbit = space_orbit.TaijiEqualArmOrbit()
+        # a different kappa0 must give a different position at a fixed
+        # time (i.e. the parameter is not silently ignored)
+        self.assertGreater(
+            numpy.max(numpy.abs(
+                orbit.compute_position([1e7])
+                - default_orbit.compute_position([1e7]))),
+            1e6)
+
+    def test_arm_lengths_match_design_values(self):
+        cases = [
+            (space_orbit.LisaEqualArmOrbit(), ARMLENGTH),
+            (space_orbit.TaijiEqualArmOrbit(), TAIJI_ARMLENGTH),
+        ]
+        times = numpy.random.uniform(0.0, 3.15e7, size=20)
+        for orbit, expected_armlength in cases:
+            for d in _arm_lengths(orbit, times):
+                self.assertLess(
+                    numpy.max(numpy.abs(d - expected_armlength)), 1.0)
+
+    def test_velocity_matches_finite_difference_of_position(self):
+        """`compute_velocity` is an exact analytic derivative, not a
+        finite-difference approximation -- but a central finite difference
+        of `compute_position`, at a small enough step, must still agree
+        with it to high precision.
+        """
+        dt = 1.0  # s
+        for orbit in (space_orbit.LisaEqualArmOrbit(),
+                      space_orbit.TaijiEqualArmOrbit()):
+            t = numpy.random.uniform(1e5, 3.1e7, size=10)
+            finite_diff_vel = (orbit.compute_position(t + dt)
+                               - orbit.compute_position(t - dt)) / (2 * dt)
+            self.assertLess(
+                numpy.max(numpy.abs(
+                    orbit.compute_velocity(t) - finite_diff_vel)), 1e-3)
+
+    def test_acceleration_matches_finite_difference_of_velocity(self):
+        """Same rationale, one derivative order up."""
+        dt = 1.0  # s
+        for orbit in (space_orbit.LisaEqualArmOrbit(),
+                      space_orbit.TaijiEqualArmOrbit()):
+            t = numpy.random.uniform(1e5, 3.1e7, size=10)
+            finite_diff_acc = (orbit.compute_velocity(t + dt)
+                               - orbit.compute_velocity(t - dt)) / (2 * dt)
+            self.assertLess(
+                numpy.max(numpy.abs(
+                    orbit.compute_acceleration(t) - finite_diff_acc)), 1e-6)
+
+
+suite = unittest.TestSuite()
+suite.addTest(unittest.TestLoader().loadTestsFromTestCase(
+    TestEqualArmAnalyticOrbits))
+
+if __name__ == '__main__':
+    results = unittest.TextTestRunner(verbosity=2).run(suite)
+    simple_exit(results)

--- a/test/test_coordinates_space_orbit.py
+++ b/test/test_coordinates_space_orbit.py
@@ -22,10 +22,10 @@ hand-written reimplementation of the same closed-form orbit (the LISA Data
 Challenge manual's "Equal arm analytic orbit", LISA-LCST-SGS-MAN-001 Sec.
 8.1.1 Eq. 48-52; Rubbo, Cornish & Poujade 2004, Phys. Rev. D 69, 082003),
 written independently in this file so the tests compare two implementations
-rather than comparing the code to itself. `LisaEqualArmOrbit` is
+so these are two independent implementations. `LisaEqualArmOrbit` is
 additionally required to reproduce `pycbc.coordinates.space`'s pre-existing
 hard-coded LISA orbit with its default `t0`, since that default is meant to
-stand in for the existing code path exactly.
+stand in for the existing code path.
 """
 import numpy
 import unittest
@@ -132,7 +132,7 @@ class AnalyticTaijiOrbit(_TaijiGuidingCenterFixture,
     """Reference implementation of the Taiji heliocentric orbit --
     `AnalyticEqualArmOrbit`'s formula with Taiji's own guiding-center
     convention and eccentricity. Used only to check that
-    `constellation_frame`/`NumericOrbits` handle a constellation genuinely
+    `constellation_frame`/`NumericOrbits` handle a constellation
     different from the LISA fixture above (different arm length,
     eccentricity, and heliocentric lead angle).
     """


### PR DESCRIPTION
<!---
Please delete these comments when you submit the pull request

Please add a title which is a concise description of what you are doing,
e.g. 'Fix bug with numpy import in pycbc_coinc_findtrigs' or 'add high frequency sky location dependent response for long detectors'
-->

<!---
This is a brief template for making pull requests for PyCBC.
This is _not_ a proscriptive template - you can use a different style if you want.
Please do think about the questions posed here and whether the details will be useful to include in your PR
Please add sufficient details so that people looking back at the request with no context around the work can understand the changes.
To choose reviewers, please look at the git blame for the code you are changing (if applicable),
or discuss in the #pycbc-code channel of the gwastro slack.
Please add labels as appropriate
-->

<!-- TOP-LEVEL SUMMARY: Please provide a brief, one-or-two-sentence description of the PR here
-->

## Standard information about the request

<!--- Some basic info about the change (delete as appropriate) -->
This is a: new feature

<!--- What codes will this affect? (delete as apropriate)
If you do not know which areas will be affected, please ask in the gwastro #pycbc-code slack
-->
This change affects: inference, LISA-related code

<!--- What code areas will this affect? (delete as apropriate) -->
This change changes: documentation, result presentation / plotting, scientific output

<!--- Some things which help with code management (delete as appropriate) -->
This change: has appropriate unit tests, follows style guidelines (See e.g. [PEP8](https://peps.python.org/pep-0008/)), has been proposed using the [contribution guidelines](https://github.com/gwastro/pycbc/blob/master/CONTRIBUTING.md)

## Motivation
<!--- Describe why your changes are being made -->
Add equal-arm analytic constellation orbits for LISA and Taiji.

## Contents
<!--- Describe your changes, this doesn't need to be a line-by-line code change discussion,
but rather a general discussion of the methods chosen -->
Adding `LisaEqualArmOrbit` and `TaijiEqualArmOrbit` classes. These classes implement orbital models for equal-arm triangular constellations—assuming rigid, circular orbits and a first-order approximation in eccentricity—based on the work of Rubbo, Cornish, and Poujade (2004, Phys. Rev. D 69, 082003). While the same functional form was previously hard-coded for LISA within `pycbc.coordinates.space`, it is now exposed here via explicit, parameterized orbit provider classes. The Taiji orbit utilizes its specific arm length and positions the constellation center (guiding center) 20 degrees ahead of (rather than behind) the Earth-like orbital position; additionally, its default reference phase is set to Earth's actual ecliptic longitude at $t=0$.

Both classes implement `compute_position`, `compute_velocity`, and `compute_acceleration` methods, adhering to the same calling conventions and return data shapes as `lisaorbits.Orbits`, allowing them to be used wherever an orbit provider is required. Velocity and acceleration calculations rely on exact analytical derivatives rather than finite difference methods.

## Links to any issues or associated PRs
<!--- If this is fixing / working around an already-reported issue, please link to it here -->
Similar to PR https://github.com/gwastro/pycbc/pull/5422, but analytic.

## Testing performed
<!--- Describe tests for the code changes, either already performed or to be performed -->
Test routines compare each implementation class against independently written implementations—based on the same closed-form orbital equations—found in the test files. Furthermore, the tests verify that `LisaEqualArmOrbit`, when using default `t0` parameters, reproduces the existing hard-coded LISA orbital centroid positions.

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
