### PR TITLE
Deduplicate the sky-frame coordinate transforms (no behaviour change)

### DIFF
--- a/pycbc/coordinates/space.py
+++ b/pycbc/coordinates/space.py
@@ -321,6 +321,85 @@ def t_ssb_from_t_lisa(t_lisa, longitude_ssb, latitude_ssb,
     return fsolve(equation, t_lisa)[0]
 
 
+def _ensure_sky_params_arrays(*arrays):
+    """ Shared by the 4 X_to_ssb/ssb_to_X frame-transform functions below:
+    coerce each of `arrays` (scalar or array-like) to a 1-D numpy array,
+    and return them alongside `num`, the common length (from the first
+    array).
+    """
+    coerced = tuple(
+        a if isinstance(a, np.ndarray) else np.array([a]) for a in arrays)
+    return coerced + (len(coerced[0]),)
+
+
+def _validate_sky_params(longitude, latitude, polarization):
+    """ Shared by the 4 X_to_ssb/ssb_to_X frame-transform functions below:
+    range-checks the whole array at once (equivalent to the same check
+    repeated per element inside their loops), raising the same
+    ValueError text.
+    """
+    if np.any((longitude < 0) | (longitude >= 2*np.pi)):
+        raise ValueError("Longitude should within [0, 2*pi).")
+    if np.any((latitude < -np.pi/2) | (latitude > np.pi/2)):
+        raise ValueError("Latitude should within [-pi/2, pi/2].")
+    if np.any((polarization < 0) | (polarization >= 2*np.pi)):
+        raise ValueError("Polarization angle should within [0, 2*pi).")
+
+
+def _pack_sky_params_output(num, t, longitude, latitude, polarization):
+    """ Shared by the 4 X_to_ssb/ssb_to_X frame-transform functions below:
+    unwrap to scalars for a single input, otherwise keep the arrays.
+    """
+    if num == 1:
+        return (t[0], longitude[0], latitude[0], polarization[0])
+    return (t, longitude, latitude, polarization)
+
+
+def _sky_ssb_space_transform(t_src, longitude_src, latitude_src,
+                             polarization_src, t0, forward):
+    """ Shared body of `ssb_to_lisa` and `lisa_to_ssb`: rotate the GW
+    propagation vector between the SSB frame and the LISA frame at the
+    appropriate LISA-frame time, and convert the arrival time to match.
+    `forward=True` runs the SSB->LISA direction (`ssb_to_lisa`);
+    `forward=False` runs LISA->SSB (`lisa_to_ssb`).
+    """
+    t_src, longitude_src, latitude_src, polarization_src, num = \
+        _ensure_sky_params_arrays(
+            t_src, longitude_src, latitude_src, polarization_src)
+    _validate_sky_params(longitude_src, latitude_src, polarization_src)
+    t_dst = np.zeros(num)
+    longitude_dst, latitude_dst = np.zeros(num), np.zeros(num)
+    polarization_dst = np.zeros(num)
+
+    for i in range(num):
+        k_src = localization_to_propagation_vector(
+            longitude_src[i], latitude_src[i], use_astropy=False)
+        if forward:
+            t_dst[i] = t_lisa_from_ssb(
+                t_src[i], longitude_src[i], latitude_src[i], t0)
+            # t_dst was computed with the t0-corrected LISA position but
+            # corresponds to the true t_ssb, not t_ssb + t0, so t0 has to
+            # be applied again here to place LISA correctly.
+            rot = rotation_matrix_ssb_to_lisa(
+                lisa_position_ssb(t_dst[i], t0)[1])
+            k_dst = rot.T @ k_src
+        else:
+            rot = rotation_matrix_ssb_to_lisa(
+                lisa_position_ssb(t_src[i], t0)[1])
+            k_dst = rot @ k_src
+        longitude_dst[i], latitude_dst[i] = \
+            propagation_vector_to_localization(k_dst, use_astropy=False)
+        if not forward:
+            t_dst[i] = t_ssb_from_t_lisa(
+                t_src[i], longitude_dst[i], latitude_dst[i], t0)
+        polarization_dst[i] = polarization_newframe(
+            polarization_src[i], k_src, rot if forward else rot.T,
+            use_astropy=False)
+
+    return _pack_sky_params_output(
+        num, t_dst, longitude_dst, latitude_dst, polarization_dst)
+
+
 def ssb_to_lisa(t_ssb, longitude_ssb, latitude_ssb, polarization_ssb,
                 t0=TIME_OFFSET_20_DEGREES):
     """ Converting the arrive time, the sky localization, and the polarization
@@ -359,49 +438,9 @@ def ssb_to_lisa(t_ssb, longitude_ssb, latitude_ssb, polarization_ssb,
         The polarization angle of a GW signal in LISA frame.
         In the unit of 'radian'.
     """
-    if not isinstance(t_ssb, np.ndarray):
-        t_ssb = np.array([t_ssb])
-    if not isinstance(longitude_ssb, np.ndarray):
-        longitude_ssb = np.array([longitude_ssb])
-    if not isinstance(latitude_ssb, np.ndarray):
-        latitude_ssb = np.array([latitude_ssb])
-    if not isinstance(polarization_ssb, np.ndarray):
-        polarization_ssb = np.array([polarization_ssb])
-    num = len(t_ssb)
-    t_lisa, longitude_lisa = np.zeros(num), np.zeros(num)
-    latitude_lisa, polarization_lisa = np.zeros(num), np.zeros(num)
-
-    for i in range(num):
-        if longitude_ssb[i] < 0 or longitude_ssb[i] >= 2*np.pi:
-            raise ValueError("Longitude should within [0, 2*pi).")
-        if latitude_ssb[i] < -np.pi/2 or latitude_ssb[i] > np.pi/2:
-            raise ValueError("Latitude should within [-pi/2, pi/2].")
-        if polarization_ssb[i] < 0 or polarization_ssb[i] >= 2*np.pi:
-            raise ValueError("Polarization angle should within [0, 2*pi).")
-        t_lisa[i] = t_lisa_from_ssb(t_ssb[i], longitude_ssb[i],
-                                    latitude_ssb[i], t0)
-        k_ssb = localization_to_propagation_vector(
-                    longitude_ssb[i], latitude_ssb[i], use_astropy=False)
-        # Although t_lisa calculated above using the corrected LISA position
-        # vector by adding t0, it corresponds to the true t_ssb, not t_ssb+t0,
-        # we need to include t0 again to correct LISA position.
-        alpha = lisa_position_ssb(t_lisa[i], t0)[1]
-        rotation_matrix_lisa = rotation_matrix_ssb_to_lisa(alpha)
-        k_lisa = rotation_matrix_lisa.T @ k_ssb
-        longitude_lisa[i], latitude_lisa[i] = \
-            propagation_vector_to_localization(k_lisa, use_astropy=False)
-        polarization_lisa[i] = polarization_newframe(
-            polarization_ssb[i], k_ssb, rotation_matrix_lisa,
-            use_astropy=False)
-
-    if num == 1:
-        params_lisa = (t_lisa[0], longitude_lisa[0],
-                       latitude_lisa[0], polarization_lisa[0])
-    else:
-        params_lisa = (t_lisa, longitude_lisa,
-                       latitude_lisa, polarization_lisa)
-
-    return params_lisa
+    return _sky_ssb_space_transform(
+        t_ssb, longitude_ssb, latitude_ssb, polarization_ssb, t0,
+        forward=True)
 
 
 def lisa_to_ssb(t_lisa, longitude_lisa, latitude_lisa, polarization_lisa,
@@ -442,46 +481,11 @@ def lisa_to_ssb(t_lisa, longitude_lisa, latitude_lisa, polarization_lisa,
         The polarization angle of a GW signal in SSB frame.
         In the unit of 'radian'.
     """
-    if not isinstance(t_lisa, np.ndarray):
-        t_lisa = np.array([t_lisa])
-    if not isinstance(longitude_lisa, np.ndarray):
-        longitude_lisa = np.array([longitude_lisa])
-    if not isinstance(latitude_lisa, np.ndarray):
-        latitude_lisa = np.array([latitude_lisa])
-    if not isinstance(polarization_lisa, np.ndarray):
-        polarization_lisa = np.array([polarization_lisa])
-    num = len(t_lisa)
-    t_ssb, longitude_ssb = np.zeros(num), np.zeros(num)
-    latitude_ssb, polarization_ssb = np.zeros(num), np.zeros(num)
+    return _sky_ssb_space_transform(
+        t_lisa, longitude_lisa, latitude_lisa, polarization_lisa, t0,
+        forward=False)
 
-    for i in range(num):
-        if longitude_lisa[i] < 0 or longitude_lisa[i] >= 2*np.pi:
-            raise ValueError("Longitude should within [0, 2*pi).")
-        if latitude_lisa[i] < -np.pi/2 or latitude_lisa[i] > np.pi/2:
-            raise ValueError("Latitude should within [-pi/2, pi/2].")
-        if polarization_lisa[i] < 0 or polarization_lisa[i] >= 2*np.pi:
-            raise ValueError("Polarization angle should within [0, 2*pi).")
-        k_lisa = localization_to_propagation_vector(
-                    longitude_lisa[i], latitude_lisa[i], use_astropy=False)
-        alpha = lisa_position_ssb(t_lisa[i], t0)[1]
-        rotation_matrix_lisa = rotation_matrix_ssb_to_lisa(alpha)
-        k_ssb = rotation_matrix_lisa @ k_lisa
-        longitude_ssb[i], latitude_ssb[i] = \
-            propagation_vector_to_localization(k_ssb, use_astropy=False)
-        t_ssb[i] = t_ssb_from_t_lisa(t_lisa[i], longitude_ssb[i],
-                                     latitude_ssb[i], t0)
-        polarization_ssb[i] = polarization_newframe(
-            polarization_lisa[i], k_lisa, rotation_matrix_lisa.T,
-            use_astropy=False)
 
-    if num == 1:
-        params_ssb = (t_ssb[0], longitude_ssb[0],
-                      latitude_ssb[0], polarization_ssb[0])
-    else:
-        params_ssb = (t_ssb, longitude_ssb,
-                      latitude_ssb, polarization_ssb)
-
-    return params_ssb
 
 
 def rotation_matrix_ssb_to_geo(epsilon=np.deg2rad(23.439281)):
@@ -648,28 +652,16 @@ def ssb_to_geo(t_ssb, longitude_ssb, latitude_ssb, polarization_ssb,
         The polarization angle of a GW signal in geocentric frame.
         In the unit of 'radian'.
     """
-    if not isinstance(t_ssb, np.ndarray):
-        t_ssb = np.array([t_ssb])
-    if not isinstance(longitude_ssb, np.ndarray):
-        longitude_ssb = np.array([longitude_ssb])
-    if not isinstance(latitude_ssb, np.ndarray):
-        latitude_ssb = np.array([latitude_ssb])
-    if not isinstance(polarization_ssb, np.ndarray):
-        polarization_ssb = np.array([polarization_ssb])
-    num = len(t_ssb)
+    t_ssb, longitude_ssb, latitude_ssb, polarization_ssb, num = \
+        _ensure_sky_params_arrays(
+            t_ssb, longitude_ssb, latitude_ssb, polarization_ssb)
+    _validate_sky_params(longitude_ssb, latitude_ssb, polarization_ssb)
     t_geo = np.full(num, np.nan)
     longitude_geo = np.full(num, np.nan)
     latitude_geo = np.full(num, np.nan)
     polarization_geo = np.full(num, np.nan)
 
     for i in range(num):
-        if longitude_ssb[i] < 0 or longitude_ssb[i] >= 2*np.pi:
-            raise ValueError("Longitude should within [0, 2*pi).")
-        if latitude_ssb[i] < -np.pi/2 or latitude_ssb[i] > np.pi/2:
-            raise ValueError("Latitude should within [-pi/2, pi/2].")
-        if polarization_ssb[i] < 0 or polarization_ssb[i] >= 2*np.pi:
-            raise ValueError("Polarization angle should within [0, 2*pi).")
-
         if use_astropy:
             # BarycentricMeanEcliptic doesn't have obstime attribute,
             # it's a good inertial frame, but PrecessedGeocentric is not.
@@ -715,14 +707,8 @@ def ssb_to_geo(t_ssb, longitude_ssb, latitude_ssb, polarization_ssb,
         # LDC and LAL conventions, see Sec 4.1.5 in <LISA-LCST-SGS-MAN-001>.
         polarization_geo[i] = np.mod(polarization_geo[i]+np.pi, 2*np.pi)
 
-    if num == 1:
-        params_geo = (t_geo[0], longitude_geo[0],
-                      latitude_geo[0], polarization_geo[0])
-    else:
-        params_geo = (t_geo, longitude_geo,
-                      latitude_geo, polarization_geo)
-
-    return params_geo
+    return _pack_sky_params_output(
+        num, t_geo, longitude_geo, latitude_geo, polarization_geo)
 
 
 def geo_to_ssb(t_geo, longitude_geo, latitude_geo, polarization_geo,
@@ -764,28 +750,16 @@ def geo_to_ssb(t_geo, longitude_geo, latitude_geo, polarization_geo,
         The polarization angle of a GW signal in SSB frame.
         In the unit of 'radian'.
     """
-    if not isinstance(t_geo, np.ndarray):
-        t_geo = np.array([t_geo])
-    if not isinstance(longitude_geo, np.ndarray):
-        longitude_geo = np.array([longitude_geo])
-    if not isinstance(latitude_geo, np.ndarray):
-        latitude_geo = np.array([latitude_geo])
-    if not isinstance(polarization_geo, np.ndarray):
-        polarization_geo = np.array([polarization_geo])
-    num = len(t_geo)
+    t_geo, longitude_geo, latitude_geo, polarization_geo, num = \
+        _ensure_sky_params_arrays(
+            t_geo, longitude_geo, latitude_geo, polarization_geo)
+    _validate_sky_params(longitude_geo, latitude_geo, polarization_geo)
     t_ssb = np.full(num, np.nan)
     longitude_ssb = np.full(num, np.nan)
     latitude_ssb = np.full(num, np.nan)
     polarization_ssb = np.full(num, np.nan)
 
     for i in range(num):
-        if longitude_geo[i] < 0 or longitude_geo[i] >= 2*np.pi:
-            raise ValueError("Longitude should within [0, 2*pi).")
-        if latitude_geo[i] < -np.pi/2 or latitude_geo[i] > np.pi/2:
-            raise ValueError("Latitude should within [-pi/2, pi/2].")
-        if polarization_geo[i] < 0 or polarization_geo[i] >= 2*np.pi:
-            raise ValueError("Polarization angle should within [0, 2*pi).")
-
         if use_astropy:
             # BarycentricMeanEcliptic doesn't have obstime attribute,
             # it's a good inertial frame, but PrecessedGeocentric is not.
@@ -833,14 +807,9 @@ def geo_to_ssb(t_geo, longitude_geo, latitude_geo, polarization_geo,
         # LDC and LAL conventions, see Sec 4.1.5 in <LISA-LCST-SGS-MAN-001>.
         polarization_ssb[i] = np.mod(polarization_ssb[i]-np.pi, 2*np.pi)
 
-    if num == 1:
-        params_ssb = (t_ssb[0], longitude_ssb[0],
-                      latitude_ssb[0], polarization_ssb[0])
-    else:
-        params_ssb = (t_ssb, longitude_ssb,
-                      latitude_ssb, polarization_ssb)
+    return _pack_sky_params_output(
+        num, t_ssb, longitude_ssb, latitude_ssb, polarization_ssb)
 
-    return params_ssb
 
 
 def lisa_to_geo(t_lisa, longitude_lisa, latitude_lisa, polarization_lisa,

--- a/pycbc/transforms.py
+++ b/pycbc/transforms.py
@@ -1561,400 +1561,176 @@ class LambdaFromMultipleTOVFiles(BaseTransform):
         )
 
 
-class GEOToSSB(BaseTransform):
+# ---------------------------------------------------------------------------
+# Sky-frame (arrival time / sky localization / polarization) transforms.
+#
+# 3 frame pairs (geo<->ssb, lisa<->ssb, lisa<->geo), 2 classes each for the
+# two transform directions. All 6 are thin subclasses of `SkyFrameTransform`,
+# which implements `__init__`/`transform`/`inverse_transform`/`from_config`
+# once, driven by each subclass's `_frame_a`/`_frame_b`/`_forward`.
+# ---------------------------------------------------------------------------
+
+_SKY_FRAME_LOCALIZATION_DEFAULTS = {
+    'geo': (parameters.ra, parameters.dec),
+    'ssb': (parameters.eclipticlongitude, parameters.eclipticlatitude),
+    'lisa': (parameters.eclipticlongitude, parameters.eclipticlatitude),
+}
+
+
+def _sky_frame_default_params_name(frame_a, frame_b):
+    lon_a, lat_a = _SKY_FRAME_LOCALIZATION_DEFAULTS[frame_a]
+    lon_b, lat_b = _SKY_FRAME_LOCALIZATION_DEFAULTS[frame_b]
+    return {
+        'default_tc_' + frame_a: parameters.tc,
+        'default_longitude_' + frame_a: lon_a,
+        'default_latitude_' + frame_a: lat_a,
+        'default_polarization_' + frame_a: parameters.polarization,
+        'default_tc_' + frame_b: parameters.tc,
+        'default_longitude_' + frame_b: lon_b,
+        'default_latitude_' + frame_b: lat_b,
+        'default_polarization_' + frame_b: parameters.polarization,
+    }
+
+
+class SkyFrameTransform(BaseTransform):
+    """Base class for the 6 concrete arrival-time/sky-localization/
+    polarization transforms between pairs of the SSB, GEO and LISA frames.
+
+    Each concrete subclass sets:
+
+    _frame_a, _frame_b : str
+        The two frame names (e.g. ``'geo'``, ``'ssb'``), used both to build
+        the parameter names (``tc_geo_param``, ...) and to look up the
+        ``coordinates.<a>_to_<b>``/``<b>_to_<a>`` function pair.
+    _forward : bool
+        If True, ``transform`` goes frame_a -> frame_b (and
+        ``inverse_transform`` goes frame_b -> frame_a); if False, the
+        reverse. The two classes for a given pair (e.g. `GEOToSSB` and
+        `SSBToGEO`) share the same `_frame_a`/`_frame_b` and differ only in
+        this flag.
+    """
+
+    _frame_a = None
+    _frame_b = None
+    _forward = True
+
+    def __init__(self, **kwargs):
+        frame_a, frame_b = self._frame_a, self._frame_b
+        param_names = [
+            'tc_' + frame_a + '_param', 'longitude_' + frame_a + '_param',
+            'latitude_' + frame_a + '_param',
+            'polarization_' + frame_a + '_param',
+            'tc_' + frame_b + '_param', 'longitude_' + frame_b + '_param',
+            'latitude_' + frame_b + '_param',
+            'polarization_' + frame_b + '_param',
+        ]
+        default_keys = list(self.default_params_name.keys())
+        for i, pname in enumerate(param_names):
+            value = kwargs.pop(pname, None)
+            if value is None:
+                value = self.default_params_name[default_keys[i]]
+            setattr(self, pname, value)
+        self._param_names = param_names
+        if kwargs:
+            raise TypeError(
+                "{}.__init__ got unexpected keyword argument(s): {}".format(
+                    type(self).__name__, sorted(kwargs)))
+
+        self._forward_func = getattr(
+            coordinates, '{}_to_{}'.format(frame_a, frame_b))
+        self._backward_func = getattr(
+            coordinates, '{}_to_{}'.format(frame_b, frame_a))
+
+        a_params = [getattr(self, n) for n in param_names[:4]]
+        b_params = [getattr(self, n) for n in param_names[4:]]
+        if self._forward:
+            self._inputs, self._outputs = a_params, b_params
+        else:
+            self._inputs, self._outputs = b_params, a_params
+
+        # every subclass here is a direct subclass of SkyFrameTransform, so
+        # there's no risk of this re-running some other class's __init__.
+        super(SkyFrameTransform, self).__init__()
+
+    def _apply(self, maps, forward):
+        """Runs the frame_a->frame_b transform if `forward`, else
+        frame_b->frame_a."""
+        if forward:
+            src_names = self._param_names[:4]
+            dst_names = self._param_names[4:]
+            func = self._forward_func
+        else:
+            src_names = self._param_names[4:]
+            dst_names = self._param_names[:4]
+            func = self._backward_func
+        src_keys = [getattr(self, n) for n in src_names]
+        dst_keys = [getattr(self, n) for n in dst_names]
+        values = func(*(maps[k] for k in src_keys))
+        out = dict(zip(dst_keys, values, strict=True))
+        return self.format_output(maps, out)
+
+    def transform(self, maps):
+        """Transforms arrival time, sky localization, and polarization
+        angle from this instance's input frame to its output frame."""
+        return self._apply(maps, forward=self._forward)
+
+    def inverse_transform(self, maps):
+        """The inverse of `transform`."""
+        return self._apply(maps, forward=not self._forward)
+
+    @classmethod
+    def from_config(cls, cp, section, outputs):
+        tag = outputs
+        section_tag = "-".join([section, outputs])
+        skip_opts = []
+        additional_opts = {}
+        frame_a, frame_b = cls._frame_a, cls._frame_b
+
+        for frame in (frame_a, frame_b):
+            for field in ('tc', 'longitude', 'latitude', 'polarization'):
+                opt_name = field + '-' + frame
+                attr_name = field + '_' + frame + '_param'
+                default = cls.default_params_name[
+                    'default_' + field + '_' + frame]
+                if cp.has_option(section_tag, opt_name):
+                    skip_opts.append(opt_name)
+                    additional_opts[attr_name] = cp.get_opt_tag(
+                        section, opt_name, tag)
+                else:
+                    additional_opts[attr_name] = default
+
+        return super(SkyFrameTransform, cls).from_config(
+            cp, section, outputs, skip_opts=skip_opts,
+            additional_opts=additional_opts
+        )
+
+
+class GEOToSSB(SkyFrameTransform):
     """Converts arrival time, sky localization, and polarization angle in the
     geocentric frame to the corresponding values in the SSB frame."""
 
     name = "geo_to_ssb"
-
-    default_params_name = {
-        'default_tc_geo': parameters.tc,
-        'default_longitude_geo': parameters.ra,
-        'default_latitude_geo': parameters.dec,
-        'default_polarization_geo': parameters.polarization,
-        'default_tc_ssb': parameters.tc,
-        'default_longitude_ssb': parameters.eclipticlongitude,
-        'default_latitude_ssb': parameters.eclipticlatitude,
-        'default_polarization_ssb': parameters.polarization
-    }
-
-    def __init__(
-        self, tc_geo_param=None, longitude_geo_param=None,
-        latitude_geo_param=None, polarization_geo_param=None,
-        tc_ssb_param=None, longitude_ssb_param=None,
-        latitude_ssb_param=None, polarization_ssb_param=None
-    ):
-        params = [tc_geo_param, longitude_geo_param,
-                  latitude_geo_param, polarization_geo_param,
-                  tc_ssb_param, longitude_ssb_param,
-                  latitude_ssb_param, polarization_ssb_param]
-
-        for index in range(len(params)):
-            if params[index] is None:
-                key = list(self.default_params_name.keys())[index]
-                params[index] = self.default_params_name[key]
-
-        self.tc_geo_param = params[0]
-        self.longitude_geo_param = params[1]
-        self.latitude_geo_param = params[2]
-        self.polarization_geo_param = params[3]
-        self.tc_ssb_param = params[4]
-        self.longitude_ssb_param = params[5]
-        self.latitude_ssb_param = params[6]
-        self.polarization_ssb_param = params[7]
-        self._inputs = [self.tc_geo_param, self.longitude_geo_param,
-                        self.latitude_geo_param, self.polarization_geo_param]
-        self._outputs = [self.tc_ssb_param, self.longitude_ssb_param,
-                         self.latitude_ssb_param, self.polarization_ssb_param]
-
-        super(GEOToSSB, self).__init__()
-
-    def transform(self, maps):
-        """This function transforms arrival time, sky localization,
-        and polarization angle in the geocentric frame to the corresponding
-        values in the SSB frame.
-
-        Parameters
-        ----------
-        maps : a mapping object
-
-        Returns
-        -------
-        out : dict
-            A dict with key as parameter name and value as numpy.array or float
-            of transformed values.
-        """
-        out = {}
-        out[self.tc_ssb_param], out[self.longitude_ssb_param], \
-            out[self.latitude_ssb_param], out[self.polarization_ssb_param] = \
-            coordinates.geo_to_ssb(
-                maps[self.tc_geo_param], maps[self.longitude_geo_param],
-                maps[self.latitude_geo_param], maps[self.polarization_geo_param]
-                )
-        return self.format_output(maps, out)
-
-    def inverse_transform(self, maps):
-        """This function transforms arrival time, sky localization,
-        and polarization angle in the SSB frame to the corresponding
-        values in the geocentric frame.
-
-        Parameters
-        ----------
-        maps : a mapping object
-
-        Returns
-        -------
-        out : dict
-            A dict with key as parameter name and value as numpy.array or float
-            of transformed values.
-        """
-        out = {}
-        out[self.tc_geo_param], out[self.longitude_geo_param], \
-            out[self.latitude_geo_param], out[self.polarization_geo_param] = \
-            coordinates.ssb_to_geo(
-                maps[self.tc_ssb_param], maps[self.longitude_ssb_param],
-                maps[self.latitude_ssb_param], maps[self.polarization_ssb_param]
-                )
-        return self.format_output(maps, out)
-
-    @classmethod
-    def from_config(cls, cp, section, outputs):
-        tag = outputs
-        skip_opts = []
-        additional_opts = {}
-
-        # get custom variable names
-        variables = {
-            'tc-geo': cls.default_params_name['default_tc_geo'],
-            'longitude-geo': cls.default_params_name['default_longitude_geo'],
-            'latitude-geo': cls.default_params_name['default_latitude_geo'],
-            'polarization-geo': cls.default_params_name[
-                                    'default_polarization_geo'],
-            'tc-ssb': cls.default_params_name['default_tc_ssb'],
-            'longitude-ssb': cls.default_params_name['default_longitude_ssb'],
-            'latitude-ssb': cls.default_params_name['default_latitude_ssb'],
-            'polarization-ssb': cls.default_params_name[
-                                    'default_polarization_ssb']
-        }
-        for param_name in variables.keys():
-            name_underline = param_name.replace('-', '_')
-            if cp.has_option("-".join([section, outputs]), param_name):
-                skip_opts.append(param_name)
-                additional_opts.update(
-                    {name_underline+'_param': cp.get_opt_tag(
-                     section, param_name, tag)})
-            else:
-                additional_opts.update(
-                    {name_underline+'_param': variables[param_name]})
-
-        return super(GEOToSSB, cls).from_config(
-            cp, section, outputs, skip_opts=skip_opts,
-            additional_opts=additional_opts
-        )
+    _frame_a, _frame_b = 'geo', 'ssb'
+    default_params_name = _sky_frame_default_params_name('geo', 'ssb')
 
 
-class LISAToSSB(BaseTransform):
+class LISAToSSB(SkyFrameTransform):
     """Converts arrival time, sky localization, and polarization angle in the
     LISA frame to the corresponding values in the SSB frame."""
 
     name = "lisa_to_ssb"
-
-    default_params_name = {
-        'default_tc_lisa': parameters.tc,
-        'default_longitude_lisa': parameters.eclipticlongitude,
-        'default_latitude_lisa': parameters.eclipticlatitude,
-        'default_polarization_lisa': parameters.polarization,
-        'default_tc_ssb': parameters.tc,
-        'default_longitude_ssb': parameters.eclipticlongitude,
-        'default_latitude_ssb': parameters.eclipticlatitude,
-        'default_polarization_ssb': parameters.polarization
-    }
-
-    def __init__(
-        self, tc_lisa_param=None, longitude_lisa_param=None,
-        latitude_lisa_param=None, polarization_lisa_param=None,
-        tc_ssb_param=None, longitude_ssb_param=None,
-        latitude_ssb_param=None, polarization_ssb_param=None
-    ):
-        params = [tc_lisa_param, longitude_lisa_param,
-                  latitude_lisa_param, polarization_lisa_param,
-                  tc_ssb_param, longitude_ssb_param,
-                  latitude_ssb_param, polarization_ssb_param]
-        for index in range(len(params)):
-            if params[index] is None:
-                key = list(self.default_params_name.keys())[index]
-                params[index] = self.default_params_name[key]
-
-        self.tc_lisa_param = params[0]
-        self.longitude_lisa_param = params[1]
-        self.latitude_lisa_param = params[2]
-        self.polarization_lisa_param = params[3]
-        self.tc_ssb_param = params[4]
-        self.longitude_ssb_param = params[5]
-        self.latitude_ssb_param = params[6]
-        self.polarization_ssb_param = params[7]
-        self._inputs = [self.tc_lisa_param, self.longitude_lisa_param,
-                        self.latitude_lisa_param, self.polarization_lisa_param]
-        self._outputs = [self.tc_ssb_param, self.longitude_ssb_param,
-                         self.latitude_ssb_param, self.polarization_ssb_param]
-        super(LISAToSSB, self).__init__()
-
-    def transform(self, maps):
-        """This function transforms arrival time, sky localization,
-        and polarization angle in the LISA frame to the corresponding
-        values in the SSB frame.
-
-        Parameters
-        ----------
-        maps : a mapping object
-
-        Returns
-        -------
-        out : dict
-            A dict with key as parameter name and value as numpy.array or float
-            of transformed values.
-        """
-        out = {}
-        out[self.tc_ssb_param], out[self.longitude_ssb_param], \
-            out[self.latitude_ssb_param], out[self.polarization_ssb_param] = \
-            coordinates.lisa_to_ssb(
-                maps[self.tc_lisa_param], maps[self.longitude_lisa_param],
-                maps[self.latitude_lisa_param], maps[self.polarization_lisa_param]
-                )
-        return self.format_output(maps, out)
-
-    def inverse_transform(self, maps):
-        """This function transforms arrival time, sky localization,
-        and polarization angle in the SSB frame to the corresponding
-        values in the LISA frame.
-
-        Parameters
-        ----------
-        maps : a mapping object
-
-        Returns
-        -------
-        out : dict
-            A dict with key as parameter name and value as numpy.array or float
-            of transformed values.
-        """
-        out = {}
-        out[self.tc_lisa_param], out[self.longitude_lisa_param], \
-            out[self.latitude_lisa_param], \
-            out[self.polarization_lisa_param] = \
-            coordinates.ssb_to_lisa(
-                maps[self.tc_ssb_param], maps[self.longitude_ssb_param],
-                maps[self.latitude_ssb_param], maps[self.polarization_ssb_param]
-                )
-        return self.format_output(maps, out)
-
-    @classmethod
-    def from_config(cls, cp, section, outputs):
-        tag = outputs
-        skip_opts = []
-        additional_opts = {}
-
-        # get custom variable names
-        variables = {
-            'tc-lisa': cls.default_params_name['default_tc_lisa'],
-            'longitude-lisa': cls.default_params_name[
-                                    'default_longitude_lisa'],
-            'latitude-lisa': cls.default_params_name['default_latitude_lisa'],
-            'polarization-lisa': cls.default_params_name[
-                                    'default_polarization_lisa'],
-            'tc-ssb': cls.default_params_name['default_tc_ssb'],
-            'longitude-ssb': cls.default_params_name['default_longitude_ssb'],
-            'latitude-ssb': cls.default_params_name['default_latitude_ssb'],
-            'polarization-ssb': cls.default_params_name[
-                                    'default_polarization_ssb']
-        }
-        for param_name in variables.keys():
-            name_underline = param_name.replace('-', '_')
-            if cp.has_option("-".join([section, outputs]), param_name):
-                skip_opts.append(param_name)
-                additional_opts.update(
-                    {name_underline+'_param': cp.get_opt_tag(
-                     section, param_name, tag)})
-            else:
-                additional_opts.update(
-                    {name_underline+'_param': variables[param_name]})
-
-        return super(LISAToSSB, cls).from_config(
-            cp, section, outputs, skip_opts=skip_opts,
-            additional_opts=additional_opts
-        )
+    _frame_a, _frame_b = 'lisa', 'ssb'
+    default_params_name = _sky_frame_default_params_name('lisa', 'ssb')
 
 
-class LISAToGEO(BaseTransform):
+class LISAToGEO(SkyFrameTransform):
     """Converts arrival time, sky localization, and polarization angle in the
     LISA frame to the corresponding values in the geocentric frame."""
 
     name = "lisa_to_geo"
+    _frame_a, _frame_b = 'lisa', 'geo'
+    default_params_name = _sky_frame_default_params_name('lisa', 'geo')
 
-    default_params_name = {
-        'default_tc_lisa': parameters.tc,
-        'default_longitude_lisa': parameters.eclipticlongitude,
-        'default_latitude_lisa': parameters.eclipticlatitude,
-        'default_polarization_lisa': parameters.polarization,
-        'default_tc_geo': parameters.tc,
-        'default_longitude_geo': parameters.ra,
-        'default_latitude_geo': parameters.dec,
-        'default_polarization_geo': parameters.polarization
-    }
-
-    def __init__(
-        self, tc_lisa_param=None, longitude_lisa_param=None,
-        latitude_lisa_param=None, polarization_lisa_param=None,
-        tc_geo_param=None, longitude_geo_param=None,
-        latitude_geo_param=None, polarization_geo_param=None
-    ):
-        params = [tc_lisa_param, longitude_lisa_param,
-                  latitude_lisa_param, polarization_lisa_param,
-                  tc_geo_param, longitude_geo_param,
-                  latitude_geo_param, polarization_geo_param]
-        for index in range(len(params)):
-            if params[index] is None:
-                key = list(self.default_params_name.keys())[index]
-                params[index] = self.default_params_name[key]
-
-        self.tc_lisa_param = params[0]
-        self.longitude_lisa_param = params[1]
-        self.latitude_lisa_param = params[2]
-        self.polarization_lisa_param = params[3]
-        self.tc_geo_param = params[4]
-        self.longitude_geo_param = params[5]
-        self.latitude_geo_param = params[6]
-        self.polarization_geo_param = params[7]
-        self._inputs = [self.tc_lisa_param, self.longitude_lisa_param,
-                        self.latitude_lisa_param, self.polarization_lisa_param]
-        self._outputs = [self.tc_geo_param, self.longitude_geo_param,
-                         self.latitude_geo_param, self.polarization_geo_param]
-        super(LISAToGEO, self).__init__()
-
-    def transform(self, maps):
-        """This function transforms arrival time, sky localization,
-        and polarization angle in the LISA frame to the corresponding
-        values in the geocentric frame.
-
-        Parameters
-        ----------
-        maps : a mapping object
-
-        Returns
-        -------
-        out : dict
-            A dict with key as parameter name and value as numpy.array or float
-            of transformed values.
-        """
-        out = {}
-        out[self.tc_geo_param], out[self.longitude_geo_param], \
-            out[self.latitude_geo_param], out[self.polarization_geo_param] = \
-            coordinates.lisa_to_geo(
-                maps[self.tc_lisa_param], maps[self.longitude_lisa_param],
-                maps[self.latitude_lisa_param], maps[self.polarization_lisa_param]
-                )
-        return self.format_output(maps, out)
-
-    def inverse_transform(self, maps):
-        """This function transforms arrival time, sky localization,
-        and polarization angle in the geocentric frame to the corresponding
-        values in the LISA frame.
-
-        Parameters
-        ----------
-        maps : a mapping object
-
-        Returns
-        -------
-        out : dict
-            A dict with key as parameter name and value as numpy.array or float
-            of transformed values.
-        """
-        out = {}
-        out[self.tc_lisa_param], out[self.longitude_lisa_param], \
-            out[self.latitude_lisa_param], \
-            out[self.polarization_lisa_param] = \
-            coordinates.geo_to_lisa(
-                maps[self.tc_geo_param], maps[self.longitude_geo_param],
-                maps[self.latitude_geo_param], maps[self.polarization_geo_param]
-                )
-        return self.format_output(maps, out)
-
-    @classmethod
-    def from_config(cls, cp, section, outputs):
-        tag = outputs
-        skip_opts = []
-        additional_opts = {}
-
-        # get custom variable names
-        variables = {
-            'tc-lisa': cls.default_params_name['default_tc_lisa'],
-            'longitude-lisa': cls.default_params_name[
-                                    'default_longitude_lisa'],
-            'latitude-lisa': cls.default_params_name['default_latitude_lisa'],
-            'polarization-lisa': cls.default_params_name[
-                                    'default_polarization_lisa'],
-            'tc-geo': cls.default_params_name['default_tc_geo'],
-            'longitude-geo': cls.default_params_name['default_longitude_geo'],
-            'latitude-geo': cls.default_params_name['default_latitude_geo'],
-            'polarization-geo': cls.default_params_name[
-                                    'default_polarization_geo']
-        }
-        for param_name in variables.keys():
-            name_underline = param_name.replace('-', '_')
-            if cp.has_option("-".join([section, outputs]), param_name):
-                skip_opts.append(param_name)
-                additional_opts.update(
-                    {name_underline+'_param': cp.get_opt_tag(
-                     section, param_name, tag)})
-            else:
-                additional_opts.update(
-                    {name_underline+'_param': variables[param_name]})
-
-        return super(LISAToGEO, cls).from_config(
-            cp, section, outputs, skip_opts=skip_opts,
-            additional_opts=additional_opts
-        )
 
 
 class Log(BaseTransform):
@@ -2547,115 +2323,32 @@ class ChiPToCartesianSpin(CartesianSpinToChiP):
     inverse_jacobian = inverse.jacobian
 
 
-class SSBToGEO(GEOToSSB):
+class SSBToGEO(SkyFrameTransform):
     """The inverse of GEOToSSB."""
 
     name = "ssb_to_geo"
-    inverse = GEOToSSB
-    transform = inverse.inverse_transform
-    inverse_transform = inverse.transform
-
-    def __init__(
-        self, tc_geo_param=None, longitude_geo_param=None,
-        latitude_geo_param=None, polarization_geo_param=None,
-        tc_ssb_param=None, longitude_ssb_param=None,
-        latitude_ssb_param=None, polarization_ssb_param=None
-    ):
-        params = [tc_geo_param, longitude_geo_param,
-                  latitude_geo_param, polarization_geo_param,
-                  tc_ssb_param, longitude_ssb_param,
-                  latitude_ssb_param, polarization_ssb_param]
-        for index in range(len(params)):
-            if params[index] is None:
-                key = list(self.default_params_name.keys())[index]
-                params[index] = self.default_params_name[key]
-
-        self.tc_geo_param = params[0]
-        self.longitude_geo_param = params[1]
-        self.latitude_geo_param = params[2]
-        self.polarization_geo_param = params[3]
-        self.tc_ssb_param = params[4]
-        self.longitude_ssb_param = params[5]
-        self.latitude_ssb_param = params[6]
-        self.polarization_ssb_param = params[7]
-        self._inputs = [self.tc_ssb_param, self.longitude_ssb_param,
-                        self.latitude_ssb_param, self.polarization_ssb_param]
-        self._outputs = [self.tc_geo_param, self.longitude_geo_param,
-                         self.latitude_geo_param, self.polarization_geo_param]
+    _frame_a, _frame_b = 'geo', 'ssb'
+    _forward = False
+    default_params_name = GEOToSSB.default_params_name
 
 
-class SSBToLISA(LISAToSSB):
+class SSBToLISA(SkyFrameTransform):
     """The inverse of LISAToSSB."""
 
     name = "ssb_to_lisa"
-    inverse = LISAToSSB
-    transform = inverse.inverse_transform
-    inverse_transform = inverse.transform
-
-    def __init__(
-        self, tc_lisa_param=None, longitude_lisa_param=None,
-        latitude_lisa_param=None, polarization_lisa_param=None,
-        tc_ssb_param=None, longitude_ssb_param=None,
-        latitude_ssb_param=None, polarization_ssb_param=None
-    ):
-        params = [tc_lisa_param, longitude_lisa_param,
-                  latitude_lisa_param, polarization_lisa_param,
-                  tc_ssb_param, longitude_ssb_param,
-                  latitude_ssb_param, polarization_ssb_param]
-        for index in range(len(params)):
-            if params[index] is None:
-                key = list(self.default_params_name.keys())[index]
-                params[index] = self.default_params_name[key]
-
-        self.tc_lisa_param = params[0]
-        self.longitude_lisa_param = params[1]
-        self.latitude_lisa_param = params[2]
-        self.polarization_lisa_param = params[3]
-        self.tc_ssb_param = params[4]
-        self.longitude_ssb_param = params[5]
-        self.latitude_ssb_param = params[6]
-        self.polarization_ssb_param = params[7]
-        self._inputs = [self.tc_ssb_param, self.longitude_ssb_param,
-                        self.latitude_ssb_param, self.polarization_ssb_param]
-        self._outputs = [self.tc_lisa_param, self.longitude_lisa_param,
-                         self.latitude_lisa_param, self.polarization_lisa_param]
+    _frame_a, _frame_b = 'lisa', 'ssb'
+    _forward = False
+    default_params_name = LISAToSSB.default_params_name
 
 
-class GEOToLISA(LISAToGEO):
+class GEOToLISA(SkyFrameTransform):
     """The inverse of LISAToGEO."""
 
     name = "geo_to_lisa"
-    inverse = LISAToGEO
-    transform = inverse.inverse_transform
-    inverse_transform = inverse.transform
+    _frame_a, _frame_b = 'lisa', 'geo'
+    _forward = False
+    default_params_name = LISAToGEO.default_params_name
 
-    def __init__(
-        self, tc_lisa_param=None, longitude_lisa_param=None,
-        latitude_lisa_param=None, polarization_lisa_param=None,
-        tc_geo_param=None, longitude_geo_param=None,
-        latitude_geo_param=None, polarization_geo_param=None
-    ):
-        params = [tc_lisa_param, longitude_lisa_param,
-                  latitude_lisa_param, polarization_lisa_param,
-                  tc_geo_param, longitude_geo_param,
-                  latitude_geo_param, polarization_geo_param]
-        for index in range(len(params)):
-            if params[index] is None:
-                key = list(self.default_params_name.keys())[index]
-                params[index] = self.default_params_name[key]
-
-        self.tc_lisa_param = params[0]
-        self.longitude_lisa_param = params[1]
-        self.latitude_lisa_param = params[2]
-        self.polarization_lisa_param = params[3]
-        self.tc_geo_param = params[4]
-        self.longitude_geo_param = params[5]
-        self.latitude_geo_param = params[6]
-        self.polarization_geo_param = params[7]
-        self._inputs = [self.tc_geo_param, self.longitude_geo_param,
-                        self.latitude_geo_param, self.polarization_geo_param]
-        self._outputs = [self.tc_lisa_param, self.longitude_lisa_param,
-                         self.latitude_lisa_param, self.polarization_lisa_param]
 
 
 class Exponent(Log):
@@ -2801,8 +2494,11 @@ ChiPToCartesianSpin.inverse = CartesianSpinToChiP
 Log.inverse = Exponent
 Logit.inverse = Logistic
 GEOToSSB.inverse = SSBToGEO
+SSBToGEO.inverse = GEOToSSB
 LISAToSSB.inverse = SSBToLISA
+SSBToLISA.inverse = LISAToSSB
 LISAToGEO.inverse = GEOToLISA
+GEOToLISA.inverse = LISAToGEO
 
 
 #

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -96,8 +96,41 @@ class TestTransforms(unittest.TestCase):
                 raise ValueError(
                 "Transform {} does not map back to itself.".format(trans.name))
 
+class TestSpaceDetectorTransformsSetOutputs(unittest.TestCase):
+    """`SSBToGEO`, `SSBToLISA` and `GEOToLISA` are the inverse-direction
+    siblings of `GEOToSSB`, `LISAToSSB` and `LISAToGEO`. Before they shared
+    a base class their `__init__` set `_inputs`/`_outputs` but never called
+    `BaseTransform.__init__`, so instances never got the public
+    `.inputs`/`.outputs` sets that `from_config` relies on. This checks
+    custom parameter names survive construction and that both sets are
+    populated for the inverse direction too.
+    """
+    def test_ssb_to_lisa_custom_names(self):
+        t = transforms.SSBToLISA(
+            tc_lisa_param='tc_lisa', longitude_lisa_param='lon_lisa',
+            latitude_lisa_param='lat_lisa', polarization_lisa_param='pol_lisa')
+        self.assertEqual(t.tc_lisa_param, 'tc_lisa')
+        self.assertEqual(
+            t.outputs, {'tc_lisa', 'lon_lisa', 'lat_lisa', 'pol_lisa'})
+        self.assertEqual(
+            t.inputs, {'tc', 'eclipticlongitude', 'eclipticlatitude',
+                       'polarization'})
+
+    def test_geo_to_lisa_custom_names(self):
+        t = transforms.GEOToLISA(tc_lisa_param='tc_lisa')
+        self.assertEqual(t.tc_lisa_param, 'tc_lisa')
+        self.assertIn('tc_lisa', t.outputs)
+
+    def test_ssb_to_geo_custom_names(self):
+        t = transforms.SSBToGEO(tc_geo_param='tc_geo')
+        self.assertEqual(t.tc_geo_param, 'tc_geo')
+        self.assertIn('tc_geo', t.outputs)
+
+
 suite = unittest.TestSuite()
 suite.addTest(unittest.TestLoader().loadTestsFromTestCase(TestTransforms))
+suite.addTest(unittest.TestLoader().loadTestsFromTestCase(
+    TestSpaceDetectorTransformsSetOutputs))
 
 if __name__ == "__main__":
     results = unittest.TextTestRunner(verbosity=2).run(suite)


### PR DESCRIPTION
<!---
Please delete these comments when you submit the pull request

Please add a title which is a concise description of what you are doing,
e.g. 'Fix bug with numpy import in pycbc_coinc_findtrigs' or 'add high frequency sky location dependent response for long detectors'
-->

<!---
This is a brief template for making pull requests for PyCBC.
This is _not_ a proscriptive template - you can use a different style if you want.
Please do think about the questions posed here and whether the details will be useful to include in your PR
Please add sufficient details so that people looking back at the request with no context around the work can understand the changes.
To choose reviewers, please look at the git blame for the code you are changing (if applicable),
or discuss in the #pycbc-code channel of the gwastro slack.
Please add labels as appropriate
-->

<!-- TOP-LEVEL SUMMARY: Please provide a brief, one-or-two-sentence description of the PR here
-->

## Standard information about the request

<!--- Some basic info about the change (delete as appropriate) -->
This is a: efficiency update

<!--- What codes will this affect? (delete as apropriate)
If you do not know which areas will be affected, please ask in the gwastro #pycbc-code slack
-->
This change affects: inference

<!--- What code areas will this affect? (delete as apropriate) -->
This change changes: documentation, result presentation / plotting, scientific output

<!--- Some things which help with code management (delete as appropriate) -->
This change: has appropriate unit tests, follows style guidelines (See e.g. [PEP8](https://peps.python.org/pep-0008/)), has been proposed using the [contribution guidelines](https://github.com/gwastro/pycbc/blob/master/CONTRIBUTING.md)

## Motivation
<!--- Describe why your changes are being made -->
Simplify PR https://github.com/gwastro/pycbc/pull/4289

## Contents
<!--- Describe your changes, this doesn't need to be a line-by-line code change discussion,
but rather a general discussion of the methods chosen -->
pycbc/coordinates/space.py: `ssb_to_lisa and lisa_to_ssb` were mirror images of the same six-step algorithm, and all four of `ssb_to_lisa / lisa_to_ssb / ssb_to_geo / geo_to_ssb` repeated the same input-coercion, range-validation and scalar-vs-array output packing inline. Those are factored into `_ensure_sky_params_arrays, _validate_sky_params, _pack_sky_params_output` and `_sky_ssb_space_transform`, leaving the public functions as thin wrappers with unchanged signatures and docstrings.

pycbc/transforms.py: `GEOToSSB`, `LISAToSSB`, and `LISAToGEO` were previously three separate classes (each around 130 lines long) that manually duplicated `__init__`, `transform`, `inverse_transform`, and `from_config` methods for different coordinate transformation pairs; meanwhile, `SSBToGEO`, `SSBToLISA`, and `GEOToLISA` repeated the same `__init__` implementation yet again. Now, all six classes inherit from a common `SkyFrameTransform` base class that implements this shared logic, driven by the `_frame_a`, `_frame_b`, and `_forward` attributes of the respective subclasses.

This change also fixes an actual bug: the three original inverse transformation classes set `self._inputs` and `self._outputs` but never called `BaseTransform.__init__`, meaning their instances lacked the public `.inputs` and `.outputs` collections required by `from_config`. The test case `TestSpaceDetectorTransformsSetOutputs` covers this scenario.

## Links to any issues or associated PRs
<!--- If this is fixing / working around an already-reported issue, please link to it here -->
PR https://github.com/gwastro/pycbc/pull/4289

## Testing performed
<!--- Describe tests for the code changes, either already performed or to be performed -->
The net result is a reduction of approximately 335 lines of code while maintaining the public API unchanged. The primary basis for this conclusion is that the existing `test_coordinates_space.py` and `test_transforms.py` pass without modification. Furthermore, verification shows that when using the `astropy`-based implementation, the outputs for `ssb_to_lisa`, `lisa_to_ssb`, `ssb_to_geo`, `geo_to_ssb`, `lisa_to_geo`, and `geo_to_lisa`—tested against both random and edge-case inputs (including scalars and arrays)—are bit-for-bit identical to the old implementation (with a maximum difference of `|old - new| = 0.0`); additionally, the `ValueError` messages for all invalid input scenarios are identical.

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
