### PR TITLE
Fix Docker build

### DIFF
--- a/docker/etc/docker-install.sh
+++ b/docker/etc/docker-install.sh
@@ -4,13 +4,22 @@ set -e
 
 # Install PyCBC
 #
-# pip 26.2 excluded, see https://github.com/gwastro/pycbc/pull/5391
+# --use-feature venv-isolation is required here: pip's default ("virtual")
+# build isolation isolates sdist builds by replaying site.py's .pth
+# processing in a subprocess via a generated sitecustomize.py. Old-style
+# namespace-package .pth shims (e.g. the one shipped by sphinxcontrib-jsmath,
+# pulled in via Sphinx in requirements.txt) crash that replay with spurious
+# "ModuleNotFoundError: No module named 'traceback'/'importlib'" errors,
+# which then breaks the build of any sdist-only dependency later in the
+# install (amqplib being the one that happens to trip over it first).
+# Using pip's real venv-based isolation avoids replaying the outer
+# environment's .pth files at all.
 cd /scratch
-python -m pip install --upgrade 'pip!=26.2'
-python -m pip install -r requirements.txt
-python -m pip install -r requirements-igwn.txt
-python -m pip install -r companion.txt
-python -m pip install .
+python -m pip install --upgrade pip
+python -m pip install --use-feature venv-isolation -r requirements.txt
+python -m pip install --use-feature venv-isolation -r requirements-igwn.txt
+python -m pip install --use-feature venv-isolation -r companion.txt
+python -m pip install --use-feature venv-isolation .
 cd /
 
 # Copy PyCBC source repository into the image

--- a/docker/etc/docker-install.sh
+++ b/docker/etc/docker-install.sh
@@ -4,16 +4,8 @@ set -e
 
 # Install PyCBC
 #
-# --use-feature venv-isolation is required here: pip's default ("virtual")
-# build isolation isolates sdist builds by replaying site.py's .pth
-# processing in a subprocess via a generated sitecustomize.py. Old-style
-# namespace-package .pth shims (e.g. the one shipped by sphinxcontrib-jsmath,
-# pulled in via Sphinx in requirements.txt) crash that replay with spurious
-# "ModuleNotFoundError: No module named 'traceback'/'importlib'" errors,
-# which then breaks the build of any sdist-only dependency later in the
-# install (amqplib being the one that happens to trip over it first).
-# Using pip's real venv-based isolation avoids replaying the outer
-# environment's .pth files at all.
+# --use-feature venv-isolation is required here:
+# See https://github.com/pypa/pip/issues/14278
 cd /scratch
 python -m pip install --upgrade pip
 python -m pip install --use-feature venv-isolation -r requirements.txt


### PR DESCRIPTION
Please see https://github.com/gwastro/pycbc/pull/5391 for the details here. It looks like pypi is aware of the underlying issue (https://github.com/pypa/pip/issues/14278), but fixing it is tricksy, so we go to the original solution of adding build isolation.

This may become the default in the future and then removed as an option, but we'll deal with that as needed later. #5403 should still be useful, but that's more of a refactor than a bugfix.