### PR TITLE
demarg_reproduce

### DIFF
--- a/bin/inference/pycbc_inference_model_stats
+++ b/bin/inference/pycbc_inference_model_stats
@@ -54,6 +54,13 @@ parser.add_argument("--config-file", nargs="+", type=str, default=None,
                           "with the given file(s).")
 parser.add_argument('--reconstruct-parameters', action="store_true",
                     help="Reconstruct marginalized parameters")
+parser.add_argument("--seed", type=int, default=None,
+                    help="Seed to use for the random number generator that "
+                         "initializes the model and draws the reconstructed "
+                         "(demarginalized) parameters. Runs that use the same "
+                         "seed and the same input give identical output. If "
+                         "not given, the generator is left unseeded and the "
+                         "output is not reproducible.")
 
 
 # parse command line
@@ -84,6 +91,10 @@ if opts.config_file is None:
 else:
     cp = WorkflowConfigParser(opts.config_file)
 
+if opts.seed is not None:
+    numpy.random.seed(opts.seed)
+    logging.info("Using seed %i", opts.seed)
+
 # now load the model
 logging.info("Loading model")
 model = models.read_from_config(cp)
@@ -94,6 +105,10 @@ model.sampling_transforms = None
 # create function for calling the model to get the stats
 def callmodel(arg):
     iteration, paramvals = arg
+    
+    seed = iteration if opts.seed is None else opts.seed + iteration
+    if opts.seed is not None:
+        numpy.random.seed(seed)
     # calculate the logposterior to get all stats populated
     model.update(**{p: paramvals[p] for p in model.variable_params})
     _ = model.logposterior
@@ -102,8 +117,10 @@ def callmodel(arg):
     rec = {}
     if opts.reconstruct_parameters:
         model.update(**{p: paramvals[p] for p in model.variable_params})
-        # Ensure unique random seed for each reconstruction
-        rec = model.reconstruct(seed=iteration)
+        # Ensure a unique random seed for each reconstruction; when a global
+        # seed is given it is derived from that, so that it is independent of
+        # the order in which the pool hands out the samples
+        rec = model.reconstruct(seed=seed)
     return stats, rec
 
 # these help for parallelization for MPI

--- a/bin/inference/pycbc_inference_model_stats
+++ b/bin/inference/pycbc_inference_model_stats
@@ -54,13 +54,11 @@ parser.add_argument("--config-file", nargs="+", type=str, default=None,
                           "with the given file(s).")
 parser.add_argument('--reconstruct-parameters', action="store_true",
                     help="Reconstruct marginalized parameters")
-parser.add_argument("--seed", type=int, default=None,
+parser.add_argument("--seed", type=int, default=0,
                     help="Seed to use for the random number generator that "
                          "initializes the model and draws the reconstructed "
                          "(demarginalized) parameters. Runs that use the same "
-                         "seed and the same input give identical output. If "
-                         "not given, the generator is left unseeded and the "
-                         "output is not reproducible.")
+                         "seed and the same input give identical output.")
 
 
 # parse command line
@@ -91,9 +89,10 @@ if opts.config_file is None:
 else:
     cp = WorkflowConfigParser(opts.config_file)
 
-if opts.seed is not None:
-    numpy.random.seed(opts.seed)
-    logging.info("Using seed %i", opts.seed)
+# the seed has to be set before the model is created; marginalized models
+# draw their marginalization points at construction
+numpy.random.seed(opts.seed)
+logging.info("Using seed %i", opts.seed)
 
 # now load the model
 logging.info("Loading model")
@@ -106,9 +105,10 @@ model.sampling_transforms = None
 def callmodel(arg):
     iteration, paramvals = arg
     
-    seed = iteration if opts.seed is None else opts.seed + iteration
-    if opts.seed is not None:
-        numpy.random.seed(seed)
+    # derive a unique seed for each sample from the global one, so that the
+    # result does not depend on which process picks up which sample
+    seed = opts.seed + iteration
+    numpy.random.seed(seed)
     # calculate the logposterior to get all stats populated
     model.update(**{p: paramvals[p] for p in model.variable_params})
     _ = model.logposterior

--- a/pycbc/inference/models/brute_marg.py
+++ b/pycbc/inference/models/brute_marg.py
@@ -207,7 +207,7 @@ class BruteLISASkyModesMarginalize(BaseGaussianNoise):
     def reconstruct(self, seed=None):
         """ Reconstruct a point from unwrapping the 8-fold sky symmetry
         """
-        if seed:
+        if seed is not None:
             numpy.random.seed(seed)
         rec = {}
 

--- a/pycbc/inference/models/hierarchical.py
+++ b/pycbc/inference/models/hierarchical.py
@@ -987,7 +987,7 @@ class JointPrimaryMarginalizedModel(HierarchicalModel):
         """ Reconstruct marginalized parameters by using the primary
         model's reconstruct method, total_loglr, and others_lognl.
         """
-        if seed:
+        if seed is not None:
             numpy.random.seed(seed)
 
         if rec is None:

--- a/pycbc/inference/models/tools.py
+++ b/pycbc/inference/models/tools.py
@@ -746,7 +746,7 @@ class DistMarg():
         """ Reconstruct the distance or vectored marginalized parameter
         of this class.
         """
-        if seed:
+        if seed is not None:
             numpy.random.seed(seed)
 
         if rec is None:


### PR DESCRIPTION
This PR comes from the comment thread on https://github.com/gwastro/pycbc/pull/5408, where it came up that `pycbc_inference_model_stats` has no way to set a seed, so you can't reproduce the demarginalization. I also fixed the condition in the reconstruct() function since it was not working if the seed was zero.