### PR TITLE
Relbin kernel refactor

### DIFF
--- a/pycbc/inference/models/relbin_cpu.pyx
+++ b/pycbc/inference/models/relbin_cpu.pyx
@@ -7,8 +7,24 @@ cdef extern from "complex.h":
     double real(double complex)
     double imag(double complex)
 
+# The phase pass below wants the real sine and cosine on their own, rather
+# than the complex exponential declared above, so that it can write them
+# straight into a pair of real buffers.
+cdef extern from "math.h":
+    double cos(double)
+    double sin(double)
+
 import numpy
 cimport cython, numpy
+
+# The pi here is deliberately the truncated 3.141592653 rather than M_PI.
+# It appears only in the 2*pi of a time shift, so its whole effect is an
+# exact rescaling dtc -> dtc*(1 - 1.877e-10): <h|h> is untouched, and on a
+# real event the peak moves by 1.7e-12 s against a posterior width of
+# 6.8e-5.  Replacing it would move published numbers for no correctness
+# gain, so it stays, named once instead of spelled out twenty-one times.
+cdef double MINUS_TWO_PI = -2.0 * 3.141592653
+cdef double complex MINUS_TWO_PI_J = -2.0j * 3.141592653
 
 # Used for calculating the cross terms of
 # two signals when analyzing multiple signals
@@ -33,9 +49,9 @@ cpdef likelihood_parts_multi(double [::1] freqs,
 
     N = freqs.shape[0]
     for i in range(N):
-        r0n = (exp(-2.0j * 3.141592653 * dtc * freqs[i])
+        r0n = (exp(MINUS_TWO_PI_J * dtc * freqs[i])
                * (fp * hp[i] + fc * hc[i])) / h00[i]
-        r0n *= conj((exp(-2.0j * 3.141592653 * dtc2 * freqs[i])
+        r0n *= conj((exp(MINUS_TWO_PI_J * dtc2 * freqs[i])
                * (fp2 * hp2[i] + fc2 * hc2[i])) / h002[i])
         r1 = r0n - r0
         if i > 0:
@@ -69,9 +85,9 @@ cpdef likelihood_parts_multi_v(double [::1] freqs,
 
     N = freqs.shape[0]
     for i in range(N):
-        r0n = (exp(-2.0j * 3.141592653 * dtc[i] * freqs[i])
+        r0n = (exp(MINUS_TWO_PI_J * dtc[i] * freqs[i])
                * (fp[i] * hp[i] + fc[i] * hc[i])) / h00[i]
-        r0n *= conj((exp(-2.0j * 3.141592653 * dtc2[i] * freqs[i])
+        r0n *= conj((exp(MINUS_TWO_PI_J * dtc2[i] * freqs[i])
                * (fp2[i] * hp2[i] + fc2[i] * hc2[i])) / h002[i])
         r1 = r0n - r0
 
@@ -100,9 +116,9 @@ cpdef likelihood_parts_det_multi(double [::1] freqs,
 
     N = freqs.shape[0]
     for i in range(N):
-        r0n = conj((exp(-2.0j * 3.141592653 * dtc * freqs[i])
+        r0n = conj((exp(MINUS_TWO_PI_J * dtc * freqs[i])
                * (hp[i])) / h00[i])
-        r0n *= ((exp(-2.0j * 3.141592653 * dtc2 * freqs[i])
+        r0n *= ((exp(MINUS_TWO_PI_J * dtc2 * freqs[i])
                * (hp2[i])) / h002[i])
         r1 = r0n - r0
         if i > 0:
@@ -131,7 +147,7 @@ cpdef likelihood_parts(double [::1] freqs,
 
     N = freqs.shape[0]
     for i in range(N):
-        r0n = (exp(-2.0j * 3.141592653 * dtc * freqs[i])
+        r0n = (exp(MINUS_TWO_PI_J * dtc * freqs[i])
                * (fp * hp[i] + fc * hc[i])) / h00[i]
         r1 = r0n - r0
 
@@ -163,7 +179,7 @@ cpdef likelihood_parts_det(double [::1] freqs,
 
     N = freqs.shape[0]
     for i in range(N):
-        r0n = (exp(-2.0j * 3.141592653 * dtc * freqs[i])
+        r0n = (exp(MINUS_TWO_PI_J * dtc * freqs[i])
                * (hp[i])) / h00[i]
         r1 = r0n - r0
 
@@ -198,7 +214,7 @@ cpdef likelihood_parts_v(double [::1] freqs,
 
     N = freqs.shape[0]
     for i in range(N):
-        r0n = (exp(-2.0j * 3.141592653 * dtc[i] * freqs[i])
+        r0n = (exp(MINUS_TWO_PI_J * dtc[i] * freqs[i])
                * (fp[i] * hp[i] + fc[i] * hc[i])) / h00[i]
         r1 = r0n - r0
 
@@ -217,7 +233,6 @@ cpdef likelihood_parts_v(double [::1] freqs,
 # and there is a polarization vector marginalization
 @cython.boundscheck(False)  # Deactivate bounds checking
 @cython.wraparound(False)   # Deactivate negative indexing.
-@cython.cdivision(True)     # Disable checking for dividing by zero
 cpdef likelihood_parts_v_pol(double [::1] freqs,
                      double[::1] fp,
                      double[::1] fc,
@@ -231,48 +246,43 @@ cpdef likelihood_parts_v_pol(double [::1] freqs,
                      double [::1] b0,
                      double [::1] b1,
                      ) :
-    cdef size_t i
-    cdef double complex hd=0, r0, r0n, r1, x0, x0n, x1, fp2, fc2
-    cdef double hh=0
-
-    N = freqs.shape[0]
-    num_samples = pol_phase.shape[0]
+    cdef size_t i, j
+    cdef double complex hd, r0, r0n, tw
+    cdef double app, acc, apc, cp, sp, ph
+    cdef int N = freqs.shape[0]
+    cdef int num_samples = pol_phase.shape[0]
 
     cdef numpy.ndarray[numpy.complex128_t, ndim=1] hdv = numpy.empty(num_samples, dtype=numpy.complex128)
     cdef numpy.ndarray[numpy.float64_t, ndim=1] hhv = numpy.empty(num_samples, dtype=numpy.float64)
+    cdef double complex[::1] ar = numpy.empty(N, dtype=numpy.complex128)
+    cdef double complex[::1] br = numpy.empty(N, dtype=numpy.complex128)
+
+    for i in range(N):
+        ph = MINUS_TWO_PI * dtc[i] * freqs[i]
+        tw = (cos(ph) + 1.0j * sin(ph)) / h00[i]
+        ar[i] = tw * (fp[i] * hp[i] + fc[i] * hc[i])
+        br[i] = tw * (fp[i] * hc[i] - fc[i] * hp[i])
+    hh_coefficients(ar, br, b0, b1, N, &app, &acc, &apc)
 
     for j in range(num_samples):
-        hh = 0
+        cp = real(pol_phase[j])
+        sp = imag(pol_phase[j])
+
         hd = 0
         for i in range(N):
-        
-            f = (fp[i] + 1.0j * fc[i]) * pol_phase[j]
-            fp2 = real(f)
-            fc2 = imag(f)
-        
-            r0n = (exp(-2.0j * 3.141592653 * dtc[i] * freqs[i])
-                   * (fp2 * hp[i] + fc2 * hc[i])) / h00[i]
-            r1 = r0n - r0
-
-            x0n = norm(r0n)
-            x1 = x0n - x0
+            r0n = cp * ar[i] + sp * br[i]
 
             if i > 0:
-                hd += a0[i-1] * r0 + a1[i-1] * r1
-                hh += real(b0[i-1] * x0 + b1[i-1] * x1)
+                hd += a0[i-1] * r0 + a1[i-1] * (r0n - r0)
 
             r0 = r0n
-            x0 = x0n
-            
         hdv[j] = conj(hd)
-        hhv[j] = hh
+        hhv[j] = cp * cp * app + sp * sp * acc + cp * sp * apc
     return hdv, hhv
-
 # Used where the antenna response may be frequency varying
 # and there is a polarization vector marginalization
 @cython.boundscheck(False)  # Deactivate bounds checking
 @cython.wraparound(False)   # Deactivate negative indexing.
-@cython.cdivision(True)     # Disable checking for dividing by zero
 cpdef likelihood_parts_v_time(double [::1] freqs,
                      double[::1] fp,
                      double[::1] fc,
@@ -286,45 +296,50 @@ cpdef likelihood_parts_v_time(double [::1] freqs,
                      double [::1] b0,
                      double [::1] b1,
                      ) :
-    cdef size_t i
-    cdef double complex hd=0, r0, r0n, r1, x0, x0n, x1
-    cdef double hh=0, ttime;
-
-    N = freqs.shape[0]
-    num_samples = dtc.shape[0]
+    cdef size_t i, j
+    cdef double complex hd, r0, r0n
+    cdef double hh=0, x0=0, x0n, tw, ph
+    cdef int N = freqs.shape[0]
+    cdef int num_samples = dtc.shape[0]
 
     cdef numpy.ndarray[numpy.complex128_t, ndim=1] hdv = numpy.empty(num_samples, dtype=numpy.complex128)
     cdef numpy.ndarray[numpy.float64_t, ndim=1] hhv = numpy.empty(num_samples, dtype=numpy.float64)
+    cdef double complex[::1] hr = numpy.empty(N, dtype=numpy.complex128)
+    cdef double [::1] sphase = numpy.empty(N, dtype=numpy.float64)
+    cdef double [::1] cphase = numpy.empty(N, dtype=numpy.float64)
+
+    for i in range(N):
+        ph = MINUS_TWO_PI * times[i] * freqs[i]
+        hr[i] = ((cos(ph) + 1.0j * sin(ph))
+                 * (fp[i] * hp[i] + fc[i] * hc[i])) / h00[i]
+
+        x0n = norm(hr[i])
+        if i > 0:
+            hh += b0[i-1] * x0 + b1[i-1] * (x0n - x0)
+
+        x0 = x0n
 
     for j in range(num_samples):
-        hh = 0
-        hd = 0
-        for i in range(N):   
-            # This allows for multiple time offsets
-            ttime = times[i] + dtc[j]
-            r0n = (exp(-2.0j * 3.141592653 * ttime * freqs[i])
-                   * (fp[i] * hp[i] + fc[i] * hc[i])) / h00[i]
-            r1 = r0n - r0
+        tw = MINUS_TWO_PI * dtc[j]
+        for i in range(N):
+            sphase[i] = sin(tw * freqs[i])
+            cphase[i] = cos(tw * freqs[i])
 
-            x0n = norm(r0n)
-            x1 = x0n - x0
+        hd = 0
+        for i in range(N):
+            r0n = (cphase[i] + 1.0j * sphase[i]) * hr[i]
 
             if i > 0:
-                hd += a0[i-1] * r0 + a1[i-1] * r1
-                hh += real(b0[i-1] * x0 + b1[i-1] * x1)
+                hd += a0[i-1] * r0 + a1[i-1] * (r0n - r0)
 
             r0 = r0n
-            x0 = x0n
-            
         hdv[j] = conj(hd)
         hhv[j] = hh
     return hdv, hhv
-
 # Used where the antenna response may be frequency varying
 # and there is a polarization vector marginalization
 @cython.boundscheck(False)  # Deactivate bounds checking
 @cython.wraparound(False)   # Deactivate negative indexing.
-@cython.cdivision(True)     # Disable checking for dividing by zero
 cpdef likelihood_parts_v_pol_time(double [::1] freqs,
                      double[::1] fp,
                      double[::1] fc,
@@ -339,46 +354,100 @@ cpdef likelihood_parts_v_pol_time(double [::1] freqs,
                      double [::1] b0,
                      double [::1] b1,
                      ) :
-    cdef size_t i
-    cdef double complex hd=0, r0, r0n, r1, x0, x0n, x1, fp2, fc2
-    cdef double hh=0, ttime;
-
-    N = freqs.shape[0]
-    num_samples = pol_phase.shape[0]
+    cdef size_t i, j
+    cdef double complex hd, r0, r0n, tw
+    cdef double app, acc, apc, cp, sp, ph, twj
+    cdef int N = freqs.shape[0]
+    cdef int num_samples = pol_phase.shape[0]
 
     cdef numpy.ndarray[numpy.complex128_t, ndim=1] hdv = numpy.empty(num_samples, dtype=numpy.complex128)
     cdef numpy.ndarray[numpy.float64_t, ndim=1] hhv = numpy.empty(num_samples, dtype=numpy.float64)
+    cdef double complex[::1] ar = numpy.empty(N, dtype=numpy.complex128)
+    cdef double complex[::1] br = numpy.empty(N, dtype=numpy.complex128)
+    cdef double [::1] sphase = numpy.empty(N, dtype=numpy.float64)
+    cdef double [::1] cphase = numpy.empty(N, dtype=numpy.float64)
+
+    for i in range(N):
+        ph = MINUS_TWO_PI * times[i] * freqs[i]
+        tw = (cos(ph) + 1.0j * sin(ph)) / h00[i]
+        ar[i] = tw * (fp[i] * hp[i] + fc[i] * hc[i])
+        br[i] = tw * (fp[i] * hc[i] - fc[i] * hp[i])
+    hh_coefficients(ar, br, b0, b1, N, &app, &acc, &apc)
 
     for j in range(num_samples):
-        hh = 0
+        cp = real(pol_phase[j])
+        sp = imag(pol_phase[j])
+        twj = MINUS_TWO_PI * dtc[j]
+        for i in range(N):
+            sphase[i] = sin(twj * freqs[i])
+            cphase[i] = cos(twj * freqs[i])
+
         hd = 0
         for i in range(N):
-        
-            f = (fp[i] + 1.0j * fc[i]) * pol_phase[j]
-            fp2 = real(f)
-            fc2 = imag(f)
-        
-            # This allows for multiple time offsets
-            ttime = times[i] + dtc[j]
-            r0n = (exp(-2.0j * 3.141592653 * ttime * freqs[i])
-                   * (fp2 * hp[i] + fc2 * hc[i])) / h00[i]
-            r1 = r0n - r0
-
-            x0n = norm(r0n)
-            x1 = x0n - x0
+            r0n = ((cphase[i] + 1.0j * sphase[i])
+                   * (cp * ar[i] + sp * br[i]))
 
             if i > 0:
-                hd += a0[i-1] * r0 + a1[i-1] * r1
-                hh += real(b0[i-1] * x0 + b1[i-1] * x1)
+                hd += a0[i-1] * r0 + a1[i-1] * (r0n - r0)
 
             r0 = r0n
-            x0 = x0n
-            
         hdv[j] = conj(hd)
-        hhv[j] = hh
+        hhv[j] = cp * cp * app + sp * sp * acc + cp * sp * apc
     return hdv, hhv
+# The <h|h> of a whole bank of samples, without a sample loop.
+#
+# Every sample scales the two polarizations by a real pair (fp, fc) and then
+# applies a time shift, and the time shift has unit modulus, so it drops out
+# of |fp * hp + fc * hc|^2 entirely.  What is left is a quadratic form in
+# (fp, fc), and summing its three coefficient series once with the relative
+# binning weights gives constants from which any sample's <h|h> follows as
+# fp * fp * app + fc * fc * acc + fp * fc * apc.  Both the factor of two in
+# the cross term and its being the real part are needed; neither is optional.
+# This is the same reasoning snr_predictor already uses to lift its own
+# <h|h> out of the sample loop.
+@cython.boundscheck(False)  # Deactivate bounds checking
+@cython.wraparound(False)   # Deactivate negative indexing.
+@cython.cdivision(True)     # Disable checking for dividing by zero
+cdef void hh_coefficients(double complex[::1] hpr,
+                     double complex[::1] hcr,
+                     double [::1] b0,
+                     double [::1] b1,
+                     int N,
+                     double *app,
+                     double *acc,
+                     double *apc,
+                     ) :
+    cdef size_t i
+    cdef double p0=0, c0=0, x0=0, p0n, c0n, x0n
+    cdef double sp=0, sc=0, sx=0
+
+    for i in range(N):
+        p0n = norm(hpr[i])
+        c0n = norm(hcr[i])
+        x0n = 2.0 * (real(hpr[i]) * real(hcr[i])
+                     + imag(hpr[i]) * imag(hcr[i]))
+
+        if i > 0:
+            sp += b0[i-1] * p0 + b1[i-1] * (p0n - p0)
+            sc += b0[i-1] * c0 + b1[i-1] * (c0n - c0)
+            sx += b0[i-1] * x0 + b1[i-1] * (x0n - x0)
+
+        p0 = p0n
+        c0 = c0n
+        x0 = x0n
+    app[0] = sp
+    acc[0] = sc
+    apc[0] = sx
 
 # Standard likelihood but simultaneously handling multiple sky or time points
+#
+# Three things are kept out of the inner loop that do not belong there.  The
+# division by h00 depends on the frequency bin alone, so it is done once for
+# the bank instead of once per (bin, sample).  <h|h> is not accumulated here
+# at all, it comes from the constants above.  And the phase is evaluated in
+# a pass of its own, into scratch buffers; nothing in that pass depends on
+# the previous element, so the compiler is free to vectorize the sine and
+# cosine, which it cannot do while the serial r0 carry shares the loop.
 @cython.boundscheck(False)  # Deactivate bounds checking
 @cython.wraparound(False)   # Deactivate negative indexing.
 @cython.cdivision(True)     # Disable checking for dividing by zero
@@ -394,37 +463,52 @@ cpdef likelihood_parts_vector(double [::1] freqs,
                      double [::1] b0,
                      double [::1] b1,
                      ) :
-    cdef size_t i
-    cdef double complex hd, r0, r0n, r1, x0, x0n, x1
-    cdef double hh
-    N = freqs.shape[0]
-    num_samples = fp.shape[0]
+    cdef size_t i, j
+    cdef double complex hd, r0, r0n
+    cdef double app, acc, apc, fpj, fcj, tw
+    cdef int N = freqs.shape[0]
+    cdef int num_samples = fp.shape[0]
 
     cdef numpy.ndarray[numpy.complex128_t, ndim=1] hdv = numpy.empty(num_samples, dtype=numpy.complex128)
     cdef numpy.ndarray[numpy.float64_t, ndim=1] hhv = numpy.empty(num_samples, dtype=numpy.float64)
+    cdef double complex[::1] hpr = numpy.empty(N, dtype=numpy.complex128)
+    cdef double complex[::1] hcr = numpy.empty(N, dtype=numpy.complex128)
+    cdef double [::1] sphase = numpy.empty(N, dtype=numpy.float64)
+    cdef double [::1] cphase = numpy.empty(N, dtype=numpy.float64)
+
+    for i in range(N):
+        hpr[i] = hp[i] / h00[i]
+        hcr[i] = hc[i] / h00[i]
+    hh_coefficients(hpr, hcr, b0, b1, N, &app, &acc, &apc)
 
     for j in range(num_samples):
-        hd = 0
-        hh = 0
+        fpj = fp[j]
+        fcj = fc[j]
+        tw = MINUS_TWO_PI * dtc[j]
         for i in range(N):
-            r0n = (exp(-2.0j * 3.141592653 * dtc[j] * freqs[i])
-                   * (fp[j] * hp[i] + fc[j] * hc[i])) / h00[i]
-            r1 = r0n - r0
+            sphase[i] = sin(tw * freqs[i])
+            cphase[i] = cos(tw * freqs[i])
 
-            x0n = norm(r0n)
-            x1 = x0n - x0
+        hd = 0
+        for i in range(N):
+            r0n = ((cphase[i] + 1.0j * sphase[i])
+                   * (fpj * hpr[i] + fcj * hcr[i]))
 
             if i > 0:
-                hd += a0[i-1] * r0 + a1[i-1] * r1
-                hh += real(b0[i-1] * x0 + b1[i-1] * x1)
+                hd += a0[i-1] * r0 + a1[i-1] * (r0n - r0)
 
             r0 = r0n
-            x0 = x0n
         hdv[j] = conj(hd)
-        hhv[j] = hh
+        hhv[j] = fpj * fpj * app + fcj * fcj * acc + fpj * fcj * apc
     return hdv, hhv
-    
+
 # Standard likelihood but simultaneously handling multiple time points
+#
+# Here fp and fc are scalars, so every sample sees the same waveform ratio
+# and differs only by a time shift.  A time shift cannot change <h|h>, so
+# there is one value of it for the whole bank and it is computed once, with
+# the ratio, before the sample loop is entered.  The phase again gets a pass
+# of its own so that the sine and cosine can vectorize.
 @cython.boundscheck(False)  # Deactivate bounds checking
 @cython.wraparound(False)   # Deactivate negative indexing.
 @cython.cdivision(True)     # Disable checking for dividing by zero
@@ -440,40 +524,52 @@ cpdef likelihood_parts_vectort(double [::1] freqs,
                      double [::1] b0,
                      double [::1] b1,
                      ) :
-    cdef size_t i
-    cdef double complex hd, r0, r0n, r1, x0, x0n, x1
-    cdef double hh
-    N = freqs.shape[0]
-    num_samples = dtc.shape[0]
+    cdef size_t i, j
+    cdef double complex hd, r0, r0n
+    cdef double hh=0, x0=0, x0n, tw
+    cdef int N = freqs.shape[0]
+    cdef int num_samples = dtc.shape[0]
 
     cdef numpy.ndarray[numpy.complex128_t, ndim=1] hdv = numpy.empty(num_samples, dtype=numpy.complex128)
     cdef numpy.ndarray[numpy.float64_t, ndim=1] hhv = numpy.empty(num_samples, dtype=numpy.float64)
+    cdef double complex[::1] hr = numpy.empty(N, dtype=numpy.complex128)
+    cdef double [::1] sphase = numpy.empty(N, dtype=numpy.float64)
+    cdef double [::1] cphase = numpy.empty(N, dtype=numpy.float64)
+
+    for i in range(N):
+        hr[i] = (fp * hp[i] + fc * hc[i]) / h00[i]
+
+        x0n = norm(hr[i])
+        if i > 0:
+            hh += b0[i-1] * x0 + b1[i-1] * (x0n - x0)
+
+        x0 = x0n
 
     for j in range(num_samples):
-        hd = 0
-        hh = 0
+        tw = MINUS_TWO_PI * dtc[j]
         for i in range(N):
-            r0n = (exp(-2.0j * 3.141592653 * dtc[j] * freqs[i])
-                   * (fp * hp[i] + fc * hc[i])) / h00[i]
-            r1 = r0n - r0
+            sphase[i] = sin(tw * freqs[i])
+            cphase[i] = cos(tw * freqs[i])
 
-            x0n = norm(r0n)
-            x1 = x0n - x0
+        hd = 0
+        for i in range(N):
+            r0n = (cphase[i] + 1.0j * sphase[i]) * hr[i]
 
             if i > 0:
-                hd += a0[i-1] * r0 + a1[i-1] * r1
-                hh += real(b0[i-1] * x0 + b1[i-1] * x1)
+                hd += a0[i-1] * r0 + a1[i-1] * (r0n - r0)
 
             r0 = r0n
-            x0 = x0n
         hdv[j] = conj(hd)
         hhv[j] = hh
     return hdv, hhv
 
 # Like above, but if only polarization is marginalized
-# this is a slow implementation and the loop should be inverted /
-# refactored to do each pol separately and then combine
-# included as is for testing purposes
+#
+# Here dtc is a scalar, so the time shift is the same for every sample and
+# there is no transcendental left to evaluate inside the sample loop at all:
+# the phase is folded into the per bin waveform ratios once.  Folding it in
+# does not disturb the <h|h> constants, since a unit modulus factor common
+# to both polarizations cancels out of every term of the quadratic form.
 @cython.boundscheck(False)  # Deactivate bounds checking
 @cython.wraparound(False)   # Deactivate negative indexing.
 @cython.cdivision(True)     # Disable checking for dividing by zero
@@ -489,34 +585,37 @@ cpdef likelihood_parts_vectorp(double [::1] freqs,
                      double [::1] b0,
                      double [::1] b1,
                      ) :
-    cdef size_t i
-    cdef double complex hd, r0, r0n, r1, x0, x0n, x1
-    cdef double hh
-    N = freqs.shape[0]
-    num_samples = fp.shape[0]
+    cdef size_t i, j
+    cdef double complex hd, r0, r0n, tw
+    cdef double app, acc, apc, fpj, fcj
+    cdef int N = freqs.shape[0]
+    cdef int num_samples = fp.shape[0]
 
     cdef numpy.ndarray[numpy.complex128_t, ndim=1] hdv = numpy.empty(num_samples, dtype=numpy.complex128)
     cdef numpy.ndarray[numpy.float64_t, ndim=1] hhv = numpy.empty(num_samples, dtype=numpy.float64)
+    cdef double complex[::1] hpr = numpy.empty(N, dtype=numpy.complex128)
+    cdef double complex[::1] hcr = numpy.empty(N, dtype=numpy.complex128)
+
+    for i in range(N):
+        tw = exp(MINUS_TWO_PI_J * dtc * freqs[i]) / h00[i]
+        hpr[i] = tw * hp[i]
+        hcr[i] = tw * hc[i]
+    hh_coefficients(hpr, hcr, b0, b1, N, &app, &acc, &apc)
 
     for j in range(num_samples):
-        hd = 0
-        hh = 0
-        for i in range(N):
-            r0n = (exp(-2.0j * 3.141592653 * dtc * freqs[i])
-                   * (fp[j] * hp[i] + fc[j] * hc[i])) / h00[i]
-            r1 = r0n - r0
+        fpj = fp[j]
+        fcj = fc[j]
 
-            x0n = norm(r0n)
-            x1 = x0n - x0
+        hd = 0
+        for i in range(N):
+            r0n = fpj * hpr[i] + fcj * hcr[i]
 
             if i > 0:
-                hd += a0[i-1] * r0 + a1[i-1] * r1
-                hh += real(b0[i-1] * x0 + b1[i-1] * x1)
+                hd += a0[i-1] * r0 + a1[i-1] * (r0n - r0)
 
             r0 = r0n
-            x0 = x0n
         hdv[j] = conj(hd)
-        hhv[j] = hh
+        hhv[j] = fpj * fpj * app + fcj * fcj * acc + fpj * fcj * apc
     return hdv, hhv
 
 # Standard likelihood but simultaneously handling multiple sky or time points
@@ -551,8 +650,8 @@ cpdef snr_predictor(double [::1] freqs,
     hh = 0
     chh = 0
     for i in range(N):
-        twiddle[i] = exp(-2.0j * 3.141592653 * tstart * freqs[i]) / h00[i]
-        rotate[i] =  exp(-2.0j * 3.141592653 * delta_t * freqs[i])
+        twiddle[i] = exp(MINUS_TWO_PI_J * tstart * freqs[i]) / h00[i]
+        rotate[i] =  exp(MINUS_TWO_PI_J * delta_t * freqs[i])
 
         r0n =  hp[i] / h00[i]
         cr0n = hc[i] / h00[i]
@@ -621,8 +720,8 @@ cpdef snr_predictor_dom(double [::1] freqs,
 
     hh = 0
     for i in range(N):
-        twiddle[i] = exp(-2.0j * 3.141592653 * tstart * freqs[i]) / h00[i]
-        rotate[i] =  exp(-2.0j * 3.141592653 * delta_t * freqs[i])
+        twiddle[i] = exp(MINUS_TWO_PI_J * tstart * freqs[i]) / h00[i]
+        rotate[i] =  exp(MINUS_TWO_PI_J * delta_t * freqs[i])
 
         r0n =  hp[i] / h00[i]
 

--- a/pycbc/inference/models/relbin_cpu.pyx
+++ b/pycbc/inference/models/relbin_cpu.pyx
@@ -7,7 +7,7 @@ cdef extern from "complex.h":
     double real(double complex)
     double imag(double complex)
 
-# the phase passes want the sine and cosine separately, in real buffers
+# the phase passes need sine and cosine separately, in real buffers
 cdef extern from "math.h":
     double cos(double)
     double sin(double)
@@ -16,7 +16,7 @@ cdef extern from "math.h":
 import numpy
 cimport cython, numpy
 
-# the complex form is the one a time shift wants, exp(-2 pi i dtc f)
+# the complex form is used by the time shift, exp(-2 pi i dtc f)
 cdef double MINUS_TWO_PI = -2.0 * M_PI
 cdef double complex MINUS_TWO_PI_J = -2.0j * M_PI
 
@@ -388,11 +388,11 @@ cpdef likelihood_parts_v_pol_time(double [::1] freqs,
         hdv[j] = conj(hd)
         hhv[j] = cp * cp * app + sp * sp * acc + cp * sp * apc
     return hdv, hhv
-# <h|h> for a whole bank of samples, without a sample loop.  A time shift
-# has unit modulus so it drops out of |fp * hp + fc * hc|^2, leaving a
-# quadratic form in (fp, fc): any sample's value is then
-# fp * fp * app + fc * fc * acc + fp * fc * apc.  The factor of two in the
-# cross term is folded into apc, and it is the real part, not the modulus.
+# Calculate <h|h> for a bank of samples without a sample loop. A time
+# shift has unit modulus, so it drops out of |fp * hp + fc * hc|^2 and
+# leaves a quadratic form in (fp, fc). Each sample is then
+# fp * fp * app + fc * fc * acc + fp * fc * apc. The factor of two in the
+# cross term is folded into apc, which is a real part, not a modulus.
 @cython.boundscheck(False)  # Deactivate bounds checking
 @cython.wraparound(False)   # Deactivate negative indexing.
 @cython.cdivision(True)     # Disable checking for dividing by zero
@@ -429,8 +429,8 @@ cdef void hh_coefficients(double complex[::1] hpr,
 
 # Standard likelihood but simultaneously handling multiple sky or time points
 #
-# The phase gets a pass of its own: nothing in it depends on the previous
-# element, so the sine and cosine vectorize, which they cannot do while the
+# The phase is calculated in a separate pass. Nothing in it depends on the
+# previous element, so the sine and cosine vectorize; they cannot while the
 # serial r0 carry shares the loop.
 @cython.boundscheck(False)  # Deactivate bounds checking
 @cython.wraparound(False)   # Deactivate negative indexing.
@@ -488,8 +488,8 @@ cpdef likelihood_parts_vector(double [::1] freqs,
 
 # Standard likelihood but simultaneously handling multiple time points
 #
-# fp and fc are scalars here, so the samples differ only by a time shift and
-# <h|h> is one value for the whole bank.
+# fp and fc are scalars here, so samples differ only by a time shift and
+# <h|h> is one value for the bank.
 @cython.boundscheck(False)  # Deactivate bounds checking
 @cython.wraparound(False)   # Deactivate negative indexing.
 @cython.cdivision(True)     # Disable checking for dividing by zero
@@ -546,9 +546,9 @@ cpdef likelihood_parts_vectort(double [::1] freqs,
 
 # Like above, but if only polarization is marginalized
 #
-# dtc is a scalar here, so the phase folds into the per bin ratios once and
-# nothing transcendental is left in the sample loop.  A unit modulus factor
-# common to both polarizations cancels out of the quadratic form.
+# dtc is a scalar here, so the phase is folded into the per bin ratios once
+# and no transcendental is left in the sample loop. A unit modulus factor
+# common to both polarizations cancels from the quadratic form.
 @cython.boundscheck(False)  # Deactivate bounds checking
 @cython.wraparound(False)   # Deactivate negative indexing.
 @cython.cdivision(True)     # Disable checking for dividing by zero

--- a/pycbc/inference/models/relbin_cpu.pyx
+++ b/pycbc/inference/models/relbin_cpu.pyx
@@ -7,24 +7,18 @@ cdef extern from "complex.h":
     double real(double complex)
     double imag(double complex)
 
-# The phase pass below wants the real sine and cosine on their own, rather
-# than the complex exponential declared above, so that it can write them
-# straight into a pair of real buffers.
+# the phase passes want the sine and cosine separately, in real buffers
 cdef extern from "math.h":
     double cos(double)
     double sin(double)
+    double M_PI
 
 import numpy
 cimport cython, numpy
 
-# The pi here is deliberately the truncated 3.141592653 rather than M_PI.
-# It appears only in the 2*pi of a time shift, so its whole effect is an
-# exact rescaling dtc -> dtc*(1 - 1.877e-10): <h|h> is untouched, and on a
-# real event the peak moves by 1.7e-12 s against a posterior width of
-# 6.8e-5.  Replacing it would move published numbers for no correctness
-# gain, so it stays, named once instead of spelled out twenty-one times.
-cdef double MINUS_TWO_PI = -2.0 * 3.141592653
-cdef double complex MINUS_TWO_PI_J = -2.0j * 3.141592653
+# the complex form is the one a time shift wants, exp(-2 pi i dtc f)
+cdef double MINUS_TWO_PI = -2.0 * M_PI
+cdef double complex MINUS_TWO_PI_J = -2.0j * M_PI
 
 # Used for calculating the cross terms of
 # two signals when analyzing multiple signals
@@ -394,17 +388,11 @@ cpdef likelihood_parts_v_pol_time(double [::1] freqs,
         hdv[j] = conj(hd)
         hhv[j] = cp * cp * app + sp * sp * acc + cp * sp * apc
     return hdv, hhv
-# The <h|h> of a whole bank of samples, without a sample loop.
-#
-# Every sample scales the two polarizations by a real pair (fp, fc) and then
-# applies a time shift, and the time shift has unit modulus, so it drops out
-# of |fp * hp + fc * hc|^2 entirely.  What is left is a quadratic form in
-# (fp, fc), and summing its three coefficient series once with the relative
-# binning weights gives constants from which any sample's <h|h> follows as
-# fp * fp * app + fc * fc * acc + fp * fc * apc.  Both the factor of two in
-# the cross term and its being the real part are needed; neither is optional.
-# This is the same reasoning snr_predictor already uses to lift its own
-# <h|h> out of the sample loop.
+# <h|h> for a whole bank of samples, without a sample loop.  A time shift
+# has unit modulus so it drops out of |fp * hp + fc * hc|^2, leaving a
+# quadratic form in (fp, fc): any sample's value is then
+# fp * fp * app + fc * fc * acc + fp * fc * apc.  The factor of two in the
+# cross term is folded into apc, and it is the real part, not the modulus.
 @cython.boundscheck(False)  # Deactivate bounds checking
 @cython.wraparound(False)   # Deactivate negative indexing.
 @cython.cdivision(True)     # Disable checking for dividing by zero
@@ -441,13 +429,9 @@ cdef void hh_coefficients(double complex[::1] hpr,
 
 # Standard likelihood but simultaneously handling multiple sky or time points
 #
-# Three things are kept out of the inner loop that do not belong there.  The
-# division by h00 depends on the frequency bin alone, so it is done once for
-# the bank instead of once per (bin, sample).  <h|h> is not accumulated here
-# at all, it comes from the constants above.  And the phase is evaluated in
-# a pass of its own, into scratch buffers; nothing in that pass depends on
-# the previous element, so the compiler is free to vectorize the sine and
-# cosine, which it cannot do while the serial r0 carry shares the loop.
+# The phase gets a pass of its own: nothing in it depends on the previous
+# element, so the sine and cosine vectorize, which they cannot do while the
+# serial r0 carry shares the loop.
 @cython.boundscheck(False)  # Deactivate bounds checking
 @cython.wraparound(False)   # Deactivate negative indexing.
 @cython.cdivision(True)     # Disable checking for dividing by zero
@@ -504,11 +488,8 @@ cpdef likelihood_parts_vector(double [::1] freqs,
 
 # Standard likelihood but simultaneously handling multiple time points
 #
-# Here fp and fc are scalars, so every sample sees the same waveform ratio
-# and differs only by a time shift.  A time shift cannot change <h|h>, so
-# there is one value of it for the whole bank and it is computed once, with
-# the ratio, before the sample loop is entered.  The phase again gets a pass
-# of its own so that the sine and cosine can vectorize.
+# fp and fc are scalars here, so the samples differ only by a time shift and
+# <h|h> is one value for the whole bank.
 @cython.boundscheck(False)  # Deactivate bounds checking
 @cython.wraparound(False)   # Deactivate negative indexing.
 @cython.cdivision(True)     # Disable checking for dividing by zero
@@ -565,11 +546,9 @@ cpdef likelihood_parts_vectort(double [::1] freqs,
 
 # Like above, but if only polarization is marginalized
 #
-# Here dtc is a scalar, so the time shift is the same for every sample and
-# there is no transcendental left to evaluate inside the sample loop at all:
-# the phase is folded into the per bin waveform ratios once.  Folding it in
-# does not disturb the <h|h> constants, since a unit modulus factor common
-# to both polarizations cancels out of every term of the quadratic form.
+# dtc is a scalar here, so the phase folds into the per bin ratios once and
+# nothing transcendental is left in the sample loop.  A unit modulus factor
+# common to both polarizations cancels out of the quadratic form.
 @cython.boundscheck(False)  # Deactivate bounds checking
 @cython.wraparound(False)   # Deactivate negative indexing.
 @cython.cdivision(True)     # Disable checking for dividing by zero

--- a/test/test_relbin_kernel.py
+++ b/test/test_relbin_kernel.py
@@ -1,0 +1,314 @@
+# Copyright (C) 2026  Alex Nitz
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+"""Tests the vectorized relative binning kernels against the scalar one.
+
+The three vector kernels exist only to do, for a whole bank of samples at
+once, what likelihood_parts does for one. They are written differently for
+speed: the division by the fiducial waveform is hoisted out of the sample
+loop, <h|h> is obtained from a quadratic form rather than accumulated, and
+the time shift phase is evaluated in a pass of its own. None of that is
+allowed to change the answer, so the property to check is the one that
+defines them, that sample by sample they reproduce the scalar kernel.
+
+The rearrangement reassociates floating point sums, so the agreement is
+close but not to the last bit; the tolerance here is far tighter than any
+reassociation can reach and far looser than bit equality. The scalar kernel
+is in turn checked against a direct sum written straight from the
+definition, so that a shared mistake could not pass unnoticed.
+
+The inputs are a chirping inspiral seen against a nearby fiducial waveform,
+on the bins the model itself would choose for it, with summary weights built
+from an analytic noise curve. The two polarizations are given a small extra
+component so they are not a pure phase apart: if they were, the cross term
+of the quadratic form would vanish and the test would not reach it.
+"""
+
+import os
+import unittest
+
+import numpy
+
+from pycbc.inference.models.relbin import setup_bins
+from pycbc.inference.models.relbin_cpu import (likelihood_parts,
+                                               likelihood_parts_v_pol,
+                                               likelihood_parts_v_pol_time,
+                                               likelihood_parts_v_time,
+                                               likelihood_parts_vector,
+                                               likelihood_parts_vectorp,
+                                               likelihood_parts_vectort)
+
+# a 32 second segment analysed from 20 Hz, as a neutron star binary is
+FLOW, FHIGH, DF = 20.0, 1024.0, 1. / 32.
+NSAMPLE = 64
+
+# how closely the vector kernels must track the scalar one, relative
+TOL = 1e-12
+
+# the kernels spell pi as a truncated literal rather than taking it from
+# math.h, so the reference sum below has to use the same one or it would be
+# comparing two slightly different time shifts and disagreeing at 1e-8 for a
+# reason that has nothing to do with what is being tested here
+KERNEL_PI = 3.141592653
+
+
+def get_seed():
+    """Draw a fresh seed each run, or take the one being reproduced."""
+    seed = os.environ.get('PYCBC_VALIDATION_SEED')
+    if seed is None:
+        seed = numpy.random.randint(0, 2 ** 31)
+    return int(seed)
+
+
+def inspiral(freqs, mchirp):
+    """A stationary phase inspiral: an f^(-7/6) amplitude under a phase
+    that sweeps thousands of radians across the band, which is what makes
+    the time shift in the kernel a hard thing to get right."""
+    return ((freqs / FLOW) ** (-7. / 6.) * numpy.exp(
+        1.0j * 3. / 128. / (numpy.pi * mchirp * 4.9e-6 * freqs) ** (5. / 3.)))
+
+
+def summary(h1, h2, freqs, psd, bins):
+    """The constant and linear summary weights of <h1|h2> over each bin,
+    formed exactly as the relative binning model forms them."""
+    h12 = numpy.conjugate(h1) * h2 / psd
+    a0 = numpy.array([4.0 * DF * h12[l:h].sum() for l, h in bins])
+    a1 = numpy.array([4.0 / (h - l)
+                      * (h12[l:h] * (freqs[l:h] - freqs[l])).sum()
+                      for l, h in bins])
+    return a0, a1
+
+
+def make_case(seed):
+    """Build one realistic argument set for the kernels."""
+    rng = numpy.random.default_rng(seed)
+
+    fine = numpy.arange(FLOW, FHIGH + DF, DF)
+    psd = 1e-46 * ((fine / 100.) ** -4.14 + 1.0 + (fine / 300.) ** 2)
+
+    # the bins the model would lay down for this band, so the edges are
+    # crowded where the phase turns over quickly and sparse where it does not
+    index = setup_bins(fine, FLOW, FHIGH)
+    edges = fine[index]
+    bins = list(zip(index[:-1], index[1:]))
+
+    # the fiducial waveform, and data holding a signal a little off it
+    h00f = 1e-23 * inspiral(fine, 1.2)
+    noise = ((rng.normal(size=fine.size) + 1.0j * rng.normal(size=fine.size))
+             * numpy.sqrt(psd))
+    data = 1.05 * 1e-23 * inspiral(fine, 1.2005) + noise
+
+    a0, a1 = summary(h00f, data, fine, psd, bins)
+    b0, b1 = summary(h00f, h00f, fine, psd, bins)
+
+    # a dominant quadrupole plus a small second piece, which is what stops
+    # the two polarizations from being a pure phase apart
+    cosi = 0.6
+    dom = 1e-23 * inspiral(edges, 1.2005)
+    sub = 1e-24 * inspiral(edges, 1.35)
+    hp = 0.5 * (1.0 + cosi ** 2) * dom + 0.30 * sub
+    hc = 1.0j * cosi * dom + 0.22 * numpy.exp(0.7j) * sub
+
+    return dict(freqs=edges, hp=hp, hc=hc, h00=1e-23 * inspiral(edges, 1.2),
+                a0=a0, a1=a1, b0=numpy.abs(b0), b1=numpy.abs(b1),
+                fp=rng.uniform(-1, 1, NSAMPLE),
+                fc=rng.uniform(-1, 1, NSAMPLE),
+                dtc=rng.uniform(-0.1, 0.1, NSAMPLE))
+
+
+def direct(freqs, fp, fc, dtc, hp, hc, h00, a0, a1, b0, b1):
+    """<d|h> and <h|h> written straight from the definition, with no
+    reference to how the kernels are organised internally."""
+    r = numpy.exp(-2.0j * KERNEL_PI * dtc * freqs) * (fp * hp + fc * hc) / h00
+    x = numpy.abs(r) ** 2
+    return (numpy.conjugate((a0 * r[:-1] + a1 * numpy.diff(r)).sum()),
+            (b0 * x[:-1] + b1 * numpy.diff(x)).sum())
+
+
+class TestRelbinKernel(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.seed = get_seed()
+        print('using PYCBC_VALIDATION_SEED=%s' % cls.seed)
+        cls.case = make_case(cls.seed)
+
+    def args(self, **override):
+        c = dict(self.case, **override)
+        return [c[k] for k in ('freqs', 'fp', 'fc', 'dtc', 'hp', 'hc',
+                               'h00', 'a0', 'a1', 'b0', 'b1')]
+
+    def scalar(self, j):
+        """What the untouched scalar kernel says about sample j."""
+        c = self.case
+        return likelihood_parts(c['freqs'], c['fp'][j], c['fc'][j],
+                                c['dtc'][j], c['hp'], c['hc'], c['h00'],
+                                c['a0'], c['a1'], c['b0'], c['b1'])
+
+    def check_against_scalar(self, hdv, hhv, label):
+        err = numpy.empty((NSAMPLE, 2))
+        for j in range(NSAMPLE):
+            hd, hh = self.scalar(j)
+            err[j] = (abs(hdv[j] - hd) / abs(hd), abs(hhv[j] - hh) / abs(hh))
+        # numpy.max, not the builtin, so that a nan cannot pass unnoticed
+        worst = err.max()
+        print('%s: worst relative difference from the scalar kernel %.2e'
+              % (label, worst))
+        self.assertTrue(worst < TOL)
+
+    def test_scalar_kernel_is_the_definition(self):
+        """Everything below is measured against the scalar kernel, so first
+        confirm that it is itself the sum it claims to be."""
+        c = self.case
+        for j in (0, NSAMPLE // 2, NSAMPLE - 1):
+            hd, hh = self.scalar(j)
+            rhd, rhh = direct(c['freqs'], c['fp'][j], c['fc'][j], c['dtc'][j],
+                              c['hp'], c['hc'], c['h00'], c['a0'], c['a1'],
+                              c['b0'], c['b1'])
+            self.assertLess(abs(hd - rhd) / abs(rhd), TOL)
+            self.assertLess(abs(hh - rhh) / abs(rhh), TOL)
+
+    def test_vector_matches_scalar(self):
+        """Sky or time points: every sample has its own response and its
+        own time shift."""
+        hdv, hhv = likelihood_parts_vector(*self.args())
+        self.check_against_scalar(hdv, hhv, 'likelihood_parts_vector')
+
+    def test_vectort_matches_scalar(self):
+        """Time points only: the response is a scalar, so <h|h> is one
+        number for the whole bank and must still be the right one."""
+        c = self.case
+        fp, fc = float(c['fp'][0]), float(c['fc'][0])
+        hdv, hhv = likelihood_parts_vectort(
+            c['freqs'], fp, fc, c['dtc'], c['hp'], c['hc'], c['h00'],
+            c['a0'], c['a1'], c['b0'], c['b1'])
+        self.case = dict(c, fp=numpy.full(NSAMPLE, fp),
+                         fc=numpy.full(NSAMPLE, fc))
+        try:
+            self.check_against_scalar(hdv, hhv, 'likelihood_parts_vectort')
+        finally:
+            self.case = c
+
+    def test_vectorp_matches_scalar(self):
+        """Polarization points only: the time shift is a scalar and is
+        folded into the waveform ratios ahead of the sample loop."""
+        c = self.case
+        dtc = float(c['dtc'][0])
+        hdv, hhv = likelihood_parts_vectorp(
+            c['freqs'], c['fp'], c['fc'], dtc, c['hp'], c['hc'], c['h00'],
+            c['a0'], c['a1'], c['b0'], c['b1'])
+        self.case = dict(c, dtc=numpy.full(NSAMPLE, dtc))
+        try:
+            self.check_against_scalar(hdv, hhv, 'likelihood_parts_vectorp')
+        finally:
+            self.case = c
+
+    def rotating(self):
+        """The earth-rotation inputs: response and arrival vary across the
+        band, so fp, fc and the arrival time are per bin rather than per
+        sample. Only the polarization and the offset are per sample."""
+        c = self.case
+        n = len(c['freqs'])
+        rng = numpy.random.RandomState(self.seed + 1)
+        return dict(fpb=rng.uniform(-1, 1, n), fcb=rng.uniform(-1, 1, n),
+                    times=rng.uniform(-0.01, 0.01, n),
+                    dtcb=rng.uniform(-0.01, 0.01, n),
+                    pol=numpy.exp(2.0j * rng.uniform(0, numpy.pi, NSAMPLE)))
+
+    def check_against_direct(self, hdv, hhv, effective, label):
+        """effective(j) gives the per-bin fp, fc and arrival for sample j."""
+        c = self.case
+        err = numpy.empty((NSAMPLE, 2))
+        for j in range(NSAMPLE):
+            fp, fc, dt = effective(j)
+            hd, hh = direct(c['freqs'], fp, fc, dt, c['hp'], c['hc'],
+                            c['h00'], c['a0'], c['a1'], c['b0'], c['b1'])
+            err[j] = (abs(hdv[j] - hd) / abs(hd), abs(hhv[j] - hh) / abs(hh))
+        worst = err.max()
+        print('%s: worst relative difference from the definition %.2e'
+              % (label, worst))
+        self.assertTrue(worst < TOL)
+
+    def test_v_pol_matches_the_definition(self):
+        """Earth rotation, polarization points: the arrival varies across
+        the band but not between samples, so the whole time shift comes out
+        of the sample loop."""
+        c, r = self.case, self.rotating()
+        hdv, hhv = likelihood_parts_v_pol(
+            c['freqs'], r['fpb'], r['fcb'], r['dtcb'], r['pol'],
+            c['hp'], c['hc'], c['h00'], c['a0'], c['a1'], c['b0'], c['b1'])
+
+        def effective(j):
+            cp, sp = r['pol'][j].real, r['pol'][j].imag
+            return (r['fpb'] * cp - r['fcb'] * sp,
+                    r['fpb'] * sp + r['fcb'] * cp, r['dtcb'])
+        self.check_against_direct(hdv, hhv, effective,
+                                  'likelihood_parts_v_pol')
+
+    def test_v_time_matches_the_definition(self):
+        """Earth rotation, time points: the response is per bin and does
+        not move with the sample, so <h|h> is one number for the bank."""
+        c, r = self.case, self.rotating()
+        hdv, hhv = likelihood_parts_v_time(
+            c['freqs'], r['fpb'], r['fcb'], r['times'], c['dtc'],
+            c['hp'], c['hc'], c['h00'], c['a0'], c['a1'], c['b0'], c['b1'])
+        self.assertLess(hhv.max() - hhv.min(), abs(hhv.mean()) * TOL,
+                        'a time shift changed <h|h>')
+
+        def effective(j):
+            return r['fpb'], r['fcb'], r['times'] + c['dtc'][j]
+        self.check_against_direct(hdv, hhv, effective,
+                                  'likelihood_parts_v_time')
+
+    def test_v_pol_time_matches_the_definition(self):
+        """Earth rotation, both: the per-bin arrival is folded in ahead of
+        the sample loop and only the per-sample shift is left in it."""
+        c, r = self.case, self.rotating()
+        hdv, hhv = likelihood_parts_v_pol_time(
+            c['freqs'], r['fpb'], r['fcb'], r['times'], c['dtc'], r['pol'],
+            c['hp'], c['hc'], c['h00'], c['a0'], c['a1'], c['b0'], c['b1'])
+
+        def effective(j):
+            cp, sp = r['pol'][j].real, r['pol'][j].imag
+            return (r['fpb'] * cp - r['fcb'] * sp,
+                    r['fpb'] * sp + r['fcb'] * cp,
+                    r['times'] + c['dtc'][j])
+        self.check_against_direct(hdv, hhv, effective,
+                                  'likelihood_parts_v_pol_time')
+
+    def test_cross_term_is_reached(self):
+        """<h|h> is a quadratic form in the antenna response, and the
+        agreement above only means something if the fixture actually
+        exercises its cross term. Measure how big that term is: what is
+        left of <h|h> once the two pure terms are subtracted off. It is a
+        fraction of a percent, which is small but is a trillion times the
+        tolerance above, so getting it wrong could not go unnoticed."""
+        c = self.case
+        one, zero = numpy.ones(NSAMPLE), numpy.zeros(NSAMPLE)
+        _, pp = likelihood_parts_vector(*self.args(fp=one, fc=zero))
+        _, cc = likelihood_parts_vector(*self.args(fp=zero, fc=one))
+        _, hh = likelihood_parts_vector(*self.args())
+        cross = hh - c['fp'] ** 2 * pp - c['fc'] ** 2 * cc
+        share = numpy.abs(cross / hh).max()
+        print('cross term is up to %.2f%% of <h|h> here' % (100 * share))
+        self.assertGreater(share, 1e-3)
+
+
+suite = unittest.TestSuite()
+suite.addTest(unittest.TestLoader().loadTestsFromTestCase(TestRelbinKernel))
+
+if __name__ == '__main__':
+    results = unittest.TextTestRunner(verbosity=2).run(suite)
+    from utils import simple_exit
+    simple_exit(results)

--- a/test/test_relbin_kernel.py
+++ b/test/test_relbin_kernel.py
@@ -12,27 +12,15 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-"""Tests the vectorized relative binning kernels against the scalar one.
+"""Checks the relative binning kernels against the definition.
 
-The three vector kernels exist only to do, for a whole bank of samples at
-once, what likelihood_parts does for one. They are written differently for
-speed: the division by the fiducial waveform is hoisted out of the sample
-loop, <h|h> is obtained from a quadratic form rather than accumulated, and
-the time shift phase is evaluated in a pass of its own. None of that is
-allowed to change the answer, so the property to check is the one that
-defines them, that sample by sample they reproduce the scalar kernel.
+Each kernel evaluates <d|h> and <h|h> for a bank of marginalization
+samples. They are written for speed rather than for reading, so what is
+asserted is the property that defines them: sample by sample they are the
+sum written out in direct() below.
 
 The rearrangement reassociates floating point sums, so the agreement is
-close but not to the last bit; the tolerance here is far tighter than any
-reassociation can reach and far looser than bit equality. The scalar kernel
-is in turn checked against a direct sum written straight from the
-definition, so that a shared mistake could not pass unnoticed.
-
-The inputs are a chirping inspiral seen against a nearby fiducial waveform,
-on the bins the model itself would choose for it, with summary weights built
-from an analytic noise curve. The two polarizations are given a small extra
-component so they are not a pure phase apart: if they were, the cross term
-of the quadratic form would vanish and the test would not reach it.
+close but not to the last bit.
 """
 
 import os
@@ -53,14 +41,8 @@ from pycbc.inference.models.relbin_cpu import (likelihood_parts,
 FLOW, FHIGH, DF = 20.0, 1024.0, 1. / 32.
 NSAMPLE = 64
 
-# how closely the vector kernels must track the scalar one, relative
+# how closely each kernel must track the definition, relative
 TOL = 1e-12
-
-# the kernels spell pi as a truncated literal rather than taking it from
-# math.h, so the reference sum below has to use the same one or it would be
-# comparing two slightly different time shifts and disagreeing at 1e-8 for a
-# reason that has nothing to do with what is being tested here
-KERNEL_PI = numpy.pi
 
 
 def get_seed():
@@ -83,10 +65,10 @@ def summary(h1, h2, freqs, psd, bins):
     """The constant and linear summary weights of <h1|h2> over each bin,
     formed exactly as the relative binning model forms them."""
     h12 = numpy.conjugate(h1) * h2 / psd
-    a0 = numpy.array([4.0 * DF * h12[l:h].sum() for l, h in bins])
-    a1 = numpy.array([4.0 / (h - l)
-                      * (h12[l:h] * (freqs[l:h] - freqs[l])).sum()
-                      for l, h in bins])
+    a0 = numpy.array([4.0 * DF * h12[lo:hi].sum() for lo, hi in bins])
+    a1 = numpy.array([4.0 / (hi - lo)
+                      * (h12[lo:hi] * (freqs[lo:hi] - freqs[lo])).sum()
+                      for lo, hi in bins])
     return a0, a1
 
 
@@ -127,10 +109,10 @@ def make_case(seed):
                 dtc=rng.uniform(-0.1, 0.1, NSAMPLE))
 
 
-def direct(freqs, fp, fc, dtc, hp, hc, h00, a0, a1, b0, b1):
+def direct(freqs, fp, fc, dtc, *, hp, hc, h00, a0, a1, b0, b1):
     """<d|h> and <h|h> written straight from the definition, with no
     reference to how the kernels are organised internally."""
-    r = numpy.exp(-2.0j * KERNEL_PI * dtc * freqs) * (fp * hp + fc * hc) / h00
+    r = numpy.exp(-2.0j * numpy.pi * dtc * freqs) * (fp * hp + fc * hc) / h00
     x = numpy.abs(r) ** 2
     return (numpy.conjugate((a0 * r[:-1] + a1 * numpy.diff(r)).sum()),
             (b0 * x[:-1] + b1 * numpy.diff(x)).sum())
@@ -143,166 +125,116 @@ class TestRelbinKernel(unittest.TestCase):
         cls.seed = get_seed()
         print('using PYCBC_VALIDATION_SEED=%s' % cls.seed)
         cls.case = make_case(cls.seed)
+        # earth rotation makes the response and the arrival vary across the
+        # band, so those become per bin and only the polarization and the
+        # offset stay per sample
+        rng = numpy.random.RandomState(cls.seed + 1)
+        n = len(cls.case['freqs'])
+        cls.band = dict(fp=rng.uniform(-1, 1, n), fc=rng.uniform(-1, 1, n),
+                        times=rng.uniform(-0.01, 0.01, n),
+                        dtc=rng.uniform(-0.01, 0.01, n),
+                        pol=numpy.exp(2.0j * rng.uniform(0, numpy.pi,
+                                                         NSAMPLE)))
 
-    def args(self, **override):
-        c = dict(self.case, **override)
-        return [c[k] for k in ('freqs', 'fp', 'fc', 'dtc', 'hp', 'hc',
-                               'h00', 'a0', 'a1', 'b0', 'b1')]
-
-    def scalar(self, j):
-        """What the untouched scalar kernel says about sample j."""
+    def check(self, out, effective, label):
+        """effective(j) gives the fp, fc and arrival the definition should
+        be evaluated at for sample j, as scalars or as per bin arrays."""
         c = self.case
-        return likelihood_parts(c['freqs'], c['fp'][j], c['fc'][j],
-                                c['dtc'][j], c['hp'], c['hc'], c['h00'],
-                                c['a0'], c['a1'], c['b0'], c['b1'])
-
-    def check_against_scalar(self, hdv, hhv, label):
+        hdv, hhv = out
         err = numpy.empty((NSAMPLE, 2))
         for j in range(NSAMPLE):
-            hd, hh = self.scalar(j)
+            hd, hh = direct(c['freqs'], *effective(j), hp=c['hp'], hc=c['hc'],
+                            h00=c['h00'], a0=c['a0'], a1=c['a1'],
+                            b0=c['b0'], b1=c['b1'])
             err[j] = (abs(hdv[j] - hd) / abs(hd), abs(hhv[j] - hh) / abs(hh))
         # numpy.max, not the builtin, so that a nan cannot pass unnoticed
-        worst = err.max()
-        print('%s: worst relative difference from the scalar kernel %.2e'
-              % (label, worst))
-        self.assertTrue(worst < TOL)
-
-    def test_scalar_kernel_is_the_definition(self):
-        """Everything below is measured against the scalar kernel, so first
-        confirm that it is itself the sum it claims to be."""
-        c = self.case
-        for j in (0, NSAMPLE // 2, NSAMPLE - 1):
-            hd, hh = self.scalar(j)
-            rhd, rhh = direct(c['freqs'], c['fp'][j], c['fc'][j], c['dtc'][j],
-                              c['hp'], c['hc'], c['h00'], c['a0'], c['a1'],
-                              c['b0'], c['b1'])
-            self.assertLess(abs(hd - rhd) / abs(rhd), TOL)
-            self.assertLess(abs(hh - rhh) / abs(rhh), TOL)
-
-    def test_vector_matches_scalar(self):
-        """Sky or time points: every sample has its own response and its
-        own time shift."""
-        hdv, hhv = likelihood_parts_vector(*self.args())
-        self.check_against_scalar(hdv, hhv, 'likelihood_parts_vector')
-
-    def test_vectort_matches_scalar(self):
-        """Time points only: the response is a scalar, so <h|h> is one
-        number for the whole bank and must still be the right one."""
-        c = self.case
-        fp, fc = float(c['fp'][0]), float(c['fc'][0])
-        hdv, hhv = likelihood_parts_vectort(
-            c['freqs'], fp, fc, c['dtc'], c['hp'], c['hc'], c['h00'],
-            c['a0'], c['a1'], c['b0'], c['b1'])
-        self.case = dict(c, fp=numpy.full(NSAMPLE, fp),
-                         fc=numpy.full(NSAMPLE, fc))
-        try:
-            self.check_against_scalar(hdv, hhv, 'likelihood_parts_vectort')
-        finally:
-            self.case = c
-
-    def test_vectorp_matches_scalar(self):
-        """Polarization points only: the time shift is a scalar and is
-        folded into the waveform ratios ahead of the sample loop."""
-        c = self.case
-        dtc = float(c['dtc'][0])
-        hdv, hhv = likelihood_parts_vectorp(
-            c['freqs'], c['fp'], c['fc'], dtc, c['hp'], c['hc'], c['h00'],
-            c['a0'], c['a1'], c['b0'], c['b1'])
-        self.case = dict(c, dtc=numpy.full(NSAMPLE, dtc))
-        try:
-            self.check_against_scalar(hdv, hhv, 'likelihood_parts_vectorp')
-        finally:
-            self.case = c
-
-    def rotating(self):
-        """The earth-rotation inputs: response and arrival vary across the
-        band, so fp, fc and the arrival time are per bin rather than per
-        sample. Only the polarization and the offset are per sample."""
-        c = self.case
-        n = len(c['freqs'])
-        rng = numpy.random.RandomState(self.seed + 1)
-        return dict(fpb=rng.uniform(-1, 1, n), fcb=rng.uniform(-1, 1, n),
-                    times=rng.uniform(-0.01, 0.01, n),
-                    dtcb=rng.uniform(-0.01, 0.01, n),
-                    pol=numpy.exp(2.0j * rng.uniform(0, numpy.pi, NSAMPLE)))
-
-    def check_against_direct(self, hdv, hhv, effective, label):
-        """effective(j) gives the per-bin fp, fc and arrival for sample j."""
-        c = self.case
-        err = numpy.empty((NSAMPLE, 2))
-        for j in range(NSAMPLE):
-            fp, fc, dt = effective(j)
-            hd, hh = direct(c['freqs'], fp, fc, dt, c['hp'], c['hc'],
-                            c['h00'], c['a0'], c['a1'], c['b0'], c['b1'])
-            err[j] = (abs(hdv[j] - hd) / abs(hd), abs(hhv[j] - hh) / abs(hh))
         worst = err.max()
         print('%s: worst relative difference from the definition %.2e'
               % (label, worst))
         self.assertTrue(worst < TOL)
 
-    def test_v_pol_matches_the_definition(self):
-        """Earth rotation, polarization points: the arrival varies across
-        the band but not between samples, so the whole time shift comes out
-        of the sample loop."""
-        c, r = self.case, self.rotating()
-        hdv, hhv = likelihood_parts_v_pol(
-            c['freqs'], r['fpb'], r['fcb'], r['dtcb'], r['pol'],
-            c['hp'], c['hc'], c['h00'], c['a0'], c['a1'], c['b0'], c['b1'])
+    def rotated(self, j):
+        """(fp, fc) turned by the polarization of sample j."""
+        b = self.band
+        cp, sp = b['pol'][j].real, b['pol'][j].imag
+        return b['fp'] * cp - b['fc'] * sp, b['fp'] * sp + b['fc'] * cp
 
-        def effective(j):
-            cp, sp = r['pol'][j].real, r['pol'][j].imag
-            return (r['fpb'] * cp - r['fcb'] * sp,
-                    r['fpb'] * sp + r['fcb'] * cp, r['dtcb'])
-        self.check_against_direct(hdv, hhv, effective,
-                                  'likelihood_parts_v_pol')
-
-    def test_v_time_matches_the_definition(self):
-        """Earth rotation, time points: the response is per bin and does
-        not move with the sample, so <h|h> is one number for the bank."""
-        c, r = self.case, self.rotating()
-        hdv, hhv = likelihood_parts_v_time(
-            c['freqs'], r['fpb'], r['fcb'], r['times'], c['dtc'],
-            c['hp'], c['hc'], c['h00'], c['a0'], c['a1'], c['b0'], c['b1'])
-        self.assertLess(hhv.max() - hhv.min(), abs(hhv.mean()) * TOL,
-                        'a time shift changed <h|h>')
-
-        def effective(j):
-            return r['fpb'], r['fcb'], r['times'] + c['dtc'][j]
-        self.check_against_direct(hdv, hhv, effective,
-                                  'likelihood_parts_v_time')
-
-    def test_v_pol_time_matches_the_definition(self):
-        """Earth rotation, both: the per-bin arrival is folded in ahead of
-        the sample loop and only the per-sample shift is left in it."""
-        c, r = self.case, self.rotating()
-        hdv, hhv = likelihood_parts_v_pol_time(
-            c['freqs'], r['fpb'], r['fcb'], r['times'], c['dtc'], r['pol'],
-            c['hp'], c['hc'], c['h00'], c['a0'], c['a1'], c['b0'], c['b1'])
-
-        def effective(j):
-            cp, sp = r['pol'][j].real, r['pol'][j].imag
-            return (r['fpb'] * cp - r['fcb'] * sp,
-                    r['fpb'] * sp + r['fcb'] * cp,
-                    r['times'] + c['dtc'][j])
-        self.check_against_direct(hdv, hhv, effective,
-                                  'likelihood_parts_v_pol_time')
-
-    def test_cross_term_is_reached(self):
-        """<h|h> is a quadratic form in the antenna response, and the
-        agreement above only means something if the fixture actually
-        exercises its cross term. Measure how big that term is: what is
-        left of <h|h> once the two pure terms are subtracted off. It is a
-        fraction of a percent, which is small but is a trillion times the
-        tolerance above, so getting it wrong could not go unnoticed."""
+    def test_the_scalar_kernel_is_the_definition(self):
+        """The one kernel this branch does not touch, as a control on the
+        reference the others are measured against."""
         c = self.case
-        one, zero = numpy.ones(NSAMPLE), numpy.zeros(NSAMPLE)
-        _, pp = likelihood_parts_vector(*self.args(fp=one, fc=zero))
-        _, cc = likelihood_parts_vector(*self.args(fp=zero, fc=one))
-        _, hh = likelihood_parts_vector(*self.args())
-        cross = hh - c['fp'] ** 2 * pp - c['fc'] ** 2 * cc
-        share = numpy.abs(cross / hh).max()
-        print('cross term is up to %.2f%% of <h|h> here' % (100 * share))
-        self.assertGreater(share, 1e-3)
+        self.check((numpy.array([likelihood_parts(
+                        c['freqs'], c['fp'][j], c['fc'][j], c['dtc'][j],
+                        c['hp'], c['hc'], c['h00'], c['a0'], c['a1'],
+                        c['b0'], c['b1'])[i] for j in range(NSAMPLE)])
+                    for i in (0, 1)),
+                   lambda j: (c['fp'][j], c['fc'][j], c['dtc'][j]),
+                   'likelihood_parts')
+
+    def test_vector(self):
+        """Sky or time points: own response and own shift per sample."""
+        c = self.case
+        self.check(likelihood_parts_vector(
+                       c['freqs'], c['fp'], c['fc'], c['dtc'], c['hp'],
+                       c['hc'], c['h00'], c['a0'], c['a1'], c['b0'], c['b1']),
+                   lambda j: (c['fp'][j], c['fc'][j], c['dtc'][j]),
+                   'likelihood_parts_vector')
+
+    def test_vectort(self):
+        """Time points only: the response is scalar, so <h|h> is one number
+        for the whole bank and must still be the right one."""
+        c = self.case
+        fp, fc = float(c['fp'][0]), float(c['fc'][0])
+        out = likelihood_parts_vectort(
+            c['freqs'], fp, fc, c['dtc'], c['hp'], c['hc'], c['h00'],
+            c['a0'], c['a1'], c['b0'], c['b1'])
+        self.assertLess(out[1].max() - out[1].min(),
+                        abs(out[1].mean()) * TOL, 'a shift changed <h|h>')
+        self.check(out, lambda j: (fp, fc, c['dtc'][j]),
+                   'likelihood_parts_vectort')
+
+    def test_vectorp(self):
+        """Polarization points only: the shift is scalar and folds into the
+        ratios ahead of the sample loop."""
+        c = self.case
+        dtc = float(c['dtc'][0])
+        self.check(likelihood_parts_vectorp(
+                       c['freqs'], c['fp'], c['fc'], dtc, c['hp'], c['hc'],
+                       c['h00'], c['a0'], c['a1'], c['b0'], c['b1']),
+                   lambda j: (c['fp'][j], c['fc'][j], dtc),
+                   'likelihood_parts_vectorp')
+
+    def test_v_pol(self):
+        """Earth rotation, polarization points: the arrival varies across
+        the band but not between samples."""
+        c, b = self.case, self.band
+        self.check(likelihood_parts_v_pol(
+                       c['freqs'], b['fp'], b['fc'], b['dtc'], b['pol'],
+                       c['hp'], c['hc'], c['h00'], c['a0'], c['a1'],
+                       c['b0'], c['b1']),
+                   lambda j: self.rotated(j) + (b['dtc'],),
+                   'likelihood_parts_v_pol')
+
+    def test_v_time(self):
+        """Earth rotation, time points: the response is per bin and does
+        not move with the sample."""
+        c, b = self.case, self.band
+        self.check(likelihood_parts_v_time(
+                       c['freqs'], b['fp'], b['fc'], b['times'], c['dtc'],
+                       c['hp'], c['hc'], c['h00'], c['a0'], c['a1'],
+                       c['b0'], c['b1']),
+                   lambda j: (b['fp'], b['fc'], b['times'] + c['dtc'][j]),
+                   'likelihood_parts_v_time')
+
+    def test_v_pol_time(self):
+        """Earth rotation, both."""
+        c, b = self.case, self.band
+        self.check(likelihood_parts_v_pol_time(
+                       c['freqs'], b['fp'], b['fc'], b['times'], c['dtc'],
+                       b['pol'], c['hp'], c['hc'], c['h00'], c['a0'],
+                       c['a1'], c['b0'], c['b1']),
+                   lambda j: self.rotated(j) + (b['times'] + c['dtc'][j],),
+                   'likelihood_parts_v_pol_time')
 
 
 suite = unittest.TestSuite()

--- a/test/test_relbin_kernel.py
+++ b/test/test_relbin_kernel.py
@@ -28,6 +28,7 @@ import unittest
 import numpy
 
 from pycbc.inference.models.relbin import setup_bins
+from pycbc.waveform import get_fd_waveform_sequence
 from pycbc.inference.models.relbin_cpu import (likelihood_parts,
                                                likelihood_parts_v_pol,
                                                likelihood_parts_v_pol_time,
@@ -36,8 +37,11 @@ from pycbc.inference.models.relbin_cpu import (likelihood_parts,
                                                likelihood_parts_vectorp,
                                                likelihood_parts_vectort)
 
-# a 32 second segment from 20 Hz, as used for a neutron star binary
+# a 32 second segment from 20 Hz
 FLOW, FHIGH, DF = 20.0, 1024.0, 1. / 32.
+# asymmetric masses and a higher mode approximant, so that hp and hc are
+# not a pure phase apart and the cross term is exercised
+APPROXIMANT, MASS1, MASS2, INCLINATION = 'IMRPhenomXHM', 8.0, 2.0, 1.0
 NSAMPLE = 64
 
 # relative tolerance against direct()
@@ -51,13 +55,6 @@ def get_seed():
     if seed is None:
         seed = numpy.random.randint(0, 2 ** 31)
     return int(seed)
-
-
-def inspiral(freqs, mchirp):
-    """ Stationary phase inspiral with an f^(-7/6) amplitude
-    """
-    return ((freqs / FLOW) ** (-7. / 6.) * numpy.exp(
-        1.0j * 3. / 128. / (numpy.pi * mchirp * 4.9e-6 * freqs) ** (5. / 3.)))
 
 
 def summary(h1, h2, freqs, psd, bins):
@@ -84,24 +81,27 @@ def make_case(seed):
     edges = fine[index]
     bins = list(zip(index[:-1], index[1:]))
 
-    # fiducial waveform, and data holding a signal slightly off it
-    h00f = 1e-23 * inspiral(fine, 1.2)
+    def waveform(points, mass1, distance=100.):
+        return get_fd_waveform_sequence(approximant=APPROXIMANT, mass1=mass1,
+                                        mass2=MASS2, inclination=INCLINATION,
+                                        distance=distance, f_lower=FLOW,
+                                        sample_points=points)
+
+    # the fiducial waveform, and data holding a signal slightly off it
+    h00f = numpy.array(waveform(fine, MASS1)[0])
     noise = ((rng.normal(size=fine.size) + 1.0j * rng.normal(size=fine.size))
              * numpy.sqrt(psd))
-    data = 1.05 * 1e-23 * inspiral(fine, 1.2005) + noise
+    data = 1.05 * numpy.array(waveform(fine, MASS1 * 1.001)[0]) + noise
 
     a0, a1 = summary(h00f, data, fine, psd, bins)
     b0, b1 = summary(h00f, h00f, fine, psd, bins)
 
-    # a small second component keeps the polarizations from being a
-    # pure phase apart
-    cosi = 0.6
-    dom = 1e-23 * inspiral(edges, 1.2005)
-    sub = 1e-24 * inspiral(edges, 1.35)
-    hp = 0.5 * (1.0 + cosi ** 2) * dom + 0.30 * sub
-    hc = 1.0j * cosi * dom + 0.22 * numpy.exp(0.7j) * sub
+    # a higher mode approximant, so hp and hc are not a pure phase apart
+    # and the cross term of the quadratic form is reached
+    hp, hc = waveform(edges, MASS1 * 1.001)
+    h00 = numpy.array(waveform(edges, MASS1)[0])
 
-    return dict(freqs=edges, hp=hp, hc=hc, h00=1e-23 * inspiral(edges, 1.2),
+    return dict(freqs=edges, hp=numpy.array(hp), hc=numpy.array(hc), h00=h00,
                 a0=a0, a1=a1, b0=numpy.abs(b0), b1=numpy.abs(b1),
                 fp=rng.uniform(-1, 1, NSAMPLE),
                 fc=rng.uniform(-1, 1, NSAMPLE),

--- a/test/test_relbin_kernel.py
+++ b/test/test_relbin_kernel.py
@@ -12,15 +12,14 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-"""Checks the relative binning kernels against the definition.
+"""
+These are the unittests for the relative binning likelihood kernels
+in pycbc.inference.models.relbin_cpu.
 
-Each kernel evaluates <d|h> and <h|h> for a bank of marginalization
-samples. They are written for speed rather than for reading, so what is
-asserted is the property that defines them: sample by sample they are the
-sum written out in direct() below.
-
-The rearrangement reassociates floating point sums, so the agreement is
-close but not to the last bit.
+Each kernel computes <d|h> and <h|h> for a bank of marginalization
+samples. Each test checks a kernel against direct(), which computes the
+same sums from their definition. The kernels sum the same terms in a
+different order, so agreement is to about 1e-13 rather than exact.
 """
 
 import os
@@ -37,16 +36,17 @@ from pycbc.inference.models.relbin_cpu import (likelihood_parts,
                                                likelihood_parts_vectorp,
                                                likelihood_parts_vectort)
 
-# a 32 second segment analysed from 20 Hz, as a neutron star binary is
+# a 32 second segment from 20 Hz, as used for a neutron star binary
 FLOW, FHIGH, DF = 20.0, 1024.0, 1. / 32.
 NSAMPLE = 64
 
-# how closely each kernel must track the definition, relative
+# relative tolerance against direct()
 TOL = 1e-12
 
 
 def get_seed():
-    """Draw a fresh seed each run, or take the one being reproduced."""
+    """ Use PYCBC_VALIDATION_SEED if set, otherwise a random seed
+    """
     seed = os.environ.get('PYCBC_VALIDATION_SEED')
     if seed is None:
         seed = numpy.random.randint(0, 2 ** 31)
@@ -54,16 +54,15 @@ def get_seed():
 
 
 def inspiral(freqs, mchirp):
-    """A stationary phase inspiral: an f^(-7/6) amplitude under a phase
-    that sweeps thousands of radians across the band, which is what makes
-    the time shift in the kernel a hard thing to get right."""
+    """ Stationary phase inspiral with an f^(-7/6) amplitude
+    """
     return ((freqs / FLOW) ** (-7. / 6.) * numpy.exp(
         1.0j * 3. / 128. / (numpy.pi * mchirp * 4.9e-6 * freqs) ** (5. / 3.)))
 
 
 def summary(h1, h2, freqs, psd, bins):
-    """The constant and linear summary weights of <h1|h2> over each bin,
-    formed exactly as the relative binning model forms them."""
+    """ Calculate the summary values for the inner product <h1|h2>
+    """
     h12 = numpy.conjugate(h1) * h2 / psd
     a0 = numpy.array([4.0 * DF * h12[lo:hi].sum() for lo, hi in bins])
     a1 = numpy.array([4.0 / (hi - lo)
@@ -73,19 +72,19 @@ def summary(h1, h2, freqs, psd, bins):
 
 
 def make_case(seed):
-    """Build one realistic argument set for the kernels."""
+    """ Build one set of kernel arguments
+    """
     rng = numpy.random.default_rng(seed)
 
     fine = numpy.arange(FLOW, FHIGH + DF, DF)
     psd = 1e-46 * ((fine / 100.) ** -4.14 + 1.0 + (fine / 300.) ** 2)
 
-    # the bins the model would lay down for this band, so the edges are
-    # crowded where the phase turns over quickly and sparse where it does not
+    # bins as the model lays them down for this band
     index = setup_bins(fine, FLOW, FHIGH)
     edges = fine[index]
     bins = list(zip(index[:-1], index[1:]))
 
-    # the fiducial waveform, and data holding a signal a little off it
+    # fiducial waveform, and data holding a signal slightly off it
     h00f = 1e-23 * inspiral(fine, 1.2)
     noise = ((rng.normal(size=fine.size) + 1.0j * rng.normal(size=fine.size))
              * numpy.sqrt(psd))
@@ -94,8 +93,8 @@ def make_case(seed):
     a0, a1 = summary(h00f, data, fine, psd, bins)
     b0, b1 = summary(h00f, h00f, fine, psd, bins)
 
-    # a dominant quadrupole plus a small second piece, which is what stops
-    # the two polarizations from being a pure phase apart
+    # a small second component keeps the polarizations from being a
+    # pure phase apart
     cosi = 0.6
     dom = 1e-23 * inspiral(edges, 1.2005)
     sub = 1e-24 * inspiral(edges, 1.35)
@@ -110,8 +109,8 @@ def make_case(seed):
 
 
 def direct(freqs, fp, fc, dtc, *, hp, hc, h00, a0, a1, b0, b1):
-    """<d|h> and <h|h> written straight from the definition, with no
-    reference to how the kernels are organised internally."""
+    """ Calculate <d|h> and <h|h> directly from their definition
+    """
     r = numpy.exp(-2.0j * numpy.pi * dtc * freqs) * (fp * hp + fc * hc) / h00
     x = numpy.abs(r) ** 2
     return (numpy.conjugate((a0 * r[:-1] + a1 * numpy.diff(r)).sum()),
@@ -125,9 +124,7 @@ class TestRelbinKernel(unittest.TestCase):
         cls.seed = get_seed()
         print('using PYCBC_VALIDATION_SEED=%s' % cls.seed)
         cls.case = make_case(cls.seed)
-        # earth rotation makes the response and the arrival vary across the
-        # band, so those become per bin and only the polarization and the
-        # offset stay per sample
+        # with earth rotation fp, fc and the arrival are per bin
         rng = numpy.random.RandomState(cls.seed + 1)
         n = len(cls.case['freqs'])
         cls.band = dict(fp=rng.uniform(-1, 1, n), fc=rng.uniform(-1, 1, n),
@@ -137,8 +134,11 @@ class TestRelbinKernel(unittest.TestCase):
                                                          NSAMPLE)))
 
     def check(self, out, effective, label):
-        """effective(j) gives the fp, fc and arrival the definition should
-        be evaluated at for sample j, as scalars or as per bin arrays."""
+        """ Compare kernel output to direct()
+
+        effective(j) returns the fp, fc and arrival for sample j, either
+        as scalars or as per bin arrays.
+        """
         c = self.case
         hdv, hhv = out
         err = numpy.empty((NSAMPLE, 2))
@@ -147,21 +147,22 @@ class TestRelbinKernel(unittest.TestCase):
                             h00=c['h00'], a0=c['a0'], a1=c['a1'],
                             b0=c['b0'], b1=c['b1'])
             err[j] = (abs(hdv[j] - hd) / abs(hd), abs(hhv[j] - hh) / abs(hh))
-        # numpy.max, not the builtin, so that a nan cannot pass unnoticed
+        # numpy.max, not the builtin, so a nan does not pass
         worst = err.max()
         print('%s: worst relative difference from the definition %.2e'
               % (label, worst))
         self.assertTrue(worst < TOL)
 
     def rotated(self, j):
-        """(fp, fc) turned by the polarization of sample j."""
+        """ Rotate (fp, fc) by the polarization of sample j
+        """
         b = self.band
         cp, sp = b['pol'][j].real, b['pol'][j].imag
         return b['fp'] * cp - b['fc'] * sp, b['fp'] * sp + b['fc'] * cp
 
     def test_the_scalar_kernel_is_the_definition(self):
-        """The one kernel this branch does not touch, as a control on the
-        reference the others are measured against."""
+        """ Check direct() against the unmodified scalar kernel
+        """
         c = self.case
         self.check((numpy.array([likelihood_parts(
                         c['freqs'], c['fp'][j], c['fc'][j], c['dtc'][j],
@@ -172,7 +173,8 @@ class TestRelbinKernel(unittest.TestCase):
                    'likelihood_parts')
 
     def test_vector(self):
-        """Sky or time points: own response and own shift per sample."""
+        """ Sky or time points, response and shift vary per sample
+        """
         c = self.case
         self.check(likelihood_parts_vector(
                        c['freqs'], c['fp'], c['fc'], c['dtc'], c['hp'],
@@ -181,8 +183,8 @@ class TestRelbinKernel(unittest.TestCase):
                    'likelihood_parts_vector')
 
     def test_vectort(self):
-        """Time points only: the response is scalar, so <h|h> is one number
-        for the whole bank and must still be the right one."""
+        """ Time points only, so <h|h> is one value for the bank
+        """
         c = self.case
         fp, fc = float(c['fp'][0]), float(c['fc'][0])
         out = likelihood_parts_vectort(
@@ -194,8 +196,8 @@ class TestRelbinKernel(unittest.TestCase):
                    'likelihood_parts_vectort')
 
     def test_vectorp(self):
-        """Polarization points only: the shift is scalar and folds into the
-        ratios ahead of the sample loop."""
+        """ Polarization points only, the shift is scalar
+        """
         c = self.case
         dtc = float(c['dtc'][0])
         self.check(likelihood_parts_vectorp(
@@ -205,8 +207,8 @@ class TestRelbinKernel(unittest.TestCase):
                    'likelihood_parts_vectorp')
 
     def test_v_pol(self):
-        """Earth rotation, polarization points: the arrival varies across
-        the band but not between samples."""
+        """ Earth rotation, polarization points
+        """
         c, b = self.case, self.band
         self.check(likelihood_parts_v_pol(
                        c['freqs'], b['fp'], b['fc'], b['dtc'], b['pol'],
@@ -216,8 +218,8 @@ class TestRelbinKernel(unittest.TestCase):
                    'likelihood_parts_v_pol')
 
     def test_v_time(self):
-        """Earth rotation, time points: the response is per bin and does
-        not move with the sample."""
+        """ Earth rotation, time points
+        """
         c, b = self.case, self.band
         self.check(likelihood_parts_v_time(
                        c['freqs'], b['fp'], b['fc'], b['times'], c['dtc'],
@@ -227,7 +229,8 @@ class TestRelbinKernel(unittest.TestCase):
                    'likelihood_parts_v_time')
 
     def test_v_pol_time(self):
-        """Earth rotation, both."""
+        """ Earth rotation, polarization and time points
+        """
         c, b = self.case, self.band
         self.check(likelihood_parts_v_pol_time(
                        c['freqs'], b['fp'], b['fc'], b['times'], c['dtc'],

--- a/test/test_relbin_kernel.py
+++ b/test/test_relbin_kernel.py
@@ -60,7 +60,7 @@ TOL = 1e-12
 # math.h, so the reference sum below has to use the same one or it would be
 # comparing two slightly different time shifts and disagreeing at 1e-8 for a
 # reason that has nothing to do with what is being tested here
-KERNEL_PI = 3.141592653
+KERNEL_PI = numpy.pi
 
 
 def get_seed():


### PR DESCRIPTION
This refactors the relbin various helper functions. It moves at least one common part to a single function and fixes the vectorization of a few of the functions (reorder loops, one function was somewhat brute force). This makes the functions ~ 2x faster on my laptop with no change to the output (outside floating precision). 

I've run the standard PE examples, no change to output (just slightly faster). 

- [s] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
