### PR TITLE
Allow peak lock to shift with sampling

### DIFF
--- a/pycbc/inference/models/relbin.py
+++ b/pycbc/inference/models/relbin.py
@@ -711,24 +711,25 @@ class RelativeTime(Relative):
             self._ref_snr = self.get_snr(wfs)
         return self._ref_snr
 
+    def coarse_series(self, ifo, wfs, tstart, delta_t, num_samples):
+        """ The predictor on any grid, used to look for the peak """
+        sdat = self.sdat[ifo]
+        dtc = tstart - self.end_time[ifo] - self.ta[ifo]
+        return snr_predictor(self.fedges[ifo], dtc, delta_t, num_samples,
+                             wfs[ifo][0], wfs[ifo][1], self.h00_sparse[ifo],
+                             sdat['a0'], sdat['a1'], sdat['b0'], sdat['b1'])
+
     def get_snr(self, wfs):
         """ Return hp/hc maximized SNR time series
         """
         delta_t = 1.0 / self.sample_rate
+        self.follow_peak(wfs)
         snrs = {}
         for ifo in wfs:
-            sdat = self.sdat[ifo]
-            dtc = self.tstart[ifo] - self.end_time[ifo] - self.ta[ifo]
-
-            snr = snr_predictor(self.fedges[ifo],
-                                dtc - delta_t * 2.0, delta_t,
-                                self.num_samples[ifo] + 4,
-                                wfs[ifo][0], wfs[ifo][1],
-                                self.h00_sparse[ifo],
-                                sdat['a0'], sdat['a1'],
-                                sdat['b0'], sdat['b1'])
-            snrs[ifo] = TimeSeries(snr, delta_t=delta_t,
-                                   epoch=self.tstart[ifo] - delta_t * 2.0)
+            start = self.tstart[ifo] - delta_t * 2.0
+            snr = self.coarse_series(ifo, wfs, start, delta_t,
+                                     self.num_samples[ifo] + 4)
+            snrs[ifo] = TimeSeries(snr, delta_t=delta_t, epoch=start)
         return snrs
 
     @catch_waveform_error
@@ -812,28 +813,34 @@ class RelativeTimeDom(RelativeTime):
     """
     name = "relative_time_dom"
 
+    def sh_series(self, ifo, wfs, tstart, delta_t, num_samples):
+        """ The predictor on any grid, as the sh and hh it returns """
+        sdat = self.sdat[ifo]
+        dtc = tstart - self.end_time[ifo] - self.ta[ifo]
+        return snr_predictor_dom(self.fedges[ifo], dtc, delta_t, num_samples,
+                                 wfs[ifo][0], self.h00_sparse[ifo],
+                                 sdat['a0'], sdat['a1'],
+                                 sdat['b0'], sdat['b1'])
+
+    def coarse_series(self, ifo, wfs, tstart, delta_t, num_samples):
+        """ The predictor on any grid, used to look for the peak """
+        return self.sh_series(ifo, wfs, tstart, delta_t, num_samples)[0]
+
     def get_snr(self, wfs):
         """ Return hp/hc maximized SNR time series
         """
         delta_t = 1.0 / self.sample_rate
+        self.follow_peak(wfs)
         snrs = {}
         self.sh = {}
         self.hh = {}
         for ifo in wfs:
-            sdat = self.sdat[ifo]
-            dtc = self.tstart[ifo] - self.end_time[ifo] - self.ta[ifo]
-
-            sh, hh = snr_predictor_dom(self.fedges[ifo],
-                                       dtc - delta_t * 2.0, delta_t,
-                                       self.num_samples[ifo] + 4,
-                                       wfs[ifo][0],
-                                       self.h00_sparse[ifo],
-                                       sdat['a0'], sdat['a1'],
-                                       sdat['b0'], sdat['b1'])
+            start = self.tstart[ifo] - delta_t * 2.0
+            sh, hh = self.sh_series(ifo, wfs, start, delta_t,
+                                    self.num_samples[ifo] + 4)
             snr = TimeSeries(abs(sh[2:-2]) / hh ** 0.5, delta_t=delta_t,
                              epoch=self.tstart[ifo])
-            self.sh[ifo] = TimeSeries(sh, delta_t=delta_t,
-                                      epoch=self.tstart[ifo] - delta_t * 2.0)
+            self.sh[ifo] = TimeSeries(sh, delta_t=delta_t, epoch=start)
             self.hh[ifo] = hh
             snrs[ifo] = snr
 

--- a/pycbc/inference/models/tools.py
+++ b/pycbc/inference/models/tools.py
@@ -657,6 +657,7 @@ class DistMarg():
         self.tstart = {ifo: tstart for ifo in self.data}
         self.num_samples = {ifo: num_samples for ifo in self.data}
         self.peak_lock_peak = {}
+        self.peak_lock_peak_snr = {}
 
         if snrs is None:
             if not hasattr(self, 'ref_snr'):
@@ -681,6 +682,7 @@ class DistMarg():
                 logging.info('%s: Max Ref SNR Peak of %s at %s',
                              ifo, peak_snr, peak_time)
                 self.peak_lock_peak[ifo] = float(peak_time)
+                self.peak_lock_peak_snr[ifo] = float(peak_snr)
 
                 if peak_snr > peak_lock_snr:
                     target = peak_snr ** 2.0 / 2.0 - numpy.log(peak_lock_ratio)
@@ -755,9 +757,12 @@ class DistMarg():
 
         # keep_ifos is not set until draw_ifos, which runs after the
         # reference series is built
-        ifo = (getattr(self, 'keep_ifos', None) or list(wfs))[0]
-        if ifo not in self.peak_lock_peak:
+        seen = [i for i in (getattr(self, 'keep_ifos', None) or list(wfs))
+                if i in self.peak_lock_peak]
+        if not seen:
             return
+        # the loudest, whose peak is the least uncertain in time
+        ifo = max(seen, key=self.peak_lock_peak_snr.get)
 
         rate = self.peak_lock_sample_rate
         locked = self.peak_lock_peak[ifo]

--- a/pycbc/inference/models/tools.py
+++ b/pycbc/inference/models/tools.py
@@ -603,6 +603,8 @@ class DistMarg():
                         peak_lock_snr=None,
                         peak_lock_ratio=1e4,
                         peak_lock_region=4,
+                        peak_lock_search_samples=None,
+                        peak_lock_search_decimate=8,
                         **kwargs):
         """ Determine where to constrain marginalization based on
         the observed reference SNR peaks.
@@ -622,7 +624,28 @@ class DistMarg():
         peak_lock_region: int
             Number of samples to inclue beyond the strict region
             determined by the relative likelihood
+        peak_lock_search_samples: int
+            How far to search for the peak before each likelihood, in
+            samples, centered on the region locked here. The region is then
+            moved to wherever the peak turned out to be. Off if not given.
+        peak_lock_search_decimate: int
+            Stride of that search, in samples. It only has to place the
+            peak inside the region, so it must be no wider than one.
         """
+        self.peak_lock_search_samples = (
+            None if peak_lock_search_samples is None
+            else int(peak_lock_search_samples))
+        self.peak_lock_search_decimate = int(peak_lock_search_decimate)
+        self.peak_lock_sample_rate = float(sample_rate)
+
+        # a model whose reference series is fixed has no peak to follow and
+        # provides no coarse_series to look for one with
+        if self.peak_lock_search_samples and not hasattr(self,
+                                                         'coarse_series'):
+            logging.warning("%s cannot search for the peak, so "
+                            "peak_lock_search_samples is ignored",
+                            type(self).__name__)
+            self.peak_lock_search_samples = None
 
         if 'tc' not in self.marginalized_vector_priors:
             return
@@ -633,6 +656,7 @@ class DistMarg():
         num_samples = int(tmax * sample_rate)
         self.tstart = {ifo: tstart for ifo in self.data}
         self.num_samples = {ifo: num_samples for ifo in self.data}
+        self.peak_lock_peak = {}
 
         if snrs is None:
             if not hasattr(self, 'ref_snr'):
@@ -656,6 +680,7 @@ class DistMarg():
 
                 logging.info('%s: Max Ref SNR Peak of %s at %s',
                              ifo, peak_snr, peak_time)
+                self.peak_lock_peak[ifo] = float(peak_time)
 
                 if peak_snr > peak_lock_snr:
                     target = peak_snr ** 2.0 / 2.0 - numpy.log(peak_lock_ratio)
@@ -691,6 +716,64 @@ class DistMarg():
         self.tend = self.tstart.copy()
         for ifo in snrs:
             self.tend[ifo] += self.num_samples[ifo] / sample_rate
+        self.peak_lock_start = self.tstart.copy()
+
+    def follow_peak(self, wfs):
+        """ Move the locked region to wherever the peak is now
+
+        The region is locked once, around a reference waveform, and the peak
+        it was locked on moves with the parameters. A coarse pass over a
+        wider range says where it went.
+
+        The offset is measured from the region as locked, not from wherever
+        the last call left it, so the region is a function of the current
+        parameters alone. It is found in one detector and applied to all of
+        them, which keeps the delays between them as they were locked.
+
+        Does nothing when the marginalization points were precalculated,
+        since those were drawn over the locked region.
+        """
+        if not getattr(self, 'peak_lock_search_samples', None):
+            return
+        # the points were drawn over the region as locked; moving away from
+        # them would lose them silently
+        if hasattr(self, 'premarg'):
+            return
+        if not hasattr(self, 'peak_lock_start'):
+            return
+
+        # keep_ifos is not set until draw_ifos, which runs after the
+        # reference series is built
+        ifo = (getattr(self, 'keep_ifos', None) or list(wfs))[0]
+        if ifo not in self.peak_lock_peak:
+            return
+
+        rate = self.peak_lock_sample_rate
+        locked = self.peak_lock_peak[ifo]
+        delta_t = self.peak_lock_search_decimate / rate
+        num = int(self.peak_lock_search_samples
+                  / self.peak_lock_search_decimate)
+        start = locked - self.peak_lock_search_samples / rate / 2.0
+        series = abs(numpy.array(
+            self.coarse_series(ifo, wfs, start, delta_t, num)))
+
+        # the peak rarely sits on a coarse sample, and its neighbours say
+        # where between them it does
+        i = int(numpy.argmax(series))
+        if 0 < i < len(series) - 1:
+            a, b, c = series[i - 1], series[i], series[i + 1]
+            curve = a - 2.0 * b + c
+            if curve < 0:
+                i += numpy.clip(0.5 * (a - c) / curve, -0.5, 0.5)
+
+        # rounded to a whole sample of the region's own grid: a fractional
+        # offset samples the series at shifted phases, which costs more than
+        # placing the region more precisely gains
+        shift = round((start + i * delta_t - locked) * rate) / rate
+
+        for name in self.peak_lock_start:
+            self.tstart[name] = self.peak_lock_start[name] + shift
+            self.tend[name] = self.tstart[name] + self.num_samples[name] / rate
 
     def draw_ifos(self, snrs, peak_snr_threshold=4.0, log=True,
                   precalculate_marginalization_points=False,

--- a/pycbc/inference/models/tools.py
+++ b/pycbc/inference/models/tools.py
@@ -696,6 +696,7 @@ class DistMarg():
             for ifo in snrs:
                 ts = self.tstart[ifo]
                 te = ts + self.num_samples[ifo] / sample_rate
+                locked = ts, te
 
                 for ifo2 in snrs:
                     if ifo == ifo2:
@@ -707,6 +708,16 @@ class DistMarg():
 
                     ts = max(ts, ts2 - dt)
                     te = min(te, te2 + dt)
+
+                # an empty intersection is a negative number of samples,
+                # which the kernel reports as an unexplained ValueError
+                if te <= ts:
+                    ts, te = locked
+                    logging.warning(
+                        '%s: the locked regions have no time in common; '
+                        'keeping %s-%s. Widen them with peak_lock_ratio or '
+                        'peak_lock_region, or check the reference '
+                        'parameters', ifo, ts, te)
 
                 self.tstart[ifo] = ts
                 self.num_samples[ifo] = int((te - ts) * sample_rate) + 1

--- a/test/test_peak_lock.py
+++ b/test/test_peak_lock.py
@@ -28,6 +28,7 @@ import numpy
 from utils import simple_exit
 
 from pycbc.detector import Detector
+from pycbc.types import TimeSeries
 from pycbc.distributions import JointDistribution, SinAngle, Uniform
 from pycbc.inference import models
 from pycbc.inference.models.tools import DistMarg
@@ -224,6 +225,40 @@ class TestPeakLockSearch(unittest.TestCase):
         self.assertEqual(model.tstart, locked,
                          "the region moved out from under precalculated "
                          "points")
+
+    def test_regions_with_no_time_in_common_do_not_go_negative(self):
+        """Locking narrowly can leave the detectors nothing to agree on.
+
+        The regions are intersected pairwise, widened by the light travel
+        time, so that a time in one has a sky position consistent with the
+        others. Peaks further apart than that leave the intersection empty,
+        and an empty region is a negative sample count that reaches the
+        kernel as ValueError: negative dimensions are not allowed.
+        """
+        rate = 4096.0
+        span = 0.1
+        peaks = {'H1': 0.02, 'L1': 0.08}          # 60 ms apart, H1-L1 is 10
+        snrs = {}
+        for ifo, at in peaks.items():
+            t = numpy.arange(int(span * rate)) / rate
+            z = 30.0 * numpy.exp(-0.5 * ((t - at) / 2e-4) ** 2.0)
+            snrs[ifo] = TimeSeries(z + 0j, delta_t=1.0 / rate, epoch=TC)
+
+        class Two(DistMarg):
+            data = {'H1': None, 'L1': None}
+            marginalized_vector_priors = {
+                'tc': Uniform(tc=(TC, TC + span))}
+
+        two = Two()
+        with self.assertLogs(level='WARNING') as caught:
+            two.setup_peak_lock(sample_rate=rate, snrs=snrs,
+                                peak_lock_snr=5.0, peak_lock_ratio=20,
+                                peak_lock_region=2)
+        self.assertIn('no time in common', caught.records[0].getMessage())
+        for ifo in peaks:
+            self.assertGreater(two.num_samples[ifo], 0,
+                               "%s region is %s samples"
+                               % (ifo, two.num_samples[ifo]))
 
     def test_a_model_that_cannot_search_says_so(self):
         """Silently ignoring the option would be worse than not having it.

--- a/test/test_peak_lock.py
+++ b/test/test_peak_lock.py
@@ -20,7 +20,9 @@ the marginalization integrates over times the signal is not at. These drive
 the reference away from the signal and check the likelihood survives it.
 """
 
+import contextlib
 import copy
+import logging
 import unittest
 
 import numpy
@@ -92,6 +94,21 @@ class TestPeakLockSearch(unittest.TestCase):
         model = self.model(**kwargs)
         model.update(**POINT)
         return model.loglr
+
+    @contextlib.contextmanager
+    def logging_enabled(self):
+        """assertLogs cannot see anything through a global logging.disable.
+
+        test_fft_unthreaded silences WARNING when it is imported and never
+        puts it back, so in a whole-suite run every module after it sees no
+        records at all. Restore whatever was set rather than assuming.
+        """
+        previous = logging.root.manager.disable
+        logging.disable(logging.NOTSET)
+        try:
+            yield
+        finally:
+            logging.disable(previous)
 
     def test_off_by_default(self):
         """A model that did not ask for it must not move its region."""
@@ -250,7 +267,8 @@ class TestPeakLockSearch(unittest.TestCase):
                 'tc': Uniform(tc=(TC, TC + span))}
 
         two = Two()
-        with self.assertLogs(level='WARNING') as caught:
+        with self.logging_enabled(), \
+                self.assertLogs(level='WARNING') as caught:
             two.setup_peak_lock(sample_rate=rate, snrs=snrs,
                                 peak_lock_snr=5.0, peak_lock_ratio=20,
                                 peak_lock_region=2)
@@ -305,7 +323,8 @@ class TestPeakLockSearch(unittest.TestCase):
             marginalized_vector_priors = {}
 
         bare = Bare()
-        with self.assertLogs(level='WARNING') as caught:
+        with self.logging_enabled(), \
+                self.assertLogs(level='WARNING') as caught:
             bare.setup_peak_lock(sample_rate=SAMPLE_RATE, **SEARCH)
         self.assertIsNone(bare.peak_lock_search_samples)
         self.assertIn('peak_lock_search_samples',
@@ -323,8 +342,11 @@ class TestPeakLockSearchRelativeTime(TestPeakLockSearch):
 
 
 suite = unittest.TestSuite()
-for case in (TestPeakLockSearch, TestPeakLockSearchRelativeTime):
-    suite.addTest(unittest.TestLoader().loadTestsFromTestCase(case))
+# not a loop variable: anything left bound at module scope here is a
+# TestCase subclass, which pytest collects and runs a second time
+suite.addTest(unittest.TestLoader().loadTestsFromTestCase(TestPeakLockSearch))
+suite.addTest(unittest.TestLoader().loadTestsFromTestCase(
+    TestPeakLockSearchRelativeTime))
 
 if __name__ == '__main__':
     results = unittest.TextTestRunner(verbosity=2).run(suite)

--- a/test/test_peak_lock.py
+++ b/test/test_peak_lock.py
@@ -1,0 +1,266 @@
+# Copyright (C) 2026  Alex Nitz
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+"""Tests moving the locked time region to wherever the peak has gone.
+
+The region is locked around a reference waveform. As the parameters move
+away from that reference the peak moves too, and once it leaves the region
+the marginalization integrates over times the signal is not at. These drive
+the reference away from the signal and check the likelihood survives it.
+"""
+
+import copy
+import unittest
+
+import numpy
+
+from utils import simple_exit
+
+from pycbc.detector import Detector
+from pycbc.distributions import JointDistribution, SinAngle, Uniform
+from pycbc.inference import models
+from pycbc.inference.models.tools import DistMarg
+from pycbc.noise import noise_from_psd
+from pycbc.psd import aLIGOZeroDetHighPower
+from pycbc.waveform import get_td_waveform
+
+TC = 1187008882.42
+FLOW, SEGLEN, SRATE = 25., 64, 2048
+SAMPLE_RATE = 4096
+VARIABLE = ['distance', 'inclination', 'tc']
+POINT = dict(distance=40., inclination=0.5)
+# how far the reference is put from the signal. The last of these moves the
+# peak by more than the width of a locked region.
+OFFSETS = [0.0, 0.002, 0.005, 0.01]
+SEARCH = dict(peak_lock_search_samples=246, peak_lock_search_decimate=8)
+
+
+class TestPeakLockSearch(unittest.TestCase):
+
+    MODEL = 'RelativeTimeDom'
+
+    @classmethod
+    def setUpClass(cls):
+        hp, hc = get_td_waveform(approximant='TaylorF2', f_lower=FLOW,
+                                 delta_t=1. / SRATE, mass1=1.4, mass2=1.35,
+                                 distance=40., inclination=0.5, coa_phase=1.1)
+        hp.start_time += TC
+        hc.start_time += TC
+        psd = aLIGOZeroDetHighPower(int(SRATE * SEGLEN / 2) + 1,
+                                    1. / SEGLEN, FLOW)
+        # one detector: a locked region can be narrower than the light
+        # travel time between two, which is a separate problem from this one
+        noise = noise_from_psd(int(SEGLEN * SRATE), 1. / SRATE, psd, seed=7)
+        noise._epoch = TC - SEGLEN / 2
+        signal = Detector('H1').project_wave(hp, hc, 1.7, -0.4, 0.3)
+        cls.data = {'H1': noise.add_into(signal).to_frequencyseries()}
+        cls.psds = {'H1': psd}
+        cls.static = dict(mass1=1.4, mass2=1.35, f_lower=FLOW,
+                          approximant='TaylorF2', ra=1.7, dec=-0.4,
+                          polarization=0.3)
+        cls.fiducial = dict(mass1=1.4, tc=TC, ra=1.7, dec=-0.4,
+                            polarization=0.3)
+
+    def model(self, mass_offset=0.0, data=None, **kwargs):
+        numpy.random.seed(5)
+        prior = JointDistribution(
+            list(VARIABLE), SinAngle(inclination=None),
+            Uniform(distance=(10, 200)), Uniform(tc=(TC - 0.1, TC + 0.1)))
+        fiducial = dict(self.fiducial)
+        fiducial['mass1'] = fiducial['mass1'] - mass_offset
+        return getattr(models, self.MODEL)(
+            list(VARIABLE), copy.deepcopy(self.data if data is None else data),
+            low_frequency_cutoff={'H1': FLOW}, psds=self.psds,
+            static_params=self.static, prior=prior,
+            fiducial_params=fiducial, epsilon=0.1, marginalize_phase=True,
+            marginalize_vector_params='tc', marginalize_vector_samples=2000,
+            sample_rate=SAMPLE_RATE, **kwargs)
+
+    def loglr(self, **kwargs):
+        model = self.model(**kwargs)
+        model.update(**POINT)
+        return model.loglr
+
+    def test_off_by_default(self):
+        """A model that did not ask for it must not move its region."""
+        model = self.model(mass_offset=0.01, peak_lock_snr=4.0)
+        before = dict(model.tstart)
+        model.update(**POINT)
+        model.loglr
+        for ifo in before:
+            self.assertEqual(before[ifo], model.tstart[ifo])
+
+    def test_the_region_follows_a_moving_peak(self):
+        """The answer has to survive the reference drifting away.
+
+        Without the search the region stops holding the peak and the
+        likelihood collapses; with it the answer stays near the one an
+        unrestricted region gives.
+        """
+        exact = self.loglr()
+        for offset in OFFSETS:
+            searched = self.loglr(mass_offset=offset, peak_lock_snr=4.0,
+                                  **SEARCH)
+            self.assertLess(
+                abs(searched - exact), 50.,
+                "with a reference %s off, searching gave %s against %s"
+                % (offset, searched, exact))
+
+    def test_it_matters(self):
+        """The largest offset must actually break the unsearched case.
+
+        Without this the test above could pass on a region that never
+        needed moving.
+        """
+        exact = self.loglr()
+        locked = self.loglr(mass_offset=OFFSETS[-1], peak_lock_snr=4.0)
+        self.assertGreater(
+            abs(locked - exact), 100.,
+            "a reference %s off did not spill out of the region; the test "
+            "proves nothing" % OFFSETS[-1])
+
+    def test_the_region_depends_only_on_the_parameters(self):
+        """Calling twice has to land the region in the same place.
+
+        The offset is measured from the region as locked, not from where the
+        last call left it, so repeated evaluation must not walk it along.
+        """
+        model = self.model(mass_offset=0.01, peak_lock_snr=4.0, **SEARCH)
+        model.update(**POINT)
+        model.loglr
+        first = dict(model.tstart)
+        for _ in range(3):
+            model.update(**POINT)
+            model.loglr
+        for ifo in first:
+            self.assertAlmostEqual(first[ifo], model.tstart[ifo], places=9)
+
+    def test_a_matched_reference_barely_moves_the_region(self):
+        """With nothing to follow, the region must stay where it was.
+
+        The offset is measured from the reference peak, so a reference that
+        is the signal has none to find and the region can move by at most
+        the sample it is rounded to. Measuring from the middle of the region
+        instead moves it by the coarse spacing, which the reference peak
+        does not sit at the centre of.
+        """
+        model = self.model(peak_lock_snr=4.0, **SEARCH)
+        before = dict(model.tstart)
+        model.update(**POINT)
+        model.loglr
+        for ifo in before:
+            self.assertLessEqual(
+                abs(model.tstart[ifo] - before[ifo]) * SAMPLE_RATE, 1.0,
+                "a matched reference moved %s by %s samples"
+                % (ifo, (model.tstart[ifo] - before[ifo]) * SAMPLE_RATE))
+
+    def test_the_region_lands_on_a_sample_of_its_own_grid(self):
+        """The region may only move by whole samples.
+
+        A fractional offset would leave the marginalization sampling the
+        series at shifted phases, which costs more than placing the region
+        more precisely gains. The reference is the signal here: that is
+        where the coarse peak has a genuine fraction of a sample to it,
+        rather than happening to land on one.
+        """
+        model = self.model(peak_lock_snr=4.0, **SEARCH)
+        before = dict(model.tstart)
+        model.update(**POINT)
+        model.loglr
+        for ifo in before:
+            samples = (model.tstart[ifo] - before[ifo]) * SAMPLE_RATE
+            self.assertAlmostEqual(
+                samples, round(samples), places=6,
+                msg="%s moved by %s samples" % (ifo, samples))
+
+    def test_the_stride_is_shorter_than_the_region(self):
+        """The search can only place the peak to within its own stride.
+
+        A stride wider than the region can leave the peak outside it even
+        though the search found it, which is the failure the search exists
+        to prevent. The region here is 10 samples against a stride of 8;
+        striding by 32 was measured to cost 157 nats.
+        """
+        model = self.model(peak_lock_snr=4.0, **SEARCH)
+        for ifo in model.num_samples:
+            self.assertLessEqual(
+                SEARCH['peak_lock_search_decimate'], model.num_samples[ifo],
+                "stride %s against a region of %s samples in %s"
+                % (SEARCH['peak_lock_search_decimate'],
+                   model.num_samples[ifo], ifo))
+
+    def test_precalculated_points_hold_the_region_still(self):
+        """Points drawn over the locked region cannot outlive it moving.
+
+        With precalculate_marginalization_points the draw is a subset of
+        points chosen once, over the region as locked. Moving the region
+        after that leaves the points describing somewhere the model is no
+        longer looking, and nothing about the result says so.
+        """
+        model = self.model(mass_offset=0.01, peak_lock_snr=4.0, **SEARCH)
+        locked = dict(model.tstart)
+        model.update(**POINT)
+        model.loglr
+        self.assertNotEqual(model.tstart['H1'], locked['H1'],
+                            "the region never moved, so this proves nothing")
+
+        # the waveforms the search would be given, and the region back where
+        # it was locked, so the only thing left to stop it is the guard
+        wfs = model.get_waveforms(model.current_params)
+        model.tstart = dict(locked)
+        model.premarg = {}
+        model.follow_peak(wfs)
+        self.assertEqual(model.tstart, locked,
+                         "the region moved out from under precalculated "
+                         "points")
+
+    def test_a_model_that_cannot_search_says_so(self):
+        """Silently ignoring the option would be worse than not having it.
+
+        The search needs the model to evaluate its predictor on a grid it
+        chooses. A model whose reference series is fixed has no such method
+        and no need of one -- SingleTemplate is one, and takes these same
+        options through the same call -- but a run that asked for the
+        search still has to be told it is not getting it.
+        """
+        self.assertFalse(hasattr(models.SingleTemplate, 'coarse_series'))
+
+        class Bare(DistMarg):
+            marginalized_vector_priors = {}
+
+        bare = Bare()
+        with self.assertLogs(level='WARNING') as caught:
+            bare.setup_peak_lock(sample_rate=SAMPLE_RATE, **SEARCH)
+        self.assertIsNone(bare.peak_lock_search_samples)
+        self.assertIn('peak_lock_search_samples',
+                      caught.records[0].getMessage())
+
+
+class TestPeakLockSearchRelativeTime(TestPeakLockSearch):
+    """The same, through the class that keeps hp and hc apart.
+
+    It has its own coarse_series, calling a different predictor, so the
+    search is a separate path there and not covered by the one above.
+    """
+
+    MODEL = 'RelativeTime'
+
+
+suite = unittest.TestSuite()
+for case in (TestPeakLockSearch, TestPeakLockSearchRelativeTime):
+    suite.addTest(unittest.TestLoader().loadTestsFromTestCase(case))
+
+if __name__ == '__main__':
+    results = unittest.TextTestRunner(verbosity=2).run(suite)
+    simple_exit(results)

--- a/test/test_peak_lock.py
+++ b/test/test_peak_lock.py
@@ -260,6 +260,36 @@ class TestPeakLockSearch(unittest.TestCase):
                                "%s region is %s samples"
                                % (ifo, two.num_samples[ifo]))
 
+    def test_the_offset_comes_from_the_loudest_detector(self):
+        """One detector supplies the offset, so it should be the best one.
+
+        The peak of a louder detector is the less uncertain in time, and
+        it is the one the likelihood is most sensitive to.
+        """
+        rate = 4096.0
+        span = 0.1
+        snrs, asked = {}, []
+        for ifo, at, amp in (('H1', 0.04, 12.0), ('L1', 0.05, 30.0)):
+            t = numpy.arange(int(span * rate)) / rate
+            z = amp * numpy.exp(-0.5 * ((t - at) / 2e-4) ** 2.0)
+            snrs[ifo] = TimeSeries(z + 0j, delta_t=1.0 / rate, epoch=TC)
+
+        class Two(DistMarg):
+            data = {'H1': None, 'L1': None}
+            marginalized_vector_priors = {'tc': Uniform(tc=(TC, TC + span))}
+
+            def coarse_series(self, ifo, wfs, tstart, delta_t, num_samples):
+                asked.append(ifo)
+                return numpy.zeros(num_samples)
+
+        two = Two()
+        two.setup_peak_lock(sample_rate=rate, snrs=snrs, peak_lock_snr=5.0,
+                            peak_lock_ratio=1e4, **SEARCH)
+        two.follow_peak({'H1': None, 'L1': None})
+        self.assertEqual(asked, ['L1'],
+                         "the offset was taken from %s, not the loudest"
+                         % asked)
+
     def test_a_model_that_cannot_search_says_so(self):
         """Silently ignoring the option would be worse than not having it.
 


### PR DESCRIPTION
Some of the models (really only two of the heterodyne models) support a 'peak lock' feature which identifies where the peaks in the SNR time series are based on the reference signal. It then only calculates the likelihood as a function of time at the windows around these peaks. This works often, but fails if the peaks can move much with the parameters. To help with this issue, this features add ina  coarse search step on a wider grid that runs for every likelihood call. It's pretty coarse so relatively cheap and just serves to move the identified windows that peak lock originally set. 

This comes with two new options

```
peak_lock_search_samples =  NUM_SAMPELS_TO_SEARCH (in units of the full sample rate)
peak_lock_search_decimation = NUM    (the coarseness relative to the full sample rate)
```

In my testing, for a lot of cases, a factor of say 128 with a decimation of 8 is probalby ok, but be aware of what this implies, and it may need to be less decimation if the peak is less well defined to begin with. 

Note, it just uses the loudest detector for this, not all of them. 


- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
