### PR TITLE
Detector response with unit direction vectors as an alternative to ra/dec

### DIFF
--- a/pycbc/detector/ground.py
+++ b/pycbc/detector/ground.py
@@ -324,44 +324,22 @@ class Detector(object):
         d = self.location - det.location
         return float(d.dot(d)**0.5 / constants.c.value)
 
-    def antenna_pattern(self, right_ascension, declination, polarization, t_gps,
-                        frequency=0,
-                        polarization_type='tensor'):
-        """Return the detector response.
+    def _antenna_pattern(self, cosgha, singha, sindec, cosdec, polarization,
+                         frequency, polarization_type):
+        """Return the detector response, given the source direction as the
+        sidereal-hour-angle and declination trigonometry.
 
-        Parameters
-        ----------
-        right_ascension: float or numpy.ndarray
-            The right ascension of the source
-        declination: float or numpy.ndarray
-            The declination of the source
-        polarization: float or numpy.ndarray
-            The polarization angle of the source
-        polarization_type: string flag: Tensor, Vector or Scalar
-            The gravitational wave polarizations. Default: 'Tensor'
-
-        Returns
-        -------
-        fplus(default) or fx or fb : float or numpy.ndarray
-            The plus or vector-x or breathing polarization factor for this sky location / orientation
-        fcross(default) or fy or fl : float or numpy.ndarray
-            The cross or vector-y or longitudnal polarization factor for this sky location / orientation
+        `antenna_pattern` and `antenna_pattern_from_direction` differ only
+        in how they arrive at these four quantities, so the response itself
+        is worked out once, here.
         """
-        if isinstance(t_gps, lal.LIGOTimeGPS):
-            t_gps = float(t_gps)
-        gha = self.gmst_estimate(t_gps) - right_ascension
-
-        cosgha = cos(gha)
-        singha = sin(gha)
-        cosdec = cos(declination)
-        sindec = sin(declination)
         cospsi = cos(polarization)
         sinpsi = sin(polarization)
 
         if frequency:
             e0 = cosdec * cosgha
             e1 = cosdec * -singha
-            e2 = sin(declination)
+            e2 = sindec
             nhat = np.array([e0, e1, e2], dtype=object)
 
             nx = nhat.dot(self.info['xvec'])
@@ -422,6 +400,97 @@ class Detector(object):
                 fb = (x * dx + y * dy).sum()
                 fl = (z * dz).sum()
             return fb, fl
+
+    def antenna_pattern(self, right_ascension, declination, polarization, t_gps,
+                        frequency=0,
+                        polarization_type='tensor'):
+        """Return the detector response.
+
+        Parameters
+        ----------
+        right_ascension: float or numpy.ndarray
+            The right ascension of the source
+        declination: float or numpy.ndarray
+            The declination of the source
+        polarization: float or numpy.ndarray
+            The polarization angle of the source
+        polarization_type: string flag: Tensor, Vector or Scalar
+            The gravitational wave polarizations. Default: \'Tensor\'
+
+        Returns
+        -------
+        fplus(default) or fx or fb : float or numpy.ndarray
+            The plus or vector-x or breathing polarization factor for this sky location / orientation
+        fcross(default) or fy or fl : float or numpy.ndarray
+            The cross or vector-y or longitudnal polarization factor for this sky location / orientation
+        """
+        if isinstance(t_gps, lal.LIGOTimeGPS):
+            t_gps = float(t_gps)
+        gha = self.gmst_estimate(t_gps) - right_ascension
+        return self._antenna_pattern(cos(gha), sin(gha), sin(declination),
+                                     cos(declination), polarization,
+                                     frequency, polarization_type)
+
+    def antenna_pattern_from_direction(self, direction, polarization=0,
+                                       frequency=0,
+                                       polarization_type='tensor'):
+        """Return the detector response for a source direction given as a
+        unit vector in the earth-fixed frame.
+
+        The same as `antenna_pattern`, for a caller that already holds the
+        direction as a vector and would otherwise convert it to a right
+        ascension and declination for that to convert straight back. The
+        sidereal time is not needed, since it only enters through the
+        vector.
+
+        Parameters
+        ----------
+        direction: numpy.ndarray or sequence
+            Unit vector from the earth centre towards the source, in the
+            same frame as `location`. Shape (3,) for one direction or
+            (3, n) for many; a sequence of three components also works.
+        polarization: float or numpy.ndarray
+            The polarization angle of the source
+        frequency: float
+            The frequency to evaluate the arm response at. Default: 0
+        polarization_type: string flag: Tensor, Vector or Scalar
+            The gravitational wave polarizations. Default: \'Tensor\'
+
+        Returns
+        -------
+        fplus(default) or fx or fb : float or numpy.ndarray
+            The plus or vector-x or breathing polarization factor.
+        fcross(default) or fy or fl : float or numpy.ndarray
+            The cross or vector-y or longitudnal polarization factor.
+        """
+        e0, e1, e2 = direction[0], direction[1], direction[2]
+        # e0 is cos(dec)cos(gha) and e1 is -cos(dec)sin(gha). The floor only
+        # keeps the poles finite, where the hour angle is degenerate anyway.
+        cosdec = np.sqrt(np.maximum(e0 * e0 + e1 * e1, 1e-300))
+        return self._antenna_pattern(e0 / cosdec, -e1 / cosdec, e2, cosdec,
+                                     polarization, frequency,
+                                     polarization_type)
+
+    def time_delay_from_direction(self, direction):
+        """Return the time delay from the earth center for a source
+        direction given as a unit vector in the earth-fixed frame.
+
+        The same quantity as `time_delay_from_earth_center`; see
+        `antenna_pattern_from_direction`.
+
+        Parameters
+        ----------
+        direction: numpy.ndarray
+            Unit vector from the earth centre towards the source, in the
+            same frame as `location`. Shape (3,) for one direction or
+            (3, n) for many.
+
+        Returns
+        -------
+        delay: float or numpy.ndarray
+            The time delay in seconds.
+        """
+        return -self.location.dot(direction) / constants.c.value
 
     def time_delay_from_earth_center(self, right_ascension, declination, t_gps):
         """Return the time delay from the earth center

--- a/test/test_detector.py
+++ b/test/test_detector.py
@@ -96,6 +96,42 @@ class TestDetector(unittest.TestCase):
 
             self.assertLess(diff.max(), tolerance)
 
+    def test_antenna_pattern_from_direction(self):
+        """The vector form must answer what the ra/dec form answers.
+
+        antenna_pattern_from_direction and time_delay_from_direction take
+        the source direction as a vector in the earth-fixed frame instead
+        of a right ascension, a declination and a time. They are the same
+        quantities, so the two forms are checked against each other over
+        the same sky positions the rest of this file uses.
+        """
+        for ifo in self.d:
+            gmst = numpy.array([ifo.gmst_estimate(t) for t in self.time])
+            gha = gmst - self.ra
+            direction = numpy.array(
+                [numpy.cos(self.dec) * numpy.cos(gha),
+                 -numpy.cos(self.dec) * numpy.sin(gha),
+                 numpy.sin(self.dec)])
+
+            fp, fc = ifo.antenna_pattern_from_direction(direction)
+            fp0, fc0 = ifo.antenna_pattern(self.ra, self.dec,
+                                           numpy.zeros_like(self.ra),
+                                           self.time)
+            self.assertLess(abs(fp - fp0).max(), 1e-12)
+            self.assertLess(abs(fc - fc0).max(), 1e-12)
+
+            delay = ifo.time_delay_from_direction(direction)
+            delay0 = numpy.array(
+                [ifo.time_delay_from_earth_center(r, d, t)
+                 for r, d, t in zip(self.ra, self.dec, self.time)])
+            self.assertLess(abs(delay - delay0).max(), 1e-12)
+
+            # one direction at a time is the same as all of them at once
+            one_fp, one_fc = ifo.antenna_pattern_from_direction(
+                direction[:, 0])
+            self.assertAlmostEqual(float(one_fp), float(fp[0]), places=12)
+            self.assertAlmostEqual(float(one_fc), float(fc[0]), places=12)
+
     def test_delay_from_detector(self):
         ra, dec, time = self.ra[0:10], self.dec[0:10], self.time[0:10]
         for d1 in self.d:


### PR DESCRIPTION
## Motivation
For sky marginalization the math is a lot easier if I switch to a unit vector system for directions rather than ra / dec. This refactors the detector class so it has an extra interface that works with that as an alternative. Otherwise, the underlying impelmentation is unaffected, just the few lines we had to convert to the unit vector form aren't there (that's what we were doing in the first few lines originally anyway). 

## Contents
This just adds two new method to access the detector antenna patter and delays but instead of using ra/dec coordinates it uses a vector direction. 

## Testing performed
This adds test that confirm it is identical to the regular channel.  The ra/dec path is the same and tested against lal already in the test suite. 

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
