### PR TITLE
Add trapezoidal distribution

### DIFF
--- a/examples/distributions/example.ini
+++ b/examples/distributions/example.ini
@@ -16,6 +16,7 @@ v7 =
 v8 =
 v9 =
 ;v10 =
+v11 =
 mass1 =
 mass2 =
 mchirp = 
@@ -101,6 +102,13 @@ max-q = 8
 ;filename = example_prior_file.hdf
 ;min-v9 = 0
 ;max-v9 = 6.28
+
+[prior-v11]
+name = trapezoid
+min-v11 = 0
+max-v11 = 10
+semimin-v11 = 2
+semimax-v11 = 6
 
 ;[prior-mass1+mass2+chi_eff+chi_a+xi1+xi2+phi_a+phi_s]
 ;name = independent_chip_chieff

--- a/pycbc/distributions/__init__.py
+++ b/pycbc/distributions/__init__.py
@@ -30,7 +30,7 @@ from pycbc.distributions.arbitrary import Arbitrary, FromFile
 from pycbc.distributions.gaussian import Gaussian
 from pycbc.distributions.power_law import UniformPowerLaw, UniformRadius
 from pycbc.distributions.sky_location import UniformSky, UniformDiskSky, FisherSky, HealpixSky
-from pycbc.distributions.uniform import Uniform
+from pycbc.distributions.uniform import Uniform, Trapezoid
 from pycbc.distributions.uniform_log import UniformLog10
 from pycbc.distributions.spins import IndependentChiPChiEff
 from pycbc.distributions.qnm import UniformF0Tau

--- a/pycbc/distributions/__init__.py
+++ b/pycbc/distributions/__init__.py
@@ -50,6 +50,7 @@ distribs = {
     UniformRadius.name : UniformRadius,
     Uniform.name : Uniform,
     UniformAngle.name : UniformAngle,
+    Trapezoid.name : Trapezoid,
     CosAngle.name : CosAngle,
     SinAngle.name : SinAngle,
     UniformSolidAngle.name : UniformSolidAngle,

--- a/pycbc/distributions/uniform.py
+++ b/pycbc/distributions/uniform.py
@@ -202,6 +202,7 @@ class Trapezoid(bounded.BoundedDist):
                 # multiply based on position in dist
                 value = kwargs[p]
                 value = numpy.asarray(value)
+
                 condlist = [(value >= a) & (value < b), 
                             (value >= b) & (value < c), 
                             (value >= c) & (value < d)]
@@ -209,9 +210,10 @@ class Trapezoid(bounded.BoundedDist):
                            1.,
                            (d - value)/(d - c)]
                 pdf *= numpy.select(condlist, outlist, 0.)
+                
                 # get the overall normalization and prefactor
-                pdf *= 2 * (d + c - a - b)
-            #pdf *= self._norm
+                pdf *= 2 / (d + c - a - b)
+            #FIXME: this might not be normalized if multidim
             return pdf.astype(numpy.float64)
         else:
             return 0.0
@@ -259,8 +261,8 @@ class Trapezoid(bounded.BoundedDist):
                     (value >= b_cdf) & (value < c_cdf), 
                     (value >= c_cdf)]
         outlist = [a + numpy.sqrt(value * pref * (b-a)),
-                    (value * pref + b + a) / 2,
-                    d-numpy.sqrt((value - 1) * pref * (c-d))]
+                   (value * pref + b + a) / 2,
+                   d-numpy.sqrt((value - 1) * pref * (c-d))]
 
         return numpy.select(condlist, outlist)
         
@@ -286,6 +288,7 @@ class Trapezoid(bounded.BoundedDist):
             A distribution instance from the pycbc.inference.prior module.
         """
         # load this class instance
-        return super(Trapezoid, cls).from_config(cp, section, variable_args, bounds_required=True)
+        return super(Trapezoid, cls).from_config(cp, section, variable_args,
+                                                 bounds_required=True)
 
 __all__ = ['Uniform', 'Trapezoid']

--- a/pycbc/distributions/uniform.py
+++ b/pycbc/distributions/uniform.py
@@ -200,20 +200,20 @@ class Trapezoid(bounded.BoundedDist):
                 c = self._semimaxs.get(p, d)
                 
                 # multiply based on position in dist
-                value = kwargs[p]
-                value = numpy.asarray(value)
+                with numpy.errstate(divide='ignore', invalid='ignore'):
+                    value = kwargs[p]
+                    value = numpy.asarray(value)
 
-                condlist = [(value >= a) & (value < b), 
-                            (value >= b) & (value < c), 
-                            (value >= c) & (value < d)]
-                outlist = [(value - a)/(b - a),
-                           1.,
-                           (d - value)/(d - c)]
-                pdf *= numpy.select(condlist, outlist, 0.)
+                    condlist = [(value >= a) & (value < b), 
+                                (value >= b) & (value < c), 
+                                (value >= c) & (value < d)]
+                    outlist = [(value - a)/(b - a),
+                               1.,
+                               (d - value)/(d - c)]
+                    pdf *= numpy.select(condlist, outlist, 0.)
                 
-                # get the overall normalization and prefactor
-                pdf *= 2 / (d + c - a - b)
-            #FIXME: this might not be normalized if multidim
+                    # get the overall normalization and prefactor
+                    pdf *= 2 / (d + c - a - b)
             return pdf.astype(numpy.float64)
         else:
             return 0.0
@@ -233,15 +233,17 @@ class Trapezoid(bounded.BoundedDist):
         pref = (d + c - a - b)
 
         # conditions based on position
-        value = numpy.asarray(value)
-        condlist = [(value >= a) & (value < b), 
-                    (value >= b) & (value < c), 
-                    (value >= c) & (value < d)]
-        outlist = [(value - a)**2 / (b - a) / pref,
-                   (2*value - a - b) / pref,
-                   1 - (d - value)**2 / (d-c) / pref]
+        # suppress divide by zero errors if a = b or c = d
+        with numpy.errstate(divide='ignore', invalid='ignore'):
+            value = numpy.asarray(value)
+            condlist = [(value >= a) & (value < b), 
+                        (value >= b) & (value < c), 
+                        (value >= c) & (value < d)]
+            outlist = [(value - a)**2 / (b - a) / pref,
+                       (2*value - a - b) / pref,
+                       1 - (d - value)**2 / (d - c) / pref]
 
-        return numpy.select(condlist, outlist)
+            return numpy.select(condlist, outlist)
     
     def _cdfinv_param(self, param, value):
         """Return the inverse cdf to map the unit interval to parameter bounds.

--- a/pycbc/distributions/uniform.py
+++ b/pycbc/distributions/uniform.py
@@ -194,24 +194,24 @@ class Trapezoid(bounded.BoundedDist):
             for p in self._params:
                 a = self._bounds[p][0]
                 d = self._bounds[p][1]
-                
+
                 # set semimin to a, semimax to d if not provided
                 b = self._semimins.get(p, a)
                 c = self._semimaxs.get(p, d)
-                
+
                 # multiply based on position in dist
                 with numpy.errstate(divide='ignore', invalid='ignore'):
                     value = kwargs[p]
                     value = numpy.asarray(value)
 
-                    condlist = [(value >= a) & (value < b), 
-                                (value >= b) & (value < c), 
+                    condlist = [(value >= a) & (value < b),
+                                (value >= b) & (value < c),
                                 (value >= c) & (value < d)]
                     outlist = [(value - a)/(b - a),
                                1.,
                                (d - value)/(d - c)]
                     pdf *= numpy.select(condlist, outlist, 0.)
-                
+
                     # get the overall normalization and prefactor
                     pdf *= 2 / (d + c - a - b)
             return pdf.astype(numpy.float64)
@@ -236,15 +236,15 @@ class Trapezoid(bounded.BoundedDist):
         # suppress divide by zero errors if a = b or c = d
         with numpy.errstate(divide='ignore', invalid='ignore'):
             value = numpy.asarray(value)
-            condlist = [(value >= a) & (value < b), 
-                        (value >= b) & (value < c), 
+            condlist = [(value >= a) & (value < b),
+                        (value >= b) & (value < c),
                         (value >= c) & (value < d)]
             outlist = [(value - a)**2 / (b - a) / pref,
                        (2*value - a - b) / pref,
                        1 - (d - value)**2 / (d - c) / pref]
 
             return numpy.select(condlist, outlist)
-    
+
     def _cdfinv_param(self, param, value):
         """Return the inverse cdf to map the unit interval to parameter bounds.
         """
@@ -256,18 +256,18 @@ class Trapezoid(bounded.BoundedDist):
         # get cdf values at turning points and provided values
         b_cdf = self.cdf(param, b)
         c_cdf = self.cdf(param, c)
-        
+
         # conditions based on position
         value = numpy.asarray(value)
-        condlist = [(value < b_cdf), 
-                    (value >= b_cdf) & (value < c_cdf), 
+        condlist = [(value < b_cdf),
+                    (value >= b_cdf) & (value < c_cdf),
                     (value >= c_cdf)]
         outlist = [a + numpy.sqrt(value * pref * (b-a)),
                    (value * pref + b + a) / 2,
                    d-numpy.sqrt((value - 1) * pref * (c-d))]
 
         return numpy.select(condlist, outlist)
-        
+
     @classmethod
     def from_config(cls, cp, section, variable_args):
         """Returns a distribution based on a configuration file. The parameters

--- a/pycbc/distributions/uniform.py
+++ b/pycbc/distributions/uniform.py
@@ -19,6 +19,7 @@ import logging
 import numpy
 
 from pycbc.distributions import bounded
+from pycbc import boundaries
 
 logger = logging.getLogger('pycbc.distributions.uniform')
 
@@ -153,4 +154,138 @@ class Uniform(bounded.BoundedDist):
                      bounds_required=True)
 
 
-__all__ = ['Uniform']
+class Trapezoid(bounded.BoundedDist):
+    """A trapezoidal distribution.
+    """
+    name = 'trapezoid'
+    def __init__(self, **params):
+        self._semimins = {}
+        self._semimaxs = {}
+        self._bounds = {}
+        for param in params:
+            # read in semimins
+            if 'semimin-' in param:
+                p = param[8:]
+                self._semimins[p] = params[param]
+            # read in semimaxs
+            elif 'semimax-' in param:
+                p = param[8:]
+                self._semimaxs[p] = params[param]
+            else:
+                bnds = params[param]
+                if bnds is None:
+                    self._bounds[param] = boundaries.Bounds()
+                elif not isinstance(bnds, boundaries.Bounds):
+                    self._bounds[param] = boundaries.Bounds(bnds[0], bnds[1])
+                else:
+                    self._bounds[param] = bnds
+            self._params = sorted(list(self._bounds.keys()))
+
+    def _pdf(self, **kwargs):
+        """Returns the pdf at the given values. The keyword arguments must
+        contain all of parameters in self's params. Unrecognized arguments are
+        ignored.
+        """
+        for p in self._params:
+            if p not in kwargs.keys():
+                raise ValueError(f'Missing parameter {p} to construct pdf.')
+        if kwargs in self:
+            pdf = numpy.ones(numpy.asarray(next(iter(kwargs.values()))).shape)
+            for p in self._params:
+                a = self._bounds[p][0]
+                d = self._bounds[p][1]
+                
+                # set semimin to a, semimax to d if not provided
+                b = self._semimins.get(p, a)
+                c = self._semimaxs.get(p, d)
+                
+                # multiply based on position in dist
+                value = kwargs[p]
+                value = numpy.asarray(value)
+                condlist = [(value >= a) & (value < b), 
+                            (value >= b) & (value < c), 
+                            (value >= c) & (value < d)]
+                outlist = [(value - a)/(b - a),
+                           1.,
+                           (d - value)/(d - c)]
+                pdf *= numpy.select(condlist, outlist, 0.)
+                # get the overall normalization and prefactor
+                pdf *= 2 * (d + c - a - b)
+            #pdf *= self._norm
+            return pdf.astype(numpy.float64)
+        else:
+            return 0.0
+
+    def _logpdf(self, **kwargs):
+        """Returns the log of the pdf at the given values. The keyword
+        arguments must contain all of parameters in self's params. Unrecognized
+        arguments are ignored.
+        """
+        return numpy.log(self._pdf(**kwargs))
+
+    def cdf(self, param, value):
+        """Return the cdf at given values."""
+        a, d = self._bounds[param]
+        b = self._semimins.get(param, a)
+        c = self._semimaxs.get(param, d)
+        pref = (d + c - a - b)
+
+        # conditions based on position
+        value = numpy.asarray(value)
+        condlist = [(value >= a) & (value < b), 
+                    (value >= b) & (value < c), 
+                    (value >= c) & (value < d)]
+        outlist = [(value - a)**2 / (b - a) / pref,
+                   (2*value - a - b) / pref,
+                   1 - (d - value)**2 / (d-c) / pref]
+
+        return numpy.select(condlist, outlist)
+    
+    def _cdfinv_param(self, param, value):
+        """Return the inverse cdf to map the unit interval to parameter bounds.
+        """
+        a, d = self._bounds[param]
+        b = self._semimins.get(param, a)
+        c = self._semimaxs.get(param, d)
+        pref = (d + c - a - b)
+
+        # get cdf values at turning points and provided values
+        b_cdf = self.cdf(param, b)
+        c_cdf = self.cdf(param, c)
+        
+        # conditions based on position
+        value = numpy.asarray(value)
+        condlist = [(value < b_cdf), 
+                    (value >= b_cdf) & (value < c_cdf), 
+                    (value >= c_cdf)]
+        outlist = [a + numpy.sqrt(value * pref * (b-a)),
+                    (value * pref + b + a) / 2,
+                    d-numpy.sqrt((value - 1) * pref * (c-d))]
+
+        return numpy.select(condlist, outlist)
+        
+    @classmethod
+    def from_config(cls, cp, section, variable_args):
+        """Returns a distribution based on a configuration file. The parameters
+        for the distribution are retrieved from the section titled
+        "[`section`-`variable_args`]" in the config file.
+
+        Parameters
+        ----------
+        cp : pycbc.workflow.WorkflowConfigParser
+            A parsed configuration file that contains the distribution
+            options.
+        section : str
+            Name of the section in the configuration file.
+        param : str
+            The name of the parameter for this distribution.
+
+        Returns
+        -------
+        Trapezoid
+            A distribution instance from the pycbc.inference.prior module.
+        """
+        # load this class instance
+        return super(Trapezoid, cls).from_config(cp, section, variable_args, bounds_required=True)
+
+__all__ = ['Uniform', 'Trapezoid']


### PR DESCRIPTION
## Standard information about the request

This PR adds a distribution class to sample with a trapezoidal distribution.

This is a new feature. This affects the distributions module, and can be used in, e.g., inference. This is purely additive; no existing functionality should be augmented.

## Motivation
In a forthcoming PR, I intend to implement a distribution class that allows for the application of a linear constraint `y >= a * x`, where x is some uniform variable. The resulting distribution on y, when properly resampled, should be a triangular distribution, which is a generalization of the trapezoidal distribution given here where both turning points are equal to the right boundary. Rather than applying a constraint during or after sampling, this will allow the user to specify linear constraints at the prior level, making it usable with, e.g., emcee samplers. This PR intends to lay the groundwork for this distribution, as it can be useful to have in its own right.

Note: this should be reducible to the uniform distribution where the left/right turning point equals the left/right bound respectively. That class is much simpler, though, so there's not much reason to overwrite that one.

## Contents
A new class `Trapezoid` has been added to `distributions.uniform` that encodes the trapezoidal distribution. It expects at least a `max-param` and `min-param` argument from config, as it inherits from `BoundedDist`. Additional kwargs `semimin-param` and `semimax-param` can be passed to specify the left and right turning point respectively. By default (i.e. the kwargs are not specified), the left turning point is set to the left bound and the right turning point is set to the right bound (i.e. a uniform distribution).

## Links to any issues or associated PRs
A future PR will implement this to apply the dependent prior as specified above.

## Testing performed
Below are histograms generated with the following config options:
```
[prior-foo]
name = trapezoid
min-foo = 0
max-foo = 1
semimin-foo = 0.1
semimax-foo = 0.5
```
The first plot shows the results of calling `Trapezoid.pdf` and `Trapezoid.rvs`. The histogram was generated with `density=True`, so this indicates that the PDF is properly normalized. The second plot shows the same PDF plotted over the scipy implementation `scipy.stats.trapezoidal.rvs`.
<img width="546" height="416" alt="Screenshot 2026-09-01 at 12 55 07 PM" src="https://github.com/user-attachments/assets/3aeb4aee-69c7-468e-8611-cafeac5fcce3" />
<img width="548" height="412" alt="Screenshot 2026-09-01 at 12 55 19 PM" src="https://github.com/user-attachments/assets/f344d857-22cd-4fad-bd64-3612ee6f2fb2" />

The third plot was generated with the following config options, to see if the default behavior works as intended:
```
[prior-bar]
name = trapezoid
min-bar = -0.08
max-bar = 0.08
semimax-bar = 0.04
```
Again, the histogram uses `density=True` to confirm the PDF is properly normalized. 
<img width="535" height="414" alt="Screenshot 2026-09-01 at 12 55 30 PM" src="https://github.com/user-attachments/assets/393d2d97-8e4b-4e55-be95-a0df99d2c2d3" />

## Additional notes
An additional unittest can be added to test that this reduces to a uniform distribution if default parameters are used. Otherwise, this should run with the `test_distributions` suite.

The distributions above indicate that the one-dimensional distributions are properly normalized. If necessary, further testing can be conducted to ensure the normalization is maintained for multi-dimensional distributions.

- [ x ] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)