### PR TITLE
Vectorize pycbc distributions

### DIFF
--- a/pycbc/boundaries.py
+++ b/pycbc/boundaries.py
@@ -349,8 +349,28 @@ class Bounds(object):
     def __abs__(self):
         return abs(self._max - self._min)
 
-    def __contains__(self, value):
+    def contains(self, value):
+        """Whether each of the given values is within the bounds.
+
+        Use this rather than ``value in self`` when ``value`` is an array.
+        Python coerces the result of ``__contains__`` to a single bool, so the
+        ``in`` operator cannot report on more than one value at a time even
+        though the comparison underneath is elementwise.
+
+        Parameters
+        ----------
+        value : float or array
+            The value(s) to test.
+
+        Returns
+        -------
+        bool or array
+            Whether each value is within the bounds.
+        """
         return self._min.smaller(value) & self._max.larger(value)
+
+    def __contains__(self, value):
+        return self.contains(value)
 
     def _reflect_well(self, value):
         """Thin wrapper around `reflect_well` that passes self as the `bounds`.
@@ -416,13 +436,13 @@ class Bounds(object):
 
         Parameters
         ----------
-        value : float
-            The value to test.
+        value : float or array
+            The value(s) to test.
 
         Returns
         -------
-        bool
-            Whether or not the value is within the bounds after the boundary
+        bool or array
+            Whether or not each value is within the bounds after the boundary
             conditions are applied.
         """
-        return self.apply_conditions(value) in self
+        return self.contains(self.apply_conditions(value))

--- a/pycbc/boundaries.py
+++ b/pycbc/boundaries.py
@@ -352,20 +352,8 @@ class Bounds(object):
     def contains(self, value):
         """Whether each of the given values is within the bounds.
 
-        Use this rather than ``value in self`` when ``value`` is an array.
-        Python coerces the result of ``__contains__`` to a single bool, so the
-        ``in`` operator cannot report on more than one value at a time even
-        though the comparison underneath is elementwise.
-
-        Parameters
-        ----------
-        value : float or array
-            The value(s) to test.
-
-        Returns
-        -------
-        bool or array
-            Whether each value is within the bounds.
+        Use this instead of ``value in self`` for an array: Python coerces the
+        result of ``__contains__`` to a single bool.
         """
         return self._min.smaller(value) & self._max.larger(value)
 

--- a/pycbc/distributions/angular.py
+++ b/pycbc/distributions/angular.py
@@ -220,10 +220,9 @@ class SinAngle(UniformAngle):
         contain all of parameters in self's params. Unrecognized arguments are
         ignored.
         """
-        if kwargs not in self:
-            return 0.
         return self._norm * \
-            self._dfunc(numpy.array([kwargs[p] for p in self._params])).prod()
+            self._dfunc(numpy.array([kwargs[p]
+                                     for p in self._params])).prod(axis=0)
 
 
     def _logpdf(self, **kwargs):
@@ -231,11 +230,10 @@ class SinAngle(UniformAngle):
         arguments must contain all of parameters in self's params. Unrecognized
         arguments are ignored.
         """
-        if kwargs not in self:
-            return -numpy.inf
         return self._lognorm + \
             numpy.log(self._dfunc(
-                numpy.array([kwargs[p] for p in self._params]))).sum()
+                numpy.array([kwargs[p]
+                             for p in self._params]))).sum(axis=0)
 
 
 class CosAngle(SinAngle):

--- a/pycbc/distributions/arbitrary.py
+++ b/pycbc/distributions/arbitrary.py
@@ -113,7 +113,7 @@ class Arbitrary(bounded.BoundedDist):
         this_pdf = jacobian * self._kde.evaluate([kwargs[p]
                                                  for p in self._params])
         if len(this_pdf) == 1:
-            return float(this_pdf)
+            return this_pdf.item()
         return this_pdf
 
     def _logpdf(self, **kwargs):

--- a/pycbc/distributions/arbitrary.py
+++ b/pycbc/distributions/arbitrary.py
@@ -68,7 +68,7 @@ class Arbitrary(bounded.BoundedDist):
                 self._transforms[tparam] = t
                 self._tparams[param] = tparam
                 # remove any sample points that fall out side of the bounds
-                outside = bnds.__contains__(samples)
+                outside = bnds.contains(samples)
                 if outside.any():
                     samples = samples[outside]
                 # transform the sample points
@@ -97,45 +97,31 @@ class Arbitrary(bounded.BoundedDist):
             if p not in kwargs.keys():
                 raise ValueError('Missing parameter {} to construct pdf.'
                                  .format(p))
-        if kwargs in self:
-            # transform into the kde space
-            jacobian = 1.
-            for param, tparam in self._tparams.items():
-                t = self._transforms[tparam]
-                try:
-                    samples = t.transform({param: kwargs[param]})
-                except ValueError as e:
-                    # can get a value error if the value is exactly == to
-                    # the bounds, in which case, just return 0.
-                    if kwargs[param] in self.bounds[param]:
-                        return 0.
-                    else:
-                        raise ValueError(e)
-                kwargs[param] = samples[tparam]
-                # update the jacobian for the transform; if p is the pdf
-                # in the params frame (the one we want) and p' is the pdf
-                # in the transformed frame (the one that's calculated) then:
-                # p = J * p', where J is the Jacobian of going from p to p'
-                jacobian *= t.jacobian(samples)
-            # for scipy < 0.15.0, gaussian_kde.pdf = gaussian_kde.evaluate
-            this_pdf = jacobian * self._kde.evaluate([kwargs[p]
-                                                      for p in self._params])
-            if len(this_pdf) == 1:
-                return float(this_pdf)
-            else:
-                return this_pdf
-        else:
-            return 0.
+        # transform into the kde space
+        jacobian = 1.
+        kwargs = dict(kwargs)
+        for param, tparam in self._tparams.items():
+            t = self._transforms[tparam]
+            samples = t.transform({param: kwargs[param]})
+            kwargs[param] = samples[tparam]
+            # update the jacobian for the transform; if p is the pdf
+            # in the params frame (the one we want) and p' is the pdf
+            # in the transformed frame (the one that's calculated) then:
+            # p = J * p', where J is the Jacobian of going from p to p'
+            jacobian *= t.jacobian(samples)
+        # for scipy < 0.15.0, gaussian_kde.pdf = gaussian_kde.evaluate
+        this_pdf = jacobian * self._kde.evaluate([kwargs[p]
+                                                 for p in self._params])
+        if len(this_pdf) == 1:
+            return float(this_pdf)
+        return this_pdf
 
     def _logpdf(self, **kwargs):
         """Returns the log of the pdf at the given values. The keyword
         arguments must contain all of parameters in self's params.
         Unrecognized arguments are ignored.
         """
-        if kwargs not in self:
-            return -numpy.inf
-        else:
-            return numpy.log(self._pdf(**kwargs))
+        return numpy.log(self._pdf(**kwargs))
 
     def set_bandwidth(self, set_bw="scott"):
         self._kde.set_bandwidth(set_bw)

--- a/pycbc/distributions/bounded.py
+++ b/pycbc/distributions/bounded.py
@@ -238,13 +238,36 @@ class BoundedDist(object):
         """dict: A dictionary of the parameter names and their bounds."""
         return self._bounds
 
-    def __contains__(self, params):
+    def contains(self, params):
+        """Whether each of the given points is within the bounds.
+
+        Use this rather than ``params in self`` when the values are arrays;
+        ``in`` can only answer for one point at a time, because Python
+        coerces ``__contains__`` to a single bool.
+
+        Parameters
+        ----------
+        params : dict
+            Maps each parameter in self to a value or an array of values.
+            Arrays and scalars may be mixed; they are broadcast against each
+            other. Unrecognized keys are ignored.
+
+        Returns
+        -------
+        bool or array
+            Whether each point is within the bounds of every parameter.
+        """
+        isin = True
         try:
-            return all(self._bounds[p].contains_conditioned(params[p])
-                       for p in self._params)
+            for param in self._params:
+                isin = isin & self._bounds[param].contains_conditioned(
+                    params[param])
         except KeyError:
             raise ValueError("must provide all parameters [%s]" %(
                 ', '.join(self._params)))
+        return isin
+
+    __contains__ = contains
 
     def apply_boundary_conditions(self, **kwargs):
         r"""Applies any boundary conditions to the given values (e.g., applying
@@ -269,18 +292,50 @@ class BoundedDist(object):
         return dict([[p, self._bounds[p].apply_conditions(val)]
                      for p,val in kwargs.items() if p in self._bounds])
 
+    def _in_bounds(self, func, outside, **kwargs):
+        """Evaluates ``func`` at the points that are within the bounds, and
+        returns ``outside`` at the rest.
+
+        The values handed to ``func`` are always within the bounds, so an
+        implementation does not have to guard against its own support: no log
+        of a negative number, and no need to test containment itself. Scalar
+        input is passed straight through and returns a scalar, so the cost of
+        a single-point call is one containment test.
+        """
+        isin = self.contains(kwargs)
+        if not getattr(isin, 'ndim', 0):
+            return func(**kwargs) if isin else outside
+        out = numpy.full(isin.shape, outside, dtype=float)
+        if isin.any():
+            inside = dict(kwargs)
+            for param in self._params:
+                val = numpy.asarray(kwargs[param])
+                if val.ndim:
+                    inside[param] = val[isin]
+            out[isin] = func(**inside)
+        return out
+
     def pdf(self, **kwargs):
         """Returns the pdf at the given values. The keyword arguments must
         contain all of parameters in self's params. Unrecognized arguments are
         ignored. Any boundary conditions are applied to the values before the
         pdf is evaluated.
+
+        The values may be arrays, in which case an array of the same shape is
+        returned.
         """
-        return self._pdf(**self.apply_boundary_conditions(**kwargs))
+        return self._in_bounds(self._pdf, 0.,
+                               **self.apply_boundary_conditions(**kwargs))
 
     def _pdf(self, **kwargs):
         """The underlying pdf function called by `self.pdf`. This must be set
         by any class that inherits from this class. Otherwise, a
         `NotImplementedError` is raised.
+
+        Only values within the bounds are passed in; `self.pdf` fills in zero
+        elsewhere. Implementations should reduce over parameters rather than
+        over everything they are given, so that an array of values returns an
+        array of the same length.
         """
         raise NotImplementedError("pdf function not set")
 
@@ -289,13 +344,20 @@ class BoundedDist(object):
         arguments must contain all of parameters in self's params.
         Unrecognized arguments are ignored. Any boundary conditions are
         applied to the values before the pdf is evaluated.
+
+        The values may be arrays, in which case an array of the same shape is
+        returned.
         """
-        return self._logpdf(**self.apply_boundary_conditions(**kwargs))
+        return self._in_bounds(self._logpdf, -numpy.inf,
+                               **self.apply_boundary_conditions(**kwargs))
 
     def _logpdf(self, **kwargs):
         """The underlying log pdf function called by `self.logpdf`. This must
         be set by any class that inherits from this class. Otherwise, a
         `NotImplementedError` is raised.
+
+        Only values within the bounds are passed in; `self.logpdf` fills in
+        ``-inf`` elsewhere. See `_pdf` on reducing over parameters only.
         """
         raise NotImplementedError("pdf function not set")
 

--- a/pycbc/distributions/bounded.py
+++ b/pycbc/distributions/bounded.py
@@ -239,29 +239,14 @@ class BoundedDist(object):
         return self._bounds
 
     def contains(self, params):
-        """Whether each of the given points is within the bounds.
-
-        Use this rather than ``params in self`` when the values are arrays;
-        ``in`` can only answer for one point at a time, because Python
-        coerces ``__contains__`` to a single bool.
-
-        Parameters
-        ----------
-        params : dict
-            Maps each parameter in self to a value or an array of values.
-            Arrays and scalars may be mixed; they are broadcast against each
-            other. Unrecognized keys are ignored.
-
-        Returns
-        -------
-        bool or array
-            Whether each point is within the bounds of every parameter.
+        """Whether each of the given points is within the bounds of every
+        parameter. ``params`` maps each parameter to a value or an array of
+        values. Use this instead of ``params in self`` for arrays.
         """
         isin = True
         try:
-            for param in self._params:
-                isin = isin & self._bounds[param].contains_conditioned(
-                    params[param])
+            for p in self._params:
+                isin = isin & self._bounds[p].contains_conditioned(params[p])
         except KeyError:
             raise ValueError("must provide all parameters [%s]" %(
                 ', '.join(self._params)))
@@ -293,14 +278,10 @@ class BoundedDist(object):
                      for p,val in kwargs.items() if p in self._bounds])
 
     def _in_bounds(self, func, outside, **kwargs):
-        """Evaluates ``func`` at the points that are within the bounds, and
-        returns ``outside`` at the rest.
-
-        The values handed to ``func`` are always within the bounds, so an
-        implementation does not have to guard against its own support: no log
-        of a negative number, and no need to test containment itself. Scalar
-        input is passed straight through and returns a scalar, so the cost of
-        a single-point call is one containment test.
+        """Evaluates ``func`` where the values are within the bounds, and
+        returns ``outside`` at the rest. ``func`` is only ever handed values
+        within them. A scalar is passed straight through, so a single-point
+        call costs one containment test.
         """
         isin = self.contains(kwargs)
         if not getattr(isin, 'ndim', 0):
@@ -308,10 +289,8 @@ class BoundedDist(object):
         out = numpy.full(isin.shape, outside, dtype=float)
         if isin.any():
             inside = dict(kwargs)
-            for param in self._params:
-                val = numpy.asarray(kwargs[param])
-                if val.ndim:
-                    inside[param] = val[isin]
+            inside.update({p: numpy.asarray(kwargs[p])[isin]
+                           for p in self._params if numpy.ndim(kwargs[p])})
             out[isin] = func(**inside)
         return out
 
@@ -319,10 +298,7 @@ class BoundedDist(object):
         """Returns the pdf at the given values. The keyword arguments must
         contain all of parameters in self's params. Unrecognized arguments are
         ignored. Any boundary conditions are applied to the values before the
-        pdf is evaluated.
-
-        The values may be arrays, in which case an array of the same shape is
-        returned.
+        pdf is evaluated. The values may be arrays.
         """
         return self._in_bounds(self._pdf, 0.,
                                **self.apply_boundary_conditions(**kwargs))
@@ -333,9 +309,8 @@ class BoundedDist(object):
         `NotImplementedError` is raised.
 
         Only values within the bounds are passed in; `self.pdf` fills in zero
-        elsewhere. Implementations should reduce over parameters rather than
-        over everything they are given, so that an array of values returns an
-        array of the same length.
+        elsewhere. Reduce over the parameters, not over everything given, so
+        that an array of values returns an array.
         """
         raise NotImplementedError("pdf function not set")
 
@@ -343,10 +318,8 @@ class BoundedDist(object):
         """Returns the log of the pdf at the given values. The keyword
         arguments must contain all of parameters in self's params.
         Unrecognized arguments are ignored. Any boundary conditions are
-        applied to the values before the pdf is evaluated.
-
-        The values may be arrays, in which case an array of the same shape is
-        returned.
+        applied to the values before the pdf is evaluated. The values may be
+        arrays.
         """
         return self._in_bounds(self._logpdf, -numpy.inf,
                                **self.apply_boundary_conditions(**kwargs))
@@ -357,7 +330,7 @@ class BoundedDist(object):
         `NotImplementedError` is raised.
 
         Only values within the bounds are passed in; `self.logpdf` fills in
-        ``-inf`` elsewhere. See `_pdf` on reducing over parameters only.
+        ``-inf`` elsewhere. See `_pdf`.
         """
         raise NotImplementedError("pdf function not set")
 

--- a/pycbc/distributions/gaussian.py
+++ b/pycbc/distributions/gaussian.py
@@ -190,12 +190,9 @@ class Gaussian(bounded.BoundedDist):
         arguments must contain all of parameters in self's params. Unrecognized
         arguments are ignored.
         """
-        if kwargs in self:
-            return sum([self._lognorm[p] +
-                        self._expnorm[p]*(kwargs[p]-self._mean[p])**2.
-                        for p in self._params])
-        else:
-            return -numpy.inf
+        return sum([self._lognorm[p] +
+                    self._expnorm[p]*(kwargs[p]-self._mean[p])**2.
+                    for p in self._params])
 
     @classmethod
     def from_config(cls, cp, section, variable_args):

--- a/pycbc/distributions/joint.py
+++ b/pycbc/distributions/joint.py
@@ -266,15 +266,7 @@ class JointDistribution(object):
         params = self.apply_boundary_conditions(**params)
         result = True
         for dist in self.distributions:
-            param_names = dist.params
-            vlen = len(params[param_names[0]])
-            contain_array = numpy.ones(vlen, dtype=bool)
-            # note: enable `__contains__` in `pycbc.distributions.bounded`
-            # to handle array-like input, it doesn't work now.
-            for i in range(vlen):
-                data = {pname: params[pname][i] for pname in param_names}
-                contain_array[i] = data in dist
-            result &= numpy.array(contain_array)
+            result &= dist.contains(params)
         result &= self.within_constraints(params)
         return result
 
@@ -294,8 +286,6 @@ class JointDistribution(object):
                 return out
 
         # evaluate
-        # note: this step may fail if arrays of values were provided, as
-        # not all distributions are vectorized currently
         logps = numpy.array([d(**params) for d in self.distributions])
         logp = logps.sum(axis=0)
 

--- a/pycbc/distributions/mass.py
+++ b/pycbc/distributions/mass.py
@@ -166,13 +166,9 @@ class QfromUniformMass1Mass2(bounded.BoundedDist):
             if p not in kwargs.keys():
                 raise ValueError(
                     'Missing parameter {} to construct pdf.'.format(p))
-        if kwargs in self:
-            pdf = self._norm * \
-                numpy.prod([(1.+kwargs[p])**(2./5)/kwargs[p]**(6./5)
-                            for p in self._params])
-            return float(pdf)
-        else:
-            return 0.0
+        return self._norm * \
+            numpy.prod([(1.+kwargs[p])**(2./5)/kwargs[p]**(6./5)
+                        for p in self._params], axis=0)
 
     def _logpdf(self, **kwargs):
         """Returns the log of the pdf at the given values. The keyword
@@ -183,10 +179,7 @@ class QfromUniformMass1Mass2(bounded.BoundedDist):
             if p not in kwargs.keys():
                 raise ValueError(
                     'Missing parameter {} to construct logpdf.'.format(p))
-        if kwargs in self:
-            return numpy.log(self._pdf(**kwargs))
-        else:
-            return -numpy.inf
+        return numpy.log(self._pdf(**kwargs))
 
     def _cdf_param(self, param, value):
         r""">>> from sympy import *

--- a/pycbc/distributions/power_law.py
+++ b/pycbc/distributions/power_law.py
@@ -154,13 +154,9 @@ class UniformPowerLaw(bounded.BoundedDist):
             if p not in kwargs.keys():
                 raise ValueError(
                             'Missing parameter {} to construct pdf.'.format(p))
-        if kwargs in self:
-            pdf = self._norm * \
-                  numpy.prod([(kwargs[p])**(self.dim - 1)
-                              for p in self._params])
-            return float(pdf)
-        else:
-            return 0.0
+        return self._norm * \
+            numpy.prod([(kwargs[p])**(self.dim - 1)
+                        for p in self._params], axis=0)
 
     def _logpdf(self, **kwargs):
         """Returns the log of the pdf at the given values. The keyword
@@ -171,13 +167,9 @@ class UniformPowerLaw(bounded.BoundedDist):
             if p not in kwargs.keys():
                 raise ValueError(
                             'Missing parameter {} to construct pdf.'.format(p))
-        if kwargs in self:
-            log_pdf = self._lognorm + \
-                      (self.dim - 1) * \
-                      numpy.log([kwargs[p] for p in self._params]).sum()
-            return log_pdf
-        else:
-            return -numpy.inf
+        return self._lognorm + \
+            (self.dim - 1) * \
+            numpy.log([kwargs[p] for p in self._params]).sum(axis=0)
 
     @classmethod
     def from_config(cls, cp, section, variable_args):

--- a/pycbc/distributions/qnm.py
+++ b/pycbc/distributions/qnm.py
@@ -145,8 +145,8 @@ class UniformF0Tau(uniform.Uniform):
     def contains(self, params):
         isin = super(UniformF0Tau, self).contains(params)
         if not getattr(isin, 'ndim', 0):
-            # the constraint costs a final mass and spin conversion, so a
-            # single point outside the bounds is not worth converting
+            # the mass and spin conversion costs 6.5 us; skip it for a single
+            # point the bounds already reject
             return isin and self._constraints(params)
         return isin & self._constraints(params)
 

--- a/pycbc/distributions/qnm.py
+++ b/pycbc/distributions/qnm.py
@@ -142,11 +142,13 @@ class UniformF0Tau(uniform.Uniform):
         self._lognorm += numpy.log(num_in) - numpy.log(nsamples)
         self._norm = numpy.exp(self._lognorm)
 
-    def __contains__(self, params):
-        isin = super(UniformF0Tau, self).__contains__(params)
-        if isin:
-            isin &= self._constraints(params)
-        return isin
+    def contains(self, params):
+        isin = super(UniformF0Tau, self).contains(params)
+        if not getattr(isin, 'ndim', 0):
+            # the constraint costs a final mass and spin conversion, so a
+            # single point outside the bounds is not worth converting
+            return isin and self._constraints(params)
+        return isin & self._constraints(params)
 
     def _constraints(self, params):
         f0 = params[self.rdfreq]
@@ -162,8 +164,8 @@ class UniformF0Tau(uniform.Uniform):
         with numpy.errstate(invalid="ignore"):
             mf = conversions.final_mass_from_f0_tau(f0, tau, l=l, m=m)
             sf = conversions.final_spin_from_f0_tau(f0, tau, l=l, m=m)
-            isin = (self.final_mass_bounds.__contains__(mf)) & (
-                    self.final_spin_bounds.__contains__(sf))
+            isin = (self.final_mass_bounds.contains(mf)
+                    & self.final_spin_bounds.contains(sf))
         return isin
 
     def rvs(self, size=1):

--- a/pycbc/distributions/spins.py
+++ b/pycbc/distributions/spins.py
@@ -167,15 +167,18 @@ class IndependentChiPChiEff(Arbitrary):
                ((s2x**2. + s2y**2. + s2z**2.) < 1.)
         return test
 
-    def __contains__(self, params):
+    def contains(self, params):
         """Determines whether the given values are in each parameter's bounds
         and satisfy the constraints.
         """
-        isin = all([params in dist for dist in self.distributions.values()])
-        if not isin:
-            return False
-        # in the individual distributions, apply constrains
-        return self._constraints(params)
+        isin = True
+        for dist in self.distributions.values():
+            isin = isin & dist.contains(params)
+        # the individual distributions do not know about the constraints; a
+        # single point already outside the bounds is not worth converting
+        if not getattr(isin, 'ndim', 0):
+            return isin and self._constraints(params)
+        return isin & self._constraints(params)
 
     def _draw(self, size=1, **kwargs):
         """Draws random samples without applying physical constrains.

--- a/pycbc/distributions/spins.py
+++ b/pycbc/distributions/spins.py
@@ -174,8 +174,7 @@ class IndependentChiPChiEff(Arbitrary):
         isin = True
         for dist in self.distributions.values():
             isin = isin & dist.contains(params)
-        # the individual distributions do not know about the constraints; a
-        # single point already outside the bounds is not worth converting
+        # the individual distributions do not know about the constraints
         if not getattr(isin, 'ndim', 0):
             return isin and self._constraints(params)
         return isin & self._constraints(params)

--- a/pycbc/distributions/uniform.py
+++ b/pycbc/distributions/uniform.py
@@ -111,20 +111,14 @@ class Uniform(bounded.BoundedDist):
         contain all of parameters in self's params. Unrecognized arguments are
         ignored.
         """
-        if kwargs in self:
-            return self._norm
-        else:
-            return 0.
+        return self._norm
 
     def _logpdf(self, **kwargs):
         """Returns the log of the pdf at the given values. The keyword
         arguments must contain all of parameters in self's params. Unrecognized
         arguments are ignored.
         """
-        if kwargs in self:
-            return self._lognorm
-        else:
-            return -numpy.inf
+        return self._lognorm
 
     @classmethod
     def from_config(cls, cp, section, variable_args):

--- a/pycbc/distributions/uniform_log.py
+++ b/pycbc/distributions/uniform_log.py
@@ -54,21 +54,15 @@ class UniformLog10(uniform.Uniform):
         contain all of parameters in self's params. Unrecognized arguments are
         ignored.
         """
-        if kwargs in self:
-            vals = numpy.array([numpy.log(10) * self._norm * kwargs[param]
-                                for param in kwargs.keys()])
-            return 1.0 / numpy.prod(vals)
-        else:
-            return 0.
+        vals = numpy.array([numpy.log(10) * self._norm * kwargs[param]
+                            for param in self._params])
+        return 1.0 / numpy.prod(vals, axis=0)
 
     def _logpdf(self, **kwargs):
         """Returns the log of the pdf at the given values. The keyword
         arguments must contain all of parameters in self's params. Unrecognized
         arguments are ignored.
         """
-        if kwargs in self:
-            return numpy.log(self._pdf(**kwargs))
-        else:
-            return -numpy.inf
+        return numpy.log(self._pdf(**kwargs))
 
 __all__ = ["UniformLog10"]

--- a/pycbc/transforms.py
+++ b/pycbc/transforms.py
@@ -2201,10 +2201,7 @@ class Logit(BaseTransform):
         """
         x = maps[self._inputvar]
         # check that x is in bounds
-        isin = self._bounds.__contains__(x)
-        if isinstance(isin, numpy.ndarray):
-            isin = isin.all()
-        if not isin:
+        if not numpy.all(self._bounds.contains(x)):
             raise ValueError("one or more values are not in bounds")
         out = {self._outputvar: self.logit(x, self._a, self._b)}
         return self.format_output(maps, out)
@@ -2254,11 +2251,8 @@ class Logit(BaseTransform):
         """
         x = maps[self._inputvar]
         # check that x is in bounds
-        isin = self._bounds.__contains__(x)
-        if isinstance(isin, numpy.ndarray) and not isin.all():
+        if not numpy.all(self._bounds.contains(x)):
             raise ValueError("one or more values are not in bounds")
-        elif not isin:
-            raise ValueError("{} is not in bounds".format(x))
         return (self._b - self._a) / ((x - self._a) * (self._b - x))
 
     def inverse_jacobian(self, maps):

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -164,6 +164,66 @@ class TestDistributions(unittest.TestCase):
                                      "functions for distribution {} "
                                      "do not agree".format(dist.name))
 
+    def test_pdf_arrays(self):
+        """ Checks that handing arrays to the PDF and its logarithm gives the
+        same answer, element by element, as asking for one point at a time.
+
+        The points straddle each parameter's bounds, so both sides of the
+        support are covered. Outside is the part a vectorized implementation
+        is most likely to get wrong: the containment test reduces to a single
+        answer unless it is kept elementwise, which silently applies one
+        point's verdict to the whole array.
+        """
+        npts = 9
+        tested = 0
+        for dist in self.dists:
+            points = {}
+            for param in dist.params:
+                low, high = dist.bounds[param][0], dist.bounds[param][1]
+                pad = 0.1 * (high - low)
+                points[param] = numpy.linspace(low - pad, high + pad, npts)
+            for name in ("pdf", "logpdf"):
+                func = getattr(dist, name)
+                array = numpy.asarray(func(**points))
+                one_at_a_time = numpy.array(
+                    [func(**{p: points[p][i] for p in dist.params})
+                     for i in range(npts)])
+                self.assertEqual(
+                    array.shape, (npts,),
+                    "{}.{} returned shape {} for {} points".format(
+                        dist.name, name, array.shape, npts))
+                numpy.testing.assert_allclose(
+                    array, one_at_a_time, rtol=0., atol=0.,
+                    err_msg="{}.{} disagrees with the one-point call".format(
+                        dist.name, name))
+            tested += 1
+        self.assertGreater(tested, 5)
+
+    def test_pdf_arrays_with_constraints(self):
+        """ Same check for a distribution that constrains more than its
+        bounds. ``UniformF0Tau`` also requires the implied final mass and
+        spin to be in range, so its containment test is the interesting one:
+        the bounds alone would admit points it has to reject.
+        """
+        npts = 9
+        dist = distributions.UniformF0Tau(f0=(10., 100.), tau=(1e-3, 1e-1))
+        points = {"f0": numpy.linspace(5., 120., npts),
+                  "tau": numpy.linspace(1e-4, 0.2, npts)}
+        isin = dist.contains(points)
+        self.assertEqual(isin.shape, (npts,))
+        # the fixture is only worth its cost if it exercises both verdicts
+        self.assertTrue(isin.any() and not isin.all())
+        for name in ("pdf", "logpdf"):
+            func = getattr(dist, name)
+            array = numpy.asarray(func(**points))
+            one_at_a_time = numpy.array(
+                [func(f0=points["f0"][i], tau=points["tau"][i])
+                 for i in range(npts)])
+            numpy.testing.assert_allclose(
+                array, one_at_a_time, rtol=0., atol=0.,
+                err_msg="UniformF0Tau.{} disagrees with the one-point "
+                        "call".format(name))
+
     def test_solid_angle(self):
         """ The uniform solid angle and uniform sky position distributions
         are two independent one-dimensional distributions. This tests checks

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -207,12 +207,18 @@ class TestDistributions(unittest.TestCase):
         """
         npts = 9
         dist = distributions.UniformF0Tau(f0=(10., 100.), tau=(1e-3, 1e-1))
-        points = {"f0": numpy.linspace(5., 120., npts),
-                  "tau": numpy.linspace(1e-4, 0.2, npts)}
+        # strictly inside both bounds, so only the constraint can reject any
+        # of these; if it is not applied they all come back accepted
+        points = {"f0": numpy.linspace(12., 98., npts),
+                  "tau": numpy.linspace(2e-3, 9e-2, npts)}
+        for param in dist.params:
+            for value in points[param]:
+                self.assertTrue(value in dist.bounds[param])
         isin = dist.contains(points)
         self.assertEqual(isin.shape, (npts,))
-        # the fixture is only worth its cost if it exercises both verdicts
-        self.assertTrue(isin.any() and not isin.all())
+        self.assertTrue(isin.any(), "the constraint rejected every point")
+        self.assertFalse(isin.all(),
+                         "the final mass and spin constraint was not applied")
         for name in ("pdf", "logpdf"):
             func = getattr(dist, name)
             array = numpy.asarray(func(**points))

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -166,13 +166,11 @@ class TestDistributions(unittest.TestCase):
 
     def test_pdf_arrays(self):
         """ Checks that handing arrays to the PDF and its logarithm gives the
-        same answer, element by element, as asking for one point at a time.
+        same answer, element by element, as asking one point at a time.
 
-        The points straddle each parameter's bounds, so both sides of the
-        support are covered. Outside is the part a vectorized implementation
-        is most likely to get wrong: the containment test reduces to a single
-        answer unless it is kept elementwise, which silently applies one
-        point's verdict to the whole array.
+        The points straddle each parameter's bounds. Outside is what a
+        vectorized containment test gets wrong when it reduces to a single
+        answer, applying one point's verdict to the whole array.
         """
         npts = 9
         tested = 0
@@ -200,15 +198,13 @@ class TestDistributions(unittest.TestCase):
         self.assertGreater(tested, 5)
 
     def test_pdf_arrays_with_constraints(self):
-        """ Same check for a distribution that constrains more than its
-        bounds. ``UniformF0Tau`` also requires the implied final mass and
-        spin to be in range, so its containment test is the interesting one:
-        the bounds alone would admit points it has to reject.
+        """ Same check where the bounds are not the whole story:
+        ``UniformF0Tau`` also requires the implied final mass and spin to be
+        in range, so the bounds alone would admit points it must reject.
         """
         npts = 9
         dist = distributions.UniformF0Tau(f0=(10., 100.), tau=(1e-3, 1e-1))
         # strictly inside both bounds, so only the constraint can reject any
-        # of these; if it is not applied they all come back accepted
         points = {"f0": numpy.linspace(12., 98., npts),
                   "tau": numpy.linspace(2e-3, 9e-2, npts)}
         for param in dist.params:

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -96,6 +96,32 @@ class TestTransforms(unittest.TestCase):
                 raise ValueError(
                 "Transform {} does not map back to itself.".format(trans.name))
 
+    def test_logit_arrays(self):
+        """ Checks that the Logit transform and its jacobian take arrays.
+
+        ``jacobian`` used to raise on an array whose values were all in
+        bounds: the array branch of its bounds check only caught the case
+        where something was out of bounds, and the scalar branch it fell
+        through to could not evaluate an array of booleans.
+        """
+        trans = transforms.Logit("x", "logitx", domain=(0., 1.))
+        values = numpy.linspace(0.01, 0.99, 5)
+        for name in ("transform", "jacobian"):
+            func = getattr(trans, name)
+            array = numpy.atleast_1d(numpy.asarray(
+                func({"x": values})["logitx"] if name == "transform"
+                else func({"x": values})))
+            self.assertEqual(array.shape, values.shape)
+            for i, value in enumerate(values):
+                one = (func({"x": value})["logitx"] if name == "transform"
+                       else func({"x": value}))
+                self.assertEqual(array[i], one)
+        # out of bounds still raises, for one value or for many
+        for bad in ({"x": numpy.array([0.5, 1.5])}, {"x": 1.5}):
+            self.assertRaises(ValueError, trans.transform, bad)
+            self.assertRaises(ValueError, trans.jacobian, bad)
+
+
 suite = unittest.TestSuite()
 suite.addTest(unittest.TestLoader().loadTestsFromTestCase(TestTransforms))
 

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -99,10 +99,9 @@ class TestTransforms(unittest.TestCase):
     def test_logit_arrays(self):
         """ Checks that the Logit transform and its jacobian take arrays.
 
-        ``jacobian`` used to raise on an array whose values were all in
-        bounds: the array branch of its bounds check only caught the case
-        where something was out of bounds, and the scalar branch it fell
-        through to could not evaluate an array of booleans.
+        ``jacobian`` used to raise on an array with everything in bounds: its
+        array branch only caught the out-of-bounds case, and the scalar branch
+        it fell through to could not evaluate an array of booleans.
         """
         trans = transforms.Logit("x", "logitx", domain=(0., 1.))
         values = numpy.linspace(0.01, 0.99, 5)
@@ -116,7 +115,6 @@ class TestTransforms(unittest.TestCase):
                 one = (func({"x": value})["logitx"] if name == "transform"
                        else func({"x": value}))
                 self.assertEqual(array[i], one)
-        # out of bounds still raises, for one value or for many
         for bad in ({"x": numpy.array([0.5, 1.5])}, {"x": 1.5}):
             self.assertRaises(ValueError, trans.transform, bad)
             self.assertRaises(ValueError, trans.jacobian, bad)


### PR DESCRIPTION
This vectorize the pycbc distributions so they can be called with arrays and so the joint distribution can take advantage of that (say via the contains method). 

This has been on our to-do list for a while, so I asked claude to take a look and address this. 

In most cases this also simplified the code since they were working around the contains method. 

[WIP] as I want to do some further manual review beyond my initial testing (e.g. of the suite and what I asked claude to look at). I'll report after that is done. 



- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
